### PR TITLE
chore: print warning in builder when failure happens.

### DIFF
--- a/barretenberg/cpp/src/barretenberg/bb/main.cpp
+++ b/barretenberg/cpp/src/barretenberg/bb/main.cpp
@@ -1314,8 +1314,7 @@ int main(int argc, char* argv[])
 {
     try {
         std::vector<std::string> args(argv + 1, argv + argc);
-        debug_logging = flag_present(args, "-d") || flag_present(args, "--debug_logging");
-        verbose_logging = debug_logging || flag_present(args, "-v") || flag_present(args, "--verbose_logging");
+        verbose_logging = flag_present(args, "-v") || flag_present(args, "--verbose_logging");
         if (args.empty()) {
             std::cerr << "No command provided.\n";
             return 1;

--- a/barretenberg/cpp/src/barretenberg/common/log.cpp
+++ b/barretenberg/cpp/src/barretenberg/common/log.cpp
@@ -7,6 +7,3 @@ bool verbose_logging = std::getenv("BB_VERBOSE") == nullptr ? false : std::strin
 #else
 bool verbose_logging = true;
 #endif
-
-// Used for `debug` in log.hpp.
-bool debug_logging = false;

--- a/barretenberg/cpp/src/barretenberg/common/log.hpp
+++ b/barretenberg/cpp/src/barretenberg/common/log.hpp
@@ -47,13 +47,10 @@ template <typename... Args> std::string benchmark_format(Args... args)
     return os.str();
 }
 
-extern bool debug_logging;
 #ifndef NDEBUG
 template <typename... Args> inline void debug(Args... args)
 {
-    if (debug_logging) {
-        logstr(format(args...).c_str());
-    }
+    logstr(format(args...).c_str());
 }
 #else
 template <typename... Args> inline void debug(Args... /*unused*/) {}

--- a/barretenberg/cpp/src/barretenberg/stdlib_circuit_builders/circuit_builder_base.hpp
+++ b/barretenberg/cpp/src/barretenberg/stdlib_circuit_builders/circuit_builder_base.hpp
@@ -18,7 +18,8 @@ template <typename FF_> class CircuitBuilderBase {
     using EmbeddedCurve = std::conditional_t<std::same_as<FF, bb::g1::coordinate_field>, curve::BN254, curve::Grumpkin>;
 
     size_t num_gates = 0;
-    bool has_dummy_witnesses;
+    // true if we have dummy witnesses (in the write_vk case)
+    bool has_dummy_witnesses = false;
 
     std::vector<uint32_t> public_inputs;
     std::vector<FF> variables;

--- a/barretenberg/cpp/src/barretenberg/stdlib_circuit_builders/circuit_builder_base.hpp
+++ b/barretenberg/cpp/src/barretenberg/stdlib_circuit_builders/circuit_builder_base.hpp
@@ -18,6 +18,7 @@ template <typename FF_> class CircuitBuilderBase {
     using EmbeddedCurve = std::conditional_t<std::same_as<FF, bb::g1::coordinate_field>, curve::BN254, curve::Grumpkin>;
 
     size_t num_gates = 0;
+    bool has_dummy_witnesses;
 
     std::vector<uint32_t> public_inputs;
     std::vector<FF> variables;
@@ -56,7 +57,7 @@ template <typename FF_> class CircuitBuilderBase {
     static constexpr uint32_t REAL_VARIABLE = UINT32_MAX - 1;
     static constexpr uint32_t FIRST_VARIABLE_IN_CLASS = UINT32_MAX - 2;
 
-    CircuitBuilderBase(size_t size_hint = 0);
+    CircuitBuilderBase(size_t size_hint = 0, bool has_dummy_witnesses = false);
 
     CircuitBuilderBase(const CircuitBuilderBase& other) = default;
     CircuitBuilderBase(CircuitBuilderBase&& other) noexcept = default;

--- a/barretenberg/cpp/src/barretenberg/stdlib_circuit_builders/circuit_builder_base_impl.hpp
+++ b/barretenberg/cpp/src/barretenberg/stdlib_circuit_builders/circuit_builder_base_impl.hpp
@@ -290,7 +290,7 @@ template <typename FF_> void CircuitBuilderBase<FF_>::failure(std::string msg)
 {
     if (!has_dummy_witnesses) {
         // We have a builder failure when we have real witnesses which is a mistake.
-        ASSERT(0 && "Builder failure when we have real witnesses");
+        info("Builder failure when we have real witnesses!"); // not a catch-all error
     }
     _failed = true;
     set_err(std::move(msg));

--- a/barretenberg/cpp/src/barretenberg/stdlib_circuit_builders/circuit_builder_base_impl.hpp
+++ b/barretenberg/cpp/src/barretenberg/stdlib_circuit_builders/circuit_builder_base_impl.hpp
@@ -287,6 +287,8 @@ template <typename FF_> void CircuitBuilderBase<FF_>::set_err(std::string msg)
 template <typename FF_> void CircuitBuilderBase<FF_>::failure(std::string msg)
 {
     _failed = true;
+    debug("Builder failed to build. This is not an error for the write_vk flow. Are you building the circuit with "
+          "invalid witnesses?");
     set_err(std::move(msg));
 }
 } // namespace bb

--- a/barretenberg/cpp/src/barretenberg/stdlib_circuit_builders/circuit_builder_base_impl.hpp
+++ b/barretenberg/cpp/src/barretenberg/stdlib_circuit_builders/circuit_builder_base_impl.hpp
@@ -3,7 +3,9 @@
 #include "circuit_builder_base.hpp"
 
 namespace bb {
-template <typename FF_> CircuitBuilderBase<FF_>::CircuitBuilderBase(size_t size_hint)
+template <typename FF_>
+CircuitBuilderBase<FF_>::CircuitBuilderBase(size_t size_hint, bool has_dummy_witnesses)
+    : has_dummy_witnesses(has_dummy_witnesses)
 {
     variables.reserve(size_hint * 3);
     variable_names.reserve(size_hint * 3);
@@ -286,9 +288,11 @@ template <typename FF_> void CircuitBuilderBase<FF_>::set_err(std::string msg)
 
 template <typename FF_> void CircuitBuilderBase<FF_>::failure(std::string msg)
 {
+    if (!has_dummy_witnesses) {
+        // We have a builder failure when we have real witnesses which is a mistake.
+        ASSERT(0 && "Builder failure when we have real witnesses");
+    }
     _failed = true;
-    debug("Builder failed to build. This is not an error for the write_vk flow. Are you building the circuit with "
-          "invalid witnesses?");
     set_err(std::move(msg));
 }
 } // namespace bb

--- a/barretenberg/cpp/src/barretenberg/stdlib_circuit_builders/ultra_circuit_builder.hpp
+++ b/barretenberg/cpp/src/barretenberg/stdlib_circuit_builders/ultra_circuit_builder.hpp
@@ -359,7 +359,7 @@ class UltraCircuitBuilder_ : public CircuitBuilderBase<typename ExecutionTrace_:
                          const std::vector<uint32_t>& public_inputs,
                          size_t varnum,
                          bool recursive = false)
-        : CircuitBuilderBase<FF>(size_hint)
+        : CircuitBuilderBase<FF>(size_hint, witness_values.empty())
     {
         // TODO(https://github.com/AztecProtocol/barretenberg/issues/870): reserve space in blocks here somehow?
 


### PR DESCRIPTION
Prints a warning when we call failure() in the builder and we are not in the write_vk case. Also enables debug logging if NDEBUG is not set.