### PR TITLE
fix: add methods to pxe that fetch contract instance and artifact from node instead of db

### DIFF
--- a/yarn-project/aztec-node/src/aztec-node/server.ts
+++ b/yarn-project/aztec-node/src/aztec-node/server.ts
@@ -332,6 +332,10 @@ export class AztecNodeService implements AztecNode {
     return this.contractDataSource.getContract(address);
   }
 
+  public getContractArtifact(address: AztecAddress): Promise<ContractArtifact | undefined> {
+    return this.contractDataSource.getContractArtifact(address);
+  }
+
   /**
    * Retrieves all private logs from up to `limit` blocks, starting from the block number `from`.
    * @param from - The block number from which to begin retrieving logs.

--- a/yarn-project/circuit-types/src/interfaces/aztec-node.ts
+++ b/yarn-project/circuit-types/src/interfaces/aztec-node.ts
@@ -410,6 +410,12 @@ export interface AztecNode
   getContractClass(id: Fr): Promise<ContractClassPublic | undefined>;
 
   /**
+   * Returns a publicly deployed contract artifact given its address.
+   * @param address - Address of the deployed contract.
+   */
+  getContractArtifact(address: AztecAddress): Promise<ContractArtifact | undefined>;
+
+  /**
    * Returns a publicly deployed contract instance given its address.
    * @param address - Address of the deployed contract.
    */
@@ -569,6 +575,8 @@ export const AztecNodeApiSchema: ApiSchemaFor<AztecNode> = {
   setConfig: z.function().args(SequencerConfigSchema.merge(ProverConfigSchema).partial()).returns(z.void()),
 
   getContractClass: z.function().args(schemas.Fr).returns(ContractClassPublicSchema.optional()),
+
+  getContractArtifact: z.function().args(schemas.AztecAddress).returns(ContractArtifactSchema.optional()),
 
   getContract: z.function().args(schemas.AztecAddress).returns(ContractInstanceWithAddressSchema.optional()),
 

--- a/yarn-project/circuit-types/src/interfaces/pxe.ts
+++ b/yarn-project/circuit-types/src/interfaces/pxe.ts
@@ -372,6 +372,19 @@ export interface PXE {
    */
   getContractArtifact(id: Fr): Promise<ContractArtifact | undefined>;
 
+
+  /**
+   * Returns a contract instance from the node given its address.
+   * @param address - Address of the deployed contract.
+   */
+  getContractInstanceFromNode(address: AztecAddress): Promise<ContractInstanceWithAddress | undefined>;
+
+  /**
+   * Returns a contract artifact from the node given its address.
+   * @param address - Address of the deployed contract.
+   */
+  getContractArtifactFromNode(address: AztecAddress): Promise<ContractArtifact | undefined>;
+
   /**
    * Queries the node to check whether the contract class with the given id has been publicly registered.
    * TODO(@spalladino): This method is strictly needed to decide whether to publicly register a class or not
@@ -534,6 +547,14 @@ export const PXESchema: ApiSchemaFor<PXE> = {
   getContractArtifact: z
     .function()
     .args(schemas.Fr)
+    .returns(z.union([ContractArtifactSchema, z.undefined()])),
+  getContractInstanceFromNode: z
+    .function()
+    .args(schemas.AztecAddress)
+    .returns(z.union([ContractInstanceWithAddressSchema, z.undefined()])),
+  getContractArtifactFromNode: z
+    .function()
+    .args(schemas.AztecAddress)
     .returns(z.union([ContractArtifactSchema, z.undefined()])),
   isContractClassPubliclyRegistered: z.function().args(schemas.Fr).returns(z.boolean()),
   isContractPubliclyDeployed: z.function().args(schemas.AztecAddress).returns(z.boolean()),

--- a/yarn-project/pxe/src/pxe_service/pxe_service.ts
+++ b/yarn-project/pxe/src/pxe_service/pxe_service.ts
@@ -150,6 +150,14 @@ export class PXEService implements PXE {
     return this.db.getContractArtifact(id);
   }
 
+  public async getContractInstanceFromNode(address: AztecAddress): Promise<ContractInstanceWithAddress | undefined> {
+    return await this.node.getContract(address);
+  }
+
+  public async getContractArtifactFromNode(address: AztecAddress): Promise<ContractArtifact | undefined> {
+    return await this.node.getContractArtifact(address);
+  }
+
   public async registerAccount(secretKey: Fr, partialAddress: PartialAddress): Promise<CompleteAddress> {
     const accounts = await this.keyStore.getAccounts();
     const accountCompleteAddress = await this.keyStore.addAccount(secretKey, partialAddress);


### PR DESCRIPTION
[Edited by Rahul]:
`pxe.registerContract` requires a contract instance. To add the instance of a new contract is a bit cumbersome. 

`pxe.getContractInstance(contractAddress)` only checks the local DB so ofcourse gives `undefined` for any new contracts (which is majority of the cases outside of sandbox).

Then the only to get the instance today is `getContractInstanceFromDeployParams` for which you need to pass `deployment salt, constructor args, public keys, deployer wallet address` which wallets won't know

The right solution is `pxe.getContractInstance()` should fetch data from the node/archiver which anyway stores this data in the contract_instance_store.

-----
[ Original content]:
Related to [this discord post](https://discord.com/channels/1144692727120937080/1315691530471739452). 

Currently, PXE doesn't have an easy way to register ( import ) an existing contract that's been deployed in other PXEs. Contract instance, one of the `pxe.registerContract()`'s param, has to be manually reconstructed which requires several params such as, salt, constructor args, public keys, deployer wallet address, etc. 

*`pxe.getContractInstance()` only returns instance stored in db if it's already been registered, or undefined.

Since these info is stored in the node, it'd be really helpful for app devs if it can be fetched from node via PXE service. Then, we don't have to hard-code them or run server that holds these information. 

### Added Methods
- [pxe_service.ts](https://github.com/AztecProtocol/aztec-packages/blob/996d9214aaf67d48673bab6554fafbc794e7afa2/yarn-project/pxe/src/pxe_service/pxe_service.ts):
```ts
  public async getContractInstanceFromNode(address: AztecAddress): Promise<ContractInstanceWithAddress | undefined> {
    return await this.node.getContract(address);
  }

  public async getContractArtifactFromNode(address: AztecAddress): Promise<ContractArtifact | undefined> {
    return await this.node.getContractArtifact(address);
  }
```

- [aztec-node/server.ts](https://github.com/AztecProtocol/aztec-packages/blob/996d9214aaf67d48673bab6554fafbc794e7afa2/yarn-project/aztec-node/src/aztec-node/server.ts):
```ts
  public getContractArtifact(address: AztecAddress): Promise<ContractArtifact | undefined> {
    return this.contractDataSource.getContractArtifact(address);
  }
```
