### PR TITLE
fix: use current base fee for public fee payment

### DIFF
--- a/yarn-project/end-to-end/src/e2e_fees/public_payments.test.ts
+++ b/yarn-project/end-to-end/src/e2e_fees/public_payments.test.ts
@@ -1,5 +1,5 @@
 import { type AccountWallet, type AztecAddress, PublicFeePaymentMethod } from '@aztec/aztec.js';
-import { type GasSettings } from '@aztec/circuits.js';
+import { GasSettings } from '@aztec/circuits.js';
 import { type TokenContract as BananaCoin, type FPCContract } from '@aztec/noir-contracts.js';
 
 import { expectMapping } from '../fixtures/utils.js';
@@ -38,12 +38,11 @@ describe('e2e_fees public_payment', () => {
 
   let initialSequencerGas: bigint;
 
-  let maxFee: bigint;
-
   beforeEach(async () => {
-    maxFee = BigInt(20e9);
-
-    expect(gasSettings.getFeeLimit().toBigInt()).toEqual(maxFee);
+    gasSettings = GasSettings.from({
+      ...gasSettings,
+      maxFeesPerGas: await aliceWallet.getCurrentBaseFees(),
+    });
 
     [
       [initialAlicePublicBananas, initialBobPublicBananas, initialFPCPublicBananas],


### PR DESCRIPTION
As #10172 got merged right after #10176 it had not run the new test against the updated master so the issue with fee payment was not caught.

To fix it, we fetch the current base fees and use those in our settings.