### PR TITLE
chore: Updated boot-node.yaml and values.yaml to make it easier to specify manual contract addresses. 

### DIFF
--- a/spartan/aztec-network/templates/boot-node.yaml
+++ b/spartan/aztec-network/templates/boot-node.yaml
@@ -307,6 +307,11 @@ data:
     export FEE_JUICE_CONTRACT_ADDRESS={{ .Values.bootNode.contracts.feeJuiceAddress }}
     export STAKING_ASSET_CONTRACT_ADDRESS={{ .Values.bootNode.contracts.stakingAssetAddress }}
     export FEE_JUICE_PORTAL_CONTRACT_ADDRESS={{ .Values.bootNode.contracts.feeJuicePortalAddress }}
+    export COIN_ISSUER_CONTRACT_ADDRESS={{ .Values.bootNode.contracts.coinIssuerAddress }}
+    export REWARD_DISTRIBUTOR_CONTRACT_ADDRESS={{ .Values.bootNode.contracts.rewardDistributorAddress }}
+    export GOVERNANCE_PROPOSER_CONTRACT_ADDRESS={{ .Values.bootNode.contracts.governanceProposerAddress }}
+    export GOVERNANCE_CONTRACT_ADDRESS={{ .Values.bootNode.contracts.governanceAddress }}
+    export SLASH_FACTORY_CONTRACT_ADDRESS={{ .Values.bootNode.contracts.slashFactoryAddress }}
 {{- end }}
 ---
 # Headless service for StatefulSet DNS entries

--- a/spartan/aztec-network/values.yaml
+++ b/spartan/aztec-network/values.yaml
@@ -94,11 +94,16 @@ bootNode:
     inboxAddress: ""
     outboxAddress: ""
     feeJuiceAddress: ""
+    stakingAssetAddress: ""
     feeJuicePortalAddress: ""
+    coinIssuerAddress: ""
+    rewardDistributorAddress: ""
+    governanceProposerAddress: ""
+    governanceAddress: ""
+    slashFactoryAddress: ""
   archiverPollingInterval: 1000
   archiverViemPollingInterval: 1000
   viemPollingInterval: 1000
-  stakingAssetAddress: ""
   storageSize: "1Gi"
   dataDir: "/data"
 


### PR DESCRIPTION
added the rest of the contracts to the contracts.env volume mount when deployContracts==false
