### PR TITLE
Implement Role-Based Access Control for Validators and Admins: l1-contract Rollup.sol

### DIFF
--- a/bootstrap.sh
+++ b/bootstrap.sh
@@ -62,12 +62,11 @@ function check_toolchains {
   fi
   # Check foundry version.
   for tool in forge anvil; do
-    if ! $tool --version 2> /dev/null | grep 25f24e6 > /dev/null; then
+    if ! $tool --version 2> /dev/null | grep 5a8bd89 > /dev/null; then
       encourage_dev_container
-      echo "$tool not in PATH or incorrect version (requires 25f24e677a6a32a62512ad4f561995589ac2c7dc)."
+      echo "$tool not in PATH or incorrect version (requires 5a8bd893eeeeb9489ea66dd52a02eeaa580e3af0)."
       echo "Installation: https://book.getfoundry.sh/getting-started/installation"
       echo "  curl -L https://foundry.paradigm.xyz | bash"
-      echo "  foundryup -v nightly-25f24e677a6a32a62512ad4f561995589ac2c7dc"
       exit 1
     fi
   done

--- a/l1-contracts/src/core/interfaces/IRollup.sol
+++ b/l1-contracts/src/core/interfaces/IRollup.sol
@@ -88,6 +88,8 @@ interface IRollup {
     Slot currentSlot
   );
 
+  function addValidator(address validator) external;
+  function removeValidator(address validator) external;
   function prune() external;
   function updateL1GasFeeOracle() external;
 


### PR DESCRIPTION
## Purpose:
The introduction of role-based access control strengthens the contract by ensuring that only authorized roles (Admin and Validators) can perform critical functions. 

Admins have control over managing validators, while validators are responsible for pruning, proposing actions, submitting epoch proofs, and submitting blocks. Currently, there is no access control in place, meaning blocks can be submitted by anyone, potentially resulting in invalid or garbage data. This change introduces proper authorization to safeguard against such risks. When it's time, this can be reviewed and merged, and is ready for any further updates.



## Changes Introduced:

1. **Role Definitions**:
   - Added role constants for `VALIDATOR_ROLE` and `ADMIN_ROLE` to define access control permissions.
   ````
   bytes32 public constant VALIDATOR_ROLE = keccak256("VALIDATOR_ROLE");
   bytes32 public constant ADMIN_ROLE = keccak256("ADMIN_ROLE"); ````

2. **Grant Roles to Deployer**:

- On contract deployment, the deployer is automatically granted both ADMIN_ROLE and VALIDATOR_ROLE.
```
_grantRole(ADMIN_ROLE, msg.sender);
_grantRole(VALIDATOR_ROLE, msg.sender);  
```

3. **New Functions for Validator Management**:

addValidator: Allows the ADMIN_ROLE holder to add new validators by granting them the VALIDATOR_ROLE.
removeValidator: Allows the ADMIN_ROLE holder to remove validators by revoking their VALIDATOR_ROLE.

```
function addValidator(address validator) external override(IRollup) onlyRole(ADMIN_ROLE) {
  grantRole(VALIDATOR_ROLE, validator);
}

function removeValidator(address validator) external override(IRollup) onlyRole(ADMIN_ROLE) {
  revokeRole(VALIDATOR_ROLE, validator);
}
```
4. **Restrict Functions to Validators**:

Functions such as prune(), proposeAndClaim(), and submitEpochRootProof() are restricted to VALIDATOR_ROLE. This ensures that only validators can execute these critical operations.

```
 function prune() external override(IRollup) onlyRole(VALIDATOR_ROLE) {
  require(canPrune(), Errors.Rollup__NothingToPrune());
  _prune();
}

function proposeAndClaim(
  ProposeArgs calldata _args,
  Signature[] memory _signatures,
  bytes calldata _body,
  bytes calldata _blobInput,
  SignedEpochProofQuote calldata _quote
) external override(IRollup) onlyRole(VALIDATOR_ROLE){
  propose(_args, _signatures, _body, _blobInput);
  claimEpochProofRight(_quote);
}

function submitEpochRootProof(SubmitEpochRootProofArgs calldata _args) external override(IRollup) onlyRole(VALIDATOR_ROLE){
  if (canPrune()) {
    _prune();
  }
}
```

5. **Access Control for Propose Function**:

The propose() function is also restricted to VALIDATOR_ROLE, ensuring that only validators can propose new actions.

```
function propose(
  ProposeArgs calldata _args,
  Signature[] memory _signatures,
  bytes calldata,
  bytes calldata _blobInput
) public override(IRollup) onlyRole(VALIDATOR_ROLE) {
  if (canPrune()) {
    _prune();
  }
  updateL1GasFeeOracle();
}
```




