### PR TITLE
chore: Exclude system metrics from k8s deployments

### DIFF
--- a/spartan/aztec-network/templates/boot-node.yaml
+++ b/spartan/aztec-network/templates/boot-node.yaml
@@ -221,7 +221,7 @@ spec:
             - name: USE_GCLOUD_OBSERVABILITY
               value: "{{ .Values.telemetry.useGcloudObservability }}"
             - name: OTEL_EXCLUDE_METRICS
-              value: "{{ .Values.bootNode.otelExcludeMetrics }}"
+              value: "{{ .Values.telemetry.excludeMetrics }}"
           ports:
             - containerPort: {{ .Values.bootNode.service.nodePort }}
             - containerPort: {{ .Values.bootNode.service.p2pTcpPort }}

--- a/spartan/aztec-network/templates/faucet.yaml
+++ b/spartan/aztec-network/templates/faucet.yaml
@@ -87,7 +87,7 @@ spec:
             - name: USE_GCLOUD_OBSERVABILITY
               value: "{{ .Values.telemetry.useGcloudObservability }}"
             - name: OTEL_EXCLUDE_METRICS
-              value: "{{ .Values.faucet.otelExcludeMetrics }}"
+              value: "{{ .Values.telemetry.excludeMetrics }}"
           ports:
             - name: http
               containerPort: {{ .Values.faucet.service.nodePort }}

--- a/spartan/aztec-network/templates/prover-agent.yaml
+++ b/spartan/aztec-network/templates/prover-agent.yaml
@@ -106,7 +106,7 @@ spec:
             - name: USE_GCLOUD_OBSERVABILITY
               value: "{{ .Values.telemetry.useGcloudObservability }}"
             - name: OTEL_EXCLUDE_METRICS
-              value: "{{ .Values.proverAgent.otelExcludeMetrics }}"
+              value: "{{ .Values.telemetry.excludeMetrics }}"
           resources:
             {{- toYaml .Values.proverAgent.resources | nindent 12 }}
 {{- end }}

--- a/spartan/aztec-network/templates/prover-broker.yaml
+++ b/spartan/aztec-network/templates/prover-broker.yaml
@@ -109,7 +109,7 @@ spec:
             - name: USE_GCLOUD_OBSERVABILITY
               value: "{{ .Values.telemetry.useGcloudObservability }}"
             - name: OTEL_EXCLUDE_METRICS
-              value: "{{ .Values.proverBroker.otelExcludeMetrics }}"
+              value: "{{ .Values.telemetry.excludeMetrics }}"
           resources:
             {{- toYaml .Values.proverBroker.resources | nindent 12 }}
       volumes:

--- a/spartan/aztec-network/templates/prover-node.yaml
+++ b/spartan/aztec-network/templates/prover-node.yaml
@@ -191,7 +191,7 @@ spec:
             - name: USE_GCLOUD_OBSERVABILITY
               value: "{{ .Values.telemetry.useGcloudObservability }}"
             - name: OTEL_EXCLUDE_METRICS
-              value: "{{ .Values.proverNode.otelExcludeMetrics }}"
+              value: "{{ .Values.telemetry.excludeMetrics }}"
           ports:
             - containerPort: {{ .Values.proverNode.service.nodePort }}
             - containerPort: {{ .Values.proverNode.service.p2pTcpPort }}

--- a/spartan/aztec-network/templates/pxe.yaml
+++ b/spartan/aztec-network/templates/pxe.yaml
@@ -106,7 +106,7 @@ spec:
             - name: USE_GCLOUD_OBSERVABILITY
               value: "{{ .Values.telemetry.useGcloudObservability }}"
             - name: OTEL_EXCLUDE_METRICS
-              value: "{{ .Values.pxe.otelExcludeMetrics }}"
+              value: "{{ .Values.telemetry.excludeMetrics }}"
           ports:
             - name: http
               containerPort: {{ .Values.pxe.service.nodePort }}

--- a/spartan/aztec-network/templates/transaction-bot.yaml
+++ b/spartan/aztec-network/templates/transaction-bot.yaml
@@ -120,7 +120,7 @@ spec:
             - name: USE_GCLOUD_OBSERVABILITY
               value: "{{ .Values.telemetry.useGcloudObservability }}"
             - name: OTEL_EXCLUDE_METRICS
-              value: "{{ .Values.bot.otelExcludeMetrics }}"
+              value: "{{ .Values.telemetry.excludeMetrics }}"
           ports:
             - name: http
               containerPort: {{ .Values.bot.service.nodePort }}

--- a/spartan/aztec-network/templates/validator.yaml
+++ b/spartan/aztec-network/templates/validator.yaml
@@ -212,7 +212,7 @@ spec:
             - name: USE_GCLOUD_OBSERVABILITY
               value: "{{ .Values.telemetry.useGcloudObservability }}"
             - name: OTEL_EXCLUDE_METRICS
-              value: "{{ .Values.validator.otelExcludeMetrics }}"
+              value: "{{ .Values.telemetry.excludeMetrics }}"
           ports:
             - containerPort: {{ .Values.validator.service.nodePort }}
             - containerPort: {{ .Values.validator.service.p2pTcpPort }}

--- a/spartan/aztec-network/values.yaml
+++ b/spartan/aztec-network/values.yaml
@@ -20,6 +20,7 @@ telemetry:
   enabled: false
   otelCollectorEndpoint:
   useGcloudObservability: false
+  excludeMetrics: "system"
 
 images:
   aztec:
@@ -88,7 +89,6 @@ bootNode:
   stakingAssetAddress: ""
   storageSize: "1Gi"
   dataDir: "/data"
-  otelExcludeMetrics: ""
 
 validator:
   # If true, the validator will use its peers to serve as the boot node.
@@ -134,7 +134,6 @@ validator:
   dataDir: "/data"
   l1FixedPriorityFeePerGas: ""
   l1GasLimitBufferPercentage: ""
-  otelExcludeMetrics: ""
 
 proverNode:
   proverPublisherPrivateKey: "0xac0974bec39a17e36ba4a6b4d238ff944bacb478cbed5efcae784d7bf4f2ff80"
@@ -171,7 +170,6 @@ proverNode:
     intervalMs: 1000
     maxParallelRequests: 100
   failedProofStore: "gs://aztec-develop/spartan/failed-proofs"
-  otelExcludeMetrics: ""
 
 pxe:
   logLevel: "debug; info: aztec:simulator, json-rpc"
@@ -188,7 +186,6 @@ pxe:
     requests:
       memory: "4Gi"
       cpu: "1"
-  otelExcludeMetrics: ""
 
 bot:
   enabled: true
@@ -218,7 +215,6 @@ bot:
     requests:
       memory: "4Gi"
       cpu: "1"
-  otelExcludeMetrics: ""
 
 ethereum:
   replicas: 1
@@ -271,7 +267,6 @@ ethereum:
       cpu: "1"
   storageSize: "80Gi"
   deployL1ContractsPrivateKey:
-  otelExcludeMetrics: ""
 
 proverAgent:
   service:
@@ -290,7 +285,6 @@ proverAgent:
       memory: "4Gi"
       cpu: "1"
   pollInterval: 200
-  otelExcludeMetrics: ""
 
 proverBroker:
   service:
@@ -308,7 +302,6 @@ proverBroker:
       memory: "4Gi"
       cpu: "1"
   maxOldSpaceSize: "3584"
-  otelExcludeMetrics: ""
 
 jobs:
   deployL1Verifier:
@@ -326,4 +319,3 @@ faucet:
     requests:
       memory: "2Gi"
       cpu: "200m"
-  otelExcludeMetrics: ""


### PR DESCRIPTION
These are automatically collected behind the scenes, no need to re-publish them.
