### PR TITLE
fix: Fail in proxy deployment should fail the step

### DIFF
--- a/spartan/aztec-network/templates/boot-node.yaml
+++ b/spartan/aztec-network/templates/boot-node.yaml
@@ -68,7 +68,8 @@ spec:
                 sleep 5
               done
               echo "Ethereum node is ready!"
-              if [ "$(cast code --rpc-url ${ETHEREUM_HOST} 0x4e59b44847b379578588920ca78fbf26c0b4956c)" = "0x" ]; then
+              PROXY_CODE="$(cast code --rpc-url ${ETHEREUM_HOST} 0x4e59b44847b379578588920ca78fbf26c0b4956c)"
+              if [ "$PROXY_CODE" = "0x" ]; then
                 echo "Deploying Deterministic Deployment Proxy"
                 cast publish --rpc-url ${ETHEREUM_HOST} 0xf8a58085174876e800830186a08080b853604580600e600039806000f350fe7fffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffe03601600081602082378035828234f58015156039578182fd5b8082525050506014600cf31ba02222222222222222222222222222222222222222222222222222222222222222a02222222222222222222222222222222222222222222222222222222222222222
               fi


### PR DESCRIPTION
Running `cast` in the conditional caused bash to swallow any error connecting to the ETHEREUM_HOST, so the step was not retried, so we proceeded without a create2-deployer, so the deploy-l1-contract step next would never succeed.

Moving it outside the conditional ensures that the exit code is propagated, so kind should retry the step (I hope!).
