### PR TITLE
fix: add yarn-project state validation before linting

### DIFF
--- a/yarn-project/precommit.sh
+++ b/yarn-project/precommit.sh
@@ -12,15 +12,35 @@ export FORCE_COLOR=true
 
 staged_files_cmd="git diff-index --diff-filter=d --relative --cached --name-only HEAD"
 
+function check_yarn_project_ready {
+  # Check if node_modules exists
+  if [ ! -d "node_modules" ]; then
+    echo "Error: node_modules not found. Please run 'yarn install' first."
+    exit 1
+  fi
+  
+  # Check if required tools are available
+  for tool in eslint prettier; do
+    if [ ! -f "node_modules/.bin/$tool" ]; then
+      echo "Error: $tool not found. Please run 'yarn install' first."
+      exit 1
+    fi
+  done
+}
+
 function lint {
   ls -d ./*/src | xargs dirname | parallel 'cd {} && ../node_modules/.bin/eslint --cache ./src'
 }
 export -f lint
 
+# Check project readiness if linting is not disabled
+if [ -z "${HOOKS_NO_LINT:-}" ]; then
+  check_yarn_project_ready
+fi
+
 parallel ::: \
   'yarn prepare:check' \
-  "$staged_files_cmd | grep -E '\.(json|js|mjs|cjs|ts)$' | parallel -N10 ./node_modules/.bin/prettier --loglevel error --write"
-  # TODO(ci3) find a way to ensure the yarn-project state is ready for linting
-  # "lint"
+  "$staged_files_cmd | grep -E '\.(json|js|mjs|cjs|ts)$' | parallel -N10 ./node_modules/.bin/prettier --loglevel error --write" \
+  "[ -n "${HOOKS_NO_LINT:-}" ] || lint"
 
 $staged_files_cmd | xargs -r git add


### PR DESCRIPTION
This PR resolves the TODO comment in precommit.sh by implementing proper
validation of the yarn-project state before running linting operations.

Changes:
- Add check_yarn_project_ready function to validate project setup
- Validate presence of both eslint and prettier
- Re-enable linting with proper state validation
- Add clear error messages for missing dependencies

Resolves: TODO(ci3) comment in precommit.sh