### PR TITLE
chore: retry deploys

### DIFF
--- a/spartan/aztec-network/templates/boot-node.yaml
+++ b/spartan/aztec-network/templates/boot-node.yaml
@@ -58,6 +58,7 @@ spec:
             - /bin/sh
             - -c
             - |
+              set -eux
               source /shared/config/service-addresses
               # it is possible that even though we asserted this above, the DNS resolver of *this* pod
               # is not yet ready to resolve the ethereum host.


### PR DESCRIPTION
sometimes this container fails, so have it exit with failure and thus retry.

Note, we won't need to make this call at all soon because this contract will be deployed in genesis in our test setup.