### PR TITLE
fix(build): l1-contracts .rebuild_patterns did not cover test files

### DIFF
--- a/l1-contracts/.rebuild_patterns
+++ b/l1-contracts/.rebuild_patterns
@@ -1,2 +1,2 @@
 ^l1-contracts/src/.*\.sol$
-^l1-contracts/test/governance/scenario/NewGovernanceProposerPayload.sol$
+^l1-contracts/test/.*\.sol$


### PR DESCRIPTION
These test files are used outside this module. The rebuild pattern has been made more conservative.
