### PR TITLE
chore: enable nightly tests

### DIFF
--- a/.github/workflows/nightly-kind-test.yml
+++ b/.github/workflows/nightly-kind-test.yml
@@ -77,7 +77,7 @@ jobs:
             ./spartan/scripts/setup_local_k8s.sh
             cd yarn-project/end-to-end
             export FORCE_COLOR=1
-            NAMESPACE=${{ matrix.test }} FRESH_INSTALL=true CLEANUP_CLUSTER=true VALUES_FILE="16-validators.yaml" ./scripts/network_test.sh ./src/spartan/${{ matrix.test }}.test.ts || true
+            NAMESPACE=${{ matrix.test }} FRESH_INSTALL=true CLEANUP_CLUSTER=true VALUES_FILE="16-validators.yaml" ./scripts/network_test.sh ./src/spartan/${{ matrix.test }}.test.ts
 
   proving-test:
     needs: build
@@ -104,7 +104,7 @@ jobs:
             ./spartan/scripts/setup_local_k8s.sh
             cd yarn-project/end-to-end
             export FORCE_COLOR=1
-            NAMESPACE=proving FRESH_INSTALL=true CLEANUP_CLUSTER=true INSTALL_TIMEOUT=45m VALUES_FILE="1-validator-with-proving.yaml" ./scripts/network_test.sh ./src/spartan/proving.test.ts || true
+            NAMESPACE=proving FRESH_INSTALL=true CLEANUP_CLUSTER=true INSTALL_TIMEOUT=45m VALUES_FILE="1-validator-with-proving.yaml" ./scripts/network_test.sh ./src/spartan/proving.test.ts
 
   success-check:
     runs-on: ubuntu-20.04


### PR DESCRIPTION
This PR allows the nightly tests to fail the whole workflow instead of silently failing.
