### PR TITLE
chore: wait for ethereum in each pod

### DIFF
--- a/spartan/aztec-network/templates/_helpers.tpl
+++ b/spartan/aztec-network/templates/_helpers.tpl
@@ -190,3 +190,14 @@ affinity:
 nodeSelector:
   cloud.google.com/gke-ephemeral-storage-local-ssd: "true"
 {{- end -}}
+
+{{- define "aztec-network.waitForEthereum" -}}
+echo "Awaiting ethereum node at ${ETHEREUM_HOST}"
+until curl -s -X POST -H 'Content-Type: application/json' \
+  -d '{"jsonrpc":"2.0","method":"eth_chainId","params":[],"id":67}' \
+  ${ETHEREUM_HOST} | grep 0x; do
+  echo "Waiting for Ethereum node ${ETHEREUM_HOST}..."
+  sleep 5
+done
+echo "Ethereum node is ready!"
+{{- end -}}

--- a/spartan/aztec-network/templates/boot-node.yaml
+++ b/spartan/aztec-network/templates/boot-node.yaml
@@ -47,14 +47,7 @@ spec:
             - |
               source /shared/config/service-addresses
               cat /shared/config/service-addresses
-              echo "Awaiting ethereum node at ${ETHEREUM_HOST}"
-              until curl -s -X POST -H 'Content-Type: application/json' \
-                -d '{"jsonrpc":"2.0","method":"eth_chainId","params":[],"id":67}' \
-                ${ETHEREUM_HOST} | grep 0x; do
-                echo "Waiting for Ethereum node ${ETHEREUM_HOST}..."
-                sleep 5
-              done
-              echo "Ethereum node is ready!"
+              {{- include "aztec-network.waitForEthereum" . | nindent 14 }}
           volumeMounts:
             - name: config
               mountPath: /shared/config
@@ -66,6 +59,10 @@ spec:
             - -c
             - |
               source /shared/config/service-addresses
+              # it is possible that even though we asserted this above, the DNS resolver of *this* pod
+              # is not yet ready to resolve the ethereum host.
+              # so we need to wait for it to be ready.
+              {{- include "aztec-network.waitForEthereum" . | nindent 14 }}
               if [ "$(cast code --rpc-url ${ETHEREUM_HOST} 0x4e59b44847b379578588920ca78fbf26c0b4956c)" = "0x" ]; then
                 echo "Deploying Deterministic Deployment Proxy"
                 cast publish --rpc-url ${ETHEREUM_HOST} 0xf8a58085174876e800830186a08080b853604580600e600039806000f350fe7fffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffe03601600081602082378035828234f58015156039578182fd5b8082525050506014600cf31ba02222222222222222222222222222222222222222222222222222222222222222a02222222222222222222222222222222222222222222222222222222222222222
@@ -82,6 +79,7 @@ spec:
               cp /scripts/deploy-l1-contracts.sh /tmp/deploy-l1-contracts.sh
               chmod +x /tmp/deploy-l1-contracts.sh
               source /shared/config/service-addresses
+              {{- include "aztec-network.waitForEthereum" . | nindent 14 }}
 
               /tmp/deploy-l1-contracts.sh "{{ .Values.aztec.l1Salt }}" "{{ .Values.ethereum.chainId }}" "{{ join "," .Values.validator.validatorAddresses }}"
           volumeMounts:

--- a/spartan/aztec-network/templates/faucet.yaml
+++ b/spartan/aztec-network/templates/faucet.yaml
@@ -40,15 +40,7 @@ spec:
             - |
               source /shared/config/service-addresses
               cat /shared/config/service-addresses
-
-              echo "Awaiting ethereum node at ${ETHEREUM_HOST}"
-              until curl -s -X POST -H 'Content-Type: application/json' \
-                -d '{"jsonrpc":"2.0","method":"web3_clientVersion","params":[],"id":67}' \
-                ${ETHEREUM_HOST} | grep -q reth; do
-                echo "Waiting for Ethereum node ${ETHEREUM_HOST}..."
-                sleep 5
-              done
-              echo "Ethereum node is ready!"
+              {{- include "aztec-network.waitForEthereum" . | nindent 14 }}
           volumeMounts:
             - name: config
               mountPath: /shared/config

--- a/spartan/aztec-network/templates/prover-node.yaml
+++ b/spartan/aztec-network/templates/prover-node.yaml
@@ -46,13 +46,8 @@ spec:
             - -c
             - |
               source /shared/config/service-addresses
-              until curl -s -X POST -H 'Content-Type: application/json' \
-                -d '{"jsonrpc":"2.0","method":"eth_chainId","params":[],"id":67}' \
-                ${ETHEREUM_HOST} | grep 0x; do
-                echo "Waiting for Ethereum node ${ETHEREUM_HOST}..."
-                sleep 5
-              done
-              echo "Ethereum node is ready!"
+              cat /shared/config/service-addresses
+              {{- include "aztec-network.waitForEthereum" . | nindent 14 }}
 
               if [ "${PROVER_BROKER_ENABLED}" == "false" ]; then
                 until curl -s -X POST ${PROVER_BROKER_HOST}/status; do

--- a/spartan/aztec-network/templates/validator.yaml
+++ b/spartan/aztec-network/templates/validator.yaml
@@ -49,15 +49,7 @@ spec:
             - |
               source /shared/config/service-addresses
               cat /shared/config/service-addresses
-              # First check ethereum node
-              until curl -s -X POST -H 'Content-Type: application/json' \
-                -d '{"jsonrpc":"2.0","method":"eth_chainId","params":[],"id":67}' \
-                $ETHEREUM_HOST | grep 0x; do
-                echo "Waiting for Ethereum node ${ETHEREUM_HOST}..."
-                sleep 5
-              done
-              echo "Ethereum node is ready!"
-
+              {{- include "aztec-network.waitForEthereum" . | nindent 14 }}
 
               if [ "{{ .Values.validator.dynamicBootNode }}" = "true" ]; then
                 echo "{{ include "aztec-network.pxeUrl" . }}" > /shared/pxe/pxe_url


### PR DESCRIPTION
Should fix some flake in kind network smoke.

Key was the following logs I found in a failing run:

```
spartan-aztec-network-boot-node-0 deploy-create2-deployer Error: 
spartan-aztec-network-boot-node-0 deploy-create2-deployer error sending request for url (http://spartan-aztec-network-ethereum.smoke:8545/)
spartan-aztec-network-boot-node-0 deploy-create2-deployer 
spartan-aztec-network-boot-node-0 deploy-create2-deployer Context:
spartan-aztec-network-boot-node-0 deploy-create2-deployer - Error #0: error sending request for url (http://spartan-aztec-network-ethereum.smoke:8545/)
spartan-aztec-network-boot-node-0 deploy-create2-deployer - Error #1: client error (Connect)
spartan-aztec-network-boot-node-0 deploy-create2-deployer - Error #2: dns error: failed to lookup address information: Name does not resolve
spartan-aztec-network-boot-node-0 deploy-create2-deployer - Error #3: failed to lookup address information: Name does not resolve
```