### PR TITLE
chore: reduce bb_prover_full_rollup to a single block epoch test

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -213,7 +213,7 @@ jobs:
 
   # all the non-bench end-to-end integration tests for aztec
   e2e:
-    needs: [build, e2e-test-gate, configure]
+    needs: [build, configure]
     if: needs.configure.outputs.non-docs == 'true'
     runs-on: ubuntu-20.04
     strategy:

--- a/yarn-project/prover-client/src/test/bb_prover_full_rollup.test.ts
+++ b/yarn-project/prover-client/src/test/bb_prover_full_rollup.test.ts
@@ -32,7 +32,7 @@ describe('prover/bb_prover/full-rollup', () => {
 
   it.each([
     [1, 1, 0, 2], // Epoch with a single block, requires one padding block proof
-    [2, 2, 0, 2], // Full epoch with two blocks
+    // [2, 2, 0, 2], // Full epoch with two blocks // TODO(#10678) disabled for time x resource usage on main runner
     // [2, 3, 0, 2], // Epoch with two blocks but the block merge tree was assembled as with 3 leaves, requires one padding block proof; commented out to reduce running time
   ])(
     'proves a private-only epoch with %i/%i blocks with %i/%i non-empty txs each',


### PR DESCRIPTION
This reduces CI burden on the main runner as proving times have gone up a lot. This should happen outside of PRs otherwise, e.g. nightly
Related https://github.com/AztecProtocol/aztec-packages/issues/10678