### PR TITLE
chore(docs): Remove additional `DEBUG` references, add note on `LOG_LEVEL`s

### DIFF
--- a/docs/docs/guides/developer_guides/smart_contracts/testing_contracts/testing.md
+++ b/docs/docs/guides/developer_guides/smart_contracts/testing_contracts/testing.md
@@ -218,10 +218,11 @@ You can use `aztec.nr`'s oracles as usual for debug logging, as explained [here]
 
 :::warning
 Remember to set the following environment variables to activate debug logging:
+
 ```bash
-export DEBUG="aztec:*"
 export LOG_LEVEL="debug"
 ```
+
 :::
 
 ### All Cheatcodes

--- a/docs/docs/reference/developer_references/sandbox_reference/sandbox-reference.md
+++ b/docs/docs/reference/developer_references/sandbox_reference/sandbox-reference.md
@@ -19,7 +19,7 @@ To change them, you can open `~/.aztec/docker-compose.sandbox.yml` and edit them
 **Sandbox**
 
 ```sh
-LOG_LEVEL=debug # Options are 'fatal', 'error', 'warn', 'info', 'verbose'debug', 'trace'
+LOG_LEVEL=debug # Options are 'fatal', 'error', 'warn', 'info', 'verbose', 'debug', 'trace'
 HOST_WORKDIR='${PWD}' # The location to store log outputs. Will use ~/.aztec where the docker-compose.yml file is stored by default.
 ETHEREUM_HOST=http://ethereum:8545 # The Ethereum JSON RPC URL. We use an anvil instance that runs in parallel to the sandbox on docker by default.
 L1_CHAIN_ID=31337 # The Chain ID that the Ethereum host is using.

--- a/docs/docs/reference/developer_references/sandbox_reference/sandbox-reference.md
+++ b/docs/docs/reference/developer_references/sandbox_reference/sandbox-reference.md
@@ -19,8 +19,7 @@ To change them, you can open `~/.aztec/docker-compose.sandbox.yml` and edit them
 **Sandbox**
 
 ```sh
-DEBUG=aztec:* # The level of debugging logs to be displayed. using "aztec:*" will log everything.
-LOG_LEVEL=debug # Setting to 'debug' will print the debug logs
+LOG_LEVEL=debug # Options are 'fatal', 'error', 'warn', 'info', 'verbose'debug', 'trace'
 HOST_WORKDIR='${PWD}' # The location to store log outputs. Will use ~/.aztec where the docker-compose.yml file is stored by default.
 ETHEREUM_HOST=http://ethereum:8545 # The Ethereum JSON RPC URL. We use an anvil instance that runs in parallel to the sandbox on docker by default.
 L1_CHAIN_ID=31337 # The Chain ID that the Ethereum host is using.

--- a/docs/docs/tutorials/codealong/js_tutorials/aztecjs-getting-started.md
+++ b/docs/docs/tutorials/codealong/js_tutorials/aztecjs-getting-started.md
@@ -75,7 +75,7 @@ yarn add @aztec/aztec.js @aztec/accounts @aztec/noir-contracts.js typescript @ty
     "build": "yarn clean && tsc -b",
     "build:dev": "tsc -b --watch",
     "clean": "rm -rf ./dest tsconfig.tsbuildinfo",
-    "start": "yarn build && DEBUG='token' node ./dest/index.js"
+    "start": "yarn build && LOG_LEVEL='info: token' node ./dest/index.js"
   },
 ```
 


### PR DESCRIPTION
Removes a few additional references to DEBUG in the docs, since it was removed here https://github.com/AztecProtocol/aztec-packages/pull/10355
