### PR TITLE
chore: Revert "remove debug_logging flag"

### DIFF
--- a/barretenberg/cpp/src/barretenberg/bb/main.cpp
+++ b/barretenberg/cpp/src/barretenberg/bb/main.cpp
@@ -1316,7 +1316,8 @@ int main(int argc, char* argv[])
 {
     try {
         std::vector<std::string> args(argv + 1, argv + argc);
-        verbose_logging = flag_present(args, "-v") || flag_present(args, "--verbose_logging");
+        debug_logging = flag_present(args, "-d") || flag_present(args, "--debug_logging");
+        verbose_logging = debug_logging || flag_present(args, "-v") || flag_present(args, "--verbose_logging");
         if (args.empty()) {
             std::cerr << "No command provided.\n";
             return 1;

--- a/barretenberg/cpp/src/barretenberg/common/log.cpp
+++ b/barretenberg/cpp/src/barretenberg/common/log.cpp
@@ -7,3 +7,6 @@ bool verbose_logging = std::getenv("BB_VERBOSE") == nullptr ? false : std::strin
 #else
 bool verbose_logging = true;
 #endif
+
+// Used for `debug` in log.hpp.
+bool debug_logging = false;

--- a/barretenberg/cpp/src/barretenberg/common/log.hpp
+++ b/barretenberg/cpp/src/barretenberg/common/log.hpp
@@ -51,6 +51,7 @@ extern bool debug_logging;
 #ifndef NDEBUG
 template <typename... Args> inline void debug(Args... args)
 {
+    // NDEBUG is used to turn off asserts, so we want this flag to prevent debug log spamming.
     if (debug_logging) {
         logstr(format(args...).c_str());
     }

--- a/barretenberg/cpp/src/barretenberg/common/log.hpp
+++ b/barretenberg/cpp/src/barretenberg/common/log.hpp
@@ -47,10 +47,13 @@ template <typename... Args> std::string benchmark_format(Args... args)
     return os.str();
 }
 
+extern bool debug_logging;
 #ifndef NDEBUG
 template <typename... Args> inline void debug(Args... args)
 {
-    logstr(format(args...).c_str());
+    if (debug_logging) {
+        logstr(format(args...).c_str());
+    }
 }
 #else
 template <typename... Args> inline void debug(Args... /*unused*/) {}


### PR DESCRIPTION
This reverts commit 3d2a89ba617f4985c1ef5ca33c00a25c4e23a5ff and adds back the debug_logging flag.
