### PR TITLE
Fix string comparison operator in Bash script Update attach_ebs_cache.sh

### DIFF
--- a/scripts/ci/attach_ebs_cache.sh
+++ b/scripts/ci/attach_ebs_cache.sh
@@ -77,7 +77,7 @@ if mount | grep -q "/var/lib/docker type ext4"; then
 fi
 
 # If no existing volume, create one
-if [ "$EXISTING_VOLUME" == "None" ]; then
+if [ "$EXISTING_VOLUME" = "None" ]; then
   VOLUME_ID=$(aws ec2 create-volume \
     --region $REGION \
     --availability-zone $AVAILABILITY_ZONE \


### PR DESCRIPTION
#### Problem:
In the Bash script, the following line uses a non-standard string comparison operator:

```bash
if [ "$EXISTING_VOLUME" == "None" ]; then
```

While the `==` operator may work in certain Bash environments, it is not POSIX-compliant and may fail in other shell interpreters like `dash` or older versions of `bash`. The POSIX standard requires the use of the single equals operator (`=`) for string comparison.

#### Why This Matters:
1. **Portability:** Using `=` ensures the script runs correctly across all POSIX-compliant shells, not just `bash`.
2. **Reliability:** Avoids potential issues when the script is executed in environments where `sh` is linked to an interpreter like `dash` (common on Debian-based systems).
3. **Best Practices:** Adhering to POSIX standards makes the script more maintainable and robust.

#### Solution:
The problematic line has been updated to use the correct operator:

```bash
if [ "$EXISTING_VOLUME" = "None" ]; then
```

This change ensures compatibility and aligns the script with Bash and POSIX conventions.

---

### Testing:
- Verified that the script functions as expected in both `bash` and `sh` environments after the change.
- Confirmed that the updated condition properly handles the case where `$EXISTING_VOLUME` equals `"None"`.

---

### Impact:
This is a minor but crucial fix to ensure the script works in a broader range of environments without unexpected failures.