### PR TITLE
fix: fix npm publishing

### DIFF
--- a/.github/workflows/publish-aztec-packages.yml
+++ b/.github/workflows/publish-aztec-packages.yml
@@ -287,8 +287,8 @@ jobs:
             --DIST_TAG=latest \
             --VERSION=$VERSION \
             --DRY_RUN=${{ (github.event.inputs.publish == 'false') && '1' || '0' }}
-      - name: Publish yarn-project NPM packages
 
+      - name: Publish yarn-project NPM packages
         run: |
           DEPLOY_TAG=${{ env.DEPLOY_TAG }}
           VERSION=${DEPLOY_TAG#aztec-packages-v}

--- a/.github/workflows/publish-aztec-packages.yml
+++ b/.github/workflows/publish-aztec-packages.yml
@@ -287,6 +287,7 @@ jobs:
             --DIST_TAG=latest \
             --VERSION=$VERSION \
             --DRY_RUN=${{ (github.event.inputs.publish == 'false') && '1' || '0' }}
+      
       - name: Publish yarn-project NPM packages
         run: |
           DEPLOY_TAG=${{ env.DEPLOY_TAG }}

--- a/.github/workflows/publish-aztec-packages.yml
+++ b/.github/workflows/publish-aztec-packages.yml
@@ -287,7 +287,6 @@ jobs:
             --DIST_TAG=latest \
             --VERSION=$VERSION \
             --DRY_RUN=${{ (github.event.inputs.publish == 'false') && '1' || '0' }}
-      
       - name: Publish yarn-project NPM packages
         run: |
           DEPLOY_TAG=${{ env.DEPLOY_TAG }}
@@ -311,8 +310,6 @@ jobs:
             --DIST_TAG=latest \
             --VERSION=$VERSION \
             --DRY_RUN=${{ (github.event.inputs.publish == 'false') && '1' || '0' }}
-
-
 
   publish-aztec-up:
     needs: [configure, publish-manifests]

--- a/.github/workflows/publish-aztec-packages.yml
+++ b/.github/workflows/publish-aztec-packages.yml
@@ -288,6 +288,7 @@ jobs:
             --VERSION=$VERSION \
             --DRY_RUN=${{ (github.event.inputs.publish == 'false') && '1' || '0' }}
       - name: Publish yarn-project NPM packages
+
         run: |
           DEPLOY_TAG=${{ env.DEPLOY_TAG }}
           VERSION=${DEPLOY_TAG#aztec-packages-v}

--- a/.github/workflows/publish-aztec-packages.yml
+++ b/.github/workflows/publish-aztec-packages.yml
@@ -275,6 +275,19 @@ jobs:
         with:
           concurrency_key: publish-npm
           dockerhub_password: "${{ env.DOCKERHUB_PASSWORD }}"
+      
+      - name: Publish bb.js NPM package
+        run: |
+          DEPLOY_TAG=${{ env.DEPLOY_TAG }}
+          VERSION=${DEPLOY_TAG#aztec-packages-v}
+          earthly-ci \
+            --no-output \
+            --secret NPM_TOKEN=${{ env.NPM_TOKEN }} \
+            ./barretenberg/ts+publish-npm \
+            --DIST_TAG=latest \
+            --VERSION=$VERSION \
+            --DRY_RUN=${{ (github.event.inputs.publish == 'false') && '1' || '0' }}
+      
       - name: Publish yarn-project NPM packages
         run: |
           DEPLOY_TAG=${{ env.DEPLOY_TAG }}
@@ -290,7 +303,7 @@ jobs:
       - name: Publish l1-contracts NPM package
         run: |
           DEPLOY_TAG=${{ env.DEPLOY_TAG }}
-          VERSION=${DEPLOY_TAG#aztec-packages-v
+          VERSION=${DEPLOY_TAG#aztec-packages-v}
           earthly-ci \
             --no-output \
             --secret NPM_TOKEN=${{ env.NPM_TOKEN }} \
@@ -299,17 +312,7 @@ jobs:
             --VERSION=$VERSION \
             --DRY_RUN=${{ (github.event.inputs.publish == 'false') && '1' || '0' }}
 
-      - name: Publish bb.js NPM package
-        run: |
-          DEPLOY_TAG=${{ env.DEPLOY_TAG }}
-          VERSION=${DEPLOY_TAG#aztec-packages-v}
-          earthly-ci \
-            --no-output \
-            --secret NPM_TOKEN=${{ env.NPM_TOKEN }} \
-            ./barretenberg/ts+publish-npm \
-            --DIST_TAG=latest \
-            --VERSION=$VERSION \
-            --DRY_RUN=${{ (github.event.inputs.publish == 'false') && '1' || '0' }}
+
 
   publish-aztec-up:
     needs: [configure, publish-manifests]

--- a/.github/workflows/publish-aztec-packages.yml
+++ b/.github/workflows/publish-aztec-packages.yml
@@ -287,7 +287,6 @@ jobs:
             --DIST_TAG=latest \
             --VERSION=$VERSION \
             --DRY_RUN=${{ (github.event.inputs.publish == 'false') && '1' || '0' }}
-      
       - name: Publish yarn-project NPM packages
         run: |
           DEPLOY_TAG=${{ env.DEPLOY_TAG }}


### PR DESCRIPTION
Please read [contributing guidelines](CONTRIBUTING.md) and remove this line.
bb.js releases is broken because of a missing brace introduced in #10029 

This PR fixes this and moves bb.js to be the first thing we publish because it's the most important.