### PR TITLE
fix: Conditionally deploy deterministic deployment proxy

### DIFF
--- a/spartan/aztec-network/templates/boot-node.yaml
+++ b/spartan/aztec-network/templates/boot-node.yaml
@@ -61,14 +61,17 @@ spec:
             - name: config
               mountPath: /shared/config
       {{- if .Values.bootNode.deployContracts }}
-        - name: deploy-create2-delpoyer
+        - name: deploy-create2-deployer
           image: {{ .Values.images.foundry.image }}
           command:
             - /bin/sh
             - -c
             - |
               source /shared/config/service-addresses
-              cast publish --rpc-url ${ETHEREUM_HOST} 0xf8a58085174876e800830186a08080b853604580600e600039806000f350fe7fffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffe03601600081602082378035828234f58015156039578182fd5b8082525050506014600cf31ba02222222222222222222222222222222222222222222222222222222222222222a02222222222222222222222222222222222222222222222222222222222222222
+              if [ "$(cast code --rpc-url ${ETHEREUM_HOST} 0x4e59b44847b379578588920ca78fbf26c0b4956c)" = "0x" ]; then
+                echo "Deploying Deterministic Deployment Proxy"
+                cast publish --rpc-url ${ETHEREUM_HOST} 0xf8a58085174876e800830186a08080b853604580600e600039806000f350fe7fffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffe03601600081602082378035828234f58015156039578182fd5b8082525050506014600cf31ba02222222222222222222222222222222222222222222222222222222222222222a02222222222222222222222222222222222222222222222222222222222222222
+              fi
           volumeMounts:
             - name: config
               mountPath: /shared/config


### PR DESCRIPTION
The boot-node init script sent the deterministic deployment proxy [deployment tx](https://github.com/Arachnid/deterministic-deployment-proxy?tab=readme-ov-file#deployment-transaction) always, regardless of the code being present or not. If the tx had already been sent, this caused the command to fail with a `nonce too low`. This commit adds a check so that it only sends the tx if the proxy has not being deployed yet.
