### PR TITLE
feat: replace quadratic removal of rc instructions

### DIFF
--- a/noir/noir-repo/compiler/noirc_evaluator/src/ssa/opt/die.rs
+++ b/noir/noir-repo/compiler/noirc_evaluator/src/ssa/opt/die.rs
@@ -201,19 +201,28 @@ impl Context {
     }
 
     fn remove_rc_instructions(self, dfg: &mut DataFlowGraph) {
-        for (rc, block) in self.rc_instructions {
-            let value = match &dfg[rc] {
-                Instruction::IncrementRc { value } => *value,
-                Instruction::DecrementRc { value } => *value,
-                other => {
-                    unreachable!("Expected IncrementRc or DecrementRc instruction, found {other:?}")
-                }
-            };
+        let unused_rc_values_by_block: HashMap<BasicBlockId, HashSet<InstructionId>> =
+            self.rc_instructions.into_iter().fold(HashMap::default(), |mut acc, (rc, block)| {
+                let value = match &dfg[rc] {
+                    Instruction::IncrementRc { value } => *value,
+                    Instruction::DecrementRc { value } => *value,
+                    other => {
+                        unreachable!(
+                            "Expected IncrementRc or DecrementRc instruction, found {other:?}"
+                        )
+                    }
+                };
 
-            // This could be more efficient if we have to remove multiple instructions in a single block
-            if !self.used_values.contains(&value) {
-                dfg[block].instructions_mut().retain(|instruction| *instruction != rc);
-            }
+                if !self.used_values.contains(&value) {
+                    acc.entry(block).or_default().insert(rc);
+                }
+                acc
+            });
+
+        for (block, instructions_to_remove) in unused_rc_values_by_block {
+            dfg[block]
+                .instructions_mut()
+                .retain(|instruction| !instructions_to_remove.contains(instruction));
         }
     }
 


### PR DESCRIPTION
Copy of https://github.com/noir-lang/noir/pull/6705. This PR cuts the time to build `rollup-base-public` by 75%.