### PR TITLE
chore: Demote error closing forks to warn

### DIFF
--- a/yarn-project/sequencer-client/src/sequencer/sequencer.ts
+++ b/yarn-project/sequencer-client/src/sequencer/sequencer.ts
@@ -497,7 +497,8 @@ export class Sequencer {
           await publicProcessorFork.close();
           await orchestratorFork.close();
         } catch (err) {
-          this.log.error(`Error closing forks`, err);
+          // This can happen if the sequencer is stopped before we hit this timeout.
+          this.log.warn(`Error closing forks for block processing`, err);
         }
       }, 5000);
     }


### PR DESCRIPTION
This can happen if the sequencer is stopped right after block processing, as @alexghr pointed out. Demoting to warn.
