### PR TITLE
chore: replace usage of stdlib with sha256 library

### DIFF
--- a/noir-projects/noir-contracts/contracts/avm_test_contract/Nargo.toml
+++ b/noir-projects/noir-contracts/contracts/avm_test_contract/Nargo.toml
@@ -7,3 +7,4 @@ type = "contract"
 [dependencies]
 aztec = { path = "../../../aztec-nr/aztec" }
 compressed_string = { path = "../../../aztec-nr/compressed-string" }
+sha256 = { tag = "v0.1.0", git = "https://github.com/noir-lang/sha256" }

--- a/noir-projects/noir-contracts/contracts/avm_test_contract/src/main.nr
+++ b/noir-projects/noir-contracts/contracts/avm_test_contract/src/main.nr
@@ -334,7 +334,7 @@ contract AvmTest {
 
     #[public]
     fn sha256_hash(data: [u8; 10]) -> [u8; 32] {
-        std::hash::sha256(data)
+        sha256::digest(data)
     }
 
     #[public]

--- a/noir-projects/noir-contracts/contracts/card_game_contract/Nargo.toml
+++ b/noir-projects/noir-contracts/contracts/card_game_contract/Nargo.toml
@@ -7,3 +7,4 @@ type = "contract"
 [dependencies]
 aztec = { path = "../../../aztec-nr/aztec" }
 value_note = { path = "../../../aztec-nr/value-note" }
+sha256 = { tag = "v0.1.0", git = "https://github.com/noir-lang/sha256" }

--- a/noir-projects/noir-contracts/contracts/card_game_contract/src/cards.nr
+++ b/noir-projects/noir-contracts/contracts/card_game_contract/src/cards.nr
@@ -160,7 +160,7 @@ pub fn get_pack_cards(
     let secret = context.request_nsk_app(owner_npk_m_hash);
     let mix = secret + seed;
     let mix_bytes: [u8; 32] = mix.to_le_bytes();
-    let random_bytes = std::hash::sha256(mix_bytes);
+    let random_bytes = sha256::digest(mix_bytes);
 
     let mut cards = [Card::from_field(0); PACK_CARDS];
     // we generate PACK_CARDS cards

--- a/noir-projects/noir-contracts/contracts/ecdsa_k_account_contract/Nargo.toml
+++ b/noir-projects/noir-contracts/contracts/ecdsa_k_account_contract/Nargo.toml
@@ -8,3 +8,4 @@ type = "contract"
 aztec = { path = "../../../aztec-nr/aztec" }
 authwit = { path = "../../../aztec-nr/authwit" }
 ecdsa_public_key_note = { path = "../ecdsa_public_key_note" }
+sha256 = { tag = "v0.1.0", git = "https://github.com/noir-lang/sha256" }

--- a/noir-projects/noir-contracts/contracts/ecdsa_k_account_contract/src/main.nr
+++ b/noir-projects/noir-contracts/contracts/ecdsa_k_account_contract/src/main.nr
@@ -70,7 +70,7 @@ contract EcdsaKAccount {
         // Verify payload signature using Ethereum's signing scheme
         // Note that noir expects the hash of the message/challenge as input to the ECDSA verification.
         let outer_hash_bytes: [u8; 32] = outer_hash.to_be_bytes();
-        let hashed_message: [u8; 32] = std::hash::sha256(outer_hash_bytes);
+        let hashed_message: [u8; 32] = sha256::digest(outer_hash_bytes);
         std::ecdsa_secp256k1::verify_signature(
             public_key.x,
             public_key.y,

--- a/noir-projects/noir-contracts/contracts/ecdsa_r_account_contract/Nargo.toml
+++ b/noir-projects/noir-contracts/contracts/ecdsa_r_account_contract/Nargo.toml
@@ -8,3 +8,4 @@ type = "contract"
 aztec = { path = "../../../aztec-nr/aztec" }
 authwit = { path = "../../../aztec-nr/authwit" }
 ecdsa_public_key_note = { path = "../ecdsa_public_key_note" }
+sha256 = { tag = "v0.1.0", git = "https://github.com/noir-lang/sha256" }

--- a/noir-projects/noir-contracts/contracts/ecdsa_r_account_contract/src/main.nr
+++ b/noir-projects/noir-contracts/contracts/ecdsa_r_account_contract/src/main.nr
@@ -68,7 +68,7 @@ contract EcdsaRAccount {
         // Verify payload signature using Ethereum's signing scheme
         // Note that noir expects the hash of the message/challenge as input to the ECDSA verification.
         let outer_hash_bytes: [u8; 32] = outer_hash.to_be_bytes();
-        let hashed_message: [u8; 32] = std::hash::sha256(outer_hash_bytes);
+        let hashed_message: [u8; 32] = sha256::digest(outer_hash_bytes);
         std::ecdsa_secp256r1::verify_signature(
             public_key.x,
             public_key.y,

--- a/noir-projects/noir-protocol-circuits/crates/types/Nargo.toml
+++ b/noir-projects/noir-protocol-circuits/crates/types/Nargo.toml
@@ -6,3 +6,4 @@ compiler_version = ">=0.18.0"
 
 [dependencies]
 ec = { tag = "v0.1.2", git = "https://github.com/noir-lang/ec" }
+sha256 = { tag = "v0.1.0", git = "https://github.com/noir-lang/sha256" }

--- a/noir-projects/noir-protocol-circuits/crates/types/src/hash.nr
+++ b/noir-projects/noir-protocol-circuits/crates/types/src/hash.nr
@@ -22,7 +22,7 @@ use crate::{
 use super::{constants::TWO_POW_64, utils::{arrays::array_concat, field::field_from_bytes}};
 
 pub fn sha256_to_field<let N: u32>(bytes_to_hash: [u8; N]) -> Field {
-    let sha256_hashed = std::hash::sha256(bytes_to_hash);
+    let sha256_hashed = sha256::digest(bytes_to_hash);
     let hash_in_a_field = field_from_bytes_32_trunc(sha256_hashed);
 
     hash_in_a_field
@@ -525,7 +525,7 @@ fn smoke_sha256_to_field() {
     assert(result == 0x448ebbc9e1a31220a2f3830c18eef61b9bd070e5084b7fa2a359fe729184c7);
 
     // to show correctness of the current ver (truncate one byte) vs old ver (mod full bytes):
-    let result_bytes = std::hash::sha256(full_buffer);
+    let result_bytes = sha256::digest(full_buffer);
     let truncated_field = crate::utils::field::field_from_bytes_32_trunc(result_bytes);
     assert(truncated_field == result);
     let mod_res = result + (result_bytes[31] as Field);


### PR DESCRIPTION
This removes the usage of sha256 from the stdlib so that we're pulling from the external library instead.