### PR TITLE
chore: switch to installing published binaries of foundry

### DIFF
--- a/barretenberg/acir_tests/Dockerfile.bb.sol
+++ b/barretenberg/acir_tests/Dockerfile.bb.sol
@@ -10,7 +10,7 @@ COPY --from=noir-acir-tests /usr/src/noir/noir-repo/test_programs /usr/src/noir/
 
 RUN curl -L https://foundry.paradigm.xyz | bash
 ENV PATH="${PATH}:/root/.foundry/bin"
-RUN foundryup
+RUN foundryup -v nightly-25f24e677a6a32a62512ad4f561995589ac2c7dc
 
 WORKDIR /usr/src/barretenberg/acir_tests
 COPY . .

--- a/barretenberg/sol/Dockerfile
+++ b/barretenberg/sol/Dockerfile
@@ -40,7 +40,7 @@ COPY ./sol .
 # Download and install foundry
 RUN curl -L https://foundry.paradigm.xyz | bash
 ENV PATH="${PATH}:/root/.foundry/bin"
-RUN foundryup
+RUN foundryup -v nightly-25f24e677a6a32a62512ad4f561995589ac2c7dc
 
 RUN cd ../cpp/srs_db && ./download_ignition.sh 3 && cd ../../sol
 

--- a/bootstrap.sh
+++ b/bootstrap.sh
@@ -74,10 +74,9 @@ function check_toolchains {
     if ! $tool --version 2> /dev/null | grep 25f24e6 > /dev/null; then
       encourage_dev_container
       echo "$tool not in PATH or incorrect version (requires 25f24e677a6a32a62512ad4f561995589ac2c7dc)."
-      echo "Installation: https://book.getfoundry.sh/getting-started/installation (requires rust 1.79+)"
-      echo "  rustup toolchain install 1.79"
+      echo "Installation: https://book.getfoundry.sh/getting-started/installation"
       echo "  curl -L https://foundry.paradigm.xyz | bash"
-      echo "  foundryup -b 25f24e677a6a32a62512ad4f561995589ac2c7dc"
+      echo "  foundryup -v nightly-25f24e677a6a32a62512ad4f561995589ac2c7dc"
       exit 1
     fi
   done

--- a/yarn-project/end-to-end/Dockerfile
+++ b/yarn-project/end-to-end/Dockerfile
@@ -39,7 +39,7 @@ RUN rm -rf /usr/src/noir-projects /usr/src/l1-contracts
 
 # Anvil. Hacky, but can't be bothered handling foundry image as we're moving to earthly.
 RUN curl -L https://foundry.paradigm.xyz | bash
-RUN /root/.foundry/bin/foundryup --version nightly-25f24e677a6a32a62512ad4f561995589ac2c7dc && mkdir -p /usr/src/foundry/bin && cp /root/.foundry/bin/anvil /usr/src/foundry/bin/anvil
+RUN /root/.foundry/bin/foundryup -v nightly-25f24e677a6a32a62512ad4f561995589ac2c7dc && mkdir -p /usr/src/foundry/bin && cp /root/.foundry/bin/anvil /usr/src/foundry/bin/anvil
 
 # Create minimal image.
 FROM node:18.19.1-slim


### PR DESCRIPTION
The nightly version of foundry we're using appears to publish arm64 binaries so it seems like it shouldn't be necessary to build from source anymore. I've updated any `foundryup` calls to pull this nightly release.