### PR TITLE
chore: update noir-bignum to v0.5.0

### DIFF
--- a/noir-projects/noir-protocol-circuits/crates/blob/Nargo.toml
+++ b/noir-projects/noir-protocol-circuits/crates/blob/Nargo.toml
@@ -5,5 +5,5 @@ authors = [""]
 compiler_version = ">=0.30.0"
 
 [dependencies]
-bigint = {tag = "v0.4.2", git = "https://github.com/noir-lang/noir-bignum" }
+bigint = { tag = "v0.5.0", git = "https://github.com/noir-lang/noir-bignum" }
 types = { path = "../types" }


### PR DESCRIPTION
This should fix a few errors that Noir will start reporting soon unless we update to this newer version.

See https://github.com/noir-lang/noir/pull/6895 and https://github.com/noir-lang/noir/pull/6645