### PR TITLE
refactor: remove get registered account from pxe

### DIFF
--- a/yarn-project/aztec.js/src/wallet/base_wallet.ts
+++ b/yarn-project/aztec.js/src/wallet/base_wallet.ts
@@ -83,9 +83,6 @@ export abstract class BaseWallet implements Wallet {
   getRegisteredAccounts(): Promise<CompleteAddress[]> {
     return this.pxe.getRegisteredAccounts();
   }
-  getRegisteredAccount(address: AztecAddress): Promise<CompleteAddress | undefined> {
-    return this.pxe.getRegisteredAccount(address);
-  }
   registerSender(address: AztecAddress): Promise<AztecAddress> {
     return this.pxe.registerSender(address);
   }

--- a/yarn-project/aztec.js/src/wallet/index.ts
+++ b/yarn-project/aztec.js/src/wallet/index.ts
@@ -21,7 +21,9 @@ export async function getWallet(
   address: AztecAddress,
   accountContract: AccountContract,
 ): Promise<AccountWallet> {
-  const completeAddress = await pxe.getRegisteredAccount(address);
+  const completeAddress = (await pxe.getRegisteredAccounts()).find(completeAddress =>
+    completeAddress.address.equals(address),
+  );
   if (!completeAddress) {
     throw new Error(`Account ${address} not found`);
   }

--- a/yarn-project/circuit-types/src/interfaces/pxe.test.ts
+++ b/yarn-project/circuit-types/src/interfaces/pxe.test.ts
@@ -113,11 +113,6 @@ describe('PXESchema', () => {
     expect(result).toEqual([expect.any(CompleteAddress)]);
   });
 
-  it('getRegisteredAccount', async () => {
-    const result = await context.client.getRegisteredAccount(address);
-    expect(result).toBeInstanceOf(CompleteAddress);
-  });
-
   it('registerSender', async () => {
     const result = await context.client.registerSender(address);
     expect(result).toEqual(address);

--- a/yarn-project/circuit-types/src/interfaces/pxe.ts
+++ b/yarn-project/circuit-types/src/interfaces/pxe.ts
@@ -106,15 +106,6 @@ export interface PXE {
   getRegisteredAccounts(): Promise<CompleteAddress[]>;
 
   /**
-   * Retrieves the complete address of the account corresponding to the provided aztec address.
-   * Complete addresses include the address, the partial address, and the encryption public key.
-   *
-   * @param address - The address of account.
-   * @returns The complete address of the requested account if found.
-   */
-  getRegisteredAccount(address: AztecAddress): Promise<CompleteAddress | undefined>;
-
-  /**
    * Registers a user contact in PXE.
    *
    * Once a new contact is registered, the PXE Service will be able to receive notes tagged from this contact.
@@ -463,10 +454,6 @@ export const PXESchema: ApiSchemaFor<PXE> = {
   addCapsule: z.function().args(z.array(schemas.Fr)).returns(z.void()),
   registerAccount: z.function().args(schemas.Fr, schemas.Fr).returns(CompleteAddress.schema),
   getRegisteredAccounts: z.function().returns(z.array(CompleteAddress.schema)),
-  getRegisteredAccount: z
-    .function()
-    .args(schemas.AztecAddress)
-    .returns(z.union([CompleteAddress.schema, z.undefined()])),
   registerSender: z.function().args(schemas.AztecAddress).returns(schemas.AztecAddress),
   getSenders: z.function().returns(z.array(schemas.AztecAddress)),
   removeSender: z.function().args(schemas.AztecAddress).returns(z.void()),

--- a/yarn-project/cli/src/cmds/pxe/get_account.ts
+++ b/yarn-project/cli/src/cmds/pxe/get_account.ts
@@ -4,7 +4,9 @@ import { type LogFn, type Logger } from '@aztec/foundation/log';
 
 export async function getAccount(aztecAddress: AztecAddress, rpcUrl: string, debugLogger: Logger, log: LogFn) {
   const client = await createCompatibleClient(rpcUrl, debugLogger);
-  const account = await client.getRegisteredAccount(aztecAddress);
+  const account = (await client.getRegisteredAccounts()).find(completeAddress =>
+    completeAddress.address.equals(aztecAddress),
+  );
 
   if (!account) {
     log(`Unknown account ${aztecAddress.toString()}`);

--- a/yarn-project/pxe/src/pxe_service/pxe_service.ts
+++ b/yarn-project/pxe/src/pxe_service/pxe_service.ts
@@ -212,12 +212,6 @@ export class PXEService implements PXE {
     );
   }
 
-  public async getRegisteredAccount(address: AztecAddress): Promise<CompleteAddress | undefined> {
-    const result = await this.getRegisteredAccounts();
-    const account = result.find(r => r.address.equals(address));
-    return Promise.resolve(account);
-  }
-
   public async registerContractClass(artifact: ContractArtifact): Promise<void> {
     const contractClassId = computeContractClassId(getContractClassFromArtifact(artifact));
     await this.db.addContractArtifact(contractClassId, artifact);
@@ -876,7 +870,9 @@ export class PXEService implements PXE {
         const [keyPrefix, account] = await this.keyStore.getKeyPrefixAndAccount(vpk);
         let secretKey = await this.keyStore.getMasterSecretKey(vpk);
         if (keyPrefix === 'iv') {
-          const registeredAccount = await this.getRegisteredAccount(account);
+          const registeredAccount = (await this.getRegisteredAccounts()).find(completeAddress =>
+            completeAddress.address.equals(account),
+          );
           if (!registeredAccount) {
             throw new Error('No registered account');
           }

--- a/yarn-project/pxe/src/pxe_service/test/pxe_test_suite.ts
+++ b/yarn-project/pxe/src/pxe_service/test/pxe_test_suite.ts
@@ -24,10 +24,6 @@ export const pxeTestSuite = (testName: string, pxeSetup: () => Promise<PXE>) => 
       // Check that the account is correctly registered using the getAccounts and getRecipients methods
       const accounts = await pxe.getRegisteredAccounts();
       expect(accounts).toContainEqual(completeAddress);
-
-      // Check that the account is correctly registered using the getAccount and getRecipient methods
-      const account = await pxe.getRegisteredAccount(completeAddress.address);
-      expect(account).toEqual(completeAddress);
     });
 
     it('does not throw when registering the same account twice (just ignores the second attempt)', async () => {


### PR DESCRIPTION
This PR simply removes `getRegisteredAccount` from the PXE to cleanup the PXE interface.