### PR TITLE
fix: double slash in faucet URL

### DIFF
--- a/yarn-project/cli/src/cmds/devnet/faucet.ts
+++ b/yarn-project/cli/src/cmds/devnet/faucet.ts
@@ -10,7 +10,7 @@ export async function dripFaucet(
   json: boolean,
   log: LogFn,
 ): Promise<void> {
-  const url = new URL(`${faucetUrl}/drip/${account.toString()}`);
+  const url = new URL(`/drip/${account.toString()}`, faucetUrl);
   url.searchParams.set('asset', asset);
   const res = await fetch(url);
   if (res.status === 200) {


### PR DESCRIPTION
Fix an issue building the drip url if `faucetUrl` contained a trialing slash
