### PR TITLE
fix: dont skip wasm civc tests

### DIFF
--- a/yarn-project/ivc-integration/src/wasm_client_ivc_integration.test.ts
+++ b/yarn-project/ivc-integration/src/wasm_client_ivc_integration.test.ts
@@ -38,7 +38,7 @@ describe('Client IVC Integration', () => {
   // 1. Run a mock app that creates two commitments
   // 2. Run the init kernel to process the app run
   // 3. Run the tail kernel to finish the client IVC chain.
-  it.skip('Should generate a verifiable client IVC proof from a simple mock tx via bb.js', async () => {
+  it('Should generate a verifiable client IVC proof from a simple mock tx via bb.js', async () => {
     const tx = {
       number_of_calls: '0x1',
     };
@@ -82,7 +82,7 @@ describe('Client IVC Integration', () => {
   // 4. Run the inner kernel to process the second app run
   // 5. Run the reset kernel to process the read request emitted by the reader app
   // 6. Run the tail kernel to finish the client IVC chain
-  it.skip('Should generate a verifiable client IVC proof from a complex mock tx', async () => {
+  it('Should generate a verifiable client IVC proof from a complex mock tx', async () => {
     const tx = {
       number_of_calls: '0x2',
     };


### PR DESCRIPTION
the native version of these tests fails and should be skipped for now but the wasm version passes and should not be skipped