### PR TITLE
chore: cleanup in AVM test fixture

### DIFF
--- a/yarn-project/simulator/src/public/fixtures/public_tx_simulation_tester.ts
+++ b/yarn-project/simulator/src/public/fixtures/public_tx_simulation_tester.ts
@@ -1,4 +1,4 @@
-import { MerkleTreeId, PublicExecutionRequest, type Tx } from '@aztec/circuit-types';
+import { MerkleTreeId, type MerkleTreeWriteOperations, PublicExecutionRequest, type Tx } from '@aztec/circuit-types';
 import {
   type AvmCircuitPublicInputs,
   CallContext,
@@ -43,10 +43,20 @@ export type TestEnqueuedCall = {
 export class PublicTxSimulationTester extends BaseAvmSimulationTester {
   private txCount = 0;
 
+  constructor(
+    private worldStateDB: WorldStateDB,
+    contractDataSource: SimpleContractDataSource,
+    merkleTrees: MerkleTreeWriteOperations,
+    skipContractDeployments: boolean,
+  ) {
+    super(contractDataSource, merkleTrees, skipContractDeployments);
+  }
+
   public static async create(skipContractDeployments = false): Promise<PublicTxSimulationTester> {
     const contractDataSource = new SimpleContractDataSource();
     const merkleTrees = await (await NativeWorldStateService.tmp()).fork();
-    return new PublicTxSimulationTester(contractDataSource, merkleTrees, skipContractDeployments);
+    const worldStateDB = new WorldStateDB(merkleTrees, contractDataSource);
+    return new PublicTxSimulationTester(worldStateDB, contractDataSource, merkleTrees, skipContractDeployments);
   }
 
   public async simulateTx(
@@ -60,8 +70,7 @@ export class PublicTxSimulationTester extends BaseAvmSimulationTester {
     globals.timestamp = TIMESTAMP;
     globals.gasFees = DEFAULT_GAS_FEES;
 
-    const worldStateDB = new WorldStateDB(this.merkleTrees, this.contractDataSource);
-    const simulator = new PublicTxSimulator(this.merkleTrees, worldStateDB, globals, /*doMerkleOperations=*/ true);
+    const simulator = new PublicTxSimulator(this.merkleTrees, this.worldStateDB, globals, /*doMerkleOperations=*/ true);
 
     const setupExecutionRequests: PublicExecutionRequest[] = [];
     for (let i = 0; i < setupCalls.length; i++) {
@@ -118,7 +127,10 @@ export class PublicTxSimulationTester extends BaseAvmSimulationTester {
       feePayer,
     );
 
+    const startTime = performance.now();
     const avmResult = await simulator.simulate(tx);
+    const endTime = performance.now();
+    this.logger.debug(`Public transaction simulation took ${endTime - startTime}ms`);
 
     if (avmResult.revertCode.isOK()) {
       await this.commitTxStateUpdates(avmResult.avmProvingRequest.inputs.publicInputs);


### PR DESCRIPTION
Pulls creation of WorldStateDB instance from `simulateTx` function into tester constructor, so that it isn't constructed again for every TX. This speeds up tests a bit, but not prod. 
