### PR TITLE
Fix : broken links

### DIFF
--- a/barretenberg/sol/README.md
+++ b/barretenberg/sol/README.md
@@ -10,7 +10,7 @@ The verifier will follow an overall architecture below, consisting of 3 contract
 
 ![Verifier architecture](./figures/verifier.png)
 
-The verification key is currently generated via [Barretenberg](https://github.com/AztecProtocol/barretenberg/blob/master/cpp/src/aztec/plonk_honk_shared/verification_key/sol_gen.hpp), Aztec's backend for generating proofs.
+The verification key is currently generated via [Barretenberg](https://github.com/AztecProtocol/barretenberg/blob/master/cpp/src/barretenberg/plonk/proof_system/verification_key/sol_gen.hpp), Aztec's backend for generating proofs.
 
 ## Current implementations
 

--- a/docs/docs/aztec/glossary/index.md
+++ b/docs/docs/aztec/glossary/index.md
@@ -22,7 +22,7 @@ Barretenberg's source code can be found [here](https://github.com/AztecProtocol/
 
 With `nargo`, you can start new projects, compile, execute, prove, verify, test, generate solidity contracts, and do pretty much all that is available in Noir.
 
-You can find more information in the nargo installation docs [here](https://noir-lang.org/docs/getting_started/installation/) and the nargo command reference [here](https://noir-lang.org/docs/reference/nargo_commands).
+You can find more information in the nargo installation docs [here](https://noir-lang.org/docs/getting_started/noir_installation/) and the nargo command reference [here](https://noir-lang.org/docs/reference/nargo_commands).
 
 ### Noir
 

--- a/noir-projects/aztec-nr/README.md
+++ b/noir-projects/aztec-nr/README.md
@@ -69,4 +69,4 @@ Replace `NARGO_VERSION_COMPATIBLE_WITH_YOUR_SANDBOX` with the version from the o
 aztec-cli get-node-info
 ```
 
-For more installation options, please view [Noir's getting started.](https://noir-lang.org/docs/getting_started/installation/other_install_methods)
+For more installation options, please view [Noir's getting started.](https://noir-lang.org/docs/getting_started/noir_installation)

--- a/noir-projects/aztec-nr/README.md
+++ b/noir-projects/aztec-nr/README.md
@@ -17,7 +17,7 @@
 
 # Aztec.nr
 
-`Aztec-nr` is a [Noir](https://noir-lang.org) framework for smart contracts on [Aztec](aztec.network).
+`Aztec-nr` is a [Noir](https://noir-lang.org) framework for smart contracts on [Aztec](https://aztec.network).
 
 ### Directory Structure
 


### PR DESCRIPTION
 ## Updated outdated or broken links to their current versions

Fixed:
1. [barretenberg/sol/README.md](https://github.com/AztecProtocol/aztec-packages/blob/master/barretenberg/sol/README.md)
2. [docs/docs/aztec/glossary/index.md](https://github.com/AztecProtocol/aztec-packages/blob/master/docs/docs/aztec/glossary/index.md)
3.  [noir-projects/aztec-nr/README.md](https://github.com/AztecProtocol/aztec-packages/blob/master/noir-projects/aztec-nr/README.md)