### PR TITLE
fix: toBlock argument in L1 getLogs is inclusive

### DIFF
--- a/yarn-project/archiver/src/archiver/data_retrieval.ts
+++ b/yarn-project/archiver/src/archiver/data_retrieval.ts
@@ -44,13 +44,15 @@ export async function retrieveBlocksFromRollup(
     if (searchStartBlock > searchEndBlock) {
       break;
     }
-    const l2BlockProposedLogs = await rollup.getEvents.L2BlockProposed(
-      {},
-      {
-        fromBlock: searchStartBlock,
-        toBlock: searchEndBlock + 1n,
-      },
-    );
+    const l2BlockProposedLogs = (
+      await rollup.getEvents.L2BlockProposed(
+        {},
+        {
+          fromBlock: searchStartBlock,
+          toBlock: searchEndBlock,
+        },
+      )
+    ).filter(log => log.blockNumber! >= searchStartBlock && log.blockNumber! <= searchEndBlock);
 
     if (l2BlockProposedLogs.length === 0) {
       break;
@@ -218,13 +220,15 @@ export async function retrieveL1ToL2Messages(
       break;
     }
 
-    const messageSentLogs = await inbox.getEvents.MessageSent(
-      {},
-      {
-        fromBlock: searchStartBlock,
-        toBlock: searchEndBlock + 1n,
-      },
-    );
+    const messageSentLogs = (
+      await inbox.getEvents.MessageSent(
+        {},
+        {
+          fromBlock: searchStartBlock,
+          toBlock: searchEndBlock,
+        },
+      )
+    ).filter(log => log.blockNumber! >= searchStartBlock && log.blockNumber! <= searchEndBlock);
 
     if (messageSentLogs.length === 0) {
       break;
@@ -251,7 +255,7 @@ export async function retrieveL2ProofVerifiedEvents(
   const logs = await publicClient.getLogs({
     address: rollupAddress.toString(),
     fromBlock: searchStartBlock,
-    toBlock: searchEndBlock ? searchEndBlock + 1n : undefined,
+    toBlock: searchEndBlock ? searchEndBlock : undefined,
     strict: true,
     event: getAbiItem({ abi: RollupAbi, name: 'L2ProofVerified' }),
   });

--- a/yarn-project/cli/src/cmds/l1/prover_stats.ts
+++ b/yarn-project/cli/src/cmds/l1/prover_stats.ts
@@ -181,7 +181,7 @@ async function getL2BlockEvents(
         name: 'L2BlockProposed',
       }),
       fromBlock: blockNum,
-      toBlock: end + 1n, // the toBlock argument in getLogs is exclusive
+      toBlock: end,
     });
 
     events.push(...newEvents);


### PR DESCRIPTION
As @alexghr identified, we got a spurious reorg on a node in the exp1 network. This was caused by the node getting a current `l1BlockNumber=245`, but then fetching an L2 block mined at 246. 

This caused the `canPrune` check to fail: 

```
const canPrune =
      localPendingBlockNumber > provenBlockNumber &&
      (await this.rollup.read.canPruneAtTime([time], { blockNumber: currentL1BlockNumber }));
```

The `canPruneAtTime` was evaluated at L1 block number 245, and it correctly returned true, since there had been a reorg shortly before (at 240), and no new L2 block had been mined so the rollup hadn't reset its state by then. However, the `localPendingBlockNumber` was incorrectly increased due to the block mined at 246, which caused the archiver to incorrectly reorg it.

This PR fixes the L1 event queries so the `toBlock` is inclusive. A quick test with cast shows that this is the case:
```
$ cast logs -r https://mainnet.infura.io/v3/$INFURA_API_KEY --from-block 0x146eade --to-block 0x146eadf --address 0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48 --json | jq .[].blockNumber | uniq
"0x146eade"
"0x146eadf"
```

And just for good measure, we also filter the logs returned by the block range searched.