### PR TITLE
chore: standardize terminology across the codebase

### DIFF
--- a/barretenberg/cpp/src/barretenberg/crypto/merkle_tree/append_only_tree/content_addressed_append_only_tree.test.cpp
+++ b/barretenberg/cpp/src/barretenberg/crypto/merkle_tree/append_only_tree/content_addressed_append_only_tree.test.cpp
@@ -463,7 +463,7 @@ TEST_F(PersistedContentAddressedAppendOnlyTreeTest, errors_are_caught_and_handle
         tree.commit(completion);
         signal.wait_for_level();
 
-        // At this stage, the tree is still in an uncommited state despite the error
+        // At this stage, the tree is still in an uncommitted state despite the error
         // Reading both committed and uncommitted data shold be ok
 
         // check the uncommitted data is accurate

--- a/barretenberg/cpp/src/barretenberg/translator_vm/translator_prover.cpp
+++ b/barretenberg/cpp/src/barretenberg/translator_vm/translator_prover.cpp
@@ -33,7 +33,7 @@ void TranslatorProver::compute_witness(CircuitBuilder& circuit_builder)
     }
 
     // Populate the wire polynomials from the wire vectors in the circuit constructor. Note: In goblin translator wires
-    // come as is, since they have to reflect the structure of polynomials in the first 4 wires, which we've commited to
+    // come as is, since they have to reflect the structure of polynomials in the first 4 wires, which we've committed to
     for (auto [wire_poly_, wire_] : zip_view(key->polynomials.get_wires(), circuit_builder.wires)) {
         auto& wire_poly = wire_poly_;
         auto& wire = wire_;
@@ -49,7 +49,7 @@ void TranslatorProver::compute_witness(CircuitBuilder& circuit_builder)
     }
 
     // We construct concatenated versions of range constraint polynomials, where several polynomials are concatenated
-    // into one. These polynomials are not commited to.
+    // into one. These polynomials are not committed to.
     bb::compute_concatenated_polynomials<Flavor>(key->polynomials);
 
     // We also contruct ordered polynomials, which have the same values as concatenated ones + enough values to bridge

--- a/barretenberg/cpp/src/barretenberg/ultra_honk/oink_prover.cpp
+++ b/barretenberg/cpp/src/barretenberg/ultra_honk/oink_prover.cpp
@@ -88,7 +88,7 @@ template <IsUltraFlavor Flavor> void OinkProver<Flavor>::execute_preamble_round(
 
 /**
  * @brief Commit to the wire polynomials (part of the witness), with the exception of the fourth wire, which is
- * only commited to after adding memory records. In the Goblin Flavor, we also commit to the ECC OP wires and the
+ * only committed to after adding memory records. In the Goblin Flavor, we also commit to the ECC OP wires and the
  * DataBus columns.
  */
 template <IsUltraFlavor Flavor> void OinkProver<Flavor>::execute_wire_commitments_round()


### PR DESCRIPTION
:warning: :warning: :warning: DO NOT CREATE THIS PR. :warning: :warning: :warning:
You are creating a PR into the wrong repository.
Please migrate your PR to https://github.com/AztecProtocol/aztec-packages/pulls with `scripts/migrate_barretenberg_branch.sh` in the aztec-packages repo.
```
Usage: scripts/migrate_barretenberg_branch.sh <Errors/barretenberg> <Migrating barretenberg changes into aztec-packages>
```

