### PR TITLE
fix: don't crash sequencer when it is too slow

### DIFF
--- a/yarn-project/sequencer-client/src/sequencer/utils.ts
+++ b/yarn-project/sequencer-client/src/sequencer/utils.ts
@@ -1,4 +1,5 @@
 import type { BlockAttestation, EthAddress } from '@aztec/circuit-types';
+import { AZTEC_SLOT_DURATION } from '@aztec/circuits.js';
 import { Signature } from '@aztec/foundation/eth-signature';
 
 export enum SequencerState {
@@ -71,4 +72,8 @@ export function orderAttestations(attestations: BlockAttestation[], orderAddress
   });
 
   return orderedAttestations;
+}
+
+export function getSecondsIntoSlot(l1GenesisTime: number): number {
+  return (Date.now() / 1000 - l1GenesisTime) % AZTEC_SLOT_DURATION;
 }


### PR DESCRIPTION
This was a commit that was meant to go in with the last PR, but I got bit by automerge.

Only change is that we have a custom error, and if `doRealWork` throws because we're too slow, we catch it.