### PR TITLE
chore: Export trace data to google cloud

### DIFF
--- a/spartan/aztec-network/templates/boot-node.yaml
+++ b/spartan/aztec-network/templates/boot-node.yaml
@@ -180,6 +180,8 @@ spec:
               value: "{{ .Values.bootNode.logLevel }}"
             - name: LOG_JSON
               value: "1"
+            - name: LOG_GCLOUD
+              value: "{{ .Values.telemetry.gcloud }}"
             - name: P2P_ENABLED
               value: "{{ .Values.bootNode.p2p.enabled }}"
             - name: COINBASE

--- a/spartan/aztec-network/templates/faucet.yaml
+++ b/spartan/aztec-network/templates/faucet.yaml
@@ -79,6 +79,8 @@ spec:
               value: "{{ .Values.faucet.l1Assets }}"
             - name: LOG_JSON
               value: "1"
+            - name: LOG_GCLOUD
+              value: "{{ .Values.telemetry.gcloud }}"
             - name: LOG_LEVEL
               value: "{{ .Values.faucet.logLevel }}"
           ports:

--- a/spartan/aztec-network/templates/prover-agent.yaml
+++ b/spartan/aztec-network/templates/prover-agent.yaml
@@ -94,6 +94,8 @@ spec:
               value: "{{ .Values.proverAgent.logLevel }}"
             - name: LOG_JSON
               value: "1"
+            - name: LOG_GCLOUD
+              value: "{{ .Values.telemetry.gcloud }}"
             - name: PROVER_REAL_PROOFS
               value: "{{ .Values.aztec.realProofs }}"
             - name: PROVER_AGENT_COUNT

--- a/spartan/aztec-network/templates/prover-broker.yaml
+++ b/spartan/aztec-network/templates/prover-broker.yaml
@@ -76,6 +76,8 @@ spec:
               value: "{{ .Values.proverBroker.logLevel }}"
             - name: LOG_JSON
               value: "1"
+            - name: LOG_GCLOUD
+              value: "{{ .Values.telemetry.gcloud }}"
             - name: PROVER_BROKER_POLL_INTERVAL_MS
               value: "{{ .Values.proverBroker.pollIntervalMs }}"
             - name: PROVER_BROKER_JOB_TIMEOUT_MS

--- a/spartan/aztec-network/templates/prover-node.yaml
+++ b/spartan/aztec-network/templates/prover-node.yaml
@@ -125,6 +125,8 @@ spec:
               value: "{{ .Values.proverNode.logLevel }}"
             - name: LOG_JSON
               value: "1"
+            - name: LOG_GCLOUD
+              value: "{{ .Values.telemetry.gcloud }}"
             - name: PROVER_REAL_PROOFS
               value: "{{ .Values.aztec.realProofs }}"
             - name: PROVER_AGENT_COUNT

--- a/spartan/aztec-network/templates/pxe.yaml
+++ b/spartan/aztec-network/templates/pxe.yaml
@@ -93,6 +93,8 @@ spec:
               value: "{{ .Values.pxe.service.nodePort }}"
             - name: LOG_JSON
               value: "1"
+            - name: LOG_GCLOUD
+              value: "{{ .Values.telemetry.gcloud }}"
             - name: LOG_LEVEL
               value: "{{ .Values.pxe.logLevel }}"
             - name: PXE_PROVER_ENABLED

--- a/spartan/aztec-network/templates/transaction-bot.yaml
+++ b/spartan/aztec-network/templates/transaction-bot.yaml
@@ -87,6 +87,8 @@ spec:
               value: "{{ .Values.bot.service.nodePort }}"
             - name: LOG_JSON
               value: "1"
+            - name: LOG_GCLOUD
+              value: "{{ .Values.telemetry.gcloud }}"
             - name: LOG_LEVEL
               value: "{{ .Values.bot.logLevel }}"
             - name: BOT_PRIVATE_KEY

--- a/spartan/aztec-network/templates/validator.yaml
+++ b/spartan/aztec-network/templates/validator.yaml
@@ -162,6 +162,8 @@ spec:
               value: "{{ .Values.validator.logLevel }}"
             - name: LOG_JSON
               value: "1"
+            - name: LOG_GCLOUD
+              value: "{{ .Values.telemetry.gcloud }}"
             - name: P2P_ENABLED
               value: "{{ .Values.validator.p2p.enabled }}"
             - name: VALIDATOR_DISABLED

--- a/spartan/aztec-network/values.yaml
+++ b/spartan/aztec-network/values.yaml
@@ -13,6 +13,7 @@ network:
 
 telemetry:
   enabled: false
+  gcloud:
   otelCollectorEndpoint:
 
 images:

--- a/spartan/terraform/deploy-release/main.tf
+++ b/spartan/terraform/deploy-release/main.tf
@@ -100,6 +100,11 @@ resource "helm_release" "aztec-gke-cluster" {
     value = var.L1_DEPLOYMENT_SALT
   }
 
+  set {
+    name  = "telemetry.gcloud"
+    value = "true"
+  }
+
   # Setting timeout and wait conditions
   timeout       = 1200 # 20 minutes in seconds
   wait          = true

--- a/yarn-project/foundation/src/config/env_var.ts
+++ b/yarn-project/foundation/src/config/env_var.ts
@@ -57,6 +57,7 @@ export type EnvVar =
   | 'L2_QUEUE_SIZE'
   | 'LOG_ELAPSED_TIME'
   | 'LOG_JSON'
+  | 'LOG_GCLOUD'
   | 'LOG_MULTILINE'
   | 'LOG_LEVEL'
   | 'MNEMONIC'

--- a/yarn-project/foundation/src/log/gcloud-logger.ts
+++ b/yarn-project/foundation/src/log/gcloud-logger.ts
@@ -1,0 +1,71 @@
+import { type pino } from 'pino';
+
+/* eslint-disable camelcase */
+
+const GOOGLE_CLOUD_TRACE_ID = 'logging.googleapis.com/trace';
+const GOOGLE_CLOUD_SPAN_ID = 'logging.googleapis.com/spanId';
+const GOOGLE_CLOUD_TRACE_SAMPLED = 'logging.googleapis.com/trace_sampled';
+
+/**
+ * Pino configuration for google cloud observability. Tweaks message and timestamp,
+ * adds trace context attributes, and injects severity level.
+ * Adapted from https://cloud.google.com/trace/docs/setup/nodejs-ot#config-structured-logging.
+ */
+export const GoogleCloudLoggerConfig = {
+  messageKey: 'message',
+  // Same as pino.stdTimeFunctions.isoTime but uses "timestamp" key instead of "time"
+  timestamp(): string {
+    return `,"timestamp":"${new Date(Date.now()).toISOString()}"`;
+  },
+  formatters: {
+    log(object: Record<string, unknown>): Record<string, unknown> {
+      // Add trace context attributes following Cloud Logging structured log format described
+      // in https://cloud.google.com/logging/docs/structured-logging#special-payload-fields
+      const { trace_id, span_id, trace_flags, ...rest } = object;
+
+      if (trace_id && span_id) {
+        return {
+          [GOOGLE_CLOUD_TRACE_ID]: trace_id,
+          [GOOGLE_CLOUD_SPAN_ID]: span_id,
+          [GOOGLE_CLOUD_TRACE_SAMPLED]: trace_flags ? trace_flags === '01' : undefined,
+          trace_flags, // Keep the original trace_flags for otel-pino-stream
+          ...rest,
+        };
+      }
+      return object;
+    },
+    level(label: string, level: number): object {
+      // Inspired by https://github.com/pinojs/pino/issues/726#issuecomment-605814879
+      // Severity labels https://cloud.google.com/logging/docs/reference/v2/rest/v2/LogEntry#LogSeverity
+      let severity: string;
+
+      switch (label as pino.Level | keyof typeof customLevels) {
+        case 'trace':
+        case 'debug':
+          severity = 'DEBUG';
+          break;
+        case 'verbose':
+        case 'info':
+          severity = 'INFO';
+          break;
+        case 'warn':
+          severity = 'WARNING';
+          break;
+        case 'error':
+          severity = 'ERROR';
+          break;
+        case 'fatal':
+          severity = 'CRITICAL';
+          break;
+        default:
+          severity = 'DEFAULT';
+          break;
+      }
+
+      return { severity, level };
+    },
+  },
+} satisfies pino.LoggerOptions;
+
+// Define custom logging levels for pino. Duplicate from pino-logger.ts.
+const customLevels = { verbose: 25 };

--- a/yarn-project/telemetry-client/src/otel.ts
+++ b/yarn-project/telemetry-client/src/otel.ts
@@ -126,7 +126,6 @@ export class OpenTelemetryClient implements TelemetryClient {
   public static async createAndStart(config: TelemetryClientConfig, log: Logger): Promise<OpenTelemetryClient> {
     const resource = await getOtelResource();
 
-    // TODO(palla/log): Should we show traces as logs in stdout when otel collection is disabled?
     const tracerProvider = new NodeTracerProvider({
       resource,
       spanProcessors: config.tracesCollectorUrl

--- a/yarn-project/telemetry-client/src/vendor/otel-pino-stream.ts
+++ b/yarn-project/telemetry-client/src/vendor/otel-pino-stream.ts
@@ -222,6 +222,10 @@ export class OTelPinoStream extends Writable {
         // [aztec] They are not redundant, we depend on them for correlation.
         // The instrumentation package seems to be adding these fields via a custom hook.
         // We push them from the logger module in foundation, so we don't want to clear them here.
+        // We do rename the google-cloud specific fields though, back to their expected names.
+        ['logging.googleapis.com/trace']: trace_id,
+        ['logging.googleapis.com/spanId']: span_id,
+        ['logging.googleapis.com/trace_sampled']: _trace_flags,
 
         ...attributes
       } = recObj;
@@ -230,6 +234,11 @@ export class OTelPinoStream extends Writable {
       if (isNaN(timestamp)) {
         attributes['time'] = time; // save the unexpected "time" field to attributes
         timestamp = Date.now();
+      }
+
+      if (span_id && trace_id) {
+        attributes['trace_id'] = trace_id;
+        attributes['span_id'] = span_id;
       }
 
       // This avoids a possible subtle bug when a Pino logger uses


### PR DESCRIPTION
Google cloud observability supports tracing, using specific fields for defining spans and traces (see [here](https://cloud.google.com/trace/docs/setup/nodejs-ot?authuser=1#config-structured-logging)).

This PR adds a LOG_GCLOUD env var that injects pino formatters based on google cloud docs to export trace data in a format that google can understand.

Fixes #10937 
