### PR TITLE
feat: burn congestion fee

### DIFF
--- a/l1-contracts/src/core/Rollup.sol
+++ b/l1-contracts/src/core/Rollup.sol
@@ -311,6 +311,10 @@ contract Rollup is EIP712("Aztec Rollup", "1"), Leonidas, IRollup, ITestRollup {
 
     require(epochProofVerifier.verify(_args.proof, publicInputs), Errors.Rollup__InvalidProof());
 
+    if (proofClaim.epochToProve == interimValues.epochToProve) {
+      PROOF_COMMITMENT_ESCROW.unstakeBond(proofClaim.bondProvider, proofClaim.bondAmount);
+    }
+
     tips.provenBlockNumber = interimValues.endBlockNumber;
 
     // @note  Only if the rollup is the canonical will it be able to meaningfully claim fees
@@ -374,10 +378,6 @@ contract Rollup is EIP712("Aztec Rollup", "1"), Leonidas, IRollup, ITestRollup {
       if (totalBurn > 0) {
         ASSET.safeTransfer(CUAUHXICALLI, totalBurn);
       }
-    }
-
-    if (proofClaim.epochToProve == interimValues.epochToProve) {
-      PROOF_COMMITMENT_ESCROW.unstakeBond(proofClaim.bondProvider, proofClaim.bondAmount);
     }
 
     emit L2ProofVerified(interimValues.endBlockNumber, _args.args[6]);

--- a/l1-contracts/src/core/interfaces/IRollup.sol
+++ b/l1-contracts/src/core/interfaces/IRollup.sol
@@ -7,14 +7,24 @@ import {IOutbox} from "@aztec/core/interfaces/messagebridge/IOutbox.sol";
 import {SignatureLib} from "@aztec/core/libraries/crypto/SignatureLib.sol";
 import {DataStructures} from "@aztec/core/libraries/DataStructures.sol";
 import {EpochProofQuoteLib} from "@aztec/core/libraries/EpochProofQuoteLib.sol";
+import {ManaBaseFeeComponents} from "@aztec/core/libraries/FeeMath.sol";
 import {ProposeArgs} from "@aztec/core/libraries/ProposeLib.sol";
 import {Timestamp, Slot, Epoch} from "@aztec/core/libraries/TimeMath.sol";
+
+struct SubmitEpochRootProofArgs {
+  uint256 epochSize;
+  bytes32[7] args;
+  bytes32[] fees;
+  bytes aggregationObject;
+  bytes proof;
+}
 
 struct FeeHeader {
   uint256 excessMana;
   uint256 feeAssetPriceNumerator;
   uint256 manaUsed;
   uint256 provingCostPerManaNumerator;
+  uint256 congestionCost;
 }
 
 struct BlockLog {
@@ -29,20 +39,12 @@ struct L1FeeData {
   uint256 blobFee;
 }
 
-struct ManaBaseFeeComponents {
-  uint256 congestionCost;
-  uint256 congestionMultiplier;
-  uint256 dataCost;
-  uint256 gasCost;
-  uint256 provingCost;
-}
-
 interface ITestRollup {
   function setEpochVerifier(address _verifier) external;
   function setVkTreeRoot(bytes32 _vkTreeRoot) external;
   function setProtocolContractTreeRoot(bytes32 _protocolContractTreeRoot) external;
   function setAssumeProvenThroughBlockNumber(uint256 _blockNumber) external;
-  function manaBaseFeeComponents(bool _inFeeAsset)
+  function getManaBaseFeeComponents(bool _inFeeAsset)
     external
     view
     returns (ManaBaseFeeComponents memory);
@@ -78,13 +80,7 @@ interface IRollup {
     EpochProofQuoteLib.SignedEpochProofQuote calldata _quote
   ) external;
 
-  function submitEpochRootProof(
-    uint256 _epochSize,
-    bytes32[7] calldata _args,
-    bytes32[] calldata _fees,
-    bytes calldata _aggregationObject,
-    bytes calldata _proof
-  ) external;
+  function submitEpochRootProof(SubmitEpochRootProofArgs calldata _args) external;
 
   function canProposeAtTime(Timestamp _ts, bytes32 _archive) external view returns (Slot, uint256);
 

--- a/l1-contracts/src/core/libraries/FeeMath.sol
+++ b/l1-contracts/src/core/libraries/FeeMath.sol
@@ -13,6 +13,14 @@ struct OracleInput {
   int256 feeAssetPriceModifier;
 }
 
+struct ManaBaseFeeComponents {
+  uint256 congestionCost;
+  uint256 congestionMultiplier;
+  uint256 dataCost;
+  uint256 gasCost;
+  uint256 provingCost;
+}
+
 library FeeMath {
   using Math for uint256;
   using SafeCast for int256;
@@ -79,6 +87,11 @@ library FeeMath {
 
   function congestionMultiplier(uint256 _numerator) internal pure returns (uint256) {
     return fakeExponential(MINIMUM_CONGESTION_MULTIPLIER, _numerator, CONGESTION_UPDATE_FRACTION);
+  }
+
+  function summedBaseFee(ManaBaseFeeComponents memory _components) internal pure returns (uint256) {
+    return _components.dataCost + _components.gasCost + _components.provingCost
+      + _components.congestionCost;
   }
 
   /**

--- a/l1-contracts/src/core/libraries/crypto/SampleLib.sol
+++ b/l1-contracts/src/core/libraries/crypto/SampleLib.sol
@@ -22,6 +22,62 @@ import {Errors} from "@aztec/core/libraries/Errors.sol";
  */
 library SampleLib {
   /**
+   * @notice  Computing a committee the most direct way.
+   *          This is horribly inefficient as we are throwing plenty of things away, but it is useful
+   *          for testing and just showcasing the simplest case.
+   *
+   * @param _committeeSize - The size of the committee
+   * @param _indexCount - The total number of indices
+   * @param _seed - The seed to use for shuffling
+   *
+   * @return indices - The indices of the committee
+   */
+  function computeCommitteeStupid(uint256 _committeeSize, uint256 _indexCount, uint256 _seed)
+    external
+    pure
+    returns (uint256[] memory)
+  {
+    uint256[] memory indices = new uint256[](_committeeSize);
+
+    for (uint256 index = 0; index < _indexCount; index++) {
+      uint256 sampledIndex = computeShuffledIndex(index, _indexCount, _seed);
+      if (sampledIndex < _committeeSize) {
+        indices[sampledIndex] = index;
+      }
+    }
+
+    return indices;
+  }
+
+  /**
+   * @notice  Computing a committee slightly more cleverly.
+   *          Only computes for the committee size, and does not sample the full set.
+   *          This is more efficient than the stupid way, but still not optimal.
+   *          To be more clever, we can compute the `shuffeRounds` and `pivots` separately
+   *          such that they get shared accross multiple indices.
+   *
+   * @param _committeeSize - The size of the committee
+   * @param _indexCount - The total number of indices
+   * @param _seed - The seed to use for shuffling
+   *
+   * @return indices - The indices of the committee
+   */
+  function computeCommitteeClever(uint256 _committeeSize, uint256 _indexCount, uint256 _seed)
+    external
+    pure
+    returns (uint256[] memory)
+  {
+    uint256[] memory indices = new uint256[](_committeeSize);
+
+    for (uint256 index = 0; index < _committeeSize; index++) {
+      uint256 originalIndex = computeOriginalIndex(index, _indexCount, _seed);
+      indices[index] = originalIndex;
+    }
+
+    return indices;
+  }
+
+  /**
    * @notice  Computes the shuffled index
    *
    * @param _index - The index to shuffle
@@ -76,62 +132,6 @@ library SampleLib {
     }
 
     return index;
-  }
-
-  /**
-   * @notice  Computing a committee the most direct way.
-   *          This is horribly inefficient as we are throwing plenty of things away, but it is useful
-   *          for testing and just showcasing the simplest case.
-   *
-   * @param _committeeSize - The size of the committee
-   * @param _indexCount - The total number of indices
-   * @param _seed - The seed to use for shuffling
-   *
-   * @return indices - The indices of the committee
-   */
-  function computeCommitteeStupid(uint256 _committeeSize, uint256 _indexCount, uint256 _seed)
-    internal
-    pure
-    returns (uint256[] memory)
-  {
-    uint256[] memory indices = new uint256[](_committeeSize);
-
-    for (uint256 index = 0; index < _indexCount; index++) {
-      uint256 sampledIndex = computeShuffledIndex(index, _indexCount, _seed);
-      if (sampledIndex < _committeeSize) {
-        indices[sampledIndex] = index;
-      }
-    }
-
-    return indices;
-  }
-
-  /**
-   * @notice  Computing a committee slightly more cleverly.
-   *          Only computes for the committee size, and does not sample the full set.
-   *          This is more efficient than the stupid way, but still not optimal.
-   *          To be more clever, we can compute the `shuffeRounds` and `pivots` separately
-   *          such that they get shared accross multiple indices.
-   *
-   * @param _committeeSize - The size of the committee
-   * @param _indexCount - The total number of indices
-   * @param _seed - The seed to use for shuffling
-   *
-   * @return indices - The indices of the committee
-   */
-  function computeCommitteeClever(uint256 _committeeSize, uint256 _indexCount, uint256 _seed)
-    internal
-    pure
-    returns (uint256[] memory)
-  {
-    uint256[] memory indices = new uint256[](_committeeSize);
-
-    for (uint256 index = 0; index < _committeeSize; index++) {
-      uint256 originalIndex = computeOriginalIndex(index, _indexCount, _seed);
-      indices[index] = originalIndex;
-    }
-
-    return indices;
   }
 
   /**

--- a/l1-contracts/test/Rollup.t.sol
+++ b/l1-contracts/test/Rollup.t.sol
@@ -725,7 +725,7 @@ contract RollupTest is DecoderBase, TimeFns {
     assertEq(rollup.getProvenBlockNumber(), 0 + toProve, "Invalid proven block number");
   }
 
-  function testRevertBlocksAcrossEpochs() public setUpFor("mixed_block_1") {
+  function testRevertSubmittingProofForBlocksAcrossEpochs() public setUpFor("mixed_block_1") {
     _testBlock("mixed_block_1", false, 1);
     _testBlock("mixed_block_2", false, TestConstants.AZTEC_EPOCH_DURATION + 1);
 

--- a/l1-contracts/test/Rollup.t.sol
+++ b/l1-contracts/test/Rollup.t.sol
@@ -14,9 +14,8 @@ import {Registry} from "@aztec/governance/Registry.sol";
 import {Inbox} from "@aztec/core/messagebridge/Inbox.sol";
 import {Outbox} from "@aztec/core/messagebridge/Outbox.sol";
 import {Errors} from "@aztec/core/libraries/Errors.sol";
-import {BlockLog} from "@aztec/core/interfaces/IRollup.sol";
 import {Rollup} from "./harnesses/Rollup.sol";
-import {IRollup} from "@aztec/core/interfaces/IRollup.sol";
+import {IRollup, BlockLog, SubmitEpochRootProofArgs} from "@aztec/core/interfaces/IRollup.sol";
 import {IProofCommitmentEscrow} from "@aztec/core/interfaces/IProofCommitmentEscrow.sol";
 import {FeeJuicePortal} from "@aztec/core/FeeJuicePortal.sol";
 import {Leonidas} from "@aztec/core/Leonidas.sol";
@@ -726,9 +725,55 @@ contract RollupTest is DecoderBase, TimeFns {
     assertEq(rollup.getProvenBlockNumber(), 0 + toProve, "Invalid proven block number");
   }
 
+  function testRevertBlocksAcrossEpochs() public setUpFor("mixed_block_1") {
+    _testBlock("mixed_block_1", false, 1);
+    _testBlock("mixed_block_2", false, TestConstants.AZTEC_EPOCH_DURATION + 1);
+
+    DecoderBase.Data memory data = load("mixed_block_2").block;
+
+    assertEq(rollup.getProvenBlockNumber(), 0, "Invalid initial proven block number");
+
+    BlockLog memory blockLog = rollup.getBlock(0);
+
+    bytes32[7] memory args = [
+      blockLog.archive,
+      data.archive,
+      blockLog.blockHash,
+      data.blockHash,
+      bytes32(0),
+      bytes32(0),
+      bytes32(0)
+    ];
+
+    bytes32[] memory fees = new bytes32[](Constants.AZTEC_MAX_EPOCH_DURATION * 2);
+
+    fees[0] = bytes32(uint256(uint160(address(0))));
+    fees[1] = bytes32(0);
+
+    bytes memory aggregationObject = "";
+    bytes memory proof = "";
+
+    vm.expectRevert(
+      abi.encodeWithSelector(Errors.Rollup__InvalidEpoch.selector, Epoch.wrap(0), Epoch.wrap(1))
+    );
+
+    rollup.submitEpochRootProof(
+      SubmitEpochRootProofArgs({
+        epochSize: 2,
+        args: args,
+        fees: fees,
+        aggregationObject: aggregationObject,
+        proof: proof
+      })
+    );
+
+    assertEq(rollup.getPendingBlockNumber(), 2, "Invalid pending block number");
+    assertEq(rollup.getProvenBlockNumber(), 0, "Invalid proven block number");
+  }
+
   function testProveEpochWithTwoMixedBlocks() public setUpFor("mixed_block_1") {
-    _testBlock("mixed_block_1", false);
-    _testBlock("mixed_block_2", false);
+    _testBlock("mixed_block_1", false, 1);
+    _testBlock("mixed_block_2", false, 2);
 
     DecoderBase.Data memory data = load("mixed_block_2").block;
 
@@ -1125,7 +1170,15 @@ contract RollupTest is DecoderBase, TimeFns {
     bytes memory aggregationObject = "";
     bytes memory proof = "";
 
-    _rollup.submitEpochRootProof(_epochSize, args, fees, aggregationObject, proof);
+    _rollup.submitEpochRootProof(
+      SubmitEpochRootProofArgs({
+        epochSize: _epochSize,
+        args: args,
+        fees: fees,
+        aggregationObject: aggregationObject,
+        proof: proof
+      })
+    );
   }
 
   function _quoteToSignedQuote(EpochProofQuoteLib.EpochProofQuote memory _quote)

--- a/yarn-project/archiver/src/archiver/data_retrieval.ts
+++ b/yarn-project/archiver/src/archiver/data_retrieval.ts
@@ -291,11 +291,20 @@ export async function getProofFromSubmitProofTx(
   let proof: Proof;
 
   if (functionName === 'submitEpochRootProof') {
-    const [_epochSize, nestedArgs, _fees, aggregationObjectHex, proofHex] = args!;
-    aggregationObject = Buffer.from(hexToBytes(aggregationObjectHex));
-    proverId = Fr.fromString(nestedArgs[6]);
-    archiveRoot = Fr.fromString(nestedArgs[1]);
-    proof = Proof.fromBuffer(Buffer.from(hexToBytes(proofHex)));
+    const [decodedArgs] = args as readonly [
+      {
+        epochSize: bigint;
+        args: readonly [Hex, Hex, Hex, Hex, Hex, Hex, Hex];
+        fees: readonly Hex[];
+        aggregationObject: Hex;
+        proof: Hex;
+      },
+    ];
+
+    aggregationObject = Buffer.from(hexToBytes(decodedArgs.aggregationObject));
+    proverId = Fr.fromString(decodedArgs.args[6]);
+    archiveRoot = Fr.fromString(decodedArgs.args[1]);
+    proof = Proof.fromBuffer(Buffer.from(hexToBytes(decodedArgs.proof)));
   } else {
     throw new Error(`Unexpected proof method called ${functionName}`);
   }

--- a/yarn-project/ethereum/src/deploy_l1_contracts.ts
+++ b/yarn-project/ethereum/src/deploy_l1_contracts.ts
@@ -22,6 +22,8 @@ import {
   RollupAbi,
   RollupBytecode,
   RollupLinkReferences,
+  SampleLibAbi,
+  SampleLibBytecode,
   TestERC20Abi,
   TestERC20Bytecode,
   TxsDecoderAbi,
@@ -172,6 +174,10 @@ export const l1Artifacts: L1ContractArtifactsForDeployment = {
         TxsDecoder: {
           contractAbi: TxsDecoderAbi,
           contractBytecode: TxsDecoderBytecode,
+        },
+        SampleLib: {
+          contractAbi: SampleLibAbi,
+          contractBytecode: SampleLibBytecode,
         },
       },
     },
@@ -623,9 +629,15 @@ export async function deployL1Contract(
       );
 
       for (const linkRef in libraries.linkReferences) {
-        for (const c in libraries.linkReferences[linkRef]) {
-          const start = 2 + 2 * libraries.linkReferences[linkRef][c][0].start;
-          const length = 2 * libraries.linkReferences[linkRef][c][0].length;
+        for (const contractName in libraries.linkReferences[linkRef]) {
+          // If the library name matches the one we just deployed, we replace it.
+          if (contractName !== libraryName) {
+            continue;
+          }
+
+          // We read the first instance to figure out what we are to replace.
+          const start = 2 + 2 * libraries.linkReferences[linkRef][contractName][0].start;
+          const length = 2 * libraries.linkReferences[linkRef][contractName][0].length;
 
           const toReplace = bytecode.slice(start, start + length);
           replacements[toReplace] = address;

--- a/yarn-project/l1-artifacts/scripts/generate-artifacts.sh
+++ b/yarn-project/l1-artifacts/scripts/generate-artifacts.sh
@@ -29,6 +29,7 @@ CONTRACTS=(
   "l1-contracts:Governance"
   "l1-contracts:NewGovernanceProposerPayload"
   "l1-contracts:TxsDecoder"
+  "l1-contracts:SampleLib"
 )
 
 

--- a/yarn-project/sequencer-client/src/publisher/l1-publisher.ts
+++ b/yarn-project/sequencer-client/src/publisher/l1-publisher.ts
@@ -707,7 +707,18 @@ export class L1Publisher {
   }): Promise<string | undefined> {
     try {
       const proofHex: Hex = `0x${args.proof.withoutPublicInputs().toString('hex')}`;
-      const txArgs = [...this.getSubmitEpochProofArgs(args), proofHex] as const;
+      const argsArray = this.getSubmitEpochProofArgs(args);
+
+      const txArgs = [
+        {
+          epochSize: argsArray[0],
+          args: argsArray[1],
+          fees: argsArray[2],
+          aggregationObject: argsArray[3],
+          proof: proofHex,
+        },
+      ] as const;
+
       this.log.info(`SubmitEpochProof proofSize=${args.proof.withoutPublicInputs().length} bytes`);
       await this.rollupContract.simulate.submitEpochRootProof(txArgs, { account: this.account });
       return await this.rollupContract.write.submitEpochRootProof(txArgs, { account: this.account });


### PR DESCRIPTION
Fixes #10063 and #10209

Uses a bit more storage than we would like, but it is to be taken care of as the separate storage optimization issue.

Uses structs for a few of the functions instead of the usual positioned args to work around a bit of stack too deep issues.

Moves the sample lib to linked library to reduce the contract size of the rollup contract.

Updates slightly in the way linked libraries are done, as there was an issue when multiple linked libraries needed.