### PR TITLE
chore: fix 404 status URL

### DIFF
--- a/barretenberg/cpp/src/barretenberg/crypto/schnorr/proof_of_possession.hpp
+++ b/barretenberg/cpp/src/barretenberg/crypto/schnorr/proof_of_possession.hpp
@@ -47,7 +47,7 @@ template <typename G1, typename Hash> struct SchnorrProofOfPossession {
         // that give std::random_device access to an entropy source that produces a string of non-deterministic
         // uniformly random bits. For example, when compiling into a wasm binary, it is essential that the random_get
         // method is overloaded to utilise a suitable entropy source
-        // (see https://github.com/WebAssembly/WASI/blob/main/phases/snapshot/docs.md)
+        // (see https://github.com/WebAssembly/WASI/blob/main/legacy/preview1/docs.md)
         // TODO: securely erase `k`
         Fr k = Fr::random_element();
 

--- a/barretenberg/cpp/src/barretenberg/crypto/schnorr/schnorr.tcc
+++ b/barretenberg/cpp/src/barretenberg/crypto/schnorr/schnorr.tcc
@@ -86,7 +86,7 @@ schnorr_signature schnorr_construct_signature(const std::string& message, const 
     // that give std::random_device access to an entropy source that produces a string of non-deterministic
     // uniformly random bits. For example, when compiling into a wasm binary, it is essential that the random_get
     // method is overloaded to utilise a suitable entropy source
-    // (see https://github.com/WebAssembly/WASI/blob/main/phases/snapshot/docs.md)
+    // (see https://github.com/WebAssembly/WASI/blob/main/legacy/preview1/docs.md)
     //
     // TODO(https://github.com/AztecProtocol/barretenberg/issues/895): securely erase `k`
     Fr k = Fr::random_element();

--- a/barretenberg/ts/src/barretenberg_wasm/barretenberg_wasm_base/index.ts
+++ b/barretenberg/ts/src/barretenberg_wasm/barretenberg_wasm_base/index.ts
@@ -18,7 +18,7 @@ export class BarretenbergWasmBase {
     /* eslint-disable camelcase */
     const importObj = {
       // We need to implement a part of the wasi api:
-      // https://github.com/WebAssembly/WASI/blob/main/phases/snapshot/docs.md
+      // https://github.com/WebAssembly/WASI/blob/main/legacy/preview1/docs.md
       // We literally only need to support random_get, everything else is noop implementated in barretenberg.wasm.
       wasi_snapshot_preview1: {
         random_get: (out: any, length: number) => {

--- a/yarn-project/foundation/src/wasm/empty_wasi_sdk.ts
+++ b/yarn-project/foundation/src/wasm/empty_wasi_sdk.ts
@@ -2,7 +2,7 @@ import { createDebugOnlyLogger } from '../log/index.js';
 
 /**
  * Dummy implementation of a necessary part of the wasi api:
- * https://github.com/WebAssembly/WASI/blob/main/phases/snapshot/docs.md
+ * https://github.com/WebAssembly/WASI/blob/main/legacy/preview1/docs.md
  * We don't use these functions, but the environment expects them.
  * TODO find a way to update off of wasi 12.
  */
@@ -25,7 +25,7 @@ export const getEmptyWasiSdk = (debug = createDebugOnlyLogger('wasm:empty_wasi_s
    * In this dummy implementation, no actual actions are performed, but the debug logger logs 'environ_get' when called.
    * Environment variables are not used in this context, so the real implementation is not required.
    *
-   * @see https://github.com/WebAssembly/WASI/blob/main/phases/snapshot/docs.md#environ_get
+   * @see https://github.com/WebAssembly/WASI/blob/main/legacy/preview1/docs.md#environ_get
    */
   environ_get() {
     debug('environ_get');
@@ -44,7 +44,7 @@ export const getEmptyWasiSdk = (debug = createDebugOnlyLogger('wasm:empty_wasi_s
    * satisfy the requirements of the WebAssembly System Interface (WASI) API,
    * which expects certain functions to be present for compatibility purposes.
    *
-   * @see https://github.com/WebAssembly/WASI/blob/main/phases/snapshot/docs.md
+   * @see https://github.com/WebAssembly/WASI/blob/main/legacy/preview1/docs.md
    */
   fd_close() {
     debug('fd_close');
@@ -61,7 +61,7 @@ export const getEmptyWasiSdk = (debug = createDebugOnlyLogger('wasm:empty_wasi_s
   /**
    * Handles the file descriptor write operation.
    * This dummy implementation of the WASI 'fd_write' function is part of the wasi API:
-   * https://github.com/WebAssembly/WASI/blob/main/phases/snapshot/docs.md
+   * https://github.com/WebAssembly/WASI/blob/main/legacy/preview1/docs.md
    * The environment expects this function, but it is not used in the current implementation.
    * It is used to write data from WebAssembly memory to a file descriptor.
    */


### PR DESCRIPTION
The previous link has expired and has been replaced with the latest address.