### PR TITLE
feat(avm): more efficient low leaf search

### DIFF
--- a/yarn-project/simulator/src/avm/avm_tree.test.ts
+++ b/yarn-project/simulator/src/avm/avm_tree.test.ts
@@ -340,7 +340,7 @@ describe('Big Random Avm Ephemeral Container Test', () => {
     };
 
     // Can be up to 64
-    const ENTRY_COUNT = 64;
+    const ENTRY_COUNT = 50;
     shuffleArray(noteHashes);
     shuffleArray(indexedHashes);
     shuffleArray(slots);


### PR DESCRIPTION
This swaps out the initial implementation of the tracking just the `indexedTreeMin` of a leaf seen by an indexed tree in favour of a vector of sorted keys that we binary search over. This has 2 benefits, especially in the scenario where the `indexedTreeMin` was storing very small key values.

1) logn search time for keys that we have already seen
2) better than linear searching of the merkleDB for keys we dont have, since we dont have to start searching from min