### PR TITLE
feat: simulate validateEpochProofQuoteHeader in the future

### DIFF
--- a/l1-contracts/src/core/Rollup.sol
+++ b/l1-contracts/src/core/Rollup.sol
@@ -339,7 +339,8 @@ contract Rollup is EIP712("Aztec Rollup", "1"), Leonidas, IRollup, ITestRollup {
     Slot slot = getSlotAt(_ts);
 
     // Consider if a prune will hit in this slot
-    uint256 pendingBlockNumber = canPrune() ? tips.provenBlockNumber : tips.pendingBlockNumber;
+    uint256 pendingBlockNumber =
+      _canPruneAtTime(_ts) ? tips.provenBlockNumber : tips.pendingBlockNumber;
 
     Slot lastSlot = blocks[pendingBlockNumber].slotNumber;
 
@@ -775,6 +776,25 @@ contract Rollup is EIP712("Aztec Rollup", "1"), Leonidas, IRollup, ITestRollup {
   }
 
   function canPrune() public view override(IRollup) returns (bool) {
+    return _canPruneAtTime(Timestamp.wrap(block.timestamp));
+  }
+
+  function _prune() internal {
+    // TODO #8656
+    delete proofClaim;
+
+    uint256 pending = tips.pendingBlockNumber;
+
+    // @note  We are not deleting the blocks, but we are "winding back" the pendingTip to the last block that was proven.
+    //        We can do because any new block proposed will overwrite a previous block in the block log,
+    //        so no values should "survive".
+    //        People must therefore read the chain using the pendingTip as a boundary.
+    tips.pendingBlockNumber = tips.provenBlockNumber;
+
+    emit PrunedPending(tips.provenBlockNumber, pending);
+  }
+
+  function _canPruneAtTime(Timestamp _ts) internal view returns (bool) {
     if (
       tips.pendingBlockNumber == tips.provenBlockNumber
         || tips.pendingBlockNumber <= assumeProvenThroughBlockNumber
@@ -782,7 +802,7 @@ contract Rollup is EIP712("Aztec Rollup", "1"), Leonidas, IRollup, ITestRollup {
       return false;
     }
 
-    Slot currentSlot = getCurrentSlot();
+    Slot currentSlot = getSlotAt(_ts);
     Epoch oldestPendingEpoch = getEpochForBlock(tips.provenBlockNumber + 1);
     Slot startSlotOfPendingEpoch = oldestPendingEpoch.toSlots();
 
@@ -803,21 +823,6 @@ contract Rollup is EIP712("Aztec Rollup", "1"), Leonidas, IRollup, ITestRollup {
     return true;
   }
 
-  function _prune() internal {
-    // TODO #8656
-    delete proofClaim;
-
-    uint256 pending = tips.pendingBlockNumber;
-
-    // @note  We are not deleting the blocks, but we are "winding back" the pendingTip to the last block that was proven.
-    //        We can do because any new block proposed will overwrite a previous block in the block log,
-    //        so no values should "survive".
-    //        People must therefore read the chain using the pendingTip as a boundary.
-    tips.pendingBlockNumber = tips.provenBlockNumber;
-
-    emit PrunedPending(tips.provenBlockNumber, pending);
-  }
-
   /**
    * @notice  Validates the header for submission
    *
@@ -836,7 +841,8 @@ contract Rollup is EIP712("Aztec Rollup", "1"), Leonidas, IRollup, ITestRollup {
     bytes32 _txEffectsHash,
     DataStructures.ExecutionFlags memory _flags
   ) internal view {
-    uint256 pendingBlockNumber = canPrune() ? tips.provenBlockNumber : tips.pendingBlockNumber;
+    uint256 pendingBlockNumber =
+      _canPruneAtTime(_currentTime) ? tips.provenBlockNumber : tips.pendingBlockNumber;
     _validateHeaderForSubmissionBase(
       _header, _currentTime, _txEffectsHash, pendingBlockNumber, _flags
     );

--- a/l1-contracts/src/core/interfaces/IRollup.sol
+++ b/l1-contracts/src/core/interfaces/IRollup.sol
@@ -32,7 +32,6 @@ interface IRollup {
 
   function prune() external;
 
-
   function claimEpochProofRight(EpochProofQuoteLib.SignedEpochProofQuote calldata _quote) external;
 
   function propose(
@@ -101,15 +100,16 @@ interface IRollup {
 
   function archive() external view returns (bytes32);
   function archiveAt(uint256 _blockNumber) external view returns (bytes32);
-  function canPruneAt(Timestamp _ts) external view returns (bool);
+  function canPrune() external view returns (bool);
   function getProvenBlockNumber() external view returns (uint256);
   function getPendingBlockNumber() external view returns (uint256);
   function getEpochToProve() external view returns (Epoch);
   function getClaimableEpoch() external view returns (Epoch);
   function getEpochForBlock(uint256 blockNumber) external view returns (Epoch);
-  function validateEpochProofRightClaimAtTime(Timestamp _ts, EpochProofQuoteLib.SignedEpochProofQuote calldata _quote)
-    external
-    view;
+  function validateEpochProofRightClaimAtTime(
+    Timestamp _ts,
+    EpochProofQuoteLib.SignedEpochProofQuote calldata _quote
+  ) external view;
   function getEpochProofPublicInputs(
     uint256 _epochSize,
     bytes32[7] calldata _args,

--- a/l1-contracts/src/core/interfaces/IRollup.sol
+++ b/l1-contracts/src/core/interfaces/IRollup.sol
@@ -32,7 +32,6 @@ interface IRollup {
 
   function prune() external;
 
-  function canPrune() external view returns (bool);
 
   function claimEpochProofRight(EpochProofQuoteLib.SignedEpochProofQuote calldata _quote) external;
 
@@ -102,12 +101,13 @@ interface IRollup {
 
   function archive() external view returns (bytes32);
   function archiveAt(uint256 _blockNumber) external view returns (bytes32);
+  function canPruneAt(Timestamp _ts) external view returns (bool);
   function getProvenBlockNumber() external view returns (uint256);
   function getPendingBlockNumber() external view returns (uint256);
   function getEpochToProve() external view returns (Epoch);
   function getClaimableEpoch() external view returns (Epoch);
   function getEpochForBlock(uint256 blockNumber) external view returns (Epoch);
-  function validateEpochProofRightClaim(EpochProofQuoteLib.SignedEpochProofQuote calldata _quote)
+  function validateEpochProofRightClaimAtTime(Timestamp _ts, EpochProofQuoteLib.SignedEpochProofQuote calldata _quote)
     external
     view;
   function getEpochProofPublicInputs(

--- a/yarn-project/archiver/src/archiver/archiver.ts
+++ b/yarn-project/archiver/src/archiver/archiver.ts
@@ -223,7 +223,6 @@ export class Archiver implements ArchiveSource {
     const { l1StartBlock } = this.l1constants;
     const { blocksSynchedTo = l1StartBlock, messagesSynchedTo = l1StartBlock } = await this.store.getSynchPoint();
     const currentL1BlockNumber = await this.publicClient.getBlockNumber();
-    const currentL1Timestamp = BigInt((await this.publicClient.getBlock()).timestamp);
 
     // ********** Ensuring Consistency of data pulled from L1 **********
 
@@ -256,7 +255,7 @@ export class Archiver implements ArchiveSource {
       // blocks from more than 2 epochs ago, so we want to make sure we have the latest view of
       // the chain locally before we start unwinding stuff. This can be optimized by figuring out
       // up to which point we're pruning, and then requesting L2 blocks up to that point only.
-      await this.handleEpochPrune(provenBlockNumber, currentL1Timestamp);
+      await this.handleEpochPrune(provenBlockNumber, currentL1BlockNumber);
     }
 
     // Store latest l1 block number and timestamp seen. Used for epoch and slots calculations.
@@ -267,11 +266,12 @@ export class Archiver implements ArchiveSource {
   }
 
   /** Checks if there'd be a reorg for the next block submission and start pruning now. */
-  private async handleEpochPrune(provenBlockNumber: bigint, currentL1Timestamp: bigint) {
+  private async handleEpochPrune(provenBlockNumber: bigint, currentL1BlockNumber: bigint) {
     const localPendingBlockNumber = BigInt(await this.getBlockNumber());
 
     const canPrune =
-      localPendingBlockNumber > provenBlockNumber && (await this.rollup.read.canPruneAt([currentL1Timestamp]));
+      localPendingBlockNumber > provenBlockNumber &&
+      (await this.rollup.read.canPrune({ blockNumber: currentL1BlockNumber }));
 
     if (canPrune) {
       this.log.verbose(`L2 prune will occur on next submission. Rolling back to last proven block.`);


### PR DESCRIPTION
This is important because by default the simulation uses the time of the previous block.

So without this the proposer in slot `n` will simulate but be told they cannot claim because they were not the proposer in slot `n-1`.

