### PR TITLE
chore: Use batch p2p reqresp for requesting txs in prover node

### DIFF
--- a/yarn-project/aztec-node/src/aztec-node/server.ts
+++ b/yarn-project/aztec-node/src/aztec-node/server.ts
@@ -59,6 +59,7 @@ import { computePublicDataTreeLeafSlot, siloNullifier } from '@aztec/circuits.js
 import { EpochCache } from '@aztec/epoch-cache';
 import { type L1ContractAddresses, createEthereumChain } from '@aztec/ethereum';
 import { AztecAddress } from '@aztec/foundation/aztec-address';
+import { compactArray } from '@aztec/foundation/collection';
 import { type Logger, createLogger } from '@aztec/foundation/log';
 import { DateProvider, Timer } from '@aztec/foundation/timer';
 import { type AztecKVStore } from '@aztec/kv-store';
@@ -498,6 +499,15 @@ export class AztecNodeService implements AztecNode, Traceable {
    */
   public getTxByHash(txHash: TxHash) {
     return Promise.resolve(this.p2pClient!.getTxByHashFromPool(txHash));
+  }
+
+  /**
+   * Method to retrieve txs from the mempool or unfinalised chain.
+   * @param txHash - The transaction hash to return.
+   * @returns - The txs if it exists.
+   */
+  public async getTxsByHash(txHashes: TxHash[]) {
+    return compactArray(await Promise.all(txHashes.map(txHash => this.getTxByHash(txHash))));
   }
 
   /**

--- a/yarn-project/circuit-types/src/interfaces/aztec-node.test.ts
+++ b/yarn-project/circuit-types/src/interfaces/aztec-node.test.ts
@@ -281,6 +281,11 @@ describe('AztecNodeApiSchema', () => {
     expect(response).toBeInstanceOf(Tx);
   });
 
+  it('getTxsByHash', async () => {
+    const response = await context.client.getTxsByHash([TxHash.random()]);
+    expect(response[0]).toBeInstanceOf(Tx);
+  });
+
   it('getPublicStorageAt', async () => {
     const response = await context.client.getPublicStorageAt(await AztecAddress.random(), Fr.random(), 1);
     expect(response).toBeInstanceOf(Fr);
@@ -558,6 +563,10 @@ class MockAztecNode implements AztecNode {
   getTxByHash(txHash: TxHash): Promise<Tx | undefined> {
     expect(txHash).toBeInstanceOf(TxHash);
     return Promise.resolve(Tx.random());
+  }
+  async getTxsByHash(txHashes: TxHash[]): Promise<Tx[]> {
+    expect(txHashes[0]).toBeInstanceOf(TxHash);
+    return [await Tx.random()];
   }
   getPublicStorageAt(contract: AztecAddress, slot: Fr, _blockNumber: number | 'latest'): Promise<Fr> {
     expect(contract).toBeInstanceOf(AztecAddress);

--- a/yarn-project/circuit-types/src/interfaces/aztec-node.ts
+++ b/yarn-project/circuit-types/src/interfaces/aztec-node.ts
@@ -53,7 +53,7 @@ import { type SequencerConfig, SequencerConfigSchema } from './configs.js';
 import { type L2BlockNumber, L2BlockNumberSchema } from './l2_block_number.js';
 import { NullifierMembershipWitness } from './nullifier_membership_witness.js';
 import { type ProverConfig, ProverConfigSchema } from './prover-client.js';
-import { type ProverCoordination, ProverCoordinationApiSchema } from './prover-coordination.js';
+import { type ProverCoordination } from './prover-coordination.js';
 
 /**
  * The aztec node.
@@ -372,6 +372,13 @@ export interface AztecNode
   getTxByHash(txHash: TxHash): Promise<Tx | undefined>;
 
   /**
+   * Method to retrieve multiple pending txs.
+   * @param txHash - The transaction hashes to return.
+   * @returns The pending txs if exist.
+   */
+  getTxsByHash(txHashes: TxHash[]): Promise<Tx[]>;
+
+  /**
    * Gets the storage value at the given contract storage slot.
    *
    * @remarks The storage slot here refers to the slot as it is defined in Noir not the index in the merkle tree.
@@ -453,9 +460,8 @@ export interface AztecNode
 }
 
 export const AztecNodeApiSchema: ApiSchemaFor<AztecNode> = {
-  ...ProverCoordinationApiSchema,
-
   getL2Tips: z.function().args().returns(L2TipsSchema),
+
   findLeavesIndexes: z
     .function()
     .args(L2BlockNumberSchema, z.nativeEnum(MerkleTreeId), z.array(schemas.Fr))
@@ -566,6 +572,8 @@ export const AztecNodeApiSchema: ApiSchemaFor<AztecNode> = {
   getPendingTxCount: z.function().returns(z.number()),
 
   getTxByHash: z.function().args(TxHash.schema).returns(Tx.schema.optional()),
+
+  getTxsByHash: z.function().args(z.array(TxHash.schema)).returns(z.array(Tx.schema)),
 
   getPublicStorageAt: z.function().args(schemas.AztecAddress, schemas.Fr, L2BlockNumberSchema).returns(schemas.Fr),
 

--- a/yarn-project/circuit-types/src/interfaces/prover-coordination.ts
+++ b/yarn-project/circuit-types/src/interfaces/prover-coordination.ts
@@ -16,6 +16,13 @@ export interface ProverCoordination {
   getTxByHash(txHash: TxHash): Promise<Tx | undefined>;
 
   /**
+   * Returns a set of transactions given their hashes if available.
+   * @param txHashes - The hashes of the transactions, used as an ID.
+   * @returns The transactions, if found, 'undefined' otherwise.
+   */
+  getTxsByHash(txHashes: TxHash[]): Promise<Tx[]>;
+
+  /**
    * Receives a quote for an epoch proof and stores it in its EpochProofQuotePool
    * @param quote - The quote to store
    */
@@ -24,5 +31,6 @@ export interface ProverCoordination {
 
 export const ProverCoordinationApiSchema: ApiSchemaFor<ProverCoordination> = {
   getTxByHash: z.function().args(TxHash.schema).returns(Tx.schema.optional()),
+  getTxsByHash: z.function().args(z.array(TxHash.schema)).returns(z.array(Tx.schema)),
   addEpochProofQuote: z.function().args(EpochProofQuote.schema).returns(z.void()),
 };

--- a/yarn-project/end-to-end/src/fixtures/utils.ts
+++ b/yarn-project/end-to-end/src/fixtures/utils.ts
@@ -716,6 +716,7 @@ export async function createAndSyncProverNode(
   const aztecNodeWithoutStop = {
     addEpochProofQuote: aztecNode.addEpochProofQuote.bind(aztecNode),
     getTxByHash: aztecNode.getTxByHash.bind(aztecNode),
+    getTxsByHash: aztecNode.getTxsByHash.bind(aztecNode),
     stop: () => Promise.resolve(),
   };
 

--- a/yarn-project/p2p/src/client/p2p_client.ts
+++ b/yarn-project/p2p/src/client/p2p_client.ts
@@ -10,6 +10,7 @@ import {
   type P2PApi,
   type P2PClientType,
   type PeerInfo,
+  type ProverCoordination,
   type Tx,
   type TxHash,
 } from '@aztec/circuit-types';
@@ -62,130 +63,131 @@ export interface P2PSyncState {
 /**
  * Interface of a P2P client.
  **/
-export type P2P<T extends P2PClientType = P2PClientType.Full> = P2PApi<T> & {
-  /**
-   * Broadcasts a block proposal to other peers.
-   *
-   * @param proposal - the block proposal
-   */
-  broadcastProposal(proposal: BlockProposal): void;
+export type P2P<T extends P2PClientType = P2PClientType.Full> = ProverCoordination &
+  P2PApi<T> & {
+    /**
+     * Broadcasts a block proposal to other peers.
+     *
+     * @param proposal - the block proposal
+     */
+    broadcastProposal(proposal: BlockProposal): void;
 
-  /**
-   * Queries the EpochProofQuote pool for quotes for the given epoch
-   *
-   * @param epoch  - the epoch to query
-   * @returns EpochProofQuotes
-   */
-  getEpochProofQuotes(epoch: bigint): Promise<EpochProofQuote[]>;
+    /**
+     * Queries the EpochProofQuote pool for quotes for the given epoch
+     *
+     * @param epoch  - the epoch to query
+     * @returns EpochProofQuotes
+     */
+    getEpochProofQuotes(epoch: bigint): Promise<EpochProofQuote[]>;
 
-  /**
-   * Adds an EpochProofQuote to the pool and broadcasts an EpochProofQuote to other peers.
-   *
-   * @param quote - the quote to broadcast
-   */
-  addEpochProofQuote(quote: EpochProofQuote): Promise<void>;
+    /**
+     * Adds an EpochProofQuote to the pool and broadcasts an EpochProofQuote to other peers.
+     *
+     * @param quote - the quote to broadcast
+     */
+    addEpochProofQuote(quote: EpochProofQuote): Promise<void>;
 
-  /**
-   * Registers a callback from the validator client that determines how to behave when
-   * foreign block proposals are received
-   *
-   * @param handler - A function taking a received block proposal and producing an attestation
-   */
-  // REVIEW: https://github.com/AztecProtocol/aztec-packages/issues/7963
-  // ^ This pattern is not my favorite (md)
-  registerBlockProposalHandler(handler: (block: BlockProposal) => Promise<BlockAttestation | undefined>): void;
+    /**
+     * Registers a callback from the validator client that determines how to behave when
+     * foreign block proposals are received
+     *
+     * @param handler - A function taking a received block proposal and producing an attestation
+     */
+    // REVIEW: https://github.com/AztecProtocol/aztec-packages/issues/7963
+    // ^ This pattern is not my favorite (md)
+    registerBlockProposalHandler(handler: (block: BlockProposal) => Promise<BlockAttestation | undefined>): void;
 
-  /**
-   * Request a list of transactions from another peer by their tx hashes.
-   * @param txHashes - Hashes of the txs to query.
-   * @returns A list of transactions or undefined if the transactions are not found.
-   */
-  requestTxs(txHashes: TxHash[]): Promise<(Tx | undefined)[]>;
+    /**
+     * Request a list of transactions from another peer by their tx hashes.
+     * @param txHashes - Hashes of the txs to query.
+     * @returns A list of transactions or undefined if the transactions are not found.
+     */
+    requestTxs(txHashes: TxHash[]): Promise<(Tx | undefined)[]>;
 
-  /**
-   * Request a transaction from another peer by its tx hash.
-   * @param txHash - Hash of the tx to query.
-   */
-  requestTxByHash(txHash: TxHash): Promise<Tx | undefined>;
+    /**
+     * Request a transaction from another peer by its tx hash.
+     * @param txHash - Hash of the tx to query.
+     */
+    requestTxByHash(txHash: TxHash): Promise<Tx | undefined>;
 
-  /**
-   * Verifies the 'tx' and, if valid, adds it to local tx pool and forwards it to other peers.
-   * @param tx - The transaction.
-   **/
-  sendTx(tx: Tx): Promise<void>;
+    /**
+     * Verifies the 'tx' and, if valid, adds it to local tx pool and forwards it to other peers.
+     * @param tx - The transaction.
+     **/
+    sendTx(tx: Tx): Promise<void>;
 
-  /**
-   * Deletes 'txs' from the pool, given hashes.
-   * NOT used if we use sendTx as reconcileTxPool will handle this.
-   * @param txHashes - Hashes to check.
-   **/
-  deleteTxs(txHashes: TxHash[]): Promise<void>;
+    /**
+     * Deletes 'txs' from the pool, given hashes.
+     * NOT used if we use sendTx as reconcileTxPool will handle this.
+     * @param txHashes - Hashes to check.
+     **/
+    deleteTxs(txHashes: TxHash[]): Promise<void>;
 
-  /**
-   * Returns a transaction in the transaction pool by its hash.
-   * @param txHash  - Hash of tx to return.
-   * @returns A single tx or undefined.
-   */
-  getTxByHashFromPool(txHash: TxHash): Promise<Tx | undefined>;
+    /**
+     * Returns a transaction in the transaction pool by its hash.
+     * @param txHash  - Hash of tx to return.
+     * @returns A single tx or undefined.
+     */
+    getTxByHashFromPool(txHash: TxHash): Promise<Tx | undefined>;
 
-  /**
-   * Returns a transaction in the transaction pool by its hash, requesting it from the network if it is not found.
-   * @param txHash  - Hash of tx to return.
-   * @returns A single tx or undefined.
-   */
-  getTxByHash(txHash: TxHash): Promise<Tx | undefined>;
+    /**
+     * Returns a transaction in the transaction pool by its hash, requesting it from the network if it is not found.
+     * @param txHash  - Hash of tx to return.
+     * @returns A single tx or undefined.
+     */
+    getTxByHash(txHash: TxHash): Promise<Tx | undefined>;
 
-  /**
-   * Returns an archived transaction from the transaction pool by its hash.
-   * @param txHash  - Hash of tx to return.
-   * @returns A single tx or undefined.
-   */
-  getArchivedTxByHash(txHash: TxHash): Promise<Tx | undefined>;
+    /**
+     * Returns an archived transaction from the transaction pool by its hash.
+     * @param txHash  - Hash of tx to return.
+     * @returns A single tx or undefined.
+     */
+    getArchivedTxByHash(txHash: TxHash): Promise<Tx | undefined>;
 
-  /**
-   * Returns whether the given tx hash is flagged as pending or mined.
-   * @param txHash - Hash of the tx to query.
-   * @returns Pending or mined depending on its status, or undefined if not found.
-   */
-  getTxStatus(txHash: TxHash): Promise<'pending' | 'mined' | undefined>;
+    /**
+     * Returns whether the given tx hash is flagged as pending or mined.
+     * @param txHash - Hash of the tx to query.
+     * @returns Pending or mined depending on its status, or undefined if not found.
+     */
+    getTxStatus(txHash: TxHash): Promise<'pending' | 'mined' | undefined>;
 
-  /** Returns an iterator over pending txs on the mempool. */
-  iteratePendingTxs(): AsyncIterableIterator<Tx>;
+    /** Returns an iterator over pending txs on the mempool. */
+    iteratePendingTxs(): AsyncIterableIterator<Tx>;
 
-  /** Returns the number of pending txs in the mempool. */
-  getPendingTxCount(): Promise<number>;
+    /** Returns the number of pending txs in the mempool. */
+    getPendingTxCount(): Promise<number>;
 
-  /**
-   * Starts the p2p client.
-   * @returns A promise signalling the completion of the block sync.
-   */
-  start(): Promise<void>;
+    /**
+     * Starts the p2p client.
+     * @returns A promise signalling the completion of the block sync.
+     */
+    start(): Promise<void>;
 
-  /**
-   * Stops the p2p client.
-   * @returns A promise signalling the completion of the stop process.
-   */
-  stop(): Promise<void>;
+    /**
+     * Stops the p2p client.
+     * @returns A promise signalling the completion of the stop process.
+     */
+    stop(): Promise<void>;
 
-  /**
-   * Indicates if the p2p client is ready for transaction submission.
-   * @returns A boolean flag indicating readiness.
-   */
-  isReady(): boolean;
+    /**
+     * Indicates if the p2p client is ready for transaction submission.
+     * @returns A boolean flag indicating readiness.
+     */
+    isReady(): boolean;
 
-  /**
-   * Returns the current status of the p2p client.
-   */
-  getStatus(): Promise<P2PSyncState>;
+    /**
+     * Returns the current status of the p2p client.
+     */
+    getStatus(): Promise<P2PSyncState>;
 
-  /**
-   * Returns the ENR of this node, if any.
-   */
-  getEnr(): ENR | undefined;
+    /**
+     * Returns the ENR of this node, if any.
+     */
+    getEnr(): ENR | undefined;
 
-  /** Identifies a p2p client. */
-  isP2PClient(): true;
-};
+    /** Identifies a p2p client. */
+    isP2PClient(): true;
+  };
 
 /**
  * The P2P client implementation.
@@ -467,6 +469,17 @@ export class P2PClient<T extends P2PClientType = P2PClientType.Full>
     return tx;
   }
 
+  /**
+   * Uses the batched Request Response protocol to request a set of transactions from the network.
+   */
+  public async requestTxsByHash(txHashes: TxHash[]): Promise<Tx[]> {
+    const txs = (await this.p2pService.sendBatchRequest(ReqRespSubProtocol.TX, txHashes)) ?? [];
+    await this.txPool.addTxs(txs);
+    const txHashesStr = txHashes.map(tx => tx.toString()).join(', ');
+    this.log.debug(`Received batched txs ${txHashesStr} (${txs.length} / ${txHashes.length}}) from peers`);
+    return txs as Tx[];
+  }
+
   public getPendingTxs(): Promise<Tx[]> {
     return Promise.resolve(this.getTxs('pending'));
   }
@@ -527,6 +540,27 @@ export class P2PClient<T extends P2PClientType = P2PClientType.Full>
       return tx;
     }
     return this.requestTxByHash(txHash);
+  }
+
+  /**
+   * Returns transactions in the transaction pool by hash.
+   * If a transaction is not in the pool, it will be requested from the network.
+   * @param txHashes - Hashes of the transactions to look for.
+   * @returns The txs found, not necessarily on the same order as the hashes.
+   */
+  async getTxsByHash(txHashes: TxHash[]): Promise<Tx[]> {
+    const txs = await Promise.all(txHashes.map(txHash => this.txPool.getTxByHash(txHash)));
+    const missingTxHashes = txs
+      .map((tx, index) => [tx, index] as const)
+      .filter(([tx, _index]) => !tx)
+      .map(([_tx, index]) => txHashes[index]);
+
+    if (missingTxHashes.length === 0) {
+      return txs as Tx[];
+    }
+
+    const missingTxs = await this.requestTxsByHash(missingTxHashes);
+    return txs.filter((tx): tx is Tx => !!tx).concat(missingTxs);
   }
 
   /**

--- a/yarn-project/prover-node/src/prover-node.ts
+++ b/yarn-project/prover-node/src/prover-node.ts
@@ -17,12 +17,9 @@ import {
   tryStop,
 } from '@aztec/circuit-types';
 import { type ContractDataSource } from '@aztec/circuits.js';
-import { asyncPool } from '@aztec/foundation/async-pool';
 import { compact } from '@aztec/foundation/collection';
 import { memoize } from '@aztec/foundation/decorators';
-import { TimeoutError } from '@aztec/foundation/error';
 import { createLogger } from '@aztec/foundation/log';
-import { retryUntil } from '@aztec/foundation/retry';
 import { DateProvider } from '@aztec/foundation/timer';
 import { type Maybe } from '@aztec/foundation/types';
 import { type P2P } from '@aztec/p2p';
@@ -333,68 +330,20 @@ export class ProverNode implements ClaimsMonitorHandler, EpochMonitorHandler, Pr
   }
 
   private async gatherTxs(epochNumber: bigint, blocks: L2Block[]) {
-    let txsToFind: TxHash[] = [];
-    const txHashToBlock = new Map<string, number>();
-    const results = new Map<string, Tx>();
+    const txsToFind: TxHash[] = blocks.flatMap(block => block.body.txEffects.map(tx => tx.txHash));
+    const txs = await this.coordination.getTxsByHash(txsToFind);
 
-    for (const block of blocks) {
-      for (const tx of block.body.txEffects) {
-        txsToFind.push(tx.txHash);
-        txHashToBlock.set(tx.txHash.toString(), block.number);
-      }
+    if (txs.length === txsToFind.length) {
+      this.log.verbose(`Gathered all ${txs.length} txs for epoch ${epochNumber}`, { epochNumber });
+      return txs;
     }
 
-    const totalTxsRequired = txsToFind.length;
-    this.log.info(
-      `Gathering a total of ${totalTxsRequired} txs for epoch=${epochNumber} made up of ${blocks.length} blocks`,
-      { epochNumber },
-    );
+    const txHashesFound = await Promise.all(txs.map(tx => tx.getTxHash()));
+    const missingTxHashes = txsToFind
+      .filter(txHashToFind => !txHashesFound.some(txHashFound => txHashToFind.equals(txHashFound)))
+      .join(', ');
 
-    let iteration = 0;
-    try {
-      await retryUntil(
-        async () => {
-          const batch = [...txsToFind];
-          txsToFind = [];
-          const batchResults = await asyncPool(this.options.txGatheringMaxParallelRequests, batch, async txHash => {
-            const tx = await this.coordination.getTxByHash(txHash);
-            return [txHash, tx] as const;
-          });
-          let found = 0;
-          for (const [txHash, maybeTx] of batchResults) {
-            if (maybeTx) {
-              found++;
-              results.set(txHash.toString(), maybeTx);
-            } else {
-              txsToFind.push(txHash);
-            }
-          }
-
-          this.log.verbose(
-            `Gathered ${found}/${batch.length} txs in iteration ${iteration} for epoch ${epochNumber}. In total ${results.size}/${totalTxsRequired} have been retrieved.`,
-            { epochNumber },
-          );
-          iteration++;
-
-          // stop when we found all transactions
-          return txsToFind.length === 0;
-        },
-        'Gather txs',
-        this.options.txGatheringTimeoutMs / 1_000,
-        this.options.txGatheringIntervalMs / 1_000,
-      );
-    } catch (err) {
-      if (err && err instanceof TimeoutError) {
-        const notFoundList = txsToFind
-          .map(txHash => `${txHash.toString()} (block ${txHashToBlock.get(txHash.toString())})`)
-          .join(', ');
-        throw new Error(`Txs not found for epoch ${epochNumber}: ${notFoundList}`);
-      } else {
-        throw err;
-      }
-    }
-
-    return Array.from(results.values());
+    throw new Error(`Txs not found for epoch ${epochNumber}: ${missingTxHashes}`);
   }
 
   /** Extracted for testing purposes. */

--- a/yarn-project/txe/src/node/txe_node.ts
+++ b/yarn-project/txe/src/node/txe_node.ts
@@ -568,6 +568,10 @@ export class TXENode implements AztecNode {
     throw new Error('TXE Node method getTxByHash not implemented');
   }
 
+  getTxsByHash(_txHashes: TxHash[]): Promise<Tx[]> {
+    throw new Error('TXE Node method getTxByHash not implemented');
+  }
+
   /**
    * Gets the storage value at the given contract storage slot.
    *


### PR DESCRIPTION
Adds a `getTxsByHash` (plural) method to the prover-coordination interface, implemented by node and p2pclient. In p2p client, uses the batch reqresp protocol to request txs. Since that already handles retries and timeouts, the retry mechanism is removed from the prover node itself.

Once we review node interfaces, we should probably remove `getTxByHash` (singular) altogether in favor of the plural, and make aztec-node no longer extend prover-coordination since we are no longer using it for that purpose.
