### PR TITLE
fix: add curl to aztec nargo container

### DIFF
--- a/aztec-nargo/Dockerfile
+++ b/aztec-nargo/Dockerfile
@@ -11,7 +11,7 @@ FROM --platform=linux/amd64 aztecprotocol/barretenberg-x86_64-linux-clang as bar
 FROM ubuntu:noble
 # Install Tini as nargo doesn't handle signals properly.
 # Install git as nargo needs it to clone.
-RUN apt-get update && apt-get install -y git tini jq && rm -rf /var/lib/apt/lists/* && apt-get clean
+RUN apt-get update && apt-get install -y git tini jq curl && rm -rf /var/lib/apt/lists/* && apt-get clean
 
 # Copy binaries to /usr/bin
 COPY --from=built-noir /usr/src/noir/noir-repo/target/release/nargo /usr/bin/nargo


### PR DESCRIPTION
## Overview

Reports aztec-nargo compile fails with `curl not found`, this probably happens in the postprocess script

Offending function
```
std::vector<uint8_t> download_bn254_g2_data()
{
    std::string url = "https://aztec-ignition.s3.amazonaws.com/MAIN%20IGNITION/flat/g2.dat";
    // IMPORTANT: this currently uses a shell, DO NOT let user-controlled strings here.
    std::string command = "curl -s '" + url + "'";
    return exec_pipe(command);
}
} // namespace
```