### PR TITLE
chore: Remove sinon in favor of a date provider

### DIFF
--- a/yarn-project/aztec-node/src/aztec-node/server.ts
+++ b/yarn-project/aztec-node/src/aztec-node/server.ts
@@ -58,7 +58,7 @@ import { type ContractArtifact } from '@aztec/foundation/abi';
 import { AztecAddress } from '@aztec/foundation/aztec-address';
 import { padArrayEnd } from '@aztec/foundation/collection';
 import { type Logger, createLogger } from '@aztec/foundation/log';
-import { Timer } from '@aztec/foundation/timer';
+import { DateProvider, Timer } from '@aztec/foundation/timer';
 import { type AztecKVStore } from '@aztec/kv-store';
 import { openTmpStore } from '@aztec/kv-store/lmdb';
 import { SHA256Trunc, StandardTree, UnbalancedTree } from '@aztec/merkle-tree';
@@ -136,10 +136,12 @@ export class AztecNodeService implements AztecNode {
       telemetry?: TelemetryClient;
       logger?: Logger;
       publisher?: L1Publisher;
+      dateProvider?: DateProvider;
     } = {},
   ): Promise<AztecNodeService> {
     const telemetry = deps.telemetry ?? new NoopTelemetryClient();
     const log = deps.logger ?? createLogger('node');
+    const dateProvider = deps.dateProvider ?? new DateProvider();
     const ethereumChain = createEthereumChain(config.l1RpcUrl, config.l1ChainId);
     //validate that the actual chain id matches that specified in configuration
     if (config.l1ChainId !== ethereumChain.chainInfo.id) {
@@ -152,7 +154,8 @@ export class AztecNodeService implements AztecNode {
 
     // we identify the P2P transaction protocol by using the rollup contract address.
     // this may well change in future
-    config.transactionProtocol = `/aztec/tx/${config.l1Contracts.rollupAddress.toString()}`;
+    const rollupAddress = config.l1Contracts.rollupAddress;
+    config.transactionProtocol = `/aztec/tx/${rollupAddress.toString()}`;
 
     // now create the merkle trees and the world state synchronizer
     const worldStateSynchronizer = await createWorldStateSynchronizer(config, archiver, telemetry);
@@ -167,7 +170,7 @@ export class AztecNodeService implements AztecNode {
     // start both and wait for them to sync from the block source
     await Promise.all([p2pClient.start(), worldStateSynchronizer.start()]);
 
-    const validatorClient = await createValidatorClient(config, config.l1Contracts.rollupAddress, p2pClient, telemetry);
+    const validatorClient = await createValidatorClient(config, rollupAddress, { p2pClient, telemetry, dateProvider });
 
     // now create the sequencer
     const sequencer = config.disableValidator

--- a/yarn-project/end-to-end/package.json
+++ b/yarn-project/end-to-end/package.json
@@ -98,7 +98,6 @@
   "devDependencies": {
     "0x": "^5.7.0",
     "@jest/globals": "^29.5.0",
-    "@sinonjs/fake-timers": "^13.0.5",
     "@types/jest": "^29.5.0",
     "@types/js-yaml": "^4.0.9",
     "@types/lodash.chunk": "^4.2.9",

--- a/yarn-project/end-to-end/src/e2e_p2p/gossip_network.test.ts
+++ b/yarn-project/end-to-end/src/e2e_p2p/gossip_network.test.ts
@@ -76,6 +76,7 @@ describe('e2e_p2p_network', () => {
     t.logger.info('Creating nodes');
     nodes = await createNodes(
       t.ctx.aztecNodeConfig,
+      t.ctx.dateProvider,
       t.bootstrapNodeEnr,
       NUM_NODES,
       BOOT_NODE_UDP_PORT,

--- a/yarn-project/end-to-end/src/e2e_p2p/p2p_network.ts
+++ b/yarn-project/end-to-end/src/e2e_p2p/p2p_network.ts
@@ -93,7 +93,7 @@ export class P2PNetworkTest {
    */
   public async syncMockSystemTime() {
     this.logger.info('Syncing mock system time');
-    const { timer, deployL1ContractsValues } = this.ctx!;
+    const { dateProvider, deployL1ContractsValues } = this.ctx!;
     // Send a tx and only update the time after the tx is mined, as eth time is not continuous
     const tx = await deployL1ContractsValues.walletClient.sendTransaction({
       to: this.baseAccount.address,
@@ -104,8 +104,7 @@ export class P2PNetworkTest {
       hash: tx,
     });
     const timestamp = await deployL1ContractsValues.publicClient.getBlock({ blockNumber: receipt.blockNumber });
-    timer.setSystemTime(Number(timestamp.timestamp) * 1000);
-    this.logger.info(`Synced mock system time to ${timestamp.timestamp * 1000n}`);
+    dateProvider.setTime(Number(timestamp.timestamp) * 1000);
   }
 
   static async create({
@@ -133,7 +132,7 @@ export class P2PNetworkTest {
   async applyBaseSnapshots() {
     await this.snapshotManager.snapshot(
       'add-validators',
-      async ({ deployL1ContractsValues, aztecNodeConfig, timer }) => {
+      async ({ deployL1ContractsValues, aztecNodeConfig, dateProvider }) => {
         const rollup = getContract({
           address: deployL1ContractsValues.l1ContractAddresses.rollupAddress.toString(),
           abi: RollupAbi,
@@ -203,7 +202,7 @@ export class P2PNetworkTest {
 
         // Set the system time in the node, only after we have warped the time and waited for a block
         // Time is only set in the NEXT block
-        timer.setSystemTime(Number(timestamp) * 1000);
+        dateProvider.setTime(Number(timestamp) * 1000);
       },
     );
   }
@@ -244,7 +243,7 @@ export class P2PNetworkTest {
   async removeInitialNode() {
     await this.snapshotManager.snapshot(
       'remove-inital-validator',
-      async ({ deployL1ContractsValues, aztecNode, timer }) => {
+      async ({ deployL1ContractsValues, aztecNode, dateProvider }) => {
         // Send and await a tx to make sure we mine a block for the warp to correctly progress.
         const receipt = await deployL1ContractsValues.publicClient.waitForTransactionReceipt({
           hash: await deployL1ContractsValues.walletClient.sendTransaction({
@@ -256,7 +255,7 @@ export class P2PNetworkTest {
         const block = await deployL1ContractsValues.publicClient.getBlock({
           blockNumber: receipt.blockNumber,
         });
-        timer.setSystemTime(Number(block.timestamp) * 1000);
+        dateProvider.setTime(Number(block.timestamp) * 1000);
 
         await aztecNode.stop();
       },

--- a/yarn-project/end-to-end/src/e2e_p2p/rediscovery.test.ts
+++ b/yarn-project/end-to-end/src/e2e_p2p/rediscovery.test.ts
@@ -46,6 +46,7 @@ describe('e2e_p2p_rediscovery', () => {
     const contexts: NodeContext[] = [];
     nodes = await createNodes(
       t.ctx.aztecNodeConfig,
+      t.ctx.dateProvider,
       t.bootstrapNodeEnr,
       NUM_NODES,
       BOOT_NODE_UDP_PORT,
@@ -72,6 +73,7 @@ describe('e2e_p2p_rediscovery', () => {
 
       const newNode = await createNode(
         t.ctx.aztecNodeConfig,
+        t.ctx.dateProvider,
         i + 1 + BOOT_NODE_UDP_PORT,
         undefined,
         i,

--- a/yarn-project/end-to-end/src/e2e_p2p/reex.test.ts
+++ b/yarn-project/end-to-end/src/e2e_p2p/reex.test.ts
@@ -65,6 +65,7 @@ describe('e2e_p2p_reex', () => {
 
     nodes = await createNodes(
       t.ctx.aztecNodeConfig,
+      t.ctx.dateProvider,
       t.bootstrapNodeEnr,
       NUM_NODES,
       BOOT_NODE_UDP_PORT,

--- a/yarn-project/end-to-end/src/e2e_p2p/reqresp.test.ts
+++ b/yarn-project/end-to-end/src/e2e_p2p/reqresp.test.ts
@@ -65,6 +65,7 @@ describe('e2e_p2p_reqresp_tx', () => {
     t.logger.info('Creating nodes');
     nodes = await createNodes(
       t.ctx.aztecNodeConfig,
+      t.ctx.dateProvider,
       t.bootstrapNodeEnr,
       NUM_NODES,
       BOOT_NODE_UDP_PORT,

--- a/yarn-project/end-to-end/src/e2e_p2p/upgrade_governance_proposer.test.ts
+++ b/yarn-project/end-to-end/src/e2e_p2p/upgrade_governance_proposer.test.ts
@@ -130,6 +130,7 @@ describe('e2e_p2p_governance_proposer', () => {
     t.logger.info('Creating nodes');
     nodes = await createNodes(
       { ...t.ctx.aztecNodeConfig, governanceProposerPayload: newPayloadAddress },
+      t.ctx.dateProvider,
       t.bootstrapNodeEnr,
       NUM_NODES,
       BOOT_NODE_UDP_PORT,

--- a/yarn-project/end-to-end/src/fixtures/setup_p2p_test.ts
+++ b/yarn-project/end-to-end/src/fixtures/setup_p2p_test.ts
@@ -4,6 +4,7 @@
 import { type AztecNodeConfig, AztecNodeService } from '@aztec/aztec-node';
 import { type SentTx, createLogger } from '@aztec/aztec.js';
 import { type AztecAddress } from '@aztec/circuits.js';
+import { type DateProvider } from '@aztec/foundation/timer';
 import { type PXEService } from '@aztec/pxe';
 
 import getPort from 'get-port';
@@ -34,6 +35,7 @@ export function generatePrivateKeys(startIndex: number, numberOfKeys: number): `
 
 export function createNodes(
   config: AztecNodeConfig,
+  dateProvider: DateProvider,
   bootstrapNodeEnr: string,
   numNodes: number,
   bootNodePort: number,
@@ -46,7 +48,7 @@ export function createNodes(
     const port = bootNodePort + i + 1;
 
     const dataDir = dataDirectory ? `${dataDirectory}-${i}` : undefined;
-    const nodePromise = createNode(config, port, bootstrapNodeEnr, i, dataDir, metricsPort);
+    const nodePromise = createNode(config, dateProvider, port, bootstrapNodeEnr, i, dataDir, metricsPort);
     nodePromises.push(nodePromise);
   }
   return Promise.all(nodePromises);
@@ -55,6 +57,7 @@ export function createNodes(
 // creates a P2P enabled instance of Aztec Node Service
 export async function createNode(
   config: AztecNodeConfig,
+  dateProvider: DateProvider,
   tcpPort: number,
   bootstrapNode: string | undefined,
   accountIndex: number,
@@ -68,6 +71,7 @@ export async function createNode(
   return await AztecNodeService.createAndSync(validatorConfig, {
     telemetry: telemetryClient,
     logger: createLogger(`node:${tcpPort}`),
+    dateProvider,
   });
 }
 

--- a/yarn-project/end-to-end/src/fixtures/utils.ts
+++ b/yarn-project/end-to-end/src/fixtures/utils.ts
@@ -279,9 +279,9 @@ export type EndToEndContext = {
   logger: Logger;
   /** The cheat codes. */
   cheatCodes: CheatCodes;
-  /** The anvil test watcher (undefined if connected to remove environment) */
+  /** The anvil test watcher (undefined if connected to remote environment) */
   watcher: AnvilTestWatcher | undefined;
-  /** Allows tweaking current system time, used by the epoch cache only (undefined if connected to remove environment) */
+  /** Allows tweaking current system time, used by the epoch cache only (undefined if connected to remote environment) */
   dateProvider: TestDateProvider | undefined;
   /** Function to stop the started services. */
   teardown: () => Promise<void>;

--- a/yarn-project/end-to-end/src/fixtures/utils.ts
+++ b/yarn-project/end-to-end/src/fixtures/utils.ts
@@ -38,6 +38,7 @@ import {
 } from '@aztec/ethereum';
 import { startAnvil } from '@aztec/ethereum/test';
 import { retryUntil } from '@aztec/foundation/retry';
+import { TestDateProvider } from '@aztec/foundation/timer';
 import { FeeJuiceContract } from '@aztec/noir-contracts.js/FeeJuice';
 import { getVKTreeRoot } from '@aztec/noir-protocol-circuits-types';
 import { ProtocolContractAddress, protocolContractTreeRoot } from '@aztec/protocol-contracts';
@@ -225,6 +226,7 @@ async function setupWithRemoteEnvironment(
     logger,
     cheatCodes,
     watcher: undefined,
+    dateProvider: undefined,
     teardown,
   };
 }
@@ -279,6 +281,8 @@ export type EndToEndContext = {
   cheatCodes: CheatCodes;
   /** The anvil test watcher (undefined if connected to remove environment) */
   watcher: AnvilTestWatcher | undefined;
+  /** Allows tweaking current system time, used by the epoch cache only (undefined if connected to remove environment) */
+  dateProvider: TestDateProvider | undefined;
   /** Function to stop the started services. */
   teardown: () => Promise<void>;
 };
@@ -415,7 +419,8 @@ export async function setup(
 
   const telemetry = await telemetryPromise;
   const publisher = new TestL1Publisher(config, telemetry);
-  const aztecNode = await AztecNodeService.createAndSync(config, { telemetry, publisher });
+  const dateProvider = new TestDateProvider();
+  const aztecNode = await AztecNodeService.createAndSync(config, { telemetry, publisher, dateProvider });
   const sequencer = aztecNode.getSequencer();
 
   let proverNode: ProverNode | undefined = undefined;
@@ -466,6 +471,7 @@ export async function setup(
     cheatCodes,
     sequencer,
     watcher,
+    dateProvider,
     teardown,
   };
 }

--- a/yarn-project/foundation/src/timer/date.test.ts
+++ b/yarn-project/foundation/src/timer/date.test.ts
@@ -1,0 +1,33 @@
+import { sleep } from '../sleep/index.js';
+import { TestDateProvider } from './date.js';
+
+describe('TestDateProvider', () => {
+  let dateProvider: TestDateProvider;
+  beforeEach(() => {
+    dateProvider = new TestDateProvider();
+  });
+
+  it('should return the current datetime', () => {
+    const currentTime = Date.now();
+    const result = dateProvider.now();
+    expect(result).toBeGreaterThanOrEqual(currentTime);
+    expect(result).toBeLessThan(currentTime + 100);
+  });
+
+  it('should return the overridden datetime', () => {
+    const overriddenTime = Date.now() + 1000;
+    dateProvider.setTime(overriddenTime);
+    const result = dateProvider.now();
+    expect(result).toBeGreaterThanOrEqual(overriddenTime);
+    expect(result).toBeLessThan(overriddenTime + 100);
+  });
+
+  it('should keep ticking after overriding', async () => {
+    const overriddenTime = Date.now() + 1000;
+    dateProvider.setTime(overriddenTime);
+    await sleep(510);
+    const result = dateProvider.now();
+    expect(result).toBeGreaterThanOrEqual(overriddenTime + 500);
+    expect(result).toBeLessThan(overriddenTime + 600);
+  });
+});

--- a/yarn-project/foundation/src/timer/date.ts
+++ b/yarn-project/foundation/src/timer/date.ts
@@ -1,0 +1,24 @@
+import { createLogger } from '../log/pino-logger.js';
+
+/** Returns current datetime. */
+export class DateProvider {
+  public now(): number {
+    return Date.now();
+  }
+}
+
+/** Returns current datetime and allows to override it. */
+export class TestDateProvider implements DateProvider {
+  private offset = 0;
+
+  constructor(private readonly logger = createLogger('foundation:test-date-provider')) {}
+
+  public now(): number {
+    return Date.now() + this.offset;
+  }
+
+  public setTime(timeMs: number) {
+    this.offset = timeMs - Date.now();
+    this.logger.warn(`Time set to ${timeMs}`);
+  }
+}

--- a/yarn-project/foundation/src/timer/index.ts
+++ b/yarn-project/foundation/src/timer/index.ts
@@ -1,3 +1,4 @@
 export { TimeoutTask, executeTimeoutWithCustomError } from './timeout.js';
 export { Timer } from './timer.js';
 export { elapsed, elapsedSync } from './elapsed.js';
+export * from './date.js';

--- a/yarn-project/validator-client/src/factory.ts
+++ b/yarn-project/validator-client/src/factory.ts
@@ -1,5 +1,6 @@
 import { EpochCache, type EpochCacheConfig } from '@aztec/epoch-cache';
 import { type EthAddress } from '@aztec/foundation/eth-address';
+import { type DateProvider } from '@aztec/foundation/timer';
 import { type P2P } from '@aztec/p2p';
 import { type TelemetryClient } from '@aztec/telemetry-client';
 
@@ -11,8 +12,11 @@ import { ValidatorClient } from './validator.js';
 export async function createValidatorClient(
   config: ValidatorClientConfig & EpochCacheConfig,
   rollupAddress: EthAddress,
-  p2pClient: P2P,
-  telemetry: TelemetryClient,
+  deps: {
+    p2pClient: P2P;
+    telemetry: TelemetryClient;
+    dateProvider: DateProvider;
+  },
 ) {
   if (config.disableValidator) {
     return undefined;
@@ -22,7 +26,7 @@ export async function createValidatorClient(
   }
 
   // Create the epoch cache
-  const epochCache = await EpochCache.create(rollupAddress, /*l1TimestampSource,*/ config);
+  const epochCache = await EpochCache.create(rollupAddress, config, deps);
 
-  return ValidatorClient.new(config, epochCache, p2pClient, telemetry);
+  return ValidatorClient.new(config, epochCache, deps.p2pClient, deps.telemetry);
 }

--- a/yarn-project/yarn.lock
+++ b/yarn-project/yarn.lock
@@ -550,7 +550,6 @@ __metadata:
     "@aztec/world-state": "workspace:^"
     "@jest/globals": ^29.5.0
     "@noble/curves": ^1.0.0
-    "@sinonjs/fake-timers": ^13.0.5
     "@swc/core": ^1.4.11
     "@swc/jest": ^0.2.36
     "@types/fs-extra": ^11.0.2
@@ -4536,7 +4535,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@sinonjs/commons@npm:^3.0.0, @sinonjs/commons@npm:^3.0.1":
+"@sinonjs/commons@npm:^3.0.0":
   version: 3.0.1
   resolution: "@sinonjs/commons@npm:3.0.1"
   dependencies:
@@ -4551,15 +4550,6 @@ __metadata:
   dependencies:
     "@sinonjs/commons": ^3.0.0
   checksum: 614d30cb4d5201550c940945d44c9e0b6d64a888ff2cd5b357f95ad6721070d6b8839cd10e15b76bf5e14af0bcc1d8f9ec00d49a46318f1f669a4bec1d7f3148
-  languageName: node
-  linkType: hard
-
-"@sinonjs/fake-timers@npm:^13.0.5":
-  version: 13.0.5
-  resolution: "@sinonjs/fake-timers@npm:13.0.5"
-  dependencies:
-    "@sinonjs/commons": ^3.0.1
-  checksum: b1c6ba87fadb7666d3aa126c9e8b4ac32b2d9e84c9e5fd074aa24cab3c8342fd655459de014b08e603be1e6c24c9f9716d76d6d2a36c50f59bb0091be61601dd
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
Sinon fake timers were altering log timestamps. Instead of tweaking the global system clock in p2p e2e tests, we introduce a date provider that is injected as a dependency into the epoch cache (the only component that relied on its time being in sync with L1), and we tweak that.
