### PR TITLE
chore: only take FF (and not Flavor) in compute_logderivative_inverse

### DIFF
--- a/barretenberg/cpp/src/barretenberg/eccvm/eccvm_composer.test.cpp
+++ b/barretenberg/cpp/src/barretenberg/eccvm/eccvm_composer.test.cpp
@@ -78,7 +78,7 @@ void complete_proving_key_for_test(bb::RelationParameters<FF>& relation_paramete
     relation_parameters.eccvm_set_permutation_delta = relation_parameters.eccvm_set_permutation_delta.invert();
 
     // Compute z_perm and inverse polynomial for our logarithmic-derivative lookup method
-    compute_logderivative_inverse<ECCVMFlavor, ECCVMFlavor::LookupRelation>(
+    compute_logderivative_inverse<FF, ECCVMFlavor::LookupRelation>(
         pk->polynomials, relation_parameters, pk->circuit_size);
     compute_grand_products<ECCVMFlavor>(pk->polynomials, relation_parameters);
 

--- a/barretenberg/cpp/src/barretenberg/eccvm/eccvm_prover.cpp
+++ b/barretenberg/cpp/src/barretenberg/eccvm/eccvm_prover.cpp
@@ -83,7 +83,7 @@ void ECCVMProver::execute_log_derivative_commitments_round()
         gamma * (gamma + beta_sqr) * (gamma + beta_sqr + beta_sqr) * (gamma + beta_sqr + beta_sqr + beta_sqr);
     relation_parameters.eccvm_set_permutation_delta = relation_parameters.eccvm_set_permutation_delta.invert();
     // Compute inverse polynomial for our logarithmic-derivative lookup method
-    compute_logderivative_inverse<Flavor, typename Flavor::LookupRelation>(
+    compute_logderivative_inverse<typename Flavor::FF, typename Flavor::LookupRelation>(
         key->polynomials, relation_parameters, key->circuit_size);
     transcript->send_to_verifier(commitment_labels.lookup_inverses,
                                  key->commitment_key->commit(key->polynomials.lookup_inverses));

--- a/barretenberg/cpp/src/barretenberg/eccvm/eccvm_trace_checker.cpp
+++ b/barretenberg/cpp/src/barretenberg/eccvm/eccvm_trace_checker.cpp
@@ -31,7 +31,7 @@ bool ECCVMTraceChecker::check(Builder& builder, numeric::RNG* engine_ptr)
 
     ProverPolynomials polynomials(builder);
     const size_t num_rows = polynomials.get_polynomial_size();
-    compute_logderivative_inverse<Flavor, ECCVMLookupRelation<FF>>(polynomials, params, num_rows);
+    compute_logderivative_inverse<FF, ECCVMLookupRelation<FF>>(polynomials, params, num_rows);
     compute_grand_product<Flavor, ECCVMSetRelation<FF>>(polynomials, params);
 
     polynomials.z_perm_shift = Polynomial(polynomials.z_perm.shifted());

--- a/barretenberg/cpp/src/barretenberg/honk/proof_system/logderivative_library.hpp
+++ b/barretenberg/cpp/src/barretenberg/honk/proof_system/logderivative_library.hpp
@@ -1,4 +1,7 @@
 #pragma once
+
+#include "barretenberg/common/constexpr_utils.hpp"
+
 #include <typeinfo>
 
 namespace bb {
@@ -22,10 +25,9 @@ namespace bb {
  * The specific algebraic relations that define read terms and write terms are defined in Flavor::LookupRelation
  *
  */
-template <typename Flavor, typename Relation, typename Polynomials>
+template <typename FF, typename Relation, typename Polynomials>
 void compute_logderivative_inverse(Polynomials& polynomials, auto& relation_parameters, const size_t circuit_size)
 {
-    using FF = typename Flavor::FF;
     using Accumulator = typename Relation::ValueAccumulator0;
     constexpr size_t READ_TERMS = Relation::READ_TERMS;
     constexpr size_t WRITE_TERMS = Relation::WRITE_TERMS;

--- a/barretenberg/cpp/src/barretenberg/vm/avm/generated/circuit_builder.cpp
+++ b/barretenberg/cpp/src/barretenberg/vm/avm/generated/circuit_builder.cpp
@@ -883,7 +883,7 @@ bool AvmCircuitBuilder::check_circuit() const
         using Relation = std::tuple_element_t<i, AvmFlavor::LookupRelations>;
         checks.push_back([&, num_rows](SignalErrorFn signal_error) {
             // Check the logderivative relation
-            bb::compute_logderivative_inverse<Flavor, Relation>(polys, params, num_rows);
+            bb::compute_logderivative_inverse<typename Flavor::FF, Relation>(polys, params, num_rows);
 
             typename Relation::SumcheckArrayOfValuesOverSubrelations lookup_result;
 

--- a/barretenberg/cpp/src/barretenberg/vm/avm/generated/prover.cpp
+++ b/barretenberg/cpp/src/barretenberg/vm/avm/generated/prover.cpp
@@ -67,7 +67,7 @@ void AvmProver::execute_log_derivative_inverse_round()
         using Relation = std::tuple_element_t<relation_idx, Flavor::LookupRelations>;
         tasks.push_back([&]() {
             AVM_TRACK_TIME(std::string("prove/execute_log_derivative_inverse_round/") + std::string(Relation::NAME),
-                           (compute_logderivative_inverse<Flavor, Relation>(
+                           (compute_logderivative_inverse<FF, Relation>(
                                prover_polynomials, relation_parameters, key->circuit_size)));
         });
     });

--- a/barretenberg/cpp/src/barretenberg/vm/avm/tests/full_poseidon2.test.cpp
+++ b/barretenberg/cpp/src/barretenberg/vm/avm/tests/full_poseidon2.test.cpp
@@ -88,7 +88,7 @@ TEST(AvmFullPoseidon2, shouldHashCorrectly)
     using PermRelations = perm_pos2_fixed_pos2_perm_relation<FF>;
 
     // Check the logderivative relation
-    bb::compute_logderivative_inverse<AvmFlavor, PermRelations>(polys, params, num_rows);
+    bb::compute_logderivative_inverse<FF, PermRelations>(polys, params, num_rows);
 
     typename PermRelations::SumcheckArrayOfValuesOverSubrelations lookup_result;
 

--- a/barretenberg/cpp/src/barretenberg/vm/avm/tests/merkle_tree.test.cpp
+++ b/barretenberg/cpp/src/barretenberg/vm/avm/tests/merkle_tree.test.cpp
@@ -109,7 +109,7 @@ TEST(AvmMerkleTree, shouldCheckMembership)
     using PermRelations = perm_merkle_poseidon2_relation<FF>;
 
     // Check the logderivative relation
-    bb::compute_logderivative_inverse<AvmFlavor, PermRelations>(polys, params, num_rows);
+    bb::compute_logderivative_inverse<FF, PermRelations>(polys, params, num_rows);
 
     typename PermRelations::SumcheckArrayOfValuesOverSubrelations lookup_result;
 

--- a/barretenberg/cpp/src/barretenberg/vm/avm/tests/range_check.test.cpp
+++ b/barretenberg/cpp/src/barretenberg/vm/avm/tests/range_check.test.cpp
@@ -118,7 +118,7 @@ TEST(AvmRangeCheck, shouldRangeCheck)
         using LookupRelations = std::tuple_element_t<i, AllLookupRelations>;
 
         // Check the logderivative relation
-        bb::compute_logderivative_inverse<AvmFlavor, LookupRelations>(polys, params, num_rows);
+        bb::compute_logderivative_inverse<FF, LookupRelations>(polys, params, num_rows);
 
         typename LookupRelations::SumcheckArrayOfValuesOverSubrelations lookup_result;
 

--- a/barretenberg/cpp/src/barretenberg/vm2/constraining/check_circuit.cpp
+++ b/barretenberg/cpp/src/barretenberg/vm2/constraining/check_circuit.cpp
@@ -57,7 +57,7 @@ void run_check_circuit(AvmFlavor::ProverPolynomials& polys, size_t num_rows)
         using Relation = std::tuple_element_t<i, typename AvmFlavor::LookupRelations>;
         checks.push_back([&, num_rows]() {
             // Compute logderivs.
-            bb::compute_logderivative_inverse<AvmFlavor, Relation>(polys, params, num_rows);
+            bb::compute_logderivative_inverse<typename AvmFlavor::FF, Relation>(polys, params, num_rows);
 
             // Check the logderivative relation
             typename Relation::SumcheckArrayOfValuesOverSubrelations lookup_result{};

--- a/barretenberg/cpp/src/barretenberg/vm2/generated/prover.cpp
+++ b/barretenberg/cpp/src/barretenberg/vm2/generated/prover.cpp
@@ -67,7 +67,7 @@ void AvmProver::execute_log_derivative_inverse_round()
         using Relation = std::tuple_element_t<relation_idx, Flavor::LookupRelations>;
         tasks.push_back([&]() {
             AVM_TRACK_TIME(std::string("prove/execute_log_derivative_inverse_round/") + std::string(Relation::NAME),
-                           (compute_logderivative_inverse<Flavor, Relation>(
+                           (compute_logderivative_inverse<FF, Relation>(
                                prover_polynomials, relation_parameters, key->circuit_size)));
         });
     });

--- a/bb-pilcom/bb-pil-backend/templates/circuit_builder.cpp.hbs
+++ b/bb-pilcom/bb-pil-backend/templates/circuit_builder.cpp.hbs
@@ -165,7 +165,7 @@ bool AvmCircuitBuilder::check_circuit() const {
         using Relation = std::tuple_element_t<i, AvmFlavor::LookupRelations>;
         checks.push_back([&, num_rows](SignalErrorFn signal_error) {
             // Check the logderivative relation
-            bb::compute_logderivative_inverse<Flavor, Relation>(polys, params, num_rows);
+            bb::compute_logderivative_inverse<typename Flavor::FF, Relation>(polys, params, num_rows);
 
             typename Relation::SumcheckArrayOfValuesOverSubrelations lookup_result;
 

--- a/bb-pilcom/bb-pil-backend/templates/prover.cpp.hbs
+++ b/bb-pilcom/bb-pil-backend/templates/prover.cpp.hbs
@@ -67,7 +67,7 @@ void AvmProver::execute_log_derivative_inverse_round()
         using Relation = std::tuple_element_t<relation_idx, Flavor::LookupRelations>;
         tasks.push_back([&]() {
             AVM_TRACK_TIME(std::string("prove/execute_log_derivative_inverse_round/") + std::string(Relation::NAME),
-                           (compute_logderivative_inverse<Flavor, Relation>(
+                           (compute_logderivative_inverse<FF, Relation>(
                                prover_polynomials, relation_parameters, key->circuit_size)));
         });
     });


### PR DESCRIPTION
The Flavor is not needed, and no other function in the file takes the Flavor as a template param. Just taking FF lets callers avoid having to import the whole flavor.
