### PR TITLE
chore: Log correlation in traces in google cloud

### DIFF
--- a/yarn-project/end-to-end/src/fixtures/get_acvm_config.ts
+++ b/yarn-project/end-to-end/src/fixtures/get_acvm_config.ts
@@ -1,4 +1,5 @@
 import { type Logger } from '@aztec/aztec.js';
+import { parseBooleanEnv } from '@aztec/foundation/config';
 import { randomBytes } from '@aztec/foundation/crypto';
 
 import { promises as fs } from 'fs';
@@ -23,7 +24,7 @@ export async function getACVMConfig(logger: Logger): Promise<
   | undefined
 > {
   try {
-    if (['1', 'true'].includes(ACVM_FORCE_WASM)) {
+    if (parseBooleanEnv(ACVM_FORCE_WASM)) {
       return undefined;
     }
     const acvmBinaryPath = ACVM_BINARY_PATH ? ACVM_BINARY_PATH : `../../noir/${NOIR_RELEASE_DIR}/acvm`;

--- a/yarn-project/foundation/src/config/index.ts
+++ b/yarn-project/foundation/src/config/index.ts
@@ -1,6 +1,6 @@
 import { type EnvVar } from './env_var.js';
 
-export { EnvVar } from './env_var.js';
+export { type EnvVar } from './env_var.js';
 
 export interface ConfigMapping {
   env?: EnvVar;

--- a/yarn-project/foundation/src/config/index.ts
+++ b/yarn-project/foundation/src/config/index.ts
@@ -102,13 +102,18 @@ export function optionalNumberConfigHelper(): Pick<ConfigMapping, 'parseEnv'> {
 export function booleanConfigHelper(
   defaultVal = false,
 ): Required<Pick<ConfigMapping, 'parseEnv' | 'defaultValue' | 'isBoolean'> & { parseVal: (val: string) => boolean }> {
-  const parse = (val: string | boolean) => (typeof val === 'boolean' ? val : ['1', 'true', 'TRUE'].includes(val));
+  const parse = (val: string | boolean) => (typeof val === 'boolean' ? val : parseBooleanEnv(val));
   return {
     parseEnv: parse,
     parseVal: parse,
     defaultValue: defaultVal,
     isBoolean: true,
   };
+}
+
+/** Parses an env var as boolean. Returns true only if value is 1, true, or TRUE. */
+export function parseBooleanEnv(val: string | undefined): boolean {
+  return val !== undefined && ['1', 'true', 'TRUE'].includes(val);
 }
 
 /**

--- a/yarn-project/foundation/src/log/gcloud-logger-config.ts
+++ b/yarn-project/foundation/src/log/gcloud-logger-config.ts
@@ -1,0 +1,71 @@
+import { type pino } from 'pino';
+
+/* eslint-disable camelcase */
+
+const GOOGLE_CLOUD_TRACE_ID = 'logging.googleapis.com/trace';
+const GOOGLE_CLOUD_SPAN_ID = 'logging.googleapis.com/spanId';
+const GOOGLE_CLOUD_TRACE_SAMPLED = 'logging.googleapis.com/trace_sampled';
+
+/**
+ * Pino configuration for google cloud observability. Tweaks message and timestamp,
+ * adds trace context attributes, and injects severity level.
+ * Adapted from https://cloud.google.com/trace/docs/setup/nodejs-ot#config-structured-logging.
+ */
+export const GoogleCloudLoggerConfig = {
+  messageKey: 'message',
+  // Same as pino.stdTimeFunctions.isoTime but uses "timestamp" key instead of "time"
+  timestamp(): string {
+    return `,"timestamp":"${new Date(Date.now()).toISOString()}"`;
+  },
+  formatters: {
+    log(object: Record<string, unknown>): Record<string, unknown> {
+      // Add trace context attributes following Cloud Logging structured log format described
+      // in https://cloud.google.com/logging/docs/structured-logging#special-payload-fields
+      const { trace_id, span_id, trace_flags, ...rest } = object;
+
+      if (trace_id && span_id) {
+        return {
+          [GOOGLE_CLOUD_TRACE_ID]: trace_id,
+          [GOOGLE_CLOUD_SPAN_ID]: span_id,
+          [GOOGLE_CLOUD_TRACE_SAMPLED]: trace_flags ? trace_flags === '01' : undefined,
+          trace_flags, // Keep the original trace_flags for otel-pino-stream
+          ...rest,
+        };
+      }
+      return object;
+    },
+    level(label: string, level: number): object {
+      // Inspired by https://github.com/pinojs/pino/issues/726#issuecomment-605814879
+      // Severity labels https://cloud.google.com/logging/docs/reference/v2/rest/v2/LogEntry#LogSeverity
+      let severity: string;
+
+      switch (label as pino.Level | keyof typeof customLevels) {
+        case 'trace':
+        case 'debug':
+          severity = 'DEBUG';
+          break;
+        case 'verbose':
+        case 'info':
+          severity = 'INFO';
+          break;
+        case 'warn':
+          severity = 'WARNING';
+          break;
+        case 'error':
+          severity = 'ERROR';
+          break;
+        case 'fatal':
+          severity = 'CRITICAL';
+          break;
+        default:
+          severity = 'DEFAULT';
+          break;
+      }
+
+      return { severity, level };
+    },
+  },
+} satisfies pino.LoggerOptions;
+
+// Define custom logging levels for pino. Duplicate from pino-logger.ts.
+const customLevels = { verbose: 25 };

--- a/yarn-project/pxe/src/config/index.ts
+++ b/yarn-project/pxe/src/config/index.ts
@@ -4,6 +4,7 @@ import {
   booleanConfigHelper,
   getConfigFromMappings,
   numberConfigHelper,
+  parseBooleanEnv,
 } from '@aztec/foundation/config';
 import { type DataStoreConfig, dataConfigMappings } from '@aztec/kv-store/config';
 import { type Network } from '@aztec/types/network';
@@ -99,7 +100,7 @@ export const allPxeConfigMappings: ConfigMappingsType<CliPXEOptions & PXEService
   ...dataConfigMappings,
   proverEnabled: {
     env: 'PXE_PROVER_ENABLED',
-    parseEnv: (val: string) => ['1', 'true', 'TRUE'].includes(val) || !!process.env.NETWORK,
+    parseEnv: (val: string) => parseBooleanEnv(val) || !!process.env.NETWORK,
     description: 'Enable real proofs',
     isBoolean: true,
   },

--- a/yarn-project/telemetry-client/src/config.ts
+++ b/yarn-project/telemetry-client/src/config.ts
@@ -1,4 +1,4 @@
-import { type ConfigMappingsType, getConfigFromMappings } from '@aztec/foundation/config';
+import { type ConfigMappingsType, booleanConfigHelper, getConfigFromMappings } from '@aztec/foundation/config';
 
 export interface TelemetryClientConfig {
   useGcloudObservability: boolean;
@@ -18,8 +18,7 @@ export const telemetryClientConfigMappings: ConfigMappingsType<TelemetryClientCo
   useGcloudObservability: {
     env: 'USE_GCLOUD_OBSERVABILITY',
     description: 'Whether to use GCP observability',
-    defaultValue: false,
-    parseEnv: (val: string) => val === 'true',
+    ...booleanConfigHelper(false),
   },
   metricsCollectorUrl: {
     env: 'OTEL_EXPORTER_OTLP_METRICS_ENDPOINT',

--- a/yarn-project/telemetry-client/src/otel.ts
+++ b/yarn-project/telemetry-client/src/otel.ts
@@ -1,7 +1,7 @@
 import { type LogData, type Logger, addLogDataHandler } from '@aztec/foundation/log';
 
-import { MetricExporter } from '@google-cloud/opentelemetry-cloud-monitoring-exporter';
-import { TraceExporter } from '@google-cloud/opentelemetry-cloud-trace-exporter';
+import { MetricExporter as GoogleCloudMetricExporter } from '@google-cloud/opentelemetry-cloud-monitoring-exporter';
+import { TraceExporter as GoogleCloudTraceExporter } from '@google-cloud/opentelemetry-cloud-trace-exporter';
 import {
   DiagConsoleLogger,
   DiagLogLevel,
@@ -237,17 +237,17 @@ export class OpenTelemetryClient implements TelemetryClient {
     });
   }
 
-  public static getGcloudClientFactory(config: TelemetryClientConfig): OpenTelemetryClientFactory {
+  private static getGcloudClientFactory(config: TelemetryClientConfig): OpenTelemetryClientFactory {
     return (resource: IResource, log: Logger) => {
       const tracerProvider = new NodeTracerProvider({
         resource,
-        spanProcessors: [new BatchSpanProcessor(new TraceExporter({ resourceFilter: /.*/ }))],
+        spanProcessors: [new BatchSpanProcessor(new GoogleCloudTraceExporter({ resourceFilter: /.*/ }))],
       });
 
       tracerProvider.register();
 
       const meterProvider = OpenTelemetryClient.createMeterProvider(resource, {
-        exporter: new MetricExporter(),
+        exporter: new GoogleCloudMetricExporter(),
         exportTimeoutMillis: config.otelExportTimeoutMs,
         exportIntervalMillis: config.otelCollectIntervalMs,
       });
@@ -256,7 +256,7 @@ export class OpenTelemetryClient implements TelemetryClient {
     };
   }
 
-  public static getCustomClientFactory(config: TelemetryClientConfig): OpenTelemetryClientFactory {
+  private static getCustomClientFactory(config: TelemetryClientConfig): OpenTelemetryClientFactory {
     return (resource: IResource, log: Logger) => {
       const tracerProvider = new NodeTracerProvider({
         resource,


### PR DESCRIPTION
Adds a google cloud logger config so that logs trace and span ids use the required naming for correlation.

Replaces #11019

Fixes #10937
