### PR TITLE
chore: centralized helm flag for proving and clean release tf deploys

### DIFF
--- a/spartan/aztec-network/templates/boot-node.yaml
+++ b/spartan/aztec-network/templates/boot-node.yaml
@@ -157,9 +157,9 @@ spec:
             - name: OTEL_EXPORTER_OTLP_LOGS_ENDPOINT
               value: {{ include "aztec-network.otelCollectorLogsEndpoint" . | quote }}
             - name: PROVER_REAL_PROOFS
-              value: "{{ .Values.bootNode.realProofs }}"
+              value: "{{ .Values.aztec.realProofs }}"
             - name: PXE_PROVER_ENABLED
-              value: "{{ .Values.bootNode.realProofs }}"
+              value: "{{ .Values.aztec.realProofs }}"
             - name: ETHEREUM_SLOT_DURATION
               value: "{{ .Values.ethereum.blockTime }}"
             - name: AZTEC_SLOT_DURATION

--- a/spartan/aztec-network/templates/prover-agent.yaml
+++ b/spartan/aztec-network/templates/prover-agent.yaml
@@ -88,7 +88,7 @@ spec:
             - name: DEBUG
               value: "{{ .Values.proverAgent.debug }}"
             - name: PROVER_REAL_PROOFS
-              value: "{{ .Values.proverAgent.realProofs }}"
+              value: "{{ .Values.aztec.realProofs }}"
             - name: PROVER_AGENT_COUNT
               value: "1"
             - name: PROVER_AGENT_POLL_INTERVAL_MS

--- a/spartan/aztec-network/templates/prover-node.yaml
+++ b/spartan/aztec-network/templates/prover-node.yaml
@@ -121,7 +121,7 @@ spec:
             - name: DEBUG
               value: "{{ .Values.proverNode.debug }}"
             - name: PROVER_REAL_PROOFS
-              value: "{{ .Values.proverNode.realProofs }}"
+              value: "{{ .Values.aztec.realProofs }}"
             - name: PROVER_AGENT_COUNT
               value: "{{ .Values.proverNode.proverAgent.count }}"
             - name: PROVER_AGENT_POLL_INTERVAL_MS

--- a/spartan/aztec-network/templates/pxe.yaml
+++ b/spartan/aztec-network/templates/pxe.yaml
@@ -87,7 +87,7 @@ spec:
             - name: DEBUG
               value: "{{ .Values.pxe.debug }}"
             - name: PXE_PROVER_ENABLED
-              value: "{{ .Values.pxe.proverEnabled }}"
+              value: "{{ .Values.aztec.realProofs }}"
           ports:
             - name: http
               containerPort: {{ .Values.pxe.service.nodePort }}

--- a/spartan/aztec-network/templates/transaction-bot.yaml
+++ b/spartan/aztec-network/templates/transaction-bot.yaml
@@ -94,9 +94,9 @@ spec:
             - name: BOT_NO_START
               value: "{{ .Values.bot.botNoStart }}"
             - name: PXE_PROVER_ENABLED
-              value: "{{ .Values.bot.pxeProverEnabled }}"
+              value: "{{ .Values.aztec.realProofs }}"
             - name: PROVER_REAL_PROOFS
-              value: "{{ .Values.bot.proverRealProofs }}"
+              value: "{{ .Values.aztec.realProofs }}"
             - name: BOT_MAX_CONSECUTIVE_ERRORS
               value: "{{ .Values.bot.maxErrors }}"
             - name: BOT_STOP_WHEN_UNHEALTHY

--- a/spartan/aztec-network/values.yaml
+++ b/spartan/aztec-network/values.yaml
@@ -33,6 +33,7 @@ aztec:
   slotDuration: 24 # in seconds, aka L2 slot duration. Must be a multiple of {{ ethereum.blockTime }}
   epochDuration: 16 # how many L2 slots in an epoch
   epochProofClaimWindow: 13 # in L2 slots
+  realProofs: false
 
 bootNode:
   peerIdPrivateKey: ""
@@ -48,7 +49,6 @@ bootNode:
   sequencer:
     maxSecondsBetweenBlocks: 0
     minTxsPerBlock: 1
-  realProofs: false
   validator:
     disabled: true
   p2p:
@@ -118,7 +118,6 @@ proverNode:
     nodePort: 8080
   logLevel: "debug"
   debug: "aztec:*,-aztec:avm_simulator*,-aztec:libp2p_service*,-aztec:circuits:artifact_hash,-json-rpc*,-aztec:world-state:database,-aztec:l2_block_stream*"
-  realProofs: false
   proverAgent:
     count: 0
     pollIntervalMs: 1000
@@ -136,9 +135,7 @@ proverNode:
   storage: "8Gi"
 
 pxe:
-  proverEnabled: false
   logLevel: "debug"
-  proverEnable: false
   debug: "aztec:*,-aztec:avm_simulator*,-aztec:libp2p_service*,-aztec:circuits:artifact_hash,-json-rpc*,-aztec:world-state:database,-aztec:l2_block_stream*"
   replicas: 1
   service:
@@ -167,8 +164,6 @@ bot:
   # Do not wait for transactions
   followChain: "NONE"
   botNoStart: false
-  pxeProverEnabled: false
-  proverRealProofs: false
   maxErrors: 3
   stopIfUnhealthy: true
   service:
@@ -222,7 +217,6 @@ proverAgent:
     spotEnabled: false
   logLevel: "debug"
   debug: "aztec:*,-aztec:avm_simulator*,-aztec:libp2p_service*,-aztec:circuits:artifact_hash,-json-rpc*,-aztec:world-state:database,-aztec:l2_block_stream*"
-  realProofs: false
   bb:
     hardwareConcurrency: ""
   nodeSelector: {}

--- a/spartan/aztec-network/values/1-validator-with-proving-and-metrics.yaml
+++ b/spartan/aztec-network/values/1-validator-with-proving-and-metrics.yaml
@@ -1,3 +1,8 @@
+aztec:
+  realProofs: true
+  slotDuration: 36
+  epochDuration: 32
+
 validator:
   replicas: 1
   validatorKeys:
@@ -11,12 +16,8 @@ bootNode:
   validator:
     disabled: true
 
-proverNode:
-  realProofs: true
-
 proverAgent:
   replicas: 6
-  realProofs: true
   bb:
     hardwareConcurrency: 16
   resources:
@@ -27,21 +28,13 @@ proverAgent:
       memory: "96Gi"
       cpu: "16"
 
-pxe:
-  proverEnabled: true
-
 bot:
   enabled: true
-  pxeProverEnabled: true
   txIntervalSeconds: 200
 
 jobs:
   deployL1Verifier:
     enable: true
-
-aztec:
-  slotDuration: 36
-  epochDuration: 32
 
 telemetry:
   enabled: true

--- a/spartan/aztec-network/values/1-validator-with-proving.yaml
+++ b/spartan/aztec-network/values/1-validator-with-proving.yaml
@@ -1,3 +1,8 @@
+aztec:
+  realProofs: true
+  slotDuration: 36
+  epochDuration: 32
+
 validator:
   replicas: 1
   validatorKeys:
@@ -11,12 +16,8 @@ bootNode:
   validator:
     disabled: true
 
-proverNode:
-  realProofs: true
-
 proverAgent:
   replicas: 6
-  realProofs: true
   bb:
     hardwareConcurrency: 16
   resources:
@@ -27,18 +28,10 @@ proverAgent:
       memory: "96Gi"
       cpu: "16"
 
-pxe:
-  proverEnabled: true
-
 bot:
   enabled: true
-  pxeProverEnabled: true
   txIntervalSeconds: 200
 
 jobs:
   deployL1Verifier:
     enable: true
-
-aztec:
-  slotDuration: 36
-  epochDuration: 32

--- a/spartan/aztec-network/values/gcp-proving-test.yaml
+++ b/spartan/aztec-network/values/gcp-proving-test.yaml
@@ -23,7 +23,6 @@ validator:
   storage: "128Gi"
 
 bootNode:
-  realProofs: true
   validator:
     disabled: true
   resources:
@@ -33,7 +32,6 @@ bootNode:
   storage: "128Gi"
 
 proverNode:
-  realProofs: true
   resources:
     requests:
       memory: "8Gi"
@@ -42,7 +40,6 @@ proverNode:
 
 proverAgent:
   replicas: 120
-  realProofs: true
   bb:
     hardwareConcurrency: 31
   resources:
@@ -50,15 +47,10 @@ proverAgent:
       memory: "116Gi"
       cpu: "31"
 
-pxe:
-  proverEnabled: true
-
 bot:
   replicas: 16
   enabled: true
-  pxeProverEnabled: true
   txIntervalSeconds: 1
-  proverRealProofs: true
   botPrivateKey: ""
   privateTransfersPerTx: 1
   publicTransfersPerTx: 1
@@ -80,3 +72,4 @@ fullnameOverride: sp
 aztec:
   slotDuration: 36
   epochDuration: 32
+  realProofs: true

--- a/spartan/aztec-network/values/multicloud-demo.yaml
+++ b/spartan/aztec-network/values/multicloud-demo.yaml
@@ -17,12 +17,8 @@ bootNode:
   validator:
     disabled: true
 
-proverNode:
-  realProofs: false
-
 proverAgent:
   replicas: 1
-  realProofs: false
   bb:
     hardwareConcurrency: 16
 

--- a/spartan/aztec-network/values/prover-node-with-agents.yaml
+++ b/spartan/aztec-network/values/prover-node-with-agents.yaml
@@ -16,22 +16,16 @@ bootNode:
   validator:
     disabled: true
 
-proverNode:
-  realProofs: false
-
 proverAgent:
   replicas: 1
-  realProofs: false
   bb:
     hardwareConcurrency: 16
 
 pxe:
   external: false
-  proverEnabled: true
 
 bot:
   enabled: false
-  pxeProverEnabled: false
   txIntervalSeconds: 200
 
 jobs:

--- a/spartan/aztec-network/values/release.yaml
+++ b/spartan/aztec-network/values/release.yaml
@@ -1,6 +1,11 @@
 network:
   public: true
 
+aztec:
+  slotDuration: 36
+  epochDuration: 32
+  realProofs: true
+
 images:
   aztec:
     pullPolicy: Always
@@ -10,7 +15,6 @@ telemetry:
   otelCollectorEndpoint: http://34.150.160.154:4318
 
 validator:
-  realProofs: true
   replicas: 48
   validatorKeys:
     - 0xac0974bec39a17e36ba4a6b4d238ff944bacb478cbed5efcae784d7bf4f2ff80
@@ -118,17 +122,12 @@ validator:
     disabled: false
 
 bootNode:
-  realProofs: true
   peerIdPrivateKey: 080212200ba8451c6d62b03c4441f0a466c0bce7a3a595f2cf50a055ded3305c77aa3af0
   validator:
     disabled: true
 
-proverNode:
-  realProofs: true
-
 proverAgent:
   replicas: 4
-  realProofs: true
   bb:
     hardwareConcurrency: 16
   gke:
@@ -141,19 +140,11 @@ proverAgent:
       memory: "96Gi"
       cpu: "16"
 
-pxe:
-  proverEnabled: true
-
 bot:
   followChain: "PENDING"
   enabled: true
-  pxeProverEnabled: true
   txIntervalSeconds: 200
 
 jobs:
   deployL1Verifier:
     enable: true
-
-aztec:
-  slotDuration: 36
-  epochDuration: 32

--- a/spartan/terraform/deploy-release/deploy.sh
+++ b/spartan/terraform/deploy-release/deploy.sh
@@ -1,5 +1,12 @@
 #!/bin/bash
 
-RELEASE_NAME="rough-rhino"
+# Usage: ./deploy.sh <release_name> <aztec_docker_image>
+# Example: ./deploy.sh rough-rhino aztecprotocol/aztec:698cd3d62680629a3f1bfc0f82604534cedbccf3-x86_64
+
+set -eu
+
+RELEASE_NAME=$1
+AZTEC_DOCKER_IMAGE=$2
+
 terraform init -backend-config="key=deploy-network/${RELEASE_NAME}/terraform.tfstate"
-terraform apply -var-file="release.tfvars"
+terraform apply -var-file="release.tfvars" -var="RELEASE_NAME=${RELEASE_NAME}" -var="AZTEC_DOCKER_IMAGE=${AZTEC_DOCKER_IMAGE}"

--- a/spartan/terraform/deploy-release/main.tf
+++ b/spartan/terraform/deploy-release/main.tf
@@ -18,32 +18,32 @@ terraform {
 provider "kubernetes" {
   alias          = "gke-cluster"
   config_path    = "~/.kube/config"
-  config_context = var.gke_cluster_context
+  config_context = var.GKE_CLUSTER_CONTEXT
 }
 
 provider "helm" {
   alias = "gke-cluster"
   kubernetes {
     config_path    = "~/.kube/config"
-    config_context = var.gke_cluster_context
+    config_context = var.GKE_CLUSTER_CONTEXT
   }
 }
 
 # Aztec Helm release for gke-cluster
 resource "helm_release" "aztec-gke-cluster" {
   provider         = helm.gke-cluster
-  name             = var.release_name
+  name             = var.RELEASE_NAME
   repository       = "../../"
   chart            = "aztec-network"
-  namespace        = var.release_name
+  namespace        = var.RELEASE_NAME
   create_namespace = true
 
   # base values file
-  values = [file("../../aztec-network/values/${var.values_file}")]
+  values = [file("../../aztec-network/values/${var.VALUES_FILE}")]
 
   set {
     name  = "images.aztec.image"
-    value = var.aztec_docker_image
+    value = var.AZTEC_DOCKER_IMAGE
   }
 
   # Setting timeout and wait conditions

--- a/spartan/terraform/deploy-release/release.tfvars
+++ b/spartan/terraform/deploy-release/release.tfvars
@@ -1,4 +1,1 @@
-release_name       = "rough-rhino"
-values_file        = "release.yaml"
-aztec_docker_image = "aztecprotocol/aztec:698cd3d62680629a3f1bfc0f82604534cedbccf3-x86_64"
-
+VALUES_FILE = "release.yaml"

--- a/spartan/terraform/deploy-release/variables.tf
+++ b/spartan/terraform/deploy-release/variables.tf
@@ -1,20 +1,20 @@
-variable "gke_cluster_context" {
+variable "GKE_CLUSTER_CONTEXT" {
   description = "GKE cluster context"
   type        = string
   default     = "gke_testnet-440309_us-east4-a_spartan-gke"
 }
 
-variable "release_name" {
+variable "RELEASE_NAME" {
   description = "Name of helm deployment and k8s namespace"
   type        = string
 }
 
-variable "values_file" {
+variable "VALUES_FILE" {
   description = "Name of the values file to use for deployment"
   type        = string
 }
 
-variable "aztec_docker_image" {
+variable "AZTEC_DOCKER_IMAGE" {
   description = "Docker image to use for the aztec network"
   type        = string
 }


### PR DESCRIPTION
Make a single flag `aztec.realProofs` in our aztec-network chart for enabling real proofs. (fix #10157)

Improve usability of deploy script for network releases. (fix #10158)