### PR TITLE
fix(docs): Add missing dependency in token tutorial

### DIFF
--- a/docs/docs/tutorials/codealong/contract_tutorials/token_contract.md
+++ b/docs/docs/tutorials/codealong/contract_tutorials/token_contract.md
@@ -48,6 +48,7 @@ Inside `Nargo.toml` paste the following:
 aztec = { git="https://github.com/AztecProtocol/aztec-packages/", tag="#include_aztec_version", directory="noir-projects/aztec-nr/aztec" }
 authwit={ git="https://github.com/AztecProtocol/aztec-packages/", tag="#include_aztec_version", directory="noir-projects/aztec-nr/authwit"}
 compressed_string = {git="https://github.com/AztecProtocol/aztec-packages/", tag="#include_aztec_version", directory="noir-projects/aztec-nr/compressed-string"}
+uint_note = { git="https://github.com/AztecProtocol/aztec-packages/", tag="#include_aztec_version", directory="noir-projects/aztec-nr/uint-note" }
 ```
 
 We will be working within `main.nr` for the rest of the tutorial.


### PR DESCRIPTION
Adds a missing dependency in the token contract tutorial.