### PR TITLE
chore: nuking redundant oracle

### DIFF
--- a/noir-projects/aztec-nr/aztec/src/context/private_context.nr
+++ b/noir-projects/aztec-nr/aztec/src/context/private_context.nr
@@ -340,7 +340,7 @@ impl PrivateContext {
         args: [Field; ARGS_COUNT],
     ) -> ReturnsHash {
         let args_hash = hash_args_array(args);
-        execution_cache::store_array(args);
+        execution_cache::store(args);
         self.call_private_function_with_args_hash(
             contract_address,
             function_selector,
@@ -356,7 +356,7 @@ impl PrivateContext {
         args: [Field; ARGS_COUNT],
     ) -> ReturnsHash {
         let args_hash = hash_args_array(args);
-        execution_cache::store_array(args);
+        execution_cache::store(args);
         self.call_private_function_with_args_hash(
             contract_address,
             function_selector,
@@ -443,7 +443,7 @@ impl PrivateContext {
         args: [Field; ARGS_COUNT],
     ) {
         let args_hash = hash_args_array(args);
-        execution_cache::store_array(args);
+        execution_cache::store(args);
         self.call_public_function_with_args_hash(
             contract_address,
             function_selector,
@@ -459,7 +459,7 @@ impl PrivateContext {
         args: [Field; ARGS_COUNT],
     ) {
         let args_hash = hash_args_array(args);
-        execution_cache::store_array(args);
+        execution_cache::store(args);
         self.call_public_function_with_args_hash(
             contract_address,
             function_selector,
@@ -531,7 +531,7 @@ impl PrivateContext {
         args: [Field; ARGS_COUNT],
     ) {
         let args_hash = hash_args_array(args);
-        execution_cache::store_array(args);
+        execution_cache::store(args);
         self.set_public_teardown_function_with_args_hash(
             contract_address,
             function_selector,

--- a/noir-projects/aztec-nr/aztec/src/oracle/execution_cache.nr
+++ b/noir-projects/aztec-nr/aztec/src/oracle/execution_cache.nr
@@ -5,19 +5,8 @@ pub fn store(values: [Field]) {
     unsafe { store_in_execution_cache_oracle_wrapper(values) };
 }
 
-/// Stores values represented as array in execution cache to be later obtained by its hash.
-pub fn store_array<let N: u32>(values: [Field; N]) {
-    /// Safety: This oracle call returns nothing: we only call it for its side effects. It is therefore always safe
-    /// to call. When loading the values, however, the caller must check that the values are indeed the preimage.
-    unsafe { store_array_in_execution_cache_oracle_wrapper(values) };
-}
-
 pub unconstrained fn store_in_execution_cache_oracle_wrapper(values: [Field]) {
     let _ = store_in_execution_cache_oracle(values);
-}
-
-pub unconstrained fn store_array_in_execution_cache_oracle_wrapper<let N: u32>(values: [Field; N]) {
-    let _ = store_array_in_execution_cache_oracle(values);
 }
 
 pub unconstrained fn load<let N: u32>(hash: Field) -> [Field; N] {
@@ -26,9 +15,6 @@ pub unconstrained fn load<let N: u32>(hash: Field) -> [Field; N] {
 
 #[oracle(storeInExecutionCache)]
 unconstrained fn store_in_execution_cache_oracle(_values: [Field]) -> Field {}
-
-#[oracle(storeArrayInExecutionCache)]
-unconstrained fn store_array_in_execution_cache_oracle<let N: u32>(_args: [Field; N]) -> Field {}
 
 #[oracle(loadFromExecutionCache)]
 unconstrained fn load_from_execution_cache_oracle<let N: u32>(_hash: Field) -> [Field; N] {}

--- a/yarn-project/simulator/src/acvm/oracle/oracle.ts
+++ b/yarn-project/simulator/src/acvm/oracle/oracle.ts
@@ -19,11 +19,6 @@ export class Oracle {
     return toACVMField(val);
   }
 
-  async storeArrayInExecutionCache(values: ACVMField[]): Promise<ACVMField> {
-    const hash = await this.typedOracle.storeArrayInExecutionCache(values.map(fromACVMField));
-    return toACVMField(hash);
-  }
-
   // Since the argument is a slice, noir automatically adds a length field to oracle call.
   async storeInExecutionCache(_length: ACVMField[], values: ACVMField[]): Promise<ACVMField> {
     const hash = await this.typedOracle.storeInExecutionCache(values.map(fromACVMField));

--- a/yarn-project/simulator/src/acvm/oracle/typed_oracle.ts
+++ b/yarn-project/simulator/src/acvm/oracle/typed_oracle.ts
@@ -56,10 +56,6 @@ export abstract class TypedOracle {
     return Fr.random();
   }
 
-  storeArrayInExecutionCache(_args: Fr[]): Promise<Fr> {
-    throw new OracleMethodNotAvailableError('storeArrayInExecutionCache');
-  }
-
   storeInExecutionCache(_values: Fr[]): Promise<Fr> {
     throw new OracleMethodNotAvailableError('storeInExecutionCache');
   }

--- a/yarn-project/simulator/src/client/client_execution_context.ts
+++ b/yarn-project/simulator/src/client/client_execution_context.ts
@@ -163,14 +163,6 @@ export class ClientExecutionContext extends ViewDataOracle {
   /**
    * Store values in the execution cache.
    * @param values - Values to store.
-   */
-  public override storeArrayInExecutionCache(args: Fr[]): Promise<Fr> {
-    return Promise.resolve(this.executionCache.store(args));
-  }
-
-  /**
-   * Store values in the execution cache.
-   * @param values - Values to store.
    * @returns The hash of the values.
    */
   public override storeInExecutionCache(values: Fr[]): Promise<Fr> {

--- a/yarn-project/txe/src/oracle/txe_oracle.ts
+++ b/yarn-project/txe/src/oracle/txe_oracle.ts
@@ -361,10 +361,6 @@ export class TXE implements TypedOracle {
     return Fr.random();
   }
 
-  storeArrayInExecutionCache(values: Fr[]) {
-    return Promise.resolve(this.executionCache.store(values));
-  }
-
   storeInExecutionCache(values: Fr[]) {
     return Promise.resolve(this.executionCache.store(values));
   }

--- a/yarn-project/txe/src/txe_service/txe_service.ts
+++ b/yarn-project/txe/src/txe_service/txe_service.ts
@@ -271,11 +271,6 @@ export class TXEService {
     return toForeignCallResult([toSingle(new Fr(blockNumber))]);
   }
 
-  async storeArrayInExecutionCache(args: ForeignCallArray) {
-    const hash = await this.typedOracle.storeArrayInExecutionCache(fromArray(args));
-    return toForeignCallResult([toSingle(hash)]);
-  }
-
   // Since the argument is a slice, noir automatically adds a length field to oracle call.
   async storeInExecutionCache(_length: ForeignCallSingle, values: ForeignCallArray) {
     const returnsHash = await this.typedOracle.storeInExecutionCache(fromArray(values));


### PR DESCRIPTION
With [this issue](https://github.com/noir-lang/noir/issues/7062) being fixed the `storeArrayInExecutionCache` oracle became redundant. Hence I am removing it in this PR.
