### PR TITLE
chore: More permissive expected json parse error msg

### DIFF
--- a/yarn-project/foundation/src/json-rpc/server/safe_json_rpc_server.test.ts
+++ b/yarn-project/foundation/src/json-rpc/server/safe_json_rpc_server.test.ts
@@ -75,7 +75,7 @@ describe('SafeJsonRpcServer', () => {
 
     it('fails if sends invalid JSON', async () => {
       const response = await send('{');
-      expectError(response, 400, 'Parse error: Unexpected end of JSON input');
+      expectError(response, 400, expect.stringContaining('Parse error'));
     });
 
     it('fails if calls non-existing method in handler', async () => {


### PR DESCRIPTION
Different versions of node have different error messages when JSON parse fails, so this test would work in node 18 but fail in 20. So we change the expectation to accept any parse error message. This was affecting devs that were running node 20 in their dev boxes.