### PR TITLE
chore: remove stale zk constants and methods

### DIFF
--- a/barretenberg/cpp/src/barretenberg/eccvm/eccvm_flavor.hpp
+++ b/barretenberg/cpp/src/barretenberg/eccvm/eccvm_flavor.hpp
@@ -60,8 +60,6 @@ class ECCVMFlavor {
     static constexpr size_t NUM_SHIFTED_ENTITIES = 26;
     // The number of entities in DerivedWitnessEntities that are not going to be shifted.
     static constexpr size_t NUM_DERIVED_WITNESS_ENTITIES_NON_SHIFTED = 1;
-    // The total number of witnesses including shifts and derived entities.
-    static constexpr size_t NUM_ALL_WITNESS_ENTITIES = NUM_WITNESS_ENTITIES + NUM_SHIFTED_ENTITIES;
     // A container to be fed to ShpleminiVerifier to avoid redundant scalar muls, the first number is the index of the
     // first witness to be shifted.
     static constexpr RepeatedCommitmentsData REPEATED_COMMITMENTS =

--- a/barretenberg/cpp/src/barretenberg/flavor/flavor.hpp
+++ b/barretenberg/cpp/src/barretenberg/flavor/flavor.hpp
@@ -242,15 +242,11 @@ auto get_unshifted_then_shifted(const auto& all_entities)
  * @details The "partial length" of a relation is 1 + the degree of the relation, where any challenges used in the
  * relation are as constants, not as variables..
  */
-template <typename Tuple, bool ZK = false> constexpr size_t compute_max_partial_relation_length()
+template <typename Tuple> constexpr size_t compute_max_partial_relation_length()
 {
     constexpr auto seq = std::make_index_sequence<std::tuple_size_v<Tuple>>();
     return []<std::size_t... Is>(std::index_sequence<Is...>) {
-        if constexpr (ZK) {
-            return std::max({ std::tuple_element_t<Is, Tuple>::ZK_RELATION_LENGTH... });
-        } else {
-            return std::max({ std::tuple_element_t<Is, Tuple>::RELATION_LENGTH... });
-        }
+        return std::max({ std::tuple_element_t<Is, Tuple>::RELATION_LENGTH... });
     }(seq);
 }
 
@@ -259,15 +255,11 @@ template <typename Tuple, bool ZK = false> constexpr size_t compute_max_partial_
  * @details The "total length" of a relation is 1 + the degree of the relation, where any challenges used in the
  * relation are regarded as variables.
  */
-template <typename Tuple, bool ZK = false> constexpr size_t compute_max_total_relation_length()
+template <typename Tuple> constexpr size_t compute_max_total_relation_length()
 {
     constexpr auto seq = std::make_index_sequence<std::tuple_size_v<Tuple>>();
     return []<std::size_t... Is>(std::index_sequence<Is...>) {
-        if constexpr (ZK) {
-            return std::max({ std::tuple_element_t<Is, Tuple>::ZK_TOTAL_RELATION_LENGTH... });
-        } else {
-            return std::max({ std::tuple_element_t<Is, Tuple>::TOTAL_RELATION_LENGTH... });
-        }
+        return std::max({ std::tuple_element_t<Is, Tuple>::TOTAL_RELATION_LENGTH... });
     }(seq);
 }
 

--- a/barretenberg/cpp/src/barretenberg/relations/auxiliary_relation.hpp
+++ b/barretenberg/cpp/src/barretenberg/relations/auxiliary_relation.hpp
@@ -39,21 +39,6 @@ template <typename FF_> class AuxiliaryRelationImpl {
         6, // RAM consistency sub-relation 2
         6  // RAM consistency sub-relation 3
     };
-    /**
-     * @brief For ZK-Flavors: The degrees of subrelations considered as polynomials only in witness polynomials,
-     * i.e. all selectors and public polynomials are treated as constants.
-     *
-     */
-    static constexpr std::array<size_t, 6> SUBRELATION_WITNESS_DEGREES{
-        2, // auxiliary sub-relation;
-        2, // ROM consistency sub-relation 1: adjacent values match if adjacent indices match and next access is a read
-           // operation
-        2, // ROM consistency sub-relation 2: index is monotonously increasing
-        3, // RAM consistency sub-relation 1: adjacent values match if adjacent indices match and next access is a read
-           // operation
-        2, // RAM consistency sub-relation 2: index is monotonously increasing
-        2  // RAM consistency sub-relation 3: next gate access type is boolean
-    };
 
     static constexpr std::array<size_t, 6> TOTAL_LENGTH_ADJUSTMENTS{
         1, // auxiliary sub-relation

--- a/barretenberg/cpp/src/barretenberg/relations/databus_lookup_relation.hpp
+++ b/barretenberg/cpp/src/barretenberg/relations/databus_lookup_relation.hpp
@@ -62,23 +62,6 @@ template <typename FF_> class DatabusLookupRelationImpl {
         LOOKUP_SUBREL_LENGTH   // log-derivative lookup argument subrelation (bus_idx 2)
     };
 
-    static constexpr size_t INVERSE_SUBREL_WITNESS_DEGREE = 4; // witness degree of inverse correctness subrelation
-    static constexpr size_t LOOKUP_SUBREL_WITNESS_DEGREE = 4;  // witness degree of log-deriv lookup subrelation
-
-    /**
-     * @brief For ZK-Flavors: Upper bound on the degrees of subrelations considered as polynomials only in witness
-     * polynomials, i.e. all selectors and public polynomials are treated as constants. The subrelation witness degree
-     * does not exceed the subrelation partial degree, which is given by LENGTH - 1 in this case.
-     */
-    static constexpr std::array<size_t, NUM_BUS_COLUMNS * 2> SUBRELATION_WITNESS_DEGREES{
-        INVERSE_SUBREL_WITNESS_DEGREE, // inverse polynomial correctness subrelation (bus_idx 0)
-        LOOKUP_SUBREL_WITNESS_DEGREE,  // log-derivative lookup argument subrelation (bus_idx 0)
-        INVERSE_SUBREL_WITNESS_DEGREE, // inverse polynomial correctness subrelation (bus_idx 1)
-        LOOKUP_SUBREL_WITNESS_DEGREE,  // log-derivative lookup argument subrelation (bus_idx 1)
-        INVERSE_SUBREL_WITNESS_DEGREE, // inverse polynomial correctness subrelation (bus_idx 2)
-        LOOKUP_SUBREL_WITNESS_DEGREE   // log-derivative lookup argument subrelation (bus_idx 2)
-    };
-
     static constexpr bool INVERSE_SUBREL_LIN_INDEPENDENT = true; // to be satisfied independently at each row
     static constexpr bool LOOKUP_SUBREL_LIN_INDEPENDENT = false; // to be satisfied as a sum across all rows
 

--- a/barretenberg/cpp/src/barretenberg/relations/delta_range_constraint_relation.hpp
+++ b/barretenberg/cpp/src/barretenberg/relations/delta_range_constraint_relation.hpp
@@ -13,17 +13,6 @@ template <typename FF_> class DeltaRangeConstraintRelationImpl {
         6, // range constrain sub-relation 3
         6  // range constrain sub-relation 4
     };
-    /**
-     * @brief For ZK-Flavors: The degrees of subrelations considered as polynomials only in witness polynomials,
-     * i.e. all selectors and public polynomials are treated as constants.
-     *
-     */
-    static constexpr std::array<size_t, 4> SUBRELATION_WITNESS_DEGREES{
-        3, // range constrain sub-relation 1
-        3, // range constrain sub-relation 2
-        3, // range constrain sub-relation 3
-        3  // range constrain sub-relation 4
-    };
 
     /**
      * @brief Returns true if the contribution from all subrelations for the provided inputs is identically zero

--- a/barretenberg/cpp/src/barretenberg/relations/ecc_op_queue_relation.hpp
+++ b/barretenberg/cpp/src/barretenberg/relations/ecc_op_queue_relation.hpp
@@ -17,21 +17,6 @@ template <typename FF_> class EccOpQueueRelationImpl {
         3, // op-queue-wire vanishes sub-relation 3
         3  // op-queue-wire vanishes sub-relation 4
     };
-    /**
-     * @brief For ZK-Flavors: The degrees of subrelations considered as polynomials only in witness polynomials,
-     * i.e. all selectors and public polynomials are treated as constants.
-     *
-     */
-    static constexpr std::array<size_t, 8> SUBRELATION_WITNESS_DEGREES{
-        1, // wire - op-queue-wire consistency sub-relation 1
-        1, // wire - op-queue-wire consistency sub-relation 2
-        1, // wire - op-queue-wire consistency sub-relation 3
-        1, // wire - op-queue-wire consistency sub-relation 4
-        1, // op-queue-wire vanishes sub-relation 1
-        1, // op-queue-wire vanishes sub-relation 2
-        1, // op-queue-wire vanishes sub-relation 3
-        1  // op-queue-wire vanishes sub-relation 4
-    };
 
     template <typename AllEntities> inline static bool skip([[maybe_unused]] const AllEntities& in)
     {

--- a/barretenberg/cpp/src/barretenberg/relations/ecc_vm/ecc_bools_relation.hpp
+++ b/barretenberg/cpp/src/barretenberg/relations/ecc_vm/ecc_bools_relation.hpp
@@ -20,18 +20,6 @@ template <typename FF_> class ECCVMBoolsRelationImpl {
     static constexpr std::array<size_t, 19> SUBRELATION_PARTIAL_LENGTHS{
         3, 3, 3, 3, 3, 3, 3, 3, 3, 3, 3, 3, 3, 3, 3, 3, 3, 3, 3,
     };
-    /**
-     * @brief For ZK-Flavors: Upper bound on the degrees of subrelations considered as polynomials only in witness
-polynomials,
-     * i.e. all selectors and public polynomials are treated as constants. The subrelation witness degree does not
-     * exceed the subrelation partial degree given by SUBRELATION_PARTIAL_LENGTH - 1.
-     */
-    static constexpr std::array<size_t, 19> SUBRELATION_WITNESS_DEGREES{
-        2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2,
-    };
-
-    // Max among {SUBRELATION_PARTIAL_LENGTH + SUBRELATION_WITNESS_DEGREE}
-    static constexpr size_t ZK_RELATION_LENGTH = 5;
 
     template <typename ContainerOverSubrelations, typename AllEntities, typename Parameters>
     static void accumulate(ContainerOverSubrelations& accumulator,

--- a/barretenberg/cpp/src/barretenberg/relations/ecc_vm/ecc_lookup_relation.hpp
+++ b/barretenberg/cpp/src/barretenberg/relations/ecc_vm/ecc_lookup_relation.hpp
@@ -20,19 +20,6 @@ template <typename FF_> class ECCVMLookupRelationImpl {
         LENGTH, // grand product construction sub-relation
         LENGTH  // left-shiftable polynomial sub-relation
     };
-    /**
-     * @brief For ZK-Flavors: Upper bound on the degrees of subrelations considered as polynomials only in witness
-polynomials,
-     * i.e. all selectors and public polynomials are treated as constants. The subrelation witness degree does not
-     * exceed the subrelation partial degree given by LENGTH - 1.
-     */
-    static constexpr std::array<size_t, 2> SUBRELATION_WITNESS_DEGREES{
-        LENGTH - 1, // grand product construction sub-relation
-        LENGTH - 1  // left-shiftable polynomial sub-relation
-    };
-
-    // Max among {SUBRELATION_PARTIAL_LENGTH + SUBRELATION_WITNESS_DEGREE}
-    static constexpr size_t ZK_RELATION_LENGTH = 17;
 
     static constexpr std::array<bool, 2> SUBRELATION_LINEARLY_INDEPENDENT = { true, false };
 

--- a/barretenberg/cpp/src/barretenberg/relations/ecc_vm/ecc_msm_relation.hpp
+++ b/barretenberg/cpp/src/barretenberg/relations/ecc_vm/ecc_msm_relation.hpp
@@ -40,16 +40,6 @@ template <typename FF_> class ECCVMMSMRelationImpl {
     static constexpr std::array<size_t, 36> SUBRELATION_PARTIAL_LENGTHS{ 8, 8, 8, 8, 8, 8, 8, 8, 8, 8, 8, 8,
                                                                          8, 8, 8, 8, 8, 8, 8, 8, 8, 8, 8, 8,
                                                                          8, 8, 8, 8, 8, 8, 8, 8, 8, 8, 8, 8 };
-    /**
-     * @brief Upper bound on the degrees of subrelations considered as polynomials only in witness polynomials,
-     * i.e. all selectors and public polynomials are treated as constants. The subrelation witness degree does not
-     * exceed the subrelation partial degree given by SUBRELATION_PARTIAL_LENGTH - 1.
-     */
-    static constexpr std::array<size_t, 36> SUBRELATION_WITNESS_DEGREES{ 7, 7, 7, 7, 7, 7, 7, 7, 7, 7, 7, 7,
-                                                                         7, 7, 7, 7, 7, 7, 7, 7, 7, 7, 7, 7,
-                                                                         7, 7, 7, 7, 7, 7, 7, 7, 7, 7, 7, 7 };
-    // Max among {SUBRELATION_PARTIAL_LENGTH + SUBRELATION_WITNESS_DEGREE}
-    static constexpr size_t ZK_RELATION_LENGTH = 15;
 
     template <typename ContainerOverSubrelations, typename AllEntities, typename Parameters>
     static void accumulate(ContainerOverSubrelations& accumulator,

--- a/barretenberg/cpp/src/barretenberg/relations/ecc_vm/ecc_point_table_relation.hpp
+++ b/barretenberg/cpp/src/barretenberg/relations/ecc_vm/ecc_point_table_relation.hpp
@@ -19,16 +19,8 @@ namespace bb {
 template <typename FF_> class ECCVMPointTableRelationImpl {
   public:
     using FF = FF_;
-    static constexpr size_t ZK_RELATION_LENGTH = 11;
 
     static constexpr std::array<size_t, 6> SUBRELATION_PARTIAL_LENGTHS{ 6, 6, 6, 6, 6, 6 };
-    /**
-     * @brief For ZK-Flavors: Upper bound on the degrees of subrelations considered as polynomials only in witness
-polynomials,
-     * i.e. all selectors and public polynomials are treated as constants. The subrelation witness degree does not
-     * exceed the subrelation partial degree given by SUBRELATION_PARTIAL_LENGTH - 1.
-     */
-    static constexpr std::array<size_t, 6> SUBRELATION_WITNESS_DEGREES{ 5, 5, 5, 5, 5, 5 };
 
     template <typename ContainerOverSubrelations, typename AllEntities, typename Parameters>
     static void accumulate(ContainerOverSubrelations& accumulator,

--- a/barretenberg/cpp/src/barretenberg/relations/ecc_vm/ecc_set_relation.hpp
+++ b/barretenberg/cpp/src/barretenberg/relations/ecc_vm/ecc_set_relation.hpp
@@ -16,19 +16,6 @@ template <typename FF_> class ECCVMSetRelationImpl {
         22, // grand product construction sub-relation
         3   // left-shiftable polynomial sub-relation
     };
-    /**
-     * @brief For ZK-Flavors: Upper bound on the degrees of subrelations considered as polynomials only in witness
-polynomials,
-     * i.e. all selectors and public polynomials are treated as constants. The subrelation witness degree does not
-     * exceed the subrelation partial degree given by SUBRELATION_PARTIAL_LENGTH - 1.
-     */
-    static constexpr std::array<size_t, 2> SUBRELATION_WITNESS_DEGREES{
-        21, // grand product construction sub-relation
-        1   // left-shiftable polynomial sub-relation
-    };
-
-    // Max among {SUBRELATION_PARTIAL_LENGTH + SUBRELATION_WITNESS_DEGREE}
-    static constexpr size_t ZK_RELATION_LENGTH = 43;
 
     template <typename Accumulator> static Accumulator convert_to_wnaf(const auto& s0, const auto& s1)
     {

--- a/barretenberg/cpp/src/barretenberg/relations/ecc_vm/ecc_transcript_relation.hpp
+++ b/barretenberg/cpp/src/barretenberg/relations/ecc_vm/ecc_transcript_relation.hpp
@@ -33,18 +33,7 @@ template <typename FF_> class ECCVMTranscriptRelationImpl {
     static constexpr std::array<size_t, 25> SUBRELATION_PARTIAL_LENGTHS{
         8, 8, 8, 8, 8, 8, 8, 8, 8, 8, 8, 8, 8, 8, 8, 8, 8, 8, 8, 8, 8, 8, 8, 8, 8,
     };
-    /**
-     * @brief Upper bound on the degrees of subrelations considered as polynomials only in
-witness polynomials,
-     * i.e. all selectors and public polynomials are treated as constants. The subrelation witness degree does
-not
-     * exceed the subrelation partial degree given by SUBRELATION_PARTIAL_LENGTH - 1.
-     */
-    static constexpr std::array<size_t, 25> SUBRELATION_WITNESS_DEGREES{
-        7, 7, 7, 7, 7, 7, 7, 7, 7, 7, 7, 7, 7, 7, 7, 7, 7, 7, 7, 7, 7, 7, 7, 7, 7,
-    };
-    // Max among {SUBRELATION_PARTIAL_LENGTH + SUBRELATION_WITNESS_DEGREE}
-    static constexpr size_t ZK_RELATION_LENGTH = 15;
+
     template <typename ContainerOverSubrelations, typename AllEntities, typename Parameters>
     static void accumulate(ContainerOverSubrelations& accumulator,
                            const AllEntities& in,

--- a/barretenberg/cpp/src/barretenberg/relations/ecc_vm/ecc_wnaf_relation.hpp
+++ b/barretenberg/cpp/src/barretenberg/relations/ecc_vm/ecc_wnaf_relation.hpp
@@ -38,18 +38,6 @@ template <typename FF_> class ECCVMWnafRelationImpl {
     static constexpr std::array<size_t, 21> SUBRELATION_PARTIAL_LENGTHS{
         5, 5, 5, 5, 5, 5, 5, 5, 5, 5, 5, 5, 5, 5, 5, 5, 5, 5, 5, 5, 5,
     };
-    /**
-     * @brief For ZK-Flavors: Upper bound on the degrees of subrelations considered as polynomials only in witness
-polynomials,
-     * i.e. all selectors and public polynomials are treated as constants. The subrelation witness degree does not
-     * exceed the subrelation partial degree given by SUBRELATION_PARTIAL_LENGTH - 1.
-     */
-    static constexpr std::array<size_t, 21> SUBRELATION_WITNESS_DEGREES{
-        4, 4, 4, 4, 4, 4, 4, 4, 4, 4, 4, 4, 4, 4, 4, 4, 4, 4, 4, 4, 4,
-    };
-
-    // Max among {SUBRELATION_PARTIAL_LENGTH + SUBRELATION_WITNESS_DEGREE}
-    static constexpr size_t ZK_RELATION_LENGTH = 9;
 
     template <typename ContainerOverSubrelations, typename AllEntities, typename Parameters>
     static void accumulate(ContainerOverSubrelations& accumulator,

--- a/barretenberg/cpp/src/barretenberg/relations/elliptic_relation.hpp
+++ b/barretenberg/cpp/src/barretenberg/relations/elliptic_relation.hpp
@@ -13,15 +13,6 @@ template <typename FF_> class EllipticRelationImpl {
         6, // x-coordinate sub-relation
         6, // y-coordinate sub-relation
     };
-    /**
-     * @brief For ZK-Flavors: The degrees of subrelations considered as polynomials only in witness polynomials,
-     * i.e. all selectors and public polynomials are treated as constants.
-     *
-     */
-    static constexpr std::array<size_t, 2> SUBRELATION_WITNESS_DEGREES{
-        3, // x-coordinate sub-relation
-        3, // y-coordinate sub-relation (because of point doubling)
-    };
 
     /**
      * @brief Returns true if the contribution from all subrelations for the provided inputs is identically zero

--- a/barretenberg/cpp/src/barretenberg/relations/logderiv_lookup_relation.hpp
+++ b/barretenberg/cpp/src/barretenberg/relations/logderiv_lookup_relation.hpp
@@ -22,15 +22,6 @@ template <typename FF_> class LogDerivLookupRelationImpl {
         LENGTH, // inverse construction sub-relation
         LENGTH  // log derivative lookup argument sub-relation
     };
-    /**
-     * @brief For ZK-Flavors: The degrees of subrelations considered as polynomials only in witness polynomials,
-     * i.e. all selectors and public polynomials are treated as constants.
-     *
-     */
-    static constexpr std::array<size_t, 2> SUBRELATION_WITNESS_DEGREES{
-        2, // inverse construction sub-relation
-        3, // log derivative lookup argument sub-relation
-    };
 
     // Note: the required correction for the second sub-relation is technically +1 but the two corrections must agree
     // due to the way the relation algebra is written so both are set to +2.

--- a/barretenberg/cpp/src/barretenberg/relations/permutation_relation.hpp
+++ b/barretenberg/cpp/src/barretenberg/relations/permutation_relation.hpp
@@ -36,16 +36,6 @@ template <typename FF_> class UltraPermutationRelationImpl {
     };
 
     /**
-     * @brief For ZK-Flavors: The degrees of subrelations considered as polynomials only in witness polynomials,
-     * i.e. all selectors and public polynomials are treated as constants.
-     *
-     */
-    static constexpr std::array<size_t, 2> SUBRELATION_WITNESS_DEGREES{
-        5, // grand product construction sub-relation
-        1  // left-shiftable polynomial sub-relation
-    };
-
-    /**
      * @brief Returns true if the contribution from all subrelations for the provided inputs is identically zero
      *
      */

--- a/barretenberg/cpp/src/barretenberg/relations/poseidon2_external_relation.hpp
+++ b/barretenberg/cpp/src/barretenberg/relations/poseidon2_external_relation.hpp
@@ -12,17 +12,6 @@ template <typename FF_> class Poseidon2ExternalRelationImpl {
         7, // external poseidon2 round sub-relation for third value
         7, // external poseidon2 round sub-relation for fourth value
     };
-    /**
-     * @brief For ZK-Flavors: The degrees of subrelations considered as polynomials only in witness polynomials,
-     * i.e. all selectors and public polynomials are treated as constants.
-     *
-     */
-    static constexpr std::array<size_t, 4> SUBRELATION_WITNESS_DEGREES{
-        5, // external poseidon2 round sub-relation for first value
-        5, // external poseidon2 round sub-relation for second value
-        5, // external poseidon2 round sub-relation for third value
-        5, // external poseidon2 round sub-relation for fourth value
-    };
 
     /**
      * @brief Returns true if the contribution from all subrelations for the provided inputs is identically zero

--- a/barretenberg/cpp/src/barretenberg/relations/poseidon2_internal_relation.hpp
+++ b/barretenberg/cpp/src/barretenberg/relations/poseidon2_internal_relation.hpp
@@ -14,17 +14,6 @@ template <typename FF_> class Poseidon2InternalRelationImpl {
         7, // internal poseidon2 round sub-relation for third value
         7, // internal poseidon2 round sub-relation for fourth value
     };
-    /**
-     * @brief For ZK-Flavors: The degrees of subrelations considered as polynomials only in witness polynomials,
-     * i.e. all selectors and public polynomials are treated as constants.
-     *
-     */
-    static constexpr std::array<size_t, 4> SUBRELATION_WITNESS_DEGREES{
-        5, // external poseidon2 round sub-relation for first value
-        5, // external poseidon2 round sub-relation for second value
-        5, // external poseidon2 round sub-relation for third value
-        5, // external poseidon2 round sub-relation for fourth value
-    };
 
     /**
      * @brief Returns true if the contribution from all subrelations for the provided inputs is identically zero

--- a/barretenberg/cpp/src/barretenberg/relations/relation_types.hpp
+++ b/barretenberg/cpp/src/barretenberg/relations/relation_types.hpp
@@ -139,9 +139,6 @@ template <typename RelationImpl> class Relation : public RelationImpl {
 
     static constexpr std::array<size_t, RelationImpl::SUBRELATION_PARTIAL_LENGTHS.size()> SUBRELATION_TOTAL_LENGTHS =
         compute_total_subrelation_lengths<RelationImpl>();
-    // Compute the subrelation partial lengths adjusted to ZK
-    static constexpr std::array<size_t, RelationImpl::SUBRELATION_PARTIAL_LENGTHS.size()> ZK_PARTIAL_LENGTHS =
-        compute_zk_partial_subrelation_lengths<RelationImpl>();
 
     static constexpr size_t RELATION_LENGTH = *std::max_element(RelationImpl::SUBRELATION_PARTIAL_LENGTHS.begin(),
                                                                 RelationImpl::SUBRELATION_PARTIAL_LENGTHS.end());

--- a/barretenberg/cpp/src/barretenberg/relations/relation_types.hpp
+++ b/barretenberg/cpp/src/barretenberg/relations/relation_types.hpp
@@ -30,10 +30,6 @@ concept HasSubrelationLinearlyIndependentMember = requires(T) {
 
 template <typename T>
 concept HasParameterLengthAdjustmentsMember = requires { T::TOTAL_LENGTH_ADJUSTMENTS; };
-// The concept needed to adjust the sumcheck univariate lengths in the case of ZK Flavors and to avoid adding redundant
-// constants to the relations that are not used by ZK flavors
-template <typename T>
-concept HasWitnessDegrees = requires { T::SUBRELATION_WITNESS_DEGREES; };
 
 /**
  * @brief Check whether a given subrelation is linearly independent from the other subrelations.
@@ -64,27 +60,6 @@ consteval std::array<size_t, RelationImpl::SUBRELATION_PARTIAL_LENGTHS.size()> c
         std::array<size_t, NUM_SUBRELATIONS> result;
         for (size_t idx = 0; idx < NUM_SUBRELATIONS; idx++) {
             result[idx] = RelationImpl::SUBRELATION_PARTIAL_LENGTHS[idx] + RelationImpl::TOTAL_LENGTH_ADJUSTMENTS[idx];
-        }
-        return result;
-    } else {
-        return RelationImpl::SUBRELATION_PARTIAL_LENGTHS;
-    }
-};
-/**
- * @brief This metod adjusts the subrelation partial lengths to ZK Flavors.
- *
- * @tparam RelationImpl
- * @return consteval
- */
-template <typename RelationImpl>
-consteval std::array<size_t, RelationImpl::SUBRELATION_PARTIAL_LENGTHS.size()> compute_zk_partial_subrelation_lengths()
-{
-    if constexpr (HasWitnessDegrees<RelationImpl>) {
-        constexpr size_t NUM_SUBRELATIONS = RelationImpl::SUBRELATION_PARTIAL_LENGTHS.size();
-        std::array<size_t, NUM_SUBRELATIONS> result;
-        for (size_t idx = 0; idx < NUM_SUBRELATIONS; idx++) {
-            result[idx] =
-                RelationImpl::SUBRELATION_PARTIAL_LENGTHS[idx] + RelationImpl::SUBRELATION_WITNESS_DEGREES[idx];
         }
         return result;
     } else {
@@ -173,9 +148,6 @@ template <typename RelationImpl> class Relation : public RelationImpl {
 
     static constexpr size_t TOTAL_RELATION_LENGTH =
         *std::max_element(SUBRELATION_TOTAL_LENGTHS.begin(), SUBRELATION_TOTAL_LENGTHS.end());
-    // Determine the maximum subrelation length in the case if ZK Flavors
-    static constexpr size_t ZK_TOTAL_RELATION_LENGTH =
-        *std::max_element(ZK_PARTIAL_LENGTHS.begin(), ZK_PARTIAL_LENGTHS.end());
 
     template <size_t NUM_KEYS>
     using ProtogalaxyTupleOfUnivariatesOverSubrelationsNoOptimisticSkipping =
@@ -188,9 +160,6 @@ template <typename RelationImpl> class Relation : public RelationImpl {
                                                  NUM_KEYS - 1>;
     using SumcheckTupleOfUnivariatesOverSubrelations =
         TupleOfUnivariates<FF, RelationImpl::SUBRELATION_PARTIAL_LENGTHS>;
-    // The container constructor for sumcheck univariates corresponding to each subrelation in ZK Flavor's relations
-    using ZKSumcheckTupleOfUnivariatesOverSubrelations =
-        TupleOfUnivariates<FF, compute_zk_partial_subrelation_lengths<RelationImpl>()>;
 
     using SumcheckArrayOfValuesOverSubrelations = ArrayOfValues<FF, RelationImpl::SUBRELATION_PARTIAL_LENGTHS>;
 

--- a/barretenberg/cpp/src/barretenberg/relations/translator_vm/translator_decomposition_relation.hpp
+++ b/barretenberg/cpp/src/barretenberg/relations/translator_vm/translator_decomposition_relation.hpp
@@ -61,65 +61,7 @@ template <typename FF_> class TranslatorDecompositionRelationImpl {
         3, // decomposition of z1 into 2 limbs subrelation
         3  // decomposition of z2 into 2 limbs subrelation
     };
-    /**
-     * @brief Upper bound on the degrees of subrelations considered as polynomials only in witness
-polynomials,
-     * i.e. all selectors and public polynomials are treated as constants. The subrelation witness degree does not
-     * exceed the subrelation partial degree given by SUBRELATION_PARTIAL_LENGTH - 1.
-     */
-    static constexpr std::array<size_t, 48> SUBRELATION_WITNESS_DEGREES{
-        2, // decomposition of P.x limb 0 into microlimbs subrelation
-        2, // decomposition of P.x limb 1 into microlimbs subrelation
-        2, // decomposition of P.x limb 2 into microlimbs subrelation
-        2, // decomposition of P.x limb 3 into microlimbs subrelation
-        2, // decomposition of P.y limb 0 into microlimbs subrelation
-        2, // decomposition of P.y limb 1 into microlimbs subrelation
-        2, // decomposition of P.y limb 2 into microlimbs subrelation
-        2, // decomposition of P.y limb 3 into microlimbs subrelation
-        2, // decomposition of z1 limb 0 into microlimbs subrelation
-        2, // decomposition of z2 limb 0 into microlimbs subrelation
-        2, // decomposition of z1 limb 1 into microlimbs subrelation
-        2, // decomposition of z2 limb 1 into microlimbs subrelation
-        2, // decomposition of accumulator limb 0 into microlimbs subrelation
-        2, // decomposition of accumulator limb 1 into microlimbs subrelation
-        2, // decomposition of accumulator limb 2 into microlimbs subrelation
-        2, // decomposition of accumulator limb 3 into microlimbs subrelation
-        2, // decomposition of quotient limb 0 into microlimbs subrelation
-        2, // decomposition of quotient limb 1 into microlimbs subrelation
-        2, // decomposition of quotient limb 2 into microlimbs subrelation
-        2, // decomposition of quotient limb 3 into microlimbs subrelation
-        2, // decomposition of low relation wide limb into microlimbs subrelation
-        2, // decomposition of high relation wide limb into microlimbs subrelation
-        2, // stricter constraint on highest microlimb of P.x limb 0 subrelation
-        2, // stricter constraint on highest microlimb of P.x limb 1 subrelation
-        2, // stricter constraint on highest microlimb of P.x limb 2 subrelation
-        2, // stricter constraint on highest microlimb of P.x limb 3 subrelation
-        2, // stricter constraint on highest microlimb of P.y limb 0 subrelation
-        2, // stricter constraint on highest microlimb of P.y limb 1 subrelation
-        2, // stricter constraint on highest microlimb of P.y limb 2 subrelation
-        2, // stricter constraint on highest microlimb of P.y limb 3 subrelation
-        2, // stricter constraint on highest microlimb of z1 limb 0 subrelation
-        2, // stricter constraint on highest microlimb of z2 limb 0 subrelation
-        2, // stricter constraint on highest microlimb of z1 limb 1 subrelation
-        2, // stricter constraint on highest microlimb of z2 limb 1 subrelation
-        2, // stricter constraint on highest microlimb of accumulator limb 0 subrelation
-        2, // stricter constraint on highest microlimb of accumulator limb 1 subrelation
-        2, // stricter constraint on highest microlimb of accumulator limb 2 subrelation
-        2, // stricter constraint on highest microlimb of accumulator limb 3 subrelation
-        2, // stricter constraint on highest microlimb of quotient limb 0 subrelation
-        2, // stricter constraint on highest microlimb of quotient limb 1 subrelation
-        2, // stricter constraint on highest microlimb of quotient limb 2 subrelation
-        2, // stricter constraint on highest microlimb of quotient limb 3 subrelation
-        2, // decomposition of x_lo into 2 limbs subrelation
-        2, // decomposition of x_hi into 2 limbs subrelation
-        2, // decomposition of y_lo into 2 limbs subrelation
-        2, // decomposition of y_hi into 2 limbs subrelation
-        2, // decomposition of z1 into 2 limbs subrelation
-        2  // decomposition of z2 into 2 limbs subrelation
-    };
 
-    // Max among {SUBRELATION_PARTIAL_LENGTH + SUBRELATION_WITNESS_DEGREE}
-    static constexpr size_t ZK_RELATION_LENGTH = 5;
     /**
      * @brief Returns true if the contribution from all subrelations for the provided inputs is identically zero
      *

--- a/barretenberg/cpp/src/barretenberg/relations/translator_vm/translator_delta_range_constraint_relation.hpp
+++ b/barretenberg/cpp/src/barretenberg/relations/translator_vm/translator_delta_range_constraint_relation.hpp
@@ -23,28 +23,6 @@ template <typename FF_> class TranslatorDeltaRangeConstraintRelationImpl {
         3  // ordered_range_constraints_4 ends with defined maximum value subrelation
 
     };
-    /**
-     * @brief Upper bound on the degrees of subrelations considered as polynomials only in witness
-polynomials,
-     * i.e. all selectors and public polynomials are treated as constants. The subrelation witness degree does not
-     * exceed the subrelation partial degree given by SUBRELATION_PARTIAL_LENGTH - 1.
-     */
-    static constexpr std::array<size_t, 10> SUBRELATION_WITNESS_DEGREES{
-        5, // ordered_range_constraints_0 step in {0,1,2,3} subrelation
-        5, // ordered_range_constraints_1 step in {0,1,2,3} subrelation
-        5, // ordered_range_constraints_2 step in {0,1,2,3} subrelation
-        5, // ordered_range_constraints_3 step in {0,1,2,3} subrelation
-        5, // ordered_range_constraints_4 step in {0,1,2,3} subrelation
-        2, // ordered_range_constraints_0 ends with defined maximum value subrelation
-        2, // ordered_range_constraints_1 ends with defined maximum value subrelation
-        2, // ordered_range_constraints_2 ends with defined maximum value subrelation
-        2, // ordered_range_constraints_3 ends with defined maximum value subrelation
-        2  // ordered_range_constraints_4 ends with defined maximum value subrelation
-
-    };
-
-    // Max among {SUBRELATION_PARTIAL_LENGTH + SUBRELATION_WITNESS_DEGREE}
-    static constexpr size_t ZK_RELATION_LENGTH = 11;
 
     /**
      * @brief Expression for the generalized permutation sort relation

--- a/barretenberg/cpp/src/barretenberg/relations/translator_vm/translator_extra_relations.hpp
+++ b/barretenberg/cpp/src/barretenberg/relations/translator_vm/translator_extra_relations.hpp
@@ -12,17 +12,7 @@ template <typename FF_> class TranslatorOpcodeConstraintRelationImpl {
     static constexpr std::array<size_t, 1> SUBRELATION_PARTIAL_LENGTHS{
         7 // opcode constraint relation
     };
-    /**
-     * @brief Upper bound on the degrees of subrelations considered as polynomials only in witness
-polynomials,
-     * i.e. all selectors and public polynomials are treated as constants. The subrelation witness degree does not
-     * exceed the subrelation partial degree given by SUBRELATION_PARTIAL_LENGTH - 1.
-     */
-    static constexpr std::array<size_t, 1> SUBRELATION_WITNESS_DEGREES{
-        6 // opcode constraint relation
-    };
-    // Max among {SUBRELATION_PARTIAL_LENGTH + SUBRELATION_WITNESS_DEGREE}
-    static constexpr size_t ZK_RELATION_LENGTH = 13;
+
     /**
      * @brief Returns true if the contribution from all subrelations for the provided inputs is identically zero
      *
@@ -49,7 +39,6 @@ polynomials,
 template <typename FF_> class TranslatorAccumulatorTransferRelationImpl {
   public:
     using FF = FF_;
-    static constexpr size_t ZK_RELATION_LENGTH = 5;
 
     // 1 + polynomial degree of this relation
     static constexpr size_t RELATION_LENGTH = 3; // degree((SOME_LAGRANGE)(A-B)) = 2
@@ -68,27 +57,7 @@ template <typename FF_> class TranslatorAccumulatorTransferRelationImpl {
         3  // accumulator limb 3 is equal to given result at the end of accumulation subrelation
 
     };
-    /**
-     * @brief For ZK-Flavors: Upper bound on the degrees of subrelations considered as polynomials only in witness
-polynomials,
-     * i.e. all selectors and public polynomials are treated as constants. The subrelation witness degree does not
-     * exceed the subrelation partial degree given by SUBRELATION_PARTIAL_LENGTH - 1.
-     */
-    static constexpr std::array<size_t, 12> SUBRELATION_WITNESS_DEGREES{
-        2, // transfer accumulator limb 0 at even index subrelation
-        2, // transfer accumulator limb 1 at even index subrelation
-        2, // transfer accumulator limb 2 at even index subrelation
-        2, // transfer accumulator limb 3 at even index subrelation
-        2, // accumulator limb 0 is zero at the start of accumulation subrelation
-        2, // accumulator limb 1 is zero at the start of accumulation subrelation
-        2, // accumulator limb 2 is zero at the start of accumulation subrelation
-        2, // accumulator limb 3 is zero at the start of accumulation subrelation
-        2, // accumulator limb 0 is equal to given result at the end of accumulation subrelation
-        2, // accumulator limb 1 is equal to given result at the end of accumulation subrelation
-        2, // accumulator limb 2 is equal to given result at the end of accumulation subrelation
-        2  // accumulator limb 3 is equal to given result at the end of accumulation subrelation
 
-    };
     /**
      * @brief Returns true if the contribution from all subrelations for the provided inputs is identically zero
      *
@@ -129,7 +98,6 @@ template <typename FF_> class TranslatorZeroConstraintsRelationImpl {
     // 1 + polynomial degree of this relation
     static constexpr size_t RELATION_LENGTH = 3; // degree((some lagrange)(A)) = 2
 
-    static constexpr size_t ZK_RELATION_LENGTH = 5;
     static constexpr std::array<size_t, 64> SUBRELATION_PARTIAL_LENGTHS{
         3, // p_x_low_limbs_range_constraint_0 is zero outside of the minicircuit
         3, // p_x_low_limbs_range_constraint_1 is zero outside of the minicircuit
@@ -197,79 +165,7 @@ template <typename FF_> class TranslatorZeroConstraintsRelationImpl {
         3, // quotient_high_limbs_range_constraint_tail is zero outside of the minicircuit
 
     };
-    /**
-     * @brief For ZK-Flavors: Upper bound on the degrees of subrelations considered as polynomials only in witness
-polynomials,
-     * i.e. all selectors and public polynomials are treated as constants. The subrelation witness degree does not
-     * exceed the subrelation partial degree given by SUBRELATION_PARTIAL_LENGTH - 1.
-     */
-    static constexpr std::array<size_t, 64> SUBRELATION_WITNESS_DEGREES{
-        2, // p_x_low_limbs_range_constraint_0 is zero outside of the minicircuit
-        2, // p_x_low_limbs_range_constraint_1 is zero outside of the minicircuit
-        2, // p_x_low_limbs_range_constraint_2 is zero outside of the minicircuit
-        2, // p_x_low_limbs_range_constraint_3 is zero outside of the minicircuit
-        2, // p_x_low_limbs_range_constraint_4 is zero outside of the minicircuit
-        2, // p_x_high_limbs_range_constraint_0 is zero outside of the minicircuit
-        2, // p_x_high_limbs_range_constraint_1 is zero outside of the minicircuit
-        2, // p_x_high_limbs_range_constraint_2 is zero outside of the minicircuit
-        2, // p_x_high_limbs_range_constraint_3 is zero outside of the minicircuit
-        2, // p_x_high_limbs_range_constraint_4 is zero outside of the minicircuit
-        2, // p_y_low_limbs_range_constraint_0 is zero outside of the minicircuit
-        2, // p_y_low_limbs_range_constraint_1 is zero outside of the minicircuit
-        2, // p_y_low_limbs_range_constraint_2 is zero outside of the minicircuit
-        2, // p_y_low_limbs_range_constraint_3 is zero outside of the minicircuit
-        2, // p_y_low_limbs_range_constraint_4 is zero outside of the minicircuit
-        2, // p_y_high_limbs_range_constraint_0 is zero outside of the minicircuit
-        2, // p_y_high_limbs_range_constraint_1 is zero outside of the minicircuit
-        2, // p_y_high_limbs_range_constraint_2 is zero outside of the minicircuit
-        2, // p_y_high_limbs_range_constraint_3 is zero outside of the minicircuit
-        2, // p_y_high_limbs_range_constraint_4 is zero outside of the minicircuit
-        2, // z_low_limbs_range_constraint_0 is zero outside of the minicircuit
-        2, // z_low_limbs_range_constraint_1 is zero outside of the minicircuit
-        2, // z_low_limbs_range_constraint_2 is zero outside of the minicircuit
-        2, // z_low_limbs_range_constraint_3 is zero outside of the minicircuit
-        2, // z_low_limbs_range_constraint_4 is zero outside of the minicircuit
-        2, // z_high_limbs_range_constraint_0 is zero outside of the minicircuit
-        2, // z_high_limbs_range_constraint_1 is zero outside of the minicircuit
-        2, // z_high_limbs_range_constraint_2 is zero outside of the minicircuit
-        2, // z_high_limbs_range_constraint_3 is zero outside of the minicircuit
-        2, // z_high_limbs_range_constraint_4 is zero outside of the minicircuit
-        2, // accumulator_low_limbs_range_constraint_0 is zero outside of the minicircuit
-        2, // accumulator_low_limbs_range_constraint_1 is zero outside of the minicircuit
-        2, // accumulator_low_limbs_range_constraint_2 is zero outside of the minicircuit
-        2, // accumulator_low_limbs_range_constraint_3 is zero outside of the minicircuit
-        2, // accumulator_low_limbs_range_constraint_4 is zero outside of the minicircuit
-        2, // accumulator_high_limbs_range_constraint_0 is zero outside of the minicircuit
-        2, // accumulator_high_limbs_range_constraint_1 is zero outside of the minicircuit
-        2, // accumulator_high_limbs_range_constraint_2 is zero outside of the minicircuit
-        2, // accumulator_high_limbs_range_constraint_3 is zero outside of the minicircuit
-        2, // accumulator_high_limbs_range_constraint_4 is zero outside of the minicircuit
-        2, // quotient_low_limbs_range_constraint_0 is zero outside of the minicircuit
-        2, // quotient_low_limbs_range_constraint_1 is zero outside of the minicircuit
-        2, // quotient_low_limbs_range_constraint_2 is zero outside of the minicircuit
-        2, // quotient_low_limbs_range_constraint_3 is zero outside of the minicircuit
-        2, // quotient_low_limbs_range_constraint_4 is zero outside of the minicircuit
-        2, // quotient_high_limbs_range_constraint_0 is zero outside of the minicircuit
-        2, // quotient_high_limbs_range_constraint_1 is zero outside of the minicircuit
-        2, // quotient_high_limbs_range_constraint_2 is zero outside of the minicircuit
-        2, // quotient_high_limbs_range_constraint_3 is zero outside of the minicircuit
-        2, // quotient_high_limbs_range_constraint_4 is zero outside of the minicircuit
-        2, // relation_wide_limbs_range_constraint_0 is zero outside of the minicircuit
-        2, // relation_wide_limbs_range_constraint_1 is zero outside of the minicircuit
-        2, // relation_wide_limbs_range_constraint_2 is zero outside of the minicircuit
-        2, // relation_wide_limbs_range_constraint_3 is zero outside of the minicircuit
-        2, // p_x_low_limbs_range_constraint_tail is zero outside of the minicircuit
-        2, // p_x_high_limbs_range_constraint_tail is zero outside of the minicircuit
-        2, // p_y_low_limbs_range_constraint_tail is zero outside of the minicircuit
-        2, // p_y_high_limbs_range_constraint_tail is zero outside of the minicircuit
-        2, // z_low_limbs_range_constraint_tail is zero outside of the minicircuit
-        2, // z_high_limbs_range_constraint_tail is zero outside of the minicircuit
-        2, // accumulator_low_limbs_range_constraint_tail is zero outside of the minicircuit
-        2, // accumulator_high_limbs_range_constraint_tail is zero outside of the minicircuit
-        2, // quotient_low_limbs_range_constraint_tail is zero outside of the minicircuit
-        2, // quotient_high_limbs_range_constraint_tail is zero outside of the minicircuit
 
-    };
     /**
      * @brief Might return true if the contribution from all subrelations for the provided inputs is identically zero
      *

--- a/barretenberg/cpp/src/barretenberg/relations/translator_vm/translator_non_native_field_relation.hpp
+++ b/barretenberg/cpp/src/barretenberg/relations/translator_vm/translator_non_native_field_relation.hpp
@@ -14,19 +14,7 @@ template <typename FF_> class TranslatorNonNativeFieldRelationImpl {
         3, // Higher wide limb subrelation (checks result is 0 in higher mod 2¹³⁶),
         3  // Prime subrelation (checks result in native field)
     };
-    /**
-     * @brief Upper bound on the degrees of subrelations considered as polynomials only in witness
-polynomials,
-     * i.e. all selectors and public polynomials are treated as constants. The subrelation witness degree does not
-     * exceed the subrelation partial degree given by SUBRELATION_PARTIAL_LENGTH - 1.
-     */
-    static constexpr std::array<size_t, 3> SUBRELATION_WITNESS_DEGREES{
-        2, // Lower wide limb subrelation (checks result is 0 mod 2¹³⁶)
-        2, // Higher wide limb subrelation (checks result is 0 in higher mod 2¹³⁶),
-        2  // Prime subrelation (checks result in native field)
-    };
-    // Max among {SUBRELATION_PARTIAL_LENGTH + SUBRELATION_WITNESS_DEGREE}
-    static constexpr size_t ZK_RELATION_LENGTH = 5;
+
     /**
      * @brief Returns true if the contribution from all subrelations for the provided inputs is identically zero
      *

--- a/barretenberg/cpp/src/barretenberg/relations/translator_vm/translator_permutation_relation.hpp
+++ b/barretenberg/cpp/src/barretenberg/relations/translator_vm/translator_permutation_relation.hpp
@@ -13,17 +13,7 @@ template <typename FF_> class TranslatorPermutationRelationImpl {
         7, // grand product construction sub-relation
         3  // left-shiftable polynomial sub-relation
     };
-    /**
-     * @brief The degrees of subrelations considered as polynomials only in witness polynomials,
-     * i.e. all selectors and public polynomials are treated as constants.
-     *
-     */
-    static constexpr std::array<size_t, 2> SUBRELATION_WITNESS_DEGREES{
-        6, // grand product construction sub-relation
-        1  // left-shiftable polynomial sub-relation
-    };
-    // Max among {SUBRELATION_PARTIAL_LENGTH + SUBRELATION_WITNESS_DEGREE}
-    static constexpr size_t ZK_RELATION_LENGTH = 13;
+
     inline static auto& get_grand_product_polynomial(auto& in) { return in.z_perm; }
     inline static auto& get_shifted_grand_product_polynomial(auto& in) { return in.z_perm_shift; }
 

--- a/barretenberg/cpp/src/barretenberg/relations/ultra_arithmetic_relation.hpp
+++ b/barretenberg/cpp/src/barretenberg/relations/ultra_arithmetic_relation.hpp
@@ -13,13 +13,6 @@ template <typename FF_> class UltraArithmeticRelationImpl {
     };
 
     /**
-     * @brief For ZK-Flavors: The degrees of subrelations considered as polynomials only in witness polynomials,
-     * i.e. all selectors and public polynomials are treated as constants.
-     *
-     */
-    static constexpr std::array<size_t, 2> SUBRELATION_WITNESS_DEGREES{ 2, 2 };
-
-    /**
      * @brief Returns true if the contribution from all subrelations for the provided inputs is identically zero
      *
      */

--- a/barretenberg/cpp/src/barretenberg/stdlib_circuit_builders/mega_flavor.hpp
+++ b/barretenberg/cpp/src/barretenberg/stdlib_circuit_builders/mega_flavor.hpp
@@ -78,8 +78,6 @@ class MegaFlavor {
     // length = 3
     static constexpr size_t BATCHED_RELATION_PARTIAL_LENGTH = MAX_PARTIAL_RELATION_LENGTH + 1;
     static constexpr size_t NUM_RELATIONS = std::tuple_size_v<Relations>;
-    // The total number of witnesses including shifts and derived entities.
-    static constexpr size_t NUM_ALL_WITNESS_ENTITIES = NUM_WITNESS_ENTITIES + NUM_SHIFTED_WITNESSES;
 
     // For instances of this flavour, used in folding, we need a unique sumcheck batching challenges for each
     // subrelation. This is because using powers of alpha would increase the degree of Protogalaxy polynomial $G$ (the

--- a/barretenberg/cpp/src/barretenberg/stdlib_circuit_builders/ultra_flavor.hpp
+++ b/barretenberg/cpp/src/barretenberg/stdlib_circuit_builders/ultra_flavor.hpp
@@ -60,9 +60,6 @@ class UltraFlavor {
     static constexpr RepeatedCommitmentsData REPEATED_COMMITMENTS = RepeatedCommitmentsData(
         NUM_PRECOMPUTED_ENTITIES, NUM_PRECOMPUTED_ENTITIES + NUM_WITNESS_ENTITIES, NUM_SHIFTED_WITNESSES);
 
-    // The total number of witnesses including shifts and derived entities.
-    static constexpr size_t NUM_ALL_WITNESS_ENTITIES = NUM_WITNESS_ENTITIES + NUM_SHIFTED_WITNESSES;
-
     // define the tuple of Relations that comprise the Sumcheck relation
     // Note: made generic for use in MegaRecursive.
     template <typename FF>

--- a/barretenberg/cpp/src/barretenberg/stdlib_circuit_builders/ultra_keccak_zk_flavor.hpp
+++ b/barretenberg/cpp/src/barretenberg/stdlib_circuit_builders/ultra_keccak_zk_flavor.hpp
@@ -4,18 +4,6 @@
 
 namespace bb {
 
-/*!
-\brief Child class of UltraFlavor that runs with ZK Sumcheck.
-\details
-Most of the properties of UltraFlavor are
-inherited without any changes, except for the MAX_PARTIAL_RELATION_LENGTH which is now computed as a maximum of
-SUBRELATION_PARTIAL_LENGTHS incremented by the corresponding SUBRELATION_WITNESS_DEGREES over all relations included in
-UltraFlavor, which also affects the size of ExtendedEdges univariate containers.
-Moreover, the container SumcheckTupleOfTuplesOfUnivariates is resized to reflect that masked
-witness polynomials are of degree at most \f$2\f$ in each variable, and hence, for any subrelation, the corresponding
-univariate accumuluator size has to be increased by the subrelation's witness degree. See more in
-\ref docs/src/sumcheck-outline.md "Sumcheck Outline".
-*/
 class UltraKeccakZKFlavor : public UltraKeccakFlavor {
   public:
     // This flavor runs with ZK Sumcheck

--- a/barretenberg/cpp/src/barretenberg/stdlib_circuit_builders/ultra_zk_flavor.hpp
+++ b/barretenberg/cpp/src/barretenberg/stdlib_circuit_builders/ultra_zk_flavor.hpp
@@ -7,14 +7,11 @@ namespace bb {
 /*!
 \brief Child class of UltraFlavor that runs with ZK Sumcheck.
 \details
-Most of the properties of UltraFlavor are
-inherited without any changes, except for the MAX_PARTIAL_RELATION_LENGTH which is now computed as a maximum of
-SUBRELATION_PARTIAL_LENGTHS incremented by the corresponding SUBRELATION_WITNESS_DEGREES over all relations included in
-UltraFlavor, which also affects the size of ExtendedEdges univariate containers.
-Moreover, the container SumcheckTupleOfTuplesOfUnivariates is resized to reflect that masked
-witness polynomials are of degree at most \f$2\f$ in each variable, and hence, for any subrelation, the corresponding
-univariate accumuluator size has to be increased by the subrelation's witness degree. See more in
-\ref docs/src/sumcheck-outline.md "Sumcheck Outline".
+Most of the properties of UltraFlavor are inherited without any changes. However, the BATCHED_RELATION_PARTIAL_LENGTH is
+incremented by 1, as we are using the sumcheck with disabled rows, where the main Honk relation is multiplied by a sum
+of multilinear Lagranges. Additionally, the transcript contains extra elements, such as commitments and evaluations of
+Libra polynomials used in Sumcheck to make it ZK, as well as a commitment and an evaluation of a hiding polynomials that
+turns the PCS stage ZK.
 */
 class UltraZKFlavor : public UltraFlavor {
   public:

--- a/barretenberg/cpp/src/barretenberg/translator_vm/translator_flavor.hpp
+++ b/barretenberg/cpp/src/barretenberg/translator_vm/translator_flavor.hpp
@@ -83,8 +83,6 @@ class TranslatorFlavor {
     static constexpr size_t NUM_PRECOMPUTED_ENTITIES = 7;
     // The total number of witness entities not including shifts.
     static constexpr size_t NUM_WITNESS_ENTITIES = 91;
-    // The total number of witnesses including shifts and derived entities.
-    static constexpr size_t NUM_ALL_WITNESS_ENTITIES = 177;
     static constexpr size_t NUM_WIRES_NON_SHIFTED = 1;
     static constexpr size_t NUM_SHIFTED_WITNESSES = 86;
     static constexpr size_t NUM_CONCATENATED = NUM_CONCATENATED_WIRES * CONCATENATION_GROUP_SIZE;

--- a/barretenberg/cpp/src/barretenberg/vm/avm/generated/flavor.hpp
+++ b/barretenberg/cpp/src/barretenberg/vm/avm/generated/flavor.hpp
@@ -97,8 +97,6 @@ class AvmFlavor {
     // We have two copies of the witness entities, so we subtract the number of fixed ones (they have no shift), one for
     // the unshifted and one for the shifted
     static constexpr size_t NUM_ALL_ENTITIES = 813;
-    // The total number of witnesses including shifts and derived entities.
-    static constexpr size_t NUM_ALL_WITNESS_ENTITIES = NUM_WITNESS_ENTITIES + NUM_SHIFTED_ENTITIES;
 
     // Need to be templated for recursive verifier
     template <typename FF_>

--- a/barretenberg/cpp/src/barretenberg/vm2/generated/flavor.hpp
+++ b/barretenberg/cpp/src/barretenberg/vm2/generated/flavor.hpp
@@ -82,8 +82,6 @@ class AvmFlavor {
     // We have two copies of the witness entities, so we subtract the number of fixed ones (they have no shift), one for
     // the unshifted and one for the shifted
     static constexpr size_t NUM_ALL_ENTITIES = 466;
-    // The total number of witnesses including shifts and derived entities.
-    static constexpr size_t NUM_ALL_WITNESS_ENTITIES = NUM_WITNESS_ENTITIES + NUM_SHIFTED_ENTITIES;
 
     // Need to be templated for recursive verifier
     template <typename FF_>

--- a/bb-pilcom/bb-pil-backend/templates/flavor.hpp.hbs
+++ b/bb-pilcom/bb-pil-backend/templates/flavor.hpp.hbs
@@ -73,8 +73,6 @@ class AvmFlavor {
     static constexpr size_t NUM_WIRES = NUM_WITNESS_ENTITIES + NUM_PRECOMPUTED_ENTITIES;
     // We have two copies of the witness entities, so we subtract the number of fixed ones (they have no shift), one for the unshifted and one for the shifted
     static constexpr size_t NUM_ALL_ENTITIES = {{len all_cols_and_shifts}};
-    // The total number of witnesses including shifts and derived entities.
-    static constexpr size_t NUM_ALL_WITNESS_ENTITIES = NUM_WITNESS_ENTITIES + NUM_SHIFTED_ENTITIES;
 
     // Need to be templated for recursive verifier
     template <typename FF_>


### PR DESCRIPTION
We're using sumcheck with disabled rows that does not require all the constants that I introduced a while ago with an implementation of a different witness masking technique. 