### PR TITLE
Fix typo circuit_base.hpp

### DIFF
--- a/barretenberg/cpp/src/barretenberg/smt_verification/circuit/circuit_base.hpp
+++ b/barretenberg/cpp/src/barretenberg/smt_verification/circuit/circuit_base.hpp
@@ -30,7 +30,7 @@ class CircuitBase {
     std::vector<bb::fr> variables;                                    // circuit witness
     std::vector<uint32_t> public_inps;                                // public inputs from the circuit
     std::unordered_map<uint32_t, std::string> variable_names;         // names of the variables
-    std::unordered_map<std::string, uint32_t> variable_names_inverse; // inverse map of the previous memeber
+    std::unordered_map<std::string, uint32_t> variable_names_inverse; // inverse map of the previous member
     std::unordered_map<uint32_t, STerm> symbolic_vars;                // all the symbolic variables from the circuit
     std::vector<uint32_t> real_variable_index;                        // indexes for assert_equal'd wires
     std::vector<uint32_t> real_variable_tags;                         // tags of the variables in the circuit


### PR DESCRIPTION
# Pull Request: Typo Fix in `circuit_base.hpp` ("memeber" → "member")



## Changes Made

- Corrected the typo "memeber" to "member" in  `circuit_base.hpp`

