### PR TITLE
chore: update `redo-typo-pr` to squash multi-commit PRs

### DIFF
--- a/scripts/redo-typo-pr
+++ b/scripts/redo-typo-pr
@@ -10,22 +10,27 @@ AUTHOR=`gh pr view $ORIGINAL_PR_NUMBER --json author --jq '.author.login'`
 
 # Step 1: Checkout the PR locally
 echo "Checking out PR #$ORIGINAL_PR_NUMBER"
-gh pr checkout $ORIGINAL_PR_NUMBER
+gh pr checkout $ORIGINAL_PR_NUMBER --branch "typo-pr-branch"
 
-# Step 2: Create a new local branch
+# Step 2: Create squash commit on master
+echo "Squashing PR branch onto master"
+git checkout master
+git merge "typo-pr-branch" --squash
+
+# Step 3: Commit squash commit to new branch
 echo "Creating new local branch $NEW_BRANCH"
 git checkout -b $NEW_BRANCH
+git commit -a --author="AztecBot <tech@aztecprotocol.com>" -m "chore: redo typo PR"
 
-# Step 3: Push the new branch to GitHub
+# Step 4: Push the new branch to GitHub
 echo "Pushing new branch $NEW_BRANCH to GitHub"
-git commit --amend --author="AztecBot <tech@aztecprotocol.com>" --no-edit
 git push origin $NEW_BRANCH
 
-# Step 4: create a new pull request
+# Step 5: create a new pull request
 echo "Creating a new pull request for $NEW_BRANCH"
 gh pr create --base master --head $NEW_BRANCH --title "chore: redo typo PR by $AUTHOR" --body "Thanks $AUTHOR for https://github.com/$REPO/pull/$ORIGINAL_PR_NUMBER. Our policy is to redo typo changes to dissuade metric farming. This is an automated script."
 
-# Step 5: Close the original PR
+# Step 6: Close the original PR
 echo "Closing original PR #$ORIGINAL_PR_NUMBER"
 gh pr close $ORIGINAL_PR_NUMBER
 


### PR DESCRIPTION
The current typo PR script only rewrites the last commit on the typo PR branch which allows it to be evaded by just having multiple commits in your typo PR. This PR squashes the branch into a single commit before updating the commit author to aztecbot to address this.