### PR TITLE
chore: Point to monorepo's nargo in vscode workspace settings

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -189,5 +189,6 @@
     "wasi",
     "memfree",
     "tmpfs"
-  ]
+  ],
+  "noir.nargoPath": "${workspaceFolder}/noir/noir-repo/target/release/nargo"
 }


### PR DESCRIPTION
Uses the new `workspaceFolder` in the vscode noir extension.
