### PR TITLE
chore: change default loglevel for sandbox

### DIFF
--- a/aztec-up/bin/docker-compose.sandbox.yml
+++ b/aztec-up/bin/docker-compose.sandbox.yml
@@ -20,7 +20,7 @@ services:
     ports:
       - "${PXE_PORT:-8080}:${PXE_PORT:-8080}"
     environment:
-      LOG_LEVEL: # Loaded from the user shell if explicitly set
+      LOG_LEVEL: '${LOG_LEVEL:-info; verbose: simulator:avm:debug_log}'
       HOST_WORKDIR: "${PWD}" # Loaded from the user shell to show log files absolute path in host
       ETHEREUM_HOST: ${ETHEREUM_HOST:-http://ethereum}:${ANVIL_PORT:-8545}
       L1_CHAIN_ID: 31337


### PR DESCRIPTION
This sets the default log level for the sandbox as suggested by @critesjosh. 

s/o @Thunkar
