### PR TITLE
chore: set max txs in spam test

### DIFF
--- a/yarn-project/end-to-end/src/e2e_block_building.test.ts
+++ b/yarn-project/end-to-end/src/e2e_block_building.test.ts
@@ -394,8 +394,10 @@ describe('e2e_block_building', () => {
         .send()
         .deployed();
 
-      logger.info('Updating min txs per block to 4');
-      await aztecNode.setConfig({ minTxsPerBlock: 4 });
+      // We set the maximum number of txs per block to 12 to ensure that the sequencer will start building a block before it receives all the txs
+      // and also to avoid it building
+      logger.info('Updating min txs per block to 4, and max txs per block to 12');
+      await aztecNode.setConfig({ minTxsPerBlock: 4, maxTxsPerBlock: 12 });
 
       logger.info('Spamming the network with public txs');
       const txs = [];


### PR DESCRIPTION
The "spam" test in block building could in some cases end up building really large blocks because the block building did not start quick enough, which caught an issue where blocks become too large to publish. Setting a max size should fix it for us to ensure that we start building the block earlier, and don't make it gigantic.