### PR TITLE
fix: replace npk_m_hash with addresses

### DIFF
--- a/boxes/boxes/react/src/contracts/src/main.nr
+++ b/boxes/boxes/react/src/contracts/src/main.nr
@@ -20,11 +20,10 @@ contract BoxReact {
     fn constructor(
         number: Field,
         owner: AztecAddress,
-        owner_npk_m_hash: Field,
         owner_ovpk_m: OvpkM
     ) {
         let numbers = storage.numbers;
-        let mut new_number = ValueNote::new(number, owner_npk_m_hash);
+        let mut new_number = ValueNote::new(number, owner);
         numbers.at(owner).initialize(&mut new_number).emit(encode_and_encrypt_note(&mut context, owner_ovpk_m, owner));
     }
 
@@ -32,11 +31,10 @@ contract BoxReact {
     fn setNumber(
         number: Field,
         owner: AztecAddress,
-        owner_npk_m_hash: Field,
         owner_ovpk_m: OvpkM
     ) {
         let numbers = storage.numbers;
-        let mut new_number = ValueNote::new(number, owner_npk_m_hash);
+        let mut new_number = ValueNote::new(number, owner);
         numbers.at(owner).replace(&mut new_number).emit(encode_and_encrypt_note(&mut context, owner_ovpk_m, owner));
     }
 

--- a/boxes/boxes/react/src/hooks/useContract.tsx
+++ b/boxes/boxes/react/src/hooks/useContract.tsx
@@ -15,13 +15,12 @@ export function useContract() {
     setWait(true);
     const wallet = await deployerEnv.getWallet();
     const salt = Fr.random();
-    const { masterNullifierPublicKey, masterOutgoingViewingPublicKey } =
+    const { masterOutgoingViewingPublicKey } =
       wallet.getCompleteAddress().publicKeys;
     const tx = await BoxReactContract.deploy(
       wallet,
       Fr.random(),
       wallet.getCompleteAddress().address,
-      masterNullifierPublicKey.hash(),
       masterOutgoingViewingPublicKey.toWrappedNoirStruct(),
     ).send({
       contractAddressSalt: salt,

--- a/boxes/boxes/react/src/hooks/useNumber.tsx
+++ b/boxes/boxes/react/src/hooks/useNumber.tsx
@@ -32,7 +32,6 @@ export function useNumber({ contract }: { contract: Contract }) {
           .setNumber(
             value,
             deployerWallet.getCompleteAddress().address,
-            masterNullifierPublicKey.hash(),
             masterOutgoingViewingPublicKey.toWrappedNoirStruct(),
           )
           .send()

--- a/boxes/boxes/react/tests/node.test.ts
+++ b/boxes/boxes/react/tests/node.test.ts
@@ -20,7 +20,6 @@ describe('BoxReact Contract Tests', () => {
       wallet,
       Fr.random(),
       accountCompleteAddress.address,
-      masterNullifierPublicKey.hash(),
       masterOutgoingViewingPublicKey.toWrappedNoirStruct()
     )
       .send({ contractAddressSalt: salt })
@@ -37,7 +36,6 @@ describe('BoxReact Contract Tests', () => {
       .setNumber(
         numberToSet,
         accountCompleteAddress.address,
-        masterNullifierPublicKey.hash(),
         masterOutgoingViewingPublicKey.toWrappedNoirStruct(),
       )
       .send()

--- a/boxes/boxes/vanilla/src/contracts/src/main.nr
+++ b/boxes/boxes/vanilla/src/contracts/src/main.nr
@@ -20,11 +20,10 @@ contract Vanilla {
     fn constructor(
         number: Field,
         owner: AztecAddress,
-        owner_npk_m_hash: Field,
         owner_ovpk_m: OvpkM
     ) {
         let numbers = storage.numbers;
-        let mut new_number = ValueNote::new(number, owner_npk_m_hash);
+        let mut new_number = ValueNote::new(number, owner);
         numbers.at(owner).initialize(&mut new_number).emit(encode_and_encrypt_note(&mut context, owner_ovpk_m, owner));
     }
 
@@ -32,11 +31,10 @@ contract Vanilla {
     fn setNumber(
         number: Field,
         owner: AztecAddress,
-        owner_npk_m_hash: Field,
         owner_ovpk_m: OvpkM
     ) {
         let numbers = storage.numbers;
-        let mut new_number = ValueNote::new(number, owner_npk_m_hash);
+        let mut new_number = ValueNote::new(number, owner);
         numbers.at(owner).replace(&mut new_number).emit(encode_and_encrypt_note(&mut context, owner_ovpk_m, owner));
     }
 

--- a/boxes/boxes/vanilla/src/index.ts
+++ b/boxes/boxes/vanilla/src/index.ts
@@ -26,7 +26,6 @@ document.querySelector('#deploy').addEventListener('click', async ({ target }: a
     wallet,
     Fr.random(),
     wallet.getCompleteAddress().address,
-    masterNullifierPublicKey.hash(),
     masterOutgoingViewingPublicKey.toWrappedNoirStruct(),
   )
     .send({ contractAddressSalt: Fr.random() })
@@ -49,7 +48,6 @@ document.querySelector('#set').addEventListener('submit', async (e: Event) => {
     .setNumber(
       parseInt(value),
       owner,
-      masterNullifierPublicKey.hash(),
       masterOutgoingViewingPublicKey.toWrappedNoirStruct(),
     )
     .send()

--- a/noir-projects/aztec-nr/address-note/src/address_note.nr
+++ b/noir-projects/aztec-nr/address-note/src/address_note.nr
@@ -1,6 +1,6 @@
 use dep::aztec::{
     context::PrivateContext,
-    keys::getters::get_nsk_app,
+    keys::getters::{get_nsk_app, get_public_keys},
     macros::notes::note,
     note::{
         note_header::NoteHeader, note_interface::NullifiableNote,
@@ -20,7 +20,7 @@ use dep::aztec::{
 pub struct AddressNote {
     address: AztecAddress,
     // The nullifying public key hash is used with the nsk_app to ensure that the note can be privately spent.
-    npk_m_hash: Field,
+    owner: AztecAddress,
     randomness: Field,
 }
 // docs:end:address_note_struct
@@ -32,7 +32,8 @@ impl NullifiableNote for AddressNote {
         context: &mut PrivateContext,
         note_hash_for_nullify: Field,
     ) -> Field {
-        let secret = context.request_nsk_app(self.npk_m_hash);
+        let owner_npk_m_hash = get_public_keys(self.owner).npk_m.hash();
+        let secret = context.request_nsk_app(owner_npk_m_hash);
         poseidon2_hash_with_separator(
             [note_hash_for_nullify, secret],
             GENERATOR_INDEX__NOTE_NULLIFIER as Field,
@@ -41,7 +42,8 @@ impl NullifiableNote for AddressNote {
 
     unconstrained fn compute_nullifier_without_context(self) -> Field {
         let note_hash_for_nullify = compute_note_hash_for_nullify(self);
-        let secret = get_nsk_app(self.npk_m_hash);
+        let owner_npk_m_hash = get_public_keys(self.owner).npk_m.hash();
+        let secret = get_nsk_app(owner_npk_m_hash);
         poseidon2_hash_with_separator(
             [note_hash_for_nullify, secret],
             GENERATOR_INDEX__NOTE_NULLIFIER as Field,
@@ -50,13 +52,13 @@ impl NullifiableNote for AddressNote {
 }
 
 impl AddressNote {
-    pub fn new(address: AztecAddress, npk_m_hash: Field) -> Self {
+    pub fn new(address: AztecAddress, owner: AztecAddress) -> Self {
         // We use the randomness to preserve the privacy of the note recipient by preventing brute-forcing, so a
         // malicious sender could use non-random values to make the note less private. But they already know the full
         // note pre-image anyway, and so the recipient already trusts them to not disclose this information. We can
         // therefore assume that the sender will cooperate in the random value generation.
         let randomness = unsafe { random() };
-        AddressNote { address, npk_m_hash, randomness, header: NoteHeader::empty() }
+        AddressNote { address, owner, randomness, header: NoteHeader::empty() }
     }
     // docs:end:address_note_def
 }

--- a/noir-projects/aztec-nr/easy-private-state/src/easy_private_uint.nr
+++ b/noir-projects/aztec-nr/easy-private-state/src/easy_private_uint.nr
@@ -23,10 +23,9 @@ impl<Context> EasyPrivateUint<Context> {
 impl EasyPrivateUint<&mut PrivateContext> {
     // Very similar to `value_note::utils::increment`.
     pub fn add(self, addend: u64, owner: AztecAddress, outgoing_viewer: AztecAddress) {
-        let owner_keys = get_public_keys(owner);
         let outgoing_viewer_keys = get_public_keys(outgoing_viewer);
         // Creates new note for the owner.
-        let mut addend_note = ValueNote::new(addend as Field, owner_keys.npk_m.hash());
+        let mut addend_note = ValueNote::new(addend as Field, owner);
 
         // Insert the new note to the owner's set of notes.
         // docs:start:insert
@@ -40,7 +39,6 @@ impl EasyPrivateUint<&mut PrivateContext> {
 
     // Very similar to `value_note::utils::decrement`.
     pub fn sub(self, subtrahend: u64, owner: AztecAddress, outgoing_viewer: AztecAddress) {
-        let owner_keys = get_public_keys(owner);
         let outgoing_viewer_keys = get_public_keys(outgoing_viewer);
 
         // docs:start:pop_notes
@@ -60,7 +58,7 @@ impl EasyPrivateUint<&mut PrivateContext> {
 
         // Creates change note for the owner.
         let result_value = minuend - subtrahend;
-        let mut result_note = ValueNote::new(result_value as Field, owner_keys.npk_m.hash());
+        let mut result_note = ValueNote::new(result_value as Field, owner);
         self.set.insert(&mut result_note).emit(encode_and_encrypt_note(
             self.context,
             outgoing_viewer_keys.ovpk_m,

--- a/noir-projects/aztec-nr/uint-note/src/uint_note.nr
+++ b/noir-projects/aztec-nr/uint-note/src/uint_note.nr
@@ -1,11 +1,12 @@
 use dep::aztec::{
-    keys::getters::get_nsk_app,
+    keys::getters::{get_nsk_app, get_public_keys},
     macros::notes::partial_note,
     note::utils::compute_note_hash_for_nullify,
     oracle::random::random,
     prelude::{NoteHeader, NullifiableNote, PrivateContext},
     protocol_types::{
-        constants::GENERATOR_INDEX__NOTE_NULLIFIER, hash::poseidon2_hash_with_separator,
+        address::AztecAddress, constants::GENERATOR_INDEX__NOTE_NULLIFIER,
+        hash::poseidon2_hash_with_separator,
     },
 };
 
@@ -14,8 +15,7 @@ use dep::aztec::{
 pub struct UintNote {
     // The amount of tokens in the note
     value: U128,
-    // The nullifying public key hash is used with the nsk_app to ensure that the note can be privately spent.
-    npk_m_hash: Field,
+    owner: AztecAddress,
     // Randomness of the note to hide its contents
     randomness: Field,
 }
@@ -28,7 +28,8 @@ impl NullifiableNote for UintNote {
         context: &mut PrivateContext,
         note_hash_for_nullify: Field,
     ) -> Field {
-        let secret = context.request_nsk_app(self.npk_m_hash);
+        let owner_npk_m_hash = get_public_keys(self.owner).npk_m.hash();
+        let secret = context.request_nsk_app(owner_npk_m_hash);
         poseidon2_hash_with_separator(
             [note_hash_for_nullify, secret],
             GENERATOR_INDEX__NOTE_NULLIFIER as Field,
@@ -38,7 +39,8 @@ impl NullifiableNote for UintNote {
 
     unconstrained fn compute_nullifier_without_context(self) -> Field {
         let note_hash_for_nullify = compute_note_hash_for_nullify(self);
-        let secret = get_nsk_app(self.npk_m_hash);
+        let owner_npk_m_hash = get_public_keys(self.owner).npk_m.hash();
+        let secret = get_nsk_app(owner_npk_m_hash);
         poseidon2_hash_with_separator(
             [note_hash_for_nullify, secret],
             GENERATOR_INDEX__NOTE_NULLIFIER,
@@ -49,19 +51,19 @@ impl NullifiableNote for UintNote {
 impl Eq for UintNote {
     fn eq(self, other: Self) -> bool {
         (self.value == other.value)
-            & (self.npk_m_hash == other.npk_m_hash)
+            & (self.owner == other.owner)
             & (self.randomness == other.randomness)
     }
 }
 
 impl UintNote {
-    pub fn new(value: U128, owner_npk_m_hash: Field) -> Self {
+    pub fn new(value: U128, owner: AztecAddress) -> Self {
         // We use the randomness to preserve the privacy of the note recipient by preventing brute-forcing, so a
         // malicious sender could use non-random values to make the note less private. But they already know the full
         // note pre-image anyway, and so the recipient already trusts them to not disclose this information. We can
         // therefore assume that the sender will cooperate in the random value generation.
         let randomness = unsafe { random() };
-        Self { value, npk_m_hash: owner_npk_m_hash, randomness, header: NoteHeader::empty() }
+        Self { value, owner, randomness, header: NoteHeader::empty() }
     }
 
     pub fn get_value(self) -> U128 {

--- a/noir-projects/aztec-nr/value-note/src/utils.nr
+++ b/noir-projects/aztec-nr/value-note/src/utils.nr
@@ -24,10 +24,9 @@ pub fn increment(
     recipient: AztecAddress,
     outgoing_viewer: AztecAddress, // docs:end:increment_args
 ) {
-    let recipient_keys = get_public_keys(recipient);
     let outgoing_viewer_ovpk_m = get_public_keys(outgoing_viewer).ovpk_m;
 
-    let mut note = ValueNote::new(amount, recipient_keys.npk_m.hash());
+    let mut note = ValueNote::new(amount, recipient);
     // Insert the new note to the owner's set of notes and emit the log if value is non-zero.
     balance.insert(&mut note).emit(encode_and_encrypt_note(
         balance.context,

--- a/noir-projects/aztec-nr/value-note/src/value_note.nr
+++ b/noir-projects/aztec-nr/value-note/src/value_note.nr
@@ -1,6 +1,6 @@
 use dep::aztec::{
     context::PrivateContext,
-    keys::getters::get_nsk_app,
+    keys::getters::{get_nsk_app, get_public_keys},
     macros::notes::note,
     note::{
         note_header::NoteHeader, note_interface::NullifiableNote,
@@ -8,8 +8,8 @@ use dep::aztec::{
     },
     oracle::random::random,
     protocol_types::{
-        constants::GENERATOR_INDEX__NOTE_NULLIFIER, hash::poseidon2_hash_with_separator,
-        traits::Serialize,
+        address::AztecAddress, constants::GENERATOR_INDEX__NOTE_NULLIFIER,
+        hash::poseidon2_hash_with_separator, traits::Serialize,
     },
 };
 
@@ -22,8 +22,7 @@ global VALUE_NOTE_LEN: u32 = 3; // 3 plus a header.
 #[derive(Serialize)]
 pub struct ValueNote {
     value: Field,
-    // The nullifying public key hash is used with the nsk_app to ensure that the note can be privately spent.
-    npk_m_hash: Field,
+    owner: AztecAddress,
     randomness: Field,
 }
 // docs:end:value-note-def
@@ -36,7 +35,8 @@ impl NullifiableNote for ValueNote {
         context: &mut PrivateContext,
         note_hash_for_nullify: Field,
     ) -> Field {
-        let secret = context.request_nsk_app(self.npk_m_hash);
+        let owner_npk_m_hash: Field = get_public_keys(self.owner).npk_m.hash();
+        let secret = context.request_nsk_app(owner_npk_m_hash);
         poseidon2_hash_with_separator(
             [note_hash_for_nullify, secret],
             GENERATOR_INDEX__NOTE_NULLIFIER as Field,
@@ -47,7 +47,8 @@ impl NullifiableNote for ValueNote {
 
     unconstrained fn compute_nullifier_without_context(self) -> Field {
         let note_hash_for_nullify = compute_note_hash_for_nullify(self);
-        let secret = get_nsk_app(self.npk_m_hash);
+        let owner_npk_m_hash: Field = get_public_keys(self.owner).npk_m.hash();
+        let secret = get_nsk_app(owner_npk_m_hash);
         poseidon2_hash_with_separator(
             [note_hash_for_nullify, secret],
             GENERATOR_INDEX__NOTE_NULLIFIER as Field,
@@ -56,21 +57,21 @@ impl NullifiableNote for ValueNote {
 }
 
 impl ValueNote {
-    pub fn new(value: Field, npk_m_hash: Field) -> Self {
+    pub fn new(value: Field, owner: AztecAddress) -> Self {
         // We use the randomness to preserve the privacy of the note recipient by preventing brute-forcing, so a
         // malicious sender could use non-random values to make the note less private. But they already know the full
         // note pre-image anyway, and so the recipient already trusts them to not disclose this information. We can
         // therefore assume that the sender will cooperate in the random value generation.
         let randomness = unsafe { random() };
         let header = NoteHeader::empty();
-        ValueNote { value, npk_m_hash, randomness, header }
+        ValueNote { value, owner, randomness, header }
     }
 }
 
 impl Eq for ValueNote {
     fn eq(self, other: Self) -> bool {
         (self.value == other.value)
-            & (self.npk_m_hash == other.npk_m_hash)
+            & (self.owner == other.owner)
             & (self.randomness == other.randomness)
     }
 }

--- a/noir-projects/noir-contracts/contracts/app_subscription_contract/src/main.nr
+++ b/noir-projects/noir-contracts/contracts/app_subscription_contract/src/main.nr
@@ -111,11 +111,10 @@ contract AppSubscription {
             &mut context,
         );
 
-        let subscriber_keys = get_public_keys(subscriber);
         let msg_sender_ovpk_m = get_public_keys(context.msg_sender()).ovpk_m;
 
         let mut subscription_note =
-            SubscriptionNote::new(subscriber_keys.npk_m.hash(), expiry_block_number, tx_count);
+            SubscriptionNote::new(subscriber, expiry_block_number, tx_count);
         storage.subscriptions.at(subscriber).initialize_or_replace(&mut subscription_note).emit(
             encode_and_encrypt_note(&mut context, msg_sender_ovpk_m, subscriber),
         );

--- a/noir-projects/noir-contracts/contracts/app_subscription_contract/src/subscription_note.nr
+++ b/noir-projects/noir-contracts/contracts/app_subscription_contract/src/subscription_note.nr
@@ -1,17 +1,17 @@
 use dep::aztec::{
     hash::poseidon2_hash_with_separator,
-    keys::getters::get_nsk_app,
+    keys::getters::{get_nsk_app, get_public_keys},
     macros::notes::note,
     note::utils::compute_note_hash_for_nullify,
     oracle::random::random,
     prelude::{NoteHeader, NullifiableNote, PrivateContext},
-    protocol_types::constants::GENERATOR_INDEX__NOTE_NULLIFIER,
+    protocol_types::{address::AztecAddress, constants::GENERATOR_INDEX__NOTE_NULLIFIER},
 };
 
 #[note]
 pub struct SubscriptionNote {
     // The nullifying public key hash is used with the nsk_app to ensure that the note can be privately spent.
-    npk_m_hash: Field,
+    owner: AztecAddress,
     expiry_block_number: Field,
     remaining_txs: Field,
     // Randomness of the note to hide its contents
@@ -24,7 +24,8 @@ impl NullifiableNote for SubscriptionNote {
         context: &mut PrivateContext,
         note_hash_for_nullify: Field,
     ) -> Field {
-        let secret = context.request_nsk_app(self.npk_m_hash);
+        let owner_npk_m_hash: Field = get_public_keys(self.owner).npk_m.hash();
+        let secret = context.request_nsk_app(owner_npk_m_hash);
         poseidon2_hash_with_separator(
             [note_hash_for_nullify, secret],
             GENERATOR_INDEX__NOTE_NULLIFIER as Field,
@@ -33,7 +34,8 @@ impl NullifiableNote for SubscriptionNote {
 
     unconstrained fn compute_nullifier_without_context(self) -> Field {
         let note_hash_for_nullify = compute_note_hash_for_nullify(self);
-        let secret = get_nsk_app(self.npk_m_hash);
+        let owner_npk_m_hash: Field = get_public_keys(self.owner).npk_m.hash();
+        let secret = get_nsk_app(owner_npk_m_hash);
         poseidon2_hash_with_separator(
             [note_hash_for_nullify, secret],
             GENERATOR_INDEX__NOTE_NULLIFIER as Field,
@@ -42,18 +44,12 @@ impl NullifiableNote for SubscriptionNote {
 }
 
 impl SubscriptionNote {
-    pub fn new(npk_m_hash: Field, expiry_block_number: Field, remaining_txs: Field) -> Self {
+    pub fn new(owner: AztecAddress, expiry_block_number: Field, remaining_txs: Field) -> Self {
         // We use the randomness to preserve the privacy of the note recipient by preventing brute-forcing, so a
         // malicious sender could use non-random values to make the note less private. But they already know the full
         // note pre-image anyway, and so the recipient already trusts them to not disclose this information. We can
         // therefore assume that the sender will cooperate in the random value generation.
         let randomness = unsafe { random() };
-        Self {
-            npk_m_hash,
-            expiry_block_number,
-            remaining_txs,
-            randomness,
-            header: NoteHeader::empty(),
-        }
+        Self { owner, expiry_block_number, remaining_txs, randomness, header: NoteHeader::empty() }
     }
 }

--- a/noir-projects/noir-contracts/contracts/card_game_contract/src/cards.nr
+++ b/noir-projects/noir-contracts/contracts/card_game_contract/src/cards.nr
@@ -1,4 +1,4 @@
-use dep::aztec::prelude::{AztecAddress, NoteGetterOptions, NoteViewerOptions, PrivateContext};
+use dep::aztec::prelude::{NoteGetterOptions, NoteViewerOptions, PrivateContext};
 
 use dep::aztec::{
     context::UnconstrainedContext,
@@ -6,6 +6,7 @@ use dep::aztec::{
     keys::getters::get_public_keys,
     note::constants::MAX_NOTES_PER_PAGE,
     protocol_types::{
+        address::AztecAddress,
         constants::MAX_NOTE_HASH_READ_REQUESTS_PER_CALL,
         traits::{FromField, Serialize, ToField},
     },
@@ -55,13 +56,13 @@ pub struct CardNote {
 }
 
 impl CardNote {
-    fn new(strength: u32, points: u32, npk_m_hash: Field) -> Self {
+    fn new(strength: u32, points: u32, owner: AztecAddress) -> Self {
         let card = Card { strength, points };
-        CardNote::from_card(card, npk_m_hash)
+        CardNote::from_card(card, owner)
     }
 
-    pub fn from_card(card: Card, npk_m_hash: Field) -> CardNote {
-        CardNote { card, note: ValueNote::new(card.to_field(), npk_m_hash) }
+    pub fn from_card(card: Card, owner: AztecAddress) -> CardNote {
+        CardNote { card, note: ValueNote::new(card.to_field(), owner) }
     }
 
     pub fn from_note(note: ValueNote) -> CardNote {
@@ -108,14 +109,11 @@ impl<Context> Deck<Context> {
 
 impl Deck<&mut PrivateContext> {
     pub fn add_cards<let N: u32>(&mut self, cards: [Card; N], owner: AztecAddress) -> [CardNote] {
-        let owner_keys = get_public_keys(owner);
-
-        let owner_npk_m_hash = owner_keys.npk_m.hash();
         let msg_sender_ovpk_m = get_public_keys(self.set.context.msg_sender()).ovpk_m;
 
         let mut inserted_cards = &[];
         for card in cards {
-            let mut card_note = CardNote::from_card(card, owner_npk_m_hash);
+            let mut card_note = CardNote::from_card(card, owner);
             self.set.insert(&mut card_note.note).emit(encode_and_encrypt_note(
                 self.set.context,
                 msg_sender_ovpk_m,

--- a/noir-projects/noir-contracts/contracts/child_contract/src/main.nr
+++ b/noir-projects/noir-contracts/contracts/child_contract/src/main.nr
@@ -56,12 +56,12 @@ contract Child {
 
     #[private]
     fn private_set_value(new_value: Field, owner: AztecAddress) -> Field {
-        let owner_keys = get_public_keys(owner);
+        let owner_ovpk_m = get_public_keys(owner).ovpk_m;
 
-        let mut note = ValueNote::new(new_value, owner_keys.npk_m.hash());
+        let mut note = ValueNote::new(new_value, owner);
         storage.a_map_with_private_values.at(owner).insert(&mut note).emit(encode_and_encrypt_note(
             &mut context,
-            owner_keys.ovpk_m,
+            owner_ovpk_m,
             owner,
         ));
         new_value

--- a/noir-projects/noir-contracts/contracts/crowdfunding_contract/src/main.nr
+++ b/noir-projects/noir-contracts/contracts/crowdfunding_contract/src/main.nr
@@ -82,13 +82,14 @@ contract Crowdfunding {
         // docs:end:do-transfer
         // 3) Create a value note for the donor so that he can later on claim a rewards token in the Claim
         // contract by proving that the hash of this note exists in the note hash tree.
-        let donor_keys = get_public_keys(donor);
         // docs:start:valuenote_new
-        let mut note = ValueNote::new(amount as Field, donor_keys.npk_m.hash());
+        let mut note = ValueNote::new(amount as Field, donor);
+
+        let donor_ovpk_m = get_public_keys(donor).ovpk_m;
         // docs:end:valuenote_new
         storage.donation_receipts.insert(&mut note).emit(encode_and_encrypt_note(
             &mut context,
-            donor_keys.ovpk_m,
+            donor_ovpk_m,
             donor,
         ));
     }

--- a/noir-projects/noir-contracts/contracts/docs_example_contract/src/main.nr
+++ b/noir-projects/noir-contracts/contracts/docs_example_contract/src/main.nr
@@ -174,12 +174,12 @@ contract DocsExample {
     // docs:start:initialize-private-mutable
     #[private]
     fn initialize_private_immutable(randomness: Field, points: u8) {
-        let msg_sender_keys = get_public_keys(context.msg_sender());
+        let mut new_card = CardNote::new(points, randomness, context.msg_sender());
 
-        let mut new_card = CardNote::new(points, randomness, msg_sender_keys.npk_m.hash());
+        let msg_sender_ovpk_m = get_public_keys(context.msg_sender()).ovpk_m;
         storage.private_immutable.initialize(&mut new_card).emit(encode_and_encrypt_note(
             &mut context,
-            msg_sender_keys.ovpk_m,
+            msg_sender_ovpk_m,
             context.msg_sender(),
         ));
     }
@@ -188,38 +188,38 @@ contract DocsExample {
     #[private]
     // msg_sender() is 0 at deploy time. So created another function
     fn initialize_private(randomness: Field, points: u8) {
-        let msg_sender_keys = get_public_keys(context.msg_sender());
+        let mut legendary_card = CardNote::new(points, randomness, context.msg_sender());
 
-        let mut legendary_card = CardNote::new(points, randomness, msg_sender_keys.npk_m.hash());
+        let msg_sender_ovpk_m = get_public_keys(context.msg_sender()).ovpk_m;
         // create and broadcast note
         storage.legendary_card.initialize(&mut legendary_card).emit(encode_and_encrypt_note(
             &mut context,
-            msg_sender_keys.ovpk_m,
+            msg_sender_ovpk_m,
             context.msg_sender(),
         ));
     }
 
     #[private]
     fn insert_notes(amounts: [u8; 3]) {
-        let msg_sender_keys = get_public_keys(context.msg_sender());
+        let msg_sender_ovpk_m = get_public_keys(context.msg_sender()).ovpk_m;
 
         for i in 0..amounts.len() {
-            let mut note = CardNote::new(amounts[i], 1, msg_sender_keys.npk_m.hash());
+            let mut note = CardNote::new(amounts[i], 1, context.msg_sender());
             storage.set.insert(&mut note).emit(encode_and_encrypt_note(
                 &mut context,
-                msg_sender_keys.ovpk_m,
+                msg_sender_ovpk_m,
                 context.msg_sender(),
             ));
         }
     }
     #[private]
     fn insert_note(amount: u8, randomness: Field) {
-        let msg_sender_keys = get_public_keys(context.msg_sender());
+        let mut note = CardNote::new(amount, randomness, context.msg_sender());
 
-        let mut note = CardNote::new(amount, randomness, msg_sender_keys.npk_m.hash());
+        let msg_sender_ovpk_m = get_public_keys(context.msg_sender()).ovpk_m;
         storage.set.insert(&mut note).emit(encode_and_encrypt_note(
             &mut context,
-            msg_sender_keys.ovpk_m,
+            msg_sender_ovpk_m,
             context.msg_sender(),
         ));
     }
@@ -231,12 +231,12 @@ contract DocsExample {
     // docs:end:state_vars-NoteGetterOptionsComparatorExampleNoir
     #[private]
     fn update_legendary_card(randomness: Field, points: u8) {
-        let msg_sender_keys = get_public_keys(context.msg_sender());
+        let mut new_card = CardNote::new(points, randomness, context.msg_sender());
 
-        let mut new_card = CardNote::new(points, randomness, msg_sender_keys.npk_m.hash());
+        let msg_sender_ovpk_m = get_public_keys(context.msg_sender()).ovpk_m;
         storage.legendary_card.replace(&mut new_card).emit(encode_and_encrypt_note(
             &mut context,
-            msg_sender_keys.ovpk_m,
+            msg_sender_ovpk_m,
             context.msg_sender(),
         ));
         DocsExample::at(context.this_address()).update_leader(context.msg_sender(), points).enqueue(
@@ -247,17 +247,17 @@ contract DocsExample {
     fn increase_legendary_points() {
         // Ensure `points` > current value
         // Also serves as a e2e test that you can `get_note()` and then `replace()`
-        let msg_sender_keys = get_public_keys(context.msg_sender());
-
         // docs:start:state_vars-PrivateMutableGet
         let card = storage.legendary_card.get_note().note;
         // docs:end:state_vars-PrivateMutableGet
         let points = card.points + 1;
-        let mut new_card = CardNote::new(points, card.randomness, msg_sender_keys.npk_m.hash());
+        let mut new_card = CardNote::new(points, card.randomness, context.msg_sender());
+
+        let msg_sender_ovpk_m = get_public_keys(context.msg_sender()).ovpk_m;
         // docs:start:state_vars-PrivateMutableReplace
         storage.legendary_card.replace(&mut new_card).emit(encode_and_encrypt_note(
             &mut context,
-            msg_sender_keys.ovpk_m,
+            msg_sender_ovpk_m,
             context.msg_sender(),
         ));
         // docs:end:state_vars-PrivateMutableReplace

--- a/noir-projects/noir-contracts/contracts/docs_example_contract/src/options.nr
+++ b/noir-projects/noir-contracts/contracts/docs_example_contract/src/options.nr
@@ -2,18 +2,20 @@ use crate::types::card_note::{CARD_NOTE_LEN, CardNote};
 use dep::aztec::prelude::NoteGetterOptions;
 
 use dep::aztec::{note::note_getter_options::SortOrder, utils::comparison::Comparator};
-use dep::aztec::protocol_types::constants::MAX_NOTE_HASH_READ_REQUESTS_PER_CALL;
+use dep::aztec::protocol_types::{
+    address::AztecAddress, constants::MAX_NOTE_HASH_READ_REQUESTS_PER_CALL,
+};
 
 // Shows how to use NoteGetterOptions and query for notes.
 
 // docs:start:state_vars-NoteGetterOptionsSelectSortOffset
 pub fn create_npk_card_getter_options(
-    account_npk_m_hash: Field,
+    account: AztecAddress,
     offset: u32,
 ) -> NoteGetterOptions<CardNote, CARD_NOTE_LEN, Field, Field> {
     let mut options = NoteGetterOptions::new();
     options
-        .select(CardNote::properties().npk_m_hash, Comparator.EQ, account_npk_m_hash)
+        .select(CardNote::properties().owner, Comparator.EQ, account)
         .sort(CardNote::properties().points, SortOrder.DESC)
         .set_offset(offset)
 }
@@ -23,13 +25,13 @@ pub fn create_npk_card_getter_options(
 pub fn create_exact_card_getter_options(
     points: u8,
     secret: Field,
-    account_npk_m_hash: Field,
+    account: AztecAddress,
 ) -> NoteGetterOptions<CardNote, CARD_NOTE_LEN, Field, Field> {
     let mut options = NoteGetterOptions::new();
     options
         .select(CardNote::properties().points, Comparator.EQ, points as Field)
         .select(CardNote::properties().randomness, Comparator.EQ, secret)
-        .select(CardNote::properties().npk_m_hash, Comparator.EQ, account_npk_m_hash)
+        .select(CardNote::properties().owner, Comparator.EQ, account)
 }
 // docs:end:state_vars-NoteGetterOptionsMultiSelects
 

--- a/noir-projects/noir-contracts/contracts/docs_example_contract/src/types/card_note.nr
+++ b/noir-projects/noir-contracts/contracts/docs_example_contract/src/types/card_note.nr
@@ -1,10 +1,10 @@
 use dep::aztec::{
-    keys::getters::get_nsk_app,
+    keys::getters::{get_nsk_app, get_public_keys},
     macros::notes::note,
     note::utils::compute_note_hash_for_nullify,
     protocol_types::{
-        constants::GENERATOR_INDEX__NOTE_NULLIFIER, hash::poseidon2_hash_with_separator,
-        traits::Serialize,
+        address::AztecAddress, constants::GENERATOR_INDEX__NOTE_NULLIFIER,
+        hash::poseidon2_hash_with_separator, traits::Serialize,
     },
 };
 use dep::aztec::prelude::{NoteHeader, NullifiableNote, PrivateContext};
@@ -16,15 +16,14 @@ global CARD_NOTE_LEN: u32 = 3; // 3 plus a header.
 pub struct CardNote {
     points: u8,
     randomness: Field,
-    // The nullifying public key hash is used with the nsk_app to ensure that the note can be privately spent.
-    npk_m_hash: Field,
+    owner: AztecAddress,
 }
 // docs:end:state_vars-CardNote
 
 // docs:start:cardnote_impl
 impl CardNote {
-    pub fn new(points: u8, randomness: Field, npk_m_hash: Field) -> Self {
-        CardNote { points, randomness, npk_m_hash, header: NoteHeader::empty() }
+    pub fn new(points: u8, randomness: Field, owner: AztecAddress) -> Self {
+        CardNote { points, randomness, owner, header: NoteHeader::empty() }
     }
 }
 // docs:end:cardnote_impl
@@ -36,7 +35,8 @@ impl NullifiableNote for CardNote {
         context: &mut PrivateContext,
         note_hash_for_nullify: Field,
     ) -> Field {
-        let secret = context.request_nsk_app(self.npk_m_hash);
+        let owner_npk_m_hash: Field = get_public_keys(self.owner).npk_m.hash();
+        let secret = context.request_nsk_app(owner_npk_m_hash);
         poseidon2_hash_with_separator(
             [note_hash_for_nullify, secret],
             GENERATOR_INDEX__NOTE_NULLIFIER as Field,
@@ -45,7 +45,8 @@ impl NullifiableNote for CardNote {
 
     unconstrained fn compute_nullifier_without_context(self) -> Field {
         let note_hash_for_nullify = compute_note_hash_for_nullify(self);
-        let secret = get_nsk_app(self.npk_m_hash);
+        let owner_npk_m_hash: Field = get_public_keys(self.owner).npk_m.hash();
+        let secret = get_nsk_app(owner_npk_m_hash);
         poseidon2_hash_with_separator(
             [note_hash_for_nullify, secret],
             GENERATOR_INDEX__NOTE_NULLIFIER as Field,
@@ -57,7 +58,7 @@ impl NullifiableNote for CardNote {
 // docs:start:serialize
 impl Serialize<3> for CardNote {
     fn serialize(self) -> [Field; 3] {
-        [self.points.to_field(), self.randomness, self.npk_m_hash.to_field()]
+        [self.points.to_field(), self.randomness, self.owner.to_field()]
     }
 }
 // docs:end:serialize
@@ -65,7 +66,7 @@ impl Serialize<3> for CardNote {
 impl Eq for CardNote {
     fn eq(self, other: Self) -> bool {
         (self.points == other.points)
-            & (self.npk_m_hash == other.npk_m_hash)
+            & (self.owner == other.owner)
             & (self.randomness == other.randomness)
     }
 }

--- a/noir-projects/noir-contracts/contracts/ecdsa_k_account_contract/src/main.nr
+++ b/noir-projects/noir-contracts/contracts/ecdsa_k_account_contract/src/main.nr
@@ -29,15 +29,15 @@ contract EcdsaKAccount {
     #[initializer]
     fn constructor(signing_pub_key_x: [u8; 32], signing_pub_key_y: [u8; 32]) {
         let this = context.this_address();
-        let this_keys = get_public_keys(this);
         // Not emitting outgoing for msg_sender here to not have to register keys for the contract through which we
         // deploy this (typically MultiCallEntrypoint). I think it's ok here as I feel the outgoing here is not that
         // important.
-        let mut pub_key_note =
-            EcdsaPublicKeyNote::new(signing_pub_key_x, signing_pub_key_y, this_keys.npk_m.hash());
+        let mut pub_key_note = EcdsaPublicKeyNote::new(signing_pub_key_x, signing_pub_key_y, this);
+
+        let this_ovpk_m = get_public_keys(this).ovpk_m;
         storage.public_key.initialize(&mut pub_key_note).emit(encode_and_encrypt_note(
             &mut context,
-            this_keys.ovpk_m,
+            this_ovpk_m,
             this,
         ));
     }

--- a/noir-projects/noir-contracts/contracts/ecdsa_public_key_note/src/lib.nr
+++ b/noir-projects/noir-contracts/contracts/ecdsa_public_key_note/src/lib.nr
@@ -1,10 +1,10 @@
 use dep::aztec::prelude::{NoteHeader, NoteInterface, NullifiableNote, PrivateContext};
 
 use dep::aztec::{
-    note::utils::compute_note_hash_for_nullify, keys::getters::get_nsk_app,
-    protocol_types::{constants::GENERATOR_INDEX__NOTE_NULLIFIER, hash::poseidon2_hash_with_separator},
+    note::utils::compute_note_hash_for_nullify, keys::getters::{get_nsk_app, get_public_keys},
+    protocol_types::{address::AztecAddress, constants::GENERATOR_INDEX__NOTE_NULLIFIER, hash::poseidon2_hash_with_separator},
     macros::notes::note_custom_interface, generators::Ga1 as Gx_1, generators::Ga2 as Gx_2,
-    generators::Ga3 as Gy_1, generators::Ga4 as Gy_2, generators::Ga5 as Gnpk_m_hash, generators::G_slot
+    generators::Ga3 as Gy_1, generators::Ga4 as Gy_2, generators::Ga5 as G_owner, generators::G_slot
 };
 
 use std::hash::from_field_unsafe;
@@ -17,8 +17,7 @@ global ECDSA_PUBLIC_KEY_NOTE_LEN: u32 = 5;
 pub struct EcdsaPublicKeyNote {
     x: [u8; 32],
     y: [u8; 32],
-    // We store the npk_m_hash only to get the secret key to compute the nullifier
-    npk_m_hash: Field,
+    owner: AztecAddress,
 }
 
 impl NoteInterface<ECDSA_PUBLIC_KEY_NOTE_LEN> for EcdsaPublicKeyNote {
@@ -27,7 +26,7 @@ impl NoteInterface<ECDSA_PUBLIC_KEY_NOTE_LEN> for EcdsaPublicKeyNote {
     // [1] = x[31]
     // [2] = y[0..31]
     // [3] = y[31]
-    // [4] = npk_m_hash
+    // [4] = owner
     fn serialize_content(self) -> [Field; ECDSA_PUBLIC_KEY_NOTE_LEN] {
         let mut x: Field = 0;
         let mut y: Field = 0;
@@ -44,7 +43,7 @@ impl NoteInterface<ECDSA_PUBLIC_KEY_NOTE_LEN> for EcdsaPublicKeyNote {
         let last_x = self.x[31] as Field;
         let last_y = self.y[31] as Field;
 
-        [x, last_x, y, last_y, self.npk_m_hash]
+        [x, last_x, y, last_y, self.owner.to_field()]
     }
 
     // Cannot use the automatic deserialization for the aforementioned reasons
@@ -64,7 +63,7 @@ impl NoteInterface<ECDSA_PUBLIC_KEY_NOTE_LEN> for EcdsaPublicKeyNote {
         }
         y[31] = serialized_note[3].to_be_bytes::<32>()[31];
 
-        EcdsaPublicKeyNote { x, y, npk_m_hash: serialized_note[4], header: NoteHeader::empty() }
+        EcdsaPublicKeyNote { x, y, owner: AztecAddress::from_field(serialized_note[4]), header: NoteHeader::empty() }
     }
 
     fn to_be_bytes(self, storage_slot: Field) -> [u8; ECDSA_PUBLIC_KEY_NOTE_LEN * 32 + 64] {
@@ -110,7 +109,7 @@ impl NoteInterface<ECDSA_PUBLIC_KEY_NOTE_LEN> for EcdsaPublicKeyNote {
     fn compute_note_hash(self) -> Field {
         let serialized = self.serialize_content();
         std::embedded_curve_ops::multi_scalar_mul(
-            [Gx_1, Gx_2, Gy_1, Gy_2, Gnpk_m_hash, G_slot],
+            [Gx_1, Gx_2, Gy_1, Gy_2, G_owner, G_slot],
             [
             from_field_unsafe(serialized[0]),
             from_field_unsafe(serialized[1]),
@@ -126,7 +125,8 @@ impl NoteInterface<ECDSA_PUBLIC_KEY_NOTE_LEN> for EcdsaPublicKeyNote {
 impl NullifiableNote for EcdsaPublicKeyNote {
 
     fn compute_nullifier(self, context: &mut PrivateContext, note_hash_for_nullify: Field) -> Field {
-        let secret = context.request_nsk_app(self.npk_m_hash);
+        let owner_npk_m_hash = get_public_keys(self.owner).npk_m.hash();
+        let secret = context.request_nsk_app(owner_npk_m_hash);
         poseidon2_hash_with_separator(
             [
             note_hash_for_nullify,
@@ -138,7 +138,8 @@ impl NullifiableNote for EcdsaPublicKeyNote {
 
     unconstrained fn compute_nullifier_without_context(self) -> Field {
         let note_hash_for_nullify = compute_note_hash_for_nullify(self);
-        let secret = get_nsk_app(self.npk_m_hash);
+        let owner_npk_m_hash = get_public_keys(self.owner).npk_m.hash();
+        let secret = get_nsk_app(owner_npk_m_hash);
         poseidon2_hash_with_separator(
             [
             note_hash_for_nullify,
@@ -150,7 +151,7 @@ impl NullifiableNote for EcdsaPublicKeyNote {
 }
 
 impl EcdsaPublicKeyNote {
-    pub fn new(x: [u8; 32], y: [u8; 32], npk_m_hash: Field) -> Self {
-        EcdsaPublicKeyNote { x, y, npk_m_hash, header: NoteHeader::empty() }
+    pub fn new(x: [u8; 32], y: [u8; 32], owner: AztecAddress) -> Self {
+        EcdsaPublicKeyNote { x, y, owner, header: NoteHeader::empty() }
     }
 }

--- a/noir-projects/noir-contracts/contracts/ecdsa_r_account_contract/src/main.nr
+++ b/noir-projects/noir-contracts/contracts/ecdsa_r_account_contract/src/main.nr
@@ -28,15 +28,14 @@ contract EcdsaRAccount {
     #[initializer]
     fn constructor(signing_pub_key_x: [u8; 32], signing_pub_key_y: [u8; 32]) {
         let this = context.this_address();
-        let this_keys = get_public_keys(this);
         // Not emitting outgoing for msg_sender here to not have to register keys for the contract through which we
         // deploy this (typically MultiCallEntrypoint). I think it's ok here as I feel the outgoing here is not that
         // important.
-        let mut pub_key_note =
-            EcdsaPublicKeyNote::new(signing_pub_key_x, signing_pub_key_y, this_keys.npk_m.hash());
+        let mut pub_key_note = EcdsaPublicKeyNote::new(signing_pub_key_x, signing_pub_key_y, this);
+        let this_ovpk_m = get_public_keys(this).ovpk_m;
         storage.public_key.initialize(&mut pub_key_note).emit(encode_and_encrypt_note(
             &mut context,
-            this_keys.ovpk_m,
+            this_ovpk_m,
             this,
         ));
     }

--- a/noir-projects/noir-contracts/contracts/escrow_contract/src/main.nr
+++ b/noir-projects/noir-contracts/contracts/escrow_contract/src/main.nr
@@ -24,14 +24,13 @@ contract Escrow {
     #[private]
     #[initializer]
     fn constructor(owner: AztecAddress) {
-        let owner_keys = get_public_keys(owner);
-        let msg_sender_keys = get_public_keys(context.msg_sender());
         // docs:start:addressnote_new
-        let mut note = AddressNote::new(owner, owner_keys.npk_m.hash());
+        let mut note = AddressNote::new(owner, owner);
         // docs:end:addressnote_new
+        let msg_sender_ovpk_m = get_public_keys(context.msg_sender()).ovpk_m;
         storage.owner.initialize(&mut note).emit(encode_and_encrypt_note(
             &mut context,
-            msg_sender_keys.ovpk_m,
+            msg_sender_ovpk_m,
             owner,
         ));
     }

--- a/noir-projects/noir-contracts/contracts/inclusion_proofs_contract/src/main.nr
+++ b/noir-projects/noir-contracts/contracts/inclusion_proofs_contract/src/main.nr
@@ -33,13 +33,12 @@ contract InclusionProofs {
     // Creates a value note owned by `owner`.
     #[private]
     fn create_note(owner: AztecAddress, value: Field) {
-        let msg_sender_keys = get_public_keys(context.msg_sender());
-        let owner_keys = get_public_keys(owner);
+        let mut note = ValueNote::new(value, owner);
 
-        let mut note = ValueNote::new(value, owner_keys.npk_m.hash());
+        let msg_sender_ovpk_m = get_public_keys(context.msg_sender()).ovpk_m;
         storage.private_values.at(owner).insert(&mut note).emit(encode_and_encrypt_note(
             &mut context,
-            msg_sender_keys.ovpk_m,
+            msg_sender_ovpk_m,
             owner,
         ));
     }
@@ -81,8 +80,7 @@ contract InclusionProofs {
         block_number: u32, // The block at which we'll prove that the note exists
     ) {
         let header = context.get_header();
-        let owner_npk_m_hash = get_public_keys(owner).npk_m.hash();
-        let mut note = ValueNote::new(1, owner_npk_m_hash);
+        let mut note = ValueNote::new(1, owner);
 
         let header = if (use_block_number) {
             context.get_header_at(block_number)

--- a/noir-projects/noir-contracts/contracts/nft_contract/src/main.nr
+++ b/noir-projects/noir-contracts/contracts/nft_contract/src/main.nr
@@ -179,15 +179,13 @@ contract NFT {
         storage: Storage<&mut PrivateContext>,
     ) -> Field {
         let to_keys = get_public_keys(to);
-        let to_npk_m_hash = to_keys.npk_m.hash();
         let to_note_slot = storage.private_nfts.at(to).storage_slot;
 
         // We create a setup payload with unpopulated/zero token id for 'to'
         // TODO(#7775): Manually fetching the randomness here is not great. If we decide to include randomness in all
         // notes we could just inject it in macros.
         let note_randomness = unsafe { random() };
-        let note_setup_payload =
-            NFTNote::setup_payload().new(to_npk_m_hash, note_randomness, to_note_slot);
+        let note_setup_payload = NFTNote::setup_payload().new(to, note_randomness, to_note_slot);
 
         // We encrypt the note log
         let setup_log = note_setup_payload.encrypt_log(context, to_keys, to);
@@ -303,9 +301,8 @@ contract NFT {
         assert(notes.len() == 1, "NFT not found when transferring");
 
         let from_ovpk_m = get_public_keys(from).ovpk_m;
-        let to_keys = get_public_keys(to);
 
-        let mut new_note = NFTNote::new(token_id, to_keys.npk_m.hash());
+        let mut new_note = NFTNote::new(token_id, to);
         nfts.at(to).insert(&mut new_note).emit(encode_and_encrypt_note(
             &mut context,
             from_ovpk_m,

--- a/noir-projects/noir-contracts/contracts/nft_contract/src/test/transfer_to_private.nr
+++ b/noir-projects/noir-contracts/contracts/nft_contract/src/test/transfer_to_private.nr
@@ -1,6 +1,5 @@
 use crate::{NFT, test::utils, types::nft_note::NFTNote};
 use dep::aztec::{
-    keys::getters::get_public_keys,
     oracle::random::random,
     prelude::{AztecAddress, NoteHeader},
     protocol_types::storage::map::derive_storage_slot_in_map,
@@ -51,14 +50,13 @@ unconstrained fn transfer_to_private_external_orchestration() {
 
     // TODO(#8771): We need to manually add the note because in the partial notes flow `notify_created_note_oracle`
     // is not called and we don't have a `NoteProcessor` in TXE.
-    let recipient_npk_m_hash = get_public_keys(recipient).npk_m.hash();
     let private_nfts_recipient_slot =
         derive_storage_slot_in_map(NFT::storage_layout().private_nfts.slot, recipient);
 
     env.add_note(
         &mut NFTNote {
             token_id,
-            npk_m_hash: recipient_npk_m_hash,
+            owner: recipient,
             randomness: note_randomness,
             header: NoteHeader::empty(),
         },

--- a/noir-projects/noir-contracts/contracts/nft_contract/src/test/utils.nr
+++ b/noir-projects/noir-contracts/contracts/nft_contract/src/test/utils.nr
@@ -1,7 +1,6 @@
 use crate::{NFT, types::nft_note::NFTNote};
 use dep::aztec::{
     hash::pedersen_hash,
-    keys::getters::get_public_keys,
     oracle::{
         execution::{get_block_number, get_contract_address},
         random::random,
@@ -74,14 +73,13 @@ pub unconstrained fn setup_mint_and_transfer_to_private(
 
     // TODO(#8771): We need to manually add the note because in the partial notes flow `notify_created_note_oracle`
     // is not called and we don't have a `NoteProcessor` in TXE.
-    let owner_npk_m_hash = get_public_keys(owner).npk_m.hash();
     let private_nfts_owner_slot =
         derive_storage_slot_in_map(NFT::storage_layout().private_nfts.slot, owner);
 
     env.add_note(
         &mut NFTNote {
             token_id: minted_token_id,
-            npk_m_hash: owner_npk_m_hash,
+            owner,
             randomness: note_randomness,
             header: NoteHeader::empty(),
         },

--- a/noir-projects/noir-contracts/contracts/nft_contract/src/types/nft_note.nr
+++ b/noir-projects/noir-contracts/contracts/nft_contract/src/types/nft_note.nr
@@ -1,10 +1,11 @@
 use dep::aztec::{
-    keys::getters::get_nsk_app,
+    keys::getters::{get_nsk_app, get_public_keys},
     macros::notes::partial_note,
     note::utils::compute_note_hash_for_nullify,
     oracle::random::random,
     prelude::{NoteHeader, NullifiableNote, PrivateContext},
     protocol_types::{
+        address::AztecAddress,
         constants::GENERATOR_INDEX__NOTE_NULLIFIER,
         hash::poseidon2_hash_with_separator,
         traits::{Empty, Eq},
@@ -16,7 +17,7 @@ pub struct NFTNote {
     // ID of the token
     token_id: Field,
     // The nullifying public key hash is used with the nsk_app to ensure that the note can be privately spent.
-    npk_m_hash: Field,
+    owner: AztecAddress,
     // Randomness of the note to hide its contents
     randomness: Field,
 }
@@ -27,7 +28,8 @@ impl NullifiableNote for NFTNote {
         context: &mut PrivateContext,
         note_hash_for_nullify: Field,
     ) -> Field {
-        let secret = context.request_nsk_app(self.npk_m_hash);
+        let owner_npk_m_hash: Field = get_public_keys(self.owner).npk_m.hash();
+        let secret = context.request_nsk_app(owner_npk_m_hash);
         poseidon2_hash_with_separator(
             [note_hash_for_nullify, secret],
             GENERATOR_INDEX__NOTE_NULLIFIER as Field,
@@ -36,7 +38,8 @@ impl NullifiableNote for NFTNote {
 
     unconstrained fn compute_nullifier_without_context(self) -> Field {
         let note_hash_for_nullify = compute_note_hash_for_nullify(self);
-        let secret = get_nsk_app(self.npk_m_hash);
+        let owner_npk_m_hash: Field = get_public_keys(self.owner).npk_m.hash();
+        let secret = get_nsk_app(owner_npk_m_hash);
         poseidon2_hash_with_separator(
             [note_hash_for_nullify, secret],
             GENERATOR_INDEX__NOTE_NULLIFIER as Field,
@@ -45,20 +48,20 @@ impl NullifiableNote for NFTNote {
 }
 
 impl NFTNote {
-    pub fn new(token_id: Field, npk_m_hash: Field) -> Self {
+    pub fn new(token_id: Field, owner: AztecAddress) -> Self {
         // We use the randomness to preserve the privacy of the note recipient by preventing brute-forcing, so a
         // malicious sender could use non-random values to make the note less private. But they already know the full
         // note pre-image anyway, and so the recipient already trusts them to not disclose this information. We can
         // therefore assume that the sender will cooperate in the random value generation.
         let randomness = unsafe { random() };
-        NFTNote { token_id, npk_m_hash, randomness, header: NoteHeader::empty() }
+        NFTNote { token_id, owner, randomness, header: NoteHeader::empty() }
     }
 }
 
 impl Eq for NFTNote {
     fn eq(self, other: Self) -> bool {
         (self.token_id == other.token_id)
-            & (self.npk_m_hash == other.npk_m_hash)
+            & (self.owner == other.owner)
             & (self.randomness == other.randomness)
     }
 }

--- a/noir-projects/noir-contracts/contracts/pending_note_hashes_contract/src/main.nr
+++ b/noir-projects/noir-contracts/contracts/pending_note_hashes_contract/src/main.nr
@@ -38,15 +38,14 @@ contract PendingNoteHashes {
     ) -> Field {
         let owner_balance = storage.balances.at(owner);
 
-        let owner_keys = get_public_keys(owner);
-        let outgoing_viewer_keys = get_public_keys(outgoing_viewer);
+        let outgoing_viewer_ovpk_m = get_public_keys(outgoing_viewer).ovpk_m;
 
-        let mut note = ValueNote::new(amount, owner_keys.npk_m.hash());
+        let mut note = ValueNote::new(amount, owner);
 
         // Insert note
         owner_balance.insert(&mut note).emit(encode_and_encrypt_note(
             &mut context,
-            outgoing_viewer_keys.ovpk_m,
+            outgoing_viewer_ovpk_m,
             owner,
         ));
 
@@ -72,10 +71,8 @@ contract PendingNoteHashes {
 
         assert(notes.len() == 0);
 
-        let owner_npk_m_hash = get_public_keys(owner).npk_m.hash();
-
         // Insert note
-        let mut note = ValueNote::new(amount, owner_npk_m_hash);
+        let mut note = ValueNote::new(amount, owner);
         owner_balance.insert(&mut note).discard();
 
         0
@@ -90,15 +87,14 @@ contract PendingNoteHashes {
     fn insert_note(amount: Field, owner: AztecAddress, outgoing_viewer: AztecAddress) {
         let owner_balance = storage.balances.at(owner);
 
-        let owner_keys = get_public_keys(owner);
-        let outgoing_viewer_keys = get_public_keys(outgoing_viewer);
+        let outgoing_viewer_ovpk_m = get_public_keys(outgoing_viewer).ovpk_m;
 
-        let mut note = ValueNote::new(amount, owner_keys.npk_m.hash());
+        let mut note = ValueNote::new(amount, owner);
 
         // Insert note
         owner_balance.insert(&mut note).emit(encode_and_encrypt_note(
             &mut context,
-            outgoing_viewer_keys.ovpk_m,
+            outgoing_viewer_ovpk_m,
             owner,
         ));
     }
@@ -114,16 +110,15 @@ contract PendingNoteHashes {
     ) {
         let mut owner_balance = storage.balances.at(owner);
 
-        let owner_keys = get_public_keys(owner);
-        let outgoing_viewer_keys = get_public_keys(outgoing_viewer);
+        let outgoing_viewer_ovpk_m = get_public_keys(outgoing_viewer).ovpk_m;
 
-        let mut note = ValueNote::new(amount, owner_keys.npk_m.hash());
+        let mut note = ValueNote::new(amount, owner);
         note.randomness = 2;
 
         // Insert note
         owner_balance.insert(&mut note).emit(encode_and_encrypt_note(
             &mut context,
-            outgoing_viewer_keys.ovpk_m,
+            outgoing_viewer_ovpk_m,
             owner,
         ));
     }
@@ -134,18 +129,17 @@ contract PendingNoteHashes {
     fn insert_note_extra_emit(amount: Field, owner: AztecAddress, outgoing_viewer: AztecAddress) {
         let mut owner_balance = storage.balances.at(owner);
 
-        let owner_keys = get_public_keys(owner);
-        let outgoing_viewer_keys = get_public_keys(outgoing_viewer);
+        let outgoing_viewer_ovpk_m = get_public_keys(outgoing_viewer).ovpk_m;
 
-        let mut note = ValueNote::new(amount, owner_keys.npk_m.hash());
+        let mut note = ValueNote::new(amount, owner);
 
         // Insert note
         let emission = owner_balance.insert(&mut note);
 
-        emission.emit(encode_and_encrypt_note(&mut context, outgoing_viewer_keys.ovpk_m, owner));
+        emission.emit(encode_and_encrypt_note(&mut context, outgoing_viewer_ovpk_m, owner));
 
         // Emit note again
-        emission.emit(encode_and_encrypt_note(&mut context, outgoing_viewer_keys.ovpk_m, owner));
+        emission.emit(encode_and_encrypt_note(&mut context, outgoing_viewer_ovpk_m, owner));
     }
 
     // Nested/inner function to get a note and confirm it matches the expected value
@@ -357,28 +351,26 @@ contract PendingNoteHashes {
     fn test_emit_bad_note_log(owner: AztecAddress, outgoing_viewer: AztecAddress) {
         let owner_balance = storage.balances.at(owner);
 
-        let owner_keys = get_public_keys(owner);
-        let owner_npk_m_hash = owner_keys.npk_m.hash();
-        let outgoing_viewer_keys = get_public_keys(outgoing_viewer);
+        let outgoing_viewer_ovpk_m = get_public_keys(outgoing_viewer).ovpk_m;
 
-        let mut good_note = ValueNote::new(10, owner_npk_m_hash);
+        let mut good_note = ValueNote::new(10, owner);
         // Insert good note with real log
         owner_balance.insert(&mut good_note).emit(encode_and_encrypt_note(
             &mut context,
-            outgoing_viewer_keys.ovpk_m,
+            outgoing_viewer_ovpk_m,
             owner,
         ));
 
         // We will emit a note log with an incorrect preimage to ensure the pxe throws
         // This note has not been inserted...
-        let mut bad_note = ValueNote::new(5, owner_npk_m_hash);
+        let mut bad_note = ValueNote::new(5, owner);
         // ...but we need a 'good' note header to get the context to add the note log
         let existing_note_header = good_note.get_header();
         bad_note.set_header(existing_note_header);
 
         NoteEmission::new(bad_note).emit(encode_and_encrypt_note(
             &mut context,
-            outgoing_viewer_keys.ovpk_m,
+            outgoing_viewer_ovpk_m,
             owner,
         ));
     }
@@ -392,12 +384,10 @@ contract PendingNoteHashes {
     ) {
         let owner_balance = storage.balances.at(owner);
 
-        let owner_keys = get_public_keys(owner);
-        let owner_npk_m_hash = owner_keys.npk_m.hash();
         let outgoing_viewer_ovpk_m = get_public_keys(outgoing_viewer).ovpk_m;
 
         for i in 0..max_notes_per_call() {
-            let mut note = ValueNote::new(i as Field, owner_npk_m_hash);
+            let mut note = ValueNote::new(i as Field, owner);
             owner_balance.insert(&mut note).emit(encode_and_encrypt_note(
                 context,
                 outgoing_viewer_ovpk_m,

--- a/noir-projects/noir-contracts/contracts/schnorr_account_contract/src/main.nr
+++ b/noir-projects/noir-contracts/contracts/schnorr_account_contract/src/main.nr
@@ -35,15 +35,14 @@ contract SchnorrAccount {
     #[initializer]
     fn constructor(signing_pub_key_x: Field, signing_pub_key_y: Field) {
         let this = context.this_address();
-        let this_keys = get_public_keys(this);
         // Not emitting outgoing for msg_sender here to not have to register keys for the contract through which we
         // deploy this (typically MultiCallEntrypoint). I think it's ok here as I feel the outgoing here is not that
         // important.
-        let mut pub_key_note =
-            PublicKeyNote::new(signing_pub_key_x, signing_pub_key_y, this_keys.npk_m.hash());
+        let mut pub_key_note = PublicKeyNote::new(signing_pub_key_x, signing_pub_key_y, this);
+        let this_ovpk_m = get_public_keys(this).ovpk_m;
         storage.signing_public_key.initialize(&mut pub_key_note).emit(encode_and_encrypt_note(
             &mut context,
-            this_keys.ovpk_m,
+            this_ovpk_m,
             this,
         ));
     }

--- a/noir-projects/noir-contracts/contracts/schnorr_account_contract/src/public_key_note.nr
+++ b/noir-projects/noir-contracts/contracts/schnorr_account_contract/src/public_key_note.nr
@@ -1,9 +1,10 @@
 use dep::aztec::{
-    keys::getters::get_nsk_app,
+    keys::getters::{get_nsk_app, get_public_keys},
     macros::notes::note,
     note::utils::compute_note_hash_for_nullify,
     protocol_types::{
-        constants::GENERATOR_INDEX__NOTE_NULLIFIER, hash::poseidon2_hash_with_separator,
+        address::AztecAddress, constants::GENERATOR_INDEX__NOTE_NULLIFIER,
+        hash::poseidon2_hash_with_separator,
     },
 };
 use dep::aztec::prelude::{NoteHeader, NullifiableNote, PrivateContext};
@@ -14,8 +15,7 @@ use dep::aztec::prelude::{NoteHeader, NullifiableNote, PrivateContext};
 pub struct PublicKeyNote {
     x: Field,
     y: Field,
-    // We store the npk_m_hash only to get the secret key to compute the nullifier
-    npk_m_hash: Field,
+    owner: AztecAddress,
 }
 
 impl NullifiableNote for PublicKeyNote {
@@ -24,7 +24,8 @@ impl NullifiableNote for PublicKeyNote {
         context: &mut PrivateContext,
         note_hash_for_nullify: Field,
     ) -> Field {
-        let secret = context.request_nsk_app(self.npk_m_hash);
+        let owner_npk_m_hash: Field = get_public_keys(self.owner).npk_m.hash();
+        let secret = context.request_nsk_app(owner_npk_m_hash);
         poseidon2_hash_with_separator(
             [note_hash_for_nullify, secret],
             GENERATOR_INDEX__NOTE_NULLIFIER as Field,
@@ -33,7 +34,8 @@ impl NullifiableNote for PublicKeyNote {
 
     unconstrained fn compute_nullifier_without_context(self) -> Field {
         let note_hash_for_nullify = compute_note_hash_for_nullify(self);
-        let secret = get_nsk_app(self.npk_m_hash);
+        let owner_npk_m_hash: Field = get_public_keys(self.owner).npk_m.hash();
+        let secret = get_nsk_app(owner_npk_m_hash);
         poseidon2_hash_with_separator(
             [note_hash_for_nullify, secret],
             GENERATOR_INDEX__NOTE_NULLIFIER as Field,
@@ -42,7 +44,7 @@ impl NullifiableNote for PublicKeyNote {
 }
 
 impl PublicKeyNote {
-    pub fn new(x: Field, y: Field, npk_m_hash: Field) -> Self {
-        PublicKeyNote { x, y, npk_m_hash, header: NoteHeader::empty() }
+    pub fn new(x: Field, y: Field, owner: AztecAddress) -> Self {
+        PublicKeyNote { x, y, owner, header: NoteHeader::empty() }
     }
 }

--- a/noir-projects/noir-contracts/contracts/spam_contract/src/main.nr
+++ b/noir-projects/noir-contracts/contracts/spam_contract/src/main.nr
@@ -31,12 +31,12 @@ contract Spam {
     #[private]
     fn spam(nullifier_seed: Field, nullifier_count: u32, call_public: bool) {
         let caller = context.msg_sender();
-        let caller_keys = get_public_keys(caller);
+        let caller_ovpk_m = get_public_keys(caller).ovpk_m;
         let amount = U128::from_integer(1);
 
         for _ in 0..MAX_NOTE_HASHES_PER_CALL {
-            storage.balances.at(caller).add(caller_keys.npk_m, U128::from_integer(amount)).emit(
-                encode_and_encrypt_note_unconstrained(&mut context, caller_keys.ovpk_m, caller),
+            storage.balances.at(caller).add(caller, U128::from_integer(amount)).emit(
+                encode_and_encrypt_note_unconstrained(&mut context, caller_ovpk_m, caller),
             );
         }
 

--- a/noir-projects/noir-contracts/contracts/spam_contract/src/types/balance_set.nr
+++ b/noir-projects/noir-contracts/contracts/spam_contract/src/types/balance_set.nr
@@ -3,7 +3,9 @@ use crate::types::token_note::OwnedNote;
 use dep::aztec::{
     context::{PrivateContext, UnconstrainedContext},
     note::note_emission::OuterNoteEmission,
-    protocol_types::{constants::MAX_NOTE_HASH_READ_REQUESTS_PER_CALL, public_keys::NpkM},
+    protocol_types::{
+        address::AztecAddress, constants::MAX_NOTE_HASH_READ_REQUESTS_PER_CALL, public_keys::NpkM,
+    },
 };
 use dep::aztec::prelude::{
     NoteGetterOptions, NoteInterface, NoteViewerOptions, NullifiableNote, PrivateSet,
@@ -56,7 +58,7 @@ impl<T> BalanceSet<T, UnconstrainedContext> {
 impl<T> BalanceSet<T, &mut PrivateContext> {
     pub fn add<let T_SERIALIZED_LEN: u32>(
         self: Self,
-        owner_npk_m: NpkM,
+        owner: AztecAddress,
         addend: U128,
     ) -> OuterNoteEmission<T>
     where
@@ -65,8 +67,7 @@ impl<T> BalanceSet<T, &mut PrivateContext> {
         if addend == U128::from_integer(0) {
             OuterNoteEmission::new(Option::none())
         } else {
-            // We fetch the nullifier public key hash from the registry / from our PXE
-            let mut addend_note = T::new(addend, owner_npk_m.hash());
+            let mut addend_note = T::new(addend, owner);
 
             // docs:start:insert
             OuterNoteEmission::new(Option::some(self.set.insert(&mut addend_note)))
@@ -76,7 +77,7 @@ impl<T> BalanceSet<T, &mut PrivateContext> {
 
     pub fn sub<let T_SERIALIZED_LEN: u32>(
         self: Self,
-        owner_npk_m: NpkM,
+        owner: AztecAddress,
         amount: U128,
     ) -> OuterNoteEmission<T>
     where
@@ -87,7 +88,7 @@ impl<T> BalanceSet<T, &mut PrivateContext> {
         // try_sub may have substracted more or less than amount. We must ensure that we subtracted at least as much as
         // we needed, and then create a new note for the owner for the change (if any).
         assert(subtracted >= amount, "Balance too low");
-        self.add(owner_npk_m, subtracted - amount)
+        self.add(owner, subtracted - amount)
     }
 
     // Attempts to remove 'target_amount' from the owner's balance. try_sub returns how much was actually subtracted

--- a/noir-projects/noir-contracts/contracts/spam_contract/src/types/token_note.nr
+++ b/noir-projects/noir-contracts/contracts/spam_contract/src/types/token_note.nr
@@ -1,16 +1,17 @@
 use dep::aztec::{
-    keys::getters::get_nsk_app,
+    keys::getters::{get_nsk_app, get_public_keys},
     macros::notes::note,
     note::utils::compute_note_hash_for_nullify,
     oracle::random::random,
     prelude::{NoteHeader, NullifiableNote, PrivateContext},
     protocol_types::{
-        constants::GENERATOR_INDEX__NOTE_NULLIFIER, hash::poseidon2_hash_with_separator,
+        address::AztecAddress, constants::GENERATOR_INDEX__NOTE_NULLIFIER,
+        hash::poseidon2_hash_with_separator,
     },
 };
 
 trait OwnedNote {
-    fn new(amount: U128, owner_npk_m_hash: Field) -> Self;
+    fn new(amount: U128, owner: AztecAddress) -> Self;
     fn get_amount(self) -> U128;
 }
 // docs:start:TokenNote
@@ -19,7 +20,7 @@ pub struct TokenNote {
     // The amount of tokens in the note
     amount: U128,
     // The nullifying public key hash is used with the nsk_app to ensure that the note can be privately spent.
-    npk_m_hash: Field,
+    owner: AztecAddress,
     // Randomness of the note to hide its contents
     randomness: Field,
 }
@@ -32,7 +33,8 @@ impl NullifiableNote for TokenNote {
         context: &mut PrivateContext,
         note_hash_for_nullify: Field,
     ) -> Field {
-        let secret = context.request_nsk_app(self.npk_m_hash);
+        let owner_npk_m_hash: Field = get_public_keys(self.owner).npk_m.hash();
+        let secret = context.request_nsk_app(owner_npk_m_hash);
         poseidon2_hash_with_separator(
             [note_hash_for_nullify, secret],
             GENERATOR_INDEX__NOTE_NULLIFIER as Field,
@@ -42,7 +44,8 @@ impl NullifiableNote for TokenNote {
 
     unconstrained fn compute_nullifier_without_context(self) -> Field {
         let note_hash_for_nullify = compute_note_hash_for_nullify(self);
-        let secret = get_nsk_app(self.npk_m_hash);
+        let owner_npk_m_hash: Field = get_public_keys(self.owner).npk_m.hash();
+        let secret = get_nsk_app(owner_npk_m_hash);
         poseidon2_hash_with_separator(
             [note_hash_for_nullify, secret],
             GENERATOR_INDEX__NOTE_NULLIFIER,
@@ -53,19 +56,19 @@ impl NullifiableNote for TokenNote {
 impl Eq for TokenNote {
     fn eq(self, other: Self) -> bool {
         (self.amount == other.amount)
-            & (self.npk_m_hash == other.npk_m_hash)
+            & (self.owner == other.owner)
             & (self.randomness == other.randomness)
     }
 }
 
 impl OwnedNote for TokenNote {
-    fn new(amount: U128, owner_npk_m_hash: Field) -> Self {
+    fn new(amount: U128, owner: AztecAddress) -> Self {
         // We use the randomness to preserve the privacy of the note recipient by preventing brute-forcing, so a
         // malicious sender could use non-random values to make the note less private. But they already know the full
         // note pre-image anyway, and so the recipient already trusts them to not disclose this information. We can
         // therefore assume that the sender will cooperate in the random value generation.
         let randomness = unsafe { random() };
-        Self { amount, npk_m_hash: owner_npk_m_hash, randomness, header: NoteHeader::empty() }
+        Self { amount, owner, randomness, header: NoteHeader::empty() }
     }
 
     fn get_amount(self) -> U128 {

--- a/noir-projects/noir-contracts/contracts/static_child_contract/src/main.nr
+++ b/noir-projects/noir-contracts/contracts/static_child_contract/src/main.nr
@@ -45,14 +45,12 @@ contract StaticChild {
     #[private]
     #[view]
     fn private_illegal_set_value(new_value: Field, owner: AztecAddress) -> Field {
-        let msg_sender_keys = get_public_keys(context.msg_sender());
-        let owner_keys = get_public_keys(owner);
+        let mut note = ValueNote::new(new_value, owner);
 
-        let mut note = ValueNote::new(new_value, owner_keys.npk_m.hash());
-
+        let msg_sender_ovpk_m = get_public_keys(context.msg_sender()).ovpk_m;
         storage.a_private_value.insert(&mut note).emit(encode_and_encrypt_note(
             &mut context,
-            msg_sender_keys.ovpk_m,
+            msg_sender_ovpk_m,
             owner,
         ));
         new_value
@@ -65,13 +63,12 @@ contract StaticChild {
         owner: AztecAddress,
         outgoing_viewer: AztecAddress,
     ) -> Field {
-        let owner_keys = get_public_keys(owner);
-        let outgoing_viewer_keys = get_public_keys(outgoing_viewer);
+        let mut note = ValueNote::new(new_value, owner);
 
-        let mut note = ValueNote::new(new_value, owner_keys.npk_m.hash());
+        let outgoing_viewer_ovpk_m = get_public_keys(outgoing_viewer).ovpk_m;
         storage.a_private_value.insert(&mut note).emit(encode_and_encrypt_note(
             &mut context,
-            outgoing_viewer_keys.ovpk_m,
+            outgoing_viewer_ovpk_m,
             owner,
         ));
         new_value
@@ -81,11 +78,10 @@ contract StaticChild {
     #[private]
     #[view]
     fn private_get_value(amount: Field, owner: AztecAddress) -> Field {
-        let owner_npk_m_hash = get_public_keys(owner).npk_m.hash();
         let mut options = NoteGetterOptions::new();
         options = options
             .select(ValueNote::properties().value, Comparator.EQ, amount)
-            .select(ValueNote::properties().npk_m_hash, Comparator.EQ, owner_npk_m_hash)
+            .select(ValueNote::properties().owner, Comparator.EQ, owner)
             .set_limit(1);
         let notes = storage.a_private_value.get_notes(options);
         notes.get(0).value

--- a/noir-projects/noir-contracts/contracts/test_contract/src/main.nr
+++ b/noir-projects/noir-contracts/contracts/test_contract/src/main.nr
@@ -102,13 +102,12 @@ contract Test {
             "this storage slot is reserved for example_constant",
         );
 
-        let outgoing_viewer_keys = get_public_keys(outgoing_viewer);
-        let owner_keys = get_public_keys(owner);
+        let outgoing_viewer_ovpk_m = get_public_keys(outgoing_viewer).ovpk_m;
 
-        let mut note = ValueNote::new(value, owner_keys.npk_m.hash());
+        let mut note = ValueNote::new(value, owner);
         create_note(&mut context, storage_slot, &mut note).emit(encode_and_encrypt_note(
             &mut context,
-            outgoing_viewer_keys.ovpk_m,
+            outgoing_viewer_ovpk_m,
             owner,
         ));
     }
@@ -337,13 +336,12 @@ contract Test {
             .call(&mut context);
         storage_slot += 1;
 
-        let msg_sender_keys = get_public_keys(context.msg_sender());
-        let owner_keys = get_public_keys(owner);
+        let msg_sender_ovpk_m = get_public_keys(context.msg_sender()).ovpk_m;
 
-        let mut note = ValueNote::new(value + 1, owner_keys.npk_m.hash());
+        let mut note = ValueNote::new(value + 1, owner);
         create_note(&mut context, storage_slot, &mut note).emit(encode_and_encrypt_note(
             &mut context,
-            msg_sender_keys.ovpk_m,
+            msg_sender_ovpk_m,
             owner,
         ));
         storage_slot += 1;

--- a/noir-projects/noir-contracts/contracts/test_log_contract/src/main.nr
+++ b/noir-projects/noir-contracts/contracts/test_log_contract/src/main.nr
@@ -39,14 +39,14 @@ contract TestLog {
     fn emit_encrypted_events(other: AztecAddress, randomness: [Field; 2], preimages: [Field; 4]) {
         let event0 = ExampleEvent0 { value0: preimages[0], value1: preimages[1] };
 
-        let other_keys = get_public_keys(other);
-        let msg_sender_keys = get_public_keys(context.msg_sender());
+        let other_ovpk_m = get_public_keys(other).ovpk_m;
+        let msg_sender_ovpk_m = get_public_keys(context.msg_sender()).ovpk_m;
 
         event0.emit(encode_and_encrypt_event_with_randomness(
             &mut context,
             randomness[0],
             // outgoing is set to other, incoming is set to msg sender
-            other_keys.ovpk_m,
+            other_ovpk_m,
             context.msg_sender(),
         ));
 
@@ -55,7 +55,7 @@ contract TestLog {
             &mut context,
             randomness[0],
             // outgoing is set to msg sender, incoming is set to other
-            msg_sender_keys.ovpk_m,
+            msg_sender_ovpk_m,
             other,
         ));
 
@@ -68,7 +68,7 @@ contract TestLog {
             &mut context,
             randomness[1],
             // outgoing is set to other, incoming is set to msg sender
-            other_keys.ovpk_m,
+            other_ovpk_m,
             context.msg_sender(),
         ));
     }

--- a/noir-projects/noir-contracts/contracts/token_blacklist_contract/src/main.nr
+++ b/noir-projects/noir-contracts/contracts/token_blacklist_contract/src/main.nr
@@ -187,12 +187,11 @@ contract TokenBlacklist {
         assert(notes.len() == 1, "note not popped");
 
         // Add the token note to user's balances set
-        let msg_sender_keys = get_public_keys(context.msg_sender());
-        let to_keys = get_public_keys(to);
+        let msg_sender_ovpk_m = get_public_keys(context.msg_sender()).ovpk_m;
         // TODO: constrain encryption below - we are using unconstrained here only becuase of the following Noir issue
         // https://github.com/noir-lang/noir/issues/5771
         storage.balances.add(to, U128::from_integer(amount)).emit(
-            encode_and_encrypt_note_unconstrained(&mut context, msg_sender_keys.ovpk_m, to),
+            encode_and_encrypt_note_unconstrained(&mut context, msg_sender_ovpk_m, to),
         );
     }
 
@@ -209,11 +208,11 @@ contract TokenBlacklist {
             assert(nonce == 0, "invalid nonce");
         }
 
-        let from_keys = get_public_keys(from);
+        let from_ovpk_m = get_public_keys(from).ovpk_m;
         // TODO: constrain encryption below - we are using unconstrained here only becuase of the following Noir issue
         // https://github.com/noir-lang/noir/issues/5771
         storage.balances.sub(from, U128::from_integer(amount)).emit(
-            encode_and_encrypt_note_unconstrained(&mut context, from_keys.ovpk_m, from),
+            encode_and_encrypt_note_unconstrained(&mut context, from_ovpk_m, from),
         );
 
         TokenBlacklist::at(context.this_address())._increase_public_balance(to, amount).enqueue(
@@ -235,18 +234,17 @@ contract TokenBlacklist {
             assert(nonce == 0, "invalid nonce");
         }
 
-        let from_keys = get_public_keys(from);
-        let to_keys = get_public_keys(to);
+        let from_ovpk_m = get_public_keys(from).ovpk_m;
 
         let amount = U128::from_integer(amount);
         storage.balances.sub(from, amount).emit(encode_and_encrypt_note_unconstrained(
             &mut context,
-            from_keys.ovpk_m,
+            from_ovpk_m,
             from,
         ));
         storage.balances.add(to, amount).emit(encode_and_encrypt_note_unconstrained(
             &mut context,
-            from_keys.ovpk_m,
+            from_ovpk_m,
             to,
         ));
     }
@@ -262,11 +260,11 @@ contract TokenBlacklist {
             assert(nonce == 0, "invalid nonce");
         }
 
-        let from_keys = get_public_keys(from);
+        let from_ovpk_m = get_public_keys(from).ovpk_m;
         // TODO: constrain encryption below - we are using unconstrained here only becuase of the following Noir issue
         // https://github.com/noir-lang/noir/issues/5771
         storage.balances.sub(from, U128::from_integer(amount)).emit(
-            encode_and_encrypt_note_unconstrained(&mut context, from_keys.ovpk_m, from),
+            encode_and_encrypt_note_unconstrained(&mut context, from_ovpk_m, from),
         );
 
         TokenBlacklist::at(context.this_address())._reduce_total_supply(amount).enqueue(&mut context);

--- a/noir-projects/noir-contracts/contracts/token_blacklist_contract/src/types/balances_map.nr
+++ b/noir-projects/noir-contracts/contracts/token_blacklist_contract/src/types/balances_map.nr
@@ -1,7 +1,6 @@
 use crate::types::token_note::OwnedNote;
 use dep::aztec::{
     context::{PrivateContext, UnconstrainedContext},
-    keys::getters::get_public_keys,
     note::note_emission::OuterNoteEmission,
     protocol_types::constants::MAX_NOTE_HASH_READ_REQUESTS_PER_CALL,
 };
@@ -79,9 +78,7 @@ impl<T> BalancesMap<T, &mut PrivateContext> {
         } else {
             let context = self.map.context;
 
-            // We fetch the nullifier public key hash from the registry / from our PXE
-            let owner_npk_m_hash = get_public_keys(owner).npk_m.hash();
-            let mut addend_note = T::new(addend, owner_npk_m_hash);
+            let mut addend_note = T::new(addend, owner);
 
             // docs:start:insert
             OuterNoteEmission::new(Option::some(self.map.at(owner).insert(&mut addend_note)))

--- a/noir-projects/noir-contracts/contracts/token_blacklist_contract/src/types/token_note.nr
+++ b/noir-projects/noir-contracts/contracts/token_blacklist_contract/src/types/token_note.nr
@@ -1,16 +1,17 @@
 use dep::aztec::{
-    keys::getters::get_nsk_app,
+    keys::getters::{get_nsk_app, get_public_keys},
     macros::notes::note,
     note::utils::compute_note_hash_for_nullify,
     oracle::random::random,
     prelude::{NoteHeader, NullifiableNote, PrivateContext},
     protocol_types::{
-        constants::GENERATOR_INDEX__NOTE_NULLIFIER, hash::poseidon2_hash_with_separator,
+        address::AztecAddress, constants::GENERATOR_INDEX__NOTE_NULLIFIER,
+        hash::poseidon2_hash_with_separator,
     },
 };
 
 trait OwnedNote {
-    fn new(amount: U128, owner_npk_m_hash: Field) -> Self;
+    fn new(amount: U128, owner: AztecAddress) -> Self;
     fn get_amount(self) -> U128;
 }
 
@@ -18,8 +19,7 @@ trait OwnedNote {
 pub struct TokenNote {
     // The amount of tokens in the note
     amount: U128,
-    // The nullifying public key hash is used with the nsk_app to ensure that the note can be privately spent.
-    npk_m_hash: Field,
+    owner: AztecAddress,
     // Randomness of the note to hide its contents
     randomness: Field,
 }
@@ -31,7 +31,8 @@ impl NullifiableNote for TokenNote {
         context: &mut PrivateContext,
         note_hash_for_nullify: Field,
     ) -> Field {
-        let secret = context.request_nsk_app(self.npk_m_hash);
+        let owner_npk_m_hash: Field = get_public_keys(self.owner).npk_m.hash();
+        let secret = context.request_nsk_app(owner_npk_m_hash);
         poseidon2_hash_with_separator(
             [note_hash_for_nullify, secret],
             GENERATOR_INDEX__NOTE_NULLIFIER as Field,
@@ -41,7 +42,8 @@ impl NullifiableNote for TokenNote {
 
     unconstrained fn compute_nullifier_without_context(self) -> Field {
         let note_hash_for_nullify = compute_note_hash_for_nullify(self);
-        let secret = get_nsk_app(self.npk_m_hash);
+        let owner_npk_m_hash: Field = get_public_keys(self.owner).npk_m.hash();
+        let secret = get_nsk_app(owner_npk_m_hash);
         poseidon2_hash_with_separator(
             [note_hash_for_nullify, secret],
             GENERATOR_INDEX__NOTE_NULLIFIER as Field,
@@ -52,19 +54,19 @@ impl NullifiableNote for TokenNote {
 impl Eq for TokenNote {
     fn eq(self, other: Self) -> bool {
         (self.amount == other.amount)
-            & (self.npk_m_hash == other.npk_m_hash)
+            & (self.owner == other.owner)
             & (self.randomness == other.randomness)
     }
 }
 
 impl OwnedNote for TokenNote {
-    fn new(amount: U128, owner_npk_m_hash: Field) -> Self {
+    fn new(amount: U128, owner: AztecAddress) -> Self {
         // We use the randomness to preserve the privacy of the note recipient by preventing brute-forcing, so a
         // malicious sender could use non-random values to make the note less private. But they already know the full
         // note pre-image anyway, and so the recipient already trusts them to not disclose this information. We can
         // therefore assume that the sender will cooperate in the random value generation.
         let randomness = unsafe { random() };
-        Self { amount, npk_m_hash: owner_npk_m_hash, randomness, header: NoteHeader::empty() }
+        Self { amount, owner, randomness, header: NoteHeader::empty() }
     }
 
     fn get_amount(self) -> U128 {

--- a/noir-projects/noir-contracts/contracts/token_contract/src/main.nr
+++ b/noir-projects/noir-contracts/contracts/token_contract/src/main.nr
@@ -224,9 +224,9 @@ contract Token {
     #[private]
     fn privately_mint_private_note(amount: Field) {
         let caller = context.msg_sender();
-        let caller_keys = get_public_keys(caller);
-        storage.balances.at(caller).add(caller_keys.npk_m, U128::from_integer(amount)).emit(
-            encode_and_encrypt_note(&mut context, caller_keys.ovpk_m, caller),
+        let caller_ovpk_m = get_public_keys(caller).ovpk_m;
+        storage.balances.at(caller).add(caller, U128::from_integer(amount)).emit(
+            encode_and_encrypt_note(&mut context, caller_ovpk_m, caller),
         );
         Token::at(context.this_address())
             .assert_minter_and_mint(context.msg_sender(), amount)
@@ -305,11 +305,12 @@ contract Token {
         // Note: Using context.msg_sender() as a sender below makes this incompatible with escrows because we send
         // outgoing logs to that address and to send outgoing logs you need to get a hold of ovsk_m.
         let from = context.msg_sender();
-        let from_keys = get_public_keys(from);
-        let to_keys = get_public_keys(to);
-        storage.balances.at(to).add(to_keys.npk_m, U128::from_integer(amount)).emit(
-            encode_and_encrypt_note(&mut context, from_keys.ovpk_m, to),
-        );
+        let from_ovpk_m = get_public_keys(from).ovpk_m;
+        storage.balances.at(to).add(to, U128::from_integer(amount)).emit(encode_and_encrypt_note(
+            &mut context,
+            from_ovpk_m,
+            to,
+        ));
     }
     // docs:end:redeem_shield
     // docs:start:unshield
@@ -321,11 +322,11 @@ contract Token {
             assert(nonce == 0, "invalid nonce");
         }
 
-        let from_keys = get_public_keys(from);
+        let from_ovpk_m = get_public_keys(from).ovpk_m;
         // TODO: constrain encryption below - we are using unconstrained here only becuase of the following Noir issue
         // https://github.com/noir-lang/noir/issues/5771
-        storage.balances.at(from).sub(from_keys.npk_m, U128::from_integer(amount)).emit(
-            encode_and_encrypt_note_unconstrained(&mut context, from_keys.ovpk_m, from),
+        storage.balances.at(from).sub(from, U128::from_integer(amount)).emit(
+            encode_and_encrypt_note_unconstrained(&mut context, from_ovpk_m, from),
         );
         Token::at(context.this_address())._increase_public_balance(to, amount).enqueue(&mut context);
     }
@@ -335,8 +336,7 @@ contract Token {
     fn transfer(to: AztecAddress, amount: Field) {
         let from = context.msg_sender();
 
-        let from_keys = get_public_keys(from);
-        let to_keys = get_public_keys(to);
+        let from_ovpk_m = get_public_keys(from).ovpk_m;
 
         let amount = U128::from_integer(amount);
         // We reduce `from`'s balance by amount by recursively removing notes over potentially multiple calls. This
@@ -352,18 +352,22 @@ contract Token {
             amount,
             INITIAL_TRANSFER_CALL_MAX_NOTES,
         );
-        storage.balances.at(from).add(from_keys.npk_m, change).emit(
-            encode_and_encrypt_note_unconstrained(&mut context, from_keys.ovpk_m, from),
-        );
-        storage.balances.at(to).add(to_keys.npk_m, amount).emit(
-            encode_and_encrypt_note_unconstrained(&mut context, from_keys.ovpk_m, to),
-        );
+        storage.balances.at(from).add(from, change).emit(encode_and_encrypt_note_unconstrained(
+            &mut context,
+            from_ovpk_m,
+            from,
+        ));
+        storage.balances.at(to).add(to, amount).emit(encode_and_encrypt_note_unconstrained(
+            &mut context,
+            from_ovpk_m,
+            to,
+        ));
         // We don't constrain encryption of the note log in `transfer` (unlike in `transfer_from`) because the transfer
         // function is only designed to be used in situations where the event is not strictly necessary (e.g. payment to
         // another person where the payment is considered to be successful when the other party successfully decrypts a
         // note).
         Transfer { from, to, amount: amount.to_field() }.emit(
-            encode_and_encrypt_event_unconstrained(&mut context, from_keys.ovpk_m, to),
+            encode_and_encrypt_event_unconstrained(&mut context, from_ovpk_m, to),
         );
     }
     // docs:end:transfer
@@ -437,24 +441,27 @@ contract Token {
             assert(nonce == 0, "invalid nonce");
         }
         // docs:end:assert_current_call_valid_authwit
-        let from_keys = get_public_keys(from);
-        let to_keys = get_public_keys(to);
+        let from_ovpk_m = get_public_keys(from).ovpk_m;
 
         let amount = U128::from_integer(amount);
         // docs:start:increase_private_balance
         // docs:start:encrypted
         // TODO: constrain encryption below - we are using unconstrained here only becuase of the following Noir issue
         // https://github.com/noir-lang/noir/issues/5771
-        storage.balances.at(from).sub(from_keys.npk_m, amount).emit(
-            encode_and_encrypt_note_unconstrained(&mut context, from_keys.ovpk_m, from),
-        );
+        storage.balances.at(from).sub(from, amount).emit(encode_and_encrypt_note_unconstrained(
+            &mut context,
+            from_ovpk_m,
+            from,
+        ));
         // docs:end:encrypted
         // docs:end:increase_private_balance
         // TODO: constrain encryption below - we are using unconstrained here only becuase of the following Noir issue
         // https://github.com/noir-lang/noir/issues/5771
-        storage.balances.at(to).add(to_keys.npk_m, amount).emit(
-            encode_and_encrypt_note_unconstrained(&mut context, from_keys.ovpk_m, to),
-        );
+        storage.balances.at(to).add(to, amount).emit(encode_and_encrypt_note_unconstrained(
+            &mut context,
+            from_ovpk_m,
+            to,
+        ));
     }
     // docs:end:transfer_from
     // docs:start:burn
@@ -465,11 +472,11 @@ contract Token {
         } else {
             assert(nonce == 0, "invalid nonce");
         }
-        let from_keys = get_public_keys(from);
+        let from_ovpk_m = get_public_keys(from).ovpk_m;
         // TODO: constrain encryption below - we are using unconstrained here only becuase of the following Noir issue
         // https://github.com/noir-lang/noir/issues/5771
-        storage.balances.at(from).sub(from_keys.npk_m, U128::from_integer(amount)).emit(
-            encode_and_encrypt_note_unconstrained(&mut context, from_keys.ovpk_m, from),
+        storage.balances.at(from).sub(from, U128::from_integer(amount)).emit(
+            encode_and_encrypt_note_unconstrained(&mut context, from_ovpk_m, from),
         );
         Token::at(context.this_address())._reduce_total_supply(amount).enqueue(&mut context);
     }
@@ -508,9 +515,6 @@ contract Token {
         let fee_payer_keys = get_public_keys(fee_payer);
         let user_keys = get_public_keys(user);
 
-        let fee_payer_npk_m_hash = fee_payer_keys.npk_m.hash();
-        let user_npk_m_hash = user_keys.npk_m.hash();
-
         // 3. Deduct the funded amount from the user's balance - this is a maximum fee a user is willing to pay
         // (called fee limit in aztec spec). The difference between fee limit and the actual tx fee will be refunded
         // to the user in the `complete_refund(...)` function.
@@ -521,9 +525,11 @@ contract Token {
             U128::from_integer(funded_amount),
             INITIAL_TRANSFER_CALL_MAX_NOTES,
         );
-        storage.balances.at(user).add(user_keys.npk_m, change).emit(
-            encode_and_encrypt_note_unconstrained(&mut context, user_keys.ovpk_m, user),
-        );
+        storage.balances.at(user).add(user, change).emit(encode_and_encrypt_note_unconstrained(
+            &mut context,
+            user_keys.ovpk_m,
+            user,
+        ));
 
         // 4. Now we get the partial payloads
         // TODO(#7775): Manually fetching the randomness here is not great. If we decide to include randomness in all
@@ -532,13 +538,13 @@ contract Token {
         let user_randomness = unsafe { random() };
 
         let fee_payer_setup_payload = UintNote::setup_payload().new(
-            fee_payer_npk_m_hash,
+            fee_payer,
             fee_payer_randomness,
             storage.balances.at(fee_payer).set.storage_slot,
         );
 
         let user_setup_payload = UintNote::setup_payload().new(
-            user_npk_m_hash,
+            user,
             user_randomness,
             storage.balances.at(user).set.storage_slot,
         );

--- a/noir-projects/noir-contracts/contracts/token_contract/src/test/refunds.nr
+++ b/noir-projects/noir-contracts/contracts/token_contract/src/test/refunds.nr
@@ -1,10 +1,7 @@
 use crate::{test::utils, Token};
 
 use dep::authwit::cheatcodes as authwit_cheatcodes;
-use dep::aztec::{
-    keys::getters::get_public_keys, prelude::NoteHeader,
-    protocol_types::storage::map::derive_storage_slot_in_map,
-};
+use dep::aztec::{prelude::NoteHeader, protocol_types::storage::map::derive_storage_slot_in_map};
 use dep::uint_note::uint_note::UintNote;
 use std::test::OracleMock;
 
@@ -36,8 +33,6 @@ unconstrained fn setup_refund_success() {
     env.impersonate(fee_payer);
 
     setup_refund_from_call_interface.call(&mut env.private());
-    let user_npk_m_hash = get_public_keys(user).npk_m.hash();
-    let fee_payer_npk_m_hash = get_public_keys(fee_payer).npk_m.hash();
 
     let fee_payer_balances_slot =
         derive_storage_slot_in_map(Token::storage_layout().balances.slot, fee_payer);
@@ -51,7 +46,7 @@ unconstrained fn setup_refund_success() {
     env.add_note(
         &mut UintNote {
             value: U128::from_integer(funded_amount - 1),
-            npk_m_hash: user_npk_m_hash,
+            owner: user,
             randomness: user_randomness,
             header: NoteHeader::empty(),
         },
@@ -61,7 +56,7 @@ unconstrained fn setup_refund_success() {
     env.add_note(
         &mut UintNote {
             value: U128::from_integer(1),
-            npk_m_hash: fee_payer_npk_m_hash,
+            owner: fee_payer,
             randomness: fee_payer_randomness,
             header: NoteHeader::empty(),
         },

--- a/noir-projects/noir-contracts/contracts/token_contract/src/types/balance_set.nr
+++ b/noir-projects/noir-contracts/contracts/token_contract/src/types/balance_set.nr
@@ -1,7 +1,9 @@
 use dep::aztec::{
     context::{PrivateContext, UnconstrainedContext},
     note::note_emission::OuterNoteEmission,
-    protocol_types::{constants::MAX_NOTE_HASH_READ_REQUESTS_PER_CALL, public_keys::NpkM},
+    protocol_types::{
+        address::AztecAddress, constants::MAX_NOTE_HASH_READ_REQUESTS_PER_CALL, public_keys::NpkM,
+    },
 };
 use dep::aztec::prelude::{NoteGetterOptions, NoteViewerOptions, PrivateSet};
 use dep::uint_note::uint_note::UintNote;
@@ -42,12 +44,12 @@ impl BalanceSet<UnconstrainedContext> {
 }
 
 impl BalanceSet<&mut PrivateContext> {
-    pub fn add(self: Self, owner_npk_m: NpkM, addend: U128) -> OuterNoteEmission<UintNote> {
+    pub fn add(self: Self, owner: AztecAddress, addend: U128) -> OuterNoteEmission<UintNote> {
         if addend == U128::from_integer(0) {
             OuterNoteEmission::new(Option::none())
         } else {
             // We fetch the nullifier public key hash from the registry / from our PXE
-            let mut addend_note = UintNote::new(addend, owner_npk_m.hash());
+            let mut addend_note = UintNote::new(addend, owner);
 
             // docs:start:insert
             OuterNoteEmission::new(Option::some(self.set.insert(&mut addend_note)))
@@ -55,13 +57,13 @@ impl BalanceSet<&mut PrivateContext> {
         }
     }
 
-    pub fn sub(self: Self, owner_npk_m: NpkM, amount: U128) -> OuterNoteEmission<UintNote> {
+    pub fn sub(self: Self, owner: AztecAddress, amount: U128) -> OuterNoteEmission<UintNote> {
         let subtracted = self.try_sub(amount, MAX_NOTE_HASH_READ_REQUESTS_PER_CALL);
 
         // try_sub may have substracted more or less than amount. We must ensure that we subtracted at least as much as
         // we needed, and then create a new note for the owner for the change (if any).
         assert(subtracted >= amount, "Balance too low");
-        self.add(owner_npk_m, subtracted - amount)
+        self.add(owner, subtracted - amount)
     }
 
     // Attempts to remove 'target_amount' from the owner's balance. try_sub returns how much was actually subtracted

--- a/yarn-project/end-to-end/src/e2e_crowdfunding_and_claim.test.ts
+++ b/yarn-project/end-to-end/src/e2e_crowdfunding_and_claim.test.ts
@@ -195,7 +195,7 @@ describe('e2e_crowdfunding_and_claim', () => {
       },
       value: uniqueNote.note.items[0],
       // eslint-disable-next-line camelcase
-      npk_m_hash: uniqueNote.note.items[1],
+      owner: uniqueNote.note.items[1],
       randomness: uniqueNote.note.items[2],
     };
   };
@@ -322,7 +322,7 @@ describe('e2e_crowdfunding_and_claim', () => {
           .methods.claim(anotherDonationNote, unrelatedWallet.getAddress())
           .send()
           .wait(),
-      ).rejects.toThrow('Could not find key prefix.');
+      ).rejects.toThrow('No public key registered for address');
     }
   });
 

--- a/yarn-project/protocol-contracts/src/protocol_contract_data.ts
+++ b/yarn-project/protocol-contracts/src/protocol_contract_data.ts
@@ -55,9 +55,9 @@ export const ProtocolContractLeaf = {
   ContractClassRegisterer: Fr.fromString('0x147ba3294403576dbad10f86d3ffd4eb83fb230ffbcd5c8b153dd02942d0611f'),
   MultiCallEntrypoint: Fr.fromString('0x154b701b41d6cf6da7204fef36b2ee9578b449d21b3792a9287bf45eba48fd26'),
   FeeJuice: Fr.fromString('0x21c9ab2e339c9b3394e4e1ff3b7cf37be4e0fc0bc177a192d287d98963b9b254'),
-  Router: Fr.fromString('0x2779d7e4ccba389da358a0c9362364d0c65e14cd4d9df929e6722187e808e068'),
+  Router: Fr.fromString('0x2b0b558e92b7a13cde0a2ecc7570c181a6fbae2bdc6f966cacfc39a784635394'),
 };
 
 export const protocolContractTreeRoot = Fr.fromString(
-  '0x00724e4de088411c873c3d6975491eb48889bfa51bc854744a4fcc307ee9abd8',
+  '0x0d560ad12f14dd5026070bc037ac343535db339212f0904dfc96c4aea4dcc8ab',
 );

--- a/yarn-project/simulator/src/client/private_execution.test.ts
+++ b/yarn-project/simulator/src/client/private_execution.test.ts
@@ -401,8 +401,8 @@ describe('Private Execution test suite', () => {
       );
 
       const notes = [
-        buildNote(60n, ownerCompleteAddress.publicKeys.masterNullifierPublicKey.hash(), storageSlot, valueNoteTypeId),
-        buildNote(80n, ownerCompleteAddress.publicKeys.masterNullifierPublicKey.hash(), storageSlot, valueNoteTypeId),
+        buildNote(60n, ownerCompleteAddress.address, storageSlot, valueNoteTypeId),
+        buildNote(80n, ownerCompleteAddress.address, storageSlot, valueNoteTypeId),
       ];
       oracle.getNotes.mockResolvedValue(notes);
 
@@ -468,14 +468,7 @@ describe('Private Execution test suite', () => {
 
       const storageSlot = deriveStorageSlotInMap(new Fr(1n), owner);
 
-      const notes = [
-        buildNote(
-          balance,
-          ownerCompleteAddress.publicKeys.masterNullifierPublicKey.hash(),
-          storageSlot,
-          valueNoteTypeId,
-        ),
-      ];
+      const notes = [buildNote(balance, ownerCompleteAddress.address, storageSlot, valueNoteTypeId)];
       oracle.getNotes.mockResolvedValue(notes);
 
       const consumedNotes = await asyncMap(notes, ({ nonce, note }) =>


### PR DESCRIPTION
Because key rotation is scrapped, we are moving back to having addresses denote the owner of a note. This allows us to eventually remove the requirement of having public keys to send to a user.
