### PR TITLE
chore: update external joiner script for new networks

### DIFF
--- a/spartan/releases/rough-rhino/Earthfile
+++ b/spartan/releases/rough-rhino/Earthfile
@@ -8,9 +8,8 @@ deps:
         curl \
         git \
         make \
-        nodejs \
-        npm \
-        unzip
+        unzip \
+        jq
 
 test-setup:
     FROM +deps
@@ -43,7 +42,8 @@ test-install:
         -p 8080 \
         -p2p 40400 \
         -ip 1.2.3.4 \
-        -k 0x00
+        -k 0x00 \
+        -n "troll-turtle"
     # Verify docker-compose.yml was created and contains correct values
     RUN test -f .env && \
         test -f docker-compose.yml && \
@@ -73,7 +73,8 @@ test-start-stop:
         -p 8080 \
         -p2p 40400 \
         -ip 1.2.3.4 \
-        -k 0x00
+        -k 0x00 \
+        -n "troll-turtle"
     # Test start command
     RUN ./aztec-spartan.sh start 2>&1 | grep -q "Starting containers" && \
         echo "✅ Start command test passed" || \
@@ -97,7 +98,8 @@ test-data-dir:
         -p2p 40400 \
         -ip 1.2.3.4 \
         -k 0x00 \
-        -d ./aztec-data
+        -d ./aztec-data \
+        -n "troll-turtle"
     # Verify docker-compose.yml uses bind mount instead of named volume
     RUN grep -q "volumes:" docker-compose.yml && \
         grep -q "./aztec-data:/var/lib/aztec" docker-compose.yml && \
@@ -113,7 +115,8 @@ test-p2p-key:
         -p2p 40400 \
         -ip 1.2.3.4 \
         -k 0x00 \
-        -pk 00000
+        -pk 00000 \
+        -n "troll-turtle"
     # Verify the P2P private key was set in the .env file
     RUN test -f .env && \
         grep -q "PEER_ID_PRIVATE_KEY=00000" .env && \

--- a/spartan/releases/rough-rhino/aztec-spartan.sh
+++ b/spartan/releases/rough-rhino/aztec-spartan.sh
@@ -1,5 +1,7 @@
 #!/bin/bash
 
+set -e
+
 # Colors and formatting
 BLUE='\033[0;34m'
 GREEN='\033[0;32m'
@@ -8,7 +10,6 @@ YELLOW='\033[1;33m'
 NC='\033[0m' # No Color
 
 # Global variables
-ARCH=$(uname -m)
 DEFAULT_P2P_PORT="40400"
 DEFAULT_PORT="8080"
 DEFAULT_KEY="0x0000000000000000000000000000000000000000000000000000000000000001"
@@ -16,10 +17,27 @@ DEFAULT_KEY="0x0000000000000000000000000000000000000000000000000000000000000001"
 DEFAULT_IP=$(curl -s --connect-timeout 5 https://api.ipify.org?format=json | grep -o '"ip":"[^"]*' | cut -d'"' -f4 || echo "")
 DEFAULT_BIND_MOUNT_DIR="$HOME/aztec-data"
 
+
 # Parse command line arguments
 parse_args() {
     while [[ $# -gt 0 ]]; do
         case $1 in
+            -b|--bootnode-url)
+                BOOTNODE_URL="$2"
+                shift 2
+                ;;
+            -n|--network)
+                NETWORK="$2"
+                shift 2
+                ;;
+            -i|--image)
+                IMAGE="$2"
+                shift 2
+                ;;
+            -e|--ethereum-host)
+                ETHEREUM_HOST="$2"
+                shift 2
+                ;;
             -p|--port)
                 CLI_PORT="$2"
                 shift 2
@@ -107,12 +125,64 @@ get_public_ip() {
     fi
 }
 
+get_node_info() {
+    echo -e "${BLUE}Fetching node info...${NC}"
+    CMD="get-node-info --node-url ${BOOTNODE_URL} --json"
+    # TODO: use the correct (corresponding) image
+    # Can't do it today because `release/troll-turtle` doesn't support --json flag
+    NODE_INFO=$(curl -X POST -H 'Content-Type: application/json' -d '{"jsonrpc":"2.0","method":"node_getNodeInfo","params":[],"id":1}' -s ${BOOTNODE_URL})
+
+    # Extract the relevant fields
+    result=$(echo $NODE_INFO | jq -r '.result')
+    L1_CHAIN_ID=$(echo $result | jq -r '.l1ChainId')
+    BOOTSTRAP_NODES=$(echo $result | jq -r '.enr')
+    REGISTRY_CONTRACT_ADDRESS=$(echo $result | jq -r '.l1ContractAddresses.registryAddress')
+    GOVERNANCE_PROPOSER_CONTRACT_ADDRESS=$(echo $result | jq -r '.l1ContractAddresses.governanceProposerAddress')
+    FEE_JUICE_CONTRACT_ADDRESS=$(echo $result | jq -r '.l1ContractAddresses.feeJuiceAddress')
+    ROLLUP_CONTRACT_ADDRESS=$(echo $result | jq -r '.l1ContractAddresses.rollupAddress')
+    REWARD_DISTRIBUTOR_CONTRACT_ADDRESS=$(echo $result | jq -r '.l1ContractAddresses.rewardDistributorAddress')
+    GOVERNANCE_CONTRACT_ADDRESS=$(echo $result | jq -r '.l1ContractAddresses.governanceAddress')
+    COIN_ISSUER_CONTRACT_ADDRESS=$(echo $result | jq -r '.l1ContractAddresses.coinIssuerAddress')
+    FEE_JUICE_PORTAL_CONTRACT_ADDRESS=$(echo $result | jq -r '.l1ContractAddresses.feeJuicePortalAddress')
+    INBOX_CONTRACT_ADDRESS=$(echo $result | jq -r '.l1ContractAddresses.inboxAddress')
+    OUTBOX_CONTRACT_ADDRESS=$(echo $result | jq -r '.l1ContractAddresses.outboxAddress')
+
+    echo -e "${GREEN}Node info fetched successfully${NC}"
+    return 0
+}
+
 # Configure environment
 configure_environment() {
     local args=("$@")
     parse_args "${args[@]}"
 
     echo -e "${BLUE}Configuring environment...${NC}"
+    if [ -n "$NETWORK" ]; then
+        NETWORK="$NETWORK"
+    else
+        read -p "Network [troll-turtle]: " NETWORK
+        NETWORK=${NETWORK:-troll-turtle}
+    fi
+
+    # if the network is `troll-turtle`
+    if [ "$NETWORK" = "troll-turtle" ]; then
+        BOOTNODE_URL="${BOOTNODE_URL:-http://34.82.213.6:8080}"
+        ETHEREUM_HOST="${ETHEREUM_HOST:-http://34.19.127.9:8545}"
+        IMAGE="${IMAGE:-aztecprotocol/aztec:0.67.1}"
+    else
+        # unknown network
+        echo -e "${RED}Unknown network: $NETWORK${NC}"
+    fi
+
+    # Check that bootnode, ethereum host, and image are set
+    if [ -z "$BOOTNODE_URL" ] || [ -z "$ETHEREUM_HOST" ] || [ -z "$IMAGE" ]; then
+        echo -e "${RED}Bootnode, Ethereum host, and image are required${NC}"
+        exit 1
+    fi
+
+    # get the node info
+    get_node_info
+
 
     if [ -n "$CLI_P2P_PORT" ]; then
         P2P_PORT="$CLI_P2P_PORT"
@@ -184,25 +254,25 @@ DEBUG=aztec:*,-aztec:avm_simulator*,-aztec:circuits:artifact_hash,-aztec:libp2p_
 LOG_LEVEL=debug
 AZTEC_PORT=${PORT}
 P2P_ENABLED=true
-L1_CHAIN_ID=1337
+L1_CHAIN_ID=${L1_CHAIN_ID}
 PROVER_REAL_PROOFS=true
 PXE_PROVER_ENABLED=true
 ETHEREUM_SLOT_DURATION=12sec
 AZTEC_SLOT_DURATION=36
 AZTEC_EPOCH_DURATION=32
 AZTEC_EPOCH_PROOF_CLAIM_WINDOW_IN_L2_SLOTS=13
-ETHEREUM_HOST=http://34.48.76.131:8545
-BOOTSTRAP_NODES=enr:-Jq4QO_3szmgtG2cbEdnFDIhpGAQkc1HwfNy4-M6sG9QmQbPTmp9PMOHR3xslfR23hORiU-GpA7uM9uXw49lFcnuuvYGjWF6dGVjX25ldHdvcmsBgmlkgnY0gmlwhCIwTIOJc2VjcDI1NmsxoQKQTN17XKCwjYSSwmTc-6YzCMhd3v6Ofl8TS-WunX6LCoN0Y3CCndCDdWRwgp3Q
-REGISTRY_CONTRACT_ADDRESS=0x5fbdb2315678afecb367f032d93f642f64180aa3
-GOVERNANCE_PROPOSER_CONTRACT_ADDRESS=0x9fe46736679d2d9a65f0992f2272de9f3c7fa6e0
-FEE_JUICE_CONTRACT_ADDRESS=0xe7f1725e7734ce288f8367e1bb143e90bb3f0512
-ROLLUP_CONTRACT_ADDRESS=0x2279b7a0a67db372996a5fab50d91eaa73d2ebe6
-REWARD_DISTRIBUTOR_CONTRACT_ADDRESS=0x5fc8d32690cc91d4c39d9d3abcbd16989f875707
-GOVERNANCE_CONTRACT_ADDRESS=0xcf7ed3acca5a467e9e704c703e8d87f634fb0fc9
-COIN_ISSUER_CONTRACT_ADDRESS=0xdc64a140aa3e981100a9beca4e685f962f0cf6c9
-FEE_JUICE_PORTAL_CONTRACT_ADDRESS=0x0165878a594ca255338adfa4d48449f69242eb8f
-INBOX_CONTRACT_ADDRESS=0xed179b78d5781f93eb169730d8ad1be7313123f4
-OUTBOX_CONTRACT_ADDRESS=0x1016b5aaa3270a65c315c664ecb238b6db270b64
+ETHEREUM_HOST=${ETHEREUM_HOST}
+BOOTSTRAP_NODES=${BOOTSTRAP_NODES}
+REGISTRY_CONTRACT_ADDRESS=${REGISTRY_CONTRACT_ADDRESS}
+GOVERNANCE_PROPOSER_CONTRACT_ADDRESS=${GOVERNANCE_PROPOSER_CONTRACT_ADDRESS}
+FEE_JUICE_CONTRACT_ADDRESS=${FEE_JUICE_CONTRACT_ADDRESS}
+ROLLUP_CONTRACT_ADDRESS=${ROLLUP_CONTRACT_ADDRESS}
+REWARD_DISTRIBUTOR_CONTRACT_ADDRESS=${REWARD_DISTRIBUTOR_CONTRACT_ADDRESS}
+GOVERNANCE_CONTRACT_ADDRESS=${GOVERNANCE_CONTRACT_ADDRESS}
+COIN_ISSUER_CONTRACT_ADDRESS=${COIN_ISSUER_CONTRACT_ADDRESS}
+FEE_JUICE_PORTAL_CONTRACT_ADDRESS=${FEE_JUICE_PORTAL_CONTRACT_ADDRESS}
+INBOX_CONTRACT_ADDRESS=${INBOX_CONTRACT_ADDRESS}
+OUTBOX_CONTRACT_ADDRESS=${OUTBOX_CONTRACT_ADDRESS}
 P2P_UDP_LISTEN_ADDR=0.0.0.0:${P2P_PORT}
 P2P_TCP_LISTEN_ADDR=0.0.0.0:${P2P_PORT}
 DATA_DIRECTORY=/var/lib/aztec
@@ -216,7 +286,7 @@ services:
         network_mode: host
         restart: unless-stopped
         env_file: .env
-        image: aztecprotocol/aztec:698cd3d62680629a3f1bfc0f82604534cedbccf3-${ARCH}
+        image: ${IMAGE}
         entrypoint: >
             sh -c '
 


### PR DESCRIPTION
The script now takes an explicit reference to a network.

Networks have hardcoded configurations to loadbalancers that sit in front of boot-nodes and the ethereum host.

For now, only `troll-turtle` is supported. Users can override to join custom networks by setting their own image, boot node, and ethereum host.

Note: this means that if the `troll-turtle` network goes down, these test will fail. 

I'm fine with that for now, but I filed https://github.com/AztecProtocol/aztec-packages/issues/10809