### PR TITLE
fix: fix proverEnabled flag in cli-wallet

### DIFF
--- a/yarn-project/cli-wallet/src/bin/index.ts
+++ b/yarn-project/cli-wallet/src/bin/index.ts
@@ -86,27 +86,19 @@ async function main() {
         .env('AZTEC_NODE_URL')
         .default(`http://${LOCALHOST}:8080`),
     )
-    .addOption(
-      new Option('-b, --bb-binary-path <string>', 'Path to the BB binary')
-        .env('BB_BINARY_PATH')
-        .default(`$HOME/.bb/bb`),
-    )
-    .addOption(
-      new Option('-w, --bb-working-directory <string>', 'Path to the BB working directory')
-        .env('BB_WORKING_DIRECTORY')
-        .default(`$HOME/.bb-workdir`),
-    )
     .hook('preSubcommand', async command => {
       const { dataDir, remotePxe, nodeUrl } = command.optsWithGlobals();
 
       if (!remotePxe) {
         debugLogger.info('Using local PXE service');
+
+        // Always enable proving when profiling
         const subcommand = command.args[0];
         const isProfiling = command.args.includes('--profile');
-        const enableProving = subcommand === 'simulate' && isProfiling;
+        const proverEnabled = subcommand === 'simulate' && isProfiling;
 
         await pxeWrapper.init(nodeUrl, join(dataDir, 'pxe'), {
-          proverEnabled: enableProving,
+          ...(proverEnabled && { proverEnabled }), // only override if we're profiling
         });
       }
       db.init(AztecLmdbStore.open(dataDir));


### PR DESCRIPTION
Fix in cli-wallet proving was disabled even with env `PXE_PROVER_ENABLED=1`