### PR TITLE
fix: boxes playwright + web bundles

### DIFF
--- a/boxes/Dockerfile
+++ b/boxes/Dockerfile
@@ -21,5 +21,5 @@ COPY . .
 ENV AZTEC_NARGO=/usr/aztec-nargo/compile_then_postprocess.sh
 ENV AZTEC_BUILDER=/usr/src/yarn-project/builder/aztec-builder-dest
 RUN yarn
-RUN npx -y playwright@1.50 install --with-deps
+RUN npx -y playwright@1.50.0 install --with-deps
 ENTRYPOINT ["/bin/sh", "-c"]

--- a/boxes/Dockerfile
+++ b/boxes/Dockerfile
@@ -21,5 +21,5 @@ COPY . .
 ENV AZTEC_NARGO=/usr/aztec-nargo/compile_then_postprocess.sh
 ENV AZTEC_BUILDER=/usr/src/yarn-project/builder/aztec-builder-dest
 RUN yarn
-RUN npx -y playwright@1.50.0 install --with-deps
+RUN npx -y playwright@1.50 install --with-deps
 ENTRYPOINT ["/bin/sh", "-c"]

--- a/boxes/docker-compose.yml
+++ b/boxes/docker-compose.yml
@@ -41,6 +41,7 @@ services:
     working_dir: /root/aztec-packages/boxes
     entrypoint: >
       sh -c '
+        npx -y playwright@1.50 install --with-deps
         yarn workspace @aztec/$$BOX test --project=$$BROWSER
       '
     environment:

--- a/build-images/Earthfile
+++ b/build-images/Earthfile
@@ -195,7 +195,7 @@ build:
           -o /usr/local/bin/yq && chmod +x /usr/local/bin/yq
 
   # Install playwright for browser testing.
-  RUN npx -y playwright@1.50 install --with-deps
+  RUN npx -y playwright@1.50.0 install --with-deps
 
   ARG TARGETARCH
   # NOTE: bump this version when doing non-backwards compatible changes

--- a/build-images/Earthfile
+++ b/build-images/Earthfile
@@ -195,7 +195,7 @@ build:
           -o /usr/local/bin/yq && chmod +x /usr/local/bin/yq
 
   # Install playwright for browser testing.
-  RUN npx -y playwright@1.50.0 install --with-deps
+  RUN npx -y playwright@1.50 install --with-deps
 
   ARG TARGETARCH
   # NOTE: bump this version when doing non-backwards compatible changes

--- a/gaztec/src/components/contract/contract.tsx
+++ b/gaztec/src/components/contract/contract.tsx
@@ -429,6 +429,7 @@ export function ContractComponent() {
                 />
                 <IconButton
                   onClick={(e) => {
+                    setCurrentContractAddress(null);
                     setCurrentContract(null);
                     setContractArtifact(null);
                   }}

--- a/gaztec/src/components/contract/contract.tsx
+++ b/gaztec/src/components/contract/contract.tsx
@@ -133,6 +133,7 @@ export function ContractComponent() {
     currentContractAddress,
     currentContract,
     setCurrentContract,
+    setCurrentContractAddress,
     setCurrentTx,
   } = useContext(AztecContext);
 
@@ -160,7 +161,10 @@ export function ContractComponent() {
       });
       setIsLoadingArtifact(false);
     };
-    if (currentContractAddress) {
+    if (
+      currentContractAddress &&
+      currentContract?.address !== currentContractAddress
+    ) {
       loadCurrentContract();
     }
   }, [currentContractAddress]);
@@ -201,6 +205,7 @@ export function ContractComponent() {
       setCurrentContract(
         await Contract.at(contract.address, contractArtifact, wallet)
       );
+      setCurrentContractAddress(contract.address);
     }
     setOpenDeployContractDialog(false);
     setOpenRegisterContractDialog(false);

--- a/gaztec/src/components/sidebar/sidebar.tsx
+++ b/gaztec/src/components/sidebar/sidebar.tsx
@@ -208,6 +208,8 @@ export function SidebarComponent() {
     };
     if (currentContractAddress && walletDB) {
       refreshTransactions();
+    } else {
+      setTransactions([]);
     }
   }, [currentContractAddress, currentTx]);
 

--- a/yarn-project/aztec.js/src/api/ethereum.ts
+++ b/yarn-project/aztec.js/src/api/ethereum.ts
@@ -1,1 +1,2 @@
-export { deployL1Contract, deployL1Contracts, DeployL1Contracts } from '@aztec/ethereum';
+export { deployL1Contract, deployL1Contracts, DeployL1Contracts } from '@aztec/ethereum/deploy-l1-contracts';
+export { EthCheatCodes } from '@aztec/ethereum/eth-cheatcodes';

--- a/yarn-project/aztec.js/src/contract/contract.test.ts
+++ b/yarn-project/aztec.js/src/contract/contract.test.ts
@@ -14,7 +14,7 @@ import {
   GasFees,
   type NodeInfo,
 } from '@aztec/circuits.js';
-import { type L1ContractAddresses } from '@aztec/ethereum';
+import { type L1ContractAddresses } from '@aztec/ethereum/l1-contract-addresses';
 import { type AbiDecoded, type ContractArtifact, FunctionType } from '@aztec/foundation/abi';
 
 import { type MockProxy, mock } from 'jest-mock-extended';

--- a/yarn-project/aztec.js/src/index.ts
+++ b/yarn-project/aztec.js/src/index.ts
@@ -147,13 +147,12 @@ export { elapsed } from '@aztec/foundation/timer';
 export { type FieldsOf } from '@aztec/foundation/types';
 export { fileURLToPath } from '@aztec/foundation/url';
 
-export { EthCheatCodes, deployL1Contract, deployL1Contracts, type DeployL1Contracts } from '@aztec/ethereum';
-
 // Start of section that exports public api via granular api.
 // Here you *can* do `export *` as the granular api defacto exports things explicitly.
 // This entire index file will be deprecated at some point after we're satisfied.
 export * from './api/abi.js';
 export * from './api/fee.js';
+export * from './api/addresses.js';
+export * from './api/ethereum.js';
 // Granular export, even if not in the api folder
 export * from './contract/index.js';
-export * from './api/addresses.js';

--- a/yarn-project/aztec.js/src/utils/chain_monitor.ts
+++ b/yarn-project/aztec.js/src/utils/chain_monitor.ts
@@ -1,4 +1,4 @@
-import { type RollupContract } from '@aztec/ethereum';
+import { type RollupContract } from '@aztec/ethereum/contracts';
 import { createLogger } from '@aztec/foundation/log';
 
 import { type PublicClient } from 'viem';

--- a/yarn-project/aztec.js/src/utils/cheat_codes.ts
+++ b/yarn-project/aztec.js/src/utils/cheat_codes.ts
@@ -1,7 +1,8 @@
 import { type EpochProofClaim, type Note, type PXE } from '@aztec/circuit-types';
 import { type AztecAddress, EthAddress, Fr } from '@aztec/circuits.js';
 import { deriveStorageSlotInMap } from '@aztec/circuits.js/hash';
-import { EthCheatCodes, type L1ContractAddresses } from '@aztec/ethereum';
+import { EthCheatCodes } from '@aztec/ethereum/eth-cheatcodes';
+import { type L1ContractAddresses } from '@aztec/ethereum/l1-contract-addresses';
 import { createLogger } from '@aztec/foundation/log';
 import { RollupAbi } from '@aztec/l1-artifacts';
 

--- a/yarn-project/aztec.js/src/utils/l1_contracts.ts
+++ b/yarn-project/aztec.js/src/utils/l1_contracts.ts
@@ -1,4 +1,4 @@
-import { type L1ContractAddresses } from '@aztec/ethereum';
+import { type L1ContractAddresses } from '@aztec/ethereum/l1-contract-addresses';
 import { retryUntil } from '@aztec/foundation/retry';
 
 import { createPXEClient } from '../rpc_clients/index.js';

--- a/yarn-project/aztec.js/src/utils/portal_manager.ts
+++ b/yarn-project/aztec.js/src/utils/portal_manager.ts
@@ -7,7 +7,7 @@ import {
   type SiblingPath,
   computeSecretHash,
 } from '@aztec/aztec.js';
-import { extractEvent } from '@aztec/ethereum';
+import { extractEvent } from '@aztec/ethereum/utils';
 import { sha256ToField } from '@aztec/foundation/crypto';
 import { FeeJuicePortalAbi, OutboxAbi, TestERC20Abi, TokenPortalAbi } from '@aztec/l1-artifacts';
 

--- a/yarn-project/circuit-types/src/interfaces/aztec-node.test.ts
+++ b/yarn-project/circuit-types/src/interfaces/aztec-node.test.ts
@@ -18,7 +18,7 @@ import {
   PublicKeys,
   getContractClassFromArtifact,
 } from '@aztec/circuits.js';
-import { type L1ContractAddresses, L1ContractsNames } from '@aztec/ethereum';
+import { type L1ContractAddresses, L1ContractsNames } from '@aztec/ethereum/l1-contract-addresses';
 import { type ContractArtifact } from '@aztec/foundation/abi';
 import { memoize } from '@aztec/foundation/decorators';
 import { type JsonRpcTestContext, createJsonRpcTestSetup } from '@aztec/foundation/json-rpc/test';

--- a/yarn-project/circuit-types/src/interfaces/aztec-node.ts
+++ b/yarn-project/circuit-types/src/interfaces/aztec-node.ts
@@ -16,7 +16,7 @@ import {
   type ProtocolContractAddresses,
   ProtocolContractAddressesSchema,
 } from '@aztec/circuits.js';
-import { type L1ContractAddresses, L1ContractAddressesSchema } from '@aztec/ethereum';
+import { type L1ContractAddresses, L1ContractAddressesSchema } from '@aztec/ethereum/l1-contract-addresses';
 import type { AztecAddress } from '@aztec/foundation/aztec-address';
 import type { Fr } from '@aztec/foundation/fields';
 import { createSafeJsonRpcClient, defaultFetch } from '@aztec/foundation/json-rpc/client';

--- a/yarn-project/circuit-types/src/interfaces/pxe.test.ts
+++ b/yarn-project/circuit-types/src/interfaces/pxe.test.ts
@@ -16,7 +16,7 @@ import {
   PublicKeys,
   getContractClassFromArtifact,
 } from '@aztec/circuits.js';
-import { type L1ContractAddresses, L1ContractsNames } from '@aztec/ethereum';
+import { type L1ContractAddresses, L1ContractsNames } from '@aztec/ethereum/l1-contract-addresses';
 import { type AbiDecoded, type ContractArtifact, EventSelector } from '@aztec/foundation/abi';
 import { memoize } from '@aztec/foundation/decorators';
 import { type JsonRpcTestContext, createJsonRpcTestSetup } from '@aztec/foundation/json-rpc/test';

--- a/yarn-project/circuits.js/src/contract/interfaces/node-info.ts
+++ b/yarn-project/circuits.js/src/contract/interfaces/node-info.ts
@@ -1,4 +1,4 @@
-import { type L1ContractAddresses, L1ContractAddressesSchema } from '@aztec/ethereum';
+import { type L1ContractAddresses, L1ContractAddressesSchema } from '@aztec/ethereum/l1-contract-addresses';
 import { type ZodFor } from '@aztec/foundation/schemas';
 
 import { z } from 'zod';

--- a/yarn-project/end-to-end/src/e2e_p2p/p2p_network.ts
+++ b/yarn-project/end-to-end/src/e2e_p2p/p2p_network.ts
@@ -2,7 +2,7 @@ import { getSchnorrAccount } from '@aztec/accounts/schnorr';
 import { type AztecNodeConfig, type AztecNodeService } from '@aztec/aztec-node';
 import { type AccountWalletWithSecretKey } from '@aztec/aztec.js';
 import { ChainMonitor } from '@aztec/aztec.js/utils';
-import { L1TxUtils, RollupContract, getL1ContractsConfigEnvVars } from '@aztec/ethereum';
+import { L1TxUtilsWithBlobs, RollupContract, getL1ContractsConfigEnvVars } from '@aztec/ethereum';
 import { EthCheatCodesWithState } from '@aztec/ethereum/test';
 import { type Logger, createLogger } from '@aztec/foundation/log';
 import { RollupAbi, TestERC20Abi } from '@aztec/l1-artifacts';
@@ -55,7 +55,7 @@ export class P2PNetworkTest {
 
   private cleanupInterval: NodeJS.Timeout | undefined = undefined;
 
-  private gasUtils: L1TxUtils | undefined = undefined;
+  private gasUtils: L1TxUtilsWithBlobs | undefined = undefined;
 
   constructor(
     testName: string,
@@ -301,7 +301,7 @@ export class P2PNetworkTest {
     this.ctx = await this.snapshotManager.setup();
     this.startSyncMockSystemTimeInterval();
 
-    this.gasUtils = new L1TxUtils(
+    this.gasUtils = new L1TxUtilsWithBlobs(
       this.ctx.deployL1ContractsValues.publicClient,
       this.ctx.deployL1ContractsValues.walletClient,
       this.logger,

--- a/yarn-project/ethereum/package.json
+++ b/yarn-project/ethereum/package.json
@@ -4,9 +4,12 @@
   "type": "module",
   "exports": {
     ".": "./dest/index.js",
+    "./eth-cheatcodes": "./dest/eth_cheat_codes.js",
     "./test": "./dest/test/index.js",
     "./contracts": "./dest/contracts/index.js",
-    "./l1-contract-addresses": "./dest/l1_contract_addresses.js"
+    "./deploy-l1-contracts": "./dest/deploy_l1_contracts.js",
+    "./l1-contract-addresses": "./dest/l1_contract_addresses.js",
+    "./utils": "./dest/utils.js"
   },
   "typedocOptions": {
     "entryPoints": [

--- a/yarn-project/ethereum/src/index.ts
+++ b/yarn-project/ethereum/src/index.ts
@@ -3,6 +3,7 @@ export * from './deploy_l1_contracts.js';
 export * from './chain.js';
 export * from './eth_cheat_codes.js';
 export * from './l1_tx_utils.js';
+export * from './l1_tx_utils_with_blobs.js';
 export * from './l1_contract_addresses.js';
 export * from './l1_reader.js';
 export * from './utils.js';

--- a/yarn-project/ethereum/src/l1_tx_utils.test.ts
+++ b/yarn-project/ethereum/src/l1_tx_utils.test.ts
@@ -19,7 +19,8 @@ import { mnemonicToAccount, privateKeyToAccount } from 'viem/accounts';
 import { foundry } from 'viem/chains';
 
 import { EthCheatCodes } from './eth_cheat_codes.js';
-import { L1TxUtils, defaultL1TxUtilsConfig } from './l1_tx_utils.js';
+import { defaultL1TxUtilsConfig } from './l1_tx_utils.js';
+import { L1TxUtilsWithBlobs } from './l1_tx_utils_with_blobs.js';
 import { startAnvil } from './test/start_anvil.js';
 import { formatViemError } from './utils.js';
 
@@ -35,7 +36,7 @@ export type PendingTransaction = {
 };
 
 describe('GasUtils', () => {
-  let gasUtils: L1TxUtils;
+  let gasUtils: L1TxUtilsWithBlobs;
   let walletClient: WalletClient<HttpTransport, Chain, Account>;
   let publicClient: PublicClient<HttpTransport, Chain>;
   let anvil: Anvil;
@@ -73,7 +74,7 @@ describe('GasUtils', () => {
     });
     await cheatCodes.evmMine();
 
-    gasUtils = new L1TxUtils(publicClient, walletClient, logger, {
+    gasUtils = new L1TxUtilsWithBlobs(publicClient, walletClient, logger, {
       gasLimitBufferPercentage: 20,
       maxGwei: 500n,
       minGwei: 1n,
@@ -201,7 +202,7 @@ describe('GasUtils', () => {
     await cheatCodes.evmMine();
 
     // First deploy without any buffer
-    const baselineGasUtils = new L1TxUtils(publicClient, walletClient, logger, {
+    const baselineGasUtils = new L1TxUtilsWithBlobs(publicClient, walletClient, logger, {
       gasLimitBufferPercentage: 0,
       maxGwei: 500n,
       minGwei: 10n, // Increased minimum gas price
@@ -221,7 +222,7 @@ describe('GasUtils', () => {
     });
 
     // Now deploy with 20% buffer
-    const bufferedGasUtils = new L1TxUtils(publicClient, walletClient, logger, {
+    const bufferedGasUtils = new L1TxUtilsWithBlobs(publicClient, walletClient, logger, {
       gasLimitBufferPercentage: 20,
       maxGwei: 500n,
       minGwei: 1n,
@@ -280,7 +281,7 @@ describe('GasUtils', () => {
   });
 
   it('respects minimum gas price bump for replacements', async () => {
-    const gasUtils = new L1TxUtils(publicClient, walletClient, logger, {
+    const gasUtils = new L1TxUtilsWithBlobs(publicClient, walletClient, logger, {
       ...defaultL1TxUtilsConfig,
       priorityFeeRetryBumpPercentage: 5, // Set lower than minimum 10%
     });

--- a/yarn-project/ethereum/src/l1_tx_utils_with_blobs.ts
+++ b/yarn-project/ethereum/src/l1_tx_utils_with_blobs.ts
@@ -2,7 +2,7 @@ import { Blob } from '@aztec/foundation/blob';
 
 import { formatGwei } from 'viem';
 
-import { GasPrice, L1TxUtils } from './l1_tx_utils.js';
+import { type GasPrice, L1TxUtils } from './l1_tx_utils.js';
 
 export class L1TxUtilsWithBlobs extends L1TxUtils {
   /**

--- a/yarn-project/ethereum/src/l1_tx_utils_with_blobs.ts
+++ b/yarn-project/ethereum/src/l1_tx_utils_with_blobs.ts
@@ -1,0 +1,86 @@
+import { Blob } from '@aztec/foundation/blob';
+
+import { formatGwei } from 'viem';
+
+import { GasPrice, L1TxUtils } from './l1_tx_utils.js';
+
+export class L1TxUtilsWithBlobs extends L1TxUtils {
+  /**
+   * Attempts to cancel a transaction by sending a 0-value tx to self with same nonce but higher gas prices
+   * @param nonce - The nonce of the transaction to cancel
+   * @param previousGasPrice - The gas price of the previous transaction
+   * @param attempts - The number of attempts to cancel the transaction
+   * @returns The hash of the cancellation transaction
+   */
+  override async attemptTxCancellation(nonce: number, isBlobTx = false, previousGasPrice?: GasPrice, attempts = 0) {
+    const account = this.walletClient.account;
+
+    // Get gas price with higher priority fee for cancellation
+    const cancelGasPrice = await this.getGasPrice(
+      {
+        ...this.config,
+        // Use high bump for cancellation to ensure it replaces the original tx
+        priorityFeeRetryBumpPercentage: 150, // 150% bump should be enough to replace any tx
+      },
+      isBlobTx,
+      attempts + 1,
+      previousGasPrice,
+    );
+
+    this.logger?.debug(`Attempting to cancel transaction with nonce ${nonce}`, {
+      maxFeePerGas: formatGwei(cancelGasPrice.maxFeePerGas),
+      maxPriorityFeePerGas: formatGwei(cancelGasPrice.maxPriorityFeePerGas),
+    });
+    const request = {
+      to: account.address,
+      value: 0n,
+    };
+
+    // Send 0-value tx to self with higher gas price
+    if (!isBlobTx) {
+      const cancelTxHash = await this.walletClient.sendTransaction({
+        ...request,
+        nonce,
+        gas: 21_000n, // Standard ETH transfer gas
+        maxFeePerGas: cancelGasPrice.maxFeePerGas,
+        maxPriorityFeePerGas: cancelGasPrice.maxPriorityFeePerGas,
+      });
+      const receipt = await this.monitorTransaction(
+        request,
+        cancelTxHash,
+        { gasLimit: 21_000n },
+        undefined,
+        undefined,
+        true,
+      );
+
+      return receipt.transactionHash;
+    } else {
+      const blobData = new Uint8Array(131072).fill(0);
+      const kzg = Blob.getViemKzgInstance();
+      const blobInputs = {
+        blobs: [blobData],
+        kzg,
+        maxFeePerBlobGas: cancelGasPrice.maxFeePerBlobGas!,
+      };
+      const cancelTxHash = await this.walletClient.sendTransaction({
+        ...request,
+        ...blobInputs,
+        nonce,
+        gas: 21_000n,
+        maxFeePerGas: cancelGasPrice.maxFeePerGas,
+        maxPriorityFeePerGas: cancelGasPrice.maxPriorityFeePerGas,
+      });
+      const receipt = await this.monitorTransaction(
+        request,
+        cancelTxHash,
+        { gasLimit: 21_000n },
+        undefined,
+        blobInputs,
+        true,
+      );
+
+      return receipt.transactionHash;
+    }
+  }
+}

--- a/yarn-project/kv-store/src/config.ts
+++ b/yarn-project/kv-store/src/config.ts
@@ -1,4 +1,4 @@
-import { l1ContractAddressesMapping } from '@aztec/ethereum';
+import { l1ContractAddressesMapping } from '@aztec/ethereum/l1-contract-addresses';
 import { type ConfigMappingsType, getConfigFromMappings, numberConfigHelper } from '@aztec/foundation/config';
 import { type EthAddress } from '@aztec/foundation/eth-address';
 

--- a/yarn-project/sequencer-client/src/publisher/l1-publisher.ts
+++ b/yarn-project/sequencer-client/src/publisher/l1-publisher.ts
@@ -23,6 +23,7 @@ import {
   type GasPrice,
   type L1ContractsConfig,
   L1TxUtils,
+  L1TxUtilsWithBlobs,
   createEthereumChain,
   formatViemError,
 } from '@aztec/ethereum';
@@ -237,7 +238,7 @@ export class L1Publisher {
       this.governanceProposerAddress = EthAddress.fromString(l1Contracts.governanceProposerAddress.toString());
     }
 
-    this.l1TxUtils = new L1TxUtils(this.publicClient, this.walletClient, this.log, config);
+    this.l1TxUtils = new L1TxUtilsWithBlobs(this.publicClient, this.walletClient, this.log, config);
   }
 
   public registerSlashPayloadGetter(callback: GetSlashPayloadCallBack) {

--- a/yarn-project/sequencer-client/src/publisher/l1-publisher.ts
+++ b/yarn-project/sequencer-client/src/publisher/l1-publisher.ts
@@ -22,7 +22,7 @@ import {
   FormattedViemError,
   type GasPrice,
   type L1ContractsConfig,
-  L1TxUtils,
+  type L1TxUtils,
   L1TxUtilsWithBlobs,
   createEthereumChain,
   formatViemError,


### PR DESCRIPTION
Don't really get why the correct version is not being installed

@ludamad pulling `aztecprotocol/build:2.0` locally reveals the playwright version is wrong, which explains all the failures. Maybe I messed up badly by not bumping the image version? Can we fix it without pushing for 3.0? I added a stopgap measure in the boxes docker-compose, but it takes way too long as it is, so would love to fix it for good.