### PR TITLE
chore(avm): do not use commit_sparse

### DIFF
--- a/barretenberg/cpp/src/barretenberg/vm/avm/generated/prover.cpp
+++ b/barretenberg/cpp/src/barretenberg/vm/avm/generated/prover.cpp
@@ -52,7 +52,7 @@ void AvmProver::execute_wire_commitments_round()
     auto wire_polys = prover_polynomials.get_wires();
     auto labels = commitment_labels.get_wires();
     for (size_t idx = 0; idx < wire_polys.size(); ++idx) {
-        transcript->send_to_verifier(labels[idx], commitment_key->commit_sparse(wire_polys[idx]));
+        transcript->send_to_verifier(labels[idx], commitment_key->commit(wire_polys[idx]));
     }
 }
 

--- a/barretenberg/cpp/src/barretenberg/vm2/generated/prover.cpp
+++ b/barretenberg/cpp/src/barretenberg/vm2/generated/prover.cpp
@@ -52,7 +52,7 @@ void AvmProver::execute_wire_commitments_round()
     auto wire_polys = prover_polynomials.get_wires();
     auto labels = commitment_labels.get_wires();
     for (size_t idx = 0; idx < wire_polys.size(); ++idx) {
-        transcript->send_to_verifier(labels[idx], commitment_key->commit_sparse(wire_polys[idx]));
+        transcript->send_to_verifier(labels[idx], commitment_key->commit(wire_polys[idx]));
     }
 }
 

--- a/bb-pilcom/bb-pil-backend/templates/prover.cpp.hbs
+++ b/bb-pilcom/bb-pil-backend/templates/prover.cpp.hbs
@@ -52,7 +52,7 @@ void AvmProver::execute_wire_commitments_round()
     auto wire_polys = prover_polynomials.get_wires();
     auto labels = commitment_labels.get_wires();
     for (size_t idx = 0; idx < wire_polys.size(); ++idx) {
-        transcript->send_to_verifier(labels[idx], commitment_key->commit_sparse(wire_polys[idx]));
+        transcript->send_to_verifier(labels[idx], commitment_key->commit(wire_polys[idx]));
     }
 }
 


### PR DESCRIPTION
Experiments in vm1 showed that we are at 90% median column fullness. I'm switching us to use the normal `commit` method which makes sense now that we are using tight polynomials (with virtual size). We could later use `commit` or `commit_sparse` depending on the runtime sparcity of a column (which we know), see: https://github.com/AztecProtocol/aztec-packages/blob/master/barretenberg/cpp/src/barretenberg/vm2/constraining/README.md

For now we use `commit` since the performance is almost the same for our current situation but the memory footprint is lower.
