### PR TITLE
fix: remove unnecessary ivpk's from aztec-nr

### DIFF
--- a/boxes/boxes/react/src/contracts/src/main.nr
+++ b/boxes/boxes/react/src/contracts/src/main.nr
@@ -3,7 +3,7 @@ use dep::aztec::macros::aztec;
 #[aztec]
 contract BoxReact {
     use dep::aztec::{
-        protocol_types::public_keys::{IvpkM, OvpkM},
+        protocol_types::public_keys::OvpkM,
         prelude::{AztecAddress, PrivateMutable, Map, NoteInterface, NoteHeader, Point},
         encrypted_logs::encrypted_note_emission::encode_and_encrypt_note,
         macros::{storage::storage, functions::{private, public, initializer}}
@@ -21,12 +21,11 @@ contract BoxReact {
         number: Field,
         owner: AztecAddress,
         owner_npk_m_hash: Field,
-        owner_ovpk_m: OvpkM,
-        owner_ivpk_m: IvpkM
+        owner_ovpk_m: OvpkM
     ) {
         let numbers = storage.numbers;
         let mut new_number = ValueNote::new(number, owner_npk_m_hash);
-        numbers.at(owner).initialize(&mut new_number).emit(encode_and_encrypt_note(&mut context, owner_ovpk_m, owner_ivpk_m, owner));
+        numbers.at(owner).initialize(&mut new_number).emit(encode_and_encrypt_note(&mut context, owner_ovpk_m, owner));
     }
 
     #[private]
@@ -34,12 +33,11 @@ contract BoxReact {
         number: Field,
         owner: AztecAddress,
         owner_npk_m_hash: Field,
-        owner_ovpk_m: OvpkM,
-        owner_ivpk_m: IvpkM
+        owner_ovpk_m: OvpkM
     ) {
         let numbers = storage.numbers;
         let mut new_number = ValueNote::new(number, owner_npk_m_hash);
-        numbers.at(owner).replace(&mut new_number).emit(encode_and_encrypt_note(&mut context, owner_ovpk_m, owner_ivpk_m, owner));
+        numbers.at(owner).replace(&mut new_number).emit(encode_and_encrypt_note(&mut context, owner_ovpk_m, owner));
     }
 
     unconstrained fn getNumber(owner: AztecAddress) -> pub ValueNote {

--- a/boxes/boxes/react/src/hooks/useContract.tsx
+++ b/boxes/boxes/react/src/hooks/useContract.tsx
@@ -15,7 +15,7 @@ export function useContract() {
     setWait(true);
     const wallet = await deployerEnv.getWallet();
     const salt = Fr.random();
-    const { masterNullifierPublicKey, masterIncomingViewingPublicKey, masterOutgoingViewingPublicKey } =
+    const { masterNullifierPublicKey, masterOutgoingViewingPublicKey } =
       wallet.getCompleteAddress().publicKeys;
     const tx = await BoxReactContract.deploy(
       wallet,
@@ -23,7 +23,6 @@ export function useContract() {
       wallet.getCompleteAddress().address,
       masterNullifierPublicKey.hash(),
       masterOutgoingViewingPublicKey.toWrappedNoirStruct(),
-      masterIncomingViewingPublicKey.toWrappedNoirStruct(),
     ).send({
       contractAddressSalt: salt,
     });

--- a/boxes/boxes/react/src/hooks/useNumber.tsx
+++ b/boxes/boxes/react/src/hooks/useNumber.tsx
@@ -25,7 +25,7 @@ export function useNumber({ contract }: { contract: Contract }) {
 
       const value = BigInt(el.value);
       const deployerWallet = await deployerEnv.getWallet();
-      const { masterNullifierPublicKey, masterIncomingViewingPublicKey, masterOutgoingViewingPublicKey } =
+      const { masterNullifierPublicKey, masterOutgoingViewingPublicKey } =
         deployerWallet.getCompleteAddress().publicKeys;
       await toast.promise(
         contract!.methods
@@ -34,7 +34,6 @@ export function useNumber({ contract }: { contract: Contract }) {
             deployerWallet.getCompleteAddress().address,
             masterNullifierPublicKey.hash(),
             masterOutgoingViewingPublicKey.toWrappedNoirStruct(),
-            masterIncomingViewingPublicKey.toWrappedNoirStruct(),
           )
           .send()
           .wait(),

--- a/boxes/boxes/react/tests/node.test.ts
+++ b/boxes/boxes/react/tests/node.test.ts
@@ -14,15 +14,14 @@ describe('BoxReact Contract Tests', () => {
     wallet = await deployerEnv.getWallet();
     accountCompleteAddress = wallet.getCompleteAddress();
     const salt = Fr.random();
-    const { masterNullifierPublicKey, masterIncomingViewingPublicKey, masterOutgoingViewingPublicKey } =
+    const { masterNullifierPublicKey, masterOutgoingViewingPublicKey } =
       accountCompleteAddress.publicKeys;
     contract = await BoxReactContract.deploy(
       wallet,
       Fr.random(),
       accountCompleteAddress.address,
       masterNullifierPublicKey.hash(),
-      masterOutgoingViewingPublicKey.toWrappedNoirStruct(),
-      masterIncomingViewingPublicKey.toWrappedNoirStruct(),
+      masterOutgoingViewingPublicKey.toWrappedNoirStruct()
     )
       .send({ contractAddressSalt: salt })
       .deployed();
@@ -32,7 +31,7 @@ describe('BoxReact Contract Tests', () => {
 
   test('Can set a number', async () => {
     logger.info(`${await wallet.getRegisteredAccounts()}`);
-    const { masterNullifierPublicKey, masterIncomingViewingPublicKey, masterOutgoingViewingPublicKey } =
+    const { masterNullifierPublicKey, masterOutgoingViewingPublicKey } =
       accountCompleteAddress.publicKeys;
     await contract.methods
       .setNumber(
@@ -40,7 +39,6 @@ describe('BoxReact Contract Tests', () => {
         accountCompleteAddress.address,
         masterNullifierPublicKey.hash(),
         masterOutgoingViewingPublicKey.toWrappedNoirStruct(),
-        masterIncomingViewingPublicKey.toWrappedNoirStruct(),
       )
       .send()
       .wait();

--- a/boxes/boxes/vanilla/src/contracts/src/main.nr
+++ b/boxes/boxes/vanilla/src/contracts/src/main.nr
@@ -3,7 +3,7 @@ use dep::aztec::macros::aztec;
 #[aztec]
 contract Vanilla {
     use dep::aztec::{
-        protocol_types::public_keys::{IvpkM, OvpkM},
+        protocol_types::public_keys::OvpkM,
         prelude::{AztecAddress, PrivateMutable, Map, NoteInterface, NoteHeader, Point},
         encrypted_logs::encrypted_note_emission::encode_and_encrypt_note,
         macros::{storage::storage, functions::{private, public, initializer}}
@@ -21,12 +21,11 @@ contract Vanilla {
         number: Field,
         owner: AztecAddress,
         owner_npk_m_hash: Field,
-        owner_ovpk_m: OvpkM,
-        owner_ivpk_m: IvpkM
+        owner_ovpk_m: OvpkM
     ) {
         let numbers = storage.numbers;
         let mut new_number = ValueNote::new(number, owner_npk_m_hash);
-        numbers.at(owner).initialize(&mut new_number).emit(encode_and_encrypt_note(&mut context, owner_ovpk_m, owner_ivpk_m, owner));
+        numbers.at(owner).initialize(&mut new_number).emit(encode_and_encrypt_note(&mut context, owner_ovpk_m, owner));
     }
 
     #[private]
@@ -34,12 +33,11 @@ contract Vanilla {
         number: Field,
         owner: AztecAddress,
         owner_npk_m_hash: Field,
-        owner_ovpk_m: OvpkM,
-        owner_ivpk_m: IvpkM
+        owner_ovpk_m: OvpkM
     ) {
         let numbers = storage.numbers;
         let mut new_number = ValueNote::new(number, owner_npk_m_hash);
-        numbers.at(owner).replace(&mut new_number).emit(encode_and_encrypt_note(&mut context, owner_ovpk_m, owner_ivpk_m, owner));
+        numbers.at(owner).replace(&mut new_number).emit(encode_and_encrypt_note(&mut context, owner_ovpk_m, owner));
     }
 
     unconstrained fn getNumber(owner: AztecAddress) -> pub ValueNote {

--- a/boxes/boxes/vanilla/src/index.ts
+++ b/boxes/boxes/vanilla/src/index.ts
@@ -20,7 +20,7 @@ const setWait = (state: boolean): void =>
 document.querySelector('#deploy').addEventListener('click', async ({ target }: any) => {
   setWait(true);
   wallet = await account.register();
-  const { masterNullifierPublicKey, masterIncomingViewingPublicKey, masterOutgoingViewingPublicKey } =
+  const { masterNullifierPublicKey, masterOutgoingViewingPublicKey } =
     wallet.getCompleteAddress().publicKeys;
   contract = await VanillaContract.deploy(
     wallet,
@@ -28,7 +28,6 @@ document.querySelector('#deploy').addEventListener('click', async ({ target }: a
     wallet.getCompleteAddress().address,
     masterNullifierPublicKey.hash(),
     masterOutgoingViewingPublicKey.toWrappedNoirStruct(),
-    masterIncomingViewingPublicKey.toWrappedNoirStruct(),
   )
     .send({ contractAddressSalt: Fr.random() })
     .deployed();
@@ -45,14 +44,13 @@ document.querySelector('#set').addEventListener('submit', async (e: Event) => {
 
   const { value } = document.querySelector('#number') as HTMLInputElement;
   const { address: owner, publicKeys } = wallet.getCompleteAddress();
-  const { masterNullifierPublicKey, masterIncomingViewingPublicKey, masterOutgoingViewingPublicKey } = publicKeys;
+  const { masterNullifierPublicKey, masterOutgoingViewingPublicKey } = publicKeys;
   await contract.methods
     .setNumber(
       parseInt(value),
       owner,
       masterNullifierPublicKey.hash(),
       masterOutgoingViewingPublicKey.toWrappedNoirStruct(),
-      masterIncomingViewingPublicKey.toWrappedNoirStruct(),
     )
     .send()
     .wait();

--- a/noir-projects/aztec-nr/aztec/src/encrypted_logs/encrypted_event_emission.nr
+++ b/noir-projects/aztec-nr/aztec/src/encrypted_logs/encrypted_event_emission.nr
@@ -2,11 +2,7 @@ use crate::{
     context::PrivateContext, encrypted_logs::payload::compute_private_log_payload,
     event::event_interface::EventInterface, keys::getters::get_ovsk_app, oracle::random::random,
 };
-use dep::protocol_types::{
-    address::AztecAddress,
-    hash::sha256_to_field,
-    public_keys::{IvpkM, OvpkM},
-};
+use dep::protocol_types::{address::AztecAddress, hash::sha256_to_field, public_keys::OvpkM};
 
 /// Computes private event log payload and a log hash
 fn compute_payload_and_hash<Event, let N: u32>(
@@ -15,7 +11,6 @@ fn compute_payload_and_hash<Event, let N: u32>(
     randomness: Field,
     ovsk_app: Field,
     ovpk: OvpkM,
-    ivpk: IvpkM,
     recipient: AztecAddress,
 ) -> ([u8; 416 + N * 32], Field)
 where
@@ -42,22 +37,20 @@ unconstrained fn compute_payload_and_hash_unconstrained<Event, let N: u32>(
     event: Event,
     randomness: Field,
     ovpk: OvpkM,
-    ivpk: IvpkM,
     recipient: AztecAddress,
 ) -> ([u8; 416 + N * 32], Field)
 where
     Event: EventInterface<N>,
 {
     let ovsk_app = get_ovsk_app(ovpk.hash());
-    compute_payload_and_hash(context, event, randomness, ovsk_app, ovpk, ivpk, recipient)
+    compute_payload_and_hash(context, event, randomness, ovsk_app, ovpk, recipient)
 }
 
 pub fn encode_and_encrypt_event<Event, let N: u32>(
     context: &mut PrivateContext,
     ovpk: OvpkM,
-    ivpk: IvpkM,
     recipient: AztecAddress,
-) -> fn[(&mut PrivateContext, OvpkM, IvpkM, AztecAddress)](Event) -> ()
+) -> fn[(&mut PrivateContext, OvpkM, AztecAddress)](Event) -> ()
 where
     Event: EventInterface<N>,
 {
@@ -69,7 +62,7 @@ where
         let randomness = unsafe { random() };
         let ovsk_app: Field = context.request_ovsk_app(ovpk.hash());
         let (encrypted_log, log_hash) =
-            compute_payload_and_hash(*context, e, randomness, ovsk_app, ovpk, ivpk, recipient);
+            compute_payload_and_hash(*context, e, randomness, ovsk_app, ovpk, recipient);
         context.emit_raw_event_log_with_masked_address(randomness, encrypted_log, log_hash);
     }
 }
@@ -77,9 +70,8 @@ where
 pub fn encode_and_encrypt_event_unconstrained<Event, let N: u32>(
     context: &mut PrivateContext,
     ovpk: OvpkM,
-    ivpk: IvpkM,
     recipient: AztecAddress,
-) -> fn[(&mut PrivateContext, OvpkM, IvpkM, AztecAddress)](Event) -> ()
+) -> fn[(&mut PrivateContext, OvpkM, AztecAddress)](Event) -> ()
 where
     Event: EventInterface<N>,
 {
@@ -90,7 +82,7 @@ where
         // value generation.
         let randomness = unsafe { random() };
         let (encrypted_log, log_hash) = unsafe {
-            compute_payload_and_hash_unconstrained(*context, e, randomness, ovpk, ivpk, recipient)
+            compute_payload_and_hash_unconstrained(*context, e, randomness, ovpk, recipient)
         };
         context.emit_raw_event_log_with_masked_address(randomness, encrypted_log, log_hash);
     }
@@ -103,16 +95,15 @@ pub fn encode_and_encrypt_event_with_randomness<Event, let N: u32>(
     context: &mut PrivateContext,
     randomness: Field,
     ovpk: OvpkM,
-    ivpk: IvpkM,
     recipient: AztecAddress,
-) -> fn[(&mut PrivateContext, OvpkM, Field, IvpkM, AztecAddress)](Event) -> ()
+) -> fn[(&mut PrivateContext, OvpkM, Field, AztecAddress)](Event) -> ()
 where
     Event: EventInterface<N>,
 {
     |e: Event| {
         let ovsk_app: Field = context.request_ovsk_app(ovpk.hash());
         let (encrypted_log, log_hash) =
-            compute_payload_and_hash(*context, e, randomness, ovsk_app, ovpk, ivpk, recipient);
+            compute_payload_and_hash(*context, e, randomness, ovsk_app, ovpk, recipient);
         context.emit_raw_event_log_with_masked_address(randomness, encrypted_log, log_hash);
     }
 }
@@ -121,9 +112,8 @@ pub fn encode_and_encrypt_event_with_randomness_unconstrained<Event, let N: u32>
     context: &mut PrivateContext,
     randomness: Field,
     ovpk: OvpkM,
-    ivpk: IvpkM,
     recipient: AztecAddress,
-) -> fn[(&mut PrivateContext, Field, OvpkM, IvpkM, AztecAddress)](Event) -> ()
+) -> fn[(&mut PrivateContext, Field, OvpkM, AztecAddress)](Event) -> ()
 where
     Event: EventInterface<N>,
 {
@@ -143,7 +133,7 @@ where
         // return the log from this function to the app, otherwise it could try to do stuff with it and then that might
         // be wrong.
         let (encrypted_log, log_hash) = unsafe {
-            compute_payload_and_hash_unconstrained(*context, e, randomness, ovpk, ivpk, recipient)
+            compute_payload_and_hash_unconstrained(*context, e, randomness, ovpk, recipient)
         };
         context.emit_raw_event_log_with_masked_address(randomness, encrypted_log, log_hash);
     }

--- a/noir-projects/aztec-nr/aztec/src/encrypted_logs/encrypted_note_emission.nr
+++ b/noir-projects/aztec-nr/aztec/src/encrypted_logs/encrypted_note_emission.nr
@@ -8,7 +8,7 @@ use dep::protocol_types::{
     abis::note_hash::NoteHash,
     address::AztecAddress,
     hash::sha256_to_field,
-    public_keys::{IvpkM, OvpkM, PublicKeys},
+    public_keys::{OvpkM, PublicKeys},
 };
 
 /// Computes private note log payload and a log hash
@@ -17,7 +17,6 @@ fn compute_payload_and_hash<Note, let N: u32>(
     note: Note,
     ovsk_app: Field,
     ovpk: OvpkM,
-    ivpk: IvpkM,
     recipient: AztecAddress,
 ) -> (u32, [u8; 417 + N * 32], Field)
 where
@@ -47,14 +46,13 @@ unconstrained fn compute_payload_and_hash_unconstrained<Note, let N: u32>(
     context: PrivateContext,
     note: Note,
     ovpk: OvpkM,
-    ivpk: IvpkM,
     recipient: AztecAddress,
 ) -> (u32, [u8; 417 + N * 32], Field)
 where
     Note: NoteInterface<N>,
 {
     let ovsk_app = get_ovsk_app(ovpk.hash());
-    compute_payload_and_hash(context, note, ovsk_app, ovpk, ivpk, recipient)
+    compute_payload_and_hash(context, note, ovsk_app, ovpk, recipient)
 }
 
 // This function seems to be affected by the following Noir bug:
@@ -63,9 +61,8 @@ where
 pub fn encode_and_encrypt_note<Note, let N: u32>(
     context: &mut PrivateContext,
     ovpk: OvpkM,
-    ivpk: IvpkM,
     recipient: AztecAddress,
-) -> fn[(&mut PrivateContext, OvpkM, IvpkM, AztecAddress)](NoteEmission<Note>) -> ()
+) -> fn[(&mut PrivateContext, OvpkM, AztecAddress)](NoteEmission<Note>) -> ()
 where
     Note: NoteInterface<N>,
 {
@@ -73,7 +70,7 @@ where
         let ovsk_app: Field = context.request_ovsk_app(ovpk.hash());
 
         let (note_hash_counter, encrypted_log, log_hash) =
-            compute_payload_and_hash(*context, e.note, ovsk_app, ovpk, ivpk, recipient);
+            compute_payload_and_hash(*context, e.note, ovsk_app, ovpk, recipient);
         context.emit_raw_note_log(note_hash_counter, encrypted_log, log_hash);
     }
 }
@@ -81,9 +78,8 @@ where
 pub fn encode_and_encrypt_note_unconstrained<Note, let N: u32>(
     context: &mut PrivateContext,
     ovpk: OvpkM,
-    ivpk: IvpkM,
     recipient: AztecAddress,
-) -> fn[(&mut PrivateContext, OvpkM, IvpkM, AztecAddress)](NoteEmission<Note>) -> ()
+) -> fn[(&mut PrivateContext, OvpkM, AztecAddress)](NoteEmission<Note>) -> ()
 where
     Note: NoteInterface<N>,
 {
@@ -107,9 +103,8 @@ where
         // for the log to be deleted when it shouldn't have (which is fine - they can already make the content be
         // whatever), or cause for the log to not be deleted when it should have (which is also fine - it'll be a log
         // for a note that doesn't exist).
-        let (note_hash_counter, encrypted_log, log_hash) = unsafe {
-            compute_payload_and_hash_unconstrained(*context, e.note, ovpk, ivpk, recipient)
-        };
+        let (note_hash_counter, encrypted_log, log_hash) =
+            unsafe { compute_payload_and_hash_unconstrained(*context, e.note, ovpk, recipient) };
         context.emit_raw_note_log(note_hash_counter, encrypted_log, log_hash);
     }
 }

--- a/noir-projects/aztec-nr/aztec/src/encrypted_logs/payload.nr
+++ b/noir-projects/aztec-nr/aztec/src/encrypted_logs/payload.nr
@@ -1,10 +1,6 @@
 use dep::protocol_types::{
-    address::AztecAddress,
-    constants::GENERATOR_INDEX__SYMMETRIC_KEY,
-    hash::poseidon2_hash_with_separator,
-    point::Point,
-    public_keys::{IvpkM, OvpkM},
-    scalar::Scalar,
+    address::AztecAddress, constants::GENERATOR_INDEX__SYMMETRIC_KEY,
+    hash::poseidon2_hash_with_separator, point::Point, public_keys::OvpkM, scalar::Scalar,
 };
 use std::{
     aes128::aes128_encrypt, embedded_curve_ops::fixed_base_scalar_mul as derive_public_key,
@@ -122,7 +118,7 @@ pub fn compute_incoming_body_ciphertext<let P: u32>(
     aes128_encrypt(plaintext, iv, sym_key)
 }
 
-/// Encrypts ephemeral secret key and recipient's ivpk --> with this information the recipient of outgoing will
+/// Encrypts ephemeral secret key and recipient's address point --> with this information the recipient of outgoing will
 /// be able to derive the key with which the incoming log can be decrypted.
 pub fn compute_outgoing_body_ciphertext(
     recipient: AztecAddress,
@@ -138,7 +134,8 @@ pub fn compute_outgoing_body_ciphertext(
     let serialized_eph_sk_low: [u8; 32] = eph_sk.lo.to_be_bytes();
 
     let address_bytes: [u8; 32] = recipient.to_field().to_be_bytes();
-    let serialized_recipient_ivpk = point_to_bytes(recipient.to_address_point().to_point());
+    let serialized_recipient_address_point =
+        point_to_bytes(recipient.to_address_point().to_point());
 
     for i in 0..32 {
         buffer[i] = serialized_eph_sk_high[i];
@@ -146,7 +143,7 @@ pub fn compute_outgoing_body_ciphertext(
         buffer[i + 64] = address_bytes[i];
     }
     for i in 0..32 {
-        buffer[i + 96] = serialized_recipient_ivpk[i];
+        buffer[i + 96] = serialized_recipient_address_point[i];
     }
 
     // We compute the symmetric key using poseidon.
@@ -172,10 +169,7 @@ mod test {
         compute_private_log_payload,
     };
     use dep::protocol_types::{
-        address::AztecAddress,
-        point::Point,
-        public_keys::{IvpkM, OvpkM},
-        scalar::Scalar,
+        address::AztecAddress, point::Point, public_keys::OvpkM, scalar::Scalar,
     };
     use protocol_types::public_keys::AddressPoint;
     use std::embedded_curve_ops::fixed_base_scalar_mul as derive_public_key;
@@ -192,14 +186,6 @@ mod test {
             inner: Point {
                 x: 0x07f696b8b233de2c1935e43c793399586f532da5ff7c0356636a75acb862e964,
                 y: 0x156e8a3e42bfca3663936ba98c7fd26386a14657c23b5f5146f1a94b6c465154,
-                is_infinite: false,
-            },
-        };
-
-        let ivpk_m = IvpkM {
-            inner: Point {
-                x: 0x18dd22d6a4032eefe3a7a55703f583396596235f7c186e450c92981186ee7404,
-                y: 0x2e49e00996565114016a1a478309842ecbaf930fb716c3f498e7e10370631d75,
                 is_infinite: false,
             },
         };
@@ -282,7 +268,7 @@ mod test {
             0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 3,
         ];
 
-        // `compute_incoming_body_ciphertext(...)` function then derives symmetric key from `eph_sk` and `ivpk` and encrypts
+        // `compute_incoming_body_ciphertext(...)` function then derives symmetric key from `eph_sk` and `address_point` and encrypts
         // the note plaintext using AES-128.
         let ciphertext = compute_incoming_body_ciphertext(plaintext, eph_sk, address_point);
 

--- a/noir-projects/aztec-nr/easy-private-state/src/easy_private_uint.nr
+++ b/noir-projects/aztec-nr/easy-private-state/src/easy_private_uint.nr
@@ -33,7 +33,6 @@ impl EasyPrivateUint<&mut PrivateContext> {
         self.set.insert(&mut addend_note).emit(encode_and_encrypt_note(
             self.context,
             outgoing_viewer_keys.ovpk_m,
-            owner_keys.ivpk_m,
             owner,
         ));
         // docs:end:insert
@@ -65,7 +64,6 @@ impl EasyPrivateUint<&mut PrivateContext> {
         self.set.insert(&mut result_note).emit(encode_and_encrypt_note(
             self.context,
             outgoing_viewer_keys.ovpk_m,
-            owner_keys.ivpk_m,
             owner,
         ));
     }

--- a/noir-projects/aztec-nr/value-note/src/utils.nr
+++ b/noir-projects/aztec-nr/value-note/src/utils.nr
@@ -32,7 +32,6 @@ pub fn increment(
     balance.insert(&mut note).emit(encode_and_encrypt_note(
         balance.context,
         outgoing_viewer_ovpk_m,
-        recipient_keys.ivpk_m,
         recipient,
     ));
 }

--- a/noir-projects/noir-contracts/contracts/app_subscription_contract/src/main.nr
+++ b/noir-projects/noir-contracts/contracts/app_subscription_contract/src/main.nr
@@ -52,7 +52,6 @@ contract AppSubscription {
         storage.subscriptions.at(user_address).replace(&mut note).emit(encode_and_encrypt_note(
             &mut context,
             keys.ovpk_m,
-            keys.ivpk_m,
             user_address,
         ));
 
@@ -118,12 +117,7 @@ contract AppSubscription {
         let mut subscription_note =
             SubscriptionNote::new(subscriber_keys.npk_m.hash(), expiry_block_number, tx_count);
         storage.subscriptions.at(subscriber).initialize_or_replace(&mut subscription_note).emit(
-            encode_and_encrypt_note(
-                &mut context,
-                msg_sender_ovpk_m,
-                subscriber_keys.ivpk_m,
-                subscriber,
-            ),
+            encode_and_encrypt_note(&mut context, msg_sender_ovpk_m, subscriber),
         );
     }
 

--- a/noir-projects/noir-contracts/contracts/card_game_contract/src/cards.nr
+++ b/noir-projects/noir-contracts/contracts/card_game_contract/src/cards.nr
@@ -110,7 +110,6 @@ impl Deck<&mut PrivateContext> {
     pub fn add_cards<let N: u32>(&mut self, cards: [Card; N], owner: AztecAddress) -> [CardNote] {
         let owner_keys = get_public_keys(owner);
 
-        let owner_ivpk_m = owner_keys.ivpk_m;
         let owner_npk_m_hash = owner_keys.npk_m.hash();
         let msg_sender_ovpk_m = get_public_keys(self.set.context.msg_sender()).ovpk_m;
 
@@ -120,7 +119,6 @@ impl Deck<&mut PrivateContext> {
             self.set.insert(&mut card_note.note).emit(encode_and_encrypt_note(
                 self.set.context,
                 msg_sender_ovpk_m,
-                owner_ivpk_m,
                 owner,
             ));
             inserted_cards = inserted_cards.push_back(card_note);

--- a/noir-projects/noir-contracts/contracts/child_contract/src/main.nr
+++ b/noir-projects/noir-contracts/contracts/child_contract/src/main.nr
@@ -62,7 +62,6 @@ contract Child {
         storage.a_map_with_private_values.at(owner).insert(&mut note).emit(encode_and_encrypt_note(
             &mut context,
             owner_keys.ovpk_m,
-            owner_keys.ivpk_m,
             owner,
         ));
         new_value

--- a/noir-projects/noir-contracts/contracts/crowdfunding_contract/src/main.nr
+++ b/noir-projects/noir-contracts/contracts/crowdfunding_contract/src/main.nr
@@ -89,7 +89,6 @@ contract Crowdfunding {
         storage.donation_receipts.insert(&mut note).emit(encode_and_encrypt_note(
             &mut context,
             donor_keys.ovpk_m,
-            donor_keys.ivpk_m,
             donor,
         ));
     }

--- a/noir-projects/noir-contracts/contracts/docs_example_contract/src/main.nr
+++ b/noir-projects/noir-contracts/contracts/docs_example_contract/src/main.nr
@@ -180,7 +180,6 @@ contract DocsExample {
         storage.private_immutable.initialize(&mut new_card).emit(encode_and_encrypt_note(
             &mut context,
             msg_sender_keys.ovpk_m,
-            msg_sender_keys.ivpk_m,
             context.msg_sender(),
         ));
     }
@@ -196,7 +195,6 @@ contract DocsExample {
         storage.legendary_card.initialize(&mut legendary_card).emit(encode_and_encrypt_note(
             &mut context,
             msg_sender_keys.ovpk_m,
-            msg_sender_keys.ivpk_m,
             context.msg_sender(),
         ));
     }
@@ -210,7 +208,6 @@ contract DocsExample {
             storage.set.insert(&mut note).emit(encode_and_encrypt_note(
                 &mut context,
                 msg_sender_keys.ovpk_m,
-                msg_sender_keys.ivpk_m,
                 context.msg_sender(),
             ));
         }
@@ -223,7 +220,6 @@ contract DocsExample {
         storage.set.insert(&mut note).emit(encode_and_encrypt_note(
             &mut context,
             msg_sender_keys.ovpk_m,
-            msg_sender_keys.ivpk_m,
             context.msg_sender(),
         ));
     }
@@ -241,7 +237,6 @@ contract DocsExample {
         storage.legendary_card.replace(&mut new_card).emit(encode_and_encrypt_note(
             &mut context,
             msg_sender_keys.ovpk_m,
-            msg_sender_keys.ivpk_m,
             context.msg_sender(),
         ));
         DocsExample::at(context.this_address()).update_leader(context.msg_sender(), points).enqueue(
@@ -263,7 +258,6 @@ contract DocsExample {
         storage.legendary_card.replace(&mut new_card).emit(encode_and_encrypt_note(
             &mut context,
             msg_sender_keys.ovpk_m,
-            msg_sender_keys.ivpk_m,
             context.msg_sender(),
         ));
         // docs:end:state_vars-PrivateMutableReplace

--- a/noir-projects/noir-contracts/contracts/ecdsa_k_account_contract/src/main.nr
+++ b/noir-projects/noir-contracts/contracts/ecdsa_k_account_contract/src/main.nr
@@ -38,7 +38,6 @@ contract EcdsaKAccount {
         storage.public_key.initialize(&mut pub_key_note).emit(encode_and_encrypt_note(
             &mut context,
             this_keys.ovpk_m,
-            this_keys.ivpk_m,
             this,
         ));
     }

--- a/noir-projects/noir-contracts/contracts/ecdsa_r_account_contract/src/main.nr
+++ b/noir-projects/noir-contracts/contracts/ecdsa_r_account_contract/src/main.nr
@@ -37,7 +37,6 @@ contract EcdsaRAccount {
         storage.public_key.initialize(&mut pub_key_note).emit(encode_and_encrypt_note(
             &mut context,
             this_keys.ovpk_m,
-            this_keys.ivpk_m,
             this,
         ));
     }

--- a/noir-projects/noir-contracts/contracts/escrow_contract/src/main.nr
+++ b/noir-projects/noir-contracts/contracts/escrow_contract/src/main.nr
@@ -32,7 +32,6 @@ contract Escrow {
         storage.owner.initialize(&mut note).emit(encode_and_encrypt_note(
             &mut context,
             msg_sender_keys.ovpk_m,
-            owner_keys.ivpk_m,
             owner,
         ));
     }

--- a/noir-projects/noir-contracts/contracts/inclusion_proofs_contract/src/main.nr
+++ b/noir-projects/noir-contracts/contracts/inclusion_proofs_contract/src/main.nr
@@ -40,7 +40,6 @@ contract InclusionProofs {
         storage.private_values.at(owner).insert(&mut note).emit(encode_and_encrypt_note(
             &mut context,
             msg_sender_keys.ovpk_m,
-            owner_keys.ivpk_m,
             owner,
         ));
     }

--- a/noir-projects/noir-contracts/contracts/nft_contract/src/main.nr
+++ b/noir-projects/noir-contracts/contracts/nft_contract/src/main.nr
@@ -309,7 +309,6 @@ contract NFT {
         nfts.at(to).insert(&mut new_note).emit(encode_and_encrypt_note(
             &mut context,
             from_ovpk_m,
-            to_keys.ivpk_m,
             to,
         ));
     }

--- a/noir-projects/noir-contracts/contracts/pending_note_hashes_contract/src/main.nr
+++ b/noir-projects/noir-contracts/contracts/pending_note_hashes_contract/src/main.nr
@@ -47,7 +47,6 @@ contract PendingNoteHashes {
         owner_balance.insert(&mut note).emit(encode_and_encrypt_note(
             &mut context,
             outgoing_viewer_keys.ovpk_m,
-            owner_keys.ivpk_m,
             owner,
         ));
 
@@ -100,7 +99,6 @@ contract PendingNoteHashes {
         owner_balance.insert(&mut note).emit(encode_and_encrypt_note(
             &mut context,
             outgoing_viewer_keys.ovpk_m,
-            owner_keys.ivpk_m,
             owner,
         ));
     }
@@ -126,7 +124,6 @@ contract PendingNoteHashes {
         owner_balance.insert(&mut note).emit(encode_and_encrypt_note(
             &mut context,
             outgoing_viewer_keys.ovpk_m,
-            owner_keys.ivpk_m,
             owner,
         ));
     }
@@ -145,20 +142,10 @@ contract PendingNoteHashes {
         // Insert note
         let emission = owner_balance.insert(&mut note);
 
-        emission.emit(encode_and_encrypt_note(
-            &mut context,
-            outgoing_viewer_keys.ovpk_m,
-            owner_keys.ivpk_m,
-            owner,
-        ));
+        emission.emit(encode_and_encrypt_note(&mut context, outgoing_viewer_keys.ovpk_m, owner));
 
         // Emit note again
-        emission.emit(encode_and_encrypt_note(
-            &mut context,
-            outgoing_viewer_keys.ovpk_m,
-            owner_keys.ivpk_m,
-            owner,
-        ));
+        emission.emit(encode_and_encrypt_note(&mut context, outgoing_viewer_keys.ovpk_m, owner));
     }
 
     // Nested/inner function to get a note and confirm it matches the expected value
@@ -379,7 +366,6 @@ contract PendingNoteHashes {
         owner_balance.insert(&mut good_note).emit(encode_and_encrypt_note(
             &mut context,
             outgoing_viewer_keys.ovpk_m,
-            owner_keys.ivpk_m,
             owner,
         ));
 
@@ -393,7 +379,6 @@ contract PendingNoteHashes {
         NoteEmission::new(bad_note).emit(encode_and_encrypt_note(
             &mut context,
             outgoing_viewer_keys.ovpk_m,
-            owner_keys.ivpk_m,
             owner,
         ));
     }
@@ -409,7 +394,6 @@ contract PendingNoteHashes {
 
         let owner_keys = get_public_keys(owner);
         let owner_npk_m_hash = owner_keys.npk_m.hash();
-        let owner_ivpk_m = owner_keys.ivpk_m;
         let outgoing_viewer_ovpk_m = get_public_keys(outgoing_viewer).ovpk_m;
 
         for i in 0..max_notes_per_call() {
@@ -417,7 +401,6 @@ contract PendingNoteHashes {
             owner_balance.insert(&mut note).emit(encode_and_encrypt_note(
                 context,
                 outgoing_viewer_ovpk_m,
-                owner_ivpk_m,
                 owner,
             ));
         }

--- a/noir-projects/noir-contracts/contracts/schnorr_account_contract/src/main.nr
+++ b/noir-projects/noir-contracts/contracts/schnorr_account_contract/src/main.nr
@@ -44,7 +44,6 @@ contract SchnorrAccount {
         storage.signing_public_key.initialize(&mut pub_key_note).emit(encode_and_encrypt_note(
             &mut context,
             this_keys.ovpk_m,
-            this_keys.ivpk_m,
             this,
         ));
     }

--- a/noir-projects/noir-contracts/contracts/spam_contract/src/main.nr
+++ b/noir-projects/noir-contracts/contracts/spam_contract/src/main.nr
@@ -36,12 +36,7 @@ contract Spam {
 
         for _ in 0..MAX_NOTE_HASHES_PER_CALL {
             storage.balances.at(caller).add(caller_keys.npk_m, U128::from_integer(amount)).emit(
-                encode_and_encrypt_note_unconstrained(
-                    &mut context,
-                    caller_keys.ovpk_m,
-                    caller_keys.ivpk_m,
-                    caller,
-                ),
+                encode_and_encrypt_note_unconstrained(&mut context, caller_keys.ovpk_m, caller),
             );
         }
 

--- a/noir-projects/noir-contracts/contracts/static_child_contract/src/main.nr
+++ b/noir-projects/noir-contracts/contracts/static_child_contract/src/main.nr
@@ -53,7 +53,6 @@ contract StaticChild {
         storage.a_private_value.insert(&mut note).emit(encode_and_encrypt_note(
             &mut context,
             msg_sender_keys.ovpk_m,
-            owner_keys.ivpk_m,
             owner,
         ));
         new_value
@@ -73,7 +72,6 @@ contract StaticChild {
         storage.a_private_value.insert(&mut note).emit(encode_and_encrypt_note(
             &mut context,
             outgoing_viewer_keys.ovpk_m,
-            owner_keys.ivpk_m,
             owner,
         ));
         new_value

--- a/noir-projects/noir-contracts/contracts/test_contract/src/main.nr
+++ b/noir-projects/noir-contracts/contracts/test_contract/src/main.nr
@@ -109,7 +109,6 @@ contract Test {
         create_note(&mut context, storage_slot, &mut note).emit(encode_and_encrypt_note(
             &mut context,
             outgoing_viewer_keys.ovpk_m,
-            owner_keys.ivpk_m,
             owner,
         ));
     }
@@ -289,7 +288,6 @@ contract Test {
         outgoing_viewer: AztecAddress,
         nest: bool,
     ) {
-        let owner_ivpk_m = get_public_keys(owner).ivpk_m;
         let outgoing_viewer_ovpk_m = get_public_keys(outgoing_viewer).ovpk_m;
 
         let event = ExampleEvent {
@@ -305,7 +303,6 @@ contract Test {
             // testing only - a secret random value is passed in here to salt / mask the address
             5,
             outgoing_viewer_ovpk_m,
-            owner_ivpk_m,
             owner,
         ));
 
@@ -323,7 +320,6 @@ contract Test {
                 // testing only - a randomness of 0 signals the kernels to not mask the address
                 0,
                 outgoing_viewer_ovpk_m,
-                owner_ivpk_m,
                 owner,
             ));
         }
@@ -348,7 +344,6 @@ contract Test {
         create_note(&mut context, storage_slot, &mut note).emit(encode_and_encrypt_note(
             &mut context,
             msg_sender_keys.ovpk_m,
-            owner_keys.ivpk_m,
             owner,
         ));
         storage_slot += 1;

--- a/noir-projects/noir-contracts/contracts/test_log_contract/src/main.nr
+++ b/noir-projects/noir-contracts/contracts/test_log_contract/src/main.nr
@@ -47,7 +47,6 @@ contract TestLog {
             randomness[0],
             // outgoing is set to other, incoming is set to msg sender
             other_keys.ovpk_m,
-            msg_sender_keys.ivpk_m,
             context.msg_sender(),
         ));
 
@@ -57,7 +56,6 @@ contract TestLog {
             randomness[0],
             // outgoing is set to msg sender, incoming is set to other
             msg_sender_keys.ovpk_m,
-            other_keys.ivpk_m,
             other,
         ));
 
@@ -71,7 +69,6 @@ contract TestLog {
             randomness[1],
             // outgoing is set to other, incoming is set to msg sender
             other_keys.ovpk_m,
-            msg_sender_keys.ivpk_m,
             context.msg_sender(),
         ));
     }

--- a/noir-projects/noir-contracts/contracts/token_blacklist_contract/src/main.nr
+++ b/noir-projects/noir-contracts/contracts/token_blacklist_contract/src/main.nr
@@ -192,12 +192,7 @@ contract TokenBlacklist {
         // TODO: constrain encryption below - we are using unconstrained here only becuase of the following Noir issue
         // https://github.com/noir-lang/noir/issues/5771
         storage.balances.add(to, U128::from_integer(amount)).emit(
-            encode_and_encrypt_note_unconstrained(
-                &mut context,
-                msg_sender_keys.ovpk_m,
-                to_keys.ivpk_m,
-                to,
-            ),
+            encode_and_encrypt_note_unconstrained(&mut context, msg_sender_keys.ovpk_m, to),
         );
     }
 
@@ -218,12 +213,7 @@ contract TokenBlacklist {
         // TODO: constrain encryption below - we are using unconstrained here only becuase of the following Noir issue
         // https://github.com/noir-lang/noir/issues/5771
         storage.balances.sub(from, U128::from_integer(amount)).emit(
-            encode_and_encrypt_note_unconstrained(
-                &mut context,
-                from_keys.ovpk_m,
-                from_keys.ivpk_m,
-                from,
-            ),
+            encode_and_encrypt_note_unconstrained(&mut context, from_keys.ovpk_m, from),
         );
 
         TokenBlacklist::at(context.this_address())._increase_public_balance(to, amount).enqueue(
@@ -252,13 +242,11 @@ contract TokenBlacklist {
         storage.balances.sub(from, amount).emit(encode_and_encrypt_note_unconstrained(
             &mut context,
             from_keys.ovpk_m,
-            from_keys.ivpk_m,
             from,
         ));
         storage.balances.add(to, amount).emit(encode_and_encrypt_note_unconstrained(
             &mut context,
             from_keys.ovpk_m,
-            to_keys.ivpk_m,
             to,
         ));
     }
@@ -278,12 +266,7 @@ contract TokenBlacklist {
         // TODO: constrain encryption below - we are using unconstrained here only becuase of the following Noir issue
         // https://github.com/noir-lang/noir/issues/5771
         storage.balances.sub(from, U128::from_integer(amount)).emit(
-            encode_and_encrypt_note_unconstrained(
-                &mut context,
-                from_keys.ovpk_m,
-                from_keys.ivpk_m,
-                from,
-            ),
+            encode_and_encrypt_note_unconstrained(&mut context, from_keys.ovpk_m, from),
         );
 
         TokenBlacklist::at(context.this_address())._reduce_total_supply(amount).enqueue(&mut context);

--- a/noir-projects/noir-contracts/contracts/token_contract/src/main.nr
+++ b/noir-projects/noir-contracts/contracts/token_contract/src/main.nr
@@ -226,7 +226,7 @@ contract Token {
         let caller = context.msg_sender();
         let caller_keys = get_public_keys(caller);
         storage.balances.at(caller).add(caller_keys.npk_m, U128::from_integer(amount)).emit(
-            encode_and_encrypt_note(&mut context, caller_keys.ovpk_m, caller_keys.ivpk_m, caller),
+            encode_and_encrypt_note(&mut context, caller_keys.ovpk_m, caller),
         );
         Token::at(context.this_address())
             .assert_minter_and_mint(context.msg_sender(), amount)
@@ -308,7 +308,7 @@ contract Token {
         let from_keys = get_public_keys(from);
         let to_keys = get_public_keys(to);
         storage.balances.at(to).add(to_keys.npk_m, U128::from_integer(amount)).emit(
-            encode_and_encrypt_note(&mut context, from_keys.ovpk_m, to_keys.ivpk_m, to),
+            encode_and_encrypt_note(&mut context, from_keys.ovpk_m, to),
         );
     }
     // docs:end:redeem_shield
@@ -325,12 +325,7 @@ contract Token {
         // TODO: constrain encryption below - we are using unconstrained here only becuase of the following Noir issue
         // https://github.com/noir-lang/noir/issues/5771
         storage.balances.at(from).sub(from_keys.npk_m, U128::from_integer(amount)).emit(
-            encode_and_encrypt_note_unconstrained(
-                &mut context,
-                from_keys.ovpk_m,
-                from_keys.ivpk_m,
-                from,
-            ),
+            encode_and_encrypt_note_unconstrained(&mut context, from_keys.ovpk_m, from),
         );
         Token::at(context.this_address())._increase_public_balance(to, amount).enqueue(&mut context);
     }
@@ -358,32 +353,17 @@ contract Token {
             INITIAL_TRANSFER_CALL_MAX_NOTES,
         );
         storage.balances.at(from).add(from_keys.npk_m, change).emit(
-            encode_and_encrypt_note_unconstrained(
-                &mut context,
-                from_keys.ovpk_m,
-                from_keys.ivpk_m,
-                from,
-            ),
+            encode_and_encrypt_note_unconstrained(&mut context, from_keys.ovpk_m, from),
         );
         storage.balances.at(to).add(to_keys.npk_m, amount).emit(
-            encode_and_encrypt_note_unconstrained(
-                &mut context,
-                from_keys.ovpk_m,
-                to_keys.ivpk_m,
-                to,
-            ),
+            encode_and_encrypt_note_unconstrained(&mut context, from_keys.ovpk_m, to),
         );
         // We don't constrain encryption of the note log in `transfer` (unlike in `transfer_from`) because the transfer
         // function is only designed to be used in situations where the event is not strictly necessary (e.g. payment to
         // another person where the payment is considered to be successful when the other party successfully decrypts a
         // note).
         Transfer { from, to, amount: amount.to_field() }.emit(
-            encode_and_encrypt_event_unconstrained(
-                &mut context,
-                from_keys.ovpk_m,
-                to_keys.ivpk_m,
-                to,
-            ),
+            encode_and_encrypt_event_unconstrained(&mut context, from_keys.ovpk_m, to),
         );
     }
     // docs:end:transfer
@@ -466,24 +446,14 @@ contract Token {
         // TODO: constrain encryption below - we are using unconstrained here only becuase of the following Noir issue
         // https://github.com/noir-lang/noir/issues/5771
         storage.balances.at(from).sub(from_keys.npk_m, amount).emit(
-            encode_and_encrypt_note_unconstrained(
-                &mut context,
-                from_keys.ovpk_m,
-                from_keys.ivpk_m,
-                from,
-            ),
+            encode_and_encrypt_note_unconstrained(&mut context, from_keys.ovpk_m, from),
         );
         // docs:end:encrypted
         // docs:end:increase_private_balance
         // TODO: constrain encryption below - we are using unconstrained here only becuase of the following Noir issue
         // https://github.com/noir-lang/noir/issues/5771
         storage.balances.at(to).add(to_keys.npk_m, amount).emit(
-            encode_and_encrypt_note_unconstrained(
-                &mut context,
-                from_keys.ovpk_m,
-                to_keys.ivpk_m,
-                to,
-            ),
+            encode_and_encrypt_note_unconstrained(&mut context, from_keys.ovpk_m, to),
         );
     }
     // docs:end:transfer_from
@@ -499,12 +469,7 @@ contract Token {
         // TODO: constrain encryption below - we are using unconstrained here only becuase of the following Noir issue
         // https://github.com/noir-lang/noir/issues/5771
         storage.balances.at(from).sub(from_keys.npk_m, U128::from_integer(amount)).emit(
-            encode_and_encrypt_note_unconstrained(
-                &mut context,
-                from_keys.ovpk_m,
-                from_keys.ivpk_m,
-                from,
-            ),
+            encode_and_encrypt_note_unconstrained(&mut context, from_keys.ovpk_m, from),
         );
         Token::at(context.this_address())._reduce_total_supply(amount).enqueue(&mut context);
     }
@@ -557,12 +522,7 @@ contract Token {
             INITIAL_TRANSFER_CALL_MAX_NOTES,
         );
         storage.balances.at(user).add(user_keys.npk_m, change).emit(
-            encode_and_encrypt_note_unconstrained(
-                &mut context,
-                user_keys.ovpk_m,
-                user_keys.ivpk_m,
-                user,
-            ),
+            encode_and_encrypt_note_unconstrained(&mut context, user_keys.ovpk_m, user),
         );
 
         // 4. Now we get the partial payloads


### PR DESCRIPTION
Now that we encrypt using address points and not ivpk's, ivpk's were removed from the encryption APIs. This change just removes the unused variable to clean up the interfaces and is a step to not require any public keys of the recipient.
