### PR TITLE
fix: attempt to fix flake in e2e cross chain messaging test

### DIFF
--- a/yarn-project/simulator/src/avm/journal/journal.ts
+++ b/yarn-project/simulator/src/avm/journal/journal.ts
@@ -379,8 +379,8 @@ export class AvmPersistableStateManager {
       } else {
         // Sanity check that the leaf value is skipped by low leaf when it doesn't exist
         assert(
-          siloedNullifier.toBigInt() > leafPreimage.nullifier.toBigInt() &&
-            siloedNullifier.toBigInt() < leafPreimage.nextNullifier.toBigInt(),
+          leafPreimage.nullifier.toBigInt() < siloedNullifier.toBigInt() &&
+            (leafPreimage.nextIndex === 0n || leafPreimage.nextNullifier.toBigInt() > siloedNullifier.toBigInt()),
           'Nullifier tree low leaf should skip the target leaf nullifier when the target leaf does not exist.',
         );
       }


### PR DESCRIPTION
I was missing a case in this nullifier check assertion. There are actually 2 ways for a low nullifier leaf to "skip" a target nullifier. Low leaf nullifier < target nullifier and either:
1. low leaf next nullifier > target nullifier
2. or (was missing) low leaf's "next index" is 0 (it is the largest-value nullifier in the tree)

I also switched the order of the left/right hand operands in the assertion to match the very similar public data assertion.

The test failure I'm trying to fix is pasted below. I was unable to replicate it locally.
![image](https://github.com/user-attachments/assets/262e435c-46c6-4b8f-9ad8-958a064fdd92)
