### PR TITLE
chore: Fix customTags is not iterable in e2e-prover-full

### DIFF
--- a/.github/ensure-tester/action.yml
+++ b/.github/ensure-tester/action.yml
@@ -78,6 +78,7 @@ runs:
         ec2_subnet_id: subnet-4cfabd25
         ec2_security_group_id: sg-0ccd4e5df0dcca0c9
         ec2_key_name: "build-instance"
+        ec2_instance_tags: '[]'
 
     - name: Ensure Tester Cleanup
       uses: gacts/run-and-post-run@v1


### PR DESCRIPTION
e2e-prover-full has been failing with `customTags is not iterable` since commit `6e94c1ac13d63826a8ecd29eec74c79c053a2a05`. This is an attempt to fix it.

See [here](https://github.com/AztecProtocol/aztec-packages/actions/runs/12603823032/job/35130125257) for a failed run.

This also affects kind tests and acir-bench.