### PR TITLE
fix(testdata): relative path calculation

### DIFF
--- a/yarn-project/foundation/src/testing/files/index.ts
+++ b/yarn-project/foundation/src/testing/files/index.ts
@@ -67,7 +67,7 @@ export function updateProtocolCircuitSampleInputs(circuitName: string, value: st
 }
 
 function getPathToFile(targetFileFromRepoRoot: string) {
-  const repoRoot = resolve(dirname(fileURLToPath(import.meta.url)), '../../../../');
+  const repoRoot = resolve(dirname(fileURLToPath(import.meta.url)), '../../../../../');
   if (!existsSync(join(repoRoot, 'CODEOWNERS'))) {
     throw new Error(`Path to repo root is incorrect (got ${repoRoot})`);
   }


### PR DESCRIPTION
Testdata file utils were moved one level deeper into `files`. Resolution wasn't failing in CI/etc because it's only triggered when generating data with `AZTEC_GENERATE_TEST_DATA=1`.
