### PR TITLE
test: minting only private or public balance in Token TXE tests

### DIFF
--- a/noir-projects/noir-contracts/contracts/token_contract/src/test/burn.nr
+++ b/noir-projects/noir-contracts/contracts/token_contract/src/test/burn.nr
@@ -6,7 +6,7 @@ use dep::aztec::oracle::random::random;
 #[test]
 unconstrained fn burn_public_success() {
     let (env, token_contract_address, owner, recipient, mint_amount) =
-        utils::setup_and_mint(/* with_account_contracts */ false);
+        utils::setup_and_mint_public(/* with_account_contracts */ false);
     let burn_amount = mint_amount / 10;
 
     // Burn less than balance
@@ -17,7 +17,7 @@ unconstrained fn burn_public_success() {
 #[test]
 unconstrained fn burn_public_on_behalf_of_other() {
     let (env, token_contract_address, owner, recipient, mint_amount) =
-        utils::setup_and_mint(/* with_account_contracts */ true);
+        utils::setup_and_mint_public(/* with_account_contracts */ true);
     let burn_amount = mint_amount / 10;
 
     // Burn on behalf of other
@@ -38,7 +38,7 @@ unconstrained fn burn_public_on_behalf_of_other() {
 #[test(should_fail_with = "attempt to subtract with underflow")]
 unconstrained fn burn_public_failure_more_than_balance() {
     let (env, token_contract_address, owner, _, mint_amount) =
-        utils::setup_and_mint(/* with_account_contracts */ false);
+        utils::setup_and_mint_public(/* with_account_contracts */ false);
 
     // Burn more than balance
     let burn_amount = mint_amount * 10;
@@ -49,7 +49,7 @@ unconstrained fn burn_public_failure_more_than_balance() {
 #[test(should_fail_with = "invalid nonce")]
 unconstrained fn burn_public_failure_on_behalf_of_self_non_zero_nonce() {
     let (env, token_contract_address, owner, _, mint_amount) =
-        utils::setup_and_mint(/* with_account_contracts */ false);
+        utils::setup_and_mint_public(/* with_account_contracts */ false);
 
     // Burn on behalf of self with non-zero nonce
     let burn_amount = mint_amount / 10;
@@ -62,7 +62,7 @@ unconstrained fn burn_public_failure_on_behalf_of_self_non_zero_nonce() {
 #[test(should_fail_with = "unauthorized")]
 unconstrained fn burn_public_failure_on_behalf_of_other_without_approval() {
     let (env, token_contract_address, owner, recipient, mint_amount) =
-        utils::setup_and_mint(/* with_account_contracts */ true);
+        utils::setup_and_mint_public(/* with_account_contracts */ true);
 
     // Burn on behalf of other without approval
     let burn_amount = mint_amount / 10;
@@ -76,7 +76,7 @@ unconstrained fn burn_public_failure_on_behalf_of_other_without_approval() {
 #[test(should_fail_with = "unauthorized")]
 unconstrained fn burn_public_failure_on_behalf_of_other_wrong_caller() {
     let (env, token_contract_address, owner, recipient, mint_amount) =
-        utils::setup_and_mint(/* with_account_contracts */ true);
+        utils::setup_and_mint_public(/* with_account_contracts */ true);
 
     // Burn on behalf of other, wrong designated caller
     let burn_amount = mint_amount / 10;
@@ -91,7 +91,7 @@ unconstrained fn burn_public_failure_on_behalf_of_other_wrong_caller() {
 #[test]
 unconstrained fn burn_private_on_behalf_of_self() {
     let (env, token_contract_address, owner, _, mint_amount) =
-        utils::setup_and_mint(/* with_account_contracts */ false);
+        utils::setup_and_mint_public(/* with_account_contracts */ false);
     let burn_amount = mint_amount / 10;
 
     // Burn less than balance
@@ -102,7 +102,7 @@ unconstrained fn burn_private_on_behalf_of_self() {
 #[test]
 unconstrained fn burn_private_on_behalf_of_other() {
     let (env, token_contract_address, owner, recipient, mint_amount) =
-        utils::setup_and_mint(/* with_account_contracts */ true);
+        utils::setup_and_mint_public(/* with_account_contracts */ true);
     let burn_amount = mint_amount / 10;
 
     // Burn on behalf of other
@@ -122,7 +122,7 @@ unconstrained fn burn_private_on_behalf_of_other() {
 #[test(should_fail_with = "Balance too low")]
 unconstrained fn burn_private_failure_more_than_balance() {
     let (env, token_contract_address, owner, _, mint_amount) =
-        utils::setup_and_mint(/* with_account_contracts */ false);
+        utils::setup_and_mint_public(/* with_account_contracts */ false);
 
     // Burn more than balance
     let burn_amount = mint_amount * 10;
@@ -132,7 +132,7 @@ unconstrained fn burn_private_failure_more_than_balance() {
 #[test(should_fail_with = "invalid nonce")]
 unconstrained fn burn_private_failure_on_behalf_of_self_non_zero_nonce() {
     let (env, token_contract_address, owner, _, mint_amount) =
-        utils::setup_and_mint(/* with_account_contracts */ false);
+        utils::setup_and_mint_public(/* with_account_contracts */ false);
 
     // Burn more than balance
     let burn_amount = mint_amount / 10;
@@ -142,7 +142,7 @@ unconstrained fn burn_private_failure_on_behalf_of_self_non_zero_nonce() {
 #[test(should_fail_with = "Balance too low")]
 unconstrained fn burn_private_failure_on_behalf_of_other_more_than_balance() {
     let (env, token_contract_address, owner, recipient, mint_amount) =
-        utils::setup_and_mint(/* with_account_contracts */ true);
+        utils::setup_and_mint_public(/* with_account_contracts */ true);
 
     // Burn more than balance
     let burn_amount = mint_amount * 10;
@@ -161,7 +161,7 @@ unconstrained fn burn_private_failure_on_behalf_of_other_more_than_balance() {
 #[test(should_fail_with = "Authorization not found for message hash")]
 unconstrained fn burn_private_failure_on_behalf_of_other_without_approval() {
     let (env, token_contract_address, owner, recipient, mint_amount) =
-        utils::setup_and_mint(/* with_account_contracts */ true);
+        utils::setup_and_mint_public(/* with_account_contracts */ true);
 
     // Burn more than balance
     let burn_amount = mint_amount / 10;
@@ -175,7 +175,7 @@ unconstrained fn burn_private_failure_on_behalf_of_other_without_approval() {
 #[test(should_fail_with = "Authorization not found for message hash")]
 unconstrained fn burn_private_failure_on_behalf_of_other_wrong_designated_caller() {
     let (env, token_contract_address, owner, recipient, mint_amount) =
-        utils::setup_and_mint(/* with_account_contracts */ true);
+        utils::setup_and_mint_public(/* with_account_contracts */ true);
 
     // Burn more than balance
     let burn_amount = mint_amount / 10;

--- a/noir-projects/noir-contracts/contracts/token_contract/src/test/burn.nr
+++ b/noir-projects/noir-contracts/contracts/token_contract/src/test/burn.nr
@@ -91,7 +91,7 @@ unconstrained fn burn_public_failure_on_behalf_of_other_wrong_caller() {
 #[test]
 unconstrained fn burn_private_on_behalf_of_self() {
     let (env, token_contract_address, owner, _, mint_amount) =
-        utils::setup_and_mint_public(/* with_account_contracts */ false);
+        utils::setup_and_mint_private(/* with_account_contracts */ false);
     let burn_amount = mint_amount / 10;
 
     // Burn less than balance
@@ -102,7 +102,7 @@ unconstrained fn burn_private_on_behalf_of_self() {
 #[test]
 unconstrained fn burn_private_on_behalf_of_other() {
     let (env, token_contract_address, owner, recipient, mint_amount) =
-        utils::setup_and_mint_public(/* with_account_contracts */ true);
+        utils::setup_and_mint_private(/* with_account_contracts */ true);
     let burn_amount = mint_amount / 10;
 
     // Burn on behalf of other

--- a/noir-projects/noir-contracts/contracts/token_contract/src/test/refunds.nr
+++ b/noir-projects/noir-contracts/contracts/token_contract/src/test/refunds.nr
@@ -10,7 +10,8 @@ use std::test::OracleMock;
 
 #[test]
 unconstrained fn setup_refund_success() {
-    let (env, token_contract_address, owner, recipient, mint_amount) = utils::setup_and_mint_private(true);
+    let (env, token_contract_address, owner, recipient, mint_amount) =
+        utils::setup_and_mint_private(true);
 
     // Renaming owner and recipient to match naming in Token
     let user = owner;
@@ -78,7 +79,8 @@ unconstrained fn setup_refund_success() {
 //#[test(should_fail_with="funded amount not enough to cover tx fee")]
 #[test(should_fail_with = "Balance too low")]
 unconstrained fn setup_refund_insufficient_funded_amount() {
-    let (env, token_contract_address, owner, recipient, _mint_amount) = utils::setup_and_mint_private(true);
+    let (env, token_contract_address, owner, recipient, _mint_amount) =
+        utils::setup_and_mint_private(true);
 
     // Renaming owner and recipient to match naming in Token
     let user = owner;

--- a/noir-projects/noir-contracts/contracts/token_contract/src/test/refunds.nr
+++ b/noir-projects/noir-contracts/contracts/token_contract/src/test/refunds.nr
@@ -10,7 +10,7 @@ use std::test::OracleMock;
 
 #[test]
 unconstrained fn setup_refund_success() {
-    let (env, token_contract_address, owner, recipient, mint_amount) = utils::setup_and_mint(true);
+    let (env, token_contract_address, owner, recipient, mint_amount) = utils::setup_and_mint_private(true);
 
     // Renaming owner and recipient to match naming in Token
     let user = owner;
@@ -78,7 +78,7 @@ unconstrained fn setup_refund_success() {
 //#[test(should_fail_with="funded amount not enough to cover tx fee")]
 #[test(should_fail_with = "Balance too low")]
 unconstrained fn setup_refund_insufficient_funded_amount() {
-    let (env, token_contract_address, owner, recipient, _mint_amount) = utils::setup_and_mint(true);
+    let (env, token_contract_address, owner, recipient, _mint_amount) = utils::setup_and_mint_private(true);
 
     // Renaming owner and recipient to match naming in Token
     let user = owner;

--- a/noir-projects/noir-contracts/contracts/token_contract/src/test/shielding.nr
+++ b/noir-projects/noir-contracts/contracts/token_contract/src/test/shielding.nr
@@ -30,7 +30,7 @@ unconstrained fn shielding_on_behalf_of_self() {
 
     // Check balances
     utils::check_public_balance(token_contract_address, owner, mint_amount - shield_amount);
-    utils::check_private_balance(token_contract_address, owner, mint_amount + shield_amount);
+    utils::check_private_balance(token_contract_address, owner, shield_amount);
 }
 
 #[test]
@@ -70,7 +70,7 @@ unconstrained fn shielding_on_behalf_of_other() {
 
     // Check balances
     utils::check_public_balance(token_contract_address, owner, mint_amount - shield_amount);
-    utils::check_private_balance(token_contract_address, owner, mint_amount + shield_amount);
+    utils::check_private_balance(token_contract_address, owner, shield_amount);
 }
 
 #[test]
@@ -88,7 +88,7 @@ unconstrained fn shielding_failure_on_behalf_of_self_more_than_balance() {
 
     // Check balances
     utils::check_public_balance(token_contract_address, owner, mint_amount);
-    utils::check_private_balance(token_contract_address, owner, mint_amount);
+    utils::check_private_balance(token_contract_address, owner, 0);
 }
 
 #[test]
@@ -106,7 +106,7 @@ unconstrained fn shielding_failure_on_behalf_of_self_invalid_nonce() {
 
     // Check balances
     utils::check_public_balance(token_contract_address, owner, mint_amount);
-    utils::check_private_balance(token_contract_address, owner, mint_amount);
+    utils::check_private_balance(token_contract_address, owner, 0);
 }
 
 #[test]
@@ -132,7 +132,7 @@ unconstrained fn shielding_failure_on_behalf_of_other_more_than_balance() {
 
     // Check balances
     utils::check_public_balance(token_contract_address, owner, mint_amount);
-    utils::check_private_balance(token_contract_address, owner, mint_amount);
+    utils::check_private_balance(token_contract_address, owner, 0);
 }
 
 #[test]
@@ -154,7 +154,7 @@ unconstrained fn shielding_failure_on_behalf_of_other_wrong_caller() {
 
     // Check balances
     utils::check_public_balance(token_contract_address, owner, mint_amount);
-    utils::check_private_balance(token_contract_address, owner, mint_amount);
+    utils::check_private_balance(token_contract_address, owner, 0);
 }
 
 #[test]
@@ -175,5 +175,5 @@ unconstrained fn shielding_failure_on_behalf_of_other_without_approval() {
 
     // Check balances
     utils::check_public_balance(token_contract_address, owner, mint_amount);
-    utils::check_private_balance(token_contract_address, owner, mint_amount);
+    utils::check_private_balance(token_contract_address, owner, 0);
 }

--- a/noir-projects/noir-contracts/contracts/token_contract/src/test/shielding.nr
+++ b/noir-projects/noir-contracts/contracts/token_contract/src/test/shielding.nr
@@ -7,7 +7,7 @@ use dep::aztec::{hash::compute_secret_hash, oracle::random::random};
 unconstrained fn shielding_on_behalf_of_self() {
     // Setup without account contracts. We are not using authwits here, so dummy accounts are enough
     let (env, token_contract_address, owner, _, mint_amount) =
-        utils::setup_and_mint(/* with_account_contracts */ false);
+        utils::setup_and_mint_public(/* with_account_contracts */ false);
     let secret = random();
     let secret_hash = compute_secret_hash(secret);
     // Shield tokens
@@ -36,7 +36,7 @@ unconstrained fn shielding_on_behalf_of_self() {
 #[test]
 unconstrained fn shielding_on_behalf_of_other() {
     let (env, token_contract_address, owner, recipient, mint_amount) =
-        utils::setup_and_mint(/* with_account_contracts */ true);
+        utils::setup_and_mint_public(/* with_account_contracts */ true);
     let secret = random();
     let secret_hash = compute_secret_hash(secret);
 
@@ -77,7 +77,7 @@ unconstrained fn shielding_on_behalf_of_other() {
 unconstrained fn shielding_failure_on_behalf_of_self_more_than_balance() {
     // Setup without account contracts. We are not using authwits here, so dummy accounts are enough
     let (env, token_contract_address, owner, _, mint_amount) =
-        utils::setup_and_mint(/* with_account_contracts */ true);
+        utils::setup_and_mint_public(/* with_account_contracts */ true);
     let secret = random();
     let secret_hash = compute_secret_hash(secret);
     // Shield tokens
@@ -95,7 +95,7 @@ unconstrained fn shielding_failure_on_behalf_of_self_more_than_balance() {
 unconstrained fn shielding_failure_on_behalf_of_self_invalid_nonce() {
     // Setup without account contracts. We are not using authwits here, so dummy accounts are enough
     let (env, token_contract_address, owner, _, mint_amount) =
-        utils::setup_and_mint(/* with_account_contracts */ true);
+        utils::setup_and_mint_public(/* with_account_contracts */ true);
     let secret = random();
     let secret_hash = compute_secret_hash(secret);
     // Shield tokens
@@ -113,7 +113,7 @@ unconstrained fn shielding_failure_on_behalf_of_self_invalid_nonce() {
 unconstrained fn shielding_failure_on_behalf_of_other_more_than_balance() {
     // Setup without account contracts. We are not using authwits here, so dummy accounts are enough
     let (env, token_contract_address, owner, recipient, mint_amount) =
-        utils::setup_and_mint(/* with_account_contracts */ true);
+        utils::setup_and_mint_public(/* with_account_contracts */ true);
     let secret = random();
     let secret_hash = compute_secret_hash(secret);
     // Shield tokens on behalf of owner
@@ -139,7 +139,7 @@ unconstrained fn shielding_failure_on_behalf_of_other_more_than_balance() {
 unconstrained fn shielding_failure_on_behalf_of_other_wrong_caller() {
     // Setup without account contracts. We are not using authwits here, so dummy accounts are enough
     let (env, token_contract_address, owner, recipient, mint_amount) =
-        utils::setup_and_mint(/* with_account_contracts */ true);
+        utils::setup_and_mint_public(/* with_account_contracts */ true);
     let secret = random();
     let secret_hash = compute_secret_hash(secret);
     // Shield tokens on behalf of owner
@@ -161,7 +161,7 @@ unconstrained fn shielding_failure_on_behalf_of_other_wrong_caller() {
 unconstrained fn shielding_failure_on_behalf_of_other_without_approval() {
     // Setup without account contracts. We are not using authwits here, so dummy accounts are enough
     let (env, token_contract_address, owner, recipient, mint_amount) =
-        utils::setup_and_mint(/* with_account_contracts */ true);
+        utils::setup_and_mint_public(/* with_account_contracts */ true);
     let secret = random();
     let secret_hash = compute_secret_hash(secret);
     // Shield tokens on behalf of owner

--- a/noir-projects/noir-contracts/contracts/token_contract/src/test/transfer_private.nr
+++ b/noir-projects/noir-contracts/contracts/token_contract/src/test/transfer_private.nr
@@ -7,7 +7,7 @@ use dep::aztec::test::helpers::cheatcodes;
 unconstrained fn transfer_private() {
     // Setup without account contracts. We are not using authwits here, so dummy accounts are enough
     let (env, token_contract_address, owner, recipient, mint_amount) =
-        utils::setup_and_mint(/* with_account_contracts */ false);
+        utils::setup_and_mint_private(/* with_account_contracts */ false);
 
     // docs:start:txe_test_transfer_private
     // Transfer tokens
@@ -23,7 +23,7 @@ unconstrained fn transfer_private() {
 unconstrained fn transfer_private_to_self() {
     // Setup without account contracts. We are not using authwits here, so dummy accounts are enough
     let (env, token_contract_address, owner, _, mint_amount) =
-        utils::setup_and_mint(/* with_account_contracts */ false);
+        utils::setup_and_mint_private(/* with_account_contracts */ false);
     // Transfer tokens
     let transfer_amount = 1000;
     Token::at(token_contract_address).transfer(owner, transfer_amount).call(&mut env.private());
@@ -36,7 +36,7 @@ unconstrained fn transfer_private_to_self() {
 unconstrained fn transfer_private_to_non_deployed_account() {
     // Setup without account contracts. We are not using authwits here, so dummy accounts are enough
     let (env, token_contract_address, owner, _, mint_amount) =
-        utils::setup_and_mint(/* with_account_contracts */ false);
+        utils::setup_and_mint_private(/* with_account_contracts */ false);
     let not_deployed = cheatcodes::create_account();
     // Transfer tokens
     let transfer_amount = 1000;
@@ -57,7 +57,7 @@ unconstrained fn transfer_private_to_non_deployed_account() {
 unconstrained fn transfer_private_on_behalf_of_other() {
     // Setup with account contracts. Slower since we actually deploy them, but needed for authwits.
     let (env, token_contract_address, owner, recipient, mint_amount) =
-        utils::setup_and_mint(/* with_account_contracts */ true);
+        utils::setup_and_mint_private(/* with_account_contracts */ true);
     // Add authwit
     // docs:start:private_authwit
     let transfer_amount = 1000;
@@ -82,7 +82,7 @@ unconstrained fn transfer_private_on_behalf_of_other() {
 unconstrained fn transfer_private_failure_more_than_balance() {
     // Setup without account contracts. We are not using authwits here, so dummy accounts are enough
     let (env, token_contract_address, _, recipient, mint_amount) =
-        utils::setup_and_mint(/* with_account_contracts */ false);
+        utils::setup_and_mint_private(/* with_account_contracts */ false);
     // Transfer tokens
     let transfer_amount = mint_amount + 1;
     Token::at(token_contract_address).transfer(recipient, transfer_amount).call(&mut env.private());
@@ -93,7 +93,7 @@ unconstrained fn transfer_private_failure_more_than_balance() {
 unconstrained fn transfer_private_failure_on_behalf_of_self_non_zero_nonce() {
     // Setup without account contracts. We are not using authwits here, so dummy accounts are enough
     let (env, token_contract_address, owner, recipient, _) =
-        utils::setup_and_mint(/* with_account_contracts */ false);
+        utils::setup_and_mint_private(/* with_account_contracts */ false);
     // Add authwit
     let transfer_amount = 1000;
     let transfer_private_from_call_interface =
@@ -112,7 +112,7 @@ unconstrained fn transfer_private_failure_on_behalf_of_self_non_zero_nonce() {
 unconstrained fn transfer_private_failure_on_behalf_of_more_than_balance() {
     // Setup with account contracts. Slower since we actually deploy them, but needed for authwits.
     let (env, token_contract_address, owner, recipient, mint_amount) =
-        utils::setup_and_mint(/* with_account_contracts */ true);
+        utils::setup_and_mint_private(/* with_account_contracts */ true);
     // Add authwit
     let transfer_amount = mint_amount + 1;
     let transfer_private_from_call_interface =
@@ -132,7 +132,7 @@ unconstrained fn transfer_private_failure_on_behalf_of_more_than_balance() {
 unconstrained fn transfer_private_failure_on_behalf_of_other_without_approval() {
     // Setup with account contracts. Slower since we actually deploy them, but needed for authwits.
     let (env, token_contract_address, owner, recipient, _) =
-        utils::setup_and_mint(/* with_account_contracts */ true);
+        utils::setup_and_mint_private(/* with_account_contracts */ true);
     // Add authwit
     let transfer_amount = 1000;
     let transfer_private_from_call_interface =
@@ -147,7 +147,7 @@ unconstrained fn transfer_private_failure_on_behalf_of_other_without_approval() 
 unconstrained fn transfer_private_failure_on_behalf_of_other_wrong_caller() {
     // Setup with account contracts. Slower since we actually deploy them, but needed for authwits.
     let (env, token_contract_address, owner, recipient, _) =
-        utils::setup_and_mint(/* with_account_contracts */ true);
+        utils::setup_and_mint_private(/* with_account_contracts */ true);
     // Add authwit
     let transfer_amount = 1000;
     let transfer_private_from_call_interface =

--- a/noir-projects/noir-contracts/contracts/token_contract/src/test/transfer_public.nr
+++ b/noir-projects/noir-contracts/contracts/token_contract/src/test/transfer_public.nr
@@ -7,7 +7,7 @@ use dep::aztec::oracle::random::random;
 unconstrained fn public_transfer() {
     // Setup without account contracts. We are not using authwits here, so dummy accounts are enough
     let (env, token_contract_address, owner, recipient, mint_amount) =
-        utils::setup_and_mint(/* with_account_contracts */ false);
+        utils::setup_and_mint_public(/* with_account_contracts */ false);
     // Transfer tokens
     let transfer_amount = mint_amount / 10;
     Token::at(token_contract_address).transfer_public(owner, recipient, transfer_amount, 0).call(
@@ -23,7 +23,7 @@ unconstrained fn public_transfer() {
 unconstrained fn public_transfer_to_self() {
     // Setup without account contracts. We are not using authwits here, so dummy accounts are enough
     let (env, token_contract_address, owner, _, mint_amount) =
-        utils::setup_and_mint(/* with_account_contracts */ false);
+        utils::setup_and_mint_public(/* with_account_contracts */ false);
     // Transfer tokens
     let transfer_amount = mint_amount / 10;
     // docs:start:call_public
@@ -39,7 +39,7 @@ unconstrained fn public_transfer_to_self() {
 unconstrained fn public_transfer_on_behalf_of_other() {
     // Setup with account contracts. Slower since we actually deploy them, but needed for authwits.
     let (env, token_contract_address, owner, recipient, mint_amount) =
-        utils::setup_and_mint(/* with_account_contracts */ true);
+        utils::setup_and_mint_public(/* with_account_contracts */ true);
     let transfer_amount = mint_amount / 10;
     let public_transfer_from_call_interface =
         Token::at(token_contract_address).transfer_public(owner, recipient, transfer_amount, 1);
@@ -61,7 +61,7 @@ unconstrained fn public_transfer_on_behalf_of_other() {
 unconstrained fn public_transfer_failure_more_than_balance() {
     // Setup without account contracts. We are not using authwits here, so dummy accounts are enough
     let (env, token_contract_address, owner, recipient, mint_amount) =
-        utils::setup_and_mint(/* with_account_contracts */ false);
+        utils::setup_and_mint_public(/* with_account_contracts */ false);
     // Transfer tokens
     let transfer_amount = mint_amount + 1;
     let public_transfer_call_interface =
@@ -74,7 +74,7 @@ unconstrained fn public_transfer_failure_more_than_balance() {
 unconstrained fn public_transfer_failure_on_behalf_of_self_non_zero_nonce() {
     // Setup without account contracts. We are not using authwits here, so dummy accounts are enough
     let (env, token_contract_address, owner, recipient, mint_amount) =
-        utils::setup_and_mint(/* with_account_contracts */ false);
+        utils::setup_and_mint_public(/* with_account_contracts */ false);
     // Transfer tokens
     let transfer_amount = mint_amount / 10;
     let public_transfer_call_interface = Token::at(token_contract_address).transfer_public(
@@ -96,7 +96,7 @@ unconstrained fn public_transfer_failure_on_behalf_of_self_non_zero_nonce() {
 unconstrained fn public_transfer_failure_on_behalf_of_other_without_approval() {
     // Setup with account contracts. Slower since we actually deploy them, but needed for authwits.
     let (env, token_contract_address, owner, recipient, mint_amount) =
-        utils::setup_and_mint(/* with_account_contracts */ true);
+        utils::setup_and_mint_public(/* with_account_contracts */ true);
     let transfer_amount = mint_amount / 10;
     let public_transfer_from_call_interface =
         Token::at(token_contract_address).transfer_public(owner, recipient, transfer_amount, 1);
@@ -110,7 +110,7 @@ unconstrained fn public_transfer_failure_on_behalf_of_other_without_approval() {
 unconstrained fn public_transfer_failure_on_behalf_of_other_more_than_balance() {
     // Setup with account contracts. Slower since we actually deploy them, but needed for authwits.
     let (env, token_contract_address, owner, recipient, mint_amount) =
-        utils::setup_and_mint(/* with_account_contracts */ true);
+        utils::setup_and_mint_public(/* with_account_contracts */ true);
     let transfer_amount = mint_amount + 1;
     // docs:start:public_authwit
     let public_transfer_from_call_interface =
@@ -131,7 +131,7 @@ unconstrained fn public_transfer_failure_on_behalf_of_other_more_than_balance() 
 unconstrained fn public_transfer_failure_on_behalf_of_other_wrong_caller() {
     // Setup with account contracts. Slower since we actually deploy them, but needed for authwits.
     let (env, token_contract_address, owner, recipient, mint_amount) =
-        utils::setup_and_mint(/* with_account_contracts */ true);
+        utils::setup_and_mint_public(/* with_account_contracts */ true);
     let transfer_amount = mint_amount / 10;
     let public_transfer_from_call_interface =
         Token::at(token_contract_address).transfer_public(owner, recipient, transfer_amount, 1);

--- a/noir-projects/noir-contracts/contracts/token_contract/src/test/unshielding.nr
+++ b/noir-projects/noir-contracts/contracts/token_contract/src/test/unshielding.nr
@@ -14,7 +14,7 @@ unconstrained fn unshield_on_behalf_of_self() {
         &mut env.private(),
     );
     utils::check_private_balance(token_contract_address, owner, mint_amount - unshield_amount);
-    utils::check_public_balance(token_contract_address, owner, mint_amount + unshield_amount);
+    utils::check_public_balance(token_contract_address, owner, unshield_amount);
 }
 
 #[test]

--- a/noir-projects/noir-contracts/contracts/token_contract/src/test/unshielding.nr
+++ b/noir-projects/noir-contracts/contracts/token_contract/src/test/unshielding.nr
@@ -7,7 +7,7 @@ use dep::aztec::oracle::random::random;
 unconstrained fn unshield_on_behalf_of_self() {
     // Setup without account contracts. We are not using authwits here, so dummy accounts are enough
     let (env, token_contract_address, owner, _, mint_amount) =
-        utils::setup_and_mint(/* with_account_contracts */ false);
+        utils::setup_and_mint_private(/* with_account_contracts */ false);
 
     let unshield_amount = mint_amount / 10;
     Token::at(token_contract_address).unshield(owner, owner, unshield_amount, 0).call(
@@ -20,7 +20,7 @@ unconstrained fn unshield_on_behalf_of_self() {
 #[test]
 unconstrained fn unshield_on_behalf_of_other() {
     let (env, token_contract_address, owner, recipient, mint_amount) =
-        utils::setup_and_mint(/* with_account_contracts */ true);
+        utils::setup_and_mint_private(/* with_account_contracts */ true);
 
     let unshield_amount = mint_amount / 10;
     let unshield_call_interface =
@@ -42,7 +42,7 @@ unconstrained fn unshield_on_behalf_of_other() {
 unconstrained fn unshield_failure_more_than_balance() {
     // Setup without account contracts. We are not using authwits here, so dummy accounts are enough
     let (env, token_contract_address, owner, _, mint_amount) =
-        utils::setup_and_mint(/* with_account_contracts */ false);
+        utils::setup_and_mint_private(/* with_account_contracts */ false);
 
     let unshield_amount = mint_amount + 1;
     Token::at(token_contract_address).unshield(owner, owner, unshield_amount, 0).call(
@@ -54,7 +54,7 @@ unconstrained fn unshield_failure_more_than_balance() {
 unconstrained fn unshield_failure_on_behalf_of_self_non_zero_nonce() {
     // Setup without account contracts. We are not using authwits here, so dummy accounts are enough
     let (env, token_contract_address, owner, _, mint_amount) =
-        utils::setup_and_mint(/* with_account_contracts */ false);
+        utils::setup_and_mint_private(/* with_account_contracts */ false);
 
     let unshield_amount = mint_amount + 1;
     Token::at(token_contract_address).unshield(owner, owner, unshield_amount, random()).call(
@@ -65,7 +65,7 @@ unconstrained fn unshield_failure_on_behalf_of_self_non_zero_nonce() {
 #[test(should_fail_with = "Balance too low")]
 unconstrained fn unshield_failure_on_behalf_of_other_more_than_balance() {
     let (env, token_contract_address, owner, recipient, mint_amount) =
-        utils::setup_and_mint(/* with_account_contracts */ true);
+        utils::setup_and_mint_private(/* with_account_contracts */ true);
 
     let unshield_amount = mint_amount + 1;
     let unshield_call_interface =
@@ -84,7 +84,7 @@ unconstrained fn unshield_failure_on_behalf_of_other_more_than_balance() {
 #[test(should_fail_with = "Authorization not found for message hash")]
 unconstrained fn unshield_failure_on_behalf_of_other_invalid_designated_caller() {
     let (env, token_contract_address, owner, recipient, mint_amount) =
-        utils::setup_and_mint(/* with_account_contracts */ true);
+        utils::setup_and_mint_private(/* with_account_contracts */ true);
 
     let unshield_amount = mint_amount + 1;
     let unshield_call_interface =
@@ -103,7 +103,7 @@ unconstrained fn unshield_failure_on_behalf_of_other_invalid_designated_caller()
 #[test(should_fail_with = "Authorization not found for message hash")]
 unconstrained fn unshield_failure_on_behalf_of_other_no_approval() {
     let (env, token_contract_address, owner, recipient, mint_amount) =
-        utils::setup_and_mint(/* with_account_contracts */ true);
+        utils::setup_and_mint_private(/* with_account_contracts */ true);
 
     let unshield_amount = mint_amount + 1;
     let unshield_call_interface =

--- a/noir-projects/noir-contracts/contracts/token_contract/src/test/utils.nr
+++ b/noir-projects/noir-contracts/contracts/token_contract/src/test/utils.nr
@@ -51,11 +51,7 @@ pub unconstrained fn setup_and_mint_public(
     let (env, token_contract_address, owner, recipient) = setup(with_account_contracts);
     let mint_amount = 10000;
     // Mint some tokens
-    let secret = random();
     Token::at(token_contract_address).mint_public(owner, mint_amount).call(&mut env.public());
-
-    // Time travel so we can read keys from the registry
-    env.advance_block_by(6);
 
     (env, token_contract_address, owner, recipient, mint_amount)
 }
@@ -70,9 +66,6 @@ pub unconstrained fn setup_and_mint_private(
     let secret = random();
     let secret_hash = compute_secret_hash(secret);
     Token::at(token_contract_address).mint_private(mint_amount, secret_hash).call(&mut env.public());
-
-    // Time travel so we can read keys from the registry
-    env.advance_block_by(6);
 
     // docs:start:txe_test_add_note
     // We need to manually add the note to TXE because `TransparentNote` does not support automatic note log delivery.

--- a/noir-projects/noir-contracts/contracts/token_contract/src/test/utils.nr
+++ b/noir-projects/noir-contracts/contracts/token_contract/src/test/utils.nr
@@ -44,7 +44,23 @@ pub unconstrained fn setup(
     (&mut env, token_contract_address, owner, recipient)
 }
 
-pub unconstrained fn setup_and_mint(
+pub unconstrained fn setup_and_mint_public(
+    with_account_contracts: bool,
+) -> (&mut TestEnvironment, AztecAddress, AztecAddress, AztecAddress, Field) {
+    // Setup
+    let (env, token_contract_address, owner, recipient) = setup(with_account_contracts);
+    let mint_amount = 10000;
+    // Mint some tokens
+    let secret = random();
+    Token::at(token_contract_address).mint_public(owner, mint_amount).call(&mut env.public());
+
+    // Time travel so we can read keys from the registry
+    env.advance_block_by(6);
+
+    (env, token_contract_address, owner, recipient, mint_amount)
+}
+
+pub unconstrained fn setup_and_mint_private(
     with_account_contracts: bool,
 ) -> (&mut TestEnvironment, AztecAddress, AztecAddress, AztecAddress, Field) {
     // Setup
@@ -54,7 +70,6 @@ pub unconstrained fn setup_and_mint(
     let secret = random();
     let secret_hash = compute_secret_hash(secret);
     Token::at(token_contract_address).mint_private(mint_amount, secret_hash).call(&mut env.public());
-    Token::at(token_contract_address).mint_public(owner, mint_amount).call(&mut env.public());
 
     // Time travel so we can read keys from the registry
     env.advance_block_by(6);


### PR DESCRIPTION
Currently in the token TXE tests we were by default minting both the private and public balance. This is messy and wasteful as we always need either just private or public balance. This PR separates the test util mint func into 2 - one for private, one for public.
