### PR TITLE
test: fixing broken sample-dapp tests

### DIFF
--- a/yarn-project/end-to-end/src/sample-dapp/contracts.mjs
+++ b/yarn-project/end-to-end/src/sample-dapp/contracts.mjs
@@ -7,8 +7,8 @@ import { readFileSync } from 'fs';
 // docs:end:imports
 
 // docs:start:get-tokens
-export async function getToken(client) {
+export async function getToken(wallet) {
   const addresses = JSON.parse(readFileSync('addresses.json'));
-  return TokenContract.at(AztecAddress.fromString(addresses.token), client);
+  return TokenContract.at(AztecAddress.fromString(addresses.token), wallet);
 }
 // docs:end:get-tokens

--- a/yarn-project/end-to-end/src/sample-dapp/index.mjs
+++ b/yarn-project/end-to-end/src/sample-dapp/index.mjs
@@ -1,6 +1,6 @@
 // docs:start:imports
 import { getInitialTestAccountsWallets } from '@aztec/accounts/testing';
-import { createPXEClient, waitForPXE } from '@aztec/aztec.js';
+import { BatchCall, createPXEClient, waitForPXE } from '@aztec/aztec.js';
 import { fileURLToPath } from '@aztec/foundation/url';
 
 import { getToken } from './contracts.mjs';
@@ -33,13 +33,20 @@ async function showPrivateBalances(pxe) {
 
 // docs:start:mintPrivateFunds
 async function mintPrivateFunds(pxe) {
-  const [owner] = await getInitialTestAccountsWallets(pxe);
-  const token = await getToken(owner);
+  const [ownerWallet] = await getInitialTestAccountsWallets(pxe);
+  const token = await getToken(ownerWallet);
 
   await showPrivateBalances(pxe);
 
   const mintAmount = 20n;
-  await mintTokensToPrivate(token, owner, owner.getAddress(), mintAmount);
+  // We don't have the functionality to mint to private so we mint to the owner address in public and transfer
+  // the tokens to the recipient in private. We use BatchCall to speed the process up.
+  await new BatchCall(ownerWallet, [
+    token.methods.mint_public(ownerWallet.getAddress(), mintAmount).request(),
+    token.methods.transfer_to_private(ownerWallet.getAddress(), mintAmount).request(),
+  ])
+    .send()
+    .wait();
 
   await showPrivateBalances(pxe);
 }

--- a/yarn-project/end-to-end/src/sample-dapp/index.test.mjs
+++ b/yarn-project/end-to-end/src/sample-dapp/index.test.mjs
@@ -5,6 +5,8 @@ import { deployToken } from '../fixtures/token_utils';
 
 const { PXE_URL = 'http://localhost:8080', ETHEREUM_HOST = 'http://localhost:8545' } = process.env;
 
+// Note: To run this test you need to spin up Aztec sandbox. Build the aztec image (or pull it with aztec-up if on
+// master) and then run this test as usual (yarn test src/sample-dapp/index.test.mjs).
 describe('token', () => {
   // docs:start:setup
   let owner, recipient, token;
@@ -16,7 +18,7 @@ describe('token', () => {
     recipient = await createAccount(pxe);
 
     const initialBalance = 69;
-    await deployToken(owner, initialBalance, createDebugLogger('sample_dapp'));
+    token = await deployToken(owner, initialBalance, createDebugLogger('sample_dapp'));
   }, 120_000);
   // docs:end:setup
 

--- a/yarn-project/protocol-contracts/src/protocol_contract_data.ts
+++ b/yarn-project/protocol-contracts/src/protocol_contract_data.ts
@@ -50,14 +50,14 @@ export const ProtocolContractAddress: Record<ProtocolContractName, AztecAddress>
 };
 
 export const ProtocolContractLeaf = {
-  AuthRegistry: Fr.fromString('0x13794ed6c957a68bc852fe4c2a161019a53011b08331d8eb0287483a7845d334'),
+  AuthRegistry: Fr.fromString('0x16f00633c07cb18f29a819d16a8b5140dea24787ca2a030dc54379a8e6896e3e'),
   ContractInstanceDeployer: Fr.fromString('0x04a661c9d4d295fc485a7e0f3de40c09b35366343bce8ad229106a8ef4076fe5'),
   ContractClassRegisterer: Fr.fromString('0x147ba3294403576dbad10f86d3ffd4eb83fb230ffbcd5c8b153dd02942d0611f'),
   MultiCallEntrypoint: Fr.fromString('0x154b701b41d6cf6da7204fef36b2ee9578b449d21b3792a9287bf45eba48fd26'),
-  FeeJuice: Fr.fromString('0x146cb9b7cda808b4d5e066773e2fe0131d4ac4f7238bc0f093dce70f7c0f3421'),
-  Router: Fr.fromString('0x19e9ec99aedfe3ea69ba91b862b815df7d1796fa802985a154159cd739fe4817'),
+  FeeJuice: Fr.fromString('0x2422b0101aba5f5050e8c086a6bdd62b185b188acfba58c77b0016769b96efd6'),
+  Router: Fr.fromString('0x1cedd0ce59239cb4d55408257d8942bdbd1ac6f0ddab9980157255391dbaa596'),
 };
 
 export const protocolContractTreeRoot = Fr.fromString(
-  '0x149eb7ca5c1f23580f2449edfbb65ec70160e5d4b6f8313f061b8a8d73d014ab',
+  '0x21fb5ab0a0a9b4f282d47d379ec7b5fdf59457a19a593c17f7c29954e1e88dec',
 );


### PR DESCRIPTION
Fixing broke sample dapp tests

## Note for reviewer
I failed to run sample dapp ci test as when I run it against sandbox I was getting a seemingly unrelated error which would indicate that account contract addresses are derived differently between the aztec.js used in the test and the one used by sandbox. Running it locally using earthly failed because of a tag mismatch.  I absolutely suck at devops so I failed to get that working. But the issue in the CI run was simply an import error so I think we can just yolo this in and see.

I managed to run the other test and I've verified that it got fixed.