### PR TITLE
chore(ci): reenable `rerun-check` job

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1062,7 +1062,7 @@ jobs:
       actions: write
     needs:
       - merge-check
-    if: github.event.pull_request.draft == false && !cancelled() && !true
+    if: github.event.pull_request.draft == false && !cancelled()
     steps:
       - name: Check for Rerun
         env:


### PR DESCRIPTION
This was accidentally disabled in https://github.com/AztecProtocol/aztec-packages/pull/10629