### PR TITLE
chore: missed test account retrieval simplification in one spot

### DIFF
--- a/yarn-project/end-to-end/src/e2e_token_contract/token_contract_test.ts
+++ b/yarn-project/end-to-end/src/e2e_token_contract/token_contract_test.ts
@@ -4,7 +4,6 @@ import { DocsExampleContract } from '@aztec/noir-contracts.js/DocsExample';
 import { TokenContract } from '@aztec/noir-contracts.js/Token';
 
 import { jest } from '@jest/globals';
-import { strict as assert } from 'assert';
 
 import {
   type ISnapshotManager,
@@ -49,20 +48,7 @@ export class TokenContractTest {
     await this.snapshotManager.snapshot('3_accounts', addAccounts(3, this.logger), async ({ accountKeys }, { pxe }) => {
       const accountManagers = accountKeys.map(ak => getSchnorrAccount(pxe, ak[0], ak[1], 1));
       this.wallets = await Promise.all(accountManagers.map(a => a.getWallet()));
-
-      // This Map and loop ensure that this.accounts has the same order as this.wallets and this.keys
-      const registeredAccounts: Map<string, CompleteAddress> = new Map(
-        (await pxe.getRegisteredAccounts()).map(acc => [acc.address.toString(), acc]),
-      );
-      for (let i = 0; i < this.wallets.length; i++) {
-        const wallet = this.wallets[i];
-        const walletAddr = wallet.getAddress().toString();
-        assert(
-          registeredAccounts.has(walletAddr),
-          `Test account ${walletAddr} not registered, but it should have been`,
-        );
-        this.accounts.push(registeredAccounts.get(walletAddr)!);
-      }
+      this.accounts = accountManagers.map(a => a.getCompleteAddress());
     });
 
     await this.snapshotManager.snapshot(


### PR DESCRIPTION
I merged https://github.com/AztecProtocol/aztec-packages/pull/10949 too quickly and missed this one.