### PR TITLE
chore(avm): make check_relation safer

### DIFF
--- a/barretenberg/cpp/src/barretenberg/vm2/constraining/relations/alu.test.cpp
+++ b/barretenberg/cpp/src/barretenberg/vm2/constraining/relations/alu.test.cpp
@@ -19,26 +19,26 @@ using alu = bb::avm2::alu<FF>;
 
 TEST(AluConstrainingTest, BasicAdd)
 {
-    TestTraceContainer::RowTraceContainer trace = {
+    auto trace = TestTraceContainer::from_rows({
         { .alu_ia = 1, .alu_ib = 2, .alu_ic = 3, .alu_sel_op_add = 1 },
-    };
+    });
 
     check_relation<alu>(trace);
 }
 
 TEST(AluConstrainingTest, NegativeSelNonBoolean)
 {
-    TestTraceContainer::RowTraceContainer trace = {
+    auto trace = TestTraceContainer::from_rows({
         // Negative test, this should be a boolean only!
         { .alu_sel_op_add = 23 },
-    };
+    });
 
     EXPECT_THROW_WITH_MESSAGE(check_relation<alu>(trace, alu::SR_SEL_ADD_BINARY), "SEL_ADD_BINARY");
 }
 
 TEST(AluConstrainingTest, NegativeAdd)
 {
-    TestTraceContainer::RowTraceContainer trace = {
+    auto trace = TestTraceContainer::from_rows({
         {
             // Wrong ADD.
             .alu_ia = 1,
@@ -47,7 +47,7 @@ TEST(AluConstrainingTest, NegativeAdd)
             // Observe that I'm making subrelation SEL_ADD_BINARY fail too, but we'll only check subrelation ALU_ADD!
             .alu_sel_op_add = 1,
         },
-    };
+    });
 
     EXPECT_THROW_WITH_MESSAGE(check_relation<alu>(trace, alu::SR_ALU_ADD), "ALU_ADD");
 }

--- a/barretenberg/cpp/src/barretenberg/vm2/constraining/relations/bc_decomposition.test.cpp
+++ b/barretenberg/cpp/src/barretenberg/vm2/constraining/relations/bc_decomposition.test.cpp
@@ -20,7 +20,6 @@ using tracegen::TestTraceContainer;
 using FF = AvmFlavorSettings::FF;
 using C = Column;
 using bc_decomposition = bb::avm2::bc_decomposition<FF>;
-using testing::SizeIs;
 
 std::vector<uint8_t> random_bytes(size_t n)
 {
@@ -38,66 +37,48 @@ TEST(BytecodeDecompositionConstrainingTest, EmptyRow)
         { { C::precomputed_first_row, 1 } },
     });
 
-    check_relation<bc_decomposition>(trace.as_rows());
+    check_relation<bc_decomposition>(trace);
 }
 
 TEST(BytecodeDecompositionConstrainingTest, SingleBytecode)
 {
-    TestTraceContainer trace({
-        { { C::precomputed_first_row, 1 } },
-    });
-
+    TestTraceContainer trace;
     BytecodeTraceBuilder builder;
     builder.process_decomposition(
         { { .bytecode_id = 1, .bytecode = std::make_shared<std::vector<uint8_t>>(random_bytes(40)) } }, trace);
 
-    auto rows = trace.as_rows();
-    EXPECT_THAT(rows, SizeIs(1 + 40));
-
-    check_relation<bc_decomposition>(rows);
+    EXPECT_EQ(trace.get_num_rows(), 1 + 40);
+    check_relation<bc_decomposition>(trace);
 }
 
 TEST(BytecodeDecompositionConstrainingTest, ShortSingleBytecode)
 {
-    TestTraceContainer trace({
-        { { C::precomputed_first_row, 1 } },
-    });
-
     // Bytecode is shorter than the sliding window.
+    TestTraceContainer trace;
     BytecodeTraceBuilder builder;
     builder.process_decomposition(
         { { .bytecode_id = 1, .bytecode = std::make_shared<std::vector<uint8_t>>(random_bytes(5)) } }, trace);
 
-    auto rows = trace.as_rows();
-    EXPECT_THAT(rows, SizeIs(1 + 5));
-
-    check_relation<bc_decomposition>(rows);
+    EXPECT_EQ(trace.get_num_rows(), 1 + 5);
+    check_relation<bc_decomposition>(trace);
 }
 
 TEST(BytecodeDecompositionConstrainingTest, MultipleBytecodes)
 {
-    TestTraceContainer trace({
-        { { C::precomputed_first_row, 1 } },
-    });
-
+    TestTraceContainer trace;
     BytecodeTraceBuilder builder;
     builder.process_decomposition(
         { { .bytecode_id = 1, .bytecode = std::make_shared<std::vector<uint8_t>>(random_bytes(40)) },
           { .bytecode_id = 2, .bytecode = std::make_shared<std::vector<uint8_t>>(random_bytes(55)) } },
         trace);
 
-    auto rows = trace.as_rows();
-    EXPECT_THAT(rows, SizeIs(1 + 40 + 55));
-
-    check_relation<bc_decomposition>(rows);
+    EXPECT_EQ(trace.get_num_rows(), 1 + 40 + 55);
+    check_relation<bc_decomposition>(trace);
 }
 
 TEST(BytecodeDecompositionConstrainingTest, MultipleBytecodesWithShortOnes)
 {
-    TestTraceContainer trace({
-        { { C::precomputed_first_row, 1 } },
-    });
-
+    TestTraceContainer trace;
     BytecodeTraceBuilder builder;
     builder.process_decomposition(
         { { .bytecode_id = 1, .bytecode = std::make_shared<std::vector<uint8_t>>(random_bytes(40)) },
@@ -107,10 +88,8 @@ TEST(BytecodeDecompositionConstrainingTest, MultipleBytecodesWithShortOnes)
           { .bytecode_id = 5, .bytecode = std::make_shared<std::vector<uint8_t>>(random_bytes(2)) } },
         trace);
 
-    auto rows = trace.as_rows();
-    EXPECT_THAT(rows, SizeIs(1 + 40 + 5 + 10 + 55 + 2));
-
-    check_relation<bc_decomposition>(rows);
+    EXPECT_EQ(trace.get_num_rows(), 1 + 40 + 5 + 10 + 55 + 2);
+    check_relation<bc_decomposition>(trace);
 }
 
 } // namespace

--- a/barretenberg/cpp/src/barretenberg/vm2/constraining/relations/execution.test.cpp
+++ b/barretenberg/cpp/src/barretenberg/vm2/constraining/relations/execution.test.cpp
@@ -26,7 +26,7 @@ TEST(ExecutionConstrainingTest, Basic)
     });
     // clang-format on
 
-    check_relation<execution>(trace.as_rows());
+    check_relation<execution>(trace);
 }
 
 TEST(ExecutionConstrainingTest, Continuity)
@@ -40,7 +40,7 @@ TEST(ExecutionConstrainingTest, Continuity)
     });
     // clang-format on
 
-    check_relation<execution>(trace.as_rows(), execution::SR_TRACE_CONTINUITY_1, execution::SR_TRACE_CONTINUITY_2);
+    check_relation<execution>(trace, execution::SR_TRACE_CONTINUITY_1, execution::SR_TRACE_CONTINUITY_2);
 }
 
 TEST(ExecutionConstrainingTest, ContinuityBrokenFirstRow)
@@ -54,8 +54,7 @@ TEST(ExecutionConstrainingTest, ContinuityBrokenFirstRow)
     });
     // clang-format on
 
-    EXPECT_THROW_WITH_MESSAGE(check_relation<execution>(trace.as_rows(), execution::SR_TRACE_CONTINUITY_2),
-                              "TRACE_CONTINUITY_2");
+    EXPECT_THROW_WITH_MESSAGE(check_relation<execution>(trace, execution::SR_TRACE_CONTINUITY_2), "TRACE_CONTINUITY_2");
 }
 
 TEST(ExecutionConstrainingTest, ContinuityBrokenInMiddle)
@@ -69,10 +68,8 @@ TEST(ExecutionConstrainingTest, ContinuityBrokenInMiddle)
     });
     // clang-format on
 
-    EXPECT_THROW_WITH_MESSAGE(check_relation<execution>(trace.as_rows(), execution::SR_TRACE_CONTINUITY_1),
-                              "TRACE_CONTINUITY_1");
-    EXPECT_THROW_WITH_MESSAGE(check_relation<execution>(trace.as_rows(), execution::SR_TRACE_CONTINUITY_2),
-                              "TRACE_CONTINUITY_2");
+    EXPECT_THROW_WITH_MESSAGE(check_relation<execution>(trace, execution::SR_TRACE_CONTINUITY_1), "TRACE_CONTINUITY_1");
+    EXPECT_THROW_WITH_MESSAGE(check_relation<execution>(trace, execution::SR_TRACE_CONTINUITY_2), "TRACE_CONTINUITY_2");
 }
 
 TEST(ExecutionConstrainingTest, ContinuityBrokenAtTheEnd)
@@ -85,8 +82,7 @@ TEST(ExecutionConstrainingTest, ContinuityBrokenAtTheEnd)
     });
     // clang-format on
 
-    EXPECT_THROW_WITH_MESSAGE(check_relation<execution>(trace.as_rows(), execution::SR_TRACE_CONTINUITY_1),
-                              "TRACE_CONTINUITY_1");
+    EXPECT_THROW_WITH_MESSAGE(check_relation<execution>(trace, execution::SR_TRACE_CONTINUITY_1), "TRACE_CONTINUITY_1");
 }
 
 TEST(ExecutionConstrainingTest, ContinuityMultipleLast)
@@ -100,8 +96,7 @@ TEST(ExecutionConstrainingTest, ContinuityMultipleLast)
     });
     // clang-format on
 
-    EXPECT_THROW_WITH_MESSAGE(check_relation<execution>(trace.as_rows(), execution::SR_LAST_IS_LAST),
-                              "LAST_IS_LAST.*row 1");
+    EXPECT_THROW_WITH_MESSAGE(check_relation<execution>(trace, execution::SR_LAST_IS_LAST), "LAST_IS_LAST.*row 1");
 }
 
 } // namespace

--- a/barretenberg/cpp/src/barretenberg/vm2/constraining/relations/range_check.test.cpp
+++ b/barretenberg/cpp/src/barretenberg/vm2/constraining/relations/range_check.test.cpp
@@ -26,7 +26,7 @@ TEST(RangeCheckConstrainingTest, EmptyRow)
         { { C::precomputed_clk, 1 } },
     });
 
-    check_relation<range_check>(trace.as_rows());
+    check_relation<range_check>(trace);
 }
 
 TEST(RangeCheckConstrainingTest, IsLteMutuallyExclusive)
@@ -35,7 +35,7 @@ TEST(RangeCheckConstrainingTest, IsLteMutuallyExclusive)
         { { C::range_check_sel, 1 }, { C::range_check_is_lte_u32, 1 } },
     });
 
-    check_relation<range_check>(trace.as_rows(), range_check::SR_IS_LTE_MUTUALLY_EXCLUSIVE);
+    check_relation<range_check>(trace, range_check::SR_IS_LTE_MUTUALLY_EXCLUSIVE);
 }
 
 TEST(RangeCheckConstrainingTest, NegativeIsLteMutuallyExclusive)
@@ -45,7 +45,7 @@ TEST(RangeCheckConstrainingTest, NegativeIsLteMutuallyExclusive)
         { { C::range_check_sel, 1 }, { C::range_check_is_lte_u32, 1 }, { C::range_check_is_lte_u112, 1 } },
     });
 
-    EXPECT_THROW_WITH_MESSAGE(check_relation<range_check>(trace.as_rows(), range_check::SR_IS_LTE_MUTUALLY_EXCLUSIVE),
+    EXPECT_THROW_WITH_MESSAGE(check_relation<range_check>(trace, range_check::SR_IS_LTE_MUTUALLY_EXCLUSIVE),
                               "IS_LTE_MUTUALLY_EXCLUSIVE");
 }
 
@@ -67,7 +67,7 @@ TEST(RangeCheckConstrainingTest, CheckRecomposition)
         { C::range_check_u16_r7, dynamic_slice_register },
     } });
 
-    check_relation<range_check>(trace.as_rows(), range_check::SR_CHECK_RECOMPOSITION);
+    check_relation<range_check>(trace, range_check::SR_CHECK_RECOMPOSITION);
 }
 
 TEST(RangeCheckConstrainingTest, NegativeCheckRecomposition)
@@ -89,7 +89,7 @@ TEST(RangeCheckConstrainingTest, NegativeCheckRecomposition)
         { C::range_check_u16_r7, dynamic_slice_register },
     } });
 
-    EXPECT_THROW_WITH_MESSAGE(check_relation<range_check>(trace.as_rows(), range_check::SR_CHECK_RECOMPOSITION),
+    EXPECT_THROW_WITH_MESSAGE(check_relation<range_check>(trace, range_check::SR_CHECK_RECOMPOSITION),
                               "CHECK_RECOMPOSITION");
 }
 
@@ -126,7 +126,7 @@ TEST(RangeCheckConstrainingTest, Full)
         { C::range_check_sel_r1_16_bit_rng_lookup, 1 },
     } });
 
-    check_relation<range_check>(trace.as_rows());
+    check_relation<range_check>(trace);
 }
 
 TEST(RangeCheckConstrainingTest, NegativeMissingLookup)
@@ -162,7 +162,7 @@ TEST(RangeCheckConstrainingTest, NegativeMissingLookup)
         { C::range_check_sel_r1_16_bit_rng_lookup, 0 }, // BAD! SHOULD BE 1
     } });
 
-    EXPECT_THROW_WITH_MESSAGE(check_relation<range_check>(trace.as_rows()), "Relation range_check");
+    EXPECT_THROW_WITH_MESSAGE(check_relation<range_check>(trace), "Relation range_check");
 }
 
 TEST(RangeCheckConstrainingTest, WithTracegen)
@@ -187,7 +187,7 @@ TEST(RangeCheckConstrainingTest, WithTracegen)
         },
         trace);
 
-    check_relation<range_check>(trace.as_rows());
+    check_relation<range_check>(trace);
 }
 
 TEST(RangeCheckConstrainingTest, NegativeWithTracegen)
@@ -210,7 +210,7 @@ TEST(RangeCheckConstrainingTest, NegativeWithTracegen)
         },
         trace);
 
-    EXPECT_THROW_WITH_MESSAGE(check_relation<range_check>(trace.as_rows()), "Relation range_check");
+    EXPECT_THROW_WITH_MESSAGE(check_relation<range_check>(trace), "Relation range_check");
 }
 
 } // namespace

--- a/barretenberg/cpp/src/barretenberg/vm2/constraining/relations/sha256.test.cpp
+++ b/barretenberg/cpp/src/barretenberg/vm2/constraining/relations/sha256.test.cpp
@@ -33,7 +33,7 @@ TEST(Sha256ConstrainingTest, EmptyRow)
         { { C::precomputed_clk, 1 } },
     });
 
-    check_relation<sha256>(trace.as_rows());
+    check_relation<sha256>(trace);
 }
 
 // This test imports a bunch of external code since hand-generating the sha256 trace is a bit laborious atm.
@@ -71,9 +71,7 @@ TEST(Sha256ConstrainingTest, Basic)
     const auto sha256_event_container = sha256_event_emitter.dump_events();
     builder.process(sha256_event_container);
 
-    TestTraceContainer::RowTraceContainer rows = trace.as_rows();
-
-    check_relation<sha256>(rows);
+    check_relation<sha256>(trace);
 }
 
 } // namespace

--- a/barretenberg/cpp/src/barretenberg/vm2/constraining/testing/check_relation.hpp
+++ b/barretenberg/cpp/src/barretenberg/vm2/constraining/testing/check_relation.hpp
@@ -5,6 +5,7 @@
 #include <stdexcept>
 
 #include "barretenberg/common/log.hpp"
+#include "barretenberg/vm2/tracegen/test_trace_container.hpp"
 
 namespace bb::avm2::constraining {
 
@@ -28,13 +29,14 @@ void check_relation_internal(const Trace& trace, std::span<size_t> subrelations)
     }
 }
 
-template <typename Relation, typename Trace, typename... Ts> void check_relation(const Trace& trace, Ts... subrelation)
+template <typename Relation, typename... Ts>
+void check_relation(const tracegen::TestTraceContainer& trace, Ts... subrelation)
 {
     std::array<size_t, sizeof...(Ts)> subrelations = { subrelation... };
-    check_relation_internal<Relation>(trace, subrelations);
+    check_relation_internal<Relation>(trace.as_rows(), subrelations);
 }
 
-template <typename Relation, typename Trace> void check_relation(const Trace& trace)
+template <typename Relation> void check_relation(const tracegen::TestTraceContainer& trace)
 {
     auto subrelations = std::make_index_sequence<Relation::SUBRELATION_PARTIAL_LENGTHS.size()>();
     [&]<size_t... Is>(std::index_sequence<Is...>) { check_relation<Relation>(trace, Is...); }(subrelations);


### PR DESCRIPTION
This requires you to use a TestTraceContainer. Then we do `as_rows()` which most importantly generates the shifted columns.
