### PR TITLE
chore: rc-2 release on Sepolia

### DIFF
--- a/spartan/aztec-network/templates/validator.yaml
+++ b/spartan/aztec-network/templates/validator.yaml
@@ -203,6 +203,8 @@ spec:
               value: {{ .Values.validator.l1FixedPriorityFeePerGas | quote }}
             - name: L1_GAS_LIMIT_BUFFER_PERCENTAGE
               value: {{ .Values.validator.l1GasLimitBufferPercentage | quote }}
+            - name: L1_GAS_PRICE_MAX
+              value: {{ .Values.validator.l1GasPriceMax | quote }}
             - name: DATA_DIRECTORY
               value: "{{ .Values.validator.dataDir }}"
             - name: DATA_STORE_MAP_SIZE_KB

--- a/spartan/aztec-network/values.yaml
+++ b/spartan/aztec-network/values.yaml
@@ -132,6 +132,7 @@ validator:
   viemPollingInterval: 1000
   storageSize: "1Gi"
   dataDir: "/data"
+  l1GasPriceMax: 100
   l1FixedPriorityFeePerGas: ""
   l1GasLimitBufferPercentage: ""
 

--- a/spartan/aztec-network/values/rc-2.yaml
+++ b/spartan/aztec-network/values/rc-2.yaml
@@ -5,6 +5,7 @@ aztec:
   slotDuration: 36
   epochDuration: 32
   realProofs: true
+
 images:
   aztec:
     pullPolicy: Always
@@ -22,6 +23,7 @@ validator:
   l1FixedPriorityFeePerGas: 2
   l1GasLimitBufferPercentage: 15
   replicas: 48
+  l1GasPriceMax: 500
   storageSize: "100Gi"
   resources:
     requests:

--- a/spartan/aztec-network/values/sepolia-48-validators-with-metrics.yaml
+++ b/spartan/aztec-network/values/sepolia-48-validators-with-metrics.yaml
@@ -16,6 +16,7 @@ ethereum:
 validator:
   l1FixedPriorityFeePerGas: 2
   l1GasLimitBufferPercentage: 15
+  l1GasPriceMax: 500
   replicas: 48
   validatorKeys:
   validatorAddresses:

--- a/spartan/aztec-network/values/sepolia-48-validators-with-proving-and-metrics.yaml
+++ b/spartan/aztec-network/values/sepolia-48-validators-with-proving-and-metrics.yaml
@@ -6,6 +6,10 @@ aztec:
   epochDuration: 32
   realProofs: true
 
+images:
+  aztec:
+    pullPolicy: Always
+
 network:
   setupL2Contracts: false
   public: false

--- a/spartan/aztec-network/values/sepolia-48-validators-with-proving-and-metrics.yaml
+++ b/spartan/aztec-network/values/sepolia-48-validators-with-proving-and-metrics.yaml
@@ -5,9 +5,6 @@ aztec:
   slotDuration: 36
   epochDuration: 32
   realProofs: true
-images:
-  aztec:
-    pullPolicy: Always
 
 network:
   setupL2Contracts: false
@@ -22,6 +19,7 @@ validator:
   l1FixedPriorityFeePerGas: 2
   l1GasLimitBufferPercentage: 15
   replicas: 48
+  l1GasPriceMax: 500
   storageSize: "100Gi"
   resources:
     requests:


### PR DESCRIPTION
- Update sepolia values for 
  - Higher max fee
  - new values for network with proofs
- Update rc-2 to deploy on Sepolia (from `sepolia-48-validators-with-proving-and-metrics.yaml`)