### PR TITLE
chore: disable broken honk test

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -95,6 +95,7 @@ jobs:
               - 'noir/noir-repo/**'
             bb:
               - 'barretenberg/cpp/**'
+              - 'barretenberg/acir_tests/**'
             noir-projects:
               - 'noir-projects/**'
             yarn-project:

--- a/barretenberg/acir_tests/bootstrap.sh
+++ b/barretenberg/acir_tests/bootstrap.sh
@@ -124,7 +124,7 @@ function test_cmds {
   echo SYS=ultra_honk FLOW=prove_then_verify RECURSIVE=true $run_test assert_statement
   echo SYS=ultra_honk FLOW=prove_then_verify RECURSIVE=true $run_test double_verify_honk_proof
   echo SYS=ultra_honk FLOW=prove_and_verify_program $run_test merkle_insert
-  echo SYS=ultra_rollup_honk FLOW=prove_then_verify $run_test verify_rollup_honk_proof
+  # echo SYS=ultra_rollup_honk FLOW=prove_then_verify $run_test verify_rollup_honk_proof
 
   # barretenberg-acir-tests-bb-client-ivc:
   echo FLOW=prove_then_verify_client_ivc $run_test 6_array


### PR DESCRIPTION
This PR disables the failing test added in https://github.com/AztecProtocol/aztec-packages/pull/10342 pending a fix by @lucasxia01. I've also updated the path filter so that changes to `acir_tests` will trigger these tests being run in CI.
