### PR TITLE
chore: remove some templates in templates

### DIFF
--- a/barretenberg/cpp/src/barretenberg/plonk/proof_system/verification_key/sol_gen.hpp
+++ b/barretenberg/cpp/src/barretenberg/plonk/proof_system/verification_key/sol_gen.hpp
@@ -145,10 +145,6 @@ inline void output_vk_sol(std::ostream& os, std::shared_ptr<plonk::verification_
 {
     CircuitType circuit_type = static_cast<CircuitType>(key->circuit_type);
     switch (circuit_type) {
-    case CircuitType::STANDARD: {
-        return output_vk_sol_standard(os, key, class_name);
-        break;
-    }
     case CircuitType::ULTRA: {
         return output_vk_sol_ultra(os, key, class_name);
         break;

--- a/barretenberg/cpp/src/barretenberg/solidity_helpers/circuits/add_2_circuit.hpp
+++ b/barretenberg/cpp/src/barretenberg/solidity_helpers/circuits/add_2_circuit.hpp
@@ -2,8 +2,9 @@
 #include "barretenberg/stdlib/primitives/field/field.hpp"
 #include "barretenberg/stdlib/primitives/witness/witness.hpp"
 
-template <typename Builder> class Add2Circuit {
+class Add2Circuit {
   public:
+    using Builder = bb::UltraCircuitBuilder;
     using public_witness_ct = bb::stdlib::public_witness_t<Builder>;
     using field_ct = bb::stdlib::field_t<Builder>;
 

--- a/barretenberg/cpp/src/barretenberg/solidity_helpers/circuits/blake_circuit.hpp
+++ b/barretenberg/cpp/src/barretenberg/solidity_helpers/circuits/blake_circuit.hpp
@@ -3,8 +3,9 @@
 #include "barretenberg/stdlib/primitives/field/field.hpp"
 #include "barretenberg/stdlib/primitives/witness/witness.hpp"
 
-template <typename Builder> class BlakeCircuit {
+class BlakeCircuit {
   public:
+    using Builder = bb::UltraCircuitBuilder;
     using field_ct = bb::stdlib::field_t<Builder>;
     using public_witness_ct = bb::stdlib::public_witness_t<Builder>;
     using byte_array_ct = bb::stdlib::byte_array<Builder>;

--- a/barretenberg/cpp/src/barretenberg/solidity_helpers/circuits/ecdsa_circuit.hpp
+++ b/barretenberg/cpp/src/barretenberg/solidity_helpers/circuits/ecdsa_circuit.hpp
@@ -13,9 +13,9 @@
 #include "barretenberg/stdlib/primitives/witness/witness.hpp"
 
 namespace bb {
-
-template <typename Builder> class EcdsaCircuit {
+class EcdsaCircuit {
   public:
+    using Builder = bb::UltraCircuitBuilder;
     using field_ct = stdlib::field_t<Builder>;
     using bool_ct = stdlib::bool_t<Builder>;
     using public_witness_ct = stdlib::public_witness_t<Builder>;

--- a/barretenberg/cpp/src/barretenberg/solidity_helpers/circuits/recursive_circuit.hpp
+++ b/barretenberg/cpp/src/barretenberg/solidity_helpers/circuits/recursive_circuit.hpp
@@ -16,11 +16,10 @@ using numeric::uint256_t;
 
 class RecursiveCircuit {
     using InnerComposer = UltraComposer;
-    using InnerBuilder = UltraCircuitBuilder;
-    using OuterBuilder = UltraCircuitBuilder;
+    using Builder = UltraCircuitBuilder;
 
-    using inner_curve = bn254<InnerBuilder>;
-    using outer_curve = bn254<OuterBuilder>;
+    using inner_curve = bn254<Builder>;
+    using outer_curve = bn254<Builder>;
 
     using verification_key_pt = recursion::verification_key<outer_curve>;
     using recursive_settings = recursion::recursive_ultra_verifier_settings<outer_curve>;
@@ -35,7 +34,7 @@ class RecursiveCircuit {
     using inner_scalar_field = typename inner_curve::ScalarFieldNative;
     using outer_scalar_field = typename outer_curve::BaseFieldNative;
     using pairing_target_field = bb::fq12;
-    static constexpr bool is_ultra_to_ultra = std::is_same_v<OuterBuilder, bb::UltraCircuitBuilder>;
+    static constexpr bool is_ultra_to_ultra = std::is_same_v<Builder, bb::UltraCircuitBuilder>;
     using ProverOfInnerCircuit =
         std::conditional_t<is_ultra_to_ultra, plonk::UltraProver, plonk::UltraToStandardProver>;
     using VerifierOfInnerProof =
@@ -48,7 +47,7 @@ class RecursiveCircuit {
         std::shared_ptr<verification_key_pt> verification_key;
     };
 
-    static void create_inner_circuit_no_tables(InnerBuilder& builder, uint256_t public_inputs[])
+    static void create_inner_circuit_no_tables(Builder& builder, uint256_t public_inputs[])
     {
         // A nice Pythagorean triples circuit example: "I know a & b s.t. a^2 + b^2 = c^2".
         inner_scalar_field_ct a(witness_ct(&builder, public_inputs[0]));
@@ -62,7 +61,7 @@ class RecursiveCircuit {
         c_sq.set_public();
     };
 
-    static circuit_outputs create_outer_circuit(InnerBuilder& inner_circuit, OuterBuilder& outer_builder)
+    static circuit_outputs create_outer_circuit(Builder& inner_circuit, Builder& outer_builder)
     {
         ProverOfInnerCircuit prover;
         InnerComposer inner_composer;
@@ -95,7 +94,7 @@ class RecursiveCircuit {
         return { output, verification_key };
     };
 
-    static bool check_pairing_point_accum_public_inputs(OuterBuilder& builder, const bb::pairing::miller_lines* lines)
+    static bool check_pairing_point_accum_public_inputs(Builder& builder, const bb::pairing::miller_lines* lines)
     {
         if (builder.contains_pairing_point_accumulator &&
             builder.pairing_point_accumulator_public_input_indices.size() == 16) {
@@ -159,10 +158,10 @@ class RecursiveCircuit {
     }
 
   public:
-    static OuterBuilder generate(uint256_t inputs[])
+    static Builder generate(uint256_t inputs[])
     {
-        InnerBuilder inner_circuit;
-        OuterBuilder outer_circuit;
+        Builder inner_circuit;
+        Builder outer_circuit;
 
         create_inner_circuit_no_tables(inner_circuit, inputs);
 

--- a/barretenberg/cpp/src/barretenberg/solidity_helpers/circuits/recursive_circuit.hpp
+++ b/barretenberg/cpp/src/barretenberg/solidity_helpers/circuits/recursive_circuit.hpp
@@ -34,13 +34,8 @@ class RecursiveCircuit {
     using inner_scalar_field = typename inner_curve::ScalarFieldNative;
     using outer_scalar_field = typename outer_curve::BaseFieldNative;
     using pairing_target_field = bb::fq12;
-    static constexpr bool is_ultra_to_ultra = std::is_same_v<Builder, bb::UltraCircuitBuilder>;
-    using ProverOfInnerCircuit =
-        std::conditional_t<is_ultra_to_ultra, plonk::UltraProver, plonk::UltraToStandardProver>;
-    using VerifierOfInnerProof =
-        std::conditional_t<is_ultra_to_ultra, plonk::UltraVerifier, plonk::UltraToStandardVerifier>;
-    using RecursiveSettings =
-        std::conditional_t<is_ultra_to_ultra, recursive_settings, ultra_to_standard_recursive_settings>;
+    using ProverOfInnerCircuit = plonk::UltraProver;
+    using VerifierOfInnerProof = plonk::UltraVerifier;
 
     struct circuit_outputs {
         stdlib::recursion::aggregation_state<outer_curve> aggregation_state;
@@ -88,7 +83,7 @@ class RecursiveCircuit {
 
         transcript::Manifest recursive_manifest = InnerComposer::create_manifest(prover.key->num_public_inputs);
 
-        auto output = recursion::verify_proof<outer_curve, RecursiveSettings>(
+        auto output = recursion::verify_proof<outer_curve, recursive_settings>(
             &outer_builder, verification_key, recursive_manifest, proof_to_recursively_verify);
 
         return { output, verification_key };

--- a/barretenberg/cpp/src/barretenberg/solidity_helpers/honk_key_gen.cpp
+++ b/barretenberg/cpp/src/barretenberg/solidity_helpers/honk_key_gen.cpp
@@ -16,11 +16,10 @@ using namespace bb;
 using DeciderProvingKey = DeciderProvingKey_<UltraKeccakFlavor>;
 using VerificationKey = UltraKeccakFlavor::VerificationKey;
 
-template <template <typename> typename Circuit>
-void generate_keys_honk(const std::string& output_path, std::string circuit_name)
+template <typename Circuit> void generate_keys_honk(const std::string& output_path, std::string circuit_name)
 {
     uint256_t public_inputs[4] = { 0, 0, 0, 0 };
-    UltraCircuitBuilder builder = Circuit<UltraCircuitBuilder>::generate(public_inputs);
+    UltraCircuitBuilder builder = Circuit::generate(public_inputs);
 
     auto proving_key = std::make_shared<DeciderProvingKey>(builder);
     UltraKeccakProver prover(proving_key);

--- a/barretenberg/cpp/src/barretenberg/solidity_helpers/honk_proof_gen.cpp
+++ b/barretenberg/cpp/src/barretenberg/solidity_helpers/honk_proof_gen.cpp
@@ -16,14 +16,14 @@ using namespace bb;
 using numeric::uint256_t;
 
 // Get rid of the inner typename
-template <template <typename> typename Circuit, typename Flavor> void generate_proof(uint256_t inputs[])
+template <typename Circuit, typename Flavor> void generate_proof(uint256_t inputs[])
 {
     using DeciderProvingKey = DeciderProvingKey_<Flavor>;
     using VerificationKey = typename Flavor::VerificationKey;
     using Prover = UltraProver_<Flavor>;
     using Verifier = UltraVerifier_<Flavor>;
 
-    UltraCircuitBuilder builder = Circuit<UltraCircuitBuilder>::generate(inputs);
+    UltraCircuitBuilder builder = Circuit::generate(inputs);
 
     auto instance = std::make_shared<DeciderProvingKey>(builder);
     Prover prover(instance);

--- a/barretenberg/cpp/src/barretenberg/solidity_helpers/key_gen.cpp
+++ b/barretenberg/cpp/src/barretenberg/solidity_helpers/key_gen.cpp
@@ -12,18 +12,17 @@
 #include "utils/instance_sol_gen.hpp"
 #include "utils/utils.hpp"
 
-template <typename Composer, template <typename> typename Circuit>
-void generate_keys(std::string output_path, std::string flavor_prefix, std::string circuit_name)
+template <typename Circuit> void generate_keys(std::string output_path, std::string circuit_name)
 {
     uint256_t public_inputs[4] = { 0, 0, 0, 0 };
-    auto circuit = Circuit<typename Composer::CircuitBuilder>::generate(public_inputs);
+    auto circuit = Circuit::generate(public_inputs);
 
-    Composer composer;
+    UltraComposer composer;
     std::shared_ptr<plonk::verification_key> vkey = composer.compute_verification_key(circuit);
 
     // Make verification key file upper case
     circuit_name.at(0) = static_cast<char>(std::toupper(static_cast<unsigned char>(circuit_name.at(0))));
-    flavor_prefix.at(0) = static_cast<char>(std::toupper(static_cast<unsigned char>(flavor_prefix.at(0))));
+    std::string flavor_prefix = "UltraPlonk";
 
     std::string vk_class_name = circuit_name + flavor_prefix + "VerificationKey";
     std::string base_class_name = "Base" + flavor_prefix + "Verifier";
@@ -54,34 +53,28 @@ int main(int argc, char** argv)
 {
     std::vector<std::string> args(argv, argv + argc);
 
-    if (args.size() < 5) {
-        info("usage: ", args[0], "[plonk flavor] [circuit flavor] [output path] [srs path]");
+    if (args.size() < 4) {
+        info("usage: ", args[0], "[circuit type] [output path] [srs path]");
         return 1;
     }
 
-    const std::string plonk_flavor = args[1];
-    const std::string circuit_flavor = args[2];
-    const std::string output_path = args[3];
-    const std::string srs_path = args[4];
+    const std::string circuit_flavor = args[1];
+    const std::string output_path = args[2];
+    const std::string srs_path = args[3];
 
     bb::srs::init_crs_factory(srs_path);
     // @todo - Add support for unrolled standard verifier. Needs a new solidity verifier contract.
 
-    if (plonk_flavor != "ultra") {
-        info("Flavor must be ultra");
-        return 1;
-    }
-
-    info("Generating ", plonk_flavor, " keys for ", circuit_flavor, " circuit");
+    info("Generating  keys for ", circuit_flavor, " circuit");
 
     if (circuit_flavor == "blake") {
-        generate_keys<bb::plonk::UltraComposer, BlakeCircuit>(output_path, plonk_flavor, circuit_flavor);
+        generate_keys<BlakeCircuit>(output_path, circuit_flavor);
     } else if (circuit_flavor == "add2") {
-        generate_keys<bb::plonk::UltraComposer, Add2Circuit>(output_path, plonk_flavor, circuit_flavor);
+        generate_keys<Add2Circuit>(output_path, circuit_flavor);
     } else if (circuit_flavor == "recursive") {
-        generate_keys<bb::plonk::UltraComposer, RecursiveCircuit>(output_path, plonk_flavor, circuit_flavor);
+        generate_keys<RecursiveCircuit>(output_path, circuit_flavor);
     } else if (circuit_flavor == "ecdsa") {
-        generate_keys<bb::plonk::UltraComposer, EcdsaCircuit>(output_path, plonk_flavor, circuit_flavor);
+        generate_keys<EcdsaCircuit>(output_path, circuit_flavor);
     } else {
         info("Unsupported circuit");
         return 1;

--- a/barretenberg/cpp/src/barretenberg/solidity_helpers/key_gen.cpp
+++ b/barretenberg/cpp/src/barretenberg/solidity_helpers/key_gen.cpp
@@ -22,7 +22,7 @@ template <typename Circuit> void generate_keys(std::string output_path, std::str
 
     // Make verification key file upper case
     circuit_name.at(0) = static_cast<char>(std::toupper(static_cast<unsigned char>(circuit_name.at(0))));
-    std::string flavor_prefix = "UltraPlonk";
+    std::string flavor_prefix = "Ultra";
 
     std::string vk_class_name = circuit_name + flavor_prefix + "VerificationKey";
     std::string base_class_name = "Base" + flavor_prefix + "Verifier";

--- a/barretenberg/cpp/src/barretenberg/solidity_helpers/proof_gen.cpp
+++ b/barretenberg/cpp/src/barretenberg/solidity_helpers/proof_gen.cpp
@@ -14,11 +14,11 @@
 using namespace bb::numeric;
 using numeric::uint256_t;
 
-template <typename Composer, template <typename> typename Circuit> void generate_proof(uint256_t inputs[])
+template <typename Circuit> void generate_proof(uint256_t inputs[])
 {
-    auto builder = Circuit<typename Composer::CircuitBuilder>::generate(inputs);
+    UltraCircuitBuilder builder = Circuit::generate(inputs);
 
-    Composer composer;
+    UltraComposer composer;
     // @todo this only works for ultra! Why is ultra part of function name on ultra composer?
     auto prover = composer.create_ultra_with_keccak_prover(builder);
     auto proof = prover.construct_proof();
@@ -58,9 +58,9 @@ int main(int argc, char** argv)
     }
 
     const std::string plonk_flavor = args[1];
-    const std::string circuit_flavor = args[2];
-    const std::string srs_path = args[3];
-    const std::string string_input = args[4];
+    const std::string circuit_flavor = args[1];
+    const std::string srs_path = args[2];
+    const std::string string_input = args[3];
 
     bb::srs::init_crs_factory(srs_path);
 
@@ -85,13 +85,13 @@ int main(int argc, char** argv)
     }
 
     if (circuit_flavor == "blake") {
-        generate_proof<UltraComposer, BlakeCircuit>(inputs);
+        generate_proof<BlakeCircuit>(inputs);
     } else if (circuit_flavor == "add2") {
-        generate_proof<UltraComposer, Add2Circuit>(inputs);
+        generate_proof<Add2Circuit>(inputs);
     } else if (circuit_flavor == "ecdsa") {
-        generate_proof<UltraComposer, EcdsaCircuit>(inputs);
+        generate_proof<EcdsaCircuit>(inputs);
     } else if (circuit_flavor == "recursive") {
-        generate_proof<UltraComposer, RecursiveCircuit>(inputs);
+        generate_proof<RecursiveCircuit>(inputs);
     } else {
         info("Invalid circuit flavor: " + circuit_flavor);
         return 1;

--- a/barretenberg/sol/scripts/init.sh
+++ b/barretenberg/sol/scripts/init.sh
@@ -1,11 +1,9 @@
 #!/usr/bin/env bash
 
-
-PLONK_FLAVOUR="ultra"
 SRS_PATH="../cpp/srs_db/ignition"
 OUTPUT_PATH="./src/ultra"
 
-../cpp/build/bin/solidity_key_gen $PLONK_FLAVOUR add2 $OUTPUT_PATH $SRS_PATH
-../cpp/build/bin/solidity_key_gen $PLONK_FLAVOUR blake $OUTPUT_PATH $SRS_PATH
-../cpp/build/bin/solidity_key_gen $PLONK_FLAVOUR ecdsa $OUTPUT_PATH $SRS_PATH
-../cpp/build/bin/solidity_key_gen $PLONK_FLAVOUR recursive $OUTPUT_PATH $SRS_PATH
+../cpp/build/bin/solidity_key_gen add2 $OUTPUT_PATH $SRS_PATH
+../cpp/build/bin/solidity_key_gen blake $OUTPUT_PATH $SRS_PATH
+../cpp/build/bin/solidity_key_gen ecdsa $OUTPUT_PATH $SRS_PATH
+../cpp/build/bin/solidity_key_gen recursive $OUTPUT_PATH $SRS_PATH

--- a/barretenberg/sol/src/ultra/keys/Add2UltraVerificationKey.sol
+++ b/barretenberg/sol/src/ultra/keys/Add2UltraVerificationKey.sol
@@ -1,11 +1,11 @@
-// Verification Key Hash: 35075d72ebcadda27f270f249615b163ee9b368feb3e481a43da7d265d3882aa
+// Verification Key Hash: 594d0af354947ea7aa13eece55ec3ccdce54dff437d9354a8a50cb2a0438a86a
 // SPDX-License-Identifier: Apache-2.0
 // Copyright 2022 Aztec
 pragma solidity >=0.8.4;
 
 library Add2UltraVerificationKey {
     function verificationKeyHash() internal pure returns (bytes32) {
-        return 0x35075d72ebcadda27f270f249615b163ee9b368feb3e481a43da7d265d3882aa;
+        return 0x594d0af354947ea7aa13eece55ec3ccdce54dff437d9354a8a50cb2a0438a86a;
     }
 
     function loadVerificationKey(uint256 _vk, uint256 _omegaInverseLoc) internal pure {

--- a/barretenberg/sol/src/ultra/keys/BlakeUltraVerificationKey.sol
+++ b/barretenberg/sol/src/ultra/keys/BlakeUltraVerificationKey.sol
@@ -1,11 +1,11 @@
-// Verification Key Hash: a1a6bc0ef32c16cad98318142e333ba99cf5d47bd499dd54341842a761cee8e1
+// Verification Key Hash: 6c68aa62aa452a4dbb84e1246b10262e6fb6ff860b59d906db6fb0807d11b872
 // SPDX-License-Identifier: Apache-2.0
 // Copyright 2022 Aztec
 pragma solidity >=0.8.4;
 
 library BlakeUltraVerificationKey {
     function verificationKeyHash() internal pure returns (bytes32) {
-        return 0xa1a6bc0ef32c16cad98318142e333ba99cf5d47bd499dd54341842a761cee8e1;
+        return 0x6c68aa62aa452a4dbb84e1246b10262e6fb6ff860b59d906db6fb0807d11b872;
     }
 
     function loadVerificationKey(uint256 _vk, uint256 _omegaInverseLoc) internal pure {

--- a/barretenberg/sol/src/ultra/keys/EcdsaUltraVerificationKey.sol
+++ b/barretenberg/sol/src/ultra/keys/EcdsaUltraVerificationKey.sol
@@ -1,11 +1,11 @@
-// Verification Key Hash: c24940ebcac32ad1f759cedc6005b1ff4de4eb135c3db1d2cebb6f20ab2bd19f
+// Verification Key Hash: 7d146c779845c11f731974db664e09fa3d3f98c34d1a982e72f0e76a747b59fc
 // SPDX-License-Identifier: Apache-2.0
 // Copyright 2022 Aztec
 pragma solidity >=0.8.4;
 
 library EcdsaUltraVerificationKey {
     function verificationKeyHash() internal pure returns (bytes32) {
-        return 0xc24940ebcac32ad1f759cedc6005b1ff4de4eb135c3db1d2cebb6f20ab2bd19f;
+        return 0x7d146c779845c11f731974db664e09fa3d3f98c34d1a982e72f0e76a747b59fc;
     }
 
     function loadVerificationKey(uint256 _vk, uint256 _omegaInverseLoc) internal pure {


### PR DESCRIPTION
Clean up some functionality for generating solidity test circuits as we don't have any utility of creating `StandardCircuits`