### PR TITLE
chore: Log error in retry module

### DIFF
--- a/yarn-project/foundation/src/retry/index.ts
+++ b/yarn-project/foundation/src/retry/index.ts
@@ -64,7 +64,7 @@ export async function retry<Result>(
         throw err;
       }
       log.verbose(`${name} failed. Will retry in ${s}s...`);
-      !failSilently && log.error(err);
+      !failSilently && log.error(`Error while retrying ${name}`, err);
       await sleep(s * 1000);
       continue;
     }


### PR DESCRIPTION
Should deal with the annoying `{}` log entries