### PR TITLE
fix: Bump inotify limits on tester

### DIFF
--- a/.github/ensure-tester/run
+++ b/.github/ensure-tester/run
@@ -5,6 +5,7 @@ ttl=$1
 scripts/run_on_tester "
   set -eu;
   sudo shutdown -P $ttl;
+  sudo sysctl fs.inotify.max_user_watches=65536
   function clone {
     if ! [ -d ~/run-$RUN_ID ]; then
       mkdir -p ~/run-$RUN_ID;

--- a/yarn-project/end-to-end/scripts/network_test.sh
+++ b/yarn-project/end-to-end/scripts/network_test.sh
@@ -61,7 +61,6 @@ fi
 
 STERN_PID=""
 function copy_stern_to_log() {
-  ulimit -n 4096
   stern spartan -n $NAMESPACE >$SCRIPT_DIR/network-test.log &
   echo "disabled until less resource intensive solution than stern implemented" >$SCRIPT_DIR/network-test.log &
   STERN_PID=$!


### PR DESCRIPTION
Assuming the current default for inotify max user watches on the tester machine is 8192, this PR bumps it to 64k. We were getting errors when trying to tail k8s logs caused by hitting inotify limits, for example:

```
spartan-aztec-network-boot-node-0 wait-for-ethereum export ETHEREUM_HOST=http://spartan-aztec-network-ethereum.smoke:8545
spartan-aztec-network-boot-node-0 wait-for-ethereum export BOOT_NODE_HOST=http://spartan-aztec-network-boot-node.smoke:8080
spartan-aztec-network-boot-node-0 wait-for-ethereum export PROVER_NODE_HOST=http://spartan-aztec-network-prover-node.smoke:8080
spartan-aztec-network-boot-node-0 wait-for-ethereum export PROVER_BROKER_HOST=http://spartan-aztec-network-prover-broker.smoke:8084
spartan-aztec-network-boot-node-0 wait-for-ethereum Awaiting ethereum node at http://spartan-aztec-network-ethereum.smoke:8545
spartan-aztec-network-boot-node-0 wait-for-ethereum Waiting for Ethereum node http://spartan-aztec-network-ethereum.smoke:8545...
spartan-aztec-network-boot-node-0 wait-for-ethereum to create fsnotify watcher: too many open files
```
