### PR TITLE
feat: Faster random sampling

### DIFF
--- a/barretenberg/cpp/src/barretenberg/ecc/fields/field_impl.hpp
+++ b/barretenberg/cpp/src/barretenberg/ecc/fields/field_impl.hpp
@@ -691,14 +691,8 @@ template <class T> field<T> field<T>::random_element(numeric::RNG* engine) noexc
     constexpr field pow_2_256 = field(uint256_t(1) << 128).sqr();
     field lo;
     field hi;
-    *(uint256_t*)lo.data = engine->get_random_uint256();
-    *(uint256_t*)hi.data = engine->get_random_uint256();
-    lo.self_reduce_once();
-    lo.self_reduce_once();
-    lo.self_reduce_once();
-    hi.self_reduce_once();
-    hi.self_reduce_once();
-    hi.self_reduce_once();
+    lo = engine->get_random_uint256();
+    hi = engine->get_random_uint256();
     return lo + (pow_2_256 * hi);
 }
 

--- a/barretenberg/cpp/src/barretenberg/numeric/random/engine.cpp
+++ b/barretenberg/cpp/src/barretenberg/numeric/random/engine.cpp
@@ -65,7 +65,7 @@ template <size_t size_in_unsigned_ints> std::array<unsigned int, size_in_unsigne
     }
 
     memcpy(&random_data, random_buffer_wrapper.buffer + random_buffer_wrapper.offset, random_data_buffer_size);
-    random_buffer_wrapper.offset += random_data_buffer_size;
+    random_buffer_wrapper.offset += static_cast<ssize_t>(random_data_buffer_size);
     return random_data;
 }
 } // namespace


### PR DESCRIPTION
This PR:
1. Replaces the mechanism of sampling random data from using random_device to directly using the system APIs
2. Removes an accidental unchecked random field element transformation that got in due to a dirty branch in https://github.com/AztecProtocol/aztec-packages/pull/9627

169x in Native, 35x in wasm
 Before, native:
 ![image](https://github.com/user-attachments/assets/45668f04-8c97-46cf-a363-6529bab1ea02)
After:
![image](https://github.com/user-attachments/assets/44990762-2a84-425e-ab95-fe1ed4cec45a)

Before, wasm:
![image](https://github.com/user-attachments/assets/61ccbf12-5800-49e5-93b3-f729d3b6b927)
After:
![image](https://github.com/user-attachments/assets/a5f42934-5a3c-4d94-9db0-3210c4e25429)
