### PR TITLE
fix: Client IVC paths in bb prover

### DIFF
--- a/yarn-project/bb-prover/src/bb/execute.ts
+++ b/yarn-project/bb-prover/src/bb/execute.ts
@@ -8,6 +8,7 @@ import { promises as fs } from 'fs';
 import { basename, dirname, join } from 'path';
 
 import { type UltraHonkFlavor } from '../honk.js';
+import { CLIENT_IVC_PROOF_FILE_NAME, CLIENT_IVC_VK_FILE_NAME } from '../prover/client_ivc_proof_utils.js';
 
 export const VK_FILENAME = 'vk';
 export const VK_FIELDS_FILENAME = 'vk_fields.json';
@@ -345,8 +346,8 @@ export async function generateTubeProof(
   }
 
   // // Paths for the inputs
-  const vkPath = join(workingDirectory, 'client_ivc_vk.bin');
-  const proofPath = join(workingDirectory, 'client_ivc_proof.bin');
+  const vkPath = join(workingDirectory, CLIENT_IVC_VK_FILE_NAME);
+  const proofPath = join(workingDirectory, CLIENT_IVC_PROOF_FILE_NAME);
 
   // The proof is written to e.g. /workingDirectory/proof
   const outputPath = workingDirectory;

--- a/yarn-project/bb-prover/src/prover/client_ivc_proof_utils.ts
+++ b/yarn-project/bb-prover/src/prover/client_ivc_proof_utils.ts
@@ -3,6 +3,9 @@ import { ClientIvcProof } from '@aztec/circuits.js';
 import { promises as fs } from 'fs';
 import { join } from 'path';
 
+export const CLIENT_IVC_VK_FILE_NAME = 'client_ivc_vk';
+export const CLIENT_IVC_PROOF_FILE_NAME = 'client_ivc_proof';
+
 /**
  * TODO(#7371): eventually remove client_ivc_prove_output_all_msgpack and properly handle these accumulators and VKs
  * Create a ClientIvcProof from the result of client_ivc_prove_output_all or client_ivc_prove_output_all_msgpack
@@ -11,7 +14,7 @@ import { join } from 'path';
  */
 export async function readFromOutputDirectory(directory: string) {
   const [clientIvcVkBuffer, clientIvcProofBuffer] = await Promise.all(
-    ['client_ivc_vk', 'client_ivc_proof'].map(fileName => fs.readFile(join(directory, fileName))),
+    [CLIENT_IVC_VK_FILE_NAME, CLIENT_IVC_PROOF_FILE_NAME].map(fileName => fs.readFile(join(directory, fileName))),
   );
   return new ClientIvcProof(clientIvcProofBuffer, clientIvcVkBuffer);
 }
@@ -32,8 +35,8 @@ export async function readFromOutputDirectory(directory: string) {
 export async function writeToOutputDirectory(clientIvcProof: ClientIvcProof, directory: string) {
   const { clientIvcProofBuffer, clientIvcVkBuffer } = clientIvcProof;
   const fileData = [
-    ['client_ivc_proof', clientIvcProofBuffer],
-    ['client_ivc_vk', clientIvcVkBuffer],
+    [CLIENT_IVC_PROOF_FILE_NAME, clientIvcProofBuffer],
+    [CLIENT_IVC_VK_FILE_NAME, clientIvcVkBuffer],
   ] as const;
   await Promise.all(fileData.map(([fileName, buffer]) => fs.writeFile(join(directory, fileName), buffer)));
 }


### PR DESCRIPTION
We were checking for the wrong paths. Since we didn't actually await for the result of `filePresent`, we always assumed the files were there, so we never threw until #11629.