### PR TITLE
chore: turn get_vk_merkle_tree into a global

### DIFF
--- a/noir-projects/noir-protocol-circuits/crates/parity-lib/src/root/root_parity_inputs.nr
+++ b/noir-projects/noir-protocol-circuits/crates/parity-lib/src/root/root_parity_inputs.nr
@@ -63,7 +63,7 @@ mod tests {
         constants::{BASE_PARITY_INDEX, NUM_BASE_PARITY_PER_ROOT_PARITY},
         hash::verification_key_hash,
         proof::{recursive_proof::RecursiveProof, verification_key::VerificationKey},
-        tests::fixtures::vk_tree::{generate_fake_honk_vk_for_index, get_vk_merkle_tree},
+        tests::fixtures::vk_tree::{generate_fake_honk_vk_for_index, VK_MERKLE_TREE},
         traits::Empty,
     };
 
@@ -76,7 +76,7 @@ mod tests {
             0x53042d820859d80c474d4694e03778f8dc0ac88fc1c3a97b4369c1096e904a,
         ];
 
-        let vk_tree = get_vk_merkle_tree();
+        let vk_tree = VK_MERKLE_TREE;
 
         let vk_path = vk_tree.get_sibling_path(BASE_PARITY_INDEX);
         let vk_tree_root = vk_tree.get_root();

--- a/noir-projects/noir-protocol-circuits/crates/rollup-lib/src/block_merge/block_merge_rollup_inputs.nr
+++ b/noir-projects/noir-protocol-circuits/crates/rollup-lib/src/block_merge/block_merge_rollup_inputs.nr
@@ -185,7 +185,7 @@ mod tests {
     fn valid_previous_circuit_block_root() {
         let mut inputs = default_block_merge_rollup_inputs();
         let vk_tree: MerkleTree<fixtures::vk_tree::VK_TREE_WIDTH> =
-            comptime { fixtures::vk_tree::VK_MERKLE_TREE };
+            fixtures::vk_tree::VK_MERKLE_TREE;
         inputs.previous_rollup_data[0].vk =
             fixtures::vk_tree::generate_fake_rollup_honk_vk_for_index(BLOCK_ROOT_ROLLUP_INDEX);
         inputs.previous_rollup_data[0].vk_witness.leaf_index = BLOCK_ROOT_ROLLUP_INDEX as Field;
@@ -198,7 +198,7 @@ mod tests {
     fn valid_previous_circuit_block_merge() {
         let mut inputs = default_block_merge_rollup_inputs();
         let vk_tree: MerkleTree<fixtures::vk_tree::VK_TREE_WIDTH> =
-            comptime { fixtures::vk_tree::VK_MERKLE_TREE };
+            fixtures::vk_tree::VK_MERKLE_TREE;
         inputs.previous_rollup_data[0].vk =
             fixtures::vk_tree::generate_fake_rollup_honk_vk_for_index(BLOCK_MERGE_ROLLUP_INDEX);
         inputs.previous_rollup_data[0].vk_witness.leaf_index = BLOCK_MERGE_ROLLUP_INDEX as Field;
@@ -211,7 +211,7 @@ mod tests {
     fn invalid_previous_circuit() {
         let mut inputs = default_block_merge_rollup_inputs();
         let vk_tree: MerkleTree<fixtures::vk_tree::VK_TREE_WIDTH> =
-            comptime { fixtures::vk_tree::VK_MERKLE_TREE };
+            fixtures::vk_tree::VK_MERKLE_TREE;
         inputs.previous_rollup_data[0].vk =
             fixtures::vk_tree::generate_fake_rollup_honk_vk_for_index(ROOT_PARITY_INDEX);
         inputs.previous_rollup_data[0].vk_witness.leaf_index = ROOT_PARITY_INDEX as Field;

--- a/noir-projects/noir-protocol-circuits/crates/rollup-lib/src/block_merge/block_merge_rollup_inputs.nr
+++ b/noir-projects/noir-protocol-circuits/crates/rollup-lib/src/block_merge/block_merge_rollup_inputs.nr
@@ -185,7 +185,7 @@ mod tests {
     fn valid_previous_circuit_block_root() {
         let mut inputs = default_block_merge_rollup_inputs();
         let vk_tree: MerkleTree<fixtures::vk_tree::VK_TREE_WIDTH> =
-            comptime { fixtures::vk_tree::get_vk_merkle_tree() };
+            comptime { fixtures::vk_tree::VK_MERKLE_TREE };
         inputs.previous_rollup_data[0].vk =
             fixtures::vk_tree::generate_fake_rollup_honk_vk_for_index(BLOCK_ROOT_ROLLUP_INDEX);
         inputs.previous_rollup_data[0].vk_witness.leaf_index = BLOCK_ROOT_ROLLUP_INDEX as Field;
@@ -198,7 +198,7 @@ mod tests {
     fn valid_previous_circuit_block_merge() {
         let mut inputs = default_block_merge_rollup_inputs();
         let vk_tree: MerkleTree<fixtures::vk_tree::VK_TREE_WIDTH> =
-            comptime { fixtures::vk_tree::get_vk_merkle_tree() };
+            comptime { fixtures::vk_tree::VK_MERKLE_TREE };
         inputs.previous_rollup_data[0].vk =
             fixtures::vk_tree::generate_fake_rollup_honk_vk_for_index(BLOCK_MERGE_ROLLUP_INDEX);
         inputs.previous_rollup_data[0].vk_witness.leaf_index = BLOCK_MERGE_ROLLUP_INDEX as Field;
@@ -211,7 +211,7 @@ mod tests {
     fn invalid_previous_circuit() {
         let mut inputs = default_block_merge_rollup_inputs();
         let vk_tree: MerkleTree<fixtures::vk_tree::VK_TREE_WIDTH> =
-            comptime { fixtures::vk_tree::get_vk_merkle_tree() };
+            comptime { fixtures::vk_tree::VK_MERKLE_TREE };
         inputs.previous_rollup_data[0].vk =
             fixtures::vk_tree::generate_fake_rollup_honk_vk_for_index(ROOT_PARITY_INDEX);
         inputs.previous_rollup_data[0].vk_witness.leaf_index = ROOT_PARITY_INDEX as Field;

--- a/noir-projects/noir-protocol-circuits/crates/rollup-lib/src/merge/merge_rollup_inputs.nr
+++ b/noir-projects/noir-protocol-circuits/crates/rollup-lib/src/merge/merge_rollup_inputs.nr
@@ -182,7 +182,7 @@ mod tests {
         let mut inputs = default_merge_rollup_inputs();
 
         let vk_tree: MerkleTree<fixtures::vk_tree::VK_TREE_WIDTH> =
-            comptime { fixtures::vk_tree::get_vk_merkle_tree() };
+            comptime { fixtures::vk_tree::VK_MERKLE_TREE };
 
         inputs.previous_rollup_data[0].vk =
             fixtures::vk_tree::generate_fake_rollup_honk_vk_for_index(PRIVATE_BASE_ROLLUP_VK_INDEX);
@@ -199,7 +199,7 @@ mod tests {
         let mut inputs = default_merge_rollup_inputs();
 
         let vk_tree: MerkleTree<fixtures::vk_tree::VK_TREE_WIDTH> =
-            comptime { fixtures::vk_tree::get_vk_merkle_tree() };
+            comptime { fixtures::vk_tree::VK_MERKLE_TREE };
 
         inputs.previous_rollup_data[0].vk =
             fixtures::vk_tree::generate_fake_rollup_honk_vk_for_index(MERGE_ROLLUP_INDEX);
@@ -214,7 +214,7 @@ mod tests {
     fn invalid_previous_circuit() {
         let mut inputs = default_merge_rollup_inputs();
         let vk_tree: MerkleTree<fixtures::vk_tree::VK_TREE_WIDTH> =
-            comptime { fixtures::vk_tree::get_vk_merkle_tree() };
+            comptime { fixtures::vk_tree::VK_MERKLE_TREE };
         inputs.previous_rollup_data[0].vk =
             fixtures::vk_tree::generate_fake_rollup_honk_vk_for_index(ROOT_PARITY_INDEX);
         inputs.previous_rollup_data[0].vk_witness.leaf_index = ROOT_PARITY_INDEX as Field;

--- a/noir-projects/noir-protocol-circuits/crates/rollup-lib/src/merge/merge_rollup_inputs.nr
+++ b/noir-projects/noir-protocol-circuits/crates/rollup-lib/src/merge/merge_rollup_inputs.nr
@@ -182,7 +182,7 @@ mod tests {
         let mut inputs = default_merge_rollup_inputs();
 
         let vk_tree: MerkleTree<fixtures::vk_tree::VK_TREE_WIDTH> =
-            comptime { fixtures::vk_tree::VK_MERKLE_TREE };
+            fixtures::vk_tree::VK_MERKLE_TREE;
 
         inputs.previous_rollup_data[0].vk =
             fixtures::vk_tree::generate_fake_rollup_honk_vk_for_index(PRIVATE_BASE_ROLLUP_VK_INDEX);
@@ -199,7 +199,7 @@ mod tests {
         let mut inputs = default_merge_rollup_inputs();
 
         let vk_tree: MerkleTree<fixtures::vk_tree::VK_TREE_WIDTH> =
-            comptime { fixtures::vk_tree::VK_MERKLE_TREE };
+            fixtures::vk_tree::VK_MERKLE_TREE;
 
         inputs.previous_rollup_data[0].vk =
             fixtures::vk_tree::generate_fake_rollup_honk_vk_for_index(MERGE_ROLLUP_INDEX);
@@ -214,7 +214,7 @@ mod tests {
     fn invalid_previous_circuit() {
         let mut inputs = default_merge_rollup_inputs();
         let vk_tree: MerkleTree<fixtures::vk_tree::VK_TREE_WIDTH> =
-            comptime { fixtures::vk_tree::VK_MERKLE_TREE };
+            fixtures::vk_tree::VK_MERKLE_TREE;
         inputs.previous_rollup_data[0].vk =
             fixtures::vk_tree::generate_fake_rollup_honk_vk_for_index(ROOT_PARITY_INDEX);
         inputs.previous_rollup_data[0].vk_witness.leaf_index = ROOT_PARITY_INDEX as Field;

--- a/noir-projects/noir-protocol-circuits/crates/rollup-lib/src/tests/previous_rollup_block_data.nr
+++ b/noir-projects/noir-protocol-circuits/crates/rollup-lib/src/tests/previous_rollup_block_data.nr
@@ -10,8 +10,7 @@ pub fn default_previous_rollup_block_data() -> [PreviousRollupBlockData; 2] {
     let mut previous_rollup_data = [PreviousRollupBlockData::empty(); 2];
 
     let vk_index = BLOCK_ROOT_ROLLUP_INDEX;
-    let vk_tree: MerkleTree<fixtures::vk_tree::VK_TREE_WIDTH> =
-        comptime { fixtures::vk_tree::VK_MERKLE_TREE };
+    let vk_tree: MerkleTree<fixtures::vk_tree::VK_TREE_WIDTH> = fixtures::vk_tree::VK_MERKLE_TREE;
     let vk_path = vk_tree.get_sibling_path(vk_index);
     let vk_tree_root = vk_tree.get_root();
 

--- a/noir-projects/noir-protocol-circuits/crates/rollup-lib/src/tests/previous_rollup_block_data.nr
+++ b/noir-projects/noir-protocol-circuits/crates/rollup-lib/src/tests/previous_rollup_block_data.nr
@@ -11,7 +11,7 @@ pub fn default_previous_rollup_block_data() -> [PreviousRollupBlockData; 2] {
 
     let vk_index = BLOCK_ROOT_ROLLUP_INDEX;
     let vk_tree: MerkleTree<fixtures::vk_tree::VK_TREE_WIDTH> =
-        comptime { fixtures::vk_tree::get_vk_merkle_tree() };
+        comptime { fixtures::vk_tree::VK_MERKLE_TREE };
     let vk_path = vk_tree.get_sibling_path(vk_index);
     let vk_tree_root = vk_tree.get_root();
 

--- a/noir-projects/noir-protocol-circuits/crates/rollup-lib/src/tests/previous_rollup_data.nr
+++ b/noir-projects/noir-protocol-circuits/crates/rollup-lib/src/tests/previous_rollup_data.nr
@@ -16,7 +16,7 @@ pub fn default_previous_rollup_data<let N: u32, let M: u32>(
 
     let vk_index = PUBLIC_BASE_ROLLUP_VK_INDEX;
     let vk_tree: MerkleTree<fixtures::vk_tree::VK_TREE_WIDTH> =
-        comptime { fixtures::vk_tree::get_vk_merkle_tree() };
+        comptime { fixtures::vk_tree::VK_MERKLE_TREE };
     let vk_path = vk_tree.get_sibling_path(vk_index);
     let vk_tree_root = vk_tree.get_root();
 

--- a/noir-projects/noir-protocol-circuits/crates/rollup-lib/src/tests/previous_rollup_data.nr
+++ b/noir-projects/noir-protocol-circuits/crates/rollup-lib/src/tests/previous_rollup_data.nr
@@ -15,8 +15,7 @@ pub fn default_previous_rollup_data<let N: u32, let M: u32>(
     let mut previous_rollup_data = [PreviousRollupData::empty(); 2];
 
     let vk_index = PUBLIC_BASE_ROLLUP_VK_INDEX;
-    let vk_tree: MerkleTree<fixtures::vk_tree::VK_TREE_WIDTH> =
-        comptime { fixtures::vk_tree::VK_MERKLE_TREE };
+    let vk_tree: MerkleTree<fixtures::vk_tree::VK_TREE_WIDTH> = fixtures::vk_tree::VK_MERKLE_TREE;
     let vk_path = vk_tree.get_sibling_path(vk_index);
     let vk_tree_root = vk_tree.get_root();
 

--- a/noir-projects/noir-protocol-circuits/crates/rollup-lib/src/tests/rollup_fixture_builder.nr
+++ b/noir-projects/noir-protocol-circuits/crates/rollup-lib/src/tests/rollup_fixture_builder.nr
@@ -45,7 +45,7 @@ pub struct RollupFixtureBuilder {
 
 impl RollupFixtureBuilder {
     pub fn new() -> Self {
-        let vk_tree = comptime { fixtures::vk_tree::get_vk_merkle_tree() };
+        let vk_tree = comptime { fixtures::vk_tree::VK_MERKLE_TREE };
         let vk_tree_root = vk_tree.get_root();
 
         let mut global_variables = GlobalVariables::empty();

--- a/noir-projects/noir-protocol-circuits/crates/rollup-lib/src/tests/rollup_fixture_builder.nr
+++ b/noir-projects/noir-protocol-circuits/crates/rollup-lib/src/tests/rollup_fixture_builder.nr
@@ -45,7 +45,7 @@ pub struct RollupFixtureBuilder {
 
 impl RollupFixtureBuilder {
     pub fn new() -> Self {
-        let vk_tree = comptime { fixtures::vk_tree::VK_MERKLE_TREE };
+        let vk_tree = fixtures::vk_tree::VK_MERKLE_TREE;
         let vk_tree_root = vk_tree.get_root();
 
         let mut global_variables = GlobalVariables::empty();

--- a/noir-projects/noir-protocol-circuits/crates/types/src/tests/fixture_builder.nr
+++ b/noir-projects/noir-protocol-circuits/crates/types/src/tests/fixture_builder.nr
@@ -216,7 +216,7 @@ impl FixtureBuilder {
     pub fn in_vk_tree(&mut self, vk_index: u32) -> Self {
         self.vk_index = vk_index;
         let vk_tree: MerkleTree<fixtures::vk_tree::VK_TREE_WIDTH> =
-            comptime { fixtures::vk_tree::VK_MERKLE_TREE };
+            fixtures::vk_tree::VK_MERKLE_TREE;
 
         self.honk_vk = fixtures::vk_tree::generate_fake_honk_vk_for_index(vk_index);
         self.client_ivc_vk = fixtures::vk_tree::generate_fake_client_ivc_vk_for_index(vk_index);

--- a/noir-projects/noir-protocol-circuits/crates/types/src/tests/fixture_builder.nr
+++ b/noir-projects/noir-protocol-circuits/crates/types/src/tests/fixture_builder.nr
@@ -216,7 +216,7 @@ impl FixtureBuilder {
     pub fn in_vk_tree(&mut self, vk_index: u32) -> Self {
         self.vk_index = vk_index;
         let vk_tree: MerkleTree<fixtures::vk_tree::VK_TREE_WIDTH> =
-            comptime { fixtures::vk_tree::get_vk_merkle_tree() };
+            comptime { fixtures::vk_tree::VK_MERKLE_TREE };
 
         self.honk_vk = fixtures::vk_tree::generate_fake_honk_vk_for_index(vk_index);
         self.client_ivc_vk = fixtures::vk_tree::generate_fake_client_ivc_vk_for_index(vk_index);
@@ -229,7 +229,7 @@ impl FixtureBuilder {
     }
 
     pub fn vk_tree_root() -> Field {
-        fixtures::vk_tree::get_vk_merkle_tree().get_root()
+        fixtures::vk_tree::VK_MERKLE_TREE.get_root()
     }
 
     pub fn set_protocol_contract_root(&mut self) {

--- a/noir-projects/noir-protocol-circuits/crates/types/src/tests/fixtures/vk_tree.nr
+++ b/noir-projects/noir-protocol-circuits/crates/types/src/tests/fixtures/vk_tree.nr
@@ -41,7 +41,7 @@ pub fn generate_fake_client_ivc_vk_for_index(
     VerificationKey { key, hash: verification_key_hash(key) }
 }
 
-pub fn get_vk_merkle_tree() -> MerkleTree<VK_TREE_WIDTH> {
+pub global VK_MERKLE_TREE: MerkleTree<VK_TREE_WIDTH> = {
     let mut leaves = [0; VK_TREE_WIDTH];
 
     // Fake VK hashes for testing purposes
@@ -76,4 +76,4 @@ pub fn get_vk_merkle_tree() -> MerkleTree<VK_TREE_WIDTH> {
         generate_fake_rollup_honk_vk_for_index(BLOCK_ROOT_ROLLUP_EMPTY_INDEX).hash;
 
     MerkleTree::new(leaves)
-}
+};


### PR DESCRIPTION
Calling `get_vk_merkle_tree` during comptime takes 80ms on my machine. It's called several times during compilation.

Running `time nargo check --force` inside `rollup-base-private` used to take 1.3 seconds on my machine. With this change it takes 0.6 seconds. It's not that much for a human, but `nargo check` is what LSP uses so this should speed up LSP in these projects by a noticeable amount.