### PR TITLE
feat: add canPruneAtTime

### DIFF
--- a/l1-contracts/src/core/interfaces/IRollup.sol
+++ b/l1-contracts/src/core/interfaces/IRollup.sol
@@ -101,6 +101,7 @@ interface IRollup {
   function archive() external view returns (bytes32);
   function archiveAt(uint256 _blockNumber) external view returns (bytes32);
   function canPrune() external view returns (bool);
+  function canPruneAtTime(Timestamp _ts) external view returns (bool);
   function getProvenBlockNumber() external view returns (uint256);
   function getPendingBlockNumber() external view returns (uint256);
   function getEpochToProve() external view returns (Epoch);

--- a/l1-contracts/test/Rollup.t.sol
+++ b/l1-contracts/test/Rollup.t.sol
@@ -266,16 +266,18 @@ contract RollupTest is DecoderBase {
     );
   }
 
-  function testMissingProofSlashesBond(uint256 slotsToJump) public setUpFor("mixed_block_1") {
-    // @note, this gives a an overflow if bounding to type(uint256).max
-    // Tracked by https://github.com/AztecProtocol/aztec-packages/issues/9362
-    slotsToJump =
-      bound(slotsToJump, 2 * Constants.AZTEC_EPOCH_DURATION, 1e20 * Constants.AZTEC_EPOCH_DURATION);
+  function testMissingProofSlashesBond(uint256 _slotToHit) public setUpFor("mixed_block_1") {
+    Slot lower = rollup.getCurrentSlot() + Slot.wrap(2 * Constants.AZTEC_EPOCH_DURATION);
+    Slot upper = Slot.wrap(
+      (type(uint256).max - Timestamp.unwrap(rollup.GENESIS_TIME())) / rollup.SLOT_DURATION()
+    );
+    Slot slotToHit = Slot.wrap(bound(_slotToHit, lower.unwrap(), upper.unwrap()));
+
     _testBlock("mixed_block_1", false, 1);
     rollup.claimEpochProofRight(signedQuote);
-    warpToL2Slot(slotsToJump);
+    warpToL2Slot(slotToHit.unwrap());
     rollup.prune();
-    _testBlock("mixed_block_1", true, slotsToJump);
+    _testBlock("mixed_block_1", true, slotToHit.unwrap());
 
     assertEq(
       proofCommitmentEscrow.deposits(quote.prover), 9 * quote.bondAmount, "Invalid escrow balance"

--- a/l1-contracts/test/Rollup.t.sol
+++ b/l1-contracts/test/Rollup.t.sol
@@ -418,9 +418,7 @@ contract RollupTest is DecoderBase {
     (bytes32 preArchive, bytes32 preBlockHash,) = rollup.blocks(0);
     _submitEpochProof(rollup, 1, preArchive, archive, preBlockHash, blockHash, proverId);
 
-    vm.expectRevert(
-      abi.encodeWithSelector(Errors.Rollup__InvalidPreviousArchive.selector, archive, preArchive)
-    );
+    vm.expectRevert(abi.encodeWithSelector(Errors.Rollup__InvalidBlockNumber.selector, 1, 2));
     _submitEpochProof(rollup, 1, preArchive, archive, preBlockHash, blockHash, proverId);
   }
 

--- a/l1-contracts/test/governance/governance-proposer/pushProposal.t.sol
+++ b/l1-contracts/test/governance/governance-proposer/pushProposal.t.sol
@@ -52,24 +52,20 @@ contract PushProposalTest is GovernanceProposerBase {
     _;
   }
 
-  function test_WhenRoundTooFarInPast(uint256 _slotsToJump)
+  function test_WhenRoundTooFarInPast(uint256 _slotToHit)
     external
     givenCanonicalInstanceHoldCode
     whenRoundInPast
   {
     // it revert
 
-    uint256 lower = Timestamp.unwrap(
-      leonidas.getTimestampForSlot(
-        leonidas.getCurrentSlot()
-          + Slot.wrap(governanceProposer.M() * governanceProposer.LIFETIME_IN_ROUNDS() + 1)
-      )
+    Slot lower = leonidas.getCurrentSlot()
+      + Slot.wrap(governanceProposer.M() * governanceProposer.LIFETIME_IN_ROUNDS() + 1);
+    Slot upper = Slot.wrap(
+      (type(uint256).max - Timestamp.unwrap(leonidas.GENESIS_TIME())) / leonidas.SLOT_DURATION()
     );
-    uint256 upper =
-      (type(uint256).max - Timestamp.unwrap(leonidas.GENESIS_TIME())) / leonidas.SLOT_DURATION();
-    uint256 time = bound(_slotsToJump, lower, upper);
-
-    vm.warp(time);
+    Slot slotToHit = Slot.wrap(bound(_slotToHit, lower.unwrap(), upper.unwrap()));
+    vm.warp(Timestamp.unwrap(leonidas.getTimestampForSlot(slotToHit)));
 
     vm.expectRevert(
       abi.encodeWithSelector(

--- a/yarn-project/archiver/src/archiver/archiver.test.ts
+++ b/yarn-project/archiver/src/archiver/archiver.test.ts
@@ -6,7 +6,7 @@ import {
   LogType,
   UnencryptedL2BlockL2Logs,
 } from '@aztec/circuit-types';
-import { GENESIS_ARCHIVE_ROOT } from '@aztec/circuits.js';
+import { ETHEREUM_SLOT_DURATION, GENESIS_ARCHIVE_ROOT } from '@aztec/circuits.js';
 import { EthAddress } from '@aztec/foundation/eth-address';
 import { Fr } from '@aztec/foundation/fields';
 import { sleep } from '@aztec/foundation/sleep';
@@ -60,7 +60,7 @@ describe('Archiver', () => {
     now = +new Date();
     publicClient = mock<PublicClient<HttpTransport, Chain>>({
       getBlock: ((args: any) => ({
-        timestamp: args.blockNumber * 1000n + BigInt(now),
+        timestamp: args.blockNumber * BigInt(ETHEREUM_SLOT_DURATION) + BigInt(now),
       })) as any,
     });
 
@@ -98,7 +98,7 @@ describe('Archiver', () => {
     let latestBlockNum = await archiver.getBlockNumber();
     expect(latestBlockNum).toEqual(0);
 
-    blocks.forEach((b, i) => (b.header.globalVariables.timestamp = new Fr(now + 1000 * (i + 1))));
+    blocks.forEach((b, i) => (b.header.globalVariables.timestamp = new Fr(now + ETHEREUM_SLOT_DURATION * (i + 1))));
     const rollupTxs = blocks.map(makeRollupTx);
 
     publicClient.getBlockNumber.mockResolvedValueOnce(2500n).mockResolvedValueOnce(2600n).mockResolvedValueOnce(2700n);

--- a/yarn-project/archiver/src/archiver/archiver.ts
+++ b/yarn-project/archiver/src/archiver/archiver.ts
@@ -249,7 +249,7 @@ export class Archiver implements ArchiveSource {
 
     // Store latest l1 block number and timestamp seen. Used for epoch and slots calculations.
     if (!this.l1BlockNumber || this.l1BlockNumber < currentL1BlockNumber) {
-      this.l1Timestamp = await this.publicClient.getBlock({ blockNumber: currentL1BlockNumber }).then(b => b.timestamp);
+      this.l1Timestamp = (await this.publicClient.getBlock({ blockNumber: currentL1BlockNumber })).timestamp;
       this.l1BlockNumber = currentL1BlockNumber;
     }
 


### PR DESCRIPTION
A minor change to help on #9308. Instead of the archiver using the current time, it will use the time of the next ethereum block.

Also addresses an issue, where it would be possible to submit a proof for blocks that should have been pruned, but have not yet been because of no new publications.