### PR TITLE
chore: increase default peer discovery heartbeat to 30 seconds

### DIFF
--- a/yarn-project/p2p/src/config.ts
+++ b/yarn-project/p2p/src/config.ts
@@ -170,7 +170,7 @@ export const p2pConfigMappings: ConfigMappingsType<P2PConfig> = {
   peerCheckIntervalMS: {
     env: 'P2P_PEER_CHECK_INTERVAL_MS',
     description: 'The frequency in which to check for new peers.',
-    ...numberConfigHelper(1_000),
+    ...numberConfigHelper(30_000),
   },
   l2QueueSize: {
     env: 'P2P_L2_QUEUE_SIZE',


### PR DESCRIPTION
Inline with the value of this setting in lodestar