### PR TITLE
fix: issue in partial notes API

### DIFF
--- a/noir-projects/aztec-nr/aztec/src/encrypted_logs/encrypted_note_emission.nr
+++ b/noir-projects/aztec-nr/aztec/src/encrypted_logs/encrypted_note_emission.nr
@@ -5,10 +5,7 @@ use crate::{
     note::{note_emission::NoteEmission, note_interface::NoteInterface},
 };
 use dep::protocol_types::{
-    abis::note_hash::NoteHash,
-    address::AztecAddress,
-    hash::sha256_to_field,
-    public_keys::{OvpkM, PublicKeys},
+    abis::note_hash::NoteHash, address::AztecAddress, hash::sha256_to_field, public_keys::OvpkM,
 };
 
 /// Computes private note log payload and a log hash

--- a/noir-projects/aztec-nr/aztec/src/macros/notes/mod.nr
+++ b/noir-projects/aztec-nr/aztec/src/macros/notes/mod.nr
@@ -463,13 +463,13 @@ comptime fn generate_setup_payload(
                 }
             }
 
-            fn encrypt_log(self, context: &mut PrivateContext, recipient_keys: aztec::protocol_types::public_keys::PublicKeys, recipient: aztec::protocol_types::address::AztecAddress) -> [Field; $encrypted_log_field_length] {
-                let ovsk_app: Field  = context.request_ovsk_app(recipient_keys.ovpk_m.hash());
+            fn encrypt_log(self, context: &mut PrivateContext, ovpk: aztec::protocol_types::public_keys::OvpkM, recipient: aztec::protocol_types::address::AztecAddress) -> [Field; $encrypted_log_field_length] {
+                let ovsk_app: Field  = context.request_ovsk_app(ovpk.hash());
 
                 let encrypted_log_bytes: [u8; $encrypted_log_byte_length] = aztec::encrypted_logs::payload::compute_private_log_payload(
                     context.this_address(),
                     ovsk_app,
-                    recipient_keys.ovpk_m,
+                    ovpk,
                     recipient,
                     self.log_plaintext,
                     true

--- a/noir-projects/noir-contracts/contracts/nft_contract/src/main.nr
+++ b/noir-projects/noir-contracts/contracts/nft_contract/src/main.nr
@@ -178,7 +178,6 @@ contract NFT {
         context: &mut PrivateContext,
         storage: Storage<&mut PrivateContext>,
     ) -> Field {
-        let to_keys = get_public_keys(to);
         let to_note_slot = storage.private_nfts.at(to).storage_slot;
 
         // We create a setup payload with unpopulated/zero token id for 'to'
@@ -187,8 +186,9 @@ contract NFT {
         let note_randomness = unsafe { random() };
         let note_setup_payload = NFTNote::setup_payload().new(to, note_randomness, to_note_slot);
 
-        // We encrypt the note log
-        let setup_log = note_setup_payload.encrypt_log(context, to_keys, to);
+        // We set the ovpk to the message sender's ovpk and we encrypt the log.
+        let from_ovpk = get_public_keys(context.msg_sender()).ovpk_m;
+        let setup_log = note_setup_payload.encrypt_log(context, from_ovpk, to);
 
         // Using the x-coordinate as a hiding point slot is safe against someone else interfering with it because
         // we have a guarantee that the public functions of the transaction are executed right after the private ones

--- a/noir-projects/noir-contracts/contracts/token_contract/src/main.nr
+++ b/noir-projects/noir-contracts/contracts/token_contract/src/main.nr
@@ -511,9 +511,8 @@ contract Token {
         // the authwit flow here and check that the user really permitted fee_payer to set up a refund on their behalf.
         assert_current_call_valid_authwit(&mut context, user);
 
-        // 2. Get all the relevant keys
-        let fee_payer_keys = get_public_keys(fee_payer);
-        let user_keys = get_public_keys(user);
+        // 2. Since user is the logical sender of all the notes we get user's ovpk and use that in all of them.
+        let user_ovpk = get_public_keys(user).ovpk_m;
 
         // 3. Deduct the funded amount from the user's balance - this is a maximum fee a user is willing to pay
         // (called fee limit in aztec spec). The difference between fee limit and the actual tx fee will be refunded
@@ -527,7 +526,7 @@ contract Token {
         );
         storage.balances.at(user).add(user, change).emit(encode_and_encrypt_note_unconstrained(
             &mut context,
-            user_keys.ovpk_m,
+            user_ovpk,
             user,
         ));
 
@@ -566,8 +565,8 @@ contract Token {
 
         // 6. We compute setup logs
         let fee_payer_setup_log =
-            fee_payer_setup_payload.encrypt_log(&mut context, fee_payer_keys, fee_payer);
-        let user_setup_log = user_setup_payload.encrypt_log(&mut context, user_keys, user);
+            fee_payer_setup_payload.encrypt_log(&mut context, user_ovpk, fee_payer);
+        let user_setup_log = user_setup_payload.encrypt_log(&mut context, user_ovpk, user);
 
         // 7. We store the hiding points an logs in transients storage
         Token::at(context.this_address())


### PR DESCRIPTION
When refactoring the token contract I realized that we incorrectly populate ovpk in partial notes. This PR fixes it.
