### PR TITLE
chore: renaming emit unencrypted -> emit public

### DIFF
--- a/docs/docs/guides/developer_guides/js_apps/test.md
+++ b/docs/docs/guides/developer_guides/js_apps/test.md
@@ -121,11 +121,11 @@ Public state behaves as a key-value store, much like in the EVM. We can directly
 
 You can check the logs of events emitted by contracts. Contracts in Aztec can emit both encrypted and unencrypted events.
 
-#### Querying unencrypted logs
+#### Querying public logs
 
-We can query the PXE for the unencrypted logs emitted in the block where our transaction is mined. Logs need to be unrolled and formatted as strings for consumption.
+We can query the PXE for the public logs emitted in the block where our transaction is mined.
 
-#include_code unencrypted-logs /yarn-project/end-to-end/src/guides/dapp_testing.test.ts typescript
+#include_code public-logs /yarn-project/end-to-end/src/guides/dapp_testing.test.ts typescript
 
 ## Cheats
 

--- a/docs/docs/guides/developer_guides/smart_contracts/writing_contracts/how_to_emit_event.md
+++ b/docs/docs/guides/developer_guides/smart_contracts/writing_contracts/how_to_emit_event.md
@@ -38,11 +38,11 @@ Aztec.nr enables smart contract developers to design custom notes, meaning devel
 
 Unencrypted events are events which can be read by anyone. They can be emitted **only** by public functions.
 
-### Call emit_unencrypted_log
+### Call emit_public_log
 
-To emit unencrypted logs you don't need to import any library. You call the context method `emit_unencrypted_log`:
+To emit public logs you don't need to import any library. You call the context method `emit_public_log`:
 
-#include_code emit_unencrypted /noir-projects/noir-contracts/contracts/test_contract/src/main.nr rust
+#include_code emit_public /noir-projects/noir-contracts/contracts/test_contract/src/main.nr rust
 
 ### Querying the unencrypted event
 

--- a/docs/docs/guides/privacy_considerations.md
+++ b/docs/docs/guides/privacy_considerations.md
@@ -53,13 +53,13 @@ Any time a private function makes a call to a public function, information is le
 
 ### Crossing the public -> private boundary
 
-If a public function sends a message to be consumed by a private function, the act of consuming that message might be leaked if not following recommended patterns. 
+If a public function sends a message to be consumed by a private function, the act of consuming that message might be leaked if not following recommended patterns.
 
 ### Timing of transactions
 
 Information about the nature of a transaction can be leaked based on the timing of that transaction.
 
-If a transaction is executed at 8am GMT, it's much less likely to have been made by someone in the USA. 
+If a transaction is executed at 8am GMT, it's much less likely to have been made by someone in the USA.
 
 If there's a spike in transactions on the last day of every month, those might be salaries.
 
@@ -79,7 +79,7 @@ A 'Function Fingerprint' is any data which is exposed by a function to the outsi
   - All arguments which are passed to public functions.
 - All calls to L1 functions (in the form of L2 -> L1 messages).
   - The contents of L2 -> L1 messages.
-- All unencrypted logs (topics and arguments).
+- All public logs (topics and arguments).
 - The roots of all trees which have been read from.
 - The _number_ of ['side effects'](<https://en.wikipedia.org/wiki/Side_effect_(computer_science)>):
   - \# new note hashes

--- a/docs/docs/migration_notes.md
+++ b/docs/docs/migration_notes.md
@@ -16,6 +16,12 @@ Any log emitted from public is now known as a public log, rather than an unencry
 + getPublicEvents<T>(eventMetadata: EventMetadataDefinition, from: number, limit: number): Promise<T[]>
 ```
 
+The context method in aztec.nr is now:
+```diff
+- context.emit_unencrypted_log(log)
++ context.emit_public_log(log)
+```
+
 These logs were treated as bytes in the node and as hashes in the protocol circuits. Now, public logs are treated as fields everywhere:
 ```diff
 - unencryptedLogs: UnencryptedTxL2Logs

--- a/docs/docs/protocol-specs/calls/static-calls.md
+++ b/docs/docs/protocol-specs/calls/static-calls.md
@@ -10,10 +10,8 @@ In particular, the following fields of the returned `CallStackItem` must be zero
 - `new_nullifiers`
 - `nullified_commitments`
 - `new_l2_to_l1_msgs`
-- `encrypted_logs_hash`
-- `unencrypted_logs_hash`
-- `encrypted_log_preimages_length`
-- `unencrypted_log_preimages_length`
+- `private_logs`
+- `public_logs`
 
 From the moment a static call is made, every subsequent nested call is forced to be static by setting a flag in the derived `CallContext`, which propagates through the call stack.
 

--- a/docs/docs/protocol-specs/contract-deployment/classes.md
+++ b/docs/docs/protocol-specs/contract-deployment/classes.md
@@ -240,7 +240,7 @@ fn register(
 
   emit_nullifier(contract_class_id);
 
-  emit_unencrypted_event(ContractClassRegistered::new(
+  emit_public_log(ContractClassRegistered::new(
     contract_class_id,
     version,
     artifact_hash,
@@ -277,7 +277,7 @@ fn broadcast_private_function(
   artifact_function_tree_leaf_index: Field,
   function: { selector: Field, metadata_hash: Field, vk_hash: Field, bytecode: Field[] },
 )
-  emit_unencrypted_event ClassPrivateFunctionBroadcasted(
+  emit_public_log ClassPrivateFunctionBroadcasted(
     contract_class_id,
     artifact_metadata_hash,
     unconstrained_functions_artifact_tree_root,
@@ -298,7 +298,7 @@ fn broadcast_unconstrained_function(
   artifact_function_tree_leaf_index: Field
   function: { selector: Field, metadata_hash: Field, bytecode: Field[] }[],
 )
-  emit_unencrypted_event ClassUnconstrainedFunctionBroadcasted(
+  emit_public_log ClassUnconstrainedFunctionBroadcasted(
     contract_class_id,
     artifact_metadata_hash,
     private_functions_artifact_tree_root,

--- a/docs/docs/protocol-specs/contract-deployment/instances.md
+++ b/docs/docs/protocol-specs/contract-deployment/instances.md
@@ -130,7 +130,7 @@ fn deploy (
 
   emit_nullifier(address);
 
-  emit_unencrypted_event(ContractInstanceDeployed::new(address, version, salt, contract_class_id, initialization_hash, public_keys_hash));
+  emit_public_log(ContractInstanceDeployed::new(address, version, salt, contract_class_id, initialization_hash, public_keys_hash));
 ```
 
 > See [address](../addresses-and-keys/address.md) for `address_crh`.

--- a/docs/docs/protocol-specs/logs/index.md
+++ b/docs/docs/protocol-specs/logs/index.md
@@ -4,6 +4,7 @@ title: Logs
 
 <!-- Did we resolve how to prevent impersonation for all kinds of log? -->
 <!-- We have a DoS problem, if a user sends a huge, malicious log preimage which DOES NOT hash to the logs_hash in the public inputs. The sequencer wastes time computing the hash, but cannot include the hash in their tx. -->
+<!-- TODO: completely overhaul this, it's been incorrect for a long time. -->
 
 Logs on Aztec are similar to logs on Ethereum, enabling smart contracts to convey arbitrary data to external entities. Offchain applications can use logs to interpret events that have occurred on-chain. There are three types of log:
 
@@ -64,12 +65,12 @@ Both the `accumulated_logs_hash` and `accumulated_logs_length` for each type are
 
 When publishing a block on L1, the raw logs of each type and their lengths are provided (**Availability**), hashed and accumulated into each respective `accumulated_logs_hash` and `accumulated_logs_length`, then included in the on-chain recalculation of `txs_effect_hash`. If this value doesn't match the one from the rollup circuits, the block will not be valid (**Immutability**).
 
-<!-- 
+<!--
 In cases where two proofs are combined to form a single proof, the _accumulated_logs_hash_ and _accumulated_logs_length_ from the two child proofs must be merged into one accumulated value:
 
 - _`accumulated_logs_hash = hash(proof_0.accumulated_logs_hash, proof_1.accumulated_logs_hash)`_
   - If either hash is zero, the new hash will be _`proof_0.accumulated_logs_hash | proof_1.accumulated_logs_hash`_.
-- _`accumulated_logs_length = proof_0.accumulated_logs_length + proof_1.accumulated_logs_length`_ 
+- _`accumulated_logs_length = proof_0.accumulated_logs_length + proof_1.accumulated_logs_length`_
 -->
 
 For private and public kernel circuits, beyond aggregating logs from a function call, they ensure that the contract's address emitting the logs is linked to the _logs_hash_. For more details, refer to the "Hashing" sections in [Unencrypted Log](#hashing-1), [Encrypted Log](#hashing-2), and [Encrypted Note Preimage](#hashing-3).

--- a/docs/docs/tutorials/codealong/contract_tutorials/crowdfunding_contract.md
+++ b/docs/docs/tutorials/codealong/contract_tutorials/crowdfunding_contract.md
@@ -199,4 +199,4 @@ Follow the account contract tutorial on the [next page](./write_accounts_contrac
  - [Initializer functions](../../../guides/developer_guides/smart_contracts/writing_contracts/initializers.md)
  - [Versions](../../../guides/developer_guides/local_env/versions-updating.md).
  - [Authorizing actions](../../../aztec/concepts/accounts/index.md#authorizing-actions)
- - [Unencrypted logs](../../../guides/developer_guides/smart_contracts/writing_contracts/how_to_emit_event.md#call-emit_unencrypted_log)
+ - [Public logs](../../../guides/developer_guides/smart_contracts/writing_contracts/how_to_emit_event.md#call-emit_public_log)

--- a/noir-projects/aztec-nr/aztec/src/context/public_context.nr
+++ b/noir-projects/aztec-nr/aztec/src/context/public_context.nr
@@ -16,13 +16,13 @@ impl PublicContext {
     pub fn new(compute_args_hash: fn() -> Field) -> Self {
         PublicContext { args_hash: Option::none(), compute_args_hash }
     }
-    // TODO(MW): continue renaming unencrypted -> public
-    pub fn emit_unencrypted_log<T, let N: u32>(_self: &mut Self, log: T)
+
+    pub fn emit_public_log<T, let N: u32>(_self: &mut Self, log: T)
     where
         T: Serialize<N>,
     {
         /// Safety: AVM opcodes are constrained by the AVM itself
-        unsafe { emit_unencrypted_log(Serialize::serialize(log).as_slice()) };
+        unsafe { emit_public_log(Serialize::serialize(log).as_slice()) };
     }
 
     pub fn note_hash_exists(_self: Self, note_hash: Field, leaf_index: Field) -> bool {
@@ -295,8 +295,8 @@ unconstrained fn nullifier_exists(nullifier: Field, address: Field) -> u1 {
 unconstrained fn emit_nullifier(nullifier: Field) {
     emit_nullifier_opcode(nullifier)
 }
-unconstrained fn emit_unencrypted_log(message: [Field]) {
-    emit_unencrypted_log_opcode(message)
+unconstrained fn emit_public_log(message: [Field]) {
+    emit_public_log_opcode(message)
 }
 unconstrained fn l1_to_l2_msg_exists(msg_hash: Field, msg_leaf_index: Field) -> u1 {
     l1_to_l2_msg_exists_opcode(msg_hash, msg_leaf_index)
@@ -398,8 +398,9 @@ unconstrained fn nullifier_exists_opcode(nullifier: Field, address: Field) -> u1
 #[oracle(avmOpcodeEmitNullifier)]
 unconstrained fn emit_nullifier_opcode(nullifier: Field) {}
 
+// TODO(#11124): rename unencrypted to public in avm
 #[oracle(avmOpcodeEmitUnencryptedLog)]
-unconstrained fn emit_unencrypted_log_opcode(message: [Field]) {}
+unconstrained fn emit_public_log_opcode(message: [Field]) {}
 
 #[oracle(avmOpcodeL1ToL2MsgExists)]
 unconstrained fn l1_to_l2_msg_exists_opcode(msg_hash: Field, msg_leaf_index: Field) -> u1 {}

--- a/noir-projects/aztec-nr/aztec/src/macros/notes/mod.nr
+++ b/noir-projects/aztec-nr/aztec/src/macros/notes/mod.nr
@@ -578,28 +578,29 @@ comptime fn get_setup_log_plaintext_body(
 ///     }
 ///
 ///     fn emit_log(self) {
-///         let setup_log_fields: [Field; 16] = self.context.storage_read(self.setup_log_slot);
+///         let setup_log_fields: [Field; 8] = self.context.storage_read(self.setup_log_slot);
 ///
-///         let setup_log: [u8; 481] = aztec::utils::bytes::fields_to_bytes(setup_log_fields);
+///         let mut finalization_log = [0; 11];
 ///
-///         let mut finalization_log = [0; 513];
-///
-///         for i in 0..setup_log.len() {
-///             finalization_log[i] = setup_log[i];
+///         for i in 0..setup_log_fields.len() {
+///             finalization_log[i + 1] = setup_log_fields[i];
 ///         }
 ///
 ///         for i in 0..self.public_values.len() {
-///             let public_value_bytes: [u8; 32] = self.public_values[i].to_be_bytes();
-///             for j in 0..public_value_bytes.len() {
-///                 finalization_log[160 + i * 32 + j] = public_value_bytes[j];
-///             }
+///            finalization_log[i + 1 + 8] = self.public_values[j];
 ///         }
 ///
-///         self.context.emit_unencrypted_log(finalization_log);
+///         finalization_log[0] = aztec::protocol_types::utils::field::field_from_bytes([
+///                 (2 >> 8) as u8, 2 as u8, 0,
+///                 (8 >> 8) as u8, 8 as u8, 0,
+///                 (91 >> 8) as u8, 91 as u8,
+///                ], true);
+///
+///         self.context.emit_public_log(finalization_log);
 ///
 ///         // We reset public storage to zero to achieve the effect of transient storage - kernels will squash
 ///         // the writes
-///         // self.context.storage_write(self.setup_log_slot, [0; 16]);
+///         // self.context.storage_write(self.setup_log_slot, [0; 8]);
 ///     }
 /// }
 ///
@@ -749,7 +750,7 @@ comptime fn generate_finalization_payload(
                 ], true);
 
                 // We emit the finalization log via the public logs stream
-                self.context.emit_unencrypted_log(finalization_log);
+                self.context.emit_public_log(finalization_log);
 
                 // We reset public storage to zero to achieve the effect of transient storage - kernels will squash
                 // the writes

--- a/noir-projects/aztec-nr/aztec/src/unencrypted_logs/unencrypted_event_emission.nr
+++ b/noir-projects/aztec-nr/aztec/src/unencrypted_logs/unencrypted_event_emission.nr
@@ -16,7 +16,7 @@ where
 
     emitted_log[serialized_event.len()] = selector.to_field();
 
-    context.emit_unencrypted_log(emitted_log);
+    context.emit_public_log(emitted_log);
 }
 
 pub fn encode_event<Event, let N: u32>(

--- a/noir-projects/noir-contracts/contracts/avm_test_contract/src/main.nr
+++ b/noir-projects/noir-contracts/contracts/avm_test_contract/src/main.nr
@@ -463,12 +463,12 @@ contract AvmTest {
     }
 
     #[public]
-    fn emit_unencrypted_log() {
-        context.emit_unencrypted_log(/*message=*/ [10, 20, 30]);
-        context.emit_unencrypted_log(/*message=*/ "Hello, world!");
+    fn emit_public_log() {
+        context.emit_public_log(/*message=*/ [10, 20, 30]);
+        context.emit_public_log(/*message=*/ "Hello, world!");
         let s: CompressedString<2, 44> =
             CompressedString::from_string("A long time ago, in a galaxy far far away...");
-        context.emit_unencrypted_log(/*message=*/ s);
+        context.emit_public_log(/*message=*/ s);
     }
 
     #[public]
@@ -517,9 +517,9 @@ contract AvmTest {
     }
 
     #[public]
-    fn n_new_unencrypted_logs(num: u32) {
+    fn n_new_public_logs(num: u32) {
         for i in 0..num {
-            context.emit_unencrypted_log(/*message=*/ [i as Field]);
+            context.emit_public_log(/*message=*/ [i as Field]);
         }
     }
 
@@ -706,8 +706,8 @@ contract AvmTest {
         let _ = get_l2_gas_left();
         dep::aztec::oracle::debug_log::debug_log("get_da_gas_left");
         let _ = get_da_gas_left();
-        dep::aztec::oracle::debug_log::debug_log("emit_unencrypted_log");
-        let _ = emit_unencrypted_log();
+        dep::aztec::oracle::debug_log::debug_log("emit_public_log");
+        let _ = emit_public_log();
         dep::aztec::oracle::debug_log::debug_log("note_hash_exists");
         let _ = note_hash_exists(1, 2);
         dep::aztec::oracle::debug_log::debug_log("new_note_hash");

--- a/noir-projects/noir-contracts/contracts/benchmarking_contract/src/main.nr
+++ b/noir-projects/noir-contracts/contracts/benchmarking_contract/src/main.nr
@@ -50,6 +50,6 @@ contract Benchmarking {
     // Emits a public log.
     #[public]
     fn broadcast(owner: AztecAddress) {
-        context.emit_unencrypted_log(storage.balances.at(owner).read());
+        context.emit_public_log(storage.balances.at(owner).read());
     }
 }

--- a/noir-projects/noir-contracts/contracts/child_contract/src/main.nr
+++ b/noir-projects/noir-contracts/contracts/child_contract/src/main.nr
@@ -48,7 +48,7 @@ contract Child {
     #[public]
     fn pub_set_value(new_value: Field) -> Field {
         storage.current_value.write(new_value);
-        context.emit_unencrypted_log(new_value);
+        context.emit_public_log(new_value);
 
         new_value
     }
@@ -77,7 +77,7 @@ contract Child {
     fn pub_inc_value(new_value: Field) -> Field {
         let old_value = storage.current_value.read();
         storage.current_value.write(old_value + new_value);
-        context.emit_unencrypted_log(new_value);
+        context.emit_public_log(new_value);
 
         new_value
     }
@@ -88,7 +88,7 @@ contract Child {
     fn pub_inc_value_internal(new_value: Field) -> Field {
         let old_value = storage.current_value.read();
         storage.current_value.write(old_value + new_value);
-        context.emit_unencrypted_log(new_value);
+        context.emit_public_log(new_value);
 
         new_value
     }
@@ -97,13 +97,13 @@ contract Child {
     fn set_value_twice_with_nested_first() {
         let _result = Child::at(context.this_address()).pub_set_value(10).call(&mut context);
         storage.current_value.write(20);
-        context.emit_unencrypted_log(20);
+        context.emit_public_log(20);
     }
 
     #[public]
     fn set_value_twice_with_nested_last() {
         storage.current_value.write(20);
-        context.emit_unencrypted_log(20);
+        context.emit_public_log(20);
         let _result = Child::at(context.this_address()).pub_set_value(10).call(&mut context);
     }
 
@@ -112,6 +112,6 @@ contract Child {
         Child::at(context.this_address()).set_value_twice_with_nested_first().call(&mut context);
         Child::at(context.this_address()).set_value_twice_with_nested_last().call(&mut context);
         storage.current_value.write(20);
-        context.emit_unencrypted_log(20);
+        context.emit_public_log(20);
     }
 }

--- a/noir-projects/noir-contracts/contracts/static_child_contract/src/main.nr
+++ b/noir-projects/noir-contracts/contracts/static_child_contract/src/main.nr
@@ -36,7 +36,7 @@ contract StaticChild {
     #[public]
     fn pub_set_value(new_value: Field) -> Field {
         storage.current_value.write(new_value);
-        context.emit_unencrypted_log(new_value);
+        context.emit_public_log(new_value);
         new_value
     }
 
@@ -84,7 +84,7 @@ contract StaticChild {
     fn pub_inc_value(new_value: Field) -> Field {
         let old_value = storage.current_value.read();
         storage.current_value.write(old_value + new_value);
-        context.emit_unencrypted_log(new_value);
+        context.emit_public_log(new_value);
         new_value
     }
 
@@ -94,7 +94,7 @@ contract StaticChild {
     fn pub_illegal_inc_value(new_value: Field) -> Field {
         let old_value = storage.current_value.read();
         storage.current_value.write(old_value + new_value);
-        context.emit_unencrypted_log(new_value);
+        context.emit_public_log(new_value);
         new_value
     }
 }

--- a/noir-projects/noir-contracts/contracts/test_contract/src/main.nr
+++ b/noir-projects/noir-contracts/contracts/test_contract/src/main.nr
@@ -344,12 +344,12 @@ contract Test {
     // docs:end:is-time-equal
 
     #[public]
-    fn emit_unencrypted(value: Field) {
-        // docs:start:emit_unencrypted
-        context.emit_unencrypted_log(/*message=*/ value);
-        context.emit_unencrypted_log(/*message=*/ [10, 20, 30]);
-        context.emit_unencrypted_log(/*message=*/ "Hello, world!");
-        // docs:end:emit_unencrypted
+    fn emit_public(value: Field) {
+        // docs:start:emit_public
+        context.emit_public_log(/*message=*/ value);
+        context.emit_public_log(/*message=*/ [10, 20, 30]);
+        context.emit_public_log(/*message=*/ "Hello, world!");
+        // docs:end:emit_public
     }
 
     #[public]

--- a/yarn-project/bb-prover/src/avm_proving.test.ts
+++ b/yarn-project/bb-prover/src/avm_proving.test.ts
@@ -97,7 +97,7 @@ describe('AVM WitGen, "check circuit" tests', () => {
     async () => {
       await proveAndVerifyAvmTestContractSimple(
         /*checkCircuitOnly=*/ true, // quick
-        'n_new_unencrypted_logs',
+        'n_new_public_logs',
         /*args=*/ [new Fr(MAX_PUBLIC_LOGS_PER_TX + 1)],
         /*expectRevert=*/ true,
       );

--- a/yarn-project/end-to-end/src/e2e_deploy_contract/deploy_method.test.ts
+++ b/yarn-project/end-to-end/src/e2e_deploy_contract/deploy_method.test.ts
@@ -107,7 +107,7 @@ describe('e2e_deploy_contract deploy method', () => {
     logger.debug(`Deploying contract with no constructor`);
     const contract = await TestContract.deploy(wallet).send().deployed();
     logger.debug(`Call a public function to check that it was publicly deployed`);
-    const receipt = await contract.methods.emit_unencrypted(42).send().wait();
+    const receipt = await contract.methods.emit_public(42).send().wait();
     const logs = await pxe.getPublicLogs({ txHash: receipt.txHash });
     expect(logs.logs[0].log.log[0]).toEqual(new Fr(42));
   });

--- a/yarn-project/end-to-end/src/guides/dapp_testing.test.ts
+++ b/yarn-project/end-to-end/src/guides/dapp_testing.test.ts
@@ -132,16 +132,16 @@ describe('guides/dapp/testing', () => {
       });
 
       it('checks public logs, [Kinda broken with current implementation]', async () => {
-        // docs:start:unencrypted-logs
+        // docs:start:public-logs
         const value = Fr.fromHexString('ef'); // Only 1 bytes will make its way in there :( so no larger stuff
-        const tx = await testContract.methods.emit_unencrypted(value).send().wait();
+        const tx = await testContract.methods.emit_public(value).send().wait();
         const filter = {
           fromBlock: tx.blockNumber!,
           limit: 1, // 1 log expected
         };
         const logs = (await pxe.getPublicLogs(filter)).logs;
         expect(logs[0].log.log[0]).toEqual(value);
-        // docs:end:unencrypted-logs
+        // docs:end:public-logs
       });
 
       it('asserts a local transaction simulation fails by calling simulate', async () => {

--- a/yarn-project/simulator/src/avm/avm_simulator.test.ts
+++ b/yarn-project/simulator/src/avm/avm_simulator.test.ts
@@ -696,7 +696,7 @@ describe('AVM simulator: transpiled Noir contracts', () => {
     describe('Public Logs', () => {
       it(`Emit public logs (should be traced)`, async () => {
         const context = createContext();
-        const bytecode = getAvmTestContractBytecode('emit_unencrypted_log');
+        const bytecode = getAvmTestContractBytecode('emit_public_log');
 
         const results = await new AvmSimulator(context).executeBytecode(bytecode);
         expect(results.reverted).toBe(false);

--- a/yarn-project/simulator/src/avm/opcodes/accrued_substate.ts
+++ b/yarn-project/simulator/src/avm/opcodes/accrued_substate.ts
@@ -201,7 +201,7 @@ export class L1ToL2MessageExists extends Instruction {
 }
 
 export class EmitUnencryptedLog extends Instruction {
-  // TODO(MW): rename unencrypted -> public
+  // TODO(#11124): rename unencrypted -> public
   static type: string = 'EMITUNENCRYPTEDLOG';
   static readonly opcode: Opcode = Opcode.EMITUNENCRYPTEDLOG;
   // Informs (de)serialization. See Instruction.deserialize.


### PR DESCRIPTION
This turned out much smaller than I thought it would be...

Renames the context method `emit_unencrypted` to `emit_public`. I didn't touch AVM to avoid giving the team a bunch of awful conflicts. But I'm happy to blitz through and rename all `unencrypted`s to `public`s in the AVM whenever!

Continues #11091 for #9589
