### PR TITLE
fix: pod anti affinity spans all namespaces

### DIFF
--- a/spartan/aztec-network/templates/_helpers.tpl
+++ b/spartan/aztec-network/templates/_helpers.tpl
@@ -170,6 +170,8 @@ affinity:
               values:
                 - validator
                 - boot-node
-                - prover
+                - prover-node
+                - prover-broker
         topologyKey: "kubernetes.io/hostname"
+        namespaceSelector: {}
 {{- end -}}

--- a/spartan/aztec-network/templates/prover-broker.yaml
+++ b/spartan/aztec-network/templates/prover-broker.yaml
@@ -21,6 +21,7 @@ spec:
       {{- if .Values.network.public }}
       hostNetwork: true
       dnsPolicy: ClusterFirstWithHostNet
+      {{- include "aztec-network.publicAntiAffinity" . | nindent 6 }}
       {{- end }}
       volumes:
         - name: config


### PR DESCRIPTION
also grant anti-affinity to the prover node/broker.