### PR TITLE
fix: set resource limits on Loki pods

### DIFF
--- a/spartan/metrics/values/kind.yaml
+++ b/spartan/metrics/values/kind.yaml
@@ -56,8 +56,26 @@ loki:
             period: 24h
           object_store: filesystem # we're storing on filesystem so there's no real persistence here.
           schema: v13
+    limits_config:
+      ingestion_rate_mb: 4
+      ingestion_burst_size_mb: 6
+      max_global_streams_per_user: 5000
+      max_query_series: 500
+      max_query_lookback: 24h
+      max_query_length: 1h
+      max_query_parallelism: 8
+      query_timeout: 3m
   singleBinary:
     replicas: 1
+    resources:
+      requests:
+        cpu: 100m
+        memory: 256Mi
+      limits:
+        cpu: 2000m
+        memory: 2Gi
+    persistence:
+      size: 10Gi
   read:
     replicas: 0
   backend:

--- a/yarn-project/end-to-end/src/spartan/utils.ts
+++ b/yarn-project/end-to-end/src/spartan/utils.ts
@@ -107,7 +107,7 @@ export async function startPortForward({
     if (str.includes('Starting port forward')) {
       logger.info(str);
     } else {
-      logger.debug(str);
+      logger.silent(str);
     }
   });
   process.stderr?.on('data', data => {


### PR DESCRIPTION
This PR sets limits so that Loki doesn't consume too many resources in kind clusters. 