### PR TITLE
refactor: add sender to encode and encrypt

### DIFF
--- a/boxes/boxes/react/src/contracts/src/main.nr
+++ b/boxes/boxes/react/src/contracts/src/main.nr
@@ -26,7 +26,7 @@ contract BoxReact {
         let mut new_number = ValueNote::new(number, owner);
 
         let owner_ovpk_m = get_public_keys(owner).ovpk_m;
-        numbers.at(owner).initialize(&mut new_number).emit(encode_and_encrypt_note(&mut context, owner_ovpk_m, owner));
+        numbers.at(owner).initialize(&mut new_number).emit(encode_and_encrypt_note(&mut context, owner_ovpk_m, owner, context.msg_sender()));
     }
 
     #[private]
@@ -38,7 +38,7 @@ contract BoxReact {
         let mut new_number = ValueNote::new(number, owner);
 
         let owner_ovpk_m = get_public_keys(owner).ovpk_m;
-        numbers.at(owner).replace(&mut new_number).emit(encode_and_encrypt_note(&mut context, owner_ovpk_m, owner));
+        numbers.at(owner).replace(&mut new_number).emit(encode_and_encrypt_note(&mut context, owner_ovpk_m, owner, context.msg_sender()));
     }
 
     unconstrained fn getNumber(owner: AztecAddress) -> pub ValueNote {

--- a/boxes/boxes/vanilla/src/contracts/src/main.nr
+++ b/boxes/boxes/vanilla/src/contracts/src/main.nr
@@ -26,7 +26,7 @@ contract Vanilla {
         let mut new_number = ValueNote::new(number, owner);
 
         let owner_ovpk_m = get_public_keys(owner).ovpk_m;
-        numbers.at(owner).initialize(&mut new_number).emit(encode_and_encrypt_note(&mut context, owner_ovpk_m, owner));
+        numbers.at(owner).initialize(&mut new_number).emit(encode_and_encrypt_note(&mut context, owner_ovpk_m, owner, context.msg_sender()));
     }
 
     #[private]
@@ -38,7 +38,7 @@ contract Vanilla {
         let mut new_number = ValueNote::new(number, owner);
 
         let owner_ovpk_m = get_public_keys(owner).ovpk_m;
-        numbers.at(owner).replace(&mut new_number).emit(encode_and_encrypt_note(&mut context, owner_ovpk_m, owner));
+        numbers.at(owner).replace(&mut new_number).emit(encode_and_encrypt_note(&mut context, owner_ovpk_m, owner, context.msg_sender()));
     }
 
     unconstrained fn getNumber(owner: AztecAddress) -> pub ValueNote {

--- a/noir-projects/aztec-nr/aztec/src/encrypted_logs/encrypted_event_emission.nr
+++ b/noir-projects/aztec-nr/aztec/src/encrypted_logs/encrypted_event_emission.nr
@@ -12,6 +12,7 @@ fn compute_payload_and_hash<Event, let N: u32>(
     ovsk_app: Field,
     ovpk: OvpkM,
     recipient: AztecAddress,
+    sender: AztecAddress,
 ) -> ([u8; 384 + N * 32], Field)
 where
     Event: EventInterface<N>,
@@ -25,6 +26,7 @@ where
         ovsk_app,
         ovpk,
         recipient,
+        sender,
         plaintext,
         false,
     );
@@ -38,19 +40,29 @@ unconstrained fn compute_payload_and_hash_unconstrained<Event, let N: u32>(
     randomness: Field,
     ovpk: OvpkM,
     recipient: AztecAddress,
+    sender: AztecAddress,
 ) -> ([u8; 384 + N * 32], Field)
 where
     Event: EventInterface<N>,
 {
     let ovsk_app = get_ovsk_app(ovpk.hash());
-    compute_payload_and_hash(context, event, randomness, ovsk_app, ovpk, recipient)
+    compute_payload_and_hash(
+        context,
+        event,
+        randomness,
+        ovsk_app,
+        ovpk,
+        recipient,
+        sender,
+    )
 }
 
 pub fn encode_and_encrypt_event<Event, let N: u32>(
     context: &mut PrivateContext,
     ovpk: OvpkM,
     recipient: AztecAddress,
-) -> fn[(&mut PrivateContext, OvpkM, AztecAddress)](Event) -> ()
+    sender: AztecAddress,
+) -> fn[(&mut PrivateContext, OvpkM, AztecAddress, AztecAddress)](Event) -> ()
 where
     Event: EventInterface<N>,
 {
@@ -62,7 +74,7 @@ where
         let randomness = unsafe { random() };
         let ovsk_app: Field = context.request_ovsk_app(ovpk.hash());
         let (encrypted_log, log_hash) =
-            compute_payload_and_hash(*context, e, randomness, ovsk_app, ovpk, recipient);
+            compute_payload_and_hash(*context, e, randomness, ovsk_app, ovpk, recipient, sender);
         context.emit_raw_event_log_with_masked_address(randomness, encrypted_log, log_hash);
     }
 }
@@ -71,7 +83,8 @@ pub fn encode_and_encrypt_event_unconstrained<Event, let N: u32>(
     context: &mut PrivateContext,
     ovpk: OvpkM,
     recipient: AztecAddress,
-) -> fn[(&mut PrivateContext, OvpkM, AztecAddress)](Event) -> ()
+    sender: AztecAddress,
+) -> fn[(&mut PrivateContext, OvpkM, AztecAddress, AztecAddress)](Event) -> ()
 where
     Event: EventInterface<N>,
 {
@@ -82,7 +95,7 @@ where
         // value generation.
         let randomness = unsafe { random() };
         let (encrypted_log, log_hash) = unsafe {
-            compute_payload_and_hash_unconstrained(*context, e, randomness, ovpk, recipient)
+            compute_payload_and_hash_unconstrained(*context, e, randomness, ovpk, recipient, sender)
         };
         context.emit_raw_event_log_with_masked_address(randomness, encrypted_log, log_hash);
     }
@@ -96,14 +109,15 @@ pub fn encode_and_encrypt_event_with_randomness<Event, let N: u32>(
     randomness: Field,
     ovpk: OvpkM,
     recipient: AztecAddress,
-) -> fn[(&mut PrivateContext, OvpkM, Field, AztecAddress)](Event) -> ()
+    sender: AztecAddress,
+) -> fn[(&mut PrivateContext, OvpkM, Field, AztecAddress, AztecAddress)](Event) -> ()
 where
     Event: EventInterface<N>,
 {
     |e: Event| {
         let ovsk_app: Field = context.request_ovsk_app(ovpk.hash());
         let (encrypted_log, log_hash) =
-            compute_payload_and_hash(*context, e, randomness, ovsk_app, ovpk, recipient);
+            compute_payload_and_hash(*context, e, randomness, ovsk_app, ovpk, recipient, sender);
         context.emit_raw_event_log_with_masked_address(randomness, encrypted_log, log_hash);
     }
 }
@@ -113,7 +127,8 @@ pub fn encode_and_encrypt_event_with_randomness_unconstrained<Event, let N: u32>
     randomness: Field,
     ovpk: OvpkM,
     recipient: AztecAddress,
-) -> fn[(&mut PrivateContext, Field, OvpkM, AztecAddress)](Event) -> ()
+    sender: AztecAddress,
+) -> fn[(&mut PrivateContext, Field, OvpkM, AztecAddress, AztecAddress)](Event) -> ()
 where
     Event: EventInterface<N>,
 {
@@ -133,7 +148,7 @@ where
         // return the log from this function to the app, otherwise it could try to do stuff with it and then that might
         // be wrong.
         let (encrypted_log, log_hash) = unsafe {
-            compute_payload_and_hash_unconstrained(*context, e, randomness, ovpk, recipient)
+            compute_payload_and_hash_unconstrained(*context, e, randomness, ovpk, recipient, sender)
         };
         context.emit_raw_event_log_with_masked_address(randomness, encrypted_log, log_hash);
     }

--- a/noir-projects/aztec-nr/aztec/src/encrypted_logs/encrypted_note_emission.nr
+++ b/noir-projects/aztec-nr/aztec/src/encrypted_logs/encrypted_note_emission.nr
@@ -15,6 +15,7 @@ fn compute_payload_and_hash<Note, let N: u32>(
     ovsk_app: Field,
     ovpk: OvpkM,
     recipient: AztecAddress,
+    sender: AztecAddress,
 ) -> (u32, [u8; 385 + N * 32], Field)
 where
     Note: NoteInterface<N>,
@@ -32,8 +33,15 @@ where
     let plaintext = note.to_be_bytes(storage_slot);
 
     // For note logs we always include public values prefix
-    let encrypted_log: [u8; 385 + N * 32] =
-        compute_private_log_payload(contract_address, ovsk_app, ovpk, recipient, plaintext, true);
+    let encrypted_log: [u8; 385 + N * 32] = compute_private_log_payload(
+        contract_address,
+        ovsk_app,
+        ovpk,
+        recipient,
+        sender,
+        plaintext,
+        true,
+    );
     let log_hash = sha256_to_field(encrypted_log);
 
     (note_hash_counter, encrypted_log, log_hash)
@@ -44,12 +52,13 @@ unconstrained fn compute_payload_and_hash_unconstrained<Note, let N: u32>(
     note: Note,
     ovpk: OvpkM,
     recipient: AztecAddress,
+    sender: AztecAddress,
 ) -> (u32, [u8; 385 + N * 32], Field)
 where
     Note: NoteInterface<N>,
 {
     let ovsk_app = get_ovsk_app(ovpk.hash());
-    compute_payload_and_hash(context, note, ovsk_app, ovpk, recipient)
+    compute_payload_and_hash(context, note, ovsk_app, ovpk, recipient, sender)
 }
 
 // This function seems to be affected by the following Noir bug:
@@ -59,7 +68,9 @@ pub fn encode_and_encrypt_note<Note, let N: u32>(
     context: &mut PrivateContext,
     ovpk: OvpkM,
     recipient: AztecAddress,
-) -> fn[(&mut PrivateContext, OvpkM, AztecAddress)](NoteEmission<Note>) -> ()
+    // TODO: We need this because to compute a tagging secret, we require a sender. Should we have the tagging secret oracle take a ovpk_m as input instead of the address?
+    sender: AztecAddress,
+) -> fn[(&mut PrivateContext, OvpkM, AztecAddress, AztecAddress)](NoteEmission<Note>) -> ()
 where
     Note: NoteInterface<N>,
 {
@@ -67,7 +78,7 @@ where
         let ovsk_app: Field = context.request_ovsk_app(ovpk.hash());
 
         let (note_hash_counter, encrypted_log, log_hash) =
-            compute_payload_and_hash(*context, e.note, ovsk_app, ovpk, recipient);
+            compute_payload_and_hash(*context, e.note, ovsk_app, ovpk, recipient, sender);
         context.emit_raw_note_log(note_hash_counter, encrypted_log, log_hash);
     }
 }
@@ -76,7 +87,9 @@ pub fn encode_and_encrypt_note_unconstrained<Note, let N: u32>(
     context: &mut PrivateContext,
     ovpk: OvpkM,
     recipient: AztecAddress,
-) -> fn[(&mut PrivateContext, OvpkM, AztecAddress)](NoteEmission<Note>) -> ()
+    // TODO: We need this because to compute a tagging secret, we require a sender. Should we have the tagging secret oracle take a ovpk_m as input instead of the address?
+    sender: AztecAddress,
+) -> fn[(&mut PrivateContext, OvpkM, AztecAddress, AztecAddress)](NoteEmission<Note>) -> ()
 where
     Note: NoteInterface<N>,
 {
@@ -100,8 +113,9 @@ where
         // for the log to be deleted when it shouldn't have (which is fine - they can already make the content be
         // whatever), or cause for the log to not be deleted when it should have (which is also fine - it'll be a log
         // for a note that doesn't exist).
-        let (note_hash_counter, encrypted_log, log_hash) =
-            unsafe { compute_payload_and_hash_unconstrained(*context, e.note, ovpk, recipient) };
+        let (note_hash_counter, encrypted_log, log_hash) = unsafe {
+            compute_payload_and_hash_unconstrained(*context, e.note, ovpk, recipient, sender)
+        };
         context.emit_raw_note_log(note_hash_counter, encrypted_log, log_hash);
     }
 }

--- a/noir-projects/aztec-nr/aztec/src/encrypted_logs/payload.nr
+++ b/noir-projects/aztec-nr/aztec/src/encrypted_logs/payload.nr
@@ -19,6 +19,7 @@ fn compute_private_log_payload<let P: u32, let M: u32>(
     ovsk_app: Field,
     ovpk: OvpkM,
     recipient: AztecAddress,
+    sender: AztecAddress,
     plaintext: [u8; P],
     include_public_values_prefix: bool,
 ) -> [u8; M] {
@@ -206,11 +207,16 @@ mod test {
             0x25afb798ea6d0b8c1618e50fdeafa463059415013d3b7c75d46abf5e242be70c,
         );
 
+        let sender = AztecAddress::from_field(
+            0x25afb798ea6d0b8c1618e50fdeafa463059415013d3b7c75d46abf5e242be70c,
+        );
+
         let log = compute_private_log_payload(
             contract_address,
             ovsk_app,
             ovpk_m,
             recipient,
+            sender,
             plaintext,
             false,
         );

--- a/noir-projects/aztec-nr/aztec/src/macros/notes/mod.nr
+++ b/noir-projects/aztec-nr/aztec/src/macros/notes/mod.nr
@@ -463,7 +463,7 @@ comptime fn generate_setup_payload(
                 }
             }
 
-            fn encrypt_log(self, context: &mut PrivateContext, ovpk: aztec::protocol_types::public_keys::OvpkM, recipient: aztec::protocol_types::address::AztecAddress) -> [Field; $encrypted_log_field_length] {
+            fn encrypt_log(self, context: &mut PrivateContext, ovpk: aztec::protocol_types::public_keys::OvpkM, recipient: aztec::protocol_types::address::AztecAddress, sender: aztec::protocol_types::address::AztecAddress) -> [Field; $encrypted_log_field_length] {
                 let ovsk_app: Field  = context.request_ovsk_app(ovpk.hash());
 
                 let encrypted_log_bytes: [u8; $encrypted_log_byte_length] = aztec::encrypted_logs::payload::compute_private_log_payload(
@@ -471,6 +471,7 @@ comptime fn generate_setup_payload(
                     ovsk_app,
                     ovpk,
                     recipient,
+                    sender,
                     self.log_plaintext,
                     true
                 );

--- a/noir-projects/aztec-nr/easy-private-state/src/easy_private_uint.nr
+++ b/noir-projects/aztec-nr/easy-private-state/src/easy_private_uint.nr
@@ -22,7 +22,13 @@ impl<Context> EasyPrivateUint<Context> {
 
 impl EasyPrivateUint<&mut PrivateContext> {
     // Very similar to `value_note::utils::increment`.
-    pub fn add(self, addend: u64, owner: AztecAddress, outgoing_viewer: AztecAddress, sender: AztecAddress) {
+    pub fn add(
+        self,
+        addend: u64,
+        owner: AztecAddress,
+        outgoing_viewer: AztecAddress,
+        sender: AztecAddress,
+    ) {
         let outgoing_viewer_keys = get_public_keys(outgoing_viewer);
         // Creates new note for the owner.
         let mut addend_note = ValueNote::new(addend as Field, owner);
@@ -39,7 +45,13 @@ impl EasyPrivateUint<&mut PrivateContext> {
     }
 
     // Very similar to `value_note::utils::decrement`.
-    pub fn sub(self, subtrahend: u64, owner: AztecAddress, outgoing_viewer: AztecAddress, sender: AztecAddress) {
+    pub fn sub(
+        self,
+        subtrahend: u64,
+        owner: AztecAddress,
+        outgoing_viewer: AztecAddress,
+        sender: AztecAddress,
+    ) {
         let outgoing_viewer_keys = get_public_keys(outgoing_viewer);
 
         // docs:start:pop_notes

--- a/noir-projects/aztec-nr/easy-private-state/src/easy_private_uint.nr
+++ b/noir-projects/aztec-nr/easy-private-state/src/easy_private_uint.nr
@@ -22,7 +22,7 @@ impl<Context> EasyPrivateUint<Context> {
 
 impl EasyPrivateUint<&mut PrivateContext> {
     // Very similar to `value_note::utils::increment`.
-    pub fn add(self, addend: u64, owner: AztecAddress, outgoing_viewer: AztecAddress) {
+    pub fn add(self, addend: u64, owner: AztecAddress, outgoing_viewer: AztecAddress, sender: AztecAddress) {
         let outgoing_viewer_keys = get_public_keys(outgoing_viewer);
         // Creates new note for the owner.
         let mut addend_note = ValueNote::new(addend as Field, owner);
@@ -33,12 +33,13 @@ impl EasyPrivateUint<&mut PrivateContext> {
             self.context,
             outgoing_viewer_keys.ovpk_m,
             owner,
+            sender,
         ));
         // docs:end:insert
     }
 
     // Very similar to `value_note::utils::decrement`.
-    pub fn sub(self, subtrahend: u64, owner: AztecAddress, outgoing_viewer: AztecAddress) {
+    pub fn sub(self, subtrahend: u64, owner: AztecAddress, outgoing_viewer: AztecAddress, sender: AztecAddress) {
         let outgoing_viewer_keys = get_public_keys(outgoing_viewer);
 
         // docs:start:pop_notes
@@ -63,6 +64,7 @@ impl EasyPrivateUint<&mut PrivateContext> {
             self.context,
             outgoing_viewer_keys.ovpk_m,
             owner,
+            sender,
         ));
     }
 }

--- a/noir-projects/aztec-nr/value-note/src/utils.nr
+++ b/noir-projects/aztec-nr/value-note/src/utils.nr
@@ -23,6 +23,7 @@ pub fn increment(
     amount: Field,
     recipient: AztecAddress,
     outgoing_viewer: AztecAddress, // docs:end:increment_args
+    sender: AztecAddress,
 ) {
     let outgoing_viewer_ovpk_m = get_public_keys(outgoing_viewer).ovpk_m;
 
@@ -32,6 +33,7 @@ pub fn increment(
         balance.context,
         outgoing_viewer_ovpk_m,
         recipient,
+        sender,
     ));
 }
 
@@ -44,8 +46,9 @@ pub fn decrement(
     amount: Field,
     owner: AztecAddress,
     outgoing_viewer: AztecAddress,
+    sender: AztecAddress,
 ) {
-    let sum = decrement_by_at_most(balance, amount, owner, outgoing_viewer);
+    let sum = decrement_by_at_most(balance, amount, owner, outgoing_viewer, sender);
     assert(sum == amount, "Balance too low");
 }
 
@@ -62,6 +65,7 @@ pub fn decrement_by_at_most(
     max_amount: Field,
     owner: AztecAddress,
     outgoing_viewer: AztecAddress,
+    sender: AztecAddress,
 ) -> Field {
     let options = create_note_getter_options_for_decreasing_balance(max_amount);
     let notes = balance.pop_notes(options);
@@ -80,7 +84,7 @@ pub fn decrement_by_at_most(
         change_value = decremented - max_amount;
         decremented -= change_value;
     }
-    increment(balance, change_value, owner, outgoing_viewer);
+    increment(balance, change_value, owner, outgoing_viewer, sender);
 
     decremented
 }

--- a/noir-projects/noir-contracts/contracts/app_subscription_contract/src/main.nr
+++ b/noir-projects/noir-contracts/contracts/app_subscription_contract/src/main.nr
@@ -117,7 +117,12 @@ contract AppSubscription {
         let mut subscription_note =
             SubscriptionNote::new(subscriber, expiry_block_number, tx_count);
         storage.subscriptions.at(subscriber).initialize_or_replace(&mut subscription_note).emit(
-            encode_and_encrypt_note(&mut context, msg_sender_ovpk_m, subscriber, context.msg_sender()),
+            encode_and_encrypt_note(
+                &mut context,
+                msg_sender_ovpk_m,
+                subscriber,
+                context.msg_sender(),
+            ),
         );
     }
 

--- a/noir-projects/noir-contracts/contracts/app_subscription_contract/src/main.nr
+++ b/noir-projects/noir-contracts/contracts/app_subscription_contract/src/main.nr
@@ -53,6 +53,7 @@ contract AppSubscription {
             &mut context,
             keys.ovpk_m,
             user_address,
+            user_address,
         ));
 
         context.set_as_fee_payer();
@@ -116,7 +117,7 @@ contract AppSubscription {
         let mut subscription_note =
             SubscriptionNote::new(subscriber, expiry_block_number, tx_count);
         storage.subscriptions.at(subscriber).initialize_or_replace(&mut subscription_note).emit(
-            encode_and_encrypt_note(&mut context, msg_sender_ovpk_m, subscriber),
+            encode_and_encrypt_note(&mut context, msg_sender_ovpk_m, subscriber, context.msg_sender()),
         );
     }
 

--- a/noir-projects/noir-contracts/contracts/benchmarking_contract/src/main.nr
+++ b/noir-projects/noir-contracts/contracts/benchmarking_contract/src/main.nr
@@ -22,7 +22,13 @@ contract Benchmarking {
     #[private]
     fn create_note(owner: AztecAddress, outgoing_viewer: AztecAddress, value: Field) {
         // docs:start:increment_valuenote
-        increment(storage.notes.at(owner), value, owner, outgoing_viewer);
+        increment(
+            storage.notes.at(owner),
+            value,
+            owner,
+            outgoing_viewer,
+            outgoing_viewer,
+        );
         // docs:end:increment_valuenote
     }
     // Deletes a note at a specific index in the set and creates a new one with the same value.
@@ -36,7 +42,13 @@ contract Benchmarking {
         let mut getter_options = NoteGetterOptions::new();
         let notes = owner_notes.pop_notes(getter_options.set_limit(1).set_offset(index));
         let note = notes.get(0);
-        increment(owner_notes, note.value, owner, outgoing_viewer);
+        increment(
+            owner_notes,
+            note.value,
+            owner,
+            outgoing_viewer,
+            outgoing_viewer,
+        );
     }
 
     // Reads and writes to public storage and enqueues a call to another public function.

--- a/noir-projects/noir-contracts/contracts/card_game_contract/src/cards.nr
+++ b/noir-projects/noir-contracts/contracts/card_game_contract/src/cards.nr
@@ -118,6 +118,7 @@ impl Deck<&mut PrivateContext> {
                 self.set.context,
                 msg_sender_ovpk_m,
                 owner,
+                self.set.context.msg_sender(),
             ));
             inserted_cards = inserted_cards.push_back(card_note);
         }

--- a/noir-projects/noir-contracts/contracts/child_contract/src/main.nr
+++ b/noir-projects/noir-contracts/contracts/child_contract/src/main.nr
@@ -63,6 +63,7 @@ contract Child {
             &mut context,
             owner_ovpk_m,
             owner,
+            context.msg_sender(),
         ));
         new_value
     }

--- a/noir-projects/noir-contracts/contracts/counter_contract/src/main.nr
+++ b/noir-projects/noir-contracts/contracts/counter_contract/src/main.nr
@@ -24,7 +24,7 @@ contract Counter {
     // We can name our initializer anything we want as long as it's marked as aztec(initializer)
     fn initialize(headstart: u64, owner: AztecAddress, outgoing_viewer: AztecAddress) {
         let counters = storage.counters;
-        counters.at(owner).add(headstart, owner, outgoing_viewer);
+        counters.at(owner).add(headstart, owner, outgoing_viewer, context.msg_sender());
     }
     // docs:end:constructor
 
@@ -38,7 +38,7 @@ contract Counter {
             );
         }
         let counters = storage.counters;
-        counters.at(owner).add(1, owner, outgoing_viewer);
+        counters.at(owner).add(1, owner, outgoing_viewer, context.msg_sender());
     }
     // docs:end:increment
     // docs:start:get_counter

--- a/noir-projects/noir-contracts/contracts/crowdfunding_contract/src/main.nr
+++ b/noir-projects/noir-contracts/contracts/crowdfunding_contract/src/main.nr
@@ -91,6 +91,7 @@ contract Crowdfunding {
             &mut context,
             donor_ovpk_m,
             donor,
+            donor,
         ));
     }
     // docs:end:donate

--- a/noir-projects/noir-contracts/contracts/docs_example_contract/src/main.nr
+++ b/noir-projects/noir-contracts/contracts/docs_example_contract/src/main.nr
@@ -181,6 +181,7 @@ contract DocsExample {
             &mut context,
             msg_sender_ovpk_m,
             context.msg_sender(),
+            context.msg_sender(),
         ));
     }
     // docs:end:initialize-private-mutable
@@ -196,6 +197,7 @@ contract DocsExample {
             &mut context,
             msg_sender_ovpk_m,
             context.msg_sender(),
+            context.msg_sender(),
         ));
     }
 
@@ -209,6 +211,7 @@ contract DocsExample {
                 &mut context,
                 msg_sender_ovpk_m,
                 context.msg_sender(),
+                context.msg_sender(),
             ));
         }
     }
@@ -220,6 +223,7 @@ contract DocsExample {
         storage.set.insert(&mut note).emit(encode_and_encrypt_note(
             &mut context,
             msg_sender_ovpk_m,
+            context.msg_sender(),
             context.msg_sender(),
         ));
     }
@@ -237,6 +241,7 @@ contract DocsExample {
         storage.legendary_card.replace(&mut new_card).emit(encode_and_encrypt_note(
             &mut context,
             msg_sender_ovpk_m,
+            context.msg_sender(),
             context.msg_sender(),
         ));
         DocsExample::at(context.this_address()).update_leader(context.msg_sender(), points).enqueue(
@@ -258,6 +263,7 @@ contract DocsExample {
         storage.legendary_card.replace(&mut new_card).emit(encode_and_encrypt_note(
             &mut context,
             msg_sender_ovpk_m,
+            context.msg_sender(),
             context.msg_sender(),
         ));
         // docs:end:state_vars-PrivateMutableReplace

--- a/noir-projects/noir-contracts/contracts/easy_private_token_contract/src/main.nr
+++ b/noir-projects/noir-contracts/contracts/easy_private_token_contract/src/main.nr
@@ -21,7 +21,7 @@ contract EasyPrivateToken {
     fn constructor(initial_supply: u64, owner: AztecAddress, outgoing_viewer: AztecAddress) {
         let balances = storage.balances;
 
-        balances.at(owner).add(initial_supply, owner, outgoing_viewer);
+        balances.at(owner).add(initial_supply, owner, outgoing_viewer, context.msg_sender());
     }
 
     // Mints `amount` of tokens to `owner`.
@@ -29,7 +29,7 @@ contract EasyPrivateToken {
     fn mint(amount: u64, owner: AztecAddress, outgoing_viewer: AztecAddress) {
         let balances = storage.balances;
 
-        balances.at(owner).add(amount, owner, outgoing_viewer);
+        balances.at(owner).add(amount, owner, outgoing_viewer, context.msg_sender());
     }
 
     // Transfers `amount` of tokens from `sender` to a `recipient`.
@@ -42,8 +42,8 @@ contract EasyPrivateToken {
     ) {
         let balances = storage.balances;
 
-        balances.at(sender).sub(amount, sender, outgoing_viewer);
-        balances.at(recipient).add(amount, recipient, outgoing_viewer);
+        balances.at(sender).sub(amount, sender, outgoing_viewer, sender);
+        balances.at(recipient).add(amount, recipient, outgoing_viewer, sender);
     }
 
     // Helper function to get the balance of a user ("unconstrained" is a Noir alternative of Solidity's "view" function).

--- a/noir-projects/noir-contracts/contracts/ecdsa_k_account_contract/src/main.nr
+++ b/noir-projects/noir-contracts/contracts/ecdsa_k_account_contract/src/main.nr
@@ -39,6 +39,7 @@ contract EcdsaKAccount {
             &mut context,
             this_ovpk_m,
             this,
+            this,
         ));
     }
 

--- a/noir-projects/noir-contracts/contracts/ecdsa_r_account_contract/src/main.nr
+++ b/noir-projects/noir-contracts/contracts/ecdsa_r_account_contract/src/main.nr
@@ -37,6 +37,7 @@ contract EcdsaRAccount {
             &mut context,
             this_ovpk_m,
             this,
+            this,
         ));
     }
 

--- a/noir-projects/noir-contracts/contracts/escrow_contract/src/main.nr
+++ b/noir-projects/noir-contracts/contracts/escrow_contract/src/main.nr
@@ -32,6 +32,7 @@ contract Escrow {
             &mut context,
             msg_sender_ovpk_m,
             owner,
+            context.msg_sender(),
         ));
     }
 

--- a/noir-projects/noir-contracts/contracts/inclusion_proofs_contract/src/main.nr
+++ b/noir-projects/noir-contracts/contracts/inclusion_proofs_contract/src/main.nr
@@ -40,6 +40,7 @@ contract InclusionProofs {
             &mut context,
             msg_sender_ovpk_m,
             owner,
+            context.msg_sender(),
         ));
     }
     // docs:end:create_note

--- a/noir-projects/noir-contracts/contracts/nft_contract/src/main.nr
+++ b/noir-projects/noir-contracts/contracts/nft_contract/src/main.nr
@@ -307,6 +307,7 @@ contract NFT {
             &mut context,
             from_ovpk_m,
             to,
+            from,
         ));
     }
 

--- a/noir-projects/noir-contracts/contracts/nft_contract/src/main.nr
+++ b/noir-projects/noir-contracts/contracts/nft_contract/src/main.nr
@@ -188,7 +188,8 @@ contract NFT {
 
         // We set the ovpk to the message sender's ovpk and we encrypt the log.
         let from_ovpk = get_public_keys(context.msg_sender()).ovpk_m;
-        let setup_log = note_setup_payload.encrypt_log(context, from_ovpk, to);
+        let setup_log =
+            note_setup_payload.encrypt_log(context, from_ovpk, to, context.msg_sender());
 
         // Using the x-coordinate as a hiding point slot is safe against someone else interfering with it because
         // we have a guarantee that the public functions of the transaction are executed right after the private ones

--- a/noir-projects/noir-contracts/contracts/pending_note_hashes_contract/src/main.nr
+++ b/noir-projects/noir-contracts/contracts/pending_note_hashes_contract/src/main.nr
@@ -47,6 +47,7 @@ contract PendingNoteHashes {
             &mut context,
             outgoing_viewer_ovpk_m,
             owner,
+            context.msg_sender(),
         ));
 
         let options = NoteGetterOptions::with_filter(filter_notes_min_sum, amount);
@@ -96,6 +97,7 @@ contract PendingNoteHashes {
             &mut context,
             outgoing_viewer_ovpk_m,
             owner,
+            context.msg_sender(),
         ));
     }
 
@@ -120,6 +122,7 @@ contract PendingNoteHashes {
             &mut context,
             outgoing_viewer_ovpk_m,
             owner,
+            context.msg_sender(),
         ));
     }
 
@@ -136,10 +139,10 @@ contract PendingNoteHashes {
         // Insert note
         let emission = owner_balance.insert(&mut note);
 
-        emission.emit(encode_and_encrypt_note(&mut context, outgoing_viewer_ovpk_m, owner));
+        emission.emit(encode_and_encrypt_note(&mut context, outgoing_viewer_ovpk_m, owner, context.msg_sender()));
 
         // Emit note again
-        emission.emit(encode_and_encrypt_note(&mut context, outgoing_viewer_ovpk_m, owner));
+        emission.emit(encode_and_encrypt_note(&mut context, outgoing_viewer_ovpk_m, owner, context.msg_sender()));
     }
 
     // Nested/inner function to get a note and confirm it matches the expected value
@@ -359,6 +362,7 @@ contract PendingNoteHashes {
             &mut context,
             outgoing_viewer_ovpk_m,
             owner,
+            context.msg_sender(),
         ));
 
         // We will emit a note log with an incorrect preimage to ensure the pxe throws
@@ -372,6 +376,7 @@ contract PendingNoteHashes {
             &mut context,
             outgoing_viewer_ovpk_m,
             owner,
+            context.msg_sender(),
         ));
     }
 
@@ -392,6 +397,7 @@ contract PendingNoteHashes {
                 context,
                 outgoing_viewer_ovpk_m,
                 owner,
+                context.msg_sender(),
             ));
         }
     }

--- a/noir-projects/noir-contracts/contracts/pending_note_hashes_contract/src/main.nr
+++ b/noir-projects/noir-contracts/contracts/pending_note_hashes_contract/src/main.nr
@@ -139,10 +139,20 @@ contract PendingNoteHashes {
         // Insert note
         let emission = owner_balance.insert(&mut note);
 
-        emission.emit(encode_and_encrypt_note(&mut context, outgoing_viewer_ovpk_m, owner, context.msg_sender()));
+        emission.emit(encode_and_encrypt_note(
+            &mut context,
+            outgoing_viewer_ovpk_m,
+            owner,
+            context.msg_sender(),
+        ));
 
         // Emit note again
-        emission.emit(encode_and_encrypt_note(&mut context, outgoing_viewer_ovpk_m, owner, context.msg_sender()));
+        emission.emit(encode_and_encrypt_note(
+            &mut context,
+            outgoing_viewer_ovpk_m,
+            owner,
+            context.msg_sender(),
+        ));
     }
 
     // Nested/inner function to get a note and confirm it matches the expected value

--- a/noir-projects/noir-contracts/contracts/schnorr_account_contract/src/main.nr
+++ b/noir-projects/noir-contracts/contracts/schnorr_account_contract/src/main.nr
@@ -44,6 +44,7 @@ contract SchnorrAccount {
             &mut context,
             this_ovpk_m,
             this,
+            this,
         ));
     }
 

--- a/noir-projects/noir-contracts/contracts/spam_contract/src/main.nr
+++ b/noir-projects/noir-contracts/contracts/spam_contract/src/main.nr
@@ -36,7 +36,7 @@ contract Spam {
 
         for _ in 0..MAX_NOTE_HASHES_PER_CALL {
             storage.balances.at(caller).add(caller, U128::from_integer(amount)).emit(
-                encode_and_encrypt_note_unconstrained(&mut context, caller_ovpk_m, caller),
+                encode_and_encrypt_note_unconstrained(&mut context, caller_ovpk_m, caller, caller),
             );
         }
 

--- a/noir-projects/noir-contracts/contracts/stateful_test_contract/src/main.nr
+++ b/noir-projects/noir-contracts/contracts/stateful_test_contract/src/main.nr
@@ -45,7 +45,7 @@ contract StatefulTest {
     fn create_note(owner: AztecAddress, outgoing_viewer: AztecAddress, value: Field) {
         if (value != 0) {
             let loc = storage.notes.at(owner);
-            increment(loc, value, owner, outgoing_viewer);
+            increment(loc, value, owner, outgoing_viewer, context.msg_sender());
         }
     }
 
@@ -54,7 +54,7 @@ contract StatefulTest {
     fn create_note_no_init_check(owner: AztecAddress, outgoing_viewer: AztecAddress, value: Field) {
         if (value != 0) {
             let loc = storage.notes.at(owner);
-            increment(loc, value, owner, outgoing_viewer);
+            increment(loc, value, owner, outgoing_viewer, context.msg_sender());
         }
     }
 
@@ -64,10 +64,10 @@ contract StatefulTest {
         let sender = context.msg_sender();
 
         let sender_notes = storage.notes.at(sender);
-        decrement(sender_notes, amount, sender, context.msg_sender());
+        decrement(sender_notes, amount, sender, sender, sender);
 
         let recipient_notes = storage.notes.at(recipient);
-        increment(recipient_notes, amount, recipient, context.msg_sender());
+        increment(recipient_notes, amount, recipient, sender, sender);
     }
 
     #[private]
@@ -76,10 +76,10 @@ contract StatefulTest {
         let sender = context.msg_sender();
 
         let sender_notes = storage.notes.at(sender);
-        decrement(sender_notes, amount, sender, context.msg_sender());
+        decrement(sender_notes, amount, sender, sender, sender);
 
         let recipient_notes = storage.notes.at(recipient);
-        increment(recipient_notes, amount, recipient, context.msg_sender());
+        increment(recipient_notes, amount, recipient, sender, sender);
     }
 
     #[public]

--- a/noir-projects/noir-contracts/contracts/static_child_contract/src/main.nr
+++ b/noir-projects/noir-contracts/contracts/static_child_contract/src/main.nr
@@ -52,6 +52,7 @@ contract StaticChild {
             &mut context,
             msg_sender_ovpk_m,
             owner,
+            context.msg_sender(),
         ));
         new_value
     }
@@ -70,6 +71,7 @@ contract StaticChild {
             &mut context,
             outgoing_viewer_ovpk_m,
             owner,
+            context.msg_sender(),
         ));
         new_value
     }

--- a/noir-projects/noir-contracts/contracts/test_contract/src/main.nr
+++ b/noir-projects/noir-contracts/contracts/test_contract/src/main.nr
@@ -304,6 +304,7 @@ contract Test {
             5,
             outgoing_viewer_ovpk_m,
             owner,
+            outgoing_viewer,
         ));
 
         // this contract has reached max number of functions, so using this one fn
@@ -321,6 +322,7 @@ contract Test {
                 0,
                 outgoing_viewer_ovpk_m,
                 owner,
+                outgoing_viewer,
             ));
         }
     }

--- a/noir-projects/noir-contracts/contracts/test_contract/src/main.nr
+++ b/noir-projects/noir-contracts/contracts/test_contract/src/main.nr
@@ -109,6 +109,7 @@ contract Test {
             &mut context,
             outgoing_viewer_ovpk_m,
             owner,
+            context.msg_sender(),
         ));
     }
 
@@ -343,6 +344,7 @@ contract Test {
             &mut context,
             msg_sender_ovpk_m,
             owner,
+            context.msg_sender(),
         ));
         storage_slot += 1;
         Test::at(context.this_address())

--- a/noir-projects/noir-contracts/contracts/test_log_contract/src/main.nr
+++ b/noir-projects/noir-contracts/contracts/test_log_contract/src/main.nr
@@ -48,6 +48,7 @@ contract TestLog {
             // outgoing is set to other, incoming is set to msg sender
             other_ovpk_m,
             context.msg_sender(),
+            other,
         ));
 
         // We duplicate the emission, but specifying different incoming and outgoing parties
@@ -57,6 +58,7 @@ contract TestLog {
             // outgoing is set to msg sender, incoming is set to other
             msg_sender_ovpk_m,
             other,
+            context.msg_sender(),
         ));
 
         let event1 = ExampleEvent1 {
@@ -70,6 +72,7 @@ contract TestLog {
             // outgoing is set to other, incoming is set to msg sender
             other_ovpk_m,
             context.msg_sender(),
+            other,
         ));
     }
 

--- a/noir-projects/noir-contracts/contracts/token_blacklist_contract/src/main.nr
+++ b/noir-projects/noir-contracts/contracts/token_blacklist_contract/src/main.nr
@@ -191,7 +191,7 @@ contract TokenBlacklist {
         // TODO: constrain encryption below - we are using unconstrained here only becuase of the following Noir issue
         // https://github.com/noir-lang/noir/issues/5771
         storage.balances.add(to, U128::from_integer(amount)).emit(
-            encode_and_encrypt_note_unconstrained(&mut context, msg_sender_ovpk_m, to),
+            encode_and_encrypt_note_unconstrained(&mut context, msg_sender_ovpk_m, to, context.msg_sender()),
         );
     }
 
@@ -212,7 +212,7 @@ contract TokenBlacklist {
         // TODO: constrain encryption below - we are using unconstrained here only becuase of the following Noir issue
         // https://github.com/noir-lang/noir/issues/5771
         storage.balances.sub(from, U128::from_integer(amount)).emit(
-            encode_and_encrypt_note_unconstrained(&mut context, from_ovpk_m, from),
+            encode_and_encrypt_note_unconstrained(&mut context, from_ovpk_m, from, from),
         );
 
         TokenBlacklist::at(context.this_address())._increase_public_balance(to, amount).enqueue(
@@ -241,11 +241,13 @@ contract TokenBlacklist {
             &mut context,
             from_ovpk_m,
             from,
+            from,
         ));
         storage.balances.add(to, amount).emit(encode_and_encrypt_note_unconstrained(
             &mut context,
             from_ovpk_m,
             to,
+            from,
         ));
     }
 
@@ -264,7 +266,7 @@ contract TokenBlacklist {
         // TODO: constrain encryption below - we are using unconstrained here only becuase of the following Noir issue
         // https://github.com/noir-lang/noir/issues/5771
         storage.balances.sub(from, U128::from_integer(amount)).emit(
-            encode_and_encrypt_note_unconstrained(&mut context, from_ovpk_m, from),
+            encode_and_encrypt_note_unconstrained(&mut context, from_ovpk_m, from, from),
         );
 
         TokenBlacklist::at(context.this_address())._reduce_total_supply(amount).enqueue(&mut context);

--- a/noir-projects/noir-contracts/contracts/token_blacklist_contract/src/main.nr
+++ b/noir-projects/noir-contracts/contracts/token_blacklist_contract/src/main.nr
@@ -191,7 +191,12 @@ contract TokenBlacklist {
         // TODO: constrain encryption below - we are using unconstrained here only becuase of the following Noir issue
         // https://github.com/noir-lang/noir/issues/5771
         storage.balances.add(to, U128::from_integer(amount)).emit(
-            encode_and_encrypt_note_unconstrained(&mut context, msg_sender_ovpk_m, to, context.msg_sender()),
+            encode_and_encrypt_note_unconstrained(
+                &mut context,
+                msg_sender_ovpk_m,
+                to,
+                context.msg_sender(),
+            ),
         );
     }
 

--- a/noir-projects/noir-contracts/contracts/token_contract/src/main.nr
+++ b/noir-projects/noir-contracts/contracts/token_contract/src/main.nr
@@ -311,6 +311,7 @@ contract Token {
             &mut context,
             from_ovpk_m,
             to,
+            context.msg_sender(),
         ));
     }
     // docs:end:redeem_shield
@@ -327,7 +328,7 @@ contract Token {
         // TODO: constrain encryption below - we are using unconstrained here only becuase of the following Noir issue
         // https://github.com/noir-lang/noir/issues/5771
         storage.balances.at(from).sub(from, U128::from_integer(amount)).emit(
-            encode_and_encrypt_note_unconstrained(&mut context, from_ovpk_m, from),
+            encode_and_encrypt_note_unconstrained(&mut context, from_ovpk_m, from, from),
         );
         Token::at(context.this_address())._increase_public_balance(to, amount).enqueue(&mut context);
     }
@@ -453,6 +454,7 @@ contract Token {
             &mut context,
             from_ovpk_m,
             from,
+            from,
         ));
         // docs:end:encrypted
         // docs:end:increase_private_balance
@@ -462,6 +464,7 @@ contract Token {
             &mut context,
             from_ovpk_m,
             to,
+            from,
         ));
     }
     // docs:end:transfer_from
@@ -477,7 +480,7 @@ contract Token {
         // TODO: constrain encryption below - we are using unconstrained here only becuase of the following Noir issue
         // https://github.com/noir-lang/noir/issues/5771
         storage.balances.at(from).sub(from, U128::from_integer(amount)).emit(
-            encode_and_encrypt_note_unconstrained(&mut context, from_ovpk_m, from),
+            encode_and_encrypt_note_unconstrained(&mut context, from_ovpk_m, from, from),
         );
         Token::at(context.this_address())._reduce_total_supply(amount).enqueue(&mut context);
     }
@@ -709,6 +712,7 @@ contract Token {
         storage.balances.at(user).add(user, change).emit(encode_and_encrypt_note_unconstrained(
             &mut context,
             user_ovpk,
+            user,
             user,
         ));
 

--- a/noir-projects/noir-contracts/contracts/token_contract/src/main.nr
+++ b/noir-projects/noir-contracts/contracts/token_contract/src/main.nr
@@ -227,7 +227,7 @@ contract Token {
         let caller = context.msg_sender();
         let caller_ovpk_m = get_public_keys(caller).ovpk_m;
         storage.balances.at(caller).add(caller, U128::from_integer(amount)).emit(
-            encode_and_encrypt_note(&mut context, caller_ovpk_m, caller),
+            encode_and_encrypt_note(&mut context, caller_ovpk_m, caller, caller),
         );
         Token::at(context.this_address())
             .assert_minter_and_mint(context.msg_sender(), amount)
@@ -358,18 +358,20 @@ contract Token {
             &mut context,
             from_ovpk_m,
             from,
+            from,
         ));
         storage.balances.at(to).add(to, amount).emit(encode_and_encrypt_note_unconstrained(
             &mut context,
             from_ovpk_m,
             to,
+            from,
         ));
         // We don't constrain encryption of the note log in `transfer` (unlike in `transfer_from`) because the transfer
         // function is only designed to be used in situations where the event is not strictly necessary (e.g. payment to
         // another person where the payment is considered to be successful when the other party successfully decrypts a
         // note).
         Transfer { from, to, amount: amount.to_field() }.emit(
-            encode_and_encrypt_event_unconstrained(&mut context, from_ovpk_m, to),
+            encode_and_encrypt_event_unconstrained(&mut context, from_ovpk_m, to, from),
         );
     }
     // docs:end:transfer
@@ -532,7 +534,8 @@ contract Token {
 
         // We set the ovpk to the message sender's ovpk and we encrypt the log.
         let from_ovpk = get_public_keys(context.msg_sender()).ovpk_m;
-        let setup_log = note_setup_payload.encrypt_log(context, from_ovpk, to);
+        let setup_log =
+            note_setup_payload.encrypt_log(context, from_ovpk, to, context.msg_sender());
 
         // Using the x-coordinate as a hiding point slot is safe against someone else interfering with it because
         // we have a guarantee that the public functions of the transaction are executed right after the private ones
@@ -751,8 +754,9 @@ contract Token {
 
         // 6. We compute setup logs
         let fee_payer_setup_log =
-            fee_payer_setup_payload.encrypt_log(&mut context, user_ovpk, fee_payer);
-        let user_setup_log = user_setup_payload.encrypt_log(&mut context, user_ovpk, user);
+            fee_payer_setup_payload.encrypt_log(&mut context, user_ovpk, fee_payer, fee_payer);
+        let user_setup_log =
+            user_setup_payload.encrypt_log(&mut context, user_ovpk, user, fee_payer);
 
         // 7. We store the hiding points an logs in transients storage
         Token::at(context.this_address())


### PR DESCRIPTION
This PR is purely plumbing, as we add a sender to encode_and_encrypt, changing the API because in the future we will require the sender as a param to request the shared secret from the PXE that will be used to compute the tag.

We are using a placeholder of `msg_sender` and trying to infer from context who the sender should be whenever possible.

For the fee / partial note stuff, it may be good to have a better understanding who the sender is.

Finally, some patterns arise, namely that we should probably add self as an implicit member of the address book :D. 

To note: this pollutes the API even more, and is beyond the standard of sane. as discussed on Slack, we should abstract this pollution wherever possible.