### PR TITLE
chore: fix devbox

### DIFF
--- a/build-images/Earthfile
+++ b/build-images/Earthfile
@@ -328,7 +328,7 @@ devbox:
   SAVE IMAGE aztecprotocol/devbox:1.0
 
 devbox-manifest:
-  LET VERSION = 1.0
+  LET VERSION = 1.1
   ARG TARGETARCH
   WAIT
     BUILD +devbox

--- a/build-images/Earthfile
+++ b/build-images/Earthfile
@@ -428,5 +428,5 @@ sysbox:
   EXPOSE 22
 
   ARG TARGETARCH
-  SAVE IMAGE aztecprotocol/sysbox:1.0-$TARGETARCH
-  SAVE IMAGE aztecprotocol/sysbox:1.0
+  SAVE IMAGE aztecprotocol/sysbox:1.1-$TARGETARCH
+  SAVE IMAGE aztecprotocol/sysbox:1.1

--- a/build-images/Earthfile
+++ b/build-images/Earthfile
@@ -323,9 +323,9 @@ devbox:
   CMD ["/bin/zsh"]
 
   ARG TARGETARCH
-  SAVE IMAGE --push aztecprotocol/devbox:1.0-$TARGETARCH
+  SAVE IMAGE --push aztecprotocol/devbox:1.1-$TARGETARCH
   # Save it without the arch tag as this is what's referenced in devcontainer.json
-  SAVE IMAGE aztecprotocol/devbox:1.0
+  SAVE IMAGE aztecprotocol/devbox:1.1
 
 devbox-manifest:
   LET VERSION = 1.1

--- a/build-images/Earthfile
+++ b/build-images/Earthfile
@@ -141,6 +141,8 @@ build:
           # Python (clang bindings for wasm bindgen.)
           python3 \
           python3-clang \
+          # Unminimize ubuntu installation, recently removed from base images
+          unminimize \
       && apt-get -y autoremove \
       && apt-get clean \
       && rm -rf /var/lib/apt/lists/* /tmp/* /var/tmp/*

--- a/build-images/run.sh
+++ b/build-images/run.sh
@@ -41,5 +41,5 @@ else
     -vdevbox-var-lib-docker:/var/lib/docker \
     -v$HOME/.ssh/id_rsa:/home/aztec-dev/.ssh/id_rsa:ro \
     --privileged \
-    aztecprotocol/devbox:1.0
+    aztecprotocol/devbox:1.1
 fi


### PR DESCRIPTION
:1.1 has been pushed to docker hub, devs should no longer get a foundry image check failure

<img width="861" alt="image" src="https://github.com/user-attachments/assets/d6e02425-d95d-49c6-8497-d21bcf84b404">
