### PR TITLE
fix(bb.js): don't minify bb.js - webpack config

### DIFF
--- a/barretenberg/ts/webpack.config.js
+++ b/barretenberg/ts/webpack.config.js
@@ -3,6 +3,9 @@ import { fileURLToPath } from 'url';
 import ResolveTypeScriptPlugin from 'resolve-typescript-plugin';
 import webpack from 'webpack';
 
+/**
+ * @type {import('webpack').Configuration}
+ */
 export default {
   target: 'web',
   mode: 'production',
@@ -39,6 +42,9 @@ export default {
     library: {
       type: 'module',
     },
+  },
+  optimization: {
+    minimize: false,
   },
   experiments: {
     outputModule: true,


### PR DESCRIPTION
Libraries should not be minified. Minification and bundling is usually done on app end. Unminifying bb.js will allow patching top-level await as a temporary workaround to fix Safari.