### PR TITLE
chore: Remove Proxy from json rpc client

### DIFF
--- a/yarn-project/foundation/src/json-rpc/client/safe_json_rpc_client.ts
+++ b/yarn-project/foundation/src/json-rpc/client/safe_json_rpc_client.ts
@@ -44,18 +44,10 @@ export function createSafeJsonRpcClient<T extends object>(
     return (schema as ApiSchema)[methodName].returnType().parse(res.result);
   };
 
-  // Intercept any RPC methods with a proxy
-  const proxy = new Proxy(
-    {},
-    {
-      get: (target, method: string) => {
-        if (['then', 'catch'].includes(method)) {
-          return Reflect.get(target, method);
-        }
-        return (...params: any[]) => request(method, params);
-      },
-    },
-  ) as T;
+  const proxy: any = {};
+  for (const method of Object.keys(schema)) {
+    proxy[method] = (...params: any[]) => request(method, params);
+  }
 
-  return proxy;
+  return proxy as T;
 }

--- a/yarn-project/foundation/src/json-rpc/test/integration.test.ts
+++ b/yarn-project/foundation/src/json-rpc/test/integration.test.ts
@@ -118,10 +118,8 @@ describe('JsonRpc integration', () => {
       await expect(() => client.fail()).rejects.toThrow('Test state failed');
     });
 
-    it('fails if calls non-existing method in handler', async () => {
-      await expect(() => (client as TestState).forceClear()).rejects.toThrow(
-        'Unspecified method forceClear in client schema',
-      );
+    it('fails if calls non-existing method in handler', () => {
+      expect(() => (client as TestState).forceClear()).toThrow(/not a function/i);
     });
   });
 


### PR DESCRIPTION
Using a proxy as a json rpc client means that dynamic checks for functions in the returned object fail. For instance, `typeof pxe.getTransactions` returns true even if the method is not part of the pxe schema, since the proxy creates a fake function for every single property requested. But then it fails when we try to invoke it.

Since we now have schemas, we can drop usage of the proxy and just create an object with exactly the methods we need.
