### PR TITLE
chore: turn on masking in ultra and mega zk + oink clean-up

### DIFF
--- a/barretenberg/cpp/src/barretenberg/commitment_schemes/commitment_key.hpp
+++ b/barretenberg/cpp/src/barretenberg/commitment_schemes/commitment_key.hpp
@@ -337,6 +337,26 @@ template <class Curve> class CommitmentKey {
 
         return result;
     }
+
+    enum class CommitType { Default, Structured, Sparse, StructuredNonZeroComplement };
+
+    Commitment commit_with_type(PolynomialSpan<const Fr> poly,
+                                CommitType type,
+                                const std::vector<std::pair<size_t, size_t>>& active_ranges = {},
+                                size_t final_active_wire_idx = 0)
+    {
+        switch (type) {
+        case CommitType::Structured:
+            return commit_structured(poly, active_ranges, final_active_wire_idx);
+        case CommitType::Sparse:
+            return commit_sparse(poly);
+        case CommitType::StructuredNonZeroComplement:
+            return commit_structured_with_nonzero_complement(poly, active_ranges, final_active_wire_idx);
+        case CommitType::Default:
+        default:
+            return commit(poly);
+        }
+    }
 };
 
 } // namespace bb

--- a/barretenberg/cpp/src/barretenberg/ultra_honk/mega_honk.test.cpp
+++ b/barretenberg/cpp/src/barretenberg/ultra_honk/mega_honk.test.cpp
@@ -114,7 +114,8 @@ TYPED_TEST(MegaHonkTests, BasicStructured)
 {
     using Flavor = TypeParam;
 
-    // MegaZKFlavor is only used to prove the Hiding Circuit.
+    // In MegaZKFlavor, we mask witness polynomials by placing random values at the indices `dyadic_circuit_size`-i for
+    // i=1,2,3. This mechanism does not work with structured polynomials yet.
     if constexpr (std::is_same_v<Flavor, MegaZKFlavor>) {
         GTEST_SKIP() << "Skipping 'BasicStructured' test for MegaZKFlavor.";
     }
@@ -149,7 +150,8 @@ TYPED_TEST(MegaHonkTests, DynamicVirtualSizeIncrease)
 {
     using Flavor = TypeParam;
 
-    // MegaZKFlavor is only used to prove the Hiding Circuit.
+    // In MegaZKFlavor, we mask witness polynomials by placing random values at the indices `dyadic_circuit_size`-i for
+    // i=1,2,3. This mechanism does not work with structured polynomials yet.
     if constexpr (std::is_same_v<Flavor, MegaZKFlavor>) {
         GTEST_SKIP() << "Skipping 'DynamicVirtualSizeIncrease' test for MegaZKFlavor.";
     }
@@ -392,8 +394,8 @@ TYPED_TEST(MegaHonkTests, StructuredTraceOverflow)
 TYPED_TEST(MegaHonkTests, PolySwap)
 {
     using Flavor = TypeParam;
-
-    // MegaZKFlavor is only used to prove the Hiding Circuit.
+    // In MegaZKFlavor, we mask witness polynomials by placing random values at the indices `dyadic_circuit_size`-i, for
+    // i=1,2,3. This mechanism does not work with structured polynomials yet.
     if constexpr (std::is_same_v<Flavor, MegaZKFlavor>) {
         GTEST_SKIP() << "Skipping 'PolySwap' test for MegaZKFlavor.";
     }

--- a/barretenberg/cpp/src/barretenberg/ultra_honk/mega_honk.test.cpp
+++ b/barretenberg/cpp/src/barretenberg/ultra_honk/mega_honk.test.cpp
@@ -113,6 +113,11 @@ TYPED_TEST(MegaHonkTests, Basic)
 TYPED_TEST(MegaHonkTests, BasicStructured)
 {
     using Flavor = TypeParam;
+
+    // MegaZKFlavor is only used to prove the Hiding Circuit.
+    if constexpr (std::is_same_v<Flavor, MegaZKFlavor>) {
+        GTEST_SKIP() << "Skipping 'BasicStructured' test for MegaZKFlavor.";
+    }
     typename Flavor::CircuitBuilder builder;
     using Prover = UltraProver_<Flavor>;
     using Verifier = UltraVerifier_<Flavor>;
@@ -143,6 +148,11 @@ TYPED_TEST(MegaHonkTests, BasicStructured)
 TYPED_TEST(MegaHonkTests, DynamicVirtualSizeIncrease)
 {
     using Flavor = TypeParam;
+
+    // MegaZKFlavor is only used to prove the Hiding Circuit.
+    if constexpr (std::is_same_v<Flavor, MegaZKFlavor>) {
+        GTEST_SKIP() << "Skipping 'DynamicVirtualSizeIncrease' test for MegaZKFlavor.";
+    }
     typename Flavor::CircuitBuilder builder;
     using Prover = UltraProver_<Flavor>;
     using Verifier = UltraVerifier_<Flavor>;
@@ -382,6 +392,11 @@ TYPED_TEST(MegaHonkTests, StructuredTraceOverflow)
 TYPED_TEST(MegaHonkTests, PolySwap)
 {
     using Flavor = TypeParam;
+
+    // MegaZKFlavor is only used to prove the Hiding Circuit.
+    if constexpr (std::is_same_v<Flavor, MegaZKFlavor>) {
+        GTEST_SKIP() << "Skipping 'PolySwap' test for MegaZKFlavor.";
+    }
     using Builder = Flavor::CircuitBuilder;
 
     TraceSettings trace_settings{ SMALL_TEST_STRUCTURE_FOR_OVERFLOWS };

--- a/barretenberg/cpp/src/barretenberg/ultra_honk/oink_prover.cpp
+++ b/barretenberg/cpp/src/barretenberg/ultra_honk/oink_prover.cpp
@@ -109,7 +109,9 @@ template <IsUltraFlavor Flavor> void OinkProver<Flavor>::execute_wire_commitment
 
     if constexpr (IsMegaFlavor<Flavor>) {
 
-        // Commit to Goblin ECC op wires. Currently, they are not masked in MegaZKFlavor
+        // Commit to Goblin ECC op wires.
+        // To avoid possible issues with the current work on the merge protocol, they are not
+        // masked in MegaZKFlavor
         for (auto [polynomial, label] :
              zip_view(proving_key->proving_key.polynomials.get_ecc_op_wires(), commitment_labels.get_ecc_op_wires())) {
             {

--- a/barretenberg/cpp/src/barretenberg/ultra_honk/oink_prover.hpp
+++ b/barretenberg/cpp/src/barretenberg/ultra_honk/oink_prover.hpp
@@ -43,7 +43,6 @@ template <IsUltraFlavor Flavor> class OinkProver {
     std::string domain_separator;
     ExecutionTraceUsageTracker trace_usage_tracker;
 
-    typename Flavor::WitnessCommitments witness_commitments;
     typename Flavor::CommitmentLabels commitment_labels;
     using RelationSeparator = typename Flavor::RelationSeparator;
 

--- a/barretenberg/cpp/src/barretenberg/ultra_honk/oink_prover.hpp
+++ b/barretenberg/cpp/src/barretenberg/ultra_honk/oink_prover.hpp
@@ -64,6 +64,41 @@ template <IsUltraFlavor Flavor> class OinkProver {
     void execute_log_derivative_inverse_round();
     void execute_grand_product_computation_round();
     RelationSeparator generate_alphas_round();
+
+  private:
+    static void mask_witness_polynomial(Polynomial<FF>& polynomial)
+    {
+        const size_t circuit_size = polynomial.virtual_size();
+        if constexpr (Flavor::HasZK) {
+            for (size_t idx = 1; idx < MASKING_OFFSET; idx++) {
+                polynomial.at(circuit_size - idx) = FF::random_element();
+            }
+        }
+    }
+
+    /**
+     * @brief A uniform method to mask, commit, and send the corresponding commitment to the verifier.
+     *
+     * @param polynomial
+     * @param label
+     * @param type
+     */
+    void commit_to_witness_polynomial(Polynomial<FF>& polynomial,
+                                      const std::string& label,
+                                      CommitmentKey::CommitType type = CommitmentKey::CommitType::Default)
+    {
+        // Mask if needed
+        if constexpr (Flavor::HasZK) {
+            mask_witness_polynomial(polynomial);
+        };
+
+        typename Flavor::Commitment commitment;
+
+        commitment = proving_key->proving_key.commitment_key->commit_with_type(
+            polynomial, type, proving_key->proving_key.active_region_data.get_ranges());
+        // Send the commitment to the verifier
+        transcript->send_to_verifier(domain_separator + label, commitment);
+    }
 };
 
 using MegaOinkProver = OinkProver<MegaFlavor>;

--- a/barretenberg/cpp/src/barretenberg/ultra_honk/oink_prover.hpp
+++ b/barretenberg/cpp/src/barretenberg/ultra_honk/oink_prover.hpp
@@ -64,41 +64,10 @@ template <IsUltraFlavor Flavor> class OinkProver {
     void execute_log_derivative_inverse_round();
     void execute_grand_product_computation_round();
     RelationSeparator generate_alphas_round();
-
-  private:
-    static void mask_witness_polynomial(Polynomial<FF>& polynomial)
-    {
-        const size_t circuit_size = polynomial.virtual_size();
-        if constexpr (Flavor::HasZK) {
-            for (size_t idx = 1; idx < MASKING_OFFSET; idx++) {
-                polynomial.at(circuit_size - idx) = FF::random_element();
-            }
-        }
-    }
-
-    /**
-     * @brief A uniform method to mask, commit, and send the corresponding commitment to the verifier.
-     *
-     * @param polynomial
-     * @param label
-     * @param type
-     */
+    void mask_witness_polynomial(Polynomial<FF>& polynomial);
     void commit_to_witness_polynomial(Polynomial<FF>& polynomial,
                                       const std::string& label,
-                                      CommitmentKey::CommitType type = CommitmentKey::CommitType::Default)
-    {
-        // Mask if needed
-        if constexpr (Flavor::HasZK) {
-            mask_witness_polynomial(polynomial);
-        };
-
-        typename Flavor::Commitment commitment;
-
-        commitment = proving_key->proving_key.commitment_key->commit_with_type(
-            polynomial, type, proving_key->proving_key.active_region_data.get_ranges());
-        // Send the commitment to the verifier
-        transcript->send_to_verifier(domain_separator + label, commitment);
-    }
+                                      const CommitmentKey::CommitType type = CommitmentKey::CommitType::Default);
 };
 
 using MegaOinkProver = OinkProver<MegaFlavor>;


### PR DESCRIPTION
We have a mechanism to mask witness commitments and evaluations in ZK Flavors, in this PR the masking is enabled. 

It is also a precursor to short scalars in UH ZK Recursive verifier, as it eliminates the edge cases from `bn254_endo_batch_mul`. 

Cleaned up oink prover using a newly introduced `commit_with_type` method