### PR TITLE
fix: implement `Packable` for ContractClassId

### DIFF
--- a/noir-projects/noir-protocol-circuits/crates/types/src/contract_class_id.nr
+++ b/noir-projects/noir-protocol-circuits/crates/types/src/contract_class_id.nr
@@ -1,5 +1,5 @@
 use crate::constants::GENERATOR_INDEX__CONTRACT_LEAF;
-use crate::traits::{Deserialize, FromField, Serialize, ToField};
+use crate::traits::{Deserialize, FromField, Packable, Serialize, ToField};
 
 pub struct ContractClassId {
     pub inner: Field,
@@ -32,6 +32,17 @@ impl Serialize<1> for ContractClassId {
 impl Deserialize<1> for ContractClassId {
     fn deserialize(fields: [Field; 1]) -> Self {
         Self { inner: fields[0] }
+    }
+}
+
+// Implement the Packable trait so ContractClassId can be stored in contract's storage.
+impl Packable<1> for ContractClassId {
+    fn pack(self) -> [Field; 1] {
+        self.serialize()
+    }
+
+    fn unpack(fields: [Field; 1]) -> Self {
+        Self::deserialize(fields)
     }
 }
 


### PR DESCRIPTION
I am storing a ContractClassId in contract storage so that I can verify deployed contracts match expectations. That broke after https://github.com/AztecProtocol/aztec-packages/pull/11136