### PR TITLE
feat: Kickoff tube circuits at the beginning of proving job

### DIFF
--- a/yarn-project/circuit-types/src/interfaces/epoch-prover.ts
+++ b/yarn-project/circuit-types/src/interfaces/epoch-prover.ts
@@ -2,6 +2,7 @@ import { type BlockHeader, type Fr, type Proof } from '@aztec/circuits.js';
 import { type RootRollupPublicInputs } from '@aztec/circuits.js/rollup';
 
 import { type L2Block } from '../l2_block.js';
+import { type Tx } from '../tx/tx.js';
 import { type BlockBuilder } from './block-builder.js';
 
 /** Coordinates the proving of an entire epoch. */
@@ -13,6 +14,12 @@ export interface EpochProver extends Omit<BlockBuilder, 'setBlockCompleted'> {
    * @param totalNumBlocks - The total number of blocks expected in the epoch (must be at least one).
    **/
   startNewEpoch(epochNumber: number, firstBlockNumber: number, totalNumBlocks: number): void;
+
+  /**
+   * Kickstarts tube circuits for the specified txs. These will be used during epoch proving.
+   * Note that if the tube circuits are not started this way, they will be started nontheless after processing.
+   */
+  startTubeCircuits(txs: Tx[]): void;
 
   /** Pads the block with empty txs if it hasn't reached the declared number of txs. */
   setBlockCompleted(blockNumber: number, expectedBlockHeader?: BlockHeader): Promise<L2Block>;

--- a/yarn-project/circuits.js/src/structs/client_ivc_proof.ts
+++ b/yarn-project/circuits.js/src/structs/client_ivc_proof.ts
@@ -22,6 +22,10 @@ export class ClientIvcProof {
     return new ClientIvcProof(Buffer.from(''), Buffer.from(''));
   }
 
+  static fake(fill = Math.floor(Math.random() * 255)) {
+    return new ClientIvcProof(Buffer.alloc(1, fill), Buffer.alloc(1, fill));
+  }
+
   static get schema() {
     return bufferSchemaFor(ClientIvcProof);
   }

--- a/yarn-project/prover-client/src/orchestrator/epoch-proving-state.ts
+++ b/yarn-project/prover-client/src/orchestrator/epoch-proving-state.ts
@@ -1,4 +1,8 @@
-import { type MerkleTreeId, type PublicInputsAndRecursiveProof } from '@aztec/circuit-types';
+import {
+  type MerkleTreeId,
+  type ProofAndVerificationKey,
+  type PublicInputsAndRecursiveProof,
+} from '@aztec/circuit-types';
 import {
   ARCHIVE_HEIGHT,
   AppendOnlyTreeSnapshot,
@@ -9,6 +13,7 @@ import {
   MembershipWitness,
   type NESTED_RECURSIVE_ROLLUP_HONK_PROOF_LENGTH,
   NUMBER_OF_L1_L2_MESSAGES_PER_ROLLUP,
+  type TUBE_PROOF_LENGTH,
   VK_TREE_HEIGHT,
 } from '@aztec/circuits.js';
 import {
@@ -55,6 +60,9 @@ export class EpochProvingState {
     | undefined;
   private rootRollupProvingOutput: PublicInputsAndRecursiveProof<RootRollupPublicInputs> | undefined;
   private provingStateLifecycle = PROVING_STATE_LIFECYCLE.PROVING_STATE_CREATED;
+
+  // Map from tx hash to tube proof promise. Used when kickstarting tube proofs before tx processing.
+  public readonly cachedTubeProofs = new Map<string, Promise<ProofAndVerificationKey<typeof TUBE_PROOF_LENGTH>>>();
 
   public blocks: (BlockProvingState | undefined)[] = [];
 

--- a/yarn-project/prover-client/src/prover-client/server-epoch-prover.ts
+++ b/yarn-project/prover-client/src/prover-client/server-epoch-prover.ts
@@ -1,4 +1,4 @@
-import { type EpochProver, type L2Block, type ProcessedTx } from '@aztec/circuit-types';
+import { type EpochProver, type L2Block, type ProcessedTx, type Tx } from '@aztec/circuit-types';
 import { type BlockHeader, type Fr, type GlobalVariables, type Proof } from '@aztec/circuits.js';
 import { type RootRollupPublicInputs } from '@aztec/circuits.js/rollup';
 
@@ -12,6 +12,9 @@ export class ServerEpochProver implements EpochProver {
   startNewEpoch(epochNumber: number, firstBlockNumber: number, totalNumBlocks: number): void {
     this.orchestrator.startNewEpoch(epochNumber, firstBlockNumber, totalNumBlocks);
     this.facade.start();
+  }
+  startTubeCircuits(txs: Tx[]): void {
+    this.orchestrator.startTubeCircuits(txs);
   }
   setBlockCompleted(blockNumber: number, expectedBlockHeader?: BlockHeader): Promise<L2Block> {
     return this.orchestrator.setBlockCompleted(blockNumber, expectedBlockHeader);

--- a/yarn-project/prover-node/src/job/epoch-proving-job.ts
+++ b/yarn-project/prover-node/src/job/epoch-proving-job.ts
@@ -91,6 +91,7 @@ export class EpochProvingJob implements Traceable {
 
     try {
       this.prover.startNewEpoch(epochNumber, fromBlock, epochSizeBlocks);
+      this.prover.startTubeCircuits(this.txs);
 
       await asyncPool(this.config.parallelBlockLimit, this.blocks, async block => {
         this.checkState();


### PR DESCRIPTION
Adds the option in the orchestrator to kickoff tube circuits before going through processed txs, allowing to start proving tubes without AVM simulation being completed.

Fixes #10998