### PR TITLE
fix: Prover node aborts execution at epoch end

### DIFF
--- a/yarn-project/archiver/src/archiver/archiver.ts
+++ b/yarn-project/archiver/src/archiver/archiver.ts
@@ -508,8 +508,8 @@ export class Archiver implements ArchiveSource, Traceable {
     return Promise.resolve();
   }
 
-  public getL1Constants(): L1RollupConstants {
-    return this.l1constants;
+  public getL1Constants(): Promise<L1RollupConstants> {
+    return Promise.resolve(this.l1constants);
   }
 
   public getRollupAddress(): Promise<EthAddress> {

--- a/yarn-project/archiver/src/test/mock_l2_block_source.ts
+++ b/yarn-project/archiver/src/test/mock_l2_block_source.ts
@@ -1,4 +1,5 @@
 import {
+  type L1RollupConstants,
   L2Block,
   L2BlockHash,
   type L2BlockSource,
@@ -6,8 +7,8 @@ import {
   type TxHash,
   TxReceipt,
   TxStatus,
+  getSlotRangeForEpoch,
 } from '@aztec/circuit-types';
-import { getSlotRangeForEpoch } from '@aztec/circuit-types';
 import { type BlockHeader, EthAddress } from '@aztec/circuits.js';
 import { DefaultL1ContractsConfig } from '@aztec/ethereum';
 import { createLogger } from '@aztec/foundation/log';
@@ -184,6 +185,10 @@ export class MockL2BlockSource implements L2BlockSource {
   }
 
   isEpochComplete(_epochNumber: bigint): Promise<boolean> {
+    throw new Error('Method not implemented.');
+  }
+
+  getL1Constants(): Promise<L1RollupConstants> {
     throw new Error('Method not implemented.');
   }
 

--- a/yarn-project/aztec.js/src/index.ts
+++ b/yarn-project/aztec.js/src/index.ts
@@ -125,7 +125,6 @@ export {
   mockEpochProofQuote,
   mockTx,
   type AztecNode,
-  type EpochConstants,
   type LogFilter,
   type PXE,
   type PartialAddress,

--- a/yarn-project/circuit-types/src/epoch-helpers/index.test.ts
+++ b/yarn-project/circuit-types/src/epoch-helpers/index.test.ts
@@ -1,12 +1,11 @@
-import { type EpochConstants, getTimestampRangeForEpoch } from './index.js';
+import { type L1RollupConstants, getTimestampRangeForEpoch } from './index.js';
 
 describe('EpochHelpers', () => {
-  let constants: EpochConstants;
+  let constants: Omit<L1RollupConstants, 'l1StartBlock'>;
   const l1GenesisTime = 1734440000n;
 
   beforeEach(() => {
     constants = {
-      l1GenesisBlock: 10n,
       l1GenesisTime: l1GenesisTime,
       epochDuration: 4,
       slotDuration: 24,

--- a/yarn-project/circuit-types/src/interfaces/archiver.test.ts
+++ b/yarn-project/circuit-types/src/interfaces/archiver.test.ts
@@ -21,6 +21,7 @@ import { readFileSync } from 'fs';
 import omit from 'lodash.omit';
 import { resolve } from 'path';
 
+import { EmptyL1RollupConstants, type L1RollupConstants } from '../epoch-helpers/index.js';
 import { type InBlock, randomInBlock } from '../in_block.js';
 import { L2Block } from '../l2_block.js';
 import { type L2Tips } from '../l2_block_source.js';
@@ -248,6 +249,11 @@ describe('ArchiverApiSchema', () => {
       privateFunctions: [],
     });
   });
+
+  it('getL1Constants', async () => {
+    const result = await context.client.getL1Constants();
+    expect(result).toEqual(EmptyL1RollupConstants);
+  });
 });
 
 class MockArchiver implements ArchiverApi {
@@ -387,5 +393,8 @@ class MockArchiver implements ArchiverApi {
   }
   addContractClass(_contractClass: ContractClassPublic): Promise<void> {
     return Promise.resolve();
+  }
+  getL1Constants(): Promise<L1RollupConstants> {
+    return Promise.resolve(EmptyL1RollupConstants);
   }
 }

--- a/yarn-project/circuit-types/src/interfaces/archiver.ts
+++ b/yarn-project/circuit-types/src/interfaces/archiver.ts
@@ -10,6 +10,7 @@ import { type ApiSchemaFor, optional, schemas } from '@aztec/foundation/schemas'
 
 import { z } from 'zod';
 
+import { L1RollupConstantsSchema } from '../epoch-helpers/index.js';
 import { inBlockSchemaFor } from '../in_block.js';
 import { L2Block } from '../l2_block.js';
 import { type L2BlockSource, L2TipsSchema } from '../l2_block_source.js';
@@ -77,4 +78,5 @@ export const ArchiverApiSchema: ApiSchemaFor<ArchiverApi> = {
     .function()
     .args(schemas.AztecAddress, schemas.FunctionSelector)
     .returns(optional(z.string())),
+  getL1Constants: z.function().args().returns(L1RollupConstantsSchema),
 };

--- a/yarn-project/circuit-types/src/interfaces/prover-node.ts
+++ b/yarn-project/circuit-types/src/interfaces/prover-node.ts
@@ -15,9 +15,20 @@ const EpochProvingJobState = [
   'publishing-proof',
   'completed',
   'failed',
+  'stopped',
+  'timed-out',
 ] as const;
 
 export type EpochProvingJobState = (typeof EpochProvingJobState)[number];
+
+export const EpochProvingJobTerminalState: EpochProvingJobState[] = [
+  'completed',
+  'failed',
+  'stopped',
+  'timed-out',
+] as const;
+
+export type EpochProvingJobTerminalState = (typeof EpochProvingJobTerminalState)[number];
 
 /** JSON RPC public interface to a prover node. */
 export interface ProverNodeApi {

--- a/yarn-project/circuit-types/src/l2_block_source.ts
+++ b/yarn-project/circuit-types/src/l2_block_source.ts
@@ -2,6 +2,7 @@ import { type BlockHeader, type EthAddress } from '@aztec/circuits.js';
 
 import { z } from 'zod';
 
+import { type L1RollupConstants } from './epoch-helpers/index.js';
 import { type InBlock } from './in_block.js';
 import { type L2Block } from './l2_block.js';
 import { type TxHash } from './tx/tx_hash.js';
@@ -106,6 +107,11 @@ export interface L2BlockSource {
    * Returns the tips of the L2 chain.
    */
   getL2Tips(): Promise<L2Tips>;
+
+  /**
+   * Returns the rollup constants for the current chain.
+   */
+  getL1Constants(): Promise<L1RollupConstants>;
 }
 
 /**

--- a/yarn-project/circuits.js/src/structs/proof.ts
+++ b/yarn-project/circuits.js/src/structs/proof.ts
@@ -99,6 +99,11 @@ export class Proof {
       this.buffer.length === EMPTY_PROOF_SIZE && this.buffer.every(byte => byte === 0) && this.numPublicInputs === 0
     );
   }
+
+  /** Returns an empty proof. */
+  static empty() {
+    return makeEmptyProof();
+  }
 }
 
 /**

--- a/yarn-project/circuits.js/src/structs/rollup/block_root_or_block_merge_public_inputs.ts
+++ b/yarn-project/circuits.js/src/structs/rollup/block_root_or_block_merge_public_inputs.ts
@@ -168,4 +168,8 @@ export class FeeRecipient {
     }
     return { recipient: this.recipient.toString(), value: this.value.toString() };
   }
+
+  static random() {
+    return new FeeRecipient(EthAddress.random(), Fr.random());
+  }
 }

--- a/yarn-project/circuits.js/src/structs/rollup/root_rollup.ts
+++ b/yarn-project/circuits.js/src/structs/rollup/root_rollup.ts
@@ -1,3 +1,4 @@
+import { makeTuple } from '@aztec/foundation/array';
 import { Fr } from '@aztec/foundation/fields';
 import { bufferSchemaFor } from '@aztec/foundation/schemas';
 import { BufferReader, type Tuple, serializeToBuffer, serializeToFields } from '@aztec/foundation/serialize';
@@ -183,5 +184,23 @@ export class RootRollupPublicInputs {
   /** Creates an instance from a string. */
   static get schema() {
     return bufferSchemaFor(RootRollupPublicInputs);
+  }
+
+  /** Creates a random instance. */
+  static random() {
+    return new RootRollupPublicInputs(
+      AppendOnlyTreeSnapshot.random(),
+      AppendOnlyTreeSnapshot.random(),
+      Fr.random(),
+      Fr.random(),
+      Fr.random(),
+      Fr.random(),
+      Fr.random(),
+      makeTuple(AZTEC_MAX_EPOCH_DURATION, FeeRecipient.random),
+      Fr.random(),
+      Fr.random(),
+      Fr.random(),
+      makeTuple(AZTEC_MAX_EPOCH_DURATION, BlockBlobPublicInputs.empty),
+    );
   }
 }

--- a/yarn-project/circuits.js/src/structs/trees/append_only_tree_snapshot.ts
+++ b/yarn-project/circuits.js/src/structs/trees/append_only_tree_snapshot.ts
@@ -88,4 +88,8 @@ export class AppendOnlyTreeSnapshot {
   public equals(other: this) {
     return this.root.equals(other.root) && this.nextAvailableLeafIndex === other.nextAvailableLeafIndex;
   }
+
+  static random() {
+    return new AppendOnlyTreeSnapshot(Fr.random(), Math.floor(Math.random() * 1000));
+  }
 }

--- a/yarn-project/end-to-end/src/e2e_block_building.test.ts
+++ b/yarn-project/end-to-end/src/e2e_block_building.test.ts
@@ -29,7 +29,8 @@ import { type TestDateProvider } from '@aztec/foundation/timer';
 import { StatefulTestContract, StatefulTestContractArtifact } from '@aztec/noir-contracts.js/StatefulTest';
 import { TestContract } from '@aztec/noir-contracts.js/Test';
 import { TokenContract } from '@aztec/noir-contracts.js/Token';
-import { type Sequencer, type SequencerClient, SequencerState } from '@aztec/sequencer-client';
+import { type SequencerClient, SequencerState } from '@aztec/sequencer-client';
+import { type TestSequencerClient } from '@aztec/sequencer-client/test';
 import { PublicProcessorFactory, type PublicTxResult, PublicTxSimulator, type WorldStateDB } from '@aztec/simulator';
 import { type TelemetryClient } from '@aztec/telemetry-client';
 import { NoopTelemetryClient } from '@aztec/telemetry-client/noop';
@@ -59,7 +60,7 @@ describe('e2e_block_building', () => {
     const artifact = StatefulTestContractArtifact;
 
     beforeAll(async () => {
-      let sequencerClient;
+      let sequencerClient: SequencerClient | undefined;
       ({
         teardown,
         pxe,
@@ -70,8 +71,7 @@ describe('e2e_block_building', () => {
         dateProvider,
         cheatCodes,
       } = await setup(2));
-      // Bypass accessibility modifiers in sequencer
-      sequencer = sequencerClient! as unknown as TestSequencerClient;
+      sequencer = sequencerClient! as TestSequencerClient;
     });
 
     afterEach(() => aztecNode.setConfig({ minTxsPerBlock: 1 }));
@@ -609,13 +609,6 @@ async function sendAndWait(calls: ContractFunctionInteraction[]) {
       .map(p => p.wait()),
   );
 }
-
-type TestSequencer = Omit<Sequencer, 'publicProcessorFactory' | 'timeTable'> & {
-  publicProcessorFactory: PublicProcessorFactory;
-  timeTable: Record<SequencerState, number>;
-  processTxTime: number;
-};
-type TestSequencerClient = Omit<SequencerClient, 'sequencer'> & { sequencer: TestSequencer };
 
 const TEST_PUBLIC_TX_SIMULATION_DELAY_MS = 300;
 

--- a/yarn-project/end-to-end/src/e2e_epochs.test.ts
+++ b/yarn-project/end-to-end/src/e2e_epochs.test.ts
@@ -1,8 +1,15 @@
+import { type Logger, getTimestampRangeForEpoch, retryUntil, sleep } from '@aztec/aztec.js';
 // eslint-disable-next-line no-restricted-imports
-import { type EpochConstants, type Logger, getTimestampRangeForEpoch, retryUntil } from '@aztec/aztec.js';
+import { type L1RollupConstants } from '@aztec/circuit-types';
+import { Proof } from '@aztec/circuits.js';
+import { RootRollupPublicInputs } from '@aztec/circuits.js/rollup';
 import { RollupContract } from '@aztec/ethereum/contracts';
 import { type Delayer, waitUntilL1Timestamp } from '@aztec/ethereum/test';
+import { promiseWithResolvers } from '@aztec/foundation/promise';
+import { type TestProverNode } from '@aztec/prover-node/test';
+import { type TestL1Publisher, type TestSequencerClient } from '@aztec/sequencer-client/test';
 
+import { jest } from '@jest/globals';
 import { type PublicClient } from 'viem';
 
 import { type EndToEndContext, setup } from './fixtures/utils.js';
@@ -14,7 +21,7 @@ describe('e2e_epochs', () => {
   let context: EndToEndContext;
   let l1Client: PublicClient;
   let rollup: RollupContract;
-  let constants: EpochConstants;
+  let constants: L1RollupConstants;
   let logger: Logger;
   let proverDelayer: Delayer;
   let sequencerDelayer: Delayer;
@@ -80,11 +87,8 @@ describe('e2e_epochs', () => {
       logger.info(msg);
     }, 200);
 
-    // The "as any" cast sucks, but it saves us from having to define test-only types for the provernode
-    // and sequencer that are exactly like the real ones but with the publisher exposed. We should
-    // do it if we see the this pattern popping up in more places.
-    proverDelayer = (context.proverNode as any).publisher.delayer;
-    sequencerDelayer = (context.sequencer as any).sequencer.publisher.delayer;
+    proverDelayer = ((context.proverNode as TestProverNode).publisher as TestL1Publisher).delayer!;
+    sequencerDelayer = ((context.sequencer as TestSequencerClient).sequencer.publisher as TestL1Publisher).delayer!;
     expect(proverDelayer).toBeDefined();
     expect(sequencerDelayer).toBeDefined();
 
@@ -92,16 +96,17 @@ describe('e2e_epochs', () => {
     constants = {
       epochDuration: EPOCH_DURATION_IN_L2_SLOTS,
       slotDuration: L1_BLOCK_TIME_IN_S * L2_SLOT_DURATION_IN_L1_SLOTS,
-      l1GenesisBlock: await rollup.getL1StartBlock(),
+      l1StartBlock: await rollup.getL1StartBlock(),
       l1GenesisTime: await rollup.getL1GenesisTime(),
       ethereumSlotDuration: L1_BLOCK_TIME_IN_S,
     };
 
-    logger.info(`L2 genesis at L1 block ${constants.l1GenesisBlock} (timestamp ${constants.l1GenesisTime})`);
+    logger.info(`L2 genesis at L1 block ${constants.l1StartBlock} (timestamp ${constants.l1GenesisTime})`);
   });
 
   afterEach(async () => {
     clearInterval(handle);
+    jest.restoreAllMocks();
     await context.teardown();
   });
 
@@ -156,7 +161,7 @@ describe('e2e_epochs', () => {
     logger.info(`Test succeeded`);
   });
 
-  it('submits proof claim alone if there is no txs to build a block', async () => {
+  it('submits proof claim alone if there are no txs to build a block', async () => {
     context.sequencer?.updateSequencerConfig({ minTxsPerBlock: 1 });
     await waitUntilEpochStarts(1);
     const blockNumberAtEndOfEpoch0 = Number(await rollup.getBlockNumber());
@@ -165,5 +170,40 @@ describe('e2e_epochs', () => {
     await waitUntilProvenL2BlockNumber(blockNumberAtEndOfEpoch0);
     expect(l2BlockNumber).toEqual(blockNumberAtEndOfEpoch0);
     logger.info(`Test succeeded`);
+  });
+
+  it('aborts proving if end of next epoch is reached', async () => {
+    // Inject a delay in prover node proving equal to the length of an epoch, to make sure deadline will be hit
+    const epochProverManager = (context.proverNode as TestProverNode).prover;
+    const originalCreate = epochProverManager.createEpochProver.bind(epochProverManager);
+    const finaliseEpochPromise = promiseWithResolvers<void>();
+    jest.spyOn(epochProverManager, 'createEpochProver').mockImplementation(() => {
+      const prover = originalCreate();
+      jest.spyOn(prover, 'finaliseEpoch').mockImplementation(async () => {
+        const seconds = L1_BLOCK_TIME_IN_S * L2_SLOT_DURATION_IN_L1_SLOTS * EPOCH_DURATION_IN_L2_SLOTS;
+        logger.warn(`Finalise epoch: sleeping ${seconds}s.`);
+        await sleep(L1_BLOCK_TIME_IN_S * L2_SLOT_DURATION_IN_L1_SLOTS * EPOCH_DURATION_IN_L2_SLOTS * 1000);
+        logger.warn(`Finalise epoch: returning.`);
+        finaliseEpochPromise.resolve();
+        return { publicInputs: RootRollupPublicInputs.random(), proof: Proof.empty() };
+      });
+      return prover;
+    });
+
+    await waitUntilEpochStarts(1);
+    logger.info(`Starting epoch 1`);
+    const proverTxCount = proverDelayer.getTxs().length;
+
+    await waitUntilEpochStarts(2);
+    logger.info(`Starting epoch 2`);
+
+    // No proof for epoch zero should have landed during epoch one
+    expect(l2ProvenBlockNumber).toEqual(0);
+
+    // Wait until the prover job finalises (and a bit more) and check that it aborted and never attempted to submit a tx
+    logger.info(`Awaiting finalise epoch`);
+    await finaliseEpochPromise.promise;
+    await sleep(1000);
+    expect(proverDelayer.getTxs().length - proverTxCount).toEqual(0);
   });
 });

--- a/yarn-project/end-to-end/src/fixtures/utils.ts
+++ b/yarn-project/end-to-end/src/fixtures/utils.ts
@@ -45,7 +45,8 @@ import { getVKTreeRoot } from '@aztec/noir-protocol-circuits-types';
 import { ProtocolContractAddress, protocolContractTreeRoot } from '@aztec/protocol-contracts';
 import { type ProverNode, type ProverNodeConfig, createProverNode } from '@aztec/prover-node';
 import { type PXEService, type PXEServiceConfig, createPXEService, getPXEServiceConfig } from '@aztec/pxe';
-import { type SequencerClient, TestL1Publisher } from '@aztec/sequencer-client';
+import { type SequencerClient } from '@aztec/sequencer-client';
+import { TestL1Publisher } from '@aztec/sequencer-client/test';
 import { NoopTelemetryClient } from '@aztec/telemetry-client/noop';
 import { createAndStartTelemetryClient, getConfigEnvVars as getTelemetryConfig } from '@aztec/telemetry-client/start';
 

--- a/yarn-project/ethereum/src/deploy_l1_contracts.ts
+++ b/yarn-project/ethereum/src/deploy_l1_contracts.ts
@@ -404,7 +404,7 @@ export const deployL1Contracts = async (
   logger.verbose(`Deployed Rollup at ${rollupAddress}`, rollupConfigArgs);
 
   const slashFactoryAddress = await deployer.deploy(l1Artifacts.slashFactory, [rollupAddress.toString()]);
-  logger.info(`Deployed SlashFactory at ${slashFactoryAddress}`);
+  logger.verbose(`Deployed SlashFactory at ${slashFactoryAddress}`);
 
   await deployer.waitForDeployments();
   logger.verbose(`All core contracts have been deployed`);

--- a/yarn-project/ethereum/src/test/tx_delayer.ts
+++ b/yarn-project/ethereum/src/test/tx_delayer.ts
@@ -27,7 +27,7 @@ export function waitUntilBlock<T extends Client>(client: T, blockNumber: number 
       return currentBlockNumber >= BigInt(blockNumber);
     },
     `Wait until L1 block ${blockNumber}`,
-    60,
+    120,
     0.1,
   );
 }
@@ -52,7 +52,7 @@ export function waitUntilL1Timestamp<T extends Client>(client: T, timestamp: num
       return currentTs >= BigInt(timestamp);
     },
     `Wait until L1 timestamp ${timestamp}`,
-    60,
+    120,
     0.1,
   );
 }
@@ -144,7 +144,7 @@ export function withDelayer<T extends WalletClient>(
           return Promise.resolve(txHash);
         } else {
           const txHash = await client.sendRawTransaction(...args);
-          logger.debug(`Sent tx immediately ${txHash}`);
+          logger.verbose(`Sent tx immediately ${txHash}`);
           delayer.txs.push(txHash);
           return txHash;
         }

--- a/yarn-project/prover-node/package.json
+++ b/yarn-project/prover-node/package.json
@@ -4,7 +4,8 @@
   "type": "module",
   "exports": {
     ".": "./dest/index.js",
-    "./config": "./dest/config.js"
+    "./config": "./dest/config.js",
+    "./test": "./dest/test/index.js"
   },
   "inherits": [
     "../package.common.json"

--- a/yarn-project/prover-node/src/job/epoch-proving-job.test.ts
+++ b/yarn-project/prover-node/src/job/epoch-proving-job.test.ts
@@ -1,0 +1,155 @@
+import {
+  type EpochProver,
+  type L1ToL2MessageSource,
+  L2Block,
+  type L2BlockSource,
+  type MerkleTreeWriteOperations,
+  type ProcessedTx,
+  type Tx,
+  type WorldStateSynchronizer,
+} from '@aztec/circuit-types';
+import { BlockHeader, Proof } from '@aztec/circuits.js';
+import { RootRollupPublicInputs } from '@aztec/circuits.js/rollup';
+import { times } from '@aztec/foundation/collection';
+import { sleep } from '@aztec/foundation/sleep';
+import { type L1Publisher } from '@aztec/sequencer-client';
+import { type PublicProcessor, type PublicProcessorFactory } from '@aztec/simulator';
+import { NoopTelemetryClient } from '@aztec/telemetry-client/noop';
+
+import { type MockProxy, mock } from 'jest-mock-extended';
+
+import { ProverNodeMetrics } from '../metrics.js';
+import { EpochProvingJob } from './epoch-proving-job.js';
+
+describe('epoch-proving-job', () => {
+  // Dependencies
+  let prover: MockProxy<EpochProver>;
+  let publisher: MockProxy<L1Publisher>;
+  let l2BlockSource: MockProxy<L2BlockSource>;
+  let l1ToL2MessageSource: MockProxy<L1ToL2MessageSource>;
+  let worldState: MockProxy<WorldStateSynchronizer>;
+  let publicProcessorFactory: MockProxy<PublicProcessorFactory>;
+  let metrics: ProverNodeMetrics;
+
+  // Created by a dependency
+  let db: MockProxy<MerkleTreeWriteOperations>;
+  let publicProcessor: MockProxy<PublicProcessor>;
+
+  // Objects
+  let publicInputs: RootRollupPublicInputs;
+  let proof: Proof;
+  let blocks: L2Block[];
+  let txs: Tx[];
+  let header: BlockHeader;
+  let epochNumber: number;
+
+  // Constants
+  const NUM_BLOCKS = 3;
+  const TXS_PER_BLOCK = 2;
+  const NUM_TXS = NUM_BLOCKS * TXS_PER_BLOCK;
+
+  // Subject factory
+  const createJob = (opts: { deadline?: Date; parallelBlockLimit?: number } = {}) =>
+    new EpochProvingJob(
+      worldState,
+      BigInt(epochNumber),
+      blocks,
+      txs,
+      prover,
+      publicProcessorFactory,
+      publisher,
+      l2BlockSource,
+      l1ToL2MessageSource,
+      metrics,
+      opts.deadline,
+      { parallelBlockLimit: opts.parallelBlockLimit ?? 32 },
+    );
+
+  beforeEach(() => {
+    prover = mock<EpochProver>();
+    publisher = mock<L1Publisher>();
+    l2BlockSource = mock<L2BlockSource>();
+    l1ToL2MessageSource = mock<L1ToL2MessageSource>();
+    worldState = mock<WorldStateSynchronizer>();
+    publicProcessorFactory = mock<PublicProcessorFactory>();
+    db = mock<MerkleTreeWriteOperations>();
+    publicProcessor = mock<PublicProcessor>();
+    metrics = new ProverNodeMetrics(new NoopTelemetryClient());
+
+    publicInputs = RootRollupPublicInputs.random();
+    proof = Proof.empty();
+    header = BlockHeader.empty();
+    epochNumber = 1;
+    blocks = times(NUM_BLOCKS, i => L2Block.random(i + 1, TXS_PER_BLOCK));
+    txs = times(NUM_TXS, i =>
+      mock<Tx>({
+        getTxHash: () => blocks[i % NUM_BLOCKS].body.txEffects[i % TXS_PER_BLOCK].txHash,
+      }),
+    );
+
+    l1ToL2MessageSource.getL1ToL2Messages.mockResolvedValue([]);
+    l2BlockSource.getBlockHeader.mockResolvedValue(header);
+    publicProcessorFactory.create.mockReturnValue(publicProcessor);
+    worldState.fork.mockResolvedValue(db);
+    prover.finaliseEpoch.mockResolvedValue({ publicInputs, proof });
+    publisher.submitEpochProof.mockResolvedValue(true);
+    publicProcessor.process.mockImplementation((txs: Iterable<Tx>) =>
+      Promise.resolve([Array.from(txs).map(tx => mock<ProcessedTx>({ hash: tx.getTxHash() })), [], []]),
+    );
+  });
+
+  it('works', async () => {
+    const job = createJob();
+    await job.run();
+
+    expect(job.getState()).toEqual('completed');
+    expect(db.close).toHaveBeenCalledTimes(NUM_BLOCKS);
+    expect(publicProcessor.process).toHaveBeenCalledTimes(NUM_BLOCKS);
+    expect(publisher.submitEpochProof).toHaveBeenCalledWith(
+      expect.objectContaining({ epochNumber, proof, publicInputs }),
+    );
+  });
+
+  it('fails if fails to process txs for a block', async () => {
+    publicProcessor.process.mockImplementation((txs: Iterable<Tx>) =>
+      Promise.resolve([[], Array.from(txs).map(tx => ({ error: new Error('Failed to process tx'), tx })), []]),
+    );
+
+    const job = createJob();
+    await job.run();
+
+    expect(job.getState()).toEqual('failed');
+    expect(publisher.submitEpochProof).not.toHaveBeenCalled();
+  });
+
+  it('fails if does not process all txs for a block', async () => {
+    publicProcessor.process.mockImplementation((_txs: Iterable<Tx>) => Promise.resolve([[], [], []]));
+
+    const job = createJob();
+    await job.run();
+
+    expect(job.getState()).toEqual('failed');
+    expect(publisher.submitEpochProof).not.toHaveBeenCalled();
+  });
+
+  it('times out if deadline is hit', async () => {
+    prover.startNewBlock.mockImplementation(() => sleep(200));
+    const deadline = new Date(Date.now() + 100);
+    const job = createJob({ deadline });
+    await job.run();
+
+    expect(job.getState()).toEqual('timed-out');
+    expect(publisher.submitEpochProof).not.toHaveBeenCalled();
+  });
+
+  it('halts if stopped externally', async () => {
+    prover.startNewBlock.mockImplementation(() => sleep(200));
+    const job = createJob();
+    void job.run();
+    await sleep(100);
+    await job.stop();
+
+    expect(job.getState()).toEqual('stopped');
+    expect(publisher.submitEpochProof).not.toHaveBeenCalled();
+  });
+});

--- a/yarn-project/prover-node/src/prover-node.test.ts
+++ b/yarn-project/prover-node/src/prover-node.test.ts
@@ -1,4 +1,5 @@
 import {
+  EmptyL1RollupConstants,
   type EpochProofClaim,
   EpochProofQuote,
   EpochProofQuotePayload,
@@ -150,6 +151,7 @@ describe('prover-node', () => {
 
     // Archiver returns a bunch of fake blocks
     l2BlockSource.getBlocksForEpoch.mockResolvedValue(blocks);
+    l2BlockSource.getL1Constants.mockResolvedValue(EmptyL1RollupConstants);
 
     // Coordination plays along and returns a tx whenever requested
     mockCoordination.getTxByHash.mockImplementation(hash =>
@@ -472,6 +474,7 @@ describe('prover-node', () => {
   class TestProverNode extends ProverNode {
     protected override doCreateEpochProvingJob(
       epochNumber: bigint,
+      _deadline: Date | undefined,
       _blocks: L2Block[],
       _txs: Tx[],
       _publicProcessorFactory: PublicProcessorFactory,

--- a/yarn-project/prover-node/src/test/index.ts
+++ b/yarn-project/prover-node/src/test/index.ts
@@ -1,0 +1,11 @@
+import { type EpochProverManager } from '@aztec/circuit-types';
+import { type L1Publisher } from '@aztec/sequencer-client';
+
+import { ProverNode } from '../prover-node.js';
+
+class TestProverNode_ extends ProverNode {
+  public override prover!: EpochProverManager;
+  public override publisher!: L1Publisher;
+}
+
+export type TestProverNode = TestProverNode_;

--- a/yarn-project/sequencer-client/package.json
+++ b/yarn-project/sequencer-client/package.json
@@ -4,7 +4,8 @@
   "type": "module",
   "exports": {
     ".": "./dest/index.js",
-    "./config": "./dest/config.js"
+    "./config": "./dest/config.js",
+    "./test": "./dest/test/index.js"
   },
   "typedocOptions": {
     "entryPoints": [

--- a/yarn-project/sequencer-client/src/publisher/index.ts
+++ b/yarn-project/sequencer-client/src/publisher/index.ts
@@ -1,2 +1,1 @@
 export { L1Publisher, L1SubmitEpochProofArgs } from './l1-publisher.js';
-export * from './test-l1-publisher.js';

--- a/yarn-project/sequencer-client/src/sequencer/sequencer.ts
+++ b/yarn-project/sequencer-client/src/sequencer/sequencer.ts
@@ -85,7 +85,7 @@ export class Sequencer {
   private allowedInSetup: AllowedElement[] = getDefaultAllowedSetupFunctions();
   private maxBlockSizeInBytes: number = 1024 * 1024;
   private maxBlockGas: Gas = new Gas(10e9, 10e9);
-  private processTxTime: number = 12;
+  protected processTxTime: number = 12;
   private metrics: SequencerMetrics;
   private isFlushing: boolean = false;
 
@@ -97,22 +97,22 @@ export class Sequencer {
   protected enforceTimeTable: boolean = false;
 
   constructor(
-    private publisher: L1Publisher,
-    private validatorClient: ValidatorClient | undefined, // During migration the validator client can be inactive
-    private globalsBuilder: GlobalVariableBuilder,
-    private p2pClient: P2P,
-    private worldState: WorldStateSynchronizer,
-    private slasherClient: SlasherClient,
-    private blockBuilderFactory: BlockBuilderFactory,
-    private l2BlockSource: L2BlockSource,
-    private l1ToL2MessageSource: L1ToL2MessageSource,
-    private publicProcessorFactory: PublicProcessorFactory,
-    private contractDataSource: ContractDataSource,
+    protected publisher: L1Publisher,
+    protected validatorClient: ValidatorClient | undefined, // During migration the validator client can be inactive
+    protected globalsBuilder: GlobalVariableBuilder,
+    protected p2pClient: P2P,
+    protected worldState: WorldStateSynchronizer,
+    protected slasherClient: SlasherClient,
+    protected blockBuilderFactory: BlockBuilderFactory,
+    protected l2BlockSource: L2BlockSource,
+    protected l1ToL2MessageSource: L1ToL2MessageSource,
+    protected publicProcessorFactory: PublicProcessorFactory,
+    protected contractDataSource: ContractDataSource,
     protected l1Constants: SequencerRollupConstants,
-    private dateProvider: DateProvider,
+    protected dateProvider: DateProvider,
     telemetry: TelemetryClient,
-    private config: SequencerConfig = {},
-    private log = createLogger('sequencer'),
+    protected config: SequencerConfig = {},
+    protected log = createLogger('sequencer'),
   ) {
     this.updateConfig(config);
     this.metrics = new SequencerMetrics(telemetry, () => this.state, 'Sequencer');

--- a/yarn-project/sequencer-client/src/test/index.ts
+++ b/yarn-project/sequencer-client/src/test/index.ts
@@ -1,0 +1,23 @@
+import { type PublicProcessorFactory } from '@aztec/simulator';
+
+import { SequencerClient } from '../client/sequencer-client.js';
+import { type L1Publisher } from '../publisher/l1-publisher.js';
+import { Sequencer } from '../sequencer/sequencer.js';
+import { type SequencerState } from '../sequencer/utils.js';
+
+class TestSequencer_ extends Sequencer {
+  public override publicProcessorFactory!: PublicProcessorFactory;
+  public override timeTable!: Record<SequencerState, number>;
+  public override processTxTime!: number;
+  public override publisher!: L1Publisher;
+}
+
+export type TestSequencer = TestSequencer_;
+
+class TestSequencerClient_ extends SequencerClient {
+  public override sequencer!: TestSequencer;
+}
+
+export type TestSequencerClient = TestSequencerClient_;
+
+export * from './test-l1-publisher.js';

--- a/yarn-project/sequencer-client/src/test/test-l1-publisher.ts
+++ b/yarn-project/sequencer-client/src/test/test-l1-publisher.ts
@@ -3,7 +3,7 @@ import { type Delayer, withDelayer } from '@aztec/ethereum/test';
 
 import { type Chain, type HttpTransport, type PrivateKeyAccount, type WalletClient } from 'viem';
 
-import { L1Publisher } from './l1-publisher.js';
+import { L1Publisher } from '../publisher/l1-publisher.js';
 
 export class TestL1Publisher extends L1Publisher {
   public delayer: Delayer | undefined;


### PR DESCRIPTION
Prover node aborts all jobs once it hits the end of the next epoch to be proven.

Fixes #10802
