### PR TITLE
chore: mark contracts as pub

### DIFF
--- a/noir-projects/noir-contracts/bootstrap.sh
+++ b/noir-projects/noir-contracts/bootstrap.sh
@@ -101,7 +101,7 @@ function compile {
 
   local contract=$1
   # Calculate filename because nargo...
-  contract_name=$(cat contracts/$1/src/main.nr | awk '/^contract / { print $2 }')
+  contract_name=$(cat contracts/$1/src/main.nr | awk '/^contract / { print $2 } /^pub contract / { print $3 }')
   local filename="$contract-$contract_name.json"
   local json_path="./target/$filename"
   contract_hash="$(cache_content_hash \

--- a/noir-projects/noir-contracts/contracts/amm_contract/src/main.nr
+++ b/noir-projects/noir-contracts/contracts/amm_contract/src/main.nr
@@ -33,7 +33,7 @@ use dep::aztec::macros::aztec;
 ///   contract can trigger a reentrant call. This eliminates the following attack vector:
 ///   `AMM.private_fn --> AMM.public_fn --> ExternalContract.fn --> AMM.public_fn`.
 #[aztec]
-contract AMM {
+pub contract AMM {
     use crate::{
         config::Config,
         lib::{get_amount_in, get_amount_out, get_amounts_on_remove, get_amounts_to_add},

--- a/noir-projects/noir-contracts/contracts/app_subscription_contract/src/main.nr
+++ b/noir-projects/noir-contracts/contracts/app_subscription_contract/src/main.nr
@@ -4,7 +4,7 @@ mod dapp_payload;
 use dep::aztec::macros::aztec;
 
 #[aztec]
-contract AppSubscription {
+pub contract AppSubscription {
     use crate::{dapp_payload::DAppPayload, subscription_note::SubscriptionNote};
 
     use authwit::auth::assert_current_call_valid_authwit;

--- a/noir-projects/noir-contracts/contracts/auth_contract/src/main.nr
+++ b/noir-projects/noir-contracts/contracts/auth_contract/src/main.nr
@@ -5,7 +5,7 @@ mod test;
 use dep::aztec::macros::aztec;
 
 #[aztec]
-contract Auth {
+pub contract Auth {
     use dep::aztec::{
         macros::{functions::{initializer, private, public, view}, storage::storage},
         protocol_types::address::AztecAddress,

--- a/noir-projects/noir-contracts/contracts/auth_registry_contract/src/main.nr
+++ b/noir-projects/noir-contracts/contracts/auth_registry_contract/src/main.nr
@@ -1,7 +1,7 @@
 use dep::aztec::macros::aztec;
 
 #[aztec]
-contract AuthRegistry {
+pub contract AuthRegistry {
     use dep::authwit::auth::{
         assert_current_call_valid_authwit, compute_authwit_message_hash, IS_VALID_SELECTOR,
     };

--- a/noir-projects/noir-contracts/contracts/auth_wit_test_contract/src/main.nr
+++ b/noir-projects/noir-contracts/contracts/auth_wit_test_contract/src/main.nr
@@ -1,7 +1,7 @@
 use dep::aztec::macros::aztec;
 
 #[aztec]
-contract AuthWitTest {
+pub contract AuthWitTest {
     use dep::aztec::{macros::functions::{private, public}, protocol_types::address::AztecAddress};
 
     use dep::authwit::auth::{

--- a/noir-projects/noir-contracts/contracts/avm_initializer_test_contract/src/main.nr
+++ b/noir-projects/noir-contracts/contracts/avm_initializer_test_contract/src/main.nr
@@ -1,7 +1,7 @@
 use dep::aztec::macros::aztec;
 
 #[aztec]
-contract AvmInitializerTest {
+pub contract AvmInitializerTest {
     // Libs
     use dep::aztec::{
         macros::{functions::{initializer, public}, storage::storage},

--- a/noir-projects/noir-contracts/contracts/avm_test_contract/src/main.nr
+++ b/noir-projects/noir-contracts/contracts/avm_test_contract/src/main.nr
@@ -2,7 +2,7 @@ mod note;
 use dep::aztec::macros::aztec;
 
 #[aztec]
-contract AvmTest {
+pub contract AvmTest {
     use crate::note::Note;
 
     global big_field_128_bits: Field = 0x001234567890abcdef1234567890abcdef;

--- a/noir-projects/noir-contracts/contracts/benchmarking_contract/src/main.nr
+++ b/noir-projects/noir-contracts/contracts/benchmarking_contract/src/main.nr
@@ -6,7 +6,7 @@
 use dep::aztec::macros::aztec;
 
 #[aztec]
-contract Benchmarking {
+pub contract Benchmarking {
     use dep::aztec::prelude::{AztecAddress, Map, NoteGetterOptions, PrivateSet, PublicMutable};
     use dep::value_note::{utils::increment, value_note::ValueNote};
 

--- a/noir-projects/noir-contracts/contracts/card_game_contract/src/main.nr
+++ b/noir-projects/noir-contracts/contracts/card_game_contract/src/main.nr
@@ -4,7 +4,7 @@ mod game;
 use dep::aztec::macros::aztec;
 
 #[aztec]
-contract CardGame {
+pub contract CardGame {
     use dep::aztec::{hash::pedersen_hash, state_vars::{Map, PublicMutable}};
     use dep::aztec::protocol_types::address::AztecAddress;
 

--- a/noir-projects/noir-contracts/contracts/child_contract/src/main.nr
+++ b/noir-projects/noir-contracts/contracts/child_contract/src/main.nr
@@ -2,7 +2,7 @@
 use dep::aztec::macros::aztec;
 
 #[aztec]
-contract Child {
+pub contract Child {
     use dep::aztec::prelude::{AztecAddress, Map, PrivateSet, PublicMutable};
 
     use dep::aztec::{

--- a/noir-projects/noir-contracts/contracts/claim_contract/src/main.nr
+++ b/noir-projects/noir-contracts/contracts/claim_contract/src/main.nr
@@ -1,7 +1,7 @@
 use dep::aztec::macros::aztec;
 
 #[aztec]
-contract Claim {
+pub contract Claim {
     use dep::aztec::{
         macros::{functions::{initializer, private, public}, storage::storage},
         note::utils::compute_note_hash_for_nullify,

--- a/noir-projects/noir-contracts/contracts/contract_class_registerer_contract/src/main.nr
+++ b/noir-projects/noir-contracts/contracts/contract_class_registerer_contract/src/main.nr
@@ -4,7 +4,7 @@ mod capsule;
 use dep::aztec::macros::aztec;
 
 #[aztec]
-contract ContractClassRegisterer {
+pub contract ContractClassRegisterer {
     use dep::aztec::protocol_types::{
         abis::log_hash::LogHash,
         constants::{

--- a/noir-projects/noir-contracts/contracts/contract_instance_deployer_contract/src/main.nr
+++ b/noir-projects/noir-contracts/contracts/contract_instance_deployer_contract/src/main.nr
@@ -1,7 +1,7 @@
 use dep::aztec::macros::aztec;
 
 #[aztec]
-contract ContractInstanceDeployer {
+pub contract ContractInstanceDeployer {
     use dep::aztec::macros::{events::event, functions::private};
     use dep::aztec::protocol_types::{
         address::{AztecAddress, PartialAddress},

--- a/noir-projects/noir-contracts/contracts/counter_contract/src/main.nr
+++ b/noir-projects/noir-contracts/contracts/counter_contract/src/main.nr
@@ -3,7 +3,7 @@ use dep::aztec::macros::aztec;
 mod test;
 
 #[aztec]
-contract Counter {
+pub contract Counter {
     // docs:end:setup
     // docs:start:imports
     use aztec::macros::{functions::{initializer, private}, storage::storage};

--- a/noir-projects/noir-contracts/contracts/crowdfunding_contract/src/main.nr
+++ b/noir-projects/noir-contracts/contracts/crowdfunding_contract/src/main.nr
@@ -2,7 +2,7 @@
 use dep::aztec::macros::aztec;
 
 #[aztec]
-contract Crowdfunding {
+pub contract Crowdfunding {
     // docs:end:empty-contract
 
     // docs:start:all-deps

--- a/noir-projects/noir-contracts/contracts/docs_example_contract/src/main.nr
+++ b/noir-projects/noir-contracts/contracts/docs_example_contract/src/main.nr
@@ -14,7 +14,7 @@ mod types;
 use dep::aztec::macros::aztec;
 
 #[aztec]
-contract DocsExample {
+pub contract DocsExample {
     // how to import dependencies defined in your workspace
     use dep::aztec::{
         encrypted_logs::log_assembly_strategies::default_aes128::note::encode_and_encrypt_note,

--- a/noir-projects/noir-contracts/contracts/easy_private_token_contract/src/main.nr
+++ b/noir-projects/noir-contracts/contracts/easy_private_token_contract/src/main.nr
@@ -2,7 +2,7 @@
 use dep::aztec::macros::aztec;
 
 #[aztec]
-contract EasyPrivateToken {
+pub contract EasyPrivateToken {
     use dep::aztec::macros::{functions::{initializer, private}, storage::storage};
     use dep::aztec::prelude::{AztecAddress, Map};
     use dep::easy_private_state::EasyPrivateUint;

--- a/noir-projects/noir-contracts/contracts/easy_private_voting_contract/src/main.nr
+++ b/noir-projects/noir-contracts/contracts/easy_private_voting_contract/src/main.nr
@@ -3,7 +3,7 @@ mod test;
 use dep::aztec::macros::aztec;
 
 #[aztec]
-contract EasyPrivateVoting {
+pub contract EasyPrivateVoting {
     // docs:end:declaration
     // docs:start:imports
     use dep::aztec::{

--- a/noir-projects/noir-contracts/contracts/ecdsa_k_account_contract/src/main.nr
+++ b/noir-projects/noir-contracts/contracts/ecdsa_k_account_contract/src/main.nr
@@ -3,7 +3,7 @@
 use dep::aztec::macros::aztec;
 
 #[aztec]
-contract EcdsaKAccount {
+pub contract EcdsaKAccount {
     use dep::aztec::{
         encrypted_logs::log_assembly_strategies::default_aes128::note::encode_and_encrypt_note,
         macros::{functions::{initializer, noinitcheck, private, view}, storage::storage},

--- a/noir-projects/noir-contracts/contracts/ecdsa_r_account_contract/src/main.nr
+++ b/noir-projects/noir-contracts/contracts/ecdsa_r_account_contract/src/main.nr
@@ -2,7 +2,7 @@
 use dep::aztec::macros::aztec;
 
 #[aztec]
-contract EcdsaRAccount {
+pub contract EcdsaRAccount {
     use dep::aztec::{
         encrypted_logs::log_assembly_strategies::default_aes128::note::encode_and_encrypt_note,
         macros::{functions::{initializer, noinitcheck, private, view}, storage::storage},

--- a/noir-projects/noir-contracts/contracts/escrow_contract/src/main.nr
+++ b/noir-projects/noir-contracts/contracts/escrow_contract/src/main.nr
@@ -2,7 +2,7 @@
 use dep::aztec::macros::aztec;
 
 #[aztec]
-contract Escrow {
+pub contract Escrow {
     use dep::aztec::{
         encrypted_logs::log_assembly_strategies::default_aes128::note::encode_and_encrypt_note,
         macros::{functions::{initializer, private}, storage::storage},

--- a/noir-projects/noir-contracts/contracts/fee_juice_contract/src/main.nr
+++ b/noir-projects/noir-contracts/contracts/fee_juice_contract/src/main.nr
@@ -3,7 +3,7 @@ mod lib;
 use dep::aztec::macros::aztec;
 
 #[aztec]
-contract FeeJuice {
+pub contract FeeJuice {
     use dep::aztec::{
         macros::{functions::{internal, private, public, view}, storage::storage},
         protocol_types::address::{AztecAddress, EthAddress},

--- a/noir-projects/noir-contracts/contracts/fpc_contract/src/main.nr
+++ b/noir-projects/noir-contracts/contracts/fpc_contract/src/main.nr
@@ -9,7 +9,7 @@ use dep::aztec::macros::aztec;
 /// Accepted asset funds sent by the users to this contract stay in this contract and later on can
 /// be pulled by the admin using the `pull_funds` function.
 #[aztec]
-contract FPC {
+pub contract FPC {
     use crate::config::Config;
     use dep::aztec::{
         macros::{functions::{initializer, internal, private, public}, storage::storage},

--- a/noir-projects/noir-contracts/contracts/import_test_contract/src/main.nr
+++ b/noir-projects/noir-contracts/contracts/import_test_contract/src/main.nr
@@ -3,7 +3,7 @@
 use dep::aztec::macros::aztec;
 
 #[aztec]
-contract ImportTest {
+pub contract ImportTest {
     use dep::aztec::prelude::AztecAddress;
 
     use dep::test::Test::{self, DeepStruct, DummyNote};

--- a/noir-projects/noir-contracts/contracts/inclusion_proofs_contract/src/main.nr
+++ b/noir-projects/noir-contracts/contracts/inclusion_proofs_contract/src/main.nr
@@ -2,7 +2,7 @@
 use dep::aztec::macros::aztec;
 
 #[aztec]
-contract InclusionProofs {
+pub contract InclusionProofs {
     use dep::aztec::encrypted_logs::log_assembly_strategies::default_aes128::note::encode_and_encrypt_note;
     use dep::aztec::prelude::{AztecAddress, Map, NoteGetterOptions, PrivateSet, PublicMutable};
 

--- a/noir-projects/noir-contracts/contracts/lending_contract/src/main.nr
+++ b/noir-projects/noir-contracts/contracts/lending_contract/src/main.nr
@@ -13,7 +13,7 @@ mod helpers;
 use dep::aztec::macros::aztec;
 
 #[aztec]
-contract Lending {
+pub contract Lending {
     use dep::aztec::prelude::{AztecAddress, Map, PublicMutable};
 
     use crate::asset::Asset;

--- a/noir-projects/noir-contracts/contracts/multi_call_entrypoint_contract/src/main.nr
+++ b/noir-projects/noir-contracts/contracts/multi_call_entrypoint_contract/src/main.nr
@@ -3,7 +3,7 @@
 use dep::aztec::macros::aztec;
 
 #[aztec]
-contract MultiCallEntrypoint {
+pub contract MultiCallEntrypoint {
     use dep::authwit::entrypoint::app::AppPayload;
     use dep::aztec::macros::functions::private;
 

--- a/noir-projects/noir-contracts/contracts/nft_contract/src/main.nr
+++ b/noir-projects/noir-contracts/contracts/nft_contract/src/main.nr
@@ -7,7 +7,7 @@ use dep::aztec::macros::aztec;
 // Minimal NFT implementation with `AuthWit` support that allows minting in public-only and transfers in both public
 // and private.
 #[aztec]
-contract NFT {
+pub contract NFT {
     use crate::types::nft_note::NFTNote;
     use dep::authwit::auth::{
         assert_current_call_valid_authwit, assert_current_call_valid_authwit_public,

--- a/noir-projects/noir-contracts/contracts/parent_contract/src/main.nr
+++ b/noir-projects/noir-contracts/contracts/parent_contract/src/main.nr
@@ -2,7 +2,7 @@
 use dep::aztec::macros::aztec;
 
 #[aztec]
-contract Parent {
+pub contract Parent {
     use dep::aztec::{context::gas::GasOpts, macros::functions::{private, public}};
     use dep::aztec::prelude::{AztecAddress, FunctionSelector};
     // Private function to call another private function in the target_contract using the provided selector

--- a/noir-projects/noir-contracts/contracts/pending_note_hashes_contract/src/main.nr
+++ b/noir-projects/noir-contracts/contracts/pending_note_hashes_contract/src/main.nr
@@ -5,7 +5,7 @@
 use dep::aztec::macros::aztec;
 
 #[aztec]
-contract PendingNoteHashes {
+pub contract PendingNoteHashes {
     // Libs
     use dep::aztec::encrypted_logs::log_assembly_strategies::default_aes128::note::encode_and_encrypt_note;
     use dep::aztec::macros::{functions::private, storage::storage};

--- a/noir-projects/noir-contracts/contracts/price_feed_contract/src/main.nr
+++ b/noir-projects/noir-contracts/contracts/price_feed_contract/src/main.nr
@@ -3,7 +3,7 @@ mod asset;
 use dep::aztec::macros::aztec;
 
 #[aztec]
-contract PriceFeed {
+pub contract PriceFeed {
     use crate::asset::Asset;
     use dep::aztec::prelude::{Map, PublicMutable};
 

--- a/noir-projects/noir-contracts/contracts/router_contract/src/main.nr
+++ b/noir-projects/noir-contracts/contracts/router_contract/src/main.nr
@@ -7,7 +7,7 @@ use dep::aztec::macros::aztec;
 /// call. This is achieved by having a private function on this contract that enques the public call and hence
 /// the `msg_sender` in the public call is the address of this contract.
 #[aztec]
-contract Router {
+pub contract Router {
     use aztec::{macros::functions::{internal, private, public, view}, utils::comparison::compare};
 
     // docs:start:check_timestamp

--- a/noir-projects/noir-contracts/contracts/schnorr_account_contract/src/main.nr
+++ b/noir-projects/noir-contracts/contracts/schnorr_account_contract/src/main.nr
@@ -5,7 +5,7 @@ mod public_key_note;
 use dep::aztec::macros::aztec;
 
 #[aztec]
-contract SchnorrAccount {
+pub contract SchnorrAccount {
     use dep::authwit::{
         account::AccountActions,
         auth::{compute_authwit_message_hash, compute_authwit_nullifier},

--- a/noir-projects/noir-contracts/contracts/schnorr_hardcoded_account_contract/src/main.nr
+++ b/noir-projects/noir-contracts/contracts/schnorr_hardcoded_account_contract/src/main.nr
@@ -3,7 +3,7 @@
 use dep::aztec::macros::aztec;
 
 #[aztec]
-contract SchnorrHardcodedAccount {
+pub contract SchnorrHardcodedAccount {
     use dep::authwit::{
         account::AccountActions,
         auth_witness::get_auth_witness,

--- a/noir-projects/noir-contracts/contracts/schnorr_single_key_account_contract/src/main.nr
+++ b/noir-projects/noir-contracts/contracts/schnorr_single_key_account_contract/src/main.nr
@@ -4,7 +4,7 @@ mod auth_oracle;
 use dep::aztec::macros::aztec;
 
 #[aztec]
-contract SchnorrSingleKeyAccount {
+pub contract SchnorrSingleKeyAccount {
     use dep::aztec::prelude::PrivateContext;
 
     use dep::authwit::{account::AccountActions, entrypoint::{app::AppPayload, fee::FeePayload}};

--- a/noir-projects/noir-contracts/contracts/spam_contract/src/main.nr
+++ b/noir-projects/noir-contracts/contracts/spam_contract/src/main.nr
@@ -4,7 +4,7 @@ use dep::aztec::macros::aztec;
 
 // A contract used for testing a random hodgepodge of small features from simulator and end-to-end tests.
 #[aztec]
-contract Spam {
+pub contract Spam {
 
     use dep::aztec::{
         encrypted_logs::log_assembly_strategies::default_aes128::note::encode_and_encrypt_note_unconstrained,

--- a/noir-projects/noir-contracts/contracts/stateful_test_contract/src/main.nr
+++ b/noir-projects/noir-contracts/contracts/stateful_test_contract/src/main.nr
@@ -2,7 +2,7 @@
 use dep::aztec::macros::aztec;
 
 #[aztec]
-contract StatefulTest {
+pub contract StatefulTest {
     use dep::aztec::macros::{
         functions::{
             initialization_utils::assert_is_initialized_private, initializer, noinitcheck, private,

--- a/noir-projects/noir-contracts/contracts/static_child_contract/src/main.nr
+++ b/noir-projects/noir-contracts/contracts/static_child_contract/src/main.nr
@@ -2,7 +2,7 @@
 use dep::aztec::macros::aztec;
 
 #[aztec]
-contract StaticChild {
+pub contract StaticChild {
     use dep::aztec::prelude::{AztecAddress, PrivateSet, PublicMutable};
 
     use dep::aztec::{

--- a/noir-projects/noir-contracts/contracts/static_parent_contract/src/main.nr
+++ b/noir-projects/noir-contracts/contracts/static_parent_contract/src/main.nr
@@ -2,7 +2,7 @@
 use dep::aztec::macros::aztec;
 
 #[aztec]
-contract StaticParent {
+pub contract StaticParent {
     use dep::aztec::{context::gas::GasOpts, macros::functions::{private, public, view}};
     use dep::aztec::prelude::{AztecAddress, FunctionSelector};
     use dep::static_child_contract::StaticChild;

--- a/noir-projects/noir-contracts/contracts/test_contract/src/main.nr
+++ b/noir-projects/noir-contracts/contracts/test_contract/src/main.nr
@@ -5,7 +5,7 @@ mod test_note;
 use dep::aztec::macros::aztec;
 
 #[aztec]
-contract Test {
+pub contract Test {
     // Note: If you import a new kind of note you will most likely need to update the test_note_type_id test
     // as the note type ids of current notes might have changed.
 

--- a/noir-projects/noir-contracts/contracts/test_log_contract/src/main.nr
+++ b/noir-projects/noir-contracts/contracts/test_log_contract/src/main.nr
@@ -1,7 +1,7 @@
 use dep::aztec::macros::aztec;
 
 #[aztec]
-contract TestLog {
+pub contract TestLog {
     use dep::aztec::encrypted_logs::log_assembly_strategies::default_aes128::event::encode_and_encrypt_event;
     use dep::aztec::macros::{events::event, functions::{private, public}, storage::storage};
     use dep::aztec::prelude::PrivateSet;

--- a/noir-projects/noir-contracts/contracts/token_blacklist_contract/src/main.nr
+++ b/noir-projects/noir-contracts/contracts/token_blacklist_contract/src/main.nr
@@ -11,7 +11,7 @@ mod types;
 use dep::aztec::macros::aztec;
 
 #[aztec]
-contract TokenBlacklist {
+pub contract TokenBlacklist {
     // Libs
     use dep::aztec::{
         encrypted_logs::log_assembly_strategies::default_aes128::note::{

--- a/noir-projects/noir-contracts/contracts/token_bridge_contract/src/main.nr
+++ b/noir-projects/noir-contracts/contracts/token_bridge_contract/src/main.nr
@@ -8,7 +8,7 @@
 use dep::aztec::macros::aztec;
 
 #[aztec]
-contract TokenBridge {
+pub contract TokenBridge {
     use dep::aztec::prelude::{AztecAddress, EthAddress, PublicImmutable};
 
     use dep::token_portal_content_hash_lib::{

--- a/noir-projects/noir-contracts/contracts/token_contract/src/main.nr
+++ b/noir-projects/noir-contracts/contracts/token_contract/src/main.nr
@@ -12,7 +12,7 @@ use dep::aztec::macros::aztec;
 // To be read as `caller` calls function at `contract` defined by `selector` with `args`
 // Including a nonce in the message hash ensures that the message can only be used once.
 #[aztec]
-contract Token {
+pub contract Token {
     // Libs
     use std::meta::derive;
 

--- a/noir-projects/noir-contracts/contracts/uniswap_contract/src/main.nr
+++ b/noir-projects/noir-contracts/contracts/uniswap_contract/src/main.nr
@@ -7,7 +7,7 @@ mod util;
 use dep::aztec::macros::aztec;
 
 #[aztec]
-contract Uniswap {
+pub contract Uniswap {
     use dep::aztec::prelude::{AztecAddress, EthAddress, FunctionSelector, PublicImmutable};
 
     use dep::authwit::auth::{


### PR DESCRIPTION
This PR enables contracts to be imported from other contracts without warnings / future errors of trying to import from a private module. 

Metaprogramming currently does not and most likely will not support changing the visibility of modules that they describe hence why we need to modify each and every contract with `pub`.