### PR TITLE
feat: reorder blocks for efficiency

### DIFF
--- a/barretenberg/cpp/src/barretenberg/plonk_honk_shared/arithmetization/max_block_size_tracker.hpp
+++ b/barretenberg/cpp/src/barretenberg/plonk_honk_shared/arithmetization/max_block_size_tracker.hpp
@@ -30,10 +30,10 @@ struct MaxBlockSizeTracker {
     }
 
     // For printing only. Must match the order of the members in the arithmetization
-    std::vector<std::string> block_labels{
-        "ecc_op", "pub_inputs", "arithmetic", "delta_range",        "elliptic",
-        "aux",    "lookup",     "busread",    "poseidon2_external", "poseidon2_internal"
-    };
+    std::vector<std::string> block_labels{ "ecc_op",      "pub_inputs",         "arithmetic",
+                                           "delta_range", "elliptic",           "aux",
+                                           "busread",     "poseidon2_external", "poseidon2_internal",
+                                           "lookup" };
 
     void print()
     {

--- a/barretenberg/cpp/src/barretenberg/plonk_honk_shared/arithmetization/max_block_size_tracker.hpp
+++ b/barretenberg/cpp/src/barretenberg/plonk_honk_shared/arithmetization/max_block_size_tracker.hpp
@@ -30,9 +30,9 @@ struct MaxBlockSizeTracker {
     }
 
     // For printing only. Must match the order of the members in the arithmetization
-    std::vector<std::string> block_labels{ "ecc_op",      "pub_inputs",         "arithmetic",
-                                           "delta_range", "elliptic",           "aux",
-                                           "busread",     "poseidon2_external", "poseidon2_internal",
+    std::vector<std::string> block_labels{ "ecc_op",     "pub_inputs",         "busread",
+                                           "arithmetic", "delta_range",        "elliptic",
+                                           "aux",        "poseidon2_external", "poseidon2_internal",
                                            "lookup" };
 
     void print()

--- a/barretenberg/cpp/src/barretenberg/plonk_honk_shared/arithmetization/mega_arithmetization.hpp
+++ b/barretenberg/cpp/src/barretenberg/plonk_honk_shared/arithmetization/mega_arithmetization.hpp
@@ -23,25 +23,27 @@ template <typename FF_> class MegaArith {
     template <typename T> struct MegaTraceBlocks {
         T ecc_op;
         T pub_inputs;
+        T busread;
         T arithmetic;
         T delta_range;
         T elliptic;
         T aux;
-        T busread;
         T poseidon2_external;
         T poseidon2_internal;
         T lookup;
 
         auto get()
         {
-            return RefArray{ ecc_op, pub_inputs, arithmetic,         delta_range,        elliptic,
-                             aux,    busread,    poseidon2_external, poseidon2_internal, lookup };
+            return RefArray{ ecc_op,     pub_inputs,         busread,
+                             arithmetic, delta_range,        elliptic,
+                             aux,        poseidon2_external, poseidon2_internal,
+                             lookup };
         }
 
         auto get_gate_blocks()
         {
-            return RefArray{ arithmetic, delta_range,        elliptic,           aux,
-                             busread,    poseidon2_external, poseidon2_internal, lookup };
+            return RefArray{ busread, arithmetic,         delta_range,        elliptic,
+                             aux,     poseidon2_external, poseidon2_internal, lookup };
         }
 
         bool operator==(const MegaTraceBlocks& other) const = default;
@@ -55,11 +57,11 @@ template <typename FF_> class MegaArith {
             const uint32_t FIXED_SIZE = 1 << 14;
             this->ecc_op = FIXED_SIZE;
             this->pub_inputs = FIXED_SIZE;
+            this->busread = FIXED_SIZE;
             this->arithmetic = 1 << 15;
             this->delta_range = FIXED_SIZE;
             this->elliptic = FIXED_SIZE;
             this->aux = FIXED_SIZE;
-            this->busread = FIXED_SIZE;
             this->poseidon2_external = FIXED_SIZE;
             this->poseidon2_internal = 1 << 15;
             this->lookup = FIXED_SIZE;
@@ -72,11 +74,11 @@ template <typename FF_> class MegaArith {
         {
             this->ecc_op = 1 << 10;
             this->pub_inputs = 1 << 7;
+            this->busread = 1 << 7;
             this->arithmetic = 201000;
             this->delta_range = 90000;
             this->elliptic = 9000;
             this->aux = 137000;
-            this->busread = 1 << 7;
             this->poseidon2_external = 2500;
             this->poseidon2_internal = 11500;
             this->lookup = 72000;
@@ -89,11 +91,11 @@ template <typename FF_> class MegaArith {
         {
             this->ecc_op = 1 << 10;
             this->pub_inputs = 4000;
+            this->busread = 6000;
             this->arithmetic = 200000;
             this->delta_range = 25000;
             this->elliptic = 80000;
             this->aux = 100000;
-            this->busread = 6000;
             this->poseidon2_external = 30000;
             this->poseidon2_internal = 150000;
             this->lookup = 200000;
@@ -131,11 +133,11 @@ template <typename FF_> class MegaArith {
         auto& q_2() { return this->selectors[3]; };
         auto& q_3() { return this->selectors[4]; };
         auto& q_4() { return this->selectors[5]; };
-        auto& q_arith() { return this->selectors[6]; };
-        auto& q_delta_range() { return this->selectors[7]; };
-        auto& q_elliptic() { return this->selectors[8]; };
-        auto& q_aux() { return this->selectors[9]; };
-        auto& q_busread() { return this->selectors[10]; };
+        auto& q_busread() { return this->selectors[6]; };
+        auto& q_arith() { return this->selectors[7]; };
+        auto& q_delta_range() { return this->selectors[8]; };
+        auto& q_elliptic() { return this->selectors[9]; };
+        auto& q_aux() { return this->selectors[10]; };
         auto& q_poseidon2_external() { return this->selectors[11]; };
         auto& q_poseidon2_internal() { return this->selectors[12]; };
         auto& q_lookup_type() { return this->selectors[13]; };
@@ -202,11 +204,11 @@ template <typename FF_> class MegaArith {
             info("Gate blocks summary: (actual gates / fixed capacity)");
             info("goblin ecc op :\t", this->ecc_op.size(), "/", this->ecc_op.get_fixed_size());
             info("pub inputs    :\t", this->pub_inputs.size(), "/", this->pub_inputs.get_fixed_size());
+            info("busread       :\t", this->busread.size(), "/", this->busread.get_fixed_size());
             info("arithmetic    :\t", this->arithmetic.size(), "/", this->arithmetic.get_fixed_size());
             info("delta range   :\t", this->delta_range.size(), "/", this->delta_range.get_fixed_size());
             info("elliptic      :\t", this->elliptic.size(), "/", this->elliptic.get_fixed_size());
             info("auxiliary     :\t", this->aux.size(), "/", this->aux.get_fixed_size());
-            info("busread       :\t", this->busread.size(), "/", this->busread.get_fixed_size());
             info("poseidon ext  :\t", this->poseidon2_external.size(), "/", this->poseidon2_external.get_fixed_size());
             info("poseidon int  :\t", this->poseidon2_internal.size(), "/", this->poseidon2_internal.get_fixed_size());
             info("lookups       :\t", this->lookup.size(), "/", this->lookup.get_fixed_size());

--- a/barretenberg/cpp/src/barretenberg/plonk_honk_shared/arithmetization/mega_arithmetization.hpp
+++ b/barretenberg/cpp/src/barretenberg/plonk_honk_shared/arithmetization/mega_arithmetization.hpp
@@ -27,21 +27,21 @@ template <typename FF_> class MegaArith {
         T delta_range;
         T elliptic;
         T aux;
-        T lookup;
         T busread;
         T poseidon2_external;
         T poseidon2_internal;
+        T lookup;
 
         auto get()
         {
-            return RefArray{ ecc_op, pub_inputs, arithmetic, delta_range,        elliptic,
-                             aux,    lookup,     busread,    poseidon2_external, poseidon2_internal };
+            return RefArray{ ecc_op, pub_inputs, arithmetic,         delta_range,        elliptic,
+                             aux,    busread,    poseidon2_external, poseidon2_internal, lookup };
         }
 
         auto get_gate_blocks()
         {
-            return RefArray{ arithmetic, delta_range, elliptic,           aux,
-                             lookup,     busread,     poseidon2_external, poseidon2_internal };
+            return RefArray{ arithmetic, delta_range,        elliptic,           aux,
+                             busread,    poseidon2_external, poseidon2_internal, lookup };
         }
 
         bool operator==(const MegaTraceBlocks& other) const = default;
@@ -59,10 +59,10 @@ template <typename FF_> class MegaArith {
             this->delta_range = FIXED_SIZE;
             this->elliptic = FIXED_SIZE;
             this->aux = FIXED_SIZE;
-            this->lookup = FIXED_SIZE;
             this->busread = FIXED_SIZE;
             this->poseidon2_external = FIXED_SIZE;
             this->poseidon2_internal = 1 << 15;
+            this->lookup = FIXED_SIZE;
         }
     };
 
@@ -76,10 +76,10 @@ template <typename FF_> class MegaArith {
             this->delta_range = 90000;
             this->elliptic = 9000;
             this->aux = 137000;
-            this->lookup = 72000;
             this->busread = 1 << 7;
             this->poseidon2_external = 2500;
             this->poseidon2_internal = 11500;
+            this->lookup = 72000;
         }
     };
 
@@ -93,10 +93,10 @@ template <typename FF_> class MegaArith {
             this->delta_range = 25000;
             this->elliptic = 80000;
             this->aux = 100000;
-            this->lookup = 200000;
             this->busread = 6000;
             this->poseidon2_external = 30000;
             this->poseidon2_internal = 150000;
+            this->lookup = 200000;
         }
     };
 
@@ -135,10 +135,10 @@ template <typename FF_> class MegaArith {
         auto& q_delta_range() { return this->selectors[7]; };
         auto& q_elliptic() { return this->selectors[8]; };
         auto& q_aux() { return this->selectors[9]; };
-        auto& q_lookup_type() { return this->selectors[10]; };
-        auto& q_busread() { return this->selectors[11]; };
-        auto& q_poseidon2_external() { return this->selectors[12]; };
-        auto& q_poseidon2_internal() { return this->selectors[13]; };
+        auto& q_busread() { return this->selectors[10]; };
+        auto& q_poseidon2_external() { return this->selectors[11]; };
+        auto& q_poseidon2_internal() { return this->selectors[12]; };
+        auto& q_lookup_type() { return this->selectors[13]; };
 
         /**
          * @brief Add zeros to all selectors which are not part of the conventional Ultra arithmetization
@@ -206,10 +206,10 @@ template <typename FF_> class MegaArith {
             info("delta range   :\t", this->delta_range.size(), "/", this->delta_range.get_fixed_size());
             info("elliptic      :\t", this->elliptic.size(), "/", this->elliptic.get_fixed_size());
             info("auxiliary     :\t", this->aux.size(), "/", this->aux.get_fixed_size());
-            info("lookups       :\t", this->lookup.size(), "/", this->lookup.get_fixed_size());
             info("busread       :\t", this->busread.size(), "/", this->busread.get_fixed_size());
             info("poseidon ext  :\t", this->poseidon2_external.size(), "/", this->poseidon2_external.get_fixed_size());
             info("poseidon int  :\t", this->poseidon2_internal.size(), "/", this->poseidon2_internal.get_fixed_size());
+            info("lookups       :\t", this->lookup.size(), "/", this->lookup.get_fixed_size());
             info("");
         }
 

--- a/barretenberg/cpp/src/barretenberg/stdlib_circuit_builders/mega_flavor.hpp
+++ b/barretenberg/cpp/src/barretenberg/stdlib_circuit_builders/mega_flavor.hpp
@@ -118,10 +118,10 @@ class MegaFlavor {
                               q_delta_range,        // column 7
                               q_elliptic,           // column 8
                               q_aux,                // column 9
-                              q_lookup,             // column 10
-                              q_busread,            // column 11
-                              q_poseidon2_external, // column 12
-                              q_poseidon2_internal, // column 13
+                              q_busread,            // column 10
+                              q_poseidon2_external, // column 11
+                              q_poseidon2_internal, // column 12
+                              q_lookup,             // column 13
                               sigma_1,              // column 14
                               sigma_2,              // column 15
                               sigma_3,              // column 16
@@ -145,8 +145,8 @@ class MegaFlavor {
         auto get_non_gate_selectors() { return RefArray{ q_m, q_c, q_l, q_r, q_o, q_4 }; };
         auto get_gate_selectors()
         {
-            return RefArray{ q_arith,  q_delta_range, q_elliptic,           q_aux,
-                             q_lookup, q_busread,     q_poseidon2_external, q_poseidon2_internal };
+            return RefArray{ q_arith,   q_delta_range,        q_elliptic,           q_aux,
+                             q_busread, q_poseidon2_external, q_poseidon2_internal, q_lookup };
         }
         auto get_selectors() { return concatenate(get_non_gate_selectors(), get_gate_selectors()); }
 
@@ -606,10 +606,10 @@ class MegaFlavor {
                         const Commitment& q_delta_range,
                         const Commitment& q_elliptic,
                         const Commitment& q_aux,
-                        const Commitment& q_lookup,
                         const Commitment& q_busread,
                         const Commitment& q_poseidon2_external,
                         const Commitment& q_poseidon2_internal,
+                        const Commitment& q_lookup,
                         const Commitment& sigma_1,
                         const Commitment& sigma_2,
                         const Commitment& sigma_3,
@@ -644,10 +644,10 @@ class MegaFlavor {
             this->q_delta_range = q_delta_range;
             this->q_elliptic = q_elliptic;
             this->q_aux = q_aux;
-            this->q_lookup = q_lookup;
             this->q_busread = q_busread;
             this->q_poseidon2_external = q_poseidon2_external;
             this->q_poseidon2_internal = q_poseidon2_internal;
+            this->q_lookup = q_lookup;
             this->sigma_1 = sigma_1;
             this->sigma_2 = sigma_2;
             this->sigma_3 = sigma_3;
@@ -682,10 +682,10 @@ class MegaFlavor {
                        q_delta_range,
                        q_elliptic,
                        q_aux,
-                       q_lookup,
                        q_busread,
                        q_poseidon2_external,
                        q_poseidon2_internal,
+                       q_lookup,
                        sigma_1,
                        sigma_2,
                        sigma_3,
@@ -788,10 +788,10 @@ class MegaFlavor {
             q_delta_range = "Q_SORT";
             q_elliptic = "Q_ELLIPTIC";
             q_aux = "Q_AUX";
-            q_lookup = "Q_LOOKUP";
             q_busread = "Q_BUSREAD";
             q_poseidon2_external = "Q_POSEIDON2_EXTERNAL";
             q_poseidon2_internal = "Q_POSEIDON2_INTERNAL";
+            q_lookup = "Q_LOOKUP";
             sigma_1 = "SIGMA_1";
             sigma_2 = "SIGMA_2";
             sigma_3 = "SIGMA_3";

--- a/barretenberg/cpp/src/barretenberg/stdlib_circuit_builders/mega_flavor.hpp
+++ b/barretenberg/cpp/src/barretenberg/stdlib_circuit_builders/mega_flavor.hpp
@@ -114,11 +114,11 @@ class MegaFlavor {
                               q_r,                  // column 3
                               q_o,                  // column 4
                               q_4,                  // column 5
-                              q_arith,              // column 6
-                              q_delta_range,        // column 7
-                              q_elliptic,           // column 8
-                              q_aux,                // column 9
-                              q_busread,            // column 10
+                              q_busread,            // column 6
+                              q_arith,              // column 7
+                              q_delta_range,        // column 8
+                              q_elliptic,           // column 9
+                              q_aux,                // column 10
                               q_poseidon2_external, // column 11
                               q_poseidon2_internal, // column 12
                               q_lookup,             // column 13
@@ -145,8 +145,10 @@ class MegaFlavor {
         auto get_non_gate_selectors() { return RefArray{ q_m, q_c, q_l, q_r, q_o, q_4 }; };
         auto get_gate_selectors()
         {
-            return RefArray{ q_arith,   q_delta_range,        q_elliptic,           q_aux,
-                             q_busread, q_poseidon2_external, q_poseidon2_internal, q_lookup };
+            return RefArray{
+                q_busread, q_arith, q_delta_range, q_elliptic, q_aux, q_poseidon2_external, q_poseidon2_internal,
+                q_lookup
+            };
         }
         auto get_selectors() { return concatenate(get_non_gate_selectors(), get_gate_selectors()); }
 
@@ -602,11 +604,11 @@ class MegaFlavor {
                         const Commitment& q_r,
                         const Commitment& q_o,
                         const Commitment& q_4,
+                        const Commitment& q_busread,
                         const Commitment& q_arith,
                         const Commitment& q_delta_range,
                         const Commitment& q_elliptic,
                         const Commitment& q_aux,
-                        const Commitment& q_busread,
                         const Commitment& q_poseidon2_external,
                         const Commitment& q_poseidon2_internal,
                         const Commitment& q_lookup,
@@ -640,11 +642,11 @@ class MegaFlavor {
             this->q_r = q_r;
             this->q_o = q_o;
             this->q_4 = q_4;
+            this->q_busread = q_busread;
             this->q_arith = q_arith;
             this->q_delta_range = q_delta_range;
             this->q_elliptic = q_elliptic;
             this->q_aux = q_aux;
-            this->q_busread = q_busread;
             this->q_poseidon2_external = q_poseidon2_external;
             this->q_poseidon2_internal = q_poseidon2_internal;
             this->q_lookup = q_lookup;
@@ -678,11 +680,11 @@ class MegaFlavor {
                        q_r,
                        q_o,
                        q_4,
+                       q_busread,
                        q_arith,
                        q_delta_range,
                        q_elliptic,
                        q_aux,
-                       q_busread,
                        q_poseidon2_external,
                        q_poseidon2_internal,
                        q_lookup,
@@ -784,11 +786,11 @@ class MegaFlavor {
             q_o = "Q_O";
             q_4 = "Q_4";
             q_m = "Q_M";
+            q_busread = "Q_BUSREAD";
             q_arith = "Q_ARITH";
             q_delta_range = "Q_SORT";
             q_elliptic = "Q_ELLIPTIC";
             q_aux = "Q_AUX";
-            q_busread = "Q_BUSREAD";
             q_poseidon2_external = "Q_POSEIDON2_EXTERNAL";
             q_poseidon2_internal = "Q_POSEIDON2_INTERNAL";
             q_lookup = "Q_LOOKUP";


### PR DESCRIPTION
Reorders blocks (Mega only) so that data bus reads are close to the top of the trace and lookups are at the bottom. This helps minimize both the memory required to store the log-deriv inverse polynomials as well as the "active" region of the trace by minimizing the distance (maximizing the overlap) of the various lookup gates with the data from which they read. (Note: tables are constructed at the bottom of the trace).