### PR TITLE
feat(p2p): batch request response

### DIFF
--- a/yarn-project/p2p/src/services/reqresp/connection-sampler/batch_connection_sampler.test.ts
+++ b/yarn-project/p2p/src/services/reqresp/connection-sampler/batch_connection_sampler.test.ts
@@ -1,0 +1,150 @@
+import { describe, expect, it, jest } from '@jest/globals';
+import { createSecp256k1PeerId } from '@libp2p/peer-id-factory';
+import { Libp2p } from 'libp2p';
+
+import { BatchConnectionSampler } from './batch_connection_sampler.js';
+import { ConnectionSampler } from './connection_sampler.js';
+import { RandomSampler } from './connection_sampler.js';
+
+describe('BatchConnectionSampler', () => {
+  const mockRandomSampler = {
+    random: jest.fn(),
+  } as jest.Mocked<RandomSampler>;
+
+  let peers: Awaited<ReturnType<typeof createSecp256k1PeerId>>[];
+  let libp2p: jest.Mocked<Libp2p>;
+  let connectionSampler: ConnectionSampler;
+
+  beforeEach(async () => {
+    jest.clearAllMocks();
+
+    // Create a set of test peers
+    peers = await Promise.all(new Array(5).fill(0).map(() => createSecp256k1PeerId()));
+
+    // Mock libp2p to return our test peers
+    libp2p = {
+      getPeers: jest.fn().mockReturnValue(peers),
+    } as unknown as jest.Mocked<Libp2p>;
+
+    // Create a real connection sampler with mocked random sampling
+    connectionSampler = new ConnectionSampler(libp2p, 1000, mockRandomSampler);
+  });
+
+  afterEach(async () => {
+    await connectionSampler.stop();
+  });
+
+  it('initializes with correct number of peers and request distribution', async () => {
+    // Mock random to return sequential indices
+    mockRandomSampler.random.mockImplementation(_ => 0);
+
+    const sampler = new BatchConnectionSampler(connectionSampler, /* batchSize */ 10, /* maxPeers */ 3);
+
+    expect(sampler.activePeerCount).toBe(3);
+    expect(sampler.requestsPerBucket).toBe(3); // floor(10/3) = 3
+    expect(mockRandomSampler.random).toHaveBeenCalledTimes(3);
+  });
+
+  it('assigns requests to peers deterministically with wraparound', async () => {
+    // Mock to return first two peers
+    let callCount = 0;
+    mockRandomSampler.random.mockImplementation(() => callCount++ % 2);
+
+    // With 5 requests and 2 peers:
+    // floor(5/2) = 2 requests per peer
+    // Peer 0: 0,1,4 (gets extra from wraparound)
+    // Peer 1: 2,3
+    const sampler = new BatchConnectionSampler(connectionSampler, /* batchSize */ 5, /* maxPeers */ 2);
+    const assignments = new Array(5).fill(0).map((_, i) => sampler.getPeerForRequest(i));
+
+    // First peer gets first bucket and wraparound
+    expect(assignments[0]).toBe(peers[0]); // First bucket
+    expect(assignments[1]).toBe(peers[0]); // First bucket
+    expect(assignments[4]).toBe(peers[0]); // Wraparound
+
+    // Second peer gets middle bucket
+    expect(assignments[2]).toBe(peers[1]);
+    expect(assignments[3]).toBe(peers[1]);
+  });
+
+  it('handles peer removal and replacement', async () => {
+    let callCount = 0;
+    mockRandomSampler.random.mockImplementation(max => {
+      if (callCount < 2) return callCount++; // Return 0, then 1 for initial peers
+      return 2; // Return index 2 for replacement peer
+    });
+
+    // With 4 requests and 2 peers:
+    // floor(4/2) = 2 requests per peer
+    // Initial distribution:
+    // Peer 0: 0,1
+    // Peer 1: 2,3
+    const sampler = new BatchConnectionSampler(connectionSampler, /* batchSize */ 4, /* maxPeers */ 2);
+
+    const initialPeer = sampler.getPeerForRequest(0);
+    expect(initialPeer).toBe(peers[0]);
+
+    sampler.removePeerAndReplace(peers[0]);
+
+    // After replacement:
+    // Replacement peer should handle the same bucket
+    const newPeer = sampler.getPeerForRequest(0);
+    expect(newPeer).toBe(peers[2]);
+    expect(sampler.getPeerForRequest(1)).toBe(peers[2]);
+
+    // Other peer's bucket remains unchanged
+    expect(sampler.getPeerForRequest(2)).toBe(peers[1]);
+    expect(sampler.getPeerForRequest(3)).toBe(peers[1]);
+  });
+
+  it('distributes requests according to documentation example', async () => {
+    let callCount = 0;
+    mockRandomSampler.random.mockImplementation(() => {
+      if (callCount < 3) return callCount++;
+      return 0;
+    });
+
+    // Example from doc comment:
+    // Peers:    [P1]      [P2]     [P3]
+    // Requests: 0,1,2,9 | 3,4,5 | 6,7,8
+    const sampler = new BatchConnectionSampler(connectionSampler, /* batchSize */ 10, /* maxPeers */ 3);
+
+    expect(sampler.activePeerCount).toBe(3);
+    expect(sampler.requestsPerBucket).toBe(3); // floor(10/3) = 3
+
+    // P1's bucket (0-2) plus wraparound (9)
+    expect(sampler.getPeerForRequest(0)).toBe(peers[0]);
+    expect(sampler.getPeerForRequest(1)).toBe(peers[0]);
+    expect(sampler.getPeerForRequest(2)).toBe(peers[0]);
+    expect(sampler.getPeerForRequest(9)).toBe(peers[0]); // Wraparound
+
+    // P2's bucket (3-5)
+    expect(sampler.getPeerForRequest(3)).toBe(peers[1]);
+    expect(sampler.getPeerForRequest(4)).toBe(peers[1]);
+    expect(sampler.getPeerForRequest(5)).toBe(peers[1]);
+
+    // P3's bucket (6-8)
+    expect(sampler.getPeerForRequest(6)).toBe(peers[2]);
+    expect(sampler.getPeerForRequest(7)).toBe(peers[2]);
+    expect(sampler.getPeerForRequest(8)).toBe(peers[2]);
+  });
+
+  it('handles edge cases', async () => {
+    mockRandomSampler.random.mockImplementation(() => 0);
+    libp2p.getPeers.mockReturnValue([]);
+
+    const sampler = new BatchConnectionSampler(connectionSampler, /* batchSize */ 5, /* maxPeers */ 2);
+    expect(sampler.activePeerCount).toBe(0);
+    expect(sampler.getPeerForRequest(0)).toBeUndefined();
+
+    let i = 0;
+    mockRandomSampler.random.mockImplementation(() => i++ % 3);
+
+    libp2p.getPeers.mockReturnValue(peers);
+    const samplerWithMorePeers = new BatchConnectionSampler(connectionSampler, /* batchSize */ 2, /* maxPeers */ 3);
+    expect(samplerWithMorePeers.requestsPerBucket).toBe(1); // floor(2/3) = 0
+    // First two requests go to first two peers
+    expect(samplerWithMorePeers.getPeerForRequest(0)).toBe(peers[0]);
+    expect(samplerWithMorePeers.getPeerForRequest(1)).toBe(peers[1]);
+  });
+});

--- a/yarn-project/p2p/src/services/reqresp/connection-sampler/batch_connection_sampler.test.ts
+++ b/yarn-project/p2p/src/services/reqresp/connection-sampler/batch_connection_sampler.test.ts
@@ -93,6 +93,24 @@ describe('BatchConnectionSampler', () => {
     expect(sampler.getPeerForRequest(3)).toBe(peers[1]);
   });
 
+  it('handles peer removal and replacement - no replacement available', () => {
+    mockRandomSampler.random.mockImplementation(() => 2);
+    const sampler = new BatchConnectionSampler(connectionSampler, /* batchSize */ 4, /* maxPeers */ 2);
+
+    expect(sampler.activePeerCount).toBe(2);
+    expect(sampler.getPeerForRequest(0)).toBe(peers[0]);
+
+    // Will sample no peers
+    libp2p.getPeers.mockReturnValue([]);
+
+    // Remove peer 0, its requests will be distributed to peer 1
+    sampler.removePeerAndReplace(peers[0]);
+    // Decrease the number of active peers
+    expect(sampler.activePeerCount).toBe(1);
+
+    expect(sampler.getPeerForRequest(0)).toBe(peers[1]);
+  });
+
   it('distributes requests according to documentation example', () => {
     let callCount = 0;
     mockRandomSampler.random.mockImplementation(() => {

--- a/yarn-project/p2p/src/services/reqresp/connection-sampler/batch_connection_sampler.ts
+++ b/yarn-project/p2p/src/services/reqresp/connection-sampler/batch_connection_sampler.ts
@@ -61,7 +61,9 @@ export class BatchConnectionSampler {
    */
   removePeerAndReplace(peerId: PeerId): void {
     const index = this.batch.findIndex(p => p === peerId);
-    if (index === -1) return;
+    if (index === -1) {
+      return;
+    }
 
     const newPeer = this.connectionSampler.getPeer();
     if (newPeer) {

--- a/yarn-project/p2p/src/services/reqresp/connection-sampler/batch_connection_sampler.ts
+++ b/yarn-project/p2p/src/services/reqresp/connection-sampler/batch_connection_sampler.ts
@@ -1,0 +1,94 @@
+import { createLogger } from '@aztec/foundation/log';
+
+import { type PeerId } from '@libp2p/interface';
+
+import { ConnectionSampler } from './connection_sampler.js';
+
+/**
+ * Manages batches of peers for parallel request processing.
+ * Tracks active peers and provides deterministic peer assignment for requests.
+ *
+ * Example with 3 peers and 10 requests:
+ *
+ * Peers:    [P1]      [P2]     [P3]
+ *           ↓ ↓ ↓ ↓   ↓ ↓ ↓   ↓ ↓ ↓
+ * Requests: 0,1,2,9 | 3,4,5 | 6,7,8
+ *
+ * Each peer handles a bucket of consecutive requests.
+ * If a peer fails, it is replaced while maintaining the same bucket.
+ */
+export class BatchConnectionSampler {
+  private readonly logger = createLogger('p2p:reqresp:batch-connection-sampler');
+  private readonly batch: PeerId[] = [];
+  private readonly requestsPerPeer: number;
+
+  constructor(
+    private readonly connectionSampler: ConnectionSampler,
+    private readonly batchSize: number,
+    private readonly maxPeers: number,
+  ) {
+    // Calculate how many requests each peer should handle, cannot be 0
+    this.requestsPerPeer = Math.max(1, Math.floor(batchSize / maxPeers));
+
+    // Sample initial peers
+    this.batch = this.connectionSampler.samplePeersBatch(maxPeers);
+  }
+
+  /**
+   * Gets the peer responsible for handling a specific request index
+   *
+   * @param index - The request index
+   * @returns The peer assigned to handle this request
+   */
+  getPeerForRequest(index: number): PeerId | undefined {
+    if (this.batch.length === 0) return undefined;
+
+    // Calculate which peer bucket this index belongs to
+    const peerIndex = Math.floor(index / this.requestsPerPeer) % this.batch.length;
+    return this.batch[peerIndex];
+  }
+
+  /**
+   * Removes a peer and replaces it with a new one, maintaining the same position
+   * in the batch array to keep request distribution consistent
+   *
+   * @param peerId - The peer to remove and replace
+   */
+  removePeerAndReplace(peerId: PeerId): void {
+    const index = this.batch.findIndex(p => p === peerId);
+    if (index !== -1) {
+      const newPeer = this.addReplacement();
+      if (newPeer) {
+        this.batch[index] = newPeer;
+        this.logger.trace(`Replaced peer ${peerId} with ${newPeer}`, { peerId, newPeer });
+      } else {
+        // If we couldn't get a replacement, remove the peer and compact the array
+        this.batch.splice(index, 1);
+        this.logger.trace(`Removed peer ${peerId}`, { peerId });
+      }
+    }
+  }
+
+  /**
+   * Adds a new peer
+   *
+   * @returns The new peer if successful, undefined otherwise
+   */
+  private addReplacement(): PeerId | undefined {
+    return this.connectionSampler.getPeer();
+  }
+
+  /**
+   * Gets the number of active peers
+   */
+  get activePeerCount(): number {
+    return this.batch.length;
+  }
+
+  /**
+   * Gets the number of requests each peer is assigned to handle
+   */
+  get requestsPerBucket(): number {
+    return this.requestsPerPeer;
+  }
+}

--- a/yarn-project/p2p/src/services/reqresp/connection-sampler/batch_connection_sampler.ts
+++ b/yarn-project/p2p/src/services/reqresp/connection-sampler/batch_connection_sampler.ts
@@ -67,6 +67,7 @@ export class BatchConnectionSampler {
 
     const excluding = new Map([[peerId, true]]);
     const newPeer = this.connectionSampler.getPeer(excluding);
+
     if (newPeer) {
       this.batch[index] = newPeer;
       this.logger.trace(`Replaced peer ${peerId} with ${newPeer}`, { peerId, newPeer });

--- a/yarn-project/p2p/src/services/reqresp/connection-sampler/batch_connection_sampler.ts
+++ b/yarn-project/p2p/src/services/reqresp/connection-sampler/batch_connection_sampler.ts
@@ -65,7 +65,8 @@ export class BatchConnectionSampler {
       return;
     }
 
-    const newPeer = this.connectionSampler.getPeer();
+    const excluding = new Map([[peerId, true]]);
+    const newPeer = this.connectionSampler.getPeer(excluding);
     if (newPeer) {
       this.batch[index] = newPeer;
       this.logger.trace(`Replaced peer ${peerId} with ${newPeer}`, { peerId, newPeer });

--- a/yarn-project/p2p/src/services/reqresp/connection-sampler/connection_sampler.test.ts
+++ b/yarn-project/p2p/src/services/reqresp/connection-sampler/connection_sampler.test.ts
@@ -167,4 +167,95 @@ describe('ConnectionSampler', () => {
       expect((sampler as any).streams.size).toBe(0);
     });
   });
+
+  describe('samplePeersBatch', () => {
+    beforeEach(async () => {
+      // Create test peers
+      peers = await Promise.all(new Array(5).fill(0).map(() => createSecp256k1PeerId()));
+
+      // Mock libp2p
+      mockLibp2p = {
+        getPeers: jest.fn().mockReturnValue(peers),
+        dialProtocol: jest.fn(),
+      };
+
+      mockRandomSampler = mock<RandomSampler>();
+      sampler = new ConnectionSampler(mockLibp2p, 1000, mockRandomSampler);
+    });
+
+    it('prioritizes peers without active connections', () => {
+      // Set up some peers with active connections
+      sampler['activeConnectionsCount'].set(peers[3], 1);
+      sampler['activeConnectionsCount'].set(peers[4], 2);
+
+      // Sample 3 peers
+      const sampledPeers = sampler.samplePeersBatch(3);
+
+      // Should get peers[0,1,2] first as they have no connections
+      expect(sampledPeers).toHaveLength(3);
+      expect(sampledPeers).toContain(peers[0]);
+      expect(sampledPeers).toContain(peers[1]);
+      expect(sampledPeers).toContain(peers[2]);
+      // Should not include peers with active connections when enough peers without connections exist
+      expect(sampledPeers).not.toContain(peers[3]);
+      expect(sampledPeers).not.toContain(peers[4]);
+    });
+
+    it('falls back to peers with connections when needed', () => {
+      // Set up most peers with active connections
+      sampler['activeConnectionsCount'].set(peers[1], 1);
+      sampler['activeConnectionsCount'].set(peers[2], 1);
+      sampler['activeConnectionsCount'].set(peers[3], 1);
+      sampler['activeConnectionsCount'].set(peers[4], 1);
+
+      mockRandomSampler.random.mockReturnValue(0); // Always pick first available peer
+
+      const sampledPeers = sampler.samplePeersBatch(3);
+
+      // Should get peers[0] first (no connections), then some with connections
+      expect(sampledPeers).toHaveLength(3);
+      expect(sampledPeers[0]).toBe(peers[0]); // The only peer without connections
+      expect(sampledPeers.slice(1)).toEqual(expect.arrayContaining([peers[1]])); // Should include some peers with connections
+    });
+
+    it('handles case when all peers have active connections', () => {
+      // Set up all peers with active connections
+      peers.forEach(peer => sampler['activeConnectionsCount'].set(peer, 1));
+
+      mockRandomSampler.random.mockReturnValue(0); // Always pick first available peer
+
+      const sampledPeers = sampler.samplePeersBatch(3);
+
+      expect(sampledPeers).toHaveLength(3);
+      expect(sampledPeers).toEqual(expect.arrayContaining([peers[0], peers[1], peers[2]]));
+    });
+
+    it('handles case when fewer peers available than requested', () => {
+      // Mock libp2p to return fewer peers
+      const fewPeers = peers.slice(0, 2);
+      mockLibp2p.getPeers.mockReturnValue(fewPeers);
+
+      const sampledPeers = sampler.samplePeersBatch(5);
+
+      expect(sampledPeers).toHaveLength(2); // Should only return available peers
+      expect(sampledPeers).toEqual(expect.arrayContaining(fewPeers));
+    });
+
+    it('handles case when no peers available', () => {
+      mockLibp2p.getPeers.mockReturnValue([]);
+
+      const sampledPeers = sampler.samplePeersBatch(3);
+
+      expect(sampledPeers).toHaveLength(0);
+    });
+
+    it('returns exactly the number of peers requested when available', () => {
+      const sampledPeers = sampler.samplePeersBatch(3);
+
+      expect(sampledPeers).toHaveLength(3);
+      // Verify all peers are unique
+      const uniquePeers = new Set(sampledPeers);
+      expect(uniquePeers.size).toBe(3);
+    });
+  });
 });

--- a/yarn-project/p2p/src/services/reqresp/connection-sampler/connection_sampler.test.ts
+++ b/yarn-project/p2p/src/services/reqresp/connection-sampler/connection_sampler.test.ts
@@ -41,6 +41,12 @@ describe('ConnectionSampler', () => {
       expect(peers).toContain(peer);
     });
 
+    it('returns undefined if no peers are available', () => {
+      mockLibp2p.getPeers.mockReturnValue([]);
+      const peer = sampler.getPeer(excluding);
+      expect(peer).toBeUndefined();
+    });
+
     it('attempts to find peer with no active connections', async () => {
       // Setup: Create active connection to first two peers
       const mockStream1: Partial<Stream> = { id: '1', close: jest.fn() } as Partial<Stream>;

--- a/yarn-project/p2p/src/services/reqresp/connection-sampler/connection_sampler.ts
+++ b/yarn-project/p2p/src/services/reqresp/connection-sampler/connection_sampler.ts
@@ -171,7 +171,7 @@ export class ConnectionSampler {
 
       await stream?.close();
     } catch (error) {
-      this.logger.error(`Failed to close connection to peer ${streamId}`, { error });
+      this.logger.warn(`Failed to close connection to peer with stream id ${streamId}`);
     } finally {
       this.streams.delete(streamId);
     }

--- a/yarn-project/p2p/src/services/reqresp/connection-sampler/connection_sampler.ts
+++ b/yarn-project/p2p/src/services/reqresp/connection-sampler/connection_sampler.ts
@@ -72,6 +72,25 @@ export class ConnectionSampler {
     return peers[randomIndex];
   }
 
+  /**
+   * Samples a batch of peers from the libp2p node
+   *
+   * @param maxPeers - The maximum number of peers to sample
+   * @returns The sampled peers
+   */
+  samplePeersBatch(maxPeers: number): PeerId[] {
+    const peers = [];
+    for (let i = 0; i < maxPeers; i++) {
+      const peer = this.getPeer();
+      // Can be undefined if we have no peers
+      if (peer) {
+        peers.push(peer);
+      }
+    }
+    this.logger.trace(`Batch sampled ${peers.length} peers`, { peers });
+    return peers;
+  }
+
   // Set of passthrough functions to keep track of active connections
 
   /**

--- a/yarn-project/p2p/src/services/reqresp/metrics.ts
+++ b/yarn-project/p2p/src/services/reqresp/metrics.ts
@@ -1,0 +1,57 @@
+// Request response metrics
+import { Attributes, Metrics, ValueType } from '@aztec/telemetry-client';
+import { type TelemetryClient, type Tracer, type UpDownCounter } from '@aztec/telemetry-client';
+
+export class ReqRespMetrics {
+  public readonly tracer: Tracer;
+
+  private readonly sentRequests: UpDownCounter;
+  private readonly receivedRequests: UpDownCounter;
+
+  private readonly failedOutboundRequests: UpDownCounter;
+  private readonly failedInboundRequests: UpDownCounter;
+
+  constructor(readonly telemetryClient: TelemetryClient, name = 'ReqResp') {
+    this.tracer = telemetryClient.getTracer(name);
+
+    const meter = telemetryClient.getMeter(name);
+    this.sentRequests = meter.createUpDownCounter(Metrics.P2P_REQ_RESP_SENT_REQUESTS, {
+      description: 'Number of requests sent to peers',
+      unit: 'requests',
+      valueType: ValueType.INT,
+    });
+    this.receivedRequests = meter.createUpDownCounter(Metrics.P2P_REQ_RESP_RECEIVED_REQUESTS, {
+      description: 'Number of requests received from peers',
+      unit: 'requests',
+      valueType: ValueType.INT,
+    });
+
+    this.failedOutboundRequests = meter.createUpDownCounter(Metrics.P2P_REQ_RESP_FAILED_OUTBOUND_REQUESTS, {
+      description: 'Number of failed outbound requests - nodes not getting valid responses',
+      unit: 'requests',
+      valueType: ValueType.INT,
+    });
+
+    this.failedInboundRequests = meter.createUpDownCounter(Metrics.P2P_REQ_RESP_FAILED_INBOUND_REQUESTS, {
+      description: 'Number of failed inbound requests - node failing to respond to requests',
+      unit: 'requests',
+      valueType: ValueType.INT,
+    });
+  }
+
+  public recordRequestSent(protocol: string) {
+    this.sentRequests.add(1, { [Attributes.P2P_REQ_RESP_PROTOCOL]: protocol });
+  }
+
+  public recordRequestReceived(protocol: string) {
+    this.receivedRequests.add(1, { [Attributes.P2P_REQ_RESP_PROTOCOL]: protocol });
+  }
+
+  public recordRequestError(protocol: string) {
+    this.failedOutboundRequests.add(1, { [Attributes.P2P_REQ_RESP_PROTOCOL]: protocol });
+  }
+
+  public recordResponseError(protocol: string) {
+    this.failedInboundRequests.add(1, { [Attributes.P2P_REQ_RESP_PROTOCOL]: protocol });
+  }
+}

--- a/yarn-project/p2p/src/services/reqresp/reqresp.test.ts
+++ b/yarn-project/p2p/src/services/reqresp/reqresp.test.ts
@@ -29,7 +29,7 @@ describe('ReqResp', () => {
   let peerManager: MockProxy<PeerManager>;
   let peerScoring: MockProxy<PeerScoring>;
   let nodes: ReqRespNode[];
-  let logger = createLogger('test:reqresp.test.ts');
+  const logger = createLogger('test:reqresp.test.ts');
 
   beforeEach(() => {
     peerScoring = mock<PeerScoring>();
@@ -80,7 +80,7 @@ describe('ReqResp', () => {
     expect(res).toBeUndefined();
   });
 
-  it.only('should request from a later peer if other peers are offline', async () => {
+  it('should request from a later peer if other peers are offline', async () => {
     nodes = await createNodes(peerScoring, 4);
 
     await startNodes(nodes);

--- a/yarn-project/p2p/src/services/reqresp/reqresp.test.ts
+++ b/yarn-project/p2p/src/services/reqresp/reqresp.test.ts
@@ -1,4 +1,5 @@
 import { PeerErrorSeverity, TxHash, mockTx } from '@aztec/circuit-types';
+import { createLogger } from '@aztec/foundation/log';
 import { sleep } from '@aztec/foundation/sleep';
 
 import { describe, expect, it, jest } from '@jest/globals';
@@ -28,6 +29,7 @@ describe('ReqResp', () => {
   let peerManager: MockProxy<PeerManager>;
   let peerScoring: MockProxy<PeerScoring>;
   let nodes: ReqRespNode[];
+  let logger = createLogger('test:reqresp.test.ts');
 
   beforeEach(() => {
     peerScoring = mock<PeerScoring>();
@@ -78,7 +80,7 @@ describe('ReqResp', () => {
     expect(res).toBeUndefined();
   });
 
-  it('should request from a later peer if other peers are offline', async () => {
+  it.only('should request from a later peer if other peers are offline', async () => {
     nodes = await createNodes(peerScoring, 4);
 
     await startNodes(nodes);
@@ -96,6 +98,7 @@ describe('ReqResp', () => {
     if (!res) {
       // The peer chosen is randomly selected, and the node above wont respond, so if
       // we wait and try again, there will only be one node to chose from
+      logger.debug('No response from node, retrying');
       await sleep(500);
       res = await nodes[0].req.sendRequest(ReqRespSubProtocol.PING, PING_REQUEST);
     }

--- a/yarn-project/p2p/src/services/reqresp/reqresp.ts
+++ b/yarn-project/p2p/src/services/reqresp/reqresp.ts
@@ -173,6 +173,11 @@ export class ReqResp {
       for (let i = 0; i < numberOfPeers; i++) {
         // Sample a peer to make a request to
         const peer = this.connectionSampler.getPeer(attemptedPeers);
+        if (!peer) {
+          this.logger.debug('No peers available to send requests to');
+          return undefined;
+        }
+
         attemptedPeers.set(peer, true);
 
         this.logger.trace(`Sending request to peer: ${peer.toString()}`);
@@ -285,10 +290,10 @@ export class ReqResp {
         // Make parallel requests for each peer's batch
         // A batch entry will look something like this:
         // PeerId0: [0, 1, 2, 3]
-        // PeerId1: [0, 1, 2, 3]
+        // PeerId1: [4, 5, 6, 7]
 
         // Peer Id 0 will send requests 0, 1, 2, 3 in serial
-        // while simultaneously Peer Id 1 will send requests 0, 1, 2, 3 in serial
+        // while simultaneously Peer Id 1 will send requests 4, 5, 6, 7 in serial
 
         const batchResults = await Promise.all(
           Array.from(requestBatches.entries()).map(async ([peer, indices]) => {

--- a/yarn-project/p2p/src/services/reqresp/reqresp.ts
+++ b/yarn-project/p2p/src/services/reqresp/reqresp.ts
@@ -150,14 +150,17 @@ export class ReqResp {
       // Attempt to ask all of our peers, but sampled in a random order
       // This function is wrapped in a timeout, so we will exit the loop if we have not received a response
       const numberOfPeers = this.libp2p.getPeers().length;
+
       if (numberOfPeers === 0) {
         this.logger.debug('No active peers to send requests to');
         return undefined;
       }
 
+      let attemptedPeers: Map<PeerId, boolean> = new Map();
       for (let i = 0; i < numberOfPeers; i++) {
         // Sample a peer to make a request to
-        const peer = this.connectionSampler.getPeer();
+        const peer = this.connectionSampler.getPeer(attemptedPeers);
+        attemptedPeers.set(peer, true);
 
         this.logger.trace(`Sending request to peer: ${peer.toString()}`);
         const response = await this.sendRequestToPeer(peer, subProtocol, requestBuffer);

--- a/yarn-project/p2p/src/services/reqresp/reqresp.ts
+++ b/yarn-project/p2p/src/services/reqresp/reqresp.ts
@@ -156,7 +156,7 @@ export class ReqResp {
         return undefined;
       }
 
-      let attemptedPeers: Map<PeerId, boolean> = new Map();
+      const attemptedPeers: Map<PeerId, boolean> = new Map();
       for (let i = 0; i < numberOfPeers; i++) {
         // Sample a peer to make a request to
         const peer = this.connectionSampler.getPeer(attemptedPeers);

--- a/yarn-project/telemetry-client/src/attributes.ts
+++ b/yarn-project/telemetry-client/src/attributes.ts
@@ -84,6 +84,8 @@ export const ROLLUP_PROVER_ID = 'aztec.rollup.prover_id';
 export const PROOF_TIMED_OUT = 'aztec.proof.timed_out';
 
 export const P2P_ID = 'aztec.p2p.id';
+export const P2P_REQ_RESP_PROTOCOL = 'aztec.p2p.req_resp.protocol';
+export const P2P_REQ_RESP_BATCH_REQUESTS_COUNT = 'aztec.p2p.req_resp.batch_requests_count';
 export const POOL_NAME = 'aztec.pool.name';
 
 export const SEQUENCER_STATE = 'aztec.sequencer.state';

--- a/yarn-project/telemetry-client/src/metrics.ts
+++ b/yarn-project/telemetry-client/src/metrics.ts
@@ -71,6 +71,11 @@ export const L1_PUBLISHER_TX_BLOBDATA_GAS_COST = 'aztec.l1_publisher.tx_blobdata
 export const PEER_MANAGER_GOODBYES_SENT = 'aztec.peer_manager.goodbyes_sent';
 export const PEER_MANAGER_GOODBYES_RECEIVED = 'aztec.peer_manager.goodbyes_received';
 
+export const P2P_REQ_RESP_SENT_REQUESTS = 'aztec.p2p.req_resp.sent_requests';
+export const P2P_REQ_RESP_RECEIVED_REQUESTS = 'aztec.p2p.req_resp.received_requests';
+export const P2P_REQ_RESP_FAILED_OUTBOUND_REQUESTS = 'aztec.p2p.req_resp.failed_outbound_requests';
+export const P2P_REQ_RESP_FAILED_INBOUND_REQUESTS = 'aztec.p2p.req_resp.failed_inbound_requests';
+
 export const PUBLIC_PROCESSOR_TX_DURATION = 'aztec.public_processor.tx_duration';
 export const PUBLIC_PROCESSOR_TX_COUNT = 'aztec.public_processor.tx_count';
 export const PUBLIC_PROCESSOR_TX_PHASE_COUNT = 'aztec.public_processor.tx_phase_count';


### PR DESCRIPTION
## Overview

Adds batch functionality to libp2p reqresp. 

Adds:
- Batch connection sampler
    - Manages a number of peers performing a number of request response jobs 
    - Samples peers we do not have active reqresp connections with and splits work among them

- reqresp.sendBatchRequest
    - Uses the batch connection sampler to request lots of items spread among many peers
    
  part of https://github.com/AztecProtocol/aztec-packages/issues/8458
