### PR TITLE
chore: remove duplicate and unused flavor related concepts

### DIFF
--- a/barretenberg/cpp/src/barretenberg/flavor/flavor.hpp
+++ b/barretenberg/cpp/src/barretenberg/flavor/flavor.hpp
@@ -357,13 +357,7 @@ template <typename T>
 concept IsPlonkFlavor = IsAnyOf<T, plonk::flavor::Standard, plonk::flavor::Ultra>;
 
 template <typename T>
-concept IsUltraPlonkFlavor = IsAnyOf<T, plonk::flavor::Ultra, UltraKeccakFlavor>;
-
-template <typename T>
 concept IsUltraPlonkOrHonk = IsAnyOf<T, plonk::flavor::Ultra, UltraFlavor, UltraKeccakFlavor, UltraFlavorWithZK, MegaFlavor, MegaZKFlavor>;
-
-template <typename T>
-concept IsHonkFlavor = IsAnyOf<T, UltraFlavor, UltraKeccakFlavor, UltraFlavorWithZK, MegaFlavor, MegaZKFlavor>;
 
 template <typename T>
 concept IsUltraFlavor = IsAnyOf<T, UltraFlavor, UltraKeccakFlavor, UltraFlavorWithZK, MegaFlavor, MegaZKFlavor>;
@@ -400,7 +394,6 @@ AvmRecursiveFlavor_<UltraCircuitBuilder>>;
 template <typename T> concept IsECCVMRecursiveFlavor = IsAnyOf<T, ECCVMRecursiveFlavor_<UltraCircuitBuilder>>;
 
 
-template <typename T> concept IsGrumpkinFlavor = IsAnyOf<T, ECCVMFlavor>;
 
 template <typename T> concept IsFoldingFlavor = IsAnyOf<T, UltraFlavor,
                                                            // Note(md): must be here to use oink prover

--- a/barretenberg/cpp/src/barretenberg/plonk_honk_shared/composer/permutation_lib.hpp
+++ b/barretenberg/cpp/src/barretenberg/plonk_honk_shared/composer/permutation_lib.hpp
@@ -154,7 +154,7 @@ PermutationMapping<Flavor::NUM_WIRES, generalized> compute_permutation_mapping(
     const auto num_public_inputs = static_cast<uint32_t>(circuit_constructor.public_inputs.size());
 
     size_t pub_inputs_offset = 0;
-    if constexpr (IsHonkFlavor<Flavor>) {
+    if constexpr (IsUltraFlavor<Flavor>) {
         pub_inputs_offset = proving_key->pub_inputs_offset;
     }
     for (size_t i = 0; i < num_public_inputs; ++i) {
@@ -374,7 +374,7 @@ void compute_permutation_argument_polynomials(const typename Flavor::CircuitBuil
                                               typename Flavor::ProvingKey* key,
                                               const std::vector<CyclicPermutation>& copy_cycles)
 {
-    constexpr bool generalized = IsUltraPlonkFlavor<Flavor> || IsUltraFlavor<Flavor>;
+    constexpr bool generalized = IsUltraPlonkOrHonk<Flavor>;
     auto mapping = compute_permutation_mapping<Flavor, generalized>(circuit, key, copy_cycles);
 
     if constexpr (IsPlonkFlavor<Flavor>) { // any Plonk flavor

--- a/barretenberg/cpp/src/barretenberg/stdlib/honk_verifier/decider_recursive_verifier.cpp
+++ b/barretenberg/cpp/src/barretenberg/stdlib/honk_verifier/decider_recursive_verifier.cpp
@@ -45,9 +45,7 @@ std::array<typename Flavor::GroupElement, 2> DeciderRecursiveVerifier_<Flavor>::
     return pairing_points;
 }
 
-template class DeciderRecursiveVerifier_<bb::UltraRecursiveFlavor_<UltraCircuitBuilder>>;
 template class DeciderRecursiveVerifier_<bb::MegaRecursiveFlavor_<MegaCircuitBuilder>>;
-template class DeciderRecursiveVerifier_<bb::UltraRecursiveFlavor_<MegaCircuitBuilder>>;
 template class DeciderRecursiveVerifier_<bb::MegaRecursiveFlavor_<UltraCircuitBuilder>>;
 template class DeciderRecursiveVerifier_<bb::UltraRecursiveFlavor_<CircuitSimulatorBN254>>;
 template class DeciderRecursiveVerifier_<bb::MegaRecursiveFlavor_<CircuitSimulatorBN254>>;

--- a/barretenberg/cpp/src/barretenberg/trace_to_polynomials/trace_to_polynomials.cpp
+++ b/barretenberg/cpp/src/barretenberg/trace_to_polynomials/trace_to_polynomials.cpp
@@ -37,7 +37,7 @@ void TraceToPolynomials<Flavor>::populate(Builder& builder,
     // data
     auto trace_data = construct_trace_data(builder, proving_key, is_structured);
 
-    if constexpr (IsHonkFlavor<Flavor>) {
+    if constexpr (IsUltraFlavor<Flavor>) {
         proving_key.pub_inputs_offset = trace_data.pub_inputs_offset;
     }
     if constexpr (IsUltraPlonkOrHonk<Flavor>) {
@@ -101,7 +101,7 @@ typename TraceToPolynomials<Flavor>::TraceData TraceToPolynomials<Flavor>::const
         auto block_size = static_cast<uint32_t>(block.size());
 
         // Save ranges over which the blocks are "active" for use in structured commitments
-        if constexpr (IsHonkFlavor<Flavor>) {
+        if constexpr (IsUltraFlavor<Flavor>) {
             if (block.size() > 0) {
                 proving_key.active_block_ranges.emplace_back(offset, offset + block.size());
             }

--- a/barretenberg/cpp/src/barretenberg/trace_to_polynomials/trace_to_polynomials.hpp
+++ b/barretenberg/cpp/src/barretenberg/trace_to_polynomials/trace_to_polynomials.hpp
@@ -31,7 +31,7 @@ template <class Flavor> class TraceToPolynomials {
 
             PROFILE_THIS_NAME("TraceData constructor");
 
-            if constexpr (IsHonkFlavor<Flavor>) {
+            if constexpr (IsUltraFlavor<Flavor>) {
                 // Initialize and share the wire and selector polynomials
                 for (auto [wire, other_wire] : zip_view(wires, proving_key.polynomials.get_wires())) {
                     wire = other_wire.share();

--- a/barretenberg/cpp/src/barretenberg/ultra_honk/decider_proving_key.cpp
+++ b/barretenberg/cpp/src/barretenberg/ultra_honk/decider_proving_key.cpp
@@ -11,7 +11,7 @@ namespace bb {
  * @tparam Flavor
  * @param circuit
  */
-template <IsHonkFlavor Flavor> size_t DeciderProvingKey_<Flavor>::compute_dyadic_size(Circuit& circuit)
+template <IsUltraFlavor Flavor> size_t DeciderProvingKey_<Flavor>::compute_dyadic_size(Circuit& circuit)
 {
     // for the lookup argument the circuit size must be at least as large as the sum of all tables used
     const size_t min_size_due_to_lookups = circuit.get_tables_size();
@@ -37,7 +37,7 @@ template <IsHonkFlavor Flavor> size_t DeciderProvingKey_<Flavor>::compute_dyadic
  * @tparam Flavor
  * @param circuit
  */
-template <IsHonkFlavor Flavor>
+template <IsUltraFlavor Flavor>
 void DeciderProvingKey_<Flavor>::construct_databus_polynomials(Circuit& circuit)
     requires IsMegaFlavor<Flavor>
 {
@@ -96,7 +96,7 @@ void DeciderProvingKey_<Flavor>::construct_databus_polynomials(Circuit& circuit)
  * @tparam Flavor
  * @param circuit
  */
-template <IsHonkFlavor Flavor>
+template <IsUltraFlavor Flavor>
 void DeciderProvingKey_<Flavor>::move_structured_trace_overflow_to_overflow_block(Circuit& circuit)
 {
     auto& blocks = circuit.blocks;

--- a/barretenberg/cpp/src/barretenberg/ultra_honk/decider_proving_key.hpp
+++ b/barretenberg/cpp/src/barretenberg/ultra_honk/decider_proving_key.hpp
@@ -20,7 +20,7 @@ namespace bb {
  * @details This is the equivalent of ω in the paper.
  */
 
-template <IsHonkFlavor Flavor> class DeciderProvingKey_ {
+template <IsUltraFlavor Flavor> class DeciderProvingKey_ {
     using Circuit = typename Flavor::CircuitBuilder;
     using ProvingKey = typename Flavor::ProvingKey;
     using VerificationKey = typename Flavor::VerificationKey;
@@ -186,7 +186,7 @@ template <IsHonkFlavor Flavor> class DeciderProvingKey_ {
                     ASSERT(dyadic_circuit_size > max_tables_size);
 
                     // Allocate the table polynomials
-                    if constexpr (IsHonkFlavor<Flavor>) {
+                    if constexpr (IsUltraFlavor<Flavor>) {
                         for (auto& poly : proving_key.polynomials.get_tables()) {
                             poly = typename Flavor::Polynomial(max_tables_size, dyadic_circuit_size, table_offset);
                         }


### PR DESCRIPTION
We had two duplicate concepts pointing to the same set of types as well as some unused instantiations (we are not folding Ultra keys).