### PR TITLE
feat: bump bignum to `v0.5.2`

### DIFF
--- a/noir-projects/noir-protocol-circuits/crates/blob/Nargo.toml
+++ b/noir-projects/noir-protocol-circuits/crates/blob/Nargo.toml
@@ -5,5 +5,5 @@ authors = [""]
 compiler_version = ">=0.30.0"
 
 [dependencies]
-bigint = { tag = "v0.5.0", git = "https://github.com/noir-lang/noir-bignum" }
+bigint = { tag = "main", git = "https://github.com/noir-lang/noir-bignum" }
 types = { path = "../types" }

--- a/noir-projects/noir-protocol-circuits/crates/blob/Nargo.toml
+++ b/noir-projects/noir-protocol-circuits/crates/blob/Nargo.toml
@@ -5,5 +5,5 @@ authors = [""]
 compiler_version = ">=0.30.0"
 
 [dependencies]
-bigint = { tag = "main", git = "https://github.com/noir-lang/noir-bignum" }
+bigint = { tag = "v0.5.2", git = "https://github.com/noir-lang/noir-bignum" }
 types = { path = "../types" }


### PR DESCRIPTION
Bumping this to take advantage of some fixes and optimizations