### PR TITLE
feat: Multicloud deployment using Terraform and Helm

### DIFF
--- a/spartan/aztec-network/values.yaml
+++ b/spartan/aztec-network/values.yaml
@@ -11,8 +11,8 @@ telemetry:
 
 images:
   aztec:
-    image: aztecprotocol/aztec:master
-    pullPolicy: Always
+    image: aztecprotocol/aztec
+    pullPolicy: IfNotPresent
   curl:
     image: curlimages/curl:7.81.0
     pullPolicy: IfNotPresent
@@ -186,7 +186,7 @@ ethereum:
     requests:
       memory: "2Gi"
       cpu: "200m"
-  storage: "120Gi"
+  storage: "80Gi"
 
 proverAgent:
   enabled: true

--- a/spartan/aztec-network/values.yaml
+++ b/spartan/aztec-network/values.yaml
@@ -186,7 +186,7 @@ ethereum:
     requests:
       memory: "2Gi"
       cpu: "200m"
-  storage: "8Gi"
+  storage: "120Gi"
 
 proverAgent:
   enabled: true

--- a/spartan/aztec-network/values.yaml
+++ b/spartan/aztec-network/values.yaml
@@ -11,8 +11,8 @@ telemetry:
 
 images:
   aztec:
-    image: aztecprotocol/aztec
-    pullPolicy: IfNotPresent
+    image: aztecprotocol/aztec:master
+    pullPolicy: Always
   curl:
     image: curlimages/curl:7.81.0
     pullPolicy: IfNotPresent

--- a/spartan/terraform/multicloud-deploy/main.tf
+++ b/spartan/terraform/multicloud-deploy/main.tf
@@ -1,0 +1,123 @@
+terraform {
+  backend "s3" {
+    bucket = "aztec-terraform"
+    key    = "multicloud-deploy/terraform.tfstate"
+    region = "eu-west-2"
+  }
+  required_providers {
+    helm = {
+      source  = "hashicorp/helm"
+      version = "~> 2.12.1"
+    }
+    kubernetes = {
+      source  = "hashicorp/kubernetes"
+      version = "~> 2.24.0"
+    }
+  }
+}
+
+# Define providers for different contexts
+provider "kubernetes" {
+  alias          = "cluster1"
+  config_path    = "~/.kube/config"
+  config_context = "arn:aws:eks:us-east-1:278380418400:cluster/spartan"
+}
+
+provider "kubernetes" {
+  alias          = "cluster2"
+  config_path    = "~/.kube/config"
+  config_context = "gke_testnet-440309_us-east1_spartan-provers"
+}
+
+# Helm providers for each cluster
+provider "helm" {
+  alias = "cluster1"
+  kubernetes {
+    config_path    = "~/.kube/config"
+    config_context = "arn:aws:eks:us-east-1:278380418400:cluster/spartan"
+  }
+}
+
+provider "helm" {
+  alias = "cluster2"
+  kubernetes {
+    config_path    = "~/.kube/config"
+    config_context = "gke_testnet-440309_us-east1_spartan-provers"
+  }
+}
+
+# Deploy to cluster1
+resource "kubernetes_namespace" "example_cluster1" {
+  provider = kubernetes.cluster1
+  metadata {
+    name = "my-namespace-cluster1"
+  }
+}
+
+# Deploy to cluster2
+resource "kubernetes_namespace" "example_cluster2" {
+  provider = kubernetes.cluster2
+  metadata {
+    name = "my-namespace-cluster2"
+  }
+}
+
+# Example Helm release for cluster1
+resource "helm_release" "nginx_cluster1" {
+  provider   = helm.cluster1
+  name       = "nginx"
+  repository = "https://charts.bitnami.com/bitnami"
+  chart      = "nginx"
+  namespace  = kubernetes_namespace.example_cluster1.metadata[0].name
+
+  values = [
+    <<-EOT
+    service:
+      type: ClusterIP
+    replicaCount: 2
+    EOT
+  ]
+}
+
+# Example Helm release for cluster2
+resource "helm_release" "nginx_cluster2" {
+  provider   = helm.cluster2
+  name       = "nginx"
+  repository = "https://charts.bitnami.com/bitnami"
+  chart      = "nginx"
+  namespace  = kubernetes_namespace.example_cluster2.metadata[0].name
+
+  # Different configuration for cluster2
+  values = [
+    <<-EOT
+    service:
+      type: ClusterIP
+    replicaCount: 3
+    resources:
+      limits:
+        cpu: 200m
+        memory: 256Mi
+      requests:
+        cpu: 100m
+        memory: 128Mi
+    EOT
+  ]
+}
+
+# Variables remain the same
+variable "clusters" {
+  type = map(string)
+  default = {
+    cluster1 = "cluster1-context"
+    cluster2 = "cluster2-context"
+  }
+}
+
+# Data source remains the same
+data "kubernetes_service" "example" {
+  provider = kubernetes.cluster1
+  metadata {
+    name      = "existing-service"
+    namespace = "default"
+  }
+}

--- a/spartan/terraform/multicloud-deploy/outputs.tf
+++ b/spartan/terraform/multicloud-deploy/outputs.tf
@@ -1,0 +1,1 @@
+# placeholder

--- a/spartan/terraform/multicloud-deploy/outputs.tf
+++ b/spartan/terraform/multicloud-deploy/outputs.tf
@@ -1,1 +1,25 @@
-# placeholder
+output "eks_cluster_deployment" {
+  description = "Details of the EKS cluster Helm deployment"
+  value = {
+    name        = helm_release.aztec-eks-cluster.name
+    namespace   = helm_release.aztec-eks-cluster.namespace
+    chart       = helm_release.aztec-eks-cluster.chart
+    version     = helm_release.aztec-eks-cluster.version
+    status      = helm_release.aztec-eks-cluster.status
+    values_file = var.eks-values-file
+    cluster     = var.eks_cluster_context
+  }
+}
+
+output "gke_cluster_deployment" {
+  description = "Details of the GKE cluster Helm deployment"
+  value = {
+    name        = helm_release.aztec-gke-cluster.name
+    namespace   = helm_release.aztec-gke-cluster.namespace
+    chart       = helm_release.aztec-gke-cluster.chart
+    version     = helm_release.aztec-gke-cluster.version
+    status      = helm_release.aztec-gke-cluster.status
+    values_file = var.gke-values-file
+    cluster     = var.gke_cluster_context
+  }
+}

--- a/spartan/terraform/multicloud-deploy/variables.tf
+++ b/spartan/terraform/multicloud-deploy/variables.tf
@@ -1,0 +1,1 @@
+# placeholder

--- a/spartan/terraform/multicloud-deploy/variables.tf
+++ b/spartan/terraform/multicloud-deploy/variables.tf
@@ -1,1 +1,4 @@
-# placeholder
+variable "testnet_name" {
+  type    = string
+  default = "mainnet"
+}

--- a/spartan/terraform/multicloud-deploy/variables.tf
+++ b/spartan/terraform/multicloud-deploy/variables.tf
@@ -1,4 +1,29 @@
+variable "eks_cluster_context" {
+  description = "EKS cluster context"
+  type        = string
+  default     = "arn:aws:eks:us-east-1:278380418400:cluster/spartan"
+}
+
+variable "gke_cluster_context" {
+  description = "GKE cluster context"
+  type        = string
+  default     = "gke_testnet-440309_us-east1_spartan-provers"
+}
+
 variable "testnet_name" {
-  type    = string
-  default = "mainnet"
+  description = "Name of helm deployment and k8s namespace"
+  type        = string
+  default     = "terratest"
+}
+
+variable "eks-values-file" {
+  description = "Name of the values file to use for eks cluster"
+  type        = string
+  default     = "1-validators.yaml"
+}
+
+variable "gke-values-file" {
+  description = "Name of the values file to use for gke cluster"
+  type        = string
+  default     = "1-validators.yaml"
 }


### PR DESCRIPTION
# Change Log

- **Multicloud deployment using Terraform and Helm**
New Terraform code has been added to place helm deployments onto 2 separate Kubernetes clusters (1 AWS, 1 GCloud). Although Terraform has the ability to `set` values, this is intentionally not used, to simplify customizations to only exist inside of Helm for simpler portability between cloud and local machine environments. 

- **Anvil node storage increase**
Anvil currently fails and is evicted from Kubernetes due to exhausting available disc space. At the moment this happens after a few days of block activity. The new disc value is intended to allow Anvil to run continuously for a period of weeks of environments such as long-lived `devnet` deployments. 

- **Updated default deployment image**
The default image in `values.yaml` is updated to use the latest `master` branch build.