### PR TITLE
chore: Fix typos in documentation

### DIFF
--- a/build-images/README.md
+++ b/build-images/README.md
@@ -18,7 +18,7 @@ Your repo will be mounted at `/workspaces/aztec-packages`, and your home directo
 
 ## GitHub Codespaces
 
-This is also compatible with GitHub codespaces. Visit the repo at `http://github.com/aztecprotocol/aztec-packages`.
+This is also compatible with GitHub codespaces. Visit the repo at `https://github.com/aztecprotocol/aztec-packages`.
 Press `.`, and open a terminal window. You will be prompted to create a new machine.
 You can then continue to work within the browser, or reopen the codespace in your local vscode.
 

--- a/build-system/README.md
+++ b/build-system/README.md
@@ -35,7 +35,7 @@ We avoid using any Circle CI specific features. They are very general purpose, a
 
 The build system leverages image names and tags in the docker image registry to keep track of it's historical success or failure in terms of builds, tests, and deployments. It's otherwise stateless, meaning it only needs a container registry to track state.
 
-We work in terms of _contest hashes_, not commit hashes or branches. Content hashes are like commit hashes, but are scoped to files matching the rebuild patterns.
+We work in terms of _content hashes_, not commit hashes or branches. Content hashes are like commit hashes, but are scoped to files matching the rebuild patterns.
 
 There is a `build_manifest.yml` that describes various settings for each project (dependencies, rebuild patterns, etc). The dependencies as listed in the build manifest represent the graph such that if project A changes, all projects that depend on A will also be rebuilt. This likely closely mirrors the workflow graph as defined in Circle CI's `config.yml`. In the future we can generate a target CI platforms configuration from this build manifest.
 

--- a/docs/docs/aztec/concepts/accounts/index.md
+++ b/docs/docs/aztec/concepts/accounts/index.md
@@ -37,7 +37,7 @@ A simple example would be Gnosis Safe (see [_Account Abstraction is NOT coming_]
 
 Ethereum is currently following this approach via [EIP4337](https://eips.ethereum.org/EIPS/eip-4337), an evolution of the [GSN](https://opengsn.org/). This EIP defines a standard method for relaying meta-transactions in a decentralized way, including options for delegating payment to other agents (called paymasters). See [this chart](https://x.com/koeppelmann/status/1632257610455089154) on how 4337 relates to other smart contract wallet efforts.
 
-Implementing AA at the application layer has the main drawback that it's more complex than doing so at the protocol layer. It also leads to duplicated efforts in both layers (eg the wrapper transaction in a meta-transactions still needs to be checked for its ECDSA signature, and then the smart contract wallet needs to verify another set of signatures).
+Implementing AA at the application layer has the main drawback that it's more complex than doing so at the protocol layer. It also leads to duplicated efforts in both layers (e.g. the wrapper transaction in a meta-transactions still needs to be checked for its ECDSA signature, and then the smart contract wallet needs to verify another set of signatures).
 
 Now, there have also been multiple proposals for getting AA implemented at the _protocol_ level in Ethereum. This usually implies introducing a new transaction type or set of opcodes where signature verification and fee payment is handled by the EVM. See EIPs [2803](https://eips.ethereum.org/EIPS/eip-2803), [2938](https://eips.ethereum.org/EIPS/eip-2938), or [3074](https://eips.ethereum.org/EIPS/eip-3074). None of these have gained traction due to the efforts involved in implementing while keeping backwards compatibility.
 
@@ -76,7 +76,7 @@ Read more about how to write an account contract [here](../../../tutorials/codea
 
 ### Account contracts and wallets
 
-Account contracts are tightly coupled to the wallet software that users use to interact with the protocol. Dapps submit to the wallet software one or more function calls to be executed (eg "call swap in X contract"), and the wallet encodes and authenticates the request as a valid payload for the user's account contract. The account contract then validates the request encoded and authenticated by the wallet, and executes the function calls requested by the dapp.
+Account contracts are tightly coupled to the wallet software that users use to interact with the protocol. Dapps submit to the wallet software one or more function calls to be executed (e.g. "call swap in X contract"), and the wallet encodes and authenticates the request as a valid payload for the user's account contract. The account contract then validates the request encoded and authenticated by the wallet, and executes the function calls requested by the dapp.
 
 ### Execution requests
 

--- a/docs/docs/aztec/concepts/accounts/keys.md
+++ b/docs/docs/aztec/concepts/accounts/keys.md
@@ -11,8 +11,8 @@ In short, there is a **nullifier key** (to spend your notes), an **incoming view
 Each account in Aztec is backed by 4 key pairs:
 
 - A **nullifier key pair** used for note nullifier computation, comprising the master nullifier secret key (`nsk_m`) and master nullifier public key (`Npk_m`).
-- A **incoming viewing key pair** used to encrypt a note for the recipient, consisting of the master incoming viewing secret key (`ivsk_m`) and master incoming viewing public key (`Ivpk_m`).
-- A **outgoing viewing key pair** used to encrypt a note for the sender, includes the master outgoing viewing secret key (`ovsk_m`) and master outgoing viewing public key (`Ovpk_m`).
+- An **incoming viewing key pair** used to encrypt a note for the recipient, consisting of the master incoming viewing secret key (`ivsk_m`) and master incoming viewing public key (`Ivpk_m`).
+- An **outgoing viewing key pair** used to encrypt a note for the sender, includes the master outgoing viewing secret key (`ovsk_m`) and master outgoing viewing public key (`Ovpk_m`).
 - A **tagging key pair** used to compute tags in a [tagging note discovery scheme](../../../protocol-specs/private-message-delivery/private-msg-delivery.md#note-tagging), comprising the master tagging secret key (`tsk_m`) and master tagging public key (`Tpk_m`).
 
 :::info
@@ -124,7 +124,7 @@ A compromise between the two solutions above is to use shared state. This would 
 #### Reusing some of the in-protocol keys
 
 It is possible to use some of the key pairs defined in protocol (e.g. incoming viewing keys) as the signing key.
-Since this key is part of the address preimage (more on this on the privacy master key section), you it can be validated against the account contract address rather than having to store it.
+Since this key is part of the address preimage (more on this on the privacy master key section), it can be validated against the account contract address rather than having to store it.
 However, this approach is not recommended since it reduces the security of the user's account.
 
 #### Using a separate keystore

--- a/docs/docs/aztec/concepts/circuits/rollup_circuits/index.md
+++ b/docs/docs/aztec/concepts/circuits/rollup_circuits/index.md
@@ -12,7 +12,7 @@ The way we 'squish' all this data is in a 'binary tree of proofs' topology.
 > Example: If there were 16 txs in a rollup, we'd arrange the 16 kernel proofs into 8 pairs and merge each pair into a single proof (using zk-snark recursion techniques), resulting in 8 output proofs. We'd then arrange those 8 proofs into pairs and again merge each pair into a single proof, resulting in 4 output proofs. And so on until we'd be left with a single proof, which represents the correctness of the original 16 txs.
 > This 'binary tree of proofs' topology allows proof generation to be greatly parallelized across prover instances. Each layer of the tree can be computed in parallel. Or alternatively, subtrees can be coordinated to be computed in parallel.
 
-> Note: 'binary tree of proofs' is actually an over simplification. The Rollup Circuits are designed so that a Sequencer can actually deviate from a neat, symmetrical tree, for the purposes of efficiency, and instead sometimes create wonky trees.
+> Note: 'binary tree of proofs' is actually an oversimplification. The Rollup Circuits are designed so that a Sequencer can actually deviate from a neat, symmetrical tree, for the purposes of efficiency, and instead sometimes create wonky trees.
 
 Some of the Rollup Circuits also do some protocol checks and computations, for efficiency reasons. We might rearrange which circuit does what computation, as we discover opportunities for efficiency.
 

--- a/docs/docs/aztec/concepts/communication/cross_chain_calls.md
+++ b/docs/docs/aztec/concepts/communication/cross_chain_calls.md
@@ -13,7 +13,7 @@ import Image from "@theme/IdealImage";
 
 In Aztec, what we call _portals_ are the key element in facilitating communication between L1 and L2. While typical L2 solutions rely on synchronous communication with L1, Aztec's privacy-first nature means this is not possible. You can learn more about why in the previous section.
 
-Traditional L1 \<-\> L2 communication might involve direct calls between L2 nd L1 contracts. However, in Aztec, due to the privacy components and the way transactions are processed (kernel proofs built on historical data), direct calls between L1 and L2 would not be possible if we want to maintain privacy.
+Traditional L1 \<-\> L2 communication might involve direct calls between L2 and L1 contracts. However, in Aztec, due to the privacy components and the way transactions are processed (kernel proofs built on historical data), direct calls between L1 and L2 would not be possible if we want to maintain privacy.
 
 Portals are the solution to this problem, acting as bridges for communication between the two layers. These portals can transmit messages from public functions in L1 to private functions in L2 and vice versa, thus enabling messaging while maintaining privacy.
 
@@ -108,7 +108,7 @@ For the sake of cross-chain messages, this means inserting and nullifying L1 $\r
 While a message could theoretically be arbitrarily long, we want to limit the cost of the insertion on L1 as much as possible. Therefore, we allow the users to send 32 bytes of "content" between L1 and L2. If 32 suffices, no packing required. If the 32 is too "small" for the message directly, the sender should simply pass along a `sha256(content)` instead of the content directly (note that this hash should fit in a field element which is ~254 bits. More info on this below). The content can then either be emitted as an event on L2 or kept by the sender, who should then be the only entity that can "unpack" the message.
 In this manner, there is some way to "unpack" the content on the receiving domain.
 
-The message that is passed along, require the `sender/recipient` pair to be communicated as well (we need to know who should receive the message and be able to check). By having the pending messages be a contract on L1, we can ensure that the `sender = msg.sender` and let only `content` and `recipient` be provided by the caller. Summing up, we can use the struct's seen below, and only store the commitment (`sha256(LxToLyMsg)`) on chain or in the trees, this way, we need only update a single storage slot per message.
+The message that is passed along, require the `sender/recipient` pair to be communicated as well (we need to know who should receive the message and be able to check). By having the pending messages be a contract on L1, we can ensure that the `sender = msg.sender` and let only `content` and `recipient` be provided by the caller. Summing up, we can use the structs seen below, and only store the commitment (`sha256(LxToLyMsg)`) on chain or in the trees, this way, we need only update a single storage slot per message.
 
 ```solidity
 struct L1Actor {

--- a/docs/docs/aztec/concepts/state_model/index.md
+++ b/docs/docs/aztec/concepts/state_model/index.md
@@ -20,7 +20,7 @@ Private state is encrypted and therefore is "owned" by a user or a set of users 
 
 Private state is represented in an append-only database since updating a record would leak information about the transaction graph.
 
-The act of "deleting" a private satate variable can be represented by adding an associated nullifier to a nullifier set. The nullifier is generated such that, without knowing the decryption key of the owner, an observer cannot link a state record with a nullifier.
+The act of "deleting" a private state variable can be represented by adding an associated nullifier to a nullifier set. The nullifier is generated such that, without knowing the decryption key of the owner, an observer cannot link a state record with a nullifier.
 
 Modification of state variables can be emulated by nullifying the state record and creating a new record to represent the variable. Private state has an intrinsic UTXO structure and this must be represented in the language semantics of manipulating private state.
 

--- a/docs/docs/aztec/concepts/storage/trees/indexed_merkle_tree.mdx
+++ b/docs/docs/aztec/concepts/storage/trees/indexed_merkle_tree.mdx
@@ -30,7 +30,7 @@ The content was also covered in a presentation for the [Privacy + Scaling Explor
 
 ## Primer on Nullifier Trees
 
-Currently the only feasible way to get privacy in public blockchains is via a UTXO model. In this model, state is stored in encrypted UTXO's in merkle trees. However, to maintain privacy, state can not be updated. The very act of performing an update leaks information. In order to simulate "updating" the state, we "destroy" old UTXO's and create new ones for each state update. Resulting in a merkle tree that is append-only.
+Currently the only feasible way to get privacy in public blockchains is via a UTXO model. In this model, state is stored in encrypted UTXO's in merkle trees. However, to maintain privacy, state cannot be updated. The very act of performing an update leaks information. In order to simulate "updating" the state, we "destroy" old UTXO's and create new ones for each state update. Resulting in a merkle tree that is append-only.
 
 A classic merkle tree:
 
@@ -219,7 +219,7 @@ In the following example we insert a subtree of size 4 into our tree at step 4. 
 
 #### Performance gains from subtree insertion
 
-Lets go back over the numbers:
+Let's go back over the numbers:
 Insertions into a sparse nullifier tree involve 1 non membership check (254 hashes) and 1 insertion (254 hashes). If we were performing insertion for 4 values that would entail 2032 hashes.
 In the depth 32 indexed tree construction, each subtree insertion costs 1 non membership check (32 hashes), 1 pointer update (32 hashes) for each value as well as the cost of constructing and inserting a subtree (~67 hashes. Which is 327 hashes, an incredible efficiency increase.)
 

--- a/docs/docs/aztec/concepts/wallets/architecture.md
+++ b/docs/docs/aztec/concepts/wallets/architecture.md
@@ -3,7 +3,7 @@ title: Wallet Architecture
 tags: [protocol, accounts]
 ---
 
-This page talks about the architecture of a wallet in Aztec. Wallets expose to dapps an interface that allows them to act on behalf of the user, such as querying private state or sending transactions. Bear mind that, as in Ethereum, wallets should require user confirmation whenever carrying out a potentially sensitive action requested by a dapp.
+This page talks about the architecture of a wallet in Aztec. Wallets expose to dapps an interface that allows them to act on behalf of the user, such as querying private state or sending transactions. Bear in mind that, as in Ethereum, wallets should require user confirmation whenever carrying out a potentially sensitive action requested by a dapp.
 
 ## Overview
 
@@ -23,6 +23,6 @@ The account interface is used for creating an _execution request_ out of one or 
 
 ## PXE interface
 
-A wallet exposes the PXE interface to dapps by running an PXE instance. The PXE requires a keystore and a database implementation for storing keys, private state, and recipient encryption public keys.
+A wallet exposes the PXE interface to dapps by running a PXE instance. The PXE requires a keystore and a database implementation for storing keys, private state, and recipient encryption public keys.
 
 #include_code pxe-interface /yarn-project/circuit-types/src/interfaces/pxe.ts typescript

--- a/docs/docs/aztec/concepts/wallets/index.md
+++ b/docs/docs/aztec/concepts/wallets/index.md
@@ -4,7 +4,7 @@ sidebar_position: 1
 tags: [accounts]
 ---
 
-In this page we will cover the main responsibilities of a wallet in the Aztec network.
+On this page we will cover the main responsibilities of a wallet in the Aztec network.
 
 Refer to [writing an account contract](../../../tutorials/codealong/contract_tutorials/write_accounts_contract.md) for a tutorial on how to write a contract to back a user's account.
 

--- a/docs/docs/aztec/how_to_participate.md
+++ b/docs/docs/aztec/how_to_participate.md
@@ -18,5 +18,5 @@ Decentralization is one of our core values, so we want to encourage participatio
 
 ## Grants
 
-- The Aztec Labs Grants Program supports developers building with, and contributing to, the Noir programming language and the Aztec network. Applications can submitted on the [Grants page](https://aztec.network/grants/) of the Aztec website. 
+- The Aztec Labs Grants Program supports developers building with, and contributing to, the Noir programming language and the Aztec network. Applications can be submitted on the [Grants page](https://aztec.network/grants/) of the Aztec website. 
 - We are currently operating with a retroactive grants funding model, and we strive to respond back to grants applications with a decision within a few days. Check out our [grants page](https://aztec.network/grants/) for more information

--- a/docs/docs/aztec/smart_contracts/functions/attributes.md
+++ b/docs/docs/aztec/smart_contracts/functions/attributes.md
@@ -77,7 +77,7 @@ This function takes the application context, and converts it into the `PrivateCi
 
 ## Unconstrained functions
 
-Unconstrained functions are an underlying part of Noir. In short, they are functions which are not directly constrained and therefore should be seen as un-trusted. That they are un-trusted means that the developer must make sure to constrain their return values when used. Note: Calling an unconstrained function from a private function means that you are injecting unconstrained values.
+Unconstrained functions are an underlying part of Noir. In short, they are functions which are not directly constrained and therefore should be seen as untrusted. That they are un-trusted means that the developer must make sure to constrain their return values when used. Note: Calling an unconstrained function from a private function means that you are injecting unconstrained values.
 
 Defining a function as `unconstrained` tells Aztec to simulate it completely client-side in the [ACIR simulator](../../concepts/pxe/index.md) without generating proofs. They are useful for extracting information from a user through an [oracle](../oracles/index.md).
 

--- a/docs/docs/aztec/smart_contracts/functions/context.md
+++ b/docs/docs/aztec/smart_contracts/functions/context.md
@@ -6,9 +6,9 @@ tags: [functions, context]
 
 ## What is the context
 
-The context is an object that is made available within every function in `Aztec.nr`. As mentioned in the [kernel circuit documentation](../../concepts/circuits/kernels/private_kernel.md). At the beginning of a function's execution, the context contains all of the kernel information that application needs to execute. During the lifecycle of a transaction, the function will update the context with each of it's side effects (created notes, nullifiers etc.). At the end of a function's execution the mutated context is returned to the kernel to be checked for validity.
+The context is an object that is made available within every function in `Aztec.nr`. As mentioned in the [kernel circuit documentation](../../concepts/circuits/kernels/private_kernel.md). At the beginning of a function's execution, the context contains all of the kernel information that application needs to execute. During the lifecycle of a transaction, the function will update the context with each of its side effects (created notes, nullifiers etc.). At the end of a function's execution the mutated context is returned to the kernel to be checked for validity.
 
-Behind the scenes, Aztec.nr will pass data the kernel needs to and from a circuit, this is abstracted away from the developer. In an developer's eyes; the context is a useful structure that allows access and mutate the state of the `Aztec` blockchain.
+Behind the scenes, Aztec.nr will pass data the kernel needs to and from a circuit, this is abstracted away from the developer. In a developer's eyes; the context is a useful structure that allows access and mutate the state of the `Aztec` blockchain.
 
 On this page, you'll learn
 

--- a/docs/docs/aztec/smart_contracts/functions/index.md
+++ b/docs/docs/aztec/smart_contracts/functions/index.md
@@ -7,7 +7,7 @@ Functions serve as the building blocks of smart contracts. Functions can be eith
 
 For a more practical guide of using multiple types of functions, follow the [token tutorial](../../../tutorials/codealong/contract_tutorials/token_contract.md).
 
-Currently, any function is "mutable" in the sense that it might alter state. However, we also support support static calls, similarly to EVM. A static call is essentially a call that does not alter state (it keeps state static).
+Currently, any function is "mutable" in the sense that it might alter state. However, we also support static calls, similarly to EVM. A static call is essentially a call that does not alter state (it keeps state static).
 
 ## Initializer functions
 

--- a/docs/docs/aztec/smart_contracts/functions/visibility.md
+++ b/docs/docs/aztec/smart_contracts/functions/visibility.md
@@ -6,7 +6,7 @@ tags: [functions]
 
 In Aztec there are multiple different types of visibility that can be applied to functions. Namely we have `data visibility` and `function visibility`. This page explains these types of visibility.
 
-For a practical guide of using multiple types of data and function visibility,follow the [token tutorial](../../../tutorials/codealong/contract_tutorials/token_contract.md). 
+For a practical guide of using multiple types of data and function visibility, follow the [token tutorial](../../../tutorials/codealong/contract_tutorials/token_contract.md). 
 
 ### Data Visibility
 

--- a/docs/docs/aztec/smart_contracts_overview.md
+++ b/docs/docs/aztec/smart_contracts_overview.md
@@ -19,7 +19,7 @@ A "smart contract" is defined as a set of public and private functions written a
 
 [Noir](https://noir-lang.org) is a programming language designed for converting high-level programs into ZK circuits. Based on Rust, the goal is to present an idiomatic way of writing private smart contracts that is familiar to Ethereum developers. Noir is under active development adding features such as contracts, functions and storage variables.
 
-The end goal is a language that is intuitive to use for developers with no cryptographic knowledge and empowers developers to easily write programable private smart contracts.
+The end goal is a language that is intuitive to use for developers with no cryptographic knowledge and empowers developers to easily write programmable private smart contracts.
 
 There are no plans for EVM compatibility or to support Solidity in Aztec. The privacy-first nature of Aztec is fundamentally incompatible with the EVM architecture and Solidity's semantics. In addition, the heavy use of client-side proof construction makes this impractical.
 

--- a/docs/docs/guides/developer_guides/js_apps/authwit.md
+++ b/docs/docs/guides/developer_guides/js_apps/authwit.md
@@ -85,7 +85,7 @@ Create a private authwit like this:
 In this example,
 
 - `wallets[0]` is the authwit giver
-- `wallets[1]` is the authwit reciever and caller of the function
+- `wallets[1]` is the authwit receiver and caller of the function
 - `action` was [defined previously](#define-the-action)
 
 If you created an arbitrary message, you can create the authwit by replacing these params with the outer hash:


### PR DESCRIPTION
This pull request corrects a number of typos across various documentation files.

- **Total corrections**: 17 typos and grammatical issues.

For clarity, here are a few examples:
![image](https://github.com/user-attachments/assets/af43ad08-e417-473a-96b9-9eca51ce3965)
![image](https://github.com/user-attachments/assets/22ae80d7-20ec-4d74-a767-dd19f39cd9dd)
![image](https://github.com/user-attachments/assets/8caeb8bc-8799-4612-9977-4bcdbffc1335)