### PR TITLE
fix: e2e labels

### DIFF
--- a/scripts/ci/get_bench_jobs.sh
+++ b/scripts/ci/get_bench_jobs.sh
@@ -5,7 +5,8 @@ set -eu
 cd "$(dirname "$0")"/../..
 
 BRANCH=$1
-LABELS=$2
+# support labels with hyphens for backwards compatibility:
+LABELS=$(echo $2 | sed 's/-/_/g')
 
 # Define the allow_list
 allow_list=()

--- a/scripts/ci/get_e2e_jobs.sh
+++ b/scripts/ci/get_e2e_jobs.sh
@@ -5,7 +5,8 @@ set -eu
 cd "$(dirname "$0")"/../..
 
 BRANCH=$1
-LABELS=$2
+# support labels with hyphens for backwards compatibility:
+LABELS=$(echo $2 | sed 's/-/_/g')
 
 # Function to parse YAML and extract test names
 get_test_names() {


### PR DESCRIPTION
These use hyphens while internally things now use underscores