### PR TITLE
chore(ci): move playwright install to `+deps`

### DIFF
--- a/yarn-project/Earthfile
+++ b/yarn-project/Earthfile
@@ -53,7 +53,6 @@ build:
     WORKDIR /usr/src/yarn-project
     COPY . .
     RUN ./bootstrap.sh full
-    RUN cd ivc-integration && chmod +x run_browser_tests.sh
 
 
 build-dev:

--- a/yarn-project/Earthfile
+++ b/yarn-project/Earthfile
@@ -6,7 +6,6 @@ deps:
     LET tsconfigs = $(git ls-files "**/tsconfig*.json" tsconfig*.json)
     FROM ../build-images+from-registry
 
-    ENV PUPPETEER_SKIP_CHROMIUM_DOWNLOAD=true
     RUN npx playwright install && npx playwright install-deps
 
     # copy bb, bb-js and noir-packages
@@ -53,6 +52,7 @@ build:
 
     WORKDIR /usr/src/yarn-project
     COPY . .
+    ENV PUPPETEER_SKIP_CHROMIUM_DOWNLOAD=true
     RUN ./bootstrap.sh full
 
 

--- a/yarn-project/Earthfile
+++ b/yarn-project/Earthfile
@@ -30,6 +30,9 @@ deps:
     # by initialising the module more than once. So at present I don't see a viable alternative.
     RUN ln -s /usr/src/yarn-project/node_modules /usr/src/node_modules
 
+    ENV PUPPETEER_SKIP_CHROMIUM_DOWNLOAD=true
+    RUN npx playwright install && npx playwright install-deps
+
 build:
     # Prefetch targets to not wait for +deps.
     BUILD ../barretenberg/cpp/+build
@@ -49,9 +52,8 @@ build:
 
     WORKDIR /usr/src/yarn-project
     COPY . .
-    ENV PUPPETEER_SKIP_CHROMIUM_DOWNLOAD=true
     RUN ./bootstrap.sh full
-    RUN cd ivc-integration && chmod +x run_browser_tests.sh && npx playwright install && npx playwright install-deps
+    RUN cd ivc-integration && chmod +x run_browser_tests.sh
 
 
 build-dev:

--- a/yarn-project/Earthfile
+++ b/yarn-project/Earthfile
@@ -5,6 +5,10 @@ deps:
     LET packages = $(git ls-files "**/package*.json" package*.json)
     LET tsconfigs = $(git ls-files "**/tsconfig*.json" tsconfig*.json)
     FROM ../build-images+from-registry
+
+    ENV PUPPETEER_SKIP_CHROMIUM_DOWNLOAD=true
+    RUN npx playwright install && npx playwright install-deps
+
     # copy bb, bb-js and noir-packages
     COPY ../barretenberg/cpp/+preset-release/bin /usr/src/barretenberg/cpp/build/bin
     COPY ../barretenberg/cpp/+preset-release-world-state/bin /usr/src/barretenberg/cpp/build/bin
@@ -29,9 +33,6 @@ deps:
     # Also, --preserve-symlinks causes duplication of portalled instances such as bb.js, and breaks the singleton logic
     # by initialising the module more than once. So at present I don't see a viable alternative.
     RUN ln -s /usr/src/yarn-project/node_modules /usr/src/node_modules
-
-    ENV PUPPETEER_SKIP_CHROMIUM_DOWNLOAD=true
-    RUN npx playwright install && npx playwright install-deps
 
 build:
     # Prefetch targets to not wait for +deps.


### PR DESCRIPTION
We never cache playwright because of it running after bootstrapping `yarn-packages`. I've then moved it to run in the `+deps` target so that we can avoid redoing this work.

I've taken the `PUPPETEER_SKIP_CHROMIUM_DOWNLOAD` env var up here as well but I'm not sure if it is supposed to be applied for bootstrapping.