### PR TITLE
fix: url in bbup install

### DIFF
--- a/barretenberg/bbup/install
+++ b/barretenberg/bbup/install
@@ -12,7 +12,7 @@ ERROR="✗"
 
 BB_DIR="${HOME}/.bb"
 INSTALL_PATH="${BB_DIR}/bbup"
-BBUP_URL="https://raw.githubusercontent.com/AztecProtocol/aztec-packages/main/barretenberg/bbup/bbup"
+BBUP_URL="https://raw.githubusercontent.com/AztecProtocol/aztec-packages/master/barretenberg/bbup/bbup"
 
 # Create .bb directory if it doesn't exist
 mkdir -p "$BB_DIR"


### PR DESCRIPTION
Fix bbup url so that `curl -L https://bbup.dev | bash` does not fail with 404 error
