### PR TITLE
Fix: Update sol_gen.hpp link

### DIFF
--- a/barretenberg/sol/README.md
+++ b/barretenberg/sol/README.md
@@ -10,7 +10,7 @@ The verifier will follow an overall architecture below, consisting of 3 contract
 
 ![Verifier architecture](./figures/verifier.png)
 
-The verification key is currently generated via [Barretenberg](https://github.com/AztecProtocol/barretenberg/blob/master/cpp/src/aztec/plonk_honk_shared/verification_key/sol_gen.hpp), Aztec's backend for generating proofs.
+The verification key is currently generated via [Barretenberg](https://github.com/AztecProtocol/barretenberg/blob/master/cpp/src/barretenberg/plonk/proof_system/verification_key/sol_gen.hpp), Aztec's backend for generating proofs.
 
 ## Current implementations
 


### PR DESCRIPTION
**Description of changes:**  
Replaced an outdated link to `sol_gen.hpp` with the correct and working link in the AztecProtocol repository.
Thank you so much for your hard work! I hope this helps you !
