### PR TITLE
fix: don't take down runners with faulty runner check

### DIFF
--- a/.github/spot-runner-action/src/main.ts
+++ b/.github/spot-runner-action/src/main.ts
@@ -23,10 +23,11 @@ async function pollSpotStatus(
     }
     try {
       core.info("Found ec2 instance, looking for runners.");
-      if (process.env.WAIT_FOR_RUNNERS === "false" || await ghClient.hasRunner([config.githubJobId])) {
+      // TODO find out whatever happened here but we seem to not be able to wait for runners
+      //if (process.env.WAIT_FOR_RUNNERS === "false" || await ghClient.hasRunner([config.githubJobId])) {
         // we have runners
         return instances[0].InstanceId!;
-      }
+      //}
     } catch (err) {}
     // wait 10 seconds
     await new Promise((r) => setTimeout(r, 10000));


### PR DESCRIPTION
Things work technically but this will cause interference unless merged
