### PR TITLE
fix: De-dup pubkey conversion of cli-wallet param

### DIFF
--- a/yarn-project/cli-wallet/src/cmds/index.ts
+++ b/yarn-project/cli-wallet/src/cmds/index.ts
@@ -206,7 +206,7 @@ export function injectCommands(
       wallet,
       artifactPath,
       json,
-      publicKey ? PublicKeys.fromString(publicKey) : undefined,
+      publicKey,
       args,
       salt,
       typeof init === 'string' ? init : undefined,

--- a/yarn-project/cli-wallet/src/cmds/index.ts
+++ b/yarn-project/cli-wallet/src/cmds/index.ts
@@ -3,7 +3,6 @@ import { createCompatibleClient } from '@aztec/aztec.js/rpc';
 import { TxHash } from '@aztec/aztec.js/tx_hash';
 import { createAztecNodeClient } from '@aztec/circuit-types';
 import { GasFees } from '@aztec/circuits.js';
-import { PublicKeys } from '@aztec/circuits.js/types';
 import {
   ETHEREUM_HOST,
   PRIVATE_KEY,


### PR DESCRIPTION
The public key option has a [function](https://github.com/AztecProtocol/aztec-packages/blob/master/yarn-project/cli-wallet/src/cmds/index.ts#L157) that interpreted the string to a public key, and this conversion was attempted [again](https://github.com/AztecProtocol/aztec-packages/blob/master/yarn-project/cli-wallet/src/cmds/index.ts#L209) on the PublicKeys type.

TODO: Fix the comments of the cli wallet and `parsePublicKey` to better reflect that publicKey is not actually singular and a concatenation of all the contract's keys and is only used circumspectly when decrypting (but directly for nullifying)