### PR TITLE
fix: bump lookup table constant and improve logging

### DIFF
--- a/barretenberg/cpp/src/barretenberg/constants.hpp
+++ b/barretenberg/cpp/src/barretenberg/constants.hpp
@@ -13,7 +13,8 @@ static constexpr uint32_t CONST_PG_LOG_N = 20;
 
 static constexpr uint32_t CONST_ECCVM_LOG_N = 15;
 
-static constexpr uint32_t MAX_LOOKUP_TABLES_SIZE = 77000;
+// TODO(https://github.com/AztecProtocol/barretenberg/issues/1193): potentially reenable for better memory performance
+// static constexpr uint32_t MAX_LOOKUP_TABLES_SIZE = 80000;
 
 static constexpr uint32_t MAX_DATABUS_SIZE = 10000;
 

--- a/barretenberg/cpp/src/barretenberg/constants.hpp
+++ b/barretenberg/cpp/src/barretenberg/constants.hpp
@@ -13,7 +13,7 @@ static constexpr uint32_t CONST_PG_LOG_N = 20;
 
 static constexpr uint32_t CONST_ECCVM_LOG_N = 15;
 
-static constexpr uint32_t MAX_LOOKUP_TABLES_SIZE = 75000;
+static constexpr uint32_t MAX_LOOKUP_TABLES_SIZE = 77000;
 
 static constexpr uint32_t MAX_DATABUS_SIZE = 10000;
 

--- a/barretenberg/cpp/src/barretenberg/goblin/mock_circuits.hpp
+++ b/barretenberg/cpp/src/barretenberg/goblin/mock_circuits.hpp
@@ -8,6 +8,7 @@
 #include "barretenberg/crypto/merkle_tree/merkle_tree.hpp"
 #include "barretenberg/srs/global_crs.hpp"
 #include "barretenberg/stdlib/encryption/ecdsa/ecdsa.hpp"
+#include "barretenberg/stdlib/hash/keccak/keccak.hpp"
 #include "barretenberg/stdlib/hash/sha256/sha256.hpp"
 #include "barretenberg/stdlib/honk_verifier/ultra_recursive_verifier.hpp"
 #include "barretenberg/stdlib/primitives/curves/secp256k1.hpp"

--- a/barretenberg/cpp/src/barretenberg/plonk_honk_shared/composer/composer_lib.hpp
+++ b/barretenberg/cpp/src/barretenberg/plonk_honk_shared/composer/composer_lib.hpp
@@ -22,6 +22,7 @@ void construct_lookup_table_polynomials(const RefArray<typename Flavor::Polynomi
     //  |          table     randomness
     //  ignored, as used for regular constraints and padding to the next power of 2.
     // TODO(https://github.com/AztecProtocol/barretenberg/issues/1033): construct tables and counts at top of trace
+    // TODO(https://github.com/AztecProtocol/barretenberg/issues/1193): make max table size mechanism more robust
     const size_t tables_size = circuit.get_tables_size();
     if (tables_size > MAX_LOOKUP_TABLES_SIZE) {
         info("\nTotal lookup tables size = ",

--- a/barretenberg/cpp/src/barretenberg/plonk_honk_shared/composer/composer_lib.hpp
+++ b/barretenberg/cpp/src/barretenberg/plonk_honk_shared/composer/composer_lib.hpp
@@ -23,7 +23,13 @@ void construct_lookup_table_polynomials(const RefArray<typename Flavor::Polynomi
     //  ignored, as used for regular constraints and padding to the next power of 2.
     // TODO(https://github.com/AztecProtocol/barretenberg/issues/1033): construct tables and counts at top of trace
     const size_t tables_size = circuit.get_tables_size();
-    ASSERT(tables_size <= MAX_LOOKUP_TABLES_SIZE); // if false, may need to increase constant
+    if (tables_size > MAX_LOOKUP_TABLES_SIZE) {
+        info("\nTotal lookup tables size = ",
+             tables_size,
+             " exceeds constant MAX_LOOKUP_TABLES_SIZE = ",
+             MAX_LOOKUP_TABLES_SIZE);
+        ASSERT(false);
+    }
     ASSERT(dyadic_circuit_size > tables_size + additional_offset);
     size_t offset = circuit.blocks.lookup.trace_offset;
     if constexpr (IsPlonkFlavor<Flavor>) {

--- a/barretenberg/cpp/src/barretenberg/plonk_honk_shared/composer/composer_lib.hpp
+++ b/barretenberg/cpp/src/barretenberg/plonk_honk_shared/composer/composer_lib.hpp
@@ -22,15 +22,7 @@ void construct_lookup_table_polynomials(const RefArray<typename Flavor::Polynomi
     //  |          table     randomness
     //  ignored, as used for regular constraints and padding to the next power of 2.
     // TODO(https://github.com/AztecProtocol/barretenberg/issues/1033): construct tables and counts at top of trace
-    // TODO(https://github.com/AztecProtocol/barretenberg/issues/1193): make max table size mechanism more robust
     const size_t tables_size = circuit.get_tables_size();
-    if (tables_size > MAX_LOOKUP_TABLES_SIZE) {
-        info("\nTotal lookup tables size = ",
-             tables_size,
-             " exceeds constant MAX_LOOKUP_TABLES_SIZE = ",
-             MAX_LOOKUP_TABLES_SIZE);
-        ASSERT(false);
-    }
     ASSERT(dyadic_circuit_size > tables_size + additional_offset);
     size_t offset = circuit.blocks.lookup.trace_offset;
     if constexpr (IsPlonkFlavor<Flavor>) {

--- a/barretenberg/cpp/src/barretenberg/ultra_honk/CMakeLists.txt
+++ b/barretenberg/cpp/src/barretenberg/ultra_honk/CMakeLists.txt
@@ -1,1 +1,1 @@
-barretenberg_module(ultra_honk sumcheck stdlib_primitives)
+barretenberg_module(ultra_honk sumcheck stdlib_primitives stdlib_keccak stdlib_sha256)

--- a/barretenberg/cpp/src/barretenberg/ultra_honk/decider_proving_key.cpp
+++ b/barretenberg/cpp/src/barretenberg/ultra_honk/decider_proving_key.cpp
@@ -99,8 +99,8 @@ void DeciderProvingKey_<Flavor>::allocate_table_lookup_polynomials(const Circuit
     PROFILE_THIS_NAME("allocate_table_lookup_polynomials");
 
     size_t table_offset = circuit.blocks.lookup.trace_offset;
-    const size_t max_tables_size =
-        std::min(static_cast<size_t>(MAX_LOOKUP_TABLES_SIZE), dyadic_circuit_size - table_offset);
+    // TODO(https://github.com/AztecProtocol/barretenberg/issues/1193): can potentially improve memory footprint
+    const size_t max_tables_size = dyadic_circuit_size - table_offset;
     ASSERT(dyadic_circuit_size > max_tables_size);
 
     // Allocate the polynomials containing the actual table data


### PR DESCRIPTION
Remove the MAX_LOOKUP_TABLES_SIZE constant (for now) to avoid pain for developers. Added TODO to reconsider this in the future to continue to benefit from the memory gains afforded by MAX_LOOKUP_TABLES_SIZE