### PR TITLE
chore: remove ovpk as param in boxes contracts

### DIFF
--- a/boxes/boxes/react/src/contracts/src/main.nr
+++ b/boxes/boxes/react/src/contracts/src/main.nr
@@ -4,6 +4,7 @@ use dep::aztec::macros::aztec;
 contract BoxReact {
     use dep::aztec::{
         protocol_types::public_keys::OvpkM,
+        keys::getters::get_public_keys,
         prelude::{AztecAddress, PrivateMutable, Map, NoteInterface, NoteHeader, Point},
         encrypted_logs::encrypted_note_emission::encode_and_encrypt_note,
         macros::{storage::storage, functions::{private, public, initializer}}
@@ -19,22 +20,24 @@ contract BoxReact {
     #[initializer]
     fn constructor(
         number: Field,
-        owner: AztecAddress,
-        owner_ovpk_m: OvpkM
+        owner: AztecAddress
     ) {
         let numbers = storage.numbers;
         let mut new_number = ValueNote::new(number, owner);
+
+        let owner_ovpk_m = get_public_keys(owner).ovpk_m;
         numbers.at(owner).initialize(&mut new_number).emit(encode_and_encrypt_note(&mut context, owner_ovpk_m, owner));
     }
 
     #[private]
     fn setNumber(
         number: Field,
-        owner: AztecAddress,
-        owner_ovpk_m: OvpkM
+        owner: AztecAddress
     ) {
         let numbers = storage.numbers;
         let mut new_number = ValueNote::new(number, owner);
+
+        let owner_ovpk_m = get_public_keys(owner).ovpk_m;
         numbers.at(owner).replace(&mut new_number).emit(encode_and_encrypt_note(&mut context, owner_ovpk_m, owner));
     }
 

--- a/boxes/boxes/react/src/hooks/useContract.tsx
+++ b/boxes/boxes/react/src/hooks/useContract.tsx
@@ -15,13 +15,11 @@ export function useContract() {
     setWait(true);
     const wallet = await deployerEnv.getWallet();
     const salt = Fr.random();
-    const { masterOutgoingViewingPublicKey } =
-      wallet.getCompleteAddress().publicKeys;
+
     const tx = await BoxReactContract.deploy(
       wallet,
       Fr.random(),
       wallet.getCompleteAddress().address,
-      masterOutgoingViewingPublicKey.toWrappedNoirStruct(),
     ).send({
       contractAddressSalt: salt,
     });

--- a/boxes/boxes/react/src/hooks/useNumber.tsx
+++ b/boxes/boxes/react/src/hooks/useNumber.tsx
@@ -25,14 +25,12 @@ export function useNumber({ contract }: { contract: Contract }) {
 
       const value = BigInt(el.value);
       const deployerWallet = await deployerEnv.getWallet();
-      const { masterNullifierPublicKey, masterOutgoingViewingPublicKey } =
-        deployerWallet.getCompleteAddress().publicKeys;
+
       await toast.promise(
         contract!.methods
           .setNumber(
             value,
             deployerWallet.getCompleteAddress().address,
-            masterOutgoingViewingPublicKey.toWrappedNoirStruct(),
           )
           .send()
           .wait(),

--- a/boxes/boxes/react/tests/node.test.ts
+++ b/boxes/boxes/react/tests/node.test.ts
@@ -14,13 +14,11 @@ describe('BoxReact Contract Tests', () => {
     wallet = await deployerEnv.getWallet();
     accountCompleteAddress = wallet.getCompleteAddress();
     const salt = Fr.random();
-    const { masterNullifierPublicKey, masterOutgoingViewingPublicKey } =
-      accountCompleteAddress.publicKeys;
+
     contract = await BoxReactContract.deploy(
       wallet,
       Fr.random(),
-      accountCompleteAddress.address,
-      masterOutgoingViewingPublicKey.toWrappedNoirStruct()
+      accountCompleteAddress.address
     )
       .send({ contractAddressSalt: salt })
       .deployed();
@@ -30,13 +28,11 @@ describe('BoxReact Contract Tests', () => {
 
   test('Can set a number', async () => {
     logger.info(`${await wallet.getRegisteredAccounts()}`);
-    const { masterNullifierPublicKey, masterOutgoingViewingPublicKey } =
-      accountCompleteAddress.publicKeys;
+
     await contract.methods
       .setNumber(
         numberToSet,
-        accountCompleteAddress.address,
-        masterOutgoingViewingPublicKey.toWrappedNoirStruct(),
+        accountCompleteAddress.address
       )
       .send()
       .wait();

--- a/boxes/boxes/vanilla/src/contracts/src/main.nr
+++ b/boxes/boxes/vanilla/src/contracts/src/main.nr
@@ -4,6 +4,7 @@ use dep::aztec::macros::aztec;
 contract Vanilla {
     use dep::aztec::{
         protocol_types::public_keys::OvpkM,
+        keys::getters::get_public_keys,
         prelude::{AztecAddress, PrivateMutable, Map, NoteInterface, NoteHeader, Point},
         encrypted_logs::encrypted_note_emission::encode_and_encrypt_note,
         macros::{storage::storage, functions::{private, public, initializer}}
@@ -19,22 +20,24 @@ contract Vanilla {
     #[initializer]
     fn constructor(
         number: Field,
-        owner: AztecAddress,
-        owner_ovpk_m: OvpkM
+        owner: AztecAddress
     ) {
         let numbers = storage.numbers;
         let mut new_number = ValueNote::new(number, owner);
+
+        let owner_ovpk_m = get_public_keys(owner).ovpk_m;
         numbers.at(owner).initialize(&mut new_number).emit(encode_and_encrypt_note(&mut context, owner_ovpk_m, owner));
     }
 
     #[private]
     fn setNumber(
         number: Field,
-        owner: AztecAddress,
-        owner_ovpk_m: OvpkM
+        owner: AztecAddress
     ) {
         let numbers = storage.numbers;
         let mut new_number = ValueNote::new(number, owner);
+
+        let owner_ovpk_m = get_public_keys(owner).ovpk_m;
         numbers.at(owner).replace(&mut new_number).emit(encode_and_encrypt_note(&mut context, owner_ovpk_m, owner));
     }
 

--- a/boxes/boxes/vanilla/src/index.ts
+++ b/boxes/boxes/vanilla/src/index.ts
@@ -20,13 +20,11 @@ const setWait = (state: boolean): void =>
 document.querySelector('#deploy').addEventListener('click', async ({ target }: any) => {
   setWait(true);
   wallet = await account.register();
-  const { masterNullifierPublicKey, masterOutgoingViewingPublicKey } =
-    wallet.getCompleteAddress().publicKeys;
+
   contract = await VanillaContract.deploy(
     wallet,
     Fr.random(),
-    wallet.getCompleteAddress().address,
-    masterOutgoingViewingPublicKey.toWrappedNoirStruct(),
+    wallet.getCompleteAddress().address
   )
     .send({ contractAddressSalt: Fr.random() })
     .deployed();
@@ -42,13 +40,11 @@ document.querySelector('#set').addEventListener('submit', async (e: Event) => {
   setWait(true);
 
   const { value } = document.querySelector('#number') as HTMLInputElement;
-  const { address: owner, publicKeys } = wallet.getCompleteAddress();
-  const { masterNullifierPublicKey, masterOutgoingViewingPublicKey } = publicKeys;
+  const { address: owner } = wallet.getCompleteAddress();
   await contract.methods
     .setNumber(
       parseInt(value),
       owner,
-      masterOutgoingViewingPublicKey.toWrappedNoirStruct(),
     )
     .send()
     .wait();


### PR DESCRIPTION
As pointed out in [this](https://github.com/AztecProtocol/aztec-packages/pull/9461#discussion_r1818878758) PR comment, we can use get_public_keys to fetch the ovpk, instead of getting it passed in as a param.
