### PR TITLE
fix: boot node pod dns in Google Kubernetes Engine

### DIFF
--- a/spartan/aztec-network/templates/boot-node.yaml
+++ b/spartan/aztec-network/templates/boot-node.yaml
@@ -190,6 +190,7 @@ data:
     export FEE_JUICE_PORTAL_CONTRACT_ADDRESS={{ .Values.bootNode.contracts.feeJuicePortalAddress }}
 {{- end }}
 ---
+# Headless service for StatefulSet DNS entries
 apiVersion: v1
 kind: Service
 metadata:
@@ -197,7 +198,7 @@ metadata:
   labels:
     {{- include "aztec-network.labels" . | nindent 4 }}
 spec:
-  type: ClusterIP
+  clusterIP: None
   selector:
     {{- include "aztec-network.selectorLabels" . | nindent 4 }}
     app: boot-node


### PR DESCRIPTION
# Change Log

- Change boot node service to headless for pod-level dns

Currently pod dns names do not resolve in Google Kubernetes Engine, even though they resolve in EKS (a difference of cluster-level DNS implementation). Setting the boot node service to headless prevents it from being assigned and IP and instead inserts the required pod DNS entries. This change has been tested both in AWS and GCloud. 