### PR TITLE
fix: remove arch tag in sandbox images

### DIFF
--- a/aztec-up/bin/aztec
+++ b/aztec-up/bin/aztec
@@ -1,6 +1,8 @@
 #!/usr/bin/env bash
 set -euo pipefail
 
+export ARCH_TAG=$(uname -m)
+
 # Directory of env_var file
 TS_ENV_VAR_FILE=/usr/src/yarn-project/foundation/src/config/env_var.ts
 LOCAL_TS_FILE=./env_var.ts

--- a/aztec-up/bin/aztec
+++ b/aztec-up/bin/aztec
@@ -1,8 +1,6 @@
 #!/usr/bin/env bash
 set -euo pipefail
 
-export ARCH_TAG=$(uname -m)
-
 # Directory of env_var file
 TS_ENV_VAR_FILE=/usr/src/yarn-project/foundation/src/config/env_var.ts
 LOCAL_TS_FILE=./env_var.ts

--- a/aztec-up/bin/docker-compose.sandbox.yml
+++ b/aztec-up/bin/docker-compose.sandbox.yml
@@ -1,6 +1,6 @@
 services:
   ethereum:
-    image: aztecprotocol/foundry:25f24e677a6a32a62512ad4f561995589ac2c7dc-${ARCH_TAG:-amd64}
+    image: aztecprotocol/foundry:25f24e677a6a32a62512ad4f561995589ac2c7dc
     entrypoint: >
       sh -c '
       if [ -n "$$FORK_BLOCK_NUMBER" ] && [ -n "$$FORK_URL" ]; then


### PR DESCRIPTION
aztecprotocol/foundry has been pushed as a manifest