### PR TITLE
chore: Bump mocha timeout

### DIFF
--- a/yarn-project/kv-store/.mocharc.json
+++ b/yarn-project/kv-store/.mocharc.json
@@ -1,13 +1,14 @@
 {
-    "require": "ts-node/register",
-    "extensions": [
-      "ts"
-    ],
-    "spec": [
-      "./src/**/!(indexeddb)/*.test.ts"
-    ],
-    "node-option": [
-      "experimental-specifier-resolution=node",
-      "loader=ts-node/esm"
-    ]
-  }
+  "require": "ts-node/register",
+  "extensions": [
+    "ts"
+  ],
+  "spec": [
+    "./src/**/!(indexeddb)/*.test.ts"
+  ],
+  "node-option": [
+    "experimental-specifier-resolution=node",
+    "loader=ts-node/esm"
+  ],
+  "timeout": 30000
+}


### PR DESCRIPTION
Equivalent of #10550 but for mocha, introduced in #10353.

Fixes timeout from [this run](https://github.com/AztecProtocol/aztec-packages/actions/runs/12250863217/job/34177362100).
