### PR TITLE
chore: Teardown context in prover coordination test

### DIFF
--- a/yarn-project/end-to-end/src/prover-coordination/e2e_prover_coordination.test.ts
+++ b/yarn-project/end-to-end/src/prover-coordination/e2e_prover_coordination.test.ts
@@ -128,6 +128,10 @@ describe('e2e_prover_coordination', () => {
     await performEscrow(10000000n);
   });
 
+  afterEach(async () => {
+    await snapshotManager.teardown();
+  });
+
   const expectProofClaimOnL1 = async (expected: {
     epochToProve: bigint;
     basisPointFee: number;


### PR DESCRIPTION
The network from the first test kept running in parallel while the second one ran. This should not cause issues for the second run since they use a different rollup contract on L1, but having two anvil test watchers could be having weird consequences.
