### PR TITLE
fix: limit max block size

### DIFF
--- a/spartan/aztec-network/templates/validator.yaml
+++ b/spartan/aztec-network/templates/validator.yaml
@@ -120,6 +120,8 @@ spec:
               value: "{{ .Values.validator.sequencer.maxSecondsBetweenBlocks }}"
             - name: SEQ_MIN_TX_PER_BLOCK
               value: "{{ .Values.validator.sequencer.minTxsPerBlock }}"
+            - name: SEQ_MAX_TX_PER_BLOCK
+              value: "{{ .Values.validator.sequencer.maxTxsPerBlock }}"
             - name: P2P_TCP_ANNOUNCE_ADDR
               {{- if .Values.validator.externalTcpHost }}
               value: "{{ .Values.validator.externalTcpHost }}:{{ .Values.validator.service.p2pTcpPort }}"

--- a/spartan/aztec-network/values.yaml
+++ b/spartan/aztec-network/values.yaml
@@ -76,6 +76,7 @@ validator:
   sequencer:
     maxSecondsBetweenBlocks: 0
     minTxsPerBlock: 1
+    maxTxsPerBlock: 4
   validator:
     disabled: false
   p2p:

--- a/yarn-project/p2p/src/service/discV5_service.ts
+++ b/yarn-project/p2p/src/service/discV5_service.ts
@@ -72,6 +72,7 @@ export class DiscV5Service extends EventEmitter implements PeerDiscoveryService 
       bindAddrs: { ip4: listenMultiAddrUdp },
       config: {
         lookupTimeout: 2000,
+        requestTimeout: 2000,
         allowUnverifiedSessions: true,
       },
     });


### PR DESCRIPTION
I had seen a sequencer trying to build a block with 100+ transactions, which results in a death spiral.

Also increase the timeout on discv5 for when that is supported across multiple nodes.