### PR TITLE
chore: Clean up archiver logs

### DIFF
--- a/yarn-project/archiver/src/archiver/archiver.test.ts
+++ b/yarn-project/archiver/src/archiver/archiver.test.ts
@@ -255,7 +255,7 @@ describe('Archiver', () => {
   }, 10_000);
 
   it('skip event search if no changes found', async () => {
-    const loggerSpy = jest.spyOn((archiver as any).log, 'verbose');
+    const loggerSpy = jest.spyOn((archiver as any).log, 'debug');
 
     let latestBlockNum = await archiver.getBlockNumber();
     expect(latestBlockNum).toEqual(0);
@@ -294,15 +294,12 @@ describe('Archiver', () => {
     expect(latestBlockNum).toEqual(numL2BlocksInTest);
 
     // For some reason, this is 1-indexed.
-    expect(loggerSpy).toHaveBeenNthCalledWith(
-      1,
-      `Retrieved no new L1 -> L2 messages between L1 blocks ${1n} and ${50}.`,
-    );
-    expect(loggerSpy).toHaveBeenNthCalledWith(2, `No blocks to retrieve from ${1n} to ${50n}`);
+    expect(loggerSpy).toHaveBeenNthCalledWith(1, `Retrieved no new L1 to L2 messages between L1 blocks 1 and 50.`);
+    expect(loggerSpy).toHaveBeenNthCalledWith(2, `No blocks to retrieve from 1 to 50`);
   }, 10_000);
 
   it('handles L2 reorg', async () => {
-    const loggerSpy = jest.spyOn((archiver as any).log, 'verbose');
+    const loggerSpy = jest.spyOn((archiver as any).log, 'debug');
 
     let latestBlockNum = await archiver.getBlockNumber();
     expect(latestBlockNum).toEqual(0);
@@ -354,17 +351,13 @@ describe('Archiver', () => {
     expect(latestBlockNum).toEqual(numL2BlocksInTest);
 
     // For some reason, this is 1-indexed.
-    expect(loggerSpy).toHaveBeenNthCalledWith(
-      1,
-      `Retrieved no new L1 -> L2 messages between L1 blocks ${1n} and ${50}.`,
-    );
-    expect(loggerSpy).toHaveBeenNthCalledWith(2, `No blocks to retrieve from ${1n} to ${50n}`);
+    expect(loggerSpy).toHaveBeenNthCalledWith(1, `Retrieved no new L1 to L2 messages between L1 blocks 1 and 50.`);
+    expect(loggerSpy).toHaveBeenNthCalledWith(2, `No blocks to retrieve from 1 to 50`);
 
     // Lets take a look to see if we can find re-org stuff!
     await sleep(1000);
 
-    expect(loggerSpy).toHaveBeenNthCalledWith(6, `L2 prune have occurred, unwind state`);
-    expect(loggerSpy).toHaveBeenNthCalledWith(7, `Unwinding 1 block from block 2`);
+    expect(loggerSpy).toHaveBeenNthCalledWith(9, `L2 prune has been detected.`);
 
     // Should also see the block number be reduced
     latestBlockNum = await archiver.getBlockNumber();

--- a/yarn-project/archiver/src/archiver/kv_archiver_store/log_store.ts
+++ b/yarn-project/archiver/src/archiver/kv_archiver_store/log_store.ts
@@ -94,7 +94,7 @@ export class LogStore {
           }
           const tag = new Fr(correctedBuffer);
 
-          this.#log.verbose(`Found tagged unencrypted log with tag ${tag.toString()} in block ${block.number}`);
+          this.#log.debug(`Found tagged unencrypted log with tag ${tag.toString()} in block ${block.number}`);
           const currentLogs = taggedLogs.get(tag.toString()) ?? [];
           currentLogs.push(
             new TxScopedL2Log(txHash, dataStartIndexForTx, block.number, /* isFromPublic */ true, log.data).toBuffer(),

--- a/yarn-project/circuits.js/src/structs/global_variables.ts
+++ b/yarn-project/circuits.js/src/structs/global_variables.ts
@@ -159,10 +159,22 @@ export class GlobalVariables {
     );
   }
 
+  toInspect() {
+    return {
+      chainId: this.chainId.toNumber(),
+      version: this.version.toNumber(),
+      blockNumber: this.blockNumber.toNumber(),
+      slotNumber: this.slotNumber.toNumber(),
+      timestamp: this.timestamp.toNumber(),
+      coinbase: this.coinbase.toString(),
+      feeRecipient: this.feeRecipient.toString(),
+      feePerDaGas: this.gasFees.feePerDaGas.toNumber(),
+      feePerL2Gas: this.gasFees.feePerL2Gas.toNumber(),
+    };
+  }
+
   [inspect.custom]() {
-    return `GlobalVariables { chainId: ${this.chainId.toString()}, version: ${this.version.toString()}, blockNumber: ${this.blockNumber.toString()}, slotNumber: ${this.slotNumber.toString()}, timestamp: ${this.timestamp.toString()}, coinbase: ${this.coinbase.toString()}, feeRecipient: ${this.feeRecipient.toString()}, gasFees: ${inspect(
-      this.gasFees,
-    )} }`;
+    return `GlobalVariables ${inspect(this.toInspect())}`;
   }
 
   public equals(other: this): boolean {


### PR DESCRIPTION
- Logs reorgs as warn
- Logs every new L2 block downloaded as info
- Logs messages and contracts retrieved as verbose
- Logs everything else (including detailed block info) as debug

Fixes #10428 as we log one entry per block synced