### PR TITLE
fix: Don't retransmit txs upon node restart

### DIFF
--- a/yarn-project/p2p/src/client/p2p_client.test.ts
+++ b/yarn-project/p2p/src/client/p2p_client.test.ts
@@ -104,17 +104,6 @@ describe('In-Memory P2P Client', () => {
     expect(txPool.addTxs).toHaveBeenCalledTimes(2);
   });
 
-  it('republishes previously stored txs on start', async () => {
-    const tx1 = mockTx();
-    const tx2 = mockTx();
-    txPool.getAllTxs.mockReturnValue([tx1, tx2]);
-
-    await client.start();
-    expect(p2pService.propagate).toHaveBeenCalledTimes(2);
-    expect(p2pService.propagate).toHaveBeenCalledWith(tx1);
-    expect(p2pService.propagate).toHaveBeenCalledWith(tx2);
-  });
-
   it('restores the previous block number it was at', async () => {
     await client.start();
     await client.stop();

--- a/yarn-project/p2p/src/client/p2p_client.ts
+++ b/yarn-project/p2p/src/client/p2p_client.ts
@@ -380,9 +380,6 @@ export class P2PClient<T extends P2PClientType = P2PClientType.Full>
       this.log.debug(`Block ${syncedLatestBlock} (proven ${syncedProvenBlock}) already beyond current block`);
     }
 
-    // publish any txs in TxPool after its doing initial sync
-    this.syncPromise = this.syncPromise.then(() => this.publishStoredTxs());
-
     this.blockStream.start();
     this.log.verbose(`Started block downloader from block ${syncedLatestBlock}`);
 


### PR DESCRIPTION
A long time ago, the node was written such that it would broadcast all txs in it's pool after a restart. This seems unnecessary now and can cause lib-p2p errors when it does so. Removed.
