### PR TITLE
chore: Sync logging with jest

### DIFF
--- a/yarn-project/end-to-end/package.json
+++ b/yarn-project/end-to-end/package.json
@@ -144,9 +144,9 @@
     },
     "reporters": [
       [
-        "default",
+        "summary",
         {
-          "summaryThreshold": 9999
+          "summaryThreshold": 0
         }
       ]
     ],

--- a/yarn-project/end-to-end/package.local.json
+++ b/yarn-project/end-to-end/package.local.json
@@ -4,5 +4,15 @@
     "formatting": "run -T prettier --check ./src \"!src/web/main.js\" && run -T eslint ./src",
     "test": "LOG_LEVEL=${LOG_LEVEL:-verbose} NODE_NO_WARNINGS=1 node --experimental-vm-modules ../node_modules/.bin/jest --testTimeout=300000 --forceExit",
     "test:unit": "NODE_NO_WARNINGS=1 node --experimental-vm-modules ../node_modules/.bin/jest src/fixtures"
+  },
+  "jest": {
+    "reporters": [
+      [
+        "summary",
+        {
+          "summaryThreshold": 0
+        }
+      ]
+    ]
   }
 }

--- a/yarn-project/end-to-end/src/e2e_p2p/p2p_network.ts
+++ b/yarn-project/end-to-end/src/e2e_p2p/p2p_network.ts
@@ -90,7 +90,7 @@ export class P2PNetworkTest {
   }) {
     const port = basePort || (await getPort());
 
-    const telemetry = await getEndToEndTestTelemetryClient(metricsPort, /*service name*/ `bootstrapnode`);
+    const telemetry = await getEndToEndTestTelemetryClient(metricsPort);
     const bootstrapNode = await createBootstrapNodeFromPrivateKey(BOOTSTRAP_NODE_PRIVATE_KEY, port, telemetry);
     const bootstrapNodeEnr = bootstrapNode.getENR().encodeTxt();
 

--- a/yarn-project/end-to-end/src/fixtures/setup_p2p_test.ts
+++ b/yarn-project/end-to-end/src/fixtures/setup_p2p_test.ts
@@ -63,7 +63,7 @@ export async function createNode(
 ) {
   const validatorConfig = await createValidatorConfig(config, bootstrapNode, tcpPort, accountIndex, dataDirectory);
 
-  const telemetryClient = await getEndToEndTestTelemetryClient(metricsPort, /*serviceName*/ `node:${tcpPort}`);
+  const telemetryClient = await getEndToEndTestTelemetryClient(metricsPort);
 
   return await AztecNodeService.createAndSync(validatorConfig, {
     telemetry: telemetryClient,

--- a/yarn-project/end-to-end/src/fixtures/snapshot_manager.ts
+++ b/yarn-project/end-to-end/src/fixtures/snapshot_manager.ts
@@ -345,7 +345,7 @@ async function setupFromFresh(
     aztecNodeConfig.bbWorkingDirectory = bbConfig.bbWorkingDirectory;
   }
 
-  const telemetry = await getEndToEndTestTelemetryClient(opts.metricsPort, /*serviceName*/ statePath);
+  const telemetry = await getEndToEndTestTelemetryClient(opts.metricsPort);
 
   logger.verbose('Creating and synching an aztec node...');
   const aztecNode = await AztecNodeService.createAndSync(aztecNodeConfig, { telemetry });

--- a/yarn-project/telemetry-client/src/vendor/otel-pino-stream.ts
+++ b/yarn-project/telemetry-client/src/vendor/otel-pino-stream.ts
@@ -129,9 +129,9 @@ export function getTimeConverter(pinoLogger: any, pinoMod: any) {
 }
 
 interface OTelPinoStreamOptions {
-  messageKey: string;
+  messageKey?: string;
   levels: any; // Pino.LevelMapping
-  otelTimestampFromTime: (time: any) => number;
+  otelTimestampFromTime?: (time: any) => number;
 }
 
 /**
@@ -153,7 +153,7 @@ export class OTelPinoStream extends Writable {
     // to transports. Eventually OTelPinoStream might be able to use this
     // for auto-configuration in newer pino versions. The event currently does
     // not include the `timeSym` value that is needed here, however.
-    this._messageKey = options.messageKey;
+    this._messageKey = options.messageKey ?? 'msg';
     this._levels = options.levels;
 
     // [aztec] The following will break if we set up a custom time function in our logger


### PR DESCRIPTION
Jest would overwrite pino logs when logging via a worker thread. This changes logging so that we only use pino-pretty if running in jest, and we only use it as a stream in the main loop. See https://github.com/pinojs/pino-pretty?tab=readme-ov-file#usage-with-jest for more info.

This PR also restores OTLP exports via `getEndToEndTestTelemetryClient`, which had been broken in a previous PR. Export now works by using a multistream destination (again, main loop) to send logs to OTEL. Note that there was an error in how we created the telemetry clients: since starting a new OTEL telemetry client involved registering metrics/traces/logs in the global OTEL variables, there were multiple errors in the lines of `Attempted duplicate registration of API: trace`. This is now fixed by having a single test telemetry client instance. This requires _not_ setting the service name, which is unfortunate.

![image](https://github.com/user-attachments/assets/5208178c-7765-444f-b0f9-e3f4b7532e43)

As a last change here, the jest reporter for end-to-end tests is now set to `summary`. This means that jest will no longer write to the console `RUNS my-test-suite` every second or so, overwriting the actual logs we are trying to read.