### PR TITLE
fix: otel log batching

### DIFF
--- a/yarn-project/end-to-end/scripts/e2e_test_config.yml
+++ b/yarn-project/end-to-end/scripts/e2e_test_config.yml
@@ -101,25 +101,6 @@ tests:
     test_path: 'guides/writing_an_account_contract.test.ts'
   integration_l1_publisher:
     use_compose: true
-  kind_network_4epochs:
-    env:
-      NAMESPACE: 'smoke'
-      FRESH_INSTALL: 'true'
-      VALUES_FILE: '$-default.yaml'
-    command: './scripts/network_test.sh ./src/spartan/4epochs.test.ts'
-    ignore_failures: true
-  kind_network_smoke:
-    env:
-      NAMESPACE: 'smoke'
-      FRESH_INSTALL: 'true'
-      VALUES_FILE: '$-default.yaml'
-    command: './scripts/network_test.sh ./src/spartan/smoke.test.ts'
-  kind_network_transfer:
-    env:
-      NAMESPACE: 'transfer'
-      FRESH_INSTALL: 'true'
-      VALUES_FILE: '$-default.yaml'
-    command: './scripts/network_test.sh ./src/spartan/transfer.test.ts'
   pxe:
     use_compose: true
   uniswap_trade_on_l1_from_l2:

--- a/yarn-project/telemetry-client/package.json
+++ b/yarn-project/telemetry-client/package.json
@@ -33,6 +33,7 @@
     "@opentelemetry/exporter-metrics-otlp-http": "^0.52.0",
     "@opentelemetry/exporter-trace-otlp-http": "^0.54.0",
     "@opentelemetry/host-metrics": "^0.35.2",
+    "@opentelemetry/otlp-exporter-base": "^0.54.0",
     "@opentelemetry/resource-detector-aws": "^1.5.2",
     "@opentelemetry/resources": "^1.25.0",
     "@opentelemetry/sdk-logs": "^0.54.0",

--- a/yarn-project/telemetry-client/src/otel.ts
+++ b/yarn-project/telemetry-client/src/otel.ts
@@ -120,7 +120,7 @@ export class OpenTelemetryClient implements TelemetryClient {
         }),
       ],
     });
-    const loggerProvider = registerOtelLoggerProvider(logsCollector);
+    const loggerProvider = registerOtelLoggerProvider(resource, logsCollector);
 
     const service = new OpenTelemetryClient(resource, meterProvider, tracerProvider, loggerProvider, log);
     service.start();

--- a/yarn-project/telemetry-client/src/otelLoggerProvider.ts
+++ b/yarn-project/telemetry-client/src/otelLoggerProvider.ts
@@ -1,18 +1,29 @@
 import { logs as otelLogs } from '@opentelemetry/api-logs';
 import { OTLPLogExporter } from '@opentelemetry/exporter-logs-otlp-http';
-import { LoggerProvider, SimpleLogRecordProcessor } from '@opentelemetry/sdk-logs';
+import { CompressionAlgorithm } from '@opentelemetry/otlp-exporter-base';
+import { type IResource } from '@opentelemetry/resources';
+import { BatchLogRecordProcessor, LoggerProvider } from '@opentelemetry/sdk-logs';
 
-export function registerOtelLoggerProvider(otelLogsUrl?: URL) {
-  const loggerProvider = new LoggerProvider();
+export function registerOtelLoggerProvider(resource: IResource, otelLogsUrl?: URL) {
+  const loggerProvider = new LoggerProvider({ resource });
   if (!otelLogsUrl) {
     // If no URL provided, return it disconnected.
     return loggerProvider;
   }
   const logExporter = new OTLPLogExporter({
+    compression: CompressionAlgorithm.GZIP,
     url: otelLogsUrl.href,
   });
   // Add a processor to the logger provider
-  loggerProvider.addLogRecordProcessor(new SimpleLogRecordProcessor(logExporter));
+  loggerProvider.addLogRecordProcessor(
+    new BatchLogRecordProcessor(logExporter, {
+      /** The maximum batch size of every export. It must be smaller or equal to
+       * maxQueueSize. */
+      maxExportBatchSize: 1024,
+      /** The maximum queue size. After the size is reached log records are dropped. */
+      maxQueueSize: 4096,
+    }),
+  );
   otelLogs.setGlobalLoggerProvider(loggerProvider);
 
   return loggerProvider;

--- a/yarn-project/yarn.lock
+++ b/yarn-project/yarn.lock
@@ -1162,6 +1162,7 @@ __metadata:
     "@opentelemetry/exporter-metrics-otlp-http": ^0.52.0
     "@opentelemetry/exporter-trace-otlp-http": ^0.54.0
     "@opentelemetry/host-metrics": ^0.35.2
+    "@opentelemetry/otlp-exporter-base": ^0.54.0
     "@opentelemetry/resource-detector-aws": ^1.5.2
     "@opentelemetry/resources": ^1.25.0
     "@opentelemetry/sdk-logs": ^0.54.0
@@ -3583,7 +3584,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@opentelemetry/otlp-exporter-base@npm:0.54.0":
+"@opentelemetry/otlp-exporter-base@npm:0.54.0, @opentelemetry/otlp-exporter-base@npm:^0.54.0":
   version: 0.54.0
   resolution: "@opentelemetry/otlp-exporter-base@npm:0.54.0"
   dependencies:


### PR DESCRIPTION
- pass our resource metadata object to otel logging
- use gzip
- use the batched exporter
- double the batch size on batch exporter
- Bundled some e2e cleanup

Trying to clear out issues with a 48 validator setup:

```
{"stack":"Error: Concurrent export limit reached\n    at OTLPLogExporter.export (/usr/src/yarn-project/node_modules/@opentelemetry/otlp-exporter-base/build/src/OTLPExporterBase.js:53:24)\n    at /usr/src/yarn-project/node_modules/@opentelemetry/sdk-logs/node_modules/@opentelemetry/core/build/src/internal/exporter.js:29:28\n    at AsyncLocalStorage.run (node:async_hooks:338:14)\n    at AsyncLocalStorageContextManager.with (/usr/src/yarn-project/node_modules/@opentelemetry/context-async-hooks/build/src/AsyncLocalStorageContextManager.js:33:40)\n    at ContextAPI.with (/usr/src/yarn-project/node_modules/@opentelemetry/api/build/src/api/context.js:60:46)\n    at /usr/src/yarn-project/node_modules/@opentelemetry/sdk-logs/node_modules/@opentelemetry/core/build/src/internal/exporter.js:28:27\n    at new Promise (<anonymous>)\n    at Object._export (/usr/src/yarn-project/node_modules/@opentelemetry/sdk-logs/node_modules/@opentelemetry/core/build/src/internal/exporter.js:26:12)\n    at doExport (/usr/src/yarn-project/node_modules/@opentelemetry/sdk-logs/build/src/export/SimpleLogRecordProcessor.js:32:14)\n    at SimpleLogRecordProcessor.onEmit (/usr/src/yarn-project/node_modules/@opentelemetry/sdk-logs/build/src/export/SimpleLogRecordProcessor.js:55:18)","message":"Concurrent export limit reached","name":"Error"}
```