### PR TITLE
feat: split up eccvm proof into two proofs

### DIFF
--- a/barretenberg/cpp/src/barretenberg/benchmark/goblin_bench/eccvm.bench.cpp
+++ b/barretenberg/cpp/src/barretenberg/benchmark/goblin_bench/eccvm.bench.cpp
@@ -61,7 +61,7 @@ void eccvm_prove(State& state) noexcept
     Builder builder = generate_trace(target_num_gates);
     ECCVMProver prover(builder);
     for (auto _ : state) {
-        auto proof = prover.construct_proof();
+        ECCVMProof proof = prover.construct_proof();
     };
 }
 

--- a/barretenberg/cpp/src/barretenberg/commitment_schemes/ipa/ipa.hpp
+++ b/barretenberg/cpp/src/barretenberg/commitment_schemes/ipa/ipa.hpp
@@ -142,6 +142,7 @@ template <typename Curve_> class IPA {
 
         size_t poly_length = polynomial.size();
 
+        // TODO(https://github.com/AztecProtocol/barretenberg/issues/1150): Hash more things here.
         // Step 1.
         // Send polynomial degree + 1 = d to the verifier
         transcript->send_to_verifier("IPA:poly_degree_plus_1", static_cast<uint32_t>(poly_length));

--- a/barretenberg/cpp/src/barretenberg/eccvm/eccvm_composer.test.cpp
+++ b/barretenberg/cpp/src/barretenberg/eccvm/eccvm_composer.test.cpp
@@ -63,7 +63,7 @@ TEST_F(ECCVMTests, BaseCase)
 {
     ECCVMCircuitBuilder builder = generate_circuit(&engine);
     ECCVMProver prover(builder);
-    HonkProof proof = prover.construct_proof();
+    ECCVMProof proof = prover.construct_proof();
     ECCVMVerifier verifier(prover.key);
     bool verified = verifier.verify_proof(proof);
 
@@ -79,7 +79,7 @@ TEST_F(ECCVMTests, EqFails)
     builder.op_queue->num_transcript_rows++;
     ECCVMProver prover(builder);
 
-    auto proof = prover.construct_proof();
+    ECCVMProof proof = prover.construct_proof();
     ECCVMVerifier verifier(prover.key);
     bool verified = verifier.verify_proof(proof);
     ASSERT_FALSE(verified);

--- a/barretenberg/cpp/src/barretenberg/eccvm/eccvm_flavor.hpp
+++ b/barretenberg/cpp/src/barretenberg/eccvm/eccvm_flavor.hpp
@@ -1188,22 +1188,6 @@ class ECCVMFlavor {
                 NativeTranscript::template deserialize_from_buffer<FF>(NativeTranscript::proof_data, num_frs_read);
 
             shplonk_q2_comm = NativeTranscript::template deserialize_from_buffer<Commitment>(proof_data, num_frs_read);
-
-            // ipa_poly_degree = NativeTranscript::template
-            // deserialize_from_buffer<uint32_t>(NativeTranscript::proof_data,
-            //                                                                                num_frs_read);
-
-            // for (size_t i = 0; i < CONST_ECCVM_LOG_N; ++i) {
-            //     ipa_l_comms.emplace_back(NativeTranscript::template deserialize_from_buffer<Commitment>(
-            //         NativeTranscript::proof_data, num_frs_read));
-            //     ipa_r_comms.emplace_back(NativeTranscript::template deserialize_from_buffer<Commitment>(
-            //         NativeTranscript::proof_data, num_frs_read));
-            // }
-            // ipa_G_0_eval = NativeTranscript::template
-            // deserialize_from_buffer<Commitment>(NativeTranscript::proof_data,
-            //                                                                               num_frs_read);
-            // ipa_a_0_eval =
-            //     NativeTranscript::template deserialize_from_buffer<FF>(NativeTranscript::proof_data, num_frs_read);
         }
 
         void serialize_full_transcript()
@@ -1346,14 +1330,60 @@ class ECCVMFlavor {
 
             NativeTranscript::template serialize_to_buffer(shplonk_q2_comm, NativeTranscript::proof_data);
 
-            // NativeTranscript::template serialize_to_buffer(ipa_poly_degree, NativeTranscript::proof_data);
-            // for (size_t i = 0; i < CONST_ECCVM_LOG_N; ++i) {
-            //     NativeTranscript::template serialize_to_buffer(ipa_l_comms[i], NativeTranscript::proof_data);
-            //     NativeTranscript::template serialize_to_buffer(ipa_r_comms[i], NativeTranscript::proof_data);
-            // }
+            ASSERT(NativeTranscript::proof_data.size() == old_proof_length);
+        }
+    };
 
-            // serialize_to_buffer(ipa_G_0_eval, proof_data);
-            // serialize_to_buffer(ipa_a_0_eval, proof_data);
+    /**
+     * @brief Derived class that defines proof structure for ECCVM IPA proof, as well as supporting functions.
+     *
+     */
+    class IPATranscript : public NativeTranscript {
+      public:
+        uint32_t ipa_poly_degree;
+        std::vector<Commitment> ipa_l_comms;
+        std::vector<Commitment> ipa_r_comms;
+        Commitment ipa_G_0_eval;
+        FF ipa_a_0_eval;
+
+        IPATranscript() = default;
+
+        IPATranscript(const HonkProof& proof)
+            : NativeTranscript(proof)
+        {}
+
+        void deserialize_full_transcript()
+        {
+            // take current proof and put them into the struct
+            size_t num_frs_read = 0;
+            ipa_poly_degree = NativeTranscript::template deserialize_from_buffer<uint32_t>(NativeTranscript::proof_data,
+                                                                                           num_frs_read);
+
+            for (size_t i = 0; i < CONST_ECCVM_LOG_N; ++i) {
+                ipa_l_comms.emplace_back(NativeTranscript::template deserialize_from_buffer<Commitment>(
+                    NativeTranscript::proof_data, num_frs_read));
+                ipa_r_comms.emplace_back(NativeTranscript::template deserialize_from_buffer<Commitment>(
+                    NativeTranscript::proof_data, num_frs_read));
+            }
+            ipa_G_0_eval = NativeTranscript::template deserialize_from_buffer<Commitment>(NativeTranscript::proof_data,
+                                                                                          num_frs_read);
+            ipa_a_0_eval =
+                NativeTranscript::template deserialize_from_buffer<FF>(NativeTranscript::proof_data, num_frs_read);
+        }
+
+        void serialize_full_transcript()
+        {
+            size_t old_proof_length = NativeTranscript::proof_data.size();
+            NativeTranscript::proof_data.clear();
+
+            NativeTranscript::template serialize_to_buffer(ipa_poly_degree, NativeTranscript::proof_data);
+            for (size_t i = 0; i < CONST_ECCVM_LOG_N; ++i) {
+                NativeTranscript::template serialize_to_buffer(ipa_l_comms[i], NativeTranscript::proof_data);
+                NativeTranscript::template serialize_to_buffer(ipa_r_comms[i], NativeTranscript::proof_data);
+            }
+
+            serialize_to_buffer(ipa_G_0_eval, proof_data);
+            serialize_to_buffer(ipa_a_0_eval, proof_data);
 
             ASSERT(NativeTranscript::proof_data.size() == old_proof_length);
         }

--- a/barretenberg/cpp/src/barretenberg/eccvm/eccvm_flavor.hpp
+++ b/barretenberg/cpp/src/barretenberg/eccvm/eccvm_flavor.hpp
@@ -951,11 +951,6 @@ class ECCVMFlavor {
         FF translation_eval_z1;
         FF translation_eval_z2;
         Commitment shplonk_q2_comm;
-        uint32_t ipa_poly_degree;
-        std::vector<Commitment> ipa_l_comms;
-        std::vector<Commitment> ipa_r_comms;
-        Commitment ipa_G_0_eval;
-        FF ipa_a_0_eval;
 
         Transcript() = default;
 

--- a/barretenberg/cpp/src/barretenberg/eccvm/eccvm_flavor.hpp
+++ b/barretenberg/cpp/src/barretenberg/eccvm/eccvm_flavor.hpp
@@ -1189,19 +1189,21 @@ class ECCVMFlavor {
 
             shplonk_q2_comm = NativeTranscript::template deserialize_from_buffer<Commitment>(proof_data, num_frs_read);
 
-            ipa_poly_degree = NativeTranscript::template deserialize_from_buffer<uint32_t>(NativeTranscript::proof_data,
-                                                                                           num_frs_read);
+            // ipa_poly_degree = NativeTranscript::template
+            // deserialize_from_buffer<uint32_t>(NativeTranscript::proof_data,
+            //                                                                                num_frs_read);
 
-            for (size_t i = 0; i < CONST_ECCVM_LOG_N; ++i) {
-                ipa_l_comms.emplace_back(NativeTranscript::template deserialize_from_buffer<Commitment>(
-                    NativeTranscript::proof_data, num_frs_read));
-                ipa_r_comms.emplace_back(NativeTranscript::template deserialize_from_buffer<Commitment>(
-                    NativeTranscript::proof_data, num_frs_read));
-            }
-            ipa_G_0_eval = NativeTranscript::template deserialize_from_buffer<Commitment>(NativeTranscript::proof_data,
-                                                                                          num_frs_read);
-            ipa_a_0_eval =
-                NativeTranscript::template deserialize_from_buffer<FF>(NativeTranscript::proof_data, num_frs_read);
+            // for (size_t i = 0; i < CONST_ECCVM_LOG_N; ++i) {
+            //     ipa_l_comms.emplace_back(NativeTranscript::template deserialize_from_buffer<Commitment>(
+            //         NativeTranscript::proof_data, num_frs_read));
+            //     ipa_r_comms.emplace_back(NativeTranscript::template deserialize_from_buffer<Commitment>(
+            //         NativeTranscript::proof_data, num_frs_read));
+            // }
+            // ipa_G_0_eval = NativeTranscript::template
+            // deserialize_from_buffer<Commitment>(NativeTranscript::proof_data,
+            //                                                                               num_frs_read);
+            // ipa_a_0_eval =
+            //     NativeTranscript::template deserialize_from_buffer<FF>(NativeTranscript::proof_data, num_frs_read);
         }
 
         void serialize_full_transcript()
@@ -1344,14 +1346,14 @@ class ECCVMFlavor {
 
             NativeTranscript::template serialize_to_buffer(shplonk_q2_comm, NativeTranscript::proof_data);
 
-            NativeTranscript::template serialize_to_buffer(ipa_poly_degree, NativeTranscript::proof_data);
-            for (size_t i = 0; i < CONST_ECCVM_LOG_N; ++i) {
-                NativeTranscript::template serialize_to_buffer(ipa_l_comms[i], NativeTranscript::proof_data);
-                NativeTranscript::template serialize_to_buffer(ipa_r_comms[i], NativeTranscript::proof_data);
-            }
+            // NativeTranscript::template serialize_to_buffer(ipa_poly_degree, NativeTranscript::proof_data);
+            // for (size_t i = 0; i < CONST_ECCVM_LOG_N; ++i) {
+            //     NativeTranscript::template serialize_to_buffer(ipa_l_comms[i], NativeTranscript::proof_data);
+            //     NativeTranscript::template serialize_to_buffer(ipa_r_comms[i], NativeTranscript::proof_data);
+            // }
 
-            serialize_to_buffer(ipa_G_0_eval, proof_data);
-            serialize_to_buffer(ipa_a_0_eval, proof_data);
+            // serialize_to_buffer(ipa_G_0_eval, proof_data);
+            // serialize_to_buffer(ipa_a_0_eval, proof_data);
 
             ASSERT(NativeTranscript::proof_data.size() == old_proof_length);
         }

--- a/barretenberg/cpp/src/barretenberg/eccvm/eccvm_prover.cpp
+++ b/barretenberg/cpp/src/barretenberg/eccvm/eccvm_prover.cpp
@@ -183,7 +183,7 @@ void ECCVMProver::execute_pcs_rounds()
     const OpeningClaim batch_opening_claim = Shplonk::prove(key->commitment_key, opening_claims, transcript);
 
     // Compute the opening proof for the batched opening claim with the univariate PCS
-    PCS::compute_opening_proof(key->commitment_key, batch_opening_claim, transcript);
+    PCS::compute_opening_proof(key->commitment_key, batch_opening_claim, ipa_transcript);
 
     // Produce another challenge passed as input to the translator verifier
     translation_batching_challenge_v = transcript->template get_challenge<FF>("Translation:batching_challenge");
@@ -191,13 +191,12 @@ void ECCVMProver::execute_pcs_rounds()
     vinfo("computed opening proof");
 }
 
-HonkProof ECCVMProver::export_proof()
+ECCVMProof ECCVMProver::export_proof()
 {
-    proof = transcript->export_proof();
-    return proof;
+    return { transcript->export_proof(), ipa_transcript->export_proof() };
 }
 
-HonkProof ECCVMProver::construct_proof()
+ECCVMProof ECCVMProver::construct_proof()
 {
     PROFILE_THIS_NAME("ECCVMProver::construct_proof");
 

--- a/barretenberg/cpp/src/barretenberg/eccvm/eccvm_prover.cpp
+++ b/barretenberg/cpp/src/barretenberg/eccvm/eccvm_prover.cpp
@@ -12,8 +12,11 @@
 
 namespace bb {
 
-ECCVMProver::ECCVMProver(CircuitBuilder& builder, const std::shared_ptr<Transcript>& transcript)
+ECCVMProver::ECCVMProver(CircuitBuilder& builder,
+                         const std::shared_ptr<Transcript>& transcript,
+                         const std::shared_ptr<Transcript>& ipa_transcript)
     : transcript(transcript)
+    , ipa_transcript(ipa_transcript)
 {
     PROFILE_THIS_NAME("ECCVMProver(CircuitBuilder&)");
 

--- a/barretenberg/cpp/src/barretenberg/eccvm/eccvm_prover.hpp
+++ b/barretenberg/cpp/src/barretenberg/eccvm/eccvm_prover.hpp
@@ -27,7 +27,8 @@ class ECCVMProver {
     using CircuitBuilder = typename Flavor::CircuitBuilder;
 
     explicit ECCVMProver(CircuitBuilder& builder,
-                         const std::shared_ptr<Transcript>& transcript = std::make_shared<Transcript>());
+                         const std::shared_ptr<Transcript>& transcript = std::make_shared<Transcript>(),
+                         const std::shared_ptr<Transcript>& ipa_transcript = std::make_shared<Transcript>());
 
     BB_PROFILE void execute_preamble_round();
     BB_PROFILE void execute_wire_commitments_round();

--- a/barretenberg/cpp/src/barretenberg/eccvm/eccvm_prover.hpp
+++ b/barretenberg/cpp/src/barretenberg/eccvm/eccvm_prover.hpp
@@ -37,10 +37,11 @@ class ECCVMProver {
     BB_PROFILE void execute_pcs_rounds();
     BB_PROFILE void execute_transcript_consistency_univariate_opening_round();
 
-    HonkProof export_proof();
-    HonkProof construct_proof();
+    ECCVMProof export_proof();
+    ECCVMProof construct_proof();
 
     std::shared_ptr<Transcript> transcript;
+    std::shared_ptr<Transcript> ipa_transcript;
 
     TranslationEvaluations translation_evaluations;
 
@@ -62,9 +63,6 @@ class ECCVMProver {
     FF translation_batching_challenge_v; // to be rederived by the translator verifier
 
     SumcheckOutput<Flavor> sumcheck_output;
-
-  private:
-    HonkProof proof;
 };
 
 } // namespace bb

--- a/barretenberg/cpp/src/barretenberg/eccvm/eccvm_transcript.test.cpp
+++ b/barretenberg/cpp/src/barretenberg/eccvm/eccvm_transcript.test.cpp
@@ -205,6 +205,19 @@ class ECCVMTranscriptTests : public ::testing::Test {
         manifest_expected.add_challenge(round, "Shplonk:z");
 
         round++;
+        manifest_expected.add_challenge(round, "Translation:batching_challenge");
+
+        return manifest_expected;
+    }
+
+    TranscriptManifest construct_eccvm_ipa_manifest()
+    {
+        TranscriptManifest manifest_expected;
+        // Size of types is number of bb::frs needed to represent the type
+        size_t frs_per_Fr = bb::field_conversion::calc_num_bn254_frs<FF>();
+        size_t frs_per_G = bb::field_conversion::calc_num_bn254_frs<typename Flavor::Commitment>();
+        size_t frs_per_uint32 = bb::field_conversion::calc_num_bn254_frs<uint32_t>();
+        size_t round = 0;
         manifest_expected.add_entry(round, "IPA:poly_degree_plus_1", frs_per_uint32);
         manifest_expected.add_challenge(round, "IPA:generator_challenge");
 
@@ -220,8 +233,6 @@ class ECCVMTranscriptTests : public ::testing::Test {
         round++;
         manifest_expected.add_entry(round, "IPA:G_0", frs_per_G);
         manifest_expected.add_entry(round, "IPA:a_0", frs_per_Fr);
-        manifest_expected.add_challenge(round, "Translation:batching_challenge");
-
         return manifest_expected;
     }
 
@@ -280,6 +291,15 @@ TEST_F(ECCVMTranscriptTests, ProverManifestConsistency)
     // Note: a manifest can be printed using manifest.print()
     for (size_t round = 0; round < manifest_expected.size(); ++round) {
         ASSERT_EQ(prover_manifest[round], manifest_expected[round]) << "Prover manifest discrepency in round " << round;
+    }
+
+    auto ipa_manifest_expected = this->construct_eccvm_ipa_manifest();
+    auto prover_ipa_manifest = prover.ipa_transcript->get_manifest();
+
+    // Note: a manifest can be printed using manifest.print()
+    for (size_t round = 0; round < ipa_manifest_expected.size(); ++round) {
+        ASSERT_EQ(prover_ipa_manifest[round], ipa_manifest_expected[round])
+            << "IPA prover manifest discrepency in round " << round;
     }
 }
 

--- a/barretenberg/cpp/src/barretenberg/eccvm/eccvm_verifier.cpp
+++ b/barretenberg/cpp/src/barretenberg/eccvm/eccvm_verifier.cpp
@@ -128,7 +128,7 @@ bool ECCVMVerifier::verify_proof(const ECCVMProof& proof)
         Shplonk::reduce_verification(key->pcs_verification_key->get_g1_identity(), opening_claims, transcript);
 
     const bool batched_opening_verified =
-        PCS::reduce_verify(key->pcs_verification_key, batch_opening_claim, transcript);
+        PCS::reduce_verify(key->pcs_verification_key, batch_opening_claim, ipa_transcript);
     vinfo("eccvm sumcheck verified?: ", sumcheck_verified.value());
     vinfo("batch opening verified?: ", batched_opening_verified);
     return sumcheck_verified.value() && batched_opening_verified;

--- a/barretenberg/cpp/src/barretenberg/eccvm/eccvm_verifier.cpp
+++ b/barretenberg/cpp/src/barretenberg/eccvm/eccvm_verifier.cpp
@@ -16,8 +16,8 @@ bool ECCVMVerifier::verify_proof(const ECCVMProof& proof)
     using OpeningClaim = OpeningClaim<Curve>;
 
     RelationParameters<FF> relation_parameters;
-    transcript = std::make_shared<Transcript>(proof.first);
-    ipa_transcript = std::make_shared<Transcript>(proof.second);
+    transcript = std::make_shared<Transcript>(proof.pre_ipa_proof);
+    ipa_transcript = std::make_shared<Transcript>(proof.ipa_proof);
     VerifierCommitments commitments{ key };
     CommitmentLabels commitment_labels;
 

--- a/barretenberg/cpp/src/barretenberg/eccvm/eccvm_verifier.cpp
+++ b/barretenberg/cpp/src/barretenberg/eccvm/eccvm_verifier.cpp
@@ -8,7 +8,7 @@ namespace bb {
 /**
  * @brief This function verifies an ECCVM Honk proof for given program settings.
  */
-bool ECCVMVerifier::verify_proof(const HonkProof& proof)
+bool ECCVMVerifier::verify_proof(const ECCVMProof& proof)
 {
     using Curve = typename Flavor::Curve;
     using Shplemini = ShpleminiVerifier_<Curve>;
@@ -16,7 +16,8 @@ bool ECCVMVerifier::verify_proof(const HonkProof& proof)
     using OpeningClaim = OpeningClaim<Curve>;
 
     RelationParameters<FF> relation_parameters;
-    transcript = std::make_shared<Transcript>(proof);
+    transcript = std::make_shared<Transcript>(proof.first);
+    ipa_transcript = std::make_shared<Transcript>(proof.second);
     VerifierCommitments commitments{ key };
     CommitmentLabels commitment_labels;
 

--- a/barretenberg/cpp/src/barretenberg/eccvm/eccvm_verifier.hpp
+++ b/barretenberg/cpp/src/barretenberg/eccvm/eccvm_verifier.hpp
@@ -22,10 +22,11 @@ class ECCVMVerifier {
     explicit ECCVMVerifier(const std::shared_ptr<ECCVMVerifier::ProvingKey>& proving_key)
         : ECCVMVerifier(std::make_shared<ECCVMFlavor::VerificationKey>(proving_key)){};
 
-    bool verify_proof(const HonkProof& proof);
+    bool verify_proof(const ECCVMProof& proof);
 
     std::shared_ptr<VerificationKey> key;
     std::map<std::string, Commitment> commitments;
     std::shared_ptr<Transcript> transcript;
+    std::shared_ptr<Transcript> ipa_transcript;
 };
 } // namespace bb

--- a/barretenberg/cpp/src/barretenberg/goblin/types.hpp
+++ b/barretenberg/cpp/src/barretenberg/goblin/types.hpp
@@ -21,8 +21,8 @@ struct GoblinProof {
 
     size_t size() const
     {
-        return merge_proof.size() + eccvm_proof.first.size() + eccvm_proof.second.size() + translator_proof.size() +
-               TranslationEvaluations::size();
+        return merge_proof.size() + eccvm_proof.pre_ipa_proof.size() + eccvm_proof.ipa_proof.size() +
+               translator_proof.size() + TranslationEvaluations::size();
     };
 
     MSGPACK_FIELDS(merge_proof, eccvm_proof, translator_proof, translation_evaluations);

--- a/barretenberg/cpp/src/barretenberg/goblin/types.hpp
+++ b/barretenberg/cpp/src/barretenberg/goblin/types.hpp
@@ -15,13 +15,14 @@ struct GoblinProof {
     using FF = MegaFlavor::FF;
 
     HonkProof merge_proof;
-    HonkProof eccvm_proof;
+    ECCVMProof eccvm_proof;
     HonkProof translator_proof;
     ECCVMProver::TranslationEvaluations translation_evaluations;
 
     size_t size() const
     {
-        return merge_proof.size() + eccvm_proof.size() + translator_proof.size() + TranslationEvaluations::size();
+        return merge_proof.size() + eccvm_proof.first.size() + eccvm_proof.second.size() + translator_proof.size() +
+               TranslationEvaluations::size();
     };
 
     MSGPACK_FIELDS(merge_proof, eccvm_proof, translator_proof, translation_evaluations);

--- a/barretenberg/cpp/src/barretenberg/honk/proof_system/types/proof.hpp
+++ b/barretenberg/cpp/src/barretenberg/honk/proof_system/types/proof.hpp
@@ -11,7 +11,8 @@ static constexpr size_t HONK_PROOF_PUBLIC_INPUT_OFFSET = 3;
 // Where the number of public inputs is specified in a proof
 static constexpr size_t PUBLIC_INPUTS_SIZE_INDEX = 1;
 
-using HonkProof = std::vector<bb::fr>; // this can be fr?
+using HonkProof = std::vector<bb::fr>;              // this can be fr?
+using ECCVMProof = std::pair<HonkProof, HonkProof>; // Pair of Honk proof and IPA proof
 
 template <typename Builder> using StdlibProof = std::vector<bb::stdlib::field_t<Builder>>;
 

--- a/barretenberg/cpp/src/barretenberg/honk/proof_system/types/proof.hpp
+++ b/barretenberg/cpp/src/barretenberg/honk/proof_system/types/proof.hpp
@@ -11,8 +11,11 @@ static constexpr size_t HONK_PROOF_PUBLIC_INPUT_OFFSET = 3;
 // Where the number of public inputs is specified in a proof
 static constexpr size_t PUBLIC_INPUTS_SIZE_INDEX = 1;
 
-using HonkProof = std::vector<bb::fr>;              // this can be fr?
-using ECCVMProof = std::pair<HonkProof, HonkProof>; // Pair of Honk proof and IPA proof
+using HonkProof = std::vector<bb::fr>; // this can be fr?
+struct ECCVMProof {
+    HonkProof pre_ipa_proof;
+    HonkProof ipa_proof;
+};
 
 template <typename Builder> using StdlibProof = std::vector<bb::stdlib::field_t<Builder>>;
 

--- a/barretenberg/cpp/src/barretenberg/honk/proof_system/types/proof.hpp
+++ b/barretenberg/cpp/src/barretenberg/honk/proof_system/types/proof.hpp
@@ -15,6 +15,8 @@ using HonkProof = std::vector<bb::fr>; // this can be fr?
 struct ECCVMProof {
     HonkProof pre_ipa_proof;
     HonkProof ipa_proof;
+
+    MSGPACK_FIELDS(pre_ipa_proof, ipa_proof);
 };
 
 template <typename Builder> using StdlibProof = std::vector<bb::stdlib::field_t<Builder>>;

--- a/barretenberg/cpp/src/barretenberg/stdlib/eccvm_verifier/eccvm_recursive_verifier.cpp
+++ b/barretenberg/cpp/src/barretenberg/stdlib/eccvm_verifier/eccvm_recursive_verifier.cpp
@@ -142,7 +142,7 @@ template <typename Flavor> void ECCVMRecursiveVerifier_<Flavor>::verify_proof(co
 
     // TODO(https://github.com/AztecProtocol/barretenberg/issues/1142): Handle this return value correctly.
     const typename PCS::VerifierAccumulator batched_opening_accumulator =
-        PCS::reduce_verify(batch_opening_claim, transcript);
+        PCS::reduce_verify(batch_opening_claim, ipa_transcript);
     ASSERT(sumcheck_verified);
 }
 

--- a/barretenberg/cpp/src/barretenberg/stdlib/eccvm_verifier/eccvm_recursive_verifier.cpp
+++ b/barretenberg/cpp/src/barretenberg/stdlib/eccvm_verifier/eccvm_recursive_verifier.cpp
@@ -25,8 +25,8 @@ template <typename Flavor> void ECCVMRecursiveVerifier_<Flavor>::verify_proof(co
 
     RelationParameters<FF> relation_parameters;
 
-    StdlibProof<Builder> stdlib_proof = bb::convert_proof_to_witness(builder, proof.first);
-    StdlibProof<Builder> stdlib_ipa_proof = bb::convert_proof_to_witness(builder, proof.second);
+    StdlibProof<Builder> stdlib_proof = bb::convert_proof_to_witness(builder, proof.pre_ipa_proof);
+    StdlibProof<Builder> stdlib_ipa_proof = bb::convert_proof_to_witness(builder, proof.ipa_proof);
     transcript = std::make_shared<Transcript>(stdlib_proof);
     ipa_transcript = std::make_shared<Transcript>(stdlib_ipa_proof);
 

--- a/barretenberg/cpp/src/barretenberg/stdlib/eccvm_verifier/eccvm_recursive_verifier.cpp
+++ b/barretenberg/cpp/src/barretenberg/stdlib/eccvm_verifier/eccvm_recursive_verifier.cpp
@@ -16,7 +16,7 @@ ECCVMRecursiveVerifier_<Flavor>::ECCVMRecursiveVerifier_(
 /**
  * @brief This function verifies an ECCVM Honk proof for given program settings up to sumcheck.
  */
-template <typename Flavor> void ECCVMRecursiveVerifier_<Flavor>::verify_proof(const HonkProof& proof)
+template <typename Flavor> void ECCVMRecursiveVerifier_<Flavor>::verify_proof(const ECCVMProof& proof)
 {
     using Curve = typename Flavor::Curve;
     using Shplemini = ShpleminiVerifier_<Curve>;
@@ -25,8 +25,10 @@ template <typename Flavor> void ECCVMRecursiveVerifier_<Flavor>::verify_proof(co
 
     RelationParameters<FF> relation_parameters;
 
-    StdlibProof<Builder> stdlib_proof = bb::convert_proof_to_witness(builder, proof);
+    StdlibProof<Builder> stdlib_proof = bb::convert_proof_to_witness(builder, proof.first);
+    StdlibProof<Builder> stdlib_ipa_proof = bb::convert_proof_to_witness(builder, proof.second);
     transcript = std::make_shared<Transcript>(stdlib_proof);
+    ipa_transcript = std::make_shared<Transcript>(stdlib_ipa_proof);
 
     VerifierCommitments commitments{ key };
     CommitmentLabels commitment_labels;

--- a/barretenberg/cpp/src/barretenberg/stdlib/eccvm_verifier/eccvm_recursive_verifier.hpp
+++ b/barretenberg/cpp/src/barretenberg/stdlib/eccvm_verifier/eccvm_recursive_verifier.hpp
@@ -21,11 +21,12 @@ template <typename Flavor> class ECCVMRecursiveVerifier_ {
                                      const std::shared_ptr<NativeVerificationKey>& native_verifier_key);
 
     // TODO(https://github.com/AztecProtocol/barretenberg/issues/991): switch recursive verifiers to StdlibProof
-    void verify_proof(const HonkProof& proof);
+    void verify_proof(const ECCVMProof& proof);
 
     std::shared_ptr<VerificationKey> key;
 
     Builder* builder;
     std::shared_ptr<Transcript> transcript;
+    std::shared_ptr<Transcript> ipa_transcript;
 };
 } // namespace bb

--- a/barretenberg/cpp/src/barretenberg/stdlib/eccvm_verifier/eccvm_recursive_verifier.test.cpp
+++ b/barretenberg/cpp/src/barretenberg/stdlib/eccvm_verifier/eccvm_recursive_verifier.test.cpp
@@ -77,7 +77,7 @@ template <typename RecursiveFlavor> class ECCVMRecursiveTests : public ::testing
     {
         InnerBuilder builder = generate_circuit(&engine);
         InnerProver prover(builder);
-        auto proof = prover.construct_proof();
+        ECCVMProof proof = prover.construct_proof();
         auto verification_key = std::make_shared<typename InnerFlavor::VerificationKey>(prover.key);
 
         info("ECCVM Recursive Verifier");
@@ -128,7 +128,7 @@ template <typename RecursiveFlavor> class ECCVMRecursiveTests : public ::testing
         InnerBuilder builder = generate_circuit(&engine);
         builder.op_queue->add_erroneous_equality_op_for_testing();
         InnerProver prover(builder);
-        auto proof = prover.construct_proof();
+        ECCVMProof proof = prover.construct_proof();
         auto verification_key = std::make_shared<typename InnerFlavor::VerificationKey>(prover.key);
 
         OuterBuilder outer_circuit;

--- a/barretenberg/cpp/src/barretenberg/stdlib/goblin_verifier/goblin_recursive_verifier.test.cpp
+++ b/barretenberg/cpp/src/barretenberg/stdlib/goblin_verifier/goblin_recursive_verifier.test.cpp
@@ -112,7 +112,7 @@ TEST_F(GoblinRecursiveVerifierTests, ECCVMFailure)
     auto [proof, verifier_input] = create_goblin_prover_output();
 
     // Tamper with the ECCVM proof
-    for (auto& val : proof.eccvm_proof.first) {
+    for (auto& val : proof.eccvm_proof.pre_ipa_proof) {
         if (val > 0) { // tamper by finding the tenth non-zero value and incrementing it by 1
             // tamper by finding the first non-zero value
             // and incrementing it by 1

--- a/barretenberg/cpp/src/barretenberg/stdlib/goblin_verifier/goblin_recursive_verifier.test.cpp
+++ b/barretenberg/cpp/src/barretenberg/stdlib/goblin_verifier/goblin_recursive_verifier.test.cpp
@@ -112,7 +112,7 @@ TEST_F(GoblinRecursiveVerifierTests, ECCVMFailure)
     auto [proof, verifier_input] = create_goblin_prover_output();
 
     // Tamper with the ECCVM proof
-    for (auto& val : proof.eccvm_proof) {
+    for (auto& val : proof.eccvm_proof.first) {
         if (val > 0) { // tamper by finding the tenth non-zero value and incrementing it by 1
             // tamper by finding the first non-zero value
             // and incrementing it by 1


### PR DESCRIPTION
Splits ECCVM proof into pre-IPA proof and IPA proof.

We want the IPA proof to be separate from the rest of the ECCVM proof so we don't have to run IPA accumulation in the tube and base rollup circuits.