### PR TITLE
chore(ci): fix CI to create baseline gate reports

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -562,7 +562,7 @@ jobs:
 
   protocol-circuits-gates-report:
     needs: [ci-rest, configure]
-    if: needs.configure.outputs.non-docs == 'true' && needs.configure.outputs.non-bb == 'true'
+    if: github.ref_name == 'master' || (needs.configure.outputs.non-docs == 'true' && needs.configure.outputs.non-bb == 'true')
     runs-on: ubuntu-latest
     permissions:
       pull-requests: write
@@ -600,7 +600,7 @@ jobs:
 
   public-functions-size-report:
     needs: [ci-rest, configure]
-    if: needs.configure.outputs.non-docs == 'true'
+    if:  github.ref_name == 'master' || needs.configure.outputs.non-docs == 'true'
     runs-on: ubuntu-latest
     permissions:
       pull-requests: write


### PR DESCRIPTION
CI3 broke this job as it's required to be run on master.