### PR TITLE
feat: Add Origin Tags to cycle group

### DIFF
--- a/barretenberg/cpp/src/barretenberg/stdlib/primitives/group/cycle_group.cpp
+++ b/barretenberg/cpp/src/barretenberg/stdlib/primitives/group/cycle_group.cpp
@@ -700,23 +700,110 @@ typename cycle_group<Builder>::cycle_scalar cycle_group<Builder>::cycle_scalar::
 template <typename Builder> cycle_group<Builder>::cycle_scalar::cycle_scalar(BigScalarField& scalar)
 {
     auto* ctx = get_context() ? get_context() : scalar.get_context();
-    const uint256_t value((scalar.get_value() % uint512_t(ScalarField::modulus)).lo);
-    const uint256_t value_lo = value.slice(0, LO_BITS);
-    const uint256_t value_hi = value.slice(LO_BITS, HI_BITS);
+
     if (scalar.is_constant()) {
+        const uint256_t value((scalar.get_value() % uint512_t(ScalarField::modulus)).lo);
+        const uint256_t value_lo = value.slice(0, LO_BITS);
+        const uint256_t value_hi = value.slice(LO_BITS, HI_BITS);
+
         lo = value_lo;
         hi = value_hi;
         // N.B. to be able to call assert equal, these cannot be constants
     } else {
-        lo = witness_t(ctx, value_lo);
-        hi = witness_t(ctx, value_hi);
-        field_t zero = field_t(0);
-        zero.convert_constant_to_fixed_witness(ctx);
-        BigScalarField lo_big(lo, zero);
-        BigScalarField hi_big(hi, zero);
-        BigScalarField res = lo_big + hi_big * BigScalarField((uint256_t(1) << LO_BITS));
-        scalar.assert_equal(res);
-        validate_scalar_is_in_field();
+        // To efficiently convert a bigfield into a cycle scalar,
+        // we are going to explicitly rely on the fact that `scalar.lo` and `scalar.hi`
+        // are implicitly range-constrained to be 128 bits when they are converted into 4-bit lookup window slices
+
+        // First check: can the scalar actually fit into LO_BITS + HI_BITS?
+        // If it can, we can tolerate the scalar being > ScalarField::modulus, because performing a scalar mul
+        // implicilty performs a modular reduction
+        // If not, call `self_reduce` to cut enougn modulus multiples until the above condition is met
+        if (scalar.get_maximum_value() >= (uint512_t(1) << (LO_BITS + HI_BITS))) {
+            scalar.self_reduce();
+        }
+
+        field_t limb0 = scalar.binary_basis_limbs[0].element;
+        field_t limb1 = scalar.binary_basis_limbs[1].element;
+        field_t limb2 = scalar.binary_basis_limbs[2].element;
+        field_t limb3 = scalar.binary_basis_limbs[3].element;
+
+        // The general plan is as follows:
+        // 1. ensure limb0 contains no more than BigScalarField::NUM_LIMB_BITS
+        // 2. define limb1_lo = limb1.slice(0, LO_BITS - BigScalarField::NUM_LIMB_BITS)
+        // 3. define limb1_hi = limb1.slice(LO_BITS - BigScalarField::NUM_LIMB_BITS, <whatever maximum bound of limb1
+        // is>)
+        // 4. construct *this.lo out of limb0 and limb1_lo
+        // 5. construct *this.hi out of limb1_hi, limb2 and limb3
+        // This is a lot of logic, but very cheap on constraints.
+        // For fresh bignums that have come out of a MUL operation,
+        // the only "expensive" part is a size (LO_BITS - BigScalarField::NUM_LIMB_BITS) range check
+
+        // to convert into a cycle_scalar, we need to convert 4*68 bit limbs into 2*128 bit limbs
+        // we also need to ensure that the number of bits in cycle_scalar is < LO_BITS + HI_BITS
+        // note: we do not need to validate that the scalar is within the field modulus
+        // because performing a scalar multiplication implicitly performs a modular reduction (ecc group is
+        // multiplicative modulo BigField::modulus)
+
+        uint256_t limb1_max = scalar.binary_basis_limbs[1].maximum_value;
+
+        // Ensure that limb0 only contains at most NUM_LIMB_BITS. If it exceeds this value, slice of the excess and add
+        // it into limb1
+        if (scalar.binary_basis_limbs[0].maximum_value > BigScalarField::DEFAULT_MAXIMUM_LIMB) {
+            const uint256_t limb = limb0.get_value();
+            const uint256_t lo_v = limb.slice(0, BigScalarField::NUM_LIMB_BITS);
+            const uint256_t hi_v = limb >> BigScalarField::NUM_LIMB_BITS;
+            field_t lo = field_t::from_witness(ctx, lo_v);
+            field_t hi = field_t::from_witness(ctx, hi_v);
+
+            uint256_t hi_max = (scalar.binary_basis_limbs[0].maximum_value >> BigScalarField::NUM_LIMB_BITS);
+            const uint64_t hi_bits = hi_max.get_msb() + 1;
+            lo.create_range_constraint(BigScalarField::NUM_LIMB_BITS);
+            hi.create_range_constraint(static_cast<size_t>(hi_bits));
+            limb0.assert_equal(lo + hi * BigScalarField::shift_1);
+
+            limb1 += hi;
+            limb1_max += hi_max;
+            limb0 = lo;
+        }
+
+        // sanity check that limb[1] is the limb that contributs both to *this.lo and *this.hi
+        ASSERT((BigScalarField::NUM_LIMB_BITS * 2 > LO_BITS) && (BigScalarField::NUM_LIMB_BITS < LO_BITS));
+
+        // limb1 is the tricky one as it contributs to both *this.lo and *this.hi
+        // By this point, we know that limb1 fits in the range `1 << BigScalarField::NUM_LIMB_BITS to  (1 <<
+        // BigScalarField::NUM_LIMB_BITS) + limb1_max.get_maximum_value() we need to slice this limb into 2. The first
+        // is LO_BITS - BigScalarField::NUM_LIMB_BITS (which reprsents its contribution to *this.lo) and the second
+        // represents the limbs contribution to *this.hi Step 1: compute the max bit sizes of both slices
+        const size_t lo_bits_in_limb_1 = LO_BITS - BigScalarField::NUM_LIMB_BITS;
+        const size_t hi_bits_in_limb_1 = (static_cast<size_t>(limb1_max.get_msb()) + 1) - lo_bits_in_limb_1;
+
+        // Step 2: compute the witness values of both slices
+        const uint256_t limb_1 = limb1.get_value();
+        const uint256_t limb_1_hi_multiplicand = (uint256_t(1) << lo_bits_in_limb_1);
+        const uint256_t limb_1_hi_v = limb_1 >> lo_bits_in_limb_1;
+        const uint256_t limb_1_lo_v = limb_1 - (limb_1_hi_v << lo_bits_in_limb_1);
+
+        // Step 3: instantiate both slices as witnesses and validate their sum equals limb1
+        field_t limb_1_lo = field_t::from_witness(ctx, limb_1_lo_v);
+        field_t limb_1_hi = field_t::from_witness(ctx, limb_1_hi_v);
+        limb1.assert_equal(limb_1_hi * limb_1_hi_multiplicand + limb_1_lo);
+
+        // Step 4: apply range constraints to validate both slices represent the expected contributions to *this.lo and
+        // *this,hi
+        limb_1_lo.create_range_constraint(lo_bits_in_limb_1);
+        limb_1_hi.create_range_constraint(hi_bits_in_limb_1);
+
+        // construct *this.lo out of:
+        // a. `limb0` (the first NUM_LIMB_BITS bits of scalar)
+        // b. `limb_1_lo` (the first LO_BITS - NUM_LIMB_BITS) of limb1
+        lo = limb0 + (limb_1_lo * BigScalarField::shift_1);
+
+        const uint256_t limb_2_shift = uint256_t(1) << (BigScalarField::NUM_LIMB_BITS - lo_bits_in_limb_1);
+        const uint256_t limb_3_shift =
+            uint256_t(1) << ((BigScalarField::NUM_LIMB_BITS - lo_bits_in_limb_1) + BigScalarField::NUM_LIMB_BITS);
+
+        // construct *this.hi out of limb2, limb3 and the remaining term from limb1 not contributing to `lo`
+        hi = limb_1_hi.add_two(limb2 * limb_2_shift, limb3 * limb_3_shift);
     }
     lo.set_origin_tag(scalar.get_origin_tag());
     hi.set_origin_tag(scalar.get_origin_tag());

--- a/barretenberg/cpp/src/barretenberg/stdlib/primitives/group/cycle_group.cpp
+++ b/barretenberg/cpp/src/barretenberg/stdlib/primitives/group/cycle_group.cpp
@@ -1,4 +1,5 @@
 #include "../field/field.hpp"
+#include "barretenberg/common/zip_view.hpp"
 #include "barretenberg/crypto/pedersen_commitment/pedersen.hpp"
 #include "barretenberg/ecc/curves/grumpkin/grumpkin.hpp"
 
@@ -6,6 +7,7 @@
 #include "barretenberg/stdlib/primitives/plookup/plookup.hpp"
 #include "barretenberg/stdlib_circuit_builders/plookup_tables/fixed_base/fixed_base.hpp"
 #include "barretenberg/stdlib_circuit_builders/plookup_tables/types.hpp"
+#include "barretenberg/transcript/origin_tag.hpp"
 namespace bb::stdlib {
 
 template <typename Builder>
@@ -240,7 +242,9 @@ cycle_group<Builder> cycle_group<Builder>::dbl() const
     auto x3 = lambda_squared - x1 - x1;
     auto y3 = lambda * (x1 - x3) - y1;
     if (is_constant()) {
-        return cycle_group(x3, y3, is_point_at_infinity().get_value());
+        auto result = cycle_group(x3, y3, is_point_at_infinity().get_value());
+        result.set_origin_tag(get_origin_tag());
+        return result;
     }
     cycle_group result(witness_t(context, x3), witness_t(context, y3), is_point_at_infinity());
     context->create_ecc_dbl_gate(bb::ecc_dbl_gate_<FF>{
@@ -249,6 +253,8 @@ cycle_group<Builder> cycle_group<Builder>::dbl() const
         .x3 = result.x.get_witness_index(),
         .y3 = result.y.get_witness_index(),
     });
+    result.x.set_origin_tag(OriginTag(x.get_origin_tag(), y.get_origin_tag()));
+    result.y.set_origin_tag(OriginTag(x.get_origin_tag(), y.get_origin_tag()));
     return result;
 }
 
@@ -297,10 +303,12 @@ cycle_group<Builder> cycle_group<Builder>::unconditional_add(const cycle_group& 
     const bool rhs_constant = other.is_constant();
     if (lhs_constant && !rhs_constant) {
         auto lhs = cycle_group::from_constant_witness(context, get_value());
+        lhs.set_origin_tag(get_origin_tag());
         return lhs.unconditional_add(other);
     }
     if (!lhs_constant && rhs_constant) {
         auto rhs = cycle_group::from_constant_witness(context, other.get_value());
+        rhs.set_origin_tag(other.get_origin_tag());
         return unconditional_add(rhs);
     }
 
@@ -308,7 +316,9 @@ cycle_group<Builder> cycle_group<Builder>::unconditional_add(const cycle_group& 
     const auto p2 = other.get_value();
     AffineElement p3(Element(p1) + Element(p2));
     if (lhs_constant && rhs_constant) {
-        return cycle_group(p3);
+        auto result = cycle_group(p3);
+        result.set_origin_tag(OriginTag(get_origin_tag(), other.get_origin_tag()));
+        return result;
     }
     field_t r_x(witness_t(context, p3.x));
     field_t r_y(witness_t(context, p3.y));
@@ -325,6 +335,7 @@ cycle_group<Builder> cycle_group<Builder>::unconditional_add(const cycle_group& 
     };
     context->create_ecc_add_gate(add_gate);
 
+    result.set_origin_tag(OriginTag(get_origin_tag(), other.get_origin_tag()));
     return result;
 }
 
@@ -350,17 +361,21 @@ cycle_group<Builder> cycle_group<Builder>::unconditional_subtract(const cycle_gr
 
         if (lhs_constant && !rhs_constant) {
             auto lhs = cycle_group<Builder>::from_constant_witness(context, get_value());
+            lhs.set_origin_tag(get_origin_tag());
             return lhs.unconditional_subtract(other);
         }
         if (!lhs_constant && rhs_constant) {
             auto rhs = cycle_group<Builder>::from_constant_witness(context, other.get_value());
+            rhs.set_origin_tag(other.get_origin_tag());
             return unconditional_subtract(rhs);
         }
         auto p1 = get_value();
         auto p2 = other.get_value();
         AffineElement p3(Element(p1) - Element(p2));
         if (lhs_constant && rhs_constant) {
-            return cycle_group(p3);
+            auto result = cycle_group(p3);
+            result.set_origin_tag(OriginTag(get_origin_tag(), other.get_origin_tag()));
+            return result;
         }
         field_t r_x(witness_t(context, p3.x));
         field_t r_y(witness_t(context, p3.y));
@@ -377,6 +392,7 @@ cycle_group<Builder> cycle_group<Builder>::unconditional_subtract(const cycle_gr
         };
         context->create_ecc_add_gate(add_gate);
 
+        result.set_origin_tag(OriginTag(get_origin_tag(), other.get_origin_tag()));
         return result;
     }
 }
@@ -593,6 +609,8 @@ template <typename Builder> cycle_group<Builder>::cycle_scalar::cycle_scalar(con
         // bb::fq modulus otherwise we could have two representations for in
         validate_scalar_is_in_field();
     }
+    lo.set_origin_tag(in.get_origin_tag());
+    hi.set_origin_tag(in.get_origin_tag());
 }
 
 template <typename Builder> cycle_group<Builder>::cycle_scalar::cycle_scalar(const ScalarField& in)
@@ -663,6 +681,10 @@ typename cycle_group<Builder>::cycle_scalar cycle_group<Builder>::cycle_scalar::
     field_t lo = witness_t(in.get_context(), lo_v);
     field_t hi = witness_t(in.get_context(), hi_v);
     lo.add_two(hi * (uint256_t(1) << LO_BITS), -in).assert_equal(0);
+
+    lo.set_origin_tag(in.get_origin_tag());
+    hi.set_origin_tag(in.get_origin_tag());
+
     cycle_scalar result{ lo, hi, NUM_BITS, skip_primality_test, true };
     return result;
 }
@@ -678,111 +700,26 @@ typename cycle_group<Builder>::cycle_scalar cycle_group<Builder>::cycle_scalar::
 template <typename Builder> cycle_group<Builder>::cycle_scalar::cycle_scalar(BigScalarField& scalar)
 {
     auto* ctx = get_context() ? get_context() : scalar.get_context();
-
+    const uint256_t value((scalar.get_value() % uint512_t(ScalarField::modulus)).lo);
+    const uint256_t value_lo = value.slice(0, LO_BITS);
+    const uint256_t value_hi = value.slice(LO_BITS, HI_BITS);
     if (scalar.is_constant()) {
-        const uint256_t value((scalar.get_value() % uint512_t(ScalarField::modulus)).lo);
-        const uint256_t value_lo = value.slice(0, LO_BITS);
-        const uint256_t value_hi = value.slice(LO_BITS, HI_BITS);
-
         lo = value_lo;
         hi = value_hi;
         // N.B. to be able to call assert equal, these cannot be constants
     } else {
-        // To efficiently convert a bigfield into a cycle scalar,
-        // we are going to explicitly rely on the fact that `scalar.lo` and `scalar.hi`
-        // are implicitly range-constrained to be 128 bits when they are converted into 4-bit lookup window slices
-
-        // First check: can the scalar actually fit into LO_BITS + HI_BITS?
-        // If it can, we can tolerate the scalar being > ScalarField::modulus, because performing a scalar mul
-        // implicilty performs a modular reduction
-        // If not, call `self_reduce` to cut enougn modulus multiples until the above condition is met
-        if (scalar.get_maximum_value() >= (uint512_t(1) << (LO_BITS + HI_BITS))) {
-            scalar.self_reduce();
-        }
-
-        field_t limb0 = scalar.binary_basis_limbs[0].element;
-        field_t limb1 = scalar.binary_basis_limbs[1].element;
-        field_t limb2 = scalar.binary_basis_limbs[2].element;
-        field_t limb3 = scalar.binary_basis_limbs[3].element;
-
-        // The general plan is as follows:
-        // 1. ensure limb0 contains no more than BigScalarField::NUM_LIMB_BITS
-        // 2. define limb1_lo = limb1.slice(0, LO_BITS - BigScalarField::NUM_LIMB_BITS)
-        // 3. define limb1_hi = limb1.slice(LO_BITS - BigScalarField::NUM_LIMB_BITS, <whatever maximum bound of limb1
-        // is>)
-        // 4. construct *this.lo out of limb0 and limb1_lo
-        // 5. construct *this.hi out of limb1_hi, limb2 and limb3
-        // This is a lot of logic, but very cheap on constraints.
-        // For fresh bignums that have come out of a MUL operation,
-        // the only "expensive" part is a size (LO_BITS - BigScalarField::NUM_LIMB_BITS) range check
-
-        // to convert into a cycle_scalar, we need to convert 4*68 bit limbs into 2*128 bit limbs
-        // we also need to ensure that the number of bits in cycle_scalar is < LO_BITS + HI_BITS
-        // note: we do not need to validate that the scalar is within the field modulus
-        // because performing a scalar multiplication implicitly performs a modular reduction (ecc group is
-        // multiplicative modulo BigField::modulus)
-
-        uint256_t limb1_max = scalar.binary_basis_limbs[1].maximum_value;
-
-        // Ensure that limb0 only contains at most NUM_LIMB_BITS. If it exceeds this value, slice of the excess and add
-        // it into limb1
-        if (scalar.binary_basis_limbs[0].maximum_value > BigScalarField::DEFAULT_MAXIMUM_LIMB) {
-            const uint256_t limb = limb0.get_value();
-            const uint256_t lo_v = limb.slice(0, BigScalarField::NUM_LIMB_BITS);
-            const uint256_t hi_v = limb >> BigScalarField::NUM_LIMB_BITS;
-            field_t lo = field_t::from_witness(ctx, lo_v);
-            field_t hi = field_t::from_witness(ctx, hi_v);
-
-            uint256_t hi_max = (scalar.binary_basis_limbs[0].maximum_value >> BigScalarField::NUM_LIMB_BITS);
-            const uint64_t hi_bits = hi_max.get_msb() + 1;
-            lo.create_range_constraint(BigScalarField::NUM_LIMB_BITS);
-            hi.create_range_constraint(static_cast<size_t>(hi_bits));
-            limb0.assert_equal(lo + hi * BigScalarField::shift_1);
-
-            limb1 += hi;
-            limb1_max += hi_max;
-            limb0 = lo;
-        }
-
-        // sanity check that limb[1] is the limb that contributs both to *this.lo and *this.hi
-        ASSERT((BigScalarField::NUM_LIMB_BITS * 2 > LO_BITS) && (BigScalarField::NUM_LIMB_BITS < LO_BITS));
-
-        // limb1 is the tricky one as it contributs to both *this.lo and *this.hi
-        // By this point, we know that limb1 fits in the range `1 << BigScalarField::NUM_LIMB_BITS to  (1 <<
-        // BigScalarField::NUM_LIMB_BITS) + limb1_max.get_maximum_value() we need to slice this limb into 2. The first
-        // is LO_BITS - BigScalarField::NUM_LIMB_BITS (which reprsents its contribution to *this.lo) and the second
-        // represents the limbs contribution to *this.hi Step 1: compute the max bit sizes of both slices
-        const size_t lo_bits_in_limb_1 = LO_BITS - BigScalarField::NUM_LIMB_BITS;
-        const size_t hi_bits_in_limb_1 = (static_cast<size_t>(limb1_max.get_msb()) + 1) - lo_bits_in_limb_1;
-
-        // Step 2: compute the witness values of both slices
-        const uint256_t limb_1 = limb1.get_value();
-        const uint256_t limb_1_hi_multiplicand = (uint256_t(1) << lo_bits_in_limb_1);
-        const uint256_t limb_1_hi_v = limb_1 >> lo_bits_in_limb_1;
-        const uint256_t limb_1_lo_v = limb_1 - (limb_1_hi_v << lo_bits_in_limb_1);
-
-        // Step 3: instantiate both slices as witnesses and validate their sum equals limb1
-        field_t limb_1_lo = field_t::from_witness(ctx, limb_1_lo_v);
-        field_t limb_1_hi = field_t::from_witness(ctx, limb_1_hi_v);
-        limb1.assert_equal(limb_1_hi * limb_1_hi_multiplicand + limb_1_lo);
-
-        // Step 4: apply range constraints to validate both slices represent the expected contributions to *this.lo and
-        // *this,hi
-        limb_1_lo.create_range_constraint(lo_bits_in_limb_1);
-        limb_1_hi.create_range_constraint(hi_bits_in_limb_1);
-
-        // construct *this.lo out of:
-        // a. `limb0` (the first NUM_LIMB_BITS bits of scalar)
-        // b. `limb_1_lo` (the first LO_BITS - NUM_LIMB_BITS) of limb1
-        lo = limb0 + (limb_1_lo * BigScalarField::shift_1);
-
-        const uint256_t limb_2_shift = uint256_t(1) << (BigScalarField::NUM_LIMB_BITS - lo_bits_in_limb_1);
-        const uint256_t limb_3_shift =
-            uint256_t(1) << ((BigScalarField::NUM_LIMB_BITS - lo_bits_in_limb_1) + BigScalarField::NUM_LIMB_BITS);
-
-        // construct *this.hi out of limb2, limb3 and the remaining term from limb1 not contributing to `lo`
-        hi = limb_1_hi.add_two(limb2 * limb_2_shift, limb3 * limb_3_shift);
+        lo = witness_t(ctx, value_lo);
+        hi = witness_t(ctx, value_hi);
+        field_t zero = field_t(0);
+        zero.convert_constant_to_fixed_witness(ctx);
+        BigScalarField lo_big(lo, zero);
+        BigScalarField hi_big(hi, zero);
+        BigScalarField res = lo_big + hi_big * BigScalarField((uint256_t(1) << LO_BITS));
+        scalar.assert_equal(res);
+        validate_scalar_is_in_field();
     }
+    lo.set_origin_tag(scalar.get_origin_tag());
+    hi.set_origin_tag(scalar.get_origin_tag());
 };
 
 template <typename Builder> bool cycle_group<Builder>::cycle_scalar::is_constant() const
@@ -909,6 +846,10 @@ cycle_group<Builder>::straus_scalar_slice::straus_scalar_slice(Builder* context,
             }
             field_t::accumulate(linear_elements).assert_equal(scalar);
         }
+        auto tag = scalar.get_origin_tag();
+        for (auto& element : result) {
+            element.set_origin_tag(tag);
+        }
         return result;
     };
 
@@ -960,6 +901,7 @@ cycle_group<Builder>::straus_lookup_table::straus_lookup_table(Builder* context,
                                                                size_t table_bits)
     : _table_bits(table_bits)
     , _context(context)
+    , tag(OriginTag(base_point.get_origin_tag(), offset_generator.get_origin_tag()))
 {
     const size_t table_size = 1UL << table_bits;
     point_table.resize(table_size);
@@ -1024,6 +966,8 @@ template <typename Builder> cycle_group<Builder> cycle_group<Builder>::straus_lo
     }
     field_t x = _index * (point_table[1].x - point_table[0].x) + point_table[0].x;
     field_t y = _index * (point_table[1].y - point_table[0].y) + point_table[0].y;
+    x.set_origin_tag(OriginTag(tag, _index.get_origin_tag()));
+    y.set_origin_tag(OriginTag(tag, _index.get_origin_tag()));
     return cycle_group(x, y, false);
 }
 
@@ -1086,7 +1030,9 @@ typename cycle_group<Builder>::batch_mul_internal_output cycle_group<Builder>::_
 
     std::vector<straus_scalar_slice> scalar_slices;
     std::vector<straus_lookup_table> point_tables;
+    OriginTag tag{};
     for (size_t i = 0; i < num_points; ++i) {
+        tag = OriginTag(tag, scalars[i].get_origin_tag(), base_points[i].get_origin_tag());
         scalar_slices.emplace_back(straus_scalar_slice(context, scalars[i], TABLE_BITS));
         point_tables.emplace_back(straus_lookup_table(context, base_points[i], offset_generators[i + 1], TABLE_BITS));
     }
@@ -1140,6 +1086,8 @@ typename cycle_group<Builder>::batch_mul_internal_output cycle_group<Builder>::_
         auto x_diff = x2 - x1;
         x_diff.assert_is_not_zero("_variable_base_batch_mul_internal x-coordinate collision");
     }
+
+    accumulator.set_origin_tag(tag);
     /**
      * offset_generator_accumulator represents the sum of all the offset generator terms present in `accumulator`.
      * We don't subtract off yet, as we may be able to combine `offset_generator_accumulator` with other constant terms
@@ -1177,7 +1125,9 @@ typename cycle_group<Builder>::batch_mul_internal_output cycle_group<Builder>::_
     std::vector<AffineElement> plookup_base_points;
     std::vector<field_t> plookup_scalars;
 
+    OriginTag tag{};
     for (size_t i = 0; i < num_points; ++i) {
+        tag = OriginTag(tag, scalars[i].get_origin_tag());
         std::optional<std::array<MultiTableId, 2>> table_id =
             plookup::fixed_base::table::get_lookup_table_ids_for_point(base_points[i]);
         ASSERT(table_id.has_value());
@@ -1218,6 +1168,7 @@ typename cycle_group<Builder>::batch_mul_internal_output cycle_group<Builder>::_
      * We don't subtract off yet, as we may be able to combine `offset_generator_accumulator` with other constant terms
      * in `batch_mul` before performing the subtraction.
      */
+    accumulator.set_origin_tag(tag);
     return { accumulator, offset_generator_accumulator };
 }
 
@@ -1354,6 +1305,10 @@ cycle_group<Builder> cycle_group<Builder>::batch_mul(const std::vector<cycle_gro
     std::vector<cycle_scalar> fixed_base_scalars;
     std::vector<AffineElement> fixed_base_points;
 
+    OriginTag result_tag;
+    for (auto [point, scalar] : zip_view(base_points, scalars)) {
+        result_tag = OriginTag(result_tag, OriginTag(point.get_origin_tag(), scalar.get_origin_tag()));
+    }
     size_t num_bits = 0;
     for (auto& s : scalars) {
         num_bits = std::max(num_bits, s.num_bits());
@@ -1409,7 +1364,9 @@ cycle_group<Builder> cycle_group<Builder>::batch_mul(const std::vector<cycle_gro
 
     // If all inputs are constant, return the computed constant component and call it a day.
     if (!has_non_constant_component) {
-        return cycle_group(constant_acc);
+        auto result = cycle_group(constant_acc);
+        result.set_origin_tag(result_tag);
+        return result;
     }
 
     // add the constant component into our offset accumulator
@@ -1475,6 +1432,7 @@ cycle_group<Builder> cycle_group<Builder>::batch_mul(const std::vector<cycle_gro
         // This would be slightly cheaper than operator- as we do not have to evaluate the double edge case.
         result = result - AffineElement(offset_accumulator);
     }
+    result.set_origin_tag(result_tag);
     return result;
 }
 

--- a/barretenberg/cpp/src/barretenberg/stdlib/primitives/group/cycle_group.cpp
+++ b/barretenberg/cpp/src/barretenberg/stdlib/primitives/group/cycle_group.cpp
@@ -1196,7 +1196,7 @@ typename cycle_group<Builder>::batch_mul_internal_output cycle_group<Builder>::_
         x_diff.assert_is_not_zero("_variable_base_batch_mul_internal x-coordinate collision");
     }
 
-    // Set the final accumulator's tag to the merge of all points' and scalars' tags
+    // Set the final accumulator's tag to the union of all points' and scalars' tags
     accumulator.set_origin_tag(tag);
     /**
      * offset_generator_accumulator represents the sum of all the offset generator terms present in `accumulator`.
@@ -1280,7 +1280,7 @@ typename cycle_group<Builder>::batch_mul_internal_output cycle_group<Builder>::_
      * We don't subtract off yet, as we may be able to combine `offset_generator_accumulator` with other constant terms
      * in `batch_mul` before performing the subtraction.
      */
-    // Set accumulator's origin tag to the merge of all scalars' tags
+    // Set accumulator's origin tag to the union of all scalars' tags
     accumulator.set_origin_tag(tag);
     return { accumulator, offset_generator_accumulator };
 }
@@ -1546,7 +1546,7 @@ cycle_group<Builder> cycle_group<Builder>::batch_mul(const std::vector<cycle_gro
         // This would be slightly cheaper than operator- as we do not have to evaluate the double edge case.
         result = result - AffineElement(offset_accumulator);
     }
-    // Ensure the tag of the result is a merge of all inputs
+    // Ensure the tag of the result is a union of all inputs
     result.set_origin_tag(result_tag);
     return result;
 }

--- a/barretenberg/cpp/src/barretenberg/stdlib/primitives/group/cycle_group.hpp
+++ b/barretenberg/cpp/src/barretenberg/stdlib/primitives/group/cycle_group.hpp
@@ -108,7 +108,17 @@ template <typename Builder> class cycle_group {
         void validate_scalar_is_in_field() const;
 
         explicit cycle_scalar(BigScalarField&);
+        /**
+         * @brief Get the origin tag of the cycle_scalar (a merge of the lo and hi tags)
+         *
+         * @return OriginTag
+         */
         OriginTag get_origin_tag() const { return OriginTag(lo.get_origin_tag(), hi.get_origin_tag()); }
+        /**
+         * @brief Set the origin tag of lo and hi members of cycle scalar
+         *
+         * @param tag
+         */
         void set_origin_tag(const OriginTag& tag)
         {
             lo.set_origin_tag(tag);
@@ -232,12 +242,22 @@ template <typename Builder> class cycle_group {
     static cycle_group conditional_assign(const bool_t& predicate, const cycle_group& lhs, const cycle_group& rhs);
     cycle_group operator/(const cycle_group& other) const;
 
+    /**
+     * @brief Set the origin tag for x, y and _is_infinity members of cycle_group
+     *
+     * @param tag
+     */
     void set_origin_tag(OriginTag tag)
     {
         x.set_origin_tag(tag);
         y.set_origin_tag(tag);
         _is_infinity.set_origin_tag(tag);
     }
+    /**
+     * @brief Get the origin tag of cycle_group (a merege of origin tags of x, y and _is_infinity members)
+     *
+     * @return OriginTag
+     */
     OriginTag get_origin_tag() const
     {
         return OriginTag(x.get_origin_tag(), y.get_origin_tag(), _is_infinity.get_origin_tag());

--- a/barretenberg/cpp/src/barretenberg/stdlib/primitives/group/cycle_group.hpp
+++ b/barretenberg/cpp/src/barretenberg/stdlib/primitives/group/cycle_group.hpp
@@ -7,6 +7,7 @@
 #include "barretenberg/stdlib/primitives/circuit_builders/circuit_builders.hpp"
 #include "barretenberg/stdlib/primitives/field/field.hpp"
 #include "barretenberg/stdlib_circuit_builders/plookup_tables/fixed_base/fixed_base_params.hpp"
+#include "barretenberg/transcript/origin_tag.hpp"
 #include <optional>
 
 namespace bb::stdlib {
@@ -107,6 +108,12 @@ template <typename Builder> class cycle_group {
         void validate_scalar_is_in_field() const;
 
         explicit cycle_scalar(BigScalarField&);
+        OriginTag get_origin_tag() const { return OriginTag(lo.get_origin_tag(), hi.get_origin_tag()); }
+        void set_origin_tag(const OriginTag& tag)
+        {
+            lo.set_origin_tag(tag);
+            hi.set_origin_tag(tag);
+        }
     };
 
     /**
@@ -158,6 +165,7 @@ template <typename Builder> class cycle_group {
         Builder* _context;
         std::vector<cycle_group> point_table;
         size_t rom_id = 0;
+        OriginTag tag{};
     };
 
   private:
@@ -223,6 +231,18 @@ template <typename Builder> class cycle_group {
     void assert_equal(const cycle_group& other, std::string const& msg = "cycle_group::assert_equal") const;
     static cycle_group conditional_assign(const bool_t& predicate, const cycle_group& lhs, const cycle_group& rhs);
     cycle_group operator/(const cycle_group& other) const;
+
+    void set_origin_tag(OriginTag tag)
+    {
+        x.set_origin_tag(tag);
+        y.set_origin_tag(tag);
+        _is_infinity.set_origin_tag(tag);
+    }
+    OriginTag get_origin_tag() const
+    {
+        return OriginTag(x.get_origin_tag(), y.get_origin_tag(), _is_infinity.get_origin_tag());
+    }
+
     field_t x;
     field_t y;
 

--- a/barretenberg/cpp/src/barretenberg/stdlib/primitives/group/cycle_group.test.cpp
+++ b/barretenberg/cpp/src/barretenberg/stdlib/primitives/group/cycle_group.test.cpp
@@ -167,7 +167,7 @@ TYPED_TEST(CycleGroupTest, TestStandardForm)
     EXPECT_EQ(standard_c.is_point_at_infinity().get_value(), false);
     EXPECT_EQ(standard_d.is_point_at_infinity().get_value(), true);
 
-    // Ensure that the tags in the standard from remain the same
+    // Ensure that the tags in the standard form remain the same
     EXPECT_EQ(standard_a.get_origin_tag(), submitted_value_origin_tag);
     EXPECT_EQ(standard_b.get_origin_tag(), challenge_origin_tag);
     EXPECT_EQ(standard_c.get_origin_tag(), next_challenge_tag);

--- a/barretenberg/cpp/src/barretenberg/stdlib/primitives/group/cycle_group.test.cpp
+++ b/barretenberg/cpp/src/barretenberg/stdlib/primitives/group/cycle_group.test.cpp
@@ -1,5 +1,6 @@
 #include "barretenberg/stdlib/primitives/group/cycle_group.hpp"
 #include "barretenberg/circuit_checker/circuit_checker.hpp"
+#include "barretenberg/common/ref_span.hpp"
 #include "barretenberg/crypto/pedersen_commitment/pedersen.hpp"
 #include "barretenberg/crypto/pedersen_hash/pedersen.hpp"
 #include "barretenberg/numeric/random/engine.hpp"
@@ -7,6 +8,7 @@
 #include "barretenberg/stdlib/primitives/field/field.hpp"
 #include "barretenberg/stdlib/primitives/witness/witness.hpp"
 #include "barretenberg/stdlib_circuit_builders/plookup_tables/fixed_base/fixed_base.hpp"
+#include "barretenberg/transcript/origin_tag.hpp"
 #include <gtest/gtest.h>
 
 #define STDLIB_TYPE_ALIASES                                                                                            \
@@ -50,6 +52,37 @@ template <class Builder> class CycleGroupTest : public ::testing::Test {
 
 using CircuitTypes = ::testing::Types<bb::UltraCircuitBuilder>;
 TYPED_TEST_SUITE(CycleGroupTest, CircuitTypes);
+
+STANDARD_TESTING_TAGS
+/**
+ * @brief Check basic tag interactions
+ *
+ */
+TYPED_TEST(CycleGroupTest, TestBasicTagLogic)
+{
+    STDLIB_TYPE_ALIASES
+    Builder builder;
+
+    auto lhs = TestFixture::generators[0];
+    cycle_group_ct a = cycle_group_ct::from_witness(&builder, lhs);
+    // Set the whole tag first
+    a.set_origin_tag(next_challenge_tag);
+    // Set tags of x an y
+    a.x.set_origin_tag(submitted_value_origin_tag);
+    a.y.set_origin_tag(challenge_origin_tag);
+
+    // The tag of the _is_point_at_infinity member should stay as next_challenge_tag, so the whole thing should be the
+    // merge of all 3
+
+    EXPECT_EQ(a.get_origin_tag(), first_second_third_merged_tag);
+
+#ifndef NDEBUG
+    cycle_group_ct b = cycle_group_ct::from_witness(&builder, TestFixture::generators[1]);
+    b.x.set_origin_tag(instant_death_tag);
+    // Even requesting the tag of the whole structure can cause instant death
+    EXPECT_THROW(b.get_origin_tag(), std::runtime_error);
+#endif
+}
 
 /**
  * @brief Checks that a point on the curve passes the validate_is_on_curve check
@@ -110,29 +143,60 @@ TYPED_TEST(CycleGroupTest, TestStandardForm)
     STDLIB_TYPE_ALIASES;
     auto builder = Builder();
 
-    size_t num_repetitions = 5;
-    for (size_t i = 0; i < num_repetitions; ++i) {
-        cycle_group_ct input_a(Element::random_element());
-        cycle_group_ct input_b(Element::random_element());
-        input_b.set_point_at_infinity(true);
-        auto standard_a = input_a.get_standard_form();
-        auto standard_b = input_b.get_standard_form();
-        EXPECT_EQ(standard_a.is_point_at_infinity().get_value(), false);
-        EXPECT_EQ(standard_b.is_point_at_infinity().get_value(), true);
-        auto input_a_x = input_a.x.get_value();
-        auto input_a_y = input_a.y.get_value();
+    cycle_group_ct input_a = cycle_group_ct::from_witness(&builder, Element::random_element());
+    cycle_group_ct input_b = cycle_group_ct::from_witness(&builder, Element::random_element());
+    cycle_group_ct input_c = cycle_group_ct(Element::random_element());
+    cycle_group_ct input_d = cycle_group_ct(Element::random_element());
 
-        auto standard_a_x = standard_a.x.get_value();
-        auto standard_a_y = standard_a.y.get_value();
+    input_b.set_point_at_infinity(true);
+    input_d.set_point_at_infinity(true);
 
-        auto standard_b_x = standard_b.x.get_value();
-        auto standard_b_y = standard_b.y.get_value();
+    input_a.set_origin_tag(submitted_value_origin_tag);
+    input_b.set_origin_tag(challenge_origin_tag);
+    input_c.set_origin_tag(next_challenge_tag);
+    input_d.set_origin_tag(first_two_merged_tag);
 
-        EXPECT_EQ(input_a_x, standard_a_x);
-        EXPECT_EQ(input_a_y, standard_a_y);
-        EXPECT_EQ(standard_b_x, 0);
-        EXPECT_EQ(standard_b_y, 0);
-    }
+    auto standard_a = input_a.get_standard_form();
+    auto standard_b = input_b.get_standard_form();
+    auto standard_c = input_c.get_standard_form();
+    auto standard_d = input_d.get_standard_form();
+
+    EXPECT_EQ(standard_a.is_point_at_infinity().get_value(), false);
+    EXPECT_EQ(standard_b.is_point_at_infinity().get_value(), true);
+    EXPECT_EQ(standard_c.is_point_at_infinity().get_value(), false);
+    EXPECT_EQ(standard_d.is_point_at_infinity().get_value(), true);
+
+    EXPECT_EQ(standard_a.get_origin_tag(), submitted_value_origin_tag);
+    EXPECT_EQ(standard_b.get_origin_tag(), challenge_origin_tag);
+    EXPECT_EQ(standard_c.get_origin_tag(), next_challenge_tag);
+    EXPECT_EQ(standard_d.get_origin_tag(), first_two_merged_tag);
+
+    auto input_a_x = input_a.x.get_value();
+    auto input_a_y = input_a.y.get_value();
+    auto input_c_x = input_c.x.get_value();
+    auto input_c_y = input_c.y.get_value();
+
+    auto standard_a_x = standard_a.x.get_value();
+    auto standard_a_y = standard_a.y.get_value();
+
+    auto standard_b_x = standard_b.x.get_value();
+    auto standard_b_y = standard_b.y.get_value();
+
+    auto standard_c_x = standard_c.x.get_value();
+    auto standard_c_y = standard_c.y.get_value();
+
+    auto standard_d_x = standard_d.x.get_value();
+    auto standard_d_y = standard_d.y.get_value();
+
+    EXPECT_EQ(input_a_x, standard_a_x);
+    EXPECT_EQ(input_a_y, standard_a_y);
+    EXPECT_EQ(standard_b_x, 0);
+    EXPECT_EQ(standard_b_y, 0);
+    EXPECT_EQ(input_c_x, standard_c_x);
+    EXPECT_EQ(input_c_y, standard_c_y);
+    EXPECT_EQ(standard_d_x, 0);
+    EXPECT_EQ(standard_d_y, 0);
+
     EXPECT_TRUE(CircuitChecker::check(builder));
 }
 TYPED_TEST(CycleGroupTest, TestDbl)
@@ -142,18 +206,27 @@ TYPED_TEST(CycleGroupTest, TestDbl)
 
     auto lhs = TestFixture::generators[0];
     cycle_group_ct a = cycle_group_ct::from_witness(&builder, lhs);
+    cycle_group_ct b = cycle_group_ct(lhs);
+    a.set_origin_tag(submitted_value_origin_tag);
+    b.set_origin_tag(challenge_origin_tag);
     cycle_group_ct c;
+    cycle_group_ct d;
     std::cout << "pre = " << builder.get_estimated_num_finalized_gates() << std::endl;
     for (size_t i = 0; i < 3; ++i) {
         c = a.dbl();
     }
     std::cout << "post = " << builder.get_estimated_num_finalized_gates() << std::endl;
+    d = b.dbl();
     AffineElement expected(Element(lhs).dbl());
     AffineElement result = c.get_value();
     EXPECT_EQ(result, expected);
+    EXPECT_EQ(d.get_value(), expected);
 
     bool proof_result = CircuitChecker::check(builder);
     EXPECT_EQ(proof_result, true);
+
+    EXPECT_EQ(c.get_origin_tag(), submitted_value_origin_tag);
+    EXPECT_EQ(d.get_origin_tag(), challenge_origin_tag);
 }
 
 TYPED_TEST(CycleGroupTest, TestUnconditionalAdd)
@@ -165,10 +238,13 @@ TYPED_TEST(CycleGroupTest, TestUnconditionalAdd)
         [&](const AffineElement& lhs, const AffineElement& rhs, const bool lhs_constant, const bool rhs_constant) {
             cycle_group_ct a = lhs_constant ? cycle_group_ct(lhs) : cycle_group_ct::from_witness(&builder, lhs);
             cycle_group_ct b = rhs_constant ? cycle_group_ct(rhs) : cycle_group_ct::from_witness(&builder, rhs);
+            a.set_origin_tag(submitted_value_origin_tag);
+            b.set_origin_tag(challenge_origin_tag);
             cycle_group_ct c = a.unconditional_add(b);
             AffineElement expected(Element(lhs) + Element(rhs));
             AffineElement result = c.get_value();
             EXPECT_EQ(result, expected);
+            EXPECT_EQ(c.get_origin_tag(), first_two_merged_tag);
         };
 
     add(TestFixture::generators[0], TestFixture::generators[1], false, false);
@@ -234,56 +310,79 @@ TYPED_TEST(CycleGroupTest, TestAdd)
     {
         cycle_group_ct a = cycle_group_ct::from_witness(&builder, lhs);
         cycle_group_ct b = cycle_group_ct::from_witness(&builder, rhs);
+        a.set_origin_tag(submitted_value_origin_tag);
+        b.set_origin_tag(challenge_origin_tag);
         cycle_group_ct c = a + b;
         AffineElement expected(Element(lhs) + Element(rhs));
         AffineElement result = c.get_value();
         EXPECT_EQ(result, expected);
+        EXPECT_EQ(c.get_origin_tag(), first_two_merged_tag);
     }
 
     // case 2. lhs is point at infinity
     {
         cycle_group_ct a = point_at_infinity;
         cycle_group_ct b = cycle_group_ct::from_witness(&builder, rhs);
+        a.set_origin_tag(submitted_value_origin_tag);
+        b.set_origin_tag(challenge_origin_tag);
+
         cycle_group_ct c = a + b;
         AffineElement result = c.get_value();
         EXPECT_EQ(result, rhs);
+        EXPECT_EQ(c.get_origin_tag(), first_two_merged_tag);
     }
 
     // case 3. rhs is point at infinity
     {
         cycle_group_ct a = cycle_group_ct::from_witness(&builder, lhs);
         cycle_group_ct b = point_at_infinity;
+        a.set_origin_tag(submitted_value_origin_tag);
+        b.set_origin_tag(challenge_origin_tag);
+
         cycle_group_ct c = a + b;
         AffineElement result = c.get_value();
         EXPECT_EQ(result, lhs);
+        EXPECT_EQ(c.get_origin_tag(), first_two_merged_tag);
     }
 
     // case 4. both points are at infinity
     {
         cycle_group_ct a = point_at_infinity;
         cycle_group_ct b = point_at_infinity;
+        a.set_origin_tag(submitted_value_origin_tag);
+        b.set_origin_tag(challenge_origin_tag);
+
         cycle_group_ct c = a + b;
         EXPECT_TRUE(c.is_point_at_infinity().get_value());
         EXPECT_TRUE(c.get_value().is_point_at_infinity());
+        EXPECT_EQ(c.get_origin_tag(), first_two_merged_tag);
     }
 
     // case 5. lhs = -rhs
     {
         cycle_group_ct a = cycle_group_ct::from_witness(&builder, lhs);
         cycle_group_ct b = cycle_group_ct::from_witness(&builder, -lhs);
+        a.set_origin_tag(submitted_value_origin_tag);
+        b.set_origin_tag(challenge_origin_tag);
+
         cycle_group_ct c = a + b;
         EXPECT_TRUE(c.is_point_at_infinity().get_value());
         EXPECT_TRUE(c.get_value().is_point_at_infinity());
+        EXPECT_EQ(c.get_origin_tag(), first_two_merged_tag);
     }
 
     // case 6. lhs = rhs
     {
         cycle_group_ct a = cycle_group_ct::from_witness(&builder, lhs);
         cycle_group_ct b = cycle_group_ct::from_witness(&builder, lhs);
+        a.set_origin_tag(submitted_value_origin_tag);
+        b.set_origin_tag(challenge_origin_tag);
+
         cycle_group_ct c = a + b;
         AffineElement expected((Element(lhs)).dbl());
         AffineElement result = c.get_value();
         EXPECT_EQ(result, expected);
+        EXPECT_EQ(c.get_origin_tag(), first_two_merged_tag);
     }
 
     bool proof_result = CircuitChecker::check(builder);
@@ -299,10 +398,14 @@ TYPED_TEST(CycleGroupTest, TestUnconditionalSubtract)
         [&](const AffineElement& lhs, const AffineElement& rhs, const bool lhs_constant, const bool rhs_constant) {
             cycle_group_ct a = lhs_constant ? cycle_group_ct(lhs) : cycle_group_ct::from_witness(&builder, lhs);
             cycle_group_ct b = rhs_constant ? cycle_group_ct(rhs) : cycle_group_ct::from_witness(&builder, rhs);
+            a.set_origin_tag(submitted_value_origin_tag);
+            b.set_origin_tag(challenge_origin_tag);
+
             cycle_group_ct c = a.unconditional_subtract(b);
             AffineElement expected(Element(lhs) - Element(rhs));
             AffineElement result = c.get_value();
             EXPECT_EQ(result, expected);
+            EXPECT_EQ(c.get_origin_tag(), first_two_merged_tag);
         };
 
     add(TestFixture::generators[0], TestFixture::generators[1], false, false);
@@ -370,56 +473,80 @@ TYPED_TEST(CycleGroupTest, TestSubtract)
     {
         cycle_group_ct a = cycle_group_ct::from_witness(&builder, lhs);
         cycle_group_ct b = cycle_group_ct::from_witness(&builder, rhs);
+        a.set_origin_tag(submitted_value_origin_tag);
+        b.set_origin_tag(challenge_origin_tag);
+
         cycle_group_ct c = a - b;
         AffineElement expected(Element(lhs) - Element(rhs));
         AffineElement result = c.get_value();
         EXPECT_EQ(result, expected);
+        EXPECT_EQ(c.get_origin_tag(), first_two_merged_tag);
     }
 
     // case 2. lhs is point at infinity
     {
         cycle_group_ct a = point_at_infinity;
         cycle_group_ct b = cycle_group_ct::from_witness(&builder, rhs);
+        a.set_origin_tag(submitted_value_origin_tag);
+        b.set_origin_tag(challenge_origin_tag);
+
         cycle_group_ct c = a - b;
         AffineElement result = c.get_value();
         EXPECT_EQ(result, -rhs);
+        EXPECT_EQ(c.get_origin_tag(), first_two_merged_tag);
     }
 
     // case 3. rhs is point at infinity
     {
         cycle_group_ct a = cycle_group_ct::from_witness(&builder, lhs);
         cycle_group_ct b = point_at_infinity;
+        a.set_origin_tag(submitted_value_origin_tag);
+        b.set_origin_tag(challenge_origin_tag);
+
         cycle_group_ct c = a - b;
         AffineElement result = c.get_value();
         EXPECT_EQ(result, lhs);
+        EXPECT_EQ(c.get_origin_tag(), first_two_merged_tag);
     }
 
     // case 4. both points are at infinity
     {
         cycle_group_ct a = point_at_infinity;
         cycle_group_ct b = point_at_infinity;
+        a.set_origin_tag(submitted_value_origin_tag);
+        b.set_origin_tag(challenge_origin_tag);
+
         cycle_group_ct c = a - b;
         EXPECT_TRUE(c.is_point_at_infinity().get_value());
         EXPECT_TRUE(c.get_value().is_point_at_infinity());
+        EXPECT_EQ(c.get_origin_tag(), first_two_merged_tag);
     }
 
     // case 5. lhs = -rhs
     {
         cycle_group_ct a = cycle_group_ct::from_witness(&builder, lhs);
         cycle_group_ct b = cycle_group_ct::from_witness(&builder, -lhs);
+        a.set_origin_tag(submitted_value_origin_tag);
+        b.set_origin_tag(challenge_origin_tag);
+
         cycle_group_ct c = a - b;
         AffineElement expected((Element(lhs)).dbl());
         AffineElement result = c.get_value();
         EXPECT_EQ(result, expected);
+        EXPECT_EQ(c.get_origin_tag(), first_two_merged_tag);
     }
 
     // case 6. lhs = rhs
     {
         cycle_group_ct a = cycle_group_ct::from_witness(&builder, lhs);
         cycle_group_ct b = cycle_group_ct::from_witness(&builder, lhs);
+        a.set_origin_tag(submitted_value_origin_tag);
+        b.set_origin_tag(challenge_origin_tag);
+
         cycle_group_ct c = a - b;
         EXPECT_TRUE(c.is_point_at_infinity().get_value());
         EXPECT_TRUE(c.get_value().is_point_at_infinity());
+        EXPECT_EQ(c.get_origin_tag(), first_two_merged_tag);
     }
 
     bool proof_result = CircuitChecker::check(builder);
@@ -432,7 +559,18 @@ TYPED_TEST(CycleGroupTest, TestBatchMul)
     auto builder = Builder();
 
     const size_t num_muls = 1;
+    auto assign_and_merge_tags = [](auto& points, auto& scalars) {
+        OriginTag merged_tag;
+        for (size_t i = 0; i < points.size(); i++) {
+            const auto point_tag = OriginTag(/*parent_index=*/0, /*round_index=*/i, /*is_submitted=*/true);
+            const auto scalar_tag = OriginTag(/*parent_index=*/0, /*round_index=*/i, /*is_submitted=*/false);
 
+            merged_tag = OriginTag(merged_tag, OriginTag(point_tag, scalar_tag));
+            points[i].set_origin_tag(point_tag);
+            scalars[i].set_origin_tag(scalar_tag);
+        }
+        return merged_tag;
+    };
     // case 1, general MSM with inputs that are combinations of constant and witnesses
     {
         std::vector<cycle_group_ct> points;
@@ -463,8 +601,11 @@ TYPED_TEST(CycleGroupTest, TestBatchMul)
             points.emplace_back(cycle_group_ct(element));
             scalars.emplace_back(typename cycle_group_ct::cycle_scalar(scalar));
         }
+        const auto expected_tag = assign_and_merge_tags(points, scalars);
+
         auto result = cycle_group_ct::batch_mul(points, scalars);
         EXPECT_EQ(result.get_value(), AffineElement(expected));
+        EXPECT_EQ(result.get_origin_tag(), expected_tag);
     }
 
     // case 2, MSM that produces point at infinity
@@ -480,8 +621,12 @@ TYPED_TEST(CycleGroupTest, TestBatchMul)
         points.emplace_back(cycle_group_ct::from_witness(&builder, element));
         scalars.emplace_back(cycle_group_ct::cycle_scalar::from_witness(&builder, -scalar));
 
+        const auto expected_tag = assign_and_merge_tags(points, scalars);
+
         auto result = cycle_group_ct::batch_mul(points, scalars);
         EXPECT_TRUE(result.is_point_at_infinity().get_value());
+
+        EXPECT_EQ(result.get_origin_tag(), expected_tag);
     }
 
     // case 3. Multiply by zero
@@ -493,8 +638,11 @@ TYPED_TEST(CycleGroupTest, TestBatchMul)
         typename Group::subgroup_field scalar = 0;
         points.emplace_back(cycle_group_ct::from_witness(&builder, element));
         scalars.emplace_back(cycle_group_ct::cycle_scalar::from_witness(&builder, scalar));
+
+        const auto expected_tag = assign_and_merge_tags(points, scalars);
         auto result = cycle_group_ct::batch_mul(points, scalars);
         EXPECT_TRUE(result.is_point_at_infinity().get_value());
+        EXPECT_EQ(result.get_origin_tag(), expected_tag);
     }
 
     // case 4. Inputs are points at infinity
@@ -519,8 +667,11 @@ TYPED_TEST(CycleGroupTest, TestBatchMul)
             points.emplace_back(point);
             scalars.emplace_back(cycle_group_ct::cycle_scalar::from_witness(&builder, scalar));
         }
+
+        const auto expected_tag = assign_and_merge_tags(points, scalars);
         auto result = cycle_group_ct::batch_mul(points, scalars);
         EXPECT_TRUE(result.is_point_at_infinity().get_value());
+        EXPECT_EQ(result.get_origin_tag(), expected_tag);
     }
 
     // case 5, fixed-base MSM with inputs that are combinations of constant and witnesses (group elements are in
@@ -547,9 +698,11 @@ TYPED_TEST(CycleGroupTest, TestBatchMul)
             scalars.emplace_back(typename cycle_group_ct::cycle_scalar(scalar));
             scalars_native.emplace_back(uint256_t(scalar));
         }
+        const auto expected_tag = assign_and_merge_tags(points, scalars);
         auto result = cycle_group_ct::batch_mul(points, scalars);
         EXPECT_EQ(result.get_value(), AffineElement(expected));
         EXPECT_EQ(result.get_value(), crypto::pedersen_commitment::commit_native(scalars_native));
+        EXPECT_EQ(result.get_origin_tag(), expected_tag);
     }
 
     // case 6, fixed-base MSM with inputs that are combinations of constant and witnesses (some group elements are
@@ -584,8 +737,10 @@ TYPED_TEST(CycleGroupTest, TestBatchMul)
             scalars.emplace_back(cycle_group_ct::cycle_scalar::from_witness(&builder, scalar));
             scalars_native.emplace_back(scalar);
         }
+        const auto expected_tag = assign_and_merge_tags(points, scalars);
         auto result = cycle_group_ct::batch_mul(points, scalars);
         EXPECT_EQ(result.get_value(), AffineElement(expected));
+        EXPECT_EQ(result.get_origin_tag(), expected_tag);
     }
 
     // case 7, Fixed-base MSM where input scalars are 0
@@ -605,8 +760,10 @@ TYPED_TEST(CycleGroupTest, TestBatchMul)
             points.emplace_back((element));
             scalars.emplace_back(typename cycle_group_ct::cycle_scalar(scalar));
         }
+        const auto expected_tag = assign_and_merge_tags(points, scalars);
         auto result = cycle_group_ct::batch_mul(points, scalars);
         EXPECT_EQ(result.is_point_at_infinity().get_value(), true);
+        EXPECT_EQ(result.get_origin_tag(), expected_tag);
     }
 
     bool check_result = CircuitChecker::check(builder);
@@ -624,28 +781,34 @@ TYPED_TEST(CycleGroupTest, TestMul)
     {
         cycle_group_ct point;
         typename cycle_group_ct::cycle_scalar scalar;
+        cycle_group_ct result;
         for (size_t i = 0; i < num_muls; ++i) {
             auto element = TestFixture::generators[i];
             typename Group::subgroup_field native_scalar = Group::subgroup_field::random_element(&engine);
+            auto expected_result = element * native_scalar;
 
             // 1: add entry where point, scalar are witnesses
             point = (cycle_group_ct::from_witness(&builder, element));
             scalar = (cycle_group_ct::cycle_scalar::from_witness(&builder, native_scalar));
-            EXPECT_EQ((point * scalar).get_value(), (element * native_scalar));
+            point.set_origin_tag(submitted_value_origin_tag);
+            scalar.set_origin_tag(challenge_origin_tag);
+            result = point * scalar;
+
+            EXPECT_EQ((result).get_value(), (expected_result));
 
             // 2: add entry where point is constant, scalar is witness
             point = (cycle_group_ct(element));
             scalar = (cycle_group_ct::cycle_scalar::from_witness(&builder, native_scalar));
 
-            EXPECT_EQ((point * scalar).get_value(), (element * native_scalar));
+            EXPECT_EQ((result).get_value(), (expected_result));
 
             // 3: add entry where point is witness, scalar is constant
             point = (cycle_group_ct::from_witness(&builder, element));
-            EXPECT_EQ((point * scalar).get_value(), (element * native_scalar));
+            EXPECT_EQ((result).get_value(), (expected_result));
 
             // 4: add entry where point is constant, scalar is constant
             point = (cycle_group_ct(element));
-            EXPECT_EQ((point * scalar).get_value(), (element * native_scalar));
+            EXPECT_EQ((result).get_value(), (expected_result));
         }
     }
 
@@ -684,14 +847,13 @@ TYPED_TEST(CycleGroupTest, TestConversionFromBigfield)
         } else {
             big_elt = FF_ct(elt);
         }
-        cycle_scalar_ct scalar_from_big(big_elt);
-        EXPECT_EQ(elt, scalar_from_big.get_value());
-        cycle_scalar_ct scalar_from_elt(big_elt);
-        EXPECT_EQ(elt, scalar_from_elt.get_value());
+        big_elt.set_origin_tag(submitted_value_origin_tag);
+        cycle_scalar_ct scalar_from_big_elt(big_elt);
+        EXPECT_EQ(elt, scalar_from_big_elt.get_value());
+        EXPECT_EQ(scalar_from_big_elt.get_origin_tag(), big_elt.get_origin_tag());
         if (construct_witnesses) {
             EXPECT_FALSE(big_elt.is_constant());
-            EXPECT_FALSE(scalar_from_big.is_constant());
-            EXPECT_FALSE(scalar_from_elt.is_constant());
+            EXPECT_FALSE(scalar_from_big_elt.is_constant());
             EXPECT_TRUE(CircuitChecker::check(builder));
         }
     };

--- a/barretenberg/cpp/src/barretenberg/stdlib/primitives/group/cycle_group.test.cpp
+++ b/barretenberg/cpp/src/barretenberg/stdlib/primitives/group/cycle_group.test.cpp
@@ -72,7 +72,7 @@ TYPED_TEST(CycleGroupTest, TestBasicTagLogic)
     a.y.set_origin_tag(challenge_origin_tag);
 
     // The tag of the _is_point_at_infinity member should stay as next_challenge_tag, so the whole thing should be the
-    // merge of all 3
+    // union of all 3
 
     EXPECT_EQ(a.get_origin_tag(), first_second_third_merged_tag);
 
@@ -151,6 +151,7 @@ TYPED_TEST(CycleGroupTest, TestStandardForm)
     input_b.set_point_at_infinity(true);
     input_d.set_point_at_infinity(true);
 
+    // Assign different tags to all inputs
     input_a.set_origin_tag(submitted_value_origin_tag);
     input_b.set_origin_tag(challenge_origin_tag);
     input_c.set_origin_tag(next_challenge_tag);
@@ -166,6 +167,7 @@ TYPED_TEST(CycleGroupTest, TestStandardForm)
     EXPECT_EQ(standard_c.is_point_at_infinity().get_value(), false);
     EXPECT_EQ(standard_d.is_point_at_infinity().get_value(), true);
 
+    // Ensure that the tags in the standard from remain the same
     EXPECT_EQ(standard_a.get_origin_tag(), submitted_value_origin_tag);
     EXPECT_EQ(standard_b.get_origin_tag(), challenge_origin_tag);
     EXPECT_EQ(standard_c.get_origin_tag(), next_challenge_tag);
@@ -207,6 +209,7 @@ TYPED_TEST(CycleGroupTest, TestDbl)
     auto lhs = TestFixture::generators[0];
     cycle_group_ct a = cycle_group_ct::from_witness(&builder, lhs);
     cycle_group_ct b = cycle_group_ct(lhs);
+    // Assign two different tags
     a.set_origin_tag(submitted_value_origin_tag);
     b.set_origin_tag(challenge_origin_tag);
     cycle_group_ct c;
@@ -225,6 +228,7 @@ TYPED_TEST(CycleGroupTest, TestDbl)
     bool proof_result = CircuitChecker::check(builder);
     EXPECT_EQ(proof_result, true);
 
+    // Ensure the tags stay the same after doubling
     EXPECT_EQ(c.get_origin_tag(), submitted_value_origin_tag);
     EXPECT_EQ(d.get_origin_tag(), challenge_origin_tag);
 }
@@ -238,12 +242,14 @@ TYPED_TEST(CycleGroupTest, TestUnconditionalAdd)
         [&](const AffineElement& lhs, const AffineElement& rhs, const bool lhs_constant, const bool rhs_constant) {
             cycle_group_ct a = lhs_constant ? cycle_group_ct(lhs) : cycle_group_ct::from_witness(&builder, lhs);
             cycle_group_ct b = rhs_constant ? cycle_group_ct(rhs) : cycle_group_ct::from_witness(&builder, rhs);
+            // Assign two different tags
             a.set_origin_tag(submitted_value_origin_tag);
             b.set_origin_tag(challenge_origin_tag);
             cycle_group_ct c = a.unconditional_add(b);
             AffineElement expected(Element(lhs) + Element(rhs));
             AffineElement result = c.get_value();
             EXPECT_EQ(result, expected);
+            // Ensure the tags in the result are merged
             EXPECT_EQ(c.get_origin_tag(), first_two_merged_tag);
         };
 
@@ -310,12 +316,14 @@ TYPED_TEST(CycleGroupTest, TestAdd)
     {
         cycle_group_ct a = cycle_group_ct::from_witness(&builder, lhs);
         cycle_group_ct b = cycle_group_ct::from_witness(&builder, rhs);
+        // Here and in the following cases we assign two different tags
         a.set_origin_tag(submitted_value_origin_tag);
         b.set_origin_tag(challenge_origin_tag);
         cycle_group_ct c = a + b;
         AffineElement expected(Element(lhs) + Element(rhs));
         AffineElement result = c.get_value();
         EXPECT_EQ(result, expected);
+        // We expect the tags to be merged in the result
         EXPECT_EQ(c.get_origin_tag(), first_two_merged_tag);
     }
 
@@ -394,10 +402,11 @@ TYPED_TEST(CycleGroupTest, TestUnconditionalSubtract)
     STDLIB_TYPE_ALIASES;
     auto builder = Builder();
 
-    auto add =
+    auto subtract =
         [&](const AffineElement& lhs, const AffineElement& rhs, const bool lhs_constant, const bool rhs_constant) {
             cycle_group_ct a = lhs_constant ? cycle_group_ct(lhs) : cycle_group_ct::from_witness(&builder, lhs);
             cycle_group_ct b = rhs_constant ? cycle_group_ct(rhs) : cycle_group_ct::from_witness(&builder, rhs);
+            // Assign two different tags
             a.set_origin_tag(submitted_value_origin_tag);
             b.set_origin_tag(challenge_origin_tag);
 
@@ -405,13 +414,14 @@ TYPED_TEST(CycleGroupTest, TestUnconditionalSubtract)
             AffineElement expected(Element(lhs) - Element(rhs));
             AffineElement result = c.get_value();
             EXPECT_EQ(result, expected);
+            // Expect tags to be merged in the result
             EXPECT_EQ(c.get_origin_tag(), first_two_merged_tag);
         };
 
-    add(TestFixture::generators[0], TestFixture::generators[1], false, false);
-    add(TestFixture::generators[0], TestFixture::generators[1], false, true);
-    add(TestFixture::generators[0], TestFixture::generators[1], true, false);
-    add(TestFixture::generators[0], TestFixture::generators[1], true, true);
+    subtract(TestFixture::generators[0], TestFixture::generators[1], false, false);
+    subtract(TestFixture::generators[0], TestFixture::generators[1], false, true);
+    subtract(TestFixture::generators[0], TestFixture::generators[1], true, false);
+    subtract(TestFixture::generators[0], TestFixture::generators[1], true, true);
 
     bool proof_result = CircuitChecker::check(builder);
     EXPECT_EQ(proof_result, true);
@@ -473,6 +483,7 @@ TYPED_TEST(CycleGroupTest, TestSubtract)
     {
         cycle_group_ct a = cycle_group_ct::from_witness(&builder, lhs);
         cycle_group_ct b = cycle_group_ct::from_witness(&builder, rhs);
+        // Here and in the following cases we set 2 different tags to a and b
         a.set_origin_tag(submitted_value_origin_tag);
         b.set_origin_tag(challenge_origin_tag);
 
@@ -480,6 +491,7 @@ TYPED_TEST(CycleGroupTest, TestSubtract)
         AffineElement expected(Element(lhs) - Element(rhs));
         AffineElement result = c.get_value();
         EXPECT_EQ(result, expected);
+        // We expect the tag of the result to be the union of a and b tags
         EXPECT_EQ(c.get_origin_tag(), first_two_merged_tag);
     }
 
@@ -559,6 +571,12 @@ TYPED_TEST(CycleGroupTest, TestBatchMul)
     auto builder = Builder();
 
     const size_t num_muls = 1;
+    /**
+     * @brief Assign different tags to all points and scalars and return the union of that tag
+     *
+     *@details We assign the tags with the same round index to a (point,scalar) pair, but the point is treated as
+     *submitted value, while scalar as a challenge. Merging these tags should not run into any edgecases
+     */
     auto assign_and_merge_tags = [](auto& points, auto& scalars) {
         OriginTag merged_tag;
         for (size_t i = 0; i < points.size(); i++) {
@@ -601,10 +619,13 @@ TYPED_TEST(CycleGroupTest, TestBatchMul)
             points.emplace_back(cycle_group_ct(element));
             scalars.emplace_back(typename cycle_group_ct::cycle_scalar(scalar));
         }
+
+        // Here and in the following cases assign different tags to points and scalars and get the union of them back
         const auto expected_tag = assign_and_merge_tags(points, scalars);
 
         auto result = cycle_group_ct::batch_mul(points, scalars);
         EXPECT_EQ(result.get_value(), AffineElement(expected));
+        // The tag should the union of all tags
         EXPECT_EQ(result.get_origin_tag(), expected_tag);
     }
 

--- a/barretenberg/cpp/src/barretenberg/transcript/origin_tag.hpp
+++ b/barretenberg/cpp/src/barretenberg/transcript/origin_tag.hpp
@@ -54,13 +54,13 @@ struct OriginTag {
     // Parent tag is supposed to represent the index of a unique trancript object that generated the value. It uses
     // a concrete index, not bits for now, since we never expect two different indices to be used in the same
     // computation apart from equality assertion
-    size_t parent_tag;
+    size_t parent_tag = 0;
 
     // Child tag specifies which submitted values and challenges have been used to generate this element
     // The lower 128 bits represent using a submitted value from a corresponding round (the shift represents the
     // round) The higher 128 bits represent using a challenge value from an corresponding round (the shift
     // represents the round)
-    numeric::uint256_t child_tag;
+    numeric::uint256_t child_tag = 0;
 
     // Instant death is used for poisoning values we should never use in arithmetic
     bool instant_death = false;


### PR DESCRIPTION
Adds Origin Tag support (mechanism for tracking dangerous interactions of stdlib primitives) to cycle_group
