### PR TITLE
fix: Fuzzer value mutation and instruction write

### DIFF
--- a/barretenberg/cpp/src/barretenberg/common/fuzzer.hpp
+++ b/barretenberg/cpp/src/barretenberg/common/fuzzer.hpp
@@ -234,9 +234,9 @@ inline static FF mutateFieldElement(FF e, T& rng)
             e = e.to_montgomery_form();
         }
         if (rng.next() & 1) {
-            value_data = e + FF(rng.next() & 0xff);
+            e += FF(rng.next() & 0xff);
         } else {
-            value_data = e - FF(rng.next() & 0xff);
+            e -= FF(rng.next() & 0xff);
         }
         if (convert_to_montgomery) {
             e = e.from_montgomery_form();
@@ -244,7 +244,6 @@ inline static FF mutateFieldElement(FF e, T& rng)
     } else { // 25% to use special values
 
         // Substitute field element with a special value
-        MONT_CONVERSION_LOCAL
         switch (rng.next() % 8) {
         case 0:
             e = FF::zero();
@@ -274,7 +273,9 @@ inline static FF mutateFieldElement(FF e, T& rng)
             abort();
             break;
         }
-        INV_MONT_CONVERSION_LOCAL
+        if (convert_to_montgomery) {
+            e = e.from_montgomery_form();
+        }
     }
     // Return instruction
     return e;

--- a/barretenberg/cpp/src/barretenberg/stdlib/primitives/bigfield/bigfield.fuzzer.hpp
+++ b/barretenberg/cpp/src/barretenberg/stdlib/primitives/bigfield/bigfield.fuzzer.hpp
@@ -740,7 +740,8 @@ template <typename Builder> class BigFieldBase {
             if constexpr (instruction_opcode == Instruction::OPCODE::CONSTANT ||
                           instruction_opcode == Instruction::OPCODE::WITNESS ||
                           instruction_opcode == Instruction::OPCODE::CONSTANT_WITNESS) {
-                bb::fq::serialize_to_buffer(instruction.arguments.element.value, Data);
+                *Data = instruction.id;
+                bb::fq::serialize_to_buffer(instruction.arguments.element.value, Data + 1);
             }
 
             if constexpr (instruction_opcode == Instruction::OPCODE::SQR ||

--- a/barretenberg/cpp/src/barretenberg/stdlib/primitives/bigfield/bigfield.fuzzer.hpp
+++ b/barretenberg/cpp/src/barretenberg/stdlib/primitives/bigfield/bigfield.fuzzer.hpp
@@ -404,16 +404,15 @@ template <typename Builder> class BigFieldBase {
                     e = e.to_montgomery_form();
                 }
                 if (rng.next() & 1) {
-                    value_data = e + bb::fq(rng.next() & 0xff);
+                    e += bb::fq(rng.next() & 0xff);
                 } else {
-                    value_data = e - bb::fq(rng.next() & 0xff);
+                    e -= bb::fq(rng.next() & 0xff);
                 }
                 if (convert_to_montgomery) {
                     e = e.from_montgomery_form();
                 }
             } else {
                 // Substitute field element with a special value
-                MONT_CONVERSION
                 switch (rng.next() % 9) {
                 case 0:
                     e = bb::fq::zero();
@@ -446,7 +445,9 @@ template <typename Builder> class BigFieldBase {
                     abort();
                     break;
                 }
-                INV_MONT_CONVERSION
+                if (convert_to_montgomery) {
+                    e = e.from_montgomery_form();
+                }
             }
             // Return instruction
             return e;
@@ -739,10 +740,7 @@ template <typename Builder> class BigFieldBase {
             if constexpr (instruction_opcode == Instruction::OPCODE::CONSTANT ||
                           instruction_opcode == Instruction::OPCODE::WITNESS ||
                           instruction_opcode == Instruction::OPCODE::CONSTANT_WITNESS) {
-                *Data = instruction.id;
-                memcpy(Data + 1,
-                       &instruction.arguments.element.value.data[0],
-                       sizeof(instruction.arguments.element.value.data));
+                bb::fq::serialize_to_buffer(instruction.arguments.element.value, Data);
             }
 
             if constexpr (instruction_opcode == Instruction::OPCODE::SQR ||

--- a/barretenberg/cpp/src/barretenberg/stdlib/primitives/field/field.fuzzer.hpp
+++ b/barretenberg/cpp/src/barretenberg/stdlib/primitives/field/field.fuzzer.hpp
@@ -647,6 +647,7 @@ template <typename Builder> class FieldBase {
             if constexpr (instruction_opcode == Instruction::OPCODE::CONSTANT ||
                           instruction_opcode == Instruction::OPCODE::WITNESS ||
                           instruction_opcode == Instruction::OPCODE::CONSTANT_WITNESS) {
+                *Data = instruction.id;
                 bb::fr::serialize_to_buffer(insturction.arguments.element.data, Data);
             }
 

--- a/barretenberg/cpp/src/barretenberg/stdlib/primitives/field/field.fuzzer.hpp
+++ b/barretenberg/cpp/src/barretenberg/stdlib/primitives/field/field.fuzzer.hpp
@@ -367,16 +367,15 @@ template <typename Builder> class FieldBase {
                     e = e.to_montgomery_form();
                 }
                 if (rng.next() & 1) {
-                    value_data = e + bb::fr(rng.next() & 0xff);
+                    e += bb::fr(rng.next() & 0xff);
                 } else {
-                    value_data = e - bb::fr(rng.next() & 0xff);
+                    e -= bb::fr(rng.next() & 0xff);
                 }
                 if (convert_to_montgomery) {
                     e = e.from_montgomery_form();
                 }
             } else {
                 // Substitute field element with a special value
-                MONT_CONVERSION
                 switch (rng.next() % 9) {
                 case 0:
                     e = bb::fr::zero();
@@ -409,7 +408,9 @@ template <typename Builder> class FieldBase {
                     abort();
                     break;
                 }
-                INV_MONT_CONVERSION
+                if (convert_to_montgomery) {
+                    e = e.from_montgomery_form();
+                }
             }
             // Return instruction
             return e;
@@ -646,8 +647,7 @@ template <typename Builder> class FieldBase {
             if constexpr (instruction_opcode == Instruction::OPCODE::CONSTANT ||
                           instruction_opcode == Instruction::OPCODE::WITNESS ||
                           instruction_opcode == Instruction::OPCODE::CONSTANT_WITNESS) {
-                *Data = instruction.id;
-                memcpy(Data + 1, &instruction.arguments.element.data[0], sizeof(instruction.arguments.element.data));
+                bb::fr::serialize_to_buffer(insturction.arguments.element.data, Data);
             }
 
             if constexpr (instruction_opcode == Instruction::OPCODE::ASSERT_ZERO ||

--- a/barretenberg/cpp/src/barretenberg/stdlib/primitives/field/field.fuzzer.hpp
+++ b/barretenberg/cpp/src/barretenberg/stdlib/primitives/field/field.fuzzer.hpp
@@ -648,7 +648,7 @@ template <typename Builder> class FieldBase {
                           instruction_opcode == Instruction::OPCODE::WITNESS ||
                           instruction_opcode == Instruction::OPCODE::CONSTANT_WITNESS) {
                 *Data = instruction.id;
-                bb::fr::serialize_to_buffer(insturction.arguments.element.data, Data);
+                bb::fr::serialize_to_buffer(insturction.arguments.element.data, Data + 1);
             }
 
             if constexpr (instruction_opcode == Instruction::OPCODE::ASSERT_ZERO ||

--- a/barretenberg/cpp/src/barretenberg/stdlib/primitives/safe_uint/safe_uint.fuzzer.hpp
+++ b/barretenberg/cpp/src/barretenberg/stdlib/primitives/safe_uint/safe_uint.fuzzer.hpp
@@ -326,16 +326,15 @@ template <typename Builder> class SafeUintFuzzBase {
                     e = e.to_montgomery_form();
                 }
                 if (rng.next() & 1) {
-                    value_data = e + fr(rng.next() & 0xff);
+                    e += fr(rng.next() & 0xff);
                 } else {
-                    value_data = e - fr(rng.next() & 0xff);
+                    e -= fr(rng.next() & 0xff);
                 }
                 if (convert_to_montgomery) {
                     e = e.from_montgomery_form();
                 }
             } else {
                 // Substitute field element with a special value
-                MONT_CONVERSION
                 switch (rng.next() % 8) {
                 case 0:
                     e = fr::zero();
@@ -365,7 +364,9 @@ template <typename Builder> class SafeUintFuzzBase {
                     abort();
                     break;
                 }
-                INV_MONT_CONVERSION
+                if (convert_to_montgomery) {
+                    e = e.from_montgomery_form();
+                }
             }
             // Return instruction
             return e;
@@ -533,9 +534,8 @@ template <typename Builder> class SafeUintFuzzBase {
             if constexpr (instruction_opcode == Instruction::OPCODE::CONSTANT ||
                           instruction_opcode == Instruction::OPCODE::WITNESS ||
                           instruction_opcode == Instruction::OPCODE::CONSTANT_WITNESS) {
-                *Data = instruction.id;
-                *(Data + 1) = instruction.arguments.element.bit_range;
-                fr::serialize_to_buffer(instruction.arguments.element.value, Data + 2);
+                *Data = instruction.arguments.element.bit_range;
+                fr::serialize_to_buffer(instruction.arguments.element.value, Data + 1);
             }
 
             if constexpr (instruction_opcode == Instruction::OPCODE::ADD ||

--- a/barretenberg/cpp/src/barretenberg/stdlib/primitives/safe_uint/safe_uint.fuzzer.hpp
+++ b/barretenberg/cpp/src/barretenberg/stdlib/primitives/safe_uint/safe_uint.fuzzer.hpp
@@ -534,8 +534,9 @@ template <typename Builder> class SafeUintFuzzBase {
             if constexpr (instruction_opcode == Instruction::OPCODE::CONSTANT ||
                           instruction_opcode == Instruction::OPCODE::WITNESS ||
                           instruction_opcode == Instruction::OPCODE::CONSTANT_WITNESS) {
-                *Data = instruction.arguments.element.bit_range;
-                fr::serialize_to_buffer(instruction.arguments.element.value, Data + 1);
+                *Data = instruction.id;
+                *(Data + 1) = instruction.arguments.element.bit_range;
+                fr::serialize_to_buffer(instruction.arguments.element.value, Data + 2);
             }
 
             if constexpr (instruction_opcode == Instruction::OPCODE::ADD ||


### PR DESCRIPTION
This pr fixes two issues in fuzzers:

- `mutateFieldElement` 

Previously in 2/3 cases the value was not mutated at all. The rest of the cases were handled by LibFuzzer completely. Now it's not.


- `writeInstruciton`

The value that was written using `memcpy` was parsed incorrectly by `field::serialize_from_buffer`. 