### PR TITLE
fix: typos in documentation files

### DIFF
--- a/build-system/scripts/build
+++ b/build-system/scripts/build
@@ -68,7 +68,7 @@ if [ -d $ROOT_PATH/$PROJECT_DIR/terraform ]; then
   popd
 fi
 
-# For each dependency, substitute references to the dependency in dockerfile, with the relevent built image uri.
+# For each dependency, substitute references to the dependency in dockerfile, with the relevant built image uri.
 # This is necessary vs pulling and retagging the image, as that doesn't work with buildx.
 # We have to perform a bit of probing to determine which actual image we want to use.
 # When we used buildx to create a multiarch image, there will be no images with "-$ARCH" suffixes (normalise this?).
@@ -91,7 +91,7 @@ for PARENT_REPO in $(query_manifest dependencies $REPOSITORY); do
     fi
   fi
 
-  # Substitute references to parent repo, with the relevent built image uri.
+  # Substitute references to parent repo, with the relevant built image uri.
   DEPLOY_URI=aztecprotocol/$PARENT_REPO
   PARENT_IMAGE_URI=$ECR_URL/$PARENT_REPO:$PARENT_IMAGE_TAG
   sed -i "s#^FROM \\(.*\\)${DEPLOY_URI}\\( \|$\\)#FROM \\1${PARENT_IMAGE_URI}\\2#" $DOCKERFILE

--- a/docs/src/components/TutorialCard/CardHeader/index.js
+++ b/docs/src/components/TutorialCard/CardHeader/index.js
@@ -1,7 +1,7 @@
 import React,  { CSSProperties } from 'react'; // CSSProperties allows inline styling with better type checking.
 import clsx from 'clsx'; // clsx helps manage conditional className names in a clean and concise manner.
 const CardHeader = ({
-  className, // classNamees for the container card
+  className, // classNames for the container card
   style, // Custom styles for the container card
   children, // Content to be included within the card
   textAlign, 

--- a/noir/noir-repo/docs/versioned_docs/version-v0.33.0/index.mdx
+++ b/noir/noir-repo/docs/versioned_docs/version-v0.33.0/index.mdx
@@ -51,7 +51,7 @@ Noir can be used both in complex cloud-based backends and in user's smartphones,
     Aztec Contracts leverage Noir to allow for the storage and execution of private information. Writing an Aztec Contract is as easy as writing Noir, and Aztec developers can easily interact with the network storage and execution through the [Aztec.nr](https://docs.aztec.network/developers/contracts/main) library.
   </TabItem>
   <TabItem value="Solidity Verifiers" label="Solidity Verifiers">
-    <img src={require("@site/static/img/solidity_verifier_ex.png").default} style={{display: "block", margin: "2rem auto"}} alt="Soliditry Verifier Example"  />
+    <img src={require("@site/static/img/solidity_verifier_ex.png").default} style={{display: "block", margin: "2rem auto"}} alt="Solidity Verifier Example"  />
     Noir can auto-generate Solidity verifier contracts that verify Noir proofs. This allows for non-interactive verification of proofs containing private information in an immutable system. This feature powers a multitude of use-case scenarios, from P2P chess tournaments, to [Aztec Layer-2 Blockchain](https://docs.aztec.network/)
   </TabItem>
   <TabItem value="Full-Stack Development" label="Full-Stack Development">


### PR DESCRIPTION
This pull request contains changes to improve clarity, correctness and structure.

**Description correction:**
Corrected `relevent` to `relevant` x2. 
Corrected `classNamees` to `classNames`
Corrected `Soliditry` to `Solidity`

Please review the changes and let me know if any additional changes are needed.
