### PR TITLE
feat(avm)!: cleanup CALL

### DIFF
--- a/barretenberg/cpp/src/barretenberg/vm/avm/tests/execution.test.cpp
+++ b/barretenberg/cpp/src/barretenberg/vm/avm/tests/execution.test.cpp
@@ -2101,31 +2101,33 @@ TEST_F(AvmExecutionTests, opCallOpcodes)
                                + to_hex(AvmMemoryTag::U32) +
                                "07" // val
                                "01" +
-                               to_hex(OpCode::CALLDATACOPY) + // opcode CALLDATACOPY
-                               "00"                           // Indirect flag
-                               "0000"                         // cd_offset
-                               "0001"                         // copy_size
-                               "0000"                         // dst_offset
-                               + bytecode_preamble            // Load up memory offsets
-                               + to_hex(OpCode::CALL) +       // opcode CALL
-                               "003f"                         // Indirect flag
-                               "0011"                         // gas offset
-                               "0012"                         // addr offset
-                               "0013"                         // args offset
-                               "0014"                         // args size offset
-                               "0015"                         // ret offset
-                               "0002"                         // ret size
-                               "0016"                         // success offset
-                               "0017"                         // function_selector_offset
-                               + to_hex(OpCode::RETURN) +     // opcode RETURN
-                               "00"                           // Indirect flag
-                               "0100"                         // ret offset 8
-                               "0003";                        // ret size 3 (extra read is for the success flag)
+                               to_hex(OpCode::CALLDATACOPY) +     // opcode CALLDATACOPY
+                               "00"                               // Indirect flag
+                               "0000"                             // cd_offset
+                               "0001"                             // copy_size
+                               "0000"                             // dst_offset
+                               + bytecode_preamble                // Load up memory offsets
+                               + to_hex(OpCode::CALL) +           // opcode CALL
+                               "001f"                             // Indirect flag
+                               "0011"                             // gas offset
+                               "0012"                             // addr offset
+                               "0013"                             // args offset
+                               "0014"                             // args size offset
+                               "0016"                             // success offset
+                               + to_hex(OpCode::RETURNDATACOPY) + // opcode RETURNDATACOPY
+                               "00"                               // Indirect flag
+                               "0011"                             // start offset (0)
+                               "0012"                             // ret size (2)
+                               "0100"                             // dst offset
+                               + to_hex(OpCode::RETURN) +         // opcode RETURN
+                               "00"                               // Indirect flag
+                               "0100"                             // ret offset 8
+                               "0003";                            // ret size 3 (extra read is for the success flag)
 
     auto bytecode = hex_to_bytes(bytecode_hex);
     auto instructions = Deserialization::parse(bytecode);
 
-    std::vector<FF> returndata = {};
+    std::vector<FF> returndata;
 
     // Generate Hint for call operation
     auto execution_hints = ExecutionHints().with_externalcall_hints({ {
@@ -2219,7 +2221,6 @@ TEST_F(AvmExecutionTests, opGetContractInstanceOpcode)
 TEST_F(AvmExecutionTests, opGetContractInstanceOpcodeBadEnum)
 {
     const uint8_t address_byte = 0x42;
-    const FF address(address_byte);
 
     std::string bytecode_hex = to_hex(OpCode::SET_8) +                             // opcode SET
                                "00"                                                // Indirect flag

--- a/barretenberg/cpp/src/barretenberg/vm/avm/trace/deserialization.cpp
+++ b/barretenberg/cpp/src/barretenberg/vm/avm/trace/deserialization.cpp
@@ -34,10 +34,7 @@ const std::vector<OperandType> external_call_format = { OperandType::INDIRECT16,
                                                         /*addrOffset=*/OperandType::UINT16,
                                                         /*argsOffset=*/OperandType::UINT16,
                                                         /*argsSize=*/OperandType::UINT16,
-                                                        /*retOffset=*/OperandType::UINT16,
-                                                        /*retSize*/ OperandType::UINT16,
-                                                        /*successOffset=*/OperandType::UINT16,
-                                                        /*functionSelector=*/OperandType::UINT16 };
+                                                        /*successOffset=*/OperandType::UINT16 };
 
 // Contrary to TS, the format does not contain the opcode byte which prefixes any instruction.
 // The format for OpCode::SET has to be handled separately as it is variable based on the tag.

--- a/barretenberg/cpp/src/barretenberg/vm/avm/trace/execution.cpp
+++ b/barretenberg/cpp/src/barretenberg/vm/avm/trace/execution.cpp
@@ -644,10 +644,7 @@ std::vector<Row> Execution::gen_trace(std::vector<FF> const& calldata,
                                   std::get<uint16_t>(inst.operands.at(2)),
                                   std::get<uint16_t>(inst.operands.at(3)),
                                   std::get<uint16_t>(inst.operands.at(4)),
-                                  std::get<uint16_t>(inst.operands.at(5)),
-                                  std::get<uint16_t>(inst.operands.at(6)),
-                                  std::get<uint16_t>(inst.operands.at(7)),
-                                  std::get<uint16_t>(inst.operands.at(8)));
+                                  std::get<uint16_t>(inst.operands.at(5)));
             break;
         case OpCode::STATICCALL:
             trace_builder.op_static_call(std::get<uint16_t>(inst.operands.at(0)),
@@ -655,10 +652,7 @@ std::vector<Row> Execution::gen_trace(std::vector<FF> const& calldata,
                                          std::get<uint16_t>(inst.operands.at(2)),
                                          std::get<uint16_t>(inst.operands.at(3)),
                                          std::get<uint16_t>(inst.operands.at(4)),
-                                         std::get<uint16_t>(inst.operands.at(5)),
-                                         std::get<uint16_t>(inst.operands.at(6)),
-                                         std::get<uint16_t>(inst.operands.at(7)),
-                                         std::get<uint16_t>(inst.operands.at(8)));
+                                         std::get<uint16_t>(inst.operands.at(5)));
             break;
         case OpCode::RETURN: {
             auto ret = trace_builder.op_return(std::get<uint8_t>(inst.operands.at(0)),

--- a/barretenberg/cpp/src/barretenberg/vm/avm/trace/trace.hpp
+++ b/barretenberg/cpp/src/barretenberg/vm/avm/trace/trace.hpp
@@ -133,19 +133,13 @@ class AvmTraceBuilder {
                  uint32_t addr_offset,
                  uint32_t args_offset,
                  uint32_t args_size,
-                 uint32_t ret_offset,
-                 uint32_t ret_size,
-                 uint32_t success_offset,
-                 uint32_t function_selector_offset);
+                 uint32_t success_offset);
     void op_static_call(uint16_t indirect,
                         uint32_t gas_offset,
                         uint32_t addr_offset,
                         uint32_t args_offset,
                         uint32_t args_size,
-                        uint32_t ret_offset,
-                        uint32_t ret_size,
-                        uint32_t success_offset,
-                        uint32_t function_selector_offset);
+                        uint32_t success_offset);
     std::vector<FF> op_return(uint8_t indirect, uint32_t ret_offset, uint32_t ret_size);
     // REVERT Opcode (that just call return under the hood for now)
     std::vector<FF> op_revert(uint8_t indirect, uint32_t ret_offset, uint32_t ret_size_offset);
@@ -263,10 +257,7 @@ class AvmTraceBuilder {
                                  uint32_t addr_offset,
                                  uint32_t args_offset,
                                  uint32_t args_size_offset,
-                                 uint32_t ret_offset,
-                                 uint32_t ret_size,
-                                 uint32_t success_offset,
-                                 [[maybe_unused]] uint32_t function_selector_offset);
+                                 uint32_t success_offset);
 
     void execute_gasleft(EnvironmentVariable var, uint8_t indirect, uint32_t dst_offset);
 

--- a/noir-projects/aztec-nr/aztec/src/context/public_context.nr
+++ b/noir-projects/aztec-nr/aztec/src/context/public_context.nr
@@ -77,16 +77,10 @@ impl PublicContext {
         gas_opts: GasOpts,
     ) -> [Field] {
         let args = args.push_front(function_selector.to_field());
-        // TODO(https://github.com/AztecProtocol/aztec-packages/issues/9061): modify call opcode and remove <0>.
-        let (_, success) = call::<0>(
-            gas_for_call(gas_opts),
-            contract_address,
-            args,
-            PUBLIC_DISPATCH_SELECTOR,
-        );
+        let success = call(gas_for_call(gas_opts), contract_address, args);
 
         let result_data = returndata_copy(0, returndata_size());
-        if success == 0 {
+        if !success {
             // Rethrow the revert data.
             avm_revert(result_data);
         }
@@ -101,16 +95,10 @@ impl PublicContext {
         gas_opts: GasOpts,
     ) -> [Field] {
         let args = args.push_front(function_selector.to_field());
-        // TODO(https://github.com/AztecProtocol/aztec-packages/issues/9061): modify call_static opcode and remove <0>.
-        let (_, success) = call_static::<0>(
-            gas_for_call(gas_opts),
-            contract_address,
-            args,
-            PUBLIC_DISPATCH_SELECTOR,
-        );
+        let success = call_static(gas_for_call(gas_opts), contract_address, args);
 
         let result_data = returndata_copy(0, returndata_size());
-        if success == 0 {
+        if !success {
             // Rethrow the revert data.
             avm_revert(result_data);
         }
@@ -277,21 +265,11 @@ unconstrained fn l1_to_l2_msg_exists(msg_hash: Field, msg_leaf_index: Field) -> 
 unconstrained fn send_l2_to_l1_msg(recipient: EthAddress, content: Field) {
     send_l2_to_l1_msg_opcode(recipient, content)
 }
-unconstrained fn call<let RET_SIZE: u32>(
-    gas: [Field; 2],
-    address: AztecAddress,
-    args: [Field],
-    function_selector: Field,
-) -> ([Field; RET_SIZE], u8) {
-    call_opcode(gas, address, args, function_selector)
+unconstrained fn call(gas: [Field; 2], address: AztecAddress, args: [Field]) -> bool {
+    call_opcode(gas, address, args)
 }
-unconstrained fn call_static<let RET_SIZE: u32>(
-    gas: [Field; 2],
-    address: AztecAddress,
-    args: [Field],
-    function_selector: Field,
-) -> ([Field; RET_SIZE], u8) {
-    call_static_opcode(gas, address, args, function_selector)
+unconstrained fn call_static(gas: [Field; 2], address: AztecAddress, args: [Field]) -> bool {
+    call_static_opcode(gas, address, args)
 }
 
 pub unconstrained fn calldata_copy<let N: u32>(cdoffset: u32, copy_size: u32) -> [Field; N] {
@@ -417,24 +395,18 @@ unconstrained fn return_opcode<let N: u32>(returndata: [Field; N]) {}
 unconstrained fn revert_opcode(revertdata: [Field]) {}
 
 #[oracle(avmOpcodeCall)]
-unconstrained fn call_opcode<let RET_SIZE: u32>(
+unconstrained fn call_opcode(
     gas: [Field; 2], // gas allocation: [l2_gas, da_gas]
     address: AztecAddress,
     args: [Field],
-    // TODO(5110): consider passing in calldata directly
-    function_selector: Field,
-) -> ([Field; RET_SIZE], u8) {}
-//    ^ return data      ^ success
+) -> bool {}
 
 #[oracle(avmOpcodeStaticCall)]
-unconstrained fn call_static_opcode<let RET_SIZE: u32>(
+unconstrained fn call_static_opcode(
     gas: [Field; 2], // gas allocation: [l2_gas, da_gas]
     address: AztecAddress,
     args: [Field],
-    // TODO(5110): consider passing in calldata directly
-    function_selector: Field,
-) -> ([Field; RET_SIZE], u8) {}
-//    ^ return data      ^ success
+) -> bool {}
 
 #[oracle(avmOpcodeStorageRead)]
 unconstrained fn storage_read_opcode(storage_slot: Field) -> Field {}

--- a/yarn-project/simulator/src/avm/serialization/bytecode_serialization.test.ts
+++ b/yarn-project/simulator/src/avm/serialization/bytecode_serialization.test.ts
@@ -84,10 +84,7 @@ describe('Bytecode Serialization', () => {
         /*addrOffset=*/ 0xa234,
         /*argsOffset=*/ 0xb234,
         /*argsSize=*/ 0xc234,
-        /*retOffset=*/ 0xd234,
-        /*retSize=*/ 0xe234,
         /*successOffset=*/ 0xf234,
-        /*functionSelectorOffset=*/ 0xf334,
       ),
       new StaticCall(
         /*indirect=*/ 0x01,
@@ -95,10 +92,7 @@ describe('Bytecode Serialization', () => {
         /*addrOffset=*/ 0xa234,
         /*argsOffset=*/ 0xb234,
         /*argsSize=*/ 0xc234,
-        /*retOffset=*/ 0xd234,
-        /*retSize=*/ 0xe234,
         /*successOffset=*/ 0xf234,
-        /*functionSelectorOffset=*/ 0xf334,
       ),
     ];
     const bytecode = Buffer.concat(instructions.map(i => i.serialize()));
@@ -122,10 +116,7 @@ describe('Bytecode Serialization', () => {
         /*addrOffset=*/ 0xa234,
         /*argsOffset=*/ 0xb234,
         /*argsSize=*/ 0xc234,
-        /*retOffset=*/ 0xd234,
-        /*retSize=*/ 0xe234,
         /*successOffset=*/ 0xf234,
-        /*functionSelectorOffset=*/ 0xf334,
       ),
       new StaticCall(
         /*indirect=*/ 0x01,
@@ -133,10 +124,7 @@ describe('Bytecode Serialization', () => {
         /*addrOffset=*/ 0xa234,
         /*argsOffset=*/ 0xb234,
         /*argsSize=*/ 0xc234,
-        /*retOffset=*/ 0xd234,
-        /*retSize=*/ 0xe234,
         /*successOffset=*/ 0xf234,
-        /*functionSelectorOffset=*/ 0xf334,
       ),
     ];
 

--- a/yarn-project/txe/src/oracle/txe_oracle.ts
+++ b/yarn-project/txe/src/oracle/txe_oracle.ts
@@ -781,24 +781,17 @@ export class TXE implements TypedOracle {
 
   // AVM oracles
 
-  async avmOpcodeCall(
-    targetContractAddress: AztecAddress,
-    functionSelector: FunctionSelector,
-    args: Fr[],
-    isStaticCall: boolean,
-  ) {
+  async avmOpcodeCall(targetContractAddress: AztecAddress, args: Fr[], isStaticCall: boolean) {
     // Store and modify env
     const currentContractAddress = AztecAddress.fromField(this.contractAddress);
     const currentMessageSender = AztecAddress.fromField(this.msgSender);
-    const currentFunctionSelector = FunctionSelector.fromField(this.functionSelector.toField());
     this.setMsgSender(this.contractAddress);
     this.setContractAddress(targetContractAddress);
-    this.setFunctionSelector(functionSelector);
 
     const callContext = new CallContext(
       /* msgSender */ currentContractAddress,
       targetContractAddress,
-      functionSelector,
+      FunctionSelector.fromField(new Fr(PUBLIC_DISPATCH_SELECTOR)),
       isStaticCall,
     );
 
@@ -821,7 +814,6 @@ export class TXE implements TypedOracle {
 
     this.setContractAddress(currentContractAddress);
     this.setMsgSender(currentMessageSender);
-    this.setFunctionSelector(currentFunctionSelector);
 
     return executionResult;
   }

--- a/yarn-project/txe/src/txe_service/txe_service.ts
+++ b/yarn-project/txe/src/txe_service/txe_service.ts
@@ -218,8 +218,9 @@ export class TXEService {
     args: ForeignCallArray,
   ) {
     const parsedAddress = fromSingle(address);
-    const parsedSelector = FunctionSelector.fromField(fromSingle(functionSelector));
-    const result = await (this.typedOracle as TXE).avmOpcodeCall(parsedAddress, parsedSelector, fromArray(args), false);
+    const parsedSelector = fromSingle(functionSelector);
+    const extendedArgs = [parsedSelector, ...fromArray(args)];
+    const result = await (this.typedOracle as TXE).avmOpcodeCall(parsedAddress, extendedArgs, false);
     if (!result.reverted) {
       throw new ExpectedFailureError('Public call did not revert');
     }
@@ -730,11 +731,9 @@ export class TXEService {
     address: ForeignCallSingle,
     _length: ForeignCallSingle,
     args: ForeignCallArray,
-    functionSelector: ForeignCallSingle,
   ) {
     const result = await (this.typedOracle as TXE).avmOpcodeCall(
       fromSingle(address),
-      FunctionSelector.fromField(fromSingle(functionSelector)),
       fromArray(args),
       /* isStaticCall */ false,
     );
@@ -754,7 +753,7 @@ export class TXEService {
       }
     }
 
-    return toForeignCallResult([toArray(result.returnValues), toSingle(new Fr(!result.reverted))]);
+    return toForeignCallResult([toSingle(new Fr(!result.reverted))]);
   }
 
   async avmOpcodeStaticCall(
@@ -762,11 +761,9 @@ export class TXEService {
     address: ForeignCallSingle,
     _length: ForeignCallSingle,
     args: ForeignCallArray,
-    functionSelector: ForeignCallSingle,
   ) {
     const result = await (this.typedOracle as TXE).avmOpcodeCall(
       fromSingle(address),
-      FunctionSelector.fromField(fromSingle(functionSelector)),
       fromArray(args),
       /* isStaticCall */ true,
     );
@@ -786,6 +783,6 @@ export class TXEService {
       }
     }
 
-    return toForeignCallResult([toArray(result.returnValues), toSingle(new Fr(!result.reverted))]);
+    return toForeignCallResult([toSingle(new Fr(!result.reverted))]);
   }
 }


### PR DESCRIPTION
* (Static)CALL now returns just the success bit
* Properly returns U1 instead of U8
* Removed FunctionSelector

Fixes #8998. Part of #9061.