### PR TITLE
fix: remove src build from doc build flow

### DIFF
--- a/docs/Earthfile
+++ b/docs/Earthfile
@@ -42,7 +42,6 @@ deploy-preview:
   ARG AZTEC_BOT_COMMENTER_GITHUB_TOKEN
   ARG PR
   FROM +serve
-  COPY --dir ../yarn-project/+scripts-prod/usr/src/yarn-project /usr/src
   COPY ./netlify.toml .
   COPY ./deploy_preview.sh .
   RUN NETLIFY_AUTH_TOKEN=$NETLIFY_AUTH_TOKEN NETLIFY_SITE_ID=$NETLIFY_SITE_ID ./deploy_preview.sh $PR $AZTEC_BOT_COMMENTER_GITHUB_TOKEN

--- a/docs/Earthfile
+++ b/docs/Earthfile
@@ -44,7 +44,7 @@ deploy-preview:
   ARG AZTEC_BOT_COMMENTER_GITHUB_TOKEN
   ARG PR
   FROM +serve
-  COPY --dir ../yarn-project/+scripts-prod/usr/src/yarn-project /usr/src
+  COPY --dir ../yarn-project/+scripts-preview/usr/src/yarn-project /usr/src
   COPY ./netlify.toml .
   COPY ./deploy_preview.sh .
   RUN NETLIFY_AUTH_TOKEN=$NETLIFY_AUTH_TOKEN NETLIFY_SITE_ID=$NETLIFY_SITE_ID ./deploy_preview.sh $PR $AZTEC_BOT_COMMENTER_GITHUB_TOKEN

--- a/docs/Earthfile
+++ b/docs/Earthfile
@@ -7,6 +7,8 @@ deps:
   RUN apt update && apt install -y jq curl perl && rm -rf /var/lib/apt/lists/* && apt-get clean
   COPY ./yarn.lock ./yarn.lock
   COPY ./package.json ./package.json
+  COPY ./barretenberg/ts ./barretenberg/ts
+  COPY ./docs ./docs
   RUN yarn install --frozen-lockfile
 
 build:

--- a/docs/Earthfile
+++ b/docs/Earthfile
@@ -1,14 +1,12 @@
 VERSION 0.8
 
-FROM ../build-images/+from-registry
+FROM ../build-images/+base-slim-node
 WORKDIR /usr/src/docs
 
 deps:
   RUN apt update && apt install -y jq curl perl && rm -rf /var/lib/apt/lists/* && apt-get clean
   COPY ./yarn.lock ./yarn.lock
   COPY ./package.json ./package.json
-  COPY ./barretenberg/ts ./barretenberg/ts
-  COPY ./docs ./docs
   RUN yarn install --frozen-lockfile
 
 build:

--- a/docs/Earthfile
+++ b/docs/Earthfile
@@ -15,6 +15,7 @@ build:
   ENV COMMIT_TAG=$COMMIT_TAG
   BUILD ../+release-meta
   FROM +deps
+  COPY --dir ../yarn-project/+build-dev/usr/src /usr
   COPY ../+release-meta/usr/src/.release-please-manifest.json /usr/src
   COPY . .
   RUN ./scripts/build.sh
@@ -42,6 +43,7 @@ deploy-preview:
   ARG AZTEC_BOT_COMMENTER_GITHUB_TOKEN
   ARG PR
   FROM +serve
+  COPY --dir ../yarn-project/+scripts-prod/usr/src/yarn-project /usr/src
   COPY ./netlify.toml .
   COPY ./deploy_preview.sh .
   RUN NETLIFY_AUTH_TOKEN=$NETLIFY_AUTH_TOKEN NETLIFY_SITE_ID=$NETLIFY_SITE_ID ./deploy_preview.sh $PR $AZTEC_BOT_COMMENTER_GITHUB_TOKEN

--- a/docs/Earthfile
+++ b/docs/Earthfile
@@ -13,7 +13,7 @@ build:
   ARG ENV
   ARG COMMIT_TAG
   ENV COMMIT_TAG=$COMMIT_TAG
-  BUILD ../yarn-project/+build-docs-dev
+  BUILD ../yarn-project/+build-dev
   BUILD ../+release-meta
   FROM +deps
   COPY --dir ../yarn-project/+build-dev/usr/src /usr
@@ -37,7 +37,7 @@ serve:
 
 
 deploy-preview:
-  BUILD ../yarn-project/+scripts-prod
+  BUILD ../yarn-project/+scripts-preview
   ARG ENV
   ARG NETLIFY_AUTH_TOKEN
   ARG NETLIFY_SITE_ID

--- a/docs/Earthfile
+++ b/docs/Earthfile
@@ -1,6 +1,6 @@
 VERSION 0.8
 
-FROM ../build-images/+base-slim-node
+FROM ../build-images/+from-registry
 WORKDIR /usr/src/docs
 
 deps:

--- a/docs/Earthfile
+++ b/docs/Earthfile
@@ -13,10 +13,8 @@ build:
   ARG ENV
   ARG COMMIT_TAG
   ENV COMMIT_TAG=$COMMIT_TAG
-  BUILD ../yarn-project/+build-dev
   BUILD ../+release-meta
   FROM +deps
-  COPY --dir ../yarn-project/+build-dev/usr/src /usr
   COPY ../+release-meta/usr/src/.release-please-manifest.json /usr/src
   COPY . .
   RUN ./scripts/build.sh

--- a/docs/Earthfile
+++ b/docs/Earthfile
@@ -13,6 +13,7 @@ build:
   ARG ENV
   ARG COMMIT_TAG
   ENV COMMIT_TAG=$COMMIT_TAG
+  BUILD ../yarn-project/+build-docs-dev
   BUILD ../+release-meta
   FROM +deps
   COPY --dir ../yarn-project/+build-dev/usr/src /usr

--- a/docs/deploy_preview.sh
+++ b/docs/deploy_preview.sh
@@ -27,6 +27,12 @@ echo "Unique deploy URL: $DOCS_PREVIEW_URL"
 
 cd ../yarn-project/scripts
 
+# Check if directory exists
+ls -la ../barretenberg/ts
+
+# Check if it has a package.json
+cat ../barretenberg/ts/package.json
+
 yarn install
 yarn build
 

--- a/docs/deploy_preview.sh
+++ b/docs/deploy_preview.sh
@@ -26,11 +26,6 @@ DOCS_PREVIEW_URL=$(echo "$DEPLOY_OUTPUT" | grep -E "https://.*aztec-docs-dev.net
 echo "Unique deploy URL: $DOCS_PREVIEW_URL"
 
 cd ../yarn-project/scripts
-
-echo "Current directory: $(pwd)"
-echo "Checking if docs-preview.js exists:"
-ls -la dest/bin/
-
 yarn build
 
 AZTEC_BOT_COMMENTER_GITHUB_TOKEN=$AZTEC_BOT_COMMENTER_GITHUB_TOKEN PR_NUMBER=$PR_NUMBER DOCS_PREVIEW_URL=$DOCS_PREVIEW_URL yarn docs-preview-comment

--- a/docs/deploy_preview.sh
+++ b/docs/deploy_preview.sh
@@ -26,6 +26,8 @@ DOCS_PREVIEW_URL=$(echo "$DEPLOY_OUTPUT" | grep -E "https://.*aztec-docs-dev.net
 echo "Unique deploy URL: $DOCS_PREVIEW_URL"
 
 cd ../yarn-project/scripts
+
+yarn install
 yarn build
 
 AZTEC_BOT_COMMENTER_GITHUB_TOKEN=$AZTEC_BOT_COMMENTER_GITHUB_TOKEN PR_NUMBER=$PR_NUMBER DOCS_PREVIEW_URL=$DOCS_PREVIEW_URL yarn docs-preview-comment

--- a/docs/deploy_preview.sh
+++ b/docs/deploy_preview.sh
@@ -27,13 +27,4 @@ echo "Unique deploy URL: $DOCS_PREVIEW_URL"
 
 cd ../yarn-project/scripts
 
-# Check if directory exists
-ls -la ../barretenberg/ts
-
-# Check if it has a package.json
-cat ../barretenberg/ts/package.json
-
-yarn install
-yarn build
-
 AZTEC_BOT_COMMENTER_GITHUB_TOKEN=$AZTEC_BOT_COMMENTER_GITHUB_TOKEN PR_NUMBER=$PR_NUMBER DOCS_PREVIEW_URL=$DOCS_PREVIEW_URL yarn docs-preview-comment

--- a/docs/deploy_preview.sh
+++ b/docs/deploy_preview.sh
@@ -26,4 +26,11 @@ DOCS_PREVIEW_URL=$(echo "$DEPLOY_OUTPUT" | grep -E "https://.*aztec-docs-dev.net
 echo "Unique deploy URL: $DOCS_PREVIEW_URL"
 
 cd ../yarn-project/scripts
-AZTEC_BOT_COMMENTER_GITHUB_TOKEN=$AZTEC_BOT_COMMENTER_GITHUB_TOKEN PR_NUMBER=$PR_NUMBER DOCS_PREVIEW_URL=$DOCS_PREVIEW_URL yarn docs-preview-comment 
+
+echo "Current directory: $(pwd)"
+echo "Checking if docs-preview.js exists:"
+ls -la dest/bin/
+
+yarn build
+
+AZTEC_BOT_COMMENTER_GITHUB_TOKEN=$AZTEC_BOT_COMMENTER_GITHUB_TOKEN PR_NUMBER=$PR_NUMBER DOCS_PREVIEW_URL=$DOCS_PREVIEW_URL yarn docs-preview-comment

--- a/docs/deploy_preview.sh
+++ b/docs/deploy_preview.sh
@@ -26,4 +26,8 @@ DOCS_PREVIEW_URL=$(echo "$DEPLOY_OUTPUT" | grep -E "https://.*aztec-docs-dev.net
 echo "Unique deploy URL: $DOCS_PREVIEW_URL"
 
 cd ../yarn-project/scripts
+
+yarn install
+yarn build
+
 AZTEC_BOT_COMMENTER_GITHUB_TOKEN=$AZTEC_BOT_COMMENTER_GITHUB_TOKEN PR_NUMBER=$PR_NUMBER DOCS_PREVIEW_URL=$DOCS_PREVIEW_URL yarn docs-preview-comment

--- a/docs/deploy_preview.sh
+++ b/docs/deploy_preview.sh
@@ -26,5 +26,4 @@ DOCS_PREVIEW_URL=$(echo "$DEPLOY_OUTPUT" | grep -E "https://.*aztec-docs-dev.net
 echo "Unique deploy URL: $DOCS_PREVIEW_URL"
 
 cd ../yarn-project/scripts
-
 AZTEC_BOT_COMMENTER_GITHUB_TOKEN=$AZTEC_BOT_COMMENTER_GITHUB_TOKEN PR_NUMBER=$PR_NUMBER DOCS_PREVIEW_URL=$DOCS_PREVIEW_URL yarn docs-preview-comment

--- a/docs/deploy_preview.sh
+++ b/docs/deploy_preview.sh
@@ -26,8 +26,4 @@ DOCS_PREVIEW_URL=$(echo "$DEPLOY_OUTPUT" | grep -E "https://.*aztec-docs-dev.net
 echo "Unique deploy URL: $DOCS_PREVIEW_URL"
 
 cd ../yarn-project/scripts
-
-yarn install
-yarn build
-
 AZTEC_BOT_COMMENTER_GITHUB_TOKEN=$AZTEC_BOT_COMMENTER_GITHUB_TOKEN PR_NUMBER=$PR_NUMBER DOCS_PREVIEW_URL=$DOCS_PREVIEW_URL yarn docs-preview-comment

--- a/yarn-project/Earthfile
+++ b/yarn-project/Earthfile
@@ -53,9 +53,34 @@ build:
     RUN ./bootstrap.sh full
     RUN cd ivc-integration && chmod +x run_browser_tests.sh && npx playwright install && npx playwright install-deps
 
+build-docs:
+    # Prefetch targets to not wait for +deps.
+    BUILD ../barretenberg/cpp/+build
+    BUILD ../barretenberg/ts/+build
+    BUILD ../noir/+nargo
+    BUILD --pass-args ../noir-projects/+build
+    BUILD ../l1-contracts/+build
+    BUILD ../barretenberg/ts/+build
+    BUILD ../noir/+packages
+    FROM +deps
+
+    COPY ../barretenberg/cpp/+preset-release/bin/bb /usr/src/barretenberg/cpp/build/bin/bb
+    COPY ../barretenberg/cpp/+preset-release-world-state/bin/world_state_napi.node /usr/src/barretenberg/cpp/build/bin/world_state_napi.node
+    COPY ../noir/+nargo/acvm /usr/src/noir/noir-repo/target/release/acvm
+    COPY --dir ../noir-projects/+build/. /usr/src/noir-projects
+    COPY ../l1-contracts/+build/usr/src/l1-contracts /usr/src/l1-contracts
+
+    WORKDIR /usr/src/yarn-project
+    COPY . .
+    ENV PUPPETEER_SKIP_CHROMIUM_DOWNLOAD=true
+    RUN cd ivc-integration && chmod +x run_browser_tests.sh && npx playwright install && npx playwright install-deps
 
 build-dev:
     FROM +build
+    SAVE ARTIFACT /usr/src /usr/src
+
+build-docs-dev:
+    FROM +build-docs
     SAVE ARTIFACT /usr/src /usr/src
 
 cli-base:
@@ -244,7 +269,7 @@ end-to-end:
     ENTRYPOINT ["yarn", "test"]
 
 scripts-prod:
-    FROM +deps
+    FROM +build-docs
     RUN yarn workspaces focus @aztec/scripts --production && yarn cache clean
     SAVE ARTIFACT /usr/src /usr/src
 

--- a/yarn-project/Earthfile
+++ b/yarn-project/Earthfile
@@ -55,13 +55,6 @@ build:
 
 build-docs:
     # Prefetch targets to not wait for +deps.
-    BUILD ../barretenberg/cpp/+build
-    BUILD ../barretenberg/ts/+build
-    BUILD ../noir/+nargo
-    BUILD --pass-args ../noir-projects/+build
-    BUILD ../l1-contracts/+build
-    BUILD ../barretenberg/ts/+build
-    BUILD ../noir/+packages
     FROM +deps
 
     COPY ../barretenberg/cpp/+preset-release/bin/bb /usr/src/barretenberg/cpp/build/bin/bb
@@ -269,7 +262,7 @@ end-to-end:
     ENTRYPOINT ["yarn", "test"]
 
 scripts-prod:
-    FROM +build-docs
+    FROM +build-docs-dev
     RUN yarn workspaces focus @aztec/scripts --production && yarn cache clean
     SAVE ARTIFACT /usr/src /usr/src
 

--- a/yarn-project/Earthfile
+++ b/yarn-project/Earthfile
@@ -1,324 +1,323 @@
 VERSION 0.8
 
 deps:
-    LOCALLY
-    LET packages = $(git ls-files "**/package*.json" package*.json)
-    LET tsconfigs = $(git ls-files "**/tsconfig*.json" tsconfig*.json)
-    FROM ../build-images+from-registry
-    # copy bb, bb-js and noir-packages
-    COPY ../barretenberg/cpp/+preset-release/bin /usr/src/barretenberg/cpp/build/bin
-    COPY ../barretenberg/cpp/+preset-release-world-state/bin /usr/src/barretenberg/cpp/build/bin
-    COPY ../barretenberg/ts/+build/build /usr/src/barretenberg/ts
-    COPY ../noir/+packages/packages /usr/src/noir/packages
-    WORKDIR /usr/src/yarn-project
-    COPY --dir .yarn .yarnrc.yml yarn.lock .
-    FOR file IN $packages
-        COPY $file $file
-    END
-    RUN yarn install --immutable
-    FOR file IN $tsconfigs
-        COPY $file $file
-    END
-    COPY scripts/update_package_jsons.mjs scripts/update_package_jsons.mjs
-    RUN yarn prepare:check
+LOCALLY
+LET packages = $(git ls-files "**/package*.json" package*.json)
+LET tsconfigs = $(git ls-files "**/tsconfig*.json" tsconfig*.json)
+FROM ../build-images+from-registry
+# copy bb, bb-js and noir-packages
+COPY ../barretenberg/cpp/+preset-release/bin /usr/src/barretenberg/cpp/build/bin
+COPY ../barretenberg/cpp/+preset-release-world-state/bin /usr/src/barretenberg/cpp/build/bin
+COPY ../barretenberg/ts/+build/build /usr/src/barretenberg/ts
+COPY ../noir/+packages/packages /usr/src/noir/packages
+WORKDIR /usr/src/yarn-project
+COPY --dir .yarn .yarnrc.yml yarn.lock .
+FOR file IN $packages
+COPY $file $file
+END
+RUN yarn install --immutable
+FOR file IN $tsconfigs
+COPY $file $file
+END
+COPY scripts/update_package_jsons.mjs scripts/update_package_jsons.mjs
+RUN yarn prepare:check
 
-    # We install a symlink to yarn-project's node_modules at a location that all portalled packages can find as they
-    # walk up the tree as part of module resolution. The supposedly idiomatic way of supporting module resolution
-    # correctly for portalled packages, is to use --preserve-symlinks when running node.
-    # This does kind of work, but jest doesn't honor it correctly, so this seems like a neat workaround.
-    # Also, --preserve-symlinks causes duplication of portalled instances such as bb.js, and breaks the singleton logic
-    # by initialising the module more than once. So at present I don't see a viable alternative.
-    RUN ln -s /usr/src/yarn-project/node_modules /usr/src/node_modules
+# We install a symlink to yarn-project's node_modules at a location that all portalled packages can find as they
+# walk up the tree as part of module resolution. The supposedly idiomatic way of supporting module resolution
+# correctly for portalled packages, is to use --preserve-symlinks when running node.
+# This does kind of work, but jest doesn't honor it correctly, so this seems like a neat workaround.
+# Also, --preserve-symlinks causes duplication of portalled instances such as bb.js, and breaks the singleton logic
+# by initialising the module more than once. So at present I don't see a viable alternative.
+RUN ln -s /usr/src/yarn-project/node_modules /usr/src/node_modules
 
 build:
-    # Prefetch targets to not wait for +deps.
-    BUILD ../barretenberg/cpp/+build
-    BUILD ../barretenberg/ts/+build
-    BUILD ../noir/+nargo
-    BUILD --pass-args ../noir-projects/+build
-    BUILD ../l1-contracts/+build
-    BUILD ../barretenberg/ts/+build
-    BUILD ../noir/+packages
-    FROM +deps
+# Prefetch targets to not wait for +deps.
+BUILD ../barretenberg/cpp/+build
+BUILD ../barretenberg/ts/+build
+BUILD ../noir/+nargo
+BUILD --pass-args ../noir-projects/+build
+BUILD ../l1-contracts/+build
+BUILD ../barretenberg/ts/+build
+BUILD ../noir/+packages
+FROM +deps
 
-    COPY ../barretenberg/cpp/+preset-release/bin/bb /usr/src/barretenberg/cpp/build/bin/bb
-    COPY ../barretenberg/cpp/+preset-release-world-state/bin/world_state_napi.node /usr/src/barretenberg/cpp/build/bin/world_state_napi.node
-    COPY ../noir/+nargo/acvm /usr/src/noir/noir-repo/target/release/acvm
-    COPY --dir ../noir-projects/+build/. /usr/src/noir-projects
-    COPY ../l1-contracts/+build/usr/src/l1-contracts /usr/src/l1-contracts
+COPY ../barretenberg/cpp/+preset-release/bin/bb /usr/src/barretenberg/cpp/build/bin/bb
+COPY ../barretenberg/cpp/+preset-release-world-state/bin/world_state_napi.node /usr/src/barretenberg/cpp/build/bin/world_state_napi.node
+COPY ../noir/+nargo/acvm /usr/src/noir/noir-repo/target/release/acvm
+COPY --dir ../noir-projects/+build/. /usr/src/noir-projects
+COPY ../l1-contracts/+build/usr/src/l1-contracts /usr/src/l1-contracts
 
-    WORKDIR /usr/src/yarn-project
-    COPY . .
-    ENV PUPPETEER_SKIP_CHROMIUM_DOWNLOAD=true
-    RUN ./bootstrap.sh full
-    RUN cd ivc-integration && chmod +x run_browser_tests.sh && npx playwright install && npx playwright install-deps
+WORKDIR /usr/src/yarn-project
+COPY . .
+ENV PUPPETEER_SKIP_CHROMIUM_DOWNLOAD=true
+RUN ./bootstrap.sh full
+RUN cd ivc-integration && chmod +x run_browser_tests.sh && npx playwright install && npx playwright install-deps
 
 
 build-dev:
-    FROM +build
-    SAVE ARTIFACT /usr/src /usr/src
+FROM +build
+SAVE ARTIFACT /usr/src /usr/src
 
 cli-base:
-    FROM +build
-    # Remove a bunch of stuff that we don't need that takes up space.
-    RUN rm -rf \
-        ../noir-projects \
-        ../l1-contracts \
-        ../barretenberg/ts/src \
-        ../barretenberg/ts/dest/node-cjs \
-        ../barretenberg/ts/dest/browser
+FROM +build
+# Remove a bunch of stuff that we don't need that takes up space.
+RUN rm -rf \
+    ../noir-projects \
+    ../l1-contracts \
+    ../barretenberg/ts/src \
+    ../barretenberg/ts/dest/node-cjs \
+    ../barretenberg/ts/dest/browser
 
 bb-cli:
-    FROM +cli-base
+FROM +cli-base
 
-    ENV BB_WORKING_DIRECTORY=/usr/src/bb
-    ENV BB_BINARY_PATH=/usr/src/barretenberg/cpp/build/bin/bb
-    ENV ACVM_WORKING_DIRECTORY=/usr/src/acvm
-    ENV ACVM_BINARY_PATH=/usr/src/noir/noir-repo/target/release/acvm
+ENV BB_WORKING_DIRECTORY=/usr/src/bb
+ENV BB_BINARY_PATH=/usr/src/barretenberg/cpp/build/bin/bb
+ENV ACVM_WORKING_DIRECTORY=/usr/src/acvm
+ENV ACVM_BINARY_PATH=/usr/src/noir/noir-repo/target/release/acvm
 
-    RUN mkdir -p $BB_WORKING_DIRECTORY $ACVM_WORKING_DIRECTORY
+RUN mkdir -p $BB_WORKING_DIRECTORY $ACVM_WORKING_DIRECTORY
 
-    RUN yarn workspaces focus @aztec/bb-prover --production && yarn cache clean
-    RUN rm -rf \
-        aztec.js/dest/main.js \
-        end-to-end \
-        **/src
+RUN yarn workspaces focus @aztec/bb-prover --production && yarn cache clean
+RUN rm -rf \
+    aztec.js/dest/main.js \
+    end-to-end \
+    **/src
 
-    # yarn symlinks the binary to node_modules/.bin
-    ENTRYPOINT ["/usr/src/yarn-project/node_modules/.bin/bb-cli"]
+# yarn symlinks the binary to node_modules/.bin
+ENTRYPOINT ["/usr/src/yarn-project/node_modules/.bin/bb-cli"]
 
 # helper target to generate vks in parallel
 verification-key:
-    ARG circuit="RootRollupArtifact"
-    FROM +bb-cli
+ARG circuit="RootRollupArtifact"
+FROM +bb-cli
 
-    # this needs to be exported as an env var for RUN to pick it up
-    ENV CIRCUIT=$circuit
-    RUN --entrypoint write-vk -c $CIRCUIT
+# this needs to be exported as an env var for RUN to pick it up
+ENV CIRCUIT=$circuit
+RUN --entrypoint write-vk -c $CIRCUIT
 
-    SAVE ARTIFACT /usr/src/bb /usr/src/bb
+SAVE ARTIFACT /usr/src/bb /usr/src/bb
 
 protocol-verification-keys:
-    LOCALLY
-    LET circuits = "RootRollupArtifact PrivateKernelTailArtifact PrivateKernelTailToPublicArtifact"
+LOCALLY
+LET circuits = "RootRollupArtifact PrivateKernelTailArtifact PrivateKernelTailToPublicArtifact"
 
-    FOR circuit IN $circuits
-        BUILD +verification-key --circuit=$circuit
-    END
+FOR circuit IN $circuits
+BUILD +verification-key --circuit=$circuit
+END
 
-    # this could be FROM scratch
-    # but FOR doesn't work without /bin/sh
-    FROM ubuntu:noble
-    WORKDIR /usr/src/bb
+# this could be FROM scratch
+# but FOR doesn't work without /bin/sh
+FROM ubuntu:noble
+WORKDIR /usr/src/bb
 
-    FOR circuit IN $circuits
-        COPY (+verification-key/usr/src/bb --circuit=$circuit) .
-    END
+FOR circuit IN $circuits
+COPY (+verification-key/usr/src/bb --circuit=$circuit) .
+END
 
-    SAVE ARTIFACT /usr/src/bb /usr/src/bb
+SAVE ARTIFACT /usr/src/bb /usr/src/bb
 
 rollup-verifier-contract:
-    FROM +bb-cli
-    COPY --dir +protocol-verification-keys/usr/src/bb /usr/src
-    RUN --entrypoint write-contract -c RootRollupArtifact -n UltraHonkVerifier.sol
-    SAVE ARTIFACT /usr/src/bb /usr/src/bb
+FROM +bb-cli
+COPY --dir +protocol-verification-keys/usr/src/bb /usr/src
+RUN --entrypoint write-contract -c RootRollupArtifact -n UltraHonkVerifier.sol
+SAVE ARTIFACT /usr/src/bb /usr/src/bb
 
 txe:
-    FROM +cli-base
-    RUN yarn workspaces focus @aztec/txe && yarn cache clean
-    ENTRYPOINT ["node", "--no-warnings", "/usr/src/yarn-project/txe/dest/bin/index.js"]
-    SAVE ARTIFACT /usr/src /usr/src
+FROM +cli-base
+RUN yarn workspaces focus @aztec/txe && yarn cache clean
+ENTRYPOINT ["node", "--no-warnings", "/usr/src/yarn-project/txe/dest/bin/index.js"]
+SAVE ARTIFACT /usr/src /usr/src
 
 cli-wallet-build:
-    FROM +cli-base
-    RUN yarn workspaces focus @aztec/cli-wallet --production && yarn cache clean
-    SAVE ARTIFACT /usr/src /usr/src
+FROM +cli-base
+RUN yarn workspaces focus @aztec/cli-wallet --production && yarn cache clean
+SAVE ARTIFACT /usr/src /usr/src
 
 cli-wallet:
-    FROM ubuntu:noble
-    RUN apt update && apt install nodejs curl socat -y && rm -rf /var/lib/apt/lists/* /tmp/* /var/tmp/*
-    COPY +cli-wallet-build/usr/src /usr/src
-    ENTRYPOINT ["/usr/src/yarn-project/cli-wallet/wallet-entrypoint.sh"]
+FROM ubuntu:noble
+RUN apt update && apt install nodejs curl socat -y && rm -rf /var/lib/apt/lists/* /tmp/* /var/tmp/*
+COPY +cli-wallet-build/usr/src /usr/src
+ENTRYPOINT ["/usr/src/yarn-project/cli-wallet/wallet-entrypoint.sh"]
 
 export-cli-wallet:
-    FROM +cli-wallet
-    ARG DIST_TAG="latest"
-    ARG ARCH
-    SAVE IMAGE --push aztecprotocol/cli-wallet:${DIST_TAG}${ARCH:+-$ARCH}
+FROM +cli-wallet
+ARG DIST_TAG="latest"
+ARG ARCH
+SAVE IMAGE --push aztecprotocol/cli-wallet:${DIST_TAG}${ARCH:+-$ARCH}
 
 aztec-prod:
-    FROM +cli-base
-    RUN yarn workspaces focus @aztec/aztec --production && yarn cache clean
-    COPY --dir +rollup-verifier-contract/usr/src/bb /usr/src
-    SAVE ARTIFACT /usr/src /usr/src
+FROM +cli-base
+RUN yarn workspaces focus @aztec/aztec --production && yarn cache clean
+COPY --dir +rollup-verifier-contract/usr/src/bb /usr/src
+SAVE ARTIFACT /usr/src /usr/src
 
 aztec:
-    FROM ubuntu:noble
-    RUN apt update && apt install nodejs curl jq -y && rm -rf /var/lib/apt/lists/* /tmp/* /var/tmp/*
-    COPY +aztec-prod/usr/src /usr/src
-    ENV BB_WORKING_DIRECTORY=/usr/src/bb
-    ENV BB_BINARY_PATH=/usr/src/barretenberg/cpp/build/bin/bb
-    ENV ACVM_WORKING_DIRECTORY=/usr/src/acvm
-    ENV ACVM_BINARY_PATH=/usr/src/noir/noir-repo/target/release/acvm
-    RUN mkdir -p $BB_WORKING_DIRECTORY $ACVM_WORKING_DIRECTORY /usr/src/yarn-project/world-state/build
-    ENTRYPOINT ["node", "--no-warnings", "/usr/src/yarn-project/aztec/dest/bin/index.js"]
-    LET port=8080
-    ENV PORT=$port
-    HEALTHCHECK --interval=10s --timeout=10s --retries=6 --start-period=120s \
-        CMD curl -fsS http://127.0.0.1:$port/status
-    EXPOSE $port
+FROM ubuntu:noble
+RUN apt update && apt install nodejs curl jq -y && rm -rf /var/lib/apt/lists/* /tmp/* /var/tmp/*
+COPY +aztec-prod/usr/src /usr/src
+ENV BB_WORKING_DIRECTORY=/usr/src/bb
+ENV BB_BINARY_PATH=/usr/src/barretenberg/cpp/build/bin/bb
+ENV ACVM_WORKING_DIRECTORY=/usr/src/acvm
+ENV ACVM_BINARY_PATH=/usr/src/noir/noir-repo/target/release/acvm
+RUN mkdir -p $BB_WORKING_DIRECTORY $ACVM_WORKING_DIRECTORY /usr/src/yarn-project/world-state/build
+ENTRYPOINT ["node", "--no-warnings", "/usr/src/yarn-project/aztec/dest/bin/index.js"]
+LET port=8080
+ENV PORT=$port
+HEALTHCHECK --interval=10s --timeout=10s --retries=6 --start-period=120s \
+    CMD curl -fsS http://127.0.0.1:$port/status
+EXPOSE $port
 
 aztec-faucet-build:
-    FROM +cli-base
-    RUN yarn workspaces focus @aztec/aztec-faucet --production && yarn cache clean
-    RUN rm -rf \
-        aztec.js/dest/main.js \
-        end-to-end \
-        **/src
-    SAVE ARTIFACT /usr/src /usr/src
+FROM +cli-base
+RUN yarn workspaces focus @aztec/aztec-faucet --production && yarn cache clean
+RUN rm -rf \
+    aztec.js/dest/main.js \
+    end-to-end \
+    **/src
+SAVE ARTIFACT /usr/src /usr/src
 
 aztec-faucet:
-    FROM ubuntu:noble
-    RUN apt update && apt install nodejs curl -y && rm -rf /var/lib/apt/lists/* /tmp/* /var/tmp/*
-    COPY +aztec-faucet-build/usr/src /usr/src
-    ENTRYPOINT ["node", "--no-warnings", "/usr/src/yarn-project/aztec-faucet/dest/bin/index.js"]
-    LET port=8080
+FROM ubuntu:noble
+RUN apt update && apt install nodejs curl -y && rm -rf /var/lib/apt/lists/* /tmp/* /var/tmp/*
+COPY +aztec-faucet-build/usr/src /usr/src
+ENTRYPOINT ["node", "--no-warnings", "/usr/src/yarn-project/aztec-faucet/dest/bin/index.js"]
+LET port=8080
 
 export-aztec-faucet:
-    FROM +aztec-faucet
-    ARG DIST_TAG="latest"
-    ARG ARCH
-    SAVE IMAGE --push aztecprotocol/aztec-faucet:${DIST_TAG}${ARCH:+-$ARCH}
+FROM +aztec-faucet
+ARG DIST_TAG="latest"
+ARG ARCH
+SAVE IMAGE --push aztecprotocol/aztec-faucet:${DIST_TAG}${ARCH:+-$ARCH}
 
 # We care about creating a slimmed down e2e image because we have to serialize it from earthly to docker for running.
 end-to-end-prod:
-    BUILD ../spartan/+charts
-    FROM +cli-base
-    RUN yarn workspaces focus @aztec/end-to-end @aztec/cli-wallet --production && yarn cache clean
-    COPY --dir +rollup-verifier-contract/usr/src/bb /usr/src
-    COPY --dir +build-dev/usr/src/noir-projects/noir-contracts /usr/src/noir-projects/noir-contracts
-    COPY --dir ../spartan/+charts/usr/src/spartan /usr/src/spartan
+BUILD ../spartan/+charts
+FROM +cli-base
+RUN yarn workspaces focus @aztec/end-to-end @aztec/cli-wallet --production && yarn cache clean
+COPY --dir +rollup-verifier-contract/usr/src/bb /usr/src
+COPY --dir +build-dev/usr/src/noir-projects/noir-contracts /usr/src/noir-projects/noir-contracts
+COPY --dir ../spartan/+charts/usr/src/spartan /usr/src/spartan
 
-    SAVE ARTIFACT /usr/src /usr/src
+SAVE ARTIFACT /usr/src /usr/src
 
 anvil:
-    FROM ../build-images+from-registry
-    SAVE ARTIFACT /opt/foundry/bin/anvil
+FROM ../build-images+from-registry
+SAVE ARTIFACT /opt/foundry/bin/anvil
 
 end-to-end-base:
-    FROM ubuntu:noble
-    # add repository for chromium
-    RUN apt-get update && apt-get install -y software-properties-common \
-        && add-apt-repository ppa:xtradeb/apps -y && apt-get update \
-        && apt-get install -y wget gnupg \
-        && wget -q -O - https://dl-ssl.google.com/linux/linux_signing_key.pub | apt-key add - \
-        && echo "deb [arch=$(dpkg --print-architecture)] http://dl.google.com/linux/chrome/deb/ stable main" >> /etc/apt/sources.list.d/google-chrome.list \
-        && apt update && apt install curl chromium nodejs netcat-openbsd -y \
-        && rm -rf /var/lib/apt/lists/* \
-        && mkdir -p /usr/local/bin \
-        && curl -fsSL -o /usr/local/bin/kubectl "https://dl.k8s.io/release/$(curl -L -s https://dl.k8s.io/release/stable.txt)/bin/linux/amd64/kubectl" \
-        && chmod +x /usr/local/bin/kubectl \
-        && curl -fsSL -o get_helm.sh https://raw.githubusercontent.com/helm/helm/main/scripts/get-helm-3 \
-        && chmod +x get_helm.sh \
-        && ./get_helm.sh \
-        && rm get_helm.sh
+FROM ubuntu:noble
+# add repository for chromium
+RUN apt-get update && apt-get install -y software-properties-common \
+    && add-apt-repository ppa:xtradeb/apps -y && apt-get update \
+    && apt-get install -y wget gnupg \
+    && wget -q -O - https://dl-ssl.google.com/linux/linux_signing_key.pub | apt-key add - \
+    && echo "deb [arch=$(dpkg --print-architecture)] http://dl.google.com/linux/chrome/deb/ stable main" >> /etc/apt/sources.list.d/google-chrome.list \
+    && apt update && apt install curl chromium nodejs netcat-openbsd -y \
+    && rm -rf /var/lib/apt/lists/* \
+    && mkdir -p /usr/local/bin \
+    && curl -fsSL -o /usr/local/bin/kubectl "https://dl.k8s.io/release/$(curl -L -s https://dl.k8s.io/release/stable.txt)/bin/linux/amd64/kubectl" \
+    && chmod +x /usr/local/bin/kubectl \
+    && curl -fsSL -o get_helm.sh https://raw.githubusercontent.com/helm/helm/main/scripts/get-helm-3 \
+    && chmod +x get_helm.sh \
+    && ./get_helm.sh \
+    && rm get_helm.sh
 
-    ENV CHROME_BIN="/usr/bin/chromium"
-    ENV PATH=/opt/foundry/bin:/usr/local/bin:$PATH
-    ENV HARDWARE_CONCURRENCY=""
-    ENV FAKE_PROOFS=""
-    ENV BB_WORKING_DIRECTORY=/usr/src/bb
-    ENV BB_BINARY_PATH=/usr/src/barretenberg/cpp/build/bin/bb
-    ENV ACVM_WORKING_DIRECTORY=/usr/src/acvm
-    ENV ACVM_BINARY_PATH=/usr/src/noir/noir-repo/target/release/acvm
-    ENV PROVER_AGENT_CONCURRENCY=8
-    RUN mkdir -p $BB_WORKING_DIRECTORY $ACVM_WORKING_DIRECTORY /usr/src/yarn-project/world-state/build
-    RUN ln -s /usr/src/yarn-project/.yarn/releases/yarn-3.6.3.cjs /usr/local/bin/yarn
+ENV CHROME_BIN="/usr/bin/chromium"
+ENV PATH=/opt/foundry/bin:/usr/local/bin:$PATH
+ENV HARDWARE_CONCURRENCY=""
+ENV FAKE_PROOFS=""
+ENV BB_WORKING_DIRECTORY=/usr/src/bb
+ENV BB_BINARY_PATH=/usr/src/barretenberg/cpp/build/bin/bb
+ENV ACVM_WORKING_DIRECTORY=/usr/src/acvm
+ENV ACVM_BINARY_PATH=/usr/src/noir/noir-repo/target/release/acvm
+ENV PROVER_AGENT_CONCURRENCY=8
+RUN mkdir -p $BB_WORKING_DIRECTORY $ACVM_WORKING_DIRECTORY /usr/src/yarn-project/world-state/build
+RUN ln -s /usr/src/yarn-project/.yarn/releases/yarn-3.6.3.cjs /usr/local/bin/yarn
 
 end-to-end:
-    FROM +end-to-end-base
+FROM +end-to-end-base
 
-    COPY +anvil/anvil /opt/foundry/bin/anvil
-    COPY +end-to-end-prod/usr/src /usr/src
-    WORKDIR /usr/src/yarn-project/end-to-end
-    ENTRYPOINT ["yarn", "test"]
+COPY +anvil/anvil /opt/foundry/bin/anvil
+COPY +end-to-end-prod/usr/src /usr/src
+WORKDIR /usr/src/yarn-project/end-to-end
+ENTRYPOINT ["yarn", "test"]
 
 scripts-prod:
-    FROM +build
-    RUN yarn workspaces focus @aztec/scripts --production && yarn cache clean
-    SAVE ARTIFACT /usr/src /usr/src
+RUN yarn workspaces focus @aztec/scripts --production && yarn cache clean
+SAVE ARTIFACT /usr/src /usr/src
 
 all:
-    BUILD +aztec
-    BUILD +end-to-end
+BUILD +aztec
+BUILD +end-to-end
 
 export-aztec:
-    ARG EARTHLY_GIT_HASH
-    FROM +aztec
-    SAVE IMAGE aztecprotocol/aztec:$EARTHLY_GIT_HASH
+ARG EARTHLY_GIT_HASH
+FROM +aztec
+SAVE IMAGE aztecprotocol/aztec:$EARTHLY_GIT_HASH
 
 export-aztec-arch:
-    FROM +aztec
-    ARG DIST_TAG="latest"
-    ARG ARCH
-    SAVE IMAGE --push aztecprotocol/aztec:${DIST_TAG}${ARCH:+-$ARCH}
+FROM +aztec
+ARG DIST_TAG="latest"
+ARG ARCH
+SAVE IMAGE --push aztecprotocol/aztec:${DIST_TAG}${ARCH:+-$ARCH}
 
 export-end-to-end:
-    ARG EARTHLY_GIT_HASH
-    FROM +end-to-end
-    SAVE IMAGE aztecprotocol/end-to-end:$EARTHLY_GIT_HASH
+ARG EARTHLY_GIT_HASH
+FROM +end-to-end
+SAVE IMAGE aztecprotocol/end-to-end:$EARTHLY_GIT_HASH
 
 export-e2e-test-images:
-    BUILD +export-aztec
-    BUILD +export-end-to-end
+BUILD +export-aztec
+BUILD +export-end-to-end
 
 format-check:
-    FROM +build
-    RUN yarn formatting
+FROM +build
+RUN yarn formatting
 
 test:
-    FROM +build
-    RUN yarn test
+FROM +build
+RUN yarn test
 
 run-e2e:
-    ARG test
-    ARG debug=""
-    FROM +end-to-end
-    RUN DEBUG=$debug yarn test $test
+ARG test
+ARG debug=""
+FROM +end-to-end
+RUN DEBUG=$debug yarn test $test
 
 prover-client-test:
-    FROM +build
-    ARG test
-    ARG debug=""
-    RUN cd prover-client && DEBUG=$debug yarn test $test
+FROM +build
+ARG test
+ARG debug=""
+RUN cd prover-client && DEBUG=$debug yarn test $test
 
 # NOTE: This is not in the end-to-end Earthfile as that is entirely LOCALLY commands that will go away sometime.
 # Running this inside the main builder as the point is not to run this through dockerization.
 network-test:
-    ARG test=./test-transfer.sh
-    ARG validators=3
-    FROM +build
-    WORKDIR /usr/src/
-    # Bare minimum git setup to run 'git rev-parse --show-toplevel'
-    RUN git init -b master
-    COPY ../scripts/+scripts/run_interleaved.sh scripts/run_interleaved.sh
-    WORKDIR /usr/src/yarn-project
-    # All script arguments are in the end-to-end/scripts/native-network folder
-    ENV LOG_LEVEL=verbose
-    RUN INTERLEAVED=true end-to-end/scripts/native_network_test.sh \
-        "$test" \
-        ./deploy-l1-contracts.sh \
-        ./deploy-l2-contracts.sh \
-        ./boot-node.sh \
-        ./ethereum.sh \
-        "./prover-node.sh 8078 false" \
-        ./pxe.sh \
-        "./validators.sh $validators"
+ARG test=./test-transfer.sh
+ARG validators=3
+FROM +build
+WORKDIR /usr/src/
+# Bare minimum git setup to run 'git rev-parse --show-toplevel'
+RUN git init -b master
+COPY ../scripts/+scripts/run_interleaved.sh scripts/run_interleaved.sh
+WORKDIR /usr/src/yarn-project
+# All script arguments are in the end-to-end/scripts/native-network folder
+ENV LOG_LEVEL=verbose
+RUN INTERLEAVED=true end-to-end/scripts/native_network_test.sh \
+    "$test" \
+    ./deploy-l1-contracts.sh \
+    ./deploy-l2-contracts.sh \
+    ./boot-node.sh \
+    ./ethereum.sh \
+    "./prover-node.sh 8078 false" \
+    ./pxe.sh \
+    "./validators.sh $validators"
 
 publish-npm:
-    FROM +build
-    ARG DIST_TAG="latest"
-    ARG VERSION
-    ARG DRY_RUN=0
-    WORKDIR /usr/src/yarn-project
-    RUN --secret NPM_TOKEN ./publish_npm.sh $DIST_TAG $VERSION $DRY_RUN
+FROM +build
+ARG DIST_TAG="latest"
+ARG VERSION
+ARG DRY_RUN=0
+WORKDIR /usr/src/yarn-project
+RUN --secret NPM_TOKEN ./publish_npm.sh $DIST_TAG $VERSION $DRY_RUN

--- a/yarn-project/Earthfile
+++ b/yarn-project/Earthfile
@@ -52,25 +52,8 @@ build:
     RUN ./bootstrap.sh full
     RUN cd ivc-integration && chmod +x run_browser_tests.sh && npx playwright install && npx playwright install-deps
 
-build-docs:
-    FROM +deps
-    COPY ../barretenberg/cpp/+preset-release/bin/bb /usr/src/barretenberg/cpp/build/bin/bb
-    COPY ../barretenberg/cpp/+preset-release-world-state/bin/world_state_napi.node /usr/src/barretenberg/cpp/build/bin/world_state_napi.node
-    COPY ../noir/+nargo/acvm /usr/src/noir/noir-repo/target/release/acvm
-    COPY --dir ../noir-projects/+build/. /usr/src/noir-projects
-    COPY ../l1-contracts/+build/usr/src/l1-contracts /usr/src/l1-contracts
-
-    WORKDIR /usr/src/yarn-project
-    COPY . .
-    ENV PUPPETEER_SKIP_CHROMIUM_DOWNLOAD=true
-    RUN cd ivc-integration && chmod +x run_browser_tests.sh && npx playwright install && npx playwright install-deps
-
 build-dev:
     FROM +build
-    SAVE ARTIFACT /usr/src /usr/src
-
-build-docs-dev:
-    FROM +build-docs
     SAVE ARTIFACT /usr/src /usr/src
 
 cli-base:

--- a/yarn-project/Earthfile
+++ b/yarn-project/Earthfile
@@ -53,10 +53,7 @@ build:
     RUN cd ivc-integration && chmod +x run_browser_tests.sh && npx playwright install && npx playwright install-deps
 
 build-docs:
-    # Prefetch targets to not wait for +deps.
-    BUILD ../barretenberg/ts/+build
     FROM +deps
-
     COPY ../barretenberg/cpp/+preset-release/bin/bb /usr/src/barretenberg/cpp/build/bin/bb
     COPY ../barretenberg/cpp/+preset-release-world-state/bin/world_state_napi.node /usr/src/barretenberg/cpp/build/bin/world_state_napi.node
     COPY ../noir/+nargo/acvm /usr/src/noir/noir-repo/target/release/acvm

--- a/yarn-project/Earthfile
+++ b/yarn-project/Earthfile
@@ -244,6 +244,7 @@ end-to-end:
     ENTRYPOINT ["yarn", "test"]
 
 scripts-prod:
+    FROM +deps
     RUN yarn workspaces focus @aztec/scripts --production && yarn cache clean
     SAVE ARTIFACT /usr/src /usr/src
 

--- a/yarn-project/Earthfile
+++ b/yarn-project/Earthfile
@@ -37,7 +37,6 @@ build:
     BUILD ../noir/+nargo
     BUILD --pass-args ../noir-projects/+build
     BUILD ../l1-contracts/+build
-    BUILD ../barretenberg/ts/+build
     BUILD ../noir/+packages
     FROM +deps
 
@@ -55,6 +54,7 @@ build:
 
 build-docs:
     # Prefetch targets to not wait for +deps.
+    BUILD ../barretenberg/ts/+build
     FROM +deps
 
     COPY ../barretenberg/cpp/+preset-release/bin/bb /usr/src/barretenberg/cpp/build/bin/bb

--- a/yarn-project/Earthfile
+++ b/yarn-project/Earthfile
@@ -1,323 +1,323 @@
 VERSION 0.8
 
 deps:
-LOCALLY
-LET packages = $(git ls-files "**/package*.json" package*.json)
-LET tsconfigs = $(git ls-files "**/tsconfig*.json" tsconfig*.json)
-FROM ../build-images+from-registry
-# copy bb, bb-js and noir-packages
-COPY ../barretenberg/cpp/+preset-release/bin /usr/src/barretenberg/cpp/build/bin
-COPY ../barretenberg/cpp/+preset-release-world-state/bin /usr/src/barretenberg/cpp/build/bin
-COPY ../barretenberg/ts/+build/build /usr/src/barretenberg/ts
-COPY ../noir/+packages/packages /usr/src/noir/packages
-WORKDIR /usr/src/yarn-project
-COPY --dir .yarn .yarnrc.yml yarn.lock .
-FOR file IN $packages
-COPY $file $file
-END
-RUN yarn install --immutable
-FOR file IN $tsconfigs
-COPY $file $file
-END
-COPY scripts/update_package_jsons.mjs scripts/update_package_jsons.mjs
-RUN yarn prepare:check
+    LOCALLY
+    LET packages = $(git ls-files "**/package*.json" package*.json)
+    LET tsconfigs = $(git ls-files "**/tsconfig*.json" tsconfig*.json)
+    FROM ../build-images+from-registry
+    # copy bb, bb-js and noir-packages
+    COPY ../barretenberg/cpp/+preset-release/bin /usr/src/barretenberg/cpp/build/bin
+    COPY ../barretenberg/cpp/+preset-release-world-state/bin /usr/src/barretenberg/cpp/build/bin
+    COPY ../barretenberg/ts/+build/build /usr/src/barretenberg/ts
+    COPY ../noir/+packages/packages /usr/src/noir/packages
+    WORKDIR /usr/src/yarn-project
+    COPY --dir .yarn .yarnrc.yml yarn.lock .
+    FOR file IN $packages
+        COPY $file $file
+    END
+    RUN yarn install --immutable
+    FOR file IN $tsconfigs
+        COPY $file $file
+    END
+    COPY scripts/update_package_jsons.mjs scripts/update_package_jsons.mjs
+    RUN yarn prepare:check
 
-# We install a symlink to yarn-project's node_modules at a location that all portalled packages can find as they
-# walk up the tree as part of module resolution. The supposedly idiomatic way of supporting module resolution
-# correctly for portalled packages, is to use --preserve-symlinks when running node.
-# This does kind of work, but jest doesn't honor it correctly, so this seems like a neat workaround.
-# Also, --preserve-symlinks causes duplication of portalled instances such as bb.js, and breaks the singleton logic
-# by initialising the module more than once. So at present I don't see a viable alternative.
-RUN ln -s /usr/src/yarn-project/node_modules /usr/src/node_modules
+    # We install a symlink to yarn-project's node_modules at a location that all portalled packages can find as they
+    # walk up the tree as part of module resolution. The supposedly idiomatic way of supporting module resolution
+    # correctly for portalled packages, is to use --preserve-symlinks when running node.
+    # This does kind of work, but jest doesn't honor it correctly, so this seems like a neat workaround.
+    # Also, --preserve-symlinks causes duplication of portalled instances such as bb.js, and breaks the singleton logic
+    # by initialising the module more than once. So at present I don't see a viable alternative.
+    RUN ln -s /usr/src/yarn-project/node_modules /usr/src/node_modules
 
 build:
-# Prefetch targets to not wait for +deps.
-BUILD ../barretenberg/cpp/+build
-BUILD ../barretenberg/ts/+build
-BUILD ../noir/+nargo
-BUILD --pass-args ../noir-projects/+build
-BUILD ../l1-contracts/+build
-BUILD ../barretenberg/ts/+build
-BUILD ../noir/+packages
-FROM +deps
+    # Prefetch targets to not wait for +deps.
+    BUILD ../barretenberg/cpp/+build
+    BUILD ../barretenberg/ts/+build
+    BUILD ../noir/+nargo
+    BUILD --pass-args ../noir-projects/+build
+    BUILD ../l1-contracts/+build
+    BUILD ../barretenberg/ts/+build
+    BUILD ../noir/+packages
+    FROM +deps
 
-COPY ../barretenberg/cpp/+preset-release/bin/bb /usr/src/barretenberg/cpp/build/bin/bb
-COPY ../barretenberg/cpp/+preset-release-world-state/bin/world_state_napi.node /usr/src/barretenberg/cpp/build/bin/world_state_napi.node
-COPY ../noir/+nargo/acvm /usr/src/noir/noir-repo/target/release/acvm
-COPY --dir ../noir-projects/+build/. /usr/src/noir-projects
-COPY ../l1-contracts/+build/usr/src/l1-contracts /usr/src/l1-contracts
+    COPY ../barretenberg/cpp/+preset-release/bin/bb /usr/src/barretenberg/cpp/build/bin/bb
+    COPY ../barretenberg/cpp/+preset-release-world-state/bin/world_state_napi.node /usr/src/barretenberg/cpp/build/bin/world_state_napi.node
+    COPY ../noir/+nargo/acvm /usr/src/noir/noir-repo/target/release/acvm
+    COPY --dir ../noir-projects/+build/. /usr/src/noir-projects
+    COPY ../l1-contracts/+build/usr/src/l1-contracts /usr/src/l1-contracts
 
-WORKDIR /usr/src/yarn-project
-COPY . .
-ENV PUPPETEER_SKIP_CHROMIUM_DOWNLOAD=true
-RUN ./bootstrap.sh full
-RUN cd ivc-integration && chmod +x run_browser_tests.sh && npx playwright install && npx playwright install-deps
+    WORKDIR /usr/src/yarn-project
+    COPY . .
+    ENV PUPPETEER_SKIP_CHROMIUM_DOWNLOAD=true
+    RUN ./bootstrap.sh full
+    RUN cd ivc-integration && chmod +x run_browser_tests.sh && npx playwright install && npx playwright install-deps
 
 
 build-dev:
-FROM +build
-SAVE ARTIFACT /usr/src /usr/src
+    FROM +build
+    SAVE ARTIFACT /usr/src /usr/src
 
 cli-base:
-FROM +build
-# Remove a bunch of stuff that we don't need that takes up space.
-RUN rm -rf \
-    ../noir-projects \
-    ../l1-contracts \
-    ../barretenberg/ts/src \
-    ../barretenberg/ts/dest/node-cjs \
-    ../barretenberg/ts/dest/browser
+    FROM +build
+    # Remove a bunch of stuff that we don't need that takes up space.
+    RUN rm -rf \
+        ../noir-projects \
+        ../l1-contracts \
+        ../barretenberg/ts/src \
+        ../barretenberg/ts/dest/node-cjs \
+        ../barretenberg/ts/dest/browser
 
 bb-cli:
-FROM +cli-base
+    FROM +cli-base
 
-ENV BB_WORKING_DIRECTORY=/usr/src/bb
-ENV BB_BINARY_PATH=/usr/src/barretenberg/cpp/build/bin/bb
-ENV ACVM_WORKING_DIRECTORY=/usr/src/acvm
-ENV ACVM_BINARY_PATH=/usr/src/noir/noir-repo/target/release/acvm
+    ENV BB_WORKING_DIRECTORY=/usr/src/bb
+    ENV BB_BINARY_PATH=/usr/src/barretenberg/cpp/build/bin/bb
+    ENV ACVM_WORKING_DIRECTORY=/usr/src/acvm
+    ENV ACVM_BINARY_PATH=/usr/src/noir/noir-repo/target/release/acvm
 
-RUN mkdir -p $BB_WORKING_DIRECTORY $ACVM_WORKING_DIRECTORY
+    RUN mkdir -p $BB_WORKING_DIRECTORY $ACVM_WORKING_DIRECTORY
 
-RUN yarn workspaces focus @aztec/bb-prover --production && yarn cache clean
-RUN rm -rf \
-    aztec.js/dest/main.js \
-    end-to-end \
-    **/src
+    RUN yarn workspaces focus @aztec/bb-prover --production && yarn cache clean
+    RUN rm -rf \
+        aztec.js/dest/main.js \
+        end-to-end \
+        **/src
 
-# yarn symlinks the binary to node_modules/.bin
-ENTRYPOINT ["/usr/src/yarn-project/node_modules/.bin/bb-cli"]
+    # yarn symlinks the binary to node_modules/.bin
+    ENTRYPOINT ["/usr/src/yarn-project/node_modules/.bin/bb-cli"]
 
 # helper target to generate vks in parallel
 verification-key:
-ARG circuit="RootRollupArtifact"
-FROM +bb-cli
+    ARG circuit="RootRollupArtifact"
+    FROM +bb-cli
 
-# this needs to be exported as an env var for RUN to pick it up
-ENV CIRCUIT=$circuit
-RUN --entrypoint write-vk -c $CIRCUIT
+    # this needs to be exported as an env var for RUN to pick it up
+    ENV CIRCUIT=$circuit
+    RUN --entrypoint write-vk -c $CIRCUIT
 
-SAVE ARTIFACT /usr/src/bb /usr/src/bb
+    SAVE ARTIFACT /usr/src/bb /usr/src/bb
 
 protocol-verification-keys:
-LOCALLY
-LET circuits = "RootRollupArtifact PrivateKernelTailArtifact PrivateKernelTailToPublicArtifact"
+    LOCALLY
+    LET circuits = "RootRollupArtifact PrivateKernelTailArtifact PrivateKernelTailToPublicArtifact"
 
-FOR circuit IN $circuits
-BUILD +verification-key --circuit=$circuit
-END
+    FOR circuit IN $circuits
+        BUILD +verification-key --circuit=$circuit
+    END
 
-# this could be FROM scratch
-# but FOR doesn't work without /bin/sh
-FROM ubuntu:noble
-WORKDIR /usr/src/bb
+    # this could be FROM scratch
+    # but FOR doesn't work without /bin/sh
+    FROM ubuntu:noble
+    WORKDIR /usr/src/bb
 
-FOR circuit IN $circuits
-COPY (+verification-key/usr/src/bb --circuit=$circuit) .
-END
+    FOR circuit IN $circuits
+        COPY (+verification-key/usr/src/bb --circuit=$circuit) .
+    END
 
-SAVE ARTIFACT /usr/src/bb /usr/src/bb
+    SAVE ARTIFACT /usr/src/bb /usr/src/bb
 
 rollup-verifier-contract:
-FROM +bb-cli
-COPY --dir +protocol-verification-keys/usr/src/bb /usr/src
-RUN --entrypoint write-contract -c RootRollupArtifact -n UltraHonkVerifier.sol
-SAVE ARTIFACT /usr/src/bb /usr/src/bb
+    FROM +bb-cli
+    COPY --dir +protocol-verification-keys/usr/src/bb /usr/src
+    RUN --entrypoint write-contract -c RootRollupArtifact -n UltraHonkVerifier.sol
+    SAVE ARTIFACT /usr/src/bb /usr/src/bb
 
 txe:
-FROM +cli-base
-RUN yarn workspaces focus @aztec/txe && yarn cache clean
-ENTRYPOINT ["node", "--no-warnings", "/usr/src/yarn-project/txe/dest/bin/index.js"]
-SAVE ARTIFACT /usr/src /usr/src
+    FROM +cli-base
+    RUN yarn workspaces focus @aztec/txe && yarn cache clean
+    ENTRYPOINT ["node", "--no-warnings", "/usr/src/yarn-project/txe/dest/bin/index.js"]
+    SAVE ARTIFACT /usr/src /usr/src
 
 cli-wallet-build:
-FROM +cli-base
-RUN yarn workspaces focus @aztec/cli-wallet --production && yarn cache clean
-SAVE ARTIFACT /usr/src /usr/src
+    FROM +cli-base
+    RUN yarn workspaces focus @aztec/cli-wallet --production && yarn cache clean
+    SAVE ARTIFACT /usr/src /usr/src
 
 cli-wallet:
-FROM ubuntu:noble
-RUN apt update && apt install nodejs curl socat -y && rm -rf /var/lib/apt/lists/* /tmp/* /var/tmp/*
-COPY +cli-wallet-build/usr/src /usr/src
-ENTRYPOINT ["/usr/src/yarn-project/cli-wallet/wallet-entrypoint.sh"]
+    FROM ubuntu:noble
+    RUN apt update && apt install nodejs curl socat -y && rm -rf /var/lib/apt/lists/* /tmp/* /var/tmp/*
+    COPY +cli-wallet-build/usr/src /usr/src
+    ENTRYPOINT ["/usr/src/yarn-project/cli-wallet/wallet-entrypoint.sh"]
 
 export-cli-wallet:
-FROM +cli-wallet
-ARG DIST_TAG="latest"
-ARG ARCH
-SAVE IMAGE --push aztecprotocol/cli-wallet:${DIST_TAG}${ARCH:+-$ARCH}
+    FROM +cli-wallet
+    ARG DIST_TAG="latest"
+    ARG ARCH
+    SAVE IMAGE --push aztecprotocol/cli-wallet:${DIST_TAG}${ARCH:+-$ARCH}
 
 aztec-prod:
-FROM +cli-base
-RUN yarn workspaces focus @aztec/aztec --production && yarn cache clean
-COPY --dir +rollup-verifier-contract/usr/src/bb /usr/src
-SAVE ARTIFACT /usr/src /usr/src
+    FROM +cli-base
+    RUN yarn workspaces focus @aztec/aztec --production && yarn cache clean
+    COPY --dir +rollup-verifier-contract/usr/src/bb /usr/src
+    SAVE ARTIFACT /usr/src /usr/src
 
 aztec:
-FROM ubuntu:noble
-RUN apt update && apt install nodejs curl jq -y && rm -rf /var/lib/apt/lists/* /tmp/* /var/tmp/*
-COPY +aztec-prod/usr/src /usr/src
-ENV BB_WORKING_DIRECTORY=/usr/src/bb
-ENV BB_BINARY_PATH=/usr/src/barretenberg/cpp/build/bin/bb
-ENV ACVM_WORKING_DIRECTORY=/usr/src/acvm
-ENV ACVM_BINARY_PATH=/usr/src/noir/noir-repo/target/release/acvm
-RUN mkdir -p $BB_WORKING_DIRECTORY $ACVM_WORKING_DIRECTORY /usr/src/yarn-project/world-state/build
-ENTRYPOINT ["node", "--no-warnings", "/usr/src/yarn-project/aztec/dest/bin/index.js"]
-LET port=8080
-ENV PORT=$port
-HEALTHCHECK --interval=10s --timeout=10s --retries=6 --start-period=120s \
-    CMD curl -fsS http://127.0.0.1:$port/status
-EXPOSE $port
+    FROM ubuntu:noble
+    RUN apt update && apt install nodejs curl jq -y && rm -rf /var/lib/apt/lists/* /tmp/* /var/tmp/*
+    COPY +aztec-prod/usr/src /usr/src
+    ENV BB_WORKING_DIRECTORY=/usr/src/bb
+    ENV BB_BINARY_PATH=/usr/src/barretenberg/cpp/build/bin/bb
+    ENV ACVM_WORKING_DIRECTORY=/usr/src/acvm
+    ENV ACVM_BINARY_PATH=/usr/src/noir/noir-repo/target/release/acvm
+    RUN mkdir -p $BB_WORKING_DIRECTORY $ACVM_WORKING_DIRECTORY /usr/src/yarn-project/world-state/build
+    ENTRYPOINT ["node", "--no-warnings", "/usr/src/yarn-project/aztec/dest/bin/index.js"]
+    LET port=8080
+    ENV PORT=$port
+    HEALTHCHECK --interval=10s --timeout=10s --retries=6 --start-period=120s \
+        CMD curl -fsS http://127.0.0.1:$port/status
+    EXPOSE $port
 
 aztec-faucet-build:
-FROM +cli-base
-RUN yarn workspaces focus @aztec/aztec-faucet --production && yarn cache clean
-RUN rm -rf \
-    aztec.js/dest/main.js \
-    end-to-end \
-    **/src
-SAVE ARTIFACT /usr/src /usr/src
+    FROM +cli-base
+    RUN yarn workspaces focus @aztec/aztec-faucet --production && yarn cache clean
+    RUN rm -rf \
+        aztec.js/dest/main.js \
+        end-to-end \
+        **/src
+    SAVE ARTIFACT /usr/src /usr/src
 
 aztec-faucet:
-FROM ubuntu:noble
-RUN apt update && apt install nodejs curl -y && rm -rf /var/lib/apt/lists/* /tmp/* /var/tmp/*
-COPY +aztec-faucet-build/usr/src /usr/src
-ENTRYPOINT ["node", "--no-warnings", "/usr/src/yarn-project/aztec-faucet/dest/bin/index.js"]
-LET port=8080
+    FROM ubuntu:noble
+    RUN apt update && apt install nodejs curl -y && rm -rf /var/lib/apt/lists/* /tmp/* /var/tmp/*
+    COPY +aztec-faucet-build/usr/src /usr/src
+    ENTRYPOINT ["node", "--no-warnings", "/usr/src/yarn-project/aztec-faucet/dest/bin/index.js"]
+    LET port=8080
 
 export-aztec-faucet:
-FROM +aztec-faucet
-ARG DIST_TAG="latest"
-ARG ARCH
-SAVE IMAGE --push aztecprotocol/aztec-faucet:${DIST_TAG}${ARCH:+-$ARCH}
+    FROM +aztec-faucet
+    ARG DIST_TAG="latest"
+    ARG ARCH
+    SAVE IMAGE --push aztecprotocol/aztec-faucet:${DIST_TAG}${ARCH:+-$ARCH}
 
 # We care about creating a slimmed down e2e image because we have to serialize it from earthly to docker for running.
 end-to-end-prod:
-BUILD ../spartan/+charts
-FROM +cli-base
-RUN yarn workspaces focus @aztec/end-to-end @aztec/cli-wallet --production && yarn cache clean
-COPY --dir +rollup-verifier-contract/usr/src/bb /usr/src
-COPY --dir +build-dev/usr/src/noir-projects/noir-contracts /usr/src/noir-projects/noir-contracts
-COPY --dir ../spartan/+charts/usr/src/spartan /usr/src/spartan
+    BUILD ../spartan/+charts
+    FROM +cli-base
+    RUN yarn workspaces focus @aztec/end-to-end @aztec/cli-wallet --production && yarn cache clean
+    COPY --dir +rollup-verifier-contract/usr/src/bb /usr/src
+    COPY --dir +build-dev/usr/src/noir-projects/noir-contracts /usr/src/noir-projects/noir-contracts
+    COPY --dir ../spartan/+charts/usr/src/spartan /usr/src/spartan
 
-SAVE ARTIFACT /usr/src /usr/src
+    SAVE ARTIFACT /usr/src /usr/src
 
 anvil:
-FROM ../build-images+from-registry
-SAVE ARTIFACT /opt/foundry/bin/anvil
+    FROM ../build-images+from-registry
+    SAVE ARTIFACT /opt/foundry/bin/anvil
 
 end-to-end-base:
-FROM ubuntu:noble
-# add repository for chromium
-RUN apt-get update && apt-get install -y software-properties-common \
-    && add-apt-repository ppa:xtradeb/apps -y && apt-get update \
-    && apt-get install -y wget gnupg \
-    && wget -q -O - https://dl-ssl.google.com/linux/linux_signing_key.pub | apt-key add - \
-    && echo "deb [arch=$(dpkg --print-architecture)] http://dl.google.com/linux/chrome/deb/ stable main" >> /etc/apt/sources.list.d/google-chrome.list \
-    && apt update && apt install curl chromium nodejs netcat-openbsd -y \
-    && rm -rf /var/lib/apt/lists/* \
-    && mkdir -p /usr/local/bin \
-    && curl -fsSL -o /usr/local/bin/kubectl "https://dl.k8s.io/release/$(curl -L -s https://dl.k8s.io/release/stable.txt)/bin/linux/amd64/kubectl" \
-    && chmod +x /usr/local/bin/kubectl \
-    && curl -fsSL -o get_helm.sh https://raw.githubusercontent.com/helm/helm/main/scripts/get-helm-3 \
-    && chmod +x get_helm.sh \
-    && ./get_helm.sh \
-    && rm get_helm.sh
+    FROM ubuntu:noble
+    # add repository for chromium
+    RUN apt-get update && apt-get install -y software-properties-common \
+        && add-apt-repository ppa:xtradeb/apps -y && apt-get update \
+        && apt-get install -y wget gnupg \
+        && wget -q -O - https://dl-ssl.google.com/linux/linux_signing_key.pub | apt-key add - \
+        && echo "deb [arch=$(dpkg --print-architecture)] http://dl.google.com/linux/chrome/deb/ stable main" >> /etc/apt/sources.list.d/google-chrome.list \
+        && apt update && apt install curl chromium nodejs netcat-openbsd -y \
+        && rm -rf /var/lib/apt/lists/* \
+        && mkdir -p /usr/local/bin \
+        && curl -fsSL -o /usr/local/bin/kubectl "https://dl.k8s.io/release/$(curl -L -s https://dl.k8s.io/release/stable.txt)/bin/linux/amd64/kubectl" \
+        && chmod +x /usr/local/bin/kubectl \
+        && curl -fsSL -o get_helm.sh https://raw.githubusercontent.com/helm/helm/main/scripts/get-helm-3 \
+        && chmod +x get_helm.sh \
+        && ./get_helm.sh \
+        && rm get_helm.sh
 
-ENV CHROME_BIN="/usr/bin/chromium"
-ENV PATH=/opt/foundry/bin:/usr/local/bin:$PATH
-ENV HARDWARE_CONCURRENCY=""
-ENV FAKE_PROOFS=""
-ENV BB_WORKING_DIRECTORY=/usr/src/bb
-ENV BB_BINARY_PATH=/usr/src/barretenberg/cpp/build/bin/bb
-ENV ACVM_WORKING_DIRECTORY=/usr/src/acvm
-ENV ACVM_BINARY_PATH=/usr/src/noir/noir-repo/target/release/acvm
-ENV PROVER_AGENT_CONCURRENCY=8
-RUN mkdir -p $BB_WORKING_DIRECTORY $ACVM_WORKING_DIRECTORY /usr/src/yarn-project/world-state/build
-RUN ln -s /usr/src/yarn-project/.yarn/releases/yarn-3.6.3.cjs /usr/local/bin/yarn
+    ENV CHROME_BIN="/usr/bin/chromium"
+    ENV PATH=/opt/foundry/bin:/usr/local/bin:$PATH
+    ENV HARDWARE_CONCURRENCY=""
+    ENV FAKE_PROOFS=""
+    ENV BB_WORKING_DIRECTORY=/usr/src/bb
+    ENV BB_BINARY_PATH=/usr/src/barretenberg/cpp/build/bin/bb
+    ENV ACVM_WORKING_DIRECTORY=/usr/src/acvm
+    ENV ACVM_BINARY_PATH=/usr/src/noir/noir-repo/target/release/acvm
+    ENV PROVER_AGENT_CONCURRENCY=8
+    RUN mkdir -p $BB_WORKING_DIRECTORY $ACVM_WORKING_DIRECTORY /usr/src/yarn-project/world-state/build
+    RUN ln -s /usr/src/yarn-project/.yarn/releases/yarn-3.6.3.cjs /usr/local/bin/yarn
 
 end-to-end:
-FROM +end-to-end-base
+    FROM +end-to-end-base
 
-COPY +anvil/anvil /opt/foundry/bin/anvil
-COPY +end-to-end-prod/usr/src /usr/src
-WORKDIR /usr/src/yarn-project/end-to-end
-ENTRYPOINT ["yarn", "test"]
+    COPY +anvil/anvil /opt/foundry/bin/anvil
+    COPY +end-to-end-prod/usr/src /usr/src
+    WORKDIR /usr/src/yarn-project/end-to-end
+    ENTRYPOINT ["yarn", "test"]
 
 scripts-prod:
-RUN yarn workspaces focus @aztec/scripts --production && yarn cache clean
-SAVE ARTIFACT /usr/src /usr/src
+    RUN yarn workspaces focus @aztec/scripts --production && yarn cache clean
+    SAVE ARTIFACT /usr/src /usr/src
 
 all:
-BUILD +aztec
-BUILD +end-to-end
+    BUILD +aztec
+    BUILD +end-to-end
 
 export-aztec:
-ARG EARTHLY_GIT_HASH
-FROM +aztec
-SAVE IMAGE aztecprotocol/aztec:$EARTHLY_GIT_HASH
+    ARG EARTHLY_GIT_HASH
+    FROM +aztec
+    SAVE IMAGE aztecprotocol/aztec:$EARTHLY_GIT_HASH
 
 export-aztec-arch:
-FROM +aztec
-ARG DIST_TAG="latest"
-ARG ARCH
-SAVE IMAGE --push aztecprotocol/aztec:${DIST_TAG}${ARCH:+-$ARCH}
+    FROM +aztec
+    ARG DIST_TAG="latest"
+    ARG ARCH
+    SAVE IMAGE --push aztecprotocol/aztec:${DIST_TAG}${ARCH:+-$ARCH}
 
 export-end-to-end:
-ARG EARTHLY_GIT_HASH
-FROM +end-to-end
-SAVE IMAGE aztecprotocol/end-to-end:$EARTHLY_GIT_HASH
+    ARG EARTHLY_GIT_HASH
+    FROM +end-to-end
+    SAVE IMAGE aztecprotocol/end-to-end:$EARTHLY_GIT_HASH
 
 export-e2e-test-images:
-BUILD +export-aztec
-BUILD +export-end-to-end
+    BUILD +export-aztec
+    BUILD +export-end-to-end
 
 format-check:
-FROM +build
-RUN yarn formatting
+    FROM +build
+    RUN yarn formatting
 
 test:
-FROM +build
-RUN yarn test
+    FROM +build
+    RUN yarn test
 
 run-e2e:
-ARG test
-ARG debug=""
-FROM +end-to-end
-RUN DEBUG=$debug yarn test $test
+    ARG test
+    ARG debug=""
+    FROM +end-to-end
+    RUN DEBUG=$debug yarn test $test
 
 prover-client-test:
-FROM +build
-ARG test
-ARG debug=""
-RUN cd prover-client && DEBUG=$debug yarn test $test
+    FROM +build
+    ARG test
+    ARG debug=""
+    RUN cd prover-client && DEBUG=$debug yarn test $test
 
 # NOTE: This is not in the end-to-end Earthfile as that is entirely LOCALLY commands that will go away sometime.
 # Running this inside the main builder as the point is not to run this through dockerization.
 network-test:
-ARG test=./test-transfer.sh
-ARG validators=3
-FROM +build
-WORKDIR /usr/src/
-# Bare minimum git setup to run 'git rev-parse --show-toplevel'
-RUN git init -b master
-COPY ../scripts/+scripts/run_interleaved.sh scripts/run_interleaved.sh
-WORKDIR /usr/src/yarn-project
-# All script arguments are in the end-to-end/scripts/native-network folder
-ENV LOG_LEVEL=verbose
-RUN INTERLEAVED=true end-to-end/scripts/native_network_test.sh \
-    "$test" \
-    ./deploy-l1-contracts.sh \
-    ./deploy-l2-contracts.sh \
-    ./boot-node.sh \
-    ./ethereum.sh \
-    "./prover-node.sh 8078 false" \
-    ./pxe.sh \
-    "./validators.sh $validators"
+    ARG test=./test-transfer.sh
+    ARG validators=3
+    FROM +build
+    WORKDIR /usr/src/
+    # Bare minimum git setup to run 'git rev-parse --show-toplevel'
+    RUN git init -b master
+    COPY ../scripts/+scripts/run_interleaved.sh scripts/run_interleaved.sh
+    WORKDIR /usr/src/yarn-project
+    # All script arguments are in the end-to-end/scripts/native-network folder
+    ENV LOG_LEVEL=verbose
+    RUN INTERLEAVED=true end-to-end/scripts/native_network_test.sh \
+        "$test" \
+        ./deploy-l1-contracts.sh \
+        ./deploy-l2-contracts.sh \
+        ./boot-node.sh \
+        ./ethereum.sh \
+        "./prover-node.sh 8078 false" \
+        ./pxe.sh \
+        "./validators.sh $validators"
 
 publish-npm:
-FROM +build
-ARG DIST_TAG="latest"
-ARG VERSION
-ARG DRY_RUN=0
-WORKDIR /usr/src/yarn-project
-RUN --secret NPM_TOKEN ./publish_npm.sh $DIST_TAG $VERSION $DRY_RUN
+    FROM +build
+    ARG DIST_TAG="latest"
+    ARG VERSION
+    ARG DRY_RUN=0
+    WORKDIR /usr/src/yarn-project
+    RUN --secret NPM_TOKEN ./publish_npm.sh $DIST_TAG $VERSION $DRY_RUN

--- a/yarn-project/Earthfile
+++ b/yarn-project/Earthfile
@@ -261,8 +261,13 @@ end-to-end:
     WORKDIR /usr/src/yarn-project/end-to-end
     ENTRYPOINT ["yarn", "test"]
 
+scripts-preview:
+    FROM +build
+    RUN yarn workspaces focus @aztec/scripts --production && yarn cache clean
+    SAVE ARTIFACT /usr/src /usr/src
+
 scripts-prod:
-    FROM +build-docs-dev
+    FROM +deps
     RUN yarn workspaces focus @aztec/scripts --production && yarn cache clean
     SAVE ARTIFACT /usr/src /usr/src
 


### PR DESCRIPTION
This PR removes the src build step from the docs build flow. 

Successful CI Run: https://github.com/AztecProtocol/aztec-packages/actions/runs/11960317707

- I have verified that `/yarn-project/+scripts-prod` is only referenced by `/docs/Earthfile` and does not have other dependences
- The actual doc build itself is covered by setting the yarn workspace + inheriting `FROM +serve` within the current workflow (see below). `FROM +serve` itself uses `COPY +build/build build`, which made a duplicate request to build src (it appears src was being built twice).

```
deploy-preview:
  BUILD ../yarn-project/+scripts-prod
  ARG ENV
  ARG NETLIFY_AUTH_TOKEN
  ARG NETLIFY_SITE_ID
  ARG AZTEC_BOT_COMMENTER_GITHUB_TOKEN
  ARG PR
  FROM +serve
  COPY --dir ../yarn-project/+scripts-prod/usr/src/yarn-project /usr/src
  COPY ./netlify.toml .
  COPY ./deploy_preview.sh .
  RUN NETLIFY_AUTH_TOKEN=$NETLIFY_AUTH_TOKEN NETLIFY_SITE_ID=$NETLIFY_SITE_ID ./deploy_preview.sh $PR $AZTEC_BOT_COMMENTER_GITHUB_TOKEN

deploy-prod:
  BUILD ../yarn-project/+scripts-prod
  ARG NETLIFY_AUTH_TOKEN
  ARG NETLIFY_SITE_ID
  FROM +serve
  COPY ./netlify.toml .
  COPY ./deploy_prod.sh .
  RUN NETLIFY_AUTH_TOKEN=$NETLIFY_AUTH_TOKEN NETLIFY_SITE_ID=$NETLIFY_SITE_ID ./deploy_prod.sh
```