### PR TITLE
fix: prover-agent.yaml syntax

### DIFF
--- a/spartan/aztec-network/templates/prover-agent.yaml
+++ b/spartan/aztec-network/templates/prover-agent.yaml
@@ -30,6 +30,7 @@ spec:
         operator: "Equal"
         value: "true"
         effect: "NoSchedule"
+      {{- end }}
       serviceAccountName: {{ include "aztec-network.fullname" . }}-node
       {{- if .Values.network.public }}
       hostNetwork: true


### PR DESCRIPTION
This is breaking kind smoke test (and the heavier kind tests)