### PR TITLE
fix(avm): Set GITHUB_RUN_URL in github action config of AVM full tests

### DIFF
--- a/.github/workflows/vm_full_tests.yml
+++ b/.github/workflows/vm_full_tests.yml
@@ -24,6 +24,7 @@ jobs:
       AWS_ACCESS_KEY_ID: ${{ secrets.AWS_ACCESS_KEY_ID }}
       AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
       BUILD_INSTANCE_SSH_KEY: ${{ secrets.BUILD_INSTANCE_SSH_KEY }}
+      GITHUB_RUN_URL: "https://github.com/${{ github.repository }}/actions/runs/${{ github.run_id }}/attempts/${{ github.run_attempt }}"
       GIT_COMMIT: ${{ github.sha }}
     steps:
       - uses: actions/checkout@v4

--- a/.github/workflows/vm_full_tests.yml
+++ b/.github/workflows/vm_full_tests.yml
@@ -35,4 +35,4 @@ jobs:
         with:
           run: |
             sudo shutdown -P 75 # hack until core part of the scripts
-            earthly-ci --no-output ./barretenberg/cpp/+vm-full-test --hardware_concurrency=64  # limit our parallelism to half our cores
+            scripts/earthly-ci --no-output ./barretenberg/cpp/+vm-full-test --hardware_concurrency=64  # limit our parallelism to half our cores


### PR DESCRIPTION
Fix for AVM full tests github action in new CI 2.5
Should fix failure like: https://github.com/AztecProtocol/aztec-packages/actions/runs/12408496961/job/34640280753 