### PR TITLE
chore: Add circuit input checks to bootstrap.sh

### DIFF
--- a/noir-projects/noir-protocol-circuits/bootstrap.sh
+++ b/noir-projects/noir-protocol-circuits/bootstrap.sh
@@ -138,6 +138,9 @@ function build {
   return $code
 }
 
+# We don't blindly execute all circuits as some will have no `Prover.toml`.
+CIRCUITS_TO_EXECUTE="private-kernel-init private-kernel-inner private-kernel-reset private-kernel-tail-to-public private-kernel-tail rollup-base-private rollup-base-public rollup-block-root rollup-block-root-single-tx rollup-block-merge rollup-merge rollup-root"
+
 function test {
   set -eu
   name=$(basename "$PWD")
@@ -147,8 +150,7 @@ function test {
   RAYON_NUM_THREADS= $NARGO test --skip-brillig-constraints-check
   cache_upload_flag $name-tests-$CIRCUITS_HASH
 
-  circuits="private-kernel-init private-kernel-inner private-kernel-reset private-kernel-tail-to-public private-kernel-tail rollup-base-private rollup-base-public rollup-block-root rollup-block-merge rollup-merge rollup-root"
-  for circuit in $circuits; do
+  for circuit in $CIRCUITS_TO_EXECUTE; do
     $NARGO execute --program-dir noir-projects/noir-protocol-circuits/crates/$circuit --silence-warnings --skip-brillig-constraints-check
   done
 }
@@ -176,8 +178,7 @@ case "$CMD" in
     $NARGO test --list-tests --silence-warnings | while read -r package test; do
       echo "noir-projects/scripts/run_test.sh noir-protocol-circuits $package $test"
     done
-    circuits="private-kernel-init private-kernel-inner private-kernel-reset private-kernel-tail-to-public private-kernel-tail rollup-base-private rollup-base-public rollup-block-root rollup-block-merge rollup-merge rollup-root"
-    for circuit in $circuits; do
+    for circuit in $CIRCUITS_TO_EXECUTE; do
       echo "$NARGO execute --program-dir noir-projects/noir-protocol-circuits/crates/$circuit --silence-warnings --skip-brillig-constraints-check"
     done
     ;;

--- a/noir-projects/noir-protocol-circuits/bootstrap.sh
+++ b/noir-projects/noir-protocol-circuits/bootstrap.sh
@@ -139,7 +139,7 @@ function build {
 }
 
 # We don't blindly execute all circuits as some will have no `Prover.toml`.
-CIRCUITS_TO_EXECUTE="private-kernel-init private-kernel-inner private-kernel-reset private-kernel-tail-to-public private-kernel-tail rollup-base-private rollup-base-public rollup-block-root rollup-block-root-single-tx rollup-block-merge rollup-merge rollup-root"
+CIRCUITS_TO_EXECUTE="private-kernel-init private-kernel-inner private-kernel-reset private-kernel-tail-to-public private-kernel-tail rollup-base-private rollup-base-public rollup-block-root rollup-block-merge rollup-merge rollup-root"
 
 function test {
   set -eu

--- a/noir-projects/noir-protocol-circuits/bootstrap.sh
+++ b/noir-projects/noir-protocol-circuits/bootstrap.sh
@@ -146,6 +146,11 @@ function test {
 
   RAYON_NUM_THREADS= $NARGO test --skip-brillig-constraints-check
   cache_upload_flag $name-tests-$CIRCUITS_HASH
+
+  circuits="private-kernel-init private-kernel-inner private-kernel-reset private-kernel-tail-to-public private-kernel-tail rollup-base-private rollup-base-public rollup-block-root rollup-block-merge rollup-merge rollup-root"
+  for circuit in $circuits; do
+    $NARGO execute --program-dir noir-projects/noir-protocol-circuits/crates/$circuit --silence-warnings --skip-brillig-constraints-check
+  done
 }
 
 export -f compile test build
@@ -170,6 +175,10 @@ case "$CMD" in
   "test-cmds")
     $NARGO test --list-tests --silence-warnings | while read -r package test; do
       echo "noir-projects/scripts/run_test.sh noir-protocol-circuits $package $test"
+    done
+    circuits="private-kernel-init private-kernel-inner private-kernel-reset private-kernel-tail-to-public private-kernel-tail rollup-base-private rollup-base-public rollup-block-root rollup-block-merge rollup-merge rollup-root"
+    for circuit in $circuits; do
+      echo "$NARGO execute --program-dir noir-projects/noir-protocol-circuits/crates/$circuit --silence-warnings --skip-brillig-constraints-check"
     done
     ;;
   "ci")


### PR DESCRIPTION
This pulls across the tests which are in earthly so they exist in bootstrap.sh as well

https://github.com/AztecProtocol/aztec-packages/blob/642bce68a3e0eea29fa3ebb8c11cf4af02fe992b/noir-projects/Earthfile#L13-L17

There's a small amount of duplication here as it seems like `bootstrap test` doesn't make use of `bootstrap test-cmds` in this package. I'm not sure what's up so I'm doing light touches.