### PR TITLE
fix: also publish to version tag if on master, not just to master

### DIFF
--- a/.github/workflows/publish-aztec-packages.yml
+++ b/.github/workflows/publish-aztec-packages.yml
@@ -275,7 +275,7 @@ jobs:
         with:
           concurrency_key: publish-npm
           dockerhub_password: "${{ env.DOCKERHUB_PASSWORD }}"
-      
+
       - name: Publish bb.js NPM package
         run: |
           DEPLOY_TAG=${{ env.DEPLOY_TAG }}
@@ -335,11 +335,15 @@ jobs:
         working-directory: ./aztec-up/terraform
         run: |
           terraform init
+
+          # Also publish a master tag if we're on the master branch
           if [ "${{ github.ref_name }}" == "master" ]; then
             TAG=master
-          else
-            TAG=${{ env.DEPLOY_TAG }}
+            export TF_VAR_VERSION=${TAG#aztec-packages-v}
+            terraform apply -auto-approve
           fi
+
+          TAG=${{ env.DEPLOY_TAG }}
           export TF_VAR_VERSION=${TAG#aztec-packages-v}
           terraform apply -auto-approve
 


### PR DESCRIPTION
## Overview

A switch condition was being hit to deploy with master as the tag if we were on master, but it was NOT also deploying to the version when i think it should.

This has left the docker composes unupdated after the last release, when they should have been updated


WARNING: I HAVE NOT RAN THIS SCRIPT CHANGE