### PR TITLE
chore: Add aztec not evm compatbile on front page of docs

### DIFF
--- a/docs/docs/index.mdx
+++ b/docs/docs/index.mdx
@@ -20,6 +20,8 @@ On Ethereum today, everything is publicly visible, by everyone. In the real worl
 - composability between private/public execution and private/public state
 - public and private messaging with Ethereum
 
+To make this possible, Aztec is *not EVM compatible* and is extending the Ethereum ecosystem by creating a new alt-VM! 
+
 To learn more about how Aztec achieves these things, check out the [Aztec concepts overview](/aztec/concepts_overview).
 
 ## Start coding


### PR DESCRIPTION
Way too many times we get ethereum's large app or infra builders who check our docs and not 100% sure if aztec is evm compatible or no

it wastes their time and ours. So this makes it obvious in the front page