### PR TITLE
**Fix Typo in `client_ivc.hpp`**

### DIFF
--- a/barretenberg/cpp/src/barretenberg/client_ivc/client_ivc.hpp
+++ b/barretenberg/cpp/src/barretenberg/client_ivc/client_ivc.hpp
@@ -165,7 +165,7 @@ class ClientIVC {
      * @param circuit The incoming statement
      * @param precomputed_vk The verification key of the incoming statement OR a mocked key whose metadata needs to be
      * set using the proving key produced from `circuit` in order to pass some assertions in the Oink prover.
-     * @param mock_vk A boolean to say whether the precomputed vk shoudl have its metadata set.
+     * @param mock_vk A boolean to say whether the precomputed vk should have its metadata set.
      */
     void accumulate(ClientCircuit& circuit,
                     const bool _one_circuit = false,


### PR DESCRIPTION

# Pull Request Title  
**Fix Typo in `client_ivc.hpp`**

## Description  
This pull request fixes a typo in the `client_ivc.hpp` file to ensure the documentation is accurate.

### Changes Made:
- **File Modified:** `client_ivc.hpp`
- **Summary of Changes:**
  - Corrected the typo "shoudl" to "should" in the documentation for the `mock_vk` parameter.

## Related Issues  
N/A

## Checklist  
- [x] Fixed typo in the documentation.
- [x] Verified that the fix does not impact code functionality.

## Testing  
N/A (Typo fix in documentation)

## Additional Notes  
This change ensures clarity in the documentation, improving readability and accuracy.

---

**Allow edits by maintainers:** [x]
