### PR TITLE
Remove unused parameter in action handler and fix typos

### DIFF
--- a/barretenberg/acir_tests/headless-test/src/index.ts
+++ b/barretenberg/acir_tests/headless-test/src/index.ts
@@ -66,7 +66,7 @@ program
     "Specify the path to the gzip encoded ACIR witness",
     "./target/witness.gz"
   )
-  .action(async ({ bytecodePath, witnessPath, recursive }) => {
+  .action(async ({ bytecodePath, witnessPath, }) => {
     const acir = readBytecodeFile(bytecodePath);
     const witness = readWitnessFile(witnessPath);
     const threads = Math.min(os.cpus().length, 16);

--- a/barretenberg/acir_tests/run_acir_tests.sh
+++ b/barretenberg/acir_tests/run_acir_tests.sh
@@ -55,8 +55,8 @@ export BIN CRS_PATH VERBOSE BRANCH RECURSIVE
 cd acir_tests
 
 # Convert them to array
-# There are no issues witht the tests below but as they check proper handling of dependencies or circuits that are part of a workspace
-# running these require extra gluecode so they are skipped for the purpose of this script
+# There are no issues with the tests below but as they check proper handling of dependencies or circuits that are part of a workspace
+# running these require extra glue code so they are skipped for the purpose of this script
 SKIP_ARRAY=(diamond_deps_0 workspace workspace_default_member)
 
 # TODO(https://github.com/AztecProtocol/barretenberg/issues/1108): problem regardless the proof system used

--- a/barretenberg/cpp/docs/Fuzzing.md
+++ b/barretenberg/cpp/docs/Fuzzing.md
@@ -61,7 +61,7 @@ The purpose of each parameter:
 - -shrink=1 - If a new testcase is encountered that has the same coverage as some previous one in the corpus and the testcase is smaller, replace the one in the corpus with the new one. Helps keep exec/s higher.
 - -artifact_prefix=crashes/ - Where to save crashes/timeouts/ooms.
 - -use_value_profile=1 - Leverage libfuzzer internal CMP analysis. Very useful, but blows the corpus up.
-- <PATH_TO_CORPUS> (../../../<fuzzer_type>_testcases) - The path to the folder, where corpus testcases are going to be saved and loaded from (also loads testcases from there at the start of fuzzing).
+- <PATH_TO_CORPUS> (`../../../<fuzzer_type>_testcases`) - The path to the folder, where corpus testcases are going to be saved and loaded from (also loads testcases from there at the start of fuzzing).
 
 Log structure is described here https://llvm.org/docs/LibFuzzer.html
 

--- a/barretenberg/cpp/docs/Fuzzing.md
+++ b/barretenberg/cpp/docs/Fuzzing.md
@@ -61,7 +61,7 @@ The purpose of each parameter:
 - -shrink=1 - If a new testcase is encountered that has the same coverage as some previous one in the corpus and the testcase is smaller, replace the one in the corpus with the new one. Helps keep exec/s higher.
 - -artifact_prefix=crashes/ - Where to save crashes/timeouts/ooms.
 - -use_value_profile=1 - Leverage libfuzzer internal CMP analysis. Very useful, but blows the corpus up.
-- <PATH_TO_CORPUS> (../../../<fuzzer_type>\_testcases) - The path to the folder, where corpus testcases are going to be saved and loaded from (also loads testcases from there at the start of fuzzing).
+- <PATH_TO_CORPUS> (../../../<fuzzer_type>_testcases) - The path to the folder, where corpus testcases are going to be saved and loaded from (also loads testcases from there at the start of fuzzing).
 
 Log structure is described here https://llvm.org/docs/LibFuzzer.html
 

--- a/barretenberg/cpp/installation/bbup
+++ b/barretenberg/cpp/installation/bbup
@@ -49,7 +49,7 @@ main() {
 
   # Reject unsupported architectures.
   if [ "${ARCHITECTURE}" != "x86_64" ] && [ "${ARCHITECTURE}" != "aarch64" ]; then
-    err "unsupported architecure: $ARCHITECTURE-$PLATFORM"
+    err "unsupported architecture: $ARCHITECTURE-$PLATFORM"
   fi
 
   BBUP_TAG=$BBUP_VERSION

--- a/barretenberg/cpp/pil/avm/gadgets/mem_slice.pil
+++ b/barretenberg/cpp/pil/avm/gadgets/mem_slice.pil
@@ -22,12 +22,12 @@ namespace slice(256);
     // a memory operation. The following relations ensure that exactly one operation
     // selector sel_cd_cpy/sel_return is activated per row with a non-zero counter and
     // that within a given operation the pertaining selector is enabled. (One prevents
-    // to activate sel_return during a callatacopy operation and vice-versa.)
+    // to activate sel_return during a calldatacopy operation and vice-versa.)
 
     sel_mem_active = sel_cd_cpy + sel_return;
 
     // Instruction decomposition guarantees that sel_cd_cpy and sel_return are mutually exclusive on
-    // the first row of the calldatcopy/return operation.
+    // the first row of the calldatacopy/return operation.
 
     // Show that cnt != 0 <==> sel_mem_active == 1
     // one_min_inv == 1 - cnt^(-1) if cnt != 0 else == 0


### PR DESCRIPTION

Removed unused parameter `recursive` and trailing comma to maintain cleaner code and follow best practices.
