### PR TITLE
fix: Block building test timeout

### DIFF
--- a/yarn-project/end-to-end/src/e2e_block_building.test.ts
+++ b/yarn-project/end-to-end/src/e2e_block_building.test.ts
@@ -287,6 +287,8 @@ describe('e2e_block_building', () => {
       testContract = await TestContract.deploy(owner).send().deployed();
     }, 60_000);
 
+    afterEach(() => teardown());
+
     it('calls a method with nested note encrypted logs', async () => {
       // account setup
       const privateKey = new Fr(7n);
@@ -394,14 +396,12 @@ describe('e2e_block_building', () => {
         .send()
         .deployed();
 
-      // We set the maximum number of txs per block to 12 to ensure that the sequencer will start building a block before it receives all the txs
-      // and also to avoid it building
-      logger.info('Updating min txs per block to 4, and max txs per block to 12');
-      await aztecNode.setConfig({ minTxsPerBlock: 4, maxTxsPerBlock: 12 });
+      logger.info('Updating txs per block to 4');
+      await aztecNode.setConfig({ minTxsPerBlock: 4, maxTxsPerBlock: 4 });
 
       logger.info('Spamming the network with public txs');
       const txs = [];
-      for (let i = 0; i < 30; i++) {
+      for (let i = 0; i < 24; i++) {
         const tx = token.methods.mint_to_public(owner.getAddress(), 10n);
         txs.push(tx.send({ skipPublicSimulation: false }));
       }

--- a/yarn-project/sequencer-client/src/sequencer/sequencer.ts
+++ b/yarn-project/sequencer-client/src/sequencer/sequencer.ts
@@ -128,7 +128,7 @@ export class Sequencer {
    * @param config - New parameters.
    */
   public updateConfig(config: SequencerConfig) {
-    this.log.info(`Sequencer config set`, omit(pickFromSchema(this.config, SequencerConfigSchema), 'allowedInSetup'));
+    this.log.info(`Sequencer config set`, omit(pickFromSchema(config, SequencerConfigSchema), 'allowedInSetup'));
 
     if (config.transactionPollingIntervalMS !== undefined) {
       this.pollingIntervalMs = config.transactionPollingIntervalMS;


### PR DESCRIPTION
The test `can simulate public txs while building a block` would, in some cases, build blocks with varying tx sizes. An example run built blocks with 4, 12, and 12 txs. This totals 28 txs, so the remaining 2 txs never get mined and the test timeout.

This fixes it by forcing the sequencer to build with just 4 txs consistently, and making the total number of txs a multiple of it.

