### PR TITLE
chore: remove explicit collector address

### DIFF
--- a/spartan/aztec-network/values/release-devnet.yaml
+++ b/spartan/aztec-network/values/release-devnet.yaml
@@ -1,6 +1,5 @@
 telemetry:
   enabled: true
-  otelCollectorEndpoint: http://35.197.100.168:4318
 
 validator:
   replicas: 1


### PR DESCRIPTION
Removes the explicit OpenTelemetry Collector address and instead uses the default (like all the other services) which should be accessible over internal DNS resolution
