### PR TITLE
feat: improve PXE contract DB capabilities

### DIFF
--- a/noir-projects/aztec-nr/aztec/src/lib.nr
+++ b/noir-projects/aztec-nr/aztec/src/lib.nr
@@ -10,6 +10,7 @@ mod note;
 mod event;
 mod oracle;
 mod state_vars;
+mod pxe_db;
 mod prelude;
 mod encrypted_logs;
 mod unencrypted_logs;

--- a/noir-projects/aztec-nr/aztec/src/oracle/pxe_db.nr
+++ b/noir-projects/aztec-nr/aztec/src/oracle/pxe_db.nr
@@ -1,83 +1,249 @@
 use protocol_types::{address::AztecAddress, traits::{Deserialize, Serialize}};
 
-#[oracle(store)]
-unconstrained fn store_oracle<let N: u32>(
-    contract_address: AztecAddress,
-    key: Field,
-    values: [Field; N],
-) {}
-
-/// Store a value of type T that implements Serialize in local PXE database. The data is scoped to the current
-/// contract. If the data under the key already exists, it is overwritten.
-pub unconstrained fn store<T, let N: u32>(contract_address: AztecAddress, key: Field, value: T)
+/// Stores arbitrary information in a per-contract non-volatile database, which can later be retrieved with `load`. If
+/// data was already stored at this slot, it is overwrriten.
+pub unconstrained fn store<T, let N: u32>(contract_address: AztecAddress, slot: Field, value: T)
 where
     T: Serialize<N>,
 {
     let serialized = value.serialize();
-    store_oracle(contract_address, key, serialized);
+    store_oracle(contract_address, slot, serialized);
 }
 
-/// Load data from local PXE database. We pass in `t_size` as a parameter to have the information of how many fields
-/// we need to pad if the key does not exist (note that the actual response size is `t_size + 1` as the Option prefixes
-/// the response with a boolean indicating if the data exists).
-///
-/// Note that we need to return an Option<[Field; N]> as we cannot return an Option<T> directly. This is because then
-/// the shape of T would affect the expected oracle response (e.g. if we were returning a struct of 3 u32 values
-/// then the expected response shape would be 3 single items. If instead we had a struct containing
-/// `u32, [Field;10], u32`, then the expected shape would be single, array, single.).
-#[oracle(load)]
-unconstrained fn load_oracle<let N: u32>(
-    contract_address: AztecAddress,
-    key: Field,
-    t_size: u32,
-) -> Option<[Field; N]> {}
-
-/// Load a value of type T that implements Deserialize from local PXE database. The data is scoped to the current
-/// contract. If the key does not exist, Option::none() is returned.
-pub unconstrained fn load<T, let N: u32>(contract_address: AztecAddress, key: Field) -> Option<T>
+/// Returns data previously stored via `dbStore` in the per-contract non-volatile database. Returns Option::none() if
+/// nothing was stored at the given slot.
+pub unconstrained fn load<T, let N: u32>(contract_address: AztecAddress, slot: Field) -> Option<T>
 where
     T: Deserialize<N>,
 {
-    let serialized_option = load_oracle::<N>(contract_address, key, N);
+    let serialized_option = load_oracle::<N>(contract_address, slot, N);
     serialized_option.map(|arr| Deserialize::deserialize(arr))
 }
 
+/// Deletes data in the per-contract non-volatile database. Does nothing if no data was present.
+pub unconstrained fn delete(contract_address: AztecAddress, slot: Field) {
+    delete_oracle(contract_address, slot);
+}
+
+/// Copies a number of contiguous entries in the per-contract non-volatile database. This allows for efficient data
+/// structures by avoiding repeated calls to `dbLoad` and `dbStore`.
+/// Supports overlapping source and destination regions (which will result in the overlapped source values being
+/// overwritten). All copied slots must exist in the database (i.e. have been stored and not deleted)
+pub unconstrained fn copy(
+    contract_address: AztecAddress,
+    src_slot: Field,
+    dst_slot: Field,
+    num_entries: u32,
+) {
+    copy_oracle(contract_address, src_slot, dst_slot, num_entries);
+}
+
+#[oracle(dbStore)]
+unconstrained fn store_oracle<let N: u32>(
+    contract_address: AztecAddress,
+    slot: Field,
+    values: [Field; N],
+) {}
+
+/// We need to pass in `array_len` (the value of N) as a parameter to tell the oracle how many fields the response must
+/// have.
+///
+/// Note that the oracle returns an Option<[Field; N]> because we cannot return an Option<T> directly. That would
+/// require for the oracle resolver to know the shape of T (e.g. if T were a struct of 3 u32 values then the expected
+/// response shape would be 3 single items, whereas it were a struct containing `u32, [Field;10], u32` then the expected
+/// shape would be single, array, single.). Instead, we return the serialization and deserialize in Noir.
+#[oracle(dbLoad)]
+unconstrained fn load_oracle<let N: u32>(
+    contract_address: AztecAddress,
+    slot: Field,
+    array_len: u32,
+) -> Option<[Field; N]> {}
+
+#[oracle(dbDelete)]
+unconstrained fn delete_oracle(contract_address: AztecAddress, slot: Field) {}
+
+#[oracle(dbCopy)]
+unconstrained fn copy_oracle(
+    contract_address: AztecAddress,
+    src_slot: Field,
+    dst_slot: Field,
+    num_entries: u32,
+) {}
+
 mod test {
+    // These tests are sort of redundant since we already test the oracle implementation directly in TypeScript, but
+    // they are cheap regardless and help ensure both that the TXE implementation works accordingly and that the Noir
+    // oracles are hooked up correctly.
+
     use crate::{
-        oracle::{pxe_db::{load, store}, random::random},
+        oracle::pxe_db::{copy, delete, load, store},
         test::{helpers::test_environment::TestEnvironment, mocks::mock_struct::MockStruct},
     };
+    use protocol_types::{address::AztecAddress, traits::{FromField, ToField}};
+
+    unconstrained fn setup() -> AztecAddress {
+        let env = TestEnvironment::new();
+        env.contract_address()
+    }
+
+    global SLOT: Field = 1;
 
     #[test]
-    unconstrained fn stores_loads_and_overwrites_data() {
-        let env = TestEnvironment::new();
+    unconstrained fn stores_and_loads() {
+        let contract_address = setup();
 
-        let contract_address = env.contract_address();
-        let key = random();
         let value = MockStruct::new(5, 6);
-        store(contract_address, key, value);
+        store(contract_address, SLOT, value);
 
-        let loaded_value: MockStruct = load(contract_address, key).unwrap();
-
-        assert(loaded_value == value, "Stored and loaded values should be equal");
-
-        // Now we test that the value gets overwritten correctly.
-        let new_value = MockStruct::new(7, 8);
-        store(contract_address, key, new_value);
-
-        let loaded_value: MockStruct = load(contract_address, key).unwrap();
-
-        assert(loaded_value == new_value, "Stored and loaded values should be equal");
+        assert_eq(load(contract_address, SLOT).unwrap(), value);
     }
 
     #[test]
-    unconstrained fn load_non_existent_key() {
-        let env = TestEnvironment::new();
+    unconstrained fn store_overwrites() {
+        let contract_address = setup();
 
-        let contract_address = env.contract_address();
-        let key = random();
-        let loaded_value: Option<MockStruct> = load(contract_address, key);
+        let value = MockStruct::new(5, 6);
+        store(contract_address, SLOT, value);
 
-        assert(loaded_value == Option::none(), "Value should not exist");
+        let new_value = MockStruct::new(7, 8);
+        store(contract_address, SLOT, new_value);
+
+        assert_eq(load(contract_address, SLOT).unwrap(), new_value);
+    }
+
+    #[test]
+    unconstrained fn loads_empty_slot() {
+        let contract_address = setup();
+
+        let loaded_value: Option<MockStruct> = load(contract_address, SLOT);
+        assert_eq(loaded_value, Option::none());
+    }
+
+    #[test]
+    unconstrained fn deletes_stored_value() {
+        let contract_address = setup();
+
+        let value = MockStruct::new(5, 6);
+        store(contract_address, SLOT, value);
+        delete(contract_address, SLOT);
+
+        let loaded_value: Option<MockStruct> = load(contract_address, SLOT);
+        assert_eq(loaded_value, Option::none());
+    }
+
+    #[test]
+    unconstrained fn deletes_empty_slot() {
+        let contract_address = setup();
+
+        delete(contract_address, SLOT);
+        let loaded_value: Option<MockStruct> = load(contract_address, SLOT);
+        assert_eq(loaded_value, Option::none());
+    }
+
+    #[test]
+    unconstrained fn copies_non_overlapping_values() {
+        let contract_address = setup();
+
+        let src = 5;
+
+        let values = [MockStruct::new(5, 6), MockStruct::new(7, 8), MockStruct::new(9, 10)];
+        store(contract_address, src, values[0]);
+        store(contract_address, src + 1, values[1]);
+        store(contract_address, src + 2, values[2]);
+
+        let dst = 10;
+        copy(contract_address, src, dst, 3);
+
+        assert_eq(load(contract_address, dst).unwrap(), values[0]);
+        assert_eq(load(contract_address, dst + 1).unwrap(), values[1]);
+        assert_eq(load(contract_address, dst + 2).unwrap(), values[2]);
+    }
+
+    #[test]
+    unconstrained fn copies_overlapping_values_with_src_ahead() {
+        let contract_address = setup();
+
+        let src = 1;
+
+        let values = [MockStruct::new(5, 6), MockStruct::new(7, 8), MockStruct::new(9, 10)];
+        store(contract_address, src, values[0]);
+        store(contract_address, src + 1, values[1]);
+        store(contract_address, src + 2, values[2]);
+
+        let dst = 2;
+        copy(contract_address, src, dst, 3);
+
+        assert_eq(load(contract_address, dst).unwrap(), values[0]);
+        assert_eq(load(contract_address, dst + 1).unwrap(), values[1]);
+        assert_eq(load(contract_address, dst + 2).unwrap(), values[2]);
+
+        // src[1] and src[2] should have been overwritten since they are also dst[0] and dst[1]
+        assert_eq(load(contract_address, src).unwrap(), values[0]); // src[0] (unchanged)
+        assert_eq(load(contract_address, src + 1).unwrap(), values[0]); // dst[0]
+        assert_eq(load(contract_address, src + 2).unwrap(), values[1]); // dst[1]
+    }
+
+    #[test]
+    unconstrained fn copies_overlapping_values_with_dst_ahead() {
+        let contract_address = setup();
+
+        let src = 2;
+
+        let values = [MockStruct::new(5, 6), MockStruct::new(7, 8), MockStruct::new(9, 10)];
+        store(contract_address, src, values[0]);
+        store(contract_address, src + 1, values[1]);
+        store(contract_address, src + 2, values[2]);
+
+        let dst = 1;
+        copy(contract_address, src, dst, 3);
+
+        assert_eq(load(contract_address, dst).unwrap(), values[0]);
+        assert_eq(load(contract_address, dst + 1).unwrap(), values[1]);
+        assert_eq(load(contract_address, dst + 2).unwrap(), values[2]);
+
+        // src[0] and src[1] should have been overwritten since they are also dst[1] and dst[2]
+        assert_eq(load(contract_address, src).unwrap(), values[1]); // dst[1]
+        assert_eq(load(contract_address, src + 1).unwrap(), values[2]); // dst[2]
+        assert_eq(load(contract_address, src + 2).unwrap(), values[2]); // src[2] (unchanged)
+    }
+
+    #[test(should_fail_with = "copy empty slot")]
+    unconstrained fn cannot_copy_empty_values() {
+        let contract_address = setup();
+
+        copy(contract_address, SLOT, SLOT, 1);
+    }
+
+    #[test(should_fail_with = "not allowed to access")]
+    unconstrained fn cannot_store_other_contract() {
+        let contract_address = setup();
+        let other_contract_address = AztecAddress::from_field(contract_address.to_field() + 1);
+
+        let value = MockStruct::new(5, 6);
+        store(other_contract_address, SLOT, value);
+    }
+
+    #[test(should_fail_with = "not allowed to access")]
+    unconstrained fn cannot_load_other_contract() {
+        let contract_address = setup();
+        let other_contract_address = AztecAddress::from_field(contract_address.to_field() + 1);
+
+        let _: Option<MockStruct> = load(other_contract_address, SLOT);
+    }
+
+    #[test(should_fail_with = "not allowed to access")]
+    unconstrained fn cannot_delete_other_contract() {
+        let contract_address = setup();
+        let other_contract_address = AztecAddress::from_field(contract_address.to_field() + 1);
+
+        delete(other_contract_address, SLOT);
+    }
+
+    #[test(should_fail_with = "not allowed to access")]
+    unconstrained fn cannot_copy_other_contract() {
+        let contract_address = setup();
+        let other_contract_address = AztecAddress::from_field(contract_address.to_field() + 1);
+
+        copy(other_contract_address, SLOT, SLOT, 0);
     }
 }

--- a/noir-projects/aztec-nr/aztec/src/pxe_db/mod.nr
+++ b/noir-projects/aztec-nr/aztec/src/pxe_db/mod.nr
@@ -1,0 +1,181 @@
+use crate::oracle::pxe_db;
+use protocol_types::{address::AztecAddress, traits::{Deserialize, Serialize}};
+
+/// A dynamically sized array backed by PXE's non-volatile database. Values are persisted until deleted, so they can be
+/// e.g. stored during simulation of a transaction and later retrieved during witness generation. All values are scoped
+/// per contract address, so external contracts cannot access them.
+pub struct DBArray<T> {
+    contract_address: AztecAddress,
+    /// An array's base slot is the slot in PXE's database in which the array lenght is stored. Array elements are
+    /// stored contiguously in the following slots, so e.g. if the base slot is 5, then the length is stored at slot 5,
+    /// the first element (index 0) at slot 6, the second (index 1) at slot 7, and so on.
+    base_slot: Field,
+}
+
+impl<T, let N: u32> DBArray<T>
+where
+    T: Serialize<N> + Deserialize<N>,
+{
+    /// Returns a DBArray connected to a contact's PXE database at a base database slot. Array elements are be stored at
+    /// contiguous slots following the base slot, so there should be sufficient space between array base slots to
+    /// accomodate elements. A reasonable strategy is to make the base slot a hash of a unique value.
+    pub unconstrained fn at(contract_address: AztecAddress, base_slot: Field) -> Self {
+        Self { contract_address, base_slot }
+    }
+
+    /// Returns the number of elements stored in the array.
+    pub unconstrained fn len(self) -> u32 {
+        // An uninitialized array defaults to a length of 0.
+        pxe_db::load(self.contract_address, self.base_slot).unwrap_or(0) as u32
+    }
+
+    /// Stores a value at the end of the array.
+    pub unconstrained fn push(self, value: T) {
+        let current_length = self.len();
+
+        // The slot corresponding to the index `current_length` is the first slot immediately after the end of the
+        // array, which is where we want to place the new value.
+        pxe_db::store(self.contract_address, self.slot_at(current_length), value);
+
+        // Then we simply update the length.
+        let new_length = current_length + 1;
+        pxe_db::store(self.contract_address, self.base_slot, new_length);
+    }
+
+    /// Retrieves the value stored in the array at `index`. Throws if the index is out of bounds.
+    pub unconstrained fn get(self, index: u32) -> T {
+        assert(index < self.len(), "Attempted to read past the length of a DBArray");
+
+        pxe_db::load(self.contract_address, self.slot_at(index)).unwrap()
+    }
+
+    /// Deletes the value stored in the array at `index`. Throws if the index is out of bounds.
+    pub unconstrained fn remove(self, index: u32) {
+        let current_length = self.len();
+        assert(index < current_length, "Attempted to delete past the length of a DBArray");
+
+        // In order to be able to remove elements at arbitrary indices, we need to shift the entire contents of the
+        // array past the removed element one slot backward so that we don't end up with a gap and preserve the
+        // contiguous slots. We can skip this when deleting the last element however.
+        if index != current_length - 1 {
+            // The souce and destination regions overlap, but `copy` supports this.
+            pxe_db::copy(
+                self.contract_address,
+                self.slot_at(index + 1),
+                self.slot_at(index),
+                current_length - index - 1,
+            );
+        }
+
+        // We can now delete the last element (which has either been copied to the slot immediately before it, or was
+        // the element we meant to delete in the first place) and update the length.
+        pxe_db::delete(self.contract_address, self.slot_at(current_length - 1));
+        pxe_db::store(self.contract_address, self.base_slot, current_length - 1);
+    }
+
+    unconstrained fn slot_at(self, index: u32) -> Field {
+        // Elements are stored immediately after the base slot, so we add 1 to it to compute the slot for the first
+        // element.
+        self.base_slot + 1 + index as Field
+    }
+}
+
+mod test {
+    use crate::test::helpers::test_environment::TestEnvironment;
+    use super::DBArray;
+    use protocol_types::address::AztecAddress;
+
+    global SLOT: Field = 1230;
+
+    unconstrained fn setup() -> AztecAddress {
+        TestEnvironment::new().unkonstrained().this_address()
+    }
+
+    #[test]
+    unconstrained fn empty_array() {
+        let contract_address = setup();
+
+        let array: DBArray<Field> = DBArray::at(contract_address, SLOT);
+        assert_eq(array.len(), 0);
+    }
+
+    #[test(should_fail_with = "Attempted to read past the length of a DBArray")]
+    unconstrained fn empty_array_read() {
+        let contract_address = setup();
+
+        let array = DBArray::at(contract_address, SLOT);
+        let _: Field = array.get(0);
+    }
+
+    #[test]
+    unconstrained fn array_push() {
+        let contract_address = setup();
+
+        let array = DBArray::at(contract_address, SLOT);
+        array.push(5);
+
+        assert_eq(array.len(), 1);
+        assert_eq(array.get(0), 5);
+    }
+
+    #[test(should_fail_with = "Attempted to read past the length of a DBArray")]
+    unconstrained fn read_past_len() {
+        let contract_address = setup();
+
+        let array = DBArray::at(contract_address, SLOT);
+        array.push(5);
+
+        let _ = array.get(1);
+    }
+
+    #[test]
+    unconstrained fn array_remove_last() {
+        let contract_address = setup();
+
+        let array = DBArray::at(contract_address, SLOT);
+
+        array.push(5);
+        array.remove(0);
+
+        assert_eq(array.len(), 0);
+    }
+
+    #[test]
+    unconstrained fn array_remove_some() {
+        let contract_address = setup();
+
+        let array = DBArray::at(contract_address, SLOT);
+
+        array.push(7);
+        array.push(8);
+        array.push(9);
+
+        assert_eq(array.len(), 3);
+        assert_eq(array.get(0), 7);
+        assert_eq(array.get(1), 8);
+        assert_eq(array.get(2), 9);
+
+        array.remove(1);
+
+        assert_eq(array.len(), 2);
+        assert_eq(array.get(0), 7);
+        assert_eq(array.get(1), 9);
+    }
+
+    #[test]
+    unconstrained fn array_remove_all() {
+        let contract_address = setup();
+
+        let array = DBArray::at(contract_address, SLOT);
+
+        array.push(7);
+        array.push(8);
+        array.push(9);
+
+        array.remove(1);
+        array.remove(1);
+        array.remove(0);
+
+        assert_eq(array.len(), 0);
+    }
+}

--- a/noir-projects/aztec-nr/aztec/src/pxe_db/mod.nr
+++ b/noir-projects/aztec-nr/aztec/src/pxe_db/mod.nr
@@ -6,7 +6,7 @@ use protocol_types::{address::AztecAddress, traits::{Deserialize, Serialize}};
 /// per contract address, so external contracts cannot access them.
 pub struct DBArray<T> {
     contract_address: AztecAddress,
-    /// An array's base slot is the slot in PXE's database in which the array lenght is stored. Array elements are
+    /// An array's base slot is the slot in PXE's database in which the array length is stored. Array elements are
     /// stored contiguously in the following slots, so e.g. if the base slot is 5, then the length is stored at slot 5,
     /// the first element (index 0) at slot 6, the second (index 1) at slot 7, and so on.
     base_slot: Field,

--- a/noir-projects/aztec-nr/aztec/src/test/mocks/mock_struct.nr
+++ b/noir-projects/aztec-nr/aztec/src/test/mocks/mock_struct.nr
@@ -6,7 +6,7 @@ pub(crate) struct MockStruct {
 }
 
 impl MockStruct {
-    fn new(a: Field, b: Field) -> Self {
+    pub(crate) fn new(a: Field, b: Field) -> Self {
         Self { a, b }
     }
 }

--- a/yarn-project/pxe/src/database/pxe_database.ts
+++ b/yarn-project/pxe/src/database/pxe_database.ts
@@ -215,20 +215,39 @@ export interface PxeDatabase extends ContractArtifactDatabase, ContractInstanceD
   resetNoteSyncData(): Promise<void>;
 
   /**
-   * Used by contracts during execution to store arbitrary data in the local PXE database. The data is siloed/scoped
-   * to a specific `contract`.
-   * @param contract - An address of a contract that is requesting to store the data.
-   * @param key - A field element representing the key to store the data under.
-   * @param values - An array of field elements representing the data to store.
+   * Stores arbitrary information in a per-contract non-volatile database, which can later be retrieved with `dbLoad`.
+   * If data was already stored at this slot, it is overwrriten.
+   * @param contractAddress - The contract address to scope the data under.
+   * @param slot - The slot in the database in which to store the value. Slots need not be contiguous.
+   * @param values - The data to store.
    */
-  store(contract: AztecAddress, key: Fr, values: Fr[]): Promise<void>;
+  dbStore(contractAddress: AztecAddress, slot: Fr, values: Fr[]): Promise<void>;
 
   /**
-   * Used by contracts during execution to load arbitrary data from the local PXE database. The data is siloed/scoped
-   * to a specific `contract`.
-   * @param contract - An address of a contract that is requesting to load the data.
-   * @param key - A field element representing the key under which to load the data..
-   * @returns An array of field elements representing the stored data or `null` if no data is stored under the key.
+   * Returns data previously stored via `dbStore` in the per-contract non-volatile database.
+   * @param contractAddress - The contract address under which the data is scoped.
+   * @param slot - The slot in the database to read.
+   * @returns The stored data or `null` if no data is stored under the slot.
    */
-  load(contract: AztecAddress, key: Fr): Promise<Fr[] | null>;
+  dbLoad(contractAddress: AztecAddress, slot: Fr): Promise<Fr[] | null>;
+
+  /**
+   * Deletes data in the per-contract non-volatile database. Does nothing if no data was present.
+   * @param contractAddress - The contract address under which the data is scoped.
+   * @param slot - The slot in the database to delete.
+   */
+  dbDelete(contractAddress: AztecAddress, slot: Fr): Promise<void>;
+
+  /**
+   * Copies a number of contiguous entries in the per-contract non-volatile database. This allows for efficient data
+   * structures by avoiding repeated calls to `dbLoad` and `dbStore`.
+   * Supports overlapping source and destination regions (which will result in the overlapped source values being
+   * overwritten). All copied slots must exist in the database (i.e. have been stored and not deleted)
+   *
+   * @param contractAddress - The contract address under which the data is scoped.
+   * @param srcSlot - The first slot to copy from.
+   * @param dstSlot - The first slot to copy to.
+   * @param numEntries - The number of entries to copy.
+   */
+  dbCopy(contractAddress: AztecAddress, srcSlot: Fr, dstSlot: Fr, numEntries: number): Promise<void>;
 }

--- a/yarn-project/pxe/src/simulator_oracle/index.ts
+++ b/yarn-project/pxe/src/simulator_oracle/index.ts
@@ -804,26 +804,20 @@ export class SimulatorOracle implements DBOracle {
     );
   }
 
-  /**
-   * Used by contracts during execution to store arbitrary data in the local PXE database. The data is siloed/scoped
-   * to a specific `contract`.
-   * @param contract - An address of a contract that is requesting to store the data.
-   * @param key - A field element representing the key to store the data under.
-   * @param values - An array of field elements representing the data to store.
-   */
-  store(contract: AztecAddress, key: Fr, values: Fr[]): Promise<void> {
-    return this.db.store(contract, key, values);
+  dbStore(contractAddress: AztecAddress, slot: Fr, values: Fr[]): Promise<void> {
+    return this.db.dbStore(contractAddress, slot, values);
   }
 
-  /**
-   * Used by contracts during execution to load arbitrary data from the local PXE database. The data is siloed/scoped
-   * to a specific `contract`.
-   * @param contract - An address of a contract that is requesting to load the data.
-   * @param key - A field element representing the key under which to load the data..
-   * @returns An array of field elements representing the stored data or `null` if no data is stored under the key.
-   */
-  load(contract: AztecAddress, key: Fr): Promise<Fr[] | null> {
-    return this.db.load(contract, key);
+  dbLoad(contractAddress: AztecAddress, slot: Fr): Promise<Fr[] | null> {
+    return this.db.dbLoad(contractAddress, slot);
+  }
+
+  dbDelete(contractAddress: AztecAddress, slot: Fr): Promise<void> {
+    return this.db.dbDelete(contractAddress, slot);
+  }
+
+  dbCopy(contractAddress: AztecAddress, srcSlot: Fr, dstSlot: Fr, numEntries: number): Promise<void> {
+    return this.db.dbCopy(contractAddress, srcSlot, dstSlot, numEntries);
   }
 }
 

--- a/yarn-project/simulator/src/acvm/oracle/typed_oracle.ts
+++ b/yarn-project/simulator/src/acvm/oracle/typed_oracle.ts
@@ -250,11 +250,19 @@ export abstract class TypedOracle {
     throw new OracleMethodNotAvailableError('deliverNote');
   }
 
-  store(_contract: AztecAddress, _key: Fr, _values: Fr[]): Promise<void> {
-    throw new OracleMethodNotAvailableError('store');
+  dbStore(_contractAddress: AztecAddress, _key: Fr, _values: Fr[]): Promise<void> {
+    throw new OracleMethodNotAvailableError('dbStore');
   }
 
-  load(_contract: AztecAddress, _key: Fr): Promise<Fr[] | null> {
-    throw new OracleMethodNotAvailableError('load');
+  dbLoad(_contractAddress: AztecAddress, _key: Fr): Promise<Fr[] | null> {
+    throw new OracleMethodNotAvailableError('dbLoad');
+  }
+
+  dbDelete(_contractAddress: AztecAddress, _key: Fr): Promise<void> {
+    throw new OracleMethodNotAvailableError('dbDelete');
+  }
+
+  dbCopy(_contractAddress: AztecAddress, _srcKey: Fr, _dstKey: Fr, _numEntries: number): Promise<void> {
+    throw new OracleMethodNotAvailableError('dbCopy');
   }
 }

--- a/yarn-project/simulator/src/client/db_oracle.ts
+++ b/yarn-project/simulator/src/client/db_oracle.ts
@@ -263,20 +263,39 @@ export interface DBOracle extends CommitmentsDB {
   removeNullifiedNotes(contractAddress: AztecAddress): Promise<void>;
 
   /**
-   * Used by contracts during execution to store arbitrary data in the local PXE database. The data is siloed/scoped
-   * to a specific `contract`.
-   * @param contract - An address of a contract that is requesting to store the data.
-   * @param key - A field element representing the key to store the data under.
-   * @param values - An array of field elements representing the data to store.
+   * Stores arbitrary information in a per-contract non-volatile database, which can later be retrieved with `dbLoad`.
+   * * If data was already stored at this slot, it is overwrriten.
+   * @param contractAddress - The contract address to scope the data under.
+   * @param slot - The slot in the database in which to store the value. Slots need not be contiguous.
+   * @param values - The data to store.
    */
-  store(contract: AztecAddress, key: Fr, values: Fr[]): Promise<void>;
+  dbStore(contractAddress: AztecAddress, slot: Fr, values: Fr[]): Promise<void>;
 
   /**
-   * Used by contracts during execution to load arbitrary data from the local PXE database. The data is siloed/scoped
-   * to a specific `contract`.
-   * @param contract - An address of a contract that is requesting to load the data.
-   * @param key - A field element representing the key under which to load the data..
-   * @returns An array of field elements representing the stored data or `null` if no data is stored under the key.
+   * Returns data previously stored via `dbStore` in the per-contract non-volatile database.
+   * @param contractAddress - The contract address under which the data is scoped.
+   * @param slot - The slot in the database to read.
+   * @returns The stored data or `null` if no data is stored under the slot.
    */
-  load(contract: AztecAddress, key: Fr): Promise<Fr[] | null>;
+  dbLoad(contractAddress: AztecAddress, slot: Fr): Promise<Fr[] | null>;
+
+  /**
+   * Deletes data in the per-contract non-volatile database. Does nothing if no data was present.
+   * @param contractAddress - The contract address under which the data is scoped.
+   * @param slot - The slot in the database to delete.
+   */
+  dbDelete(contractAddress: AztecAddress, slot: Fr): Promise<void>;
+
+  /**
+   * Copies a number of contiguous entries in the per-contract non-volatile database. This allows for efficient data
+   * structures by avoiding repeated calls to `dbLoad` and `dbStore`.
+   * Supports overlapping source and destination regions (which will result in the overlapped source values being
+   * overwritten). All copied slots must exist in the database (i.e. have been stored and not deleted)
+   *
+   * @param contractAddress - The contract address under which the data is scoped.
+   * @param srcSlot - The first slot to copy from.
+   * @param dstSlot - The first slot to copy to.
+   * @param numEntries - The number of entries to copy.
+   */
+  dbCopy(contractAddress: AztecAddress, srcSlot: Fr, dstSlot: Fr, numEntries: number): Promise<void>;
 }

--- a/yarn-project/simulator/src/client/view_data_oracle.ts
+++ b/yarn-project/simulator/src/client/view_data_oracle.ts
@@ -328,23 +328,35 @@ export class ViewDataOracle extends TypedOracle {
     await this.db.deliverNote(contractAddress, storageSlot, nonce, content, noteHash, nullifier, txHash, recipient);
   }
 
-  public override store(contract: AztecAddress, key: Fr, values: Fr[]): Promise<void> {
-    if (!contract.equals(this.contractAddress)) {
-      // TODO(#10727): instead of this check check that this.contractAddress is allowed to process notes for contract
-      throw new Error(
-        `Contract address ${contract} does not match the oracle's contract address ${this.contractAddress}`,
-      );
+  public override dbStore(contractAddress: AztecAddress, slot: Fr, values: Fr[]): Promise<void> {
+    if (!contractAddress.equals(this.contractAddress)) {
+      // TODO(#10727): instead of this check that this.contractAddress is allowed to access the external DB
+      throw new Error(`Contract ${contractAddress} is not allowed to access ${this.contractAddress}'s PXE DB`);
     }
-    return this.db.store(this.contractAddress, key, values);
+    return this.db.dbStore(this.contractAddress, slot, values);
   }
 
-  public override load(contract: AztecAddress, key: Fr): Promise<Fr[] | null> {
-    if (!contract.equals(this.contractAddress)) {
-      // TODO(#10727): instead of this check check that this.contractAddress is allowed to process notes for contract
-      throw new Error(
-        `Contract address ${contract} does not match the oracle's contract address ${this.contractAddress}`,
-      );
+  public override dbLoad(contractAddress: AztecAddress, slot: Fr): Promise<Fr[] | null> {
+    if (!contractAddress.equals(this.contractAddress)) {
+      // TODO(#10727): instead of this check that this.contractAddress is allowed to access the external DB
+      throw new Error(`Contract ${contractAddress} is not allowed to access ${this.contractAddress}'s PXE DB`);
     }
-    return this.db.load(this.contractAddress, key);
+    return this.db.dbLoad(this.contractAddress, slot);
+  }
+
+  public override dbDelete(contractAddress: AztecAddress, slot: Fr): Promise<void> {
+    if (!contractAddress.equals(this.contractAddress)) {
+      // TODO(#10727): instead of this check that this.contractAddress is allowed to access the external DB
+      throw new Error(`Contract ${contractAddress} is not allowed to access ${this.contractAddress}'s PXE DB`);
+    }
+    return this.db.dbDelete(this.contractAddress, slot);
+  }
+
+  public override dbCopy(contractAddress: AztecAddress, srcSlot: Fr, dstSlot: Fr, numEntries: number): Promise<void> {
+    if (!contractAddress.equals(this.contractAddress)) {
+      // TODO(#10727): instead of this check that this.contractAddress is allowed to access the external DB
+      throw new Error(`Contract ${contractAddress} is not allowed to access ${this.contractAddress}'s PXE DB`);
+    }
+    return this.db.dbCopy(this.contractAddress, srcSlot, dstSlot, numEntries);
   }
 }

--- a/yarn-project/txe/src/oracle/txe_oracle.ts
+++ b/yarn-project/txe/src/oracle/txe_oracle.ts
@@ -1072,36 +1072,35 @@ export class TXE implements TypedOracle {
     return preimage.value;
   }
 
-  /**
-   * Used by contracts during execution to store arbitrary data in the local PXE database. The data is siloed/scoped
-   * to a specific `contract`.
-   * @param contract - The contract address to store the data under.
-   * @param key - A field element representing the key to store the data under.
-   * @param values - An array of field elements representing the data to store.
-   */
-  store(contract: AztecAddress, key: Fr, values: Fr[]): Promise<void> {
-    if (!contract.equals(this.contractAddress)) {
-      // TODO(#10727): instead of this check check that this.contractAddress is allowed to process notes for contract
-      throw new Error(
-        `Contract address ${contract} does not match the oracle's contract address ${this.contractAddress}`,
-      );
+  dbStore(contractAddress: AztecAddress, slot: Fr, values: Fr[]): Promise<void> {
+    if (!contractAddress.equals(this.contractAddress)) {
+      // TODO(#10727): instead of this check that this.contractAddress is allowed to access the external DB
+      throw new Error(`Contract ${contractAddress} is not allowed to access ${this.contractAddress}'s PXE DB`);
     }
-    return this.txeDatabase.store(this.contractAddress, key, values);
+    return this.txeDatabase.dbStore(this.contractAddress, slot, values);
   }
 
-  /**
-   * Used by contracts during execution to load arbitrary data from the local PXE database. The data is siloed/scoped
-   * to a specific `contract`.
-   * @param contract - The contract address to load the data from.
-   * @param key - A field element representing the key under which to load the data..
-   * @returns An array of field elements representing the stored data or `null` if no data is stored under the key.
-   */
-  load(contract: AztecAddress, key: Fr): Promise<Fr[] | null> {
-    if (!contract.equals(this.contractAddress)) {
-      // TODO(#10727): instead of this check check that this.contractAddress is allowed to process notes for contract
-      this.debug(`Data not found for contract ${contract.toString()} and key ${key.toString()}`);
-      return Promise.resolve(null);
+  dbLoad(contractAddress: AztecAddress, slot: Fr): Promise<Fr[] | null> {
+    if (!contractAddress.equals(this.contractAddress)) {
+      // TODO(#10727): instead of this check that this.contractAddress is allowed to access the external DB
+      throw new Error(`Contract ${contractAddress} is not allowed to access ${this.contractAddress}'s PXE DB`);
     }
-    return this.txeDatabase.load(this.contractAddress, key);
+    return this.txeDatabase.dbLoad(this.contractAddress, slot);
+  }
+
+  dbDelete(contractAddress: AztecAddress, slot: Fr): Promise<void> {
+    if (!contractAddress.equals(this.contractAddress)) {
+      // TODO(#10727): instead of this check that this.contractAddress is allowed to access the external DB
+      throw new Error(`Contract ${contractAddress} is not allowed to access ${this.contractAddress}'s PXE DB`);
+    }
+    return this.txeDatabase.dbDelete(this.contractAddress, slot);
+  }
+
+  dbCopy(contractAddress: AztecAddress, srcSlot: Fr, dstSlot: Fr, numEntries: number): Promise<void> {
+    if (!contractAddress.equals(this.contractAddress)) {
+      // TODO(#10727): instead of this check that this.contractAddress is allowed to access the external DB
+      throw new Error(`Contract ${contractAddress} is not allowed to access ${this.contractAddress}'s PXE DB`);
+    }
+    return this.txeDatabase.dbCopy(this.contractAddress, srcSlot, dstSlot, numEntries);
   }
 }

--- a/yarn-project/txe/src/txe_service/txe_service.ts
+++ b/yarn-project/txe/src/txe_service/txe_service.ts
@@ -588,35 +588,47 @@ export class TXEService {
     return toForeignCallResult([]);
   }
 
-  async store(contract: ForeignCallSingle, key: ForeignCallSingle, values: ForeignCallArray) {
-    const processedContract = AztecAddress.fromField(fromSingle(contract));
-    const processedKey = fromSingle(key);
-    const processedValues = fromArray(values);
-    await this.typedOracle.store(processedContract, processedKey, processedValues);
+  async dbStore(contractAddress: ForeignCallSingle, slot: ForeignCallSingle, values: ForeignCallArray) {
+    await this.typedOracle.dbStore(
+      AztecAddress.fromField(fromSingle(contractAddress)),
+      fromSingle(slot),
+      fromArray(values),
+    );
     return toForeignCallResult([]);
   }
 
-  /**
-   * Load data from pxe db.
-   * @param contract - The contract address.
-   * @param key - The key to load.
-   * @param tSize - The size of the serialized object to return.
-   * @returns The data found flag and the serialized object concatenated in one array.
-   */
-  async load(contract: ForeignCallSingle, key: ForeignCallSingle, tSize: ForeignCallSingle) {
-    const processedContract = AztecAddress.fromField(fromSingle(contract));
-    const processedKey = fromSingle(key);
-    const values = await this.typedOracle.load(processedContract, processedKey);
+  async dbLoad(contractAddress: ForeignCallSingle, slot: ForeignCallSingle, tSize: ForeignCallSingle) {
+    const values = await this.typedOracle.dbLoad(AztecAddress.fromField(fromSingle(contractAddress)), fromSingle(slot));
     // We are going to return a Noir Option struct to represent the possibility of null values. Options are a struct
     // with two fields: `some` (a boolean) and `value` (a field array in this case).
     if (values === null) {
       // No data was found so we set `some` to 0 and pad `value` with zeros get the correct return size.
-      const processedTSize = fromSingle(tSize).toNumber();
-      return toForeignCallResult([toSingle(new Fr(0)), toArray(Array(processedTSize).fill(new Fr(0)))]);
+      return toForeignCallResult([toSingle(new Fr(0)), toArray(Array(fromSingle(tSize).toNumber()).fill(new Fr(0)))]);
     } else {
       // Data was found so we set `some` to 1 and return it along with `value`.
       return toForeignCallResult([toSingle(new Fr(1)), toArray(values)]);
     }
+  }
+
+  async dbDelete(contractAddress: ForeignCallSingle, slot: ForeignCallSingle) {
+    await this.typedOracle.dbDelete(AztecAddress.fromField(fromSingle(contractAddress)), fromSingle(slot));
+    return toForeignCallResult([]);
+  }
+
+  async dbCopy(
+    contractAddress: ForeignCallSingle,
+    srcSlot: ForeignCallSingle,
+    dstSlot: ForeignCallSingle,
+    numEntries: ForeignCallSingle,
+  ) {
+    await this.typedOracle.dbCopy(
+      AztecAddress.fromField(fromSingle(contractAddress)),
+      fromSingle(srcSlot),
+      fromSingle(dstSlot),
+      fromSingle(numEntries).toNumber(),
+    );
+
+    return toForeignCallResult([]);
   }
 
   // AVM opcodes


### PR DESCRIPTION
This extends the features introduced in https://github.com/AztecProtocol/aztec-packages/pull/10867 so that we can also delete entries and copy multiple entries from one place to another. With these two new primitives I also built a Noir `DBArray`, which is a dynamic array backed by this database supporting pushes and deletion of arbitrary indexes (which we'll need for https://github.com/AztecProtocol/aztec-packages/issues/10724).

I took the liberty of renaming `store` and `load` to `dbStore` and `dbLoad` in TS, since I found the original names to be too generic. I kept those in Noir since we call them as `pxe_db::store` etc. anyway, and don't really expose them much either. I also renamed `key` to `slot`, since the actual kv store _does_ have a key, but it's not what we now call the slot (the key is `${contract}:${slot}`).

I found it slightly annoying that I had to modify so many TS files to get this working, perhaps a symptom of over-abstraction?