### PR TITLE
feat(p2p): timeout peers, disconnect from badly scored peers

### DIFF
--- a/yarn-project/p2p/src/bootstrap/bootstrap.ts
+++ b/yarn-project/p2p/src/bootstrap/bootstrap.ts
@@ -4,12 +4,12 @@ import { type AztecKVStore } from '@aztec/kv-store';
 import { OtelMetricsAdapter, type TelemetryClient } from '@aztec/telemetry-client';
 
 import { Discv5, type Discv5EventEmitter } from '@chainsafe/discv5';
-import { SignableENR } from '@chainsafe/enr';
+import { type ENR, SignableENR } from '@chainsafe/enr';
 import type { PeerId } from '@libp2p/interface';
 import { type Multiaddr, multiaddr } from '@multiformats/multiaddr';
 
 import type { BootnodeConfig } from '../config.js';
-import { AZTEC_ENR_KEY, AZTEC_NET } from '../services/discv5/discV5_service.js';
+import { AZTEC_ENR_KEY, AZTEC_NET } from '../services/types.js';
 import { convertToMultiaddr, createLibP2PPeerIdFromPrivateKey, getPeerIdPrivateKey } from '../util.js';
 
 /**
@@ -107,7 +107,7 @@ export class BootstrapNode implements P2PBootstrapApi {
    */
   public getPeerId() {
     this.assertPeerId();
-    return this.peerId;
+    return this.peerId!;
   }
 
   public getENR() {
@@ -122,6 +122,6 @@ export class BootstrapNode implements P2PBootstrapApi {
 
   public getRoutingTable() {
     this.assertNodeStarted();
-    return Promise.resolve(this.node!.kadValues().map(enr => enr.encodeTxt()));
+    return Promise.resolve(this.node!.kadValues().map((enr: ENR) => enr.encodeTxt()));
   }
 }

--- a/yarn-project/p2p/src/services/discv5/discV5_service.ts
+++ b/yarn-project/p2p/src/services/discv5/discV5_service.ts
@@ -78,8 +78,8 @@ export class DiscV5Service extends EventEmitter implements PeerDiscoveryService 
       metricsRegistry,
     });
 
-    this.discv5.on(Discv5Event.DISCOVERED, this.onDiscovered);
-    this.discv5.on(Discv5Event.ENR_ADDED, this.onEnrAdded);
+    this.discv5.on(Discv5Event.DISCOVERED, this.onDiscovered.bind(this));
+    this.discv5.on(Discv5Event.ENR_ADDED, this.onEnrAdded.bind(this));
   }
 
   public async start(): Promise<void> {

--- a/yarn-project/p2p/src/services/discv5/discV5_service.ts
+++ b/yarn-project/p2p/src/services/discv5/discV5_service.ts
@@ -11,26 +11,16 @@ import EventEmitter from 'events';
 import type { P2PConfig } from '../../config.js';
 import { convertToMultiaddr } from '../../util.js';
 import { type PeerDiscoveryService, PeerDiscoveryState } from '../service.js';
-
-export const AZTEC_ENR_KEY = 'aztec_network';
+import { AZTEC_ENR_KEY, AZTEC_NET, Discv5Event, PeerEvent } from '../types.js';
 
 const delayBeforeStart = 2000; // 2sec
-
-export enum AztecENR {
-  devnet = 0x01,
-  testnet = 0x02,
-  mainnet = 0x03,
-}
-
-// TODO: Make this an env var
-export const AZTEC_NET = AztecENR.devnet;
 
 /**
  * Peer discovery service using Discv5.
  */
 export class DiscV5Service extends EventEmitter implements PeerDiscoveryService {
   /** The Discv5 instance */
-  private discv5: Discv5;
+  private discv5: Discv5 & Discv5EventEmitter;
 
   /** This instance's ENR */
   private enr: SignableENR;
@@ -88,8 +78,8 @@ export class DiscV5Service extends EventEmitter implements PeerDiscoveryService 
       metricsRegistry,
     });
 
-    (this.discv5 as Discv5EventEmitter).on('discovered', (enr: ENR) => this.onDiscovered(enr));
-    (this.discv5 as Discv5EventEmitter).on('enrAdded', async (enr: ENR) => {
+    this.discv5.on(Discv5Event.DISCOVERED, (enr: ENR) => this.onDiscovered(enr));
+    this.discv5.on(Discv5Event.ENR_ADDED, async (enr: ENR) => {
       const multiAddrTcp = await enr.getFullMultiaddr('tcp');
       const multiAddrUdp = await enr.getFullMultiaddr('udp');
       this.logger.debug(`Added ENR ${enr.encodeTxt()}`, { multiAddrTcp, multiAddrUdp, nodeId: enr.nodeId });
@@ -179,7 +169,7 @@ export class DiscV5Service extends EventEmitter implements PeerDiscoveryService 
       const network = value[0];
       // check if the peer is on the same network
       if (network === AZTEC_NET) {
-        this.emit('peer:discovered', enr);
+        this.emit(PeerEvent.DISCOVERED, enr);
       }
     }
   }

--- a/yarn-project/p2p/src/services/libp2p/libp2p_service.ts
+++ b/yarn-project/p2p/src/services/libp2p/libp2p_service.ts
@@ -214,7 +214,7 @@ export class LibP2PService<T extends P2PClientType> extends WithTracer implement
    */
   public async stop() {
     // Remove gossip sub listener
-    this.node.services.pubsub.removeEventListener(GossipSubEvent.MESSAGE, this.handleGossipSubEvent);
+    this.node.services.pubsub.removeEventListener(GossipSubEvent.MESSAGE, this.handleGossipSubEvent.bind(this));
 
     // Stop peer manager
     this.logger.debug('Stopping peer manager...');

--- a/yarn-project/p2p/src/services/libp2p/libp2p_service.ts
+++ b/yarn-project/p2p/src/services/libp2p/libp2p_service.ts
@@ -211,6 +211,9 @@ export class LibP2PService<T extends P2PClientType> extends WithTracer implement
     // Remove gossip sub listener
     this.node.services.pubsub.removeEventListener(GossipSubEvent.MESSAGE, this.handleGossipSubEvent);
 
+    // Stop peer manager
+    this.peerManager.stop();
+
     this.logger.debug('Stopping job queue...');
     await this.jobQueue.end();
     this.logger.debug('Stopping running promise...');

--- a/yarn-project/p2p/src/services/libp2p/libp2p_service.ts
+++ b/yarn-project/p2p/src/services/libp2p/libp2p_service.ts
@@ -64,6 +64,7 @@ import {
 } from '../reqresp/interface.js';
 import { ReqResp } from '../reqresp/reqresp.js';
 import type { P2PService, PeerDiscoveryService } from '../service.js';
+import { GossipSubEvent } from '../types.js';
 
 interface MessageValidator {
   validator: {
@@ -179,7 +180,7 @@ export class LibP2PService<T extends P2PClientType> extends WithTracer implement
     }
 
     // add GossipSub listener
-    this.node.services.pubsub.addEventListener('gossipsub:message', async e => {
+    this.node.services.pubsub.addEventListener(GossipSubEvent.MESSAGE, async e => {
       const { msg } = e.detail;
       this.logger.trace(`Received PUBSUB message.`);
 

--- a/yarn-project/p2p/src/services/libp2p/libp2p_service.ts
+++ b/yarn-project/p2p/src/services/libp2p/libp2p_service.ts
@@ -125,7 +125,7 @@ export class LibP2PService<T extends P2PClientType> extends WithTracer implement
   ) {
     super(telemetry, 'LibP2PService');
 
-    this.peerManager = new PeerManager(node, peerDiscoveryService, config, this.tracer, logger);
+    this.peerManager = new PeerManager(node, peerDiscoveryService, config, telemetry, logger);
     this.node.services.pubsub.score.params.appSpecificScore = (peerId: string) => {
       return this.peerManager.getPeerScore(peerId);
     };

--- a/yarn-project/p2p/src/services/libp2p/libp2p_service.ts
+++ b/yarn-project/p2p/src/services/libp2p/libp2p_service.ts
@@ -26,7 +26,12 @@ import type { AztecKVStore } from '@aztec/kv-store';
 import { Attributes, OtelMetricsAdapter, type TelemetryClient, WithTracer, trackSpan } from '@aztec/telemetry-client';
 
 import { type ENR } from '@chainsafe/enr';
-import { type GossipSub, type GossipSubComponents, GossipsubMessage, gossipsub } from '@chainsafe/libp2p-gossipsub';
+import {
+  type GossipSub,
+  type GossipSubComponents,
+  type GossipsubMessage,
+  gossipsub,
+} from '@chainsafe/libp2p-gossipsub';
 import { createPeerScoreParams, createTopicScoreParams } from '@chainsafe/libp2p-gossipsub/score';
 import { noise } from '@chainsafe/libp2p-noise';
 import { yamux } from '@chainsafe/libp2p-yamux';
@@ -212,6 +217,7 @@ export class LibP2PService<T extends P2PClientType> extends WithTracer implement
     this.node.services.pubsub.removeEventListener(GossipSubEvent.MESSAGE, this.handleGossipSubEvent);
 
     // Stop peer manager
+    this.logger.debug('Stopping peer manager...');
     this.peerManager.stop();
 
     this.logger.debug('Stopping job queue...');

--- a/yarn-project/p2p/src/services/peer-scoring/peer_scoring.ts
+++ b/yarn-project/p2p/src/services/peer-scoring/peer_scoring.ts
@@ -9,6 +9,16 @@ const DefaultPeerPenalties = {
   [PeerErrorSeverity.HighToleranceError]: 2,
 };
 
+export enum PeerScoreState {
+  Banned,
+  Disconnect,
+  Healthy,
+}
+
+// TODO: move into config / constants
+const MIN_SCORE_BEFORE_BAN = -100;
+const MIN_SCORE_BEFORE_DISCONNECT = -50;
+
 export class PeerScoring {
   private scores: Map<string, number> = new Map();
   private lastUpdateTime: Map<string, number> = new Map();
@@ -63,6 +73,17 @@ export class PeerScoring {
 
   getScore(peerId: string): number {
     return this.scores.get(peerId) || 0;
+  }
+
+  getScoreState(peerId: string) {
+    // TODO: permanently store banned peers???
+    const score = this.getScore(peerId);
+    if (score < MIN_SCORE_BEFORE_BAN) {
+      return PeerScoreState.Banned;
+    } else if (score < MIN_SCORE_BEFORE_DISCONNECT) {
+      return PeerScoreState.Disconnect;
+    }
+    return PeerScoreState.Healthy;
   }
 
   getStats(): { medianScore: number } {

--- a/yarn-project/p2p/src/services/peer_manager.test.ts
+++ b/yarn-project/p2p/src/services/peer_manager.test.ts
@@ -1,0 +1,263 @@
+import { PeerErrorSeverity } from '@aztec/circuit-types';
+import { createLogger } from '@aztec/foundation/log';
+import { sleep } from '@aztec/foundation/sleep';
+import { NoopTelemetryClient } from '@aztec/telemetry-client/noop';
+
+import { ENR, SignableENR } from '@chainsafe/enr';
+import { jest } from '@jest/globals';
+import { createSecp256k1PeerId } from '@libp2p/peer-id-factory';
+import { multiaddr } from '@multiformats/multiaddr';
+
+import { getP2PDefaultConfig } from '../config.js';
+import { PeerManager } from './peer_manager.js';
+import { PeerEvent } from './types.js';
+
+describe('PeerManager', () => {
+  const mockLibP2PNode: any = {
+    addEventListener: jest.fn(),
+    removeEventListener: jest.fn(),
+    getPeers: jest.fn().mockReturnValue([]),
+    getDialQueue: jest.fn().mockReturnValue([]),
+    getConnections: jest.fn().mockReturnValue([]),
+    peerStore: {
+      merge: jest.fn(),
+    },
+    dial: jest.fn(),
+    hangUp: jest.fn(),
+  };
+
+  const mockPeerDiscoveryService: any = {
+    on: jest.fn(),
+    off: jest.fn(),
+    isBootstrapPeer: jest.fn().mockReturnValue(false),
+    runRandomNodesQuery: jest.fn(),
+  };
+
+  let peerManager: PeerManager;
+  // The function provided to the discovery servive callback will be run here
+  let discoveredPeerCallback: (enr: ENR) => Promise<void>;
+
+  beforeEach(async () => {
+    jest.useFakeTimers();
+
+    // Reset all mocks
+    jest.clearAllMocks();
+
+    // Setup default mock returns
+    mockLibP2PNode.getPeers.mockReturnValue([]);
+    mockLibP2PNode.getDialQueue.mockReturnValue([]);
+    mockLibP2PNode.getConnections.mockReturnValue([]);
+
+    // Capture the callback for discovered peers
+    mockPeerDiscoveryService.on.mockImplementation((event: string, callback: any) => {
+      if (event === PeerEvent.DISCOVERED) {
+        discoveredPeerCallback = callback;
+      }
+    });
+
+    peerManager = new PeerManager(
+      mockLibP2PNode,
+      mockPeerDiscoveryService,
+      getP2PDefaultConfig(),
+      new NoopTelemetryClient(),
+      createLogger('test'),
+    );
+  });
+
+  afterEach(() => {
+    jest.useRealTimers();
+  });
+
+  const createMockENR = async () => {
+    const peerId = await createSecp256k1PeerId();
+    const enr = SignableENR.createFromPeerId(peerId);
+    // Add required TCP multiaddr
+    enr.setLocationMultiaddr(multiaddr('/ip4/127.0.0.1/tcp/8000'));
+    return enr.toENR();
+  };
+
+  describe('peer management', () => {
+    it('should return connected peers', async () => {
+      const peerId = await createSecp256k1PeerId();
+      mockLibP2PNode.getPeers.mockReturnValue([peerId]);
+
+      const peers = peerManager.getPeers();
+      expect(peers).toHaveLength(1);
+      expect(peers[0].id).toBe(peerId.toString());
+      expect(peers[0].status).toBe('connected');
+    });
+
+    it('should return peers in dial queue', async () => {
+      const peerId = await createSecp256k1PeerId();
+      mockLibP2PNode.getDialQueue.mockReturnValue([
+        {
+          peerId,
+          status: 'queued',
+          multiaddrs: [multiaddr('/ip4/127.0.0.1/tcp/8000')],
+        },
+      ]);
+
+      const peers = peerManager.getPeers(true);
+      expect(peers).toHaveLength(1);
+      expect(peers[0].id).toBe(peerId.toString());
+      expect(peers[0].status).toBe('dialing');
+    });
+
+    it('should penalize peers', async () => {
+      const peerId = await createSecp256k1PeerId();
+
+      peerManager.penalizePeer(peerId, PeerErrorSeverity.LowToleranceError);
+
+      const peers = peerManager.getPeers();
+      const penalizedPeer = peers.find(p => p.id === peerId.toString());
+      //   expect(penalizedPeer?.score).toBeLessThan(0);
+    });
+
+    it('should handle heartbeat', () => {
+      // Mock some connected peers
+      const connections = [{ remotePeer: 'peer1' }, { remotePeer: 'peer2' }];
+      mockLibP2PNode.getConnections.mockReturnValue(connections);
+
+      peerManager.heartbeat();
+
+      // Verify that discover was called
+      expect(mockPeerDiscoveryService.runRandomNodesQuery).toHaveBeenCalled();
+    });
+  });
+
+  describe('peer timeout functionality', () => {
+    it('should attempt to dial a discovered peer', async () => {
+      const enr = await createMockENR();
+      await discoveredPeerCallback(enr);
+
+      expect(mockLibP2PNode.dial).toHaveBeenCalled();
+    });
+
+    it('should retry failed dials up to MAX_DIAL_ATTEMPTS', async () => {
+      jest.useRealTimers();
+      const enr = await createMockENR();
+      mockLibP2PNode.dial.mockRejectedValue(new Error('Connection failed'));
+
+      // First attempt - adds it to the cache
+      await discoveredPeerCallback(enr);
+      expect(mockLibP2PNode.dial).toHaveBeenCalledTimes(1);
+
+      // dial peer happens asynchronously, so we need to wait
+      await sleep(100);
+
+      // Second attempt
+      await (peerManager as any).discover();
+      expect(mockLibP2PNode.dial).toHaveBeenCalledTimes(2);
+
+      // Third attempt
+      await (peerManager as any).discover();
+      expect(mockLibP2PNode.dial).toHaveBeenCalledTimes(3);
+
+      // After the third attempt, the peer should be removed from
+      // the cache, and placed in timeout
+      await discoveredPeerCallback(enr);
+      expect(mockLibP2PNode.dial).toHaveBeenCalledTimes(3);
+    });
+
+    it('should timeout a peer after max dial attempts and ignore it for the timeout period', async () => {
+      const enr = await createMockENR();
+      mockLibP2PNode.dial.mockRejectedValue(new Error('Connection failed'));
+
+      // Fail three times to trigger timeout
+      for (let i = 0; i < 3; i++) {
+        await discoveredPeerCallback(enr);
+      }
+      expect(mockLibP2PNode.dial).toHaveBeenCalledTimes(3);
+
+      // Try to dial immediately after timeout - should be ignored
+      mockLibP2PNode.dial.mockClear();
+      await discoveredPeerCallback(enr);
+      expect(mockLibP2PNode.dial).not.toHaveBeenCalled();
+
+      // Advance time by 4 minutes (less than timeout period)
+      jest.advanceTimersByTime(4 * 60 * 1000);
+      await discoveredPeerCallback(enr);
+      expect(mockLibP2PNode.dial).not.toHaveBeenCalled();
+
+      // Advance time to complete 5 minute timeout
+      jest.advanceTimersByTime(1 * 60 * 1000);
+      await discoveredPeerCallback(enr);
+      expect(mockLibP2PNode.dial).toHaveBeenCalled();
+    });
+
+    it('should cleanup expired timeouts during heartbeat', async () => {
+      const enr = await createMockENR();
+      mockLibP2PNode.dial.mockRejectedValue(new Error('Connection failed'));
+
+      // Fail three times to trigger timeout
+      for (let i = 0; i < 3; i++) {
+        await discoveredPeerCallback(enr);
+      }
+
+      // Verify peer is timed out
+      mockLibP2PNode.dial.mockClear();
+      await discoveredPeerCallback(enr);
+      expect(mockLibP2PNode.dial).not.toHaveBeenCalled();
+
+      // Advance time past timeout period and trigger heartbeat
+      jest.advanceTimersByTime(5 * 60 * 1000);
+      peerManager.heartbeat();
+
+      // Peer should now be allowed to dial again
+      await discoveredPeerCallback(enr);
+      expect(mockLibP2PNode.dial).toHaveBeenCalled();
+    });
+
+    it('should include timed out peers in getPeers when includePending is true', async () => {
+      const enr = await createMockENR();
+      const peerId = await enr.peerId();
+      mockLibP2PNode.dial.mockRejectedValue(new Error('Connection failed'));
+
+      // Fail three times to trigger timeout
+      for (let i = 0; i < 3; i++) {
+        await discoveredPeerCallback(enr);
+      }
+
+      const peers = peerManager.getPeers(true);
+      const timedOutPeer = peers.find(p => p.id === peerId.toString());
+      expect(timedOutPeer).toBeDefined();
+      expect(timedOutPeer?.status).toBe('cached');
+    });
+
+    it('should handle multiple peer discoveries and timeouts', async () => {
+      const enr1 = await createMockENR();
+      const enr2 = await createMockENR();
+      const peerId1 = await enr1.peerId();
+      const peerId2 = await enr2.peerId();
+      mockLibP2PNode.dial.mockRejectedValue(new Error('Connection failed'));
+
+      // Fail peer1 three times
+      for (let i = 0; i < 3; i++) {
+        await discoveredPeerCallback(enr1);
+      }
+
+      // Try peer2 once
+      await discoveredPeerCallback(enr2);
+
+      const peers = peerManager.getPeers(true);
+      expect(peers).toHaveLength(2);
+
+      const peer1 = peers.find(p => p.id === peerId1.toString());
+      const peer2 = peers.find(p => p.id === peerId2.toString());
+
+      expect(peer1?.status).toBe('cached'); // timed out
+      expect(peer2?.status).toBe('cached'); // in dial queue
+    });
+
+    it('should properly clean up peers on stop', async () => {
+      const enr = await createMockENR();
+      await discoveredPeerCallback(enr);
+
+      peerManager.stop();
+
+      expect(mockLibP2PNode.removeEventListener).toHaveBeenCalledWith(PeerEvent.CONNECTED, expect.any(Function));
+      expect(mockLibP2PNode.removeEventListener).toHaveBeenCalledWith(PeerEvent.DISCONNECTED, expect.any(Function));
+      expect(mockPeerDiscoveryService.off).toHaveBeenCalledWith(PeerEvent.DISCOVERED, expect.any(Function));
+    });
+  });
+});

--- a/yarn-project/p2p/src/services/peer_manager.ts
+++ b/yarn-project/p2p/src/services/peer_manager.ts
@@ -225,7 +225,7 @@ export class PeerManager extends WithTracer {
     const connectedHealthyPeers: Connection[] = [];
 
     for (const peer of connections) {
-      const score = this.peerScoring.getScore(peer.remotePeer.toString());
+      const score = this.peerScoring.getScoreState(peer.remotePeer.toString());
       switch (score) {
         // TODO: add goodbye and give reasons
         case PeerScoreState.Banned:
@@ -242,6 +242,7 @@ export class PeerManager extends WithTracer {
 
   // TODO: send a goodbye with a reason to the peer
   private async disconnectPeer(peer: PeerId) {
+    this.logger.debug(`Disconnecting peer ${peer.toString()}`);
     await this.libP2PNode.hangUp(peer);
   }
 

--- a/yarn-project/p2p/src/services/peer_manager.ts
+++ b/yarn-project/p2p/src/services/peer_manager.ts
@@ -11,6 +11,7 @@ import { type P2PConfig } from '../config.js';
 import { type PubSubLibp2p } from '../util.js';
 import { PeerScoring } from './peer-scoring/peer_scoring.js';
 import { type PeerDiscoveryService } from './service.js';
+import { PeerEvent } from './types.js';
 
 const MAX_DIAL_ATTEMPTS = 3;
 const MAX_CACHED_PEERS = 100;
@@ -36,7 +37,7 @@ export class PeerManager implements Traceable {
   ) {
     this.peerScoring = new PeerScoring(config);
     // Handle new established connections
-    this.libP2PNode.addEventListener('peer:connect', evt => {
+    this.libP2PNode.addEventListener(PeerEvent.CONNECTED, evt => {
       const peerId = evt.detail;
       if (this.peerDiscoveryService.isBootstrapPeer(peerId)) {
         this.logger.verbose(`Connected to bootstrap peer ${peerId.toString()}`);
@@ -46,7 +47,7 @@ export class PeerManager implements Traceable {
     });
 
     // Handle lost connections
-    this.libP2PNode.addEventListener('peer:disconnect', evt => {
+    this.libP2PNode.addEventListener(PeerEvent.DISCONNECTED, evt => {
       const peerId = evt.detail;
       if (this.peerDiscoveryService.isBootstrapPeer(peerId)) {
         this.logger.verbose(`Disconnected from bootstrap peer ${peerId.toString()}`);
@@ -56,7 +57,7 @@ export class PeerManager implements Traceable {
     });
 
     // Handle Discovered peers
-    this.peerDiscoveryService.on('peer:discovered', async (enr: ENR) => {
+    this.peerDiscoveryService.on(PeerEvent.DISCOVERED, async (enr: ENR) => {
       await this.handleDiscoveredPeer(enr);
     });
   }

--- a/yarn-project/p2p/src/services/peer_manager.ts
+++ b/yarn-project/p2p/src/services/peer_manager.ts
@@ -37,12 +37,12 @@ export class PeerManager implements Traceable {
   ) {
     this.peerScoring = new PeerScoring(config);
     // Handle new established connections
-    this.libP2PNode.addEventListener(PeerEvent.CONNECTED, this.handleConnectedPeerEvent);
+    this.libP2PNode.addEventListener(PeerEvent.CONNECTED, this.handleConnectedPeerEvent.bind(this));
     // Handle lost connections
-    this.libP2PNode.addEventListener(PeerEvent.DISCONNECTED, this.handleDisconnectedPeerEvent);
+    this.libP2PNode.addEventListener(PeerEvent.DISCONNECTED, this.handleDisconnectedPeerEvent.bind(this));
 
     // Handle Discovered peers
-    this.peerDiscoveryService.on(PeerEvent.DISCOVERED, this.handleDiscoveredPeer);
+    this.peerDiscoveryService.on(PeerEvent.DISCOVERED, this.handleDiscoveredPeer.bind(this));
   }
 
   @trackSpan('PeerManager.heartbeat')

--- a/yarn-project/p2p/src/services/reqresp/reqresp.integration.test.ts
+++ b/yarn-project/p2p/src/services/reqresp/reqresp.integration.test.ts
@@ -29,8 +29,8 @@ import { type AttestationPool } from '../../mem_pools/attestation_pool/attestati
 import { type EpochProofQuotePool } from '../../mem_pools/epoch_proof_quote_pool/epoch_proof_quote_pool.js';
 import { type TxPool } from '../../mem_pools/tx_pool/index.js';
 import { AlwaysFalseCircuitVerifier, AlwaysTrueCircuitVerifier } from '../../mocks/index.js';
+import { AZTEC_ENR_KEY, AZTEC_NET } from '../../services/types.js';
 import { convertToMultiaddr, createLibP2PPeerIdFromPrivateKey } from '../../util.js';
-import { AZTEC_ENR_KEY, AZTEC_NET } from '../discv5/discV5_service.js';
 
 const TEST_TIMEOUT = 80000;
 

--- a/yarn-project/p2p/src/services/types.ts
+++ b/yarn-project/p2p/src/services/types.ts
@@ -1,0 +1,44 @@
+/***************************************************
+ *                    Events
+ ***************************************************/
+
+/**
+ * Events emitted from the libp2p node.
+ */
+export enum PeerEvent {
+  DISCOVERED = 'peer:discovered',
+  CONNECTED = 'peer:connect',
+  DISCONNECTED = 'peer:disconnect',
+}
+
+/**
+ * Events emitted from the Discv5 service.
+ */
+export enum Discv5Event {
+  DISCOVERED = 'discovered',
+  ENR_ADDED = 'enrAdded',
+}
+
+/**
+ * Events emitted from the GossipSub protocol.
+ */
+export enum GossipSubEvent {
+  MESSAGE = 'gossipsub:message',
+}
+
+/***************************************************
+ *                    Types
+ ***************************************************/
+/**
+ * Aztec network specific types
+ */
+export const AZTEC_ENR_KEY = 'aztec_network';
+
+export enum AztecENR {
+  devnet = 0x01,
+  testnet = 0x02,
+  mainnet = 0x03,
+}
+
+// TODO: Make this an env var
+export const AZTEC_NET = AztecENR.devnet;


### PR DESCRIPTION
Contents:
- Add a peer score state, such that on each discovery heartbeat those with unhealthy scores are disconnected from
- Bans are not in action and are not persisted
- Added a timeout feature to discovery, where if a peer fails the 3 retries it is added to an ignore mapping, which should not be dialled again, after the timeout, it can resume attempting to connect to it.
- Added unit tests for some peer manager stuff, the retries 


Misc:
- replacing strings in event emitters with enums with the string in it
- Make sure to close all event listeners

Follow up:
- With disconnects, send goodbye messages along side reasons


fixes: https://github.com/AztecProtocol/aztec-packages/issues/10878