### PR TITLE
chore: field encoding should use `fromString` instead of `fromHexString`

### DIFF
--- a/noir-projects/aztec-nr/aztec/src/macros/mod.nr
+++ b/noir-projects/aztec-nr/aztec/src/macros/mod.nr
@@ -75,7 +75,7 @@ comptime fn generate_contract_interface(m: Module) -> Quoted {
 
     quote {
         pub struct $module_name {
-            target_contract: dep::aztec::protocol_types::address::AztecAddress
+            pub target_contract: dep::aztec::protocol_types::address::AztecAddress
         }
 
         impl $module_name {

--- a/yarn-project/foundation/src/abi/encoder.test.ts
+++ b/yarn-project/foundation/src/abi/encoder.test.ts
@@ -180,7 +180,7 @@ describe('abi/encoder', () => {
     };
     const args = ['garbage'];
 
-    expect(() => encodeArguments(testFunctionAbi, args)).toThrow('Invalid hex-encoded string: "garbage"');
+    expect(() => encodeArguments(testFunctionAbi, args)).toThrow('Tried to create a Fr from an invalid string');
   });
 
   it('throws when passing string argument as integer', () => {

--- a/yarn-project/foundation/src/abi/encoder.ts
+++ b/yarn-project/foundation/src/abi/encoder.ts
@@ -50,7 +50,7 @@ class ArgumentEncoder {
         } else if (typeof arg === 'bigint') {
           this.flattened.push(new Fr(arg));
         } else if (typeof arg === 'string') {
-          this.flattened.push(Fr.fromHexString(arg));
+          this.flattened.push(Fr.fromString(arg));
         } else if (typeof arg === 'boolean') {
           this.flattened.push(new Fr(arg ? 1n : 0n));
         } else if (typeof arg === 'object') {


### PR DESCRIPTION
Related #10331
