### PR TITLE
chore: remove some instances of `--silence-warnings`

### DIFF
--- a/noir-projects/aztec-nr/bootstrap.sh
+++ b/noir-projects/aztec-nr/bootstrap.sh
@@ -9,7 +9,7 @@ export NARGO=${NARGO:-../../noir/noir-repo/target/release/nargo}
 
 function test_cmds {
   i=0
-  $NARGO test --list-tests --silence-warnings | while read -r package test; do
+  $NARGO test --list-tests | while read -r package test; do
     # We assume there are 8 txe's running.
     port=$((45730 + (i++ % ${NUM_TXES:-1})))
     echo "noir-projects/scripts/run_test.sh aztec-nr $package $test $port"

--- a/noir-projects/noir-contracts/bootstrap.sh
+++ b/noir-projects/noir-contracts/bootstrap.sh
@@ -144,7 +144,7 @@ function build {
 
 function test_cmds {
   i=0
-  $NARGO test --list-tests --silence-warnings | while read -r package test; do
+  $NARGO test --list-tests | while read -r package test; do
     # We assume there are 8 txe's running.
     port=$((45730 + (i++ % ${NUM_TXES:-1})))
     echo "noir-projects/scripts/run_test.sh noir-contracts $package $test $port"

--- a/noir-projects/noir-contracts/bootstrap.sh
+++ b/noir-projects/noir-contracts/bootstrap.sh
@@ -105,7 +105,7 @@ function compile {
     "^noir-projects/aztec-nr/" \
   )"
   if ! cache_download contract-$contract_hash.tar.gz &> /dev/null; then
-    $NARGO compile --package $contract --silence-warnings --inliner-aggressiveness 0
+    $NARGO compile --package $contract --inliner-aggressiveness 0
     $TRANSPILER $json_path $json_path
     cache_upload contract-$contract_hash.tar.gz $json_path &> /dev/null
   fi

--- a/noir-projects/noir-protocol-circuits/bootstrap.sh
+++ b/noir-projects/noir-protocol-circuits/bootstrap.sh
@@ -67,7 +67,7 @@ function compile {
     SECONDS=0
     rm -f $json_path
     # TODO: --skip-brillig-constraints-check added temporarily for blobs build time.
-    local compile_cmd="$NARGO compile --package $name --silence-warnings --skip-brillig-constraints-check"
+    local compile_cmd="$NARGO compile --package $name --skip-brillig-constraints-check"
     echo_stderr "$compile_cmd"
     dump_fail "$compile_cmd"
     echo_stderr "Compilation complete for: $name (${SECONDS}s)"

--- a/noir-projects/noir-protocol-circuits/bootstrap.sh
+++ b/noir-projects/noir-protocol-circuits/bootstrap.sh
@@ -138,7 +138,7 @@ function test {
   CIRCUITS_HASH=$(cache_content_hash ../../noir/.rebuild_patterns "^noir-projects/$name")
   test_should_run $name-tests-$CIRCUITS_HASH || return 0
 
-  RAYON_NUM_THREADS= $NARGO test --silence-warnings --skip-brillig-constraints-check
+  RAYON_NUM_THREADS= $NARGO test --skip-brillig-constraints-check
   cache_upload_flag $name-tests-$CIRCUITS_HASH
 }
 

--- a/noir-projects/scripts/check.sh
+++ b/noir-projects/scripts/check.sh
@@ -3,7 +3,7 @@ set -eu
 
 cd $(dirname "$0")/../
 
-nargo check --program-dir ./aztec-nr --silence-warnings
-nargo check --program-dir ./noir-contracts --silence-warnings
-nargo check --program-dir ./noir-protocol-circuits --silence-warnings
-nargo check --program-dir ./mock-protocol-circuits --silence-warnings
+nargo check --program-dir ./aztec-nr
+nargo check --program-dir ./noir-contracts
+nargo check --program-dir ./noir-protocol-circuits
+nargo check --program-dir ./mock-protocol-circuits


### PR DESCRIPTION
Warnings were silenced due to the old aztec macros causing a lot of warnings which weren't possible to address. This is no longer the case so aztec-packages should not silence these as this just prevents people from addressing them.