### PR TITLE
fix: yarn build:fast

### DIFF
--- a/yarn-project/package.json
+++ b/yarn-project/package.json
@@ -12,7 +12,7 @@
     "format": "yarn prettier --cache -w .",
     "test": "FORCE_COLOR=true yarn workspaces foreach --exclude @aztec/aztec3-packages --exclude @aztec/end-to-end --exclude @aztec/prover-client -p -v run test && yarn workspaces foreach --include @aztec/end-to-end -p -v run test:unit",
     "build": "FORCE_COLOR=true yarn workspaces foreach --parallel --topological-dev --verbose --exclude @aztec/aztec3-packages --exclude @aztec/docs run build",
-    "build:fast": "cd foundation && yarn build && cd ../circuits.js && yarn build && cd ../l1-contracts && yarn generate && cd .. && yarn generate && tsc -b",
+    "build:fast": "cd foundation && yarn build && cd ../circuits.js && yarn build && cd ../l1-artifacts && yarn generate && cd .. && yarn generate && tsc -b",
     "build:dev": "./watch.sh",
     "generate": "FORCE_COLOR=true yarn workspaces foreach --parallel --topological-dev --verbose run generate",
     "clean": "yarn workspaces foreach -p -v run clean"


### PR DESCRIPTION
incorrect name in script