### PR TITLE
chore: better reqresp logging + handle empty responses in snappy

### DIFF
--- a/yarn-project/p2p/src/errors/reqresp.error.ts
+++ b/yarn-project/p2p/src/errors/reqresp.error.ts
@@ -19,3 +19,17 @@ export class CollectiveReqRespTimeoutError extends Error {
     super(`Request to all peers timed out`);
   }
 }
+
+/** Invalid response error
+ *
+ * This error will be thrown when a response is received that is not valid.
+ *
+ * This error does not need to be punished as message validators will handle punishing invalid
+ * requests
+ * @category Errors
+ */
+export class InvalidResponseError extends Error {
+  constructor() {
+    super(`Invalid response received`);
+  }
+}

--- a/yarn-project/p2p/src/errors/reqresp.error.ts
+++ b/yarn-project/p2p/src/errors/reqresp.error.ts
@@ -3,7 +3,7 @@
  * This error will be thrown when a request to a specific peer times out.
  * @category Errors
  */
-export class IndiviualReqRespTimeoutError extends Error {
+export class IndividualReqRespTimeoutError extends Error {
   constructor() {
     super(`Request to peer timed out`);
   }

--- a/yarn-project/p2p/src/service/encoding.ts
+++ b/yarn-project/p2p/src/service/encoding.ts
@@ -49,13 +49,31 @@ export function getMsgIdFn(message: Message) {
   return sha256(Buffer.concat(vec)).subarray(0, 20);
 }
 
+/**
+ * Snappy transform for libp2p gossipsub
+ */
 export class SnappyTransform implements DataTransform {
+  // Topic string included to satisfy DataTransform interface
   inboundTransform(_topicStr: string, data: Uint8Array): Uint8Array {
-    const uncompressed = Buffer.from(uncompressSync(Buffer.from(data), { asBuffer: true }));
-    return new Uint8Array(uncompressed);
+    return this.inboundTransformNoTopic(Buffer.from(data));
   }
 
+  public inboundTransformNoTopic(data: Buffer): Buffer {
+    if (data.length === 0) {
+      return data;
+    }
+    return Buffer.from(uncompressSync(data));
+  }
+
+  // Topic string included to satisfy DataTransform interface
   outboundTransform(_topicStr: string, data: Uint8Array): Uint8Array {
-    return new Uint8Array(compressSync(Buffer.from(data)));
+    return this.outboundTransformNoTopic(Buffer.from(data));
+  }
+
+  public outboundTransformNoTopic(data: Buffer): Buffer {
+    if (data.length === 0) {
+      return data;
+    }
+    return Buffer.from(compressSync(data));
   }
 }

--- a/yarn-project/p2p/src/service/encoding.ts
+++ b/yarn-project/p2p/src/service/encoding.ts
@@ -62,7 +62,7 @@ export class SnappyTransform implements DataTransform {
     if (data.length === 0) {
       return data;
     }
-    return Buffer.from(uncompressSync(data));
+    return Buffer.from(uncompressSync(data, { asBuffer: true }));
   }
 
   // Topic string included to satisfy DataTransform interface

--- a/yarn-project/p2p/src/service/reqresp/reqresp.test.ts
+++ b/yarn-project/p2p/src/service/reqresp/reqresp.test.ts
@@ -4,7 +4,7 @@ import { sleep } from '@aztec/foundation/sleep';
 import { describe, expect, it, jest } from '@jest/globals';
 import { type MockProxy, mock } from 'jest-mock-extended';
 
-import { CollectiveReqRespTimeoutError, IndiviualReqRespTimeoutError } from '../../errors/reqresp.error.js';
+import { CollectiveReqRespTimeoutError, IndividualReqRespTimeoutError } from '../../errors/reqresp.error.js';
 import {
   MOCK_SUB_PROTOCOL_HANDLERS,
   MOCK_SUB_PROTOCOL_VALIDATORS,
@@ -213,7 +213,7 @@ describe('ReqResp', () => {
       const peerId = nodes[1].p2p.peerId.toString();
       expect(loggerSpy).toHaveBeenCalledWith(
         `Timeout error: ${
-          new IndiviualReqRespTimeoutError().message
+          new IndividualReqRespTimeoutError().message
         } | peerId: ${peerId.toString()} | subProtocol: ${TX_REQ_PROTOCOL}`,
       );
 

--- a/yarn-project/p2p/src/service/reqresp/reqresp.test.ts
+++ b/yarn-project/p2p/src/service/reqresp/reqresp.test.ts
@@ -92,8 +92,20 @@ describe('ReqResp', () => {
     const res = await nodes[0].req.sendRequest(PING_PROTOCOL, PING_REQUEST);
 
     // We expect the logger to have been called twice with the peer ids citing the inability to connect
-    expect(loggerSpy).toHaveBeenCalledWith(`Connection reset: ${nodes[1].p2p.peerId.toString()}`);
-    expect(loggerSpy).toHaveBeenCalledWith(`Connection reset: ${nodes[2].p2p.peerId.toString()}`);
+    expect(loggerSpy).toHaveBeenCalledWith(
+      expect.stringContaining(`Connection reset: ${nodes[1].p2p.peerId.toString()}`),
+      {
+        peerId: nodes[1].p2p.peerId.toString(),
+        subProtocol: PING_PROTOCOL,
+      },
+    );
+    expect(loggerSpy).toHaveBeenCalledWith(
+      expect.stringContaining(`Connection reset: ${nodes[2].p2p.peerId.toString()}`),
+      {
+        peerId: nodes[2].p2p.peerId.toString(),
+        subProtocol: PING_PROTOCOL,
+      },
+    );
 
     expect(res?.toBuffer().toString('utf-8')).toEqual('pong');
   });
@@ -117,7 +129,7 @@ describe('ReqResp', () => {
 
     // Make sure the error message is logged
     const errorMessage = `Rate limit exceeded for ${PING_PROTOCOL} from ${nodes[0].p2p.peerId.toString()}`;
-    expect(loggerSpy).toHaveBeenCalledWith(errorMessage);
+    expect(loggerSpy).toHaveBeenCalledWith(expect.stringContaining(errorMessage));
   });
 
   describe('Tx req protocol', () => {
@@ -214,7 +226,11 @@ describe('ReqResp', () => {
       expect(loggerSpy).toHaveBeenCalledWith(
         `Timeout error: ${
           new IndividualReqRespTimeoutError().message
-        } | peerId: ${peerId.toString()} | subProtocol: ${TX_REQ_PROTOCOL}`,
+        } | peerId: ${peerId} | subProtocol: ${TX_REQ_PROTOCOL}`,
+        expect.objectContaining({
+          peerId: peerId,
+          subProtocol: TX_REQ_PROTOCOL,
+        }),
       );
 
       // Expect the peer to be penalized for timing out


### PR DESCRIPTION
Catch all error handling meant that some things were logged as errors when really they were not, such as the snappy compressing an empty item.