### PR TITLE
chore: Fix flake in circuit-types log-id

### DIFF
--- a/yarn-project/circuit-types/src/logs/log_id.test.ts
+++ b/yarn-project/circuit-types/src/logs/log_id.test.ts
@@ -1,14 +1,9 @@
-import { randomInt } from '@aztec/foundation/crypto';
-
 import { LogId } from './log_id.js';
 
 describe('LogId', () => {
   let logId: LogId;
   beforeEach(() => {
-    const blockNumber = randomInt(1000);
-    const txIndex = randomInt(1000);
-    const logIndex = randomInt(1000);
-    logId = new LogId(blockNumber, txIndex, logIndex);
+    logId = LogId.random();
   });
 
   it('toBuffer and fromBuffer works', () => {


### PR DESCRIPTION
Once in 1000 runs the test would fail with invalid block number (see [here](https://github.com/AztecProtocol/aztec-packages/actions/runs/13011571052/job/36290974832?pr=11560#step:3:1608)).
