### PR TITLE
chore: Fix invalid random log id

### DIFF
--- a/yarn-project/circuit-types/src/logs/log_id.ts
+++ b/yarn-project/circuit-types/src/logs/log_id.ts
@@ -34,7 +34,7 @@ export class LogId {
 
   static random() {
     return new LogId(
-      Math.floor(Math.random() * 1000),
+      Math.floor(Math.random() * 1000) + 1,
       Math.floor(Math.random() * 1000),
       Math.floor(Math.random() * 100),
     );


### PR DESCRIPTION
Calling `LogId.random` would sometimes return an invalid instance. Spotted by @charlielye.