### PR TITLE
chore: Do not include noir source code in errors

### DIFF
--- a/yarn-project/circuit-types/src/simulation_error.ts
+++ b/yarn-project/circuit-types/src/simulation_error.ts
@@ -4,51 +4,29 @@ import { schemas } from '@aztec/foundation/schemas';
 
 import { z } from 'zod';
 
-/**
- * Address and selector of a function that failed during simulation.
- */
+/** Address and selector of a function that failed during simulation. */
 export interface FailingFunction {
-  /**
-   * The address of the contract that failed.
-   */
+  /** The address of the contract that failed. */
   contractAddress: AztecAddress;
-  /**
-   * The name of the contract that failed.
-   */
+  /** The name of the contract that failed. */
   contractName?: string;
-  /**
-   * The selector of the function that failed.
-   */
+  /** The selector of the function that failed. */
   functionSelector?: FunctionSelector;
-  /**
-   * The name of the function that failed.
-   */
+  /** The name of the function that failed. */
   functionName?: string;
 }
 
-/**
- * A pointer to a failing section of the noir source code.
- */
+/** A pointer to a failing section of the noir source code. */
 export interface SourceCodeLocation {
-  /**
-   * The path to the source file.
-   */
+  /** The path to the source file. */
   filePath: string;
-  /**
-   * The line number of the call.
-   */
+  /** The line number of the call. */
   line: number;
-  /**
-   * The column number of the call.
-   */
+  /** The column number of the call. */
   column: number;
-  /**
-   * The source code of the file.
-   */
-  fileSource: string;
-  /**
-   * The source code text of the failed constraint.
-   */
+  /** The source code of the file. */
+  fileSource?: string;
+  /** The source code text of the failed constraint. */
   locationText: string;
 }
 
@@ -56,27 +34,21 @@ const SourceCodeLocationSchema = z.object({
   filePath: z.string(),
   line: z.number(),
   column: z.number(),
-  fileSource: z.string(),
+  fileSource: z.string().optional(),
   locationText: z.string(),
 });
 
-/**
- * A stack of noir source code locations.
- */
+/** A stack of noir source code locations. */
 export type NoirCallStack = SourceCodeLocation[] | OpcodeLocation[];
 
 const NoirCallStackSchema: z.ZodType<NoirCallStack> = z.union([z.array(SourceCodeLocationSchema), z.array(z.string())]);
 
-/**
- * Checks if a call stack is unresolved.
- */
+/** Checks if a call stack is unresolved. */
 export function isNoirCallStackUnresolved(callStack: NoirCallStack): callStack is OpcodeLocation[] {
   return typeof callStack[0] === 'string';
 }
 
-/**
- * An error during the simulation of a function call.
- */
+/** An error during the simulation of a function call. */
 export class SimulationError extends Error {
   constructor(
     private originalMessage: string,

--- a/yarn-project/simulator/src/common/errors.ts
+++ b/yarn-project/simulator/src/common/errors.ts
@@ -110,7 +110,7 @@ function getSourceCodeLocationsFromOpcodeLocation(
   return callStack.map(call => {
     const { file: fileId, span } = call;
 
-    const { path, source } = files[fileId];
+    const { path: filePath, source } = files[fileId];
 
     const locationText = source.substring(span.start, span.end);
     const precedingText = source.substring(0, span.start);
@@ -119,13 +119,7 @@ function getSourceCodeLocationsFromOpcodeLocation(
     const line = previousLines.length;
     const column = previousLines[previousLines.length - 1].length + 1;
 
-    return {
-      filePath: path,
-      line,
-      column,
-      fileSource: source,
-      locationText,
-    };
+    return { filePath, line, column, locationText };
   });
 }
 


### PR DESCRIPTION
Makes exceptions less scary. Example after this PR:

```
[21:00:33.240] ERROR: pxe:service Error: [Simulation error: Assertion failed: Balance too low 'subtracted > U128::from_integer(0)'
at subtracted > U128::from_integer(0) (/usr/src/noir-projects/noir-contracts/contracts/token_contract/src/main.nr:320:16)
at e::types:: (/usr/src/noir-projects/noir-contracts/contracts/token_contract/src/main.nr:49:13)
at Token._recurse_subtract_balance
at Token.transfer
at SchnorrAccount.entrypoint] {
  originalMessage: 'Assertion failed: Balance too low',
  functionErrorStack: [
    {
      contractAddress: AztecAddress<0x2dccaa1d652bd443516c0ba0ddd84717e5406245de4bf49b99ffc60bc814f09e>,
      functionSelector: Selector<0x27e740b2>,
      contractName: 'SchnorrAccount',
      functionName: 'entrypoint'
    },
    {
      contractAddress: AztecAddress<0x2d3b210f5a5907b73494d149c264d4467ef34cc0325707612ef07174d21a21a1>,
      functionSelector: Selector<0x9462d279>,
      contractName: 'Token',
      functionName: 'transfer'
    },
    {
      contractAddress: AztecAddress<0x2d3b210f5a5907b73494d149c264d4467ef34cc0325707612ef07174d21a21a1>,
      functionSelector: Selector<0x62e8310a>,
      contractName: 'Token',
      functionName: '_recurse_subtract_balance'
    }
  ],
  revertData: [],
  noirErrorStack: [
    {
      filePath: '/usr/src/noir-projects/noir-contracts/contracts/token_contract/src/main.nr',
      line: 49,
      column: 13,
      locationText: 'e::types::'
    },
    {
      filePath: '/usr/src/noir-projects/noir-contracts/contracts/token_contract/src/main.nr',
      line: 320,
      column: 16,
      locationText: 'subtracted > U128::from_integer(0)'
    }
  ],
  [cause]: Error: Assertion failed
      at Object.<anonymous>.module.exports.__wbg_constructor_f8f83aa6ec3644b9 (/home/santiago/Projects/aztec3-packages/noir/packages/acvm_js/nodejs/acvm_js.js:659:17)
      at acvm_js::js_execution_error::JsExecutionError::new::hebdb1fd5d8918eaa (wasm://wasm/0091f51a:1:1188728)
      at acvm_js::execute::ProgramExecutor<B>::execute_circuit::{{closure}}::hdef4865f37ab532b (wasm://wasm/0091f51a:1:321389)
      at acvm_js::execute::execute_program_with_native_program_and_return::{{closure}}::h4055275b2107668e (wasm://wasm/0091f51a:1:1028816)
      at wasm_bindgen_futures::future_to_promise::{{closure}}::{{closure}}::haf134c5ffdb252dd (wasm://wasm/0091f51a:1:710177)
      at wasm_bindgen_futures::queue::Queue::new::{{closure}}::he31c90183f9be757 (wasm://wasm/0091f51a:1:1231070)
      at <dyn core::ops::function::FnMut<(A,)>+Output = R as wasm_bindgen::closure::WasmClosure>::describe::invoke::h624a3dfbf78ca22a (wasm://wasm/0091f51a:1:1580845)
      at __wbg_adapter_22 (/home/santiago/Projects/aztec3-packages/noir/packages/acvm_js/nodejs/acvm_js.js:220:10)
      at real (/home/santiago/Projects/aztec3-packages/noir/packages/acvm_js/nodejs/acvm_js.js:205:20)Error: 
      at /home/santiago/Projects/aztec3-packages/yarn-project/simulator/src/acvm/acvm.ts:73:19
      at acvm (/home/santiago/Projects/aztec3-packages/yarn-project/simulator/src/acvm/acvm.ts:47:34)
      at executePrivateFunction (/home/santiago/Projects/aztec3-packages/yarn-project/simulator/src/client/private_execution.ts:35:31)
      at ClientExecutionContext.callPrivateFunction (/home/santiago/Projects/aztec3-packages/yarn-project/simulator/src/client/client_execution_context.ts:380:34)
      at Oracle.callPrivateFunction (/home/santiago/Projects/aztec3-packages/yarn-project/simulator/src/acvm/oracle/oracle.ts:330:51)
      at /home/santiago/Projects/aztec3-packages/yarn-project/simulator/src/acvm/acvm.ts:58:24Error: 
      at /home/santiago/Projects/aztec3-packages/yarn-project/simulator/src/acvm/acvm.ts:73:19
      at acvm (/home/santiago/Projects/aztec3-packages/yarn-project/simulator/src/acvm/acvm.ts:47:34)
      at executePrivateFunction (/home/santiago/Projects/aztec3-packages/yarn-project/simulator/src/client/private_execution.ts:35:31)
      at ClientExecutionContext.callPrivateFunction (/home/santiago/Projects/aztec3-packages/yarn-project/simulator/src/client/client_execution_context.ts:380:34)
      at Oracle.callPrivateFunction (/home/santiago/Projects/aztec3-packages/yarn-project/simulator/src/acvm/oracle/oracle.ts:330:51)
      at /home/santiago/Projects/aztec3-packages/yarn-project/simulator/src/acvm/acvm.ts:58:24Error: 
      at /home/santiago/Projects/aztec3-packages/yarn-project/simulator/src/acvm/acvm.ts:73:19
      at acvm (/home/santiago/Projects/aztec3-packages/yarn-project/simulator/src/acvm/acvm.ts:47:34)
      at executePrivateFunction (/home/santiago/Projects/aztec3-packages/yarn-project/simulator/src/client/private_execution.ts:35:31)
      at AcirSimulator.run (/home/santiago/Projects/aztec3-packages/yarn-project/simulator/src/client/simulator.ts:90:31)
      at PXEService._PXEService_executePrivate (/home/santiago/Projects/aztec3-packages/yarn-project/pxe/src/pxe_service/pxe_service.ts:773:22)
      at /home/santiago/Projects/aztec3-packages/yarn-project/pxe/src/pxe_service/pxe_service.ts:544:40
      at /home/santiago/Projects/aztec3-packages/yarn-project/foundation/src/queue/serial_queue.ts:63:23
      at FifoMemoryQueue.process (/home/santiago/Projects/aztec3-packages/yarn-project/foundation/src/queue/base_memory_queue.ts:132:9) {
    callStack: [ '8687' ],
    rawAssertionPayload: { selector: '15238796416211288225', data: [] },
    brilligFunctionId: undefined
  }
}
```