### PR TITLE
feat: multiplier oracle

### DIFF
--- a/l1-contracts/foundry.toml
+++ b/l1-contracts/foundry.toml
@@ -17,6 +17,7 @@ fs_permissions = [
   {access = "read", path = "./test/fixtures/mixed_block_2.json"},
   {access = "read", path = "./test/fixtures/empty_block_1.json"},
   {access = "read", path = "./test/fixtures/empty_block_2.json"},
+  {access = "read", path = "./test/fixtures/fee_data_points.json"}
 ]
 
 [fmt]

--- a/l1-contracts/src/core/libraries/Errors.sol
+++ b/l1-contracts/src/core/libraries/Errors.sol
@@ -109,4 +109,8 @@ library Errors {
   error ProofCommitmentEscrow__InsufficientBalance(uint256 balance, uint256 requested); // 0x09b8b789
   error ProofCommitmentEscrow__NotOwner(address caller); // 0x2ac332c1
   error ProofCommitmentEscrow__WithdrawRequestNotReady(uint256 current, Timestamp readyAt); // 0xb32ab8a7
+
+  // FeeMath
+  error FeeMath__InvalidProvingCostModifier(); // 0x8b9d62ac
+  error FeeMath__InvalidFeeAssetPriceModifier(); // 0xf2fb32ad
 }

--- a/l1-contracts/src/core/libraries/FeeMath.sol
+++ b/l1-contracts/src/core/libraries/FeeMath.sol
@@ -1,0 +1,80 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright 2024 Aztec Labs.
+pragma solidity >=0.8.27;
+
+import {Math} from "@oz/utils/math/Math.sol";
+import {SafeCast} from "@oz/utils/math/SafeCast.sol";
+import {SignedMath} from "@oz/utils/math/SignedMath.sol";
+
+import {Errors} from "./Errors.sol";
+
+struct OracleInput {
+  int256 provingCostModifier;
+  int256 feeAssetPriceModifier;
+}
+
+library FeeMath {
+  using Math for uint256;
+  using SafeCast for int256;
+  using SafeCast for uint256;
+  using SignedMath for int256;
+
+  // These values are taken from the model, but mostly pulled out of the ass
+  uint256 internal constant MINIMUM_PROVING_COST_PER_MANA = 5415357955;
+  uint256 internal constant MAX_PROVING_COST_MODIFIER = 1000000000;
+  uint256 internal constant PROVING_UPDATE_FRACTION = 100000000000;
+
+  uint256 internal constant MINIMUM_FEE_ASSET_PRICE = 10000000000;
+  uint256 internal constant MAX_FEE_ASSET_PRICE_MODIFIER = 1000000000;
+  uint256 internal constant FEE_ASSET_PRICE_UPDATE_FRACTION = 100000000000;
+
+  function assertValid(OracleInput memory _self) internal pure returns (bool) {
+    require(
+      SignedMath.abs(_self.provingCostModifier) <= MAX_PROVING_COST_MODIFIER,
+      Errors.FeeMath__InvalidProvingCostModifier()
+    );
+    require(
+      SignedMath.abs(_self.feeAssetPriceModifier) <= MAX_FEE_ASSET_PRICE_MODIFIER,
+      Errors.FeeMath__InvalidFeeAssetPriceModifier()
+    );
+    return true;
+  }
+
+  function clampedAdd(uint256 _a, int256 _b) internal pure returns (uint256) {
+    if (_b >= 0) {
+      return _a + _b.toUint256();
+    }
+
+    uint256 sub = SignedMath.abs(_b);
+
+    if (_a > sub) {
+      return _a - sub;
+    }
+
+    return 0;
+  }
+
+  function provingCostPerMana(uint256 _numerator) internal pure returns (uint256) {
+    return fakeExponential(MINIMUM_PROVING_COST_PER_MANA, _numerator, PROVING_UPDATE_FRACTION);
+  }
+
+  function feeAssetPriceModifier(uint256 _numerator) internal pure returns (uint256) {
+    return fakeExponential(MINIMUM_FEE_ASSET_PRICE, _numerator, FEE_ASSET_PRICE_UPDATE_FRACTION);
+  }
+
+  function fakeExponential(uint256 _factor, uint256 _numerator, uint256 _denominator)
+    private
+    pure
+    returns (uint256)
+  {
+    uint256 i = 1;
+    uint256 output = 0;
+    uint256 numeratorAccumulator = _factor * _denominator;
+    while (numeratorAccumulator > 0) {
+      output += numeratorAccumulator;
+      numeratorAccumulator = (numeratorAccumulator * _numerator) / (_denominator * i);
+      i += 1;
+    }
+    return output / _denominator;
+  }
+}

--- a/l1-contracts/test/fees/FeeModelTestPoints.t.sol
+++ b/l1-contracts/test/fees/FeeModelTestPoints.t.sol
@@ -1,0 +1,65 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright 2024 Aztec Labs.
+// solhint-disable var-name-mixedcase
+pragma solidity >=0.8.27;
+
+import {Test} from "forge-std/Test.sol";
+
+// Remember that foundry json parsing is alphabetically done, so you MUST
+// sort the struct fields alphabetically or prepare for a headache.
+
+struct L1Fees {
+  uint256 base_fee;
+  uint256 blob_fee;
+}
+
+struct Header {
+  uint256 excess_mana;
+  uint256 fee_asset_price_numerator;
+  uint256 mana_used;
+  uint256 proving_cast_per_mana_numerator;
+}
+
+struct OracleInput {
+  int256 fee_asset_price_modifier;
+  int256 proving_cost_modifier;
+}
+
+struct ManaBaseFeeComponents {
+  uint256 congestion_cost;
+  uint256 congestion_multiplier;
+  uint256 data_cost;
+  uint256 gas_cost;
+  uint256 proving_cost;
+}
+
+struct TestPointOutputs {
+  uint256 fee_asset_price_at_execution;
+  ManaBaseFeeComponents mana_base_fee_components_in_fee_asset;
+  ManaBaseFeeComponents mana_base_fee_components_in_wei;
+}
+
+struct TestPoint {
+  uint256 l1_block_number;
+  L1Fees l1_fees;
+  Header header;
+  OracleInput oracle_input;
+  TestPointOutputs outputs;
+  Header parent_header;
+}
+
+contract FeeModelTestPoints is Test {
+  TestPoint[] public points;
+
+  constructor() {
+    string memory root = vm.projectRoot();
+    string memory path = string.concat(root, "/test/fixtures/fee_data_points.json");
+    string memory json = vm.readFile(path);
+    bytes memory jsonBytes = vm.parseJson(json);
+    TestPoint[] memory dataPoints = abi.decode(jsonBytes, (TestPoint[]));
+
+    for (uint256 i = 0; i < dataPoints.length; i++) {
+      points.push(dataPoints[i]);
+    }
+  }
+}

--- a/l1-contracts/test/fees/MinimalFeeModel.sol
+++ b/l1-contracts/test/fees/MinimalFeeModel.sol
@@ -1,0 +1,44 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright 2024 Aztec Labs.
+pragma solidity >=0.8.27;
+
+import {FeeMath, OracleInput} from "@aztec/core/libraries/FeeMath.sol";
+
+contract MinimalFeeModel {
+  using FeeMath for OracleInput;
+  using FeeMath for uint256;
+
+  struct DataPoint {
+    uint256 provingCostNumerator;
+    uint256 feeAssetPriceNumerator;
+  }
+
+  uint256 public populatedThrough = 0;
+  mapping(uint256 _slotNumber => DataPoint _dataPoint) public dataPoints;
+
+  constructor() {
+    dataPoints[0] = DataPoint({provingCostNumerator: 0, feeAssetPriceNumerator: 0});
+  }
+
+  // See the `add_slot` function in the `fee-model.ipynb` notebook for more context.
+  function addSlot(OracleInput memory _oracleInput) public {
+    _oracleInput.assertValid();
+
+    DataPoint memory parent = dataPoints[populatedThrough];
+
+    dataPoints[++populatedThrough] = DataPoint({
+      provingCostNumerator: parent.provingCostNumerator.clampedAdd(_oracleInput.provingCostModifier),
+      feeAssetPriceNumerator: parent.feeAssetPriceNumerator.clampedAdd(
+        _oracleInput.feeAssetPriceModifier
+      )
+    });
+  }
+
+  function getFeeAssetPrice(uint256 _slotNumber) public view returns (uint256) {
+    return FeeMath.feeAssetPriceModifier(dataPoints[_slotNumber].feeAssetPriceNumerator);
+  }
+
+  function getProvingCost(uint256 _slotNumber) public view returns (uint256) {
+    return FeeMath.provingCostPerMana(dataPoints[_slotNumber].provingCostNumerator);
+  }
+}

--- a/l1-contracts/test/fees/MinimalFeeModel.t.sol
+++ b/l1-contracts/test/fees/MinimalFeeModel.t.sol
@@ -1,0 +1,69 @@
+// SPDX-License-Identifier: UNLICENSED
+pragma solidity >=0.8.27;
+
+import {OracleInput, FeeMath} from "@aztec/core/libraries/FeeMath.sol";
+import {FeeModelTestPoints} from "./FeeModelTestPoints.t.sol";
+import {MinimalFeeModel} from "./MinimalFeeModel.sol";
+import {Errors} from "@aztec/core/libraries/Errors.sol";
+
+contract MinimalFeeModelTest is FeeModelTestPoints {
+  MinimalFeeModel internal feeContract;
+
+  function setUp() public {
+    feeContract = new MinimalFeeModel();
+
+    for (uint256 i = 0; i < points.length; i++) {
+      feeContract.addSlot(
+        OracleInput({
+          provingCostModifier: points[i].oracle_input.proving_cost_modifier,
+          feeAssetPriceModifier: points[i].oracle_input.fee_asset_price_modifier
+        })
+      );
+    }
+  }
+
+  function test_computeProvingCost() public {
+    for (uint256 i = 0; i < points.length; i++) {
+      assertEq(
+        feeContract.getProvingCost(i),
+        points[i].outputs.mana_base_fee_components_in_wei.proving_cost,
+        "Computed proving cost does not match expected value"
+      );
+    }
+  }
+
+  function test_computeFeeAssetPrice() public {
+    for (uint256 i = 0; i < points.length; i++) {
+      assertEq(
+        feeContract.getFeeAssetPrice(i),
+        points[i].outputs.fee_asset_price_at_execution,
+        "Computed fee asset price does not match expected value"
+      );
+    }
+  }
+
+  function test_invalidOracleInput() public {
+    uint256 provingBoundary = FeeMath.MAX_PROVING_COST_MODIFIER + 1;
+    uint256 feeAssetPriceBoundary = FeeMath.MAX_FEE_ASSET_PRICE_MODIFIER + 1;
+
+    vm.expectRevert(abi.encodeWithSelector(Errors.FeeMath__InvalidProvingCostModifier.selector));
+    feeContract.addSlot(
+      OracleInput({provingCostModifier: int256(provingBoundary), feeAssetPriceModifier: 0})
+    );
+
+    vm.expectRevert(abi.encodeWithSelector(Errors.FeeMath__InvalidProvingCostModifier.selector));
+    feeContract.addSlot(
+      OracleInput({provingCostModifier: -int256(provingBoundary), feeAssetPriceModifier: 0})
+    );
+
+    vm.expectRevert(abi.encodeWithSelector(Errors.FeeMath__InvalidFeeAssetPriceModifier.selector));
+    feeContract.addSlot(
+      OracleInput({provingCostModifier: 0, feeAssetPriceModifier: int256(feeAssetPriceBoundary)})
+    );
+
+    vm.expectRevert(abi.encodeWithSelector(Errors.FeeMath__InvalidFeeAssetPriceModifier.selector));
+    feeContract.addSlot(
+      OracleInput({provingCostModifier: 0, feeAssetPriceModifier: -int256(feeAssetPriceBoundary)})
+    );
+  }
+}

--- a/l1-contracts/test/fixtures/fee_data_points.json
+++ b/l1-contracts/test/fixtures/fee_data_points.json
@@ -1,0 +1,26682 @@
+[
+    {
+        "l1_block_number": 20973164,
+        "l1_fees": {
+            "blob_fee": 23,
+            "base_fee": 14402849460
+        },
+        "parent_header": {
+            "excess_mana": 0,
+            "mana_used": 0,
+            "proving_cost_per_mana_numerator": 0,
+            "fee_asset_price_numerator": 0
+        },
+        "header": {
+            "excess_mana": 0,
+            "mana_used": 199990283,
+            "proving_cost_per_mana_numerator": 0,
+            "fee_asset_price_numerator": 669375682
+        },
+        "oracle_input": {
+            "proving_cost_modifier": -59048622,
+            "fee_asset_price_modifier": 669375682
+        },
+        "outputs": {
+            "fee_asset_price_at_execution": 10000000000,
+            "mana_base_fee_components_in_wei": {
+                "data_cost": 0,
+                "gas_cost": 47709438,
+                "proving_cost": 5415357955,
+                "congestion_cost": 0,
+                "congestion_multiplier": 1000000000
+            },
+            "mana_base_fee_components_in_fee_asset": {
+                "data_cost": 0,
+                "gas_cost": 477094380,
+                "proving_cost": 54153579550,
+                "congestion_cost": 0,
+                "congestion_multiplier": 1000000000
+            }
+        }
+    },
+    {
+        "l1_block_number": 20973167,
+        "l1_fees": {
+            "blob_fee": 25,
+            "base_fee": 14415907878
+        },
+        "parent_header": {
+            "excess_mana": 0,
+            "mana_used": 199990283,
+            "proving_cost_per_mana_numerator": 0,
+            "fee_asset_price_numerator": 669375682
+        },
+        "header": {
+            "excess_mana": 99990283,
+            "mana_used": 199990996,
+            "proving_cost_per_mana_numerator": 0,
+            "fee_asset_price_numerator": 1462908027
+        },
+        "oracle_input": {
+            "proving_cost_modifier": -178362315,
+            "fee_asset_price_modifier": 793532345
+        },
+        "outputs": {
+            "fee_asset_price_at_execution": 10067162100,
+            "mana_base_fee_components_in_wei": {
+                "data_cost": 0,
+                "gas_cost": 47752694,
+                "proving_cost": 5415357955,
+                "congestion_cost": 678008355,
+                "congestion_multiplier": 1124106649
+            },
+            "mana_base_fee_components_in_fee_asset": {
+                "data_cost": 0,
+                "gas_cost": 480734111,
+                "proving_cost": 54517286362,
+                "congestion_cost": 6825620014,
+                "congestion_multiplier": 1124106649
+            }
+        }
+    },
+    {
+        "l1_block_number": 20973170,
+        "l1_fees": {
+            "blob_fee": 31,
+            "base_fee": 13994212243
+        },
+        "parent_header": {
+            "excess_mana": 99990283,
+            "mana_used": 199990996,
+            "proving_cost_per_mana_numerator": 0,
+            "fee_asset_price_numerator": 1462908027
+        },
+        "header": {
+            "excess_mana": 199981279,
+            "mana_used": 199997039,
+            "proving_cost_per_mana_numerator": 17455936,
+            "fee_asset_price_numerator": 1631363588
+        },
+        "oracle_input": {
+            "proving_cost_modifier": 17455936,
+            "fee_asset_price_modifier": 168455561
+        },
+        "outputs": {
+            "fee_asset_price_at_execution": 10147366089,
+            "mana_base_fee_components_in_wei": {
+                "data_cost": 0,
+                "gas_cost": 46355828,
+                "proving_cost": 5415357955,
+                "congestion_cost": 1439799586,
+                "congestion_multiplier": 1263616814
+            },
+            "mana_base_fee_components_in_fee_asset": {
+                "data_cost": 0,
+                "gas_cost": 470389557,
+                "proving_cost": 54951619672,
+                "congestion_cost": 14610173493,
+                "congestion_multiplier": 1263616814
+            }
+        }
+    },
+    {
+        "l1_block_number": 20973173,
+        "l1_fees": {
+            "blob_fee": 29,
+            "base_fee": 14784230064
+        },
+        "parent_header": {
+            "excess_mana": 199981279,
+            "mana_used": 199997039,
+            "proving_cost_per_mana_numerator": 17455936,
+            "fee_asset_price_numerator": 1631363588
+        },
+        "header": {
+            "excess_mana": 299978318,
+            "mana_used": 199997697,
+            "proving_cost_per_mana_numerator": 0,
+            "fee_asset_price_numerator": 1040346471
+        },
+        "oracle_input": {
+            "proving_cost_modifier": -99066077,
+            "fee_asset_price_modifier": -591017117
+        },
+        "outputs": {
+            "fee_asset_price_at_execution": 10164474298,
+            "mana_base_fee_components_in_wei": {
+                "data_cost": 0,
+                "gas_cost": 48972762,
+                "proving_cost": 5416303338,
+                "congestion_cost": 2297882391,
+                "congestion_multiplier": 1420451291
+            },
+            "mana_base_fee_components_in_fee_asset": {
+                "data_cost": 0,
+                "gas_cost": 497782380,
+                "proving_cost": 55053876069,
+                "congestion_cost": 23356766503,
+                "congestion_multiplier": 1420451291
+            }
+        }
+    },
+    {
+        "l1_block_number": 20973176,
+        "l1_fees": {
+            "blob_fee": 32,
+            "base_fee": 15016479747
+        },
+        "parent_header": {
+            "excess_mana": 299978318,
+            "mana_used": 199997697,
+            "proving_cost_per_mana_numerator": 0,
+            "fee_asset_price_numerator": 1040346471
+        },
+        "header": {
+            "excess_mana": 399976015,
+            "mana_used": 199996235,
+            "proving_cost_per_mana_numerator": 0,
+            "fee_asset_price_numerator": 1412024221
+        },
+        "oracle_input": {
+            "proving_cost_modifier": -142153798,
+            "fee_asset_price_modifier": 371677750
+        },
+        "outputs": {
+            "fee_asset_price_at_execution": 10104577689,
+            "mana_base_fee_components_in_wei": {
+                "data_cost": 0,
+                "gas_cost": 49742089,
+                "proving_cost": 5415357955,
+                "congestion_cost": 3261312622,
+                "congestion_multiplier": 1596752593
+            },
+            "mana_base_fee_components_in_fee_asset": {
+                "data_cost": 0,
+                "gas_cost": 502622802,
+                "proving_cost": 54719905170,
+                "congestion_cost": 32954186757,
+                "congestion_multiplier": 1596752593
+            }
+        }
+    },
+    {
+        "l1_block_number": 20973179,
+        "l1_fees": {
+            "blob_fee": 35,
+            "base_fee": 14552539238
+        },
+        "parent_header": {
+            "excess_mana": 399976015,
+            "mana_used": 199996235,
+            "proving_cost_per_mana_numerator": 0,
+            "fee_asset_price_numerator": 1412024221
+        },
+        "header": {
+            "excess_mana": 499972250,
+            "mana_used": 199997933,
+            "proving_cost_per_mana_numerator": 40177098,
+            "fee_asset_price_numerator": 1893950162
+        },
+        "oracle_input": {
+            "proving_cost_modifier": 40177098,
+            "fee_asset_price_modifier": 481925941
+        },
+        "outputs": {
+            "fee_asset_price_at_execution": 10142204037,
+            "mana_base_fee_components_in_wei": {
+                "data_cost": 0,
+                "gas_cost": 48205286,
+                "proving_cost": 5415357955,
+                "congestion_cost": 4343165122,
+                "congestion_multiplier": 1794932708
+            },
+            "mana_base_fee_components_in_fee_asset": {
+                "data_cost": 0,
+                "gas_cost": 488907846,
+                "proving_cost": 54923665313,
+                "congestion_cost": 44049266833,
+                "congestion_multiplier": 1794932708
+            }
+        }
+    },
+    {
+        "l1_block_number": 20973182,
+        "l1_fees": {
+            "blob_fee": 50,
+            "base_fee": 14547546861
+        },
+        "parent_header": {
+            "excess_mana": 499972250,
+            "mana_used": 199997933,
+            "proving_cost_per_mana_numerator": 40177098,
+            "fee_asset_price_numerator": 1893950162
+        },
+        "header": {
+            "excess_mana": 599970183,
+            "mana_used": 199994817,
+            "proving_cost_per_mana_numerator": 0,
+            "fee_asset_price_numerator": 1856798629
+        },
+        "oracle_input": {
+            "proving_cost_modifier": -60537230,
+            "fee_asset_price_modifier": -37151533
+        },
+        "outputs": {
+            "fee_asset_price_at_execution": 10191199916,
+            "mana_base_fee_components_in_wei": {
+                "data_cost": 0,
+                "gas_cost": 48188748,
+                "proving_cost": 5417534125,
+                "congestion_cost": 5562541884,
+                "congestion_multiplier": 2017713853
+            },
+            "mana_base_fee_components_in_fee_asset": {
+                "data_cost": 0,
+                "gas_cost": 491101164,
+                "proving_cost": 55211173319,
+                "congestion_cost": 56688976380,
+                "congestion_multiplier": 2017713853
+            }
+        }
+    },
+    {
+        "l1_block_number": 20973185,
+        "l1_fees": {
+            "blob_fee": 72,
+            "base_fee": 14232502274
+        },
+        "parent_header": {
+            "excess_mana": 599970183,
+            "mana_used": 199994817,
+            "proving_cost_per_mana_numerator": 0,
+            "fee_asset_price_numerator": 1856798629
+        },
+        "header": {
+            "excess_mana": 699965000,
+            "mana_used": 199996278,
+            "proving_cost_per_mana_numerator": 0,
+            "fee_asset_price_numerator": 1582709589
+        },
+        "oracle_input": {
+            "proving_cost_modifier": -50166503,
+            "fee_asset_price_modifier": -274089040
+        },
+        "outputs": {
+            "fee_asset_price_at_execution": 10187414432,
+            "mana_base_fee_components_in_wei": {
+                "data_cost": 0,
+                "gas_cost": 47145163,
+                "proving_cost": 5415357955,
+                "congestion_cost": 6927205544,
+                "congestion_multiplier": 2268137591
+            },
+            "mana_base_fee_components_in_fee_asset": {
+                "data_cost": 0,
+                "gas_cost": 480287313,
+                "proving_cost": 55168495785,
+                "congestion_cost": 70570313732,
+                "congestion_multiplier": 2268137591
+            }
+        }
+    },
+    {
+        "l1_block_number": 20973188,
+        "l1_fees": {
+            "blob_fee": 98,
+            "base_fee": 14127655188
+        },
+        "parent_header": {
+            "excess_mana": 699965000,
+            "mana_used": 199996278,
+            "proving_cost_per_mana_numerator": 0,
+            "fee_asset_price_numerator": 1582709589
+        },
+        "header": {
+            "excess_mana": 799961278,
+            "mana_used": 199984012,
+            "proving_cost_per_mana_numerator": 33783426,
+            "fee_asset_price_numerator": 1246258072
+        },
+        "oracle_input": {
+            "proving_cost_modifier": 33783426,
+            "fee_asset_price_modifier": -336451517
+        },
+        "outputs": {
+            "fee_asset_price_at_execution": 10159530077,
+            "mana_base_fee_components_in_wei": {
+                "data_cost": 0,
+                "gas_cost": 46797857,
+                "proving_cost": 5415357955,
+                "congestion_cost": 8464410270,
+                "congestion_multiplier": 2549646433
+            },
+            "mana_base_fee_components_in_fee_asset": {
+                "data_cost": 0,
+                "gas_cost": 475444235,
+                "proving_cost": 55017492021,
+                "congestion_cost": 85994430722,
+                "congestion_multiplier": 2549646433
+            }
+        }
+    },
+    {
+        "l1_block_number": 20973191,
+        "l1_fees": {
+            "blob_fee": 115,
+            "base_fee": 14102980851
+        },
+        "parent_header": {
+            "excess_mana": 799961278,
+            "mana_used": 199984012,
+            "proving_cost_per_mana_numerator": 33783426,
+            "fee_asset_price_numerator": 1246258072
+        },
+        "header": {
+            "excess_mana": 899945290,
+            "mana_used": 199999674,
+            "proving_cost_per_mana_numerator": 0,
+            "fee_asset_price_numerator": 954592539
+        },
+        "oracle_input": {
+            "proving_cost_modifier": -106484723,
+            "fee_asset_price_modifier": -291665533
+        },
+        "outputs": {
+            "fee_asset_price_at_execution": 10125405622,
+            "mana_base_fee_components_in_wei": {
+                "data_cost": 0,
+                "gas_cost": 46716124,
+                "proving_cost": 5417187757,
+                "congestion_cost": 10195936862,
+                "congestion_multiplier": 2866053482
+            },
+            "mana_base_fee_components_in_fee_asset": {
+                "data_cost": 0,
+                "gas_cost": 473019704,
+                "proving_cost": 54851223370,
+                "congestion_cost": 103237996424,
+                "congestion_multiplier": 2866053482
+            }
+        }
+    },
+    {
+        "l1_block_number": 20973194,
+        "l1_fees": {
+            "blob_fee": 120,
+            "base_fee": 14702466429
+        },
+        "parent_header": {
+            "excess_mana": 899945290,
+            "mana_used": 199999674,
+            "proving_cost_per_mana_numerator": 0,
+            "fee_asset_price_numerator": 954592539
+        },
+        "header": {
+            "excess_mana": 999944964,
+            "mana_used": 199996424,
+            "proving_cost_per_mana_numerator": 0,
+            "fee_asset_price_numerator": 1071432807
+        },
+        "oracle_input": {
+            "proving_cost_modifier": -52977520,
+            "fee_asset_price_modifier": 116840268
+        },
+        "outputs": {
+            "fee_asset_price_at_execution": 10095916330,
+            "mana_base_fee_components_in_wei": {
+                "data_cost": 0,
+                "gas_cost": 48701920,
+                "proving_cost": 5415357955,
+                "congestion_cost": 12139967236,
+                "congestion_multiplier": 3221785177
+            },
+            "mana_base_fee_components_in_fee_asset": {
+                "data_cost": 0,
+                "gas_cost": 491690509,
+                "proving_cost": 54673000810,
+                "congestion_cost": 122564093463,
+                "congestion_multiplier": 3221785177
+            }
+        }
+    },
+    {
+        "l1_block_number": 20973197,
+        "l1_fees": {
+            "blob_fee": 106,
+            "base_fee": 14850593518
+        },
+        "parent_header": {
+            "excess_mana": 999944964,
+            "mana_used": 199996424,
+            "proving_cost_per_mana_numerator": 0,
+            "fee_asset_price_numerator": 1071432807
+        },
+        "header": {
+            "excess_mana": 1099941388,
+            "mana_used": 177366071,
+            "proving_cost_per_mana_numerator": 60087242,
+            "fee_asset_price_numerator": 758010157
+        },
+        "oracle_input": {
+            "proving_cost_modifier": 60087242,
+            "fee_asset_price_modifier": -313422650
+        },
+        "outputs": {
+            "fee_asset_price_at_execution": 10107719320,
+            "mana_base_fee_components_in_wei": {
+                "data_cost": 0,
+                "gas_cost": 49192591,
+                "proving_cost": 5415357955,
+                "congestion_cost": 14326172616,
+                "congestion_multiplier": 3621656163
+            },
+            "mana_base_fee_components_in_fee_asset": {
+                "data_cost": 0,
+                "gas_cost": 497224902,
+                "proving_cost": 54736918226,
+                "congestion_cost": 144804931732,
+                "congestion_multiplier": 3621656163
+            }
+        }
+    },
+    {
+        "l1_block_number": 20973200,
+        "l1_fees": {
+            "blob_fee": 87,
+            "base_fee": 15618137990
+        },
+        "parent_header": {
+            "excess_mana": 1099941388,
+            "mana_used": 177366071,
+            "proving_cost_per_mana_numerator": 60087242,
+            "fee_asset_price_numerator": 758010157
+        },
+        "header": {
+            "excess_mana": 1177307459,
+            "mana_used": 105632955,
+            "proving_cost_per_mana_numerator": 0,
+            "fee_asset_price_numerator": 1098791969
+        },
+        "oracle_input": {
+            "proving_cost_modifier": -134258021,
+            "fee_asset_price_modifier": 340781812
+        },
+        "outputs": {
+            "fee_asset_price_at_execution": 10076089032,
+            "mana_base_fee_components_in_wei": {
+                "data_cost": 0,
+                "gas_cost": 51735082,
+                "proving_cost": 5418612872,
+                "congestion_cost": 16218364323,
+                "congestion_multiplier": 3964777462
+            },
+            "mana_base_fee_components_in_fee_asset": {
+                "data_cost": 0,
+                "gas_cost": 521287292,
+                "proving_cost": 54598425728,
+                "congestion_cost": 163417682871,
+                "congestion_multiplier": 3964777462
+            }
+        }
+    },
+    {
+        "l1_block_number": 20973203,
+        "l1_fees": {
+            "blob_fee": 98,
+            "base_fee": 15809788248
+        },
+        "parent_header": {
+            "excess_mana": 1177307459,
+            "mana_used": 105632955,
+            "proving_cost_per_mana_numerator": 0,
+            "fee_asset_price_numerator": 1098791969
+        },
+        "header": {
+            "excess_mana": 1182940414,
+            "mana_used": 199957829,
+            "proving_cost_per_mana_numerator": 0,
+            "fee_asset_price_numerator": 1670588844
+        },
+        "oracle_input": {
+            "proving_cost_modifier": -46759887,
+            "fee_asset_price_modifier": 571796875
+        },
+        "outputs": {
+            "fee_asset_price_at_execution": 10110485085,
+            "mana_base_fee_components_in_wei": {
+                "data_cost": 0,
+                "gas_cost": 52369923,
+                "proving_cost": 5415357955,
+                "congestion_cost": 16353940462,
+                "congestion_multiplier": 3990993851
+            },
+            "mana_base_fee_components_in_fee_asset": {
+                "data_cost": 0,
+                "gas_cost": 529485325,
+                "proving_cost": 54751895833,
+                "congestion_cost": 165346271122,
+                "congestion_multiplier": 3990993851
+            }
+        }
+    },
+    {
+        "l1_block_number": 20973206,
+        "l1_fees": {
+            "blob_fee": 130,
+            "base_fee": 16615048160
+        },
+        "parent_header": {
+            "excess_mana": 1182940414,
+            "mana_used": 199957829,
+            "proving_cost_per_mana_numerator": 0,
+            "fee_asset_price_numerator": 1670588844
+        },
+        "header": {
+            "excess_mana": 1282898243,
+            "mana_used": 120218002,
+            "proving_cost_per_mana_numerator": 0,
+            "fee_asset_price_numerator": 1430564163
+        },
+        "oracle_input": {
+            "proving_cost_modifier": -30308858,
+            "fee_asset_price_modifier": -240024681
+        },
+        "outputs": {
+            "fee_asset_price_at_execution": 10168462121,
+            "mana_base_fee_components_in_wei": {
+                "data_cost": 0,
+                "gas_cost": 55037347,
+                "proving_cost": 5415357955,
+                "congestion_cost": 19070522199,
+                "congestion_multiplier": 4486132381
+            },
+            "mana_base_fee_components_in_fee_asset": {
+                "data_cost": 0,
+                "gas_cost": 559645178,
+                "proving_cost": 55065862237,
+                "congestion_cost": 193917882608,
+                "congestion_multiplier": 4486132381
+            }
+        }
+    },
+    {
+        "l1_block_number": 20973209,
+        "l1_fees": {
+            "blob_fee": 164,
+            "base_fee": 17184203834
+        },
+        "parent_header": {
+            "excess_mana": 1282898243,
+            "mana_used": 120218002,
+            "proving_cost_per_mana_numerator": 0,
+            "fee_asset_price_numerator": 1430564163
+        },
+        "header": {
+            "excess_mana": 1303116245,
+            "mana_used": 108663083,
+            "proving_cost_per_mana_numerator": 42974511,
+            "fee_asset_price_numerator": 1398913434
+        },
+        "oracle_input": {
+            "proving_cost_modifier": 42974511,
+            "fee_asset_price_modifier": -31650729
+        },
+        "outputs": {
+            "fee_asset_price_at_execution": 10144084570,
+            "mana_base_fee_components_in_wei": {
+                "data_cost": 0,
+                "gas_cost": 56922675,
+                "proving_cost": 5415357955,
+                "congestion_cost": 19664734632,
+                "congestion_multiplier": 4593517212
+            },
+            "mana_base_fee_components_in_fee_asset": {
+                "data_cost": 0,
+                "gas_cost": 577428429,
+                "proving_cost": 54933849072,
+                "congestion_cost": 199480731153,
+                "congestion_multiplier": 4593517212
+            }
+        }
+    },
+    {
+        "l1_block_number": 20973212,
+        "l1_fees": {
+            "blob_fee": 164,
+            "base_fee": 19878985864
+        },
+        "parent_header": {
+            "excess_mana": 1303116245,
+            "mana_used": 108663083,
+            "proving_cost_per_mana_numerator": 42974511,
+            "fee_asset_price_numerator": 1398913434
+        },
+        "header": {
+            "excess_mana": 1311779328,
+            "mana_used": 98368116,
+            "proving_cost_per_mana_numerator": 65600657,
+            "fee_asset_price_numerator": 1496985754
+        },
+        "oracle_input": {
+            "proving_cost_modifier": 22626146,
+            "fee_asset_price_modifier": 98072320
+        },
+        "outputs": {
+            "fee_asset_price_at_execution": 10140874401,
+            "mana_base_fee_components_in_wei": {
+                "data_cost": 0,
+                "gas_cost": 65849140,
+                "proving_cost": 5417685678,
+                "congestion_cost": 19961782930,
+                "congestion_multiplier": 4640312972
+            },
+            "mana_base_fee_components_in_fee_asset": {
+                "data_cost": 0,
+                "gas_cost": 667767858,
+                "proving_cost": 54940070004,
+                "congestion_cost": 202429933513,
+                "congestion_multiplier": 4640312972
+            }
+        }
+    },
+    {
+        "l1_block_number": 20973215,
+        "l1_fees": {
+            "blob_fee": 200,
+            "base_fee": 18840462804
+        },
+        "parent_header": {
+            "excess_mana": 1311779328,
+            "mana_used": 98368116,
+            "proving_cost_per_mana_numerator": 65600657,
+            "fee_asset_price_numerator": 1496985754
+        },
+        "header": {
+            "excess_mana": 1310147444,
+            "mana_used": 105469376,
+            "proving_cost_per_mana_numerator": 0,
+            "fee_asset_price_numerator": 954626605
+        },
+        "oracle_input": {
+            "proving_cost_modifier": -66070337,
+            "fee_asset_price_modifier": -542359149
+        },
+        "outputs": {
+            "fee_asset_price_at_execution": 10150824670,
+            "mana_base_fee_components_in_wei": {
+                "data_cost": 0,
+                "gas_cost": 62409033,
+                "proving_cost": 5418911630,
+                "congestion_cost": 19905205811,
+                "congestion_multiplier": 4631461656
+            },
+            "mana_base_fee_components_in_fee_asset": {
+                "data_cost": 0,
+                "gas_cost": 633503151,
+                "proving_cost": 55006421858,
+                "congestion_cost": 202054254207,
+                "congestion_multiplier": 4631461656
+            }
+        }
+    },
+    {
+        "l1_block_number": 20973218,
+        "l1_fees": {
+            "blob_fee": 216,
+            "base_fee": 17587430794
+        },
+        "parent_header": {
+            "excess_mana": 1310147444,
+            "mana_used": 105469376,
+            "proving_cost_per_mana_numerator": 0,
+            "fee_asset_price_numerator": 954626605
+        },
+        "header": {
+            "excess_mana": 1315616820,
+            "mana_used": 105844331,
+            "proving_cost_per_mana_numerator": 141121635,
+            "fee_asset_price_numerator": 1612884691
+        },
+        "oracle_input": {
+            "proving_cost_modifier": 141121635,
+            "fee_asset_price_modifier": 658258086
+        },
+        "outputs": {
+            "fee_asset_price_at_execution": 10095919769,
+            "mana_base_fee_components_in_wei": {
+                "data_cost": 0,
+                "gas_cost": 58258364,
+                "proving_cost": 5415357955,
+                "congestion_cost": 20039972298,
+                "congestion_multiplier": 4661194196
+            },
+            "mana_base_fee_components_in_fee_asset": {
+                "data_cost": 0,
+                "gas_cost": 588171768,
+                "proving_cost": 54673019434,
+                "congestion_cost": 202321952493,
+                "congestion_multiplier": 4661194196
+            }
+        }
+    },
+    {
+        "l1_block_number": 20973221,
+        "l1_fees": {
+            "blob_fee": 192,
+            "base_fee": 18240173510
+        },
+        "parent_header": {
+            "excess_mana": 1315616820,
+            "mana_used": 105844331,
+            "proving_cost_per_mana_numerator": 141121635,
+            "fee_asset_price_numerator": 1612884691
+        },
+        "header": {
+            "excess_mana": 1321461151,
+            "mana_used": 98446274,
+            "proving_cost_per_mana_numerator": 96693946,
+            "fee_asset_price_numerator": 1167331383
+        },
+        "oracle_input": {
+            "proving_cost_modifier": -44427689,
+            "fee_asset_price_modifier": -445553308
+        },
+        "outputs": {
+            "fee_asset_price_at_execution": 10162596188,
+            "mana_base_fee_components_in_wei": {
+                "data_cost": 0,
+                "gas_cost": 60420574,
+                "proving_cost": 5423005591,
+                "congestion_cost": 20251258146,
+                "congestion_multiplier": 4693176043
+            },
+            "mana_base_fee_components_in_fee_asset": {
+                "data_cost": 0,
+                "gas_cost": 614029895,
+                "proving_cost": 55111815946,
+                "congestion_cost": 205805358836,
+                "congestion_multiplier": 4693176043
+            }
+        }
+    },
+    {
+        "l1_block_number": 20973224,
+        "l1_fees": {
+            "blob_fee": 171,
+            "base_fee": 21493716770
+        },
+        "parent_header": {
+            "excess_mana": 1321461151,
+            "mana_used": 98446274,
+            "proving_cost_per_mana_numerator": 96693946,
+            "fee_asset_price_numerator": 1167331383
+        },
+        "header": {
+            "excess_mana": 1319907425,
+            "mana_used": 84600050,
+            "proving_cost_per_mana_numerator": 224636242,
+            "fee_asset_price_numerator": 1265476079
+        },
+        "oracle_input": {
+            "proving_cost_modifier": 127942296,
+            "fee_asset_price_modifier": 98144696
+        },
+        "outputs": {
+            "fee_asset_price_at_execution": 10117417128,
+            "mana_base_fee_components_in_wei": {
+                "data_cost": 0,
+                "gas_cost": 71197936,
+                "proving_cost": 5420596810,
+                "congestion_cost": 20235353911,
+                "congestion_multiplier": 4684652258
+            },
+            "mana_base_fee_components_in_fee_asset": {
+                "data_cost": 0,
+                "gas_cost": 720339217,
+                "proving_cost": 54842439009,
+                "congestion_cost": 204729516250,
+                "congestion_multiplier": 4684652258
+            }
+        }
+    },
+    {
+        "l1_block_number": 20973227,
+        "l1_fees": {
+            "blob_fee": 152,
+            "base_fee": 21129802751
+        },
+        "parent_header": {
+            "excess_mana": 1319907425,
+            "mana_used": 84600050,
+            "proving_cost_per_mana_numerator": 224636242,
+            "fee_asset_price_numerator": 1265476079
+        },
+        "header": {
+            "excess_mana": 1304507475,
+            "mana_used": 110635621,
+            "proving_cost_per_mana_numerator": 289339939,
+            "fee_asset_price_numerator": 1664231361
+        },
+        "oracle_input": {
+            "proving_cost_modifier": 64703697,
+            "fee_asset_price_modifier": 398755282
+        },
+        "outputs": {
+            "fee_asset_price_at_execution": 10127351711,
+            "mana_base_fee_components_in_wei": {
+                "data_cost": 0,
+                "gas_cost": 69992471,
+                "proving_cost": 5427536485,
+                "congestion_cost": 19796603683,
+                "congestion_multiplier": 4601000348
+            },
+            "mana_base_fee_components_in_fee_asset": {
+                "data_cost": 0,
+                "gas_cost": 708838370,
+                "proving_cost": 54966570907,
+                "congestion_cost": 200487168181,
+                "congestion_multiplier": 4601000348
+            }
+        }
+    },
+    {
+        "l1_block_number": 20973230,
+        "l1_fees": {
+            "blob_fee": 216,
+            "base_fee": 19428171353
+        },
+        "parent_header": {
+            "excess_mana": 1304507475,
+            "mana_used": 110635621,
+            "proving_cost_per_mana_numerator": 289339939,
+            "fee_asset_price_numerator": 1664231361
+        },
+        "header": {
+            "excess_mana": 1315143096,
+            "mana_used": 107193381,
+            "proving_cost_per_mana_numerator": 203772621,
+            "fee_asset_price_numerator": 2266740945
+        },
+        "oracle_input": {
+            "proving_cost_modifier": -85567318,
+            "fee_asset_price_modifier": 602509584
+        },
+        "outputs": {
+            "fee_asset_price_at_execution": 10167815683,
+            "mana_base_fee_components_in_wei": {
+                "data_cost": 0,
+                "gas_cost": 64355817,
+                "proving_cost": 5431049438,
+                "congestion_cost": 20105552379,
+                "congestion_multiplier": 4658611412
+            },
+            "mana_base_fee_components_in_fee_asset": {
+                "data_cost": 0,
+                "gas_cost": 654358085,
+                "proving_cost": 55221909650,
+                "congestion_cost": 204429550794,
+                "congestion_multiplier": 4658611412
+            }
+        }
+    },
+    {
+        "l1_block_number": 20973233,
+        "l1_fees": {
+            "blob_fee": 243,
+            "base_fee": 20070480259
+        },
+        "parent_header": {
+            "excess_mana": 1315143096,
+            "mana_used": 107193381,
+            "proving_cost_per_mana_numerator": 203772621,
+            "fee_asset_price_numerator": 2266740945
+        },
+        "header": {
+            "excess_mana": 1322336477,
+            "mana_used": 101466733,
+            "proving_cost_per_mana_numerator": 34521604,
+            "fee_asset_price_numerator": 2167173930
+        },
+        "oracle_input": {
+            "proving_cost_modifier": -169251017,
+            "fee_asset_price_modifier": -99567015
+        },
+        "outputs": {
+            "fee_asset_price_at_execution": 10229262673,
+            "mana_base_fee_components_in_wei": {
+                "data_cost": 0,
+                "gas_cost": 66483465,
+                "proving_cost": 5426404222,
+                "congestion_cost": 20312615910,
+                "congestion_multiplier": 4697984934
+            },
+            "mana_base_fee_components_in_fee_asset": {
+                "data_cost": 0,
+                "gas_cost": 680076826,
+                "proving_cost": 55508114156,
+                "congestion_cost": 207783083719,
+                "congestion_multiplier": 4697984934
+            }
+        }
+    },
+    {
+        "l1_block_number": 20973236,
+        "l1_fees": {
+            "blob_fee": 333,
+            "base_fee": 18248910855
+        },
+        "parent_header": {
+            "excess_mana": 1322336477,
+            "mana_used": 101466733,
+            "proving_cost_per_mana_numerator": 34521604,
+            "fee_asset_price_numerator": 2167173930
+        },
+        "header": {
+            "excess_mana": 1323803210,
+            "mana_used": 91541959,
+            "proving_cost_per_mana_numerator": 76429561,
+            "fee_asset_price_numerator": 1301363172
+        },
+        "oracle_input": {
+            "proving_cost_modifier": 41907957,
+            "fee_asset_price_modifier": -865810758
+        },
+        "outputs": {
+            "fee_asset_price_at_execution": 10219082770,
+            "mana_base_fee_components_in_wei": {
+                "data_cost": 1,
+                "gas_cost": 60449517,
+                "proving_cost": 5417227746,
+                "congestion_cost": 20300567526,
+                "congestion_multiplier": 4706053962
+            },
+            "mana_base_fee_components_in_fee_asset": {
+                "data_cost": 10,
+                "gas_cost": 617738617,
+                "proving_cost": 55359098720,
+                "congestion_cost": 207453179826,
+                "congestion_multiplier": 4706053962
+            }
+        }
+    },
+    {
+        "l1_block_number": 20973239,
+        "l1_fees": {
+            "blob_fee": 347,
+            "base_fee": 20770060420
+        },
+        "parent_header": {
+            "excess_mana": 1323803210,
+            "mana_used": 91541959,
+            "proving_cost_per_mana_numerator": 76429561,
+            "fee_asset_price_numerator": 1301363172
+        },
+        "header": {
+            "excess_mana": 1315345169,
+            "mana_used": 122131829,
+            "proving_cost_per_mana_numerator": 262665832,
+            "fee_asset_price_numerator": 335413966
+        },
+        "oracle_input": {
+            "proving_cost_modifier": 186236271,
+            "fee_asset_price_modifier": -965949206
+        },
+        "outputs": {
+            "fee_asset_price_at_execution": 10130986775,
+            "mana_base_fee_components_in_wei": {
+                "data_cost": 1,
+                "gas_cost": 68800825,
+                "proving_cost": 5419498471,
+                "congestion_cost": 20085600043,
+                "congestion_multiplier": 4659712956
+            },
+            "mana_base_fee_components_in_fee_asset": {
+                "data_cost": 10,
+                "gas_cost": 697020248,
+                "proving_cost": 54904867336,
+                "congestion_cost": 203486948403,
+                "congestion_multiplier": 4659712956
+            }
+        }
+    },
+    {
+        "l1_block_number": 20973242,
+        "l1_fees": {
+            "blob_fee": 263,
+            "base_fee": 20083364753
+        },
+        "parent_header": {
+            "excess_mana": 1315345169,
+            "mana_used": 122131829,
+            "proving_cost_per_mana_numerator": 262665832,
+            "fee_asset_price_numerator": 335413966
+        },
+        "header": {
+            "excess_mana": 1337476998,
+            "mana_used": 94686801,
+            "proving_cost_per_mana_numerator": 285649568,
+            "fee_asset_price_numerator": 522653958
+        },
+        "oracle_input": {
+            "proving_cost_modifier": 22983736,
+            "fee_asset_price_modifier": 187239992
+        },
+        "outputs": {
+            "fee_asset_price_at_execution": 10033597710,
+            "mana_base_fee_components_in_wei": {
+                "data_cost": 1,
+                "gas_cost": 66526145,
+                "proving_cost": 5429600947,
+                "congestion_cost": 20786069334,
+                "congestion_multiplier": 4781948449
+            },
+            "mana_base_fee_components_in_fee_asset": {
+                "data_cost": 10,
+                "gas_cost": 667496576,
+                "proving_cost": 54478431628,
+                "congestion_cost": 208559057669,
+                "congestion_multiplier": 4781948449
+            }
+        }
+    },
+    {
+        "l1_block_number": 20973245,
+        "l1_fees": {
+            "blob_fee": 333,
+            "base_fee": 18976916853
+        },
+        "parent_header": {
+            "excess_mana": 1337476998,
+            "mana_used": 94686801,
+            "proving_cost_per_mana_numerator": 285649568,
+            "fee_asset_price_numerator": 522653958
+        },
+        "header": {
+            "excess_mana": 1332163799,
+            "mana_used": 98391768,
+            "proving_cost_per_mana_numerator": 327049540,
+            "fee_asset_price_numerator": 466383850
+        },
+        "oracle_input": {
+            "proving_cost_modifier": 41399972,
+            "fee_asset_price_modifier": -56270108
+        },
+        "outputs": {
+            "fee_asset_price_at_execution": 10052402217,
+            "mana_base_fee_components_in_wei": {
+                "data_cost": 1,
+                "gas_cost": 62861037,
+                "proving_cost": 5430849016,
+                "congestion_cost": 20614124850,
+                "congestion_multiplier": 4752313946
+            },
+            "mana_base_fee_components_in_fee_asset": {
+                "data_cost": 10,
+                "gas_cost": 631904427,
+                "proving_cost": 54593078688,
+                "congestion_cost": 207221474343,
+                "congestion_multiplier": 4752313946
+            }
+        }
+    },
+    {
+        "l1_block_number": 20973248,
+        "l1_fees": {
+            "blob_fee": 347,
+            "base_fee": 18939331593
+        },
+        "parent_header": {
+            "excess_mana": 1332163799,
+            "mana_used": 98391768,
+            "proving_cost_per_mana_numerator": 327049540,
+            "fee_asset_price_numerator": 466383850
+        },
+        "header": {
+            "excess_mana": 1330555567,
+            "mana_used": 97285971,
+            "proving_cost_per_mana_numerator": 349440774,
+            "fee_asset_price_numerator": 1263490118
+        },
+        "oracle_input": {
+            "proving_cost_modifier": 22391234,
+            "fee_asset_price_modifier": 797106268
+        },
+        "outputs": {
+            "fee_asset_price_at_execution": 10046747311,
+            "mana_base_fee_components_in_wei": {
+                "data_cost": 1,
+                "gas_cost": 62736535,
+                "proving_cost": 5433097851,
+                "congestion_cost": 20572997901,
+                "congestion_multiplier": 4743380250
+            },
+            "mana_base_fee_components_in_fee_asset": {
+                "data_cost": 10,
+                "gas_cost": 630298114,
+                "proving_cost": 54584961224,
+                "congestion_cost": 206691711341,
+                "congestion_multiplier": 4743380250
+            }
+        }
+    },
+    {
+        "l1_block_number": 20973251,
+        "l1_fees": {
+            "blob_fee": 361,
+            "base_fee": 18547987166
+        },
+        "parent_header": {
+            "excess_mana": 1330555567,
+            "mana_used": 97285971,
+            "proving_cost_per_mana_numerator": 349440774,
+            "fee_asset_price_numerator": 1263490118
+        },
+        "header": {
+            "excess_mana": 1327841538,
+            "mana_used": 94195956,
+            "proving_cost_per_mana_numerator": 521756115,
+            "fee_asset_price_numerator": 634906412
+        },
+        "oracle_input": {
+            "proving_cost_modifier": 172315341,
+            "fee_asset_price_modifier": -628583706
+        },
+        "outputs": {
+            "fee_asset_price_at_execution": 10127150587,
+            "mana_base_fee_components_in_wei": {
+                "data_cost": 1,
+                "gas_cost": 61440207,
+                "proving_cost": 5434314525,
+                "congestion_cost": 20490052884,
+                "congestion_multiplier": 4728341944
+            },
+            "mana_base_fee_components_in_fee_asset": {
+                "data_cost": 10,
+                "gas_cost": 622214228,
+                "proving_cost": 55034121531,
+                "congestion_cost": 207505851091,
+                "congestion_multiplier": 4728341944
+            }
+        }
+    },
+    {
+        "l1_block_number": 20973254,
+        "l1_fees": {
+            "blob_fee": 406,
+            "base_fee": 19027558519
+        },
+        "parent_header": {
+            "excess_mana": 1327841538,
+            "mana_used": 94195956,
+            "proving_cost_per_mana_numerator": 521756115,
+            "fee_asset_price_numerator": 634906412
+        },
+        "header": {
+            "excess_mana": 1322037494,
+            "mana_used": 104831684,
+            "proving_cost_per_mana_numerator": 328317385,
+            "fee_asset_price_numerator": 1493437131
+        },
+        "oracle_input": {
+            "proving_cost_modifier": -193438730,
+            "fee_asset_price_modifier": 858530719
+        },
+        "outputs": {
+            "fee_asset_price_at_execution": 10063692621,
+            "mana_base_fee_components_in_wei": {
+                "data_cost": 1,
+                "gas_cost": 63028787,
+                "proving_cost": 5443686755,
+                "congestion_cost": 20354702941,
+                "congestion_multiplier": 4696341818
+            },
+            "mana_base_fee_components_in_fee_asset": {
+                "data_cost": 10,
+                "gas_cost": 634302338,
+                "proving_cost": 54783590227,
+                "congestion_cost": 204843473789,
+                "congestion_multiplier": 4696341818
+            }
+        }
+    },
+    {
+        "l1_block_number": 20973257,
+        "l1_fees": {
+            "blob_fee": 285,
+            "base_fee": 19960437790
+        },
+        "parent_header": {
+            "excess_mana": 1322037494,
+            "mana_used": 104831684,
+            "proving_cost_per_mana_numerator": 328317385,
+            "fee_asset_price_numerator": 1493437131
+        },
+        "header": {
+            "excess_mana": 1326869178,
+            "mana_used": 95091170,
+            "proving_cost_per_mana_numerator": 0,
+            "fee_asset_price_numerator": 683470723
+        },
+        "oracle_input": {
+            "proving_cost_modifier": -408184922,
+            "fee_asset_price_modifier": -809966408
+        },
+        "outputs": {
+            "fee_asset_price_at_execution": 10150464462,
+            "mana_base_fee_components_in_wei": {
+                "data_cost": 1,
+                "gas_cost": 66118950,
+                "proving_cost": 5433166735,
+                "congestion_cost": 20473652263,
+                "congestion_multiplier": 4722965751
+            },
+            "mana_base_fee_components_in_fee_asset": {
+                "data_cost": 10,
+                "gas_cost": 671138052,
+                "proving_cost": 55149165859,
+                "congestion_cost": 207817079702,
+                "congestion_multiplier": 4722965751
+            }
+        }
+    },
+    {
+        "l1_block_number": 20973260,
+        "l1_fees": {
+            "blob_fee": 320,
+            "base_fee": 20847107469
+        },
+        "parent_header": {
+            "excess_mana": 1326869178,
+            "mana_used": 95091170,
+            "proving_cost_per_mana_numerator": 0,
+            "fee_asset_price_numerator": 683470723
+        },
+        "header": {
+            "excess_mana": 1321960348,
+            "mana_used": 98931930,
+            "proving_cost_per_mana_numerator": 0,
+            "fee_asset_price_numerator": 263974984
+        },
+        "oracle_input": {
+            "proving_cost_modifier": -89389051,
+            "fee_asset_price_modifier": -419495739
+        },
+        "outputs": {
+            "fee_asset_price_at_execution": 10068581171,
+            "mana_base_fee_components_in_wei": {
+                "data_cost": 1,
+                "gas_cost": 69056043,
+                "proving_cost": 5415357955,
+                "congestion_cost": 20269944100,
+                "congestion_multiplier": 4695917942
+            },
+            "mana_base_fee_components_in_fee_asset": {
+                "data_cost": 10,
+                "gas_cost": 695296374,
+                "proving_cost": 54524971139,
+                "congestion_cost": 204089577502,
+                "congestion_multiplier": 4695917942
+            }
+        }
+    },
+    {
+        "l1_block_number": 20973263,
+        "l1_fees": {
+            "blob_fee": 375,
+            "base_fee": 18902464529
+        },
+        "parent_header": {
+            "excess_mana": 1321960348,
+            "mana_used": 98931930,
+            "proving_cost_per_mana_numerator": 0,
+            "fee_asset_price_numerator": 263974984
+        },
+        "header": {
+            "excess_mana": 1320892278,
+            "mana_used": 95278001,
+            "proving_cost_per_mana_numerator": 100690211,
+            "fee_asset_price_numerator": 311174512
+        },
+        "oracle_input": {
+            "proving_cost_modifier": 100690211,
+            "fee_asset_price_modifier": 47199528
+        },
+        "outputs": {
+            "fee_asset_price_at_execution": 10026432370,
+            "mana_base_fee_components_in_wei": {
+                "data_cost": 1,
+                "gas_cost": 62614413,
+                "proving_cost": 5415357955,
+                "congestion_cost": 20214010516,
+                "congestion_multiplier": 4690053391
+            },
+            "mana_base_fee_components_in_fee_asset": {
+                "data_cost": 10,
+                "gas_cost": 627799177,
+                "proving_cost": 54296720295,
+                "congestion_cost": 202674409365,
+                "congestion_multiplier": 4690053391
+            }
+        }
+    },
+    {
+        "l1_block_number": 20973266,
+        "l1_fees": {
+            "blob_fee": 308,
+            "base_fee": 18299097163
+        },
+        "parent_header": {
+            "excess_mana": 1320892278,
+            "mana_used": 95278001,
+            "proving_cost_per_mana_numerator": 100690211,
+            "fee_asset_price_numerator": 311174512
+        },
+        "header": {
+            "excess_mana": 1316170279,
+            "mana_used": 101936608,
+            "proving_cost_per_mana_numerator": 0,
+            "fee_asset_price_numerator": 630116718
+        },
+        "oracle_input": {
+            "proving_cost_modifier": -154605323,
+            "fee_asset_price_modifier": 318942206
+        },
+        "outputs": {
+            "fee_asset_price_at_execution": 10031165916,
+            "mana_base_fee_components_in_wei": {
+                "data_cost": 1,
+                "gas_cost": 60615759,
+                "proving_cost": 5420813436,
+                "congestion_cost": 20085126946,
+                "congestion_multiplier": 4664213516
+            },
+            "mana_base_fee_components_in_fee_asset": {
+                "data_cost": 10,
+                "gas_cost": 608046735,
+                "proving_cost": 54377078976,
+                "congestion_cost": 201477240839,
+                "congestion_multiplier": 4664213516
+            }
+        }
+    },
+    {
+        "l1_block_number": 20973269,
+        "l1_fees": {
+            "blob_fee": 375,
+            "base_fee": 18189059913
+        },
+        "parent_header": {
+            "excess_mana": 1316170279,
+            "mana_used": 101936608,
+            "proving_cost_per_mana_numerator": 0,
+            "fee_asset_price_numerator": 630116718
+        },
+        "header": {
+            "excess_mana": 1318106887,
+            "mana_used": 99042382,
+            "proving_cost_per_mana_numerator": 3337252,
+            "fee_asset_price_numerator": 195106265
+        },
+        "oracle_input": {
+            "proving_cost_modifier": 3337252,
+            "fee_asset_price_modifier": -435010453
+        },
+        "outputs": {
+            "fee_asset_price_at_execution": 10063210612,
+            "mana_base_fee_components_in_wei": {
+                "data_cost": 1,
+                "gas_cost": 60251260,
+                "proving_cost": 5415357955,
+                "congestion_cost": 20121734902,
+                "congestion_multiplier": 4674793819
+            },
+            "mana_base_fee_components_in_fee_asset": {
+                "data_cost": 10,
+                "gas_cost": 606321119,
+                "proving_cost": 54495887640,
+                "congestion_cost": 202489256197,
+                "congestion_multiplier": 4674793819
+            }
+        }
+    },
+    {
+        "l1_block_number": 20973272,
+        "l1_fees": {
+            "blob_fee": 361,
+            "base_fee": 17956791785
+        },
+        "parent_header": {
+            "excess_mana": 1318106887,
+            "mana_used": 99042382,
+            "proving_cost_per_mana_numerator": 3337252,
+            "fee_asset_price_numerator": 195106265
+        },
+        "header": {
+            "excess_mana": 1317149269,
+            "mana_used": 114460674,
+            "proving_cost_per_mana_numerator": 0,
+            "fee_asset_price_numerator": 0
+        },
+        "oracle_input": {
+            "proving_cost_modifier": -158447076,
+            "fee_asset_price_modifier": -941718501
+        },
+        "outputs": {
+            "fee_asset_price_at_execution": 10019529672,
+            "mana_base_fee_components_in_wei": {
+                "data_cost": 1,
+                "gas_cost": 59481872,
+                "proving_cost": 5415538682,
+                "congestion_cost": 20090911237,
+                "congestion_multiplier": 4669559052
+            },
+            "mana_base_fee_components_in_fee_asset": {
+                "data_cost": 10,
+                "gas_cost": 595980381,
+                "proving_cost": 54261150514,
+                "congestion_cost": 201301481276,
+                "congestion_multiplier": 4669559052
+            }
+        }
+    },
+    {
+        "l1_block_number": 20973275,
+        "l1_fees": {
+            "blob_fee": 422,
+            "base_fee": 18168683930
+        },
+        "parent_header": {
+            "excess_mana": 1317149269,
+            "mana_used": 114460674,
+            "proving_cost_per_mana_numerator": 0,
+            "fee_asset_price_numerator": 0
+        },
+        "header": {
+            "excess_mana": 1331609943,
+            "mana_used": 101559769,
+            "proving_cost_per_mana_numerator": 21048022,
+            "fee_asset_price_numerator": 0
+        },
+        "oracle_input": {
+            "proving_cost_modifier": 21048022,
+            "fee_asset_price_modifier": -5887937
+        },
+        "outputs": {
+            "fee_asset_price_at_execution": 10000000000,
+            "mana_base_fee_components_in_wei": {
+                "data_cost": 1,
+                "gas_cost": 60183765,
+                "proving_cost": 5415357955,
+                "congestion_cost": 20529094799,
+                "congestion_multiplier": 4749235390
+            },
+            "mana_base_fee_components_in_fee_asset": {
+                "data_cost": 10,
+                "gas_cost": 601837650,
+                "proving_cost": 54153579550,
+                "congestion_cost": 205290947990,
+                "congestion_multiplier": 4749235390
+            }
+        }
+    },
+    {
+        "l1_block_number": 20973278,
+        "l1_fees": {
+            "blob_fee": 422,
+            "base_fee": 17010109252
+        },
+        "parent_header": {
+            "excess_mana": 1331609943,
+            "mana_used": 101559769,
+            "proving_cost_per_mana_numerator": 21048022,
+            "fee_asset_price_numerator": 0
+        },
+        "header": {
+            "excess_mana": 1333169712,
+            "mana_used": 102249578,
+            "proving_cost_per_mana_numerator": 0,
+            "fee_asset_price_numerator": 515233807
+        },
+        "oracle_input": {
+            "proving_cost_modifier": -92908145,
+            "fee_asset_price_modifier": 515233807
+        },
+        "outputs": {
+            "fee_asset_price_at_execution": 10000000000,
+            "mana_base_fee_components_in_wei": {
+                "data_cost": 1,
+                "gas_cost": 56345986,
+                "proving_cost": 5416497900,
+                "congestion_cost": 20566456544,
+                "congestion_multiplier": 4757910324
+            },
+            "mana_base_fee_components_in_fee_asset": {
+                "data_cost": 10,
+                "gas_cost": 563459860,
+                "proving_cost": 54164979000,
+                "congestion_cost": 205664565440,
+                "congestion_multiplier": 4757910324
+            }
+        }
+    },
+    {
+        "l1_block_number": 20973281,
+        "l1_fees": {
+            "blob_fee": 361,
+            "base_fee": 17657903515
+        },
+        "parent_header": {
+            "excess_mana": 1333169712,
+            "mana_used": 102249578,
+            "proving_cost_per_mana_numerator": 0,
+            "fee_asset_price_numerator": 515233807
+        },
+        "header": {
+            "excess_mana": 1335419290,
+            "mana_used": 92477431,
+            "proving_cost_per_mana_numerator": 0,
+            "fee_asset_price_numerator": 0
+        },
+        "oracle_input": {
+            "proving_cost_modifier": -31551963,
+            "fee_asset_price_modifier": -549794876
+        },
+        "outputs": {
+            "fee_asset_price_at_execution": 10051656341,
+            "mana_base_fee_components_in_wei": {
+                "data_cost": 1,
+                "gas_cost": 58491805,
+                "proving_cost": 5415357955,
+                "congestion_cost": 20638875014,
+                "congestion_multiplier": 4770449668
+            },
+            "mana_base_fee_components_in_fee_asset": {
+                "data_cost": 10,
+                "gas_cost": 587939522,
+                "proving_cost": 54433317127,
+                "congestion_cost": 207454878905,
+                "congestion_multiplier": 4770449668
+            }
+        }
+    },
+    {
+        "l1_block_number": 20973284,
+        "l1_fees": {
+            "blob_fee": 422,
+            "base_fee": 18297705033
+        },
+        "parent_header": {
+            "excess_mana": 1335419290,
+            "mana_used": 92477431,
+            "proving_cost_per_mana_numerator": 0,
+            "fee_asset_price_numerator": 0
+        },
+        "header": {
+            "excess_mana": 1327896721,
+            "mana_used": 96681271,
+            "proving_cost_per_mana_numerator": 79671009,
+            "fee_asset_price_numerator": 592774955
+        },
+        "oracle_input": {
+            "proving_cost_modifier": 79671009,
+            "fee_asset_price_modifier": 592774955
+        },
+        "outputs": {
+            "fee_asset_price_at_execution": 10000000000,
+            "mana_base_fee_components_in_wei": {
+                "data_cost": 1,
+                "gas_cost": 60611147,
+                "proving_cost": 5415357955,
+                "congestion_cost": 20417957054,
+                "congestion_multiplier": 4728647235
+            },
+            "mana_base_fee_components_in_fee_asset": {
+                "data_cost": 10,
+                "gas_cost": 606111470,
+                "proving_cost": 54153579550,
+                "congestion_cost": 204179570540,
+                "congestion_multiplier": 4728647235
+            }
+        }
+    },
+    {
+        "l1_block_number": 20973287,
+        "l1_fees": {
+            "blob_fee": 361,
+            "base_fee": 19092004533
+        },
+        "parent_header": {
+            "excess_mana": 1327896721,
+            "mana_used": 96681271,
+            "proving_cost_per_mana_numerator": 79671009,
+            "fee_asset_price_numerator": 592774955
+        },
+        "header": {
+            "excess_mana": 1324577992,
+            "mana_used": 89190304,
+            "proving_cost_per_mana_numerator": 288691509,
+            "fee_asset_price_numerator": 1507728668
+        },
+        "oracle_input": {
+            "proving_cost_modifier": 209020500,
+            "fee_asset_price_modifier": 914953713
+        },
+        "outputs": {
+            "fee_asset_price_at_execution": 10059453534,
+            "mana_base_fee_components_in_wei": {
+                "data_cost": 1,
+                "gas_cost": 63242265,
+                "proving_cost": 5419674144,
+                "congestion_cost": 20343384886,
+                "congestion_multiplier": 4710321910
+            },
+            "mana_base_fee_components_in_fee_asset": {
+                "data_cost": 10,
+                "gas_cost": 636182626,
+                "proving_cost": 54518960220,
+                "congestion_cost": 204643334984,
+                "congestion_multiplier": 4710321910
+            }
+        }
+    },
+    {
+        "l1_block_number": 20973290,
+        "l1_fees": {
+            "blob_fee": 390,
+            "base_fee": 18698500008
+        },
+        "parent_header": {
+            "excess_mana": 1324577992,
+            "mana_used": 89190304,
+            "proving_cost_per_mana_numerator": 288691509,
+            "fee_asset_price_numerator": 1507728668
+        },
+        "header": {
+            "excess_mana": 1313768296,
+            "mana_used": 105278121,
+            "proving_cost_per_mana_numerator": 133541491,
+            "fee_asset_price_numerator": 1803567814
+        },
+        "oracle_input": {
+            "proving_cost_modifier": -155150018,
+            "fee_asset_price_modifier": 295839146
+        },
+        "outputs": {
+            "fee_asset_price_at_execution": 10151915223,
+            "mana_base_fee_components_in_wei": {
+                "data_cost": 1,
+                "gas_cost": 61938781,
+                "proving_cost": 5431014221,
+                "congestion_cost": 20055452452,
+                "congestion_multiplier": 4651123984
+            },
+            "mana_base_fee_components_in_fee_asset": {
+                "data_cost": 10,
+                "gas_cost": 628797253,
+                "proving_cost": 55135195946,
+                "congestion_cost": 203601253051,
+                "congestion_multiplier": 4651123984
+            }
+        }
+    },
+    {
+        "l1_block_number": 20973293,
+        "l1_fees": {
+            "blob_fee": 285,
+            "base_fee": 18642710735
+        },
+        "parent_header": {
+            "excess_mana": 1313768296,
+            "mana_used": 105278121,
+            "proving_cost_per_mana_numerator": 133541491,
+            "fee_asset_price_numerator": 1803567814
+        },
+        "header": {
+            "excess_mana": 1319046417,
+            "mana_used": 86926182,
+            "proving_cost_per_mana_numerator": 75741087,
+            "fee_asset_price_numerator": 2094753268
+        },
+        "oracle_input": {
+            "proving_cost_modifier": -57800404,
+            "fee_asset_price_modifier": 291185454
+        },
+        "outputs": {
+            "fee_asset_price_at_execution": 10181993031,
+            "mana_base_fee_components_in_wei": {
+                "data_cost": 1,
+                "gas_cost": 61753979,
+                "proving_cost": 5422594535,
+                "congestion_cost": 20182048312,
+                "congestion_multiplier": 4679935412
+            },
+            "mana_base_fee_components_in_fee_asset": {
+                "data_cost": 10,
+                "gas_cost": 628778583,
+                "proving_cost": 55212819765,
+                "congestion_cost": 205493475264,
+                "congestion_multiplier": 4679935412
+            }
+        }
+    },
+    {
+        "l1_block_number": 20973296,
+        "l1_fees": {
+            "blob_fee": 406,
+            "base_fee": 17157660059
+        },
+        "parent_header": {
+            "excess_mana": 1319046417,
+            "mana_used": 86926182,
+            "proving_cost_per_mana_numerator": 75741087,
+            "fee_asset_price_numerator": 2094753268
+        },
+        "header": {
+            "excess_mana": 1305972599,
+            "mana_used": 121671900,
+            "proving_cost_per_mana_numerator": 194735085,
+            "fee_asset_price_numerator": 1536756867
+        },
+        "oracle_input": {
+            "proving_cost_modifier": 118993998,
+            "fee_asset_price_modifier": -557996401
+        },
+        "outputs": {
+            "fee_asset_price_at_execution": 10211684722,
+            "mana_base_fee_components_in_wei": {
+                "data_cost": 1,
+                "gas_cost": 56834748,
+                "proving_cost": 5419461159,
+                "congestion_cost": 19763372123,
+                "congestion_multiplier": 4608894124
+            },
+            "mana_base_fee_components_in_fee_asset": {
+                "data_cost": 10,
+                "gas_cost": 580378527,
+                "proving_cost": 55341828718,
+                "congestion_cost": 201817325163,
+                "congestion_multiplier": 4608894124
+            }
+        }
+    },
+    {
+        "l1_block_number": 20973299,
+        "l1_fees": {
+            "blob_fee": 578,
+            "base_fee": 17844563894
+        },
+        "parent_header": {
+            "excess_mana": 1305972599,
+            "mana_used": 121671900,
+            "proving_cost_per_mana_numerator": 194735085,
+            "fee_asset_price_numerator": 1536756867
+        },
+        "header": {
+            "excess_mana": 1327644499,
+            "mana_used": 94239640,
+            "proving_cost_per_mana_numerator": 144284685,
+            "fee_asset_price_numerator": 1259440678
+        },
+        "oracle_input": {
+            "proving_cost_modifier": -50450400,
+            "fee_asset_price_modifier": -277316189
+        },
+        "outputs": {
+            "fee_asset_price_at_execution": 10154862569,
+            "mana_base_fee_components_in_wei": {
+                "data_cost": 2,
+                "gas_cost": 59110117,
+                "proving_cost": 5425913831,
+                "congestion_cost": 20444066586,
+                "congestion_multiplier": 4727252018
+            },
+            "mana_base_fee_components_in_fee_asset": {
+                "data_cost": 20,
+                "gas_cost": 600255114,
+                "proving_cost": 55099409265,
+                "congestion_cost": 207606686532,
+                "congestion_multiplier": 4727252018
+            }
+        }
+    },
+    {
+        "l1_block_number": 20973302,
+        "l1_fees": {
+            "blob_fee": 514,
+            "base_fee": 18350427669
+        },
+        "parent_header": {
+            "excess_mana": 1327644499,
+            "mana_used": 94239640,
+            "proving_cost_per_mana_numerator": 144284685,
+            "fee_asset_price_numerator": 1259440678
+        },
+        "header": {
+            "excess_mana": 1321884139,
+            "mana_used": 104298436,
+            "proving_cost_per_mana_numerator": 150042426,
+            "fee_asset_price_numerator": 714535872
+        },
+        "oracle_input": {
+            "proving_cost_modifier": 5757741,
+            "fee_asset_price_modifier": -544904806
+        },
+        "outputs": {
+            "fee_asset_price_at_execution": 10126740503,
+            "mana_base_fee_components_in_wei": {
+                "data_cost": 2,
+                "gas_cost": 60785791,
+                "proving_cost": 5423177126,
+                "congestion_cost": 20265980859,
+                "congestion_multiplier": 4695499251
+            },
+            "mana_base_fee_components_in_fee_asset": {
+                "data_cost": 20,
+                "gas_cost": 615561931,
+                "proving_cost": 54919107456,
+                "congestion_cost": 205228329197,
+                "congestion_multiplier": 4695499251
+            }
+        }
+    },
+    {
+        "l1_block_number": 20973305,
+        "l1_fees": {
+            "blob_fee": 556,
+            "base_fee": 18935369029
+        },
+        "parent_header": {
+            "excess_mana": 1321884139,
+            "mana_used": 104298436,
+            "proving_cost_per_mana_numerator": 150042426,
+            "fee_asset_price_numerator": 714535872
+        },
+        "header": {
+            "excess_mana": 1326182575,
+            "mana_used": 95940065,
+            "proving_cost_per_mana_numerator": 143665287,
+            "fee_asset_price_numerator": 0
+        },
+        "oracle_input": {
+            "proving_cost_modifier": -6377139,
+            "fee_asset_price_modifier": -730072379
+        },
+        "outputs": {
+            "fee_asset_price_at_execution": 10071709477,
+            "mana_base_fee_components_in_wei": {
+                "data_cost": 2,
+                "gas_cost": 62723409,
+                "proving_cost": 5423489388,
+                "congestion_cost": 20404175589,
+                "congestion_multiplier": 4719173196
+            },
+            "mana_base_fee_components_in_fee_asset": {
+                "data_cost": 20,
+                "gas_cost": 631731952,
+                "proving_cost": 54623809467,
+                "congestion_cost": 205504928650,
+                "congestion_multiplier": 4719173196
+            }
+        }
+    },
+    {
+        "l1_block_number": 20973308,
+        "l1_fees": {
+            "blob_fee": 494,
+            "base_fee": 18629157863
+        },
+        "parent_header": {
+            "excess_mana": 1326182575,
+            "mana_used": 95940065,
+            "proving_cost_per_mana_numerator": 143665287,
+            "fee_asset_price_numerator": 0
+        },
+        "header": {
+            "excess_mana": 1322122640,
+            "mana_used": 118650737,
+            "proving_cost_per_mana_numerator": 27347406,
+            "fee_asset_price_numerator": 126873686
+        },
+        "oracle_input": {
+            "proving_cost_modifier": -116317881,
+            "fee_asset_price_modifier": 126873686
+        },
+        "outputs": {
+            "fee_asset_price_at_execution": 10000000000,
+            "mana_base_fee_components_in_wei": {
+                "data_cost": 1,
+                "gas_cost": 61709085,
+                "proving_cost": 5423143535,
+                "congestion_cost": 20276456344,
+                "congestion_multiplier": 4696809695
+            },
+            "mana_base_fee_components_in_fee_asset": {
+                "data_cost": 10,
+                "gas_cost": 617090850,
+                "proving_cost": 54231435350,
+                "congestion_cost": 202764563440,
+                "congestion_multiplier": 4696809695
+            }
+        }
+    },
+    {
+        "l1_block_number": 20973311,
+        "l1_fees": {
+            "blob_fee": 556,
+            "base_fee": 17703911185
+        },
+        "parent_header": {
+            "excess_mana": 1322122640,
+            "mana_used": 118650737,
+            "proving_cost_per_mana_numerator": 27347406,
+            "fee_asset_price_numerator": 126873686
+        },
+        "header": {
+            "excess_mana": 1340773377,
+            "mana_used": 83539329,
+            "proving_cost_per_mana_numerator": 33755883,
+            "fee_asset_price_numerator": 330994440
+        },
+        "oracle_input": {
+            "proving_cost_modifier": 6408477,
+            "fee_asset_price_modifier": 204120754
+        },
+        "outputs": {
+            "fee_asset_price_at_execution": 10012695420,
+            "mana_base_fee_components_in_wei": {
+                "data_cost": 2,
+                "gas_cost": 58644205,
+                "proving_cost": 5416839117,
+                "congestion_cost": 20809174136,
+                "congestion_multiplier": 4800426904
+            },
+            "mana_base_fee_components_in_fee_asset": {
+                "data_cost": 20,
+                "gas_cost": 587186562,
+                "proving_cost": 54237160217,
+                "congestion_cost": 208355922565,
+                "congestion_multiplier": 4800426904
+            }
+        }
+    },
+    {
+        "l1_block_number": 20973314,
+        "l1_fees": {
+            "blob_fee": 625,
+            "base_fee": 19202542875
+        },
+        "parent_header": {
+            "excess_mana": 1340773377,
+            "mana_used": 83539329,
+            "proving_cost_per_mana_numerator": 33755883,
+            "fee_asset_price_numerator": 330994440
+        },
+        "header": {
+            "excess_mana": 1324312706,
+            "mana_used": 102397541,
+            "proving_cost_per_mana_numerator": 0,
+            "fee_asset_price_numerator": 189252938
+        },
+        "oracle_input": {
+            "proving_cost_modifier": -191695900,
+            "fee_asset_price_modifier": -141741502
+        },
+        "outputs": {
+            "fee_asset_price_at_execution": 10033154283,
+            "mana_base_fee_components_in_wei": {
+                "data_cost": 2,
+                "gas_cost": 63608423,
+                "proving_cost": 5417186265,
+                "congestion_cost": 20327500884,
+                "congestion_multiplier": 4708860126
+            },
+            "mana_base_fee_components_in_fee_asset": {
+                "data_cost": 20,
+                "gas_cost": 638193121,
+                "proving_cost": 54351465576,
+                "congestion_cost": 203948952556,
+                "congestion_multiplier": 4708860126
+            }
+        }
+    },
+    {
+        "l1_block_number": 20973317,
+        "l1_fees": {
+            "blob_fee": 556,
+            "base_fee": 20520058840
+        },
+        "parent_header": {
+            "excess_mana": 1324312706,
+            "mana_used": 102397541,
+            "proving_cost_per_mana_numerator": 0,
+            "fee_asset_price_numerator": 189252938
+        },
+        "header": {
+            "excess_mana": 1326710247,
+            "mana_used": 58716486,
+            "proving_cost_per_mana_numerator": 92573408,
+            "fee_asset_price_numerator": 635898020
+        },
+        "oracle_input": {
+            "proving_cost_modifier": 92573408,
+            "fee_asset_price_modifier": 446645082
+        },
+        "outputs": {
+            "fee_asset_price_at_execution": 10018943213,
+            "mana_base_fee_components_in_wei": {
+                "data_cost": 2,
+                "gas_cost": 67972694,
+                "proving_cost": 5415357955,
+                "congestion_cost": 20409437028,
+                "congestion_multiplier": 4722087601
+            },
+            "mana_base_fee_components_in_fee_asset": {
+                "data_cost": 20,
+                "gas_cost": 681014561,
+                "proving_cost": 54256163829,
+                "congestion_cost": 204480990592,
+                "congestion_multiplier": 4722087601
+            }
+        }
+    },
+    {
+        "l1_block_number": 20973320,
+        "l1_fees": {
+            "blob_fee": 791,
+            "base_fee": 19995965669
+        },
+        "parent_header": {
+            "excess_mana": 1326710247,
+            "mana_used": 58716486,
+            "proving_cost_per_mana_numerator": 92573408,
+            "fee_asset_price_numerator": 635898020
+        },
+        "header": {
+            "excess_mana": 1285426733,
+            "mana_used": 121832935,
+            "proving_cost_per_mana_numerator": 160371045,
+            "fee_asset_price_numerator": 448986186
+        },
+        "oracle_input": {
+            "proving_cost_modifier": 67797637,
+            "fee_asset_price_modifier": -186911834
+        },
+        "outputs": {
+            "fee_asset_price_at_execution": 10063792414,
+            "mana_base_fee_components_in_wei": {
+                "data_cost": 3,
+                "gas_cost": 66236636,
+                "proving_cost": 5420373457,
+                "congestion_cost": 19199972338,
+                "congestion_multiplier": 4499423506
+            },
+            "mana_base_fee_components_in_fee_asset": {
+                "data_cost": 30,
+                "gas_cost": 666591754,
+                "proving_cost": 54549513277,
+                "congestion_cost": 193224535964,
+                "congestion_multiplier": 4499423506
+            }
+        }
+    },
+    {
+        "l1_block_number": 20973323,
+        "l1_fees": {
+            "blob_fee": 703,
+            "base_fee": 19348276407
+        },
+        "parent_header": {
+            "excess_mana": 1285426733,
+            "mana_used": 121832935,
+            "proving_cost_per_mana_numerator": 160371045,
+            "fee_asset_price_numerator": 448986186
+        },
+        "header": {
+            "excess_mana": 1307259668,
+            "mana_used": 107794157,
+            "proving_cost_per_mana_numerator": 101292328,
+            "fee_asset_price_numerator": 0
+        },
+        "oracle_input": {
+            "proving_cost_modifier": -59078717,
+            "fee_asset_price_modifier": -711503255
+        },
+        "outputs": {
+            "fee_asset_price_at_execution": 10044999563,
+            "mana_base_fee_components_in_wei": {
+                "data_cost": 2,
+                "gas_cost": 64091165,
+                "proving_cost": 5424049588,
+                "congestion_cost": 19844237501,
+                "congestion_multiplier": 4615839751
+            },
+            "mana_base_fee_components_in_fee_asset": {
+                "data_cost": 20,
+                "gas_cost": 643795724,
+                "proving_cost": 54484575741,
+                "congestion_cost": 199335357025,
+                "congestion_multiplier": 4615839751
+            }
+        }
+    },
+    {
+        "l1_block_number": 20973326,
+        "l1_fees": {
+            "blob_fee": 1002,
+            "base_fee": 19136803008
+        },
+        "parent_header": {
+            "excess_mana": 1307259668,
+            "mana_used": 107794157,
+            "proving_cost_per_mana_numerator": 101292328,
+            "fee_asset_price_numerator": 0
+        },
+        "header": {
+            "excess_mana": 1315053825,
+            "mana_used": 104770501,
+            "proving_cost_per_mana_numerator": 67807403,
+            "fee_asset_price_numerator": 0
+        },
+        "oracle_input": {
+            "proving_cost_modifier": -33484925,
+            "fee_asset_price_modifier": -1000000000
+        },
+        "outputs": {
+            "fee_asset_price_at_execution": 10000000000,
+            "mana_base_fee_components_in_wei": {
+                "data_cost": 3,
+                "gas_cost": 63390659,
+                "proving_cost": 5420846076,
+                "congestion_cost": 20062022743,
+                "congestion_multiplier": 4658124859
+            },
+            "mana_base_fee_components_in_fee_asset": {
+                "data_cost": 30,
+                "gas_cost": 633906590,
+                "proving_cost": 54208460760,
+                "congestion_cost": 200620227430,
+                "congestion_multiplier": 4658124859
+            }
+        }
+    },
+    {
+        "l1_block_number": 20973329,
+        "l1_fees": {
+            "blob_fee": 1127,
+            "base_fee": 19212580019
+        },
+        "parent_header": {
+            "excess_mana": 1315053825,
+            "mana_used": 104770501,
+            "proving_cost_per_mana_numerator": 67807403,
+            "fee_asset_price_numerator": 0
+        },
+        "header": {
+            "excess_mana": 1319824326,
+            "mana_used": 97876951,
+            "proving_cost_per_mana_numerator": 0,
+            "fee_asset_price_numerator": 0
+        },
+        "oracle_input": {
+            "proving_cost_modifier": -111587454,
+            "fee_asset_price_modifier": -215251746
+        },
+        "outputs": {
+            "fee_asset_price_at_execution": 10000000000,
+            "mana_base_fee_components_in_wei": {
+                "data_cost": 4,
+                "gas_cost": 63641671,
+                "proving_cost": 5419031213,
+                "congestion_cost": 20199245969,
+                "congestion_multiplier": 4684196811
+            },
+            "mana_base_fee_components_in_fee_asset": {
+                "data_cost": 40,
+                "gas_cost": 636416710,
+                "proving_cost": 54190312130,
+                "congestion_cost": 201992459690,
+                "congestion_multiplier": 4684196811
+            }
+        }
+    },
+    {
+        "l1_block_number": 20973332,
+        "l1_fees": {
+            "blob_fee": 1172,
+            "base_fee": 20277424411
+        },
+        "parent_header": {
+            "excess_mana": 1319824326,
+            "mana_used": 97876951,
+            "proving_cost_per_mana_numerator": 0,
+            "fee_asset_price_numerator": 0
+        },
+        "header": {
+            "excess_mana": 1317701277,
+            "mana_used": 46254371,
+            "proving_cost_per_mana_numerator": 0,
+            "fee_asset_price_numerator": 0
+        },
+        "oracle_input": {
+            "proving_cost_modifier": -99796762,
+            "fee_asset_price_modifier": -683803507
+        },
+        "outputs": {
+            "fee_asset_price_at_execution": 10000000000,
+            "mana_base_fee_components_in_wei": {
+                "data_cost": 4,
+                "gas_cost": 67168968,
+                "proving_cost": 5415357955,
+                "congestion_cost": 20134996032,
+                "congestion_multiplier": 4672575858
+            },
+            "mana_base_fee_components_in_fee_asset": {
+                "data_cost": 40,
+                "gas_cost": 671689680,
+                "proving_cost": 54153579550,
+                "congestion_cost": 201349960320,
+                "congestion_multiplier": 4672575858
+            }
+        }
+    },
+    {
+        "l1_block_number": 20973335,
+        "l1_fees": {
+            "blob_fee": 1268,
+            "base_fee": 19528446485
+        },
+        "parent_header": {
+            "excess_mana": 1317701277,
+            "mana_used": 46254371,
+            "proving_cost_per_mana_numerator": 0,
+            "fee_asset_price_numerator": 0
+        },
+        "header": {
+            "excess_mana": 1263955648,
+            "mana_used": 134292665,
+            "proving_cost_per_mana_numerator": 0,
+            "fee_asset_price_numerator": 63367084
+        },
+        "oracle_input": {
+            "proving_cost_modifier": -100537926,
+            "fee_asset_price_modifier": 63367084
+        },
+        "outputs": {
+            "fee_asset_price_at_execution": 10000000000,
+            "mana_base_fee_components_in_wei": {
+                "data_cost": 4,
+                "gas_cost": 64687978,
+                "proving_cost": 5415357955,
+                "congestion_cost": 18565303154,
+                "congestion_multiplier": 4387800644
+            },
+            "mana_base_fee_components_in_fee_asset": {
+                "data_cost": 40,
+                "gas_cost": 646879780,
+                "proving_cost": 54153579550,
+                "congestion_cost": 185653031540,
+                "congestion_multiplier": 4387800644
+            }
+        }
+    },
+    {
+        "l1_block_number": 20973338,
+        "l1_fees": {
+            "blob_fee": 1372,
+            "base_fee": 19587243385
+        },
+        "parent_header": {
+            "excess_mana": 1263955648,
+            "mana_used": 134292665,
+            "proving_cost_per_mana_numerator": 0,
+            "fee_asset_price_numerator": 63367084
+        },
+        "header": {
+            "excess_mana": 1298248313,
+            "mana_used": 120510766,
+            "proving_cost_per_mana_numerator": 0,
+            "fee_asset_price_numerator": 0
+        },
+        "oracle_input": {
+            "proving_cost_modifier": -209476542,
+            "fee_asset_price_modifier": -928399810
+        },
+        "outputs": {
+            "fee_asset_price_at_execution": 10006338716,
+            "mana_base_fee_components_in_wei": {
+                "data_cost": 5,
+                "gas_cost": 64882743,
+                "proving_cost": 5415357955,
+                "congestion_cost": 19550371183,
+                "congestion_multiplier": 4567429287
+            },
+            "mana_base_fee_components_in_fee_asset": {
+                "data_cost": 50,
+                "gas_cost": 649238703,
+                "proving_cost": 54187905966,
+                "congestion_cost": 195627636080,
+                "congestion_multiplier": 4567429287
+            }
+        }
+    },
+    {
+        "l1_block_number": 20973341,
+        "l1_fees": {
+            "blob_fee": 1736,
+            "base_fee": 18965878234
+        },
+        "parent_header": {
+            "excess_mana": 1298248313,
+            "mana_used": 120510766,
+            "proving_cost_per_mana_numerator": 0,
+            "fee_asset_price_numerator": 0
+        },
+        "header": {
+            "excess_mana": 1318759079,
+            "mana_used": 108139250,
+            "proving_cost_per_mana_numerator": 96857364,
+            "fee_asset_price_numerator": 0
+        },
+        "oracle_input": {
+            "proving_cost_modifier": 96857364,
+            "fee_asset_price_modifier": -933894862
+        },
+        "outputs": {
+            "fee_asset_price_at_execution": 10000000000,
+            "mana_base_fee_components_in_wei": {
+                "data_cost": 6,
+                "gas_cost": 62824471,
+                "proving_cost": 5415357955,
+                "congestion_cost": 20150740009,
+                "congestion_multiplier": 4678362351
+            },
+            "mana_base_fee_components_in_fee_asset": {
+                "data_cost": 60,
+                "gas_cost": 628244710,
+                "proving_cost": 54153579550,
+                "congestion_cost": 201507400090,
+                "congestion_multiplier": 4678362351
+            }
+        }
+    },
+    {
+        "l1_block_number": 20973344,
+        "l1_fees": {
+            "blob_fee": 1543,
+            "base_fee": 18373599419
+        },
+        "parent_header": {
+            "excess_mana": 1318759079,
+            "mana_used": 108139250,
+            "proving_cost_per_mana_numerator": 96857364,
+            "fee_asset_price_numerator": 0
+        },
+        "header": {
+            "excess_mana": 1326898329,
+            "mana_used": 98216650,
+            "proving_cost_per_mana_numerator": 222484067,
+            "fee_asset_price_numerator": 0
+        },
+        "oracle_input": {
+            "proving_cost_modifier": 125626703,
+            "fee_asset_price_modifier": -619139751
+        },
+        "outputs": {
+            "fee_asset_price_at_execution": 10000000000,
+            "mana_base_fee_components_in_wei": {
+                "data_cost": 6,
+                "gas_cost": 60862548,
+                "proving_cost": 5420605668,
+                "congestion_cost": 20408201454,
+                "congestion_multiplier": 4723126839
+            },
+            "mana_base_fee_components_in_fee_asset": {
+                "data_cost": 60,
+                "gas_cost": 608625480,
+                "proving_cost": 54206056680,
+                "congestion_cost": 204082014540,
+                "congestion_multiplier": 4723126839
+            }
+        }
+    },
+    {
+        "l1_block_number": 20973347,
+        "l1_fees": {
+            "blob_fee": 1669,
+            "base_fee": 18117964296
+        },
+        "parent_header": {
+            "excess_mana": 1326898329,
+            "mana_used": 98216650,
+            "proving_cost_per_mana_numerator": 222484067,
+            "fee_asset_price_numerator": 0
+        },
+        "header": {
+            "excess_mana": 1325114979,
+            "mana_used": 99643547,
+            "proving_cost_per_mana_numerator": 268172405,
+            "fee_asset_price_numerator": 562767444
+        },
+        "oracle_input": {
+            "proving_cost_modifier": 45688338,
+            "fee_asset_price_modifier": 562767444
+        },
+        "outputs": {
+            "fee_asset_price_at_execution": 10000000000,
+            "mana_base_fee_components_in_wei": {
+                "data_cost": 6,
+                "gas_cost": 60015756,
+                "proving_cost": 5427419676,
+                "congestion_cost": 20376396428,
+                "congestion_multiplier": 4713282217
+            },
+            "mana_base_fee_components_in_fee_asset": {
+                "data_cost": 60,
+                "gas_cost": 600157560,
+                "proving_cost": 54274196760,
+                "congestion_cost": 203763964280,
+                "congestion_multiplier": 4713282217
+            }
+        }
+    },
+    {
+        "l1_block_number": 20973350,
+        "l1_fees": {
+            "blob_fee": 1484,
+            "base_fee": 18635391729
+        },
+        "parent_header": {
+            "excess_mana": 1325114979,
+            "mana_used": 99643547,
+            "proving_cost_per_mana_numerator": 268172405,
+            "fee_asset_price_numerator": 562767444
+        },
+        "header": {
+            "excess_mana": 1324758526,
+            "mana_used": 94493495,
+            "proving_cost_per_mana_numerator": 275475534,
+            "fee_asset_price_numerator": 55546249
+        },
+        "oracle_input": {
+            "proving_cost_modifier": 7303129,
+            "fee_asset_price_modifier": -507221195
+        },
+        "outputs": {
+            "fee_asset_price_at_execution": 10056435395,
+            "mana_base_fee_components_in_wei": {
+                "data_cost": 5,
+                "gas_cost": 61729735,
+                "proving_cost": 5429899940,
+                "congestion_cost": 20381178325,
+                "congestion_multiplier": 4711316952
+            },
+            "mana_base_fee_components_in_fee_asset": {
+                "data_cost": 50,
+                "gas_cost": 620781091,
+                "proving_cost": 54605437947,
+                "congestion_cost": 204962003099,
+                "congestion_multiplier": 4711316952
+            }
+        }
+    },
+    {
+        "l1_block_number": 20973353,
+        "l1_fees": {
+            "blob_fee": 1669,
+            "base_fee": 17699124203
+        },
+        "parent_header": {
+            "excess_mana": 1324758526,
+            "mana_used": 94493495,
+            "proving_cost_per_mana_numerator": 275475534,
+            "fee_asset_price_numerator": 55546249
+        },
+        "header": {
+            "excess_mana": 1319252021,
+            "mana_used": 40141150,
+            "proving_cost_per_mana_numerator": 60908371,
+            "fee_asset_price_numerator": 0
+        },
+        "oracle_input": {
+            "proving_cost_modifier": -214567163,
+            "fee_asset_price_modifier": -205759070
+        },
+        "outputs": {
+            "fee_asset_price_at_execution": 10005556167,
+            "mana_base_fee_components_in_wei": {
+                "data_cost": 6,
+                "gas_cost": 58628348,
+                "proving_cost": 5430296507,
+                "congestion_cost": 20205069087,
+                "congestion_multiplier": 4681061337
+            },
+            "mana_base_fee_components_in_fee_asset": {
+                "data_cost": 60,
+                "gas_cost": 586609228,
+                "proving_cost": 54333136704,
+                "congestion_cost": 202162953608,
+                "congestion_multiplier": 4681061337
+            }
+        }
+    },
+    {
+        "l1_block_number": 20973356,
+        "l1_fees": {
+            "blob_fee": 1878,
+            "base_fee": 19049659164
+        },
+        "parent_header": {
+            "excess_mana": 1319252021,
+            "mana_used": 40141150,
+            "proving_cost_per_mana_numerator": 60908371,
+            "fee_asset_price_numerator": 0
+        },
+        "header": {
+            "excess_mana": 1259393171,
+            "mana_used": 139643833,
+            "proving_cost_per_mana_numerator": 23579480,
+            "fee_asset_price_numerator": 554264977
+        },
+        "oracle_input": {
+            "proving_cost_modifier": -37328891,
+            "fee_asset_price_modifier": 554264977
+        },
+        "outputs": {
+            "fee_asset_price_at_execution": 10000000000,
+            "mana_base_fee_components_in_wei": {
+                "data_cost": 7,
+                "gas_cost": 63101995,
+                "proving_cost": 5418657366,
+                "congestion_cost": 18443053437,
+                "congestion_multiplier": 4364440538
+            },
+            "mana_base_fee_components_in_fee_asset": {
+                "data_cost": 70,
+                "gas_cost": 631019950,
+                "proving_cost": 54186573660,
+                "congestion_cost": 184430534370,
+                "congestion_multiplier": 4364440538
+            }
+        }
+    },
+    {
+        "l1_block_number": 20973359,
+        "l1_fees": {
+            "blob_fee": 2113,
+            "base_fee": 17952935112
+        },
+        "parent_header": {
+            "excess_mana": 1259393171,
+            "mana_used": 139643833,
+            "proving_cost_per_mana_numerator": 23579480,
+            "fee_asset_price_numerator": 554264977
+        },
+        "header": {
+            "excess_mana": 1299037004,
+            "mana_used": 107564368,
+            "proving_cost_per_mana_numerator": 83622719,
+            "fee_asset_price_numerator": 563075097
+        },
+        "oracle_input": {
+            "proving_cost_modifier": 60043239,
+            "fee_asset_price_modifier": 8810120
+        },
+        "outputs": {
+            "fee_asset_price_at_execution": 10055580386,
+            "mana_base_fee_components_in_wei": {
+                "data_cost": 8,
+                "gas_cost": 59469097,
+                "proving_cost": 5416635018,
+                "congestion_cost": 19558704904,
+                "congestion_multiplier": 4571645912
+            },
+            "mana_base_fee_components_in_fee_asset": {
+                "data_cost": 80,
+                "gas_cost": 597996285,
+                "proving_cost": 54467408845,
+                "congestion_cost": 196674129408,
+                "congestion_multiplier": 4571645912
+            }
+        }
+    },
+    {
+        "l1_block_number": 20973362,
+        "l1_fees": {
+            "blob_fee": 2377,
+            "base_fee": 17889199584
+        },
+        "parent_header": {
+            "excess_mana": 1299037004,
+            "mana_used": 107564368,
+            "proving_cost_per_mana_numerator": 83622719,
+            "fee_asset_price_numerator": 563075097
+        },
+        "header": {
+            "excess_mana": 1306601372,
+            "mana_used": 101620485,
+            "proving_cost_per_mana_numerator": 229458629,
+            "fee_asset_price_numerator": 494396072
+        },
+        "oracle_input": {
+            "proving_cost_modifier": 145835910,
+            "fee_asset_price_modifier": -68679025
+        },
+        "outputs": {
+            "fee_asset_price_at_execution": 10056466334,
+            "mana_base_fee_components_in_wei": {
+                "data_cost": 9,
+                "gas_cost": 59257973,
+                "proving_cost": 5419888318,
+                "congestion_cost": 19792243312,
+                "congestion_multiplier": 4612285971
+            },
+            "mana_base_fee_components_in_fee_asset": {
+                "data_cost": 90,
+                "gas_cost": 595925810,
+                "proving_cost": 54504924404,
+                "congestion_cost": 199040028541,
+                "congestion_multiplier": 4612285971
+            }
+        }
+    },
+    {
+        "l1_block_number": 20973365,
+        "l1_fees": {
+            "blob_fee": 2571,
+            "base_fee": 19972641950
+        },
+        "parent_header": {
+            "excess_mana": 1306601372,
+            "mana_used": 101620485,
+            "proving_cost_per_mana_numerator": 229458629,
+            "fee_asset_price_numerator": 494396072
+        },
+        "header": {
+            "excess_mana": 1308221857,
+            "mana_used": 94418152,
+            "proving_cost_per_mana_numerator": 141959240,
+            "fee_asset_price_numerator": 0
+        },
+        "oracle_input": {
+            "proving_cost_modifier": -87499389,
+            "fee_asset_price_modifier": -885807858
+        },
+        "outputs": {
+            "fee_asset_price_at_execution": 10049562022,
+            "mana_base_fee_components_in_wei": {
+                "data_cost": 10,
+                "gas_cost": 66159376,
+                "proving_cost": 5427798228,
+                "congestion_cost": 19893834839,
+                "congestion_multiplier": 4621039010
+            },
+            "mana_base_fee_components_in_fee_asset": {
+                "data_cost": 100,
+                "gas_cost": 664872752,
+                "proving_cost": 54546994935,
+                "congestion_cost": 199924327069,
+                "congestion_multiplier": 4621039010
+            }
+        }
+    },
+    {
+        "l1_block_number": 20973368,
+        "l1_fees": {
+            "blob_fee": 3661,
+            "base_fee": 19697758125
+        },
+        "parent_header": {
+            "excess_mana": 1308221857,
+            "mana_used": 94418152,
+            "proving_cost_per_mana_numerator": 141959240,
+            "fee_asset_price_numerator": 0
+        },
+        "header": {
+            "excess_mana": 1302640009,
+            "mana_used": 101926798,
+            "proving_cost_per_mana_numerator": 156388847,
+            "fee_asset_price_numerator": 697009676
+        },
+        "oracle_input": {
+            "proving_cost_modifier": 14429607,
+            "fee_asset_price_modifier": 697009676
+        },
+        "outputs": {
+            "fee_asset_price_at_execution": 10000000000,
+            "mana_base_fee_components_in_wei": {
+                "data_cost": 14,
+                "gas_cost": 65248823,
+                "proving_cost": 5423051015,
+                "congestion_cost": 19708256647,
+                "congestion_multiplier": 4590958435
+            },
+            "mana_base_fee_components_in_fee_asset": {
+                "data_cost": 140,
+                "gas_cost": 652488230,
+                "proving_cost": 54230510150,
+                "congestion_cost": 197082566470,
+                "congestion_multiplier": 4590958435
+            }
+        }
+    },
+    {
+        "l1_block_number": 20973371,
+        "l1_fees": {
+            "blob_fee": 4118,
+            "base_fee": 18752355505
+        },
+        "parent_header": {
+            "excess_mana": 1302640009,
+            "mana_used": 101926798,
+            "proving_cost_per_mana_numerator": 156388847,
+            "fee_asset_price_numerator": 697009676
+        },
+        "header": {
+            "excess_mana": 1304566807,
+            "mana_used": 115778581,
+            "proving_cost_per_mana_numerator": 0,
+            "fee_asset_price_numerator": 1399718159
+        },
+        "oracle_input": {
+            "proving_cost_modifier": -161415172,
+            "fee_asset_price_modifier": 702708483
+        },
+        "outputs": {
+            "fee_asset_price_at_execution": 10069944444,
+            "mana_base_fee_components_in_wei": {
+                "data_cost": 16,
+                "gas_cost": 62117177,
+                "proving_cost": 5423833596,
+                "congestion_cost": 19756662945,
+                "congestion_multiplier": 4601319754
+            },
+            "mana_base_fee_components_in_fee_asset": {
+                "data_cost": 161,
+                "gas_cost": 625516521,
+                "proving_cost": 54617702985,
+                "congestion_cost": 198948498254,
+                "congestion_multiplier": 4601319754
+            }
+        }
+    },
+    {
+        "l1_block_number": 20973374,
+        "l1_fees": {
+            "blob_fee": 5864,
+            "base_fee": 18133633771
+        },
+        "parent_header": {
+            "excess_mana": 1304566807,
+            "mana_used": 115778581,
+            "proving_cost_per_mana_numerator": 0,
+            "fee_asset_price_numerator": 1399718159
+        },
+        "header": {
+            "excess_mana": 1320345388,
+            "mana_used": 101438272,
+            "proving_cost_per_mana_numerator": 0,
+            "fee_asset_price_numerator": 592952138
+        },
+        "oracle_input": {
+            "proving_cost_modifier": -154381148,
+            "fee_asset_price_modifier": -806766021
+        },
+        "outputs": {
+            "fee_asset_price_at_execution": 10140956007,
+            "mana_base_fee_components_in_wei": {
+                "data_cost": 23,
+                "gas_cost": 60067661,
+                "proving_cost": 5415357955,
+                "congestion_cost": 20188186538,
+                "congestion_multiplier": 4687053367
+            },
+            "mana_base_fee_components_in_fee_asset": {
+                "data_cost": 233,
+                "gas_cost": 609143507,
+                "proving_cost": 54916906783,
+                "congestion_cost": 204727511542,
+                "congestion_multiplier": 4687053367
+            }
+        }
+    },
+    {
+        "l1_block_number": 20973377,
+        "l1_fees": {
+            "blob_fee": 6099,
+            "base_fee": 18370080806
+        },
+        "parent_header": {
+            "excess_mana": 1320345388,
+            "mana_used": 101438272,
+            "proving_cost_per_mana_numerator": 0,
+            "fee_asset_price_numerator": 592952138
+        },
+        "header": {
+            "excess_mana": 1321783660,
+            "mana_used": 97073818,
+            "proving_cost_per_mana_numerator": 32850276,
+            "fee_asset_price_numerator": 0
+        },
+        "oracle_input": {
+            "proving_cost_modifier": 32850276,
+            "fee_asset_price_modifier": -629066323
+        },
+        "outputs": {
+            "fee_asset_price_at_execution": 10059471357,
+            "mana_base_fee_components_in_wei": {
+                "data_cost": 23,
+                "gas_cost": 60850892,
+                "proving_cost": 5415357955,
+                "congestion_cost": 20234303063,
+                "congestion_multiplier": 4694947279
+            },
+            "mana_base_fee_components_in_fee_asset": {
+                "data_cost": 231,
+                "gas_cost": 612127805,
+                "proving_cost": 54475638236,
+                "congestion_cost": 203546392091,
+                "congestion_multiplier": 4694947279
+            }
+        }
+    },
+    {
+        "l1_block_number": 20973380,
+        "l1_fees": {
+            "blob_fee": 5421,
+            "base_fee": 18504594480
+        },
+        "parent_header": {
+            "excess_mana": 1321783660,
+            "mana_used": 97073818,
+            "proving_cost_per_mana_numerator": 32850276,
+            "fee_asset_price_numerator": 0
+        },
+        "header": {
+            "excess_mana": 1318857478,
+            "mana_used": 100868624,
+            "proving_cost_per_mana_numerator": 99918728,
+            "fee_asset_price_numerator": 0
+        },
+        "oracle_input": {
+            "proving_cost_modifier": 67068452,
+            "fee_asset_price_modifier": -125217171
+        },
+        "outputs": {
+            "fee_asset_price_at_execution": 10000000000,
+            "mana_base_fee_components_in_wei": {
+                "data_cost": 21,
+                "gas_cost": 61296469,
+                "proving_cost": 5417137207,
+                "congestion_cost": 20154615135,
+                "congestion_multiplier": 4678900987
+            },
+            "mana_base_fee_components_in_fee_asset": {
+                "data_cost": 210,
+                "gas_cost": 612964690,
+                "proving_cost": 54171372070,
+                "congestion_cost": 201546151350,
+                "congestion_multiplier": 4678900987
+            }
+        }
+    },
+    {
+        "l1_block_number": 20973383,
+        "l1_fees": {
+            "blob_fee": 6343,
+            "base_fee": 17141190330
+        },
+        "parent_header": {
+            "excess_mana": 1318857478,
+            "mana_used": 100868624,
+            "proving_cost_per_mana_numerator": 99918728,
+            "fee_asset_price_numerator": 0
+        },
+        "header": {
+            "excess_mana": 1319726102,
+            "mana_used": 99789829,
+            "proving_cost_per_mana_numerator": 72115258,
+            "fee_asset_price_numerator": 318131719
+        },
+        "oracle_input": {
+            "proving_cost_modifier": -27803470,
+            "fee_asset_price_modifier": 318131719
+        },
+        "outputs": {
+            "fee_asset_price_at_execution": 10000000000,
+            "mana_base_fee_components_in_wei": {
+                "data_cost": 24,
+                "gas_cost": 56780192,
+                "proving_cost": 5420771615,
+                "congestion_cost": 20177430492,
+                "congestion_multiplier": 4683658524
+            },
+            "mana_base_fee_components_in_fee_asset": {
+                "data_cost": 240,
+                "gas_cost": 567801920,
+                "proving_cost": 54207716150,
+                "congestion_cost": 201774304920,
+                "congestion_multiplier": 4683658524
+            }
+        }
+    },
+    {
+        "l1_block_number": 20973386,
+        "l1_fees": {
+            "blob_fee": 7136,
+            "base_fee": 15977836153
+        },
+        "parent_header": {
+            "excess_mana": 1319726102,
+            "mana_used": 99789829,
+            "proving_cost_per_mana_numerator": 72115258,
+            "fee_asset_price_numerator": 318131719
+        },
+        "header": {
+            "excess_mana": 1319515931,
+            "mana_used": 109710155,
+            "proving_cost_per_mana_numerator": 89852123,
+            "fee_asset_price_numerator": 331643801
+        },
+        "oracle_input": {
+            "proving_cost_modifier": 17736865,
+            "fee_asset_price_modifier": 13512082
+        },
+        "outputs": {
+            "fee_asset_price_at_execution": 10031863829,
+            "mana_base_fee_components_in_wei": {
+                "data_cost": 28,
+                "gas_cost": 52926582,
+                "proving_cost": 5419264662,
+                "congestion_cost": 20151382412,
+                "congestion_multiplier": 4682506954
+            },
+            "mana_base_fee_components_in_fee_asset": {
+                "data_cost": 280,
+                "gas_cost": 530952263,
+                "proving_cost": 54365325142,
+                "congestion_cost": 202155924323,
+                "congestion_multiplier": 4682506954
+            }
+        }
+    },
+    {
+        "l1_block_number": 20973389,
+        "l1_fees": {
+            "blob_fee": 6343,
+            "base_fee": 18525791343
+        },
+        "parent_header": {
+            "excess_mana": 1319515931,
+            "mana_used": 109710155,
+            "proving_cost_per_mana_numerator": 89852123,
+            "fee_asset_price_numerator": 331643801
+        },
+        "header": {
+            "excess_mana": 1329226086,
+            "mana_used": 112920909,
+            "proving_cost_per_mana_numerator": 220131378,
+            "fee_asset_price_numerator": 572844933
+        },
+        "oracle_input": {
+            "proving_cost_modifier": 130279255,
+            "fee_asset_price_modifier": 241201132
+        },
+        "outputs": {
+            "fee_asset_price_at_execution": 10033219434,
+            "mana_base_fee_components_in_wei": {
+                "data_cost": 24,
+                "gas_cost": 61366683,
+                "proving_cost": 5420225955,
+                "congestion_cost": 20479272349,
+                "congestion_multiplier": 4736007692
+            },
+            "mana_base_fee_components_in_fee_asset": {
+                "data_cost": 240,
+                "gas_cost": 615705396,
+                "proving_cost": 54382316388,
+                "congestion_cost": 205473033326,
+                "congestion_multiplier": 4736007692
+            }
+        }
+    },
+    {
+        "l1_block_number": 20973392,
+        "l1_fees": {
+            "blob_fee": 5638,
+            "base_fee": 19690491466
+        },
+        "parent_header": {
+            "excess_mana": 1329226086,
+            "mana_used": 112920909,
+            "proving_cost_per_mana_numerator": 220131378,
+            "fee_asset_price_numerator": 572844933
+        },
+        "header": {
+            "excess_mana": 1342146995,
+            "mana_used": 97817168,
+            "proving_cost_per_mana_numerator": 191036242,
+            "fee_asset_price_numerator": 616910498
+        },
+        "oracle_input": {
+            "proving_cost_modifier": -29095136,
+            "fee_asset_price_modifier": 44065565
+        },
+        "outputs": {
+            "fee_asset_price_at_execution": 10057448882,
+            "mana_base_fee_components_in_wei": {
+                "data_cost": 22,
+                "gas_cost": 65224752,
+                "proving_cost": 5427291987,
+                "congestion_cost": 20916316888,
+                "congestion_multiplier": 4808148031
+            },
+            "mana_base_fee_components_in_fee_asset": {
+                "data_cost": 221,
+                "gas_cost": 655994609,
+                "proving_cost": 54584711726,
+                "congestion_cost": 210364787900,
+                "congestion_multiplier": 4808148031
+            }
+        }
+    },
+    {
+        "l1_block_number": 20973395,
+        "l1_fees": {
+            "blob_fee": 6343,
+            "base_fee": 20475655040
+        },
+        "parent_header": {
+            "excess_mana": 1342146995,
+            "mana_used": 97817168,
+            "proving_cost_per_mana_numerator": 191036242,
+            "fee_asset_price_numerator": 616910498
+        },
+        "header": {
+            "excess_mana": 1339964163,
+            "mana_used": 90562122,
+            "proving_cost_per_mana_numerator": 184355731,
+            "fee_asset_price_numerator": 493961965
+        },
+        "oracle_input": {
+            "proving_cost_modifier": -6680511,
+            "fee_asset_price_modifier": -122948533
+        },
+        "outputs": {
+            "fee_asset_price_at_execution": 10061881730,
+            "mana_base_fee_components_in_wei": {
+                "data_cost": 24,
+                "gas_cost": 67825607,
+                "proving_cost": 5425713139,
+                "congestion_cost": 20852836497,
+                "congestion_multiplier": 4795884105
+            },
+            "mana_base_fee_components_in_fee_asset": {
+                "data_cost": 241,
+                "gas_cost": 682453235,
+                "proving_cost": 54592883905,
+                "congestion_cost": 209818774567,
+                "congestion_multiplier": 4795884105
+            }
+        }
+    },
+    {
+        "l1_block_number": 20973398,
+        "l1_fees": {
+            "blob_fee": 7136,
+            "base_fee": 18119718386
+        },
+        "parent_header": {
+            "excess_mana": 1339964163,
+            "mana_used": 90562122,
+            "proving_cost_per_mana_numerator": 184355731,
+            "fee_asset_price_numerator": 493961965
+        },
+        "header": {
+            "excess_mana": 1330526285,
+            "mana_used": 96393394,
+            "proving_cost_per_mana_numerator": 47505824,
+            "fee_asset_price_numerator": 152096606
+        },
+        "oracle_input": {
+            "proving_cost_modifier": -136849907,
+            "fee_asset_price_modifier": -341865359
+        },
+        "outputs": {
+            "fee_asset_price_at_execution": 10049518396,
+            "mana_base_fee_components_in_wei": {
+                "data_cost": 28,
+                "gas_cost": 60021567,
+                "proving_cost": 5425350686,
+                "congestion_cost": 20532942860,
+                "congestion_multiplier": 4743217745
+            },
+            "mana_base_fee_components_in_fee_asset": {
+                "data_cost": 281,
+                "gas_cost": 603187841,
+                "proving_cost": 54522161523,
+                "congestion_cost": 206346186995,
+                "congestion_multiplier": 4743217745
+            }
+        }
+    },
+    {
+        "l1_block_number": 20973401,
+        "l1_fees": {
+            "blob_fee": 9393,
+            "base_fee": 18420060434
+        },
+        "parent_header": {
+            "excess_mana": 1330526285,
+            "mana_used": 96393394,
+            "proving_cost_per_mana_numerator": 47505824,
+            "fee_asset_price_numerator": 152096606
+        },
+        "header": {
+            "excess_mana": 1326919679,
+            "mana_used": 80950635,
+            "proving_cost_per_mana_numerator": 158293696,
+            "fee_asset_price_numerator": 254761933
+        },
+        "oracle_input": {
+            "proving_cost_modifier": 110787872,
+            "fee_asset_price_modifier": 102665327
+        },
+        "outputs": {
+            "fee_asset_price_at_execution": 10015221233,
+            "mana_base_fee_components_in_wei": {
+                "data_cost": 36,
+                "gas_cost": 61016450,
+                "proving_cost": 5417931176,
+                "congestion_cost": 20399463512,
+                "congestion_multiplier": 4723244822
+            },
+            "mana_base_fee_components_in_fee_asset": {
+                "data_cost": 360,
+                "gas_cost": 611093245,
+                "proving_cost": 54261779352,
+                "congestion_cost": 204305140107,
+                "congestion_multiplier": 4723244822
+            }
+        }
+    },
+    {
+        "l1_block_number": 20973404,
+        "l1_fees": {
+            "blob_fee": 9032,
+            "base_fee": 18056451924
+        },
+        "parent_header": {
+            "excess_mana": 1326919679,
+            "mana_used": 80950635,
+            "proving_cost_per_mana_numerator": 158293696,
+            "fee_asset_price_numerator": 254761933
+        },
+        "header": {
+            "excess_mana": 1307870314,
+            "mana_used": 104359267,
+            "proving_cost_per_mana_numerator": 3583324,
+            "fee_asset_price_numerator": 32654620
+        },
+        "oracle_input": {
+            "proving_cost_modifier": -154710372,
+            "fee_asset_price_modifier": -222107313
+        },
+        "outputs": {
+            "fee_asset_price_at_execution": 10025508672,
+            "mana_base_fee_components_in_wei": {
+                "data_cost": 35,
+                "gas_cost": 59811996,
+                "proving_cost": 5423936913,
+                "congestion_cost": 19846448260,
+                "congestion_multiplier": 4619138743
+            },
+            "mana_base_fee_components_in_fee_asset": {
+                "data_cost": 350,
+                "gas_cost": 599645684,
+                "proving_cost": 54377726557,
+                "congestion_cost": 198970739139,
+                "congestion_multiplier": 4619138743
+            }
+        }
+    },
+    {
+        "l1_block_number": 20973407,
+        "l1_fees": {
+            "blob_fee": 8350,
+            "base_fee": 18137301254
+        },
+        "parent_header": {
+            "excess_mana": 1307870314,
+            "mana_used": 104359267,
+            "proving_cost_per_mana_numerator": 3583324,
+            "fee_asset_price_numerator": 32654620
+        },
+        "header": {
+            "excess_mana": 1312229581,
+            "mana_used": 104159990,
+            "proving_cost_per_mana_numerator": 0,
+            "fee_asset_price_numerator": 629122643
+        },
+        "oracle_input": {
+            "proving_cost_modifier": -24449045,
+            "fee_asset_price_modifier": 596468023
+        },
+        "outputs": {
+            "fee_asset_price_at_execution": 10003265995,
+            "mana_base_fee_components_in_wei": {
+                "data_cost": 32,
+                "gas_cost": 60079810,
+                "proving_cost": 5415552008,
+                "congestion_cost": 19946402356,
+                "congestion_multiplier": 4642758115
+            },
+            "mana_base_fee_components_in_fee_asset": {
+                "data_cost": 320,
+                "gas_cost": 600994320,
+                "proving_cost": 54173207245,
+                "congestion_cost": 199529168410,
+                "congestion_multiplier": 4642758115
+            }
+        }
+    },
+    {
+        "l1_block_number": 20973410,
+        "l1_fees": {
+            "blob_fee": 7719,
+            "base_fee": 17694593322
+        },
+        "parent_header": {
+            "excess_mana": 1312229581,
+            "mana_used": 104159990,
+            "proving_cost_per_mana_numerator": 0,
+            "fee_asset_price_numerator": 629122643
+        },
+        "header": {
+            "excess_mana": 1316389571,
+            "mana_used": 100721544,
+            "proving_cost_per_mana_numerator": 0,
+            "fee_asset_price_numerator": 0
+        },
+        "oracle_input": {
+            "proving_cost_modifier": -1988703,
+            "fee_asset_price_modifier": -660845787
+        },
+        "outputs": {
+            "fee_asset_price_at_execution": 10063110577,
+            "mana_base_fee_components_in_wei": {
+                "data_cost": 30,
+                "gas_cost": 58613340,
+                "proving_cost": 5415357955,
+                "congestion_cost": 20064351281,
+                "congestion_multiplier": 4665410374
+            },
+            "mana_base_fee_components_in_fee_asset": {
+                "data_cost": 301,
+                "gas_cost": 589832521,
+                "proving_cost": 54495345915,
+                "congestion_cost": 201909785596,
+                "congestion_multiplier": 4665410374
+            }
+        }
+    },
+    {
+        "l1_block_number": 20973413,
+        "l1_fees": {
+            "blob_fee": 7422,
+            "base_fee": 17130338099
+        },
+        "parent_header": {
+            "excess_mana": 1316389571,
+            "mana_used": 100721544,
+            "proving_cost_per_mana_numerator": 0,
+            "fee_asset_price_numerator": 0
+        },
+        "header": {
+            "excess_mana": 1317111115,
+            "mana_used": 98622363,
+            "proving_cost_per_mana_numerator": 0,
+            "fee_asset_price_numerator": 0
+        },
+        "oracle_input": {
+            "proving_cost_modifier": -70656247,
+            "fee_asset_price_modifier": -322344917
+        },
+        "outputs": {
+            "fee_asset_price_at_execution": 10000000000,
+            "mana_base_fee_components_in_wei": {
+                "data_cost": 29,
+                "gas_cost": 56744244,
+                "proving_cost": 5415357955,
+                "congestion_cost": 20079061631,
+                "congestion_multiplier": 4669350607
+            },
+            "mana_base_fee_components_in_fee_asset": {
+                "data_cost": 290,
+                "gas_cost": 567442440,
+                "proving_cost": 54153579550,
+                "congestion_cost": 200790616310,
+                "congestion_multiplier": 4669350607
+            }
+        }
+    },
+    {
+        "l1_block_number": 20973416,
+        "l1_fees": {
+            "blob_fee": 7422,
+            "base_fee": 16184100257
+        },
+        "parent_header": {
+            "excess_mana": 1317111115,
+            "mana_used": 98622363,
+            "proving_cost_per_mana_numerator": 0,
+            "fee_asset_price_numerator": 0
+        },
+        "header": {
+            "excess_mana": 1315733478,
+            "mana_used": 100888431,
+            "proving_cost_per_mana_numerator": 3503723,
+            "fee_asset_price_numerator": 0
+        },
+        "oracle_input": {
+            "proving_cost_modifier": 3503723,
+            "fee_asset_price_modifier": -870786204
+        },
+        "outputs": {
+            "fee_asset_price_at_execution": 10000000000,
+            "mana_base_fee_components_in_wei": {
+                "data_cost": 29,
+                "gas_cost": 53609832,
+                "proving_cost": 5415357955,
+                "congestion_cost": 20026432851,
+                "congestion_multiplier": 4661830445
+            },
+            "mana_base_fee_components_in_fee_asset": {
+                "data_cost": 290,
+                "gas_cost": 536098320,
+                "proving_cost": 54153579550,
+                "congestion_cost": 200264328510,
+                "congestion_multiplier": 4661830445
+            }
+        }
+    },
+    {
+        "l1_block_number": 20973419,
+        "l1_fees": {
+            "blob_fee": 5864,
+            "base_fee": 15185448051
+        },
+        "parent_header": {
+            "excess_mana": 1315733478,
+            "mana_used": 100888431,
+            "proving_cost_per_mana_numerator": 3503723,
+            "fee_asset_price_numerator": 0
+        },
+        "header": {
+            "excess_mana": 1316621909,
+            "mana_used": 94491057,
+            "proving_cost_per_mana_numerator": 0,
+            "fee_asset_price_numerator": 0
+        },
+        "oracle_input": {
+            "proving_cost_modifier": -61497457,
+            "fee_asset_price_modifier": -550404902
+        },
+        "outputs": {
+            "fee_asset_price_at_execution": 10000000000,
+            "mana_base_fee_components_in_wei": {
+                "data_cost": 23,
+                "gas_cost": 50301796,
+                "proving_cost": 5415547697,
+                "congestion_cost": 20041514385,
+                "congestion_multiplier": 4666678771
+            },
+            "mana_base_fee_components_in_fee_asset": {
+                "data_cost": 230,
+                "gas_cost": 503017960,
+                "proving_cost": 54155476970,
+                "congestion_cost": 200415143850,
+                "congestion_multiplier": 4666678771
+            }
+        }
+    },
+    {
+        "l1_block_number": 20973422,
+        "l1_fees": {
+            "blob_fee": 7422,
+            "base_fee": 15575959350
+        },
+        "parent_header": {
+            "excess_mana": 1316621909,
+            "mana_used": 94491057,
+            "proving_cost_per_mana_numerator": 0,
+            "fee_asset_price_numerator": 0
+        },
+        "header": {
+            "excess_mana": 1311112966,
+            "mana_used": 107964581,
+            "proving_cost_per_mana_numerator": 81072380,
+            "fee_asset_price_numerator": 56425732
+        },
+        "oracle_input": {
+            "proving_cost_modifier": 81072380,
+            "fee_asset_price_modifier": 56425732
+        },
+        "outputs": {
+            "fee_asset_price_at_execution": 10000000000,
+            "mana_base_fee_components_in_wei": {
+                "data_cost": 29,
+                "gas_cost": 51595365,
+                "proving_cost": 5415357955,
+                "congestion_cost": 19881650612,
+                "congestion_multiplier": 4636696592
+            },
+            "mana_base_fee_components_in_fee_asset": {
+                "data_cost": 290,
+                "gas_cost": 515953650,
+                "proving_cost": 54153579550,
+                "congestion_cost": 198816506120,
+                "congestion_multiplier": 4636696592
+            }
+        }
+    },
+    {
+        "l1_block_number": 20973425,
+        "l1_fees": {
+            "blob_fee": 7422,
+            "base_fee": 16430884636
+        },
+        "parent_header": {
+            "excess_mana": 1311112966,
+            "mana_used": 107964581,
+            "proving_cost_per_mana_numerator": 81072380,
+            "fee_asset_price_numerator": 56425732
+        },
+        "header": {
+            "excess_mana": 1319077547,
+            "mana_used": 100806765,
+            "proving_cost_per_mana_numerator": 0,
+            "fee_asset_price_numerator": 0
+        },
+        "oracle_input": {
+            "proving_cost_modifier": -218500226,
+            "fee_asset_price_modifier": -122148504
+        },
+        "outputs": {
+            "fee_asset_price_at_execution": 10005644165,
+            "mana_base_fee_components_in_wei": {
+                "data_cost": 29,
+                "gas_cost": 54427305,
+                "proving_cost": 5419750094,
+                "congestion_cost": 20145552480,
+                "congestion_multiplier": 4680105869
+            },
+            "mana_base_fee_components_in_fee_asset": {
+                "data_cost": 290,
+                "gas_cost": 544580246,
+                "proving_cost": 54228090903,
+                "congestion_cost": 201569229622,
+                "congestion_multiplier": 4680105869
+            }
+        }
+    },
+    {
+        "l1_block_number": 20973428,
+        "l1_fees": {
+            "blob_fee": 8028,
+            "base_fee": 16321037138
+        },
+        "parent_header": {
+            "excess_mana": 1319077547,
+            "mana_used": 100806765,
+            "proving_cost_per_mana_numerator": 0,
+            "fee_asset_price_numerator": 0
+        },
+        "header": {
+            "excess_mana": 1319884312,
+            "mana_used": 101075675,
+            "proving_cost_per_mana_numerator": 196535371,
+            "fee_asset_price_numerator": 0
+        },
+        "oracle_input": {
+            "proving_cost_modifier": 196535371,
+            "fee_asset_price_modifier": -861438231
+        },
+        "outputs": {
+            "fee_asset_price_at_execution": 10000000000,
+            "mana_base_fee_components_in_wei": {
+                "data_cost": 31,
+                "gas_cost": 54063435,
+                "proving_cost": 5415357955,
+                "congestion_cost": 20152223111,
+                "congestion_multiplier": 4684525576
+            },
+            "mana_base_fee_components_in_fee_asset": {
+                "data_cost": 310,
+                "gas_cost": 540634350,
+                "proving_cost": 54153579550,
+                "congestion_cost": 201522231110,
+                "congestion_multiplier": 4684525576
+            }
+        }
+    },
+    {
+        "l1_block_number": 20973431,
+        "l1_fees": {
+            "blob_fee": 9393,
+            "base_fee": 16122514868
+        },
+        "parent_header": {
+            "excess_mana": 1319884312,
+            "mana_used": 101075675,
+            "proving_cost_per_mana_numerator": 196535371,
+            "fee_asset_price_numerator": 0
+        },
+        "header": {
+            "excess_mana": 1320959987,
+            "mana_used": 100604576,
+            "proving_cost_per_mana_numerator": 210400315,
+            "fee_asset_price_numerator": 0
+        },
+        "oracle_input": {
+            "proving_cost_modifier": 13864944,
+            "fee_asset_price_modifier": -310116113
+        },
+        "outputs": {
+            "fee_asset_price_at_execution": 10000000000,
+            "mana_base_fee_components_in_wei": {
+                "data_cost": 36,
+                "gas_cost": 53405830,
+                "proving_cost": 5426011514,
+                "congestion_cost": 20221378610,
+                "congestion_multiplier": 4690424950
+            },
+            "mana_base_fee_components_in_fee_asset": {
+                "data_cost": 360,
+                "gas_cost": 534058300,
+                "proving_cost": 54260115140,
+                "congestion_cost": 202213786100,
+                "congestion_multiplier": 4690424950
+            }
+        }
+    },
+    {
+        "l1_block_number": 20973434,
+        "l1_fees": {
+            "blob_fee": 12365,
+            "base_fee": 16014219091
+        },
+        "parent_header": {
+            "excess_mana": 1320959987,
+            "mana_used": 100604576,
+            "proving_cost_per_mana_numerator": 210400315,
+            "fee_asset_price_numerator": 0
+        },
+        "header": {
+            "excess_mana": 1321564563,
+            "mana_used": 103203146,
+            "proving_cost_per_mana_numerator": 270784851,
+            "fee_asset_price_numerator": 184588769
+        },
+        "oracle_input": {
+            "proving_cost_modifier": 60384536,
+            "fee_asset_price_modifier": 184588769
+        },
+        "outputs": {
+            "fee_asset_price_at_execution": 10000000000,
+            "mana_base_fee_components_in_wei": {
+                "data_cost": 48,
+                "gas_cost": 53047100,
+                "proving_cost": 5426763880,
+                "congestion_cost": 20241018634,
+                "congestion_multiplier": 4693743914
+            },
+            "mana_base_fee_components_in_fee_asset": {
+                "data_cost": 480,
+                "gas_cost": 530471000,
+                "proving_cost": 54267638800,
+                "congestion_cost": 202410186340,
+                "congestion_multiplier": 4693743914
+            }
+        }
+    },
+    {
+        "l1_block_number": 20973437,
+        "l1_fees": {
+            "blob_fee": 10568,
+            "base_fee": 15999039375
+        },
+        "parent_header": {
+            "excess_mana": 1321564563,
+            "mana_used": 103203146,
+            "proving_cost_per_mana_numerator": 270784851,
+            "fee_asset_price_numerator": 184588769
+        },
+        "header": {
+            "excess_mana": 1324767709,
+            "mana_used": 103564808,
+            "proving_cost_per_mana_numerator": 148275372,
+            "fee_asset_price_numerator": 706703095
+        },
+        "oracle_input": {
+            "proving_cost_modifier": -122509479,
+            "fee_asset_price_modifier": 522114326
+        },
+        "outputs": {
+            "fee_asset_price_at_execution": 10018475923,
+            "mana_base_fee_components_in_wei": {
+                "data_cost": 41,
+                "gas_cost": 52996817,
+                "proving_cost": 5430041795,
+                "congestion_cost": 20349571847,
+                "congestion_multiplier": 4711367571
+            },
+            "mana_base_fee_components_in_fee_asset": {
+                "data_cost": 410,
+                "gas_cost": 530947335,
+                "proving_cost": 54400742984,
+                "congestion_cost": 203871695592,
+                "congestion_multiplier": 4711367571
+            }
+        }
+    },
+    {
+        "l1_block_number": 20973440,
+        "l1_fees": {
+            "blob_fee": 12365,
+            "base_fee": 15287943997
+        },
+        "parent_header": {
+            "excess_mana": 1324767709,
+            "mana_used": 103564808,
+            "proving_cost_per_mana_numerator": 148275372,
+            "fee_asset_price_numerator": 706703095
+        },
+        "header": {
+            "excess_mana": 1328332517,
+            "mana_used": 83509824,
+            "proving_cost_per_mana_numerator": 210001776,
+            "fee_asset_price_numerator": 1706703095
+        },
+        "oracle_input": {
+            "proving_cost_modifier": 61726404,
+            "fee_asset_price_modifier": 1000000000
+        },
+        "outputs": {
+            "fee_asset_price_at_execution": 10070920613,
+            "mana_base_fee_components_in_wei": {
+                "data_cost": 48,
+                "gas_cost": 50641314,
+                "proving_cost": 5423393553,
+                "congestion_cost": 20423946683,
+                "congestion_multiplier": 4731058899
+            },
+            "mana_base_fee_components_in_fee_asset": {
+                "data_cost": 483,
+                "gas_cost": 510004653,
+                "proving_cost": 54618565925,
+                "congestion_cost": 205687945648,
+                "congestion_multiplier": 4731058899
+            }
+        }
+    },
+    {
+        "l1_block_number": 20973443,
+        "l1_fees": {
+            "blob_fee": 11889,
+            "base_fee": 16054573592
+        },
+        "parent_header": {
+            "excess_mana": 1328332517,
+            "mana_used": 83509824,
+            "proving_cost_per_mana_numerator": 210001776,
+            "fee_asset_price_numerator": 1706703095
+        },
+        "header": {
+            "excess_mana": 1311842341,
+            "mana_used": 102290817,
+            "proving_cost_per_mana_numerator": 251023939,
+            "fee_asset_price_numerator": 931130184
+        },
+        "oracle_input": {
+            "proving_cost_modifier": 41022163,
+            "fee_asset_price_modifier": -775572911
+        },
+        "outputs": {
+            "fee_asset_price_at_execution": 10172135048,
+            "mana_base_fee_components_in_wei": {
+                "data_cost": 46,
+                "gas_cost": 53180775,
+                "proving_cost": 5426742252,
+                "congestion_cost": 19950509844,
+                "congestion_multiplier": 4640655093
+            },
+            "mana_base_fee_components_in_fee_asset": {
+                "data_cost": 467,
+                "gas_cost": 540962025,
+                "proving_cost": 55201555058,
+                "congestion_cost": 202939280409,
+                "congestion_multiplier": 4640655093
+            }
+        }
+    },
+    {
+        "l1_block_number": 20973446,
+        "l1_fees": {
+            "blob_fee": 13910,
+            "base_fee": 15218141837
+        },
+        "parent_header": {
+            "excess_mana": 1311842341,
+            "mana_used": 102290817,
+            "proving_cost_per_mana_numerator": 251023939,
+            "fee_asset_price_numerator": 931130184
+        },
+        "header": {
+            "excess_mana": 1314133158,
+            "mana_used": 65360376,
+            "proving_cost_per_mana_numerator": 398208983,
+            "fee_asset_price_numerator": 981642141
+        },
+        "oracle_input": {
+            "proving_cost_modifier": 147185044,
+            "fee_asset_price_modifier": 50511957
+        },
+        "outputs": {
+            "fee_asset_price_at_execution": 10093547868,
+            "mana_base_fee_components_in_wei": {
+                "data_cost": 54,
+                "gas_cost": 50410094,
+                "proving_cost": 5428968876,
+                "congestion_cost": 20016773868,
+                "congestion_multiplier": 4653109920
+            },
+            "mana_base_fee_components_in_fee_asset": {
+                "data_cost": 545,
+                "gas_cost": 508816696,
+                "proving_cost": 54797557223,
+                "congestion_cost": 202040265199,
+                "congestion_multiplier": 4653109920
+            }
+        }
+    },
+    {
+        "l1_block_number": 20973449,
+        "l1_fees": {
+            "blob_fee": 16276,
+            "base_fee": 13615000865
+        },
+        "parent_header": {
+            "excess_mana": 1314133158,
+            "mana_used": 65360376,
+            "proving_cost_per_mana_numerator": 398208983,
+            "fee_asset_price_numerator": 981642141
+        },
+        "header": {
+            "excess_mana": 1279493534,
+            "mana_used": 139029355,
+            "proving_cost_per_mana_numerator": 374671734,
+            "fee_asset_price_numerator": 931807111
+        },
+        "oracle_input": {
+            "proving_cost_modifier": -23537249,
+            "fee_asset_price_modifier": -49835030
+        },
+        "outputs": {
+            "fee_asset_price_at_execution": 10098647605,
+            "mana_base_fee_components_in_wei": {
+                "data_cost": 63,
+                "gas_cost": 45099690,
+                "proving_cost": 5436965389,
+                "congestion_cost": 19013432147,
+                "congestion_multiplier": 4468297376
+            },
+            "mana_base_fee_components_in_fee_asset": {
+                "data_cost": 636,
+                "gas_cost": 455445876,
+                "proving_cost": 54905997504,
+                "congestion_cost": 192009951014,
+                "congestion_multiplier": 4468297376
+            }
+        }
+    },
+    {
+        "l1_block_number": 20973452,
+        "l1_fees": {
+            "blob_fee": 12365,
+            "base_fee": 15419645270
+        },
+        "parent_header": {
+            "excess_mana": 1279493534,
+            "mana_used": 139029355,
+            "proving_cost_per_mana_numerator": 374671734,
+            "fee_asset_price_numerator": 931807111
+        },
+        "header": {
+            "excess_mana": 1318522889,
+            "mana_used": 111326678,
+            "proving_cost_per_mana_numerator": 418751286,
+            "fee_asset_price_numerator": 1920185324
+        },
+        "oracle_input": {
+            "proving_cost_modifier": 44079552,
+            "fee_asset_price_modifier": 988378213
+        },
+        "outputs": {
+            "fee_asset_price_at_execution": 10093616194,
+            "mana_base_fee_components_in_wei": {
+                "data_cost": 48,
+                "gas_cost": 51077574,
+                "proving_cost": 5435685828,
+                "congestion_cost": 20175211633,
+                "congestion_multiplier": 4677069700
+            },
+            "mana_base_fee_components_in_fee_asset": {
+                "data_cost": 484,
+                "gas_cost": 515557428,
+                "proving_cost": 54865726498,
+                "congestion_cost": 203640842856,
+                "congestion_multiplier": 4677069700
+            }
+        }
+    },
+    {
+        "l1_block_number": 20973455,
+        "l1_fees": {
+            "blob_fee": 11889,
+            "base_fee": 14609143504
+        },
+        "parent_header": {
+            "excess_mana": 1318522889,
+            "mana_used": 111326678,
+            "proving_cost_per_mana_numerator": 418751286,
+            "fee_asset_price_numerator": 1920185324
+        },
+        "header": {
+            "excess_mana": 1329849567,
+            "mana_used": 88606966,
+            "proving_cost_per_mana_numerator": 415078001,
+            "fee_asset_price_numerator": 1682521585
+        },
+        "oracle_input": {
+            "proving_cost_modifier": -3673285,
+            "fee_asset_price_modifier": -237663739
+        },
+        "outputs": {
+            "fee_asset_price_at_execution": 10193873944,
+            "mana_base_fee_components_in_wei": {
+                "data_cost": 46,
+                "gas_cost": 48392787,
+                "proving_cost": 5438082382,
+                "congestion_cost": 20516475132,
+                "congestion_multiplier": 4739463741
+            },
+            "mana_base_fee_components_in_fee_asset": {
+                "data_cost": 468,
+                "gas_cost": 493309970,
+                "proving_cost": 55435126299,
+                "congestion_cost": 209142361270,
+                "congestion_multiplier": 4739463741
+            }
+        }
+    },
+    {
+        "l1_block_number": 20973458,
+        "l1_fees": {
+            "blob_fee": 9770,
+            "base_fee": 15085608411
+        },
+        "parent_header": {
+            "excess_mana": 1329849567,
+            "mana_used": 88606966,
+            "proving_cost_per_mana_numerator": 415078001,
+            "fee_asset_price_numerator": 1682521585
+        },
+        "header": {
+            "excess_mana": 1318456533,
+            "mana_used": 102801105,
+            "proving_cost_per_mana_numerator": 429004476,
+            "fee_asset_price_numerator": 2444732238
+        },
+        "oracle_input": {
+            "proving_cost_modifier": 13926475,
+            "fee_asset_price_modifier": 762210653
+        },
+        "outputs": {
+            "fee_asset_price_at_execution": 10169675569,
+            "mana_base_fee_components_in_wei": {
+                "data_cost": 38,
+                "gas_cost": 49971077,
+                "proving_cost": 5437882629,
+                "congestion_cost": 20177228091,
+                "congestion_multiplier": 4676706602
+            },
+            "mana_base_fee_components_in_fee_asset": {
+                "data_cost": 386,
+                "gas_cost": 508189640,
+                "proving_cost": 55301502119,
+                "congestion_cost": 205195863567,
+                "congestion_multiplier": 4676706602
+            }
+        }
+    },
+    {
+        "l1_block_number": 20973461,
+        "l1_fees": {
+            "blob_fee": 11431,
+            "base_fee": 14312834898
+        },
+        "parent_header": {
+            "excess_mana": 1318456533,
+            "mana_used": 102801105,
+            "proving_cost_per_mana_numerator": 429004476,
+            "fee_asset_price_numerator": 2444732238
+        },
+        "header": {
+            "excess_mana": 1321257638,
+            "mana_used": 98200479,
+            "proving_cost_per_mana_numerator": 378149572,
+            "fee_asset_price_numerator": 2307269582
+        },
+        "oracle_input": {
+            "proving_cost_modifier": -50854904,
+            "fee_asset_price_modifier": -137462656
+        },
+        "outputs": {
+            "fee_asset_price_at_execution": 10247486083,
+            "mana_base_fee_components_in_wei": {
+                "data_cost": 44,
+                "gas_cost": 47411265,
+                "proving_cost": 5438639987,
+                "congestion_cost": 20254823317,
+                "congestion_multiplier": 4692058682
+            },
+            "mana_base_fee_components_in_fee_asset": {
+                "data_cost": 450,
+                "gas_cost": 485846278,
+                "proving_cost": 55732387577,
+                "congestion_cost": 207561020054,
+                "congestion_multiplier": 4692058682
+            }
+        }
+    },
+    {
+        "l1_block_number": 20973464,
+        "l1_fees": {
+            "blob_fee": 13375,
+            "base_fee": 14648933305
+        },
+        "parent_header": {
+            "excess_mana": 1321257638,
+            "mana_used": 98200479,
+            "proving_cost_per_mana_numerator": 378149572,
+            "fee_asset_price_numerator": 2307269582
+        },
+        "header": {
+            "excess_mana": 1319458117,
+            "mana_used": 111026869,
+            "proving_cost_per_mana_numerator": 466968694,
+            "fee_asset_price_numerator": 3297800050
+        },
+        "oracle_input": {
+            "proving_cost_modifier": 88819122,
+            "fee_asset_price_modifier": 990530468
+        },
+        "outputs": {
+            "fee_asset_price_at_execution": 10233409294,
+            "mana_base_fee_components_in_wei": {
+                "data_cost": 52,
+                "gas_cost": 48524591,
+                "proving_cost": 5435874875,
+                "congestion_cost": 20194602317,
+                "congestion_multiplier": 4682190229
+            },
+            "mana_base_fee_components_in_fee_asset": {
+                "data_cost": 532,
+                "gas_cost": 496572000,
+                "proving_cost": 55627532466,
+                "congestion_cost": 206659631039,
+                "congestion_multiplier": 4682190229
+            }
+        }
+    },
+    {
+        "l1_block_number": 20973467,
+        "l1_fees": {
+            "blob_fee": 12365,
+            "base_fee": 14460098285
+        },
+        "parent_header": {
+            "excess_mana": 1319458117,
+            "mana_used": 111026869,
+            "proving_cost_per_mana_numerator": 466968694,
+            "fee_asset_price_numerator": 3297800050
+        },
+        "header": {
+            "excess_mana": 1330484986,
+            "mana_used": 89014895,
+            "proving_cost_per_mana_numerator": 569856216,
+            "fee_asset_price_numerator": 3100410811
+        },
+        "oracle_input": {
+            "proving_cost_modifier": 102887522,
+            "fee_asset_price_modifier": -197389239
+        },
+        "outputs": {
+            "fee_asset_price_at_execution": 10335278018,
+            "mana_base_fee_components_in_wei": {
+                "data_cost": 48,
+                "gas_cost": 47899075,
+                "proving_cost": 5440705116,
+                "congestion_cost": 20543782871,
+                "congestion_multiplier": 4742988559
+            },
+            "mana_base_fee_components_in_fee_asset": {
+                "data_cost": 496,
+                "gas_cost": 495050256,
+                "proving_cost": 56231199987,
+                "congestion_cost": 212325707513,
+                "congestion_multiplier": 4742988559
+            }
+        }
+    },
+    {
+        "l1_block_number": 20973470,
+        "l1_fees": {
+            "blob_fee": 9393,
+            "base_fee": 13977736089
+        },
+        "parent_header": {
+            "excess_mana": 1330484986,
+            "mana_used": 89014895,
+            "proving_cost_per_mana_numerator": 569856216,
+            "fee_asset_price_numerator": 3100410811
+        },
+        "header": {
+            "excess_mana": 1319499881,
+            "mana_used": 86837462,
+            "proving_cost_per_mana_numerator": 400019914,
+            "fee_asset_price_numerator": 2376944353
+        },
+        "oracle_input": {
+            "proving_cost_modifier": -169836302,
+            "fee_asset_price_modifier": -723466458
+        },
+        "outputs": {
+            "fee_asset_price_at_execution": 10314897413,
+            "mana_base_fee_components_in_wei": {
+                "data_cost": 36,
+                "gas_cost": 46301250,
+                "proving_cost": 5446305804,
+                "congestion_cost": 20226080839,
+                "congestion_multiplier": 4682419024
+            },
+            "mana_base_fee_components_in_fee_asset": {
+                "data_cost": 371,
+                "gas_cost": 477592643,
+                "proving_cost": 56178085648,
+                "congestion_cost": 208629948921,
+                "congestion_multiplier": 4682419024
+            }
+        }
+    },
+    {
+        "l1_block_number": 20973473,
+        "l1_fees": {
+            "blob_fee": 10161,
+            "base_fee": 13453174678
+        },
+        "parent_header": {
+            "excess_mana": 1319499881,
+            "mana_used": 86837462,
+            "proving_cost_per_mana_numerator": 400019914,
+            "fee_asset_price_numerator": 2376944353
+        },
+        "header": {
+            "excess_mana": 1306337343,
+            "mana_used": 110299037,
+            "proving_cost_per_mana_numerator": 433582759,
+            "fee_asset_price_numerator": 2738803177
+        },
+        "oracle_input": {
+            "proving_cost_modifier": 33562845,
+            "fee_asset_price_modifier": 361858824
+        },
+        "outputs": {
+            "fee_asset_price_at_execution": 10240541883,
+            "mana_base_fee_components_in_wei": {
+                "data_cost": 39,
+                "gas_cost": 44563641,
+                "proving_cost": 5437063850,
+                "congestion_cost": 19793397213,
+                "congestion_multiplier": 4610861392
+            },
+            "mana_base_fee_components_in_fee_asset": {
+                "data_cost": 399,
+                "gas_cost": 456355832,
+                "proving_cost": 55678480076,
+                "congestion_cost": 202695113166,
+                "congestion_multiplier": 4610861392
+            }
+        }
+    },
+    {
+        "l1_block_number": 20973476,
+        "l1_fees": {
+            "blob_fee": 9032,
+            "base_fee": 13408774809
+        },
+        "parent_header": {
+            "excess_mana": 1306337343,
+            "mana_used": 110299037,
+            "proving_cost_per_mana_numerator": 433582759,
+            "fee_asset_price_numerator": 2738803177
+        },
+        "header": {
+            "excess_mana": 1316636380,
+            "mana_used": 103749155,
+            "proving_cost_per_mana_numerator": 508162696,
+            "fee_asset_price_numerator": 1738803177
+        },
+        "oracle_input": {
+            "proving_cost_modifier": 74579937,
+            "fee_asset_price_modifier": -1000000000
+        },
+        "outputs": {
+            "fee_asset_price_at_execution": 10277665314,
+            "mana_base_fee_components_in_wei": {
+                "data_cost": 35,
+                "gas_cost": 44416566,
+                "proving_cost": 5438888989,
+                "congestion_cost": 20105953448,
+                "congestion_multiplier": 4666757783
+            },
+            "mana_base_fee_components_in_fee_asset": {
+                "data_cost": 359,
+                "gas_cost": 456498599,
+                "proving_cost": 55899080708,
+                "congestion_cost": 206642260357,
+                "congestion_multiplier": 4666757783
+            }
+        }
+    },
+    {
+        "l1_block_number": 20973479,
+        "l1_fees": {
+            "blob_fee": 9032,
+            "base_fee": 12441369415
+        },
+        "parent_header": {
+            "excess_mana": 1316636380,
+            "mana_used": 103749155,
+            "proving_cost_per_mana_numerator": 508162696,
+            "fee_asset_price_numerator": 1738803177
+        },
+        "header": {
+            "excess_mana": 1320385535,
+            "mana_used": 95638144,
+            "proving_cost_per_mana_numerator": 427579520,
+            "fee_asset_price_numerator": 1939889114
+        },
+        "oracle_input": {
+            "proving_cost_modifier": -80583176,
+            "fee_asset_price_modifier": 201085937
+        },
+        "outputs": {
+            "fee_asset_price_at_execution": 10175400836,
+            "mana_base_fee_components_in_wei": {
+                "data_cost": 35,
+                "gas_cost": 41212036,
+                "proving_cost": 5442946822,
+                "congestion_cost": 20221593936,
+                "congestion_multiplier": 4687273533
+            },
+            "mana_base_fee_components_in_fee_asset": {
+                "data_cost": 356,
+                "gas_cost": 419348985,
+                "proving_cost": 55384165642,
+                "congestion_cost": 205762823841,
+                "congestion_multiplier": 4687273533
+            }
+        }
+    },
+    {
+        "l1_block_number": 20973482,
+        "l1_fees": {
+            "blob_fee": 8350,
+            "base_fee": 13666269945
+        },
+        "parent_header": {
+            "excess_mana": 1320385535,
+            "mana_used": 95638144,
+            "proving_cost_per_mana_numerator": 427579520,
+            "fee_asset_price_numerator": 1939889114
+        },
+        "header": {
+            "excess_mana": 1316023679,
+            "mana_used": 90637725,
+            "proving_cost_per_mana_numerator": 357292279,
+            "fee_asset_price_numerator": 1840626366
+        },
+        "oracle_input": {
+            "proving_cost_modifier": -70287241,
+            "fee_asset_price_modifier": -99262748
+        },
+        "outputs": {
+            "fee_asset_price_at_execution": 10195882722,
+            "mana_base_fee_components_in_wei": {
+                "data_cost": 32,
+                "gas_cost": 45269519,
+                "proving_cost": 5438562490,
+                "congestion_cost": 20089544709,
+                "congestion_multiplier": 4663413569
+            },
+            "mana_base_fee_components_in_fee_asset": {
+                "data_cost": 326,
+                "gas_cost": 461562706,
+                "proving_cost": 55450945324,
+                "congestion_cost": 204830641791,
+                "congestion_multiplier": 4663413569
+            }
+        }
+    },
+    {
+        "l1_block_number": 20973485,
+        "l1_fees": {
+            "blob_fee": 10991,
+            "base_fee": 14378775361
+        },
+        "parent_header": {
+            "excess_mana": 1316023679,
+            "mana_used": 90637725,
+            "proving_cost_per_mana_numerator": 357292279,
+            "fee_asset_price_numerator": 1840626366
+        },
+        "header": {
+            "excess_mana": 1306661404,
+            "mana_used": 122727699,
+            "proving_cost_per_mana_numerator": 551873296,
+            "fee_asset_price_numerator": 2609752577
+        },
+        "oracle_input": {
+            "proving_cost_modifier": 194581017,
+            "fee_asset_price_modifier": 769126211
+        },
+        "outputs": {
+            "fee_asset_price_at_execution": 10185767030,
+            "mana_base_fee_components_in_wei": {
+                "data_cost": 43,
+                "gas_cost": 47629693,
+                "proving_cost": 5434741217,
+                "congestion_cost": 19805667788,
+                "congestion_multiplier": 4612609938
+            },
+            "mana_base_fee_components_in_fee_asset": {
+                "data_cost": 437,
+                "gas_cost": 485144956,
+                "proving_cost": 55357007904,
+                "congestion_cost": 201735917962,
+                "congestion_multiplier": 4612609938
+            }
+        }
+    },
+    {
+        "l1_block_number": 20973488,
+        "l1_fees": {
+            "blob_fee": 9770,
+            "base_fee": 14272987887
+        },
+        "parent_header": {
+            "excess_mana": 1306661404,
+            "mana_used": 122727699,
+            "proving_cost_per_mana_numerator": 551873296,
+            "fee_asset_price_numerator": 2609752577
+        },
+        "header": {
+            "excess_mana": 1329389103,
+            "mana_used": 99727233,
+            "proving_cost_per_mana_numerator": 285835544,
+            "fee_asset_price_numerator": 3084375033
+        },
+        "oracle_input": {
+            "proving_cost_modifier": -266037752,
+            "fee_asset_price_modifier": 474622456
+        },
+        "outputs": {
+            "fee_asset_price_at_execution": 10264410480,
+            "mana_base_fee_components_in_wei": {
+                "data_cost": 38,
+                "gas_cost": 47279272,
+                "proving_cost": 5445326487,
+                "congestion_cost": 20525379444,
+                "congestion_multiplier": 4736911077
+            },
+            "mana_base_fee_components_in_fee_asset": {
+                "data_cost": 390,
+                "gas_cost": 485293855,
+                "proving_cost": 55893066260,
+                "congestion_cost": 210680919870,
+                "congestion_multiplier": 4736911077
+            }
+        }
+    },
+    {
+        "l1_block_number": 20973491,
+        "l1_fees": {
+            "blob_fee": 9393,
+            "base_fee": 14695176958
+        },
+        "parent_header": {
+            "excess_mana": 1329389103,
+            "mana_used": 99727233,
+            "proving_cost_per_mana_numerator": 285835544,
+            "fee_asset_price_numerator": 3084375033
+        },
+        "header": {
+            "excess_mana": 1329116336,
+            "mana_used": 82105056,
+            "proving_cost_per_mana_numerator": 412888248,
+            "fee_asset_price_numerator": 3116627095
+        },
+        "oracle_input": {
+            "proving_cost_modifier": 127052704,
+            "fee_asset_price_modifier": 32252062
+        },
+        "outputs": {
+            "fee_asset_price_at_execution": 10313243472,
+            "mana_base_fee_components_in_wei": {
+                "data_cost": 36,
+                "gas_cost": 48677773,
+                "proving_cost": 5430859116,
+                "congestion_cost": 20468259993,
+                "congestion_multiplier": 4735399592
+            },
+            "mana_base_fee_components_in_fee_asset": {
+                "data_cost": 371,
+                "gas_cost": 502025724,
+                "proving_cost": 56009772325,
+                "congestion_cost": 211094148756,
+                "congestion_multiplier": 4735399592
+            }
+        }
+    },
+    {
+        "l1_block_number": 20973494,
+        "l1_fees": {
+            "blob_fee": 12860,
+            "base_fee": 14320169685
+        },
+        "parent_header": {
+            "excess_mana": 1329116336,
+            "mana_used": 82105056,
+            "proving_cost_per_mana_numerator": 412888248,
+            "fee_asset_price_numerator": 3116627095
+        },
+        "header": {
+            "excess_mana": 1311221392,
+            "mana_used": 93681672,
+            "proving_cost_per_mana_numerator": 304560378,
+            "fee_asset_price_numerator": 3756345736
+        },
+        "oracle_input": {
+            "proving_cost_modifier": -108327870,
+            "fee_asset_price_modifier": 639718641
+        },
+        "outputs": {
+            "fee_asset_price_at_execution": 10316570242,
+            "mana_base_fee_components_in_wei": {
+                "data_cost": 50,
+                "gas_cost": 47435562,
+                "proving_cost": 5437763554,
+                "congestion_cost": 19951231737,
+                "congestion_multiplier": 4637284834
+            },
+            "mana_base_fee_components_in_fee_asset": {
+                "data_cost": 515,
+                "gas_cost": 489372307,
+                "proving_cost": 56099069664,
+                "congestion_cost": 205828283629,
+                "congestion_multiplier": 4637284834
+            }
+        }
+    },
+    {
+        "l1_block_number": 20973497,
+        "l1_fees": {
+            "blob_fee": 14467,
+            "base_fee": 14624476597
+        },
+        "parent_header": {
+            "excess_mana": 1311221392,
+            "mana_used": 93681672,
+            "proving_cost_per_mana_numerator": 304560378,
+            "fee_asset_price_numerator": 3756345736
+        },
+        "header": {
+            "excess_mana": 1304903064,
+            "mana_used": 109568285,
+            "proving_cost_per_mana_numerator": 292493513,
+            "fee_asset_price_numerator": 4217767568
+        },
+        "oracle_input": {
+            "proving_cost_modifier": -12066865,
+            "fee_asset_price_modifier": 461421832
+        },
+        "outputs": {
+            "fee_asset_price_at_execution": 10382778813,
+            "mana_base_fee_components_in_wei": {
+                "data_cost": 56,
+                "gas_cost": 48443578,
+                "proving_cost": 5431876130,
+                "congestion_cost": 19746306546,
+                "congestion_multiplier": 4603130364
+            },
+            "mana_base_fee_components_in_fee_asset": {
+                "data_cost": 581,
+                "gas_cost": 502978955,
+                "proving_cost": 56397968397,
+                "congestion_cost": 205021533240,
+                "congestion_multiplier": 4603130364
+            }
+        }
+    },
+    {
+        "l1_block_number": 20973500,
+        "l1_fees": {
+            "blob_fee": 16276,
+            "base_fee": 15231641377
+        },
+        "parent_header": {
+            "excess_mana": 1304903064,
+            "mana_used": 109568285,
+            "proving_cost_per_mana_numerator": 292493513,
+            "fee_asset_price_numerator": 4217767568
+        },
+        "header": {
+            "excess_mana": 1314471349,
+            "mana_used": 102110913,
+            "proving_cost_per_mana_numerator": 267362944,
+            "fee_asset_price_numerator": 4455082919
+        },
+        "oracle_input": {
+            "proving_cost_modifier": -25130569,
+            "fee_asset_price_modifier": 237315351
+        },
+        "outputs": {
+            "fee_asset_price_at_execution": 10430797921,
+            "mana_base_fee_components_in_wei": {
+                "data_cost": 63,
+                "gas_cost": 50454812,
+                "proving_cost": 5431220713,
+                "congestion_cost": 20035258100,
+                "congestion_multiplier": 4654951443
+            },
+            "mana_base_fee_components_in_fee_asset": {
+                "data_cost": 657,
+                "gas_cost": 526283948,
+                "proving_cost": 56651965721,
+                "congestion_cost": 208983728536,
+                "congestion_multiplier": 4654951443
+            }
+        }
+    },
+    {
+        "l1_block_number": 20973503,
+        "l1_fees": {
+            "blob_fee": 16276,
+            "base_fee": 13996481627
+        },
+        "parent_header": {
+            "excess_mana": 1314471349,
+            "mana_used": 102110913,
+            "proving_cost_per_mana_numerator": 267362944,
+            "fee_asset_price_numerator": 4455082919
+        },
+        "header": {
+            "excess_mana": 1316582262,
+            "mana_used": 110421352,
+            "proving_cost_per_mana_numerator": 453360181,
+            "fee_asset_price_numerator": 4592575600
+        },
+        "oracle_input": {
+            "proving_cost_modifier": 185997237,
+            "fee_asset_price_modifier": 137492681
+        },
+        "outputs": {
+            "fee_asset_price_at_execution": 10455581202,
+            "mana_base_fee_components_in_wei": {
+                "data_cost": 63,
+                "gas_cost": 46363345,
+                "proving_cost": 5429855988,
+                "congestion_cost": 20078351978,
+                "congestion_multiplier": 4666462303
+            },
+            "mana_base_fee_components_in_fee_asset": {
+                "data_cost": 658,
+                "gas_cost": 484755718,
+                "proving_cost": 56772300197,
+                "congestion_cost": 209930839508,
+                "congestion_multiplier": 4666462303
+            }
+        }
+    },
+    {
+        "l1_block_number": 20973506,
+        "l1_fees": {
+            "blob_fee": 13375,
+            "base_fee": 13706103465
+        },
+        "parent_header": {
+            "excess_mana": 1316582262,
+            "mana_used": 110421352,
+            "proving_cost_per_mana_numerator": 453360181,
+            "fee_asset_price_numerator": 4592575600
+        },
+        "header": {
+            "excess_mana": 1327003614,
+            "mana_used": 108194469,
+            "proving_cost_per_mana_numerator": 374375618,
+            "fee_asset_price_numerator": 5151371732
+        },
+        "oracle_input": {
+            "proving_cost_modifier": -78984563,
+            "fee_asset_price_modifier": 558796132
+        },
+        "outputs": {
+            "fee_asset_price_at_execution": 10469966748,
+            "mana_base_fee_components_in_wei": {
+                "data_cost": 52,
+                "gas_cost": 45401467,
+                "proving_cost": 5439964768,
+                "congestion_cost": 20425906088,
+                "congestion_multiplier": 4723708686
+            },
+            "mana_base_fee_components_in_fee_asset": {
+                "data_cost": 544,
+                "gas_cost": 475351849,
+                "proving_cost": 56956250231,
+                "congestion_cost": 213858557539,
+                "congestion_multiplier": 4723708686
+            }
+        }
+    },
+    {
+        "l1_block_number": 20973509,
+        "l1_fees": {
+            "blob_fee": 16928,
+            "base_fee": 15294708227
+        },
+        "parent_header": {
+            "excess_mana": 1327003614,
+            "mana_used": 108194469,
+            "proving_cost_per_mana_numerator": 374375618,
+            "fee_asset_price_numerator": 5151371732
+        },
+        "header": {
+            "excess_mana": 1335198083,
+            "mana_used": 92861766,
+            "proving_cost_per_mana_numerator": 195541519,
+            "fee_asset_price_numerator": 5340082778
+        },
+        "oracle_input": {
+            "proving_cost_modifier": -178834099,
+            "fee_asset_price_modifier": 188711046
+        },
+        "outputs": {
+            "fee_asset_price_at_execution": 10528636286,
+            "mana_base_fee_components_in_wei": {
+                "data_cost": 66,
+                "gas_cost": 50663721,
+                "proving_cost": 5435669732,
+                "congestion_cost": 20679171565,
+                "congestion_multiplier": 4769215177
+            },
+            "mana_base_fee_components_in_fee_asset": {
+                "data_cost": 694,
+                "gas_cost": 533419891,
+                "proving_cost": 57230189579,
+                "congestion_cost": 217723476103,
+                "congestion_multiplier": 4769215177
+            }
+        }
+    },
+    {
+        "l1_block_number": 20973512,
+        "l1_fees": {
+            "blob_fee": 11889,
+            "base_fee": 16431846806
+        },
+        "parent_header": {
+            "excess_mana": 1335198083,
+            "mana_used": 92861766,
+            "proving_cost_per_mana_numerator": 195541519,
+            "fee_asset_price_numerator": 5340082778
+        },
+        "header": {
+            "excess_mana": 1328059849,
+            "mana_used": 88389595,
+            "proving_cost_per_mana_numerator": 283776529,
+            "fee_asset_price_numerator": 6340082778
+        },
+        "oracle_input": {
+            "proving_cost_modifier": 88235010,
+            "fee_asset_price_modifier": 1000000000
+        },
+        "outputs": {
+            "fee_asset_price_at_execution": 10548523745,
+            "mana_base_fee_components_in_wei": {
+                "data_cost": 46,
+                "gas_cost": 54430492,
+                "proving_cost": 5425957588,
+                "congestion_cost": 20439380598,
+                "congestion_multiplier": 4729549829
+            },
+            "mana_base_fee_components_in_fee_asset": {
+                "data_cost": 485,
+                "gas_cost": 574161337,
+                "proving_cost": 57235842456,
+                "congestion_cost": 215605291571,
+                "congestion_multiplier": 4729549829
+            }
+        }
+    },
+    {
+        "l1_block_number": 20973515,
+        "l1_fees": {
+            "blob_fee": 12365,
+            "base_fee": 17477541478
+        },
+        "parent_header": {
+            "excess_mana": 1328059849,
+            "mana_used": 88389595,
+            "proving_cost_per_mana_numerator": 283776529,
+            "fee_asset_price_numerator": 6340082778
+        },
+        "header": {
+            "excess_mana": 1316449444,
+            "mana_used": 97332202,
+            "proving_cost_per_mana_numerator": 259044148,
+            "fee_asset_price_numerator": 7340082778
+        },
+        "oracle_input": {
+            "proving_cost_modifier": -24732381,
+            "fee_asset_price_modifier": 1000000000
+        },
+        "outputs": {
+            "fee_asset_price_at_execution": 10654538171,
+            "mana_base_fee_components_in_wei": {
+                "data_cost": 48,
+                "gas_cost": 57894356,
+                "proving_cost": 5430747295,
+                "congestion_cost": 20119918075,
+                "congestion_multiplier": 4665737204
+            },
+            "mana_base_fee_components_in_fee_asset": {
+                "data_cost": 511,
+                "gas_cost": 616837625,
+                "proving_cost": 57862104351,
+                "congestion_cost": 214368435127,
+                "congestion_multiplier": 4665737204
+            }
+        }
+    },
+    {
+        "l1_block_number": 20973518,
+        "l1_fees": {
+            "blob_fee": 13375,
+            "base_fee": 15978208780
+        },
+        "parent_header": {
+            "excess_mana": 1316449444,
+            "mana_used": 97332202,
+            "proving_cost_per_mana_numerator": 259044148,
+            "fee_asset_price_numerator": 7340082778
+        },
+        "header": {
+            "excess_mana": 1313781646,
+            "mana_used": 107383104,
+            "proving_cost_per_mana_numerator": 285050814,
+            "fee_asset_price_numerator": 6978325524
+        },
+        "oracle_input": {
+            "proving_cost_modifier": 26006666,
+            "fee_asset_price_modifier": -361757254
+        },
+        "outputs": {
+            "fee_asset_price_at_execution": 10761618060,
+            "mana_base_fee_components_in_wei": {
+                "data_cost": 52,
+                "gas_cost": 52927816,
+                "proving_cost": 5429404308,
+                "congestion_cost": 20017072781,
+                "congestion_multiplier": 4651196633
+            },
+            "mana_base_fee_components_in_fee_asset": {
+                "data_cost": 559,
+                "gas_cost": 569588940,
+                "proving_cost": 58429175456,
+                "congestion_cost": 215416091948,
+                "congestion_multiplier": 4651196633
+            }
+        }
+    },
+    {
+        "l1_block_number": 20973521,
+        "l1_fees": {
+            "blob_fee": 9393,
+            "base_fee": 15694997319
+        },
+        "parent_header": {
+            "excess_mana": 1313781646,
+            "mana_used": 107383104,
+            "proving_cost_per_mana_numerator": 285050814,
+            "fee_asset_price_numerator": 6978325524
+        },
+        "header": {
+            "excess_mana": 1321164750,
+            "mana_used": 99195845,
+            "proving_cost_per_mana_numerator": 356671899,
+            "fee_asset_price_numerator": 6942005273
+        },
+        "oracle_input": {
+            "proving_cost_modifier": 71621085,
+            "fee_asset_price_modifier": -36320251
+        },
+        "outputs": {
+            "fee_asset_price_at_execution": 10722757459,
+            "mana_base_fee_components_in_wei": {
+                "data_cost": 36,
+                "gas_cost": 51989678,
+                "proving_cost": 5430816498,
+                "congestion_cost": 20240046593,
+                "congestion_multiplier": 4691548782
+            },
+            "mana_base_fee_components_in_fee_asset": {
+                "data_cost": 386,
+                "gas_cost": 557472707,
+                "proving_cost": 58233328112,
+                "congestion_cost": 217029110575,
+                "congestion_multiplier": 4691548782
+            }
+        }
+    },
+    {
+        "l1_block_number": 20973524,
+        "l1_fees": {
+            "blob_fee": 9770,
+            "base_fee": 16114710895
+        },
+        "parent_header": {
+            "excess_mana": 1321164750,
+            "mana_used": 99195845,
+            "proving_cost_per_mana_numerator": 356671899,
+            "fee_asset_price_numerator": 6942005273
+        },
+        "header": {
+            "excess_mana": 1320360595,
+            "mana_used": 75773539,
+            "proving_cost_per_mana_numerator": 236578589,
+            "fee_asset_price_numerator": 7295623463
+        },
+        "oracle_input": {
+            "proving_cost_modifier": -120093310,
+            "fee_asset_price_modifier": 353618190
+        },
+        "outputs": {
+            "fee_asset_price_at_execution": 10718863633,
+            "mana_base_fee_components_in_wei": {
+                "data_cost": 38,
+                "gas_cost": 53379979,
+                "proving_cost": 5434707501,
+                "congestion_cost": 20235329235,
+                "congestion_multiplier": 4687136761
+            },
+            "mana_base_fee_components_in_fee_asset": {
+                "data_cost": 407,
+                "gas_cost": 572172715,
+                "proving_cost": 58253888588,
+                "congestion_cost": 216899734638,
+                "congestion_multiplier": 4687136761
+            }
+        }
+    },
+    {
+        "l1_block_number": 20973527,
+        "l1_fees": {
+            "blob_fee": 9032,
+            "base_fee": 15193310536
+        },
+        "parent_header": {
+            "excess_mana": 1320360595,
+            "mana_used": 75773539,
+            "proving_cost_per_mana_numerator": 236578589,
+            "fee_asset_price_numerator": 7295623463
+        },
+        "header": {
+            "excess_mana": 1296134134,
+            "mana_used": 118152636,
+            "proving_cost_per_mana_numerator": 155286419,
+            "fee_asset_price_numerator": 7974068845
+        },
+        "oracle_input": {
+            "proving_cost_modifier": -81292170,
+            "fee_asset_price_modifier": 678445382
+        },
+        "outputs": {
+            "fee_asset_price_at_execution": 10756834581,
+            "mana_base_fee_components_in_wei": {
+                "data_cost": 35,
+                "gas_cost": 50327841,
+                "proving_cost": 5428184699,
+                "congestion_cost": 19482386766,
+                "congestion_multiplier": 4556145304
+            },
+            "mana_base_fee_components_in_fee_asset": {
+                "data_cost": 376,
+                "gas_cost": 541368260,
+                "proving_cost": 58390084882,
+                "congestion_cost": 209568811684,
+                "congestion_multiplier": 4556145304
+            }
+        }
+    },
+    {
+        "l1_block_number": 20973530,
+        "l1_fees": {
+            "blob_fee": 8028,
+            "base_fee": 15696924869
+        },
+        "parent_header": {
+            "excess_mana": 1296134134,
+            "mana_used": 118152636,
+            "proving_cost_per_mana_numerator": 155286419,
+            "fee_asset_price_numerator": 7974068845
+        },
+        "header": {
+            "excess_mana": 1314286770,
+            "mana_used": 112950187,
+            "proving_cost_per_mana_numerator": 121267759,
+            "fee_asset_price_numerator": 8775829688
+        },
+        "oracle_input": {
+            "proving_cost_modifier": -34018660,
+            "fee_asset_price_modifier": 801760843
+        },
+        "outputs": {
+            "fee_asset_price_at_execution": 10830061952,
+            "mana_base_fee_components_in_wei": {
+                "data_cost": 31,
+                "gas_cost": 51996063,
+                "proving_cost": 5423773803,
+                "congestion_cost": 20008169045,
+                "congestion_multiplier": 4653946280
+            },
+            "mana_base_fee_components_in_fee_asset": {
+                "data_cost": 335,
+                "gas_cost": 563120583,
+                "proving_cost": 58739806300,
+                "congestion_cost": 216689710303,
+                "congestion_multiplier": 4653946280
+            }
+        }
+    },
+    {
+        "l1_block_number": 20973533,
+        "l1_fees": {
+            "blob_fee": 6861,
+            "base_fee": 17589348647
+        },
+        "parent_header": {
+            "excess_mana": 1314286770,
+            "mana_used": 112950187,
+            "proving_cost_per_mana_numerator": 121267759,
+            "fee_asset_price_numerator": 8775829688
+        },
+        "header": {
+            "excess_mana": 1327236957,
+            "mana_used": 86247445,
+            "proving_cost_per_mana_numerator": 156972445,
+            "fee_asset_price_numerator": 9300867729
+        },
+        "oracle_input": {
+            "proving_cost_modifier": 35704686,
+            "fee_asset_price_modifier": 525038041
+        },
+        "outputs": {
+            "fee_asset_price_at_execution": 10917242169,
+            "mana_base_fee_components_in_wei": {
+                "data_cost": 26,
+                "gas_cost": 58264717,
+                "proving_cost": 5421929021,
+                "congestion_cost": 20413713484,
+                "congestion_multiplier": 4724998488
+            },
+            "mana_base_fee_components_in_fee_asset": {
+                "data_cost": 283,
+                "gas_cost": 636090025,
+                "proving_cost": 59192512145,
+                "congestion_cost": 222861453673,
+                "congestion_multiplier": 4724998488
+            }
+        }
+    },
+    {
+        "l1_block_number": 20973536,
+        "l1_fees": {
+            "blob_fee": 7422,
+            "base_fee": 21124868019
+        },
+        "parent_header": {
+            "excess_mana": 1327236957,
+            "mana_used": 86247445,
+            "proving_cost_per_mana_numerator": 156972445,
+            "fee_asset_price_numerator": 9300867729
+        },
+        "header": {
+            "excess_mana": 1313484402,
+            "mana_used": 93046450,
+            "proving_cost_per_mana_numerator": 67913921,
+            "fee_asset_price_numerator": 9836646214
+        },
+        "oracle_input": {
+            "proving_cost_modifier": -89058524,
+            "fee_asset_price_modifier": 535778485
+        },
+        "outputs": {
+            "fee_asset_price_at_execution": 10974712583,
+            "mana_base_fee_components_in_wei": {
+                "data_cost": 29,
+                "gas_cost": 69976125,
+                "proving_cost": 5423865250,
+                "congestion_cost": 20050210096,
+                "congestion_multiplier": 4649579342
+            },
+            "mana_base_fee_components_in_fee_asset": {
+                "data_cost": 318,
+                "gas_cost": 767967859,
+                "proving_cost": 59525362207,
+                "congestion_cost": 220045293032,
+                "congestion_multiplier": 4649579342
+            }
+        }
+    },
+    {
+        "l1_block_number": 20973539,
+        "l1_fees": {
+            "blob_fee": 6597,
+            "base_fee": 20799423931
+        },
+        "parent_header": {
+            "excess_mana": 1313484402,
+            "mana_used": 93046450,
+            "proving_cost_per_mana_numerator": 67913921,
+            "fee_asset_price_numerator": 9836646214
+        },
+        "header": {
+            "excess_mana": 1306530852,
+            "mana_used": 111312010,
+            "proving_cost_per_mana_numerator": 0,
+            "fee_asset_price_numerator": 10091294188
+        },
+        "oracle_input": {
+            "proving_cost_modifier": -226866819,
+            "fee_asset_price_modifier": 254647974
+        },
+        "outputs": {
+            "fee_asset_price_at_execution": 11033670532,
+            "mana_base_fee_components_in_wei": {
+                "data_cost": 25,
+                "gas_cost": 68898091,
+                "proving_cost": 5419036986,
+                "congestion_cost": 19821902621,
+                "congestion_multiplier": 4611905435
+            },
+            "mana_base_fee_components_in_fee_asset": {
+                "data_cost": 275,
+                "gas_cost": 760198836,
+                "proving_cost": 59791868704,
+                "congestion_cost": 218708342837,
+                "congestion_multiplier": 4611905435
+            }
+        }
+    },
+    {
+        "l1_block_number": 20973542,
+        "l1_fees": {
+            "blob_fee": 5864,
+            "base_fee": 19793695587
+        },
+        "parent_header": {
+            "excess_mana": 1306530852,
+            "mana_used": 111312010,
+            "proving_cost_per_mana_numerator": 0,
+            "fee_asset_price_numerator": 10091294188
+        },
+        "header": {
+            "excess_mana": 1317842862,
+            "mana_used": 104587798,
+            "proving_cost_per_mana_numerator": 19892327,
+            "fee_asset_price_numerator": 10346274506
+        },
+        "oracle_input": {
+            "proving_cost_modifier": 19892327,
+            "fee_asset_price_modifier": 254980318
+        },
+        "outputs": {
+            "fee_asset_price_at_execution": 11061803355,
+            "mana_base_fee_components_in_wei": {
+                "data_cost": 23,
+                "gas_cost": 65566616,
+                "proving_cost": 5415357955,
+                "congestion_cost": 20133354110,
+                "congestion_multiplier": 4673349955
+            },
+            "mana_base_fee_components_in_fee_asset": {
+                "data_cost": 254,
+                "gas_cost": 725285012,
+                "proving_cost": 59903624795,
+                "congestion_cost": 222711204041,
+                "congestion_multiplier": 4673349955
+            }
+        }
+    },
+    {
+        "l1_block_number": 20973545,
+        "l1_fees": {
+            "blob_fee": 6597,
+            "base_fee": 20094986128
+        },
+        "parent_header": {
+            "excess_mana": 1317842862,
+            "mana_used": 104587798,
+            "proving_cost_per_mana_numerator": 19892327,
+            "fee_asset_price_numerator": 10346274506
+        },
+        "header": {
+            "excess_mana": 1322430660,
+            "mana_used": 104970014,
+            "proving_cost_per_mana_numerator": 32749244,
+            "fee_asset_price_numerator": 9864976938
+        },
+        "oracle_input": {
+            "proving_cost_modifier": 12856917,
+            "fee_asset_price_modifier": -481297568
+        },
+        "outputs": {
+            "fee_asset_price_at_execution": 11090044767,
+            "mana_base_fee_components_in_wei": {
+                "data_cost": 25,
+                "gas_cost": 66564641,
+                "proving_cost": 5416435302,
+                "congestion_cost": 20278889922,
+                "congestion_multiplier": 4698502652
+            },
+            "mana_base_fee_components_in_fee_asset": {
+                "data_cost": 277,
+                "gas_cost": 738204848,
+                "proving_cost": 60068509976,
+                "congestion_cost": 224893797060,
+                "congestion_multiplier": 4698502652
+            }
+        }
+    },
+    {
+        "l1_block_number": 20973548,
+        "l1_fees": {
+            "blob_fee": 9393,
+            "base_fee": 18609737244
+        },
+        "parent_header": {
+            "excess_mana": 1322430660,
+            "mana_used": 104970014,
+            "proving_cost_per_mana_numerator": 32749244,
+            "fee_asset_price_numerator": 9864976938
+        },
+        "header": {
+            "excess_mana": 1327400674,
+            "mana_used": 52607414,
+            "proving_cost_per_mana_numerator": 81068013,
+            "fee_asset_price_numerator": 9361738499
+        },
+        "oracle_input": {
+            "proving_cost_modifier": 48318769,
+            "fee_asset_price_modifier": -503238439
+        },
+        "outputs": {
+            "fee_asset_price_at_execution": 11036796894,
+            "mana_base_fee_components_in_wei": {
+                "data_cost": 36,
+                "gas_cost": 61644754,
+                "proving_cost": 5417131734,
+                "congestion_cost": 20413393404,
+                "congestion_multiplier": 4725903642
+            },
+            "mana_base_fee_components_in_fee_asset": {
+                "data_cost": 397,
+                "gas_cost": 680360629,
+                "proving_cost": 59787782696,
+                "congestion_cost": 225298476917,
+                "congestion_multiplier": 4725903642
+            }
+        }
+    },
+    {
+        "l1_block_number": 20973551,
+        "l1_fees": {
+            "blob_fee": 11889,
+            "base_fee": 18614276755
+        },
+        "parent_header": {
+            "excess_mana": 1327400674,
+            "mana_used": 52607414,
+            "proving_cost_per_mana_numerator": 81068013,
+            "fee_asset_price_numerator": 9361738499
+        },
+        "header": {
+            "excess_mana": 1280008088,
+            "mana_used": 127805778,
+            "proving_cost_per_mana_numerator": 0,
+            "fee_asset_price_numerator": 8901487473
+        },
+        "oracle_input": {
+            "proving_cost_modifier": -141528716,
+            "fee_asset_price_modifier": -460251026
+        },
+        "outputs": {
+            "fee_asset_price_at_execution": 10981395008,
+            "mana_base_fee_components_in_wei": {
+                "data_cost": 46,
+                "gas_cost": 61659791,
+                "proving_cost": 5419749858,
+                "congestion_cost": 19025908518,
+                "congestion_multiplier": 4470988227
+            },
+            "mana_base_fee_components_in_fee_asset": {
+                "data_cost": 505,
+                "gas_cost": 677110521,
+                "proving_cost": 59516414035,
+                "congestion_cost": 208931016822,
+                "congestion_multiplier": 4470988227
+            }
+        }
+    },
+    {
+        "l1_block_number": 20973554,
+        "l1_fees": {
+            "blob_fee": 10991,
+            "base_fee": 18020600851
+        },
+        "parent_header": {
+            "excess_mana": 1280008088,
+            "mana_used": 127805778,
+            "proving_cost_per_mana_numerator": 0,
+            "fee_asset_price_numerator": 8901487473
+        },
+        "header": {
+            "excess_mana": 1307813866,
+            "mana_used": 94149668,
+            "proving_cost_per_mana_numerator": 0,
+            "fee_asset_price_numerator": 8724451260
+        },
+        "oracle_input": {
+            "proving_cost_modifier": -63645948,
+            "fee_asset_price_modifier": -177036213
+        },
+        "outputs": {
+            "fee_asset_price_at_execution": 10930969157,
+            "mana_base_fee_components_in_wei": {
+                "data_cost": 43,
+                "gas_cost": 59693240,
+                "proving_cost": 5415357955,
+                "congestion_cost": 19813299852,
+                "congestion_multiplier": 4618833686
+            },
+            "mana_base_fee_components_in_fee_asset": {
+                "data_cost": 470,
+                "gas_cost": 652504965,
+                "proving_cost": 59195110780,
+                "congestion_cost": 216578569580,
+                "congestion_multiplier": 4618833686
+            }
+        }
+    },
+    {
+        "l1_block_number": 20973557,
+        "l1_fees": {
+            "blob_fee": 12365,
+            "base_fee": 18277826651
+        },
+        "parent_header": {
+            "excess_mana": 1307813866,
+            "mana_used": 94149668,
+            "proving_cost_per_mana_numerator": 0,
+            "fee_asset_price_numerator": 8724451260
+        },
+        "header": {
+            "excess_mana": 1301963534,
+            "mana_used": 99444246,
+            "proving_cost_per_mana_numerator": 60729549,
+            "fee_asset_price_numerator": 8166861291
+        },
+        "oracle_input": {
+            "proving_cost_modifier": 60729549,
+            "fee_asset_price_modifier": -557589969
+        },
+        "outputs": {
+            "fee_asset_price_at_execution": 10911634503,
+            "mana_base_fee_components_in_wei": {
+                "data_cost": 48,
+                "gas_cost": 60545300,
+                "proving_cost": 5415357955,
+                "congestion_cost": 19643851606,
+                "congestion_multiplier": 4587326240
+            },
+            "mana_base_fee_components_in_fee_asset": {
+                "data_cost": 523,
+                "gas_cost": 660648184,
+                "proving_cost": 59090406707,
+                "congestion_cost": 214346528955,
+                "congestion_multiplier": 4587326240
+            }
+        }
+    },
+    {
+        "l1_block_number": 20973560,
+        "l1_fees": {
+            "blob_fee": 17605,
+            "base_fee": 17939510902
+        },
+        "parent_header": {
+            "excess_mana": 1301963534,
+            "mana_used": 99444246,
+            "proving_cost_per_mana_numerator": 60729549,
+            "fee_asset_price_numerator": 8166861291
+        },
+        "header": {
+            "excess_mana": 1301407780,
+            "mana_used": 116843419,
+            "proving_cost_per_mana_numerator": 0,
+            "fee_asset_price_numerator": 8056731716
+        },
+        "oracle_input": {
+            "proving_cost_modifier": -133462995,
+            "fee_asset_price_modifier": -110129575
+        },
+        "outputs": {
+            "fee_asset_price_at_execution": 10850961633,
+            "mana_base_fee_components_in_wei": {
+                "data_cost": 69,
+                "gas_cost": 59424629,
+                "proving_cost": 5418647676,
+                "congestion_cost": 19635297943,
+                "congestion_multiplier": 4584344383
+            },
+            "mana_base_fee_components_in_fee_asset": {
+                "data_cost": 748,
+                "gas_cost": 644814369,
+                "proving_cost": 58797538035,
+                "congestion_cost": 213061864632,
+                "congestion_multiplier": 4584344383
+            }
+        }
+    },
+    {
+        "l1_block_number": 20973563,
+        "l1_fees": {
+            "blob_fee": 19806,
+            "base_fee": 17915455837
+        },
+        "parent_header": {
+            "excess_mana": 1301407780,
+            "mana_used": 116843419,
+            "proving_cost_per_mana_numerator": 0,
+            "fee_asset_price_numerator": 8056731716
+        },
+        "header": {
+            "excess_mana": 1318251199,
+            "mana_used": 106156025,
+            "proving_cost_per_mana_numerator": 0,
+            "fee_asset_price_numerator": 7883590148
+        },
+        "oracle_input": {
+            "proving_cost_modifier": -98037428,
+            "fee_asset_price_modifier": -173141568
+        },
+        "outputs": {
+            "fee_asset_price_at_execution": 10839018093,
+            "mana_base_fee_components_in_wei": {
+                "data_cost": 77,
+                "gas_cost": 59344947,
+                "proving_cost": 5415357955,
+                "congestion_cost": 20122726305,
+                "congestion_multiplier": 4675583202
+            },
+            "mana_base_fee_components_in_fee_asset": {
+                "data_cost": 834,
+                "gas_cost": 643240954,
+                "proving_cost": 58697162854,
+                "congestion_cost": 218110594500,
+                "congestion_multiplier": 4675583202
+            }
+        }
+    },
+    {
+        "l1_block_number": 20973566,
+        "l1_fees": {
+            "blob_fee": 16276,
+            "base_fee": 17059822050
+        },
+        "parent_header": {
+            "excess_mana": 1318251199,
+            "mana_used": 106156025,
+            "proving_cost_per_mana_numerator": 0,
+            "fee_asset_price_numerator": 7883590148
+        },
+        "header": {
+            "excess_mana": 1324407224,
+            "mana_used": 91163155,
+            "proving_cost_per_mana_numerator": 0,
+            "fee_asset_price_numerator": 7801958587
+        },
+        "oracle_input": {
+            "proving_cost_modifier": -13958851,
+            "fee_asset_price_modifier": -81631561
+        },
+        "outputs": {
+            "fee_asset_price_at_execution": 10820267485,
+            "mana_base_fee_components_in_wei": {
+                "data_cost": 63,
+                "gas_cost": 56510660,
+                "proving_cost": 5415357955,
+                "congestion_cost": 20297245101,
+                "congestion_multiplier": 4709380889
+            },
+            "mana_base_fee_components_in_fee_asset": {
+                "data_cost": 681,
+                "gas_cost": 611460456,
+                "proving_cost": 58595621600,
+                "congestion_cost": 219621621201,
+                "congestion_multiplier": 4709380889
+            }
+        }
+    },
+    {
+        "l1_block_number": 20973569,
+        "l1_fees": {
+            "blob_fee": 19806,
+            "base_fee": 16555278446
+        },
+        "parent_header": {
+            "excess_mana": 1324407224,
+            "mana_used": 91163155,
+            "proving_cost_per_mana_numerator": 0,
+            "fee_asset_price_numerator": 7801958587
+        },
+        "header": {
+            "excess_mana": 1315570379,
+            "mana_used": 110308203,
+            "proving_cost_per_mana_numerator": 77408002,
+            "fee_asset_price_numerator": 7466434184
+        },
+        "oracle_input": {
+            "proving_cost_modifier": 77408002,
+            "fee_asset_price_modifier": -335524403
+        },
+        "outputs": {
+            "fee_asset_price_at_execution": 10811438336,
+            "mana_base_fee_components_in_wei": {
+                "data_cost": 77,
+                "gas_cost": 54839359,
+                "proving_cost": 5415357955,
+                "congestion_cost": 20026069534,
+                "congestion_multiplier": 4660940932
+            },
+            "mana_base_fee_components_in_fee_asset": {
+                "data_cost": 832,
+                "gas_cost": 592892348,
+                "proving_cost": 58547808597,
+                "congestion_cost": 216510615879,
+                "congestion_multiplier": 4660940932
+            }
+        }
+    },
+    {
+        "l1_block_number": 20973572,
+        "l1_fees": {
+            "blob_fee": 20599,
+            "base_fee": 16295282001
+        },
+        "parent_header": {
+            "excess_mana": 1315570379,
+            "mana_used": 110308203,
+            "proving_cost_per_mana_numerator": 77408002,
+            "fee_asset_price_numerator": 7466434184
+        },
+        "header": {
+            "excess_mana": 1325878582,
+            "mana_used": 110082615,
+            "proving_cost_per_mana_numerator": 0,
+            "fee_asset_price_numerator": 7232729626
+        },
+        "oracle_input": {
+            "proving_cost_modifier": -205859688,
+            "fee_asset_price_modifier": -233704558
+        },
+        "outputs": {
+            "fee_asset_price_at_execution": 10775224109,
+            "mana_base_fee_components_in_wei": {
+                "data_cost": 80,
+                "gas_cost": 53978121,
+                "proving_cost": 5419551498,
+                "congestion_cost": 20347819386,
+                "congestion_multiplier": 4717495018
+            },
+            "mana_base_fee_components_in_fee_asset": {
+                "data_cost": 862,
+                "gas_cost": 581626350,
+                "proving_cost": 58396881961,
+                "congestion_cost": 219252314013,
+                "congestion_multiplier": 4717495018
+            }
+        }
+    },
+    {
+        "l1_block_number": 20973575,
+        "l1_fees": {
+            "blob_fee": 23174,
+            "base_fee": 15308679642
+        },
+        "parent_header": {
+            "excess_mana": 1325878582,
+            "mana_used": 110082615,
+            "proving_cost_per_mana_numerator": 0,
+            "fee_asset_price_numerator": 7232729626
+        },
+        "header": {
+            "excess_mana": 1335961197,
+            "mana_used": 105815738,
+            "proving_cost_per_mana_numerator": 0,
+            "fee_asset_price_numerator": 6254996440
+        },
+        "oracle_input": {
+            "proving_cost_modifier": -84442481,
+            "fee_asset_price_modifier": -977733186
+        },
+        "outputs": {
+            "fee_asset_price_at_execution": 10750071323,
+            "mana_base_fee_components_in_wei": {
+                "data_cost": 91,
+                "gas_cost": 50710001,
+                "proving_cost": 5415357955,
+                "congestion_cost": 20626072440,
+                "congestion_multiplier": 4773475241
+            },
+            "mana_base_fee_components_in_fee_asset": {
+                "data_cost": 978,
+                "gas_cost": 545136127,
+                "proving_cost": 58215484255,
+                "congestion_cost": 221731749843,
+                "congestion_multiplier": 4773475241
+            }
+        }
+    },
+    {
+        "l1_block_number": 20973578,
+        "l1_fees": {
+            "blob_fee": 23174,
+            "base_fee": 15069272311
+        },
+        "parent_header": {
+            "excess_mana": 1335961197,
+            "mana_used": 105815738,
+            "proving_cost_per_mana_numerator": 0,
+            "fee_asset_price_numerator": 6254996440
+        },
+        "header": {
+            "excess_mana": 1341776935,
+            "mana_used": 95248719,
+            "proving_cost_per_mana_numerator": 40498148,
+            "fee_asset_price_numerator": 6365721613
+        },
+        "oracle_input": {
+            "proving_cost_modifier": 40498148,
+            "fee_asset_price_modifier": 110725173
+        },
+        "outputs": {
+            "fee_asset_price_at_execution": 10645476470,
+            "mana_base_fee_components_in_wei": {
+                "data_cost": 91,
+                "gas_cost": 49916964,
+                "proving_cost": 5415357955,
+                "congestion_cost": 20801201205,
+                "congestion_multiplier": 4806066697
+            },
+            "mana_base_fee_components_in_fee_asset": {
+                "data_cost": 968,
+                "gas_cost": 531389865,
+                "proving_cost": 57649065686,
+                "congestion_cost": 221438697975,
+                "congestion_multiplier": 4806066697
+            }
+        }
+    },
+    {
+        "l1_block_number": 20973581,
+        "l1_fees": {
+            "blob_fee": 23174,
+            "base_fee": 15303102977
+        },
+        "parent_header": {
+            "excess_mana": 1341776935,
+            "mana_used": 95248719,
+            "proving_cost_per_mana_numerator": 40498148,
+            "fee_asset_price_numerator": 6365721613
+        },
+        "header": {
+            "excess_mana": 1337025654,
+            "mana_used": 90408891,
+            "proving_cost_per_mana_numerator": 0,
+            "fee_asset_price_numerator": 6906882271
+        },
+        "oracle_input": {
+            "proving_cost_modifier": -69662332,
+            "fee_asset_price_modifier": 541160658
+        },
+        "outputs": {
+            "fee_asset_price_at_execution": 10657270221,
+            "mana_base_fee_components_in_wei": {
+                "data_cost": 91,
+                "gas_cost": 50691528,
+                "proving_cost": 5417551518,
+                "congestion_cost": 20666808808,
+                "congestion_multiplier": 4779423901
+            },
+            "mana_base_fee_components_in_fee_asset": {
+                "data_cost": 969,
+                "gas_cost": 540233311,
+                "proving_cost": 57736310463,
+                "congestion_cost": 220251766072,
+                "congestion_multiplier": 4779423901
+            }
+        }
+    },
+    {
+        "l1_block_number": 20973584,
+        "l1_fees": {
+            "blob_fee": 20599,
+            "base_fee": 15137821864
+        },
+        "parent_header": {
+            "excess_mana": 1337025654,
+            "mana_used": 90408891,
+            "proving_cost_per_mana_numerator": 0,
+            "fee_asset_price_numerator": 6906882271
+        },
+        "header": {
+            "excess_mana": 1327434545,
+            "mana_used": 95066489,
+            "proving_cost_per_mana_numerator": 0,
+            "fee_asset_price_numerator": 6335884269
+        },
+        "oracle_input": {
+            "proving_cost_modifier": -141635049,
+            "fee_asset_price_modifier": -570998002
+        },
+        "outputs": {
+            "fee_asset_price_at_execution": 10715099508,
+            "mana_base_fee_components_in_wei": {
+                "data_cost": 80,
+                "gas_cost": 50144034,
+                "proving_cost": 5415357955,
+                "congestion_cost": 20364957681,
+                "congestion_multiplier": 4726090929
+            },
+            "mana_base_fee_components_in_fee_asset": {
+                "data_cost": 857,
+                "gas_cost": 537298314,
+                "proving_cost": 58026099359,
+                "congestion_cost": 218212548028,
+                "congestion_multiplier": 4726090929
+            }
+        }
+    },
+    {
+        "l1_block_number": 20973587,
+        "l1_fees": {
+            "blob_fee": 23174,
+            "base_fee": 15472115815
+        },
+        "parent_header": {
+            "excess_mana": 1327434545,
+            "mana_used": 95066489,
+            "proving_cost_per_mana_numerator": 0,
+            "fee_asset_price_numerator": 6335884269
+        },
+        "header": {
+            "excess_mana": 1322501034,
+            "mana_used": 106900881,
+            "proving_cost_per_mana_numerator": 0,
+            "fee_asset_price_numerator": 5626654198
+        },
+        "oracle_input": {
+            "proving_cost_modifier": -38760060,
+            "fee_asset_price_modifier": -709230071
+        },
+        "outputs": {
+            "fee_asset_price_at_execution": 10654090849,
+            "mana_base_fee_components_in_wei": {
+                "data_cost": 91,
+                "gas_cost": 51251383,
+                "proving_cost": 5415357955,
+                "congestion_cost": 20220384392,
+                "congestion_multiplier": 4698889532
+            },
+            "mana_base_fee_components_in_fee_asset": {
+                "data_cost": 969,
+                "gas_cost": 546036890,
+                "proving_cost": 57695715632,
+                "congestion_cost": 215429812314,
+                "congestion_multiplier": 4698889532
+            }
+        }
+    },
+    {
+        "l1_block_number": 20973590,
+        "l1_fees": {
+            "blob_fee": 19806,
+            "base_fee": 16177942905
+        },
+        "parent_header": {
+            "excess_mana": 1322501034,
+            "mana_used": 106900881,
+            "proving_cost_per_mana_numerator": 0,
+            "fee_asset_price_numerator": 5626654198
+        },
+        "header": {
+            "excess_mana": 1329401915,
+            "mana_used": 100313077,
+            "proving_cost_per_mana_numerator": 57773876,
+            "fee_asset_price_numerator": 5720592720
+        },
+        "oracle_input": {
+            "proving_cost_modifier": 57773876,
+            "fee_asset_price_modifier": 93938522
+        },
+        "outputs": {
+            "fee_asset_price_at_execution": 10578796154,
+            "mana_base_fee_components_in_wei": {
+                "data_cost": 77,
+                "gas_cost": 53589435,
+                "proving_cost": 5415357955,
+                "congestion_cost": 20437358702,
+                "congestion_multiplier": 4736982084
+            },
+            "mana_base_fee_components_in_fee_asset": {
+                "data_cost": 814,
+                "gas_cost": 566911708,
+                "proving_cost": 57287967906,
+                "congestion_cost": 216202651634,
+                "congestion_multiplier": 4736982084
+            }
+        }
+    },
+    {
+        "l1_block_number": 20973593,
+        "l1_fees": {
+            "blob_fee": 17605,
+            "base_fee": 15631978451
+        },
+        "parent_header": {
+            "excess_mana": 1329401915,
+            "mana_used": 100313077,
+            "proving_cost_per_mana_numerator": 57773876,
+            "fee_asset_price_numerator": 5720592720
+        },
+        "header": {
+            "excess_mana": 1329714992,
+            "mana_used": 84502427,
+            "proving_cost_per_mana_numerator": 0,
+            "fee_asset_price_numerator": 5666336427
+        },
+        "oracle_input": {
+            "proving_cost_modifier": -101826303,
+            "fee_asset_price_modifier": -54256293
+        },
+        "outputs": {
+            "fee_asset_price_at_execution": 10588738388,
+            "mana_base_fee_components_in_wei": {
+                "data_cost": 69,
+                "gas_cost": 51780928,
+                "proving_cost": 5418487521,
+                "congestion_cost": 20451788955,
+                "congestion_multiplier": 4738717558
+            },
+            "mana_base_fee_components_in_fee_asset": {
+                "data_cost": 730,
+                "gas_cost": 548294700,
+                "proving_cost": 57374946818,
+                "congestion_cost": 216558642811,
+                "congestion_multiplier": 4738717558
+            }
+        }
+    },
+    {
+        "l1_block_number": 20973596,
+        "l1_fees": {
+            "blob_fee": 14467,
+            "base_fee": 14200105654
+        },
+        "parent_header": {
+            "excess_mana": 1329714992,
+            "mana_used": 84502427,
+            "proving_cost_per_mana_numerator": 0,
+            "fee_asset_price_numerator": 5666336427
+        },
+        "header": {
+            "excess_mana": 1314217419,
+            "mana_used": 111946924,
+            "proving_cost_per_mana_numerator": 92058319,
+            "fee_asset_price_numerator": 5034697877
+        },
+        "oracle_input": {
+            "proving_cost_modifier": 92058319,
+            "fee_asset_price_modifier": -631638550
+        },
+        "outputs": {
+            "fee_asset_price_at_execution": 10582994890,
+            "mana_base_fee_components_in_wei": {
+                "data_cost": 56,
+                "gas_cost": 47037849,
+                "proving_cost": 5415357955,
+                "congestion_cost": 19957238382,
+                "congestion_multiplier": 4653568671
+            },
+            "mana_base_fee_components_in_fee_asset": {
+                "data_cost": 592,
+                "gas_cost": 497801315,
+                "proving_cost": 57310705565,
+                "congestion_cost": 211207351815,
+                "congestion_multiplier": 4653568671
+            }
+        }
+    },
+    {
+        "l1_block_number": 20973599,
+        "l1_fees": {
+            "blob_fee": 19806,
+            "base_fee": 13624273988
+        },
+        "parent_header": {
+            "excess_mana": 1314217419,
+            "mana_used": 111946924,
+            "proving_cost_per_mana_numerator": 92058319,
+            "fee_asset_price_numerator": 5034697877
+        },
+        "header": {
+            "excess_mana": 1326164343,
+            "mana_used": 90155196,
+            "proving_cost_per_mana_numerator": 95464087,
+            "fee_asset_price_numerator": 5794889457
+        },
+        "oracle_input": {
+            "proving_cost_modifier": 3405768,
+            "fee_asset_price_modifier": 760191580
+        },
+        "outputs": {
+            "fee_asset_price_at_execution": 10516359284,
+            "mana_base_fee_components_in_wei": {
+                "data_cost": 77,
+                "gas_cost": 45130407,
+                "proving_cost": 5420345537,
+                "congestion_cost": 20326501733,
+                "congestion_multiplier": 4719072530
+            },
+            "mana_base_fee_components_in_fee_asset": {
+                "data_cost": 809,
+                "gas_cost": 474607574,
+                "proving_cost": 57002301110,
+                "congestion_cost": 213760795211,
+                "congestion_multiplier": 4719072530
+            }
+        }
+    },
+    {
+        "l1_block_number": 20973602,
+        "l1_fees": {
+            "blob_fee": 21424,
+            "base_fee": 14061825642
+        },
+        "parent_header": {
+            "excess_mana": 1326164343,
+            "mana_used": 90155196,
+            "proving_cost_per_mana_numerator": 95464087,
+            "fee_asset_price_numerator": 5794889457
+        },
+        "header": {
+            "excess_mana": 1316319539,
+            "mana_used": 101203237,
+            "proving_cost_per_mana_numerator": 65367598,
+            "fee_asset_price_numerator": 6106040447
+        },
+        "oracle_input": {
+            "proving_cost_modifier": -30096489,
+            "fee_asset_price_modifier": 311150990
+        },
+        "outputs": {
+            "fee_asset_price_at_execution": 10596608399,
+            "mana_base_fee_components_in_wei": {
+                "data_cost": 84,
+                "gas_cost": 46579797,
+                "proving_cost": 5420530145,
+                "congestion_cost": 20037111969,
+                "congestion_multiplier": 4665028118
+            },
+            "mana_base_fee_components_in_fee_asset": {
+                "data_cost": 890,
+                "gas_cost": 493587868,
+                "proving_cost": 57439235261,
+                "congestion_cost": 212325428982,
+                "congestion_multiplier": 4665028118
+            }
+        }
+    },
+    {
+        "l1_block_number": 20973605,
+        "l1_fees": {
+            "blob_fee": 16928,
+            "base_fee": 14532060269
+        },
+        "parent_header": {
+            "excess_mana": 1316319539,
+            "mana_used": 101203237,
+            "proving_cost_per_mana_numerator": 65367598,
+            "fee_asset_price_numerator": 6106040447
+        },
+        "header": {
+            "excess_mana": 1317522776,
+            "mana_used": 91749672,
+            "proving_cost_per_mana_numerator": 0,
+            "fee_asset_price_numerator": 6443912293
+        },
+        "oracle_input": {
+            "proving_cost_modifier": -82937069,
+            "fee_asset_price_modifier": 337871846
+        },
+        "outputs": {
+            "fee_asset_price_at_execution": 10629631199,
+            "mana_base_fee_components_in_wei": {
+                "data_cost": 66,
+                "gas_cost": 48137449,
+                "proving_cost": 5418899001,
+                "congestion_cost": 20072771878,
+                "congestion_multiplier": 4671600111
+            },
+            "mana_base_fee_components_in_fee_asset": {
+                "data_cost": 701,
+                "gas_cost": 511683329,
+                "proving_cost": 57600897885,
+                "congestion_cost": 213366162204,
+                "congestion_multiplier": 4671600111
+            }
+        }
+    },
+    {
+        "l1_block_number": 20973608,
+        "l1_fees": {
+            "blob_fee": 17605,
+            "base_fee": 14271585742
+        },
+        "parent_header": {
+            "excess_mana": 1317522776,
+            "mana_used": 91749672,
+            "proving_cost_per_mana_numerator": 0,
+            "fee_asset_price_numerator": 6443912293
+        },
+        "header": {
+            "excess_mana": 1309272448,
+            "mana_used": 112543125,
+            "proving_cost_per_mana_numerator": 0,
+            "fee_asset_price_numerator": 6440084946
+        },
+        "oracle_input": {
+            "proving_cost_modifier": -150216996,
+            "fee_asset_price_modifier": -3827347
+        },
+        "outputs": {
+            "fee_asset_price_at_execution": 10665606471,
+            "mana_base_fee_components_in_wei": {
+                "data_cost": 69,
+                "gas_cost": 47274627,
+                "proving_cost": 5415357955,
+                "congestion_cost": 19811453536,
+                "congestion_multiplier": 4626722645
+            },
+            "mana_base_fee_components_in_fee_asset": {
+                "data_cost": 735,
+                "gas_cost": 504212567,
+                "proving_cost": 57758076847,
+                "congestion_cost": 211301167033,
+                "congestion_multiplier": 4626722645
+            }
+        }
+    },
+    {
+        "l1_block_number": 20973611,
+        "l1_fees": {
+            "blob_fee": 20599,
+            "base_fee": 14166674563
+        },
+        "parent_header": {
+            "excess_mana": 1309272448,
+            "mana_used": 112543125,
+            "proving_cost_per_mana_numerator": 0,
+            "fee_asset_price_numerator": 6440084946
+        },
+        "header": {
+            "excess_mana": 1321815573,
+            "mana_used": 99544210,
+            "proving_cost_per_mana_numerator": 34927497,
+            "fee_asset_price_numerator": 5702092437
+        },
+        "oracle_input": {
+            "proving_cost_modifier": 34927497,
+            "fee_asset_price_modifier": -737992509
+        },
+        "outputs": {
+            "fee_asset_price_at_execution": 10665198269,
+            "mana_base_fee_components_in_wei": {
+                "data_cost": 80,
+                "gas_cost": 46927109,
+                "proving_cost": 5415357955,
+                "congestion_cost": 20183813190,
+                "congestion_multiplier": 4695122583
+            },
+            "mana_base_fee_components_in_fee_asset": {
+                "data_cost": 853,
+                "gas_cost": 500486921,
+                "proving_cost": 57755866287,
+                "congestion_cost": 215264369495,
+                "congestion_multiplier": 4695122583
+            }
+        }
+    },
+    {
+        "l1_block_number": 20973614,
+        "l1_fees": {
+            "blob_fee": 23174,
+            "base_fee": 13909087252
+        },
+        "parent_header": {
+            "excess_mana": 1321815573,
+            "mana_used": 99544210,
+            "proving_cost_per_mana_numerator": 34927497,
+            "fee_asset_price_numerator": 5702092437
+        },
+        "header": {
+            "excess_mana": 1321359783,
+            "mana_used": 83475620,
+            "proving_cost_per_mana_numerator": 0,
+            "fee_asset_price_numerator": 4840039687
+        },
+        "oracle_input": {
+            "proving_cost_modifier": -179338485,
+            "fee_asset_price_modifier": -862052750
+        },
+        "outputs": {
+            "fee_asset_price_at_execution": 10586779623,
+            "mana_base_fee_components_in_wei": {
+                "data_cost": 91,
+                "gas_cost": 46073851,
+                "proving_cost": 5417249734,
+                "congestion_cost": 20173975333,
+                "congestion_multiplier": 4692619462
+            },
+            "mana_base_fee_components_in_fee_asset": {
+                "data_cost": 963,
+                "gas_cost": 487773706,
+                "proving_cost": 57351229096,
+                "congestion_cost": 213577430970,
+                "congestion_multiplier": 4692619462
+            }
+        }
+    },
+    {
+        "l1_block_number": 20973617,
+        "l1_fees": {
+            "blob_fee": 29330,
+            "base_fee": 12839237179
+        },
+        "parent_header": {
+            "excess_mana": 1321359783,
+            "mana_used": 83475620,
+            "proving_cost_per_mana_numerator": 0,
+            "fee_asset_price_numerator": 4840039687
+        },
+        "header": {
+            "excess_mana": 1304835403,
+            "mana_used": 117833942,
+            "proving_cost_per_mana_numerator": 0,
+            "fee_asset_price_numerator": 4567935259
+        },
+        "oracle_input": {
+            "proving_cost_modifier": -93855121,
+            "fee_asset_price_modifier": -272104428
+        },
+        "outputs": {
+            "fee_asset_price_at_execution": 10495908240,
+            "mana_base_fee_components_in_wei": {
+                "data_cost": 115,
+                "gas_cost": 42529973,
+                "proving_cost": 5415357955,
+                "congestion_cost": 19663493358,
+                "congestion_multiplier": 4602765979
+            },
+            "mana_base_fee_components_in_fee_asset": {
+                "data_cost": 1207,
+                "gas_cost": 446390694,
+                "proving_cost": 56839100182,
+                "congestion_cost": 206386221963,
+                "congestion_multiplier": 4602765979
+            }
+        }
+    },
+    {
+        "l1_block_number": 20973620,
+        "l1_fees": {
+            "blob_fee": 35692,
+            "base_fee": 11710398600
+        },
+        "parent_header": {
+            "excess_mana": 1304835403,
+            "mana_used": 117833942,
+            "proving_cost_per_mana_numerator": 0,
+            "fee_asset_price_numerator": 4567935259
+        },
+        "header": {
+            "excess_mana": 1322669345,
+            "mana_used": 107648739,
+            "proving_cost_per_mana_numerator": 0,
+            "fee_asset_price_numerator": 4485569068
+        },
+        "oracle_input": {
+            "proving_cost_modifier": -57253967,
+            "fee_asset_price_modifier": -82366191
+        },
+        "outputs": {
+            "fee_asset_price_at_execution": 10467387230,
+            "mana_base_fee_components_in_wei": {
+                "data_cost": 140,
+                "gas_cost": 38790695,
+                "proving_cost": 5415357955,
+                "congestion_cost": 20179341210,
+                "congestion_multiplier": 4699814946
+            },
+            "mana_base_fee_components_in_fee_asset": {
+                "data_cost": 1465,
+                "gas_cost": 406037225,
+                "proving_cost": 56684648704,
+                "congestion_cost": 211224978491,
+                "congestion_multiplier": 4699814946
+            }
+        }
+    },
+    {
+        "l1_block_number": 20973623,
+        "l1_fees": {
+            "blob_fee": 34318,
+            "base_fee": 11226899085
+        },
+        "parent_header": {
+            "excess_mana": 1322669345,
+            "mana_used": 107648739,
+            "proving_cost_per_mana_numerator": 0,
+            "fee_asset_price_numerator": 4485569068
+        },
+        "header": {
+            "excess_mana": 1330318084,
+            "mana_used": 107126075,
+            "proving_cost_per_mana_numerator": 73369673,
+            "fee_asset_price_numerator": 3485569068
+        },
+        "oracle_input": {
+            "proving_cost_modifier": 73369673,
+            "fee_asset_price_modifier": -1000000000
+        },
+        "outputs": {
+            "fee_asset_price_at_execution": 10458769192,
+            "mana_base_fee_components_in_wei": {
+                "data_cost": 134,
+                "gas_cost": 37189103,
+                "proving_cost": 5415357955,
+                "congestion_cost": 20403772164,
+                "congestion_multiplier": 4742062461
+            },
+            "mana_base_fee_components_in_fee_asset": {
+                "data_cost": 1401,
+                "gas_cost": 388952244,
+                "proving_cost": 56637978943,
+                "congestion_cost": 213398343709,
+                "congestion_multiplier": 4742062461
+            }
+        }
+    },
+    {
+        "l1_block_number": 20973626,
+        "l1_fees": {
+            "blob_fee": 30505,
+            "base_fee": 11990879691
+        },
+        "parent_header": {
+            "excess_mana": 1330318084,
+            "mana_used": 107126075,
+            "proving_cost_per_mana_numerator": 73369673,
+            "fee_asset_price_numerator": 3485569068
+        },
+        "header": {
+            "excess_mana": 1337444159,
+            "mana_used": 103590464,
+            "proving_cost_per_mana_numerator": 0,
+            "fee_asset_price_numerator": 2648632075
+        },
+        "oracle_input": {
+            "proving_cost_modifier": -178086909,
+            "fee_asset_price_modifier": -836936993
+        },
+        "outputs": {
+            "fee_asset_price_at_execution": 10354702700,
+            "mana_base_fee_components_in_wei": {
+                "data_cost": 119,
+                "gas_cost": 39719788,
+                "proving_cost": 5419332643,
+                "congestion_cost": 20644852354,
+                "congestion_multiplier": 4781764723
+            },
+            "mana_base_fee_components_in_fee_asset": {
+                "data_cost": 1232,
+                "gas_cost": 411286596,
+                "proving_cost": 56115578350,
+                "congestion_cost": 213771308411,
+                "congestion_multiplier": 4781764723
+            }
+        }
+    },
+    {
+        "l1_block_number": 20973629,
+        "l1_fees": {
+            "blob_fee": 30505,
+            "base_fee": 12389925316
+        },
+        "parent_header": {
+            "excess_mana": 1337444159,
+            "mana_used": 103590464,
+            "proving_cost_per_mana_numerator": 0,
+            "fee_asset_price_numerator": 2648632075
+        },
+        "header": {
+            "excess_mana": 1341034623,
+            "mana_used": 75455999,
+            "proving_cost_per_mana_numerator": 154461127,
+            "fee_asset_price_numerator": 2282803058
+        },
+        "oracle_input": {
+            "proving_cost_modifier": 154461127,
+            "fee_asset_price_modifier": -365829017
+        },
+        "outputs": {
+            "fee_asset_price_at_execution": 10268402007,
+            "mana_base_fee_components_in_wei": {
+                "data_cost": 119,
+                "gas_cost": 41041627,
+                "proving_cost": 5415357955,
+                "congestion_cost": 20744655554,
+                "congestion_multiplier": 4801894416
+            },
+            "mana_base_fee_components_in_fee_asset": {
+                "data_cost": 1221,
+                "gas_cost": 421431925,
+                "proving_cost": 55607072493,
+                "congestion_cost": 213014462725,
+                "congestion_multiplier": 4801894416
+            }
+        }
+    },
+    {
+        "l1_block_number": 20973632,
+        "l1_fees": {
+            "blob_fee": 35692,
+            "base_fee": 13053650178
+        },
+        "parent_header": {
+            "excess_mana": 1341034623,
+            "mana_used": 75455999,
+            "proving_cost_per_mana_numerator": 154461127,
+            "fee_asset_price_numerator": 2282803058
+        },
+        "header": {
+            "excess_mana": 1316490622,
+            "mana_used": 37243071,
+            "proving_cost_per_mana_numerator": 237298150,
+            "fee_asset_price_numerator": 2606097745
+        },
+        "oracle_input": {
+            "proving_cost_modifier": 82837023,
+            "fee_asset_price_modifier": 323294687
+        },
+        "outputs": {
+            "fee_asset_price_at_execution": 10230905841,
+            "mana_base_fee_components_in_wei": {
+                "data_cost": 140,
+                "gas_cost": 43240216,
+                "proving_cost": 5423729041,
+                "congestion_cost": 20041702048,
+                "congestion_multiplier": 4665961997
+            },
+            "mana_base_fee_components_in_fee_asset": {
+                "data_cost": 1432,
+                "gas_cost": 442386578,
+                "proving_cost": 55489661125,
+                "congestion_cost": 205044766546,
+                "congestion_multiplier": 4665961997
+            }
+        }
+    },
+    {
+        "l1_block_number": 20973635,
+        "l1_fees": {
+            "blob_fee": 37121,
+            "base_fee": 12793394041
+        },
+        "parent_header": {
+            "excess_mana": 1316490622,
+            "mana_used": 37243071,
+            "proving_cost_per_mana_numerator": 237298150,
+            "fee_asset_price_numerator": 2606097745
+        },
+        "header": {
+            "excess_mana": 1253733693,
+            "mana_used": 148558024,
+            "proving_cost_per_mana_numerator": 262704790,
+            "fee_asset_price_numerator": 2753929735
+        },
+        "oracle_input": {
+            "proving_cost_modifier": 25406640,
+            "fee_asset_price_modifier": 147831990
+        },
+        "outputs": {
+            "fee_asset_price_at_execution": 10264035340,
+            "mana_base_fee_components_in_wei": {
+                "data_cost": 145,
+                "gas_cost": 42378117,
+                "proving_cost": 5428223758,
+                "congestion_cost": 18247939638,
+                "congestion_multiplier": 4335636475
+            },
+            "mana_base_fee_components_in_fee_asset": {
+                "data_cost": 1488,
+                "gas_cost": 434970490,
+                "proving_cost": 55715480485,
+                "congestion_cost": 187297497326,
+                "congestion_multiplier": 4335636475
+            }
+        }
+    },
+    {
+        "l1_block_number": 20973638,
+        "l1_fees": {
+            "blob_fee": 40153,
+            "base_fee": 12536317780
+        },
+        "parent_header": {
+            "excess_mana": 1253733693,
+            "mana_used": 148558024,
+            "proving_cost_per_mana_numerator": 262704790,
+            "fee_asset_price_numerator": 2753929735
+        },
+        "header": {
+            "excess_mana": 1302291717,
+            "mana_used": 113034877,
+            "proving_cost_per_mana_numerator": 189011056,
+            "fee_asset_price_numerator": 3394892634
+        },
+        "oracle_input": {
+            "proving_cost_modifier": -73693734,
+            "fee_asset_price_modifier": 640962899
+        },
+        "outputs": {
+            "fee_asset_price_at_execution": 10279220089,
+            "mana_base_fee_components_in_wei": {
+                "data_cost": 157,
+                "gas_cost": 41526552,
+                "proving_cost": 5429603062,
+                "congestion_cost": 19636366169,
+                "congestion_multiplier": 4589087993
+            },
+            "mana_base_fee_components_in_fee_asset": {
+                "data_cost": 1613,
+                "gas_cost": 426860567,
+                "proving_cost": 55812084870,
+                "congestion_cost": 201846529599,
+                "congestion_multiplier": 4589087993
+            }
+        }
+    },
+    {
+        "l1_block_number": 20973641,
+        "l1_fees": {
+            "blob_fee": 35692,
+            "base_fee": 13073165878
+        },
+        "parent_header": {
+            "excess_mana": 1302291717,
+            "mana_used": 113034877,
+            "proving_cost_per_mana_numerator": 189011056,
+            "fee_asset_price_numerator": 3394892634
+        },
+        "header": {
+            "excess_mana": 1315326594,
+            "mana_used": 103158900,
+            "proving_cost_per_mana_numerator": 234196404,
+            "fee_asset_price_numerator": 4210671750
+        },
+        "oracle_input": {
+            "proving_cost_modifier": 45185348,
+            "fee_asset_price_modifier": 815779116
+        },
+        "outputs": {
+            "fee_asset_price_at_execution": 10345317680,
+            "mana_base_fee_components_in_wei": {
+                "data_cost": 140,
+                "gas_cost": 43304861,
+                "proving_cost": 5425603259,
+                "congestion_cost": 20014080594,
+                "congestion_multiplier": 4659611689
+            },
+            "mana_base_fee_components_in_fee_asset": {
+                "data_cost": 1448,
+                "gas_cost": 448002544,
+                "proving_cost": 56129589319,
+                "congestion_cost": 207052021818,
+                "congestion_multiplier": 4659611689
+            }
+        }
+    },
+    {
+        "l1_block_number": 20973644,
+        "l1_fees": {
+            "blob_fee": 31726,
+            "base_fee": 13867324942
+        },
+        "parent_header": {
+            "excess_mana": 1315326594,
+            "mana_used": 103158900,
+            "proving_cost_per_mana_numerator": 234196404,
+            "fee_asset_price_numerator": 4210671750
+        },
+        "header": {
+            "excess_mana": 1318485494,
+            "mana_used": 104972183,
+            "proving_cost_per_mana_numerator": 0,
+            "fee_asset_price_numerator": 3935539809
+        },
+        "oracle_input": {
+            "proving_cost_modifier": -353785666,
+            "fee_asset_price_modifier": -275131941
+        },
+        "outputs": {
+            "fee_asset_price_at_execution": 10430057797,
+            "mana_base_fee_components_in_wei": {
+                "data_cost": 124,
+                "gas_cost": 45935513,
+                "proving_cost": 5428055391,
+                "congestion_cost": 20127126415,
+                "congestion_multiplier": 4676865072
+            },
+            "mana_base_fee_components_in_fee_asset": {
+                "data_cost": 1293,
+                "gas_cost": 479110055,
+                "proving_cost": 56614931453,
+                "congestion_cost": 209927091795,
+                "congestion_multiplier": 4676865072
+            }
+        }
+    },
+    {
+        "l1_block_number": 20973647,
+        "l1_fees": {
+            "blob_fee": 22282,
+            "base_fee": 13249689068
+        },
+        "parent_header": {
+            "excess_mana": 1318485494,
+            "mana_used": 104972183,
+            "proving_cost_per_mana_numerator": 0,
+            "fee_asset_price_numerator": 3935539809
+        },
+        "header": {
+            "excess_mana": 1323457677,
+            "mana_used": 96706411,
+            "proving_cost_per_mana_numerator": 36679632,
+            "fee_asset_price_numerator": 3198003093
+        },
+        "oracle_input": {
+            "proving_cost_modifier": 36679632,
+            "fee_asset_price_modifier": -737536716
+        },
+        "outputs": {
+            "fee_asset_price_at_execution": 10401400817,
+            "mana_base_fee_components_in_wei": {
+                "data_cost": 87,
+                "gas_cost": 43889595,
+                "proving_cost": 5415357955,
+                "congestion_cost": 20221882032,
+                "congestion_multiplier": 4704151813
+            },
+            "mana_base_fee_components_in_fee_asset": {
+                "data_cost": 904,
+                "gas_cost": 456513269,
+                "proving_cost": 56327308657,
+                "congestion_cost": 210335900288,
+                "congestion_multiplier": 4704151813
+            }
+        }
+    },
+    {
+        "l1_block_number": 20973650,
+        "l1_fees": {
+            "blob_fee": 25067,
+            "base_fee": 12734890786
+        },
+        "parent_header": {
+            "excess_mana": 1323457677,
+            "mana_used": 96706411,
+            "proving_cost_per_mana_numerator": 36679632,
+            "fee_asset_price_numerator": 3198003093
+        },
+        "header": {
+            "excess_mana": 1320164088,
+            "mana_used": 95903793,
+            "proving_cost_per_mana_numerator": 0,
+            "fee_asset_price_numerator": 3461054523
+        },
+        "oracle_input": {
+            "proving_cost_modifier": -88632265,
+            "fee_asset_price_modifier": 263051430
+        },
+        "outputs": {
+            "fee_asset_price_at_execution": 10324968870,
+            "mana_base_fee_components_in_wei": {
+                "data_cost": 98,
+                "gas_cost": 42184325,
+                "proving_cost": 5417344652,
+                "congestion_cost": 20124147647,
+                "congestion_multiplier": 4686059250
+            },
+            "mana_base_fee_components_in_fee_asset": {
+                "data_cost": 1011,
+                "gas_cost": 435551842,
+                "proving_cost": 55933914889,
+                "congestion_cost": 207781197990,
+                "congestion_multiplier": 4686059250
+            }
+        }
+    },
+    {
+        "l1_block_number": 20973653,
+        "l1_fees": {
+            "blob_fee": 22282,
+            "base_fee": 13407760302
+        },
+        "parent_header": {
+            "excess_mana": 1320164088,
+            "mana_used": 95903793,
+            "proving_cost_per_mana_numerator": 0,
+            "fee_asset_price_numerator": 3461054523
+        },
+        "header": {
+            "excess_mana": 1316067881,
+            "mana_used": 81430584,
+            "proving_cost_per_mana_numerator": 58298087,
+            "fee_asset_price_numerator": 3252958372
+        },
+        "oracle_input": {
+            "proving_cost_modifier": 58298087,
+            "fee_asset_price_modifier": -208096151
+        },
+        "outputs": {
+            "fee_asset_price_at_execution": 10352164602,
+            "mana_base_fee_components_in_wei": {
+                "data_cost": 87,
+                "gas_cost": 44413206,
+                "proving_cost": 5415357955,
+                "congestion_cost": 20002716866,
+                "congestion_multiplier": 4663654750
+            },
+            "mana_base_fee_components_in_fee_asset": {
+                "data_cost": 900,
+                "gas_cost": 459772819,
+                "proving_cost": 56060676928,
+                "congestion_cost": 207071417484,
+                "congestion_multiplier": 4663654750
+            }
+        }
+    },
+    {
+        "l1_block_number": 20973656,
+        "l1_fees": {
+            "blob_fee": 25067,
+            "base_fee": 13114282564
+        },
+        "parent_header": {
+            "excess_mana": 1316067881,
+            "mana_used": 81430584,
+            "proving_cost_per_mana_numerator": 58298087,
+            "fee_asset_price_numerator": 3252958372
+        },
+        "header": {
+            "excess_mana": 1297498465,
+            "mana_used": 116095544,
+            "proving_cost_per_mana_numerator": 177160749,
+            "fee_asset_price_numerator": 2252958372
+        },
+        "oracle_input": {
+            "proving_cost_modifier": 118862662,
+            "fee_asset_price_modifier": -1000000000
+        },
+        "outputs": {
+            "fee_asset_price_at_execution": 10330644545,
+            "mana_base_fee_components_in_wei": {
+                "data_cost": 98,
+                "gas_cost": 43441060,
+                "proving_cost": 5418515925,
+                "congestion_cost": 19463268612,
+                "congestion_multiplier": 4563423937
+            },
+            "mana_base_fee_components_in_fee_asset": {
+                "data_cost": 1012,
+                "gas_cost": 448774149,
+                "proving_cost": 55976761982,
+                "congestion_cost": 201068109714,
+                "congestion_multiplier": 4563423937
+            }
+        }
+    },
+    {
+        "l1_block_number": 20973659,
+        "l1_fees": {
+            "blob_fee": 35692,
+            "base_fee": 12944326949
+        },
+        "parent_header": {
+            "excess_mana": 1297498465,
+            "mana_used": 116095544,
+            "proving_cost_per_mana_numerator": 177160749,
+            "fee_asset_price_numerator": 2252958372
+        },
+        "header": {
+            "excess_mana": 1313594009,
+            "mana_used": 109242161,
+            "proving_cost_per_mana_numerator": 28596982,
+            "fee_asset_price_numerator": 1397045405
+        },
+        "oracle_input": {
+            "proving_cost_modifier": -148563767,
+            "fee_asset_price_modifier": -855912967
+        },
+        "outputs": {
+            "fee_asset_price_at_execution": 10227852915,
+            "mana_base_fee_components_in_wei": {
+                "data_cost": 140,
+                "gas_cost": 42878083,
+                "proving_cost": 5424960347,
+                "congestion_cost": 19958571173,
+                "congestion_multiplier": 4650175644
+            },
+            "mana_base_fee_components_in_fee_asset": {
+                "data_cost": 1431,
+                "gas_cost": 438550726,
+                "proving_cost": 55485696498,
+                "congestion_cost": 204133330351,
+                "congestion_multiplier": 4650175644
+            }
+        }
+    },
+    {
+        "l1_block_number": 20973662,
+        "l1_fees": {
+            "blob_fee": 40153,
+            "base_fee": 13369037262
+        },
+        "parent_header": {
+            "excess_mana": 1313594009,
+            "mana_used": 109242161,
+            "proving_cost_per_mana_numerator": 28596982,
+            "fee_asset_price_numerator": 1397045405
+        },
+        "header": {
+            "excess_mana": 1322836170,
+            "mana_used": 108183872,
+            "proving_cost_per_mana_numerator": 304511687,
+            "fee_asset_price_numerator": 1620690980
+        },
+        "oracle_input": {
+            "proving_cost_modifier": 275914705,
+            "fee_asset_price_modifier": 223645575
+        },
+        "outputs": {
+            "fee_asset_price_at_execution": 10140684968,
+            "mana_base_fee_components_in_wei": {
+                "data_cost": 157,
+                "gas_cost": 44284935,
+                "proving_cost": 5416906805,
+                "congestion_cost": 20210409632,
+                "congestion_multiplier": 4700732370
+            },
+            "mana_base_fee_components_in_fee_asset": {
+                "data_cost": 1592,
+                "gas_cost": 449079574,
+                "proving_cost": 54931145410,
+                "congestion_cost": 204947397152,
+                "congestion_multiplier": 4700732370
+            }
+        }
+    },
+    {
+        "l1_block_number": 20973665,
+        "l1_fees": {
+            "blob_fee": 52854,
+            "base_fee": 13746614736
+        },
+        "parent_header": {
+            "excess_mana": 1322836170,
+            "mana_used": 108183872,
+            "proving_cost_per_mana_numerator": 304511687,
+            "fee_asset_price_numerator": 1620690980
+        },
+        "header": {
+            "excess_mana": 1331020042,
+            "mana_used": 100370566,
+            "proving_cost_per_mana_numerator": 216866276,
+            "fee_asset_price_numerator": 1091240296
+        },
+        "oracle_input": {
+            "proving_cost_modifier": -87645411,
+            "fee_asset_price_modifier": -529450684
+        },
+        "outputs": {
+            "fee_asset_price_at_execution": 10163389541,
+            "mana_base_fee_components_in_wei": {
+                "data_cost": 207,
+                "gas_cost": 45535661,
+                "proving_cost": 5431873485,
+                "congestion_cost": 20518149071,
+                "congestion_multiplier": 4745958673
+            },
+            "mana_base_fee_components_in_fee_asset": {
+                "data_cost": 2103,
+                "gas_cost": 462796660,
+                "proving_cost": 55206246165,
+                "congestion_cost": 208533941668,
+                "congestion_multiplier": 4745958673
+            }
+        }
+    },
+    {
+        "l1_block_number": 20973668,
+        "l1_fees": {
+            "blob_fee": 43433,
+            "base_fee": 12637057600
+        },
+        "parent_header": {
+            "excess_mana": 1331020042,
+            "mana_used": 100370566,
+            "proving_cost_per_mana_numerator": 216866276,
+            "fee_asset_price_numerator": 1091240296
+        },
+        "header": {
+            "excess_mana": 1331390608,
+            "mana_used": 89670939,
+            "proving_cost_per_mana_numerator": 192384436,
+            "fee_asset_price_numerator": 91240296
+        },
+        "oracle_input": {
+            "proving_cost_modifier": -24481840,
+            "fee_asset_price_modifier": -1000000000
+        },
+        "outputs": {
+            "fee_asset_price_at_execution": 10109721603,
+            "mana_base_fee_components_in_wei": {
+                "data_cost": 170,
+                "gas_cost": 41860253,
+                "proving_cost": 5427114783,
+                "congestion_cost": 20497810885,
+                "congestion_multiplier": 4748016788
+            },
+            "mana_base_fee_components_in_fee_asset": {
+                "data_cost": 1718,
+                "gas_cost": 423195504,
+                "proving_cost": 54866619563,
+                "congestion_cost": 207227161518,
+                "congestion_multiplier": 4748016788
+            }
+        }
+    },
+    {
+        "l1_block_number": 20973671,
+        "l1_fees": {
+            "blob_fee": 37121,
+            "base_fee": 14261690469
+        },
+        "parent_header": {
+            "excess_mana": 1331390608,
+            "mana_used": 89670939,
+            "proving_cost_per_mana_numerator": 192384436,
+            "fee_asset_price_numerator": 91240296
+        },
+        "header": {
+            "excess_mana": 1321061547,
+            "mana_used": 91748908,
+            "proving_cost_per_mana_numerator": 252885275,
+            "fee_asset_price_numerator": 125382631
+        },
+        "oracle_input": {
+            "proving_cost_modifier": 60500839,
+            "fee_asset_price_modifier": 34142335
+        },
+        "outputs": {
+            "fee_asset_price_at_execution": 10009128193,
+            "mana_base_fee_components_in_wei": {
+                "data_cost": 145,
+                "gas_cost": 47241849,
+                "proving_cost": 5425786288,
+                "congestion_cost": 20200850642,
+                "congestion_multiplier": 4690982323
+            },
+            "mana_base_fee_components_in_fee_asset": {
+                "data_cost": 1451,
+                "gas_cost": 472849722,
+                "proving_cost": 54307390504,
+                "congestion_cost": 202192903683,
+                "congestion_multiplier": 4690982323
+            }
+        }
+    },
+    {
+        "l1_block_number": 20973674,
+        "l1_fees": {
+            "blob_fee": 40153,
+            "base_fee": 14838773563
+        },
+        "parent_header": {
+            "excess_mana": 1321061547,
+            "mana_used": 91748908,
+            "proving_cost_per_mana_numerator": 252885275,
+            "fee_asset_price_numerator": 125382631
+        },
+        "header": {
+            "excess_mana": 1312810455,
+            "mana_used": 108557927,
+            "proving_cost_per_mana_numerator": 223094872,
+            "fee_asset_price_numerator": 512679736
+        },
+        "oracle_input": {
+            "proving_cost_modifier": -29790403,
+            "fee_asset_price_modifier": 387297105
+        },
+        "outputs": {
+            "fee_asset_price_at_execution": 10012546126,
+            "mana_base_fee_components_in_wei": {
+                "data_cost": 157,
+                "gas_cost": 49153437,
+                "proving_cost": 5429069928,
+                "congestion_cost": 19973134627,
+                "congestion_multiplier": 4645914510
+            },
+            "mana_base_fee_components_in_fee_asset": {
+                "data_cost": 1571,
+                "gas_cost": 492151055,
+                "proving_cost": 54358813075,
+                "congestion_cost": 199981931733,
+                "congestion_multiplier": 4645914510
+            }
+        }
+    },
+    {
+        "l1_block_number": 20973677,
+        "l1_fees": {
+            "blob_fee": 37121,
+            "base_fee": 14896911474
+        },
+        "parent_header": {
+            "excess_mana": 1312810455,
+            "mana_used": 108557927,
+            "proving_cost_per_mana_numerator": 223094872,
+            "fee_asset_price_numerator": 512679736
+        },
+        "header": {
+            "excess_mana": 1321368382,
+            "mana_used": 110851131,
+            "proving_cost_per_mana_numerator": 85700300,
+            "fee_asset_price_numerator": 443662552
+        },
+        "oracle_input": {
+            "proving_cost_modifier": -137394572,
+            "fee_asset_price_modifier": -69017184
+        },
+        "outputs": {
+            "fee_asset_price_at_execution": 10051399618,
+            "mana_base_fee_components_in_wei": {
+                "data_cost": 145,
+                "gas_cost": 49346019,
+                "proving_cost": 5427452827,
+                "congestion_cost": 20223993114,
+                "congestion_multiplier": 4692666674
+            },
+            "mana_base_fee_components_in_fee_asset": {
+                "data_cost": 1457,
+                "gas_cost": 495996556,
+                "proving_cost": 54553497272,
+                "congestion_cost": 203279436660,
+                "congestion_multiplier": 4692666674
+            }
+        }
+    },
+    {
+        "l1_block_number": 20973680,
+        "l1_fees": {
+            "blob_fee": 27115,
+            "base_fee": 17507207114
+        },
+        "parent_header": {
+            "excess_mana": 1321368382,
+            "mana_used": 110851131,
+            "proving_cost_per_mana_numerator": 85700300,
+            "fee_asset_price_numerator": 443662552
+        },
+        "header": {
+            "excess_mana": 1332219513,
+            "mana_used": 100945171,
+            "proving_cost_per_mana_numerator": 158359051,
+            "fee_asset_price_numerator": 1140511040
+        },
+        "oracle_input": {
+            "proving_cost_modifier": 72658751,
+            "fee_asset_price_modifier": 696848488
+        },
+        "outputs": {
+            "fee_asset_price_at_execution": 10044464819,
+            "mana_base_fee_components_in_wei": {
+                "data_cost": 106,
+                "gas_cost": 57992623,
+                "proving_cost": 5420000922,
+                "congestion_cost": 20556849011,
+                "congestion_multiplier": 4752623738
+            },
+            "mana_base_fee_components_in_fee_asset": {
+                "data_cost": 1064,
+                "gas_cost": 582504861,
+                "proving_cost": 54441008579,
+                "congestion_cost": 206482546680,
+                "congestion_multiplier": 4752623738
+            }
+        }
+    },
+    {
+        "l1_block_number": 20973683,
+        "l1_fees": {
+            "blob_fee": 27115,
+            "base_fee": 17359812143
+        },
+        "parent_header": {
+            "excess_mana": 1332219513,
+            "mana_used": 100945171,
+            "proving_cost_per_mana_numerator": 158359051,
+            "fee_asset_price_numerator": 1140511040
+        },
+        "header": {
+            "excess_mana": 1333164684,
+            "mana_used": 95398013,
+            "proving_cost_per_mana_numerator": 233651354,
+            "fee_asset_price_numerator": 1146490236
+        },
+        "oracle_input": {
+            "proving_cost_modifier": 75292303,
+            "fee_asset_price_modifier": 5979196
+        },
+        "outputs": {
+            "fee_asset_price_at_execution": 10114703966,
+            "mana_base_fee_components_in_wei": {
+                "data_cost": 106,
+                "gas_cost": 57504377,
+                "proving_cost": 5423940458,
+                "congestion_cost": 20598625108,
+                "congestion_multiplier": 4757882334
+            },
+            "mana_base_fee_components_in_fee_asset": {
+                "data_cost": 1072,
+                "gas_cost": 581639750,
+                "proving_cost": 54861552061,
+                "congestion_cost": 208348995074,
+                "congestion_multiplier": 4757882334
+            }
+        }
+    },
+    {
+        "l1_block_number": 20973686,
+        "l1_fees": {
+            "blob_fee": 29330,
+            "base_fee": 16774258941
+        },
+        "parent_header": {
+            "excess_mana": 1333164684,
+            "mana_used": 95398013,
+            "proving_cost_per_mana_numerator": 233651354,
+            "fee_asset_price_numerator": 1146490236
+        },
+        "header": {
+            "excess_mana": 1328562697,
+            "mana_used": 104797878,
+            "proving_cost_per_mana_numerator": 350116580,
+            "fee_asset_price_numerator": 1091371198
+        },
+        "oracle_input": {
+            "proving_cost_modifier": 116465226,
+            "fee_asset_price_modifier": -55119038
+        },
+        "outputs": {
+            "fee_asset_price_at_execution": 10115308762,
+            "mana_base_fee_components_in_wei": {
+                "data_cost": 115,
+                "gas_cost": 55564732,
+                "proving_cost": 5428025805,
+                "congestion_cost": 20466587412,
+                "congestion_multiplier": 4732333194
+            },
+            "mana_base_fee_components_in_fee_asset": {
+                "data_cost": 1163,
+                "gas_cost": 562054420,
+                "proving_cost": 54906156985,
+                "congestion_cost": 207025850976,
+                "congestion_multiplier": 4732333194
+            }
+        }
+    },
+    {
+        "l1_block_number": 20973689,
+        "l1_fees": {
+            "blob_fee": 40153,
+            "base_fee": 16436884687
+        },
+        "parent_header": {
+            "excess_mana": 1328562697,
+            "mana_used": 104797878,
+            "proving_cost_per_mana_numerator": 350116580,
+            "fee_asset_price_numerator": 1091371198
+        },
+        "header": {
+            "excess_mana": 1333360575,
+            "mana_used": 94135126,
+            "proving_cost_per_mana_numerator": 487258535,
+            "fee_asset_price_numerator": 1295374975
+        },
+        "oracle_input": {
+            "proving_cost_modifier": 137141955,
+            "fee_asset_price_modifier": 204003777
+        },
+        "outputs": {
+            "fee_asset_price_at_execution": 10109734837,
+            "mana_base_fee_components_in_wei": {
+                "data_cost": 157,
+                "gas_cost": 54447180,
+                "proving_cost": 5434351251,
+                "congestion_cost": 20632245310,
+                "congestion_multiplier": 4758972930
+            },
+            "mana_base_fee_components_in_fee_asset": {
+                "data_cost": 1587,
+                "gas_cost": 550446552,
+                "proving_cost": 54939850158,
+                "congestion_cost": 208586529176,
+                "congestion_multiplier": 4758972930
+            }
+        }
+    },
+    {
+        "l1_block_number": 20973692,
+        "l1_fees": {
+            "blob_fee": 50819,
+            "base_fee": 15897028148
+        },
+        "parent_header": {
+            "excess_mana": 1333360575,
+            "mana_used": 94135126,
+            "proving_cost_per_mana_numerator": 487258535,
+            "fee_asset_price_numerator": 1295374975
+        },
+        "header": {
+            "excess_mana": 1327495701,
+            "mana_used": 88175023,
+            "proving_cost_per_mana_numerator": 692563901,
+            "fee_asset_price_numerator": 614727199
+        },
+        "oracle_input": {
+            "proving_cost_modifier": 205305366,
+            "fee_asset_price_modifier": -680647776
+        },
+        "outputs": {
+            "fee_asset_price_at_execution": 10130380130,
+            "mana_base_fee_components_in_wei": {
+                "data_cost": 199,
+                "gas_cost": 52658905,
+                "proving_cost": 5441809139,
+                "congestion_cost": 20474746377,
+                "congestion_multiplier": 4726429105
+            },
+            "mana_base_fee_components_in_fee_asset": {
+                "data_cost": 2015,
+                "gas_cost": 533454724,
+                "proving_cost": 55127595172,
+                "congestion_cost": 207416963864,
+                "congestion_multiplier": 4726429105
+            }
+        }
+    },
+    {
+        "l1_block_number": 20973695,
+        "l1_fees": {
+            "blob_fee": 41761,
+            "base_fee": 14721886802
+        },
+        "parent_header": {
+            "excess_mana": 1327495701,
+            "mana_used": 88175023,
+            "proving_cost_per_mana_numerator": 692563901,
+            "fee_asset_price_numerator": 614727199
+        },
+        "header": {
+            "excess_mana": 1315670724,
+            "mana_used": 95588997,
+            "proving_cost_per_mana_numerator": 693229477,
+            "fee_asset_price_numerator": 1107651260
+        },
+        "oracle_input": {
+            "proving_cost_modifier": 665576,
+            "fee_asset_price_modifier": 492924061
+        },
+        "outputs": {
+            "fee_asset_price_at_execution": 10061662052,
+            "mana_base_fee_components_in_wei": {
+                "data_cost": 164,
+                "gas_cost": 48766250,
+                "proving_cost": 5452992942,
+                "congestion_cost": 20144626829,
+                "congestion_multiplier": 4661488176
+            },
+            "mana_base_fee_components_in_fee_asset": {
+                "data_cost": 1650,
+                "gas_cost": 490669527,
+                "proving_cost": 54866172154,
+                "congestion_cost": 202688427317,
+                "congestion_multiplier": 4661488176
+            }
+        }
+    },
+    {
+        "l1_block_number": 20973698,
+        "l1_fees": {
+            "blob_fee": 32996,
+            "base_fee": 13847852742
+        },
+        "parent_header": {
+            "excess_mana": 1315670724,
+            "mana_used": 95588997,
+            "proving_cost_per_mana_numerator": 693229477,
+            "fee_asset_price_numerator": 1107651260
+        },
+        "header": {
+            "excess_mana": 1311259721,
+            "mana_used": 98042679,
+            "proving_cost_per_mana_numerator": 627079751,
+            "fee_asset_price_numerator": 1021247990
+        },
+        "oracle_input": {
+            "proving_cost_modifier": -66149726,
+            "fee_asset_price_modifier": -86403270
+        },
+        "outputs": {
+            "fee_asset_price_at_execution": 10111380842,
+            "mana_base_fee_components_in_wei": {
+                "data_cost": 129,
+                "gas_cost": 45871012,
+                "proving_cost": 5453029235,
+                "congestion_cost": 20002210509,
+                "congestion_multiplier": 4637492797
+            },
+            "mana_base_fee_components_in_fee_asset": {
+                "data_cost": 1304,
+                "gas_cost": 463819271,
+                "proving_cost": 55137655337,
+                "congestion_cost": 202249968138,
+                "congestion_multiplier": 4637492797
+            }
+        }
+    },
+    {
+        "l1_block_number": 20973701,
+        "l1_fees": {
+            "blob_fee": 37121,
+            "base_fee": 12795525944
+        },
+        "parent_header": {
+            "excess_mana": 1311259721,
+            "mana_used": 98042679,
+            "proving_cost_per_mana_numerator": 627079751,
+            "fee_asset_price_numerator": 1021247990
+        },
+        "header": {
+            "excess_mana": 1309302400,
+            "mana_used": 116369229,
+            "proving_cost_per_mana_numerator": 355053462,
+            "fee_asset_price_numerator": 400314957
+        },
+        "oracle_input": {
+            "proving_cost_modifier": -272026289,
+            "fee_asset_price_modifier": -620933033
+        },
+        "outputs": {
+            "fee_asset_price_at_execution": 10102648052,
+            "mana_base_fee_components_in_wei": {
+                "data_cost": 145,
+                "gas_cost": 42385179,
+                "proving_cost": 5449423264,
+                "congestion_cost": 19918157015,
+                "congestion_multiplier": 4626884786
+            },
+            "mana_base_fee_components_in_fee_asset": {
+                "data_cost": 1464,
+                "gas_cost": 428202546,
+                "proving_cost": 55053605322,
+                "congestion_cost": 201226130167,
+                "congestion_multiplier": 4626884786
+            }
+        }
+    },
+    {
+        "l1_block_number": 20973704,
+        "l1_fees": {
+            "blob_fee": 32996,
+            "base_fee": 12974547741
+        },
+        "parent_header": {
+            "excess_mana": 1309302400,
+            "mana_used": 116369229,
+            "proving_cost_per_mana_numerator": 355053462,
+            "fee_asset_price_numerator": 400314957
+        },
+        "header": {
+            "excess_mana": 1325671629,
+            "mana_used": 96645177,
+            "proving_cost_per_mana_numerator": 400248833,
+            "fee_asset_price_numerator": 497696853
+        },
+        "oracle_input": {
+            "proving_cost_modifier": 45195371,
+            "fee_asset_price_modifier": 97381896
+        },
+        "outputs": {
+            "fee_asset_price_at_execution": 10040111728,
+            "mana_base_fee_components_in_wei": {
+                "data_cost": 129,
+                "gas_cost": 42978189,
+                "proving_cost": 5434619545,
+                "congestion_cost": 20356686621,
+                "congestion_multiplier": 4716352885
+            },
+            "mana_base_fee_components_in_fee_asset": {
+                "data_cost": 1295,
+                "gas_cost": 431505819,
+                "proving_cost": 54564187430,
+                "congestion_cost": 204383408086,
+                "congestion_multiplier": 4716352885
+            }
+        }
+    },
+    {
+        "l1_block_number": 20973707,
+        "l1_fees": {
+            "blob_fee": 31726,
+            "base_fee": 12024548672
+        },
+        "parent_header": {
+            "excess_mana": 1325671629,
+            "mana_used": 96645177,
+            "proving_cost_per_mana_numerator": 400248833,
+            "fee_asset_price_numerator": 497696853
+        },
+        "header": {
+            "excess_mana": 1322316806,
+            "mana_used": 117502004,
+            "proving_cost_per_mana_numerator": 365016066,
+            "fee_asset_price_numerator": 360522242
+        },
+        "oracle_input": {
+            "proving_cost_modifier": -35232767,
+            "fee_asset_price_modifier": -137174611
+        },
+        "outputs": {
+            "fee_asset_price_at_execution": 10049893742,
+            "mana_base_fee_components_in_wei": {
+                "data_cost": 124,
+                "gas_cost": 39831317,
+                "proving_cost": 5437076296,
+                "congestion_cost": 20252930111,
+                "congestion_multiplier": 4697876810
+            },
+            "mana_base_fee_components_in_fee_asset": {
+                "data_cost": 1246,
+                "gas_cost": 400300503,
+                "proving_cost": 54642039041,
+                "congestion_cost": 203539795579,
+                "congestion_multiplier": 4697876810
+            }
+        }
+    },
+    {
+        "l1_block_number": 20973710,
+        "l1_fees": {
+            "blob_fee": 28201,
+            "base_fee": 12463433465
+        },
+        "parent_header": {
+            "excess_mana": 1322316806,
+            "mana_used": 117502004,
+            "proving_cost_per_mana_numerator": 365016066,
+            "fee_asset_price_numerator": 360522242
+        },
+        "header": {
+            "excess_mana": 1339818810,
+            "mana_used": 80370368,
+            "proving_cost_per_mana_numerator": 207515968,
+            "fee_asset_price_numerator": 587790795
+        },
+        "oracle_input": {
+            "proving_cost_modifier": -157500098,
+            "fee_asset_price_modifier": 227268553
+        },
+        "outputs": {
+            "fee_asset_price_at_execution": 10036117290,
+            "mana_base_fee_components_in_wei": {
+                "data_cost": 110,
+                "gas_cost": 41285123,
+                "proving_cost": 5435161001,
+                "congestion_cost": 20783488988,
+                "congestion_multiplier": 4795068572
+            },
+            "mana_base_fee_components_in_fee_asset": {
+                "data_cost": 1103,
+                "gas_cost": 414342336,
+                "proving_cost": 54547913296,
+                "congestion_cost": 208585533178,
+                "congestion_multiplier": 4795068572
+            }
+        }
+    },
+    {
+        "l1_block_number": 20973713,
+        "l1_fees": {
+            "blob_fee": 25067,
+            "base_fee": 11667927282
+        },
+        "parent_header": {
+            "excess_mana": 1339818810,
+            "mana_used": 80370368,
+            "proving_cost_per_mana_numerator": 207515968,
+            "fee_asset_price_numerator": 587790795
+        },
+        "header": {
+            "excess_mana": 1320189178,
+            "mana_used": 122543064,
+            "proving_cost_per_mana_numerator": 255539944,
+            "fee_asset_price_numerator": 888025172
+        },
+        "oracle_input": {
+            "proving_cost_modifier": 48023976,
+            "fee_asset_price_modifier": 300234377
+        },
+        "outputs": {
+            "fee_asset_price_at_execution": 10058952167,
+            "mana_base_fee_components_in_wei": {
+                "data_cost": 98,
+                "gas_cost": 38650009,
+                "proving_cost": 5426607355,
+                "congestion_cost": 20146014638,
+                "congestion_multiplier": 4686196813
+            },
+            "mana_base_fee_components_in_fee_asset": {
+                "data_cost": 985,
+                "gas_cost": 388778591,
+                "proving_cost": 54585983813,
+                "congestion_cost": 202647797599,
+                "congestion_multiplier": 4686196813
+            }
+        }
+    },
+    {
+        "l1_block_number": 20973716,
+        "l1_fees": {
+            "blob_fee": 17605,
+            "base_fee": 12588865223
+        },
+        "parent_header": {
+            "excess_mana": 1320189178,
+            "mana_used": 122543064,
+            "proving_cost_per_mana_numerator": 255539944,
+            "fee_asset_price_numerator": 888025172
+        },
+        "header": {
+            "excess_mana": 1342732242,
+            "mana_used": 100615032,
+            "proving_cost_per_mana_numerator": 286957295,
+            "fee_asset_price_numerator": 981528734
+        },
+        "oracle_input": {
+            "proving_cost_modifier": 31417351,
+            "fee_asset_price_modifier": 93503562
+        },
+        "outputs": {
+            "fee_asset_price_at_execution": 10089197981,
+            "mana_base_fee_components_in_wei": {
+                "data_cost": 69,
+                "gas_cost": 41700616,
+                "proving_cost": 5429214054,
+                "congestion_cost": 20852071397,
+                "congestion_multiplier": 4811441485
+            },
+            "mana_base_fee_components_in_fee_asset": {
+                "data_cost": 696,
+                "gas_cost": 420725770,
+                "proving_cost": 54776415472,
+                "congestion_cost": 210380676638,
+                "congestion_multiplier": 4811441485
+            }
+        }
+    },
+    {
+        "l1_block_number": 20973719,
+        "l1_fees": {
+            "blob_fee": 19806,
+            "base_fee": 12041731239
+        },
+        "parent_header": {
+            "excess_mana": 1342732242,
+            "mana_used": 100615032,
+            "proving_cost_per_mana_numerator": 286957295,
+            "fee_asset_price_numerator": 981528734
+        },
+        "header": {
+            "excess_mana": 1343347274,
+            "mana_used": 77006488,
+            "proving_cost_per_mana_numerator": 143731815,
+            "fee_asset_price_numerator": 1796621780
+        },
+        "oracle_input": {
+            "proving_cost_modifier": -143225480,
+            "fee_asset_price_modifier": 815093046
+        },
+        "outputs": {
+            "fee_asset_price_at_execution": 10098636152,
+            "mana_base_fee_components_in_wei": {
+                "data_cost": 77,
+                "gas_cost": 39888234,
+                "proving_cost": 5430920037,
+                "congestion_cost": 20870614033,
+                "congestion_multiplier": 4814904984
+            },
+            "mana_base_fee_components_in_fee_asset": {
+                "data_cost": 777,
+                "gas_cost": 402816761,
+                "proving_cost": 54844885424,
+                "congestion_cost": 210764737388,
+                "congestion_multiplier": 4814904984
+            }
+        }
+    },
+    {
+        "l1_block_number": 20973722,
+        "l1_fees": {
+            "blob_fee": 22282,
+            "base_fee": 11999031875
+        },
+        "parent_header": {
+            "excess_mana": 1343347274,
+            "mana_used": 77006488,
+            "proving_cost_per_mana_numerator": 143731815,
+            "fee_asset_price_numerator": 1796621780
+        },
+        "header": {
+            "excess_mana": 1320353762,
+            "mana_used": 106572663,
+            "proving_cost_per_mana_numerator": 204284475,
+            "fee_asset_price_numerator": 1339655635
+        },
+        "oracle_input": {
+            "proving_cost_modifier": 60552660,
+            "fee_asset_price_modifier": -456966145
+        },
+        "outputs": {
+            "fee_asset_price_at_execution": 10181285811,
+            "mana_base_fee_components_in_wei": {
+                "data_cost": 87,
+                "gas_cost": 39746793,
+                "proving_cost": 5423147143,
+                "congestion_cost": 20142232668,
+                "congestion_multiplier": 4687099289
+            },
+            "mana_base_fee_components_in_fee_asset": {
+                "data_cost": 885,
+                "gas_cost": 404673459,
+                "proving_cost": 55214611057,
+                "congestion_cost": 205073827664,
+                "congestion_multiplier": 4687099289
+            }
+        }
+    },
+    {
+        "l1_block_number": 20973725,
+        "l1_fees": {
+            "blob_fee": 25067,
+            "base_fee": 11451155317
+        },
+        "parent_header": {
+            "excess_mana": 1320353762,
+            "mana_used": 106572663,
+            "proving_cost_per_mana_numerator": 204284475,
+            "fee_asset_price_numerator": 1339655635
+        },
+        "header": {
+            "excess_mana": 1326926425,
+            "mana_used": 107682586,
+            "proving_cost_per_mana_numerator": 22685411,
+            "fee_asset_price_numerator": 1288771117
+        },
+        "oracle_input": {
+            "proving_cost_modifier": -181599064,
+            "fee_asset_price_modifier": -50884518
+        },
+        "outputs": {
+            "fee_asset_price_at_execution": 10134866922,
+            "mana_base_fee_components_in_wei": {
+                "data_cost": 98,
+                "gas_cost": 37931951,
+                "proving_cost": 5426431997,
+                "congestion_cost": 20345368845,
+                "congestion_multiplier": 4723282101
+            },
+            "mana_base_fee_components_in_fee_asset": {
+                "data_cost": 993,
+                "gas_cost": 384435275,
+                "proving_cost": 54996166150,
+                "congestion_cost": 206197605723,
+                "congestion_multiplier": 4723282101
+            }
+        }
+    },
+    {
+        "l1_block_number": 20973728,
+        "l1_fees": {
+            "blob_fee": 30505,
+            "base_fee": 11303347796
+        },
+        "parent_header": {
+            "excess_mana": 1326926425,
+            "mana_used": 107682586,
+            "proving_cost_per_mana_numerator": 22685411,
+            "fee_asset_price_numerator": 1288771117
+        },
+        "header": {
+            "excess_mana": 1334609011,
+            "mana_used": 99341302,
+            "proving_cost_per_mana_numerator": 39587039,
+            "fee_asset_price_numerator": 2288771117
+        },
+        "oracle_input": {
+            "proving_cost_modifier": 16901628,
+            "fee_asset_price_modifier": 1000000000
+        },
+        "outputs": {
+            "fee_asset_price_at_execution": 10129711156,
+            "mana_base_fee_components_in_wei": {
+                "data_cost": 119,
+                "gas_cost": 37442339,
+                "proving_cost": 5416586590,
+                "congestion_cost": 20539487789,
+                "congestion_multiplier": 4765929299
+            },
+            "mana_base_fee_components_in_fee_asset": {
+                "data_cost": 1205,
+                "gas_cost": 379280079,
+                "proving_cost": 54868457608,
+                "congestion_cost": 208059078594,
+                "congestion_multiplier": 4765929299
+            }
+        }
+    },
+    {
+        "l1_block_number": 20973731,
+        "l1_fees": {
+            "blob_fee": 27115,
+            "base_fee": 11131576212
+        },
+        "parent_header": {
+            "excess_mana": 1334609011,
+            "mana_used": 99341302,
+            "proving_cost_per_mana_numerator": 39587039,
+            "fee_asset_price_numerator": 2288771117
+        },
+        "header": {
+            "excess_mana": 1333950313,
+            "mana_used": 98924508,
+            "proving_cost_per_mana_numerator": 102816084,
+            "fee_asset_price_numerator": 2351903422
+        },
+        "oracle_input": {
+            "proving_cost_modifier": 63229045,
+            "fee_asset_price_modifier": 63132305
+        },
+        "outputs": {
+            "fee_asset_price_at_execution": 10231516445,
+            "mana_base_fee_components_in_wei": {
+                "data_cost": 106,
+                "gas_cost": 36873346,
+                "proving_cost": 5417502159,
+                "congestion_cost": 20520766766,
+                "congestion_multiplier": 4762257723
+            },
+            "mana_base_fee_components_in_fee_asset": {
+                "data_cost": 1084,
+                "gas_cost": 377270245,
+                "proving_cost": 55429262430,
+                "congestion_cost": 209958562630,
+                "congestion_multiplier": 4762257723
+            }
+        }
+    },
+    {
+        "l1_block_number": 20973734,
+        "l1_fees": {
+            "blob_fee": 27115,
+            "base_fee": 11324057276
+        },
+        "parent_header": {
+            "excess_mana": 1333950313,
+            "mana_used": 98924508,
+            "proving_cost_per_mana_numerator": 102816084,
+            "fee_asset_price_numerator": 2351903422
+        },
+        "header": {
+            "excess_mana": 1332874821,
+            "mana_used": 92189342,
+            "proving_cost_per_mana_numerator": 236788546,
+            "fee_asset_price_numerator": 1804191747
+        },
+        "oracle_input": {
+            "proving_cost_modifier": 133972462,
+            "fee_asset_price_modifier": -547711675
+        },
+        "outputs": {
+            "fee_asset_price_at_execution": 10237977877,
+            "mana_base_fee_components_in_wei": {
+                "data_cost": 106,
+                "gas_cost": 37510939,
+                "proving_cost": 5420928677,
+                "congestion_cost": 20503368030,
+                "congestion_multiplier": 4756269021
+            },
+            "mana_base_fee_components_in_fee_asset": {
+                "data_cost": 1085,
+                "gas_cost": 384036163,
+                "proving_cost": 55499347867,
+                "congestion_cost": 209913028295,
+                "congestion_multiplier": 4756269021
+            }
+        }
+    },
+    {
+        "l1_block_number": 20973737,
+        "l1_fees": {
+            "blob_fee": 23174,
+            "base_fee": 12400836887
+        },
+        "parent_header": {
+            "excess_mana": 1332874821,
+            "mana_used": 92189342,
+            "proving_cost_per_mana_numerator": 236788546,
+            "fee_asset_price_numerator": 1804191747
+        },
+        "header": {
+            "excess_mana": 1325064163,
+            "mana_used": 95916080,
+            "proving_cost_per_mana_numerator": 141587906,
+            "fee_asset_price_numerator": 2358872831
+        },
+        "oracle_input": {
+            "proving_cost_modifier": -95200640,
+            "fee_asset_price_modifier": 554681084
+        },
+        "outputs": {
+            "fee_asset_price_at_execution": 10182056561,
+            "mana_base_fee_components_in_wei": {
+                "data_cost": 91,
+                "gas_cost": 41077772,
+                "proving_cost": 5428196095,
+                "congestion_cost": 20307425133,
+                "congestion_multiplier": 4713001998
+            },
+            "mana_base_fee_components_in_fee_asset": {
+                "data_cost": 926,
+                "gas_cost": 418256197,
+                "proving_cost": 55270199663,
+                "congestion_cost": 206771351312,
+                "congestion_multiplier": 4713001998
+            }
+        }
+    },
+    {
+        "l1_block_number": 20973740,
+        "l1_fees": {
+            "blob_fee": 28201,
+            "base_fee": 12009113331
+        },
+        "parent_header": {
+            "excess_mana": 1325064163,
+            "mana_used": 95916080,
+            "proving_cost_per_mana_numerator": 141587906,
+            "fee_asset_price_numerator": 2358872831
+        },
+        "header": {
+            "excess_mana": 1320980243,
+            "mana_used": 82886232,
+            "proving_cost_per_mana_numerator": 228305694,
+            "fee_asset_price_numerator": 2538942324
+        },
+        "oracle_input": {
+            "proving_cost_modifier": 86717788,
+            "fee_asset_price_modifier": 180069493
+        },
+        "outputs": {
+            "fee_asset_price_at_execution": 10238691428,
+            "mana_base_fee_components_in_wei": {
+                "data_cost": 110,
+                "gas_cost": 39780187,
+                "proving_cost": 5423030877,
+                "congestion_cost": 20160701910,
+                "congestion_multiplier": 4690536112
+            },
+            "mana_base_fee_components_in_fee_asset": {
+                "data_cost": 1126,
+                "gas_cost": 407297059,
+                "proving_cost": 55524739754,
+                "congestion_cost": 206419205828,
+                "congestion_multiplier": 4690536112
+            }
+        }
+    },
+    {
+        "l1_block_number": 20973743,
+        "l1_fees": {
+            "blob_fee": 29330,
+            "base_fee": 11347704848
+        },
+        "parent_header": {
+            "excess_mana": 1320980243,
+            "mana_used": 82886232,
+            "proving_cost_per_mana_numerator": 228305694,
+            "fee_asset_price_numerator": 2538942324
+        },
+        "header": {
+            "excess_mana": 1303866475,
+            "mana_used": 99575548,
+            "proving_cost_per_mana_numerator": 191313213,
+            "fee_asset_price_numerator": 2276176576
+        },
+        "oracle_input": {
+            "proving_cost_modifier": -36992481,
+            "fee_asset_price_modifier": -262765748
+        },
+        "outputs": {
+            "fee_asset_price_at_execution": 10257144798,
+            "mana_base_fee_components_in_wei": {
+                "data_cost": 115,
+                "gas_cost": 37589272,
+                "proving_cost": 5427735649,
+                "congestion_cost": 19661785712,
+                "congestion_multiplier": 4597551030
+            },
+            "mana_base_fee_components_in_fee_asset": {
+                "data_cost": 1179,
+                "gas_cost": 385558605,
+                "proving_cost": 55673070477,
+                "congestion_cost": 201673783035,
+                "congestion_multiplier": 4597551030
+            }
+        }
+    },
+    {
+        "l1_block_number": 20973746,
+        "l1_fees": {
+            "blob_fee": 32996,
+            "base_fee": 11581848907
+        },
+        "parent_header": {
+            "excess_mana": 1303866475,
+            "mana_used": 99575548,
+            "proving_cost_per_mana_numerator": 191313213,
+            "fee_asset_price_numerator": 2276176576
+        },
+        "header": {
+            "excess_mana": 1303442023,
+            "mana_used": 112024559,
+            "proving_cost_per_mana_numerator": 80126553,
+            "fee_asset_price_numerator": 2827578672
+        },
+        "oracle_input": {
+            "proving_cost_modifier": -111186660,
+            "fee_asset_price_modifier": 551402096
+        },
+        "outputs": {
+            "fee_asset_price_at_execution": 10230227914,
+            "mana_base_fee_components_in_wei": {
+                "data_cost": 129,
+                "gas_cost": 38364874,
+                "proving_cost": 5425728166,
+                "congestion_cost": 19644881570,
+                "congestion_multiplier": 4595268412
+            },
+            "mana_base_fee_components_in_fee_asset": {
+                "data_cost": 1319,
+                "gas_cost": 392481404,
+                "proving_cost": 55506435737,
+                "congestion_cost": 200971615804,
+                "congestion_multiplier": 4595268412
+            }
+        }
+    },
+    {
+        "l1_block_number": 20973749,
+        "l1_fees": {
+            "blob_fee": 29330,
+            "base_fee": 11435533437
+        },
+        "parent_header": {
+            "excess_mana": 1303442023,
+            "mana_used": 112024559,
+            "proving_cost_per_mana_numerator": 80126553,
+            "fee_asset_price_numerator": 2827578672
+        },
+        "header": {
+            "excess_mana": 1315466582,
+            "mana_used": 120164071,
+            "proving_cost_per_mana_numerator": 56045946,
+            "fee_asset_price_numerator": 3348463536
+        },
+        "oracle_input": {
+            "proving_cost_modifier": -24080607,
+            "fee_asset_price_modifier": 520884864
+        },
+        "outputs": {
+            "fee_asset_price_at_execution": 10286793414,
+            "mana_base_fee_components_in_wei": {
+                "data_cost": 115,
+                "gas_cost": 37880204,
+                "proving_cost": 5419698833,
+                "congestion_cost": 19976785911,
+                "congestion_multiplier": 4660374931
+            },
+            "mana_base_fee_components_in_fee_asset": {
+                "data_cost": 1182,
+                "gas_cost": 389665833,
+                "proving_cost": 55751322261,
+                "congestion_cost": 205497069742,
+                "congestion_multiplier": 4660374931
+            }
+        }
+    },
+    {
+        "l1_block_number": 20973752,
+        "l1_fees": {
+            "blob_fee": 41761,
+            "base_fee": 11193020248
+        },
+        "parent_header": {
+            "excess_mana": 1315466582,
+            "mana_used": 120164071,
+            "proving_cost_per_mana_numerator": 56045946,
+            "fee_asset_price_numerator": 3348463536
+        },
+        "header": {
+            "excess_mana": 1335630653,
+            "mana_used": 94218981,
+            "proving_cost_per_mana_numerator": 26648853,
+            "fee_asset_price_numerator": 3252411517
+        },
+        "oracle_input": {
+            "proving_cost_modifier": -29397093,
+            "fee_asset_price_modifier": -96052019
+        },
+        "outputs": {
+            "fee_asset_price_at_execution": 10340515557,
+            "mana_base_fee_components_in_wei": {
+                "data_cost": 164,
+                "gas_cost": 37076879,
+                "proving_cost": 5418393894,
+                "congestion_cost": 20576015236,
+                "congestion_multiplier": 4771629521
+            },
+            "mana_base_fee_components_in_fee_asset": {
+                "data_cost": 1695,
+                "gas_cost": 383394044,
+                "proving_cost": 56028986354,
+                "congestion_cost": 212766605648,
+                "congestion_multiplier": 4771629521
+            }
+        }
+    },
+    {
+        "l1_block_number": 20973755,
+        "l1_fees": {
+            "blob_fee": 30505,
+            "base_fee": 10757053816
+        },
+        "parent_header": {
+            "excess_mana": 1335630653,
+            "mana_used": 94218981,
+            "proving_cost_per_mana_numerator": 26648853,
+            "fee_asset_price_numerator": 3252411517
+        },
+        "header": {
+            "excess_mana": 1329849634,
+            "mana_used": 105066595,
+            "proving_cost_per_mana_numerator": 0,
+            "fee_asset_price_numerator": 3510685066
+        },
+        "oracle_input": {
+            "proving_cost_modifier": -199703229,
+            "fee_asset_price_modifier": 258273549
+        },
+        "outputs": {
+            "fee_asset_price_at_execution": 10330588052,
+            "mana_base_fee_components_in_wei": {
+                "data_cost": 119,
+                "gas_cost": 35632740,
+                "proving_cost": 5416801278,
+                "congestion_cost": 20389181783,
+                "congestion_multiplier": 4739464113
+            },
+            "mana_base_fee_components_in_fee_asset": {
+                "data_cost": 1229,
+                "gas_cost": 368107158,
+                "proving_cost": 55958742562,
+                "congestion_cost": 210632237717,
+                "congestion_multiplier": 4739464113
+            }
+        }
+    },
+    {
+        "l1_block_number": 20973758,
+        "l1_fees": {
+            "blob_fee": 25067,
+            "base_fee": 10381187963
+        },
+        "parent_header": {
+            "excess_mana": 1329849634,
+            "mana_used": 105066595,
+            "proving_cost_per_mana_numerator": 0,
+            "fee_asset_price_numerator": 3510685066
+        },
+        "header": {
+            "excess_mana": 1334916229,
+            "mana_used": 89931642,
+            "proving_cost_per_mana_numerator": 0,
+            "fee_asset_price_numerator": 3335505808
+        },
+        "oracle_input": {
+            "proving_cost_modifier": -49792707,
+            "fee_asset_price_modifier": -175179258
+        },
+        "outputs": {
+            "fee_asset_price_at_execution": 10357303713,
+            "mana_base_fee_components_in_wei": {
+                "data_cost": 98,
+                "gas_cost": 34387685,
+                "proving_cost": 5415357955,
+                "congestion_cost": 20532694724,
+                "congestion_multiplier": 4767642696
+            },
+            "mana_base_fee_components_in_fee_asset": {
+                "data_cost": 1015,
+                "gas_cost": 356163697,
+                "proving_cost": 56088507054,
+                "congestion_cost": 212663355302,
+                "congestion_multiplier": 4767642696
+            }
+        }
+    },
+    {
+        "l1_block_number": 20973761,
+        "l1_fees": {
+            "blob_fee": 25067,
+            "base_fee": 12244616598
+        },
+        "parent_header": {
+            "excess_mana": 1334916229,
+            "mana_used": 89931642,
+            "proving_cost_per_mana_numerator": 0,
+            "fee_asset_price_numerator": 3335505808
+        },
+        "header": {
+            "excess_mana": 1324847871,
+            "mana_used": 101874759,
+            "proving_cost_per_mana_numerator": 90251834,
+            "fee_asset_price_numerator": 3015527291
+        },
+        "oracle_input": {
+            "proving_cost_modifier": 90251834,
+            "fee_asset_price_modifier": -319978517
+        },
+        "outputs": {
+            "fee_asset_price_at_execution": 10339175748,
+            "mana_base_fee_components_in_wei": {
+                "data_cost": 98,
+                "gas_cost": 40560292,
+                "proving_cost": 5415357955,
+                "congestion_cost": 20251329375,
+                "congestion_multiplier": 4711809469
+            },
+            "mana_base_fee_components_in_fee_asset": {
+                "data_cost": 1013,
+                "gas_cost": 419359987,
+                "proving_cost": 55990337635,
+                "congestion_cost": 209382053538,
+                "congestion_multiplier": 4711809469
+            }
+        }
+    },
+    {
+        "l1_block_number": 20973764,
+        "l1_fees": {
+            "blob_fee": 20599,
+            "base_fee": 11587680957
+        },
+        "parent_header": {
+            "excess_mana": 1324847871,
+            "mana_used": 101874759,
+            "proving_cost_per_mana_numerator": 90251834,
+            "fee_asset_price_numerator": 3015527291
+        },
+        "header": {
+            "excess_mana": 1326722630,
+            "mana_used": 94633541,
+            "proving_cost_per_mana_numerator": 0,
+            "fee_asset_price_numerator": 2948017643
+        },
+        "oracle_input": {
+            "proving_cost_modifier": -202786759,
+            "fee_asset_price_modifier": -67509648
+        },
+        "outputs": {
+            "fee_asset_price_at_execution": 10306145480,
+            "mana_base_fee_components_in_wei": {
+                "data_cost": 80,
+                "gas_cost": 38384193,
+                "proving_cost": 5420247621,
+                "congestion_cost": 20317879543,
+                "congestion_multiplier": 4722156016
+            },
+            "mana_base_fee_components_in_fee_asset": {
+                "data_cost": 824,
+                "gas_cost": 395593077,
+                "proving_cost": 55861860519,
+                "congestion_cost": 209399022415,
+                "congestion_multiplier": 4722156016
+            }
+        }
+    },
+    {
+        "l1_block_number": 20973767,
+        "l1_fees": {
+            "blob_fee": 23174,
+            "base_fee": 11392419394
+        },
+        "parent_header": {
+            "excess_mana": 1326722630,
+            "mana_used": 94633541,
+            "proving_cost_per_mana_numerator": 0,
+            "fee_asset_price_numerator": 2948017643
+        },
+        "header": {
+            "excess_mana": 1321356171,
+            "mana_used": 107027137,
+            "proving_cost_per_mana_numerator": 0,
+            "fee_asset_price_numerator": 2964670861
+        },
+        "oracle_input": {
+            "proving_cost_modifier": -569992,
+            "fee_asset_price_modifier": 16653218
+        },
+        "outputs": {
+            "fee_asset_price_at_execution": 10299190185,
+            "mana_base_fee_components_in_wei": {
+                "data_cost": 91,
+                "gas_cost": 37737389,
+                "proving_cost": 5415357955,
+                "congestion_cost": 20136098191,
+                "congestion_multiplier": 4692599631
+            },
+            "mana_base_fee_components_in_fee_asset": {
+                "data_cost": 937,
+                "gas_cost": 388664546,
+                "proving_cost": 55773801498,
+                "congestion_cost": 207385504852,
+                "congestion_multiplier": 4692599631
+            }
+        }
+    },
+    {
+        "l1_block_number": 20973770,
+        "l1_fees": {
+            "blob_fee": 26071,
+            "base_fee": 11075431045
+        },
+        "parent_header": {
+            "excess_mana": 1321356171,
+            "mana_used": 107027137,
+            "proving_cost_per_mana_numerator": 0,
+            "fee_asset_price_numerator": 2964670861
+        },
+        "header": {
+            "excess_mana": 1328383308,
+            "mana_used": 98027217,
+            "proving_cost_per_mana_numerator": 0,
+            "fee_asset_price_numerator": 2914036442
+        },
+        "oracle_input": {
+            "proving_cost_modifier": -8209932,
+            "fee_asset_price_modifier": -50634419
+        },
+        "outputs": {
+            "fee_asset_price_at_execution": 10300905475,
+            "mana_base_fee_components_in_wei": {
+                "data_cost": 102,
+                "gas_cost": 36687365,
+                "proving_cost": 5415357955,
+                "congestion_cost": 20343435448,
+                "congestion_multiplier": 4731340052
+            },
+            "mana_base_fee_components_in_fee_asset": {
+                "data_cost": 1050,
+                "gas_cost": 377913078,
+                "proving_cost": 55783090407,
+                "congestion_cost": 209555805586,
+                "congestion_multiplier": 4731340052
+            }
+        }
+    },
+    {
+        "l1_block_number": 20973773,
+        "l1_fees": {
+            "blob_fee": 20599,
+            "base_fee": 11109198013
+        },
+        "parent_header": {
+            "excess_mana": 1328383308,
+            "mana_used": 98027217,
+            "proving_cost_per_mana_numerator": 0,
+            "fee_asset_price_numerator": 2914036442
+        },
+        "header": {
+            "excess_mana": 1326410525,
+            "mana_used": 95385211,
+            "proving_cost_per_mana_numerator": 85267716,
+            "fee_asset_price_numerator": 3385377647
+        },
+        "oracle_input": {
+            "proving_cost_modifier": 85267716,
+            "fee_asset_price_modifier": 471341205
+        },
+        "outputs": {
+            "fee_asset_price_at_execution": 10295690992,
+            "mana_base_fee_components_in_wei": {
+                "data_cost": 80,
+                "gas_cost": 36799218,
+                "proving_cost": 5415357955,
+                "congestion_cost": 20284380171,
+                "congestion_multiplier": 4720431974
+            },
+            "mana_base_fee_components_in_fee_asset": {
+                "data_cost": 823,
+                "gas_cost": 378873377,
+                "proving_cost": 55754852115,
+                "congestion_cost": 208841710204,
+                "congestion_multiplier": 4720431974
+            }
+        }
+    },
+    {
+        "l1_block_number": 20973776,
+        "l1_fees": {
+            "blob_fee": 19044,
+            "base_fee": 10883747585
+        },
+        "parent_header": {
+            "excess_mana": 1326410525,
+            "mana_used": 95385211,
+            "proving_cost_per_mana_numerator": 85267716,
+            "fee_asset_price_numerator": 3385377647
+        },
+        "header": {
+            "excess_mana": 1321795736,
+            "mana_used": 108511444,
+            "proving_cost_per_mana_numerator": 0,
+            "fee_asset_price_numerator": 3548299411
+        },
+        "oracle_input": {
+            "proving_cost_modifier": -113972577,
+            "fee_asset_price_modifier": 162921764
+        },
+        "outputs": {
+            "fee_asset_price_at_execution": 10344333371,
+            "mana_base_fee_components_in_wei": {
+                "data_cost": 74,
+                "gas_cost": 36052413,
+                "proving_cost": 5419977476,
+                "congestion_cost": 20160104991,
+                "congestion_multiplier": 4695013614
+            },
+            "mana_base_fee_components_in_fee_asset": {
+                "data_cost": 765,
+                "gas_cost": 372938178,
+                "proving_cost": 56066053875,
+                "congestion_cost": 208542846821,
+                "congestion_multiplier": 4695013614
+            }
+        }
+    },
+    {
+        "l1_block_number": 20973779,
+        "l1_fees": {
+            "blob_fee": 15649,
+            "base_fee": 10780629747
+        },
+        "parent_header": {
+            "excess_mana": 1321795736,
+            "mana_used": 108511444,
+            "proving_cost_per_mana_numerator": 0,
+            "fee_asset_price_numerator": 3548299411
+        },
+        "header": {
+            "excess_mana": 1330307180,
+            "mana_used": 93449181,
+            "proving_cost_per_mana_numerator": 0,
+            "fee_asset_price_numerator": 3189620902
+        },
+        "oracle_input": {
+            "proving_cost_modifier": -93357778,
+            "fee_asset_price_modifier": -358678509
+        },
+        "outputs": {
+            "fee_asset_price_at_execution": 10361200278,
+            "mana_base_fee_components_in_wei": {
+                "data_cost": 61,
+                "gas_cost": 35710836,
+                "proving_cost": 5415357955,
+                "congestion_cost": 20397910350,
+                "congestion_multiplier": 4742001964
+            },
+            "mana_base_fee_components_in_fee_asset": {
+                "data_cost": 632,
+                "gas_cost": 370007123,
+                "proving_cost": 56109608348,
+                "congestion_cost": 211346834389,
+                "congestion_multiplier": 4742001964
+            }
+        }
+    },
+    {
+        "l1_block_number": 20973782,
+        "l1_fees": {
+            "blob_fee": 13910,
+            "base_fee": 11769070727
+        },
+        "parent_header": {
+            "excess_mana": 1330307180,
+            "mana_used": 93449181,
+            "proving_cost_per_mana_numerator": 0,
+            "fee_asset_price_numerator": 3189620902
+        },
+        "header": {
+            "excess_mana": 1323756361,
+            "mana_used": 102696150,
+            "proving_cost_per_mana_numerator": 0,
+            "fee_asset_price_numerator": 3501596935
+        },
+        "oracle_input": {
+            "proving_cost_modifier": -140392501,
+            "fee_asset_price_modifier": 311976033
+        },
+        "outputs": {
+            "fee_asset_price_at_execution": 10324103448,
+            "mana_base_fee_components_in_wei": {
+                "data_cost": 54,
+                "gas_cost": 38985046,
+                "proving_cost": 5415357955,
+                "congestion_cost": 20212682757,
+                "congestion_multiplier": 4705796015
+            },
+            "mana_base_fee_components_in_fee_asset": {
+                "data_cost": 557,
+                "gas_cost": 402485647,
+                "proving_cost": 55908715735,
+                "congestion_cost": 208677827744,
+                "congestion_multiplier": 4705796015
+            }
+        }
+    },
+    {
+        "l1_block_number": 20973785,
+        "l1_fees": {
+            "blob_fee": 14467,
+            "base_fee": 11246048481
+        },
+        "parent_header": {
+            "excess_mana": 1323756361,
+            "mana_used": 102696150,
+            "proving_cost_per_mana_numerator": 0,
+            "fee_asset_price_numerator": 3501596935
+        },
+        "header": {
+            "excess_mana": 1326452511,
+            "mana_used": 114672112,
+            "proving_cost_per_mana_numerator": 169825398,
+            "fee_asset_price_numerator": 2803029127
+        },
+        "oracle_input": {
+            "proving_cost_modifier": 169825398,
+            "fee_asset_price_modifier": -698567808
+        },
+        "outputs": {
+            "fee_asset_price_at_execution": 10356362471,
+            "mana_base_fee_components_in_wei": {
+                "data_cost": 56,
+                "gas_cost": 37252535,
+                "proving_cost": 5415357955,
+                "congestion_cost": 20287331028,
+                "congestion_multiplier": 4720663865
+            },
+            "mana_base_fee_components_in_fee_asset": {
+                "data_cost": 579,
+                "gas_cost": 385800755,
+                "proving_cost": 56083409892,
+                "congestion_cost": 210102953695,
+                "congestion_multiplier": 4720663865
+            }
+        }
+    },
+    {
+        "l1_block_number": 20973788,
+        "l1_fees": {
+            "blob_fee": 11431,
+            "base_fee": 11164890840
+        },
+        "parent_header": {
+            "excess_mana": 1326452511,
+            "mana_used": 114672112,
+            "proving_cost_per_mana_numerator": 169825398,
+            "fee_asset_price_numerator": 2803029127
+        },
+        "header": {
+            "excess_mana": 1341124623,
+            "mana_used": 91197669,
+            "proving_cost_per_mana_numerator": 185721686,
+            "fee_asset_price_numerator": 3523632779
+        },
+        "oracle_input": {
+            "proving_cost_modifier": 15896288,
+            "fee_asset_price_modifier": 720603652
+        },
+        "outputs": {
+            "fee_asset_price_at_execution": 10284268363,
+            "mana_base_fee_components_in_wei": {
+                "data_cost": 44,
+                "gas_cost": 36983700,
+                "proving_cost": 5424562421,
+                "congestion_cost": 20766983585,
+                "congestion_multiplier": 4802400082
+            },
+            "mana_base_fee_components_in_fee_asset": {
+                "data_cost": 452,
+                "gas_cost": 380350295,
+                "proving_cost": 55787655689,
+                "congestion_cost": 213573232278,
+                "congestion_multiplier": 4802400082
+            }
+        }
+    },
+    {
+        "l1_block_number": 20973791,
+        "l1_fees": {
+            "blob_fee": 10991,
+            "base_fee": 10813707297
+        },
+        "parent_header": {
+            "excess_mana": 1341124623,
+            "mana_used": 91197669,
+            "proving_cost_per_mana_numerator": 185721686,
+            "fee_asset_price_numerator": 3523632779
+        },
+        "header": {
+            "excess_mana": 1332322292,
+            "mana_used": 106948598,
+            "proving_cost_per_mana_numerator": 0,
+            "fee_asset_price_numerator": 3627293630
+        },
+        "oracle_input": {
+            "proving_cost_modifier": -193404025,
+            "fee_asset_price_modifier": 103660851
+        },
+        "outputs": {
+            "fee_asset_price_at_execution": 10358644834,
+            "mana_base_fee_components_in_wei": {
+                "data_cost": 43,
+                "gas_cost": 35820405,
+                "proving_cost": 5425424794,
+                "congestion_cost": 20497119876,
+                "congestion_multiplier": 4753195282
+            },
+            "mana_base_fee_components_in_fee_asset": {
+                "data_cost": 445,
+                "gas_cost": 371050853,
+                "proving_cost": 56200048514,
+                "congestion_cost": 212322384915,
+                "congestion_multiplier": 4753195282
+            }
+        }
+    },
+    {
+        "l1_block_number": 20973794,
+        "l1_fees": {
+            "blob_fee": 11431,
+            "base_fee": 11438721490
+        },
+        "parent_header": {
+            "excess_mana": 1332322292,
+            "mana_used": 106948598,
+            "proving_cost_per_mana_numerator": 0,
+            "fee_asset_price_numerator": 3627293630
+        },
+        "header": {
+            "excess_mana": 1339270890,
+            "mana_used": 98247953,
+            "proving_cost_per_mana_numerator": 0,
+            "fee_asset_price_numerator": 3405798460
+        },
+        "oracle_input": {
+            "proving_cost_modifier": -104227219,
+            "fee_asset_price_modifier": -221495170
+        },
+        "outputs": {
+            "fee_asset_price_at_execution": 10369388261,
+            "mana_base_fee_components_in_wei": {
+                "data_cost": 44,
+                "gas_cost": 37890764,
+                "proving_cost": 5415357955,
+                "congestion_cost": 20678695309,
+                "congestion_multiplier": 4791995599
+            },
+            "mana_base_fee_components_in_fee_asset": {
+                "data_cost": 456,
+                "gas_cost": 392904043,
+                "proving_cost": 56153949207,
+                "congestion_cost": 214425420389,
+                "congestion_multiplier": 4791995599
+            }
+        }
+    },
+    {
+        "l1_block_number": 20973797,
+        "l1_fees": {
+            "blob_fee": 13910,
+            "base_fee": 10815929413
+        },
+        "parent_header": {
+            "excess_mana": 1339270890,
+            "mana_used": 98247953,
+            "proving_cost_per_mana_numerator": 0,
+            "fee_asset_price_numerator": 3405798460
+        },
+        "header": {
+            "excess_mana": 1337518843,
+            "mana_used": 93403246,
+            "proving_cost_per_mana_numerator": 0,
+            "fee_asset_price_numerator": 4405798460
+        },
+        "oracle_input": {
+            "proving_cost_modifier": -24507243,
+            "fee_asset_price_modifier": 1000000000
+        },
+        "outputs": {
+            "fee_asset_price_at_execution": 10346445984,
+            "mana_base_fee_components_in_wei": {
+                "data_cost": 54,
+                "gas_cost": 35827766,
+                "proving_cost": 5415357955,
+                "congestion_cost": 20617379840,
+                "congestion_multiplier": 4782182573
+            },
+            "mana_base_fee_components_in_fee_asset": {
+                "data_cost": 558,
+                "gas_cost": 370690045,
+                "proving_cost": 56029708565,
+                "congestion_cost": 213316606846,
+                "congestion_multiplier": 4782182573
+            }
+        }
+    },
+    {
+        "l1_block_number": 20973800,
+        "l1_fees": {
+            "blob_fee": 10991,
+            "base_fee": 10583530192
+        },
+        "parent_header": {
+            "excess_mana": 1337518843,
+            "mana_used": 93403246,
+            "proving_cost_per_mana_numerator": 0,
+            "fee_asset_price_numerator": 4405798460
+        },
+        "header": {
+            "excess_mana": 1330922089,
+            "mana_used": 89690723,
+            "proving_cost_per_mana_numerator": 0,
+            "fee_asset_price_numerator": 4114053528
+        },
+        "oracle_input": {
+            "proving_cost_modifier": -22027852,
+            "fee_asset_price_modifier": -291744932
+        },
+        "outputs": {
+            "fee_asset_price_at_execution": 10450429495,
+            "mana_base_fee_components_in_wei": {
+                "data_cost": 43,
+                "gas_cost": 35057943,
+                "proving_cost": 5415357955,
+                "congestion_cost": 20414068498,
+                "congestion_multiplier": 4745414794
+            },
+            "mana_base_fee_components_in_fee_asset": {
+                "data_cost": 449,
+                "gas_cost": 366370561,
+                "proving_cost": 56592816498,
+                "congestion_cost": 213335783544,
+                "congestion_multiplier": 4745414794
+            }
+        }
+    },
+    {
+        "l1_block_number": 20973803,
+        "l1_fees": {
+            "blob_fee": 9032,
+            "base_fee": 11186336309
+        },
+        "parent_header": {
+            "excess_mana": 1330922089,
+            "mana_used": 89690723,
+            "proving_cost_per_mana_numerator": 0,
+            "fee_asset_price_numerator": 4114053528
+        },
+        "header": {
+            "excess_mana": 1320612812,
+            "mana_used": 87770657,
+            "proving_cost_per_mana_numerator": 0,
+            "fee_asset_price_numerator": 4743652738
+        },
+        "oracle_input": {
+            "proving_cost_modifier": -11552448,
+            "fee_asset_price_modifier": 629599210
+        },
+        "outputs": {
+            "fee_asset_price_at_execution": 10419985328,
+            "mana_base_fee_components_in_wei": {
+                "data_cost": 35,
+                "gas_cost": 37054739,
+                "proving_cost": 5415357955,
+                "congestion_cost": 20111334004,
+                "congestion_multiplier": 4688520111
+            },
+            "mana_base_fee_components_in_fee_asset": {
+                "data_cost": 364,
+                "gas_cost": 386109836,
+                "proving_cost": 56427950436,
+                "congestion_cost": 209559805248,
+                "congestion_multiplier": 4688520111
+            }
+        }
+    },
+    {
+        "l1_block_number": 20973806,
+        "l1_fees": {
+            "blob_fee": 8684,
+            "base_fee": 11129408959
+        },
+        "parent_header": {
+            "excess_mana": 1320612812,
+            "mana_used": 87770657,
+            "proving_cost_per_mana_numerator": 0,
+            "fee_asset_price_numerator": 4743652738
+        },
+        "header": {
+            "excess_mana": 1308383469,
+            "mana_used": 102859592,
+            "proving_cost_per_mana_numerator": 0,
+            "fee_asset_price_numerator": 5197759505
+        },
+        "oracle_input": {
+            "proving_cost_modifier": -4484625,
+            "fee_asset_price_modifier": 454106767
+        },
+        "outputs": {
+            "fee_asset_price_at_execution": 10485796429,
+            "mana_base_fee_components_in_wei": {
+                "data_cost": 34,
+                "gas_cost": 36866167,
+                "proving_cost": 5415357955,
+                "congestion_cost": 19747480824,
+                "congestion_multiplier": 4621912867
+            },
+            "mana_base_fee_components_in_fee_asset": {
+                "data_cost": 356,
+                "gas_cost": 386571122,
+                "proving_cost": 56784341106,
+                "congestion_cost": 207068063906,
+                "congestion_multiplier": 4621912867
+            }
+        }
+    },
+    {
+        "l1_block_number": 20973809,
+        "l1_fees": {
+            "blob_fee": 8684,
+            "base_fee": 11133709414
+        },
+        "parent_header": {
+            "excess_mana": 1308383469,
+            "mana_used": 102859592,
+            "proving_cost_per_mana_numerator": 0,
+            "fee_asset_price_numerator": 5197759505
+        },
+        "header": {
+            "excess_mana": 1311243061,
+            "mana_used": 114671108,
+            "proving_cost_per_mana_numerator": 0,
+            "fee_asset_price_numerator": 6197759505
+        },
+        "oracle_input": {
+            "proving_cost_modifier": -117737933,
+            "fee_asset_price_modifier": 1000000000
+        },
+        "outputs": {
+            "fee_asset_price_at_execution": 10533521419,
+            "mana_base_fee_components_in_wei": {
+                "data_cost": 34,
+                "gas_cost": 36880412,
+                "proving_cost": 5415357955,
+                "congestion_cost": 19831985061,
+                "congestion_multiplier": 4637402403
+            },
+            "mana_base_fee_components_in_fee_asset": {
+                "data_cost": 358,
+                "gas_cost": 388480609,
+                "proving_cost": 57042789010,
+                "congestion_cost": 208900639421,
+                "congestion_multiplier": 4637402403
+            }
+        }
+    },
+    {
+        "l1_block_number": 20973812,
+        "l1_fees": {
+            "blob_fee": 9770,
+            "base_fee": 10564687507
+        },
+        "parent_header": {
+            "excess_mana": 1311243061,
+            "mana_used": 114671108,
+            "proving_cost_per_mana_numerator": 0,
+            "fee_asset_price_numerator": 6197759505
+        },
+        "header": {
+            "excess_mana": 1325914169,
+            "mana_used": 96314421,
+            "proving_cost_per_mana_numerator": 0,
+            "fee_asset_price_numerator": 7197759505
+        },
+        "oracle_input": {
+            "proving_cost_modifier": -61178209,
+            "fee_asset_price_modifier": 1000000000
+        },
+        "outputs": {
+            "fee_asset_price_at_execution": 10639385069,
+            "mana_base_fee_components_in_wei": {
+                "data_cost": 38,
+                "gas_cost": 34995527,
+                "proving_cost": 5415357955,
+                "congestion_cost": 20262732642,
+                "congestion_multiplier": 4717691443
+            },
+            "mana_base_fee_components_in_fee_asset": {
+                "data_cost": 404,
+                "gas_cost": 372330887,
+                "proving_cost": 57616078569,
+                "congestion_cost": 215583015128,
+                "congestion_multiplier": 4717691443
+            }
+        }
+    },
+    {
+        "l1_block_number": 20973815,
+        "l1_fees": {
+            "blob_fee": 10991,
+            "base_fee": 9916160334
+        },
+        "parent_header": {
+            "excess_mana": 1325914169,
+            "mana_used": 96314421,
+            "proving_cost_per_mana_numerator": 0,
+            "fee_asset_price_numerator": 7197759505
+        },
+        "header": {
+            "excess_mana": 1322228590,
+            "mana_used": 105614317,
+            "proving_cost_per_mana_numerator": 87880734,
+            "fee_asset_price_numerator": 7535535998
+        },
+        "oracle_input": {
+            "proving_cost_modifier": 87880734,
+            "fee_asset_price_modifier": 337776493
+        },
+        "outputs": {
+            "fee_asset_price_at_execution": 10746312667,
+            "mana_base_fee_components_in_wei": {
+                "data_cost": 43,
+                "gas_cost": 32847281,
+                "proving_cost": 5415357955,
+                "congestion_cost": 20144150367,
+                "congestion_multiplier": 4697391955
+            },
+            "mana_base_fee_components_in_fee_asset": {
+                "data_cost": 462,
+                "gas_cost": 352987151,
+                "proving_cost": 58195129788,
+                "congestion_cost": 216475338254,
+                "congestion_multiplier": 4697391955
+            }
+        }
+    },
+    {
+        "l1_block_number": 20973818,
+        "l1_fees": {
+            "blob_fee": 9770,
+            "base_fee": 11009914791
+        },
+        "parent_header": {
+            "excess_mana": 1322228590,
+            "mana_used": 105614317,
+            "proving_cost_per_mana_numerator": 87880734,
+            "fee_asset_price_numerator": 7535535998
+        },
+        "header": {
+            "excess_mana": 1327842907,
+            "mana_used": 104200639,
+            "proving_cost_per_mana_numerator": 136531463,
+            "fee_asset_price_numerator": 6535535998
+        },
+        "oracle_input": {
+            "proving_cost_modifier": 48650729,
+            "fee_asset_price_modifier": -1000000000
+        },
+        "outputs": {
+            "fee_asset_price_at_execution": 10782672558,
+            "mana_base_fee_components_in_wei": {
+                "data_cost": 38,
+                "gas_cost": 36470342,
+                "proving_cost": 5420119103,
+                "congestion_cost": 20344072763,
+                "congestion_multiplier": 4728349517
+            },
+            "mana_base_fee_components_in_fee_asset": {
+                "data_cost": 409,
+                "gas_cost": 393247755,
+                "proving_cost": 58443369513,
+                "congestion_cost": 219363475099,
+                "congestion_multiplier": 4728349517
+            }
+        }
+    },
+    {
+        "l1_block_number": 20973821,
+        "l1_fees": {
+            "blob_fee": 10568,
+            "base_fee": 11544661257
+        },
+        "parent_header": {
+            "excess_mana": 1327842907,
+            "mana_used": 104200639,
+            "proving_cost_per_mana_numerator": 136531463,
+            "fee_asset_price_numerator": 6535535998
+        },
+        "header": {
+            "excess_mana": 1332043546,
+            "mana_used": 95146481,
+            "proving_cost_per_mana_numerator": 93236650,
+            "fee_asset_price_numerator": 6189753188
+        },
+        "oracle_input": {
+            "proving_cost_modifier": -43294813,
+            "fee_asset_price_modifier": -345782810
+        },
+        "outputs": {
+            "fee_asset_price_at_execution": 10675383173,
+            "mana_base_fee_components_in_wei": {
+                "data_cost": 41,
+                "gas_cost": 38241690,
+                "proving_cost": 5422756672,
+                "congestion_cost": 20487729330,
+                "congestion_multiplier": 4751645362
+            },
+            "mana_base_fee_components_in_fee_asset": {
+                "data_cost": 437,
+                "gas_cost": 408244693,
+                "proving_cost": 57890005327,
+                "congestion_cost": 218714360942,
+                "congestion_multiplier": 4751645362
+            }
+        }
+    },
+    {
+        "l1_block_number": 20973824,
+        "l1_fees": {
+            "blob_fee": 9032,
+            "base_fee": 11598807653
+        },
+        "parent_header": {
+            "excess_mana": 1332043546,
+            "mana_used": 95146481,
+            "proving_cost_per_mana_numerator": 93236650,
+            "fee_asset_price_numerator": 6189753188
+        },
+        "header": {
+            "excess_mana": 1327190027,
+            "mana_used": 85556181,
+            "proving_cost_per_mana_numerator": 194872565,
+            "fee_asset_price_numerator": 6205591853
+        },
+        "oracle_input": {
+            "proving_cost_modifier": 101635915,
+            "fee_asset_price_modifier": 15838665
+        },
+        "outputs": {
+            "fee_asset_price_at_execution": 10638533280,
+            "mana_base_fee_components_in_wei": {
+                "data_cost": 35,
+                "gas_cost": 38421050,
+                "proving_cost": 5420409407,
+                "congestion_cost": 20332719122,
+                "congestion_multiplier": 4724739054
+            },
+            "mana_base_fee_components_in_fee_asset": {
+                "data_cost": 372,
+                "gas_cost": 408743619,
+                "proving_cost": 57665205867,
+                "congestion_cost": 216310309052,
+                "congestion_multiplier": 4724739054
+            }
+        }
+    },
+    {
+        "l1_block_number": 20973827,
+        "l1_fees": {
+            "blob_fee": 9032,
+            "base_fee": 11635181863
+        },
+        "parent_header": {
+            "excess_mana": 1327190027,
+            "mana_used": 85556181,
+            "proving_cost_per_mana_numerator": 194872565,
+            "fee_asset_price_numerator": 6205591853
+        },
+        "header": {
+            "excess_mana": 1312746208,
+            "mana_used": 100135907,
+            "proving_cost_per_mana_numerator": 240667911,
+            "fee_asset_price_numerator": 6278612236
+        },
+        "oracle_input": {
+            "proving_cost_modifier": 45795346,
+            "fee_asset_price_modifier": 73020383
+        },
+        "outputs": {
+            "fee_asset_price_at_execution": 10640218416,
+            "mana_base_fee_components_in_wei": {
+                "data_cost": 35,
+                "gas_cost": 38541539,
+                "proving_cost": 5425921291,
+                "congestion_cost": 19921056176,
+                "congestion_multiplier": 4645565295
+            },
+            "mana_base_fee_components_in_fee_asset": {
+                "data_cost": 372,
+                "gas_cost": 410090393,
+                "proving_cost": 57732987644,
+                "congestion_cost": 211964388790,
+                "congestion_multiplier": 4645565295
+            }
+        }
+    },
+    {
+        "l1_block_number": 20973830,
+        "l1_fees": {
+            "blob_fee": 9770,
+            "base_fee": 10954393731
+        },
+        "parent_header": {
+            "excess_mana": 1312746208,
+            "mana_used": 100135907,
+            "proving_cost_per_mana_numerator": 240667911,
+            "fee_asset_price_numerator": 6278612236
+        },
+        "header": {
+            "excess_mana": 1312882115,
+            "mana_used": 102142387,
+            "proving_cost_per_mana_numerator": 301905516,
+            "fee_asset_price_numerator": 6462410828
+        },
+        "oracle_input": {
+            "proving_cost_modifier": 61237605,
+            "fee_asset_price_modifier": 183798592
+        },
+        "outputs": {
+            "fee_asset_price_at_execution": 10647990781,
+            "mana_base_fee_components_in_wei": {
+                "data_cost": 38,
+                "gas_cost": 36286429,
+                "proving_cost": 5428406679,
+                "congestion_cost": 19925932750,
+                "congestion_multiplier": 4646304050
+            },
+            "mana_base_fee_components_in_fee_asset": {
+                "data_cost": 404,
+                "gas_cost": 386377561,
+                "proving_cost": 57801624273,
+                "congestion_cost": 212171148224,
+                "congestion_multiplier": 4646304050
+            }
+        }
+    },
+    {
+        "l1_block_number": 20973833,
+        "l1_fees": {
+            "blob_fee": 9032,
+            "base_fee": 12832884693
+        },
+        "parent_header": {
+            "excess_mana": 1312882115,
+            "mana_used": 102142387,
+            "proving_cost_per_mana_numerator": 301905516,
+            "fee_asset_price_numerator": 6462410828
+        },
+        "header": {
+            "excess_mana": 1315024502,
+            "mana_used": 108099379,
+            "proving_cost_per_mana_numerator": 186947548,
+            "fee_asset_price_numerator": 6196588479
+        },
+        "oracle_input": {
+            "proving_cost_modifier": -114957968,
+            "fee_asset_price_modifier": -265822349
+        },
+        "outputs": {
+            "fee_asset_price_at_execution": 10667579635,
+            "mana_base_fee_components_in_wei": {
+                "data_cost": 35,
+                "gas_cost": 42508930,
+                "proving_cost": 5431731923,
+                "congestion_cost": 20024581849,
+                "congestion_multiplier": 4657965051
+            },
+            "mana_base_fee_components_in_fee_asset": {
+                "data_cost": 373,
+                "gas_cost": 453467395,
+                "proving_cost": 57943432844,
+                "congestion_cost": 213613821531,
+                "congestion_multiplier": 4657965051
+            }
+        }
+    },
+    {
+        "l1_block_number": 20973836,
+        "l1_fees": {
+            "blob_fee": 7422,
+            "base_fee": 11598902204
+        },
+        "parent_header": {
+            "excess_mana": 1315024502,
+            "mana_used": 108099379,
+            "proving_cost_per_mana_numerator": 186947548,
+            "fee_asset_price_numerator": 6196588479
+        },
+        "header": {
+            "excess_mana": 1323123881,
+            "mana_used": 112983367,
+            "proving_cost_per_mana_numerator": 317869118,
+            "fee_asset_price_numerator": 5612257785
+        },
+        "oracle_input": {
+            "proving_cost_modifier": 130921570,
+            "fee_asset_price_modifier": -584330694
+        },
+        "outputs": {
+            "fee_asset_price_at_execution": 10639260480,
+            "mana_base_fee_components_in_wei": {
+                "data_cost": 29,
+                "gas_cost": 38421363,
+                "proving_cost": 5425491302,
+                "congestion_cost": 20229125958,
+                "congestion_multiplier": 4702315006
+            },
+            "mana_base_fee_components_in_fee_asset": {
+                "data_cost": 308,
+                "gas_cost": 408774888,
+                "proving_cost": 57723215193,
+                "congestion_cost": 215222940349,
+                "congestion_multiplier": 4702315006
+            }
+        }
+    },
+    {
+        "l1_block_number": 20973839,
+        "l1_fees": {
+            "blob_fee": 8684,
+            "base_fee": 11475907941
+        },
+        "parent_header": {
+            "excess_mana": 1323123881,
+            "mana_used": 112983367,
+            "proving_cost_per_mana_numerator": 317869118,
+            "fee_asset_price_numerator": 5612257785
+        },
+        "header": {
+            "excess_mana": 1336107248,
+            "mana_used": 78716153,
+            "proving_cost_per_mana_numerator": 324730950,
+            "fee_asset_price_numerator": 5123208967
+        },
+        "oracle_input": {
+            "proving_cost_modifier": 6861832,
+            "fee_asset_price_modifier": -489048818
+        },
+        "outputs": {
+            "fee_asset_price_at_execution": 10577273297,
+            "mana_base_fee_components_in_wei": {
+                "data_cost": 34,
+                "gas_cost": 38013945,
+                "proving_cost": 5432599093,
+                "congestion_cost": 20647685682,
+                "congestion_multiplier": 4774291000
+            },
+            "mana_base_fee_components_in_fee_asset": {
+                "data_cost": 359,
+                "gas_cost": 402083885,
+                "proving_cost": 57462085319,
+                "congestion_cost": 218396214409,
+                "congestion_multiplier": 4774291000
+            }
+        }
+    },
+    {
+        "l1_block_number": 20973842,
+        "l1_fees": {
+            "blob_fee": 9032,
+            "base_fee": 11221372712
+        },
+        "parent_header": {
+            "excess_mana": 1336107248,
+            "mana_used": 78716153,
+            "proving_cost_per_mana_numerator": 324730950,
+            "fee_asset_price_numerator": 5123208967
+        },
+        "header": {
+            "excess_mana": 1314823401,
+            "mana_used": 100573975,
+            "proving_cost_per_mana_numerator": 462472768,
+            "fee_asset_price_numerator": 5461974111
+        },
+        "oracle_input": {
+            "proving_cost_modifier": 137741818,
+            "fee_asset_price_modifier": 338765144
+        },
+        "outputs": {
+            "fee_asset_price_at_execution": 10525671549,
+            "mana_base_fee_components_in_wei": {
+                "data_cost": 35,
+                "gas_cost": 37170797,
+                "proving_cost": 5432971881,
+                "congestion_cost": 20003596494,
+                "congestion_multiplier": 4656869216
+            },
+            "mana_base_fee_components_in_fee_asset": {
+                "data_cost": 368,
+                "gas_cost": 391247600,
+                "proving_cost": 57185677554,
+                "congestion_cost": 210551286494,
+                "congestion_multiplier": 4656869216
+            }
+        }
+    },
+    {
+        "l1_block_number": 20973845,
+        "l1_fees": {
+            "blob_fee": 7136,
+            "base_fee": 11631406437
+        },
+        "parent_header": {
+            "excess_mana": 1314823401,
+            "mana_used": 100573975,
+            "proving_cost_per_mana_numerator": 462472768,
+            "fee_asset_price_numerator": 5461974111
+        },
+        "header": {
+            "excess_mana": 1315397376,
+            "mana_used": 109913708,
+            "proving_cost_per_mana_numerator": 413470065,
+            "fee_asset_price_numerator": 5513990530
+        },
+        "oracle_input": {
+            "proving_cost_modifier": -49002703,
+            "fee_asset_price_modifier": 52016419
+        },
+        "outputs": {
+            "fee_asset_price_at_execution": 10561389320,
+            "mana_base_fee_components_in_wei": {
+                "data_cost": 28,
+                "gas_cost": 38529033,
+                "proving_cost": 5440460512,
+                "congestion_cost": 20053088632,
+                "congestion_multiplier": 4659997590
+            },
+            "mana_base_fee_components_in_fee_asset": {
+                "data_cost": 295,
+                "gas_cost": 406920117,
+                "proving_cost": 57458821547,
+                "congestion_cost": 211788476111,
+                "congestion_multiplier": 4659997590
+            }
+        }
+    },
+    {
+        "l1_block_number": 20973848,
+        "l1_fees": {
+            "blob_fee": 9032,
+            "base_fee": 11248483537
+        },
+        "parent_header": {
+            "excess_mana": 1315397376,
+            "mana_used": 109913708,
+            "proving_cost_per_mana_numerator": 413470065,
+            "fee_asset_price_numerator": 5513990530
+        },
+        "header": {
+            "excess_mana": 1325311084,
+            "mana_used": 96372911,
+            "proving_cost_per_mana_numerator": 224365590,
+            "fee_asset_price_numerator": 6431399838
+        },
+        "oracle_input": {
+            "proving_cost_modifier": -189104475,
+            "fee_asset_price_modifier": 917409308
+        },
+        "outputs": {
+            "fee_asset_price_at_execution": 10566884406,
+            "mana_base_fee_components_in_wei": {
+                "data_cost": 35,
+                "gas_cost": 37260601,
+                "proving_cost": 5437795192,
+                "congestion_cost": 20336349006,
+                "congestion_multiplier": 4714363770
+            },
+            "mana_base_fee_components_in_fee_asset": {
+                "data_cost": 369,
+                "gas_cost": 393728463,
+                "proving_cost": 57460553217,
+                "congestion_cost": 214891849186,
+                "congestion_multiplier": 4714363770
+            }
+        }
+    },
+    {
+        "l1_block_number": 20973851,
+        "l1_fees": {
+            "blob_fee": 9393,
+            "base_fee": 10907228421
+        },
+        "parent_header": {
+            "excess_mana": 1325311084,
+            "mana_used": 96372911,
+            "proving_cost_per_mana_numerator": 224365590,
+            "fee_asset_price_numerator": 6431399838
+        },
+        "header": {
+            "excess_mana": 1321683995,
+            "mana_used": 108674213,
+            "proving_cost_per_mana_numerator": 293389751,
+            "fee_asset_price_numerator": 5928393552
+        },
+        "oracle_input": {
+            "proving_cost_modifier": 69024161,
+            "fee_asset_price_modifier": -503006286
+        },
+        "outputs": {
+            "fee_asset_price_at_execution": 10664272026,
+            "mana_base_fee_components_in_wei": {
+                "data_cost": 36,
+                "gas_cost": 36130194,
+                "proving_cost": 5427521795,
+                "congestion_cost": 20184915177,
+                "congestion_multiplier": 4694399842
+            },
+            "mana_base_fee_components_in_fee_asset": {
+                "data_cost": 383,
+                "gas_cost": 385302217,
+                "proving_cost": 57880568848,
+                "congestion_cost": 215257426269,
+                "congestion_multiplier": 4694399842
+            }
+        }
+    },
+    {
+        "l1_block_number": 20973854,
+        "l1_fees": {
+            "blob_fee": 7422,
+            "base_fee": 9545453468
+        },
+        "parent_header": {
+            "excess_mana": 1321683995,
+            "mana_used": 108674213,
+            "proving_cost_per_mana_numerator": 293389751,
+            "fee_asset_price_numerator": 5928393552
+        },
+        "header": {
+            "excess_mana": 1330358208,
+            "mana_used": 97567357,
+            "proving_cost_per_mana_numerator": 358988705,
+            "fee_asset_price_numerator": 5941926306
+        },
+        "oracle_input": {
+            "proving_cost_modifier": 65598954,
+            "fee_asset_price_modifier": 13532754
+        },
+        "outputs": {
+            "fee_asset_price_at_execution": 10610764752,
+            "mana_base_fee_components_in_wei": {
+                "data_cost": 29,
+                "gas_cost": 31619314,
+                "proving_cost": 5431269390,
+                "congestion_cost": 20443687015,
+                "congestion_multiplier": 4742285083
+            },
+            "mana_base_fee_components_in_fee_asset": {
+                "data_cost": 307,
+                "gas_cost": 335505102,
+                "proving_cost": 57629921802,
+                "congestion_cost": 216923153579,
+                "congestion_multiplier": 4742285083
+            }
+        }
+    },
+    {
+        "l1_block_number": 20973857,
+        "l1_fees": {
+            "blob_fee": 7422,
+            "base_fee": 10287223911
+        },
+        "parent_header": {
+            "excess_mana": 1330358208,
+            "mana_used": 97567357,
+            "proving_cost_per_mana_numerator": 358988705,
+            "fee_asset_price_numerator": 5941926306
+        },
+        "header": {
+            "excess_mana": 1327925565,
+            "mana_used": 94180350,
+            "proving_cost_per_mana_numerator": 559496247,
+            "fee_asset_price_numerator": 5925072455
+        },
+        "oracle_input": {
+            "proving_cost_modifier": 200507542,
+            "fee_asset_price_modifier": -16853851
+        },
+        "outputs": {
+            "fee_asset_price_at_execution": 10612200778,
+            "mana_base_fee_components_in_wei": {
+                "data_cost": 29,
+                "gas_cost": 34076429,
+                "proving_cost": 5434833414,
+                "congestion_cost": 20392508412,
+                "congestion_multiplier": 4728806817
+            },
+            "mana_base_fee_components_in_fee_asset": {
+                "data_cost": 307,
+                "gas_cost": 361625906,
+                "proving_cost": 57675543384,
+                "congestion_cost": 216409393635,
+                "congestion_multiplier": 4728806817
+            }
+        }
+    },
+    {
+        "l1_block_number": 20973860,
+        "l1_fees": {
+            "blob_fee": 8350,
+            "base_fee": 10427086319
+        },
+        "parent_header": {
+            "excess_mana": 1327925565,
+            "mana_used": 94180350,
+            "proving_cost_per_mana_numerator": 559496247,
+            "fee_asset_price_numerator": 5925072455
+        },
+        "header": {
+            "excess_mana": 1322105915,
+            "mana_used": 109300669,
+            "proving_cost_per_mana_numerator": 478003486,
+            "fee_asset_price_numerator": 5647205267
+        },
+        "oracle_input": {
+            "proving_cost_modifier": -81492761,
+            "fee_asset_price_modifier": -277867188
+        },
+        "outputs": {
+            "fee_asset_price_at_execution": 10610412364,
+            "mana_base_fee_components_in_wei": {
+                "data_cost": 32,
+                "gas_cost": 34539723,
+                "proving_cost": 5445741597,
+                "congestion_cost": 20259053557,
+                "congestion_multiplier": 4696717788
+            },
+            "mana_base_fee_components_in_fee_asset": {
+                "data_cost": 339,
+                "gas_cost": 366480703,
+                "proving_cost": 57781563971,
+                "congestion_cost": 214956912344,
+                "congestion_multiplier": 4696717788
+            }
+        }
+    },
+    {
+        "l1_block_number": 20973863,
+        "l1_fees": {
+            "blob_fee": 8684,
+            "base_fee": 9924491355
+        },
+        "parent_header": {
+            "excess_mana": 1322105915,
+            "mana_used": 109300669,
+            "proving_cost_per_mana_numerator": 478003486,
+            "fee_asset_price_numerator": 5647205267
+        },
+        "header": {
+            "excess_mana": 1331406584,
+            "mana_used": 85994446,
+            "proving_cost_per_mana_numerator": 530330013,
+            "fee_asset_price_numerator": 5789146465
+        },
+        "oracle_input": {
+            "proving_cost_modifier": 52326527,
+            "fee_asset_price_modifier": 141941198
+        },
+        "outputs": {
+            "fee_asset_price_at_execution": 10580970433,
+            "mana_base_fee_components_in_wei": {
+                "data_cost": 34,
+                "gas_cost": 32874877,
+                "proving_cost": 5441305520,
+                "congestion_cost": 20517805989,
+                "congestion_multiplier": 4748105538
+            },
+            "mana_base_fee_components_in_fee_asset": {
+                "data_cost": 359,
+                "gas_cost": 347848101,
+                "proving_cost": 57574292824,
+                "congestion_cost": 217098298519,
+                "congestion_multiplier": 4748105538
+            }
+        }
+    },
+    {
+        "l1_block_number": 20973866,
+        "l1_fees": {
+            "blob_fee": 8028,
+            "base_fee": 9354627250
+        },
+        "parent_header": {
+            "excess_mana": 1331406584,
+            "mana_used": 85994446,
+            "proving_cost_per_mana_numerator": 530330013,
+            "fee_asset_price_numerator": 5789146465
+        },
+        "header": {
+            "excess_mana": 1317401030,
+            "mana_used": 115714558,
+            "proving_cost_per_mana_numerator": 545799712,
+            "fee_asset_price_numerator": 6088022736
+        },
+        "oracle_input": {
+            "proving_cost_modifier": 15469699,
+            "fee_asset_price_modifier": 298876271
+        },
+        "outputs": {
+            "fee_asset_price_at_execution": 10595999854,
+            "mana_base_fee_components_in_wei": {
+                "data_cost": 31,
+                "gas_cost": 30987202,
+                "proving_cost": 5444153511,
+                "congestion_cost": 20098884264,
+                "congestion_multiplier": 4670934722
+            },
+            "mana_base_fee_components_in_fee_asset": {
+                "data_cost": 328,
+                "gas_cost": 328340387,
+                "proving_cost": 57686249807,
+                "congestion_cost": 212967774726,
+                "congestion_multiplier": 4670934722
+            }
+        }
+    },
+    {
+        "l1_block_number": 20973869,
+        "l1_fees": {
+            "blob_fee": 8028,
+            "base_fee": 9518637418
+        },
+        "parent_header": {
+            "excess_mana": 1317401030,
+            "mana_used": 115714558,
+            "proving_cost_per_mana_numerator": 545799712,
+            "fee_asset_price_numerator": 6088022736
+        },
+        "header": {
+            "excess_mana": 1333115588,
+            "mana_used": 80109579,
+            "proving_cost_per_mana_numerator": 517094254,
+            "fee_asset_price_numerator": 5088022736
+        },
+        "oracle_input": {
+            "proving_cost_modifier": -28705458,
+            "fee_asset_price_modifier": -1000000000
+        },
+        "outputs": {
+            "fee_asset_price_at_execution": 10627716156,
+            "mana_base_fee_components_in_wei": {
+                "data_cost": 31,
+                "gas_cost": 31530486,
+                "proving_cost": 5444995771,
+                "congestion_cost": 20578644676,
+                "congestion_multiplier": 4757609038
+            },
+            "mana_base_fee_components_in_fee_asset": {
+                "data_cost": 329,
+                "gas_cost": 335097055,
+                "proving_cost": 57867869524,
+                "congestion_cost": 218703994491,
+                "congestion_multiplier": 4757609038
+            }
+        }
+    },
+    {
+        "l1_block_number": 20973872,
+        "l1_fees": {
+            "blob_fee": 7136,
+            "base_fee": 9000307024
+        },
+        "parent_header": {
+            "excess_mana": 1333115588,
+            "mana_used": 80109579,
+            "proving_cost_per_mana_numerator": 517094254,
+            "fee_asset_price_numerator": 5088022736
+        },
+        "header": {
+            "excess_mana": 1313225167,
+            "mana_used": 104097263,
+            "proving_cost_per_mana_numerator": 663259335,
+            "fee_asset_price_numerator": 5536783075
+        },
+        "oracle_input": {
+            "proving_cost_modifier": 146165081,
+            "fee_asset_price_modifier": 448760339
+        },
+        "outputs": {
+            "fee_asset_price_at_execution": 10521968613,
+            "mana_base_fee_components_in_wei": {
+                "data_cost": 28,
+                "gas_cost": 29813517,
+                "proving_cost": 5443432984,
+                "congestion_cost": 19967330046,
+                "congestion_multiplier": 4648169316
+            },
+            "mana_base_fee_components_in_fee_asset": {
+                "data_cost": 294,
+                "gas_cost": 313696890,
+                "proving_cost": 57275631004,
+                "congestion_cost": 210095620029,
+                "congestion_multiplier": 4648169316
+            }
+        }
+    },
+    {
+        "l1_block_number": 20973875,
+        "l1_fees": {
+            "blob_fee": 7136,
+            "base_fee": 9715580015
+        },
+        "parent_header": {
+            "excess_mana": 1313225167,
+            "mana_used": 104097263,
+            "proving_cost_per_mana_numerator": 663259335,
+            "fee_asset_price_numerator": 5536783075
+        },
+        "header": {
+            "excess_mana": 1317322430,
+            "mana_used": 99293585,
+            "proving_cost_per_mana_numerator": 616335512,
+            "fee_asset_price_numerator": 6206207375
+        },
+        "oracle_input": {
+            "proving_cost_modifier": -46923823,
+            "fee_asset_price_modifier": 669424300
+        },
+        "outputs": {
+            "fee_asset_price_at_execution": 10569293142,
+            "mana_base_fee_components_in_wei": {
+                "data_cost": 28,
+                "gas_cost": 32182858,
+                "proving_cost": 5451395200,
+                "congestion_cost": 20127501840,
+                "congestion_multiplier": 4670505193
+            },
+            "mana_base_fee_components_in_fee_asset": {
+                "data_cost": 295,
+                "gas_cost": 340150060,
+                "proving_cost": 57617393901,
+                "congestion_cost": 212733467163,
+                "congestion_multiplier": 4670505193
+            }
+        }
+    },
+    {
+        "l1_block_number": 20973878,
+        "l1_fees": {
+            "blob_fee": 6099,
+            "base_fee": 8927204530
+        },
+        "parent_header": {
+            "excess_mana": 1317322430,
+            "mana_used": 99293585,
+            "proving_cost_per_mana_numerator": 616335512,
+            "fee_asset_price_numerator": 6206207375
+        },
+        "header": {
+            "excess_mana": 1316616015,
+            "mana_used": 101973942,
+            "proving_cost_per_mana_numerator": 744096576,
+            "fee_asset_price_numerator": 6298133503
+        },
+        "oracle_input": {
+            "proving_cost_modifier": 127761064,
+            "fee_asset_price_modifier": 91926128
+        },
+        "outputs": {
+            "fee_asset_price_at_execution": 10640283909,
+            "mana_base_fee_components_in_wei": {
+                "data_cost": 23,
+                "gas_cost": 29571365,
+                "proving_cost": 5448837797,
+                "congestion_cost": 20087390356,
+                "congestion_multiplier": 4666646590
+            },
+            "mana_base_fee_components_in_fee_asset": {
+                "data_cost": 244,
+                "gas_cost": 314647719,
+                "proving_cost": 57977181134,
+                "congestion_cost": 213735536378,
+                "congestion_multiplier": 4666646590
+            }
+        }
+    },
+    {
+        "l1_block_number": 20973881,
+        "l1_fees": {
+            "blob_fee": 5421,
+            "base_fee": 10606716360
+        },
+        "parent_header": {
+            "excess_mana": 1316616015,
+            "mana_used": 101973942,
+            "proving_cost_per_mana_numerator": 744096576,
+            "fee_asset_price_numerator": 6298133503
+        },
+        "header": {
+            "excess_mana": 1318589957,
+            "mana_used": 108359431,
+            "proving_cost_per_mana_numerator": 823483761,
+            "fee_asset_price_numerator": 7008616691
+        },
+        "oracle_input": {
+            "proving_cost_modifier": 79387185,
+            "fee_asset_price_modifier": 710483188
+        },
+        "outputs": {
+            "fee_asset_price_at_execution": 10650069607,
+            "mana_base_fee_components_in_wei": {
+                "data_cost": 21,
+                "gas_cost": 35134747,
+                "proving_cost": 5455803739,
+                "congestion_cost": 20192578903,
+                "congestion_multiplier": 4677436722
+            },
+            "mana_base_fee_components_in_fee_asset": {
+                "data_cost": 223,
+                "gas_cost": 374187501,
+                "proving_cost": 58104689582,
+                "congestion_cost": 215052370861,
+                "congestion_multiplier": 4677436722
+            }
+        }
+    },
+    {
+        "l1_block_number": 20973884,
+        "l1_fees": {
+            "blob_fee": 6597,
+            "base_fee": 10633601318
+        },
+        "parent_header": {
+            "excess_mana": 1318589957,
+            "mana_used": 108359431,
+            "proving_cost_per_mana_numerator": 823483761,
+            "fee_asset_price_numerator": 7008616691
+        },
+        "header": {
+            "excess_mana": 1326949388,
+            "mana_used": 93769846,
+            "proving_cost_per_mana_numerator": 804692960,
+            "fee_asset_price_numerator": 6632734847
+        },
+        "oracle_input": {
+            "proving_cost_modifier": -18790801,
+            "fee_asset_price_modifier": -375881844
+        },
+        "outputs": {
+            "fee_asset_price_at_execution": 10726005999,
+            "mana_base_fee_components_in_wei": {
+                "data_cost": 25,
+                "gas_cost": 35223804,
+                "proving_cost": 5460136668,
+                "congestion_cost": 20461474743,
+                "congestion_multiplier": 4723409002
+            },
+            "mana_base_fee_components_in_fee_asset": {
+                "data_cost": 268,
+                "gas_cost": 377810733,
+                "proving_cost": 58565458656,
+                "congestion_cost": 219469900841,
+                "congestion_multiplier": 4723409002
+            }
+        }
+    },
+    {
+        "l1_block_number": 20973887,
+        "l1_fees": {
+            "blob_fee": 5638,
+            "base_fee": 10484045237
+        },
+        "parent_header": {
+            "excess_mana": 1326949388,
+            "mana_used": 93769846,
+            "proving_cost_per_mana_numerator": 804692960,
+            "fee_asset_price_numerator": 6632734847
+        },
+        "header": {
+            "excess_mana": 1320719234,
+            "mana_used": 103746665,
+            "proving_cost_per_mana_numerator": 679575357,
+            "fee_asset_price_numerator": 6735831846
+        },
+        "oracle_input": {
+            "proving_cost_modifier": -125117603,
+            "fee_asset_price_modifier": 103096999
+        },
+        "outputs": {
+            "fee_asset_price_at_execution": 10685764567,
+            "mana_base_fee_components_in_wei": {
+                "data_cost": 22,
+                "gas_cost": 34728399,
+                "proving_cost": 5459110761,
+                "congestion_cost": 20267343728,
+                "congestion_multiplier": 4689103932
+            },
+            "mana_base_fee_components_in_fee_asset": {
+                "data_cost": 235,
+                "gas_cost": 371099495,
+                "proving_cost": 58334772337,
+                "congestion_cost": 216572063475,
+                "congestion_multiplier": 4689103932
+            }
+        }
+    },
+    {
+        "l1_block_number": 20973890,
+        "l1_fees": {
+            "blob_fee": 5012,
+            "base_fee": 10168986743
+        },
+        "parent_header": {
+            "excess_mana": 1320719234,
+            "mana_used": 103746665,
+            "proving_cost_per_mana_numerator": 679575357,
+            "fee_asset_price_numerator": 6735831846
+        },
+        "header": {
+            "excess_mana": 1324465899,
+            "mana_used": 90509291,
+            "proving_cost_per_mana_numerator": 739167168,
+            "fee_asset_price_numerator": 6908356568
+        },
+        "oracle_input": {
+            "proving_cost_modifier": 59591811,
+            "fee_asset_price_modifier": 172524722
+        },
+        "outputs": {
+            "fee_asset_price_at_execution": 10696786951,
+            "mana_base_fee_components_in_wei": {
+                "data_cost": 19,
+                "gas_cost": 33684768,
+                "proving_cost": 5452284723,
+                "congestion_cost": 20351324121,
+                "congestion_multiplier": 4709704198
+            },
+            "mana_base_fee_components_in_fee_asset": {
+                "data_cost": 203,
+                "gas_cost": 360318786,
+                "proving_cost": 58321928078,
+                "congestion_cost": 217693778293,
+                "congestion_multiplier": 4709704198
+            }
+        }
+    },
+    {
+        "l1_block_number": 20973893,
+        "l1_fees": {
+            "blob_fee": 5212,
+            "base_fee": 10173503699
+        },
+        "parent_header": {
+            "excess_mana": 1324465899,
+            "mana_used": 90509291,
+            "proving_cost_per_mana_numerator": 739167168,
+            "fee_asset_price_numerator": 6908356568
+        },
+        "header": {
+            "excess_mana": 1314975190,
+            "mana_used": 95614584,
+            "proving_cost_per_mana_numerator": 803144628,
+            "fee_asset_price_numerator": 5992437132
+        },
+        "oracle_input": {
+            "proving_cost_modifier": 63977460,
+            "fee_asset_price_modifier": -915919436
+        },
+        "outputs": {
+            "fee_asset_price_at_execution": 10715257481,
+            "mana_base_fee_components_in_wei": {
+                "data_cost": 20,
+                "gas_cost": 33699731,
+                "proving_cost": 5455534807,
+                "congestion_cost": 20077953031,
+                "congestion_multiplier": 4657696318
+            },
+            "mana_base_fee_components_in_fee_asset": {
+                "data_cost": 214,
+                "gas_cost": 361101294,
+                "proving_cost": 58457460153,
+                "congestion_cost": 215140436418,
+                "congestion_multiplier": 4657696318
+            }
+        }
+    },
+    {
+        "l1_block_number": 20973896,
+        "l1_fees": {
+            "blob_fee": 4633,
+            "base_fee": 9849078319
+        },
+        "parent_header": {
+            "excess_mana": 1314975190,
+            "mana_used": 95614584,
+            "proving_cost_per_mana_numerator": 803144628,
+            "fee_asset_price_numerator": 5992437132
+        },
+        "header": {
+            "excess_mana": 1310589774,
+            "mana_used": 118091830,
+            "proving_cost_per_mana_numerator": 902000402,
+            "fee_asset_price_numerator": 5439598060
+        },
+        "oracle_input": {
+            "proving_cost_modifier": 98855774,
+            "fee_asset_price_modifier": -552839072
+        },
+        "outputs": {
+            "fee_asset_price_at_execution": 10617562442,
+            "mana_base_fee_components_in_wei": {
+                "data_cost": 18,
+                "gas_cost": 32625071,
+                "proving_cost": 5459026236,
+                "congestion_cost": 19955887569,
+                "congestion_multiplier": 4633859178
+            },
+            "mana_base_fee_components_in_fee_asset": {
+                "data_cost": 191,
+                "gas_cost": 346398728,
+                "proving_cost": 57961551933,
+                "congestion_cost": 211882882349,
+                "congestion_multiplier": 4633859178
+            }
+        }
+    },
+    {
+        "l1_block_number": 20973899,
+        "l1_fees": {
+            "blob_fee": 3960,
+            "base_fee": 9095741753
+        },
+        "parent_header": {
+            "excess_mana": 1310589774,
+            "mana_used": 118091830,
+            "proving_cost_per_mana_numerator": 902000402,
+            "fee_asset_price_numerator": 5439598060
+        },
+        "header": {
+            "excess_mana": 1328681604,
+            "mana_used": 98625135,
+            "proving_cost_per_mana_numerator": 877969508,
+            "fee_asset_price_numerator": 5844735540
+        },
+        "oracle_input": {
+            "proving_cost_modifier": -24030894,
+            "fee_asset_price_modifier": 405137480
+        },
+        "outputs": {
+            "fee_asset_price_at_execution": 10559026363,
+            "mana_base_fee_components_in_wei": {
+                "data_cost": 15,
+                "gas_cost": 30129644,
+                "proving_cost": 5464425467,
+                "congestion_cost": 20511128175,
+                "congestion_multiplier": 4732991608
+            },
+            "mana_base_fee_components_in_fee_asset": {
+                "data_cost": 158,
+                "gas_cost": 318139705,
+                "proving_cost": 57699012564,
+                "congestion_cost": 216577543134,
+                "congestion_multiplier": 4732991608
+            }
+        }
+    },
+    {
+        "l1_block_number": 20973902,
+        "l1_fees": {
+            "blob_fee": 5638,
+            "base_fee": 10224559786
+        },
+        "parent_header": {
+            "excess_mana": 1328681604,
+            "mana_used": 98625135,
+            "proving_cost_per_mana_numerator": 877969508,
+            "fee_asset_price_numerator": 5844735540
+        },
+        "header": {
+            "excess_mana": 1327306739,
+            "mana_used": 106256841,
+            "proving_cost_per_mana_numerator": 1003946519,
+            "fee_asset_price_numerator": 6652818122
+        },
+        "oracle_input": {
+            "proving_cost_modifier": 125977011,
+            "fee_asset_price_modifier": 808082582
+        },
+        "outputs": {
+            "fee_asset_price_at_execution": 10601891709,
+            "mana_base_fee_components_in_wei": {
+                "data_cost": 22,
+                "gas_cost": 33868854,
+                "proving_cost": 5463112474,
+                "congestion_cost": 20478367886,
+                "congestion_multiplier": 4725384276
+            },
+            "mana_base_fee_components_in_fee_asset": {
+                "data_cost": 233,
+                "gas_cost": 359073922,
+                "proving_cost": 57919326843,
+                "congestion_cost": 217109438704,
+                "congestion_multiplier": 4725384276
+            }
+        }
+    },
+    {
+        "l1_block_number": 20973905,
+        "l1_fees": {
+            "blob_fee": 6343,
+            "base_fee": 9839987831
+        },
+        "parent_header": {
+            "excess_mana": 1327306739,
+            "mana_used": 106256841,
+            "proving_cost_per_mana_numerator": 1003946519,
+            "fee_asset_price_numerator": 6652818122
+        },
+        "header": {
+            "excess_mana": 1333563580,
+            "mana_used": 80690418,
+            "proving_cost_per_mana_numerator": 944388983,
+            "fee_asset_price_numerator": 7269251791
+        },
+        "oracle_input": {
+            "proving_cost_modifier": -59557536,
+            "fee_asset_price_modifier": 616433669
+        },
+        "outputs": {
+            "fee_asset_price_at_execution": 10687910834,
+            "mana_base_fee_components_in_wei": {
+                "data_cost": 24,
+                "gas_cost": 32594959,
+                "proving_cost": 5469999077,
+                "congestion_cost": 20690322611,
+                "congestion_multiplier": 4760103396
+            },
+            "mana_base_fee_components_in_fee_asset": {
+                "data_cost": 256,
+                "gas_cost": 348372015,
+                "proving_cost": 58462862397,
+                "congestion_cost": 221136323193,
+                "congestion_multiplier": 4760103396
+            }
+        }
+    },
+    {
+        "l1_block_number": 20973908,
+        "l1_fees": {
+            "blob_fee": 5638,
+            "base_fee": 9805616497
+        },
+        "parent_header": {
+            "excess_mana": 1333563580,
+            "mana_used": 80690418,
+            "proving_cost_per_mana_numerator": 944388983,
+            "fee_asset_price_numerator": 7269251791
+        },
+        "header": {
+            "excess_mana": 1314253998,
+            "mana_used": 94413917,
+            "proving_cost_per_mana_numerator": 1122815630,
+            "fee_asset_price_numerator": 7087350090
+        },
+        "oracle_input": {
+            "proving_cost_modifier": 178426647,
+            "fee_asset_price_modifier": -181901701
+        },
+        "outputs": {
+            "fee_asset_price_at_execution": 10753998198,
+            "mana_base_fee_components_in_wei": {
+                "data_cost": 22,
+                "gas_cost": 32481104,
+                "proving_cost": 5466742250,
+                "congestion_cost": 20092885494,
+                "congestion_multiplier": 4653767836
+            },
+            "mana_base_fee_components_in_fee_asset": {
+                "data_cost": 236,
+                "gas_cost": 349301733,
+                "proving_cost": 58789336305,
+                "congestion_cost": 216078854395,
+                "congestion_multiplier": 4653767836
+            }
+        }
+    },
+    {
+        "l1_block_number": 20973911,
+        "l1_fees": {
+            "blob_fee": 6861,
+            "base_fee": 10431780206
+        },
+        "parent_header": {
+            "excess_mana": 1314253998,
+            "mana_used": 94413917,
+            "proving_cost_per_mana_numerator": 1122815630,
+            "fee_asset_price_numerator": 7087350090
+        },
+        "header": {
+            "excess_mana": 1308667915,
+            "mana_used": 94607795,
+            "proving_cost_per_mana_numerator": 1062906274,
+            "fee_asset_price_numerator": 7390849530
+        },
+        "oracle_input": {
+            "proving_cost_modifier": -59909356,
+            "fee_asset_price_modifier": 303499440
+        },
+        "outputs": {
+            "fee_asset_price_at_execution": 10734454273,
+            "mana_base_fee_components_in_wei": {
+                "data_cost": 26,
+                "gas_cost": 34555271,
+                "proving_cost": 5476505082,
+                "congestion_cost": 19969058916,
+                "congestion_multiplier": 4623451304
+            },
+            "mana_base_fee_components_in_fee_asset": {
+                "data_cost": 279,
+                "gas_cost": 370931976,
+                "proving_cost": 58787293378,
+                "congestion_cost": 214356949808,
+                "congestion_multiplier": 4623451304
+            }
+        }
+    },
+    {
+        "l1_block_number": 20973914,
+        "l1_fees": {
+            "blob_fee": 5638,
+            "base_fee": 9780268893
+        },
+        "parent_header": {
+            "excess_mana": 1308667915,
+            "mana_used": 94607795,
+            "proving_cost_per_mana_numerator": 1062906274,
+            "fee_asset_price_numerator": 7390849530
+        },
+        "header": {
+            "excess_mana": 1303275710,
+            "mana_used": 102054688,
+            "proving_cost_per_mana_numerator": 1109743580,
+            "fee_asset_price_numerator": 7115220745
+        },
+        "oracle_input": {
+            "proving_cost_modifier": 46837306,
+            "fee_asset_price_modifier": -275628785
+        },
+        "outputs": {
+            "fee_asset_price_at_execution": 10767082771,
+            "mana_base_fee_components_in_wei": {
+                "data_cost": 22,
+                "gas_cost": 32397140,
+                "proving_cost": 5473225126,
+                "congestion_cost": 19789267384,
+                "congestion_multiplier": 4594374323
+            },
+            "mana_base_fee_components_in_fee_asset": {
+                "data_cost": 236,
+                "gas_cost": 348822687,
+                "proving_cost": 58930667955,
+                "congestion_cost": 213072679900,
+                "congestion_multiplier": 4594374323
+            }
+        }
+    },
+    {
+        "l1_block_number": 20973917,
+        "l1_fees": {
+            "blob_fee": 5421,
+            "base_fee": 9759622835
+        },
+        "parent_header": {
+            "excess_mana": 1303275710,
+            "mana_used": 102054688,
+            "proving_cost_per_mana_numerator": 1109743580,
+            "fee_asset_price_numerator": 7115220745
+        },
+        "header": {
+            "excess_mana": 1305330398,
+            "mana_used": 111328474,
+            "proving_cost_per_mana_numerator": 1232702340,
+            "fee_asset_price_numerator": 6300753413
+        },
+        "oracle_input": {
+            "proving_cost_modifier": 122958760,
+            "fee_asset_price_modifier": -814467332
+        },
+        "outputs": {
+            "fee_asset_price_at_execution": 10737446453,
+            "mana_base_fee_components_in_wei": {
+                "data_cost": 21,
+                "gas_cost": 32328750,
+                "proving_cost": 5475789238,
+                "congestion_cost": 19859147220,
+                "congestion_multiplier": 4605432416
+            },
+            "mana_base_fee_components_in_fee_asset": {
+                "data_cost": 225,
+                "gas_cost": 347128222,
+                "proving_cost": 58795993730,
+                "congestion_cost": 213236529876,
+                "congestion_multiplier": 4605432416
+            }
+        }
+    },
+    {
+        "l1_block_number": 20973920,
+        "l1_fees": {
+            "blob_fee": 5421,
+            "base_fee": 9073108440
+        },
+        "parent_header": {
+            "excess_mana": 1305330398,
+            "mana_used": 111328474,
+            "proving_cost_per_mana_numerator": 1232702340,
+            "fee_asset_price_numerator": 6300753413
+        },
+        "header": {
+            "excess_mana": 1316658872,
+            "mana_used": 100397610,
+            "proving_cost_per_mana_numerator": 1217180126,
+            "fee_asset_price_numerator": 6073245524
+        },
+        "oracle_input": {
+            "proving_cost_modifier": -15522214,
+            "fee_asset_price_modifier": -227507889
+        },
+        "outputs": {
+            "fee_asset_price_at_execution": 10650348633,
+            "mana_base_fee_components_in_wei": {
+                "data_cost": 21,
+                "gas_cost": 30054671,
+                "proving_cost": 5482526341,
+                "congestion_cost": 20213976412,
+                "congestion_multiplier": 4666880594
+            },
+            "mana_base_fee_components_in_fee_asset": {
+                "data_cost": 223,
+                "gas_cost": 320092724,
+                "proving_cost": 58390816921,
+                "congestion_cost": 215285896047,
+                "congestion_multiplier": 4666880594
+            }
+        }
+    },
+    {
+        "l1_block_number": 20973923,
+        "l1_fees": {
+            "blob_fee": 5638,
+            "base_fee": 9354730809
+        },
+        "parent_header": {
+            "excess_mana": 1316658872,
+            "mana_used": 100397610,
+            "proving_cost_per_mana_numerator": 1217180126,
+            "fee_asset_price_numerator": 6073245524
+        },
+        "header": {
+            "excess_mana": 1317056482,
+            "mana_used": 124200577,
+            "proving_cost_per_mana_numerator": 1270767834,
+            "fee_asset_price_numerator": 6054705245
+        },
+        "oracle_input": {
+            "proving_cost_modifier": 53587708,
+            "fee_asset_price_modifier": -18540279
+        },
+        "outputs": {
+            "fee_asset_price_at_execution": 10626145791,
+            "mana_base_fee_components_in_wei": {
+                "data_cost": 22,
+                "gas_cost": 30987545,
+                "proving_cost": 5481675398,
+                "congestion_cost": 20226247898,
+                "congestion_multiplier": 4669052149
+            },
+            "mana_base_fee_components_in_fee_asset": {
+                "data_cost": 233,
+                "gas_cost": 329278170,
+                "proving_cost": 58249081958,
+                "congestion_cost": 214927058969,
+                "congestion_multiplier": 4669052149
+            }
+        }
+    },
+    {
+        "l1_block_number": 20973926,
+        "l1_fees": {
+            "blob_fee": 4819,
+            "base_fee": 9798923863
+        },
+        "parent_header": {
+            "excess_mana": 1317056482,
+            "mana_used": 124200577,
+            "proving_cost_per_mana_numerator": 1270767834,
+            "fee_asset_price_numerator": 6054705245
+        },
+        "header": {
+            "excess_mana": 1341257059,
+            "mana_used": 90324589,
+            "proving_cost_per_mana_numerator": 1657418320,
+            "fee_asset_price_numerator": 5270904101
+        },
+        "oracle_input": {
+            "proving_cost_modifier": 386650486,
+            "fee_asset_price_modifier": -783801144
+        },
+        "outputs": {
+            "fee_asset_price_at_execution": 10624175857,
+            "mana_base_fee_components_in_wei": {
+                "data_cost": 18,
+                "gas_cost": 32458935,
+                "proving_cost": 5484613689,
+                "congestion_cost": 20982223216,
+                "congestion_multiplier": 4803144272
+            },
+            "mana_base_fee_components_in_fee_asset": {
+                "data_cost": 191,
+                "gas_cost": 344849433,
+                "proving_cost": 58269500339,
+                "congestion_cost": 222918829317,
+                "congestion_multiplier": 4803144272
+            }
+        }
+    },
+    {
+        "l1_block_number": 20973929,
+        "l1_fees": {
+            "blob_fee": 5012,
+            "base_fee": 9491280379
+        },
+        "parent_header": {
+            "excess_mana": 1341257059,
+            "mana_used": 90324589,
+            "proving_cost_per_mana_numerator": 1657418320,
+            "fee_asset_price_numerator": 5270904101
+        },
+        "header": {
+            "excess_mana": 1331581648,
+            "mana_used": 83908793,
+            "proving_cost_per_mana_numerator": 1571081596,
+            "fee_asset_price_numerator": 5007899122
+        },
+        "oracle_input": {
+            "proving_cost_modifier": -86336724,
+            "fee_asset_price_modifier": -263004979
+        },
+        "outputs": {
+            "fee_asset_price_at_execution": 10541228939,
+            "mana_base_fee_components_in_wei": {
+                "data_cost": 19,
+                "gas_cost": 31439866,
+                "proving_cost": 5505861025,
+                "congestion_cost": 20759773951,
+                "congestion_multiplier": 4749078168
+            },
+            "mana_base_fee_components_in_fee_asset": {
+                "data_cost": 200,
+                "gas_cost": 331414825,
+                "proving_cost": 58038541570,
+                "congestion_cost": 218833529939,
+                "congestion_multiplier": 4749078168
+            }
+        }
+    },
+    {
+        "l1_block_number": 20973932,
+        "l1_fees": {
+            "blob_fee": 4455,
+            "base_fee": 9788598711
+        },
+        "parent_header": {
+            "excess_mana": 1331581648,
+            "mana_used": 83908793,
+            "proving_cost_per_mana_numerator": 1571081596,
+            "fee_asset_price_numerator": 5007899122
+        },
+        "header": {
+            "excess_mana": 1315490441,
+            "mana_used": 98745137,
+            "proving_cost_per_mana_numerator": 1657954574,
+            "fee_asset_price_numerator": 4495793528
+        },
+        "oracle_input": {
+            "proving_cost_modifier": 86872978,
+            "fee_asset_price_modifier": -512105594
+        },
+        "outputs": {
+            "fee_asset_price_at_execution": 10513541408,
+            "mana_base_fee_components_in_wei": {
+                "data_cost": 17,
+                "gas_cost": 32424733,
+                "proving_cost": 5501109496,
+                "congestion_cost": 20255529924,
+                "congestion_multiplier": 4660505027
+            },
+            "mana_base_fee_components_in_fee_asset": {
+                "data_cost": 178,
+                "gas_cost": 340898773,
+                "proving_cost": 57836142476,
+                "congestion_cost": 212957352596,
+                "congestion_multiplier": 4660505027
+            }
+        }
+    },
+    {
+        "l1_block_number": 20973935,
+        "l1_fees": {
+            "blob_fee": 5421,
+            "base_fee": 9503524710
+        },
+        "parent_header": {
+            "excess_mana": 1315490441,
+            "mana_used": 98745137,
+            "proving_cost_per_mana_numerator": 1657954574,
+            "fee_asset_price_numerator": 4495793528
+        },
+        "header": {
+            "excess_mana": 1314235578,
+            "mana_used": 115661879,
+            "proving_cost_per_mana_numerator": 1655074242,
+            "fee_asset_price_numerator": 4636831107
+        },
+        "oracle_input": {
+            "proving_cost_modifier": -2880332,
+            "fee_asset_price_modifier": 141037579
+        },
+        "outputs": {
+            "fee_asset_price_at_execution": 10459838599,
+            "mana_base_fee_components_in_wei": {
+                "data_cost": 21,
+                "gas_cost": 31480425,
+                "proving_cost": 5505890550,
+                "congestion_cost": 20231712676,
+                "congestion_multiplier": 4653667542
+            },
+            "mana_base_fee_components_in_fee_asset": {
+                "data_cost": 219,
+                "gas_cost": 329280164,
+                "proving_cost": 57590726496,
+                "congestion_cost": 211620449172,
+                "congestion_multiplier": 4653667542
+            }
+        }
+    },
+    {
+        "l1_block_number": 20973938,
+        "l1_fees": {
+            "blob_fee": 4455,
+            "base_fee": 9905469541
+        },
+        "parent_header": {
+            "excess_mana": 1314235578,
+            "mana_used": 115661879,
+            "proving_cost_per_mana_numerator": 1655074242,
+            "fee_asset_price_numerator": 4636831107
+        },
+        "header": {
+            "excess_mana": 1329897457,
+            "mana_used": 99047538,
+            "proving_cost_per_mana_numerator": 1660322455,
+            "fee_asset_price_numerator": 3636831107
+        },
+        "oracle_input": {
+            "proving_cost_modifier": 5248213,
+            "fee_asset_price_modifier": -1000000000
+        },
+        "outputs": {
+            "fee_asset_price_at_execution": 10474601310,
+            "mana_base_fee_components_in_wei": {
+                "data_cost": 17,
+                "gas_cost": 32811867,
+                "proving_cost": 5505731965,
+                "congestion_cost": 20712654750,
+                "congestion_multiplier": 4739729307
+            },
+            "mana_base_fee_components_in_fee_asset": {
+                "data_cost": 178,
+                "gas_cost": 343691225,
+                "proving_cost": 57670347253,
+                "congestion_cost": 216956800577,
+                "congestion_multiplier": 4739729307
+            }
+        }
+    },
+    {
+        "l1_block_number": 20973941,
+        "l1_fees": {
+            "blob_fee": 5864,
+            "base_fee": 9492348783
+        },
+        "parent_header": {
+            "excess_mana": 1329897457,
+            "mana_used": 99047538,
+            "proving_cost_per_mana_numerator": 1660322455,
+            "fee_asset_price_numerator": 3636831107
+        },
+        "header": {
+            "excess_mana": 1328944995,
+            "mana_used": 94579490,
+            "proving_cost_per_mana_numerator": 1590454455,
+            "fee_asset_price_numerator": 3398858887
+        },
+        "oracle_input": {
+            "proving_cost_modifier": -69868000,
+            "fee_asset_price_modifier": -237972220
+        },
+        "outputs": {
+            "fee_asset_price_at_execution": 10370377286,
+            "mana_base_fee_components_in_wei": {
+                "data_cost": 23,
+                "gas_cost": 31443405,
+                "proving_cost": 5506020925,
+                "congestion_cost": 20679385896,
+                "congestion_multiplier": 4734450387
+            },
+            "mana_base_fee_components_in_fee_asset": {
+                "data_cost": 238,
+                "gas_cost": 326079973,
+                "proving_cost": 57099514336,
+                "congestion_cost": 214453033784,
+                "congestion_multiplier": 4734450387
+            }
+        }
+    },
+    {
+        "l1_block_number": 20973944,
+        "l1_fees": {
+            "blob_fee": 5421,
+            "base_fee": 9491302205
+        },
+        "parent_header": {
+            "excess_mana": 1328944995,
+            "mana_used": 94579490,
+            "proving_cost_per_mana_numerator": 1590454455,
+            "fee_asset_price_numerator": 3398858887
+        },
+        "header": {
+            "excess_mana": 1323524485,
+            "mana_used": 99099030,
+            "proving_cost_per_mana_numerator": 1570502674,
+            "fee_asset_price_numerator": 2562088416
+        },
+        "oracle_input": {
+            "proving_cost_modifier": -19951781,
+            "fee_asset_price_modifier": -836770471
+        },
+        "outputs": {
+            "fee_asset_price_at_execution": 10345728010,
+            "mana_base_fee_components_in_wei": {
+                "data_cost": 21,
+                "gas_cost": 31439938,
+                "proving_cost": 5502175322,
+                "congestion_cost": 20499385874,
+                "congestion_multiplier": 4704519529
+            },
+            "mana_base_fee_components_in_fee_asset": {
+                "data_cost": 217,
+                "gas_cost": 325269047,
+                "proving_cost": 56924009344,
+                "congestion_cost": 212081070624,
+                "congestion_multiplier": 4704519529
+            }
+        }
+    },
+    {
+        "l1_block_number": 20973947,
+        "l1_fees": {
+            "blob_fee": 6343,
+            "base_fee": 9257844367
+        },
+        "parent_header": {
+            "excess_mana": 1323524485,
+            "mana_used": 99099030,
+            "proving_cost_per_mana_numerator": 1570502674,
+            "fee_asset_price_numerator": 2562088416
+        },
+        "header": {
+            "excess_mana": 1322623515,
+            "mana_used": 93079232,
+            "proving_cost_per_mana_numerator": 1555242058,
+            "fee_asset_price_numerator": 2926917934
+        },
+        "oracle_input": {
+            "proving_cost_modifier": -15260616,
+            "fee_asset_price_modifier": 364829518
+        },
+        "outputs": {
+            "fee_asset_price_at_execution": 10259519201,
+            "mana_base_fee_components_in_wei": {
+                "data_cost": 24,
+                "gas_cost": 30666609,
+                "proving_cost": 5501077649,
+                "congestion_cost": 20465036161,
+                "congestion_multiplier": 4699562944
+            },
+            "mana_base_fee_components_in_fee_asset": {
+                "data_cost": 246,
+                "gas_cost": 314624663,
+                "proving_cost": 56438411766,
+                "congestion_cost": 209961431442,
+                "congestion_multiplier": 4699562944
+            }
+        }
+    },
+    {
+        "l1_block_number": 20973950,
+        "l1_fees": {
+            "blob_fee": 5638,
+            "base_fee": 9626673028
+        },
+        "parent_header": {
+            "excess_mana": 1322623515,
+            "mana_used": 93079232,
+            "proving_cost_per_mana_numerator": 1555242058,
+            "fee_asset_price_numerator": 2926917934
+        },
+        "header": {
+            "excess_mana": 1315702747,
+            "mana_used": 96637310,
+            "proving_cost_per_mana_numerator": 1584358417,
+            "fee_asset_price_numerator": 3926917934
+        },
+        "oracle_input": {
+            "proving_cost_modifier": 29116359,
+            "fee_asset_price_modifier": 1000000000
+        },
+        "outputs": {
+            "fee_asset_price_at_execution": 10297017316,
+            "mana_base_fee_components_in_wei": {
+                "data_cost": 22,
+                "gas_cost": 31888354,
+                "proving_cost": 5500238215,
+                "congestion_cost": 20256782314,
+                "congestion_multiplier": 4661662831
+            },
+            "mana_base_fee_components_in_fee_asset": {
+                "data_cost": 226,
+                "gas_cost": 328354933,
+                "proving_cost": 56636048141,
+                "congestion_cost": 208584438253,
+                "congestion_multiplier": 4661662831
+            }
+        }
+    },
+    {
+        "l1_block_number": 20973953,
+        "l1_fees": {
+            "blob_fee": 6099,
+            "base_fee": 9541396841
+        },
+        "parent_header": {
+            "excess_mana": 1315702747,
+            "mana_used": 96637310,
+            "proving_cost_per_mana_numerator": 1584358417,
+            "fee_asset_price_numerator": 3926917934
+        },
+        "header": {
+            "excess_mana": 1312340057,
+            "mana_used": 125044278,
+            "proving_cost_per_mana_numerator": 1579456904,
+            "fee_asset_price_numerator": 3734805086
+        },
+        "oracle_input": {
+            "proving_cost_modifier": -4901513,
+            "fee_asset_price_modifier": -192112848
+        },
+        "outputs": {
+            "fee_asset_price_at_execution": 10400504060,
+            "mana_base_fee_components_in_wei": {
+                "data_cost": 23,
+                "gas_cost": 31605877,
+                "proving_cost": 5501839917,
+                "congestion_cost": 20160325534,
+                "congestion_multiplier": 4643358262
+            },
+            "mana_base_fee_components_in_fee_asset": {
+                "data_cost": 239,
+                "gas_cost": 328717052,
+                "proving_cost": 57221908394,
+                "congestion_cost": 209677547567,
+                "congestion_multiplier": 4643358262
+            }
+        }
+    },
+    {
+        "l1_block_number": 20973956,
+        "l1_fees": {
+            "blob_fee": 6861,
+            "base_fee": 9340810233
+        },
+        "parent_header": {
+            "excess_mana": 1312340057,
+            "mana_used": 125044278,
+            "proving_cost_per_mana_numerator": 1579456904,
+            "fee_asset_price_numerator": 3734805086
+        },
+        "header": {
+            "excess_mana": 1337384335,
+            "mana_used": 92840403,
+            "proving_cost_per_mana_numerator": 1533184551,
+            "fee_asset_price_numerator": 4050526531
+        },
+        "oracle_input": {
+            "proving_cost_modifier": -46272353,
+            "fee_asset_price_modifier": 315721445
+        },
+        "outputs": {
+            "fee_asset_price_at_execution": 10380542536,
+            "mana_base_fee_components_in_wei": {
+                "data_cost": 26,
+                "gas_cost": 30941433,
+                "proving_cost": 5501570250,
+                "congestion_cost": 20920805967,
+                "congestion_multiplier": 4781430039
+            },
+            "mana_base_fee_components_in_fee_asset": {
+                "data_cost": 269,
+                "gas_cost": 321188861,
+                "proving_cost": 57109283994,
+                "congestion_cost": 217169316227,
+                "congestion_multiplier": 4781430039
+            }
+        }
+    },
+    {
+        "l1_block_number": 20973959,
+        "l1_fees": {
+            "blob_fee": 7422,
+            "base_fee": 9311121822
+        },
+        "parent_header": {
+            "excess_mana": 1337384335,
+            "mana_used": 92840403,
+            "proving_cost_per_mana_numerator": 1533184551,
+            "fee_asset_price_numerator": 4050526531
+        },
+        "header": {
+            "excess_mana": 1330224738,
+            "mana_used": 92611181,
+            "proving_cost_per_mana_numerator": 1542731920,
+            "fee_asset_price_numerator": 3926603946
+        },
+        "oracle_input": {
+            "proving_cost_modifier": 9547369,
+            "fee_asset_price_modifier": -123922585
+        },
+        "outputs": {
+            "fee_asset_price_at_execution": 10413367926,
+            "mana_base_fee_components_in_wei": {
+                "data_cost": 29,
+                "gas_cost": 30843091,
+                "proving_cost": 5499025133,
+                "congestion_cost": 20690248623,
+                "congestion_multiplier": 4741544586
+            },
+            "mana_base_fee_components_in_fee_asset": {
+                "data_cost": 301,
+                "gas_cost": 321180454,
+                "proving_cost": 57263371944,
+                "congestion_cost": 215455171391,
+                "congestion_multiplier": 4741544586
+            }
+        }
+    },
+    {
+        "l1_block_number": 20973962,
+        "l1_fees": {
+            "blob_fee": 8684,
+            "base_fee": 9375527733
+        },
+        "parent_header": {
+            "excess_mana": 1330224738,
+            "mana_used": 92611181,
+            "proving_cost_per_mana_numerator": 1542731920,
+            "fee_asset_price_numerator": 3926603946
+        },
+        "header": {
+            "excess_mana": 1322835919,
+            "mana_used": 103198759,
+            "proving_cost_per_mana_numerator": 1476736516,
+            "fee_asset_price_numerator": 2927316841
+        },
+        "oracle_input": {
+            "proving_cost_modifier": -65995404,
+            "fee_asset_price_modifier": -999287105
+        },
+        "outputs": {
+            "fee_asset_price_at_execution": 10400471404,
+            "mana_base_fee_components_in_wei": {
+                "data_cost": 34,
+                "gas_cost": 31056435,
+                "proving_cost": 5499550171,
+                "congestion_cost": 20467287386,
+                "congestion_multiplier": 4700730990
+            },
+            "mana_base_fee_components_in_fee_asset": {
+                "data_cost": 353,
+                "gas_cost": 323001564,
+                "proving_cost": 57197914288,
+                "congestion_cost": 212869437175,
+                "congestion_multiplier": 4700730990
+            }
+        }
+    },
+    {
+        "l1_block_number": 20973965,
+        "l1_fees": {
+            "blob_fee": 8350,
+            "base_fee": 8792547319
+        },
+        "parent_header": {
+            "excess_mana": 1322835919,
+            "mana_used": 103198759,
+            "proving_cost_per_mana_numerator": 1476736516,
+            "fee_asset_price_numerator": 2927316841
+        },
+        "header": {
+            "excess_mana": 1326034678,
+            "mana_used": 92233494,
+            "proving_cost_per_mana_numerator": 1472519754,
+            "fee_asset_price_numerator": 3313885765
+        },
+        "oracle_input": {
+            "proving_cost_modifier": -4216762,
+            "fee_asset_price_modifier": 386568924
+        },
+        "outputs": {
+            "fee_asset_price_at_execution": 10297058391,
+            "mana_base_fee_components_in_wei": {
+                "data_cost": 32,
+                "gas_cost": 29125312,
+                "proving_cost": 5495921918,
+                "congestion_cost": 20544096300,
+                "congestion_multiplier": 4718356663
+            },
+            "mana_base_fee_components_in_fee_asset": {
+                "data_cost": 329,
+                "gas_cost": 299905038,
+                "proving_cost": 56591828902,
+                "congestion_cost": 211543759191,
+                "congestion_multiplier": 4718356663
+            }
+        }
+    },
+    {
+        "l1_block_number": 20973968,
+        "l1_fees": {
+            "blob_fee": 6099,
+            "base_fee": 9043161445
+        },
+        "parent_header": {
+            "excess_mana": 1326034678,
+            "mana_used": 92233494,
+            "proving_cost_per_mana_numerator": 1472519754,
+            "fee_asset_price_numerator": 3313885765
+        },
+        "header": {
+            "excess_mana": 1318268172,
+            "mana_used": 101693104,
+            "proving_cost_per_mana_numerator": 1551966076,
+            "fee_asset_price_numerator": 3766445324
+        },
+        "oracle_input": {
+            "proving_cost_modifier": 79446322,
+            "fee_asset_price_modifier": 452559559
+        },
+        "outputs": {
+            "fee_asset_price_at_execution": 10336940656,
+            "mana_base_fee_components_in_wei": {
+                "data_cost": 23,
+                "gas_cost": 29955472,
+                "proving_cost": 5495690172,
+                "congestion_cost": 20310483450,
+                "congestion_multiplier": 4675676052
+            },
+            "mana_base_fee_components_in_fee_asset": {
+                "data_cost": 237,
+                "gas_cost": 309647936,
+                "proving_cost": 56808623171,
+                "congestion_cost": 209948262117,
+                "congestion_multiplier": 4675676052
+            }
+        }
+    },
+    {
+        "l1_block_number": 20973971,
+        "l1_fees": {
+            "blob_fee": 8684,
+            "base_fee": 8911568646
+        },
+        "parent_header": {
+            "excess_mana": 1318268172,
+            "mana_used": 101693104,
+            "proving_cost_per_mana_numerator": 1551966076,
+            "fee_asset_price_numerator": 3766445324
+        },
+        "header": {
+            "excess_mana": 1319961276,
+            "mana_used": 102102019,
+            "proving_cost_per_mana_numerator": 1468317618,
+            "fee_asset_price_numerator": 4300917324
+        },
+        "oracle_input": {
+            "proving_cost_modifier": -83648458,
+            "fee_asset_price_modifier": 534472000
+        },
+        "outputs": {
+            "fee_asset_price_at_execution": 10383827484,
+            "mana_base_fee_components_in_wei": {
+                "data_cost": 34,
+                "gas_cost": 29519571,
+                "proving_cost": 5500058031,
+                "congestion_cost": 20376202882,
+                "congestion_multiplier": 4684947427
+            },
+            "mana_base_fee_components_in_fee_asset": {
+                "data_cost": 353,
+                "gas_cost": 306526132,
+                "proving_cost": 57111653745,
+                "congestion_cost": 211582975505,
+                "congestion_multiplier": 4684947427
+            }
+        }
+    },
+    {
+        "l1_block_number": 20973974,
+        "l1_fees": {
+            "blob_fee": 9770,
+            "base_fee": 9868061066
+        },
+        "parent_header": {
+            "excess_mana": 1319961276,
+            "mana_used": 102102019,
+            "proving_cost_per_mana_numerator": 1468317618,
+            "fee_asset_price_numerator": 4300917324
+        },
+        "header": {
+            "excess_mana": 1322063295,
+            "mana_used": 102474076,
+            "proving_cost_per_mana_numerator": 1511499768,
+            "fee_asset_price_numerator": 4227336050
+        },
+        "oracle_input": {
+            "proving_cost_modifier": 43182150,
+            "fee_asset_price_modifier": -73581274
+        },
+        "outputs": {
+            "fee_asset_price_at_execution": 10439474711,
+            "mana_base_fee_components_in_wei": {
+                "data_cost": 38,
+                "gas_cost": 32687952,
+                "proving_cost": 5495459241,
+                "congestion_cost": 20434705522,
+                "congestion_multiplier": 4696483590
+            },
+            "mana_base_fee_components_in_fee_asset": {
+                "data_cost": 396,
+                "gas_cost": 341245048,
+                "proving_cost": 57369707771,
+                "congestion_cost": 213327591523,
+                "congestion_multiplier": 4696483590
+            }
+        }
+    },
+    {
+        "l1_block_number": 20973977,
+        "l1_fees": {
+            "blob_fee": 11889,
+            "base_fee": 10572529939
+        },
+        "parent_header": {
+            "excess_mana": 1322063295,
+            "mana_used": 102474076,
+            "proving_cost_per_mana_numerator": 1511499768,
+            "fee_asset_price_numerator": 4227336050
+        },
+        "header": {
+            "excess_mana": 1324537371,
+            "mana_used": 105245190,
+            "proving_cost_per_mana_numerator": 1609749354,
+            "fee_asset_price_numerator": 4807977124
+        },
+        "oracle_input": {
+            "proving_cost_modifier": 98249586,
+            "fee_asset_price_modifier": 580641074
+        },
+        "outputs": {
+            "fee_asset_price_at_execution": 10431796038,
+            "mana_base_fee_components_in_wei": {
+                "data_cost": 46,
+                "gas_cost": 35021505,
+                "proving_cost": 5497832811,
+                "congestion_cost": 20527432179,
+                "congestion_multiplier": 4710098050
+            },
+            "mana_base_fee_components_in_fee_asset": {
+                "data_cost": 479,
+                "gas_cost": 365337197,
+                "proving_cost": 57352270535,
+                "congestion_cost": 214137985675,
+                "congestion_multiplier": 4710098050
+            }
+        }
+    },
+    {
+        "l1_block_number": 20973980,
+        "l1_fees": {
+            "blob_fee": 13375,
+            "base_fee": 9920545956
+        },
+        "parent_header": {
+            "excess_mana": 1324537371,
+            "mana_used": 105245190,
+            "proving_cost_per_mana_numerator": 1609749354,
+            "fee_asset_price_numerator": 4807977124
+        },
+        "header": {
+            "excess_mana": 1329782561,
+            "mana_used": 48176168,
+            "proving_cost_per_mana_numerator": 1671284806,
+            "fee_asset_price_numerator": 4979384835
+        },
+        "oracle_input": {
+            "proving_cost_modifier": 61535452,
+            "fee_asset_price_modifier": 171407711
+        },
+        "outputs": {
+            "fee_asset_price_at_execution": 10492543523,
+            "mana_base_fee_components_in_wei": {
+                "data_cost": 52,
+                "gas_cost": 32861808,
+                "proving_cost": 5503237063,
+                "congestion_cost": 20699984279,
+                "congestion_multiplier": 4739092196
+            },
+            "mana_base_fee_components_in_fee_asset": {
+                "data_cost": 545,
+                "gas_cost": 344803950,
+                "proving_cost": 57742954400,
+                "congestion_cost": 217195485972,
+                "congestion_multiplier": 4739092196
+            }
+        }
+    },
+    {
+        "l1_block_number": 20973983,
+        "l1_fees": {
+            "blob_fee": 12860,
+            "base_fee": 9493896905
+        },
+        "parent_header": {
+            "excess_mana": 1329782561,
+            "mana_used": 48176168,
+            "proving_cost_per_mana_numerator": 1671284806,
+            "fee_asset_price_numerator": 4979384835
+        },
+        "header": {
+            "excess_mana": 1277958729,
+            "mana_used": 143539543,
+            "proving_cost_per_mana_numerator": 1636083342,
+            "fee_asset_price_numerator": 5620347702
+        },
+        "oracle_input": {
+            "proving_cost_modifier": -35201464,
+            "fee_asset_price_modifier": 640962867
+        },
+        "outputs": {
+            "fee_asset_price_at_execution": 10510543974,
+            "mana_base_fee_components_in_wei": {
+                "data_cost": 50,
+                "gas_cost": 31448533,
+                "proving_cost": 5506624547,
+                "congestion_cost": 19163287882,
+                "congestion_multiplier": 4460280757
+            },
+            "mana_base_fee_components_in_fee_asset": {
+                "data_cost": 525,
+                "gas_cost": 330541189,
+                "proving_cost": 57877619449,
+                "congestion_cost": 201416579970,
+                "congestion_multiplier": 4460280757
+            }
+        }
+    },
+    {
+        "l1_block_number": 20973986,
+        "l1_fees": {
+            "blob_fee": 15047,
+            "base_fee": 10231684676
+        },
+        "parent_header": {
+            "excess_mana": 1277958729,
+            "mana_used": 143539543,
+            "proving_cost_per_mana_numerator": 1636083342,
+            "fee_asset_price_numerator": 5620347702
+        },
+        "header": {
+            "excess_mana": 1321498272,
+            "mana_used": 106821640,
+            "proving_cost_per_mana_numerator": 1535185490,
+            "fee_asset_price_numerator": 5430436092
+        },
+        "oracle_input": {
+            "proving_cost_modifier": -100897852,
+            "fee_asset_price_modifier": -189911610
+        },
+        "outputs": {
+            "fee_asset_price_at_execution": 10578129024,
+            "mana_base_fee_components_in_wei": {
+                "data_cost": 59,
+                "gas_cost": 33892455,
+                "proving_cost": 5504686476,
+                "congestion_cost": 20456076199,
+                "congestion_multiplier": 4693379879
+            },
+            "mana_base_fee_components_in_fee_asset": {
+                "data_cost": 624,
+                "gas_cost": 358518761,
+                "proving_cost": 58229283779,
+                "congestion_cost": 216387013357,
+                "congestion_multiplier": 4693379879
+            }
+        }
+    },
+    {
+        "l1_block_number": 20973989,
+        "l1_fees": {
+            "blob_fee": 13910,
+            "base_fee": 10687936636
+        },
+        "parent_header": {
+            "excess_mana": 1321498272,
+            "mana_used": 106821640,
+            "proving_cost_per_mana_numerator": 1535185490,
+            "fee_asset_price_numerator": 5430436092
+        },
+        "header": {
+            "excess_mana": 1328319912,
+            "mana_used": 97504621,
+            "proving_cost_per_mana_numerator": 1734574868,
+            "fee_asset_price_numerator": 5466526012
+        },
+        "oracle_input": {
+            "proving_cost_modifier": 199389378,
+            "fee_asset_price_modifier": 36089920
+        },
+        "outputs": {
+            "fee_asset_price_at_execution": 10558058993,
+            "mana_base_fee_components_in_wei": {
+                "data_cost": 54,
+                "gas_cost": 35403790,
+                "proving_cost": 5499135166,
+                "congestion_cost": 20649304863,
+                "congestion_multiplier": 4730989126
+            },
+            "mana_base_fee_components_in_fee_asset": {
+                "data_cost": 570,
+                "gas_cost": 373795303,
+                "proving_cost": 58060193493,
+                "congestion_cost": 218016578907,
+                "congestion_multiplier": 4730989126
+            }
+        }
+    },
+    {
+        "l1_block_number": 20973992,
+        "l1_fees": {
+            "blob_fee": 12860,
+            "base_fee": 9937916645
+        },
+        "parent_header": {
+            "excess_mana": 1328319912,
+            "mana_used": 97504621,
+            "proving_cost_per_mana_numerator": 1734574868,
+            "fee_asset_price_numerator": 5466526012
+        },
+        "header": {
+            "excess_mana": 1325824533,
+            "mana_used": 99530321,
+            "proving_cost_per_mana_numerator": 1721795670,
+            "fee_asset_price_numerator": 6329274402
+        },
+        "oracle_input": {
+            "proving_cost_modifier": -12779198,
+            "fee_asset_price_modifier": 862748390
+        },
+        "outputs": {
+            "fee_asset_price_at_execution": 10561870075,
+            "mana_base_fee_components_in_wei": {
+                "data_cost": 50,
+                "gas_cost": 32919348,
+                "proving_cost": 5510110796,
+                "congestion_cost": 20604533572,
+                "congestion_multiplier": 4717196705
+            },
+            "mana_base_fee_components_in_fee_asset": {
+                "data_cost": 528,
+                "gas_cost": 347689876,
+                "proving_cost": 58197074326,
+                "congestion_cost": 217622406543,
+                "congestion_multiplier": 4717196705
+            }
+        }
+    },
+    {
+        "l1_block_number": 20973995,
+        "l1_fees": {
+            "blob_fee": 16276,
+            "base_fee": 9399164298
+        },
+        "parent_header": {
+            "excess_mana": 1325824533,
+            "mana_used": 99530321,
+            "proving_cost_per_mana_numerator": 1721795670,
+            "fee_asset_price_numerator": 6329274402
+        },
+        "header": {
+            "excess_mana": 1325354854,
+            "mana_used": 96817789,
+            "proving_cost_per_mana_numerator": 1836689389,
+            "fee_asset_price_numerator": 7008968044
+        },
+        "oracle_input": {
+            "proving_cost_modifier": 114893719,
+            "fee_asset_price_modifier": 679693642
+        },
+        "outputs": {
+            "fee_asset_price_at_execution": 10653386651,
+            "mana_base_fee_components_in_wei": {
+                "data_cost": 63,
+                "gas_cost": 31134731,
+                "proving_cost": 5509406693,
+                "congestion_cost": 20580924235,
+                "congestion_multiplier": 4714605203
+            },
+            "mana_base_fee_components_in_fee_asset": {
+                "data_cost": 671,
+                "gas_cost": 331690327,
+                "proving_cost": 58693839718,
+                "congestion_cost": 219256543510,
+                "congestion_multiplier": 4714605203
+            }
+        }
+    },
+    {
+        "l1_block_number": 20973998,
+        "l1_fees": {
+            "blob_fee": 16928,
+            "base_fee": 9340485439
+        },
+        "parent_header": {
+            "excess_mana": 1325354854,
+            "mana_used": 96817789,
+            "proving_cost_per_mana_numerator": 1836689389,
+            "fee_asset_price_numerator": 7008968044
+        },
+        "header": {
+            "excess_mana": 1322172643,
+            "mana_used": 101220698,
+            "proving_cost_per_mana_numerator": 1881114566,
+            "fee_asset_price_numerator": 7096178621
+        },
+        "oracle_input": {
+            "proving_cost_modifier": 44425177,
+            "fee_asset_price_modifier": 87210577
+        },
+        "outputs": {
+            "fee_asset_price_at_execution": 10726043685,
+            "mana_base_fee_components_in_wei": {
+                "data_cost": 66,
+                "gas_cost": 30940358,
+                "proving_cost": 5515740293,
+                "congestion_cost": 20506547210,
+                "congestion_multiplier": 4697084483
+            },
+            "mana_base_fee_components_in_fee_asset": {
+                "data_cost": 707,
+                "gas_cost": 331867631,
+                "proving_cost": 59162071337,
+                "congestion_cost": 219954121202,
+                "congestion_multiplier": 4697084483
+            }
+        }
+    },
+    {
+        "l1_block_number": 20974001,
+        "l1_fees": {
+            "blob_fee": 16276,
+            "base_fee": 9254721351
+        },
+        "parent_header": {
+            "excess_mana": 1322172643,
+            "mana_used": 101220698,
+            "proving_cost_per_mana_numerator": 1881114566,
+            "fee_asset_price_numerator": 7096178621
+        },
+        "header": {
+            "excess_mana": 1323393341,
+            "mana_used": 106226548,
+            "proving_cost_per_mana_numerator": 1946421425,
+            "fee_asset_price_numerator": 6322662659
+        },
+        "oracle_input": {
+            "proving_cost_modifier": 65306859,
+            "fee_asset_price_modifier": -773515962
+        },
+        "outputs": {
+            "fee_asset_price_at_execution": 10735402010,
+            "mana_base_fee_components_in_wei": {
+                "data_cost": 63,
+                "gas_cost": 30656264,
+                "proving_cost": 5518191215,
+                "congestion_cost": 20551808930,
+                "congestion_multiplier": 4703797730
+            },
+            "mana_base_fee_components_in_fee_asset": {
+                "data_cost": 676,
+                "gas_cost": 329107318,
+                "proving_cost": 59240001061,
+                "congestion_cost": 220631930896,
+                "congestion_multiplier": 4703797730
+            }
+        }
+    },
+    {
+        "l1_block_number": 20974004,
+        "l1_fees": {
+            "blob_fee": 15047,
+            "base_fee": 8967315970
+        },
+        "parent_header": {
+            "excess_mana": 1323393341,
+            "mana_used": 106226548,
+            "proving_cost_per_mana_numerator": 1946421425,
+            "fee_asset_price_numerator": 6322662659
+        },
+        "header": {
+            "excess_mana": 1329619889,
+            "mana_used": 96207687,
+            "proving_cost_per_mana_numerator": 1796145148,
+            "fee_asset_price_numerator": 6222816783
+        },
+        "oracle_input": {
+            "proving_cost_modifier": -150276277,
+            "fee_asset_price_modifier": -99845876
+        },
+        "outputs": {
+            "fee_asset_price_at_execution": 10652682299,
+            "mana_base_fee_components_in_wei": {
+                "data_cost": 59,
+                "gas_cost": 29704234,
+                "proving_cost": 5521796150,
+                "congestion_cost": 20752565150,
+                "congestion_multiplier": 4738190308
+            },
+            "mana_base_fee_components_in_fee_asset": {
+                "data_cost": 628,
+                "gas_cost": 316429767,
+                "proving_cost": 58821940105,
+                "congestion_cost": 221070483432,
+                "congestion_multiplier": 4738190308
+            }
+        }
+    },
+    {
+        "l1_block_number": 20974007,
+        "l1_fees": {
+            "blob_fee": 19806,
+            "base_fee": 8078456063
+        },
+        "parent_header": {
+            "excess_mana": 1329619889,
+            "mana_used": 96207687,
+            "proving_cost_per_mana_numerator": 1796145148,
+            "fee_asset_price_numerator": 6222816783
+        },
+        "header": {
+            "excess_mana": 1325827576,
+            "mana_used": 95453902,
+            "proving_cost_per_mana_numerator": 1888136398,
+            "fee_asset_price_numerator": 5673515616
+        },
+        "oracle_input": {
+            "proving_cost_modifier": 91991250,
+            "fee_asset_price_modifier": -549301167
+        },
+        "outputs": {
+            "fee_asset_price_at_execution": 10642051344,
+            "mana_base_fee_components_in_wei": {
+                "data_cost": 77,
+                "gas_cost": 26759885,
+                "proving_cost": 5513504432,
+                "congestion_cost": 20594345598,
+                "congestion_multiplier": 4717213500
+            },
+            "mana_base_fee_components_in_fee_asset": {
+                "data_cost": 819,
+                "gas_cost": 284780070,
+                "proving_cost": 58674997250,
+                "congestion_cost": 219166083249,
+                "congestion_multiplier": 4717213500
+            }
+        }
+    },
+    {
+        "l1_block_number": 20974010,
+        "l1_fees": {
+            "blob_fee": 25067,
+            "base_fee": 9018975363
+        },
+        "parent_header": {
+            "excess_mana": 1325827576,
+            "mana_used": 95453902,
+            "proving_cost_per_mana_numerator": 1888136398,
+            "fee_asset_price_numerator": 5673515616
+        },
+        "header": {
+            "excess_mana": 1321281478,
+            "mana_used": 104937181,
+            "proving_cost_per_mana_numerator": 2039920330,
+            "fee_asset_price_numerator": 5051607601
+        },
+        "oracle_input": {
+            "proving_cost_modifier": 151783932,
+            "fee_asset_price_modifier": -621908015
+        },
+        "outputs": {
+            "fee_asset_price_at_execution": 10583754690,
+            "mana_base_fee_components_in_wei": {
+                "data_cost": 98,
+                "gas_cost": 29875355,
+                "proving_cost": 5518578707,
+                "congestion_cost": 20485944518,
+                "congestion_multiplier": 4692189559
+            },
+            "mana_base_fee_components_in_fee_asset": {
+                "data_cost": 1037,
+                "gas_cost": 316193428,
+                "proving_cost": 58407283272,
+                "congestion_cost": 216818211371,
+                "congestion_multiplier": 4692189559
+            }
+        }
+    },
+    {
+        "l1_block_number": 20974013,
+        "l1_fees": {
+            "blob_fee": 28201,
+            "base_fee": 9158435578
+        },
+        "parent_header": {
+            "excess_mana": 1321281478,
+            "mana_used": 104937181,
+            "proving_cost_per_mana_numerator": 2039920330,
+            "fee_asset_price_numerator": 5051607601
+        },
+        "header": {
+            "excess_mana": 1326218659,
+            "mana_used": 101453540,
+            "proving_cost_per_mana_numerator": 1852905038,
+            "fee_asset_price_numerator": 4399385648
+        },
+        "oracle_input": {
+            "proving_cost_modifier": -187015292,
+            "fee_asset_price_modifier": -652221953
+        },
+        "outputs": {
+            "fee_asset_price_at_execution": 10518137721,
+            "mana_base_fee_components_in_wei": {
+                "data_cost": 110,
+                "gas_cost": 30337317,
+                "proving_cost": 5526961383,
+                "congestion_cost": 20669664012,
+                "congestion_multiplier": 4719372436
+            },
+            "mana_base_fee_components_in_fee_asset": {
+                "data_cost": 1156,
+                "gas_cost": 319092078,
+                "proving_cost": 58133341005,
+                "congestion_cost": 217406372725,
+                "congestion_multiplier": 4719372436
+            }
+        }
+    },
+    {
+        "l1_block_number": 20974016,
+        "l1_fees": {
+            "blob_fee": 37121,
+            "base_fee": 9951217330
+        },
+        "parent_header": {
+            "excess_mana": 1326218659,
+            "mana_used": 101453540,
+            "proving_cost_per_mana_numerator": 1852905038,
+            "fee_asset_price_numerator": 4399385648
+        },
+        "header": {
+            "excess_mana": 1327672199,
+            "mana_used": 92561346,
+            "proving_cost_per_mana_numerator": 1919364892,
+            "fee_asset_price_numerator": 4334899474
+        },
+        "oracle_input": {
+            "proving_cost_modifier": 66459854,
+            "fee_asset_price_modifier": -64486174
+        },
+        "outputs": {
+            "fee_asset_price_at_execution": 10449759350,
+            "mana_base_fee_components_in_wei": {
+                "data_cost": 145,
+                "gas_cost": 32963407,
+                "proving_cost": 5516634779,
+                "congestion_cost": 20685601821,
+                "congestion_multiplier": 4727405226
+            },
+            "mana_base_fee_components_in_fee_asset": {
+                "data_cost": 1515,
+                "gas_cost": 344459670,
+                "proving_cost": 57647505862,
+                "congestion_cost": 216159561039,
+                "congestion_multiplier": 4727405226
+            }
+        }
+    },
+    {
+        "l1_block_number": 20974019,
+        "l1_fees": {
+            "blob_fee": 32996,
+            "base_fee": 9879258021
+        },
+        "parent_header": {
+            "excess_mana": 1327672199,
+            "mana_used": 92561346,
+            "proving_cost_per_mana_numerator": 1919364892,
+            "fee_asset_price_numerator": 4334899474
+        },
+        "header": {
+            "excess_mana": 1320233545,
+            "mana_used": 103870747,
+            "proving_cost_per_mana_numerator": 1888407636,
+            "fee_asset_price_numerator": 4717096533
+        },
+        "oracle_input": {
+            "proving_cost_modifier": -30957256,
+            "fee_asset_price_modifier": 382197059
+        },
+        "outputs": {
+            "fee_asset_price_at_execution": 10443022872,
+            "mana_base_fee_components_in_wei": {
+                "data_cost": 129,
+                "gas_cost": 32725042,
+                "proving_cost": 5520302345,
+                "congestion_cost": 20470903183,
+                "congestion_multiplier": 4686440077
+            },
+            "mana_base_fee_components_in_fee_asset": {
+                "data_cost": 1347,
+                "gas_cost": 341748362,
+                "proving_cost": 57648643649,
+                "congestion_cost": 213778110150,
+                "congestion_multiplier": 4686440077
+            }
+        }
+    },
+    {
+        "l1_block_number": 20974022,
+        "l1_fees": {
+            "blob_fee": 35692,
+            "base_fee": 9794908709
+        },
+        "parent_header": {
+            "excess_mana": 1320233545,
+            "mana_used": 103870747,
+            "proving_cost_per_mana_numerator": 1888407636,
+            "fee_asset_price_numerator": 4717096533
+        },
+        "header": {
+            "excess_mana": 1324104292,
+            "mana_used": 102289492,
+            "proving_cost_per_mana_numerator": 1853045549,
+            "fee_asset_price_numerator": 4428560011
+        },
+        "oracle_input": {
+            "proving_cost_modifier": -35362087,
+            "fee_asset_price_modifier": -288536522
+        },
+        "outputs": {
+            "fee_asset_price_at_execution": 10483012169,
+            "mana_base_fee_components_in_wei": {
+                "data_cost": 140,
+                "gas_cost": 32445635,
+                "proving_cost": 5518593675,
+                "congestion_cost": 20581655781,
+                "congestion_multiplier": 4707712036
+            },
+            "mana_base_fee_components_in_fee_asset": {
+                "data_cost": 1467,
+                "gas_cost": 340127986,
+                "proving_cost": 57851484650,
+                "congestion_cost": 215757748010,
+                "congestion_multiplier": 4707712036
+            }
+        }
+    },
+    {
+        "l1_block_number": 20974025,
+        "l1_fees": {
+            "blob_fee": 41761,
+            "base_fee": 10075139545
+        },
+        "parent_header": {
+            "excess_mana": 1324104292,
+            "mana_used": 102289492,
+            "proving_cost_per_mana_numerator": 1853045549,
+            "fee_asset_price_numerator": 4428560011
+        },
+        "header": {
+            "excess_mana": 1326393784,
+            "mana_used": 89592734,
+            "proving_cost_per_mana_numerator": 1892499027,
+            "fee_asset_price_numerator": 5175900812
+        },
+        "oracle_input": {
+            "proving_cost_modifier": 39453478,
+            "fee_asset_price_modifier": 747340801
+        },
+        "outputs": {
+            "fee_asset_price_at_execution": 10452808445,
+            "mana_base_fee_components_in_wei": {
+                "data_cost": 164,
+                "gas_cost": 33373899,
+                "proving_cost": 5516642530,
+                "congestion_cost": 20647946045,
+                "congestion_multiplier": 4720339516
+            },
+            "mana_base_fee_components_in_fee_asset": {
+                "data_cost": 1714,
+                "gas_cost": 348850973,
+                "proving_cost": 57664407625,
+                "congestion_cost": 215829024791,
+                "congestion_multiplier": 4720339516
+            }
+        }
+    },
+    {
+        "l1_block_number": 20974028,
+        "l1_fees": {
+            "blob_fee": 46981,
+            "base_fee": 9477608461
+        },
+        "parent_header": {
+            "excess_mana": 1326393784,
+            "mana_used": 89592734,
+            "proving_cost_per_mana_numerator": 1892499027,
+            "fee_asset_price_numerator": 5175900812
+        },
+        "header": {
+            "excess_mana": 1315986518,
+            "mana_used": 102069463,
+            "proving_cost_per_mana_numerator": 1945964437,
+            "fee_asset_price_numerator": 5637447585
+        },
+        "oracle_input": {
+            "proving_cost_modifier": 53465410,
+            "fee_asset_price_modifier": 461546773
+        },
+        "outputs": {
+            "fee_asset_price_at_execution": 10531219180,
+            "mana_base_fee_components_in_wei": {
+                "data_cost": 184,
+                "gas_cost": 31394578,
+                "proving_cost": 5518819467,
+                "congestion_cost": 20331604794,
+                "congestion_multiplier": 4663210816
+            },
+            "mana_base_fee_components_in_fee_asset": {
+                "data_cost": 1937,
+                "gas_cost": 330623181,
+                "proving_cost": 58119897421,
+                "congestion_cost": 214116586366,
+                "congestion_multiplier": 4663210816
+            }
+        }
+    },
+    {
+        "l1_block_number": 20974031,
+        "l1_fees": {
+            "blob_fee": 59461,
+            "base_fee": 9019167943
+        },
+        "parent_header": {
+            "excess_mana": 1315986518,
+            "mana_used": 102069463,
+            "proving_cost_per_mana_numerator": 1945964437,
+            "fee_asset_price_numerator": 5637447585
+        },
+        "header": {
+            "excess_mana": 1318055981,
+            "mana_used": 97994787,
+            "proving_cost_per_mana_numerator": 1936088689,
+            "fee_asset_price_numerator": 5007018649
+        },
+        "oracle_input": {
+            "proving_cost_modifier": -9875748,
+            "fee_asset_price_modifier": -630428936
+        },
+        "outputs": {
+            "fee_asset_price_at_execution": 10579938026,
+            "mana_base_fee_components_in_wei": {
+                "data_cost": 233,
+                "gas_cost": 29875993,
+                "proving_cost": 5521770916,
+                "congestion_cost": 20399612901,
+                "congestion_multiplier": 4674515397
+            },
+            "mana_base_fee_components_in_fee_asset": {
+                "data_cost": 2465,
+                "gas_cost": 316086154,
+                "proving_cost": 58419994085,
+                "congestion_cost": 215826640246,
+                "congestion_multiplier": 4674515397
+            }
+        }
+    },
+    {
+        "l1_block_number": 20974034,
+        "l1_fees": {
+            "blob_fee": 72358,
+            "base_fee": 9324283056
+        },
+        "parent_header": {
+            "excess_mana": 1318055981,
+            "mana_used": 97994787,
+            "proving_cost_per_mana_numerator": 1936088689,
+            "fee_asset_price_numerator": 5007018649
+        },
+        "header": {
+            "excess_mana": 1316050768,
+            "mana_used": 99918209,
+            "proving_cost_per_mana_numerator": 1958868996,
+            "fee_asset_price_numerator": 5270966323
+        },
+        "oracle_input": {
+            "proving_cost_modifier": 22780307,
+            "fee_asset_price_modifier": 263947674
+        },
+        "outputs": {
+            "fee_asset_price_at_execution": 10513448839,
+            "mana_base_fee_components_in_wei": {
+                "data_cost": 284,
+                "gas_cost": 30886687,
+                "proving_cost": 5521225626,
+                "congestion_cost": 20340505260,
+                "congestion_multiplier": 4663561375
+            },
+            "mana_base_fee_components_in_fee_asset": {
+                "data_cost": 2985,
+                "gas_cost": 324725603,
+                "proving_cost": 58047123147,
+                "congestion_cost": 213848861410,
+                "congestion_multiplier": 4663561375
+            }
+        }
+    },
+    {
+        "l1_block_number": 20974037,
+        "l1_fees": {
+            "blob_fee": 75255,
+            "base_fee": 9492816563
+        },
+        "parent_header": {
+            "excess_mana": 1316050768,
+            "mana_used": 99918209,
+            "proving_cost_per_mana_numerator": 1958868996,
+            "fee_asset_price_numerator": 5270966323
+        },
+        "header": {
+            "excess_mana": 1315968977,
+            "mana_used": 99985093,
+            "proving_cost_per_mana_numerator": 1994790733,
+            "fee_asset_price_numerator": 4558441443
+        },
+        "oracle_input": {
+            "proving_cost_modifier": 35921737,
+            "fee_asset_price_modifier": -712524880
+        },
+        "outputs": {
+            "fee_asset_price_at_execution": 10541235498,
+            "mana_base_fee_components_in_wei": {
+                "data_cost": 295,
+                "gas_cost": 31444954,
+                "proving_cost": 5522483522,
+                "congestion_cost": 20344680423,
+                "congestion_multiplier": 4663115114
+            },
+            "mana_base_fee_components_in_fee_asset": {
+                "data_cost": 3109,
+                "gas_cost": 331468665,
+                "proving_cost": 58213799339,
+                "congestion_cost": 214458067470,
+                "congestion_multiplier": 4663115114
+            }
+        }
+    },
+    {
+        "l1_block_number": 20974040,
+        "l1_fees": {
+            "blob_fee": 66894,
+            "base_fee": 9282090683
+        },
+        "parent_header": {
+            "excess_mana": 1315968977,
+            "mana_used": 99985093,
+            "proving_cost_per_mana_numerator": 1994790733,
+            "fee_asset_price_numerator": 4558441443
+        },
+        "header": {
+            "excess_mana": 1315954070,
+            "mana_used": 110668432,
+            "proving_cost_per_mana_numerator": 1762277778,
+            "fee_asset_price_numerator": 5018819856
+        },
+        "oracle_input": {
+            "proving_cost_modifier": -232512955,
+            "fee_asset_price_modifier": 460378413
+        },
+        "outputs": {
+            "fee_asset_price_at_execution": 10466393523,
+            "mana_base_fee_components_in_wei": {
+                "data_cost": 263,
+                "gas_cost": 30746925,
+                "proving_cost": 5524467650,
+                "congestion_cost": 20348939634,
+                "congestion_multiplier": 4663033785
+            },
+            "mana_base_fee_components_in_fee_asset": {
+                "data_cost": 2752,
+                "gas_cost": 321809416,
+                "proving_cost": 57821252429,
+                "congestion_cost": 212980009985,
+                "congestion_multiplier": 4663033785
+            }
+        }
+    },
+    {
+        "l1_block_number": 20974043,
+        "l1_fees": {
+            "blob_fee": 52854,
+            "base_fee": 9331294615
+        },
+        "parent_header": {
+            "excess_mana": 1315954070,
+            "mana_used": 110668432,
+            "proving_cost_per_mana_numerator": 1762277778,
+            "fee_asset_price_numerator": 5018819856
+        },
+        "header": {
+            "excess_mana": 1326622502,
+            "mana_used": 94321207,
+            "proving_cost_per_mana_numerator": 1584325470,
+            "fee_asset_price_numerator": 4350620895
+        },
+        "oracle_input": {
+            "proving_cost_modifier": -177952308,
+            "fee_asset_price_modifier": -668198961
+        },
+        "outputs": {
+            "fee_asset_price_at_execution": 10514689627,
+            "mana_base_fee_components_in_wei": {
+                "data_cost": 207,
+                "gas_cost": 30909913,
+                "proving_cost": 5511637469,
+                "congestion_cost": 20627160897,
+                "congestion_multiplier": 4721602849
+            },
+            "mana_base_fee_components_in_fee_asset": {
+                "data_cost": 2176,
+                "gas_cost": 325008141,
+                "proving_cost": 57953157323,
+                "congestion_cost": 216888194718,
+                "congestion_multiplier": 4721602849
+            }
+        }
+    },
+    {
+        "l1_block_number": 20974046,
+        "l1_fees": {
+            "blob_fee": 54971,
+            "base_fee": 9208669518
+        },
+        "parent_header": {
+            "excess_mana": 1326622502,
+            "mana_used": 94321207,
+            "proving_cost_per_mana_numerator": 1584325470,
+            "fee_asset_price_numerator": 4350620895
+        },
+        "header": {
+            "excess_mana": 1320943709,
+            "mana_used": 92582756,
+            "proving_cost_per_mana_numerator": 1701387963,
+            "fee_asset_price_numerator": 4237511017
+        },
+        "oracle_input": {
+            "proving_cost_modifier": 117062493,
+            "fee_asset_price_modifier": -113109878
+        },
+        "outputs": {
+            "fee_asset_price_at_execution": 10444664793,
+            "mana_base_fee_components_in_wei": {
+                "data_cost": 216,
+                "gas_cost": 30503717,
+                "proving_cost": 5501838104,
+                "congestion_cost": 20416198881,
+                "congestion_multiplier": 4690335620
+            },
+            "mana_base_fee_components_in_fee_asset": {
+                "data_cost": 2256,
+                "gas_cost": 318601099,
+                "proving_cost": 57464854741,
+                "congestion_cost": 213240353659,
+                "congestion_multiplier": 4690335620
+            }
+        }
+    },
+    {
+        "l1_block_number": 20974049,
+        "l1_fees": {
+            "blob_fee": 41761,
+            "base_fee": 9312230602
+        },
+        "parent_header": {
+            "excess_mana": 1320943709,
+            "mana_used": 92582756,
+            "proving_cost_per_mana_numerator": 1701387963,
+            "fee_asset_price_numerator": 4237511017
+        },
+        "header": {
+            "excess_mana": 1313526465,
+            "mana_used": 110100940,
+            "proving_cost_per_mana_numerator": 1786169668,
+            "fee_asset_price_numerator": 4586868437
+        },
+        "oracle_input": {
+            "proving_cost_modifier": 84781705,
+            "fee_asset_price_modifier": 349357420
+        },
+        "outputs": {
+            "fee_asset_price_at_execution": 10432857524,
+            "mana_base_fee_components_in_wei": {
+                "data_cost": 164,
+                "gas_cost": 30846763,
+                "proving_cost": 5508282465,
+                "congestion_cost": 20216759715,
+                "congestion_multiplier": 4649808171
+            },
+            "mana_base_fee_components_in_fee_asset": {
+                "data_cost": 1710,
+                "gas_cost": 321819883,
+                "proving_cost": 57467126159,
+                "congestion_cost": 210918573703,
+                "congestion_multiplier": 4649808171
+            }
+        }
+    },
+    {
+        "l1_block_number": 20974052,
+        "l1_fees": {
+            "blob_fee": 41761,
+            "base_fee": 9243837121
+        },
+        "parent_header": {
+            "excess_mana": 1313526465,
+            "mana_used": 110100940,
+            "proving_cost_per_mana_numerator": 1786169668,
+            "fee_asset_price_numerator": 4586868437
+        },
+        "header": {
+            "excess_mana": 1323627405,
+            "mana_used": 91251238,
+            "proving_cost_per_mana_numerator": 1733491217,
+            "fee_asset_price_numerator": 4656046491
+        },
+        "oracle_input": {
+            "proving_cost_modifier": -52678451,
+            "fee_asset_price_modifier": 69178054
+        },
+        "outputs": {
+            "fee_asset_price_at_execution": 10469369227,
+            "mana_base_fee_components_in_wei": {
+                "data_cost": 164,
+                "gas_cost": 30620210,
+                "proving_cost": 5512954461,
+                "congestion_cost": 20539421871,
+                "congestion_multiplier": 4705086065
+            },
+            "mana_base_fee_components_in_fee_asset": {
+                "data_cost": 1716,
+                "gas_cost": 320574284,
+                "proving_cost": 57717155783,
+                "congestion_cost": 215034791276,
+                "congestion_multiplier": 4705086065
+            }
+        }
+    },
+    {
+        "l1_block_number": 20974055,
+        "l1_fees": {
+            "blob_fee": 35692,
+            "base_fee": 8867356451
+        },
+        "parent_header": {
+            "excess_mana": 1323627405,
+            "mana_used": 91251238,
+            "proving_cost_per_mana_numerator": 1733491217,
+            "fee_asset_price_numerator": 4656046491
+        },
+        "header": {
+            "excess_mana": 1314878643,
+            "mana_used": 117778673,
+            "proving_cost_per_mana_numerator": 1558279507,
+            "fee_asset_price_numerator": 4221180692
+        },
+        "oracle_input": {
+            "proving_cost_modifier": -175211710,
+            "fee_asset_price_modifier": -434865799
+        },
+        "outputs": {
+            "fee_asset_price_at_execution": 10476614239,
+            "mana_base_fee_components_in_wei": {
+                "data_cost": 140,
+                "gas_cost": 29373118,
+                "proving_cost": 5510051086,
+                "congestion_cost": 20258617713,
+                "congestion_multiplier": 4657170214
+            },
+            "mana_base_fee_components_in_fee_asset": {
+                "data_cost": 1466,
+                "gas_cost": 307730826,
+                "proving_cost": 57726679665,
+                "congestion_cost": 212241722794,
+                "congestion_multiplier": 4657170214
+            }
+        }
+    },
+    {
+        "l1_block_number": 20974058,
+        "l1_fees": {
+            "blob_fee": 30505,
+            "base_fee": 8944349837
+        },
+        "parent_header": {
+            "excess_mana": 1314878643,
+            "mana_used": 117778673,
+            "proving_cost_per_mana_numerator": 1558279507,
+            "fee_asset_price_numerator": 4221180692
+        },
+        "header": {
+            "excess_mana": 1332657316,
+            "mana_used": 94983045,
+            "proving_cost_per_mana_numerator": 1526777300,
+            "fee_asset_price_numerator": 4367616093
+        },
+        "oracle_input": {
+            "proving_cost_modifier": -31502207,
+            "fee_asset_price_modifier": 146435401
+        },
+        "outputs": {
+            "fee_asset_price_at_execution": 10431153944,
+            "mana_base_fee_components_in_wei": {
+                "data_cost": 119,
+                "gas_cost": 29628158,
+                "proving_cost": 5500405284,
+                "congestion_cost": 20765601159,
+                "congestion_multiplier": 4755058795
+            },
+            "mana_base_fee_components_in_fee_asset": {
+                "data_cost": 1241,
+                "gas_cost": 309055877,
+                "proving_cost": 57375574271,
+                "congestion_cost": 216609182429,
+                "congestion_multiplier": 4755058795
+            }
+        }
+    },
+    {
+        "l1_block_number": 20974061,
+        "l1_fees": {
+            "blob_fee": 32996,
+            "base_fee": 9186237001
+        },
+        "parent_header": {
+            "excess_mana": 1332657316,
+            "mana_used": 94983045,
+            "proving_cost_per_mana_numerator": 1526777300,
+            "fee_asset_price_numerator": 4367616093
+        },
+        "header": {
+            "excess_mana": 1327640361,
+            "mana_used": 106363982,
+            "proving_cost_per_mana_numerator": 1463686342,
+            "fee_asset_price_numerator": 4520398689
+        },
+        "oracle_input": {
+            "proving_cost_modifier": -63090958,
+            "fee_asset_price_modifier": 152782596
+        },
+        "outputs": {
+            "fee_asset_price_at_execution": 10446440035,
+            "mana_base_fee_components_in_wei": {
+                "data_cost": 129,
+                "gas_cost": 30429410,
+                "proving_cost": 5498672808,
+                "congestion_cost": 20608231336,
+                "congestion_multiplier": 4727229131
+            },
+            "mana_base_fee_components_in_fee_asset": {
+                "data_cost": 1347,
+                "gas_cost": 317879006,
+                "proving_cost": 57441555760,
+                "congestion_cost": 215282652878,
+                "congestion_multiplier": 4727229131
+            }
+        }
+    },
+    {
+        "l1_block_number": 20974064,
+        "l1_fees": {
+            "blob_fee": 28201,
+            "base_fee": 8647342222
+        },
+        "parent_header": {
+            "excess_mana": 1327640361,
+            "mana_used": 106363982,
+            "proving_cost_per_mana_numerator": 1463686342,
+            "fee_asset_price_numerator": 4520398689
+        },
+        "header": {
+            "excess_mana": 1334004343,
+            "mana_used": 96516464,
+            "proving_cost_per_mana_numerator": 1472271650,
+            "fee_asset_price_numerator": 4708785624
+        },
+        "oracle_input": {
+            "proving_cost_modifier": 8585308,
+            "fee_asset_price_modifier": 188386935
+        },
+        "outputs": {
+            "fee_asset_price_at_execution": 10462412576,
+            "mana_base_fee_components_in_wei": {
+                "data_cost": 110,
+                "gas_cost": 28644321,
+                "proving_cost": 5495204737,
+                "congestion_cost": 20783807180,
+                "congestion_multiplier": 4762558779
+            },
+            "mana_base_fee_components_in_fee_asset": {
+                "data_cost": 1150,
+                "gas_cost": 299688704,
+                "proving_cost": 57493099148,
+                "congestion_cost": 217448765617,
+                "congestion_multiplier": 4762558779
+            }
+        }
+    },
+    {
+        "l1_block_number": 20974067,
+        "l1_fees": {
+            "blob_fee": 26071,
+            "base_fee": 9137278849
+        },
+        "parent_header": {
+            "excess_mana": 1334004343,
+            "mana_used": 96516464,
+            "proving_cost_per_mana_numerator": 1472271650,
+            "fee_asset_price_numerator": 4708785624
+        },
+        "header": {
+            "excess_mana": 1330520807,
+            "mana_used": 90569854,
+            "proving_cost_per_mana_numerator": 1289735269,
+            "fee_asset_price_numerator": 5085567680
+        },
+        "oracle_input": {
+            "proving_cost_modifier": -182536381,
+            "fee_asset_price_modifier": 376782056
+        },
+        "outputs": {
+            "fee_asset_price_at_execution": 10482140971,
+            "mana_base_fee_components_in_wei": {
+                "data_cost": 102,
+                "gas_cost": 30267236,
+                "proving_cost": 5495676537,
+                "congestion_cost": 20684643182,
+                "congestion_multiplier": 4743187345
+            },
+            "mana_base_fee_components_in_fee_asset": {
+                "data_cost": 1069,
+                "gas_cost": 317265434,
+                "proving_cost": 57606456191,
+                "congestion_cost": 216819345768,
+                "congestion_multiplier": 4743187345
+            }
+        }
+    },
+    {
+        "l1_block_number": 20974070,
+        "l1_fees": {
+            "blob_fee": 22282,
+            "base_fee": 8823926412
+        },
+        "parent_header": {
+            "excess_mana": 1330520807,
+            "mana_used": 90569854,
+            "proving_cost_per_mana_numerator": 1289735269,
+            "fee_asset_price_numerator": 5085567680
+        },
+        "header": {
+            "excess_mana": 1321090661,
+            "mana_used": 106526420,
+            "proving_cost_per_mana_numerator": 1281893651,
+            "fee_asset_price_numerator": 5053281775
+        },
+        "oracle_input": {
+            "proving_cost_modifier": -7841618,
+            "fee_asset_price_modifier": -32285905
+        },
+        "outputs": {
+            "fee_asset_price_at_execution": 10521710296,
+            "mana_base_fee_components_in_wei": {
+                "data_cost": 87,
+                "gas_cost": 29229256,
+                "proving_cost": 5485654079,
+                "congestion_cost": 20356218469,
+                "congestion_multiplier": 4691142117
+            },
+            "mana_base_fee_components_in_fee_asset": {
+                "data_cost": 915,
+                "gas_cost": 307541763,
+                "proving_cost": 57718463003,
+                "congestion_cost": 214182233452,
+                "congestion_multiplier": 4691142117
+            }
+        }
+    },
+    {
+        "l1_block_number": 20974073,
+        "l1_fees": {
+            "blob_fee": 16276,
+            "base_fee": 8118906685
+        },
+        "parent_header": {
+            "excess_mana": 1321090661,
+            "mana_used": 106526420,
+            "proving_cost_per_mana_numerator": 1281893651,
+            "fee_asset_price_numerator": 5053281775
+        },
+        "header": {
+            "excess_mana": 1327617081,
+            "mana_used": 109708384,
+            "proving_cost_per_mana_numerator": 1333514174,
+            "fee_asset_price_numerator": 5729363449
+        },
+        "oracle_input": {
+            "proving_cost_modifier": 51620523,
+            "fee_asset_price_modifier": 676081674
+        },
+        "outputs": {
+            "fee_asset_price_at_execution": 10518313815,
+            "mana_base_fee_components_in_wei": {
+                "data_cost": 63,
+                "gas_cost": 26893878,
+                "proving_cost": 5485223931,
+                "congestion_cost": 20544216587,
+                "congestion_multiplier": 4727100375
+            },
+            "mana_base_fee_components_in_fee_asset": {
+                "data_cost": 662,
+                "gas_cost": 282878248,
+                "proving_cost": 57695306651,
+                "congestion_cost": 216090517145,
+                "congestion_multiplier": 4727100375
+            }
+        }
+    },
+    {
+        "l1_block_number": 20974076,
+        "l1_fees": {
+            "blob_fee": 15649,
+            "base_fee": 8773229158
+        },
+        "parent_header": {
+            "excess_mana": 1327617081,
+            "mana_used": 109708384,
+            "proving_cost_per_mana_numerator": 1333514174,
+            "fee_asset_price_numerator": 5729363449
+        },
+        "header": {
+            "excess_mana": 1337325465,
+            "mana_used": 102116789,
+            "proving_cost_per_mana_numerator": 1262796025,
+            "fee_asset_price_numerator": 5693645457
+        },
+        "oracle_input": {
+            "proving_cost_modifier": -70718149,
+            "fee_asset_price_modifier": -35717992
+        },
+        "outputs": {
+            "fee_asset_price_at_execution": 10589667138,
+            "mana_base_fee_components_in_wei": {
+                "data_cost": 61,
+                "gas_cost": 29061321,
+                "proving_cost": 5488056164,
+                "congestion_cost": 20860777103,
+                "congestion_multiplier": 4781100716
+            },
+            "mana_base_fee_components_in_fee_asset": {
+                "data_cost": 645,
+                "gas_cost": 307749715,
+                "proving_cost": 58116688011,
+                "congestion_cost": 220908685760,
+                "congestion_multiplier": 4781100716
+            }
+        }
+    },
+    {
+        "l1_block_number": 20974079,
+        "l1_fees": {
+            "blob_fee": 14467,
+            "base_fee": 8811930844
+        },
+        "parent_header": {
+            "excess_mana": 1337325465,
+            "mana_used": 102116789,
+            "proving_cost_per_mana_numerator": 1262796025,
+            "fee_asset_price_numerator": 5693645457
+        },
+        "header": {
+            "excess_mana": 1339442254,
+            "mana_used": 86520455,
+            "proving_cost_per_mana_numerator": 1345831705,
+            "fee_asset_price_numerator": 5664501917
+        },
+        "oracle_input": {
+            "proving_cost_modifier": 83035680,
+            "fee_asset_price_modifier": -29143540
+        },
+        "outputs": {
+            "fee_asset_price_at_execution": 10585885397,
+            "mana_base_fee_components_in_wei": {
+                "data_cost": 56,
+                "gas_cost": 29189520,
+                "proving_cost": 5484176484,
+                "congestion_cost": 20911957474,
+                "congestion_multiplier": 4792956471
+            },
+            "mana_base_fee_components_in_fee_asset": {
+                "data_cost": 592,
+                "gas_cost": 308996913,
+                "proving_cost": 58054863756,
+                "congestion_cost": 221371585246,
+                "congestion_multiplier": 4792956471
+            }
+        }
+    },
+    {
+        "l1_block_number": 20974082,
+        "l1_fees": {
+            "blob_fee": 10568,
+            "base_fee": 8983995122
+        },
+        "parent_header": {
+            "excess_mana": 1339442254,
+            "mana_used": 86520455,
+            "proving_cost_per_mana_numerator": 1345831705,
+            "fee_asset_price_numerator": 5664501917
+        },
+        "header": {
+            "excess_mana": 1325962709,
+            "mana_used": 95650619,
+            "proving_cost_per_mana_numerator": 1431637765,
+            "fee_asset_price_numerator": 5095534826
+        },
+        "oracle_input": {
+            "proving_cost_modifier": 85806060,
+            "fee_asset_price_modifier": -568967091
+        },
+        "outputs": {
+            "fee_asset_price_at_execution": 10582800745,
+            "mana_base_fee_components_in_wei": {
+                "data_cost": 41,
+                "gas_cost": 29759483,
+                "proving_cost": 5488732198,
+                "congestion_cost": 20517528044,
+                "congestion_multiplier": 4717959377
+            },
+            "mana_base_fee_components_in_fee_asset": {
+                "data_cost": 433,
+                "gas_cost": 314938678,
+                "proving_cost": 58086159194,
+                "congestion_cost": 217132911069,
+                "congestion_multiplier": 4717959377
+            }
+        }
+    },
+    {
+        "l1_block_number": 20974085,
+        "l1_fees": {
+            "blob_fee": 9770,
+            "base_fee": 9107507567
+        },
+        "parent_header": {
+            "excess_mana": 1325962709,
+            "mana_used": 95650619,
+            "proving_cost_per_mana_numerator": 1431637765,
+            "fee_asset_price_numerator": 5095534826
+        },
+        "header": {
+            "excess_mana": 1321613328,
+            "mana_used": 100534579,
+            "proving_cost_per_mana_numerator": 1304815455,
+            "fee_asset_price_numerator": 5440940203
+        },
+        "oracle_input": {
+            "proving_cost_modifier": -126822310,
+            "fee_asset_price_modifier": 345405377
+        },
+        "outputs": {
+            "fee_asset_price_at_execution": 10522759062,
+            "mana_base_fee_components_in_wei": {
+                "data_cost": 38,
+                "gas_cost": 30168618,
+                "proving_cost": 5493443884,
+                "congestion_cost": 20404289476,
+                "congestion_multiplier": 4694011723
+            },
+            "mana_base_fee_components_in_fee_asset": {
+                "data_cost": 399,
+                "gas_cost": 317457098,
+                "proving_cost": 57806186411,
+                "congestion_cost": 214709421987,
+                "congestion_multiplier": 4694011723
+            }
+        }
+    },
+    {
+        "l1_block_number": 20974088,
+        "l1_fees": {
+            "blob_fee": 9770,
+            "base_fee": 8571228619
+        },
+        "parent_header": {
+            "excess_mana": 1321613328,
+            "mana_used": 100534579,
+            "proving_cost_per_mana_numerator": 1304815455,
+            "fee_asset_price_numerator": 5440940203
+        },
+        "header": {
+            "excess_mana": 1322147907,
+            "mana_used": 105255685,
+            "proving_cost_per_mana_numerator": 1331312627,
+            "fee_asset_price_numerator": 4921429737
+        },
+        "oracle_input": {
+            "proving_cost_modifier": 26497172,
+            "fee_asset_price_modifier": -519510466
+        },
+        "outputs": {
+            "fee_asset_price_at_execution": 10559168081,
+            "mana_base_fee_components_in_wei": {
+                "data_cost": 38,
+                "gas_cost": 28392194,
+                "proving_cost": 5486481388,
+                "congestion_cost": 20388204010,
+                "congestion_multiplier": 4696948546
+            },
+            "mana_base_fee_components_in_fee_asset": {
+                "data_cost": 401,
+                "gas_cost": 299797948,
+                "proving_cost": 57932679149,
+                "congestion_cost": 215282473011,
+                "congestion_multiplier": 4696948546
+            }
+        }
+    },
+    {
+        "l1_block_number": 20974091,
+        "l1_fees": {
+            "blob_fee": 8350,
+            "base_fee": 9165139797
+        },
+        "parent_header": {
+            "excess_mana": 1322147907,
+            "mana_used": 105255685,
+            "proving_cost_per_mana_numerator": 1331312627,
+            "fee_asset_price_numerator": 4921429737
+        },
+        "header": {
+            "excess_mana": 1327403592,
+            "mana_used": 101065209,
+            "proving_cost_per_mana_numerator": 1299439387,
+            "fee_asset_price_numerator": 4946730380
+        },
+        "oracle_input": {
+            "proving_cost_modifier": -31873240,
+            "fee_asset_price_modifier": 25300643
+        },
+        "outputs": {
+            "fee_asset_price_at_execution": 10504454343,
+            "mana_base_fee_components_in_wei": {
+                "data_cost": 32,
+                "gas_cost": 30359525,
+                "proving_cost": 5487935343,
+                "congestion_cost": 20560724103,
+                "congestion_multiplier": 4725919777
+            },
+            "mana_base_fee_components_in_fee_asset": {
+                "data_cost": 336,
+                "gas_cost": 318910244,
+                "proving_cost": 57647766247,
+                "congestion_cost": 215979187598,
+                "congestion_multiplier": 4725919777
+            }
+        }
+    },
+    {
+        "l1_block_number": 20974094,
+        "l1_fees": {
+            "blob_fee": 8350,
+            "base_fee": 9073892217
+        },
+        "parent_header": {
+            "excess_mana": 1327403592,
+            "mana_used": 101065209,
+            "proving_cost_per_mana_numerator": 1299439387,
+            "fee_asset_price_numerator": 4946730380
+        },
+        "header": {
+            "excess_mana": 1328468801,
+            "mana_used": 89728000,
+            "proving_cost_per_mana_numerator": 1308013303,
+            "fee_asset_price_numerator": 4925732676
+        },
+        "oracle_input": {
+            "proving_cost_modifier": 8573916,
+            "fee_asset_price_modifier": -20997704
+        },
+        "outputs": {
+            "fee_asset_price_at_execution": 10507112373,
+            "mana_base_fee_components_in_wei": {
+                "data_cost": 32,
+                "gas_cost": 30057267,
+                "proving_cost": 5486186439,
+                "congestion_cost": 20585591951,
+                "congestion_multiplier": 4731813337
+            },
+            "mana_base_fee_components_in_fee_asset": {
+                "data_cost": 336,
+                "gas_cost": 315815081,
+                "proving_cost": 57643977413,
+                "congestion_cost": 216295127893,
+                "congestion_multiplier": 4731813337
+            }
+        }
+    },
+    {
+        "l1_block_number": 20974097,
+        "l1_fees": {
+            "blob_fee": 7422,
+            "base_fee": 8775012304
+        },
+        "parent_header": {
+            "excess_mana": 1328468801,
+            "mana_used": 89728000,
+            "proving_cost_per_mana_numerator": 1308013303,
+            "fee_asset_price_numerator": 4925732676
+        },
+        "header": {
+            "excess_mana": 1318196801,
+            "mana_used": 110180461,
+            "proving_cost_per_mana_numerator": 1308611786,
+            "fee_asset_price_numerator": 4359061244
+        },
+        "oracle_input": {
+            "proving_cost_modifier": 598483,
+            "fee_asset_price_modifier": -566671432
+        },
+        "outputs": {
+            "fee_asset_price_at_execution": 10504906353,
+            "mana_base_fee_components_in_wei": {
+                "data_cost": 29,
+                "gas_cost": 29067228,
+                "proving_cost": 5486656840,
+                "congestion_cost": 20271861518,
+                "congestion_multiplier": 4675285631
+            },
+            "mana_base_fee_components_in_fee_asset": {
+                "data_cost": 304,
+                "gas_cost": 305348508,
+                "proving_cost": 57636816295,
+                "congestion_cost": 212954006847,
+                "congestion_multiplier": 4675285631
+            }
+        }
+    },
+    {
+        "l1_block_number": 20974100,
+        "l1_fees": {
+            "blob_fee": 7136,
+            "base_fee": 8687630284
+        },
+        "parent_header": {
+            "excess_mana": 1318196801,
+            "mana_used": 110180461,
+            "proving_cost_per_mana_numerator": 1308611786,
+            "fee_asset_price_numerator": 4359061244
+        },
+        "header": {
+            "excess_mana": 1328377262,
+            "mana_used": 118939145,
+            "proving_cost_per_mana_numerator": 1405119072,
+            "fee_asset_price_numerator": 3995754984
+        },
+        "oracle_input": {
+            "proving_cost_modifier": 96507286,
+            "fee_asset_price_modifier": -363306260
+        },
+        "outputs": {
+            "fee_asset_price_at_execution": 10445546396,
+            "mana_base_fee_components_in_wei": {
+                "data_cost": 28,
+                "gas_cost": 28777775,
+                "proving_cost": 5486689677,
+                "congestion_cost": 20579900121,
+                "congestion_multiplier": 4731306584
+            },
+            "mana_base_fee_components_in_fee_asset": {
+                "data_cost": 292,
+                "gas_cost": 300599583,
+                "proving_cost": 57311471581,
+                "congestion_cost": 214968301538,
+                "congestion_multiplier": 4731306584
+            }
+        }
+    },
+    {
+        "l1_block_number": 20974103,
+        "l1_fees": {
+            "blob_fee": 6343,
+            "base_fee": 8779992851
+        },
+        "parent_header": {
+            "excess_mana": 1328377262,
+            "mana_used": 118939145,
+            "proving_cost_per_mana_numerator": 1405119072,
+            "fee_asset_price_numerator": 3995754984
+        },
+        "header": {
+            "excess_mana": 1347316407,
+            "mana_used": 83523832,
+            "proving_cost_per_mana_numerator": 1432998603,
+            "fee_asset_price_numerator": 4308644264
+        },
+        "oracle_input": {
+            "proving_cost_modifier": 27879531,
+            "fee_asset_price_modifier": 312889280
+        },
+        "outputs": {
+            "fee_asset_price_at_execution": 10407665925,
+            "mana_base_fee_components_in_wei": {
+                "data_cost": 24,
+                "gas_cost": 29083726,
+                "proving_cost": 5491987288,
+                "congestion_cost": 21186098929,
+                "congestion_multiplier": 4837316851
+            },
+            "mana_base_fee_components_in_fee_asset": {
+                "data_cost": 249,
+                "gas_cost": 302693704,
+                "proving_cost": 57158768957,
+                "congestion_cost": 220497839907,
+                "congestion_multiplier": 4837316851
+            }
+        }
+    },
+    {
+        "l1_block_number": 20974106,
+        "l1_fees": {
+            "blob_fee": 6343,
+            "base_fee": 9971002047
+        },
+        "parent_header": {
+            "excess_mana": 1347316407,
+            "mana_used": 83523832,
+            "proving_cost_per_mana_numerator": 1432998603,
+            "fee_asset_price_numerator": 4308644264
+        },
+        "header": {
+            "excess_mana": 1330840239,
+            "mana_used": 88135080,
+            "proving_cost_per_mana_numerator": 1595042674,
+            "fee_asset_price_numerator": 4514596152
+        },
+        "oracle_input": {
+            "proving_cost_modifier": 162044071,
+            "fee_asset_price_modifier": 205951888
+        },
+        "outputs": {
+            "fee_asset_price_at_execution": 10440281394,
+            "mana_base_fee_components_in_wei": {
+                "data_cost": 24,
+                "gas_cost": 33028944,
+                "proving_cost": 5493518642,
+                "congestion_cost": 20696701798,
+                "congestion_multiplier": 4744960373
+            },
+            "mana_base_fee_components_in_fee_asset": {
+                "data_cost": 250,
+                "gas_cost": 344831469,
+                "proving_cost": 57353880465,
+                "congestion_cost": 216079390698,
+                "congestion_multiplier": 4744960373
+            }
+        }
+    },
+    {
+        "l1_block_number": 20974109,
+        "l1_fees": {
+            "blob_fee": 5638,
+            "base_fee": 9495549897
+        },
+        "parent_header": {
+            "excess_mana": 1330840239,
+            "mana_used": 88135080,
+            "proving_cost_per_mana_numerator": 1595042674,
+            "fee_asset_price_numerator": 4514596152
+        },
+        "header": {
+            "excess_mana": 1318975319,
+            "mana_used": 103366901,
+            "proving_cost_per_mana_numerator": 1576902899,
+            "fee_asset_price_numerator": 4393549612
+        },
+        "oracle_input": {
+            "proving_cost_modifier": -18139775,
+            "fee_asset_price_modifier": -121046540
+        },
+        "outputs": {
+            "fee_asset_price_at_execution": 10461805508,
+            "mana_base_fee_components_in_wei": {
+                "data_cost": 22,
+                "gas_cost": 31454009,
+                "proving_cost": 5502427779,
+                "congestion_cost": 20362173397,
+                "congestion_multiplier": 4679546130
+            },
+            "mana_base_fee_components_in_fee_asset": {
+                "data_cost": 230,
+                "gas_cost": 329065724,
+                "proving_cost": 57565329245,
+                "congestion_cost": 213025097799,
+                "congestion_multiplier": 4679546130
+            }
+        }
+    },
+    {
+        "l1_block_number": 20974112,
+        "l1_fees": {
+            "blob_fee": 5012,
+            "base_fee": 9531667424
+        },
+        "parent_header": {
+            "excess_mana": 1318975319,
+            "mana_used": 103366901,
+            "proving_cost_per_mana_numerator": 1576902899,
+            "fee_asset_price_numerator": 4393549612
+        },
+        "header": {
+            "excess_mana": 1322342220,
+            "mana_used": 105121839,
+            "proving_cost_per_mana_numerator": 1304053042,
+            "fee_asset_price_numerator": 5192433162
+        },
+        "oracle_input": {
+            "proving_cost_modifier": -272849857,
+            "fee_asset_price_modifier": 798883550
+        },
+        "outputs": {
+            "fee_asset_price_at_execution": 10449149516,
+            "mana_base_fee_components_in_wei": {
+                "data_cost": 19,
+                "gas_cost": 31573648,
+                "proving_cost": 5501429742,
+                "congestion_cost": 20461137906,
+                "congestion_multiplier": 4698016501
+            },
+            "mana_base_fee_components_in_fee_asset": {
+                "data_cost": 198,
+                "gas_cost": 329917768,
+                "proving_cost": 57485261925,
+                "congestion_cost": 213801489247,
+                "congestion_multiplier": 4698016501
+            }
+        }
+    },
+    {
+        "l1_block_number": 20974115,
+        "l1_fees": {
+            "blob_fee": 4819,
+            "base_fee": 10731011935
+        },
+        "parent_header": {
+            "excess_mana": 1322342220,
+            "mana_used": 105121839,
+            "proving_cost_per_mana_numerator": 1304053042,
+            "fee_asset_price_numerator": 5192433162
+        },
+        "header": {
+            "excess_mana": 1327464059,
+            "mana_used": 108840687,
+            "proving_cost_per_mana_numerator": 1179553844,
+            "fee_asset_price_numerator": 4891944810
+        },
+        "oracle_input": {
+            "proving_cost_modifier": -124499198,
+            "fee_asset_price_modifier": -300488352
+        },
+        "outputs": {
+            "fee_asset_price_at_execution": 10532960382,
+            "mana_base_fee_components_in_wei": {
+                "data_cost": 18,
+                "gas_cost": 35546477,
+                "proving_cost": 5486439558,
+                "congestion_cost": 20576323341,
+                "congestion_multiplier": 4726254131
+            },
+            "mana_base_fee_components_in_fee_asset": {
+                "data_cost": 189,
+                "gas_cost": 374409633,
+                "proving_cost": 57788450502,
+                "congestion_cost": 216729598557,
+                "congestion_multiplier": 4726254131
+            }
+        }
+    },
+    {
+        "l1_block_number": 20974118,
+        "l1_fees": {
+            "blob_fee": 5212,
+            "base_fee": 10880046233
+        },
+        "parent_header": {
+            "excess_mana": 1327464059,
+            "mana_used": 108840687,
+            "proving_cost_per_mana_numerator": 1179553844,
+            "fee_asset_price_numerator": 4891944810
+        },
+        "header": {
+            "excess_mana": 1336304746,
+            "mana_used": 73668457,
+            "proving_cost_per_mana_numerator": 1313673273,
+            "fee_asset_price_numerator": 4922105240
+        },
+        "oracle_input": {
+            "proving_cost_modifier": 134119429,
+            "fee_asset_price_modifier": 30160430
+        },
+        "outputs": {
+            "fee_asset_price_at_execution": 10501357569,
+            "mana_base_fee_components_in_wei": {
+                "data_cost": 20,
+                "gas_cost": 36040153,
+                "proving_cost": 5479613235,
+                "congestion_cost": 20823766635,
+                "congestion_multiplier": 4775394336
+            },
+            "mana_base_fee_components_in_fee_asset": {
+                "data_cost": 210,
+                "gas_cost": 378470533,
+                "proving_cost": 57543377920,
+                "congestion_cost": 218677819367,
+                "congestion_multiplier": 4775394336
+            }
+        }
+    },
+    {
+        "l1_block_number": 20974121,
+        "l1_fees": {
+            "blob_fee": 3960,
+            "base_fee": 10929199366
+        },
+        "parent_header": {
+            "excess_mana": 1336304746,
+            "mana_used": 73668457,
+            "proving_cost_per_mana_numerator": 1313673273,
+            "fee_asset_price_numerator": 4922105240
+        },
+        "header": {
+            "excess_mana": 1309973203,
+            "mana_used": 114284930,
+            "proving_cost_per_mana_numerator": 1217891954,
+            "fee_asset_price_numerator": 4382088410
+        },
+        "oracle_input": {
+            "proving_cost_modifier": -95781319,
+            "fee_asset_price_modifier": -540016830
+        },
+        "outputs": {
+            "fee_asset_price_at_execution": 10504525301,
+            "mana_base_fee_components_in_wei": {
+                "data_cost": 15,
+                "gas_cost": 36202972,
+                "proving_cost": 5486967392,
+                "congestion_cost": 20051967119,
+                "congestion_multiplier": 4630517573
+            },
+            "mana_base_fee_components_in_fee_asset": {
+                "data_cost": 157,
+                "gas_cost": 380295035,
+                "proving_cost": 57637987795,
+                "congestion_cost": 210636395936,
+                "congestion_multiplier": 4630517573
+            }
+        }
+    },
+    {
+        "l1_block_number": 20974124,
+        "l1_fees": {
+            "blob_fee": 3661,
+            "base_fee": 10608376541
+        },
+        "parent_header": {
+            "excess_mana": 1309973203,
+            "mana_used": 114284930,
+            "proving_cost_per_mana_numerator": 1217891954,
+            "fee_asset_price_numerator": 4382088410
+        },
+        "header": {
+            "excess_mana": 1324258133,
+            "mana_used": 104636722,
+            "proving_cost_per_mana_numerator": 1276217998,
+            "fee_asset_price_numerator": 4279528698
+        },
+        "oracle_input": {
+            "proving_cost_modifier": 58326044,
+            "fee_asset_price_modifier": -102559712
+        },
+        "outputs": {
+            "fee_asset_price_at_execution": 10447951986,
+            "mana_base_fee_components_in_wei": {
+                "data_cost": 14,
+                "gas_cost": 35140247,
+                "proving_cost": 5481714418,
+                "congestion_cost": 20459583680,
+                "congestion_multiplier": 4708559473
+            },
+            "mana_base_fee_components_in_fee_asset": {
+                "data_cost": 146,
+                "gas_cost": 367143613,
+                "proving_cost": 57272689040,
+                "congestion_cost": 213760747942,
+                "congestion_multiplier": 4708559473
+            }
+        }
+    },
+    {
+        "l1_block_number": 20974127,
+        "l1_fees": {
+            "blob_fee": 2781,
+            "base_fee": 10777238232
+        },
+        "parent_header": {
+            "excess_mana": 1324258133,
+            "mana_used": 104636722,
+            "proving_cost_per_mana_numerator": 1276217998,
+            "fee_asset_price_numerator": 4279528698
+        },
+        "header": {
+            "excess_mana": 1328894855,
+            "mana_used": 83656362,
+            "proving_cost_per_mana_numerator": 1180049967,
+            "fee_asset_price_numerator": 3780652926
+        },
+        "oracle_input": {
+            "proving_cost_modifier": -96168031,
+            "fee_asset_price_modifier": -498875772
+        },
+        "outputs": {
+            "fee_asset_price_at_execution": 10437242090,
+            "mana_base_fee_components_in_wei": {
+                "data_cost": 10,
+                "gas_cost": 35699601,
+                "proving_cost": 5484912618,
+                "congestion_cost": 20614919218,
+                "congestion_multiplier": 4734172654
+            },
+            "mana_base_fee_components_in_fee_asset": {
+                "data_cost": 104,
+                "gas_cost": 372605378,
+                "proving_cost": 57247360836,
+                "congestion_cost": 215162902544,
+                "congestion_multiplier": 4734172654
+            }
+        }
+    },
+    {
+        "l1_block_number": 20974130,
+        "l1_fees": {
+            "blob_fee": 2571,
+            "base_fee": 11304295945
+        },
+        "parent_header": {
+            "excess_mana": 1328894855,
+            "mana_used": 83656362,
+            "proving_cost_per_mana_numerator": 1180049967,
+            "fee_asset_price_numerator": 3780652926
+        },
+        "header": {
+            "excess_mana": 1312551217,
+            "mana_used": 128278391,
+            "proving_cost_per_mana_numerator": 1224832645,
+            "fee_asset_price_numerator": 3584705140
+        },
+        "oracle_input": {
+            "proving_cost_modifier": 44782678,
+            "fee_asset_price_modifier": -195947786
+        },
+        "outputs": {
+            "fee_asset_price_at_execution": 10385302882,
+            "mana_base_fee_components_in_wei": {
+                "data_cost": 10,
+                "gas_cost": 37445480,
+                "proving_cost": 5479640421,
+                "congestion_cost": 20107050382,
+                "congestion_multiplier": 4644505579
+            },
+            "mana_base_fee_components_in_fee_asset": {
+                "data_cost": 103,
+                "gas_cost": 388882651,
+                "proving_cost": 56907725456,
+                "congestion_cost": 208817808280,
+                "congestion_multiplier": 4644505579
+            }
+        }
+    },
+    {
+        "l1_block_number": 20974133,
+        "l1_fees": {
+            "blob_fee": 2285,
+            "base_fee": 10659083042
+        },
+        "parent_header": {
+            "excess_mana": 1312551217,
+            "mana_used": 128278391,
+            "proving_cost_per_mana_numerator": 1224832645,
+            "fee_asset_price_numerator": 3584705140
+        },
+        "header": {
+            "excess_mana": 1340829608,
+            "mana_used": 96867550,
+            "proving_cost_per_mana_numerator": 1260260737,
+            "fee_asset_price_numerator": 3246488766
+        },
+        "oracle_input": {
+            "proving_cost_modifier": 35428092,
+            "fee_asset_price_modifier": -338216374
+        },
+        "outputs": {
+            "fee_asset_price_at_execution": 10364973035,
+            "mana_base_fee_components_in_wei": {
+                "data_cost": 8,
+                "gas_cost": 35308212,
+                "proving_cost": 5482094900,
+                "congestion_cost": 20970229829,
+                "congestion_multiplier": 4800742736
+            },
+            "mana_base_fee_components_in_fee_asset": {
+                "data_cost": 82,
+                "gas_cost": 365968665,
+                "proving_cost": 56821765813,
+                "congestion_cost": 217355866715,
+                "congestion_multiplier": 4800742736
+            }
+        }
+    },
+    {
+        "l1_block_number": 20974136,
+        "l1_fees": {
+            "blob_fee": 2031,
+            "base_fee": 9963610155
+        },
+        "parent_header": {
+            "excess_mana": 1340829608,
+            "mana_used": 96867550,
+            "proving_cost_per_mana_numerator": 1260260737,
+            "fee_asset_price_numerator": 3246488766
+        },
+        "header": {
+            "excess_mana": 1337697158,
+            "mana_used": 89334588,
+            "proving_cost_per_mana_numerator": 1221780971,
+            "fee_asset_price_numerator": 3082804055
+        },
+        "oracle_input": {
+            "proving_cost_modifier": -38479766,
+            "fee_asset_price_modifier": -163684711
+        },
+        "outputs": {
+            "fee_asset_price_at_execution": 10329976215,
+            "mana_base_fee_components_in_wei": {
+                "data_cost": 7,
+                "gas_cost": 33004458,
+                "proving_cost": 5484037446,
+                "congestion_cost": 20871964696,
+                "congestion_multiplier": 4783180377
+            },
+            "mana_base_fee_components_in_fee_asset": {
+                "data_cost": 72,
+                "gas_cost": 340935266,
+                "proving_cost": 56649976379,
+                "congestion_cost": 215606898869,
+                "congestion_multiplier": 4783180377
+            }
+        }
+    },
+    {
+        "l1_block_number": 20974139,
+        "l1_fees": {
+            "blob_fee": 1736,
+            "base_fee": 10028608487
+        },
+        "parent_header": {
+            "excess_mana": 1337697158,
+            "mana_used": 89334588,
+            "proving_cost_per_mana_numerator": 1221780971,
+            "fee_asset_price_numerator": 3082804055
+        },
+        "header": {
+            "excess_mana": 1327031746,
+            "mana_used": 99486098,
+            "proving_cost_per_mana_numerator": 1490272456,
+            "fee_asset_price_numerator": 2527104241
+        },
+        "oracle_input": {
+            "proving_cost_modifier": 268491485,
+            "fee_asset_price_modifier": -555699814
+        },
+        "outputs": {
+            "fee_asset_price_at_execution": 10313081454,
+            "mana_base_fee_components_in_wei": {
+                "data_cost": 6,
+                "gas_cost": 33219765,
+                "proving_cost": 5481927607,
+                "congestion_cost": 20537659691,
+                "congestion_multiplier": 4723864166
+            },
+            "mana_base_fee_components_in_fee_asset": {
+                "data_cost": 61,
+                "gas_cost": 342598142,
+                "proving_cost": 56535565935,
+                "congestion_cost": 211806557267,
+                "congestion_multiplier": 4723864166
+            }
+        }
+    },
+    {
+        "l1_block_number": 20974142,
+        "l1_fees": {
+            "blob_fee": 1953,
+            "base_fee": 9542754428
+        },
+        "parent_header": {
+            "excess_mana": 1327031746,
+            "mana_used": 99486098,
+            "proving_cost_per_mana_numerator": 1490272456,
+            "fee_asset_price_numerator": 2527104241
+        },
+        "header": {
+            "excess_mana": 1326517844,
+            "mana_used": 108694901,
+            "proving_cost_per_mana_numerator": 1574032256,
+            "fee_asset_price_numerator": 3142134000
+        },
+        "oracle_input": {
+            "proving_cost_modifier": 83759800,
+            "fee_asset_price_modifier": 615029759
+        },
+        "outputs": {
+            "fee_asset_price_at_execution": 10255930620,
+            "mana_base_fee_components_in_wei": {
+                "data_cost": 7,
+                "gas_cost": 31610374,
+                "proving_cost": 5496665893,
+                "congestion_cost": 20570852696,
+                "congestion_multiplier": 4721024724
+            },
+            "mana_base_fee_components_in_fee_asset": {
+                "data_cost": 71,
+                "gas_cost": 324193802,
+                "proving_cost": 56373424039,
+                "congestion_cost": 210973238044,
+                "congestion_multiplier": 4721024724
+            }
+        }
+    },
+    {
+        "l1_block_number": 20974145,
+        "l1_fees": {
+            "blob_fee": 1484,
+            "base_fee": 9528375984
+        },
+        "parent_header": {
+            "excess_mana": 1326517844,
+            "mana_used": 108694901,
+            "proving_cost_per_mana_numerator": 1574032256,
+            "fee_asset_price_numerator": 3142134000
+        },
+        "header": {
+            "excess_mana": 1335212745,
+            "mana_used": 74816411,
+            "proving_cost_per_mana_numerator": 1482684488,
+            "fee_asset_price_numerator": 3536744697
+        },
+        "oracle_input": {
+            "proving_cost_modifier": -91347768,
+            "fee_asset_price_modifier": 394610697
+        },
+        "outputs": {
+            "fee_asset_price_at_execution": 10319202015,
+            "mana_base_fee_components_in_wei": {
+                "data_cost": 5,
+                "gas_cost": 31562745,
+                "proving_cost": 5501271818,
+                "congestion_cost": 20854896694,
+                "congestion_multiplier": 4769296992
+            },
+            "mana_base_fee_components_in_fee_asset": {
+                "data_cost": 51,
+                "gas_cost": 325702341,
+                "proving_cost": 56768735229,
+                "congestion_cost": 215205891987,
+                "congestion_multiplier": 4769296992
+            }
+        }
+    },
+    {
+        "l1_block_number": 20974148,
+        "l1_fees": {
+            "blob_fee": 1543,
+            "base_fee": 9131788018
+        },
+        "parent_header": {
+            "excess_mana": 1335212745,
+            "mana_used": 74816411,
+            "proving_cost_per_mana_numerator": 1482684488,
+            "fee_asset_price_numerator": 3536744697
+        },
+        "header": {
+            "excess_mana": 1310029156,
+            "mana_used": 104983478,
+            "proving_cost_per_mana_numerator": 1414641441,
+            "fee_asset_price_numerator": 3308538546
+        },
+        "oracle_input": {
+            "proving_cost_modifier": -68043047,
+            "fee_asset_price_modifier": -228206151
+        },
+        "outputs": {
+            "fee_asset_price_at_execution": 10360003140,
+            "mana_base_fee_components_in_wei": {
+                "data_cost": 6,
+                "gas_cost": 30249047,
+                "proving_cost": 5496248823,
+                "congestion_cost": 20065722997,
+                "congestion_multiplier": 4630820720
+            },
+            "mana_base_fee_components_in_fee_asset": {
+                "data_cost": 62,
+                "gas_cost": 313380221,
+                "proving_cost": 56941155064,
+                "congestion_cost": 207880953255,
+                "congestion_multiplier": 4630820720
+            }
+        }
+    },
+    {
+        "l1_block_number": 20974151,
+        "l1_fees": {
+            "blob_fee": 1543,
+            "base_fee": 9146141907
+        },
+        "parent_header": {
+            "excess_mana": 1310029156,
+            "mana_used": 104983478,
+            "proving_cost_per_mana_numerator": 1414641441,
+            "fee_asset_price_numerator": 3308538546
+        },
+        "header": {
+            "excess_mana": 1315012634,
+            "mana_used": 107439287,
+            "proving_cost_per_mana_numerator": 1389165965,
+            "fee_asset_price_numerator": 4165704660
+        },
+        "oracle_input": {
+            "proving_cost_modifier": -25475476,
+            "fee_asset_price_modifier": 857166114
+        },
+        "outputs": {
+            "fee_asset_price_at_execution": 10336387931,
+            "mana_base_fee_components_in_wei": {
+                "data_cost": 6,
+                "gas_cost": 30296595,
+                "proving_cost": 5492510280,
+                "congestion_cost": 20201877350,
+                "congestion_multiplier": 4657900373
+            },
+            "mana_base_fee_components_in_fee_asset": {
+                "data_cost": 62,
+                "gas_cost": 313157358,
+                "proving_cost": 56772716969,
+                "congestion_cost": 208814441224,
+                "congestion_multiplier": 4657900373
+            }
+        }
+    },
+    {
+        "l1_block_number": 20974154,
+        "l1_fees": {
+            "blob_fee": 1605,
+            "base_fee": 8760412288
+        },
+        "parent_header": {
+            "excess_mana": 1315012634,
+            "mana_used": 107439287,
+            "proving_cost_per_mana_numerator": 1389165965,
+            "fee_asset_price_numerator": 4165704660
+        },
+        "header": {
+            "excess_mana": 1322451921,
+            "mana_used": 18730895,
+            "proving_cost_per_mana_numerator": 1407055898,
+            "fee_asset_price_numerator": 4506427180
+        },
+        "oracle_input": {
+            "proving_cost_modifier": 17889933,
+            "fee_asset_price_modifier": 340722520
+        },
+        "outputs": {
+            "fee_asset_price_at_execution": 10425368758,
+            "mana_base_fee_components_in_wei": {
+                "data_cost": 6,
+                "gas_cost": 29018865,
+                "proving_cost": 5491111215,
+                "congestion_cost": 20416860949,
+                "congestion_multiplier": 4698619531
+            },
+            "mana_base_fee_components_in_fee_asset": {
+                "data_cost": 62,
+                "gas_cost": 302532368,
+                "proving_cost": 57246859307,
+                "congestion_cost": 212853304274,
+                "congestion_multiplier": 4698619531
+            }
+        }
+    },
+    {
+        "l1_block_number": 20974157,
+        "l1_fees": {
+            "blob_fee": 1426,
+            "base_fee": 8436997127
+        },
+        "parent_header": {
+            "excess_mana": 1322451921,
+            "mana_used": 18730895,
+            "proving_cost_per_mana_numerator": 1407055898,
+            "fee_asset_price_numerator": 4506427180
+        },
+        "header": {
+            "excess_mana": 1241182816,
+            "mana_used": 157332552,
+            "proving_cost_per_mana_numerator": 1287220253,
+            "fee_asset_price_numerator": 5099720058
+        },
+        "oracle_input": {
+            "proving_cost_modifier": -119835645,
+            "fee_asset_price_modifier": 593292878
+        },
+        "outputs": {
+            "fee_asset_price_at_execution": 10460950921,
+            "mana_base_fee_components_in_wei": {
+                "data_cost": 5,
+                "gas_cost": 27947552,
+                "proving_cost": 5492093659,
+                "congestion_cost": 18063975452,
+                "congestion_multiplier": 4272434887
+            },
+            "mana_base_fee_components_in_fee_asset": {
+                "data_cost": 52,
+                "gas_cost": 292357969,
+                "proving_cost": 57452522220,
+                "congestion_cost": 188966360641,
+                "congestion_multiplier": 4272434887
+            }
+        }
+    },
+    {
+        "l1_block_number": 20974160,
+        "l1_fees": {
+            "blob_fee": 1219,
+            "base_fee": 10808069079
+        },
+        "parent_header": {
+            "excess_mana": 1241182816,
+            "mana_used": 157332552,
+            "proving_cost_per_mana_numerator": 1287220253,
+            "fee_asset_price_numerator": 5099720058
+        },
+        "header": {
+            "excess_mana": 1298515368,
+            "mana_used": 118327080,
+            "proving_cost_per_mana_numerator": 1088996923,
+            "fee_asset_price_numerator": 5193259556
+        },
+        "oracle_input": {
+            "proving_cost_modifier": -198223330,
+            "fee_asset_price_modifier": 93539498
+        },
+        "outputs": {
+            "fee_asset_price_at_execution": 10523199473,
+            "mana_base_fee_components_in_wei": {
+                "data_cost": 4,
+                "gas_cost": 35801728,
+                "proving_cost": 5485516115,
+                "congestion_cost": 19704791765,
+                "congestion_multiplier": 4568856623
+            },
+            "mana_base_fee_components_in_fee_asset": {
+                "data_cost": 42,
+                "gas_cost": 376748725,
+                "proving_cost": 57725180290,
+                "congestion_cost": 207357454317,
+                "congestion_multiplier": 4568856623
+            }
+        }
+    },
+    {
+        "l1_block_number": 20974163,
+        "l1_fees": {
+            "blob_fee": 1084,
+            "base_fee": 10151808592
+        },
+        "parent_header": {
+            "excess_mana": 1298515368,
+            "mana_used": 118327080,
+            "proving_cost_per_mana_numerator": 1088996923,
+            "fee_asset_price_numerator": 5193259556
+        },
+        "header": {
+            "excess_mana": 1316842448,
+            "mana_used": 89473864,
+            "proving_cost_per_mana_numerator": 1164598933,
+            "fee_asset_price_numerator": 5476749594
+        },
+        "oracle_input": {
+            "proving_cost_modifier": 75602010,
+            "fee_asset_price_modifier": 283490038
+        },
+        "outputs": {
+            "fee_asset_price_at_execution": 10533047427,
+            "mana_base_fee_components_in_wei": {
+                "data_cost": 4,
+                "gas_cost": 33627865,
+                "proving_cost": 5474653312,
+                "congestion_cost": 20203731299,
+                "congestion_multiplier": 4667883072
+            },
+            "mana_base_fee_components_in_fee_asset": {
+                "data_cost": 42,
+                "gas_cost": 354203896,
+                "proving_cost": 57664782981,
+                "congestion_cost": 212806859974,
+                "congestion_multiplier": 4667883072
+            }
+        }
+    },
+    {
+        "l1_block_number": 20974166,
+        "l1_fees": {
+            "blob_fee": 823,
+            "base_fee": 9893170338
+        },
+        "parent_header": {
+            "excess_mana": 1316842448,
+            "mana_used": 89473864,
+            "proving_cost_per_mana_numerator": 1164598933,
+            "fee_asset_price_numerator": 5476749594
+        },
+        "header": {
+            "excess_mana": 1306316312,
+            "mana_used": 57418796,
+            "proving_cost_per_mana_numerator": 1202744964,
+            "fee_asset_price_numerator": 5218827127
+        },
+        "oracle_input": {
+            "proving_cost_modifier": 38146031,
+            "fee_asset_price_modifier": -257922467
+        },
+        "outputs": {
+            "fee_asset_price_at_execution": 10562949932,
+            "mana_base_fee_components_in_wei": {
+                "data_cost": 3,
+                "gas_cost": 32771126,
+                "proving_cost": 5478793825,
+                "congestion_cost": 19900871787,
+                "congestion_multiplier": 4610747937
+            },
+            "mana_base_fee_components_in_fee_asset": {
+                "data_cost": 31,
+                "gas_cost": 346159763,
+                "proving_cost": 57872224861,
+                "congestion_cost": 210211912289,
+                "congestion_multiplier": 4610747937
+            }
+        }
+    },
+    {
+        "l1_block_number": 20974169,
+        "l1_fees": {
+            "blob_fee": 926,
+            "base_fee": 9477902554
+        },
+        "parent_header": {
+            "excess_mana": 1306316312,
+            "mana_used": 57418796,
+            "proving_cost_per_mana_numerator": 1202744964,
+            "fee_asset_price_numerator": 5218827127
+        },
+        "header": {
+            "excess_mana": 1263735108,
+            "mana_used": 144445614,
+            "proving_cost_per_mana_numerator": 1275483706,
+            "fee_asset_price_numerator": 5255608628
+        },
+        "oracle_input": {
+            "proving_cost_modifier": 72738742,
+            "fee_asset_price_modifier": 36781501
+        },
+        "outputs": {
+            "fee_asset_price_at_execution": 10535740815,
+            "mana_base_fee_components_in_wei": {
+                "data_cost": 3,
+                "gas_cost": 31395552,
+                "proving_cost": 5480884166,
+                "congestion_cost": 18668264634,
+                "congestion_multiplier": 4386668598
+            },
+            "mana_base_fee_components_in_fee_asset": {
+                "data_cost": 31,
+                "gas_cost": 330775398,
+                "proving_cost": 57745175010,
+                "congestion_cost": 196683997649,
+                "congestion_multiplier": 4386668598
+            }
+        }
+    },
+    {
+        "l1_block_number": 20974172,
+        "l1_fees": {
+            "blob_fee": 890,
+            "base_fee": 8894215403
+        },
+        "parent_header": {
+            "excess_mana": 1263735108,
+            "mana_used": 144445614,
+            "proving_cost_per_mana_numerator": 1275483706,
+            "fee_asset_price_numerator": 5255608628
+        },
+        "header": {
+            "excess_mana": 1308180722,
+            "mana_used": 113971510,
+            "proving_cost_per_mana_numerator": 1254728663,
+            "fee_asset_price_numerator": 4448615753
+        },
+        "oracle_input": {
+            "proving_cost_modifier": -20755043,
+            "fee_asset_price_modifier": -806992875
+        },
+        "outputs": {
+            "fee_asset_price_at_execution": 10539616732,
+            "mana_base_fee_components_in_wei": {
+                "data_cost": 3,
+                "gas_cost": 29462088,
+                "proving_cost": 5484872343,
+                "congestion_cost": 19966393739,
+                "congestion_multiplier": 4620816615
+            },
+            "mana_base_fee_components_in_fee_asset": {
+                "data_cost": 31,
+                "gas_cost": 310519115,
+                "proving_cost": 57808452319,
+                "congestion_cost": 210438137529,
+                "congestion_multiplier": 4620816615
+            }
+        }
+    },
+    {
+        "l1_block_number": 20974175,
+        "l1_fees": {
+            "blob_fee": 1042,
+            "base_fee": 8477418490
+        },
+        "parent_header": {
+            "excess_mana": 1308180722,
+            "mana_used": 113971510,
+            "proving_cost_per_mana_numerator": 1254728663,
+            "fee_asset_price_numerator": 4448615753
+        },
+        "header": {
+            "excess_mana": 1322152232,
+            "mana_used": 107289899,
+            "proving_cost_per_mana_numerator": 1284412021,
+            "fee_asset_price_numerator": 3610717908
+        },
+        "oracle_input": {
+            "proving_cost_modifier": 29683358,
+            "fee_asset_price_modifier": -837897845
+        },
+        "outputs": {
+            "fee_asset_price_at_execution": 10454905044,
+            "mana_base_fee_components_in_wei": {
+                "data_cost": 4,
+                "gas_cost": 28081448,
+                "proving_cost": 5483734073,
+                "congestion_cost": 20377029395,
+                "congestion_multiplier": 4696972314
+            },
+            "mana_base_fee_components_in_fee_asset": {
+                "data_cost": 41,
+                "gas_cost": 293588872,
+                "proving_cost": 57331919019,
+                "congestion_cost": 213039907403,
+                "congestion_multiplier": 4696972314
+            }
+        }
+    },
+    {
+        "l1_block_number": 20974178,
+        "l1_fees": {
+            "blob_fee": 761,
+            "base_fee": 9568615682
+        },
+        "parent_header": {
+            "excess_mana": 1322152232,
+            "mana_used": 107289899,
+            "proving_cost_per_mana_numerator": 1284412021,
+            "fee_asset_price_numerator": 3610717908
+        },
+        "header": {
+            "excess_mana": 1329442131,
+            "mana_used": 88045123,
+            "proving_cost_per_mana_numerator": 1371214073,
+            "fee_asset_price_numerator": 3074238422
+        },
+        "oracle_input": {
+            "proving_cost_modifier": 86802052,
+            "fee_asset_price_modifier": -536479486
+        },
+        "outputs": {
+            "fee_asset_price_at_execution": 10367669602,
+            "mana_base_fee_components_in_wei": {
+                "data_cost": 2,
+                "gas_cost": 31696039,
+                "proving_cost": 5485362071,
+                "congestion_cost": 20618377034,
+                "congestion_multiplier": 4737204977
+            },
+            "mana_base_fee_components_in_fee_asset": {
+                "data_cost": 20,
+                "gas_cost": 328614060,
+                "proving_cost": 56870421599,
+                "congestion_cost": 213764520817,
+                "congestion_multiplier": 4737204977
+            }
+        }
+    },
+    {
+        "l1_block_number": 20974181,
+        "l1_fees": {
+            "blob_fee": 761,
+            "base_fee": 9315023234
+        },
+        "parent_header": {
+            "excess_mana": 1329442131,
+            "mana_used": 88045123,
+            "proving_cost_per_mana_numerator": 1371214073,
+            "fee_asset_price_numerator": 3074238422
+        },
+        "header": {
+            "excess_mana": 1317487254,
+            "mana_used": 108329434,
+            "proving_cost_per_mana_numerator": 1403657471,
+            "fee_asset_price_numerator": 3193055101
+        },
+        "oracle_input": {
+            "proving_cost_modifier": 32443398,
+            "fee_asset_price_modifier": 118816679
+        },
+        "outputs": {
+            "fee_asset_price_at_execution": 10312198111,
+            "mana_base_fee_components_in_wei": {
+                "data_cost": 2,
+                "gas_cost": 30856014,
+                "proving_cost": 5490125545,
+                "congestion_cost": 20269764602,
+                "congestion_multiplier": 4671405959
+            },
+            "mana_base_fee_components_in_fee_asset": {
+                "data_cost": 20,
+                "gas_cost": 318193329,
+                "proving_cost": 56615262274,
+                "congestion_cost": 209025828239,
+                "congestion_multiplier": 4671405959
+            }
+        }
+    },
+    {
+        "l1_block_number": 20974184,
+        "l1_fees": {
+            "blob_fee": 703,
+            "base_fee": 9674041257
+        },
+        "parent_header": {
+            "excess_mana": 1317487254,
+            "mana_used": 108329434,
+            "proving_cost_per_mana_numerator": 1403657471,
+            "fee_asset_price_numerator": 3193055101
+        },
+        "header": {
+            "excess_mana": 1325816688,
+            "mana_used": 95514331,
+            "proving_cost_per_mana_numerator": 1448230411,
+            "fee_asset_price_numerator": 3108372249
+        },
+        "oracle_input": {
+            "proving_cost_modifier": 44572940,
+            "fee_asset_price_modifier": -84682852
+        },
+        "outputs": {
+            "fee_asset_price_at_execution": 10324458004,
+            "mana_base_fee_components_in_wei": {
+                "data_cost": 2,
+                "gas_cost": 32045261,
+                "proving_cost": 5491907017,
+                "congestion_cost": 20533378043,
+                "congestion_multiplier": 4717153408
+            },
+            "mana_base_fee_components_in_fee_asset": {
+                "data_cost": 20,
+                "gas_cost": 330849951,
+                "proving_cost": 56700963358,
+                "congestion_cost": 211995999285,
+                "congestion_multiplier": 4717153408
+            }
+        }
+    },
+    {
+        "l1_block_number": 20974187,
+        "l1_fees": {
+            "blob_fee": 625,
+            "base_fee": 10003788198
+        },
+        "parent_header": {
+            "excess_mana": 1325816688,
+            "mana_used": 95514331,
+            "proving_cost_per_mana_numerator": 1448230411,
+            "fee_asset_price_numerator": 3108372249
+        },
+        "header": {
+            "excess_mana": 1321331019,
+            "mana_used": 108247087,
+            "proving_cost_per_mana_numerator": 1370678469,
+            "fee_asset_price_numerator": 3067437500
+        },
+        "oracle_input": {
+            "proving_cost_modifier": -77551942,
+            "fee_asset_price_modifier": -40934749
+        },
+        "outputs": {
+            "fee_asset_price_at_execution": 10315718660,
+            "mana_base_fee_components_in_wei": {
+                "data_cost": 2,
+                "gas_cost": 33137548,
+                "proving_cost": 5494355468,
+                "congestion_cost": 20410055381,
+                "congestion_multiplier": 4692461540
+            },
+            "mana_base_fee_components_in_fee_asset": {
+                "data_cost": 20,
+                "gas_cost": 341837622,
+                "proving_cost": 56678225225,
+                "congestion_cost": 210544389145,
+                "congestion_multiplier": 4692461540
+            }
+        }
+    },
+    {
+        "l1_block_number": 20974190,
+        "l1_fees": {
+            "blob_fee": 534,
+            "base_fee": 9982107079
+        },
+        "parent_header": {
+            "excess_mana": 1321331019,
+            "mana_used": 108247087,
+            "proving_cost_per_mana_numerator": 1370678469,
+            "fee_asset_price_numerator": 3067437500
+        },
+        "header": {
+            "excess_mana": 1329578106,
+            "mana_used": 94836752,
+            "proving_cost_per_mana_numerator": 1315359805,
+            "fee_asset_price_numerator": 2072392464
+        },
+        "oracle_input": {
+            "proving_cost_modifier": -55318664,
+            "fee_asset_price_modifier": -995045036
+        },
+        "outputs": {
+            "fee_asset_price_at_execution": 10311496810,
+            "mana_base_fee_components_in_wei": {
+                "data_cost": 2,
+                "gas_cost": 33065729,
+                "proving_cost": 5490096140,
+                "congestion_cost": 20645350867,
+                "congestion_multiplier": 4737958682
+            },
+            "mana_base_fee_components_in_fee_asset": {
+                "data_cost": 20,
+                "gas_cost": 340957159,
+                "proving_cost": 56611108834,
+                "congestion_cost": 212884469606,
+                "congestion_multiplier": 4737958682
+            }
+        }
+    },
+    {
+        "l1_block_number": 20974193,
+        "l1_fees": {
+            "blob_fee": 439,
+            "base_fee": 9835913437
+        },
+        "parent_header": {
+            "excess_mana": 1329578106,
+            "mana_used": 94836752,
+            "proving_cost_per_mana_numerator": 1315359805,
+            "fee_asset_price_numerator": 2072392464
+        },
+        "header": {
+            "excess_mana": 1324414858,
+            "mana_used": 99286901,
+            "proving_cost_per_mana_numerator": 1200670532,
+            "fee_asset_price_numerator": 2044356545
+        },
+        "oracle_input": {
+            "proving_cost_modifier": -114689273,
+            "fee_asset_price_modifier": -28035919
+        },
+        "outputs": {
+            "fee_asset_price_at_execution": 10209401563,
+            "mana_base_fee_components_in_wei": {
+                "data_cost": 1,
+                "gas_cost": 32581463,
+                "proving_cost": 5487059932,
+                "congestion_cost": 20474684481,
+                "congestion_multiplier": 4709422952
+            },
+            "mana_base_fee_components_in_fee_asset": {
+                "data_cost": 10,
+                "gas_cost": 332637239,
+                "proving_cost": 56019598246,
+                "congestion_cost": 209034275742,
+                "congestion_multiplier": 4709422952
+            }
+        }
+    },
+    {
+        "l1_block_number": 20974196,
+        "l1_fees": {
+            "blob_fee": 556,
+            "base_fee": 10115073494
+        },
+        "parent_header": {
+            "excess_mana": 1324414858,
+            "mana_used": 99286901,
+            "proving_cost_per_mana_numerator": 1200670532,
+            "fee_asset_price_numerator": 2044356545
+        },
+        "header": {
+            "excess_mana": 1323701759,
+            "mana_used": 96289879,
+            "proving_cost_per_mana_numerator": 1147361388,
+            "fee_asset_price_numerator": 1998932862
+        },
+        "oracle_input": {
+            "proving_cost_modifier": -53309144,
+            "fee_asset_price_modifier": -45423683
+        },
+        "outputs": {
+            "fee_asset_price_at_execution": 10206539664,
+            "mana_base_fee_components_in_wei": {
+                "data_cost": 2,
+                "gas_cost": 33506180,
+                "proving_cost": 5480770470,
+                "congestion_cost": 20433126751,
+                "congestion_multiplier": 4705495397
+            },
+            "mana_base_fee_components_in_fee_asset": {
+                "data_cost": 20,
+                "gas_cost": 341982155,
+                "proving_cost": 55939701191,
+                "congestion_cost": 208551518643,
+                "congestion_multiplier": 4705495397
+            }
+        }
+    },
+    {
+        "l1_block_number": 20974199,
+        "l1_fees": {
+            "blob_fee": 475,
+            "base_fee": 10075372811
+        },
+        "parent_header": {
+            "excess_mana": 1323701759,
+            "mana_used": 96289879,
+            "proving_cost_per_mana_numerator": 1147361388,
+            "fee_asset_price_numerator": 1998932862
+        },
+        "header": {
+            "excess_mana": 1319991638,
+            "mana_used": 89782724,
+            "proving_cost_per_mana_numerator": 1200037686,
+            "fee_asset_price_numerator": 1805396846
+        },
+        "oracle_input": {
+            "proving_cost_modifier": 52676298,
+            "fee_asset_price_modifier": -193536016
+        },
+        "outputs": {
+            "fee_asset_price_at_execution": 10201904531,
+            "mana_base_fee_components_in_wei": {
+                "data_cost": 1,
+                "gas_cost": 33374672,
+                "proving_cost": 5477849497,
+                "congestion_cost": 20309488552,
+                "congestion_multiplier": 4685113856
+            },
+            "mana_base_fee_components_in_fee_asset": {
+                "data_cost": 10,
+                "gas_cost": 340485217,
+                "proving_cost": 55884497603,
+                "congestion_cost": 207195463280,
+                "congestion_multiplier": 4685113856
+            }
+        }
+    },
+    {
+        "l1_block_number": 20974202,
+        "l1_fees": {
+            "blob_fee": 439,
+            "base_fee": 9814380947
+        },
+        "parent_header": {
+            "excess_mana": 1319991638,
+            "mana_used": 89782724,
+            "proving_cost_per_mana_numerator": 1200037686,
+            "fee_asset_price_numerator": 1805396846
+        },
+        "header": {
+            "excess_mana": 1309774362,
+            "mana_used": 103450185,
+            "proving_cost_per_mana_numerator": 1346901685,
+            "fee_asset_price_numerator": 2325955733
+        },
+        "oracle_input": {
+            "proving_cost_modifier": 146863999,
+            "fee_asset_price_modifier": 520558887
+        },
+        "outputs": {
+            "fee_asset_price_at_execution": 10182179265,
+            "mana_base_fee_components_in_wei": {
+                "data_cost": 1,
+                "gas_cost": 32510136,
+                "proving_cost": 5480735786,
+                "congestion_cost": 20009997686,
+                "congestion_multiplier": 4629440436
+            },
+            "mana_base_fee_components_in_fee_asset": {
+                "data_cost": 10,
+                "gas_cost": 331024032,
+                "proving_cost": 55805834277,
+                "congestion_cost": 203745383531,
+                "congestion_multiplier": 4629440436
+            }
+        }
+    },
+    {
+        "l1_block_number": 20974205,
+        "l1_fees": {
+            "blob_fee": 333,
+            "base_fee": 9109952895
+        },
+        "parent_header": {
+            "excess_mana": 1309774362,
+            "mana_used": 103450185,
+            "proving_cost_per_mana_numerator": 1346901685,
+            "fee_asset_price_numerator": 2325955733
+        },
+        "header": {
+            "excess_mana": 1313224547,
+            "mana_used": 98620120,
+            "proving_cost_per_mana_numerator": 1479876845,
+            "fee_asset_price_numerator": 2117602111
+        },
+        "oracle_input": {
+            "proving_cost_modifier": 132975160,
+            "fee_asset_price_modifier": -208353622
+        },
+        "outputs": {
+            "fee_asset_price_at_execution": 10235321703,
+            "mana_base_fee_components_in_wei": {
+                "data_cost": 1,
+                "gas_cost": 30176718,
+                "proving_cost": 5488790927,
+                "congestion_cost": 20134109812,
+                "congestion_multiplier": 4648165944
+            },
+            "mana_base_fee_components_in_fee_asset": {
+                "data_cost": 10,
+                "gas_cost": 308868416,
+                "proving_cost": 56179540898,
+                "congestion_cost": 206079091129,
+                "congestion_multiplier": 4648165944
+            }
+        }
+    },
+    {
+        "l1_block_number": 20974208,
+        "l1_fees": {
+            "blob_fee": 347,
+            "base_fee": 9950819786
+        },
+        "parent_header": {
+            "excess_mana": 1313224547,
+            "mana_used": 98620120,
+            "proving_cost_per_mana_numerator": 1479876845,
+            "fee_asset_price_numerator": 2117602111
+        },
+        "header": {
+            "excess_mana": 1311844667,
+            "mana_used": 108251001,
+            "proving_cost_per_mana_numerator": 1268393069,
+            "fee_asset_price_numerator": 1217566793
+        },
+        "oracle_input": {
+            "proving_cost_modifier": -211483776,
+            "fee_asset_price_modifier": -900035318
+        },
+        "outputs": {
+            "fee_asset_price_at_execution": 10214018240,
+            "mana_base_fee_components_in_wei": {
+                "data_cost": 1,
+                "gas_cost": 32962090,
+                "proving_cost": 5496094510,
+                "congestion_cost": 20129457900,
+                "congestion_multiplier": 4640667722
+            },
+            "mana_base_fee_components_in_fee_asset": {
+                "data_cost": 10,
+                "gas_cost": 336675388,
+                "proving_cost": 56137209573,
+                "congestion_cost": 205602650151,
+                "congestion_multiplier": 4640667722
+            }
+        }
+    },
+    {
+        "l1_block_number": 20974211,
+        "l1_fees": {
+            "blob_fee": 263,
+            "base_fee": 9969692206
+        },
+        "parent_header": {
+            "excess_mana": 1311844667,
+            "mana_used": 108251001,
+            "proving_cost_per_mana_numerator": 1268393069,
+            "fee_asset_price_numerator": 1217566793
+        },
+        "header": {
+            "excess_mana": 1320095668,
+            "mana_used": 101607200,
+            "proving_cost_per_mana_numerator": 1217358203,
+            "fee_asset_price_numerator": 2217566793
+        },
+        "oracle_input": {
+            "proving_cost_modifier": -51034866,
+            "fee_asset_price_modifier": 1000000000
+        },
+        "outputs": {
+            "fee_asset_price_at_execution": 10122500931,
+            "mana_base_fee_components_in_wei": {
+                "data_cost": 1,
+                "gas_cost": 33024605,
+                "proving_cost": 5484483444,
+                "congestion_cost": 20335791912,
+                "congestion_multiplier": 4685684140
+            },
+            "mana_base_fee_components_in_fee_asset": {
+                "data_cost": 10,
+                "gas_cost": 334291594,
+                "proving_cost": 55516688767,
+                "congestion_cost": 205849072561,
+                "congestion_multiplier": 4685684140
+            }
+        }
+    },
+    {
+        "l1_block_number": 20974214,
+        "l1_fees": {
+            "blob_fee": 243,
+            "base_fee": 9652277053
+        },
+        "parent_header": {
+            "excess_mana": 1320095668,
+            "mana_used": 101607200,
+            "proving_cost_per_mana_numerator": 1217358203,
+            "fee_asset_price_numerator": 2217566793
+        },
+        "header": {
+            "excess_mana": 1321702868,
+            "mana_used": 99783600,
+            "proving_cost_per_mana_numerator": 1135291698,
+            "fee_asset_price_numerator": 2179707139
+        },
+        "oracle_input": {
+            "proving_cost_modifier": -82066505,
+            "fee_asset_price_modifier": -37859654
+        },
+        "outputs": {
+            "fee_asset_price_at_execution": 10224233756,
+            "mana_base_fee_components_in_wei": {
+                "data_cost": 0,
+                "gas_cost": 31973167,
+                "proving_cost": 5481685160,
+                "congestion_cost": 20370229997,
+                "congestion_multiplier": 4694503502
+            },
+            "mana_base_fee_components_in_fee_asset": {
+                "data_cost": 0,
+                "gas_cost": 326901133,
+                "proving_cost": 56046030452,
+                "congestion_cost": 208269993152,
+                "congestion_multiplier": 4694503502
+            }
+        }
+    },
+    {
+        "l1_block_number": 20974217,
+        "l1_fees": {
+            "blob_fee": 225,
+            "base_fee": 9865412617
+        },
+        "parent_header": {
+            "excess_mana": 1321702868,
+            "mana_used": 99783600,
+            "proving_cost_per_mana_numerator": 1135291698,
+            "fee_asset_price_numerator": 2179707139
+        },
+        "header": {
+            "excess_mana": 1321486468,
+            "mana_used": 98596813,
+            "proving_cost_per_mana_numerator": 1094238523,
+            "fee_asset_price_numerator": 1388857516
+        },
+        "oracle_input": {
+            "proving_cost_modifier": -41053175,
+            "fee_asset_price_modifier": -790849623
+        },
+        "outputs": {
+            "fee_asset_price_at_execution": 10220363630,
+            "mana_base_fee_components_in_wei": {
+                "data_cost": 0,
+                "gas_cost": 32679179,
+                "proving_cost": 5477188378,
+                "congestion_cost": 20349676832,
+                "congestion_multiplier": 4693315061
+            },
+            "mana_base_fee_components_in_fee_asset": {
+                "data_cost": 0,
+                "gas_cost": 333993092,
+                "proving_cost": 55978856893,
+                "congestion_cost": 207981096976,
+                "congestion_multiplier": 4693315061
+            }
+        }
+    },
+    {
+        "l1_block_number": 20974220,
+        "l1_fees": {
+            "blob_fee": 253,
+            "base_fee": 9818833574
+        },
+        "parent_header": {
+            "excess_mana": 1321486468,
+            "mana_used": 98596813,
+            "proving_cost_per_mana_numerator": 1094238523,
+            "fee_asset_price_numerator": 1388857516
+        },
+        "header": {
+            "excess_mana": 1320083281,
+            "mana_used": 92508710,
+            "proving_cost_per_mana_numerator": 978809119,
+            "fee_asset_price_numerator": 1109991750
+        },
+        "oracle_input": {
+            "proving_cost_modifier": -115429404,
+            "fee_asset_price_modifier": -278865766
+        },
+        "outputs": {
+            "fee_asset_price_at_execution": 10139854694,
+            "mana_base_fee_components_in_wei": {
+                "data_cost": 0,
+                "gas_cost": 32524886,
+                "proving_cost": 5474940279,
+                "congestion_cost": 20298403009,
+                "congestion_multiplier": 4685616232
+            },
+            "mana_base_fee_components_in_fee_asset": {
+                "data_cost": 0,
+                "gas_cost": 329797617,
+                "proving_cost": 55515098887,
+                "congestion_cost": 205822857031,
+                "congestion_multiplier": 4685616232
+            }
+        }
+    },
+    {
+        "l1_block_number": 20974223,
+        "l1_fees": {
+            "blob_fee": 192,
+            "base_fee": 9384598617
+        },
+        "parent_header": {
+            "excess_mana": 1320083281,
+            "mana_used": 92508710,
+            "proving_cost_per_mana_numerator": 978809119,
+            "fee_asset_price_numerator": 1109991750
+        },
+        "header": {
+            "excess_mana": 1312591991,
+            "mana_used": 106413231,
+            "proving_cost_per_mana_numerator": 816457518,
+            "fee_asset_price_numerator": 1325809432
+        },
+        "oracle_input": {
+            "proving_cost_modifier": -162351601,
+            "fee_asset_price_modifier": 215817682
+        },
+        "outputs": {
+            "fee_asset_price_at_execution": 10111617501,
+            "mana_base_fee_components_in_wei": {
+                "data_cost": 0,
+                "gas_cost": 31086482,
+                "proving_cost": 5468624234,
+                "congestion_cost": 20044944980,
+                "congestion_multiplier": 4644727153
+            },
+            "mana_base_fee_components_in_fee_asset": {
+                "data_cost": 0,
+                "gas_cost": 314334615,
+                "proving_cost": 55296636510,
+                "congestion_cost": 202686816466,
+                "congestion_multiplier": 4644727153
+            }
+        }
+    },
+    {
+        "l1_block_number": 20974226,
+        "l1_fees": {
+            "blob_fee": 152,
+            "base_fee": 8938087949
+        },
+        "parent_header": {
+            "excess_mana": 1312591991,
+            "mana_used": 106413231,
+            "proving_cost_per_mana_numerator": 816457518,
+            "fee_asset_price_numerator": 1325809432
+        },
+        "header": {
+            "excess_mana": 1319005222,
+            "mana_used": 99107098,
+            "proving_cost_per_mana_numerator": 745722018,
+            "fee_asset_price_numerator": 1445651906
+        },
+        "oracle_input": {
+            "proving_cost_modifier": -70735500,
+            "fee_asset_price_modifier": 119842474
+        },
+        "outputs": {
+            "fee_asset_price_at_execution": 10133463725,
+            "mana_base_fee_components_in_wei": {
+                "data_cost": 0,
+                "gas_cost": 29607416,
+                "proving_cost": 5459753039,
+                "congestion_cost": 20199253758,
+                "congestion_multiplier": 4679709854
+            },
+            "mana_base_fee_components_in_fee_asset": {
+                "data_cost": 0,
+                "gas_cost": 300025676,
+                "proving_cost": 55326209368,
+                "congestion_cost": 204688405228,
+                "congestion_multiplier": 4679709854
+            }
+        }
+    },
+    {
+        "l1_block_number": 20974229,
+        "l1_fees": {
+            "blob_fee": 185,
+            "base_fee": 9200504098
+        },
+        "parent_header": {
+            "excess_mana": 1319005222,
+            "mana_used": 99107098,
+            "proving_cost_per_mana_numerator": 745722018,
+            "fee_asset_price_numerator": 1445651906
+        },
+        "header": {
+            "excess_mana": 1318112320,
+            "mana_used": 103217114,
+            "proving_cost_per_mana_numerator": 746372879,
+            "fee_asset_price_numerator": 1519902006
+        },
+        "oracle_input": {
+            "proving_cost_modifier": 650861,
+            "fee_asset_price_modifier": 74250100
+        },
+        "outputs": {
+            "fee_asset_price_at_execution": 10145615199,
+            "mana_base_fee_components_in_wei": {
+                "data_cost": 0,
+                "gas_cost": 30476669,
+                "proving_cost": 5455892420,
+                "congestion_cost": 20161438249,
+                "congestion_multiplier": 4674823535
+            },
+            "mana_base_fee_components_in_fee_asset": {
+                "data_cost": 0,
+                "gas_cost": 309204556,
+                "proving_cost": 55353385060,
+                "congestion_cost": 204550194332,
+                "congestion_multiplier": 4674823535
+            }
+        }
+    },
+    {
+        "l1_block_number": 20974232,
+        "l1_fees": {
+            "blob_fee": 140,
+            "base_fee": 9021763235
+        },
+        "parent_header": {
+            "excess_mana": 1318112320,
+            "mana_used": 103217114,
+            "proving_cost_per_mana_numerator": 746372879,
+            "fee_asset_price_numerator": 1519902006
+        },
+        "header": {
+            "excess_mana": 1321329434,
+            "mana_used": 84219796,
+            "proving_cost_per_mana_numerator": 788129718,
+            "fee_asset_price_numerator": 1463242432
+        },
+        "oracle_input": {
+            "proving_cost_modifier": 41756839,
+            "fee_asset_price_modifier": -56659574
+        },
+        "outputs": {
+            "fee_asset_price_at_execution": 10153151125,
+            "mana_base_fee_components_in_wei": {
+                "data_cost": 0,
+                "gas_cost": 29884590,
+                "proving_cost": 5455927931,
+                "congestion_cost": 20256104011,
+                "congestion_multiplier": 4692452838
+            },
+            "mana_base_fee_components_in_fee_asset": {
+                "data_cost": 0,
+                "gas_cost": 303422758,
+                "proving_cost": 55394860810,
+                "congestion_cost": 205663285227,
+                "congestion_multiplier": 4692452838
+            }
+        }
+    },
+    {
+        "l1_block_number": 20974235,
+        "l1_fees": {
+            "blob_fee": 140,
+            "base_fee": 9164923160
+        },
+        "parent_header": {
+            "excess_mana": 1321329434,
+            "mana_used": 84219796,
+            "proving_cost_per_mana_numerator": 788129718,
+            "fee_asset_price_numerator": 1463242432
+        },
+        "header": {
+            "excess_mana": 1305549230,
+            "mana_used": 98726224,
+            "proving_cost_per_mana_numerator": 891349908,
+            "fee_asset_price_numerator": 1143970606
+        },
+        "oracle_input": {
+            "proving_cost_modifier": 103220190,
+            "fee_asset_price_modifier": -319271826
+        },
+        "outputs": {
+            "fee_asset_price_at_execution": 10147400023,
+            "mana_base_fee_components_in_wei": {
+                "data_cost": 0,
+                "gas_cost": 30358807,
+                "proving_cost": 5458206630,
+                "congestion_cost": 19795124387,
+                "congestion_multiplier": 4606611712
+            },
+            "mana_base_fee_components_in_fee_asset": {
+                "data_cost": 0,
+                "gas_cost": 308062958,
+                "proving_cost": 55386606082,
+                "congestion_cost": 200869045659,
+                "congestion_multiplier": 4606611712
+            }
+        }
+    },
+    {
+        "l1_block_number": 20974238,
+        "l1_fees": {
+            "blob_fee": 106,
+            "base_fee": 8939418809
+        },
+        "parent_header": {
+            "excess_mana": 1305549230,
+            "mana_used": 98726224,
+            "proving_cost_per_mana_numerator": 891349908,
+            "fee_asset_price_numerator": 1143970606
+        },
+        "header": {
+            "excess_mana": 1304275454,
+            "mana_used": 114376447,
+            "proving_cost_per_mana_numerator": 917752670,
+            "fee_asset_price_numerator": 1702129583
+        },
+        "oracle_input": {
+            "proving_cost_modifier": 26402762,
+            "fee_asset_price_modifier": 558158977
+        },
+        "outputs": {
+            "fee_asset_price_at_execution": 10115053897,
+            "mana_base_fee_components_in_wei": {
+                "data_cost": 0,
+                "gas_cost": 29611824,
+                "proving_cost": 5463843510,
+                "congestion_cost": 19775074128,
+                "congestion_multiplier": 4599751509
+            },
+            "mana_base_fee_components_in_fee_asset": {
+                "data_cost": 0,
+                "gas_cost": 299525195,
+                "proving_cost": 55267071588,
+                "congestion_cost": 200025940621,
+                "congestion_multiplier": 4599751509
+            }
+        }
+    },
+    {
+        "l1_block_number": 20974241,
+        "l1_fees": {
+            "blob_fee": 120,
+            "base_fee": 8940268760
+        },
+        "parent_header": {
+            "excess_mana": 1304275454,
+            "mana_used": 114376447,
+            "proving_cost_per_mana_numerator": 917752670,
+            "fee_asset_price_numerator": 1702129583
+        },
+        "header": {
+            "excess_mana": 1318651901,
+            "mana_used": 97571146,
+            "proving_cost_per_mana_numerator": 1019116089,
+            "fee_asset_price_numerator": 1481195032
+        },
+        "oracle_input": {
+            "proving_cost_modifier": 101363419,
+            "fee_asset_price_modifier": -220934551
+        },
+        "outputs": {
+            "fee_asset_price_at_execution": 10171669835,
+            "mana_base_fee_components_in_wei": {
+                "data_cost": 0,
+                "gas_cost": 29614640,
+                "proving_cost": 5465286306,
+                "congestion_cost": 20209013332,
+                "congestion_multiplier": 4677775729
+            },
+            "mana_base_fee_components_in_fee_asset": {
+                "data_cost": 0,
+                "gas_cost": 301230340,
+                "proving_cost": 55591087858,
+                "congestion_cost": 205559411304,
+                "congestion_multiplier": 4677775729
+            }
+        }
+    },
+    {
+        "l1_block_number": 20974244,
+        "l1_fees": {
+            "blob_fee": 106,
+            "base_fee": 9460271090
+        },
+        "parent_header": {
+            "excess_mana": 1318651901,
+            "mana_used": 97571146,
+            "proving_cost_per_mana_numerator": 1019116089,
+            "fee_asset_price_numerator": 1481195032
+        },
+        "header": {
+            "excess_mana": 1316223047,
+            "mana_used": 32027503,
+            "proving_cost_per_mana_numerator": 1187087490,
+            "fee_asset_price_numerator": 1394617026
+        },
+        "oracle_input": {
+            "proving_cost_modifier": 167971401,
+            "fee_asset_price_modifier": -86578006
+        },
+        "outputs": {
+            "fee_asset_price_at_execution": 10149221908,
+            "mana_base_fee_components_in_wei": {
+                "data_cost": 0,
+                "gas_cost": 31337147,
+                "proving_cost": 5470828915,
+                "congestion_cost": 20162695715,
+                "congestion_multiplier": 4664501487
+            },
+            "mana_base_fee_components_in_fee_asset": {
+                "data_cost": 0,
+                "gas_cost": 318047658,
+                "proving_cost": 55524656679,
+                "congestion_cost": 204635673075,
+                "congestion_multiplier": 4664501487
+            }
+        }
+    },
+    {
+        "l1_block_number": 20974247,
+        "l1_fees": {
+            "blob_fee": 102,
+            "base_fee": 9031372745
+        },
+        "parent_header": {
+            "excess_mana": 1316223047,
+            "mana_used": 32027503,
+            "proving_cost_per_mana_numerator": 1187087490,
+            "fee_asset_price_numerator": 1394617026
+        },
+        "header": {
+            "excess_mana": 1248250550,
+            "mana_used": 145636650,
+            "proving_cost_per_mana_numerator": 1106794821,
+            "fee_asset_price_numerator": 394617026
+        },
+        "oracle_input": {
+            "proving_cost_modifier": -80292669,
+            "fee_asset_price_modifier": -1000000000
+        },
+        "outputs": {
+            "fee_asset_price_at_execution": 10140438717,
+            "mana_base_fee_components_in_wei": {
+                "data_cost": 0,
+                "gas_cost": 29916422,
+                "proving_cost": 5480026065,
+                "congestion_cost": 18226400425,
+                "congestion_multiplier": 4307911193
+            },
+            "mana_base_fee_components_in_fee_asset": {
+                "data_cost": 0,
+                "gas_cost": 303365643,
+                "proving_cost": 55569868479,
+                "congestion_cost": 184823696541,
+                "congestion_multiplier": 4307911193
+            }
+        }
+    },
+    {
+        "l1_block_number": 20974250,
+        "l1_fees": {
+            "blob_fee": 95,
+            "base_fee": 9218102281
+        },
+        "parent_header": {
+            "excess_mana": 1248250550,
+            "mana_used": 145636650,
+            "proving_cost_per_mana_numerator": 1106794821,
+            "fee_asset_price_numerator": 394617026
+        },
+        "header": {
+            "excess_mana": 1293887200,
+            "mana_used": 111223594,
+            "proving_cost_per_mana_numerator": 1143972617,
+            "fee_asset_price_numerator": 893140627
+        },
+        "oracle_input": {
+            "proving_cost_modifier": 37177796,
+            "fee_asset_price_modifier": 498523601
+        },
+        "outputs": {
+            "fee_asset_price_at_execution": 10039539666,
+            "mana_base_fee_components_in_wei": {
+                "data_cost": 0,
+                "gas_cost": 30534963,
+                "proving_cost": 5475627772,
+                "congestion_cost": 19514850155,
+                "congestion_multiplier": 4544183326
+            },
+            "mana_base_fee_components_in_fee_asset": {
+                "data_cost": 0,
+                "gas_cost": 306556972,
+                "proving_cost": 54972782213,
+                "congestion_cost": 195920112207,
+                "congestion_multiplier": 4544183326
+            }
+        }
+    },
+    {
+        "l1_block_number": 20974253,
+        "l1_fees": {
+            "blob_fee": 84,
+            "base_fee": 8858491309
+        },
+        "parent_header": {
+            "excess_mana": 1293887200,
+            "mana_used": 111223594,
+            "proving_cost_per_mana_numerator": 1143972617,
+            "fee_asset_price_numerator": 893140627
+        },
+        "header": {
+            "excess_mana": 1305110794,
+            "mana_used": 92953174,
+            "proving_cost_per_mana_numerator": 1132317302,
+            "fee_asset_price_numerator": 1632530897
+        },
+        "oracle_input": {
+            "proving_cost_modifier": -11655315,
+            "fee_asset_price_modifier": 739390270
+        },
+        "outputs": {
+            "fee_asset_price_at_execution": 10089714102,
+            "mana_base_fee_components_in_wei": {
+                "data_cost": 0,
+                "gas_cost": 29343752,
+                "proving_cost": 5477663868,
+                "congestion_cost": 19848628161,
+                "congestion_multiplier": 4604249264
+            },
+            "mana_base_fee_components_in_fee_asset": {
+                "data_cost": 0,
+                "gas_cost": 296070068,
+                "proving_cost": 55268062374,
+                "congestion_cost": 200266983461,
+                "congestion_multiplier": 4604249264
+            }
+        }
+    },
+    {
+        "l1_block_number": 20974256,
+        "l1_fees": {
+            "blob_fee": 95,
+            "base_fee": 9136766129
+        },
+        "parent_header": {
+            "excess_mana": 1305110794,
+            "mana_used": 92953174,
+            "proving_cost_per_mana_numerator": 1132317302,
+            "fee_asset_price_numerator": 1632530897
+        },
+        "header": {
+            "excess_mana": 1298063968,
+            "mana_used": 107189994,
+            "proving_cost_per_mana_numerator": 1165670304,
+            "fee_asset_price_numerator": 2616929052
+        },
+        "oracle_input": {
+            "proving_cost_modifier": 33353002,
+            "fee_asset_price_modifier": 984398155
+        },
+        "outputs": {
+            "fee_asset_price_at_execution": 10164592949,
+            "mana_base_fee_components_in_wei": {
+                "data_cost": 0,
+                "gas_cost": 30265537,
+                "proving_cost": 5477025467,
+                "congestion_cost": 19641446460,
+                "congestion_multiplier": 4566444273
+            },
+            "mana_base_fee_components_in_fee_asset": {
+                "data_cost": 0,
+                "gas_cost": 307636863,
+                "proving_cost": 55671734443,
+                "congestion_cost": 199647308195,
+                "congestion_multiplier": 4566444273
+            }
+        }
+    },
+    {
+        "l1_block_number": 20974259,
+        "l1_fees": {
+            "blob_fee": 66,
+            "base_fee": 8691734272
+        },
+        "parent_header": {
+            "excess_mana": 1298063968,
+            "mana_used": 107189994,
+            "proving_cost_per_mana_numerator": 1165670304,
+            "fee_asset_price_numerator": 2616929052
+        },
+        "header": {
+            "excess_mana": 1305253962,
+            "mana_used": 112260026,
+            "proving_cost_per_mana_numerator": 1055123064,
+            "fee_asset_price_numerator": 1699841887
+        },
+        "oracle_input": {
+            "proving_cost_modifier": -110547240,
+            "fee_asset_price_modifier": -917087165
+        },
+        "outputs": {
+            "fee_asset_price_at_execution": 10265147129,
+            "mana_base_fee_components_in_wei": {
+                "data_cost": 0,
+                "gas_cost": 28791369,
+                "proving_cost": 5478852524,
+                "congestion_cost": 19855169526,
+                "congestion_multiplier": 4605020570
+            },
+            "mana_base_fee_components_in_fee_asset": {
+                "data_cost": 0,
+                "gas_cost": 295547638,
+                "proving_cost": 56241227256,
+                "congestion_cost": 203816236455,
+                "congestion_multiplier": 4605020570
+            }
+        }
+    },
+    {
+        "l1_block_number": 20974262,
+        "l1_fees": {
+            "blob_fee": 69,
+            "base_fee": 8321749796
+        },
+        "parent_header": {
+            "excess_mana": 1305253962,
+            "mana_used": 112260026,
+            "proving_cost_per_mana_numerator": 1055123064,
+            "fee_asset_price_numerator": 1699841887
+        },
+        "header": {
+            "excess_mana": 1317513988,
+            "mana_used": 109487908,
+            "proving_cost_per_mana_numerator": 1052148096,
+            "fee_asset_price_numerator": 1967593911
+        },
+        "oracle_input": {
+            "proving_cost_modifier": -2974968,
+            "fee_asset_price_modifier": 267752024
+        },
+        "outputs": {
+            "fee_asset_price_at_execution": 10171437140,
+            "mana_base_fee_components_in_wei": {
+                "data_cost": 0,
+                "gas_cost": 27565796,
+                "proving_cost": 5472799150,
+                "congestion_cost": 20194876347,
+                "congestion_multiplier": 4671552078
+            },
+            "mana_base_fee_components_in_fee_asset": {
+                "data_cost": 0,
+                "gas_cost": 280383761,
+                "proving_cost": 55666232534,
+                "congestion_cost": 205410915313,
+                "congestion_multiplier": 4671552078
+            }
+        }
+    },
+    {
+        "l1_block_number": 20974265,
+        "l1_fees": {
+            "blob_fee": 57,
+            "base_fee": 9442998411
+        },
+        "parent_header": {
+            "excess_mana": 1317513988,
+            "mana_used": 109487908,
+            "proving_cost_per_mana_numerator": 1052148096,
+            "fee_asset_price_numerator": 1967593911
+        },
+        "header": {
+            "excess_mana": 1327001896,
+            "mana_used": 114634510,
+            "proving_cost_per_mana_numerator": 960116821,
+            "fee_asset_price_numerator": 2366369325
+        },
+        "oracle_input": {
+            "proving_cost_modifier": -92031275,
+            "fee_asset_price_modifier": 398775414
+        },
+        "outputs": {
+            "fee_asset_price_at_execution": 10198707862,
+            "mana_base_fee_components_in_wei": {
+                "data_cost": 0,
+                "gas_cost": 31279932,
+                "proving_cost": 5472636338,
+                "congestion_cost": 20494928561,
+                "congestion_multiplier": 4723699191
+            },
+            "mana_base_fee_components_in_fee_asset": {
+                "data_cost": 0,
+                "gas_cost": 319014888,
+                "proving_cost": 55813819246,
+                "congestion_cost": 209021789046,
+                "congestion_multiplier": 4723699191
+            }
+        }
+    },
+    {
+        "l1_block_number": 20974268,
+        "l1_fees": {
+            "blob_fee": 64,
+            "base_fee": 9012000240
+        },
+        "parent_header": {
+            "excess_mana": 1327001896,
+            "mana_used": 114634510,
+            "proving_cost_per_mana_numerator": 960116821,
+            "fee_asset_price_numerator": 2366369325
+        },
+        "header": {
+            "excess_mana": 1341636406,
+            "mana_used": 89366688,
+            "proving_cost_per_mana_numerator": 925777547,
+            "fee_asset_price_numerator": 2157703337
+        },
+        "oracle_input": {
+            "proving_cost_modifier": -34339274,
+            "fee_asset_price_modifier": -208665988
+        },
+        "outputs": {
+            "fee_asset_price_at_execution": 10239459000,
+            "mana_base_fee_components_in_wei": {
+                "data_cost": 0,
+                "gas_cost": 29852250,
+                "proving_cost": 5467602118,
+                "congestion_cost": 20919334213,
+                "congestion_multiplier": 4805276554
+            },
+            "mana_base_fee_components_in_fee_asset": {
+                "data_cost": 0,
+                "gas_cost": 305670889,
+                "proving_cost": 55985287715,
+                "congestion_cost": 214202664981,
+                "congestion_multiplier": 4805276554
+            }
+        }
+    },
+    {
+        "l1_block_number": 20974271,
+        "l1_fees": {
+            "blob_fee": 59,
+            "base_fee": 9481407782
+        },
+        "parent_header": {
+            "excess_mana": 1341636406,
+            "mana_used": 89366688,
+            "proving_cost_per_mana_numerator": 925777547,
+            "fee_asset_price_numerator": 2157703337
+        },
+        "header": {
+            "excess_mana": 1331003094,
+            "mana_used": 89635246,
+            "proving_cost_per_mana_numerator": 923560611,
+            "fee_asset_price_numerator": 1942813050
+        },
+        "oracle_input": {
+            "proving_cost_modifier": -2216936,
+            "fee_asset_price_modifier": -214890287
+        },
+        "outputs": {
+            "fee_asset_price_at_execution": 10218115008,
+            "mana_base_fee_components_in_wei": {
+                "data_cost": 0,
+                "gas_cost": 31407163,
+                "proving_cost": 5465724906,
+                "congestion_cost": 20591512231,
+                "congestion_multiplier": 4745864566
+            },
+            "mana_base_fee_components_in_fee_asset": {
+                "data_cost": 0,
+                "gas_cost": 320922003,
+                "proving_cost": 55849405691,
+                "congestion_cost": 210406440164,
+                "congestion_multiplier": 4745864566
+            }
+        }
+    },
+    {
+        "l1_block_number": 20974274,
+        "l1_fees": {
+            "blob_fee": 54,
+            "base_fee": 9203478287
+        },
+        "parent_header": {
+            "excess_mana": 1331003094,
+            "mana_used": 89635246,
+            "proving_cost_per_mana_numerator": 923560611,
+            "fee_asset_price_numerator": 1942813050
+        },
+        "header": {
+            "excess_mana": 1320638340,
+            "mana_used": 91836527,
+            "proving_cost_per_mana_numerator": 1042882656,
+            "fee_asset_price_numerator": 2648789941
+        },
+        "oracle_input": {
+            "proving_cost_modifier": 119322045,
+            "fee_asset_price_modifier": 705976891
+        },
+        "outputs": {
+            "fee_asset_price_at_execution": 10196180847,
+            "mana_base_fee_components_in_wei": {
+                "data_cost": 0,
+                "gas_cost": 30486521,
+                "proving_cost": 5465603735,
+                "congestion_cost": 20273209097,
+                "congestion_multiplier": 4688660148
+            },
+            "mana_base_fee_components_in_fee_asset": {
+                "data_cost": 0,
+                "gas_cost": 310846081,
+                "proving_cost": 55728284120,
+                "congestion_cost": 206709306302,
+                "congestion_multiplier": 4688660148
+            }
+        }
+    },
+    {
+        "l1_block_number": 20974277,
+        "l1_fees": {
+            "blob_fee": 43,
+            "base_fee": 9064503000
+        },
+        "parent_header": {
+            "excess_mana": 1320638340,
+            "mana_used": 91836527,
+            "proving_cost_per_mana_numerator": 1042882656,
+            "fee_asset_price_numerator": 2648789941
+        },
+        "header": {
+            "excess_mana": 1312474867,
+            "mana_used": 111243703,
+            "proving_cost_per_mana_numerator": 1078349352,
+            "fee_asset_price_numerator": 3011021132
+        },
+        "oracle_input": {
+            "proving_cost_modifier": 35466696,
+            "fee_asset_price_modifier": 362231191
+        },
+        "outputs": {
+            "fee_asset_price_at_execution": 10268418217,
+            "mana_base_fee_components_in_wei": {
+                "data_cost": 0,
+                "gas_cost": 30026166,
+                "proving_cost": 5472129298,
+                "congestion_cost": 20050353589,
+                "congestion_multiplier": 4644090706
+            },
+            "mana_base_fee_components_in_fee_asset": {
+                "data_cost": 0,
+                "gas_cost": 308321229,
+                "proving_cost": 56190112169,
+                "congestion_cost": 205885416050,
+                "congestion_multiplier": 4644090706
+            }
+        }
+    },
+    {
+        "l1_block_number": 20974280,
+        "l1_fees": {
+            "blob_fee": 50,
+            "base_fee": 9027090063
+        },
+        "parent_header": {
+            "excess_mana": 1312474867,
+            "mana_used": 111243703,
+            "proving_cost_per_mana_numerator": 1078349352,
+            "fee_asset_price_numerator": 3011021132
+        },
+        "header": {
+            "excess_mana": 1323718570,
+            "mana_used": 114041429,
+            "proving_cost_per_mana_numerator": 1072397891,
+            "fee_asset_price_numerator": 3131769371
+        },
+        "oracle_input": {
+            "proving_cost_modifier": -5951461,
+            "fee_asset_price_modifier": 120748239
+        },
+        "outputs": {
+            "fee_asset_price_at_execution": 10305681079,
+            "mana_base_fee_components_in_wei": {
+                "data_cost": 0,
+                "gas_cost": 29902235,
+                "proving_cost": 5474070426,
+                "congestion_cost": 20395454769,
+                "congestion_multiplier": 4705587950
+            },
+            "mana_base_fee_components_in_fee_asset": {
+                "data_cost": 0,
+                "gas_cost": 308162897,
+                "proving_cost": 56414024014,
+                "congestion_cost": 210189052310,
+                "congestion_multiplier": 4705587950
+            }
+        }
+    },
+    {
+        "l1_block_number": 20974283,
+        "l1_fees": {
+            "blob_fee": 38,
+            "base_fee": 9084972090
+        },
+        "parent_header": {
+            "excess_mana": 1323718570,
+            "mana_used": 114041429,
+            "proving_cost_per_mana_numerator": 1072397891,
+            "fee_asset_price_numerator": 3131769371
+        },
+        "header": {
+            "excess_mana": 1337759999,
+            "mana_used": 78419505,
+            "proving_cost_per_mana_numerator": 936551251,
+            "fee_asset_price_numerator": 2673481901
+        },
+        "oracle_input": {
+            "proving_cost_modifier": -135846640,
+            "fee_asset_price_modifier": -458287470
+        },
+        "outputs": {
+            "fee_asset_price_at_execution": 10318132524,
+            "mana_base_fee_components_in_wei": {
+                "data_cost": 0,
+                "gas_cost": 30093970,
+                "proving_cost": 5473744648,
+                "congestion_cost": 20823949908,
+                "congestion_multiplier": 4783532068
+            },
+            "mana_base_fee_components_in_fee_asset": {
+                "data_cost": 0,
+                "gas_cost": 310513570,
+                "proving_cost": 56478822680,
+                "congestion_cost": 214864274823,
+                "congestion_multiplier": 4783532068
+            }
+        }
+    },
+    {
+        "l1_block_number": 20974286,
+        "l1_fees": {
+            "blob_fee": 35,
+            "base_fee": 8666650959
+        },
+        "parent_header": {
+            "excess_mana": 1337759999,
+            "mana_used": 78419505,
+            "proving_cost_per_mana_numerator": 936551251,
+            "fee_asset_price_numerator": 2673481901
+        },
+        "header": {
+            "excess_mana": 1316179504,
+            "mana_used": 103490229,
+            "proving_cost_per_mana_numerator": 998373423,
+            "fee_asset_price_numerator": 2663921959
+        },
+        "oracle_input": {
+            "proving_cost_modifier": 61822172,
+            "fee_asset_price_modifier": -9559942
+        },
+        "outputs": {
+            "fee_asset_price_at_execution": 10270954004,
+            "mana_base_fee_components_in_wei": {
+                "data_cost": 0,
+                "gas_cost": 28708281,
+                "proving_cost": 5466313799,
+                "congestion_cost": 20135210806,
+                "congestion_multiplier": 4664263858
+            },
+            "mana_base_fee_components_in_fee_asset": {
+                "data_cost": 0,
+                "gas_cost": 294861433,
+                "proving_cost": 56144257600,
+                "congestion_cost": 206807824049,
+                "congestion_multiplier": 4664263858
+            }
+        }
+    },
+    {
+        "l1_block_number": 20974289,
+        "l1_fees": {
+            "blob_fee": 38,
+            "base_fee": 8614468929
+        },
+        "parent_header": {
+            "excess_mana": 1316179504,
+            "mana_used": 103490229,
+            "proving_cost_per_mana_numerator": 998373423,
+            "fee_asset_price_numerator": 2663921959
+        },
+        "header": {
+            "excess_mana": 1319669733,
+            "mana_used": 98929763,
+            "proving_cost_per_mana_numerator": 1036853456,
+            "fee_asset_price_numerator": 2157225896
+        },
+        "oracle_input": {
+            "proving_cost_modifier": 38480033,
+            "fee_asset_price_modifier": -506696063
+        },
+        "outputs": {
+            "fee_asset_price_at_execution": 10269972154,
+            "mana_base_fee_components_in_wei": {
+                "data_cost": 0,
+                "gas_cost": 28535428,
+                "proving_cost": 5469694237,
+                "congestion_cost": 20251902251,
+                "congestion_multiplier": 4683349639
+            },
+            "mana_base_fee_components_in_fee_asset": {
+                "data_cost": 0,
+                "gas_cost": 293058050,
+                "proving_cost": 56173607504,
+                "congestion_cost": 207986472183,
+                "congestion_multiplier": 4683349639
+            }
+        }
+    },
+    {
+        "l1_block_number": 20974292,
+        "l1_fees": {
+            "blob_fee": 38,
+            "base_fee": 8495067114
+        },
+        "parent_header": {
+            "excess_mana": 1319669733,
+            "mana_used": 98929763,
+            "proving_cost_per_mana_numerator": 1036853456,
+            "fee_asset_price_numerator": 2157225896
+        },
+        "header": {
+            "excess_mana": 1318599496,
+            "mana_used": 98480109,
+            "proving_cost_per_mana_numerator": 1068580002,
+            "fee_asset_price_numerator": 2099518642
+        },
+        "oracle_input": {
+            "proving_cost_modifier": 31726546,
+            "fee_asset_price_modifier": -57707254
+        },
+        "outputs": {
+            "fee_asset_price_at_execution": 10218066223,
+            "mana_base_fee_components_in_wei": {
+                "data_cost": 0,
+                "gas_cost": 28139909,
+                "proving_cost": 5471799382,
+                "congestion_cost": 20225965830,
+                "congestion_multiplier": 4677488925
+            },
+            "mana_base_fee_components_in_fee_asset": {
+                "data_cost": 0,
+                "gas_cost": 287535453,
+                "proving_cost": 55911208444,
+                "congestion_cost": 206670258275,
+                "congestion_multiplier": 4677488925
+            }
+        }
+    },
+    {
+        "l1_block_number": 20974295,
+        "l1_fees": {
+            "blob_fee": 35,
+            "base_fee": 7894600668
+        },
+        "parent_header": {
+            "excess_mana": 1318599496,
+            "mana_used": 98480109,
+            "proving_cost_per_mana_numerator": 1068580002,
+            "fee_asset_price_numerator": 2099518642
+        },
+        "header": {
+            "excess_mana": 1317079605,
+            "mana_used": 102788618,
+            "proving_cost_per_mana_numerator": 1126364944,
+            "fee_asset_price_numerator": 1862921956
+        },
+        "oracle_input": {
+            "proving_cost_modifier": 57784942,
+            "fee_asset_price_modifier": -236596686
+        },
+        "outputs": {
+            "fee_asset_price_at_execution": 10212171359,
+            "mana_base_fee_components_in_wei": {
+                "data_cost": 0,
+                "gas_cost": 26150864,
+                "proving_cost": 5473535671,
+                "congestion_cost": 20179331409,
+                "congestion_multiplier": 4669178467
+            },
+            "mana_base_fee_components_in_fee_asset": {
+                "data_cost": 0,
+                "gas_cost": 267057104,
+                "proving_cost": 55896684211,
+                "congestion_cost": 206074790258,
+                "congestion_multiplier": 4669178467
+            }
+        }
+    },
+    {
+        "l1_block_number": 20974298,
+        "l1_fees": {
+            "blob_fee": 29,
+            "base_fee": 9295653283
+        },
+        "parent_header": {
+            "excess_mana": 1317079605,
+            "mana_used": 102788618,
+            "proving_cost_per_mana_numerator": 1126364944,
+            "fee_asset_price_numerator": 1862921956
+        },
+        "header": {
+            "excess_mana": 1319868223,
+            "mana_used": 67256254,
+            "proving_cost_per_mana_numerator": 1099051796,
+            "fee_asset_price_numerator": 2373592741
+        },
+        "oracle_input": {
+            "proving_cost_modifier": -27313148,
+            "fee_asset_price_modifier": 510670785
+        },
+        "outputs": {
+            "fee_asset_price_at_execution": 10188038260,
+            "mana_base_fee_components_in_wei": {
+                "data_cost": 0,
+                "gas_cost": 30791851,
+                "proving_cost": 5476699464,
+                "congestion_cost": 20292006953,
+                "congestion_multiplier": 4684437395
+            },
+            "mana_base_fee_components_in_fee_asset": {
+                "data_cost": 0,
+                "gas_cost": 313708556,
+                "proving_cost": 55796823677,
+                "congestion_cost": 206735743209,
+                "congestion_multiplier": 4684437395
+            }
+        }
+    },
+    {
+        "l1_block_number": 20974301,
+        "l1_fees": {
+            "blob_fee": 29,
+            "base_fee": 8488500665
+        },
+        "parent_header": {
+            "excess_mana": 1319868223,
+            "mana_used": 67256254,
+            "proving_cost_per_mana_numerator": 1099051796,
+            "fee_asset_price_numerator": 2373592741
+        },
+        "header": {
+            "excess_mana": 1287124477,
+            "mana_used": 139548221,
+            "proving_cost_per_mana_numerator": 1173630933,
+            "fee_asset_price_numerator": 2320168027
+        },
+        "oracle_input": {
+            "proving_cost_modifier": 74579137,
+            "fee_asset_price_modifier": -53424714
+        },
+        "outputs": {
+            "fee_asset_price_at_execution": 10240198666,
+            "mana_base_fee_components_in_wei": {
+                "data_cost": 0,
+                "gas_cost": 28118158,
+                "proving_cost": 5475203809,
+                "congestion_cost": 19307688946,
+                "congestion_multiplier": 4508369865
+            },
+            "mana_base_fee_components_in_fee_asset": {
+                "data_cost": 0,
+                "gas_cost": 287935524,
+                "proving_cost": 56067174740,
+                "congestion_cost": 197714570588,
+                "congestion_multiplier": 4508369865
+            }
+        }
+    },
+    {
+        "l1_block_number": 20974304,
+        "l1_fees": {
+            "blob_fee": 27,
+            "base_fee": 8290746738
+        },
+        "parent_header": {
+            "excess_mana": 1287124477,
+            "mana_used": 139548221,
+            "proving_cost_per_mana_numerator": 1173630933,
+            "fee_asset_price_numerator": 2320168027
+        },
+        "header": {
+            "excess_mana": 1326672698,
+            "mana_used": 93161620,
+            "proving_cost_per_mana_numerator": 1280813726,
+            "fee_asset_price_numerator": 2140695673
+        },
+        "oracle_input": {
+            "proving_cost_modifier": 107182793,
+            "fee_asset_price_modifier": -179472354
+        },
+        "outputs": {
+            "fee_asset_price_at_execution": 10234729330,
+            "mana_base_fee_components_in_wei": {
+                "data_cost": 0,
+                "gas_cost": 27463098,
+                "proving_cost": 5479288692,
+                "congestion_cost": 20495470194,
+                "congestion_multiplier": 4721880153
+            },
+            "mana_base_fee_components_in_fee_asset": {
+                "data_cost": 0,
+                "gas_cost": 281077374,
+                "proving_cost": 56079036683,
+                "congestion_cost": 209765589926,
+                "congestion_multiplier": 4721880153
+            }
+        }
+    },
+    {
+        "l1_block_number": 20974307,
+        "l1_fees": {
+            "blob_fee": 24,
+            "base_fee": 8892201701
+        },
+        "parent_header": {
+            "excess_mana": 1326672698,
+            "mana_used": 93161620,
+            "proving_cost_per_mana_numerator": 1280813726,
+            "fee_asset_price_numerator": 2140695673
+        },
+        "header": {
+            "excess_mana": 1319834318,
+            "mana_used": 87306878,
+            "proving_cost_per_mana_numerator": 1345813509,
+            "fee_asset_price_numerator": 1808374966
+        },
+        "oracle_input": {
+            "proving_cost_modifier": 64999783,
+            "fee_asset_price_modifier": -332320707
+        },
+        "outputs": {
+            "fee_asset_price_at_execution": 10216377293,
+            "mana_base_fee_components_in_wei": {
+                "data_cost": 0,
+                "gas_cost": 29455418,
+                "proving_cost": 5485164695,
+                "congestion_cost": 20317247825,
+                "congestion_multiplier": 4684251573
+            },
+            "mana_base_fee_components_in_fee_asset": {
+                "data_cost": 0,
+                "gas_cost": 300927663,
+                "proving_cost": 56038512038,
+                "congestion_cost": 207568669335,
+                "congestion_multiplier": 4684251573
+            }
+        }
+    },
+    {
+        "l1_block_number": 20974310,
+        "l1_fees": {
+            "blob_fee": 23,
+            "base_fee": 8265977323
+        },
+        "parent_header": {
+            "excess_mana": 1319834318,
+            "mana_used": 87306878,
+            "proving_cost_per_mana_numerator": 1345813509,
+            "fee_asset_price_numerator": 1808374966
+        },
+        "header": {
+            "excess_mana": 1307141196,
+            "mana_used": 108136345,
+            "proving_cost_per_mana_numerator": 1474632566,
+            "fee_asset_price_numerator": 1328322599
+        },
+        "oracle_input": {
+            "proving_cost_modifier": 128819057,
+            "fee_asset_price_modifier": -480052367
+        },
+        "outputs": {
+            "fee_asset_price_at_execution": 10182482507,
+            "mana_base_fee_components_in_wei": {
+                "data_cost": 0,
+                "gas_cost": 27381049,
+                "proving_cost": 5488731199,
+                "congestion_cost": 19941848910,
+                "congestion_multiplier": 4615199984
+            },
+            "mana_base_fee_components_in_fee_asset": {
+                "data_cost": 0,
+                "gas_cost": 278807052,
+                "proving_cost": 55888909419,
+                "congestion_cost": 203057527683,
+                "congestion_multiplier": 4615199984
+            }
+        }
+    },
+    {
+        "l1_block_number": 20974313,
+        "l1_fees": {
+            "blob_fee": 22,
+            "base_fee": 9126618125
+        },
+        "parent_header": {
+            "excess_mana": 1307141196,
+            "mana_used": 108136345,
+            "proving_cost_per_mana_numerator": 1474632566,
+            "fee_asset_price_numerator": 1328322599
+        },
+        "header": {
+            "excess_mana": 1315277541,
+            "mana_used": 110084780,
+            "proving_cost_per_mana_numerator": 1508104099,
+            "fee_asset_price_numerator": 1315266421
+        },
+        "oracle_input": {
+            "proving_cost_modifier": 33471533,
+            "fee_asset_price_modifier": -13056178
+        },
+        "outputs": {
+            "fee_asset_price_at_execution": 10133718399,
+            "mana_base_fee_components_in_wei": {
+                "data_cost": 0,
+                "gas_cost": 30231922,
+                "proving_cost": 5495806287,
+                "congestion_cost": 20221676266,
+                "congestion_multiplier": 4659344272
+            },
+            "mana_base_fee_components_in_fee_asset": {
+                "data_cost": 0,
+                "gas_cost": 306361784,
+                "proving_cost": 55692953287,
+                "congestion_cost": 204920772835,
+                "congestion_multiplier": 4659344272
+            }
+        }
+    },
+    {
+        "l1_block_number": 20974316,
+        "l1_fees": {
+            "blob_fee": 24,
+            "base_fee": 9501279935
+        },
+        "parent_header": {
+            "excess_mana": 1315277541,
+            "mana_used": 110084780,
+            "proving_cost_per_mana_numerator": 1508104099,
+            "fee_asset_price_numerator": 1315266421
+        },
+        "header": {
+            "excess_mana": 1325362321,
+            "mana_used": 99455031,
+            "proving_cost_per_mana_numerator": 1658641650,
+            "fee_asset_price_numerator": 906040862
+        },
+        "oracle_input": {
+            "proving_cost_modifier": 150537551,
+            "fee_asset_price_modifier": -409225559
+        },
+        "outputs": {
+            "fee_asset_price_at_execution": 10132395409,
+            "mana_base_fee_components_in_wei": {
+                "data_cost": 0,
+                "gas_cost": 31472989,
+                "proving_cost": 5497646126,
+                "congestion_cost": 20538722365,
+                "congestion_multiplier": 4714646391
+            },
+            "mana_base_fee_components_in_fee_asset": {
+                "data_cost": 0,
+                "gas_cost": 318896769,
+                "proving_cost": 55704324367,
+                "congestion_cost": 208106456197,
+                "congestion_multiplier": 4714646391
+            }
+        }
+    },
+    {
+        "l1_block_number": 20974319,
+        "l1_fees": {
+            "blob_fee": 24,
+            "base_fee": 10745149155
+        },
+        "parent_header": {
+            "excess_mana": 1325362321,
+            "mana_used": 99455031,
+            "proving_cost_per_mana_numerator": 1658641650,
+            "fee_asset_price_numerator": 906040862
+        },
+        "header": {
+            "excess_mana": 1324817352,
+            "mana_used": 105869692,
+            "proving_cost_per_mana_numerator": 1757611722,
+            "fee_asset_price_numerator": 1253906944
+        },
+        "oracle_input": {
+            "proving_cost_modifier": 98970072,
+            "fee_asset_price_modifier": 347866082
+        },
+        "outputs": {
+            "fee_asset_price_at_execution": 10091015783,
+            "mana_base_fee_components_in_wei": {
+                "data_cost": 0,
+                "gas_cost": 35593306,
+                "proving_cost": 5505928380,
+                "congestion_cost": 20568140344,
+                "congestion_multiplier": 4711641226
+            },
+            "mana_base_fee_components_in_fee_asset": {
+                "data_cost": 0,
+                "gas_cost": 359172612,
+                "proving_cost": 55560410182,
+                "congestion_cost": 207553428838,
+                "congestion_multiplier": 4711641226
+            }
+        }
+    },
+    {
+        "l1_block_number": 20974322,
+        "l1_fees": {
+            "blob_fee": 26,
+            "base_fee": 10241684423
+        },
+        "parent_header": {
+            "excess_mana": 1324817352,
+            "mana_used": 105869692,
+            "proving_cost_per_mana_numerator": 1757611722,
+            "fee_asset_price_numerator": 1253906944
+        },
+        "header": {
+            "excess_mana": 1330687044,
+            "mana_used": 39552574,
+            "proving_cost_per_mana_numerator": 1660840076,
+            "fee_asset_price_numerator": 1440977437
+        },
+        "oracle_input": {
+            "proving_cost_modifier": -96771646,
+            "fee_asset_price_modifier": 187070493
+        },
+        "outputs": {
+            "fee_asset_price_at_execution": 10126180131,
+            "mana_base_fee_components_in_wei": {
+                "data_cost": 0,
+                "gas_cost": 33925579,
+                "proving_cost": 5511380299,
+                "congestion_cost": 20762235035,
+                "congestion_multiplier": 4744109972
+            },
+            "mana_base_fee_components_in_fee_asset": {
+                "data_cost": 0,
+                "gas_cost": 343536524,
+                "proving_cost": 55809229678,
+                "congestion_cost": 210242131886,
+                "congestion_multiplier": 4744109972
+            }
+        }
+    },
+    {
+        "l1_block_number": 20974325,
+        "l1_fees": {
+            "blob_fee": 19,
+            "base_fee": 10099236170
+        },
+        "parent_header": {
+            "excess_mana": 1330687044,
+            "mana_used": 39552574,
+            "proving_cost_per_mana_numerator": 1660840076,
+            "fee_asset_price_numerator": 1440977437
+        },
+        "header": {
+            "excess_mana": 1270239618,
+            "mana_used": 128754870,
+            "proving_cost_per_mana_numerator": 1769688662,
+            "fee_asset_price_numerator": 1403976904
+        },
+        "oracle_input": {
+            "proving_cost_modifier": 108848586,
+            "fee_asset_price_modifier": -37000533
+        },
+        "outputs": {
+            "fee_asset_price_at_execution": 10145140956,
+            "mana_base_fee_components_in_wei": {
+                "data_cost": 0,
+                "gas_cost": 33453719,
+                "proving_cost": 5506049425,
+                "congestion_cost": 18946096267,
+                "congestion_multiplier": 4420179712
+            },
+            "mana_base_fee_components_in_fee_asset": {
+                "data_cost": 0,
+                "gas_cost": 339392694,
+                "proving_cost": 55859647527,
+                "congestion_cost": 192210817194,
+                "congestion_multiplier": 4420179712
+            }
+        }
+    },
+    {
+        "l1_block_number": 20974328,
+        "l1_fees": {
+            "blob_fee": 24,
+            "base_fee": 10714018785
+        },
+        "parent_header": {
+            "excess_mana": 1270239618,
+            "mana_used": 128754870,
+            "proving_cost_per_mana_numerator": 1769688662,
+            "fee_asset_price_numerator": 1403976904
+        },
+        "header": {
+            "excess_mana": 1298994488,
+            "mana_used": 122069543,
+            "proving_cost_per_mana_numerator": 1630222122,
+            "fee_asset_price_numerator": 1855086357
+        },
+        "oracle_input": {
+            "proving_cost_modifier": -139466540,
+            "fee_asset_price_modifier": 451109453
+        },
+        "outputs": {
+            "fee_asset_price_at_execution": 10141387894,
+            "mana_base_fee_components_in_wei": {
+                "data_cost": 0,
+                "gas_cost": 35490187,
+                "proving_cost": 5512045945,
+                "congestion_cost": 19812573210,
+                "congestion_multiplier": 4571418507
+            },
+            "mana_base_fee_components_in_fee_asset": {
+                "data_cost": 0,
+                "gas_cost": 359919752,
+                "proving_cost": 55899796017,
+                "congestion_cost": 200926990100,
+                "congestion_multiplier": 4571418507
+            }
+        }
+    },
+    {
+        "l1_block_number": 20974331,
+        "l1_fees": {
+            "blob_fee": 20,
+            "base_fee": 9990102695
+        },
+        "parent_header": {
+            "excess_mana": 1298994488,
+            "mana_used": 122069543,
+            "proving_cost_per_mana_numerator": 1630222122,
+            "fee_asset_price_numerator": 1855086357
+        },
+        "header": {
+            "excess_mana": 1321064031,
+            "mana_used": 101851803,
+            "proving_cost_per_mana_numerator": 1671509921,
+            "fee_asset_price_numerator": 1964747298
+        },
+        "oracle_input": {
+            "proving_cost_modifier": 41287799,
+            "fee_asset_price_modifier": 109660941
+        },
+        "outputs": {
+            "fee_asset_price_at_execution": 10187239997,
+            "mana_base_fee_components_in_wei": {
+                "data_cost": 0,
+                "gas_cost": 33092215,
+                "proving_cost": 5504363844,
+                "congestion_cost": 20438727925,
+                "congestion_multiplier": 4690995957
+            },
+            "mana_base_fee_components_in_fee_asset": {
+                "data_cost": 0,
+                "gas_cost": 337118336,
+                "proving_cost": 56074275509,
+                "congestion_cost": 208214226605,
+                "congestion_multiplier": 4690995957
+            }
+        }
+    },
+    {
+        "l1_block_number": 20974334,
+        "l1_fees": {
+            "blob_fee": 22,
+            "base_fee": 9894921586
+        },
+        "parent_header": {
+            "excess_mana": 1321064031,
+            "mana_used": 101851803,
+            "proving_cost_per_mana_numerator": 1671509921,
+            "fee_asset_price_numerator": 1964747298
+        },
+        "header": {
+            "excess_mana": 1322915834,
+            "mana_used": 96372923,
+            "proving_cost_per_mana_numerator": 1556471872,
+            "fee_asset_price_numerator": 1480377822
+        },
+        "oracle_input": {
+            "proving_cost_modifier": -115038049,
+            "fee_asset_price_modifier": -484369476
+        },
+        "outputs": {
+            "fee_asset_price_at_execution": 10198417548,
+            "mana_base_fee_components_in_wei": {
+                "data_cost": 0,
+                "gas_cost": 32776927,
+                "proving_cost": 5506636943,
+                "congestion_cost": 20502315374,
+                "congestion_multiplier": 4701170531
+            },
+            "mana_base_fee_components_in_fee_asset": {
+                "data_cost": 0,
+                "gas_cost": 334272787,
+                "proving_cost": 56158982829,
+                "congestion_cost": 209091172884,
+                "congestion_multiplier": 4701170531
+            }
+        }
+    },
+    {
+        "l1_block_number": 20974337,
+        "l1_fees": {
+            "blob_fee": 23,
+            "base_fee": 9960455736
+        },
+        "parent_header": {
+            "excess_mana": 1322915834,
+            "mana_used": 96372923,
+            "proving_cost_per_mana_numerator": 1556471872,
+            "fee_asset_price_numerator": 1480377822
+        },
+        "header": {
+            "excess_mana": 1319288757,
+            "mana_used": 109308423,
+            "proving_cost_per_mana_numerator": 1597101767,
+            "fee_asset_price_numerator": 1899533473
+        },
+        "oracle_input": {
+            "proving_cost_modifier": 40629895,
+            "fee_asset_price_modifier": 419155651
+        },
+        "outputs": {
+            "fee_asset_price_at_execution": 10149138968,
+            "mana_base_fee_components_in_wei": {
+                "data_cost": 0,
+                "gas_cost": 32994009,
+                "proving_cost": 5500305858,
+                "congestion_cost": 20369529517,
+                "congestion_multiplier": 4681262539
+            },
+            "mana_base_fee_components_in_fee_asset": {
+                "data_cost": 0,
+                "gas_cost": 334860782,
+                "proving_cost": 55823368519,
+                "congestion_cost": 206733185780,
+                "congestion_multiplier": 4681262539
+            }
+        }
+    },
+    {
+        "l1_block_number": 20974340,
+        "l1_fees": {
+            "blob_fee": 22,
+            "base_fee": 9964721878
+        },
+        "parent_header": {
+            "excess_mana": 1319288757,
+            "mana_used": 109308423,
+            "proving_cost_per_mana_numerator": 1597101767,
+            "fee_asset_price_numerator": 1899533473
+        },
+        "header": {
+            "excess_mana": 1328597180,
+            "mana_used": 102019767,
+            "proving_cost_per_mana_numerator": 1557408475,
+            "fee_asset_price_numerator": 2190235844
+        },
+        "oracle_input": {
+            "proving_cost_modifier": -39693292,
+            "fee_asset_price_modifier": 290702371
+        },
+        "outputs": {
+            "fee_asset_price_at_execution": 10191768938,
+            "mana_base_fee_components_in_wei": {
+                "data_cost": 0,
+                "gas_cost": 33008141,
+                "proving_cost": 5502541081,
+                "congestion_cost": 20661571016,
+                "congestion_multiplier": 4732524125
+            },
+            "mana_base_fee_components_in_fee_asset": {
+                "data_cost": 0,
+                "gas_cost": 336411346,
+                "proving_cost": 56080627269,
+                "congestion_cost": 210577957691,
+                "congestion_multiplier": 4732524125
+            }
+        }
+    },
+    {
+        "l1_block_number": 20974343,
+        "l1_fees": {
+            "blob_fee": 19,
+            "base_fee": 9815866122
+        },
+        "parent_header": {
+            "excess_mana": 1328597180,
+            "mana_used": 102019767,
+            "proving_cost_per_mana_numerator": 1557408475,
+            "fee_asset_price_numerator": 2190235844
+        },
+        "header": {
+            "excess_mana": 1330616947,
+            "mana_used": 91158650,
+            "proving_cost_per_mana_numerator": 1599926904,
+            "fee_asset_price_numerator": 2259250132
+        },
+        "oracle_input": {
+            "proving_cost_modifier": 42518429,
+            "fee_asset_price_modifier": 69014288
+        },
+        "outputs": {
+            "fee_asset_price_at_execution": 10221439758,
+            "mana_base_fee_components_in_wei": {
+                "data_cost": 0,
+                "gas_cost": 32515056,
+                "proving_cost": 5500357374,
+                "congestion_cost": 20713530191,
+                "congestion_multiplier": 4743720907
+            },
+            "mana_base_fee_components_in_fee_asset": {
+                "data_cost": 0,
+                "gas_cost": 332350686,
+                "proving_cost": 56221571545,
+                "congestion_cost": 211722101022,
+                "congestion_multiplier": 4743720907
+            }
+        }
+    },
+    {
+        "l1_block_number": 20974346,
+        "l1_fees": {
+            "blob_fee": 17,
+            "base_fee": 9039417707
+        },
+        "parent_header": {
+            "excess_mana": 1330616947,
+            "mana_used": 91158650,
+            "proving_cost_per_mana_numerator": 1599926904,
+            "fee_asset_price_numerator": 2259250132
+        },
+        "header": {
+            "excess_mana": 1321775597,
+            "mana_used": 107408210,
+            "proving_cost_per_mana_numerator": 1470245111,
+            "fee_asset_price_numerator": 2095941984
+        },
+        "oracle_input": {
+            "proving_cost_modifier": -129681793,
+            "fee_asset_price_modifier": -163308148
+        },
+        "outputs": {
+            "fee_asset_price_at_execution": 10228496447,
+            "mana_base_fee_components_in_wei": {
+                "data_cost": 0,
+                "gas_cost": 29943071,
+                "proving_cost": 5502696537,
+                "congestion_cost": 20442566619,
+                "congestion_multiplier": 4694902988
+            },
+            "mana_base_fee_components_in_fee_asset": {
+                "data_cost": 0,
+                "gas_cost": 306272595,
+                "proving_cost": 56284311977,
+                "congestion_cost": 209096720030,
+                "congestion_multiplier": 4694902988
+            }
+        }
+    },
+    {
+        "l1_block_number": 20974349,
+        "l1_fees": {
+            "blob_fee": 15,
+            "base_fee": 8475102127
+        },
+        "parent_header": {
+            "excess_mana": 1321775597,
+            "mana_used": 107408210,
+            "proving_cost_per_mana_numerator": 1470245111,
+            "fee_asset_price_numerator": 2095941984
+        },
+        "header": {
+            "excess_mana": 1329183807,
+            "mana_used": 98319714,
+            "proving_cost_per_mana_numerator": 1375804603,
+            "fee_asset_price_numerator": 1850876842
+        },
+        "oracle_input": {
+            "proving_cost_modifier": -94440508,
+            "fee_asset_price_modifier": -245065142
+        },
+        "outputs": {
+            "fee_asset_price_at_execution": 10211806111,
+            "mana_base_fee_components_in_wei": {
+                "data_cost": 0,
+                "gas_cost": 28073775,
+                "proving_cost": 5495565167,
+                "congestion_cost": 20635063568,
+                "congestion_multiplier": 4735773425
+            },
+            "mana_base_fee_components_in_fee_asset": {
+                "data_cost": 0,
+                "gas_cost": 286683947,
+                "proving_cost": 56119645955,
+                "congestion_cost": 210721268244,
+                "congestion_multiplier": 4735773425
+            }
+        }
+    },
+    {
+        "l1_block_number": 20974352,
+        "l1_fees": {
+            "blob_fee": 14,
+            "base_fee": 9315624609
+        },
+        "parent_header": {
+            "excess_mana": 1329183807,
+            "mana_used": 98319714,
+            "proving_cost_per_mana_numerator": 1375804603,
+            "fee_asset_price_numerator": 1850876842
+        },
+        "header": {
+            "excess_mana": 1327503521,
+            "mana_used": 79040235,
+            "proving_cost_per_mana_numerator": 1312310154,
+            "fee_asset_price_numerator": 1909017143
+        },
+        "oracle_input": {
+            "proving_cost_modifier": -63494449,
+            "fee_asset_price_modifier": 58140301
+        },
+        "outputs": {
+            "fee_asset_price_at_execution": 10186811173,
+            "mana_base_fee_components_in_wei": {
+                "data_cost": 0,
+                "gas_cost": 30858006,
+                "proving_cost": 5490377577,
+                "congestion_cost": 20574731732,
+                "congestion_multiplier": 4726472349
+            },
+            "mana_base_fee_components_in_fee_asset": {
+                "data_cost": 0,
+                "gas_cost": 314344680,
+                "proving_cost": 55929439645,
+                "congestion_cost": 209590907089,
+                "congestion_multiplier": 4726472349
+            }
+        }
+    },
+    {
+        "l1_block_number": 20974355,
+        "l1_fees": {
+            "blob_fee": 12,
+            "base_fee": 9031807679
+        },
+        "parent_header": {
+            "excess_mana": 1327503521,
+            "mana_used": 79040235,
+            "proving_cost_per_mana_numerator": 1312310154,
+            "fee_asset_price_numerator": 1909017143
+        },
+        "header": {
+            "excess_mana": 1306543756,
+            "mana_used": 107770546,
+            "proving_cost_per_mana_numerator": 1372426141,
+            "fee_asset_price_numerator": 2236036991
+        },
+        "oracle_input": {
+            "proving_cost_modifier": 60115987,
+            "fee_asset_price_modifier": 327019848
+        },
+        "outputs": {
+            "fee_asset_price_at_execution": 10192735538,
+            "mana_base_fee_components_in_wei": {
+                "data_cost": 0,
+                "gas_cost": 29917862,
+                "proving_cost": 5486892598,
+                "congestion_cost": 19926581814,
+                "congestion_multiplier": 4611975064
+            },
+            "mana_base_fee_components_in_fee_asset": {
+                "data_cost": 0,
+                "gas_cost": 304944855,
+                "proving_cost": 55926445176,
+                "congestion_cost": 203106378606,
+                "congestion_multiplier": 4611975064
+            }
+        }
+    },
+    {
+        "l1_block_number": 20974358,
+        "l1_fees": {
+            "blob_fee": 12,
+            "base_fee": 9209742295
+        },
+        "parent_header": {
+            "excess_mana": 1306543756,
+            "mana_used": 107770546,
+            "proving_cost_per_mana_numerator": 1372426141,
+            "fee_asset_price_numerator": 2236036991
+        },
+        "header": {
+            "excess_mana": 1314314302,
+            "mana_used": 108806778,
+            "proving_cost_per_mana_numerator": 1324351893,
+            "fee_asset_price_numerator": 1806378454
+        },
+        "oracle_input": {
+            "proving_cost_modifier": -48074248,
+            "fee_asset_price_modifier": -429658537
+        },
+        "outputs": {
+            "fee_asset_price_at_execution": 10226122367,
+            "mana_base_fee_components_in_wei": {
+                "data_cost": 0,
+                "gas_cost": 30507271,
+                "proving_cost": 5490192090,
+                "congestion_cost": 20173166539,
+                "congestion_multiplier": 4654096197
+            },
+            "mana_base_fee_components_in_fee_asset": {
+                "data_cost": 0,
+                "gas_cost": 311971086,
+                "proving_cost": 56143376130,
+                "congestion_cost": 206293269557,
+                "congestion_multiplier": 4654096197
+            }
+        }
+    },
+    {
+        "l1_block_number": 20974361,
+        "l1_fees": {
+            "blob_fee": 9,
+            "base_fee": 8782605352
+        },
+        "parent_header": {
+            "excess_mana": 1314314302,
+            "mana_used": 108806778,
+            "proving_cost_per_mana_numerator": 1324351893,
+            "fee_asset_price_numerator": 1806378454
+        },
+        "header": {
+            "excess_mana": 1323121080,
+            "mana_used": 90226091,
+            "proving_cost_per_mana_numerator": 1264633275,
+            "fee_asset_price_numerator": 2350054816
+        },
+        "oracle_input": {
+            "proving_cost_modifier": -59718618,
+            "fee_asset_price_modifier": 543676362
+        },
+        "outputs": {
+            "fee_asset_price_at_execution": 10182279215,
+            "mana_base_fee_components_in_wei": {
+                "data_cost": 0,
+                "gas_cost": 29092380,
+                "proving_cost": 5487553355,
+                "congestion_cost": 20424275275,
+                "congestion_multiplier": 4702299596
+            },
+            "mana_base_fee_components_in_fee_asset": {
+                "data_cost": 0,
+                "gas_cost": 296226736,
+                "proving_cost": 55875800467,
+                "congestion_cost": 207965673614,
+                "congestion_multiplier": 4702299596
+            }
+        }
+    },
+    {
+        "l1_block_number": 20974364,
+        "l1_fees": {
+            "blob_fee": 7,
+            "base_fee": 9499075723
+        },
+        "parent_header": {
+            "excess_mana": 1323121080,
+            "mana_used": 90226091,
+            "proving_cost_per_mana_numerator": 1264633275,
+            "fee_asset_price_numerator": 2350054816
+        },
+        "header": {
+            "excess_mana": 1313347171,
+            "mana_used": 111455713,
+            "proving_cost_per_mana_numerator": 1260495242,
+            "fee_asset_price_numerator": 2066832958
+        },
+        "oracle_input": {
+            "proving_cost_modifier": -4138033,
+            "fee_asset_price_modifier": -283221858
+        },
+        "outputs": {
+            "fee_asset_price_at_execution": 10237788619,
+            "mana_base_fee_components_in_wei": {
+                "data_cost": 0,
+                "gas_cost": 31465688,
+                "proving_cost": 5484277243,
+                "congestion_cost": 20126024081,
+                "congestion_multiplier": 4648832865
+            },
+            "mana_base_fee_components_in_fee_asset": {
+                "data_cost": 0,
+                "gas_cost": 322139062,
+                "proving_cost": 56146871141,
+                "congestion_cost": 206045980282,
+                "congestion_multiplier": 4648832865
+            }
+        }
+    },
+    {
+        "l1_block_number": 20974367,
+        "l1_fees": {
+            "blob_fee": 8,
+            "base_fee": 9417033890
+        },
+        "parent_header": {
+            "excess_mana": 1313347171,
+            "mana_used": 111455713,
+            "proving_cost_per_mana_numerator": 1260495242,
+            "fee_asset_price_numerator": 2066832958
+        },
+        "header": {
+            "excess_mana": 1324802884,
+            "mana_used": 102257732,
+            "proving_cost_per_mana_numerator": 1259391999,
+            "fee_asset_price_numerator": 1704421437
+        },
+        "oracle_input": {
+            "proving_cost_modifier": -1103243,
+            "fee_asset_price_modifier": -362411521
+        },
+        "outputs": {
+            "fee_asset_price_at_execution": 10208833986,
+            "mana_base_fee_components_in_wei": {
+                "data_cost": 0,
+                "gas_cost": 31193924,
+                "proving_cost": 5484050306,
+                "congestion_cost": 20470167981,
+                "congestion_multiplier": 4711561470
+            },
+            "mana_base_fee_components_in_fee_asset": {
+                "data_cost": 0,
+                "gas_cost": 318453591,
+                "proving_cost": 55985759144,
+                "congestion_cost": 208976546583,
+                "congestion_multiplier": 4711561470
+            }
+        }
+    },
+    {
+        "l1_block_number": 20974370,
+        "l1_fees": {
+            "blob_fee": 6,
+            "base_fee": 9309211929
+        },
+        "parent_header": {
+            "excess_mana": 1324802884,
+            "mana_used": 102257732,
+            "proving_cost_per_mana_numerator": 1259391999,
+            "fee_asset_price_numerator": 1704421437
+        },
+        "header": {
+            "excess_mana": 1327060616,
+            "mana_used": 98249684,
+            "proving_cost_per_mana_numerator": 1204937291,
+            "fee_asset_price_numerator": 1449652955
+        },
+        "oracle_input": {
+            "proving_cost_modifier": -54454708,
+            "fee_asset_price_modifier": -254768482
+        },
+        "outputs": {
+            "fee_asset_price_at_execution": 10171902957,
+            "mana_base_fee_components_in_wei": {
+                "data_cost": 0,
+                "gas_cost": 30836764,
+                "proving_cost": 5483989804,
+                "congestion_cost": 20537345011,
+                "congestion_multiplier": 4724023731
+            },
+            "mana_base_fee_components_in_fee_asset": {
+                "data_cost": 0,
+                "gas_cost": 313668570,
+                "proving_cost": 55782612103,
+                "congestion_cost": 208903880446,
+                "congestion_multiplier": 4724023731
+            }
+        }
+    },
+    {
+        "l1_block_number": 20974373,
+        "l1_fees": {
+            "blob_fee": 6,
+            "base_fee": 9007719109
+        },
+        "parent_header": {
+            "excess_mana": 1327060616,
+            "mana_used": 98249684,
+            "proving_cost_per_mana_numerator": 1204937291,
+            "fee_asset_price_numerator": 1449652955
+        },
+        "header": {
+            "excess_mana": 1325310300,
+            "mana_used": 103778888,
+            "proving_cost_per_mana_numerator": 1187210311,
+            "fee_asset_price_numerator": 547655613
+        },
+        "oracle_input": {
+            "proving_cost_modifier": -17726980,
+            "fee_asset_price_modifier": -901997342
+        },
+        "outputs": {
+            "fee_asset_price_at_execution": 10146021138,
+            "mana_base_fee_components_in_wei": {
+                "data_cost": 0,
+                "gas_cost": 29838069,
+                "proving_cost": 5481004326,
+                "congestion_cost": 20469249499,
+                "congestion_multiplier": 4714359445
+            },
+            "mana_base_fee_components_in_fee_asset": {
+                "data_cost": 0,
+                "gas_cost": 302737678,
+                "proving_cost": 55610385749,
+                "congestion_cost": 207681438095,
+                "congestion_multiplier": 4714359445
+            }
+        }
+    },
+    {
+        "l1_block_number": 20974376,
+        "l1_fees": {
+            "blob_fee": 6,
+            "base_fee": 8992739005
+        },
+        "parent_header": {
+            "excess_mana": 1325310300,
+            "mana_used": 103778888,
+            "proving_cost_per_mana_numerator": 1187210311,
+            "fee_asset_price_numerator": 547655613
+        },
+        "header": {
+            "excess_mana": 1329089188,
+            "mana_used": 102202562,
+            "proving_cost_per_mana_numerator": 1334620866,
+            "fee_asset_price_numerator": 390261417
+        },
+        "oracle_input": {
+            "proving_cost_modifier": 147410555,
+            "fee_asset_price_modifier": -157394196
+        },
+        "outputs": {
+            "fee_asset_price_at_execution": 10054915798,
+            "mana_base_fee_components_in_wei": {
+                "data_cost": 0,
+                "gas_cost": 29788447,
+                "proving_cost": 5480032796,
+                "congestion_cost": 20580555301,
+                "congestion_multiplier": 4735249184
+            },
+            "mana_base_fee_components_in_fee_asset": {
+                "data_cost": 0,
+                "gas_cost": 299520326,
+                "proving_cost": 55101268334,
+                "congestion_cost": 206935750627,
+                "congestion_multiplier": 4735249184
+            }
+        }
+    },
+    {
+        "l1_block_number": 20974379,
+        "l1_fees": {
+            "blob_fee": 6,
+            "base_fee": 9042037019
+        },
+        "parent_header": {
+            "excess_mana": 1329089188,
+            "mana_used": 102202562,
+            "proving_cost_per_mana_numerator": 1334620866,
+            "fee_asset_price_numerator": 390261417
+        },
+        "header": {
+            "excess_mana": 1331291750,
+            "mana_used": 102177014,
+            "proving_cost_per_mana_numerator": 1416682604,
+            "fee_asset_price_numerator": 0
+        },
+        "oracle_input": {
+            "proving_cost_modifier": 82061738,
+            "fee_asset_price_modifier": -424317117
+        },
+        "outputs": {
+            "fee_asset_price_at_execution": 10039102392,
+            "mana_base_fee_components_in_wei": {
+                "data_cost": 0,
+                "gas_cost": 29951747,
+                "proving_cost": 5488116900,
+                "congestion_cost": 20678783723,
+                "congestion_multiplier": 4747467646
+            },
+            "mana_base_fee_components_in_fee_asset": {
+                "data_cost": 0,
+                "gas_cost": 300688654,
+                "proving_cost": 55095767498,
+                "congestion_cost": 207596427137,
+                "congestion_multiplier": 4747467646
+            }
+        }
+    },
+    {
+        "l1_block_number": 20974382,
+        "l1_fees": {
+            "blob_fee": 7,
+            "base_fee": 8510788576
+        },
+        "parent_header": {
+            "excess_mana": 1331291750,
+            "mana_used": 102177014,
+            "proving_cost_per_mana_numerator": 1416682604,
+            "fee_asset_price_numerator": 0
+        },
+        "header": {
+            "excess_mana": 1333468764,
+            "mana_used": 97887752,
+            "proving_cost_per_mana_numerator": 1423671361,
+            "fee_asset_price_numerator": 360076914
+        },
+        "oracle_input": {
+            "proving_cost_modifier": 6988757,
+            "fee_asset_price_modifier": 360076914
+        },
+        "outputs": {
+            "fee_asset_price_at_execution": 10000000000,
+            "mana_base_fee_components_in_wei": {
+                "data_cost": 0,
+                "gas_cost": 28191987,
+                "proving_cost": 5492622392,
+                "congestion_cost": 20755917728,
+                "congestion_multiplier": 4759575364
+            },
+            "mana_base_fee_components_in_fee_asset": {
+                "data_cost": 0,
+                "gas_cost": 281919870,
+                "proving_cost": 54926223920,
+                "congestion_cost": 207559177280,
+                "congestion_multiplier": 4759575364
+            }
+        }
+    },
+    {
+        "l1_block_number": 20974385,
+        "l1_fees": {
+            "blob_fee": 5,
+            "base_fee": 9374725308
+        },
+        "parent_header": {
+            "excess_mana": 1333468764,
+            "mana_used": 97887752,
+            "proving_cost_per_mana_numerator": 1423671361,
+            "fee_asset_price_numerator": 360076914
+        },
+        "header": {
+            "excess_mana": 1331356516,
+            "mana_used": 97037409,
+            "proving_cost_per_mana_numerator": 1534145393,
+            "fee_asset_price_numerator": 952978592
+        },
+        "oracle_input": {
+            "proving_cost_modifier": 110474032,
+            "fee_asset_price_modifier": 592901678
+        },
+        "outputs": {
+            "fee_asset_price_at_execution": 10036072596,
+            "mana_base_fee_components_in_wei": {
+                "data_cost": 0,
+                "gas_cost": 31053777,
+                "proving_cost": 5493006272,
+                "congestion_cost": 20703223638,
+                "congestion_multiplier": 4747827405
+            },
+            "mana_base_fee_components_in_fee_asset": {
+                "data_cost": 0,
+                "gas_cost": 311657960,
+                "proving_cost": 55128209716,
+                "congestion_cost": 207779055402,
+                "congestion_multiplier": 4747827405
+            }
+        }
+    },
+    {
+        "l1_block_number": 20974388,
+        "l1_fees": {
+            "blob_fee": 5,
+            "base_fee": 8322579740
+        },
+        "parent_header": {
+            "excess_mana": 1331356516,
+            "mana_used": 97037409,
+            "proving_cost_per_mana_numerator": 1534145393,
+            "fee_asset_price_numerator": 952978592
+        },
+        "header": {
+            "excess_mana": 1328393925,
+            "mana_used": 94346326,
+            "proving_cost_per_mana_numerator": 1589826455,
+            "fee_asset_price_numerator": 1952978592
+        },
+        "oracle_input": {
+            "proving_cost_modifier": 55681062,
+            "fee_asset_price_modifier": 1000000000
+        },
+        "outputs": {
+            "fee_asset_price_at_execution": 10095753389,
+            "mana_base_fee_components_in_wei": {
+                "data_cost": 0,
+                "gas_cost": 27568545,
+                "proving_cost": 5499077970,
+                "congestion_cost": 20622122312,
+                "congestion_multiplier": 4731398825
+            },
+            "mana_base_fee_components_in_fee_asset": {
+                "data_cost": 0,
+                "gas_cost": 278325231,
+                "proving_cost": 55517335052,
+                "congestion_cost": 208195861219,
+                "congestion_multiplier": 4731398825
+            }
+        }
+    },
+    {
+        "l1_block_number": 20974391,
+        "l1_fees": {
+            "blob_fee": 4,
+            "base_fee": 8799523084
+        },
+        "parent_header": {
+            "excess_mana": 1328393925,
+            "mana_used": 94346326,
+            "proving_cost_per_mana_numerator": 1589826455,
+            "fee_asset_price_numerator": 1952978592
+        },
+        "header": {
+            "excess_mana": 1322740251,
+            "mana_used": 111007432,
+            "proving_cost_per_mana_numerator": 1527438719,
+            "fee_asset_price_numerator": 2099675722
+        },
+        "oracle_input": {
+            "proving_cost_modifier": -62387736,
+            "fee_asset_price_modifier": 146697130
+        },
+        "outputs": {
+            "fee_asset_price_at_execution": 10197217397,
+            "mana_base_fee_components_in_wei": {
+                "data_cost": 0,
+                "gas_cost": 29148420,
+                "proving_cost": 5502140768,
+                "congestion_cost": 20466903129,
+                "congestion_multiplier": 4700204859
+            },
+            "mana_base_fee_components_in_fee_asset": {
+                "data_cost": 0,
+                "gas_cost": 297232775,
+                "proving_cost": 56106525560,
+                "congestion_cost": 208705460649,
+                "congestion_multiplier": 4700204859
+            }
+        }
+    },
+    {
+        "l1_block_number": 20974394,
+        "l1_fees": {
+            "blob_fee": 4,
+            "base_fee": 8519958823
+        },
+        "parent_header": {
+            "excess_mana": 1322740251,
+            "mana_used": 111007432,
+            "proving_cost_per_mana_numerator": 1527438719,
+            "fee_asset_price_numerator": 2099675722
+        },
+        "header": {
+            "excess_mana": 1333747683,
+            "mana_used": 91076828,
+            "proving_cost_per_mana_numerator": 1499445967,
+            "fee_asset_price_numerator": 1358497570
+        },
+        "oracle_input": {
+            "proving_cost_modifier": -27992752,
+            "fee_asset_price_modifier": -741178152
+        },
+        "outputs": {
+            "fee_asset_price_at_execution": 10212187400,
+            "mana_base_fee_components_in_wei": {
+                "data_cost": 0,
+                "gas_cost": 28222363,
+                "proving_cost": 5498709178,
+                "congestion_cost": 20787501587,
+                "congestion_multiplier": 4761128835
+            },
+            "mana_base_fee_components_in_fee_asset": {
+                "data_cost": 0,
+                "gas_cost": 288212059,
+                "proving_cost": 56153848583,
+                "congestion_cost": 212285861784,
+                "congestion_multiplier": 4761128835
+            }
+        }
+    },
+    {
+        "l1_block_number": 20974397,
+        "l1_fees": {
+            "blob_fee": 4,
+            "base_fee": 9023488741
+        },
+        "parent_header": {
+            "excess_mana": 1333747683,
+            "mana_used": 91076828,
+            "proving_cost_per_mana_numerator": 1499445967,
+            "fee_asset_price_numerator": 1358497570
+        },
+        "header": {
+            "excess_mana": 1324824511,
+            "mana_used": 102348677,
+            "proving_cost_per_mana_numerator": 1684170181,
+            "fee_asset_price_numerator": 1669934689
+        },
+        "oracle_input": {
+            "proving_cost_modifier": 184724214,
+            "fee_asset_price_modifier": 311437119
+        },
+        "outputs": {
+            "fee_asset_price_at_execution": 10136776707,
+            "mana_base_fee_components_in_wei": {
+                "data_cost": 0,
+                "gas_cost": 29890306,
+                "proving_cost": 5497170153,
+                "congestion_cost": 20514683583,
+                "congestion_multiplier": 4711680691
+            },
+            "mana_base_fee_components_in_fee_asset": {
+                "data_cost": 0,
+                "gas_cost": 302991357,
+                "proving_cost": 55723586361,
+                "congestion_cost": 207952766695,
+                "congestion_multiplier": 4711680691
+            }
+        }
+    },
+    {
+        "l1_block_number": 20974400,
+        "l1_fees": {
+            "blob_fee": 4,
+            "base_fee": 8545578463
+        },
+        "parent_header": {
+            "excess_mana": 1324824511,
+            "mana_used": 102348677,
+            "proving_cost_per_mana_numerator": 1684170181,
+            "fee_asset_price_numerator": 1669934689
+        },
+        "header": {
+            "excess_mana": 1327173188,
+            "mana_used": 92938693,
+            "proving_cost_per_mana_numerator": 1871615142,
+            "fee_asset_price_numerator": 2669934689
+        },
+        "oracle_input": {
+            "proving_cost_modifier": 187444961,
+            "fee_asset_price_modifier": 1000000000
+        },
+        "outputs": {
+            "fee_asset_price_at_execution": 10168395603,
+            "mana_base_fee_components_in_wei": {
+                "data_cost": 0,
+                "gas_cost": 28307228,
+                "proving_cost": 5507334142,
+                "congestion_cost": 20618304320,
+                "congestion_multiplier": 4724645970
+            },
+            "mana_base_fee_components_in_fee_asset": {
+                "data_cost": 0,
+                "gas_cost": 287839092,
+                "proving_cost": 56000752273,
+                "congestion_cost": 209655074988,
+                "congestion_multiplier": 4724645970
+            }
+        }
+    },
+    {
+        "l1_block_number": 20974403,
+        "l1_fees": {
+            "blob_fee": 3,
+            "base_fee": 8672936965
+        },
+        "parent_header": {
+            "excess_mana": 1327173188,
+            "mana_used": 92938693,
+            "proving_cost_per_mana_numerator": 1871615142,
+            "fee_asset_price_numerator": 2669934689
+        },
+        "header": {
+            "excess_mana": 1320111881,
+            "mana_used": 100219596,
+            "proving_cost_per_mana_numerator": 1771461342,
+            "fee_asset_price_numerator": 2497321334
+        },
+        "oracle_input": {
+            "proving_cost_modifier": -100153800,
+            "fee_asset_price_modifier": -172613355
+        },
+        "outputs": {
+            "fee_asset_price_at_execution": 10270589678,
+            "mana_base_fee_components_in_wei": {
+                "data_cost": 0,
+                "gas_cost": 28729103,
+                "proving_cost": 5517667044,
+                "congestion_cost": 20442757299,
+                "congestion_multiplier": 4685773024
+            },
+            "mana_base_fee_components_in_fee_asset": {
+                "data_cost": 0,
+                "gas_cost": 295064828,
+                "proving_cost": 56669694188,
+                "congestion_cost": 209959172104,
+                "congestion_multiplier": 4685773024
+            }
+        }
+    },
+    {
+        "l1_block_number": 20974406,
+        "l1_fees": {
+            "blob_fee": 4,
+            "base_fee": 9479498490
+        },
+        "parent_header": {
+            "excess_mana": 1320111881,
+            "mana_used": 100219596,
+            "proving_cost_per_mana_numerator": 1771461342,
+            "fee_asset_price_numerator": 2497321334
+        },
+        "header": {
+            "excess_mana": 1320331477,
+            "mana_used": 87249250,
+            "proving_cost_per_mana_numerator": 1566676181,
+            "fee_asset_price_numerator": 3051306617
+        },
+        "oracle_input": {
+            "proving_cost_modifier": -204785161,
+            "fee_asset_price_modifier": 553985283
+        },
+        "outputs": {
+            "fee_asset_price_at_execution": 10252876561,
+            "mana_base_fee_components_in_wei": {
+                "data_cost": 0,
+                "gas_cost": 31400838,
+                "proving_cost": 5512143657,
+                "congestion_cost": 20438921506,
+                "congestion_multiplier": 4686977082
+            },
+            "mana_base_fee_components_in_fee_asset": {
+                "data_cost": 0,
+                "gas_cost": 321948915,
+                "proving_cost": 56515328501,
+                "congestion_cost": 209557739240,
+                "congestion_multiplier": 4686977082
+            }
+        }
+    },
+    {
+        "l1_block_number": 20974409,
+        "l1_fees": {
+            "blob_fee": 3,
+            "base_fee": 9875043082
+        },
+        "parent_header": {
+            "excess_mana": 1320331477,
+            "mana_used": 87249250,
+            "proving_cost_per_mana_numerator": 1566676181,
+            "fee_asset_price_numerator": 3051306617
+        },
+        "header": {
+            "excess_mana": 1307580727,
+            "mana_used": 115675532,
+            "proving_cost_per_mana_numerator": 1629461953,
+            "fee_asset_price_numerator": 2394692137
+        },
+        "oracle_input": {
+            "proving_cost_modifier": 62785772,
+            "fee_asset_price_modifier": -656614480
+        },
+        "outputs": {
+            "fee_asset_price_at_execution": 10309833609,
+            "mana_base_fee_components_in_wei": {
+                "data_cost": 0,
+                "gas_cost": 32711080,
+                "proving_cost": 5500867155,
+                "congestion_cost": 20018128567,
+                "congestion_multiplier": 4617573967
+            },
+            "mana_base_fee_components_in_fee_asset": {
+                "data_cost": 0,
+                "gas_cost": 337245791,
+                "proving_cost": 56713025073,
+                "congestion_cost": 206383574689,
+                "congestion_multiplier": 4617573967
+            }
+        }
+    },
+    {
+        "l1_block_number": 20974412,
+        "l1_fees": {
+            "blob_fee": 3,
+            "base_fee": 10014800521
+        },
+        "parent_header": {
+            "excess_mana": 1307580727,
+            "mana_used": 115675532,
+            "proving_cost_per_mana_numerator": 1629461953,
+            "fee_asset_price_numerator": 2394692137
+        },
+        "header": {
+            "excess_mana": 1323256259,
+            "mana_used": 105099465,
+            "proving_cost_per_mana_numerator": 1668234004,
+            "fee_asset_price_numerator": 2403049174
+        },
+        "oracle_input": {
+            "proving_cost_modifier": 38772051,
+            "fee_asset_price_modifier": 8357037
+        },
+        "outputs": {
+            "fee_asset_price_at_execution": 10242359514,
+            "mana_base_fee_components_in_wei": {
+                "data_cost": 0,
+                "gas_cost": 33174026,
+                "proving_cost": 5504322001,
+                "congestion_cost": 20505587938,
+                "congestion_multiplier": 4703043368
+            },
+            "mana_base_fee_components_in_fee_asset": {
+                "data_cost": 0,
+                "gas_cost": 339780300,
+                "proving_cost": 56377244815,
+                "congestion_cost": 210025603706,
+                "congestion_multiplier": 4703043368
+            }
+        }
+    },
+    {
+        "l1_block_number": 20974415,
+        "l1_fees": {
+            "blob_fee": 2,
+            "base_fee": 9730168250
+        },
+        "parent_header": {
+            "excess_mana": 1323256259,
+            "mana_used": 105099465,
+            "proving_cost_per_mana_numerator": 1668234004,
+            "fee_asset_price_numerator": 2403049174
+        },
+        "header": {
+            "excess_mana": 1328355724,
+            "mana_used": 103057264,
+            "proving_cost_per_mana_numerator": 1662305093,
+            "fee_asset_price_numerator": 2860952379
+        },
+        "oracle_input": {
+            "proving_cost_modifier": -5928911,
+            "fee_asset_price_modifier": 457903205
+        },
+        "outputs": {
+            "fee_asset_price_at_execution": 10243215507,
+            "mana_base_fee_components_in_wei": {
+                "data_cost": 0,
+                "gas_cost": 32231182,
+                "proving_cost": 5506456554,
+                "congestion_cost": 20665881666,
+                "congestion_multiplier": 4731187359
+            },
+            "mana_base_fee_components_in_fee_asset": {
+                "data_cost": 0,
+                "gas_cost": 330150943,
+                "proving_cost": 56403821162,
+                "congestion_cost": 211685079546,
+                "congestion_multiplier": 4731187359
+            }
+        }
+    },
+    {
+        "l1_block_number": 20974418,
+        "l1_fees": {
+            "blob_fee": 2,
+            "base_fee": 9791395571
+        },
+        "parent_header": {
+            "excess_mana": 1328355724,
+            "mana_used": 103057264,
+            "proving_cost_per_mana_numerator": 1662305093,
+            "fee_asset_price_numerator": 2860952379
+        },
+        "header": {
+            "excess_mana": 1331412988,
+            "mana_used": 91900546,
+            "proving_cost_per_mana_numerator": 1810563151,
+            "fee_asset_price_numerator": 1860952379
+        },
+        "oracle_input": {
+            "proving_cost_modifier": 148258058,
+            "fee_asset_price_modifier": -1000000000
+        },
+        "outputs": {
+            "fee_asset_price_at_execution": 10290227071,
+            "mana_base_fee_components_in_wei": {
+                "data_cost": 0,
+                "gas_cost": 32433997,
+                "proving_cost": 5506130090,
+                "congestion_cost": 20759319767,
+                "congestion_multiplier": 4748141114
+            },
+            "mana_base_fee_components_in_fee_asset": {
+                "data_cost": 0,
+                "gas_cost": 333753193,
+                "proving_cost": 56659328908,
+                "congestion_cost": 213618114241,
+                "congestion_multiplier": 4748141114
+            }
+        }
+    },
+    {
+        "l1_block_number": 20974421,
+        "l1_fees": {
+            "blob_fee": 2,
+            "base_fee": 9523218022
+        },
+        "parent_header": {
+            "excess_mana": 1331412988,
+            "mana_used": 91900546,
+            "proving_cost_per_mana_numerator": 1810563151,
+            "fee_asset_price_numerator": 1860952379
+        },
+        "header": {
+            "excess_mana": 1323313534,
+            "mana_used": 102883709,
+            "proving_cost_per_mana_numerator": 1818236942,
+            "fee_asset_price_numerator": 2187559535
+        },
+        "oracle_input": {
+            "proving_cost_modifier": 7673791,
+            "fee_asset_price_modifier": 326607156
+        },
+        "outputs": {
+            "fee_asset_price_at_execution": 10187837601,
+            "mana_base_fee_components_in_wei": {
+                "data_cost": 0,
+                "gas_cost": 31545659,
+                "proving_cost": 5514299426,
+                "congestion_cost": 20538252740,
+                "congestion_multiplier": 4703358537
+            },
+            "mana_base_fee_components_in_fee_asset": {
+                "data_cost": 0,
+                "gas_cost": 321382050,
+                "proving_cost": 56178787035,
+                "congestion_cost": 209240383523,
+                "congestion_multiplier": 4703358537
+            }
+        }
+    },
+    {
+        "l1_block_number": 20974424,
+        "l1_fees": {
+            "blob_fee": 2,
+            "base_fee": 9104142284
+        },
+        "parent_header": {
+            "excess_mana": 1323313534,
+            "mana_used": 102883709,
+            "proving_cost_per_mana_numerator": 1818236942,
+            "fee_asset_price_numerator": 2187559535
+        },
+        "header": {
+            "excess_mana": 1326197243,
+            "mana_used": 96751216,
+            "proving_cost_per_mana_numerator": 1763396743,
+            "fee_asset_price_numerator": 1387005711
+        },
+        "oracle_input": {
+            "proving_cost_modifier": -54840199,
+            "fee_asset_price_modifier": -800553824
+        },
+        "outputs": {
+            "fee_asset_price_at_execution": 10221166205,
+            "mana_base_fee_components_in_wei": {
+                "data_cost": 0,
+                "gas_cost": 30157471,
+                "proving_cost": 5514722598,
+                "congestion_cost": 20622818401,
+                "congestion_multiplier": 4719254185
+            },
+            "mana_base_fee_components_in_fee_asset": {
+                "data_cost": 0,
+                "gas_cost": 308244523,
+                "proving_cost": 56366896248,
+                "congestion_cost": 210789254492,
+                "congestion_multiplier": 4719254185
+            }
+        }
+    },
+    {
+        "l1_block_number": 20974427,
+        "l1_fees": {
+            "blob_fee": 2,
+            "base_fee": 9433024582
+        },
+        "parent_header": {
+            "excess_mana": 1326197243,
+            "mana_used": 96751216,
+            "proving_cost_per_mana_numerator": 1763396743,
+            "fee_asset_price_numerator": 1387005711
+        },
+        "header": {
+            "excess_mana": 1322948459,
+            "mana_used": 97573641,
+            "proving_cost_per_mana_numerator": 1659879098,
+            "fee_asset_price_numerator": 1287275603
+        },
+        "oracle_input": {
+            "proving_cost_modifier": -103517645,
+            "fee_asset_price_modifier": -99730108
+        },
+        "outputs": {
+            "fee_asset_price_at_execution": 10139666926,
+            "mana_base_fee_components_in_wei": {
+                "data_cost": 0,
+                "gas_cost": 31246893,
+                "proving_cost": 5511699143,
+                "congestion_cost": 20516383221,
+                "congestion_multiplier": 4701349984
+            },
+            "mana_base_fee_components_in_fee_asset": {
+                "data_cost": 0,
+                "gas_cost": 316833087,
+                "proving_cost": 55886793506,
+                "congestion_cost": 208029292387,
+                "congestion_multiplier": 4701349984
+            }
+        }
+    },
+    {
+        "l1_block_number": 20974430,
+        "l1_fees": {
+            "blob_fee": 2,
+            "base_fee": 9577344523
+        },
+        "parent_header": {
+            "excess_mana": 1322948459,
+            "mana_used": 97573641,
+            "proving_cost_per_mana_numerator": 1659879098,
+            "fee_asset_price_numerator": 1287275603
+        },
+        "header": {
+            "excess_mana": 1320522100,
+            "mana_used": 108291556,
+            "proving_cost_per_mana_numerator": 1760133785,
+            "fee_asset_price_numerator": 2109308002
+        },
+        "oracle_input": {
+            "proving_cost_modifier": 100254687,
+            "fee_asset_price_modifier": 822032399
+        },
+        "outputs": {
+            "fee_asset_price_at_execution": 10129559666,
+            "mana_base_fee_components_in_wei": {
+                "data_cost": 0,
+                "gas_cost": 31724953,
+                "proving_cost": 5505996513,
+                "congestion_cost": 20423241531,
+                "congestion_multiplier": 4688022530
+            },
+            "mana_base_fee_components_in_fee_asset": {
+                "data_cost": 0,
+                "gas_cost": 321359804,
+                "proving_cost": 55773320199,
+                "congestion_cost": 206878443661,
+                "congestion_multiplier": 4688022530
+            }
+        }
+    },
+    {
+        "l1_block_number": 20974433,
+        "l1_fees": {
+            "blob_fee": 1,
+            "base_fee": 10362139543
+        },
+        "parent_header": {
+            "excess_mana": 1320522100,
+            "mana_used": 108291556,
+            "proving_cost_per_mana_numerator": 1760133785,
+            "fee_asset_price_numerator": 2109308002
+        },
+        "header": {
+            "excess_mana": 1328813656,
+            "mana_used": 116536020,
+            "proving_cost_per_mana_numerator": 1680519423,
+            "fee_asset_price_numerator": 2585288012
+        },
+        "oracle_input": {
+            "proving_cost_modifier": -79614362,
+            "fee_asset_price_modifier": 475980010
+        },
+        "outputs": {
+            "fee_asset_price_at_execution": 10213171114,
+            "mana_base_fee_components_in_wei": {
+                "data_cost": 0,
+                "gas_cost": 34324587,
+                "proving_cost": 5511519301,
+                "congestion_cost": 20706644413,
+                "congestion_multiplier": 4733722916
+            },
+            "mana_base_fee_components_in_fee_asset": {
+                "data_cost": 0,
+                "gas_cost": 350562880,
+                "proving_cost": 56290089719,
+                "congestion_cost": 211480502586,
+                "congestion_multiplier": 4733722916
+            }
+        }
+    },
+    {
+        "l1_block_number": 20974436,
+        "l1_fees": {
+            "blob_fee": 1,
+            "base_fee": 10406464639
+        },
+        "parent_header": {
+            "excess_mana": 1328813656,
+            "mana_used": 116536020,
+            "proving_cost_per_mana_numerator": 1680519423,
+            "fee_asset_price_numerator": 2585288012
+        },
+        "header": {
+            "excess_mana": 1345349676,
+            "mana_used": 96428044,
+            "proving_cost_per_mana_numerator": 1476676325,
+            "fee_asset_price_numerator": 2439022097
+        },
+        "oracle_input": {
+            "proving_cost_modifier": -203843098,
+            "fee_asset_price_modifier": -146265915
+        },
+        "outputs": {
+            "fee_asset_price_at_execution": 10261899644,
+            "mana_base_fee_components_in_wei": {
+                "data_cost": 0,
+                "gas_cost": 34471414,
+                "proving_cost": 5507133086,
+                "congestion_cost": 21203279479,
+                "congestion_multiplier": 4826198618
+            },
+            "mana_base_fee_components_in_fee_asset": {
+                "data_cost": 0,
+                "gas_cost": 353742191,
+                "proving_cost": 56513647054,
+                "congestion_cost": 217585926137,
+                "congestion_multiplier": 4826198618
+            }
+        }
+    },
+    {
+        "l1_block_number": 20974439,
+        "l1_fees": {
+            "blob_fee": 1,
+            "base_fee": 10104922672
+        },
+        "parent_header": {
+            "excess_mana": 1345349676,
+            "mana_used": 96428044,
+            "proving_cost_per_mana_numerator": 1476676325,
+            "fee_asset_price_numerator": 2439022097
+        },
+        "header": {
+            "excess_mana": 1341777720,
+            "mana_used": 95890772,
+            "proving_cost_per_mana_numerator": 1609085406,
+            "fee_asset_price_numerator": 3126603769
+        },
+        "oracle_input": {
+            "proving_cost_modifier": 132409081,
+            "fee_asset_price_modifier": 687581672
+        },
+        "outputs": {
+            "fee_asset_price_at_execution": 10246900954,
+            "mana_base_fee_components_in_wei": {
+                "data_cost": 0,
+                "gas_cost": 33472556,
+                "proving_cost": 5495918609,
+                "congestion_cost": 21045255974,
+                "congestion_multiplier": 4806071111
+            },
+            "mana_base_fee_components_in_fee_asset": {
+                "data_cost": 0,
+                "gas_cost": 342989966,
+                "proving_cost": 56316133637,
+                "congestion_cost": 215648653517,
+                "congestion_multiplier": 4806071111
+            }
+        }
+    },
+    {
+        "l1_block_number": 20974442,
+        "l1_fees": {
+            "blob_fee": 1,
+            "base_fee": 9965861569
+        },
+        "parent_header": {
+            "excess_mana": 1341777720,
+            "mana_used": 95890772,
+            "proving_cost_per_mana_numerator": 1609085406,
+            "fee_asset_price_numerator": 3126603769
+        },
+        "header": {
+            "excess_mana": 1337668492,
+            "mana_used": 94902476,
+            "proving_cost_per_mana_numerator": 1510544942,
+            "fee_asset_price_numerator": 3479262472
+        },
+        "oracle_input": {
+            "proving_cost_modifier": -98540464,
+            "fee_asset_price_modifier": 352658703
+        },
+        "outputs": {
+            "fee_asset_price_at_execution": 10317599544,
+            "mana_base_fee_components_in_wei": {
+                "data_cost": 0,
+                "gas_cost": 33011916,
+                "proving_cost": 5503200525,
+                "congestion_cost": 20943602139,
+                "congestion_multiplier": 4783019955
+            },
+            "mana_base_fee_components_in_fee_asset": {
+                "data_cost": 0,
+                "gas_cost": 340603729,
+                "proving_cost": 56779819227,
+                "congestion_cost": 216087699879,
+                "congestion_multiplier": 4783019955
+            }
+        }
+    },
+    {
+        "l1_block_number": 20974445,
+        "l1_fees": {
+            "blob_fee": 1,
+            "base_fee": 9453701170
+        },
+        "parent_header": {
+            "excess_mana": 1337668492,
+            "mana_used": 94902476,
+            "proving_cost_per_mana_numerator": 1510544942,
+            "fee_asset_price_numerator": 3479262472
+        },
+        "header": {
+            "excess_mana": 1332570968,
+            "mana_used": 107758024,
+            "proving_cost_per_mana_numerator": 1408425412,
+            "fee_asset_price_numerator": 3570246302
+        },
+        "oracle_input": {
+            "proving_cost_modifier": -102119530,
+            "fee_asset_price_modifier": 90983830
+        },
+        "outputs": {
+            "fee_asset_price_at_execution": 10354049691,
+            "mana_base_fee_components_in_wei": {
+                "data_cost": 0,
+                "gas_cost": 31315385,
+                "proving_cost": 5497780316,
+                "congestion_cost": 20759423456,
+                "congestion_multiplier": 4754578430
+            },
+            "mana_base_fee_components_in_fee_asset": {
+                "data_cost": 0,
+                "gas_cost": 324241052,
+                "proving_cost": 56924290582,
+                "congestion_cost": 214944102019,
+                "congestion_multiplier": 4754578430
+            }
+        }
+    },
+    {
+        "l1_block_number": 20974448,
+        "l1_fees": {
+            "blob_fee": 1,
+            "base_fee": 10049137759
+        },
+        "parent_header": {
+            "excess_mana": 1332570968,
+            "mana_used": 107758024,
+            "proving_cost_per_mana_numerator": 1408425412,
+            "fee_asset_price_numerator": 3570246302
+        },
+        "header": {
+            "excess_mana": 1340328992,
+            "mana_used": 91950513,
+            "proving_cost_per_mana_numerator": 1408723465,
+            "fee_asset_price_numerator": 3283241701
+        },
+        "oracle_input": {
+            "proving_cost_modifier": 298053,
+            "fee_asset_price_modifier": -287004601
+        },
+        "outputs": {
+            "fee_asset_price_at_execution": 10363474489,
+            "mana_base_fee_components_in_wei": {
+                "data_cost": 0,
+                "gas_cost": 33287768,
+                "proving_cost": 5492168875,
+                "congestion_cost": 20985306748,
+                "congestion_multiplier": 4797931665
+            },
+            "mana_base_fee_components_in_fee_asset": {
+                "data_cost": 0,
+                "gas_cost": 344976934,
+                "proving_cost": 56917952025,
+                "congestion_cost": 217480691126,
+                "congestion_multiplier": 4797931665
+            }
+        }
+    },
+    {
+        "l1_block_number": 20974451,
+        "l1_fees": {
+            "blob_fee": 1,
+            "base_fee": 9689451624
+        },
+        "parent_header": {
+            "excess_mana": 1340328992,
+            "mana_used": 91950513,
+            "proving_cost_per_mana_numerator": 1408723465,
+            "fee_asset_price_numerator": 3283241701
+        },
+        "header": {
+            "excess_mana": 1332279505,
+            "mana_used": 83167517,
+            "proving_cost_per_mana_numerator": 1481314433,
+            "fee_asset_price_numerator": 2985347824
+        },
+        "oracle_input": {
+            "proving_cost_modifier": 72590968,
+            "fee_asset_price_modifier": -297893877
+        },
+        "outputs": {
+            "fee_asset_price_at_execution": 10333773482,
+            "mana_base_fee_components_in_wei": {
+                "data_cost": 0,
+                "gas_cost": 32096308,
+                "proving_cost": 5492185244,
+                "congestion_cost": 20732392993,
+                "congestion_multiplier": 4752957339
+            },
+            "mana_base_fee_components_in_fee_asset": {
+                "data_cost": 0,
+                "gas_cost": 331675976,
+                "proving_cost": 56754998232,
+                "congestion_cost": 214243852929,
+                "congestion_multiplier": 4752957339
+            }
+        }
+    },
+    {
+        "l1_block_number": 20974454,
+        "l1_fees": {
+            "blob_fee": 1,
+            "base_fee": 9132012958
+        },
+        "parent_header": {
+            "excess_mana": 1332279505,
+            "mana_used": 83167517,
+            "proving_cost_per_mana_numerator": 1481314433,
+            "fee_asset_price_numerator": 2985347824
+        },
+        "header": {
+            "excess_mana": 1315447022,
+            "mana_used": 104540142,
+            "proving_cost_per_mana_numerator": 1485447414,
+            "fee_asset_price_numerator": 3115043922
+        },
+        "oracle_input": {
+            "proving_cost_modifier": 4132981,
+            "fee_asset_price_modifier": 129696098
+        },
+        "outputs": {
+            "fee_asset_price_at_execution": 10303035610,
+            "mana_base_fee_components_in_wei": {
+                "data_cost": 0,
+                "gas_cost": 30249792,
+                "proving_cost": 5496173522,
+                "congestion_cost": 20228191947,
+                "congestion_multiplier": 4660268278
+            },
+            "mana_base_fee_components_in_fee_asset": {
+                "data_cost": 0,
+                "gas_cost": 311664684,
+                "proving_cost": 56627271515,
+                "congestion_cost": 208411781955,
+                "congestion_multiplier": 4660268278
+            }
+        }
+    },
+    {
+        "l1_block_number": 20974457,
+        "l1_fees": {
+            "blob_fee": 1,
+            "base_fee": 9109047599
+        },
+        "parent_header": {
+            "excess_mana": 1315447022,
+            "mana_used": 104540142,
+            "proving_cost_per_mana_numerator": 1485447414,
+            "fee_asset_price_numerator": 3115043922
+        },
+        "header": {
+            "excess_mana": 1319987164,
+            "mana_used": 98613846,
+            "proving_cost_per_mana_numerator": 1619719960,
+            "fee_asset_price_numerator": 4071641001
+        },
+        "oracle_input": {
+            "proving_cost_modifier": 134272546,
+            "fee_asset_price_modifier": 956597079
+        },
+        "outputs": {
+            "fee_asset_price_at_execution": 10316406914,
+            "mana_base_fee_components_in_wei": {
+                "data_cost": 0,
+                "gas_cost": 30173720,
+                "proving_cost": 5496400683,
+                "congestion_cost": 20365920369,
+                "congestion_multiplier": 4685089331
+            },
+            "mana_base_fee_components_in_fee_asset": {
+                "data_cost": 0,
+                "gas_cost": 311284373,
+                "proving_cost": 56703106008,
+                "congestion_cost": 210103121704,
+                "congestion_multiplier": 4685089331
+            }
+        }
+    },
+    {
+        "l1_block_number": 20974460,
+        "l1_fees": {
+            "blob_fee": 1,
+            "base_fee": 9238199253
+        },
+        "parent_header": {
+            "excess_mana": 1319987164,
+            "mana_used": 98613846,
+            "proving_cost_per_mana_numerator": 1619719960,
+            "fee_asset_price_numerator": 4071641001
+        },
+        "header": {
+            "excess_mana": 1318601010,
+            "mana_used": 93569588,
+            "proving_cost_per_mana_numerator": 1534217900,
+            "fee_asset_price_numerator": 4385474010
+        },
+        "oracle_input": {
+            "proving_cost_modifier": -85502060,
+            "fee_asset_price_modifier": 313833009
+        },
+        "outputs": {
+            "fee_asset_price_at_execution": 10415566886,
+            "mana_base_fee_components_in_wei": {
+                "data_cost": 0,
+                "gas_cost": 30601535,
+                "proving_cost": 5503785797,
+                "congestion_cost": 20352693978,
+                "congestion_multiplier": 4677497211
+            },
+            "mana_base_fee_components_in_fee_asset": {
+                "data_cost": 0,
+                "gas_cost": 318732334,
+                "proving_cost": 57325049094,
+                "congestion_cost": 211984845438,
+                "congestion_multiplier": 4677497211
+            }
+        }
+    },
+    {
+        "l1_block_number": 20974463,
+        "l1_fees": {
+            "blob_fee": 1,
+            "base_fee": 9135208521
+        },
+        "parent_header": {
+            "excess_mana": 1318601010,
+            "mana_used": 93569588,
+            "proving_cost_per_mana_numerator": 1534217900,
+            "fee_asset_price_numerator": 4385474010
+        },
+        "header": {
+            "excess_mana": 1312170598,
+            "mana_used": 101029045,
+            "proving_cost_per_mana_numerator": 1496951851,
+            "fee_asset_price_numerator": 4427090165
+        },
+        "oracle_input": {
+            "proving_cost_modifier": -37266049,
+            "fee_asset_price_modifier": 41616155
+        },
+        "outputs": {
+            "fee_asset_price_at_execution": 10448305718,
+            "mana_base_fee_components_in_wei": {
+                "data_cost": 0,
+                "gas_cost": 30260378,
+                "proving_cost": 5499081958,
+                "congestion_cost": 20140285141,
+                "congestion_multiplier": 4642437729
+            },
+            "mana_base_fee_components_in_fee_asset": {
+                "data_cost": 0,
+                "gas_cost": 316169680,
+                "proving_cost": 57456089465,
+                "congestion_cost": 210431856400,
+                "congestion_multiplier": 4642437729
+            }
+        }
+    },
+    {
+        "l1_block_number": 20974466,
+        "l1_fees": {
+            "blob_fee": 1,
+            "base_fee": 9109919091
+        },
+        "parent_header": {
+            "excess_mana": 1312170598,
+            "mana_used": 101029045,
+            "proving_cost_per_mana_numerator": 1496951851,
+            "fee_asset_price_numerator": 4427090165
+        },
+        "header": {
+            "excess_mana": 1313199643,
+            "mana_used": 103381370,
+            "proving_cost_per_mana_numerator": 1456521830,
+            "fee_asset_price_numerator": 4554855911
+        },
+        "oracle_input": {
+            "proving_cost_modifier": -40430021,
+            "fee_asset_price_modifier": 127765746
+        },
+        "outputs": {
+            "fee_asset_price_at_execution": 10452654806,
+            "mana_base_fee_components_in_wei": {
+                "data_cost": 0,
+                "gas_cost": 30176606,
+                "proving_cost": 5497033049,
+                "congestion_cost": 20163429451,
+                "congestion_multiplier": 4648030509
+            },
+            "mana_base_fee_components_in_fee_asset": {
+                "data_cost": 0,
+                "gas_cost": 315425645,
+                "proving_cost": 57458588918,
+                "congestion_cost": 210761367756,
+                "congestion_multiplier": 4648030509
+            }
+        }
+    },
+    {
+        "l1_block_number": 20974469,
+        "l1_fees": {
+            "blob_fee": 1,
+            "base_fee": 9426312134
+        },
+        "parent_header": {
+            "excess_mana": 1313199643,
+            "mana_used": 103381370,
+            "proving_cost_per_mana_numerator": 1456521830,
+            "fee_asset_price_numerator": 4554855911
+        },
+        "header": {
+            "excess_mana": 1316581013,
+            "mana_used": 93119606,
+            "proving_cost_per_mana_numerator": 1383332186,
+            "fee_asset_price_numerator": 4852570946
+        },
+        "oracle_input": {
+            "proving_cost_modifier": -73189644,
+            "fee_asset_price_modifier": 297715035
+        },
+        "outputs": {
+            "fee_asset_price_at_execution": 10466018254,
+            "mana_base_fee_components_in_wei": {
+                "data_cost": 0,
+                "gas_cost": 31224658,
+                "proving_cost": 5494811046,
+                "congestion_cost": 20260963906,
+                "congestion_multiplier": 4666455483
+            },
+            "mana_base_fee_components_in_fee_asset": {
+                "data_cost": 0,
+                "gas_cost": 326797840,
+                "proving_cost": 57508792709,
+                "congestion_cost": 212051618083,
+                "congestion_multiplier": 4666455483
+            }
+        }
+    },
+    {
+        "l1_block_number": 20974472,
+        "l1_fees": {
+            "blob_fee": 1,
+            "base_fee": 8424055996
+        },
+        "parent_header": {
+            "excess_mana": 1316581013,
+            "mana_used": 93119606,
+            "proving_cost_per_mana_numerator": 1383332186,
+            "fee_asset_price_numerator": 4852570946
+        },
+        "header": {
+            "excess_mana": 1309700619,
+            "mana_used": 109263041,
+            "proving_cost_per_mana_numerator": 1365258008,
+            "fee_asset_price_numerator": 4182988274
+        },
+        "oracle_input": {
+            "proving_cost_modifier": -18074178,
+            "fee_asset_price_modifier": -669582672
+        },
+        "outputs": {
+            "fee_asset_price_at_execution": 10497223592,
+            "mana_base_fee_components_in_wei": {
+                "data_cost": 0,
+                "gas_cost": 27904685,
+                "proving_cost": 5490790885,
+                "congestion_cost": 20027572650,
+                "congestion_multiplier": 4629041029
+            },
+            "mana_base_fee_components_in_fee_asset": {
+                "data_cost": 0,
+                "gas_cost": 292921717,
+                "proving_cost": 57638059616,
+                "congestion_cost": 210233908112,
+                "congestion_multiplier": 4629041029
+            }
+        }
+    },
+    {
+        "l1_block_number": 20974475,
+        "l1_fees": {
+            "blob_fee": 1,
+            "base_fee": 9204460195
+        },
+        "parent_header": {
+            "excess_mana": 1309700619,
+            "mana_used": 109263041,
+            "proving_cost_per_mana_numerator": 1365258008,
+            "fee_asset_price_numerator": 4182988274
+        },
+        "header": {
+            "excess_mana": 1318963660,
+            "mana_used": 86270240,
+            "proving_cost_per_mana_numerator": 1280812819,
+            "fee_asset_price_numerator": 4367269688
+        },
+        "oracle_input": {
+            "proving_cost_modifier": -84445189,
+            "fee_asset_price_modifier": 184281414
+        },
+        "outputs": {
+            "fee_asset_price_at_execution": 10427170794,
+            "mana_base_fee_components_in_wei": {
+                "data_cost": 0,
+                "gas_cost": 30489774,
+                "proving_cost": 5489798560,
+                "congestion_cost": 20311803193,
+                "congestion_multiplier": 4679482296
+            },
+            "mana_base_fee_components_in_fee_asset": {
+                "data_cost": 0,
+                "gas_cost": 317922080,
+                "proving_cost": 57243067209,
+                "congestion_cost": 211794641027,
+                "congestion_multiplier": 4679482296
+            }
+        }
+    },
+    {
+        "l1_block_number": 20974478,
+        "l1_fees": {
+            "blob_fee": 1,
+            "base_fee": 8598622425
+        },
+        "parent_header": {
+            "excess_mana": 1318963660,
+            "mana_used": 86270240,
+            "proving_cost_per_mana_numerator": 1280812819,
+            "fee_asset_price_numerator": 4367269688
+        },
+        "header": {
+            "excess_mana": 1305233900,
+            "mana_used": 122448599,
+            "proving_cost_per_mana_numerator": 1339381969,
+            "fee_asset_price_numerator": 5366579735
+        },
+        "oracle_input": {
+            "proving_cost_modifier": 58569150,
+            "fee_asset_price_modifier": 999310047
+        },
+        "outputs": {
+            "fee_asset_price_at_execution": 10446403848,
+            "mana_base_fee_components_in_wei": {
+                "data_cost": 0,
+                "gas_cost": 28482936,
+                "proving_cost": 5485164646,
+                "congestion_cost": 19876216978,
+                "congestion_multiplier": 4604912480
+            },
+            "mana_base_fee_components_in_fee_asset": {
+                "data_cost": 0,
+                "gas_cost": 297544252,
+                "proving_cost": 57300245064,
+                "congestion_cost": 207634989522,
+                "congestion_multiplier": 4604912480
+            }
+        }
+    },
+    {
+        "l1_block_number": 20974481,
+        "l1_fees": {
+            "blob_fee": 1,
+            "base_fee": 9667058305
+        },
+        "parent_header": {
+            "excess_mana": 1305233900,
+            "mana_used": 122448599,
+            "proving_cost_per_mana_numerator": 1339381969,
+            "fee_asset_price_numerator": 5366579735
+        },
+        "header": {
+            "excess_mana": 1327682499,
+            "mana_used": 93784845,
+            "proving_cost_per_mana_numerator": 1302285571,
+            "fee_asset_price_numerator": 5548916077
+        },
+        "oracle_input": {
+            "proving_cost_modifier": -37096398,
+            "fee_asset_price_modifier": 182336342
+        },
+        "outputs": {
+            "fee_asset_price_at_execution": 10551319153,
+            "mana_base_fee_components_in_wei": {
+                "data_cost": 0,
+                "gas_cost": 32022130,
+                "proving_cost": 5488378201,
+                "congestion_cost": 20577083540,
+                "congestion_multiplier": 4727462196
+            },
+            "mana_base_fee_components_in_fee_asset": {
+                "data_cost": 0,
+                "gas_cost": 337875713,
+                "proving_cost": 57909630031,
+                "congestion_cost": 217115375668,
+                "congestion_multiplier": 4727462196
+            }
+        }
+    },
+    {
+        "l1_block_number": 20974484,
+        "l1_fees": {
+            "blob_fee": 1,
+            "base_fee": 10311092960
+        },
+        "parent_header": {
+            "excess_mana": 1327682499,
+            "mana_used": 93784845,
+            "proving_cost_per_mana_numerator": 1302285571,
+            "fee_asset_price_numerator": 5548916077
+        },
+        "header": {
+            "excess_mana": 1321467344,
+            "mana_used": 65246777,
+            "proving_cost_per_mana_numerator": 1238088312,
+            "fee_asset_price_numerator": 4997963835
+        },
+        "oracle_input": {
+            "proving_cost_modifier": -64197259,
+            "fee_asset_price_modifier": -550952242
+        },
+        "outputs": {
+            "fee_asset_price_at_execution": 10570575593,
+            "mana_base_fee_components_in_wei": {
+                "data_cost": 0,
+                "gas_cost": 34155495,
+                "proving_cost": 5486342588,
+                "congestion_cost": 20388358990,
+                "congestion_multiplier": 4693210048
+            },
+            "mana_base_fee_components_in_fee_asset": {
+                "data_cost": 0,
+                "gas_cost": 361043241,
+                "proving_cost": 57993799055,
+                "congestion_cost": 215516689921,
+                "congestion_multiplier": 4693210048
+            }
+        }
+    },
+    {
+        "l1_block_number": 20974487,
+        "l1_fees": {
+            "blob_fee": 1,
+            "base_fee": 9964934537
+        },
+        "parent_header": {
+            "excess_mana": 1321467344,
+            "mana_used": 65246777,
+            "proving_cost_per_mana_numerator": 1238088312,
+            "fee_asset_price_numerator": 4997963835
+        },
+        "header": {
+            "excess_mana": 1286714121,
+            "mana_used": 129539692,
+            "proving_cost_per_mana_numerator": 1255659249,
+            "fee_asset_price_numerator": 4985871086
+        },
+        "oracle_input": {
+            "proving_cost_modifier": 17570937,
+            "fee_asset_price_modifier": -12092749
+        },
+        "outputs": {
+            "fee_asset_price_at_execution": 10512496909,
+            "mana_base_fee_components_in_wei": {
+                "data_cost": 0,
+                "gas_cost": 33008845,
+                "proving_cost": 5482821637,
+                "congestion_cost": 19339637059,
+                "congestion_multiplier": 4506205842
+            },
+            "mana_base_fee_components_in_fee_asset": {
+                "data_cost": 0,
+                "gas_cost": 347005381,
+                "proving_cost": 57638145511,
+                "congestion_cost": 203307874803,
+                "congestion_multiplier": 4506205842
+            }
+        }
+    },
+    {
+        "l1_block_number": 20974490,
+        "l1_fees": {
+            "blob_fee": 1,
+            "base_fee": 10147307115
+        },
+        "parent_header": {
+            "excess_mana": 1286714121,
+            "mana_used": 129539692,
+            "proving_cost_per_mana_numerator": 1255659249,
+            "fee_asset_price_numerator": 4985871086
+        },
+        "header": {
+            "excess_mana": 1316253813,
+            "mana_used": 107842618,
+            "proving_cost_per_mana_numerator": 1343886692,
+            "fee_asset_price_numerator": 4131913707
+        },
+        "oracle_input": {
+            "proving_cost_modifier": 88227443,
+            "fee_asset_price_modifier": -853957379
+        },
+        "outputs": {
+            "fee_asset_price_at_execution": 10511225736,
+            "mana_base_fee_components_in_wei": {
+                "data_cost": 0,
+                "gas_cost": 33612954,
+                "proving_cost": 5483785104,
+                "congestion_cost": 20219439797,
+                "congestion_multiplier": 4664669394
+            },
+            "mana_base_fee_components_in_fee_asset": {
+                "data_cost": 0,
+                "gas_cost": 353313347,
+                "proving_cost": 57641303115,
+                "congestion_cost": 212531095961,
+                "congestion_multiplier": 4664669394
+            }
+        }
+    },
+    {
+        "l1_block_number": 20974493,
+        "l1_fees": {
+            "blob_fee": 1,
+            "base_fee": 9938782318
+        },
+        "parent_header": {
+            "excess_mana": 1316253813,
+            "mana_used": 107842618,
+            "proving_cost_per_mana_numerator": 1343886692,
+            "fee_asset_price_numerator": 4131913707
+        },
+        "header": {
+            "excess_mana": 1324096431,
+            "mana_used": 112543554,
+            "proving_cost_per_mana_numerator": 1347111084,
+            "fee_asset_price_numerator": 3921942167
+        },
+        "oracle_input": {
+            "proving_cost_modifier": 3224392,
+            "fee_asset_price_modifier": -209971540
+        },
+        "outputs": {
+            "fee_asset_price_at_execution": 10421846522,
+            "mana_base_fee_components_in_wei": {
+                "data_cost": 0,
+                "gas_cost": 32922216,
+                "proving_cost": 5488625443,
+                "congestion_cost": 20472069640,
+                "congestion_multiplier": 4707668738
+            },
+            "mana_base_fee_components_in_fee_asset": {
+                "data_cost": 0,
+                "gas_cost": 343110282,
+                "proving_cost": 57201611983,
+                "congestion_cost": 213356767775,
+                "congestion_multiplier": 4707668738
+            }
+        }
+    },
+    {
+        "l1_block_number": 20974496,
+        "l1_fees": {
+            "blob_fee": 1,
+            "base_fee": 9644897398
+        },
+        "parent_header": {
+            "excess_mana": 1324096431,
+            "mana_used": 112543554,
+            "proving_cost_per_mana_numerator": 1347111084,
+            "fee_asset_price_numerator": 3921942167
+        },
+        "header": {
+            "excess_mana": 1336639985,
+            "mana_used": 73408546,
+            "proving_cost_per_mana_numerator": 1278285869,
+            "fee_asset_price_numerator": 3955137169
+        },
+        "oracle_input": {
+            "proving_cost_modifier": -68825215,
+            "fee_asset_price_modifier": 33195002
+        },
+        "outputs": {
+            "fee_asset_price_at_execution": 10399986568,
+            "mana_base_fee_components_in_wei": {
+                "data_cost": 0,
+                "gas_cost": 31948722,
+                "proving_cost": 5488802420,
+                "congestion_cost": 20853355272,
+                "congestion_multiplier": 4777267755
+            },
+            "mana_base_fee_components_in_fee_asset": {
+                "data_cost": 0,
+                "gas_cost": 332266279,
+                "proving_cost": 57083471442,
+                "congestion_cost": 216874614726,
+                "congestion_multiplier": 4777267755
+            }
+        }
+    },
+    {
+        "l1_block_number": 20974499,
+        "l1_fees": {
+            "blob_fee": 1,
+            "base_fee": 9683030291
+        },
+        "parent_header": {
+            "excess_mana": 1336639985,
+            "mana_used": 73408546,
+            "proving_cost_per_mana_numerator": 1278285869,
+            "fee_asset_price_numerator": 3955137169
+        },
+        "header": {
+            "excess_mana": 1310048531,
+            "mana_used": 113343265,
+            "proving_cost_per_mana_numerator": 1214917640,
+            "fee_asset_price_numerator": 3560832675
+        },
+        "oracle_input": {
+            "proving_cost_modifier": -63368229,
+            "fee_asset_price_modifier": -394304494
+        },
+        "outputs": {
+            "fee_asset_price_at_execution": 10403439417,
+            "mana_base_fee_components_in_wei": {
+                "data_cost": 0,
+                "gas_cost": 32075037,
+                "proving_cost": 5485026040,
+                "congestion_cost": 20032184067,
+                "congestion_multiplier": 4630925696
+            },
+            "mana_base_fee_components_in_fee_asset": {
+                "data_cost": 0,
+                "gas_cost": 333690704,
+                "proving_cost": 57063136107,
+                "congestion_cost": 208403613331,
+                "congestion_multiplier": 4630925696
+            }
+        }
+    },
+    {
+        "l1_block_number": 20974502,
+        "l1_fees": {
+            "blob_fee": 1,
+            "base_fee": 11058719709
+        },
+        "parent_header": {
+            "excess_mana": 1310048531,
+            "mana_used": 113343265,
+            "proving_cost_per_mana_numerator": 1214917640,
+            "fee_asset_price_numerator": 3560832675
+        },
+        "header": {
+            "excess_mana": 1323391796,
+            "mana_used": 94371501,
+            "proving_cost_per_mana_numerator": 1081226248,
+            "fee_asset_price_numerator": 3698989537
+        },
+        "oracle_input": {
+            "proving_cost_modifier": -133691392,
+            "fee_asset_price_modifier": 138156862
+        },
+        "outputs": {
+            "fee_asset_price_at_execution": 10362498956,
+            "mana_base_fee_components_in_wei": {
+                "data_cost": 0,
+                "gas_cost": 36632009,
+                "proving_cost": 5481551377,
+                "congestion_cost": 20438188177,
+                "congestion_multiplier": 4703789227
+            },
+            "mana_base_fee_components_in_fee_asset": {
+                "data_cost": 0,
+                "gas_cost": 379599155,
+                "proving_cost": 56802570421,
+                "congestion_cost": 211790703646,
+                "congestion_multiplier": 4703789227
+            }
+        }
+    },
+    {
+        "l1_block_number": 20974505,
+        "l1_fees": {
+            "blob_fee": 1,
+            "base_fee": 12997295205
+        },
+        "parent_header": {
+            "excess_mana": 1323391796,
+            "mana_used": 94371501,
+            "proving_cost_per_mana_numerator": 1081226248,
+            "fee_asset_price_numerator": 3698989537
+        },
+        "header": {
+            "excess_mana": 1317763297,
+            "mana_used": 93168662,
+            "proving_cost_per_mana_numerator": 1085933046,
+            "fee_asset_price_numerator": 3297057904
+        },
+        "oracle_input": {
+            "proving_cost_modifier": 4706798,
+            "fee_asset_price_modifier": -401931633
+        },
+        "outputs": {
+            "fee_asset_price_at_execution": 10376825353,
+            "mana_base_fee_components_in_wei": {
+                "data_cost": 0,
+                "gas_cost": 43053540,
+                "proving_cost": 5474227911,
+                "congestion_cost": 20264505403,
+                "congestion_multiplier": 4672914928
+            },
+            "mana_base_fee_components_in_fee_asset": {
+                "data_cost": 0,
+                "gas_cost": 446759065,
+                "proving_cost": 56805106974,
+                "congestion_cost": 210281233431,
+                "congestion_multiplier": 4672914928
+            }
+        }
+    },
+    {
+        "l1_block_number": 20974508,
+        "l1_fees": {
+            "blob_fee": 1,
+            "base_fee": 12529147099
+        },
+        "parent_header": {
+            "excess_mana": 1317763297,
+            "mana_used": 93168662,
+            "proving_cost_per_mana_numerator": 1085933046,
+            "fee_asset_price_numerator": 3297057904
+        },
+        "header": {
+            "excess_mana": 1310931959,
+            "mana_used": 93314520,
+            "proving_cost_per_mana_numerator": 1078558840,
+            "fee_asset_price_numerator": 2473855109
+        },
+        "oracle_input": {
+            "proving_cost_modifier": -7374206,
+            "fee_asset_price_modifier": -823202795
+        },
+        "outputs": {
+            "fee_asset_price_at_execution": 10335201316,
+            "mana_base_fee_components_in_wei": {
+                "data_cost": 0,
+                "gas_cost": 41502799,
+                "proving_cost": 5474485578,
+                "congestion_cost": 20054560275,
+                "congestion_multiplier": 4635714745
+            },
+            "mana_base_fee_components_in_fee_asset": {
+                "data_cost": 0,
+                "gas_cost": 428939782,
+                "proving_cost": 56579910550,
+                "congestion_cost": 207267917745,
+                "congestion_multiplier": 4635714745
+            }
+        }
+    },
+    {
+        "l1_block_number": 20974511,
+        "l1_fees": {
+            "blob_fee": 1,
+            "base_fee": 10526750513
+        },
+        "parent_header": {
+            "excess_mana": 1310931959,
+            "mana_used": 93314520,
+            "proving_cost_per_mana_numerator": 1078558840,
+            "fee_asset_price_numerator": 2473855109
+        },
+        "header": {
+            "excess_mana": 1304246479,
+            "mana_used": 103896298,
+            "proving_cost_per_mana_numerator": 1029046373,
+            "fee_asset_price_numerator": 1930554124
+        },
+        "oracle_input": {
+            "proving_cost_modifier": -49512467,
+            "fee_asset_price_modifier": -543300985
+        },
+        "outputs": {
+            "fee_asset_price_at_execution": 10250470880,
+            "mana_base_fee_components_in_wei": {
+                "data_cost": 0,
+                "gas_cost": 34869861,
+                "proving_cost": 5474081893,
+                "congestion_cost": 19829998367,
+                "congestion_multiplier": 4599595577
+            },
+            "mana_base_fee_components_in_fee_asset": {
+                "data_cost": 0,
+                "gas_cost": 357432494,
+                "proving_cost": 56111917038,
+                "congestion_cost": 203266820811,
+                "congestion_multiplier": 4599595577
+            }
+        }
+    },
+    {
+        "l1_block_number": 20974514,
+        "l1_fees": {
+            "blob_fee": 1,
+            "base_fee": 11093378624
+        },
+        "parent_header": {
+            "excess_mana": 1304246479,
+            "mana_used": 103896298,
+            "proving_cost_per_mana_numerator": 1029046373,
+            "fee_asset_price_numerator": 1930554124
+        },
+        "header": {
+            "excess_mana": 1308142777,
+            "mana_used": 117487149,
+            "proving_cost_per_mana_numerator": 984241441,
+            "fee_asset_price_numerator": 2186396974
+        },
+        "oracle_input": {
+            "proving_cost_modifier": -44804932,
+            "fee_asset_price_modifier": 255842850
+        },
+        "outputs": {
+            "fee_asset_price_at_execution": 10194930982,
+            "mana_base_fee_components_in_wei": {
+                "data_cost": 0,
+                "gas_cost": 36746816,
+                "proving_cost": 5471372211,
+                "congestion_cost": 19942758954,
+                "congestion_multiplier": 4620611475
+            },
+            "mana_base_fee_components_in_fee_asset": {
+                "data_cost": 0,
+                "gas_cost": 374631252,
+                "proving_cost": 55780262067,
+                "congestion_cost": 203315051126,
+                "congestion_multiplier": 4620611475
+            }
+        }
+    },
+    {
+        "l1_block_number": 20974517,
+        "l1_fees": {
+            "blob_fee": 1,
+            "base_fee": 10637397356
+        },
+        "parent_header": {
+            "excess_mana": 1308142777,
+            "mana_used": 117487149,
+            "proving_cost_per_mana_numerator": 984241441,
+            "fee_asset_price_numerator": 2186396974
+        },
+        "header": {
+            "excess_mana": 1325629926,
+            "mana_used": 96366063,
+            "proving_cost_per_mana_numerator": 962580842,
+            "fee_asset_price_numerator": 2295853999
+        },
+        "oracle_input": {
+            "proving_cost_modifier": -21660599,
+            "fee_asset_price_modifier": 109457025
+        },
+        "outputs": {
+            "fee_asset_price_at_execution": 10221047378,
+            "mana_base_fee_components_in_wei": {
+                "data_cost": 0,
+                "gas_cost": 35236378,
+                "proving_cost": 5468921316,
+                "congestion_cost": 20454125725,
+                "congestion_multiplier": 4716122768
+            },
+            "mana_base_fee_components_in_fee_asset": {
+                "data_cost": 0,
+                "gas_cost": 360152688,
+                "proving_cost": 55898103877,
+                "congestion_cost": 209062588110,
+                "congestion_multiplier": 4716122768
+            }
+        }
+    },
+    {
+        "l1_block_number": 20974520,
+        "l1_fees": {
+            "blob_fee": 1,
+            "base_fee": 10064163696
+        },
+        "parent_header": {
+            "excess_mana": 1325629926,
+            "mana_used": 96366063,
+            "proving_cost_per_mana_numerator": 962580842,
+            "fee_asset_price_numerator": 2295853999
+        },
+        "header": {
+            "excess_mana": 1321995989,
+            "mana_used": 104057436,
+            "proving_cost_per_mana_numerator": 1102561637,
+            "fee_asset_price_numerator": 2044244503
+        },
+        "oracle_input": {
+            "proving_cost_modifier": 139980795,
+            "fee_asset_price_modifier": -251609496
+        },
+        "outputs": {
+            "fee_asset_price_at_execution": 10232241157,
+            "mana_base_fee_components_in_wei": {
+                "data_cost": 0,
+                "gas_cost": 33337542,
+                "proving_cost": 5467736843,
+                "congestion_cost": 20332596762,
+                "congestion_multiplier": 4696113766
+            },
+            "mana_base_fee_components_in_fee_asset": {
+                "data_cost": 0,
+                "gas_cost": 341117769,
+                "proving_cost": 55947201960,
+                "congestion_cost": 208048033416,
+                "congestion_multiplier": 4696113766
+            }
+        }
+    },
+    {
+        "l1_block_number": 20974523,
+        "l1_fees": {
+            "blob_fee": 1,
+            "base_fee": 11907531280
+        },
+        "parent_header": {
+            "excess_mana": 1321995989,
+            "mana_used": 104057436,
+            "proving_cost_per_mana_numerator": 1102561637,
+            "fee_asset_price_numerator": 2044244503
+        },
+        "header": {
+            "excess_mana": 1326053425,
+            "mana_used": 102990842,
+            "proving_cost_per_mana_numerator": 1166748460,
+            "fee_asset_price_numerator": 1690058727
+        },
+        "oracle_input": {
+            "proving_cost_modifier": 64186823,
+            "fee_asset_price_modifier": -354185776
+        },
+        "outputs": {
+            "fee_asset_price_at_execution": 10206528229,
+            "mana_base_fee_components_in_wei": {
+                "data_cost": 0,
+                "gas_cost": 39443697,
+                "proving_cost": 5475395984,
+                "congestion_cost": 20506711626,
+                "congestion_multiplier": 4718460157
+            },
+            "mana_base_fee_components_in_fee_asset": {
+                "data_cost": 0,
+                "gas_cost": 402583206,
+                "proving_cost": 55884783675,
+                "congestion_cost": 209302331094,
+                "congestion_multiplier": 4718460157
+            }
+        }
+    },
+    {
+        "l1_block_number": 20974526,
+        "l1_fees": {
+            "blob_fee": 1,
+            "base_fee": 11019213472
+        },
+        "parent_header": {
+            "excess_mana": 1326053425,
+            "mana_used": 102990842,
+            "proving_cost_per_mana_numerator": 1166748460,
+            "fee_asset_price_numerator": 1690058727
+        },
+        "header": {
+            "excess_mana": 1329044267,
+            "mana_used": 107221657,
+            "proving_cost_per_mana_numerator": 1228517743,
+            "fee_asset_price_numerator": 1122668389
+        },
+        "oracle_input": {
+            "proving_cost_modifier": 61769283,
+            "fee_asset_price_modifier": -567390338
+        },
+        "outputs": {
+            "fee_asset_price_at_execution": 10170442101,
+            "mana_base_fee_components_in_wei": {
+                "data_cost": 0,
+                "gas_cost": 36501144,
+                "proving_cost": 5478911595,
+                "congestion_cost": 20600068328,
+                "congestion_multiplier": 4735000317
+            },
+            "mana_base_fee_components_in_fee_asset": {
+                "data_cost": 0,
+                "gas_cost": 371232771,
+                "proving_cost": 55722953153,
+                "congestion_cost": 209511802206,
+                "congestion_multiplier": 4735000317
+            }
+        }
+    },
+    {
+        "l1_block_number": 20974529,
+        "l1_fees": {
+            "blob_fee": 1,
+            "base_fee": 11135880229
+        },
+        "parent_header": {
+            "excess_mana": 1329044267,
+            "mana_used": 107221657,
+            "proving_cost_per_mana_numerator": 1228517743,
+            "fee_asset_price_numerator": 1122668389
+        },
+        "header": {
+            "excess_mana": 1336265924,
+            "mana_used": 91764333,
+            "proving_cost_per_mana_numerator": 1208026504,
+            "fee_asset_price_numerator": 1888536575
+        },
+        "oracle_input": {
+            "proving_cost_modifier": -20491239,
+            "fee_asset_price_modifier": 765868186
+        },
+        "outputs": {
+            "fee_asset_price_at_execution": 10112899396,
+            "mana_base_fee_components_in_wei": {
+                "data_cost": 0,
+                "gas_cost": 36887603,
+                "proving_cost": 5482296924,
+                "congestion_cost": 20835900880,
+                "congestion_multiplier": 4775177434
+            },
+            "mana_base_fee_components_in_fee_asset": {
+                "data_cost": 0,
+                "gas_cost": 373040618,
+                "proving_cost": 55441917251,
+                "congestion_cost": 210711369424,
+                "congestion_multiplier": 4775177434
+            }
+        }
+    },
+    {
+        "l1_block_number": 20974532,
+        "l1_fees": {
+            "blob_fee": 1,
+            "base_fee": 10401645769
+        },
+        "parent_header": {
+            "excess_mana": 1336265924,
+            "mana_used": 91764333,
+            "proving_cost_per_mana_numerator": 1208026504,
+            "fee_asset_price_numerator": 1888536575
+        },
+        "header": {
+            "excess_mana": 1328030257,
+            "mana_used": 87902892,
+            "proving_cost_per_mana_numerator": 1200128277,
+            "fee_asset_price_numerator": 1941013105
+        },
+        "oracle_input": {
+            "proving_cost_modifier": -7898227,
+            "fee_asset_price_modifier": 52476530
+        },
+        "outputs": {
+            "fee_asset_price_at_execution": 10190648221,
+            "mana_base_fee_components_in_wei": {
+                "data_cost": 0,
+                "gas_cost": 34455451,
+                "proving_cost": 5481173649,
+                "congestion_cost": 20569910404,
+                "congestion_multiplier": 4729386083
+            },
+            "mana_base_fee_components_in_fee_asset": {
+                "data_cost": 0,
+                "gas_cost": 351123380,
+                "proving_cost": 55856712495,
+                "congestion_cost": 209620720864,
+                "congestion_multiplier": 4729386083
+            }
+        }
+    },
+    {
+        "l1_block_number": 20974535,
+        "l1_fees": {
+            "blob_fee": 1,
+            "base_fee": 11090844407
+        },
+        "parent_header": {
+            "excess_mana": 1328030257,
+            "mana_used": 87902892,
+            "proving_cost_per_mana_numerator": 1200128277,
+            "fee_asset_price_numerator": 1941013105
+        },
+        "header": {
+            "excess_mana": 1315933149,
+            "mana_used": 92877236,
+            "proving_cost_per_mana_numerator": 1136168049,
+            "fee_asset_price_numerator": 1382043599
+        },
+        "oracle_input": {
+            "proving_cost_modifier": -63960228,
+            "fee_asset_price_modifier": -558969506
+        },
+        "outputs": {
+            "fee_asset_price_at_execution": 10195997323,
+            "mana_base_fee_components_in_wei": {
+                "data_cost": 0,
+                "gas_cost": 36738422,
+                "proving_cost": 5480740751,
+                "congestion_cost": 20210082859,
+                "congestion_multiplier": 4662919646
+            },
+            "mana_base_fee_components_in_fee_asset": {
+                "data_cost": 0,
+                "gas_cost": 374584852,
+                "proving_cost": 55881618025,
+                "congestion_cost": 206061950727,
+                "congestion_multiplier": 4662919646
+            }
+        }
+    },
+    {
+        "l1_block_number": 20974538,
+        "l1_fees": {
+            "blob_fee": 1,
+            "base_fee": 10020764445
+        },
+        "parent_header": {
+            "excess_mana": 1315933149,
+            "mana_used": 92877236,
+            "proving_cost_per_mana_numerator": 1136168049,
+            "fee_asset_price_numerator": 1382043599
+        },
+        "header": {
+            "excess_mana": 1308810385,
+            "mana_used": 106131552,
+            "proving_cost_per_mana_numerator": 893392989,
+            "fee_asset_price_numerator": 1723038366
+        },
+        "oracle_input": {
+            "proving_cost_modifier": -242775060,
+            "fee_asset_price_modifier": 340994767
+        },
+        "outputs": {
+            "fee_asset_price_at_execution": 10139163797,
+            "mana_base_fee_components_in_wei": {
+                "data_cost": 0,
+                "gas_cost": 33193782,
+                "proving_cost": 5477236377,
+                "congestion_cost": 19971022492,
+                "congestion_multiplier": 4624222051
+            },
+            "mana_base_fee_components_in_fee_asset": {
+                "data_cost": 0,
+                "gas_cost": 336557192,
+                "proving_cost": 55534596781,
+                "congestion_cost": 202489468239,
+                "congestion_multiplier": 4624222051
+            }
+        }
+    },
+    {
+        "l1_block_number": 20974541,
+        "l1_fees": {
+            "blob_fee": 1,
+            "base_fee": 9721514258
+        },
+        "parent_header": {
+            "excess_mana": 1308810385,
+            "mana_used": 106131552,
+            "proving_cost_per_mana_numerator": 893392989,
+            "fee_asset_price_numerator": 1723038366
+        },
+        "header": {
+            "excess_mana": 1314941937,
+            "mana_used": 106820614,
+            "proving_cost_per_mana_numerator": 999930664,
+            "fee_asset_price_numerator": 1858647729
+        },
+        "oracle_input": {
+            "proving_cost_modifier": 106537675,
+            "fee_asset_price_modifier": 135609363
+        },
+        "outputs": {
+            "fee_asset_price_at_execution": 10173796829,
+            "mana_base_fee_components_in_wei": {
+                "data_cost": 0,
+                "gas_cost": 32202515,
+                "proving_cost": 5463955141,
+                "congestion_cost": 20102279668,
+                "congestion_multiplier": 4657515109
+            },
+            "mana_base_fee_components_in_fee_asset": {
+                "data_cost": 0,
+                "gas_cost": 327621844,
+                "proving_cost": 55589169487,
+                "congestion_cost": 204516509141,
+                "congestion_multiplier": 4657515109
+            }
+        }
+    },
+    {
+        "l1_block_number": 20974544,
+        "l1_fees": {
+            "blob_fee": 1,
+            "base_fee": 9605454919
+        },
+        "parent_header": {
+            "excess_mana": 1314941937,
+            "mana_used": 106820614,
+            "proving_cost_per_mana_numerator": 999930664,
+            "fee_asset_price_numerator": 1858647729
+        },
+        "header": {
+            "excess_mana": 1321762551,
+            "mana_used": 94649159,
+            "proving_cost_per_mana_numerator": 1216200771,
+            "fee_asset_price_numerator": 1932155741
+        },
+        "oracle_input": {
+            "proving_cost_modifier": 216270107,
+            "fee_asset_price_modifier": 73508012
+        },
+        "outputs": {
+            "fee_asset_price_at_execution": 10187602809,
+            "mana_base_fee_components_in_wei": {
+                "data_cost": 0,
+                "gas_cost": 31818069,
+                "proving_cost": 5469779414,
+                "congestion_cost": 20327474728,
+                "congestion_multiplier": 4694831327
+            },
+            "mana_base_fee_components_in_fee_asset": {
+                "data_cost": 0,
+                "gas_cost": 324149849,
+                "proving_cost": 55723940122,
+                "congestion_cost": 207088238638,
+                "congestion_multiplier": 4694831327
+            }
+        }
+    },
+    {
+        "l1_block_number": 20974547,
+        "l1_fees": {
+            "blob_fee": 1,
+            "base_fee": 8987171015
+        },
+        "parent_header": {
+            "excess_mana": 1321762551,
+            "mana_used": 94649159,
+            "proving_cost_per_mana_numerator": 1216200771,
+            "fee_asset_price_numerator": 1932155741
+        },
+        "header": {
+            "excess_mana": 1316411710,
+            "mana_used": 99651852,
+            "proving_cost_per_mana_numerator": 1030218038,
+            "fee_asset_price_numerator": 1640498241
+        },
+        "oracle_input": {
+            "proving_cost_modifier": -185982733,
+            "fee_asset_price_modifier": -291657500
+        },
+        "outputs": {
+            "fee_asset_price_at_execution": 10195094267,
+            "mana_base_fee_components_in_wei": {
+                "data_cost": 0,
+                "gas_cost": 29770003,
+                "proving_cost": 5481621713,
+                "congestion_cost": 20202178411,
+                "congestion_multiplier": 4665531222
+            },
+            "mana_base_fee_components_in_fee_asset": {
+                "data_cost": 0,
+                "gas_cost": 303507986,
+                "proving_cost": 55885650100,
+                "congestion_cost": 205963113298,
+                "congestion_multiplier": 4665531222
+            }
+        }
+    },
+    {
+        "l1_block_number": 20974550,
+        "l1_fees": {
+            "blob_fee": 1,
+            "base_fee": 9961876485
+        },
+        "parent_header": {
+            "excess_mana": 1316411710,
+            "mana_used": 99651852,
+            "proving_cost_per_mana_numerator": 1030218038,
+            "fee_asset_price_numerator": 1640498241
+        },
+        "header": {
+            "excess_mana": 1316063562,
+            "mana_used": 111037651,
+            "proving_cost_per_mana_numerator": 873740990,
+            "fee_asset_price_numerator": 1361795236
+        },
+        "oracle_input": {
+            "proving_cost_modifier": -156477048,
+            "fee_asset_price_modifier": -278703005
+        },
+        "outputs": {
+            "fee_asset_price_at_execution": 10165402829,
+            "mana_base_fee_components_in_wei": {
+                "data_cost": 0,
+                "gas_cost": 32998715,
+                "proving_cost": 5471436318,
+                "congestion_cost": 20166219837,
+                "congestion_multiplier": 4663631184
+            },
+            "mana_base_fee_components_in_fee_asset": {
+                "data_cost": 0,
+                "gas_cost": 335445230,
+                "proving_cost": 55619354225,
+                "congestion_cost": 204997748181,
+                "congestion_multiplier": 4663631184
+            }
+        }
+    },
+    {
+        "l1_block_number": 20974553,
+        "l1_fees": {
+            "blob_fee": 1,
+            "base_fee": 9733495056
+        },
+        "parent_header": {
+            "excess_mana": 1316063562,
+            "mana_used": 111037651,
+            "proving_cost_per_mana_numerator": 873740990,
+            "fee_asset_price_numerator": 1361795236
+        },
+        "header": {
+            "excess_mana": 1327101213,
+            "mana_used": 92008411,
+            "proving_cost_per_mana_numerator": 898901189,
+            "fee_asset_price_numerator": 1044864044
+        },
+        "oracle_input": {
+            "proving_cost_modifier": 25160199,
+            "fee_asset_price_modifier": -316931192
+        },
+        "outputs": {
+            "fee_asset_price_at_execution": 10137110990,
+            "mana_base_fee_components_in_wei": {
+                "data_cost": 0,
+                "gas_cost": 32242202,
+                "proving_cost": 5462881471,
+                "congestion_cost": 20465204013,
+                "congestion_multiplier": 4724248121
+            },
+            "mana_base_fee_components_in_fee_asset": {
+                "data_cost": 0,
+                "gas_cost": 326842780,
+                "proving_cost": 55377835796,
+                "congestion_cost": 207458044512,
+                "congestion_multiplier": 4724248121
+            }
+        }
+    },
+    {
+        "l1_block_number": 20974556,
+        "l1_fees": {
+            "blob_fee": 1,
+            "base_fee": 9375339716
+        },
+        "parent_header": {
+            "excess_mana": 1327101213,
+            "mana_used": 92008411,
+            "proving_cost_per_mana_numerator": 898901189,
+            "fee_asset_price_numerator": 1044864044
+        },
+        "header": {
+            "excess_mana": 1319109624,
+            "mana_used": 102382194,
+            "proving_cost_per_mana_numerator": 1025217469,
+            "fee_asset_price_numerator": 1697126570
+        },
+        "oracle_input": {
+            "proving_cost_modifier": 126316280,
+            "fee_asset_price_modifier": 652262526
+        },
+        "outputs": {
+            "fee_asset_price_at_execution": 10105034181,
+            "mana_base_fee_components_in_wei": {
+                "data_cost": 0,
+                "gas_cost": 31055812,
+                "proving_cost": 5464256115,
+                "congestion_cost": 20224294915,
+                "congestion_multiplier": 4680281517
+            },
+            "mana_base_fee_components_in_fee_asset": {
+                "data_cost": 0,
+                "gas_cost": 313820041,
+                "proving_cost": 55216494815,
+                "congestion_cost": 204367191402,
+                "congestion_multiplier": 4680281517
+            }
+        }
+    },
+    {
+        "l1_block_number": 20974559,
+        "l1_fees": {
+            "blob_fee": 1,
+            "base_fee": 9597087327
+        },
+        "parent_header": {
+            "excess_mana": 1319109624,
+            "mana_used": 102382194,
+            "proving_cost_per_mana_numerator": 1025217469,
+            "fee_asset_price_numerator": 1697126570
+        },
+        "header": {
+            "excess_mana": 1321491818,
+            "mana_used": 110585080,
+            "proving_cost_per_mana_numerator": 988477843,
+            "fee_asset_price_numerator": 843566589
+        },
+        "oracle_input": {
+            "proving_cost_modifier": -36739626,
+            "fee_asset_price_modifier": -853559981
+        },
+        "outputs": {
+            "fee_asset_price_at_execution": 10171160957,
+            "mana_base_fee_components_in_wei": {
+                "data_cost": 0,
+                "gas_cost": 31790351,
+                "proving_cost": 5471162722,
+                "congestion_cost": 20324301130,
+                "congestion_multiplier": 4693344439
+            },
+            "mana_base_fee_components_in_fee_asset": {
+                "data_cost": 0,
+                "gas_cost": 323344776,
+                "proving_cost": 55648076667,
+                "congestion_cost": 206721738131,
+                "congestion_multiplier": 4693344439
+            }
+        }
+    },
+    {
+        "l1_block_number": 20974562,
+        "l1_fees": {
+            "blob_fee": 1,
+            "base_fee": 10268313101
+        },
+        "parent_header": {
+            "excess_mana": 1321491818,
+            "mana_used": 110585080,
+            "proving_cost_per_mana_numerator": 988477843,
+            "fee_asset_price_numerator": 843566589
+        },
+        "header": {
+            "excess_mana": 1332076898,
+            "mana_used": 92593419,
+            "proving_cost_per_mana_numerator": 932263532,
+            "fee_asset_price_numerator": 456153193
+        },
+        "oracle_input": {
+            "proving_cost_modifier": -56214311,
+            "fee_asset_price_modifier": -387413396
+        },
+        "outputs": {
+            "fee_asset_price_at_execution": 10084713463,
+            "mana_base_fee_components_in_wei": {
+                "data_cost": 0,
+                "gas_cost": 34013787,
+                "proving_cost": 5469153006,
+                "congestion_cost": 20646950577,
+                "congestion_multiplier": 4751830783
+            },
+            "mana_base_fee_components_in_fee_asset": {
+                "data_cost": 0,
+                "gas_cost": 343019295,
+                "proving_cost": 55154840950,
+                "congestion_cost": 208218580453,
+                "congestion_multiplier": 4751830783
+            }
+        }
+    },
+    {
+        "l1_block_number": 20974565,
+        "l1_fees": {
+            "blob_fee": 1,
+            "base_fee": 9810780355
+        },
+        "parent_header": {
+            "excess_mana": 1332076898,
+            "mana_used": 92593419,
+            "proving_cost_per_mana_numerator": 932263532,
+            "fee_asset_price_numerator": 456153193
+        },
+        "header": {
+            "excess_mana": 1324670317,
+            "mana_used": 90724497,
+            "proving_cost_per_mana_numerator": 794288972,
+            "fee_asset_price_numerator": 128315644
+        },
+        "oracle_input": {
+            "proving_cost_modifier": -137974560,
+            "fee_asset_price_modifier": -327837549
+        },
+        "outputs": {
+            "fee_asset_price_at_execution": 10045719515,
+            "mana_base_fee_components_in_wei": {
+                "data_cost": 0,
+                "gas_cost": 32498209,
+                "proving_cost": 5466079423,
+                "congestion_cost": 20404290947,
+                "congestion_multiplier": 4710830748
+            },
+            "mana_base_fee_components_in_fee_asset": {
+                "data_cost": 0,
+                "gas_cost": 326467892,
+                "proving_cost": 54910700730,
+                "congestion_cost": 204975783756,
+                "congestion_multiplier": 4710830748
+            }
+        }
+    },
+    {
+        "l1_block_number": 20974568,
+        "l1_fees": {
+            "blob_fee": 1,
+            "base_fee": 10144246321
+        },
+        "parent_header": {
+            "excess_mana": 1324670317,
+            "mana_used": 90724497,
+            "proving_cost_per_mana_numerator": 794288972,
+            "fee_asset_price_numerator": 128315644
+        },
+        "header": {
+            "excess_mana": 1315394814,
+            "mana_used": 111555165,
+            "proving_cost_per_mana_numerator": 868429096,
+            "fee_asset_price_numerator": 675668512
+        },
+        "oracle_input": {
+            "proving_cost_modifier": 74140124,
+            "fee_asset_price_modifier": 547352868
+        },
+        "outputs": {
+            "fee_asset_price_at_execution": 10012839800,
+            "mana_base_fee_components_in_wei": {
+                "data_cost": 0,
+                "gas_cost": 33602815,
+                "proving_cost": 5458542825,
+                "congestion_cost": 20101163092,
+                "congestion_multiplier": 4659983622
+            },
+            "mana_base_fee_components_in_fee_asset": {
+                "data_cost": 0,
+                "gas_cost": 336459603,
+                "proving_cost": 54655514848,
+                "congestion_cost": 201269725833,
+                "congestion_multiplier": 4659983622
+            }
+        }
+    },
+    {
+        "l1_block_number": 20974571,
+        "l1_fees": {
+            "blob_fee": 1,
+            "base_fee": 9686834828
+        },
+        "parent_header": {
+            "excess_mana": 1315394814,
+            "mana_used": 111555165,
+            "proving_cost_per_mana_numerator": 868429096,
+            "fee_asset_price_numerator": 675668512
+        },
+        "header": {
+            "excess_mana": 1326949979,
+            "mana_used": 99938676,
+            "proving_cost_per_mana_numerator": 896089675,
+            "fee_asset_price_numerator": 448902582
+        },
+        "oracle_input": {
+            "proving_cost_modifier": 27660579,
+            "fee_asset_price_modifier": -226765930
+        },
+        "outputs": {
+            "fee_asset_price_at_execution": 10067795630,
+            "mana_base_fee_components_in_wei": {
+                "data_cost": 0,
+                "gas_cost": 32087640,
+                "proving_cost": 5462591296,
+                "congestion_cost": 20458954959,
+                "congestion_multiplier": 4723412268
+            },
+            "mana_base_fee_components_in_fee_asset": {
+                "data_cost": 0,
+                "gas_cost": 323051801,
+                "proving_cost": 54996252778,
+                "congestion_cost": 205976577330,
+                "congestion_multiplier": 4723412268
+            }
+        }
+    },
+    {
+        "l1_block_number": 20974574,
+        "l1_fees": {
+            "blob_fee": 1,
+            "base_fee": 9943977596
+        },
+        "parent_header": {
+            "excess_mana": 1326949979,
+            "mana_used": 99938676,
+            "proving_cost_per_mana_numerator": 896089675,
+            "fee_asset_price_numerator": 448902582
+        },
+        "header": {
+            "excess_mana": 1326888655,
+            "mana_used": 99622249,
+            "proving_cost_per_mana_numerator": 877465442,
+            "fee_asset_price_numerator": 22204524
+        },
+        "oracle_input": {
+            "proving_cost_modifier": -18624233,
+            "fee_asset_price_modifier": -426698058
+        },
+        "outputs": {
+            "fee_asset_price_at_execution": 10044991165,
+            "mana_base_fee_components_in_wei": {
+                "data_cost": 0,
+                "gas_cost": 32939425,
+                "proving_cost": 5464102489,
+                "congestion_cost": 20465890418,
+                "congestion_multiplier": 4723073380
+            },
+            "mana_base_fee_components_in_fee_asset": {
+                "data_cost": 0,
+                "gas_cost": 330876233,
+                "proving_cost": 54886861226,
+                "congestion_cost": 205579688432,
+                "congestion_multiplier": 4723073380
+            }
+        }
+    },
+    {
+        "l1_block_number": 20974577,
+        "l1_fees": {
+            "blob_fee": 1,
+            "base_fee": 8945291339
+        },
+        "parent_header": {
+            "excess_mana": 1326888655,
+            "mana_used": 99622249,
+            "proving_cost_per_mana_numerator": 877465442,
+            "fee_asset_price_numerator": 22204524
+        },
+        "header": {
+            "excess_mana": 1326510904,
+            "mana_used": 84100471,
+            "proving_cost_per_mana_numerator": 805729104,
+            "fee_asset_price_numerator": 259780126
+        },
+        "oracle_input": {
+            "proving_cost_modifier": -71736338,
+            "fee_asset_price_modifier": 237575602
+        },
+        "outputs": {
+            "fee_asset_price_at_execution": 10002220698,
+            "mana_base_fee_components_in_wei": {
+                "data_cost": 0,
+                "gas_cost": 29631277,
+                "proving_cost": 5463084937,
+                "congestion_cost": 20438322281,
+                "congestion_multiplier": 4720986391
+            },
+            "mana_base_fee_components_in_fee_asset": {
+                "data_cost": 0,
+                "gas_cost": 296378572,
+                "proving_cost": 54642981231,
+                "congestion_cost": 204428610151,
+                "congestion_multiplier": 4720986391
+            }
+        }
+    },
+    {
+        "l1_block_number": 20974580,
+        "l1_fees": {
+            "blob_fee": 1,
+            "base_fee": 10038998201
+        },
+        "parent_header": {
+            "excess_mana": 1326510904,
+            "mana_used": 84100471,
+            "proving_cost_per_mana_numerator": 805729104,
+            "fee_asset_price_numerator": 259780126
+        },
+        "header": {
+            "excess_mana": 1310611375,
+            "mana_used": 103492289,
+            "proving_cost_per_mana_numerator": 792740469,
+            "fee_asset_price_numerator": 340660283
+        },
+        "oracle_input": {
+            "proving_cost_modifier": -12988635,
+            "fee_asset_price_modifier": 80880157
+        },
+        "outputs": {
+            "fee_asset_price_at_execution": 10026011784,
+            "mana_base_fee_components_in_wei": {
+                "data_cost": 0,
+                "gas_cost": 33254181,
+                "proving_cost": 5459167325,
+                "congestion_cost": 19959329538,
+                "congestion_multiplier": 4633976292
+            },
+            "mana_base_fee_components_in_fee_asset": {
+                "data_cost": 0,
+                "gas_cost": 333406810,
+                "proving_cost": 54733675931,
+                "congestion_cost": 200112473148,
+                "congestion_multiplier": 4633976292
+            }
+        }
+    },
+    {
+        "l1_block_number": 20974583,
+        "l1_fees": {
+            "blob_fee": 1,
+            "base_fee": 10272200406
+        },
+        "parent_header": {
+            "excess_mana": 1310611375,
+            "mana_used": 103492289,
+            "proving_cost_per_mana_numerator": 792740469,
+            "fee_asset_price_numerator": 340660283
+        },
+        "header": {
+            "excess_mana": 1314103664,
+            "mana_used": 0,
+            "proving_cost_per_mana_numerator": 668559792,
+            "fee_asset_price_numerator": 0
+        },
+        "oracle_input": {
+            "proving_cost_modifier": -124180677,
+            "fee_asset_price_modifier": -608328780
+        },
+        "outputs": {
+            "fee_asset_price_at_execution": 10034124118,
+            "mana_base_fee_components_in_wei": {
+                "data_cost": 0,
+                "gas_cost": 34026663,
+                "proving_cost": 5458458300,
+                "congestion_cost": 20063769391,
+                "congestion_multiplier": 4652949353
+            },
+            "mana_base_fee_components_in_fee_asset": {
+                "data_cost": 0,
+                "gas_cost": 341427759,
+                "proving_cost": 54770848075,
+                "congestion_cost": 201322352344,
+                "congestion_multiplier": 4652949353
+            }
+        }
+    },
+    {
+        "l1_block_number": 20974586,
+        "l1_fees": {
+            "blob_fee": 1,
+            "base_fee": 10159830088
+        },
+        "parent_header": {
+            "excess_mana": 1314103664,
+            "mana_used": 0,
+            "proving_cost_per_mana_numerator": 668559792,
+            "fee_asset_price_numerator": 0
+        },
+        "header": {
+            "excess_mana": 1214103664,
+            "mana_used": 174322033,
+            "proving_cost_per_mana_numerator": 520915187,
+            "fee_asset_price_numerator": 191162968
+        },
+        "oracle_input": {
+            "proving_cost_modifier": -147644605,
+            "fee_asset_price_modifier": 191162968
+        },
+        "outputs": {
+            "fee_asset_price_at_execution": 10000000000,
+            "mana_base_fee_components_in_wei": {
+                "data_cost": 0,
+                "gas_cost": 33654437,
+                "proving_cost": 5451684156,
+                "congestion_cost": 17219546656,
+                "congestion_multiplier": 4139194849
+            },
+            "mana_base_fee_components_in_fee_asset": {
+                "data_cost": 0,
+                "gas_cost": 336544370,
+                "proving_cost": 54516841560,
+                "congestion_cost": 172195466560,
+                "congestion_multiplier": 4139194849
+            }
+        }
+    },
+    {
+        "l1_block_number": 20974589,
+        "l1_fees": {
+            "blob_fee": 1,
+            "base_fee": 11362253728
+        },
+        "parent_header": {
+            "excess_mana": 1214103664,
+            "mana_used": 174322033,
+            "proving_cost_per_mana_numerator": 520915187,
+            "fee_asset_price_numerator": 191162968
+        },
+        "header": {
+            "excess_mana": 1288425697,
+            "mana_used": 118595109,
+            "proving_cost_per_mana_numerator": 416693447,
+            "fee_asset_price_numerator": 185644548
+        },
+        "oracle_input": {
+            "proving_cost_modifier": -104221740,
+            "fee_asset_price_modifier": -5518420
+        },
+        "outputs": {
+            "fee_asset_price_at_execution": 10019134580,
+            "mana_base_fee_components_in_wei": {
+                "data_cost": 0,
+                "gas_cost": 37637465,
+                "proving_cost": 5443640978,
+                "congestion_cost": 19268002426,
+                "congestion_multiplier": 4515238758
+            },
+            "mana_base_fee_components_in_fee_asset": {
+                "data_cost": 0,
+                "gas_cost": 377094827,
+                "proving_cost": 54540571563,
+                "congestion_cost": 193048709393,
+                "congestion_multiplier": 4515238758
+            }
+        }
+    },
+    {
+        "l1_block_number": 20974592,
+        "l1_fees": {
+            "blob_fee": 1,
+            "base_fee": 10488705208
+        },
+        "parent_header": {
+            "excess_mana": 1288425697,
+            "mana_used": 118595109,
+            "proving_cost_per_mana_numerator": 416693447,
+            "fee_asset_price_numerator": 185644548
+        },
+        "header": {
+            "excess_mana": 1307020806,
+            "mana_used": 107609608,
+            "proving_cost_per_mana_numerator": 453557170,
+            "fee_asset_price_numerator": 619717024
+        },
+        "oracle_input": {
+            "proving_cost_modifier": 36863723,
+            "fee_asset_price_modifier": 434072476
+        },
+        "outputs": {
+            "fee_asset_price_at_execution": 10018581697,
+            "mana_base_fee_components_in_wei": {
+                "data_cost": 0,
+                "gas_cost": 34743836,
+                "proving_cost": 5437970476,
+                "congestion_cost": 19781399242,
+                "congestion_multiplier": 4614549950
+            },
+            "mana_base_fee_components_in_fee_asset": {
+                "data_cost": 0,
+                "gas_cost": 348083959,
+                "proving_cost": 54480751479,
+                "congestion_cost": 198181564386,
+                "congestion_multiplier": 4614549950
+            }
+        }
+    },
+    {
+        "l1_block_number": 20974595,
+        "l1_fees": {
+            "blob_fee": 1,
+            "base_fee": 9462366449
+        },
+        "parent_header": {
+            "excess_mana": 1307020806,
+            "mana_used": 107609608,
+            "proving_cost_per_mana_numerator": 453557170,
+            "fee_asset_price_numerator": 619717024
+        },
+        "header": {
+            "excess_mana": 1314630414,
+            "mana_used": 92131303,
+            "proving_cost_per_mana_numerator": 531888880,
+            "fee_asset_price_numerator": 0
+        },
+        "oracle_input": {
+            "proving_cost_modifier": 78331710,
+            "fee_asset_price_modifier": -692817214
+        },
+        "outputs": {
+            "fee_asset_price_at_execution": 10062164124,
+            "mana_base_fee_components_in_wei": {
+                "data_cost": 0,
+                "gas_cost": 31344088,
+                "proving_cost": 5439975484,
+                "congestion_cost": 20002147688,
+                "congestion_multiplier": 4655817838
+            },
+            "mana_base_fee_components_in_fee_asset": {
+                "data_cost": 0,
+                "gas_cost": 315389357,
+                "proving_cost": 54737926150,
+                "congestion_cost": 201264892869,
+                "congestion_multiplier": 4655817838
+            }
+        }
+    },
+    {
+        "l1_block_number": 20974598,
+        "l1_fees": {
+            "blob_fee": 1,
+            "base_fee": 9421740766
+        },
+        "parent_header": {
+            "excess_mana": 1314630414,
+            "mana_used": 92131303,
+            "proving_cost_per_mana_numerator": 531888880,
+            "fee_asset_price_numerator": 0
+        },
+        "header": {
+            "excess_mana": 1306761717,
+            "mana_used": 103809271,
+            "proving_cost_per_mana_numerator": 538177512,
+            "fee_asset_price_numerator": 0
+        },
+        "oracle_input": {
+            "proving_cost_modifier": 6288632,
+            "fee_asset_price_modifier": -126737791
+        },
+        "outputs": {
+            "fee_asset_price_at_execution": 10000000000,
+            "mana_base_fee_components_in_wei": {
+                "data_cost": 0,
+                "gas_cost": 31209516,
+                "proving_cost": 5444238379,
+                "congestion_cost": 19783621866,
+                "congestion_multiplier": 4613151334
+            },
+            "mana_base_fee_components_in_fee_asset": {
+                "data_cost": 0,
+                "gas_cost": 312095160,
+                "proving_cost": 54442383790,
+                "congestion_cost": 197836218660,
+                "congestion_multiplier": 4613151334
+            }
+        }
+    },
+    {
+        "l1_block_number": 20974601,
+        "l1_fees": {
+            "blob_fee": 1,
+            "base_fee": 9237341401
+        },
+        "parent_header": {
+            "excess_mana": 1306761717,
+            "mana_used": 103809271,
+            "proving_cost_per_mana_numerator": 538177512,
+            "fee_asset_price_numerator": 0
+        },
+        "header": {
+            "excess_mana": 1310570988,
+            "mana_used": 113120852,
+            "proving_cost_per_mana_numerator": 543916368,
+            "fee_asset_price_numerator": 0
+        },
+        "oracle_input": {
+            "proving_cost_modifier": 5738856,
+            "fee_asset_price_modifier": -73019921
+        },
+        "outputs": {
+            "fee_asset_price_at_execution": 10000000000,
+            "mana_base_fee_components_in_wei": {
+                "data_cost": 0,
+                "gas_cost": 30598693,
+                "proving_cost": 5444580758,
+                "congestion_cost": 19895473457,
+                "congestion_multiplier": 4633757329
+            },
+            "mana_base_fee_components_in_fee_asset": {
+                "data_cost": 0,
+                "gas_cost": 305986930,
+                "proving_cost": 54445807580,
+                "congestion_cost": 198954734570,
+                "congestion_multiplier": 4633757329
+            }
+        }
+    },
+    {
+        "l1_block_number": 20974604,
+        "l1_fees": {
+            "blob_fee": 1,
+            "base_fee": 10238465003
+        },
+        "parent_header": {
+            "excess_mana": 1310570988,
+            "mana_used": 113120852,
+            "proving_cost_per_mana_numerator": 543916368,
+            "fee_asset_price_numerator": 0
+        },
+        "header": {
+            "excess_mana": 1323691840,
+            "mana_used": 92397177,
+            "proving_cost_per_mana_numerator": 426314838,
+            "fee_asset_price_numerator": 243102440
+        },
+        "oracle_input": {
+            "proving_cost_modifier": -117601530,
+            "fee_asset_price_modifier": 243102440
+        },
+        "outputs": {
+            "fee_asset_price_at_execution": 10000000000,
+            "mana_base_fee_components_in_wei": {
+                "data_cost": 0,
+                "gas_cost": 33914915,
+                "proving_cost": 5444893224,
+                "congestion_cost": 20301399153,
+                "congestion_multiplier": 4705440789
+            },
+            "mana_base_fee_components_in_fee_asset": {
+                "data_cost": 0,
+                "gas_cost": 339149150,
+                "proving_cost": 54448932240,
+                "congestion_cost": 203013991530,
+                "congestion_multiplier": 4705440789
+            }
+        }
+    },
+    {
+        "l1_block_number": 20974607,
+        "l1_fees": {
+            "blob_fee": 1,
+            "base_fee": 9761510720
+        },
+        "parent_header": {
+            "excess_mana": 1323691840,
+            "mana_used": 92397177,
+            "proving_cost_per_mana_numerator": 426314838,
+            "fee_asset_price_numerator": 243102440
+        },
+        "header": {
+            "excess_mana": 1316089017,
+            "mana_used": 101644078,
+            "proving_cost_per_mana_numerator": 570636341,
+            "fee_asset_price_numerator": 609906024
+        },
+        "oracle_input": {
+            "proving_cost_modifier": 144321503,
+            "fee_asset_price_modifier": 366803584
+        },
+        "outputs": {
+            "fee_asset_price_at_execution": 10024339817,
+            "mana_base_fee_components_in_wei": {
+                "data_cost": 0,
+                "gas_cost": 32335004,
+                "proving_cost": 5438493710,
+                "congestion_cost": 20043858555,
+                "congestion_multiplier": 4663770080
+            },
+            "mana_base_fee_components_in_fee_asset": {
+                "data_cost": 0,
+                "gas_cost": 324137068,
+                "proving_cost": 54517309041,
+                "congestion_cost": 200926449399,
+                "congestion_multiplier": 4663770080
+            }
+        }
+    },
+    {
+        "l1_block_number": 20974610,
+        "l1_fees": {
+            "blob_fee": 1,
+            "base_fee": 9386744044
+        },
+        "parent_header": {
+            "excess_mana": 1316089017,
+            "mana_used": 101644078,
+            "proving_cost_per_mana_numerator": 570636341,
+            "fee_asset_price_numerator": 609906024
+        },
+        "header": {
+            "excess_mana": 1317733095,
+            "mana_used": 92675049,
+            "proving_cost_per_mana_numerator": 666417343,
+            "fee_asset_price_numerator": 832510984
+        },
+        "oracle_input": {
+            "proving_cost_modifier": 95781002,
+            "fee_asset_price_modifier": 222604960
+        },
+        "outputs": {
+            "fee_asset_price_at_execution": 10061176973,
+            "mana_base_fee_components_in_wei": {
+                "data_cost": 0,
+                "gas_cost": 31093589,
+                "proving_cost": 5446348292,
+                "congestion_cost": 20117273616,
+                "congestion_multiplier": 4672749808
+            },
+            "mana_base_fee_components_in_fee_asset": {
+                "data_cost": 0,
+                "gas_cost": 312838101,
+                "proving_cost": 54796674022,
+                "congestion_cost": 202403450064,
+                "congestion_multiplier": 4672749808
+            }
+        }
+    },
+    {
+        "l1_block_number": 20974613,
+        "l1_fees": {
+            "blob_fee": 1,
+            "base_fee": 9635997754
+        },
+        "parent_header": {
+            "excess_mana": 1317733095,
+            "mana_used": 92675049,
+            "proving_cost_per_mana_numerator": 666417343,
+            "fee_asset_price_numerator": 832510984
+        },
+        "header": {
+            "excess_mana": 1310408144,
+            "mana_used": 98945719,
+            "proving_cost_per_mana_numerator": 637579467,
+            "fee_asset_price_numerator": 78183892
+        },
+        "oracle_input": {
+            "proving_cost_modifier": -28837876,
+            "fee_asset_price_modifier": -754327092
+        },
+        "outputs": {
+            "fee_asset_price_at_execution": 10083598599,
+            "mana_base_fee_components_in_wei": {
+                "data_cost": 0,
+                "gas_cost": 31919242,
+                "proving_cost": 5451567358,
+                "congestion_cost": 19920818941,
+                "congestion_multiplier": 4632874555
+            },
+            "mana_base_fee_components_in_fee_asset": {
+                "data_cost": 0,
+                "gas_cost": 321860823,
+                "proving_cost": 54971416973,
+                "congestion_cost": 200873541964,
+                "congestion_multiplier": 4632874555
+            }
+        }
+    },
+    {
+        "l1_block_number": 20974616,
+        "l1_fees": {
+            "blob_fee": 1,
+            "base_fee": 9497835793
+        },
+        "parent_header": {
+            "excess_mana": 1310408144,
+            "mana_used": 98945719,
+            "proving_cost_per_mana_numerator": 637579467,
+            "fee_asset_price_numerator": 78183892
+        },
+        "header": {
+            "excess_mana": 1309353863,
+            "mana_used": 104843069,
+            "proving_cost_per_mana_numerator": 727519356,
+            "fee_asset_price_numerator": 219999797
+        },
+        "oracle_input": {
+            "proving_cost_modifier": 89939889,
+            "fee_asset_price_modifier": 141815905
+        },
+        "outputs": {
+            "fee_asset_price_at_execution": 10007821446,
+            "mana_base_fee_components_in_wei": {
+                "data_cost": 0,
+                "gas_cost": 31461581,
+                "proving_cost": 5449995468,
+                "congestion_cost": 19882140315,
+                "congestion_multiplier": 4627163387
+            },
+            "mana_base_fee_components_in_fee_asset": {
+                "data_cost": 0,
+                "gas_cost": 314861885,
+                "proving_cost": 54542581525,
+                "congestion_cost": 198976910236,
+                "congestion_multiplier": 4627163387
+            }
+        }
+    },
+    {
+        "l1_block_number": 20974619,
+        "l1_fees": {
+            "blob_fee": 1,
+            "base_fee": 9784258718
+        },
+        "parent_header": {
+            "excess_mana": 1309353863,
+            "mana_used": 104843069,
+            "proving_cost_per_mana_numerator": 727519356,
+            "fee_asset_price_numerator": 219999797
+        },
+        "header": {
+            "excess_mana": 1314196932,
+            "mana_used": 108701348,
+            "proving_cost_per_mana_numerator": 695500631,
+            "fee_asset_price_numerator": 352336839
+        },
+        "oracle_input": {
+            "proving_cost_modifier": -32018725,
+            "fee_asset_price_modifier": 132337042
+        },
+        "outputs": {
+            "fee_asset_price_at_execution": 10022024197,
+            "mana_base_fee_components_in_wei": {
+                "data_cost": 0,
+                "gas_cost": 32410357,
+                "proving_cost": 5454899393,
+                "congestion_cost": 20047650914,
+                "congestion_multiplier": 4653457127
+            },
+            "mana_base_fee_components_in_fee_asset": {
+                "data_cost": 0,
+                "gas_cost": 324817382,
+                "proving_cost": 54669133708,
+                "congestion_cost": 200918042553,
+                "congestion_multiplier": 4653457127
+            }
+        }
+    },
+    {
+        "l1_block_number": 20974622,
+        "l1_fees": {
+            "blob_fee": 1,
+            "base_fee": 9822631866
+        },
+        "parent_header": {
+            "excess_mana": 1314196932,
+            "mana_used": 108701348,
+            "proving_cost_per_mana_numerator": 695500631,
+            "fee_asset_price_numerator": 352336839
+        },
+        "header": {
+            "excess_mana": 1322898280,
+            "mana_used": 91385697,
+            "proving_cost_per_mana_numerator": 809869333,
+            "fee_asset_price_numerator": 0
+        },
+        "oracle_input": {
+            "proving_cost_modifier": 114368702,
+            "fee_asset_price_modifier": -624014969
+        },
+        "outputs": {
+            "fee_asset_price_at_execution": 10035295827,
+            "mana_base_fee_components_in_wei": {
+                "data_cost": 0,
+                "gas_cost": 32537468,
+                "proving_cost": 5453153084,
+                "congestion_cost": 20302946558,
+                "congestion_multiplier": 4701073979
+            },
+            "mana_base_fee_components_in_fee_asset": {
+                "data_cost": 0,
+                "gas_cost": 326523116,
+                "proving_cost": 54724004387,
+                "congestion_cost": 203746074869,
+                "congestion_multiplier": 4701073979
+            }
+        }
+    },
+    {
+        "l1_block_number": 20974625,
+        "l1_fees": {
+            "blob_fee": 1,
+            "base_fee": 10157914688
+        },
+        "parent_header": {
+            "excess_mana": 1322898280,
+            "mana_used": 91385697,
+            "proving_cost_per_mana_numerator": 809869333,
+            "fee_asset_price_numerator": 0
+        },
+        "header": {
+            "excess_mana": 1314283977,
+            "mana_used": 116675075,
+            "proving_cost_per_mana_numerator": 782149905,
+            "fee_asset_price_numerator": 622366323
+        },
+        "oracle_input": {
+            "proving_cost_modifier": -27719428,
+            "fee_asset_price_modifier": 622366323
+        },
+        "outputs": {
+            "fee_asset_price_at_execution": 10000000000,
+            "mana_base_fee_components_in_wei": {
+                "data_cost": 0,
+                "gas_cost": 33648092,
+                "proving_cost": 5459393352,
+                "congestion_cost": 20071194812,
+                "congestion_multiplier": 4653931072
+            },
+            "mana_base_fee_components_in_fee_asset": {
+                "data_cost": 0,
+                "gas_cost": 336480920,
+                "proving_cost": 54593933520,
+                "congestion_cost": 200711948120,
+                "congestion_multiplier": 4653931072
+            }
+        }
+    },
+    {
+        "l1_block_number": 20974628,
+        "l1_fees": {
+            "blob_fee": 1,
+            "base_fee": 10107349159
+        },
+        "parent_header": {
+            "excess_mana": 1314283977,
+            "mana_used": 116675075,
+            "proving_cost_per_mana_numerator": 782149905,
+            "fee_asset_price_numerator": 622366323
+        },
+        "header": {
+            "excess_mana": 1330959052,
+            "mana_used": 26049996,
+            "proving_cost_per_mana_numerator": 742577896,
+            "fee_asset_price_numerator": 880139489
+        },
+        "oracle_input": {
+            "proving_cost_modifier": -39572009,
+            "fee_asset_price_modifier": 257773166
+        },
+        "outputs": {
+            "fee_asset_price_at_execution": 10062430704,
+            "mana_base_fee_components_in_wei": {
+                "data_cost": 0,
+                "gas_cost": 33480594,
+                "proving_cost": 5457880249,
+                "congestion_cost": 20568551121,
+                "congestion_multiplier": 4745620022
+            },
+            "mana_base_fee_components_in_fee_asset": {
+                "data_cost": 0,
+                "gas_cost": 336896157,
+                "proving_cost": 54919541796,
+                "congestion_cost": 206969620336,
+                "congestion_multiplier": 4745620022
+            }
+        }
+    },
+    {
+        "l1_block_number": 20974631,
+        "l1_fees": {
+            "blob_fee": 1,
+            "base_fee": 9986090744
+        },
+        "parent_header": {
+            "excess_mana": 1330959052,
+            "mana_used": 26049996,
+            "proving_cost_per_mana_numerator": 742577896,
+            "fee_asset_price_numerator": 880139489
+        },
+        "header": {
+            "excess_mana": 1257009048,
+            "mana_used": 151212674,
+            "proving_cost_per_mana_numerator": 809308729,
+            "fee_asset_price_numerator": 870419648
+        },
+        "oracle_input": {
+            "proving_cost_modifier": 66730833,
+            "fee_asset_price_modifier": -9719841
+        },
+        "outputs": {
+            "fee_asset_price_at_execution": 10088402410,
+            "mana_base_fee_components_in_wei": {
+                "data_cost": 0,
+                "gas_cost": 33078925,
+                "proving_cost": 5455720883,
+                "congestion_cost": 18400011532,
+                "congestion_multiplier": 4352283227
+            },
+            "mana_base_fee_components_in_fee_asset": {
+                "data_cost": 0,
+                "gas_cost": 333713506,
+                "proving_cost": 55039507704,
+                "congestion_cost": 185626720683,
+                "congestion_multiplier": 4352283227
+            }
+        }
+    },
+    {
+        "l1_block_number": 20974634,
+        "l1_fees": {
+            "blob_fee": 1,
+            "base_fee": 10010324507
+        },
+        "parent_header": {
+            "excess_mana": 1257009048,
+            "mana_used": 151212674,
+            "proving_cost_per_mana_numerator": 809308729,
+            "fee_asset_price_numerator": 870419648
+        },
+        "header": {
+            "excess_mana": 1308221722,
+            "mana_used": 101948161,
+            "proving_cost_per_mana_numerator": 809758637,
+            "fee_asset_price_numerator": 0
+        },
+        "oracle_input": {
+            "proving_cost_modifier": 449908,
+            "fee_asset_price_modifier": -1000000000
+        },
+        "outputs": {
+            "fee_asset_price_at_execution": 10087421881,
+            "mana_base_fee_components_in_wei": {
+                "data_cost": 0,
+                "gas_cost": 33159199,
+                "proving_cost": 5459362746,
+                "congestion_cost": 19888632222,
+                "congestion_multiplier": 4621038281
+            },
+            "mana_base_fee_components_in_fee_asset": {
+                "data_cost": 0,
+                "gas_cost": 334490829,
+                "proving_cost": 55070895220,
+                "congestion_cost": 200625023859,
+                "congestion_multiplier": 4621038281
+            }
+        }
+    },
+    {
+        "l1_block_number": 20974637,
+        "l1_fees": {
+            "blob_fee": 1,
+            "base_fee": 10017086529
+        },
+        "parent_header": {
+            "excess_mana": 1308221722,
+            "mana_used": 101948161,
+            "proving_cost_per_mana_numerator": 809758637,
+            "fee_asset_price_numerator": 0
+        },
+        "header": {
+            "excess_mana": 1310169883,
+            "mana_used": 111174043,
+            "proving_cost_per_mana_numerator": 741892216,
+            "fee_asset_price_numerator": 0
+        },
+        "oracle_input": {
+            "proving_cost_modifier": -67866421,
+            "fee_asset_price_modifier": -726341690
+        },
+        "outputs": {
+            "fee_asset_price_at_execution": 10000000000,
+            "mana_base_fee_components_in_wei": {
+                "data_cost": 0,
+                "gas_cost": 33181599,
+                "proving_cost": 5459387308,
+                "congestion_cost": 19946721242,
+                "congestion_multiplier": 4631583250
+            },
+            "mana_base_fee_components_in_fee_asset": {
+                "data_cost": 0,
+                "gas_cost": 331815990,
+                "proving_cost": 54593873080,
+                "congestion_cost": 199467212420,
+                "congestion_multiplier": 4631583250
+            }
+        }
+    },
+    {
+        "l1_block_number": 20974640,
+        "l1_fees": {
+            "blob_fee": 1,
+            "base_fee": 10370308177
+        },
+        "parent_header": {
+            "excess_mana": 1310169883,
+            "mana_used": 111174043,
+            "proving_cost_per_mana_numerator": 741892216,
+            "fee_asset_price_numerator": 0
+        },
+        "header": {
+            "excess_mana": 1321343926,
+            "mana_used": 94802248,
+            "proving_cost_per_mana_numerator": 773959935,
+            "fee_asset_price_numerator": 114448902
+        },
+        "oracle_input": {
+            "proving_cost_modifier": 32067719,
+            "fee_asset_price_modifier": 114448902
+        },
+        "outputs": {
+            "fee_asset_price_at_execution": 10000000000,
+            "mana_base_fee_components_in_wei": {
+                "data_cost": 0,
+                "gas_cost": 34351645,
+                "proving_cost": 5455683475,
+                "congestion_cost": 20272132568,
+                "congestion_multiplier": 4692532402
+            },
+            "mana_base_fee_components_in_fee_asset": {
+                "data_cost": 0,
+                "gas_cost": 343516450,
+                "proving_cost": 54556834750,
+                "congestion_cost": 202721325680,
+                "congestion_multiplier": 4692532402
+            }
+        }
+    },
+    {
+        "l1_block_number": 20974643,
+        "l1_fees": {
+            "blob_fee": 1,
+            "base_fee": 10404764610
+        },
+        "parent_header": {
+            "excess_mana": 1321343926,
+            "mana_used": 94802248,
+            "proving_cost_per_mana_numerator": 773959935,
+            "fee_asset_price_numerator": 114448902
+        },
+        "header": {
+            "excess_mana": 1316146174,
+            "mana_used": 109144403,
+            "proving_cost_per_mana_numerator": 798378003,
+            "fee_asset_price_numerator": 0
+        },
+        "oracle_input": {
+            "proving_cost_modifier": 24418068,
+            "fee_asset_price_modifier": -501532851
+        },
+        "outputs": {
+            "fee_asset_price_at_execution": 10011451441,
+            "mana_base_fee_components_in_wei": {
+                "data_cost": 0,
+                "gas_cost": 34465782,
+                "proving_cost": 5457433268,
+                "congestion_cost": 20122768312,
+                "congestion_multiplier": 4664081974
+            },
+            "mana_base_fee_components_in_fee_asset": {
+                "data_cost": 0,
+                "gas_cost": 345052502,
+                "proving_cost": 54636828155,
+                "congestion_cost": 201458117814,
+                "congestion_multiplier": 4664081974
+            }
+        }
+    },
+    {
+        "l1_block_number": 20974646,
+        "l1_fees": {
+            "blob_fee": 1,
+            "base_fee": 10629066393
+        },
+        "parent_header": {
+            "excess_mana": 1316146174,
+            "mana_used": 109144403,
+            "proving_cost_per_mana_numerator": 798378003,
+            "fee_asset_price_numerator": 0
+        },
+        "header": {
+            "excess_mana": 1325290577,
+            "mana_used": 34899899,
+            "proving_cost_per_mana_numerator": 839834293,
+            "fee_asset_price_numerator": 457917274
+        },
+        "oracle_input": {
+            "proving_cost_modifier": 41456290,
+            "fee_asset_price_modifier": 457917274
+        },
+        "outputs": {
+            "fee_asset_price_at_execution": 10000000000,
+            "mana_base_fee_components_in_wei": {
+                "data_cost": 0,
+                "gas_cost": 35208782,
+                "proving_cost": 5458766031,
+                "congestion_cost": 20405999564,
+                "congestion_multiplier": 4714250658
+            },
+            "mana_base_fee_components_in_fee_asset": {
+                "data_cost": 0,
+                "gas_cost": 352087820,
+                "proving_cost": 54587660310,
+                "congestion_cost": 204059995640,
+                "congestion_multiplier": 4714250658
+            }
+        }
+    },
+    {
+        "l1_block_number": 20974649,
+        "l1_fees": {
+            "blob_fee": 1,
+            "base_fee": 10631215552
+        },
+        "parent_header": {
+            "excess_mana": 1325290577,
+            "mana_used": 34899899,
+            "proving_cost_per_mana_numerator": 839834293,
+            "fee_asset_price_numerator": 457917274
+        },
+        "header": {
+            "excess_mana": 1260190476,
+            "mana_used": 128319221,
+            "proving_cost_per_mana_numerator": 981905891,
+            "fee_asset_price_numerator": 1121443867
+        },
+        "oracle_input": {
+            "proving_cost_modifier": 142071598,
+            "fee_asset_price_modifier": 663526593
+        },
+        "outputs": {
+            "fee_asset_price_at_execution": 10045896731,
+            "mana_base_fee_components_in_wei": {
+                "data_cost": 0,
+                "gas_cost": 35215901,
+                "proving_cost": 5461029502,
+                "congestion_cost": 18514178449,
+                "congestion_multiplier": 4368513793
+            },
+            "mana_base_fee_components_in_fee_asset": {
+                "data_cost": 0,
+                "gas_cost": 353775304,
+                "proving_cost": 54860938422,
+                "congestion_cost": 185991524757,
+                "congestion_multiplier": 4368513793
+            }
+        }
+    },
+    {
+        "l1_block_number": 20974652,
+        "l1_fees": {
+            "blob_fee": 1,
+            "base_fee": 10463260499
+        },
+        "parent_header": {
+            "excess_mana": 1260190476,
+            "mana_used": 128319221,
+            "proving_cost_per_mana_numerator": 981905891,
+            "fee_asset_price_numerator": 1121443867
+        },
+        "header": {
+            "excess_mana": 1288509697,
+            "mana_used": 124344163,
+            "proving_cost_per_mana_numerator": 835441805,
+            "fee_asset_price_numerator": 944547786
+        },
+        "oracle_input": {
+            "proving_cost_modifier": -146464086,
+            "fee_asset_price_modifier": -176896081
+        },
+        "outputs": {
+            "fee_asset_price_at_execution": 10112775562,
+            "mana_base_fee_components_in_wei": {
+                "data_cost": 0,
+                "gas_cost": 34659550,
+                "proving_cost": 5468793588,
+                "congestion_cost": 19348394095,
+                "congestion_multiplier": 4515682538
+            },
+            "mana_base_fee_components_in_fee_asset": {
+                "data_cost": 0,
+                "gas_cost": 350504250,
+                "proving_cost": 55304682150,
+                "congestion_cost": 195665966967,
+                "congestion_multiplier": 4515682538
+            }
+        }
+    },
+    {
+        "l1_block_number": 20974655,
+        "l1_fees": {
+            "blob_fee": 1,
+            "base_fee": 10685244750
+        },
+        "parent_header": {
+            "excess_mana": 1288509697,
+            "mana_used": 124344163,
+            "proving_cost_per_mana_numerator": 835441805,
+            "fee_asset_price_numerator": 944547786
+        },
+        "header": {
+            "excess_mana": 1312853860,
+            "mana_used": 102282782,
+            "proving_cost_per_mana_numerator": 809561222,
+            "fee_asset_price_numerator": 1057140318
+        },
+        "oracle_input": {
+            "proving_cost_modifier": -25880583,
+            "fee_asset_price_modifier": 112592532
+        },
+        "outputs": {
+            "fee_asset_price_at_execution": 10094902271,
+            "mana_base_fee_components_in_wei": {
+                "data_cost": 0,
+                "gas_cost": 35394873,
+                "proving_cost": 5460789632,
+                "congestion_cost": 20039915628,
+                "congestion_multiplier": 4646150454
+            },
+            "mana_base_fee_components_in_fee_asset": {
+                "data_cost": 0,
+                "gas_cost": 357307783,
+                "proving_cost": 55126137657,
+                "congestion_cost": 202300989783,
+                "congestion_multiplier": 4646150454
+            }
+        }
+    },
+    {
+        "l1_block_number": 20974658,
+        "l1_fees": {
+            "blob_fee": 1,
+            "base_fee": 10095519528
+        },
+        "parent_header": {
+            "excess_mana": 1312853860,
+            "mana_used": 102282782,
+            "proving_cost_per_mana_numerator": 809561222,
+            "fee_asset_price_numerator": 1057140318
+        },
+        "header": {
+            "excess_mana": 1315136642,
+            "mana_used": 92935415,
+            "proving_cost_per_mana_numerator": 706535974,
+            "fee_asset_price_numerator": 1963428252
+        },
+        "oracle_input": {
+            "proving_cost_modifier": -103025248,
+            "fee_asset_price_modifier": 906287934
+        },
+        "outputs": {
+            "fee_asset_price_at_execution": 10106274778,
+            "mana_base_fee_components_in_wei": {
+                "data_cost": 0,
+                "gas_cost": 33441408,
+                "proving_cost": 5459376531,
+                "congestion_cost": 20095893169,
+                "congestion_multiplier": 4658576234
+            },
+            "mana_base_fee_components_in_fee_asset": {
+                "data_cost": 0,
+                "gas_cost": 337968058,
+                "proving_cost": 55173959338,
+                "congestion_cost": 203094618275,
+                "congestion_multiplier": 4658576234
+            }
+        }
+    },
+    {
+        "l1_block_number": 20974661,
+        "l1_fees": {
+            "blob_fee": 1,
+            "base_fee": 9964934916
+        },
+        "parent_header": {
+            "excess_mana": 1315136642,
+            "mana_used": 92935415,
+            "proving_cost_per_mana_numerator": 706535974,
+            "fee_asset_price_numerator": 1963428252
+        },
+        "header": {
+            "excess_mana": 1308072057,
+            "mana_used": 6890906,
+            "proving_cost_per_mana_numerator": 553003059,
+            "fee_asset_price_numerator": 1708530634
+        },
+        "oracle_input": {
+            "proving_cost_modifier": -153532915,
+            "fee_asset_price_modifier": -254897618
+        },
+        "outputs": {
+            "fee_asset_price_at_execution": 10198283027,
+            "mana_base_fee_components_in_wei": {
+                "data_cost": 0,
+                "gas_cost": 33008846,
+                "proving_cost": 5453754891,
+                "congestion_cost": 19863342129,
+                "congestion_multiplier": 4620229170
+            },
+            "mana_base_fee_components_in_fee_asset": {
+                "data_cost": 0,
+                "gas_cost": 336633553,
+                "proving_cost": 55618935938,
+                "congestion_cost": 202571984893,
+                "congestion_multiplier": 4620229170
+            }
+        }
+    },
+    {
+        "l1_block_number": 20974664,
+        "l1_fees": {
+            "blob_fee": 1,
+            "base_fee": 9868829086
+        },
+        "parent_header": {
+            "excess_mana": 1308072057,
+            "mana_used": 6890906,
+            "proving_cost_per_mana_numerator": 553003059,
+            "fee_asset_price_numerator": 1708530634
+        },
+        "header": {
+            "excess_mana": 1214962963,
+            "mana_used": 191542383,
+            "proving_cost_per_mana_numerator": 649849607,
+            "fee_asset_price_numerator": 2185828457
+        },
+        "oracle_input": {
+            "proving_cost_modifier": 96846548,
+            "fee_asset_price_modifier": 477297823
+        },
+        "outputs": {
+            "fee_asset_price_at_execution": 10172320949,
+            "mana_base_fee_components_in_wei": {
+                "data_cost": 0,
+                "gas_cost": 32690496,
+                "proving_cost": 5445388007,
+                "congestion_cost": 17219564100,
+                "congestion_multiplier": 4143358404
+            },
+            "mana_base_fee_components_in_fee_asset": {
+                "data_cost": 0,
+                "gas_cost": 332538217,
+                "proving_cost": 55392234499,
+                "congestion_cost": 175162932627,
+                "congestion_multiplier": 4143358404
+            }
+        }
+    },
+    {
+        "l1_block_number": 20974667,
+        "l1_fees": {
+            "blob_fee": 1,
+            "base_fee": 9796157813
+        },
+        "parent_header": {
+            "excess_mana": 1214962963,
+            "mana_used": 191542383,
+            "proving_cost_per_mana_numerator": 649849607,
+            "fee_asset_price_numerator": 2185828457
+        },
+        "header": {
+            "excess_mana": 1306505346,
+            "mana_used": 112909870,
+            "proving_cost_per_mana_numerator": 576325080,
+            "fee_asset_price_numerator": 2027932310
+        },
+        "oracle_input": {
+            "proving_cost_modifier": -73524527,
+            "fee_asset_price_modifier": -157896147
+        },
+        "outputs": {
+            "fee_asset_price_at_execution": 10220989270,
+            "mana_base_fee_components_in_wei": {
+                "data_cost": 0,
+                "gas_cost": 32449772,
+                "proving_cost": 5450664231,
+                "congestion_cost": 19803734643,
+                "congestion_multiplier": 4611767808
+            },
+            "mana_base_fee_components_in_fee_asset": {
+                "data_cost": 0,
+                "gas_cost": 331668771,
+                "proving_cost": 55711180619,
+                "congestion_cost": 202413759292,
+                "congestion_multiplier": 4611767808
+            }
+        }
+    },
+    {
+        "l1_block_number": 20974670,
+        "l1_fees": {
+            "blob_fee": 1,
+            "base_fee": 9423895660
+        },
+        "parent_header": {
+            "excess_mana": 1306505346,
+            "mana_used": 112909870,
+            "proving_cost_per_mana_numerator": 576325080,
+            "fee_asset_price_numerator": 2027932310
+        },
+        "header": {
+            "excess_mana": 1319415216,
+            "mana_used": 88953936,
+            "proving_cost_per_mana_numerator": 561262646,
+            "fee_asset_price_numerator": 2413894340
+        },
+        "oracle_input": {
+            "proving_cost_modifier": -15062434,
+            "fee_asset_price_modifier": 385962030
+        },
+        "outputs": {
+            "fee_asset_price_at_execution": 10204863456,
+            "mana_base_fee_components_in_wei": {
+                "data_cost": 0,
+                "gas_cost": 31216654,
+                "proving_cost": 5446658129,
+                "congestion_cost": 20169289629,
+                "congestion_multiplier": 4681955216
+            },
+            "mana_base_fee_components_in_fee_asset": {
+                "data_cost": 0,
+                "gas_cost": 318561691,
+                "proving_cost": 55582402497,
+                "congestion_cost": 205824846668,
+                "congestion_multiplier": 4681955216
+            }
+        }
+    },
+    {
+        "l1_block_number": 20974673,
+        "l1_fees": {
+            "blob_fee": 1,
+            "base_fee": 8779402628
+        },
+        "parent_header": {
+            "excess_mana": 1319415216,
+            "mana_used": 88953936,
+            "proving_cost_per_mana_numerator": 561262646,
+            "fee_asset_price_numerator": 2413894340
+        },
+        "header": {
+            "excess_mana": 1308369152,
+            "mana_used": 108956671,
+            "proving_cost_per_mana_numerator": 561045656,
+            "fee_asset_price_numerator": 1553870436
+        },
+        "oracle_input": {
+            "proving_cost_modifier": -216990,
+            "fee_asset_price_modifier": -860023904
+        },
+        "outputs": {
+            "fee_asset_price_at_execution": 10244326461,
+            "mana_base_fee_components_in_wei": {
+                "data_cost": 0,
+                "gas_cost": 29081771,
+                "proving_cost": 5445837792,
+                "congestion_cost": 19829257737,
+                "congestion_multiplier": 4621835446
+            },
+            "mana_base_fee_components_in_fee_asset": {
+                "data_cost": 0,
+                "gas_cost": 297923156,
+                "proving_cost": 55788940194,
+                "congestion_cost": 203137389737,
+                "congestion_multiplier": 4621835446
+            }
+        }
+    },
+    {
+        "l1_block_number": 20974676,
+        "l1_fees": {
+            "blob_fee": 1,
+            "base_fee": 9296854474
+        },
+        "parent_header": {
+            "excess_mana": 1308369152,
+            "mana_used": 108956671,
+            "proving_cost_per_mana_numerator": 561045656,
+            "fee_asset_price_numerator": 1553870436
+        },
+        "header": {
+            "excess_mana": 1317325823,
+            "mana_used": 94389617,
+            "proving_cost_per_mana_numerator": 550791710,
+            "fee_asset_price_numerator": 769518212
+        },
+        "oracle_input": {
+            "proving_cost_modifier": -10253946,
+            "fee_asset_price_modifier": -784352224
+        },
+        "outputs": {
+            "fee_asset_price_at_execution": 10156600577,
+            "mana_base_fee_components_in_wei": {
+                "data_cost": 0,
+                "gas_cost": 30795830,
+                "proving_cost": 5445825975,
+                "congestion_cost": 20102070317,
+                "congestion_multiplier": 4670523734
+            },
+            "mana_base_fee_components_in_fee_asset": {
+                "data_cost": 0,
+                "gas_cost": 312780944,
+                "proving_cost": 55311079239,
+                "congestion_cost": 204168698980,
+                "congestion_multiplier": 4670523734
+            }
+        }
+    },
+    {
+        "l1_block_number": 20974679,
+        "l1_fees": {
+            "blob_fee": 1,
+            "base_fee": 9564836737
+        },
+        "parent_header": {
+            "excess_mana": 1317325823,
+            "mana_used": 94389617,
+            "proving_cost_per_mana_numerator": 550791710,
+            "fee_asset_price_numerator": 769518212
+        },
+        "header": {
+            "excess_mana": 1311715440,
+            "mana_used": 102928262,
+            "proving_cost_per_mana_numerator": 576833814,
+            "fee_asset_price_numerator": 741678651
+        },
+        "oracle_input": {
+            "proving_cost_modifier": 26042104,
+            "fee_asset_price_modifier": -27839561
+        },
+        "outputs": {
+            "fee_asset_price_at_execution": 10077248661,
+            "mana_base_fee_components_in_wei": {
+                "data_cost": 0,
+                "gas_cost": 31683521,
+                "proving_cost": 5445267591,
+                "congestion_cost": 19935916526,
+                "congestion_multiplier": 4639966127
+            },
+            "mana_base_fee_components_in_fee_asset": {
+                "data_cost": 0,
+                "gas_cost": 319282719,
+                "proving_cost": 54873315540,
+                "congestion_cost": 200899188117,
+                "congestion_multiplier": 4639966127
+            }
+        }
+    },
+    {
+        "l1_block_number": 20974682,
+        "l1_fees": {
+            "blob_fee": 1,
+            "base_fee": 9381667937
+        },
+        "parent_header": {
+            "excess_mana": 1311715440,
+            "mana_used": 102928262,
+            "proving_cost_per_mana_numerator": 576833814,
+            "fee_asset_price_numerator": 741678651
+        },
+        "header": {
+            "excess_mana": 1314643702,
+            "mana_used": 108617085,
+            "proving_cost_per_mana_numerator": 526666518,
+            "fee_asset_price_numerator": 351476175
+        },
+        "oracle_input": {
+            "proving_cost_modifier": -50167296,
+            "fee_asset_price_modifier": -390202476
+        },
+        "outputs": {
+            "fee_asset_price_at_execution": 10074443589,
+            "mana_base_fee_components_in_wei": {
+                "data_cost": 0,
+                "gas_cost": 31076775,
+                "proving_cost": 5446685838,
+                "congestion_cost": 20026098775,
+                "congestion_multiplier": 4655890222
+            },
+            "mana_base_fee_components_in_fee_asset": {
+                "data_cost": 0,
+                "gas_cost": 313081216,
+                "proving_cost": 54872329221,
+                "congestion_cost": 201751802416,
+                "congestion_multiplier": 4655890222
+            }
+        }
+    },
+    {
+        "l1_block_number": 20974685,
+        "l1_fees": {
+            "blob_fee": 1,
+            "base_fee": 10397713754
+        },
+        "parent_header": {
+            "excess_mana": 1314643702,
+            "mana_used": 108617085,
+            "proving_cost_per_mana_numerator": 526666518,
+            "fee_asset_price_numerator": 351476175
+        },
+        "header": {
+            "excess_mana": 1323260787,
+            "mana_used": 31017300,
+            "proving_cost_per_mana_numerator": 449660495,
+            "fee_asset_price_numerator": 0
+        },
+        "oracle_input": {
+            "proving_cost_modifier": -77006023,
+            "fee_asset_price_modifier": -788587719
+        },
+        "outputs": {
+            "fee_asset_price_at_execution": 10035209457,
+            "mana_base_fee_components_in_wei": {
+                "data_cost": 0,
+                "gas_cost": 34442426,
+                "proving_cost": 5443954069,
+                "congestion_cost": 20286876302,
+                "congestion_multiplier": 4703068283
+            },
+            "mana_base_fee_components_in_fee_asset": {
+                "data_cost": 0,
+                "gas_cost": 345636959,
+                "proving_cost": 54631219356,
+                "congestion_cost": 203583052918,
+                "congestion_multiplier": 4703068283
+            }
+        }
+    },
+    {
+        "l1_block_number": 20974688,
+        "l1_fees": {
+            "blob_fee": 1,
+            "base_fee": 9445339829
+        },
+        "parent_header": {
+            "excess_mana": 1323260787,
+            "mana_used": 31017300,
+            "proving_cost_per_mana_numerator": 449660495,
+            "fee_asset_price_numerator": 0
+        },
+        "header": {
+            "excess_mana": 1254278087,
+            "mana_used": 141703611,
+            "proving_cost_per_mana_numerator": 494464778,
+            "fee_asset_price_numerator": 227098236
+        },
+        "oracle_input": {
+            "proving_cost_modifier": 44804283,
+            "fee_asset_price_modifier": 227098236
+        },
+        "outputs": {
+            "fee_asset_price_at_execution": 10000000000,
+            "mana_base_fee_components_in_wei": {
+                "data_cost": 0,
+                "gas_cost": 31287688,
+                "proving_cost": 5439763510,
+                "congestion_cost": 18264551295,
+                "congestion_multiplier": 4338398899
+            },
+            "mana_base_fee_components_in_fee_asset": {
+                "data_cost": 0,
+                "gas_cost": 312876880,
+                "proving_cost": 54397635100,
+                "congestion_cost": 182645512950,
+                "congestion_multiplier": 4338398899
+            }
+        }
+    },
+    {
+        "l1_block_number": 20974691,
+        "l1_fees": {
+            "blob_fee": 1,
+            "base_fee": 9351751903
+        },
+        "parent_header": {
+            "excess_mana": 1254278087,
+            "mana_used": 141703611,
+            "proving_cost_per_mana_numerator": 494464778,
+            "fee_asset_price_numerator": 227098236
+        },
+        "header": {
+            "excess_mana": 1295981698,
+            "mana_used": 112723984,
+            "proving_cost_per_mana_numerator": 379373842,
+            "fee_asset_price_numerator": 0
+        },
+        "oracle_input": {
+            "proving_cost_modifier": -115090936,
+            "fee_asset_price_modifier": -707254472
+        },
+        "outputs": {
+            "fee_asset_price_at_execution": 10022735629,
+            "mana_base_fee_components_in_wei": {
+                "data_cost": 0,
+                "gas_cost": 30977678,
+                "proving_cost": 5442201303,
+                "congestion_cost": 19458972680,
+                "congestion_multiplier": 4555332787
+            },
+            "mana_base_fee_components_in_fee_asset": {
+                "data_cost": 0,
+                "gas_cost": 310481076,
+                "proving_cost": 54545744899,
+                "congestion_cost": 195032138783,
+                "congestion_multiplier": 4555332787
+            }
+        }
+    },
+    {
+        "l1_block_number": 20974694,
+        "l1_fees": {
+            "blob_fee": 1,
+            "base_fee": 9403513294
+        },
+        "parent_header": {
+            "excess_mana": 1295981698,
+            "mana_used": 112723984,
+            "proving_cost_per_mana_numerator": 379373842,
+            "fee_asset_price_numerator": 0
+        },
+        "header": {
+            "excess_mana": 1308705682,
+            "mana_used": 106107340,
+            "proving_cost_per_mana_numerator": 487357271,
+            "fee_asset_price_numerator": 873296007
+        },
+        "oracle_input": {
+            "proving_cost_modifier": 107983429,
+            "fee_asset_price_modifier": 873296007
+        },
+        "outputs": {
+            "fee_asset_price_at_execution": 10000000000,
+            "mana_base_fee_components_in_wei": {
+                "data_cost": 0,
+                "gas_cost": 31149137,
+                "proving_cost": 5435941425,
+                "congestion_cost": 19810853368,
+                "congestion_multiplier": 4623655607
+            },
+            "mana_base_fee_components_in_fee_asset": {
+                "data_cost": 0,
+                "gas_cost": 311491370,
+                "proving_cost": 54359414250,
+                "congestion_cost": 198108533680,
+                "congestion_multiplier": 4623655607
+            }
+        }
+    },
+    {
+        "l1_block_number": 20974697,
+        "l1_fees": {
+            "blob_fee": 1,
+            "base_fee": 10065091506
+        },
+        "parent_header": {
+            "excess_mana": 1308705682,
+            "mana_used": 106107340,
+            "proving_cost_per_mana_numerator": 487357271,
+            "fee_asset_price_numerator": 873296007
+        },
+        "header": {
+            "excess_mana": 1314813022,
+            "mana_used": 102389524,
+            "proving_cost_per_mana_numerator": 476280958,
+            "fee_asset_price_numerator": 16767761
+        },
+        "oracle_input": {
+            "proving_cost_modifier": -11076313,
+            "fee_asset_price_modifier": -856528246
+        },
+        "outputs": {
+            "fee_asset_price_at_execution": 10087712036,
+            "mana_base_fee_components_in_wei": {
+                "data_cost": 0,
+                "gas_cost": 33340615,
+                "proving_cost": 5441814512,
+                "congestion_cost": 20021616616,
+                "congestion_multiplier": 4656812666
+            },
+            "mana_base_fee_components_in_fee_asset": {
+                "data_cost": 0,
+                "gas_cost": 336330523,
+                "proving_cost": 54895457750,
+                "congestion_cost": 201972302917,
+                "congestion_multiplier": 4656812666
+            }
+        }
+    },
+    {
+        "l1_block_number": 20974700,
+        "l1_fees": {
+            "blob_fee": 1,
+            "base_fee": 9772465608
+        },
+        "parent_header": {
+            "excess_mana": 1314813022,
+            "mana_used": 102389524,
+            "proving_cost_per_mana_numerator": 476280958,
+            "fee_asset_price_numerator": 16767761
+        },
+        "header": {
+            "excess_mana": 1317202546,
+            "mana_used": 106334484,
+            "proving_cost_per_mana_numerator": 284814652,
+            "fee_asset_price_numerator": 0
+        },
+        "oracle_input": {
+            "proving_cost_modifier": -191466306,
+            "fee_asset_price_modifier": -345823326
+        },
+        "outputs": {
+            "fee_asset_price_at_execution": 10001676916,
+            "mana_base_fee_components_in_wei": {
+                "data_cost": 0,
+                "gas_cost": 32371292,
+                "proving_cost": 5441211793,
+                "congestion_cost": 20087229617,
+                "congestion_multiplier": 4669850134
+            },
+            "mana_base_fee_components_in_fee_asset": {
+                "data_cost": 0,
+                "gas_cost": 323767203,
+                "proving_cost": 54421242385,
+                "congestion_cost": 200905980766,
+                "congestion_multiplier": 4669850134
+            }
+        }
+    },
+    {
+        "l1_block_number": 20974703,
+        "l1_fees": {
+            "blob_fee": 1,
+            "base_fee": 10113104790
+        },
+        "parent_header": {
+            "excess_mana": 1317202546,
+            "mana_used": 106334484,
+            "proving_cost_per_mana_numerator": 284814652,
+            "fee_asset_price_numerator": 0
+        },
+        "header": {
+            "excess_mana": 1323537030,
+            "mana_used": 106033158,
+            "proving_cost_per_mana_numerator": 315246449,
+            "fee_asset_price_numerator": 0
+        },
+        "oracle_input": {
+            "proving_cost_modifier": 30431797,
+            "fee_asset_price_modifier": -538742087
+        },
+        "outputs": {
+            "fee_asset_price_at_execution": 10000000000,
+            "mana_base_fee_components_in_wei": {
+                "data_cost": 0,
+                "gas_cost": 33499659,
+                "proving_cost": 5430803673,
+                "congestion_cost": 20242995726,
+                "congestion_multiplier": 4704588581
+            },
+            "mana_base_fee_components_in_fee_asset": {
+                "data_cost": 0,
+                "gas_cost": 334996590,
+                "proving_cost": 54308036730,
+                "congestion_cost": 202429957260,
+                "congestion_multiplier": 4704588581
+            }
+        }
+    },
+    {
+        "l1_block_number": 20974706,
+        "l1_fees": {
+            "blob_fee": 1,
+            "base_fee": 9897877678
+        },
+        "parent_header": {
+            "excess_mana": 1323537030,
+            "mana_used": 106033158,
+            "proving_cost_per_mana_numerator": 315246449,
+            "fee_asset_price_numerator": 0
+        },
+        "header": {
+            "excess_mana": 1329570188,
+            "mana_used": 100781150,
+            "proving_cost_per_mana_numerator": 210183547,
+            "fee_asset_price_numerator": 0
+        },
+        "oracle_input": {
+            "proving_cost_modifier": -105062902,
+            "fee_asset_price_modifier": -356469643
+        },
+        "outputs": {
+            "fee_asset_price_at_execution": 10000000000,
+            "mana_base_fee_components_in_wei": {
+                "data_cost": 0,
+                "gas_cost": 32786719,
+                "proving_cost": 5432456615,
+                "congestion_cost": 20428613889,
+                "congestion_multiplier": 4737914790
+            },
+            "mana_base_fee_components_in_fee_asset": {
+                "data_cost": 0,
+                "gas_cost": 327867190,
+                "proving_cost": 54324566150,
+                "congestion_cost": 204286138890,
+                "congestion_multiplier": 4737914790
+            }
+        }
+    },
+    {
+        "l1_block_number": 20974709,
+        "l1_fees": {
+            "blob_fee": 1,
+            "base_fee": 9638505207
+        },
+        "parent_header": {
+            "excess_mana": 1329570188,
+            "mana_used": 100781150,
+            "proving_cost_per_mana_numerator": 210183547,
+            "fee_asset_price_numerator": 0
+        },
+        "header": {
+            "excess_mana": 1330351338,
+            "mana_used": 90026211,
+            "proving_cost_per_mana_numerator": 216028422,
+            "fee_asset_price_numerator": 889353403
+        },
+        "oracle_input": {
+            "proving_cost_modifier": 5844875,
+            "fee_asset_price_modifier": 889353403
+        },
+        "outputs": {
+            "fee_asset_price_at_execution": 10000000000,
+            "mana_base_fee_components_in_wei": {
+                "data_cost": 0,
+                "gas_cost": 31927548,
+                "proving_cost": 5426752116,
+                "congestion_cost": 20427727405,
+                "congestion_multiplier": 4742246965
+            },
+            "mana_base_fee_components_in_fee_asset": {
+                "data_cost": 0,
+                "gas_cost": 319275480,
+                "proving_cost": 54267521160,
+                "congestion_cost": 204277274050,
+                "congestion_multiplier": 4742246965
+            }
+        }
+    },
+    {
+        "l1_block_number": 20974712,
+        "l1_fees": {
+            "blob_fee": 1,
+            "base_fee": 9788093852
+        },
+        "parent_header": {
+            "excess_mana": 1330351338,
+            "mana_used": 90026211,
+            "proving_cost_per_mana_numerator": 216028422,
+            "fee_asset_price_numerator": 889353403
+        },
+        "header": {
+            "excess_mana": 1320377549,
+            "mana_used": 96281835,
+            "proving_cost_per_mana_numerator": 90907125,
+            "fee_asset_price_numerator": 874788918
+        },
+        "oracle_input": {
+            "proving_cost_modifier": -125121297,
+            "fee_asset_price_modifier": -14564485
+        },
+        "outputs": {
+            "fee_asset_price_at_execution": 10089331990,
+            "mana_base_fee_components_in_wei": {
+                "data_cost": 0,
+                "gas_cost": 32423060,
+                "proving_cost": 5427069312,
+                "congestion_cost": 20130402622,
+                "congestion_multiplier": 4687229737
+            },
+            "mana_base_fee_components_in_fee_asset": {
+                "data_cost": 0,
+                "gas_cost": 327127016,
+                "proving_cost": 54755504021,
+                "congestion_cost": 203102315145,
+                "congestion_multiplier": 4687229737
+            }
+        }
+    },
+    {
+        "l1_block_number": 20974715,
+        "l1_fees": {
+            "blob_fee": 1,
+            "base_fee": 9591156391
+        },
+        "parent_header": {
+            "excess_mana": 1320377549,
+            "mana_used": 96281835,
+            "proving_cost_per_mana_numerator": 90907125,
+            "fee_asset_price_numerator": 874788918
+        },
+        "header": {
+            "excess_mana": 1316659384,
+            "mana_used": 98802156,
+            "proving_cost_per_mana_numerator": 226700020,
+            "fee_asset_price_numerator": 1227720857
+        },
+        "oracle_input": {
+            "proving_cost_modifier": 135792895,
+            "fee_asset_price_modifier": 352931939
+        },
+        "outputs": {
+            "fee_asset_price_at_execution": 10087862637,
+            "mana_base_fee_components_in_wei": {
+                "data_cost": 0,
+                "gas_cost": 31770705,
+                "proving_cost": 5420283139,
+                "congestion_cost": 19992045676,
+                "congestion_multiplier": 4666883389
+            },
+            "mana_base_fee_components_in_fee_asset": {
+                "data_cost": 0,
+                "gas_cost": 320498507,
+                "proving_cost": 54679071759,
+                "congestion_cost": 201677010612,
+                "congestion_multiplier": 4666883389
+            }
+        }
+    },
+    {
+        "l1_block_number": 20974718,
+        "l1_fees": {
+            "blob_fee": 1,
+            "base_fee": 10060943500
+        },
+        "parent_header": {
+            "excess_mana": 1316659384,
+            "mana_used": 98802156,
+            "proving_cost_per_mana_numerator": 226700020,
+            "fee_asset_price_numerator": 1227720857
+        },
+        "header": {
+            "excess_mana": 1315461540,
+            "mana_used": 103467904,
+            "proving_cost_per_mana_numerator": 177575230,
+            "fee_asset_price_numerator": 1609108682
+        },
+        "oracle_input": {
+            "proving_cost_modifier": -49124790,
+            "fee_asset_price_modifier": 381387825
+        },
+        "outputs": {
+            "fee_asset_price_at_execution": 10123528828,
+            "mana_base_fee_components_in_wei": {
+                "data_cost": 0,
+                "gas_cost": 33326875,
+                "proving_cost": 5427648498,
+                "congestion_cost": 19989067215,
+                "congestion_multiplier": 4660347438
+            },
+            "mana_base_fee_components_in_fee_asset": {
+                "data_cost": 0,
+                "gas_cost": 337385579,
+                "proving_cost": 54946956037,
+                "congestion_cost": 202359898195,
+                "congestion_multiplier": 4660347438
+            }
+        }
+    },
+    {
+        "l1_block_number": 20974721,
+        "l1_fees": {
+            "blob_fee": 1,
+            "base_fee": 9931038619
+        },
+        "parent_header": {
+            "excess_mana": 1315461540,
+            "mana_used": 103467904,
+            "proving_cost_per_mana_numerator": 177575230,
+            "fee_asset_price_numerator": 1609108682
+        },
+        "header": {
+            "excess_mana": 1318929444,
+            "mana_used": 93820858,
+            "proving_cost_per_mana_numerator": 132035391,
+            "fee_asset_price_numerator": 1963088223
+        },
+        "oracle_input": {
+            "proving_cost_modifier": -45539839,
+            "fee_asset_price_modifier": 353979541
+        },
+        "outputs": {
+            "fee_asset_price_at_execution": 10162212455,
+            "mana_base_fee_components_in_wei": {
+                "data_cost": 0,
+                "gas_cost": 32896565,
+                "proving_cost": 5424982832,
+                "congestion_cost": 20081148201,
+                "congestion_multiplier": 4679294968
+            },
+            "mana_base_fee_components_in_fee_asset": {
+                "data_cost": 0,
+                "gas_cost": 334301882,
+                "proving_cost": 55129828103,
+                "congestion_cost": 204068894358,
+                "congestion_multiplier": 4679294968
+            }
+        }
+    },
+    {
+        "l1_block_number": 20974724,
+        "l1_fees": {
+            "blob_fee": 1,
+            "base_fee": 9547223674
+        },
+        "parent_header": {
+            "excess_mana": 1318929444,
+            "mana_used": 93820858,
+            "proving_cost_per_mana_numerator": 132035391,
+            "fee_asset_price_numerator": 1963088223
+        },
+        "header": {
+            "excess_mana": 1312750302,
+            "mana_used": 102433545,
+            "proving_cost_per_mana_numerator": 272099285,
+            "fee_asset_price_numerator": 2000138379
+        },
+        "oracle_input": {
+            "proving_cost_modifier": 140063894,
+            "fee_asset_price_modifier": 37050156
+        },
+        "outputs": {
+            "fee_asset_price_at_execution": 10198248350,
+            "mana_base_fee_components_in_wei": {
+                "data_cost": 0,
+                "gas_cost": 31625178,
+                "proving_cost": 5422512866,
+                "congestion_cost": 19883537732,
+                "congestion_multiplier": 4645587547
+            },
+            "mana_base_fee_components_in_fee_asset": {
+                "data_cost": 0,
+                "gas_cost": 322521419,
+                "proving_cost": 55300132888,
+                "congestion_cost": 202777255867,
+                "congestion_multiplier": 4645587547
+            }
+        }
+    },
+    {
+        "l1_block_number": 20974727,
+        "l1_fees": {
+            "blob_fee": 1,
+            "base_fee": 9057659802
+        },
+        "parent_header": {
+            "excess_mana": 1312750302,
+            "mana_used": 102433545,
+            "proving_cost_per_mana_numerator": 272099285,
+            "fee_asset_price_numerator": 2000138379
+        },
+        "header": {
+            "excess_mana": 1315183847,
+            "mana_used": 91742261,
+            "proving_cost_per_mana_numerator": 216089885,
+            "fee_asset_price_numerator": 2258197541
+        },
+        "oracle_input": {
+            "proving_cost_modifier": -56009400,
+            "fee_asset_price_modifier": 258059162
+        },
+        "outputs": {
+            "fee_asset_price_at_execution": 10202027517,
+            "mana_base_fee_components_in_wei": {
+                "data_cost": 0,
+                "gas_cost": 30003498,
+                "proving_cost": 5430113170,
+                "congestion_cost": 19977657964,
+                "congestion_multiplier": 4658833534
+            },
+            "mana_base_fee_components_in_fee_asset": {
+                "data_cost": 0,
+                "gas_cost": 306096512,
+                "proving_cost": 55398163980,
+                "congestion_cost": 203812616273,
+                "congestion_multiplier": 4658833534
+            }
+        }
+    },
+    {
+        "l1_block_number": 20974730,
+        "l1_fees": {
+            "blob_fee": 1,
+            "base_fee": 9445297033
+        },
+        "parent_header": {
+            "excess_mana": 1315183847,
+            "mana_used": 91742261,
+            "proving_cost_per_mana_numerator": 216089885,
+            "fee_asset_price_numerator": 2258197541
+        },
+        "header": {
+            "excess_mana": 1306926108,
+            "mana_used": 120537598,
+            "proving_cost_per_mana_numerator": 134913303,
+            "fee_asset_price_numerator": 1887680484
+        },
+        "oracle_input": {
+            "proving_cost_modifier": -81176582,
+            "fee_asset_price_modifier": -370517057
+        },
+        "outputs": {
+            "fee_asset_price_at_execution": 10228388783,
+            "mana_base_fee_components_in_wei": {
+                "data_cost": 0,
+                "gas_cost": 31287546,
+                "proving_cost": 5427072648,
+                "congestion_cost": 19726724985,
+                "congestion_multiplier": 4614038701
+            },
+            "mana_base_fee_components_in_fee_asset": {
+                "data_cost": 0,
+                "gas_cost": 320021184,
+                "proving_cost": 55510208997,
+                "congestion_cost": 201772612561,
+                "congestion_multiplier": 4614038701
+            }
+        }
+    },
+    {
+        "l1_block_number": 20974733,
+        "l1_fees": {
+            "blob_fee": 1,
+            "base_fee": 9930049927
+        },
+        "parent_header": {
+            "excess_mana": 1306926108,
+            "mana_used": 120537598,
+            "proving_cost_per_mana_numerator": 134913303,
+            "fee_asset_price_numerator": 1887680484
+        },
+        "header": {
+            "excess_mana": 1327463706,
+            "mana_used": 92120356,
+            "proving_cost_per_mana_numerator": 293230435,
+            "fee_asset_price_numerator": 1227976553
+        },
+        "oracle_input": {
+            "proving_cost_modifier": 158317132,
+            "fee_asset_price_modifier": -659703931
+        },
+        "outputs": {
+            "fee_asset_price_at_execution": 10190560981,
+            "mana_base_fee_components_in_wei": {
+                "data_cost": 0,
+                "gas_cost": 32893290,
+                "proving_cost": 5422668923,
+                "congestion_cost": 20328800583,
+                "congestion_multiplier": 4726252179
+            },
+            "mana_base_fee_components_in_fee_asset": {
+                "data_cost": 0,
+                "gas_cost": 335201077,
+                "proving_cost": 55260038339,
+                "congestion_cost": 207161882011,
+                "congestion_multiplier": 4726252179
+            }
+        }
+    },
+    {
+        "l1_block_number": 20974736,
+        "l1_fees": {
+            "blob_fee": 1,
+            "base_fee": 10365019463
+        },
+        "parent_header": {
+            "excess_mana": 1327463706,
+            "mana_used": 92120356,
+            "proving_cost_per_mana_numerator": 293230435,
+            "fee_asset_price_numerator": 1227976553
+        },
+        "header": {
+            "excess_mana": 1319584062,
+            "mana_used": 86406893,
+            "proving_cost_per_mana_numerator": 237640787,
+            "fee_asset_price_numerator": 1832755996
+        },
+        "oracle_input": {
+            "proving_cost_modifier": -55589648,
+            "fee_asset_price_modifier": 604779443
+        },
+        "outputs": {
+            "fee_asset_price_at_execution": 10123554714,
+            "mana_base_fee_components_in_wei": {
+                "data_cost": 0,
+                "gas_cost": 34334126,
+                "proving_cost": 5431260737,
+                "congestion_cost": 20129131249,
+                "congestion_multiplier": 4682880227
+            },
+            "mana_base_fee_components_in_fee_asset": {
+                "data_cost": 0,
+                "gas_cost": 347583403,
+                "proving_cost": 54983665237,
+                "congestion_cost": 203778361544,
+                "congestion_multiplier": 4682880227
+            }
+        }
+    },
+    {
+        "l1_block_number": 20974739,
+        "l1_fees": {
+            "blob_fee": 1,
+            "base_fee": 10874452459
+        },
+        "parent_header": {
+            "excess_mana": 1319584062,
+            "mana_used": 86406893,
+            "proving_cost_per_mana_numerator": 237640787,
+            "fee_asset_price_numerator": 1832755996
+        },
+        "header": {
+            "excess_mana": 1305990955,
+            "mana_used": 112381644,
+            "proving_cost_per_mana_numerator": 221200969,
+            "fee_asset_price_numerator": 1631151271
+        },
+        "oracle_input": {
+            "proving_cost_modifier": -16439818,
+            "fee_asset_price_modifier": -201604725
+        },
+        "outputs": {
+            "fee_asset_price_at_execution": 10184965404,
+            "mana_base_fee_components_in_wei": {
+                "data_cost": 0,
+                "gas_cost": 36021623,
+                "proving_cost": 5428242357,
+                "congestion_cost": 19720491044,
+                "congestion_multiplier": 4608993108
+            },
+            "mana_base_fee_components_in_fee_asset": {
+                "data_cost": 0,
+                "gas_cost": 366878984,
+                "proving_cost": 55286460610,
+                "congestion_cost": 200852519033,
+                "congestion_multiplier": 4608993108
+            }
+        }
+    },
+    {
+        "l1_block_number": 20974742,
+        "l1_fees": {
+            "blob_fee": 1,
+            "base_fee": 10537462271
+        },
+        "parent_header": {
+            "excess_mana": 1305990955,
+            "mana_used": 112381644,
+            "proving_cost_per_mana_numerator": 221200969,
+            "fee_asset_price_numerator": 1631151271
+        },
+        "header": {
+            "excess_mana": 1318372599,
+            "mana_used": 104606734,
+            "proving_cost_per_mana_numerator": 153703284,
+            "fee_asset_price_numerator": 1141096092
+        },
+        "oracle_input": {
+            "proving_cost_modifier": -67497685,
+            "fee_asset_price_modifier": -490055179
+        },
+        "outputs": {
+            "fee_asset_price_at_execution": 10164452717,
+            "mana_base_fee_components_in_wei": {
+                "data_cost": 0,
+                "gas_cost": 34905343,
+                "proving_cost": 5427350037,
+                "congestion_cost": 20080601914,
+                "congestion_multiplier": 4676247359
+            },
+            "mana_base_fee_components_in_fee_asset": {
+                "data_cost": 0,
+                "gas_cost": 354793708,
+                "proving_cost": 55166042829,
+                "congestion_cost": 204108328683,
+                "congestion_multiplier": 4676247359
+            }
+        }
+    },
+    {
+        "l1_block_number": 20974745,
+        "l1_fees": {
+            "blob_fee": 1,
+            "base_fee": 10500204149
+        },
+        "parent_header": {
+            "excess_mana": 1318372599,
+            "mana_used": 104606734,
+            "proving_cost_per_mana_numerator": 153703284,
+            "fee_asset_price_numerator": 1141096092
+        },
+        "header": {
+            "excess_mana": 1322979333,
+            "mana_used": 98393903,
+            "proving_cost_per_mana_numerator": 125449892,
+            "fee_asset_price_numerator": 692530653
+        },
+        "oracle_input": {
+            "proving_cost_modifier": -28253392,
+            "fee_asset_price_modifier": -448565439
+        },
+        "outputs": {
+            "fee_asset_price_at_execution": 10114763142,
+            "mana_base_fee_components_in_wei": {
+                "data_cost": 0,
+                "gas_cost": 34781926,
+                "proving_cost": 5423687938,
+                "congestion_cost": 20204634344,
+                "congestion_multiplier": 4701519812
+            },
+            "mana_base_fee_components_in_fee_asset": {
+                "data_cost": 0,
+                "gas_cost": 351810943,
+                "proving_cost": 54859318848,
+                "congestion_cost": 204365090760,
+                "congestion_multiplier": 4701519812
+            }
+        }
+    },
+    {
+        "l1_block_number": 20974748,
+        "l1_fees": {
+            "blob_fee": 1,
+            "base_fee": 10424404293
+        },
+        "parent_header": {
+            "excess_mana": 1322979333,
+            "mana_used": 98393903,
+            "proving_cost_per_mana_numerator": 125449892,
+            "fee_asset_price_numerator": 692530653
+        },
+        "header": {
+            "excess_mana": 1321373236,
+            "mana_used": 101125648,
+            "proving_cost_per_mana_numerator": 116545291,
+            "fee_asset_price_numerator": 1221606111
+        },
+        "oracle_input": {
+            "proving_cost_modifier": -8904601,
+            "fee_asset_price_modifier": 529075458
+        },
+        "outputs": {
+            "fee_asset_price_at_execution": 10069493419,
+            "mana_base_fee_components_in_wei": {
+                "data_cost": 0,
+                "gas_cost": 34530839,
+                "proving_cost": 5422155778,
+                "congestion_cost": 20149870247,
+                "congestion_multiplier": 4692693325
+            },
+            "mana_base_fee_components_in_fee_asset": {
+                "data_cost": 0,
+                "gas_cost": 347708056,
+                "proving_cost": 54598361923,
+                "congestion_cost": 202898985845,
+                "congestion_multiplier": 4692693325
+            }
+        }
+    },
+    {
+        "l1_block_number": 20974751,
+        "l1_fees": {
+            "blob_fee": 1,
+            "base_fee": 9876371928
+        },
+        "parent_header": {
+            "excess_mana": 1321373236,
+            "mana_used": 101125648,
+            "proving_cost_per_mana_numerator": 116545291,
+            "fee_asset_price_numerator": 1221606111
+        },
+        "header": {
+            "excess_mana": 1322498884,
+            "mana_used": 106231316,
+            "proving_cost_per_mana_numerator": 116068701,
+            "fee_asset_price_numerator": 783842434
+        },
+        "oracle_input": {
+            "proving_cost_modifier": -476590,
+            "fee_asset_price_modifier": -437763677
+        },
+        "outputs": {
+            "fee_asset_price_at_execution": 10122909819,
+            "mana_base_fee_components_in_wei": {
+                "data_cost": 0,
+                "gas_cost": 32715482,
+                "proving_cost": 5421672978,
+                "congestion_cost": 20175115907,
+                "congestion_multiplier": 4698877712
+            },
+            "mana_base_fee_components_in_fee_asset": {
+                "data_cost": 0,
+                "gas_cost": 331175873,
+                "proving_cost": 54883106624,
+                "congestion_cost": 204230878914,
+                "congestion_multiplier": 4698877712
+            }
+        }
+    },
+    {
+        "l1_block_number": 20974754,
+        "l1_fees": {
+            "blob_fee": 1,
+            "base_fee": 9360570144
+        },
+        "parent_header": {
+            "excess_mana": 1322498884,
+            "mana_used": 106231316,
+            "proving_cost_per_mana_numerator": 116068701,
+            "fee_asset_price_numerator": 783842434
+        },
+        "header": {
+            "excess_mana": 1328730200,
+            "mana_used": 94599253,
+            "proving_cost_per_mana_numerator": 195742672,
+            "fee_asset_price_numerator": 1332901608
+        },
+        "oracle_input": {
+            "proving_cost_modifier": 79673971,
+            "fee_asset_price_modifier": 549059174
+        },
+        "outputs": {
+            "fee_asset_price_at_execution": 10078692252,
+            "mana_base_fee_components_in_wei": {
+                "data_cost": 0,
+                "gas_cost": 31006888,
+                "proving_cost": 5421647139,
+                "congestion_cost": 20356179104,
+                "congestion_multiplier": 4733260721
+            },
+            "mana_base_fee_components_in_fee_asset": {
+                "data_cost": 0,
+                "gas_cost": 312508881,
+                "proving_cost": 54643113012,
+                "congestion_cost": 205163664615,
+                "congestion_multiplier": 4733260721
+            }
+        }
+    },
+    {
+        "l1_block_number": 20974757,
+        "l1_fees": {
+            "blob_fee": 1,
+            "base_fee": 9824724225
+        },
+        "parent_header": {
+            "excess_mana": 1328730200,
+            "mana_used": 94599253,
+            "proving_cost_per_mana_numerator": 195742672,
+            "fee_asset_price_numerator": 1332901608
+        },
+        "header": {
+            "excess_mana": 1323329453,
+            "mana_used": 104810216,
+            "proving_cost_per_mana_numerator": 91244335,
+            "fee_asset_price_numerator": 1328557093
+        },
+        "oracle_input": {
+            "proving_cost_modifier": -104498337,
+            "fee_asset_price_modifier": -4344515
+        },
+        "outputs": {
+            "fee_asset_price_at_execution": 10134182434,
+            "mana_base_fee_components_in_wei": {
+                "data_cost": 0,
+                "gas_cost": 32544398,
+                "proving_cost": 5425968502,
+                "congestion_cost": 20215308524,
+                "congestion_multiplier": 4703446139
+            },
+            "mana_base_fee_components_in_fee_asset": {
+                "data_cost": 0,
+                "gas_cost": 329810866,
+                "proving_cost": 54987754680,
+                "congestion_cost": 204865624541,
+                "congestion_multiplier": 4703446139
+            }
+        }
+    },
+    {
+        "l1_block_number": 20974760,
+        "l1_fees": {
+            "blob_fee": 1,
+            "base_fee": 9304831062
+        },
+        "parent_header": {
+            "excess_mana": 1323329453,
+            "mana_used": 104810216,
+            "proving_cost_per_mana_numerator": 91244335,
+            "fee_asset_price_numerator": 1328557093
+        },
+        "header": {
+            "excess_mana": 1328139669,
+            "mana_used": 22463541,
+            "proving_cost_per_mana_numerator": 70172623,
+            "fee_asset_price_numerator": 846061293
+        },
+        "oracle_input": {
+            "proving_cost_modifier": -21071712,
+            "fee_asset_price_modifier": -482495800
+        },
+        "outputs": {
+            "fee_asset_price_at_execution": 10133742162,
+            "mana_base_fee_components_in_wei": {
+                "data_cost": 0,
+                "gas_cost": 30822252,
+                "proving_cost": 5420301417,
+                "congestion_cost": 20332645168,
+                "congestion_multiplier": 4729991540
+            },
+            "mana_base_fee_components_in_fee_asset": {
+                "data_cost": 0,
+                "gas_cost": 312344754,
+                "proving_cost": 54927937000,
+                "congestion_cost": 206045783603,
+                "congestion_multiplier": 4729991540
+            }
+        }
+    },
+    {
+        "l1_block_number": 20974763,
+        "l1_fees": {
+            "blob_fee": 1,
+            "base_fee": 9375115776
+        },
+        "parent_header": {
+            "excess_mana": 1328139669,
+            "mana_used": 22463541,
+            "proving_cost_per_mana_numerator": 70172623,
+            "fee_asset_price_numerator": 846061293
+        },
+        "header": {
+            "excess_mana": 1250603210,
+            "mana_used": 150785033,
+            "proving_cost_per_mana_numerator": 0,
+            "fee_asset_price_numerator": 1599723314
+        },
+        "oracle_input": {
+            "proving_cost_modifier": -176951960,
+            "fee_asset_price_modifier": 753662021
+        },
+        "outputs": {
+            "fee_asset_price_at_execution": 10084965050,
+            "mana_base_fee_components_in_wei": {
+                "data_cost": 0,
+                "gas_cost": 31055071,
+                "proving_cost": 5419159387,
+                "congestion_cost": 18093543131,
+                "congestion_multiplier": 4319785537
+            },
+            "mana_base_fee_components_in_fee_asset": {
+                "data_cost": 0,
+                "gas_cost": 313189305,
+                "proving_cost": 54652033018,
+                "congestion_cost": 182472750106,
+                "congestion_multiplier": 4319785537
+            }
+        }
+    },
+    {
+        "l1_block_number": 20974766,
+        "l1_fees": {
+            "blob_fee": 1,
+            "base_fee": 9355897486
+        },
+        "parent_header": {
+            "excess_mana": 1250603210,
+            "mana_used": 150785033,
+            "proving_cost_per_mana_numerator": 0,
+            "fee_asset_price_numerator": 1599723314
+        },
+        "header": {
+            "excess_mana": 1301388243,
+            "mana_used": 115685651,
+            "proving_cost_per_mana_numerator": 73707425,
+            "fee_asset_price_numerator": 2586358676
+        },
+        "oracle_input": {
+            "proving_cost_modifier": 73707425,
+            "fee_asset_price_modifier": 986635362
+        },
+        "outputs": {
+            "fee_asset_price_at_execution": 10161258739,
+            "mana_base_fee_components_in_wei": {
+                "data_cost": 0,
+                "gas_cost": 30991410,
+                "proving_cost": 5415357955,
+                "congestion_cost": 19521021036,
+                "congestion_multiplier": 4584239594
+            },
+            "mana_base_fee_components_in_fee_asset": {
+                "data_cost": 0,
+                "gas_cost": 314911735,
+                "proving_cost": 55026853345,
+                "congestion_cost": 198358145596,
+                "congestion_multiplier": 4584239594
+            }
+        }
+    },
+    {
+        "l1_block_number": 20974769,
+        "l1_fees": {
+            "blob_fee": 1,
+            "base_fee": 9794644343
+        },
+        "parent_header": {
+            "excess_mana": 1301388243,
+            "mana_used": 115685651,
+            "proving_cost_per_mana_numerator": 73707425,
+            "fee_asset_price_numerator": 2586358676
+        },
+        "header": {
+            "excess_mana": 1317073894,
+            "mana_used": 107028096,
+            "proving_cost_per_mana_numerator": 10009116,
+            "fee_asset_price_numerator": 3372692979
+        },
+        "oracle_input": {
+            "proving_cost_modifier": -63698309,
+            "fee_asset_price_modifier": 786334303
+        },
+        "outputs": {
+            "fee_asset_price_at_execution": 10262009515,
+            "mana_base_fee_components_in_wei": {
+                "data_cost": 0,
+                "gas_cost": 32444759,
+                "proving_cost": 5419350947,
+                "congestion_cost": 20003441320,
+                "congestion_multiplier": 4669147268
+            },
+            "mana_base_fee_components_in_fee_asset": {
+                "data_cost": 0,
+                "gas_cost": 332948425,
+                "proving_cost": 55613430983,
+                "congestion_cost": 205275505158,
+                "congestion_multiplier": 4669147268
+            }
+        }
+    },
+    {
+        "l1_block_number": 20974772,
+        "l1_fees": {
+            "blob_fee": 1,
+            "base_fee": 10009442615
+        },
+        "parent_header": {
+            "excess_mana": 1317073894,
+            "mana_used": 107028096,
+            "proving_cost_per_mana_numerator": 10009116,
+            "fee_asset_price_numerator": 3372692979
+        },
+        "header": {
+            "excess_mana": 1324101990,
+            "mana_used": 104043606,
+            "proving_cost_per_mana_numerator": 166033820,
+            "fee_asset_price_numerator": 3617525919
+        },
+        "oracle_input": {
+            "proving_cost_modifier": 156024704,
+            "fee_asset_price_modifier": 244832940
+        },
+        "outputs": {
+            "fee_asset_price_at_execution": 10343021310,
+            "mana_base_fee_components_in_wei": {
+                "data_cost": 0,
+                "gas_cost": 33156278,
+                "proving_cost": 5415900011,
+                "congestion_cost": 20203462498,
+                "congestion_multiplier": 4707699357
+            },
+            "mana_base_fee_components_in_fee_asset": {
+                "data_cost": 0,
+                "gas_cost": 342936089,
+                "proving_cost": 56016769226,
+                "congestion_cost": 208964843152,
+                "congestion_multiplier": 4707699357
+            }
+        }
+    },
+    {
+        "l1_block_number": 20974775,
+        "l1_fees": {
+            "blob_fee": 1,
+            "base_fee": 9694844373
+        },
+        "parent_header": {
+            "excess_mana": 1324101990,
+            "mana_used": 104043606,
+            "proving_cost_per_mana_numerator": 166033820,
+            "fee_asset_price_numerator": 3617525919
+        },
+        "header": {
+            "excess_mana": 1328145596,
+            "mana_used": 99506947,
+            "proving_cost_per_mana_numerator": 47176936,
+            "fee_asset_price_numerator": 3843644767
+        },
+        "oracle_input": {
+            "proving_cost_modifier": -118856884,
+            "fee_asset_price_modifier": 226118848
+        },
+        "outputs": {
+            "fee_asset_price_at_execution": 10368375458,
+            "mana_base_fee_components_in_wei": {
+                "data_cost": 0,
+                "gas_cost": 32114171,
+                "proving_cost": 5424356749,
+                "congestion_cost": 20352769347,
+                "congestion_multiplier": 4730024341
+            },
+            "mana_base_fee_components_in_fee_asset": {
+                "data_cost": 0,
+                "gas_cost": 332971782,
+                "proving_cost": 56241767391,
+                "congestion_cost": 211025154199,
+                "congestion_multiplier": 4730024341
+            }
+        }
+    },
+    {
+        "l1_block_number": 20974778,
+        "l1_fees": {
+            "blob_fee": 1,
+            "base_fee": 9325354066
+        },
+        "parent_header": {
+            "excess_mana": 1328145596,
+            "mana_used": 99506947,
+            "proving_cost_per_mana_numerator": 47176936,
+            "fee_asset_price_numerator": 3843644767
+        },
+        "header": {
+            "excess_mana": 1327652543,
+            "mana_used": 95115604,
+            "proving_cost_per_mana_numerator": 0,
+            "fee_asset_price_numerator": 4394437425
+        },
+        "oracle_input": {
+            "proving_cost_modifier": -70276183,
+            "fee_asset_price_modifier": 550792658
+        },
+        "outputs": {
+            "fee_asset_price_at_execution": 10391846836,
+            "mana_base_fee_components_in_wei": {
+                "data_cost": 0,
+                "gas_cost": 30890235,
+                "proving_cost": 5417913357,
+                "congestion_cost": 20309306606,
+                "congestion_multiplier": 4727296509
+            },
+            "mana_base_fee_components_in_fee_asset": {
+                "data_cost": 0,
+                "gas_cost": 321006590,
+                "proving_cost": 56302125776,
+                "congestion_cost": 211051203594,
+                "congestion_multiplier": 4727296509
+            }
+        }
+    },
+    {
+        "l1_block_number": 20974781,
+        "l1_fees": {
+            "blob_fee": 1,
+            "base_fee": 8890810110
+        },
+        "parent_header": {
+            "excess_mana": 1327652543,
+            "mana_used": 95115604,
+            "proving_cost_per_mana_numerator": 0,
+            "fee_asset_price_numerator": 4394437425
+        },
+        "header": {
+            "excess_mana": 1322768147,
+            "mana_used": 105577993,
+            "proving_cost_per_mana_numerator": 0,
+            "fee_asset_price_numerator": 3884670042
+        },
+        "oracle_input": {
+            "proving_cost_modifier": -89581950,
+            "fee_asset_price_modifier": -509767383
+        },
+        "outputs": {
+            "fee_asset_price_at_execution": 10449242285,
+            "mana_base_fee_components_in_wei": {
+                "data_cost": 0,
+                "gas_cost": 29450808,
+                "proving_cost": 5415357955,
+                "congestion_cost": 20147743129,
+                "congestion_multiplier": 4700358269
+            },
+            "mana_base_fee_components_in_fee_asset": {
+                "data_cost": 0,
+                "gas_cost": 307738628,
+                "proving_cost": 56586387331,
+                "congestion_cost": 210528649450,
+                "congestion_multiplier": 4700358269
+            }
+        }
+    },
+    {
+        "l1_block_number": 20974784,
+        "l1_fees": {
+            "blob_fee": 1,
+            "base_fee": 9245683543
+        },
+        "parent_header": {
+            "excess_mana": 1322768147,
+            "mana_used": 105577993,
+            "proving_cost_per_mana_numerator": 0,
+            "fee_asset_price_numerator": 3884670042
+        },
+        "header": {
+            "excess_mana": 1328346140,
+            "mana_used": 94255340,
+            "proving_cost_per_mana_numerator": 151704970,
+            "fee_asset_price_numerator": 4074038287
+        },
+        "oracle_input": {
+            "proving_cost_modifier": 151704970,
+            "fee_asset_price_modifier": 189368245
+        },
+        "outputs": {
+            "fee_asset_price_at_execution": 10396110994,
+            "mana_base_fee_components_in_wei": {
+                "data_cost": 0,
+                "gas_cost": 30626326,
+                "proving_cost": 5415357955,
+                "congestion_cost": 20319698786,
+                "congestion_multiplier": 4731134307
+            },
+            "mana_base_fee_components_in_fee_asset": {
+                "data_cost": 0,
+                "gas_cost": 318394684,
+                "proving_cost": 56298662372,
+                "congestion_cost": 211245843943,
+                "congestion_multiplier": 4731134307
+            }
+        }
+    },
+    {
+        "l1_block_number": 20974787,
+        "l1_fees": {
+            "blob_fee": 1,
+            "base_fee": 9301265399
+        },
+        "parent_header": {
+            "excess_mana": 1328346140,
+            "mana_used": 94255340,
+            "proving_cost_per_mana_numerator": 151704970,
+            "fee_asset_price_numerator": 4074038287
+        },
+        "header": {
+            "excess_mana": 1322601480,
+            "mana_used": 92317269,
+            "proving_cost_per_mana_numerator": 150396703,
+            "fee_asset_price_numerator": 4412849079
+        },
+        "oracle_input": {
+            "proving_cost_modifier": -1308267,
+            "fee_asset_price_modifier": 338810792
+        },
+        "outputs": {
+            "fee_asset_price_at_execution": 10415816579,
+            "mana_base_fee_components_in_wei": {
+                "data_cost": 0,
+                "gas_cost": 30810441,
+                "proving_cost": 5423579556,
+                "congestion_cost": 20178198272,
+                "congestion_multiplier": 4699441786
+            },
+            "mana_base_fee_components_in_fee_asset": {
+                "data_cost": 0,
+                "gas_cost": 320915902,
+                "proving_cost": 56491009856,
+                "congestion_cost": 210172412095,
+                "congestion_multiplier": 4699441786
+            }
+        }
+    },
+    {
+        "l1_block_number": 20974790,
+        "l1_fees": {
+            "blob_fee": 1,
+            "base_fee": 10338672585
+        },
+        "parent_header": {
+            "excess_mana": 1322601480,
+            "mana_used": 92317269,
+            "proving_cost_per_mana_numerator": 150396703,
+            "fee_asset_price_numerator": 4412849079
+        },
+        "header": {
+            "excess_mana": 1314918749,
+            "mana_used": 101125366,
+            "proving_cost_per_mana_numerator": 195716802,
+            "fee_asset_price_numerator": 3855190737
+        },
+        "oracle_input": {
+            "proving_cost_modifier": 45320099,
+            "fee_asset_price_modifier": -557658342
+        },
+        "outputs": {
+            "fee_asset_price_at_execution": 10451166341,
+            "mana_base_fee_components_in_wei": {
+                "data_cost": 0,
+                "gas_cost": 34246852,
+                "proving_cost": 5423508602,
+                "congestion_cost": 19961133408,
+                "congestion_multiplier": 4657388752
+            },
+            "mana_base_fee_components_in_fee_asset": {
+                "data_cost": 0,
+                "gas_cost": 357919546,
+                "proving_cost": 56681990551,
+                "congestion_cost": 208617125601,
+                "congestion_multiplier": 4657388752
+            }
+        }
+    },
+    {
+        "l1_block_number": 20974793,
+        "l1_fees": {
+            "blob_fee": 1,
+            "base_fee": 10696471973
+        },
+        "parent_header": {
+            "excess_mana": 1314918749,
+            "mana_used": 101125366,
+            "proving_cost_per_mana_numerator": 195716802,
+            "fee_asset_price_numerator": 3855190737
+        },
+        "header": {
+            "excess_mana": 1316044115,
+            "mana_used": 78651739,
+            "proving_cost_per_mana_numerator": 281864500,
+            "fee_asset_price_numerator": 4486558706
+        },
+        "oracle_input": {
+            "proving_cost_modifier": 86147698,
+            "fee_asset_price_modifier": 631367969
+        },
+        "outputs": {
+            "fee_asset_price_at_execution": 10393046745,
+            "mana_base_fee_components_in_wei": {
+                "data_cost": 0,
+                "gas_cost": 35432063,
+                "proving_cost": 5425967098,
+                "congestion_cost": 20007972759,
+                "congestion_multiplier": 4663525073
+            },
+            "mana_base_fee_components_in_fee_asset": {
+                "data_cost": 0,
+                "gas_cost": 368247087,
+                "proving_cost": 56392329686,
+                "congestion_cost": 207943796156,
+                "congestion_multiplier": 4663525073
+            }
+        }
+    },
+    {
+        "l1_block_number": 20974796,
+        "l1_fees": {
+            "blob_fee": 1,
+            "base_fee": 10676042346
+        },
+        "parent_header": {
+            "excess_mana": 1316044115,
+            "mana_used": 78651739,
+            "proving_cost_per_mana_numerator": 281864500,
+            "fee_asset_price_numerator": 4486558706
+        },
+        "header": {
+            "excess_mana": 1294695854,
+            "mana_used": 104253914,
+            "proving_cost_per_mana_numerator": 205325868,
+            "fee_asset_price_numerator": 4626061500
+        },
+        "oracle_input": {
+            "proving_cost_modifier": -76538632,
+            "fee_asset_price_modifier": 139502794
+        },
+        "outputs": {
+            "fee_asset_price_at_execution": 10458872696,
+            "mana_base_fee_components_in_wei": {
+                "data_cost": 0,
+                "gas_cost": 35364390,
+                "proving_cost": 5430643458,
+                "congestion_cost": 19396045360,
+                "congestion_multiplier": 4548484726
+            },
+            "mana_base_fee_components_in_fee_asset": {
+                "data_cost": 0,
+                "gas_cost": 369871652,
+                "proving_cost": 56798408584,
+                "congestion_cost": 202860769226,
+                "congestion_multiplier": 4548484726
+            }
+        }
+    },
+    {
+        "l1_block_number": 20974799,
+        "l1_fees": {
+            "blob_fee": 1,
+            "base_fee": 11427276933
+        },
+        "parent_header": {
+            "excess_mana": 1294695854,
+            "mana_used": 104253914,
+            "proving_cost_per_mana_numerator": 205325868,
+            "fee_asset_price_numerator": 4626061500
+        },
+        "header": {
+            "excess_mana": 1298949768,
+            "mana_used": 121554216,
+            "proving_cost_per_mana_numerator": 194135492,
+            "fee_asset_price_numerator": 4492379499
+        },
+        "oracle_input": {
+            "proving_cost_modifier": -11190376,
+            "fee_asset_price_modifier": -133682001
+        },
+        "outputs": {
+            "fee_asset_price_at_execution": 10473473298,
+            "mana_base_fee_components_in_wei": {
+                "data_cost": 0,
+                "gas_cost": 37852854,
+                "proving_cost": 5426488508,
+                "congestion_cost": 19514142896,
+                "congestion_multiplier": 4571179325
+            },
+            "mana_base_fee_components_in_fee_asset": {
+                "data_cost": 0,
+                "gas_cost": 396450855,
+                "proving_cost": 56834182490,
+                "congestion_cost": 204380854554,
+                "congestion_multiplier": 4571179325
+            }
+        }
+    },
+    {
+        "l1_block_number": 20974802,
+        "l1_fees": {
+            "blob_fee": 1,
+            "base_fee": 11491823317
+        },
+        "parent_header": {
+            "excess_mana": 1298949768,
+            "mana_used": 121554216,
+            "proving_cost_per_mana_numerator": 194135492,
+            "fee_asset_price_numerator": 4492379499
+        },
+        "header": {
+            "excess_mana": 1320503984,
+            "mana_used": 69392636,
+            "proving_cost_per_mana_numerator": 202298936,
+            "fee_asset_price_numerator": 4437308775
+        },
+        "oracle_input": {
+            "proving_cost_modifier": 8163444,
+            "fee_asset_price_modifier": -55070724
+        },
+        "outputs": {
+            "fee_asset_price_at_execution": 10459481503,
+            "mana_base_fee_components_in_wei": {
+                "data_cost": 0,
+                "gas_cost": 38066664,
+                "proving_cost": 5425881298,
+                "congestion_cost": 20150620261,
+                "congestion_multiplier": 4687923165
+            },
+            "mana_base_fee_components_in_fee_asset": {
+                "data_cost": 0,
+                "gas_cost": 398157567,
+                "proving_cost": 56751905073,
+                "congestion_cost": 210765039893,
+                "congestion_multiplier": 4687923165
+            }
+        }
+    },
+    {
+        "l1_block_number": 20974805,
+        "l1_fees": {
+            "blob_fee": 1,
+            "base_fee": 10811344431
+        },
+        "parent_header": {
+            "excess_mana": 1320503984,
+            "mana_used": 69392636,
+            "proving_cost_per_mana_numerator": 202298936,
+            "fee_asset_price_numerator": 4437308775
+        },
+        "header": {
+            "excess_mana": 1289896620,
+            "mana_used": 123033670,
+            "proving_cost_per_mana_numerator": 292978465,
+            "fee_asset_price_numerator": 4662820355
+        },
+        "oracle_input": {
+            "proving_cost_modifier": 90679529,
+            "fee_asset_price_modifier": 225511580
+        },
+        "outputs": {
+            "fee_asset_price_at_execution": 10453722977,
+            "mana_base_fee_components_in_wei": {
+                "data_cost": 0,
+                "gas_cost": 35812578,
+                "proving_cost": 5426324255,
+                "congestion_cost": 19243195915,
+                "congestion_multiplier": 4523016084
+            },
+            "mana_base_fee_components_in_fee_asset": {
+                "data_cost": 0,
+                "gas_cost": 374374769,
+                "proving_cost": 56725290545,
+                "congestion_cost": 201163039287,
+                "congestion_multiplier": 4523016084
+            }
+        }
+    },
+    {
+        "l1_block_number": 20974808,
+        "l1_fees": {
+            "blob_fee": 1,
+            "base_fee": 11312462913
+        },
+        "parent_header": {
+            "excess_mana": 1289896620,
+            "mana_used": 123033670,
+            "proving_cost_per_mana_numerator": 292978465,
+            "fee_asset_price_numerator": 4662820355
+        },
+        "header": {
+            "excess_mana": 1312930290,
+            "mana_used": 104485851,
+            "proving_cost_per_mana_numerator": 338949112,
+            "fee_asset_price_numerator": 5084899225
+        },
+        "oracle_input": {
+            "proving_cost_modifier": 45970647,
+            "fee_asset_price_modifier": 422078870
+        },
+        "outputs": {
+            "fee_asset_price_at_execution": 10477323934,
+            "mana_base_fee_components_in_wei": {
+                "data_cost": 0,
+                "gas_cost": 37472533,
+                "proving_cost": 5431247052,
+                "congestion_cost": 19942046606,
+                "congestion_multiplier": 4646565946
+            },
+            "mana_base_fee_components_in_fee_asset": {
+                "data_cost": 0,
+                "gas_cost": 392611866,
+                "proving_cost": 56904934729,
+                "congestion_cost": 208939282197,
+                "congestion_multiplier": 4646565946
+            }
+        }
+    },
+    {
+        "l1_block_number": 20974811,
+        "l1_fees": {
+            "blob_fee": 1,
+            "base_fee": 10662810216
+        },
+        "parent_header": {
+            "excess_mana": 1312930290,
+            "mana_used": 104485851,
+            "proving_cost_per_mana_numerator": 338949112,
+            "fee_asset_price_numerator": 5084899225
+        },
+        "header": {
+            "excess_mana": 1317416141,
+            "mana_used": 95457884,
+            "proving_cost_per_mana_numerator": 410205539,
+            "fee_asset_price_numerator": 4421489069
+        },
+        "oracle_input": {
+            "proving_cost_modifier": 71256427,
+            "fee_asset_price_modifier": -663410156
+        },
+        "outputs": {
+            "fee_asset_price_at_execution": 10521639963,
+            "mana_base_fee_components_in_wei": {
+                "data_cost": 0,
+                "gas_cost": 35320558,
+                "proving_cost": 5433744405,
+                "congestion_cost": 20077032115,
+                "congestion_multiplier": 4671017304
+            },
+            "mana_base_fee_components_in_fee_asset": {
+                "data_cost": 0,
+                "gas_cost": 371630194,
+                "proving_cost": 57171902280,
+                "congestion_cost": 211243303439,
+                "congestion_multiplier": 4671017304
+            }
+        }
+    },
+    {
+        "l1_block_number": 20974814,
+        "l1_fees": {
+            "blob_fee": 1,
+            "base_fee": 10452820038
+        },
+        "parent_header": {
+            "excess_mana": 1317416141,
+            "mana_used": 95457884,
+            "proving_cost_per_mana_numerator": 410205539,
+            "fee_asset_price_numerator": 4421489069
+        },
+        "header": {
+            "excess_mana": 1312874025,
+            "mana_used": 101125688,
+            "proving_cost_per_mana_numerator": 392508919,
+            "fee_asset_price_numerator": 5338461220
+        },
+        "oracle_input": {
+            "proving_cost_modifier": -17696620,
+            "fee_asset_price_modifier": 916972151
+        },
+        "outputs": {
+            "fee_asset_price_at_execution": 10452069359,
+            "mana_base_fee_components_in_wei": {
+                "data_cost": 0,
+                "gas_cost": 34624966,
+                "proving_cost": 5437617677,
+                "congestion_cost": 19953219853,
+                "congestion_multiplier": 4646260072
+            },
+            "mana_base_fee_components_in_fee_asset": {
+                "data_cost": 0,
+                "gas_cost": 361902546,
+                "proving_cost": 56834357107,
+                "congestion_cost": 208552437838,
+                "congestion_multiplier": 4646260072
+            }
+        }
+    },
+    {
+        "l1_block_number": 20974817,
+        "l1_fees": {
+            "blob_fee": 1,
+            "base_fee": 10494444894
+        },
+        "parent_header": {
+            "excess_mana": 1312874025,
+            "mana_used": 101125688,
+            "proving_cost_per_mana_numerator": 392508919,
+            "fee_asset_price_numerator": 5338461220
+        },
+        "header": {
+            "excess_mana": 1313999713,
+            "mana_used": 113120937,
+            "proving_cost_per_mana_numerator": 440009576,
+            "fee_asset_price_numerator": 5678935638
+        },
+        "oracle_input": {
+            "proving_cost_modifier": 47500657,
+            "fee_asset_price_modifier": 340474418
+        },
+        "outputs": {
+            "fee_asset_price_at_execution": 10548352696,
+            "mana_base_fee_components_in_wei": {
+                "data_cost": 0,
+                "gas_cost": 34762848,
+                "proving_cost": 5436655487,
+                "congestion_cost": 19983717955,
+                "congestion_multiplier": 4652383483
+            },
+            "mana_base_fee_components_in_fee_asset": {
+                "data_cost": 0,
+                "gas_cost": 366690781,
+                "proving_cost": 57347759563,
+                "congestion_cost": 210795305166,
+                "congestion_multiplier": 4652383483
+            }
+        }
+    },
+    {
+        "l1_block_number": 20974820,
+        "l1_fees": {
+            "blob_fee": 1,
+            "base_fee": 11441672423
+        },
+        "parent_header": {
+            "excess_mana": 1313999713,
+            "mana_used": 113120937,
+            "proving_cost_per_mana_numerator": 440009576,
+            "fee_asset_price_numerator": 5678935638
+        },
+        "header": {
+            "excess_mana": 1327120650,
+            "mana_used": 93614567,
+            "proving_cost_per_mana_numerator": 652994890,
+            "fee_asset_price_numerator": 5682136233
+        },
+        "oracle_input": {
+            "proving_cost_modifier": 212985314,
+            "fee_asset_price_modifier": 3200595
+        },
+        "outputs": {
+            "fee_asset_price_at_execution": 10584328347,
+            "mana_base_fee_components_in_wei": {
+                "data_cost": 0,
+                "gas_cost": 37900539,
+                "proving_cost": 5439238548,
+                "congestion_cost": 20398813395,
+                "congestion_multiplier": 4724355557
+            },
+            "mana_base_fee_components_in_fee_asset": {
+                "data_cost": 0,
+                "gas_cost": 401151749,
+                "proving_cost": 57570686749,
+                "congestion_cost": 215907738861,
+                "congestion_multiplier": 4724355557
+            }
+        }
+    },
+    {
+        "l1_block_number": 20974823,
+        "l1_fees": {
+            "blob_fee": 1,
+            "base_fee": 10436948017
+        },
+        "parent_header": {
+            "excess_mana": 1327120650,
+            "mana_used": 93614567,
+            "proving_cost_per_mana_numerator": 652994890,
+            "fee_asset_price_numerator": 5682136233
+        },
+        "header": {
+            "excess_mana": 1320735217,
+            "mana_used": 92881828,
+            "proving_cost_per_mana_numerator": 643450673,
+            "fee_asset_price_numerator": 5750089006
+        },
+        "oracle_input": {
+            "proving_cost_modifier": -9544217,
+            "fee_asset_price_modifier": 67952773
+        },
+        "outputs": {
+            "fee_asset_price_at_execution": 10584667114,
+            "mana_base_fee_components_in_wei": {
+                "data_cost": 0,
+                "gas_cost": 34572390,
+                "proving_cost": 5450835673,
+                "congestion_cost": 20236721458,
+                "congestion_multiplier": 4689191620
+            },
+            "mana_base_fee_components_in_fee_asset": {
+                "data_cost": 0,
+                "gas_cost": 365937239,
+                "proving_cost": 57695281091,
+                "congestion_cost": 214198960111,
+                "congestion_multiplier": 4689191620
+            }
+        }
+    },
+    {
+        "l1_block_number": 20974826,
+        "l1_fees": {
+            "blob_fee": 1,
+            "base_fee": 12544299201
+        },
+        "parent_header": {
+            "excess_mana": 1320735217,
+            "mana_used": 92881828,
+            "proving_cost_per_mana_numerator": 643450673,
+            "fee_asset_price_numerator": 5750089006
+        },
+        "header": {
+            "excess_mana": 1313617045,
+            "mana_used": 89289918,
+            "proving_cost_per_mana_numerator": 462121778,
+            "fee_asset_price_numerator": 5871915980
+        },
+        "oracle_input": {
+            "proving_cost_modifier": -181328895,
+            "fee_asset_price_modifier": 121826974
+        },
+        "outputs": {
+            "fee_asset_price_at_execution": 10591862133,
+            "mana_base_fee_components_in_wei": {
+                "data_cost": 0,
+                "gas_cost": 41552991,
+                "proving_cost": 5450315458,
+                "congestion_cost": 20046972764,
+                "congestion_multiplier": 4650300977
+            },
+            "mana_base_fee_components_in_fee_asset": {
+                "data_cost": 0,
+                "gas_cost": 440123551,
+                "proving_cost": 57728989912,
+                "congestion_cost": 212334771700,
+                "congestion_multiplier": 4650300977
+            }
+        }
+    },
+    {
+        "l1_block_number": 20974829,
+        "l1_fees": {
+            "blob_fee": 1,
+            "base_fee": 12400332753
+        },
+        "parent_header": {
+            "excess_mana": 1313617045,
+            "mana_used": 89289918,
+            "proving_cost_per_mana_numerator": 462121778,
+            "fee_asset_price_numerator": 5871915980
+        },
+        "header": {
+            "excess_mana": 1302906963,
+            "mana_used": 111424450,
+            "proving_cost_per_mana_numerator": 557448177,
+            "fee_asset_price_numerator": 5446763525
+        },
+        "oracle_input": {
+            "proving_cost_modifier": 95326399,
+            "fee_asset_price_modifier": -425152455
+        },
+        "outputs": {
+            "fee_asset_price_at_execution": 10604773742,
+            "mana_base_fee_components_in_wei": {
+                "data_cost": 0,
+                "gas_cost": 41076102,
+                "proving_cost": 5440441416,
+                "congestion_cost": 19691762869,
+                "congestion_multiplier": 4592392582
+            },
+            "mana_base_fee_components_in_fee_asset": {
+                "data_cost": 0,
+                "gas_cost": 435602767,
+                "proving_cost": 57694650273,
+                "congestion_cost": 208826689806,
+                "congestion_multiplier": 4592392582
+            }
+        }
+    },
+    {
+        "l1_block_number": 20974832,
+        "l1_fees": {
+            "blob_fee": 1,
+            "base_fee": 12549492621
+        },
+        "parent_header": {
+            "excess_mana": 1302906963,
+            "mana_used": 111424450,
+            "proving_cost_per_mana_numerator": 557448177,
+            "fee_asset_price_numerator": 5446763525
+        },
+        "header": {
+            "excess_mana": 1314331413,
+            "mana_used": 90490628,
+            "proving_cost_per_mana_numerator": 449359153,
+            "fee_asset_price_numerator": 5218321344
+        },
+        "oracle_input": {
+            "proving_cost_modifier": -108089024,
+            "fee_asset_price_modifier": -228442181
+        },
+        "outputs": {
+            "fee_asset_price_at_execution": 10559782993,
+            "mana_base_fee_components_in_wei": {
+                "data_cost": 0,
+                "gas_cost": 41570194,
+                "proving_cost": 5445630066,
+                "congestion_cost": 20051268877,
+                "congestion_multiplier": 4654189373
+            },
+            "mana_base_fee_components_in_fee_asset": {
+                "data_cost": 0,
+                "gas_cost": 438972227,
+                "proving_cost": 57504671757,
+                "congestion_cost": 211737048075,
+                "congestion_multiplier": 4654189373
+            }
+        }
+    },
+    {
+        "l1_block_number": 20974835,
+        "l1_fees": {
+            "blob_fee": 1,
+            "base_fee": 12247487967
+        },
+        "parent_header": {
+            "excess_mana": 1314331413,
+            "mana_used": 90490628,
+            "proving_cost_per_mana_numerator": 449359153,
+            "fee_asset_price_numerator": 5218321344
+        },
+        "header": {
+            "excess_mana": 1304822041,
+            "mana_used": 113679240,
+            "proving_cost_per_mana_numerator": 514902665,
+            "fee_asset_price_numerator": 5674843125
+        },
+        "oracle_input": {
+            "proving_cost_modifier": 65543512,
+            "fee_asset_price_modifier": 456521781
+        },
+        "outputs": {
+            "fee_asset_price_at_execution": 10535687527,
+            "mana_base_fee_components_in_wei": {
+                "data_cost": 0,
+                "gas_cost": 40569803,
+                "proving_cost": 5439747118,
+                "congestion_cost": 19743905009,
+                "congestion_multiplier": 4602694022
+            },
+            "mana_base_fee_components_in_fee_asset": {
+                "data_cost": 0,
+                "gas_cost": 427430767,
+                "proving_cost": 57311475861,
+                "congestion_cost": 208015613737,
+                "congestion_multiplier": 4602694022
+            }
+        }
+    },
+    {
+        "l1_block_number": 20974838,
+        "l1_fees": {
+            "blob_fee": 1,
+            "base_fee": 12279164524
+        },
+        "parent_header": {
+            "excess_mana": 1304822041,
+            "mana_used": 113679240,
+            "proving_cost_per_mana_numerator": 514902665,
+            "fee_asset_price_numerator": 5674843125
+        },
+        "header": {
+            "excess_mana": 1318501281,
+            "mana_used": 94816566,
+            "proving_cost_per_mana_numerator": 713358368,
+            "fee_asset_price_numerator": 6674843125
+        },
+        "oracle_input": {
+            "proving_cost_modifier": 198455703,
+            "fee_asset_price_modifier": 1000000000
+        },
+        "outputs": {
+            "fee_asset_price_at_execution": 10583895191,
+            "mana_base_fee_components_in_wei": {
+                "data_cost": 0,
+                "gas_cost": 40674732,
+                "proving_cost": 5443313688,
+                "congestion_cost": 20164359222,
+                "congestion_multiplier": 4676951459
+            },
+            "mana_base_fee_components_in_fee_asset": {
+                "data_cost": 0,
+                "gas_cost": 430497100,
+                "proving_cost": 57611461565,
+                "congestion_cost": 213417464599,
+                "congestion_multiplier": 4676951459
+            }
+        }
+    },
+    {
+        "l1_block_number": 20974841,
+        "l1_fees": {
+            "blob_fee": 1,
+            "base_fee": 10902675660
+        },
+        "parent_header": {
+            "excess_mana": 1318501281,
+            "mana_used": 94816566,
+            "proving_cost_per_mana_numerator": 713358368,
+            "fee_asset_price_numerator": 6674843125
+        },
+        "header": {
+            "excess_mana": 1313317847,
+            "mana_used": 107663248,
+            "proving_cost_per_mana_numerator": 748402866,
+            "fee_asset_price_numerator": 7610408635
+        },
+        "oracle_input": {
+            "proving_cost_modifier": 35044498,
+            "fee_asset_price_modifier": 935565510
+        },
+        "outputs": {
+            "fee_asset_price_at_execution": 10690265106,
+            "mana_base_fee_components_in_wei": {
+                "data_cost": 0,
+                "gas_cost": 36115113,
+                "proving_cost": 5454126980,
+                "congestion_cost": 20032100119,
+                "congestion_multiplier": 4648673370
+            },
+            "mana_base_fee_components_in_fee_asset": {
+                "data_cost": 0,
+                "gas_cost": 386080132,
+                "proving_cost": 58306063337,
+                "congestion_cost": 214148460902,
+                "congestion_multiplier": 4648673370
+            }
+        }
+    },
+    {
+        "l1_block_number": 20974844,
+        "l1_fees": {
+            "blob_fee": 1,
+            "base_fee": 11748014686
+        },
+        "parent_header": {
+            "excess_mana": 1313317847,
+            "mana_used": 107663248,
+            "proving_cost_per_mana_numerator": 748402866,
+            "fee_asset_price_numerator": 7610408635
+        },
+        "header": {
+            "excess_mana": 1320981095,
+            "mana_used": 113716102,
+            "proving_cost_per_mana_numerator": 644992713,
+            "fee_asset_price_numerator": 8106950703
+        },
+        "oracle_input": {
+            "proving_cost_modifier": -103410153,
+            "fee_asset_price_modifier": 496542068
+        },
+        "outputs": {
+            "fee_asset_price_at_execution": 10790748852,
+            "mana_base_fee_components_in_wei": {
+                "data_cost": 0,
+                "gas_cost": 38915298,
+                "proving_cost": 5456038687,
+                "congestion_cost": 20279351804,
+                "congestion_multiplier": 4690540787
+            },
+            "mana_base_fee_components_in_fee_asset": {
+                "data_cost": 0,
+                "gas_cost": 419925207,
+                "proving_cost": 58874743198,
+                "congestion_cost": 218829392198,
+                "congestion_multiplier": 4690540787
+            }
+        }
+    },
+    {
+        "l1_block_number": 20974847,
+        "l1_fees": {
+            "blob_fee": 1,
+            "base_fee": 11555866445
+        },
+        "parent_header": {
+            "excess_mana": 1320981095,
+            "mana_used": 113716102,
+            "proving_cost_per_mana_numerator": 644992713,
+            "fee_asset_price_numerator": 8106950703
+        },
+        "header": {
+            "excess_mana": 1334697197,
+            "mana_used": 77154125,
+            "proving_cost_per_mana_numerator": 630470577,
+            "fee_asset_price_numerator": 8256440326
+        },
+        "oracle_input": {
+            "proving_cost_modifier": -14522136,
+            "fee_asset_price_modifier": 149489623
+        },
+        "outputs": {
+            "fee_asset_price_at_execution": 10844462705,
+            "mana_base_fee_components_in_wei": {
+                "data_cost": 0,
+                "gas_cost": 38278807,
+                "proving_cost": 5450399505,
+                "congestion_cost": 20672673591,
+                "congestion_multiplier": 4766421061
+            },
+            "mana_base_fee_components_in_fee_asset": {
+                "data_cost": 0,
+                "gas_cost": 415113094,
+                "proving_cost": 59106654159,
+                "congestion_cost": 224184037770,
+                "congestion_multiplier": 4766421061
+            }
+        }
+    },
+    {
+        "l1_block_number": 20974850,
+        "l1_fees": {
+            "blob_fee": 1,
+            "base_fee": 11216225347
+        },
+        "parent_header": {
+            "excess_mana": 1334697197,
+            "mana_used": 77154125,
+            "proving_cost_per_mana_numerator": 630470577,
+            "fee_asset_price_numerator": 8256440326
+        },
+        "header": {
+            "excess_mana": 1311851322,
+            "mana_used": 120250559,
+            "proving_cost_per_mana_numerator": 559447502,
+            "fee_asset_price_numerator": 8337804903
+        },
+        "oracle_input": {
+            "proving_cost_modifier": -71023075,
+            "fee_asset_price_modifier": 81364577
+        },
+        "outputs": {
+            "fee_asset_price_at_execution": 10860686175,
+            "mana_base_fee_components_in_wei": {
+                "data_cost": 0,
+                "gas_cost": 37153746,
+                "proving_cost": 5449608048,
+                "congestion_cost": 19975674820,
+                "congestion_multiplier": 4640703856
+            },
+            "mana_base_fee_components_in_fee_asset": {
+                "data_cost": 0,
+                "gas_cost": 403515175,
+                "proving_cost": 59186482786,
+                "congestion_cost": 216949535353,
+                "congestion_multiplier": 4640703856
+            }
+        }
+    },
+    {
+        "l1_block_number": 20974853,
+        "l1_fees": {
+            "blob_fee": 1,
+            "base_fee": 11547959457
+        },
+        "parent_header": {
+            "excess_mana": 1311851322,
+            "mana_used": 120250559,
+            "proving_cost_per_mana_numerator": 559447502,
+            "fee_asset_price_numerator": 8337804903
+        },
+        "header": {
+            "excess_mana": 1332101881,
+            "mana_used": 95609882,
+            "proving_cost_per_mana_numerator": 658973526,
+            "fee_asset_price_numerator": 9010707806
+        },
+        "oracle_input": {
+            "proving_cost_modifier": 99526024,
+            "fee_asset_price_modifier": 672902903
+        },
+        "outputs": {
+            "fee_asset_price_at_execution": 10869526522,
+            "mana_base_fee_components_in_wei": {
+                "data_cost": 0,
+                "gas_cost": 38252615,
+                "proving_cost": 5445738943,
+                "congestion_cost": 20575770061,
+                "congestion_multiplier": 4751969682
+            },
+            "mana_base_fee_components_in_fee_asset": {
+                "data_cost": 0,
+                "gas_cost": 415787813,
+                "proving_cost": 59192603872,
+                "congestion_cost": 223648878388,
+                "congestion_multiplier": 4751969682
+            }
+        }
+    },
+    {
+        "l1_block_number": 20974856,
+        "l1_fees": {
+            "blob_fee": 1,
+            "base_fee": 11536198807
+        },
+        "parent_header": {
+            "excess_mana": 1332101881,
+            "mana_used": 95609882,
+            "proving_cost_per_mana_numerator": 658973526,
+            "fee_asset_price_numerator": 9010707806
+        },
+        "header": {
+            "excess_mana": 1327711763,
+            "mana_used": 82020204,
+            "proving_cost_per_mana_numerator": 837434640,
+            "fee_asset_price_numerator": 8643670869
+        },
+        "oracle_input": {
+            "proving_cost_modifier": 178461114,
+            "fee_asset_price_modifier": -367036937
+        },
+        "outputs": {
+            "fee_asset_price_at_execution": 10942914520,
+            "mana_base_fee_components_in_wei": {
+                "data_cost": 0,
+                "gas_cost": 38213658,
+                "proving_cost": 5451161568,
+                "congestion_cost": 20462327177,
+                "congestion_multiplier": 4727624062
+            },
+            "mana_base_fee_components_in_fee_asset": {
+                "data_cost": 0,
+                "gas_cost": 418168792,
+                "proving_cost": 59651595073,
+                "congestion_cost": 223917497178,
+                "congestion_multiplier": 4727624062
+            }
+        }
+    },
+    {
+        "l1_block_number": 20974859,
+        "l1_fees": {
+            "blob_fee": 1,
+            "base_fee": 12543844247
+        },
+        "parent_header": {
+            "excess_mana": 1327711763,
+            "mana_used": 82020204,
+            "proving_cost_per_mana_numerator": 837434640,
+            "fee_asset_price_numerator": 8643670869
+        },
+        "header": {
+            "excess_mana": 1309731967,
+            "mana_used": 122961211,
+            "proving_cost_per_mana_numerator": 914286965,
+            "fee_asset_price_numerator": 8589826773
+        },
+        "oracle_input": {
+            "proving_cost_modifier": 76852325,
+            "fee_asset_price_modifier": -53844096
+        },
+        "outputs": {
+            "fee_asset_price_at_execution": 10902823601,
+            "mana_base_fee_components_in_wei": {
+                "data_cost": 0,
+                "gas_cost": 41551484,
+                "proving_cost": 5460898458,
+                "congestion_cost": 19969550821,
+                "congestion_multiplier": 4629210812
+            },
+            "mana_base_fee_components_in_fee_asset": {
+                "data_cost": 0,
+                "gas_cost": 453028500,
+                "proving_cost": 59539212590,
+                "congestion_cost": 217724489992,
+                "congestion_multiplier": 4629210812
+            }
+        }
+    },
+    {
+        "l1_block_number": 20974862,
+        "l1_fees": {
+            "blob_fee": 1,
+            "base_fee": 11467196389
+        },
+        "parent_header": {
+            "excess_mana": 1309731967,
+            "mana_used": 122961211,
+            "proving_cost_per_mana_numerator": 914286965,
+            "fee_asset_price_numerator": 8589826773
+        },
+        "header": {
+            "excess_mana": 1332693178,
+            "mana_used": 88377634,
+            "proving_cost_per_mana_numerator": 888132222,
+            "fee_asset_price_numerator": 7731360299
+        },
+        "oracle_input": {
+            "proving_cost_modifier": -26154743,
+            "fee_asset_price_modifier": -858466474
+        },
+        "outputs": {
+            "fee_asset_price_at_execution": 10896954654,
+            "mana_base_fee_components_in_wei": {
+                "data_cost": 0,
+                "gas_cost": 37985088,
+                "proving_cost": 5465096898,
+                "congestion_cost": 20665494386,
+                "congestion_multiplier": 4755258315
+            },
+            "mana_base_fee_components_in_fee_asset": {
+                "data_cost": 0,
+                "gas_cost": 413921781,
+                "proving_cost": 59552913077,
+                "congestion_cost": 225190955226,
+                "congestion_multiplier": 4755258315
+            }
+        }
+    },
+    {
+        "l1_block_number": 20974865,
+        "l1_fees": {
+            "blob_fee": 1,
+            "base_fee": 11847593532
+        },
+        "parent_header": {
+            "excess_mana": 1332693178,
+            "mana_used": 88377634,
+            "proving_cost_per_mana_numerator": 888132222,
+            "fee_asset_price_numerator": 7731360299
+        },
+        "header": {
+            "excess_mana": 1321070812,
+            "mana_used": 105628168,
+            "proving_cost_per_mana_numerator": 1011353411,
+            "fee_asset_price_numerator": 8653928406
+        },
+        "oracle_input": {
+            "proving_cost_modifier": 123221189,
+            "fee_asset_price_modifier": 922568107
+        },
+        "outputs": {
+            "fee_asset_price_at_execution": 10803808339,
+            "mana_base_fee_components_in_wei": {
+                "data_cost": 0,
+                "gas_cost": 39245153,
+                "proving_cost": 5463667703,
+                "congestion_cost": 20311433905,
+                "congestion_multiplier": 4691033174
+            },
+            "mana_base_fee_components_in_fee_asset": {
+                "data_cost": 0,
+                "gas_cost": 423997111,
+                "proving_cost": 59028418691,
+                "congestion_cost": 219440838999,
+                "congestion_multiplier": 4691033174
+            }
+        }
+    },
+    {
+        "l1_block_number": 20974868,
+        "l1_fees": {
+            "blob_fee": 1,
+            "base_fee": 11328194124
+        },
+        "parent_header": {
+            "excess_mana": 1321070812,
+            "mana_used": 105628168,
+            "proving_cost_per_mana_numerator": 1011353411,
+            "fee_asset_price_numerator": 8653928406
+        },
+        "header": {
+            "excess_mana": 1326698980,
+            "mana_used": 112426897,
+            "proving_cost_per_mana_numerator": 922374234,
+            "fee_asset_price_numerator": 8952196191
+        },
+        "oracle_input": {
+            "proving_cost_modifier": -88979177,
+            "fee_asset_price_modifier": 298267785
+        },
+        "outputs": {
+            "fee_asset_price_at_execution": 10903942019,
+            "mana_base_fee_components_in_wei": {
+                "data_cost": 0,
+                "gas_cost": 37524643,
+                "proving_cost": 5470404249,
+                "congestion_cost": 20500650978,
+                "congestion_multiplier": 4722025353
+            },
+            "mana_base_fee_components_in_fee_asset": {
+                "data_cost": 0,
+                "gas_cost": 409166531,
+                "proving_cost": 59648970751,
+                "congestion_cost": 223537909615,
+                "congestion_multiplier": 4722025353
+            }
+        }
+    },
+    {
+        "l1_block_number": 20974871,
+        "l1_fees": {
+            "blob_fee": 1,
+            "base_fee": 10326551989
+        },
+        "parent_header": {
+            "excess_mana": 1326698980,
+            "mana_used": 112426897,
+            "proving_cost_per_mana_numerator": 922374234,
+            "fee_asset_price_numerator": 8952196191
+        },
+        "header": {
+            "excess_mana": 1339125877,
+            "mana_used": 93159165,
+            "proving_cost_per_mana_numerator": 1096301212,
+            "fee_asset_price_numerator": 8922067968
+        },
+        "oracle_input": {
+            "proving_cost_modifier": 173926978,
+            "fee_asset_price_modifier": -30128223
+        },
+        "outputs": {
+            "fee_asset_price_at_execution": 10936513517,
+            "mana_base_fee_components_in_wei": {
+                "data_cost": 0,
+                "gas_cost": 34206703,
+                "proving_cost": 5465538893,
+                "congestion_cost": 20850539989,
+                "congestion_multiplier": 4791182633
+            },
+            "mana_base_fee_components_in_fee_asset": {
+                "data_cost": 0,
+                "gas_cost": 374102069,
+                "proving_cost": 59773939980,
+                "congestion_cost": 228032212426,
+                "congestion_multiplier": 4791182633
+            }
+        }
+    },
+    {
+        "l1_block_number": 20974874,
+        "l1_fees": {
+            "blob_fee": 1,
+            "base_fee": 10644013577
+        },
+        "parent_header": {
+            "excess_mana": 1339125877,
+            "mana_used": 93159165,
+            "proving_cost_per_mana_numerator": 1096301212,
+            "fee_asset_price_numerator": 8922067968
+        },
+        "header": {
+            "excess_mana": 1332285042,
+            "mana_used": 95153977,
+            "proving_cost_per_mana_numerator": 1124499162,
+            "fee_asset_price_numerator": 9123995500
+        },
+        "oracle_input": {
+            "proving_cost_modifier": 28197950,
+            "fee_asset_price_modifier": 201927532
+        },
+        "outputs": {
+            "fee_asset_price_at_execution": 10933219036,
+            "mana_base_fee_components_in_wei": {
+                "data_cost": 0,
+                "gas_cost": 35258294,
+                "proving_cost": 5475053211,
+                "congestion_cost": 20680133670,
+                "congestion_multiplier": 4752988130
+            },
+            "mana_base_fee_components_in_fee_asset": {
+                "data_cost": 0,
+                "gas_cost": 385486651,
+                "proving_cost": 59859955989,
+                "congestion_cost": 226100431107,
+                "congestion_multiplier": 4752988130
+            }
+        }
+    },
+    {
+        "l1_block_number": 20974877,
+        "l1_fees": {
+            "blob_fee": 1,
+            "base_fee": 10075447620
+        },
+        "parent_header": {
+            "excess_mana": 1332285042,
+            "mana_used": 95153977,
+            "proving_cost_per_mana_numerator": 1124499162,
+            "fee_asset_price_numerator": 9123995500
+        },
+        "header": {
+            "excess_mana": 1327439019,
+            "mana_used": 100954563,
+            "proving_cost_per_mana_numerator": 1154447316,
+            "fee_asset_price_numerator": 9066858318
+        },
+        "oracle_input": {
+            "proving_cost_modifier": 29948154,
+            "fee_asset_price_modifier": -57137182
+        },
+        "outputs": {
+            "fee_asset_price_at_execution": 10955318520,
+            "mana_base_fee_components_in_wei": {
+                "data_cost": 0,
+                "gas_cost": 33374920,
+                "proving_cost": 5476597282,
+                "congestion_cost": 20530793757,
+                "congestion_multiplier": 4726115669
+            },
+            "mana_base_fee_components_in_fee_asset": {
+                "data_cost": 0,
+                "gas_cost": 365632879,
+                "proving_cost": 59997867630,
+                "congestion_cost": 224921385076,
+                "congestion_multiplier": 4726115669
+            }
+        }
+    },
+    {
+        "l1_block_number": 20974880,
+        "l1_fees": {
+            "blob_fee": 1,
+            "base_fee": 9763461789
+        },
+        "parent_header": {
+            "excess_mana": 1327439019,
+            "mana_used": 100954563,
+            "proving_cost_per_mana_numerator": 1154447316,
+            "fee_asset_price_numerator": 9066858318
+        },
+        "header": {
+            "excess_mana": 1328393582,
+            "mana_used": 86609776,
+            "proving_cost_per_mana_numerator": 1082851492,
+            "fee_asset_price_numerator": 8765287529
+        },
+        "oracle_input": {
+            "proving_cost_modifier": -71595824,
+            "fee_asset_price_modifier": -301570789
+        },
+        "outputs": {
+            "fee_asset_price_at_execution": 10949060748,
+            "mana_base_fee_components_in_wei": {
+                "data_cost": 0,
+                "gas_cost": 32341467,
+                "proving_cost": 5478237667,
+                "congestion_cost": 20562158041,
+                "congestion_multiplier": 4731396926
+            },
+            "mana_base_fee_components_in_fee_asset": {
+                "data_cost": 0,
+                "gas_cost": 354108686,
+                "proving_cost": 59981557007,
+                "congestion_cost": 225136317500,
+                "congestion_multiplier": 4731396926
+            }
+        }
+    },
+    {
+        "l1_block_number": 20974883,
+        "l1_fees": {
+            "blob_fee": 1,
+            "base_fee": 10100174423
+        },
+        "parent_header": {
+            "excess_mana": 1328393582,
+            "mana_used": 86609776,
+            "proving_cost_per_mana_numerator": 1082851492,
+            "fee_asset_price_numerator": 8765287529
+        },
+        "header": {
+            "excess_mana": 1315003358,
+            "mana_used": 101994370,
+            "proving_cost_per_mana_numerator": 1293341291,
+            "fee_asset_price_numerator": 8005697334
+        },
+        "oracle_input": {
+            "proving_cost_modifier": 210489799,
+            "fee_asset_price_modifier": -759590195
+        },
+        "outputs": {
+            "fee_asset_price_at_execution": 10916091317,
+            "mana_base_fee_components_in_wei": {
+                "data_cost": 0,
+                "gas_cost": 33456827,
+                "proving_cost": 5474316882,
+                "congestion_cost": 20146609081,
+                "congestion_multiplier": 4657849822
+            },
+            "mana_base_fee_components_in_fee_asset": {
+                "data_cost": 0,
+                "gas_cost": 365217778,
+                "proving_cost": 59758142982,
+                "congestion_cost": 219922224456,
+                "congestion_multiplier": 4657849822
+            }
+        }
+    },
+    {
+        "l1_block_number": 20974886,
+        "l1_fees": {
+            "blob_fee": 1,
+            "base_fee": 9861299092
+        },
+        "parent_header": {
+            "excess_mana": 1315003358,
+            "mana_used": 101994370,
+            "proving_cost_per_mana_numerator": 1293341291,
+            "fee_asset_price_numerator": 8005697334
+        },
+        "header": {
+            "excess_mana": 1316997728,
+            "mana_used": 100770495,
+            "proving_cost_per_mana_numerator": 1274750290,
+            "fee_asset_price_numerator": 7879332404
+        },
+        "oracle_input": {
+            "proving_cost_modifier": -18591001,
+            "fee_asset_price_modifier": -126364930
+        },
+        "outputs": {
+            "fee_asset_price_at_execution": 10833487879,
+            "mana_base_fee_components_in_wei": {
+                "data_cost": 0,
+                "gas_cost": 32665553,
+                "proving_cost": 5485851896,
+                "congestion_cost": 20245957137,
+                "congestion_multiplier": 4668731199
+            },
+            "mana_base_fee_components_in_fee_asset": {
+                "data_cost": 0,
+                "gas_cost": 353881872,
+                "proving_cost": 59430910021,
+                "congestion_cost": 219334331242,
+                "congestion_multiplier": 4668731199
+            }
+        }
+    },
+    {
+        "l1_block_number": 20974889,
+        "l1_fees": {
+            "blob_fee": 1,
+            "base_fee": 9769056260
+        },
+        "parent_header": {
+            "excess_mana": 1316997728,
+            "mana_used": 100770495,
+            "proving_cost_per_mana_numerator": 1274750290,
+            "fee_asset_price_numerator": 7879332404
+        },
+        "header": {
+            "excess_mana": 1317768223,
+            "mana_used": 93740114,
+            "proving_cost_per_mana_numerator": 1134591213,
+            "fee_asset_price_numerator": 8058266347
+        },
+        "oracle_input": {
+            "proving_cost_modifier": -140159077,
+            "fee_asset_price_modifier": 178933943
+        },
+        "outputs": {
+            "fee_asset_price_at_execution": 10819806795,
+            "mana_base_fee_components_in_wei": {
+                "data_cost": 0,
+                "gas_cost": 32359998,
+                "proving_cost": 5484832116,
+                "congestion_cost": 20264325870,
+                "congestion_multiplier": 4672941861
+            },
+            "mana_base_fee_components_in_fee_asset": {
+                "data_cost": 0,
+                "gas_cost": 350128926,
+                "proving_cost": 59344823798,
+                "congestion_cost": 219256090744,
+                "congestion_multiplier": 4672941861
+            }
+        }
+    },
+    {
+        "l1_block_number": 20974892,
+        "l1_fees": {
+            "blob_fee": 1,
+            "base_fee": 9623430979
+        },
+        "parent_header": {
+            "excess_mana": 1317768223,
+            "mana_used": 93740114,
+            "proving_cost_per_mana_numerator": 1134591213,
+            "fee_asset_price_numerator": 8058266347
+        },
+        "header": {
+            "excess_mana": 1311508337,
+            "mana_used": 108023757,
+            "proving_cost_per_mana_numerator": 1392064986,
+            "fee_asset_price_numerator": 7449911189
+        },
+        "oracle_input": {
+            "proving_cost_modifier": 257473773,
+            "fee_asset_price_modifier": -608355158
+        },
+        "outputs": {
+            "fee_asset_price_at_execution": 10839184433,
+            "mana_base_fee_components_in_wei": {
+                "data_cost": 0,
+                "gas_cost": 31877615,
+                "proving_cost": 5477150011,
+                "congestion_cost": 20046480829,
+                "congestion_multiplier": 4638841950
+            },
+            "mana_base_fee_components_in_fee_asset": {
+                "data_cost": 0,
+                "gas_cost": 345527348,
+                "proving_cost": 59367839136,
+                "congestion_cost": 217287502938,
+                "congestion_multiplier": 4638841950
+            }
+        }
+    },
+    {
+        "l1_block_number": 20974895,
+        "l1_fees": {
+            "blob_fee": 1,
+            "base_fee": 9512609521
+        },
+        "parent_header": {
+            "excess_mana": 1311508337,
+            "mana_used": 108023757,
+            "proving_cost_per_mana_numerator": 1392064986,
+            "fee_asset_price_numerator": 7449911189
+        },
+        "header": {
+            "excess_mana": 1319532094,
+            "mana_used": 94907192,
+            "proving_cost_per_mana_numerator": 1301384261,
+            "fee_asset_price_numerator": 7256716944
+        },
+        "oracle_input": {
+            "proving_cost_modifier": -90680725,
+            "fee_asset_price_modifier": -193194245
+        },
+        "outputs": {
+            "fee_asset_price_at_execution": 10773443867,
+            "mana_base_fee_components_in_wei": {
+                "data_cost": 0,
+                "gas_cost": 31510519,
+                "proving_cost": 5491270406,
+                "congestion_cost": 20338168203,
+                "congestion_multiplier": 4682595504
+            },
+            "mana_base_fee_components_in_fee_asset": {
+                "data_cost": 0,
+                "gas_cost": 339476807,
+                "proving_cost": 59159893477,
+                "congestion_cost": 219112113492,
+                "congestion_multiplier": 4682595504
+            }
+        }
+    },
+    {
+        "l1_block_number": 20974898,
+        "l1_fees": {
+            "blob_fee": 1,
+            "base_fee": 10044576348
+        },
+        "parent_header": {
+            "excess_mana": 1319532094,
+            "mana_used": 94907192,
+            "proving_cost_per_mana_numerator": 1301384261,
+            "fee_asset_price_numerator": 7256716944
+        },
+        "header": {
+            "excess_mana": 1314439286,
+            "mana_used": 107252047,
+            "proving_cost_per_mana_numerator": 1319569211,
+            "fee_asset_price_numerator": 6585416524
+        },
+        "oracle_input": {
+            "proving_cost_modifier": 18184950,
+            "fee_asset_price_modifier": -671300420
+        },
+        "outputs": {
+            "fee_asset_price_at_execution": 10752650286,
+            "mana_base_fee_components_in_wei": {
+                "data_cost": 0,
+                "gas_cost": 33272659,
+                "proving_cost": 5486293139,
+                "congestion_cost": 20172781146,
+                "congestion_multiplier": 4654776822
+            },
+            "mana_base_fee_components_in_fee_asset": {
+                "data_cost": 0,
+                "gas_cost": 357769266,
+                "proving_cost": 58992191490,
+                "congestion_cost": 216910860958,
+                "congestion_multiplier": 4654776822
+            }
+        }
+    },
+    {
+        "l1_block_number": 20974901,
+        "l1_fees": {
+            "blob_fee": 1,
+            "base_fee": 10070103513
+        },
+        "parent_header": {
+            "excess_mana": 1314439286,
+            "mana_used": 107252047,
+            "proving_cost_per_mana_numerator": 1319569211,
+            "fee_asset_price_numerator": 6585416524
+        },
+        "header": {
+            "excess_mana": 1321691333,
+            "mana_used": 121405371,
+            "proving_cost_per_mana_numerator": 1304115838,
+            "fee_asset_price_numerator": 6808203349
+        },
+        "oracle_input": {
+            "proving_cost_modifier": -15453373,
+            "fee_asset_price_modifier": 222786825
+        },
+        "outputs": {
+            "fee_asset_price_at_execution": 10680709439,
+            "mana_base_fee_components_in_wei": {
+                "data_cost": 0,
+                "gas_cost": 33357217,
+                "proving_cost": 5487290910,
+                "congestion_cost": 20395704072,
+                "congestion_multiplier": 4694440146
+            },
+            "mana_base_fee_components_in_fee_asset": {
+                "data_cost": 0,
+                "gas_cost": 356278742,
+                "proving_cost": 58608159816,
+                "congestion_cost": 217840588996,
+                "congestion_multiplier": 4694440146
+            }
+        }
+    },
+    {
+        "l1_block_number": 20974904,
+        "l1_fees": {
+            "blob_fee": 1,
+            "base_fee": 10137549634
+        },
+        "parent_header": {
+            "excess_mana": 1321691333,
+            "mana_used": 121405371,
+            "proving_cost_per_mana_numerator": 1304115838,
+            "fee_asset_price_numerator": 6808203349
+        },
+        "header": {
+            "excess_mana": 1343096704,
+            "mana_used": 90671800,
+            "proving_cost_per_mana_numerator": 1172290607,
+            "fee_asset_price_numerator": 6521145587
+        },
+        "oracle_input": {
+            "proving_cost_modifier": -131825231,
+            "fee_asset_price_modifier": -287057762
+        },
+        "outputs": {
+            "fee_asset_price_at_execution": 10704531178,
+            "mana_base_fee_components_in_wei": {
+                "data_cost": 0,
+                "gas_cost": 33580633,
+                "proving_cost": 5486443004,
+                "congestion_cost": 21050574921,
+                "congestion_multiplier": 4813493620
+            },
+            "mana_base_fee_components_in_fee_asset": {
+                "data_cost": 0,
+                "gas_cost": 359464932,
+                "proving_cost": 58729800192,
+                "congestion_cost": 225336535556,
+                "congestion_multiplier": 4813493620
+            }
+        }
+    },
+    {
+        "l1_block_number": 20974907,
+        "l1_fees": {
+            "blob_fee": 1,
+            "base_fee": 9517302233
+        },
+        "parent_header": {
+            "excess_mana": 1343096704,
+            "mana_used": 90671800,
+            "proving_cost_per_mana_numerator": 1172290607,
+            "fee_asset_price_numerator": 6521145587
+        },
+        "header": {
+            "excess_mana": 1333768504,
+            "mana_used": 111628561,
+            "proving_cost_per_mana_numerator": 1241261106,
+            "fee_asset_price_numerator": 7094785441
+        },
+        "oracle_input": {
+            "proving_cost_modifier": 68970499,
+            "fee_asset_price_modifier": 573639854
+        },
+        "outputs": {
+            "fee_asset_price_at_execution": 10673847052,
+            "mana_base_fee_components_in_wei": {
+                "data_cost": 0,
+                "gas_cost": 31526063,
+                "proving_cost": 5479215252,
+                "congestion_cost": 20727247225,
+                "congestion_multiplier": 4761244820
+            },
+            "mana_base_fee_components_in_fee_asset": {
+                "data_cost": 0,
+                "gas_cost": 336504374,
+                "proving_cost": 58484305564,
+                "congestion_cost": 221239466688,
+                "congestion_multiplier": 4761244820
+            }
+        }
+    },
+    {
+        "l1_block_number": 20974910,
+        "l1_fees": {
+            "blob_fee": 1,
+            "base_fee": 9424484397
+        },
+        "parent_header": {
+            "excess_mana": 1333768504,
+            "mana_used": 111628561,
+            "proving_cost_per_mana_numerator": 1241261106,
+            "fee_asset_price_numerator": 7094785441
+        },
+        "header": {
+            "excess_mana": 1345397065,
+            "mana_used": 76010152,
+            "proving_cost_per_mana_numerator": 1123733641,
+            "fee_asset_price_numerator": 7441702780
+        },
+        "oracle_input": {
+            "proving_cost_modifier": -117527465,
+            "fee_asset_price_modifier": 346917339
+        },
+        "outputs": {
+            "fee_asset_price_at_execution": 10735252448,
+            "mana_base_fee_components_in_wei": {
+                "data_cost": 0,
+                "gas_cost": 31218604,
+                "proving_cost": 5482995598,
+                "congestion_cost": 21099954340,
+                "congestion_multiplier": 4826466214
+            },
+            "mana_base_fee_components_in_fee_asset": {
+                "data_cost": 0,
+                "gas_cost": 335139595,
+                "proving_cost": 58861341915,
+                "congestion_cost": 226513336481,
+                "congestion_multiplier": 4826466214
+            }
+        }
+    },
+    {
+        "l1_block_number": 20974913,
+        "l1_fees": {
+            "blob_fee": 1,
+            "base_fee": 9284979161
+        },
+        "parent_header": {
+            "excess_mana": 1345397065,
+            "mana_used": 76010152,
+            "proving_cost_per_mana_numerator": 1123733641,
+            "fee_asset_price_numerator": 7441702780
+        },
+        "header": {
+            "excess_mana": 1321407217,
+            "mana_used": 102379463,
+            "proving_cost_per_mana_numerator": 1087220094,
+            "fee_asset_price_numerator": 7782300821
+        },
+        "oracle_input": {
+            "proving_cost_modifier": -36513547,
+            "fee_asset_price_modifier": 340598041
+        },
+        "outputs": {
+            "fee_asset_price_at_execution": 10772559575,
+            "mana_base_fee_components_in_wei": {
+                "data_cost": 0,
+                "gas_cost": 30756493,
+                "proving_cost": 5476555358,
+                "congestion_cost": 20337841232,
+                "congestion_multiplier": 4692879899
+            },
+            "mana_base_fee_components_in_fee_asset": {
+                "data_cost": 0,
+                "gas_cost": 331326153,
+                "proving_cost": 58996518859,
+                "congestion_cost": 219090606298,
+                "congestion_multiplier": 4692879899
+            }
+        }
+    },
+    {
+        "l1_block_number": 20974916,
+        "l1_fees": {
+            "blob_fee": 1,
+            "base_fee": 9349531035
+        },
+        "parent_header": {
+            "excess_mana": 1321407217,
+            "mana_used": 102379463,
+            "proving_cost_per_mana_numerator": 1087220094,
+            "fee_asset_price_numerator": 7782300821
+        },
+        "header": {
+            "excess_mana": 1323786680,
+            "mana_used": 97560775,
+            "proving_cost_per_mana_numerator": 975214132,
+            "fee_asset_price_numerator": 7994655497
+        },
+        "oracle_input": {
+            "proving_cost_modifier": -112005962,
+            "fee_asset_price_modifier": 212354676
+        },
+        "outputs": {
+            "fee_asset_price_at_execution": 10809313257,
+            "mana_base_fee_components_in_wei": {
+                "data_cost": 0,
+                "gas_cost": 30970321,
+                "proving_cost": 5474556038,
+                "congestion_cost": 20403276690,
+                "congestion_multiplier": 4705962947
+            },
+            "mana_base_fee_components_in_fee_asset": {
+                "data_cost": 0,
+                "gas_cost": 334767901,
+                "proving_cost": 59176191157,
+                "congestion_cost": 220545409211,
+                "congestion_multiplier": 4705962947
+            }
+        }
+    },
+    {
+        "l1_block_number": 20974919,
+        "l1_fees": {
+            "blob_fee": 1,
+            "base_fee": 9390478247
+        },
+        "parent_header": {
+            "excess_mana": 1323786680,
+            "mana_used": 97560775,
+            "proving_cost_per_mana_numerator": 975214132,
+            "fee_asset_price_numerator": 7994655497
+        },
+        "header": {
+            "excess_mana": 1321347455,
+            "mana_used": 99274649,
+            "proving_cost_per_mana_numerator": 937389994,
+            "fee_asset_price_numerator": 7861276742
+        },
+        "oracle_input": {
+            "proving_cost_modifier": -37824138,
+            "fee_asset_price_modifier": -133378755
+        },
+        "outputs": {
+            "fee_asset_price_at_execution": 10832291729,
+            "mana_base_fee_components_in_wei": {
+                "data_cost": 0,
+                "gas_cost": 31105959,
+                "proving_cost": 5468427642,
+                "congestion_cost": 20307312571,
+                "congestion_multiplier": 4692551777
+            },
+            "mana_base_fee_components_in_fee_asset": {
+                "data_cost": 0,
+                "gas_cost": 336948822,
+                "proving_cost": 59235603517,
+                "congestion_cost": 219974734001,
+                "congestion_multiplier": 4692551777
+            }
+        }
+    },
+    {
+        "l1_block_number": 20974922,
+        "l1_fees": {
+            "blob_fee": 1,
+            "base_fee": 9142314696
+        },
+        "parent_header": {
+            "excess_mana": 1321347455,
+            "mana_used": 99274649,
+            "proving_cost_per_mana_numerator": 937389994,
+            "fee_asset_price_numerator": 7861276742
+        },
+        "header": {
+            "excess_mana": 1320622104,
+            "mana_used": 100673187,
+            "proving_cost_per_mana_numerator": 971394804,
+            "fee_asset_price_numerator": 8578845048
+        },
+        "oracle_input": {
+            "proving_cost_modifier": 34004810,
+            "fee_asset_price_modifier": 717568306
+        },
+        "outputs": {
+            "fee_asset_price_at_execution": 10817853384,
+            "mana_base_fee_components_in_wei": {
+                "data_cost": 0,
+                "gas_cost": 30283917,
+                "proving_cost": 5466359647,
+                "congestion_cost": 20274760503,
+                "congestion_multiplier": 4688571083
+            },
+            "mana_base_fee_components_in_fee_asset": {
+                "data_cost": 0,
+                "gas_cost": 327606973,
+                "proving_cost": 59134277205,
+                "congestion_cost": 219329386517,
+                "congestion_multiplier": 4688571083
+            }
+        }
+    },
+    {
+        "l1_block_number": 20974925,
+        "l1_fees": {
+            "blob_fee": 1,
+            "base_fee": 9969641609
+        },
+        "parent_header": {
+            "excess_mana": 1320622104,
+            "mana_used": 100673187,
+            "proving_cost_per_mana_numerator": 971394804,
+            "fee_asset_price_numerator": 8578845048
+        },
+        "header": {
+            "excess_mana": 1321295291,
+            "mana_used": 102820127,
+            "proving_cost_per_mana_numerator": 1013995161,
+            "fee_asset_price_numerator": 9578845048
+        },
+        "oracle_input": {
+            "proving_cost_modifier": 42600357,
+            "fee_asset_price_modifier": 1000000000
+        },
+        "outputs": {
+            "fee_asset_price_at_execution": 10895758046,
+            "mana_base_fee_components_in_wei": {
+                "data_cost": 0,
+                "gas_cost": 33024437,
+                "proving_cost": 5468218788,
+                "congestion_cost": 20312049967,
+                "congestion_multiplier": 4692265391
+            },
+            "mana_base_fee_components_in_fee_asset": {
+                "data_cost": 0,
+                "gas_cost": 359826275,
+                "proving_cost": 59580388856,
+                "congestion_cost": 221315181858,
+                "congestion_multiplier": 4692265391
+            }
+        }
+    },
+    {
+        "l1_block_number": 20974928,
+        "l1_fees": {
+            "blob_fee": 1,
+            "base_fee": 9852702429
+        },
+        "parent_header": {
+            "excess_mana": 1321295291,
+            "mana_used": 102820127,
+            "proving_cost_per_mana_numerator": 1013995161,
+            "fee_asset_price_numerator": 9578845048
+        },
+        "header": {
+            "excess_mana": 1324115418,
+            "mana_used": 98269123,
+            "proving_cost_per_mana_numerator": 919091259,
+            "fee_asset_price_numerator": 9292279788
+        },
+        "oracle_input": {
+            "proving_cost_modifier": -94903902,
+            "fee_asset_price_modifier": -286565260
+        },
+        "outputs": {
+            "fee_asset_price_at_execution": 11005262235,
+            "mana_base_fee_components_in_wei": {
+                "data_cost": 0,
+                "gas_cost": 32637076,
+                "proving_cost": 5470548765,
+                "congestion_cost": 20404565630,
+                "congestion_multiplier": 4707773319
+            },
+            "mana_base_fee_components_in_fee_asset": {
+                "data_cost": 0,
+                "gas_cost": 359179579,
+                "proving_cost": 60204823728,
+                "congestion_cost": 224557595549,
+                "congestion_multiplier": 4707773319
+            }
+        }
+    },
+    {
+        "l1_block_number": 20974931,
+        "l1_fees": {
+            "blob_fee": 1,
+            "base_fee": 9051667803
+        },
+        "parent_header": {
+            "excess_mana": 1324115418,
+            "mana_used": 98269123,
+            "proving_cost_per_mana_numerator": 919091259,
+            "fee_asset_price_numerator": 9292279788
+        },
+        "header": {
+            "excess_mana": 1322384541,
+            "mana_used": 97911435,
+            "proving_cost_per_mana_numerator": 728383216,
+            "fee_asset_price_numerator": 9763078118
+        },
+        "oracle_input": {
+            "proving_cost_modifier": -190708043,
+            "fee_asset_price_modifier": 470798330
+        },
+        "outputs": {
+            "fee_asset_price_at_execution": 10973770121,
+            "mana_base_fee_components_in_wei": {
+                "data_cost": 0,
+                "gas_cost": 29983649,
+                "proving_cost": 5465359464,
+                "congestion_cost": 20323147897,
+                "congestion_multiplier": 4698249132
+            },
+            "mana_base_fee_components_in_fee_asset": {
+                "data_cost": 0,
+                "gas_cost": 329033671,
+                "proving_cost": 59975598386,
+                "congestion_cost": 223021553156,
+                "congestion_multiplier": 4698249132
+            }
+        }
+    },
+    {
+        "l1_block_number": 20974934,
+        "l1_fees": {
+            "blob_fee": 1,
+            "base_fee": 9177771259
+        },
+        "parent_header": {
+            "excess_mana": 1322384541,
+            "mana_used": 97911435,
+            "proving_cost_per_mana_numerator": 728383216,
+            "fee_asset_price_numerator": 9763078118
+        },
+        "header": {
+            "excess_mana": 1320295976,
+            "mana_used": 99481176,
+            "proving_cost_per_mana_numerator": 580576659,
+            "fee_asset_price_numerator": 9915158567
+        },
+        "oracle_input": {
+            "proving_cost_modifier": -147806557,
+            "fee_asset_price_modifier": 152080449
+        },
+        "outputs": {
+            "fee_asset_price_at_execution": 11025556256,
+            "mana_base_fee_components_in_wei": {
+                "data_cost": 0,
+                "gas_cost": 30401367,
+                "proving_cost": 5454946516,
+                "congestion_cost": 20223284071,
+                "congestion_multiplier": 4686782407
+            },
+            "mana_base_fee_components_in_fee_asset": {
+                "data_cost": 0,
+                "gas_cost": 335191982,
+                "proving_cost": 60143819685,
+                "congestion_cost": 222972956205,
+                "congestion_multiplier": 4686782407
+            }
+        }
+    },
+    {
+        "l1_block_number": 20974937,
+        "l1_fees": {
+            "blob_fee": 1,
+            "base_fee": 9151655035
+        },
+        "parent_header": {
+            "excess_mana": 1320295976,
+            "mana_used": 99481176,
+            "proving_cost_per_mana_numerator": 580576659,
+            "fee_asset_price_numerator": 9915158567
+        },
+        "header": {
+            "excess_mana": 1319777152,
+            "mana_used": 102737449,
+            "proving_cost_per_mana_numerator": 599954471,
+            "fee_asset_price_numerator": 9619014183
+        },
+        "oracle_input": {
+            "proving_cost_modifier": 19377812,
+            "fee_asset_price_modifier": -296144384
+        },
+        "outputs": {
+            "fee_asset_price_at_execution": 11042336728,
+            "mana_base_fee_components_in_wei": {
+                "data_cost": 0,
+                "gas_cost": 30314857,
+                "proving_cost": 5446889703,
+                "congestion_cost": 20177683551,
+                "congestion_multiplier": 4683938281
+            },
+            "mana_base_fee_components_in_fee_asset": {
+                "data_cost": 0,
+                "gas_cost": 334746858,
+                "proving_cost": 60146390220,
+                "congestion_cost": 222808776161,
+                "congestion_multiplier": 4683938281
+            }
+        }
+    },
+    {
+        "l1_block_number": 20974940,
+        "l1_fees": {
+            "blob_fee": 1,
+            "base_fee": 10111441008
+        },
+        "parent_header": {
+            "excess_mana": 1319777152,
+            "mana_used": 102737449,
+            "proving_cost_per_mana_numerator": 599954471,
+            "fee_asset_price_numerator": 9619014183
+        },
+        "header": {
+            "excess_mana": 1322514601,
+            "mana_used": 116287303,
+            "proving_cost_per_mana_numerator": 559406423,
+            "fee_asset_price_numerator": 9289033428
+        },
+        "oracle_input": {
+            "proving_cost_modifier": -40548048,
+            "fee_asset_price_modifier": -329980755
+        },
+        "outputs": {
+            "fee_asset_price_at_execution": 11009683842,
+            "mana_base_fee_components_in_wei": {
+                "data_cost": 0,
+                "gas_cost": 33494148,
+                "proving_cost": 5447945294,
+                "congestion_cost": 20275647821,
+                "congestion_multiplier": 4698964120
+            },
+            "mana_base_fee_components_in_fee_asset": {
+                "data_cost": 0,
+                "gas_cost": 368759980,
+                "proving_cost": 59980155275,
+                "congestion_cost": 223228472200,
+                "congestion_multiplier": 4698964120
+            }
+        }
+    },
+    {
+        "l1_block_number": 20974943,
+        "l1_fees": {
+            "blob_fee": 1,
+            "base_fee": 9743090500
+        },
+        "parent_header": {
+            "excess_mana": 1322514601,
+            "mana_used": 116287303,
+            "proving_cost_per_mana_numerator": 559406423,
+            "fee_asset_price_numerator": 9289033428
+        },
+        "header": {
+            "excess_mana": 1338801904,
+            "mana_used": 92831721,
+            "proving_cost_per_mana_numerator": 522669976,
+            "fee_asset_price_numerator": 9057063136
+        },
+        "oracle_input": {
+            "proving_cost_modifier": -36736447,
+            "fee_asset_price_modifier": -231970292
+        },
+        "outputs": {
+            "fee_asset_price_at_execution": 10973413879,
+            "mana_base_fee_components_in_wei": {
+                "data_cost": 0,
+                "gas_cost": 32273987,
+                "proving_cost": 5445736706,
+                "congestion_cost": 20758192326,
+                "congestion_multiplier": 4789366887
+            },
+            "mana_base_fee_components_in_fee_asset": {
+                "data_cost": 0,
+                "gas_cost": 354155816,
+                "proving_cost": 59758322751,
+                "congestion_cost": 227788235773,
+                "congestion_multiplier": 4789366887
+            }
+        }
+    },
+    {
+        "l1_block_number": 20974946,
+        "l1_fees": {
+            "blob_fee": 1,
+            "base_fee": 9439894878
+        },
+        "parent_header": {
+            "excess_mana": 1338801904,
+            "mana_used": 92831721,
+            "proving_cost_per_mana_numerator": 522669976,
+            "fee_asset_price_numerator": 9057063136
+        },
+        "header": {
+            "excess_mana": 1331633625,
+            "mana_used": 77640995,
+            "proving_cost_per_mana_numerator": 580693964,
+            "fee_asset_price_numerator": 9091408259
+        },
+        "oracle_input": {
+            "proving_cost_modifier": 58023988,
+            "fee_asset_price_modifier": 34345123
+        },
+        "outputs": {
+            "fee_asset_price_at_execution": 10947988320,
+            "mana_base_fee_components_in_wei": {
+                "data_cost": 0,
+                "gas_cost": 31269651,
+                "proving_cost": 5443736503,
+                "congestion_cost": 20527807305,
+                "congestion_multiplier": 4749366983
+            },
+            "mana_base_fee_components_in_fee_asset": {
+                "data_cost": 0,
+                "gas_cost": 342339773,
+                "proving_cost": 59597963652,
+                "congestion_cost": 224738194610,
+                "congestion_multiplier": 4749366983
+            }
+        }
+    },
+    {
+        "l1_block_number": 20974949,
+        "l1_fees": {
+            "blob_fee": 1,
+            "base_fee": 9405583805
+        },
+        "parent_header": {
+            "excess_mana": 1331633625,
+            "mana_used": 77640995,
+            "proving_cost_per_mana_numerator": 580693964,
+            "fee_asset_price_numerator": 9091408259
+        },
+        "header": {
+            "excess_mana": 1309274620,
+            "mana_used": 119848095,
+            "proving_cost_per_mana_numerator": 400210010,
+            "fee_asset_price_numerator": 8805169513
+        },
+        "oracle_input": {
+            "proving_cost_modifier": -180483954,
+            "fee_asset_price_modifier": -286238746
+        },
+        "outputs": {
+            "fee_asset_price_at_execution": 10951749066,
+            "mana_base_fee_components_in_wei": {
+                "data_cost": 0,
+                "gas_cost": 31155996,
+                "proving_cost": 5446896093,
+                "congestion_cost": 19867439967,
+                "congestion_multiplier": 4626734402
+            },
+            "mana_base_fee_components_in_fee_asset": {
+                "data_cost": 0,
+                "gas_cost": 341212650,
+                "proving_cost": 59653039199,
+                "congestion_cost": 217583217102,
+                "congestion_multiplier": 4626734402
+            }
+        }
+    },
+    {
+        "l1_block_number": 20974952,
+        "l1_fees": {
+            "blob_fee": 1,
+            "base_fee": 9725564097
+        },
+        "parent_header": {
+            "excess_mana": 1309274620,
+            "mana_used": 119848095,
+            "proving_cost_per_mana_numerator": 400210010,
+            "fee_asset_price_numerator": 8805169513
+        },
+        "header": {
+            "excess_mana": 1329122715,
+            "mana_used": 104571961,
+            "proving_cost_per_mana_numerator": 389834369,
+            "fee_asset_price_numerator": 8101281380
+        },
+        "oracle_input": {
+            "proving_cost_modifier": -10375641,
+            "fee_asset_price_modifier": -703888133
+        },
+        "outputs": {
+            "fee_asset_price_at_execution": 10920445739,
+            "mana_base_fee_components_in_wei": {
+                "data_cost": 0,
+                "gas_cost": 32215931,
+                "proving_cost": 5437074185,
+                "congestion_cost": 20430177368,
+                "congestion_multiplier": 4735434935
+            },
+            "mana_base_fee_components_in_fee_asset": {
+                "data_cost": 0,
+                "gas_cost": 351812326,
+                "proving_cost": 59375273616,
+                "congestion_cost": 223106643385,
+                "congestion_multiplier": 4735434935
+            }
+        }
+    },
+    {
+        "l1_block_number": 20974955,
+        "l1_fees": {
+            "blob_fee": 1,
+            "base_fee": 9211947631
+        },
+        "parent_header": {
+            "excess_mana": 1329122715,
+            "mana_used": 104571961,
+            "proving_cost_per_mana_numerator": 389834369,
+            "fee_asset_price_numerator": 8101281380
+        },
+        "header": {
+            "excess_mana": 1333694676,
+            "mana_used": 101810527,
+            "proving_cost_per_mana_numerator": 427108560,
+            "fee_asset_price_numerator": 8211979675
+        },
+        "oracle_input": {
+            "proving_cost_modifier": 37274191,
+            "fee_asset_price_modifier": 110698295
+        },
+        "outputs": {
+            "fee_asset_price_at_execution": 10843847915,
+            "mana_base_fee_components_in_wei": {
+                "data_cost": 0,
+                "gas_cost": 30514576,
+                "proving_cost": 5436510083,
+                "congestion_cost": 20560569849,
+                "congestion_multiplier": 4760833567
+            },
+            "mana_base_fee_components_in_fee_asset": {
+                "data_cost": 0,
+                "gas_cost": 330895421,
+                "proving_cost": 58952688528,
+                "congestion_cost": 222955692488,
+                "congestion_multiplier": 4760833567
+            }
+        }
+    },
+    {
+        "l1_block_number": 20974958,
+        "l1_fees": {
+            "blob_fee": 1,
+            "base_fee": 9168730681
+        },
+        "parent_header": {
+            "excess_mana": 1333694676,
+            "mana_used": 101810527,
+            "proving_cost_per_mana_numerator": 427108560,
+            "fee_asset_price_numerator": 8211979675
+        },
+        "header": {
+            "excess_mana": 1335505203,
+            "mana_used": 95686443,
+            "proving_cost_per_mana_numerator": 441651375,
+            "fee_asset_price_numerator": 7634681671
+        },
+        "oracle_input": {
+            "proving_cost_modifier": 14542815,
+            "fee_asset_price_modifier": -577298004
+        },
+        "outputs": {
+            "fee_asset_price_at_execution": 10855858516,
+            "mana_base_fee_components_in_wei": {
+                "data_cost": 0,
+                "gas_cost": 30371420,
+                "proving_cost": 5438536876,
+                "congestion_cost": 20622866034,
+                "congestion_multiplier": 4770929209
+            },
+            "mana_base_fee_components_in_fee_asset": {
+                "data_cost": 0,
+                "gas_cost": 329707838,
+                "proving_cost": 59039986859,
+                "congestion_cost": 223878915859,
+                "congestion_multiplier": 4770929209
+            }
+        }
+    },
+    {
+        "l1_block_number": 20974961,
+        "l1_fees": {
+            "blob_fee": 1,
+            "base_fee": 9071304225
+        },
+        "parent_header": {
+            "excess_mana": 1335505203,
+            "mana_used": 95686443,
+            "proving_cost_per_mana_numerator": 441651375,
+            "fee_asset_price_numerator": 7634681671
+        },
+        "header": {
+            "excess_mana": 1331191646,
+            "mana_used": 87209194,
+            "proving_cost_per_mana_numerator": 252255241,
+            "fee_asset_price_numerator": 7846156025
+        },
+        "oracle_input": {
+            "proving_cost_modifier": -189396134,
+            "fee_asset_price_modifier": 211474354
+        },
+        "outputs": {
+            "fee_asset_price_at_execution": 10793368413,
+            "mana_base_fee_components_in_wei": {
+                "data_cost": 0,
+                "gas_cost": 30048695,
+                "proving_cost": 5439327850,
+                "congestion_cost": 20493270678,
+                "congestion_multiplier": 4746911647
+            },
+            "mana_base_fee_components_in_fee_asset": {
+                "data_cost": 0,
+                "gas_cost": 324326635,
+                "proving_cost": 58708669404,
+                "congestion_cost": 221191420414,
+                "congestion_multiplier": 4746911647
+            }
+        }
+    },
+    {
+        "l1_block_number": 20974964,
+        "l1_fees": {
+            "blob_fee": 1,
+            "base_fee": 8301086454
+        },
+        "parent_header": {
+            "excess_mana": 1331191646,
+            "mana_used": 87209194,
+            "proving_cost_per_mana_numerator": 252255241,
+            "fee_asset_price_numerator": 7846156025
+        },
+        "header": {
+            "excess_mana": 1318400840,
+            "mana_used": 103763183,
+            "proving_cost_per_mana_numerator": 370929871,
+            "fee_asset_price_numerator": 7994895828
+        },
+        "oracle_input": {
+            "proving_cost_modifier": 118674630,
+            "fee_asset_price_modifier": 148739803
+        },
+        "outputs": {
+            "fee_asset_price_at_execution": 10816217770,
+            "mana_base_fee_components_in_wei": {
+                "data_cost": 0,
+                "gas_cost": 27497348,
+                "proving_cost": 5429035723,
+                "congestion_cost": 20060408407,
+                "congestion_multiplier": 4676401874
+            },
+            "mana_base_fee_components_in_fee_asset": {
+                "data_cost": 0,
+                "gas_cost": 297417304,
+                "proving_cost": 58721632661,
+                "congestion_cost": 216977745885,
+                "congestion_multiplier": 4676401874
+            }
+        }
+    },
+    {
+        "l1_block_number": 20974967,
+        "l1_fees": {
+            "blob_fee": 1,
+            "base_fee": 8897960618
+        },
+        "parent_header": {
+            "excess_mana": 1318400840,
+            "mana_used": 103763183,
+            "proving_cost_per_mana_numerator": 370929871,
+            "fee_asset_price_numerator": 7994895828
+        },
+        "header": {
+            "excess_mana": 1322164023,
+            "mana_used": 96243533,
+            "proving_cost_per_mana_numerator": 435025193,
+            "fee_asset_price_numerator": 8064434274
+        },
+        "oracle_input": {
+            "proving_cost_modifier": 64095322,
+            "fee_asset_price_modifier": 69538446
+        },
+        "outputs": {
+            "fee_asset_price_at_execution": 10832317762,
+            "mana_base_fee_components_in_wei": {
+                "data_cost": 0,
+                "gas_cost": 29474494,
+                "proving_cost": 5435482436,
+                "congestion_cost": 20204148580,
+                "congestion_multiplier": 4697037111
+            },
+            "mana_base_fee_components_in_fee_asset": {
+                "data_cost": 0,
+                "gas_cost": 319277084,
+                "proving_cost": 58878872936,
+                "congestion_cost": 218857757529,
+                "congestion_multiplier": 4697037111
+            }
+        }
+    },
+    {
+        "l1_block_number": 20974970,
+        "l1_fees": {
+            "blob_fee": 1,
+            "base_fee": 8878052220
+        },
+        "parent_header": {
+            "excess_mana": 1322164023,
+            "mana_used": 96243533,
+            "proving_cost_per_mana_numerator": 435025193,
+            "fee_asset_price_numerator": 8064434274
+        },
+        "header": {
+            "excess_mana": 1318407556,
+            "mana_used": 108984685,
+            "proving_cost_per_mana_numerator": 460258625,
+            "fee_asset_price_numerator": 7922857959
+        },
+        "oracle_input": {
+            "proving_cost_modifier": 25233432,
+            "fee_asset_price_modifier": -141576315
+        },
+        "outputs": {
+            "fee_asset_price_at_execution": 10839853007,
+            "mana_base_fee_components_in_wei": {
+                "data_cost": 0,
+                "gas_cost": 29408547,
+                "proving_cost": 5438967442,
+                "congestion_cost": 20104148674,
+                "congestion_multiplier": 4676438620
+            },
+            "mana_base_fee_components_in_fee_asset": {
+                "data_cost": 0,
+                "gas_cost": 318784326,
+                "proving_cost": 58957607581,
+                "congestion_cost": 217926016457,
+                "congestion_multiplier": 4676438620
+            }
+        }
+    },
+    {
+        "l1_block_number": 20974973,
+        "l1_fees": {
+            "blob_fee": 1,
+            "base_fee": 8944979149
+        },
+        "parent_header": {
+            "excess_mana": 1318407556,
+            "mana_used": 108984685,
+            "proving_cost_per_mana_numerator": 460258625,
+            "fee_asset_price_numerator": 7922857959
+        },
+        "header": {
+            "excess_mana": 1327392241,
+            "mana_used": 79765363,
+            "proving_cost_per_mana_numerator": 534368547,
+            "fee_asset_price_numerator": 8870191059
+        },
+        "oracle_input": {
+            "proving_cost_modifier": 74109922,
+            "fee_asset_price_modifier": 947333100
+        },
+        "outputs": {
+            "fee_asset_price_at_execution": 10824517201,
+            "mana_base_fee_components_in_wei": {
+                "data_cost": 0,
+                "gas_cost": 29630243,
+                "proving_cost": 5440340054,
+                "congestion_cost": 20380327197,
+                "congestion_multiplier": 4725857014
+            },
+            "mana_base_fee_components_in_fee_asset": {
+                "data_cost": 0,
+                "gas_cost": 320733075,
+                "proving_cost": 58889054493,
+                "congestion_cost": 220607202305,
+                "congestion_multiplier": 4725857014
+            }
+        }
+    },
+    {
+        "l1_block_number": 20974976,
+        "l1_fees": {
+            "blob_fee": 1,
+            "base_fee": 8661304425
+        },
+        "parent_header": {
+            "excess_mana": 1327392241,
+            "mana_used": 79765363,
+            "proving_cost_per_mana_numerator": 534368547,
+            "fee_asset_price_numerator": 8870191059
+        },
+        "header": {
+            "excess_mana": 1307157604,
+            "mana_used": 111586525,
+            "proving_cost_per_mana_numerator": 631784323,
+            "fee_asset_price_numerator": 8097895451
+        },
+        "oracle_input": {
+            "proving_cost_modifier": 97415776,
+            "fee_asset_price_modifier": -772295608
+        },
+        "outputs": {
+            "fee_asset_price_at_execution": 10927548691,
+            "mana_base_fee_components_in_wei": {
+                "data_cost": 0,
+                "gas_cost": 28690570,
+                "proving_cost": 5444373380,
+                "congestion_cost": 19786705617,
+                "congestion_multiplier": 4615288584
+            },
+            "mana_base_fee_components_in_fee_asset": {
+                "data_cost": 0,
+                "gas_cost": 313517600,
+                "proving_cost": 59493655201,
+                "congestion_cost": 216220189064,
+                "congestion_multiplier": 4615288584
+            }
+        }
+    },
+    {
+        "l1_block_number": 20974979,
+        "l1_fees": {
+            "blob_fee": 1,
+            "base_fee": 8725503529
+        },
+        "parent_header": {
+            "excess_mana": 1307157604,
+            "mana_used": 111586525,
+            "proving_cost_per_mana_numerator": 631784323,
+            "fee_asset_price_numerator": 8097895451
+        },
+        "header": {
+            "excess_mana": 1318744129,
+            "mana_used": 89963278,
+            "proving_cost_per_mana_numerator": 528282288,
+            "fee_asset_price_numerator": 7833069405
+        },
+        "oracle_input": {
+            "proving_cost_modifier": -103502035,
+            "fee_asset_price_modifier": -264826046
+        },
+        "outputs": {
+            "fee_asset_price_at_execution": 10843480756,
+            "mana_base_fee_components_in_wei": {
+                "data_cost": 0,
+                "gas_cost": 28903230,
+                "proving_cost": 5449679642,
+                "congestion_cost": 20151764655,
+                "congestion_multiplier": 4678280520
+            },
+            "mana_base_fee_components_in_fee_asset": {
+                "data_cost": 0,
+                "gas_cost": 313411618,
+                "proving_cost": 59093496324,
+                "congestion_cost": 218515272235,
+                "congestion_multiplier": 4678280520
+            }
+        }
+    },
+    {
+        "l1_block_number": 20974982,
+        "l1_fees": {
+            "blob_fee": 1,
+            "base_fee": 8635480789
+        },
+        "parent_header": {
+            "excess_mana": 1318744129,
+            "mana_used": 89963278,
+            "proving_cost_per_mana_numerator": 528282288,
+            "fee_asset_price_numerator": 7833069405
+        },
+        "header": {
+            "excess_mana": 1308707407,
+            "mana_used": 105050231,
+            "proving_cost_per_mana_numerator": 534505171,
+            "fee_asset_price_numerator": 8001097969
+        },
+        "oracle_input": {
+            "proving_cost_modifier": 6222883,
+            "fee_asset_price_modifier": 168028564
+        },
+        "outputs": {
+            "fee_asset_price_at_execution": 10814802386,
+            "mana_base_fee_components_in_wei": {
+                "data_cost": 0,
+                "gas_cost": 28605030,
+                "proving_cost": 5444042031,
+                "congestion_cost": 19831039272,
+                "congestion_multiplier": 4623664938
+            },
+            "mana_base_fee_components_in_fee_asset": {
+                "data_cost": 0,
+                "gas_cost": 309357746,
+                "proving_cost": 58876238746,
+                "congestion_cost": 214468770835,
+                "congestion_multiplier": 4623664938
+            }
+        }
+    },
+    {
+        "l1_block_number": 20974985,
+        "l1_fees": {
+            "blob_fee": 1,
+            "base_fee": 9253198960
+        },
+        "parent_header": {
+            "excess_mana": 1308707407,
+            "mana_used": 105050231,
+            "proving_cost_per_mana_numerator": 534505171,
+            "fee_asset_price_numerator": 8001097969
+        },
+        "header": {
+            "excess_mana": 1313757638,
+            "mana_used": 91611611,
+            "proving_cost_per_mana_numerator": 559614429,
+            "fee_asset_price_numerator": 8101746392
+        },
+        "oracle_input": {
+            "proving_cost_modifier": 25109258,
+            "fee_asset_price_modifier": 100648423
+        },
+        "outputs": {
+            "fee_asset_price_at_execution": 10832989618,
+            "mana_base_fee_components_in_wei": {
+                "data_cost": 0,
+                "gas_cost": 30651221,
+                "proving_cost": 5444380818,
+                "congestion_cost": 19989703249,
+                "congestion_multiplier": 4651065986
+            },
+            "mana_base_fee_components_in_fee_asset": {
+                "data_cost": 0,
+                "gas_cost": 332044358,
+                "proving_cost": 58978920877,
+                "congestion_cost": 216548247763,
+                "congestion_multiplier": 4651065986
+            }
+        }
+    },
+    {
+        "l1_block_number": 20974988,
+        "l1_fees": {
+            "blob_fee": 1,
+            "base_fee": 8772488689
+        },
+        "parent_header": {
+            "excess_mana": 1313757638,
+            "mana_used": 91611611,
+            "proving_cost_per_mana_numerator": 559614429,
+            "fee_asset_price_numerator": 8101746392
+        },
+        "header": {
+            "excess_mana": 1305369249,
+            "mana_used": 113252671,
+            "proving_cost_per_mana_numerator": 417177712,
+            "fee_asset_price_numerator": 8070934001
+        },
+        "oracle_input": {
+            "proving_cost_modifier": -142436717,
+            "fee_asset_price_modifier": -30812391
+        },
+        "outputs": {
+            "fee_asset_price_at_execution": 10843898340,
+            "mana_base_fee_components_in_wei": {
+                "data_cost": 0,
+                "gas_cost": 29058868,
+                "proving_cost": 5445748033,
+                "congestion_cost": 19740192412,
+                "congestion_multiplier": 4605641764
+            },
+            "mana_base_fee_components_in_fee_asset": {
+                "data_cost": 0,
+                "gas_cost": 315111410,
+                "proving_cost": 59053138055,
+                "congestion_cost": 214060639727,
+                "congestion_multiplier": 4605641764
+            }
+        }
+    },
+    {
+        "l1_block_number": 20974991,
+        "l1_fees": {
+            "blob_fee": 1,
+            "base_fee": 8898215086
+        },
+        "parent_header": {
+            "excess_mana": 1305369249,
+            "mana_used": 113252671,
+            "proving_cost_per_mana_numerator": 417177712,
+            "fee_asset_price_numerator": 8070934001
+        },
+        "header": {
+            "excess_mana": 1318621920,
+            "mana_used": 90250478,
+            "proving_cost_per_mana_numerator": 245435262,
+            "fee_asset_price_numerator": 7785208408
+        },
+        "oracle_input": {
+            "proving_cost_modifier": -171742450,
+            "fee_asset_price_modifier": -285725593
+        },
+        "outputs": {
+            "fee_asset_price_at_execution": 10840557591,
+            "mana_base_fee_components_in_wei": {
+                "data_cost": 0,
+                "gas_cost": 29475337,
+                "proving_cost": 5437996810,
+                "congestion_cost": 20107239241,
+                "congestion_multiplier": 4677611646
+            },
+            "mana_base_fee_components_in_fee_asset": {
+                "data_cost": 0,
+                "gas_cost": 319529088,
+                "proving_cost": 58950917598,
+                "congestion_cost": 217973684988,
+                "congestion_multiplier": 4677611646
+            }
+        }
+    },
+    {
+        "l1_block_number": 20974994,
+        "l1_fees": {
+            "blob_fee": 1,
+            "base_fee": 9375929800
+        },
+        "parent_header": {
+            "excess_mana": 1318621920,
+            "mana_used": 90250478,
+            "proving_cost_per_mana_numerator": 245435262,
+            "fee_asset_price_numerator": 7785208408
+        },
+        "header": {
+            "excess_mana": 1308872398,
+            "mana_used": 95210532,
+            "proving_cost_per_mana_numerator": 318267081,
+            "fee_asset_price_numerator": 8018327579
+        },
+        "oracle_input": {
+            "proving_cost_modifier": 72831819,
+            "fee_asset_price_modifier": 233119171
+        },
+        "outputs": {
+            "fee_asset_price_at_execution": 10809627552,
+            "mana_base_fee_components_in_wei": {
+                "data_cost": 0,
+                "gas_cost": 31057767,
+                "proving_cost": 5428665476,
+                "congestion_cost": 19789081232,
+                "congestion_multiplier": 4624557574
+            },
+            "mana_base_fee_components_in_fee_asset": {
+                "data_cost": 0,
+                "gas_cost": 335722893,
+                "proving_cost": 58681851899,
+                "congestion_cost": 213912597714,
+                "congestion_multiplier": 4624557574
+            }
+        }
+    },
+    {
+        "l1_block_number": 20974997,
+        "l1_fees": {
+            "blob_fee": 1,
+            "base_fee": 9712139037
+        },
+        "parent_header": {
+            "excess_mana": 1308872398,
+            "mana_used": 95210532,
+            "proving_cost_per_mana_numerator": 318267081,
+            "fee_asset_price_numerator": 8018327579
+        },
+        "header": {
+            "excess_mana": 1304082930,
+            "mana_used": 57474297,
+            "proving_cost_per_mana_numerator": 377674874,
+            "fee_asset_price_numerator": 8058999714
+        },
+        "oracle_input": {
+            "proving_cost_modifier": 59407793,
+            "fee_asset_price_modifier": 40672135
+        },
+        "outputs": {
+            "fee_asset_price_at_execution": 10834856261,
+            "mana_base_fee_components_in_wei": {
+                "data_cost": 0,
+                "gas_cost": 32171460,
+                "proving_cost": 5432620712,
+                "congestion_cost": 19666232392,
+                "congestion_multiplier": 4598715518
+            },
+            "mana_base_fee_components_in_fee_asset": {
+                "data_cost": 0,
+                "gas_cost": 348573144,
+                "proving_cost": 58861664535,
+                "congestion_cost": 213080801162,
+                "congestion_multiplier": 4598715518
+            }
+        }
+    },
+    {
+        "l1_block_number": 20975000,
+        "l1_fees": {
+            "blob_fee": 1,
+            "base_fee": 10320266532
+        },
+        "parent_header": {
+            "excess_mana": 1304082930,
+            "mana_used": 57474297,
+            "proving_cost_per_mana_numerator": 377674874,
+            "fee_asset_price_numerator": 8058999714
+        },
+        "header": {
+            "excess_mana": 1261557227,
+            "mana_used": 135729420,
+            "proving_cost_per_mana_numerator": 417528624,
+            "fee_asset_price_numerator": 7594293458
+        },
+        "oracle_input": {
+            "proving_cost_modifier": 39853750,
+            "fee_asset_price_modifier": -464706256
+        },
+        "outputs": {
+            "fee_asset_price_at_execution": 10839263925,
+            "mana_base_fee_components_in_wei": {
+                "data_cost": 0,
+                "gas_cost": 34185882,
+                "proving_cost": 5435849071,
+                "congestion_cost": 18464130689,
+                "congestion_multiplier": 4375505065
+            },
+            "mana_base_fee_components_in_fee_asset": {
+                "data_cost": 0,
+                "gas_cost": 370549797,
+                "proving_cost": 58920602737,
+                "congestion_cost": 200137585683,
+                "congestion_multiplier": 4375505065
+            }
+        }
+    },
+    {
+        "l1_block_number": 20975003,
+        "l1_fees": {
+            "blob_fee": 1,
+            "base_fee": 10168459328
+        },
+        "parent_header": {
+            "excess_mana": 1261557227,
+            "mana_used": 135729420,
+            "proving_cost_per_mana_numerator": 417528624,
+            "fee_asset_price_numerator": 7594293458
+        },
+        "header": {
+            "excess_mana": 1297286647,
+            "mana_used": 112984877,
+            "proving_cost_per_mana_numerator": 524867736,
+            "fee_asset_price_numerator": 7779610709
+        },
+        "oracle_input": {
+            "proving_cost_modifier": 107339112,
+            "fee_asset_price_modifier": 185317251
+        },
+        "outputs": {
+            "fee_asset_price_at_execution": 10789010044,
+            "mana_base_fee_components_in_wei": {
+                "data_cost": 0,
+                "gas_cost": 33683021,
+                "proving_cost": 5438015893,
+                "congestion_cost": 19491795489,
+                "congestion_multiplier": 4562293137
+            },
+            "mana_base_fee_components_in_fee_asset": {
+                "data_cost": 0,
+                "gas_cost": 363406451,
+                "proving_cost": 58670808089,
+                "congestion_cost": 210297177306,
+                "congestion_multiplier": 4562293137
+            }
+        }
+    },
+    {
+        "l1_block_number": 20975006,
+        "l1_fees": {
+            "blob_fee": 1,
+            "base_fee": 10401786820
+        },
+        "parent_header": {
+            "excess_mana": 1297286647,
+            "mana_used": 112984877,
+            "proving_cost_per_mana_numerator": 524867736,
+            "fee_asset_price_numerator": 7779610709
+        },
+        "header": {
+            "excess_mana": 1310271524,
+            "mana_used": 110485095,
+            "proving_cost_per_mana_numerator": 519626542,
+            "fee_asset_price_numerator": 8264827175
+        },
+        "oracle_input": {
+            "proving_cost_modifier": -5241194,
+            "fee_asset_price_modifier": 485216466
+        },
+        "outputs": {
+            "fee_asset_price_at_execution": 10809022478,
+            "mana_base_fee_components_in_wei": {
+                "data_cost": 0,
+                "gas_cost": 34455918,
+                "proving_cost": 5443856145,
+                "congestion_cost": 19897963890,
+                "congestion_multiplier": 4632134070
+            },
+            "mana_base_fee_components_in_fee_asset": {
+                "data_cost": 0,
+                "gas_cost": 372434792,
+                "proving_cost": 58842763438,
+                "congestion_cost": 215077538953,
+                "congestion_multiplier": 4632134070
+            }
+        }
+    },
+    {
+        "l1_block_number": 20975009,
+        "l1_fees": {
+            "blob_fee": 1,
+            "base_fee": 10702980460
+        },
+        "parent_header": {
+            "excess_mana": 1310271524,
+            "mana_used": 110485095,
+            "proving_cost_per_mana_numerator": 519626542,
+            "fee_asset_price_numerator": 8264827175
+        },
+        "header": {
+            "excess_mana": 1320756619,
+            "mana_used": 102141151,
+            "proving_cost_per_mana_numerator": 478575697,
+            "fee_asset_price_numerator": 7482690588
+        },
+        "oracle_input": {
+            "proving_cost_modifier": -41050845,
+            "fee_asset_price_modifier": -782136587
+        },
+        "outputs": {
+            "fee_asset_price_at_execution": 10861597083,
+            "mana_base_fee_components_in_wei": {
+                "data_cost": 0,
+                "gas_cost": 35453622,
+                "proving_cost": 5443570829,
+                "congestion_cost": 20213814437,
+                "congestion_multiplier": 4689309040
+            },
+            "mana_base_fee_components_in_fee_asset": {
+                "data_cost": 0,
+                "gas_cost": 385082957,
+                "proving_cost": 59125873037,
+                "congestion_cost": 219554307925,
+                "congestion_multiplier": 4689309040
+            }
+        }
+    },
+    {
+        "l1_block_number": 20975012,
+        "l1_fees": {
+            "blob_fee": 1,
+            "base_fee": 11536948339
+        },
+        "parent_header": {
+            "excess_mana": 1320756619,
+            "mana_used": 102141151,
+            "proving_cost_per_mana_numerator": 478575697,
+            "fee_asset_price_numerator": 7482690588
+        },
+        "header": {
+            "excess_mana": 1322897770,
+            "mana_used": 95947526,
+            "proving_cost_per_mana_numerator": 556287357,
+            "fee_asset_price_numerator": 7910988307
+        },
+        "oracle_input": {
+            "proving_cost_modifier": 77711660,
+            "fee_asset_price_modifier": 428297719
+        },
+        "outputs": {
+            "fee_asset_price_at_execution": 10776975916,
+            "mana_base_fee_components_in_wei": {
+                "data_cost": 0,
+                "gas_cost": 38216141,
+                "proving_cost": 5441336656,
+                "congestion_cost": 20280214903,
+                "congestion_multiplier": 4701071174
+            },
+            "mana_base_fee_components_in_fee_asset": {
+                "data_cost": 0,
+                "gas_cost": 411854431,
+                "proving_cost": 58641154092,
+                "congestion_cost": 218559387580,
+                "congestion_multiplier": 4701071174
+            }
+        }
+    },
+    {
+        "l1_block_number": 20975015,
+        "l1_fees": {
+            "blob_fee": 1,
+            "base_fee": 11359031521
+        },
+        "parent_header": {
+            "excess_mana": 1322897770,
+            "mana_used": 95947526,
+            "proving_cost_per_mana_numerator": 556287357,
+            "fee_asset_price_numerator": 7910988307
+        },
+        "header": {
+            "excess_mana": 1318845296,
+            "mana_used": 92861285,
+            "proving_cost_per_mana_numerator": 577567345,
+            "fee_asset_price_numerator": 8043579839
+        },
+        "oracle_input": {
+            "proving_cost_modifier": 21279988,
+            "fee_asset_price_modifier": 132591532
+        },
+        "outputs": {
+            "fee_asset_price_at_execution": 10823232445,
+            "mana_base_fee_components_in_wei": {
+                "data_cost": 0,
+                "gas_cost": 37626791,
+                "proving_cost": 5445566852,
+                "congestion_cost": 20171760841,
+                "congestion_multiplier": 4678834299
+            },
+            "mana_base_fee_components_in_fee_asset": {
+                "data_cost": 0,
+                "gas_cost": 407243505,
+                "proving_cost": 58938635833,
+                "congestion_cost": 218323656407,
+                "congestion_multiplier": 4678834299
+            }
+        }
+    },
+    {
+        "l1_block_number": 20975018,
+        "l1_fees": {
+            "blob_fee": 1,
+            "base_fee": 11201567819
+        },
+        "parent_header": {
+            "excess_mana": 1318845296,
+            "mana_used": 92861285,
+            "proving_cost_per_mana_numerator": 577567345,
+            "fee_asset_price_numerator": 8043579839
+        },
+        "header": {
+            "excess_mana": 1311706581,
+            "mana_used": 107725422,
+            "proving_cost_per_mana_numerator": 576270642,
+            "fee_asset_price_numerator": 8673737845
+        },
+        "oracle_input": {
+            "proving_cost_modifier": -1296703,
+            "fee_asset_price_modifier": 630158006
+        },
+        "outputs": {
+            "fee_asset_price_at_execution": 10837592653,
+            "mana_base_fee_components_in_wei": {
+                "data_cost": 0,
+                "gas_cost": 37105193,
+                "proving_cost": 5446725792,
+                "congestion_cost": 19960695297,
+                "congestion_multiplier": 4639918034
+            },
+            "mana_base_fee_components_in_fee_asset": {
+                "data_cost": 0,
+                "gas_cost": 402130967,
+                "proving_cost": 59029395426,
+                "congestion_cost": 216325884699,
+                "congestion_multiplier": 4639918034
+            }
+        }
+    },
+    {
+        "l1_block_number": 20975021,
+        "l1_fees": {
+            "blob_fee": 1,
+            "base_fee": 9913252976
+        },
+        "parent_header": {
+            "excess_mana": 1311706581,
+            "mana_used": 107725422,
+            "proving_cost_per_mana_numerator": 576270642,
+            "fee_asset_price_numerator": 8673737845
+        },
+        "header": {
+            "excess_mana": 1319432003,
+            "mana_used": 114906142,
+            "proving_cost_per_mana_numerator": 589826202,
+            "fee_asset_price_numerator": 9223117112
+        },
+        "oracle_input": {
+            "proving_cost_modifier": 13555560,
+            "fee_asset_price_modifier": 549379267
+        },
+        "outputs": {
+            "fee_asset_price_at_execution": 10906102243,
+            "mana_base_fee_components_in_wei": {
+                "data_cost": 0,
+                "gas_cost": 32837650,
+                "proving_cost": 5446655164,
+                "congestion_cost": 20175751030,
+                "congestion_multiplier": 4682047174
+            },
+            "mana_base_fee_components_in_fee_asset": {
+                "data_cost": 0,
+                "gas_cost": 358130768,
+                "proving_cost": 59401778100,
+                "congestion_cost": 220038803562,
+                "congestion_multiplier": 4682047174
+            }
+        }
+    },
+    {
+        "l1_block_number": 20975024,
+        "l1_fees": {
+            "blob_fee": 1,
+            "base_fee": 10599983896
+        },
+        "parent_header": {
+            "excess_mana": 1319432003,
+            "mana_used": 114906142,
+            "proving_cost_per_mana_numerator": 589826202,
+            "fee_asset_price_numerator": 9223117112
+        },
+        "header": {
+            "excess_mana": 1334338145,
+            "mana_used": 94649328,
+            "proving_cost_per_mana_numerator": 551090117,
+            "fee_asset_price_numerator": 9243600887
+        },
+        "oracle_input": {
+            "proving_cost_modifier": -38736085,
+            "fee_asset_price_modifier": 20483775
+        },
+        "outputs": {
+            "fee_asset_price_at_execution": 10966182992,
+            "mana_base_fee_components_in_wei": {
+                "data_cost": 0,
+                "gas_cost": 35112446,
+                "proving_cost": 5447393539,
+                "congestion_cost": 20638450530,
+                "congestion_multiplier": 4764419152
+            },
+            "mana_base_fee_components_in_fee_asset": {
+                "data_cost": 0,
+                "gas_cost": 385049508,
+                "proving_cost": 59737114378,
+                "congestion_cost": 226325025183,
+                "congestion_multiplier": 4764419152
+            }
+        }
+    },
+    {
+        "l1_block_number": 20975027,
+        "l1_fees": {
+            "blob_fee": 1,
+            "base_fee": 11446110527
+        },
+        "parent_header": {
+            "excess_mana": 1334338145,
+            "mana_used": 94649328,
+            "proving_cost_per_mana_numerator": 551090117,
+            "fee_asset_price_numerator": 9243600887
+        },
+        "header": {
+            "excess_mana": 1328987473,
+            "mana_used": 92306873,
+            "proving_cost_per_mana_numerator": 580816426,
+            "fee_asset_price_numerator": 8644364312
+        },
+        "oracle_input": {
+            "proving_cost_modifier": 29726309,
+            "fee_asset_price_modifier": -599236575
+        },
+        "outputs": {
+            "fee_asset_price_at_execution": 10968429510,
+            "mana_base_fee_components_in_wei": {
+                "data_cost": 0,
+                "gas_cost": 37915241,
+                "proving_cost": 5445283841,
+                "congestion_cost": 20478025152,
+                "congestion_multiplier": 4734685691
+            },
+            "mana_base_fee_components_in_fee_asset": {
+                "data_cost": 0,
+                "gas_cost": 415870648,
+                "proving_cost": 59726211971,
+                "congestion_cost": 224611775383,
+                "congestion_multiplier": 4734685691
+            }
+        }
+    },
+    {
+        "l1_block_number": 20975030,
+        "l1_fees": {
+            "blob_fee": 1,
+            "base_fee": 11076948971
+        },
+        "parent_header": {
+            "excess_mana": 1328987473,
+            "mana_used": 92306873,
+            "proving_cost_per_mana_numerator": 580816426,
+            "fee_asset_price_numerator": 8644364312
+        },
+        "header": {
+            "excess_mana": 1321294346,
+            "mana_used": 101265912,
+            "proving_cost_per_mana_numerator": 620609103,
+            "fee_asset_price_numerator": 8736960733
+        },
+        "oracle_input": {
+            "proving_cost_modifier": 39792677,
+            "fee_asset_price_modifier": 92596421
+        },
+        "outputs": {
+            "fee_asset_price_at_execution": 10902899206,
+            "mana_base_fee_components_in_wei": {
+                "data_cost": 0,
+                "gas_cost": 36692393,
+                "proving_cost": 5446902763,
+                "congestion_cost": 20246860163,
+                "congestion_multiplier": 4692260203
+            },
+            "mana_base_fee_components_in_fee_asset": {
+                "data_cost": 0,
+                "gas_cost": 400053462,
+                "proving_cost": 59387031809,
+                "congestion_cost": 220749475595,
+                "congestion_multiplier": 4692260203
+            }
+        }
+    },
+    {
+        "l1_block_number": 20975033,
+        "l1_fees": {
+            "blob_fee": 1,
+            "base_fee": 11283306741
+        },
+        "parent_header": {
+            "excess_mana": 1321294346,
+            "mana_used": 101265912,
+            "proving_cost_per_mana_numerator": 620609103,
+            "fee_asset_price_numerator": 8736960733
+        },
+        "header": {
+            "excess_mana": 1322560258,
+            "mana_used": 100901498,
+            "proving_cost_per_mana_numerator": 595189786,
+            "fee_asset_price_numerator": 9164105855
+        },
+        "oracle_input": {
+            "proving_cost_modifier": -25419317,
+            "fee_asset_price_modifier": 427145122
+        },
+        "outputs": {
+            "fee_asset_price_at_execution": 10912999576,
+            "mana_base_fee_components_in_wei": {
+                "data_cost": 0,
+                "gas_cost": 37375953,
+                "proving_cost": 5449070663,
+                "congestion_cost": 20295546381,
+                "congestion_multiplier": 4699215139
+            },
+            "mana_base_fee_components_in_fee_asset": {
+                "data_cost": 0,
+                "gas_cost": 407883759,
+                "proving_cost": 59465705834,
+                "congestion_cost": 221485289050,
+                "congestion_multiplier": 4699215139
+            }
+        }
+    },
+    {
+        "l1_block_number": 20975036,
+        "l1_fees": {
+            "blob_fee": 1,
+            "base_fee": 10860587186
+        },
+        "parent_header": {
+            "excess_mana": 1322560258,
+            "mana_used": 100901498,
+            "proving_cost_per_mana_numerator": 595189786,
+            "fee_asset_price_numerator": 9164105855
+        },
+        "header": {
+            "excess_mana": 1323461756,
+            "mana_used": 97604527,
+            "proving_cost_per_mana_numerator": 652162855,
+            "fee_asset_price_numerator": 8932035693
+        },
+        "oracle_input": {
+            "proving_cost_modifier": 56973069,
+            "fee_asset_price_modifier": -232070162
+        },
+        "outputs": {
+            "fee_asset_price_at_execution": 10959713619,
+            "mana_base_fee_components_in_wei": {
+                "data_cost": 0,
+                "gas_cost": 35975695,
+                "proving_cost": 5447685722,
+                "congestion_cost": 20312437487,
+                "congestion_multiplier": 4704174263
+            },
+            "mana_base_fee_components_in_fee_asset": {
+                "data_cost": 0,
+                "gas_cost": 394283314,
+                "proving_cost": 59705075399,
+                "congestion_cost": 222618497761,
+                "congestion_multiplier": 4704174263
+            }
+        }
+    },
+    {
+        "l1_block_number": 20975039,
+        "l1_fees": {
+            "blob_fee": 1,
+            "base_fee": 10866970943
+        },
+        "parent_header": {
+            "excess_mana": 1323461756,
+            "mana_used": 97604527,
+            "proving_cost_per_mana_numerator": 652162855,
+            "fee_asset_price_numerator": 8932035693
+        },
+        "header": {
+            "excess_mana": 1321066283,
+            "mana_used": 90323102,
+            "proving_cost_per_mana_numerator": 633173688,
+            "fee_asset_price_numerator": 8577437773
+        },
+        "oracle_input": {
+            "proving_cost_modifier": -18989167,
+            "fee_asset_price_modifier": -354597920
+        },
+        "outputs": {
+            "fee_asset_price_at_execution": 10934308883,
+            "mana_base_fee_components_in_wei": {
+                "data_cost": 0,
+                "gas_cost": 35996841,
+                "proving_cost": 5450790320,
+                "congestion_cost": 20251777044,
+                "congestion_multiplier": 4691008317
+            },
+            "mana_base_fee_components_in_fee_asset": {
+                "data_cost": 0,
+                "gas_cost": 393600578,
+                "proving_cost": 59600625015,
+                "congestion_cost": 221439185628,
+                "congestion_multiplier": 4691008317
+            }
+        }
+    },
+    {
+        "l1_block_number": 20975042,
+        "l1_fees": {
+            "blob_fee": 1,
+            "base_fee": 11041792448
+        },
+        "parent_header": {
+            "excess_mana": 1321066283,
+            "mana_used": 90323102,
+            "proving_cost_per_mana_numerator": 633173688,
+            "fee_asset_price_numerator": 8577437773
+        },
+        "header": {
+            "excess_mana": 1311389385,
+            "mana_used": 90949554,
+            "proving_cost_per_mana_numerator": 529914617,
+            "fee_asset_price_numerator": 8467260121
+        },
+        "oracle_input": {
+            "proving_cost_modifier": -103259071,
+            "fee_asset_price_modifier": -110177652
+        },
+        "outputs": {
+            "fee_asset_price_at_execution": 10895604714,
+            "mana_base_fee_components_in_wei": {
+                "data_cost": 0,
+                "gas_cost": 36575937,
+                "proving_cost": 5449755359,
+                "congestion_cost": 19960350715,
+                "congestion_multiplier": 4638196390
+            },
+            "mana_base_fee_components_in_fee_asset": {
+                "data_cost": 0,
+                "gas_cost": 398516951,
+                "proving_cost": 59378380179,
+                "congestion_cost": 217480091343,
+                "congestion_multiplier": 4638196390
+            }
+        }
+    },
+    {
+        "l1_block_number": 20975045,
+        "l1_fees": {
+            "blob_fee": 1,
+            "base_fee": 11833006757
+        },
+        "parent_header": {
+            "excess_mana": 1311389385,
+            "mana_used": 90949554,
+            "proving_cost_per_mana_numerator": 529914617,
+            "fee_asset_price_numerator": 8467260121
+        },
+        "header": {
+            "excess_mana": 1302338939,
+            "mana_used": 112229615,
+            "proving_cost_per_mana_numerator": 474886245,
+            "fee_asset_price_numerator": 8426877839
+        },
+        "oracle_input": {
+            "proving_cost_modifier": -55028372,
+            "fee_asset_price_modifier": -40382282
+        },
+        "outputs": {
+            "fee_asset_price_at_execution": 10883606803,
+            "mana_base_fee_components_in_wei": {
+                "data_cost": 0,
+                "gas_cost": 39196834,
+                "proving_cost": 5444130897,
+                "congestion_cost": 19681536035,
+                "congestion_multiplier": 4589341546
+            },
+            "mana_base_fee_components_in_fee_asset": {
+                "data_cost": 0,
+                "gas_cost": 426602929,
+                "proving_cost": 59251780067,
+                "congestion_cost": 214206099484,
+                "congestion_multiplier": 4589341546
+            }
+        }
+    },
+    {
+        "l1_block_number": 20975048,
+        "l1_fees": {
+            "blob_fee": 1,
+            "base_fee": 11691009725
+        },
+        "parent_header": {
+            "excess_mana": 1302338939,
+            "mana_used": 112229615,
+            "proving_cost_per_mana_numerator": 474886245,
+            "fee_asset_price_numerator": 8426877839
+        },
+        "header": {
+            "excess_mana": 1314568554,
+            "mana_used": 101270628,
+            "proving_cost_per_mana_numerator": 632296174,
+            "fee_asset_price_numerator": 8794436593
+        },
+        "oracle_input": {
+            "proving_cost_modifier": 157409929,
+            "fee_asset_price_modifier": 367558754
+        },
+        "outputs": {
+            "fee_asset_price_at_execution": 10879212642,
+            "mana_base_fee_components_in_wei": {
+                "data_cost": 0,
+                "gas_cost": 38726469,
+                "proving_cost": 5441135904,
+                "congestion_cost": 20031532129,
+                "congestion_multiplier": 4655480880
+            },
+            "mana_base_fee_components_in_fee_asset": {
+                "data_cost": 0,
+                "gas_cost": 421313491,
+                "proving_cost": 59195274513,
+                "congestion_cost": 217927297576,
+                "congestion_multiplier": 4655480880
+            }
+        }
+    },
+    {
+        "l1_block_number": 20975051,
+        "l1_fees": {
+            "blob_fee": 1,
+            "base_fee": 11981504880
+        },
+        "parent_header": {
+            "excess_mana": 1314568554,
+            "mana_used": 101270628,
+            "proving_cost_per_mana_numerator": 632296174,
+            "fee_asset_price_numerator": 8794436593
+        },
+        "header": {
+            "excess_mana": 1315839182,
+            "mana_used": 95222710,
+            "proving_cost_per_mana_numerator": 423476750,
+            "fee_asset_price_numerator": 9220027633
+        },
+        "oracle_input": {
+            "proving_cost_modifier": -208819424,
+            "fee_asset_price_modifier": 425591040
+        },
+        "outputs": {
+            "fee_asset_price_at_execution": 10919273719,
+            "mana_base_fee_components_in_wei": {
+                "data_cost": 0,
+                "gas_cost": 39688734,
+                "proving_cost": 5449707537,
+                "congestion_cost": 20104403476,
+                "congestion_multiplier": 4662407027
+            },
+            "mana_base_fee_components_in_fee_asset": {
+                "data_cost": 0,
+                "gas_cost": 433372150,
+                "proving_cost": 59506848285,
+                "congestion_cost": 219525484511,
+                "congestion_multiplier": 4662407027
+            }
+        }
+    },
+    {
+        "l1_block_number": 20975054,
+        "l1_fees": {
+            "blob_fee": 1,
+            "base_fee": 12160928021
+        },
+        "parent_header": {
+            "excess_mana": 1315839182,
+            "mana_used": 95222710,
+            "proving_cost_per_mana_numerator": 423476750,
+            "fee_asset_price_numerator": 9220027633
+        },
+        "header": {
+            "excess_mana": 1311061892,
+            "mana_used": 123820176,
+            "proving_cost_per_mana_numerator": 348788374,
+            "fee_asset_price_numerator": 8941079810
+        },
+        "oracle_input": {
+            "proving_cost_modifier": -74688376,
+            "fee_asset_price_modifier": -278947823
+        },
+        "outputs": {
+            "fee_asset_price_at_execution": 10965844199,
+            "mana_base_fee_components_in_wei": {
+                "data_cost": 0,
+                "gas_cost": 40283074,
+                "proving_cost": 5438339362,
+                "congestion_cost": 19922569607,
+                "congestion_multiplier": 4636419527
+            },
+            "mana_base_fee_components_in_fee_asset": {
+                "data_cost": 0,
+                "gas_cost": 441737913,
+                "proving_cost": 59635982144,
+                "congestion_cost": 218467794354,
+                "congestion_multiplier": 4636419527
+            }
+        }
+    },
+    {
+        "l1_block_number": 20975057,
+        "l1_fees": {
+            "blob_fee": 1,
+            "base_fee": 12913546101
+        },
+        "parent_header": {
+            "excess_mana": 1311061892,
+            "mana_used": 123820176,
+            "proving_cost_per_mana_numerator": 348788374,
+            "fee_asset_price_numerator": 8941079810
+        },
+        "header": {
+            "excess_mana": 1334882068,
+            "mana_used": 93982896,
+            "proving_cost_per_mana_numerator": 195305836,
+            "fee_asset_price_numerator": 8870005590
+        },
+        "oracle_input": {
+            "proving_cost_modifier": -153482538,
+            "fee_asset_price_modifier": -71074220
+        },
+        "outputs": {
+            "fee_asset_price_at_execution": 10935297840,
+            "mana_base_fee_components_in_wei": {
+                "data_cost": 0,
+                "gas_cost": 42776121,
+                "proving_cost": 5434279072,
+                "congestion_cost": 20634543335,
+                "congestion_multiplier": 4767452145
+            },
+            "mana_base_fee_components_in_fee_asset": {
+                "data_cost": 0,
+                "gas_cost": 467769623,
+                "proving_cost": 59425460197,
+                "congestion_cost": 225644877160,
+                "congestion_multiplier": 4767452145
+            }
+        }
+    },
+    {
+        "l1_block_number": 20975060,
+        "l1_fees": {
+            "blob_fee": 1,
+            "base_fee": 14539177654
+        },
+        "parent_header": {
+            "excess_mana": 1334882068,
+            "mana_used": 93982896,
+            "proving_cost_per_mana_numerator": 195305836,
+            "fee_asset_price_numerator": 8870005590
+        },
+        "header": {
+            "excess_mana": 1328864964,
+            "mana_used": 90824690,
+            "proving_cost_per_mana_numerator": 122449014,
+            "fee_asset_price_numerator": 9650640266
+        },
+        "oracle_input": {
+            "proving_cost_modifier": -72856822,
+            "fee_asset_price_modifier": 780634676
+        },
+        "outputs": {
+            "fee_asset_price_at_execution": 10927528423,
+            "mana_base_fee_components_in_wei": {
+                "data_cost": 0,
+                "gas_cost": 48161025,
+                "proving_cost": 5425944800,
+                "congestion_cost": 20440349967,
+                "congestion_multiplier": 4734007091
+            },
+            "mana_base_fee_components_in_fee_asset": {
+                "data_cost": 0,
+                "gas_cost": 526280969,
+                "proving_cost": 59292166023,
+                "congestion_cost": 223362505240,
+                "congestion_multiplier": 4734007091
+            }
+        }
+    },
+    {
+        "l1_block_number": 20975063,
+        "l1_fees": {
+            "blob_fee": 1,
+            "base_fee": 16652594433
+        },
+        "parent_header": {
+            "excess_mana": 1328864964,
+            "mana_used": 90824690,
+            "proving_cost_per_mana_numerator": 122449014,
+            "fee_asset_price_numerator": 9650640266
+        },
+        "header": {
+            "excess_mana": 1319689654,
+            "mana_used": 105117350,
+            "proving_cost_per_mana_numerator": 0,
+            "fee_asset_price_numerator": 9709646324
+        },
+        "oracle_input": {
+            "proving_cost_modifier": -141123043,
+            "fee_asset_price_modifier": 59006058
+        },
+        "outputs": {
+            "fee_asset_price_at_execution": 11013166324,
+            "mana_base_fee_components_in_wei": {
+                "data_cost": 0,
+                "gas_cost": 55161719,
+                "proving_cost": 5421993068,
+                "congestion_cost": 20174873988,
+                "congestion_multiplier": 4683458798
+            },
+            "mana_base_fee_components_in_fee_asset": {
+                "data_cost": 0,
+                "gas_cost": 607505186,
+                "proving_cost": 59713311465,
+                "congestion_cost": 222189242795,
+                "congestion_multiplier": 4683458798
+            }
+        }
+    },
+    {
+        "l1_block_number": 20975066,
+        "l1_fees": {
+            "blob_fee": 1,
+            "base_fee": 18249319128
+        },
+        "parent_header": {
+            "excess_mana": 1319689654,
+            "mana_used": 105117350,
+            "proving_cost_per_mana_numerator": 0,
+            "fee_asset_price_numerator": 9709646324
+        },
+        "header": {
+            "excess_mana": 1324807004,
+            "mana_used": 101364337,
+            "proving_cost_per_mana_numerator": 128284611,
+            "fee_asset_price_numerator": 9289510144
+        },
+        "oracle_input": {
+            "proving_cost_modifier": 128284611,
+            "fee_asset_price_modifier": -420136180
+        },
+        "outputs": {
+            "fee_asset_price_at_execution": 11019666677,
+            "mana_base_fee_components_in_wei": {
+                "data_cost": 0,
+                "gas_cost": 60450869,
+                "proving_cost": 5415357955,
+                "congestion_cost": 20323925414,
+                "congestion_multiplier": 4711584182
+            },
+            "mana_base_fee_components_in_fee_asset": {
+                "data_cost": 0,
+                "gas_cost": 666148426,
+                "proving_cost": 59675439600,
+                "congestion_cost": 223962883630,
+                "congestion_multiplier": 4711584182
+            }
+        }
+    },
+    {
+        "l1_block_number": 20975069,
+        "l1_fees": {
+            "blob_fee": 1,
+            "base_fee": 18581711762
+        },
+        "parent_header": {
+            "excess_mana": 1324807004,
+            "mana_used": 101364337,
+            "proving_cost_per_mana_numerator": 128284611,
+            "fee_asset_price_numerator": 9289510144
+        },
+        "header": {
+            "excess_mana": 1326171341,
+            "mana_used": 98775140,
+            "proving_cost_per_mana_numerator": 10819532,
+            "fee_asset_price_numerator": 9750284946
+        },
+        "oracle_input": {
+            "proving_cost_modifier": -117465079,
+            "fee_asset_price_modifier": 460774802
+        },
+        "outputs": {
+            "fee_asset_price_at_execution": 10973466191,
+            "mana_base_fee_components_in_wei": {
+                "data_cost": 0,
+                "gas_cost": 61551920,
+                "proving_cost": 5422309483,
+                "congestion_cost": 20395090193,
+                "congestion_multiplier": 4719111169
+            },
+            "mana_base_fee_components_in_fee_asset": {
+                "data_cost": 0,
+                "gas_cost": 675437913,
+                "proving_cost": 59501529788,
+                "congestion_cost": 223804832695,
+                "congestion_multiplier": 4719111169
+            }
+        }
+    },
+    {
+        "l1_block_number": 20975072,
+        "l1_fees": {
+            "blob_fee": 1,
+            "base_fee": 18508034366
+        },
+        "parent_header": {
+            "excess_mana": 1326171341,
+            "mana_used": 98775140,
+            "proving_cost_per_mana_numerator": 10819532,
+            "fee_asset_price_numerator": 9750284946
+        },
+        "header": {
+            "excess_mana": 1324946481,
+            "mana_used": 102197042,
+            "proving_cost_per_mana_numerator": 26005399,
+            "fee_asset_price_numerator": 9952218389
+        },
+        "oracle_input": {
+            "proving_cost_modifier": 15185867,
+            "fee_asset_price_modifier": 201933443
+        },
+        "outputs": {
+            "fee_asset_price_at_execution": 11024145828,
+            "mana_base_fee_components_in_wei": {
+                "data_cost": 0,
+                "gas_cost": 61307863,
+                "proving_cost": 5415943903,
+                "congestion_cost": 20333492677,
+                "congestion_multiplier": 4712353119
+            },
+            "mana_base_fee_components_in_fee_asset": {
+                "data_cost": 0,
+                "gas_cost": 675866822,
+                "proving_cost": 59706155382,
+                "congestion_cost": 224159388463,
+                "congestion_multiplier": 4712353119
+            }
+        }
+    },
+    {
+        "l1_block_number": 20975075,
+        "l1_fees": {
+            "blob_fee": 1,
+            "base_fee": 16846912203
+        },
+        "parent_header": {
+            "excess_mana": 1324946481,
+            "mana_used": 102197042,
+            "proving_cost_per_mana_numerator": 26005399,
+            "fee_asset_price_numerator": 9952218389
+        },
+        "header": {
+            "excess_mana": 1327143523,
+            "mana_used": 88168307,
+            "proving_cost_per_mana_numerator": 114842777,
+            "fee_asset_price_numerator": 10106089984
+        },
+        "oracle_input": {
+            "proving_cost_modifier": 88837378,
+            "fee_asset_price_modifier": 153871595
+        },
+        "outputs": {
+            "fee_asset_price_at_execution": 11046429757,
+            "mana_base_fee_components_in_wei": {
+                "data_cost": 0,
+                "gas_cost": 55805396,
+                "proving_cost": 5416766423,
+                "congestion_cost": 20382495173,
+                "congestion_multiplier": 4724481989
+            },
+            "mana_base_fee_components_in_fee_asset": {
+                "data_cost": 0,
+                "gas_cost": 616450386,
+                "proving_cost": 59835929801,
+                "congestion_cost": 225153801200,
+                "congestion_multiplier": 4724481989
+            }
+        }
+    },
+    {
+        "l1_block_number": 20975078,
+        "l1_fees": {
+            "blob_fee": 1,
+            "base_fee": 20153470138
+        },
+        "parent_header": {
+            "excess_mana": 1327143523,
+            "mana_used": 88168307,
+            "proving_cost_per_mana_numerator": 114842777,
+            "fee_asset_price_numerator": 10106089984
+        },
+        "header": {
+            "excess_mana": 1315311830,
+            "mana_used": 116305637,
+            "proving_cost_per_mana_numerator": 126735087,
+            "fee_asset_price_numerator": 10553381925
+        },
+        "oracle_input": {
+            "proving_cost_modifier": 11892310,
+            "fee_asset_price_modifier": 447291941
+        },
+        "outputs": {
+            "fee_asset_price_at_execution": 11063440158,
+            "mana_base_fee_components_in_wei": {
+                "data_cost": 0,
+                "gas_cost": 66758369,
+                "proving_cost": 5421580674,
+                "congestion_cost": 20084747964,
+                "congestion_multiplier": 4659531200
+            },
+            "mana_base_fee_components_in_fee_asset": {
+                "data_cost": 0,
+                "gas_cost": 738577220,
+                "proving_cost": 59981333348,
+                "congestion_cost": 222206407188,
+                "congestion_multiplier": 4659531200
+            }
+        }
+    },
+    {
+        "l1_block_number": 20975081,
+        "l1_fees": {
+            "blob_fee": 1,
+            "base_fee": 20365754346
+        },
+        "parent_header": {
+            "excess_mana": 1315311830,
+            "mana_used": 116305637,
+            "proving_cost_per_mana_numerator": 126735087,
+            "fee_asset_price_numerator": 10553381925
+        },
+        "header": {
+            "excess_mana": 1331617467,
+            "mana_used": 83202142,
+            "proving_cost_per_mana_numerator": 5960869,
+            "fee_asset_price_numerator": 10576638721
+        },
+        "oracle_input": {
+            "proving_cost_modifier": -120774218,
+            "fee_asset_price_modifier": 23256796
+        },
+        "outputs": {
+            "fee_asset_price_at_execution": 11113036873,
+            "mana_base_fee_components_in_wei": {
+                "data_cost": 0,
+                "gas_cost": 67461561,
+                "proving_cost": 5422225464,
+                "congestion_cost": 20582358386,
+                "congestion_multiplier": 4749277198
+            },
+            "mana_base_fee_components_in_fee_asset": {
+                "data_cost": 0,
+                "gas_cost": 749702814,
+                "proving_cost": 60257391515,
+                "congestion_cost": 228732507676,
+                "congestion_multiplier": 4749277198
+            }
+        }
+    },
+    {
+        "l1_block_number": 20975084,
+        "l1_fees": {
+            "blob_fee": 1,
+            "base_fee": 19718960848
+        },
+        "parent_header": {
+            "excess_mana": 1331617467,
+            "mana_used": 83202142,
+            "proving_cost_per_mana_numerator": 5960869,
+            "fee_asset_price_numerator": 10576638721
+        },
+        "header": {
+            "excess_mana": 1314819609,
+            "mana_used": 104175730,
+            "proving_cost_per_mana_numerator": 14836989,
+            "fee_asset_price_numerator": 10419130569
+        },
+        "oracle_input": {
+            "proving_cost_modifier": 8876120,
+            "fee_asset_price_modifier": -157508152
+        },
+        "outputs": {
+            "fee_asset_price_at_execution": 11115621710,
+            "mana_base_fee_components_in_wei": {
+                "data_cost": 0,
+                "gas_cost": 65319057,
+                "proving_cost": 5415680767,
+                "congestion_cost": 20043186286,
+                "congestion_multiplier": 4656848555
+            },
+            "mana_base_fee_components_in_fee_asset": {
+                "data_cost": 0,
+                "gas_cost": 726061928,
+                "proving_cost": 60198658708,
+                "congestion_cost": 222792476618,
+                "congestion_multiplier": 4656848555
+            }
+        }
+    },
+    {
+        "l1_block_number": 20975087,
+        "l1_fees": {
+            "blob_fee": 1,
+            "base_fee": 18161430857
+        },
+        "parent_header": {
+            "excess_mana": 1314819609,
+            "mana_used": 104175730,
+            "proving_cost_per_mana_numerator": 14836989,
+            "fee_asset_price_numerator": 10419130569
+        },
+        "header": {
+            "excess_mana": 1318995339,
+            "mana_used": 81358527,
+            "proving_cost_per_mana_numerator": 0,
+            "fee_asset_price_numerator": 10344089503
+        },
+        "oracle_input": {
+            "proving_cost_modifier": -21425270,
+            "fee_asset_price_modifier": -75041066
+        },
+        "outputs": {
+            "fee_asset_price_at_execution": 11098127481,
+            "mana_base_fee_components_in_wei": {
+                "data_cost": 0,
+                "gas_cost": 60159739,
+                "proving_cost": 5416161490,
+                "congestion_cost": 20150976855,
+                "congestion_multiplier": 4679655742
+            },
+            "mana_base_fee_components_in_fee_asset": {
+                "data_cost": 0,
+                "gas_cost": 667660452,
+                "proving_cost": 60109250673,
+                "congestion_cost": 223638110003,
+                "congestion_multiplier": 4679655742
+            }
+        }
+    },
+    {
+        "l1_block_number": 20975090,
+        "l1_fees": {
+            "blob_fee": 1,
+            "base_fee": 19301653207
+        },
+        "parent_header": {
+            "excess_mana": 1318995339,
+            "mana_used": 81358527,
+            "proving_cost_per_mana_numerator": 0,
+            "fee_asset_price_numerator": 10344089503
+        },
+        "header": {
+            "excess_mana": 1300353866,
+            "mana_used": 120465579,
+            "proving_cost_per_mana_numerator": 92323832,
+            "fee_asset_price_numerator": 9546868216
+        },
+        "oracle_input": {
+            "proving_cost_modifier": 92323832,
+            "fee_asset_price_modifier": -797221287
+        },
+        "outputs": {
+            "fee_asset_price_at_execution": 11089802451,
+            "mana_base_fee_components_in_wei": {
+                "data_cost": 0,
+                "gas_cost": 63936726,
+                "proving_cost": 5415357955,
+                "congestion_cost": 19608724511,
+                "congestion_multiplier": 4578695006
+            },
+            "mana_base_fee_components_in_fee_asset": {
+                "data_cost": 0,
+                "gas_cost": 709045660,
+                "proving_cost": 60055249922,
+                "congestion_cost": 217456881143,
+                "congestion_multiplier": 4578695006
+            }
+        }
+    },
+    {
+        "l1_block_number": 20975093,
+        "l1_fees": {
+            "blob_fee": 1,
+            "base_fee": 19362551866
+        },
+        "parent_header": {
+            "excess_mana": 1300353866,
+            "mana_used": 120465579,
+            "proving_cost_per_mana_numerator": 92323832,
+            "fee_asset_price_numerator": 9546868216
+        },
+        "header": {
+            "excess_mana": 1320819445,
+            "mana_used": 103670134,
+            "proving_cost_per_mana_numerator": 0,
+            "fee_asset_price_numerator": 10053927891
+        },
+        "oracle_input": {
+            "proving_cost_modifier": -165526439,
+            "fee_asset_price_modifier": 507059675
+        },
+        "outputs": {
+            "fee_asset_price_at_execution": 11001743664,
+            "mana_base_fee_components_in_wei": {
+                "data_cost": 0,
+                "gas_cost": 64138453,
+                "proving_cost": 5420359929,
+                "congestion_cost": 20235900005,
+                "congestion_multiplier": 4689653747
+            },
+            "mana_base_fee_components_in_fee_asset": {
+                "data_cost": 0,
+                "gas_cost": 705634818,
+                "proving_cost": 59633410505,
+                "congestion_cost": 222630184665,
+                "congestion_multiplier": 4689653747
+            }
+        }
+    },
+    {
+        "l1_block_number": 20975096,
+        "l1_fees": {
+            "blob_fee": 1,
+            "base_fee": 17613864145
+        },
+        "parent_header": {
+            "excess_mana": 1320819445,
+            "mana_used": 103670134,
+            "proving_cost_per_mana_numerator": 0,
+            "fee_asset_price_numerator": 10053927891
+        },
+        "header": {
+            "excess_mana": 1324489579,
+            "mana_used": 106564847,
+            "proving_cost_per_mana_numerator": 0,
+            "fee_asset_price_numerator": 9640848007
+        },
+        "oracle_input": {
+            "proving_cost_modifier": -24024628,
+            "fee_asset_price_modifier": -413079884
+        },
+        "outputs": {
+            "fee_asset_price_at_execution": 11057670741,
+            "mana_base_fee_components_in_wei": {
+                "data_cost": 0,
+                "gas_cost": 58345924,
+                "proving_cost": 5415357955,
+                "congestion_cost": 20306536505,
+                "congestion_multiplier": 4709834685
+            },
+            "mana_base_fee_components_in_fee_asset": {
+                "data_cost": 0,
+                "gas_cost": 645170016,
+                "proving_cost": 59881245211,
+                "congestion_cost": 224542994562,
+                "congestion_multiplier": 4709834685
+            }
+        }
+    },
+    {
+        "l1_block_number": 20975099,
+        "l1_fees": {
+            "blob_fee": 1,
+            "base_fee": 18068788476
+        },
+        "parent_header": {
+            "excess_mana": 1324489579,
+            "mana_used": 106564847,
+            "proving_cost_per_mana_numerator": 0,
+            "fee_asset_price_numerator": 9640848007
+        },
+        "header": {
+            "excess_mana": 1331054426,
+            "mana_used": 87336617,
+            "proving_cost_per_mana_numerator": 0,
+            "fee_asset_price_numerator": 10276407143
+        },
+        "oracle_input": {
+            "proving_cost_modifier": -75005104,
+            "fee_asset_price_modifier": 635559136
+        },
+        "outputs": {
+            "fee_asset_price_at_execution": 11012087939,
+            "mana_base_fee_components_in_wei": {
+                "data_cost": 0,
+                "gas_cost": 59852861,
+                "proving_cost": 5415357955,
+                "congestion_cost": 20510958830,
+                "congestion_multiplier": 4746149604
+            },
+            "mana_base_fee_components_in_fee_asset": {
+                "data_cost": 0,
+                "gas_cost": 659104968,
+                "proving_cost": 59634398021,
+                "congestion_cost": 225868482349,
+                "congestion_multiplier": 4746149604
+            }
+        }
+    },
+    {
+        "l1_block_number": 20975102,
+        "l1_fees": {
+            "blob_fee": 1,
+            "base_fee": 16794255548
+        },
+        "parent_header": {
+            "excess_mana": 1331054426,
+            "mana_used": 87336617,
+            "proving_cost_per_mana_numerator": 0,
+            "fee_asset_price_numerator": 10276407143
+        },
+        "header": {
+            "excess_mana": 1318391043,
+            "mana_used": 113102161,
+            "proving_cost_per_mana_numerator": 113584083,
+            "fee_asset_price_numerator": 10577915632
+        },
+        "oracle_input": {
+            "proving_cost_modifier": 113584083,
+            "fee_asset_price_modifier": 301508489
+        },
+        "outputs": {
+            "fee_asset_price_at_execution": 11082299151,
+            "mana_base_fee_components_in_wei": {
+                "data_cost": 0,
+                "gas_cost": 55630971,
+                "proving_cost": 5415357955,
+                "congestion_cost": 20113260678,
+                "congestion_multiplier": 4676348271
+            },
+            "mana_base_fee_components_in_fee_asset": {
+                "data_cost": 0,
+                "gas_cost": 616519062,
+                "proving_cost": 60014616867,
+                "congestion_cost": 222901171735,
+                "congestion_multiplier": 4676348271
+            }
+        }
+    },
+    {
+        "l1_block_number": 20975105,
+        "l1_fees": {
+            "blob_fee": 1,
+            "base_fee": 17225028163
+        },
+        "parent_header": {
+            "excess_mana": 1318391043,
+            "mana_used": 113102161,
+            "proving_cost_per_mana_numerator": 113584083,
+            "fee_asset_price_numerator": 10577915632
+        },
+        "header": {
+            "excess_mana": 1331493204,
+            "mana_used": 101779107,
+            "proving_cost_per_mana_numerator": 74612133,
+            "fee_asset_price_numerator": 10778362448
+        },
+        "oracle_input": {
+            "proving_cost_modifier": -38971950,
+            "fee_asset_price_modifier": 200446816
+        },
+        "outputs": {
+            "fee_asset_price_at_execution": 11115763647,
+            "mana_base_fee_components_in_wei": {
+                "data_cost": 0,
+                "gas_cost": 57057905,
+                "proving_cost": 5421512434,
+                "congestion_cost": 20536896241,
+                "congestion_multiplier": 4748586761
+            },
+            "mana_base_fee_components_in_fee_asset": {
+                "data_cost": 0,
+                "gas_cost": 634242186,
+                "proving_cost": 60264250825,
+                "congestion_cost": 228283284657,
+                "congestion_multiplier": 4748586761
+            }
+        }
+    },
+    {
+        "l1_block_number": 20975108,
+        "l1_fees": {
+            "blob_fee": 1,
+            "base_fee": 16802177302
+        },
+        "parent_header": {
+            "excess_mana": 1331493204,
+            "mana_used": 101779107,
+            "proving_cost_per_mana_numerator": 74612133,
+            "fee_asset_price_numerator": 10778362448
+        },
+        "header": {
+            "excess_mana": 1333272311,
+            "mana_used": 92008465,
+            "proving_cost_per_mana_numerator": 202382631,
+            "fee_asset_price_numerator": 11242911350
+        },
+        "oracle_input": {
+            "proving_cost_modifier": 127770498,
+            "fee_asset_price_modifier": 464548902
+        },
+        "outputs": {
+            "fee_asset_price_at_execution": 11138067188,
+            "mana_base_fee_components_in_wei": {
+                "data_cost": 0,
+                "gas_cost": 55657212,
+                "proving_cost": 5419399976,
+                "congestion_cost": 20577901158,
+                "congestion_multiplier": 4758481501
+            },
+            "mana_base_fee_components_in_fee_asset": {
+                "data_cost": 0,
+                "gas_cost": 619913766,
+                "proving_cost": 60361641051,
+                "congestion_cost": 229198045685,
+                "congestion_multiplier": 4758481501
+            }
+        }
+    },
+    {
+        "l1_block_number": 20975111,
+        "l1_fees": {
+            "blob_fee": 1,
+            "base_fee": 15985470904
+        },
+        "parent_header": {
+            "excess_mana": 1333272311,
+            "mana_used": 92008465,
+            "proving_cost_per_mana_numerator": 202382631,
+            "fee_asset_price_numerator": 11242911350
+        },
+        "header": {
+            "excess_mana": 1325280776,
+            "mana_used": 99264175,
+            "proving_cost_per_mana_numerator": 152318466,
+            "fee_asset_price_numerator": 11312887858
+        },
+        "oracle_input": {
+            "proving_cost_modifier": -50064165,
+            "fee_asset_price_modifier": 69976508
+        },
+        "outputs": {
+            "fee_asset_price_at_execution": 11189929326,
+            "mana_base_fee_components_in_wei": {
+                "data_cost": 0,
+                "gas_cost": 52951872,
+                "proving_cost": 5426328796,
+                "congestion_cost": 20351125622,
+                "congestion_multiplier": 4714196599
+            },
+            "mana_base_fee_components_in_fee_asset": {
+                "data_cost": 0,
+                "gas_cost": 592527705,
+                "proving_cost": 60720235726,
+                "congestion_cost": 227727657414,
+                "congestion_multiplier": 4714196599
+            }
+        }
+    },
+    {
+        "l1_block_number": 20975114,
+        "l1_fees": {
+            "blob_fee": 1,
+            "base_fee": 15707407969
+        },
+        "parent_header": {
+            "excess_mana": 1325280776,
+            "mana_used": 99264175,
+            "proving_cost_per_mana_numerator": 152318466,
+            "fee_asset_price_numerator": 11312887858
+        },
+        "header": {
+            "excess_mana": 1324544951,
+            "mana_used": 105837320,
+            "proving_cost_per_mana_numerator": 147122574,
+            "fee_asset_price_numerator": 11397366686
+        },
+        "oracle_input": {
+            "proving_cost_modifier": -5195892,
+            "fee_asset_price_modifier": 84478828
+        },
+        "outputs": {
+            "fee_asset_price_at_execution": 11197762388,
+            "mana_base_fee_components_in_wei": {
+                "data_cost": 0,
+                "gas_cost": 52030788,
+                "proving_cost": 5423612830,
+                "congestion_cost": 20315403438,
+                "congestion_multiplier": 4710139822
+            },
+            "mana_base_fee_components_in_fee_asset": {
+                "data_cost": 0,
+                "gas_cost": 582628400,
+                "proving_cost": 60732327754,
+                "congestion_cost": 227487060515,
+                "congestion_multiplier": 4710139822
+            }
+        }
+    },
+    {
+        "l1_block_number": 20975117,
+        "l1_fees": {
+            "blob_fee": 1,
+            "base_fee": 14997613813
+        },
+        "parent_header": {
+            "excess_mana": 1324544951,
+            "mana_used": 105837320,
+            "proving_cost_per_mana_numerator": 147122574,
+            "fee_asset_price_numerator": 11397366686
+        },
+        "header": {
+            "excess_mana": 1330382271,
+            "mana_used": 90145608,
+            "proving_cost_per_mana_numerator": 75063816,
+            "fee_asset_price_numerator": 11723591217
+        },
+        "oracle_input": {
+            "proving_cost_modifier": -72058758,
+            "fee_asset_price_modifier": 326224531
+        },
+        "outputs": {
+            "fee_asset_price_at_execution": 11207226123,
+            "mana_base_fee_components_in_wei": {
+                "data_cost": 0,
+                "gas_cost": 49679595,
+                "proving_cost": 5423331032,
+                "congestion_cost": 20482296757,
+                "congestion_multiplier": 4742418598
+            },
+            "mana_base_fee_components_in_fee_asset": {
+                "data_cost": 0,
+                "gas_cost": 556770454,
+                "proving_cost": 60780497215,
+                "congestion_cost": 229549731274,
+                "congestion_multiplier": 4742418598
+            }
+        }
+    },
+    {
+        "l1_block_number": 20975120,
+        "l1_fees": {
+            "blob_fee": 1,
+            "base_fee": 14135639349
+        },
+        "parent_header": {
+            "excess_mana": 1330382271,
+            "mana_used": 90145608,
+            "proving_cost_per_mana_numerator": 75063816,
+            "fee_asset_price_numerator": 11723591217
+        },
+        "header": {
+            "excess_mana": 1320527879,
+            "mana_used": 90915825,
+            "proving_cost_per_mana_numerator": 27208757,
+            "fee_asset_price_numerator": 10969222287
+        },
+        "oracle_input": {
+            "proving_cost_modifier": -47855059,
+            "fee_asset_price_modifier": -754368930
+        },
+        "outputs": {
+            "fee_asset_price_at_execution": 11243846544,
+            "mana_base_fee_components_in_wei": {
+                "data_cost": 0,
+                "gas_cost": 46824305,
+                "proving_cost": 5419424455,
+                "congestion_cost": 20159821850,
+                "congestion_multiplier": 4688054228
+            },
+            "mana_base_fee_components_in_fee_asset": {
+                "data_cost": 0,
+                "gas_cost": 526485299,
+                "proving_cost": 60935176928,
+                "congestion_cost": 226673943235,
+                "congestion_multiplier": 4688054228
+            }
+        }
+    },
+    {
+        "l1_block_number": 20975123,
+        "l1_fees": {
+            "blob_fee": 1,
+            "base_fee": 13793046280
+        },
+        "parent_header": {
+            "excess_mana": 1320527879,
+            "mana_used": 90915825,
+            "proving_cost_per_mana_numerator": 27208757,
+            "fee_asset_price_numerator": 10969222287
+        },
+        "header": {
+            "excess_mana": 1311443704,
+            "mana_used": 101140231,
+            "proving_cost_per_mana_numerator": 179746030,
+            "fee_asset_price_numerator": 10987035599
+        },
+        "oracle_input": {
+            "proving_cost_modifier": 152537273,
+            "fee_asset_price_modifier": 17813312
+        },
+        "outputs": {
+            "fee_asset_price_at_execution": 11159345584,
+            "mana_base_fee_components_in_wei": {
+                "data_cost": 0,
+                "gas_cost": 45689465,
+                "proving_cost": 5416831607,
+                "congestion_cost": 19875334697,
+                "congestion_multiplier": 4638491172
+            },
+            "mana_base_fee_components_in_fee_asset": {
+                "data_cost": 0,
+                "gas_cost": 509864529,
+                "proving_cost": 60448295872,
+                "congestion_cost": 221795728481,
+                "congestion_multiplier": 4638491172
+            }
+        }
+    },
+    {
+        "l1_block_number": 20975126,
+        "l1_fees": {
+            "blob_fee": 1,
+            "base_fee": 13713634735
+        },
+        "parent_header": {
+            "excess_mana": 1311443704,
+            "mana_used": 101140231,
+            "proving_cost_per_mana_numerator": 179746030,
+            "fee_asset_price_numerator": 10987035599
+        },
+        "header": {
+            "excess_mana": 1312583935,
+            "mana_used": 95308047,
+            "proving_cost_per_mana_numerator": 186248322,
+            "fee_asset_price_numerator": 10453873707
+        },
+        "oracle_input": {
+            "proving_cost_modifier": 6502292,
+            "fee_asset_price_modifier": -533161892
+        },
+        "outputs": {
+            "fee_asset_price_at_execution": 11161333610,
+            "mana_base_fee_components_in_wei": {
+                "data_cost": 0,
+                "gas_cost": 45426415,
+                "proving_cost": 5425100599,
+                "congestion_cost": 19938338854,
+                "congestion_multiplier": 4644683374
+            },
+            "mana_base_fee_components_in_fee_asset": {
+                "data_cost": 0,
+                "gas_cost": 507019372,
+                "proving_cost": 60551357653,
+                "congestion_cost": 222538451578,
+                "congestion_multiplier": 4644683374
+            }
+        }
+    },
+    {
+        "l1_block_number": 20975129,
+        "l1_fees": {
+            "blob_fee": 1,
+            "base_fee": 13219632519
+        },
+        "parent_header": {
+            "excess_mana": 1312583935,
+            "mana_used": 95308047,
+            "proving_cost_per_mana_numerator": 186248322,
+            "fee_asset_price_numerator": 10453873707
+        },
+        "header": {
+            "excess_mana": 1307891982,
+            "mana_used": 93623516,
+            "proving_cost_per_mana_numerator": 135139372,
+            "fee_asset_price_numerator": 10080607623
+        },
+        "oracle_input": {
+            "proving_cost_modifier": -51108950,
+            "fee_asset_price_modifier": -373266084
+        },
+        "outputs": {
+            "fee_asset_price_at_execution": 11101983988,
+            "mana_base_fee_components_in_wei": {
+                "data_cost": 0,
+                "gas_cost": 43790032,
+                "proving_cost": 5425453366,
+                "congestion_cost": 19794591146,
+                "congestion_multiplier": 4619255847
+            },
+            "mana_base_fee_components_in_fee_asset": {
+                "data_cost": 0,
+                "gas_cost": 486156234,
+                "proving_cost": 60233296396,
+                "congestion_cost": 219759233951,
+                "congestion_multiplier": 4619255847
+            }
+        }
+    },
+    {
+        "l1_block_number": 20975132,
+        "l1_fees": {
+            "blob_fee": 1,
+            "base_fee": 12935777298
+        },
+        "parent_header": {
+            "excess_mana": 1307891982,
+            "mana_used": 93623516,
+            "proving_cost_per_mana_numerator": 135139372,
+            "fee_asset_price_numerator": 10080607623
+        },
+        "header": {
+            "excess_mana": 1301515498,
+            "mana_used": 110330450,
+            "proving_cost_per_mana_numerator": 0,
+            "fee_asset_price_numerator": 10211821717
+        },
+        "oracle_input": {
+            "proving_cost_modifier": -240364208,
+            "fee_asset_price_modifier": 131214094
+        },
+        "outputs": {
+            "fee_asset_price_at_execution": 11060621292,
+            "mana_base_fee_components_in_wei": {
+                "data_cost": 0,
+                "gas_cost": 42849762,
+                "proving_cost": 5422681182,
+                "congestion_cost": 19593503128,
+                "congestion_multiplier": 4584922184
+            },
+            "mana_base_fee_components_in_fee_asset": {
+                "data_cost": 0,
+                "gas_cost": 473944989,
+                "proving_cost": 59978222941,
+                "congestion_cost": 216716317882,
+                "congestion_multiplier": 4584922184
+            }
+        }
+    },
+    {
+        "l1_block_number": 20975135,
+        "l1_fees": {
+            "blob_fee": 1,
+            "base_fee": 13008513572
+        },
+        "parent_header": {
+            "excess_mana": 1301515498,
+            "mana_used": 110330450,
+            "proving_cost_per_mana_numerator": 0,
+            "fee_asset_price_numerator": 10211821717
+        },
+        "header": {
+            "excess_mana": 1311845948,
+            "mana_used": 90935667,
+            "proving_cost_per_mana_numerator": 0,
+            "fee_asset_price_numerator": 10435521602
+        },
+        "oracle_input": {
+            "proving_cost_modifier": -124659637,
+            "fee_asset_price_modifier": 223699885
+        },
+        "outputs": {
+            "fee_asset_price_at_execution": 11075143912,
+            "mana_base_fee_components_in_wei": {
+                "data_cost": 0,
+                "gas_cost": 43090701,
+                "proving_cost": 5415357955,
+                "congestion_cost": 19872435803,
+                "congestion_multiplier": 4640674678
+            },
+            "mana_base_fee_components_in_fee_asset": {
+                "data_cost": 0,
+                "gas_cost": 477235714,
+                "proving_cost": 59975868686,
+                "congestion_cost": 220090086400,
+                "congestion_multiplier": 4640674678
+            }
+        }
+    },
+    {
+        "l1_block_number": 20975138,
+        "l1_fees": {
+            "blob_fee": 1,
+            "base_fee": 13141320281
+        },
+        "parent_header": {
+            "excess_mana": 1311845948,
+            "mana_used": 90935667,
+            "proving_cost_per_mana_numerator": 0,
+            "fee_asset_price_numerator": 10435521602
+        },
+        "header": {
+            "excess_mana": 1302781615,
+            "mana_used": 119918223,
+            "proving_cost_per_mana_numerator": 157775447,
+            "fee_asset_price_numerator": 10260006113
+        },
+        "oracle_input": {
+            "proving_cost_modifier": 157775447,
+            "fee_asset_price_modifier": -175515489
+        },
+        "outputs": {
+            "fee_asset_price_at_execution": 11099946727,
+            "mana_base_fee_components_in_wei": {
+                "data_cost": 0,
+                "gas_cost": 43530623,
+                "proving_cost": 5415357955,
+                "congestion_cost": 19606794501,
+                "congestion_multiplier": 4591719124
+            },
+            "mana_base_fee_components_in_fee_asset": {
+                "data_cost": 0,
+                "gas_cost": 483187596,
+                "proving_cost": 60110184808,
+                "congestion_cost": 217634374448,
+                "congestion_multiplier": 4591719124
+            }
+        }
+    },
+    {
+        "l1_block_number": 20975141,
+        "l1_fees": {
+            "blob_fee": 1,
+            "base_fee": 12955542361
+        },
+        "parent_header": {
+            "excess_mana": 1302781615,
+            "mana_used": 119918223,
+            "proving_cost_per_mana_numerator": 157775447,
+            "fee_asset_price_numerator": 10260006113
+        },
+        "header": {
+            "excess_mana": 1322699838,
+            "mana_used": 90906414,
+            "proving_cost_per_mana_numerator": 0,
+            "fee_asset_price_numerator": 10929680429
+        },
+        "oracle_input": {
+            "proving_cost_modifier": -166691750,
+            "fee_asset_price_modifier": 669674316
+        },
+        "outputs": {
+            "fee_asset_price_at_execution": 11080481689,
+            "mana_base_fee_components_in_wei": {
+                "data_cost": 0,
+                "gas_cost": 42915234,
+                "proving_cost": 5423908804,
+                "congestion_cost": 20227153949,
+                "congestion_multiplier": 4699982624
+            },
+            "mana_base_fee_components_in_fee_asset": {
+                "data_cost": 0,
+                "gas_cost": 475521464,
+                "proving_cost": 60099522185,
+                "congestion_cost": 224126608952,
+                "congestion_multiplier": 4699982624
+            }
+        }
+    },
+    {
+        "l1_block_number": 20975144,
+        "l1_fees": {
+            "blob_fee": 1,
+            "base_fee": 12711944992
+        },
+        "parent_header": {
+            "excess_mana": 1322699838,
+            "mana_used": 90906414,
+            "proving_cost_per_mana_numerator": 0,
+            "fee_asset_price_numerator": 10929680429
+        },
+        "header": {
+            "excess_mana": 1313606252,
+            "mana_used": 109329982,
+            "proving_cost_per_mana_numerator": 27373813,
+            "fee_asset_price_numerator": 11439057352
+        },
+        "oracle_input": {
+            "proving_cost_modifier": 27373813,
+            "fee_asset_price_modifier": 509376923
+        },
+        "outputs": {
+            "fee_asset_price_at_execution": 11154933844,
+            "mana_base_fee_components_in_wei": {
+                "data_cost": 0,
+                "gas_cost": 42108317,
+                "proving_cost": 5415357955,
+                "congestion_cost": 19921073991,
+                "congestion_multiplier": 4650242255
+            },
+            "mana_base_fee_components_in_fee_asset": {
+                "data_cost": 0,
+                "gas_cost": 469715490,
+                "proving_cost": 60407959729,
+                "congestion_cost": 222218262471,
+                "congestion_multiplier": 4650242255
+            }
+        }
+    },
+    {
+        "l1_block_number": 20975147,
+        "l1_fees": {
+            "blob_fee": 1,
+            "base_fee": 12647455153
+        },
+        "parent_header": {
+            "excess_mana": 1313606252,
+            "mana_used": 109329982,
+            "proving_cost_per_mana_numerator": 27373813,
+            "fee_asset_price_numerator": 11439057352
+        },
+        "header": {
+            "excess_mana": 1322936234,
+            "mana_used": 112778076,
+            "proving_cost_per_mana_numerator": 49560232,
+            "fee_asset_price_numerator": 11250716091
+        },
+        "oracle_input": {
+            "proving_cost_modifier": 22186419,
+            "fee_asset_price_modifier": -188341261
+        },
+        "outputs": {
+            "fee_asset_price_at_execution": 11211899464,
+            "mana_base_fee_components_in_wei": {
+                "data_cost": 0,
+                "gas_cost": 41894695,
+                "proving_cost": 5416840547,
+                "congestion_cost": 20204322533,
+                "congestion_multiplier": 4701282740
+            },
+            "mana_base_fee_components_in_fee_asset": {
+                "data_cost": 0,
+                "gas_cost": 469719108,
+                "proving_cost": 60733071625,
+                "congestion_cost": 226528832978,
+                "congestion_multiplier": 4701282740
+            }
+        }
+    },
+    {
+        "l1_block_number": 20975150,
+        "l1_fees": {
+            "blob_fee": 1,
+            "base_fee": 12756925909
+        },
+        "parent_header": {
+            "excess_mana": 1322936234,
+            "mana_used": 112778076,
+            "proving_cost_per_mana_numerator": 49560232,
+            "fee_asset_price_numerator": 11250716091
+        },
+        "header": {
+            "excess_mana": 1335714310,
+            "mana_used": 85860560,
+            "proving_cost_per_mana_numerator": 72408886,
+            "fee_asset_price_numerator": 11664879860
+        },
+        "oracle_input": {
+            "proving_cost_modifier": 22848654,
+            "fee_asset_price_modifier": 414163769
+        },
+        "outputs": {
+            "fee_asset_price_at_execution": 11190802705,
+            "mana_base_fee_components_in_wei": {
+                "data_cost": 0,
+                "gas_cost": 42257317,
+                "proving_cost": 5418042484,
+                "congestion_cost": 20596778232,
+                "congestion_multiplier": 4772096585
+            },
+            "mana_base_fee_components_in_fee_asset": {
+                "data_cost": 0,
+                "gas_cost": 472893297,
+                "proving_cost": 60632244485,
+                "congestion_cost": 230494481552,
+                "congestion_multiplier": 4772096585
+            }
+        }
+    },
+    {
+        "l1_block_number": 20975153,
+        "l1_fees": {
+            "blob_fee": 1,
+            "base_fee": 11185568066
+        },
+        "parent_header": {
+            "excess_mana": 1335714310,
+            "mana_used": 85860560,
+            "proving_cost_per_mana_numerator": 72408886,
+            "fee_asset_price_numerator": 11664879860
+        },
+        "header": {
+            "excess_mana": 1321574870,
+            "mana_used": 96504708,
+            "proving_cost_per_mana_numerator": 97425002,
+            "fee_asset_price_numerator": 12050972543
+        },
+        "oracle_input": {
+            "proving_cost_modifier": 25016116,
+            "fee_asset_price_modifier": 386092683
+        },
+        "outputs": {
+            "fee_asset_price_at_execution": 11237247066,
+            "mana_base_fee_components_in_wei": {
+                "data_cost": 0,
+                "gas_cost": 37052194,
+                "proving_cost": 5419280575,
+                "congestion_cost": 20154604803,
+                "congestion_multiplier": 4693800517
+            },
+            "mana_base_fee_components_in_fee_asset": {
+                "data_cost": 0,
+                "gas_cost": 416364658,
+                "proving_cost": 60897794741,
+                "congestion_cost": 226482273688,
+                "congestion_multiplier": 4693800517
+            }
+        }
+    },
+    {
+        "l1_block_number": 20975156,
+        "l1_fees": {
+            "blob_fee": 1,
+            "base_fee": 12473704501
+        },
+        "parent_header": {
+            "excess_mana": 1321574870,
+            "mana_used": 96504708,
+            "proving_cost_per_mana_numerator": 97425002,
+            "fee_asset_price_numerator": 12050972543
+        },
+        "header": {
+            "excess_mana": 1318079578,
+            "mana_used": 92818286,
+            "proving_cost_per_mana_numerator": 97491349,
+            "fee_asset_price_numerator": 11679832926
+        },
+        "oracle_input": {
+            "proving_cost_modifier": 66347,
+            "fee_asset_price_modifier": -371139617
+        },
+        "outputs": {
+            "fee_asset_price_at_execution": 11280717118,
+            "mana_base_fee_components_in_wei": {
+                "data_cost": 0,
+                "gas_cost": 41319146,
+                "proving_cost": 5420636438,
+                "congestion_cost": 20070744800,
+                "congestion_multiplier": 4674644455
+            },
+            "mana_base_fee_components_in_fee_asset": {
+                "data_cost": 0,
+                "gas_cost": 466109597,
+                "proving_cost": 61148666256,
+                "congestion_cost": 226412394436,
+                "congestion_multiplier": 4674644455
+            }
+        }
+    },
+    {
+        "l1_block_number": 20975159,
+        "l1_fees": {
+            "blob_fee": 1,
+            "base_fee": 12501243261
+        },
+        "parent_header": {
+            "excess_mana": 1318079578,
+            "mana_used": 92818286,
+            "proving_cost_per_mana_numerator": 97491349,
+            "fee_asset_price_numerator": 11679832926
+        },
+        "header": {
+            "excess_mana": 1310897864,
+            "mana_used": 109584810,
+            "proving_cost_per_mana_numerator": 263701092,
+            "fee_asset_price_numerator": 11377695280
+        },
+        "oracle_input": {
+            "proving_cost_modifier": 166209743,
+            "fee_asset_price_modifier": -302137646
+        },
+        "outputs": {
+            "fee_asset_price_at_execution": 11238927505,
+            "mana_base_fee_components_in_wei": {
+                "data_cost": 0,
+                "gas_cost": 41410368,
+                "proving_cost": 5420640034,
+                "congestion_cost": 19857447142,
+                "congestion_multiplier": 4635529825
+            },
+            "mana_base_fee_components_in_fee_asset": {
+                "data_cost": 0,
+                "gas_cost": 465408123,
+                "proving_cost": 60922180372,
+                "congestion_cost": 223176408863,
+                "congestion_multiplier": 4635529825
+            }
+        }
+    },
+    {
+        "l1_block_number": 20975162,
+        "l1_fees": {
+            "blob_fee": 1,
+            "base_fee": 12443066368
+        },
+        "parent_header": {
+            "excess_mana": 1310897864,
+            "mana_used": 109584810,
+            "proving_cost_per_mana_numerator": 263701092,
+            "fee_asset_price_numerator": 11377695280
+        },
+        "header": {
+            "excess_mana": 1320482674,
+            "mana_used": 99018256,
+            "proving_cost_per_mana_numerator": 466096273,
+            "fee_asset_price_numerator": 11454742859
+        },
+        "oracle_input": {
+            "proving_cost_modifier": 202395181,
+            "fee_asset_price_modifier": 77047579
+        },
+        "outputs": {
+            "fee_asset_price_at_execution": 11205021721,
+            "mana_base_fee_components_in_wei": {
+                "data_cost": 0,
+                "gas_cost": 41217657,
+                "proving_cost": 5429657158,
+                "congestion_cost": 20175526521,
+                "congestion_multiplier": 4687806284
+            },
+            "mana_base_fee_components_in_fee_asset": {
+                "data_cost": 0,
+                "gas_cost": 461844741,
+                "proving_cost": 60839426392,
+                "congestion_cost": 226067212900,
+                "congestion_multiplier": 4687806284
+            }
+        }
+    }
+]


### PR DESCRIPTION
Fixes #9718. Implements the oracles relying directly on the `fake_exponential` e,g., the proving cost and fee asset cost.

Using the data generated from  https://github.com/AztecProtocol/engineering-designs/pull/38 and checks that the solidity implementation matches the values from the python.

The `MinimalFeeModel` showcase the storage needed and computations, the same logic logic will end up living closer to the rollup contract in what #9804