### PR TITLE
feat: Google Cloud Kubernetes cluster + AWS Firewall Rules

### DIFF
--- a/spartan/terraform/gke-cluster/main.tf
+++ b/spartan/terraform/gke-cluster/main.tf
@@ -107,7 +107,7 @@ resource "google_container_node_pool" "primary_nodes" {
 
   # Node configuration
   node_config {
-    machine_type = "e2-medium"
+    machine_type = "n1-standard-16"
 
     service_account = google_service_account.gke_sa.email
     oauth_scopes = [
@@ -142,7 +142,7 @@ resource "google_container_node_pool" "spot_nodes" {
 
   # Node configuration
   node_config {
-    machine_type = "e2-medium"
+    machine_type = "n1-standard-16"
     spot         = true
 
     service_account = google_service_account.gke_sa.email

--- a/spartan/terraform/gke-cluster/main.tf
+++ b/spartan/terraform/gke-cluster/main.tf
@@ -1,0 +1,173 @@
+terraform {
+  backend "s3" {
+    bucket = "aztec-terraform"
+    key    = "spartan-gke-cluster/terraform.tfstate"
+    region = "eu-west-2"
+  }
+  required_providers {
+    google = {
+      source  = "hashicorp/google"
+      version = "~> 5.0"
+    }
+  }
+}
+
+# Configure the Google Cloud provider
+provider "google" {
+  project = "testnet-440309"
+  region  = var.region
+}
+
+# Create the service account
+resource "google_service_account" "gke_sa" {
+  account_id   = "gke-nodes-sa"
+  display_name = "GKE Nodes Service Account"
+  description  = "Service account for GKE nodes"
+}
+
+# Add IAM roles to the service account
+resource "google_project_iam_member" "gke_sa_roles" {
+  for_each = toset([
+    "roles/logging.logWriter",
+    "roles/monitoring.metricWriter",
+    "roles/monitoring.viewer",
+    "roles/artifactregistry.reader"
+  ])
+
+  project = "testnet-440309"
+  role    = each.key
+  member  = "serviceAccount:${google_service_account.gke_sa.email}"
+}
+
+# Create ingress firewall rule for UDP
+resource "google_compute_firewall" "udp_ingress" {
+  name    = "allow-udp-ingress-40400-40499"
+  network = "default"
+
+  allow {
+    protocol = "udp"
+    ports    = ["40400-40499"]
+  }
+
+  direction     = "INGRESS"
+  source_ranges = ["0.0.0.0/0"]
+  target_tags   = ["gke-node"]
+}
+
+# Create egress firewall rule for UDP
+resource "google_compute_firewall" "udp_egress" {
+  name    = "allow-udp-egress-40400-40499"
+  network = "default"
+
+  allow {
+    protocol = "udp"
+    ports    = ["40400-40499"]
+  }
+
+  direction          = "EGRESS"
+  destination_ranges = ["0.0.0.0/0"]
+  target_tags        = ["gke-node"]
+}
+
+# Create a GKE cluster
+resource "google_container_cluster" "primary" {
+  name               = "spartan-gke"
+  location           = var.zone
+  initial_node_count = 1
+
+  # Remove default node pool after cluster creation
+  remove_default_node_pool = true
+
+  # Kubernetes version
+  min_master_version = "latest"
+
+  # Network configuration
+  network    = "default"
+  subnetwork = "default"
+
+  # Master auth configuration
+  master_auth {
+    client_certificate_config {
+      issue_client_certificate = false
+    }
+  }
+}
+
+# Create primary node pool with autoscaling
+resource "google_container_node_pool" "primary_nodes" {
+  name     = "primary-node-pool"
+  location = var.zone
+  cluster  = google_container_cluster.primary.name
+
+  # Enable autoscaling
+  autoscaling {
+    min_node_count = 1
+    max_node_count = 5
+  }
+
+  # Node configuration
+  node_config {
+    machine_type = "e2-medium"
+
+    service_account = google_service_account.gke_sa.email
+    oauth_scopes = [
+      "https://www.googleapis.com/auth/cloud-platform"
+    ]
+
+    labels = {
+      env = "production"
+    }
+
+    tags = ["gke-node"]
+  }
+
+  # Management configuration
+  management {
+    auto_repair  = true
+    auto_upgrade = true
+  }
+}
+
+# Create spot instance node pool with autoscaling
+resource "google_container_node_pool" "spot_nodes" {
+  name     = "spot-node-pool"
+  location = var.zone
+  cluster  = google_container_cluster.primary.name
+
+  # Enable autoscaling
+  autoscaling {
+    min_node_count = 0
+    max_node_count = 10
+  }
+
+  # Node configuration
+  node_config {
+    machine_type = "e2-medium"
+    spot         = true
+
+    service_account = google_service_account.gke_sa.email
+    oauth_scopes = [
+      "https://www.googleapis.com/auth/cloud-platform"
+    ]
+
+    labels = {
+      env  = "production"
+      pool = "spot"
+    }
+
+    tags = ["gke-node", "spot"]
+
+    # Spot instance termination handler
+    taint {
+      key    = "cloud.google.com/gke-spot"
+      value  = "true"
+      effect = "NO_SCHEDULE"
+    }
+  }
+
+  # Management configuration
+  management {
+    auto_repair  = true
+    auto_upgrade = true
+  }
+}

--- a/spartan/terraform/gke-cluster/main.tf
+++ b/spartan/terraform/gke-cluster/main.tf
@@ -107,7 +107,7 @@ resource "google_container_node_pool" "primary_nodes" {
 
   # Node configuration
   node_config {
-    machine_type = "n1-standard-16"
+    machine_type = "t2d-standard-16"
 
     service_account = google_service_account.gke_sa.email
     oauth_scopes = [
@@ -142,7 +142,7 @@ resource "google_container_node_pool" "spot_nodes" {
 
   # Node configuration
   node_config {
-    machine_type = "n1-standard-16"
+    machine_type = "t2d-standard-16"
     spot         = true
 
     service_account = google_service_account.gke_sa.email

--- a/spartan/terraform/gke-cluster/main.tf
+++ b/spartan/terraform/gke-cluster/main.tf
@@ -14,7 +14,7 @@ terraform {
 
 # Configure the Google Cloud provider
 provider "google" {
-  project = "testnet-440309"
+  project = var.project
   region  = var.region
 }
 
@@ -34,7 +34,7 @@ resource "google_project_iam_member" "gke_sa_roles" {
     "roles/artifactregistry.reader"
   ])
 
-  project = "testnet-440309"
+  project = var.project
   role    = each.key
   member  = "serviceAccount:${google_service_account.gke_sa.email}"
 }

--- a/spartan/terraform/gke-cluster/outputs.tf
+++ b/spartan/terraform/gke-cluster/outputs.tf
@@ -1,9 +1,7 @@
-# Output the cluster endpoint
 output "cluster_endpoint" {
   value = google_container_cluster.primary.endpoint
 }
 
-# Output the service account email
 output "service_account_email" {
   value = google_service_account.gke_sa.email
 }

--- a/spartan/terraform/gke-cluster/outputs.tf
+++ b/spartan/terraform/gke-cluster/outputs.tf
@@ -7,3 +7,13 @@ output "cluster_endpoint" {
 output "service_account_email" {
   value = google_service_account.gke_sa.email
 }
+
+output "region" {
+  description = "Google cloud region"
+  value       = var.region
+}
+
+output "kubernetes_cluster_name" {
+  description = "GKE Cluster Name"
+  value       = google_container_cluster.primary.name
+}

--- a/spartan/terraform/gke-cluster/outputs.tf
+++ b/spartan/terraform/gke-cluster/outputs.tf
@@ -1,0 +1,9 @@
+# Output the cluster endpoint
+output "cluster_endpoint" {
+  value = google_container_cluster.primary.endpoint
+}
+
+# Output the service account email
+output "service_account_email" {
+  value = google_service_account.gke_sa.email
+}

--- a/spartan/terraform/gke-cluster/variables.tf
+++ b/spartan/terraform/gke-cluster/variables.tf
@@ -1,0 +1,7 @@
+variable "region" {
+  default = "us-east4"
+}
+
+variable "zone" {
+  default = "us-east4-a"
+}

--- a/spartan/terraform/gke-cluster/variables.tf
+++ b/spartan/terraform/gke-cluster/variables.tf
@@ -1,3 +1,7 @@
+variable "project" {
+  default = "testnet-440309"
+}
+
 variable "region" {
   default = "us-east4"
 }


### PR DESCRIPTION
# Change Log

fixes: #9821 

- **New Google Kubernetes Engine Cluster**
New cluster includes regular and spot instance node pools, as well as required firewall rules for ingress and egress on ports `40400-40499`.

- **Additional security group for existing AWS Kubernetes Cluster**
Security group added to Kubernetes cluster to permit ingress and egress of ports 40400-40499.