### PR TITLE
fix: Added start/stop guards to running promise and serial queue

### DIFF
--- a/yarn-project/foundation/src/promise/running-promise.ts
+++ b/yarn-project/foundation/src/promise/running-promise.ts
@@ -23,6 +23,10 @@ export class RunningPromise {
    * Starts the running promise.
    */
   public start() {
+    if (this.running) {
+      this.logger.warn(`Attempted to start running promise that was already started`);
+      return;
+    }
     this.running = true;
 
     const poll = async () => {
@@ -54,6 +58,10 @@ export class RunningPromise {
    * and waits for the currently executing function to complete.
    */
   async stop(): Promise<void> {
+    if (!this.running) {
+      this.logger.warn(`Running promise was not started`);
+      return;
+    }
     this.running = false;
     this.interruptibleSleep.interrupt();
     await this.runningPromise;

--- a/yarn-project/foundation/src/queue/serial_queue.ts
+++ b/yarn-project/foundation/src/queue/serial_queue.ts
@@ -6,6 +6,7 @@ import { FifoMemoryQueue } from './fifo_memory_queue.js';
 export class SerialQueue {
   private readonly queue = new FifoMemoryQueue<() => Promise<void>>();
   private runningPromise!: Promise<void>;
+  private started = false;
 
   /**
    * Initializes the execution of enqueued functions in the serial queue.
@@ -14,7 +15,11 @@ export class SerialQueue {
    * This method should be called once to start processing the queue.
    */
   public start() {
+    if (this.started) {
+      return;
+    }
     this.runningPromise = this.queue.process(fn => fn());
+    this.started = true;
   }
 
   /**


### PR DESCRIPTION
This PR adds guards to `SerialQueue` and `RunningPromise` so they can't inadvertantly be 'started' multiple times.
