### PR TITLE
refactor: consolidate contract functions in pxe

### DIFF
--- a/yarn-project/accounts/src/testing/create_account.ts
+++ b/yarn-project/accounts/src/testing/create_account.ts
@@ -47,7 +47,9 @@ export async function createAccounts(
       let skipClassRegistration = true;
       if (index === 0) {
         // for the first account, check if the contract class is already registered, otherwise we should register now
-        if (!(await pxe.isContractClassPubliclyRegistered(account.getInstance().contractClassId))) {
+        if (
+          !(await pxe.getContractClassMetadata(account.getInstance().contractClassId)).isContractClassPubliclyRegistered
+        ) {
           skipClassRegistration = false;
         }
       }

--- a/yarn-project/aztec.js/src/contract/contract.test.ts
+++ b/yarn-project/aztec.js/src/contract/contract.test.ts
@@ -150,7 +150,11 @@ describe('Contract Class', () => {
     wallet = mock<Wallet>();
     wallet.simulateTx.mockResolvedValue(mockTxSimulationResult);
     wallet.createTxExecutionRequest.mockResolvedValue(mockTxRequest);
-    wallet.getContractInstance.mockResolvedValue(contractInstance);
+    wallet.getContractMetadata.mockResolvedValue({
+      contractInstance,
+      isContractInitialized: true,
+      isContractPubliclyDeployed: true,
+    });
     wallet.sendTx.mockResolvedValue(mockTxHash);
     wallet.simulateUnconstrained.mockResolvedValue(mockUnconstrainedResultValue as any as AbiDecoded);
     wallet.getTxReceipt.mockResolvedValue(mockTxReceipt);

--- a/yarn-project/aztec.js/src/contract/contract.ts
+++ b/yarn-project/aztec.js/src/contract/contract.ts
@@ -22,7 +22,7 @@ export class Contract extends ContractBase {
    * @returns A promise that resolves to a new Contract instance.
    */
   public static async at(address: AztecAddress, artifact: ContractArtifact, wallet: Wallet): Promise<Contract> {
-    const instance = await wallet.getContractInstance(address);
+    const instance = (await wallet.getContractMetadata(address)).contractInstance;
     if (instance === undefined) {
       throw new Error(`Contract instance at ${address.toString()} has not been registered in the wallet's PXE`);
     }

--- a/yarn-project/aztec.js/src/contract/deploy_method.ts
+++ b/yarn-project/aztec.js/src/contract/deploy_method.ts
@@ -153,7 +153,7 @@ export class DeployMethod<TContract extends ContractBase = Contract> extends Bas
 
     // Register the contract class if it hasn't been published already.
     if (!options.skipClassRegistration) {
-      if (await this.wallet.isContractClassPubliclyRegistered(contractClass.id)) {
+      if ((await this.wallet.getContractClassMetadata(contractClass.id)).isContractClassPubliclyRegistered) {
         this.log.debug(
           `Skipping registration of already registered contract class ${contractClass.id.toString()} for ${instance.address.toString()}`,
         );

--- a/yarn-project/aztec.js/src/wallet/base_wallet.ts
+++ b/yarn-project/aztec.js/src/wallet/base_wallet.ts
@@ -1,5 +1,7 @@
 import {
   type AuthWitness,
+  type ContractClassMetadata,
+  type ContractMetadata,
   type EventMetadataDefinition,
   type ExtendedNote,
   type GetContractClassLogsResponse,
@@ -22,7 +24,6 @@ import {
 import {
   type AztecAddress,
   type CompleteAddress,
-  type ContractClassWithId,
   type ContractInstanceWithAddress,
   type Fr,
   type GasFees,
@@ -65,15 +66,6 @@ export abstract class BaseWallet implements Wallet {
 
   getAddress() {
     return this.getCompleteAddress().address;
-  }
-  getContractInstance(address: AztecAddress): Promise<ContractInstanceWithAddress | undefined> {
-    return this.pxe.getContractInstance(address);
-  }
-  getContractClass(id: Fr): Promise<ContractClassWithId | undefined> {
-    return this.pxe.getContractClass(id);
-  }
-  getContractArtifact(id: Fr): Promise<ContractArtifact | undefined> {
-    return this.pxe.getContractArtifact(id);
   }
   addCapsule(capsule: Fr[]): Promise<void> {
     return this.pxe.addCapsule(capsule);
@@ -182,17 +174,14 @@ export abstract class BaseWallet implements Wallet {
   getAuthWitness(messageHash: Fr) {
     return this.pxe.getAuthWitness(messageHash);
   }
-  isContractClassPubliclyRegistered(id: Fr): Promise<boolean> {
-    return this.pxe.isContractClassPubliclyRegistered(id);
-  }
-  isContractPubliclyDeployed(address: AztecAddress): Promise<boolean> {
-    return this.pxe.isContractPubliclyDeployed(address);
-  }
-  isContractInitialized(address: AztecAddress): Promise<boolean> {
-    return this.pxe.isContractInitialized(address);
-  }
   getPXEInfo(): Promise<PXEInfo> {
     return this.pxe.getPXEInfo();
+  }
+  getContractClassMetadata(id: Fr, includeArtifact: boolean = false): Promise<ContractClassMetadata> {
+    return this.pxe.getContractClassMetadata(id, includeArtifact);
+  }
+  getContractMetadata(address: AztecAddress): Promise<ContractMetadata> {
+    return this.pxe.getContractMetadata(address);
   }
   getPrivateEvents<T>(
     event: EventMetadataDefinition,

--- a/yarn-project/bot/src/factory.ts
+++ b/yarn-project/bot/src/factory.ts
@@ -63,7 +63,7 @@ export class BotFactory {
     const salt = Fr.ONE;
     const signingKey = deriveSigningKey(this.config.senderPrivateKey);
     const account = await getSchnorrAccount(this.pxe, this.config.senderPrivateKey, signingKey, salt);
-    const isInit = await this.pxe.isContractInitialized(account.getAddress());
+    const isInit = (await this.pxe.getContractMetadata(account.getAddress())).isContractInitialized;
     if (isInit) {
       this.log.info(`Account at ${account.getAddress().toString()} already initialized`);
       const wallet = await account.register();
@@ -112,7 +112,7 @@ export class BotFactory {
     }
 
     const address = (await deploy.getInstance(deployOpts)).address;
-    if (await this.pxe.isContractPubliclyDeployed(address)) {
+    if ((await this.pxe.getContractMetadata(address)).isContractPubliclyDeployed) {
       this.log.info(`Token at ${address.toString()} already deployed`);
       return deploy.register();
     } else {

--- a/yarn-project/circuit-types/src/interfaces/pxe.test.ts
+++ b/yarn-project/circuit-types/src/interfaces/pxe.test.ts
@@ -2,7 +2,6 @@ import {
   AztecAddress,
   ClientIvcProof,
   CompleteAddress,
-  type ContractClassWithId,
   type ContractInstanceWithAddress,
   EthAddress,
   Fr,
@@ -48,7 +47,14 @@ import { SiblingPath } from '../sibling_path/sibling_path.js';
 import { Tx, TxHash, TxProvingResult, TxReceipt, TxSimulationResult } from '../tx/index.js';
 import { TxEffect } from '../tx_effect.js';
 import { TxExecutionRequest } from '../tx_execution_request.js';
-import { type EventMetadataDefinition, type PXE, type PXEInfo, PXESchema } from './pxe.js';
+import {
+  type ContractClassMetadata,
+  type ContractMetadata,
+  type EventMetadataDefinition,
+  type PXE,
+  type PXEInfo,
+  PXESchema,
+} from './pxe.js';
 
 jest.setTimeout(12_000);
 
@@ -275,39 +281,28 @@ describe('PXESchema', () => {
     expect(result).toEqual(await handler.getPXEInfo());
   });
 
-  it('getContractInstance', async () => {
-    const result = await context.client.getContractInstance(address);
-    expect(result).toEqual(instance);
+  it('getContractMetadata', async () => {
+    const { contractInstance, isContractInitialized, isContractPubliclyDeployed } =
+      await context.client.getContractMetadata(address);
+    expect(contractInstance).toEqual(instance);
+    expect(isContractInitialized).toEqual(true);
+    expect(isContractPubliclyDeployed).toEqual(true);
   });
 
-  it('getContractClass', async () => {
-    const result = await context.client.getContractClass(Fr.random());
+  it('getContractClassMetadata', async () => {
+    const {
+      contractClass,
+      isContractClassPubliclyRegistered,
+      artifact: contractArtifact,
+    } = await context.client.getContractClassMetadata(Fr.random(), true);
     const expected = omit(
       await getContractClassFromArtifact(artifact),
       'privateFunctionsRoot',
       'publicBytecodeCommitment',
     );
-    expect(result).toEqual(expected);
-  });
-
-  it('getContractArtifact', async () => {
-    const result = await context.client.getContractArtifact(Fr.random());
-    deepStrictEqual(result, artifact);
-  });
-
-  it('isContractClassPubliclyRegistered', async () => {
-    const result = await context.client.isContractClassPubliclyRegistered(Fr.random());
-    expect(result).toBe(true);
-  });
-
-  it('isContractPubliclyDeployed', async () => {
-    const result = await context.client.isContractPubliclyDeployed(address);
-    expect(result).toBe(true);
-  });
-
-  it('isContractInitialized', async () => {
-    const result = await context.client.isContractInitialized(address);
-    expect(result).toBe(true);
+    expect(contractClass).toEqual(expected);
+    expect(isContractClassPubliclyRegistered).toEqual(true);
+    deepStrictEqual(contractArtifact, artifact);
   });
 
   it('getPrivateEvents', async () => {
@@ -520,30 +515,22 @@ class MockPXE implements PXE {
       pxeVersion: '1.0',
     });
   }
-  getContractInstance(address: AztecAddress): Promise<ContractInstanceWithAddress | undefined> {
-    expect(address).toEqual(this.address);
-    return Promise.resolve(this.instance);
-  }
-  async getContractClass(id: Fr): Promise<ContractClassWithId | undefined> {
+  async getContractClassMetadata(id: Fr, includeArtifact: boolean = false): Promise<ContractClassMetadata> {
     expect(id).toBeInstanceOf(Fr);
     const contractClass = await getContractClassFromArtifact(this.artifact);
-    return contractClass;
+    return Promise.resolve({
+      contractClass,
+      isContractClassPubliclyRegistered: true,
+      artifact: includeArtifact ? this.artifact : undefined,
+    });
   }
-  getContractArtifact(id: Fr): Promise<ContractArtifact | undefined> {
-    expect(id).toBeInstanceOf(Fr);
-    return Promise.resolve(this.artifact);
-  }
-  isContractClassPubliclyRegistered(id: Fr): Promise<boolean> {
-    expect(id).toBeInstanceOf(Fr);
-    return Promise.resolve(true);
-  }
-  isContractPubliclyDeployed(address: AztecAddress): Promise<boolean> {
+  getContractMetadata(address: AztecAddress): Promise<ContractMetadata> {
     expect(address).toEqual(this.address);
-    return Promise.resolve(true);
-  }
-  isContractInitialized(address: AztecAddress): Promise<boolean> {
-    expect(address).toEqual(this.address);
-    return Promise.resolve(true);
+    return Promise.resolve({
+      contractInstance: this.instance,
+      isContractInitialized: true,
+      isContractPubliclyDeployed: true,
+    });
   }
   getPrivateEvents<T>(
     _eventMetadata: EventMetadataDefinition,

--- a/yarn-project/circuit-types/src/interfaces/pxe.ts
+++ b/yarn-project/circuit-types/src/interfaces/pxe.ts
@@ -353,49 +353,33 @@ export interface PXE {
   getPXEInfo(): Promise<PXEInfo>;
 
   /**
-   * Returns a Contract Instance given its address, which includes the contract class identifier,
-   * initialization hash, deployment salt, and public keys hash.
+   * Returns the contract metadata given an address.
+   * The metadata consists of its contract instance, which includes the contract class identifier,
+   * initialization hash, deployment salt, and public keys hash; whether the contract instance has been initialized;
+   * and whether the contract instance with the given address has been publicly deployed.
+   * @remark - it queries the node to check whether the contract instance has been initialized / publicly deployed through a node.
+   * This query is not dependent on the PXE.
+   * @param address - The address that the contract instance resides at.
+   * @returns - It returns the contract metadata
    * TODO(@spalladino): Should we return the public keys in plain as well here?
-   * @param address - Deployment address of the contract.
    */
-  getContractInstance(address: AztecAddress): Promise<ContractInstanceWithAddress | undefined>;
+  getContractMetadata(address: AztecAddress): Promise<ContractMetadata>;
 
   /**
-   * Returns a Contract Class given its identifier.
+   * Returns the contract class metadata given a contract class id.
+   * The metadata consists of its contract class, whether it has been publicly registered, and its artifact.
+   * @remark - it queries the node to check whether the contract class with the given id has been publicly registered.
+   * @param id - Identifier of the class.
+   * @param includeArtifact - Identifier of the class.
+   * @returns - It returns the contract class metadata, with the artifact field being optional, and will only be returned if true is passed in
+   * for `includeArtifact`
    * TODO(@spalladino): The PXE actually holds artifacts and not classes, what should we return? Also,
    * should the pxe query the node for contract public info, and merge it with its own definitions?
-   * @param id - Identifier of the class.
-   */
-  getContractClass(id: Fr): Promise<ContractClassWithId | undefined>;
-
-  /**
-   * Returns the contract artifact associated to a contract class.
-   * @param id - Identifier of the class.
-   */
-  getContractArtifact(id: Fr): Promise<ContractArtifact | undefined>;
-
-  /**
-   * Queries the node to check whether the contract class with the given id has been publicly registered.
    * TODO(@spalladino): This method is strictly needed to decide whether to publicly register a class or not
    * during a public deployment. We probably want a nicer and more general API for this, but it'll have to
    * do for the time being.
-   * @param id - Identifier of the class.
    */
-  isContractClassPubliclyRegistered(id: Fr): Promise<boolean>;
-
-  /**
-   * Queries the node to check whether the contract instance with the given address has been publicly deployed,
-   * regardless of whether this PXE knows about the contract or not.
-   * TODO(@spalladino): Same notes as above.
-   */
-  isContractPubliclyDeployed(address: AztecAddress): Promise<boolean>;
-
-  /**
-   * Queries the node to check whether the contract instance with the given address has been initialized,
-   * by checking the standard initialization nullifier.
-   * @param address - Address of the contract to check.
-   */
-  isContractInitialized(address: AztecAddress): Promise<boolean>;
+  getContractClassMetadata(id: Fr, includeArtifact?: boolean): Promise<ContractClassMetadata>;
 
   /**
    * Returns the private events given search parameters.
@@ -443,6 +427,30 @@ export interface PXEInfo {
   /** Protocol contract addresses */
   protocolContractAddresses: ProtocolContractAddresses;
 }
+
+export interface ContractMetadata {
+  contractInstance?: ContractInstanceWithAddress | undefined;
+  isContractInitialized: boolean;
+  isContractPubliclyDeployed: boolean;
+}
+
+export interface ContractClassMetadata {
+  contractClass?: ContractClassWithId | undefined;
+  isContractClassPubliclyRegistered: boolean;
+  artifact?: ContractArtifact | undefined;
+}
+
+const ContractMetadataSchema = z.object({
+  contractInstance: z.union([ContractInstanceWithAddressSchema, z.undefined()]),
+  isContractInitialized: z.boolean(),
+  isContractPubliclyDeployed: z.boolean(),
+}) satisfies ZodFor<ContractMetadata>;
+
+const ContractClassMetadataSchema = z.object({
+  contractClass: z.union([ContractClassWithIdSchema, z.undefined()]),
+  isContractClassPubliclyRegistered: z.boolean(),
+  artifact: z.union([ContractArtifactSchema, z.undefined()]),
+}) satisfies ZodFor<ContractClassMetadata>;
 
 const PXEInfoSchema = z.object({
   pxeVersion: z.string(),
@@ -521,21 +529,8 @@ export const PXESchema: ApiSchemaFor<PXE> = {
   getProvenBlockNumber: z.function().returns(z.number()),
   getNodeInfo: z.function().returns(NodeInfoSchema),
   getPXEInfo: z.function().returns(PXEInfoSchema),
-  getContractInstance: z
-    .function()
-    .args(schemas.AztecAddress)
-    .returns(z.union([ContractInstanceWithAddressSchema, z.undefined()])),
-  getContractClass: z
-    .function()
-    .args(schemas.Fr)
-    .returns(z.union([ContractClassWithIdSchema, z.undefined()])),
-  getContractArtifact: z
-    .function()
-    .args(schemas.Fr)
-    .returns(z.union([ContractArtifactSchema, z.undefined()])),
-  isContractClassPubliclyRegistered: z.function().args(schemas.Fr).returns(z.boolean()),
-  isContractPubliclyDeployed: z.function().args(schemas.AztecAddress).returns(z.boolean()),
-  isContractInitialized: z.function().args(schemas.AztecAddress).returns(z.boolean()),
+  getContractMetadata: z.function().args(schemas.AztecAddress).returns(ContractMetadataSchema),
+  getContractClassMetadata: z.function().args(schemas.Fr, optional(z.boolean())).returns(ContractClassMetadataSchema),
   getPrivateEvents: z
     .function()
     .args(EventMetadataDefinitionSchema, z.number(), z.number(), z.array(schemas.Point))

--- a/yarn-project/cli/src/cmds/pxe/get_contract_data.ts
+++ b/yarn-project/cli/src/cmds/pxe/get_contract_data.ts
@@ -10,12 +10,15 @@ export async function getContractData(
   log: LogFn,
 ) {
   const client = await createCompatibleClient(rpcUrl, debugLogger);
-  const instance = await client.getContractInstance(contractAddress);
-  const contractClass = includeBytecode && instance && (await client.getContractClass(instance?.contractClassId));
+  const {
+    contractInstance: instance,
+    isContractInitialized: isInitialized,
+    isContractPubliclyDeployed: isPubliclyDeployed,
+  } = await client.getContractMetadata(contractAddress);
+  const contractClass =
+    includeBytecode && instance && (await client.getContractClassMetadata(instance?.contractClassId)).contractClass;
 
   const isPrivatelyDeployed = !!instance;
-  const isPubliclyDeployed = await client.isContractPubliclyDeployed(contractAddress);
-  const isInitialized = await client.isContractInitialized(contractAddress);
   const initStr = isInitialized ? 'initialized' : 'not initialized';
   const addrStr = contractAddress.toString();
 

--- a/yarn-project/cli/src/utils/inspect.ts
+++ b/yarn-project/cli/src/utils/inspect.ts
@@ -181,17 +181,23 @@ type ArtifactMap = Record<string, ContractArtifactWithClassId>;
 type ContractArtifactWithClassId = ContractArtifact & { classId: Fr };
 async function getKnownArtifacts(pxe: PXE): Promise<ArtifactMap> {
   const knownContractAddresses = await pxe.getContracts();
-  const knownContracts = await Promise.all(knownContractAddresses.map(contract => pxe.getContractInstance(contract)));
+  const knownContracts = (
+    await Promise.all(knownContractAddresses.map(contractAddress => pxe.getContractMetadata(contractAddress)))
+  ).map(contractMetadata => contractMetadata.contractInstance);
   const classIds = [...new Set(knownContracts.map(contract => contract?.contractClassId))];
-  const knownArtifacts = await Promise.all(
-    classIds.map(classId =>
-      classId ? pxe.getContractArtifact(classId).then(a => (a ? { ...a, classId } : undefined)) : undefined,
-    ),
+  const knownArtifacts = (
+    await Promise.all(classIds.map(classId => (classId ? pxe.getContractClassMetadata(classId) : undefined)))
+  ).map(contractClassMetadata =>
+    contractClassMetadata
+      ? { ...contractClassMetadata.artifact, classId: contractClassMetadata.contractClass?.id }
+      : undefined,
   );
   const map: Record<string, ContractArtifactWithClassId> = {};
   for (const instance of knownContracts) {
     if (instance) {
-      const artifact = knownArtifacts.find(a => a?.classId.equals(instance.contractClassId));
+      const artifact = knownArtifacts.find(a =>
+        a?.classId?.equals(instance.contractClassId),
+      ) as ContractArtifactWithClassId;
       if (artifact) {
         map[instance.address.toString()] = artifact;
       }

--- a/yarn-project/end-to-end/src/e2e_block_building.test.ts
+++ b/yarn-project/end-to-end/src/e2e_block_building.test.ts
@@ -126,7 +126,8 @@ describe('e2e_block_building', () => {
       expect(receipts.map(r => r.blockNumber)).toEqual(times(TX_COUNT, () => receipts[0].blockNumber));
 
       // Assert all contracts got deployed
-      const isContractDeployed = async (address: AztecAddress) => !!(await pxe.getContractInstance(address));
+      const isContractDeployed = async (address: AztecAddress) =>
+        !!(await pxe.getContractMetadata(address)).contractInstance;
       const areDeployed = await Promise.all(receipts.map(r => isContractDeployed(r.contract.address)));
       expect(areDeployed).toEqual(times(TX_COUNT, () => true));
     });

--- a/yarn-project/end-to-end/src/e2e_deploy_contract/deploy_method.test.ts
+++ b/yarn-project/end-to-end/src/e2e_deploy_contract/deploy_method.test.ts
@@ -50,16 +50,18 @@ describe('e2e_deploy_contract deploy method', () => {
     logger.debug(`Calling public method on stateful test contract at ${contract.address.toString()}`);
     await contract.methods.increment_public_value(owner, 84).send().wait();
     expect(await contract.methods.get_public_value(owner).simulate()).toEqual(84n);
-    expect(await pxe.isContractClassPubliclyRegistered(contract.instance.contractClassId)).toBeTrue();
+    expect(
+      (await pxe.getContractClassMetadata(contract.instance.contractClassId)).isContractClassPubliclyRegistered,
+    ).toBeTrue();
   });
 
   // TODO(#10007): Remove this test. Common contracts (ie token contracts) are only distinguished
   // because we're manually adding them to the archiver to support provernet.
   it('registers a contract class for a common contract', async () => {
     const { id: tokenContractClass } = await getContractClassFromArtifact(TokenContract.artifact);
-    expect(await pxe.isContractClassPubliclyRegistered(tokenContractClass)).toBeFalse();
+    expect((await pxe.getContractClassMetadata(tokenContractClass)).isContractClassPubliclyRegistered).toBeFalse();
     await TokenContract.deploy(wallet, wallet.getAddress(), 'TOKEN', 'TKN', 18n).send().deployed();
-    expect(await pxe.isContractClassPubliclyRegistered(tokenContractClass)).toBeTrue();
+    expect((await pxe.getContractClassMetadata(tokenContractClass)).isContractClassPubliclyRegistered).toBeTrue();
   });
 
   it('publicly universally deploys and initializes a contract', async () => {

--- a/yarn-project/end-to-end/src/e2e_deploy_contract/legacy.test.ts
+++ b/yarn-project/end-to-end/src/e2e_deploy_contract/legacy.test.ts
@@ -42,8 +42,8 @@ describe('e2e_deploy_contract legacy', () => {
     const deployer = new ContractDeployer(TestContractArtifact, wallet, publicKeys);
     const receipt = await deployer.deploy().send({ contractAddressSalt: salt }).wait({ wallet });
     expect(receipt.contract.address).toEqual(deploymentData.address);
-    expect(await pxe.getContractInstance(deploymentData.address)).toBeDefined();
-    expect(await pxe.isContractPubliclyDeployed(deploymentData.address)).toBeDefined();
+    expect((await pxe.getContractMetadata(deploymentData.address)).contractInstance).toBeDefined();
+    expect((await pxe.getContractMetadata(deploymentData.address)).isContractPubliclyDeployed).toBeTrue();
   });
 
   /**
@@ -113,8 +113,12 @@ describe('e2e_deploy_contract legacy', () => {
 
     expect(badTxReceipt.status).toEqual(TxStatus.APP_LOGIC_REVERTED);
 
+    const { isContractClassPubliclyRegistered } = await pxe.getContractClassMetadata(
+      (
+        await badDeploy.getInstance()
+      ).contractClassId,
+    );
     // But the bad tx did not deploy
-    const badInstance = await badDeploy.getInstance();
-    await expect(pxe.isContractClassPubliclyRegistered(badInstance.contractClassId)).resolves.toBeFalsy();
+    expect(isContractClassPubliclyRegistered).toBeFalse();
   });
 });

--- a/yarn-project/end-to-end/src/e2e_fees/fees_test.ts
+++ b/yarn-project/end-to-end/src/e2e_fees/fees_test.ts
@@ -147,7 +147,7 @@ export class FeesTest {
         this.fpcAdmin = this.aliceAddress;
         const canonicalFeeJuice = await getCanonicalFeeJuice();
         this.feeJuiceContract = await FeeJuiceContract.at(canonicalFeeJuice.address, this.aliceWallet);
-        const bobInstance = await this.bobWallet.getContractInstance(this.bobAddress);
+        const bobInstance = (await this.bobWallet.getContractMetadata(this.bobAddress)).contractInstance;
         if (!bobInstance) {
           throw new Error('Bob instance not found');
         }
@@ -223,7 +223,7 @@ export class FeesTest {
       'fpc_setup',
       async context => {
         const feeJuiceContract = this.feeJuiceBridgeTestHarness.feeJuice;
-        expect(await context.pxe.isContractPubliclyDeployed(feeJuiceContract.address)).toBe(true);
+        expect((await context.pxe.getContractMetadata(feeJuiceContract.address)).isContractPubliclyDeployed).toBe(true);
 
         const bananaCoin = this.bananaCoin;
         const bananaFPC = await FPCContract.deploy(this.aliceWallet, bananaCoin.address, this.fpcAdmin)

--- a/yarn-project/end-to-end/src/fixtures/snapshot_manager.ts
+++ b/yarn-project/end-to-end/src/fixtures/snapshot_manager.ts
@@ -559,7 +559,10 @@ export const addAccounts =
         let skipClassRegistration = true;
         if (index === 0) {
           // for the first account, check if the contract class is already registered, otherwise we should register now
-          if (!(await pxe.isContractClassPubliclyRegistered(account.getInstance().contractClassId))) {
+          if (
+            !(await pxe.getContractClassMetadata(account.getInstance().contractClassId))
+              .isContractClassPubliclyRegistered
+          ) {
             skipClassRegistration = false;
           }
         }
@@ -599,10 +602,12 @@ export async function publicDeployAccounts(
   waitUntilProven = false,
 ) {
   const accountAddressesToDeploy = accountsToDeploy.map(a => ('address' in a ? a.address : a));
-  const instances = await Promise.all(accountAddressesToDeploy.map(account => sender.getContractInstance(account)));
+  const instances = (
+    await Promise.all(accountAddressesToDeploy.map(account => sender.getContractMetadata(account)))
+  ).map(metadata => metadata.contractInstance);
 
   const contractClass = await getContractClassFromArtifact(SchnorrAccountContractArtifact);
-  const alreadyRegistered = await sender.isContractClassPubliclyRegistered(contractClass.id);
+  const alreadyRegistered = (await sender.getContractClassMetadata(contractClass.id)).isContractClassPubliclyRegistered;
 
   const calls: FunctionCall[] = [];
   if (!alreadyRegistered) {

--- a/yarn-project/pxe/src/pxe_service/pxe_service.ts
+++ b/yarn-project/pxe/src/pxe_service/pxe_service.ts
@@ -146,13 +146,33 @@ export class PXEService implements PXE {
     return this.db.getContractInstance(address);
   }
 
-  public async getContractClass(id: Fr): Promise<ContractClassWithId | undefined> {
+  public async getContractClassMetadata(
+    id: Fr,
+    includeArtifact: boolean = false,
+  ): Promise<{
+    contractClass: ContractClassWithId | undefined;
+    isContractClassPubliclyRegistered: boolean;
+    artifact: ContractArtifact | undefined;
+  }> {
     const artifact = await this.db.getContractArtifact(id);
-    return artifact && getContractClassFromArtifact(artifact);
+
+    return {
+      contractClass: artifact && (await getContractClassFromArtifact(artifact)),
+      isContractClassPubliclyRegistered: await this.#isContractClassPubliclyRegistered(id),
+      artifact: includeArtifact ? artifact : undefined,
+    };
   }
 
-  public getContractArtifact(id: Fr): Promise<ContractArtifact | undefined> {
-    return this.db.getContractArtifact(id);
+  public async getContractMetadata(address: AztecAddress): Promise<{
+    contractInstance: ContractInstanceWithAddress | undefined;
+    isContractInitialized: boolean;
+    isContractPubliclyDeployed: boolean;
+  }> {
+    return {
+      contractInstance: await this.db.getContractInstance(address),
+      isContractInitialized: await this.#isContractInitialized(address),
+      isContractPubliclyDeployed: await this.#isContractPubliclyDeployed(address),
+    };
   }
 
   public async registerAccount(secretKey: Fr, partialAddress: PartialAddress): Promise<CompleteAddress> {
@@ -825,15 +845,15 @@ export class PXEService implements PXE {
     });
   }
 
-  public async isContractClassPubliclyRegistered(id: Fr): Promise<boolean> {
+  async #isContractClassPubliclyRegistered(id: Fr): Promise<boolean> {
     return !!(await this.node.getContractClass(id));
   }
 
-  public async isContractPubliclyDeployed(address: AztecAddress): Promise<boolean> {
+  async #isContractPubliclyDeployed(address: AztecAddress): Promise<boolean> {
     return !!(await this.node.getContract(address));
   }
 
-  public async isContractInitialized(address: AztecAddress): Promise<boolean> {
+  async #isContractInitialized(address: AztecAddress): Promise<boolean> {
     const initNullifier = await siloNullifier(address, address.toField());
     return !!(await this.node.getNullifierMembershipWitness('latest', initNullifier));
   }

--- a/yarn-project/pxe/src/pxe_service/test/pxe_test_suite.ts
+++ b/yarn-project/pxe/src/pxe_service/test/pxe_test_suite.ts
@@ -52,12 +52,12 @@ export const pxeTestSuite = (testName: string, pxeSetup: () => Promise<PXE>) => 
       const instance = await randomContractInstanceWithAddress({ contractClassId });
 
       await pxe.registerContractClass(artifact);
-      expect(await pxe.getContractClass(contractClassId)).toMatchObject(
+      expect((await pxe.getContractClassMetadata(contractClassId)).contractClass).toMatchObject(
         omit(contractClass, 'privateFunctionsRoot', 'publicBytecodeCommitment'),
       );
 
       await pxe.registerContract({ instance });
-      expect(await pxe.getContractInstance(instance.address)).toEqual(instance);
+      expect((await pxe.getContractMetadata(instance.address)).contractInstance).toEqual(instance);
     });
 
     it('refuses to register a class with a mismatched address', async () => {


### PR DESCRIPTION
In this PR, we are cleaning up the PXE interfaces by consolidating contract getter functions. As it is not easy to completely remove some of these functions (esp the node proxies), we are doing our best to clean up the outward facing interface by grouping them together.


```
isContractInitialized
getContractInstance
isContractPubliclyDeployed
```
have been merged into `getContractMetadata`

and 

```
getContractClass
isContractClassPubliclyRegistered
getContractArtifact
```

have been merged into `getContractClassMetadata`.