### PR TITLE
feat: Validator stateful set load balancers

### DIFF
--- a/spartan/aztec-network/templates/anvil.yaml
+++ b/spartan/aztec-network/templates/anvil.yaml
@@ -1,4 +1,3 @@
-{{- if not .Values.ethereum.external }}
 apiVersion: apps/v1
 kind: Deployment
 metadata:
@@ -143,5 +142,5 @@ spec:
       {{- if and (eq .Values.ethereum.service.type "NodePort") .Values.ethereum.service.nodePort }}
       nodePort: {{ .Values.ethereum.service.nodePort }}
       {{- end }}
-{{ end }}
+---
 {{ end }}

--- a/spartan/aztec-network/templates/boot-node.yaml
+++ b/spartan/aztec-network/templates/boot-node.yaml
@@ -1,4 +1,3 @@
-{{- if not .Values.bootNode.external }}
 apiVersion: apps/v1
 kind: StatefulSet
 metadata:
@@ -248,5 +247,5 @@ spec:
     - port: {{ .Values.bootNode.service.p2pUdpPort }}
       name: p2p-udp
       protocol: UDP
-{{ end }}
+---
 {{ end }}

--- a/spartan/aztec-network/templates/prover-node.yaml
+++ b/spartan/aztec-network/templates/prover-node.yaml
@@ -1,4 +1,3 @@
-{{- if not .Values.proverNode.external }}
 apiVersion: apps/v1
 kind: StatefulSet
 metadata:
@@ -216,5 +215,5 @@ spec:
     - port: {{ .Values.proverNode.service.p2pUdpPort }}
       name: p2p-udp
       protocol: UDP
-{{ end }}
+---
 {{ end }}

--- a/spartan/aztec-network/templates/prover-node.yaml
+++ b/spartan/aztec-network/templates/prover-node.yaml
@@ -120,12 +120,6 @@ spec:
               value: "0.0.0.0:{{ .Values.proverNode.service.p2pTcpPort }}"
             - name: P2P_UDP_LISTEN_ADDR
               value: "0.0.0.0:{{ .Values.proverNode.service.p2pUdpPort }}"
-            - name: OTEL_EXPORTER_OTLP_METRICS_ENDPOINT
-              value: {{ include "aztec-network.otelCollectorMetricsEndpoint" . | quote }}
-            - name: OTEL_EXPORTER_OTLP_TRACES_ENDPOINT
-              value: {{ include "aztec-network.otelCollectorTracesEndpoint" . | quote }}
-            - name: OTEL_EXPORTER_OTLP_LOGS_ENDPOINT
-              value: {{ include "aztec-network.otelCollectorLogsEndpoint" . | quote }}
           ports:
             - containerPort: {{ .Values.proverNode.service.nodePort }}
             - containerPort: {{ .Values.proverNode.service.p2pTcpPort }}

--- a/spartan/aztec-network/templates/pxe.yaml
+++ b/spartan/aztec-network/templates/pxe.yaml
@@ -1,4 +1,3 @@
-{{- if not .Values.pxe.external }}
 apiVersion: apps/v1
 kind: Deployment
 metadata:
@@ -118,5 +117,5 @@ spec:
       {{- if and (eq .Values.pxe.service.type "NodePort") .Values.pxe.service.nodePort }}
       nodePort: {{ .Values.pxe.service.nodePort }}
       {{- end }}
+---
 {{ end }}
-{{- end }}

--- a/spartan/aztec-network/templates/validator.yaml
+++ b/spartan/aztec-network/templates/validator.yaml
@@ -200,8 +200,8 @@ spec:
       protocol: TCP
 ---
 {{if .Values.network.public }}
-# Service template for TCP load balancers
 {{- range $i, $e := until (int .Values.validator.replicas) }}
+# Service template for TCP load balancers
 apiVersion: v1
 kind: Service
 metadata:

--- a/spartan/aztec-network/templates/validator.yaml
+++ b/spartan/aztec-network/templates/validator.yaml
@@ -1,4 +1,3 @@
-{{- if not .Values.validator.external }}
 apiVersion: apps/v1
 kind: StatefulSet
 metadata:
@@ -192,12 +191,13 @@ spec:
   ports:
     - port: {{ .Values.validator.service.p2pTcpPort }}
       name: p2p-tcp
+      protocol: TCP
     - port: {{ .Values.validator.service.p2pUdpPort }}
       name: p2p-udp
       protocol: UDP
     - port: {{ .Values.validator.service.nodePort }}
       name: node
-
+      protocol: TCP
 ---
 {{if .Values.network.public }}
 # Service template for TCP load balancers
@@ -205,7 +205,11 @@ spec:
 apiVersion: v1
 kind: Service
 metadata:
-  name: {{ include "aztec-network.fullname" $ }}-validator-lb-tcp-{{ $i }}
+  name: {{ include "aztec-network.fullname" $ }}-validator-{{ $i }}-lb-tcp
+  annotations:
+    service.beta.kubernetes.io/aws-load-balancer-type: "nlb"
+    service.beta.kubernetes.io/aws-load-balancer-nlb-target-type: "ip"
+    service.beta.kubernetes.io/aws-load-balancer-scheme: "internet-facing"
   labels:
     {{- include "aztec-network.labels" $ | nindent 4 }}
 spec:
@@ -217,14 +221,16 @@ spec:
   ports:
     - port: {{ $.Values.validator.service.p2pTcpPort }}
       name: p2p-tcp
+      protocol: TCP
     - port: {{ $.Values.validator.service.nodePort }}
       name: node
+      protocol: TCP
 ---
 # Service template for UDP load balancers
 apiVersion: v1
 kind: Service
 metadata:
-  name: {{ include "aztec-network.fullname" $ }}-validator-lb-udp-{{ $i }}
+  name: {{ include "aztec-network.fullname" $ }}-validator-{{ $i }}-lb-udp
   annotations:
     service.beta.kubernetes.io/aws-load-balancer-type: "nlb"
     service.beta.kubernetes.io/aws-load-balancer-nlb-target-type: "ip"
@@ -241,6 +247,6 @@ spec:
     - port: {{ $.Values.validator.service.p2pUdpPort }}
       name: p2p-udp
       protocol: UDP
+---
 {{- end }}
-{{ end }}
 {{ end }}

--- a/spartan/aztec-network/templates/validator.yaml
+++ b/spartan/aztec-network/templates/validator.yaml
@@ -19,8 +19,6 @@ spec:
         {{- include "aztec-network.selectorLabels" . | nindent 8 }}
         app: validator
     spec:
-      # We expect the validators to have already been added to the smart contract by this point - but this container still needs
-      # to be run in order to get the values
       initContainers:
         - name: wait-for-boot-node
           image: {{ .Values.images.curl.image }}
@@ -179,6 +177,7 @@ data:
   configure-validator-env.sh: |
     {{ .Files.Get "files/config/config-validator-env.sh" | nindent 4 }}
 ---
+# Headless service for StatefulSet DNS entries
 apiVersion: v1
 kind: Service
 metadata:
@@ -186,7 +185,7 @@ metadata:
   labels:
     {{- include "aztec-network.labels" . | nindent 4 }}
 spec:
-  type: ClusterIP
+  clusterIP: None
   selector:
     {{- include "aztec-network.selectorLabels" . | nindent 4 }}
     app: validator
@@ -198,43 +197,50 @@ spec:
       protocol: UDP
     - port: {{ .Values.validator.service.nodePort }}
       name: node
+
 ---
 {{if .Values.network.public }}
+# Service template for TCP load balancers
+{{- range $i, $e := until (int .Values.validator.replicas) }}
 apiVersion: v1
 kind: Service
 metadata:
-  name: {{ include "aztec-network.fullname" . }}-validator-lb-tcp
+  name: {{ include "aztec-network.fullname" $ }}-validator-lb-tcp-{{ $i }}
   labels:
-    {{- include "aztec-network.labels" . | nindent 4 }}
+    {{- include "aztec-network.labels" $ | nindent 4 }}
 spec:
   type: LoadBalancer
   selector:
-    {{- include "aztec-network.selectorLabels" . | nindent 4 }}
+    statefulset.kubernetes.io/pod-name: {{ include "aztec-network.fullname" $ }}-validator-{{ $i }}
+    {{- include "aztec-network.selectorLabels" $ | nindent 4 }}
     app: validator
   ports:
-    - port: {{ .Values.validator.service.p2pTcpPort }}
+    - port: {{ $.Values.validator.service.p2pTcpPort }}
       name: p2p-tcp
-    - port: {{ .Values.validator.service.nodePort }}
+    - port: {{ $.Values.validator.service.nodePort }}
       name: node
 ---
+# Service template for UDP load balancers
 apiVersion: v1
 kind: Service
 metadata:
-  name: {{ include "aztec-network.fullname" . }}-validator-lb-udp
+  name: {{ include "aztec-network.fullname" $ }}-validator-lb-udp-{{ $i }}
   annotations:
     service.beta.kubernetes.io/aws-load-balancer-type: "nlb"
     service.beta.kubernetes.io/aws-load-balancer-nlb-target-type: "ip"
     service.beta.kubernetes.io/aws-load-balancer-scheme: "internet-facing"
   labels:
-    {{- include "aztec-network.labels" . | nindent 4 }}
+    {{- include "aztec-network.labels" $ | nindent 4 }}
 spec:
   type: LoadBalancer
   selector:
-    {{- include "aztec-network.selectorLabels" . | nindent 4 }}
+    statefulset.kubernetes.io/pod-name: {{ include "aztec-network.fullname" $ }}-validator-{{ $i }}
+    {{- include "aztec-network.selectorLabels" $ | nindent 4 }}
     app: validator
   ports:
-    - port: {{ .Values.validator.service.p2pUdpPort }}
+    - port: {{ $.Values.validator.service.p2pUdpPort }}
       name: p2p-udp
       protocol: UDP
+{{- end }}
 {{ end }}
 {{ end }}

--- a/spartan/aztec-network/values.yaml
+++ b/spartan/aztec-network/values.yaml
@@ -21,7 +21,6 @@ images:
     pullPolicy: IfNotPresent
 
 bootNode:
-  external: false
   externalTcpHost: ""
   externalUdpHost: ""
   replicas: 1
@@ -59,7 +58,6 @@ bootNode:
   storage: "8Gi"
 
 validator:
-  external: false
   externalTcpHost: ""
   externalUdpHost: ""
   replicas: 1
@@ -92,7 +90,6 @@ validator:
   storage: "8Gi"
 
 proverNode:
-  external: false
   externalTcpHost: ""
   externalUdpHost: ""
   replicas: 1
@@ -112,7 +109,6 @@ proverNode:
   storage: "8Gi"
 
 pxe:
-  external: false
   externalHost: ""
   logLevel: "debug"
   debug: "aztec:*,-aztec:avm_simulator*,-aztec:libp2p_service*,-aztec:circuits:artifact_hash,-json-rpc*,-aztec:l2_block_stream,-aztec:world-state:database"
@@ -163,7 +159,6 @@ bot:
       cpu: "200m"
 
 ethereum:
-  external: false
   externalHost: ""
   replicas: 1
   chainId: 31337


### PR DESCRIPTION
# Change Log

- **UDP and TCP load balancers for Validator stateful set replicas**
When using `--set network.public=true`, each Validator stateful set replica gets 2 new load balancers. This configuration can also be added for other stateful sets if needed in the future.

- **Removed invalid `{{- if not .Values.< node ref >.external }}` template code**
`not` isn't a recognized base case within Helm templating. The code being removed was not functional in Kubernetes deployments. More information: https://helm.sh/docs/chart_template_guide/control_structures/#ifelse

- **Removed duplicate Otel env vars in `prover-node.yaml`**
This resolves the following Helm output warning during deployment: 

```
W1105 14:56:12.948976   57996 warnings.go:70] spec.template.spec.containers[0].env[19]: hides previous definition of "OTEL_EXPORTER_OTLP_METRICS_ENDPOINT", which may be dropped when using apply
W1105 14:56:12.949029   57996 warnings.go:70] spec.template.spec.containers[0].env[20]: hides previous definition of "OTEL_EXPORTER_OTLP_TRACES_ENDPOINT", which may be dropped when using apply
W1105 14:56:12.949040   57996 warnings.go:70] spec.template.spec.containers[0].env[21]: hides previous definition of "OTEL_EXPORTER_OTLP_LOGS_ENDPOINT", which may be dropped when using apply
```

Previous prover ENV VARS:

```
            - name: OTEL_EXPORTER_OTLP_METRICS_ENDPOINT
              value: {{ include "aztec-network.otelCollectorMetricsEndpoint" . | quote }}
            - name: OTEL_EXPORTER_OTLP_TRACES_ENDPOINT
              value: {{ include "aztec-network.otelCollectorTracesEndpoint" . | quote }}
            - name: OTEL_EXPORTER_OTLP_LOGS_ENDPOINT
              value: {{ include "aztec-network.otelCollectorLogsEndpoint" . | quote }}
           
           ... (additional vars excluded for brevity) ...
           
            - name: OTEL_EXPORTER_OTLP_METRICS_ENDPOINT
              value: {{ include "aztec-network.otelCollectorMetricsEndpoint" . | quote }}
            - name: OTEL_EXPORTER_OTLP_TRACES_ENDPOINT
              value: {{ include "aztec-network.otelCollectorTracesEndpoint" . | quote }}
            - name: OTEL_EXPORTER_OTLP_LOGS_ENDPOINT
              value: {{ include "aztec-network.otelCollectorLogsEndpoint" . | quote }}
```