### PR TITLE
fix: empty merkle tree calculator returns invalid tree

### DIFF
--- a/yarn-project/circuits.js/src/merkle/merkle_tree_calculator.test.ts
+++ b/yarn-project/circuits.js/src/merkle/merkle_tree_calculator.test.ts
@@ -37,4 +37,10 @@ describe('merkle tree root calculator', () => {
     expect(result.nodes.length).toEqual(31);
     expect(result.root).toEqual(expectedRoot);
   });
+
+  it('should correctly handle empty leaf array', () => {
+    const calculator = new MerkleTreeCalculator(4);
+    const expected = calculator.computeTree();
+    expect(expected.root).toEqual(calculator.computeTreeRoot());
+  });
 });

--- a/yarn-project/circuits.js/src/merkle/merkle_tree_calculator.ts
+++ b/yarn-project/circuits.js/src/merkle/merkle_tree_calculator.ts
@@ -23,8 +23,7 @@ export class MerkleTreeCalculator {
 
   computeTree(leaves: Buffer[] = []): MerkleTree {
     if (leaves.length === 0) {
-      // TODO(#4425): We should be returning a number of nodes that matches the tree height.
-      return new MerkleTree(this.height, [this.zeroHashes[this.zeroHashes.length - 1]]);
+      leaves = new Array(2 ** this.height).fill(this.zeroHashes[0]);
     }
 
     let result = leaves.slice();


### PR DESCRIPTION
Fixes #4425

The merkle tree calculator returns an invalid tree if it is not provided any nodes. This fixes that
