### PR TITLE
chore: dont install and run metrics stack on kind network smoke

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -381,7 +381,14 @@ jobs:
             docker pull aztecprotocol/end-to-end:${{ env.GIT_COMMIT }}
             echo ${{ secrets.DOCKERHUB_PASSWORD }} | docker login -u aztecprotocolci --password-stdin
             cd yarn-project/end-to-end
-            NAMESPACE=smoke FRESH_INSTALL=true VALUES_FILE=ci-smoke.yaml ./scripts/network_test.sh ./src/spartan/smoke.test.ts
+
+            export INSTALL_CHAOS_MESH=false
+            export INSTALL_METRICS=false
+            export NAMESPACE=smoke
+            export FRESH_INSTALL=true
+            export VALUES_FILE=ci-smoke.yaml
+
+            ./scripts/network_test.sh ./src/spartan/smoke.test.ts
       - name: Copy Network Logs
         if: always()
         run: scripts/copy_from_tester yarn-project/end-to-end/scripts/network-test.log network-test.log || true

--- a/spartan/scripts/setup_local_k8s.sh
+++ b/spartan/scripts/setup_local_k8s.sh
@@ -4,6 +4,10 @@ set -e
 
 SCRIPT_DIR="$(dirname $(realpath -s "${BASH_SOURCE[0]}"))"
 
+# Selectively install metrics and chaos mesh
+INSTALL_METRICS=${INSTALL_METRICS:-true}
+INSTALL_CHAOS_MESH=${INSTALL_CHAOS_MESH:-true}
+
 # exit if we are not on linux amd64
 if [ "$(uname)" != "Linux" ] || [ "$(uname -m)" != "x86_64" ]; then
   echo "This script is only supported on Linux amd64"
@@ -61,5 +65,13 @@ fi
 
 kubectl config use-context kind-kind || true
 
-"$SCRIPT_DIR"/../chaos-mesh/install.sh
-"$SCRIPT_DIR"/../metrics/install-kind.sh
+if [ "$INSTALL_CHAOS_MESH" = "true" ]; then
+  echo "Installing chaos mesh"
+  "$SCRIPT_DIR"/../chaos-mesh/install.sh
+fi
+
+if [ "$INSTALL_METRICS" = "true" ]; then
+  echo "Installing metrics"
+  "$SCRIPT_DIR"/../metrics/install-kind.sh
+fi
+

--- a/yarn-project/end-to-end/scripts/network_test.sh
+++ b/yarn-project/end-to-end/scripts/network_test.sh
@@ -154,7 +154,11 @@ PXE_PORT=$(echo $FREE_PORTS | awk '{print $1}')
 ANVIL_PORT=$(echo $FREE_PORTS | awk '{print $2}')
 METRICS_PORT=$(echo $FREE_PORTS | awk '{print $3}')
 
-GRAFANA_PASSWORD=$(kubectl get secrets -n metrics metrics-grafana -o jsonpath='{.data.admin-password}' | base64 --decode)
+if [ "$INSTALL_METRICS" = "true" ]; then
+  GRAFANA_PASSWORD=$(kubectl get secrets -n metrics metrics-grafana -o jsonpath='{.data.admin-password}' | base64 --decode)
+else
+  GRAFANA_PASSWORD=""
+fi
 
 # Namespace variable (assuming it's set)
 NAMESPACE=${NAMESPACE:-default}

--- a/yarn-project/end-to-end/src/spartan/smoke.test.ts
+++ b/yarn-project/end-to-end/src/spartan/smoke.test.ts
@@ -5,23 +5,11 @@ import { RollupAbi } from '@aztec/l1-artifacts';
 import { createPublicClient, getAddress, getContract, http } from 'viem';
 import { foundry } from 'viem/chains';
 
-import { type AlertConfig } from '../quality_of_service/alert_checker.js';
-import { isK8sConfig, runAlertCheck, setupEnvironment, startPortForward } from './utils.js';
+import { isK8sConfig, setupEnvironment, startPortForward } from './utils.js';
 
 const config = setupEnvironment(process.env);
 
 const debugLogger = createLogger('e2e:spartan-test:smoke');
-
-// QoS alerts for when we are running in k8s
-const qosAlerts: AlertConfig[] = [
-  {
-    alert: 'SequencerTimeToCollectAttestations',
-    expr: 'avg_over_time(aztec_sequencer_time_to_collect_attestations[2m]) > 2500',
-    labels: { severity: 'error' },
-    for: '10m',
-    annotations: {},
-  },
-];
 
 describe('smoke test', () => {
   let pxe: PXE;
@@ -35,21 +23,10 @@ describe('smoke test', () => {
         hostPort: config.HOST_PXE_PORT,
       });
       PXE_URL = `http://127.0.0.1:${config.HOST_PXE_PORT}`;
-
-      await startPortForward({
-        resource: `svc/metrics-grafana`,
-        namespace: 'metrics',
-        containerPort: config.CONTAINER_METRICS_PORT,
-        hostPort: config.HOST_METRICS_PORT,
-      });
     } else {
       PXE_URL = config.PXE_URL;
     }
     pxe = await createCompatibleClient(PXE_URL, debugLogger);
-  });
-
-  afterAll(async () => {
-    await runAlertCheck(config, qosAlerts, debugLogger);
   });
 
   it('should be able to get node enr', async () => {

--- a/yarn-project/end-to-end/src/spartan/utils.ts
+++ b/yarn-project/end-to-end/src/spartan/utils.ts
@@ -22,7 +22,7 @@ const k8sLocalConfigSchema = z.object({
   CONTAINER_ETHEREUM_PORT: z.coerce.number().default(8545),
   HOST_METRICS_PORT: z.coerce.number().min(1, 'HOST_METRICS_PORT env variable must be set'),
   CONTAINER_METRICS_PORT: z.coerce.number().default(80),
-  GRAFANA_PASSWORD: z.string().min(1, 'GRAFANA_PASSWORD env variable must be set'),
+  GRAFANA_PASSWORD: z.string().optional(),
   METRICS_API_PATH: z.string().default('/api/datasources/proxy/uid/spartan-metrics-prometheus/api/v1'),
   SPARTAN_DIR: z.string().min(1, 'SPARTAN_DIR env variable must be set'),
   K8S: z.literal('local'),


### PR DESCRIPTION
It takes a long time to install the metrics stack and chaos mesh, we probably do not need to test them in the smoke test, so this pr removes them

fixes: https://github.com/AztecProtocol/aztec-packages/issues/11363