### PR TITLE
chore: address some warnings in protocol circuits

### DIFF
--- a/noir-projects/aztec-nr/address-note/src/address_note.nr
+++ b/noir-projects/aztec-nr/address-note/src/address_note.nr
@@ -52,11 +52,15 @@ impl NullifiableNote for AddressNote {
 
 impl AddressNote {
     pub fn new(address: AztecAddress, owner: AztecAddress) -> Self {
-        // We use the randomness to preserve the privacy of the note recipient by preventing brute-forcing, so a
-        // malicious sender could use non-random values to make the note less private. But they already know the full
-        // note pre-image anyway, and so the recipient already trusts them to not disclose this information. We can
-        // therefore assume that the sender will cooperate in the random value generation.
-        let randomness = unsafe { random() };
+        let randomness = unsafe {
+            //@safety
+            // We use the randomness to preserve the privacy of the note recipient by preventing brute-forcing, so a
+            // malicious sender could use non-random values to make the note less private. But they already know the full
+            // note pre-image anyway, and so the recipient already trusts them to not disclose this information. We can
+            // therefore assume that the sender will cooperate in the random value generation.
+
+            random()
+        };
         AddressNote { address, owner, randomness, header: NoteHeader::empty() }
     }
     // docs:end:address_note_def

--- a/noir-projects/aztec-nr/aztec/src/encrypted_logs/payload.nr
+++ b/noir-projects/aztec-nr/aztec/src/encrypted_logs/payload.nr
@@ -1,15 +1,10 @@
 use dep::protocol_types::{
-    address::AztecAddress,
-    constants::{GENERATOR_INDEX__SYMMETRIC_KEY, PRIVATE_LOG_SIZE_IN_FIELDS},
-    hash::poseidon2_hash,
-    point::Point,
-    public_keys::AddressPoint,
-    scalar::Scalar,
-    utils::arrays::array_concat,
+    address::AztecAddress, constants::PRIVATE_LOG_SIZE_IN_FIELDS, hash::poseidon2_hash,
+    point::Point, public_keys::AddressPoint, scalar::Scalar, utils::arrays::array_concat,
 };
 use std::{
     aes128::aes128_encrypt, embedded_curve_ops::fixed_base_scalar_mul as derive_public_key,
-    field::bn254::decompose, hash::from_field_unsafe as fr_to_fq_unsafe,
+    hash::from_field_unsafe as fr_to_fq_unsafe,
 };
 
 use crate::{
@@ -177,14 +172,6 @@ unconstrained fn get_random_bytes<let N: u32>() -> [u8; N] {
         idx += 1;
     }
     bytes
-}
-
-/// Converts a base field element to scalar field element.
-/// This is fine because modulus of the base field is smaller than the modulus of the scalar field.
-fn fr_to_fq(r: Field) -> Scalar {
-    let (lo, hi) = decompose(r);
-
-    Scalar { lo, hi }
 }
 
 fn generate_ephemeral_key_pair() -> (Scalar, Point) {

--- a/noir-projects/aztec-nr/aztec/src/macros/events/mod.nr
+++ b/noir-projects/aztec-nr/aztec/src/macros/events/mod.nr
@@ -1,6 +1,5 @@
 use super::utils::compute_event_selector;
 use protocol_types::meta::flatten_to_fields;
-use std::meta::typ::fresh_type_variable;
 
 comptime fn generate_event_interface(s: StructDefinition) -> Quoted {
     let name = s.name();

--- a/noir-projects/aztec-nr/aztec/src/note/note_interface.nr
+++ b/noir-projects/aztec-nr/aztec/src/note/note_interface.nr
@@ -1,6 +1,6 @@
 use crate::context::PrivateContext;
 use crate::note::note_header::NoteHeader;
-use dep::protocol_types::traits::{Empty, Serialize};
+use dep::protocol_types::traits::Empty;
 
 pub trait NoteProperties<T> {
     fn properties() -> T;

--- a/noir-projects/noir-protocol-circuits/crates/blob/src/blob.nr
+++ b/noir-projects/noir-protocol-circuits/crates/blob/src/blob.nr
@@ -501,7 +501,7 @@ mod tests {
         //*                    d
         //
         let rhs = z_d_helper(challenge_z);
-        let z_minus_1 = unsafe { challenge_z.__sub(BigNum::one()) };
+        let z_minus_1 = challenge_z.__sub(BigNum::one());
         let lhs = y.__mul(z_minus_1);
         assert_eq(lhs, rhs);
     }

--- a/noir-projects/noir-protocol-circuits/crates/private-kernel-lib/src/private_kernel_reset.nr
+++ b/noir-projects/noir-protocol-circuits/crates/private-kernel-lib/src/private_kernel_reset.nr
@@ -296,10 +296,8 @@ mod tests {
         }
 
         pub fn execute(&mut self) -> PrivateKernelCircuitPublicInputs {
-            let note_hash_read_request_hints =
-                unsafe { self.note_hash_read_request_hints_builder.to_hints() };
-            let nullifier_read_request_hints =
-                unsafe { self.nullifier_read_request_hints_builder.to_hints() };
+            let note_hash_read_request_hints = self.note_hash_read_request_hints_builder.to_hints();
+            let nullifier_read_request_hints = self.nullifier_read_request_hints_builder.to_hints();
             let hints = PrivateKernelResetHints {
                 note_hash_read_request_hints,
                 nullifier_read_request_hints,

--- a/noir-projects/noir-protocol-circuits/crates/private-kernel-lib/src/tests/private_kernel_circuit_public_inputs_composer_builder/mod.nr
+++ b/noir-projects/noir-protocol-circuits/crates/private-kernel-lib/src/tests/private_kernel_circuit_public_inputs_composer_builder/mod.nr
@@ -60,12 +60,11 @@ impl PrivateKernelCircuitPublicInputsComposerBuilder {
         is_private_only: bool,
     ) -> PrivateKernelCircuitPublicInputs {
         let private_call = self.private_call.to_private_call_data();
-        unsafe {
-            self
-                .new_from_tx_request(is_private_only)
-                .with_private_call(private_call.public_inputs)
-                .finish()
-        }
+
+        self
+            .new_from_tx_request(is_private_only)
+            .with_private_call(private_call.public_inputs)
+            .finish()
     }
 
     pub fn compose_from_previous_kernel(self) -> PrivateKernelCircuitPublicInputs {

--- a/noir-projects/noir-protocol-circuits/crates/private-kernel-lib/src/tests/reset_output_validator_builder/mod.nr
+++ b/noir-projects/noir-protocol-circuits/crates/private-kernel-lib/src/tests/reset_output_validator_builder/mod.nr
@@ -70,10 +70,8 @@ impl ResetOutputValidatorBuilder {
         self,
     ) -> PrivateValidationRequestProcessor<NOTE_HASH_PENDING_AMOUNT, NOTE_HASH_SETTLED_AMOUNT, NULLIFIER_PENDING_AMOUNT, NULLIFIER_SETTLED_AMOUNT, NULLIFIER_KEYS> {
         let previous_kernel = self.previous_kernel.to_private_kernel_circuit_public_inputs();
-        let note_hash_read_request_hints =
-            unsafe { self.note_hash_read_request_hints_builder.to_hints() };
-        let nullifier_read_request_hints =
-            unsafe { self.nullifier_read_request_hints_builder.to_hints() };
+        let note_hash_read_request_hints = self.note_hash_read_request_hints_builder.to_hints();
+        let nullifier_read_request_hints = self.nullifier_read_request_hints_builder.to_hints();
 
         PrivateValidationRequestProcessor {
             validation_requests: previous_kernel.validation_requests,

--- a/noir-projects/noir-protocol-circuits/crates/rollup-lib/src/root/root_rollup_inputs.nr
+++ b/noir-projects/noir-protocol-circuits/crates/rollup-lib/src/root/root_rollup_inputs.nr
@@ -5,7 +5,7 @@ use crate::{
 use types::{
     constants::{
         BLOCK_MERGE_ROLLUP_INDEX, BLOCK_ROOT_ROLLUP_EMPTY_INDEX, BLOCK_ROOT_ROLLUP_INDEX,
-        PROOF_TYPE_ROLLUP_HONK, PROOF_TYPE_ROOT_ROLLUP_HONK,
+        PROOF_TYPE_ROOT_ROLLUP_HONK,
     },
     traits::Empty,
 };

--- a/noir-projects/noir-protocol-circuits/crates/types/src/abis/note_hash_leaf_preimage.nr
+++ b/noir-projects/noir-protocol-circuits/crates/types/src/abis/note_hash_leaf_preimage.nr
@@ -2,7 +2,6 @@ global NOTE_HASH_LEAF_PREIMAGE_LENGTH: u32 = 1;
 
 use crate::{
     abis::{read_request::ScopedReadRequest, side_effect::Readable},
-    hash::compute_siloed_note_hash,
     merkle_tree::leaf_preimage::LeafPreimage,
     traits::Empty,
 };

--- a/noir-projects/noir-protocol-circuits/crates/types/src/utils/arrays/sort_by.nr
+++ b/noir-projects/noir-protocol-circuits/crates/types/src/utils/arrays/sort_by.nr
@@ -8,10 +8,10 @@ pub unconstrained fn sort_by<T, let N: u32, Env>(
     ordering: fn[Env](T, T) -> bool,
 ) -> [T; N] {
     let mut result = array;
-    let sorted_index = unsafe { get_sorting_index(array, ordering) };
+    let sorted_index = get_sorting_index(array, ordering);
     // Ensure the indexes are correct
     for i in 0..N {
-        let pos = unsafe { find_index_hint(sorted_index, |index: u32| index == i) };
+        let pos = find_index_hint(sorted_index, |index: u32| index == i);
         assert(sorted_index[pos] == i);
     }
     // Sort the array using the indexes


### PR DESCRIPTION
This PR removes a number of unnecessary `unsafe` blocks as they just reduce code clarity.