### PR TITLE
feat: Origin Tags part 3 (Memory)

### DIFF
--- a/barretenberg/cpp/src/barretenberg/stdlib/primitives/memory/dynamic_array.hpp
+++ b/barretenberg/cpp/src/barretenberg/stdlib/primitives/memory/dynamic_array.hpp
@@ -1,6 +1,5 @@
 #pragma once
 #include "../circuit_builders/circuit_builders_fwd.hpp"
-#include "barretenberg/transcript/origin_tag.hpp"
 #include "ram_table.hpp"
 namespace bb::stdlib {
 

--- a/barretenberg/cpp/src/barretenberg/stdlib/primitives/memory/dynamic_array.hpp
+++ b/barretenberg/cpp/src/barretenberg/stdlib/primitives/memory/dynamic_array.hpp
@@ -1,5 +1,6 @@
 #pragma once
 #include "../circuit_builders/circuit_builders_fwd.hpp"
+#include "barretenberg/transcript/origin_tag.hpp"
 #include "ram_table.hpp"
 namespace bb::stdlib {
 

--- a/barretenberg/cpp/src/barretenberg/stdlib/primitives/memory/dynamic_array.test.cpp
+++ b/barretenberg/cpp/src/barretenberg/stdlib/primitives/memory/dynamic_array.test.cpp
@@ -23,7 +23,7 @@ using witness_ct = stdlib::witness_t<Builder>;
 using DynamicArray_ct = stdlib::DynamicArray<Builder>;
 
 STANDARD_TESTING_TAGS
-TEST(DynamicArray, TagConsistency)
+TEST(DynamicArray, TagCorrectness)
 {
 
     Builder builder;

--- a/barretenberg/cpp/src/barretenberg/stdlib/primitives/memory/dynamic_array.test.cpp
+++ b/barretenberg/cpp/src/barretenberg/stdlib/primitives/memory/dynamic_array.test.cpp
@@ -23,7 +23,7 @@ using witness_ct = stdlib::witness_t<Builder>;
 using DynamicArray_ct = stdlib::DynamicArray<Builder>;
 
 STANDARD_TESTING_TAGS
-TEST(DynamicArray, OriginTagConsistency)
+TEST(DynamicArray, TagConsistency)
 {
 
     Builder builder;

--- a/barretenberg/cpp/src/barretenberg/stdlib/primitives/memory/dynamic_array.test.cpp
+++ b/barretenberg/cpp/src/barretenberg/stdlib/primitives/memory/dynamic_array.test.cpp
@@ -23,6 +23,11 @@ using witness_ct = stdlib::witness_t<Builder>;
 using DynamicArray_ct = stdlib::DynamicArray<Builder>;
 
 STANDARD_TESTING_TAGS
+
+/**
+ * @brief Check that tags in Dynamic array are propagated correctly
+ *
+ */
 TEST(DynamicArray, TagCorrectness)
 {
 
@@ -31,27 +36,36 @@ TEST(DynamicArray, TagCorrectness)
 
     DynamicArray_ct array(&builder, max_size);
 
+    // Create random entries
     field_ct entry_1 = witness_ct(&builder, bb::fr::random_element());
     field_ct entry_2 = witness_ct(&builder, bb::fr::random_element());
     field_ct entry_3 = witness_ct(&builder, bb::fr::random_element());
     field_ct entry_4 = witness_ct(&builder, bb::fr::random_element());
 
+    // Assign a different tag to each entry
     entry_1.set_origin_tag(submitted_value_origin_tag);
     entry_2.set_origin_tag(challenge_origin_tag);
     entry_3.set_origin_tag(next_challenge_tag);
+    // Entry 4 has an "instant death" tag, that triggers an exception when merged with another tag
     entry_4.set_origin_tag(instant_death_tag);
 
+    // Fill out the dynamic array with the first 3 entries
     array.push(entry_1);
     array.push(entry_2);
     array.push(entry_3);
 
+    // Check that the tags are preserved
     EXPECT_EQ(array.read(1).get_origin_tag(), challenge_origin_tag);
     EXPECT_EQ(array.read(2).get_origin_tag(), next_challenge_tag);
     EXPECT_EQ(array.read(0).get_origin_tag(), submitted_value_origin_tag);
+    // Update an element of the array
     array.write(0, entry_2);
+    // Check that the tag changed
     EXPECT_EQ(array.read(0).get_origin_tag(), challenge_origin_tag);
 
 #ifndef NDEBUG
+    // Check that "instant death" happens when an "instant death"-tagged element is taken from the array and added to
+    // another one
     array.pop();
     array.pop();
     array.push(entry_4);

--- a/barretenberg/cpp/src/barretenberg/stdlib/primitives/memory/dynamic_array.test.cpp
+++ b/barretenberg/cpp/src/barretenberg/stdlib/primitives/memory/dynamic_array.test.cpp
@@ -7,6 +7,7 @@
 #include "../bool/bool.hpp"
 #include "../circuit_builders/circuit_builders.hpp"
 #include "barretenberg/circuit_checker/circuit_checker.hpp"
+#include "barretenberg/transcript/origin_tag.hpp"
 
 using namespace bb;
 
@@ -20,6 +21,46 @@ using bool_ct = stdlib::bool_t<Builder>;
 using field_ct = stdlib::field_t<Builder>;
 using witness_ct = stdlib::witness_t<Builder>;
 using DynamicArray_ct = stdlib::DynamicArray<Builder>;
+
+STANDARD_TESTING_TAGS
+TEST(DynamicArray, OriginTagConsistency)
+{
+
+    Builder builder;
+    const size_t max_size = 4;
+
+    DynamicArray_ct array(&builder, max_size);
+
+    field_ct entry_1 = witness_ct(&builder, bb::fr::random_element());
+    field_ct entry_2 = witness_ct(&builder, bb::fr::random_element());
+    field_ct entry_3 = witness_ct(&builder, bb::fr::random_element());
+    field_ct entry_4 = witness_ct(&builder, bb::fr::random_element());
+
+    entry_1.set_origin_tag(submitted_value_origin_tag);
+    entry_2.set_origin_tag(challenge_origin_tag);
+    entry_3.set_origin_tag(next_challenge_tag);
+    entry_4.set_origin_tag(instant_death_tag);
+
+    array.push(entry_1);
+    array.push(entry_2);
+    array.push(entry_3);
+
+    EXPECT_EQ(array.read(1).get_origin_tag(), challenge_origin_tag);
+    EXPECT_EQ(array.read(2).get_origin_tag(), next_challenge_tag);
+    EXPECT_EQ(array.read(0).get_origin_tag(), submitted_value_origin_tag);
+    array.write(0, entry_2);
+    EXPECT_EQ(array.read(0).get_origin_tag(), challenge_origin_tag);
+
+#ifndef NDEBUG
+    array.pop();
+    array.pop();
+    array.push(entry_4);
+    array.push(entry_2);
+    array.push(entry_3);
+
+    EXPECT_THROW(array.read(witness_ct(&builder, 1)) + array.read(witness_ct(&builder, 2)), std::runtime_error);
+#endif
+}
 
 TEST(DynamicArray, DynamicArrayReadWriteConsistency)
 {

--- a/barretenberg/cpp/src/barretenberg/stdlib/primitives/memory/ram_table.cpp
+++ b/barretenberg/cpp/src/barretenberg/stdlib/primitives/memory/ram_table.cpp
@@ -37,9 +37,9 @@ template <typename Builder> ram_table<Builder>::ram_table(const std::vector<fiel
     static_assert(HasPlookup<Builder>);
     // get the builder _context
     for (const auto& entry : table_entries) {
+        _tag = OriginTag(_tag, entry.get_origin_tag());
         if (entry.get_context() != nullptr) {
             _context = entry.get_context();
-            break;
         }
     }
     _raw_entries = table_entries;
@@ -106,6 +106,7 @@ ram_table<Builder>::ram_table(const ram_table& other)
     , _ram_table_generated_in_builder(other._ram_table_generated_in_builder)
     , _all_entries_written_to_with_constant_index(other._all_entries_written_to_with_constant_index)
     , _context(other._context)
+    , _tag(other._tag)
 {}
 
 /**
@@ -123,6 +124,7 @@ ram_table<Builder>::ram_table(ram_table&& other)
     , _ram_table_generated_in_builder(other._ram_table_generated_in_builder)
     , _all_entries_written_to_with_constant_index(other._all_entries_written_to_with_constant_index)
     , _context(other._context)
+    , _tag(other._tag)
 {}
 
 /**
@@ -142,6 +144,7 @@ template <typename Builder> ram_table<Builder>& ram_table<Builder>::operator=(co
     _all_entries_written_to_with_constant_index = other._all_entries_written_to_with_constant_index;
 
     _context = other._context;
+    _tag = other._tag;
     return *this;
 }
 
@@ -161,6 +164,7 @@ template <typename Builder> ram_table<Builder>& ram_table<Builder>::operator=(ra
     _ram_table_generated_in_builder = other._ram_table_generated_in_builder;
     _all_entries_written_to_with_constant_index = other._all_entries_written_to_with_constant_index;
     _context = other._context;
+    _tag = other._tag;
     return *this;
 }
 
@@ -197,8 +201,10 @@ template <typename Builder> field_t<Builder> ram_table<Builder>::read(const fiel
         index_wire = field_pt::from_witness_index(_context, _context->put_constant_variable(index.get_value()));
     }
 
-    uint32_t output_idx = _context->read_RAM_array(_ram_id, index_wire.normalize().get_witness_index());
-    return field_pt::from_witness_index(_context, output_idx);
+    uint32_t output_idx = _context->read_RAM_array(_ram_id, index_wire.get_normalized_witness_index());
+    auto element = field_pt::from_witness_index(_context, output_idx);
+    element.set_origin_tag(OriginTag(_tag, index.get_origin_tag()));
+    return element;
 }
 
 /**
@@ -247,8 +253,10 @@ template <typename Builder> void ram_table<Builder>::write(const field_pt& index
 
         _index_initialized[cast_index] = true;
     } else {
-        _context->write_RAM_array(_ram_id, index_wire.normalize().get_witness_index(), value_wire.get_witness_index());
+        _context->write_RAM_array(
+            _ram_id, index_wire.get_normalized_witness_index(), value_wire.get_normalized_witness_index());
     }
+    _tag = OriginTag(_tag, index.get_origin_tag(), value.get_origin_tag());
 }
 
 template class ram_table<bb::UltraCircuitBuilder>;

--- a/barretenberg/cpp/src/barretenberg/stdlib/primitives/memory/ram_table.hpp
+++ b/barretenberg/cpp/src/barretenberg/stdlib/primitives/memory/ram_table.hpp
@@ -1,6 +1,7 @@
 #pragma once
 #include "../circuit_builders/circuit_builders_fwd.hpp"
 #include "../field/field.hpp"
+#include "barretenberg/transcript/origin_tag.hpp"
 
 namespace bb::stdlib {
 
@@ -46,6 +47,10 @@ template <typename Builder> class ram_table {
         return _all_entries_written_to_with_constant_index;
     }
 
+    OriginTag get_origin_tag() { return _tag; }
+
+    void set_origin_tag(const OriginTag& origin_tag) { _tag = origin_tag; }
+
   private:
     std::vector<field_pt> _raw_entries;
     mutable std::vector<bool> _index_initialized;
@@ -54,5 +59,6 @@ template <typename Builder> class ram_table {
     mutable bool _ram_table_generated_in_builder = false;
     mutable bool _all_entries_written_to_with_constant_index = false;
     mutable Builder* _context = nullptr;
+    OriginTag _tag{};
 };
 } // namespace bb::stdlib

--- a/barretenberg/cpp/src/barretenberg/stdlib/primitives/memory/ram_table.hpp
+++ b/barretenberg/cpp/src/barretenberg/stdlib/primitives/memory/ram_table.hpp
@@ -47,18 +47,14 @@ template <typename Builder> class ram_table {
         return _all_entries_written_to_with_constant_index;
     }
 
-    OriginTag get_origin_tag() { return _tag; }
-
-    void set_origin_tag(const OriginTag& origin_tag) { _tag = origin_tag; }
-
   private:
     std::vector<field_pt> _raw_entries;
+    mutable std::vector<OriginTag> _tags;
     mutable std::vector<bool> _index_initialized;
     size_t _length = 0;
     mutable size_t _ram_id = 0; // Builder identifier for this ROM table
     mutable bool _ram_table_generated_in_builder = false;
     mutable bool _all_entries_written_to_with_constant_index = false;
     mutable Builder* _context = nullptr;
-    OriginTag _tag{};
 };
 } // namespace bb::stdlib

--- a/barretenberg/cpp/src/barretenberg/stdlib/primitives/memory/ram_table.hpp
+++ b/barretenberg/cpp/src/barretenberg/stdlib/primitives/memory/ram_table.hpp
@@ -49,6 +49,7 @@ template <typename Builder> class ram_table {
 
   private:
     std::vector<field_pt> _raw_entries;
+    // Origin Tags for detection of dangerous interactions within stdlib primitives
     mutable std::vector<OriginTag> _tags;
     mutable std::vector<bool> _index_initialized;
     size_t _length = 0;

--- a/barretenberg/cpp/src/barretenberg/stdlib/primitives/memory/ram_table.test.cpp
+++ b/barretenberg/cpp/src/barretenberg/stdlib/primitives/memory/ram_table.test.cpp
@@ -18,41 +18,56 @@ auto& engine = numeric::get_debug_randomness();
 }
 STANDARD_TESTING_TAGS
 
-TEST(ram_table, tag_correctness)
+/**
+ * @brief Check that Origin Tags within the ram table are propagated correctly (when we lookup an element it has the
+ * same tag as the one inserted originally)
+ *
+ */
+TEST(RamTable, TagCorrectness)
 {
 
     Builder builder;
     std::vector<field_ct> table_values;
+
+    // Generate random witnesses
     field_ct entry_1 = witness_ct(&builder, bb::fr::random_element());
     field_ct entry_2 = witness_ct(&builder, bb::fr::random_element());
     field_ct entry_3 = witness_ct(&builder, bb::fr::random_element());
+
+    // Tag them with 3 different tags
     entry_1.set_origin_tag(submitted_value_origin_tag);
     entry_2.set_origin_tag(challenge_origin_tag);
+    // The last tag is an instant death tag, that triggers a runtime failure if any computation happens on the element
     entry_3.set_origin_tag(instant_death_tag);
 
     table_values.emplace_back(entry_1);
     table_values.emplace_back(entry_2);
     table_values.emplace_back(entry_3);
 
+    // Initialize the table
     ram_table_ct table(table_values);
 
+    // Check that each element has the same tag as original entries
     EXPECT_EQ(table.read(field_ct(0)).get_origin_tag(), submitted_value_origin_tag);
     EXPECT_EQ(table.read(field_ct(witness_ct(&builder, 0))).get_origin_tag(), submitted_value_origin_tag);
-
     EXPECT_EQ(table.read(field_ct(1)).get_origin_tag(), challenge_origin_tag);
     EXPECT_EQ(table.read(field_ct(witness_ct(&builder, 1))).get_origin_tag(), challenge_origin_tag);
 
+    // Replace one of the elements in the table with a new one
     entry_2.set_origin_tag(next_challenge_tag);
     table.write(field_ct(1), entry_2);
 
+    // Check that the tag has been updated accordingly
     EXPECT_EQ(table.read(field_ct(1)).get_origin_tag(), next_challenge_tag);
     EXPECT_EQ(table.read(field_ct(witness_ct(&builder, 1))).get_origin_tag(), next_challenge_tag);
 
 #ifndef NDEBUG
+    // Check that interacting with the poisoned element causes a runtime error
     EXPECT_THROW(table.read(0) + table.read(2), std::runtime_error);
 #endif
 }
-TEST(ram_table, ram_table_init_read_consistency)
+
+TEST(RamTable, RamTableInitReadConsistency)
 {
     Builder builder;
 
@@ -86,7 +101,7 @@ TEST(ram_table, ram_table_init_read_consistency)
     EXPECT_EQ(verified, true);
 }
 
-TEST(ram_table, ram_table_read_write_consistency)
+TEST(RamTable, RamTableReadWriteConsistency)
 {
     Builder builder;
     const size_t table_size = 10;

--- a/barretenberg/cpp/src/barretenberg/stdlib/primitives/memory/ram_table.test.cpp
+++ b/barretenberg/cpp/src/barretenberg/stdlib/primitives/memory/ram_table.test.cpp
@@ -25,26 +25,31 @@ TEST(ram_table, tag_correctness)
     std::vector<field_ct> table_values;
     field_ct entry_1 = witness_ct(&builder, bb::fr::random_element());
     field_ct entry_2 = witness_ct(&builder, bb::fr::random_element());
+    field_ct entry_3 = witness_ct(&builder, bb::fr::random_element());
     entry_1.set_origin_tag(submitted_value_origin_tag);
     entry_2.set_origin_tag(challenge_origin_tag);
+    entry_3.set_origin_tag(instant_death_tag);
+
     table_values.emplace_back(entry_1);
     table_values.emplace_back(entry_2);
+    table_values.emplace_back(entry_3);
 
     ram_table_ct table(table_values);
 
-    EXPECT_EQ(table.get_origin_tag(), first_two_merged_tag);
+    EXPECT_EQ(table.read(field_ct(0)).get_origin_tag(), submitted_value_origin_tag);
+    EXPECT_EQ(table.read(field_ct(witness_ct(&builder, 0))).get_origin_tag(), submitted_value_origin_tag);
 
-    field_ct index = witness_ct(&builder, 0);
-    index.set_origin_tag(next_challenge_tag);
-    auto result = table.read(index);
-    EXPECT_EQ(result.get_origin_tag(), first_second_third_merged_tag);
+    EXPECT_EQ(table.read(field_ct(1)).get_origin_tag(), challenge_origin_tag);
+    EXPECT_EQ(table.read(field_ct(witness_ct(&builder, 1))).get_origin_tag(), challenge_origin_tag);
 
-    auto poison_tag = table.get_origin_tag();
-    poison_tag.poison();
-    table.set_origin_tag(poison_tag);
+    entry_2.set_origin_tag(next_challenge_tag);
+    table.write(field_ct(1), entry_2);
+
+    EXPECT_EQ(table.read(field_ct(1)).get_origin_tag(), next_challenge_tag);
+    EXPECT_EQ(table.read(field_ct(witness_ct(&builder, 1))).get_origin_tag(), next_challenge_tag);
 
 #ifndef NDEBUG
-    EXPECT_THROW(table.read(index), std::runtime_error);
+    EXPECT_THROW(table.read(0) + table.read(2), std::runtime_error);
 #endif
 }
 TEST(ram_table, ram_table_init_read_consistency)

--- a/barretenberg/cpp/src/barretenberg/stdlib/primitives/memory/rom_table.cpp
+++ b/barretenberg/cpp/src/barretenberg/stdlib/primitives/memory/rom_table.cpp
@@ -117,13 +117,14 @@ template <typename Builder> field_t<Builder> rom_table<Builder>::operator[](cons
 
 template <typename Builder> field_t<Builder> rom_table<Builder>::operator[](const field_pt& index) const
 {
-    initialize_table();
     if (index.is_constant()) {
         return operator[](static_cast<size_t>(uint256_t(index.get_value()).data[0]));
     }
     if (context == nullptr) {
         context = index.get_context();
     }
+
+    initialize_table();
     const auto native_index = uint256_t(index.get_value());
     if (native_index >= length) {
         context->failure("rom_table: ROM array access out of bounds");

--- a/barretenberg/cpp/src/barretenberg/stdlib/primitives/memory/rom_table.cpp
+++ b/barretenberg/cpp/src/barretenberg/stdlib/primitives/memory/rom_table.cpp
@@ -22,6 +22,12 @@ template <typename Builder> rom_table<Builder>::rom_table(const std::vector<fiel
     // if this is the case we might not have a valid pointer to a Builder
     // We get around this, by initializing the table when `operator[]` is called
     // with a non-const field element.
+
+    // Initialize tags
+    _tags.resize(raw_entries.size());
+    for (size_t i = 0; i < length; ++i) {
+        _tags[i] = raw_entries[i].get_origin_tag();
+    }
 }
 
 // initialize the table once we perform a read. This ensures we always have a valid

--- a/barretenberg/cpp/src/barretenberg/stdlib/primitives/memory/rom_table.cpp
+++ b/barretenberg/cpp/src/barretenberg/stdlib/primitives/memory/rom_table.cpp
@@ -52,6 +52,7 @@ template <typename Builder> void rom_table<Builder>::initialize_table() const
         context->set_ROM_element(rom_id, i, entries[i].get_witness_index());
     }
 
+    // Preserve tags to restore them in the future lookups
     _tags.resize(raw_entries.size());
     for (size_t i = 0; i < length; ++i) {
         _tags[i] = raw_entries[i].get_origin_tag();
@@ -134,6 +135,8 @@ template <typename Builder> field_t<Builder> rom_table<Builder>::operator[](cons
     auto element = field_pt::from_witness_index(context, output_idx);
 
     const size_t cast_index = static_cast<size_t>(static_cast<uint64_t>(native_index));
+
+    // If the index is legitimate, restore the tag
     if (native_index < length) {
 
         element.set_origin_tag(_tags[cast_index]);

--- a/barretenberg/cpp/src/barretenberg/stdlib/primitives/memory/rom_table.hpp
+++ b/barretenberg/cpp/src/barretenberg/stdlib/primitives/memory/rom_table.hpp
@@ -35,6 +35,7 @@ template <typename Builder> class rom_table {
   private:
     std::vector<field_pt> raw_entries;
     mutable std::vector<field_pt> entries;
+    // Origin Tags for detecting problematic interactions of stdlib primitives
     mutable std::vector<OriginTag> _tags;
     size_t length = 0;
     mutable size_t rom_id = 0; // Builder identifier for this ROM table

--- a/barretenberg/cpp/src/barretenberg/stdlib/primitives/memory/rom_table.hpp
+++ b/barretenberg/cpp/src/barretenberg/stdlib/primitives/memory/rom_table.hpp
@@ -1,6 +1,7 @@
 #pragma once
 #include "../circuit_builders/circuit_builders_fwd.hpp"
 #include "../field/field.hpp"
+#include "barretenberg/transcript/origin_tag.hpp"
 
 namespace bb::stdlib {
 
@@ -31,17 +32,13 @@ template <typename Builder> class rom_table {
 
     Builder* get_context() const { return context; }
 
-    OriginTag get_origin_tag() { return _tag; }
-
-    void set_origin_tag(const OriginTag& origin_tag) { _tag = origin_tag; }
-
   private:
     std::vector<field_pt> raw_entries;
     mutable std::vector<field_pt> entries;
+    mutable std::vector<OriginTag> _tags;
     size_t length = 0;
     mutable size_t rom_id = 0; // Builder identifier for this ROM table
     mutable bool initialized = false;
     mutable Builder* context = nullptr;
-    OriginTag _tag{};
 };
 } // namespace bb::stdlib

--- a/barretenberg/cpp/src/barretenberg/stdlib/primitives/memory/rom_table.hpp
+++ b/barretenberg/cpp/src/barretenberg/stdlib/primitives/memory/rom_table.hpp
@@ -31,6 +31,10 @@ template <typename Builder> class rom_table {
 
     Builder* get_context() const { return context; }
 
+    OriginTag get_origin_tag() { return _tag; }
+
+    void set_origin_tag(const OriginTag& origin_tag) { _tag = origin_tag; }
+
   private:
     std::vector<field_pt> raw_entries;
     mutable std::vector<field_pt> entries;
@@ -38,5 +42,6 @@ template <typename Builder> class rom_table {
     mutable size_t rom_id = 0; // Builder identifier for this ROM table
     mutable bool initialized = false;
     mutable Builder* context = nullptr;
+    OriginTag _tag{};
 };
 } // namespace bb::stdlib

--- a/barretenberg/cpp/src/barretenberg/stdlib/primitives/memory/rom_table.test.cpp
+++ b/barretenberg/cpp/src/barretenberg/stdlib/primitives/memory/rom_table.test.cpp
@@ -19,33 +19,45 @@ namespace {
 auto& engine = numeric::get_debug_randomness();
 }
 STANDARD_TESTING_TAGS
-TEST(rom_table, tag_correctness)
+
+/**
+ * @brief Ensure the tags of elements initializing the ROM table are correctly propagated
+ *
+ */
+TEST(RomTable, TagCorrectness)
 {
 
     Builder builder;
     std::vector<field_ct> table_values;
+    // Create random witness elements
     field_ct entry_1 = witness_ct(&builder, bb::fr::random_element());
     field_ct entry_2 = witness_ct(&builder, bb::fr::random_element());
     field_ct entry_3 = witness_ct(&builder, bb::fr::random_element());
+
+    // Tag all 3 with different tags
     entry_1.set_origin_tag(submitted_value_origin_tag);
     entry_2.set_origin_tag(challenge_origin_tag);
+    // The last one is "poisoned" (calculating with this element should result in runtime error)
     entry_3.set_origin_tag(instant_death_tag);
 
     table_values.emplace_back(entry_1);
     table_values.emplace_back(entry_2);
     table_values.emplace_back(entry_3);
 
+    // Initialize the table with them
     rom_table_ct table(table_values);
 
+    // Check that the tags of the first two are preserved
     EXPECT_EQ(table[field_ct(witness_ct(&builder, 0))].get_origin_tag(), submitted_value_origin_tag);
-
     EXPECT_EQ(table[field_ct(witness_ct(&builder, 1))].get_origin_tag(), challenge_origin_tag);
 
 #ifndef NDEBUG
+    // Check that computing the sum with the last once crashes the program
     EXPECT_THROW(table[0] + table[2], std::runtime_error);
 #endif
 }
-TEST(rom_table, rom_table_read_write_consistency)
+
+TEST(RomTable, RomTableReadWriteConsistency)
 {
     Builder builder;
 

--- a/barretenberg/cpp/src/barretenberg/stdlib/primitives/memory/rom_table.test.cpp
+++ b/barretenberg/cpp/src/barretenberg/stdlib/primitives/memory/rom_table.test.cpp
@@ -37,10 +37,8 @@ TEST(rom_table, tag_correctness)
 
     rom_table_ct table(table_values);
 
-    EXPECT_EQ(table[field_ct(0)].get_origin_tag(), submitted_value_origin_tag);
     EXPECT_EQ(table[field_ct(witness_ct(&builder, 0))].get_origin_tag(), submitted_value_origin_tag);
 
-    EXPECT_EQ(table[field_ct(1)].get_origin_tag(), challenge_origin_tag);
     EXPECT_EQ(table[field_ct(witness_ct(&builder, 1))].get_origin_tag(), challenge_origin_tag);
 
 #ifndef NDEBUG

--- a/barretenberg/cpp/src/barretenberg/stdlib/primitives/memory/rom_table.test.cpp
+++ b/barretenberg/cpp/src/barretenberg/stdlib/primitives/memory/rom_table.test.cpp
@@ -26,26 +26,25 @@ TEST(rom_table, tag_correctness)
     std::vector<field_ct> table_values;
     field_ct entry_1 = witness_ct(&builder, bb::fr::random_element());
     field_ct entry_2 = witness_ct(&builder, bb::fr::random_element());
+    field_ct entry_3 = witness_ct(&builder, bb::fr::random_element());
     entry_1.set_origin_tag(submitted_value_origin_tag);
     entry_2.set_origin_tag(challenge_origin_tag);
+    entry_3.set_origin_tag(instant_death_tag);
+
     table_values.emplace_back(entry_1);
     table_values.emplace_back(entry_2);
+    table_values.emplace_back(entry_3);
 
     rom_table_ct table(table_values);
 
-    EXPECT_EQ(table.get_origin_tag(), first_two_merged_tag);
+    EXPECT_EQ(table[field_ct(0)].get_origin_tag(), submitted_value_origin_tag);
+    EXPECT_EQ(table[field_ct(witness_ct(&builder, 0))].get_origin_tag(), submitted_value_origin_tag);
 
-    field_ct index = witness_ct(&builder, 0);
-    index.set_origin_tag(next_challenge_tag);
-    auto result = table[index];
-    EXPECT_EQ(result.get_origin_tag(), first_second_third_merged_tag);
-
-    auto poison_tag = table.get_origin_tag();
-    poison_tag.poison();
-    table.set_origin_tag(poison_tag);
+    EXPECT_EQ(table[field_ct(1)].get_origin_tag(), challenge_origin_tag);
+    EXPECT_EQ(table[field_ct(witness_ct(&builder, 1))].get_origin_tag(), challenge_origin_tag);
 
 #ifndef NDEBUG
-    EXPECT_THROW(table[index], std::runtime_error);
+    EXPECT_THROW(table[0] + table[2], std::runtime_error);
 #endif
 }
 TEST(rom_table, rom_table_read_write_consistency)

--- a/barretenberg/cpp/src/barretenberg/stdlib/primitives/memory/twin_rom_table.cpp
+++ b/barretenberg/cpp/src/barretenberg/stdlib/primitives/memory/twin_rom_table.cpp
@@ -61,6 +61,8 @@ template <typename Builder> void twin_rom_table<Builder>::initialize_table() con
         context->set_ROM_element_pair(
             rom_id, i, std::array<uint32_t, 2>{ entries[i][0].get_witness_index(), entries[i][1].get_witness_index() });
     }
+
+    // Ensure that the origin tags of all entries are preserved so we can assign them on lookups
     tags.resize(length);
     for (size_t i = 0; i < length; ++i) {
         tags[i] = { raw_entries[i][0].get_origin_tag(), raw_entries[i][1].get_origin_tag() };
@@ -147,6 +149,7 @@ std::array<field_t<Builder>, 2> twin_rom_table<Builder>::operator[](const field_
 
     const auto native_index = uint256_t(index.get_value());
     const size_t cast_index = static_cast<size_t>(static_cast<uint64_t>(native_index));
+    // In case of a legitimate lookup, restore the tags of the original entries to the output
     if (native_index < length) {
         pair[0].set_origin_tag(tags[cast_index][0]);
         pair[1].set_origin_tag(tags[cast_index][1]);

--- a/barretenberg/cpp/src/barretenberg/stdlib/primitives/memory/twin_rom_table.cpp
+++ b/barretenberg/cpp/src/barretenberg/stdlib/primitives/memory/twin_rom_table.cpp
@@ -27,6 +27,12 @@ twin_rom_table<Builder>::twin_rom_table(const std::vector<std::array<field_pt, 2
     // if this is the case we might not have a valid pointer to a Builder
     // We get around this, by initializing the table when `operator[]` is called
     // with a non-const field element.
+
+    // Ensure that the origin tags of all entries are preserved so we can assign them on lookups
+    tags.resize(length);
+    for (size_t i = 0; i < length; ++i) {
+        tags[i] = { raw_entries[i][0].get_origin_tag(), raw_entries[i][1].get_origin_tag() };
+    }
 }
 
 // initialize the table once we perform a read. This ensures we always have a valid

--- a/barretenberg/cpp/src/barretenberg/stdlib/primitives/memory/twin_rom_table.cpp
+++ b/barretenberg/cpp/src/barretenberg/stdlib/primitives/memory/twin_rom_table.cpp
@@ -12,13 +12,12 @@ twin_rom_table<Builder>::twin_rom_table(const std::vector<std::array<field_pt, 2
     static_assert(HasPlookup<Builder>);
     // get the builder context
     for (const auto& entry : table_entries) {
+        _tag = OriginTag(_tag, entry[0].get_origin_tag(), entry[1].get_origin_tag());
         if (entry[0].get_context() != nullptr) {
             context = entry[0].get_context();
-            break;
         }
         if (entry[1].get_context() != nullptr) {
             context = entry[1].get_context();
-            break;
         }
     }
     raw_entries = table_entries;
@@ -72,6 +71,7 @@ twin_rom_table<Builder>::twin_rom_table(const twin_rom_table& other)
     , rom_id(other.rom_id)
     , initialized(other.initialized)
     , context(other.context)
+    , _tag(other._tag)
 {}
 
 template <typename Builder>
@@ -82,6 +82,7 @@ twin_rom_table<Builder>::twin_rom_table(twin_rom_table&& other)
     , rom_id(other.rom_id)
     , initialized(other.initialized)
     , context(other.context)
+    , _tag(other._tag)
 {}
 
 template <typename Builder> twin_rom_table<Builder>& twin_rom_table<Builder>::operator=(const twin_rom_table& other)
@@ -92,6 +93,7 @@ template <typename Builder> twin_rom_table<Builder>& twin_rom_table<Builder>::op
     rom_id = other.rom_id;
     initialized = other.initialized;
     context = other.context;
+    _tag = other._tag;
     return *this;
 }
 
@@ -103,6 +105,7 @@ template <typename Builder> twin_rom_table<Builder>& twin_rom_table<Builder>::op
     rom_id = other.rom_id;
     initialized = other.initialized;
     context = other.context;
+    _tag = other._tag;
     return *this;
 }
 
@@ -132,10 +135,14 @@ std::array<field_t<Builder>, 2> twin_rom_table<Builder>::operator[](const field_
     }
 
     auto output_indices = context->read_ROM_array_pair(rom_id, index.normalize().get_witness_index());
-    return field_pair_pt{
+    auto pair = field_pair_pt{
         field_pt::from_witness_index(context, output_indices[0]),
         field_pt::from_witness_index(context, output_indices[1]),
     };
+    const auto result_tag = OriginTag(_tag, index.get_origin_tag());
+    pair[0].set_origin_tag(result_tag);
+    pair[1].set_origin_tag(result_tag);
+    return pair;
 }
 
 template class twin_rom_table<bb::UltraCircuitBuilder>;

--- a/barretenberg/cpp/src/barretenberg/stdlib/primitives/memory/twin_rom_table.cpp
+++ b/barretenberg/cpp/src/barretenberg/stdlib/primitives/memory/twin_rom_table.cpp
@@ -130,13 +130,14 @@ std::array<field_t<Builder>, 2> twin_rom_table<Builder>::operator[](const size_t
 template <typename Builder>
 std::array<field_t<Builder>, 2> twin_rom_table<Builder>::operator[](const field_pt& index) const
 {
-    initialize_table();
     if (index.is_constant()) {
         return operator[](static_cast<size_t>(uint256_t(index.get_value()).data[0]));
     }
     if (context == nullptr) {
         context = index.get_context();
     }
+
+    initialize_table();
     if (uint256_t(index.get_value()) >= length) {
         context->failure("twin_rom_table: ROM array access out of bounds");
     }

--- a/barretenberg/cpp/src/barretenberg/stdlib/primitives/memory/twin_rom_table.hpp
+++ b/barretenberg/cpp/src/barretenberg/stdlib/primitives/memory/twin_rom_table.hpp
@@ -33,6 +33,10 @@ template <typename Builder> class twin_rom_table {
 
     Builder* get_context() const { return context; }
 
+    OriginTag get_origin_tag() { return _tag; }
+
+    void set_origin_tag(const OriginTag& origin_tag) { _tag = origin_tag; }
+
   private:
     std::vector<field_pair_pt> raw_entries;
     mutable std::vector<field_pair_pt> entries;
@@ -40,5 +44,6 @@ template <typename Builder> class twin_rom_table {
     mutable size_t rom_id = 0; // Builder identifier for this ROM table
     mutable bool initialized = false;
     mutable Builder* context = nullptr;
+    OriginTag _tag{};
 };
 } // namespace bb::stdlib

--- a/barretenberg/cpp/src/barretenberg/stdlib/primitives/memory/twin_rom_table.hpp
+++ b/barretenberg/cpp/src/barretenberg/stdlib/primitives/memory/twin_rom_table.hpp
@@ -1,6 +1,7 @@
 #pragma once
 #include "../circuit_builders/circuit_builders_fwd.hpp"
 #include "../field/field.hpp"
+#include "barretenberg/transcript/origin_tag.hpp"
 
 namespace bb::stdlib {
 
@@ -33,17 +34,13 @@ template <typename Builder> class twin_rom_table {
 
     Builder* get_context() const { return context; }
 
-    OriginTag get_origin_tag() { return _tag; }
-
-    void set_origin_tag(const OriginTag& origin_tag) { _tag = origin_tag; }
-
   private:
     std::vector<field_pair_pt> raw_entries;
     mutable std::vector<field_pair_pt> entries;
+    mutable std::vector<std::array<OriginTag, 2>> tags;
     size_t length = 0;
     mutable size_t rom_id = 0; // Builder identifier for this ROM table
     mutable bool initialized = false;
     mutable Builder* context = nullptr;
-    OriginTag _tag{};
 };
 } // namespace bb::stdlib

--- a/barretenberg/cpp/src/barretenberg/stdlib/primitives/memory/twin_rom_table.hpp
+++ b/barretenberg/cpp/src/barretenberg/stdlib/primitives/memory/twin_rom_table.hpp
@@ -37,6 +37,8 @@ template <typename Builder> class twin_rom_table {
   private:
     std::vector<field_pair_pt> raw_entries;
     mutable std::vector<field_pair_pt> entries;
+
+    // Origin Tags used for tracking dangerous interactions in stdlib primtives
     mutable std::vector<std::array<OriginTag, 2>> tags;
     size_t length = 0;
     mutable size_t rom_id = 0; // Builder identifier for this ROM table

--- a/barretenberg/cpp/src/barretenberg/stdlib/primitives/memory/twin_rom_table.test.cpp
+++ b/barretenberg/cpp/src/barretenberg/stdlib/primitives/memory/twin_rom_table.test.cpp
@@ -21,6 +21,7 @@ namespace {
 auto& engine = numeric::get_debug_randomness();
 }
 STANDARD_TESTING_TAGS
+
 TEST(TwinRomTable, TagCorrectness)
 {
 
@@ -29,30 +30,27 @@ TEST(TwinRomTable, TagCorrectness)
     field_ct entry_1 = witness_ct(&builder, bb::fr::random_element());
     field_ct entry_2 = witness_ct(&builder, bb::fr::random_element());
     field_ct entry_3 = witness_ct(&builder, bb::fr::random_element());
+    field_ct entry_4 = witness_ct(&builder, bb::fr::random_element());
+
     entry_1.set_origin_tag(submitted_value_origin_tag);
     entry_2.set_origin_tag(challenge_origin_tag);
     entry_3.set_origin_tag(next_challenge_tag);
+    entry_4.set_origin_tag(instant_death_tag);
     table_values.emplace_back(field_pair_ct{ entry_1, entry_2 });
-    table_values.emplace_back(field_pair_ct{ entry_1, entry_3 });
+    table_values.emplace_back(field_pair_ct{ entry_3, entry_4 });
 
     twin_rom_table_ct table(table_values);
 
-    EXPECT_EQ(table.get_origin_tag(), first_second_third_merged_tag);
+    EXPECT_EQ(table[field_ct(0)][0].get_origin_tag(), submitted_value_origin_tag);
+    EXPECT_EQ(table[field_ct(witness_ct(&builder, 0))][1].get_origin_tag(), challenge_origin_tag);
 
-    field_ct index = witness_ct(&builder, 0);
-    index.set_origin_tag(next_submitted_value_origin_tag);
-    auto result = table[index];
-    EXPECT_EQ(result[0].get_origin_tag(), first_to_fourth_merged_tag);
-    EXPECT_EQ(result[1].get_origin_tag(), first_to_fourth_merged_tag);
-
-    auto poison_tag = table.get_origin_tag();
-    poison_tag.poison();
-    table.set_origin_tag(poison_tag);
+    EXPECT_EQ(table[field_ct(1)][0].get_origin_tag(), next_challenge_tag);
 
 #ifndef NDEBUG
-    EXPECT_THROW(table[index], std::runtime_error);
+    EXPECT_THROW(table[1][1] + 1, std::runtime_error);
 #endif
 }
+
 TEST(TwinRomTable, ReadWriteConsistency)
 {
     Builder builder;

--- a/barretenberg/cpp/src/barretenberg/stdlib/primitives/memory/twin_rom_table.test.cpp
+++ b/barretenberg/cpp/src/barretenberg/stdlib/primitives/memory/twin_rom_table.test.cpp
@@ -1,11 +1,12 @@
 
+#include <array>
 #include <gtest/gtest.h>
 
 #include "barretenberg/circuit_checker/circuit_checker.hpp"
 #include "barretenberg/numeric/random/engine.hpp"
 #include "barretenberg/stdlib_circuit_builders/ultra_circuit_builder.hpp"
 #include "barretenberg/transcript/origin_tag.hpp"
-#include "rom_table.hpp"
+#include "twin_rom_table.hpp"
 
 using namespace bb;
 
@@ -13,32 +14,36 @@ using namespace bb;
 using Builder = UltraCircuitBuilder;
 using field_ct = stdlib::field_t<Builder>;
 using witness_ct = stdlib::witness_t<Builder>;
-using rom_table_ct = stdlib::rom_table<Builder>;
+using twin_rom_table_ct = stdlib::twin_rom_table<Builder>;
+using field_pair_ct = std::array<field_ct, 2>;
 
 namespace {
 auto& engine = numeric::get_debug_randomness();
 }
 STANDARD_TESTING_TAGS
-TEST(rom_table, tag_correctness)
+TEST(TwinRomTable, TagCorrectness)
 {
 
     Builder builder;
-    std::vector<field_ct> table_values;
+    std::vector<field_pair_ct> table_values;
     field_ct entry_1 = witness_ct(&builder, bb::fr::random_element());
     field_ct entry_2 = witness_ct(&builder, bb::fr::random_element());
+    field_ct entry_3 = witness_ct(&builder, bb::fr::random_element());
     entry_1.set_origin_tag(submitted_value_origin_tag);
     entry_2.set_origin_tag(challenge_origin_tag);
-    table_values.emplace_back(entry_1);
-    table_values.emplace_back(entry_2);
+    entry_3.set_origin_tag(next_challenge_tag);
+    table_values.emplace_back(field_pair_ct{ entry_1, entry_2 });
+    table_values.emplace_back(field_pair_ct{ entry_1, entry_3 });
 
-    rom_table_ct table(table_values);
+    twin_rom_table_ct table(table_values);
 
-    EXPECT_EQ(table.get_origin_tag(), first_two_merged_tag);
+    EXPECT_EQ(table.get_origin_tag(), first_second_third_merged_tag);
 
     field_ct index = witness_ct(&builder, 0);
-    index.set_origin_tag(next_challenge_tag);
+    index.set_origin_tag(next_submitted_value_origin_tag);
     auto result = table[index];
-    EXPECT_EQ(result.get_origin_tag(), first_second_third_merged_tag);
+    EXPECT_EQ(result[0].get_origin_tag(), first_to_fourth_merged_tag);
+    EXPECT_EQ(result[1].get_origin_tag(), first_to_fourth_merged_tag);
 
     auto poison_tag = table.get_origin_tag();
     poison_tag.poison();
@@ -48,20 +53,21 @@ TEST(rom_table, tag_correctness)
     EXPECT_THROW(table[index], std::runtime_error);
 #endif
 }
-TEST(rom_table, rom_table_read_write_consistency)
+TEST(TwinRomTable, ReadWriteConsistency)
 {
     Builder builder;
 
-    std::vector<field_ct> table_values;
+    std::vector<field_pair_ct> table_values;
     const size_t table_size = 10;
     for (size_t i = 0; i < table_size; ++i) {
-        table_values.emplace_back(witness_ct(&builder, bb::fr::random_element()));
+        table_values.emplace_back(field_pair_ct{ witness_ct(&builder, bb::fr::random_element()),
+                                                 witness_ct(&builder, bb::fr::random_element()) });
     }
 
-    rom_table_ct table(table_values);
+    twin_rom_table_ct table(table_values);
 
-    field_ct result(0);
-    fr expected(0);
+    field_pair_ct result{ field_ct(0), field_ct(0) };
+    std::array<fr, 2> expected{ 0, 0 };
 
     for (size_t i = 0; i < 10; ++i) {
         field_ct index(witness_ct(&builder, (uint64_t)i));
@@ -75,19 +81,24 @@ TEST(rom_table, rom_table_read_write_consistency)
             if (i != 0) {
                 EXPECT_EQ(after_n - before_n, 1ULL);
             }
-            result += to_add; // variable lookup
+            result[0] += to_add[0]; // variable lookup
+            result[1] += to_add[1]; // variable lookup
         } else {
             const auto before_n = builder.num_gates;
             const auto to_add = table[i]; // constant lookup
             const auto after_n = builder.num_gates;
             // should cost 0 gates. Constant lookups are free
             EXPECT_EQ(after_n - before_n, 0ULL);
-            result += to_add;
+            result[0] += to_add[0];
+            result[1] += to_add[1];
         }
-        expected += table_values[i].get_value();
+        auto expected_values = table_values[i];
+        expected[0] += expected_values[0].get_value();
+        expected[1] += expected_values[1].get_value();
     }
 
-    EXPECT_EQ(result.get_value(), expected);
+    EXPECT_EQ(result[0].get_value(), expected[0]);
+    EXPECT_EQ(result[1].get_value(), expected[1]);
 
     bool verified = CircuitChecker::check(builder);
     EXPECT_EQ(verified, true);

--- a/barretenberg/cpp/src/barretenberg/stdlib/primitives/memory/twin_rom_table.test.cpp
+++ b/barretenberg/cpp/src/barretenberg/stdlib/primitives/memory/twin_rom_table.test.cpp
@@ -57,7 +57,7 @@ TEST(TwinRomTable, TagCorrectness)
     twin_rom_table_ct table(table_values);
 
     // Check that the tags in positions [0][0], [0][1], [1][0] are preserved
-    EXPECT_EQ(table[field_ct(0)][0].get_origin_tag(), submitted_value_origin_tag);
+    EXPECT_EQ(table[field_ct(witness_ct(&builder, 0))][0].get_origin_tag(), submitted_value_origin_tag);
     EXPECT_EQ(table[field_ct(witness_ct(&builder, 0))][1].get_origin_tag(), challenge_origin_tag);
     EXPECT_EQ(table[field_ct(1)][0].get_origin_tag(), next_challenge_tag);
 

--- a/barretenberg/cpp/src/barretenberg/stdlib/primitives/memory/twin_rom_table.test.cpp
+++ b/barretenberg/cpp/src/barretenberg/stdlib/primitives/memory/twin_rom_table.test.cpp
@@ -22,56 +22,80 @@ auto& engine = numeric::get_debug_randomness();
 }
 STANDARD_TESTING_TAGS
 
+/**
+ * @brief Check the correctness of tag propagation within the twin rom tables
+ *
+ */
 TEST(TwinRomTable, TagCorrectness)
 {
 
     Builder builder;
     std::vector<field_pair_ct> table_values;
+
+    // Create random entries
     field_ct entry_1 = witness_ct(&builder, bb::fr::random_element());
     field_ct entry_2 = witness_ct(&builder, bb::fr::random_element());
     field_ct entry_3 = witness_ct(&builder, bb::fr::random_element());
     field_ct entry_4 = witness_ct(&builder, bb::fr::random_element());
 
+    // Assign different standard tags to them
     entry_1.set_origin_tag(submitted_value_origin_tag);
     entry_2.set_origin_tag(challenge_origin_tag);
     entry_3.set_origin_tag(next_challenge_tag);
+
+    // Assign the instant death tag to one of the
+    // entries
+    // It causes an error in Debug if it is being merged with another tag (when arithmetic actions are being performed
+    // on it)
     entry_4.set_origin_tag(instant_death_tag);
+
+    // Form entries in the twin table
     table_values.emplace_back(field_pair_ct{ entry_1, entry_2 });
     table_values.emplace_back(field_pair_ct{ entry_3, entry_4 });
 
+    // Initialize the table
     twin_rom_table_ct table(table_values);
 
+    // Check that the tags in positions [0][0], [0][1], [1][0] are preserved
     EXPECT_EQ(table[field_ct(0)][0].get_origin_tag(), submitted_value_origin_tag);
     EXPECT_EQ(table[field_ct(witness_ct(&builder, 0))][1].get_origin_tag(), challenge_origin_tag);
-
     EXPECT_EQ(table[field_ct(1)][0].get_origin_tag(), next_challenge_tag);
 
 #ifndef NDEBUG
+    // Check that working with position [1][1] in debug causes "instant death"
     EXPECT_THROW(table[1][1] + 1, std::runtime_error);
 #endif
 }
 
+/**
+ * @brief Check the consistency of read-write operations in the TwinRomTable
+ *
+ */
 TEST(TwinRomTable, ReadWriteConsistency)
 {
     Builder builder;
 
     std::vector<field_pair_ct> table_values;
     const size_t table_size = 10;
+    // Generate random witness pairs to put in the table
     for (size_t i = 0; i < table_size; ++i) {
         table_values.emplace_back(field_pair_ct{ witness_ct(&builder, bb::fr::random_element()),
                                                  witness_ct(&builder, bb::fr::random_element()) });
     }
 
+    // Initialize the table
     twin_rom_table_ct table(table_values);
 
     field_pair_ct result{ field_ct(0), field_ct(0) };
     std::array<fr, 2> expected{ 0, 0 };
 
+    // Go throught the cycle of accessing all entries
     for (size_t i = 0; i < 10; ++i) {
         field_ct index(witness_ct(&builder, (uint64_t)i));
 
         if (i % 2 == 0) {
             const auto before_n = builder.num_gates;
+            // Get the entry from the table
             const auto to_add = table[index];
             const auto after_n = builder.num_gates;
             // should cost 1 gates (the ROM read adds 1 extra gate when the proving key is constructed)
@@ -79,6 +103,7 @@ TEST(TwinRomTable, ReadWriteConsistency)
             if (i != 0) {
                 EXPECT_EQ(after_n - before_n, 1ULL);
             }
+            // Accumulate each of the positions in the result
             result[0] += to_add[0]; // variable lookup
             result[1] += to_add[1]; // variable lookup
         } else {
@@ -90,11 +115,14 @@ TEST(TwinRomTable, ReadWriteConsistency)
             result[0] += to_add[0];
             result[1] += to_add[1];
         }
+        // Accumulate original values
         auto expected_values = table_values[i];
         expected[0] += expected_values[0].get_value();
         expected[1] += expected_values[1].get_value();
     }
 
+    // Check that the sum of the original values is the same as the sum of the ones received from the TwinRomTable
+    // primitive
     EXPECT_EQ(result[0].get_value(), expected[0]);
     EXPECT_EQ(result[1].get_value(), expected[1]);
 


### PR DESCRIPTION
This PR:
1. Adds Origin Tags for tracking dangerous interactions to all stdlib memory primitives
2. Expands  the tests from TwinRomTable
3. Fixes a bug with the use of nonnormalized value.
