### PR TITLE
chore: update boundary in test

### DIFF
--- a/l1-contracts/test/Rollup.t.sol
+++ b/l1-contracts/test/Rollup.t.sol
@@ -266,16 +266,18 @@ contract RollupTest is DecoderBase {
     );
   }
 
-  function testMissingProofSlashesBond(uint256 slotsToJump) public setUpFor("mixed_block_1") {
-    // @note, this gives a an overflow if bounding to type(uint256).max
-    // Tracked by https://github.com/AztecProtocol/aztec-packages/issues/9362
-    slotsToJump =
-      bound(slotsToJump, 2 * Constants.AZTEC_EPOCH_DURATION, 1e20 * Constants.AZTEC_EPOCH_DURATION);
+  function testMissingProofSlashesBond(uint256 _slotToHit) public setUpFor("mixed_block_1") {
+    Slot lower = rollup.getCurrentSlot() + Slot.wrap(2 * Constants.AZTEC_EPOCH_DURATION);
+    Slot upper = Slot.wrap(
+      (type(uint256).max - Timestamp.unwrap(rollup.GENESIS_TIME())) / rollup.SLOT_DURATION()
+    );
+    Slot slotToHit = Slot.wrap(bound(_slotToHit, lower.unwrap(), upper.unwrap()));
+
     _testBlock("mixed_block_1", false, 1);
     rollup.claimEpochProofRight(signedQuote);
-    warpToL2Slot(slotsToJump);
+    warpToL2Slot(slotToHit.unwrap());
     rollup.prune();
-    _testBlock("mixed_block_1", true, slotsToJump);
+    _testBlock("mixed_block_1", true, slotToHit.unwrap());
 
     assertEq(
       proofCommitmentEscrow.deposits(quote.prover), 9 * quote.bondAmount, "Invalid escrow balance"

--- a/l1-contracts/test/governance/governance-proposer/pushProposal.t.sol
+++ b/l1-contracts/test/governance/governance-proposer/pushProposal.t.sol
@@ -52,24 +52,20 @@ contract PushProposalTest is GovernanceProposerBase {
     _;
   }
 
-  function test_WhenRoundTooFarInPast(uint256 _slotsToJump)
+  function test_WhenRoundTooFarInPast(uint256 _slotToHit)
     external
     givenCanonicalInstanceHoldCode
     whenRoundInPast
   {
     // it revert
 
-    uint256 lower = Timestamp.unwrap(
-      leonidas.getTimestampForSlot(
-        leonidas.getCurrentSlot()
-          + Slot.wrap(governanceProposer.M() * governanceProposer.LIFETIME_IN_ROUNDS() + 1)
-      )
+    Slot lower = leonidas.getCurrentSlot()
+      + Slot.wrap(governanceProposer.M() * governanceProposer.LIFETIME_IN_ROUNDS() + 1);
+    Slot upper = Slot.wrap(
+      (type(uint256).max - Timestamp.unwrap(leonidas.GENESIS_TIME())) / leonidas.SLOT_DURATION()
     );
-    uint256 upper =
-      (type(uint256).max - Timestamp.unwrap(leonidas.GENESIS_TIME())) / leonidas.SLOT_DURATION();
-    uint256 time = bound(_slotsToJump, lower, upper);
-
-    vm.warp(time);
+    Slot slotToHit = Slot.wrap(bound(_slotToHit, lower.unwrap(), upper.unwrap()));
+    vm.warp(Timestamp.unwrap(leonidas.getTimestampForSlot(slotToHit)));
 
     vm.expectRevert(
       abi.encodeWithSelector(


### PR DESCRIPTION
Fixes #9362.

The boundary don't support using `type(uint256).max`, since the value is a slot and not a timestamp. So when the timestamp is to be computed from the slot we end up multiplying by the slot duration and adding the genesis time (so if slot number is large, it will overflow). `slot * slot_duration + genesis_time`. 

Instead, we can do similar to what was done in `pushProposal.t.sol` for a computation of the limits. Both are updated to keep it aligned and easier to read.