### PR TITLE
feat: fetch addresses from registry

### DIFF
--- a/l1-contracts/test/governance/scenario/RegisterNewRollupVersionPayload.sol
+++ b/l1-contracts/test/governance/scenario/RegisterNewRollupVersionPayload.sol
@@ -1,0 +1,31 @@
+// SPDX-License-Identifier: UNLICENSED
+pragma solidity >=0.8.27;
+
+import {IPayload} from "@aztec/governance/interfaces/IPayload.sol";
+import {IRegistry} from "@aztec/governance/interfaces/IRegistry.sol";
+
+/**
+ * @title RegisterNewRollupVersionPayload
+ * @author Aztec Labs
+ * @notice A payload that registers a new rollup version.
+ */
+contract RegisterNewRollupVersionPayload is IPayload {
+  IRegistry public immutable REGISTRY;
+  address public immutable ROLLUP;
+
+  constructor(IRegistry _registry, address _rollup) {
+    REGISTRY = _registry;
+    ROLLUP = _rollup;
+  }
+
+  function getActions() external view override(IPayload) returns (IPayload.Action[] memory) {
+    IPayload.Action[] memory res = new IPayload.Action[](1);
+
+    res[0] = Action({
+      target: address(REGISTRY),
+      data: abi.encodeWithSelector(IRegistry.upgrade.selector, ROLLUP)
+    });
+
+    return res;
+  }
+}

--- a/spartan/aztec-network/files/config/config-prover-env.sh
+++ b/spartan/aztec-network/files/config/config-prover-env.sh
@@ -19,7 +19,6 @@ coin_issuer_address=$(echo "$output" | grep -oP 'CoinIssuer Address: \K0x[a-fA-F
 reward_distributor_address=$(echo "$output" | grep -oP 'RewardDistributor Address: \K0x[a-fA-F0-9]{40}')
 governance_proposer_address=$(echo "$output" | grep -oP 'GovernanceProposer Address: \K0x[a-fA-F0-9]{40}')
 governance_address=$(echo "$output" | grep -oP 'Governance Address: \K0x[a-fA-F0-9]{40}')
-slash_factory_address=$(echo "$output" | grep -oP 'SlashFactory Address: \K0x[a-fA-F0-9]{40}')
 
 # Write the addresses to a file in the shared volume
 cat <<EOF >/shared/contracts/contracts.env
@@ -35,7 +34,6 @@ export COIN_ISSUER_CONTRACT_ADDRESS=$coin_issuer_address
 export REWARD_DISTRIBUTOR_CONTRACT_ADDRESS=$reward_distributor_address
 export GOVERNANCE_PROPOSER_CONTRACT_ADDRESS=$governance_proposer_address
 export GOVERNANCE_CONTRACT_ADDRESS=$governance_address
-export SLASH_FACTORY_CONTRACT_ADDRESS=$slash_factory_address
 EOF
 
 cat /shared/contracts/contracts.env

--- a/yarn-project/aztec.js/src/contract/contract.test.ts
+++ b/yarn-project/aztec.js/src/contract/contract.test.ts
@@ -41,7 +41,6 @@ describe('Contract Class', () => {
     coinIssuerAddress: EthAddress.random(),
     rewardDistributorAddress: EthAddress.random(),
     governanceProposerAddress: EthAddress.random(),
-    slashFactoryAddress: EthAddress.random(),
   };
 
   const defaultArtifact: ContractArtifact = {

--- a/yarn-project/cli/src/cmds/l1/deploy_l1_contracts.ts
+++ b/yarn-project/cli/src/cmds/l1/deploy_l1_contracts.ts
@@ -58,6 +58,6 @@ export async function deployL1Contracts(
     log(`RewardDistributor Address: ${l1ContractAddresses.rewardDistributorAddress.toString()}`);
     log(`GovernanceProposer Address: ${l1ContractAddresses.governanceProposerAddress.toString()}`);
     log(`Governance Address: ${l1ContractAddresses.governanceAddress.toString()}`);
-    log(`SlashFactory Address: ${l1ContractAddresses.slashFactoryAddress.toString()}`);
+    log(`SlashFactory Address: ${l1ContractAddresses.slashFactoryAddress?.toString()}`);
   }
 }

--- a/yarn-project/cli/src/cmds/pxe/get_node_info.ts
+++ b/yarn-project/cli/src/cmds/pxe/get_node_info.ts
@@ -34,7 +34,7 @@ export async function getNodeInfo(
         rewardDistributor: info.l1ContractAddresses.rewardDistributorAddress.toString(),
         governanceProposer: info.l1ContractAddresses.governanceProposerAddress.toString(),
         governance: info.l1ContractAddresses.governanceAddress.toString(),
-        slashFactory: info.l1ContractAddresses.slashFactoryAddress.toString(),
+        slashFactory: info.l1ContractAddresses.slashFactoryAddress?.toString(),
       },
       protocolContractAddresses: {
         classRegisterer: info.protocolContractAddresses.classRegisterer.toString(),
@@ -60,7 +60,7 @@ export async function getNodeInfo(
     log(` RewardDistributor Address: ${info.l1ContractAddresses.rewardDistributorAddress.toString()}`);
     log(` GovernanceProposer Address: ${info.l1ContractAddresses.governanceProposerAddress.toString()}`);
     log(` Governance Address: ${info.l1ContractAddresses.governanceAddress.toString()}`);
-    log(` SlashFactory Address: ${info.l1ContractAddresses.slashFactoryAddress.toString()}`);
+    log(` SlashFactory Address: ${info.l1ContractAddresses.slashFactoryAddress?.toString()}`);
 
     log(`L2 Contract Addresses:`);
     log(` Class Registerer: ${info.protocolContractAddresses.classRegisterer.toString()}`);

--- a/yarn-project/end-to-end/src/e2e_p2p/slashing.test.ts
+++ b/yarn-project/end-to-end/src/e2e_p2p/slashing.test.ts
@@ -83,7 +83,7 @@ describe('e2e_p2p_slashing', () => {
     });
 
     const slashFactory = getContract({
-      address: getAddress(t.ctx.deployL1ContractsValues.l1ContractAddresses.slashFactoryAddress.toString()),
+      address: getAddress(t.ctx.deployL1ContractsValues.l1ContractAddresses.slashFactoryAddress!.toString()),
       abi: SlashFactoryAbi,
       client: t.ctx.deployL1ContractsValues.publicClient,
     });

--- a/yarn-project/ethereum/package.json
+++ b/yarn-project/ethereum/package.json
@@ -49,6 +49,7 @@
     "@viem/anvil": "^0.0.10",
     "get-port": "^7.1.0",
     "jest": "^29.5.0",
+    "lodash.omit": "^4.5.0",
     "ts-node": "^10.9.1",
     "typescript": "^5.0.4"
   },

--- a/yarn-project/ethereum/src/contracts/registry.test.ts
+++ b/yarn-project/ethereum/src/contracts/registry.test.ts
@@ -1,0 +1,256 @@
+import { Fr } from '@aztec/foundation/fields';
+import { type Logger, createLogger } from '@aztec/foundation/log';
+import { TestERC20Abi as FeeJuiceAbi, GovernanceAbi } from '@aztec/l1-artifacts';
+
+import type { Anvil } from '@viem/anvil';
+import omit from 'lodash.omit';
+import { getContract } from 'viem';
+import { type PrivateKeyAccount, privateKeyToAccount } from 'viem/accounts';
+import { foundry } from 'viem/chains';
+
+import { DefaultL1ContractsConfig } from '../config.js';
+import { createL1Clients, deployL1Contracts, deployRollupAndPeriphery } from '../deploy_l1_contracts.js';
+import { EthCheatCodes } from '../eth_cheat_codes.js';
+import type { L1ContractAddresses } from '../l1_contract_addresses.js';
+import { defaultL1TxUtilsConfig } from '../l1_tx_utils.js';
+import { startAnvil } from '../test/start_anvil.js';
+import type { L1Clients } from '../types.js';
+import { RegistryContract } from './registry.js';
+
+const originalVersionSalt = 42;
+
+describe('Registry', () => {
+  let anvil: Anvil;
+  let rpcUrl: string;
+  let privateKey: PrivateKeyAccount;
+  let logger: Logger;
+
+  let vkTreeRoot: Fr;
+  let protocolContractTreeRoot: Fr;
+  let l2FeeJuiceAddress: Fr;
+  let publicClient: L1Clients['publicClient'];
+  let walletClient: L1Clients['walletClient'];
+  let registry: RegistryContract;
+  let deployedAddresses: L1ContractAddresses;
+
+  beforeAll(async () => {
+    logger = createLogger('ethereum:test:registry');
+    // this is the 6th address that gets funded by the junk mnemonic
+    privateKey = privateKeyToAccount('0x8b3a350cf5c34c9194ca85829a2df0ec3153be0318b5e2d3348e872092edffba');
+    vkTreeRoot = Fr.random();
+    protocolContractTreeRoot = Fr.random();
+    l2FeeJuiceAddress = Fr.random();
+
+    ({ anvil, rpcUrl } = await startAnvil());
+
+    ({ publicClient, walletClient } = createL1Clients(rpcUrl, privateKey));
+
+    const deployed = await deployL1Contracts(rpcUrl, privateKey, foundry, logger, {
+      ...DefaultL1ContractsConfig,
+      salt: originalVersionSalt,
+      vkTreeRoot,
+      protocolContractTreeRoot,
+      l2FeeJuiceAddress,
+      genesisArchiveRoot: Fr.random(),
+      genesisBlockHash: Fr.random(),
+    });
+    // Since the registry cannot "see" the slash factory, we omit it from the addresses for this test
+    deployedAddresses = omit(deployed.l1ContractAddresses, 'slashFactoryAddress');
+    registry = new RegistryContract(publicClient, deployedAddresses.registryAddress);
+  });
+
+  afterAll(async () => {
+    await anvil.stop();
+  });
+
+  it('gets rollup versions', async () => {
+    const rollupAddress = deployedAddresses.rollupAddress;
+    {
+      const address = await registry.getCanonicalAddress();
+      expect(address).toEqual(rollupAddress);
+    }
+    {
+      const address = await registry.getRollupAddress('canonical');
+      expect(address).toEqual(rollupAddress);
+    }
+    {
+      const address = await registry.getRollupAddress(1);
+      expect(address).toEqual(rollupAddress);
+    }
+  });
+
+  it('handles non-existent versions', async () => {
+    const address = await registry.getRollupAddress(2);
+    expect(address).toBeUndefined();
+  });
+
+  it('collects addresses', async () => {
+    await expect(
+      RegistryContract.collectAddresses(publicClient, deployedAddresses.registryAddress, 'canonical'),
+    ).resolves.toEqual(deployedAddresses);
+
+    await expect(
+      RegistryContract.collectAddresses(publicClient, deployedAddresses.registryAddress, 1),
+    ).resolves.toEqual(deployedAddresses);
+
+    // Version 2 does not exist
+
+    await expect(RegistryContract.collectAddresses(publicClient, deployedAddresses.registryAddress, 2)).rejects.toThrow(
+      'Rollup address is undefined',
+    );
+  });
+
+  it('adds a version to the registry', async () => {
+    const addresses = await RegistryContract.collectAddresses(
+      publicClient,
+      deployedAddresses.registryAddress,
+      'canonical',
+    );
+    const newVersionSalt = originalVersionSalt + 1;
+
+    const { rollup: newRollup, payloadAddress } = await deployRollupAndPeriphery(
+      rpcUrl,
+      foundry,
+      privateKey,
+      {
+        ...DefaultL1ContractsConfig,
+        salt: newVersionSalt,
+        vkTreeRoot,
+        protocolContractTreeRoot,
+        l2FeeJuiceAddress,
+        genesisArchiveRoot: Fr.random(),
+        genesisBlockHash: Fr.random(),
+      },
+      {
+        feeJuicePortalAddress: addresses.feeJuicePortalAddress,
+        rewardDistributorAddress: addresses.rewardDistributorAddress,
+        stakingAssetAddress: addresses.stakingAssetAddress,
+        registryAddress: deployedAddresses.registryAddress,
+      },
+      logger,
+      defaultL1TxUtilsConfig,
+    );
+
+    const { governance, voteAmount } = await createGovernanceProposal(
+      payloadAddress.toString(),
+      addresses,
+      privateKey,
+      publicClient,
+      logger,
+    );
+
+    await executeGovernanceProposal(0n, governance, voteAmount, privateKey, publicClient, walletClient, rpcUrl, logger);
+
+    const newAddresses = await newRollup.getRollupAddresses();
+
+    const newCanonicalAddresses = await RegistryContract.collectAddresses(
+      publicClient,
+      deployedAddresses.registryAddress,
+      'canonical',
+    );
+
+    expect(newCanonicalAddresses).toEqual({
+      ...deployedAddresses,
+      ...newAddresses,
+    });
+
+    await expect(
+      RegistryContract.collectAddresses(publicClient, deployedAddresses.registryAddress, 2),
+    ).resolves.toEqual(newCanonicalAddresses);
+
+    await expect(
+      RegistryContract.collectAddresses(publicClient, deployedAddresses.registryAddress, 1),
+    ).resolves.toEqual(deployedAddresses);
+  });
+});
+
+async function executeGovernanceProposal(
+  proposalId: bigint,
+  governance: any,
+  voteAmount: bigint,
+  privateKey: PrivateKeyAccount,
+  publicClient: L1Clients['publicClient'],
+  walletClient: L1Clients['walletClient'],
+  rpcUrl: string,
+  logger: Logger,
+) {
+  const proposal = await governance.read.getProposal([proposalId]);
+
+  const waitL1Block = async () => {
+    await publicClient.waitForTransactionReceipt({
+      hash: await walletClient.sendTransaction({
+        to: privateKey.address,
+        value: 1n,
+        account: privateKey,
+      }),
+    });
+  };
+
+  const cheatCodes = new EthCheatCodes(rpcUrl, logger);
+
+  const timeToActive = proposal.creation + proposal.config.votingDelay;
+  logger.info(`Warping to ${timeToActive + 1n}`);
+  await cheatCodes.warp(Number(timeToActive + 1n));
+  logger.info(`Warped to ${timeToActive + 1n}`);
+  await waitL1Block();
+
+  logger.info(`Voting`);
+  const voteTx = await governance.write.vote([proposalId, voteAmount, true], { account: privateKey });
+  await publicClient.waitForTransactionReceipt({ hash: voteTx });
+  logger.info(`Voted`);
+
+  const timeToExecutable = timeToActive + proposal.config.votingDuration + proposal.config.executionDelay + 1n;
+  logger.info(`Warping to ${timeToExecutable}`);
+  await cheatCodes.warp(Number(timeToExecutable));
+  logger.info(`Warped to ${timeToExecutable}`);
+  await waitL1Block();
+
+  const executeTx = await governance.write.execute([proposalId], { account: privateKey });
+  await publicClient.waitForTransactionReceipt({ hash: executeTx });
+  logger.info(`Executed proposal`);
+}
+
+async function createGovernanceProposal(
+  payloadAddress: `0x${string}`,
+  addresses: L1ContractAddresses,
+  privateKey: PrivateKeyAccount,
+  publicClient: L1Clients['publicClient'],
+  logger: Logger,
+) {
+  const token = getContract({
+    address: addresses.feeJuiceAddress.toString(),
+    abi: FeeJuiceAbi,
+    client: publicClient,
+  });
+
+  const governance = getContract({
+    address: addresses.governanceAddress.toString(),
+    abi: GovernanceAbi,
+    client: publicClient,
+  });
+
+  const lockAmount = 10000n * 10n ** 18n;
+  const voteAmount = 10000n * 10n ** 18n;
+
+  const mintTx = await token.write.mint([privateKey.address, lockAmount + voteAmount], { account: privateKey });
+  await publicClient.waitForTransactionReceipt({ hash: mintTx });
+  logger.info(`Minted tokens`);
+
+  const approveTx = await token.write.approve([addresses.governanceAddress.toString(), lockAmount + voteAmount], {
+    account: privateKey,
+  });
+  await publicClient.waitForTransactionReceipt({ hash: approveTx });
+  logger.info(`Approved tokens`);
+
+  const depositTx = await governance.write.deposit([privateKey.address, lockAmount + voteAmount], {
+    account: privateKey,
+  });
+  await publicClient.waitForTransactionReceipt({ hash: depositTx });
+  logger.info(`Deposited tokens`);
+
+  await governance.write.proposeWithLock([payloadAddress, privateKey.address], {
+    account: privateKey,
+  });
+
+  return { governance, voteAmount };
+}

--- a/yarn-project/ethereum/src/contracts/registry.ts
+++ b/yarn-project/ethereum/src/contracts/registry.ts
@@ -1,0 +1,100 @@
+import { EthAddress } from '@aztec/foundation/eth-address';
+import { RegistryAbi } from '@aztec/l1-artifacts/RegistryAbi';
+import { TestERC20Abi } from '@aztec/l1-artifacts/TestERC20Abi';
+
+import {
+  type Chain,
+  type GetContractReturnType,
+  type Hex,
+  type HttpTransport,
+  type PublicClient,
+  getContract,
+} from 'viem';
+
+import type { L1ContractAddresses } from '../l1_contract_addresses.js';
+import type { L1Clients } from '../types.js';
+import { GovernanceContract } from './governance.js';
+import { RollupContract } from './rollup.js';
+
+export class RegistryContract {
+  public address: EthAddress;
+  private readonly registry: GetContractReturnType<typeof RegistryAbi, PublicClient<HttpTransport, Chain>>;
+
+  constructor(public readonly client: L1Clients['publicClient'], address: Hex | EthAddress) {
+    if (address instanceof EthAddress) {
+      address = address.toString();
+    }
+    this.address = EthAddress.fromString(address);
+    this.registry = getContract({ address, abi: RegistryAbi, client });
+  }
+
+  /**
+   * Returns the address of the rollup for a given version.
+   * @param version - The version of the rollup. 'canonical' can be used to get the canonical address (i.e. the latest version).
+   * @returns The address of the rollup. If the rollup is not set for this version, returns undefined.
+   */
+  public async getRollupAddress(version: number | bigint | 'canonical'): Promise<EthAddress | undefined> {
+    if (version === 'canonical') {
+      return this.getCanonicalAddress();
+    }
+
+    if (typeof version === 'number') {
+      version = BigInt(version);
+    }
+
+    const snapshot = await this.registry.read.getSnapshot([version]);
+    const address = EthAddress.fromString(snapshot.rollup);
+    return address.equals(EthAddress.ZERO) ? undefined : address;
+  }
+
+  /**
+   * Returns the canonical address of the rollup.
+   * @returns The canonical address of the rollup. If the rollup is not set, returns undefined.
+   */
+  public async getCanonicalAddress(): Promise<EthAddress | undefined> {
+    const snapshot = await this.registry.read.getCurrentSnapshot();
+    const address = EthAddress.fromString(snapshot.rollup);
+    return address.equals(EthAddress.ZERO) ? undefined : address;
+  }
+
+  public async getGovernanceAddresses(): Promise<
+    Pick<L1ContractAddresses, 'governanceProposerAddress' | 'governanceAddress'>
+  > {
+    const governanceAddress = await this.registry.read.getGovernance();
+    const governance = new GovernanceContract(this.client, governanceAddress);
+    const governanceProposer = await governance.getProposer();
+    return {
+      governanceAddress: governance.address,
+      governanceProposerAddress: governanceProposer.address,
+    };
+  }
+
+  public static async collectAddresses(
+    client: L1Clients['publicClient'],
+    registryAddress: Hex | EthAddress,
+    rollupVersion: number | bigint | 'canonical',
+  ): Promise<L1ContractAddresses> {
+    const registry = new RegistryContract(client, registryAddress);
+    const governanceAddresses = await registry.getGovernanceAddresses();
+    const rollupAddress = await registry.getRollupAddress(rollupVersion);
+
+    if (rollupAddress === undefined) {
+      throw new Error('Rollup address is undefined');
+    }
+
+    const rollup = new RollupContract(client, rollupAddress);
+    const addresses = await rollup.getRollupAddresses();
+    const feeAsset = getContract({
+      address: addresses.feeJuiceAddress.toString(),
+      abi: TestERC20Abi,
+      client,
+    });
+    const coinIssuer = await feeAsset.read.owner();
+    return {
+      registryAddress: registry.address,
+      ...governanceAddresses,
+      ...addresses,
+      coinIssuerAddress: EthAddress.fromString(coinIssuer),
+    };
+  }
+}

--- a/yarn-project/ethereum/src/contracts/rollup.ts
+++ b/yarn-project/ethereum/src/contracts/rollup.ts
@@ -62,7 +62,10 @@ export class RollupContract {
     return new RollupContract(client, address);
   }
 
-  constructor(public readonly client: PublicClient<HttpTransport, Chain>, address: Hex) {
+  constructor(public readonly client: PublicClient<HttpTransport, Chain>, address: Hex | EthAddress) {
+    if (address instanceof EthAddress) {
+      address = address.toString();
+    }
     this.rollup = getContract({ address, abi: RollupAbi, client });
   }
 

--- a/yarn-project/ethereum/src/l1_contract_addresses.ts
+++ b/yarn-project/ethereum/src/l1_contract_addresses.ts
@@ -21,13 +21,12 @@ export const L1ContractsNames = [
   'governanceProposerAddress',
   'governanceAddress',
   'stakingAssetAddress',
-  'slashFactoryAddress',
 ] as const;
 
 /** Provides the directory of current L1 contract addresses */
 export type L1ContractAddresses = {
   [K in (typeof L1ContractsNames)[number]]: EthAddress;
-};
+} & { slashFactoryAddress?: EthAddress | undefined };
 
 export const L1ContractAddressesSchema = z.object({
   rollupAddress: schemas.EthAddress,
@@ -41,7 +40,7 @@ export const L1ContractAddressesSchema = z.object({
   rewardDistributorAddress: schemas.EthAddress,
   governanceProposerAddress: schemas.EthAddress,
   governanceAddress: schemas.EthAddress,
-  slashFactoryAddress: schemas.EthAddress,
+  slashFactoryAddress: schemas.EthAddress.optional(),
 }) satisfies ZodFor<L1ContractAddresses>;
 
 const parseEnv = (val: string) => EthAddress.fromString(val);

--- a/yarn-project/l1-artifacts/scripts/generate-artifacts.sh
+++ b/yarn-project/l1-artifacts/scripts/generate-artifacts.sh
@@ -27,6 +27,7 @@ contracts=(
   "GovernanceProposer"
   "Governance"
   "NewGovernanceProposerPayload"
+  "RegisterNewRollupVersionPayload"
   "ValidatorSelectionLib"
   "ExtRollupLib"
   "SlashingProposer"

--- a/yarn-project/yarn.lock
+++ b/yarn-project/yarn.lock
@@ -694,6 +694,7 @@ __metadata:
     dotenv: "npm:^16.0.3"
     get-port: "npm:^7.1.0"
     jest: "npm:^29.5.0"
+    lodash.omit: "npm:^4.5.0"
     ts-node: "npm:^10.9.1"
     tslib: "npm:^2.4.0"
     typescript: "npm:^5.0.4"


### PR DESCRIPTION
Key changes:
- Makes slash factory address optional in L1ContractAddresses interface
- Adds new RegisterNewRollupVersionPayload contract for registering new rollup versions
- Adds new Registry contract with methods for managing rollup versions
- Extracts rollup deployment logic into separate deployRollupAndPeriphery function
- Adds collectAddresses and collectAddressesSafe methods to Registry for fetching contract addresses
- Transfers fee asset ownership to coin issuer during deployment

