### PR TITLE
chore: remove warnings from types and rollup lib crates

### DIFF
--- a/noir-projects/noir-protocol-circuits/crates/rollup-lib/src/abis/block_root_or_block_merge_public_inputs.nr
+++ b/noir-projects/noir-protocol-circuits/crates/rollup-lib/src/abis/block_root_or_block_merge_public_inputs.nr
@@ -5,7 +5,7 @@ use dep::types::{
         AZTEC_MAX_EPOCH_DURATION, BLOCK_ROOT_OR_BLOCK_MERGE_PUBLIC_INPUTS_LENGTH,
         FEE_RECIPIENT_LENGTH,
     },
-    traits::{Deserialize, Empty, Serialize},
+    traits::{Deserialize, Empty, Serialize, ToField},
     utils::reader::Reader,
 };
 use blob::blob_public_inputs::BlockBlobPublicInputs;

--- a/noir-projects/noir-protocol-circuits/crates/rollup-lib/src/abis/previous_rollup_block_data.nr
+++ b/noir-projects/noir-protocol-circuits/crates/rollup-lib/src/abis/previous_rollup_block_data.nr
@@ -6,7 +6,7 @@ use dep::types::{
         rollup_recursive_proof::NestedRecursiveProof,
         verification_key::{RollupHonkVerificationKey, VerificationKey},
     },
-    traits::Empty,
+    traits::{Empty, Serialize},
     utils::arrays::find_index_hint,
 };
 
@@ -18,7 +18,7 @@ pub struct PreviousRollupBlockData {
 }
 
 impl PreviousRollupBlockData {
-    fn verify(self, proof_type_id: u32) {
+    pub fn verify(self, proof_type_id: u32) {
         let inputs = BlockRootOrBlockMergePublicInputs::serialize(
             self.block_root_or_block_merge_public_inputs,
         );
@@ -48,6 +48,7 @@ impl PreviousRollupBlockData {
         self.vk.check_hash();
 
         let leaf_index = self.vk_witness.leaf_index as u32;
+        /// Safety: This is a hint which is constrained by the asserts below.
         let index_hint =
             unsafe { find_index_hint(allowed_indices, |index: u32| index == leaf_index) };
         assert(index_hint < N, "Invalid vk index");

--- a/noir-projects/noir-protocol-circuits/crates/rollup-lib/src/abis/previous_rollup_data.nr
+++ b/noir-projects/noir-protocol-circuits/crates/rollup-lib/src/abis/previous_rollup_data.nr
@@ -7,7 +7,7 @@ use dep::types::{
         traits::Verifiable,
         verification_key::{RollupHonkVerificationKey, VerificationKey},
     },
-    traits::Empty,
+    traits::{Empty, Serialize},
     utils::arrays::find_index_hint,
 };
 
@@ -48,6 +48,7 @@ impl PreviousRollupData {
         self.vk.check_hash();
 
         let leaf_index = self.vk_witness.leaf_index as u32;
+        /// Safety: This is a hint which is constrained by the asserts below.
         let index_hint =
             unsafe { find_index_hint(allowed_indices, |index: u32| index == leaf_index) };
         assert(index_hint < N, "Invalid vk index");

--- a/noir-projects/noir-protocol-circuits/crates/rollup-lib/src/base/components/archive.nr
+++ b/noir-projects/noir-protocol-circuits/crates/rollup-lib/src/base/components/archive.nr
@@ -2,6 +2,7 @@ use types::{
     block_header::BlockHeader,
     constants::ARCHIVE_HEIGHT,
     merkle_tree::membership::{assert_check_membership, MembershipWitness},
+    traits::Hash,
 };
 
 // Check that the block header used is a member of the blocks tree --> since the block header

--- a/noir-projects/noir-protocol-circuits/crates/rollup-lib/src/base/components/private_base_rollup_output_composer/compute_transaction_fee.nr
+++ b/noir-projects/noir-protocol-circuits/crates/rollup-lib/src/base/components/private_base_rollup_output_composer/compute_transaction_fee.nr
@@ -29,7 +29,7 @@ pub fn compute_transaction_fee(
 
 mod tests {
     use super::compute_transaction_fee;
-    use types::abis::{gas::Gas, gas_fees::GasFees, gas_settings::GasSettings};
+    use types::{abis::{gas::Gas, gas_fees::GasFees, gas_settings::GasSettings}, traits::Empty};
 
     struct TestBuilder {
         gas_fees: GasFees,

--- a/noir-projects/noir-protocol-circuits/crates/rollup-lib/src/base/components/private_tube_data_validator.nr
+++ b/noir-projects/noir-protocol-circuits/crates/rollup-lib/src/base/components/private_tube_data_validator.nr
@@ -1,5 +1,8 @@
 use super::validate_tube_data::validate_max_fees_per_gas;
-use dep::types::abis::{constant_rollup_data::ConstantRollupData, tube::PrivateTubeData};
+use dep::types::{
+    abis::{constant_rollup_data::ConstantRollupData, tube::PrivateTubeData},
+    proof::traits::Verifiable,
+};
 
 pub struct PrivateTubeDataValidator {
     pub data: PrivateTubeData,

--- a/noir-projects/noir-protocol-circuits/crates/rollup-lib/src/base/components/public_tube_data_validator.nr
+++ b/noir-projects/noir-protocol-circuits/crates/rollup-lib/src/base/components/public_tube_data_validator.nr
@@ -1,5 +1,8 @@
 use super::validate_tube_data::validate_max_fees_per_gas;
-use dep::types::abis::{constant_rollup_data::ConstantRollupData, tube::PublicTubeData};
+use dep::types::{
+    abis::{constant_rollup_data::ConstantRollupData, tube::PublicTubeData},
+    proof::traits::Verifiable,
+};
 
 pub struct PublicTubeDataValidator {
     pub data: PublicTubeData,

--- a/noir-projects/noir-protocol-circuits/crates/rollup-lib/src/base/private_base_rollup.nr
+++ b/noir-projects/noir-protocol-circuits/crates/rollup-lib/src/base/private_base_rollup.nr
@@ -33,6 +33,7 @@ use dep::types::{
     },
     messaging::l2_to_l1_message::ScopedL2ToL1Message,
     partial_state_reference::PartialStateReference,
+    traits::{Empty, Hash},
 };
 
 global ALLOWED_PREVIOUS_CIRCUITS: [u32; 1] = [TUBE_VK_INDEX];
@@ -231,7 +232,7 @@ mod tests {
             constant_rollup_data::ConstantRollupData, gas::Gas, gas_fees::GasFees,
             kernel_circuit_public_inputs::PrivateToRollupKernelCircuitPublicInputs,
             nullifier_leaf_preimage::NullifierLeafPreimage, public_data_write::PublicDataWrite,
-            sponge_blob::SpongeBlob,
+            side_effect::OrderedValue, sponge_blob::SpongeBlob,
         },
         address::{AztecAddress, EthAddress},
         constants::{
@@ -254,7 +255,7 @@ mod tests {
             fixtures::{self, merkle_tree::generate_full_sha_tree},
             merkle_tree_utils::NonEmptyMerkleTree,
         },
-        traits::{Empty, is_empty},
+        traits::{Empty, FromField, Hash, is_empty},
         utils::{
             arrays::{array_concat, get_sorted_tuple::get_sorted_tuple},
             field::{field_from_bytes, full_field_less_than},
@@ -429,6 +430,7 @@ mod tests {
             let mut low_nullifier_membership_witness =
                 [MembershipWitness::empty(); MAX_NULLIFIERS_PER_TX];
 
+            /// Safety: This is a mock for testing only
             let sorted_new_nullifier_tuples = unsafe {
                 get_sorted_tuple(
                     self.nullifiers.storage().map(|insertion: NullifierInsertion| insertion.value),
@@ -604,6 +606,7 @@ mod tests {
         }
 
         fn execute(self) -> BaseOrMergeRollupPublicInputs {
+            /// Safety: This is a mock for testing only
             let inputs = unsafe { self.build_inputs() };
             inputs.execute()
         }

--- a/noir-projects/noir-protocol-circuits/crates/rollup-lib/src/base/public_base_rollup.nr
+++ b/noir-projects/noir-protocol-circuits/crates/rollup-lib/src/base/public_base_rollup.nr
@@ -29,7 +29,7 @@ use dep::types::{
     },
     messaging::l2_to_l1_message::ScopedL2ToL1Message,
     partial_state_reference::PartialStateReference,
-    traits::is_empty,
+    traits::{Hash, is_empty},
     utils::arrays::array_merge,
 };
 
@@ -285,11 +285,10 @@ mod tests {
     use crate::abis::tx_effect::TxEffect;
     use dep::types::{
         abis::{
-            accumulated_data::PrivateToRollupAccumulatedData,
             append_only_tree_snapshot::AppendOnlyTreeSnapshot,
             constant_rollup_data::ConstantRollupData,
             nullifier_leaf_preimage::NullifierLeafPreimage, public_data_write::PublicDataWrite,
-            sponge_blob::SpongeBlob,
+            side_effect::OrderedValue, sponge_blob::SpongeBlob,
         },
         address::EthAddress,
         constants::{
@@ -304,7 +303,7 @@ mod tests {
         },
         data::{PublicDataTreeLeaf, PublicDataTreeLeafPreimage},
         hash::silo_l2_to_l1_message,
-        merkle_tree::MembershipWitness,
+        merkle_tree::{leaf_preimage::LeafPreimage, MembershipWitness},
         messaging::l2_to_l1_message::ScopedL2ToL1Message,
         partial_state_reference::PartialStateReference,
         tests::{
@@ -313,7 +312,7 @@ mod tests {
             merkle_tree_utils::NonEmptyMerkleTree,
             utils::pad_end,
         },
-        traits::{Empty, is_empty},
+        traits::{Empty, Hash, is_empty},
         utils::{
             arrays::{array_concat, get_sorted_tuple::get_sorted_tuple},
             field::{field_from_bytes, full_field_less_than},
@@ -476,6 +475,7 @@ mod tests {
             let mut low_nullifier_membership_witness =
                 [MembershipWitness::empty(); MAX_NULLIFIERS_PER_TX];
 
+            /// Safety: This is a mock for testing only
             let sorted_new_nullifier_tuples = unsafe {
                 get_sorted_tuple(
                     self.nullifiers.storage().map(|insertion: NullifierInsertion| insertion.value),
@@ -702,6 +702,7 @@ mod tests {
         }
 
         fn execute(self) -> BaseOrMergeRollupPublicInputs {
+            /// Safety: This is a mock for testing only
             let inputs = unsafe { self.build_inputs() };
             inputs.execute()
         }

--- a/noir-projects/noir-protocol-circuits/crates/rollup-lib/src/block_root/block_root_rollup_inputs.nr
+++ b/noir-projects/noir-protocol-circuits/crates/rollup-lib/src/block_root/block_root_rollup_inputs.nr
@@ -65,6 +65,7 @@ pub(crate) mod tests {
         },
         hash::accumulate_sha256,
         tests::{merkle_tree_utils::compute_zero_hashes, utils::assert_array_eq},
+        traits::Empty,
         utils::arrays::array_concat,
     };
 
@@ -156,6 +157,7 @@ pub(crate) mod tests {
         }
 
         pub fn mock_evaluate_blobs(self) -> Self {
+            /// Safety: This is a mock for testing only
             unsafe {
                 let _ = OracleMock::mock("evaluateBlobs").returns(BlockBlobPublicInputs::empty());
             }

--- a/noir-projects/noir-protocol-circuits/crates/rollup-lib/src/block_root/components/block_root_rollup_inputs_validator.nr
+++ b/noir-projects/noir-protocol-circuits/crates/rollup-lib/src/block_root/components/block_root_rollup_inputs_validator.nr
@@ -3,7 +3,7 @@ use crate::{
     merge::utils::validate_consecutive_rollups::validate_consecutive_rollups,
 };
 use parity_lib::root::root_rollup_parity_input::RootRollupParityInput;
-use types::abis::sponge_blob::SpongeBlob;
+use types::{abis::sponge_blob::SpongeBlob, proof::traits::Verifiable};
 
 pub struct BlockRootRollupInputsValidator<let NUM_ROLLUPS: u32, let N: u32> {
     previous_rollups: [PreviousRollupData; NUM_ROLLUPS],

--- a/noir-projects/noir-protocol-circuits/crates/rollup-lib/src/block_root/components/block_root_rollup_output_composer.nr
+++ b/noir-projects/noir-protocol-circuits/crates/rollup-lib/src/block_root/components/block_root_rollup_output_composer.nr
@@ -17,6 +17,7 @@ use types::{
     merkle_tree::{append_only_tree, calculate_empty_tree_root},
     partial_state_reference::PartialStateReference,
     state_reference::StateReference,
+    traits::{Empty, Hash},
 };
 
 pub struct BlockRootRollupOutputComposer {
@@ -188,7 +189,7 @@ impl BlockRootRollupOutputComposer {
                 self.merged_rollup.end_sponge_blob,
             );
         } else {
-            // TODO(#10323): this was added to save simulation time, if/when simulation times of unconstrained are improved, remove this.
+            /// Safety: TODO(#10323): this was added to save simulation time, if/when simulation times of unconstrained are improved, remove this.
             blob_public_inputs[0] = unsafe {
                 blob::mock_blob_oracle::evaluate_blobs(
                     self.data.blobs_fields,

--- a/noir-projects/noir-protocol-circuits/crates/rollup-lib/src/block_root/empty_block_root_rollup_inputs.nr
+++ b/noir-projects/noir-protocol-circuits/crates/rollup-lib/src/block_root/empty_block_root_rollup_inputs.nr
@@ -18,6 +18,7 @@ use types::{
         ARCHIVE_HEIGHT, BLOBS_PER_BLOCK, FIELDS_PER_BLOB, L1_TO_L2_MSG_SUBTREE_SIBLING_PATH_LENGTH,
     },
     partial_state_reference::PartialStateReference,
+    traits::Empty,
 };
 
 pub global EMPTY_BLOBS_HASH: Field =
@@ -101,6 +102,7 @@ mod tests {
         },
         partial_state_reference::PartialStateReference,
         tests::{merkle_tree_utils::compute_zero_hashes, utils::assert_array_eq},
+        traits::Empty,
     };
 
     fn compute_l1_l2_empty_snapshot() -> (AppendOnlyTreeSnapshot, [Field; L1_TO_L2_MSG_SUBTREE_SIBLING_PATH_LENGTH]) {

--- a/noir-projects/noir-protocol-circuits/crates/rollup-lib/src/components.nr
+++ b/noir-projects/noir-protocol-circuits/crates/rollup-lib/src/components.nr
@@ -19,7 +19,7 @@ use dep::types::{
     },
     hash::{accumulate_sha256, silo_unencrypted_log_hash},
     merkle_tree::VariableMerkleTree,
-    traits::is_empty,
+    traits::{Empty, is_empty},
     utils::arrays::{array_length, array_merge},
 };
 use blob::blob_public_inputs::BlockBlobPublicInputs;
@@ -208,6 +208,7 @@ fn get_tx_effects_hash_input(
         silo_unencrypted_log_hash(log)
     });
 
+    /// Safety: This constructs the array of effects and is constrained below.
     let mut tx_effects_hash_input = unsafe {
         get_tx_effects_hash_input_helper(
             tx_effect.tx_hash,

--- a/noir-projects/noir-protocol-circuits/crates/rollup-lib/src/merge/merge_rollup_inputs.nr
+++ b/noir-projects/noir-protocol-circuits/crates/rollup-lib/src/merge/merge_rollup_inputs.nr
@@ -5,6 +5,7 @@ use crate::merge::utils::{
 };
 use dep::types::{
     constants::{MERGE_ROLLUP_INDEX, PRIVATE_BASE_ROLLUP_VK_INDEX, PUBLIC_BASE_ROLLUP_VK_INDEX},
+    proof::traits::Verifiable,
     traits::Empty,
 };
 

--- a/noir-projects/noir-protocol-circuits/crates/rollup-lib/src/tests/block_merge_rollup_inputs.nr
+++ b/noir-projects/noir-protocol-circuits/crates/rollup-lib/src/tests/block_merge_rollup_inputs.nr
@@ -1,5 +1,6 @@
 use crate::block_merge::BlockMergeRollupInputs;
 use crate::tests::previous_rollup_block_data::default_previous_rollup_block_data;
+use dep::types::traits::Empty;
 
 pub fn default_block_merge_rollup_inputs() -> BlockMergeRollupInputs {
     let mut inputs = BlockMergeRollupInputs::empty();

--- a/noir-projects/noir-protocol-circuits/crates/rollup-lib/src/tests/l1_to_l2_roots.nr
+++ b/noir-projects/noir-protocol-circuits/crates/rollup-lib/src/tests/l1_to_l2_roots.nr
@@ -1,6 +1,7 @@
 use dep::parity_lib::root::root_rollup_parity_input::RootRollupParityInput;
 use dep::types::constants::ROOT_PARITY_INDEX;
 use dep::types::tests::fixtures;
+use dep::types::traits::Empty;
 use types::merkle_tree::merkle_tree::MerkleTree;
 
 pub fn default_root_rollup_parity_input() -> RootRollupParityInput {

--- a/noir-projects/noir-protocol-circuits/crates/rollup-lib/src/tests/merge_rollup_inputs.nr
+++ b/noir-projects/noir-protocol-circuits/crates/rollup-lib/src/tests/merge_rollup_inputs.nr
@@ -1,5 +1,6 @@
 use crate::merge::MergeRollupInputs;
 use crate::tests::previous_rollup_data::default_previous_rollup_data;
+use dep::types::traits::Empty;
 
 pub fn default_merge_rollup_inputs() -> MergeRollupInputs {
     let mut inputs = MergeRollupInputs::empty();

--- a/noir-projects/noir-protocol-circuits/crates/rollup-lib/src/tests/previous_rollup_block_data.nr
+++ b/noir-projects/noir-protocol-circuits/crates/rollup-lib/src/tests/previous_rollup_block_data.nr
@@ -3,6 +3,7 @@ use dep::types::abis::append_only_tree_snapshot::AppendOnlyTreeSnapshot;
 use dep::types::constants::BLOCK_ROOT_ROLLUP_INDEX;
 use dep::types::merkle_tree::MembershipWitness;
 use dep::types::tests::fixtures;
+use dep::types::traits::Empty;
 use types::merkle_tree::merkle_tree::MerkleTree;
 
 pub fn default_previous_rollup_block_data() -> [PreviousRollupBlockData; 2] {

--- a/noir-projects/noir-protocol-circuits/crates/rollup-lib/src/tests/previous_rollup_data.nr
+++ b/noir-projects/noir-protocol-circuits/crates/rollup-lib/src/tests/previous_rollup_data.nr
@@ -4,6 +4,7 @@ use dep::types::abis::append_only_tree_snapshot::AppendOnlyTreeSnapshot;
 use dep::types::constants::PUBLIC_BASE_ROLLUP_VK_INDEX;
 use dep::types::merkle_tree::MembershipWitness;
 use dep::types::tests::fixtures;
+use dep::types::traits::Empty;
 use types::abis::sponge_blob::SpongeBlob;
 use types::merkle_tree::merkle_tree::MerkleTree;
 

--- a/noir-projects/noir-protocol-circuits/crates/rollup-lib/src/tests/root_rollup_inputs.nr
+++ b/noir-projects/noir-protocol-circuits/crates/rollup-lib/src/tests/root_rollup_inputs.nr
@@ -1,5 +1,6 @@
 use crate::root::root_rollup_inputs::RootRollupInputs;
 use crate::tests::previous_rollup_block_data::default_previous_rollup_block_data;
+use dep::types::traits::Empty;
 
 pub fn default_root_rollup_inputs() -> RootRollupInputs {
     let mut inputs = RootRollupInputs::empty();

--- a/noir-projects/noir-protocol-circuits/crates/types/src/abis/avm_circuit_public_inputs.nr
+++ b/noir-projects/noir-protocol-circuits/crates/types/src/abis/avm_circuit_public_inputs.nr
@@ -18,7 +18,7 @@ use crate::{
         MAX_ENQUEUED_CALLS_PER_TX,
     },
     proof::{avm_proof::AvmProof, traits::Verifiable, vk_data::VkData},
-    traits::{Deserialize, Empty, Serialize},
+    traits::{Deserialize, Empty, FromField, Serialize, ToField},
     utils::reader::Reader,
 };
 

--- a/noir-projects/noir-protocol-circuits/crates/types/src/abis/call_context.nr
+++ b/noir-projects/noir-protocol-circuits/crates/types/src/abis/call_context.nr
@@ -2,7 +2,7 @@ use crate::{
     abis::function_selector::FunctionSelector,
     address::AztecAddress,
     constants::CALL_CONTEXT_LENGTH,
-    traits::{Deserialize, Empty, Serialize},
+    traits::{Deserialize, Empty, FromField, Serialize, ToField},
     utils::reader::Reader,
 };
 

--- a/noir-projects/noir-protocol-circuits/crates/types/src/abis/contract_class_function_leaf_preimage.nr
+++ b/noir-projects/noir-protocol-circuits/crates/types/src/abis/contract_class_function_leaf_preimage.nr
@@ -1,7 +1,7 @@
 use crate::abis::function_selector::FunctionSelector;
 use crate::constants::GENERATOR_INDEX__FUNCTION_LEAF;
 use crate::hash::poseidon2_hash_with_separator;
-use crate::traits::Hash;
+use crate::traits::{Hash, ToField};
 
 pub struct ContractClassFunctionLeafPreimage {
     pub selector: FunctionSelector,

--- a/noir-projects/noir-protocol-circuits/crates/types/src/abis/function_data.nr
+++ b/noir-projects/noir-protocol-circuits/crates/types/src/abis/function_data.nr
@@ -1,7 +1,7 @@
 use crate::{
     abis::function_selector::FunctionSelector,
     constants::FUNCTION_DATA_LENGTH,
-    traits::{Deserialize, Empty, Serialize},
+    traits::{Deserialize, Empty, FromField, Serialize, ToField},
 };
 
 pub struct FunctionData {

--- a/noir-projects/noir-protocol-circuits/crates/types/src/abis/global_variables.nr
+++ b/noir-projects/noir-protocol-circuits/crates/types/src/abis/global_variables.nr
@@ -2,7 +2,7 @@ use crate::{
     abis::gas_fees::GasFees,
     address::{AztecAddress, EthAddress},
     constants::GLOBAL_VARIABLES_LENGTH,
-    traits::{Deserialize, Empty, Serialize},
+    traits::{Deserialize, Empty, FromField, Serialize, ToField},
     utils::reader::Reader,
 };
 

--- a/noir-projects/noir-protocol-circuits/crates/types/src/abis/log_hash.nr
+++ b/noir-projects/noir-protocol-circuits/crates/types/src/abis/log_hash.nr
@@ -2,7 +2,7 @@ use crate::{
     abis::side_effect::{Ordered, OrderedValue, Scoped},
     address::AztecAddress,
     constants::{LOG_HASH_LENGTH, SCOPED_LOG_HASH_LENGTH},
-    traits::{Deserialize, Empty, Serialize},
+    traits::{Deserialize, Empty, Serialize, ToField},
     utils::{arrays::array_concat, reader::Reader},
 };
 

--- a/noir-projects/noir-protocol-circuits/crates/types/src/abis/note_hash.nr
+++ b/noir-projects/noir-protocol-circuits/crates/types/src/abis/note_hash.nr
@@ -2,7 +2,7 @@ use crate::{
     abis::{read_request::ScopedReadRequest, side_effect::{Ordered, OrderedValue, Readable, Scoped}},
     address::AztecAddress,
     constants::{NOTE_HASH_LENGTH, SCOPED_NOTE_HASH_LENGTH},
-    traits::{Deserialize, Empty, Serialize},
+    traits::{Deserialize, Empty, Serialize, ToField},
     utils::{arrays::array_concat, reader::Reader},
 };
 

--- a/noir-projects/noir-protocol-circuits/crates/types/src/abis/note_hash_leaf_preimage.nr
+++ b/noir-projects/noir-protocol-circuits/crates/types/src/abis/note_hash_leaf_preimage.nr
@@ -2,7 +2,6 @@ global NOTE_HASH_LEAF_PREIMAGE_LENGTH: u32 = 1;
 
 use crate::{
     abis::{read_request::ScopedReadRequest, side_effect::Readable},
-    hash::compute_siloed_note_hash,
     merkle_tree::leaf_preimage::LeafPreimage,
     traits::Empty,
 };

--- a/noir-projects/noir-protocol-circuits/crates/types/src/abis/nullifier.nr
+++ b/noir-projects/noir-protocol-circuits/crates/types/src/abis/nullifier.nr
@@ -3,7 +3,7 @@ use crate::{
     address::AztecAddress,
     constants::{NULLIFIER_LENGTH, SCOPED_NULLIFIER_LENGTH},
     hash::compute_siloed_nullifier,
-    traits::{Deserialize, Empty, Serialize},
+    traits::{Deserialize, Empty, Serialize, ToField},
     utils::{arrays::array_concat, reader::Reader},
 };
 

--- a/noir-projects/noir-protocol-circuits/crates/types/src/abis/public_call_request.nr
+++ b/noir-projects/noir-protocol-circuits/crates/types/src/abis/public_call_request.nr
@@ -2,7 +2,7 @@ use crate::{
     abis::function_selector::FunctionSelector,
     address::AztecAddress,
     constants::PUBLIC_CALL_REQUEST_LENGTH,
-    traits::{Deserialize, Empty, Serialize},
+    traits::{Deserialize, Empty, FromField, Serialize, ToField},
     utils::reader::Reader,
 };
 

--- a/noir-projects/noir-protocol-circuits/crates/types/src/abis/read_request.nr
+++ b/noir-projects/noir-protocol-circuits/crates/types/src/abis/read_request.nr
@@ -2,7 +2,7 @@ use crate::{
     abis::side_effect::{Ordered, Scoped},
     address::AztecAddress,
     constants::{READ_REQUEST_LENGTH, SCOPED_READ_REQUEST_LEN},
-    traits::{Deserialize, Empty, Serialize},
+    traits::{Deserialize, Empty, Serialize, ToField},
     utils::{arrays::array_concat, reader::Reader},
 };
 

--- a/noir-projects/noir-protocol-circuits/crates/types/src/abis/side_effect/scoped.nr
+++ b/noir-projects/noir-protocol-circuits/crates/types/src/abis/side_effect/scoped.nr
@@ -1,7 +1,7 @@
 use crate::{
     address::AztecAddress,
     tests::types::TestValue,
-    traits::{Deserialize, Empty, Serialize},
+    traits::{Deserialize, Empty, Serialize, ToField},
     utils::{arrays::array_concat, reader::Reader},
 };
 

--- a/noir-projects/noir-protocol-circuits/crates/types/src/abis/sponge_blob.nr
+++ b/noir-projects/noir-protocol-circuits/crates/types/src/abis/sponge_blob.nr
@@ -1,9 +1,9 @@
 use crate::{
     constants::{BLOBS_PER_BLOCK, FIELDS_PER_BLOB, SPONGE_BLOB_LENGTH},
     hash::poseidon2_absorb_chunks_existing_sponge,
+    poseidon2::Poseidon2Sponge,
     traits::{Deserialize, Empty, Serialize},
 };
-use std::hash::poseidon2::Poseidon2;
 
 // A Poseidon2 sponge used to accumulate data that will be added to blob(s)
 // (More accurately called BlobSponge, but that's not as fun)
@@ -22,19 +22,19 @@ use std::hash::poseidon2::Poseidon2;
 global IV: Field = (FIELDS_PER_BLOB * BLOBS_PER_BLOCK) as Field * 18446744073709551616;
 
 pub struct SpongeBlob {
-    pub sponge: Poseidon2,
+    pub sponge: Poseidon2Sponge,
     pub fields: u32,
     pub expected_fields: u32, // The hinted number of tx effects this will absorb
 }
 
 impl SpongeBlob {
     pub fn new_full_blobs() -> Self {
-        Self { sponge: Poseidon2::new(IV), fields: 0, expected_fields: 0 }
+        Self { sponge: Poseidon2Sponge::new(IV), fields: 0, expected_fields: 0 }
     }
 
     pub fn new(expected_fields_hint: u32) -> Self {
         Self {
-            sponge: Poseidon2::new((expected_fields_hint as Field) * 18446744073709551616),
+            sponge: Poseidon2Sponge::new((expected_fields_hint as Field) * 18446744073709551616),
             fields: 0,
             expected_fields: expected_fields_hint,
         }
@@ -87,7 +87,7 @@ impl Serialize<SPONGE_BLOB_LENGTH> for SpongeBlob {
 impl Deserialize<SPONGE_BLOB_LENGTH> for SpongeBlob {
     fn deserialize(fields: [Field; SPONGE_BLOB_LENGTH]) -> Self {
         Self {
-            sponge: Poseidon2 {
+            sponge: Poseidon2Sponge {
                 cache: [fields[0], fields[1], fields[2]],
                 state: [fields[3], fields[4], fields[5], fields[6]],
                 cache_size: fields[7] as u32,
@@ -101,7 +101,7 @@ impl Deserialize<SPONGE_BLOB_LENGTH> for SpongeBlob {
 
 impl Empty for SpongeBlob {
     fn empty() -> Self {
-        Self { sponge: Poseidon2::new(0), fields: 0, expected_fields: 0 }
+        Self { sponge: Poseidon2Sponge::new(0), fields: 0, expected_fields: 0 }
     }
 }
 
@@ -129,7 +129,7 @@ unconstrained fn absorb() {
     spongeblob.absorb(input_4, input_4.len());
     // ...and create a normal poseidon2 hash of the same input
     let input: [Field; 7] = array_concat(input_3, input_4);
-    let expected = Poseidon2::hash(input, input.len());
+    let expected = Poseidon2Sponge::hash(input, input.len());
     assert(spongeblob.squeeze() == expected);
 }
 

--- a/noir-projects/noir-protocol-circuits/crates/types/src/abis/tube.nr
+++ b/noir-projects/noir-protocol-circuits/crates/types/src/abis/tube.nr
@@ -4,6 +4,7 @@ use crate::{
     },
     constants::{PROOF_TYPE_ROLLUP_HONK, ROLLUP_HONK_VERIFICATION_KEY_LENGTH_IN_FIELDS},
     proof::{traits::Verifiable, tube_proof::TubeProof, vk_data::VkData},
+    traits::Serialize,
 };
 
 pub struct PublicTubeData {

--- a/noir-projects/noir-protocol-circuits/crates/types/src/abis/validation_requests/scoped_key_validation_request_and_generator.nr
+++ b/noir-projects/noir-protocol-circuits/crates/types/src/abis/validation_requests/scoped_key_validation_request_and_generator.nr
@@ -5,7 +5,7 @@ use crate::{
     },
     address::AztecAddress,
     constants::SCOPED_KEY_VALIDATION_REQUEST_AND_GENERATOR_LENGTH,
-    traits::{Deserialize, Empty, Serialize},
+    traits::{Deserialize, Empty, Serialize, ToField},
     utils::{arrays::array_concat, reader::Reader},
 };
 

--- a/noir-projects/noir-protocol-circuits/crates/types/src/address/aztec_address.nr
+++ b/noir-projects/noir-protocol-circuits/crates/types/src/address/aztec_address.nr
@@ -10,7 +10,7 @@ use crate::{
     contract_class_id::ContractClassId,
     hash::{poseidon2_hash_with_separator, private_functions_root_from_siblings},
     merkle_tree::membership::MembershipWitness,
-    public_keys::{IvpkM, NpkM, OvpkM, PublicKeys, TpkM},
+    public_keys::{IvpkM, NpkM, OvpkM, PublicKeys, ToPoint, TpkM},
     traits::{Deserialize, Empty, FromField, Serialize, ToField},
 };
 
@@ -19,7 +19,10 @@ use dep::std::embedded_curve_ops::EmbeddedCurvePoint as Point;
 
 use crate::public_keys::AddressPoint;
 use ec::{pow, sqrt};
-use std::embedded_curve_ops::{EmbeddedCurveScalar, fixed_base_scalar_mul as derive_public_key};
+use std::{
+    embedded_curve_ops::{EmbeddedCurveScalar, fixed_base_scalar_mul as derive_public_key},
+    ops::Add,
+};
 
 // Aztec address
 pub struct AztecAddress {

--- a/noir-projects/noir-protocol-circuits/crates/types/src/constants.nr
+++ b/noir-projects/noir-protocol-circuits/crates/types/src/constants.nr
@@ -1,4 +1,4 @@
-use crate::address::AztecAddress;
+use crate::{address::AztecAddress, traits::FromField};
 
 pub global MAX_FIELD_VALUE: Field =
     21888242871839275222246405745257275088548364400416034343698204186575808495616;

--- a/noir-projects/noir-protocol-circuits/crates/types/src/contract_instance.nr
+++ b/noir-projects/noir-protocol-circuits/crates/types/src/contract_instance.nr
@@ -3,7 +3,7 @@ use crate::{
     constants::CONTRACT_INSTANCE_LENGTH,
     contract_class_id::ContractClassId,
     public_keys::PublicKeys,
-    traits::{Deserialize, Hash, Serialize},
+    traits::{Deserialize, FromField, Hash, Serialize, ToField},
 };
 
 pub struct ContractInstance {

--- a/noir-projects/noir-protocol-circuits/crates/types/src/data/hash.nr
+++ b/noir-projects/noir-protocol-circuits/crates/types/src/data/hash.nr
@@ -1,4 +1,4 @@
-use crate::{address::AztecAddress, constants::GENERATOR_INDEX__PUBLIC_LEAF_INDEX};
+use crate::{address::AztecAddress, constants::GENERATOR_INDEX__PUBLIC_LEAF_INDEX, traits::ToField};
 
 pub fn compute_public_data_tree_index(
     contract_address: AztecAddress,

--- a/noir-projects/noir-protocol-circuits/crates/types/src/hash.nr
+++ b/noir-projects/noir-protocol-circuits/crates/types/src/hash.nr
@@ -6,7 +6,7 @@ use crate::{
         note_hash::ScopedNoteHash,
         nullifier::ScopedNullifier,
         private_log::{PrivateLog, PrivateLogData},
-        side_effect::scoped::Scoped,
+        side_effect::{OrderedValue, scoped::Scoped},
     },
     address::{AztecAddress, EthAddress},
     constants::{
@@ -15,7 +15,8 @@ use crate::{
     },
     merkle_tree::root::root_from_sibling_path,
     messaging::l2_to_l1_message::{L2ToL1Message, ScopedL2ToL1Message},
-    traits::{is_empty, ToField},
+    poseidon2::Poseidon2Sponge,
+    traits::{FromField, Hash, is_empty, ToField},
     utils::field::field_from_bytes_32_trunc,
 };
 use super::utils::{arrays::array_concat, field::field_from_bytes};
@@ -285,10 +286,10 @@ fn poseidon2_absorb_chunks<let N: u32>(
     input: [Field; N],
     in_len: u32,
     variable: bool,
-) -> std::hash::poseidon2::Poseidon2 {
+) -> Poseidon2Sponge {
     let two_pow_64 = 18446744073709551616;
     let iv: Field = (in_len as Field) * two_pow_64;
-    let mut sponge = std::hash::poseidon2::Poseidon2::new(iv);
+    let mut sponge = Poseidon2Sponge::new(iv);
     // Even though shift is always 1 here, if we input in_len = 0 we get an underflow
     // since we cannot isolate computation branches. The below is just to avoid that.
     let shift = if in_len == 0 { 0 } else { 1 };
@@ -314,11 +315,11 @@ fn poseidon2_absorb_chunks<let N: u32>(
 // NB: If it's not required to check that the non-absorbed elts of 'input' are 0s, set skip_0_check=true
 #[no_predicates]
 pub fn poseidon2_absorb_chunks_existing_sponge<let N: u32>(
-    in_sponge: std::hash::poseidon2::Poseidon2,
+    in_sponge: Poseidon2Sponge,
     input: [Field; N],
     in_len: u32,
     skip_0_check: bool,
-) -> std::hash::poseidon2::Poseidon2 {
+) -> Poseidon2Sponge {
     let mut sponge = in_sponge;
     // 'shift' is to account for already added inputs
     let mut shift = 0;
@@ -355,12 +356,12 @@ pub fn poseidon2_absorb_chunks_existing_sponge<let N: u32>(
 // for 0s costs 3N gates. Current approach is approx 2N gates.
 #[no_predicates]
 fn poseidon2_absorb_chunks_loop<let N: u32, let M: u32>(
-    in_sponge: std::hash::poseidon2::Poseidon2,
+    in_sponge: Poseidon2Sponge,
     input: [Field; N],
     in_len: u32,
     variable: bool,
     shift: u32,
-) -> std::hash::poseidon2::Poseidon2 {
+) -> Poseidon2Sponge {
     assert(in_len <= N, "Given in_len to absorb is larger than the input array len");
     // When we have an existing sponge, we may have a shift of 0, and the final 'k+2' below = N
     // The below avoids an overflow
@@ -424,7 +425,7 @@ where
     let in_len = inputs.len() + 1;
     let two_pow_64 = 18446744073709551616;
     let iv: Field = (in_len as Field) * two_pow_64;
-    let mut sponge = std::hash::poseidon2::Poseidon2::new(iv);
+    let mut sponge = Poseidon2Sponge::new(iv);
     sponge.absorb(separator.to_field());
 
     for i in 0..inputs.len() {
@@ -491,11 +492,11 @@ fn existing_sponge_poseidon_chunks_matches_fixed() {
     }
     // absorb 250 of the 501 things
     let two_pow_64 = 18446744073709551616;
-    let empty_sponge = std::hash::poseidon2::Poseidon2::new((in_len as Field) * two_pow_64);
+    let empty_sponge = Poseidon2Sponge::new((in_len as Field) * two_pow_64);
     let first_sponge = poseidon2_absorb_chunks_existing_sponge(empty_sponge, input, 250, true);
     // now absorb the final 251 (since they are all 3s, im being lazy and not making a new array)
     let mut final_sponge = poseidon2_absorb_chunks_existing_sponge(first_sponge, input, 251, true);
-    let fixed_len_hash = std::hash::poseidon2::Poseidon2::hash(fixed_input, fixed_input.len());
+    let fixed_len_hash = Poseidon2Sponge::hash(fixed_input, fixed_input.len());
     assert(final_sponge.squeeze() == fixed_len_hash);
 }
 

--- a/noir-projects/noir-protocol-circuits/crates/types/src/indexed_tagging_secret.nr
+++ b/noir-projects/noir-protocol-circuits/crates/types/src/indexed_tagging_secret.nr
@@ -1,4 +1,4 @@
-use crate::traits::{Deserialize, Serialize};
+use crate::traits::{Deserialize, Serialize, ToField};
 use super::{address::aztec_address::AztecAddress, hash::poseidon2_hash};
 use std::meta::derive;
 

--- a/noir-projects/noir-protocol-circuits/crates/types/src/lib.nr
+++ b/noir-projects/noir-protocol-circuits/crates/types/src/lib.nr
@@ -13,6 +13,7 @@ pub mod contract_instance;
 
 pub mod messaging;
 pub mod hash;
+pub mod poseidon2;
 pub mod traits;
 pub mod type_serialization;
 

--- a/noir-projects/noir-protocol-circuits/crates/types/src/messaging/l2_to_l1_message.nr
+++ b/noir-projects/noir-protocol-circuits/crates/types/src/messaging/l2_to_l1_message.nr
@@ -2,7 +2,7 @@ use crate::{
     abis::side_effect::{Ordered, Scoped},
     address::{AztecAddress, EthAddress},
     constants::{L2_TO_L1_MESSAGE_LENGTH, SCOPED_L2_TO_L1_MESSAGE_LENGTH},
-    traits::{Deserialize, Empty, Serialize},
+    traits::{Deserialize, Empty, Serialize, ToField},
     utils::{arrays::array_concat, reader::Reader},
 };
 

--- a/noir-projects/noir-protocol-circuits/crates/types/src/poseidon2.nr
+++ b/noir-projects/noir-protocol-circuits/crates/types/src/poseidon2.nr
@@ -1,0 +1,86 @@
+// NB: This is a clone of noir/noir-repo/noir_stdlib/src/hash/poseidon2.nr
+// It exists as we sometimes need to perform custom absorbtion, but the stdlib version
+// has a private absorb() method (it's also designed to just be a hasher)
+// Can be removed when standalone noir poseidon lib exists: See noir#6679
+
+comptime global RATE: u32 = 3;
+
+pub struct Poseidon2Sponge {
+    pub cache: [Field; 3],
+    pub state: [Field; 4],
+    pub cache_size: u32,
+    pub squeeze_mode: bool, // 0 => absorb, 1 => squeeze
+}
+
+impl Poseidon2Sponge {
+    #[no_predicates]
+    pub fn hash<let N: u32>(input: [Field; N], message_size: u32) -> Field {
+        Poseidon2Sponge::hash_internal(input, message_size, message_size != N)
+    }
+
+    pub(crate) fn new(iv: Field) -> Poseidon2Sponge {
+        let mut result =
+            Poseidon2Sponge { cache: [0; 3], state: [0; 4], cache_size: 0, squeeze_mode: false };
+        result.state[RATE] = iv;
+        result
+    }
+
+    fn perform_duplex(&mut self) {
+        // add the cache into sponge state
+        for i in 0..RATE {
+            // We effectively zero-pad the cache by only adding to the state
+            // cache that is less than the specified `cache_size`
+            if i < self.cache_size {
+                self.state[i] += self.cache[i];
+            }
+        }
+        self.state = std::hash::poseidon2_permutation(self.state, 4);
+    }
+
+    pub fn absorb(&mut self, input: Field) {
+        assert(!self.squeeze_mode);
+        if self.cache_size == RATE {
+            // If we're absorbing, and the cache is full, apply the sponge permutation to compress the cache
+            self.perform_duplex();
+            self.cache[0] = input;
+            self.cache_size = 1;
+        } else {
+            // If we're absorbing, and the cache is not full, add the input into the cache
+            self.cache[self.cache_size] = input;
+            self.cache_size += 1;
+        }
+    }
+
+    pub fn squeeze(&mut self) -> Field {
+        assert(!self.squeeze_mode);
+        // If we're in absorb mode, apply sponge permutation to compress the cache.
+        self.perform_duplex();
+        self.squeeze_mode = true;
+
+        // Pop one item off the top of the permutation and return it.
+        self.state[0]
+    }
+
+    fn hash_internal<let N: u32>(
+        input: [Field; N],
+        in_len: u32,
+        is_variable_length: bool,
+    ) -> Field {
+        let two_pow_64 = 18446744073709551616;
+        let iv: Field = (in_len as Field) * two_pow_64;
+        let mut sponge = Poseidon2Sponge::new(iv);
+        for i in 0..input.len() {
+            if i < in_len {
+                sponge.absorb(input[i]);
+            }
+        }
+
+        // In the case where the hash preimage is variable-length, we append `1` to the end of the input, to distinguish
+        // from fixed-length hashes. (the combination of this additional field element + the hash IV ensures
+        // fixed-length and variable-length hashes do not collide)
+        if is_variable_length {
+            sponge.absorb(1);
+        }
+        sponge.squeeze()
+    }
+}

--- a/noir-projects/noir-protocol-circuits/crates/types/src/storage/map.nr
+++ b/noir-projects/noir-protocol-circuits/crates/types/src/storage/map.nr
@@ -8,7 +8,7 @@ where
 }
 
 mod test {
-    use crate::{address::AztecAddress, storage::map::derive_storage_slot_in_map};
+    use crate::{address::AztecAddress, storage::map::derive_storage_slot_in_map, traits::FromField};
 
     #[test]
     fn test_derive_storage_slot_in_map_matches_typescript() {

--- a/noir-projects/noir-protocol-circuits/crates/types/src/tests/fixture_builder.nr
+++ b/noir-projects/noir-protocol-circuits/crates/types/src/tests/fixture_builder.nr
@@ -31,7 +31,7 @@ use crate::{
         public_call_request::PublicCallRequest,
         public_data_write::PublicDataWrite,
         read_request::{ReadRequest, ScopedReadRequest},
-        side_effect::{Counted, scoped::Scoped},
+        side_effect::{Counted, OrderedValue, scoped::Scoped},
         tube::{PrivateTubeData, PublicTubeData},
         tx_constant_data::TxConstantData,
         validation_requests::{
@@ -66,7 +66,7 @@ use crate::{
     },
     public_keys::PublicKeys,
     tests::fixtures::{self, contract_functions::ContractFunction, contracts::ContractData},
-    traits::Empty,
+    traits::{Deserialize, Empty, FromField},
     transaction::{tx_context::TxContext, tx_request::TxRequest},
 };
 

--- a/noir-projects/noir-protocol-circuits/crates/types/src/tests/fixtures/protocol_contract_tree.nr
+++ b/noir-projects/noir-protocol-circuits/crates/types/src/tests/fixtures/protocol_contract_tree.nr
@@ -1,6 +1,6 @@
 use crate::{
     constants::PROTOCOL_CONTRACT_TREE_HEIGHT, merkle_tree::merkle_tree::MerkleTree,
-    tests::fixtures::contracts::get_protocol_contract,
+    tests::fixtures::contracts::get_protocol_contract, traits::ToField,
 };
 
 global PROTOCOL_CONTRACT_TREE_WIDTH: u32 = 1 << PROTOCOL_CONTRACT_TREE_HEIGHT as u8;

--- a/noir-projects/noir-protocol-circuits/crates/types/src/transaction/tx_request.nr
+++ b/noir-projects/noir-protocol-circuits/crates/types/src/transaction/tx_request.nr
@@ -3,7 +3,7 @@ use crate::{
     address::AztecAddress,
     constants::{GENERATOR_INDEX__TX_REQUEST, TX_REQUEST_LENGTH},
     hash::poseidon2_hash_with_separator,
-    traits::{Deserialize, Empty, Hash, Serialize},
+    traits::{Deserialize, Empty, Hash, Serialize, ToField},
     transaction::tx_context::TxContext,
     utils::reader::Reader,
 };
@@ -80,6 +80,7 @@ mod tests {
             gas_fees::GasFees, gas_settings::GasSettings,
         },
         address::AztecAddress,
+        traits::{Deserialize, Empty, FromField, Hash, Serialize},
         transaction::{tx_context::TxContext, tx_request::TxRequest},
     };
 

--- a/noir-projects/noir-protocol-circuits/crates/types/src/utils/arrays/assert_combined_array.nr
+++ b/noir-projects/noir-protocol-circuits/crates/types/src/utils/arrays/assert_combined_array.nr
@@ -36,6 +36,7 @@ where
 mod tests {
     use crate::{
         tests::{types::TestValue, utils::pad_end},
+        traits::Empty,
         utils::arrays::assert_combined_array::{assert_combined_array, combine_arrays},
     };
 

--- a/noir-projects/noir-protocol-circuits/crates/types/src/utils/arrays/assert_combined_transformed_array.nr
+++ b/noir-projects/noir-protocol-circuits/crates/types/src/utils/arrays/assert_combined_transformed_array.nr
@@ -55,6 +55,7 @@ mod tests {
             types::{is_summed_from_two_values, sum_two_values, TestTwoValues, TestValue},
             utils::pad_end,
         },
+        traits::Empty,
         utils::arrays::assert_combined_transformed_array::{
             assert_combined_transformed_array, combine_and_transform_arrays,
         },

--- a/noir-projects/noir-protocol-circuits/crates/types/src/utils/arrays/assert_exposed_sorted_transformed_value_array.nr
+++ b/noir-projects/noir-protocol-circuits/crates/types/src/utils/arrays/assert_exposed_sorted_transformed_value_array.nr
@@ -48,6 +48,7 @@ where
 mod tests {
     use crate::{
         tests::types::{is_combined_from_two_values, TestCombinedValue, TestTwoValues},
+        traits::Empty,
         utils::arrays::assert_exposed_sorted_transformed_value_array::{
             assert_exposed_sorted_transformed_value_array, get_order_hints::OrderHint,
         },

--- a/noir-projects/noir-protocol-circuits/crates/types/src/utils/arrays/assert_exposed_sorted_transformed_value_array/get_order_hints.nr
+++ b/noir-projects/noir-protocol-circuits/crates/types/src/utils/arrays/assert_exposed_sorted_transformed_value_array/get_order_hints.nr
@@ -63,6 +63,7 @@ where
 mod tests {
     use crate::{
         tests::{types::TestValue, utils::pad_end},
+        traits::Empty,
         utils::arrays::assert_exposed_sorted_transformed_value_array::get_order_hints::{
             get_order_hints_asc, get_order_hints_desc, OrderHint,
         },

--- a/noir-projects/noir-protocol-circuits/crates/types/src/utils/arrays/assert_sorted_transformed_value_array.nr
+++ b/noir-projects/noir-protocol-circuits/crates/types/src/utils/arrays/assert_sorted_transformed_value_array.nr
@@ -63,6 +63,7 @@ where
 mod tests {
     use crate::{
         tests::types::{is_summed_from_two_values, TestTwoValues, TestValue},
+        traits::Empty,
         utils::arrays::assert_sorted_transformed_value_array::{
             assert_sorted_transformed_value_array,
             assert_sorted_transformed_value_array_capped_size,

--- a/noir-projects/noir-protocol-circuits/crates/types/src/utils/arrays/assert_split_sorted_transformed_value_arrays.nr
+++ b/noir-projects/noir-protocol-circuits/crates/types/src/utils/arrays/assert_split_sorted_transformed_value_arrays.nr
@@ -133,6 +133,7 @@ where
 mod tests {
     use crate::{
         tests::types::{combine_two_values, TestCombinedValue, TestTwoValues},
+        traits::Empty,
         utils::arrays::assert_split_sorted_transformed_value_arrays::{
             assert_split_sorted_transformed_value_arrays_asc,
             assert_split_sorted_transformed_value_arrays_desc,

--- a/noir-projects/noir-protocol-circuits/crates/types/src/utils/arrays/assert_split_sorted_transformed_value_arrays/get_split_order_hints.nr
+++ b/noir-projects/noir-protocol-circuits/crates/types/src/utils/arrays/assert_split_sorted_transformed_value_arrays/get_split_order_hints.nr
@@ -100,6 +100,7 @@ where
 mod tests {
     use crate::{
         tests::{types::TestValue, utils::pad_end},
+        traits::Empty,
         utils::arrays::assert_split_sorted_transformed_value_arrays::get_split_order_hints::{
             get_split_order_hints_asc, get_split_order_hints_desc, SplitOrderHints,
         },

--- a/noir-projects/noir-protocol-circuits/crates/types/src/utils/arrays/assert_split_transformed_value_arrays.nr
+++ b/noir-projects/noir-protocol-circuits/crates/types/src/utils/arrays/assert_split_transformed_value_arrays.nr
@@ -76,6 +76,7 @@ where
 mod tests {
     use crate::{
         tests::{types::TestValue, utils::pad_end},
+        traits::Empty,
         utils::arrays::assert_split_transformed_value_arrays::{
             assert_split_transformed_value_arrays, assert_split_transformed_value_arrays_with_hint,
         },

--- a/noir-projects/noir-protocol-circuits/crates/types/src/utils/arrays/sort_by_counter.nr
+++ b/noir-projects/noir-protocol-circuits/crates/types/src/utils/arrays/sort_by_counter.nr
@@ -31,6 +31,7 @@ where
 mod tests {
     use crate::{
         tests::types::TestValue,
+        traits::Empty,
         utils::arrays::sort_by_counter::{
             compare_by_counter_empty_padded_asc, compare_by_counter_empty_padded_desc,
             sort_by_counter_asc, sort_by_counter_desc,

--- a/yarn-project/noir-protocol-circuits-types/src/conversion/server.ts
+++ b/yarn-project/noir-protocol-circuits-types/src/conversion/server.ts
@@ -81,7 +81,7 @@ import type {
   Field as NoirField,
   ParityPublicInputs as ParityPublicInputsNoir,
   RootParityInput as ParityRootParityInputNoir,
-  Poseidon2 as Poseidon2SpongeNoir,
+  Poseidon2Sponge as Poseidon2SpongeNoir,
   PreviousRollupBlockData as PreviousRollupBlockDataNoir,
   PreviousRollupData as PreviousRollupDataNoir,
   PrivateBaseRollupInputs as PrivateBaseRollupInputsNoir,


### PR DESCRIPTION
This PR just removes warnings from `types` and `rollup-lib` crates, including those from using private methods of std `Poseidon2` by adding a temporary clone.
Note: this isn't all of noir-protocol-circuits, so it doesn't close #11251 but it does contribute to it.
