### PR TITLE
chore: check artifact consistency

### DIFF
--- a/yarn-project/circuits.js/src/contract/artifact_hash.test.ts
+++ b/yarn-project/circuits.js/src/contract/artifact_hash.test.ts
@@ -1,13 +1,7 @@
 import { type ContractArtifact } from '@aztec/foundation/abi';
-import { loadContractArtifact } from '@aztec/types/abi';
-import type { NoirCompiledContract } from '@aztec/types/noir';
 
-import { readFileSync } from 'fs';
-
-import { getPathToFixture, getTestContractArtifact } from '../tests/fixtures.js';
+import { getTestContractArtifact } from '../tests/fixtures.js';
 import { computeArtifactHash } from './artifact_hash.js';
-
-const TEST_CONTRACT_ARTIFACT_HASH = `"0x19142676527045a118066698e292cc35db16ab4d7bd16610d35d2e1c607eb8b2"`;
 
 describe('ArtifactHash', () => {
   it('calculates the artifact hash', () => {
@@ -31,19 +25,8 @@ describe('ArtifactHash', () => {
     const testArtifact = getTestContractArtifact();
 
     const calculatedArtifactHash = computeArtifactHash(testArtifact).toString();
-    expect(calculatedArtifactHash).toMatchInlineSnapshot(TEST_CONTRACT_ARTIFACT_HASH);
     for (let i = 0; i < 1000; i++) {
       expect(computeArtifactHash(testArtifact).toString()).toBe(calculatedArtifactHash);
     }
-  });
-
-  it('calculates the test contract artifact hash', () => {
-    const path = getPathToFixture('Test.test.json');
-    const content = JSON.parse(readFileSync(path).toString()) as NoirCompiledContract;
-    content.outputs.structs.functions.reverse();
-
-    const testArtifact = loadContractArtifact(content);
-
-    expect(computeArtifactHash(testArtifact).toString()).toMatchInlineSnapshot(TEST_CONTRACT_ARTIFACT_HASH);
   });
 });

--- a/yarn-project/end-to-end/src/composed/integration_l1_publisher.test.ts
+++ b/yarn-project/end-to-end/src/composed/integration_l1_publisher.test.ts
@@ -195,7 +195,8 @@ describe('L1Publisher integration', () => {
     prevHeader = fork.getInitialHeader();
     await fork.close();
 
-    baseFee = new GasFees(0, await rollup.read.getManaBaseFee([true]));
+    const ts = (await publicClient.getBlock()).timestamp;
+    baseFee = new GasFees(0, await rollup.read.getManaBaseFeeAt([ts, true]));
 
     // We jump to the next epoch such that the committee can be setup.
     const timeToJump = await rollup.read.EPOCH_DURATION();


### PR DESCRIPTION
When noir was updated it could lead to the artifact-hash changing which would break a few tests checking against a snapshot.

This pr alters the check such that it is instead checking that multiple computations agree with each other, but no longer checking that it match the checkpoint.