### PR TITLE
chore: Log manual contract class registrations

### DIFF
--- a/yarn-project/aztec-node/src/aztec-node/server.ts
+++ b/yarn-project/aztec-node/src/aztec-node/server.ts
@@ -852,10 +852,12 @@ export class AztecNodeService implements AztecNode {
 
   // TODO(#10007): Remove this method
   public addContractClass(contractClass: ContractClassPublic): Promise<void> {
+    this.log.info(`Adding contract class via API ${contractClass.id}`);
     return this.contractDataSource.addContractClass(contractClass);
   }
 
   public addContractArtifact(address: AztecAddress, artifact: ContractArtifact): Promise<void> {
+    this.log.info(`Adding contract artifact ${artifact.name} for ${address.toString()} via API`);
     // TODO: Node should validate the artifact before accepting it
     return this.contractDataSource.addContractArtifact(address, artifact);
   }


### PR DESCRIPTION
To track when a pxe manually registered a deployed contract class on a node.
