### PR TITLE
chore: fix public keys deserialization

### DIFF
--- a/yarn-project/circuits.js/src/types/public_keys.test.ts
+++ b/yarn-project/circuits.js/src/types/public_keys.test.ts
@@ -4,6 +4,19 @@ import { updateInlineTestData } from '@aztec/foundation/testing';
 import { PublicKeys } from './public_keys.js';
 
 describe('PublicKeys', () => {
+  it('serialization and deserialization', () => {
+    const pk = PublicKeys.random();
+    const serialized = pk.toString();
+    const deserialized = PublicKeys.fromString(serialized);
+
+    expect(pk).toEqual(deserialized);
+
+    const serializedWithoutPrefix = serialized.slice(2);
+    const deserializedWithoutPrefix = PublicKeys.fromString(serializedWithoutPrefix);
+
+    expect(pk).toEqual(deserializedWithoutPrefix);
+  });
+
   it('computes public keys hash', () => {
     const keys = new PublicKeys(
       new Point(new Fr(1n), new Fr(2n), false),

--- a/yarn-project/circuits.js/src/types/public_keys.ts
+++ b/yarn-project/circuits.js/src/types/public_keys.ts
@@ -2,7 +2,7 @@ import { poseidon2HashWithSeparator } from '@aztec/foundation/crypto';
 import { Fr, Point } from '@aztec/foundation/fields';
 import { schemas } from '@aztec/foundation/schemas';
 import { BufferReader, FieldReader, serializeToBuffer } from '@aztec/foundation/serialize';
-import { bufferToHex } from '@aztec/foundation/string';
+import { bufferToHex, withoutHexPrefix } from '@aztec/foundation/string';
 import { type FieldsOf } from '@aztec/foundation/types';
 
 import { z } from 'zod';
@@ -189,6 +189,6 @@ export class PublicKeys {
   }
 
   static fromString(keys: string) {
-    return PublicKeys.fromBuffer(Buffer.from(keys, 'hex'));
+    return PublicKeys.fromBuffer(Buffer.from(withoutHexPrefix(keys), 'hex'));
   }
 }


### PR DESCRIPTION
This fixes public keys deserialization by allowing it to be a prepended hex string.
