### PR TITLE
feat!: removing register recipient in e2e tests as it is unnecessary now !

### DIFF
--- a/yarn-project/circuit-types/src/logs/l1_payload/encrypted_log_payload.ts
+++ b/yarn-project/circuit-types/src/logs/l1_payload/encrypted_log_payload.ts
@@ -94,7 +94,7 @@ export class EncryptedLogPayload {
    * Produces the same output as `decryptAsOutgoing`.
    *
    * @param ciphertext - The ciphertext for the log
-   * @param addressSecret - The incoming viewing secret key, used to decrypt the logs
+   * @param addressSecret - The address secret, used to decrypt the logs
    * @returns The decrypted log payload
    */
   public static decryptAsIncoming(

--- a/yarn-project/end-to-end/src/benchmarks/bench_prover.test.ts
+++ b/yarn-project/end-to-end/src/benchmarks/bench_prover.test.ts
@@ -153,8 +153,6 @@ describe('benchmarks/proving', () => {
       await pxe.registerContract(initialTestContract);
       await pxe.registerContract(initialFpContract);
 
-      await pxe.registerRecipient(recipient);
-
       provingPxes.push(pxe);
     }
     /*TODO(post-honk): We wait 5 seconds for a race condition in setting up 4 nodes.

--- a/yarn-project/end-to-end/src/composed/e2e_persistence.test.ts
+++ b/yarn-project/end-to-end/src/composed/e2e_persistence.test.ts
@@ -209,8 +209,6 @@ describe('Aztec persistence', () => {
     });
 
     it('pxe does not know of the deployed contract', async () => {
-      await context.pxe.registerRecipient(ownerAddress);
-
       const wallet = await getUnsafeSchnorrAccount(context.pxe, Fr.random(), Fr.ZERO).waitSetup();
       await expect(TokenBlacklistContract.at(contractAddress, wallet)).rejects.toThrow(/has not been registered/);
     });
@@ -220,7 +218,6 @@ describe('Aztec persistence', () => {
         artifact: TokenBlacklistContract.artifact,
         instance: contractInstance,
       });
-      await context.pxe.registerRecipient(ownerAddress);
 
       const wallet = await getUnsafeSchnorrAccount(context.pxe, Fr.random(), Fr.ZERO).waitSetup();
       const contract = await TokenBlacklistContract.at(contractAddress, wallet);

--- a/yarn-project/end-to-end/src/e2e_2_pxes.test.ts
+++ b/yarn-project/end-to-end/src/e2e_2_pxes.test.ts
@@ -61,11 +61,6 @@ describe('e2e_2_pxes', () => {
 
     const token = await deployToken(walletA, initialBalance, logger);
 
-    // Add account B to wallet A
-    await pxeA.registerRecipient(walletB.getCompleteAddress());
-    // Add account A to wallet B
-    await pxeB.registerRecipient(walletA.getCompleteAddress());
-
     // Add token to PXE B (PXE A already has it because it was deployed through it)
     await pxeB.registerContract(token);
 
@@ -145,11 +140,6 @@ describe('e2e_2_pxes', () => {
 
     const token = await deployToken(walletA, userABalance, logger);
 
-    // Add account B to wallet A
-    await pxeA.registerRecipient(walletB.getCompleteAddress());
-    // Add account A to wallet B
-    await pxeB.registerRecipient(walletA.getCompleteAddress());
-
     // Add token to PXE B (PXE A already has it because it was deployed through it)
     await pxeB.registerContract(token);
 
@@ -194,11 +184,6 @@ describe('e2e_2_pxes', () => {
 
     const token = await deployToken(walletA, initialBalance, logger);
 
-    // Add account B to wallet A
-    await pxeA.registerRecipient(walletB.getCompleteAddress());
-    // Add account A to wallet B
-    await pxeB.registerRecipient(walletA.getCompleteAddress());
-
     // Check initial balances are as expected
     await expectTokenBalance(walletA, token, walletA.getAddress(), initialBalance, logger);
     // don't check userB yet
@@ -228,9 +213,6 @@ describe('e2e_2_pxes', () => {
     const sharedAccountOnB = getUnsafeSchnorrAccount(pxeB, sharedSecretKey, sharedAccountOnA.salt);
     await sharedAccountOnB.register();
     const sharedWalletOnB = await sharedAccountOnB.getWallet();
-
-    // Register wallet B in the pxe of wallet A
-    await pxeA.registerRecipient(walletB.getCompleteAddress());
 
     // deploy the contract on PXE A
     const token = await deployToken(walletA, initialBalance, logger);
@@ -304,8 +286,6 @@ describe('e2e_2_pxes', () => {
 
     // 4. Adds the nullified public key note to PXE B
     {
-      // We need to register the recipient to be able to obtain IvpkM for the note
-      await pxeB.registerRecipient(walletA.getCompleteAddress());
       // We need to register the contract to be able to compute the note hash by calling compute_note_hash_and_optionally_a_nullifier(...)
       await pxeB.registerContract(testContract);
       await pxeB.addNullifiedNote(note);

--- a/yarn-project/end-to-end/src/e2e_event_logs.test.ts
+++ b/yarn-project/end-to-end/src/e2e_event_logs.test.ts
@@ -5,7 +5,6 @@ import {
   EventType,
   Fr,
   L1EventPayload,
-  type PXE,
 } from '@aztec/aztec.js';
 import { EventSelector } from '@aztec/foundation/abi';
 import { makeTuple } from '@aztec/foundation/array';
@@ -24,18 +23,15 @@ describe('Logs', () => {
 
   let wallets: AccountWalletWithSecretKey[];
   let node: AztecNode;
-  let pxe: PXE;
 
   let teardown: () => Promise<void>;
 
   beforeAll(async () => {
-    ({ teardown, wallets, aztecNode: node, pxe } = await setup(2));
+    ({ teardown, wallets, aztecNode: node } = await setup(2));
 
     await ensureAccountsPubliclyDeployed(wallets[0], wallets.slice(0, 2));
 
     testLogContract = await TestLogContract.deploy(wallets[0]).send().deployed();
-
-    await pxe.registerRecipient(wallets[1].getCompleteAddress());
   });
 
   afterAll(() => teardown());

--- a/yarn-project/end-to-end/src/e2e_fees/account_init.test.ts
+++ b/yarn-project/end-to-end/src/e2e_fees/account_init.test.ts
@@ -182,9 +182,6 @@ describe('e2e_fees account_init', () => {
       const bobsSigningPubKey = new Schnorr().computePublicKey(bobsPrivateSigningKey);
       const bobsInstance = bobsAccountManager.getInstance();
 
-      // alice registers bobs keys in the pxe
-      await pxe.registerRecipient(bobsCompleteAddress);
-
       // and deploys bob's account, paying the fee from her balance
       const paymentMethod = new FeeJuicePaymentMethod(aliceAddress);
       const tx = await SchnorrAccountContract.deployWithPublicKeys(

--- a/yarn-project/end-to-end/src/e2e_token_contract/transfer_private.test.ts
+++ b/yarn-project/end-to-end/src/e2e_token_contract/transfer_private.test.ts
@@ -61,7 +61,6 @@ describe('e2e_token_contract transfer private', () => {
     expect(amount).toBeGreaterThan(0n);
 
     const nonDeployed = CompleteAddress.random();
-    await wallets[0].registerRecipient(nonDeployed);
 
     await asset.methods.transfer(nonDeployed.address, amount).send().wait();
 

--- a/yarn-project/pxe/src/note_processor/utils/produce_note_daos.ts
+++ b/yarn-project/pxe/src/note_processor/utils/produce_note_daos.ts
@@ -17,7 +17,7 @@ import { produceNoteDaosForKey } from './produce_note_daos_for_key.js';
  *
  * @param simulator - An instance of AcirSimulator.
  * @param db - An instance of PxeDatabase.
- * @param addressPoint - The public counterpart to the secret key to be used in the decryption of incoming note logs.
+ * @param addressPoint - The public counterpart to the address secret, which is used in the decryption of incoming note logs.
  * @param ovpkM - The public counterpart to the secret key to be used in the decryption of outgoing note logs.
  * @param payload - An instance of l1NotePayload.
  * @param txHash - The hash of the transaction that created the note. Equivalent to the first nullifier of the transaction.

--- a/yarn-project/pxe/src/synchronizer/synchronizer.ts
+++ b/yarn-project/pxe/src/synchronizer/synchronizer.ts
@@ -371,15 +371,15 @@ export class Synchronizer {
 
   async #removeNullifiedNotes(notes: IncomingNoteDao[]) {
     // now group the decoded incoming notes by public key
-    const publicKeyToIncomingNotes: Map<PublicKey, IncomingNoteDao[]> = new Map();
+    const addressPointToIncomingNotes: Map<PublicKey, IncomingNoteDao[]> = new Map();
     for (const noteDao of notes) {
-      const notesForPublicKey = publicKeyToIncomingNotes.get(noteDao.addressPoint) ?? [];
-      notesForPublicKey.push(noteDao);
-      publicKeyToIncomingNotes.set(noteDao.addressPoint, notesForPublicKey);
+      const notesForAddressPoint = addressPointToIncomingNotes.get(noteDao.addressPoint) ?? [];
+      notesForAddressPoint.push(noteDao);
+      addressPointToIncomingNotes.set(noteDao.addressPoint, notesForAddressPoint);
     }
 
     // now for each group, look for the nullifiers in the nullifier tree
-    for (const [publicKey, notes] of publicKeyToIncomingNotes.entries()) {
+    for (const [publicKey, notes] of addressPointToIncomingNotes.entries()) {
       const nullifiers = notes.map(n => n.siloedNullifier);
       const relevantNullifiers: Fr[] = [];
       for (const nullifier of nullifiers) {


### PR DESCRIPTION
We no longer need to register public keys to send notes !

Also dealing w/ some comments that have arisen from a previous PR in the stack's diffs showing up