### PR TITLE
fix: txe block headers

### DIFF
--- a/noir-projects/aztec-nr/aztec/src/oracle/block_header.nr
+++ b/noir-projects/aztec-nr/aztec/src/oracle/block_header.nr
@@ -94,12 +94,12 @@ mod test {
         let current_header = env.private().historical_header;
 
         let target_block_number = 3;
-        let bad_header = get_block_header_at_internal(target_block_number - 1);
+        let bad_header = get_block_header_at_internal(target_block_number);
 
         // We pass in a different block number than the header received
         constrain_get_block_header_at_internal(
             bad_header,
-            2,
+            target_block_number - 1,
             current_header.global_variables.block_number as u32 - 1,
             current_header.last_archive.root,
         );

--- a/yarn-project/txe/src/oracle/txe_oracle.ts
+++ b/yarn-project/txe/src/oracle/txe_oracle.ts
@@ -501,6 +501,8 @@ export class TXE implements TypedOracle {
       Fr.ZERO,
     );
 
+    header.globalVariables.blockNumber = new Fr(blockNumber);
+
     return header;
   }
 
@@ -739,6 +741,8 @@ export class TXE implements TypedOracle {
       Fr.ZERO,
       Fr.ZERO,
     );
+
+    header.globalVariables.blockNumber = new Fr(blockNumber);
 
     l2Block.header = header;
 


### PR DESCRIPTION
This fixes a bug in which block headers were not actually being correctly used (set or received). This was found when observing strange behavior when doing txe inclusion proof tests.