### PR TITLE
feat: Claim epoch proof rights without a block

### DIFF
--- a/yarn-project/circuit-types/src/prover_coordination/epoch_proof_quote.ts
+++ b/yarn-project/circuit-types/src/prover_coordination/epoch_proof_quote.ts
@@ -78,6 +78,13 @@ export class EpochProofQuote extends Gossipable {
     };
   }
 
+  toInspect() {
+    return {
+      signature: this.signature.toString(),
+      ...this.payload.toInspect(),
+    };
+  }
+
   /**
    * Get the size of the epoch proof quote in bytes.
    * @returns The size of the epoch proof quote in bytes.

--- a/yarn-project/circuit-types/src/prover_coordination/epoch_proof_quote_payload.ts
+++ b/yarn-project/circuit-types/src/prover_coordination/epoch_proof_quote_payload.ts
@@ -114,6 +114,16 @@ export class EpochProofQuotePayload {
     };
   }
 
+  toInspect() {
+    return {
+      epochToProve: Number(this.epochToProve),
+      validUntilSlot: this.validUntilSlot.toString(),
+      bondAmount: this.bondAmount.toString(),
+      prover: this.prover.toString(),
+      basisPointFee: this.basisPointFee,
+    };
+  }
+
   getSize(): number {
     // We cache size to avoid recalculating it
     if (this.size) {

--- a/yarn-project/sequencer-client/src/publisher/l1-publisher-metrics.ts
+++ b/yarn-project/sequencer-client/src/publisher/l1-publisher-metrics.ts
@@ -1,4 +1,4 @@
-import type { L1PublishBlockStats, L1PublishProofStats } from '@aztec/circuit-types/stats';
+import type { L1PublishBlockStats, L1PublishProofStats, L1PublishStats } from '@aztec/circuit-types/stats';
 import {
   Attributes,
   type Histogram,
@@ -10,7 +10,7 @@ import {
 
 import { formatEther } from 'viem/utils';
 
-export type L1TxType = 'submitProof' | 'process';
+export type L1TxType = 'submitProof' | 'process' | 'claimEpochProofRight';
 
 export class L1PublisherMetrics {
   private gasPrice: Histogram;
@@ -74,7 +74,11 @@ export class L1PublisherMetrics {
     this.recordTx('process', durationMs, stats);
   }
 
-  private recordTx(txType: L1TxType, durationMs: number, stats: Omit<L1PublishProofStats, 'eventName'>) {
+  recordClaimEpochProofRightTx(durationMs: number, stats: L1PublishStats) {
+    this.recordTx('claimEpochProofRight', durationMs, stats);
+  }
+
+  private recordTx(txType: L1TxType, durationMs: number, stats: L1PublishStats) {
     const attributes = {
       [Attributes.L1_TX_TYPE]: txType,
       [Attributes.L1_SENDER]: stats.sender,

--- a/yarn-project/sequencer-client/src/publisher/l1-publisher.ts
+++ b/yarn-project/sequencer-client/src/publisher/l1-publisher.ts
@@ -7,7 +7,7 @@ import {
   type TxHash,
   getHashedSignaturePayload,
 } from '@aztec/circuit-types';
-import { type L1PublishBlockStats, type L1PublishProofStats } from '@aztec/circuit-types/stats';
+import { type L1PublishBlockStats, type L1PublishProofStats, type L1PublishStats } from '@aztec/circuit-types/stats';
 import {
   AGGREGATION_OBJECT_LENGTH,
   AZTEC_MAX_EPOCH_DURATION,
@@ -38,7 +38,6 @@ import { ExtRollupLibAbi, GovernanceProposerAbi, LeonidasLibAbi, RollupAbi } fro
 import { type TelemetryClient } from '@aztec/telemetry-client';
 
 import pick from 'lodash.pick';
-import { inspect } from 'util';
 import {
   type BaseError,
   type Chain,
@@ -71,7 +70,7 @@ import { privateKeyToAccount } from 'viem/accounts';
 
 import { type PublisherConfig, type TxSenderConfig } from './config.js';
 import { L1PublisherMetrics } from './l1-publisher-metrics.js';
-import { prettyLogViemError, prettyLogViemErrorMsg } from './utils.js';
+import { prettyLogViemErrorMsg } from './utils.js';
 
 /**
  * Stats for a sent transaction.
@@ -615,6 +614,53 @@ export class L1Publisher {
     return false;
   }
 
+  /** Calls claimEpochProofRight in the Rollup contract to submit a chosen prover quote for the previous epoch. */
+  public async claimEpochProofRight(proofQuote: EpochProofQuote) {
+    const timer = new Timer();
+
+    let receipt;
+    try {
+      this.log.debug(`Submitting claimEpochProofRight transaction`);
+      receipt = await this.l1TxUtils.sendAndMonitorTransaction({
+        to: this.rollupContract.address,
+        data: encodeFunctionData({
+          abi: RollupAbi,
+          functionName: 'claimEpochProofRight',
+          args: [proofQuote.toViemArgs()],
+        }),
+      });
+    } catch (err) {
+      this.log.error(`Failed to claim epoch proof right: ${prettyLogViemErrorMsg(err)}`, err, {
+        proofQuote: proofQuote.toInspect(),
+      });
+      return false;
+    }
+
+    if (receipt.status === 'success') {
+      const tx = await this.getTransactionStats(receipt.transactionHash);
+      const stats: L1PublishStats = {
+        gasPrice: receipt.effectiveGasPrice,
+        gasUsed: receipt.gasUsed,
+        transactionHash: receipt.transactionHash,
+        ...pick(tx!, 'calldataGas', 'calldataSize', 'sender'),
+      };
+      this.log.verbose(`Submitted claim epoch proof right to L1 rollup contract`, {
+        ...stats,
+        ...proofQuote.toInspect(),
+      });
+      this.metrics.recordClaimEpochProofRightTx(timer.ms(), stats);
+      return true;
+    } else {
+      this.metrics.recordFailedTx('claimEpochProofRight');
+      // TODO: Get the error message from the reverted tx
+      this.log.error(`Claim epoch proof right tx reverted`, {
+        txHash: receipt.transactionHash,
+        ...proofQuote.toInspect(),
+      });
+      return false;
+    }
+  }
+
   private async tryGetErrorFromRevertedTx(
     data: Hex,
     args: {
@@ -958,8 +1004,7 @@ export class L1Publisher {
         data,
       };
     } catch (err) {
-      prettyLogViemError(err, this.log);
-      this.log.error(`Rollup publish failed`, err);
+      this.log.error(`Rollup publish failed: ${prettyLogViemErrorMsg(err)}`, err);
       return undefined;
     }
   }
@@ -972,9 +1017,6 @@ export class L1Publisher {
       return undefined;
     }
     try {
-      this.log.info(`ProposeAndClaim`);
-      this.log.info(inspect(quote.payload));
-
       const kzg = Blob.getViemKzgInstance();
       const { args, gas } = await this.prepareProposeTx(encodedData);
       const data = encodeFunctionData({
@@ -1002,9 +1044,7 @@ export class L1Publisher {
         data,
       };
     } catch (err) {
-      prettyLogViemError(err, this.log);
-      const errorMessage = err instanceof Error ? err.message : String(err);
-      this.log.error(`Rollup publish failed`, errorMessage);
+      this.log.error(`Rollup publish failed: ${prettyLogViemErrorMsg(err)}`, err);
       return undefined;
     }
   }

--- a/yarn-project/sequencer-client/src/publisher/utils.ts
+++ b/yarn-project/sequencer-client/src/publisher/utils.ts
@@ -1,5 +1,3 @@
-import { type Logger } from '@aztec/foundation/log';
-
 import { BaseError, ContractFunctionRevertedError } from 'viem';
 
 export function prettyLogViemErrorMsg(err: any) {
@@ -12,12 +10,5 @@ export function prettyLogViemErrorMsg(err: any) {
       return `${errorName}${args}`;
     }
   }
-}
-
-// TODO(palla/log): Review this method
-export function prettyLogViemError(err: any, logger: Logger) {
-  const msg = prettyLogViemErrorMsg(err);
-  if (msg) {
-    logger.debug(`canProposeAtTime failed with "${msg}"`);
-  }
+  return err?.message ?? err;
 }

--- a/yarn-project/sequencer-client/src/sequencer/sequencer.ts
+++ b/yarn-project/sequencer-client/src/sequencer/sequencer.ts
@@ -283,6 +283,7 @@ export class Sequencer {
     const pendingTxs = await this.p2pClient.getPendingTxs();
 
     if (!this.shouldProposeBlock(historicalHeader, { pendingTxsCount: pendingTxs.length })) {
+      await this.claimEpochProofRightIfAvailable(slot);
       return;
     }
 
@@ -315,6 +316,7 @@ export class Sequencer {
 
     // Bail if we don't have enough valid txs
     if (!this.shouldProposeBlock(historicalHeader, { validTxsCount: validTxs.length })) {
+      await this.claimEpochProofRightIfAvailable(slot);
       return;
     }
 
@@ -428,7 +430,7 @@ export class Sequencer {
     );
 
     // We need to have at least minTxsPerBLock txs.
-    if (args.pendingTxsCount != undefined && args.pendingTxsCount < this.minTxsPerBLock) {
+    if (args.pendingTxsCount !== undefined && args.pendingTxsCount < this.minTxsPerBLock) {
       this.log.verbose(
         `Not creating block because not enough txs in the pool (got ${args.pendingTxsCount} min ${this.minTxsPerBLock})`,
       );
@@ -436,7 +438,7 @@ export class Sequencer {
     }
 
     // Bail if we don't have enough valid txs
-    if (args.validTxsCount != undefined && args.validTxsCount < this.minTxsPerBLock) {
+    if (args.validTxsCount !== undefined && args.validTxsCount < this.minTxsPerBLock) {
       this.log.verbose(
         `Not creating block because not enough valid txs loaded from the pool (got ${args.validTxsCount} min ${this.minTxsPerBLock})`,
       );
@@ -701,7 +703,7 @@ export class Sequencer {
       // Find out which epoch we are currently in
       const epochToProve = await this.publisher.getClaimableEpoch();
       if (epochToProve === undefined) {
-        this.log.debug(`No epoch to prove`);
+        this.log.trace(`No epoch to prove at slot ${slotNumber}`);
         return undefined;
       }
 
@@ -714,7 +716,10 @@ export class Sequencer {
       });
       // ensure these quotes are still valid for the slot and have the contract validate them
       const validQuotesPromise = Promise.all(
-        quotes.filter(x => x.payload.validUntilSlot >= slotNumber).map(x => this.publisher.validateProofQuote(x)),
+        quotes
+          .filter(x => x.payload.validUntilSlot >= slotNumber)
+          .filter(x => x.payload.epochToProve === epochToProve)
+          .map(x => this.publisher.validateProofQuote(x)),
       );
 
       const validQuotes = (await validQuotesPromise).filter((q): q is EpochProofQuote => !!q);
@@ -727,7 +732,7 @@ export class Sequencer {
         (a: EpochProofQuote, b: EpochProofQuote) => a.payload.basisPointFee - b.payload.basisPointFee,
       );
       const quote = sortedQuotes[0];
-      this.log.info(`Selected proof quote for proof claim`, quote.payload);
+      this.log.info(`Selected proof quote for proof claim`, { quote: quote.toInspect() });
       return quote;
     } catch (err) {
       this.log.error(`Failed to create proof claim for previous epoch`, err, { slotNumber });
@@ -785,6 +790,29 @@ export class Sequencer {
     }
 
     return toReturn;
+  }
+
+  @trackSpan(
+    'Sequencer.claimEpochProofRightIfAvailable',
+    slotNumber => ({ [Attributes.SLOT_NUMBER]: Number(slotNumber) }),
+    epoch => ({ [Attributes.EPOCH_NUMBER]: Number(epoch) }),
+  )
+  /** Collects an epoch proof quote if there is an epoch to prove, and submits it to the L1 contract. */
+  protected async claimEpochProofRightIfAvailable(slotNumber: bigint) {
+    const proofQuote = await this.createProofClaimForPreviousEpoch(slotNumber);
+    if (proofQuote === undefined) {
+      return;
+    }
+
+    const epoch = proofQuote.payload.epochToProve;
+    const ctx = { slotNumber, epoch, quote: proofQuote.toInspect() };
+    this.log.verbose(`Claiming proof right for epoch ${epoch}`, ctx);
+    const success = await this.publisher.claimEpochProofRight(proofQuote);
+    if (!success) {
+      throw new Error(`Failed to claim proof right for epoch ${epoch}`);
+    }
+    this.log.info(`Claimed proof right for epoch ${epoch}`, ctx);
+    return epoch;
   }
 
   /**


### PR DESCRIPTION
If the sequencer does not have enough txs to build a block, it will still try to submit an epoch proof if there's one available.

Fixes #9404
