### PR TITLE
fix: Sequencer times out L1 tx at end of L2 slot

### DIFF
--- a/yarn-project/ethereum/src/l1_tx_utils.test.ts
+++ b/yarn-project/ethereum/src/l1_tx_utils.test.ts
@@ -299,4 +299,22 @@ describe('GasUtils', () => {
     const expectedEstimate = baseEstimate + (baseEstimate * 20n) / 100n;
     expect(bufferedEstimate).toBe(expectedEstimate);
   });
+
+  it('stops trying after timeout', async () => {
+    await cheatCodes.setAutomine(false);
+    await cheatCodes.setIntervalMining(0);
+
+    const now = Date.now();
+    await expect(
+      gasUtils.sendAndMonitorTransaction(
+        {
+          to: '0x1234567890123456789012345678901234567890',
+          data: '0x',
+          value: 0n,
+        },
+        { txTimeoutAt: new Date(now + 1000) },
+      ),
+    ).rejects.toThrow(/timed out/);
+    expect(Date.now() - now).toBeGreaterThanOrEqual(990);
+  }, 60_000);
 });

--- a/yarn-project/sequencer-client/src/sequencer/sequencer.test.ts
+++ b/yarn-project/sequencer-client/src/sequencer/sequencer.test.ts
@@ -130,6 +130,13 @@ describe('sequencer', () => {
     return tx;
   };
 
+  const expectPublisherProposeL2Block = (txHashes: TxHash[], proofQuote?: EpochProofQuote) => {
+    expect(publisher.proposeL2Block).toHaveBeenCalledTimes(1);
+    expect(publisher.proposeL2Block).toHaveBeenCalledWith(block, getSignatures(), txHashes, proofQuote, {
+      txTimeoutAt: expect.any(Date),
+    });
+  };
+
   beforeEach(() => {
     lastBlockNumber = 0;
     newBlockNumber = lastBlockNumber + 1;
@@ -257,8 +264,7 @@ describe('sequencer', () => {
       Array(NUMBER_OF_L1_L2_MESSAGES_PER_ROLLUP).fill(new Fr(0n)),
     );
 
-    expect(publisher.proposeL2Block).toHaveBeenCalledTimes(1);
-    expect(publisher.proposeL2Block).toHaveBeenCalledWith(block, getSignatures(), [txHash], undefined);
+    expectPublisherProposeL2Block([txHash]);
   });
 
   it.each([
@@ -317,7 +323,7 @@ describe('sequencer', () => {
       globalVariables,
       Array(NUMBER_OF_L1_L2_MESSAGES_PER_ROLLUP).fill(new Fr(0n)),
     );
-    expect(publisher.proposeL2Block).toHaveBeenCalledWith(block, getSignatures(), [txHash], undefined);
+    expectPublisherProposeL2Block([txHash]);
   });
 
   it('builds a block out of several txs rejecting invalid txs', async () => {
@@ -340,7 +346,7 @@ describe('sequencer', () => {
       globalVariables,
       Array(NUMBER_OF_L1_L2_MESSAGES_PER_ROLLUP).fill(new Fr(0n)),
     );
-    expect(publisher.proposeL2Block).toHaveBeenCalledWith(block, getSignatures(), validTxHashes, undefined);
+    expectPublisherProposeL2Block(validTxHashes);
     expect(p2p.deleteTxs).toHaveBeenCalledWith([invalidTx.getTxHash()]);
   });
 
@@ -370,13 +376,8 @@ describe('sequencer', () => {
       globalVariables,
       times(NUMBER_OF_L1_L2_MESSAGES_PER_ROLLUP, Fr.zero),
     );
-    expect(publisher.proposeL2Block).toHaveBeenCalledTimes(1);
-    expect(publisher.proposeL2Block).toHaveBeenCalledWith(
-      block,
-      getSignatures(),
-      neededTxs.map(tx => tx.getTxHash()),
-      undefined,
-    );
+
+    expectPublisherProposeL2Block(neededTxs.map(tx => tx.getTxHash()));
   });
 
   it('builds a block that contains zero real transactions once flushed', async () => {
@@ -409,8 +410,7 @@ describe('sequencer', () => {
       times(NUMBER_OF_L1_L2_MESSAGES_PER_ROLLUP, Fr.zero),
     );
     expect(blockBuilder.addTxs).toHaveBeenCalledWith([]);
-    expect(publisher.proposeL2Block).toHaveBeenCalledTimes(1);
-    expect(publisher.proposeL2Block).toHaveBeenCalledWith(block, getSignatures(), [], undefined);
+    expectPublisherProposeL2Block([]);
   });
 
   it('builds a block that contains less than the minimum number of transactions once flushed', async () => {
@@ -443,9 +443,8 @@ describe('sequencer', () => {
       globalVariables,
       Array(NUMBER_OF_L1_L2_MESSAGES_PER_ROLLUP).fill(new Fr(0n)),
     );
-    expect(publisher.proposeL2Block).toHaveBeenCalledTimes(1);
 
-    expect(publisher.proposeL2Block).toHaveBeenCalledWith(block, getSignatures(), postFlushTxHashes, undefined);
+    expectPublisherProposeL2Block(postFlushTxHashes);
   });
 
   it('aborts building a block if the chain moves underneath it', async () => {
@@ -533,7 +532,7 @@ describe('sequencer', () => {
       publisher.getClaimableEpoch.mockImplementation(() => Promise.resolve(currentEpoch - 1n));
 
       await sequencer.doRealWork();
-      expect(publisher.proposeL2Block).toHaveBeenCalledWith(block, getSignatures(), [txHash], proofQuote);
+      expectPublisherProposeL2Block([txHash], proofQuote);
     });
 
     it('submits a valid proof quote even without a block', async () => {
@@ -568,7 +567,7 @@ describe('sequencer', () => {
       publisher.getClaimableEpoch.mockImplementation(() => Promise.resolve(undefined));
 
       await sequencer.doRealWork();
-      expect(publisher.proposeL2Block).toHaveBeenCalledWith(block, getSignatures(), [txHash], undefined);
+      expectPublisherProposeL2Block([txHash]);
     });
 
     it('does not submit a quote with an expired slot number', async () => {
@@ -585,7 +584,7 @@ describe('sequencer', () => {
       publisher.getClaimableEpoch.mockImplementation(() => Promise.resolve(currentEpoch - 1n));
 
       await sequencer.doRealWork();
-      expect(publisher.proposeL2Block).toHaveBeenCalledWith(block, getSignatures(), [txHash], undefined);
+      expectPublisherProposeL2Block([txHash]);
     });
 
     it('does not submit a valid quote if unable to claim epoch', async () => {
@@ -600,7 +599,7 @@ describe('sequencer', () => {
       publisher.getClaimableEpoch.mockResolvedValue(undefined);
 
       await sequencer.doRealWork();
-      expect(publisher.proposeL2Block).toHaveBeenCalledWith(block, getSignatures(), [txHash], undefined);
+      expectPublisherProposeL2Block([txHash]);
     });
 
     it('does not submit an invalid quote', async () => {
@@ -619,7 +618,7 @@ describe('sequencer', () => {
       publisher.getClaimableEpoch.mockImplementation(() => Promise.resolve(currentEpoch - 1n));
 
       await sequencer.doRealWork();
-      expect(publisher.proposeL2Block).toHaveBeenCalledWith(block, getSignatures(), [txHash], undefined);
+      expectPublisherProposeL2Block([txHash]);
     });
 
     it('selects the lowest cost valid quote', async () => {
@@ -652,7 +651,7 @@ describe('sequencer', () => {
       publisher.getClaimableEpoch.mockImplementation(() => Promise.resolve(currentEpoch - 1n));
 
       await sequencer.doRealWork();
-      expect(publisher.proposeL2Block).toHaveBeenCalledWith(block, getSignatures(), [txHash], validQuotes[0]);
+      expectPublisherProposeL2Block([txHash], validQuotes[0]);
     });
   });
 });

--- a/yarn-project/sequencer-client/src/sequencer/sequencer.ts
+++ b/yarn-project/sequencer-client/src/sequencer/sequencer.ts
@@ -772,7 +772,13 @@ export class Sequencer {
     // Publishes new block to the network and awaits the tx to be mined
     this.setState(SequencerState.PUBLISHING_BLOCK, block.header.globalVariables.slotNumber.toBigInt());
 
-    const publishedL2Block = await this.publisher.proposeL2Block(block, attestations, txHashes, proofQuote);
+    // Time out tx at the end of the slot
+    const slot = block.header.globalVariables.slotNumber.toNumber();
+    const txTimeoutAt = new Date((this.getSlotStartTimestamp(slot) + this.aztecSlotDuration) * 1000);
+
+    const publishedL2Block = await this.publisher.proposeL2Block(block, attestations, txHashes, proofQuote, {
+      txTimeoutAt,
+    });
     if (!publishedL2Block) {
       throw new Error(`Failed to publish block ${block.number}`);
     }


### PR DESCRIPTION
Sets the L1 tx utils timeout to the end of the L2 slot.
