### PR TITLE
feat: optionally handle rpc errors with 200 + err body

### DIFF
--- a/noir-projects/Earthfile
+++ b/noir-projects/Earthfile
@@ -2,7 +2,7 @@ VERSION 0.8
 test:
   BUILD +test-protocol-circuits
   BUILD +test-aztec-nr
-  # BUILD +test-contracts
+  BUILD +test-contracts
 
 test-protocol-circuits:
   FROM ../+bootstrap

--- a/yarn-project/aztec/src/cli/aztec_start_action.ts
+++ b/yarn-project/aztec/src/cli/aztec_start_action.ts
@@ -102,7 +102,7 @@ export async function aztecStart(options: any, userLog: LogFn, debugLogger: Logg
   installSignalHandlers(debugLogger.info, signalHandlers);
 
   if (Object.entries(services).length > 0) {
-    const rpcServer = createNamespacedSafeJsonRpcServer(services, debugLogger);
+    const rpcServer = createNamespacedSafeJsonRpcServer(services, false, debugLogger);
     const { port } = await startHttpRpcServer(rpcServer, { port: options.port });
     debugLogger.info(`Aztec Server listening on port ${port}`);
   }

--- a/yarn-project/bot/src/rpc.ts
+++ b/yarn-project/bot/src/rpc.ts
@@ -9,7 +9,7 @@ import { type BotRunner } from './runner.js';
  * @returns An JSON-RPC HTTP server
  */
 export function createBotRunnerRpcServer(botRunner: BotRunner) {
-  createSafeJsonRpcServer(botRunner, BotRunnerApiSchema, botRunner.isHealthy.bind(botRunner));
+  createSafeJsonRpcServer(botRunner, BotRunnerApiSchema, false, botRunner.isHealthy.bind(botRunner));
 }
 
 export function getBotRunnerApiHandler(botRunner: BotRunner): ApiHandler {

--- a/yarn-project/txe/src/index.ts
+++ b/yarn-project/txe/src/index.ts
@@ -120,5 +120,5 @@ const TXEDispatcherApiSchema: ApiSchemaFor<TXEDispatcher> = {
  * @returns A TXE RPC server.
  */
 export function createTXERpcServer(logger: Logger) {
-  return createSafeJsonRpcServer(new TXEDispatcher(logger), TXEDispatcherApiSchema);
+  return createSafeJsonRpcServer(new TXEDispatcher(logger), TXEDispatcherApiSchema, true);
 }


### PR DESCRIPTION
Makes our JSON RPC servers optionally handle errors conforming to the JSON RPC spec: 

- Return a 200 HTTP status code
- Include an error object with `message`, `code` and `data`

This allows us to revert https://github.com/AztecProtocol/aztec-packages/pull/11047 by unbreaking TXE
