### PR TITLE
fix: Fix mac build by calling `count` on durations

### DIFF
--- a/barretenberg/cpp/src/barretenberg/client_ivc/client_ivc.cpp
+++ b/barretenberg/cpp/src/barretenberg/client_ivc/client_ivc.cpp
@@ -355,7 +355,7 @@ bool ClientIVC::prove_and_verify()
     auto proof = prove();
     auto end = std::chrono::steady_clock::now();
     auto diff = std::chrono::duration_cast<std::chrono::milliseconds>(end - start);
-    vinfo("time to call ClientIVC::prove: ", diff, " ms.");
+    vinfo("time to call ClientIVC::prove: ", diff.count(), " ms.");
     return verify(proof);
 }
 

--- a/barretenberg/cpp/src/barretenberg/dsl/acir_proofs/c_bind.cpp
+++ b/barretenberg/cpp/src/barretenberg/dsl/acir_proofs/c_bind.cpp
@@ -264,7 +264,7 @@ WASM_EXPORT void acir_prove_and_verify_aztec_client(uint8_t const* acir_stack,
     }
     auto end = std::chrono::steady_clock::now();
     auto diff = std::chrono::duration_cast<std::chrono::milliseconds>(end - start);
-    vinfo("time to construct and accumulate all circuits: ", diff);
+    vinfo("time to construct and accumulate all circuits: ", diff.count());
 
     vinfo("calling ivc.prove_and_verify...");
     bool result = ivc.prove_and_verify();

--- a/barretenberg/cpp/src/barretenberg/ultra_honk/decider_proving_key.hpp
+++ b/barretenberg/cpp/src/barretenberg/ultra_honk/decider_proving_key.hpp
@@ -295,7 +295,7 @@ template <IsHonkFlavor Flavor> class DeciderProvingKey_ {
         }
         auto end = std::chrono::steady_clock::now();
         auto diff = std::chrono::duration_cast<std::chrono::milliseconds>(end - start);
-        vinfo("time to construct proving key: ", diff, " ms.");
+        vinfo("time to construct proving key: ", diff.count(), " ms.");
     }
 
     DeciderProvingKey_() = default;


### PR DESCRIPTION
We can print `std::chrono` durations our usual PR test builds but not on mac. Should fix the mac build if this is the only issue.