### PR TITLE
chore: Jest reporters for CI

### DIFF
--- a/yarn-project/foundation/src/log/log_history.test.ts
+++ b/yarn-project/foundation/src/log/log_history.test.ts
@@ -5,7 +5,8 @@ import { LogHistory } from './log_history.js';
 
 jest.useFakeTimers({ doNotFake: ['performance'] });
 
-describe('log history', () => {
+// We skip log history tests since this class is not used and it pollutes the logs in CI.
+describe.skip('log history', () => {
   let debug: (msg: string) => void;
   let logHistory: LogHistory;
   const timestamp = new Date().toISOString();

--- a/yarn-project/jest.root.config.js
+++ b/yarn-project/jest.root.config.js
@@ -1,0 +1,21 @@
+const { cwd } = require('process');
+const { join } = require('path');
+const { readFileSync } = require('fs');
+
+// Loads the jest config from the package.json in the working directory and overrides the reporters.
+// Note we cannot just use the `--reporters` CLI option because it does not allow setting options,
+// and we need the `summaryThreshold` option to show actual errors when tests fail.
+// This file is only used from the yarn project root `test` script.
+/** @type {import('jest').Config} */
+const config = {
+  ...JSON.parse(readFileSync(join(cwd(), 'package.json'), 'utf-8')).jest,
+  // CI-friendly reporters config
+  reporters: [
+    ['github-actions', { silent: false }],
+    ['summary', { summaryThreshold: 0 }],
+  ],
+  // Override rootDir to the src of the current package
+  rootDir: join(cwd(), 'src'),
+};
+
+module.exports = config;

--- a/yarn-project/kv-store/package.json
+++ b/yarn-project/kv-store/package.json
@@ -17,7 +17,7 @@
     "formatting:fix": "run -T eslint --fix ./src && run -T prettier -w ./src",
     "test:node": "NODE_NO_WARNINGS=1 mocha --config ./.mocharc.json --reporter dot",
     "test:browser": "wtr --config ./web-test-runner.config.mjs",
-    "test": "yarn test:node && yarn test:browser"
+    "test": "yarn test:node && yarn test:browser && true"
   },
   "inherits": [
     "../package.common.json",

--- a/yarn-project/kv-store/package.local.json
+++ b/yarn-project/kv-store/package.local.json
@@ -1,5 +1,5 @@
 {
   "scripts": {
-    "test": "yarn test:node && yarn test:browser"
+    "test": "yarn test:node && yarn test:browser && true"
   }
 }

--- a/yarn-project/package.json
+++ b/yarn-project/package.json
@@ -10,7 +10,7 @@
     "formatting:fix": "FORCE_COLOR=true yarn workspaces foreach -A -p -v run formatting:fix",
     "lint": "yarn eslint --cache --ignore-pattern l1-artifacts .",
     "format": "yarn prettier --cache -w .",
-    "test": "RAYON_NUM_THREADS=4 FORCE_COLOR=true yarn workspaces foreach -A --exclude @aztec/aztec3-packages --exclude @aztec/bb-prover --exclude @aztec/prover-client -p -v run test --reporters=summary",
+    "test": "RAYON_NUM_THREADS=4 FORCE_COLOR=true yarn workspaces foreach -A --exclude @aztec/aztec3-packages --exclude @aztec/bb-prover --exclude @aztec/prover-client -p -v run test --config=../jest.root.config.js",
     "build": "FORCE_COLOR=true yarn workspaces foreach -A --parallel --topological-dev --verbose --exclude @aztec/aztec3-packages --exclude @aztec/docs run build",
     "build:fast": "cd foundation && yarn build && cd ../l1-artifacts && yarn build && cd ../circuits.js && yarn build && cd .. && yarn generate && tsc -b",
     "build:dev": "./watch.sh",

--- a/yarn-project/sequencer-client/src/config.test.ts
+++ b/yarn-project/sequencer-client/src/config.test.ts
@@ -2,8 +2,8 @@ import { AztecAddress, Fr, FunctionSelector } from '@aztec/circuits.js';
 
 import { parseSequencerAllowList } from './config.js';
 
-describe.only('sequencer config', () => {
-  it.only('parse a sequencer config', () => {
+describe('sequencer config', () => {
+  it('parse a sequencer config', () => {
     const instance = { address: AztecAddress.random() };
     const instanceFunction = { address: AztecAddress.random(), selector: FunctionSelector.random() };
     const classId = { classId: Fr.random() };

--- a/yarn-project/sequencer-client/src/config.test.ts
+++ b/yarn-project/sequencer-client/src/config.test.ts
@@ -2,8 +2,8 @@ import { AztecAddress, Fr, FunctionSelector } from '@aztec/circuits.js';
 
 import { parseSequencerAllowList } from './config.js';
 
-describe('sequencer config', () => {
-  it('parse a sequencer config', () => {
+describe.only('sequencer config', () => {
+  it.only('parse a sequencer config', () => {
     const instance = { address: AztecAddress.random() };
     const instanceFunction = { address: AztecAddress.random(), selector: FunctionSelector.random() };
     const classId = { classId: Fr.random() };
@@ -20,7 +20,7 @@ describe('sequencer config', () => {
     const stringifiedAllowList = configStrings.join(',');
 
     const allowList = parseSequencerAllowList(stringifiedAllowList);
-
+    expect(false).toBeTruthy();
     expect(allowList).toEqual(config);
   });
 });

--- a/yarn-project/sequencer-client/src/config.test.ts
+++ b/yarn-project/sequencer-client/src/config.test.ts
@@ -20,7 +20,6 @@ describe('sequencer config', () => {
     const stringifiedAllowList = configStrings.join(',');
 
     const allowList = parseSequencerAllowList(stringifiedAllowList);
-    expect(false).toBeTruthy();
     expect(allowList).toEqual(config);
   });
 });


### PR DESCRIPTION
Switches to jest summary reporter with a zero threshold so we can see what test failed on CI.

### Before
![image](https://github.com/user-attachments/assets/1ce397ee-34df-46a7-9450-2db8dd0e843f)

### After
![Screenshot from 2025-01-09 11-55-46](https://github.com/user-attachments/assets/a40c754c-403a-4be8-9848-c02f086aa2f6)
