### PR TITLE
feat: sync tags as sender

### DIFF
--- a/yarn-project/pxe/src/database/kv_pxe_database.ts
+++ b/yarn-project/pxe/src/database/kv_pxe_database.ts
@@ -668,26 +668,21 @@ export class KVPxeDatabase implements PxeDatabase {
     return incomingNotesSize + outgoingNotesSize + treeRootsSize + authWitsSize + addressesSize;
   }
 
-  async incrementTaggingSecretsIndexesAsSender(appTaggingSecrets: Fr[]): Promise<void> {
-    await this.#incrementTaggingSecretsIndexes(appTaggingSecrets, this.#taggingSecretIndexesForSenders);
-  }
-
-  async #incrementTaggingSecretsIndexes(appTaggingSecrets: Fr[], storageMap: AztecMap<string, number>): Promise<void> {
-    const indexes = await this.#getTaggingSecretsIndexes(appTaggingSecrets, storageMap);
-    await this.db.transaction(() => {
-      indexes.forEach((taggingSecretIndex, listIndex) => {
-        const nextIndex = taggingSecretIndex + 1;
-        void storageMap.set(appTaggingSecrets[listIndex].toString(), nextIndex);
-      });
-    });
+  async setTaggingSecretsIndexesAsSender(indexedSecrets: IndexedTaggingSecret[]): Promise<void> {
+    await this.#setTaggingSecretsIndexes(indexedSecrets, this.#taggingSecretIndexesForSenders);
   }
 
   async setTaggingSecretsIndexesAsRecipient(indexedSecrets: IndexedTaggingSecret[]): Promise<void> {
-    await this.db.transaction(() => {
-      indexedSecrets.forEach(indexedSecret => {
-        void this.#taggingSecretIndexesForRecipients.set(indexedSecret.secret.toString(), indexedSecret.index);
-      });
-    });
+    await this.#setTaggingSecretsIndexes(indexedSecrets, this.#taggingSecretIndexesForRecipients);
+  }
+
+  #setTaggingSecretsIndexes(
+    indexedSecrets: IndexedTaggingSecret[],
+    storageMap: AztecMap<string, number>,
+  ): Promise<Promise<void>[]> {
+    return this.db.transaction(() =>
+      indexedSecrets.map(indexedSecret => storageMap.set(indexedSecret.secret.toString(), indexedSecret.index)),
+    );
   }
 
   async getTaggingSecretsIndexesAsRecipient(appTaggingSecrets: Fr[]) {

--- a/yarn-project/pxe/src/database/kv_pxe_database.ts
+++ b/yarn-project/pxe/src/database/kv_pxe_database.ts
@@ -676,13 +676,12 @@ export class KVPxeDatabase implements PxeDatabase {
     await this.#setTaggingSecretsIndexes(indexedSecrets, this.#taggingSecretIndexesForRecipients);
   }
 
-  #setTaggingSecretsIndexes(
-    indexedSecrets: IndexedTaggingSecret[],
-    storageMap: AztecMap<string, number>,
-  ): Promise<Promise<void>[]> {
-    return this.db.transaction(() =>
-      indexedSecrets.map(indexedSecret => storageMap.set(indexedSecret.secret.toString(), indexedSecret.index)),
-    );
+  #setTaggingSecretsIndexes(indexedSecrets: IndexedTaggingSecret[], storageMap: AztecMap<string, number>) {
+    return this.db.transaction(() => {
+      indexedSecrets.forEach(
+        indexedSecret => void storageMap.set(indexedSecret.secret.toString(), indexedSecret.index),
+      );
+    });
   }
 
   async getTaggingSecretsIndexesAsRecipient(appTaggingSecrets: Fr[]) {

--- a/yarn-project/pxe/src/database/pxe_database.ts
+++ b/yarn-project/pxe/src/database/pxe_database.ts
@@ -201,12 +201,7 @@ export interface PxeDatabase extends ContractArtifactDatabase, ContractInstanceD
    */
   getTaggingSecretsIndexesAsSender(appTaggingSecrets: Fr[]): Promise<number[]>;
 
-  /**
-   * Increments the index for the provided app siloed tagging secrets in the senders database
-   * To be used when the generated tags have been used as sender
-   * @param appTaggingSecrets - The app siloed tagging secrets.
-   */
-  incrementTaggingSecretsIndexesAsSender(appTaggingSecrets: Fr[]): Promise<void>;
+  setTaggingSecretsIndexesAsSender(indexedTaggingSecrets: IndexedTaggingSecret[]): Promise<void>;
 
   /**
    * Sets the index for the provided app siloed tagging secrets

--- a/yarn-project/pxe/src/database/pxe_database.ts
+++ b/yarn-project/pxe/src/database/pxe_database.ts
@@ -201,6 +201,11 @@ export interface PxeDatabase extends ContractArtifactDatabase, ContractInstanceD
    */
   getTaggingSecretsIndexesAsSender(appTaggingSecrets: Fr[]): Promise<number[]>;
 
+  /**
+   * Sets the index for the provided app siloed tagging secrets
+   * To be used when the generated tags have been "seen" as a sender
+   * @param appTaggingSecrets - The app siloed tagging secrets.
+   */
   setTaggingSecretsIndexesAsSender(indexedTaggingSecrets: IndexedTaggingSecret[]): Promise<void>;
 
   /**

--- a/yarn-project/pxe/src/simulator_oracle/index.ts
+++ b/yarn-project/pxe/src/simulator_oracle/index.ts
@@ -360,11 +360,14 @@ export class SimulatorOracle implements DBOracle {
     // We use our current empty consecutive slots from the front, as well as the previous consecutive empty slots from the back to see if we ever hit a time where there
     // is a window in which we see the combination of them to be greater than the window's size. If true, we rewind current index to the start of said window and use it.
     // Assuming two windows of 5:
-    // [0, 1, 0, 0, 0], [0, 0, 0, 1, 1]
-    // We can see that when processing the second window, the previous amount of empty slots from the back of the window (3), added with the empty elements from the front of the window (3)
+    // [0, 1, 0, 1, 0], [0, 0, 0, 0, 0]
+    // We can see that when processing the second window, the previous amount of empty slots from the back of the window (1), added with the empty elements from the front of the window (5)
     // is greater than 5 (6) and therefore we have found a window to use.
-    // We simply need to take the number of elements (10) - the size of the window (5) - the number of consecutive empty elements from the back of the last window (3) = 2;
+    // We simply need to take the number of elements (10) - the size of the window (5) - the number of consecutive empty elements from the back of the last window (1) = 4;
     // This is the first index of our desired window.
+    // Note that if we ever see a situation like so:
+    // [0, 1, 0, 1, 0], [0, 0, 0, 0, 1]
+    // This also returns the correct index (4), but this is indicative of a problem / desync. i.e. we should never have a window that has a log that exists after the window.
 
     do {
       const currentTags = [...new Array(INDEX_OFFSET)].map((_, i) => {

--- a/yarn-project/pxe/src/simulator_oracle/simulator_oracle.test.ts
+++ b/yarn-project/pxe/src/simulator_oracle/simulator_oracle.test.ts
@@ -299,8 +299,7 @@ describe('Simulator oracle', () => {
       const indexesAsSenderAfterSync = await database.getTaggingSecretsIndexesAsSender(secrets);
       expect(indexesAsSenderAfterSync).toStrictEqual([1, 1, 1, 1, 1, 2, 2, 2, 2, 2]);
 
-      // We expect getLogsByTags to be called N + 1 times, where N is the index.
-      expect(aztecNode.getLogsByTags.mock.calls.length).toBe(2 * 5 + 3 * 5);
+      expect(aztecNode.getLogsByTags.mock.calls.length).toBe(NUM_SENDERS);
     });
 
     it('should sync tagged logs with a sender index offset', async () => {

--- a/yarn-project/pxe/src/simulator_oracle/simulator_oracle.test.ts
+++ b/yarn-project/pxe/src/simulator_oracle/simulator_oracle.test.ts
@@ -143,7 +143,7 @@ describe('Simulator oracle', () => {
   describe('sync tagged logs', () => {
     const NUM_SENDERS = 10;
     const SENDER_OFFSET_WINDOW_SIZE = 10;
-    let senders: { completeAddress: CompleteAddress; ivsk: Fq }[];
+    let senders: { completeAddress: CompleteAddress; ivsk: Fq; secretKey: Fr }[];
 
     function generateMockLogs(senderOffset: number) {
       const logs: { [k: string]: TxScopedL2Log[] } = {};
@@ -231,7 +231,7 @@ describe('Simulator oracle', () => {
         const partialAddress = Fr.random();
         const address = computeAddress(keys.publicKeys, partialAddress);
         const completeAddress = new CompleteAddress(address, keys.publicKeys, partialAddress);
-        return { completeAddress, ivsk: keys.masterIncomingViewingSecretKey };
+        return { completeAddress, ivsk: keys.masterIncomingViewingSecretKey, secretKey: new Fr(index) };
       });
       for (const sender of senders) {
         await database.addContactAddress(sender.completeAddress.address);
@@ -265,6 +265,42 @@ describe('Simulator oracle', () => {
       // We should have called the node 12 times:
       // 2 times with logs (sliding the window) + 10 times with no results (window size)
       expect(aztecNode.getLogsByTags.mock.calls.length).toBe(2 + SENDER_OFFSET_WINDOW_SIZE);
+    });
+
+    it('should sync tagged logs as senders', async () => {
+      for (const sender of senders) {
+        await database.addCompleteAddress(sender.completeAddress);
+        await keyStore.addAccount(sender.secretKey, sender.completeAddress.partialAddress);
+      }
+
+      const senderOffset = 0;
+      generateMockLogs(senderOffset);
+
+      // Recompute the secrets (as recipient) to ensure indexes are updated
+      const ivsk = await keyStore.getMasterIncomingViewingSecretKey(recipient.address);
+      const secrets = senders.map(sender => {
+        const firstSenderSharedSecret = computeTaggingSecret(recipient, ivsk, sender.completeAddress.address);
+        return poseidon2Hash([firstSenderSharedSecret.x, firstSenderSharedSecret.y, contractAddress]);
+      });
+
+      const indexesAsSender = await database.getTaggingSecretsIndexesAsSender(secrets);
+      expect(indexesAsSender).toStrictEqual([0, 0, 0, 0, 0, 0, 0, 0, 0, 0]);
+
+      expect(aztecNode.getLogsByTags.mock.calls.length).toBe(0);
+
+      for (let i = 0; i < senders.length; i++) {
+        await simulatorOracle.syncTaggedLogsAsSender(
+          contractAddress,
+          senders[i].completeAddress.address,
+          recipient.address,
+        );
+      }
+
+      const indexesAsSenderAfterSync = await database.getTaggingSecretsIndexesAsSender(secrets);
+      expect(indexesAsSenderAfterSync).toStrictEqual([1, 1, 1, 1, 1, 2, 2, 2, 2, 2]);
+
+      // We expect getLogsByTags to be called N + 1 times, where N is the index.
+      expect(aztecNode.getLogsByTags.mock.calls.length).toBe(2 * 5 + 3 * 5);
     });
 
     it('should sync tagged logs with a sender index offset', async () => {

--- a/yarn-project/pxe/src/simulator_oracle/simulator_oracle.test.ts
+++ b/yarn-project/pxe/src/simulator_oracle/simulator_oracle.test.ts
@@ -304,7 +304,7 @@ describe('Simulator oracle', () => {
       aztecNode.getLogsByTags.mockReset();
 
       // We add more logs at the end of the window to make sure we only detect them and bump the indexes if it lies within our window
-      senderOffset = 11;
+      senderOffset = 10;
       generateMockLogs(senderOffset);
       for (let i = 0; i < senders.length; i++) {
         await simulatorOracle.syncTaggedLogsAsSender(
@@ -315,7 +315,7 @@ describe('Simulator oracle', () => {
       }
 
       indexesAsSenderAfterSync = await database.getTaggingSecretsIndexesAsSender(secrets);
-      expect(indexesAsSenderAfterSync).toStrictEqual([1, 1, 1, 1, 1, 13, 13, 13, 13, 13]);
+      expect(indexesAsSenderAfterSync).toStrictEqual([11, 11, 11, 11, 11, 12, 12, 12, 12, 12]);
 
       expect(aztecNode.getLogsByTags.mock.calls.length).toBe(NUM_SENDERS * 2);
     });

--- a/yarn-project/txe/src/oracle/txe_oracle.ts
+++ b/yarn-project/txe/src/oracle/txe_oracle.ts
@@ -773,8 +773,9 @@ export class TXE implements TypedOracle {
   }
 
   async incrementAppTaggingSecretIndexAsSender(sender: AztecAddress, recipient: AztecAddress): Promise<void> {
-    const directionalSecret = await this.#calculateTaggingSecret(this.contractAddress, sender, recipient);
-    await this.txeDatabase.incrementTaggingSecretsIndexesAsSender([directionalSecret]);
+    const appSecret = await this.#calculateTaggingSecret(this.contractAddress, sender, recipient);
+    const [index] = await this.txeDatabase.getTaggingSecretsIndexesAsSender([appSecret]);
+    await this.txeDatabase.setTaggingSecretsIndexesAsSender([new IndexedTaggingSecret(appSecret, index + 1)]);
   }
 
   async getAppTaggingSecretAsSender(sender: AztecAddress, recipient: AztecAddress): Promise<IndexedTaggingSecret> {


### PR DESCRIPTION
This PR enables simple multi-device support by simply syncing the tagging secret indexes when fetching calculating the tag latest tag to use as a sender. The calculated tag uses the largest found index (recent), whether it be from on device, or from remote.

Resolves #9762.
