### PR TITLE
chore: Delete stray todos

### DIFF
--- a/barretenberg/cpp/src/barretenberg/bb/main.cpp
+++ b/barretenberg/cpp/src/barretenberg/bb/main.cpp
@@ -129,7 +129,6 @@ std::string vk_to_json(std::vector<bb::fr> const& data)
     return format("[", join(map(rotated, [](auto fr) { return format("\"", fr, "\""); })), "]");
 }
 
-// WORKTODO: delete?
 std::string honk_vk_to_json(std::vector<bb::fr>& data)
 {
     return format("[", join(map(data, [](auto fr) { return format("\"", fr, "\""); })), "]");

--- a/barretenberg/cpp/src/barretenberg/dsl/acir_format/ivc_recursion_constraint.test.cpp
+++ b/barretenberg/cpp/src/barretenberg/dsl/acir_format/ivc_recursion_constraint.test.cpp
@@ -213,7 +213,7 @@ TEST_F(IvcRecursionConstraintTest, GenerateVK)
         // Construct kernel consisting only of the kernel completion logic
         AcirProgram program = construct_mock_kernel_program(ivc.verification_queue, { num_app_public_inputs });
         Builder kernel = acir_format::create_kernel_circuit(program.constraints, ivc);
-        // WORKTODO: this would normally happen in accumulate()
+        // Note that this would normally happen in accumulate()
         kernel.add_pairing_point_accumulator(stdlib::recursion::init_default_agg_obj_indices<Builder>(kernel));
 
         auto proving_key = std::make_shared<DeciderProvingKey_<MegaFlavor>>(kernel, trace_settings);

--- a/barretenberg/cpp/src/barretenberg/plonk_honk_shared/execution_trace/mega_execution_trace.hpp
+++ b/barretenberg/cpp/src/barretenberg/plonk_honk_shared/execution_trace/mega_execution_trace.hpp
@@ -190,13 +190,6 @@ class MegaExecutionTraceBlocks : public MegaTraceBlockData<MegaTraceBlock> {
         this->overflow.fixed_size = settings.overflow_capacity;
     }
 
-    // WORKTODO: use or remove
-    MegaExecutionTraceBlocks(const TraceSettings& settings)
-        : MegaExecutionTraceBlocks()
-    {
-        set_fixed_block_sizes(settings);
-    }
-
     void compute_offsets(bool is_structured)
     {
         uint32_t offset = 1; // start at 1 because the 0th row is unused for selectors for Honk

--- a/barretenberg/cpp/src/barretenberg/stdlib_circuit_builders/circuit_simulator.hpp
+++ b/barretenberg/cpp/src/barretenberg/stdlib_circuit_builders/circuit_simulator.hpp
@@ -47,9 +47,8 @@ class CircuitSimulatorBN254 {
     static constexpr size_t UINT_LOG2_BASE = 2; // Would be 6 for UltraPlonk
     static constexpr size_t DEFAULT_PLOOKUP_RANGE_BITNUM = 1028;
 
-    static constexpr size_t num_gates = 0;  // WORKTODO: it was dumb to make this static.
-                                            // Should agree with what is in circuit builders
-    static constexpr uint32_t zero_idx = 0; // Ditto?
+    size_t num_gates = 0;
+    static constexpr uint32_t zero_idx = 0; // Should agree with what is in circuit builders
     std::vector<FF> public_inputs;
 
     void add_pairing_point_accumulator(const PairingPointAccumulatorIndices& proof_element_limbs)


### PR DESCRIPTION
A few `WORKTODO`s were lingering in the code. This is a tag @ledwards2225 and I use to mark todos that we intend to delete before a particular PR merges. Sometimes they get missed.