### PR TITLE
chore: Do not run e2e-2-pxes along with e2e pxe test

### DIFF
--- a/yarn-project/end-to-end/scripts/e2e_test_config.yml
+++ b/yarn-project/end-to-end/scripts/e2e_test_config.yml
@@ -75,6 +75,8 @@ tests:
     env:
       HARDWARE_CONCURRENCY: '32'
   e2e_public_testnet: {}
+  e2e_pxe:
+    use_compose: true
   e2e_sandbox_example:
     use_compose: true
   e2e_state_vars: {}
@@ -111,8 +113,6 @@ tests:
     use_compose: true
     test_path: 'guides/writing_an_account_contract.test.ts'
   integration_l1_publisher:
-    use_compose: true
-  pxe:
     use_compose: true
   # https://github.com/AztecProtocol/aztec-packages/issues/10030
   # uniswap_trade_on_l1_from_l2:

--- a/yarn-project/end-to-end/src/composed/e2e_pxe.test.ts
+++ b/yarn-project/end-to-end/src/composed/e2e_pxe.test.ts
@@ -9,4 +9,4 @@ const setupEnv = async () => {
   return pxe;
 };
 
-pxeTestSuite('pxe', setupEnv);
+pxeTestSuite('e2e_pxe', setupEnv);


### PR DESCRIPTION
Running the e2e pxe test would also run 2-pxes on the same job, since jest matches tests by substring. This renames the pxe to e2e-pxe to avoid clashes.

