### PR TITLE
chore(ci): remove duplicated install of playwright

### DIFF
--- a/boxes/Earthfile
+++ b/boxes/Earthfile
@@ -52,7 +52,6 @@ boxes:
     RUN npx playwright install --with-deps
     COPY --dir +build/usr/src /usr
     WORKDIR /usr/src/boxes
-    RUN yarn install-browsers
     ENTRYPOINT ["/bin/sh", "-c"]
 
 npx:


### PR DESCRIPTION
`yarn install-browsers` runs `playwright install --with-deps` but 3 lines above we're running... `playwright install --with-deps`