### PR TITLE
fix: don't U128::from_integer(u128)

### DIFF
--- a/noir-projects/noir-contracts/contracts/lending_contract/src/main.nr
+++ b/noir-projects/noir-contracts/contracts/lending_contract/src/main.nr
@@ -313,11 +313,8 @@ contract Lending {
         let collateral = storage.collateral.at(owner).read();
         let static_debt = storage.static_debt.at(owner).read();
         let asset: Asset = storage.assets.at(0).read();
-        let debt = debt_value(
-            U128::from_integer(static_debt),
-            U128::from_integer(asset.interest_accumulator),
-        )
-            .to_integer();
+        let debt =
+            debt_value(U128::from_integer(static_debt), asset.interest_accumulator).to_integer();
         Position { collateral, static_debt, debt }
     }
 

--- a/noir-projects/noir-contracts/contracts/spam_contract/src/main.nr
+++ b/noir-projects/noir-contracts/contracts/spam_contract/src/main.nr
@@ -33,7 +33,7 @@ contract Spam {
         let amount = U128::from_integer(1);
 
         for _ in 0..MAX_NOTE_HASHES_PER_CALL {
-            storage.balances.at(caller).add(caller, U128::from_integer(amount)).emit(
+            storage.balances.at(caller).add(caller, amount).emit(
                 encode_and_encrypt_note_unconstrained(&mut context, caller, caller),
             );
         }


### PR DESCRIPTION
In Noir we are removing the (private) built-ins `as_field` and `from_field`, which allowed casting any type to and from Field by truncating its bits. This uncovered two bugs where we were doing `U128::from_integer(x)` with `x` itself being a `U128`. That code won't compile anymore (and I think it was incorrect) so I'm doing those changes in this PR.

See https://github.com/noir-lang/noir/pull/6845