### PR TITLE
chore: range error flake

### DIFF
--- a/yarn-project/circuit-types/src/logs/l1_payload/encrypted_log_payload.ts
+++ b/yarn-project/circuit-types/src/logs/l1_payload/encrypted_log_payload.ts
@@ -156,13 +156,7 @@ export class EncryptedLogPayload {
       return new EncryptedLogPayload(tag, AztecAddress.fromBuffer(incomingHeader), incomingBodyPlaintext);
     } catch (e: any) {
       // Following error messages are expected to occur when decryption fails
-      if (
-        !(e instanceof NotOnCurveError) &&
-        !e.message.endsWith('is greater or equal to field modulus.') &&
-        !e.message.startsWith('Invalid AztecAddress length') &&
-        !e.message.startsWith('Selector must fit in') &&
-        !e.message.startsWith('Attempted to read beyond buffer length')
-      ) {
+      if (!this.isAcceptableError(e)) {
         // If we encounter an unexpected error, we rethrow it
         throw e;
       }
@@ -222,18 +216,23 @@ export class EncryptedLogPayload {
       return new EncryptedLogPayload(tag, contractAddress, incomingBody);
     } catch (e: any) {
       // Following error messages are expected to occur when decryption fails
-      if (
-        !(e instanceof NotOnCurveError) &&
-        !e.message.endsWith('is greater or equal to field modulus.') &&
-        !e.message.startsWith('Invalid AztecAddress length') &&
-        !e.message.startsWith('Selector must fit in') &&
-        !e.message.startsWith('Attempted to read beyond buffer length')
-      ) {
+      if (!this.isAcceptableError(e)) {
         // If we encounter an unexpected error, we rethrow it
         throw e;
       }
       return;
     }
+  }
+
+  private static isAcceptableError(e: any) {
+    return (
+      e instanceof NotOnCurveError ||
+      e.message.endsWith('is greater or equal to field modulus.') ||
+      e.message.startsWith('Invalid AztecAddress length') ||
+      e.message.startsWith('Selector must fit in') ||
+      e.message.startsWith('Attempted to read beyond buffer length') ||
+      e.message.startsWith('RangeError [ERR_BUFFER_OUT_OF_BOUNDS]:')
+    );
   }
 
   public toBuffer() {


### PR DESCRIPTION
The trial decryption could sometimes fail with a `RangeError` when out of bounds of the buffers. This seems to not have been hit in the test previously, but in the re-org cases it happens relatively often which seems to lead to a case of the PXE shitting itself.

Generally we should probably look at the error handling in there, as its setup relying on strings feels very brittle to me.

---

The example where I think this caused crashed/timeouts in synching:
- PXE sending transactions
- Reorg happens
- New PXE to be synched because they don't handle reorgs currently
- The new PXE will run with new keys in its trial decryption
- Some case is now causing the "new" value because of a buffer out of bounds
- Throwing error
- PXE throwing tantrum.


