### PR TITLE
chore: Rename logger modules

### DIFF
--- a/boxes/boxes/react/tests/node.test.ts
+++ b/boxes/boxes/react/tests/node.test.ts
@@ -1,8 +1,8 @@
-import { AccountWallet, CompleteAddress, Contract, Fr, createDebugLogger } from '@aztec/aztec.js';
+import { AccountWallet, CompleteAddress, Contract, Fr, createLogger } from '@aztec/aztec.js';
 import { BoxReactContract } from '../artifacts/BoxReact.js';
 import { deployerEnv } from '../src/config.js';
 
-const logger = createDebugLogger('aztec:http-pxe-client');
+const logger = createLogger('aztec:http-pxe-client');
 
 describe('BoxReact Contract Tests', () => {
   let wallet: AccountWallet;

--- a/docs/docs/tutorials/codealong/contract_tutorials/token_bridge/4_typescript_glue_code.md
+++ b/docs/docs/tutorials/codealong/contract_tutorials/token_bridge/4_typescript_glue_code.md
@@ -38,7 +38,7 @@ Open `cross_chain_messaging.test.ts` and paste the initial description of the te
 
 ```typescript
 import { beforeAll, describe, beforeEach, expect, jest, it} from '@jest/globals'
-import { AccountWallet, AztecAddress, BatchCall, type DebugLogger, EthAddress, Fr, computeAuthWitMessageHash, createDebugLogger, createPXEClient, waitForPXE, L1ToL2Message, L1Actor, L2Actor, type PXE, type Wallet } from '@aztec/aztec.js';
+import { AccountWallet, AztecAddress, BatchCall, type DebugLogger, EthAddress, Fr, computeAuthWitMessageHash, createLogger, createPXEClient, waitForPXE, L1ToL2Message, L1Actor, L2Actor, type PXE, type Wallet } from '@aztec/aztec.js';
 import { getInitialTestAccountsWallets } from '@aztec/accounts/testing';
 import { TokenContract } from '@aztec/noir-contracts.js/Token';
 import { sha256ToField } from '@aztec/foundation/crypto';
@@ -92,7 +92,7 @@ describe('e2e_cross_chain_messaging', () => {
   let outbox: any;
 
   beforeAll(async () => {
-      logger = createDebugLogger('aztec:e2e_uniswap');
+      logger = createLogger('aztec:e2e_uniswap');
       const pxe = createPXEClient(PXE_URL);
       await waitForPXE(pxe);
       wallets = await getInitialTestAccountsWallets(pxe);
@@ -102,7 +102,7 @@ describe('e2e_cross_chain_messaging', () => {
   })
 
   beforeEach(async () => {
-    logger = createDebugLogger('aztec:e2e_uniswap');
+    logger = createLogger('aztec:e2e_uniswap');
     const pxe = createPXEClient(PXE_URL);
     await waitForPXE(pxe);
 

--- a/yarn-project/archiver/src/archiver/archiver.ts
+++ b/yarn-project/archiver/src/archiver/archiver.ts
@@ -40,7 +40,7 @@ import { type ContractArtifact } from '@aztec/foundation/abi';
 import { type AztecAddress } from '@aztec/foundation/aztec-address';
 import { type EthAddress } from '@aztec/foundation/eth-address';
 import { Fr } from '@aztec/foundation/fields';
-import { type DebugLogger, createDebugLogger } from '@aztec/foundation/log';
+import { type Logger, createLogger } from '@aztec/foundation/log';
 import { RunningPromise } from '@aztec/foundation/running-promise';
 import { count } from '@aztec/foundation/string';
 import { elapsed } from '@aztec/foundation/timer';
@@ -116,7 +116,7 @@ export class Archiver implements ArchiveSource {
     private readonly config: { pollingIntervalMs: number; batchSize: number },
     private readonly instrumentation: ArchiverInstrumentation,
     private readonly l1constants: L1RollupConstants,
-    private readonly log: DebugLogger = createDebugLogger('aztec:archiver'),
+    private readonly log: DebugLogger = createDebugLogger('archiver'),
   ) {
     this.store = new ArchiverStoreHelper(dataStore);
 
@@ -836,7 +836,7 @@ class ArchiverStoreHelper
       | 'addFunctions'
     >
 {
-  #log = createDebugLogger('aztec:archiver:block-helper');
+  #log = createLogger('archiver:block-helper');
 
   constructor(private readonly store: ArchiverDataStore) {}
 

--- a/yarn-project/archiver/src/archiver/archiver.ts
+++ b/yarn-project/archiver/src/archiver/archiver.ts
@@ -116,7 +116,7 @@ export class Archiver implements ArchiveSource {
     private readonly config: { pollingIntervalMs: number; batchSize: number },
     private readonly instrumentation: ArchiverInstrumentation,
     private readonly l1constants: L1RollupConstants,
-    private readonly log: DebugLogger = createDebugLogger('archiver'),
+    private readonly log: Logger = createLogger('archiver'),
   ) {
     this.store = new ArchiverStoreHelper(dataStore);
 

--- a/yarn-project/archiver/src/archiver/data_retrieval.ts
+++ b/yarn-project/archiver/src/archiver/data_retrieval.ts
@@ -3,7 +3,7 @@ import { AppendOnlyTreeSnapshot, BlockHeader, Fr, Proof } from '@aztec/circuits.
 import { asyncPool } from '@aztec/foundation/async-pool';
 import { type EthAddress } from '@aztec/foundation/eth-address';
 import { type ViemSignature } from '@aztec/foundation/eth-signature';
-import { type DebugLogger, createDebugLogger } from '@aztec/foundation/log';
+import { type Logger, createLogger } from '@aztec/foundation/log';
 import { numToUInt32BE } from '@aztec/foundation/serialize';
 import { type InboxAbi, RollupAbi } from '@aztec/l1-artifacts';
 
@@ -36,7 +36,7 @@ export async function retrieveBlocksFromRollup(
   publicClient: PublicClient,
   searchStartBlock: bigint,
   searchEndBlock: bigint,
-  logger: DebugLogger = createDebugLogger('aztec:archiver'),
+  logger: Logger = createLogger('archiver'),
 ): Promise<L1Published<L2Block>[]> {
   const retrievedBlocks: L1Published<L2Block>[] = [];
   do {
@@ -78,7 +78,7 @@ export async function processL2BlockProposedLogs(
   rollup: GetContractReturnType<typeof RollupAbi, PublicClient<HttpTransport, Chain>>,
   publicClient: PublicClient,
   logs: GetContractEventsReturnType<typeof RollupAbi, 'L2BlockProposed'>,
-  logger: DebugLogger,
+  logger: Logger,
 ): Promise<L1Published<L2Block>[]> {
   const retrievedBlocks: L1Published<L2Block>[] = [];
   await asyncPool(10, logs, async log => {

--- a/yarn-project/archiver/src/archiver/instrumentation.ts
+++ b/yarn-project/archiver/src/archiver/instrumentation.ts
@@ -1,5 +1,5 @@
 import { type L2Block } from '@aztec/circuit-types';
-import { createDebugLogger } from '@aztec/foundation/log';
+import { createLogger } from '@aztec/foundation/log';
 import {
   Attributes,
   type Gauge,
@@ -22,7 +22,7 @@ export class ArchiverInstrumentation {
   private proofsSubmittedCount: UpDownCounter;
   private dbMetrics: LmdbMetrics;
 
-  private log = createDebugLogger('aztec:archiver:instrumentation');
+  private log = createLogger('archiver:instrumentation');
 
   constructor(private telemetry: TelemetryClient, lmdbStats?: LmdbStatsCallback) {
     const meter = telemetry.getMeter('Archiver');

--- a/yarn-project/archiver/src/archiver/kv_archiver_store/block_store.ts
+++ b/yarn-project/archiver/src/archiver/kv_archiver_store/block_store.ts
@@ -1,6 +1,6 @@
 import { Body, type InBlock, L2Block, L2BlockHash, type TxEffect, type TxHash, TxReceipt } from '@aztec/circuit-types';
 import { AppendOnlyTreeSnapshot, type AztecAddress, BlockHeader, INITIAL_L2_BLOCK_NUM } from '@aztec/circuits.js';
-import { createDebugLogger } from '@aztec/foundation/log';
+import { createLogger } from '@aztec/foundation/log';
 import { type AztecKVStore, type AztecMap, type AztecSingleton, type Range } from '@aztec/kv-store';
 
 import { type L1Published, type L1PublishedData } from '../structs/published.js';
@@ -38,7 +38,7 @@ export class BlockStore {
   /** Index mapping a contract's address (as a string) to its location in a block */
   #contractIndex: AztecMap<string, BlockIndexValue>;
 
-  #log = createDebugLogger('aztec:archiver:block_store');
+  #log = createLogger('archiver:block_store');
 
   constructor(private db: AztecKVStore) {
     this.#blocks = db.openMap('archiver_blocks');

--- a/yarn-project/archiver/src/archiver/kv_archiver_store/kv_archiver_store.ts
+++ b/yarn-project/archiver/src/archiver/kv_archiver_store/kv_archiver_store.ts
@@ -19,7 +19,7 @@ import {
 } from '@aztec/circuits.js';
 import { type ContractArtifact, FunctionSelector } from '@aztec/foundation/abi';
 import { type AztecAddress } from '@aztec/foundation/aztec-address';
-import { createDebugLogger } from '@aztec/foundation/log';
+import { createLogger } from '@aztec/foundation/log';
 import { type AztecKVStore } from '@aztec/kv-store';
 
 import { type ArchiverDataStore, type ArchiverL1SynchPoint } from '../archiver_store.js';
@@ -46,7 +46,7 @@ export class KVArchiverDataStore implements ArchiverDataStore {
   #contractArtifactStore: ContractArtifactsStore;
   private functionNames = new Map<string, string>();
 
-  #log = createDebugLogger('aztec:archiver:data-store');
+  #log = createLogger('archiver:data-store');
 
   constructor(private db: AztecKVStore, logsMaxPageSize: number = 1000) {
     this.#blockStore = new BlockStore(db);

--- a/yarn-project/archiver/src/archiver/kv_archiver_store/log_store.ts
+++ b/yarn-project/archiver/src/archiver/kv_archiver_store/log_store.ts
@@ -11,7 +11,7 @@ import {
 } from '@aztec/circuit-types';
 import { Fr, PrivateLog } from '@aztec/circuits.js';
 import { INITIAL_L2_BLOCK_NUM, MAX_NOTE_HASHES_PER_TX } from '@aztec/circuits.js/constants';
-import { createDebugLogger } from '@aztec/foundation/log';
+import { createLogger } from '@aztec/foundation/log';
 import { BufferReader } from '@aztec/foundation/serialize';
 import { type AztecKVStore, type AztecMap } from '@aztec/kv-store';
 
@@ -27,7 +27,7 @@ export class LogStore {
   #unencryptedLogsByBlock: AztecMap<number, Buffer>;
   #contractClassLogsByBlock: AztecMap<number, Buffer>;
   #logsMaxPageSize: number;
-  #log = createDebugLogger('aztec:archiver:log_store');
+  #log = createLogger('archiver:log_store');
 
   constructor(private db: AztecKVStore, private blockStore: BlockStore, logsMaxPageSize: number = 1000) {
     this.#logsByTag = db.openMap('archiver_tagged_logs_by_tag');

--- a/yarn-project/archiver/src/archiver/kv_archiver_store/message_store.ts
+++ b/yarn-project/archiver/src/archiver/kv_archiver_store/message_store.ts
@@ -1,6 +1,6 @@
 import { InboxLeaf } from '@aztec/circuit-types';
 import { Fr, L1_TO_L2_MSG_SUBTREE_HEIGHT } from '@aztec/circuits.js';
-import { createDebugLogger } from '@aztec/foundation/log';
+import { createLogger } from '@aztec/foundation/log';
 import { type AztecKVStore, type AztecMap, type AztecSingleton } from '@aztec/kv-store';
 
 import { type DataRetrieval } from '../structs/data_retrieval.js';
@@ -14,7 +14,7 @@ export class MessageStore {
   #lastSynchedL1Block: AztecSingleton<bigint>;
   #totalMessageCount: AztecSingleton<bigint>;
 
-  #log = createDebugLogger('aztec:archiver:message_store');
+  #log = createLogger('archiver:message_store');
 
   #l1ToL2MessagesSubtreeSize = 2 ** L1_TO_L2_MSG_SUBTREE_HEIGHT;
 

--- a/yarn-project/archiver/src/archiver/kv_archiver_store/nullifier_store.ts
+++ b/yarn-project/archiver/src/archiver/kv_archiver_store/nullifier_store.ts
@@ -1,13 +1,13 @@
 import { type InBlock, type L2Block } from '@aztec/circuit-types';
 import { type Fr, MAX_NULLIFIERS_PER_TX } from '@aztec/circuits.js';
-import { createDebugLogger } from '@aztec/foundation/log';
+import { createLogger } from '@aztec/foundation/log';
 import { type AztecKVStore, type AztecMap } from '@aztec/kv-store';
 
 export class NullifierStore {
   #nullifiersToBlockNumber: AztecMap<string, number>;
   #nullifiersToBlockHash: AztecMap<string, string>;
   #nullifiersToIndex: AztecMap<string, number>;
-  #log = createDebugLogger('aztec:archiver:log_store');
+  #log = createLogger('archiver:log_store');
 
   constructor(private db: AztecKVStore) {
     this.#nullifiersToBlockNumber = db.openMap('archiver_nullifiers_to_block_number');

--- a/yarn-project/archiver/src/archiver/memory_archiver_store/memory_archiver_store.ts
+++ b/yarn-project/archiver/src/archiver/memory_archiver_store/memory_archiver_store.ts
@@ -30,7 +30,7 @@ import {
 } from '@aztec/circuits.js';
 import { type ContractArtifact, FunctionSelector } from '@aztec/foundation/abi';
 import { type AztecAddress } from '@aztec/foundation/aztec-address';
-import { createDebugLogger } from '@aztec/foundation/log';
+import { createLogger } from '@aztec/foundation/log';
 
 import { type ArchiverDataStore, type ArchiverL1SynchPoint } from '../archiver_store.js';
 import { type DataRetrieval } from '../structs/data_retrieval.js';
@@ -86,7 +86,7 @@ export class MemoryArchiverStore implements ArchiverDataStore {
   private lastProvenL2BlockNumber: number = 0;
   private lastProvenL2EpochNumber: number = 0;
 
-  #log = createDebugLogger('aztec:archiver:data-store');
+  #log = createLogger('archiver:data-store');
 
   constructor(
     /** The max number of logs that can be obtained in 1 "getUnencryptedLogs" call. */

--- a/yarn-project/archiver/src/factory.ts
+++ b/yarn-project/archiver/src/factory.ts
@@ -4,7 +4,7 @@ import {
   computePublicBytecodeCommitment,
   getContractClassFromArtifact,
 } from '@aztec/circuits.js';
-import { createDebugLogger } from '@aztec/foundation/log';
+import { createLogger } from '@aztec/foundation/log';
 import { type Maybe } from '@aztec/foundation/types';
 import { type DataStoreConfig } from '@aztec/kv-store/config';
 import { createStore } from '@aztec/kv-store/lmdb';
@@ -24,7 +24,7 @@ export async function createArchiver(
   opts: { blockUntilSync: boolean } = { blockUntilSync: true },
 ): Promise<ArchiverApi & Maybe<Service>> {
   if (!config.archiverUrl) {
-    const store = await createStore('archiver', config, createDebugLogger('aztec:archiver:lmdb'));
+    const store = await createStore('archiver', config, createLogger('archiver:lmdb'));
     const archiverStore = new KVArchiverDataStore(store, config.maxLogs);
     await registerProtocolContracts(archiverStore);
     await registerCommonContracts(archiverStore);

--- a/yarn-project/archiver/src/index.ts
+++ b/yarn-project/archiver/src/index.ts
@@ -2,7 +2,4 @@ export * from './archiver/index.js';
 export * from './factory.js';
 export * from './rpc/index.js';
 
-export {
-  retrieveBlocksFromRollup as retrieveBlockFromRollup,
-  retrieveL2ProofVerifiedEvents,
-} from './archiver/data_retrieval.js';
+export { retrieveBlocksFromRollup, retrieveL2ProofVerifiedEvents } from './archiver/data_retrieval.js';

--- a/yarn-project/archiver/src/test/mock_l2_block_source.ts
+++ b/yarn-project/archiver/src/test/mock_l2_block_source.ts
@@ -10,7 +10,7 @@ import {
 import { getSlotRangeForEpoch } from '@aztec/circuit-types';
 import { type BlockHeader, EthAddress } from '@aztec/circuits.js';
 import { DefaultL1ContractsConfig } from '@aztec/ethereum';
-import { createDebugLogger } from '@aztec/foundation/log';
+import { createLogger } from '@aztec/foundation/log';
 
 /**
  * A mocked implementation of L2BlockSource to be used in tests.
@@ -21,7 +21,7 @@ export class MockL2BlockSource implements L2BlockSource {
   private provenEpochNumber: number = 0;
   private provenBlockNumber: number = 0;
 
-  private log = createDebugLogger('aztec:archiver:mock_l2_block_source');
+  private log = createLogger('archiver:mock_l2_block_source');
 
   public createBlocks(numBlocks: number) {
     for (let i = 0; i < numBlocks; i++) {

--- a/yarn-project/aztec-faucet/src/bin/index.ts
+++ b/yarn-project/aztec-faucet/src/bin/index.ts
@@ -1,7 +1,7 @@
 #!/usr/bin/env -S node --no-warnings
 import { NULL_KEY, createEthereumChain } from '@aztec/ethereum';
 import { EthAddress } from '@aztec/foundation/eth-address';
-import { createDebugLogger } from '@aztec/foundation/log';
+import { createLogger } from '@aztec/foundation/log';
 import { TestERC20Abi } from '@aztec/l1-artifacts';
 
 import http from 'http';
@@ -34,7 +34,7 @@ const {
   EXTRA_ASSET_AMOUNT = '',
 } = process.env;
 
-const logger = createDebugLogger('aztec:faucet');
+const logger = createLogger('faucet');
 
 const rpcUrl = RPC_URL;
 const l1ChainId = +L1_CHAIN_ID;

--- a/yarn-project/aztec-node/src/aztec-node/server.ts
+++ b/yarn-project/aztec-node/src/aztec-node/server.ts
@@ -57,7 +57,7 @@ import { type L1ContractAddresses, createEthereumChain } from '@aztec/ethereum';
 import { type ContractArtifact } from '@aztec/foundation/abi';
 import { AztecAddress } from '@aztec/foundation/aztec-address';
 import { padArrayEnd } from '@aztec/foundation/collection';
-import { type DebugLogger, createDebugLogger } from '@aztec/foundation/log';
+import { type Logger, createLogger } from '@aztec/foundation/log';
 import { Timer } from '@aztec/foundation/timer';
 import { type AztecKVStore } from '@aztec/kv-store';
 import { openTmpStore } from '@aztec/kv-store/lmdb';
@@ -105,7 +105,7 @@ export class AztecNodeService implements AztecNode {
     protected readonly globalVariableBuilder: GlobalVariableBuilder,
     private proofVerifier: ClientProtocolCircuitVerifier,
     private telemetry: TelemetryClient,
-    private log = createDebugLogger('aztec:node'),
+    private log = createLogger('node'),
   ) {
     this.packageVersion = getPackageInfo().version;
     this.metrics = new NodeMetrics(telemetry, 'AztecNodeService');
@@ -140,12 +140,12 @@ export class AztecNodeService implements AztecNode {
     config: AztecNodeConfig,
     deps: {
       telemetry?: TelemetryClient;
-      logger?: DebugLogger;
+      logger?: Logger;
       publisher?: L1Publisher;
     } = {},
   ): Promise<AztecNodeService> {
     const telemetry = deps.telemetry ?? new NoopTelemetryClient();
-    const log = deps.logger ?? createDebugLogger('aztec:node');
+    const log = deps.logger ?? createLogger('node');
     const ethereumChain = createEthereumChain(config.l1RpcUrl, config.l1ChainId);
     //validate that the actual chain id matches that specified in configuration
     if (config.l1ChainId !== ethereumChain.chainInfo.id) {

--- a/yarn-project/aztec-node/src/bin/index.ts
+++ b/yarn-project/aztec-node/src/bin/index.ts
@@ -1,5 +1,5 @@
 #!/usr/bin/env -S node --no-warnings
-import { createDebugLogger } from '@aztec/foundation/log';
+import { createLogger } from '@aztec/foundation/log';
 
 import http from 'http';
 
@@ -7,7 +7,7 @@ import { type AztecNodeConfig, AztecNodeService, createAztecNodeRpcServer, getCo
 
 const { AZTEC_NODE_PORT = 8081, API_PREFIX = '' } = process.env;
 
-const logger = createDebugLogger('aztec:node');
+const logger = createLogger('node');
 
 /**
  * Creates the node from provided config

--- a/yarn-project/aztec.js/src/contract/base_contract_interaction.ts
+++ b/yarn-project/aztec.js/src/contract/base_contract_interaction.ts
@@ -30,7 +30,7 @@ export type SendMethodOptions = {
  * Implements the sequence create/simulate/send.
  */
 export abstract class BaseContractInteraction {
-  protected log = createLogger('js:contract_interaction');
+  protected log = createLogger('aztecjs:contract_interaction');
 
   constructor(protected wallet: Wallet) {}
 

--- a/yarn-project/aztec.js/src/contract/base_contract_interaction.ts
+++ b/yarn-project/aztec.js/src/contract/base_contract_interaction.ts
@@ -1,6 +1,6 @@
 import { type TxExecutionRequest, type TxProvingResult } from '@aztec/circuit-types';
 import { type Fr, GasSettings } from '@aztec/circuits.js';
-import { createDebugLogger } from '@aztec/foundation/log';
+import { createLogger } from '@aztec/foundation/log';
 
 import { type Wallet } from '../account/wallet.js';
 import { type ExecutionRequestInit } from '../entrypoint/entrypoint.js';
@@ -30,7 +30,7 @@ export type SendMethodOptions = {
  * Implements the sequence create/simulate/send.
  */
 export abstract class BaseContractInteraction {
-  protected log = createDebugLogger('aztec:js:contract_interaction');
+  protected log = createLogger('js:contract_interaction');
 
   constructor(protected wallet: Wallet) {}
 

--- a/yarn-project/aztec.js/src/contract/deploy_sent_tx.ts
+++ b/yarn-project/aztec.js/src/contract/deploy_sent_tx.ts
@@ -24,7 +24,7 @@ export type DeployTxReceipt<TContract extends ContractBase = Contract> = FieldsO
  * A contract deployment transaction sent to the network, extending SentTx with methods to create a contract instance.
  */
 export class DeploySentTx<TContract extends Contract = Contract> extends SentTx {
-  private log = createLogger('js:deploy_sent_tx');
+  private log = createLogger('aztecjs:deploy_sent_tx');
 
   constructor(
     wallet: PXE | Wallet,

--- a/yarn-project/aztec.js/src/contract/deploy_sent_tx.ts
+++ b/yarn-project/aztec.js/src/contract/deploy_sent_tx.ts
@@ -1,6 +1,6 @@
 import { type PXE, type TxHash, type TxReceipt } from '@aztec/circuit-types';
 import { type AztecAddress, type ContractInstanceWithAddress } from '@aztec/circuits.js';
-import { createDebugLogger } from '@aztec/foundation/log';
+import { createLogger } from '@aztec/foundation/log';
 import { type FieldsOf } from '@aztec/foundation/types';
 
 import { type Wallet } from '../account/index.js';
@@ -24,7 +24,7 @@ export type DeployTxReceipt<TContract extends ContractBase = Contract> = FieldsO
  * A contract deployment transaction sent to the network, extending SentTx with methods to create a contract instance.
  */
 export class DeploySentTx<TContract extends Contract = Contract> extends SentTx {
-  private log = createDebugLogger('aztec:js:deploy_sent_tx');
+  private log = createLogger('js:deploy_sent_tx');
 
   constructor(
     wallet: PXE | Wallet,

--- a/yarn-project/aztec.js/src/index.ts
+++ b/yarn-project/aztec.js/src/index.ts
@@ -159,7 +159,7 @@ export { decodeFromAbi, encodeArguments, type AbiType } from '@aztec/foundation/
 export { toBigIntBE } from '@aztec/foundation/bigint-buffer';
 export { sha256 } from '@aztec/foundation/crypto';
 export { makeFetch } from '@aztec/foundation/json-rpc/client';
-export { createDebugLogger, type DebugLogger } from '@aztec/foundation/log';
+export { createLogger, type Logger } from '@aztec/foundation/log';
 export { retry, retryUntil } from '@aztec/foundation/retry';
 export { to2Fields, toBigInt } from '@aztec/foundation/serialize';
 export { sleep } from '@aztec/foundation/sleep';

--- a/yarn-project/aztec.js/src/rpc_clients/node/index.ts
+++ b/yarn-project/aztec.js/src/rpc_clients/node/index.ts
@@ -1,6 +1,6 @@
 import { type PXE } from '@aztec/circuit-types';
 import { jsonStringify } from '@aztec/foundation/json-rpc';
-import { type DebugLogger } from '@aztec/foundation/log';
+import { type Logger } from '@aztec/foundation/log';
 import { NoRetryError, makeBackoff, retry } from '@aztec/foundation/retry';
 
 import { Axios, type AxiosError } from 'axios';
@@ -51,7 +51,7 @@ async function axiosFetch(host: string, rpcMethod: string, body: any, useApiEndp
  * @param _logger - Debug logger to warn version incompatibilities.
  * @returns A PXE client.
  */
-export function createCompatibleClient(rpcUrl: string, logger: DebugLogger): Promise<PXE> {
+export function createCompatibleClient(rpcUrl: string, logger: Logger): Promise<PXE> {
   // Use axios due to timeout issues with fetch when proving TXs.
   const fetch = async (host: string, rpcMethod: string, body: any, useApiEndpoints: boolean) => {
     return await retry(

--- a/yarn-project/aztec.js/src/utils/anvil_test_watcher.ts
+++ b/yarn-project/aztec.js/src/utils/anvil_test_watcher.ts
@@ -1,4 +1,4 @@
-import { type DebugLogger, type EthCheatCodes, createDebugLogger } from '@aztec/aztec.js';
+import { type EthCheatCodes, type Logger, createLogger } from '@aztec/aztec.js';
 import { type EthAddress } from '@aztec/circuits.js';
 import { RunningPromise } from '@aztec/foundation/running-promise';
 import { RollupAbi } from '@aztec/l1-artifacts';
@@ -18,7 +18,7 @@ export class AnvilTestWatcher {
 
   private filledRunningPromise?: RunningPromise;
 
-  private logger: DebugLogger = createDebugLogger(`aztec:utils:watcher`);
+  private logger: Logger = createLogger(`aztec:utils:watcher`);
 
   constructor(
     private cheatcodes: EthCheatCodes,

--- a/yarn-project/aztec.js/src/utils/anvil_test_watcher.ts
+++ b/yarn-project/aztec.js/src/utils/anvil_test_watcher.ts
@@ -18,7 +18,7 @@ export class AnvilTestWatcher {
 
   private filledRunningPromise?: RunningPromise;
 
-  private logger: Logger = createLogger(`aztec:utils:watcher`);
+  private logger: Logger = createLogger(`aztecjs:utils:watcher`);
 
   constructor(
     private cheatcodes: EthCheatCodes,

--- a/yarn-project/aztec.js/src/utils/anvil_test_watcher.ts
+++ b/yarn-project/aztec.js/src/utils/anvil_test_watcher.ts
@@ -31,7 +31,7 @@ export class AnvilTestWatcher {
       client: publicClient,
     });
 
-    this.logger.info(`Watcher created for rollup at ${rollupAddress}`);
+    this.logger.debug(`Watcher created for rollup at ${rollupAddress}`);
   }
 
   async start() {
@@ -48,7 +48,7 @@ export class AnvilTestWatcher {
     if (isAutoMining) {
       this.filledRunningPromise = new RunningPromise(() => this.mineIfSlotFilled(), 1000);
       this.filledRunningPromise.start();
-      this.logger.info(`Watcher started`);
+      this.logger.info(`Watcher started for rollup at ${this.rollup.address}`);
     } else {
       this.logger.info(`Watcher not started because not auto mining`);
     }

--- a/yarn-project/aztec.js/src/utils/cheat_codes.ts
+++ b/yarn-project/aztec.js/src/utils/cheat_codes.ts
@@ -51,7 +51,7 @@ export class RollupCheatCodes {
   private client: WalletClient & PublicClient;
   private rollup: GetContractReturnType<typeof RollupAbi, WalletClient>;
 
-  private logger = createLogger('js:cheat_codes');
+  private logger = createLogger('aztecjs:cheat_codes');
 
   constructor(private ethCheatCodes: EthCheatCodes, addresses: Pick<L1ContractAddresses, 'rollupAddress'>) {
     this.client = createWalletClient({ chain: foundry, transport: http(ethCheatCodes.rpcUrl) }).extend(publicActions);
@@ -197,7 +197,7 @@ export class AztecCheatCodes {
     /**
      * The logger to use for the aztec cheatcodes
      */
-    public logger = createLogger('cheat_codes:aztec'),
+    public logger = createLogger('aztecjs:cheat_codes'),
   ) {}
 
   /**

--- a/yarn-project/aztec.js/src/utils/cheat_codes.ts
+++ b/yarn-project/aztec.js/src/utils/cheat_codes.ts
@@ -2,7 +2,7 @@ import { type EpochProofClaim, type Note, type PXE } from '@aztec/circuit-types'
 import { type AztecAddress, EthAddress, Fr } from '@aztec/circuits.js';
 import { deriveStorageSlotInMap } from '@aztec/circuits.js/hash';
 import { EthCheatCodes, type L1ContractAddresses } from '@aztec/ethereum';
-import { createDebugLogger } from '@aztec/foundation/log';
+import { createLogger } from '@aztec/foundation/log';
 import { RollupAbi } from '@aztec/l1-artifacts';
 
 import {
@@ -51,7 +51,7 @@ export class RollupCheatCodes {
   private client: WalletClient & PublicClient;
   private rollup: GetContractReturnType<typeof RollupAbi, WalletClient>;
 
-  private logger = createDebugLogger('aztec:js:cheat_codes');
+  private logger = createLogger('js:cheat_codes');
 
   constructor(private ethCheatCodes: EthCheatCodes, addresses: Pick<L1ContractAddresses, 'rollupAddress'>) {
     this.client = createWalletClient({ chain: foundry, transport: http(ethCheatCodes.rpcUrl) }).extend(publicActions);
@@ -197,7 +197,7 @@ export class AztecCheatCodes {
     /**
      * The logger to use for the aztec cheatcodes
      */
-    public logger = createDebugLogger('aztec:cheat_codes:aztec'),
+    public logger = createLogger('cheat_codes:aztec'),
   ) {}
 
   /**

--- a/yarn-project/aztec.js/src/utils/node.ts
+++ b/yarn-project/aztec.js/src/utils/node.ts
@@ -1,8 +1,8 @@
 import { type AztecNode } from '@aztec/circuit-types';
-import { type DebugLogger } from '@aztec/foundation/log';
+import { type Logger } from '@aztec/foundation/log';
 import { retryUntil } from '@aztec/foundation/retry';
 
-export const waitForNode = async (node: AztecNode, logger?: DebugLogger) => {
+export const waitForNode = async (node: AztecNode, logger?: Logger) => {
   await retryUntil(async () => {
     try {
       logger?.verbose('Attempting to contact Aztec node...');

--- a/yarn-project/aztec.js/src/utils/portal_manager.ts
+++ b/yarn-project/aztec.js/src/utils/portal_manager.ts
@@ -1,8 +1,8 @@
 import {
   type AztecAddress,
-  type DebugLogger,
   EthAddress,
   Fr,
+  type Logger,
   type PXE,
   type SiblingPath,
   computeSecretHash,
@@ -49,7 +49,7 @@ function stringifyEthAddress(address: EthAddress | Hex, name?: string) {
 }
 
 /** Generates a pair secret and secret hash */
-export function generateClaimSecret(logger?: DebugLogger): [Fr, Fr] {
+export function generateClaimSecret(logger?: Logger): [Fr, Fr] {
   const secret = Fr.random();
   const secretHash = computeSecretHash(secret);
   logger?.verbose(`Generated claim secret=${secret.toString()} hash=${secretHash.toString()}`);
@@ -65,7 +65,7 @@ export class L1TokenManager {
     public readonly address: EthAddress,
     private publicClient: PublicClient<HttpTransport, Chain>,
     private walletClient: WalletClient<HttpTransport, Chain, Account>,
-    private logger: DebugLogger,
+    private logger: Logger,
   ) {
     this.contract = getContract({
       address: this.address.toString(),
@@ -122,7 +122,7 @@ export class L1FeeJuicePortalManager {
     tokenAddress: EthAddress,
     private readonly publicClient: PublicClient<HttpTransport, Chain>,
     private readonly walletClient: WalletClient<HttpTransport, Chain, Account>,
-    private readonly logger: DebugLogger,
+    private readonly logger: Logger,
   ) {
     this.tokenManager = new L1TokenManager(tokenAddress, publicClient, walletClient, logger);
     this.contract = getContract({
@@ -192,7 +192,7 @@ export class L1FeeJuicePortalManager {
     pxe: PXE,
     publicClient: PublicClient<HttpTransport, Chain>,
     walletClient: WalletClient<HttpTransport, Chain, Account>,
-    logger: DebugLogger,
+    logger: Logger,
   ): Promise<L1FeeJuicePortalManager> {
     const {
       l1ContractAddresses: { feeJuiceAddress, feeJuicePortalAddress },
@@ -216,7 +216,7 @@ export class L1ToL2TokenPortalManager {
     tokenAddress: EthAddress,
     protected publicClient: PublicClient<HttpTransport, Chain>,
     protected walletClient: WalletClient<HttpTransport, Chain, Account>,
-    protected logger: DebugLogger,
+    protected logger: Logger,
   ) {
     this.tokenManager = new L1TokenManager(tokenAddress, publicClient, walletClient, logger);
     this.portal = getContract({
@@ -334,7 +334,7 @@ export class L1TokenPortalManager extends L1ToL2TokenPortalManager {
     outboxAddress: EthAddress,
     publicClient: PublicClient<HttpTransport, Chain>,
     walletClient: WalletClient<HttpTransport, Chain, Account>,
-    logger: DebugLogger,
+    logger: Logger,
   ) {
     super(portalAddress, tokenAddress, publicClient, walletClient, logger);
     this.outbox = getContract({

--- a/yarn-project/aztec.js/src/utils/pxe.ts
+++ b/yarn-project/aztec.js/src/utils/pxe.ts
@@ -1,8 +1,8 @@
 import { type PXE } from '@aztec/circuit-types';
-import { type DebugLogger } from '@aztec/foundation/log';
+import { type Logger } from '@aztec/foundation/log';
 import { retryUntil } from '@aztec/foundation/retry';
 
-export const waitForPXE = async (pxe: PXE, logger?: DebugLogger) => {
+export const waitForPXE = async (pxe: PXE, logger?: Logger) => {
   await retryUntil(async () => {
     try {
       logger?.verbose('Attempting to contact PXE...');

--- a/yarn-project/aztec/src/bin/index.ts
+++ b/yarn-project/aztec/src/bin/index.ts
@@ -8,7 +8,7 @@ import { injectCommands as injectInfrastructureCommands } from '@aztec/cli/infra
 import { injectCommands as injectL1Commands } from '@aztec/cli/l1';
 import { injectCommands as injectMiscCommands } from '@aztec/cli/misc';
 import { injectCommands as injectPXECommands } from '@aztec/cli/pxe';
-import { createConsoleLogger, createDebugLogger } from '@aztec/foundation/log';
+import { createConsoleLogger, createLogger } from '@aztec/foundation/log';
 
 import { Command } from 'commander';
 import { readFileSync } from 'fs';
@@ -17,7 +17,7 @@ import { dirname, resolve } from 'path';
 import { injectAztecCommands } from '../cli/index.js';
 
 const userLog = createConsoleLogger();
-const debugLogger = createDebugLogger('aztec:cli');
+const debugLogger = createLogger('cli');
 
 /** CLI & full node main entrypoint */
 async function main() {

--- a/yarn-project/aztec/src/cli/cli.ts
+++ b/yarn-project/aztec/src/cli/cli.ts
@@ -5,7 +5,7 @@ import {
   createNamespacedSafeJsonRpcServer,
   startHttpRpcServer,
 } from '@aztec/foundation/json-rpc/server';
-import { type DebugLogger, type LogFn } from '@aztec/foundation/log';
+import { type LogFn, type Logger } from '@aztec/foundation/log';
 
 import { Command } from 'commander';
 
@@ -25,7 +25,7 @@ import {
  * @param userLog - log function for logging user output.
  * @param debugLogger - logger for logging debug messages.
  */
-export function injectAztecCommands(program: Command, userLog: LogFn, debugLogger: DebugLogger): Command {
+export function injectAztecCommands(program: Command, userLog: LogFn, debugLogger: Logger): Command {
   const startCmd = new Command('start').description(
     'Starts Aztec modules. Options for each module can be set as key-value pairs (e.g. "option1=value1,option2=value2") or as environment variables.',
   );

--- a/yarn-project/aztec/src/cli/cmds/start_archiver.ts
+++ b/yarn-project/aztec/src/cli/cmds/start_archiver.ts
@@ -1,5 +1,5 @@
 import { Archiver, type ArchiverConfig, KVArchiverDataStore, archiverConfigMappings } from '@aztec/archiver';
-import { createDebugLogger } from '@aztec/aztec.js';
+import { createLogger } from '@aztec/aztec.js';
 import { ArchiverApiSchema } from '@aztec/circuit-types';
 import { type NamespacedApiHandlers } from '@aztec/foundation/json-rpc/server';
 import { type DataStoreConfig, dataConfigMappings } from '@aztec/kv-store/config';
@@ -26,7 +26,7 @@ export async function startArchiver(
     'archiver',
   );
 
-  const storeLog = createDebugLogger('aztec:archiver:lmdb');
+  const storeLog = createLogger('archiver:lmdb');
   const store = await createStore('archiver', archiverConfig, storeLog);
   const archiverStore = new KVArchiverDataStore(store, archiverConfig.maxLogs);
 

--- a/yarn-project/aztec/src/cli/cmds/start_p2p_bootstrap.ts
+++ b/yarn-project/aztec/src/cli/cmds/start_p2p_bootstrap.ts
@@ -1,4 +1,4 @@
-import { type DebugLogger } from '@aztec/aztec.js';
+import { type Logger } from '@aztec/aztec.js';
 import { type LogFn } from '@aztec/foundation/log';
 import { type BootnodeConfig, bootnodeConfigMappings } from '@aztec/p2p';
 import runBootstrapNode from '@aztec/p2p-bootstrap';
@@ -9,7 +9,7 @@ import {
 
 import { extractRelevantOptions } from '../util.js';
 
-export const startP2PBootstrap = async (options: any, userLog: LogFn, debugLogger: DebugLogger) => {
+export const startP2PBootstrap = async (options: any, userLog: LogFn, debugLogger: Logger) => {
   // Start a P2P bootstrap node.
   const config = extractRelevantOptions<BootnodeConfig>(options, bootnodeConfigMappings, 'p2p');
   const telemetryClient = await createAndStartTelemetryClient(getTelemetryClientConfig());

--- a/yarn-project/aztec/src/cli/cmds/start_txe.ts
+++ b/yarn-project/aztec/src/cli/cmds/start_txe.ts
@@ -1,8 +1,8 @@
 import { startHttpRpcServer } from '@aztec/foundation/json-rpc/server';
-import { type DebugLogger } from '@aztec/foundation/log';
+import { type Logger } from '@aztec/foundation/log';
 import { createTXERpcServer } from '@aztec/txe';
 
-export async function startTXE(options: any, debugLogger: DebugLogger) {
+export async function startTXE(options: any, debugLogger: Logger) {
   debugLogger.info(`Setting up TXE...`);
 
   const txeServer = createTXERpcServer(debugLogger);

--- a/yarn-project/aztec/src/examples/token.ts
+++ b/yarn-project/aztec/src/examples/token.ts
@@ -1,9 +1,9 @@
 import { getSingleKeyAccount } from '@aztec/accounts/single_key';
 import { type AccountWallet, Fr, createPXEClient } from '@aztec/aztec.js';
-import { createDebugLogger } from '@aztec/foundation/log';
+import { createLogger } from '@aztec/foundation/log';
 import { TokenContract } from '@aztec/noir-contracts.js/Token';
 
-const logger = createDebugLogger('aztec:http-rpc-client');
+const logger = createLogger('http-rpc-client');
 
 export const alicePrivateKey = Fr.random();
 export const bobPrivateKey = Fr.random();

--- a/yarn-project/aztec/src/examples/token.ts
+++ b/yarn-project/aztec/src/examples/token.ts
@@ -3,7 +3,7 @@ import { type AccountWallet, Fr, createPXEClient } from '@aztec/aztec.js';
 import { createLogger } from '@aztec/foundation/log';
 import { TokenContract } from '@aztec/noir-contracts.js/Token';
 
-const logger = createLogger('http-rpc-client');
+const logger = createLogger('example:token');
 
 export const alicePrivateKey = Fr.random();
 export const bobPrivateKey = Fr.random();

--- a/yarn-project/aztec/src/sandbox.ts
+++ b/yarn-project/aztec/src/sandbox.ts
@@ -11,7 +11,7 @@ import {
   deployL1Contracts,
   getL1ContractsConfigEnvVars,
 } from '@aztec/ethereum';
-import { createDebugLogger } from '@aztec/foundation/log';
+import { createLogger } from '@aztec/foundation/log';
 import { getVKTreeRoot } from '@aztec/noir-protocol-circuits-types';
 import { ProtocolContractAddress, protocolContractTreeRoot } from '@aztec/protocol-contracts';
 import { type PXEServiceConfig, createPXEService, getPXEServiceConfig } from '@aztec/pxe';
@@ -27,7 +27,7 @@ import { foundry } from 'viem/chains';
 
 export const defaultMnemonic = 'test test test test test test test test test test test junk';
 
-const logger = createDebugLogger('aztec:sandbox');
+const logger = createLogger('sandbox');
 
 const localAnvil = foundry;
 

--- a/yarn-project/bb-prover/src/avm_proving.test.ts
+++ b/yarn-project/bb-prover/src/avm_proving.test.ts
@@ -90,7 +90,7 @@ describe('AVM WitGen, proof generation and verification', () => {
 async function proveAndVerifyAvmTestContract(functionName: string, calldata: Fr[] = [], expectRevert = false) {
   const avmCircuitInputs = await simulateAvmTestContractGenerateCircuitInputs(functionName, calldata, expectRevert);
 
-  const internalLogger = createLogger('avm-proving-test');
+  const internalLogger = createLogger('bb-prover:avm-proving-test');
   const logger = (msg: string, _data?: any) => internalLogger.verbose(msg);
 
   // The paths for the barretenberg binary and the write path are hardcoded for now.

--- a/yarn-project/bb-prover/src/avm_proving.test.ts
+++ b/yarn-project/bb-prover/src/avm_proving.test.ts
@@ -7,7 +7,7 @@ import {
   VerificationKeyData,
 } from '@aztec/circuits.js';
 import { Fr } from '@aztec/foundation/fields';
-import { createDebugLogger } from '@aztec/foundation/log';
+import { createLogger } from '@aztec/foundation/log';
 import { simulateAvmTestContractGenerateCircuitInputs } from '@aztec/simulator/public/fixtures';
 
 import fs from 'node:fs/promises';
@@ -90,7 +90,7 @@ describe('AVM WitGen, proof generation and verification', () => {
 async function proveAndVerifyAvmTestContract(functionName: string, calldata: Fr[] = [], expectRevert = false) {
   const avmCircuitInputs = await simulateAvmTestContractGenerateCircuitInputs(functionName, calldata, expectRevert);
 
-  const internalLogger = createDebugLogger('aztec:avm-proving-test');
+  const internalLogger = createLogger('avm-proving-test');
   const logger = (msg: string, _data?: any) => internalLogger.verbose(msg);
 
   // The paths for the barretenberg binary and the write path are hardcoded for now.

--- a/yarn-project/bb-prover/src/bb/execute.ts
+++ b/yarn-project/bb-prover/src/bb/execute.ts
@@ -1,6 +1,6 @@
 import { type AvmCircuitInputs } from '@aztec/circuits.js';
 import { sha256 } from '@aztec/foundation/crypto';
-import { type DebugLogger, type LogFn } from '@aztec/foundation/log';
+import { type LogFn, type Logger } from '@aztec/foundation/log';
 import { Timer } from '@aztec/foundation/timer';
 import { type NoirCompiledCircuit } from '@aztec/types/noir';
 
@@ -508,7 +508,7 @@ export async function generateAvmProof(
   pathToBB: string,
   workingDirectory: string,
   input: AvmCircuitInputs,
-  logger: DebugLogger,
+  logger: Logger,
 ): Promise<BBFailure | BBSuccess> {
   // Check that the working directory exists
   try {

--- a/yarn-project/bb-prover/src/prover/bb_private_kernel_prover.ts
+++ b/yarn-project/bb-prover/src/prover/bb_private_kernel_prover.ts
@@ -20,7 +20,7 @@ import {
   type VerificationKeyData,
 } from '@aztec/circuits.js';
 import { runInDirectory } from '@aztec/foundation/fs';
-import { type DebugLogger, createDebugLogger } from '@aztec/foundation/log';
+import { type Logger, createLogger } from '@aztec/foundation/log';
 import { Timer } from '@aztec/foundation/timer';
 import {
   ClientCircuitArtifacts,
@@ -79,10 +79,10 @@ export class BBNativePrivateKernelProver implements PrivateKernelProver {
     private bbBinaryPath: string,
     private bbWorkingDirectory: string,
     private skipCleanup: boolean,
-    private log = createDebugLogger('aztec:bb-native-prover'),
+    private log = createLogger('bb-native-prover'),
   ) {}
 
-  public static async new(config: BBConfig, log?: DebugLogger) {
+  public static async new(config: BBConfig, log?: Logger) {
     await fs.mkdir(config.bbWorkingDirectory, { recursive: true });
     return new BBNativePrivateKernelProver(config.bbBinaryPath, config.bbWorkingDirectory, !!config.bbSkipCleanup, log);
   }

--- a/yarn-project/bb-prover/src/prover/bb_private_kernel_prover.ts
+++ b/yarn-project/bb-prover/src/prover/bb_private_kernel_prover.ts
@@ -79,7 +79,7 @@ export class BBNativePrivateKernelProver implements PrivateKernelProver {
     private bbBinaryPath: string,
     private bbWorkingDirectory: string,
     private skipCleanup: boolean,
-    private log = createLogger('bb-native-prover'),
+    private log = createLogger('bb-prover:native'),
   ) {}
 
   public static async new(config: BBConfig, log?: Logger) {

--- a/yarn-project/bb-prover/src/prover/bb_prover.ts
+++ b/yarn-project/bb-prover/src/prover/bb_prover.ts
@@ -42,7 +42,7 @@ import {
   makeRecursiveProofFromBinary,
 } from '@aztec/circuits.js';
 import { runInDirectory } from '@aztec/foundation/fs';
-import { createDebugLogger } from '@aztec/foundation/log';
+import { createLogger } from '@aztec/foundation/log';
 import { BufferReader } from '@aztec/foundation/serialize';
 import { Timer } from '@aztec/foundation/timer';
 import {
@@ -100,7 +100,7 @@ import { ProverInstrumentation } from '../instrumentation.js';
 import { mapProtocolArtifactNameToCircuitName } from '../stats.js';
 import { extractAvmVkData, extractVkData } from '../verification_key/verification_key_data.js';
 
-const logger = createDebugLogger('aztec:bb-prover');
+const logger = createLogger('bb-prover');
 
 // All `ServerCircuitArtifact` are recursive.
 const SERVER_CIRCUIT_RECURSIVE = true;

--- a/yarn-project/bb-prover/src/test/test_circuit_prover.ts
+++ b/yarn-project/bb-prover/src/test/test_circuit_prover.ts
@@ -78,7 +78,7 @@ import { mapProtocolArtifactNameToCircuitName } from '../stats.js';
 export class TestCircuitProver implements ServerCircuitProver {
   private wasmSimulator = new WASMSimulator();
   private instrumentation: ProverInstrumentation;
-  private logger = createLogger('test-prover');
+  private logger = createLogger('bb-prover:test-prover');
 
   constructor(
     telemetry: TelemetryClient,

--- a/yarn-project/bb-prover/src/test/test_circuit_prover.ts
+++ b/yarn-project/bb-prover/src/test/test_circuit_prover.ts
@@ -35,7 +35,7 @@ import {
   makeEmptyRecursiveProof,
   makeRecursiveProof,
 } from '@aztec/circuits.js';
-import { createDebugLogger } from '@aztec/foundation/log';
+import { createLogger } from '@aztec/foundation/log';
 import { sleep } from '@aztec/foundation/sleep';
 import { Timer } from '@aztec/foundation/timer';
 import {
@@ -78,7 +78,7 @@ import { mapProtocolArtifactNameToCircuitName } from '../stats.js';
 export class TestCircuitProver implements ServerCircuitProver {
   private wasmSimulator = new WASMSimulator();
   private instrumentation: ProverInstrumentation;
-  private logger = createDebugLogger('aztec:test-prover');
+  private logger = createLogger('test-prover');
 
   constructor(
     telemetry: TelemetryClient,

--- a/yarn-project/bb-prover/src/verifier/bb_verifier.ts
+++ b/yarn-project/bb-prover/src/verifier/bb_verifier.ts
@@ -36,7 +36,7 @@ export class BBCircuitVerifier implements ClientProtocolCircuitVerifier {
   public static async new(
     config: BBConfig,
     initialCircuits: ProtocolArtifact[] = [],
-    logger = createLogger('bb-verifier'),
+    logger = createLogger('bb-prover:verifier'),
   ) {
     await fs.mkdir(config.bbWorkingDirectory, { recursive: true });
     const keys = new Map<ProtocolArtifact, Promise<VerificationKeyData>>();

--- a/yarn-project/bb-prover/src/verifier/bb_verifier.ts
+++ b/yarn-project/bb-prover/src/verifier/bb_verifier.ts
@@ -2,7 +2,7 @@ import { type ClientProtocolCircuitVerifier, Tx } from '@aztec/circuit-types';
 import { type CircuitVerificationStats } from '@aztec/circuit-types/stats';
 import { type Proof, type VerificationKeyData } from '@aztec/circuits.js';
 import { runInDirectory } from '@aztec/foundation/fs';
-import { type DebugLogger, type LogFn, createDebugLogger } from '@aztec/foundation/log';
+import { type LogFn, type Logger, createLogger } from '@aztec/foundation/log';
 import {
   type ClientProtocolArtifact,
   type ProtocolArtifact,
@@ -30,13 +30,13 @@ export class BBCircuitVerifier implements ClientProtocolCircuitVerifier {
   private constructor(
     private config: BBConfig,
     private verificationKeys = new Map<ProtocolArtifact, Promise<VerificationKeyData>>(),
-    private logger: DebugLogger,
+    private logger: Logger,
   ) {}
 
   public static async new(
     config: BBConfig,
     initialCircuits: ProtocolArtifact[] = [],
-    logger = createDebugLogger('aztec:bb-verifier'),
+    logger = createLogger('bb-verifier'),
   ) {
     await fs.mkdir(config.bbWorkingDirectory, { recursive: true });
     const keys = new Map<ProtocolArtifact, Promise<VerificationKeyData>>();

--- a/yarn-project/bot/src/bot.ts
+++ b/yarn-project/bot/src/bot.ts
@@ -5,7 +5,7 @@ import {
   NoFeePaymentMethod,
   type SendMethodOptions,
   type Wallet,
-  createDebugLogger,
+  createLogger,
 } from '@aztec/aztec.js';
 import { type AztecNode, type FunctionCall, type PXE } from '@aztec/circuit-types';
 import { Gas } from '@aztec/circuits.js';
@@ -19,7 +19,7 @@ import { getBalances, getPrivateBalance, isStandardTokenContract } from './utils
 const TRANSFER_AMOUNT = 1;
 
 export class Bot {
-  private log = createDebugLogger('aztec:bot');
+  private log = createLogger('bot');
 
   private attempts: number = 0;
   private successes: number = 0;

--- a/yarn-project/bot/src/factory.ts
+++ b/yarn-project/bot/src/factory.ts
@@ -4,7 +4,7 @@ import {
   BatchCall,
   type DeployMethod,
   type DeployOptions,
-  createDebugLogger,
+  createLogger,
   createPXEClient,
   retryUntil,
 } from '@aztec/aztec.js';
@@ -22,7 +22,7 @@ const MIN_BALANCE = 1e3;
 export class BotFactory {
   private pxe: PXE;
   private node?: AztecNode;
-  private log = createDebugLogger('aztec:bot');
+  private log = createLogger('bot');
 
   constructor(private readonly config: BotConfig, dependencies: { pxe?: PXE; node?: AztecNode } = {}) {
     if (config.flushSetupTransactions && !dependencies.node) {

--- a/yarn-project/bot/src/runner.ts
+++ b/yarn-project/bot/src/runner.ts
@@ -1,4 +1,4 @@
-import { type AztecNode, type PXE, createAztecNodeClient, createDebugLogger } from '@aztec/aztec.js';
+import { type AztecNode, type PXE, createAztecNodeClient, createLogger } from '@aztec/aztec.js';
 import { RunningPromise } from '@aztec/foundation/running-promise';
 
 import { Bot } from './bot.js';
@@ -6,7 +6,7 @@ import { type BotConfig } from './config.js';
 import { type BotRunnerApi } from './interface.js';
 
 export class BotRunner implements BotRunnerApi {
-  private log = createDebugLogger('aztec:bot');
+  private log = createLogger('bot');
   private bot?: Promise<Bot>;
   private pxe?: PXE;
   private node: AztecNode;

--- a/yarn-project/circuit-types/src/interfaces/merkle_tree_operations.ts
+++ b/yarn-project/circuit-types/src/interfaces/merkle_tree_operations.ts
@@ -263,7 +263,7 @@ export interface MerkleTreeWriteOperations extends MerkleTreeReadOperations {
 export async function inspectTree(
   db: MerkleTreeReadOperations,
   treeId: MerkleTreeId,
-  log = createLogger('inspect-tree'),
+  log = createLogger('types:inspect-tree'),
 ) {
   const info = await db.getTreeInfo(treeId);
   const output = [`Tree id=${treeId} size=${info.size} root=0x${info.root.toString('hex')}`];

--- a/yarn-project/circuit-types/src/interfaces/merkle_tree_operations.ts
+++ b/yarn-project/circuit-types/src/interfaces/merkle_tree_operations.ts
@@ -5,7 +5,7 @@ import {
   type PublicDataTreeLeaf,
   type StateReference,
 } from '@aztec/circuits.js';
-import { createDebugLogger } from '@aztec/foundation/log';
+import { createLogger } from '@aztec/foundation/log';
 import { type IndexedTreeLeafPreimage } from '@aztec/foundation/trees';
 
 import { type MerkleTreeId } from '../merkle_tree_id.js';
@@ -263,7 +263,7 @@ export interface MerkleTreeWriteOperations extends MerkleTreeReadOperations {
 export async function inspectTree(
   db: MerkleTreeReadOperations,
   treeId: MerkleTreeId,
-  log = createDebugLogger('aztec:inspect-tree'),
+  log = createLogger('inspect-tree'),
 ) {
   const info = await db.getTreeInfo(treeId);
   const output = [`Tree id=${treeId} size=${info.size} root=0x${info.root.toString('hex')}`];

--- a/yarn-project/circuit-types/src/interfaces/service.ts
+++ b/yarn-project/circuit-types/src/interfaces/service.ts
@@ -1,4 +1,4 @@
-import { type DebugLogger } from '@aztec/foundation/log';
+import { type Logger } from '@aztec/foundation/log';
 import { type Maybe } from '@aztec/foundation/types';
 
 /** Represents a local service that can be started and stopped. */
@@ -14,7 +14,7 @@ export interface Service {
 }
 
 /** Tries to call stop on a given object and awaits it. Logs any errors and does not rethrow. */
-export async function tryStop(service: Maybe<Service>, logger?: DebugLogger): Promise<void> {
+export async function tryStop(service: Maybe<Service>, logger?: Logger): Promise<void> {
   try {
     return typeof service === 'object' && service && 'stop' in service && typeof service.stop === 'function'
       ? await service.stop()

--- a/yarn-project/circuit-types/src/l2_block_downloader/l2_block_downloader.ts
+++ b/yarn-project/circuit-types/src/l2_block_downloader/l2_block_downloader.ts
@@ -1,12 +1,12 @@
 import { INITIAL_L2_BLOCK_NUM } from '@aztec/circuits.js/constants';
-import { createDebugLogger } from '@aztec/foundation/log';
+import { createLogger } from '@aztec/foundation/log';
 import { FifoMemoryQueue, Semaphore, SerialQueue } from '@aztec/foundation/queue';
 import { InterruptibleSleep } from '@aztec/foundation/sleep';
 
 import { type L2Block } from '../l2_block.js';
 import { type L2BlockSource } from '../l2_block_source.js';
 
-const log = createDebugLogger('aztec:l2_block_downloader');
+const log = createLogger('l2_block_downloader');
 
 /**
  * Downloads L2 blocks from a L2BlockSource.

--- a/yarn-project/circuit-types/src/l2_block_downloader/l2_block_downloader.ts
+++ b/yarn-project/circuit-types/src/l2_block_downloader/l2_block_downloader.ts
@@ -6,7 +6,7 @@ import { InterruptibleSleep } from '@aztec/foundation/sleep';
 import { type L2Block } from '../l2_block.js';
 import { type L2BlockSource } from '../l2_block_source.js';
 
-const log = createLogger('l2_block_downloader');
+const log = createLogger('types:l2_block_downloader');
 
 /**
  * Downloads L2 blocks from a L2BlockSource.

--- a/yarn-project/circuit-types/src/l2_block_downloader/l2_block_stream.ts
+++ b/yarn-project/circuit-types/src/l2_block_downloader/l2_block_stream.ts
@@ -1,5 +1,5 @@
 import { AbortError } from '@aztec/foundation/error';
-import { createDebugLogger } from '@aztec/foundation/log';
+import { createLogger } from '@aztec/foundation/log';
 import { RunningPromise } from '@aztec/foundation/running-promise';
 
 import { type L2Block } from '../l2_block.js';
@@ -9,7 +9,7 @@ import { type L2BlockId, type L2BlockSource, type L2Tips } from '../l2_block_sou
 export class L2BlockStream {
   private readonly runningPromise: RunningPromise;
 
-  private readonly log = createDebugLogger('aztec:l2_block_stream');
+  private readonly log = createLogger('l2_block_stream');
 
   constructor(
     private l2BlockSource: Pick<L2BlockSource, 'getBlocks' | 'getBlockHeader' | 'getL2Tips'>,

--- a/yarn-project/circuit-types/src/l2_block_downloader/l2_block_stream.ts
+++ b/yarn-project/circuit-types/src/l2_block_downloader/l2_block_stream.ts
@@ -9,7 +9,7 @@ import { type L2BlockId, type L2BlockSource, type L2Tips } from '../l2_block_sou
 export class L2BlockStream {
   private readonly runningPromise: RunningPromise;
 
-  private readonly log = createLogger('l2_block_stream');
+  private readonly log = createLogger('types:l2_block_stream');
 
   constructor(
     private l2BlockSource: Pick<L2BlockSource, 'getBlocks' | 'getBlockHeader' | 'getL2Tips'>,

--- a/yarn-project/circuits.js/src/barretenberg/crypto/grumpkin/index.test.ts
+++ b/yarn-project/circuits.js/src/barretenberg/crypto/grumpkin/index.test.ts
@@ -1,9 +1,9 @@
-import { createDebugLogger } from '@aztec/foundation/log';
+import { createLogger } from '@aztec/foundation/log';
 
 import { GrumpkinScalar, type Point } from '../../../index.js';
 import { Grumpkin } from './index.js';
 
-const log = createDebugLogger('bb:grumpkin_test');
+const log = createLogger('bb:grumpkin_test');
 
 describe('grumpkin', () => {
   let grumpkin!: Grumpkin;

--- a/yarn-project/circuits.js/src/barretenberg/crypto/grumpkin/index.test.ts
+++ b/yarn-project/circuits.js/src/barretenberg/crypto/grumpkin/index.test.ts
@@ -3,7 +3,7 @@ import { createLogger } from '@aztec/foundation/log';
 import { GrumpkinScalar, type Point } from '../../../index.js';
 import { Grumpkin } from './index.js';
 
-const log = createLogger('bb:grumpkin_test');
+const log = createLogger('circuits:grumpkin_test');
 
 describe('grumpkin', () => {
   let grumpkin!: Grumpkin;

--- a/yarn-project/circuits.js/src/contract/artifact_hash.ts
+++ b/yarn-project/circuits.js/src/contract/artifact_hash.ts
@@ -1,7 +1,7 @@
 import { type ContractArtifact, type FunctionArtifact, FunctionSelector, FunctionType } from '@aztec/foundation/abi';
 import { sha256 } from '@aztec/foundation/crypto';
 import { Fr, reduceFn } from '@aztec/foundation/fields';
-import { createDebugLogger } from '@aztec/foundation/log';
+import { createLogger } from '@aztec/foundation/log';
 import { numToUInt8 } from '@aztec/foundation/serialize';
 
 import { type MerkleTree } from '../merkle/merkle_tree.js';
@@ -103,7 +103,7 @@ export function computeFunctionMetadataHash(fn: FunctionArtifact) {
 }
 
 function getLogger() {
-  return createDebugLogger('aztec:circuits:artifact_hash');
+  return createLogger('circuits:artifact_hash');
 }
 
 export function getArtifactMerkleTreeHasher() {

--- a/yarn-project/circuits.js/src/contract/private_function_membership_proof.ts
+++ b/yarn-project/circuits.js/src/contract/private_function_membership_proof.ts
@@ -1,7 +1,7 @@
 import { type ContractArtifact, type FunctionSelector, FunctionType } from '@aztec/foundation/abi';
 import { poseidon2Hash } from '@aztec/foundation/crypto';
 import { Fr } from '@aztec/foundation/fields';
-import { createDebugLogger } from '@aztec/foundation/log';
+import { createLogger } from '@aztec/foundation/log';
 
 import { computeRootFromSiblingPath } from '../merkle/index.js';
 import {
@@ -29,7 +29,7 @@ export function createPrivateFunctionMembershipProof(
   selector: FunctionSelector,
   artifact: ContractArtifact,
 ): PrivateFunctionMembershipProof {
-  const log = createDebugLogger('aztec:circuits:function_membership_proof');
+  const log = createLogger('circuits:function_membership_proof');
 
   // Locate private function definition and artifact
   const privateFunctions = artifact.functions
@@ -107,7 +107,7 @@ export function isValidPrivateFunctionMembershipProof(
   fn: ExecutablePrivateFunctionWithMembershipProof,
   contractClass: Pick<ContractClassPublic, 'privateFunctionsRoot' | 'artifactHash'>,
 ) {
-  const log = createDebugLogger('aztec:circuits:function_membership_proof');
+  const log = createLogger('circuits:function_membership_proof');
 
   // Check private function tree membership
   const functionLeaf = computePrivateFunctionLeaf(fn);

--- a/yarn-project/circuits.js/src/contract/unconstrained_function_membership_proof.ts
+++ b/yarn-project/circuits.js/src/contract/unconstrained_function_membership_proof.ts
@@ -1,6 +1,6 @@
 import { type ContractArtifact, type FunctionSelector, FunctionType } from '@aztec/foundation/abi';
 import { Fr } from '@aztec/foundation/fields';
-import { createDebugLogger } from '@aztec/foundation/log';
+import { createLogger } from '@aztec/foundation/log';
 
 import { computeRootFromSiblingPath } from '../merkle/index.js';
 import {
@@ -26,7 +26,7 @@ export function createUnconstrainedFunctionMembershipProof(
   selector: FunctionSelector,
   artifact: ContractArtifact,
 ): UnconstrainedFunctionMembershipProof {
-  const log = createDebugLogger('aztec:circuits:function_membership_proof');
+  const log = createLogger('circuits:function_membership_proof');
 
   // Locate function artifact
   const fn = artifact.functions.find(fn => selector.equals(fn));
@@ -85,7 +85,7 @@ export function isValidUnconstrainedFunctionMembershipProof(
   fn: UnconstrainedFunctionWithMembershipProof,
   contractClass: Pick<ContractClassPublic, 'artifactHash'>,
 ) {
-  const log = createDebugLogger('aztec:circuits:function_membership_proof');
+  const log = createLogger('circuits:function_membership_proof');
 
   const functionArtifactHash = computeFunctionArtifactHash(fn);
   const computedArtifactFunctionTreeRoot = Fr.fromBuffer(

--- a/yarn-project/cli-wallet/src/bin/index.ts
+++ b/yarn-project/cli-wallet/src/bin/index.ts
@@ -1,6 +1,6 @@
 import { Fr, computeSecretHash, fileURLToPath } from '@aztec/aztec.js';
 import { LOCALHOST } from '@aztec/cli/cli-utils';
-import { type LogFn, createConsoleLogger, createDebugLogger } from '@aztec/foundation/log';
+import { type LogFn, createConsoleLogger, createLogger } from '@aztec/foundation/log';
 import { AztecLmdbStore } from '@aztec/kv-store/lmdb';
 import { type PXEService } from '@aztec/pxe';
 
@@ -14,7 +14,7 @@ import { createAliasOption } from '../utils/options/index.js';
 import { PXEWrapper } from '../utils/pxe_wrapper.js';
 
 const userLog = createConsoleLogger();
-const debugLogger = createDebugLogger('aztec:wallet');
+const debugLogger = createLogger('wallet');
 
 const { WALLET_DATA_DIRECTORY } = process.env;
 

--- a/yarn-project/cli-wallet/src/cmds/bridge_fee_juice.ts
+++ b/yarn-project/cli-wallet/src/cmds/bridge_fee_juice.ts
@@ -3,7 +3,7 @@ import { prettyPrintJSON } from '@aztec/cli/utils';
 import { createEthereumChain, createL1Clients } from '@aztec/ethereum';
 import { type AztecAddress } from '@aztec/foundation/aztec-address';
 import { Fr } from '@aztec/foundation/fields';
-import { type DebugLogger, type LogFn } from '@aztec/foundation/log';
+import { type LogFn, type Logger } from '@aztec/foundation/log';
 
 export async function bridgeL1FeeJuice(
   amount: bigint,
@@ -18,7 +18,7 @@ export async function bridgeL1FeeJuice(
   wait: boolean,
   interval = 60_000,
   log: LogFn,
-  debugLogger: DebugLogger,
+  debugLogger: Logger,
 ) {
   // Prepare L1 client
   const chain = createEthereumChain(l1RpcUrl, chainId);

--- a/yarn-project/cli-wallet/src/cmds/create_account.ts
+++ b/yarn-project/cli-wallet/src/cmds/create_account.ts
@@ -1,7 +1,7 @@
 import { type DeployAccountOptions, type PXE } from '@aztec/aztec.js';
 import { prettyPrintJSON } from '@aztec/cli/cli-utils';
 import { Fr } from '@aztec/foundation/fields';
-import { type DebugLogger, type LogFn } from '@aztec/foundation/log';
+import { type LogFn, type Logger } from '@aztec/foundation/log';
 
 import { type AccountType, createOrRetrieveAccount } from '../utils/accounts.js';
 import { type IFeeOpts, printGasEstimates } from '../utils/options/fees.js';
@@ -18,7 +18,7 @@ export async function createAccount(
   wait: boolean,
   feeOpts: IFeeOpts,
   json: boolean,
-  debugLogger: DebugLogger,
+  debugLogger: Logger,
   log: LogFn,
 ) {
   secretKey ??= Fr.random();

--- a/yarn-project/cli-wallet/src/cmds/deploy.ts
+++ b/yarn-project/cli-wallet/src/cmds/deploy.ts
@@ -2,7 +2,7 @@ import { type AccountWalletWithSecretKey, ContractDeployer, type DeployMethod, F
 import { PublicKeys } from '@aztec/circuits.js';
 import { GITHUB_TAG_PREFIX, encodeArgs, getContractArtifact } from '@aztec/cli/utils';
 import { getInitializer } from '@aztec/foundation/abi';
-import { type DebugLogger, type LogFn } from '@aztec/foundation/log';
+import { type LogFn, type Logger } from '@aztec/foundation/log';
 
 import { type IFeeOpts, printGasEstimates } from '../utils/options/fees.js';
 
@@ -21,7 +21,7 @@ export async function deploy(
   universalDeploy: boolean | undefined,
   wait: boolean,
   feeOpts: IFeeOpts,
-  debugLogger: DebugLogger,
+  debugLogger: Logger,
   log: LogFn,
   logJson: (output: any) => void,
 ) {

--- a/yarn-project/cli-wallet/src/cmds/deploy_account.ts
+++ b/yarn-project/cli-wallet/src/cmds/deploy_account.ts
@@ -1,6 +1,6 @@
 import { type AccountManager, type DeployAccountOptions } from '@aztec/aztec.js';
 import { prettyPrintJSON } from '@aztec/cli/cli-utils';
-import { type DebugLogger, type LogFn } from '@aztec/foundation/log';
+import { type LogFn, type Logger } from '@aztec/foundation/log';
 
 import { type IFeeOpts, printGasEstimates } from '../utils/options/fees.js';
 
@@ -9,7 +9,7 @@ export async function deployAccount(
   wait: boolean,
   feeOpts: IFeeOpts,
   json: boolean,
-  debugLogger: DebugLogger,
+  debugLogger: Logger,
   log: LogFn,
 ) {
   const out: Record<string, any> = {};

--- a/yarn-project/cli-wallet/src/cmds/index.ts
+++ b/yarn-project/cli-wallet/src/cmds/index.ts
@@ -13,7 +13,7 @@ import {
   parsePublicKey,
   pxeOption,
 } from '@aztec/cli/utils';
-import { type DebugLogger, type LogFn } from '@aztec/foundation/log';
+import { type LogFn, type Logger } from '@aztec/foundation/log';
 
 import { type Command, Option } from 'commander';
 import inquirer from 'inquirer';
@@ -44,7 +44,7 @@ import { type PXEWrapper } from '../utils/pxe_wrapper.js';
 export function injectCommands(
   program: Command,
   log: LogFn,
-  debugLogger: DebugLogger,
+  debugLogger: Logger,
   db?: WalletDB,
   pxeWrapper?: PXEWrapper,
 ) {

--- a/yarn-project/cli/src/cmds/contracts/index.ts
+++ b/yarn-project/cli/src/cmds/contracts/index.ts
@@ -1,8 +1,8 @@
-import { type DebugLogger, type LogFn } from '@aztec/foundation/log';
+import { type LogFn, type Logger } from '@aztec/foundation/log';
 
 import { type Command } from 'commander';
 
-export function injectCommands(program: Command, log: LogFn, debugLogger: DebugLogger) {
+export function injectCommands(program: Command, log: LogFn, debugLogger: Logger) {
   program
     .command('inspect-contract')
     .description('Shows list of external callable functions for a contract')

--- a/yarn-project/cli/src/cmds/contracts/inspect_contract.ts
+++ b/yarn-project/cli/src/cmds/contracts/inspect_contract.ts
@@ -6,11 +6,11 @@ import {
   decodeFunctionSignatureWithParameterNames,
 } from '@aztec/foundation/abi';
 import { sha256 } from '@aztec/foundation/crypto';
-import { type DebugLogger, type LogFn } from '@aztec/foundation/log';
+import { type LogFn, type Logger } from '@aztec/foundation/log';
 
 import { getContractArtifact } from '../../utils/aztec.js';
 
-export async function inspectContract(contractArtifactFile: string, debugLogger: DebugLogger, log: LogFn) {
+export async function inspectContract(contractArtifactFile: string, debugLogger: Logger, log: LogFn) {
   const contractArtifact = await getContractArtifact(contractArtifactFile, log);
   const contractFns = contractArtifact.functions.filter(f => f.name !== 'compute_note_hash_and_optionally_a_nullifier');
   if (contractFns.length === 0) {

--- a/yarn-project/cli/src/cmds/devnet/bootstrap_network.ts
+++ b/yarn-project/cli/src/cmds/devnet/bootstrap_network.ts
@@ -9,7 +9,7 @@ import {
   createL1Clients,
   deployL1Contract,
 } from '@aztec/ethereum';
-import { type DebugLogger, type LogFn } from '@aztec/foundation/log';
+import { type LogFn, type Logger } from '@aztec/foundation/log';
 
 import { getContract } from 'viem';
 import { privateKeyToAccount } from 'viem/accounts';
@@ -34,7 +34,7 @@ export async function bootstrapNetwork(
   l1Mnemonic: string,
   json: boolean,
   log: LogFn,
-  debugLog: DebugLogger,
+  debugLog: Logger,
 ) {
   const pxe = await createCompatibleClient(pxeUrl, debugLog);
 
@@ -249,7 +249,7 @@ async function fundFPC(
   wallet: Wallet,
   l1Clients: L1Clients,
   fpcAddress: AztecAddress,
-  debugLog: DebugLogger,
+  debugLog: Logger,
 ) {
   // eslint-disable-next-line @typescript-eslint/ban-ts-comment
   // @ts-ignore - Importing noir-contracts.js even in devDeps results in a circular dependency error. Need to ignore because this line doesn't cause an error in a dev environment

--- a/yarn-project/cli/src/cmds/devnet/index.ts
+++ b/yarn-project/cli/src/cmds/devnet/index.ts
@@ -1,10 +1,10 @@
-import { type DebugLogger, type LogFn } from '@aztec/foundation/log';
+import { type LogFn, type Logger } from '@aztec/foundation/log';
 
 import { type Command } from 'commander';
 
 import { ETHEREUM_HOST, l1ChainIdOption, parseEthereumAddress, pxeOption } from '../../utils/commands.js';
 
-export function injectCommands(program: Command, log: LogFn, debugLogger: DebugLogger) {
+export function injectCommands(program: Command, log: LogFn, debugLogger: Logger) {
   program
     .command('bootstrap-network')
     .description('Bootstrap a new network')

--- a/yarn-project/cli/src/cmds/infrastructure/index.ts
+++ b/yarn-project/cli/src/cmds/infrastructure/index.ts
@@ -1,10 +1,10 @@
-import { type DebugLogger, type LogFn } from '@aztec/foundation/log';
+import { type LogFn, type Logger } from '@aztec/foundation/log';
 
 import { type Command } from 'commander';
 
 import { ETHEREUM_HOST, l1ChainIdOption, parseOptionalInteger, pxeOption } from '../../utils/commands.js';
 
-export function injectCommands(program: Command, log: LogFn, debugLogger: DebugLogger) {
+export function injectCommands(program: Command, log: LogFn, debugLogger: Logger) {
   program
     .command('setup-protocol-contracts')
     .description('Bootstrap the blockchain by initializing all the protocol contracts')

--- a/yarn-project/cli/src/cmds/infrastructure/sequencers.ts
+++ b/yarn-project/cli/src/cmds/infrastructure/sequencers.ts
@@ -1,6 +1,6 @@
 import { createCompatibleClient } from '@aztec/aztec.js';
 import { MINIMUM_STAKE, createEthereumChain } from '@aztec/ethereum';
-import { type DebugLogger, type LogFn } from '@aztec/foundation/log';
+import { type LogFn, type Logger } from '@aztec/foundation/log';
 import { RollupAbi, TestERC20Abi } from '@aztec/l1-artifacts';
 
 import { createPublicClient, createWalletClient, getContract, http } from 'viem';
@@ -15,7 +15,7 @@ export async function sequencers(opts: {
   chainId: number;
   blockNumber?: number;
   log: LogFn;
-  debugLogger: DebugLogger;
+  debugLogger: Logger;
 }) {
   const { command, who: maybeWho, mnemonic, rpcUrl, l1RpcUrl, chainId, log, debugLogger } = opts;
   const client = await createCompatibleClient(rpcUrl, debugLogger);

--- a/yarn-project/cli/src/cmds/l1/bridge_erc20.ts
+++ b/yarn-project/cli/src/cmds/l1/bridge_erc20.ts
@@ -1,7 +1,7 @@
 import { L1ToL2TokenPortalManager } from '@aztec/aztec.js';
 import { type AztecAddress, type EthAddress, type Fr } from '@aztec/circuits.js';
 import { createEthereumChain, createL1Clients } from '@aztec/ethereum';
-import { type DebugLogger, type LogFn } from '@aztec/foundation/log';
+import { type LogFn, type Logger } from '@aztec/foundation/log';
 
 import { prettyPrintJSON } from '../../utils/commands.js';
 
@@ -18,7 +18,7 @@ export async function bridgeERC20(
   mint: boolean,
   json: boolean,
   log: LogFn,
-  debugLogger: DebugLogger,
+  debugLogger: Logger,
 ) {
   // Prepare L1 client
   const chain = createEthereumChain(l1RpcUrl, chainId);

--- a/yarn-project/cli/src/cmds/l1/deploy_l1_contracts.ts
+++ b/yarn-project/cli/src/cmds/l1/deploy_l1_contracts.ts
@@ -1,6 +1,6 @@
 import { getL1ContractsConfigEnvVars } from '@aztec/ethereum';
 import { type EthAddress } from '@aztec/foundation/eth-address';
-import { type DebugLogger, type LogFn } from '@aztec/foundation/log';
+import { type LogFn, type Logger } from '@aztec/foundation/log';
 
 import { deployAztecContracts } from '../../utils/aztec.js';
 
@@ -13,7 +13,7 @@ export async function deployL1Contracts(
   json: boolean,
   initialValidators: EthAddress[],
   log: LogFn,
-  debugLogger: DebugLogger,
+  debugLogger: Logger,
 ) {
   const config = getL1ContractsConfigEnvVars();
 

--- a/yarn-project/cli/src/cmds/l1/deploy_l1_verifier.ts
+++ b/yarn-project/cli/src/cmds/l1/deploy_l1_verifier.ts
@@ -1,6 +1,6 @@
 import { createCompatibleClient } from '@aztec/aztec.js';
 import { compileContract, createEthereumChain, createL1Clients, deployL1Contract } from '@aztec/ethereum';
-import { type DebugLogger, type LogFn } from '@aztec/foundation/log';
+import { type LogFn, type Logger } from '@aztec/foundation/log';
 
 import { InvalidOptionArgumentError } from 'commander';
 // @ts-expect-error solc-js doesn't publish its types https://github.com/ethereum/solc-js/issues/689
@@ -17,7 +17,7 @@ export async function deployUltraHonkVerifier(
   bbBinaryPath: string,
   bbWorkingDirectory: string,
   log: LogFn,
-  debugLogger: DebugLogger,
+  debugLogger: Logger,
 ) {
   if (!bbBinaryPath || !bbWorkingDirectory) {
     throw new InvalidOptionArgumentError('Missing path to bb binary and working directory');
@@ -79,7 +79,7 @@ export async function deployMockVerifier(
   mnemonic: string,
   pxeRpcUrl: string,
   log: LogFn,
-  debugLogger: DebugLogger,
+  debugLogger: Logger,
 ) {
   const { publicClient, walletClient } = createL1Clients(
     ethRpcUrl,

--- a/yarn-project/cli/src/cmds/l1/index.ts
+++ b/yarn-project/cli/src/cmds/l1/index.ts
@@ -1,5 +1,5 @@
 import { EthAddress } from '@aztec/foundation/eth-address';
-import { type DebugLogger, type LogFn } from '@aztec/foundation/log';
+import { type LogFn, type Logger } from '@aztec/foundation/log';
 
 import { type Command, Option } from 'commander';
 
@@ -14,7 +14,7 @@ import {
   pxeOption,
 } from '../../utils/commands.js';
 
-export function injectCommands(program: Command, log: LogFn, debugLogger: DebugLogger) {
+export function injectCommands(program: Command, log: LogFn, debugLogger: Logger) {
   const { BB_BINARY_PATH, BB_WORKING_DIRECTORY } = process.env;
 
   program

--- a/yarn-project/cli/src/cmds/l1/prover_stats.ts
+++ b/yarn-project/cli/src/cmds/l1/prover_stats.ts
@@ -3,7 +3,7 @@ import { createAztecNodeClient } from '@aztec/circuit-types';
 import { EthAddress } from '@aztec/circuits.js';
 import { createEthereumChain } from '@aztec/ethereum';
 import { compactArray, mapValues, unique } from '@aztec/foundation/collection';
-import { type LogFn, type Logger, createDebugLogger } from '@aztec/foundation/log';
+import { type LogFn, type Logger, createLogger } from '@aztec/foundation/log';
 import { RollupAbi } from '@aztec/l1-artifacts';
 
 import chunk from 'lodash.chunk';
@@ -22,7 +22,7 @@ export async function proverStats(opts: {
   provingTimeout: bigint | undefined;
   rawLogs: boolean;
 }) {
-  const debugLog = createDebugLogger('aztec:cli:prover_stats');
+  const debugLog = createLogger('cli:prover_stats');
   const { startBlock, chainId, l1RpcUrl, l1RollupAddress, batchSize, nodeUrl, provingTimeout, endBlock, rawLogs, log } =
     opts;
   if (!l1RollupAddress && !nodeUrl) {

--- a/yarn-project/cli/src/cmds/l1/update_l1_validators.ts
+++ b/yarn-project/cli/src/cmds/l1/update_l1_validators.ts
@@ -1,7 +1,7 @@
 import { EthCheatCodes } from '@aztec/aztec.js';
 import { type EthAddress } from '@aztec/circuits.js';
 import { MINIMUM_STAKE, createEthereumChain, getL1ContractsConfigEnvVars, isAnvilTestChain } from '@aztec/ethereum';
-import { type DebugLogger, type LogFn } from '@aztec/foundation/log';
+import { type LogFn, type Logger } from '@aztec/foundation/log';
 import { RollupAbi, TestERC20Abi } from '@aztec/l1-artifacts';
 
 import { createPublicClient, createWalletClient, getContract, http } from 'viem';
@@ -17,7 +17,7 @@ export interface RollupCommandArgs {
 
 export interface LoggerArgs {
   log: LogFn;
-  debugLogger: DebugLogger;
+  debugLogger: Logger;
 }
 
 export function generateL1Account() {
@@ -198,7 +198,7 @@ export async function debugRollup({ rpcUrl, chainId, rollupAddress, log }: Rollu
   log(`Proposer NOW: ${proposer.toString()}`);
 }
 
-function makeDualLog(log: LogFn, debugLogger: DebugLogger) {
+function makeDualLog(log: LogFn, debugLogger: Logger) {
   return (msg: string) => {
     log(msg);
     debugLogger.info(msg);

--- a/yarn-project/cli/src/cmds/pxe/add_contract.ts
+++ b/yarn-project/cli/src/cmds/pxe/add_contract.ts
@@ -2,7 +2,7 @@ import { AztecAddress, type ContractInstanceWithAddress, type Fr, getContractCla
 import { createCompatibleClient } from '@aztec/aztec.js';
 import { PublicKeys } from '@aztec/circuits.js';
 import { computeContractAddressFromInstance } from '@aztec/circuits.js/contract';
-import { type DebugLogger, type LogFn } from '@aztec/foundation/log';
+import { type LogFn, type Logger } from '@aztec/foundation/log';
 
 import { getContractArtifact } from '../../utils/aztec.js';
 
@@ -14,7 +14,7 @@ export async function addContract(
   salt: Fr,
   publicKeys: PublicKeys,
   deployer: AztecAddress | undefined,
-  debugLogger: DebugLogger,
+  debugLogger: Logger,
   log: LogFn,
 ) {
   const artifact = await getContractArtifact(contractArtifactPath, log);

--- a/yarn-project/cli/src/cmds/pxe/block_number.ts
+++ b/yarn-project/cli/src/cmds/pxe/block_number.ts
@@ -1,7 +1,7 @@
 import { createCompatibleClient } from '@aztec/aztec.js';
-import { type DebugLogger, type LogFn } from '@aztec/foundation/log';
+import { type LogFn, type Logger } from '@aztec/foundation/log';
 
-export async function blockNumber(rpcUrl: string, debugLogger: DebugLogger, log: LogFn) {
+export async function blockNumber(rpcUrl: string, debugLogger: Logger, log: LogFn) {
   const client = await createCompatibleClient(rpcUrl, debugLogger);
   const [latestNum, provenNum] = await Promise.all([client.getBlockNumber(), client.getProvenBlockNumber()]);
   log(`Latest block: ${latestNum}`);

--- a/yarn-project/cli/src/cmds/pxe/get_account.ts
+++ b/yarn-project/cli/src/cmds/pxe/get_account.ts
@@ -1,8 +1,8 @@
 import { type AztecAddress } from '@aztec/aztec.js';
 import { createCompatibleClient } from '@aztec/aztec.js';
-import { type DebugLogger, type LogFn } from '@aztec/foundation/log';
+import { type LogFn, type Logger } from '@aztec/foundation/log';
 
-export async function getAccount(aztecAddress: AztecAddress, rpcUrl: string, debugLogger: DebugLogger, log: LogFn) {
+export async function getAccount(aztecAddress: AztecAddress, rpcUrl: string, debugLogger: Logger, log: LogFn) {
   const client = await createCompatibleClient(rpcUrl, debugLogger);
   const account = await client.getRegisteredAccount(aztecAddress);
 

--- a/yarn-project/cli/src/cmds/pxe/get_accounts.ts
+++ b/yarn-project/cli/src/cmds/pxe/get_accounts.ts
@@ -1,10 +1,10 @@
 import { createCompatibleClient } from '@aztec/aztec.js';
-import { type DebugLogger, type LogFn } from '@aztec/foundation/log';
+import { type LogFn, type Logger } from '@aztec/foundation/log';
 
 export async function getAccounts(
   rpcUrl: string,
   json: boolean,
-  debugLogger: DebugLogger,
+  debugLogger: Logger,
   log: LogFn,
   logJson: (output: any) => void,
 ) {

--- a/yarn-project/cli/src/cmds/pxe/get_block.ts
+++ b/yarn-project/cli/src/cmds/pxe/get_block.ts
@@ -1,5 +1,5 @@
 import { createCompatibleClient } from '@aztec/aztec.js';
-import { type DebugLogger, type LogFn } from '@aztec/foundation/log';
+import { type LogFn, type Logger } from '@aztec/foundation/log';
 
 import { inspectBlock } from '../../utils/inspect.js';
 
@@ -7,7 +7,7 @@ export async function getBlock(
   rpcUrl: string,
   maybeBlockNumber: number | undefined,
   follow: boolean,
-  debugLogger: DebugLogger,
+  debugLogger: Logger,
   log: LogFn,
 ) {
   const client = await createCompatibleClient(rpcUrl, debugLogger);

--- a/yarn-project/cli/src/cmds/pxe/get_contract_data.ts
+++ b/yarn-project/cli/src/cmds/pxe/get_contract_data.ts
@@ -1,12 +1,12 @@
 import { type AztecAddress } from '@aztec/aztec.js';
 import { createCompatibleClient } from '@aztec/aztec.js';
-import { type DebugLogger, type LogFn } from '@aztec/foundation/log';
+import { type LogFn, type Logger } from '@aztec/foundation/log';
 
 export async function getContractData(
   rpcUrl: string,
   contractAddress: AztecAddress,
   includeBytecode: boolean,
-  debugLogger: DebugLogger,
+  debugLogger: Logger,
   log: LogFn,
 ) {
   const client = await createCompatibleClient(rpcUrl, debugLogger);

--- a/yarn-project/cli/src/cmds/pxe/get_current_base_fee.ts
+++ b/yarn-project/cli/src/cmds/pxe/get_current_base_fee.ts
@@ -1,8 +1,8 @@
 import { createCompatibleClient } from '@aztec/aztec.js';
 import { jsonStringify } from '@aztec/foundation/json-rpc';
-import { type DebugLogger, type LogFn } from '@aztec/foundation/log';
+import { type LogFn, type Logger } from '@aztec/foundation/log';
 
-export async function getCurrentBaseFee(rpcUrl: string, debugLogger: DebugLogger, log: LogFn) {
+export async function getCurrentBaseFee(rpcUrl: string, debugLogger: Logger, log: LogFn) {
   const client = await createCompatibleClient(rpcUrl, debugLogger);
   const fees = await client.getCurrentBaseFees();
   log(`Current fees: ${jsonStringify(fees)}`);

--- a/yarn-project/cli/src/cmds/pxe/get_l1_to_l2_message_witness.ts
+++ b/yarn-project/cli/src/cmds/pxe/get_l1_to_l2_message_witness.ts
@@ -1,12 +1,12 @@
 import { type AztecAddress, type Fr, createCompatibleClient } from '@aztec/aztec.js';
-import { type DebugLogger, type LogFn } from '@aztec/foundation/log';
+import { type LogFn, type Logger } from '@aztec/foundation/log';
 
 export async function getL1ToL2MessageWitness(
   rpcUrl: string,
   contractAddress: AztecAddress,
   messageHash: Fr,
   secret: Fr,
-  debugLogger: DebugLogger,
+  debugLogger: Logger,
   log: LogFn,
 ) {
   const client = await createCompatibleClient(rpcUrl, debugLogger);

--- a/yarn-project/cli/src/cmds/pxe/get_logs.ts
+++ b/yarn-project/cli/src/cmds/pxe/get_logs.ts
@@ -1,6 +1,6 @@
 import { type AztecAddress, type LogFilter, type LogId, type TxHash } from '@aztec/aztec.js';
 import { createCompatibleClient } from '@aztec/aztec.js';
-import { type DebugLogger, type LogFn } from '@aztec/foundation/log';
+import { type LogFn, type Logger } from '@aztec/foundation/log';
 import { sleep } from '@aztec/foundation/sleep';
 
 export async function getLogs(
@@ -11,7 +11,7 @@ export async function getLogs(
   contractAddress: AztecAddress,
   rpcUrl: string,
   follow: boolean,
-  debugLogger: DebugLogger,
+  debugLogger: Logger,
   log: LogFn,
 ) {
   const pxe = await createCompatibleClient(rpcUrl, debugLogger);

--- a/yarn-project/cli/src/cmds/pxe/get_node_info.ts
+++ b/yarn-project/cli/src/cmds/pxe/get_node_info.ts
@@ -1,7 +1,7 @@
 import { type AztecNode, type PXE, createAztecNodeClient, createCompatibleClient } from '@aztec/aztec.js';
-import { type DebugLogger, type LogFn } from '@aztec/foundation/log';
+import { type LogFn, type Logger } from '@aztec/foundation/log';
 
-export async function getNodeInfo(rpcUrl: string, pxeRequest: boolean, debugLogger: DebugLogger, log: LogFn) {
+export async function getNodeInfo(rpcUrl: string, pxeRequest: boolean, debugLogger: Logger, log: LogFn) {
   let client: AztecNode | PXE;
   if (pxeRequest) {
     client = await createCompatibleClient(rpcUrl, debugLogger);

--- a/yarn-project/cli/src/cmds/pxe/get_pxe_info.ts
+++ b/yarn-project/cli/src/cmds/pxe/get_pxe_info.ts
@@ -1,7 +1,7 @@
 import { createCompatibleClient } from '@aztec/aztec.js';
-import { type DebugLogger, type LogFn } from '@aztec/foundation/log';
+import { type LogFn, type Logger } from '@aztec/foundation/log';
 
-export async function getPXEInfo(rpcUrl: string, debugLogger: DebugLogger, log: LogFn) {
+export async function getPXEInfo(rpcUrl: string, debugLogger: Logger, log: LogFn) {
   const client = await createCompatibleClient(rpcUrl, debugLogger);
   const info = await client.getPXEInfo();
   log(`PXE Version: ${info.pxeVersion}`);

--- a/yarn-project/cli/src/cmds/pxe/index.ts
+++ b/yarn-project/cli/src/cmds/pxe/index.ts
@@ -1,5 +1,5 @@
 import { Fr } from '@aztec/circuits.js';
-import { type DebugLogger, type LogFn } from '@aztec/foundation/log';
+import { type LogFn, type Logger } from '@aztec/foundation/log';
 
 import { type Command } from 'commander';
 
@@ -18,7 +18,7 @@ import {
   pxeOption,
 } from '../../utils/commands.js';
 
-export function injectCommands(program: Command, log: LogFn, debugLogger: DebugLogger) {
+export function injectCommands(program: Command, log: LogFn, debugLogger: Logger) {
   program
     .command('add-contract')
     .description(

--- a/yarn-project/cli/src/utils/aztec.ts
+++ b/yarn-project/cli/src/utils/aztec.ts
@@ -3,7 +3,7 @@ import { type PXE } from '@aztec/circuit-types';
 import { type DeployL1Contracts, type L1ContractsConfig } from '@aztec/ethereum';
 import { FunctionType } from '@aztec/foundation/abi';
 import { type EthAddress } from '@aztec/foundation/eth-address';
-import { type DebugLogger, type LogFn } from '@aztec/foundation/log';
+import { type LogFn, type Logger } from '@aztec/foundation/log';
 import { type NoirPackageConfig } from '@aztec/foundation/noir';
 import { RollupAbi } from '@aztec/l1-artifacts';
 import { ProtocolContractAddress, protocolContractTreeRoot } from '@aztec/protocol-contracts';
@@ -59,7 +59,7 @@ export async function deployAztecContracts(
   salt: number | undefined,
   initialValidators: EthAddress[],
   config: L1ContractsConfig,
-  debugLogger: DebugLogger,
+  debugLogger: Logger,
 ): Promise<DeployL1Contracts> {
   const { createEthereumChain, deployL1Contracts } = await import('@aztec/ethereum');
   const { mnemonicToAccount, privateKeyToAccount } = await import('viem/accounts');

--- a/yarn-project/end-to-end/src/composed/e2e_aztec_js_browser.test.ts
+++ b/yarn-project/end-to-end/src/composed/e2e_aztec_js_browser.test.ts
@@ -1,4 +1,4 @@
-import { createDebugLogger, fileURLToPath } from '@aztec/aztec.js';
+import { createLogger, fileURLToPath } from '@aztec/aztec.js';
 import { startPXEHttpServer } from '@aztec/pxe';
 
 import Koa from 'koa';
@@ -15,8 +15,8 @@ const __dirname = dirname(__filename);
 const PORT = 4000;
 const PXE_PORT = 4001;
 
-const logger = createDebugLogger('aztec:e2e_aztec_browser.js:web');
-const pageLogger = createDebugLogger('aztec:e2e_aztec_browser.js:web:page');
+const logger = createLogger('e2e_aztec_browser.js:web');
+const pageLogger = createLogger('e2e_aztec_browser.js:web:page');
 
 /**
  * This test is a bit of a special case as it's on a web browser and not only on anvil and node.js.

--- a/yarn-project/end-to-end/src/composed/e2e_aztec_js_browser.test.ts
+++ b/yarn-project/end-to-end/src/composed/e2e_aztec_js_browser.test.ts
@@ -15,8 +15,8 @@ const __dirname = dirname(__filename);
 const PORT = 4000;
 const PXE_PORT = 4001;
 
-const logger = createLogger('e2e_aztec_browser.js:web');
-const pageLogger = createLogger('e2e_aztec_browser.js:web:page');
+const logger = createLogger('e2e:aztec_browser.js:web');
+const pageLogger = createLogger('e2e:aztec_browser.js:web:page');
 
 /**
  * This test is a bit of a special case as it's on a web browser and not only on anvil and node.js.

--- a/yarn-project/end-to-end/src/composed/e2e_sandbox_example.test.ts
+++ b/yarn-project/end-to-end/src/composed/e2e_sandbox_example.test.ts
@@ -14,7 +14,7 @@ describe('e2e_sandbox_example', () => {
   it('sandbox example works', async () => {
     // docs:start:setup
     ////////////// CREATE THE CLIENT INTERFACE AND CONTACT THE SANDBOX //////////////
-    const logger = createLogger('token');
+    const logger = createLogger('e2e:token');
 
     // We create PXE client connected to the sandbox URL
     const pxe = createPXEClient(PXE_URL);
@@ -118,7 +118,7 @@ describe('e2e_sandbox_example', () => {
   });
 
   it('can create accounts on the sandbox', async () => {
-    const logger = createLogger('token');
+    const logger = createLogger('e2e:token');
     // We create PXE client connected to the sandbox URL
     const pxe = createPXEClient(PXE_URL);
     // Wait for sandbox to be ready

--- a/yarn-project/end-to-end/src/composed/e2e_sandbox_example.test.ts
+++ b/yarn-project/end-to-end/src/composed/e2e_sandbox_example.test.ts
@@ -1,7 +1,7 @@
 // docs:start:imports
 import { getSchnorrAccount } from '@aztec/accounts/schnorr';
 import { getDeployedTestAccountsWallets } from '@aztec/accounts/testing';
-import { Fr, GrumpkinScalar, type PXE, createDebugLogger, createPXEClient, waitForPXE } from '@aztec/aztec.js';
+import { Fr, GrumpkinScalar, type PXE, createLogger, createPXEClient, waitForPXE } from '@aztec/aztec.js';
 
 import { format } from 'util';
 
@@ -14,7 +14,7 @@ describe('e2e_sandbox_example', () => {
   it('sandbox example works', async () => {
     // docs:start:setup
     ////////////// CREATE THE CLIENT INTERFACE AND CONTACT THE SANDBOX //////////////
-    const logger = createDebugLogger('token');
+    const logger = createLogger('token');
 
     // We create PXE client connected to the sandbox URL
     const pxe = createPXEClient(PXE_URL);
@@ -118,7 +118,7 @@ describe('e2e_sandbox_example', () => {
   });
 
   it('can create accounts on the sandbox', async () => {
-    const logger = createDebugLogger('token');
+    const logger = createLogger('token');
     // We create PXE client connected to the sandbox URL
     const pxe = createPXEClient(PXE_URL);
     // Wait for sandbox to be ready

--- a/yarn-project/end-to-end/src/composed/integration_l1_publisher.test.ts
+++ b/yarn-project/end-to-end/src/composed/integration_l1_publisher.test.ts
@@ -1,6 +1,6 @@
 import { type ArchiveSource } from '@aztec/archiver';
 import { getConfigEnvVars } from '@aztec/aztec-node';
-import { AztecAddress, EthCheatCodes, Fr, GlobalVariables, type L2Block, createDebugLogger } from '@aztec/aztec.js';
+import { AztecAddress, EthCheatCodes, Fr, GlobalVariables, type L2Block, createLogger } from '@aztec/aztec.js';
 // eslint-disable-next-line no-restricted-imports
 import {
   type L2Tips,
@@ -60,7 +60,7 @@ import { setupL1Contracts } from '../fixtures/utils.js';
 const sequencerPK = '0x47e179ec197488593b187f80a00eb0da91f1b9d0b13f8733639f19c30a34926a';
 const deployerPK = '0x8b3a350cf5c34c9194ca85829a2df0ec3153be0318b5e2d3348e872092edffba';
 
-const logger = createDebugLogger('aztec:integration_l1_publisher');
+const logger = createLogger('integration_l1_publisher');
 
 const config = getConfigEnvVars();
 config.l1RpcUrl = config.l1RpcUrl || 'http://127.0.0.1:8545';

--- a/yarn-project/end-to-end/src/composed/integration_l1_publisher.test.ts
+++ b/yarn-project/end-to-end/src/composed/integration_l1_publisher.test.ts
@@ -590,14 +590,14 @@ describe('L1Publisher integration', () => {
       // Test first call
       expect(loggerErrorSpy).toHaveBeenNthCalledWith(
         1,
-        expect.stringMatching(/^L1 Transaction 0x[a-f0-9]{64} reverted$/),
+        expect.stringMatching(/^L1 transaction 0x[a-f0-9]{64} reverted$/i),
       );
 
       // Test second call
       expect(loggerErrorSpy).toHaveBeenNthCalledWith(
         2,
         expect.stringMatching(
-          /^Rollup process tx reverted\. The contract function "propose" reverted\. Error: Rollup__InvalidInHash/,
+          /^Rollup process tx reverted\. The contract function "propose" reverted\. Error: Rollup__InvalidInHash/i,
         ),
         undefined,
         expect.objectContaining({

--- a/yarn-project/end-to-end/src/devnet/e2e_smoke.test.ts
+++ b/yarn-project/end-to-end/src/devnet/e2e_smoke.test.ts
@@ -17,7 +17,7 @@ import { DefaultMultiCallEntrypoint } from '@aztec/aztec.js/entrypoint';
 import { PXESchema } from '@aztec/circuit-types';
 import { deriveSigningKey } from '@aztec/circuits.js';
 import { createNamespacedSafeJsonRpcServer, startHttpRpcServer } from '@aztec/foundation/json-rpc/server';
-import { type DebugLogger } from '@aztec/foundation/log';
+import { type Logger } from '@aztec/foundation/log';
 import { promiseWithResolvers } from '@aztec/foundation/promise';
 import { FeeJuiceContract, TestContract } from '@aztec/noir-contracts.js';
 
@@ -58,7 +58,7 @@ describe('End-to-end tests for devnet', () => {
   // eslint-disable-next-line
   let pxe: PXE;
   let pxeUrl: string; // needed for the CLI
-  let logger: DebugLogger;
+  let logger: Logger;
   let l1ChainId: number;
   let feeJuiceL1: EthAddress;
   let teardown: () => void | Promise<void>;

--- a/yarn-project/end-to-end/src/e2e_2_pxes.test.ts
+++ b/yarn-project/end-to-end/src/e2e_2_pxes.test.ts
@@ -3,9 +3,9 @@ import { createAccounts } from '@aztec/accounts/testing';
 import {
   type AztecAddress,
   type AztecNode,
-  type DebugLogger,
   type ExtendedNote,
   Fr,
+  type Logger,
   type PXE,
   type Wallet,
   retryUntil,
@@ -28,7 +28,7 @@ describe('e2e_2_pxes', () => {
   let pxeB: PXE;
   let walletA: Wallet;
   let walletB: Wallet;
-  let logger: DebugLogger;
+  let logger: Logger;
   let teardownA: () => Promise<void>;
   let teardownB: () => Promise<void>;
 

--- a/yarn-project/end-to-end/src/e2e_account_contracts.test.ts
+++ b/yarn-project/end-to-end/src/e2e_account_contracts.test.ts
@@ -6,9 +6,9 @@ import {
   AccountManager,
   AccountWallet,
   type CompleteAddress,
-  type DebugLogger,
   Fr,
   GrumpkinScalar,
+  type Logger,
   type PXE,
   type Wallet,
 } from '@aztec/aztec.js';
@@ -29,7 +29,7 @@ function itShouldBehaveLikeAnAccountContract(
     let secretKey: Fr;
 
     let pxe: PXE;
-    let logger: DebugLogger;
+    let logger: Logger;
     let teardown: () => Promise<void>;
 
     beforeEach(async () => {

--- a/yarn-project/end-to-end/src/e2e_amm.test.ts
+++ b/yarn-project/end-to-end/src/e2e_amm.test.ts
@@ -1,4 +1,4 @@
-import { type AccountWallet, type DebugLogger, Fr, type Wallet } from '@aztec/aztec.js';
+import { type AccountWallet, Fr, type Logger, type Wallet } from '@aztec/aztec.js';
 import { AMMContract, type TokenContract } from '@aztec/noir-contracts.js';
 
 import { jest } from '@jest/globals';
@@ -13,7 +13,7 @@ describe('AMM', () => {
 
   let teardown: () => Promise<void>;
 
-  let logger: DebugLogger;
+  let logger: Logger;
 
   let adminWallet: AccountWallet;
   let liquidityProvider: AccountWallet;

--- a/yarn-project/end-to-end/src/e2e_blacklist_token_contract/blacklist_token_contract_test.ts
+++ b/yarn-project/end-to-end/src/e2e_blacklist_token_contract/blacklist_token_contract_test.ts
@@ -70,7 +70,7 @@ export class BlacklistTokenContractTest {
   blacklisted!: AccountWallet;
 
   constructor(testName: string) {
-    this.logger = createLogger(`aztec:e2e_blacklist_token_contract:${testName}`);
+    this.logger = createLogger(`e2e:e2e_blacklist_token_contract:${testName}`);
     this.snapshotManager = createSnapshotManager(`e2e_blacklist_token_contract/${testName}`, dataPath);
   }
 

--- a/yarn-project/end-to-end/src/e2e_blacklist_token_contract/blacklist_token_contract_test.ts
+++ b/yarn-project/end-to-end/src/e2e_blacklist_token_contract/blacklist_token_contract_test.ts
@@ -2,13 +2,13 @@ import { getSchnorrAccount } from '@aztec/accounts/schnorr';
 import {
   type AccountWallet,
   type CompleteAddress,
-  type DebugLogger,
   ExtendedNote,
   Fr,
+  type Logger,
   Note,
   type TxHash,
   computeSecretHash,
-  createDebugLogger,
+  createLogger,
 } from '@aztec/aztec.js';
 import { DocsExampleContract, TokenBlacklistContract, type TokenContract } from '@aztec/noir-contracts.js';
 
@@ -58,7 +58,7 @@ export class BlacklistTokenContractTest {
   static DELAY = 2;
 
   private snapshotManager: ISnapshotManager;
-  logger: DebugLogger;
+  logger: Logger;
   wallets: AccountWallet[] = [];
   accounts: CompleteAddress[] = [];
   asset!: TokenBlacklistContract;
@@ -70,7 +70,7 @@ export class BlacklistTokenContractTest {
   blacklisted!: AccountWallet;
 
   constructor(testName: string) {
-    this.logger = createDebugLogger(`aztec:e2e_blacklist_token_contract:${testName}`);
+    this.logger = createLogger(`aztec:e2e_blacklist_token_contract:${testName}`);
     this.snapshotManager = createSnapshotManager(`e2e_blacklist_token_contract/${testName}`, dataPath);
   }
 

--- a/yarn-project/end-to-end/src/e2e_block_building.test.ts
+++ b/yarn-project/end-to-end/src/e2e_block_building.test.ts
@@ -5,11 +5,11 @@ import {
   type CheatCodes,
   ContractDeployer,
   ContractFunctionInteraction,
-  type DebugLogger,
   Fq,
   Fr,
   L1EventPayload,
   L1NotePayload,
+  type Logger,
   type PXE,
   TxStatus,
   type Wallet,
@@ -31,7 +31,7 @@ import { setup } from './fixtures/utils.js';
 
 describe('e2e_block_building', () => {
   let pxe: PXE;
-  let logger: DebugLogger;
+  let logger: Logger;
   let owner: Wallet;
   let minter: Wallet;
   let aztecNode: AztecNode;

--- a/yarn-project/end-to-end/src/e2e_card_game.test.ts
+++ b/yarn-project/end-to-end/src/e2e_card_game.test.ts
@@ -3,8 +3,8 @@ import { INITIAL_TEST_SECRET_KEYS } from '@aztec/accounts/testing';
 import {
   type AccountWallet,
   AztecAddress,
-  type DebugLogger,
   GrumpkinScalar,
+  type Logger,
   type PXE,
   type Wallet,
   computeAppNullifierSecretKey,
@@ -67,7 +67,7 @@ describe('e2e_card_game', () => {
   jest.setTimeout(TIMEOUT);
 
   let pxe: PXE;
-  let logger: DebugLogger;
+  let logger: Logger;
   let teardown: () => Promise<void>;
 
   let wallets: AccountWallet[];

--- a/yarn-project/end-to-end/src/e2e_cross_chain_messaging/cross_chain_messaging_test.ts
+++ b/yarn-project/end-to-end/src/e2e_cross_chain_messaging/cross_chain_messaging_test.ts
@@ -52,7 +52,7 @@ export class CrossChainMessagingTest {
   outbox!: any; // GetContractReturnType<typeof OutboxAbi> | undefined;
 
   constructor(testName: string) {
-    this.logger = createLogger(`aztec:e2e_cross_chain_messaging:${testName}`);
+    this.logger = createLogger(`e2e:e2e_cross_chain_messaging:${testName}`);
     this.snapshotManager = createSnapshotManager(`e2e_cross_chain_messaging/${testName}`, dataPath);
   }
 

--- a/yarn-project/end-to-end/src/e2e_cross_chain_messaging/cross_chain_messaging_test.ts
+++ b/yarn-project/end-to-end/src/e2e_cross_chain_messaging/cross_chain_messaging_test.ts
@@ -5,10 +5,10 @@ import {
   AztecAddress,
   type AztecNode,
   type CompleteAddress,
-  type DebugLogger,
   EthAddress,
+  type Logger,
   type PXE,
-  createDebugLogger,
+  createLogger,
 } from '@aztec/aztec.js';
 import { createL1Clients } from '@aztec/ethereum';
 import { InboxAbi, OutboxAbi, RollupAbi } from '@aztec/l1-artifacts';
@@ -30,7 +30,7 @@ const { E2E_DATA_PATH: dataPath } = process.env;
 
 export class CrossChainMessagingTest {
   private snapshotManager: ISnapshotManager;
-  logger: DebugLogger;
+  logger: Logger;
   wallets: AccountWallet[] = [];
   accounts: CompleteAddress[] = [];
   aztecNode!: AztecNode;
@@ -52,7 +52,7 @@ export class CrossChainMessagingTest {
   outbox!: any; // GetContractReturnType<typeof OutboxAbi> | undefined;
 
   constructor(testName: string) {
-    this.logger = createDebugLogger(`aztec:e2e_cross_chain_messaging:${testName}`);
+    this.logger = createLogger(`aztec:e2e_cross_chain_messaging:${testName}`);
     this.snapshotManager = createSnapshotManager(`e2e_cross_chain_messaging/${testName}`, dataPath);
   }
 

--- a/yarn-project/end-to-end/src/e2e_crowdfunding_and_claim.test.ts
+++ b/yarn-project/end-to-end/src/e2e_crowdfunding_and_claim.test.ts
@@ -3,8 +3,8 @@ import {
   type AccountWallet,
   type AztecNode,
   type CheatCodes,
-  type DebugLogger,
   Fr,
+  type Logger,
   type PXE,
   PackedValues,
   TxExecutionRequest,
@@ -45,7 +45,7 @@ describe('e2e_crowdfunding_and_claim', () => {
   let operatorWallet: AccountWallet;
   let donorWallets: AccountWallet[];
   let wallets: AccountWallet[];
-  let logger: DebugLogger;
+  let logger: Logger;
 
   let donationToken: TokenContract;
   let rewardToken: TokenContract;

--- a/yarn-project/end-to-end/src/e2e_deploy_contract/contract_class_registration.test.ts
+++ b/yarn-project/end-to-end/src/e2e_deploy_contract/contract_class_registration.test.ts
@@ -4,9 +4,9 @@ import {
   type ContractArtifact,
   type ContractClassWithId,
   type ContractInstanceWithAddress,
-  type DebugLogger,
   type FieldsOf,
   Fr,
+  type Logger,
   type PXE,
   type TxReceipt,
   TxStatus,
@@ -33,7 +33,7 @@ describe('e2e_deploy_contract contract class registration', () => {
   const t = new DeployTest('contract class');
 
   let pxe: PXE;
-  let logger: DebugLogger;
+  let logger: Logger;
   let wallet: Wallet;
   let aztecNode: AztecNode;
 

--- a/yarn-project/end-to-end/src/e2e_deploy_contract/deploy_method.test.ts
+++ b/yarn-project/end-to-end/src/e2e_deploy_contract/deploy_method.test.ts
@@ -1,5 +1,5 @@
 import { getDeployedTestAccountsWallets } from '@aztec/accounts/testing';
-import { AztecAddress, type DebugLogger, type PXE, type Wallet, createPXEClient, makeFetch } from '@aztec/aztec.js';
+import { AztecAddress, type Logger, type PXE, type Wallet, createPXEClient, makeFetch } from '@aztec/aztec.js';
 import { CounterContract, StatefulTestContract } from '@aztec/noir-contracts.js';
 import { TestContract } from '@aztec/noir-contracts.js/Test';
 import { TokenContract } from '@aztec/noir-contracts.js/Token';
@@ -10,7 +10,7 @@ describe('e2e_deploy_contract deploy method', () => {
   const t = new DeployTest('deploy method');
 
   let pxe: PXE;
-  let logger: DebugLogger;
+  let logger: Logger;
   let wallet: Wallet;
 
   const ignoredArg = AztecAddress.random();

--- a/yarn-project/end-to-end/src/e2e_deploy_contract/deploy_test.ts
+++ b/yarn-project/end-to-end/src/e2e_deploy_contract/deploy_test.ts
@@ -29,7 +29,7 @@ export class DeployTest {
   public aztecNode!: AztecNode;
 
   constructor(testName: string) {
-    this.logger = createLogger(`aztec:e2e_deploy_contract:${testName}`);
+    this.logger = createLogger(`e2e:e2e_deploy_contract:${testName}`);
     this.snapshotManager = createSnapshotManager(`e2e_deploy_contract/${testName}`, dataPath);
   }
 

--- a/yarn-project/end-to-end/src/e2e_deploy_contract/deploy_test.ts
+++ b/yarn-project/end-to-end/src/e2e_deploy_contract/deploy_test.ts
@@ -5,12 +5,12 @@ import {
   type AztecNode,
   type ContractArtifact,
   type ContractBase,
-  type DebugLogger,
   Fr,
+  type Logger,
   type PXE,
   type PublicKeys,
   type Wallet,
-  createDebugLogger,
+  createLogger,
   getContractInstanceFromDeployParams,
 } from '@aztec/aztec.js';
 import { type StatefulTestContract } from '@aztec/noir-contracts.js';
@@ -23,13 +23,13 @@ export class DeployTest {
   private snapshotManager: ISnapshotManager;
   private wallets: AccountWallet[] = [];
 
-  public logger: DebugLogger;
+  public logger: Logger;
   public pxe!: PXE;
   public wallet!: AccountWallet;
   public aztecNode!: AztecNode;
 
   constructor(testName: string) {
-    this.logger = createDebugLogger(`aztec:e2e_deploy_contract:${testName}`);
+    this.logger = createLogger(`aztec:e2e_deploy_contract:${testName}`);
     this.snapshotManager = createSnapshotManager(`e2e_deploy_contract/${testName}`, dataPath);
   }
 

--- a/yarn-project/end-to-end/src/e2e_deploy_contract/legacy.test.ts
+++ b/yarn-project/end-to-end/src/e2e_deploy_contract/legacy.test.ts
@@ -1,8 +1,8 @@
 import {
   AztecAddress,
   ContractDeployer,
-  type DebugLogger,
   Fr,
+  type Logger,
   type PXE,
   TxStatus,
   type Wallet,
@@ -18,7 +18,7 @@ describe('e2e_deploy_contract legacy', () => {
   const t = new DeployTest('legacy');
 
   let pxe: PXE;
-  let logger: DebugLogger;
+  let logger: Logger;
   let wallet: Wallet;
 
   beforeAll(async () => {

--- a/yarn-project/end-to-end/src/e2e_deploy_contract/private_initialization.test.ts
+++ b/yarn-project/end-to-end/src/e2e_deploy_contract/private_initialization.test.ts
@@ -1,4 +1,4 @@
-import { BatchCall, type DebugLogger, Fr, type PXE, SignerlessWallet, type Wallet } from '@aztec/aztec.js';
+import { BatchCall, Fr, type Logger, type PXE, SignerlessWallet, type Wallet } from '@aztec/aztec.js';
 import { siloNullifier } from '@aztec/circuits.js/hash';
 import { StatefulTestContract } from '@aztec/noir-contracts.js';
 import { TestContract } from '@aztec/noir-contracts.js/Test';
@@ -9,7 +9,7 @@ describe('e2e_deploy_contract private initialization', () => {
   const t = new DeployTest('private initialization');
 
   let pxe: PXE;
-  let logger: DebugLogger;
+  let logger: Logger;
   let wallet: Wallet;
 
   beforeAll(async () => {

--- a/yarn-project/end-to-end/src/e2e_epochs.test.ts
+++ b/yarn-project/end-to-end/src/e2e_epochs.test.ts
@@ -1,5 +1,5 @@
 // eslint-disable-next-line no-restricted-imports
-import { type DebugLogger, type EpochConstants, getTimestampRangeForEpoch, retryUntil } from '@aztec/aztec.js';
+import { type EpochConstants, type Logger, getTimestampRangeForEpoch, retryUntil } from '@aztec/aztec.js';
 import { RollupContract } from '@aztec/ethereum/contracts';
 import { type Delayer, waitUntilL1Timestamp } from '@aztec/ethereum/test';
 
@@ -15,7 +15,7 @@ describe('e2e_epochs', () => {
   let l1Client: PublicClient;
   let rollup: RollupContract;
   let constants: EpochConstants;
-  let logger: DebugLogger;
+  let logger: Logger;
   let proverDelayer: Delayer;
   let sequencerDelayer: Delayer;
 

--- a/yarn-project/end-to-end/src/e2e_escrow_contract.test.ts
+++ b/yarn-project/end-to-end/src/e2e_escrow_contract.test.ts
@@ -2,8 +2,8 @@ import {
   type AccountWallet,
   type AztecAddress,
   BatchCall,
-  type DebugLogger,
   Fr,
+  type Logger,
   type PXE,
   deriveKeys,
 } from '@aztec/aztec.js';
@@ -19,7 +19,7 @@ describe('e2e_escrow_contract', () => {
   let wallet: AccountWallet;
   let recipientWallet: AccountWallet;
 
-  let logger: DebugLogger;
+  let logger: Logger;
   let teardown: () => Promise<void>;
 
   let token: TokenContract;

--- a/yarn-project/end-to-end/src/e2e_fees/account_init.test.ts
+++ b/yarn-project/end-to-end/src/e2e_fees/account_init.test.ts
@@ -2,10 +2,10 @@ import { getSchnorrAccount } from '@aztec/accounts/schnorr';
 import {
   type AccountManager,
   type AccountWallet,
-  type DebugLogger,
   FeeJuicePaymentMethod,
   FeeJuicePaymentMethodWithClaim,
   Fr,
+  type Logger,
   type PXE,
   PrivateFeePaymentMethod,
   PublicFeePaymentMethod,
@@ -43,7 +43,7 @@ describe('e2e_fees account_init', () => {
   });
 
   // eslint-disable-next-line @typescript-eslint/no-unused-vars
-  let logger: DebugLogger;
+  let logger: Logger;
   let pxe: PXE;
   let gasSettings: GasSettings;
   let bananaCoin: BananaCoin;

--- a/yarn-project/end-to-end/src/e2e_fees/fees_test.ts
+++ b/yarn-project/end-to-end/src/e2e_fees/fees_test.ts
@@ -83,7 +83,7 @@ export class FeesTest {
   public readonly APP_SPONSORED_TX_GAS_LIMIT = BigInt(10e9);
 
   constructor(testName: string) {
-    this.logger = createLogger(`aztec:e2e_fees:${testName}`);
+    this.logger = createLogger(`e2e:e2e_fees:${testName}`);
     this.snapshotManager = createSnapshotManager(`e2e_fees/${testName}`, dataPath);
   }
 

--- a/yarn-project/end-to-end/src/e2e_fees/fees_test.ts
+++ b/yarn-project/end-to-end/src/e2e_fees/fees_test.ts
@@ -3,10 +3,10 @@ import {
   type AccountWallet,
   type AztecAddress,
   type AztecNode,
-  type DebugLogger,
+  type Logger,
   type PXE,
   SignerlessWallet,
-  createDebugLogger,
+  createLogger,
   sleep,
 } from '@aztec/aztec.js';
 import { DefaultMultiCallEntrypoint } from '@aztec/aztec.js/entrypoint';
@@ -51,7 +51,7 @@ export class FeesTest {
   private snapshotManager: ISnapshotManager;
   private wallets: AccountWallet[] = [];
 
-  public logger: DebugLogger;
+  public logger: Logger;
   public pxe!: PXE;
   public aztecNode!: AztecNode;
 
@@ -83,7 +83,7 @@ export class FeesTest {
   public readonly APP_SPONSORED_TX_GAS_LIMIT = BigInt(10e9);
 
   constructor(testName: string) {
-    this.logger = createDebugLogger(`aztec:e2e_fees:${testName}`);
+    this.logger = createLogger(`aztec:e2e_fees:${testName}`);
     this.snapshotManager = createSnapshotManager(`e2e_fees/${testName}`, dataPath);
   }
 

--- a/yarn-project/end-to-end/src/e2e_l1_with_wall_time.test.ts
+++ b/yarn-project/end-to-end/src/e2e_l1_with_wall_time.test.ts
@@ -1,5 +1,5 @@
 import { getSchnorrAccount } from '@aztec/accounts/schnorr';
-import { type DebugLogger, Fr, GrumpkinScalar, type PXE, TxStatus } from '@aztec/aztec.js';
+import { Fr, GrumpkinScalar, type Logger, type PXE, TxStatus } from '@aztec/aztec.js';
 import { EthAddress } from '@aztec/circuits.js';
 import { getL1ContractsConfigEnvVars } from '@aztec/ethereum';
 import { type PXEService } from '@aztec/pxe';
@@ -9,7 +9,7 @@ import { privateKeyToAccount } from 'viem/accounts';
 import { getPrivateKeyFromIndex, setup } from './fixtures/utils.js';
 
 describe('e2e_l1_with_wall_time', () => {
-  let logger: DebugLogger;
+  let logger: Logger;
   let teardown: () => Promise<void>;
   let pxe: PXE;
 

--- a/yarn-project/end-to-end/src/e2e_lending_contract.test.ts
+++ b/yarn-project/end-to-end/src/e2e_lending_contract.test.ts
@@ -1,4 +1,4 @@
-import { type AccountWallet, type CheatCodes, type DebugLogger, type DeployL1Contracts, Fr } from '@aztec/aztec.js';
+import { type AccountWallet, type CheatCodes, type DeployL1Contracts, Fr, type Logger } from '@aztec/aztec.js';
 import { RollupAbi } from '@aztec/l1-artifacts';
 import { LendingContract, PriceFeedContract, TokenContract } from '@aztec/noir-contracts.js';
 
@@ -14,7 +14,7 @@ describe('e2e_lending_contract', () => {
   let wallet: AccountWallet;
   let deployL1ContractsValues: DeployL1Contracts;
 
-  let logger: DebugLogger;
+  let logger: Logger;
   let teardown: () => Promise<void>;
 
   let cc: CheatCodes;

--- a/yarn-project/end-to-end/src/e2e_multiple_accounts_1_enc_key.test.ts
+++ b/yarn-project/end-to-end/src/e2e_multiple_accounts_1_enc_key.test.ts
@@ -1,9 +1,9 @@
 import { getSchnorrAccount } from '@aztec/accounts/schnorr';
 import {
   type CompleteAddress,
-  type DebugLogger,
   Fr,
   GrumpkinScalar,
+  type Logger,
   type PXE,
   type Wallet,
   deriveKeys,
@@ -17,7 +17,7 @@ describe('e2e_multiple_accounts_1_enc_key', () => {
   let pxe: PXE;
   const wallets: Wallet[] = [];
   const accounts: CompleteAddress[] = [];
-  let logger: DebugLogger;
+  let logger: Logger;
   let teardown: () => Promise<void>;
 
   let token: TokenContract;

--- a/yarn-project/end-to-end/src/e2e_nested_contract/nested_contract_test.ts
+++ b/yarn-project/end-to-end/src/e2e_nested_contract/nested_contract_test.ts
@@ -23,7 +23,7 @@ export class NestedContractTest {
   childContract!: ChildContract;
 
   constructor(testName: string) {
-    this.logger = createLogger(`aztec:e2e_nested_contract:${testName}`);
+    this.logger = createLogger(`e2e:e2e_nested_contract:${testName}`);
     this.snapshotManager = createSnapshotManager(`e2e_nested_contract/${testName}`, dataPath);
   }
 

--- a/yarn-project/end-to-end/src/e2e_nested_contract/nested_contract_test.ts
+++ b/yarn-project/end-to-end/src/e2e_nested_contract/nested_contract_test.ts
@@ -1,11 +1,5 @@
 import { getSchnorrAccount } from '@aztec/accounts/schnorr';
-import {
-  type AccountWallet,
-  type CompleteAddress,
-  type DebugLogger,
-  type PXE,
-  createDebugLogger,
-} from '@aztec/aztec.js';
+import { type AccountWallet, type CompleteAddress, type Logger, type PXE, createLogger } from '@aztec/aztec.js';
 import { ChildContract, ParentContract } from '@aztec/noir-contracts.js';
 
 import {
@@ -20,7 +14,7 @@ const { E2E_DATA_PATH: dataPath } = process.env;
 
 export class NestedContractTest {
   private snapshotManager: ISnapshotManager;
-  logger: DebugLogger;
+  logger: Logger;
   wallets: AccountWallet[] = [];
   accounts: CompleteAddress[] = [];
   pxe!: PXE;
@@ -29,7 +23,7 @@ export class NestedContractTest {
   childContract!: ChildContract;
 
   constructor(testName: string) {
-    this.logger = createDebugLogger(`aztec:e2e_nested_contract:${testName}`);
+    this.logger = createLogger(`aztec:e2e_nested_contract:${testName}`);
     this.snapshotManager = createSnapshotManager(`e2e_nested_contract/${testName}`, dataPath);
   }
 

--- a/yarn-project/end-to-end/src/e2e_non_contract_account.test.ts
+++ b/yarn-project/end-to-end/src/e2e_non_contract_account.test.ts
@@ -1,4 +1,4 @@
-import { type DebugLogger, ExtendedNote, Fr, Note, type PXE, SignerlessWallet, type Wallet } from '@aztec/aztec.js';
+import { ExtendedNote, Fr, type Logger, Note, type PXE, SignerlessWallet, type Wallet } from '@aztec/aztec.js';
 import { siloNullifier } from '@aztec/circuits.js/hash';
 import { TestContract } from '@aztec/noir-contracts.js/Test';
 
@@ -9,7 +9,7 @@ describe('e2e_non_contract_account', () => {
   let nonContractAccountWallet: Wallet;
   let teardown: () => Promise<void>;
 
-  let logger: DebugLogger;
+  let logger: Logger;
 
   let contract: TestContract;
   let wallet: Wallet;

--- a/yarn-project/end-to-end/src/e2e_p2p/p2p_network.ts
+++ b/yarn-project/end-to-end/src/e2e_p2p/p2p_network.ts
@@ -2,7 +2,7 @@ import { getSchnorrAccount } from '@aztec/accounts/schnorr';
 import { type AztecNodeConfig, type AztecNodeService } from '@aztec/aztec-node';
 import { type AccountWalletWithSecretKey } from '@aztec/aztec.js';
 import { EthCheatCodes, MINIMUM_STAKE, getL1ContractsConfigEnvVars } from '@aztec/ethereum';
-import { type DebugLogger, createDebugLogger } from '@aztec/foundation/log';
+import { type Logger, createLogger } from '@aztec/foundation/log';
 import { RollupAbi, TestERC20Abi } from '@aztec/l1-artifacts';
 import { SpamContract } from '@aztec/noir-contracts.js';
 import { type BootstrapNode } from '@aztec/p2p';
@@ -36,7 +36,7 @@ export class P2PNetworkTest {
   private snapshotManager: ISnapshotManager;
   private baseAccount;
 
-  public logger: DebugLogger;
+  public logger: Logger;
 
   public ctx!: SubsystemsContext;
   public attesterPrivateKeys: `0x${string}`[] = [];
@@ -61,7 +61,7 @@ export class P2PNetworkTest {
     // If set enable metrics collection
     metricsPort?: number,
   ) {
-    this.logger = createDebugLogger(`aztec:e2e_p2p:${testName}`);
+    this.logger = createLogger(`aztec:e2e_p2p:${testName}`);
 
     // Set up the base account and node private keys for the initial network deployment
     this.baseAccount = privateKeyToAccount(`0x${getPrivateKeyFromIndex(0)!.toString('hex')}`);

--- a/yarn-project/end-to-end/src/e2e_p2p/p2p_network.ts
+++ b/yarn-project/end-to-end/src/e2e_p2p/p2p_network.ts
@@ -61,7 +61,7 @@ export class P2PNetworkTest {
     // If set enable metrics collection
     metricsPort?: number,
   ) {
-    this.logger = createLogger(`aztec:e2e_p2p:${testName}`);
+    this.logger = createLogger(`e2e:e2e_p2p:${testName}`);
 
     // Set up the base account and node private keys for the initial network deployment
     this.baseAccount = privateKeyToAccount(`0x${getPrivateKeyFromIndex(0)!.toString('hex')}`);

--- a/yarn-project/end-to-end/src/e2e_p2p/shared.ts
+++ b/yarn-project/end-to-end/src/e2e_p2p/shared.ts
@@ -1,6 +1,6 @@
 import { getSchnorrAccount } from '@aztec/accounts/schnorr';
 import { type AztecNodeService } from '@aztec/aztec-node';
-import { type DebugLogger, type SentTx } from '@aztec/aztec.js';
+import { type Logger, type SentTx } from '@aztec/aztec.js';
 import { CompleteAddress, TxStatus } from '@aztec/aztec.js';
 import { Fr, GrumpkinScalar } from '@aztec/foundation/fields';
 import { type SpamContract } from '@aztec/noir-contracts.js';
@@ -9,7 +9,7 @@ import { type PXEService, createPXEService, getPXEServiceConfig as getRpcConfig 
 import { type NodeContext } from '../fixtures/setup_p2p_test.js';
 
 // submits a set of transactions to the provided Private eXecution Environment (PXE)
-export const submitComplexTxsTo = async (logger: DebugLogger, spamContract: SpamContract, numTxs: number) => {
+export const submitComplexTxsTo = async (logger: Logger, spamContract: SpamContract, numTxs: number) => {
   const txs: SentTx[] = [];
 
   const seed = 1234n;
@@ -34,7 +34,7 @@ export const submitComplexTxsTo = async (logger: DebugLogger, spamContract: Spam
 
 // creates an instance of the PXE and submit a given number of transactions to it.
 export const createPXEServiceAndSubmitTransactions = async (
-  logger: DebugLogger,
+  logger: Logger,
   node: AztecNodeService,
   numTxs: number,
 ): Promise<NodeContext> => {
@@ -55,7 +55,7 @@ export const createPXEServiceAndSubmitTransactions = async (
 };
 
 // submits a set of transactions to the provided Private eXecution Environment (PXE)
-const submitTxsTo = async (logger: DebugLogger, pxe: PXEService, numTxs: number) => {
+const submitTxsTo = async (logger: Logger, pxe: PXEService, numTxs: number) => {
   const provenTxs = [];
   for (let i = 0; i < numTxs; i++) {
     const accountManager = getSchnorrAccount(pxe, Fr.random(), GrumpkinScalar.random(), Fr.random());

--- a/yarn-project/end-to-end/src/e2e_pending_note_hashes_contract.test.ts
+++ b/yarn-project/end-to-end/src/e2e_pending_note_hashes_contract.test.ts
@@ -1,4 +1,4 @@
-import { type AztecAddress, type AztecNode, type DebugLogger, Fr, type Wallet } from '@aztec/aztec.js';
+import { type AztecAddress, type AztecNode, Fr, type Logger, type Wallet } from '@aztec/aztec.js';
 import {
   MAX_NOTE_HASHES_PER_CALL,
   MAX_NOTE_HASHES_PER_TX,
@@ -12,7 +12,7 @@ import { setup } from './fixtures/utils.js';
 describe('e2e_pending_note_hashes_contract', () => {
   let aztecNode: AztecNode;
   let wallet: Wallet;
-  let logger: DebugLogger;
+  let logger: Logger;
   let owner: AztecAddress;
   let teardown: () => Promise<void>;
   let contract: PendingNoteHashesContract;

--- a/yarn-project/end-to-end/src/e2e_private_voting_contract.test.ts
+++ b/yarn-project/end-to-end/src/e2e_private_voting_contract.test.ts
@@ -1,4 +1,4 @@
-import { type AccountWallet, type AztecAddress, type DebugLogger, Fr } from '@aztec/aztec.js';
+import { type AccountWallet, type AztecAddress, Fr, type Logger } from '@aztec/aztec.js';
 import { EasyPrivateVotingContract } from '@aztec/noir-contracts.js/EasyPrivateVoting';
 
 import { setup } from './fixtures/utils.js';
@@ -6,7 +6,7 @@ import { setup } from './fixtures/utils.js';
 describe('e2e_voting_contract', () => {
   let wallet: AccountWallet;
 
-  let logger: DebugLogger;
+  let logger: Logger;
   let teardown: () => Promise<void>;
 
   let votingContract: EasyPrivateVotingContract;

--- a/yarn-project/end-to-end/src/e2e_prover/e2e_prover_test.ts
+++ b/yarn-project/end-to-end/src/e2e_prover/e2e_prover_test.ts
@@ -93,7 +93,7 @@ export class FullProverTest {
     coinbase: EthAddress,
     private realProofs = true,
   ) {
-    this.logger = createLogger(`aztec:full_prover_test:${testName}`);
+    this.logger = createLogger(`e2e:full_prover_test:${testName}`);
     this.snapshotManager = createSnapshotManager(
       `full_prover_integration/${testName}`,
       dataPath,

--- a/yarn-project/end-to-end/src/e2e_prover/e2e_prover_test.ts
+++ b/yarn-project/end-to-end/src/e2e_prover/e2e_prover_test.ts
@@ -5,13 +5,13 @@ import {
   type AztecNode,
   type CheatCodes,
   type CompleteAddress,
-  type DebugLogger,
   type DeployL1Contracts,
   EthAddress,
   type Fq,
   Fr,
+  type Logger,
   type PXE,
-  createDebugLogger,
+  createLogger,
   deployL1Contract,
 } from '@aztec/aztec.js';
 import {
@@ -67,7 +67,7 @@ export class FullProverTest {
   static TOKEN_SYMBOL = 'USD';
   static TOKEN_DECIMALS = 18n;
   private snapshotManager: ISnapshotManager;
-  logger: DebugLogger;
+  logger: Logger;
   keys: Array<[Fr, Fq]> = [];
   wallets: AccountWalletWithSecretKey[] = [];
   accounts: CompleteAddress[] = [];
@@ -93,7 +93,7 @@ export class FullProverTest {
     coinbase: EthAddress,
     private realProofs = true,
   ) {
-    this.logger = createDebugLogger(`aztec:full_prover_test:${testName}`);
+    this.logger = createLogger(`aztec:full_prover_test:${testName}`);
     this.snapshotManager = createSnapshotManager(
       `full_prover_integration/${testName}`,
       dataPath,

--- a/yarn-project/end-to-end/src/e2e_synching.test.ts
+++ b/yarn-project/end-to-end/src/e2e_synching.test.ts
@@ -39,10 +39,10 @@ import {
   AnvilTestWatcher,
   BatchCall,
   type Contract,
-  type DebugLogger,
   Fr,
   GrumpkinScalar,
-  createDebugLogger,
+  type Logger,
+  createLogger,
   sleep,
 } from '@aztec/aztec.js';
 // eslint-disable-next-line no-restricted-imports
@@ -96,7 +96,7 @@ type VariantDefinition = {
  *
  */
 class TestVariant {
-  private logger: DebugLogger = createDebugLogger(`test_variant`);
+  private logger: Logger = createLogger(`test_variant`);
   private pxe!: PXEService;
   private token!: TokenContract;
   private spam!: SpamContract;

--- a/yarn-project/end-to-end/src/e2e_token_contract/token_contract_test.ts
+++ b/yarn-project/end-to-end/src/e2e_token_contract/token_contract_test.ts
@@ -1,5 +1,5 @@
 import { getSchnorrAccount } from '@aztec/accounts/schnorr';
-import { type AccountWallet, type CompleteAddress, type DebugLogger, createDebugLogger } from '@aztec/aztec.js';
+import { type AccountWallet, type CompleteAddress, type Logger, createLogger } from '@aztec/aztec.js';
 import { DocsExampleContract, TokenContract } from '@aztec/noir-contracts.js';
 
 import { jest } from '@jest/globals';
@@ -21,7 +21,7 @@ export class TokenContractTest {
   static TOKEN_SYMBOL = 'USD';
   static TOKEN_DECIMALS = 18n;
   private snapshotManager: ISnapshotManager;
-  logger: DebugLogger;
+  logger: Logger;
   wallets: AccountWallet[] = [];
   accounts: CompleteAddress[] = [];
   asset!: TokenContract;
@@ -29,7 +29,7 @@ export class TokenContractTest {
   badAccount!: DocsExampleContract;
 
   constructor(testName: string) {
-    this.logger = createDebugLogger(`aztec:e2e_token_contract:${testName}`);
+    this.logger = createLogger(`aztec:e2e_token_contract:${testName}`);
     this.snapshotManager = createSnapshotManager(`e2e_token_contract/${testName}`, dataPath, {
       metricsPort: metricsPort ? parseInt(metricsPort) : undefined,
     });

--- a/yarn-project/end-to-end/src/e2e_token_contract/token_contract_test.ts
+++ b/yarn-project/end-to-end/src/e2e_token_contract/token_contract_test.ts
@@ -29,7 +29,7 @@ export class TokenContractTest {
   badAccount!: DocsExampleContract;
 
   constructor(testName: string) {
-    this.logger = createLogger(`aztec:e2e_token_contract:${testName}`);
+    this.logger = createLogger(`e2e:e2e_token_contract:${testName}`);
     this.snapshotManager = createSnapshotManager(`e2e_token_contract/${testName}`, dataPath, {
       metricsPort: metricsPort ? parseInt(metricsPort) : undefined,
     });

--- a/yarn-project/end-to-end/src/fixtures/get_acvm_config.ts
+++ b/yarn-project/end-to-end/src/fixtures/get_acvm_config.ts
@@ -1,4 +1,4 @@
-import { type DebugLogger } from '@aztec/aztec.js';
+import { type Logger } from '@aztec/aztec.js';
 import { randomBytes } from '@aztec/foundation/crypto';
 
 import { promises as fs } from 'fs';
@@ -14,7 +14,7 @@ const {
 } = process.env;
 
 // Determines if we have access to the acvm binary and a tmp folder for temp files
-export async function getACVMConfig(logger: DebugLogger): Promise<
+export async function getACVMConfig(logger: Logger): Promise<
   | {
       acvmWorkingDirectory: string;
       acvmBinaryPath: string;

--- a/yarn-project/end-to-end/src/fixtures/get_bb_config.ts
+++ b/yarn-project/end-to-end/src/fixtures/get_bb_config.ts
@@ -1,4 +1,4 @@
-import { type DebugLogger, fileURLToPath } from '@aztec/aztec.js';
+import { type Logger, fileURLToPath } from '@aztec/aztec.js';
 import { type BBConfig } from '@aztec/bb-prover';
 
 import fs from 'node:fs/promises';
@@ -14,7 +14,7 @@ const {
 } = process.env;
 
 export const getBBConfig = async (
-  logger: DebugLogger,
+  logger: Logger,
 ): Promise<(BBConfig & { cleanup: () => Promise<void> }) | undefined> => {
   try {
     const bbBinaryPath =

--- a/yarn-project/end-to-end/src/fixtures/setup_l1_contracts.test.ts
+++ b/yarn-project/end-to-end/src/fixtures/setup_l1_contracts.test.ts
@@ -13,7 +13,7 @@ describe('deploy_l1_contracts', () => {
   let logger: Logger;
 
   beforeAll(async () => {
-    logger = createLogger('setup_l1_contracts');
+    logger = createLogger('e2e:setup_l1_contracts');
     privateKey = privateKeyToAccount('0x8b3a350cf5c34c9194ca85829a2df0ec3153be0318b5e2d3348e872092edffba');
 
     ({ anvil, rpcUrl } = await startAnvil());

--- a/yarn-project/end-to-end/src/fixtures/setup_l1_contracts.test.ts
+++ b/yarn-project/end-to-end/src/fixtures/setup_l1_contracts.test.ts
@@ -1,4 +1,4 @@
-import { type DebugLogger, createDebugLogger } from '@aztec/foundation/log';
+import { type Logger, createLogger } from '@aztec/foundation/log';
 
 import { type Anvil } from '@viem/anvil';
 import { type PrivateKeyAccount } from 'viem';
@@ -10,10 +10,10 @@ describe('deploy_l1_contracts', () => {
   let anvil: Anvil;
   let rpcUrl: string;
   let privateKey: PrivateKeyAccount;
-  let logger: DebugLogger;
+  let logger: Logger;
 
   beforeAll(async () => {
-    logger = createDebugLogger('aztec:setup_l1_contracts');
+    logger = createLogger('setup_l1_contracts');
     privateKey = privateKeyToAccount('0x8b3a350cf5c34c9194ca85829a2df0ec3153be0318b5e2d3348e872092edffba');
 
     ({ anvil, rpcUrl } = await startAnvil());

--- a/yarn-project/end-to-end/src/fixtures/setup_l1_contracts.ts
+++ b/yarn-project/end-to-end/src/fixtures/setup_l1_contracts.ts
@@ -1,4 +1,4 @@
-import { type DebugLogger, deployL1Contracts } from '@aztec/aztec.js';
+import { type Logger, deployL1Contracts } from '@aztec/aztec.js';
 import { type DeployL1ContractsArgs, type L1ContractsConfig } from '@aztec/ethereum';
 import { getVKTreeRoot } from '@aztec/noir-protocol-circuits-types';
 import { ProtocolContractAddress, protocolContractTreeRoot } from '@aztec/protocol-contracts';
@@ -11,7 +11,7 @@ export { deployAndInitializeTokenAndBridgeContracts } from '../shared/cross_chai
 export const setupL1Contracts = async (
   l1RpcUrl: string,
   account: HDAccount | PrivateKeyAccount,
-  logger: DebugLogger,
+  logger: Logger,
   args: Pick<DeployL1ContractsArgs, 'assumeProvenThrough' | 'initialValidators'> & L1ContractsConfig,
 ) => {
   const l1Data = await deployL1Contracts(l1RpcUrl, account, foundry, logger, {

--- a/yarn-project/end-to-end/src/fixtures/setup_p2p_test.ts
+++ b/yarn-project/end-to-end/src/fixtures/setup_p2p_test.ts
@@ -67,7 +67,7 @@ export async function createNode(
 
   return await AztecNodeService.createAndSync(validatorConfig, {
     telemetry: telemetryClient,
-    logger: createLogger(`aztec:node-${tcpPort}`),
+    logger: createLogger(`node:${tcpPort}`),
   });
 }
 

--- a/yarn-project/end-to-end/src/fixtures/setup_p2p_test.ts
+++ b/yarn-project/end-to-end/src/fixtures/setup_p2p_test.ts
@@ -2,7 +2,7 @@
  * Test fixtures and utilities to set up and run a test using multiple validators
  */
 import { type AztecNodeConfig, AztecNodeService } from '@aztec/aztec-node';
-import { type SentTx, createDebugLogger } from '@aztec/aztec.js';
+import { type SentTx, createLogger } from '@aztec/aztec.js';
 import { type AztecAddress } from '@aztec/circuits.js';
 import { type PXEService } from '@aztec/pxe';
 
@@ -67,7 +67,7 @@ export async function createNode(
 
   return await AztecNodeService.createAndSync(validatorConfig, {
     telemetry: telemetryClient,
-    logger: createDebugLogger(`aztec:node-${tcpPort}`),
+    logger: createLogger(`aztec:node-${tcpPort}`),
   });
 }
 

--- a/yarn-project/end-to-end/src/fixtures/snapshot_manager.ts
+++ b/yarn-project/end-to-end/src/fixtures/snapshot_manager.ts
@@ -96,7 +96,7 @@ class MockSnapshotManager implements ISnapshotManager {
     private config: Partial<AztecNodeConfig> = {},
     private deployL1ContractsArgs: Partial<DeployL1ContractsArgs> = { assumeProvenThrough: Number.MAX_SAFE_INTEGER },
   ) {
-    this.logger = createLogger(`aztec:snapshot_manager:${testName}`);
+    this.logger = createLogger(`e2e:snapshot_manager:${testName}`);
     this.logger.warn(`No data path given, will not persist any snapshots.`);
   }
 
@@ -145,7 +145,7 @@ class SnapshotManager implements ISnapshotManager {
     private deployL1ContractsArgs: Partial<DeployL1ContractsArgs> = { assumeProvenThrough: Number.MAX_SAFE_INTEGER },
   ) {
     this.livePath = join(this.dataPath, 'live', testName);
-    this.logger = createLogger(`aztec:snapshot_manager:${testName}`);
+    this.logger = createLogger(`e2e:snapshot_manager:${testName}`);
   }
 
   public async snapshot<T>(

--- a/yarn-project/end-to-end/src/fixtures/snapshot_manager.ts
+++ b/yarn-project/end-to-end/src/fixtures/snapshot_manager.ts
@@ -6,11 +6,11 @@ import {
   BatchCall,
   CheatCodes,
   type CompleteAddress,
-  type DebugLogger,
   type DeployL1Contracts,
   EthCheatCodes,
   Fr,
   GrumpkinScalar,
+  type Logger,
   type PXE,
   type Wallet,
 } from '@aztec/aztec.js';
@@ -18,7 +18,7 @@ import { deployInstance, registerContractClass } from '@aztec/aztec.js/deploymen
 import { type DeployL1ContractsArgs, createL1Clients, getL1ContractsConfigEnvVars, l1Artifacts } from '@aztec/ethereum';
 import { startAnvil } from '@aztec/ethereum/test';
 import { asyncMap } from '@aztec/foundation/async-map';
-import { type Logger, createDebugLogger } from '@aztec/foundation/log';
+import { createLogger } from '@aztec/foundation/log';
 import { resolver, reviver } from '@aztec/foundation/serialize';
 import { type ProverNode } from '@aztec/prover-node';
 import { type PXEService, createPXEService, getPXEServiceConfig } from '@aztec/pxe';
@@ -89,14 +89,14 @@ export interface ISnapshotManager {
 /** Snapshot manager that does not perform snapshotting, it just applies transition and restoration functions as it receives them. */
 class MockSnapshotManager implements ISnapshotManager {
   private context?: SubsystemsContext;
-  private logger: DebugLogger;
+  private logger: Logger;
 
   constructor(
     testName: string,
     private config: Partial<AztecNodeConfig> = {},
     private deployL1ContractsArgs: Partial<DeployL1ContractsArgs> = { assumeProvenThrough: Number.MAX_SAFE_INTEGER },
   ) {
-    this.logger = createDebugLogger(`aztec:snapshot_manager:${testName}`);
+    this.logger = createLogger(`aztec:snapshot_manager:${testName}`);
     this.logger.warn(`No data path given, will not persist any snapshots.`);
   }
 
@@ -136,7 +136,7 @@ class SnapshotManager implements ISnapshotManager {
   private snapshotStack: SnapshotEntry[] = [];
   private context?: SubsystemsContext;
   private livePath: string;
-  private logger: DebugLogger;
+  private logger: Logger;
 
   constructor(
     testName: string,
@@ -145,7 +145,7 @@ class SnapshotManager implements ISnapshotManager {
     private deployL1ContractsArgs: Partial<DeployL1ContractsArgs> = { assumeProvenThrough: Number.MAX_SAFE_INTEGER },
   ) {
     this.livePath = join(this.dataPath, 'live', testName);
-    this.logger = createDebugLogger(`aztec:snapshot_manager:${testName}`);
+    this.logger = createLogger(`aztec:snapshot_manager:${testName}`);
   }
 
   public async snapshot<T>(
@@ -482,7 +482,7 @@ async function setupFromState(statePath: string, logger: Logger): Promise<Subsys
  * The 'restore' function is not provided, as it must be a closure within the test context to capture the results.
  */
 export const addAccounts =
-  (numberOfAccounts: number, logger: DebugLogger, waitUntilProven = false) =>
+  (numberOfAccounts: number, logger: Logger, waitUntilProven = false) =>
   async ({ pxe }: { pxe: PXE }) => {
     // Generate account keys.
     const accountKeys: [Fr, GrumpkinScalar][] = Array.from({ length: numberOfAccounts }).map(_ => [

--- a/yarn-project/end-to-end/src/fixtures/token_utils.ts
+++ b/yarn-project/end-to-end/src/fixtures/token_utils.ts
@@ -1,8 +1,8 @@
 // docs:start:token_utils
-import { type AztecAddress, type DebugLogger, type Wallet } from '@aztec/aztec.js';
+import { type AztecAddress, type Logger, type Wallet } from '@aztec/aztec.js';
 import { TokenContract } from '@aztec/noir-contracts.js';
 
-export async function deployToken(adminWallet: Wallet, initialAdminBalance: bigint, logger: DebugLogger) {
+export async function deployToken(adminWallet: Wallet, initialAdminBalance: bigint, logger: Logger) {
   logger.info(`Deploying Token contract...`);
   const contract = await TokenContract.deploy(adminWallet, adminWallet.getAddress(), 'TokenName', 'TokenSymbol', 18)
     .send()
@@ -35,7 +35,7 @@ export async function expectTokenBalance(
   token: TokenContract,
   owner: AztecAddress,
   expectedBalance: bigint,
-  logger: DebugLogger,
+  logger: Logger,
 ) {
   // Then check the balance
   const contractWithWallet = await TokenContract.at(token.address, wallet);

--- a/yarn-project/end-to-end/src/fixtures/utils.ts
+++ b/yarn-project/end-to-end/src/fixtures/utils.ts
@@ -10,16 +10,16 @@ import {
   BatchCall,
   CheatCodes,
   type ContractMethod,
-  type DebugLogger,
   type DeployL1Contracts,
   EthCheatCodes,
+  type Logger,
   NoFeePaymentMethod,
   type PXE,
   type SentTx,
   SignerlessWallet,
   type Wallet,
   createAztecNodeClient,
-  createDebugLogger,
+  createLogger,
   createPXEClient,
   deployL1Contracts,
   makeFetch,
@@ -95,7 +95,7 @@ export const getPrivateKeyFromIndex = (index: number): Buffer | null => {
 export const setupL1Contracts = async (
   l1RpcUrl: string,
   account: HDAccount | PrivateKeyAccount,
-  logger: DebugLogger,
+  logger: Logger,
   args: Partial<DeployL1ContractsArgs> = {},
   chain: Chain = foundry,
 ) => {
@@ -137,7 +137,7 @@ export async function setupPXEService(
   /**
    * Logger instance named as the current test.
    */
-  logger: DebugLogger;
+  logger: Logger;
   /**
    * Teardown function
    */
@@ -169,7 +169,7 @@ export async function setupPXEService(
 async function setupWithRemoteEnvironment(
   account: Account,
   config: AztecNodeConfig,
-  logger: DebugLogger,
+  logger: Logger,
   numberOfAccounts: number,
 ) {
   // we are setting up against a remote environment, l1 contracts are already deployed
@@ -276,7 +276,7 @@ export type EndToEndContext = {
   /** The wallets to be used. */
   wallets: AccountWalletWithSecretKey[];
   /** Logger instance named as the current test. */
-  logger: DebugLogger;
+  logger: Logger;
   /** The cheat codes. */
   cheatCodes: CheatCodes;
   /** The anvil test watcher (undefined if connected to remove environment) */
@@ -544,9 +544,9 @@ export function getLogger() {
   const describeBlockName = expect.getState().currentTestName?.split(' ')[0].replaceAll('/', ':');
   if (!describeBlockName) {
     const name = expect.getState().testPath?.split('/').pop()?.split('.')[0] ?? 'unknown';
-    return createDebugLogger('aztec:' + name);
+    return createLogger('' + name);
   }
-  return createDebugLogger('aztec:' + describeBlockName);
+  return createLogger('' + describeBlockName);
 }
 
 /**

--- a/yarn-project/end-to-end/src/fixtures/utils.ts
+++ b/yarn-project/end-to-end/src/fixtures/utils.ts
@@ -544,9 +544,9 @@ export function getLogger() {
   const describeBlockName = expect.getState().currentTestName?.split(' ')[0].replaceAll('/', ':');
   if (!describeBlockName) {
     const name = expect.getState().testPath?.split('/').pop()?.split('.')[0] ?? 'unknown';
-    return createLogger('' + name);
+    return createLogger('e2e:' + name);
   }
-  return createLogger('' + describeBlockName);
+  return createLogger('e2e:' + describeBlockName);
 }
 
 /**

--- a/yarn-project/end-to-end/src/prover-coordination/e2e_prover_coordination.test.ts
+++ b/yarn-project/end-to-end/src/prover-coordination/e2e_prover_coordination.test.ts
@@ -61,9 +61,9 @@ describe('e2e_prover_coordination', () => {
   let snapshotManager: ISnapshotManager;
 
   beforeEach(async () => {
-    logger = createLogger('prover_coordination:e2e_json_coordination');
+    logger = createLogger('e2e:prover_coordination');
     snapshotManager = createSnapshotManager(
-      `prover_coordination/e2e_json_coordination`,
+      `prover_coordination/e2e_prover_coordination`,
       process.env.E2E_DATA_PATH,
       { startProverNode: true },
       { assumeProvenThrough: undefined },

--- a/yarn-project/end-to-end/src/prover-coordination/e2e_prover_coordination.test.ts
+++ b/yarn-project/end-to-end/src/prover-coordination/e2e_prover_coordination.test.ts
@@ -2,11 +2,11 @@ import { getSchnorrAccount } from '@aztec/accounts/schnorr';
 import { createAccount } from '@aztec/accounts/testing';
 import {
   type AccountWalletWithSecretKey,
-  type DebugLogger,
   EpochProofQuote,
   EpochProofQuotePayload,
+  type Logger,
   TxStatus,
-  createDebugLogger,
+  createLogger,
   retryUntil,
   sleep,
 } from '@aztec/aztec.js';
@@ -57,11 +57,11 @@ describe('e2e_prover_coordination', () => {
   let proverSigner: Secp256k1Signer;
   let proverWallet: WalletClient<HttpTransport, Chain, Account>;
 
-  let logger: DebugLogger;
+  let logger: Logger;
   let snapshotManager: ISnapshotManager;
 
   beforeEach(async () => {
-    logger = createDebugLogger('aztec:prover_coordination:e2e_json_coordination');
+    logger = createLogger('prover_coordination:e2e_json_coordination');
     snapshotManager = createSnapshotManager(
       `prover_coordination/e2e_json_coordination`,
       process.env.E2E_DATA_PATH,

--- a/yarn-project/end-to-end/src/public-testnet/e2e_public_testnet_transfer.test.ts
+++ b/yarn-project/end-to-end/src/public-testnet/e2e_public_testnet_transfer.test.ts
@@ -1,5 +1,5 @@
 import { createAccounts } from '@aztec/accounts/testing';
-import { type DebugLogger, Fr, type PXE } from '@aztec/aztec.js';
+import { Fr, type Logger, type PXE } from '@aztec/aztec.js';
 import { EasyPrivateTokenContract } from '@aztec/noir-contracts.js';
 
 import { foundry, sepolia } from 'viem/chains';
@@ -16,7 +16,7 @@ describe(`deploys and transfers a private only token`, () => {
   let secretKey2: Fr;
 
   let pxe: PXE;
-  let logger: DebugLogger;
+  let logger: Logger;
   let teardown: () => Promise<void>;
 
   beforeEach(async () => {

--- a/yarn-project/end-to-end/src/quality_of_service/alert_checker.ts
+++ b/yarn-project/end-to-end/src/quality_of_service/alert_checker.ts
@@ -1,4 +1,4 @@
-import { type DebugLogger } from '@aztec/aztec.js';
+import { type Logger } from '@aztec/aztec.js';
 
 import * as fs from 'fs';
 import * as yaml from 'js-yaml';
@@ -24,9 +24,9 @@ const DEFAULT_CONFIG: AlertCheckerConfig = {
 
 export class AlertChecker {
   private config: AlertCheckerConfig;
-  private logger: DebugLogger;
+  private logger: Logger;
 
-  constructor(logger: DebugLogger, config: Partial<AlertCheckerConfig> = {}) {
+  constructor(logger: Logger, config: Partial<AlertCheckerConfig> = {}) {
     this.config = { ...DEFAULT_CONFIG, ...config };
     this.logger = logger;
   }

--- a/yarn-project/end-to-end/src/sample-dapp/index.test.mjs
+++ b/yarn-project/end-to-end/src/sample-dapp/index.test.mjs
@@ -1,5 +1,5 @@
 import { createAccount } from '@aztec/accounts/testing';
-import { createDebugLogger, createPXEClient, waitForPXE } from '@aztec/aztec.js';
+import { createLogger, createPXEClient, waitForPXE } from '@aztec/aztec.js';
 
 import { deployToken } from '../fixtures/token_utils';
 
@@ -18,7 +18,7 @@ describe('token', () => {
     recipient = await createAccount(pxe);
 
     const initialBalance = 69;
-    token = await deployToken(owner, initialBalance, createDebugLogger('sample_dapp'));
+    token = await deployToken(owner, initialBalance, createLogger('sample_dapp'));
   }, 120_000);
   // docs:end:setup
 

--- a/yarn-project/end-to-end/src/sample-dapp/index.test.mjs
+++ b/yarn-project/end-to-end/src/sample-dapp/index.test.mjs
@@ -18,7 +18,7 @@ describe('token', () => {
     recipient = await createAccount(pxe);
 
     const initialBalance = 69;
-    token = await deployToken(owner, initialBalance, createLogger('sample_dapp'));
+    token = await deployToken(owner, initialBalance, createLogger('e2e:sample_dapp'));
   }, 120_000);
   // docs:end:setup
 

--- a/yarn-project/end-to-end/src/shared/browser.ts
+++ b/yarn-project/end-to-end/src/shared/browser.ts
@@ -52,7 +52,7 @@ export const browserTestSuite = (
      */
     pxeURL: string;
   }>,
-  pageLogger: AztecJs.DebugLogger,
+  pageLogger: AztecJs.Logger,
 ) =>
   describe('e2e_aztec.js_browser', () => {
     const initialBalance = 33n;

--- a/yarn-project/end-to-end/src/shared/cross_chain_test_harness.ts
+++ b/yarn-project/end-to-end/src/shared/cross_chain_test_harness.ts
@@ -3,7 +3,6 @@ import {
   type AccountWallet,
   type AztecAddress,
   type AztecNode,
-  type DebugLogger,
   EthAddress,
   type FieldsOf,
   Fr,
@@ -11,6 +10,7 @@ import {
   L1TokenPortalManager,
   type L2AmountClaim,
   type L2AmountClaimWithRecipient,
+  type Logger,
   type PXE,
   type SiblingPath,
   type TxReceipt,
@@ -145,7 +145,7 @@ export class CrossChainTestHarness {
     publicClient: PublicClient<HttpTransport, Chain>,
     walletClient: WalletClient<HttpTransport, Chain, Account>,
     wallet: AccountWallet,
-    logger: DebugLogger,
+    logger: Logger,
     underlyingERC20Address?: EthAddress,
   ): Promise<CrossChainTestHarness> {
     const ethAccount = EthAddress.fromString((await walletClient.getAddresses())[0]);
@@ -190,7 +190,7 @@ export class CrossChainTestHarness {
     /** Private eXecution Environment (PXE). */
     public pxeService: PXE,
     /** Logger. */
-    public logger: DebugLogger,
+    public logger: Logger,
 
     /** L2 Token contract. */
     public l2Token: TokenContract,

--- a/yarn-project/end-to-end/src/shared/gas_portal_test_harness.ts
+++ b/yarn-project/end-to-end/src/shared/gas_portal_test_harness.ts
@@ -1,11 +1,11 @@
 import {
   type AztecAddress,
   type AztecNode,
-  type DebugLogger,
   EthAddress,
   L1FeeJuicePortalManager,
   type L1TokenManager,
   type L2AmountClaim,
+  type Logger,
   type PXE,
   type Wallet,
 } from '@aztec/aztec.js';
@@ -28,7 +28,7 @@ export interface FeeJuicePortalTestingHarnessFactoryConfig {
   publicClient: PublicClient<HttpTransport, Chain>;
   walletClient: WalletClient<HttpTransport, Chain, Account>;
   wallet: Wallet;
-  logger: DebugLogger;
+  logger: Logger;
   mockL1?: boolean;
 }
 
@@ -83,7 +83,7 @@ export class GasBridgingTestHarness implements IGasBridgingTestHarness {
     /** Private eXecution Environment (PXE). */
     public pxeService: PXE,
     /** Logger. */
-    public logger: DebugLogger,
+    public logger: Logger,
 
     /** L2 Token/Bridge contract. */
     public feeJuice: FeeJuiceContract,

--- a/yarn-project/end-to-end/src/shared/jest_setup.ts
+++ b/yarn-project/end-to-end/src/shared/jest_setup.ts
@@ -8,6 +8,6 @@ beforeEach(() => {
   if (!testPath || !currentTestName) {
     return;
   }
-  const logger = createLogger(`aztec:${basename(testPath).replace('.test.ts', '')}`);
+  const logger = createLogger(`e2e:${basename(testPath).replace('.test.ts', '')}`);
   logger.info(`Running test: ${currentTestName}`);
 });

--- a/yarn-project/end-to-end/src/shared/jest_setup.ts
+++ b/yarn-project/end-to-end/src/shared/jest_setup.ts
@@ -1,4 +1,4 @@
-import { createDebugLogger } from '@aztec/aztec.js';
+import { createLogger } from '@aztec/aztec.js';
 
 import { beforeEach, expect } from '@jest/globals';
 import { basename } from 'path';
@@ -8,6 +8,6 @@ beforeEach(() => {
   if (!testPath || !currentTestName) {
     return;
   }
-  const logger = createDebugLogger(`aztec:${basename(testPath).replace('.test.ts', '')}`);
+  const logger = createLogger(`aztec:${basename(testPath).replace('.test.ts', '')}`);
   logger.info(`Running test: ${currentTestName}`);
 });

--- a/yarn-project/end-to-end/src/shared/uniswap_l1_l2.ts
+++ b/yarn-project/end-to-end/src/shared/uniswap_l1_l2.ts
@@ -2,9 +2,9 @@ import {
   type AccountWallet,
   AztecAddress,
   type AztecNode,
-  type DebugLogger,
   EthAddress,
   Fr,
+  type Logger,
   type PXE,
   computeAuthWitMessageHash,
   generateClaimSecret,
@@ -48,7 +48,7 @@ export type UniswapSetupContext = {
   /** The Private eXecution Environment (PXE). */
   pxe: PXE;
   /** Logger instance named as the current test. */
-  logger: DebugLogger;
+  logger: Logger;
   /** Viem Public client instance. */
   publicClient: PublicClient<HttpTransport, Chain>;
   /** Viem Wallet Client instance. */
@@ -76,7 +76,7 @@ export const uniswapL1L2TestSuite = (
 
     let aztecNode: AztecNode;
     let pxe: PXE;
-    let logger: DebugLogger;
+    let logger: Logger;
 
     let walletClient: WalletClient<HttpTransport, Chain, Account>;
     let publicClient: PublicClient<HttpTransport, Chain>;

--- a/yarn-project/end-to-end/src/simulators/token_simulator.ts
+++ b/yarn-project/end-to-end/src/simulators/token_simulator.ts
@@ -1,5 +1,5 @@
 /* eslint-disable jsdoc/require-jsdoc */
-import { type AztecAddress, BatchCall, type DebugLogger, type Wallet } from '@aztec/aztec.js';
+import { type AztecAddress, BatchCall, type Logger, type Wallet } from '@aztec/aztec.js';
 import { type TokenContract } from '@aztec/noir-contracts.js/Token';
 
 import chunk from 'lodash.chunk';
@@ -14,7 +14,7 @@ export class TokenSimulator {
   constructor(
     protected token: TokenContract,
     protected defaultWallet: Wallet,
-    protected logger: DebugLogger,
+    protected logger: Logger,
     protected accounts: AztecAddress[],
   ) {}
 

--- a/yarn-project/end-to-end/src/spartan/4epochs.test.ts
+++ b/yarn-project/end-to-end/src/spartan/4epochs.test.ts
@@ -14,7 +14,7 @@ const config = setupEnvironment(process.env);
 describe('token transfer test', () => {
   jest.setTimeout(10 * 60 * 4000); // 40 minutes
 
-  const logger = createLogger(`aztec:spartan:4epochs`);
+  const logger = createLogger(`e2e:spartan:4epochs`);
   const l1Config = getL1ContractsConfigEnvVars();
 
   // We want plenty of minted tokens for a lot of slots that fill up multiple epochs

--- a/yarn-project/end-to-end/src/spartan/4epochs.test.ts
+++ b/yarn-project/end-to-end/src/spartan/4epochs.test.ts
@@ -1,6 +1,6 @@
 import { EthCheatCodes, readFieldCompressedString } from '@aztec/aztec.js';
 import { getL1ContractsConfigEnvVars } from '@aztec/ethereum';
-import { createDebugLogger } from '@aztec/foundation/log';
+import { createLogger } from '@aztec/foundation/log';
 import { TokenContract } from '@aztec/noir-contracts.js';
 
 import { jest } from '@jest/globals';
@@ -14,7 +14,7 @@ const config = setupEnvironment(process.env);
 describe('token transfer test', () => {
   jest.setTimeout(10 * 60 * 4000); // 40 minutes
 
-  const logger = createDebugLogger(`aztec:spartan:4epochs`);
+  const logger = createLogger(`aztec:spartan:4epochs`);
   const l1Config = getL1ContractsConfigEnvVars();
 
   // We want plenty of minted tokens for a lot of slots that fill up multiple epochs

--- a/yarn-project/end-to-end/src/spartan/gating-passive.test.ts
+++ b/yarn-project/end-to-end/src/spartan/gating-passive.test.ts
@@ -41,7 +41,7 @@ const {
   SPARTAN_DIR,
   INSTANCE_NAME,
 } = config;
-const debugLogger = createLogger('spartan-test:gating-passive');
+const debugLogger = createLogger('e2e:spartan-test:gating-passive');
 
 describe('a test that passively observes the network in the presence of network chaos', () => {
   jest.setTimeout(60 * 60 * 1000); // 60 minutes

--- a/yarn-project/end-to-end/src/spartan/gating-passive.test.ts
+++ b/yarn-project/end-to-end/src/spartan/gating-passive.test.ts
@@ -1,5 +1,5 @@
 import { EthCheatCodes, createCompatibleClient, sleep } from '@aztec/aztec.js';
-import { createDebugLogger } from '@aztec/foundation/log';
+import { createLogger } from '@aztec/foundation/log';
 
 import { expect, jest } from '@jest/globals';
 
@@ -41,7 +41,7 @@ const {
   SPARTAN_DIR,
   INSTANCE_NAME,
 } = config;
-const debugLogger = createDebugLogger('aztec:spartan-test:gating-passive');
+const debugLogger = createLogger('spartan-test:gating-passive');
 
 describe('a test that passively observes the network in the presence of network chaos', () => {
   jest.setTimeout(60 * 60 * 1000); // 60 minutes

--- a/yarn-project/end-to-end/src/spartan/proving.test.ts
+++ b/yarn-project/end-to-end/src/spartan/proving.test.ts
@@ -9,7 +9,7 @@ import { isK8sConfig, setupEnvironment, startPortForward } from './utils.js';
 jest.setTimeout(2_400_000); // 40 minutes
 
 const config = setupEnvironment(process.env);
-const debugLogger = createLogger('spartan-test:proving');
+const debugLogger = createLogger('e2e:spartan-test:proving');
 const SLEEP_MS = 1000;
 
 describe('proving test', () => {

--- a/yarn-project/end-to-end/src/spartan/proving.test.ts
+++ b/yarn-project/end-to-end/src/spartan/proving.test.ts
@@ -1,5 +1,5 @@
 import { type PXE, createCompatibleClient, sleep } from '@aztec/aztec.js';
-import { createDebugLogger } from '@aztec/foundation/log';
+import { createLogger } from '@aztec/foundation/log';
 
 import { jest } from '@jest/globals';
 import { type ChildProcess } from 'child_process';
@@ -9,7 +9,7 @@ import { isK8sConfig, setupEnvironment, startPortForward } from './utils.js';
 jest.setTimeout(2_400_000); // 40 minutes
 
 const config = setupEnvironment(process.env);
-const debugLogger = createDebugLogger('aztec:spartan-test:proving');
+const debugLogger = createLogger('spartan-test:proving');
 const SLEEP_MS = 1000;
 
 describe('proving test', () => {

--- a/yarn-project/end-to-end/src/spartan/reorg.test.ts
+++ b/yarn-project/end-to-end/src/spartan/reorg.test.ts
@@ -20,7 +20,7 @@ if (!isK8sConfig(config)) {
 }
 const { NAMESPACE, HOST_PXE_PORT, HOST_ETHEREUM_PORT, CONTAINER_PXE_PORT, CONTAINER_ETHEREUM_PORT, SPARTAN_DIR } =
   config;
-const debugLogger = createLogger('spartan-test:reorg');
+const debugLogger = createLogger('e2e:spartan-test:reorg');
 
 async function checkBalances(testWallets: TestWallets, mintAmount: bigint, totalAmountTransferred: bigint) {
   testWallets.wallets.forEach(async w => {

--- a/yarn-project/end-to-end/src/spartan/reorg.test.ts
+++ b/yarn-project/end-to-end/src/spartan/reorg.test.ts
@@ -1,5 +1,5 @@
 import { EthCheatCodes, sleep } from '@aztec/aztec.js';
-import { createDebugLogger } from '@aztec/foundation/log';
+import { createLogger } from '@aztec/foundation/log';
 
 import { expect, jest } from '@jest/globals';
 
@@ -20,7 +20,7 @@ if (!isK8sConfig(config)) {
 }
 const { NAMESPACE, HOST_PXE_PORT, HOST_ETHEREUM_PORT, CONTAINER_PXE_PORT, CONTAINER_ETHEREUM_PORT, SPARTAN_DIR } =
   config;
-const debugLogger = createDebugLogger('aztec:spartan-test:reorg');
+const debugLogger = createLogger('spartan-test:reorg');
 
 async function checkBalances(testWallets: TestWallets, mintAmount: bigint, totalAmountTransferred: bigint) {
   testWallets.wallets.forEach(async w => {

--- a/yarn-project/end-to-end/src/spartan/smoke.test.ts
+++ b/yarn-project/end-to-end/src/spartan/smoke.test.ts
@@ -1,5 +1,5 @@
 import { type PXE, createCompatibleClient } from '@aztec/aztec.js';
-import { createDebugLogger } from '@aztec/foundation/log';
+import { createLogger } from '@aztec/foundation/log';
 import { RollupAbi } from '@aztec/l1-artifacts';
 
 import { createPublicClient, getAddress, getContract, http } from 'viem';
@@ -10,7 +10,7 @@ import { isK8sConfig, runAlertCheck, setupEnvironment, startPortForward } from '
 
 const config = setupEnvironment(process.env);
 
-const debugLogger = createDebugLogger('aztec:spartan-test:smoke');
+const debugLogger = createLogger('spartan-test:smoke');
 
 // QoS alerts for when we are running in k8s
 const qosAlerts: AlertConfig[] = [

--- a/yarn-project/end-to-end/src/spartan/smoke.test.ts
+++ b/yarn-project/end-to-end/src/spartan/smoke.test.ts
@@ -10,7 +10,7 @@ import { isK8sConfig, runAlertCheck, setupEnvironment, startPortForward } from '
 
 const config = setupEnvironment(process.env);
 
-const debugLogger = createLogger('spartan-test:smoke');
+const debugLogger = createLogger('e2e:spartan-test:smoke');
 
 // QoS alerts for when we are running in k8s
 const qosAlerts: AlertConfig[] = [

--- a/yarn-project/end-to-end/src/spartan/transfer.test.ts
+++ b/yarn-project/end-to-end/src/spartan/transfer.test.ts
@@ -1,5 +1,5 @@
 import { readFieldCompressedString } from '@aztec/aztec.js';
-import { createDebugLogger } from '@aztec/foundation/log';
+import { createLogger } from '@aztec/foundation/log';
 import { TokenContract } from '@aztec/noir-contracts.js';
 
 import { jest } from '@jest/globals';
@@ -12,7 +12,7 @@ const config = setupEnvironment(process.env);
 describe('token transfer test', () => {
   jest.setTimeout(10 * 60 * 2000); // 20 minutes
 
-  const logger = createDebugLogger(`aztec:spartan-test:transfer`);
+  const logger = createLogger(`aztec:spartan-test:transfer`);
   const MINT_AMOUNT = 20n;
 
   const ROUNDS = 5n;

--- a/yarn-project/end-to-end/src/spartan/transfer.test.ts
+++ b/yarn-project/end-to-end/src/spartan/transfer.test.ts
@@ -12,7 +12,7 @@ const config = setupEnvironment(process.env);
 describe('token transfer test', () => {
   jest.setTimeout(10 * 60 * 2000); // 20 minutes
 
-  const logger = createLogger(`aztec:spartan-test:transfer`);
+  const logger = createLogger(`e2e:spartan-test:transfer`);
   const MINT_AMOUNT = 20n;
 
   const ROUNDS = 5n;

--- a/yarn-project/end-to-end/src/spartan/utils.ts
+++ b/yarn-project/end-to-end/src/spartan/utils.ts
@@ -11,7 +11,7 @@ import { AlertChecker, type AlertConfig } from '../quality_of_service/alert_chec
 
 const execAsync = promisify(exec);
 
-const logger = createLogger('k8s-utils');
+const logger = createLogger('e2e:k8s-utils');
 
 const k8sLocalConfigSchema = z.object({
   INSTANCE_NAME: z.string().min(1, 'INSTANCE_NAME env variable must be set'),

--- a/yarn-project/end-to-end/src/spartan/utils.ts
+++ b/yarn-project/end-to-end/src/spartan/utils.ts
@@ -1,4 +1,4 @@
-import { createDebugLogger, sleep } from '@aztec/aztec.js';
+import { createLogger, sleep } from '@aztec/aztec.js';
 import type { Logger } from '@aztec/foundation/log';
 
 import { exec, execSync, spawn } from 'child_process';
@@ -11,7 +11,7 @@ import { AlertChecker, type AlertConfig } from '../quality_of_service/alert_chec
 
 const execAsync = promisify(exec);
 
-const logger = createDebugLogger('k8s-utils');
+const logger = createLogger('k8s-utils');
 
 const k8sLocalConfigSchema = z.object({
   INSTANCE_NAME: z.string().min(1, 'INSTANCE_NAME env variable must be set'),

--- a/yarn-project/epoch-cache/src/epoch_cache.ts
+++ b/yarn-project/epoch-cache/src/epoch_cache.ts
@@ -32,7 +32,7 @@ export class EpochCache {
   private committee: EthAddress[];
   private cachedEpoch: bigint;
   private cachedSampleSeed: bigint;
-  private readonly log: Logger = createLogger('aztec:EpochCache');
+  private readonly log: Logger = createLogger('epoch-cache');
 
   constructor(
     private rollup: RollupContract,

--- a/yarn-project/epoch-cache/src/epoch_cache.ts
+++ b/yarn-project/epoch-cache/src/epoch_cache.ts
@@ -6,7 +6,7 @@ import {
 } from '@aztec/circuit-types';
 import { RollupContract, createEthereumChain } from '@aztec/ethereum';
 import { EthAddress } from '@aztec/foundation/eth-address';
-import { type Logger, createDebugLogger } from '@aztec/foundation/log';
+import { type Logger, createLogger } from '@aztec/foundation/log';
 
 import { createPublicClient, encodeAbiParameters, http, keccak256 } from 'viem';
 
@@ -32,7 +32,7 @@ export class EpochCache {
   private committee: EthAddress[];
   private cachedEpoch: bigint;
   private cachedSampleSeed: bigint;
-  private readonly log: Logger = createDebugLogger('aztec:EpochCache');
+  private readonly log: Logger = createLogger('aztec:EpochCache');
 
   constructor(
     private rollup: RollupContract,

--- a/yarn-project/ethereum/src/deploy_l1_contracts.ts
+++ b/yarn-project/ethereum/src/deploy_l1_contracts.ts
@@ -1,7 +1,7 @@
 import { type AztecAddress } from '@aztec/foundation/aztec-address';
 import { EthAddress } from '@aztec/foundation/eth-address';
 import { type Fr } from '@aztec/foundation/fields';
-import { type DebugLogger } from '@aztec/foundation/log';
+import { type Logger } from '@aztec/foundation/log';
 import {
   CoinIssuerAbi,
   CoinIssuerBytecode,
@@ -284,7 +284,7 @@ export const deployL1Contracts = async (
   rpcUrl: string,
   account: HDAccount | PrivateKeyAccount,
   chain: Chain,
-  logger: DebugLogger,
+  logger: Logger,
   args: DeployL1ContractsArgs,
 ): Promise<DeployL1Contracts> => {
   // We are assuming that you are running this on a local anvil node which have 1s block times
@@ -576,7 +576,7 @@ class L1Deployer {
     private walletClient: WalletClient<HttpTransport, Chain, Account>,
     private publicClient: PublicClient<HttpTransport, Chain>,
     maybeSalt: number | undefined,
-    private logger: DebugLogger,
+    private logger: Logger,
   ) {
     this.salt = maybeSalt ? padHex(numberToHex(maybeSalt), { size: 32 }) : undefined;
   }
@@ -666,7 +666,7 @@ export async function deployL1Contract(
   args: readonly unknown[] = [],
   maybeSalt?: Hex,
   libraries?: Libraries,
-  logger?: DebugLogger,
+  logger?: Logger,
 ): Promise<{ address: EthAddress; txHash: Hex | undefined }> {
   let txHash: Hex | undefined = undefined;
   let resultingAddress: Hex | null | undefined = undefined;

--- a/yarn-project/ethereum/src/deploy_l1_contracts.ts
+++ b/yarn-project/ethereum/src/deploy_l1_contracts.ts
@@ -307,7 +307,7 @@ export const deployL1Contracts = async (
     logger.info(`Set block interval to ${args.ethereumSlotDuration}`);
   }
 
-  logger.info(`Deploying contracts from ${account.address.toString()}...`);
+  logger.verbose(`Deploying contracts from ${account.address.toString()}`);
 
   const walletClient = createWalletClient({ account, chain, transport: http(rpcUrl) });
   const publicClient = createPublicClient({ chain, transport: http(rpcUrl) });
@@ -366,7 +366,7 @@ export const deployL1Contracts = async (
 
   logger.verbose(`Waiting for governance contracts to be deployed`);
   await govDeployer.waitForDeployments();
-  logger.info(`All governance contracts deployed`);
+  logger.verbose(`All governance contracts deployed`);
 
   const deployer = new L1Deployer(walletClient, publicClient, args.salt, logger);
 
@@ -504,7 +504,7 @@ export const deployL1Contracts = async (
   // Set initial blocks as proven if requested
   if (args.assumeProvenThrough && args.assumeProvenThrough > 0) {
     await rollup.write.setAssumeProvenThroughBlockNumber([BigInt(args.assumeProvenThrough)], { account });
-    logger.info(`Set Rollup assumedProvenUntil to ${args.assumeProvenThrough}`);
+    logger.warn(`Set Rollup assumedProvenUntil to ${args.assumeProvenThrough}`);
   }
 
   // Inbox and Outbox are immutable and are deployed from Rollup's constructor so we just fetch them from the contract.

--- a/yarn-project/ethereum/src/eth_cheat_codes.ts
+++ b/yarn-project/ethereum/src/eth_cheat_codes.ts
@@ -1,7 +1,7 @@
 import { toBigIntBE, toHex } from '@aztec/foundation/bigint-buffer';
 import { keccak256 } from '@aztec/foundation/crypto';
 import { type EthAddress } from '@aztec/foundation/eth-address';
-import { createDebugLogger } from '@aztec/foundation/log';
+import { createLogger } from '@aztec/foundation/log';
 
 import fs from 'fs';
 import { type Hex } from 'viem';
@@ -18,7 +18,7 @@ export class EthCheatCodes {
     /**
      * The logger to use for the eth cheatcodes
      */
-    public logger = createDebugLogger('aztec:cheat_codes:eth'),
+    public logger = createLogger('cheat_codes:eth'),
   ) {}
 
   async rpcCall(method: string, params: any[]) {

--- a/yarn-project/ethereum/src/eth_cheat_codes.ts
+++ b/yarn-project/ethereum/src/eth_cheat_codes.ts
@@ -18,7 +18,7 @@ export class EthCheatCodes {
     /**
      * The logger to use for the eth cheatcodes
      */
-    public logger = createLogger('cheat_codes:eth'),
+    public logger = createLogger('ethereum:cheat_codes'),
   ) {}
 
   async rpcCall(method: string, params: any[]) {

--- a/yarn-project/ethereum/src/l1_tx_utils.test.ts
+++ b/yarn-project/ethereum/src/l1_tx_utils.test.ts
@@ -38,7 +38,7 @@ describe('GasUtils', () => {
   let anvil: Anvil;
   let cheatCodes: EthCheatCodes;
   const initialBaseFee = WEI_CONST; // 1 gwei
-  const logger = createLogger('l1_gas_test');
+  const logger = createLogger('ethereum:test:l1_gas_test');
 
   beforeAll(async () => {
     const { anvil: anvilInstance, rpcUrl } = await startAnvil(1);

--- a/yarn-project/ethereum/src/l1_tx_utils.test.ts
+++ b/yarn-project/ethereum/src/l1_tx_utils.test.ts
@@ -1,5 +1,5 @@
 import { EthAddress } from '@aztec/foundation/eth-address';
-import { createDebugLogger } from '@aztec/foundation/log';
+import { createLogger } from '@aztec/foundation/log';
 import { sleep } from '@aztec/foundation/sleep';
 
 import { type Anvil } from '@viem/anvil';
@@ -38,7 +38,7 @@ describe('GasUtils', () => {
   let anvil: Anvil;
   let cheatCodes: EthCheatCodes;
   const initialBaseFee = WEI_CONST; // 1 gwei
-  const logger = createDebugLogger('l1_gas_test');
+  const logger = createLogger('l1_gas_test');
 
   beforeAll(async () => {
     const { anvil: anvilInstance, rpcUrl } = await startAnvil(1);

--- a/yarn-project/ethereum/src/l1_tx_utils.ts
+++ b/yarn-project/ethereum/src/l1_tx_utils.ts
@@ -4,7 +4,7 @@ import {
   getDefaultConfig,
   numberConfigHelper,
 } from '@aztec/foundation/config';
-import { type DebugLogger } from '@aztec/foundation/log';
+import { type Logger } from '@aztec/foundation/log';
 import { makeBackoff, retry } from '@aztec/foundation/retry';
 import { sleep } from '@aztec/foundation/sleep';
 
@@ -140,7 +140,7 @@ export class L1TxUtils {
   constructor(
     private readonly publicClient: PublicClient,
     private readonly walletClient: WalletClient<HttpTransport, Chain, Account>,
-    private readonly logger?: DebugLogger,
+    private readonly logger?: Logger,
     config?: Partial<L1TxUtilsConfig>,
   ) {
     this.config = {

--- a/yarn-project/ethereum/src/l1_tx_utils.ts
+++ b/yarn-project/ethereum/src/l1_tx_utils.ts
@@ -178,9 +178,11 @@ export class L1TxUtils {
       maxPriorityFeePerGas: gasPrice.maxPriorityFeePerGas,
     });
 
-    this.logger?.verbose(
-      `Sent L1 transaction ${txHash} with gas limit ${gasLimit} and price ${formatGwei(gasPrice.maxFeePerGas)} gwei`,
-    );
+    this.logger?.verbose(`Sent L1 transaction ${txHash}`, {
+      gasLimit,
+      maxFeePerGas: formatGwei(gasPrice.maxFeePerGas),
+      maxPriorityFeePerGas: formatGwei(gasPrice.maxPriorityFeePerGas),
+    });
 
     return { txHash, gasLimit, gasPrice };
   }
@@ -230,9 +232,9 @@ export class L1TxUtils {
             try {
               const receipt = await this.publicClient.getTransactionReceipt({ hash });
               if (receipt) {
-                this.logger?.debug(`L1 Transaction ${hash} confirmed`);
+                this.logger?.debug(`L1 transaction ${hash} mined`);
                 if (receipt.status === 'reverted') {
-                  this.logger?.error(`L1 Transaction ${hash} reverted`);
+                  this.logger?.error(`L1 transaction ${hash} reverted`);
                 }
                 return receipt;
               }
@@ -255,7 +257,7 @@ export class L1TxUtils {
         const timePassed = Date.now() - lastAttemptSent;
 
         if (tx && timePassed < gasConfig.stallTimeMs!) {
-          this.logger?.debug(`L1 Transaction ${currentTxHash} pending. Time passed: ${timePassed}ms`);
+          this.logger?.debug(`L1 transaction ${currentTxHash} pending. Time passed: ${timePassed}ms.`);
 
           // Check timeout before continuing
           if (gasConfig.txTimeoutMs) {
@@ -280,7 +282,7 @@ export class L1TxUtils {
           );
 
           this.logger?.debug(
-            `L1 Transaction ${currentTxHash} appears stuck. Attempting speed-up ${attempts}/${gasConfig.maxAttempts} ` +
+            `L1 transaction ${currentTxHash} appears stuck. Attempting speed-up ${attempts}/${gasConfig.maxAttempts} ` +
               `with new priority fee ${formatGwei(newGasPrice.maxPriorityFeePerGas)} gwei`,
           );
 
@@ -308,7 +310,7 @@ export class L1TxUtils {
         txTimedOut = Date.now() - initialTxTime > gasConfig.txTimeoutMs!;
       }
     }
-    throw new Error(`L1 Transaction ${currentTxHash} timed out`);
+    throw new Error(`L1 transaction ${currentTxHash} timed out`);
   }
 
   /**
@@ -377,10 +379,12 @@ export class L1TxUtils {
     // Ensure priority fee doesn't exceed max fee
     const maxPriorityFeePerGas = priorityFee > maxFeePerGas ? maxFeePerGas : priorityFee;
 
-    this.logger?.debug(
-      `Gas price calculation (attempt ${attempt}): baseFee=${formatGwei(baseFee)}, ` +
-        `maxPriorityFee=${formatGwei(maxPriorityFeePerGas)}, maxFee=${formatGwei(maxFeePerGas)}`,
-    );
+    this.logger?.debug(`Computed gas price`, {
+      attempt,
+      baseFee: formatGwei(baseFee),
+      maxFeePerGas: formatGwei(maxFeePerGas),
+      maxPriorityFeePerGas: formatGwei(maxPriorityFeePerGas),
+    });
 
     return { maxFeePerGas, maxPriorityFeePerGas };
   }

--- a/yarn-project/ethereum/src/test/tx_delayer.test.ts
+++ b/yarn-project/ethereum/src/test/tx_delayer.test.ts
@@ -1,4 +1,4 @@
-import { type DebugLogger, createDebugLogger } from '@aztec/foundation/log';
+import { type Logger, createLogger } from '@aztec/foundation/log';
 import { TestERC20Abi, TestERC20Bytecode } from '@aztec/l1-artifacts';
 
 import { type Anvil } from '@viem/anvil';
@@ -13,7 +13,7 @@ import { type Delayer, withDelayer } from './tx_delayer.js';
 describe('tx_delayer', () => {
   let anvil: Anvil;
   let rpcUrl: string;
-  let logger: DebugLogger;
+  let logger: Logger;
   let account: PrivateKeyAccount;
   let client: ViemClient;
   let delayer: Delayer;
@@ -22,7 +22,7 @@ describe('tx_delayer', () => {
 
   beforeAll(async () => {
     ({ anvil, rpcUrl } = await startAnvil(ETHEREUM_SLOT_DURATION));
-    logger = createDebugLogger('aztec:ethereum:test:tx_delayer');
+    logger = createLogger('ethereum:test:tx_delayer');
   });
 
   beforeEach(() => {

--- a/yarn-project/ethereum/src/test/tx_delayer.ts
+++ b/yarn-project/ethereum/src/test/tx_delayer.ts
@@ -1,4 +1,4 @@
-import { type DebugLogger, createDebugLogger } from '@aztec/foundation/log';
+import { type Logger, createLogger } from '@aztec/foundation/log';
 import { retryUntil } from '@aztec/foundation/retry';
 
 import { inspect } from 'util';
@@ -12,7 +12,7 @@ import {
   walletActions,
 } from 'viem';
 
-export function waitUntilBlock<T extends Client>(client: T, blockNumber: number | bigint, logger?: DebugLogger) {
+export function waitUntilBlock<T extends Client>(client: T, blockNumber: number | bigint, logger?: Logger) {
   const publicClient =
     'getBlockNumber' in client && typeof client.getBlockNumber === 'function'
       ? (client as unknown as PublicClient)
@@ -30,7 +30,7 @@ export function waitUntilBlock<T extends Client>(client: T, blockNumber: number 
   );
 }
 
-export function waitUntilL1Timestamp<T extends Client>(client: T, timestamp: number | bigint, logger?: DebugLogger) {
+export function waitUntilL1Timestamp<T extends Client>(client: T, timestamp: number | bigint, logger?: Logger) {
   const publicClient =
     'getBlockNumber' in client && typeof client.getBlockNumber === 'function'
       ? (client as unknown as PublicClient)
@@ -94,7 +94,7 @@ export function withDelayer<T extends WalletClient>(
   client: T,
   opts: { ethereumSlotDuration: bigint | number },
 ): { client: T; delayer: Delayer } {
-  const logger = createDebugLogger('aztec:ethereum:tx_delayer');
+  const logger = createLogger('ethereum:tx_delayer');
   const delayer = new DelayerImpl(opts);
   const extended = client
     // Tweak sendRawTransaction so it uses the delay defined in the delayer.

--- a/yarn-project/ethereum/src/utils.ts
+++ b/yarn-project/ethereum/src/utils.ts
@@ -1,5 +1,5 @@
 import { type Fr } from '@aztec/foundation/fields';
-import { type DebugLogger } from '@aztec/foundation/log';
+import { type Logger } from '@aztec/foundation/log';
 
 import {
   type Abi,
@@ -27,7 +27,7 @@ export function extractEvent<
   abi: TAbi,
   eventName: TEventName,
   filter?: (log: TEventType) => boolean,
-  logger?: DebugLogger,
+  logger?: Logger,
 ): TEventType {
   const event = tryExtractEvent(logs, address, abi, eventName, filter, logger);
   if (!event) {
@@ -46,7 +46,7 @@ function tryExtractEvent<
   abi: TAbi,
   eventName: TEventName,
   filter?: (log: TEventType) => boolean,
-  logger?: DebugLogger,
+  logger?: Logger,
 ): TEventType | undefined {
   for (const log of logs) {
     if (log.address.toLowerCase() === address.toLowerCase()) {

--- a/yarn-project/foundation/src/collection/object.ts
+++ b/yarn-project/foundation/src/collection/object.ts
@@ -28,3 +28,25 @@ export function compact<T extends object>(obj: T): { [P in keyof T]+?: Exclude<T
   }
   return result;
 }
+
+/** Returns a new object by picking the given keys. */
+export function pick<T extends object, U extends keyof T>(object: T, ...props: U[]): Pick<T, U>;
+export function pick<T extends object>(object: T, ...props: string[]): Partial<T>;
+export function pick<T extends object>(object: T, ...props: string[]): Partial<T> {
+  const obj: any = {};
+  for (const prop of props) {
+    obj[prop] = (object as any)[prop];
+  }
+  return obj;
+}
+
+/** Returns a new object by omitting the given keys. */
+export function omit<T extends object, K extends keyof T>(object: T, ...props: K[]): Omit<T, K>;
+export function omit<T extends object>(object: T, ...props: string[]): Partial<T>;
+export function omit<T extends object>(object: T, ...props: string[]): Partial<T> {
+  const obj: any = { ...object };
+  for (const prop of props) {
+    delete obj[prop];
+  }
+  return obj;
+}

--- a/yarn-project/foundation/src/crypto/random/randomness_singleton.ts
+++ b/yarn-project/foundation/src/crypto/random/randomness_singleton.ts
@@ -1,4 +1,4 @@
-import { createDebugLogger } from '../../log/pino-logger.js';
+import { createLogger } from '../../log/pino-logger.js';
 
 /**
  * A number generator which is used as a source of randomness in the system. If the SEED env variable is set, the
@@ -13,10 +13,7 @@ export class RandomnessSingleton {
 
   private counter = 0;
 
-  private constructor(
-    private readonly seed?: number,
-    private readonly log = createDebugLogger('aztec:randomness_singleton'),
-  ) {
+  private constructor(private readonly seed?: number, private readonly log = createLogger('randomness_singleton')) {
     if (seed !== undefined) {
       this.log.debug(`Using pseudo-randomness with seed: ${seed}`);
       this.counter = seed;

--- a/yarn-project/foundation/src/crypto/random/randomness_singleton.ts
+++ b/yarn-project/foundation/src/crypto/random/randomness_singleton.ts
@@ -13,7 +13,10 @@ export class RandomnessSingleton {
 
   private counter = 0;
 
-  private constructor(private readonly seed?: number, private readonly log = createLogger('randomness_singleton')) {
+  private constructor(
+    private readonly seed?: number,
+    private readonly log = createLogger('foundation:randomness_singleton'),
+  ) {
     if (seed !== undefined) {
       this.log.debug(`Using pseudo-randomness with seed: ${seed}`);
       this.counter = seed;

--- a/yarn-project/foundation/src/json-rpc/client/fetch.ts
+++ b/yarn-project/foundation/src/json-rpc/client/fetch.ts
@@ -1,10 +1,10 @@
 import { format, inspect } from 'util';
 
-import { type DebugLogger, createDebugLogger } from '../../log/index.js';
+import { type Logger, createLogger } from '../../log/index.js';
 import { NoRetryError, makeBackoff, retry } from '../../retry/index.js';
 import { jsonStringify } from '../convert.js';
 
-const log = createDebugLogger('json-rpc:json_rpc_client');
+const log = createLogger('json-rpc:json_rpc_client');
 
 /**
  * A normal fetch function that does not retry.
@@ -73,7 +73,7 @@ export async function defaultFetch(
  * @param log - Optional logger for logging attempts.
  * @returns A fetch function.
  */
-export function makeFetch(retries: number[], defaultNoRetry: boolean, log?: DebugLogger) {
+export function makeFetch(retries: number[], defaultNoRetry: boolean, log?: Logger) {
   return async (host: string, rpcMethod: string, body: any, useApiEndpoints: boolean, noRetry?: boolean) => {
     return await retry(
       () => defaultFetch(host, rpcMethod, body, useApiEndpoints, noRetry ?? defaultNoRetry),

--- a/yarn-project/foundation/src/json-rpc/client/safe_json_rpc_client.ts
+++ b/yarn-project/foundation/src/json-rpc/client/safe_json_rpc_client.ts
@@ -1,6 +1,6 @@
 import { format } from 'util';
 
-import { createDebugLogger } from '../../log/pino-logger.js';
+import { createLogger } from '../../log/pino-logger.js';
 import { type ApiSchema, type ApiSchemaFor, schemaHasMethod } from '../../schemas/api.js';
 import { defaultFetch } from './fetch.js';
 
@@ -19,7 +19,7 @@ export function createSafeJsonRpcClient<T extends object>(
   useApiEndpoints: boolean = false,
   namespaceMethods?: string | false,
   fetch = defaultFetch,
-  log = createDebugLogger('json-rpc:client'),
+  log = createLogger('json-rpc:client'),
 ): T {
   let id = 0;
   const request = async (methodName: string, params: any[]): Promise<any> => {

--- a/yarn-project/foundation/src/json-rpc/server/safe_json_rpc_server.ts
+++ b/yarn-project/foundation/src/json-rpc/server/safe_json_rpc_server.ts
@@ -8,7 +8,7 @@ import { type AddressInfo } from 'net';
 import { format, inspect } from 'util';
 import { ZodError } from 'zod';
 
-import { type DebugLogger, createDebugLogger } from '../../log/index.js';
+import { type Logger, createLogger } from '../../log/index.js';
 import { promiseWithResolvers } from '../../promise/utils.js';
 import { type ApiSchema, type ApiSchemaFor, parseWithOptionals, schemaHasMethod } from '../../schemas/index.js';
 import { jsonStringify } from '../convert.js';
@@ -27,7 +27,7 @@ export class SafeJsonRpcServer {
     /** Health check function */
     private readonly healthCheck: StatusCheckFn = () => true,
     /** Logger */
-    private log = createDebugLogger('json-rpc:server'),
+    private log = createLogger('json-rpc:server'),
   ) {}
 
   public isHealthy(): boolean | Promise<boolean> {
@@ -170,7 +170,7 @@ interface Proxy {
  * before forwarding calls, and then converts outputs into JSON using default conversions.
  */
 export class SafeJsonProxy<T extends object = any> implements Proxy {
-  private log = createDebugLogger('json-rpc:proxy');
+  private log = createLogger('json-rpc:proxy');
   private schema: ApiSchema;
 
   constructor(private handler: T, schema: ApiSchemaFor<T>) {
@@ -233,7 +233,7 @@ export function makeHandler<T extends object>(handler: T, schema: ApiSchemaFor<T
   return [handler, schema];
 }
 
-function makeAggregateHealthcheck(namedHandlers: NamespacedApiHandlers, log?: DebugLogger): StatusCheckFn {
+function makeAggregateHealthcheck(namedHandlers: NamespacedApiHandlers, log?: Logger): StatusCheckFn {
   return async () => {
     try {
       const results = await Promise.all(
@@ -259,7 +259,7 @@ function makeAggregateHealthcheck(namedHandlers: NamespacedApiHandlers, log?: De
  */
 export function createNamespacedSafeJsonRpcServer(
   handlers: NamespacedApiHandlers,
-  log = createDebugLogger('json-rpc:server'),
+  log = createLogger('json-rpc:server'),
 ): SafeJsonRpcServer {
   const proxy = new NamespacedSafeJsonProxy(handlers);
   const healthCheck = makeAggregateHealthcheck(handlers, log);

--- a/yarn-project/foundation/src/log/log-filters.ts
+++ b/yarn-project/foundation/src/log/log-filters.ts
@@ -42,7 +42,13 @@ export function parseFilters(definition: string | undefined): LogFilters {
     const sanitizedLevel = level.trim().toLowerCase();
     assertLogLevel(sanitizedLevel);
     for (const module of modules.split(',')) {
-      filters.push([module.trim().toLowerCase(), sanitizedLevel as LogLevel | 'silent']);
+      filters.push([
+        module
+          .trim()
+          .toLowerCase()
+          .replace(/^aztec:/, ''),
+        sanitizedLevel as LogLevel | 'silent',
+      ]);
     }
   }
   return filters.reverse();

--- a/yarn-project/foundation/src/log/log_fn.ts
+++ b/yarn-project/foundation/src/log/log_fn.ts
@@ -2,4 +2,4 @@
 export type LogData = Record<string, string | number | bigint | boolean | { toString(): string } | undefined>;
 
 /** A callable logger instance. */
-export type LogFn = (msg: string, data?: LogData) => void;
+export type LogFn = (msg: string, data?: unknown) => void;

--- a/yarn-project/foundation/src/log/pino-logger.ts
+++ b/yarn-project/foundation/src/log/pino-logger.ts
@@ -11,11 +11,8 @@ import { type LogLevel } from './log-levels.js';
 import { type LogData, type LogFn } from './log_fn.js';
 
 export function createLogger(module: string): Logger {
-  // TODO(palla/log): Rename all module names to remove the aztec prefix
-  const pinoLogger = logger.child(
-    { module: module.replace(/^aztec:/, '') },
-    { level: getLogLevelFromFilters(logFilters, module) },
-  );
+  module = module.replace(/^aztec:/, '');
+  const pinoLogger = logger.child({ module }, { level: getLogLevelFromFilters(logFilters, module) });
 
   // We check manually for isLevelEnabled to avoid calling processLogData unnecessarily.
   // Note that isLevelEnabled is missing from the browser version of pino.

--- a/yarn-project/foundation/src/log/pino-logger.ts
+++ b/yarn-project/foundation/src/log/pino-logger.ts
@@ -10,8 +10,7 @@ import { getLogLevelFromFilters, parseEnv } from './log-filters.js';
 import { type LogLevel } from './log-levels.js';
 import { type LogData, type LogFn } from './log_fn.js';
 
-// TODO(palla/log): Rename to createLogger
-export function createDebugLogger(module: string): DebugLogger {
+export function createLogger(module: string): Logger {
   // TODO(palla/log): Rename all module names to remove the aztec prefix
   const pinoLogger = logger.child(
     { module: module.replace(/^aztec:/, '') },
@@ -177,13 +176,6 @@ export type Logger = { [K in LogLevel]: LogFn } & { /** Error log function */ er
   level: LogLevel;
   isLevelEnabled: (level: LogLevel) => boolean;
 };
-
-/**
- * Logger that supports multiple severity levels and can be called directly to issue a debug statement.
- * Intended as a drop-in replacement for the debug module.
- * TODO(palla/log): Remove this alias
- */
-export type DebugLogger = Logger;
 
 /**
  * Concatenates a log message and an exception.

--- a/yarn-project/foundation/src/log/pino-logger.ts
+++ b/yarn-project/foundation/src/log/pino-logger.ts
@@ -19,26 +19,26 @@ export function createLogger(module: string): Logger {
 
   // We check manually for isLevelEnabled to avoid calling processLogData unnecessarily.
   // Note that isLevelEnabled is missing from the browser version of pino.
-  const logFn = (level: LogLevel, msg: string, data?: LogData) =>
-    isLevelEnabled(pinoLogger, level) && pinoLogger[level](processLogData(data ?? {}), msg);
+  const logFn = (level: LogLevel, msg: string, data?: unknown) =>
+    isLevelEnabled(pinoLogger, level) && pinoLogger[level](processLogData((data as LogData) ?? {}), msg);
 
   return {
     silent: () => {},
     // TODO(palla/log): Should we move err to data instead of the text message?
     /** Log as fatal. Use when an error has brought down the system. */
-    fatal: (msg: string, err?: unknown, data?: LogData) => logFn('fatal', formatErr(msg, err), data),
+    fatal: (msg: string, err?: unknown, data?: unknown) => logFn('fatal', formatErr(msg, err), data),
     /** Log as error. Use for errors in general. */
-    error: (msg: string, err?: unknown, data?: LogData) => logFn('error', formatErr(msg, err), data),
+    error: (msg: string, err?: unknown, data?: unknown) => logFn('error', formatErr(msg, err), data),
     /** Log as warn. Use for when we stray from the happy path. */
-    warn: (msg: string, data?: LogData) => logFn('warn', msg, data),
+    warn: (msg: string, data?: unknown) => logFn('warn', msg, data),
     /** Log as info. Use for providing an operator with info on what the system is doing. */
-    info: (msg: string, data?: LogData) => logFn('info', msg, data),
+    info: (msg: string, data?: unknown) => logFn('info', msg, data),
     /** Log as verbose. Use for when we need additional insight on what a subsystem is doing. */
-    verbose: (msg: string, data?: LogData) => logFn('verbose', msg, data),
+    verbose: (msg: string, data?: unknown) => logFn('verbose', msg, data),
     /** Log as debug. Use for when we need debugging info to troubleshoot an issue on a specific component. */
-    debug: (msg: string, data?: LogData) => logFn('debug', msg, data),
+    debug: (msg: string, data?: unknown) => logFn('debug', msg, data),
     /** Log as trace. Use for when we want to denial-of-service any recipient of the logs. */
-    trace: (msg: string, data?: LogData) => logFn('trace', msg, data),
+    trace: (msg: string, data?: unknown) => logFn('trace', msg, data),
     level: pinoLogger.level as LogLevel,
     isLevelEnabled: (level: LogLevel) => isLevelEnabled(pinoLogger, level),
   };

--- a/yarn-project/foundation/src/queue/base_memory_queue.ts
+++ b/yarn-project/foundation/src/queue/base_memory_queue.ts
@@ -1,11 +1,11 @@
 import { TimeoutError } from '../error/index.js';
-import { createDebugLogger } from '../log/index.js';
+import { createLogger } from '../log/index.js';
 
 export abstract class BaseMemoryQueue<T> {
   private waiting: ((item: T | null) => void)[] = [];
   private flushing = false;
 
-  constructor(private log = createDebugLogger('aztec:foundation:memory_fifo')) {}
+  constructor(private log = createLogger('foundation:memory_fifo')) {}
 
   protected abstract get items(): {
     length: number;

--- a/yarn-project/foundation/src/queue/bounded_serial_queue.ts
+++ b/yarn-project/foundation/src/queue/bounded_serial_queue.ts
@@ -1,4 +1,4 @@
-import { createDebugLogger } from '../log/index.js';
+import { createLogger } from '../log/index.js';
 import { Semaphore } from './semaphore.js';
 import { SerialQueue } from './serial_queue.js';
 
@@ -10,7 +10,7 @@ export class BoundedSerialQueue {
   private readonly queue = new SerialQueue();
   private semaphore: Semaphore;
 
-  constructor(maxQueueSize: number, private log = createDebugLogger('aztec:foundation:bounded_serial_queue')) {
+  constructor(maxQueueSize: number, private log = createLogger('foundation:bounded_serial_queue')) {
     this.semaphore = new Semaphore(maxQueueSize);
   }
 

--- a/yarn-project/foundation/src/queue/fifo_memory_queue.ts
+++ b/yarn-project/foundation/src/queue/fifo_memory_queue.ts
@@ -1,4 +1,4 @@
-import { type DebugLogger } from '../log/index.js';
+import { type Logger } from '../log/index.js';
 import { BaseMemoryQueue } from './base_memory_queue.js';
 
 /**
@@ -9,7 +9,7 @@ import { BaseMemoryQueue } from './base_memory_queue.js';
 export class FifoMemoryQueue<T> extends BaseMemoryQueue<T> {
   private container = new FifoQueue<T>();
 
-  constructor(log?: DebugLogger) {
+  constructor(log?: Logger) {
     super(log);
   }
 

--- a/yarn-project/foundation/src/retry/index.ts
+++ b/yarn-project/foundation/src/retry/index.ts
@@ -1,4 +1,4 @@
-import { createDebugLogger } from '../log/index.js';
+import { createLogger } from '../log/index.js';
 import { sleep } from '../sleep/index.js';
 import { Timer } from '../timer/index.js';
 
@@ -48,7 +48,7 @@ export async function retry<Result>(
   fn: () => Promise<Result>,
   name = 'Operation',
   backoff = backoffGenerator(),
-  log = createDebugLogger('aztec:foundation:retry'),
+  log = createLogger('foundation:retry'),
   failSilently = false,
 ) {
   while (true) {

--- a/yarn-project/foundation/src/schemas/utils.ts
+++ b/yarn-project/foundation/src/schemas/utils.ts
@@ -3,13 +3,16 @@ import {
   type ParseInput,
   type ParseReturnType,
   ZodFirstPartyTypeKind,
+  type ZodObject,
   ZodOptional,
   ZodParsedType,
+  type ZodRawShape,
   type ZodType,
   type ZodTypeAny,
   z,
 } from 'zod';
 
+import { pick } from '../collection/object.js';
 import { isHex, withoutHexPrefix } from '../string/index.js';
 import { type ZodFor } from './types.js';
 
@@ -101,4 +104,9 @@ export function mapSchema<TKey, TValue>(key: ZodFor<TKey>, value: ZodFor<TValue>
 /** Creates a schema for a js Set type that matches the serialization used in jsonStringify. */
 export function setSchema<T>(value: ZodFor<T>): ZodFor<Set<T>> {
   return z.array(value).transform(entries => new Set(entries));
+}
+
+/** Given an already parsed and validated object, extracts the keys defined in the given schema. Does not validate again. */
+export function pickFromSchema<T extends object, S extends ZodObject<ZodRawShape>>(obj: T, schema: S) {
+  return pick(obj, ...Object.keys(schema.shape));
 }

--- a/yarn-project/foundation/src/transport/dispatch/create_dispatch_fn.ts
+++ b/yarn-project/foundation/src/transport/dispatch/create_dispatch_fn.ts
@@ -1,6 +1,6 @@
 import { format } from 'util';
 
-import { createDebugLogger } from '../../log/index.js';
+import { createLogger } from '../../log/index.js';
 
 /**
  * Represents a message object for dispatching function calls.
@@ -26,7 +26,7 @@ export interface DispatchMsg {
  * @param log - Optional logging function for debugging purposes.
  * @returns A dispatch function that accepts a DispatchMsg object and calls the target's method with provided arguments.
  */
-export function createDispatchFn(targetFn: () => any, log = createDebugLogger('aztec:foundation:dispatch')) {
+export function createDispatchFn(targetFn: () => any, log = createLogger('foundation:dispatch')) {
   return async ({ fn, args }: DispatchMsg) => {
     const target = targetFn();
     log.debug(format(`dispatching to ${target}: ${fn}`, args));

--- a/yarn-project/foundation/src/transport/transport_client.ts
+++ b/yarn-project/foundation/src/transport/transport_client.ts
@@ -6,7 +6,7 @@ import { type EventMessage, type ResponseMessage, isEventMessage } from './dispa
 import { type Connector } from './interface/connector.js';
 import { type Socket } from './interface/socket.js';
 
-const log = createLogger('transport_client');
+const log = createLogger('foundation:transport_client');
 
 /**
  * Represents a pending request in the TransportClient.

--- a/yarn-project/foundation/src/transport/transport_client.ts
+++ b/yarn-project/foundation/src/transport/transport_client.ts
@@ -1,12 +1,12 @@
 import EventEmitter from 'events';
 import { format } from 'util';
 
-import { createDebugLogger } from '../log/index.js';
+import { createLogger } from '../log/index.js';
 import { type EventMessage, type ResponseMessage, isEventMessage } from './dispatch/messages.js';
 import { type Connector } from './interface/connector.js';
 import { type Socket } from './interface/socket.js';
 
-const log = createDebugLogger('aztec:transport_client');
+const log = createLogger('transport_client');
 
 /**
  * Represents a pending request in the TransportClient.

--- a/yarn-project/foundation/src/wasm/wasm_module.ts
+++ b/yarn-project/foundation/src/wasm/wasm_module.ts
@@ -59,7 +59,7 @@ export class WasmModule implements IWasmModule {
   constructor(
     private module: WebAssembly.Module | Buffer,
     private importFn: (module: WasmModule) => any,
-    loggerName = 'aztec:wasm',
+    loggerName = 'wasm',
   ) {
     this.debug = createDebugOnlyLogger(loggerName);
     this.mutexQ.put(true);

--- a/yarn-project/foundation/src/worker/worker_pool.ts
+++ b/yarn-project/foundation/src/worker/worker_pool.ts
@@ -1,7 +1,7 @@
-import { createDebugLogger } from '../log/index.js';
+import { createLogger } from '../log/index.js';
 import { type WasmWorker } from './wasm_worker.js';
 
-const log = createDebugLogger('bb:worker_pool');
+const log = createLogger('bb:worker_pool');
 
 /**
  * Type of a worker factory.

--- a/yarn-project/foundation/src/worker/worker_pool.ts
+++ b/yarn-project/foundation/src/worker/worker_pool.ts
@@ -1,7 +1,7 @@
 import { createLogger } from '../log/index.js';
 import { type WasmWorker } from './wasm_worker.js';
 
-const log = createLogger('bb:worker_pool');
+const log = createLogger('foundation:worker_pool');
 
 /**
  * Type of a worker factory.

--- a/yarn-project/ivc-integration/src/avm_integration.test.ts
+++ b/yarn-project/ivc-integration/src/avm_integration.test.ts
@@ -22,7 +22,7 @@ import { MockPublicBaseCircuit, witnessGenMockPublicBaseCircuit } from './index.
 
 // Auto-generated types from noir are not in camel case.
 /* eslint-disable camelcase */
-const logger = createLogger('avm-integration');
+const logger = createLogger('ivc-integration:test:avm-integration');
 
 describe('AVM Integration', () => {
   let bbWorkingDirectory: string;
@@ -122,7 +122,7 @@ describe('AVM Integration', () => {
 async function proveAvmTestContract(functionName: string, calldata: Fr[] = []): Promise<BBSuccess> {
   const avmCircuitInputs = await simulateAvmTestContractGenerateCircuitInputs(functionName, calldata);
 
-  const internalLogger = createLogger('avm-proving-test');
+  const internalLogger = createLogger('ivc-integration:test:avm-proving');
 
   // The paths for the barretenberg binary and the write path are hardcoded for now.
   const bbPath = path.resolve('../../barretenberg/cpp/build/bin/bb');

--- a/yarn-project/ivc-integration/src/avm_integration.test.ts
+++ b/yarn-project/ivc-integration/src/avm_integration.test.ts
@@ -7,7 +7,7 @@ import {
   PUBLIC_CIRCUIT_PUBLIC_INPUTS_LENGTH,
 } from '@aztec/circuits.js/constants';
 import { Fr } from '@aztec/foundation/fields';
-import { createDebugLogger } from '@aztec/foundation/log';
+import { createLogger } from '@aztec/foundation/log';
 import { BufferReader } from '@aztec/foundation/serialize';
 import { type FixedLengthArray } from '@aztec/noir-protocol-circuits-types/types';
 import { simulateAvmTestContractGenerateCircuitInputs } from '@aztec/simulator/public/fixtures';
@@ -22,7 +22,7 @@ import { MockPublicBaseCircuit, witnessGenMockPublicBaseCircuit } from './index.
 
 // Auto-generated types from noir are not in camel case.
 /* eslint-disable camelcase */
-const logger = createDebugLogger('aztec:avm-integration');
+const logger = createLogger('avm-integration');
 
 describe('AVM Integration', () => {
   let bbWorkingDirectory: string;
@@ -122,7 +122,7 @@ describe('AVM Integration', () => {
 async function proveAvmTestContract(functionName: string, calldata: Fr[] = []): Promise<BBSuccess> {
   const avmCircuitInputs = await simulateAvmTestContractGenerateCircuitInputs(functionName, calldata);
 
-  const internalLogger = createDebugLogger('aztec:avm-proving-test');
+  const internalLogger = createLogger('avm-proving-test');
 
   // The paths for the barretenberg binary and the write path are hardcoded for now.
   const bbPath = path.resolve('../../barretenberg/cpp/build/bin/bb');

--- a/yarn-project/ivc-integration/src/native_client_ivc_integration.test.ts
+++ b/yarn-project/ivc-integration/src/native_client_ivc_integration.test.ts
@@ -1,6 +1,6 @@
 import { BB_RESULT, executeBbClientIvcProof, verifyClientIvcProof } from '@aztec/bb-prover';
 import { ClientIvcProof } from '@aztec/circuits.js';
-import { createDebugLogger } from '@aztec/foundation/log';
+import { createLogger } from '@aztec/foundation/log';
 
 import { jest } from '@jest/globals';
 import { encode } from '@msgpack/msgpack';
@@ -13,7 +13,7 @@ import { generate3FunctionTestingIVCStack, generate6FunctionTestingIVCStack } fr
 
 /* eslint-disable camelcase */
 
-const logger = createDebugLogger('aztec:clientivc-integration');
+const logger = createLogger('clientivc-integration');
 
 jest.setTimeout(120_000);
 

--- a/yarn-project/ivc-integration/src/native_client_ivc_integration.test.ts
+++ b/yarn-project/ivc-integration/src/native_client_ivc_integration.test.ts
@@ -13,7 +13,7 @@ import { generate3FunctionTestingIVCStack, generate6FunctionTestingIVCStack } fr
 
 /* eslint-disable camelcase */
 
-const logger = createLogger('clientivc-integration');
+const logger = createLogger('ivc-integration:test:native');
 
 jest.setTimeout(120_000);
 

--- a/yarn-project/ivc-integration/src/scripts/generate_ts_from_abi.ts
+++ b/yarn-project/ivc-integration/src/scripts/generate_ts_from_abi.ts
@@ -5,7 +5,7 @@ import { type CompiledCircuit } from '@noir-lang/types';
 import { pascalCase } from 'change-case';
 import { promises as fs } from 'fs';
 
-const log = createConsoleLogger('aztec:mock-circuits');
+const log = createConsoleLogger('mock-circuits');
 
 const circuits = [
   'app_creator',

--- a/yarn-project/ivc-integration/src/wasm_client_ivc_integration.test.ts
+++ b/yarn-project/ivc-integration/src/wasm_client_ivc_integration.test.ts
@@ -1,4 +1,4 @@
-import { createDebugLogger } from '@aztec/foundation/log';
+import { createLogger } from '@aztec/foundation/log';
 
 import { jest } from '@jest/globals';
 import { ungzip } from 'pako';
@@ -27,7 +27,7 @@ import {
 
 /* eslint-disable camelcase */
 
-const logger = createDebugLogger('aztec:clientivc-integration');
+const logger = createLogger('clientivc-integration');
 
 jest.setTimeout(120_000);
 

--- a/yarn-project/ivc-integration/src/wasm_client_ivc_integration.test.ts
+++ b/yarn-project/ivc-integration/src/wasm_client_ivc_integration.test.ts
@@ -27,7 +27,7 @@ import {
 
 /* eslint-disable camelcase */
 
-const logger = createLogger('clientivc-integration');
+const logger = createLogger('ivc-integration:test:wasm');
 
 jest.setTimeout(120_000);
 

--- a/yarn-project/kv-store/src/indexeddb/index.ts
+++ b/yarn-project/kv-store/src/indexeddb/index.ts
@@ -1,4 +1,4 @@
-import { type Logger, createDebugLogger } from '@aztec/foundation/log';
+import { type Logger, createLogger } from '@aztec/foundation/log';
 
 import { type DataStoreConfig } from '../config.js';
 import { initStoreForRollup } from '../utils.js';
@@ -6,11 +6,7 @@ import { AztecIndexedDBStore } from './store.js';
 
 export { AztecIndexedDBStore } from './store.js';
 
-export async function createStore(
-  name: string,
-  config: DataStoreConfig,
-  log: Logger = createDebugLogger('aztec:kv-store'),
-) {
+export async function createStore(name: string, config: DataStoreConfig, log: Logger = createLogger('kv-store')) {
   let { dataDirectory } = config;
   if (typeof dataDirectory !== 'undefined') {
     dataDirectory = `${dataDirectory}/${name}`;
@@ -21,11 +17,7 @@ export async function createStore(
       ? `Creating ${name} data store at directory ${dataDirectory} with map size ${config.dataStoreMapSizeKB} KB`
       : `Creating ${name} ephemeral data store with map size ${config.dataStoreMapSizeKB} KB`,
   );
-  const store = await AztecIndexedDBStore.open(
-    createDebugLogger('aztec:kv-store:indexeddb'),
-    dataDirectory ?? '',
-    false,
-  );
+  const store = await AztecIndexedDBStore.open(createLogger('kv-store:indexeddb'), dataDirectory ?? '', false);
   if (config.l1Contracts?.rollupAddress) {
     return initStoreForRollup(store, config.l1Contracts.rollupAddress, log);
   }
@@ -33,5 +25,5 @@ export async function createStore(
 }
 
 export function openTmpStore(ephemeral: boolean = false): Promise<AztecIndexedDBStore> {
-  return AztecIndexedDBStore.open(createDebugLogger('aztec:kv-store:indexeddb'), undefined, ephemeral);
+  return AztecIndexedDBStore.open(createLogger('kv-store:indexeddb'), undefined, ephemeral);
 }

--- a/yarn-project/kv-store/src/lmdb/index.ts
+++ b/yarn-project/kv-store/src/lmdb/index.ts
@@ -1,4 +1,4 @@
-import { type Logger, createDebugLogger } from '@aztec/foundation/log';
+import { type Logger, createLogger } from '@aztec/foundation/log';
 
 import { join } from 'path';
 
@@ -8,7 +8,7 @@ import { AztecLmdbStore } from './store.js';
 
 export { AztecLmdbStore } from './store.js';
 
-export function createStore(name: string, config: DataStoreConfig, log: Logger = createDebugLogger('aztec:kv-store')) {
+export function createStore(name: string, config: DataStoreConfig, log: Logger = createLogger('kv-store')) {
   let { dataDirectory } = config;
   if (typeof dataDirectory !== 'undefined') {
     dataDirectory = join(dataDirectory, name);

--- a/yarn-project/kv-store/src/lmdb/store.ts
+++ b/yarn-project/kv-store/src/lmdb/store.ts
@@ -1,4 +1,4 @@
-import { createDebugLogger } from '@aztec/foundation/log';
+import { createLogger } from '@aztec/foundation/log';
 
 import { promises as fs, mkdirSync } from 'fs';
 import { type Database, type RootDatabase, open } from 'lmdb';
@@ -27,7 +27,7 @@ export class AztecLmdbStore implements AztecKVStore, AztecAsyncKVStore {
   #rootDb: RootDatabase;
   #data: Database<unknown, Key>;
   #multiMapData: Database<unknown, Key>;
-  #log = createDebugLogger('aztec:kv-store:lmdb');
+  #log = createLogger('kv-store:lmdb');
 
   constructor(rootDb: RootDatabase, public readonly isEphemeral: boolean, private path?: string) {
     this.#rootDb = rootDb;
@@ -62,7 +62,7 @@ export class AztecLmdbStore implements AztecKVStore, AztecAsyncKVStore {
     path?: string,
     mapSizeKb = 1 * 1024 * 1024, // defaults to 1 GB map size
     ephemeral: boolean = false,
-    log = createDebugLogger('aztec:kv-store:lmdb'),
+    log = createLogger('kv-store:lmdb'),
   ): AztecLmdbStore {
     if (path) {
       mkdirSync(path, { recursive: true });

--- a/yarn-project/merkle-tree/src/sparse_tree/sparse_tree.test.ts
+++ b/yarn-project/merkle-tree/src/sparse_tree/sparse_tree.test.ts
@@ -14,7 +14,7 @@ import { standardBasedTreeTestSuite } from '../test/standard_based_test_suite.js
 import { treeTestSuite } from '../test/test_suite.js';
 import { SparseTree } from './sparse_tree.js';
 
-const log = createLogger('sparse_tree_test');
+const log = createLogger('merkle-tree:test:sparse_tree');
 
 const createDb = async (
   db: AztecKVStore,

--- a/yarn-project/merkle-tree/src/sparse_tree/sparse_tree.test.ts
+++ b/yarn-project/merkle-tree/src/sparse_tree/sparse_tree.test.ts
@@ -1,7 +1,7 @@
 import { SiblingPath } from '@aztec/circuit-types';
 import { randomBigInt } from '@aztec/foundation/crypto';
 import { Fr } from '@aztec/foundation/fields';
-import { createDebugLogger } from '@aztec/foundation/log';
+import { createLogger } from '@aztec/foundation/log';
 import { type AztecKVStore } from '@aztec/kv-store';
 import { openTmpStore } from '@aztec/kv-store/lmdb';
 import { type Hasher } from '@aztec/types/interfaces';
@@ -14,7 +14,7 @@ import { standardBasedTreeTestSuite } from '../test/standard_based_test_suite.js
 import { treeTestSuite } from '../test/test_suite.js';
 import { SparseTree } from './sparse_tree.js';
 
-const log = createDebugLogger('aztec:sparse_tree_test');
+const log = createLogger('sparse_tree_test');
 
 const createDb = async (
   db: AztecKVStore,

--- a/yarn-project/merkle-tree/src/tree_base.ts
+++ b/yarn-project/merkle-tree/src/tree_base.ts
@@ -84,7 +84,7 @@ export abstract class TreeBase<T extends Bufferable> implements MerkleTree<T> {
     this.root = root ? root : current;
     this.maxIndex = 2n ** BigInt(depth) - 1n;
 
-    this.log = createLogger(`aztec:merkle-tree:${name.toLowerCase()}`);
+    this.log = createLogger(`merkle-tree:${name.toLowerCase()}`);
   }
 
   /**

--- a/yarn-project/merkle-tree/src/tree_base.ts
+++ b/yarn-project/merkle-tree/src/tree_base.ts
@@ -1,6 +1,6 @@
 import { SiblingPath } from '@aztec/circuit-types';
 import { toBigIntLE, toBufferLE } from '@aztec/foundation/bigint-buffer';
-import { type DebugLogger, createDebugLogger } from '@aztec/foundation/log';
+import { type Logger, createLogger } from '@aztec/foundation/log';
 import { type Bufferable, type FromBuffer, serializeToBuffer } from '@aztec/foundation/serialize';
 import { type AztecKVStore, type AztecMap, type AztecSingleton } from '@aztec/kv-store';
 import { type Hasher } from '@aztec/types/interfaces';
@@ -51,7 +51,7 @@ export abstract class TreeBase<T extends Bufferable> implements MerkleTree<T> {
   private root!: Buffer;
   private zeroHashes: Buffer[] = [];
   private cache: { [key: string]: Buffer } = {};
-  protected log: DebugLogger;
+  protected log: Logger;
   protected hasher: HasherWithStats;
 
   private nodes: AztecMap<string, Buffer>;
@@ -84,7 +84,7 @@ export abstract class TreeBase<T extends Bufferable> implements MerkleTree<T> {
     this.root = root ? root : current;
     this.maxIndex = 2n ** BigInt(depth) - 1n;
 
-    this.log = createDebugLogger(`aztec:merkle-tree:${name.toLowerCase()}`);
+    this.log = createLogger(`aztec:merkle-tree:${name.toLowerCase()}`);
   }
 
   /**

--- a/yarn-project/noir-protocol-circuits-types/src/index.ts
+++ b/yarn-project/noir-protocol-circuits-types/src/index.ts
@@ -23,7 +23,7 @@ import {
   type RootRollupInputs,
   type RootRollupPublicInputs,
 } from '@aztec/circuits.js';
-import { applyStringFormatting, createDebugLogger } from '@aztec/foundation/log';
+import { applyStringFormatting, createLogger } from '@aztec/foundation/log';
 
 import { type ForeignCallInput, type ForeignCallOutput } from '@noir-lang/acvm_js';
 import { type CompiledCircuit, type InputMap, Noir } from '@noir-lang/noir_js';
@@ -730,7 +730,7 @@ function fromACVMField(field: string): Fr {
 
 export function foreignCallHandler(name: string, args: ForeignCallInput[]): Promise<ForeignCallOutput[]> {
   // ForeignCallInput is actually a string[], so the args are string[][].
-  const log = createDebugLogger('aztec:noir-protocol-circuits:oracle');
+  const log = createLogger('noir-protocol-circuits:oracle');
 
   if (name === 'debugLog') {
     assert(args.length === 3, 'expected 3 arguments for debugLog: msg, fields_length, fields');

--- a/yarn-project/noir-protocol-circuits-types/src/scripts/generate_private_kernel_reset_data.ts
+++ b/yarn-project/noir-protocol-circuits-types/src/scripts/generate_private_kernel_reset_data.ts
@@ -14,7 +14,7 @@ import { createConsoleLogger } from '@aztec/foundation/log';
 
 import { promises as fs } from 'fs';
 
-const log = createConsoleLogger('aztec:autogenerate');
+const log = createConsoleLogger('autogenerate');
 
 const outputFilename = './src/private_kernel_reset_data.ts';
 

--- a/yarn-project/noir-protocol-circuits-types/src/scripts/generate_ts_from_abi.ts
+++ b/yarn-project/noir-protocol-circuits-types/src/scripts/generate_ts_from_abi.ts
@@ -5,7 +5,7 @@ import { type CompiledCircuit } from '@noir-lang/types';
 import { pascalCase } from 'change-case';
 import { promises as fs } from 'fs';
 
-const log = createConsoleLogger('aztec:autogenerate');
+const log = createConsoleLogger('autogenerate');
 
 const circuits = [
   'parity_base',

--- a/yarn-project/noir-protocol-circuits-types/src/scripts/generate_vk_hashes.ts
+++ b/yarn-project/noir-protocol-circuits-types/src/scripts/generate_vk_hashes.ts
@@ -6,7 +6,7 @@ import { fileURLToPath } from '@aztec/foundation/url';
 import { promises as fs } from 'fs';
 import { join } from 'path';
 
-const log = createConsoleLogger('aztec:autogenerate');
+const log = createConsoleLogger('autogenerate');
 
 function resolveRelativePath(relativePath: string) {
   return fileURLToPath(new URL(relativePath, import.meta.url).href);

--- a/yarn-project/p2p-bootstrap/src/index.ts
+++ b/yarn-project/p2p-bootstrap/src/index.ts
@@ -7,7 +7,7 @@ import { NoopTelemetryClient } from '@aztec/telemetry-client/noop';
 import Koa from 'koa';
 import Router from 'koa-router';
 
-const debugLogger = createLogger('bootstrap_node');
+const debugLogger = createLogger('p2p-bootstrap:bootstrap_node');
 
 const { HTTP_PORT } = process.env;
 

--- a/yarn-project/p2p-bootstrap/src/index.ts
+++ b/yarn-project/p2p-bootstrap/src/index.ts
@@ -1,4 +1,4 @@
-import { createDebugLogger } from '@aztec/foundation/log';
+import { createLogger } from '@aztec/foundation/log';
 import { createStore } from '@aztec/kv-store/lmdb';
 import { type BootnodeConfig, BootstrapNode } from '@aztec/p2p';
 import { type TelemetryClient } from '@aztec/telemetry-client';
@@ -7,7 +7,7 @@ import { NoopTelemetryClient } from '@aztec/telemetry-client/noop';
 import Koa from 'koa';
 import Router from 'koa-router';
 
-const debugLogger = createDebugLogger('aztec:bootstrap_node');
+const debugLogger = createLogger('bootstrap_node');
 
 const { HTTP_PORT } = process.env;
 

--- a/yarn-project/p2p/src/bootstrap/bootstrap.ts
+++ b/yarn-project/p2p/src/bootstrap/bootstrap.ts
@@ -21,7 +21,7 @@ export class BootstrapNode {
   constructor(
     private store: AztecKVStore,
     private telemetry: TelemetryClient,
-    private logger = createLogger('p2p_bootstrap'),
+    private logger = createLogger('p2p:bootstrap'),
   ) {}
 
   /**

--- a/yarn-project/p2p/src/bootstrap/bootstrap.ts
+++ b/yarn-project/p2p/src/bootstrap/bootstrap.ts
@@ -1,4 +1,4 @@
-import { createDebugLogger } from '@aztec/foundation/log';
+import { createLogger } from '@aztec/foundation/log';
 import { type AztecKVStore } from '@aztec/kv-store';
 import { OtelMetricsAdapter, type TelemetryClient } from '@aztec/telemetry-client';
 
@@ -21,7 +21,7 @@ export class BootstrapNode {
   constructor(
     private store: AztecKVStore,
     private telemetry: TelemetryClient,
-    private logger = createDebugLogger('aztec:p2p_bootstrap'),
+    private logger = createLogger('p2p_bootstrap'),
   ) {}
 
   /**

--- a/yarn-project/p2p/src/client/index.ts
+++ b/yarn-project/p2p/src/client/index.ts
@@ -1,5 +1,5 @@
 import type { ClientProtocolCircuitVerifier, L2BlockSource, WorldStateSynchronizer } from '@aztec/circuit-types';
-import { createDebugLogger } from '@aztec/foundation/log';
+import { createLogger } from '@aztec/foundation/log';
 import { type AztecKVStore } from '@aztec/kv-store';
 import { type DataStoreConfig } from '@aztec/kv-store/config';
 import { createStore } from '@aztec/kv-store/lmdb';
@@ -35,7 +35,7 @@ export const createP2PClient = async (
   } = {},
 ) => {
   let config = { ..._config };
-  const store = deps.store ?? (await createStore('p2p', config, createDebugLogger('aztec:p2p:lmdb')));
+  const store = deps.store ?? (await createStore('p2p', config, createLogger('p2p:lmdb')));
 
   const mempools: MemPools = {
     txPool: deps.txPool ?? new AztecKVTxPool(store, telemetry),

--- a/yarn-project/p2p/src/client/p2p_client.ts
+++ b/yarn-project/p2p/src/client/p2p_client.ts
@@ -12,7 +12,7 @@ import {
   type TxHash,
 } from '@aztec/circuit-types';
 import { INITIAL_L2_BLOCK_NUM } from '@aztec/circuits.js/constants';
-import { createDebugLogger } from '@aztec/foundation/log';
+import { createLogger } from '@aztec/foundation/log';
 import { type AztecKVStore, type AztecMap, type AztecSingleton } from '@aztec/kv-store';
 import { Attributes, type TelemetryClient, WithTracer, trackSpan } from '@aztec/telemetry-client';
 import { NoopTelemetryClient } from '@aztec/telemetry-client/noop';
@@ -223,7 +223,7 @@ export class P2PClient extends WithTracer implements P2P {
     private p2pService: P2PService,
     private keepProvenTxsFor: number,
     telemetry: TelemetryClient = new NoopTelemetryClient(),
-    private log = createDebugLogger('aztec:p2p'),
+    private log = createLogger('p2p'),
   ) {
     super(telemetry, 'P2PClient');
 

--- a/yarn-project/p2p/src/mem_pools/attestation_pool/memory_attestation_pool.ts
+++ b/yarn-project/p2p/src/mem_pools/attestation_pool/memory_attestation_pool.ts
@@ -1,5 +1,5 @@
 import { type BlockAttestation } from '@aztec/circuit-types';
-import { createDebugLogger } from '@aztec/foundation/log';
+import { createLogger } from '@aztec/foundation/log';
 import { type TelemetryClient } from '@aztec/telemetry-client';
 
 import { PoolInstrumentation, PoolName } from '../instrumentation.js';
@@ -10,7 +10,7 @@ export class InMemoryAttestationPool implements AttestationPool {
 
   private attestations: Map</*slot=*/ bigint, Map</*proposalId*/ string, Map</*address=*/ string, BlockAttestation>>>;
 
-  constructor(telemetry: TelemetryClient, private log = createDebugLogger('aztec:attestation_pool')) {
+  constructor(telemetry: TelemetryClient, private log = createLogger('attestation_pool')) {
     this.attestations = new Map();
     this.metrics = new PoolInstrumentation(telemetry, PoolName.ATTESTATION_POOL);
   }

--- a/yarn-project/p2p/src/mem_pools/attestation_pool/memory_attestation_pool.ts
+++ b/yarn-project/p2p/src/mem_pools/attestation_pool/memory_attestation_pool.ts
@@ -10,7 +10,7 @@ export class InMemoryAttestationPool implements AttestationPool {
 
   private attestations: Map</*slot=*/ bigint, Map</*proposalId*/ string, Map</*address=*/ string, BlockAttestation>>>;
 
-  constructor(telemetry: TelemetryClient, private log = createLogger('attestation_pool')) {
+  constructor(telemetry: TelemetryClient, private log = createLogger('p2p:attestation_pool')) {
     this.attestations = new Map();
     this.metrics = new PoolInstrumentation(telemetry, PoolName.ATTESTATION_POOL);
   }

--- a/yarn-project/p2p/src/mem_pools/tx_pool/aztec_kv_tx_pool.ts
+++ b/yarn-project/p2p/src/mem_pools/tx_pool/aztec_kv_tx_pool.ts
@@ -1,6 +1,6 @@
 import { Tx, TxHash } from '@aztec/circuit-types';
 import { type TxAddedToPoolStats } from '@aztec/circuit-types/stats';
-import { type Logger, createDebugLogger } from '@aztec/foundation/log';
+import { type Logger, createLogger } from '@aztec/foundation/log';
 import { type AztecKVStore, type AztecMap, type AztecSet } from '@aztec/kv-store';
 import { type TelemetryClient } from '@aztec/telemetry-client';
 
@@ -30,7 +30,7 @@ export class AztecKVTxPool implements TxPool {
    * @param store - A KV store.
    * @param log - A logger.
    */
-  constructor(store: AztecKVStore, telemetry: TelemetryClient, log = createDebugLogger('aztec:tx_pool')) {
+  constructor(store: AztecKVStore, telemetry: TelemetryClient, log = createLogger('tx_pool')) {
     this.#txs = store.openMap('txs');
     this.#minedTxs = store.openMap('minedTxs');
     this.#pendingTxs = store.openSet('pendingTxs');

--- a/yarn-project/p2p/src/mem_pools/tx_pool/aztec_kv_tx_pool.ts
+++ b/yarn-project/p2p/src/mem_pools/tx_pool/aztec_kv_tx_pool.ts
@@ -30,7 +30,7 @@ export class AztecKVTxPool implements TxPool {
    * @param store - A KV store.
    * @param log - A logger.
    */
-  constructor(store: AztecKVStore, telemetry: TelemetryClient, log = createLogger('tx_pool')) {
+  constructor(store: AztecKVStore, telemetry: TelemetryClient, log = createLogger('p2p:tx_pool')) {
     this.#txs = store.openMap('txs');
     this.#minedTxs = store.openMap('minedTxs');
     this.#pendingTxs = store.openSet('pendingTxs');

--- a/yarn-project/p2p/src/mem_pools/tx_pool/memory_tx_pool.ts
+++ b/yarn-project/p2p/src/mem_pools/tx_pool/memory_tx_pool.ts
@@ -1,6 +1,6 @@
 import { Tx, TxHash } from '@aztec/circuit-types';
 import { type TxAddedToPoolStats } from '@aztec/circuit-types/stats';
-import { createDebugLogger } from '@aztec/foundation/log';
+import { createLogger } from '@aztec/foundation/log';
 import { type TelemetryClient } from '@aztec/telemetry-client';
 
 import { PoolInstrumentation, PoolName } from '../instrumentation.js';
@@ -23,7 +23,7 @@ export class InMemoryTxPool implements TxPool {
    * Class constructor for in-memory TxPool. Initiates our transaction pool as a JS Map.
    * @param log - A logger.
    */
-  constructor(telemetry: TelemetryClient, private log = createDebugLogger('aztec:tx_pool')) {
+  constructor(telemetry: TelemetryClient, private log = createLogger('tx_pool')) {
     this.txs = new Map<bigint, Tx>();
     this.minedTxs = new Map();
     this.pendingTxs = new Set();

--- a/yarn-project/p2p/src/mem_pools/tx_pool/memory_tx_pool.ts
+++ b/yarn-project/p2p/src/mem_pools/tx_pool/memory_tx_pool.ts
@@ -23,7 +23,7 @@ export class InMemoryTxPool implements TxPool {
    * Class constructor for in-memory TxPool. Initiates our transaction pool as a JS Map.
    * @param log - A logger.
    */
-  constructor(telemetry: TelemetryClient, private log = createLogger('tx_pool')) {
+  constructor(telemetry: TelemetryClient, private log = createLogger('p2p:tx_pool')) {
     this.txs = new Map<bigint, Tx>();
     this.minedTxs = new Map();
     this.pendingTxs = new Set();

--- a/yarn-project/p2p/src/service/discV5_service.ts
+++ b/yarn-project/p2p/src/service/discV5_service.ts
@@ -46,7 +46,7 @@ export class DiscV5Service extends EventEmitter implements PeerDiscoveryService 
     private peerId: PeerId,
     config: P2PConfig,
     telemetry: TelemetryClient,
-    private logger = createLogger('discv5_service'),
+    private logger = createLogger('p2p:discv5_service'),
   ) {
     super();
     const { tcpAnnounceAddress, udpAnnounceAddress, udpListenAddress, bootstrapNodes } = config;

--- a/yarn-project/p2p/src/service/discV5_service.ts
+++ b/yarn-project/p2p/src/service/discV5_service.ts
@@ -1,4 +1,4 @@
-import { createDebugLogger } from '@aztec/foundation/log';
+import { createLogger } from '@aztec/foundation/log';
 import { sleep } from '@aztec/foundation/sleep';
 import { OtelMetricsAdapter, type TelemetryClient } from '@aztec/telemetry-client';
 
@@ -46,7 +46,7 @@ export class DiscV5Service extends EventEmitter implements PeerDiscoveryService 
     private peerId: PeerId,
     config: P2PConfig,
     telemetry: TelemetryClient,
-    private logger = createDebugLogger('aztec:discv5_service'),
+    private logger = createLogger('discv5_service'),
   ) {
     super();
     const { tcpAnnounceAddress, udpAnnounceAddress, udpListenAddress, bootstrapNodes } = config;

--- a/yarn-project/p2p/src/service/libp2p_service.ts
+++ b/yarn-project/p2p/src/service/libp2p_service.ts
@@ -88,7 +88,7 @@ export class LibP2PService extends WithTracer implements P2PService {
     private worldStateSynchronizer: WorldStateSynchronizer,
     private telemetry: TelemetryClient,
     private requestResponseHandlers: ReqRespSubProtocolHandlers = DEFAULT_SUB_PROTOCOL_HANDLERS,
-    private logger = createLogger('libp2p_service'),
+    private logger = createLogger('p2p:libp2p_service'),
   ) {
     super(telemetry, 'LibP2PService');
 

--- a/yarn-project/p2p/src/service/libp2p_service.ts
+++ b/yarn-project/p2p/src/service/libp2p_service.ts
@@ -15,7 +15,7 @@ import {
   metricsTopicStrToLabels,
 } from '@aztec/circuit-types';
 import { Fr } from '@aztec/circuits.js';
-import { createDebugLogger } from '@aztec/foundation/log';
+import { createLogger } from '@aztec/foundation/log';
 import { SerialQueue } from '@aztec/foundation/queue';
 import { RunningPromise } from '@aztec/foundation/running-promise';
 import type { AztecKVStore } from '@aztec/kv-store';
@@ -88,7 +88,7 @@ export class LibP2PService extends WithTracer implements P2PService {
     private worldStateSynchronizer: WorldStateSynchronizer,
     private telemetry: TelemetryClient,
     private requestResponseHandlers: ReqRespSubProtocolHandlers = DEFAULT_SUB_PROTOCOL_HANDLERS,
-    private logger = createDebugLogger('aztec:libp2p_service'),
+    private logger = createLogger('libp2p_service'),
   ) {
     super(telemetry, 'LibP2PService');
 

--- a/yarn-project/p2p/src/service/peer_manager.ts
+++ b/yarn-project/p2p/src/service/peer_manager.ts
@@ -1,4 +1,4 @@
-import { createDebugLogger } from '@aztec/foundation/log';
+import { createLogger } from '@aztec/foundation/log';
 
 import { type ENR } from '@chainsafe/enr';
 import { type PeerId } from '@libp2p/interface';
@@ -27,7 +27,7 @@ export class PeerManager {
     private libP2PNode: PubSubLibp2p,
     private peerDiscoveryService: PeerDiscoveryService,
     private config: P2PConfig,
-    private logger = createDebugLogger('aztec:p2p:peer_manager'),
+    private logger = createLogger('p2p:peer_manager'),
   ) {
     this.peerScoring = new PeerScoring(config);
     // Handle new established connections

--- a/yarn-project/p2p/src/service/reqresp/reqresp.integration.test.ts
+++ b/yarn-project/p2p/src/service/reqresp/reqresp.integration.test.ts
@@ -82,7 +82,7 @@ describe('Req Resp p2p client integration', () => {
   let kvStore: AztecKVStore;
   let worldState: WorldStateSynchronizer;
   let proofVerifier: ClientProtocolCircuitVerifier;
-  const logger = createLogger('p2p-client-integration-test');
+  const logger = createLogger('p2p:test:client-integration');
 
   beforeEach(() => {
     ({ txPool, attestationPool, epochProofQuotePool } = makeMockPools());

--- a/yarn-project/p2p/src/service/reqresp/reqresp.integration.test.ts
+++ b/yarn-project/p2p/src/service/reqresp/reqresp.integration.test.ts
@@ -1,7 +1,7 @@
 // An integration test for the p2p client to test req resp protocols
 import { MockL2BlockSource } from '@aztec/archiver/test';
 import { type ClientProtocolCircuitVerifier, type WorldStateSynchronizer, mockTx } from '@aztec/circuit-types';
-import { createDebugLogger } from '@aztec/foundation/log';
+import { createLogger } from '@aztec/foundation/log';
 import { sleep } from '@aztec/foundation/sleep';
 import { type AztecKVStore } from '@aztec/kv-store';
 import { type DataStoreConfig } from '@aztec/kv-store/config';
@@ -82,7 +82,7 @@ describe('Req Resp p2p client integration', () => {
   let kvStore: AztecKVStore;
   let worldState: WorldStateSynchronizer;
   let proofVerifier: ClientProtocolCircuitVerifier;
-  const logger = createDebugLogger('p2p-client-integration-test');
+  const logger = createLogger('p2p-client-integration-test');
 
   beforeEach(() => {
     ({ txPool, attestationPool, epochProofQuotePool } = makeMockPools());

--- a/yarn-project/p2p/src/service/reqresp/reqresp.ts
+++ b/yarn-project/p2p/src/service/reqresp/reqresp.ts
@@ -1,5 +1,5 @@
 // @attribution: lodestar impl for inspiration
-import { type Logger, createDebugLogger } from '@aztec/foundation/log';
+import { type Logger, createLogger } from '@aztec/foundation/log';
 import { executeTimeoutWithCustomError } from '@aztec/foundation/timer';
 
 import { type IncomingStreamData, type PeerId, type Stream } from '@libp2p/interface';
@@ -50,7 +50,7 @@ export class ReqResp {
   private rateLimiter: RequestResponseRateLimiter;
 
   constructor(config: P2PReqRespConfig, protected readonly libp2p: Libp2p, private peerManager: PeerManager) {
-    this.logger = createDebugLogger('aztec:p2p:reqresp');
+    this.logger = createLogger('p2p:reqresp');
 
     this.overallRequestTimeoutMs = config.overallRequestTimeoutMs;
     this.individualRequestTimeoutMs = config.individualRequestTimeoutMs;

--- a/yarn-project/p2p/src/tx_validator/data_validator.ts
+++ b/yarn-project/p2p/src/tx_validator/data_validator.ts
@@ -1,8 +1,8 @@
 import { Tx, type TxValidator } from '@aztec/circuit-types';
-import { createDebugLogger } from '@aztec/foundation/log';
+import { createLogger } from '@aztec/foundation/log';
 
 export class DataTxValidator implements TxValidator<Tx> {
-  #log = createDebugLogger('aztec:sequencer:tx_validator:tx_data');
+  #log = createLogger('sequencer:tx_validator:tx_data');
 
   validateTxs(txs: Tx[]): Promise<[validTxs: Tx[], invalidTxs: Tx[]]> {
     const validTxs: Tx[] = [];

--- a/yarn-project/p2p/src/tx_validator/data_validator.ts
+++ b/yarn-project/p2p/src/tx_validator/data_validator.ts
@@ -2,7 +2,7 @@ import { Tx, type TxValidator } from '@aztec/circuit-types';
 import { createLogger } from '@aztec/foundation/log';
 
 export class DataTxValidator implements TxValidator<Tx> {
-  #log = createLogger('sequencer:tx_validator:tx_data');
+  #log = createLogger('p2p:tx_validator:tx_data');
 
   validateTxs(txs: Tx[]): Promise<[validTxs: Tx[], invalidTxs: Tx[]]> {
     const validTxs: Tx[] = [];

--- a/yarn-project/p2p/src/tx_validator/double_spend_validator.ts
+++ b/yarn-project/p2p/src/tx_validator/double_spend_validator.ts
@@ -7,7 +7,7 @@ export interface NullifierSource {
 }
 
 export class DoubleSpendTxValidator<T extends AnyTx> implements TxValidator<T> {
-  #log = createLogger('sequencer:tx_validator:tx_double_spend');
+  #log = createLogger('p2p:tx_validator:tx_double_spend');
   #nullifierSource: NullifierSource;
 
   constructor(nullifierSource: NullifierSource, private readonly isValidatingBlock: boolean = true) {

--- a/yarn-project/p2p/src/tx_validator/double_spend_validator.ts
+++ b/yarn-project/p2p/src/tx_validator/double_spend_validator.ts
@@ -1,13 +1,13 @@
 import { type AnyTx, Tx, type TxValidator } from '@aztec/circuit-types';
 import { Fr } from '@aztec/circuits.js';
-import { createDebugLogger } from '@aztec/foundation/log';
+import { createLogger } from '@aztec/foundation/log';
 
 export interface NullifierSource {
   getNullifierIndex: (nullifier: Fr) => Promise<bigint | undefined>;
 }
 
 export class DoubleSpendTxValidator<T extends AnyTx> implements TxValidator<T> {
-  #log = createDebugLogger('aztec:sequencer:tx_validator:tx_double_spend');
+  #log = createLogger('sequencer:tx_validator:tx_double_spend');
   #nullifierSource: NullifierSource;
 
   constructor(nullifierSource: NullifierSource, private readonly isValidatingBlock: boolean = true) {

--- a/yarn-project/p2p/src/tx_validator/metadata_validator.ts
+++ b/yarn-project/p2p/src/tx_validator/metadata_validator.ts
@@ -1,9 +1,9 @@
 import { type AnyTx, Tx, type TxValidator } from '@aztec/circuit-types';
 import { type Fr } from '@aztec/circuits.js';
-import { createDebugLogger } from '@aztec/foundation/log';
+import { createLogger } from '@aztec/foundation/log';
 
 export class MetadataTxValidator<T extends AnyTx> implements TxValidator<T> {
-  #log = createDebugLogger('aztec:sequencer:tx_validator:tx_metadata');
+  #log = createLogger('sequencer:tx_validator:tx_metadata');
 
   constructor(private chainId: Fr, private blockNumber: Fr) {}
 

--- a/yarn-project/p2p/src/tx_validator/metadata_validator.ts
+++ b/yarn-project/p2p/src/tx_validator/metadata_validator.ts
@@ -3,7 +3,7 @@ import { type Fr } from '@aztec/circuits.js';
 import { createLogger } from '@aztec/foundation/log';
 
 export class MetadataTxValidator<T extends AnyTx> implements TxValidator<T> {
-  #log = createLogger('sequencer:tx_validator:tx_metadata');
+  #log = createLogger('p2p:tx_validator:tx_metadata');
 
   constructor(private chainId: Fr, private blockNumber: Fr) {}
 

--- a/yarn-project/p2p/src/tx_validator/tx_proof_validator.ts
+++ b/yarn-project/p2p/src/tx_validator/tx_proof_validator.ts
@@ -1,8 +1,8 @@
 import { type ClientProtocolCircuitVerifier, Tx, type TxValidator } from '@aztec/circuit-types';
-import { createDebugLogger } from '@aztec/foundation/log';
+import { createLogger } from '@aztec/foundation/log';
 
 export class TxProofValidator implements TxValidator<Tx> {
-  #log = createDebugLogger('aztec:sequencer:tx_validator:private_proof');
+  #log = createLogger('sequencer:tx_validator:private_proof');
 
   constructor(private verifier: ClientProtocolCircuitVerifier) {}
 

--- a/yarn-project/p2p/src/tx_validator/tx_proof_validator.ts
+++ b/yarn-project/p2p/src/tx_validator/tx_proof_validator.ts
@@ -2,7 +2,7 @@ import { type ClientProtocolCircuitVerifier, Tx, type TxValidator } from '@aztec
 import { createLogger } from '@aztec/foundation/log';
 
 export class TxProofValidator implements TxValidator<Tx> {
-  #log = createLogger('sequencer:tx_validator:private_proof');
+  #log = createLogger('p2p:tx_validator:private_proof');
 
   constructor(private verifier: ClientProtocolCircuitVerifier) {}
 

--- a/yarn-project/proof-verifier/src/proof_verifier.ts
+++ b/yarn-project/proof-verifier/src/proof_verifier.ts
@@ -1,7 +1,7 @@
 import { retrieveL2ProofsFromRollup } from '@aztec/archiver/data-retrieval';
 import { BBCircuitVerifier } from '@aztec/bb-prover';
 import { createEthereumChain } from '@aztec/ethereum';
-import { type DebugLogger, createDebugLogger } from '@aztec/foundation/log';
+import { type Logger, createLogger } from '@aztec/foundation/log';
 import { RunningPromise } from '@aztec/foundation/running-promise';
 import { Attributes, Metrics, type TelemetryClient, type UpDownCounter, ValueType } from '@aztec/telemetry-client';
 
@@ -22,7 +22,7 @@ export class ProofVerifier {
     private client: PublicClient,
     private verifier: BBCircuitVerifier,
     telemetryClient: TelemetryClient,
-    private logger: DebugLogger,
+    private logger: Logger,
   ) {
     this.runningPromise = new RunningPromise(this.work.bind(this), config.pollIntervalMs);
     this.proofVerified = telemetryClient.getMeter('ProofVerifier').createUpDownCounter(Metrics.PROOF_VERIFIER_COUNT, {
@@ -33,7 +33,7 @@ export class ProofVerifier {
   }
 
   static async new(config: ProofVerifierConfig, telemetryClient: TelemetryClient): Promise<ProofVerifier> {
-    const logger = createDebugLogger('aztec:block-verifier-bot');
+    const logger = createLogger('block-verifier-bot');
     const verifier = await BBCircuitVerifier.new(config, [], logger);
     const client = createPublicClient({
       chain: createEthereumChain(config.l1Url, config.l1ChainId).chainInfo,

--- a/yarn-project/proof-verifier/src/proof_verifier.ts
+++ b/yarn-project/proof-verifier/src/proof_verifier.ts
@@ -33,7 +33,7 @@ export class ProofVerifier {
   }
 
   static async new(config: ProofVerifierConfig, telemetryClient: TelemetryClient): Promise<ProofVerifier> {
-    const logger = createLogger('block-verifier-bot');
+    const logger = createLogger('proof-verifier:block-verifier-bot');
     const verifier = await BBCircuitVerifier.new(config, [], logger);
     const client = createPublicClient({
       chain: createEthereumChain(config.l1Url, config.l1ChainId).chainInfo,

--- a/yarn-project/protocol-contracts/src/scripts/generate_data.ts
+++ b/yarn-project/protocol-contracts/src/scripts/generate_data.ts
@@ -23,7 +23,7 @@ import path from 'path';
 
 import { buildProtocolContractTree } from '../build_protocol_contract_tree.js';
 
-const log = createConsoleLogger('aztec:autogenerate');
+const log = createConsoleLogger('autogenerate');
 
 const noirContractsRoot = '../../noir-projects/noir-contracts';
 const srcPath = path.join(noirContractsRoot, './target');

--- a/yarn-project/prover-client/src/block_builder/light.test.ts
+++ b/yarn-project/prover-client/src/block_builder/light.test.ts
@@ -78,7 +78,7 @@ describe('LightBlockBuilder', () => {
   let emptyProof: RecursiveProof<typeof NESTED_RECURSIVE_PROOF_LENGTH>;
 
   beforeAll(async () => {
-    logger = createLogger('sequencer-client:test:block-builder');
+    logger = createLogger('prover-client:test:block-builder');
     simulator = new TestCircuitProver(new NoopTelemetryClient());
     vkTreeRoot = getVKTreeRoot();
     emptyProof = makeEmptyRecursiveProof(NESTED_RECURSIVE_PROOF_LENGTH);

--- a/yarn-project/prover-client/src/block_builder/light.test.ts
+++ b/yarn-project/prover-client/src/block_builder/light.test.ts
@@ -37,7 +37,7 @@ import {
 } from '@aztec/circuits.js';
 import { makeGlobalVariables } from '@aztec/circuits.js/testing';
 import { padArrayEnd, times } from '@aztec/foundation/collection';
-import { type DebugLogger, createDebugLogger } from '@aztec/foundation/log';
+import { type Logger, createLogger } from '@aztec/foundation/log';
 import { type Tuple, assertLength } from '@aztec/foundation/serialize';
 import {
   ProtocolCircuitVks,
@@ -65,7 +65,7 @@ jest.setTimeout(50_000);
 
 describe('LightBlockBuilder', () => {
   let simulator: ServerCircuitProver;
-  let logger: DebugLogger;
+  let logger: Logger;
   let globalVariables: GlobalVariables;
   let l1ToL2Messages: Fr[];
   let vkTreeRoot: Fr;
@@ -78,7 +78,7 @@ describe('LightBlockBuilder', () => {
   let emptyProof: RecursiveProof<typeof NESTED_RECURSIVE_PROOF_LENGTH>;
 
   beforeAll(async () => {
-    logger = createDebugLogger('aztec:sequencer-client:test:block-builder');
+    logger = createLogger('sequencer-client:test:block-builder');
     simulator = new TestCircuitProver(new NoopTelemetryClient());
     vkTreeRoot = getVKTreeRoot();
     emptyProof = makeEmptyRecursiveProof(NESTED_RECURSIVE_PROOF_LENGTH);

--- a/yarn-project/prover-client/src/block_builder/light.ts
+++ b/yarn-project/prover-client/src/block_builder/light.ts
@@ -32,7 +32,7 @@ export class LightweightBlockBuilder implements BlockBuilder {
 
   private readonly txs: ProcessedTx[] = [];
 
-  private readonly logger = createLogger('sequencer-client:block_builder_light');
+  private readonly logger = createLogger('prover-client:block_builder');
 
   constructor(private db: MerkleTreeWriteOperations, private telemetry: TelemetryClient) {}
 

--- a/yarn-project/prover-client/src/block_builder/light.ts
+++ b/yarn-project/prover-client/src/block_builder/light.ts
@@ -8,7 +8,7 @@ import {
 } from '@aztec/circuit-types';
 import { Fr, type GlobalVariables, NUMBER_OF_L1_L2_MESSAGES_PER_ROLLUP } from '@aztec/circuits.js';
 import { padArrayEnd } from '@aztec/foundation/collection';
-import { createDebugLogger } from '@aztec/foundation/log';
+import { createLogger } from '@aztec/foundation/log';
 import { getVKTreeRoot } from '@aztec/noir-protocol-circuits-types';
 import { protocolContractTreeRoot } from '@aztec/protocol-contracts';
 import { type TelemetryClient } from '@aztec/telemetry-client';
@@ -32,7 +32,7 @@ export class LightweightBlockBuilder implements BlockBuilder {
 
   private readonly txs: ProcessedTx[] = [];
 
-  private readonly logger = createDebugLogger('aztec:sequencer-client:block_builder_light');
+  private readonly logger = createLogger('sequencer-client:block_builder_light');
 
   constructor(private db: MerkleTreeWriteOperations, private telemetry: TelemetryClient) {}
 

--- a/yarn-project/prover-client/src/mocks/fixtures.ts
+++ b/yarn-project/prover-client/src/mocks/fixtures.ts
@@ -11,7 +11,7 @@ import {
 } from '@aztec/circuits.js';
 import { padArrayEnd } from '@aztec/foundation/collection';
 import { randomBytes } from '@aztec/foundation/crypto';
-import { type DebugLogger } from '@aztec/foundation/log';
+import { type Logger } from '@aztec/foundation/log';
 import { fileURLToPath } from '@aztec/foundation/url';
 import { NativeACVMSimulator, type SimulationProvider, WASMSimulator } from '@aztec/simulator';
 
@@ -30,7 +30,7 @@ const {
 } = process.env;
 
 // Determines if we have access to the bb binary and a tmp folder for temp files
-export const getEnvironmentConfig = async (logger: DebugLogger) => {
+export const getEnvironmentConfig = async (logger: Logger) => {
   try {
     const expectedBBPath = BB_BINARY_PATH
       ? BB_BINARY_PATH
@@ -68,7 +68,7 @@ export const getEnvironmentConfig = async (logger: DebugLogger) => {
 
 export async function getSimulationProvider(
   config: { acvmWorkingDirectory: string | undefined; acvmBinaryPath: string | undefined },
-  logger?: DebugLogger,
+  logger?: Logger,
 ): Promise<SimulationProvider> {
   if (config.acvmBinaryPath && config.acvmWorkingDirectory) {
     try {

--- a/yarn-project/prover-client/src/mocks/test_context.ts
+++ b/yarn-project/prover-client/src/mocks/test_context.ts
@@ -12,7 +12,7 @@ import { makeBloatedProcessedTx } from '@aztec/circuit-types/test';
 import { type AppendOnlyTreeSnapshot, BlockHeader, type Gas, type GlobalVariables } from '@aztec/circuits.js';
 import { times } from '@aztec/foundation/collection';
 import { Fr } from '@aztec/foundation/fields';
-import { type DebugLogger } from '@aztec/foundation/log';
+import { type Logger } from '@aztec/foundation/log';
 import { getVKTreeRoot } from '@aztec/noir-protocol-circuits-types';
 import { protocolContractTreeRoot } from '@aztec/protocol-contracts';
 import {
@@ -53,7 +53,7 @@ export class TestContext {
     public orchestrator: TestProvingOrchestrator,
     public blockNumber: number,
     public directoriesToCleanup: string[],
-    public logger: DebugLogger,
+    public logger: Logger,
   ) {}
 
   public get epochProver() {
@@ -61,7 +61,7 @@ export class TestContext {
   }
 
   static async new(
-    logger: DebugLogger,
+    logger: Logger,
     proverCount = 4,
     createProver: (bbConfig: BBProverConfig) => Promise<ServerCircuitProver> = _ =>
       Promise.resolve(new TestCircuitProver(new NoopTelemetryClient(), new WASMSimulator())),

--- a/yarn-project/prover-client/src/orchestrator/block-building-helpers.ts
+++ b/yarn-project/prover-client/src/orchestrator/block-building-helpers.ts
@@ -52,7 +52,7 @@ import {
 import { makeTuple } from '@aztec/foundation/array';
 import { padArrayEnd } from '@aztec/foundation/collection';
 import { sha256Trunc } from '@aztec/foundation/crypto';
-import { type DebugLogger } from '@aztec/foundation/log';
+import { type Logger } from '@aztec/foundation/log';
 import { type Tuple, assertLength, toFriendlyJSON } from '@aztec/foundation/serialize';
 import { computeUnbalancedMerkleRoot } from '@aztec/foundation/trees';
 import { getVKIndex, getVKSiblingPath, getVKTreeRoot } from '@aztec/noir-protocol-circuits-types';
@@ -299,7 +299,7 @@ export function buildHeaderFromCircuitOutputs(
   parityPublicInputs: ParityPublicInputs,
   rootRollupOutputs: BlockRootOrBlockMergePublicInputs,
   updatedL1ToL2TreeSnapshot: AppendOnlyTreeSnapshot,
-  logger?: DebugLogger,
+  logger?: Logger,
 ) {
   const contentCommitment = new ContentCommitment(
     new Fr(previousMergeData[0].numTxs + previousMergeData[1].numTxs),

--- a/yarn-project/prover-client/src/orchestrator/orchestrator.ts
+++ b/yarn-project/prover-client/src/orchestrator/orchestrator.ts
@@ -77,7 +77,7 @@ import {
 import { ProvingOrchestratorMetrics } from './orchestrator_metrics.js';
 import { TxProvingState } from './tx-proving-state.js';
 
-const logger = createLogger('prover:proving-orchestrator');
+const logger = createLogger('prover-client:orchestrator');
 
 /**
  * Implements an event driven proving scheduler to build the recursive proof tree. The idea being:

--- a/yarn-project/prover-client/src/orchestrator/orchestrator.ts
+++ b/yarn-project/prover-client/src/orchestrator/orchestrator.ts
@@ -42,7 +42,7 @@ import {
 import { makeTuple } from '@aztec/foundation/array';
 import { maxBy, padArrayEnd } from '@aztec/foundation/collection';
 import { AbortError } from '@aztec/foundation/error';
-import { createDebugLogger } from '@aztec/foundation/log';
+import { createLogger } from '@aztec/foundation/log';
 import { promiseWithResolvers } from '@aztec/foundation/promise';
 import { type Tuple } from '@aztec/foundation/serialize';
 import { pushTestData } from '@aztec/foundation/testing';
@@ -77,7 +77,7 @@ import {
 import { ProvingOrchestratorMetrics } from './orchestrator_metrics.js';
 import { TxProvingState } from './tx-proving-state.js';
 
-const logger = createDebugLogger('aztec:prover:proving-orchestrator');
+const logger = createLogger('prover:proving-orchestrator');
 
 /**
  * Implements an event driven proving scheduler to build the recursive proof tree. The idea being:

--- a/yarn-project/prover-client/src/orchestrator/orchestrator_errors.test.ts
+++ b/yarn-project/prover-client/src/orchestrator/orchestrator_errors.test.ts
@@ -5,7 +5,7 @@ import { createLogger } from '@aztec/foundation/log';
 import { TestContext } from '../mocks/test_context.js';
 import { type ProvingOrchestrator } from './orchestrator.js';
 
-const logger = createLogger('orchestrator-errors');
+const logger = createLogger('prover-client:test:orchestrator-errors');
 
 describe('prover/orchestrator/errors', () => {
   let context: TestContext;

--- a/yarn-project/prover-client/src/orchestrator/orchestrator_errors.test.ts
+++ b/yarn-project/prover-client/src/orchestrator/orchestrator_errors.test.ts
@@ -1,11 +1,11 @@
 import { Fr } from '@aztec/circuits.js';
 import { times } from '@aztec/foundation/collection';
-import { createDebugLogger } from '@aztec/foundation/log';
+import { createLogger } from '@aztec/foundation/log';
 
 import { TestContext } from '../mocks/test_context.js';
 import { type ProvingOrchestrator } from './orchestrator.js';
 
-const logger = createDebugLogger('aztec:orchestrator-errors');
+const logger = createLogger('orchestrator-errors');
 
 describe('prover/orchestrator/errors', () => {
   let context: TestContext;

--- a/yarn-project/prover-client/src/orchestrator/orchestrator_failures.test.ts
+++ b/yarn-project/prover-client/src/orchestrator/orchestrator_failures.test.ts
@@ -1,7 +1,7 @@
 import { TestCircuitProver } from '@aztec/bb-prover';
 import { type ServerCircuitProver } from '@aztec/circuit-types';
 import { timesAsync } from '@aztec/foundation/collection';
-import { createDebugLogger } from '@aztec/foundation/log';
+import { createLogger } from '@aztec/foundation/log';
 import { WASMSimulator } from '@aztec/simulator';
 import { NoopTelemetryClient } from '@aztec/telemetry-client/noop';
 
@@ -10,7 +10,7 @@ import { jest } from '@jest/globals';
 import { TestContext } from '../mocks/test_context.js';
 import { ProvingOrchestrator } from './orchestrator.js';
 
-const logger = createDebugLogger('aztec:orchestrator-failures');
+const logger = createLogger('orchestrator-failures');
 
 describe('prover/orchestrator/failures', () => {
   let context: TestContext;

--- a/yarn-project/prover-client/src/orchestrator/orchestrator_failures.test.ts
+++ b/yarn-project/prover-client/src/orchestrator/orchestrator_failures.test.ts
@@ -10,7 +10,7 @@ import { jest } from '@jest/globals';
 import { TestContext } from '../mocks/test_context.js';
 import { ProvingOrchestrator } from './orchestrator.js';
 
-const logger = createLogger('orchestrator-failures');
+const logger = createLogger('prover-client:test:orchestrator-failures');
 
 describe('prover/orchestrator/failures', () => {
   let context: TestContext;

--- a/yarn-project/prover-client/src/orchestrator/orchestrator_lifecycle.test.ts
+++ b/yarn-project/prover-client/src/orchestrator/orchestrator_lifecycle.test.ts
@@ -1,6 +1,6 @@
 import { type ServerCircuitProver } from '@aztec/circuit-types';
 import { NUM_BASE_PARITY_PER_ROOT_PARITY } from '@aztec/circuits.js';
-import { createDebugLogger } from '@aztec/foundation/log';
+import { createLogger } from '@aztec/foundation/log';
 import { type PromiseWithResolvers, promiseWithResolvers } from '@aztec/foundation/promise';
 import { sleep } from '@aztec/foundation/sleep';
 import { NoopTelemetryClient } from '@aztec/telemetry-client/noop';
@@ -11,7 +11,7 @@ import { TestCircuitProver } from '../../../bb-prover/src/test/test_circuit_prov
 import { TestContext } from '../mocks/test_context.js';
 import { ProvingOrchestrator } from './orchestrator.js';
 
-const logger = createDebugLogger('aztec:orchestrator-lifecycle');
+const logger = createLogger('orchestrator-lifecycle');
 
 describe('prover/orchestrator/lifecycle', () => {
   let context: TestContext;

--- a/yarn-project/prover-client/src/orchestrator/orchestrator_lifecycle.test.ts
+++ b/yarn-project/prover-client/src/orchestrator/orchestrator_lifecycle.test.ts
@@ -11,7 +11,7 @@ import { TestCircuitProver } from '../../../bb-prover/src/test/test_circuit_prov
 import { TestContext } from '../mocks/test_context.js';
 import { ProvingOrchestrator } from './orchestrator.js';
 
-const logger = createLogger('orchestrator-lifecycle');
+const logger = createLogger('prover-client:test:orchestrator-lifecycle');
 
 describe('prover/orchestrator/lifecycle', () => {
   let context: TestContext;

--- a/yarn-project/prover-client/src/orchestrator/orchestrator_mixed_blocks.test.ts
+++ b/yarn-project/prover-client/src/orchestrator/orchestrator_mixed_blocks.test.ts
@@ -6,7 +6,7 @@ import { createLogger } from '@aztec/foundation/log';
 
 import { TestContext } from '../mocks/test_context.js';
 
-const logger = createLogger('orchestrator-mixed-blocks');
+const logger = createLogger('prover-client:test:orchestrator-mixed-blocks');
 
 describe('prover/orchestrator/mixed-blocks', () => {
   let context: TestContext;

--- a/yarn-project/prover-client/src/orchestrator/orchestrator_mixed_blocks.test.ts
+++ b/yarn-project/prover-client/src/orchestrator/orchestrator_mixed_blocks.test.ts
@@ -2,11 +2,11 @@ import { NUMBER_OF_L1_L2_MESSAGES_PER_ROLLUP } from '@aztec/circuits.js';
 import { fr } from '@aztec/circuits.js/testing';
 import { range } from '@aztec/foundation/array';
 import { times } from '@aztec/foundation/collection';
-import { createDebugLogger } from '@aztec/foundation/log';
+import { createLogger } from '@aztec/foundation/log';
 
 import { TestContext } from '../mocks/test_context.js';
 
-const logger = createDebugLogger('aztec:orchestrator-mixed-blocks');
+const logger = createLogger('orchestrator-mixed-blocks');
 
 describe('prover/orchestrator/mixed-blocks', () => {
   let context: TestContext;

--- a/yarn-project/prover-client/src/orchestrator/orchestrator_multi_public_functions.test.ts
+++ b/yarn-project/prover-client/src/orchestrator/orchestrator_multi_public_functions.test.ts
@@ -6,7 +6,7 @@ import { protocolContractTreeRoot } from '@aztec/protocol-contracts';
 
 import { TestContext } from '../mocks/test_context.js';
 
-const logger = createLogger('orchestrator-multi-public-functions');
+const logger = createLogger('prover-client:test:orchestrator-multi-public-functions');
 
 describe('prover/orchestrator/public-functions', () => {
   let context: TestContext;

--- a/yarn-project/prover-client/src/orchestrator/orchestrator_multi_public_functions.test.ts
+++ b/yarn-project/prover-client/src/orchestrator/orchestrator_multi_public_functions.test.ts
@@ -1,12 +1,12 @@
 import { EmptyTxValidator, mockTx } from '@aztec/circuit-types';
 import { times } from '@aztec/foundation/collection';
-import { createDebugLogger } from '@aztec/foundation/log';
+import { createLogger } from '@aztec/foundation/log';
 import { getVKTreeRoot } from '@aztec/noir-protocol-circuits-types';
 import { protocolContractTreeRoot } from '@aztec/protocol-contracts';
 
 import { TestContext } from '../mocks/test_context.js';
 
-const logger = createDebugLogger('aztec:orchestrator-multi-public-functions');
+const logger = createLogger('orchestrator-multi-public-functions');
 
 describe('prover/orchestrator/public-functions', () => {
   let context: TestContext;

--- a/yarn-project/prover-client/src/orchestrator/orchestrator_multiple_blocks.test.ts
+++ b/yarn-project/prover-client/src/orchestrator/orchestrator_multiple_blocks.test.ts
@@ -1,9 +1,9 @@
 import { timesAsync } from '@aztec/foundation/collection';
-import { createDebugLogger } from '@aztec/foundation/log';
+import { createLogger } from '@aztec/foundation/log';
 
 import { TestContext } from '../mocks/test_context.js';
 
-const logger = createDebugLogger('aztec:orchestrator-multi-blocks');
+const logger = createLogger('orchestrator-multi-blocks');
 
 describe('prover/orchestrator/multi-block', () => {
   let context: TestContext;

--- a/yarn-project/prover-client/src/orchestrator/orchestrator_multiple_blocks.test.ts
+++ b/yarn-project/prover-client/src/orchestrator/orchestrator_multiple_blocks.test.ts
@@ -3,7 +3,7 @@ import { createLogger } from '@aztec/foundation/log';
 
 import { TestContext } from '../mocks/test_context.js';
 
-const logger = createLogger('orchestrator-multi-blocks');
+const logger = createLogger('prover-client:test:orchestrator-multi-blocks');
 
 describe('prover/orchestrator/multi-block', () => {
   let context: TestContext;

--- a/yarn-project/prover-client/src/orchestrator/orchestrator_public_functions.test.ts
+++ b/yarn-project/prover-client/src/orchestrator/orchestrator_public_functions.test.ts
@@ -5,7 +5,7 @@ import { protocolContractTreeRoot } from '@aztec/protocol-contracts';
 
 import { TestContext } from '../mocks/test_context.js';
 
-const logger = createLogger('orchestrator-public-functions');
+const logger = createLogger('prover-client:test:orchestrator-public-functions');
 
 describe('prover/orchestrator/public-functions', () => {
   let context: TestContext;

--- a/yarn-project/prover-client/src/orchestrator/orchestrator_public_functions.test.ts
+++ b/yarn-project/prover-client/src/orchestrator/orchestrator_public_functions.test.ts
@@ -1,11 +1,11 @@
 import { mockTx } from '@aztec/circuit-types';
-import { createDebugLogger } from '@aztec/foundation/log';
+import { createLogger } from '@aztec/foundation/log';
 import { getVKTreeRoot } from '@aztec/noir-protocol-circuits-types';
 import { protocolContractTreeRoot } from '@aztec/protocol-contracts';
 
 import { TestContext } from '../mocks/test_context.js';
 
-const logger = createDebugLogger('aztec:orchestrator-public-functions');
+const logger = createLogger('orchestrator-public-functions');
 
 describe('prover/orchestrator/public-functions', () => {
   let context: TestContext;

--- a/yarn-project/prover-client/src/orchestrator/orchestrator_single_blocks.test.ts
+++ b/yarn-project/prover-client/src/orchestrator/orchestrator_single_blocks.test.ts
@@ -7,7 +7,7 @@ import { sleep } from '@aztec/foundation/sleep';
 
 import { TestContext } from '../mocks/test_context.js';
 
-const logger = createLogger('orchestrator-single-blocks');
+const logger = createLogger('prover-client:test:orchestrator-single-blocks');
 
 describe('prover/orchestrator/blocks', () => {
   let context: TestContext;

--- a/yarn-project/prover-client/src/orchestrator/orchestrator_single_blocks.test.ts
+++ b/yarn-project/prover-client/src/orchestrator/orchestrator_single_blocks.test.ts
@@ -2,12 +2,12 @@ import { NUMBER_OF_L1_L2_MESSAGES_PER_ROLLUP } from '@aztec/circuits.js';
 import { fr } from '@aztec/circuits.js/testing';
 import { range } from '@aztec/foundation/array';
 import { times } from '@aztec/foundation/collection';
-import { createDebugLogger } from '@aztec/foundation/log';
+import { createLogger } from '@aztec/foundation/log';
 import { sleep } from '@aztec/foundation/sleep';
 
 import { TestContext } from '../mocks/test_context.js';
 
-const logger = createDebugLogger('aztec:orchestrator-single-blocks');
+const logger = createLogger('orchestrator-single-blocks');
 
 describe('prover/orchestrator/blocks', () => {
   let context: TestContext;

--- a/yarn-project/prover-client/src/orchestrator/orchestrator_workflow.test.ts
+++ b/yarn-project/prover-client/src/orchestrator/orchestrator_workflow.test.ts
@@ -13,7 +13,7 @@ import {
   makeRecursiveProof,
 } from '@aztec/circuits.js';
 import { makeParityPublicInputs } from '@aztec/circuits.js/testing';
-import { createDebugLogger } from '@aztec/foundation/log';
+import { createLogger } from '@aztec/foundation/log';
 import { promiseWithResolvers } from '@aztec/foundation/promise';
 import { sleep } from '@aztec/foundation/sleep';
 import { ProtocolCircuitVks } from '@aztec/noir-protocol-circuits-types';
@@ -23,7 +23,7 @@ import { type MockProxy, mock } from 'jest-mock-extended';
 import { TestContext } from '../mocks/test_context.js';
 import { type ProvingOrchestrator } from './orchestrator.js';
 
-const logger = createDebugLogger('aztec:orchestrator-workflow');
+const logger = createLogger('orchestrator-workflow');
 
 describe('prover/orchestrator', () => {
   describe('workflow', () => {

--- a/yarn-project/prover-client/src/orchestrator/orchestrator_workflow.test.ts
+++ b/yarn-project/prover-client/src/orchestrator/orchestrator_workflow.test.ts
@@ -23,7 +23,7 @@ import { type MockProxy, mock } from 'jest-mock-extended';
 import { TestContext } from '../mocks/test_context.js';
 import { type ProvingOrchestrator } from './orchestrator.js';
 
-const logger = createLogger('orchestrator-workflow');
+const logger = createLogger('prover-client:test:orchestrator-workflow');
 
 describe('prover/orchestrator', () => {
   describe('workflow', () => {

--- a/yarn-project/prover-client/src/prover-agent/memory-proving-queue.ts
+++ b/yarn-project/prover-client/src/prover-agent/memory-proving-queue.ts
@@ -32,7 +32,7 @@ import type {
 } from '@aztec/circuits.js';
 import { randomBytes } from '@aztec/foundation/crypto';
 import { AbortError, TimeoutError } from '@aztec/foundation/error';
-import { createDebugLogger } from '@aztec/foundation/log';
+import { createLogger } from '@aztec/foundation/log';
 import { type PromiseWithResolvers, RunningPromise, promiseWithResolvers } from '@aztec/foundation/promise';
 import { PriorityMemoryQueue } from '@aztec/foundation/queue';
 import { type TelemetryClient } from '@aztec/telemetry-client';
@@ -57,7 +57,7 @@ const defaultTimeSource = () => Date.now();
  * The queue accumulates jobs and provides them to agents prioritized by block number.
  */
 export class MemoryProvingQueue implements ServerCircuitProver, ProvingJobSource {
-  private log = createDebugLogger('aztec:prover-client:prover-pool:queue');
+  private log = createLogger('prover-client:prover-pool:queue');
   private queue = new PriorityMemoryQueue<ProvingJobWithResolvers>(
     (a, b) => (a.epochNumber ?? 0) - (b.epochNumber ?? 0),
   );

--- a/yarn-project/prover-client/src/prover-agent/prover-agent.ts
+++ b/yarn-project/prover-client/src/prover-agent/prover-agent.ts
@@ -8,7 +8,7 @@ import {
   type ServerCircuitProver,
   makeProvingRequestResult,
 } from '@aztec/circuit-types';
-import { createDebugLogger } from '@aztec/foundation/log';
+import { createLogger } from '@aztec/foundation/log';
 import { RunningPromise } from '@aztec/foundation/running-promise';
 import { elapsed } from '@aztec/foundation/timer';
 
@@ -38,7 +38,7 @@ export class ProverAgent implements ProverAgentApi {
     private maxConcurrency = 1,
     /** How long to wait between jobs */
     private pollIntervalMs = 100,
-    private log = createDebugLogger('aztec:prover-client:prover-agent'),
+    private log = createLogger('prover-client:prover-agent'),
   ) {}
 
   setMaxConcurrency(maxConcurrency: number): Promise<void> {

--- a/yarn-project/prover-client/src/prover-client/prover-client.ts
+++ b/yarn-project/prover-client/src/prover-client/prover-client.ts
@@ -12,7 +12,7 @@ import {
 } from '@aztec/circuit-types/interfaces';
 import { Fr } from '@aztec/circuits.js';
 import { times } from '@aztec/foundation/collection';
-import { createDebugLogger } from '@aztec/foundation/log';
+import { createLogger } from '@aztec/foundation/log';
 import { NativeACVMSimulator } from '@aztec/simulator';
 import { type TelemetryClient } from '@aztec/telemetry-client';
 
@@ -38,7 +38,7 @@ export class ProverClient implements EpochProverManager {
     private telemetry: TelemetryClient,
     private orchestratorClient: ProvingJobProducer,
     private agentClient?: ProvingJobConsumer,
-    private log = createDebugLogger('aztec:prover-client:tx-prover'),
+    private log = createLogger('prover-client:tx-prover'),
   ) {
     // TODO(palla/prover-node): Cache the paddingTx here, and not in each proving orchestrator,
     // so it can be reused across multiple ones and not recomputed every time.

--- a/yarn-project/prover-client/src/proving_broker/caching_broker_facade.ts
+++ b/yarn-project/prover-client/src/proving_broker/caching_broker_facade.ts
@@ -33,7 +33,7 @@ import {
   type TubeInputs,
 } from '@aztec/circuits.js';
 import { sha256 } from '@aztec/foundation/crypto';
-import { createDebugLogger } from '@aztec/foundation/log';
+import { createLogger } from '@aztec/foundation/log';
 import { retryUntil } from '@aztec/foundation/retry';
 
 import { InlineProofStore, type ProofStore } from './proof_store.js';
@@ -52,7 +52,7 @@ export class CachingBrokerFacade implements ServerCircuitProver {
     private proofStore: ProofStore = new InlineProofStore(),
     private waitTimeoutMs = MAX_WAIT_MS,
     private pollIntervalMs = 1000,
-    private log = createDebugLogger('aztec:prover-client:caching-prover-broker'),
+    private log = createLogger('prover-client:caching-prover-broker'),
   ) {}
 
   private async enqueueAndWaitForJob<T extends ProvingRequestType>(

--- a/yarn-project/prover-client/src/proving_broker/proving_agent.ts
+++ b/yarn-project/prover-client/src/proving_broker/proving_agent.ts
@@ -8,7 +8,7 @@ import {
   ProvingRequestType,
   type ServerCircuitProver,
 } from '@aztec/circuit-types';
-import { createDebugLogger } from '@aztec/foundation/log';
+import { createLogger } from '@aztec/foundation/log';
 import { RunningPromise } from '@aztec/foundation/running-promise';
 import { Timer } from '@aztec/foundation/timer';
 import { type TelemetryClient } from '@aztec/telemetry-client';
@@ -39,7 +39,7 @@ export class ProvingAgent {
     private proofAllowList: Array<ProvingRequestType> = [],
     /** How long to wait between jobs */
     private pollIntervalMs = 1000,
-    private log = createDebugLogger('aztec:prover-client:proving-agent'),
+    private log = createLogger('prover-client:proving-agent'),
   ) {
     this.instrumentation = new ProvingAgentInstrumentation(client);
     this.runningPromise = new RunningPromise(this.safeWork, this.pollIntervalMs);

--- a/yarn-project/prover-client/src/proving_broker/proving_broker.ts
+++ b/yarn-project/prover-client/src/proving_broker/proving_broker.ts
@@ -9,7 +9,7 @@ import {
   type ProvingJobStatus,
   ProvingRequestType,
 } from '@aztec/circuit-types';
-import { createDebugLogger } from '@aztec/foundation/log';
+import { createLogger } from '@aztec/foundation/log';
 import { type PromiseWithResolvers, RunningPromise, promiseWithResolvers } from '@aztec/foundation/promise';
 import { PriorityMemoryQueue } from '@aztec/foundation/queue';
 import { Timer } from '@aztec/foundation/timer';
@@ -87,7 +87,7 @@ export class ProvingBroker implements ProvingJobProducer, ProvingJobConsumer {
     private database: ProvingBrokerDatabase,
     client: TelemetryClient,
     { jobTimeoutMs = 30_000, timeoutIntervalMs = 10_000, maxRetries = 3 }: ProofRequestBrokerConfig = {},
-    private logger = createDebugLogger('aztec:prover-client:proving-broker'),
+    private logger = createLogger('prover-client:proving-broker'),
   ) {
     this.instrumentation = new ProvingBrokerInstrumentation(client);
     this.timeoutPromise = new RunningPromise(this.timeoutCheck, timeoutIntervalMs);

--- a/yarn-project/prover-client/src/test/bb_prover_base_rollup.test.ts
+++ b/yarn-project/prover-client/src/test/bb_prover_base_rollup.test.ts
@@ -8,7 +8,7 @@ import {
   PrivateTubeData,
   VkWitnessData,
 } from '@aztec/circuits.js';
-import { createDebugLogger } from '@aztec/foundation/log';
+import { createLogger } from '@aztec/foundation/log';
 import { getVKSiblingPath, getVKTreeRoot } from '@aztec/noir-protocol-circuits-types';
 import { protocolContractTreeRoot } from '@aztec/protocol-contracts';
 import { NoopTelemetryClient } from '@aztec/telemetry-client/noop';
@@ -16,7 +16,7 @@ import { NoopTelemetryClient } from '@aztec/telemetry-client/noop';
 import { TestContext } from '../mocks/test_context.js';
 import { buildBaseRollupHints } from '../orchestrator/block-building-helpers.js';
 
-const logger = createDebugLogger('aztec:bb-prover-base-rollup');
+const logger = createLogger('bb-prover-base-rollup');
 
 describe('prover/bb_prover/base-rollup', () => {
   let context: TestContext;

--- a/yarn-project/prover-client/src/test/bb_prover_base_rollup.test.ts
+++ b/yarn-project/prover-client/src/test/bb_prover_base_rollup.test.ts
@@ -16,7 +16,7 @@ import { NoopTelemetryClient } from '@aztec/telemetry-client/noop';
 import { TestContext } from '../mocks/test_context.js';
 import { buildBaseRollupHints } from '../orchestrator/block-building-helpers.js';
 
-const logger = createLogger('bb-prover-base-rollup');
+const logger = createLogger('prover-client:test:bb-prover-base-rollup');
 
 describe('prover/bb_prover/base-rollup', () => {
   let context: TestContext;

--- a/yarn-project/prover-client/src/test/bb_prover_full_rollup.test.ts
+++ b/yarn-project/prover-client/src/test/bb_prover_full_rollup.test.ts
@@ -22,7 +22,7 @@ describe('prover/bb_prover/full-rollup', () => {
       prover = await BBNativeRollupProver.new(bbConfig, new NoopTelemetryClient());
       return prover;
     };
-    log = createLogger('bb-prover-full-rollup');
+    log = createLogger('prover-client:test:bb-prover-full-rollup');
     context = await TestContext.new(log, 1, buildProver);
   });
 

--- a/yarn-project/prover-client/src/test/bb_prover_full_rollup.test.ts
+++ b/yarn-project/prover-client/src/test/bb_prover_full_rollup.test.ts
@@ -3,7 +3,7 @@ import { mockTx } from '@aztec/circuit-types';
 import { Fr, NUMBER_OF_L1_L2_MESSAGES_PER_ROLLUP } from '@aztec/circuits.js';
 import { makeTuple } from '@aztec/foundation/array';
 import { times } from '@aztec/foundation/collection';
-import { type DebugLogger, createDebugLogger } from '@aztec/foundation/log';
+import { type Logger, createLogger } from '@aztec/foundation/log';
 import { getTestData, isGenerateTestDataEnabled, writeTestData } from '@aztec/foundation/testing';
 import { getVKTreeRoot } from '@aztec/noir-protocol-circuits-types';
 import { NoopTelemetryClient } from '@aztec/telemetry-client/noop';
@@ -15,14 +15,14 @@ import { TestContext } from '../mocks/test_context.js';
 describe('prover/bb_prover/full-rollup', () => {
   let context: TestContext;
   let prover: BBNativeRollupProver;
-  let log: DebugLogger;
+  let log: Logger;
 
   beforeEach(async () => {
     const buildProver = async (bbConfig: BBProverConfig) => {
       prover = await BBNativeRollupProver.new(bbConfig, new NoopTelemetryClient());
       return prover;
     };
-    log = createDebugLogger('aztec:bb-prover-full-rollup');
+    log = createLogger('bb-prover-full-rollup');
     context = await TestContext.new(log, 1, buildProver);
   });
 

--- a/yarn-project/prover-client/src/test/bb_prover_parity.test.ts
+++ b/yarn-project/prover-client/src/test/bb_prover_parity.test.ts
@@ -13,7 +13,7 @@ import {
 } from '@aztec/circuits.js';
 import { makeTuple } from '@aztec/foundation/array';
 import { randomBytes } from '@aztec/foundation/crypto';
-import { createDebugLogger } from '@aztec/foundation/log';
+import { createLogger } from '@aztec/foundation/log';
 import {
   ProtocolCircuitVkIndexes,
   ServerCircuitVks,
@@ -24,7 +24,7 @@ import { NoopTelemetryClient } from '@aztec/telemetry-client/noop';
 
 import { TestContext } from '../mocks/test_context.js';
 
-const logger = createDebugLogger('aztec:bb-prover-parity');
+const logger = createLogger('bb-prover-parity');
 
 describe('prover/bb_prover/parity', () => {
   let context: TestContext;

--- a/yarn-project/prover-client/src/test/bb_prover_parity.test.ts
+++ b/yarn-project/prover-client/src/test/bb_prover_parity.test.ts
@@ -24,7 +24,7 @@ import { NoopTelemetryClient } from '@aztec/telemetry-client/noop';
 
 import { TestContext } from '../mocks/test_context.js';
 
-const logger = createLogger('bb-prover-parity');
+const logger = createLogger('prover-client:test:bb-prover-parity');
 
 describe('prover/bb_prover/parity', () => {
   let context: TestContext;

--- a/yarn-project/prover-node/src/bond/bond-manager.ts
+++ b/yarn-project/prover-node/src/bond/bond-manager.ts
@@ -1,10 +1,10 @@
-import { createDebugLogger } from '@aztec/foundation/log';
+import { createLogger } from '@aztec/foundation/log';
 
 import { type EscrowContract } from './escrow-contract.js';
 import { type TokenContract } from './token-contract.js';
 
 export class BondManager {
-  private readonly logger = createDebugLogger('aztec:prover-node:bond-manager');
+  private readonly logger = createLogger('prover-node:bond-manager');
 
   constructor(
     private readonly tokenContract: TokenContract,

--- a/yarn-project/prover-node/src/bond/token-contract.ts
+++ b/yarn-project/prover-node/src/bond/token-contract.ts
@@ -1,5 +1,5 @@
 import { EthAddress } from '@aztec/circuits.js';
-import { createDebugLogger } from '@aztec/foundation/log';
+import { createLogger } from '@aztec/foundation/log';
 import { IERC20Abi, TestERC20Abi } from '@aztec/l1-artifacts';
 
 import {
@@ -21,7 +21,7 @@ const MIN_ALLOWANCE = 1n << 255n;
 
 export class TokenContract {
   private token: GetContractReturnType<typeof IERC20Abi, WalletClient<HttpTransport, Chain, PrivateKeyAccount>>;
-  private logger = createDebugLogger('aztec:prover-node:token-contract');
+  private logger = createLogger('prover-node:token-contract');
 
   constructor(
     private readonly client: Client<

--- a/yarn-project/prover-node/src/factory.ts
+++ b/yarn-project/prover-node/src/factory.ts
@@ -39,7 +39,7 @@ export async function createProverNode(
   } = {},
 ) {
   const telemetry = deps.telemetry ?? new NoopTelemetryClient();
-  const log = deps.log ?? createLogger('prover');
+  const log = deps.log ?? createLogger('prover-node');
   const archiver = deps.archiver ?? (await createArchiver(config, telemetry, { blockUntilSync: true }));
   log.verbose(`Created archiver and synced to block ${await archiver.getBlockNumber()}`);
 

--- a/yarn-project/prover-node/src/factory.ts
+++ b/yarn-project/prover-node/src/factory.ts
@@ -2,7 +2,7 @@ import { type Archiver, createArchiver } from '@aztec/archiver';
 import { type ProverCoordination, type ProvingJobBroker } from '@aztec/circuit-types';
 import { createEthereumChain } from '@aztec/ethereum';
 import { Buffer32 } from '@aztec/foundation/buffer';
-import { type DebugLogger, createDebugLogger } from '@aztec/foundation/log';
+import { type Logger, createLogger } from '@aztec/foundation/log';
 import { type DataStoreConfig } from '@aztec/kv-store/config';
 import { RollupAbi } from '@aztec/l1-artifacts';
 import { createProverClient } from '@aztec/prover-client';
@@ -31,7 +31,7 @@ export async function createProverNode(
   config: ProverNodeConfig & DataStoreConfig,
   deps: {
     telemetry?: TelemetryClient;
-    log?: DebugLogger;
+    log?: Logger;
     aztecNodeTxProvider?: ProverCoordination;
     archiver?: Archiver;
     publisher?: L1Publisher;
@@ -39,7 +39,7 @@ export async function createProverNode(
   } = {},
 ) {
   const telemetry = deps.telemetry ?? new NoopTelemetryClient();
-  const log = deps.log ?? createDebugLogger('aztec:prover');
+  const log = deps.log ?? createLogger('prover');
   const archiver = deps.archiver ?? (await createArchiver(config, telemetry, { blockUntilSync: true }));
   log.verbose(`Created archiver and synced to block ${await archiver.getBlockNumber()}`);
 

--- a/yarn-project/prover-node/src/job/epoch-proving-job.ts
+++ b/yarn-project/prover-node/src/job/epoch-proving-job.ts
@@ -29,7 +29,7 @@ import { type ProverNodeMetrics } from '../metrics.js';
  */
 export class EpochProvingJob {
   private state: EpochProvingJobState = 'initialized';
-  private log = createLogger('epoch-proving-job');
+  private log = createLogger('prover-node:epoch-proving-job');
   private uuid: string;
 
   private runPromise: Promise<void> | undefined;

--- a/yarn-project/prover-node/src/job/epoch-proving-job.ts
+++ b/yarn-project/prover-node/src/job/epoch-proving-job.ts
@@ -12,7 +12,7 @@ import {
   type TxHash,
 } from '@aztec/circuit-types';
 import { asyncPool } from '@aztec/foundation/async-pool';
-import { createDebugLogger } from '@aztec/foundation/log';
+import { createLogger } from '@aztec/foundation/log';
 import { promiseWithResolvers } from '@aztec/foundation/promise';
 import { Timer } from '@aztec/foundation/timer';
 import { type L1Publisher } from '@aztec/sequencer-client';
@@ -29,7 +29,7 @@ import { type ProverNodeMetrics } from '../metrics.js';
  */
 export class EpochProvingJob {
   private state: EpochProvingJobState = 'initialized';
-  private log = createDebugLogger('aztec:epoch-proving-job');
+  private log = createLogger('epoch-proving-job');
   private uuid: string;
 
   private runPromise: Promise<void> | undefined;

--- a/yarn-project/prover-node/src/monitors/claims-monitor.ts
+++ b/yarn-project/prover-node/src/monitors/claims-monitor.ts
@@ -1,6 +1,6 @@
 import { type EpochProofClaim } from '@aztec/circuit-types';
 import { type EthAddress } from '@aztec/circuits.js';
-import { createDebugLogger } from '@aztec/foundation/log';
+import { createLogger } from '@aztec/foundation/log';
 import { RunningPromise } from '@aztec/foundation/running-promise';
 import { type L1Publisher } from '@aztec/sequencer-client';
 
@@ -10,7 +10,7 @@ export interface ClaimsMonitorHandler {
 
 export class ClaimsMonitor {
   private runningPromise: RunningPromise;
-  private log = createDebugLogger('aztec:prover-node:claims-monitor');
+  private log = createLogger('prover-node:claims-monitor');
 
   private handler: ClaimsMonitorHandler | undefined;
   private lastClaimEpochNumber: bigint | undefined;

--- a/yarn-project/prover-node/src/monitors/epoch-monitor.ts
+++ b/yarn-project/prover-node/src/monitors/epoch-monitor.ts
@@ -1,5 +1,5 @@
 import { type L2BlockSource } from '@aztec/circuit-types';
-import { createDebugLogger } from '@aztec/foundation/log';
+import { createLogger } from '@aztec/foundation/log';
 import { RunningPromise } from '@aztec/foundation/running-promise';
 
 export interface EpochMonitorHandler {
@@ -9,7 +9,7 @@ export interface EpochMonitorHandler {
 
 export class EpochMonitor {
   private runningPromise: RunningPromise;
-  private log = createDebugLogger('aztec:prover-node:epoch-monitor');
+  private log = createLogger('prover-node:epoch-monitor');
 
   private handler: EpochMonitorHandler | undefined;
 

--- a/yarn-project/prover-node/src/prover-cache/cache_manager.ts
+++ b/yarn-project/prover-node/src/prover-cache/cache_manager.ts
@@ -1,5 +1,5 @@
 import { type ProverCache } from '@aztec/circuit-types';
-import { createDebugLogger } from '@aztec/foundation/log';
+import { createLogger } from '@aztec/foundation/log';
 import { AztecLmdbStore } from '@aztec/kv-store/lmdb';
 import { InMemoryProverCache } from '@aztec/prover-client';
 
@@ -14,7 +14,7 @@ const EPOCH_DIR_SEPARATOR = '_';
 const EPOCH_HASH_FILENAME = 'epoch_hash.txt';
 
 export class ProverCacheManager {
-  constructor(private cacheDir?: string, private log = createDebugLogger('aztec:prover-node:cache-manager')) {}
+  constructor(private cacheDir?: string, private log = createLogger('prover-node:cache-manager')) {}
 
   public async openCache(epochNumber: bigint, epochHash: Buffer): Promise<ProverCache> {
     if (!this.cacheDir) {

--- a/yarn-project/prover-node/src/prover-coordination/factory.ts
+++ b/yarn-project/prover-node/src/prover-coordination/factory.ts
@@ -1,7 +1,7 @@
 import { type ArchiveSource, type Archiver } from '@aztec/archiver';
 import { BBCircuitVerifier, TestCircuitVerifier } from '@aztec/bb-prover';
 import { type ProverCoordination, type WorldStateSynchronizer, createAztecNodeClient } from '@aztec/circuit-types';
-import { createDebugLogger } from '@aztec/foundation/log';
+import { createLogger } from '@aztec/foundation/log';
 import { type DataStoreConfig } from '@aztec/kv-store/config';
 import { createP2PClient } from '@aztec/p2p';
 import { type TelemetryClient } from '@aztec/telemetry-client';
@@ -26,7 +26,7 @@ export async function createProverCoordination(
   config: ProverNodeConfig & DataStoreConfig,
   deps: ProverCoordinationDeps,
 ): Promise<ProverCoordination> {
-  const log = createDebugLogger('aztec:createProverCoordination');
+  const log = createLogger('createProverCoordination');
 
   if (deps.aztecNodeTxProvider) {
     log.info('Using prover coordination via aztec node');

--- a/yarn-project/prover-node/src/prover-coordination/factory.ts
+++ b/yarn-project/prover-node/src/prover-coordination/factory.ts
@@ -26,7 +26,7 @@ export async function createProverCoordination(
   config: ProverNodeConfig & DataStoreConfig,
   deps: ProverCoordinationDeps,
 ): Promise<ProverCoordination> {
-  const log = createLogger('createProverCoordination');
+  const log = createLogger('prover-node:prover-coordination');
 
   if (deps.aztecNodeTxProvider) {
     log.info('Using prover coordination via aztec node');

--- a/yarn-project/prover-node/src/prover-node.ts
+++ b/yarn-project/prover-node/src/prover-node.ts
@@ -16,7 +16,7 @@ import {
 import { type ContractDataSource } from '@aztec/circuits.js';
 import { compact } from '@aztec/foundation/collection';
 import { sha256 } from '@aztec/foundation/crypto';
-import { createDebugLogger } from '@aztec/foundation/log';
+import { createLogger } from '@aztec/foundation/log';
 import { type Maybe } from '@aztec/foundation/types';
 import { type L1Publisher } from '@aztec/sequencer-client';
 import { PublicProcessorFactory } from '@aztec/simulator';
@@ -44,7 +44,7 @@ export type ProverNodeOptions = {
  * proof for the epoch, and submits it to L1.
  */
 export class ProverNode implements ClaimsMonitorHandler, EpochMonitorHandler, ProverNodeApi {
-  private log = createDebugLogger('aztec:prover-node');
+  private log = createLogger('prover-node');
 
   private latestEpochWeAreProving: bigint | undefined;
   private jobs: Map<string, EpochProvingJob> = new Map();

--- a/yarn-project/pxe/package.json
+++ b/yarn-project/pxe/package.json
@@ -24,7 +24,7 @@
     "formatting": "run -T prettier --check ./src && run -T eslint ./src",
     "formatting:fix": "run -T eslint --fix ./src && run -T prettier -w ./src",
     "test": "NODE_NO_WARNINGS=1 node --experimental-vm-modules ../node_modules/.bin/jest --passWithNoTests",
-    "start": "DEBUG='aztec:*' && node ./dest/bin/index.js",
+    "start": "LOG_LEVEL=${LOG_LEVEL:-debug} && node ./dest/bin/index.js",
     "generate": "node ./scripts/generate_package_info.js"
   },
   "inherits": [

--- a/yarn-project/pxe/src/bin/index.ts
+++ b/yarn-project/pxe/src/bin/index.ts
@@ -9,7 +9,7 @@ import { createPXEService } from '../utils/index.js';
 
 const { PXE_PORT = 8080, AZTEC_NODE_URL = 'http://localhost:8079' } = process.env;
 
-const logger = createLogger('pxe_service');
+const logger = createLogger('pxe:service');
 
 /**
  * Create and start a new PXE HTTP Server

--- a/yarn-project/pxe/src/bin/index.ts
+++ b/yarn-project/pxe/src/bin/index.ts
@@ -1,7 +1,7 @@
 #!/usr/bin/env -S node --no-warnings
 import { createAztecNodeClient } from '@aztec/circuit-types';
 import { init } from '@aztec/foundation/crypto';
-import { createDebugLogger } from '@aztec/foundation/log';
+import { createLogger } from '@aztec/foundation/log';
 
 import { getPXEServiceConfig } from '../config/index.js';
 import { startPXEHttpServer } from '../pxe_http/index.js';
@@ -9,7 +9,7 @@ import { createPXEService } from '../utils/index.js';
 
 const { PXE_PORT = 8080, AZTEC_NODE_URL = 'http://localhost:8079' } = process.env;
 
-const logger = createDebugLogger('aztec:pxe_service');
+const logger = createLogger('pxe_service');
 
 /**
  * Create and start a new PXE HTTP Server

--- a/yarn-project/pxe/src/kernel_oracle/index.ts
+++ b/yarn-project/pxe/src/kernel_oracle/index.ts
@@ -12,7 +12,7 @@ import {
   computeContractClassIdPreimage,
   computeSaltedInitializationHash,
 } from '@aztec/circuits.js';
-import { createDebugLogger } from '@aztec/foundation/log';
+import { createLogger } from '@aztec/foundation/log';
 import { type Tuple } from '@aztec/foundation/serialize';
 import { type KeyStore } from '@aztec/key-store';
 import { getVKIndex, getVKSiblingPath } from '@aztec/noir-protocol-circuits-types';
@@ -31,7 +31,7 @@ export class KernelOracle implements ProvingDataOracle {
     private keyStore: KeyStore,
     private node: AztecNode,
     private blockNumber: L2BlockNumber = 'latest',
-    private log = createDebugLogger('aztec:pxe:kernel_oracle'),
+    private log = createLogger('pxe:kernel_oracle'),
   ) {}
 
   public async getContractAddressPreimage(address: AztecAddress) {

--- a/yarn-project/pxe/src/kernel_prover/kernel_prover.ts
+++ b/yarn-project/pxe/src/kernel_prover/kernel_prover.ts
@@ -55,7 +55,7 @@ const NULL_PROVE_OUTPUT: PrivateKernelSimulateOutput<PrivateKernelCircuitPublicI
  * constructs private call data based on the execution results.
  */
 export class KernelProver {
-  private log = createLogger('kernel-prover');
+  private log = createLogger('pxe:kernel-prover');
 
   constructor(private oracle: ProvingDataOracle, private proofCreator: PrivateKernelProver) {}
 

--- a/yarn-project/pxe/src/kernel_prover/kernel_prover.ts
+++ b/yarn-project/pxe/src/kernel_prover/kernel_prover.ts
@@ -26,7 +26,7 @@ import {
 import { hashVK } from '@aztec/circuits.js/hash';
 import { makeTuple } from '@aztec/foundation/array';
 import { vkAsFieldsMegaHonk } from '@aztec/foundation/crypto';
-import { createDebugLogger } from '@aztec/foundation/log';
+import { createLogger } from '@aztec/foundation/log';
 import { assertLength } from '@aztec/foundation/serialize';
 import { pushTestData } from '@aztec/foundation/testing';
 import { getVKTreeRoot } from '@aztec/noir-protocol-circuits-types';
@@ -55,7 +55,7 @@ const NULL_PROVE_OUTPUT: PrivateKernelSimulateOutput<PrivateKernelCircuitPublicI
  * constructs private call data based on the execution results.
  */
 export class KernelProver {
-  private log = createDebugLogger('aztec:kernel-prover');
+  private log = createLogger('kernel-prover');
 
   constructor(private oracle: ProvingDataOracle, private proofCreator: PrivateKernelProver) {}
 

--- a/yarn-project/pxe/src/kernel_prover/test/test_circuit_prover.ts
+++ b/yarn-project/pxe/src/kernel_prover/test/test_circuit_prover.ts
@@ -35,7 +35,7 @@ import { type WitnessMap } from '@noir-lang/types';
  * Test Proof Creator executes circuit simulations and provides fake proofs.
  */
 export class TestPrivateKernelProver implements PrivateKernelProver {
-  constructor(private log = createLogger('test_proof_creator')) {}
+  constructor(private log = createLogger('pxe:test_proof_creator')) {}
 
   createClientIvcProof(_acirs: Buffer[], _witnessStack: WitnessMap[]): Promise<ClientIvcProof> {
     return Promise.resolve(ClientIvcProof.empty());

--- a/yarn-project/pxe/src/kernel_prover/test/test_circuit_prover.ts
+++ b/yarn-project/pxe/src/kernel_prover/test/test_circuit_prover.ts
@@ -15,7 +15,7 @@ import {
   type PrivateKernelTailCircuitPublicInputs,
   VerificationKeyAsFields,
 } from '@aztec/circuits.js';
-import { createDebugLogger } from '@aztec/foundation/log';
+import { createLogger } from '@aztec/foundation/log';
 import { elapsed } from '@aztec/foundation/timer';
 import {
   type ProtocolArtifact,
@@ -35,7 +35,7 @@ import { type WitnessMap } from '@noir-lang/types';
  * Test Proof Creator executes circuit simulations and provides fake proofs.
  */
 export class TestPrivateKernelProver implements PrivateKernelProver {
-  constructor(private log = createDebugLogger('aztec:test_proof_creator')) {}
+  constructor(private log = createLogger('test_proof_creator')) {}
 
   createClientIvcProof(_acirs: Buffer[], _witnessStack: WitnessMap[]): Promise<ClientIvcProof> {
     return Promise.resolve(ClientIvcProof.empty());

--- a/yarn-project/pxe/src/pxe_service/create_pxe_service.ts
+++ b/yarn-project/pxe/src/pxe_service/create_pxe_service.ts
@@ -1,7 +1,7 @@
 import { BBNativePrivateKernelProver } from '@aztec/bb-prover';
 import { type AztecNode, type PrivateKernelProver } from '@aztec/circuit-types';
 import { randomBytes } from '@aztec/foundation/crypto';
-import { createDebugLogger } from '@aztec/foundation/log';
+import { createLogger } from '@aztec/foundation/log';
 import { KeyStore } from '@aztec/key-store';
 import { createStore } from '@aztec/kv-store/lmdb';
 import { L2TipsStore } from '@aztec/kv-store/stores';
@@ -38,10 +38,10 @@ export async function createPXEService(
   } as PXEServiceConfig;
 
   const keyStore = new KeyStore(
-    await createStore('pxe_key_store', configWithContracts, createDebugLogger('aztec:pxe:keystore:lmdb')),
+    await createStore('pxe_key_store', configWithContracts, createLogger('pxe:keystore:lmdb')),
   );
 
-  const store = await createStore('pxe_data', configWithContracts, createDebugLogger('aztec:pxe:data:lmdb'));
+  const store = await createStore('pxe_data', configWithContracts, createLogger('pxe:data:lmdb'));
 
   const db = await KVPxeDatabase.create(store);
   const tips = new L2TipsStore(store, 'pxe');
@@ -62,6 +62,6 @@ function createProver(config: PXEServiceConfig, logSuffix?: string) {
     throw new Error(`Prover must be configured with binary path and working directory`);
   }
   const bbConfig = config as Required<Pick<PXEServiceConfig, 'bbBinaryPath' | 'bbWorkingDirectory'>> & PXEServiceConfig;
-  const log = createDebugLogger('aztec:pxe:bb-native-prover' + (logSuffix ? `:${logSuffix}` : ''));
+  const log = createLogger('pxe:bb-native-prover' + (logSuffix ? `:${logSuffix}` : ''));
   return BBNativePrivateKernelProver.new({ bbSkipCleanup: false, ...bbConfig }, log);
 }

--- a/yarn-project/pxe/src/pxe_service/error_enriching.ts
+++ b/yarn-project/pxe/src/pxe_service/error_enriching.ts
@@ -1,6 +1,6 @@
 import { type SimulationError, isNoirCallStackUnresolved } from '@aztec/circuit-types';
 import { AztecAddress, Fr, FunctionSelector, PUBLIC_DISPATCH_SELECTOR } from '@aztec/circuits.js';
-import { type DebugLogger } from '@aztec/foundation/log';
+import { type Logger } from '@aztec/foundation/log';
 import { resolveAssertionMessageFromRevertData, resolveOpcodeLocations } from '@aztec/simulator/errors';
 
 import { type ContractDataOracle, type PxeDatabase } from '../index.js';
@@ -10,7 +10,7 @@ import { type ContractDataOracle, type PxeDatabase } from '../index.js';
  * can be found in the PXE database
  * @param err - The error to enrich.
  */
-export async function enrichSimulationError(err: SimulationError, db: PxeDatabase, logger: DebugLogger) {
+export async function enrichSimulationError(err: SimulationError, db: PxeDatabase, logger: Logger) {
   // Maps contract addresses to the set of functions selectors that were in error.
   // Map and Set do reference equality for their keys instead of value equality, so we store the string
   // representation to get e.g. different contract address objects with the same address value to match.
@@ -56,7 +56,7 @@ export async function enrichPublicSimulationError(
   err: SimulationError,
   contractDataOracle: ContractDataOracle,
   db: PxeDatabase,
-  logger: DebugLogger,
+  logger: Logger,
 ) {
   const callStack = err.getCallStack();
   const originalFailingFunction = callStack[callStack.length - 1];

--- a/yarn-project/pxe/src/pxe_service/pxe_service.ts
+++ b/yarn-project/pxe/src/pxe_service/pxe_service.ts
@@ -56,7 +56,7 @@ import {
   encodeArguments,
 } from '@aztec/foundation/abi';
 import { Fr, type Point } from '@aztec/foundation/fields';
-import { type DebugLogger, createDebugLogger } from '@aztec/foundation/log';
+import { type Logger, createLogger } from '@aztec/foundation/log';
 import { SerialQueue } from '@aztec/foundation/queue';
 import { type KeyStore } from '@aztec/key-store';
 import { type L2TipsStore } from '@aztec/kv-store/stores';
@@ -88,7 +88,7 @@ export class PXEService implements PXE {
   private synchronizer: Synchronizer;
   private contractDataOracle: ContractDataOracle;
   private simulator: AcirSimulator;
-  private log: DebugLogger;
+  private log: Logger;
   private packageVersion: string;
   // serialize synchronizer and calls to proveTx.
   // ensures that state is not changed while simulating
@@ -103,7 +103,7 @@ export class PXEService implements PXE {
     config: PXEServiceConfig,
     logSuffix?: string,
   ) {
-    this.log = createDebugLogger(logSuffix ? `aztec:pxe_service_${logSuffix}` : `aztec:pxe_service`);
+    this.log = createLogger(logSuffix ? `aztec:pxe_service_${logSuffix}` : `aztec:pxe_service`);
     this.synchronizer = new Synchronizer(node, db, tipsStore, config, logSuffix);
     this.contractDataOracle = new ContractDataOracle(db);
     this.simulator = getAcirSimulator(db, node, keyStore, this.contractDataOracle);

--- a/yarn-project/pxe/src/pxe_service/pxe_service.ts
+++ b/yarn-project/pxe/src/pxe_service/pxe_service.ts
@@ -103,7 +103,7 @@ export class PXEService implements PXE {
     config: PXEServiceConfig,
     logSuffix?: string,
   ) {
-    this.log = createLogger(logSuffix ? `aztec:pxe_service_${logSuffix}` : `aztec:pxe_service`);
+    this.log = createLogger(logSuffix ? `pxe:service:${logSuffix}` : `pxe:service`);
     this.synchronizer = new Synchronizer(node, db, tipsStore, config, logSuffix);
     this.contractDataOracle = new ContractDataOracle(db);
     this.simulator = getAcirSimulator(db, node, keyStore, this.contractDataOracle);

--- a/yarn-project/pxe/src/simulator_oracle/index.ts
+++ b/yarn-project/pxe/src/simulator_oracle/index.ts
@@ -29,7 +29,7 @@ import {
 import { type FunctionArtifact, getFunctionArtifact } from '@aztec/foundation/abi';
 import { poseidon2Hash } from '@aztec/foundation/crypto';
 import { tryJsonStringify } from '@aztec/foundation/json-rpc';
-import { createDebugLogger } from '@aztec/foundation/log';
+import { createLogger } from '@aztec/foundation/log';
 import { type KeyStore } from '@aztec/key-store';
 import { MessageLoadOracleInputs } from '@aztec/simulator/acvm';
 import { type AcirSimulator, type DBOracle } from '@aztec/simulator/client';
@@ -50,7 +50,7 @@ export class SimulatorOracle implements DBOracle {
     private db: PxeDatabase,
     private keyStore: KeyStore,
     private aztecNode: AztecNode,
-    private log = createDebugLogger('aztec:pxe:simulator_oracle'),
+    private log = createLogger('pxe:simulator_oracle'),
   ) {}
 
   getKeyValidationRequest(pkMHash: Fr, contractAddress: AztecAddress): Promise<KeyValidationRequest> {

--- a/yarn-project/pxe/src/synchronizer/synchronizer.ts
+++ b/yarn-project/pxe/src/synchronizer/synchronizer.ts
@@ -31,7 +31,7 @@ export class Synchronizer implements L2BlockStreamEventHandler {
     config: Partial<Pick<PXEConfig, 'l2BlockPollingIntervalMS' | 'l2StartingBlock'>> = {},
     logSuffix?: string,
   ) {
-    this.log = createLogger(logSuffix ? `aztec:pxe_synchronizer_${logSuffix}` : 'aztec:pxe_synchronizer');
+    this.log = createLogger(logSuffix ? `pxe:synchronizer:${logSuffix}` : 'pxe:synchronizer');
     this.blockStream = this.createBlockStream(config);
   }
 

--- a/yarn-project/pxe/src/synchronizer/synchronizer.ts
+++ b/yarn-project/pxe/src/synchronizer/synchronizer.ts
@@ -5,7 +5,7 @@ import {
   type L2BlockStreamEventHandler,
 } from '@aztec/circuit-types';
 import { INITIAL_L2_BLOCK_NUM } from '@aztec/circuits.js';
-import { type DebugLogger, createDebugLogger } from '@aztec/foundation/log';
+import { type Logger, createLogger } from '@aztec/foundation/log';
 import { type L2TipsStore } from '@aztec/kv-store/stores';
 
 import { type PXEConfig } from '../config/index.js';
@@ -21,7 +21,7 @@ import { type PxeDatabase } from '../database/index.js';
 export class Synchronizer implements L2BlockStreamEventHandler {
   private running = false;
   private initialSyncBlockNumber = INITIAL_L2_BLOCK_NUM - 1;
-  private log: DebugLogger;
+  private log: Logger;
   protected readonly blockStream: L2BlockStream;
 
   constructor(
@@ -31,7 +31,7 @@ export class Synchronizer implements L2BlockStreamEventHandler {
     config: Partial<Pick<PXEConfig, 'l2BlockPollingIntervalMS' | 'l2StartingBlock'>> = {},
     logSuffix?: string,
   ) {
-    this.log = createDebugLogger(logSuffix ? `aztec:pxe_synchronizer_${logSuffix}` : 'aztec:pxe_synchronizer');
+    this.log = createLogger(logSuffix ? `aztec:pxe_synchronizer_${logSuffix}` : 'aztec:pxe_synchronizer');
     this.blockStream = this.createBlockStream(config);
   }
 

--- a/yarn-project/pxe/src/utils/index.ts
+++ b/yarn-project/pxe/src/utils/index.ts
@@ -1,7 +1,7 @@
 import { BBNativePrivateKernelProver } from '@aztec/bb-prover';
 import { type AztecNode, type PrivateKernelProver } from '@aztec/circuit-types';
 import { randomBytes } from '@aztec/foundation/crypto';
-import { createDebugLogger } from '@aztec/foundation/log';
+import { createLogger } from '@aztec/foundation/log';
 import { KeyStore } from '@aztec/key-store';
 import { createStore } from '@aztec/kv-store/lmdb';
 import { L2TipsStore } from '@aztec/kv-store/stores';
@@ -38,10 +38,10 @@ export async function createPXEService(
   } as PXEServiceConfig;
 
   const keyStore = new KeyStore(
-    await createStore('pxe_key_store', configWithContracts, createDebugLogger('aztec:pxe:keystore:lmdb')),
+    await createStore('pxe_key_store', configWithContracts, createLogger('pxe:keystore:lmdb')),
   );
 
-  const store = await createStore('pxe_data', configWithContracts, createDebugLogger('aztec:pxe:data:lmdb'));
+  const store = await createStore('pxe_data', configWithContracts, createLogger('pxe:data:lmdb'));
 
   const db = await KVPxeDatabase.create(store);
   const tips = new L2TipsStore(store, 'pxe');
@@ -62,6 +62,6 @@ function createProver(config: PXEServiceConfig, logSuffix?: string) {
     throw new Error(`Prover must be configured with binary path and working directory`);
   }
   const bbConfig = config as Required<Pick<PXEServiceConfig, 'bbBinaryPath' | 'bbWorkingDirectory'>> & PXEServiceConfig;
-  const log = createDebugLogger('aztec:pxe:bb-native-prover' + (logSuffix ? `:${logSuffix}` : ''));
+  const log = createLogger('pxe:bb-native-prover' + (logSuffix ? `:${logSuffix}` : ''));
   return BBNativePrivateKernelProver.new({ bbSkipCleanup: false, ...bbConfig }, log);
 }

--- a/yarn-project/sequencer-client/src/global_variable_builder/global_builder.ts
+++ b/yarn-project/sequencer-client/src/global_variable_builder/global_builder.ts
@@ -103,7 +103,7 @@ export class GlobalVariableBuilder implements GlobalVariableBuilderInterface {
       feeRecipient,
       gasFees,
     );
-    this.log.debug(`Built global variables for block ${blockNumber}`, globalVariables.toFriendlyJSON());
+
     return globalVariables;
   }
 }

--- a/yarn-project/sequencer-client/src/global_variable_builder/global_builder.ts
+++ b/yarn-project/sequencer-client/src/global_variable_builder/global_builder.ts
@@ -2,7 +2,7 @@ import { type GlobalVariableBuilder as GlobalVariableBuilderInterface } from '@a
 import { type AztecAddress, type EthAddress, GasFees, GlobalVariables } from '@aztec/circuits.js';
 import { type L1ContractsConfig, type L1ReaderConfig, createEthereumChain } from '@aztec/ethereum';
 import { Fr } from '@aztec/foundation/fields';
-import { createDebugLogger } from '@aztec/foundation/log';
+import { createLogger } from '@aztec/foundation/log';
 import { RollupAbi } from '@aztec/l1-artifacts';
 
 import {
@@ -20,7 +20,7 @@ import type * as chains from 'viem/chains';
  * Simple global variables builder.
  */
 export class GlobalVariableBuilder implements GlobalVariableBuilderInterface {
-  private log = createDebugLogger('aztec:sequencer:global_variable_builder');
+  private log = createLogger('sequencer:global_variable_builder');
 
   private rollupContract: GetContractReturnType<typeof RollupAbi, PublicClient<HttpTransport, chains.Chain>>;
   private publicClient: PublicClient<HttpTransport, chains.Chain>;

--- a/yarn-project/sequencer-client/src/publisher/l1-publisher.ts
+++ b/yarn-project/sequencer-client/src/publisher/l1-publisher.ts
@@ -150,6 +150,7 @@ export class L1Publisher {
   private myLastVote: bigint = 0n;
 
   protected log = createLogger('sequencer:publisher');
+  protected governanceLog = createLogger('sequencer:publisher:governance');
 
   protected rollupContract: GetContractReturnType<
     typeof RollupAbi,
@@ -342,7 +343,7 @@ export class L1Publisher {
       await this.rollupContract.read.validateEpochProofRightClaimAtTime(args, { account: this.account });
     } catch (err) {
       const errorName = tryGetCustomErrorName(err);
-      this.log.warn(`Proof quote validation failed: ${errorName}`);
+      this.log.warn(`Proof quote validation failed: ${errorName}`, quote);
       return undefined;
     }
     return quote;
@@ -432,7 +433,7 @@ export class L1Publisher {
       this.governanceProposerContract.read.computeRound([slotNumber]),
     ]);
 
-    if (proposer != this.account.address) {
+    if (proposer.toLowerCase() !== this.account.address.toLowerCase()) {
       return false;
     }
 
@@ -450,14 +451,14 @@ export class L1Publisher {
     const cachedMyLastVote = this.myLastVote;
     this.myLastVote = slotNumber;
 
+    this.governanceLog.verbose(`Casting vote for ${this.payload}`);
+
     let txHash;
     try {
-      txHash = await this.governanceProposerContract.write.vote([this.payload.toString()], {
-        account: this.account,
-      });
+      txHash = await this.governanceProposerContract.write.vote([this.payload.toString()], { account: this.account });
     } catch (err) {
       const msg = prettyLogViemErrorMsg(err);
-      this.log.error(`Governance: Failed to vote`, msg);
+      this.governanceLog.error(`Failed to vote`, msg);
       this.myLastVote = cachedMyLastVote;
       return false;
     }
@@ -465,14 +466,13 @@ export class L1Publisher {
     if (txHash) {
       const receipt = await this.getTransactionReceipt(txHash);
       if (!receipt) {
-        this.log.info(`Failed to get receipt for tx ${txHash}`);
+        this.governanceLog.warn(`Failed to get receipt for tx ${txHash}`);
         this.myLastVote = cachedMyLastVote;
         return false;
       }
     }
 
-    this.log.info(`Governance: Cast vote for ${this.payload}`);
-
+    this.governanceLog.info(`Cast vote for ${this.payload}`);
     return true;
   }
 
@@ -522,7 +522,7 @@ export class L1Publisher {
       signatures: attestations ?? [],
     });
 
-    this.log.verbose(`Submitting propose transaction`);
+    this.log.debug(`Submitting propose transaction`);
     const result = proofQuote
       ? await this.sendProposeAndClaimTx(proposeTxArgs, proofQuote)
       : await this.sendProposeTx(proposeTxArgs);
@@ -545,7 +545,7 @@ export class L1Publisher {
         ...block.getStats(),
         eventName: 'rollup-published-to-l1',
       };
-      this.log.info(`Published L2 block to L1 rollup contract`, { ...stats, ...ctx });
+      this.log.verbose(`Published L2 block to L1 rollup contract`, { ...stats, ...ctx });
       this.metrics.recordProcessBlockTx(timer.ms(), stats);
       return true;
     }
@@ -843,8 +843,7 @@ export class L1Publisher {
       };
     } catch (err) {
       prettyLogViemError(err, this.log);
-      const errorMessage = err instanceof Error ? err.message : String(err);
-      this.log.error(`Rollup publish failed`, errorMessage);
+      this.log.error(`Rollup publish failed`, err);
       return undefined;
     }
   }

--- a/yarn-project/sequencer-client/src/publisher/l1-publisher.ts
+++ b/yarn-project/sequencer-client/src/publisher/l1-publisher.ts
@@ -28,7 +28,7 @@ import { makeTuple } from '@aztec/foundation/array';
 import { areArraysEqual, compactArray, times } from '@aztec/foundation/collection';
 import { type Signature } from '@aztec/foundation/eth-signature';
 import { Fr } from '@aztec/foundation/fields';
-import { createDebugLogger } from '@aztec/foundation/log';
+import { createLogger } from '@aztec/foundation/log';
 import { type Tuple, serializeToBuffer } from '@aztec/foundation/serialize';
 import { InterruptibleSleep } from '@aztec/foundation/sleep';
 import { Timer } from '@aztec/foundation/timer';
@@ -149,7 +149,7 @@ export class L1Publisher {
   private payload: EthAddress = EthAddress.ZERO;
   private myLastVote: bigint = 0n;
 
-  protected log = createDebugLogger('aztec:sequencer:publisher');
+  protected log = createLogger('sequencer:publisher');
 
   protected rollupContract: GetContractReturnType<
     typeof RollupAbi,

--- a/yarn-project/sequencer-client/src/publisher/utils.ts
+++ b/yarn-project/sequencer-client/src/publisher/utils.ts
@@ -14,6 +14,7 @@ export function prettyLogViemErrorMsg(err: any) {
   }
 }
 
+// TODO(palla/log): Review this method
 export function prettyLogViemError(err: any, logger: Logger) {
   const msg = prettyLogViemErrorMsg(err);
   if (msg) {

--- a/yarn-project/sequencer-client/src/sequencer/sequencer.ts
+++ b/yarn-project/sequencer-client/src/sequencer/sequencer.ts
@@ -22,7 +22,7 @@ import {
 import { AztecAddress } from '@aztec/foundation/aztec-address';
 import { EthAddress } from '@aztec/foundation/eth-address';
 import { Fr } from '@aztec/foundation/fields';
-import { createDebugLogger } from '@aztec/foundation/log';
+import { createLogger } from '@aztec/foundation/log';
 import { RunningPromise } from '@aztec/foundation/running-promise';
 import { Timer, elapsed } from '@aztec/foundation/timer';
 import { type P2P } from '@aztec/p2p';
@@ -108,7 +108,7 @@ export class Sequencer {
     private aztecSlotDuration: number,
     telemetry: TelemetryClient,
     private config: SequencerConfig = {},
-    private log = createDebugLogger('aztec:sequencer'),
+    private log = createLogger('sequencer'),
   ) {
     this.updateConfig(config);
     this.metrics = new SequencerMetrics(telemetry, () => this.state, 'Sequencer');

--- a/yarn-project/sequencer-client/src/sequencer/sequencer.ts
+++ b/yarn-project/sequencer-client/src/sequencer/sequencer.ts
@@ -4,6 +4,7 @@ import {
   type L2Block,
   type L2BlockSource,
   type ProcessedTx,
+  SequencerConfigSchema,
   Tx,
   type TxHash,
   type TxValidator,
@@ -20,18 +21,18 @@ import {
   StateReference,
 } from '@aztec/circuits.js';
 import { AztecAddress } from '@aztec/foundation/aztec-address';
+import { omit } from '@aztec/foundation/collection';
 import { EthAddress } from '@aztec/foundation/eth-address';
 import { Fr } from '@aztec/foundation/fields';
 import { createLogger } from '@aztec/foundation/log';
 import { RunningPromise } from '@aztec/foundation/running-promise';
+import { pickFromSchema } from '@aztec/foundation/schemas';
 import { Timer, elapsed } from '@aztec/foundation/timer';
 import { type P2P } from '@aztec/p2p';
 import { type BlockBuilderFactory } from '@aztec/prover-client/block-builder';
 import { type PublicProcessorFactory } from '@aztec/simulator';
 import { Attributes, type TelemetryClient, type Tracer, trackSpan } from '@aztec/telemetry-client';
 import { type ValidatorClient } from '@aztec/validator-client';
-
-import { inspect } from 'util';
 
 import { type GlobalVariableBuilder } from '../global_variable_builder/global_builder.js';
 import { type L1Publisher } from '../publisher/l1-publisher.js';
@@ -112,7 +113,6 @@ export class Sequencer {
   ) {
     this.updateConfig(config);
     this.metrics = new SequencerMetrics(telemetry, () => this.state, 'Sequencer');
-    this.log.verbose(`Initialized sequencer with ${this.minTxsPerBLock}-${this.maxTxsPerBlock} txs per block.`);
 
     // Register the block builder with the validator client for re-execution
     this.validatorClient?.registerBlockBuilder(this.buildBlock.bind(this));
@@ -127,6 +127,11 @@ export class Sequencer {
    * @param config - New parameters.
    */
   public updateConfig(config: SequencerConfig) {
+    this.log.info(
+      `Sequencer config set`,
+      omit(pickFromSchema(this.config, SequencerConfigSchema), 'allowedInSetup', 'allowedInTeardown'),
+    );
+
     if (config.transactionPollingIntervalMS !== undefined) {
       this.pollingIntervalMs = config.transactionPollingIntervalMS;
     }
@@ -188,9 +193,9 @@ export class Sequencer {
    */
   public start() {
     this.runningPromise = new RunningPromise(this.work.bind(this), this.pollingIntervalMs);
-    this.runningPromise.start();
     this.setState(SequencerState.IDLE, 0n, true /** force */);
-    this.log.info('Sequencer started');
+    this.runningPromise.start();
+    this.log.info(`Sequencer started`);
     return Promise.resolve();
   }
 
@@ -237,11 +242,8 @@ export class Sequencer {
     const prevBlockSynced = await this.isBlockSynced();
     // Do not go forward with new block if the previous one has not been mined and processed
     if (!prevBlockSynced) {
-      this.log.debug('Previous block has not been mined and processed yet');
       return;
     }
-
-    this.log.debug('Previous block has been mined and processed');
 
     this.setState(SequencerState.PROPOSER_CHECK, 0n);
 
@@ -278,6 +280,12 @@ export class Sequencer {
       return;
     }
 
+    this.log.verbose(`Preparing proposal for block ${newBlockNumber} at slot ${slot}`, {
+      chainTipArchive: new Fr(chainTipArchive),
+      blockNumber: newBlockNumber,
+      slot,
+    });
+
     this.setState(SequencerState.WAITING_FOR_TXS, slot);
 
     // Get txs to build the new block.
@@ -286,7 +294,11 @@ export class Sequencer {
     if (!this.shouldProposeBlock(historicalHeader, { pendingTxsCount: pendingTxs.length })) {
       return;
     }
-    this.log.debug(`Retrieved ${pendingTxs.length} txs from P2P pool`);
+
+    this.log.verbose(
+      `Retrieved ${pendingTxs.length} txs for block ${newBlockNumber} with global variables`,
+      newGlobalVariables.toInspect(),
+    );
 
     // If I created a "partial" header here that should make our job much easier.
     const proposalHeader = new BlockHeader(
@@ -322,7 +334,7 @@ export class Sequencer {
       //        be in for a world of pain.
       await this.buildBlockAndAttemptToPublish(validTxs, proposalHeader, historicalHeader);
     } catch (err) {
-      this.log.error(`Error assembling block`, (err as any).stack);
+      this.log.error(`Error assembling block`, err, { blockNumber: newBlockNumber, slot });
     }
     this.setState(SequencerState.IDLE, 0n);
   }
@@ -357,18 +369,14 @@ export class Sequencer {
       const [slot, blockNumber] = await this.publisher.canProposeAtNextEthBlock(tipArchive);
 
       if (proposalBlockNumber !== blockNumber) {
-        const msg = `Block number mismatch. Expected ${proposalBlockNumber} but got ${blockNumber}`;
-        this.log.debug(msg);
+        const msg = `Sequencer block number mismatch. Expected ${proposalBlockNumber} but got ${blockNumber}.`;
+        this.log.warn(msg);
         throw new Error(msg);
       }
-
-      this.log.verbose(`Can propose block ${proposalBlockNumber} at slot ${slot}`, {
-        publisherAddress: this.publisher.publisherAddress,
-      });
       return slot;
     } catch (err) {
       const msg = prettyLogViemErrorMsg(err);
-      this.log.verbose(
+      this.log.debug(
         `Rejected from being able to propose at next block with ${tipArchive.toString('hex')}: ${msg ? `${msg}` : ''}`,
       );
       throw err;
@@ -412,15 +420,14 @@ export class Sequencer {
    */
   setState(proposedState: SequencerState, currentSlotNumber: bigint, force: boolean = false) {
     if (this.state === SequencerState.STOPPED && force !== true) {
-      this.log.warn(
-        `Cannot set sequencer from ${this.state} to ${proposedState} as it is stopped. Set force=true to override.`,
-      );
+      this.log.warn(`Cannot set sequencer from ${this.state} to ${proposedState} as it is stopped.`);
       return;
     }
     const secondsIntoSlot = getSecondsIntoSlot(this.l1GenesisTime, this.aztecSlotDuration, Number(currentSlotNumber));
     if (!this.doIHaveEnoughTimeLeft(proposedState, secondsIntoSlot)) {
       throw new SequencerTooSlowError(this.state, proposedState, this.timeTable[proposedState], secondsIntoSlot);
     }
+    this.log.debug(`Transitioning from ${this.state} to ${proposedState}`);
     this.state = proposedState;
   }
 
@@ -441,7 +448,7 @@ export class Sequencer {
     // If we haven't hit the maxSecondsBetweenBlocks, we need to have at least minTxsPerBLock txs.
     // Do not go forward with new block if not enough time has passed since last block
     if (this.minSecondsBetweenBlocks > 0 && elapsedSinceLastBlock < this.minSecondsBetweenBlocks) {
-      this.log.debug(
+      this.log.verbose(
         `Not creating block because not enough time ${this.minSecondsBetweenBlocks} has passed since last block`,
       );
       return false;
@@ -457,7 +464,7 @@ export class Sequencer {
             `Creating block with only ${args.pendingTxsCount} txs as more than ${this.maxSecondsBetweenBlocks}s have passed since last block`,
           );
         } else {
-          this.log.debug(
+          this.log.verbose(
             `Not creating block because not enough txs in the pool (got ${args.pendingTxsCount} min ${this.minTxsPerBLock})`,
           );
           return false;
@@ -469,7 +476,7 @@ export class Sequencer {
     if (args.validTxsCount != undefined) {
       // Bail if we don't have enough valid txs
       if (!skipCheck && args.validTxsCount < this.minTxsPerBLock) {
-        this.log.debug(
+        this.log.verbose(
           `Not creating block because not enough valid txs loaded from the pool (got ${args.validTxsCount} min ${this.minTxsPerBLock})`,
         );
         return false;
@@ -482,7 +489,7 @@ export class Sequencer {
     // we should bail.
     if (args.processedTxsCount != undefined) {
       if (args.processedTxsCount === 0 && !skipCheck && this.minTxsPerBLock > 0) {
-        this.log.verbose('No txs processed correctly to build block. Exiting');
+        this.log.verbose('No txs processed correctly to build block.');
         return false;
       }
     }
@@ -506,18 +513,25 @@ export class Sequencer {
     historicalHeader?: BlockHeader,
     interrupt?: (processedTxs: ProcessedTx[]) => Promise<void>,
   ) {
-    this.log.debug('Requesting L1 to L2 messages from contract');
-    const l1ToL2Messages = await this.l1ToL2MessageSource.getL1ToL2Messages(newGlobalVariables.blockNumber.toBigInt());
-    this.log.verbose(
-      `Retrieved ${l1ToL2Messages.length} L1 to L2 messages for block ${newGlobalVariables.blockNumber.toNumber()}`,
-    );
+    const blockNumber = newGlobalVariables.blockNumber.toBigInt();
+    const slot = newGlobalVariables.slotNumber.toBigInt();
+
+    this.log.debug(`Requesting L1 to L2 messages from contract for block ${blockNumber}`);
+    const l1ToL2Messages = await this.l1ToL2MessageSource.getL1ToL2Messages(blockNumber);
+
+    this.log.verbose(`Building block ${blockNumber}`, {
+      msgCount: l1ToL2Messages.length,
+      txCount: validTxs.length,
+      slot,
+      blockNumber,
+    });
 
     const numRealTxs = validTxs.length;
     const blockSize = Math.max(2, numRealTxs);
 
     // Sync to the previous block at least
     await this.worldState.syncImmediate(newGlobalVariables.blockNumber.toNumber() - 1);
-    this.log.verbose(`Synced to previous block ${newGlobalVariables.blockNumber.toNumber() - 1}`);
+    this.log.debug(`Synced to previous block ${newGlobalVariables.blockNumber.toNumber() - 1}`);
 
     // NB: separating the dbs because both should update the state
     const publicProcessorFork = await this.worldState.fork();
@@ -539,7 +553,7 @@ export class Sequencer {
       );
       if (failedTxs.length > 0) {
         const failedTxData = failedTxs.map(fail => fail.tx);
-        this.log.debug(`Dropping failed txs ${Tx.getHashes(failedTxData).join(', ')}`);
+        this.log.verbose(`Dropping failed txs ${Tx.getHashes(failedTxData).join(', ')}`);
         await this.p2pClient.deleteTxs(Tx.getHashes(failedTxData));
       }
 
@@ -577,15 +591,12 @@ export class Sequencer {
     await this.publisher.validateBlockForSubmission(proposalHeader);
 
     const newGlobalVariables = proposalHeader.globalVariables;
+    const blockNumber = newGlobalVariables.blockNumber.toNumber();
+    const slot = newGlobalVariables.slotNumber.toBigInt();
 
-    this.metrics.recordNewBlock(newGlobalVariables.blockNumber.toNumber(), validTxs.length);
+    this.metrics.recordNewBlock(blockNumber, validTxs.length);
     const workTimer = new Timer();
-    this.setState(SequencerState.CREATING_BLOCK, newGlobalVariables.slotNumber.toBigInt());
-    this.log.info(
-      `Building blockNumber=${newGlobalVariables.blockNumber.toNumber()} txCount=${
-        validTxs.length
-      } slotNumber=${newGlobalVariables.slotNumber.toNumber()}`,
-    );
+    this.setState(SequencerState.CREATING_BLOCK, slot);
 
     /**
      * BuildBlock is shared between the sequencer and the validator for re-execution
@@ -621,43 +632,48 @@ export class Sequencer {
       await this.publisher.validateBlockForSubmission(block.header);
 
       const workDuration = workTimer.ms();
-      this.log.info(
-        `Assembled block ${block.number} (txEffectsHash: ${block.header.contentCommitment.txsEffectsHash.toString(
-          'hex',
-        )})`,
-        {
-          eventName: 'l2-block-built',
-          creator: this.publisher.getSenderAddress().toString(),
-          duration: workDuration,
-          publicProcessDuration: publicProcessorDuration,
-          rollupCircuitsDuration: blockBuildingTimer.ms(),
-          ...block.getStats(),
-        } satisfies L2BlockBuiltStats,
-      );
+      const blockStats: L2BlockBuiltStats = {
+        eventName: 'l2-block-built',
+        creator: this.publisher.getSenderAddress().toString(),
+        duration: workDuration,
+        publicProcessDuration: publicProcessorDuration,
+        rollupCircuitsDuration: blockBuildingTimer.ms(),
+        ...block.getStats(),
+      };
+
+      this.log.verbose(`Built block ${block.number}`, {
+        txEffectsHash: block.header.contentCommitment.txsEffectsHash.toString('hex'),
+        ...blockStats,
+      });
 
       if (this.isFlushing) {
-        this.log.info(`Flushing completed`);
+        this.log.verbose(`Flushing completed`);
       }
 
       const txHashes = validTxs.map(tx => tx.getTxHash());
 
       this.isFlushing = false;
-      this.log.verbose('Collecting attestations');
+      this.log.debug('Collecting attestations');
       const stopCollectingAttestationsTimer = this.metrics.startCollectingAttestationsTimer();
       const attestations = await this.collectAttestations(block, txHashes);
-      this.log.verbose('Attestations collected');
+      this.log.verbose(`Collected ${attestations?.length ?? 0} attestations`);
       stopCollectingAttestationsTimer();
-      this.log.verbose('Collecting proof quotes');
 
+      this.log.debug('Collecting proof quotes');
       const proofQuote = await this.createProofClaimForPreviousEpoch(newGlobalVariables.slotNumber.toBigInt());
-      this.log.info(proofQuote ? `Using proof quote ${inspect(proofQuote.payload)}` : 'No proof quote available');
 
       await this.publishL2Block(block, attestations, txHashes, proofQuote);
       this.metrics.recordPublishedBlock(workDuration);
       this.log.info(
-        `Submitted rollup block ${block.number} with ${numProcessedTxs} transactions duration=${Math.ceil(
-          workDuration,
-        )}ms (Submitter: ${this.publisher.getSenderAddress()})`,
+        `Published rollup block ${block.number} with ${numProcessedTxs} transactions in ${Math.ceil(workDuration)}ms`,
+        {
+          blockNumber: block.number,
+          blockHash: block.hash(),
+          slot,
+          txCount: numProcessedTxs,
+          duration: Math.ceil(workDuration),
+          submitter: this.publisher.getSenderAddress().toString(),
+        },
       );
     } catch (err) {
       this.metrics.recordFailedBlock();
@@ -678,11 +694,12 @@ export class Sequencer {
   protected async collectAttestations(block: L2Block, txHashes: TxHash[]): Promise<Signature[] | undefined> {
     // TODO(https://github.com/AztecProtocol/aztec-packages/issues/7962): inefficient to have a round trip in here - this should be cached
     const committee = await this.publisher.getCurrentEpochCommittee();
-    this.log.debug(`Attesting committee length ${committee.length}`);
 
     if (committee.length === 0) {
-      this.log.verbose(`Attesting committee length is 0, skipping`);
+      this.log.verbose(`Attesting committee length is 0`);
       return undefined;
+    } else {
+      this.log.debug(`Attesting committee length ${committee.length}`);
     }
 
     if (!this.validatorClient) {
@@ -693,7 +710,7 @@ export class Sequencer {
 
     const numberOfRequiredAttestations = Math.floor((committee.length * 2) / 3) + 1;
 
-    this.log.info('Creating block proposal');
+    this.log.debug('Creating block proposal');
     const proposal = await this.validatorClient.createBlockProposal(block.header, block.archive.root, txHashes);
     if (!proposal) {
       this.log.verbose(`Failed to create block proposal, skipping`);
@@ -703,12 +720,11 @@ export class Sequencer {
     const slotNumber = block.header.globalVariables.slotNumber.toBigInt();
 
     this.setState(SequencerState.PUBLISHING_BLOCK_TO_PEERS, slotNumber);
-    this.log.info('Broadcasting block proposal to validators');
+    this.log.debug('Broadcasting block proposal to validators');
     this.validatorClient.broadcastBlockProposal(proposal);
 
     this.setState(SequencerState.WAITING_FOR_ATTESTATIONS, slotNumber);
     const attestations = await this.validatorClient.collectAttestations(proposal, numberOfRequiredAttestations);
-    this.log.info(`Collected attestations from validators, number of attestations: ${attestations.length}`);
 
     // note: the smart contract requires that the signatures are provided in the order of the committee
     return orderAttestations(attestations, committee);
@@ -719,16 +735,17 @@ export class Sequencer {
       // Find out which epoch we are currently in
       const epochToProve = await this.publisher.getClaimableEpoch();
       if (epochToProve === undefined) {
-        this.log.verbose(`No epoch to prove`);
+        this.log.debug(`No epoch to prove`);
         return undefined;
       }
 
       // Get quotes for the epoch to be proven
       const quotes = await this.p2pClient.getEpochProofQuotes(epochToProve);
-      this.log.info(`Retrieved ${quotes.length} quotes, slot: ${slotNumber}, epoch to prove: ${epochToProve}`);
-      for (const quote of quotes) {
-        this.log.verbose(inspect(quote.payload));
-      }
+      this.log.verbose(`Retrieved ${quotes.length} quotes for slot ${slotNumber} epoch ${epochToProve}`, {
+        epochToProve,
+        slotNumber,
+        quotes: quotes.map(q => q.payload),
+      });
       // ensure these quotes are still valid for the slot and have the contract validate them
       const validQuotesPromise = Promise.all(
         quotes.filter(x => x.payload.validUntilSlot >= slotNumber).map(x => this.publisher.validateProofQuote(x)),
@@ -743,9 +760,11 @@ export class Sequencer {
       const sortedQuotes = validQuotes.sort(
         (a: EpochProofQuote, b: EpochProofQuote) => a.payload.basisPointFee - b.payload.basisPointFee,
       );
-      return sortedQuotes[0];
+      const quote = sortedQuotes[0];
+      this.log.info(`Selected proof quote for proof claim`, quote.payload);
+      return quote;
     } catch (err) {
-      this.log.error(`Failed to create proof claim for previous epoch: ${err}`);
+      this.log.error(`Failed to create proof claim for previous epoch`, err, { slotNumber });
       return undefined;
     }
   }
@@ -790,7 +809,7 @@ export class Sequencer {
     for (const tx of txs) {
       const txSize = tx.getSize() - tx.clientIvcProof.clientIvcProofBuffer.length;
       if (totalSize + txSize > maxSize) {
-        this.log.warn(
+        this.log.debug(
           `Dropping tx ${tx.getTxHash()} with estimated size ${txSize} due to exceeding ${maxSize} block size limit (currently at ${totalSize})`,
         );
         continue;
@@ -827,7 +846,7 @@ export class Sequencer {
       p2p >= l2BlockSource.number &&
       l1ToL2MessageSource >= l2BlockSource.number;
 
-    this.log.verbose(`Sequencer sync check ${result ? 'succeeded' : 'failed'}`, {
+    this.log.debug(`Sequencer sync check ${result ? 'succeeded' : 'failed'}`, {
       worldStateNumber: worldState.number,
       worldStateHash: worldState.hash,
       l2BlockSourceNumber: l2BlockSource.number,

--- a/yarn-project/sequencer-client/src/tx_validator/gas_validator.ts
+++ b/yarn-project/sequencer-client/src/tx_validator/gas_validator.ts
@@ -1,6 +1,6 @@
 import { type Tx, TxExecutionPhase, type TxValidator } from '@aztec/circuit-types';
 import { type AztecAddress, type Fr, FunctionSelector } from '@aztec/circuits.js';
-import { createDebugLogger } from '@aztec/foundation/log';
+import { createLogger } from '@aztec/foundation/log';
 import { computeFeePayerBalanceStorageSlot, getExecutionRequestsByPhase } from '@aztec/simulator';
 
 /** Provides a view into public contract state */
@@ -9,7 +9,7 @@ export interface PublicStateSource {
 }
 
 export class GasTxValidator implements TxValidator<Tx> {
-  #log = createDebugLogger('aztec:sequencer:tx_validator:tx_gas');
+  #log = createLogger('sequencer:tx_validator:tx_gas');
   #publicDataSource: PublicStateSource;
   #feeJuiceAddress: AztecAddress;
 

--- a/yarn-project/sequencer-client/src/tx_validator/phases_validator.ts
+++ b/yarn-project/sequencer-client/src/tx_validator/phases_validator.ts
@@ -6,11 +6,11 @@ import {
   type TxValidator,
 } from '@aztec/circuit-types';
 import { type ContractDataSource } from '@aztec/circuits.js';
-import { createDebugLogger } from '@aztec/foundation/log';
+import { createLogger } from '@aztec/foundation/log';
 import { ContractsDataSourcePublicDB, getExecutionRequestsByPhase } from '@aztec/simulator';
 
 export class PhasesTxValidator implements TxValidator<Tx> {
-  #log = createDebugLogger('aztec:sequencer:tx_validator:tx_phases');
+  #log = createLogger('sequencer:tx_validator:tx_phases');
   private contractDataSource: ContractsDataSourcePublicDB;
 
   constructor(contracts: ContractDataSource, private setupAllowList: AllowedElement[]) {

--- a/yarn-project/simulator/src/acvm/acvm.ts
+++ b/yarn-project/simulator/src/acvm/acvm.ts
@@ -1,6 +1,6 @@
 import { type NoirCallStack } from '@aztec/circuit-types';
 import type { FunctionDebugMetadata } from '@aztec/foundation/abi';
-import { createDebugLogger } from '@aztec/foundation/log';
+import { createLogger } from '@aztec/foundation/log';
 
 import {
   type ExecutionError,
@@ -42,7 +42,7 @@ export async function acvm(
   initialWitness: ACVMWitness,
   callback: ACIRCallback,
 ): Promise<ACIRExecutionResult> {
-  const logger = createDebugLogger('aztec:simulator:acvm');
+  const logger = createLogger('simulator:acvm');
 
   const solvedAndReturnWitness = await executeCircuitWithReturnWitness(
     acir,

--- a/yarn-project/simulator/src/avm/avm_memory_types.ts
+++ b/yarn-project/simulator/src/avm/avm_memory_types.ts
@@ -227,7 +227,7 @@ export enum TypeTag {
 export type TaggedMemoryInterface = FunctionsOf<TaggedMemory>;
 
 export class TaggedMemory implements TaggedMemoryInterface {
-  static readonly log: Logger = createLogger('avm_simulator:memory');
+  static readonly log: Logger = createLogger('simulator:avm:memory');
 
   // Whether to track and validate memory accesses for each instruction.
   static readonly TRACK_MEMORY_ACCESSES = process.env.NODE_ENV === 'test';

--- a/yarn-project/simulator/src/avm/avm_memory_types.ts
+++ b/yarn-project/simulator/src/avm/avm_memory_types.ts
@@ -10,7 +10,7 @@ import {
 import { AztecAddress } from '@aztec/foundation/aztec-address';
 import { toBufferBE } from '@aztec/foundation/bigint-buffer';
 import { Fr } from '@aztec/foundation/fields';
-import { type DebugLogger, createDebugLogger } from '@aztec/foundation/log';
+import { type Logger, createLogger } from '@aztec/foundation/log';
 import { type FunctionsOf } from '@aztec/foundation/types';
 
 import { strict as assert } from 'assert';
@@ -227,7 +227,7 @@ export enum TypeTag {
 export type TaggedMemoryInterface = FunctionsOf<TaggedMemory>;
 
 export class TaggedMemory implements TaggedMemoryInterface {
-  static readonly log: DebugLogger = createDebugLogger('aztec:avm_simulator:memory');
+  static readonly log: Logger = createLogger('avm_simulator:memory');
 
   // Whether to track and validate memory accesses for each instruction.
   static readonly TRACK_MEMORY_ACCESSES = process.env.NODE_ENV === 'test';

--- a/yarn-project/simulator/src/avm/avm_simulator.ts
+++ b/yarn-project/simulator/src/avm/avm_simulator.ts
@@ -54,7 +54,7 @@ export class AvmSimulator {
       context.machineState.gasLeft.l2Gas <= MAX_L2_GAS_PER_ENQUEUED_CALL,
       `Cannot allocate more than ${MAX_L2_GAS_PER_ENQUEUED_CALL} to the AVM for execution of an enqueued call`,
     );
-    this.log = createLogger(`aztec:avm_simulator:core(f:${context.environment.functionSelector.toString()})`);
+    this.log = createLogger(`simulator:avm:core(f:${context.environment.functionSelector.toString()})`);
     // TODO(palla/log): Should tallies be printed on debug, or only on trace?
     if (this.log.isLevelEnabled('debug')) {
       this.tallyPrintFunction = this.printOpcodeTallies;

--- a/yarn-project/simulator/src/avm/avm_simulator.ts
+++ b/yarn-project/simulator/src/avm/avm_simulator.ts
@@ -5,7 +5,7 @@ import {
   type GlobalVariables,
   MAX_L2_GAS_PER_ENQUEUED_CALL,
 } from '@aztec/circuits.js';
-import { type DebugLogger, createDebugLogger } from '@aztec/foundation/log';
+import { type Logger, createLogger } from '@aztec/foundation/log';
 
 import { strict as assert } from 'assert';
 
@@ -41,7 +41,7 @@ type PcTally = {
 };
 
 export class AvmSimulator {
-  private log: DebugLogger;
+  private log: Logger;
   private bytecode: Buffer | undefined;
   private opcodeTallies: Map<string, OpcodeTally> = new Map();
   private pcTallies: Map<number, PcTally> = new Map();
@@ -54,7 +54,7 @@ export class AvmSimulator {
       context.machineState.gasLeft.l2Gas <= MAX_L2_GAS_PER_ENQUEUED_CALL,
       `Cannot allocate more than ${MAX_L2_GAS_PER_ENQUEUED_CALL} to the AVM for execution of an enqueued call`,
     );
-    this.log = createDebugLogger(`aztec:avm_simulator:core(f:${context.environment.functionSelector.toString()})`);
+    this.log = createLogger(`aztec:avm_simulator:core(f:${context.environment.functionSelector.toString()})`);
     // TODO(palla/log): Should tallies be printed on debug, or only on trace?
     if (this.log.isLevelEnabled('debug')) {
       this.tallyPrintFunction = this.printOpcodeTallies;

--- a/yarn-project/simulator/src/avm/journal/journal.ts
+++ b/yarn-project/simulator/src/avm/journal/journal.ts
@@ -16,7 +16,7 @@ import {
 import { computePublicDataTreeLeafSlot, siloNoteHash, siloNullifier } from '@aztec/circuits.js/hash';
 import { Fr } from '@aztec/foundation/fields';
 import { jsonStringify } from '@aztec/foundation/json-rpc';
-import { createDebugLogger } from '@aztec/foundation/log';
+import { createLogger } from '@aztec/foundation/log';
 
 import { strict as assert } from 'assert';
 
@@ -39,7 +39,7 @@ import { PublicStorage } from './public_storage.js';
  * Manages merging of successful/reverted child state into current state.
  */
 export class AvmPersistableStateManager {
-  private readonly log = createDebugLogger('aztec:avm_simulator:state_manager');
+  private readonly log = createLogger('avm_simulator:state_manager');
 
   /** Make sure a forked state is never merged twice. */
   private alreadyMergedIntoParent = false;

--- a/yarn-project/simulator/src/avm/journal/journal.ts
+++ b/yarn-project/simulator/src/avm/journal/journal.ts
@@ -39,7 +39,7 @@ import { PublicStorage } from './public_storage.js';
  * Manages merging of successful/reverted child state into current state.
  */
 export class AvmPersistableStateManager {
-  private readonly log = createLogger('avm_simulator:state_manager');
+  private readonly log = createLogger('simulator:avm:state_manager');
 
   /** Make sure a forked state is never merged twice. */
   private alreadyMergedIntoParent = false;

--- a/yarn-project/simulator/src/avm/opcodes/misc.ts
+++ b/yarn-project/simulator/src/avm/opcodes/misc.ts
@@ -1,4 +1,4 @@
-import { applyStringFormatting, createDebugLogger } from '@aztec/foundation/log';
+import { applyStringFormatting, createLogger } from '@aztec/foundation/log';
 
 import { type AvmContext } from '../avm_context.js';
 import { TypeTag } from '../avm_memory_types.js';
@@ -9,7 +9,7 @@ import { Instruction } from './instruction.js';
 export class DebugLog extends Instruction {
   static type: string = 'DEBUGLOG';
   static readonly opcode: Opcode = Opcode.DEBUGLOG;
-  static readonly logger = createDebugLogger('aztec:avm_simulator:debug_log');
+  static readonly logger = createLogger('avm_simulator:debug_log');
 
   // Informs (de)serialization. See Instruction.deserialize.
   static readonly wireFormat: OperandType[] = [

--- a/yarn-project/simulator/src/avm/opcodes/misc.ts
+++ b/yarn-project/simulator/src/avm/opcodes/misc.ts
@@ -9,7 +9,7 @@ import { Instruction } from './instruction.js';
 export class DebugLog extends Instruction {
   static type: string = 'DEBUGLOG';
   static readonly opcode: Opcode = Opcode.DEBUGLOG;
-  static readonly logger = createLogger('avm_simulator:debug_log');
+  static readonly logger = createLogger('simulator:avm:debug_log');
 
   // Informs (de)serialization. See Instruction.deserialize.
   static readonly wireFormat: OperandType[] = [

--- a/yarn-project/simulator/src/client/client_execution_context.ts
+++ b/yarn-project/simulator/src/client/client_execution_context.ts
@@ -23,7 +23,7 @@ import { computeUniqueNoteHash, siloNoteHash } from '@aztec/circuits.js/hash';
 import { type FunctionAbi, type FunctionArtifact, type NoteSelector, countArgumentsSize } from '@aztec/foundation/abi';
 import { AztecAddress } from '@aztec/foundation/aztec-address';
 import { Fr } from '@aztec/foundation/fields';
-import { applyStringFormatting, createDebugLogger } from '@aztec/foundation/log';
+import { applyStringFormatting, createLogger } from '@aztec/foundation/log';
 
 import { type NoteData, toACVMWitness } from '../acvm/index.js';
 import { type PackedValuesCache } from '../common/packed_values_cache.js';
@@ -74,7 +74,7 @@ export class ClientExecutionContext extends ViewDataOracle {
     db: DBOracle,
     private node: AztecNode,
     protected sideEffectCounter: number = 0,
-    log = createDebugLogger('aztec:simulator:client_execution_context'),
+    log = createLogger('simulator:client_execution_context'),
     scopes?: AztecAddress[],
   ) {
     super(callContext.contractAddress, authWitnesses, db, node, log, scopes);

--- a/yarn-project/simulator/src/client/private_execution.test.ts
+++ b/yarn-project/simulator/src/client/private_execution.test.ts
@@ -52,7 +52,7 @@ import { times } from '@aztec/foundation/collection';
 import { poseidon2Hash, poseidon2HashWithSeparator, randomInt } from '@aztec/foundation/crypto';
 import { EthAddress } from '@aztec/foundation/eth-address';
 import { Fr } from '@aztec/foundation/fields';
-import { type DebugLogger, createDebugLogger } from '@aztec/foundation/log';
+import { type Logger, createLogger } from '@aztec/foundation/log';
 import { type FieldsOf } from '@aztec/foundation/types';
 import { openTmpStore } from '@aztec/kv-store/lmdb';
 import { type AppendOnlyTree, Poseidon, StandardTree, newTree } from '@aztec/merkle-tree';
@@ -83,7 +83,7 @@ describe('Private Execution test suite', () => {
   let acirSimulator: AcirSimulator;
 
   let header = BlockHeader.empty();
-  let logger: DebugLogger;
+  let logger: Logger;
 
   const defaultContractAddress = AztecAddress.random();
   const ownerSk = Fr.fromString('2dcc5485a58316776299be08c78fa3788a1a7961ae30dc747fb1be17692a8d32');
@@ -184,7 +184,7 @@ describe('Private Execution test suite', () => {
   };
 
   beforeAll(() => {
-    logger = createDebugLogger('aztec:test:private_execution');
+    logger = createLogger('test:private_execution');
 
     const ownerPartialAddress = Fr.random();
     ownerCompleteAddress = CompleteAddress.fromSecretKeyAndPartialAddress(ownerSk, ownerPartialAddress);

--- a/yarn-project/simulator/src/client/private_execution.test.ts
+++ b/yarn-project/simulator/src/client/private_execution.test.ts
@@ -184,7 +184,7 @@ describe('Private Execution test suite', () => {
   };
 
   beforeAll(() => {
-    logger = createLogger('test:private_execution');
+    logger = createLogger('simulator:test:private_execution');
 
     const ownerPartialAddress = Fr.random();
     ownerCompleteAddress = CompleteAddress.fromSecretKeyAndPartialAddress(ownerSk, ownerPartialAddress);

--- a/yarn-project/simulator/src/client/private_execution.ts
+++ b/yarn-project/simulator/src/client/private_execution.ts
@@ -8,7 +8,7 @@ import {
 } from '@aztec/circuits.js';
 import { type FunctionArtifact, type FunctionSelector, countArgumentsSize } from '@aztec/foundation/abi';
 import { type AztecAddress } from '@aztec/foundation/aztec-address';
-import { createDebugLogger } from '@aztec/foundation/log';
+import { createLogger } from '@aztec/foundation/log';
 import { Timer } from '@aztec/foundation/timer';
 
 import { fromACVMField, witnessMapToFields } from '../acvm/deserialize.js';
@@ -24,7 +24,7 @@ export async function executePrivateFunction(
   artifact: FunctionArtifact,
   contractAddress: AztecAddress,
   functionSelector: FunctionSelector,
-  log = createDebugLogger('aztec:simulator:private_execution'),
+  log = createLogger('simulator:private_execution'),
 ): Promise<PrivateExecutionResult> {
   const functionName = await context.getDebugFunctionName();
   log.verbose(`Executing external function ${functionName}@${contractAddress}`);

--- a/yarn-project/simulator/src/client/simulator.ts
+++ b/yarn-project/simulator/src/client/simulator.ts
@@ -10,7 +10,7 @@ import {
 } from '@aztec/foundation/abi';
 import { AztecAddress } from '@aztec/foundation/aztec-address';
 import { Fr } from '@aztec/foundation/fields';
-import { type DebugLogger, createDebugLogger } from '@aztec/foundation/log';
+import { type Logger, createLogger } from '@aztec/foundation/log';
 
 import { createSimulationError } from '../common/errors.js';
 import { PackedValuesCache } from '../common/packed_values_cache.js';
@@ -25,10 +25,10 @@ import { ViewDataOracle } from './view_data_oracle.js';
  * The ACIR simulator.
  */
 export class AcirSimulator {
-  private log: DebugLogger;
+  private log: Logger;
 
   constructor(private db: DBOracle, private node: AztecNode) {
-    this.log = createDebugLogger('aztec:simulator');
+    this.log = createLogger('simulator');
   }
 
   /**

--- a/yarn-project/simulator/src/client/unconstrained_execution.ts
+++ b/yarn-project/simulator/src/client/unconstrained_execution.ts
@@ -1,7 +1,7 @@
 import { type AbiDecoded, type FunctionArtifact, type FunctionSelector, decodeFromAbi } from '@aztec/foundation/abi';
 import { type AztecAddress } from '@aztec/foundation/aztec-address';
 import { type Fr } from '@aztec/foundation/fields';
-import { createDebugLogger } from '@aztec/foundation/log';
+import { createLogger } from '@aztec/foundation/log';
 
 import { witnessMapToFields } from '../acvm/deserialize.js';
 import { Oracle, acvm, extractCallStack, toACVMWitness } from '../acvm/index.js';
@@ -18,7 +18,7 @@ export async function executeUnconstrainedFunction(
   contractAddress: AztecAddress,
   functionSelector: FunctionSelector,
   args: Fr[],
-  log = createDebugLogger('aztec:simulator:unconstrained_execution'),
+  log = createLogger('simulator:unconstrained_execution'),
 ): Promise<AbiDecoded> {
   log.verbose(`Executing unconstrained function ${contractAddress}:${functionSelector}(${artifact.name})`);
 

--- a/yarn-project/simulator/src/client/view_data_oracle.ts
+++ b/yarn-project/simulator/src/client/view_data_oracle.ts
@@ -16,7 +16,7 @@ import {
 import { siloNullifier } from '@aztec/circuits.js/hash';
 import { AztecAddress } from '@aztec/foundation/aztec-address';
 import { Fr } from '@aztec/foundation/fields';
-import { applyStringFormatting, createDebugLogger } from '@aztec/foundation/log';
+import { applyStringFormatting, createLogger } from '@aztec/foundation/log';
 
 import { type NoteData, TypedOracle } from '../acvm/index.js';
 import { type DBOracle } from './db_oracle.js';
@@ -33,7 +33,7 @@ export class ViewDataOracle extends TypedOracle {
     protected readonly authWitnesses: AuthWitness[],
     protected readonly db: DBOracle,
     protected readonly aztecNode: AztecNode,
-    protected log = createDebugLogger('aztec:simulator:client_view_context'),
+    protected log = createLogger('simulator:client_view_context'),
     protected readonly scopes?: AztecAddress[],
   ) {
     super();

--- a/yarn-project/simulator/src/providers/acvm_native.ts
+++ b/yarn-project/simulator/src/providers/acvm_native.ts
@@ -9,7 +9,7 @@ import { promises as fs } from 'fs';
 
 import { type SimulationProvider } from './simulation_provider.js';
 
-const logger = createLogger('acvm-native');
+const logger = createLogger('simulator:acvm-native');
 
 export enum ACVM_RESULT {
   SUCCESS,

--- a/yarn-project/simulator/src/providers/acvm_native.ts
+++ b/yarn-project/simulator/src/providers/acvm_native.ts
@@ -1,5 +1,5 @@
 import { runInDirectory } from '@aztec/foundation/fs';
-import { createDebugLogger } from '@aztec/foundation/log';
+import { createLogger } from '@aztec/foundation/log';
 import { Timer } from '@aztec/foundation/timer';
 import { type NoirCompiledCircuit } from '@aztec/types/noir';
 
@@ -9,7 +9,7 @@ import { promises as fs } from 'fs';
 
 import { type SimulationProvider } from './simulation_provider.js';
 
-const logger = createDebugLogger('aztec:acvm-native');
+const logger = createLogger('acvm-native');
 
 export enum ACVM_RESULT {
   SUCCESS,

--- a/yarn-project/simulator/src/providers/factory.ts
+++ b/yarn-project/simulator/src/providers/factory.ts
@@ -1,4 +1,4 @@
-import { type DebugLogger, createDebugLogger } from '@aztec/foundation/log';
+import { type Logger, createLogger } from '@aztec/foundation/log';
 
 import { promises as fs } from 'fs';
 
@@ -21,7 +21,7 @@ export function getSimulationProviderConfigFromEnv() {
 
 export async function createSimulationProvider(
   config: SimulationProviderConfig,
-  logger: DebugLogger = createDebugLogger('aztec:simulator'),
+  logger: Logger = createLogger('simulator'),
 ): Promise<SimulationProvider> {
   if (config.acvmBinaryPath && config.acvmWorkingDirectory) {
     try {

--- a/yarn-project/simulator/src/public/enqueued_call_side_effect_trace.ts
+++ b/yarn-project/simulator/src/public/enqueued_call_side_effect_trace.ts
@@ -49,7 +49,7 @@ import { computePublicDataTreeLeafSlot } from '@aztec/circuits.js/hash';
 import { padArrayEnd } from '@aztec/foundation/collection';
 import { Fr } from '@aztec/foundation/fields';
 import { jsonStringify } from '@aztec/foundation/json-rpc';
-import { createDebugLogger } from '@aztec/foundation/log';
+import { createLogger } from '@aztec/foundation/log';
 
 import { assert } from 'console';
 
@@ -99,7 +99,7 @@ export class SideEffectArrayLengths {
  * Trace side effects for an entire enqueued call.
  */
 export class PublicEnqueuedCallSideEffectTrace implements PublicSideEffectTraceInterface {
-  public log = createDebugLogger('aztec:public_enqueued_call_side_effect_trace');
+  public log = createLogger('public_enqueued_call_side_effect_trace');
 
   /** The side effect counter increments with every call to the trace. */
   private sideEffectCounter: number;

--- a/yarn-project/simulator/src/public/enqueued_call_side_effect_trace.ts
+++ b/yarn-project/simulator/src/public/enqueued_call_side_effect_trace.ts
@@ -99,7 +99,7 @@ export class SideEffectArrayLengths {
  * Trace side effects for an entire enqueued call.
  */
 export class PublicEnqueuedCallSideEffectTrace implements PublicSideEffectTraceInterface {
-  public log = createLogger('public_enqueued_call_side_effect_trace');
+  public log = createLogger('simulator:public_enqueued_call_side_effect_trace');
 
   /** The side effect counter increments with every call to the trace. */
   private sideEffectCounter: number;

--- a/yarn-project/simulator/src/public/public_db_sources.ts
+++ b/yarn-project/simulator/src/public/public_db_sources.ts
@@ -39,7 +39,7 @@ export class ContractsDataSourcePublicDB implements PublicContractsDB {
   private classCache = new Map<string, ContractClassPublic>();
   private bytecodeCommitmentCache = new Map<string, Fr>();
 
-  private log = createLogger('sequencer:contracts-data-source');
+  private log = createLogger('simulator:contracts-data-source');
 
   constructor(private dataSource: ContractDataSource) {}
   /**
@@ -152,7 +152,7 @@ export class ContractsDataSourcePublicDB implements PublicContractsDB {
  * A public state DB that reads and writes to the world state.
  */
 export class WorldStateDB extends ContractsDataSourcePublicDB implements PublicStateDB, CommitmentsDB {
-  private logger = createLogger('sequencer:world-state-db');
+  private logger = createLogger('simulator:world-state-db');
 
   private publicCommittedWriteCache: Map<bigint, Fr> = new Map();
   private publicCheckpointedWriteCache: Map<bigint, Fr> = new Map();

--- a/yarn-project/simulator/src/public/public_db_sources.ts
+++ b/yarn-project/simulator/src/public/public_db_sources.ts
@@ -20,7 +20,7 @@ import {
   computePublicBytecodeCommitment,
 } from '@aztec/circuits.js';
 import { computeL1ToL2MessageNullifier, computePublicDataTreeLeafSlot } from '@aztec/circuits.js/hash';
-import { createDebugLogger } from '@aztec/foundation/log';
+import { createLogger } from '@aztec/foundation/log';
 import { Timer } from '@aztec/foundation/timer';
 import { ContractClassRegisteredEvent, ContractInstanceDeployedEvent } from '@aztec/protocol-contracts';
 import {
@@ -39,7 +39,7 @@ export class ContractsDataSourcePublicDB implements PublicContractsDB {
   private classCache = new Map<string, ContractClassPublic>();
   private bytecodeCommitmentCache = new Map<string, Fr>();
 
-  private log = createDebugLogger('aztec:sequencer:contracts-data-source');
+  private log = createLogger('sequencer:contracts-data-source');
 
   constructor(private dataSource: ContractDataSource) {}
   /**
@@ -152,7 +152,7 @@ export class ContractsDataSourcePublicDB implements PublicContractsDB {
  * A public state DB that reads and writes to the world state.
  */
 export class WorldStateDB extends ContractsDataSourcePublicDB implements PublicStateDB, CommitmentsDB {
-  private logger = createDebugLogger('aztec:sequencer:world-state-db');
+  private logger = createLogger('sequencer:world-state-db');
 
   private publicCommittedWriteCache: Map<bigint, Fr> = new Map();
   private publicCheckpointedWriteCache: Map<bigint, Fr> = new Map();

--- a/yarn-project/simulator/src/public/public_processor.ts
+++ b/yarn-project/simulator/src/public/public_processor.ts
@@ -23,7 +23,7 @@ import {
   PublicDataWrite,
 } from '@aztec/circuits.js';
 import { padArrayEnd } from '@aztec/foundation/collection';
-import { createDebugLogger } from '@aztec/foundation/log';
+import { createLogger } from '@aztec/foundation/log';
 import { Timer } from '@aztec/foundation/timer';
 import { ContractClassRegisteredEvent, ProtocolContractAddress } from '@aztec/protocol-contracts';
 import { Attributes, type TelemetryClient, type Tracer, trackSpan } from '@aztec/telemetry-client';
@@ -85,7 +85,7 @@ export class PublicProcessor {
     protected worldStateDB: WorldStateDB,
     protected publicTxSimulator: PublicTxSimulator,
     telemetryClient: TelemetryClient,
-    private log = createDebugLogger('aztec:simulator:public-processor'),
+    private log = createLogger('simulator:public-processor'),
   ) {
     this.metrics = new PublicProcessorMetrics(telemetryClient, 'PublicProcessor');
   }

--- a/yarn-project/simulator/src/public/public_tx_context.ts
+++ b/yarn-project/simulator/src/public/public_tx_context.ts
@@ -74,7 +74,7 @@ export class PublicTxContext {
     public readonly revertibleAccumulatedDataFromPrivate: PrivateToPublicAccumulatedData,
     public trace: PublicEnqueuedCallSideEffectTrace, // FIXME(dbanks12): should be private
   ) {
-    this.log = createLogger(`aztec:public_tx_context`);
+    this.log = createLogger(`simulator:public_tx_context`);
     this.gasUsed = startGasUsed;
   }
 
@@ -372,7 +372,7 @@ class PhaseStateManager {
   private currentlyActiveStateManager: AvmPersistableStateManager | undefined;
 
   constructor(private readonly txStateManager: AvmPersistableStateManager) {
-    this.log = createLogger(`aztec:public_phase_state_manager`);
+    this.log = createLogger(`simulator:public_phase_state_manager`);
   }
 
   fork() {

--- a/yarn-project/simulator/src/public/public_tx_context.ts
+++ b/yarn-project/simulator/src/public/public_tx_context.ts
@@ -25,7 +25,7 @@ import {
   TreeSnapshots,
   countAccumulatedItems,
 } from '@aztec/circuits.js';
-import { type DebugLogger, createDebugLogger } from '@aztec/foundation/log';
+import { type Logger, createLogger } from '@aztec/foundation/log';
 
 import { strict as assert } from 'assert';
 import { inspect } from 'util';
@@ -42,7 +42,7 @@ import { getCallRequestsByPhase, getExecutionRequestsByPhase } from './utils.js'
  * The transaction-level context for public execution.
  */
 export class PublicTxContext {
-  private log: DebugLogger;
+  private log: Logger;
 
   /* Gas used including private, teardown gas _limit_, setup and app logic */
   private gasUsed: Gas;
@@ -74,7 +74,7 @@ export class PublicTxContext {
     public readonly revertibleAccumulatedDataFromPrivate: PrivateToPublicAccumulatedData,
     public trace: PublicEnqueuedCallSideEffectTrace, // FIXME(dbanks12): should be private
   ) {
-    this.log = createDebugLogger(`aztec:public_tx_context`);
+    this.log = createLogger(`aztec:public_tx_context`);
     this.gasUsed = startGasUsed;
   }
 
@@ -367,12 +367,12 @@ export class PublicTxContext {
  * transaction level one.
  */
 class PhaseStateManager {
-  private log: DebugLogger;
+  private log: Logger;
 
   private currentlyActiveStateManager: AvmPersistableStateManager | undefined;
 
   constructor(private readonly txStateManager: AvmPersistableStateManager) {
-    this.log = createDebugLogger(`aztec:public_phase_state_manager`);
+    this.log = createLogger(`aztec:public_phase_state_manager`);
   }
 
   fork() {

--- a/yarn-project/simulator/src/public/public_tx_simulator.ts
+++ b/yarn-project/simulator/src/public/public_tx_simulator.ts
@@ -18,7 +18,7 @@ import {
   type PublicCallRequest,
   type RevertCode,
 } from '@aztec/circuits.js';
-import { type DebugLogger, createDebugLogger } from '@aztec/foundation/log';
+import { type Logger, createLogger } from '@aztec/foundation/log';
 import { Timer } from '@aztec/foundation/timer';
 import { Attributes, type TelemetryClient, type Tracer, trackSpan } from '@aztec/telemetry-client';
 
@@ -53,7 +53,7 @@ export type PublicTxResult = {
 export class PublicTxSimulator {
   metrics: ExecutorMetrics;
 
-  private log: DebugLogger;
+  private log: Logger;
 
   constructor(
     private db: MerkleTreeReadOperations,
@@ -62,7 +62,7 @@ export class PublicTxSimulator {
     private globalVariables: GlobalVariables,
     private doMerkleOperations: boolean = false,
   ) {
-    this.log = createDebugLogger(`aztec:public_tx_simulator`);
+    this.log = createLogger(`aztec:public_tx_simulator`);
     this.metrics = new ExecutorMetrics(telemetryClient, 'PublicTxSimulator');
   }
 

--- a/yarn-project/simulator/src/public/public_tx_simulator.ts
+++ b/yarn-project/simulator/src/public/public_tx_simulator.ts
@@ -62,7 +62,7 @@ export class PublicTxSimulator {
     private globalVariables: GlobalVariables,
     private doMerkleOperations: boolean = false,
   ) {
-    this.log = createLogger(`aztec:public_tx_simulator`);
+    this.log = createLogger(`simulator:public_tx_simulator`);
     this.metrics = new ExecutorMetrics(telemetryClient, 'PublicTxSimulator');
   }
 

--- a/yarn-project/simulator/src/public/side_effect_trace.ts
+++ b/yarn-project/simulator/src/public/side_effect_trace.ts
@@ -46,7 +46,7 @@ import {
 } from '@aztec/circuits.js';
 import { Fr } from '@aztec/foundation/fields';
 import { jsonStringify } from '@aztec/foundation/json-rpc';
-import { createDebugLogger } from '@aztec/foundation/log';
+import { createLogger } from '@aztec/foundation/log';
 
 import { assert } from 'console';
 
@@ -68,7 +68,7 @@ const emptyNullifierPath = () => new Array(NULLIFIER_TREE_HEIGHT).fill(Fr.zero()
 const emptyL1ToL2MessagePath = () => new Array(L1_TO_L2_MSG_TREE_HEIGHT).fill(Fr.zero());
 
 export class PublicSideEffectTrace implements PublicSideEffectTraceInterface {
-  public log = createDebugLogger('aztec:public_side_effect_trace');
+  public log = createLogger('public_side_effect_trace');
 
   /** The side effect counter increments with every call to the trace. */
   private sideEffectCounter: number; // kept as number until finalized for efficiency

--- a/yarn-project/telemetry-client/src/otel.ts
+++ b/yarn-project/telemetry-client/src/otel.ts
@@ -1,4 +1,4 @@
-import { type DebugLogger, type LogData, addLogDataHandler } from '@aztec/foundation/log';
+import { type LogData, type Logger, addLogDataHandler } from '@aztec/foundation/log';
 
 import {
   DiagConsoleLogger,
@@ -34,7 +34,7 @@ export class OpenTelemetryClient implements TelemetryClient {
     private meterProvider: MeterProvider,
     private traceProvider: TracerProvider,
     private loggerProvider: LoggerProvider,
-    private log: DebugLogger,
+    private log: Logger,
   ) {}
 
   getMeter(name: string): Meter {
@@ -96,7 +96,7 @@ export class OpenTelemetryClient implements TelemetryClient {
     ]);
   }
 
-  public static async createAndStart(config: TelemetryClientConfig, log: DebugLogger): Promise<OpenTelemetryClient> {
+  public static async createAndStart(config: TelemetryClientConfig, log: Logger): Promise<OpenTelemetryClient> {
     const resource = await getOtelResource();
 
     // TODO(palla/log): Should we show traces as logs in stdout when otel collection is disabled?

--- a/yarn-project/telemetry-client/src/prom_otel_adapter.ts
+++ b/yarn-project/telemetry-client/src/prom_otel_adapter.ts
@@ -285,7 +285,10 @@ class NoopOtelAvgMinMax<Labels extends LabelsGeneric = NoLabels> implements IAvg
 export class OtelMetricsAdapter extends Registry implements MetricsRegister {
   private readonly meter: Meter;
 
-  constructor(telemetryClient: TelemetryClient, private logger: Logger = createLogger('otel-metrics-adapter')) {
+  constructor(
+    telemetryClient: TelemetryClient,
+    private logger: Logger = createLogger('telemetry:otel-metrics-adapter'),
+  ) {
     super();
     this.meter = telemetryClient.getMeter('metrics-adapter');
   }

--- a/yarn-project/telemetry-client/src/prom_otel_adapter.ts
+++ b/yarn-project/telemetry-client/src/prom_otel_adapter.ts
@@ -1,4 +1,4 @@
-import { type Logger, createDebugLogger } from '@aztec/foundation/log';
+import { type Logger, createLogger } from '@aztec/foundation/log';
 
 import { Registry } from 'prom-client';
 
@@ -285,7 +285,7 @@ class NoopOtelAvgMinMax<Labels extends LabelsGeneric = NoLabels> implements IAvg
 export class OtelMetricsAdapter extends Registry implements MetricsRegister {
   private readonly meter: Meter;
 
-  constructor(telemetryClient: TelemetryClient, private logger: Logger = createDebugLogger('otel-metrics-adapter')) {
+  constructor(telemetryClient: TelemetryClient, private logger: Logger = createLogger('otel-metrics-adapter')) {
     super();
     this.meter = telemetryClient.getMeter('metrics-adapter');
   }

--- a/yarn-project/telemetry-client/src/start.ts
+++ b/yarn-project/telemetry-client/src/start.ts
@@ -8,7 +8,7 @@ import { type TelemetryClient } from './telemetry.js';
 export * from './config.js';
 
 export async function createAndStartTelemetryClient(config: TelemetryClientConfig): Promise<TelemetryClient> {
-  const log = createLogger('telemetry-client');
+  const log = createLogger('telemetry:client');
   if (config.metricsCollectorUrl) {
     log.info('Using OpenTelemetry client');
     return await OpenTelemetryClient.createAndStart(config, log);

--- a/yarn-project/telemetry-client/src/start.ts
+++ b/yarn-project/telemetry-client/src/start.ts
@@ -1,4 +1,4 @@
-import { createDebugLogger } from '@aztec/foundation/log';
+import { createLogger } from '@aztec/foundation/log';
 
 import { type TelemetryClientConfig } from './config.js';
 import { NoopTelemetryClient } from './noop.js';
@@ -8,7 +8,7 @@ import { type TelemetryClient } from './telemetry.js';
 export * from './config.js';
 
 export async function createAndStartTelemetryClient(config: TelemetryClientConfig): Promise<TelemetryClient> {
-  const log = createDebugLogger('aztec:telemetry-client');
+  const log = createLogger('telemetry-client');
   if (config.metricsCollectorUrl) {
     log.info('Using OpenTelemetry client');
     return await OpenTelemetryClient.createAndStart(config, log);

--- a/yarn-project/txe/src/bin/index.ts
+++ b/yarn-project/txe/src/bin/index.ts
@@ -10,7 +10,7 @@ import { createTXERpcServer } from '../index.js';
 async function main() {
   const { TXE_PORT = 8080 } = process.env;
 
-  const logger = createLogger('txe_service');
+  const logger = createLogger('txe:service');
   logger.info(`Setting up TXE...`);
 
   const txeServer = createTXERpcServer(logger);

--- a/yarn-project/txe/src/bin/index.ts
+++ b/yarn-project/txe/src/bin/index.ts
@@ -1,5 +1,5 @@
 #!/usr/bin/env -S node --no-warnings
-import { createDebugLogger } from '@aztec/aztec.js';
+import { createLogger } from '@aztec/aztec.js';
 import { startHttpRpcServer } from '@aztec/foundation/json-rpc/server';
 
 import { createTXERpcServer } from '../index.js';
@@ -10,7 +10,7 @@ import { createTXERpcServer } from '../index.js';
 async function main() {
   const { TXE_PORT = 8080 } = process.env;
 
-  const logger = createDebugLogger('aztec:txe_service');
+  const logger = createLogger('txe_service');
   logger.info(`Setting up TXE...`);
 
   const txeServer = createTXERpcServer(logger);

--- a/yarn-project/validator-client/src/validator.ts
+++ b/yarn-project/validator-client/src/validator.ts
@@ -10,7 +10,7 @@ import { type BlockHeader, type GlobalVariables } from '@aztec/circuits.js';
 import { type EpochCache } from '@aztec/epoch-cache';
 import { Buffer32 } from '@aztec/foundation/buffer';
 import { type Fr } from '@aztec/foundation/fields';
-import { createDebugLogger } from '@aztec/foundation/log';
+import { createLogger } from '@aztec/foundation/log';
 import { sleep } from '@aztec/foundation/sleep';
 import { type Timer } from '@aztec/foundation/timer';
 import { type P2P } from '@aztec/p2p';
@@ -74,7 +74,7 @@ export class ValidatorClient extends WithTracer implements Validator {
     private p2pClient: P2P,
     private config: ValidatorClientConfig,
     telemetry: TelemetryClient = new NoopTelemetryClient(),
-    private log = createDebugLogger('aztec:validator'),
+    private log = createLogger('validator'),
   ) {
     // Instantiate tracer
     super(telemetry, 'Validator');

--- a/yarn-project/world-state/src/native/native_world_state.ts
+++ b/yarn-project/world-state/src/native/native_world_state.ts
@@ -20,7 +20,7 @@ import {
   StateReference,
 } from '@aztec/circuits.js';
 import { padArrayEnd } from '@aztec/foundation/collection';
-import { createDebugLogger } from '@aztec/foundation/log';
+import { createLogger } from '@aztec/foundation/log';
 
 import assert from 'assert/strict';
 import { mkdir, mkdtemp, rm } from 'fs/promises';
@@ -58,7 +58,7 @@ export class NativeWorldStateService implements MerkleTreeDatabase {
 
   protected constructor(
     protected readonly instance: NativeWorldState,
-    protected readonly log = createDebugLogger('aztec:world-state:database'),
+    protected readonly log = createLogger('world-state:database'),
     private readonly cleanup = () => Promise.resolve(),
   ) {}
 
@@ -66,7 +66,7 @@ export class NativeWorldStateService implements MerkleTreeDatabase {
     rollupAddress: EthAddress,
     dataDir: string,
     dbMapSizeKb: number,
-    log = createDebugLogger('aztec:world-state:database'),
+    log = createLogger('world-state:database'),
     cleanup = () => Promise.resolve(),
   ): Promise<NativeWorldStateService> {
     const worldStateDirectory = join(dataDir, 'world_state');
@@ -102,7 +102,7 @@ export class NativeWorldStateService implements MerkleTreeDatabase {
   }
 
   static async tmp(rollupAddress = EthAddress.ZERO, cleanupTmpDir = true): Promise<NativeWorldStateService> {
-    const log = createDebugLogger('aztec:world-state:database');
+    const log = createLogger('world-state:database');
     const dataDir = await mkdtemp(join(tmpdir(), 'aztec-world-state-'));
     const dbMapSizeKb = 10 * 1024 * 1024;
     log.debug(`Created temporary world state database at: ${dataDir} with size: ${dbMapSizeKb}`);

--- a/yarn-project/world-state/src/native/native_world_state_cmp.test.ts
+++ b/yarn-project/world-state/src/native/native_world_state_cmp.test.ts
@@ -6,7 +6,7 @@ import {
   type MerkleTreeWriteOperations,
 } from '@aztec/circuit-types';
 import { EthAddress, Fr, GENESIS_ARCHIVE_ROOT, NullifierLeaf, PublicDataTreeLeaf } from '@aztec/circuits.js';
-import { type DebugLogger, createDebugLogger } from '@aztec/foundation/log';
+import { type Logger, createLogger } from '@aztec/foundation/log';
 import { elapsed } from '@aztec/foundation/timer';
 import { type AztecKVStore } from '@aztec/kv-store';
 import { AztecLmdbStore } from '@aztec/kv-store/lmdb';
@@ -30,7 +30,7 @@ describe('NativeWorldState', () => {
   let nativeWS: NativeWorldStateService;
   let legacyWS: MerkleTrees;
 
-  let log: DebugLogger;
+  let log: Logger;
 
   let legacyStore: AztecKVStore;
 
@@ -42,7 +42,7 @@ describe('NativeWorldState', () => {
     nativeDataDir = await mkdtemp(join(tmpdir(), 'native_world_state_test-'));
     legacyDataDir = await mkdtemp(join(tmpdir(), 'js_world_state_test-'));
 
-    log = createDebugLogger('aztec:world-state:test:native_world_state_cmp');
+    log = createLogger('world-state:test:native_world_state_cmp');
   });
 
   afterAll(async () => {

--- a/yarn-project/world-state/src/native/native_world_state_instance.ts
+++ b/yarn-project/world-state/src/native/native_world_state_instance.ts
@@ -10,7 +10,7 @@ import {
   NULLIFIER_TREE_HEIGHT,
   PUBLIC_DATA_TREE_HEIGHT,
 } from '@aztec/circuits.js';
-import { createDebugLogger } from '@aztec/foundation/log';
+import { createLogger } from '@aztec/foundation/log';
 import { SerialQueue } from '@aztec/foundation/queue';
 import { Timer } from '@aztec/foundation/timer';
 
@@ -82,7 +82,7 @@ export class NativeWorldState implements NativeWorldStateInstance {
   private queue = new SerialQueue();
 
   /** Creates a new native WorldState instance */
-  constructor(dataDir: string, dbMapSizeKb: number, private log = createDebugLogger('aztec:world-state:database')) {
+  constructor(dataDir: string, dbMapSizeKb: number, private log = createLogger('world-state:database')) {
     log.info(`Creating world state data store at directory ${dataDir} with map size ${dbMapSizeKb} KB`);
     this.instance = new NATIVE_MODULE[NATIVE_CLASS_NAME](
       dataDir,

--- a/yarn-project/world-state/src/synchronizer/factory.ts
+++ b/yarn-project/world-state/src/synchronizer/factory.ts
@@ -1,5 +1,5 @@
 import { type L1ToL2MessageSource, type L2BlockSource } from '@aztec/circuit-types';
-import { createDebugLogger } from '@aztec/foundation/log';
+import { createLogger } from '@aztec/foundation/log';
 import { type DataStoreConfig } from '@aztec/kv-store/config';
 import { createStore } from '@aztec/kv-store/lmdb';
 import { type TelemetryClient } from '@aztec/telemetry-client';
@@ -34,10 +34,7 @@ export async function createWorldState(
 
   // If a data directory is provided in config, then create a persistent store.
   const merkleTrees = ['true', '1'].includes(process.env.USE_LEGACY_WORLD_STATE ?? '')
-    ? await MerkleTrees.new(
-        await createStore('world-state', newConfig, createDebugLogger('aztec:world-state:lmdb')),
-        client,
-      )
+    ? await MerkleTrees.new(await createStore('world-state', newConfig, createLogger('world-state:lmdb')), client)
     : newConfig.dataDirectory
     ? await NativeWorldStateService.new(
         config.l1Contracts.rollupAddress,

--- a/yarn-project/world-state/src/synchronizer/instrumentation.ts
+++ b/yarn-project/world-state/src/synchronizer/instrumentation.ts
@@ -1,5 +1,5 @@
 import { MerkleTreeId } from '@aztec/circuit-types';
-import { type DebugLogger, createDebugLogger } from '@aztec/foundation/log';
+import { type Logger, createLogger } from '@aztec/foundation/log';
 import { type Gauge, type Meter, type TelemetryClient, ValueType } from '@aztec/telemetry-client';
 
 import { type DBStats, type TreeDBStats, type TreeMeta, type WorldStateStatusFull } from '../native/message.js';
@@ -40,7 +40,7 @@ class TreeInstrumentation {
   private finalisedHeight: Gauge;
   private oldestBlock: Gauge;
 
-  constructor(meter: Meter, treeName: TreeTypeString, private log: DebugLogger) {
+  constructor(meter: Meter, treeName: TreeTypeString, private log: Logger) {
     this.dbMapSize = meter.createGauge(`aztec.world_state.db_map_size.${treeName}`, {
       description: `The current configured map size for the ${treeName} tree`,
       valueType: ValueType.INT,
@@ -100,7 +100,7 @@ class TreeInstrumentation {
 export class WorldStateInstrumentation {
   private treeInstrumentation: Map<MerkleTreeId, TreeInstrumentation> = new Map<MerkleTreeId, TreeInstrumentation>();
 
-  constructor(telemetry: TelemetryClient, private log = createDebugLogger('aztec:world-state:instrumentation')) {
+  constructor(telemetry: TelemetryClient, private log = createLogger('world-state:instrumentation')) {
     const meter = telemetry.getMeter('World State');
     this.treeInstrumentation.set(MerkleTreeId.ARCHIVE, new TreeInstrumentation(meter, 'archive', log));
     this.treeInstrumentation.set(MerkleTreeId.L1_TO_L2_MESSAGE_TREE, new TreeInstrumentation(meter, 'message', log));

--- a/yarn-project/world-state/src/synchronizer/server_world_state_synchronizer.test.ts
+++ b/yarn-project/world-state/src/synchronizer/server_world_state_synchronizer.test.ts
@@ -10,7 +10,7 @@ import { Fr, MerkleTreeCalculator } from '@aztec/circuits.js';
 import { L1_TO_L2_MSG_SUBTREE_HEIGHT } from '@aztec/circuits.js/constants';
 import { times } from '@aztec/foundation/collection';
 import { randomInt } from '@aztec/foundation/crypto';
-import { type DebugLogger, createDebugLogger } from '@aztec/foundation/log';
+import { type Logger, createLogger } from '@aztec/foundation/log';
 import { SHA256Trunc } from '@aztec/merkle-tree';
 import { NoopTelemetryClient } from '@aztec/telemetry-client/noop';
 
@@ -24,7 +24,7 @@ import { ServerWorldStateSynchronizer } from './server_world_state_synchronizer.
 describe('ServerWorldStateSynchronizer', () => {
   jest.setTimeout(30_000);
 
-  let log: DebugLogger;
+  let log: Logger;
 
   let l1ToL2Messages: Fr[];
   let inHash: Buffer;
@@ -40,7 +40,7 @@ describe('ServerWorldStateSynchronizer', () => {
   const LATEST_BLOCK_NUMBER = 5;
 
   beforeAll(() => {
-    log = createDebugLogger('aztec:world-state:test:server_world_state_synchronizer');
+    log = createLogger('world-state:test:server_world_state_synchronizer');
 
     // Seed l1 to l2 msgs
     l1ToL2Messages = times(randomInt(2 ** L1_TO_L2_MSG_SUBTREE_HEIGHT), Fr.random);

--- a/yarn-project/world-state/src/synchronizer/server_world_state_synchronizer.ts
+++ b/yarn-project/world-state/src/synchronizer/server_world_state_synchronizer.ts
@@ -19,7 +19,7 @@ import { type L2BlockHandledStats } from '@aztec/circuit-types/stats';
 import { MerkleTreeCalculator } from '@aztec/circuits.js';
 import { L1_TO_L2_MSG_SUBTREE_HEIGHT } from '@aztec/circuits.js/constants';
 import { type Fr } from '@aztec/foundation/fields';
-import { createDebugLogger } from '@aztec/foundation/log';
+import { createLogger } from '@aztec/foundation/log';
 import { promiseWithResolvers } from '@aztec/foundation/promise';
 import { elapsed } from '@aztec/foundation/timer';
 import { SHA256Trunc } from '@aztec/merkle-tree';
@@ -54,7 +54,7 @@ export class ServerWorldStateSynchronizer
     private readonly l2BlockSource: L2BlockSource & L1ToL2MessageSource,
     private readonly config: WorldStateConfig,
     telemetry: TelemetryClient,
-    private readonly log = createDebugLogger('aztec:world_state'),
+    private readonly log = createLogger('world_state'),
   ) {
     this.instrumentation = new WorldStateInstrumentation(telemetry);
     this.merkleTreeCommitted = this.merkleTreeDb.getCommitted();

--- a/yarn-project/world-state/src/test/integration.test.ts
+++ b/yarn-project/world-state/src/test/integration.test.ts
@@ -1,7 +1,7 @@
 import { MockPrefilledArchiver } from '@aztec/archiver/test';
 import { type L2Block, MerkleTreeId } from '@aztec/circuit-types';
 import { EthAddress, type Fr } from '@aztec/circuits.js';
-import { type DebugLogger, createDebugLogger } from '@aztec/foundation/log';
+import { type Logger, createLogger } from '@aztec/foundation/log';
 import { sleep } from '@aztec/foundation/sleep';
 import { type DataStoreConfig } from '@aztec/kv-store/config';
 import { NoopTelemetryClient } from '@aztec/telemetry-client/noop';
@@ -22,7 +22,7 @@ describe('world-state integration', () => {
   let db: NativeWorldStateService;
   let synchronizer: TestWorldStateSynchronizer;
   let config: WorldStateConfig & DataStoreConfig;
-  let log: DebugLogger;
+  let log: Logger;
 
   let blocks: L2Block[];
   let messages: Fr[][];
@@ -30,7 +30,7 @@ describe('world-state integration', () => {
   const MAX_BLOCK_COUNT = 20;
 
   beforeAll(async () => {
-    log = createDebugLogger('aztec:world-state:test:integration');
+    log = createLogger('world-state:test:integration');
     rollupAddress = EthAddress.random();
     const db = await NativeWorldStateService.tmp(rollupAddress);
     log.info(`Generating ${MAX_BLOCK_COUNT} mock blocks`);

--- a/yarn-project/world-state/src/world-state-db/merkle_trees.ts
+++ b/yarn-project/world-state/src/world-state-db/merkle_trees.ts
@@ -31,7 +31,7 @@ import {
   StateReference,
 } from '@aztec/circuits.js';
 import { padArrayEnd } from '@aztec/foundation/collection';
-import { type DebugLogger, createDebugLogger } from '@aztec/foundation/log';
+import { type Logger, createLogger } from '@aztec/foundation/log';
 import { SerialQueue } from '@aztec/foundation/queue';
 import { Timer, elapsed } from '@aztec/foundation/timer';
 import { type IndexedTreeLeafPreimage } from '@aztec/foundation/trees';
@@ -111,7 +111,7 @@ export class MerkleTrees implements MerkleTreeAdminDatabase {
   private initialStateReference: AztecSingleton<Buffer>;
   private metrics: WorldStateMetrics;
 
-  private constructor(private store: AztecKVStore, private telemetryClient: TelemetryClient, private log: DebugLogger) {
+  private constructor(private store: AztecKVStore, private telemetryClient: TelemetryClient, private log: Logger) {
     this.initialStateReference = store.openSingleton('merkle_trees_initial_state_reference');
     this.metrics = new WorldStateMetrics(telemetryClient);
   }
@@ -121,7 +121,7 @@ export class MerkleTrees implements MerkleTreeAdminDatabase {
    * @param store - The db instance to use for data persistance.
    * @returns - A fully initialized MerkleTrees instance.
    */
-  public static async new(store: AztecKVStore, client: TelemetryClient, log = createDebugLogger('aztec:merkle_trees')) {
+  public static async new(store: AztecKVStore, client: TelemetryClient, log = createLogger('merkle_trees')) {
     const merkleTrees = new MerkleTrees(store, client, log);
     await merkleTrees.#init();
     return merkleTrees;
@@ -236,11 +236,7 @@ export class MerkleTrees implements MerkleTreeAdminDatabase {
   // that can work on a read-only store and one that actually writes to the store. This implies
   // having read-only versions of the kv-stores, all kv-containers, and all trees.
   public async ephemeralFork(): Promise<MerkleTreeWriteOperations> {
-    const forked = new MerkleTrees(
-      this.store,
-      this.telemetryClient,
-      createDebugLogger('aztec:merkle_trees:ephemeral_fork'),
-    );
+    const forked = new MerkleTrees(this.store, this.telemetryClient, createLogger('merkle_trees:ephemeral_fork'));
     await forked.#init(true);
     return new MerkleTreeReadOperationsFacade(forked, true);
   }

--- a/yarn-project/world-state/src/world-state-db/merkle_trees.ts
+++ b/yarn-project/world-state/src/world-state-db/merkle_trees.ts
@@ -121,7 +121,11 @@ export class MerkleTrees implements MerkleTreeAdminDatabase {
    * @param store - The db instance to use for data persistance.
    * @returns - A fully initialized MerkleTrees instance.
    */
-  public static async new(store: AztecKVStore, client: TelemetryClient, log = createLogger('merkle_trees')) {
+  public static async new(
+    store: AztecKVStore,
+    client: TelemetryClient,
+    log = createLogger('world-state:merkle_trees'),
+  ) {
     const merkleTrees = new MerkleTrees(store, client, log);
     await merkleTrees.#init();
     return merkleTrees;
@@ -236,7 +240,11 @@ export class MerkleTrees implements MerkleTreeAdminDatabase {
   // that can work on a read-only store and one that actually writes to the store. This implies
   // having read-only versions of the kv-stores, all kv-containers, and all trees.
   public async ephemeralFork(): Promise<MerkleTreeWriteOperations> {
-    const forked = new MerkleTrees(this.store, this.telemetryClient, createLogger('merkle_trees:ephemeral_fork'));
+    const forked = new MerkleTrees(
+      this.store,
+      this.telemetryClient,
+      createLogger('world-state:merkle_trees:ephemeral_fork'),
+    );
     await forked.#init(true);
     return new MerkleTreeReadOperationsFacade(forked, true);
   }


### PR DESCRIPTION
Renames logger module names. Removes the `aztec:` prefix from all of them, and ensures that every logger module name is prefixed with the package name. Also renames `DebugLogger` to just `Logger`.

Note that #10125 suggests using eslint to enforce this. Writing a custom eslint rule requires either creating a whole new package, or upgrading to eslint 9 which uses a new config format. Both of these options seemed overkill for just enforcing this convention.

Includes sequencer cleanup from #10404

Fixes #10125