### PR TITLE
fix: Sequencer timetable accounts for spare time

### DIFF
--- a/yarn-project/sequencer-client/src/sequencer/sequencer.test.ts
+++ b/yarn-project/sequencer-client/src/sequencer/sequencer.test.ts
@@ -267,13 +267,10 @@ describe('sequencer', () => {
     expectPublisherProposeL2Block([txHash]);
   });
 
-  it.each([
-    { delayedState: SequencerState.INITIALIZING_PROPOSAL },
-    // It would be nice to add the other states, but we would need to inject delays within the `work` loop
-  ])('does not build a block if it does not have enough time left in the slot', async ({ delayedState }) => {
-    // trick the sequencer into thinking that we are just too far into slot 1
+  it('does not build a block if it does not have enough time left in the slot', async () => {
+    // Trick the sequencer into thinking that we are just too far into slot 1
     sequencer.setL1GenesisTime(
-      Math.floor(Date.now() / 1000) - slotDuration * 1 - (sequencer.getTimeTable()[delayedState] + 1),
+      Math.floor(Date.now() / 1000) - slotDuration * 1 - (sequencer.getTimeTable().initialTime + 1),
     );
 
     const tx = makeTx();
@@ -283,7 +280,7 @@ describe('sequencer', () => {
     await expect(sequencer.doRealWork()).rejects.toThrow(
       expect.objectContaining({
         name: 'SequencerTooSlowError',
-        message: expect.stringContaining(`Too far into slot to transition to ${delayedState}`),
+        message: expect.stringContaining(`Too far into slot`),
       }),
     );
 
@@ -658,7 +655,7 @@ describe('sequencer', () => {
 
 class TestSubject extends Sequencer {
   public getTimeTable() {
-    return this.timeTable;
+    return this.timetable;
   }
 
   public setL1GenesisTime(l1GenesisTime: number) {

--- a/yarn-project/sequencer-client/src/sequencer/timetable.test.ts
+++ b/yarn-project/sequencer-client/src/sequencer/timetable.test.ts
@@ -22,7 +22,7 @@ describe('sequencer-timetable', () => {
       expect(timetable.getMaxAllowedTime(SequencerState.COLLECTING_ATTESTATIONS)).toEqual(
         aztecSlotDuration -
           (ethereumSlotDuration - maxL1TxInclusionTimeIntoSlot) -
-          timetable.attestationPropagationTime,
+          timetable.attestationPropagationTime * 2,
       );
     });
   });

--- a/yarn-project/sequencer-client/src/sequencer/timetable.test.ts
+++ b/yarn-project/sequencer-client/src/sequencer/timetable.test.ts
@@ -99,9 +99,32 @@ describe('sequencer-timetable', () => {
     it('sets deadline', () => {
       const actual = timetable.getValidatorReexecTimeEnd(10);
       const available = aztecSlotDuration - timetable.attestationPropagationTime - timetable.l1PublishingTime - 10;
-      const expected = available / 2 + 10;
+      const expected = available + 10;
       expect(actual).toEqual(expected);
-      expect(expected).toEqual(16);
+      expect(expected).toEqual(22);
+    });
+
+    it('sets time available equal to block building', () => {
+      const { blockValidationTime, attestationPropagationTime, l1PublishingTime } = timetable;
+
+      const intoSlot = 3;
+      const blockBuildDeadline = timetable.getBlockProposalExecTimeEnd(intoSlot);
+      const blockBuildAvailable = blockBuildDeadline - intoSlot;
+
+      const validatorIntoSlot = blockBuildDeadline + blockValidationTime + attestationPropagationTime;
+      const validatorDeadline = timetable.getValidatorReexecTimeEnd(validatorIntoSlot);
+      const validatorAvailable = validatorDeadline - validatorIntoSlot;
+
+      expect(blockBuildAvailable).toEqual(validatorAvailable);
+
+      expect(
+        blockBuildAvailable +
+          validatorAvailable +
+          intoSlot +
+          blockValidationTime +
+          attestationPropagationTime * 2 +
+          l1PublishingTime,
+      ).toEqual(aztecSlotDuration);
     });
   });
 });

--- a/yarn-project/sequencer-client/src/sequencer/timetable.test.ts
+++ b/yarn-project/sequencer-client/src/sequencer/timetable.test.ts
@@ -1,0 +1,107 @@
+import { SequencerTimetable } from './timetable.js';
+import { SequencerState } from './utils.js';
+
+describe('sequencer-timetable', () => {
+  let timetable: SequencerTimetable;
+
+  const ethereumSlotDuration = 12;
+  const aztecSlotDuration = 36;
+  const maxL1TxInclusionTimeIntoSlot = 0;
+  const enforce = true;
+
+  beforeEach(() => {
+    timetable = new SequencerTimetable(ethereumSlotDuration, aztecSlotDuration, maxL1TxInclusionTimeIntoSlot, enforce);
+  });
+
+  describe('maxAllowedTime', () => {
+    it('computes time from slot start', () => {
+      expect(timetable.getMaxAllowedTime(SequencerState.INITIALIZING_PROPOSAL)).toEqual(timetable.initialTime);
+    });
+
+    it('computes time from slot end', () => {
+      expect(timetable.getMaxAllowedTime(SequencerState.COLLECTING_ATTESTATIONS)).toEqual(
+        aztecSlotDuration -
+          (ethereumSlotDuration - maxL1TxInclusionTimeIntoSlot) -
+          timetable.attestationPropagationTime,
+      );
+    });
+  });
+
+  describe('assertTimeLeft', () => {
+    it('throws if time is up', () => {
+      expect(() => timetable.assertTimeLeft(SequencerState.INITIALIZING_PROPOSAL, 5)).toThrow(/Too far into slot/);
+    });
+
+    it('does not throw if enough time left', () => {
+      expect(() => timetable.assertTimeLeft(SequencerState.INITIALIZING_PROPOSAL, 1)).not.toThrow();
+    });
+
+    it('handles negative seconds into slot', () => {
+      expect(() => timetable.assertTimeLeft(SequencerState.INITIALIZING_PROPOSAL, -1)).not.toThrow();
+      expect(() => timetable.assertTimeLeft(SequencerState.PUBLISHING_BLOCK, -1)).not.toThrow();
+    });
+
+    it('skips check if enforcement is off', () => {
+      timetable = new SequencerTimetable(ethereumSlotDuration, aztecSlotDuration, maxL1TxInclusionTimeIntoSlot, false);
+      expect(() => timetable.assertTimeLeft(SequencerState.INITIALIZING_PROPOSAL, 1000)).not.toThrow();
+    });
+  });
+
+  describe('getBlockProposalExecTimeEnd', () => {
+    it('sets deadline considering unused time from init phase', () => {
+      const actual = timetable.getBlockProposalExecTimeEnd(1);
+      const available =
+        aztecSlotDuration -
+        timetable.attestationPropagationTime * 2 -
+        timetable.l1PublishingTime -
+        timetable.blockValidationTime -
+        1;
+      const expected = available / 2 + 1;
+      expect(actual).toEqual(expected);
+      expect(expected).toEqual(10);
+    });
+
+    it('sets deadline considering starting before slot', () => {
+      const actual = timetable.getBlockProposalExecTimeEnd(-1);
+      const available =
+        aztecSlotDuration -
+        timetable.attestationPropagationTime * 2 -
+        timetable.l1PublishingTime -
+        timetable.blockValidationTime +
+        1;
+      const expected = available / 2 - 1;
+      expect(actual).toEqual(expected);
+      expect(expected).toEqual(9);
+    });
+
+    it('sets deadline when building on time', () => {
+      const intoSlot = timetable.initialTime + timetable.blockPrepareTime;
+      const actual = timetable.getBlockProposalExecTimeEnd(intoSlot);
+      const available =
+        aztecSlotDuration -
+        timetable.attestationPropagationTime * 2 -
+        timetable.l1PublishingTime -
+        timetable.blockValidationTime -
+        intoSlot;
+      const expected = available / 2 + intoSlot;
+      expect(actual).toEqual(expected);
+      expect(expected).toEqual(11.5);
+    });
+
+    it('sets deadline before current time if too late', () => {
+      const intoSlot = aztecSlotDuration - 4;
+      const actual = timetable.getBlockProposalExecTimeEnd(intoSlot);
+      expect(actual).toBeLessThan(intoSlot);
+    });
+  });
+
+  describe('getValidatorReexecTimeEnd', () => {
+    it('sets deadline', () => {
+      const actual = timetable.getValidatorReexecTimeEnd(10);
+      const available = aztecSlotDuration - timetable.attestationPropagationTime - timetable.l1PublishingTime - 10;
+      const expected = available / 2 + 10;
+      expect(actual).toEqual(expected);
+      expect(expected).toEqual(16);
+    });
+  });
+});

--- a/yarn-project/sequencer-client/src/sequencer/timetable.ts
+++ b/yarn-project/sequencer-client/src/sequencer/timetable.ts
@@ -1,0 +1,127 @@
+import { createLogger } from '@aztec/aztec.js';
+
+import { type SequencerMetrics } from './metrics.js';
+import { SequencerState } from './utils.js';
+
+export class SequencerTimetable {
+  /** How late into the slot can we be to start working */
+  public readonly initialTime = 2;
+
+  /** How long it takes to get ready to start building */
+  public readonly blockPrepareTime = 2;
+
+  /** How long it takes to for proposals and attestations to travel across the p2p layer (one-way) */
+  public readonly attestationPropagationTime = 2;
+
+  /** How much time we spend validating and processing a block after building it, and assembling the proposal to send to attestors */
+  public readonly blockValidationTime = 1;
+
+  /**
+   * How long it takes to get a published block into L1. L1 builders typically accept txs up to 4 seconds into their slot,
+   * but we'll timeout sooner to give it more time to propagate (remember we also have blobs!). Still, when working in anvil,
+   * we can just post in the very last second of the L1 slot and still expect the tx to be accepted.
+   */
+  public readonly l1PublishingTime;
+
+  constructor(
+    private readonly ethereumSlotDuration: number,
+    private readonly aztecSlotDuration: number,
+    private readonly maxL1TxInclusionTimeIntoSlot: number,
+    private readonly enforce: boolean = true,
+    private readonly metrics?: SequencerMetrics,
+    private readonly log = createLogger('sequencer:timetable'),
+  ) {
+    this.l1PublishingTime = this.ethereumSlotDuration - this.maxL1TxInclusionTimeIntoSlot;
+  }
+
+  private get afterBlockBuildingTimeNeededWithoutReexec() {
+    return this.blockValidationTime + this.attestationPropagationTime * 2 + this.l1PublishingTime;
+  }
+
+  public getBlockProposalExecTimeEnd(secondsIntoSlot: number): number {
+    // We are N seconds into the slot. We need to account for `afterBlockBuildingTimeNeededWithoutReexec` seconds,
+    // send then split the remaining time between the re-execution and the block building.
+    const maxAllowed = this.aztecSlotDuration - this.afterBlockBuildingTimeNeededWithoutReexec;
+    const available = maxAllowed - secondsIntoSlot;
+    const executionTimeEnd = secondsIntoSlot + available / 2;
+    this.log.debug(`Block proposal execution time deadline is ${executionTimeEnd}`, {
+      secondsIntoSlot,
+      maxAllowed,
+      available,
+      executionTimeEnd,
+    });
+    return executionTimeEnd;
+  }
+
+  private get afterBlockReexecTimeNeeded() {
+    return this.attestationPropagationTime + this.l1PublishingTime;
+  }
+
+  public getValidatorReexecTimeEnd(secondsIntoSlot: number): number {
+    // We are N seconds into the slot. We need to account for `afterBlockReexecTimeNeeded` seconds.
+    const maxAllowed = this.aztecSlotDuration - this.afterBlockReexecTimeNeeded;
+    const available = maxAllowed - secondsIntoSlot;
+    const validationTimeEnd = secondsIntoSlot + available / 2;
+    this.log.debug(`Validator re-execution time deadline is ${validationTimeEnd}`, {
+      secondsIntoSlot,
+      maxAllowed,
+      available,
+      validationTimeEnd,
+    });
+    return validationTimeEnd;
+  }
+
+  public getMaxAllowedTime(state: SequencerState): number | undefined {
+    switch (state) {
+      case SequencerState.STOPPED:
+      case SequencerState.IDLE:
+      case SequencerState.SYNCHRONIZING:
+      case SequencerState.PROPOSER_CHECK:
+        return; // We don't really care about times for this states
+      case SequencerState.INITIALIZING_PROPOSAL:
+        return this.initialTime;
+      case SequencerState.CREATING_BLOCK:
+        return this.initialTime + this.blockPrepareTime;
+      case SequencerState.COLLECTING_ATTESTATIONS:
+        return this.aztecSlotDuration - this.l1PublishingTime - this.attestationPropagationTime;
+      case SequencerState.PUBLISHING_BLOCK:
+        return this.aztecSlotDuration - this.l1PublishingTime;
+      default: {
+        const _exhaustiveCheck: never = state;
+        throw new Error(`Unexpected state: ${state}`);
+      }
+    }
+  }
+
+  public assertTimeLeft(newState: SequencerState, secondsIntoSlot: number) {
+    if (!this.enforce) {
+      return;
+    }
+
+    const maxAllowedTime = this.getMaxAllowedTime(newState);
+    if (maxAllowedTime === undefined) {
+      return;
+    }
+
+    const bufferSeconds = maxAllowedTime - secondsIntoSlot;
+    if (bufferSeconds < 0) {
+      throw new SequencerTooSlowError(newState, maxAllowedTime, secondsIntoSlot);
+    }
+
+    this.metrics?.recordStateTransitionBufferMs(Math.floor(bufferSeconds * 1000), newState);
+    this.log.trace(`Enough time to transition to ${newState}`, { maxAllowedTime, secondsIntoSlot });
+  }
+}
+
+export class SequencerTooSlowError extends Error {
+  constructor(
+    public readonly proposedState: SequencerState,
+    public readonly maxAllowedTime: number,
+    public readonly currentTime: number,
+  ) {
+    super(
+      `Too far into slot for ${proposedState} (time into slot ${currentTime}s greater than ${maxAllowedTime}s allowance)`,
+    );
+    this.name = 'SequencerTooSlowError';
+  }
+}

--- a/yarn-project/sequencer-client/src/sequencer/timetable.ts
+++ b/yarn-project/sequencer-client/src/sequencer/timetable.ts
@@ -61,7 +61,7 @@ export class SequencerTimetable {
     // We are N seconds into the slot. We need to account for `afterBlockReexecTimeNeeded` seconds.
     const maxAllowed = this.aztecSlotDuration - this.afterBlockReexecTimeNeeded;
     const available = maxAllowed - secondsIntoSlot;
-    const validationTimeEnd = secondsIntoSlot + available / 2;
+    const validationTimeEnd = secondsIntoSlot + available;
     this.log.debug(`Validator re-execution time deadline is ${validationTimeEnd}`, {
       secondsIntoSlot,
       maxAllowed,

--- a/yarn-project/sequencer-client/src/sequencer/timetable.ts
+++ b/yarn-project/sequencer-client/src/sequencer/timetable.ts
@@ -58,14 +58,10 @@ export class SequencerTimetable {
   }
 
   public getValidatorReexecTimeEnd(secondsIntoSlot: number): number {
-    // We are N seconds into the slot. We need to account for `afterBlockReexecTimeNeeded` seconds.
-    const maxAllowed = this.aztecSlotDuration - this.afterBlockReexecTimeNeeded;
-    const available = maxAllowed - secondsIntoSlot;
-    const validationTimeEnd = secondsIntoSlot + available;
+    // We need to leave for `afterBlockReexecTimeNeeded` seconds available.
+    const validationTimeEnd = this.aztecSlotDuration - this.afterBlockReexecTimeNeeded;
     this.log.debug(`Validator re-execution time deadline is ${validationTimeEnd}`, {
       secondsIntoSlot,
-      maxAllowed,
-      available,
       validationTimeEnd,
     });
     return validationTimeEnd;
@@ -83,7 +79,7 @@ export class SequencerTimetable {
       case SequencerState.CREATING_BLOCK:
         return this.initialTime + this.blockPrepareTime;
       case SequencerState.COLLECTING_ATTESTATIONS:
-        return this.aztecSlotDuration - this.l1PublishingTime - this.attestationPropagationTime;
+        return this.aztecSlotDuration - this.l1PublishingTime - 2 * this.attestationPropagationTime;
       case SequencerState.PUBLISHING_BLOCK:
         return this.aztecSlotDuration - this.l1PublishingTime;
       default: {

--- a/yarn-project/sequencer-client/src/sequencer/timetable.ts
+++ b/yarn-project/sequencer-client/src/sequencer/timetable.ts
@@ -5,10 +5,10 @@ import { SequencerState } from './utils.js';
 
 export class SequencerTimetable {
   /** How late into the slot can we be to start working */
-  public readonly initialTime = 2;
+  public readonly initialTime = 3;
 
   /** How long it takes to get ready to start building */
-  public readonly blockPrepareTime = 2;
+  public readonly blockPrepareTime = 1;
 
   /** How long it takes to for proposals and attestations to travel across the p2p layer (one-way) */
   public readonly attestationPropagationTime = 2;

--- a/yarn-project/sequencer-client/src/test/index.ts
+++ b/yarn-project/sequencer-client/src/test/index.ts
@@ -3,12 +3,11 @@ import { type PublicProcessorFactory } from '@aztec/simulator/server';
 import { SequencerClient } from '../client/sequencer-client.js';
 import { type L1Publisher } from '../publisher/l1-publisher.js';
 import { Sequencer } from '../sequencer/sequencer.js';
-import { type SequencerState } from '../sequencer/utils.js';
+import { type SequencerTimetable } from '../sequencer/timetable.js';
 
 class TestSequencer_ extends Sequencer {
   public override publicProcessorFactory!: PublicProcessorFactory;
-  public override timeTable!: Record<SequencerState, number>;
-  public override processTxTime!: number;
+  public override timetable!: SequencerTimetable;
   public override publisher!: L1Publisher;
 }
 


### PR DESCRIPTION
Extracts sequencer timetable into its own class.

Fixes #11203

> The current timetable approach does account for that extra time, but the issue is that exclusively assigned to the proposer. This can lead to asymmetries between sequencer and validator processing time. For example, let's assume a timetable on a 24s L2 slot with something like:
> 
> Init: 4s
> Block building: 8s
> Propagation: 10s
> Block validation reexec: 14s
> Propagate back: 16s
> Submit: 20s
>
> Let's say that the block starts early, and init ends up taking less than 4s. So when the sequencer starts building the block, it's 2s into the slot. The deadline for block building will still be at 8s, so the sequencer will allocate 6s (instead of 4) for building the block. But validators will still be expected to reexec in 4s, which could lead to failed attestations.
>  


