### PR TITLE
Update ec_primitives.md

### DIFF
--- a/noir/noir-repo/docs/versioned_docs/version-v0.39.0/noir/standard_library/cryptographic_primitives/ec_primitives.md
+++ b/noir/noir-repo/docs/versioned_docs/version-v0.39.0/noir/standard_library/cryptographic_primitives/ec_primitives.md
@@ -18,7 +18,7 @@ curve you want to use, which would be specified using any one of the methods
 `std::ec::{tecurve,montcurve,swcurve}::{affine,curvegroup}::new` which take the coefficients in the
 defining equation together with a generator point as parameters. You can find more detail in the
 comments in
-[`noir_stdlib/src/ec/mod.nr`](https://github.com/noir-lang/noir/blob/master/noir_stdlib/src/ec/mod.nr), but
+[`noir_stdlib/src/ec/mod.nr`](), but
 the gist of it is that the elliptic curves of interest are usually expressed in one of the standard
 forms implemented here (Twisted Edwards, Montgomery and Short Weierstraß), and in addition to that,
 you could choose to use `affine` coordinates (Cartesian coordinates - the usual (x,y) - possibly


### PR DESCRIPTION

I removed the broken link to the ec/mod.nr file and replaced it with a placeholder `[]()`. 

It would be helpful if someone could provide the correct working link to the current location of the ec module implementation in the noir-lang repository.
