### PR TITLE
feat(avm): interactions microbenchmarks

### DIFF
--- a/barretenberg/cpp/src/barretenberg/vm2/constraining/benchmark/relations_acc.bench.cpp
+++ b/barretenberg/cpp/src/barretenberg/vm2/constraining/benchmark/relations_acc.bench.cpp
@@ -1,21 +1,29 @@
 #include <benchmark/benchmark.h>
 
+#include <cstddef>
+#include <cstdint>
+#include <tuple>
+
 #include "barretenberg/common/constexpr_utils.hpp"
 #include "barretenberg/relations/relation_parameters.hpp"
 #include "barretenberg/vm2/common/field.hpp"
 #include "barretenberg/vm2/generated/columns.hpp"
 #include "barretenberg/vm2/generated/flavor.hpp"
 #include "barretenberg/vm2/generated/full_row.hpp"
-#include "barretenberg/vm2/generated/relations/range_check.hpp"
 
 using namespace benchmark;
 using namespace bb::avm2;
 
 namespace {
 
-AvmFullRow<FF> get_random_row()
+// Getters are needed for interaction accumulation to work.
+struct FullRowWithGetters : public AvmFullRow<FF> {
+    DEFINE_GETTERS(DEFAULT_GETTERS, AVM2_ALL_ENTITIES);
+};
+
+FullRowWithGetters get_random_row()
 {
-    AvmFullRow<FF> row;
+    FullRowWithGetters row;
     for (size_t i = 0; i < NUM_COLUMNS_WITH_SHIFTS; i++) {
         row.get_column(static_cast<ColumnAndShifts>(i)) = FF::random_element();
     }
@@ -36,7 +44,7 @@ bb::RelationParameters<FF> get_params()
     };
 }
 
-template <typename Relation> void BM_accumulate_random(State& state)
+template <typename Relation> void BM_accumulate_relation(State& state)
 {
     auto row = get_random_row();
     auto params = get_params();
@@ -49,15 +57,42 @@ template <typename Relation> void BM_accumulate_random(State& state)
     }
 }
 
+template <typename Relation> constexpr size_t get_interactions_count()
+{
+    size_t count = 0;
+    using AllInteractions = typename AvmFlavor::LookupRelations;
+    bb::constexpr_for<0, std::tuple_size_v<AllInteractions>, 1>([&]<size_t i>() {
+        using Interaction = std::tuple_element_t<i, AllInteractions>;
+        if constexpr (Relation::NAME == Interaction::RELATION_NAME) {
+            count++;
+        }
+    });
+    return count;
+}
+
+template <typename Relation> void BM_accumulate_interactions(State& state)
+{
+    using AllInteractions = typename AvmFlavor::LookupRelations;
+    bb::constexpr_for<0, std::tuple_size_v<AllInteractions>, 1>([&]<size_t i>() {
+        using Interaction = std::tuple_element_t<i, AllInteractions>;
+        if constexpr (Relation::NAME == Interaction::RELATION_NAME) {
+            BM_accumulate_relation<Interaction>(state);
+        }
+    });
+}
+
 } // namespace
 
 int main(int argc, char** argv)
 {
     bb::constexpr_for<0, std::tuple_size_v<typename AvmFlavor::MainRelations>, 1>([&]<size_t i>() {
         using Relation = std::tuple_element_t<i, typename AvmFlavor::MainRelations>;
-        BENCHMARK(BM_accumulate_random<Relation>)
-            ->Name(std::string(Relation::NAME) + "_acc_random")
-            ->Unit(kMicrosecond);
+        BENCHMARK(BM_accumulate_relation<Relation>)->Name(std::string(Relation::NAME) + "_acc")->Unit(kMicrosecond);
+        if (get_interactions_count<Relation>() > 0) {
+            BENCHMARK(BM_accumulate_interactions<Relation>)
+                ->Name(std::string(Relation::NAME) + "_interactions_acc")
+                ->Unit(kMicrosecond);
+        }
     });
 
     ::benchmark::Initialize(&argc, argv);

--- a/barretenberg/cpp/src/barretenberg/vm2/generated/relations/lookups_bc_decomposition.hpp
+++ b/barretenberg/cpp/src/barretenberg/vm2/generated/relations/lookups_bc_decomposition.hpp
@@ -15,6 +15,7 @@ namespace bb::avm2 {
 class lookup_bytecode_bytes_are_bytes_lookup_settings {
   public:
     static constexpr std::string_view NAME = "LOOKUP_BYTECODE_BYTES_ARE_BYTES";
+    static constexpr std::string_view RELATION_NAME = "bc_decomposition";
 
     static constexpr size_t READ_TERMS = 1;
     static constexpr size_t WRITE_TERMS = 1;
@@ -74,6 +75,7 @@ class lookup_bytecode_bytes_are_bytes_relation
   public:
     using Settings = lookup_bytecode_bytes_are_bytes_lookup_settings;
     static constexpr std::string_view NAME = lookup_bytecode_bytes_are_bytes_lookup_settings::NAME;
+    static constexpr std::string_view RELATION_NAME = lookup_bytecode_bytes_are_bytes_lookup_settings::RELATION_NAME;
 
     template <typename AllEntities> inline static bool skip(const AllEntities& in)
     {
@@ -96,6 +98,7 @@ class lookup_bytecode_bytes_are_bytes_relation
 class lookup_bytecode_remaining_abs_diff_u16_lookup_settings {
   public:
     static constexpr std::string_view NAME = "LOOKUP_BYTECODE_REMAINING_ABS_DIFF_U16";
+    static constexpr std::string_view RELATION_NAME = "bc_decomposition";
 
     static constexpr size_t READ_TERMS = 1;
     static constexpr size_t WRITE_TERMS = 1;
@@ -155,6 +158,8 @@ class lookup_bytecode_remaining_abs_diff_u16_relation
   public:
     using Settings = lookup_bytecode_remaining_abs_diff_u16_lookup_settings;
     static constexpr std::string_view NAME = lookup_bytecode_remaining_abs_diff_u16_lookup_settings::NAME;
+    static constexpr std::string_view RELATION_NAME =
+        lookup_bytecode_remaining_abs_diff_u16_lookup_settings::RELATION_NAME;
 
     template <typename AllEntities> inline static bool skip(const AllEntities& in)
     {
@@ -177,6 +182,7 @@ class lookup_bytecode_remaining_abs_diff_u16_relation
 class lookup_bytecode_to_read_unary_lookup_settings {
   public:
     static constexpr std::string_view NAME = "LOOKUP_BYTECODE_TO_READ_UNARY";
+    static constexpr std::string_view RELATION_NAME = "bc_decomposition";
 
     static constexpr size_t READ_TERMS = 1;
     static constexpr size_t WRITE_TERMS = 1;
@@ -241,6 +247,7 @@ class lookup_bytecode_to_read_unary_relation
   public:
     using Settings = lookup_bytecode_to_read_unary_lookup_settings;
     static constexpr std::string_view NAME = lookup_bytecode_to_read_unary_lookup_settings::NAME;
+    static constexpr std::string_view RELATION_NAME = lookup_bytecode_to_read_unary_lookup_settings::RELATION_NAME;
 
     template <typename AllEntities> inline static bool skip(const AllEntities& in)
     {

--- a/barretenberg/cpp/src/barretenberg/vm2/generated/relations/lookups_bitwise.hpp
+++ b/barretenberg/cpp/src/barretenberg/vm2/generated/relations/lookups_bitwise.hpp
@@ -15,6 +15,7 @@ namespace bb::avm2 {
 class lookup_bitw_byte_lengths_lookup_settings {
   public:
     static constexpr std::string_view NAME = "LOOKUP_BITW_BYTE_LENGTHS";
+    static constexpr std::string_view RELATION_NAME = "bitwise";
 
     static constexpr size_t READ_TERMS = 1;
     static constexpr size_t WRITE_TERMS = 1;
@@ -76,6 +77,7 @@ class lookup_bitw_byte_lengths_relation : public GenericLookupRelation<lookup_bi
   public:
     using Settings = lookup_bitw_byte_lengths_lookup_settings;
     static constexpr std::string_view NAME = lookup_bitw_byte_lengths_lookup_settings::NAME;
+    static constexpr std::string_view RELATION_NAME = lookup_bitw_byte_lengths_lookup_settings::RELATION_NAME;
 
     template <typename AllEntities> inline static bool skip(const AllEntities& in)
     {
@@ -98,6 +100,7 @@ class lookup_bitw_byte_lengths_relation : public GenericLookupRelation<lookup_bi
 class lookup_bitw_byte_operations_lookup_settings {
   public:
     static constexpr std::string_view NAME = "LOOKUP_BITW_BYTE_OPERATIONS";
+    static constexpr std::string_view RELATION_NAME = "bitwise";
 
     static constexpr size_t READ_TERMS = 1;
     static constexpr size_t WRITE_TERMS = 1;
@@ -168,6 +171,7 @@ class lookup_bitw_byte_operations_relation
   public:
     using Settings = lookup_bitw_byte_operations_lookup_settings;
     static constexpr std::string_view NAME = lookup_bitw_byte_operations_lookup_settings::NAME;
+    static constexpr std::string_view RELATION_NAME = lookup_bitw_byte_operations_lookup_settings::RELATION_NAME;
 
     template <typename AllEntities> inline static bool skip(const AllEntities& in)
     {

--- a/barretenberg/cpp/src/barretenberg/vm2/generated/relations/lookups_execution.hpp
+++ b/barretenberg/cpp/src/barretenberg/vm2/generated/relations/lookups_execution.hpp
@@ -15,6 +15,7 @@ namespace bb::avm2 {
 class lookup_dummy_precomputed_lookup_settings {
   public:
     static constexpr std::string_view NAME = "LOOKUP_DUMMY_PRECOMPUTED";
+    static constexpr std::string_view RELATION_NAME = "execution";
 
     static constexpr size_t READ_TERMS = 1;
     static constexpr size_t WRITE_TERMS = 1;
@@ -84,6 +85,7 @@ class lookup_dummy_precomputed_relation : public GenericLookupRelation<lookup_du
   public:
     using Settings = lookup_dummy_precomputed_lookup_settings;
     static constexpr std::string_view NAME = lookup_dummy_precomputed_lookup_settings::NAME;
+    static constexpr std::string_view RELATION_NAME = lookup_dummy_precomputed_lookup_settings::RELATION_NAME;
 
     template <typename AllEntities> inline static bool skip(const AllEntities& in)
     {
@@ -106,6 +108,7 @@ class lookup_dummy_precomputed_relation : public GenericLookupRelation<lookup_du
 class lookup_dummy_dynamic_lookup_settings {
   public:
     static constexpr std::string_view NAME = "LOOKUP_DUMMY_DYNAMIC";
+    static constexpr std::string_view RELATION_NAME = "execution";
 
     static constexpr size_t READ_TERMS = 1;
     static constexpr size_t WRITE_TERMS = 1;
@@ -174,6 +177,7 @@ class lookup_dummy_dynamic_relation : public GenericLookupRelation<lookup_dummy_
   public:
     using Settings = lookup_dummy_dynamic_lookup_settings;
     static constexpr std::string_view NAME = lookup_dummy_dynamic_lookup_settings::NAME;
+    static constexpr std::string_view RELATION_NAME = lookup_dummy_dynamic_lookup_settings::RELATION_NAME;
 
     template <typename AllEntities> inline static bool skip(const AllEntities& in)
     {

--- a/barretenberg/cpp/src/barretenberg/vm2/generated/relations/lookups_poseidon2_hash.hpp
+++ b/barretenberg/cpp/src/barretenberg/vm2/generated/relations/lookups_poseidon2_hash.hpp
@@ -15,6 +15,7 @@ namespace bb::avm2 {
 class lookup_pos2_perm_lookup_settings {
   public:
     static constexpr std::string_view NAME = "LOOKUP_POS2_PERM";
+    static constexpr std::string_view RELATION_NAME = "poseidon2_hash";
 
     static constexpr size_t READ_TERMS = 1;
     static constexpr size_t WRITE_TERMS = 1;
@@ -93,6 +94,7 @@ class lookup_pos2_perm_relation : public GenericLookupRelation<lookup_pos2_perm_
   public:
     using Settings = lookup_pos2_perm_lookup_settings;
     static constexpr std::string_view NAME = lookup_pos2_perm_lookup_settings::NAME;
+    static constexpr std::string_view RELATION_NAME = lookup_pos2_perm_lookup_settings::RELATION_NAME;
 
     template <typename AllEntities> inline static bool skip(const AllEntities& in)
     {

--- a/barretenberg/cpp/src/barretenberg/vm2/generated/relations/lookups_range_check.hpp
+++ b/barretenberg/cpp/src/barretenberg/vm2/generated/relations/lookups_range_check.hpp
@@ -15,6 +15,7 @@ namespace bb::avm2 {
 class lookup_rng_chk_pow_2_lookup_settings {
   public:
     static constexpr std::string_view NAME = "LOOKUP_RNG_CHK_POW_2";
+    static constexpr std::string_view RELATION_NAME = "range_check";
 
     static constexpr size_t READ_TERMS = 1;
     static constexpr size_t WRITE_TERMS = 1;
@@ -77,6 +78,7 @@ class lookup_rng_chk_pow_2_relation : public GenericLookupRelation<lookup_rng_ch
   public:
     using Settings = lookup_rng_chk_pow_2_lookup_settings;
     static constexpr std::string_view NAME = lookup_rng_chk_pow_2_lookup_settings::NAME;
+    static constexpr std::string_view RELATION_NAME = lookup_rng_chk_pow_2_lookup_settings::RELATION_NAME;
 
     template <typename AllEntities> inline static bool skip(const AllEntities& in)
     {
@@ -99,6 +101,7 @@ class lookup_rng_chk_pow_2_relation : public GenericLookupRelation<lookup_rng_ch
 class lookup_rng_chk_diff_lookup_settings {
   public:
     static constexpr std::string_view NAME = "LOOKUP_RNG_CHK_DIFF";
+    static constexpr std::string_view RELATION_NAME = "range_check";
 
     static constexpr size_t READ_TERMS = 1;
     static constexpr size_t WRITE_TERMS = 1;
@@ -157,6 +160,7 @@ class lookup_rng_chk_diff_relation : public GenericLookupRelation<lookup_rng_chk
   public:
     using Settings = lookup_rng_chk_diff_lookup_settings;
     static constexpr std::string_view NAME = lookup_rng_chk_diff_lookup_settings::NAME;
+    static constexpr std::string_view RELATION_NAME = lookup_rng_chk_diff_lookup_settings::RELATION_NAME;
 
     template <typename AllEntities> inline static bool skip(const AllEntities& in)
     {
@@ -179,6 +183,7 @@ class lookup_rng_chk_diff_relation : public GenericLookupRelation<lookup_rng_chk
 class lookup_rng_chk_is_r0_16_bit_lookup_settings {
   public:
     static constexpr std::string_view NAME = "LOOKUP_RNG_CHK_IS_R0_16_BIT";
+    static constexpr std::string_view RELATION_NAME = "range_check";
 
     static constexpr size_t READ_TERMS = 1;
     static constexpr size_t WRITE_TERMS = 1;
@@ -238,6 +243,7 @@ class lookup_rng_chk_is_r0_16_bit_relation
   public:
     using Settings = lookup_rng_chk_is_r0_16_bit_lookup_settings;
     static constexpr std::string_view NAME = lookup_rng_chk_is_r0_16_bit_lookup_settings::NAME;
+    static constexpr std::string_view RELATION_NAME = lookup_rng_chk_is_r0_16_bit_lookup_settings::RELATION_NAME;
 
     template <typename AllEntities> inline static bool skip(const AllEntities& in)
     {
@@ -260,6 +266,7 @@ class lookup_rng_chk_is_r0_16_bit_relation
 class lookup_rng_chk_is_r1_16_bit_lookup_settings {
   public:
     static constexpr std::string_view NAME = "LOOKUP_RNG_CHK_IS_R1_16_BIT";
+    static constexpr std::string_view RELATION_NAME = "range_check";
 
     static constexpr size_t READ_TERMS = 1;
     static constexpr size_t WRITE_TERMS = 1;
@@ -319,6 +326,7 @@ class lookup_rng_chk_is_r1_16_bit_relation
   public:
     using Settings = lookup_rng_chk_is_r1_16_bit_lookup_settings;
     static constexpr std::string_view NAME = lookup_rng_chk_is_r1_16_bit_lookup_settings::NAME;
+    static constexpr std::string_view RELATION_NAME = lookup_rng_chk_is_r1_16_bit_lookup_settings::RELATION_NAME;
 
     template <typename AllEntities> inline static bool skip(const AllEntities& in)
     {
@@ -341,6 +349,7 @@ class lookup_rng_chk_is_r1_16_bit_relation
 class lookup_rng_chk_is_r2_16_bit_lookup_settings {
   public:
     static constexpr std::string_view NAME = "LOOKUP_RNG_CHK_IS_R2_16_BIT";
+    static constexpr std::string_view RELATION_NAME = "range_check";
 
     static constexpr size_t READ_TERMS = 1;
     static constexpr size_t WRITE_TERMS = 1;
@@ -400,6 +409,7 @@ class lookup_rng_chk_is_r2_16_bit_relation
   public:
     using Settings = lookup_rng_chk_is_r2_16_bit_lookup_settings;
     static constexpr std::string_view NAME = lookup_rng_chk_is_r2_16_bit_lookup_settings::NAME;
+    static constexpr std::string_view RELATION_NAME = lookup_rng_chk_is_r2_16_bit_lookup_settings::RELATION_NAME;
 
     template <typename AllEntities> inline static bool skip(const AllEntities& in)
     {
@@ -422,6 +432,7 @@ class lookup_rng_chk_is_r2_16_bit_relation
 class lookup_rng_chk_is_r3_16_bit_lookup_settings {
   public:
     static constexpr std::string_view NAME = "LOOKUP_RNG_CHK_IS_R3_16_BIT";
+    static constexpr std::string_view RELATION_NAME = "range_check";
 
     static constexpr size_t READ_TERMS = 1;
     static constexpr size_t WRITE_TERMS = 1;
@@ -481,6 +492,7 @@ class lookup_rng_chk_is_r3_16_bit_relation
   public:
     using Settings = lookup_rng_chk_is_r3_16_bit_lookup_settings;
     static constexpr std::string_view NAME = lookup_rng_chk_is_r3_16_bit_lookup_settings::NAME;
+    static constexpr std::string_view RELATION_NAME = lookup_rng_chk_is_r3_16_bit_lookup_settings::RELATION_NAME;
 
     template <typename AllEntities> inline static bool skip(const AllEntities& in)
     {
@@ -503,6 +515,7 @@ class lookup_rng_chk_is_r3_16_bit_relation
 class lookup_rng_chk_is_r4_16_bit_lookup_settings {
   public:
     static constexpr std::string_view NAME = "LOOKUP_RNG_CHK_IS_R4_16_BIT";
+    static constexpr std::string_view RELATION_NAME = "range_check";
 
     static constexpr size_t READ_TERMS = 1;
     static constexpr size_t WRITE_TERMS = 1;
@@ -562,6 +575,7 @@ class lookup_rng_chk_is_r4_16_bit_relation
   public:
     using Settings = lookup_rng_chk_is_r4_16_bit_lookup_settings;
     static constexpr std::string_view NAME = lookup_rng_chk_is_r4_16_bit_lookup_settings::NAME;
+    static constexpr std::string_view RELATION_NAME = lookup_rng_chk_is_r4_16_bit_lookup_settings::RELATION_NAME;
 
     template <typename AllEntities> inline static bool skip(const AllEntities& in)
     {
@@ -584,6 +598,7 @@ class lookup_rng_chk_is_r4_16_bit_relation
 class lookup_rng_chk_is_r5_16_bit_lookup_settings {
   public:
     static constexpr std::string_view NAME = "LOOKUP_RNG_CHK_IS_R5_16_BIT";
+    static constexpr std::string_view RELATION_NAME = "range_check";
 
     static constexpr size_t READ_TERMS = 1;
     static constexpr size_t WRITE_TERMS = 1;
@@ -643,6 +658,7 @@ class lookup_rng_chk_is_r5_16_bit_relation
   public:
     using Settings = lookup_rng_chk_is_r5_16_bit_lookup_settings;
     static constexpr std::string_view NAME = lookup_rng_chk_is_r5_16_bit_lookup_settings::NAME;
+    static constexpr std::string_view RELATION_NAME = lookup_rng_chk_is_r5_16_bit_lookup_settings::RELATION_NAME;
 
     template <typename AllEntities> inline static bool skip(const AllEntities& in)
     {
@@ -665,6 +681,7 @@ class lookup_rng_chk_is_r5_16_bit_relation
 class lookup_rng_chk_is_r6_16_bit_lookup_settings {
   public:
     static constexpr std::string_view NAME = "LOOKUP_RNG_CHK_IS_R6_16_BIT";
+    static constexpr std::string_view RELATION_NAME = "range_check";
 
     static constexpr size_t READ_TERMS = 1;
     static constexpr size_t WRITE_TERMS = 1;
@@ -724,6 +741,7 @@ class lookup_rng_chk_is_r6_16_bit_relation
   public:
     using Settings = lookup_rng_chk_is_r6_16_bit_lookup_settings;
     static constexpr std::string_view NAME = lookup_rng_chk_is_r6_16_bit_lookup_settings::NAME;
+    static constexpr std::string_view RELATION_NAME = lookup_rng_chk_is_r6_16_bit_lookup_settings::RELATION_NAME;
 
     template <typename AllEntities> inline static bool skip(const AllEntities& in)
     {
@@ -746,6 +764,7 @@ class lookup_rng_chk_is_r6_16_bit_relation
 class lookup_rng_chk_is_r7_16_bit_lookup_settings {
   public:
     static constexpr std::string_view NAME = "LOOKUP_RNG_CHK_IS_R7_16_BIT";
+    static constexpr std::string_view RELATION_NAME = "range_check";
 
     static constexpr size_t READ_TERMS = 1;
     static constexpr size_t WRITE_TERMS = 1;
@@ -805,6 +824,7 @@ class lookup_rng_chk_is_r7_16_bit_relation
   public:
     using Settings = lookup_rng_chk_is_r7_16_bit_lookup_settings;
     static constexpr std::string_view NAME = lookup_rng_chk_is_r7_16_bit_lookup_settings::NAME;
+    static constexpr std::string_view RELATION_NAME = lookup_rng_chk_is_r7_16_bit_lookup_settings::RELATION_NAME;
 
     template <typename AllEntities> inline static bool skip(const AllEntities& in)
     {

--- a/barretenberg/cpp/src/barretenberg/vm2/generated/relations/lookups_sha256.hpp
+++ b/barretenberg/cpp/src/barretenberg/vm2/generated/relations/lookups_sha256.hpp
@@ -15,6 +15,7 @@ namespace bb::avm2 {
 class lookup_sha256_round_constant_lookup_settings {
   public:
     static constexpr std::string_view NAME = "LOOKUP_SHA256_ROUND_CONSTANT";
+    static constexpr std::string_view RELATION_NAME = "sha256";
 
     static constexpr size_t READ_TERMS = 1;
     static constexpr size_t WRITE_TERMS = 1;
@@ -79,6 +80,7 @@ class lookup_sha256_round_constant_relation
   public:
     using Settings = lookup_sha256_round_constant_lookup_settings;
     static constexpr std::string_view NAME = lookup_sha256_round_constant_lookup_settings::NAME;
+    static constexpr std::string_view RELATION_NAME = lookup_sha256_round_constant_lookup_settings::RELATION_NAME;
 
     template <typename AllEntities> inline static bool skip(const AllEntities& in)
     {

--- a/barretenberg/cpp/src/barretenberg/vm2/generated/relations/perms_execution.hpp
+++ b/barretenberg/cpp/src/barretenberg/vm2/generated/relations/perms_execution.hpp
@@ -15,6 +15,7 @@ namespace bb::avm2 {
 class perm_dummy_dynamic_permutation_settings {
   public:
     static constexpr std::string_view NAME = "PERM_DUMMY_DYNAMIC";
+    static constexpr std::string_view RELATION_NAME = "execution";
 
     // This constant defines how many columns are bundled together to form each set.
     constexpr static size_t COLUMNS_PER_SET = 4;
@@ -67,6 +68,7 @@ class perm_dummy_dynamic_relation : public GenericPermutationRelation<perm_dummy
   public:
     using Settings = perm_dummy_dynamic_permutation_settings;
     static constexpr std::string_view NAME = perm_dummy_dynamic_permutation_settings::NAME;
+    static constexpr std::string_view RELATION_NAME = perm_dummy_dynamic_permutation_settings::RELATION_NAME;
 
     template <typename AllEntities> inline static bool skip(const AllEntities& in)
     {

--- a/bb-pilcom/bb-pil-backend/src/lookup_builder.rs
+++ b/bb-pilcom/bb-pil-backend/src/lookup_builder.rs
@@ -21,6 +21,8 @@ use crate::utils::sanitize_name;
 pub struct Lookup {
     /// The name of the lookup
     pub name: String,
+    /// The relation in which the lookup was declared
+    pub owning_relation: String,
     /// The file name of the lookup
     pub file_name: String,
     /// The inverse column name
@@ -72,19 +74,18 @@ impl LookupBuilder for BBFiles {
                         "Inverse column name must be provided within lookup attribute - #[<here>]",
                     )
                     .to_lowercase();
-                let file_name = format!(
-                    "lookups_{}.hpp",
-                    lookup
-                        .source
-                        .file_name
-                        .as_ref()
-                        .and_then(|file_name| Path::new(file_name.as_ref()).file_stem())
-                        .map(|stem| stem.to_string_lossy().into_owned())
-                        .unwrap_or_default()
-                        .replace(".pil", "")
-                );
+                let relation = lookup
+                    .source
+                    .file_name
+                    .as_ref()
+                    .and_then(|file_name| Path::new(file_name.as_ref()).file_stem())
+                    .map(|stem| stem.to_string_lossy().into_owned())
+                    .unwrap_or_default()
+                    .replace(".pil", "");
+                let file_name = format!("lookups_{}.hpp", relation);
                 Lookup {
                     name: name.clone(),
+                    owning_relation: relation,
                     file_name: file_name,
                     inverse: format!("{}_inv", &name),
                     counts_poly: format!("{}_counts", &name),
@@ -175,6 +176,7 @@ fn create_lookup_settings_data(lookup: &Lookup) -> Json {
 
     json!({
         "lookup_name": lookup.name,
+        "relation_name": lookup.owning_relation,
         "lhs_selector": lhs_selector,
         "rhs_selector": rhs_selector,
         "lhs_cols": lhs_cols,

--- a/bb-pilcom/bb-pil-backend/src/permutation_builder.rs
+++ b/bb-pilcom/bb-pil-backend/src/permutation_builder.rs
@@ -19,6 +19,8 @@ use crate::utils::sanitize_name;
 pub struct Permutation {
     /// The name of the lookup
     pub name: String,
+    /// The relation in which the permutation was declared
+    pub owning_relation: String,
     /// The file name of the lookup
     pub file_name: String,
     /// The inverse column name
@@ -66,18 +68,18 @@ impl PermutationBuilder for BBFiles {
                     .clone()
                     .expect("Permutation name must be provided using attribute syntax")
                     .to_lowercase();
-                let file_name = format!(
-                    "perms_{}.hpp",
-                    perm.source
-                        .file_name
-                        .as_ref()
-                        .and_then(|file_name| Path::new(file_name.as_ref()).file_stem())
-                        .map(|stem| stem.to_string_lossy().into_owned())
-                        .unwrap_or_default()
-                        .replace(".pil", "")
-                );
+                let relation = perm
+                    .source
+                    .file_name
+                    .as_ref()
+                    .and_then(|file_name| Path::new(file_name.as_ref()).file_stem())
+                    .map(|stem| stem.to_string_lossy().into_owned())
+                    .unwrap_or_default()
+                    .replace(".pil", "");
+                let file_name = format!("perms_{}.hpp", relation);
                 Permutation {
                     name: name.clone(),
+                    owning_relation: relation,
                     file_name: file_name,
                     inverse: format!("{}_inv", &name),
                     left: get_perm_side(&perm.left),
@@ -161,6 +163,7 @@ fn create_permutation_settings_data(permutation: &Permutation) -> Json {
 
     json!({
         "perm_name": permutation.name,
+        "relation_name": permutation.owning_relation,
         "columns_per_set": columns_per_set,
         "lhs_selector": lhs_selector,
         "rhs_selector": rhs_selector,

--- a/bb-pilcom/bb-pil-backend/templates/lookup.hpp.hbs
+++ b/bb-pilcom/bb-pil-backend/templates/lookup.hpp.hbs
@@ -16,6 +16,7 @@ namespace bb::{{snakeCase root_name}} {
 class {{lookup_name}}_lookup_settings {
   public:
     static constexpr std::string_view NAME = "{{shoutySnakeCase lookup_name}}";
+    static constexpr std::string_view RELATION_NAME = "{{relation_name}}";
 
     static constexpr size_t READ_TERMS = {{read_terms}};
     static constexpr size_t WRITE_TERMS = {{write_terms}};
@@ -87,6 +88,7 @@ template <typename FF_> class {{lookup_name}}_relation : public GenericLookupRel
     public:
         using Settings = {{lookup_name}}_lookup_settings;
         static constexpr std::string_view NAME = {{lookup_name}}_lookup_settings::NAME;
+        static constexpr std::string_view RELATION_NAME = {{lookup_name}}_lookup_settings::RELATION_NAME;
 
         {{! TODO: This is a safe skippable condition, but there might be a better one. --}}
         template <typename AllEntities> inline static bool skip(const AllEntities& in)

--- a/bb-pilcom/bb-pil-backend/templates/permutation.hpp.hbs
+++ b/bb-pilcom/bb-pil-backend/templates/permutation.hpp.hbs
@@ -16,6 +16,7 @@ namespace bb::{{snakeCase root_name}} {
 class {{perm_name}}_permutation_settings {
   public:
     static constexpr std::string_view NAME = "{{shoutySnakeCase perm_name}}";
+    static constexpr std::string_view RELATION_NAME = "{{relation_name}}";
 
     // This constant defines how many columns are bundled together to form each set.
     constexpr static size_t COLUMNS_PER_SET = {{columns_per_set}};
@@ -53,6 +54,7 @@ template <typename FF_> class {{perm_name}}_relation : public GenericPermutation
     public:
         using Settings = {{perm_name}}_permutation_settings;
         static constexpr std::string_view NAME = {{perm_name}}_permutation_settings::NAME;
+        static constexpr std::string_view RELATION_NAME = {{perm_name}}_permutation_settings::RELATION_NAME;
 
         {{! TODO: This is a safe skippable condition, but there might be a better one. --}}
         template <typename AllEntities> inline static bool skip(const AllEntities& in)


### PR DESCRIPTION
```
----------------------------------------------------------------------------
Benchmark                                  Time             CPU   Iterations
----------------------------------------------------------------------------
alu_acc                                0.123 us        0.123 us      5733323
bc_decomposition_acc                    8.74 us         8.74 us        80218
bc_decomposition_interactions_acc       1.10 us         1.10 us       635912
bc_retrieval_acc                       0.024 us        0.024 us     29223517
bitwise_acc                             1.42 us         1.42 us       493467
bitwise_interactions_acc               0.947 us        0.947 us       756449
ecc_acc                                 2.59 us         2.59 us       268431
execution_acc                          0.519 us        0.519 us      1348920
execution_interactions_acc              1.53 us         1.53 us       459332
instr_fetching_acc                     0.024 us        0.024 us     29175405
poseidon2_hash_acc                      1.86 us         1.86 us       377966
poseidon2_hash_interactions_acc        0.743 us        0.743 us       943393
poseidon2_perm_acc                      44.1 us         44.1 us        16011
range_check_acc                         2.68 us         2.68 us       260746
range_check_interactions_acc            3.53 us         3.53 us       198772
sha256_acc                              6.25 us         6.24 us       112169
sha256_interactions_acc                0.406 us        0.406 us      1736243
```
