### PR TITLE
chore: continuing work on merkle hinting for avm

### DIFF
--- a/yarn-project/bb-prover/package.json
+++ b/yarn-project/bb-prover/package.json
@@ -71,6 +71,7 @@
     "@aztec/noir-protocol-circuits-types": "workspace:^",
     "@aztec/simulator": "workspace:^",
     "@aztec/telemetry-client": "workspace:^",
+    "@aztec/world-state": "workspace:^",
     "@msgpack/msgpack": "^3.0.0-beta2",
     "@noir-lang/noirc_abi": "portal:../../noir/packages/noirc_abi",
     "@noir-lang/types": "portal:../../noir/packages/types",

--- a/yarn-project/bb-prover/src/avm_proving.test.ts
+++ b/yarn-project/bb-prover/src/avm_proving.test.ts
@@ -21,13 +21,13 @@ import {
   resolveAvmTestContractAssertionMessage,
 } from '@aztec/simulator/avm/fixtures';
 import { NoopTelemetryClient } from '@aztec/telemetry-client/noop';
+import { MerkleTrees } from '@aztec/world-state';
 
 import { mock } from 'jest-mock-extended';
 import fs from 'node:fs/promises';
 import { tmpdir } from 'node:os';
 import path from 'path';
 
-import { MerkleTrees } from '../../world-state/src/world-state-db/merkle_trees.js';
 import { type BBSuccess, BB_RESULT, generateAvmProof, verifyAvmProof } from './bb/execute.js';
 import { getPublicInputs } from './test/test_avm.js';
 import { extractAvmVkData } from './verification_key/verification_key_data.js';
@@ -102,12 +102,12 @@ const proveAndVerifyAvmTestContract = async (
 
   const storageValue = new Fr(5);
   worldStateDB.storageRead.mockResolvedValue(Promise.resolve(storageValue));
-  // const slot = contractInstance.address;
 
   const trace = new PublicSideEffectTrace(startSideEffectCounter);
   const telemetry = new NoopTelemetryClient();
-  const merkleTree = await (await MerkleTrees.new(openTmpStore(), telemetry)).fork();
-  const persistableState = initPersistableStateManager({ worldStateDB, trace, merkleTree });
+  const merkleTrees = await (await MerkleTrees.new(openTmpStore(), telemetry)).fork();
+  worldStateDB.getMerkleInterface.mockReturnValue(merkleTrees);
+  const persistableState = initPersistableStateManager({ worldStateDB, trace, merkleTrees, doMerkleOperations: true });
   const environment = initExecutionEnvironment({
     functionSelector,
     calldata,

--- a/yarn-project/bb-prover/tsconfig.json
+++ b/yarn-project/bb-prover/tsconfig.json
@@ -25,11 +25,19 @@
       "path": "../telemetry-client"
     },
     {
+      "path": "../world-state"
+    },
+    {
       "path": "../ethereum"
+    },
+    {
+      "path": "../kv-store"
     },
     {
       "path": "../types"
     }
   ],
-  "include": ["src"]
+  "include": [
+    "src"
+  ]
 }

--- a/yarn-project/circuits.js/src/structs/avm/avm.ts
+++ b/yarn-project/circuits.js/src/structs/avm/avm.ts
@@ -837,13 +837,17 @@ export class AvmPublicDataWriteTreeHint {
 
 export class AvmExecutionHints {
   public readonly enqueuedCalls: Vector<AvmEnqueuedCallHint>;
+
   public readonly storageValues: Vector<AvmKeyValueHint>;
   public readonly noteHashExists: Vector<AvmKeyValueHint>;
   public readonly nullifierExists: Vector<AvmKeyValueHint>;
   public readonly l1ToL2MessageExists: Vector<AvmKeyValueHint>;
+
   public readonly externalCalls: Vector<AvmExternalCallHint>;
+
   public readonly contractInstances: Vector<AvmContractInstanceHint>;
   public readonly contractBytecodeHints: Vector<AvmContractBytecodeHints>;
+
   public readonly storageReadRequest: Vector<AvmPublicDataReadTreeHint>;
   public readonly storageUpdateRequest: Vector<AvmPublicDataWriteTreeHint>;
   public readonly nullifierReadRequest: Vector<AvmNullifierReadTreeHint>;

--- a/yarn-project/ivc-integration/package.json
+++ b/yarn-project/ivc-integration/package.json
@@ -69,7 +69,10 @@
   },
   "devDependencies": {
     "@aztec/bb-prover": "workspace:^",
+    "@aztec/kv-store": "workspace:^",
     "@aztec/simulator": "workspace:^",
+    "@aztec/telemetry-client": "workspace:^",
+    "@aztec/world-state": "workspace:^",
     "@jest/globals": "^29.5.0",
     "@msgpack/msgpack": "^3.0.0-beta2",
     "@types/jest": "^29.5.0",

--- a/yarn-project/ivc-integration/tsconfig.json
+++ b/yarn-project/ivc-integration/tsconfig.json
@@ -20,8 +20,21 @@
       "path": "../bb-prover"
     },
     {
+      "path": "../kv-store"
+    },
+    {
       "path": "../simulator"
+    },
+    {
+      "path": "../telemetry-client"
+    },
+    {
+      "path": "../world-state"
     }
   ],
-  "include": ["src", "artifacts/*.d.json.ts", "artifacts/**/*.d.json.ts"]
+  "include": [
+    "src",
+    "artifacts/*.d.json.ts",
+    "artifacts/**/*.d.json.ts"
+  ]
 }

--- a/yarn-project/simulator/src/avm/fixtures/index.ts
+++ b/yarn-project/simulator/src/avm/fixtures/index.ts
@@ -42,7 +42,8 @@ export function initPersistableStateManager(overrides?: {
   trace?: PublicSideEffectTraceInterface;
   publicStorage?: PublicStorage;
   nullifiers?: NullifierManager;
-  merkleTree?: MerkleTreeWriteOperations;
+  doMerkleOperations?: boolean;
+  merkleTrees?: MerkleTreeWriteOperations;
 }): AvmPersistableStateManager {
   const worldStateDB = overrides?.worldStateDB || mock<WorldStateDB>();
   return new AvmPersistableStateManager(
@@ -50,6 +51,8 @@ export function initPersistableStateManager(overrides?: {
     overrides?.trace || mock<PublicSideEffectTraceInterface>(),
     overrides?.publicStorage || new PublicStorage(worldStateDB),
     overrides?.nullifiers || new NullifierManager(worldStateDB),
+    overrides?.doMerkleOperations || false,
+    overrides?.merkleTrees || mock<MerkleTreeWriteOperations>(),
   );
 }
 

--- a/yarn-project/simulator/src/avm/journal/journal.test.ts
+++ b/yarn-project/simulator/src/avm/journal/journal.test.ts
@@ -54,22 +54,8 @@ describe('journal', () => {
 
       // We expect the journal to store the access in [storedVal, cachedVal] - [time0, time1]
       expect(trace.tracePublicStorageRead).toHaveBeenCalledTimes(2);
-      expect(trace.tracePublicStorageRead).toHaveBeenNthCalledWith(
-        /*nthCall=*/ 1,
-        address,
-        slot,
-        storedValue,
-        /*exists=*/ true,
-        /*cached=*/ false,
-      );
-      expect(trace.tracePublicStorageRead).toHaveBeenNthCalledWith(
-        /*nthCall=*/ 2,
-        address,
-        slot,
-        cachedValue,
-        /*exists=*/ true,
-        /*cached=*/ true,
-      );
+      expect(trace.tracePublicStorageRead).toHaveBeenNthCalledWith(/*nthCall=*/ 1, address, slot, storedValue);
+      expect(trace.tracePublicStorageRead).toHaveBeenNthCalledWith(/*nthCall=*/ 2, address, slot, cachedValue);
     });
   });
 
@@ -99,13 +85,7 @@ describe('journal', () => {
       const exists = await persistableState.checkNullifierExists(address, utxo);
       expect(exists).toEqual(false);
       expect(trace.traceNullifierCheck).toHaveBeenCalledTimes(1);
-      expect(trace.traceNullifierCheck).toHaveBeenCalledWith(
-        address,
-        utxo,
-        /*leafIndex=*/ Fr.ZERO,
-        exists,
-        /*isPending=*/ false,
-      );
+      expect(trace.traceNullifierCheck).toHaveBeenCalledWith(address, utxo, exists);
     });
 
     it('checkNullifierExists works for existing nullifiers', async () => {
@@ -113,12 +93,13 @@ describe('journal', () => {
       const exists = await persistableState.checkNullifierExists(address, utxo);
       expect(exists).toEqual(true);
       expect(trace.traceNullifierCheck).toHaveBeenCalledTimes(1);
-      expect(trace.traceNullifierCheck).toHaveBeenCalledWith(address, utxo, leafIndex, exists, /*isPending=*/ false);
+      expect(trace.traceNullifierCheck).toHaveBeenCalledWith(address, utxo, exists);
     });
 
     it('writeNullifier works', async () => {
       await persistableState.writeNullifier(address, utxo);
       expect(trace.traceNewNullifier).toHaveBeenCalledWith(expect.objectContaining(address), /*nullifier=*/ utxo);
+      expect(trace.traceNewNullifier).toHaveBeenCalledWith(address, /*nullifier=*/ utxo);
     });
 
     it('checkL1ToL2MessageExists works for missing message', async () => {

--- a/yarn-project/simulator/src/avm/opcodes/accrued_substate.test.ts
+++ b/yarn-project/simulator/src/avm/opcodes/accrued_substate.test.ts
@@ -169,14 +169,8 @@ describe('Accrued Substate', () => {
         expect(trace.traceNullifierCheck).toHaveBeenCalledTimes(1);
         const isPending = false;
         // leafIndex is returned from DB call for nullifiers, so it is absent on DB miss
-        const tracedLeafIndex = exists && !isPending ? leafIndex : Fr.ZERO;
-        expect(trace.traceNullifierCheck).toHaveBeenCalledWith(
-          address,
-          /*nullifier=*/ value0,
-          tracedLeafIndex,
-          exists,
-          isPending,
-        );
+        const _tracedLeafIndex = exists && !isPending ? leafIndex : Fr.ZERO;
+        expect(trace.traceNullifierCheck).toHaveBeenCalledWith(address, /*nullifier=*/ value0, exists);
       });
     });
   });

--- a/yarn-project/simulator/src/public/dual_side_effect_trace.ts
+++ b/yarn-project/simulator/src/public/dual_side_effect_trace.ts
@@ -41,17 +41,19 @@ export class DualSideEffectTrace implements PublicSideEffectTraceInterface {
   public tracePublicStorageRead(
     contractAddress: Fr,
     slot: Fr,
+    value: Fr,
     leafPreimage: PublicDataTreeLeafPreimage,
     leafIndex: Fr,
     path: Fr[],
   ) {
-    this.innerCallTrace.tracePublicStorageRead(contractAddress, slot, leafPreimage, leafIndex, path);
-    this.enqueuedCallTrace.tracePublicStorageRead(contractAddress, slot, leafPreimage, leafIndex, path);
+    this.innerCallTrace.tracePublicStorageRead(contractAddress, slot, value, leafPreimage, leafIndex, path);
+    this.enqueuedCallTrace.tracePublicStorageRead(contractAddress, slot, value, leafPreimage, leafIndex, path);
   }
 
   public tracePublicStorageWrite(
     contractAddress: Fr,
     slot: Fr,
+    value: Fr,
     lowLeafPreimage: PublicDataTreeLeafPreimage,
     lowLeafIndex: Fr,
     lowLeafPath: Fr[],
@@ -61,6 +63,7 @@ export class DualSideEffectTrace implements PublicSideEffectTraceInterface {
     this.innerCallTrace.tracePublicStorageWrite(
       contractAddress,
       slot,
+      value,
       lowLeafPreimage,
       lowLeafIndex,
       lowLeafPath,
@@ -70,6 +73,7 @@ export class DualSideEffectTrace implements PublicSideEffectTraceInterface {
     this.enqueuedCallTrace.tracePublicStorageWrite(
       contractAddress,
       slot,
+      value,
       lowLeafPreimage,
       lowLeafIndex,
       lowLeafPath,

--- a/yarn-project/simulator/src/public/enqueued_call_side_effect_trace.test.ts
+++ b/yarn-project/simulator/src/public/enqueued_call_side_effect_trace.test.ts
@@ -108,7 +108,7 @@ describe('Enqueued-call Side Effect Trace', () => {
 
   it('Should trace storage reads', () => {
     const leafPreimage = new PublicDataTreeLeafPreimage(slot, value, Fr.ZERO, 0n);
-    trace.tracePublicStorageRead(address, slot, leafPreimage, Fr.ZERO, []);
+    trace.tracePublicStorageRead(address, slot, value, leafPreimage, Fr.ZERO, []);
     expect(trace.getCounter()).toBe(startCounterPlus1);
 
     const expectedArray = PublicValidationRequests.empty().publicDataReads;
@@ -117,14 +117,14 @@ describe('Enqueued-call Side Effect Trace', () => {
 
     const circuitPublicInputs = toVMCircuitPublicInputs(trace);
     expect(circuitPublicInputs.validationRequests.publicDataReads).toEqual(expectedArray);
-    expect(trace.getAvmCircuitHints().storageValues.items).toEqual([{ key: startCounterFr, value: value }]);
+    expect(trace.getAvmCircuitHints().storageValues.items).toEqual([{ key: startCounterFr, value }]);
   });
 
   it('Should trace storage writes', () => {
     const lowLeafPreimage = new PublicDataTreeLeafPreimage(slot, value, Fr.ZERO, 0n);
     const newLeafPreimage = new PublicDataTreeLeafPreimage(slot, value, Fr.ZERO, 0n);
 
-    trace.tracePublicStorageWrite(address, slot, lowLeafPreimage, Fr.ZERO, [], newLeafPreimage, []);
+    trace.tracePublicStorageWrite(address, slot, value, lowLeafPreimage, Fr.ZERO, [], newLeafPreimage, []);
     expect(trace.getCounter()).toBe(startCounterPlus1);
 
     const expectedArray = PublicAccumulatedData.empty().publicDataUpdateRequests;
@@ -276,10 +276,10 @@ describe('Enqueued-call Side Effect Trace', () => {
     it('Should enforce maximum number of public storage reads', () => {
       for (let i = 0; i < MAX_PUBLIC_DATA_READS_PER_TX; i++) {
         const leafPreimage = new PublicDataTreeLeafPreimage(new Fr(i), new Fr(i), Fr.ZERO, 0n);
-        trace.tracePublicStorageRead(address, slot, leafPreimage, Fr.ZERO, []);
+        trace.tracePublicStorageRead(address, slot, value, leafPreimage, Fr.ZERO, []);
       }
       const leafPreimage = new PublicDataTreeLeafPreimage(new Fr(42), new Fr(42), Fr.ZERO, 0n);
-      expect(() => trace.tracePublicStorageRead(address, slot, leafPreimage, Fr.ZERO, [])).toThrow(
+      expect(() => trace.tracePublicStorageRead(address, slot, value, leafPreimage, Fr.ZERO, [])).toThrow(
         SideEffectLimitReachedError,
       );
     });
@@ -288,11 +288,11 @@ describe('Enqueued-call Side Effect Trace', () => {
       for (let i = 0; i < MAX_PUBLIC_DATA_UPDATE_REQUESTS_PER_TX; i++) {
         const lowLeafPreimage = new PublicDataTreeLeafPreimage(new Fr(i), new Fr(i), Fr.ZERO, 0n);
         const newLeafPreimage = new PublicDataTreeLeafPreimage(new Fr(i + 1), new Fr(i + 1), Fr.ZERO, 0n);
-        trace.tracePublicStorageWrite(address, slot, lowLeafPreimage, Fr.ZERO, [], newLeafPreimage, []);
+        trace.tracePublicStorageWrite(address, slot, value, lowLeafPreimage, Fr.ZERO, [], newLeafPreimage, []);
       }
       const leafPreimage = new PublicDataTreeLeafPreimage(new Fr(42), new Fr(42), Fr.ZERO, 0n);
       expect(() =>
-        trace.tracePublicStorageWrite(new Fr(42), new Fr(42), leafPreimage, Fr.ZERO, [], leafPreimage, []),
+        trace.tracePublicStorageWrite(new Fr(42), new Fr(42), value, leafPreimage, Fr.ZERO, [], leafPreimage, []),
       ).toThrow(SideEffectLimitReachedError);
     });
 
@@ -417,9 +417,9 @@ describe('Enqueued-call Side Effect Trace', () => {
       let testCounter = startCounter;
       const leafPreimage = new PublicDataTreeLeafPreimage(slot, value, Fr.ZERO, 0n);
       const lowLeafPreimage = new NullifierLeafPreimage(utxo, Fr.ZERO, 0n);
-      nestedTrace.tracePublicStorageRead(address, slot, leafPreimage, Fr.ZERO, []);
+      nestedTrace.tracePublicStorageRead(address, slot, value, leafPreimage, Fr.ZERO, []);
       testCounter++;
-      nestedTrace.tracePublicStorageWrite(address, slot, leafPreimage, Fr.ZERO, [], leafPreimage, []);
+      nestedTrace.tracePublicStorageWrite(address, slot, value, leafPreimage, Fr.ZERO, [], leafPreimage, []);
       testCounter++;
       nestedTrace.traceNoteHashCheck(address, utxo, leafIndex, existsDefault, []);
       // counter does not increment for note hash checks

--- a/yarn-project/simulator/src/public/enqueued_call_side_effect_trace.ts
+++ b/yarn-project/simulator/src/public/enqueued_call_side_effect_trace.ts
@@ -16,6 +16,7 @@ import {
   type ContractClassIdPreimage,
   EthAddress,
   Gas,
+  L1_TO_L2_MSG_TREE_HEIGHT,
   L2ToL1Message,
   LogHash,
   MAX_ENCRYPTED_LOGS_PER_TX,
@@ -31,14 +32,17 @@ import {
   MAX_PUBLIC_DATA_READS_PER_TX,
   MAX_PUBLIC_DATA_UPDATE_REQUESTS_PER_TX,
   MAX_UNENCRYPTED_LOGS_PER_TX,
+  NOTE_HASH_TREE_HEIGHT,
+  NULLIFIER_TREE_HEIGHT,
   NoteHash,
   Nullifier,
-  type NullifierLeafPreimage,
+  NullifierLeafPreimage,
+  PUBLIC_DATA_TREE_HEIGHT,
   PublicAccumulatedData,
   PublicAccumulatedDataArrayLengths,
   PublicCallRequest,
   PublicDataRead,
-  type PublicDataTreeLeafPreimage,
+  PublicDataTreeLeafPreimage,
   PublicDataUpdateRequest,
   PublicInnerCallRequest,
   PublicValidationRequestArrayLengths,
@@ -59,12 +63,19 @@ import { padArrayEnd } from '@aztec/foundation/collection';
 import { Fr } from '@aztec/foundation/fields';
 import { createDebugLogger } from '@aztec/foundation/log';
 
+import { assert } from 'console';
+
 import { type AvmContractCallResult } from '../avm/avm_contract_call_result.js';
 import { type AvmExecutionEnvironment } from '../avm/avm_execution_environment.js';
 import { createSimulationError } from '../common/errors.js';
 import { type EnqueuedPublicCallExecutionResultWithSideEffects, type PublicFunctionCallResult } from './execution.js';
 import { SideEffectLimitReachedError } from './side_effect_errors.js';
 import { type PublicSideEffectTraceInterface } from './side_effect_trace_interface.js';
+
+const emptyPublicDataPath = () => new Array(PUBLIC_DATA_TREE_HEIGHT).fill(Fr.zero());
+const emptyNoteHashPath = () => new Array(NOTE_HASH_TREE_HEIGHT).fill(Fr.zero());
+const emptyNullifierPath = () => new Array(NULLIFIER_TREE_HEIGHT).fill(Fr.zero());
+const emptyL1ToL2MessagePath = () => new Array(L1_TO_L2_MSG_TREE_HEIGHT).fill(Fr.zero());
 
 /**
  * A struct containing just the side effects as regular arrays
@@ -168,11 +179,16 @@ export class PublicEnqueuedCallSideEffectTrace implements PublicSideEffectTraceI
 
   public tracePublicStorageRead(
     contractAddress: Fr,
-    slot: Fr, // old
-    leafPreimage: PublicDataTreeLeafPreimage,
-    leafIndex: Fr,
-    path: Fr[],
+    slot: Fr,
+    value: Fr,
+    leafPreimage: PublicDataTreeLeafPreimage = PublicDataTreeLeafPreimage.empty(),
+    leafIndex: Fr = Fr.zero(),
+    path: Fr[] = emptyPublicDataPath(),
   ) {
+    if (!leafIndex.equals(Fr.zero())) {
+      // if we have real merkle hint content, make sure the value matches the the provided preimage
+      assert(leafPreimage.value.equals(value), 'Value mismatch when tracing in public data write');
+    }
     // NOTE: exists and cached are unused for now but may be used for optimizations or kernel hints later
     if (
       this.publicDataReads.length + this.previousValidationRequestArrayLengths.publicDataReads >=
@@ -182,10 +198,12 @@ export class PublicEnqueuedCallSideEffectTrace implements PublicSideEffectTraceI
     }
 
     const leafSlot = computePublicDataTreeLeafSlot(contractAddress, slot);
-    // Temp for backward compatibility
-    const { value } = leafPreimage;
+
     this.publicDataReads.push(new PublicDataRead(leafSlot, value, this.sideEffectCounter));
 
+    this.avmCircuitHints.storageValues.items.push(
+      new AvmKeyValueHint(/*key=*/ new Fr(this.sideEffectCounter), /*value=*/ value),
+    );
     this.avmCircuitHints.storageReadRequest.items.push(new AvmPublicDataReadTreeHint(leafPreimage, leafIndex, path));
     this.log.debug(`SLOAD cnt: ${this.sideEffectCounter} val: ${value} slot: ${slot}`);
     this.incrementSideEffectCounter();
@@ -194,12 +212,17 @@ export class PublicEnqueuedCallSideEffectTrace implements PublicSideEffectTraceI
   public tracePublicStorageWrite(
     contractAddress: Fr,
     slot: Fr,
-    lowLeafPreimage: PublicDataTreeLeafPreimage,
-    lowLeafIndex: Fr,
-    lowLeafPath: Fr[],
-    newLeafPreimage: PublicDataTreeLeafPreimage,
-    insertionPath: Fr[],
+    value: Fr,
+    lowLeafPreimage: PublicDataTreeLeafPreimage = PublicDataTreeLeafPreimage.empty(),
+    lowLeafIndex: Fr = Fr.zero(),
+    lowLeafPath: Fr[] = emptyPublicDataPath(),
+    newLeafPreimage: PublicDataTreeLeafPreimage = PublicDataTreeLeafPreimage.empty(),
+    insertionPath: Fr[] = emptyPublicDataPath(),
   ) {
+    if (!lowLeafIndex.equals(Fr.zero())) {
+      // if we have real merkle hint content, make sure the value matches the the provided preimage
+      assert(newLeafPreimage.value.equals(value), 'Value mismatch when tracing in public data read');
+    }
     if (
       this.publicDataWrites.length + this.previousAccumulatedDataArrayLengths.publicDataUpdateRequests >=
       MAX_PUBLIC_DATA_UPDATE_REQUESTS_PER_TX
@@ -211,8 +234,6 @@ export class PublicEnqueuedCallSideEffectTrace implements PublicSideEffectTraceI
     }
 
     const leafSlot = computePublicDataTreeLeafSlot(contractAddress, slot);
-    // Temp for backward compatibility
-    const { value } = newLeafPreimage;
     this.publicDataWrites.push(new PublicDataUpdateRequest(leafSlot, value, this.sideEffectCounter));
 
     // New hinting
@@ -225,7 +246,13 @@ export class PublicEnqueuedCallSideEffectTrace implements PublicSideEffectTraceI
   }
 
   // TODO(8287): _exists can be removed once we have the vm properly handling the equality check
-  public traceNoteHashCheck(_contractAddress: Fr, noteHash: Fr, leafIndex: Fr, exists: boolean, path: Fr[]) {
+  public traceNoteHashCheck(
+    _contractAddress: Fr,
+    noteHash: Fr,
+    leafIndex: Fr,
+    exists: boolean,
+    path: Fr[] = emptyNoteHashPath(),
+  ) {
     // NOTE: contractAddress is unused because noteHash is an already-siloed leaf
     if (
       this.noteHashReadRequests.length + this.previousValidationRequestArrayLengths.noteHashReadRequests >=
@@ -244,7 +271,7 @@ export class PublicEnqueuedCallSideEffectTrace implements PublicSideEffectTraceI
     // NOTE: counter does not increment for note hash checks (because it doesn't rely on pending note hashes)
   }
 
-  public traceNewNoteHash(contractAddress: Fr, noteHash: Fr, leafIndex: Fr, path: Fr[]) {
+  public traceNewNoteHash(contractAddress: Fr, noteHash: Fr, leafIndex: Fr, path: Fr[] = emptyNoteHashPath()) {
     if (this.noteHashes.length + this.previousAccumulatedDataArrayLengths.noteHashes >= MAX_NOTE_HASHES_PER_TX) {
       throw new SideEffectLimitReachedError('note hash', MAX_NOTE_HASHES_PER_TX);
     }
@@ -261,9 +288,9 @@ export class PublicEnqueuedCallSideEffectTrace implements PublicSideEffectTraceI
     contractAddress: Fr,
     nullifier: Fr,
     exists: boolean,
-    lowLeafPreimage: NullifierLeafPreimage,
-    lowLeafIndex: Fr,
-    lowLeafPath: Fr[],
+    lowLeafPreimage: NullifierLeafPreimage = NullifierLeafPreimage.empty(),
+    lowLeafIndex: Fr = Fr.zero(),
+    lowLeafPath: Fr[] = emptyNullifierPath(),
   ) {
     // NOTE: isPending and leafIndex are unused for now but may be used for optimizations or kernel hints later
     this.enforceLimitOnNullifierChecks();
@@ -293,10 +320,10 @@ export class PublicEnqueuedCallSideEffectTrace implements PublicSideEffectTraceI
   public traceNewNullifier(
     contractAddress: Fr,
     nullifier: Fr,
-    lowLeafPreimage: NullifierLeafPreimage,
-    lowLeafIndex: Fr,
-    lowLeafPath: Fr[],
-    insertionPath: Fr[],
+    lowLeafPreimage: NullifierLeafPreimage = NullifierLeafPreimage.empty(),
+    lowLeafIndex: Fr = Fr.zero(),
+    lowLeafPath: Fr[] = emptyNullifierPath(),
+    insertionPath: Fr[] = emptyNullifierPath(),
   ) {
     if (this.nullifiers.length + this.previousAccumulatedDataArrayLengths.nullifiers >= MAX_NULLIFIERS_PER_TX) {
       throw new SideEffectLimitReachedError('nullifier', MAX_NULLIFIERS_PER_TX);
@@ -313,7 +340,13 @@ export class PublicEnqueuedCallSideEffectTrace implements PublicSideEffectTraceI
   }
 
   // TODO(8287): _exists can be removed once we have the vm properly handling the equality check
-  public traceL1ToL2MessageCheck(_contractAddress: Fr, msgHash: Fr, msgLeafIndex: Fr, exists: boolean, path: Fr[]) {
+  public traceL1ToL2MessageCheck(
+    _contractAddress: Fr,
+    msgHash: Fr,
+    msgLeafIndex: Fr,
+    exists: boolean,
+    path: Fr[] = emptyL1ToL2MessagePath(),
+  ) {
     // NOTE: contractAddress is unused because msgHash is an already-siloed leaf
     if (
       this.l1ToL2MsgReadRequests.length + this.previousValidationRequestArrayLengths.l1ToL2MsgReadRequests >=

--- a/yarn-project/simulator/src/public/side_effect_trace.test.ts
+++ b/yarn-project/simulator/src/public/side_effect_trace.test.ts
@@ -71,7 +71,7 @@ describe('Side Effect Trace', () => {
 
   it('Should trace storage reads', () => {
     const leafPreimage = new PublicDataTreeLeafPreimage(slot, value, Fr.ZERO, 0n);
-    trace.tracePublicStorageRead(address, slot, leafPreimage, Fr.ZERO, []);
+    trace.tracePublicStorageRead(address, slot, value, leafPreimage, Fr.ZERO, []);
     expect(trace.getCounter()).toBe(startCounterPlus1);
 
     const pxResult = toPxResult(trace);
@@ -92,7 +92,7 @@ describe('Side Effect Trace', () => {
     const lowLeafPreimage = new PublicDataTreeLeafPreimage(slot, value, Fr.ZERO, 0n);
     const newLeafPreimage = new PublicDataTreeLeafPreimage(slot, value, Fr.ZERO, 0n);
 
-    trace.tracePublicStorageWrite(address, slot, lowLeafPreimage, Fr.ZERO, [], newLeafPreimage, []);
+    trace.tracePublicStorageWrite(address, slot, value, lowLeafPreimage, Fr.ZERO, [], newLeafPreimage, []);
     expect(trace.getCounter()).toBe(startCounterPlus1);
 
     const pxResult = toPxResult(trace);
@@ -251,10 +251,10 @@ describe('Side Effect Trace', () => {
     it('Should enforce maximum number of public storage reads', () => {
       for (let i = 0; i < MAX_PUBLIC_DATA_READS_PER_TX; i++) {
         const leafPreimage = new PublicDataTreeLeafPreimage(new Fr(i), new Fr(i), Fr.ZERO, 0n);
-        trace.tracePublicStorageRead(address, slot, leafPreimage, Fr.ZERO, []);
+        trace.tracePublicStorageRead(address, slot, value, leafPreimage, Fr.ZERO, []);
       }
       const leafPreimage = new PublicDataTreeLeafPreimage(new Fr(42), new Fr(42), Fr.ZERO, 0n);
-      expect(() => trace.tracePublicStorageRead(address, new Fr(42), leafPreimage, Fr.ZERO, [])).toThrow(
+      expect(() => trace.tracePublicStorageRead(address, new Fr(42), value, leafPreimage, Fr.ZERO, [])).toThrow(
         SideEffectLimitReachedError,
       );
     });
@@ -263,11 +263,11 @@ describe('Side Effect Trace', () => {
       for (let i = 0; i < MAX_PUBLIC_DATA_UPDATE_REQUESTS_PER_TX; i++) {
         const lowLeafPreimage = new PublicDataTreeLeafPreimage(new Fr(i), new Fr(i), Fr.ZERO, 0n);
         const newLeafPreimage = new PublicDataTreeLeafPreimage(new Fr(i + 1), new Fr(i + 1), Fr.ZERO, 0n);
-        trace.tracePublicStorageWrite(address, slot, lowLeafPreimage, Fr.ZERO, [], newLeafPreimage, []);
+        trace.tracePublicStorageWrite(address, slot, value, lowLeafPreimage, Fr.ZERO, [], newLeafPreimage, []);
       }
       const leafPreimage = new PublicDataTreeLeafPreimage(new Fr(42), new Fr(42), Fr.ZERO, 0n);
       expect(() =>
-        trace.tracePublicStorageWrite(new Fr(42), new Fr(42), leafPreimage, Fr.ZERO, [], leafPreimage, []),
+        trace.tracePublicStorageWrite(new Fr(42), new Fr(42), value, leafPreimage, Fr.ZERO, [], leafPreimage, []),
       ).toThrow(SideEffectLimitReachedError);
     });
 
@@ -391,9 +391,9 @@ describe('Side Effect Trace', () => {
     let testCounter = startCounter;
     const leafPreimage = new PublicDataTreeLeafPreimage(slot, value, Fr.ZERO, 0n);
     const lowLeafPreimage = new NullifierLeafPreimage(utxo, Fr.ZERO, 0n);
-    nestedTrace.tracePublicStorageRead(address, slot, leafPreimage, Fr.ZERO, []);
+    nestedTrace.tracePublicStorageRead(address, slot, value, leafPreimage, Fr.ZERO, []);
     testCounter++;
-    nestedTrace.tracePublicStorageWrite(address, slot, leafPreimage, Fr.ZERO, [], leafPreimage, []);
+    nestedTrace.tracePublicStorageWrite(address, slot, value, leafPreimage, Fr.ZERO, [], leafPreimage, []);
     testCounter++;
     nestedTrace.traceNoteHashCheck(address, utxo, leafIndex, existsDefault, []);
     // counter does not increment for note hash checks

--- a/yarn-project/simulator/src/public/side_effect_trace.ts
+++ b/yarn-project/simulator/src/public/side_effect_trace.ts
@@ -19,6 +19,7 @@ import {
   ContractStorageUpdateRequest,
   EthAddress,
   Gas,
+  L1_TO_L2_MSG_TREE_HEIGHT,
   L2ToL1Message,
   LogHash,
   MAX_L1_TO_L2_MSG_READ_REQUESTS_PER_TX,
@@ -31,11 +32,14 @@ import {
   MAX_PUBLIC_DATA_READS_PER_TX,
   MAX_PUBLIC_DATA_UPDATE_REQUESTS_PER_TX,
   MAX_UNENCRYPTED_LOGS_PER_TX,
+  NOTE_HASH_TREE_HEIGHT,
+  NULLIFIER_TREE_HEIGHT,
   NoteHash,
   Nullifier,
-  type NullifierLeafPreimage,
+  NullifierLeafPreimage,
+  PUBLIC_DATA_TREE_HEIGHT,
   type PublicCallRequest,
-  type PublicDataTreeLeafPreimage,
+  PublicDataTreeLeafPreimage,
   type PublicInnerCallRequest,
   ReadRequest,
   SerializableContractInstance,
@@ -44,6 +48,8 @@ import {
 } from '@aztec/circuits.js';
 import { Fr } from '@aztec/foundation/fields';
 import { createDebugLogger } from '@aztec/foundation/log';
+
+import { assert } from 'console';
 
 import { type AvmContractCallResult } from '../avm/avm_contract_call_result.js';
 import { type AvmExecutionEnvironment } from '../avm/avm_execution_environment.js';
@@ -57,6 +63,11 @@ import { SideEffectLimitReachedError } from './side_effect_errors.js';
 import { type PublicSideEffectTraceInterface } from './side_effect_trace_interface.js';
 
 export type TracedContractInstance = { exists: boolean } & ContractInstanceWithAddress;
+
+const emptyPublicDataPath = () => new Array(PUBLIC_DATA_TREE_HEIGHT).fill(Fr.zero());
+const emptyNoteHashPath = () => new Array(NOTE_HASH_TREE_HEIGHT).fill(Fr.zero());
+const emptyNullifierPath = () => new Array(NULLIFIER_TREE_HEIGHT).fill(Fr.zero());
+const emptyL1ToL2MessagePath = () => new Array(L1_TO_L2_MSG_TREE_HEIGHT).fill(Fr.zero());
 
 export class PublicSideEffectTrace implements PublicSideEffectTraceInterface {
   public log = createDebugLogger('aztec:public_side_effect_trace');
@@ -110,15 +121,19 @@ export class PublicSideEffectTrace implements PublicSideEffectTraceInterface {
   public tracePublicStorageRead(
     contractAddress: Fr,
     slot: Fr,
-    leafPreimage: PublicDataTreeLeafPreimage,
-    leafIndex: Fr,
-    path: Fr[],
+    value: Fr,
+    leafPreimage: PublicDataTreeLeafPreimage = PublicDataTreeLeafPreimage.empty(),
+    leafIndex: Fr = Fr.zero(),
+    path: Fr[] = emptyPublicDataPath(),
   ) {
+    if (!leafIndex.equals(Fr.zero())) {
+      // if we have real merkle hint content, make sure the value matches the the provided preimage
+      assert(leafPreimage.value.equals(value), 'Value mismatch when tracing in public data write');
+    }
     if (this.contractStorageReads.length >= MAX_PUBLIC_DATA_READS_PER_TX) {
       throw new SideEffectLimitReachedError('contract storage read', MAX_PUBLIC_DATA_READS_PER_TX);
     }
-    // Temp for backward compatibility
-    const { value } = leafPreimage;
+
     this.contractStorageReads.push(
       new ContractStorageRead(slot, value, this.sideEffectCounter, AztecAddress.fromField(contractAddress)),
     );
@@ -136,17 +151,21 @@ export class PublicSideEffectTrace implements PublicSideEffectTraceInterface {
   public tracePublicStorageWrite(
     contractAddress: Fr,
     slot: Fr,
-    lowLeafPreimage: PublicDataTreeLeafPreimage,
-    lowLeafIndex: Fr,
-    lowLeafPath: Fr[],
-    newLeafPreimage: PublicDataTreeLeafPreimage,
-    insertionPath: Fr[],
+    value: Fr,
+    lowLeafPreimage: PublicDataTreeLeafPreimage = PublicDataTreeLeafPreimage.empty(),
+    lowLeafIndex: Fr = Fr.zero(),
+    lowLeafPath: Fr[] = emptyPublicDataPath(),
+    newLeafPreimage: PublicDataTreeLeafPreimage = PublicDataTreeLeafPreimage.empty(),
+    insertionPath: Fr[] = emptyPublicDataPath(),
   ) {
+    if (!lowLeafIndex.equals(Fr.zero())) {
+      // if we have real merkle hint content, make sure the value matches the the provided preimage
+      assert(newLeafPreimage.value.equals(value), 'Value mismatch when tracing in public data read');
+    }
     if (this.contractStorageUpdateRequests.length >= MAX_PUBLIC_DATA_UPDATE_REQUESTS_PER_TX) {
       throw new SideEffectLimitReachedError('contract storage write', MAX_PUBLIC_DATA_UPDATE_REQUESTS_PER_TX);
     }
-    // Temp for backward compatibility
-    const { value } = newLeafPreimage;
+
     this.contractStorageUpdateRequests.push(
       new ContractStorageUpdateRequest(slot, value, this.sideEffectCounter, contractAddress),
     );
@@ -161,7 +180,13 @@ export class PublicSideEffectTrace implements PublicSideEffectTraceInterface {
   }
 
   // TODO(8287): _exists can be removed once we have the vm properly handling the equality check
-  public traceNoteHashCheck(_contractAddress: Fr, noteHash: Fr, leafIndex: Fr, exists: boolean, path: Fr[]) {
+  public traceNoteHashCheck(
+    _contractAddress: Fr,
+    noteHash: Fr,
+    leafIndex: Fr,
+    exists: boolean,
+    path: Fr[] = emptyNoteHashPath(),
+  ) {
     // NOTE: contractAddress is unused but will be important when an AVM circuit processes an entire enqueued call
     if (this.noteHashReadRequests.length >= MAX_NOTE_HASH_READ_REQUESTS_PER_TX) {
       throw new SideEffectLimitReachedError('note hash read request', MAX_NOTE_HASH_READ_REQUESTS_PER_TX);
@@ -176,7 +201,7 @@ export class PublicSideEffectTrace implements PublicSideEffectTraceInterface {
     // NOTE: counter does not increment for note hash checks (because it doesn't rely on pending note hashes)
   }
 
-  public traceNewNoteHash(_contractAddress: Fr, noteHash: Fr, leafIndex: Fr, path: Fr[]) {
+  public traceNewNoteHash(_contractAddress: Fr, noteHash: Fr, leafIndex: Fr, path: Fr[] = emptyNoteHashPath()) {
     if (this.noteHashes.length >= MAX_NOTE_HASHES_PER_TX) {
       throw new SideEffectLimitReachedError('note hash', MAX_NOTE_HASHES_PER_TX);
     }
@@ -192,9 +217,9 @@ export class PublicSideEffectTrace implements PublicSideEffectTraceInterface {
     _contractAddress: Fr,
     nullifier: Fr,
     exists: boolean,
-    lowLeafPreimage: NullifierLeafPreimage,
-    lowLeafIndex: Fr,
-    lowLeafPath: Fr[],
+    lowLeafPreimage: NullifierLeafPreimage = NullifierLeafPreimage.empty(),
+    lowLeafIndex: Fr = Fr.zero(),
+    lowLeafPath: Fr[] = emptyNullifierPath(),
   ) {
     // NOTE: contractAddress is unused but will be important when an AVM circuit processes an entire enqueued call
     // NOTE: isPending and leafIndex are unused for now but may be used for optimizations or kernel hints later
@@ -222,10 +247,10 @@ export class PublicSideEffectTrace implements PublicSideEffectTraceInterface {
   public traceNewNullifier(
     _contractAddress: Fr,
     nullifier: Fr,
-    lowLeafPreimage: NullifierLeafPreimage,
-    lowLeafIndex: Fr,
-    lowLeafPath: Fr[],
-    insertionPath: Fr[],
+    lowLeafPreimage: NullifierLeafPreimage = NullifierLeafPreimage.empty(),
+    lowLeafIndex: Fr = Fr.zero(),
+    lowLeafPath: Fr[] = emptyNullifierPath(),
+    insertionPath: Fr[] = emptyNullifierPath(),
   ) {
     // NOTE: contractAddress is unused but will be important when an AVM circuit processes an entire enqueued call
     if (this.nullifiers.length >= MAX_NULLIFIERS_PER_TX) {
@@ -240,7 +265,13 @@ export class PublicSideEffectTrace implements PublicSideEffectTraceInterface {
   }
 
   // TODO(8287): _exists can be removed once we have the vm properly handling the equality check
-  public traceL1ToL2MessageCheck(_contractAddress: Fr, msgHash: Fr, msgLeafIndex: Fr, exists: boolean, path: Fr[]) {
+  public traceL1ToL2MessageCheck(
+    _contractAddress: Fr,
+    msgHash: Fr,
+    msgLeafIndex: Fr,
+    exists: boolean,
+    path: Fr[] = emptyL1ToL2MessagePath(),
+  ) {
     // NOTE: contractAddress is unused but will be important when an AVM circuit processes an entire enqueued call
     if (this.l1ToL2MsgReadRequests.length >= MAX_L1_TO_L2_MSG_READ_REQUESTS_PER_TX) {
       throw new SideEffectLimitReachedError('l1 to l2 message read request', MAX_L1_TO_L2_MSG_READ_REQUESTS_PER_TX);

--- a/yarn-project/simulator/src/public/side_effect_trace_interface.ts
+++ b/yarn-project/simulator/src/public/side_effect_trace_interface.ts
@@ -22,38 +22,40 @@ export interface PublicSideEffectTraceInterface {
   tracePublicStorageRead(
     contractAddress: Fr,
     slot: Fr,
-    leafPreimage: PublicDataTreeLeafPreimage,
-    leafIndex: Fr,
-    path: Fr[],
+    value: Fr,
+    leafPreimage?: PublicDataTreeLeafPreimage,
+    leafIndex?: Fr,
+    path?: Fr[],
   ): void;
   tracePublicStorageWrite(
     contractAddress: Fr,
     slot: Fr, // This is the storage slot not the computed leaf slot
-    lowLeafPreimage: PublicDataTreeLeafPreimage,
-    lowLeafIndex: Fr,
-    lowLeafPath: Fr[],
-    newLeafPreimage: PublicDataTreeLeafPreimage,
-    insertionPath: Fr[],
+    value: Fr,
+    lowLeafPreimage?: PublicDataTreeLeafPreimage,
+    lowLeafIndex?: Fr,
+    lowLeafPath?: Fr[],
+    newLeafPreimage?: PublicDataTreeLeafPreimage,
+    insertionPath?: Fr[],
   ): void;
-  traceNoteHashCheck(contractAddress: Fr, noteHash: Fr, leafIndex: Fr, exists: boolean, path: Fr[]): void;
-  traceNewNoteHash(contractAddress: Fr, noteHash: Fr, leafIndex: Fr, path: Fr[]): void;
+  traceNoteHashCheck(contractAddress: Fr, noteHash: Fr, leafIndex: Fr, exists: boolean, path?: Fr[]): void;
+  traceNewNoteHash(contractAddress: Fr, noteHash: Fr, leafIndex?: Fr, path?: Fr[]): void;
   traceNullifierCheck(
     contractAddress: Fr,
     nullifier: Fr,
     exists: boolean,
-    lowLeafPreimage: NullifierLeafPreimage,
-    lowLeafIndex: Fr,
-    lowLeafPath: Fr[],
+    lowLeafPreimage?: NullifierLeafPreimage,
+    lowLeafIndex?: Fr,
+    lowLeafPath?: Fr[],
   ): void;
   traceNewNullifier(
     contractAddress: Fr,
     nullifier: Fr,
-    lowLeafPreimage: NullifierLeafPreimage,
-    lowLeafIndex: Fr,
-    lowLeafPath: Fr[],
-    insertionPath: Fr[],
+    lowLeafPreimage?: NullifierLeafPreimage,
+    lowLeafIndex?: Fr,
+    lowLeafPath?: Fr[],
+    insertionPath?: Fr[],
   ): void;
-  traceL1ToL2MessageCheck(contractAddress: Fr, msgHash: Fr, msgLeafIndex: Fr, exists: boolean, path: Fr[]): void;
+  traceL1ToL2MessageCheck(contractAddress: Fr, msgHash: Fr, msgLeafIndex: Fr, exists: boolean, path?: Fr[]): void;
   traceNewL2ToL1Message(contractAddress: Fr, recipient: Fr, content: Fr): void;
   traceUnencryptedLog(contractAddress: Fr, log: Fr[]): void;
   traceGetContractInstance(contractAddress: Fr, exists: boolean, instance?: SerializableContractInstance): void;

--- a/yarn-project/yarn.lock
+++ b/yarn-project/yarn.lock
@@ -293,6 +293,7 @@ __metadata:
     "@aztec/simulator": "workspace:^"
     "@aztec/telemetry-client": "workspace:^"
     "@aztec/types": "workspace:^"
+    "@aztec/world-state": "workspace:^"
     "@jest/globals": ^29.5.0
     "@msgpack/msgpack": ^3.0.0-beta2
     "@noir-lang/noirc_abi": "portal:../../noir/packages/noirc_abi"
@@ -694,8 +695,11 @@ __metadata:
     "@aztec/bb-prover": "workspace:^"
     "@aztec/circuits.js": "workspace:^"
     "@aztec/foundation": "workspace:^"
+    "@aztec/kv-store": "workspace:^"
     "@aztec/simulator": "workspace:^"
+    "@aztec/telemetry-client": "workspace:^"
     "@aztec/types": "workspace:^"
+    "@aztec/world-state": "workspace:^"
     "@jest/globals": ^29.5.0
     "@msgpack/msgpack": ^3.0.0-beta2
     "@noir-lang/noir_codegen": "portal:../../noir/packages/noir_codegen"


### PR DESCRIPTION
This builds on the base PR #9658, cleans things up a bit, and starts updating tests.

- Adds some public storage tests to `avm_simulator.test.ts` that test with a real merkle tree.
- Adds a flag to toggle use of real merkle ops in state manager (sets that flag for all old tests)
- Changes trace functions to allow all merkle args to be undefined (e.g. when flag is set)

I haven't:
- Added real merkle tests for nullifier, note hash, message ops
- Updated the state manager tests with some real merkle tests
- Updated opcode tests with real merkle tests (if we even want that)