### PR TITLE
chore: Patch jest to not use JSON serialization in message passing ci3

### DIFF
--- a/yarn-project/.yarn/patches/jest-runner-npm-29.7.0-3bc9f82b58.patch
+++ b/yarn-project/.yarn/patches/jest-runner-npm-29.7.0-3bc9f82b58.patch
@@ -1,0 +1,13 @@
+diff --git a/build/index.js b/build/index.js
+index 65c0ed180a1f44a5095f80d572aacb68be1db3da..3bb4938110a50a2eca1b2f01466b7be16c9c8145 100644
+--- a/build/index.js
++++ b/build/index.js
+@@ -124,7 +124,7 @@ class TestRunner extends _types.EmittingTestRunner {
+       enableWorkerThreads: this._globalConfig.workerThreads,
+       exposedMethods: ['worker'],
+       forkOptions: {
+-        serialization: 'json',
++        serialization: 'advanced',
+         stdio: 'pipe'
+       },
+       // The workerIdleMemoryLimit should've been converted to a number during

--- a/yarn-project/package.json
+++ b/yarn-project/package.json
@@ -82,6 +82,7 @@
     "@noir-lang/types": "portal:../noir/packages/types",
     "@noir-lang/noirc_abi": "portal:../noir/packages/noirc_abi",
     "@noir-lang/noir_codegen": "portal:../noir/packages/noir_codegen",
-    "@noir-lang/noir_js": "file:../noir/packages/noir_js"
+    "@noir-lang/noir_js": "file:../noir/packages/noir_js",
+    "jest-runner@npm:^29.7.0": "patch:jest-runner@npm%3A29.7.0#~/.yarn/patches/jest-runner-npm-29.7.0-3bc9f82b58.patch"
   }
 }

--- a/yarn-project/yarn.lock
+++ b/yarn-project/yarn.lock
@@ -13290,7 +13290,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"jest-runner@npm:^29.7.0":
+"jest-runner@npm:29.7.0":
   version: 29.7.0
   resolution: "jest-runner@npm:29.7.0"
   dependencies:
@@ -13316,6 +13316,35 @@ __metadata:
     p-limit: "npm:^3.1.0"
     source-map-support: "npm:0.5.13"
   checksum: 10/9d8748a494bd90f5c82acea99be9e99f21358263ce6feae44d3f1b0cd90991b5df5d18d607e73c07be95861ee86d1cbab2a3fc6ca4b21805f07ac29d47c1da1e
+  languageName: node
+  linkType: hard
+
+"jest-runner@patch:jest-runner@npm%3A29.7.0#~/.yarn/patches/jest-runner-npm-29.7.0-3bc9f82b58.patch":
+  version: 29.7.0
+  resolution: "jest-runner@patch:jest-runner@npm%3A29.7.0#~/.yarn/patches/jest-runner-npm-29.7.0-3bc9f82b58.patch::version=29.7.0&hash=a79dea"
+  dependencies:
+    "@jest/console": "npm:^29.7.0"
+    "@jest/environment": "npm:^29.7.0"
+    "@jest/test-result": "npm:^29.7.0"
+    "@jest/transform": "npm:^29.7.0"
+    "@jest/types": "npm:^29.6.3"
+    "@types/node": "npm:*"
+    chalk: "npm:^4.0.0"
+    emittery: "npm:^0.13.1"
+    graceful-fs: "npm:^4.2.9"
+    jest-docblock: "npm:^29.7.0"
+    jest-environment-node: "npm:^29.7.0"
+    jest-haste-map: "npm:^29.7.0"
+    jest-leak-detector: "npm:^29.7.0"
+    jest-message-util: "npm:^29.7.0"
+    jest-resolve: "npm:^29.7.0"
+    jest-runtime: "npm:^29.7.0"
+    jest-util: "npm:^29.7.0"
+    jest-watcher: "npm:^29.7.0"
+    jest-worker: "npm:^29.7.0"
+    p-limit: "npm:^3.1.0"
+    source-map-support: "npm:0.5.13"
+  checksum: 10/d520c4f40179a22626d547b9fdf5f802a7e40d27e50f13a3ecca327581e78164dcdc8c650ed2974ef8f82caef935f7e356f7ce2d1f8dac65a9556101da79a27c
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
Restores the patch from #5883 which was [removed](https://github.com/AztecProtocol/aztec-packages/pull/10042/files#diff-ce07a7dc313882291a1eb38f5c47598d992270d769e487fd3970dcf61af71b01) in CI3.
