### PR TITLE
chore(sequencer): add InvalidArchive to canProposeAtNextEthBlock ignored errors

### DIFF
--- a/yarn-project/sequencer-client/src/publisher/sequencer-publisher.ts
+++ b/yarn-project/sequencer-client/src/publisher/sequencer-publisher.ts
@@ -249,7 +249,7 @@ export class SequencerPublisher {
    * @returns The slot and block number if it is possible to propose, undefined otherwise
    */
   public canProposeAtNextEthBlock(tipArchive: Buffer) {
-    const ignoredErrors = ['SlotAlreadyInChain', 'InvalidProposer'];
+    const ignoredErrors = ['SlotAlreadyInChain', 'InvalidProposer', 'InvalidArchive'];
     return this.rollupContract
       .canProposeAtNextEthBlock(tipArchive, this.getForwarderAddress().toString(), this.ethereumSlotDuration)
       .catch(err => {


### PR DESCRIPTION
We see alot of this as the sequencer attempts to check if it can propose before it has successfully synced