### PR TITLE
fix: pxe release

### DIFF
--- a/yarn-project/publish_npm.sh
+++ b/yarn-project/publish_npm.sh
@@ -57,6 +57,14 @@ function deploy_package() {
     for PKG in $(jq --raw-output ".dependencies | keys[] | select(contains(\"@aztec/\"))" package.json); do
       jq --arg v $VERSION ".dependencies[\"$PKG\"] = \$v" package.json >$TMP && mv $TMP package.json
     done
+
+    # TODO: Remove this after @noir package resolution is fixed
+    if [[ "$PACKAGE_NAME" == "@aztec/pxe" ]]; then
+      # Hardcodes "1.0.0-beta.1" for @noir-lang/types
+      for PKG in $(jq --raw-output ".dependencies | keys[] | . == \"@noir-lang/types\")" package.json); do
+        jq ".dependencies[\"$PKG\"] = 1.0.0-beta.1" package.json >$TMP && mv $TMP package.json
+      done
+    fi
   fi
 
   # Publish


### PR DESCRIPTION
This is a bit of a hack, and should be deleted once `@noir-lang/` package resolution is fixed.

The pxe release is currently broken as is, so this fixes that.