### PR TITLE
fix: Increase test timeouts

### DIFF
--- a/yarn-project/world-state/src/native/native_world_state.test.ts
+++ b/yarn-project/world-state/src/native/native_world_state.test.ts
@@ -16,6 +16,7 @@ import {
 } from '@aztec/circuits.js';
 import { makeContentCommitment, makeGlobalVariables } from '@aztec/circuits.js/testing';
 
+import { jest } from '@jest/globals';
 import { mkdtemp, rm } from 'fs/promises';
 import { tmpdir } from 'os';
 import { join } from 'path';
@@ -25,6 +26,8 @@ import { INITIAL_NULLIFIER_TREE_SIZE, INITIAL_PUBLIC_DATA_TREE_SIZE } from '../w
 import { type WorldStateStatusSummary } from './message.js';
 import { NativeWorldStateService, WORLD_STATE_VERSION_FILE } from './native_world_state.js';
 import { WorldStateVersion } from './world_state_version.js';
+
+jest.setTimeout(60_000);
 
 describe('NativeWorldState', () => {
   let dataDir: string;
@@ -52,7 +55,7 @@ describe('NativeWorldState', () => {
 
       await ws.handleL2BlockAndMessages(block, messages);
       await ws.close();
-    }, 30_000);
+    });
 
     it('correctly restores committed state', async () => {
       const ws = await NativeWorldStateService.new(rollupAddress, dataDir, defaultDBMapSize);
@@ -243,7 +246,7 @@ describe('NativeWorldState', () => {
 
       const forkAtZero = await ws.fork(0);
       await compareChains(forkAtGenesis, forkAtZero);
-    }, 30_000);
+    });
   });
 
   describe('Pending and Proven chain', () => {
@@ -278,7 +281,7 @@ describe('NativeWorldState', () => {
           expect(status.summary.finalisedBlockNumber).toBe(0n);
         }
       }
-    }, 30_000);
+    });
 
     it('Can finalise multiple blocks', async () => {
       const fork = await ws.fork();
@@ -297,7 +300,7 @@ describe('NativeWorldState', () => {
       expect(status.unfinalisedBlockNumber).toBe(16n);
       expect(status.oldestHistoricalBlock).toBe(1n);
       expect(status.finalisedBlockNumber).toBe(8n);
-    }, 30_000);
+    });
 
     it('Can prune historic blocks', async () => {
       const fork = await ws.fork();
@@ -348,7 +351,7 @@ describe('NativeWorldState', () => {
           'Unable to remove historical block, block not found',
         );
       }
-    }, 30_000);
+    });
 
     it('Can re-org', async () => {
       const nonReorgState = await NativeWorldStateService.tmp();
@@ -448,7 +451,7 @@ describe('NativeWorldState', () => {
       }
 
       await compareChains(ws.getCommitted(), nonReorgState.getCommitted());
-    }, 30_000);
+    });
 
     it('Forks are deleted during a re-org', async () => {
       const fork = await ws.fork();
@@ -480,7 +483,7 @@ describe('NativeWorldState', () => {
           await expect(blockForks[i].getSiblingPath(MerkleTreeId.NULLIFIER_TREE, 0n)).rejects.toThrow('Fork not found');
         }
       }
-    }, 30_000);
+    });
   });
 
   describe('status reporting', () => {
@@ -596,6 +599,6 @@ describe('NativeWorldState', () => {
       expect(statuses[0].dbStats.publicDataTreeStats.mapSize).toBe(mapSizeBytes);
 
       await ws.close();
-    }, 30_000);
+    });
   });
 });

--- a/yarn-project/world-state/src/native/native_world_state_cmp.test.ts
+++ b/yarn-project/world-state/src/native/native_world_state_cmp.test.ts
@@ -133,24 +133,20 @@ describe('NativeWorldState', () => {
           .fill(0)
           .map(() => new PublicDataTreeLeaf(Fr.random(), Fr.random()).toBuffer()),
       ],
-    ])(
-      'inserting real leaves into %s',
-      async (_, treeId, leaves) => {
-        const height = Math.ceil(Math.log2(leaves.length) | 0);
-        const [native, js] = await Promise.all([
-          nativeFork.batchInsert(treeId, leaves, height),
-          legacyLatest.batchInsert(treeId, leaves, height),
-        ]);
+    ])('inserting real leaves into %s', async (_, treeId, leaves) => {
+      const height = Math.ceil(Math.log2(leaves.length) | 0);
+      const [native, js] = await Promise.all([
+        nativeFork.batchInsert(treeId, leaves, height),
+        legacyLatest.batchInsert(treeId, leaves, height),
+      ]);
 
-        expect(native.sortedNewLeaves.map(Fr.fromBuffer)).toEqual(js.sortedNewLeaves.map(Fr.fromBuffer));
-        expect(native.sortedNewLeavesIndexes).toEqual(js.sortedNewLeavesIndexes);
-        expect(native.newSubtreeSiblingPath.toFields()).toEqual(js.newSubtreeSiblingPath.toFields());
-        expect(native.lowLeavesWitnessData).toEqual(js.lowLeavesWitnessData);
+      expect(native.sortedNewLeaves.map(Fr.fromBuffer)).toEqual(js.sortedNewLeaves.map(Fr.fromBuffer));
+      expect(native.sortedNewLeavesIndexes).toEqual(js.sortedNewLeavesIndexes);
+      expect(native.newSubtreeSiblingPath.toFields()).toEqual(js.newSubtreeSiblingPath.toFields());
+      expect(native.lowLeavesWitnessData).toEqual(js.lowLeavesWitnessData);
 
-        await assertSameTree(treeId, nativeFork, legacyLatest);
-      },
-      60_000,
-    );
+      await assertSameTree(treeId, nativeFork, legacyLatest);
+    });
 
     it.each<[string, FrTreeId, Fr[]]>([
       [MerkleTreeId[MerkleTreeId.NOTE_HASH_TREE], MerkleTreeId.NOTE_HASH_TREE, Array(64).fill(0).map(Fr.random)],

--- a/yarn-project/world-state/src/test/integration.test.ts
+++ b/yarn-project/world-state/src/test/integration.test.ts
@@ -14,6 +14,8 @@ import { createWorldState } from '../synchronizer/factory.js';
 import { ServerWorldStateSynchronizer } from '../synchronizer/server_world_state_synchronizer.js';
 import { mockBlocks } from './utils.js';
 
+jest.setTimeout(60_000);
+
 describe('world-state integration', () => {
   let rollupAddress: EthAddress;
   let archiver: MockPrefilledArchiver;
@@ -34,7 +36,7 @@ describe('world-state integration', () => {
     log.info(`Generating ${MAX_BLOCK_COUNT} mock blocks`);
     ({ blocks, messages } = await mockBlocks(1, MAX_BLOCK_COUNT, 1, db));
     log.info(`Generated ${blocks.length} mock blocks`);
-  }, 30_000);
+  });
 
   beforeEach(async () => {
     config = {


### PR DESCRIPTION
Some world state tests can take a few seconds to run on a local machine. In CI, they can take much longer and this is causing flakes. As much as I dislike increasing test timeouts to fix flakes, this feels like the only option.
