### PR TITLE
fix: aztec-up incorrect URL

### DIFF
--- a/aztec-up/bin/aztec-up
+++ b/aztec-up/bin/aztec-up
@@ -4,10 +4,6 @@ set -euo pipefail
 export VERSION=${1:-${VERSION:-}}
 export NON_INTERACTIVE=1
 
-if [ -n "$VERSION" ] && [ "$VERSION" != "latest" ]; then
-  INSTALL_URL="https://install.aztec.network/$VERSION/aztec-install"
-else
-  INSTALL_URL="https://install.aztec.network/aztec-install"
-fi
+INSTALL_URL="https://install.aztec.network/aztec-install"
 
-bash -i <(curl -s $INSTALL_URL)
+VERSION=$VERSION bash -i <(curl -s $INSTALL_URL)

--- a/yarn-project/yarn.lock
+++ b/yarn-project/yarn.lock
@@ -3512,6 +3512,7 @@ __metadata:
     "@noir-lang/acvm_js": 0.54.0
     "@noir-lang/noirc_abi": 0.38.0
     "@noir-lang/types": 0.38.0
+  checksum: 99cdc1f1e352d45a8968261dc7f1d68d58b5bca8177e25c610667eb60954436356c56852e6a23fbf69ddb8db9b92494736438c0852f4702d33e8d0e981e60552
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
There is no script at `https://install.aztec.network/master/aztec-install` only at `https://install.aztec.network/aztec-install` and it seems to me that we should always download that script and instead pass the version to that script.