### PR TITLE
fix: rename `prove_note_validity` to `prove_note_exists_and_not_nullified`

### DIFF
--- a/docs/docs/developers/guides/smart_contracts/writing_contracts/how_to_prove_history.md
+++ b/docs/docs/developers/guides/smart_contracts/writing_contracts/how_to_prove_history.md
@@ -4,7 +4,7 @@ sidebar_position: 4
 tags: [contracts]
 ---
 
-The Aztec Protocol uses an append-only Merkle tree to store hashes of the headers of all previous blocks in the chain as its leaves. This is known as the Archive tree. 
+The Aztec Protocol uses an append-only Merkle tree to store hashes of the headers of all previous blocks in the chain as its leaves. This is known as the Archive tree.
 
 This page is a quick introductory guide to creating historical proofs proofs from the archive tree.
 
@@ -55,9 +55,9 @@ To prove that a note existed in a specified block, call `prove_note_inclusion` o
 
 Here, if `block_number` exists as an argument, it will prove inclusion in that block. Else, it will use the current block.
 
-This will only prove the note existed at the specific block number, not whether or not the note has been nullified. You can prove that a note existed and had not been nullified in a specified block by using `prove_note_validity` on the block header which takes the following arguments:
+This will only prove the note existed at the specific block number, not whether or not the note has been nullified. You can prove that a note exists and has not been nullified in a specified block by using `prove_note_exists_and_not_nullified` on the block header which takes the following arguments:
 
-#include_code prove_note_validity noir-projects/noir-contracts/contracts/inclusion_proofs_contract/src/main.nr rust
+#include_code prove_note_exists_and_not_nullified noir-projects/noir-contracts/contracts/inclusion_proofs_contract/src/main.nr rust
 
 ## Create a nullifier to prove inclusion of
 

--- a/noir-projects/aztec-nr/aztec/src/history/note_validity.nr
+++ b/noir-projects/aztec-nr/aztec/src/history/note_validity.nr
@@ -2,8 +2,8 @@ use crate::{context::PrivateContext, note::note_interface::{NoteInterface, Nulli
 
 use dep::protocol_types::block_header::BlockHeader;
 
-trait ProveNoteValidity {
-    fn prove_note_validity<Note, let N: u32>(
+trait ProveNoteExistsAndNotNullified {
+    fn prove_note_exists_and_not_nullified<Note, let N: u32>(
         header: BlockHeader,
         note: Note,
         storage_slot: Field,
@@ -13,8 +13,8 @@ trait ProveNoteValidity {
         Note: NoteInterface<N> + NullifiableNote;
 }
 
-impl ProveNoteValidity for BlockHeader {
-    fn prove_note_validity<Note, let N: u32>(
+impl ProveNoteExistsAndNotNullified for BlockHeader {
+    fn prove_note_exists_and_not_nullified<Note, let N: u32>(
         self,
         note: Note,
         storage_slot: Field,

--- a/noir-projects/noir-contracts/contracts/counter_contract/src/main.nr
+++ b/noir-projects/noir-contracts/contracts/counter_contract/src/main.nr
@@ -155,7 +155,7 @@ pub contract Counter {
 
         let old_note = notes.get(0);
 
-        env.private().get_block_header().prove_note_validity(
+        env.private().get_block_header().prove_note_exists_and_not_nullified(
             old_note,
             owner_slot,
             &mut env.private(),
@@ -164,7 +164,7 @@ pub contract Counter {
         destroy_note(&mut env.private(), old_note, owner_slot);
         env.advance_block_by(1);
 
-        env.private().get_block_header().prove_note_is_nullified(
+        env.private().get_block_header().prove_note_exists_and_not_nullified(
             old_note,
             owner_slot,
             &mut env.private(),
@@ -263,7 +263,7 @@ pub contract Counter {
 
         let old_note = notes.get(0);
 
-        env.private().get_block_header().prove_note_validity(
+        env.private().get_block_header().prove_note_exists_and_not_nullified(
             old_note,
             owner_slot,
             &mut env.private(),

--- a/noir-projects/noir-contracts/contracts/inclusion_proofs_contract/src/main.nr
+++ b/noir-projects/noir-contracts/contracts/inclusion_proofs_contract/src/main.nr
@@ -144,7 +144,7 @@ pub contract InclusionProofs {
             context.get_block_header()
         };
         // docs:start:prove_note_validity
-        header.prove_note_validity(note, note_storage_slot, &mut context);
+        header.prove_note_exists_and_not_nullified(note, note_storage_slot, &mut context);
         // docs:end:prove_note_validity
     }
 


### PR DESCRIPTION
Rename `prove_note_validity` to `prove_note_exists_and_not_nullified`

Fixes #11967

The function `prove_note_validity` has been renamed to better describe its actual functionality. The new name `prove_note_exists_and_not_nullified` clearly indicates that the function:
1. Proves that the note exists in the note tree
2. Proves that the note has not been nullified

Changes:
- Renamed trait and implementation in `note_validity.nr`
- Updated function calls in contracts
- Updated documentation

No functional changes were made, only renaming for better clarity.