### PR TITLE
fix: tweaking Fr and Fq fromString functionality to distinguish number-only strings

### DIFF
--- a/yarn-project/accounts/src/testing/configuration.ts
+++ b/yarn-project/accounts/src/testing/configuration.ts
@@ -9,9 +9,9 @@ import { Fr } from '@aztec/foundation/fields';
 import { SchnorrAccountContractArtifact, getSchnorrAccount } from '../schnorr/index.js';
 
 export const INITIAL_TEST_SECRET_KEYS = [
-  Fr.fromString('2153536ff6628eee01cf4024889ff977a18d9fa61d0e414422f7681cf085c281'),
-  Fr.fromString('aebd1b4be76efa44f5ee655c20bf9ea60f7ae44b9a7fd1fd9f189c7a0b0cdae'),
-  Fr.fromString('0f6addf0da06c33293df974a565b03d1ab096090d907d98055a8b7f4954e120c'),
+  Fr.fromHexString('2153536ff6628eee01cf4024889ff977a18d9fa61d0e414422f7681cf085c281'),
+  Fr.fromHexString('aebd1b4be76efa44f5ee655c20bf9ea60f7ae44b9a7fd1fd9f189c7a0b0cdae'),
+  Fr.fromHexString('0f6addf0da06c33293df974a565b03d1ab096090d907d98055a8b7f4954e120c'),
 ];
 
 export const INITIAL_TEST_ENCRYPTION_KEYS = INITIAL_TEST_SECRET_KEYS.map(secretKey =>

--- a/yarn-project/archiver/src/archiver/archiver.ts
+++ b/yarn-project/archiver/src/archiver/archiver.ts
@@ -921,7 +921,7 @@ class ArchiverStoreHelper
     for (const [classIdString, classEvents] of Object.entries(
       groupBy([...privateFnEvents, ...unconstrainedFnEvents], e => e.contractClassId.toString()),
     )) {
-      const contractClassId = Fr.fromString(classIdString);
+      const contractClassId = Fr.fromHexString(classIdString);
       const contractClass = await this.getContractClass(contractClassId);
       if (!contractClass) {
         this.#log.warn(`Skipping broadcasted functions as contract class ${contractClassId.toString()} was not found`);

--- a/yarn-project/archiver/src/archiver/data_retrieval.ts
+++ b/yarn-project/archiver/src/archiver/data_retrieval.ts
@@ -203,7 +203,7 @@ export async function retrieveL1ToL2Messages(
 
     for (const log of messageSentLogs) {
       const { index, hash } = log.args;
-      retrievedL1ToL2Messages.push(new InboxLeaf(index!, Fr.fromString(hash!)));
+      retrievedL1ToL2Messages.push(new InboxLeaf(index!, Fr.fromHexString(hash!)));
     }
 
     // handles the case when there are no new messages:
@@ -230,7 +230,7 @@ export async function retrieveL2ProofVerifiedEvents(
   return logs.map(log => ({
     l1BlockNumber: log.blockNumber,
     l2BlockNumber: log.args.blockNumber,
-    proverId: Fr.fromString(log.args.proverId),
+    proverId: Fr.fromHexString(log.args.proverId),
     txHash: log.transactionHash,
   }));
 }
@@ -297,8 +297,8 @@ export async function getProofFromSubmitProofTx(
     ];
 
     aggregationObject = Buffer.from(hexToBytes(decodedArgs.aggregationObject));
-    proverId = Fr.fromString(decodedArgs.args[6]);
-    archiveRoot = Fr.fromString(decodedArgs.args[1]);
+    proverId = Fr.fromHexString(decodedArgs.args[6]);
+    archiveRoot = Fr.fromHexString(decodedArgs.args[1]);
     proof = Proof.fromBuffer(Buffer.from(hexToBytes(decodedArgs.proof)));
   } else {
     throw new Error(`Unexpected proof method called ${functionName}`);

--- a/yarn-project/archiver/src/archiver/kv_archiver_store/contract_class_store.ts
+++ b/yarn-project/archiver/src/archiver/kv_archiver_store/contract_class_store.ts
@@ -53,7 +53,7 @@ export class ContractClassStore {
   }
 
   getContractClassIds(): Fr[] {
-    return Array.from(this.#contractClasses.keys()).map(key => Fr.fromString(key));
+    return Array.from(this.#contractClasses.keys()).map(key => Fr.fromHexString(key));
   }
 
   async addFunctions(

--- a/yarn-project/archiver/src/archiver/memory_archiver_store/memory_archiver_store.ts
+++ b/yarn-project/archiver/src/archiver/memory_archiver_store/memory_archiver_store.ts
@@ -105,7 +105,7 @@ export class MemoryArchiverStore implements ArchiverDataStore {
   }
 
   public getContractClassIds(): Promise<Fr[]> {
-    return Promise.resolve(Array.from(this.contractClasses.keys()).map(key => Fr.fromString(key)));
+    return Promise.resolve(Array.from(this.contractClasses.keys()).map(key => Fr.fromHexString(key)));
   }
 
   public getContractInstance(address: AztecAddress): Promise<ContractInstanceWithAddress | undefined> {

--- a/yarn-project/aztec/src/cli/cmds/start_pxe.ts
+++ b/yarn-project/aztec/src/cli/cmds/start_pxe.ts
@@ -93,8 +93,8 @@ export async function addPXE(
       l2Contracts[key] = {
         name: key,
         address: AztecAddress.fromString(basicContractsInfo[key].address),
-        initHash: Fr.fromString(basicContractsInfo[key].initHash),
-        salt: Fr.fromString(basicContractsInfo[key].salt),
+        initHash: Fr.fromHexString(basicContractsInfo[key].initHash),
+        salt: Fr.fromHexString(basicContractsInfo[key].salt),
         artifact: await getContractArtifact(artifactName, userLog),
       };
     }

--- a/yarn-project/bb-prover/src/prover/bb_private_kernel_prover.ts
+++ b/yarn-project/bb-prover/src/prover/bb_private_kernel_prover.ts
@@ -392,7 +392,7 @@ export class BBNativePrivateKernelProver implements PrivateKernelProver {
       fs.readFile(`${filePath}/${PROOF_FIELDS_FILENAME}`, { encoding: 'utf-8' }),
     ]);
     const json = JSON.parse(proofString);
-    const fields = json.map(Fr.fromString);
+    const fields = json.map(Fr.fromHexString);
     const numPublicInputs = vkData.numPublicInputs - AGGREGATION_OBJECT_LENGTH;
     const fieldsWithoutPublicInputs = fields.slice(numPublicInputs);
     this.log.info(

--- a/yarn-project/bb-prover/src/prover/bb_prover.ts
+++ b/yarn-project/bb-prover/src/prover/bb_prover.ts
@@ -795,8 +795,8 @@ export class BBNativeRollupProver implements ServerCircuitProver {
       const json = JSON.parse(proofString);
       const fields = json
         .slice(0, 3)
-        .map(Fr.fromString)
-        .concat(json.slice(3 + numPublicInputs).map(Fr.fromString));
+        .map(Fr.fromHexString)
+        .concat(json.slice(3 + numPublicInputs).map(Fr.fromHexString));
       return new RecursiveProof(
         fields,
         new Proof(proof.binaryProof.buffer, vk.numPublicInputs),
@@ -877,8 +877,8 @@ export class BBNativeRollupProver implements ServerCircuitProver {
 
     const fieldsWithoutPublicInputs = json
       .slice(0, 3)
-      .map(Fr.fromString)
-      .concat(json.slice(3 + numPublicInputs).map(Fr.fromString));
+      .map(Fr.fromHexString)
+      .concat(json.slice(3 + numPublicInputs).map(Fr.fromHexString));
     logger.debug(
       `Circuit path: ${filePath}, complete proof length: ${json.length}, num public inputs: ${numPublicInputs}, circuit size: ${vkData.circuitSize}, is recursive: ${vkData.isRecursive}, raw length: ${binaryProof.length}`,
     );

--- a/yarn-project/bb-prover/src/verification_key/verification_key_data.ts
+++ b/yarn-project/bb-prover/src/verification_key/verification_key_data.ts
@@ -23,7 +23,7 @@ export async function extractVkData(vkDirectoryPath: string): Promise<Verificati
     fs.readFile(path.join(vkDirectoryPath, VK_FILENAME)),
   ]);
   const fieldsJson = JSON.parse(rawFields);
-  const fields = fieldsJson.map(Fr.fromString);
+  const fields = fieldsJson.map(Fr.fromHexString);
   // The hash is not included in the BB response
   const vkHash = hashVK(fields);
   const vkAsFields = new VerificationKeyAsFields(fields, vkHash);
@@ -37,7 +37,7 @@ export async function extractAvmVkData(vkDirectoryPath: string): Promise<Verific
     fs.readFile(path.join(vkDirectoryPath, VK_FILENAME)),
   ]);
   const fieldsJson = JSON.parse(rawFields);
-  const fields = fieldsJson.map(Fr.fromString);
+  const fields = fieldsJson.map(Fr.fromHexString);
   // The first item is the hash, this is not part of the actual VK
   // TODO: is the above actually the case?
   const vkHash = fields[0];

--- a/yarn-project/bot/src/config.ts
+++ b/yarn-project/bot/src/config.ts
@@ -105,20 +105,20 @@ export const botConfigMappings: ConfigMappingsType<BotConfig> = {
   senderPrivateKey: {
     env: 'BOT_PRIVATE_KEY',
     description: 'Signing private key for the sender account.',
-    parseEnv: (val: string) => Fr.fromString(val),
+    parseEnv: (val: string) => Fr.fromHexString(val),
     defaultValue: Fr.random(),
   },
   recipientEncryptionSecret: {
     env: 'BOT_RECIPIENT_ENCRYPTION_SECRET',
     description: 'Encryption secret for a recipient account.',
-    parseEnv: (val: string) => Fr.fromString(val),
-    defaultValue: Fr.fromString('0xcafecafe'),
+    parseEnv: (val: string) => Fr.fromHexString(val),
+    defaultValue: Fr.fromHexString('0xcafecafe'),
   },
   tokenSalt: {
     env: 'BOT_TOKEN_SALT',
     description: 'Salt for the token contract deployment.',
-    parseEnv: (val: string) => Fr.fromString(val),
-    defaultValue: Fr.fromString('1'),
+    parseEnv: (val: string) => Fr.fromHexString(val),
+    defaultValue: Fr.fromHexString('1'),
   },
   txIntervalSeconds: {
     env: 'BOT_TX_INTERVAL_SECONDS',

--- a/yarn-project/circuit-types/src/interfaces/prover-client.ts
+++ b/yarn-project/circuit-types/src/interfaces/prover-client.ts
@@ -73,7 +73,7 @@ export const proverConfigMappings: ConfigMappingsType<ProverConfig> = {
 };
 
 function parseProverId(str: string) {
-  return Fr.fromString(str.startsWith('0x') ? str : Buffer.from(str, 'utf8').toString('hex'));
+  return Fr.fromHexString(str.startsWith('0x') ? str : Buffer.from(str, 'utf8').toString('hex'));
 }
 
 /**

--- a/yarn-project/circuits.js/src/contract/contract_class.test.ts
+++ b/yarn-project/circuits.js/src/contract/contract_class.test.ts
@@ -10,7 +10,7 @@ describe('ContractClass', () => {
     const artifact = getBenchmarkContractArtifact();
     const contractClass = getContractClassFromArtifact({
       ...artifact,
-      artifactHash: Fr.fromString('0x1234'),
+      artifactHash: Fr.fromHexString('0x1234'),
     });
 
     // Assert bytecode has a reasonable length

--- a/yarn-project/circuits.js/src/contract/contract_class_id.test.ts
+++ b/yarn-project/circuits.js/src/contract/contract_class_id.test.ts
@@ -8,12 +8,12 @@ describe('ContractClass', () => {
     it('calculates the contract class id', () => {
       const contractClass: ContractClass = {
         version: 1,
-        artifactHash: Fr.fromString('0x1234'),
+        artifactHash: Fr.fromHexString('0x1234'),
         packedBytecode: Buffer.from('123456789012345678901234567890', 'hex'),
         privateFunctions: [
           {
             selector: FunctionSelector.fromString('0x12345678'),
-            vkHash: Fr.fromString('0x1234'),
+            vkHash: Fr.fromHexString('0x1234'),
           },
         ],
         publicFunctions: [

--- a/yarn-project/circuits.js/src/keys/derivation.test.ts
+++ b/yarn-project/circuits.js/src/keys/derivation.test.ts
@@ -11,7 +11,7 @@ describe('🔑', () => {
     const masterOutgoingViewingPublicKey = new Point(new Fr(5), new Fr(6), false);
     const masterTaggingPublicKey = new Point(new Fr(7), new Fr(8), false);
 
-    const expected = Fr.fromString('0x0fecd9a32db731fec1fded1b9ff957a1625c069245a3613a2538bd527068b0ad');
+    const expected = Fr.fromHexString('0x0fecd9a32db731fec1fded1b9ff957a1625c069245a3613a2538bd527068b0ad');
     expect(
       new PublicKeys(
         masterNullifierPublicKey,
@@ -59,7 +59,7 @@ describe('🔑', () => {
 
     const publicKeys = new PublicKeys(npkM, ivpkM, ovpkM, tpkM);
 
-    const partialAddress = Fr.fromString('0x0a7c585381b10f4666044266a02405bf6e01fa564c8517d4ad5823493abd31de');
+    const partialAddress = Fr.fromHexString('0x0a7c585381b10f4666044266a02405bf6e01fa564c8517d4ad5823493abd31de');
 
     const address = computeAddress(publicKeys, partialAddress).toString();
     expect(address).toMatchSnapshot();

--- a/yarn-project/circuits.js/src/structs/complete_address.test.ts
+++ b/yarn-project/circuits.js/src/structs/complete_address.test.ts
@@ -40,7 +40,7 @@ describe('CompleteAddress', () => {
     );
 
     const address = new AztecAddress(
-      Fr.fromString('0x24e4646f58b9fbe7d38e317db8d5636c423fbbdfbe119fc190fe9c64747e0c62'),
+      Fr.fromHexString('0x24e4646f58b9fbe7d38e317db8d5636c423fbbdfbe119fc190fe9c64747e0c62'),
     );
     const npkM = Point.fromString(
       '0x22f7fcddfa3ce3e8f0cc8e82d7b94cdd740afa3e77f8e4a63ea78a239432dcab0471657de2b6216ade6c506d28fbc22ba8b8ed95c871ad9f3e3984e90d9723a7',
@@ -55,7 +55,7 @@ describe('CompleteAddress', () => {
       '0x00d3d81beb009873eb7116327cf47c612d5758ef083d4fda78e9b63980b2a7622f567d22d2b02fe1f4ad42db9d58a36afd1983e7e2909d1cab61cafedad6193a',
     );
 
-    const partialAddress = Fr.fromString('0x0a7c585381b10f4666044266a02405bf6e01fa564c8517d4ad5823493abd31de');
+    const partialAddress = Fr.fromHexString('0x0a7c585381b10f4666044266a02405bf6e01fa564c8517d4ad5823493abd31de');
 
     const completeAddressFromComponents = new CompleteAddress(
       address,

--- a/yarn-project/cli-wallet/src/cmds/bridge_fee_juice.ts
+++ b/yarn-project/cli-wallet/src/cmds/bridge_fee_juice.ts
@@ -68,7 +68,7 @@ export async function bridgeL1FeeJuice(
         setTimeout(async () => {
           const witness = await pxe.getL1ToL2MembershipWitness(
             feeJuiceAddress,
-            Fr.fromString(messageHash),
+            Fr.fromHexString(messageHash),
             claimSecret,
           );
           resolve(witness);

--- a/yarn-project/cli-wallet/src/utils/options/fees.ts
+++ b/yarn-project/cli-wallet/src/utils/options/fees.ts
@@ -164,8 +164,8 @@ export function parsePaymentMethod(
           }
           log(`Using Fee Juice for fee payments with claim for ${claimAmount} tokens`);
           return new FeeJuicePaymentMethodWithClaim(sender.getAddress(), {
-            claimAmount: typeof claimAmount === 'string' ? Fr.fromString(claimAmount) : new Fr(claimAmount),
-            claimSecret: Fr.fromString(claimSecret),
+            claimAmount: typeof claimAmount === 'string' ? Fr.fromHexString(claimAmount) : new Fr(claimAmount),
+            claimSecret: Fr.fromHexString(claimSecret),
             messageLeafIndex: BigInt(messageLeafIndex),
           });
         } else {

--- a/yarn-project/cli/src/cmds/devnet/bootstrap_network.ts
+++ b/yarn-project/cli/src/cmds/devnet/bootstrap_network.ts
@@ -274,7 +274,12 @@ async function fundFPC(
     true,
   );
 
-  await retryUntil(async () => await wallet.isL1ToL2MessageSynced(Fr.fromString(messageHash)), 'message sync', 600, 1);
+  await retryUntil(
+    async () => await wallet.isL1ToL2MessageSynced(Fr.fromHexString(messageHash)),
+    'message sync',
+    600,
+    1,
+  );
 
   const counter = await CounterContract.at(counterAddress, wallet);
 

--- a/yarn-project/cli/src/utils/commands.ts
+++ b/yarn-project/cli/src/utils/commands.ts
@@ -300,7 +300,7 @@ export function parsePublicKey(publicKey: string): PublicKeys | undefined {
  */
 export function parsePartialAddress(address: string): Fr {
   try {
-    return Fr.fromString(address);
+    return Fr.fromHexString(address);
   } catch (err) {
     throw new InvalidArgumentError(`Invalid partial address: ${address}`);
   }
@@ -314,7 +314,7 @@ export function parsePartialAddress(address: string): Fr {
  */
 export function parseSecretKey(secretKey: string): Fr {
   try {
-    return Fr.fromString(secretKey);
+    return Fr.fromHexString(secretKey);
   } catch (err) {
     throw new InvalidArgumentError(`Invalid encryption secret key: ${secretKey}`);
   }
@@ -330,7 +330,7 @@ export function parseField(field: string): Fr {
   try {
     const isHex = field.startsWith('0x') || field.match(new RegExp(`^[0-9a-f]{${Fr.SIZE_IN_BYTES * 2}}$`, 'i'));
     if (isHex) {
-      return Fr.fromString(field);
+      return Fr.fromHexString(field);
     }
 
     if (['true', 'false'].includes(field)) {

--- a/yarn-project/end-to-end/src/devnet/e2e_smoke.test.ts
+++ b/yarn-project/end-to-end/src/devnet/e2e_smoke.test.ts
@@ -179,8 +179,8 @@ describe('End-to-end tests for devnet', () => {
       .deploy({
         fee: {
           paymentMethod: new FeeJuicePaymentMethodWithClaim(l2Account.getAddress(), {
-            claimAmount: Fr.fromString(claimAmount),
-            claimSecret: Fr.fromString(claimSecret.value),
+            claimAmount: Fr.fromHexString(claimAmount),
+            claimSecret: Fr.fromHexString(claimSecret.value),
             messageLeafIndex: BigInt(messageLeafIndex),
           }),
         },

--- a/yarn-project/end-to-end/src/e2e_authwit.test.ts
+++ b/yarn-project/end-to-end/src/e2e_authwit.test.ts
@@ -43,7 +43,7 @@ describe('e2e_authwit_tests', () => {
         // 6. We check that the authwit is NOT valid in private for wallet[1] (check that it is not signed by 1)
 
         // docs:start:compute_inner_authwit_hash
-        const innerHash = computeInnerAuthWitHash([Fr.fromString('0xdead')]);
+        const innerHash = computeInnerAuthWitHash([Fr.fromHexString('0xdead')]);
         // docs:end:compute_inner_authwit_hash
         // docs:start:compute_arbitrary_authwit_hash
 
@@ -87,7 +87,7 @@ describe('e2e_authwit_tests', () => {
       });
       describe('failure case', () => {
         it('invalid chain id', async () => {
-          const innerHash = computeInnerAuthWitHash([Fr.fromString('0xdead'), Fr.fromString('0xbeef')]);
+          const innerHash = computeInnerAuthWitHash([Fr.fromHexString('0xdead'), Fr.fromHexString('0xbeef')]);
           const intent = { consumer: auth.address, innerHash };
 
           const messageHash = computeAuthWitMessageHash(intent, { chainId: Fr.random(), version });
@@ -119,7 +119,7 @@ describe('e2e_authwit_tests', () => {
         });
 
         it('invalid version', async () => {
-          const innerHash = computeInnerAuthWitHash([Fr.fromString('0xdead'), Fr.fromString('0xbeef')]);
+          const innerHash = computeInnerAuthWitHash([Fr.fromHexString('0xdead'), Fr.fromHexString('0xbeef')]);
           const intent = { consumer: auth.address, innerHash };
 
           const messageHash = computeAuthWitMessageHash(intent, { chainId, version: Fr.random() });
@@ -157,7 +157,7 @@ describe('e2e_authwit_tests', () => {
   describe('Public', () => {
     describe('arbitrary data', () => {
       it('happy path', async () => {
-        const innerHash = computeInnerAuthWitHash([Fr.fromString('0xdead'), Fr.fromString('0x01')]);
+        const innerHash = computeInnerAuthWitHash([Fr.fromHexString('0xdead'), Fr.fromHexString('0x01')]);
 
         const intent = { consumer: wallets[1].getAddress(), innerHash };
 
@@ -185,7 +185,7 @@ describe('e2e_authwit_tests', () => {
 
       describe('failure case', () => {
         it('cancel before usage', async () => {
-          const innerHash = computeInnerAuthWitHash([Fr.fromString('0xdead'), Fr.fromString('0x02')]);
+          const innerHash = computeInnerAuthWitHash([Fr.fromHexString('0xdead'), Fr.fromHexString('0x02')]);
           const intent = { consumer: auth.address, innerHash };
 
           expect(await wallets[0].lookupValidity(wallets[0].getAddress(), intent)).toEqual({

--- a/yarn-project/end-to-end/src/e2e_cross_chain_messaging/token_bridge_public.test.ts
+++ b/yarn-project/end-to-end/src/e2e_cross_chain_messaging/token_bridge_public.test.ts
@@ -48,7 +48,7 @@ describe('e2e_cross_chain_messaging token_bridge_public', () => {
     // 2. Deposit tokens to the TokenPortal
     logger.verbose(`2. Deposit tokens to the TokenPortal`);
     const claim = await crossChainTestHarness.sendTokensToPortalPublic(bridgeAmount);
-    const msgHash = Fr.fromString(claim.messageHash);
+    const msgHash = Fr.fromHexString(claim.messageHash);
     expect(await crossChainTestHarness.getL1BalanceOf(ethAccount)).toBe(l1TokenBalance - bridgeAmount);
 
     // Wait for the message to be available for consumption
@@ -116,7 +116,7 @@ describe('e2e_cross_chain_messaging token_bridge_public', () => {
 
     await crossChainTestHarness.mintTokensOnL1(l1TokenBalance);
     const claim = await crossChainTestHarness.sendTokensToPortalPublic(bridgeAmount);
-    const msgHash = Fr.fromString(claim.messageHash);
+    const msgHash = Fr.fromHexString(claim.messageHash);
     expect(await crossChainTestHarness.getL1BalanceOf(ethAccount)).toBe(l1TokenBalance - bridgeAmount);
 
     await crossChainTestHarness.makeMessageConsumable(msgHash);

--- a/yarn-project/end-to-end/src/fixtures/l1_to_l2_messaging.ts
+++ b/yarn-project/end-to-end/src/fixtures/l1_to_l2_messaging.ts
@@ -53,5 +53,5 @@ export async function sendL1ToL2Message(
   const receivedMsgHash = topics.args.hash;
   const receivedGlobalLeafIndex = topics.args.index;
 
-  return [Fr.fromString(receivedMsgHash), new Fr(receivedGlobalLeafIndex)];
+  return [Fr.fromHexString(receivedMsgHash), new Fr(receivedGlobalLeafIndex)];
 }

--- a/yarn-project/end-to-end/src/guides/dapp_testing.test.ts
+++ b/yarn-project/end-to-end/src/guides/dapp_testing.test.ts
@@ -133,7 +133,7 @@ describe('guides/dapp/testing', () => {
 
       it('checks unencrypted logs, [Kinda broken with current implementation]', async () => {
         // docs:start:unencrypted-logs
-        const value = Fr.fromString('ef'); // Only 1 bytes will make its way in there :( so no larger stuff
+        const value = Fr.fromHexString('ef'); // Only 1 bytes will make its way in there :( so no larger stuff
         const tx = await testContract.methods.emit_unencrypted(value).send().wait();
         const filter = {
           fromBlock: tx.blockNumber!,

--- a/yarn-project/end-to-end/src/guides/writing_an_account_contract.test.ts
+++ b/yarn-project/end-to-end/src/guides/writing_an_account_contract.test.ts
@@ -14,7 +14,7 @@ import { TokenContract } from '@aztec/noir-contracts.js/Token';
 import { setup } from '../fixtures/utils.js';
 
 // docs:start:account-contract
-const PRIVATE_KEY = GrumpkinScalar.fromString('0xd35d743ac0dfe3d6dbe6be8c877cb524a00ab1e3d52d7bada095dfc8894ccfa');
+const PRIVATE_KEY = GrumpkinScalar.fromHexString('0xd35d743ac0dfe3d6dbe6be8c877cb524a00ab1e3d52d7bada095dfc8894ccfa');
 
 /** Account contract implementation that authenticates txs using Schnorr signatures. */
 class SchnorrHardcodedKeyAccountContract extends DefaultAccountContract {

--- a/yarn-project/end-to-end/src/shared/browser.ts
+++ b/yarn-project/end-to-end/src/shared/browser.ts
@@ -125,7 +125,7 @@ export const browserTestSuite = (
         async (rpcUrl, secretKeyString) => {
           const { Fr, createPXEClient, getUnsafeSchnorrAccount } = window.AztecJs;
           const pxe = createPXEClient(rpcUrl!);
-          const secretKey = Fr.fromString(secretKeyString);
+          const secretKey = Fr.fromHexString(secretKeyString);
           const account = getUnsafeSchnorrAccount(pxe, secretKey);
           await account.waitSetup();
           const completeAddress = account.getCompleteAddress();

--- a/yarn-project/end-to-end/src/shared/cross_chain_test_harness.ts
+++ b/yarn-project/end-to-end/src/shared/cross_chain_test_harness.ts
@@ -359,7 +359,7 @@ export class CrossChainTestHarness {
    * it's included it becomes available for consumption in the next block because the l1 to l2 message tree.
    */
   async makeMessageConsumable(msgHash: Fr | Hex) {
-    const frMsgHash = typeof msgHash === 'string' ? Fr.fromString(msgHash) : msgHash;
+    const frMsgHash = typeof msgHash === 'string' ? Fr.fromHexString(msgHash) : msgHash;
     // We poll isL1ToL2MessageSynced endpoint until the message is available
     await retryUntil(async () => await this.aztecNode.isL1ToL2MessageSynced(frMsgHash), 'message sync', 10);
 

--- a/yarn-project/end-to-end/src/shared/uniswap_l1_l2.ts
+++ b/yarn-project/end-to-end/src/shared/uniswap_l1_l2.ts
@@ -195,7 +195,7 @@ export const uniswapL1L2TestSuite = (
         wethAmountToBridge,
       );
 
-      await wethCrossChainHarness.makeMessageConsumable(Fr.fromString(wethDepositClaim.messageHash));
+      await wethCrossChainHarness.makeMessageConsumable(Fr.fromHexString(wethDepositClaim.messageHash));
 
       // 2. Claim WETH on L2
       logger.info('Minting weth on L2');
@@ -331,7 +331,7 @@ export const uniswapL1L2TestSuite = (
       // We get the msg leaf from event so that we can later wait for it to be available for consumption
       const inboxAddress = daiCrossChainHarness.l1ContractAddresses.inboxAddress.toString();
       const txLog = extractEvent(txReceipt.logs, inboxAddress, InboxAbi, 'MessageSent');
-      const tokenOutMsgHash = Fr.fromString(txLog.args.hash);
+      const tokenOutMsgHash = Fr.fromHexString(txLog.args.hash);
       const tokenOutMsgIndex = txLog.args.index;
 
       // weth was swapped to dai and send to portal
@@ -559,7 +559,7 @@ export const uniswapL1L2TestSuite = (
     //       data: txLog.data,
     //       topics: txLog.topics,
     //     });
-    //     outTokenDepositMsgHash = Fr.fromString(topics.args.hash);
+    //     outTokenDepositMsgHash = Fr.fromHexString(topics.args.hash);
     //   }
 
     //   // weth was swapped to dai and send to portal

--- a/yarn-project/foundation/src/abi/encoder.ts
+++ b/yarn-project/foundation/src/abi/encoder.ts
@@ -49,7 +49,7 @@ class ArgumentEncoder {
         } else if (typeof arg === 'bigint') {
           this.flattened.push(new Fr(arg));
         } else if (typeof arg === 'string') {
-          this.flattened.push(Fr.fromString(arg));
+          this.flattened.push(Fr.fromHexString(arg));
         } else if (typeof arg === 'boolean') {
           this.flattened.push(new Fr(arg ? 1n : 0n));
         } else if (typeof arg === 'object') {
@@ -58,7 +58,7 @@ class ArgumentEncoder {
           } else if (typeof arg.toField === 'function') {
             this.flattened.push(arg.toField());
           } else if (typeof arg.value === 'string') {
-            this.flattened.push(Fr.fromString(arg.value));
+            this.flattened.push(Fr.fromHexString(arg.value));
           } else {
             throw new Error(`Argument for ${name} cannot be serialized to a field`);
           }

--- a/yarn-project/foundation/src/fields/fields.test.ts
+++ b/yarn-project/foundation/src/fields/fields.test.ts
@@ -33,16 +33,53 @@ describe('GrumpkinScalar Serialization', () => {
     expect(deserialized).toEqual(original);
 
     // Note odd number of digits
-    const arbitraryString = '123';
-    const arbitraryHexString = '0x123';
-    const expectedBigInt = 291n;
+    const arbitraryNumericString = '123';
+    const arbitraryNumericStringPrepended = '0x123';
+    const expectedBigIntFromHex = 291n;
 
-    expect(GrumpkinScalar.fromString(arbitraryString).toBigInt()).toEqual(expectedBigInt);
-    expect(GrumpkinScalar.fromString(arbitraryHexString).toBigInt()).toEqual(expectedBigInt);
+    const anotherString = '1000a000';
+    const anotherStringPrepended = '0x1000a000';
 
-    const incorrectlyFormattedString = '12xx34xx45';
+    const expectedValueOfAnotherHexString = 268476416n;
 
-    expect(() => GrumpkinScalar.fromString(incorrectlyFormattedString).toBigInt()).toThrow();
+    expect(GrumpkinScalar.fromString(arbitraryNumericString).toBigInt()).toEqual(BigInt(arbitraryNumericString));
+    expect(GrumpkinScalar.fromString(arbitraryNumericStringPrepended).toBigInt()).toEqual(expectedBigIntFromHex);
+
+    expect(() => GrumpkinScalar.fromString(anotherString)).toThrow('Tried to create a Fq from an invalid string');
+    expect(GrumpkinScalar.fromString(anotherStringPrepended).toBigInt()).toEqual(expectedValueOfAnotherHexString);
+
+    const nonHexEncodedString = '0x12xx34xx45';
+    expect(() => GrumpkinScalar.fromHexString(nonHexEncodedString)).toThrow('Invalid hex-encoded string');
+  });
+
+  // Test case for GrumpkinScalar.fromHexString
+  it('fromHexString should serialize and deserialize correctly', () => {
+    const original = GrumpkinScalar.random();
+    const hexString = original.toString();
+    const deserialized = GrumpkinScalar.fromHexString(hexString);
+
+    // Check if the deserialized instance is equal to the original
+    expect(deserialized).toEqual(original);
+
+    // Note odd number of digits
+    const arbitraryNumericString = '123';
+    const arbitraryNumericStringPrepended = '0x123';
+    const expectedBigIntFromHex = 291n;
+
+    const anotherString = 'deadbeef';
+    const anotherStringPrepended = '0xdeadbeef';
+
+    const expectedValueOfAnotherHexString = 3735928559n;
+
+    expect(GrumpkinScalar.fromHexString(arbitraryNumericString).toBigInt()).toEqual(expectedBigIntFromHex);
+    expect(GrumpkinScalar.fromHexString(arbitraryNumericStringPrepended).toBigInt()).toEqual(expectedBigIntFromHex);
+
+    expect(GrumpkinScalar.fromHexString(anotherString).toBigInt()).toEqual(expectedValueOfAnotherHexString);
+    expect(GrumpkinScalar.fromHexString(anotherStringPrepended).toBigInt()).toEqual(expectedValueOfAnotherHexString);
+
+    const nonHexEncodedString = '12xx34xx45';
+
+    expect(() => GrumpkinScalar.fromHexString(nonHexEncodedString).toBigInt()).toThrow();
   });
 
   // Test case for GrumpkinScalar.toBuffer
@@ -59,7 +96,7 @@ describe('GrumpkinScalar Serialization', () => {
   it('toString should serialize and deserialize correctly', () => {
     const original = GrumpkinScalar.random();
     const hexString = original.toString();
-    const deserialized = GrumpkinScalar.fromString(hexString);
+    const deserialized = GrumpkinScalar.fromHexString(hexString);
 
     // Check if the deserialized instance is equal to the original
     expect(deserialized).toEqual(original);

--- a/yarn-project/foundation/src/fields/fields.ts
+++ b/yarn-project/foundation/src/fields/fields.ts
@@ -233,11 +233,30 @@ export class Fr extends BaseField {
   }
 
   /**
+   * Creates a Fr instance from a string.
+   * @param buf - the string to create a Fr from.
+   * @returns the Fr instance
+   * @remarks if the string only consists of numbers, we assume we are parsing a bigint,
+   * otherwise we require the hex string to be prepended with "0x", to ensure there is no misunderstanding
+   * as to what is being parsed.
+   */
+  static fromString(buf: string) {
+    if (buf.match(/^\d+$/) !== null) {
+      return new Fr(toBufferBE(BigInt(buf), 32));
+    }
+    if (buf.match(/^0x/i) !== null) {
+      return fromHexString(buf, Fr);
+    }
+
+    throw new Error('Tried to create a Fr from an invalid string');
+  }
+
+  /**
    * Creates a Fr instance from a hex string.
    * @param buf - a hex encoded string.
    * @returns the Fr instance
    */
-  static fromString(buf: string) {
+  static fromHexString(buf: string) {
     return fromHexString(buf, Fr);
   }
 
@@ -369,11 +388,30 @@ export class Fq extends BaseField {
   }
 
   /**
+   * Creates a Fq instance from a string.
+   * @param buf - the string to create a Fq from.
+   * @returns the Fq instance
+   * @remarks if the string only consists of numbers, we assume we are parsing a bigint,
+   * otherwise we require the hex string to be prepended with "0x", to ensure there is no misunderstanding
+   * as to what is being parsed.
+   */
+  static fromString(buf: string) {
+    if (buf.match(/^\d+$/) !== null) {
+      return new Fq(toBufferBE(BigInt(buf), 32));
+    }
+    if (buf.match(/^0x/i) !== null) {
+      return fromHexString(buf, Fq);
+    }
+
+    throw new Error('Tried to create a Fq from an invalid string');
+  }
+
+  /**
    * Creates a Fq instance from a hex string.
    * @param buf - a hex encoded string.
    * @returns the Fq instance
    */
-  static fromString(buf: string) {
+  static fromHexString(buf: string) {
     return fromHexString(buf, Fq);
   }
 

--- a/yarn-project/foundation/src/schemas/utils.ts
+++ b/yarn-project/foundation/src/schemas/utils.ts
@@ -75,10 +75,10 @@ export function hexSchemaFor<TClass extends { fromString(str: string): any } | {
   string
 > {
   const stringSchema = refinement ? z.string().refine(refinement, `Not a valid instance`) : z.string();
-  const hexSchema = stringSchema.refine(isHex, 'Not a valid hex string').transform(withoutHexPrefix);
+  const hexSchema = stringSchema.refine(isHex, 'Not a valid hex string');
   return 'fromString' in klazz
     ? hexSchema.transform(klazz.fromString.bind(klazz))
-    : hexSchema.transform(str => Buffer.from(str, 'hex')).transform(klazz.fromBuffer.bind(klazz));
+    : hexSchema.transform(str => Buffer.from(withoutHexPrefix(str), 'hex')).transform(klazz.fromBuffer.bind(klazz));
 }
 
 /**

--- a/yarn-project/noir-protocol-circuits-types/src/scripts/generate_vk_hashes.ts
+++ b/yarn-project/noir-protocol-circuits-types/src/scripts/generate_vk_hashes.ts
@@ -33,7 +33,7 @@ const main = async () => {
       if (!content.vkHash) {
         const { keyAsFields } = content;
 
-        content.vkHash = hashVK(keyAsFields.map((str: string) => Fr.fromString(str))).toString();
+        content.vkHash = hashVK(keyAsFields.map((str: string) => Fr.fromHexString(str))).toString();
         await fs.writeFile(keyPath, JSON.stringify(content, null, 2));
       }
     }

--- a/yarn-project/noir-protocol-circuits-types/src/type_conversion.ts
+++ b/yarn-project/noir-protocol-circuits-types/src/type_conversion.ts
@@ -255,7 +255,7 @@ export function mapFieldToNoir(field: Fr): NoirField {
  * @returns The fr.
  */
 export function mapFieldFromNoir(field: NoirField): Fr {
-  return Fr.fromString(field);
+  return Fr.fromHexString(field);
 }
 
 /** Maps a field to a noir wrapped field type (ie any type implemented as struct with an inner Field). */
@@ -274,7 +274,7 @@ export function mapWrappedFieldFromNoir(wrappedField: { inner: NoirField }): Fr 
  * @returns The number
  */
 export function mapNumberFromNoir(number: NoirField): number {
-  return Number(Fr.fromString(number).toBigInt());
+  return Number(Fr.fromHexString(number).toBigInt());
 }
 
 export function mapNumberToNoir(number: number): NoirField {

--- a/yarn-project/noir-protocol-circuits-types/src/utils/vk_json.ts
+++ b/yarn-project/noir-protocol-circuits-types/src/utils/vk_json.ts
@@ -10,8 +10,8 @@ export function keyJsonToVKData(json: VkJson): VerificationKeyData {
   const { keyAsBytes, keyAsFields, vkHash } = json;
   return new VerificationKeyData(
     new VerificationKeyAsFields(
-      keyAsFields.map((str: string) => Fr.fromString(str)),
-      Fr.fromString(vkHash),
+      keyAsFields.map((str: string) => Fr.fromHexString(str)),
+      Fr.fromHexString(vkHash),
     ),
     Buffer.from(keyAsBytes, 'hex'),
   );

--- a/yarn-project/protocol-contracts/src/scripts/generate_data.ts
+++ b/yarn-project/protocol-contracts/src/scripts/generate_data.ts
@@ -137,7 +137,7 @@ function generateContractAddresses(names: string[]) {
 function generateContractLeaves(names: string[], leaves: Fr[]) {
   return `
     export const ProtocolContractLeaf = {
-      ${leaves.map((leaf, i) => `${names[i]}: Fr.fromString('${leaf.toString()}')`).join(',\n')}
+      ${leaves.map((leaf, i) => `${names[i]}: Fr.fromHexString('${leaf.toString()}')`).join(',\n')}
     };
   `;
 }
@@ -145,7 +145,7 @@ function generateContractLeaves(names: string[], leaves: Fr[]) {
 function generateRoot(names: string[], leaves: Fr[]) {
   const root = computeRoot(names, leaves);
   return `
-    export const protocolContractTreeRoot = Fr.fromString('${root.toString()}');
+    export const protocolContractTreeRoot = Fr.fromHexString('${root.toString()}');
   `;
 }
 
@@ -154,7 +154,7 @@ function generateLogTags() {
   export const REGISTERER_CONTRACT_CLASS_REGISTERED_TAG = new Fr(${REGISTERER_CONTRACT_CLASS_REGISTERED_MAGIC_VALUE}n);
   export const REGISTERER_PRIVATE_FUNCTION_BROADCASTED_TAG = new Fr(${REGISTERER_PRIVATE_FUNCTION_BROADCASTED_MAGIC_VALUE}n);
   export const REGISTERER_UNCONSTRAINED_FUNCTION_BROADCASTED_TAG = new Fr(${REGISTERER_UNCONSTRAINED_FUNCTION_BROADCASTED_MAGIC_VALUE}n);
-  export const DEPLOYER_CONTRACT_INSTANCE_DEPLOYED_TAG = Fr.fromString('${poseidon2Hash([
+  export const DEPLOYER_CONTRACT_INSTANCE_DEPLOYED_TAG = Fr.fromHexString('${poseidon2Hash([
     DEPLOYER_CONTRACT_ADDRESS,
     DEPLOYER_CONTRACT_INSTANCE_DEPLOYED_MAGIC_VALUE,
   ])}');

--- a/yarn-project/pxe/src/database/incoming_note_dao.ts
+++ b/yarn-project/pxe/src/database/incoming_note_dao.ts
@@ -78,7 +78,7 @@ export class IncomingNoteDao implements NoteData {
       this.noteTypeId,
       this.txHash.buffer,
       this.l2BlockNumber,
-      Fr.fromString(this.l2BlockHash),
+      Fr.fromHexString(this.l2BlockHash),
       this.nonce,
       this.noteHash,
       this.siloedNullifier,

--- a/yarn-project/pxe/src/database/outgoing_note_dao.ts
+++ b/yarn-project/pxe/src/database/outgoing_note_dao.ts
@@ -71,7 +71,7 @@ export class OutgoingNoteDao {
       this.noteTypeId,
       this.txHash.buffer,
       this.l2BlockNumber,
-      Fr.fromString(this.l2BlockHash),
+      Fr.fromHexString(this.l2BlockHash),
       this.nonce,
       this.noteHash,
       this.index,

--- a/yarn-project/pxe/src/simulator_oracle/index.ts
+++ b/yarn-project/pxe/src/simulator_oracle/index.ts
@@ -521,7 +521,7 @@ export class SimulatorOracle implements DBOracle {
         });
         await this.db.setTaggingSecretsIndexesAsRecipient(
           Object.keys(secretsToIncrement).map(
-            secret => new IndexedTaggingSecret(Fr.fromString(secret), secretsToIncrement[secret]),
+            secret => new IndexedTaggingSecret(Fr.fromHexString(secret), secretsToIncrement[secret]),
           ),
         );
         currentTagggingSecrets = newTaggingSecrets;

--- a/yarn-project/sequencer-client/src/config.ts
+++ b/yarn-project/sequencer-client/src/config.ts
@@ -189,12 +189,12 @@ export function parseSequencerAllowList(value: string): AllowedElement[] {
     } else if (typeString === 'C') {
       if (selector) {
         entries.push({
-          classId: Fr.fromString(identifierString),
+          classId: Fr.fromHexString(identifierString),
           selector,
         });
       } else {
         entries.push({
-          classId: Fr.fromString(identifierString),
+          classId: Fr.fromHexString(identifierString),
         });
       }
     }

--- a/yarn-project/sequencer-client/src/publisher/l1-publisher.ts
+++ b/yarn-project/sequencer-client/src/publisher/l1-publisher.ts
@@ -687,7 +687,7 @@ export class L1Publisher {
       : proof.extractAggregationObject();
     const argsPublicInputs = [...publicInputs.toFields(), ...aggregationObject];
 
-    if (!areArraysEqual(rollupPublicInputs.map(Fr.fromString), argsPublicInputs, (a, b) => a.equals(b))) {
+    if (!areArraysEqual(rollupPublicInputs.map(Fr.fromHexString), argsPublicInputs, (a, b) => a.equals(b))) {
       const fmt = (inputs: Fr[] | readonly string[]) => inputs.map(x => x.toString()).join(', ');
       throw new Error(
         `Root rollup public inputs mismatch:\nRollup:  ${fmt(rollupPublicInputs)}\nComputed:${fmt(argsPublicInputs)}`,

--- a/yarn-project/simulator/src/acvm/serialize.ts
+++ b/yarn-project/simulator/src/acvm/serialize.ts
@@ -32,7 +32,7 @@ export function toACVMField(
   } else if (typeof value === 'boolean' || typeof value === 'number' || typeof value === 'bigint') {
     buffer = new Fr(value).toBuffer();
   } else if (typeof value === 'string') {
-    buffer = Fr.fromString(value).toBuffer();
+    buffer = Fr.fromHexString(value).toBuffer();
   } else {
     buffer = value.toBuffer();
   }

--- a/yarn-project/simulator/src/client/private_execution.test.ts
+++ b/yarn-project/simulator/src/client/private_execution.test.ts
@@ -85,8 +85,8 @@ describe('Private Execution test suite', () => {
   let logger: Logger;
 
   const defaultContractAddress = AztecAddress.random();
-  const ownerSk = Fr.fromString('2dcc5485a58316776299be08c78fa3788a1a7961ae30dc747fb1be17692a8d32');
-  const recipientSk = Fr.fromString('0c9ed344548e8f9ba8aa3c9f8651eaa2853130f6c1e9c050ccf198f7ea18a7ec');
+  const ownerSk = Fr.fromHexString('2dcc5485a58316776299be08c78fa3788a1a7961ae30dc747fb1be17692a8d32');
+  const recipientSk = Fr.fromHexString('0c9ed344548e8f9ba8aa3c9f8651eaa2853130f6c1e9c050ccf198f7ea18a7ec');
   let owner: AztecAddress;
   let recipient: AztecAddress;
   let ownerCompleteAddress: CompleteAddress;

--- a/yarn-project/simulator/src/client/simulator.test.ts
+++ b/yarn-project/simulator/src/client/simulator.test.ts
@@ -20,7 +20,7 @@ describe('Simulator', () => {
   let appNullifierSecretKey: Fr;
 
   beforeEach(() => {
-    const ownerSk = Fr.fromString('2dcc5485a58316776299be08c78fa3788a1a7961ae30dc747fb1be17692a8d32');
+    const ownerSk = Fr.fromHexString('2dcc5485a58316776299be08c78fa3788a1a7961ae30dc747fb1be17692a8d32');
     const allOwnerKeys = deriveKeys(ownerSk);
 
     ownerMasterNullifierPublicKey = allOwnerKeys.publicKeys.masterNullifierPublicKey;

--- a/yarn-project/simulator/src/client/unconstrained_execution.test.ts
+++ b/yarn-project/simulator/src/client/unconstrained_execution.test.ts
@@ -27,7 +27,7 @@ describe('Unconstrained Execution test suite', () => {
   });
 
   describe('private token contract', () => {
-    const ownerSecretKey = Fr.fromString('2dcc5485a58316776299be08c78fa3788a1a7961ae30dc747fb1be17692a8d32');
+    const ownerSecretKey = Fr.fromHexString('2dcc5485a58316776299be08c78fa3788a1a7961ae30dc747fb1be17692a8d32');
 
     let owner: AztecAddress;
 


### PR DESCRIPTION
1. Created new `fromHexString`, which is simply the same code as the previous `fromString`. Modified all previous Fr and Fq callsites to use `fromHexString`. This was done mainly to keep code paths the same, and as a slight optimization. 
2. Added a `fromString` that is less foot-gun-ny.
&nbsp;&nbsp;&nbsp;&nbsp;Numeric strings get parsed as numbers, hex-prefixed strings get parsed as hex, and anything not in these cases throws an error. Note that this stops "valid" hex strings like `deadbeef`, or `000000000a00000` that are not correctly prefixed to throw. This is admittedly an opinionated call, and I am open to changing this behavior. It was set like this though because I wanted to completely disambiguate and leave no room for potential (accidental) unexpected or unintended deserialization.
3. Modified the schema to not trim the hex prefix.
