### PR TITLE
chore: Use native acvm when available on orchestrator tests

### DIFF
--- a/yarn-project/prover-client/src/mocks/fixtures.ts
+++ b/yarn-project/prover-client/src/mocks/fixtures.ts
@@ -39,7 +39,7 @@ export const getEnvironmentConfig = async (logger: Logger) => {
     const tempWorkingDirectory = `${TEMP_DIR}/${randomBytes(4).toString('hex')}`;
     const bbWorkingDirectory = BB_WORKING_DIRECTORY ? BB_WORKING_DIRECTORY : `${tempWorkingDirectory}/bb`;
     await fs.mkdir(bbWorkingDirectory, { recursive: true });
-    logger.verbose(`Using native BB binary at ${expectedBBPath} with working directory ${bbWorkingDirectory}`);
+    logger.info(`Found native BB binary at ${expectedBBPath} with working directory ${bbWorkingDirectory}`);
 
     const expectedAcvmPath = ACVM_BINARY_PATH
       ? ACVM_BINARY_PATH
@@ -47,7 +47,7 @@ export const getEnvironmentConfig = async (logger: Logger) => {
     await fs.access(expectedAcvmPath, fs.constants.R_OK);
     const acvmWorkingDirectory = ACVM_WORKING_DIRECTORY ? ACVM_WORKING_DIRECTORY : `${tempWorkingDirectory}/acvm`;
     await fs.mkdir(acvmWorkingDirectory, { recursive: true });
-    logger.verbose(`Using native ACVM binary at ${expectedAcvmPath} with working directory ${acvmWorkingDirectory}`);
+    logger.info(`Found native ACVM binary at ${expectedAcvmPath} with working directory ${acvmWorkingDirectory}`);
 
     const bbSkipCleanup = ['1', 'true'].includes(BB_SKIP_CLEANUP);
     bbSkipCleanup && logger.verbose(`Not going to clean up BB working directory ${bbWorkingDirectory} after run`);
@@ -61,7 +61,7 @@ export const getEnvironmentConfig = async (logger: Logger) => {
       bbSkipCleanup,
     };
   } catch (err) {
-    logger.verbose(`Native BB not available, error: ${err}`);
+    logger.info(`Native BB not available: ${err}`);
     return undefined;
   }
 };

--- a/yarn-project/prover-client/src/orchestrator/orchestrator_failures.test.ts
+++ b/yarn-project/prover-client/src/orchestrator/orchestrator_failures.test.ts
@@ -1,13 +1,11 @@
-import { TestCircuitProver } from '@aztec/bb-prover';
 import { type ServerCircuitProver } from '@aztec/circuit-types';
 import { timesAsync } from '@aztec/foundation/collection';
 import { createLogger } from '@aztec/foundation/log';
-import { WASMSimulatorWithBlobs } from '@aztec/simulator/server';
 
 import { jest } from '@jest/globals';
 
 import { TestContext } from '../mocks/test_context.js';
-import { ProvingOrchestrator } from './orchestrator.js';
+import { type ProvingOrchestrator } from './orchestrator.js';
 
 const logger = createLogger('prover-client:test:orchestrator-failures');
 const LONG_TIMEOUT = 600_000;
@@ -15,6 +13,7 @@ const LONG_TIMEOUT = 600_000;
 describe('prover/orchestrator/failures', () => {
   let context: TestContext;
   let orchestrator: ProvingOrchestrator;
+  let prover: ServerCircuitProver;
 
   beforeEach(async () => {
     context = await TestContext.new(logger);
@@ -25,11 +24,8 @@ describe('prover/orchestrator/failures', () => {
   });
 
   describe('error handling', () => {
-    let mockProver: ServerCircuitProver;
-
     beforeEach(() => {
-      mockProver = new TestCircuitProver(new WASMSimulatorWithBlobs());
-      orchestrator = new ProvingOrchestrator(context.worldState, mockProver);
+      ({ prover, orchestrator } = context);
     });
 
     const run = async (message: string) => {
@@ -80,24 +76,24 @@ describe('prover/orchestrator/failures', () => {
     it.each([
       [
         'Private Base Rollup Failed',
-        (msg: string) => jest.spyOn(mockProver, 'getPrivateBaseRollupProof').mockRejectedValue(msg),
+        (msg: string) => jest.spyOn(prover, 'getPrivateBaseRollupProof').mockRejectedValue(msg),
       ],
       [
         'Public Base Rollup Failed',
-        (msg: string) => jest.spyOn(mockProver, 'getPublicBaseRollupProof').mockRejectedValue(msg),
+        (msg: string) => jest.spyOn(prover, 'getPublicBaseRollupProof').mockRejectedValue(msg),
       ],
-      ['Merge Rollup Failed', (msg: string) => jest.spyOn(mockProver, 'getMergeRollupProof').mockRejectedValue(msg)],
+      ['Merge Rollup Failed', (msg: string) => jest.spyOn(prover, 'getMergeRollupProof').mockRejectedValue(msg)],
       [
         'Block Root Rollup Failed',
-        (msg: string) => jest.spyOn(mockProver, 'getBlockRootRollupProof').mockRejectedValue(msg),
+        (msg: string) => jest.spyOn(prover, 'getBlockRootRollupProof').mockRejectedValue(msg),
       ],
       [
         'Block Merge Rollup Failed',
-        (msg: string) => jest.spyOn(mockProver, 'getBlockMergeRollupProof').mockRejectedValue(msg),
+        (msg: string) => jest.spyOn(prover, 'getBlockMergeRollupProof').mockRejectedValue(msg),
       ],
-      ['Root Rollup Failed', (msg: string) => jest.spyOn(mockProver, 'getRootRollupProof').mockRejectedValue(msg)],
-      ['Base Parity Failed', (msg: string) => jest.spyOn(mockProver, 'getBaseParityProof').mockRejectedValue(msg)],
-      ['Root Parity Failed', (msg: string) => jest.spyOn(mockProver, 'getRootParityProof').mockRejectedValue(msg)],
+      ['Root Rollup Failed', (msg: string) => jest.spyOn(prover, 'getRootRollupProof').mockRejectedValue(msg)],
+      ['Base Parity Failed', (msg: string) => jest.spyOn(prover, 'getBaseParityProof').mockRejectedValue(msg)],
+      ['Root Parity Failed', (msg: string) => jest.spyOn(prover, 'getRootParityProof').mockRejectedValue(msg)],
     ] as const)(
       'handles a %s error',
       async (message: string, makeFailedProof: (msg: string) => void) => {


### PR DESCRIPTION
Local tests show a 2x speedup.
