### PR TITLE
feat: use address book in recipient tag calculation

### DIFF
--- a/yarn-project/pxe/src/simulator_oracle/simulator_oracle.test.ts
+++ b/yarn-project/pxe/src/simulator_oracle/simulator_oracle.test.ts
@@ -66,7 +66,7 @@ describe('Simulator oracle', () => {
       return { completeAddress, ivsk: keys.masterIncomingViewingSecretKey };
     });
     for (const sender of senders) {
-      await database.addCompleteAddress(sender.completeAddress);
+      await database.addContactAddress(sender.completeAddress.address);
     }
 
     const logs: { [k: string]: EncryptedL2NoteLog[] } = {};


### PR DESCRIPTION
A simple refactor to use our address book instead of the complete address db (which was used before because we were using registerRecipient as a standin for the address book) when we calculate tags for getting our incoming notes from the node.
