### PR TITLE
chore: pre-commit hook to warn of constant.nr change

### DIFF
--- a/bootstrap.sh
+++ b/bootstrap.sh
@@ -304,6 +304,7 @@ hooks_dir=$(git rev-parse --git-path hooks)
 echo "(cd barretenberg/cpp && ./format.sh staged)" >$hooks_dir/pre-commit
 echo "./yarn-project/precommit.sh" >>$hooks_dir/pre-commit
 echo "./noir-projects/precommit.sh" >>$hooks_dir/pre-commit
+echo "./yarn-project/circuits.js/precommit.sh" >>$hooks_dir/pre-commit
 chmod +x $hooks_dir/pre-commit
 
 github_group "pull submodules"

--- a/yarn-project/circuits.js/precommit.sh
+++ b/yarn-project/circuits.js/precommit.sh
@@ -25,7 +25,7 @@ if git diff --cached --name-only | grep -Fxq "$FILE_TO_WATCH"; then
     echo ""
     echo "Depending on the constants you've changed, these might include: constants.gen.ts, ConstantsGen.sol, constants_gen.pil, aztec_constants.hpp."
     echo ""
-    echo -e "You can regenerate these by running: '\033[33myarn remake-constants\033[0m' from the 'yarn-project/circuits.js' dir."
+    echo -e "You can regenerate these by running: '\033[33myarn remake-constants\033[0m' from the 'yarn-project/circuits.js' dir. If you have changed tree sizes, also run ./yarn-project/update-snapshots.sh."
     echo ""
     echo "We don't automatically regenerate them for you in this git hook, because you'll likely need to also re-build components of the repo. End."
     echo ""

--- a/yarn-project/circuits.js/precommit.sh
+++ b/yarn-project/circuits.js/precommit.sh
@@ -1,0 +1,35 @@
+#!/bin/bash
+
+# Precommit hook to generate the constants if constants.nr is changed. This will save developers hours of time hunting a bug, when in fact all they needed to do was run this script (trust me, I have trodden this dark path before...).
+
+#!/bin/bash
+set -euo pipefail  # Fail on errors, unset variables, and pipeline failures
+
+cd "$(dirname "$0")"  # Change to the script's directory
+
+export FORCE_COLOR=true
+
+FILE_TO_WATCH="noir-projects/noir-protocol-circuits/crates/types/src/constants.nr"  # Relative path
+
+# Check if constants.nr is staged for commit
+if git diff --cached --name-only | grep -Fxq "$FILE_TO_WATCH"; then
+    echo "It looks like you changed $FILE_TO_WATCH."
+    echo ""
+    echo "Regenerating the other constants files, so you don't lose a day of your life wondering why things aren't working..."
+    echo ""
+
+    COMMAND="yarn remake-constants"
+
+    echo "Running `$COMMAND`..."
+    echo ""
+    $COMMAND # Run the command
+
+    # Stage all the constants files, if they've been changed by the script:
+    # We move to the top-level of the repo first, so that we don't have to specify full relative paths, in case someone does some refiling that breaks those paths.
+    # cd ../../
+    # git add -u -- *constants.gen.ts *ConstantsGen.sol *constants_gen.pil *aztec_constants.hpp
+
+    echo "Constants files re-generated."
+    echo ""
+    echo "We haven't actually re-staged those re-generated files for you, because there might actually be additional files that you'll need to manually update, e.g. yarn-project/noir-protocol-circuits-types/src/types/index.ts. Sorry about that. But at least it's caught your attention as something that needs to be fixed!"
+fi


### PR DESCRIPTION
Edit: A git hook might not be the best approach to this, so maybe there's a better CI solution that can be built?

I just lost 6 hours of my life hunting a bug, because a few days ago I'd changed a single number in constants.nr. I'd forgotten to update the downstream constants files, or perhaps I'd wrongly assumed that bootstrap.sh or CI or something would update the associated constants `.ts` and `.sol` etc. files.

Anyway, I have channelled my furious anger into trying to prevent someone else wasting countless hours over something so easily avoidable and automatable.

Out of interest, why isn't this automatically caught already?

## About the PR:

- It identifies whether the `constants.nr` file has been changed _and_ staged. (No point doing anything if it's not been staged).
- It just warns the dev about this, to make them aware that they might need to run some scripts.
- ~It runs the remake-constants script.~
- *It does not re-stage the resulting, re-generated constant files*, because I noticed (by chance I had a `build:dev` watch window open) that there are other typescript files that need to be generated, which aren't covered by the `remake-constants` script. Ideally, if someone knows where the scripts are to regenerate all of those lingering constants files as well, we would run those scripts too within this script. But of course, the auto-generated files themselves don't necessarily tell you how to generate them (sigh). E.g. /mnt/user-data/mike/aztec-packages/yarn-project/noir-protocol-circuits-types/src/types/index.ts
