### PR TITLE
fix: Do not attempt proof quote on empty epoch

### DIFF
--- a/yarn-project/prover-node/src/prover-node.test.ts
+++ b/yarn-project/prover-node/src/prover-node.test.ts
@@ -175,6 +175,12 @@ describe('prover-node', () => {
       expect(coordination.addEpochProofQuote).toHaveBeenCalledWith(toExpectedQuote(10n));
     });
 
+    it('does not send a quote if there are no blocks in the epoch', async () => {
+      l2BlockSource.getBlocksForEpoch.mockResolvedValue([]);
+      await proverNode.handleEpochCompleted(10n);
+      expect(coordination.addEpochProofQuote).not.toHaveBeenCalled();
+    });
+
     it('does not send a quote on a finished epoch if the provider does not return one', async () => {
       quoteProvider.getQuote.mockResolvedValue(undefined);
       await proverNode.handleEpochCompleted(10n);

--- a/yarn-project/prover-node/src/prover-node.ts
+++ b/yarn-project/prover-node/src/prover-node.ts
@@ -128,9 +128,14 @@ export class ProverNode implements ClaimsMonitorHandler, EpochMonitorHandler, Pr
     try {
       // Construct a quote for the epoch
       const blocks = await this.l2BlockSource.getBlocksForEpoch(epochNumber);
+      if (blocks.length === 0) {
+        this.log.info(`No blocks found for epoch ${epochNumber}`);
+        return;
+      }
+
       const partialQuote = await this.quoteProvider.getQuote(Number(epochNumber), blocks);
       if (!partialQuote) {
-        this.log.verbose(`No quote produced for epoch ${epochNumber}`);
+        this.log.info(`No quote produced for epoch ${epochNumber}`);
         return;
       }
 


### PR DESCRIPTION
Fixes the [following error](https://github.com/AztecProtocol/aztec-packages/actions/runs/12201704715/job/34044555922#step:5:2809):

```
  ./yarn-project+network-test | [./prover-node.sh 8078 false] [17:14:59.111] ERROR: prover-node Error handling epoch completed: TypeError: Cannot read properties of undefined (reading 'number')
  ./yarn-project+network-test | [./prover-node.sh 8078 false]     at ProverNode.handleEpochCompleted (file:///usr/src/yarn-project/prover-node/dest/prover-node.js:106:91)
  ./yarn-project+network-test | [./prover-node.sh 8078 false]     at process.processTicksAndRejections (node:internal/process/task_queues:95:5)
  ./yarn-project+network-test | [./prover-node.sh 8078 false]     at async ProverNode.handleInitialEpochSync (file:///usr/src/yarn-project/prover-node/dest/prover-node.js:69:17)
  ./yarn-project+network-test | [./prover-node.sh 8078 false]     at async EpochMonitor.work (file:///usr/src/yarn-project/prover-node/dest/monitors/epoch-monitor.js:23:17)
  ./yarn-project+network-test | [./prover-node.sh 8078 false]     at async poll (file:///usr/src/yarn-project/foundation/dest/promise/running-promise.js:25:17)
```