### PR TITLE
Remove excess 0x in cli wallet log

### DIFF
--- a/yarn-project/cli-wallet/src/cmds/create_account.ts
+++ b/yarn-project/cli-wallet/src/cmds/create_account.ts
@@ -49,7 +49,7 @@ export async function createAccount(
   } else {
     log(`\nNew account:\n`);
     log(`Address:         ${address.toString()}`);
-    log(`Public key:      0x${publicKeys.toString()}`);
+    log(`Public key:      ${publicKeys.toString()}`);
     if (secretKey) {
       log(`Secret key:     ${secretKey.toString()}`);
     }

--- a/yarn-project/cli-wallet/src/cmds/deploy_account.ts
+++ b/yarn-project/cli-wallet/src/cmds/deploy_account.ts
@@ -27,7 +27,7 @@ export async function deployAccount(
   } else {
     log(`\nNew account:\n`);
     log(`Address:         ${address.toString()}`);
-    log(`Public key:      0x${publicKeys.toString()}`);
+    log(`Public key:      ${publicKeys.toString()}`);
     if (secretKey) {
       log(`Secret key:     ${secretKey.toString()}`);
     }


### PR DESCRIPTION
[toString](https://github.com/AztecProtocol/aztec-packages/blob/master/yarn-project/circuits.js/src/types/public_keys.ts#L188) calls [bufferToHex](https://github.com/AztecProtocol/aztec-packages/blob/master/yarn-project/foundation/src/string/index.ts#L18) which already includes `0x`