### PR TITLE
chore: Bump timeout for after-hook for data store test again

### DIFF
--- a/yarn-project/p2p/src/service/data_store.test.ts
+++ b/yarn-project/p2p/src/service/data_store.test.ts
@@ -17,7 +17,7 @@ import { fromString as uint8ArrayFromString } from 'uint8arrays/from-string';
 
 import { AztecDatastore } from './data_store.js';
 
-const CLEANUP_TIMEOUT = 30_000;
+const CLEANUP_TIMEOUT = 60_000;
 
 describe('AztecDatastore with AztecLmdbStore', () => {
   let datastore: AztecDatastore;


### PR DESCRIPTION
As the CI gets progressively slower, time for another timeout bump (first round was on #6364). 

Note that the data-store test suite [runs in 80s in CI](https://github.com/AztecProtocol/aztec-packages/actions/runs/12048028648/job/33595376516#step:5:2662) but takes 4s locally.
