### PR TITLE
refactor: add note to deliver note

### DIFF
--- a/yarn-project/aztec.js/src/wallet/base_wallet.ts
+++ b/yarn-project/aztec.js/src/wallet/base_wallet.ts
@@ -124,11 +124,8 @@ export abstract class BaseWallet implements Wallet {
   getPublicStorageAt(contract: AztecAddress, storageSlot: Fr): Promise<any> {
     return this.pxe.getPublicStorageAt(contract, storageSlot);
   }
-  addNote(note: ExtendedNote): Promise<void> {
-    return this.pxe.addNote(note, this.getAddress());
-  }
-  addNullifiedNote(note: ExtendedNote): Promise<void> {
-    return this.pxe.addNullifiedNote(note);
+  deliverNote(note: ExtendedNote, isNullified?: boolean): Promise<void> {
+    return this.pxe.deliverNote(note, isNullified, this.getAddress());
   }
   getBlock(number: number): Promise<L2Block | undefined> {
     return this.pxe.getBlock(number);

--- a/yarn-project/circuit-types/src/interfaces/pxe.test.ts
+++ b/yarn-project/circuit-types/src/interfaces/pxe.test.ts
@@ -203,12 +203,9 @@ describe('PXESchema', () => {
     expect(result).toEqual([expect.any(BigInt), expect.any(SiblingPath)]);
   });
 
-  it('addNote', async () => {
-    await context.client.addNote(ExtendedNote.random(), address);
-  });
-
-  it('addNullifiedNote', async () => {
-    await context.client.addNullifiedNote(ExtendedNote.random());
+  it('deliverNote', async () => {
+    await context.client.deliverNote(ExtendedNote.random(), false, address);
+    await context.client.deliverNote(ExtendedNote.random(), true, address);
   });
 
   it('getBlock', async () => {
@@ -419,13 +416,10 @@ class MockPXE implements PXE {
     expect(secret).toBeInstanceOf(Fr);
     return Promise.resolve([1n, SiblingPath.random(L1_TO_L2_MSG_TREE_HEIGHT)]);
   }
-  addNote(note: ExtendedNote, scope?: AztecAddress | undefined): Promise<void> {
+  deliverNote(note: ExtendedNote, isNullified: boolean = false, scope?: AztecAddress): Promise<void> {
     expect(note).toBeInstanceOf(ExtendedNote);
+    expect(typeof isNullified).toBe('boolean');
     expect(scope).toEqual(this.address);
-    return Promise.resolve();
-  }
-  addNullifiedNote(note: ExtendedNote): Promise<void> {
-    expect(note).toBeInstanceOf(ExtendedNote);
     return Promise.resolve();
   }
   getBlock(number: number): Promise<L2Block | undefined> {

--- a/yarn-project/circuit-types/src/interfaces/pxe.ts
+++ b/yarn-project/circuit-types/src/interfaces/pxe.ts
@@ -246,22 +246,16 @@ export interface PXE {
   ): Promise<[bigint, SiblingPath<typeof L1_TO_L2_MSG_TREE_HEIGHT>]>;
 
   /**
-   * Adds a note to the database.
-   * @throws If the note hash of the note doesn't exist in the tree.
-   * @param note - The note to add.
+   * Delivers a previously created note to the database. This note can be non-nullified or nullified.
+   * @param note - The note to deliver.
+   * @param nullified - Whether or not the note we want to deliver is nullified. Currently optional.
    * @param scope - The scope to add the note under. Currently optional.
-   */
-  addNote(note: ExtendedNote, scope?: AztecAddress): Promise<void>;
-
-  /**
-   * Adds a nullified note to the database.
    * @throws If the note hash of the note doesn't exist in the tree.
-   * @param note - The note to add.
-   * @dev We are not deriving a nullifier in this function since that would require having the nullifier secret key
+   * @dev When we deliver a nullified note, we are not deriving a nullifier in this function since that would require having the nullifier secret key
    * which is undesirable. Instead, we are just adding the note to the database as nullified and the nullifier is set
    * to 0 in the db.
    */
-  addNullifiedNote(note: ExtendedNote): Promise<void>;
+  deliverNote(note: ExtendedNote, nullified?: boolean, scope?: AztecAddress): Promise<void>;
 
   /**
    * Get the given block.
@@ -503,8 +497,10 @@ export const PXESchema: ApiSchemaFor<PXE> = {
     .function()
     .args(schemas.AztecAddress, schemas.Fr, schemas.Fr)
     .returns(z.tuple([schemas.BigInt, SiblingPath.schemaFor(L1_TO_L2_MSG_TREE_HEIGHT)])),
-  addNote: z.function().args(ExtendedNote.schema, optional(schemas.AztecAddress)).returns(z.void()),
-  addNullifiedNote: z.function().args(ExtendedNote.schema).returns(z.void()),
+  deliverNote: z
+    .function()
+    .args(ExtendedNote.schema, optional(z.boolean()), optional(schemas.AztecAddress))
+    .returns(z.void()),
   getBlock: z
     .function()
     .args(z.number())

--- a/yarn-project/cli-wallet/src/cmds/add_note.ts
+++ b/yarn-project/cli-wallet/src/cmds/add_note.ts
@@ -26,5 +26,5 @@ export async function addNote(
   }
 
   const extendedNote = new ExtendedNote(note, address, contractAddress, storageField.slot, contractNote.id, txHash);
-  await wallet.addNote(extendedNote);
+  await wallet.deliverNote(extendedNote);
 }

--- a/yarn-project/end-to-end/src/composed/e2e_persistence.test.ts
+++ b/yarn-project/end-to-end/src/composed/e2e_persistence.test.ts
@@ -337,6 +337,6 @@ async function addPendingShieldNoteToPXE(
     TokenBlacklistContract.notes.TransparentNote.id,
     txHash,
   );
-  await wallet.addNote(extendedNote);
+  await wallet.deliverNote(extendedNote);
   // docs:end:pxe_add_note
 }

--- a/yarn-project/end-to-end/src/e2e_2_pxes.test.ts
+++ b/yarn-project/end-to-end/src/e2e_2_pxes.test.ts
@@ -271,7 +271,7 @@ describe('e2e_2_pxes', () => {
     {
       // We need to register the contract to be able to compute the note hash by calling compute_note_hash_and_optionally_a_nullifier(...)
       await pxeB.registerContract(testContract);
-      await pxeB.addNullifiedNote(note);
+      await pxeB.deliverNote(note, true);
     }
 
     // 5. Try fetching the nullified note

--- a/yarn-project/end-to-end/src/e2e_blacklist_token_contract/blacklist_token_contract_test.ts
+++ b/yarn-project/end-to-end/src/e2e_blacklist_token_contract/blacklist_token_contract_test.ts
@@ -164,7 +164,7 @@ export class BlacklistTokenContractTest {
       TokenBlacklistContract.notes.TransparentNote.id,
       txHash,
     );
-    await this.wallets[accountIndex].addNote(extendedNote);
+    await this.wallets[accountIndex].deliverNote(extendedNote);
   }
 
   async applyMintSnapshot() {

--- a/yarn-project/end-to-end/src/e2e_non_contract_account.test.ts
+++ b/yarn-project/end-to-end/src/e2e_non_contract_account.test.ts
@@ -67,7 +67,7 @@ describe('e2e_non_contract_account', () => {
       TestContract.notes.TestNote.id,
       txHash,
     );
-    await wallet.addNote(extendedNote);
+    await wallet.deliverNote(extendedNote);
 
     expect(await contract.methods.get_constant().simulate()).toEqual(value);
   });

--- a/yarn-project/pxe/src/pxe_service/pxe_service.ts
+++ b/yarn-project/pxe/src/pxe_service/pxe_service.ts
@@ -338,7 +338,15 @@ export class PXEService implements PXE {
     return await getNonNullifiedL1ToL2MessageWitness(this.node, contractAddress, messageHash, secret);
   }
 
-  public async addNote(note: ExtendedNote, scope?: AztecAddress) {
+  public async deliverNote(note: ExtendedNote, nullified: boolean = false, scope?: AztecAddress) {
+    if (!nullified) {
+      await this.#addNote(note, scope);
+    } else {
+      await this.#addNullifiedNote(note);
+    }
+  }
+
+  async #addNote(note: ExtendedNote, scope?: AztecAddress) {
     const owner = await this.db.getCompleteAddress(note.owner);
     if (!owner) {
       throw new Error(`Unknown account: ${note.owner.toString()}`);
@@ -392,7 +400,7 @@ export class PXEService implements PXE {
     }
   }
 
-  public async addNullifiedNote(note: ExtendedNote) {
+  async #addNullifiedNote(note: ExtendedNote) {
     const { data: nonces, l2BlockHash, l2BlockNumber } = await this.#getNoteNonces(note);
     if (nonces.length === 0) {
       throw new Error(`Cannot find the note in tx: ${note.txHash}.`);


### PR DESCRIPTION
In this PR, we are renaming `pxe.addNote` to `pxe.deliverNote`. The rationale was because in this function, we aren't actually 'adding a note' to state, as this can only be used when a note (hash) already exists. This is used to deliver the existing note (most likely to self), and (most likely) when said note was not emitted.