### PR TITLE
chore: publish aztec/native to npm

### DIFF
--- a/yarn-project/publish_npm.sh
+++ b/yarn-project/publish_npm.sh
@@ -79,6 +79,7 @@ function deploy_package() {
 
 # New packages here should be added after the last package that they depend on
 deploy_package foundation
+deploy_package native
 deploy_package types
 deploy_package circuits.js
 deploy_package circuit-types


### PR DESCRIPTION
The new package is a dependency to both world-state and kv-store
