### PR TITLE
chore: Trace and handle errors in running promises

### DIFF
--- a/yarn-project/archiver/src/archiver/archiver.test.ts
+++ b/yarn-project/archiver/src/archiver/archiver.test.ts
@@ -5,6 +5,7 @@ import { EthAddress } from '@aztec/foundation/eth-address';
 import { Fr } from '@aztec/foundation/fields';
 import { sleep } from '@aztec/foundation/sleep';
 import { type InboxAbi, RollupAbi } from '@aztec/l1-artifacts';
+import { NoopTelemetryClient } from '@aztec/telemetry-client/noop';
 
 import { jest } from '@jest/globals';
 import { type MockProxy, mock } from 'jest-mock-extended';
@@ -84,7 +85,8 @@ describe('Archiver', () => {
       }) as any,
     });
 
-    instrumentation = mock({ isEnabled: () => true });
+    const tracer = new NoopTelemetryClient().getTracer();
+    instrumentation = mock<ArchiverInstrumentation>({ isEnabled: () => true, tracer });
     archiverStore = new MemoryArchiverStore(1000);
 
     archiver = new Archiver(

--- a/yarn-project/archiver/src/archiver/instrumentation.ts
+++ b/yarn-project/archiver/src/archiver/instrumentation.ts
@@ -8,11 +8,14 @@ import {
   type LmdbStatsCallback,
   Metrics,
   type TelemetryClient,
+  type Tracer,
   type UpDownCounter,
   ValueType,
 } from '@aztec/telemetry-client';
 
 export class ArchiverInstrumentation {
+  public readonly tracer: Tracer;
+
   private blockHeight: Gauge;
   private blockSize: Gauge;
   private syncDuration: Histogram;
@@ -24,6 +27,7 @@ export class ArchiverInstrumentation {
   private log = createLogger('archiver:instrumentation');
 
   private constructor(private telemetry: TelemetryClient, lmdbStats?: LmdbStatsCallback) {
+    this.tracer = telemetry.getTracer('Archiver');
     const meter = telemetry.getMeter('Archiver');
     this.blockHeight = meter.createGauge(Metrics.ARCHIVER_BLOCK_HEIGHT, {
       description: 'The height of the latest block processed by the archiver',

--- a/yarn-project/aztec-node/src/aztec-node/server.ts
+++ b/yarn-project/aztec-node/src/aztec-node/server.ts
@@ -74,7 +74,7 @@ import {
 import { ProtocolContractAddress } from '@aztec/protocol-contracts';
 import { GlobalVariableBuilder, type L1Publisher, SequencerClient } from '@aztec/sequencer-client';
 import { PublicProcessorFactory } from '@aztec/simulator';
-import { type TelemetryClient } from '@aztec/telemetry-client';
+import { Attributes, type TelemetryClient, type Traceable, type Tracer, trackSpan } from '@aztec/telemetry-client';
 import { NoopTelemetryClient } from '@aztec/telemetry-client/noop';
 import { createValidatorClient } from '@aztec/validator-client';
 import { createWorldStateSynchronizer } from '@aztec/world-state';
@@ -85,10 +85,11 @@ import { NodeMetrics } from './node_metrics.js';
 /**
  * The aztec node.
  */
-export class AztecNodeService implements AztecNode {
+export class AztecNodeService implements AztecNode, Traceable {
   private packageVersion: string;
-
   private metrics: NodeMetrics;
+
+  public readonly tracer: Tracer;
 
   constructor(
     protected config: AztecNodeConfig,
@@ -109,6 +110,7 @@ export class AztecNodeService implements AztecNode {
   ) {
     this.packageVersion = getPackageInfo().version;
     this.metrics = new NodeMetrics(telemetry, 'AztecNodeService');
+    this.tracer = telemetry.getTracer('AztecNodeService');
 
     this.log.info(`Aztec Node started on chain 0x${l1ChainId.toString(16)}`, config.l1Contracts);
   }
@@ -782,6 +784,9 @@ export class AztecNodeService implements AztecNode {
    * Simulates the public part of a transaction with the current state.
    * @param tx - The transaction to simulate.
    **/
+  @trackSpan('AztecNodeService.simulatePublicCalls', (tx: Tx) => ({
+    [Attributes.TX_HASH]: tx.tryGetTxHash()?.toString(),
+  }))
   public async simulatePublicCalls(tx: Tx): Promise<PublicSimulationOutput> {
     const txHash = tx.getTxHash();
     const blockNumber = (await this.blockSource.getBlockNumber()) + 1;

--- a/yarn-project/aztec.js/src/utils/anvil_test_watcher.ts
+++ b/yarn-project/aztec.js/src/utils/anvil_test_watcher.ts
@@ -46,7 +46,7 @@ export class AnvilTestWatcher {
     const isAutoMining = await this.cheatcodes.isAutoMining();
 
     if (isAutoMining) {
-      this.filledRunningPromise = new RunningPromise(() => this.mineIfSlotFilled(), 1000);
+      this.filledRunningPromise = new RunningPromise(() => this.mineIfSlotFilled(), this.logger, 1000);
       this.filledRunningPromise.start();
       this.logger.info(`Watcher started for rollup at ${this.rollup.address}`);
     } else {

--- a/yarn-project/aztec/src/cli/cmds/start_bot.ts
+++ b/yarn-project/aztec/src/cli/cmds/start_bot.ts
@@ -2,6 +2,11 @@ import { type BotConfig, BotRunner, botConfigMappings, getBotRunnerApiHandler } 
 import { type AztecNode, type PXE } from '@aztec/circuit-types';
 import { type NamespacedApiHandlers } from '@aztec/foundation/json-rpc/server';
 import { type LogFn } from '@aztec/foundation/log';
+import { type TelemetryClient } from '@aztec/telemetry-client';
+import {
+  createAndStartTelemetryClient,
+  getConfigEnvVars as getTelemetryClientConfig,
+} from '@aztec/telemetry-client/start';
 
 import { extractRelevantOptions } from '../util.js';
 
@@ -25,14 +30,15 @@ export async function startBot(
     pxe = await addPXE(options, signalHandlers, services, userLog);
   }
 
-  await addBot(options, signalHandlers, services, { pxe });
+  const telemetry = await createAndStartTelemetryClient(getTelemetryClientConfig());
+  await addBot(options, signalHandlers, services, { pxe, telemetry });
 }
 
 export function addBot(
   options: any,
   signalHandlers: (() => Promise<void>)[],
   services: NamespacedApiHandlers,
-  deps: { pxe?: PXE; node?: AztecNode } = {},
+  deps: { pxe?: PXE; node?: AztecNode; telemetry: TelemetryClient },
 ) {
   const config = extractRelevantOptions<BotConfig>(options, botConfigMappings, 'bot');
 

--- a/yarn-project/aztec/src/cli/cmds/start_node.ts
+++ b/yarn-project/aztec/src/cli/cmds/start_node.ts
@@ -88,10 +88,10 @@ export async function startNode(
   }
 
   const telemetryConfig = extractRelevantOptions<TelemetryClientConfig>(options, telemetryClientConfigMappings, 'tel');
-  const telemetryClient = await createAndStartTelemetryClient(telemetryConfig);
+  const telemetry = await createAndStartTelemetryClient(telemetryConfig);
 
   // Create and start Aztec Node
-  const node = await createAztecNode(nodeConfig, telemetryClient);
+  const node = await createAztecNode(nodeConfig, telemetry);
 
   // Add node and p2p to services list
   services.node = [node, AztecNodeApiSchema];
@@ -110,6 +110,6 @@ export async function startNode(
   // Add a txs bot if requested
   if (options.bot) {
     const { addBot } = await import('./start_bot.js');
-    await addBot(options, signalHandlers, services, { pxe, node });
+    await addBot(options, signalHandlers, services, { pxe, node, telemetry });
   }
 }

--- a/yarn-project/bot/package.json
+++ b/yarn-project/bot/package.json
@@ -64,6 +64,7 @@
     "@aztec/foundation": "workspace:^",
     "@aztec/noir-contracts.js": "workspace:^",
     "@aztec/protocol-contracts": "workspace:^",
+    "@aztec/telemetry-client": "workspace:^",
     "@aztec/types": "workspace:^",
     "source-map-support": "^0.5.21",
     "tslib": "^2.4.0",

--- a/yarn-project/bot/src/runner.ts
+++ b/yarn-project/bot/src/runner.ts
@@ -1,11 +1,12 @@
 import { type AztecNode, type PXE, createAztecNodeClient, createLogger } from '@aztec/aztec.js';
 import { RunningPromise } from '@aztec/foundation/running-promise';
+import { type TelemetryClient, type Traceable, type Tracer, trackSpan } from '@aztec/telemetry-client';
 
 import { Bot } from './bot.js';
 import { type BotConfig } from './config.js';
 import { type BotRunnerApi } from './interface.js';
 
-export class BotRunner implements BotRunnerApi {
+export class BotRunner implements BotRunnerApi, Traceable {
   private log = createLogger('bot');
   private bot?: Promise<Bot>;
   private pxe?: PXE;
@@ -14,13 +15,19 @@ export class BotRunner implements BotRunnerApi {
   private consecutiveErrors = 0;
   private healthy = true;
 
-  public constructor(private config: BotConfig, dependencies: { pxe?: PXE; node?: AztecNode }) {
+  public readonly tracer: Tracer;
+
+  public constructor(
+    private config: BotConfig,
+    dependencies: { pxe?: PXE; node?: AztecNode; telemetry: TelemetryClient },
+  ) {
+    this.tracer = dependencies.telemetry.getTracer('Bot');
     this.pxe = dependencies.pxe;
     if (!dependencies.node && !config.nodeUrl) {
       throw new Error(`Missing node URL in config or dependencies`);
     }
     this.node = dependencies.node ?? createAztecNodeClient(config.nodeUrl!);
-    this.runningPromise = new RunningPromise(() => this.#work(), config.txIntervalSeconds * 1000);
+    this.runningPromise = new RunningPromise(() => this.#work(), this.log, config.txIntervalSeconds * 1000);
   }
 
   /** Initializes the bot if needed. Blocks until the bot setup is finished. */
@@ -126,6 +133,7 @@ export class BotRunner implements BotRunnerApi {
     }
   }
 
+  @trackSpan('Bot.work')
   async #work() {
     if (this.config.maxPendingTxs > 0) {
       const pendingTxs = await this.node.getPendingTxs();
@@ -146,7 +154,7 @@ export class BotRunner implements BotRunnerApi {
     }
 
     if (!this.healthy && this.config.stopWhenUnhealthy) {
-      this.log.error(`Stopping bot due to errors`);
+      this.log.fatal(`Stopping bot due to errors`);
       process.exit(1); // workaround docker not restarting the container if its unhealthy. We have to exit instead
     }
   }

--- a/yarn-project/bot/tsconfig.json
+++ b/yarn-project/bot/tsconfig.json
@@ -31,6 +31,9 @@
       "path": "../protocol-contracts"
     },
     {
+      "path": "../telemetry-client"
+    },
+    {
       "path": "../types"
     }
   ],

--- a/yarn-project/circuit-types/src/l2_block_downloader/l2_block_stream.ts
+++ b/yarn-project/circuit-types/src/l2_block_downloader/l2_block_stream.ts
@@ -21,7 +21,7 @@ export class L2BlockStream {
       startingBlock?: number;
     } = {},
   ) {
-    this.runningPromise = new RunningPromise(() => this.work(), this.opts.pollIntervalMS ?? 1000);
+    this.runningPromise = new RunningPromise(() => this.work(), log, this.opts.pollIntervalMS ?? 1000);
   }
 
   public start() {

--- a/yarn-project/p2p/src/client/p2p_client.ts
+++ b/yarn-project/p2p/src/client/p2p_client.ts
@@ -5,7 +5,6 @@ import {
   type L2Block,
   type L2BlockId,
   type L2BlockSource,
-  L2BlockStream,
   type L2BlockStreamEvent,
   type L2Tips,
   type P2PApi,
@@ -16,7 +15,13 @@ import {
 import { INITIAL_L2_BLOCK_NUM } from '@aztec/circuits.js/constants';
 import { createLogger } from '@aztec/foundation/log';
 import { type AztecKVStore, type AztecMap, type AztecSingleton } from '@aztec/kv-store';
-import { Attributes, type TelemetryClient, WithTracer, trackSpan } from '@aztec/telemetry-client';
+import {
+  Attributes,
+  type TelemetryClient,
+  TraceableL2BlockStream,
+  WithTracer,
+  trackSpan,
+} from '@aztec/telemetry-client';
 import { NoopTelemetryClient } from '@aztec/telemetry-client/noop';
 
 import { type ENR } from '@chainsafe/enr';
@@ -221,7 +226,9 @@ export class P2PClient extends WithTracer implements P2P {
 
     this.keepAttestationsInPoolFor = keepAttestationsInPoolFor;
 
-    this.blockStream = new L2BlockStream(l2BlockSource, this, this, createLogger('p2p:block_stream'), {
+    const tracer = telemetry.getTracer('P2PL2BlockStream');
+    const logger = createLogger('p2p:l2-block-stream');
+    this.blockStream = new TraceableL2BlockStream(l2BlockSource, this, this, tracer, 'P2PL2BlockStream', logger, {
       batchSize: blockRequestBatchSize,
       pollIntervalMS: blockCheckIntervalMS,
     });

--- a/yarn-project/p2p/src/service/libp2p_service.ts
+++ b/yarn-project/p2p/src/service/libp2p_service.ts
@@ -93,7 +93,7 @@ export class LibP2PService extends WithTracer implements P2PService {
   ) {
     super(telemetry, 'LibP2PService');
 
-    this.peerManager = new PeerManager(node, peerDiscoveryService, config, logger);
+    this.peerManager = new PeerManager(node, peerDiscoveryService, config, this.tracer, logger);
     this.node.services.pubsub.score.params.appSpecificScore = (peerId: string) => {
       return this.peerManager.getPeerScore(peerId);
     };
@@ -144,9 +144,11 @@ export class LibP2PService extends WithTracer implements P2PService {
     });
 
     // Start running promise for peer discovery
-    this.discoveryRunningPromise = new RunningPromise(() => {
-      this.peerManager.heartbeat();
-    }, this.config.peerCheckIntervalMS);
+    this.discoveryRunningPromise = new RunningPromise(
+      () => this.peerManager.heartbeat(),
+      this.logger,
+      this.config.peerCheckIntervalMS,
+    );
     this.discoveryRunningPromise.start();
 
     // Define the sub protocol validators - This is done within this start() method to gain a callback to the existing validateTx function

--- a/yarn-project/p2p/src/service/peer_manager.ts
+++ b/yarn-project/p2p/src/service/peer_manager.ts
@@ -1,5 +1,6 @@
 import { type PeerInfo } from '@aztec/circuit-types';
 import { createLogger } from '@aztec/foundation/log';
+import { type Traceable, type Tracer, trackSpan } from '@aztec/telemetry-client';
 
 import { type ENR } from '@chainsafe/enr';
 import { type PeerId } from '@libp2p/interface';
@@ -21,7 +22,7 @@ type CachedPeer = {
   dialAttempts: number;
 };
 
-export class PeerManager {
+export class PeerManager implements Traceable {
   private cachedPeers: Map<string, CachedPeer> = new Map();
   private peerScoring: PeerScoring;
   private heartbeatCounter: number = 0;
@@ -30,6 +31,7 @@ export class PeerManager {
     private libP2PNode: PubSubLibp2p,
     private peerDiscoveryService: PeerDiscoveryService,
     private config: P2PConfig,
+    public readonly tracer: Tracer,
     private logger = createLogger('p2p:peer-manager'),
   ) {
     this.peerScoring = new PeerScoring(config);
@@ -59,6 +61,7 @@ export class PeerManager {
     });
   }
 
+  @trackSpan('PeerManager.heartbeat')
   public heartbeat() {
     this.heartbeatCounter++;
     this.discover();

--- a/yarn-project/prover-client/src/mocks/test_context.ts
+++ b/yarn-project/prover-client/src/mocks/test_context.ts
@@ -114,7 +114,7 @@ export class TestContext {
 
     const queue = new MemoryProvingQueue(telemetry);
     const orchestrator = new TestProvingOrchestrator(ws, queue, telemetry, Fr.ZERO);
-    const agent = new ProverAgent(localProver, proverCount);
+    const agent = new ProverAgent(localProver, proverCount, undefined, telemetry);
 
     queue.start();
     agent.start(queue);

--- a/yarn-project/prover-client/src/proving_broker/proving_agent.ts
+++ b/yarn-project/prover-client/src/proving_broker/proving_agent.ts
@@ -11,7 +11,7 @@ import {
 import { createLogger } from '@aztec/foundation/log';
 import { RunningPromise } from '@aztec/foundation/running-promise';
 import { Timer } from '@aztec/foundation/timer';
-import { type TelemetryClient } from '@aztec/telemetry-client';
+import { type TelemetryClient, type Traceable, type Tracer, trackSpan } from '@aztec/telemetry-client';
 
 import { type ProofStore } from './proof_store.js';
 import { ProvingAgentInstrumentation } from './proving_agent_instrumentation.js';
@@ -20,11 +20,13 @@ import { ProvingJobController, ProvingJobControllerStatus } from './proving_job_
 /**
  * A helper class that encapsulates a circuit prover and connects it to a job source.
  */
-export class ProvingAgent {
+export class ProvingAgent implements Traceable {
   private currentJobController?: ProvingJobController;
   private runningPromise: RunningPromise;
   private instrumentation: ProvingAgentInstrumentation;
   private idleTimer: Timer | undefined;
+
+  public readonly tracer: Tracer;
 
   constructor(
     /** The source of proving jobs */
@@ -41,8 +43,9 @@ export class ProvingAgent {
     private pollIntervalMs = 1000,
     private log = createLogger('prover-client:proving-agent'),
   ) {
+    this.tracer = client.getTracer('ProvingAgent');
     this.instrumentation = new ProvingAgentInstrumentation(client);
-    this.runningPromise = new RunningPromise(this.safeWork, this.pollIntervalMs);
+    this.runningPromise = new RunningPromise(this.work.bind(this), this.log, this.pollIntervalMs);
   }
 
   public setCircuitProver(circuitProver: ServerCircuitProver): void {
@@ -63,76 +66,73 @@ export class ProvingAgent {
     await this.runningPromise.stop();
   }
 
-  private safeWork = async () => {
-    try {
-      // every tick we need to
-      // (1) either do a heartbeat, telling the broker that we're working
-      // (2) get a new job
-      // If during (1) the broker returns a new job that means we can cancel the current job and start the new one
-      let maybeJob: { job: ProvingJob; time: number } | undefined;
-      if (this.currentJobController?.getStatus() === ProvingJobControllerStatus.PROVING) {
-        maybeJob = await this.broker.reportProvingJobProgress(
-          this.currentJobController.getJobId(),
-          this.currentJobController.getStartedAt(),
-          { allowList: this.proofAllowList },
-        );
-      } else {
-        maybeJob = await this.broker.getProvingJob({ allowList: this.proofAllowList });
-      }
-
-      if (!maybeJob) {
-        return;
-      }
-
-      let abortedProofJobId: string | undefined;
-      let abortedProofName: string | undefined;
-      if (this.currentJobController?.getStatus() === ProvingJobControllerStatus.PROVING) {
-        abortedProofJobId = this.currentJobController.getJobId();
-        abortedProofName = this.currentJobController.getProofTypeName();
-        this.currentJobController?.abort();
-      }
-
-      const { job, time } = maybeJob;
-      let inputs: ProvingJobInputs;
-      try {
-        inputs = await this.proofStore.getProofInput(job.inputsUri);
-      } catch (err) {
-        await this.broker.reportProvingJobError(job.id, 'Failed to load proof inputs', true);
-        return;
-      }
-
-      this.currentJobController = new ProvingJobController(
-        job.id,
-        inputs,
-        time,
-        this.circuitProver,
-        this.handleJobResult,
+  @trackSpan('ProvingAgent.safeWork')
+  private async work() {
+    // every tick we need to
+    // (1) either do a heartbeat, telling the broker that we're working
+    // (2) get a new job
+    // If during (1) the broker returns a new job that means we can cancel the current job and start the new one
+    let maybeJob: { job: ProvingJob; time: number } | undefined;
+    if (this.currentJobController?.getStatus() === ProvingJobControllerStatus.PROVING) {
+      maybeJob = await this.broker.reportProvingJobProgress(
+        this.currentJobController.getJobId(),
+        this.currentJobController.getStartedAt(),
+        { allowList: this.proofAllowList },
       );
-
-      if (abortedProofJobId) {
-        this.log.info(
-          `Aborting job id=${abortedProofJobId} type=${abortedProofName} to start new job id=${this.currentJobController.getJobId()} type=${this.currentJobController.getProofTypeName()} inputsUri=${truncateString(
-            job.inputsUri,
-          )}`,
-        );
-      } else {
-        this.log.info(
-          `Starting job id=${this.currentJobController.getJobId()} type=${this.currentJobController.getProofTypeName()} inputsUri=${truncateString(
-            job.inputsUri,
-          )}`,
-        );
-      }
-
-      if (this.idleTimer) {
-        this.instrumentation.recordIdleTime(this.idleTimer);
-      }
-      this.idleTimer = undefined;
-
-      this.currentJobController.start();
-    } catch (err) {
-      this.log.error(`Error in ProvingAgent: ${String(err)}`);
+    } else {
+      maybeJob = await this.broker.getProvingJob({ allowList: this.proofAllowList });
     }
-  };
+
+    if (!maybeJob) {
+      return;
+    }
+
+    let abortedProofJobId: string | undefined;
+    let abortedProofName: string | undefined;
+    if (this.currentJobController?.getStatus() === ProvingJobControllerStatus.PROVING) {
+      abortedProofJobId = this.currentJobController.getJobId();
+      abortedProofName = this.currentJobController.getProofTypeName();
+      this.currentJobController?.abort();
+    }
+
+    const { job, time } = maybeJob;
+    let inputs: ProvingJobInputs;
+    try {
+      inputs = await this.proofStore.getProofInput(job.inputsUri);
+    } catch (err) {
+      await this.broker.reportProvingJobError(job.id, 'Failed to load proof inputs', true);
+      return;
+    }
+
+    this.currentJobController = new ProvingJobController(
+      job.id,
+      inputs,
+      time,
+      this.circuitProver,
+      this.handleJobResult,
+    );
+
+    if (abortedProofJobId) {
+      this.log.info(
+        `Aborting job id=${abortedProofJobId} type=${abortedProofName} to start new job id=${this.currentJobController.getJobId()} type=${this.currentJobController.getProofTypeName()} inputsUri=${truncateString(
+          job.inputsUri,
+        )}`,
+      );
+    } else {
+      this.log.info(
+        `Starting job id=${this.currentJobController.getJobId()} type=${this.currentJobController.getProofTypeName()} inputsUri=${truncateString(
+          job.inputsUri,
+        )}`,
+      );
+    }
+
+    if (this.idleTimer) {
+      this.instrumentation.recordIdleTime(this.idleTimer);
+    }
+    this.idleTimer = undefined;
+
+    this.currentJobController.start();
+  }
 
   handleJobResult = async <T extends ProvingRequestType>(
     jobId: ProvingJobId,

--- a/yarn-project/prover-node/src/factory.ts
+++ b/yarn-project/prover-node/src/factory.ts
@@ -71,8 +71,8 @@ export async function createProverNode(
     maxParallelBlocksPerEpoch: config.proverNodeMaxParallelBlocksPerEpoch,
   };
 
-  const claimsMonitor = new ClaimsMonitor(publisher, proverNodeConfig);
-  const epochMonitor = new EpochMonitor(archiver, proverNodeConfig);
+  const claimsMonitor = new ClaimsMonitor(publisher, telemetry, proverNodeConfig);
+  const epochMonitor = new EpochMonitor(archiver, telemetry, proverNodeConfig);
 
   const rollupContract = publisher.getRollupContract();
   const walletClient = publisher.getClient();

--- a/yarn-project/prover-node/src/monitors/claims-monitor.test.ts
+++ b/yarn-project/prover-node/src/monitors/claims-monitor.test.ts
@@ -2,6 +2,7 @@ import { type EpochProofClaim } from '@aztec/circuit-types';
 import { EthAddress } from '@aztec/circuits.js';
 import { sleep } from '@aztec/foundation/sleep';
 import { type L1Publisher } from '@aztec/sequencer-client';
+import { NoopTelemetryClient } from '@aztec/telemetry-client/noop';
 
 import { type MockProxy, mock } from 'jest-mock-extended';
 
@@ -21,7 +22,7 @@ describe('ClaimsMonitor', () => {
     publisherAddress = EthAddress.random();
     l1Publisher.getSenderAddress.mockReturnValue(publisherAddress);
 
-    claimsMonitor = new ClaimsMonitor(l1Publisher, { pollingIntervalMs: 10 });
+    claimsMonitor = new ClaimsMonitor(l1Publisher, new NoopTelemetryClient(), { pollingIntervalMs: 10 });
   });
 
   afterEach(async () => {

--- a/yarn-project/prover-node/src/monitors/claims-monitor.ts
+++ b/yarn-project/prover-node/src/monitors/claims-monitor.ts
@@ -3,20 +3,28 @@ import { type EthAddress } from '@aztec/circuits.js';
 import { createLogger } from '@aztec/foundation/log';
 import { RunningPromise } from '@aztec/foundation/running-promise';
 import { type L1Publisher } from '@aztec/sequencer-client';
+import { type TelemetryClient, type Traceable, type Tracer, trackSpan } from '@aztec/telemetry-client';
 
 export interface ClaimsMonitorHandler {
   handleClaim(proofClaim: EpochProofClaim): Promise<void>;
 }
 
-export class ClaimsMonitor {
+export class ClaimsMonitor implements Traceable {
   private runningPromise: RunningPromise;
   private log = createLogger('prover-node:claims-monitor');
 
   private handler: ClaimsMonitorHandler | undefined;
   private lastClaimEpochNumber: bigint | undefined;
 
-  constructor(private readonly l1Publisher: L1Publisher, private options: { pollingIntervalMs: number }) {
-    this.runningPromise = new RunningPromise(this.work.bind(this), this.options.pollingIntervalMs);
+  public readonly tracer: Tracer;
+
+  constructor(
+    private readonly l1Publisher: L1Publisher,
+    telemetry: TelemetryClient,
+    private options: { pollingIntervalMs: number },
+  ) {
+    this.tracer = telemetry.getTracer('ClaimsMonitor');
+    this.runningPromise = new RunningPromise(this.work.bind(this), this.log, this.options.pollingIntervalMs);
   }
 
   public start(handler: ClaimsMonitorHandler) {
@@ -31,9 +39,11 @@ export class ClaimsMonitor {
     this.log.info('Stopped ClaimsMonitor');
   }
 
+  @trackSpan('ClaimsMonitor.work')
   public async work() {
     const proofClaim = await this.l1Publisher.getProofClaim();
     if (!proofClaim) {
+      this.log.trace(`Found no proof claim`);
       return;
     }
 

--- a/yarn-project/prover-node/src/monitors/epoch-monitor.test.ts
+++ b/yarn-project/prover-node/src/monitors/epoch-monitor.test.ts
@@ -1,5 +1,6 @@
 import { type L2BlockSource } from '@aztec/circuit-types';
 import { sleep } from '@aztec/foundation/sleep';
+import { NoopTelemetryClient } from '@aztec/telemetry-client/noop';
 
 import { type MockProxy, mock } from 'jest-mock-extended';
 
@@ -20,7 +21,7 @@ describe('EpochMonitor', () => {
       },
     });
 
-    epochMonitor = new EpochMonitor(l2BlockSource, { pollingIntervalMs: 10 });
+    epochMonitor = new EpochMonitor(l2BlockSource, new NoopTelemetryClient(), { pollingIntervalMs: 10 });
   });
 
   afterEach(async () => {

--- a/yarn-project/prover-node/src/monitors/epoch-monitor.ts
+++ b/yarn-project/prover-node/src/monitors/epoch-monitor.ts
@@ -1,22 +1,29 @@
 import { type L2BlockSource } from '@aztec/circuit-types';
 import { createLogger } from '@aztec/foundation/log';
 import { RunningPromise } from '@aztec/foundation/running-promise';
+import { type TelemetryClient, type Traceable, type Tracer, trackSpan } from '@aztec/telemetry-client';
 
 export interface EpochMonitorHandler {
   handleInitialEpochSync(epochNumber: bigint): Promise<void>;
   handleEpochCompleted(epochNumber: bigint): Promise<void>;
 }
 
-export class EpochMonitor {
+export class EpochMonitor implements Traceable {
   private runningPromise: RunningPromise;
   private log = createLogger('prover-node:epoch-monitor');
+  public readonly tracer: Tracer;
 
   private handler: EpochMonitorHandler | undefined;
 
   private latestEpochNumber: bigint | undefined;
 
-  constructor(private readonly l2BlockSource: L2BlockSource, private options: { pollingIntervalMs: number }) {
-    this.runningPromise = new RunningPromise(this.work.bind(this), this.options.pollingIntervalMs);
+  constructor(
+    private readonly l2BlockSource: L2BlockSource,
+    telemetry: TelemetryClient,
+    private options: { pollingIntervalMs: number },
+  ) {
+    this.tracer = telemetry.getTracer('EpochMonitor');
+    this.runningPromise = new RunningPromise(this.work.bind(this), this.log, this.options.pollingIntervalMs);
   }
 
   public start(handler: EpochMonitorHandler) {
@@ -30,6 +37,7 @@ export class EpochMonitor {
     this.log.info('Stopped EpochMonitor');
   }
 
+  @trackSpan('EpochMonitor.work')
   public async work() {
     if (!this.latestEpochNumber) {
       const epochNumber = await this.l2BlockSource.getL2EpochNumber();

--- a/yarn-project/prover-node/src/prover-node.test.ts
+++ b/yarn-project/prover-node/src/prover-node.test.ts
@@ -249,8 +249,9 @@ describe('prover-node', () => {
     let lastEpochComplete: bigint = 0n;
 
     beforeEach(() => {
-      claimsMonitor = new ClaimsMonitor(publisher, config);
-      epochMonitor = new EpochMonitor(l2BlockSource, config);
+      const telemetry = new NoopTelemetryClient();
+      claimsMonitor = new ClaimsMonitor(publisher, telemetry, config);
+      epochMonitor = new EpochMonitor(l2BlockSource, telemetry, config);
 
       l2BlockSource.isEpochComplete.mockImplementation(epochNumber =>
         Promise.resolve(epochNumber <= lastEpochComplete),

--- a/yarn-project/sequencer-client/src/sequencer/sequencer.ts
+++ b/yarn-project/sequencer-client/src/sequencer/sequencer.ts
@@ -192,7 +192,7 @@ export class Sequencer {
    * Starts the sequencer and moves to IDLE state.
    */
   public start() {
-    this.runningPromise = new RunningPromise(this.work.bind(this), this.pollingIntervalMs);
+    this.runningPromise = new RunningPromise(this.work.bind(this), this.log, this.pollingIntervalMs);
     this.setState(SequencerState.IDLE, 0n, true /** force */);
     this.runningPromise.start();
     this.log.info(`Sequencer started with address ${this.publisher.getSenderAddress().toString()}`);
@@ -339,6 +339,7 @@ export class Sequencer {
     this.setState(SequencerState.IDLE, 0n);
   }
 
+  @trackSpan('Sequencer.work')
   protected async work() {
     try {
       await this.doRealWork();

--- a/yarn-project/simulator/src/public/public_processor.ts
+++ b/yarn-project/simulator/src/public/public_processor.ts
@@ -26,7 +26,7 @@ import { padArrayEnd } from '@aztec/foundation/collection';
 import { createLogger } from '@aztec/foundation/log';
 import { Timer } from '@aztec/foundation/timer';
 import { ContractClassRegisteredEvent, ProtocolContractAddress } from '@aztec/protocol-contracts';
-import { Attributes, type TelemetryClient, type Tracer, trackSpan } from '@aztec/telemetry-client';
+import { Attributes, type TelemetryClient, type Traceable, type Tracer, trackSpan } from '@aztec/telemetry-client';
 
 import { computeFeePayerBalanceLeafSlot, computeFeePayerBalanceStorageSlot } from './fee_payment.js';
 import { WorldStateDB } from './public_db_sources.js';
@@ -76,7 +76,7 @@ export class PublicProcessorFactory {
  * Converts Txs lifted from the P2P module into ProcessedTx objects by executing
  * any public function calls in them. Txs with private calls only are unaffected.
  */
-export class PublicProcessor {
+export class PublicProcessor implements Traceable {
   private metrics: PublicProcessorMetrics;
   constructor(
     protected db: MerkleTreeWriteOperations,
@@ -118,80 +118,9 @@ export class PublicProcessor {
         break;
       }
       try {
-        const [processedTx, returnValues] = !tx.hasPublicCalls()
-          ? await this.processPrivateOnlyTx(tx)
-          : await this.processTxWithPublicCalls(tx);
-
-        this.log.verbose(
-          !tx.hasPublicCalls()
-            ? `Processed tx ${processedTx.hash} with no public calls`
-            : `Processed tx ${processedTx.hash} with ${tx.enqueuedPublicFunctionCalls.length} public calls`,
-          {
-            txHash: processedTx.hash,
-            txFee: processedTx.txEffect.transactionFee.toBigInt(),
-            revertCode: processedTx.txEffect.revertCode.getCode(),
-            revertReason: processedTx.revertReason,
-            gasUsed: processedTx.gasUsed,
-            publicDataWriteCount: processedTx.txEffect.publicDataWrites.length,
-            nullifierCount: processedTx.txEffect.nullifiers.length,
-            noteHashCount: processedTx.txEffect.noteHashes.length,
-            contractClassLogCount: processedTx.txEffect.contractClassLogs.getTotalLogCount(),
-            unencryptedLogCount: processedTx.txEffect.unencryptedLogs.getTotalLogCount(),
-            privateLogCount: processedTx.txEffect.privateLogs.length,
-            l2ToL1MessageCount: processedTx.txEffect.l2ToL1Msgs.length,
-          },
-        );
-
-        // Commit the state updates from this transaction
-        await this.worldStateDB.commit();
-
-        // Re-validate the transaction
-        if (txValidator) {
-          // Only accept processed transactions that are not double-spends,
-          // public functions emitting nullifiers would pass earlier check but fail here.
-          // Note that we're checking all nullifiers generated in the private execution twice,
-          // we could store the ones already checked and skip them here as an optimization.
-          const [_, invalid] = await txValidator.validateTxs([processedTx]);
-          if (invalid.length) {
-            throw new Error(`Transaction ${invalid[0].hash} invalid after processing public functions`);
-          }
-        }
-        // if we were given a handler then send the transaction to it for block building or proving
-        if (processedTxHandler) {
-          await processedTxHandler.addNewTx(processedTx);
-        }
-        // Update the state so that the next tx in the loop has the correct .startState
-        // NB: before this change, all .startStates were actually incorrect, but the issue was never caught because we either:
-        // a) had only 1 tx with public calls per block, so this loop had len 1
-        // b) always had a txHandler with the same db passed to it as this.db, which updated the db in buildBaseRollupHints in this loop
-        // To see how this ^ happens, move back to one shared db in test_context and run orchestrator_multi_public_functions.test.ts
-        // The below is taken from buildBaseRollupHints:
-        await this.db.appendLeaves(
-          MerkleTreeId.NOTE_HASH_TREE,
-          padArrayEnd(processedTx.txEffect.noteHashes, Fr.ZERO, MAX_NOTE_HASHES_PER_TX),
-        );
-        try {
-          await this.db.batchInsert(
-            MerkleTreeId.NULLIFIER_TREE,
-            padArrayEnd(processedTx.txEffect.nullifiers, Fr.ZERO, MAX_NULLIFIERS_PER_TX).map(n => n.toBuffer()),
-            NULLIFIER_SUBTREE_HEIGHT,
-          );
-        } catch (error) {
-          if (txValidator) {
-            // Ideally the validator has already caught this above, but just in case:
-            throw new Error(`Transaction ${processedTx.hash} invalid after processing public functions`);
-          } else {
-            // We have no validator and assume this call should blindly process txs with duplicates being caught later
-            this.log.warn(`Detected duplicate nullifier after public processing for: ${processedTx.hash}.`);
-          }
-        }
-
-        await this.db.sequentialInsert(
-          MerkleTreeId.PUBLIC_DATA_TREE,
-          processedTx.txEffect.publicDataWrites.map(x => x.toBuffer()),
-        );
+        const [processedTx, returnValues] = await this.processTx(tx, processedTxHandler, txValidator);
         result.push(processedTx);
-        returns = returns.concat(returnValues ?? []);
+        returns = returns.concat(returnValues);
       } catch (err: any) {
         const errorMessage = err instanceof Error ? err.message : 'Unknown error';
         this.log.warn(`Failed to process tx ${tx.getTxHash()}: ${errorMessage} ${err?.stack}`);
@@ -205,6 +134,88 @@ export class PublicProcessor {
     }
 
     return [result, failed, returns];
+  }
+
+  @trackSpan('PublicProcessor.processTx', tx => ({ [Attributes.TX_HASH]: tx.tryGetTxHash()?.toString() }))
+  private async processTx(
+    tx: Tx,
+    processedTxHandler?: ProcessedTxHandler,
+    txValidator?: TxValidator<ProcessedTx>,
+  ): Promise<[ProcessedTx, NestedProcessReturnValues[]]> {
+    const [processedTx, returnValues] = !tx.hasPublicCalls()
+      ? await this.processPrivateOnlyTx(tx)
+      : await this.processTxWithPublicCalls(tx);
+
+    this.log.verbose(
+      !tx.hasPublicCalls()
+        ? `Processed tx ${processedTx.hash} with no public calls`
+        : `Processed tx ${processedTx.hash} with ${tx.enqueuedPublicFunctionCalls.length} public calls`,
+      {
+        txHash: processedTx.hash,
+        txFee: processedTx.txEffect.transactionFee.toBigInt(),
+        revertCode: processedTx.txEffect.revertCode.getCode(),
+        revertReason: processedTx.revertReason,
+        gasUsed: processedTx.gasUsed,
+        publicDataWriteCount: processedTx.txEffect.publicDataWrites.length,
+        nullifierCount: processedTx.txEffect.nullifiers.length,
+        noteHashCount: processedTx.txEffect.noteHashes.length,
+        contractClassLogCount: processedTx.txEffect.contractClassLogs.getTotalLogCount(),
+        unencryptedLogCount: processedTx.txEffect.unencryptedLogs.getTotalLogCount(),
+        privateLogCount: processedTx.txEffect.privateLogs.length,
+        l2ToL1MessageCount: processedTx.txEffect.l2ToL1Msgs.length,
+      },
+    );
+
+    // Commit the state updates from this transaction
+    await this.worldStateDB.commit();
+
+    // Re-validate the transaction
+    if (txValidator) {
+      // Only accept processed transactions that are not double-spends,
+      // public functions emitting nullifiers would pass earlier check but fail here.
+      // Note that we're checking all nullifiers generated in the private execution twice,
+      // we could store the ones already checked and skip them here as an optimization.
+      const [_, invalid] = await txValidator.validateTxs([processedTx]);
+      if (invalid.length) {
+        throw new Error(`Transaction ${invalid[0].hash} invalid after processing public functions`);
+      }
+    }
+    // if we were given a handler then send the transaction to it for block building or proving
+    if (processedTxHandler) {
+      await processedTxHandler.addNewTx(processedTx);
+    }
+    // Update the state so that the next tx in the loop has the correct .startState
+    // NB: before this change, all .startStates were actually incorrect, but the issue was never caught because we either:
+    // a) had only 1 tx with public calls per block, so this loop had len 1
+    // b) always had a txHandler with the same db passed to it as this.db, which updated the db in buildBaseRollupHints in this loop
+    // To see how this ^ happens, move back to one shared db in test_context and run orchestrator_multi_public_functions.test.ts
+    // The below is taken from buildBaseRollupHints:
+    await this.db.appendLeaves(
+      MerkleTreeId.NOTE_HASH_TREE,
+      padArrayEnd(processedTx.txEffect.noteHashes, Fr.ZERO, MAX_NOTE_HASHES_PER_TX),
+    );
+    try {
+      await this.db.batchInsert(
+        MerkleTreeId.NULLIFIER_TREE,
+        padArrayEnd(processedTx.txEffect.nullifiers, Fr.ZERO, MAX_NULLIFIERS_PER_TX).map(n => n.toBuffer()),
+        NULLIFIER_SUBTREE_HEIGHT,
+      );
+    } catch (error) {
+      if (txValidator) {
+        // Ideally the validator has already caught this above, but just in case:
+        throw new Error(`Transaction ${processedTx.hash} invalid after processing public functions`);
+      } else {
+        // We have no validator and assume this call should blindly process txs with duplicates being caught later
+        this.log.warn(`Detected duplicate nullifier after public processing for: ${processedTx.hash}.`);
+      }
+    }
+
+    await this.db.sequentialInsert(
+      MerkleTreeId.PUBLIC_DATA_TREE,
+      processedTx.txEffect.publicDataWrites.map(x => x.toBuffer()),
+    );
+
+    return [processedTx, returnValues ?? []];
   }
 
   /**

--- a/yarn-project/telemetry-client/package.json
+++ b/yarn-project/telemetry-client/package.json
@@ -27,6 +27,7 @@
     "!*.test.*"
   ],
   "dependencies": {
+    "@aztec/circuit-types": "workspace:^",
     "@aztec/foundation": "workspace:^",
     "@opentelemetry/api": "^1.9.0",
     "@opentelemetry/api-logs": "^0.55.0",

--- a/yarn-project/telemetry-client/src/attributes.ts
+++ b/yarn-project/telemetry-client/src/attributes.ts
@@ -72,6 +72,8 @@ export const L1_SENDER = 'aztec.l1.sender';
 export const TX_PHASE_NAME = 'aztec.tx.phase_name';
 /** The proving job type */
 export const PROVING_JOB_TYPE = 'aztec.proving.job_type';
+/** The proving job id */
+export const PROVING_JOB_ID = 'aztec.proving.job_id';
 
 export const MERKLE_TREE_NAME = 'aztec.merkle_tree.name';
 /** The prover-id in a root rollup proof. */
@@ -88,6 +90,9 @@ export const SIMULATOR_PHASE = 'aztec.simulator.phase';
 export const TARGET_ADDRESS = 'aztec.address.target';
 export const SENDER_ADDRESS = 'aztec.address.sender';
 export const MANA_USED = 'aztec.mana.used';
+
+/** Whether a sync process is the initial run, which is usually slower than iterative ones. */
+export const INITIAL_SYNC = 'aztec.initial_sync';
 
 /** Identifier for the tables in a world state DB */
 export const WS_DB_DATA_TYPE = 'aztec.world_state.db_type';

--- a/yarn-project/telemetry-client/src/index.ts
+++ b/yarn-project/telemetry-client/src/index.ts
@@ -3,3 +3,4 @@ export * from './histogram_utils.js';
 export * from './with_tracer.js';
 export * from './prom_otel_adapter.js';
 export * from './lmdb_metrics.js';
+export * from './wrappers/index.js';

--- a/yarn-project/telemetry-client/src/wrappers/index.ts
+++ b/yarn-project/telemetry-client/src/wrappers/index.ts
@@ -1,0 +1,1 @@
+export * from './l2_block_stream.js';

--- a/yarn-project/telemetry-client/src/wrappers/l2_block_stream.ts
+++ b/yarn-project/telemetry-client/src/wrappers/l2_block_stream.ts
@@ -1,0 +1,37 @@
+import {
+  type L2BlockSource,
+  L2BlockStream,
+  type L2BlockStreamEventHandler,
+  type L2BlockStreamLocalDataProvider,
+} from '@aztec/circuit-types';
+import { createLogger } from '@aztec/foundation/log';
+import { type Traceable, type Tracer, trackSpan } from '@aztec/telemetry-client';
+
+/** Extends an L2BlockStream with a tracer to create a new trace per iteration. */
+export class TraceableL2BlockStream extends L2BlockStream implements Traceable {
+  constructor(
+    l2BlockSource: Pick<L2BlockSource, 'getBlocks' | 'getBlockHeader' | 'getL2Tips'>,
+    localData: L2BlockStreamLocalDataProvider,
+    handler: L2BlockStreamEventHandler,
+    public readonly tracer: Tracer,
+    private readonly name: string = 'L2BlockStream',
+    log = createLogger('types:block_stream'),
+    opts: {
+      proven?: boolean;
+      pollIntervalMS?: number;
+      batchSize?: number;
+      startingBlock?: number;
+    } = {},
+  ) {
+    super(l2BlockSource, localData, handler, log, opts);
+  }
+
+  // We need to use a non-arrow function to be able to access `this`
+  // See https://www.typescriptlang.org/docs/handbook/2/functions.html#declaring-this-in-a-function
+  @trackSpan(function () {
+    return `${this!.name}.work`;
+  })
+  override work() {
+    return super.work();
+  }
+}

--- a/yarn-project/telemetry-client/tsconfig.json
+++ b/yarn-project/telemetry-client/tsconfig.json
@@ -7,6 +7,9 @@
   },
   "references": [
     {
+      "path": "../circuit-types"
+    },
+    {
       "path": "../foundation"
     }
   ],

--- a/yarn-project/validator-client/src/validator.ts
+++ b/yarn-project/validator-client/src/validator.ts
@@ -86,9 +86,15 @@ export class ValidatorClient extends WithTracer implements Validator {
     this.validationService = new ValidationService(keyStore);
 
     // Refresh epoch cache every second to trigger commiteeChanged event
-    this.epochCacheUpdateLoop = new RunningPromise(async () => {
-      await this.epochCache.getCommittee().catch(err => log.error('Error updating validator committee', err));
-    }, 1000);
+    this.epochCacheUpdateLoop = new RunningPromise(
+      () =>
+        this.epochCache
+          .getCommittee()
+          .then(() => {})
+          .catch(err => log.error('Error updating validator committee', err)),
+      log,
+      1000,
+    );
 
     // Listen to commiteeChanged event to alert operator when their validator has entered the committee
     this.epochCache.on('committeeChanged', (newCommittee, epochNumber) => {

--- a/yarn-project/world-state/src/synchronizer/instrumentation.ts
+++ b/yarn-project/world-state/src/synchronizer/instrumentation.ts
@@ -15,7 +15,7 @@ export class WorldStateInstrumentation {
   private dbNumItems: Gauge;
   private dbUsedSize: Gauge;
 
-  constructor(telemetry: TelemetryClient, private log = createLogger('world-state:instrumentation')) {
+  constructor(public readonly telemetry: TelemetryClient, private log = createLogger('world-state:instrumentation')) {
     const meter = telemetry.getMeter('World State');
     this.dbMapSize = meter.createGauge(`aztec.world_state.db_map_size`, {
       description: `The current configured map size for each merkle tree`,

--- a/yarn-project/yarn.lock
+++ b/yarn-project/yarn.lock
@@ -343,6 +343,7 @@ __metadata:
     "@aztec/foundation": "workspace:^"
     "@aztec/noir-contracts.js": "workspace:^"
     "@aztec/protocol-contracts": "workspace:^"
+    "@aztec/telemetry-client": "workspace:^"
     "@aztec/types": "workspace:^"
     "@jest/globals": ^29.5.0
     "@types/jest": ^29.5.0
@@ -1237,6 +1238,7 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "@aztec/telemetry-client@workspace:telemetry-client"
   dependencies:
+    "@aztec/circuit-types": "workspace:^"
     "@aztec/foundation": "workspace:^"
     "@jest/globals": ^29.5.0
     "@opentelemetry/api": ^1.9.0


### PR DESCRIPTION
- Adds a try/catch to every iteration of a running promise, and logs any exceptions
- Adds a `trackSpan` to every running promise job
- Adds a `simulatePublicCalls` to the aztec node server just because