### PR TITLE
chore: Sanity checking of proving job IDs

### DIFF
--- a/yarn-project/circuit-types/src/interfaces/proving-job.ts
+++ b/yarn-project/circuit-types/src/interfaces/proving-job.ts
@@ -296,7 +296,7 @@ export const makeProvingJobId = (epochNumber: number, type: ProvingRequestType, 
 
 export const getEpochFromProvingJobId = (id: ProvingJobId) => {
   const components = id.split(':');
-  const epochNumber = parseInt(components[0], 10);
+  const epochNumber = components.length < 1 ? Number.NaN : parseInt(components[0], 10);
   if (!Number.isSafeInteger(epochNumber) || epochNumber < 0) {
     throw new Error(`Proving Job ID ${id} does not contain valid epoch`);
   }

--- a/yarn-project/circuit-types/src/interfaces/proving-job.ts
+++ b/yarn-project/circuit-types/src/interfaces/proving-job.ts
@@ -296,7 +296,11 @@ export const makeProvingJobId = (epochNumber: number, type: ProvingRequestType, 
 
 export const getEpochFromProvingJobId = (id: ProvingJobId) => {
   const components = id.split(':');
-  return +components[0];
+  const epochNumber = parseInt(components[0], 10);
+  if (!Number.isSafeInteger(epochNumber) || epochNumber < 0) {
+    throw new Error(`Proving Job ID ${id} does not contain valid epoch`);
+  }
+  return epochNumber;
 };
 
 export type ProvingJob = z.infer<typeof ProvingJob>;

--- a/yarn-project/prover-client/src/proving_broker/broker_prover_facade.ts
+++ b/yarn-project/prover-client/src/proving_broker/broker_prover_facade.ts
@@ -8,6 +8,7 @@ import {
   ProvingRequestType,
   type PublicInputsAndRecursiveProof,
   type ServerCircuitProver,
+  makeProvingJobId,
 } from '@aztec/circuit-types';
 import {
   type AVM_PROOF_LENGTH_IN_FIELDS,
@@ -564,6 +565,6 @@ export class BrokerCircuitProverFacade implements ServerCircuitProver {
 
   private generateId(type: ProvingRequestType, inputs: { toBuffer(): Buffer }, epochNumber = 0) {
     const inputsHash = sha256(inputs.toBuffer());
-    return `${epochNumber}:${ProvingRequestType[type]}:${inputsHash.toString('hex')}`;
+    return makeProvingJobId(epochNumber, type, inputsHash.toString('hex'));
   }
 }


### PR DESCRIPTION
This PR ensures we use a consistent method for generating proving jobs Ids and then validates those ids.
