### PR TITLE
Fix broken link in the file README.md

### DIFF
--- a/noir-projects/aztec-nr/README.md
+++ b/noir-projects/aztec-nr/README.md
@@ -69,4 +69,4 @@ Replace `NARGO_VERSION_COMPATIBLE_WITH_YOUR_SANDBOX` with the version from the o
 aztec-cli get-node-info
 ```
 
-For more installation options, please view [Noir's getting started.](https://noir-lang.org/docs/getting_started/installation/other_install_methods)
+For more installation options, please view [Noir's getting started.](https://noir-lang.org/docs/getting_started/noir_installation)


### PR DESCRIPTION
Replaced link:
From: https://noir-lang.org/docs/getting_started/installation/other_install_methods 
To: https://noir-lang.org/docs/getting_started/noir_installation
