### PR TITLE
fix: disallow contract registration in pxe of contract with duplicate private function selectors

### DIFF
--- a/yarn-project/pxe/src/database/contracts/contract_artifact_db.ts
+++ b/yarn-project/pxe/src/database/contracts/contract_artifact_db.ts
@@ -9,6 +9,7 @@ export interface ContractArtifactDatabase {
    * Adds a new contract artifact to the database or updates an existing one.
    * @param id - Id of the corresponding contract class.
    * @param contract - Contract artifact to add.
+   * @throws - If there are duplicate private function selectors.
    */
   addContractArtifact(id: Fr, contract: ContractArtifact): Promise<void>;
   /**


### PR DESCRIPTION
Related to https://github.com/AztecProtocol/aztec-packages/issues/4433

This PR adds pretty naive validation when adding a contract artifact to the pxe database. Specifically it rejects adding contract artifacts to the PXE with duplicate private function selectors.

This also assumes the absence of partial artifacts.
