### PR TITLE
feat(p2p): validator use batch requests

### DIFF
--- a/yarn-project/p2p/src/client/p2p_client.ts
+++ b/yarn-project/p2p/src/client/p2p_client.ts
@@ -444,9 +444,9 @@ export class P2PClient<T extends P2PClientType = P2PClientType.Full>
    * @param txHashes - The hashes of the transactions to request.
    * @returns A promise that resolves to an array of transactions or undefined.
    */
-  public requestTxs(txHashes: TxHash[]): Promise<(Tx | undefined)[]> {
-    const requestPromises = txHashes.map(txHash => this.requestTxByHash(txHash));
-    return Promise.all(requestPromises);
+  public async requestTxs(txHashes: TxHash[]): Promise<(Tx | undefined)[]> {
+    const res = await this.p2pService.sendBatchRequest(ReqRespSubProtocol.TX, txHashes);
+    return Promise.resolve(res ?? []);
   }
 
   /**

--- a/yarn-project/p2p/src/services/dummy_service.ts
+++ b/yarn-project/p2p/src/services/dummy_service.ts
@@ -62,6 +62,19 @@ export class DummyP2PService implements P2PService {
   }
 
   /**
+   * Sends a batch request to a peer.
+   * @param _protocol - The protocol to send the request on.
+   * @param _requests - The requests to send.
+   * @returns The responses from the peer, otherwise undefined.
+   */
+  public sendBatchRequest<Protocol extends ReqRespSubProtocol>(
+    _protocol: Protocol,
+    _requests: InstanceType<SubProtocolMap[Protocol]['request']>[],
+  ): Promise<InstanceType<SubProtocolMap[Protocol]['response']>[]> {
+    return Promise.resolve([]);
+  }
+
+  /**
    * Returns the ENR of the peer.
    * @returns The ENR of the peer, otherwise undefined.
    */

--- a/yarn-project/p2p/src/services/libp2p/libp2p_service.ts
+++ b/yarn-project/p2p/src/services/libp2p/libp2p_service.ts
@@ -401,6 +401,19 @@ export class LibP2PService<T extends P2PClientType> extends WithTracer implement
   }
 
   /**
+   * Send a batch of requests to peers, and return the responses
+   * @param protocol - The request response protocol to use
+   * @param requests - The requests to send to the peers
+   * @returns The responses to the requests
+   */
+  sendBatchRequest<SubProtocol extends ReqRespSubProtocol>(
+    protocol: SubProtocol,
+    requests: InstanceType<SubProtocolMap[SubProtocol]['request']>[],
+  ): Promise<InstanceType<SubProtocolMap[SubProtocol]['response']>[] | undefined> {
+    return this.reqresp.sendBatchRequest(protocol, requests);
+  }
+
+  /**
    * Get the ENR of the node
    * @returns The ENR of the node
    */

--- a/yarn-project/p2p/src/services/reqresp/interface.ts
+++ b/yarn-project/p2p/src/services/reqresp/interface.ts
@@ -112,7 +112,10 @@ export const DEFAULT_SUB_PROTOCOL_HANDLERS: ReqRespSubProtocolHandlers = {
  * The Request Response Pair interface defines the methods that each
  * request response pair must implement
  */
-interface RequestResponsePair<Req, Res> {
+interface RequestResponsePair<Req extends { toBuffer(): Buffer }, Res> {
+  /**
+   * The request must implement the toBuffer method (generic serialisation)
+   */
   request: new (...args: any[]) => Req;
   /**
    * The response must implement the static fromBuffer method (generic serialisation)

--- a/yarn-project/p2p/src/services/service.ts
+++ b/yarn-project/p2p/src/services/service.ts
@@ -45,6 +45,18 @@ export interface P2PService {
     request: InstanceType<SubProtocolMap[Protocol]['request']>,
   ): Promise<InstanceType<SubProtocolMap[Protocol]['response']> | undefined>;
 
+  /**
+   * Send a batch of requests to peers, and return the responses
+   *
+   * @param protocol - The request response protocol to use
+   * @param requests - The requests to send to the peers
+   * @returns The responses to the requests
+   */
+  sendBatchRequest<Protocol extends ReqRespSubProtocol>(
+    protocol: Protocol,
+    requests: InstanceType<SubProtocolMap[Protocol]['request']>[],
+  ): Promise<InstanceType<SubProtocolMap[Protocol]['response']>[] | undefined>;
+
   // Leaky abstraction: fix https://github.com/AztecProtocol/aztec-packages/issues/7963
   registerBlockReceivedCallback(callback: (block: BlockProposal) => Promise<BlockAttestation | undefined>): void;
 


### PR DESCRIPTION
## Overview

Validator uses batch requests instead of individual request responses
