### PR TITLE
chore: CIVC verifier breakdown

### DIFF
--- a/barretenberg/cpp/src/barretenberg/commitment_schemes_recursion/ipa_recursive.test.cpp
+++ b/barretenberg/cpp/src/barretenberg/commitment_schemes_recursion/ipa_recursive.test.cpp
@@ -229,6 +229,14 @@ TEST_F(IPARecursiveTests, AccumulateMedium)
     test_accumulation(/*POLY_LENGTH=*/1024);
 }
 
+/**
+ * @brief Test accumulation with polynomials of length 1024
+ * @details More details in test_accumulation
+ */
+TEST_F(IPARecursiveTests, AccumulateLarge)
+{
+    test_accumulation(/*POLY_LENGTH=*/1 << CONST_ECCVM_LOG_N);
+}
 TEST_F(IPARecursiveTests, ConstantVerifier)
 {
     test_fixed_ipa_recursive_verifier();

--- a/barretenberg/cpp/src/barretenberg/stdlib/client_ivc_verifier/client_ivc_recursive_verifier.cpp
+++ b/barretenberg/cpp/src/barretenberg/stdlib/client_ivc_verifier/client_ivc_recursive_verifier.cpp
@@ -11,15 +11,18 @@ namespace bb::stdlib::recursion::honk {
 ClientIVCRecursiveVerifier::Output ClientIVCRecursiveVerifier::verify(const ClientIVC::Proof& proof)
 {
     // Construct stdlib Mega verification key
+    info("num gates before making mega vk ", builder->num_gates);
     auto stdlib_mega_vk = std::make_shared<RecursiveVerificationKey>(builder.get(), ivc_verification_key.mega);
-
+    info("num gates after making mega vk ", builder->num_gates);
     // Dummy aggregation object until we do proper aggregation
     aggregation_state<typename RecursiveFlavor::Curve> agg_obj =
         init_default_aggregation_state<Builder, typename RecursiveFlavor::Curve>(*builder);
+    info("num gates after default agg state ", builder->num_gates);
 
     // Perform recursive decider verification
     MegaVerifier verifier{ builder.get(), stdlib_mega_vk };
     verifier.verify_proof(proof.mega_proof, agg_obj);
+    info("num gates after mega verifier ", builder->num_gates);
 
     // Perform Goblin recursive verification
     GoblinVerifierInput goblin_verification_key{ ivc_verification_key.eccvm, ivc_verification_key.translator };

--- a/barretenberg/cpp/src/barretenberg/stdlib/goblin_verifier/goblin_recursive_verifier.cpp
+++ b/barretenberg/cpp/src/barretenberg/stdlib/goblin_verifier/goblin_recursive_verifier.cpp
@@ -13,12 +13,14 @@ GoblinRecursiveVerifierOutput GoblinRecursiveVerifier::verify(const GoblinProof&
     // Run the ECCVM recursive verifier
     ECCVMVerifier eccvm_verifier{ builder, verification_keys.eccvm_verification_key };
     auto [opening_claim, ipa_transcript] = eccvm_verifier.verify_proof(proof.eccvm_proof);
+    info("num gates after eccvm verifier ", builder->num_gates);
 
     // Run the Translator recursive verifier
     TranslatorVerifier translator_verifier{ builder,
                                             verification_keys.translator_verification_key,
                                             eccvm_verifier.transcript };
     translator_verifier.verify_proof(proof.translator_proof);
+    info("num gates after translator verifier ", builder->num_gates);
 
     // Verify the consistency between the ECCVM and Translator transcript polynomial evaluations
     // In reality the Goblin Proof is going to already be a stdlib proof and this conversion is not going to happen here
@@ -33,9 +35,11 @@ GoblinRecursiveVerifierOutput GoblinRecursiveVerifier::verify(const GoblinProof&
 
         };
     translator_verifier.verify_translation(translation_evaluations);
+    info("num gates after translation evals ", builder->num_gates);
 
     MergeVerifier merge_verifier{ builder };
     merge_verifier.verify_proof(proof.merge_proof);
+    info("num gates after merge verification ", builder->num_gates);
     return { opening_claim, ipa_transcript };
 }
 } // namespace bb::stdlib::recursion::honk


### PR DESCRIPTION
estimate about 400k if goblinized?
```
% ./bin/stdlib_client_ivc_verifier_tests --gtest_filter=*ClientTubeBase
Running main() from /home/cody/aztec-packages/barretenberg/cpp/build-assert/_deps/gtest-src/googletest/src/gtest_main.cc
Note: Google Test filter = *ClientTubeBase
[==========] Running 1 test from 1 test suite.
[----------] Global test environment set-up.
[----------] 1 test from ClientIVCRecursionTests
[ RUN      ] ClientIVCRecursionTests.ClientTubeBase
Gate blocks summary: (actual gates / fixed capacity)
goblin ecc op : 10/1024
busread       : 3/128
lookups       : 65933/72000
pub inputs    : 0/128 (populated in decider pk constructor)
arithmetic    : 184359/198000
delta range   : 81544/90000
elliptic      : 4958/9000
auxiliary     : 117772/136000
poseidon ext  : 2/2500
poseidon int  : 2/14000
overflow      : 0/0

Finalized circuit size: 454573. Log dyadic circuit size: 19.
Gate blocks summary: (actual gates / fixed capacity)
goblin ecc op : 44/1024
busread       : 3/128
lookups       : 13540/72000
pub inputs    : 0/128 (populated in decider pk constructor)
arithmetic    : 31732/198000
delta range   : 10201/90000
elliptic      : 7849/9000
auxiliary     : 11803/136000
poseidon ext  : 812/2500
poseidon int  : 4619/14000
overflow      : 0/0

Finalized circuit size: 80559. Log dyadic circuit size: 19.
Minimum required block sizes for structured trace:
ecc_op              : 44
busread             : 3
lookup              : 65933
pub_inputs          : 32
arithmetic          : 184359
delta_range         : 81544
elliptic            : 7849
aux                 : 117772
poseidon2_external  : 812
poseidon2_internal  : 4619
overflow            : 0

Finalized circuit size: 30324. Log dyadic circuit size: 15.
num gates before making mega vk 1
num gates after making mega vk 4788
num gates after default agg state 4979
num gates after mega verifier 767807
num gates after eccvm verifier 942222
num gates after translator verifier 1788241
num gates after translation evals 1788549
num gates after merge verification 1948756
ClientIVC Recursive Verifier: num prefinalized gates = 1948756
Finalized circuit size: 2611719. Log dyadic circuit size: 22.
limbs 0: 0x000000000000000000000000000000000000000000000002da9597b69416a785
limbs 1: 0x000000000000000000000000000000000000000000000000034e384930a88e92
limbs 2: 0x0000000000000000000000000000000000000000000000000000000000000000
limbs 3: 0x0000000000000000000000000000000000000000000000000000000000000000
limbs 0: 0x0000000000000000000000000000000000000000000000000000000000000000
limbs 1: 0x0000000000000000000000000000000000000000000000000000000000000000
limbs 2: 0x0000000000000000000000000000000000000000000000000000000000000000
limbs 3: 0x0000000000000000000000000000000000000000000000000000000000000000
Tube UH Recursive Verifier: num prefinalized gates = 646690
Finalized circuit size: 867049. Log dyadic circuit size: 20.
[       OK ] ClientIVCRecursionTests.ClientTubeBase (45215 ms)
[----------] 1 test from ClientIVCRecursionTests (45215 ms total)

[----------] Global test environment tear-down
[==========] 1 test from 1 test suite ran. (45215 ms total)
[  PASSED  ] 1 test.
```

Please read [contributing guidelines](CONTRIBUTING.md) and remove this line.
