### PR TITLE
draft: txe native world state

### DIFF
--- a/noir-projects/aztec-nr/authwit/src/cheatcodes.nr
+++ b/noir-projects/aztec-nr/authwit/src/cheatcodes.nr
@@ -17,7 +17,7 @@ where
     C: CallInterface<M>,
 {
     let target = call_interface.get_contract_address();
-    let inputs = cheatcodes::get_private_context_inputs(get_block_number());
+    let inputs = cheatcodes::get_private_context_inputs(get_block_number() - 1);
     let chain_id = inputs.tx_context.chain_id;
     let version = inputs.tx_context.version;
     let args_hash = hash_args(call_interface.get_args());
@@ -39,7 +39,7 @@ where
     let current_contract = get_contract_address();
     cheatcodes::set_contract_address(on_behalf_of);
     let target = call_interface.get_contract_address();
-    let inputs = cheatcodes::get_private_context_inputs(get_block_number());
+    let inputs = cheatcodes::get_private_context_inputs(get_block_number() - 1);
     let chain_id = inputs.tx_context.chain_id;
     let version = inputs.tx_context.version;
     let args_hash = hash_args(call_interface.get_args());

--- a/noir-projects/noir-contracts/contracts/router_contract/src/test.nr
+++ b/noir-projects/noir-contracts/contracts/router_contract/src/test.nr
@@ -10,7 +10,7 @@ unconstrained fn test_check_block_number() {
     let router_contract_address = router_contract.to_address();
     let router = Router::at(router_contract_address);
 
-    env.advance_block_by(9);
+    env.advance_block_by(8);
 
     // First we sanity-check that current block number is as expected
     let current_block_number = env.block_number();
@@ -28,7 +28,7 @@ unconstrained fn test_fail_check_block_number() {
     let router_contract_address = router_contract.to_address();
     let router = Router::at(router_contract_address);
 
-    env.advance_block_by(9);
+    env.advance_block_by(8);
 
     // First we sanity-check that current block number is as expected
     let current_block_number = env.block_number();

--- a/yarn-project/txe/src/util/txe_world_state_db.ts
+++ b/yarn-project/txe/src/util/txe_world_state_db.ts
@@ -3,14 +3,16 @@ import {
   type AztecAddress,
   type ContractDataSource,
   Fr,
-  PublicDataTreeLeaf,
   type PublicDataTreeLeafPreimage,
+  PublicDataWrite,
 } from '@aztec/circuits.js';
 import { computePublicDataTreeLeafSlot } from '@aztec/circuits.js/hash';
 import { WorldStateDB } from '@aztec/simulator';
 
+import { type TXE } from '../oracle/txe_oracle.js';
+
 export class TXEWorldStateDB extends WorldStateDB {
-  constructor(private merkleDb: MerkleTreeWriteOperations, dataSource: ContractDataSource) {
+  constructor(private merkleDb: MerkleTreeWriteOperations, dataSource: ContractDataSource, private txe: TXE) {
     super(merkleDb, dataSource);
   }
 
@@ -31,11 +33,7 @@ export class TXEWorldStateDB extends WorldStateDB {
   }
 
   override async storageWrite(contract: AztecAddress, slot: Fr, newValue: Fr): Promise<bigint> {
-    await this.merkleDb.batchInsert(
-      MerkleTreeId.PUBLIC_DATA_TREE,
-      [new PublicDataTreeLeaf(computePublicDataTreeLeafSlot(contract, slot), newValue).toBuffer()],
-      0,
-    );
+    await this.txe.addPublicDataWrites([new PublicDataWrite(computePublicDataTreeLeafSlot(contract, slot), newValue)]);
     return newValue.toBigInt();
   }
 


### PR DESCRIPTION
Pinging @Thunkar, the TXE (and generally)👨‍🔬. 

The biggest difference between old world state and new world state is that during the synching of blocks, the changes made to the trees MUST match the block itself. This gave me a bit of pain because it now has to more accurately model the side effect emission / collection of what happens in a tx. 

Particular things to pay attention to:
1. New world state assumes block numbers start at 1, hence we no longer start at 0. This means that we were off by 1 in a few places. 
2. Is the current behavior of the replacement of "getLatest" okay ? Previously we were using a different model, but now we need to make a distinction between what is happening in "this" block for public state, and what will be collected to be applied for the next block, for private state (outside of the execution note cache).
3. Emitting arbitrary note hashes / nullifiers (not through notifying note) is a tricky flow. I'm not sure if my approach is robust enough here, we don't use the note cache because we don't have access to the full note.

Continued in this [PR](https://github.com/AztecProtocol/aztec-packages/pull/11226) due to starting fresh after hols.