### PR TITLE
fix: map tracks duplicates

### DIFF
--- a/yarn-project/kv-store/src/interfaces/map.ts
+++ b/yarn-project/kv-store/src/interfaces/map.ts
@@ -25,13 +25,6 @@ export interface AztecMap<K extends Key, V> {
   set(key: K, val: V): Promise<void>;
 
   /**
-   * Atomically swap the value at the given key
-   * @param key - The key to swap the value at
-   * @param fn - The function to swap the value with
-   */
-  swap(key: K, fn: (val: V | undefined) => V): Promise<void>;
-
-  /**
    * Sets the value at the given key if it does not already exist.
    * @param key - The key to set the value at
    * @param val - The value to set

--- a/yarn-project/kv-store/src/lmdb/map.test.ts
+++ b/yarn-project/kv-store/src/lmdb/map.test.ts
@@ -1,14 +1,86 @@
+import { randomBytes } from '@aztec/foundation/crypto';
+
 import { type Database, open } from 'lmdb';
 
+import { type AztecMap } from '../interfaces/map.js';
 import { LmdbAztecMap } from './map.js';
 
 describe('LmdbAztecMap', () => {
-  let db: Database;
-  let map: LmdbAztecMap<string, string>;
+  describe('without duplicates', () => {
+    let db: Database;
+    let map: LmdbAztecMap<string, string>;
+
+    beforeEach(() => {
+      db = open({} as any);
+      map = new LmdbAztecMap(db, 'test');
+    });
+
+    afterEach(async () => {
+      await db.close();
+    });
+
+    testMapInterface(() => map);
+
+    it('should be able to overwrite values', async () => {
+      await map.set('foo', 'bar');
+      await map.set('foo', 'baz');
+
+      expect(map.get('foo')).toEqual('baz');
+    });
+
+    it('supports tuple keys', async () => {
+      const map = new LmdbAztecMap<[number, string], string>(db, 'test');
+
+      await map.set([5, 'bar'], 'val');
+      await map.set([0, 'foo'], 'val');
+
+      expect([...map.keys()]).toEqual([
+        [0, 'foo'],
+        [5, 'bar'],
+      ]);
+
+      expect(map.get([5, 'bar'])).toEqual('val');
+    });
+  });
+
+  describe('with duplicates', () => {
+    let db: Database;
+    let mmap: LmdbAztecMap<string, string | Buffer>;
+
+    beforeEach(() => {
+      db = open({} as any);
+      mmap = new LmdbAztecMap(db, 'test', true);
+    });
+
+    afterEach(async () => {
+      await db.close();
+    });
+
+    testMapInterface(() => mmap as AztecMap<string, string>);
+
+    it('should store many values for the same key', async () => {
+      const key = 'foo';
+      const values: Buffer[] = [];
+      for (let i = 0; i < 1000; i++) {
+        const value = randomBytes(32);
+        values.push(value);
+        await mmap.set(key, value);
+      }
+
+      const storedValues = [...mmap.getValues(key)] as Buffer[];
+      expect(storedValues.length).toEqual(values.length);
+      for (const value of storedValues) {
+        expect(values.some(v => v.equals(value))).toBe(true);
+      }
+    });
+  });
+});
+
+function testMapInterface(getMap: () => AztecMap<string, string>) {
+  let map: AztecMap<string, string>;
 
   beforeEach(() => {
-    db = open({ dupSort: true } as any);
-    map = new LmdbAztecMap(db, 'test');
+    map = getMap();
   });
 
   it('should be able to set and get values', async () => {
@@ -61,27 +133,6 @@ describe('LmdbAztecMap', () => {
     expect([...map.keys()]).toEqual(['baz', 'foo']);
   });
 
-  it('should be able to get multiple values for a single key', async () => {
-    await map.set('foo', 'bar');
-    await map.set('foo', 'baz');
-
-    expect([...map.getValues('foo')]).toEqual(['bar', 'baz']);
-  });
-
-  it('supports tuple keys', async () => {
-    const map = new LmdbAztecMap<[number, string], string>(db, 'test');
-
-    await map.set([5, 'bar'], 'val');
-    await map.set([0, 'foo'], 'val');
-
-    expect([...map.keys()]).toEqual([
-      [0, 'foo'],
-      [5, 'bar'],
-    ]);
-
-    expect(map.get([5, 'bar'])).toEqual('val');
-  });
-
   it('supports range queries', async () => {
     await map.set('a', 'a');
     await map.set('b', 'b');
@@ -96,4 +147,4 @@ describe('LmdbAztecMap', () => {
     expect([...map.keys({ start: 'b', reverse: true })]).toEqual(['d', 'c']);
     expect([...map.keys({ end: 'b', reverse: true })]).toEqual(['b', 'a']);
   });
-});
+}


### PR DESCRIPTION
This PR starts changes how MultiMap works by tracking duplicate keys in application code. This is to solve an issue where Buffer values get miss-interpreted by `ordered-binary`
