### PR TITLE
refactor: CIVC VK

### DIFF
--- a/barretenberg/cpp/src/barretenberg/bb/main.cpp
+++ b/barretenberg/cpp/src/barretenberg/bb/main.cpp
@@ -332,7 +332,6 @@ void client_ivc_prove_output_all_msgpack(const std::string& bytecodePath,
     using Program = acir_format::AcirProgram;
     using ECCVMVK = ECCVMFlavor::VerificationKey;
     using TranslatorVK = TranslatorFlavor::VerificationKey;
-    using DeciderVerificationKey = ClientIVC::DeciderVerificationKey;
 
     using namespace acir_format;
 
@@ -378,23 +377,17 @@ void client_ivc_prove_output_all_msgpack(const std::string& bytecodePath,
 
     // Write the proof and verification keys into the working directory in  'binary' format (in practice it seems this
     // directory is passed by bb.js)
-    std::string vkPath = outputDir + "/mega_vk"; // the vk of the last circuit in the stack
+    std::string vkPath = outputDir + "/client_ivc_vk"; // the vk of the last circuit in the stack
     std::string proofPath = outputDir + "/client_ivc_proof";
-    std::string translatorVkPath = outputDir + "/translator_vk";
-    std::string eccVkPath = outputDir + "/ecc_vk";
 
     auto proof = ivc.prove();
     auto eccvm_vk = std::make_shared<ECCVMVK>(ivc.goblin.get_eccvm_proving_key());
     auto translator_vk = std::make_shared<TranslatorVK>(ivc.goblin.get_translator_proving_key());
-
-    auto last_vk = std::make_shared<DeciderVerificationKey>(ivc.honk_vk);
     vinfo("ensure valid proof: ", ivc.verify(proof));
 
     vinfo("write proof and vk data to files..");
     write_file(proofPath, to_buffer(proof));
-    write_file(vkPath, to_buffer(ivc.honk_vk));
-    write_file(translatorVkPath, to_buffer(translator_vk));
-    write_file(eccVkPath, to_buffer(eccvm_vk));
+    write_file(vkPath, to_buffer(ClientIVC::VerificationKey{ ivc.honk_vk, eccvm_vk, translator_vk }));
 }
 
 template <typename T> std::shared_ptr<T> read_to_shared_ptr(const std::filesystem::path& path)
@@ -414,24 +407,20 @@ template <typename T> std::shared_ptr<T> read_to_shared_ptr(const std::filesyste
  * @param accumualtor_path Path to the file containing the serialized protogalaxy accumulator
  * @return true (resp., false) if the proof is valid (resp., invalid).
  */
-bool verify_client_ivc(const std::filesystem::path& proof_path,
-                       const std::filesystem::path& mega_vk,
-                       const std::filesystem::path& eccvm_vk_path,
-                       const std::filesystem::path& translator_vk_path)
+bool verify_client_ivc(const std::filesystem::path& proof_path, const std::filesystem::path& vk_path)
 {
     init_bn254_crs(1);
     init_grumpkin_crs(1 << 15);
 
     const auto proof = from_buffer<ClientIVC::Proof>(read_file(proof_path));
-    const auto final_vk = read_to_shared_ptr<MegaFlavor::VerificationKey>(mega_vk);
-    final_vk->pcs_verification_key = std::make_shared<VerifierCommitmentKey<curve::BN254>>();
+    const auto vk = from_buffer<ClientIVC::VerificationKey>(read_file(vk_path));
 
-    const auto eccvm_vk = read_to_shared_ptr<ECCVMFlavor::VerificationKey>(eccvm_vk_path);
-    eccvm_vk->pcs_verification_key =
-        std::make_shared<VerifierCommitmentKey<curve::Grumpkin>>(eccvm_vk->circuit_size + 1);
-    const auto translator_vk = read_to_shared_ptr<TranslatorFlavor::VerificationKey>(translator_vk_path);
-    translator_vk->pcs_verification_key = std::make_shared<VerifierCommitmentKey<curve::BN254>>();
-    const bool verified = ClientIVC::verify(proof, final_vk, eccvm_vk, translator_vk);
+    vk.mega->pcs_verification_key = std::make_shared<VerifierCommitmentKey<curve::BN254>>();
+    vk.eccvm->pcs_verification_key =
+        std::make_shared<VerifierCommitmentKey<curve::Grumpkin>>(vk.eccvm->circuit_size + 1);
+    vk.translator->pcs_verification_key = std::make_shared<VerifierCommitmentKey<curve::BN254>>();
+
+    const bool verified = ClientIVC::verify(proof, vk);
     vinfo("verified: ", verified);
     return verified;
 }
@@ -519,10 +508,8 @@ void client_ivc_prove_output_all(const std::string& bytecodePath,
 
     // Write the proof and verification keys into the working directory in  'binary' format (in practice it seems this
     // directory is passed by bb.js)
-    std::string vkPath = outputPath + "/mega_vk"; // the vk of the last circuit in the stack
+    std::string vkPath = outputPath + "/client_ivc_vk"; // the vk of the last circuit in the stack
     std::string proofPath = outputPath + "/client_ivc_proof";
-    std::string translatorVkPath = outputPath + "/translator_vk";
-    std::string eccVkPath = outputPath + "/ecc_vk";
 
     auto proof = ivc.prove();
     auto eccvm_vk = std::make_shared<ECCVMVK>(ivc.goblin.get_eccvm_proving_key());
@@ -531,9 +518,7 @@ void client_ivc_prove_output_all(const std::string& bytecodePath,
 
     vinfo("write proof and vk data to files..");
     write_file(proofPath, to_buffer(proof));
-    write_file(vkPath, to_buffer(ivc.honk_vk)); // maybe dereference
-    write_file(translatorVkPath, to_buffer(translator_vk));
-    write_file(eccVkPath, to_buffer(eccvm_vk));
+    write_file(vkPath, to_buffer(ClientIVC::VerificationKey{ ivc.honk_vk, eccvm_vk, translator_vk }));
 }
 
 /**
@@ -544,19 +529,15 @@ void client_ivc_prove_output_all(const std::string& bytecodePath,
  */
 void prove_tube(const std::string& output_path)
 {
-    using ClientIVC = stdlib::recursion::honk::ClientIVCRecursiveVerifier;
-    using StackHonkVK = typename MegaFlavor::VerificationKey;
-    using ECCVMVk = ECCVMFlavor::VerificationKey;
-    using TranslatorVk = TranslatorFlavor::VerificationKey;
-    using GoblinVerifierInput = ClientIVC::GoblinVerifierInput;
-    using VerifierInput = ClientIVC::VerifierInput;
+    using namespace stdlib::recursion::honk;
+
+    using GoblinVerifierInput = ClientIVCRecursiveVerifier::GoblinVerifierInput;
+    using VerifierInput = ClientIVCRecursiveVerifier::VerifierInput;
     using Builder = UltraCircuitBuilder;
     using GrumpkinVk = bb::VerifierCommitmentKey<curve::Grumpkin>;
 
-    std::string vkPath = output_path + "/mega_vk"; // the vk of the last circuit in the stack
+    std::string vkPath = output_path + "/client_ivc_vk"; // the vk of the last circuit in the stack
     std::string proofPath = output_path + "/client_ivc_proof";
-    std::string translatorVkPath = output_path + "/translator_vk";
-    std::string eccVkPath = output_path + "/ecc_vk";
 
     // Note: this could be decreased once we optimise the size of the ClientIVC recursiveve rifier
     init_bn254_crs(1 << 25);
@@ -564,17 +545,15 @@ void prove_tube(const std::string& output_path)
 
     // Read the proof  and verification data from given files
     auto proof = from_buffer<ClientIVC::Proof>(read_file(proofPath));
-    std::shared_ptr<StackHonkVK> mega_vk = std::make_shared<StackHonkVK>(from_buffer<StackHonkVK>(read_file(vkPath)));
-    std::shared_ptr<TranslatorVk> translator_vk =
-        std::make_shared<TranslatorVk>(from_buffer<TranslatorVk>(read_file(translatorVkPath)));
-    std::shared_ptr<ECCVMVk> eccvm_vk = std::make_shared<ECCVMVk>(from_buffer<ECCVMVk>(read_file(eccVkPath)));
+    auto vk = from_buffer<ClientIVC::VerificationKey>(read_file(vkPath));
+
     // We don't serialise and deserialise the Grumkin SRS so initialise with circuit_size + 1 to be able to recursively
     // IPA. The + 1 is to satisfy IPA verification key requirements.
     // TODO(https://github.com/AztecProtocol/barretenberg/issues/1025)
-    eccvm_vk->pcs_verification_key = std::make_shared<GrumpkinVk>(eccvm_vk->circuit_size + 1);
+    vk.eccvm->pcs_verification_key = std::make_shared<GrumpkinVk>(vk.eccvm->circuit_size + 1);
 
-    GoblinVerifierInput goblin_verifier_input{ eccvm_vk, translator_vk };
-    VerifierInput input{ mega_vk, goblin_verifier_input };
+    GoblinVerifierInput goblin_verifier_input{ vk.eccvm, vk.translator };
+    VerifierInput input{ vk.mega, goblin_verifier_input };
     auto builder = std::make_shared<Builder>();
 
     // Preserve the public inputs that should be passed to the base rollup by making them public inputs to the tube
@@ -588,9 +567,9 @@ void prove_tube(const std::string& output_path)
         auto offset = bb::HONK_PROOF_PUBLIC_INPUT_OFFSET;
         builder->add_public_variable(proof.mega_proof[i + offset]);
     }
-    ClientIVC verifier{ builder, input };
+    ClientIVCRecursiveVerifier verifier{ builder, input };
 
-    ClientIVC::Output client_ivc_rec_verifier_output = verifier.verify(proof);
+    ClientIVCRecursiveVerifier::Output client_ivc_rec_verifier_output = verifier.verify(proof);
 
     PairingPointAccumulatorIndices current_aggregation_object =
         stdlib::recursion::init_default_agg_obj_indices<Builder>(*builder);
@@ -1468,12 +1447,10 @@ int main(int argc, char* argv[])
         }
         if (command == "verify_client_ivc") {
             std::filesystem::path output_dir = get_option(args, "-o", "./target");
-            std::filesystem::path client_ivc_proof_path = output_dir / "client_ivc_proof";
-            std::filesystem::path mega_vk_path = output_dir / "mega_vk";
-            std::filesystem::path eccvm_vk_path = output_dir / "ecc_vk";
-            std::filesystem::path translator_vk_path = output_dir / "translator_vk";
+            std::filesystem::path proof_path = output_dir / "client_ivc_proof";
+            std::filesystem::path vk_path = output_dir / "client_ivc_vk";
 
-            return verify_client_ivc(client_ivc_proof_path, mega_vk_path, eccvm_vk_path, translator_vk_path) ? 0 : 1;
+            return verify_client_ivc(proof_path, vk_path) ? 0 : 1;
         }
         if (command == "fold_and_verify_program") {
             return foldAndVerifyProgram(bytecode_path, witness_path) ? 0 : 1;

--- a/barretenberg/cpp/src/barretenberg/bb/main.cpp
+++ b/barretenberg/cpp/src/barretenberg/bb/main.cpp
@@ -423,7 +423,7 @@ bool verify_client_ivc(const std::filesystem::path& proof_path,
     init_grumpkin_crs(1 << 15);
 
     const auto proof = from_buffer<ClientIVC::Proof>(read_file(proof_path));
-    const auto final_vk = read_to_shared_ptr<ClientIVC::VerificationKey>(mega_vk);
+    const auto final_vk = read_to_shared_ptr<MegaFlavor::VerificationKey>(mega_vk);
     final_vk->pcs_verification_key = std::make_shared<VerifierCommitmentKey<curve::BN254>>();
 
     const auto eccvm_vk = read_to_shared_ptr<ECCVMFlavor::VerificationKey>(eccvm_vk_path);

--- a/barretenberg/cpp/src/barretenberg/client_ivc/client_ivc.cpp
+++ b/barretenberg/cpp/src/barretenberg/client_ivc/client_ivc.cpp
@@ -156,7 +156,9 @@ void ClientIVC::complete_kernel_circuit_logic(ClientCircuit& circuit)
  * @param circuit
  * @param precomputed_vk
  */
-void ClientIVC::accumulate(ClientCircuit& circuit, const std::shared_ptr<VerificationKey>& precomputed_vk, bool mock_vk)
+void ClientIVC::accumulate(ClientCircuit& circuit,
+                           const std::shared_ptr<MegaVerificationKey>& precomputed_vk,
+                           bool mock_vk)
 {
     if (auto_verify_mode && circuit.databus_propagation_data.is_kernel) {
         complete_kernel_circuit_logic(circuit);
@@ -186,7 +188,7 @@ void ClientIVC::accumulate(ClientCircuit& circuit, const std::shared_ptr<Verific
     trace_usage_tracker.update(circuit);
 
     // Set the verification key from precomputed if available, else compute it
-    honk_vk = precomputed_vk ? precomputed_vk : std::make_shared<VerificationKey>(proving_key->proving_key);
+    honk_vk = precomputed_vk ? precomputed_vk : std::make_shared<MegaVerificationKey>(proving_key->proving_key);
     if (mock_vk) {
         honk_vk->set_metadata(proving_key->proving_key);
     }
@@ -280,7 +282,7 @@ HonkProof ClientIVC::construct_and_prove_hiding_circuit()
     merge_verification_queue.emplace_back(merge_proof);
 
     auto decider_pk = std::make_shared<DeciderProvingKey>(builder, TraceSettings(), bn254_commitment_key);
-    honk_vk = std::make_shared<VerificationKey>(decider_pk->proving_key);
+    honk_vk = std::make_shared<MegaVerificationKey>(decider_pk->proving_key);
     MegaProver prover(decider_pk);
 
     HonkProof proof = prover.construct_proof();
@@ -302,7 +304,7 @@ ClientIVC::Proof ClientIVC::prove()
 };
 
 bool ClientIVC::verify(const Proof& proof,
-                       const std::shared_ptr<VerificationKey>& mega_vk,
+                       const std::shared_ptr<MegaVerificationKey>& mega_vk,
                        const std::shared_ptr<ClientIVC::ECCVMVerificationKey>& eccvm_vk,
                        const std::shared_ptr<ClientIVC::TranslatorVerificationKey>& translator_vk)
 {
@@ -379,12 +381,12 @@ bool ClientIVC::prove_and_verify()
  * (albeit innefficient) way of separating out the cost of computing VKs from a benchmark.
  *
  * @param circuits A copy of the circuits to be accumulated (passing by reference would alter the original circuits)
- * @return std::vector<std::shared_ptr<ClientIVC::VerificationKey>>
+ * @return std::vector<std::shared_ptr<MegaFlavor::VerificationKey>>
  */
-std::vector<std::shared_ptr<ClientIVC::VerificationKey>> ClientIVC::precompute_folding_verification_keys(
+std::vector<std::shared_ptr<MegaFlavor::VerificationKey>> ClientIVC::precompute_folding_verification_keys(
     std::vector<ClientCircuit> circuits)
 {
-    std::vector<std::shared_ptr<VerificationKey>> vkeys;
+    std::vector<std::shared_ptr<MegaVerificationKey>> vkeys;
 
     for (auto& circuit : circuits) {
         accumulate(circuit);

--- a/barretenberg/cpp/src/barretenberg/client_ivc/client_ivc.cpp
+++ b/barretenberg/cpp/src/barretenberg/client_ivc/client_ivc.cpp
@@ -303,18 +303,15 @@ ClientIVC::Proof ClientIVC::prove()
     return { mega_proof, goblin.prove(merge_proof) };
 };
 
-bool ClientIVC::verify(const Proof& proof,
-                       const std::shared_ptr<MegaVerificationKey>& mega_vk,
-                       const std::shared_ptr<ClientIVC::ECCVMVerificationKey>& eccvm_vk,
-                       const std::shared_ptr<ClientIVC::TranslatorVerificationKey>& translator_vk)
+bool ClientIVC::verify(const Proof& proof, const VerificationKey& vk)
 {
 
     // Verify the hiding circuit proof
-    MegaVerifier verifer{ mega_vk };
+    MegaVerifier verifer{ vk.mega };
     bool mega_verified = verifer.verify_proof(proof.mega_proof);
     vinfo("Mega verified: ", mega_verified);
     // Goblin verification (final merge, eccvm, translator)
-    GoblinVerifier goblin_verifier{ eccvm_vk, translator_vk };
+    GoblinVerifier goblin_verifier{ vk.eccvm, vk.translator };
     bool goblin_verified = goblin_verifier.verify(proof.goblin_proof);
     vinfo("Goblin verified: ", goblin_verified);
     return goblin_verified && mega_verified;
@@ -330,7 +327,7 @@ bool ClientIVC::verify(const Proof& proof)
 {
     auto eccvm_vk = std::make_shared<ECCVMVerificationKey>(goblin.get_eccvm_proving_key());
     auto translator_vk = std::make_shared<TranslatorVerificationKey>(goblin.get_translator_proving_key());
-    return verify(proof, honk_vk, eccvm_vk, translator_vk);
+    return verify(proof, { honk_vk, eccvm_vk, translator_vk });
 }
 
 /**

--- a/barretenberg/cpp/src/barretenberg/client_ivc/client_ivc.hpp
+++ b/barretenberg/cpp/src/barretenberg/client_ivc/client_ivc.hpp
@@ -73,11 +73,13 @@ class ClientIVC {
         MSGPACK_FIELDS(mega_proof, goblin_proof);
     };
 
-    // struct _VerificationKey {
-    //     std::shared_ptr<VerificationKey> honk_verification_key;
-    //     std::shared_ptr<VerificationKey> honk_verification_key;
-    //     std::shared_ptr<VerificationKey> honk_verification_key;
-    // };
+    struct VerificationKey {
+        std::shared_ptr<MegaVerificationKey> mega;
+        std::shared_ptr<ECCVMVerificationKey> eccvm;
+        std::shared_ptr<TranslatorVerificationKey> translator;
+
+        MSGPACK_FIELDS(mega, eccvm, translator);
+    };
 
     enum class QUEUE_TYPE { OINK, PG }; // for specifying type of proof in the verification queue
 
@@ -95,6 +97,7 @@ class ClientIVC {
         std::shared_ptr<RecursiveVerificationKey> honk_verification_key;
         QUEUE_TYPE type;
     };
+
     using StdlibVerificationQueue = std::vector<StdlibVerifierInputs>;
 
     // Utility for tracking the max size of each block across the full IVC
@@ -171,10 +174,7 @@ class ClientIVC {
 
     HonkProof construct_and_prove_hiding_circuit();
 
-    static bool verify(const Proof& proof,
-                       const std::shared_ptr<MegaVerificationKey>& mega_vk,
-                       const std::shared_ptr<ClientIVC::ECCVMVerificationKey>& eccvm_vk,
-                       const std::shared_ptr<ClientIVC::TranslatorVerificationKey>& translator_vk);
+    static bool verify(const Proof& proof, const VerificationKey& vk);
 
     bool verify(const Proof& proof);
 

--- a/barretenberg/cpp/src/barretenberg/client_ivc/client_ivc.hpp
+++ b/barretenberg/cpp/src/barretenberg/client_ivc/client_ivc.hpp
@@ -27,7 +27,7 @@ class ClientIVC {
 
   public:
     using Flavor = MegaFlavor;
-    using VerificationKey = Flavor::VerificationKey;
+    using MegaVerificationKey = Flavor::VerificationKey;
     using FF = Flavor::FF;
     using FoldProof = std::vector<FF>;
     using MergeProof = std::vector<FF>;
@@ -73,12 +73,18 @@ class ClientIVC {
         MSGPACK_FIELDS(mega_proof, goblin_proof);
     };
 
+    // struct _VerificationKey {
+    //     std::shared_ptr<VerificationKey> honk_verification_key;
+    //     std::shared_ptr<VerificationKey> honk_verification_key;
+    //     std::shared_ptr<VerificationKey> honk_verification_key;
+    // };
+
     enum class QUEUE_TYPE { OINK, PG }; // for specifying type of proof in the verification queue
 
     // An entry in the native verification queue
     struct VerifierInputs {
         std::vector<FF> proof; // oink or PG
-        std::shared_ptr<VerificationKey> honk_verification_key;
+        std::shared_ptr<MegaVerificationKey> honk_verification_key;
         QUEUE_TYPE type;
     };
     using VerificationQueue = std::vector<VerifierInputs>;
@@ -101,7 +107,7 @@ class ClientIVC {
     ProverFoldOutput fold_output; // prover accumulator and fold proof
 
     std::shared_ptr<DeciderVerificationKey> verifier_accumulator; // verifier accumulator
-    std::shared_ptr<VerificationKey> honk_vk; // honk vk to be completed and folded into the accumulator
+    std::shared_ptr<MegaVerificationKey> honk_vk; // honk vk to be completed and folded into the accumulator
 
     // Set of tuples {proof, verification_key, type} to be recursively verified
     VerificationQueue verification_queue;
@@ -158,7 +164,7 @@ class ClientIVC {
      * @param mock_vk A boolean to say whether the precomputed vk shoudl have its metadata set.
      */
     void accumulate(ClientCircuit& circuit,
-                    const std::shared_ptr<VerificationKey>& precomputed_vk = nullptr,
+                    const std::shared_ptr<MegaVerificationKey>& precomputed_vk = nullptr,
                     bool mock_vk = false);
 
     Proof prove();
@@ -166,7 +172,7 @@ class ClientIVC {
     HonkProof construct_and_prove_hiding_circuit();
 
     static bool verify(const Proof& proof,
-                       const std::shared_ptr<VerificationKey>& mega_vk,
+                       const std::shared_ptr<MegaVerificationKey>& mega_vk,
                        const std::shared_ptr<ClientIVC::ECCVMVerificationKey>& eccvm_vk,
                        const std::shared_ptr<ClientIVC::TranslatorVerificationKey>& translator_vk);
 
@@ -176,7 +182,7 @@ class ClientIVC {
 
     HonkProof decider_prove() const;
 
-    std::vector<std::shared_ptr<VerificationKey>> precompute_folding_verification_keys(
+    std::vector<std::shared_ptr<MegaVerificationKey>> precompute_folding_verification_keys(
         std::vector<ClientCircuit> circuits);
 };
 } // namespace bb

--- a/barretenberg/cpp/src/barretenberg/dsl/acir_format/ivc_recursion_constraint.cpp
+++ b/barretenberg/cpp/src/barretenberg/dsl/acir_format/ivc_recursion_constraint.cpp
@@ -55,7 +55,6 @@ ClientIVC::VerifierInputs create_dummy_vkey_and_proof_oink(const TraceSettings& 
                                                            const size_t num_public_inputs = 0)
 {
     using Flavor = MegaFlavor;
-    using VerificationKey = ClientIVC::VerificationKey;
     using FF = bb::fr;
 
     MegaExecutionTraceBlocks blocks;
@@ -89,7 +88,7 @@ ClientIVC::VerifierInputs create_dummy_vkey_and_proof_oink(const TraceSettings& 
     }
 
     // Set relevant VK metadata and commitments
-    verifier_inputs.honk_verification_key = std::make_shared<VerificationKey>();
+    verifier_inputs.honk_verification_key = std::make_shared<Flavor::VerificationKey>();
     verifier_inputs.honk_verification_key->circuit_size = structured_dyadic_size;
     verifier_inputs.honk_verification_key->num_public_inputs = total_num_public_inputs;
     verifier_inputs.honk_verification_key->pub_inputs_offset = blocks.pub_inputs.trace_offset; // must be set correctly
@@ -146,7 +145,7 @@ ClientIVC::MergeProof create_dummy_merge_proof()
  * @param key_witness_indices
  */
 void populate_dummy_vk_in_constraint(MegaCircuitBuilder& builder,
-                                     const std::shared_ptr<ClientIVC::VerificationKey>& mock_verification_key,
+                                     const std::shared_ptr<MegaFlavor::VerificationKey>& mock_verification_key,
                                      std::vector<uint32_t>& key_witness_indices)
 {
     using Flavor = MegaFlavor;

--- a/barretenberg/cpp/src/barretenberg/dsl/acir_format/ivc_recursion_constraint.hpp
+++ b/barretenberg/cpp/src/barretenberg/dsl/acir_format/ivc_recursion_constraint.hpp
@@ -21,7 +21,7 @@ ClientIVC::VerifierInputs create_dummy_vkey_and_proof_oink(const TraceSettings& 
 ClientIVC::MergeProof create_dummy_merge_proof();
 
 void populate_dummy_vk_in_constraint(MegaCircuitBuilder& builder,
-                                     const std::shared_ptr<ClientIVC::VerificationKey>& mock_verification_key,
+                                     const std::shared_ptr<MegaFlavor::VerificationKey>& mock_verification_key,
                                      std::vector<uint32_t>& key_witness_indices);
 
 } // namespace acir_format

--- a/barretenberg/cpp/src/barretenberg/dsl/acir_format/ivc_recursion_constraint.test.cpp
+++ b/barretenberg/cpp/src/barretenberg/dsl/acir_format/ivc_recursion_constraint.test.cpp
@@ -186,7 +186,7 @@ TEST_F(IvcRecursionConstraintTest, GenerateVK)
     const TraceSettings trace_settings{ SMALL_TEST_STRUCTURE };
 
     // First, construct the kernel VK by running the full IVC (accumulate one app and one kernel)
-    std::shared_ptr<ClientIVC::VerificationKey> expected_kernel_vk;
+    std::shared_ptr<MegaFlavor::VerificationKey> expected_kernel_vk;
     size_t num_app_public_inputs = 0;
     {
         ClientIVC ivc{ trace_settings };
@@ -204,7 +204,7 @@ TEST_F(IvcRecursionConstraintTest, GenerateVK)
     }
 
     // Now, construct the kernel VK by mocking the post app accumulation state of the IVC
-    std::shared_ptr<ClientIVC::VerificationKey> kernel_vk;
+    std::shared_ptr<MegaFlavor::VerificationKey> kernel_vk;
     {
         ClientIVC ivc{ trace_settings };
 
@@ -218,7 +218,7 @@ TEST_F(IvcRecursionConstraintTest, GenerateVK)
 
         auto proving_key = std::make_shared<DeciderProvingKey_<MegaFlavor>>(kernel, trace_settings);
         MegaProver prover(proving_key);
-        kernel_vk = std::make_shared<ClientIVC::VerificationKey>(prover.proving_key->proving_key);
+        kernel_vk = std::make_shared<MegaFlavor::VerificationKey>(prover.proving_key->proving_key);
     }
 
     // PCS verification keys will not match so set to null before comparing
@@ -234,7 +234,7 @@ TEST_F(IvcRecursionConstraintTest, GenerateVKFromConstraints)
     const TraceSettings trace_settings{ SMALL_TEST_STRUCTURE };
 
     // First, construct the kernel VK by running the full IVC (accumulate one app and one kernel)
-    std::shared_ptr<ClientIVC::VerificationKey> expected_kernel_vk;
+    std::shared_ptr<MegaFlavor::VerificationKey> expected_kernel_vk;
     size_t num_app_public_inputs = 0;
     {
         ClientIVC ivc{ trace_settings };
@@ -253,7 +253,7 @@ TEST_F(IvcRecursionConstraintTest, GenerateVKFromConstraints)
     }
 
     // Now, construct the kernel VK by mocking the post app accumulation state of the IVC
-    std::shared_ptr<ClientIVC::VerificationKey> kernel_vk;
+    std::shared_ptr<MegaFlavor::VerificationKey> kernel_vk;
     {
         ClientIVC ivc{ trace_settings };
 
@@ -273,7 +273,7 @@ TEST_F(IvcRecursionConstraintTest, GenerateVKFromConstraints)
         // Manually construct the VK for the kernel circuit
         auto proving_key = std::make_shared<DeciderProvingKey_<MegaFlavor>>(kernel, ivc.trace_settings);
         MegaProver prover(proving_key);
-        kernel_vk = std::make_shared<ClientIVC::VerificationKey>(prover.proving_key->proving_key);
+        kernel_vk = std::make_shared<MegaFlavor::VerificationKey>(prover.proving_key->proving_key);
     }
 
     // PCS verification keys will not match so set to null before comparing

--- a/yarn-project/bb-prover/src/bb/execute.ts
+++ b/yarn-project/bb-prover/src/bb/execute.ts
@@ -431,10 +431,8 @@ export async function generateTubeProof(
   }
 
   // // Paths for the inputs
-  const vkPath = join(workingDirectory, 'mega_vk.bin');
+  const vkPath = join(workingDirectory, 'client_ivc_vk.bin');
   const proofPath = join(workingDirectory, 'client_ivc_proof.bin');
-  const translatorVkPath = join(workingDirectory, 'translator_vk.bin');
-  const eccVkPath = join(workingDirectory, 'ecc_vk.bin');
 
   // The proof is written to e.g. /workingDirectory/proof
   const outputPath = workingDirectory;

--- a/yarn-project/bb-prover/src/bb/execute.ts
+++ b/yarn-project/bb-prover/src/bb/execute.ts
@@ -448,7 +448,7 @@ export async function generateTubeProof(
   }
 
   try {
-    if (!filePresent(vkPath) || !filePresent(proofPath) || !filePresent(translatorVkPath) || !filePresent(eccVkPath)) {
+    if (!filePresent(vkPath) || !filePresent(proofPath)) {
       return { status: BB_RESULT.FAILURE, reason: `Client IVC input files not present in  ${workingDirectory}` };
     }
     const args = ['-o', outputPath, '-v'];

--- a/yarn-project/circuits.js/src/structs/client_ivc_proof.ts
+++ b/yarn-project/circuits.js/src/structs/client_ivc_proof.ts
@@ -71,19 +71,15 @@ export class ClientIvcProof {
 
   static fromBuffer(buffer: Buffer | BufferReader): ClientIvcProof {
     const reader = BufferReader.asReader(buffer);
-    return new ClientIvcProof(reader.readBuffer(), reader.readBuffer(), reader.readBuffer(), reader.readBuffer());
+    return new ClientIvcProof(reader.readBuffer(), reader.readBuffer());
   }
 
   public toBuffer() {
     return serializeToBuffer(
-      this.megaVkBuffer.length,
-      this.megaVkBuffer,
       this.clientIvcProofBuffer.length,
       this.clientIvcProofBuffer,
-      this.translatorVkBuffer.length,
-      this.translatorVkBuffer,
-      this.eccVkBuffer.length,
-      this.eccVkBuffer,
+      this.clientIvcVkBuffer.length,
+      this.clientIvcVkBuffer,
     );
   }
 }

--- a/yarn-project/circuits.js/src/structs/client_ivc_proof.ts
+++ b/yarn-project/circuits.js/src/structs/client_ivc_proof.ts
@@ -13,10 +13,8 @@ export class ClientIvcProof {
     // produced by the sequencer when making the tube proof
     // TODO(https://github.com/AztecProtocol/aztec-packages/issues/7370): Need to precompute private kernel tail VK so we can verify this immediately in the tx pool
     // which parts of these are needed to quickly verify that we have a correct IVC proof
-    public megaVkBuffer: Buffer,
     public clientIvcProofBuffer: Buffer,
-    public translatorVkBuffer: Buffer,
-    public eccVkBuffer: Buffer,
+    public clientIvcVkBuffer: Buffer,
   ) {}
 
   public isEmpty() {
@@ -24,7 +22,7 @@ export class ClientIvcProof {
   }
 
   static empty() {
-    return new ClientIvcProof(Buffer.from(''), Buffer.from(''), Buffer.from(''), Buffer.from(''));
+    return new ClientIvcProof(Buffer.from(''), Buffer.from(''));
   }
 
   /**
@@ -34,12 +32,10 @@ export class ClientIvcProof {
    * @returns the encapsulated client ivc proof
    */
   static async readFromOutputDirectory(directory: string) {
-    const [megaVkBuffer, clientIvcProofBuffer, translatorVkBuffer, eccVkBuffer] = await Promise.all(
-      ['mega_vk', 'client_ivc_proof', 'translator_vk', 'ecc_vk'].map(fileName =>
-        fs.readFile(path.join(directory, fileName)),
-      ),
+    const [clientIvcVkBuffer, clientIvcProofBuffer] = await Promise.all(
+      ['client_ivc_vk', 'client_ivc_proof'].map(fileName => fs.readFile(path.join(directory, fileName))),
     );
-    return new ClientIvcProof(megaVkBuffer, clientIvcProofBuffer, translatorVkBuffer, eccVkBuffer);
+    return new ClientIvcProof(clientIvcProofBuffer, clientIvcVkBuffer);
   }
 
   /**
@@ -56,12 +52,10 @@ export class ClientIvcProof {
    * @param directory the directory of results
    */
   async writeToOutputDirectory(directory: string) {
-    const { megaVkBuffer, clientIvcProofBuffer, translatorVkBuffer, eccVkBuffer } = this;
+    const { clientIvcProofBuffer, clientIvcVkBuffer } = this;
     const fileData = [
-      ['mega_vk', megaVkBuffer],
       ['client_ivc_proof', clientIvcProofBuffer],
-      ['translator_vk', translatorVkBuffer],
-      ['ecc_vk', eccVkBuffer],
+      ['client_ivc_vk', clientIvcVkBuffer],
     ] as const;
     await Promise.all(fileData.map(([fileName, buffer]) => fs.writeFile(path.join(directory, fileName), buffer)));
   }


### PR DESCRIPTION
As a step toward a consistent API, we add to `ClientIVC`
```
    struct VerificationKey {
        std::shared_ptr<MegaVerificationKey> mega;
        std::shared_ptr<ECCVMVerificationKey> eccvm;
        std::shared_ptr<TranslatorVerificationKey> translator;

        MSGPACK_FIELDS(mega, eccvm, translator);
    };
```

ClientIVC API before;
```
    static bool verify(const Proof& proof,
                       const std::shared_ptr<MegaVerificationKey>& mega_vk,
                       const std::shared_ptr<ClientIVC::ECCVMVerificationKey>& eccvm_vk,
                       const std::shared_ptr<ClientIVC::TranslatorVerificationKey>& translator_vk);
```
(three vk paths need to be provided to CLI)

ClientIVC API after: 
```
    static bool verify(const Proof& proof, const VerificationKey& vk);`
```
(and one vk path needs to be provided to CLI)