### PR TITLE
fix: flakey e2e_pruned_blocks test

### DIFF
--- a/yarn-project/end-to-end/src/e2e_pruned_blocks.test.ts
+++ b/yarn-project/end-to-end/src/e2e_pruned_blocks.test.ts
@@ -6,7 +6,6 @@ import {
   MerkleTreeId,
   type Wallet,
   retryUntil,
-  sleep,
 } from '@aztec/aztec.js';
 import { type CheatCodes } from '@aztec/aztec.js/utils';
 import { TokenContract } from '@aztec/noir-contracts.js/Token';


### PR DESCRIPTION
We were not accounting for archiver's own polling time, which had an inconvenient default causing for errors if the planets aligned. We now also use `retryUntil` to not have to wait for the full duration.