### PR TITLE
fix: prover-client test

### DIFF
--- a/yarn-project/prover-client/src/test/mock_prover.ts
+++ b/yarn-project/prover-client/src/test/mock_prover.ts
@@ -61,11 +61,11 @@ export class TestBroker implements ProvingJobProducer {
     private proofStore: ProofStore = new InlineProofStore(),
     agentPollInterval = 100,
   ) {
+    this.broker = new ProvingBroker(new InMemoryBrokerDatabase());
     this.agents = times(
       agentCount,
       () => new ProvingAgent(this.broker, proofStore, prover, undefined, agentPollInterval),
     );
-    this.broker = new ProvingBroker(new InMemoryBrokerDatabase());
     this.facade = new BrokerCircuitProverFacade(this.broker, proofStore);
   }
 


### PR DESCRIPTION
The `broker` field was initialized after creating the agents so it was passed as undefined. I'm surprised this wasn't caught by the TS compiler
