### PR TITLE
chore: added package version string for sandbox

### DIFF
--- a/yarn-project/aztec/src/cli/cli.ts
+++ b/yarn-project/aztec/src/cli/cli.ts
@@ -44,7 +44,8 @@ export function injectAztecCommands(program: Command, userLog: LogFn, debugLogge
 
     if (options.sandbox) {
       const sandboxOptions = extractNamespacedOptions(options, 'sandbox');
-      userLog(`${splash}\n${github}\n\n`);
+      const packageVersionString = `aztec-packages version: ${process.env.npm_package_version}`;
+      userLog(`${splash}\n${github}\n${packageVersionString}\n\n`);
       userLog(`Setting up Aztec Sandbox, please stand by...`);
       const { aztecNodeConfig, node, pxe, stop } = await createSandbox({
         enableGas: sandboxOptions.enableGas,


### PR DESCRIPTION
resolves #10686 

I've only added the version to when running the Sandbox since I have not run the node in any other mode. But this would probably help when running a node as well.