### PR TITLE
test: messing around with encryption apis

### DIFF
--- a/noir-projects/aztec-nr/aztec/src/encrypted_logs/encrypted_note_emission.nr
+++ b/noir-projects/aztec-nr/aztec/src/encrypted_logs/encrypted_note_emission.nr
@@ -1,7 +1,7 @@
 use crate::{
     context::PrivateContext,
     encrypted_logs::payload::compute_private_log_payload,
-    keys::getters::get_ovsk_app,
+    keys::getters::{get_ovsk_app, get_public_keys},
     note::{note_emission::NoteEmission, note_interface::NoteInterface},
 };
 use dep::protocol_types::{
@@ -50,6 +50,22 @@ where
 {
     let ovsk_app = get_ovsk_app(ovpk.hash());
     compute_payload_and_hash(context, note, ovsk_app, ovpk, recipient)
+}
+
+pub fn simple_encrypt<Note, let N: u32>(
+    context: &mut PrivateContext,
+) -> fn[(&mut PrivateContext,)](NoteEmission<Note>, AztecAddress) -> ()
+where
+    Note: NoteInterface<N>,
+{
+    |e: NoteEmission<Note>, recipient: AztecAddress| {
+        let ovpk = get_public_keys(context.msg_sender()).ovpk_m;
+
+        let (note_hash_counter, encrypted_log, log_hash) = unsafe {
+            compute_payload_and_hash_unconstrained(*context, e.note, ovpk, recipient)
+        };
+        context.emit_raw_note_log(note_hash_counter, encrypted_log, log_hash);
+    }
 }
 
 // This function seems to be affected by the following Noir bug:

--- a/noir-projects/aztec-nr/aztec/src/note/note_emission.nr
+++ b/noir-projects/aztec-nr/aztec/src/note/note_emission.nr
@@ -1,3 +1,4 @@
+use dep::protocol_types::address::AztecAddress;
 /**
  * A note emission struct containing the information required for emitting a note.
  * The exact `emit` logic is passed in by the application code
@@ -28,16 +29,17 @@ impl<Note> NoteEmission<Note> {
  */
 pub struct OuterNoteEmission<Note> {
     emission: Option<NoteEmission<Note>>,
+    recipient: Option<AztecAddress>,
 }
 
 impl<Note> OuterNoteEmission<Note> {
-    pub fn new(emission: Option<NoteEmission<Note>>) -> Self {
-        Self { emission }
+    pub fn new(emission: Option<NoteEmission<Note>>, recipient: Option<AztecAddress>) -> Self {
+        Self { emission, recipient }
     }
 
-    pub fn emit<Env>(self, _emit: fn[Env](NoteEmission<Note>) -> ()) {
+    pub fn emit<Env>(self, _emit: fn[Env](NoteEmission<Note>, AztecAddress) -> ()) {
         if self.emission.is_some() {
-            _emit(self.emission.unwrap());
+            _emit(self.emission.unwrap(), self.recipient.unwrap());
         }
     }
 

--- a/noir-projects/noir-contracts/contracts/token_contract/src/main.nr
+++ b/noir-projects/noir-contracts/contracts/token_contract/src/main.nr
@@ -23,7 +23,7 @@ contract Token {
         encrypted_logs::{
             encrypted_event_emission::encode_and_encrypt_event_unconstrained,
             encrypted_note_emission::{
-                encode_and_encrypt_note, encode_and_encrypt_note_unconstrained,
+                encode_and_encrypt_note, encode_and_encrypt_note_unconstrained, simple_encrypt,
             },
         },
         hash::compute_secret_hash,
@@ -847,6 +847,16 @@ contract Token {
         storage.balances.at(owner).balance_of().to_field()
     }
     // docs:end:balance_of_private
+
+    #[private]
+    fn simple_transfer_from(from: AztecAddress, to: AztecAddress, amount: Field, nonce: Field) {
+        assert(from.eq(context.msg_sender()));
+
+        let amount = U128::from_integer(amount);
+        storage.balances.at(from).sub(from, amount).emit(simple_encrypt(&mut context));
+
+        storage.balances.at(to).add(to, amount).emit(simple_encrypt(&mut context));
+    }
 }
 
 // docs:end:token_all

--- a/noir-projects/noir-contracts/contracts/token_contract/src/types/balance_set.nr
+++ b/noir-projects/noir-contracts/contracts/token_contract/src/types/balance_set.nr
@@ -46,13 +46,13 @@ impl BalanceSet<UnconstrainedContext> {
 impl BalanceSet<&mut PrivateContext> {
     pub fn add(self: Self, owner: AztecAddress, addend: U128) -> OuterNoteEmission<UintNote> {
         if addend == U128::from_integer(0) {
-            OuterNoteEmission::new(Option::none())
+            OuterNoteEmission::new(Option::none(), Option::none())
         } else {
             // We fetch the nullifier public key hash from the registry / from our PXE
             let mut addend_note = UintNote::new(addend, owner);
 
             // docs:start:insert
-            OuterNoteEmission::new(Option::some(self.set.insert(&mut addend_note)))
+            OuterNoteEmission::new(Option::some(self.set.insert(&mut addend_note)), Option::some(owner))
             // docs:end:insert
         }
     }


### PR DESCRIPTION
Quite limited at the moment, but if we were to make owner a first class citizen we could shove it into the normal note emission in `lifecycle.nr`
