### PR TITLE
fix: don't restart kind control plane automatically

### DIFF
--- a/spartan/bootstrap.sh
+++ b/spartan/bootstrap.sh
@@ -60,6 +60,7 @@ case "$cmd" in
       kind create cluster
     fi
     kubectl config use-context kind-kind || true
+    docker update --restart=no kind-control-plane >/dev/null
     ;;
   "chaos-mesh")
     chaos-mesh/install.sh


### PR DESCRIPTION
This causes pods to go back up, and if they caused issues on mainframe the issues repeat