### PR TITLE
chore: Try fix e2e block building flake

### DIFF
--- a/yarn-project/end-to-end/src/e2e_block_building.test.ts
+++ b/yarn-project/end-to-end/src/e2e_block_building.test.ts
@@ -194,7 +194,9 @@ describe('e2e_block_building', () => {
     });
 
     it('processes txs until hitting timetable', async () => {
-      const TX_COUNT = 32;
+      // We send enough txs so they are spread across multiple blocks, but not
+      // so many so that we don't end up hitting a reorg or timing out the tx wait().
+      const TX_COUNT = 16;
 
       const ownerAddress = owner.getCompleteAddress().address;
       const contract = await StatefulTestContract.deploy(owner, ownerAddress, ownerAddress, 1).send().deployed();
@@ -212,7 +214,7 @@ describe('e2e_block_building', () => {
 
       // We also cheat the sequencer's timetable so it allocates little time to processing.
       // This will leave the sequencer with just a few seconds to build the block, so it shouldn't
-      // be able to squeeze in more than ~12 txs in each. This is sensitive to the time it takes
+      // be able to squeeze in more than a few txs in each. This is sensitive to the time it takes
       // to pick up and validate the txs, so we may need to bump it to work on CI.
       jest
         .spyOn(sequencer.sequencer.timetable, 'getBlockProposalExecTimeEnd')


### PR DESCRIPTION
The test was failing [in some runs](https://github.com/AztecProtocol/aztec-packages/actions/runs/12869132447/job/35878509644#step:3:4657) because apparently the 32 txs take too long to go in (they are processed 1 or 2 per block only) and a reorg kicks in before that.

This PR reduces the total number of txs so we don't reach that point. Note that if we speed up tx processing significantly, then all txs could end up processed within one second and end up on the same block. If that happens, we'll need to increase the number of txs again.