### PR TITLE
Set pxe version in package.json

### DIFF
--- a/yarn-project/pxe/package.json
+++ b/yarn-project/pxe/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@aztec/pxe",
-  "version": "0.1.0",
+  "version": "0.68.2",
   "type": "module",
   "exports": {
     ".": "./dest/index.js",


### PR DESCRIPTION
https://github.com/AztecProtocol/aztec-packages/issues/10904 reported that pxe.getNodeInfo().nodeVersion returns 0.1.0 instead of the correct version which is 0.68.2 at the time of writing. This fix manually sets the version in package.json.
