### PR TITLE
feat: Implement resetState in TxProvingState for State Resetting tx-proving-state.ts

### DIFF
--- a/yarn-project/prover-client/src/orchestrator/tx-proving-state.ts
+++ b/yarn-project/prover-client/src/orchestrator/tx-proving-state.ts
@@ -96,6 +96,13 @@ export class TxProvingState {
 
     return new PublicBaseRollupInputs(tubeData, avmProofData, this.baseRollupHints);
   }
+public resetState() {
+  this.tube = undefined;
+  this.avm = undefined;
+
+  this.treeSnapshots.clear();
+}
+
 
   public assignTubeProof(tubeProofAndVk: ProofAndVerificationKey<RecursiveProof<typeof TUBE_PROOF_LENGTH>>) {
     this.tube = tubeProofAndVk;


### PR DESCRIPTION
Summary

This contribution introduces the resetState method to the TxProvingState class. This method allows for resetting the proving state, making it easier to reinitialize transactions when necessary.

Motivation

The addition of resetState is intended to enhance the usability of the TxProvingState class. It provides developers with a straightforward mechanism to clean and reset the state of a transaction, which can be particularly beneficial during testing or when handling failures.
Implementation Details

    Implemented the resetState method to clear the tube and avm properties.
    The method also clears the treeSnapshots if there is a need to fully reset the proving context.

Tests

Functionality was manually verified to ensure the resetState method effectively clears the state without causing undesired side effects on existing functionalities.