### PR TITLE
chore(ci): run noir tests in parallel to building e2e tests

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -504,7 +504,7 @@ jobs:
         run: earthly-ci --no-output ./+barretenberg-acir-tests-bb.js
 
   noir-format:
-    needs: [build, configure]
+    needs: [build-images, configure]
     runs-on: ${{ needs.configure.outputs.username }}-x86
     if: needs.configure.outputs.noir == 'true' || needs.configure.outputs.noir-projects == 'true'
     steps:
@@ -524,7 +524,7 @@ jobs:
           earthly-ci --no-output ./+format
 
   noir-test:
-    needs: [build, configure]
+    needs: [build-images, configure]
     runs-on: ${{ needs.configure.outputs.username }}-x86
     if: needs.configure.outputs.noir == 'true'
     steps:
@@ -537,6 +537,7 @@ jobs:
         run: earthly-ci --no-output ./noir+test
 
   noir-examples:
+    # We delay this job until after the `build` job has completed as it depends on bb being built.
     needs: [build, configure]
     runs-on: ${{ needs.configure.outputs.username }}-x86
     if: needs.configure.outputs.noir == 'true'
@@ -550,6 +551,7 @@ jobs:
         run: earthly-ci --no-output ./noir+examples
 
   noir-packages-test:
+    # We delay this job until after the `build` job has completed as it depends on bb.js being built.
     needs: [build, configure]
     runs-on: ${{ needs.configure.outputs.username }}-x86
     if: needs.configure.outputs.barretenberg == 'true' || needs.configure.outputs.noir == 'true'

--- a/noir/noir-repo/docs/versioned_docs/version-v0.36.0/getting_started/quick_start.md
+++ b/noir/noir-repo/docs/versioned_docs/version-v0.36.0/getting_started/quick_start.md
@@ -66,6 +66,7 @@ We can now use `nargo` to generate a _Prover.toml_ file, where our input values 
 ```sh
 cd hello_world
 nargo check
+```
 
 Let's feed some valid values into this file:
 
@@ -87,7 +88,7 @@ The command also automatically compiles your Noir program if it was not already 
 With circuit compiled and witness generated, we're ready to prove.
 
 ## Proving backend
- 
+
 Different proving backends may provide different tools and commands to work with Noir programs. Here Barretenberg's `bb` CLI tool is used as an example:
 
 ```sh

--- a/noir/noir-repo/docs/versioned_docs/version-v0.37.0/getting_started/quick_start.md
+++ b/noir/noir-repo/docs/versioned_docs/version-v0.37.0/getting_started/quick_start.md
@@ -66,6 +66,7 @@ We can now use `nargo` to generate a _Prover.toml_ file, where our input values 
 ```sh
 cd hello_world
 nargo check
+```
 
 Let's feed some valid values into this file:
 
@@ -87,7 +88,7 @@ The command also automatically compiles your Noir program if it was not already 
 With circuit compiled and witness generated, we're ready to prove.
 
 ## Proving backend
- 
+
 Different proving backends may provide different tools and commands to work with Noir programs. Here Barretenberg's `bb` CLI tool is used as an example:
 
 ```sh

--- a/noir/noir-repo/docs/versioned_docs/version-v0.38.0/getting_started/quick_start.md
+++ b/noir/noir-repo/docs/versioned_docs/version-v0.38.0/getting_started/quick_start.md
@@ -68,6 +68,7 @@ We can now use `nargo` to generate a _Prover.toml_ file, where our input values 
 ```sh
 cd hello_world
 nargo check
+```
 
 Let's feed some valid values into this file:
 
@@ -89,7 +90,7 @@ The command also automatically compiles your Noir program if it was not already 
 With circuit compiled and witness generated, we're ready to prove.
 
 ## Proving backend
- 
+
 Different proving backends may provide different tools and commands to work with Noir programs. Here Barretenberg's `bb` CLI tool is used as an example:
 
 ```sh


### PR DESCRIPTION
I think it's worth running these two tests in parallel with building the main e2e images.

From what I remember, the justification why we gate everything based on `build` is to avoid having N different jobs fighting over building various earthly targets slowing everything down:

`noir-test`: This doesn't share any steps past `build-images` except for `+nargo-src` so it's almost entirely separate to the main `build` step.
`noir-format`: This job shares the `+nargo` and the `noir-projects+source` steps which are both very early in the pipeline. I think the benefit of flagging up potential formatting issues 20mins earlier is worth the small amount of overlap.

That said `noir-projects+source` currently relies on a bb build which is very odd. I'd want to move that to a later step in order to avoid depending on bb.