### PR TITLE
fix: missing wasm files in cache

### DIFF
--- a/yarn-project/bootstrap.sh
+++ b/yarn-project/bootstrap.sh
@@ -44,7 +44,7 @@ function build {
     # Then one-off cases. If you've written into src, you need to update this.
     cache_upload $tar_file */{dest,fixtures,build,artifacts,generated} \
       circuit-types/src/test/artifacts \
-      end-to-end/src/web/{main.js,main.js.LICENSE.txt} \
+      end-to-end/src/web/{main.js,main.js.LICENSE.txt,*.wasm.gz} \
       ivc-integration/src/types/ \
       noir-contracts.js/{codegenCache.json,src/} \
       noir-protocol-circuits-types/src/{private_kernel_reset_data.ts,private_kernel_reset_vks.ts,private_kernel_reset_types.ts,client_artifacts_helper.ts,types/} \


### PR DESCRIPTION
New generated stuff was written to `src`, which hit pain as the cache upload patterns need to be updated