### PR TITLE
fix: enable gerousia e2e test

### DIFF
--- a/yarn-project/end-to-end/src/e2e_p2p/gerousia.test.ts
+++ b/yarn-project/end-to-end/src/e2e_p2p/gerousia.test.ts
@@ -48,7 +48,7 @@ describe('e2e_p2p_gerousia', () => {
    * For this reason we are not running it as part of the CI.
    * TODO(https://github.com/AztecProtocol/aztec-packages/issues/9164): Currently flakey
    */
-  it.skip('Should cast votes to upgrade gerousia', async () => {
+  it('Should cast votes to upgrade gerousia', async () => {
     // create the bootstrap node for the network
     if (!t.bootstrapNodeEnr) {
       throw new Error('Bootstrap node ENR is not available');


### PR DESCRIPTION
I ran it 100 times locally with no flake. 

(see `yarn-project/end-to-end/scripts/deflaker.sh`)

fix #9164