### PR TITLE
fix: downgrade to mainframe-compatible KIND

### DIFF
--- a/spartan/scripts/install_deps.sh
+++ b/spartan/scripts/install_deps.sh
@@ -12,7 +12,7 @@ fi
 
 # Install kind if it is not installed
 if ! command -v kind &> /dev/null; then
-  curl -Lo ./kind https://github.com/kubernetes-sigs/kind/releases/download/v0.26.0/kind-${os}-$(arch)
+  curl -Lo ./kind https://github.com/kubernetes-sigs/kind/releases/download/v0.23.0/kind-${os}-$(arch)
   chmod +x ./kind
   sudo mv ./kind /usr/local/bin/kind
 fi


### PR DESCRIPTION
not caught by anyone who already had KIND in their /usr/local/bin folder, which shouldn't be anyone post restart