### PR TITLE
chore: Hide note_hashes log

### DIFF
--- a/yarn-project/simulator/src/client/client_execution_context.ts
+++ b/yarn-project/simulator/src/client/client_execution_context.ts
@@ -544,10 +544,6 @@ export class ClientExecutionContext extends ViewDataOracle {
     );
   }
 
-  public override debugLog(message: string, fields: Fr[]) {
-    this.log.verbose(`${applyStringFormatting(message, fields)}`, { module: `${this.log.module}:debug_log` });
-  }
-
   public getDebugFunctionName() {
     return this.db.getDebugFunctionName(this.contractAddress, this.callContext.functionSelector);
   }

--- a/yarn-project/simulator/src/client/client_execution_context.ts
+++ b/yarn-project/simulator/src/client/client_execution_context.ts
@@ -23,7 +23,7 @@ import { computeUniqueNoteHash, siloNoteHash } from '@aztec/circuits.js/hash';
 import { type FunctionAbi, type FunctionArtifact, type NoteSelector, countArgumentsSize } from '@aztec/foundation/abi';
 import { AztecAddress } from '@aztec/foundation/aztec-address';
 import { Fr } from '@aztec/foundation/fields';
-import { applyStringFormatting, createLogger } from '@aztec/foundation/log';
+import { createLogger } from '@aztec/foundation/log';
 
 import { type NoteData, toACVMWitness } from '../acvm/index.js';
 import { type PackedValuesCache } from '../common/packed_values_cache.js';

--- a/yarn-project/simulator/src/client/view_data_oracle.ts
+++ b/yarn-project/simulator/src/client/view_data_oracle.ts
@@ -290,6 +290,10 @@ export class ViewDataOracle extends TypedOracle {
   }
 
   public override debugLog(message: string, fields: Fr[]): void {
+    // TODO(#10558) Remove this check once the debug log is fixed
+    if (message.startsWith('Context.note_hashes, after pushing new note hash:')) {
+      return;
+    }
     this.log.verbose(`${applyStringFormatting(message, fields)}`, { module: `${this.log.module}:debug_log` });
   }
 


### PR DESCRIPTION
Hides the log message `Context.note_hashes, after pushing new note hash` in the oracle. 

Note we cannot just remove it due to #10558 

https://github.com/AztecProtocol/aztec-packages/blob/f35094fd74f28d5bb41084f7b89f961a5f4d0af0/noir-projects/aztec-nr/aztec/src/context/private_context.nr#L143-L147
