### PR TITLE
refactor: nuking `Token::privately_mint_private_note(...)`

### DIFF
--- a/noir-projects/noir-contracts/contracts/token_contract/src/main.nr
+++ b/noir-projects/noir-contracts/contracts/token_contract/src/main.nr
@@ -221,25 +221,6 @@ contract Token {
         // docs:end:insert_from_public
     }
     // docs:end:mint_private
-    // TODO: Nuke this - test functions do not belong to token contract!
-    #[private]
-    fn privately_mint_private_note(amount: Field) {
-        let caller = context.msg_sender();
-        let caller_ovpk_m = get_public_keys(caller).ovpk_m;
-        storage.balances.at(caller).add(caller, U128::from_integer(amount)).emit(
-            encode_and_encrypt_note(&mut context, caller_ovpk_m, caller, caller),
-        );
-        Token::at(context.this_address())
-            .assert_minter_and_mint(context.msg_sender(), amount)
-            .enqueue(&mut context);
-    }
-    #[public]
-    #[internal]
-    fn assert_minter_and_mint(minter: AztecAddress, amount: Field) {
-        assert(storage.minters.at(minter).read(), "caller is not minter");
-        let supply = storage.total_supply.read() + U128::from_integer(amount);
-        storage.total_supply.write(supply);
-    }
     // docs:start:shield
     #[public]
     fn shield(from: AztecAddress, amount: Field, secret_hash: Field, nonce: Field) {

--- a/yarn-project/bot/src/factory.ts
+++ b/yarn-project/bot/src/factory.ts
@@ -149,7 +149,7 @@ export class BotFactory {
 
       calls.push(
         isStandardToken
-          ? token.methods.privately_mint_private_note(MINT_BALANCE).request()
+          ? token.methods.mint_to_private(sender, MINT_BALANCE).request()
           : token.methods.mint(MINT_BALANCE, sender, sender).request(),
       );
     }

--- a/yarn-project/end-to-end/src/benchmarks/bench_prover.test.ts
+++ b/yarn-project/end-to-end/src/benchmarks/bench_prover.test.ts
@@ -108,7 +108,7 @@ describe('benchmarks/proving', () => {
     await Promise.all([
       initialGasContract.methods.claim(initialFpContract.address, 1e12, claimSecret, messageLeafIndex).send().wait(),
       initialTokenContract.methods.mint_public(initialSchnorrWallet.getAddress(), 1e12).send().wait(),
-      initialTokenContract.methods.privately_mint_private_note(1e12).send().wait(),
+      initialTokenContract.methods.mint_to_private(initialSchnorrWallet.getAddress(), 1e12).send().wait(),
     ]);
 
     recipient = CompleteAddress.random();

--- a/yarn-project/end-to-end/src/benchmarks/bench_tx_size_fees.test.ts
+++ b/yarn-project/end-to-end/src/benchmarks/bench_tx_size_fees.test.ts
@@ -71,7 +71,7 @@ describe('benchmarks/tx_size_fees', () => {
       feeJuice.methods.claim(fpc.address, 100e9, fpcSecret, fpcLeafIndex).send().wait(),
       feeJuice.methods.claim(aliceWallet.getAddress(), 100e9, aliceSecret, aliceLeafIndex).send().wait(),
     ]);
-    await token.methods.privately_mint_private_note(100e9).send().wait();
+    await token.methods.mint_to_private(aliceWallet.getAddress(), 100e9).send().wait();
     await token.methods.mint_public(aliceWallet.getAddress(), 100e9).send().wait();
   });
 

--- a/yarn-project/end-to-end/src/e2e_fees/fees_test.ts
+++ b/yarn-project/end-to-end/src/e2e_fees/fees_test.ts
@@ -116,7 +116,7 @@ export class FeesTest {
   /** Alice mints Token  */
   async mintToken(amount: bigint) {
     const balanceBefore = await this.token.methods.balance_of_private(this.aliceAddress).simulate();
-    await this.token.methods.privately_mint_private_note(amount).send().wait();
+    await this.token.methods.mint_to_private(this.aliceAddress, amount).send().wait();
     const balanceAfter = await this.token.methods.balance_of_private(this.aliceAddress).simulate();
     expect(balanceAfter).toEqual(balanceBefore + amount);
   }

--- a/yarn-project/end-to-end/src/e2e_fees/private_payments.test.ts
+++ b/yarn-project/end-to-end/src/e2e_fees/private_payments.test.ts
@@ -196,7 +196,7 @@ describe('e2e_fees private_payment', () => {
      */
     const newlyMintedBananas = 10n;
     const tx = await bananaCoin.methods
-      .privately_mint_private_note(newlyMintedBananas)
+      .mint_to_private(aliceAddress, newlyMintedBananas)
       .send({
         fee: {
           gasSettings,
@@ -373,7 +373,7 @@ describe('e2e_fees private_payment', () => {
 
     await expect(
       bananaCoin.methods
-        .privately_mint_private_note(10)
+        .mint_to_private(aliceAddress, 10)
         .send({
           // we need to skip public simulation otherwise the PXE refuses to accept the TX
           skipPublicSimulation: true,

--- a/yarn-project/end-to-end/src/e2e_token_contract/private_transfer_recursion.test.ts
+++ b/yarn-project/end-to-end/src/e2e_token_contract/private_transfer_recursion.test.ts
@@ -18,10 +18,12 @@ describe('e2e_token_contract private transfer recursion', () => {
   });
 
   async function mintNotes(noteAmounts: bigint[]): Promise<bigint> {
-    // Mint all notes, 4 at a time
-    for (let mintedNotes = 0; mintedNotes < noteAmounts.length; mintedNotes += 4) {
-      const toMint = noteAmounts.slice(mintedNotes, mintedNotes + 4); // We mint 4 notes at a time
-      const actions = toMint.map(amt => asset.methods.privately_mint_private_note(amt).request());
+    // We mint only 3 notes in 1 transaction as that is the maximum public data writes we can squeeze into a tx.
+    // --> Minting one note requires 19 public data writes (16 for the note encrypted log, 3 for note hiding point).
+    const notesPerIteration = 3;
+    for (let mintedNotes = 0; mintedNotes < noteAmounts.length; mintedNotes += notesPerIteration) {
+      const toMint = noteAmounts.slice(mintedNotes, mintedNotes + notesPerIteration);
+      const actions = toMint.map(amt => asset.methods.mint_to_private(wallets[0].getAddress(), amt).request());
       await new BatchCall(wallets[0], actions).send().wait();
     }
 


### PR DESCRIPTION
It was a test function which should not exist on a standard Token contract in the first place. Since I am working on a larger Token refactor decided to go ahead and nuke it now.
