### PR TITLE
fix: Allow unwinding multiple empty blocks

### DIFF
--- a/yarn-project/archiver/src/archiver/archiver_store_test_suite.ts
+++ b/yarn-project/archiver/src/archiver/archiver_store_test_suite.ts
@@ -38,12 +38,18 @@ export function describeArchiverDataStore(testName: string, getStore: () => Arch
       [5, 2, () => blocks.slice(4, 6)],
     ];
 
+    const makeL1Published = (block: L2Block, l1BlockNumber: number): L1Published<L2Block> => ({
+      data: block,
+      l1: {
+        blockNumber: BigInt(l1BlockNumber),
+        blockHash: `0x${l1BlockNumber}`,
+        timestamp: BigInt(l1BlockNumber * 1000),
+      },
+    });
+
     beforeEach(() => {
       store = getStore();
-      blocks = times(10, i => ({
-        data: L2Block.random(i + 1),
-        l1: { blockNumber: BigInt(i + 10), blockHash: `0x${i}`, timestamp: BigInt(i * 1000) },
-      }));
+      blocks = times(10, i => makeL1Published(L2Block.random(i + 1), i + 10));
     });
 
     describe('addBlocks', () => {
@@ -68,6 +74,21 @@ export function describeArchiverDataStore(testName: string, getStore: () => Arch
 
         expect(await store.getSynchedL2BlockNumber()).toBe(blockNumber - 1);
         expect(await store.getBlocks(blockNumber, 1)).toEqual([]);
+      });
+
+      it('can unwind multiple empty blocks', async () => {
+        const emptyBlocks = times(10, i => makeL1Published(L2Block.random(i + 1, 0), i + 10));
+        await store.addBlocks(emptyBlocks);
+        expect(await store.getSynchedL2BlockNumber()).toBe(10);
+
+        await store.unwindBlocks(10, 3);
+        expect(await store.getSynchedL2BlockNumber()).toBe(7);
+        expect((await store.getBlocks(1, 10)).map(b => b.data.number)).toEqual([1, 2, 3, 4, 5, 6, 7]);
+      });
+
+      it('refuses to unwind blocks if the tip is not the last block', async () => {
+        await store.addBlocks(blocks);
+        await expect(store.unwindBlocks(5, 1)).rejects.toThrow(/can only unwind blocks from the tip/i);
       });
     });
 

--- a/yarn-project/archiver/src/archiver/memory_archiver_store/memory_archiver_store.ts
+++ b/yarn-project/archiver/src/archiver/memory_archiver_store/memory_archiver_store.ts
@@ -201,7 +201,7 @@ export class MemoryArchiverStore implements ArchiverDataStore {
   public async unwindBlocks(from: number, blocksToUnwind: number): Promise<boolean> {
     const last = await this.getSynchedL2BlockNumber();
     if (from != last) {
-      throw new Error(`Can only remove the tip`);
+      throw new Error(`Can only unwind blocks from the tip (requested ${from} but current tip is ${last})`);
     }
 
     const stopAt = from - blocksToUnwind;

--- a/yarn-project/circuit-types/src/interfaces/archiver.test.ts
+++ b/yarn-project/circuit-types/src/interfaces/archiver.test.ts
@@ -230,7 +230,7 @@ describe('ArchiverApiSchema', () => {
 
   it('addContractArtifact', async () => {
     await context.client.addContractArtifact(AztecAddress.random(), artifact);
-  });
+  }, 20_000);
 
   it('getContract', async () => {
     const address = AztecAddress.random();

--- a/yarn-project/circuit-types/src/interfaces/aztec-node.test.ts
+++ b/yarn-project/circuit-types/src/interfaces/aztec-node.test.ts
@@ -207,7 +207,7 @@ describe('AztecNodeApiSchema', () => {
 
   it('addContractArtifact', async () => {
     await context.client.addContractArtifact(AztecAddress.random(), artifact);
-  });
+  }, 20_000);
 
   it('getLogs(Encrypted)', async () => {
     const response = await context.client.getLogs(1, 1, LogType.ENCRYPTED);


### PR DESCRIPTION
The archiver kv store used the block *body* hash as identifier to store the block bodies. This means that two empty blocks would have the same identifier. So, when unwinding (ie deleting) two or more empty blocks, the first one would remove the body that corresponds to an empty block, and the second one would fail with "Body could not be retrieved".

This fixes the issue by using the block hash, guaranteed to be unique, as a key to store the block bodies.