### PR TITLE
chore: Reduce memory requests on prover node

### DIFF
--- a/spartan/aztec-network/values/exp-1.yaml
+++ b/spartan/aztec-network/values/exp-1.yaml
@@ -147,17 +147,18 @@ proverAgent:
 proverBroker:
   resources:
     requests:
-      memory: "5.5Gi"
+      memory: "5Gi"
       cpu: "1.5"
       ephemeral-storage: "275Gi"
-  maxOldSpaceSize: "5122"
+  maxOldSpaceSize: "4608"
+
 proverNode:
   resources:
     requests:
-      memory: "5.5Gi"
+      memory: "5Gi"
       cpu: "1.5"
       ephemeral-storage: "275Gi"
-  maxOldSpaceSize: "5122"
+  maxOldSpaceSize: "4608"
 
 bot:
   replicas: 10

--- a/spartan/aztec-network/values/exp-2.yaml
+++ b/spartan/aztec-network/values/exp-2.yaml
@@ -308,18 +308,18 @@ proverAgent:
 proverBroker:
   resources:
     requests:
-      memory: "5.5Gi"
+      memory: "5Gi"
       cpu: "1.5"
       ephemeral-storage: "275Gi"
-  maxOldSpaceSize: "5122"
+  maxOldSpaceSize: "4608"
 
 proverNode:
   resources:
     requests:
-      memory: "5.5Gi"
+      memory: "5Gi"
       cpu: "1.5"
       ephemeral-storage: "275Gi"
-  maxOldSpaceSize: "5122"
+  maxOldSpaceSize: "4608"
 
 bot:
   replicas: 10


### PR DESCRIPTION
This PR slightly reduces the memory request for the prover node and prover broker. The new values may be too low, requiring an additional node pool.
