### PR TITLE
fix: Fix random for Mac users 

### DIFF
--- a/barretenberg/cpp/src/barretenberg/ecc/curves/bn254/fr.test.cpp
+++ b/barretenberg/cpp/src/barretenberg/ecc/curves/bn254/fr.test.cpp
@@ -357,10 +357,7 @@ TEST(fr, BatchInvert)
     }
 
     for (size_t i = 0; i < n; ++i) {
-        EXPECT_EQ(coeffs[i].data[0], 0UL);
-        EXPECT_EQ(coeffs[i].data[1], 0UL);
-        EXPECT_EQ(coeffs[i].data[2], 0UL);
-        EXPECT_EQ(coeffs[i].data[3], 0UL);
+        EXPECT_TRUE(coeffs[i].is_zero());
     }
 }
 


### PR DESCRIPTION
mac doesn't have the getrandom function, but should have getentropy
