### PR TITLE
fix: Do not load pino-pretty in production bundles

### DIFF
--- a/yarn-project/accounts/package.json
+++ b/yarn-project/accounts/package.json
@@ -72,7 +72,10 @@
         }
       ]
     ],
-    "testTimeout": 30000
+    "testTimeout": 30000,
+    "setupFiles": [
+      "../../foundation/src/jest/setup.mjs"
+    ]
   },
   "dependencies": {
     "@aztec/aztec.js": "workspace:^",

--- a/yarn-project/archiver/package.json
+++ b/yarn-project/archiver/package.json
@@ -62,7 +62,10 @@
         }
       ]
     ],
-    "testTimeout": 30000
+    "testTimeout": 30000,
+    "setupFiles": [
+      "../../foundation/src/jest/setup.mjs"
+    ]
   },
   "dependencies": {
     "@aztec/circuit-types": "workspace:^",

--- a/yarn-project/aztec-faucet/package.json
+++ b/yarn-project/aztec-faucet/package.json
@@ -56,7 +56,10 @@
         }
       ]
     ],
-    "testTimeout": 30000
+    "testTimeout": 30000,
+    "setupFiles": [
+      "../../foundation/src/jest/setup.mjs"
+    ]
   },
   "dependencies": {
     "@aztec/ethereum": "workspace:^",

--- a/yarn-project/aztec-node/package.json
+++ b/yarn-project/aztec-node/package.json
@@ -58,7 +58,10 @@
         }
       ]
     ],
-    "testTimeout": 30000
+    "testTimeout": 30000,
+    "setupFiles": [
+      "../../foundation/src/jest/setup.mjs"
+    ]
   },
   "dependencies": {
     "@aztec/archiver": "workspace:^",

--- a/yarn-project/aztec.js/package.json
+++ b/yarn-project/aztec.js/package.json
@@ -74,7 +74,10 @@
         }
       ]
     ],
-    "testTimeout": 30000
+    "testTimeout": 30000,
+    "setupFiles": [
+      "../../foundation/src/jest/setup.mjs"
+    ]
   },
   "dependencies": {
     "@aztec/circuit-types": "workspace:^",

--- a/yarn-project/aztec/package.json
+++ b/yarn-project/aztec/package.json
@@ -110,7 +110,10 @@
         }
       ]
     ],
-    "testTimeout": 30000
+    "testTimeout": 30000,
+    "setupFiles": [
+      "../../foundation/src/jest/setup.mjs"
+    ]
   },
   "engines": {
     "node": ">=18"

--- a/yarn-project/bb-prover/package.json
+++ b/yarn-project/bb-prover/package.json
@@ -63,7 +63,10 @@
         }
       ]
     ],
-    "testTimeout": 30000
+    "testTimeout": 30000,
+    "setupFiles": [
+      "../../foundation/src/jest/setup.mjs"
+    ]
   },
   "dependencies": {
     "@aztec/circuit-types": "workspace:^",

--- a/yarn-project/bot/package.json
+++ b/yarn-project/bot/package.json
@@ -50,7 +50,10 @@
         }
       ]
     ],
-    "testTimeout": 30000
+    "testTimeout": 30000,
+    "setupFiles": [
+      "../../foundation/src/jest/setup.mjs"
+    ]
   },
   "dependencies": {
     "@aztec/accounts": "workspace:^",

--- a/yarn-project/builder/package.json
+++ b/yarn-project/builder/package.json
@@ -66,7 +66,10 @@
         }
       ]
     ],
-    "testTimeout": 30000
+    "testTimeout": 30000,
+    "setupFiles": [
+      "../../foundation/src/jest/setup.mjs"
+    ]
   },
   "dependencies": {
     "@aztec/foundation": "workspace:^",

--- a/yarn-project/circuit-types/package.json
+++ b/yarn-project/circuit-types/package.json
@@ -64,7 +64,10 @@
         }
       ]
     ],
-    "testTimeout": 30000
+    "testTimeout": 30000,
+    "setupFiles": [
+      "../../foundation/src/jest/setup.mjs"
+    ]
   },
   "dependencies": {
     "@aztec/circuits.js": "workspace:^",

--- a/yarn-project/circuits.js/package.json
+++ b/yarn-project/circuits.js/package.json
@@ -98,6 +98,9 @@
         }
       ]
     ],
-    "testTimeout": 30000
+    "testTimeout": 30000,
+    "setupFiles": [
+      "../../foundation/src/jest/setup.mjs"
+    ]
   }
 }

--- a/yarn-project/cli-wallet/package.json
+++ b/yarn-project/cli-wallet/package.json
@@ -64,7 +64,10 @@
         }
       ]
     ],
-    "testTimeout": 30000
+    "testTimeout": 30000,
+    "setupFiles": [
+      "../../foundation/src/jest/setup.mjs"
+    ]
   },
   "dependencies": {
     "@aztec/accounts": "workspace:^",

--- a/yarn-project/cli/package.json
+++ b/yarn-project/cli/package.json
@@ -64,7 +64,10 @@
         }
       ]
     ],
-    "testTimeout": 30000
+    "testTimeout": 30000,
+    "setupFiles": [
+      "../../foundation/src/jest/setup.mjs"
+    ]
   },
   "dependencies": {
     "@aztec/archiver": "workspace:^",

--- a/yarn-project/end-to-end/package.json
+++ b/yarn-project/end-to-end/package.json
@@ -156,6 +156,9 @@
     },
     "testRegex": "./src/.*\\.test\\.(js|mjs|ts)$",
     "rootDir": "./src",
-    "testTimeout": 30000
+    "testTimeout": 30000,
+    "setupFiles": [
+      "../../foundation/src/jest/setup.mjs"
+    ]
   }
 }

--- a/yarn-project/end-to-end/src/shared/browser.ts
+++ b/yarn-project/end-to-end/src/shared/browser.ts
@@ -97,7 +97,7 @@ export const browserTestSuite = (
         pageLogger.info(msg.text());
       });
       page.on('pageerror', err => {
-        pageLogger.error(err.toString());
+        pageLogger.error(`Error on web page`, err);
       });
       await page.goto(`${webServerURL}/index.html`);
       while (!(await page.evaluate(() => !!window.AztecJs))) {

--- a/yarn-project/entrypoints/package.json
+++ b/yarn-project/entrypoints/package.json
@@ -60,7 +60,10 @@
         }
       ]
     ],
-    "testTimeout": 30000
+    "testTimeout": 30000,
+    "setupFiles": [
+      "../../foundation/src/jest/setup.mjs"
+    ]
   },
   "dependencies": {
     "@aztec/aztec.js": "workspace:^",

--- a/yarn-project/epoch-cache/package.json
+++ b/yarn-project/epoch-cache/package.json
@@ -87,7 +87,10 @@
         }
       ]
     ],
-    "testTimeout": 30000
+    "testTimeout": 30000,
+    "setupFiles": [
+      "../../foundation/src/jest/setup.mjs"
+    ]
   },
   "engines": {
     "node": ">=18"

--- a/yarn-project/ethereum/package.json
+++ b/yarn-project/ethereum/package.json
@@ -86,7 +86,10 @@
         }
       ]
     ],
-    "testTimeout": 30000
+    "testTimeout": 30000,
+    "setupFiles": [
+      "../../foundation/src/jest/setup.mjs"
+    ]
   },
   "engines": {
     "node": ">=18"

--- a/yarn-project/foundation/package.json
+++ b/yarn-project/foundation/package.json
@@ -97,7 +97,13 @@
         }
       ]
     ],
-    "testTimeout": 30000
+    "testTimeout": 30000,
+    "setupFilesAfterEnv": [
+      "../../foundation/src/jest/setup.mjs"
+    ],
+    "setupFiles": [
+      "../../foundation/src/jest/setup.mjs"
+    ]
   },
   "dependencies": {
     "@aztec/bb.js": "portal:../../barretenberg/ts",

--- a/yarn-project/foundation/src/jest/setup.mjs
+++ b/yarn-project/foundation/src/jest/setup.mjs
@@ -1,0 +1,8 @@
+import { overwriteLoggingStream, pinoPrettyOpts } from '@aztec/foundation/log';
+import pretty from 'pino-pretty';
+
+// Overwrite logging stream with pino-pretty. We define this as a separate
+// file so we don't mess up with dependencies in non-testing environments,
+// since pino-pretty messes up with browser bundles.
+// See also https://www.npmjs.com/package/pino-pretty?activeTab=readme#user-content-usage-with-jest
+overwriteLoggingStream(pretty(pinoPrettyOpts));

--- a/yarn-project/foundation/src/jest/setup.mjs
+++ b/yarn-project/foundation/src/jest/setup.mjs
@@ -1,4 +1,5 @@
 import { overwriteLoggingStream, pinoPrettyOpts } from '@aztec/foundation/log';
+
 import pretty from 'pino-pretty';
 
 // Overwrite logging stream with pino-pretty. We define this as a separate

--- a/yarn-project/ivc-integration/package.json
+++ b/yarn-project/ivc-integration/package.json
@@ -59,7 +59,10 @@
         }
       ]
     ],
-    "testTimeout": 30000
+    "testTimeout": 30000,
+    "setupFiles": [
+      "../../foundation/src/jest/setup.mjs"
+    ]
   },
   "dependencies": {
     "@aztec/bb.js": "../../ts",

--- a/yarn-project/key-store/package.json
+++ b/yarn-project/key-store/package.json
@@ -54,7 +54,10 @@
         }
       ]
     ],
-    "testTimeout": 30000
+    "testTimeout": 30000,
+    "setupFiles": [
+      "../../foundation/src/jest/setup.mjs"
+    ]
   },
   "dependencies": {
     "@aztec/circuit-types": "workspace:^",

--- a/yarn-project/kv-store/package.json
+++ b/yarn-project/kv-store/package.json
@@ -91,6 +91,9 @@
     ],
     "testRegex": "./src/.*\\.test\\.(js|mjs|ts)$",
     "rootDir": "./src",
-    "testTimeout": 30000
+    "testTimeout": 30000,
+    "setupFiles": [
+      "../../foundation/src/jest/setup.mjs"
+    ]
   }
 }

--- a/yarn-project/merkle-tree/package.json
+++ b/yarn-project/merkle-tree/package.json
@@ -55,7 +55,10 @@
         }
       ]
     ],
-    "testTimeout": 30000
+    "testTimeout": 30000,
+    "setupFiles": [
+      "../../foundation/src/jest/setup.mjs"
+    ]
   },
   "dependencies": {
     "@aztec/circuit-types": "workspace:^",

--- a/yarn-project/noir-contracts.js/package.json
+++ b/yarn-project/noir-contracts.js/package.json
@@ -54,7 +54,10 @@
         }
       ]
     ],
-    "testTimeout": 30000
+    "testTimeout": 30000,
+    "setupFiles": [
+      "../../foundation/src/jest/setup.mjs"
+    ]
   },
   "dependencies": {
     "@aztec/aztec.js": "workspace:^",

--- a/yarn-project/noir-protocol-circuits-types/package.json
+++ b/yarn-project/noir-protocol-circuits-types/package.json
@@ -58,7 +58,10 @@
         }
       ]
     ],
-    "testTimeout": 30000
+    "testTimeout": 30000,
+    "setupFiles": [
+      "../../foundation/src/jest/setup.mjs"
+    ]
   },
   "dependencies": {
     "@aztec/circuits.js": "workspace:^",

--- a/yarn-project/p2p-bootstrap/package.json
+++ b/yarn-project/p2p-bootstrap/package.json
@@ -82,7 +82,10 @@
         }
       ]
     ],
-    "testTimeout": 30000
+    "testTimeout": 30000,
+    "setupFiles": [
+      "../../foundation/src/jest/setup.mjs"
+    ]
   },
   "engines": {
     "node": ">=18"

--- a/yarn-project/p2p/package.json
+++ b/yarn-project/p2p/package.json
@@ -60,7 +60,10 @@
         }
       ]
     ],
-    "testTimeout": 30000
+    "testTimeout": 30000,
+    "setupFiles": [
+      "../../foundation/src/jest/setup.mjs"
+    ]
   },
   "dependencies": {
     "@aztec/circuit-types": "workspace:^",

--- a/yarn-project/package.common.json
+++ b/yarn-project/package.common.json
@@ -55,6 +55,9 @@
     ],
     "testTimeout": 30000,
     "testRegex": "./src/.*\\.test\\.(js|mjs|ts)$",
-    "rootDir": "./src"
+    "rootDir": "./src",
+    "setupFiles": [
+      "../../foundation/src/jest/setup.mjs"
+    ]
   }
 }

--- a/yarn-project/proof-verifier/package.json
+++ b/yarn-project/proof-verifier/package.json
@@ -75,6 +75,9 @@
     ],
     "testRegex": "./src/.*\\.test\\.(js|mjs|ts)$",
     "rootDir": "./src",
-    "testTimeout": 30000
+    "testTimeout": 30000,
+    "setupFiles": [
+      "../../foundation/src/jest/setup.mjs"
+    ]
   }
 }

--- a/yarn-project/protocol-contracts/package.json
+++ b/yarn-project/protocol-contracts/package.json
@@ -65,7 +65,10 @@
         }
       ]
     ],
-    "testTimeout": 30000
+    "testTimeout": 30000,
+    "setupFiles": [
+      "../../foundation/src/jest/setup.mjs"
+    ]
   },
   "dependencies": {
     "@aztec/circuits.js": "workspace:^",

--- a/yarn-project/prover-client/package.json
+++ b/yarn-project/prover-client/package.json
@@ -64,7 +64,10 @@
         }
       ]
     ],
-    "testTimeout": 30000
+    "testTimeout": 30000,
+    "setupFiles": [
+      "../../foundation/src/jest/setup.mjs"
+    ]
   },
   "dependencies": {
     "@aztec/bb-prover": "workspace:^",

--- a/yarn-project/prover-node/package.json
+++ b/yarn-project/prover-node/package.json
@@ -50,7 +50,10 @@
         }
       ]
     ],
-    "testTimeout": 30000
+    "testTimeout": 30000,
+    "setupFiles": [
+      "../../foundation/src/jest/setup.mjs"
+    ]
   },
   "dependencies": {
     "@aztec/archiver": "workspace:^",

--- a/yarn-project/pxe/package.json
+++ b/yarn-project/pxe/package.json
@@ -65,7 +65,10 @@
         }
       ]
     ],
-    "testTimeout": 30000
+    "testTimeout": 30000,
+    "setupFiles": [
+      "../../foundation/src/jest/setup.mjs"
+    ]
   },
   "dependencies": {
     "@aztec/bb-prover": "workspace:^",

--- a/yarn-project/scripts/package.json
+++ b/yarn-project/scripts/package.json
@@ -84,7 +84,10 @@
         }
       ]
     ],
-    "testTimeout": 30000
+    "testTimeout": 30000,
+    "setupFiles": [
+      "../../foundation/src/jest/setup.mjs"
+    ]
   },
   "engines": {
     "node": ">=18"

--- a/yarn-project/sequencer-client/package.json
+++ b/yarn-project/sequencer-client/package.json
@@ -110,6 +110,9 @@
         }
       ]
     ],
-    "testTimeout": 30000
+    "testTimeout": 30000,
+    "setupFiles": [
+      "../../foundation/src/jest/setup.mjs"
+    ]
   }
 }

--- a/yarn-project/simulator/package.json
+++ b/yarn-project/simulator/package.json
@@ -60,7 +60,10 @@
         }
       ]
     ],
-    "testTimeout": 30000
+    "testTimeout": 30000,
+    "setupFiles": [
+      "../../foundation/src/jest/setup.mjs"
+    ]
   },
   "dependencies": {
     "@aztec/circuit-types": "workspace:^",

--- a/yarn-project/telemetry-client/package.json
+++ b/yarn-project/telemetry-client/package.json
@@ -84,6 +84,9 @@
     ],
     "testRegex": "./src/.*\\.test\\.(js|mjs|ts)$",
     "rootDir": "./src",
-    "testTimeout": 30000
+    "testTimeout": 30000,
+    "setupFiles": [
+      "../../foundation/src/jest/setup.mjs"
+    ]
   }
 }

--- a/yarn-project/txe/package.json
+++ b/yarn-project/txe/package.json
@@ -58,7 +58,10 @@
         }
       ]
     ],
-    "testTimeout": 30000
+    "testTimeout": 30000,
+    "setupFiles": [
+      "../../foundation/src/jest/setup.mjs"
+    ]
   },
   "dependencies": {
     "@aztec/accounts": "workspace:^",

--- a/yarn-project/types/package.json
+++ b/yarn-project/types/package.json
@@ -60,7 +60,10 @@
         }
       ]
     ],
-    "testTimeout": 30000
+    "testTimeout": 30000,
+    "setupFiles": [
+      "../../foundation/src/jest/setup.mjs"
+    ]
   },
   "dependencies": {
     "@aztec/ethereum": "workspace:^",

--- a/yarn-project/validator-client/package.json
+++ b/yarn-project/validator-client/package.json
@@ -57,7 +57,10 @@
         }
       ]
     ],
-    "testTimeout": 30000
+    "testTimeout": 30000,
+    "setupFiles": [
+      "../../foundation/src/jest/setup.mjs"
+    ]
   },
   "dependencies": {
     "@aztec/circuit-types": "workspace:^",

--- a/yarn-project/world-state/package.json
+++ b/yarn-project/world-state/package.json
@@ -60,7 +60,10 @@
         }
       ]
     ],
-    "testTimeout": 30000
+    "testTimeout": 30000,
+    "setupFiles": [
+      "../../foundation/src/jest/setup.mjs"
+    ]
   },
   "dependencies": {
     "@aztec/circuit-types": "workspace:^",


### PR DESCRIPTION
End-to-end browser tests were broken since #10459 due to the static import of pino-pretty, which had some browser unfriendly stuff. This PR removes that import in favor of setting it up in a separate jest setup file, only run under jest. This follows the recommendation of pino-pretty of not importing it in production.

Note that, for end-users who want pretty logging, pino-pretty will still kick in but as a transport, so it gets loaded in a nodejs worker thread by pino itself, and does not pollute the static imports.

Another way of fixing this would have been adding the 'pino-pretty' exception in the webpack fallbacks, but it felt wrong to start adding so many deps in there.

Another option would have been to dynamically import (as opposed to statically) pino-pretty, and use a webpackIgnore magic comment to skip it. But it's unclear whether this would have worked with other bundlers, and besides it would have added an async operation to our otherwise synchronous logger setup.

Please read [contributing guidelines](CONTRIBUTING.md) and remove this line.
