### PR TITLE
chore: fixing test contract fixture

### DIFF
--- a/yarn-project/circuit-types/src/interfaces/pxe.test.ts
+++ b/yarn-project/circuit-types/src/interfaces/pxe.test.ts
@@ -22,6 +22,7 @@ import { type JsonRpcTestContext, createJsonRpcTestSetup } from '@aztec/foundati
 import { fileURLToPath } from '@aztec/foundation/url';
 import { loadContractArtifact } from '@aztec/types/abi';
 
+import { jest } from '@jest/globals';
 import { deepStrictEqual } from 'assert';
 import { readFileSync } from 'fs';
 import omit from 'lodash.omit';
@@ -42,6 +43,8 @@ import { TxEffect } from '../tx_effect.js';
 import { TxExecutionRequest } from '../tx_execution_request.js';
 import { type EventMetadataDefinition, type PXE, type PXEInfo, PXESchema } from './pxe.js';
 import { type SyncStatus } from './sync-status.js';
+
+jest.setTimeout(12_000);
 
 describe('PXESchema', () => {
   let handler: MockPXE;

--- a/yarn-project/circuits.js/src/contract/unconstrained_function_membership_proof.test.ts
+++ b/yarn-project/circuits.js/src/contract/unconstrained_function_membership_proof.test.ts
@@ -40,6 +40,8 @@ describe('unconstrained_function_membership_proof', () => {
     expect(artifact.functions.filter(isUnconstrained).length).toBe(1);
 
     const unconstrainedFunction = unconstrainedFns[0];
+    const selector = FunctionSelector.fromNameAndParameters(unconstrainedFunction);
+
     const proof = createUnconstrainedFunctionMembershipProof(selector, artifact);
     expect(proof.artifactTreeSiblingPath.length).toBe(0);
 

--- a/yarn-project/circuits.js/src/tests/fixtures.ts
+++ b/yarn-project/circuits.js/src/tests/fixtures.ts
@@ -13,9 +13,9 @@ export function getBenchmarkContractArtifact(): ContractArtifact {
   return loadContractArtifact(content);
 }
 
-// Copied from the build output for the contract `Benchmarking` in noir-contracts
+// Copied from the build output for the contract `Test` in noir-contracts
 export function getTestContractArtifact(): ContractArtifact {
-  const path = getPathToFixture('Benchmarking.test.json');
+  const path = getPathToFixture('Test.test.json');
   const content = JSON.parse(readFileSync(path).toString()) as NoirCompiledContract;
   return loadContractArtifact(content);
 }


### PR DESCRIPTION
This just fixes a utility function that seems to be a typo, as it is has the same content as the function above it, and uses the same artifact. This also bumps the timeout of `pxe.test.ts` because we were seeing some issues in timeouts with adding contract artifact.