### PR TITLE
fix: Check class registration nullifier in node before returning class

### DIFF
--- a/yarn-project/end-to-end/src/e2e_deploy_contract/contract_class_registration.test.ts
+++ b/yarn-project/end-to-end/src/e2e_deploy_contract/contract_class_registration.test.ts
@@ -1,3 +1,4 @@
+import { type AztecNodeService } from '@aztec/aztec-node';
 import {
   AztecAddress,
   type AztecNode,
@@ -76,7 +77,11 @@ describe('e2e_deploy_contract contract class registration', () => {
     // TODO(#10007) Remove this test as well.
     it('starts archiver with pre-registered common contracts', async () => {
       const classId = computeContractClassId(getContractClassFromArtifact(TokenContractArtifact));
-      expect(await aztecNode.getContractClass(classId)).not.toBeUndefined();
+      // The node checks the registration nullifier
+      expect(await aztecNode.getContractClass(classId)).toBeUndefined();
+      // But the archiver does not
+      const archiver = (aztecNode as AztecNodeService).getContractDataSource();
+      expect(await archiver.getContractClass(classId)).toBeDefined();
     });
 
     it('registers the contract class on the node', async () => {


### PR DESCRIPTION
Since https://github.com/AztecProtocol/aztec-packages/issues/10000 we are not broadcasting public bytecode. To work around this in some networks, we're manually adding some common contracts (Token) to archivers on startup.

Since an Aztec node returns that a class is publicly registered as long as it's on its archiver, clients were not sending txs to register the Token class.

However, we will soon check for registration nullifiers. But since clients think the Token class is registered, they never send the registration tx. So this will cause all interactions with the Token to break.

This attempts to fix this by only telling clients that a class is registered if the nullifier is present.
