### PR TITLE
chore: Disable exp-2 from nightly deployments

### DIFF
--- a/.github/workflows/nightly-masternet-deploy.yml
+++ b/.github/workflows/nightly-masternet-deploy.yml
@@ -38,17 +38,17 @@ jobs:
     secrets:
       GCP_SA_KEY: ${{ secrets.GCP_SA_KEY }}
 
-  deploy-network-exp:
-    needs: get-latest-commit
-    uses: ./.github/workflows/network-deploy.yml
-    with:
-      ref: master
-      cluster: aztec-gke-private
-      namespace: master-exp-2
-      values_file: exp-2.yaml
-      aztec_docker_image: aztecprotocol/aztec@${{ needs.get-latest-commit.outputs.commit }}
-      deployment_mnemonic_secret_name: junk-mnemonic
-      respect_tf_lock: "false"
-      run_terraform_destroy: "true"
-    secrets:
-      GCP_SA_KEY: ${{ secrets.GCP_SA_KEY }}
+  # deploy-network-exp:
+  #   needs: get-latest-commit
+  #   uses: ./.github/workflows/network-deploy.yml
+  #   with:
+  #     ref: master
+  #     cluster: aztec-gke-private
+  #     namespace: master-exp-2
+  #     values_file: exp-2.yaml
+  #     aztec_docker_image: aztecprotocol/aztec@${{ needs.get-latest-commit.outputs.commit }}
+  #     deployment_mnemonic_secret_name: junk-mnemonic
+  #     respect_tf_lock: "false"
+  #     run_terraform_destroy: "true"
+  #   secrets:
+  #     GCP_SA_KEY: ${{ secrets.GCP_SA_KEY }}


### PR DESCRIPTION
This PR simply disables the exp-2 configuration from the nightly deployments
