### PR TITLE
chore: renaming the `IntentAction` type to `IntentCall`

### DIFF
--- a/yarn-project/aztec.js/src/account/wallet.ts
+++ b/yarn-project/aztec.js/src/account/wallet.ts
@@ -1,6 +1,6 @@
 import { type AuthWitness, type PXE } from '@aztec/circuit-types';
 
-import { type IntentAction, type IntentInnerHash } from '../utils/authwit.js';
+import { type IntentCall, type IntentInnerHash } from '../utils/authwit.js';
 import { type AccountInterface } from './interface.js';
 
 /**
@@ -8,5 +8,5 @@ import { type AccountInterface } from './interface.js';
  */
 export type Wallet = AccountInterface &
   PXE & {
-    createAuthWit(intent: IntentInnerHash | IntentAction): Promise<AuthWitness>;
+    createAuthWit(intent: IntentInnerHash | IntentCall): Promise<AuthWitness>;
   };

--- a/yarn-project/aztec.js/src/index.ts
+++ b/yarn-project/aztec.js/src/index.ts
@@ -47,7 +47,7 @@ export {
   type L2Claim,
   type U128Like,
   type WrappedFieldLike,
-  type IntentAction,
+  type IntentCall,
 } from './utils/index.js';
 
 export { NoteSelector } from '@aztec/foundation/abi';

--- a/yarn-project/aztec.js/src/utils/authwit.ts
+++ b/yarn-project/aztec.js/src/utils/authwit.ts
@@ -20,7 +20,7 @@ export type IntentInnerHash = {
   innerHash: Buffer | Fr;
 };
 
-/** Intent with an action */
+/** Intent with an call */
 export type IntentCall = {
   /** The caller to approve  */
   caller: AztecAddress;

--- a/yarn-project/aztec.js/src/utils/authwit.ts
+++ b/yarn-project/aztec.js/src/utils/authwit.ts
@@ -21,7 +21,7 @@ export type IntentInnerHash = {
 };
 
 /** Intent with an action */
-export type IntentAction = {
+export type IntentCall = {
   /** The caller to approve  */
   caller: AztecAddress;
   /** The action to approve */
@@ -39,7 +39,7 @@ export type IntentAction = {
  * and use it for the authentication check.
  * Therefore, any allowed `innerHash` will therefore also have information around where it can be spent (version, chainId) and who can spend it (consumer).
  *
- * If using the `IntentAction`, the caller is the address that is making the call, for a token approval from Alice to Bob, this would be Bob.
+ * If using the `IntentCall`, the caller is the address that is making the call, for a token approval from Alice to Bob, this would be Bob.
  * The action is then used along with the `caller` to compute the `innerHash` and the consumer.
  *
  *
@@ -50,7 +50,7 @@ export type IntentAction = {
  * @param metadata - The metadata for the intent (chainId, version)
  * @returns The message hash for the action
  */
-export const computeAuthWitMessageHash = (intent: IntentInnerHash | IntentAction, metadata: IntentMetadata) => {
+export const computeAuthWitMessageHash = (intent: IntentInnerHash | IntentCall, metadata: IntentMetadata) => {
   const chainId = metadata.chainId;
   const version = metadata.version;
 

--- a/yarn-project/aztec.js/src/wallet/account_wallet.ts
+++ b/yarn-project/aztec.js/src/wallet/account_wallet.ts
@@ -7,7 +7,7 @@ import { type AccountInterface } from '../account/interface.js';
 import { ContractFunctionInteraction } from '../contract/contract_function_interaction.js';
 import { type ExecutionRequestInit } from '../entrypoint/entrypoint.js';
 import {
-  type IntentAction,
+  type IntentCall,
   type IntentInnerHash,
   computeAuthWitMessageHash,
   computeInnerAuthWitHashFromAction,
@@ -48,7 +48,7 @@ export class AccountWallet extends BaseWallet {
    * @param messageHashOrIntent - The message hash of the intent to approve
    * @returns The authentication witness
    */
-  async createAuthWit(messageHashOrIntent: Fr | Buffer | IntentAction | IntentInnerHash): Promise<AuthWitness> {
+  async createAuthWit(messageHashOrIntent: Fr | Buffer | IntentCall | IntentInnerHash): Promise<AuthWitness> {
     let messageHash: Fr;
     if (Buffer.isBuffer(messageHashOrIntent)) {
       messageHash = Fr.fromBuffer(messageHashOrIntent);
@@ -73,7 +73,7 @@ export class AccountWallet extends BaseWallet {
    * @returns - A function interaction.
    */
   public setPublicAuthWit(
-    messageHashOrIntent: Fr | Buffer | IntentInnerHash | IntentAction,
+    messageHashOrIntent: Fr | Buffer | IntentInnerHash | IntentCall,
     authorized: boolean,
   ): ContractFunctionInteraction {
     let messageHash: Fr;
@@ -91,7 +91,7 @@ export class AccountWallet extends BaseWallet {
     ]);
   }
 
-  private getInnerHashAndConsumer(intent: IntentInnerHash | IntentAction): {
+  private getInnerHashAndConsumer(intent: IntentInnerHash | IntentCall): {
     /** The inner hash */
     innerHash: Fr;
     /** The consumer of the authwit */
@@ -115,7 +115,7 @@ export class AccountWallet extends BaseWallet {
    * @param intent - A tuple of (consumer and inner hash) or (caller and action)
    * @returns The message hash
    */
-  private getMessageHash(intent: IntentInnerHash | IntentAction): Fr {
+  private getMessageHash(intent: IntentInnerHash | IntentCall): Fr {
     const chainId = this.getChainId();
     const version = this.getVersion();
     return computeAuthWitMessageHash(intent, { chainId, version });
@@ -133,7 +133,7 @@ export class AccountWallet extends BaseWallet {
    */
   async lookupValidity(
     onBehalfOf: AztecAddress,
-    intent: IntentInnerHash | IntentAction,
+    intent: IntentInnerHash | IntentCall,
   ): Promise<{
     /** boolean flag indicating if the authwit is valid in private context */
     isValidInPrivate: boolean;

--- a/yarn-project/aztec.js/src/wallet/base_wallet.ts
+++ b/yarn-project/aztec.js/src/wallet/base_wallet.ts
@@ -35,7 +35,7 @@ import type { AbiDecoded, ContractArtifact } from '@aztec/foundation/abi';
 
 import { type Wallet } from '../account/wallet.js';
 import { type ExecutionRequestInit } from '../entrypoint/entrypoint.js';
-import { type IntentAction, type IntentInnerHash } from '../utils/authwit.js';
+import { type IntentCall, type IntentInnerHash } from '../utils/authwit.js';
 
 /**
  * A base class for Wallet implementations
@@ -53,7 +53,7 @@ export abstract class BaseWallet implements Wallet {
 
   abstract createTxExecutionRequest(exec: ExecutionRequestInit): Promise<TxExecutionRequest>;
 
-  abstract createAuthWit(intent: Fr | Buffer | IntentInnerHash | IntentAction): Promise<AuthWitness>;
+  abstract createAuthWit(intent: Fr | Buffer | IntentInnerHash | IntentCall): Promise<AuthWitness>;
 
   setScopes(scopes: AztecAddress[]) {
     this.scopes = scopes;

--- a/yarn-project/aztec.js/src/wallet/signerless_wallet.ts
+++ b/yarn-project/aztec.js/src/wallet/signerless_wallet.ts
@@ -3,7 +3,7 @@ import { type CompleteAddress, type Fr } from '@aztec/circuits.js';
 
 import { DefaultEntrypoint } from '../entrypoint/default_entrypoint.js';
 import { type EntrypointInterface, type ExecutionRequestInit } from '../entrypoint/entrypoint.js';
-import { type IntentAction, type IntentInnerHash } from '../utils/authwit.js';
+import { type IntentCall, type IntentInnerHash } from '../utils/authwit.js';
 import { BaseWallet } from './base_wallet.js';
 
 /**
@@ -39,7 +39,7 @@ export class SignerlessWallet extends BaseWallet {
     throw new Error('SignerlessWallet: Method getCompleteAddress not implemented.');
   }
 
-  createAuthWit(_intent: Fr | Buffer | IntentInnerHash | IntentAction): Promise<AuthWitness> {
+  createAuthWit(_intent: Fr | Buffer | IntentInnerHash | IntentCall): Promise<AuthWitness> {
     throw new Error('SignerlessWallet: Method createAuthWit not implemented.');
   }
 


### PR DESCRIPTION
Hi! This PR introduces changes related to renaming the `IntentAction` type to `IntentCall` throughout the codebase. The main reason for this change is to make the naming more intuitive and clear, as the term "Call" better reflects the nature of the action. This update affects several files, including types, interfaces, and functions where the old term was used.

Issue #11274
