### PR TITLE
chore: Save kind smoke test logs as artifact

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -217,7 +217,7 @@ jobs:
 
   e2e:
     needs: [images-e2e, configure]
-    if: needs.configure.outputs.e2e-all == 'true' || (needs.configure.outputs.non-docs == 'true' && needs.configure.outputs.non-bb == 'true')
+    if: false
     runs-on: ubuntu-latest
     strategy:
       fail-fast: false
@@ -379,6 +379,18 @@ jobs:
             echo ${{ secrets.DOCKERHUB_PASSWORD }} | docker login -u aztecprotocolci --password-stdin
             cd yarn-project/end-to-end
             NAMESPACE=smoke FRESH_INSTALL=true VALUES_FILE=ci-smoke.yaml ./scripts/network_test.sh ./src/spartan/smoke.test.ts
+      - name: Show where network logs are
+        if: always()
+        run: tree yarn-project/end-to-end
+      - name: Copy Network Logs
+        if: always()
+        run: scripts/copy_from_tester yarn-project/end-to-end/scripts/network-test.log network-test.log || true
+      - name: Upload Network Logs
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: kind-network-smoke.log
+          path: network-test.log
 
   kind-network-test:
     needs: [images-e2e, configure]

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -361,7 +361,7 @@ jobs:
 
   kind-network-smoke:
     needs: [images-e2e, configure]
-    if: needs.configure.outputs.e2e-all == 'true' || needs.configure.outputs.yarn-project == 'true'
+    if: true
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -217,7 +217,7 @@ jobs:
 
   e2e:
     needs: [images-e2e, configure]
-    if: false
+    if: needs.configure.outputs.e2e-all == 'true' || (needs.configure.outputs.non-docs == 'true' && needs.configure.outputs.non-bb == 'true')
     runs-on: ubuntu-latest
     strategy:
       fail-fast: false
@@ -361,7 +361,7 @@ jobs:
 
   kind-network-smoke:
     needs: [images-e2e, configure]
-    if: true
+    if: needs.configure.outputs.e2e-all == 'true' || needs.configure.outputs.yarn-project == 'true'
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
@@ -379,9 +379,6 @@ jobs:
             echo ${{ secrets.DOCKERHUB_PASSWORD }} | docker login -u aztecprotocolci --password-stdin
             cd yarn-project/end-to-end
             NAMESPACE=smoke FRESH_INSTALL=true VALUES_FILE=ci-smoke.yaml ./scripts/network_test.sh ./src/spartan/smoke.test.ts
-      - name: Show where network logs are
-        if: always()
-        run: tree yarn-project/end-to-end
       - name: Copy Network Logs
         if: always()
         run: scripts/copy_from_tester yarn-project/end-to-end/scripts/network-test.log network-test.log || true

--- a/yarn-project/end-to-end/scripts/network_test.sh
+++ b/yarn-project/end-to-end/scripts/network_test.sh
@@ -62,7 +62,6 @@ fi
 STERN_PID=""
 function copy_stern_to_log() {
   stern spartan -n $NAMESPACE >$SCRIPT_DIR/network-test.log &
-  echo "disabled until less resource intensive solution than stern implemented" >$SCRIPT_DIR/network-test.log &
   STERN_PID=$!
 }
 


### PR DESCRIPTION
Saves the logs from the kind-smoke test as an artifact so we can debug failures. See [here](https://github.com/AztecProtocol/aztec-packages/actions/runs/12768996955?pr=11212) for an example run.