### PR TITLE
feat(avm): relation microbenchmarks

### DIFF
--- a/barretenberg/cpp/src/barretenberg/vm2/constraining/benchmark/README.md
+++ b/barretenberg/cpp/src/barretenberg/vm2/constraining/benchmark/README.md
@@ -1,0 +1,6 @@
+Compile with
+
+- `cmake --preset bench`.
+- `cmake --build --preset bench --target relations_acc_bench`.
+
+Run with `( cd build-bench && bin/relations_acc_bench )`.

--- a/barretenberg/cpp/src/barretenberg/vm2/constraining/benchmark/relations_acc.bench.cpp
+++ b/barretenberg/cpp/src/barretenberg/vm2/constraining/benchmark/relations_acc.bench.cpp
@@ -1,0 +1,65 @@
+#include <benchmark/benchmark.h>
+
+#include "barretenberg/common/constexpr_utils.hpp"
+#include "barretenberg/relations/relation_parameters.hpp"
+#include "barretenberg/vm2/common/field.hpp"
+#include "barretenberg/vm2/generated/columns.hpp"
+#include "barretenberg/vm2/generated/flavor.hpp"
+#include "barretenberg/vm2/generated/full_row.hpp"
+#include "barretenberg/vm2/generated/relations/range_check.hpp"
+
+using namespace benchmark;
+using namespace bb::avm2;
+
+namespace {
+
+AvmFullRow<FF> get_random_row()
+{
+    AvmFullRow<FF> row;
+    for (size_t i = 0; i < NUM_COLUMNS_WITH_SHIFTS; i++) {
+        row.get_column(static_cast<ColumnAndShifts>(i)) = FF::random_element();
+    }
+    return row;
+}
+
+bb::RelationParameters<FF> get_params()
+{
+    return {
+        .eta = 0,
+        .beta = FF::random_element(),
+        .gamma = FF::random_element(),
+        .public_input_delta = 0,
+        .lookup_grand_product_delta = 0,
+        .beta_sqr = 0,
+        .beta_cube = 0,
+        .eccvm_set_permutation_delta = 0,
+    };
+}
+
+template <typename Relation> void BM_accumulate_random(State& state)
+{
+    auto row = get_random_row();
+    auto params = get_params();
+    FF scaling_factor = 1;
+
+    typename Relation::SumcheckArrayOfValuesOverSubrelations result{};
+
+    for (auto _ : state) {
+        Relation::accumulate(result, row, params, scaling_factor);
+    }
+}
+
+} // namespace
+
+int main(int argc, char** argv)
+{
+    bb::constexpr_for<0, std::tuple_size_v<typename AvmFlavor::MainRelations>, 1>([&]<size_t i>() {
+        using Relation = std::tuple_element_t<i, typename AvmFlavor::MainRelations>;
+        BENCHMARK(BM_accumulate_random<Relation>)
+            ->Name(std::string(Relation::NAME) + "_acc_random")
+            ->Unit(kMicrosecond);
+    });
+
+    ::benchmark::Initialize(&argc, argv);
+    ::benchmark::RunSpecifiedBenchmarks();
+}


### PR DESCRIPTION
Relation accumulation microbenchmarks

```
----------------------------------------------------------------------
Benchmark                            Time             CPU   Iterations
----------------------------------------------------------------------
alu_acc_random                   0.126 us        0.126 us      5542448
bc_decomposition_acc_random       4.32 us         4.32 us       161914
bc_retrieval_acc_random          0.024 us        0.024 us     28942571
bitwise_acc_random                1.42 us         1.42 us       493754
ecc_acc_random                    2.61 us         2.61 us       269299
execution_acc_random             0.527 us        0.527 us      1309267
instr_fetching_acc_random        0.024 us        0.024 us     29060773
range_check_acc_random            2.77 us         2.77 us       257953
sha256_acc_random                 6.33 us         6.33 us       111173
```
