### PR TITLE
Fix link

### DIFF
--- a/spartan/metrics/Chart.lock
+++ b/spartan/metrics/Chart.lock
@@ -1,6 +1,6 @@
 dependencies:
 - name: opentelemetry-collector
-  repository: https://open-telemetry.github.io/opentelemetry-helm-charts
+  repository: https://github.com/open-telemetry/opentelemetry-helm-charts
   version: 0.104.0
 - name: loki
   repository: https://grafana.github.io/helm-charts

--- a/spartan/metrics/Chart.yaml
+++ b/spartan/metrics/Chart.yaml
@@ -26,7 +26,7 @@ appVersion: "1.16.0"
 dependencies:
   - name: opentelemetry-collector
     version: 0.104.0
-    repository: https://open-telemetry.github.io/opentelemetry-helm-charts
+    repository: https://github.com/open-telemetry/opentelemetry-helm-charts
   - name: loki
     version: "6.16.0"
     repository: "https://grafana.github.io/helm-charts"

--- a/spartan/metrics/install-kind.sh
+++ b/spartan/metrics/install-kind.sh
@@ -14,7 +14,7 @@ fi
 DASHBOARD_JSON=$(jq -c '.' grafana_dashboards/aztec-dashboard-all-in-one.json)
 DASHBOARD_JSON=$DASHBOARD_JSON yq e '.grafana.dashboards.default."aztec-networks".json = strenv(DASHBOARD_JSON)' values.tmp.yaml > values.yaml
 
-helm repo add open-telemetry https://open-telemetry.github.io/opentelemetry-helm-charts
+helm repo add open-telemetry https://github.com/open-telemetry/opentelemetry-helm-charts
 helm repo add grafana https://grafana.github.io/helm-charts
 helm repo add prometheus-community https://prometheus-community.github.io/helm-charts
 helm dependency update


### PR DESCRIPTION
Fix: Update OpenTelemetry Helm Repository URLs

Problem:
The current OpenTelemetry Helm repository URLs are returning 404 errors, preventing successful chart installation.

Changes:
Old URL: https://open-telemetry.github.io/opentelemetry-helm-charts
New URL: https://github.com/open-telemetry/opentelemetry-helm-charts

Modified files:
- spartan/metrics/Chart.yaml
- spartan/metrics/Chart.lock
- spartan/metrics/install-kind.sh

Testing:
✓ Verified new repository URL is accessible
✓ Helm dependency update completed successfully
✓ Chart installation works with new URL

![image](https://github.com/user-attachments/assets/19ccd3de-1be5-4dcb-a0f9-96fcc150fbcd)