### PR TITLE
fix(typo): spelling error

### DIFF
--- a/noir-projects/noir-contracts/contracts/amm_contract/src/lib.nr
+++ b/noir-projects/noir-contracts/contracts/amm_contract/src/lib.nr
@@ -21,7 +21,7 @@ pub fn get_amount_in(amount_out: U128, balance_in: U128, balance_out: U128) -> U
     assert((balance_in > U128::zero()) & (balance_out > U128::zero()), "INSUFFICIENT_LIQUIDITY");
 
     // The expression below is:
-    //    (balance_in * amount_out * 1000) / (balance_out - amout_out * 997) + 1
+    //    (balance_in * amount_out * 1000) / (balance_out - amount_out * 997) + 1
     // which is equivalent to:
     //    balance_in * (amount_out / (balance_in + amount_in)) *  1/0.997 + 1
     // resulting in an implicit 0.3% fee on the amount in, as the fee tokens are not taken into consideration. The +1

--- a/noir-projects/noir-protocol-circuits/crates/types/src/abis/sponge_blob.nr
+++ b/noir-projects/noir-protocol-circuits/crates/types/src/abis/sponge_blob.nr
@@ -43,7 +43,7 @@ impl SpongeBlob {
     // Add fields to the sponge
     pub fn absorb<let N: u32>(&mut self, input: [Field; N], in_len: u32) {
         // We skip the 0 check below, as most use cases (e.g. base rollup) constrain that the input array
-        // is contructed from i=0->in_len from an empty array, so no need to check.
+        // is constructed from i=0->in_len from an empty array, so no need to check.
         self.sponge = poseidon2_absorb_chunks_existing_sponge(self.sponge, input, in_len, true);
         self.fields += in_len;
     }

--- a/noir-projects/noir-protocol-circuits/crates/types/src/hash.nr
+++ b/noir-projects/noir-protocol-circuits/crates/types/src/hash.nr
@@ -502,10 +502,10 @@ fn existing_sponge_poseidon_chunks_matches_fixed() {
 fn poseidon_chunks_empty_inputs() {
     let in_len = 0;
     let mut input: [Field; 4096] = [0; 4096];
-    let mut contructed_empty_sponge = poseidon2_absorb_chunks(input, in_len, true);
+    let mut constructed_empty_sponge = poseidon2_absorb_chunks(input, in_len, true);
     let mut first_sponge =
-        poseidon2_absorb_chunks_existing_sponge(contructed_empty_sponge, input, in_len, true);
-    assert(first_sponge.squeeze() == contructed_empty_sponge.squeeze());
+        poseidon2_absorb_chunks_existing_sponge(constructed_empty_sponge, input, in_len, true);
+    assert(first_sponge.squeeze() == constructed_empty_sponge.squeeze());
 }
 
 #[test]

--- a/noir/noir-repo/compiler/noirc_frontend/src/parser/parser/types.rs
+++ b/noir/noir-repo/compiler/noirc_frontend/src/parser/parser/types.rs
@@ -498,10 +498,10 @@ mod tests {
         for quoted_type in QuotedType::iter() {
             let src = quoted_type.to_string();
             let typ = parse_type_no_errors(&src);
-            let UnresolvedTypeData::Quoted(parsed_qouted_type) = typ.typ else {
+            let UnresolvedTypeData::Quoted(parsed_quoted_type) = typ.typ else {
                 panic!("Expected a quoted type for {}", quoted_type)
             };
-            assert_eq!(parsed_qouted_type, quoted_type);
+            assert_eq!(parsed_quoted_type, quoted_type);
         }
     }
 


### PR DESCRIPTION
"amout_out" => "amount_out"
"contructed_empty_sponge" => "constructed_empty_sponge"
"parsed_qouted_type" => "parsed_quoted_type"
"contructed" => "constructed"

