### PR TITLE
refactor: `contact` --> `sender` in PXE API

### DIFF
--- a/docs/docs/migration_notes.md
+++ b/docs/docs/migration_notes.md
@@ -54,6 +54,17 @@ Also created a public function `pull_funds()` for admin to clawback any money in
 
 Expect more changes in FPC in the coming releases!
 
+## TBD
+
+### PXE.registerContact --> PXE.registerSender
+`registerContact` has been deemed confusing because the name is too similar to `registerContract`.
+For this reason we've decided to rename it:
+
+```diff
+- await pxe.registerContact(address);
++ await pxe.registerSender(address);
+```
+
 ## 0.67.1
 
 ### Noir contracts package no longer exposes artifacts as default export

--- a/docs/docs/migration_notes.md
+++ b/docs/docs/migration_notes.md
@@ -56,13 +56,17 @@ Expect more changes in FPC in the coming releases!
 
 ## TBD
 
-### PXE.registerContact --> PXE.registerSender
-`registerContact` has been deemed confusing because the name is too similar to `registerContract`.
+### Name change from `contact` to `sender` in PXE API
+`contact` has been deemed confusing because the name is too similar to `contract`.
 For this reason we've decided to rename it:
 
 ```diff
 - await pxe.registerContact(address);
 + await pxe.registerSender(address);
+- await pxe.getContacts();
++ await pxe.getSenders();
+- await pxe.removeContact(address);
++ await pxe.removeSender(address);
 ```
 
 ## 0.67.1

--- a/docs/docs/migration_notes.md
+++ b/docs/docs/migration_notes.md
@@ -6,7 +6,7 @@ keywords: [sandbox, aztec, notes, migration, updating, upgrading]
 
 Aztec is in full-speed development. Literally every version breaks compatibility with the previous ones. This page attempts to target errors and difficulties you might encounter when upgrading, and how to resolve them.
 ## 0.68.0
-### [archiver, node, pxe] Remove contract artifacts in node and archiver and store function names instead 
+### [archiver, node, pxe] Remove contract artifacts in node and archiver and store function names instead
 Contract artifacts were only in the archiver for debugging purposes. Instead function names are now (optionally) emitted
 when registering contract classes
 
@@ -53,8 +53,6 @@ Rename of args in all of FPC functions as FPC now stores the accepted token addr
 Also created a public function `pull_funds()` for admin to clawback any money in the FPC
 
 Expect more changes in FPC in the coming releases!
-
-## TBD
 
 ### Name change from `contact` to `sender` in PXE API
 `contact` has been deemed confusing because the name is too similar to `contract`.

--- a/yarn-project/aztec.js/src/wallet/base_wallet.ts
+++ b/yarn-project/aztec.js/src/wallet/base_wallet.ts
@@ -89,11 +89,11 @@ export abstract class BaseWallet implements Wallet {
   registerSender(address: AztecAddress): Promise<AztecAddress> {
     return this.pxe.registerSender(address);
   }
-  getContacts(): Promise<AztecAddress[]> {
-    return this.pxe.getContacts();
+  getSenders(): Promise<AztecAddress[]> {
+    return this.pxe.getSenders();
   }
-  async removeContact(address: AztecAddress): Promise<void> {
-    await this.pxe.removeContact(address);
+  async removeSender(address: AztecAddress): Promise<void> {
+    await this.pxe.removeSender(address);
   }
   registerContract(contract: {
     /** Instance */ instance: ContractInstanceWithAddress;

--- a/yarn-project/aztec.js/src/wallet/base_wallet.ts
+++ b/yarn-project/aztec.js/src/wallet/base_wallet.ts
@@ -86,8 +86,8 @@ export abstract class BaseWallet implements Wallet {
   getRegisteredAccount(address: AztecAddress): Promise<CompleteAddress | undefined> {
     return this.pxe.getRegisteredAccount(address);
   }
-  registerContact(address: AztecAddress): Promise<AztecAddress> {
-    return this.pxe.registerContact(address);
+  registerSender(address: AztecAddress): Promise<AztecAddress> {
+    return this.pxe.registerSender(address);
   }
   getContacts(): Promise<AztecAddress[]> {
     return this.pxe.getContacts();

--- a/yarn-project/circuit-types/src/interfaces/pxe.test.ts
+++ b/yarn-project/circuit-types/src/interfaces/pxe.test.ts
@@ -118,8 +118,8 @@ describe('PXESchema', () => {
     expect(result).toBeInstanceOf(CompleteAddress);
   });
 
-  it('registerContact', async () => {
-    const result = await context.client.registerContact(address);
+  it('registerSender', async () => {
+    const result = await context.client.registerSender(address);
     expect(result).toEqual(address);
   });
 
@@ -344,7 +344,7 @@ class MockPXE implements PXE {
     expect(address).toBeInstanceOf(AztecAddress);
     return Promise.resolve(CompleteAddress.random());
   }
-  registerContact(address: AztecAddress): Promise<AztecAddress> {
+  registerSender(address: AztecAddress): Promise<AztecAddress> {
     expect(address).toBeInstanceOf(AztecAddress);
     return Promise.resolve(this.address);
   }

--- a/yarn-project/circuit-types/src/interfaces/pxe.test.ts
+++ b/yarn-project/circuit-types/src/interfaces/pxe.test.ts
@@ -123,13 +123,13 @@ describe('PXESchema', () => {
     expect(result).toEqual(address);
   });
 
-  it('getContacts', async () => {
-    const result = await context.client.getContacts();
+  it('getSenders', async () => {
+    const result = await context.client.getSenders();
     expect(result).toEqual([address]);
   });
 
-  it('removeContact', async () => {
-    await context.client.removeContact(address);
+  it('removeSender', async () => {
+    await context.client.removeSender(address);
   });
 
   it('registerContractClass', async () => {
@@ -348,10 +348,10 @@ class MockPXE implements PXE {
     expect(address).toBeInstanceOf(AztecAddress);
     return Promise.resolve(this.address);
   }
-  getContacts(): Promise<AztecAddress[]> {
+  getSenders(): Promise<AztecAddress[]> {
     return Promise.resolve([this.address]);
   }
-  removeContact(address: AztecAddress): Promise<void> {
+  removeSender(address: AztecAddress): Promise<void> {
     expect(address).toBeInstanceOf(AztecAddress);
     return Promise.resolve();
   }

--- a/yarn-project/circuit-types/src/interfaces/pxe.ts
+++ b/yarn-project/circuit-types/src/interfaces/pxe.ts
@@ -126,15 +126,15 @@ export interface PXE {
   registerSender(address: AztecAddress): Promise<AztecAddress>;
 
   /**
-   * Retrieves the addresses stored as contacts on this PXE Service.
-   * @returns An array of the contacts on this PXE Service.
+   * Retrieves the addresses stored as senders on this PXE Service.
+   * @returns An array of the senders on this PXE Service.
    */
-  getContacts(): Promise<AztecAddress[]>;
+  getSenders(): Promise<AztecAddress[]>;
 
   /**
-   * Removes a contact in the address book.
+   * Removes a sender in the address book.
    */
-  removeContact(address: AztecAddress): Promise<void>;
+  removeSender(address: AztecAddress): Promise<void>;
 
   /**
    * Registers a contract class in the PXE without registering any associated contract instance with it.
@@ -468,8 +468,8 @@ export const PXESchema: ApiSchemaFor<PXE> = {
     .args(schemas.AztecAddress)
     .returns(z.union([CompleteAddress.schema, z.undefined()])),
   registerSender: z.function().args(schemas.AztecAddress).returns(schemas.AztecAddress),
-  getContacts: z.function().returns(z.array(schemas.AztecAddress)),
-  removeContact: z.function().args(schemas.AztecAddress).returns(z.void()),
+  getSenders: z.function().returns(z.array(schemas.AztecAddress)),
+  removeSender: z.function().args(schemas.AztecAddress).returns(z.void()),
   registerContractClass: z.function().args(ContractArtifactSchema).returns(z.void()),
   registerContract: z
     .function()

--- a/yarn-project/circuit-types/src/interfaces/pxe.ts
+++ b/yarn-project/circuit-types/src/interfaces/pxe.ts
@@ -123,7 +123,7 @@ export interface PXE {
    * @param address - Address of the user to add to the address book
    * @returns The address address of the account.
    */
-  registerContact(address: AztecAddress): Promise<AztecAddress>;
+  registerSender(address: AztecAddress): Promise<AztecAddress>;
 
   /**
    * Retrieves the addresses stored as contacts on this PXE Service.
@@ -467,7 +467,7 @@ export const PXESchema: ApiSchemaFor<PXE> = {
     .function()
     .args(schemas.AztecAddress)
     .returns(z.union([CompleteAddress.schema, z.undefined()])),
-  registerContact: z.function().args(schemas.AztecAddress).returns(schemas.AztecAddress),
+  registerSender: z.function().args(schemas.AztecAddress).returns(schemas.AztecAddress),
   getContacts: z.function().returns(z.array(schemas.AztecAddress)),
   removeContact: z.function().args(schemas.AztecAddress).returns(z.void()),
   registerContractClass: z.function().args(ContractArtifactSchema).returns(z.void()),

--- a/yarn-project/cli-wallet/src/cmds/index.ts
+++ b/yarn-project/cli-wallet/src/cmds/index.ts
@@ -628,13 +628,13 @@ export function injectCommands(
     .addOption(createAccountOption('Alias or address of the account to simulate from', !db, db))
     .addOption(createAliasOption('Alias for the contact. Used for easy reference in subsequent commands.', !db))
     .action(async (address, options) => {
-      const { registerContact } = await import('./register_contact.js');
+      const { registerSender } = await import('./register_contact.js');
       const { from: parsedFromAddress, rpcUrl, secretKey, alias } = options;
       const client = pxeWrapper?.getPXE() ?? (await createCompatibleClient(rpcUrl, debugLogger));
       const account = await createOrRetrieveAccount(client, parsedFromAddress, db, secretKey);
       const wallet = await getWalletWithScopes(account, db);
 
-      await registerContact(wallet, address, log);
+      await registerSender(wallet, address, log);
 
       if (db && alias) {
         await db.storeContact(address, alias, log);

--- a/yarn-project/cli-wallet/src/cmds/index.ts
+++ b/yarn-project/cli-wallet/src/cmds/index.ts
@@ -617,18 +617,18 @@ export function injectCommands(
     });
 
   program
-    .command('register-contact')
+    .command('register-sender')
     .description(
-      "Registers a contact's address in the wallet, so the note synching process will look for notes sent by them",
+      "Registers a sender's address in the wallet, so the note synching process will look for notes sent by them",
     )
-    .argument('[address]', 'The address of the contact to register', address =>
+    .argument('[address]', 'The address of the sender to register', address =>
       aliasedAddressParser('accounts', address, db),
     )
     .addOption(pxeOption)
     .addOption(createAccountOption('Alias or address of the account to simulate from', !db, db))
-    .addOption(createAliasOption('Alias for the contact. Used for easy reference in subsequent commands.', !db))
+    .addOption(createAliasOption('Alias for the sender. Used for easy reference in subsequent commands.', !db))
     .action(async (address, options) => {
-      const { registerSender } = await import('./register_contact.js');
+      const { registerSender } = await import('./register_sender.js');
       const { from: parsedFromAddress, rpcUrl, secretKey, alias } = options;
       const client = pxeWrapper?.getPXE() ?? (await createCompatibleClient(rpcUrl, debugLogger));
       const account = await createOrRetrieveAccount(client, parsedFromAddress, db, secretKey);
@@ -637,7 +637,7 @@ export function injectCommands(
       await registerSender(wallet, address, log);
 
       if (db && alias) {
-        await db.storeContact(address, alias, log);
+        await db.storeSender(address, alias, log);
       }
     });
 

--- a/yarn-project/cli-wallet/src/cmds/register_contact.ts
+++ b/yarn-project/cli-wallet/src/cmds/register_contact.ts
@@ -1,7 +1,7 @@
 import { type AccountWalletWithSecretKey, type AztecAddress } from '@aztec/aztec.js';
 import { type LogFn } from '@aztec/foundation/log';
 
-export async function registerContact(wallet: AccountWalletWithSecretKey, address: AztecAddress, log: LogFn) {
-  await wallet.registerContact(address);
+export async function registerSender(wallet: AccountWalletWithSecretKey, address: AztecAddress, log: LogFn) {
+  await wallet.registerSender(address);
   log(`Contact registered: ${address}`);
 }

--- a/yarn-project/cli-wallet/src/cmds/register_sender.ts
+++ b/yarn-project/cli-wallet/src/cmds/register_sender.ts
@@ -3,5 +3,5 @@ import { type LogFn } from '@aztec/foundation/log';
 
 export async function registerSender(wallet: AccountWalletWithSecretKey, address: AztecAddress, log: LogFn) {
   await wallet.registerSender(address);
-  log(`Contact registered: ${address}`);
+  log(`Sender registered: ${address}`);
 }

--- a/yarn-project/cli-wallet/src/storage/wallet_db.ts
+++ b/yarn-project/cli-wallet/src/storage/wallet_db.ts
@@ -82,9 +82,9 @@ export class WalletDB {
     log(`Account stored in database with alias${alias ? `es last & ${alias}` : ' last'}`);
   }
 
-  async storeContact(address: AztecAddress, alias: string, log: LogFn) {
+  async storeSender(address: AztecAddress, alias: string, log: LogFn) {
     await this.#aliases.set(`accounts:${alias}`, Buffer.from(address.toString()));
-    log(`Account stored in database with alias ${alias} as a contact`);
+    log(`Account stored in database with alias ${alias} as a sender`);
   }
 
   async storeContract(address: AztecAddress, artifactPath: string, log: LogFn, alias?: string) {

--- a/yarn-project/end-to-end/src/e2e_2_pxes.test.ts
+++ b/yarn-project/end-to-end/src/e2e_2_pxes.test.ts
@@ -49,8 +49,8 @@ describe('e2e_2_pxes', () => {
      What is a more robust solution? */
     await sleep(5000);
 
-    await walletA.registerContact(walletB.getAddress());
-    await walletB.registerContact(walletA.getAddress());
+    await walletA.registerSender(walletB.getAddress());
+    await walletB.registerSender(walletA.getAddress());
   });
 
   afterEach(async () => {
@@ -182,13 +182,13 @@ describe('e2e_2_pxes', () => {
     const sharedAccountAddress = sharedAccountOnA.getCompleteAddress();
     const sharedWalletOnA = await sharedAccountOnA.waitSetup();
 
-    await sharedWalletOnA.registerContact(walletA.getAddress());
+    await sharedWalletOnA.registerSender(walletA.getAddress());
 
     const sharedAccountOnB = getUnsafeSchnorrAccount(pxeB, sharedSecretKey, sharedAccountOnA.salt);
     await sharedAccountOnB.register();
     const sharedWalletOnB = await sharedAccountOnB.getWallet();
 
-    await sharedWalletOnB.registerContact(sharedWalletOnA.getAddress());
+    await sharedWalletOnB.registerSender(sharedWalletOnA.getAddress());
 
     // deploy the contract on PXE A
     const token = await deployToken(walletA, initialBalance, logger);

--- a/yarn-project/end-to-end/src/e2e_crowdfunding_and_claim.test.ts
+++ b/yarn-project/end-to-end/src/e2e_crowdfunding_and_claim.test.ts
@@ -116,7 +116,7 @@ describe('e2e_crowdfunding_and_claim', () => {
     // as a contact to all donor wallets, so they can receive notes
     await Promise.all(
       donorWallets.map(async wallet => {
-        await wallet.registerContact(operatorWallet.getAddress());
+        await wallet.registerSender(operatorWallet.getAddress());
       }),
     );
     // Now we mint DNT to donors

--- a/yarn-project/pxe/src/database/kv_pxe_database.ts
+++ b/yarn-project/pxe/src/database/kv_pxe_database.ts
@@ -538,7 +538,7 @@ export class KVPxeDatabase implements PxeDatabase {
     return (await toArray(this.#completeAddresses.valuesAsync())).map(v => CompleteAddress.fromBuffer(v));
   }
 
-  async addContactAddress(address: AztecAddress): Promise<boolean> {
+  async addSenderAddress(address: AztecAddress): Promise<boolean> {
     if (await this.#addressBook.hasAsync(address.toString())) {
       return false;
     }
@@ -548,11 +548,11 @@ export class KVPxeDatabase implements PxeDatabase {
     return true;
   }
 
-  async getContactAddresses(): Promise<AztecAddress[]> {
+  async getSenderAddresses(): Promise<AztecAddress[]> {
     return (await toArray(this.#addressBook.entriesAsync())).map(AztecAddress.fromString);
   }
 
-  async removeContactAddress(address: AztecAddress): Promise<boolean> {
+  async removeSenderAddress(address: AztecAddress): Promise<boolean> {
     if (!this.#addressBook.hasAsync(address.toString())) {
       return false;
     }

--- a/yarn-project/pxe/src/database/pxe_database.ts
+++ b/yarn-project/pxe/src/database/pxe_database.ts
@@ -119,24 +119,24 @@ export interface PxeDatabase extends ContractArtifactDatabase, ContractInstanceD
   setHeader(header: BlockHeader): Promise<void>;
 
   /**
-   * Adds contact address to the database.
+   * Adds sender address to the database.
    * @param address - The address to add to the address book.
    * @returns A promise resolving to true if the address was added, false if it already exists.
    */
-  addContactAddress(address: AztecAddress): Promise<boolean>;
+  addSenderAddress(address: AztecAddress): Promise<boolean>;
 
   /**
-   * Retrieves the list of contact addresses in the address book.
+   * Retrieves the list of sender addresses in the address book.
    * @returns An array of Aztec addresses.
    */
-  getContactAddresses(): Promise<AztecAddress[]>;
+  getSenderAddresses(): Promise<AztecAddress[]>;
 
   /**
-   * Removes a contact address from the database.
+   * Removes a sender address from the database.
    * @param address - The address to remove from the address book.
    * @returns A promise resolving to true if the address was removed, false if it does not exist.
    */
-  removeContactAddress(address: AztecAddress): Promise<boolean>;
+  removeSenderAddress(address: AztecAddress): Promise<boolean>;
 
   /**
    * Adds complete address to the database.

--- a/yarn-project/pxe/src/pxe_service/pxe_service.ts
+++ b/yarn-project/pxe/src/pxe_service/pxe_service.ts
@@ -167,34 +167,34 @@ export class PXEService implements PXE {
   public async registerSender(address: AztecAddress): Promise<AztecAddress> {
     const accounts = await this.keyStore.getAccounts();
     if (accounts.includes(address)) {
-      this.log.info(`Account:\n "${address.toString()}"\n already registered.`);
+      this.log.info(`Sender:\n "${address.toString()}"\n already registered.`);
       return address;
     }
 
-    const wasAdded = await this.db.addContactAddress(address);
+    const wasAdded = await this.db.addSenderAddress(address);
 
     if (wasAdded) {
-      this.log.info(`Added contact:\n ${address.toString()}`);
+      this.log.info(`Added sender:\n ${address.toString()}`);
     } else {
-      this.log.info(`Contact:\n "${address.toString()}"\n already registered.`);
+      this.log.info(`Sender:\n "${address.toString()}"\n already registered.`);
     }
 
     return address;
   }
 
-  public getContacts(): Promise<AztecAddress[]> {
-    const contacts = this.db.getContactAddresses();
+  public getSenders(): Promise<AztecAddress[]> {
+    const senders = this.db.getSenderAddresses();
 
-    return Promise.resolve(contacts);
+    return Promise.resolve(senders);
   }
 
-  public async removeContact(address: AztecAddress): Promise<void> {
-    const wasRemoved = await this.db.removeContactAddress(address);
+  public async removeSender(address: AztecAddress): Promise<void> {
+    const wasRemoved = await this.db.removeSenderAddress(address);
 
     if (wasRemoved) {
-      this.log.info(`Removed contact:\n ${address.toString()}`);
+      this.log.info(`Removed sender:\n ${address.toString()}`);
     } else {
-      this.log.info(`Contact:\n "${address.toString()}"\n not in address book.`);
+      this.log.info(`Sender:\n "${address.toString()}"\n not in address book.`);
     }
 
     return Promise.resolve();

--- a/yarn-project/pxe/src/pxe_service/pxe_service.ts
+++ b/yarn-project/pxe/src/pxe_service/pxe_service.ts
@@ -164,7 +164,7 @@ export class PXEService implements PXE {
     return accountCompleteAddress;
   }
 
-  public async registerContact(address: AztecAddress): Promise<AztecAddress> {
+  public async registerSender(address: AztecAddress): Promise<AztecAddress> {
     const accounts = await this.keyStore.getAccounts();
     if (accounts.includes(address)) {
       this.log.info(`Account:\n "${address.toString()}"\n already registered.`);

--- a/yarn-project/pxe/src/simulator_oracle/simulator_oracle.test.ts
+++ b/yarn-project/pxe/src/simulator_oracle/simulator_oracle.test.ts
@@ -226,7 +226,7 @@ describe('Simulator oracle', () => {
         return { completeAddress, ivsk: keys.masterIncomingViewingSecretKey, secretKey: new Fr(index) };
       });
       for (const sender of senders) {
-        await database.addContactAddress(sender.completeAddress.address);
+        await database.addSenderAddress(sender.completeAddress.address);
       }
       aztecNode.getLogsByTags.mockReset();
     });


### PR DESCRIPTION
`registerContact` has been deemed confusing because the name is too similar to `registerContract`.
For this reason we've decided to rename it.
