### PR TITLE
fix: contracts with no private / public functions should not fail to generate a contract artifact

### DIFF
--- a/yarn-project/types/src/abi/contract_artifact.ts
+++ b/yarn-project/types/src/abi/contract_artifact.ts
@@ -128,8 +128,8 @@ function generateFunctionArtifact(
   }
 
   let returnTypes: AbiType[] = [];
-  if (functionType === FunctionType.UNCONSTRAINED && fn.abi.return_type) {
-    returnTypes = [fn.abi.return_type.abi_type];
+  if (functionType === FunctionType.UNCONSTRAINED) {
+    returnTypes = fn.abi.return_type ? [fn.abi.return_type.abi_type] : returnTypes;
   } else {
     const pathToFind = `${contract.name}::${fn.name}_abi`;
     const abiStructs: AbiType[] = contract.outputs.structs['functions'];


### PR DESCRIPTION
If there were no public / private functions, the abi structs for functions is undefined. In the previous case, with any private / public function, unconstrained functions would just not exist in the abistructs, and returnTypes would stay an empty array, but if there were no private / public functions, abiStructs would be undefined and we would throw an error. This fixes that.