### PR TITLE
chore: fix some oracle mocks

### DIFF
--- a/noir-projects/aztec-nr/aztec/src/state_vars/shared_mutable/test.nr
+++ b/noir-projects/aztec-nr/aztec/src/state_vars/shared_mutable/test.nr
@@ -285,13 +285,15 @@ unconstrained fn test_get_current_value_in_private_bad_value_hints() {
 
     let public_state_var = in_public(env);
     public_state_var.schedule_value_change(new_value);
-
+    let _ = OracleMock::mock("getBlockNumber")
+        .returns(1)
+        .times(1);
     let schedule_block_number = env.block_number();
     let private_state_var = in_private(&mut env, schedule_block_number);
 
     let mocked: ScheduledValueChange<Field> =
         ScheduledValueChange::new(0, new_value + 1, schedule_block_number);
-    let _ = OracleMock::mock("storageRead")
+    let _ = OracleMock::mock("avmOpcodeStorageRead")
         .with_params((
             env.contract_address().to_field(), private_state_var.get_value_change_storage_slot(),
             schedule_block_number, 3,
@@ -308,13 +310,15 @@ unconstrained fn test_get_current_value_in_private_bad_delay_hints() {
 
     let public_state_var = in_public(env);
     public_state_var.schedule_value_change(new_value);
-
+    let _ = OracleMock::mock("getBlockNumber")
+        .returns(1)
+        .times(1);
     let schedule_block_number = env.block_number();
     let private_state_var = in_private(&mut env, schedule_block_number);
 
     let mocked: ScheduledDelayChange<TEST_INITIAL_DELAY> =
         ScheduledDelayChange::new(Option::none(), Option::some(42), schedule_block_number);
-    let _ = OracleMock::mock("storageRead")
+    let _ = OracleMock::mock("avmOpcodeStorageRead")
         .with_params((
             env.contract_address().to_field(), private_state_var.get_delay_change_storage_slot(),
             schedule_block_number, 1,
@@ -328,12 +332,14 @@ unconstrained fn test_get_current_value_in_private_bad_delay_hints() {
 #[test(should_fail_with = "Non-zero value change for zero hash")]
 unconstrained fn test_get_current_value_in_private_bad_zero_hash_value_hints() {
     let mut env = setup();
-
+    let _ = OracleMock::mock("getBlockNumber")
+        .returns(1)
+        .times(1);
     let historical_block_number = env.block_number();
     let state_var = in_private(&mut env, historical_block_number);
 
     let mocked: ScheduledValueChange<Field> = ScheduledValueChange::new(0, new_value, 0);
-    let _ = OracleMock::mock("storageRead")
+    let _ = OracleMock::mock("avmOpcodeStorageRead")
         .with_params((
             env.contract_address().to_field(), state_var.get_value_change_storage_slot(),
             historical_block_number, 3,
@@ -347,13 +353,15 @@ unconstrained fn test_get_current_value_in_private_bad_zero_hash_value_hints() {
 #[test(should_fail_with = "Non-zero delay change for zero hash")]
 unconstrained fn test_get_current_value_in_private_bad_zero_hash_delay_hints() {
     let mut env = setup();
-
+    let _ = OracleMock::mock("getBlockNumber")
+        .returns(1)
+        .times(1);
     let historical_block_number = env.block_number();
     let state_var = in_private(&mut env, historical_block_number);
 
     let mocked: ScheduledDelayChange<TEST_INITIAL_DELAY> =
         ScheduledDelayChange::new(Option::none(), Option::some(new_delay), 0);
-    let _ = OracleMock::mock("storageRead")
+    let _ = OracleMock::mock("avmOpcodeStorageRead")
         .with_params((
             env.contract_address().to_field(), state_var.get_delay_change_storage_slot(),
             historical_block_number, 1,


### PR DESCRIPTION
Fix a few oracle mocks in some tests.

The following tests use oracle calls that are not mocked:
test_get_public_keys_unknown, which requires createAccount oracle
transfer_to_public_failure_on_behalf_of_other_no_approval, which requires addAccount

I am not sure if I can add mocks for these?
