### PR TITLE
 Fix undefined input parameter in setup-runner workflow

### DIFF
--- a/.github/workflows/setup-runner.yml
+++ b/.github/workflows/setup-runner.yml
@@ -13,6 +13,9 @@ on:
       runner_type:
         required: true
         type: string
+      runner_action:  
+        required: true
+        type: string
     secrets:
       AWS_ACCESS_KEY_ID:
         required: true


### PR DESCRIPTION
The workflow currently tries to use inputs.runner_action in the concurrency group, but this parameter is not defined in the workflow inputs. This could lead to undefined variable errors during workflow execution. We either need to:
