### PR TITLE
**Fix Typo in `mem.pil`**

### DIFF
--- a/barretenberg/cpp/pil/avm/mem.pil
+++ b/barretenberg/cpp/pil/avm/mem.pil
@@ -92,7 +92,7 @@ namespace mem(256);
               + sel_op_slice;
 
     // Maximum one memory operation enabled per row
-    sel_mem * (sel_mem - 1) = 0; // TODO: might be infered by the main trace
+    sel_mem * (sel_mem - 1) = 0; // TODO: might be inferred by the main trace
 
     // Enforce the memory entries to be contiguous, i.e., as soon as
     // sel_mem is disabled all subsequent rows have sel_mem disabled.


### PR DESCRIPTION
# Pull Request Title  
**Fix Typo in `mem.pil`**

## Description  
This pull request fixes a typo in the `mem.pil` file where the word "infered" was corrected to "inferred" to maintain proper spelling.

### Changes Made:
- **File Modified:** `barretenberg/cpp/pil/avm/mem.pil`
- **Summary of Changes:**
  - Corrected the typo "infered" to "inferred" in the comment section.

## Checklist  
- [x] Fixed the typo in the comment.
- [x] Verified that no functionality was impacted by this change.

## Additional Notes  
This small correction ensures proper spelling and clarity in the code comments.

---

**Allow edits by maintainers:** [x]
