### PR TITLE
feat(avm)!: store public bytecode compressed in artifact

### DIFF
--- a/avm-transpiler/Cargo.lock
+++ b/avm-transpiler/Cargo.lock
@@ -61,10 +61,10 @@ dependencies = [
 ]
 
 [[package]]
-name = "adler"
-version = "1.0.2"
+name = "adler2"
+version = "2.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f26201604c87b1e01bd3d98f8d5d9a8fcbb815e8cedb41ffccbeb4bf593a35fe"
+checksum = "512761e0bb2578dd7380c6baaa0f4ce03e84f95e960231d1dec8bf4d7d6e2627"
 
 [[package]]
 name = "ahash"
@@ -306,6 +306,7 @@ dependencies = [
  "acvm",
  "base64 0.21.7",
  "env_logger",
+ "flate2",
  "log",
  "noirc_errors",
  "serde",
@@ -694,9 +695,9 @@ dependencies = [
 
 [[package]]
 name = "flate2"
-version = "1.0.30"
+version = "1.0.35"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5f54427cfd1c7829e2a139fcefea601bf088ebca651d2bf53ebc600eac295dae"
+checksum = "c936bfdafb507ebbf50b8074c54fa31c5be9a1e7e5f467dd659697041407d07c"
 dependencies = [
  "crc32fast",
  "miniz_oxide",
@@ -938,11 +939,11 @@ checksum = "78ca9ab1a0babb1e7d5695e3530886289c18cf2f87ec19a575a0abdce112e3a3"
 
 [[package]]
 name = "miniz_oxide"
-version = "0.7.4"
+version = "0.8.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b8a240ddb74feaf34a79a7add65a741f3167852fba007066dcac1ca548d89c08"
+checksum = "4ffbe83022cedc1d264172192511ae958937694cd57ce297164951b8b3568394"
 dependencies = [
- "adler",
+ "adler2",
 ]
 
 [[package]]

--- a/avm-transpiler/Cargo.toml
+++ b/avm-transpiler/Cargo.toml
@@ -18,3 +18,4 @@ env_logger = "0.11"
 log = "0.4"
 serde_json = "1.0"
 serde = { version = "1.0.136", features = ["derive"] }
+flate2 = "1.0.35"

--- a/avm-transpiler/src/transpile_contract.rs
+++ b/avm-transpiler/src/transpile_contract.rs
@@ -1,3 +1,5 @@
+use std::io::Read;
+
 use acvm::FieldElement;
 use base64::Engine;
 use log::info;
@@ -111,6 +113,12 @@ impl From<CompiledAcirContractArtifact> for TranspiledContractArtifact {
                     &brillig_pcs_to_avm_pcs,
                 );
 
+                // Gzip AVM bytecode. We compress so that the artifact is smaller, but it will be uncompressed before deployment.
+                let mut compressed_avm_bytecode = Vec::new();
+                let mut encoder =
+                    flate2::read::GzEncoder::new(&avm_bytecode[..], flate2::Compression::best());
+                let _ = encoder.read_to_end(&mut compressed_avm_bytecode);
+
                 // Push modified function entry to ABI
                 functions.push(AvmOrAcirContractFunctionArtifact::Avm(
                     AvmContractFunctionArtifact {
@@ -118,7 +126,7 @@ impl From<CompiledAcirContractArtifact> for TranspiledContractArtifact {
                         is_unconstrained: function.is_unconstrained,
                         custom_attributes: function.custom_attributes,
                         abi: function.abi,
-                        bytecode: base64::prelude::BASE64_STANDARD.encode(avm_bytecode),
+                        bytecode: base64::prelude::BASE64_STANDARD.encode(compressed_avm_bytecode),
                         debug_symbols: ProgramDebugInfo { debug_infos },
                         brillig_names: function.brillig_names,
                     },


### PR DESCRIPTION
Store public bytecode compressed in the artifact JSON, but uncompress when loading.

Closes #11150.