### PR TITLE
chore: Handle errors in e2e teardown to fix e2e token

### DIFF
--- a/yarn-project/end-to-end/src/fixtures/snapshot_manager.ts
+++ b/yarn-project/end-to-end/src/fixtures/snapshot_manager.ts
@@ -244,7 +244,7 @@ async function teardown(context: SubsystemsContext | undefined) {
     return;
   }
   try {
-    getLogger().verbose('Tearing down subsystems...');
+    getLogger().info('Tearing down subsystems');
     await context.proverNode?.stop();
     await context.aztecNode.stop();
     await context.pxe.stop();
@@ -253,12 +253,7 @@ async function teardown(context: SubsystemsContext | undefined) {
     await context.watcher.stop();
     context.timer?.uninstall();
   } catch (err) {
-    try {
-      getLogger().error('Error during teardown', err);
-    } catch (err2) {
-      // eslint-disable-next-line no-console
-      console.error(`Error logging teardown error`, err, err2);
-    }
+    getLogger().error('Error during teardown', err);
   }
 }
 

--- a/yarn-project/end-to-end/src/fixtures/snapshot_manager.ts
+++ b/yarn-project/end-to-end/src/fixtures/snapshot_manager.ts
@@ -36,7 +36,7 @@ import { MNEMONIC } from './fixtures.js';
 import { getACVMConfig } from './get_acvm_config.js';
 import { getBBConfig } from './get_bb_config.js';
 import { setupL1Contracts } from './setup_l1_contracts.js';
-import { type SetupOptions, createAndSyncProverNode, getPrivateKeyFromIndex } from './utils.js';
+import { type SetupOptions, createAndSyncProverNode, getLogger, getPrivateKeyFromIndex } from './utils.js';
 import { getEndToEndTestTelemetryClient } from './with_telemetry_utils.js';
 
 export type SubsystemsContext = {
@@ -243,13 +243,23 @@ async function teardown(context: SubsystemsContext | undefined) {
   if (!context) {
     return;
   }
-  await context.proverNode?.stop();
-  await context.aztecNode.stop();
-  await context.pxe.stop();
-  await context.acvmConfig?.cleanup();
-  await context.anvil.stop();
-  await context.watcher.stop();
-  context.timer?.uninstall();
+  try {
+    getLogger().verbose('Tearing down subsystems...');
+    await context.proverNode?.stop();
+    await context.aztecNode.stop();
+    await context.pxe.stop();
+    await context.acvmConfig?.cleanup();
+    await context.anvil.stop();
+    await context.watcher.stop();
+    context.timer?.uninstall();
+  } catch (err) {
+    try {
+      getLogger().error('Error during teardown', err);
+    } catch (err2) {
+      // eslint-disable-next-line no-console
+      console.error(`Error logging teardown error`, err, err2);
+    }
+  }
 }
 
 /**


### PR DESCRIPTION
`e2e-token` test was failing due to a telemetry shutdown from one of the test suites affecting another. Try/catching the environment teardown seems to patch the issue.