### PR TITLE
fix: deploy l2 contracts fails on 48 validator

### DIFF
--- a/spartan/aztec-network/templates/_helpers.tpl
+++ b/spartan/aztec-network/templates/_helpers.tpl
@@ -78,7 +78,7 @@ http://{{ include "aztec-network.fullname" . }}-boot-node-0.{{ include "aztec-ne
 {{- if .Values.validator.externalTcpHost -}}
 http://{{ .Values.validator.externalTcpHost }}:{{ .Values.validator.service.nodePort }}
 {{- else -}}
-http://{{ include "aztec-network.fullname" . }}-validator-0.{{ include "aztec-network.fullname" . }}-validator.{{ .Release.Namespace }}.svc.cluster.local:{{ .Values.validator.service.nodePort }}
+http://{{ include "aztec-network.fullname" . }}-validator.{{ .Release.Namespace }}.svc.cluster.local:{{ .Values.validator.service.nodePort }}
 {{- end -}}
 {{- end -}}
 

--- a/spartan/aztec-network/templates/pxe.yaml
+++ b/spartan/aztec-network/templates/pxe.yaml
@@ -49,7 +49,7 @@ spec:
             - name: ETHEREUM_HOST
               value: {{ include "aztec-network.ethereumHost" . | quote }}
             - name: AZTEC_NODE_URL
-              value: {{ include "aztec-network.bootNodeUrl" . | quote }}
+              value: {{ include "aztec-network.validatorUrl" . | quote }}
             - name: LOG_JSON
               value: "1"
             - name: LOG_LEVEL

--- a/spartan/aztec-network/values.yaml
+++ b/spartan/aztec-network/values.yaml
@@ -111,6 +111,7 @@ proverNode:
   storage: "8Gi"
 
 pxe:
+  proverEnabled: false
   externalHost: ""
   logLevel: "debug"
   debug: "aztec:*,-aztec:avm_simulator*,-aztec:libp2p_service*,-aztec:circuits:artifact_hash,-json-rpc*,-aztec:l2_block_stream,-aztec:world-state:database"

--- a/spartan/aztec-network/values/48-validators.yaml
+++ b/spartan/aztec-network/values/48-validators.yaml
@@ -1,15 +1,4 @@
-##########
-# BEWARE #
-##########
-# You need to deploy the metrics helm chart before using this values file.
-# head to spartan/metrics and run `./install.sh`
-# (then `./forward.sh` if you want to see it)
-telemetry:
-  enabled: true
-  otelCollectorEndpoint: http://metrics-opentelemetry-collector.metrics:4318
-
 validator:
-  debug: "aztec:*,-aztec:avm_simulator:*,-aztec:libp2p_service"
   replicas: 48
   validatorKeys:
     - 0xac0974bec39a17e36ba4a6b4d238ff944bacb478cbed5efcae784d7bf4f2ff80

--- a/spartan/scripts/deploy_spartan.sh
+++ b/spartan/scripts/deploy_spartan.sh
@@ -6,6 +6,7 @@ TAG=$1
 VALUES=$2
 NAMESPACE=${3:-spartan}
 PROD=${4:-true}
+IMAGE_REPO=${5:-aztecprotocol}
 PROD_ARGS=""
 if [ "$PROD" = "true" ] ; then
   PROD_ARGS="--set network.public=true --set telemetry.enabled=true --set telemetry.otelCollectorEndpoint=http://metrics-opentelemetry-collector.metrics:4318"
@@ -45,8 +46,8 @@ log_stern &
 
 function upgrade() {
   # pull and resolve the image just to be absolutely sure k8s gets the latest image in the tag we want
-  docker pull --platform linux/amd64 aztecprotocol/aztec:$TAG
-  IMAGE=$(docker inspect --format='{{index .RepoDigests 0}}' aztecprotocol/aztec:$TAG)
+  docker pull --platform linux/amd64 $IMAGE_REPO/aztec:$TAG
+  IMAGE=$(docker inspect --format='{{index .RepoDigests 0}}' $IMAGE_REPO/aztec:$TAG)
   if ! [ -z "${PRINT_ONLY:-}" ] ; then
     helm template $NAMESPACE $SCRIPT_DIR/../aztec-network \
           --namespace $NAMESPACE \

--- a/yarn-project/cli/src/cmds/misc/setup_contracts.ts
+++ b/yarn-project/cli/src/cmds/misc/setup_contracts.ts
@@ -26,10 +26,12 @@ export async function setupCanonicalL2FeeJuice(
       .prove({ fee: { paymentMethod: new NoFeePaymentMethod(), gasSettings: GasSettings.teardownless() } });
 
     await provenTx.send().wait(waitOpts);
+    log('setupCanonicalL2FeeJuice: Fee juice contract initialized');
   } catch (e: any) {
-    if (e instanceof Error) {
-      log(e.message);
+    if (e instanceof Error && e.message.includes('(method pxe_simulateTx) (code 400) Assertion failed')) {
+      log('setupCanonicalL2FeeJuice: Fee juice contract already initialized');
+    } else {
+      throw e;
     }
-    log('setupCanonicalL2FeeJuice: Fee juice contract already initialized');
   }
 }

--- a/yarn-project/cli/src/cmds/misc/setup_contracts.ts
+++ b/yarn-project/cli/src/cmds/misc/setup_contracts.ts
@@ -28,6 +28,7 @@ export async function setupCanonicalL2FeeJuice(
     await provenTx.send().wait(waitOpts);
     log('setupCanonicalL2FeeJuice: Fee juice contract initialized');
   } catch (e: any) {
+    // TODO: make this less brittle, e.g. using a 204 http code
     if (e instanceof Error && e.message.includes('(method pxe_simulateTx) (code 400) Assertion failed')) {
       log('setupCanonicalL2FeeJuice: Fee juice contract already initialized');
     } else {

--- a/yarn-project/cli/src/cmds/misc/setup_contracts.ts
+++ b/yarn-project/cli/src/cmds/misc/setup_contracts.ts
@@ -31,6 +31,7 @@ export async function setupCanonicalL2FeeJuice(
     if (e instanceof Error && e.message.includes('(method pxe_simulateTx) (code 400) Assertion failed')) {
       log('setupCanonicalL2FeeJuice: Fee juice contract already initialized');
     } else {
+      log('setupCanonicalL2FeeJuice: Error initializing fee juice contract', e);
       throw e;
     }
   }

--- a/yarn-project/protocol-contracts/src/protocol_contract_data.ts
+++ b/yarn-project/protocol-contracts/src/protocol_contract_data.ts
@@ -50,14 +50,14 @@ export const ProtocolContractAddress: Record<ProtocolContractName, AztecAddress>
 };
 
 export const ProtocolContractLeaf = {
-  AuthRegistry: Fr.fromString('0x1a129d5eeeb6eed1139d24c108050f941a6cc4cbe91a844dc10c40f4c1513b14'),
-  ContractInstanceDeployer: Fr.fromString('0x01314b6c482a9d8f5418cd0d43c17a1c5899ae7c2e1d2f82817baaf3f3b45bd9'),
-  ContractClassRegisterer: Fr.fromString('0x04b3be8e2240fc0f0a2fd5d8072afabc406e79bebefc6236d20600072246a326'),
-  MultiCallEntrypoint: Fr.fromString('0x20a2e7e882045d27b3aa9e36188b8e45483b3c11652d4a46406699e5eb4efa9b'),
-  FeeJuice: Fr.fromString('0x0edb9dfdcacb06d81507ad6b95d0789a5dbd217424b000f056034ea8fadd07c2'),
-  Router: Fr.fromString('0x195eb06e13bd2a704f50a8480aa66a30e0913e73daa453fc2bea2ab880855dae'),
+  AuthRegistry: Fr.fromString('0x0931f3bf89563f3898ae9650851083cd560ad800c2e3c561c3853eec4dd7ea8b'),
+  ContractInstanceDeployer: Fr.fromString('0x266ea4c9917455daa905c1dd1a10753714c6d0369b6f2fe23feeca6de556d164'),
+  ContractClassRegisterer: Fr.fromString('0x1ccb7a219f72a851089e956d527997b01068d5a28c9ae96b35ebeb45f068af23'),
+  MultiCallEntrypoint: Fr.fromString('0x1d060217817cf472a579638db722903fd1bbc4c3bdb0ecefa5694c0d4eed851a'),
+  FeeJuice: Fr.fromString('0x1dab5b687d0c04d2f17a1c8623dea23e7416700891ba1c6e0e86ef678f4727cb'),
+  Router: Fr.fromString('0x00827d5a8aedb9627d9e5de04735600a4dbb817d4a2f51281aab991699f5de99'),
 };
 
 export const protocolContractTreeRoot = Fr.fromString(
-  '0x28c4676f6233fc2adf42179f2a5fec7d8cae9efa6344ade2fd0db8ed9ac386da',
+  '0x0f174f6837842b1004a9a41dd736800c12c5dc19f206aed35551b07f8ca6edfb',
 );

--- a/yarn-project/protocol-contracts/src/protocol_contract_data.ts
+++ b/yarn-project/protocol-contracts/src/protocol_contract_data.ts
@@ -50,14 +50,14 @@ export const ProtocolContractAddress: Record<ProtocolContractName, AztecAddress>
 };
 
 export const ProtocolContractLeaf = {
-  AuthRegistry: Fr.fromString('0x0931f3bf89563f3898ae9650851083cd560ad800c2e3c561c3853eec4dd7ea8b'),
-  ContractInstanceDeployer: Fr.fromString('0x266ea4c9917455daa905c1dd1a10753714c6d0369b6f2fe23feeca6de556d164'),
-  ContractClassRegisterer: Fr.fromString('0x1ccb7a219f72a851089e956d527997b01068d5a28c9ae96b35ebeb45f068af23'),
-  MultiCallEntrypoint: Fr.fromString('0x1d060217817cf472a579638db722903fd1bbc4c3bdb0ecefa5694c0d4eed851a'),
-  FeeJuice: Fr.fromString('0x1dab5b687d0c04d2f17a1c8623dea23e7416700891ba1c6e0e86ef678f4727cb'),
-  Router: Fr.fromString('0x00827d5a8aedb9627d9e5de04735600a4dbb817d4a2f51281aab991699f5de99'),
+  AuthRegistry: Fr.fromString('0x1a129d5eeeb6eed1139d24c108050f941a6cc4cbe91a844dc10c40f4c1513b14'),
+  ContractInstanceDeployer: Fr.fromString('0x01314b6c482a9d8f5418cd0d43c17a1c5899ae7c2e1d2f82817baaf3f3b45bd9'),
+  ContractClassRegisterer: Fr.fromString('0x04b3be8e2240fc0f0a2fd5d8072afabc406e79bebefc6236d20600072246a326'),
+  MultiCallEntrypoint: Fr.fromString('0x20a2e7e882045d27b3aa9e36188b8e45483b3c11652d4a46406699e5eb4efa9b'),
+  FeeJuice: Fr.fromString('0x0edb9dfdcacb06d81507ad6b95d0789a5dbd217424b000f056034ea8fadd07c2'),
+  Router: Fr.fromString('0x195eb06e13bd2a704f50a8480aa66a30e0913e73daa453fc2bea2ab880855dae'),
 };
 
 export const protocolContractTreeRoot = Fr.fromString(
-  '0x0f174f6837842b1004a9a41dd736800c12c5dc19f206aed35551b07f8ca6edfb',
+  '0x28c4676f6233fc2adf42179f2a5fec7d8cae9efa6344ade2fd0db8ed9ac386da',
 );


### PR DESCRIPTION
This was sometimes erroring out on the first attempt while awaiting the transaction to settle, 
but then subsequent calls were attempting to reinitialize.

Added better logging to help clarify. 

Also adjust the validator url in the template to be the top level service, to better distribute transactions across the network and not rely so heavily on the boot node for gossiping.