### PR TITLE
fix: Race condition when cleaning epoch proof quotes

### DIFF
--- a/yarn-project/p2p/src/client/p2p_client.ts
+++ b/yarn-project/p2p/src/client/p2p_client.ts
@@ -659,12 +659,13 @@ export class P2PClient<T extends P2PClientType = P2PClientType.Full>
       await this.attestationPool?.deleteAttestationsOlderThan(lastBlockSlotMinusKeepAttestationsInPoolFor);
     }
 
-    await this.synchedProvenBlockNumber.set(lastBlockNum);
-    this.log.debug(`Synched to proven block ${lastBlockNum}`);
     const provenEpochNumber = await this.l2BlockSource.getProvenL2EpochNumber();
     if (provenEpochNumber !== undefined) {
       this.epochProofQuotePool.deleteQuotesToEpoch(BigInt(provenEpochNumber));
     }
+
+    await this.synchedProvenBlockNumber.set(lastBlockNum);
+    this.log.debug(`Synched to proven block ${lastBlockNum}`);
 
     await this.startServiceIfSynched();
   }


### PR DESCRIPTION
The test `In-Memory P2P Client › deletes expired proof quotes` was sometimes failing with `epochProofQuotePool.deleteQuotesToEpoch` not being called.

This could happen on a race condition where the p2p client reports to have synched to a given block number, but the quotes are deleted *after* the synched block number is set.

This PR ensures setting the last block number is the last operation done.
