### PR TITLE
refactor: optimization of `syncTaggedLogsAsSender`

### DIFF
--- a/yarn-project/pxe/src/simulator_oracle/index.ts
+++ b/yarn-project/pxe/src/simulator_oracle/index.ts
@@ -38,7 +38,7 @@ import { type IncomingNoteDao } from '../database/incoming_note_dao.js';
 import { type PxeDatabase } from '../database/index.js';
 import { produceNoteDaos } from '../note_decryption_utils/produce_note_daos.js';
 import { getAcirSimulator } from '../simulator/index.js';
-import { getIndexedTaggingSecretsForTheWindow, getInitialIndexesMap } from './tagging_utils.js';
+import { WINDOW_HALF_SIZE, getIndexedTaggingSecretsForTheWindow, getInitialIndexesMap } from './tagging_utils.js';
 
 /**
  * A data oracle that provides information needed for simulating a transaction.
@@ -418,9 +418,6 @@ export class SimulatorOracle implements DBOracle {
     maxBlockNumber: number,
     scopes?: AztecAddress[],
   ): Promise<Map<string, TxScopedL2Log[]>> {
-    // Half the size of the window we slide over the tagging secret indexes.
-    const WINDOW_HALF_SIZE = 10;
-
     // Ideally this algorithm would be implemented in noir, exposing its building blocks as oracles.
     // However it is impossible at the moment due to the language not supporting nested slices.
     // This nesting is necessary because for a given set of tags we don't

--- a/yarn-project/pxe/src/simulator_oracle/index.ts
+++ b/yarn-project/pxe/src/simulator_oracle/index.ts
@@ -377,8 +377,8 @@ export class SimulatorOracle implements DBOracle {
       // We find the index of the last log in the window that is not empty
       const indexOfLastLog = possibleLogs.findLastIndex(possibleLog => possibleLog.length !== 0);
 
-      if (indexOfLastLog !== -1) {
-        // We didn't find any logs in the current window so we stop looking
+      if (indexOfLastLog === -1) {
+        // We haven't found any logs in the current window so we stop looking
         break;
       }
 

--- a/yarn-project/pxe/src/simulator_oracle/index.ts
+++ b/yarn-project/pxe/src/simulator_oracle/index.ts
@@ -360,8 +360,8 @@ export class SimulatorOracle implements DBOracle {
     // we found and quit.
     // 2. If we don't find minimum consecutive empty logs in a window of logs we slide the window to latest log index
     // and repeat the process.
-    const WINDOW_SIZE = 20;
-    const MIN_CONSECUTIVE_EMPTY_LOGS = WINDOW_SIZE / 2;
+    const MIN_CONSECUTIVE_EMPTY_LOGS = 10;
+    const WINDOW_SIZE = MIN_CONSECUTIVE_EMPTY_LOGS * 2;
 
     let [numConsecutiveEmptyLogs, currentIndex] = [0, oldIndex];
     do {

--- a/yarn-project/pxe/src/simulator_oracle/index.ts
+++ b/yarn-project/pxe/src/simulator_oracle/index.ts
@@ -387,7 +387,7 @@ export class SimulatorOracle implements DBOracle {
 
       // We compute the number of consecutive empty logs we found and repeat the process if we haven't found enough.
       numConsecutiveEmptyLogs = WINDOW_SIZE - indexOfLastLog - 1;
-    } while (numConsecutiveEmptyLogs >= MIN_CONSECUTIVE_EMPTY_LOGS);
+    } while (numConsecutiveEmptyLogs < MIN_CONSECUTIVE_EMPTY_LOGS);
 
     const contractName = await this.contractDataOracle.getDebugContractName(contractAddress);
     if (currentIndex !== oldIndex) {

--- a/yarn-project/pxe/src/simulator_oracle/simulator_oracle.test.ts
+++ b/yarn-project/pxe/src/simulator_oracle/simulator_oracle.test.ts
@@ -292,12 +292,13 @@ describe('Simulator oracle', () => {
       let indexesAsSenderAfterSync = await database.getTaggingSecretsIndexesAsSender(secrets);
       expect(indexesAsSenderAfterSync).toStrictEqual([1, 1, 1, 1, 1, 2, 2, 2, 2, 2]);
 
-      // Two windows are fetch for each sender
-      expect(aztecNode.getLogsByTags.mock.calls.length).toBe(NUM_SENDERS * 2);
+      // Only 1 window is obtained for each sender
+      expect(aztecNode.getLogsByTags.mock.calls.length).toBe(NUM_SENDERS);
       aztecNode.getLogsByTags.mockReset();
 
-      // We add more logs at the end of the window to make sure we only detect them and bump the indexes if it lies within our window
-      senderOffset = 10;
+      // We add more logs to the second half of the window to test that a second iteration in `syncTaggedLogsAsSender`
+      // is handled correctly.
+      senderOffset = 11;
       generateMockLogs(senderOffset);
       for (let i = 0; i < senders.length; i++) {
         await simulatorOracle.syncTaggedLogsAsSender(
@@ -308,7 +309,7 @@ describe('Simulator oracle', () => {
       }
 
       indexesAsSenderAfterSync = await database.getTaggingSecretsIndexesAsSender(secrets);
-      expect(indexesAsSenderAfterSync).toStrictEqual([11, 11, 11, 11, 11, 12, 12, 12, 12, 12]);
+      expect(indexesAsSenderAfterSync).toStrictEqual([12, 12, 12, 12, 12, 13, 13, 13, 13, 13]);
 
       expect(aztecNode.getLogsByTags.mock.calls.length).toBe(NUM_SENDERS * 2);
     });

--- a/yarn-project/pxe/src/simulator_oracle/tagging_utils.ts
+++ b/yarn-project/pxe/src/simulator_oracle/tagging_utils.ts
@@ -1,5 +1,8 @@
 import { type Fr, IndexedTaggingSecret } from '@aztec/circuits.js';
 
+// Half the size of the window we slide over the tagging secret indexes.
+export const WINDOW_HALF_SIZE = 10;
+
 export function getIndexedTaggingSecretsForTheWindow(
   secretsAndWindows: { appTaggingSecret: Fr; leftMostIndex: number; rightMostIndex: number }[],
 ): IndexedTaggingSecret[] {


### PR DESCRIPTION
In this PR I optimize num requests to `node.getLogsByTags` done by `syncTaggedLogsAsSender`.

The algorithm is modified such that we double the window size and we quit if we find a sequence of empty slots which is equal to `MIN_CONSECUTIVE_EMPTY_LOGS`.

Why would this optimize num requests?

Because currently as it stands whenever there is a log found in the window we would do 2 requests because we are fetching window_size logs and we quit search when we stumble upon a window_size of no logs. This means that if any log was found we would have to fetch a new window.