### PR TITLE
fix(bootstrap): include crates in noir projects hashes take 2

### DIFF
--- a/noir-projects/noir-contracts/bootstrap.sh
+++ b/noir-projects/noir-contracts/bootstrap.sh
@@ -108,6 +108,7 @@ function compile {
     ../../noir/.rebuild_patterns \
     ../../avm-transpiler/.rebuild_patterns \
     "^noir-projects/noir-contracts/contracts/$contract/" \
+    "^noir-projects/noir-protocol-circuits/crates" \
     "^noir-projects/aztec-nr/" \
   )"
   if ! cache_download contract-$contract_hash.tar.gz &> /dev/null; then

--- a/noir-projects/noir-protocol-circuits/bootstrap.sh
+++ b/noir-projects/noir-protocol-circuits/bootstrap.sh
@@ -12,7 +12,6 @@ export BB=${BB:-../../barretenberg/cpp/build/bin/bb}
 export NARGO=${NARGO:-../../noir/noir-repo/target/release/nargo}
 export BB_HASH=$(cache_content_hash ../../barretenberg/cpp/.rebuild_patterns)
 export NARGO_HASH=$(cache_content_hash ../../noir/.rebuild_patterns)
-export CRATES_HASH=$(cache_content_hash crates)
 
 # Set flags for parallel
 export PARALLELISM=${PARALLELISM:-16}
@@ -42,6 +41,7 @@ rollup_honk_patterns=(
   "rollup_merge"
 )
 
+
 ivc_regex=$(IFS="|"; echo "${ivc_patterns[*]}")
 rollup_honk_regex=$(IFS="|"; echo "${rollup_honk_patterns[*]}")
 
@@ -65,12 +65,10 @@ function compile {
   local json_path="./target/$filename"
   local program_hash hash bytecode_hash vk vk_fields
   local program_hash_cmd="$NARGO check --package $name --silence-warnings --show-program-hash | cut -d' ' -f2"
+  # echo_stderr $program_hash_cmd
   program_hash=$(dump_fail "$program_hash_cmd")
-  echo_stderr "Hash preimage: $NARGO_HASH-$CRATES_HASH-$program_hash"
-  # We include CRATES_HASH as --show-program-hash does not do a good job at hashing dependencies.
-  # TODO(ci3) we may need to do a less granular hash if this doesn't work out.
-  hash=$(hash_str "$NARGO_HASH-$CRATES_HASH-$program_hash")
-
+  echo_stderr "Hash preimage: $NARGO_HASH-$program_hash"
+  hash=$(hash_str "$NARGO_HASH-$program_hash")
   if ! cache_download circuit-$hash.tar.gz 1>&2; then
     SECONDS=0
     rm -f $json_path


### PR DESCRIPTION
I was wrong here - the crates were used in the noir contracts. And that didn't use program hash.