### PR TITLE
chore(ci): run `l1-contracts` CI in parallel with `build` step

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -752,7 +752,7 @@ jobs:
           path: network-test.log
 
   l1-contracts-test:
-    needs: [build, configure]
+    needs: [build-images, configure]
     runs-on: ${{ needs.configure.outputs.username }}-x86
     if: needs.configure.outputs.l1-contracts == 'true'
     steps:


### PR DESCRIPTION
There's no real reason to wait until the `build` step has completed to run the `l1-contracts` tests afaict as the `build` step doesn't impact `l1-contracts`.