### PR TITLE
fix: Race condition in block stream

### DIFF
--- a/yarn-project/kv-store/src/stores/l2_tips_store.ts
+++ b/yarn-project/kv-store/src/stores/l2_tips_store.ts
@@ -47,10 +47,10 @@ export class L2TipsStore implements L2BlockStreamEventHandler, L2BlockStreamLoca
   public async handleBlockStreamEvent(event: L2BlockStreamEvent): Promise<void> {
     switch (event.type) {
       case 'blocks-added':
-        await this.l2TipsStore.set('latest', event.blocks.at(-1)!.number);
         for (const block of event.blocks) {
           await this.l2BlockHashesStore.set(block.number, block.header.hash().toString());
         }
+        await this.l2TipsStore.set('latest', event.blocks.at(-1)!.number);
         break;
       case 'chain-pruned':
         await this.l2TipsStore.set('latest', event.blockNumber);


### PR DESCRIPTION
Try fix a race condition in the L2 block stream:

```
[20:12:05.473] ERROR: pxe:block_stream Error processing block stream: Error: Block hash not found for block number 8
    at L2TipsStore.getL2Tip (/home/santiago/Projects/aztec3-packages-4/yarn-project/kv-store/src/stores/l2_tips_store.ts:42:13)
    at processTicksAndRejections (node:internal/process/task_queues:95:5)
    at L2TipsStore.getL2Tips (/home/santiago/Projects/aztec3-packages-4/yarn-project/kv-store/src/stores/l2_tips_store.ts:29:15)
    at L2BlockStream.work (/home/santiago/Projects/aztec3-packages-4/yarn-project/circuit-types/src/l2_block_downloader/l2_block_stream.ts:47:25)
    at Synchronizer.sync (/home/santiago/Projects/aztec3-packages-4/yarn-project/pxe/src/synchronizer/synchronizer.ts:88:5)
    at PXEService.simulateTx (/home/santiago/Projects/aztec3-packages-4/yarn-project/pxe/src/pxe_service/pxe_service.ts:501:7)
    at ContractFunctionInteraction.proveInternal (/home/santiago/Projects/aztec3-packages-4/yarn-project/aztec.js/src/contract/base_contract_interaction.ts:53:32)
    at /home/santiago/Projects/aztec3-packages-4/yarn-project/aztec.js/src/contract/base_contract_interaction.ts:78:31
    at SentTx.waitForReceipt (/home/santiago/Projects/aztec3-packages-4/yarn-project/aztec.js/src/contract/sent_tx.ts:100:20)
    at SentTx.wait (/home/santiago/Projects/aztec3-packages-4/yarn-project/aztec.js/src/contract/sent_tx.ts:67:21)
    at async Promise.all (index 0)
    at Object.<anonymous> (/home/santiago/Projects/aztec3-packages-4/yarn-project/end-to-end/src/benchmarks/bench_prover.test.ts:119:5)
```

Note that the issue the the L2 stream requesting the block hash for a block number that it should know about. This can happen if the latest block number is increased _before_ the block is saved. Storing the blocks before bumping the number seems to fix it across several local runs.

Please read [contributing guidelines](CONTRIBUTING.md) and remove this line.
