### PR TITLE
chore: remove type annotations from most lambda parameters

### DIFF
--- a/noir-projects/aztec-nr/aztec/src/context/private_context.nr
+++ b/noir-projects/aztec-nr/aztec/src/context/private_context.nr
@@ -143,7 +143,7 @@ impl PrivateContext {
         // WARNING(https://github.com/AztecProtocol/aztec-packages/issues/10558): if you delete this debug_log_format line, some tests fail.
         debug_log_format(
             "Context.note_hashes, after pushing new note hash: {0}",
-            self.note_hashes.storage().map(|nh: NoteHash| nh.value),
+            self.note_hashes.storage().map(|nh| nh.value),
         );
     }
 

--- a/noir-projects/aztec-nr/aztec/src/encrypted_logs/log_assembly_strategies/default_aes128/note.nr
+++ b/noir-projects/aztec-nr/aztec/src/encrypted_logs/log_assembly_strategies/default_aes128/note.nr
@@ -208,8 +208,7 @@ where
     let note_header = note.get_header();
     let note_hash_counter = note_header.note_hash_counter;
     // TODO(#8589): use typesystem to skip this check when not needed
-    let note_exists =
-        context.note_hashes.storage().any(|n: NoteHash| n.counter == note_hash_counter);
+    let note_exists = context.note_hashes.storage().any(|n| n.counter == note_hash_counter);
     assert(note_exists, "Can only emit a note log for an existing note.");
 }
 

--- a/noir-projects/aztec-nr/aztec/src/macros/dispatch/mod.nr
+++ b/noir-projects/aztec-nr/aztec/src/macros/dispatch/mod.nr
@@ -4,12 +4,11 @@ use std::panic;
 /// Returns an `fn public_dispatch(...)` function for the given module that's assumed to be an Aztec contract.
 pub comptime fn generate_public_dispatch(m: Module) -> Quoted {
     let functions = m.functions();
-    let functions =
-        functions.filter(|function: FunctionDefinition| function.has_named_attribute("public"));
+    let functions = functions.filter(|function| function.has_named_attribute("public"));
 
     let unit = get_type::<()>();
 
-    let ifs = functions.map(|function: FunctionDefinition| {
+    let ifs = functions.map(|function| {
         let name = function.name();
         let parameters = function.parameters();
         let return_type = function.return_type();
@@ -37,7 +36,7 @@ pub comptime fn generate_public_dispatch(m: Module) -> Quoted {
         };
 
         let mut parameter_index = 0;
-        let reads = parameters.map(|param: (Quoted, Type)| {
+        let reads = parameters.map(|param| {
             let param_name = f"arg{parameter_index}".quoted_contents();
             let param_type = param.1;
             let read = quote {
@@ -118,9 +117,8 @@ comptime fn size_in_fields(typ: Type) -> u32 {
 }
 
 comptime fn array_size_in_fields(typ: Type) -> Option<u32> {
-    typ.as_array().and_then(|typ: (Type, Type)| {
-        let (typ, element_size) = typ;
-        element_size.as_constant().map(|x: u32| x * size_in_fields(typ))
+    typ.as_array().and_then(|(typ, element_size)| {
+        element_size.as_constant().map(|x| x * size_in_fields(typ))
     })
 }
 
@@ -157,9 +155,7 @@ comptime fn str_size_in_fields(typ: Type) -> Option<u32> {
 }
 
 comptime fn struct_size_in_fields(typ: Type) -> Option<u32> {
-    typ.as_struct().map(|typ: (StructDefinition, [Type])| {
-        let struct_type = typ.0;
-        let generics = typ.1;
+    typ.as_struct().map(|(struct_type, generics)| {
         let mut size = 0;
         for field in struct_type.fields(generics) {
             size += size_in_fields(field.1);
@@ -169,7 +165,7 @@ comptime fn struct_size_in_fields(typ: Type) -> Option<u32> {
 }
 
 comptime fn tuple_size_in_fields(typ: Type) -> Option<u32> {
-    typ.as_tuple().map(|types: [Type]| {
+    typ.as_tuple().map(|types| {
         let mut size = 0;
         for typ in types {
             size += size_in_fields(typ);

--- a/noir-projects/aztec-nr/aztec/src/macros/functions/interfaces.nr
+++ b/noir-projects/aztec-nr/aztec/src/macros/functions/interfaces.nr
@@ -14,7 +14,7 @@ pub comptime mut global STUBS: UHashMap<Module, [Quoted], BuildHasherDefault<Pos
 pub(crate) comptime fn create_fn_abi_export(f: FunctionDefinition) -> Quoted {
     let name = f.name();
     let mut parameters =
-        f.parameters().map(|(name, typ): (Quoted, Type)| quote { pub $name: $typ }).join(quote {,});
+        f.parameters().map(|(name, typ)| quote { pub $name: $typ }).join(quote {,});
 
     let parameters_struct_name = f"{name}_parameters".quoted_contents();
     let parameters = quote {
@@ -71,7 +71,7 @@ pub comptime fn stub_fn(f: FunctionDefinition) -> Quoted {
         quote {
             let mut $args_acc_name = &[];
         },
-        |args_hasher, param: (Quoted, Type)| {
+        |args_hasher, param| {
             let (name, typ) = param;
             let appended_arg = add_to_field_slice(args_acc_name, name, typ);
             quote {
@@ -96,8 +96,7 @@ pub comptime fn stub_fn(f: FunctionDefinition) -> Quoted {
         args_acc
     };
 
-    let fn_parameters_list =
-        fn_parameters.map(|(name, typ): (Quoted, Type)| quote { $name: $typ }).join(quote {,});
+    let fn_parameters_list = fn_parameters.map(|(name, typ)| quote { $name: $typ }).join(quote {,});
 
     let (fn_name_str, _) = fn_name.as_str_quote();
 

--- a/noir-projects/aztec-nr/aztec/src/macros/functions/mod.nr
+++ b/noir-projects/aztec-nr/aztec/src/macros/functions/mod.nr
@@ -111,7 +111,7 @@ pub comptime fn private(f: FunctionDefinition) -> Quoted {
         quote {
             let mut $args_hasher_name = dep::aztec::hash::ArgsHasher::new();
         },
-        |args_hasher, param: (Quoted, Type)| {
+        |args_hasher, param| {
             let (name, typ) = param;
             let appended_arg = add_to_hasher(args_hasher_name, name, typ);
             quote {
@@ -250,10 +250,8 @@ comptime fn transform_public(f: FunctionDefinition) -> Quoted {
     // Public functions undergo a lot of transformations from their Aztec.nr form.
     let original_params = f.parameters();
     let args_len = original_params
-        .map(|(name, typ): (Quoted, Type)| {
-            generate_serialize_to_fields(name, typ, &[], false).0.len()
-        })
-        .fold(0, |acc: u32, val: u32| acc + val);
+        .map(|(name, typ)| generate_serialize_to_fields(name, typ, &[], false).0.len())
+        .fold(0, |acc, val| acc + val);
 
     // Unlike in the private case, in public the `context` does not need to receive the hash of the original params.
     let context_creation = quote {

--- a/noir-projects/aztec-nr/aztec/src/macros/mod.nr
+++ b/noir-projects/aztec-nr/aztec/src/macros/mod.nr
@@ -19,7 +19,7 @@ use utils::module_has_storage;
 /// Note: This is a module annotation, so the returned quote gets injected inside the module (contract) itself.
 pub comptime fn aztec(m: Module) -> Quoted {
     let interface = generate_contract_interface(m);
-    let unconstrained_functions = m.functions().filter(|f: FunctionDefinition| {
+    let unconstrained_functions = m.functions().filter(|f| {
         f.is_unconstrained() & !f.has_named_attribute("test") & !f.has_named_attribute("public")
     });
     for f in unconstrained_functions {
@@ -115,16 +115,13 @@ comptime fn generate_compute_note_hash_and_optionally_a_nullifier() -> Quoted {
     let mut max_note_content_length: u32 = 0;
     let notes = NOTES.entries();
     let body = if notes.len() > 0 {
-        max_note_content_length = notes.fold(
-            0,
-            |acc, (_, (_, len, _, _)): (Type, (StructDefinition, u32, Field, [(Quoted, u32, bool)]))| {
-                if len > acc {
-                    len
-                } else {
-                    acc
-                }
-            },
-        );
+        max_note_content_length = notes.fold(0, |acc, (_, (_, len, _, _))| {
+            if len > acc {
+                len
+            } else {
+                acc
+            }
+        });
 
         let mut if_statements_list = &[];
 
@@ -256,7 +253,7 @@ comptime fn generate_process_log() -> Quoted {
                 unique_note_hashes_in_tx,
                 first_nullifier_in_tx,
                 recipient,
-                |packed_note_content: BoundedVec<Field, _>, note_header, note_type_id| {
+                |packed_note_content, note_header, note_type_id| {
                     let hashes = $if_note_type_id_match_statements
                     else {
                         panic(f"Unknown note type id {note_type_id}")
@@ -295,11 +292,9 @@ comptime fn generate_note_exports() -> Quoted {
     let notes = NOTES.values();
     // Second value in each tuple is `note_serialized_len` and that is ignored here because it's only used when
     // generating the `compute_note_hash_and_optionally_a_nullifier` function.
-    notes
-        .map(|(s, _, note_type_id, fields): (StructDefinition, u32, Field, [(Quoted, u32, bool)])| {
-            generate_note_export(s, note_type_id, fields)
-        })
-        .join(quote {})
+    notes.map(|(s, _, note_type_id, fields)| generate_note_export(s, note_type_id, fields)).join(
+        quote {},
+    )
 }
 
 comptime fn generate_sync_notes() -> Quoted {

--- a/noir-projects/aztec-nr/aztec/src/macros/notes/mod.nr
+++ b/noir-projects/aztec-nr/aztec/src/macros/notes/mod.nr
@@ -99,9 +99,8 @@ comptime fn generate_note_interface(
     // `compute_note_hash()` is computed over all the fields so we need to merge fixed and nullable.
     let merged_fields = indexed_fixed_fields.append(indexed_nullable_fields);
     // Now we prefix each of the merged fields with `self.` since they refer to the struct members here.
-    let prefixed_merged_fields = merged_fields.map(|(name, typ, index): (Quoted, Type, u32)| {
-        (quote { self.$name }, typ, index)
-    });
+    let prefixed_merged_fields =
+        merged_fields.map(|(name, typ, index)| (quote { self.$name }, typ, index));
     let (new_generators_list, new_scalars_list, _, new_aux_vars) =
         generate_multi_scalar_mul(prefixed_merged_fields);
 
@@ -177,11 +176,10 @@ comptime fn generate_note_properties(s: StructDefinition) -> Quoted {
     let property_selector_type = type_of(PropertySelector { index: 0, offset: 0, length: 0 });
     let note_header_type: Type = type_of(NoteHeader::empty());
 
-    let non_header_fields =
-        s.fields_as_written().filter(|(_, typ): (Quoted, Type)| typ != note_header_type);
+    let non_header_fields = s.fields_as_written().filter(|(_, typ)| typ != note_header_type);
 
     let properties_types = non_header_fields
-        .map(|(name, _): (Quoted, Type)| quote { pub $name: $property_selector_type })
+        .map(|(name, _)| quote { pub $name: $property_selector_type })
         .join(quote {,});
 
     // TODO #8694: Properly handle non-field types https://github.com/AztecProtocol/aztec-packages/issues/8694
@@ -485,9 +483,7 @@ comptime fn get_setup_log_plaintext_body(
 
     // Now we compute serialization of the fixed fields. We do that by passing the whole note struct
     // to the generate_serialize_to_fields function but we omit the NoteHeader and the nullable fields.
-    let to_omit = indexed_nullable_fields.map(|(name, _, _): (Quoted, Type, u32)| name).push_back(
-        quote { header },
-    );
+    let to_omit = indexed_nullable_fields.map(|(name, _, _)| name).push_back(quote { header });
     let (fields_list, aux_vars) =
         generate_serialize_to_fields(quote { }, s.as_type(), to_omit, true);
 
@@ -607,9 +603,7 @@ comptime fn generate_finalization_payload(
     // We compute serialization of the nullable fields which are to be emitted as a public log. We do that by
     // passing the whole note struct to the `generate_serialize_to_fields(...)` function but we omit the `NoteHeader` and
     // the fixed fields.
-    let to_omit = indexed_fixed_fields.map(|(name, _, _): (Quoted, Type, u32)| name).push_back(
-        quote { header },
-    );
+    let to_omit = indexed_fixed_fields.map(|(name, _, _)| name).push_back(quote { header });
     let (nullable_fields_list, aux_vars) =
         generate_serialize_to_fields(quote { }, s.as_type(), to_omit, true);
 

--- a/noir-projects/aztec-nr/aztec/src/macros/storage/mod.nr
+++ b/noir-projects/aztec-nr/aztec/src/macros/storage/mod.nr
@@ -172,6 +172,6 @@ comptime fn add_context_generic(typ: Type, context_generic: Type) -> Type {
         generics[generics.len() - 1] = context_generic;
     }
 
-    let generics = generics.map(|typ: Type| quote {$typ}).join(quote {,});
+    let generics = generics.map(|typ| quote {$typ}).join(quote {,});
     quote { $name<$generics> }.as_type()
 }

--- a/noir-projects/aztec-nr/aztec/src/macros/utils.nr
+++ b/noir-projects/aztec-nr/aztec/src/macros/utils.nr
@@ -37,7 +37,7 @@ pub(crate) comptime fn fn_has_noinitcheck(f: FunctionDefinition) -> bool {
 /// Takes a function body as a collection of expressions, and alters it by prepending and appending quoted values.
 pub(crate) comptime fn modify_fn_body(body: [Expr], prepend: Quoted, append: Quoted) -> Expr {
     // We need to quote the body before we can alter its contents, so we fold it by quoting each expression.
-    let mut body_quote = body.fold(quote {}, |full_quote: Quoted, expr: Expr| {
+    let mut body_quote = body.fold(quote {}, |full_quote, expr| {
         let expr_quote = expr.quoted();
         quote {
                 $full_quote
@@ -61,17 +61,16 @@ pub(crate) comptime fn add_to_field_slice(slice_name: Quoted, name: Quoted, typ:
     } else if typ.as_struct().is_some() {
         quote { $slice_name = $slice_name.append($name.serialize()); }
     } else if typ.as_array().is_some() {
-        let (element_type, _) = typ.as_array().unwrap();
         let serialized_name = f"{name}_serialized".quoted_contents();
         quote {
-            let $serialized_name = $name.map(|x: $element_type | x.serialize());
+            let $serialized_name = $name.map(|x| x.serialize());
             for i in 0..$name.len() {
                 $slice_name = $slice_name.append($serialized_name[i].as_slice());
             }
         }
     } else if typ.as_str().is_some() {
         quote {
-            $slice_name = $slice_name.append($name.as_bytes().map(| byte: u8 | byte as Field).as_slice());
+            $slice_name = $slice_name.append($name.as_bytes().map(|byte| byte as Field).as_slice());
         }
     } else {
         panic(
@@ -87,17 +86,16 @@ pub(crate) comptime fn add_to_hasher(hasher_name: Quoted, name: Quoted, typ: Typ
     } else if typ.as_struct().is_some() {
         quote { $hasher_name.add_multiple($name.serialize()); }
     } else if typ.as_array().is_some() {
-        let (element_type, _) = typ.as_array().unwrap();
         let serialized_name = f"{name}_serialized".quoted_contents();
         quote {
-           let $serialized_name = $name.map(|x: $element_type | x.serialize());
+           let $serialized_name = $name.map(|x| x.serialize());
             for i in 0..$name.len() {
                 $hasher_name.add_multiple($serialized_name[i]);
             }
         }
     } else if typ.as_str().is_some() {
         quote {
-            $hasher_name.add_multiple($name.as_bytes().map(| byte: u8 | byte as Field));
+            $hasher_name.add_multiple($name.as_bytes().map(|byte| byte as Field));
         }
     } else {
         panic(
@@ -129,15 +127,13 @@ comptime fn signature_of_type(typ: Type) -> Quoted {
         f"[{element_typ_quote};{array_len}]".quoted_contents()
     } else if typ.as_struct().is_some() {
         let (s, generics) = typ.as_struct().unwrap();
-        let field_signatures = s
-            .fields(generics)
-            .map(|(_, typ): (Quoted, Type)| signature_of_type(typ))
-            .join(quote {,});
+        let field_signatures =
+            s.fields(generics).map(|(_, typ)| signature_of_type(typ)).join(quote {,});
         f"({field_signatures})".quoted_contents()
     } else if typ.as_tuple().is_some() {
         // Note that tuples are handled the same way as structs
         let types = typ.as_tuple().unwrap();
-        let field_signatures = types.map(|typ: Type| signature_of_type(typ)).join(quote {,});
+        let field_signatures = types.map(|typ| signature_of_type(typ)).join(quote {,});
         f"({field_signatures})".quoted_contents()
     } else {
         panic(f"Unsupported type {typ}")
@@ -180,8 +176,7 @@ pub(crate) comptime fn compute_fn_selector(f: FunctionDefinition) -> Field {
     //
     // The signature will be "foo(Field,AztecAddress)".
     let fn_name = f.name();
-    let args_signatures =
-        f.parameters().map(|(_, typ): (Quoted, Type)| signature_of_type(typ)).join(quote {,});
+    let args_signatures = f.parameters().map(|(_, typ)| signature_of_type(typ)).join(quote {,});
     let signature_quote = quote { $fn_name($args_signatures) };
     let (signature_str_quote, _) = signature_quote.as_str_quote();
 

--- a/noir-projects/noir-contracts/contracts/card_game_contract/src/cards.nr
+++ b/noir-projects/noir-contracts/contracts/card_game_contract/src/cards.nr
@@ -171,5 +171,5 @@ pub fn get_pack_cards(
 }
 
 pub fn compute_deck_strength<let N: u32>(cards: [Card; N]) -> Field {
-    cards.fold(0, |acc, card: Card| acc + card.strength as Field)
+    cards.fold(0, |acc, card| acc + card.strength as Field)
 }

--- a/noir-projects/noir-contracts/contracts/card_game_contract/src/main.nr
+++ b/noir-projects/noir-contracts/contracts/card_game_contract/src/main.nr
@@ -121,10 +121,7 @@ pub contract CardGame {
         assert(!game_data.claimed, "Already claimed");
         game_data.claimed = true;
 
-        assert_eq(
-            cards_hash,
-            pedersen_hash(game_data.rounds_cards.map(|card: Card| card.to_field()), 0),
-        );
+        assert_eq(cards_hash, pedersen_hash(game_data.rounds_cards.map(|card| card.to_field()), 0));
 
         let winner = game_data.winner();
         assert(player.eq(winner.address), "Not the winner");

--- a/noir-projects/noir-protocol-circuits/crates/private-kernel-lib/src/components/private_call_data_validator.nr
+++ b/noir-projects/noir-protocol-circuits/crates/private-kernel-lib/src/components/private_call_data_validator.nr
@@ -378,7 +378,7 @@ impl PrivateCallDataValidator {
                 let note_index = unsafe {
                     find_index_hint(
                         accumulated_note_hashes,
-                        |n: ScopedNoteHash| n.counter() == log.note_hash_counter,
+                        |n| n.counter() == log.note_hash_counter,
                     )
                 };
                 assert(note_index != N, "could not find note hash linked to note log");

--- a/noir-projects/noir-protocol-circuits/crates/private-kernel-lib/src/components/reset_output_composer/reset_output_hints.nr
+++ b/noir-projects/noir-protocol-circuits/crates/private-kernel-lib/src/components/reset_output_composer/reset_output_hints.nr
@@ -40,12 +40,10 @@ pub unconstrained fn generate_reset_output_hints<let NUM_TRANSIENT_DATA_INDEX_HI
     );
 
     // note_hashes
-    let sorted_note_hash_indexes =
-        get_order_hints_asc(kept_note_hashes).map(|h: OrderHint| h.sorted_index);
+    let sorted_note_hash_indexes = get_order_hints_asc(kept_note_hashes).map(|h| h.sorted_index);
 
     // nullifiers
-    let sorted_nullifier_indexes =
-        get_order_hints_asc(kept_nullifiers).map(|h: OrderHint| h.sorted_index);
+    let sorted_nullifier_indexes = get_order_hints_asc(kept_nullifiers).map(|h| h.sorted_index);
 
     // private_logs
     let transient_or_propagated_note_hash_indexes_for_logs = get_transient_or_propagated_note_hash_indexes_for_logs(
@@ -54,8 +52,7 @@ pub unconstrained fn generate_reset_output_hints<let NUM_TRANSIENT_DATA_INDEX_HI
         kept_note_hashes,
         transient_data_index_hints,
     );
-    let sorted_private_log_indexes =
-        get_order_hints_asc(kept_private_logs).map(|h: OrderHint| h.sorted_index);
+    let sorted_private_log_indexes = get_order_hints_asc(kept_private_logs).map(|h| h.sorted_index);
 
     ResetOutputHints {
         kept_note_hashes,

--- a/noir-projects/noir-protocol-circuits/crates/private-kernel-lib/src/components/reset_output_composer/reset_output_hints/get_transient_or_propagated_note_hash_indexes_for_logs.nr
+++ b/noir-projects/noir-protocol-circuits/crates/private-kernel-lib/src/components/reset_output_composer/reset_output_hints/get_transient_or_propagated_note_hash_indexes_for_logs.nr
@@ -24,10 +24,9 @@ pub unconstrained fn get_transient_or_propagated_note_hash_indexes_for_logs<let 
             if !propagated {
                 for j in 0..note_hashes.len() {
                     if note_hashes[j].counter() == log_note_hash_counter {
-                        indexes[i] = find_index_hint(
-                            transient_data_index_hints,
-                            |hint: TransientDataIndexHint| hint.note_hash_index == j,
-                        );
+                        indexes[i] = find_index_hint(transient_data_index_hints, |hint| {
+                            hint.note_hash_index == j
+                        });
                     }
                 }
             }

--- a/noir-projects/noir-protocol-circuits/crates/private-kernel-lib/src/components/reset_output_composer/reset_output_hints/squash_transient_data.nr
+++ b/noir-projects/noir-protocol-circuits/crates/private-kernel-lib/src/components/reset_output_composer/reset_output_hints/squash_transient_data.nr
@@ -41,9 +41,9 @@ pub unconstrained fn squash_transient_data<let M: u32, let N: u32, let P: u32, l
         if log.inner.note_hash_counter == 0 {
             propagated_logs.push(log);
         } else {
-            let linked_note_hash_propagated = propagated_note_hashes.storage().any(
-                |n: ScopedNoteHash| (n.counter() == log.inner.note_hash_counter),
-            );
+            let linked_note_hash_propagated = propagated_note_hashes.storage().any(|n| {
+                (n.counter() == log.inner.note_hash_counter)
+            });
             if linked_note_hash_propagated {
                 propagated_logs.push(log);
             }

--- a/noir-projects/noir-protocol-circuits/crates/private-kernel-lib/src/components/reset_output_validator.nr
+++ b/noir-projects/noir-protocol-circuits/crates/private-kernel-lib/src/components/reset_output_validator.nr
@@ -226,9 +226,7 @@ impl<let NH_RR_PENDING: u32, let NH_RR_SETTLED: u32, let NLL_RR_PENDING: u32, le
         assert_sorted_transformed_value_array_capped_size(
             kept_note_hashes,
             output_note_hashes,
-            |prev: ScopedNoteHash, out: ScopedNoteHash| {
-                out.contract_address.is_zero() & (out.counter() == prev.counter())
-            },
+            |prev, out| out.contract_address.is_zero() & (out.counter() == prev.counter()),
             sorted_indexes,
             self.note_hash_siloing_amount,
         );
@@ -240,7 +238,7 @@ impl<let NH_RR_PENDING: u32, let NH_RR_SETTLED: u32, let NLL_RR_PENDING: u32, le
         assert_sorted_transformed_value_array_capped_size(
             self.hints.kept_nullifiers,
             self.output.end.nullifiers,
-            |prev: ScopedNullifier, out: ScopedNullifier| {
+            |prev, out| {
                 (out.value() == silo_nullifier(prev))
                     & (out.counter() == prev.counter())
                     & (out.nullifier.note_hash == prev.nullifier.note_hash)
@@ -255,7 +253,7 @@ impl<let NH_RR_PENDING: u32, let NH_RR_SETTLED: u32, let NLL_RR_PENDING: u32, le
         assert_sorted_transformed_value_array_capped_size(
             self.hints.kept_private_logs,
             self.output.end.private_logs,
-            |prev: Scoped<PrivateLogData>, out: Scoped<PrivateLogData>| {
+            |prev, out| {
                 is_valid_siloed_private_log(out.inner.log, prev)
                     & (out.inner.note_hash_counter == prev.inner.note_hash_counter)
                     & (out.inner.counter == prev.inner.counter)

--- a/noir-projects/noir-protocol-circuits/crates/private-kernel-lib/src/components/tail_output_composer.nr
+++ b/noir-projects/noir-protocol-circuits/crates/private-kernel-lib/src/components/tail_output_composer.nr
@@ -46,19 +46,14 @@ impl TailOutputComposer {
     ) -> PrivateToRollupAccumulatedData {
         let source = self.output_composer.public_inputs.end;
         let mut data = PrivateToRollupAccumulatedData::empty();
-        data.note_hashes = source.note_hashes.storage().map(|n: ScopedNoteHash| n.note_hash.value);
-        data.nullifiers = source.nullifiers.storage().map(|n: ScopedNullifier| n.nullifier.value);
-        data.l2_to_l1_msgs =
-            source.l2_to_l1_msgs.storage().map(|m: ScopedL2ToL1Message| m.expose_to_public());
-        data.private_logs =
-            source.private_logs.storage().map(|l: Scoped<PrivateLogData>| l.inner.log);
-        data.contract_class_logs_hashes = source.contract_class_logs_hashes.storage().map(
-            |l: ScopedLogHash| l.expose_to_public(),
-        );
-        data.contract_class_log_preimages_length = source.contract_class_logs_hashes.storage().fold(
-            0,
-            |len, l: ScopedLogHash| len + l.log_hash.length,
-        );
+        data.note_hashes = source.note_hashes.storage().map(|n| n.note_hash.value);
+        data.nullifiers = source.nullifiers.storage().map(|n| n.nullifier.value);
+        data.l2_to_l1_msgs = source.l2_to_l1_msgs.storage().map(|m| m.expose_to_public());
+        data.private_logs = source.private_logs.storage().map(|l| l.inner.log);
+        data.contract_class_logs_hashes =
+            source.contract_class_logs_hashes.storage().map(|l| l.expose_to_public());
+        data.contract_class_log_preimages_length =
+            source.contract_class_logs_hashes.storage().fold(0, |len, l| len + l.log_hash.length);
         data
     }
 }

--- a/noir-projects/noir-protocol-circuits/crates/private-kernel-lib/src/components/tail_output_validator.nr
+++ b/noir-projects/noir-protocol-circuits/crates/private-kernel-lib/src/components/tail_output_validator.nr
@@ -92,7 +92,7 @@ impl TailOutputValidator {
 
         // private_logs
         assert_eq(
-            self.previous_kernel.end.private_logs.map(|l: Scoped<PrivateLogData>| l.inner.log),
+            self.previous_kernel.end.private_logs.map(|l| l.inner.log),
             self.output.end.private_logs,
             "mismatch private_logs",
         );
@@ -103,14 +103,14 @@ impl TailOutputValidator {
         assert_exposed_sorted_transformed_value_array(
             self.previous_kernel.end.l2_to_l1_msgs,
             self.output.end.l2_to_l1_msgs,
-            |prev: ScopedL2ToL1Message, out: ScopedL2ToL1Message| out == prev.expose_to_public(),
+            |prev, out| out == prev.expose_to_public(),
             self.hints.sorted_l2_to_l1_msg_hints,
         );
         // contract_class_logs
         assert_exposed_sorted_transformed_value_array(
             self.previous_kernel.end.contract_class_logs_hashes,
             self.output.end.contract_class_logs_hashes,
-            |prev: ScopedLogHash, out: ScopedLogHash| out == prev.expose_to_public(),
+            |prev, out| out == prev.expose_to_public(),
             self.hints.sorted_contract_class_log_hash_hints,
         );
     }

--- a/noir-projects/noir-protocol-circuits/crates/private-kernel-lib/src/components/tail_to_public_output_composer/meter_gas_used.nr
+++ b/noir-projects/noir-protocol-circuits/crates/private-kernel-lib/src/components/tail_to_public_output_composer/meter_gas_used.nr
@@ -34,7 +34,7 @@ fn meter_accumulated_data_gas_used(data: PrivateToPublicAccumulatedData) -> Gas 
 
     let mut metered_da_bytes = metered_da_fields * DA_BYTES_PER_FIELD;
     let contract_class_log_preimages_length =
-        data.contract_class_logs_hashes.fold(0, |len, l: ScopedLogHash| len + l.log_hash.length);
+        data.contract_class_logs_hashes.fold(0, |len, l| len + l.log_hash.length);
     metered_da_bytes += contract_class_log_preimages_length as u32;
     metered_l2_gas += contract_class_log_preimages_length as u32 * L2_GAS_PER_LOG_BYTE;
 

--- a/noir-projects/noir-protocol-circuits/crates/private-kernel-lib/src/components/tail_to_public_output_validator.nr
+++ b/noir-projects/noir-protocol-circuits/crates/private-kernel-lib/src/components/tail_to_public_output_validator.nr
@@ -71,7 +71,7 @@ impl TailToPublicOutputValidator {
             prev_data.note_hashes,
             output_non_revertible.note_hashes,
             output_revertible.note_hashes,
-            |prev: ScopedNoteHash, out: Field| out == prev.note_hash.value,
+            |prev, out| out == prev.note_hash.value,
             split_counter,
         );
 
@@ -80,7 +80,7 @@ impl TailToPublicOutputValidator {
             prev_data.nullifiers,
             output_non_revertible.nullifiers,
             output_revertible.nullifiers,
-            |prev: ScopedNullifier, out: Field| out == prev.nullifier.value,
+            |prev, out| out == prev.nullifier.value,
             split_counter,
         );
 
@@ -104,7 +104,7 @@ impl TailToPublicOutputValidator {
         // l2_to_l1_msgs
         assert_split_sorted_transformed_value_arrays_asc(
             prev_data.l2_to_l1_msgs,
-            prev_data.l2_to_l1_msgs.map(|log: ScopedL2ToL1Message| log.expose_to_public()),
+            prev_data.l2_to_l1_msgs.map(|log| log.expose_to_public()),
             split_counter,
             output_non_revertible.l2_to_l1_msgs,
             output_revertible.l2_to_l1_msgs,
@@ -114,7 +114,7 @@ impl TailToPublicOutputValidator {
         // contract_class_logs_hashes
         assert_split_sorted_transformed_value_arrays_asc(
             prev_data.contract_class_logs_hashes,
-            prev_data.contract_class_logs_hashes.map(|log: ScopedLogHash| log.expose_to_public()),
+            prev_data.contract_class_logs_hashes.map(|log| log.expose_to_public()),
             split_counter,
             output_non_revertible.contract_class_logs_hashes,
             output_revertible.contract_class_logs_hashes,
@@ -124,7 +124,7 @@ impl TailToPublicOutputValidator {
         // public_call_requests
         assert_split_sorted_transformed_value_arrays_desc(
             prev_data.public_call_requests,
-            prev_data.public_call_requests.map(|cr: Counted<PublicCallRequest>| cr.inner),
+            prev_data.public_call_requests.map(|cr| cr.inner),
             split_counter,
             output_non_revertible.public_call_requests,
             output_revertible.public_call_requests,

--- a/noir-projects/noir-protocol-circuits/crates/private-kernel-lib/src/private_kernel_tail.nr
+++ b/noir-projects/noir-protocol-circuits/crates/private-kernel-lib/src/private_kernel_tail.nr
@@ -156,10 +156,7 @@ mod tests {
 
         let resulting_msgs = public_inputs.end.l2_to_l1_msgs;
 
-        assert_eq(
-            resulting_msgs,
-            original_msgs.map(|mut msg: ScopedL2ToL1Message| msg.expose_to_public()),
-        );
+        assert_eq(resulting_msgs, original_msgs.map(|mut msg| msg.expose_to_public()));
     }
 
     #[test(should_fail_with = "Private call stack must be empty when executing the tail circuit")]

--- a/noir-projects/noir-protocol-circuits/crates/private-kernel-lib/src/private_kernel_tail_to_public.nr
+++ b/noir-projects/noir-protocol-circuits/crates/private-kernel-lib/src/private_kernel_tail_to_public.nr
@@ -159,9 +159,8 @@ mod tests {
 
         let public_inputs = builder.execute();
 
-        let output_nullifiers = builder.previous_kernel.nullifiers.storage().map(
-            |n: ScopedNullifier| n.nullifier.value,
-        );
+        let output_nullifiers =
+            builder.previous_kernel.nullifiers.storage().map(|n| n.nullifier.value);
 
         assert_array_eq(
             public_inputs.non_revertible_accumulated_data.nullifiers,
@@ -194,9 +193,8 @@ mod tests {
 
         let public_inputs = builder.execute();
 
-        let exposed_note_hashes = builder.previous_kernel.note_hashes.storage().map(
-            |n: ScopedNoteHash| n.note_hash.value,
-        );
+        let exposed_note_hashes =
+            builder.previous_kernel.note_hashes.storage().map(|n| n.note_hash.value);
 
         assert_array_eq(
             public_inputs.non_revertible_accumulated_data.note_hashes,
@@ -229,9 +227,8 @@ mod tests {
         // expect 2 revertible note hashes
         builder.previous_kernel.append_siloed_private_logs_for_note(3, 12);
 
-        let exposed_private_logs = builder.previous_kernel.private_logs.storage().map(
-            |n: Scoped<PrivateLogData>| n.inner.log,
-        );
+        let exposed_private_logs =
+            builder.previous_kernel.private_logs.storage().map(|n| n.inner.log);
 
         let public_inputs = builder.execute();
 

--- a/noir-projects/noir-protocol-circuits/crates/rollup-lib/src/base/private_base_rollup.nr
+++ b/noir-projects/noir-protocol-circuits/crates/rollup-lib/src/base/private_base_rollup.nr
@@ -102,13 +102,11 @@ impl PrivateBaseRollupInputs {
         all_public_data_update_requests[0] = fee_public_data_write;
 
         // Append the tx effects for blob(s)
-        let siloed_l2_to_l1_msgs = self.tube_data.public_inputs.end.l2_to_l1_msgs.map(
-            |message: ScopedL2ToL1Message| silo_l2_to_l1_message(
-                message,
-                self.tube_data.public_inputs.constants.tx_context.version,
-                self.tube_data.public_inputs.constants.tx_context.chain_id,
-            ),
-        );
+        let siloed_l2_to_l1_msgs = self.tube_data.public_inputs.end.l2_to_l1_msgs.map(|message| silo_l2_to_l1_message(
+            message,
+            self.tube_data.public_inputs.constants.tx_context.version,
+            self.tube_data.public_inputs.constants.tx_context.chain_id,
+        ));
 
         let out_hash = compute_kernel_out_hash(siloed_l2_to_l1_msgs);
         let tx_effect = TxEffect {
@@ -174,7 +172,7 @@ impl PrivateBaseRollupInputs {
     }
 
     fn create_nullifier_subtree<let N: u32>(leaves: [NullifierLeafPreimage; N]) -> Field {
-        calculate_subtree_root(leaves.map(|leaf: NullifierLeafPreimage| leaf.hash()))
+        calculate_subtree_root(leaves.map(|leaf| leaf.hash()))
     }
 
     fn build_fee_public_data_write(self, tx_fee: Field) -> PublicDataWrite {
@@ -362,7 +360,7 @@ mod tests {
         ) -> PublicDataHint {
             self.fee_payer_fee_juice_balance_pre_existing_public_data_index.map_or(
                 PublicDataHint::empty(),
-                |leaf_index_u32: u32| {
+                |leaf_index_u32| {
                     let leaf_index = leaf_index_u32 as Field;
                     let leaf_preimage = self.pre_existing_public_data[leaf_index];
                     let membership_witness = MembershipWitness {
@@ -388,11 +386,9 @@ mod tests {
         fn build_pre_existing_tx_effects(self) -> TxEffect {
             let mut res = TxEffect::empty();
             res.note_hashes = self.pre_existing_notes;
-            res.nullifiers = self.pre_existing_nullifiers.map(|nullifier: NullifierLeafPreimage| {
-                nullifier.nullifier
-            });
+            res.nullifiers = self.pre_existing_nullifiers.map(|nullifier| nullifier.nullifier);
             let all_public_data_update_requests = self.pre_existing_public_data.map(
-                |leaf_preimage: PublicDataTreeLeafPreimage| {
+                |leaf_preimage| {
                     PublicDataWrite { leaf_slot: leaf_preimage.slot, value: leaf_preimage.value }
                 },
             );
@@ -432,7 +428,7 @@ mod tests {
             /// Safety: This is a mock for testing only
             let sorted_new_nullifier_tuples = unsafe {
                 get_sorted_tuple(
-                    self.nullifiers.storage().map(|insertion: NullifierInsertion| insertion.value),
+                    self.nullifiers.storage().map(|insertion| insertion.value),
                     |a, b| full_field_less_than(b, a),
                 )
             };
@@ -504,7 +500,7 @@ mod tests {
             );
 
             let mut start_nullifier_tree = NonEmptyMerkleTree::new(
-                self.pre_existing_nullifiers.map(|preimage: NullifierLeafPreimage| preimage.hash()),
+                self.pre_existing_nullifiers.map(|preimage| preimage.hash()),
                 [0; NULLIFIER_TREE_HEIGHT],
                 [0; NULLIFIER_TREE_HEIGHT - NULLIFIER_SUBTREE_HEIGHT],
                 [0; NULLIFIER_SUBTREE_HEIGHT],
@@ -707,7 +703,7 @@ mod tests {
             NullifierLeafPreimage { nullifier: 1, next_nullifier: 7, next_index: 1 };
 
         let mut end_nullifier_tree = NonEmptyMerkleTree::new(
-            tree_nullifiers.map(|preimage: NullifierLeafPreimage| preimage.hash()),
+            tree_nullifiers.map(|preimage| preimage.hash()),
             [0; NULLIFIER_TREE_HEIGHT],
             [0; NULLIFIER_TREE_HEIGHT - NULLIFIER_SUBTREE_HEIGHT - 1],
             [0; NULLIFIER_SUBTREE_HEIGHT + 1],

--- a/noir-projects/noir-protocol-circuits/crates/rollup-lib/src/base/public_base_rollup.nr
+++ b/noir-projects/noir-protocol-circuits/crates/rollup-lib/src/base/public_base_rollup.nr
@@ -55,13 +55,11 @@ impl PublicBaseRollupInputs {
         let from_private = self.tube_data.public_inputs;
         let from_public = self.avm_proof_data.public_inputs;
         let revert_code = if reverted { 1 } else { 0 };
-        let siloed_l2_to_l1_msgs = from_public.accumulated_data.l2_to_l1_msgs.map(
-            |message: ScopedL2ToL1Message| silo_l2_to_l1_message(
-                message,
-                combined_constant_data.tx_context.version,
-                combined_constant_data.tx_context.chain_id,
-            ),
-        );
+        let siloed_l2_to_l1_msgs = from_public.accumulated_data.l2_to_l1_msgs.map(|message| silo_l2_to_l1_message(
+            message,
+            combined_constant_data.tx_context.version,
+            combined_constant_data.tx_context.chain_id,
+        ));
 
         let private_logs = if reverted {
             from_private.non_revertible_accumulated_data.private_logs
@@ -80,7 +78,7 @@ impl PublicBaseRollupInputs {
             )
         };
         let contract_class_log_preimages_length =
-            contract_class_logs_hashes.fold(0, |len, l: ScopedLogHash| len + l.log_hash.length);
+            contract_class_logs_hashes.fold(0, |len, l| len + l.log_hash.length);
 
         TxEffect {
             tx_hash: self.tube_data.public_inputs.hash(),
@@ -222,7 +220,7 @@ impl PublicBaseRollupInputs {
     }
 
     fn create_nullifier_subtree<let N: u32>(leaves: [NullifierLeafPreimage; N]) -> Field {
-        calculate_subtree_root(leaves.map(|leaf: NullifierLeafPreimage| leaf.hash()))
+        calculate_subtree_root(leaves.map(|leaf| leaf.hash()))
     }
 
     fn validate_kernel_start_state(self) {
@@ -430,11 +428,9 @@ mod tests {
         fn build_pre_existing_tx_effects(self) -> TxEffect {
             let mut res = TxEffect::empty();
             res.note_hashes = self.pre_existing_notes;
-            res.nullifiers = self.pre_existing_nullifiers.map(|nullifier: NullifierLeafPreimage| {
-                nullifier.nullifier
-            });
+            res.nullifiers = self.pre_existing_nullifiers.map(|nullifier| nullifier.nullifier);
             let all_public_data_update_requests = self.pre_existing_public_data.map(
-                |leaf_preimage: PublicDataTreeLeafPreimage| {
+                |leaf_preimage| {
                     PublicDataWrite { leaf_slot: leaf_preimage.slot, value: leaf_preimage.value }
                 },
             );
@@ -473,7 +469,7 @@ mod tests {
             /// Safety: This is a mock for testing only
             let sorted_new_nullifier_tuples = unsafe {
                 get_sorted_tuple(
-                    self.nullifiers.storage().map(|insertion: NullifierInsertion| insertion.value),
+                    self.nullifiers.storage().map(|insertion| insertion.value),
                     |a, b| full_field_less_than(b, a),
                 )
             };
@@ -584,9 +580,7 @@ mod tests {
 
             let mut start_nullifier_tree = NonEmptyMerkleTree::new(
                 pad_end::<Field, MAX_NULLIFIERS_PER_TX, MAX_NULLIFIERS_PER_TX * 2>(
-                    self.pre_existing_nullifiers.map(|preimage: NullifierLeafPreimage| {
-                        preimage.hash()
-                    }),
+                    self.pre_existing_nullifiers.map(|preimage| preimage.hash()),
                     0,
                 ),
                 [0; NULLIFIER_TREE_HEIGHT],
@@ -801,7 +795,7 @@ mod tests {
             NullifierLeafPreimage { nullifier: 1, next_nullifier: 7, next_index: 1 };
 
         let mut end_nullifier_tree = NonEmptyMerkleTree::new(
-            tree_nullifiers.map(|preimage: NullifierLeafPreimage| preimage.hash()),
+            tree_nullifiers.map(|preimage| preimage.hash()),
             [0; NULLIFIER_TREE_HEIGHT],
             [0; NULLIFIER_TREE_HEIGHT - NULLIFIER_SUBTREE_HEIGHT - 1],
             [0; NULLIFIER_SUBTREE_HEIGHT + 1],
@@ -858,7 +852,7 @@ mod tests {
         };
 
         let mut end_nullifier_tree = NonEmptyMerkleTree::new(
-            tree_nullifiers.map(|preimage: NullifierLeafPreimage| preimage.hash()),
+            tree_nullifiers.map(|preimage| preimage.hash()),
             [0; NULLIFIER_TREE_HEIGHT],
             [0; NULLIFIER_TREE_HEIGHT - NULLIFIER_SUBTREE_HEIGHT - 1],
             [0; NULLIFIER_SUBTREE_HEIGHT + 1],
@@ -1122,13 +1116,11 @@ mod tests {
         }
 
         let out_hash = builder.execute().out_hash;
-        let siloed_l2_to_l1_msgs = builder.avm_data.l2_to_l1_msgs.map(
-            |l2_to_l1_message: ScopedL2ToL1Message| silo_l2_to_l1_message(
-                l2_to_l1_message,
-                builder.constants.global_variables.version,
-                builder.constants.global_variables.chain_id,
-            ),
-        );
+        let siloed_l2_to_l1_msgs = builder.avm_data.l2_to_l1_msgs.map(|l2_to_l1_message| silo_l2_to_l1_message(
+            l2_to_l1_message,
+            builder.constants.global_variables.version,
+            builder.constants.global_variables.chain_id,
+        ));
 
         // Since we fill the tree completely, we know to expect a full tree as below
         let expected_tree = generate_full_sha_tree(siloed_l2_to_l1_msgs.storage());

--- a/noir-projects/noir-protocol-circuits/crates/types/src/abis/private_kernel_data.nr
+++ b/noir-projects/noir-protocol-circuits/crates/types/src/abis/private_kernel_data.nr
@@ -25,9 +25,8 @@ impl PrivateKernelData {
         };
         /// Safety: find_index_hint should return an index into allowed_indices where `index == index_in_allowed_list`.
         /// The assertion below then verifies that the condition is met.
-        let index_hint = unsafe {
-            find_index_hint(allowed_indices, |index: u32| index == index_in_allowed_list)
-        };
+        let index_hint =
+            unsafe { find_index_hint(allowed_indices, |index| index == index_in_allowed_list) };
         assert(index_hint < N, "Invalid vk index");
         assert_eq(allowed_indices[index_hint], index_in_allowed_list, "Invalid vk index");
 

--- a/noir-projects/noir-protocol-circuits/crates/types/src/merkle_tree/indexed_tree.nr
+++ b/noir-projects/noir-protocol-circuits/crates/types/src/merkle_tree/indexed_tree.nr
@@ -99,7 +99,7 @@ where
     );
 
     // Create new subtree to insert into the whole indexed tree
-    let subtree_root = calculate_subtree_root(insertion_subtree.map(|leaf: Leaf| leaf.as_leaf()));
+    let subtree_root = calculate_subtree_root(insertion_subtree.map(|leaf| leaf.as_leaf()));
 
     // Calculate the new root
     // We are inserting a subtree rather than a full tree here

--- a/noir-projects/noir-protocol-circuits/crates/types/src/merkle_tree/membership.nr
+++ b/noir-projects/noir-protocol-circuits/crates/types/src/merkle_tree/membership.nr
@@ -154,7 +154,7 @@ mod tests {
 
     fn build_tree() -> NonEmptyMerkleTree<4, 3, 1, 2> {
         NonEmptyMerkleTree::new(
-            leaf_preimages.map(|leaf_preimage: TestLeafPreimage| leaf_preimage.as_leaf()),
+            leaf_preimages.map(|leaf_preimage| leaf_preimage.as_leaf()),
             [0; 3],
             [0; 1],
             [0; 2],

--- a/noir-projects/noir-protocol-circuits/crates/types/src/meta/mod.nr
+++ b/noir-projects/noir-protocol-circuits/crates/types/src/meta/mod.nr
@@ -355,7 +355,7 @@ pub comptime fn generate_serialize_to_fields(
             // For struct we pref
             let nested_struct = typ.as_struct().unwrap();
             let params = nested_struct.0.fields(nested_struct.1);
-            let struct_flattened = params.map(|(param_name, param_type): (Quoted, Type)| {
+            let struct_flattened = params.map(|(param_name, param_type)| {
                 let maybe_prefixed_name = if name == quote {} {
                     // Triggered when the param name is of a value available in the current scope (e.g. a function
                     // argument) --> then we don't prefix the name with anything.
@@ -372,14 +372,10 @@ pub comptime fn generate_serialize_to_fields(
                     should_pack,
                 )
             });
-            let struct_flattened_fields = struct_flattened.fold(
-                &[],
-                |acc: [Quoted], (fields, _): (_, [Quoted])| acc.append(fields),
-            );
-            let struct_flattened_aux_vars = struct_flattened.fold(
-                &[],
-                |acc: [Quoted], (_, aux_vars): ([Quoted], _)| acc.append(aux_vars),
-            );
+            let struct_flattened_fields =
+                struct_flattened.fold(&[], |acc, (fields, _)| acc.append(fields));
+            let struct_flattened_aux_vars =
+                struct_flattened.fold(&[], |acc, (_, aux_vars)| acc.append(aux_vars));
             fields = fields.append(struct_flattened_fields);
             aux_vars = aux_vars.append(struct_flattened_aux_vars);
         } else if typ.as_array().is_some() {

--- a/noir-projects/noir-protocol-circuits/crates/types/src/proof/vk_data.nr
+++ b/noir-projects/noir-protocol-circuits/crates/types/src/proof/vk_data.nr
@@ -17,7 +17,7 @@ impl<let VK_LENGTH: u32> VkData<VK_LENGTH> {
         /// Safety: find_index_hint should return an index into allowed_indices where
         /// `index == index_in_allowed_list`. The assertion below then verifies that the condition is met.
         let index_hint =
-            unsafe { find_index_hint(allowed_indices, |index: u32| index == self.vk_index) };
+            unsafe { find_index_hint(allowed_indices, |index| index == self.vk_index) };
         assert(index_hint < N, "Invalid vk index");
         assert_eq(allowed_indices[index_hint], self.vk_index, "Invalid vk index");
 

--- a/noir-projects/noir-protocol-circuits/crates/types/src/tests/fixture_builder.nr
+++ b/noir-projects/noir-protocol-circuits/crates/types/src/tests/fixture_builder.nr
@@ -345,36 +345,28 @@ impl FixtureBuilder {
             min_revertible_side_effect_counter: self.min_revertible_side_effect_counter,
             is_fee_payer: self.is_fee_payer,
             max_block_number: self.max_block_number,
-            note_hash_read_requests: subarray(self.note_hash_read_requests.storage().map(
-                |r: ScopedReadRequest| r.read_request,
-            )),
-            nullifier_read_requests: subarray(self.nullifier_read_requests.storage().map(
-                |r: ScopedReadRequest| r.read_request,
-            )),
+            note_hash_read_requests: subarray(self.note_hash_read_requests.storage().map(|r| {
+                r.read_request
+            })),
+            nullifier_read_requests: subarray(self.nullifier_read_requests.storage().map(|r| {
+                r.read_request
+            })),
             key_validation_requests_and_generators: subarray(self
                 .scoped_key_validation_requests_and_generators
                 .storage()
-                .map(|r: ScopedKeyValidationRequestAndGenerator| r.request)),
-            note_hashes: subarray(
-                self.note_hashes.storage().map(|n: ScopedNoteHash| n.note_hash),
-            ),
-            nullifiers: subarray(
-                self.nullifiers.storage().map(|n: ScopedNullifier| n.nullifier),
-            ),
+                .map(|r| r.request)),
+            note_hashes: subarray(self.note_hashes.storage().map(|n| n.note_hash)),
+            nullifiers: subarray(self.nullifiers.storage().map(|n| n.nullifier)),
             private_call_requests: subarray(self.private_call_requests.storage()),
             public_call_requests: subarray(self.public_call_requests.storage()),
             public_teardown_call_request: self.public_teardown_call_request,
-            l2_to_l1_msgs: subarray(self.l2_to_l1_msgs.storage().map(|r: ScopedL2ToL1Message| {
-                r.message
-            })),
+            l2_to_l1_msgs: subarray(self.l2_to_l1_msgs.storage().map(|r| r.message)),
             start_side_effect_counter: self.counter_start,
             end_side_effect_counter: self.counter,
-            private_logs: subarray(self.private_logs.storage().map(|l: Scoped<PrivateLogData>| {
-                l.inner
+            private_logs: subarray(self.private_logs.storage().map(|l| l.inner)),
+            contract_class_logs_hashes: subarray(self.contract_class_logs_hashes.storage().map(|l| {
+                l.log_hash
             })),
-            contract_class_logs_hashes: subarray(self.contract_class_logs_hashes.storage().map(
-                |l: ScopedLogHash| l.log_hash,
-            )),
             historical_header: self.historical_header,
             tx_context: self.tx_context,
         }
@@ -423,32 +415,26 @@ impl FixtureBuilder {
 
     pub fn to_private_to_public_accumulated_data(self) -> PrivateToPublicAccumulatedData {
         PrivateToPublicAccumulatedData {
-            note_hashes: self.note_hashes.storage().map(|n: ScopedNoteHash| n.value()),
-            nullifiers: self.nullifiers.storage().map(|n: ScopedNullifier| n.value()),
-            l2_to_l1_msgs: self.l2_to_l1_msgs.storage().map(|m: ScopedL2ToL1Message| {
-                m.expose_to_public()
+            note_hashes: self.note_hashes.storage().map(|n| n.value()),
+            nullifiers: self.nullifiers.storage().map(|n| n.value()),
+            l2_to_l1_msgs: self.l2_to_l1_msgs.storage().map(|m| m.expose_to_public()),
+            private_logs: self.private_logs.storage().map(|l| l.inner.log),
+            contract_class_logs_hashes: self.contract_class_logs_hashes.storage().map(|l| {
+                l.expose_to_public()
             }),
-            private_logs: self.private_logs.storage().map(|l: Scoped<PrivateLogData>| l.inner.log),
-            contract_class_logs_hashes: self.contract_class_logs_hashes.storage().map(
-                |l: ScopedLogHash| l.expose_to_public(),
-            ),
-            public_call_requests: self.public_call_requests.storage().map(
-                |cr: Counted<PublicCallRequest>| cr.inner,
-            ),
+            public_call_requests: self.public_call_requests.storage().map(|cr| cr.inner),
         }
     }
 
     pub fn to_private_to_rollup_accumulated_data(self) -> PrivateToRollupAccumulatedData {
         PrivateToRollupAccumulatedData {
-            note_hashes: self.note_hashes.storage().map(|n: ScopedNoteHash| n.note_hash.value),
-            nullifiers: self.nullifiers.storage().map(|n: ScopedNullifier| n.nullifier.value),
-            l2_to_l1_msgs: self.l2_to_l1_msgs.storage().map(|m: ScopedL2ToL1Message| {
-                m.expose_to_public()
+            note_hashes: self.note_hashes.storage().map(|n| n.note_hash.value),
+            nullifiers: self.nullifiers.storage().map(|n| n.nullifier.value),
+            l2_to_l1_msgs: self.l2_to_l1_msgs.storage().map(|m| m.expose_to_public()),
+            private_logs: self.private_logs.storage().map(|l| l.inner.log),
+            contract_class_logs_hashes: self.contract_class_logs_hashes.storage().map(|l| {
+                l.expose_to_public()
             }),
-            private_logs: self.private_logs.storage().map(|l: Scoped<PrivateLogData>| l.inner.log),
-            contract_class_logs_hashes: self.contract_class_logs_hashes.storage().map(
-                |l: ScopedLogHash| l.expose_to_public(),
-            ),
             contract_class_log_preimages_length: self.contract_class_log_preimages_length,
         }
     }
@@ -555,8 +541,8 @@ impl FixtureBuilder {
 
     pub fn to_avm_accumulated_data(self) -> AvmAccumulatedData {
         AvmAccumulatedData {
-            note_hashes: self.note_hashes.storage().map(|n: ScopedNoteHash| n.note_hash.value),
-            nullifiers: self.nullifiers.storage().map(|n: ScopedNullifier| n.nullifier.value),
+            note_hashes: self.note_hashes.storage().map(|n| n.note_hash.value),
+            nullifiers: self.nullifiers.storage().map(|n| n.nullifier.value),
             l2_to_l1_msgs: self.l2_to_l1_msgs.storage(),
             public_logs: self.public_logs.storage(),
             public_data_writes: self.public_data_writes.storage(),

--- a/noir-projects/noir-protocol-circuits/crates/types/src/utils/arrays.nr
+++ b/noir-projects/noir-protocol-circuits/crates/types/src/utils/arrays.nr
@@ -115,7 +115,7 @@ where
 
     /// Safety: This is safe because we have validated the array (see function doc above) and the emptiness
     /// of the element and non-emptiness of the previous element is checked below.
-    let length = unsafe { find_index_hint(array, |elem: T| is_empty(elem)) };
+    let length = unsafe { find_index_hint(array, |elem| is_empty(elem)) };
     if length != 0 {
         assert(!is_empty(array[length - 1]));
     }
@@ -254,7 +254,7 @@ fn test_array_length_invalid_arrays() {
 unconstrained fn find_index_greater_than_min() {
     let values = [10, 20, 30, 40];
     let min = 22;
-    let index = find_index_hint(values, |v: Field| min.lt(v));
+    let index = find_index_hint(values, |v| min.lt(v));
     assert_eq(index, 2);
 }
 
@@ -262,7 +262,7 @@ unconstrained fn find_index_greater_than_min() {
 unconstrained fn find_index_not_found() {
     let values = [10, 20, 30, 40];
     let min = 100;
-    let index = find_index_hint(values, |v: Field| min.lt(v));
+    let index = find_index_hint(values, |v| min.lt(v));
     assert_eq(index, 4);
 }
 

--- a/noir-projects/noir-protocol-circuits/crates/types/src/utils/arrays/assert_combined_array.nr
+++ b/noir-projects/noir-protocol-circuits/crates/types/src/utils/arrays/assert_combined_array.nr
@@ -19,7 +19,7 @@ where
         original_array_lt,
         original_array_gte,
         combined_array,
-        |from: T, to: T| from == to,
+        |from, to| from == to,
     )
 }
 
@@ -30,7 +30,7 @@ pub unconstrained fn combine_arrays<T, let N: u32>(
 where
     T: Empty + Eq,
 {
-    combine_and_transform_arrays(original_array_lt, original_array_gte, |from: T| from)
+    combine_and_transform_arrays(original_array_lt, original_array_gte, |from| from)
 }
 
 mod tests {

--- a/noir-projects/noir-protocol-circuits/crates/types/src/utils/arrays/assert_sorted_array.nr
+++ b/noir-projects/noir-protocol-circuits/crates/types/src/utils/arrays/assert_sorted_array.nr
@@ -35,7 +35,7 @@ mod tests {
         let original = [30, 20, 90, 50, 0, 0];
         let sorted = [20, 30, 50, 90, 0, 0];
         let indexes = [1, 0, 3, 2, 0, 0];
-        assert_sorted_array(original, sorted, indexes, |a: Field, b: Field| a.lt(b));
+        assert_sorted_array(original, sorted, indexes, |a, b| a.lt(b));
     }
 
     #[test]
@@ -43,7 +43,7 @@ mod tests {
         let original = [30, 20, 90, 50, 0, 0];
         let sorted = [90, 50, 30, 20, 0, 0];
         let indexes = [2, 3, 0, 1, 0, 0];
-        assert_sorted_array(original, sorted, indexes, |a: Field, b: Field| b.lt(a));
+        assert_sorted_array(original, sorted, indexes, |a, b| b.lt(a));
     }
 
     #[test]
@@ -51,7 +51,7 @@ mod tests {
         let original = [0, 0, 0, 0, 0, 0];
         let sorted = [0, 0, 0, 0, 0, 0];
         let indexes = [0, 0, 0, 0, 0, 0];
-        assert_sorted_array(original, sorted, indexes, |a: Field, b: Field| a.lt(b));
+        assert_sorted_array(original, sorted, indexes, |a, b| a.lt(b));
     }
 
     #[test(should_fail_with = "Values not sorted")]
@@ -59,7 +59,7 @@ mod tests {
         let original = [30, 20, 90, 50, 0, 0];
         let sorted = [20, 30, 90, 50, 0, 0];
         let indexes = [1, 0, 2, 3, 0, 0];
-        assert_sorted_array(original, sorted, indexes, |a: Field, b: Field| a.lt(b));
+        assert_sorted_array(original, sorted, indexes, |a, b| a.lt(b));
     }
 
     #[test(should_fail_with = "Values not sorted")]
@@ -67,7 +67,7 @@ mod tests {
         let original = [30, 20, 90, 50, 0, 0];
         let sorted = [20, 30, 50, 0, 0, 90];
         let indexes = [1, 0, 5, 2, 0, 0];
-        assert_sorted_array(original, sorted, indexes, |a: Field, b: Field| a.lt(b));
+        assert_sorted_array(original, sorted, indexes, |a, b| a.lt(b));
     }
 
     #[test(should_fail_with = "Invalid index")]
@@ -75,7 +75,7 @@ mod tests {
         let original = [30, 20, 90, 50, 0, 0];
         let sorted = [20, 30, 50, 90, 0, 0];
         let indexes = [1, 1, 2, 3, 0, 0];
-        assert_sorted_array(original, sorted, indexes, |a: Field, b: Field| a.lt(b));
+        assert_sorted_array(original, sorted, indexes, |a, b| a.lt(b));
     }
 
     #[test(should_fail_with = "Empty values must be padded to the right")]
@@ -83,7 +83,7 @@ mod tests {
         let original = [30, 20, 90, 0, 50, 0];
         let sorted = [20, 30, 90, 0, 0, 0];
         let indexes = [1, 0, 2, 0, 0, 0];
-        assert_sorted_array(original, sorted, indexes, |a: Field, b: Field| a.lt(b));
+        assert_sorted_array(original, sorted, indexes, |a, b| a.lt(b));
     }
 
     #[test(should_fail_with = "Empty values must not be mixed with sorted values")]
@@ -91,7 +91,7 @@ mod tests {
         let original = [30, 20, 90, 0, 0, 0];
         let sorted = [20, 30, 90, 0, 0, 10];
         let indexes = [1, 0, 2, 0, 0, 0];
-        assert_sorted_array(original, sorted, indexes, |a: Field, b: Field| a.lt(b));
+        assert_sorted_array(original, sorted, indexes, |a, b| a.lt(b));
     }
 }
 

--- a/noir-projects/noir-protocol-circuits/crates/types/src/utils/arrays/assert_split_sorted_transformed_value_arrays.nr
+++ b/noir-projects/noir-protocol-circuits/crates/types/src/utils/arrays/assert_split_sorted_transformed_value_arrays.nr
@@ -176,8 +176,7 @@ mod tests {
         }
 
         pub fn new() -> Self {
-            let transformed_value_array =
-                original_array.map(|item: TestTwoValues| combine_two_values(item));
+            let transformed_value_array = original_array.map(|item| combine_two_values(item));
 
             let split_counter = 15;
             let sorted_transformed_value_array_lt = [
@@ -218,8 +217,7 @@ mod tests {
         }
 
         pub fn new_desc() -> Self {
-            let transformed_value_array =
-                original_array.map(|item: TestTwoValues| combine_two_values(item));
+            let transformed_value_array = original_array.map(|item| combine_two_values(item));
 
             let split_counter = 15;
             let sorted_transformed_value_array_lt = [

--- a/noir-projects/noir-protocol-circuits/crates/types/src/utils/arrays/assert_split_transformed_value_arrays.nr
+++ b/noir-projects/noir-protocol-circuits/crates/types/src/utils/arrays/assert_split_transformed_value_arrays.nr
@@ -61,7 +61,7 @@ where
 {
     /// Safety: The value is constrained by `assert_split_transformed_value_arrays_with_hint`.
     let num_non_revertibles =
-        unsafe { find_index_hint(sorted_array, |n: T| n.counter() >= split_counter) };
+        unsafe { find_index_hint(sorted_array, |n| n.counter() >= split_counter) };
 
     assert_split_transformed_value_arrays_with_hint(
         sorted_array,

--- a/noir-projects/noir-protocol-circuits/crates/types/src/utils/arrays/get_sorted_result.nr
+++ b/noir-projects/noir-protocol-circuits/crates/types/src/utils/arrays/get_sorted_result.nr
@@ -12,8 +12,8 @@ pub unconstrained fn get_sorted_result<let N: u32, T>(
 ) -> SortedResult<T, N> {
     let sorted = get_sorted_tuple(values, ordering);
 
-    let sorted_array = sorted.map(|t: SortedTuple<T>| t.elem);
-    let original_index_hints = sorted.map(|t: SortedTuple<T>| t.original_index);
+    let sorted_array = sorted.map(|t| t.elem);
+    let original_index_hints = sorted.map(|t| t.original_index);
     let mut sorted_index_hints = [0; N];
     for i in 0..N {
         let original_index = sorted[i].original_index;
@@ -26,7 +26,7 @@ pub unconstrained fn get_sorted_result<let N: u32, T>(
 #[test]
 unconstrained fn get_sorted_hints_asc_non_padded() {
     let values = [40, 60, 20, 50];
-    let res = get_sorted_result(values, |a: u32, b: u32| a < b);
+    let res = get_sorted_result(values, |a, b| a < b);
     assert_eq(res.sorted_array, [20, 40, 50, 60]);
     assert_eq(res.sorted_index_hints, [1, 3, 0, 2]);
     assert_eq(res.original_index_hints, [2, 0, 3, 1]);
@@ -35,7 +35,7 @@ unconstrained fn get_sorted_hints_asc_non_padded() {
 #[test]
 unconstrained fn get_sorted_hints_desc_non_padded() {
     let values = [40, 20, 60, 50];
-    let res = get_sorted_result(values, |a: u32, b: u32| b < a);
+    let res = get_sorted_result(values, |a, b| b < a);
     assert_eq(res.sorted_array, [60, 50, 40, 20]);
     assert_eq(res.sorted_index_hints, [2, 3, 0, 1]);
 }
@@ -43,7 +43,7 @@ unconstrained fn get_sorted_hints_desc_non_padded() {
 #[test]
 unconstrained fn get_sorted_hints_asc_padded() {
     let values = [40, 60, 20, 50, 0, 0];
-    let res = get_sorted_result(values, |a: u32, b: u32| (a != 0) & ((b == 0) | (a < b)));
+    let res = get_sorted_result(values, |a, b| (a != 0) & ((b == 0) | (a < b)));
     assert_eq(res.sorted_array, [20, 40, 50, 60, 0, 0]);
     assert_eq(res.sorted_index_hints, [1, 3, 0, 2, 4, 5]);
     assert_eq(res.original_index_hints, [2, 0, 3, 1, 4, 5]);
@@ -52,7 +52,7 @@ unconstrained fn get_sorted_hints_asc_padded() {
 #[test]
 unconstrained fn get_sorted_hints_desc_padded() {
     let values = [40, 60, 20, 50, 0, 0];
-    let res = get_sorted_result(values, |a: u32, b: u32| (a != 0) & ((b == 0) | (b < a)));
+    let res = get_sorted_result(values, |a, b| (a != 0) & ((b == 0) | (b < a)));
     assert_eq(res.sorted_array, [60, 50, 40, 20, 0, 0]);
     assert_eq(res.sorted_index_hints, [2, 0, 3, 1, 4, 5]);
     assert_eq(res.original_index_hints, [1, 3, 0, 2, 4, 5]);

--- a/noir-projects/noir-protocol-circuits/crates/types/src/utils/arrays/get_sorted_tuple.nr
+++ b/noir-projects/noir-protocol-circuits/crates/types/src/utils/arrays/get_sorted_tuple.nr
@@ -13,10 +13,7 @@ pub unconstrained fn get_sorted_tuple<T, let N: u32, Env>(
     for i in 0..N {
         tuples[i] = SortedTuple { elem: array[i], original_index: i };
     }
-    sort_by(
-        tuples,
-        |a: SortedTuple<T>, b: SortedTuple<T>| ordering(a.elem, b.elem),
-    )
+    sort_by(tuples, |a, b| ordering(a.elem, b.elem))
 }
 
 #[test]
@@ -28,7 +25,7 @@ unconstrained fn get_sorted_tuple_asc() {
         SortedTuple { elem: 5, original_index: 3 },
         SortedTuple { elem: 9, original_index: 2 },
     ];
-    let sorted = get_sorted_tuple(original, |a: u64, b: u64| a < b);
+    let sorted = get_sorted_tuple(original, |a, b| a < b);
     for i in 0..4 {
         assert_eq(sorted[i].elem, expected[i].elem);
         assert_eq(sorted[i].original_index, expected[i].original_index);

--- a/noir-projects/noir-protocol-circuits/crates/types/src/utils/arrays/sort_by_counter.nr
+++ b/noir-projects/noir-protocol-circuits/crates/types/src/utils/arrays/sort_by_counter.nr
@@ -40,13 +40,13 @@ mod tests {
 
     unconstrained fn asc_values_to_equal<let N: u32>(values: [u32; N], expected: [u32; N]) {
         let items = values.map(|value| TestValue { value: value as Field, counter: value });
-        let sorted = sort_by_counter_asc(items).map(|item: TestValue| item.counter);
+        let sorted = sort_by_counter_asc(items).map(|item| item.counter);
         assert_eq(sorted, expected);
     }
 
     unconstrained fn desc_values_to_equal<let N: u32>(values: [u32; N], expected: [u32; N]) {
         let items = values.map(|value| TestValue { value: value as Field, counter: value });
-        let sorted = sort_by_counter_desc(items).map(|item: TestValue| item.counter);
+        let sorted = sort_by_counter_desc(items).map(|item| item.counter);
         assert_eq(sorted, expected);
     }
 


### PR DESCRIPTION
My guess is that those annotations were added because they were previously required by the language. Now that they are not we can remove them. In most cases the type of the parameter is clear (like `note_hashes.map(|n| ...)`, it's clear that `n` is the type in the collection) and LSP will show the type anyway. Some code ends up being a bit shorter. But I mainly did this PR to check that it actually works, and for readers to know that this is now possible (in case types were added because that's how it used to be).