### PR TITLE
chore: Don't generate proofs of verifier circuits in test

### DIFF
--- a/barretenberg/cpp/src/barretenberg/stdlib/plonk_recursion/verifier/verifier.test.cpp
+++ b/barretenberg/cpp/src/barretenberg/stdlib/plonk_recursion/verifier/verifier.test.cpp
@@ -345,14 +345,8 @@ template <typename OuterComposer> class stdlib_verifier : public testing::Test {
     static void check_recursive_verification_circuit(OuterBuilder& outer_circuit, bool expected_result)
     {
         info("number of gates in recursive verification circuit = ", outer_circuit.get_estimated_num_finalized_gates());
-        OuterComposer outer_composer;
-        auto prover = outer_composer.create_prover(outer_circuit);
-        auto verifier = outer_composer.create_verifier(outer_circuit);
-        auto proof = prover.construct_proof();
-        auto result = verifier.verify_proof(proof);
-        // bool result = CircuitChecker::check(outer_circuit);
+        const bool result = CircuitChecker::check(outer_circuit);
         EXPECT_EQ(result, expected_result);
-        static_cast<void>(expected_result);
         auto g2_lines = srs::get_bn254_crs_factory()->get_verifier_crs()->get_precomputed_g2_lines();
         EXPECT_EQ(check_pairing_point_accum_public_inputs(outer_circuit, g2_lines), true);
     }


### PR DESCRIPTION
To test circuit logic we don't need to generate proofs. Running the circuit checker is much faster and more memory efficient.