### PR TITLE
fix(bootstrap): include crates in noir projects hashes

### DIFF
--- a/noir-projects/noir-protocol-circuits/bootstrap.sh
+++ b/noir-projects/noir-protocol-circuits/bootstrap.sh
@@ -12,6 +12,7 @@ export BB=${BB:-../../barretenberg/cpp/build/bin/bb}
 export NARGO=${NARGO:-../../noir/noir-repo/target/release/nargo}
 export BB_HASH=$(cache_content_hash ../../barretenberg/cpp/.rebuild_patterns)
 export NARGO_HASH=$(cache_content_hash ../../noir/.rebuild_patterns)
+export CRATES_HASH=$(cache_content_hash crates)
 
 # Set flags for parallel
 export PARALLELISM=${PARALLELISM:-16}
@@ -41,7 +42,6 @@ rollup_honk_patterns=(
   "rollup_merge"
 )
 
-
 ivc_regex=$(IFS="|"; echo "${ivc_patterns[*]}")
 rollup_honk_regex=$(IFS="|"; echo "${rollup_honk_patterns[*]}")
 
@@ -65,10 +65,12 @@ function compile {
   local json_path="./target/$filename"
   local program_hash hash bytecode_hash vk vk_fields
   local program_hash_cmd="$NARGO check --package $name --silence-warnings --show-program-hash | cut -d' ' -f2"
-  # echo_stderr $program_hash_cmd
   program_hash=$(dump_fail "$program_hash_cmd")
-  echo_stderr "Hash preimage: $NARGO_HASH-$program_hash"
-  hash=$(hash_str "$NARGO_HASH-$program_hash")
+  echo_stderr "Hash preimage: $NARGO_HASH-$CRATES_HASH-$program_hash"
+  # We include CRATES_HASH as --show-program-hash does not do a good job at hashing dependencies.
+  # TODO(ci3) we may need to do a less granular hash if this doesn't work out.
+  hash=$(hash_str "$NARGO_HASH-$CRATES_HASH-$program_hash")
+
   if ! cache_download circuit-$hash.tar.gz 1>&2; then
     SECONDS=0
     rm -f $json_path


### PR DESCRIPTION
There is an issue here with `--show-program-hash`. There were two options, investigate and fix the intended semantics of this flag, or make the cache more granular. I decided for now to just include the problematic folder.