### PR TITLE
feat: compute base-fee on l1

### DIFF
--- a/l1-contracts/src/core/libraries/FeeMath.sol
+++ b/l1-contracts/src/core/libraries/FeeMath.sol
@@ -28,6 +28,13 @@ library FeeMath {
   uint256 internal constant MAX_FEE_ASSET_PRICE_MODIFIER = 1000000000;
   uint256 internal constant FEE_ASSET_PRICE_UPDATE_FRACTION = 100000000000;
 
+  uint256 internal constant L1_GAS_PER_BLOCK_PROPOSED = 150000;
+  uint256 internal constant L1_GAS_PER_EPOCH_VERIFIED = 1000000;
+
+  uint256 internal constant MINIMUM_CONGESTION_MULTIPLIER = 1000000000;
+  uint256 internal constant MANA_TARGET = 100000000;
+  uint256 internal constant CONGESTION_UPDATE_FRACTION = 854700854;
+
   function assertValid(OracleInput memory _self) internal pure returns (bool) {
     require(
       SignedMath.abs(_self.provingCostModifier) <= MAX_PROVING_COST_MODIFIER,
@@ -68,6 +75,10 @@ library FeeMath {
 
   function feeAssetPriceModifier(uint256 _numerator) internal pure returns (uint256) {
     return fakeExponential(MINIMUM_FEE_ASSET_PRICE, _numerator, FEE_ASSET_PRICE_UPDATE_FRACTION);
+  }
+
+  function congestionMultiplier(uint256 _numerator) internal pure returns (uint256) {
+    return fakeExponential(MINIMUM_CONGESTION_MULTIPLIER, _numerator, CONGESTION_UPDATE_FRACTION);
   }
 
   /**

--- a/l1-contracts/test/base/Base.sol
+++ b/l1-contracts/test/base/Base.sol
@@ -147,6 +147,15 @@ contract TestBase is Test {
     }
   }
 
+  function assertEq(uint256 a, Slot b) internal {
+    if (Slot.wrap(a) != b) {
+      emit log("Error: a == b not satisfied [Slot]");
+      emit log_named_uint("      Left", a);
+      emit log_named_uint("     Right", b.unwrap());
+      fail();
+    }
+  }
+
   function assertEq(Slot a, uint256 b) internal {
     if (a != Slot.wrap(b)) {
       emit log("Error: a == b not satisfied [Slot]");
@@ -158,6 +167,13 @@ contract TestBase is Test {
 
   function assertEq(Slot a, Slot b, string memory err) internal {
     if (a != b) {
+      emit log_named_string("Error", err);
+      assertEq(a, b);
+    }
+  }
+
+  function assertEq(uint256 a, Slot b, string memory err) internal {
+    if (Slot.wrap(a) != b) {
       emit log_named_string("Error", err);
       assertEq(a, b);
     }

--- a/l1-contracts/test/fees/FeeModelTestPoints.t.sol
+++ b/l1-contracts/test/fees/FeeModelTestPoints.t.sol
@@ -4,6 +4,7 @@
 pragma solidity >=0.8.27;
 
 import {TestBase} from "../base/Base.sol";
+import {OracleInput as FeeMathOracleInput} from "@aztec/core/libraries/FeeMath.sol";
 
 // Remember that foundry json parsing is alphabetically done, so you MUST
 // sort the struct fields alphabetically or prepare for a headache.
@@ -95,5 +96,49 @@ contract FeeModelTestPoints is TestBase {
     for (uint256 i = 0; i < data.points.length; i++) {
       points.push(data.points[i]);
     }
+  }
+
+  function assertEq(L1Fees memory a, L1Fees memory b) internal pure {
+    assertEq(a.base_fee, b.base_fee, "base_fee mismatch");
+    assertEq(a.blob_fee, b.blob_fee, "blob_fee mismatch");
+  }
+
+  function assertEq(L1Fees memory a, L1Fees memory b, string memory _message) internal pure {
+    assertEq(a.base_fee, b.base_fee, string.concat(_message, "base_fee mismatch"));
+    assertEq(a.blob_fee, b.blob_fee, string.concat(_message, "blob_fee mismatch"));
+  }
+
+  function assertEq(L1GasOracleValues memory a, L1GasOracleValues memory b) internal pure {
+    assertEq(a.post, b.post, "post ");
+    assertEq(a.pre, b.pre, "pre ");
+    assertEq(a.slot_of_change, b.slot_of_change, "slot_of_change mismatch");
+  }
+
+  function assertEq(OracleInput memory a, FeeMathOracleInput memory b) internal pure {
+    assertEq(
+      a.fee_asset_price_modifier, b.feeAssetPriceModifier, "fee_asset_price_modifier mismatch"
+    );
+    assertEq(a.proving_cost_modifier, b.provingCostModifier, "proving_cost_modifier mismatch");
+  }
+
+  function assertEq(FeeHeader memory a, FeeHeader memory b) internal pure {
+    assertEq(a.excess_mana, b.excess_mana, "excess_mana mismatch");
+    assertEq(
+      a.fee_asset_price_numerator, b.fee_asset_price_numerator, "fee_asset_price_numerator mismatch"
+    );
+    assertEq(a.mana_used, b.mana_used, "mana_used mismatch");
+    assertEq(
+      a.proving_cost_per_mana_numerator,
+      b.proving_cost_per_mana_numerator,
+      "proving_cost_per_mana_numerator mismatch"
+    );
+  }
+
+  function assertEq(ManaBaseFeeComponents memory a, ManaBaseFeeComponents memory b) internal pure {
+    assertEq(a.congestion_cost, b.congestion_cost, "congestion_cost mismatch");
+    assertEq(a.congestion_multiplier, b.congestion_multiplier, "congestion_multiplier mismatch");
+    assertEq(a.data_cost, b.data_cost, "data_cost mismatch");
+    assertEq(a.gas_cost, b.gas_cost, "gas_cost mismatch");
+    assertEq(a.proving_cost, b.proving_cost, "proving_cost mismatch");
   }
 }

--- a/l1-contracts/test/fees/MinimalFeeModel.sol
+++ b/l1-contracts/test/fees/MinimalFeeModel.sol
@@ -23,6 +23,9 @@ contract MinimalFeeModel is TimeFns {
   // with the block.blobbasefee value if using cheatcodes to alter it.
   Vm internal constant VM = Vm(address(uint160(uint256(keccak256("hevm cheat code")))));
 
+  uint256 internal constant BLOB_GAS_PER_BLOB = 2 ** 17;
+  uint256 internal constant GAS_PER_BLOB_POINT_EVALUATION = 50_000;
+
   Slot public constant LIFETIME = Slot.wrap(5);
   Slot public constant LAG = Slot.wrap(2);
   Timestamp public immutable GENESIS_TIMESTAMP;
@@ -57,11 +60,12 @@ contract MinimalFeeModel is TimeFns {
     returns (ManaBaseFeeComponents memory)
   {
     L1Fees memory fees = getCurrentL1Fees();
-    uint256 dataCost =
-      Math.mulDiv(_blobsUsed * 2 ** 17, fees.blob_fee, FeeMath.MANA_TARGET, Math.Rounding.Ceil);
-    uint256 casUsed = FeeMath.L1_GAS_PER_BLOCK_PROPOSED + _blobsUsed * 50_000
+    uint256 dataCost = Math.mulDiv(
+      _blobsUsed * BLOB_GAS_PER_BLOB, fees.blob_fee, FeeMath.MANA_TARGET, Math.Rounding.Ceil
+    );
+    uint256 gasUsed = FeeMath.L1_GAS_PER_BLOCK_PROPOSED + _blobsUsed * GAS_PER_BLOB_POINT_EVALUATION
       + FeeMath.L1_GAS_PER_EPOCH_VERIFIED / EPOCH_DURATION;
-    uint256 gasCost = Math.mulDiv(casUsed, fees.base_fee, FeeMath.MANA_TARGET, Math.Rounding.Ceil);
+    uint256 gasCost = Math.mulDiv(gasUsed, fees.base_fee, FeeMath.MANA_TARGET, Math.Rounding.Ceil);
     uint256 provingCost = getProvingCost();
 
     uint256 congestionMultiplier = FeeMath.congestionMultiplier(calcExcessMana());


### PR DESCRIPTION
Fixes #9804.

Changes the structure slightly to just use the same `struct`s as json input is loaded in. Adds a "full" test that is checking that all our outputs are as expected, so computing base fees in both eth and fee asset etc. Having the json fixtures for test vectors is amazing.