### PR TITLE
chore: slack notifications for networks

### DIFF
--- a/spartan/metrics/.helmignore
+++ b/spartan/metrics/.helmignore
@@ -21,3 +21,5 @@
 .idea/
 *.tmproj
 .vscode/
+
+terraform/

--- a/spartan/metrics/terraform/grafana.tf
+++ b/spartan/metrics/terraform/grafana.tf
@@ -7,6 +7,11 @@ terraform {
       version = "~> 3.13.2"
     }
   }
+
+  backend "gcs" {
+    bucket = "aztec-terraform"
+    prefix = "metrics-deploy/us-west1-a/aztec-gke/metrics/alerting/terraform.tfstate"
+  }
 }
 
 provider "grafana" {
@@ -29,18 +34,21 @@ resource "grafana_contact_point" "slack" {
 
 resource "grafana_notification_policy" "ignore_policy" {
   contact_point = grafana_contact_point.slack.name
-  group_by      = ["service_namespace"]
+  group_by      = ["k8s_namespace_name"]
+
 
   policy {
     contact_point = grafana_contact_point.slack.name
-
     matcher {
-      label = "service_namespace"
-      match = "="
-      value = "smoke"
+      label = "k8s_namespace_name"
+      match = "=~"
+      value = "devnet|troll-turtle"
     }
+  }
 
-    mute_timings = ["always"]
+  policy {
+    mute_timings  = ["always"]
+    contact_point = grafana_contact_point.slack.name
   }
 }
 

--- a/spartan/metrics/terraform/variables.tf
+++ b/spartan/metrics/terraform/variables.tf
@@ -3,9 +3,11 @@ variable "grafana_url" {
 }
 
 variable "grafana_auth" {
-  type = string
+  type      = string
+  sensitive = true
 }
 
 variable "slack_url" {
-  type = string
+  type      = string
+  sensitive = true
 }


### PR DESCRIPTION
Slack alerts to #network-alerts when the proven chain stops on `devnet` or `troll-turtle`.

I deployed the TF and can confirm it is working.
