### PR TITLE
fix: Don't publish a block if we failed to create the block proposal

### DIFF
--- a/yarn-project/sequencer-client/src/sequencer/sequencer.test.ts
+++ b/yarn-project/sequencer-client/src/sequencer/sequencer.test.ts
@@ -491,7 +491,7 @@ describe('sequencer', () => {
     expect(publisher.proposeL2Block).not.toHaveBeenCalled();
   });
 
-  it('does not publish a block that received no attestations', async () => {
+  it('does not publish a block if the block proposal failed', async () => {
     const tx = makeTx();
     mockPendingTxs([tx]);
     block = await makeBlock([tx]);

--- a/yarn-project/sequencer-client/src/sequencer/sequencer.ts
+++ b/yarn-project/sequencer-client/src/sequencer/sequencer.ts
@@ -300,6 +300,9 @@ export class Sequencer {
       await this.buildBlockAndAttemptToPublish(pendingTxs, proposalHeader);
     } catch (err) {
       this.log.error(`Error assembling block`, err, { blockNumber: newBlockNumber, slot });
+
+      // If the block failed to build, we might still want to claim the proving rights
+      await this.claimEpochProofRightIfAvailable(slot);
     }
     this.setState(SequencerState.IDLE, 0n);
   }
@@ -627,8 +630,9 @@ export class Sequencer {
     this.log.debug('Creating block proposal for validators');
     const proposal = await this.validatorClient.createBlockProposal(block.header, block.archive.root, txHashes);
     if (!proposal) {
-      this.log.warn(`Failed to create block proposal, skipping collecting attestations`);
-      return undefined;
+      const msg = `Failed to create block proposal`;
+      this.log.error(msg);
+      throw new Error(msg);
     }
 
     this.log.debug('Broadcasting block proposal to validators');

--- a/yarn-project/sequencer-client/src/sequencer/sequencer.ts
+++ b/yarn-project/sequencer-client/src/sequencer/sequencer.ts
@@ -631,7 +631,6 @@ export class Sequencer {
     const proposal = await this.validatorClient.createBlockProposal(block.header, block.archive.root, txHashes);
     if (!proposal) {
       const msg = `Failed to create block proposal`;
-      this.log.error(msg);
       throw new Error(msg);
     }
 

--- a/yarn-project/simulator/src/public/public_processor.ts
+++ b/yarn-project/simulator/src/public/public_processor.ts
@@ -280,7 +280,7 @@ export class PublicProcessor implements Traceable {
     const rate = duration > 0 ? totalPublicGas.l2Gas / duration : 0;
     this.metrics.recordAllTxs(totalPublicGas, rate);
 
-    this.log.info(`Processed ${result.length} succesful txs and ${failed.length} txs in ${duration}ms`, {
+    this.log.info(`Processed ${result.length} successful txs and ${failed.length} txs in ${duration}s`, {
       duration,
       rate,
       totalPublicGas,


### PR DESCRIPTION
If we fail to build a block proposal, we shouldn't attempt to publish the block as it will fail.
