### PR TITLE
chore: parallelise inverse polynomial construction for lookup relations

### DIFF
--- a/barretenberg/cpp/src/barretenberg/benchmark/client_ivc_bench/client_ivc.bench.cpp
+++ b/barretenberg/cpp/src/barretenberg/benchmark/client_ivc_bench/client_ivc.bench.cpp
@@ -33,7 +33,7 @@ class ClientIVCBench : public benchmark::Fixture {
  */
 BENCHMARK_DEFINE_F(ClientIVCBench, Full)(benchmark::State& state)
 {
-    ClientIVC ivc{ { EXAMPLE_20 } };
+    ClientIVC ivc{ { CLIENT_IVC_BENCH_STRUCTURE } };
 
     auto total_num_circuits = 2 * static_cast<size_t>(state.range(0)); // 2x accounts for kernel circuits
     auto mocked_vkeys = mock_verification_keys(total_num_circuits);

--- a/barretenberg/cpp/src/barretenberg/benchmark/client_ivc_bench/client_ivc.bench.cpp
+++ b/barretenberg/cpp/src/barretenberg/benchmark/client_ivc_bench/client_ivc.bench.cpp
@@ -33,7 +33,7 @@ class ClientIVCBench : public benchmark::Fixture {
  */
 BENCHMARK_DEFINE_F(ClientIVCBench, Full)(benchmark::State& state)
 {
-    ClientIVC ivc{ { CLIENT_IVC_BENCH_STRUCTURE } };
+    ClientIVC ivc{ { EXAMPLE_20 } };
 
     auto total_num_circuits = 2 * static_cast<size_t>(state.range(0)); // 2x accounts for kernel circuits
     auto mocked_vkeys = mock_verification_keys(total_num_circuits);

--- a/barretenberg/cpp/src/barretenberg/relations/logderiv_lookup_relation.hpp
+++ b/barretenberg/cpp/src/barretenberg/relations/logderiv_lookup_relation.hpp
@@ -243,14 +243,15 @@ template <typename FF_> class LogDerivLookupRelationImpl {
         const auto write_inverse = inverses * read_term;                        // Degree 3 (4)
         const auto read_inverse = inverses * write_term;                        // Degree 2 (3)
 
-        // Establish the correctness of the polynomial of inverses I. Note: inverses is computed so that the value
-        // is 0 if !inverse_exists. Degrees:                     2 (3)       1 (2)        1              1
+        // Establish the correctness of the polynomial of inverses I. Note: inverses is computed so that the value is 0
+        // if !inverse_exists.
+        // Degrees:                     2 (3)       1 (2)        1              1
         std::get<0>(accumulator) +=
             ShortView((read_term * write_term * inverses - inverse_exists) * scaling_factor); // Deg 4 (6)
 
-        // Establish validity of the read. Note: no scaling factor here since this constraint is 'linearly
-        // dependent, i.e. enforced across the entire trace, not on a per-row basis. Degrees: 1            2 (3) 1
-        // 3 (4)
+        // Establish validity of the read. Note: no scaling factor here since this constraint is 'linearly dependent,
+        // i.e. enforced across the entire trace, not on a per-row basis.
+        // Degrees:                       1            2 (3)            1            3 (4)
         std::get<1>(accumulator) += read_selector * read_inverse - read_counts * write_inverse; // Deg 4 (5)
     }
 };

--- a/barretenberg/cpp/src/barretenberg/trace_to_polynomials/trace_to_polynomials.cpp
+++ b/barretenberg/cpp/src/barretenberg/trace_to_polynomials/trace_to_polynomials.cpp
@@ -102,7 +102,7 @@ typename TraceToPolynomials<Flavor>::TraceData TraceToPolynomials<Flavor>::const
         auto block_size = static_cast<uint32_t>(block.size());
 
         // Save ranges over which the blocks are "active" for use in structured commitments
-        if constexpr (IsUltraFlavor<Flavor>) {
+        if constexpr (IsUltraFlavor<Flavor>) { // Mega and Ultra
             if (block.size() > 0) {
                 proving_key.active_block_ranges.emplace_back(offset, offset + block.size());
             }

--- a/barretenberg/cpp/src/barretenberg/ultra_honk/oink_prover.cpp
+++ b/barretenberg/cpp/src/barretenberg/ultra_honk/oink_prover.cpp
@@ -206,8 +206,8 @@ template <IsUltraFlavor Flavor> void OinkProver<Flavor>::execute_log_derivative_
 
     {
         PROFILE_THIS_NAME("COMMIT::lookup_inverses");
-        witness_commitments.lookup_inverses =
-            proving_key->proving_key.commitment_key->commit(proving_key->proving_key.polynomials.lookup_inverses);
+        witness_commitments.lookup_inverses = proving_key->proving_key.commitment_key->commit_sparse(
+            proving_key->proving_key.polynomials.lookup_inverses);
     }
     transcript->send_to_verifier(domain_separator + commitment_labels.lookup_inverses,
                                  witness_commitments.lookup_inverses);


### PR DESCRIPTION
Benchmark were showing that oink is the second most expensive round in PG after combiner. On top of that one component where we see discrepancies when increasing the ambient trace size is logderivative inverses construction. A step towards improving this is parallelising the construction of inverse polynomials (which is linear). Also the inverses can be committed to with `commit_sparse` which shows a slight improvement as well.
BEFORE
```
CLIENT_IVC_BENCH_STRUCTURE(2^19)

ClientIVCBench/Full/6      29146 ms        27299 ms
ProtogalaxyProver::prove(t)            16265    58.29%
ProtogalaxyProver_::run_oink_prover_on_each_incomplete_key(t)    5624    34.58%


EXAMPLE_20(2^20)

ClientIVCBench/Full/6      37145 ms        34235 ms
ProtogalaxyProver::prove(t)            21283    60.75%
ProtogalaxyProver_::run_oink_prover_on_each_incomplete_key(t)    8818    41.43%
COMMIT::lookup_inverses(t)        406     9.82%
```

AFTER
```
CLIENT_IVC_BENCH_STRUCTURE(2^19)

ClientIVCBench/Full/6      27351 ms        25477 ms 
ProtogalaxyProver::prove(t)            14627    55.72%
ProtogalaxyProver_::run_oink_prover_on_each_incomplete_key(t)    4030    27.55%


EXAMPLE_20(2^20)
ClientIVCBench/Full/6      33852 ms        30893 ms   
ProtogalaxyProver::prove(t)            18250    56.97%
ProtogalaxyProver_::run_oink_prover_on_each_incomplete_key(t)    5526    30.28%
COMMIT::lookup_inverses(t)        301     7.43%
```

