### PR TITLE
fix: Faster polling times for archiver and sequencer

### DIFF
--- a/yarn-project/archiver/src/archiver/config.ts
+++ b/yarn-project/archiver/src/archiver/config.ts
@@ -55,7 +55,7 @@ export const archiverConfigMappings: ConfigMappingsType<ArchiverConfig> = {
   archiverPollingIntervalMS: {
     env: 'ARCHIVER_POLLING_INTERVAL_MS',
     description: 'The polling interval in ms for retrieving new L2 blocks and encrypted logs.',
-    ...numberConfigHelper(1_000),
+    ...numberConfigHelper(500),
   },
   archiverBatchSize: {
     env: 'ARCHIVER_BATCH_SIZE',

--- a/yarn-project/end-to-end/src/e2e_block_building.test.ts
+++ b/yarn-project/end-to-end/src/e2e_block_building.test.ts
@@ -78,7 +78,12 @@ describe('e2e_block_building', () => {
         sequencer: sequencerClient,
         dateProvider,
         cheatCodes,
-      } = await setup(2));
+      } = await setup(2, {
+        archiverPollingIntervalMS: 200,
+        transactionPollingIntervalMS: 200,
+        worldStateBlockCheckIntervalMS: 200,
+        blockCheckIntervalMS: 200,
+      }));
       sequencer = sequencerClient! as TestSequencerClient;
     });
 

--- a/yarn-project/p2p/src/client/factory.ts
+++ b/yarn-project/p2p/src/client/factory.ts
@@ -84,13 +84,5 @@ export const createP2PClient = async <T extends P2PClientType>(
     logger.verbose('P2P is disabled. Using dummy P2P service');
     p2pService = new DummyP2PService();
   }
-  return new P2PClient(
-    clientType,
-    store,
-    l2BlockSource,
-    mempools,
-    p2pService,
-    config.keepProvenTxsInPoolFor,
-    telemetry,
-  );
+  return new P2PClient(clientType, store, l2BlockSource, mempools, p2pService, config, telemetry);
 };

--- a/yarn-project/p2p/src/client/p2p_client.test.ts
+++ b/yarn-project/p2p/src/client/p2p_client.test.ts
@@ -49,7 +49,7 @@ describe('In-Memory P2P Client', () => {
     };
 
     kvStore = openTmpStore();
-    client = new P2PClient(P2PClientType.Full, kvStore, blockSource, mempools, p2pService, 0);
+    client = new P2PClient(P2PClientType.Full, kvStore, blockSource, mempools, p2pService);
   });
 
   const advanceToProvenBlock = async (getProvenBlockNumber: number, provenEpochNumber = getProvenBlockNumber) => {
@@ -108,7 +108,7 @@ describe('In-Memory P2P Client', () => {
     await client.start();
     await client.stop();
 
-    const client2 = new P2PClient(P2PClientType.Full, kvStore, blockSource, mempools, p2pService, 0);
+    const client2 = new P2PClient(P2PClientType.Full, kvStore, blockSource, mempools, p2pService);
     expect(client2.getSyncedLatestBlockNum()).toEqual(client.getSyncedLatestBlockNum());
   });
 
@@ -123,7 +123,9 @@ describe('In-Memory P2P Client', () => {
   });
 
   it('deletes txs after waiting the set number of blocks', async () => {
-    client = new P2PClient(P2PClientType.Full, kvStore, blockSource, mempools, p2pService, 10);
+    client = new P2PClient(P2PClientType.Full, kvStore, blockSource, mempools, p2pService, {
+      keepProvenTxsInPoolFor: 10,
+    });
     blockSource.setProvenBlockNumber(0);
     await client.start();
     expect(txPool.deleteTxs).not.toHaveBeenCalled();
@@ -140,7 +142,7 @@ describe('In-Memory P2P Client', () => {
   });
 
   it('stores and returns epoch proof quotes', async () => {
-    client = new P2PClient(P2PClientType.Full, kvStore, blockSource, mempools, p2pService, 0);
+    client = new P2PClient(P2PClientType.Full, kvStore, blockSource, mempools, p2pService);
 
     blockSource.setProvenEpochNumber(2);
     await client.start();
@@ -172,7 +174,7 @@ describe('In-Memory P2P Client', () => {
 
   // TODO(#10737) flake cc Maddiaa0
   it.skip('deletes expired proof quotes', async () => {
-    client = new P2PClient(P2PClientType.Full, kvStore, blockSource, mempools, p2pService, 0);
+    client = new P2PClient(P2PClientType.Full, kvStore, blockSource, mempools, p2pService);
 
     blockSource.setProvenEpochNumber(1);
     blockSource.setProvenBlockNumber(1);
@@ -236,7 +238,9 @@ describe('In-Memory P2P Client', () => {
     });
 
     it('deletes txs created from a pruned block', async () => {
-      client = new P2PClient(P2PClientType.Full, kvStore, blockSource, mempools, p2pService, 10);
+      client = new P2PClient(P2PClientType.Full, kvStore, blockSource, mempools, p2pService, {
+        keepProvenTxsInPoolFor: 10,
+      });
       blockSource.setProvenBlockNumber(0);
       await client.start();
 
@@ -258,7 +262,9 @@ describe('In-Memory P2P Client', () => {
     });
 
     it('moves mined and valid txs back to the pending set', async () => {
-      client = new P2PClient(P2PClientType.Full, kvStore, blockSource, mempools, p2pService, 10);
+      client = new P2PClient(P2PClientType.Full, kvStore, blockSource, mempools, p2pService, {
+        keepProvenTxsInPoolFor: 10,
+      });
       blockSource.setProvenBlockNumber(0);
       await client.start();
 

--- a/yarn-project/p2p/src/client/p2p_client.ts
+++ b/yarn-project/p2p/src/client/p2p_client.ts
@@ -27,7 +27,7 @@ import {
 
 import { type ENR } from '@chainsafe/enr';
 
-import { getP2PConfigFromEnv } from '../config.js';
+import { type P2PConfig, getP2PDefaultConfig } from '../config.js';
 import { type AttestationPool } from '../mem_pools/attestation_pool/attestation_pool.js';
 import { type EpochProofQuotePool } from '../mem_pools/epoch_proof_quote_pool/epoch_proof_quote_pool.js';
 import { type MemPools } from '../mem_pools/interface.js';
@@ -209,6 +209,8 @@ export class P2PClient<T extends P2PClientType = P2PClientType.Full>
 
   /** How many slots to keep attestations for. */
   private keepAttestationsInPoolFor: number;
+  /** How many slots to keep proven txs for. */
+  private keepProvenTxsFor: number;
 
   private blockStream;
 
@@ -227,14 +229,17 @@ export class P2PClient<T extends P2PClientType = P2PClientType.Full>
     private l2BlockSource: L2BlockSource,
     mempools: MemPools<T>,
     private p2pService: P2PService,
-    private keepProvenTxsFor: number,
+    config: Partial<P2PConfig> = {},
     telemetry: TelemetryClient = getTelemetryClient(),
     private log = createLogger('p2p'),
   ) {
     super(telemetry, 'P2PClient');
 
-    const { blockCheckIntervalMS, blockRequestBatchSize, keepAttestationsInPoolFor } = getP2PConfigFromEnv();
-
+    const { keepProvenTxsInPoolFor, blockCheckIntervalMS, blockRequestBatchSize, keepAttestationsInPoolFor } = {
+      ...getP2PDefaultConfig(),
+      ...config,
+    };
+    this.keepProvenTxsFor = keepProvenTxsInPoolFor;
     this.keepAttestationsInPoolFor = keepAttestationsInPoolFor;
 
     const tracer = telemetry.getTracer('P2PL2BlockStream');

--- a/yarn-project/prover-node/src/prover-node.test.ts
+++ b/yarn-project/prover-node/src/prover-node.test.ts
@@ -384,7 +384,7 @@ describe('prover-node', () => {
         port,
       );
       const kvStore = openTmpStore();
-      return new P2PClient(P2PClientType.Prover, kvStore, l2BlockSource, mempools, libp2pService, 0);
+      return new P2PClient(P2PClientType.Prover, kvStore, l2BlockSource, mempools, libp2pService);
     };
 
     beforeEach(async () => {

--- a/yarn-project/sequencer-client/src/config.ts
+++ b/yarn-project/sequencer-client/src/config.ts
@@ -47,7 +47,7 @@ export const sequencerConfigMappings: ConfigMappingsType<SequencerConfig> = {
   transactionPollingIntervalMS: {
     env: 'SEQ_TX_POLLING_INTERVAL_MS',
     description: 'The number of ms to wait between polling for pending txs.',
-    ...numberConfigHelper(1_000),
+    ...numberConfigHelper(500),
   },
   maxTxsPerBlock: {
     env: 'SEQ_MAX_TX_PER_BLOCK',


### PR DESCRIPTION
When timetable is enforced, the combined polling times of the archiver and sequencer could add to just over 3s, causing the sequencer to miss its slot, since we require that block building starts within the first 3s. See [here](https://github.com/AztecProtocol/aztec-packages/actions/runs/12806915326/job/35707395434?pr=11256#step:3:956) for an example run on CI where this happened.

This PR changes the default polling from 1s to 500ms for archiver and sequencer, forces 200ms for the block-building e2e test that depends on the timetable, and updates the p2p client so it properly gets its config rather than extracting it from env directly.
