### PR TITLE
chore: Ensure devnet has unproven config

### DIFF
--- a/spartan/aztec-network/values/rc-1.yaml
+++ b/spartan/aztec-network/values/rc-1.yaml
@@ -125,7 +125,7 @@ bootNode:
   storageSize: "100Gi"
 
 proverAgent:
-  replicas: 20
+  replicas: 2
   bb:
     hardwareConcurrency: 31
   gke:
@@ -138,7 +138,7 @@ proverAgent:
 bot:
   followChain: "PENDING"
   enabled: true
-  txIntervalSeconds: 10
+  txIntervalSeconds: 900
 
 jobs:
   deployL1Verifier:

--- a/spartan/aztec-network/values/release-devnet.yaml
+++ b/spartan/aztec-network/values/release-devnet.yaml
@@ -17,21 +17,13 @@ bootNode:
     disabled: true
 
 proverAgent:
-  replicas: 10
-  bb:
-    hardwareConcurrency: 31
-  gke:
-    spotEnabled: true
-  resources:
-    requests:
-      memory: "116Gi"
-      cpu: "31"
+  replicas: 1
 
 bot:
   followChain: "PENDING"
   feePaymentMethod: "none" # disabled until the bot can fund itself
   enabled: true
-  txIntervalSeconds: 200
+  txIntervalSeconds: 30
 
 network:
   public: true


### PR DESCRIPTION
This PR removes the fully proven prover agents from devnet. The network is unproven so these are not necessary. It also reduces further the throughput of masternet.
