### PR TITLE
fix(docs): added comments to quote code on the key page

### DIFF
--- a/noir-projects/noir-contracts/contracts/schnorr_account_contract/src/main.nr
+++ b/noir-projects/noir-contracts/contracts/schnorr_account_contract/src/main.nr
@@ -25,7 +25,9 @@ contract SchnorrAccount {
 
     #[storage]
     struct Storage<Context> {
+        // docs:start:public_key
         signing_public_key: PrivateImmutable<PublicKeyNote, Context>,
+        // docs:end:public_key
     }
 
     // Constructs the contract


### PR DESCRIPTION
Added comments to point to the code fragment to be quoted.
