### PR TITLE
fix: `#[aztec]` macro warnings

### DIFF
--- a/noir-projects/aztec-nr/aztec/src/context/call_interfaces.nr
+++ b/noir-projects/aztec-nr/aztec/src/context/call_interfaces.nr
@@ -467,13 +467,13 @@ impl<let N: u32> CallInterface<N> for PublicStaticVoidCallInterface<N> {
 }
 
 pub struct PublicStaticVoidCallInterface<let N: u32> {
-    target_contract: AztecAddress,
-    selector: FunctionSelector,
-    name: str<N>,
-    args: [Field],
-    return_type: (),
-    is_static: bool,
-    gas_opts: GasOpts,
+    pub target_contract: AztecAddress,
+    pub selector: FunctionSelector,
+    pub name: str<N>,
+    pub args: [Field],
+    pub return_type: (),
+    pub is_static: bool,
+    pub gas_opts: GasOpts,
 }
 
 impl<let N: u32> PublicStaticVoidCallInterface<N> {

--- a/noir-projects/aztec-nr/aztec/src/encrypted_logs/encrypt/aes128.nr
+++ b/noir-projects/aztec-nr/aztec/src/encrypted_logs/encrypt/aes128.nr
@@ -29,6 +29,7 @@ fn extract_close_to_uniformly_random_256_bits_from_ecdh_shared_secret_using_pose
     bytes
 }
 
+// TODO(#10537): Consider nuking this function.
 fn extract_close_to_uniformly_random_256_bits_from_ecdh_shared_secret_using_sha256(
     shared_secret: Point,
 ) -> [u8; 32] {
@@ -57,6 +58,7 @@ fn derive_aes_symmetric_key_and_iv_from_ecdh_shared_secret(
     (sym_key, iv)
 }
 
+// TODO(#10537): Consider nuking this function.
 pub fn derive_aes_symmetric_key_and_iv_from_ecdh_shared_secret_using_sha256(
     shared_secret: Point,
 ) -> ([u8; 16], [u8; 16]) {
@@ -66,6 +68,7 @@ pub fn derive_aes_symmetric_key_and_iv_from_ecdh_shared_secret_using_sha256(
     )
 }
 
+// TODO(#10537): This function is currently unused. Consider using it instead of the sha256 one.
 pub fn derive_aes_symmetric_key_and_iv_from_ecdh_shared_secret_using_poseidon2(
     shared_secret: Point,
 ) -> ([u8; 16], [u8; 16]) {

--- a/noir-projects/aztec-nr/aztec/src/macros/functions/interfaces.nr
+++ b/noir-projects/aztec-nr/aztec/src/macros/functions/interfaces.nr
@@ -126,10 +126,24 @@ pub comptime fn stub_fn(f: FunctionDefinition) -> Quoted {
         quote {}
     };
 
+    // We get the typed expression of `from_field` here rather than directly inlining it in the quote
+    // with `FunctionSelector::from_field()`. Direct inlining would result in missing import warnings
+    // in the generated code (specifically, warnings that FromField trait is implemented but not in scope).
+    let from_field_trait = quote { protocol_types::traits::FromField }.as_trait_constraint();
+    let function_selector_typ =
+        quote { protocol_types::abis::function_selector::FunctionSelector }.as_type();
+
+    let from_field = function_selector_typ
+        .get_trait_impl(from_field_trait)
+        .unwrap()
+        .methods()
+        .filter(|m| m.name() == quote { from_field })[0]
+        .as_typed_expr();
+
     quote {
         pub fn $fn_name(self, $fn_parameters_list) -> $call_interface_name<$call_interface_generics> {
             $args
-            let selector = dep::aztec::protocol_types::abis::function_selector::FunctionSelector::from_field($fn_selector);
+            let selector = $from_field($fn_selector);
             $call_interface_name {
                 target_contract: self.target_contract,
                 selector,

--- a/noir-projects/aztec-nr/aztec/src/macros/functions/interfaces.nr
+++ b/noir-projects/aztec-nr/aztec/src/macros/functions/interfaces.nr
@@ -1,6 +1,6 @@
 use crate::macros::utils::{
-    add_to_field_slice, compute_fn_selector, get_fn_visibility, is_fn_private, is_fn_public,
-    is_fn_view,
+    add_to_field_slice, compute_fn_selector, get_fn_visibility, get_trait_impl_method,
+    is_fn_private, is_fn_public, is_fn_view,
 };
 use std::{
     collections::umap::UHashMap,
@@ -126,19 +126,13 @@ pub comptime fn stub_fn(f: FunctionDefinition) -> Quoted {
         quote {}
     };
 
-    // We get the typed expression of `from_field` here rather than directly inlining it in the quote
-    // with `FunctionSelector::from_field()`. Direct inlining would result in missing import warnings
-    // in the generated code (specifically, warnings that FromField trait is implemented but not in scope).
-    let from_field_trait = quote { protocol_types::traits::FromField }.as_trait_constraint();
     let function_selector_typ =
         quote { protocol_types::abis::function_selector::FunctionSelector }.as_type();
-
-    let from_field = function_selector_typ
-        .get_trait_impl(from_field_trait)
-        .unwrap()
-        .methods()
-        .filter(|m| m.name() == quote { from_field })[0]
-        .as_typed_expr();
+    let from_field = get_trait_impl_method(
+        function_selector_typ,
+        quote { protocol_types::traits::FromField },
+        quote { from_field },
+    );
 
     quote {
         pub fn $fn_name(self, $fn_parameters_list) -> $call_interface_name<$call_interface_generics> {

--- a/noir-projects/aztec-nr/aztec/src/macros/mod.nr
+++ b/noir-projects/aztec-nr/aztec/src/macros/mod.nr
@@ -13,6 +13,11 @@ use dispatch::generate_public_dispatch;
 use functions::transform_unconstrained;
 use utils::module_has_storage;
 
+global NOTE_INTERFACE: TraitConstraint =
+    quote { crate::note::note_interface::NoteInterface }.as_trait_constraint();
+global PACKABLE: TraitConstraint =
+    quote { crate::protocol_types::traits::Packable<_> }.as_trait_constraint();
+
 /// Marks a contract as an Aztec contract, generating the interfaces for its functions and notes, as well as injecting
 /// the `compute_note_hash_and_optionally_a_nullifier` function PXE requires in order to validate notes.
 ///
@@ -128,10 +133,6 @@ comptime fn generate_compute_note_hash_and_optionally_a_nullifier() -> Quoted {
 
         let mut if_statements_list = &[];
 
-        let note_interface =
-            quote { crate::note::note_interface::NoteInterface }.as_trait_constraint();
-        let packable = quote { crate::protocol_types::traits::Packable<_> }.as_trait_constraint();
-
         for i in 0..notes.len() {
             let (typ, (_, _, _, _)) = notes[i];
 
@@ -139,12 +140,12 @@ comptime fn generate_compute_note_hash_and_optionally_a_nullifier() -> Quoted {
             // in the quote with `$typ::get_note_type_id()` and `$typ::unpack()`. Direct inlining would result
             // in missing import warnings in the generated code (specifically, warnings that NoteInterface and
             // Packable<N> are implemented but not in scope).
-            let get_note_type_id = typ.get_trait_impl(note_interface).unwrap().methods().filter(
+            let get_note_type_id = typ.get_trait_impl(NOTE_INTERFACE).unwrap().methods().filter(
                 |m| m.name() == quote { get_note_type_id },
             )[0]
                 .as_typed_expr();
 
-            let unpack = typ.get_trait_impl(packable).unwrap().methods().filter(|m| {
+            let unpack = typ.get_trait_impl(PACKABLE).unwrap().methods().filter(|m| {
                 m.name() == quote { unpack }
             })[0]
                 .as_typed_expr();
@@ -231,9 +232,6 @@ comptime fn generate_process_log() -> Quoted {
 
     let notes = NOTES.entries();
 
-    let note_interface = quote { crate::note::note_interface::NoteInterface }.as_trait_constraint();
-    let packable = quote { crate::protocol_types::traits::Packable<_> }.as_trait_constraint();
-
     let mut if_note_type_id_match_statements_list = &[];
     for i in 0..notes.len() {
         let (typ, (_, packed_note_length, _, _)) = notes[i];
@@ -242,12 +240,12 @@ comptime fn generate_process_log() -> Quoted {
         // in the quote with `$typ::get_note_type_id()` and `$typ::unpack()`. Direct inlining would result
         // in missing import warnings in the generated code (specifically, warnings that NoteInterface and
         // Packable<N> are implemented but not in scope).
-        let get_note_type_id = typ.get_trait_impl(note_interface).unwrap().methods().filter(|m| {
+        let get_note_type_id = typ.get_trait_impl(NOTE_INTERFACE).unwrap().methods().filter(|m| {
             m.name() == quote { get_note_type_id }
         })[0]
             .as_typed_expr();
 
-        let unpack = typ.get_trait_impl(packable).unwrap().methods().filter(|m| {
+        let unpack = typ.get_trait_impl(PACKABLE).unwrap().methods().filter(|m| {
             m.name() == quote { unpack }
         })[0]
             .as_typed_expr();

--- a/noir-projects/aztec-nr/aztec/src/macros/mod.nr
+++ b/noir-projects/aztec-nr/aztec/src/macros/mod.nr
@@ -15,8 +15,6 @@ use utils::module_has_storage;
 
 global NOTE_INTERFACE: TraitConstraint =
     quote { crate::note::note_interface::NoteInterface }.as_trait_constraint();
-global PACKABLE: TraitConstraint =
-    quote { crate::protocol_types::traits::Packable<_> }.as_trait_constraint();
 
 /// Marks a contract as an Aztec contract, generating the interfaces for its functions and notes, as well as injecting
 /// the `compute_note_hash_and_optionally_a_nullifier` function PXE requires in order to validate notes.
@@ -148,7 +146,13 @@ comptime fn generate_compute_note_hash_and_optionally_a_nullifier() -> Quoted {
             )[0]
                 .as_typed_expr();
 
-            let unpack = typ.get_trait_impl(PACKABLE).unwrap().methods().filter(|m| {
+            // We obtain the packable trait constraint here rather than storing it as a global variable. This is because
+            // the trait has a generic parameter that gets matched on first use. If we used a global variable, we would
+            // fail to get trait implementations for types that don't match the already-matched generic parameter.
+            let packable: TraitConstraint =
+                quote { crate::protocol_types::traits::Packable<_> }.as_trait_constraint();
+
+            let unpack = typ.get_trait_impl(packable).unwrap().methods().filter(|m| {
                 m.name() == quote { unpack }
             })[0]
                 .as_typed_expr();
@@ -253,7 +257,13 @@ comptime fn generate_process_log() -> Quoted {
         })[0]
             .as_typed_expr();
 
-        let unpack = typ.get_trait_impl(PACKABLE).unwrap().methods().filter(|m| {
+        // We obtain the packable trait constraint here rather than storing it as a global variable. This is because
+        // the trait has a generic parameter that gets matched on first use. If we used a global variable, we would
+        // fail to get trait implementations for types that don't match the already-matched generic parameter.
+        let packable: TraitConstraint =
+            quote { crate::protocol_types::traits::Packable<_> }.as_trait_constraint();
+
+        let unpack = typ.get_trait_impl(packable).unwrap().methods().filter(|m| {
             m.name() == quote { unpack }
         })[0]
             .as_typed_expr();

--- a/noir-projects/aztec-nr/aztec/src/macros/mod.nr
+++ b/noir-projects/aztec-nr/aztec/src/macros/mod.nr
@@ -9,6 +9,7 @@ use functions::interfaces::STUBS;
 use notes::{generate_note_export, NOTES};
 use storage::STORAGE_LAYOUT_NAME;
 
+use crate::note::note_interface::NoteInterface;
 use dispatch::generate_public_dispatch;
 use functions::transform_unconstrained;
 use utils::module_has_storage;
@@ -212,9 +213,18 @@ comptime fn generate_process_log() -> Quoted {
 
     let notes = NOTES.entries();
 
+    let note_interface = quote { NoteInterface }.as_trait_constraint();
+
     let mut if_note_type_id_match_statements_list = &[];
     for i in 0..notes.len() {
         let (typ, (_, packed_note_length, _, _)) = notes[i];
+
+        // We get the function definition of `get_note_type_id` here rather than directly inlining it in the quote
+        // with `$typ::get_note_type_id()`. Direct inlining would result in missing import warnings in the generated
+        // code (specifically, a warning that NoteInterface is implemented but not in scope).
+        let get_note_type_id = typ.get_trait_impl(note_interface).unwrap().methods().filter(|m| {
+            m.name() == quote { get_note_type_id }
+        })[0];
 
         let if_or_else_if = if i == 0 {
             quote { if }
@@ -224,7 +234,7 @@ comptime fn generate_process_log() -> Quoted {
 
         if_note_type_id_match_statements_list = if_note_type_id_match_statements_list.push_back(
             quote {
-                $if_or_else_if note_type_id == $typ::get_note_type_id() {
+                $if_or_else_if note_type_id == $get_note_type_id() {
                     // As an extra safety check we make sure that the packed_note bounded vec has the
                     // expected length, to avoid scenarios in which compute_note_hash_and_optionally_a_nullifier
                     // silently trims the end if the log were to be longer.

--- a/noir-projects/aztec-nr/aztec/src/macros/mod.nr
+++ b/noir-projects/aztec-nr/aztec/src/macros/mod.nr
@@ -140,6 +140,9 @@ comptime fn generate_compute_note_hash_and_optionally_a_nullifier() -> Quoted {
             // in the quote with `$typ::get_note_type_id()` and `$typ::unpack()`. Direct inlining would result
             // in missing import warnings in the generated code (specifically, warnings that NoteInterface and
             // Packable<N> are implemented but not in scope).
+            // Note: noir-fmt:ignore is used to avoid the following formatter bug:
+            // https://github.com/noir-lang/noir/issues/7407
+            // noir-fmt:ignore
             let get_note_type_id = typ.get_trait_impl(NOTE_INTERFACE).unwrap().methods().filter(
                 |m| m.name() == quote { get_note_type_id },
             )[0]

--- a/noir-projects/aztec-nr/aztec/src/macros/mod.nr
+++ b/noir-projects/aztec-nr/aztec/src/macros/mod.nr
@@ -11,10 +11,7 @@ use storage::STORAGE_LAYOUT_NAME;
 
 use dispatch::generate_public_dispatch;
 use functions::transform_unconstrained;
-use utils::module_has_storage;
-
-global NOTE_INTERFACE: TraitConstraint =
-    quote { crate::note::note_interface::NoteInterface }.as_trait_constraint();
+use utils::{get_trait_impl_method, module_has_storage};
 
 /// Marks a contract as an Aztec contract, generating the interfaces for its functions and notes, as well as injecting
 /// the `compute_note_hash_and_optionally_a_nullifier` function PXE requires in order to validate notes.
@@ -134,28 +131,16 @@ comptime fn generate_compute_note_hash_and_optionally_a_nullifier() -> Quoted {
         for i in 0..notes.len() {
             let (typ, (_, _, _, _)) = notes[i];
 
-            // We get the typed expressions of `get_note_type_id` and `unpack` here rather than directly inlining them
-            // in the quote with `$typ::get_note_type_id()` and `$typ::unpack()`. Direct inlining would result
-            // in missing import warnings in the generated code (specifically, warnings that NoteInterface and
-            // Packable<N> are implemented but not in scope).
-            // Note: noir-fmt:ignore is used to avoid the following formatter bug:
-            // https://github.com/noir-lang/noir/issues/7407
-            // noir-fmt:ignore
-            let get_note_type_id = typ.get_trait_impl(NOTE_INTERFACE).unwrap().methods().filter(
-                |m| m.name() == quote { get_note_type_id },
-            )[0]
-                .as_typed_expr();
-
-            // We obtain the packable trait constraint here rather than storing it as a global variable. This is because
-            // the trait has a generic parameter that gets matched on first use. If we used a global variable, we would
-            // fail to get trait implementations for types that don't match the already-matched generic parameter.
-            let packable: TraitConstraint =
-                quote { crate::protocol_types::traits::Packable<_> }.as_trait_constraint();
-
-            let unpack = typ.get_trait_impl(packable).unwrap().methods().filter(|m| {
-                m.name() == quote { unpack }
-            })[0]
-                .as_typed_expr();
+            let get_note_type_id = get_trait_impl_method(
+                typ,
+                quote { crate::note::note_interface::NoteInterface },
+                quote { get_note_type_id },
+            );
+            let unpack = get_trait_impl_method(
+                typ,
+                quote { crate::protocol_types::traits::Packable<_> },
+                quote { unpack },
+            );
 
             let if_or_else_if = if i == 0 {
                 quote { if }
@@ -248,25 +233,16 @@ comptime fn generate_process_log() -> Quoted {
     for i in 0..notes.len() {
         let (typ, (_, packed_note_length, _, _)) = notes[i];
 
-        // We get the typed expressions of `get_note_type_id` and `unpack` here rather than directly inlining them
-        // in the quote with `$typ::get_note_type_id()` and `$typ::unpack()`. Direct inlining would result
-        // in missing import warnings in the generated code (specifically, warnings that NoteInterface and
-        // Packable<N> are implemented but not in scope).
-        let get_note_type_id = typ.get_trait_impl(NOTE_INTERFACE).unwrap().methods().filter(|m| {
-            m.name() == quote { get_note_type_id }
-        })[0]
-            .as_typed_expr();
-
-        // We obtain the packable trait constraint here rather than storing it as a global variable. This is because
-        // the trait has a generic parameter that gets matched on first use. If we used a global variable, we would
-        // fail to get trait implementations for types that don't match the already-matched generic parameter.
-        let packable: TraitConstraint =
-            quote { crate::protocol_types::traits::Packable<_> }.as_trait_constraint();
-
-        let unpack = typ.get_trait_impl(packable).unwrap().methods().filter(|m| {
-            m.name() == quote { unpack }
-        })[0]
-            .as_typed_expr();
+        let get_note_type_id = get_trait_impl_method(
+            typ,
+            quote { crate::note::note_interface::NoteInterface },
+            quote { get_note_type_id },
+        );
+        let unpack = get_trait_impl_method(
+            typ,
+            quote { crate::protocol_types::traits::Packable<_> },
+            quote { unpack },
+        );
 
         let if_or_else_if = if i == 0 {
             quote { if }

--- a/noir-projects/aztec-nr/aztec/src/macros/mod.nr
+++ b/noir-projects/aztec-nr/aztec/src/macros/mod.nr
@@ -119,7 +119,7 @@ comptime fn generate_contract_interface(m: Module) -> Quoted {
 comptime fn generate_compute_note_hash_and_optionally_a_nullifier() -> Quoted {
     let mut max_note_packed_len: u32 = 0;
     let notes = NOTES.entries();
-    let body = if notes.len() > 0 {
+    if notes.len() > 0 {
         max_note_packed_len = notes.fold(
             0,
             |acc, (_, (_, len, _, _)): (Type, (StructDefinition, u32, Field, [(Quoted, u32, bool)]))| {
@@ -167,27 +167,32 @@ comptime fn generate_compute_note_hash_and_optionally_a_nullifier() -> Quoted {
         let if_statements = if_statements_list.join(quote {});
 
         quote {
-            $if_statements
-            else {
-                panic(f"Unknown note type ID: {note_type_id}")
+            unconstrained fn compute_note_hash_and_optionally_a_nullifier(
+                contract_address: aztec::protocol_types::address::AztecAddress,
+                nonce: Field,
+                storage_slot: Field,
+                note_type_id: Field,
+                compute_nullifier: bool,
+                packed_note: [Field; $max_note_packed_len],
+            ) -> pub [Field; 4] {
+                $if_statements
+                else {
+                    panic(f"Unknown note type ID: {note_type_id}")
+                }
             }
         }
     } else {
         quote {
-            panic(f"No notes defined")
-        }
-    };
-
-    quote {
-        unconstrained fn compute_note_hash_and_optionally_a_nullifier(
-            contract_address: aztec::protocol_types::address::AztecAddress,
-            nonce: Field,
-            storage_slot: Field,
-            note_type_id: Field,
-            compute_nullifier: bool,
-            packed_note: [Field; $max_note_packed_len],
-        ) -> pub [Field; 4] {
-            $body
+            unconstrained fn compute_note_hash_and_optionally_a_nullifier(
+                _contract_address: aztec::protocol_types::address::AztecAddress,
+                _nonce: Field,
+                _storage_slot: Field,
+                _note_type_id: Field,
+                _compute_nullifier: bool,
+                _packed_note: [Field; $max_note_packed_len],
+            ) -> pub [Field; 4] {
+                panic(f"No notes defined")
+            }
         }
     }
 }
@@ -277,51 +282,55 @@ comptime fn generate_process_log() -> Quoted {
 
     let if_note_type_id_match_statements = if_note_type_id_match_statements_list.join(quote {});
 
-    let body = if notes.len() > 0 {
+    if notes.len() > 0 {
         quote {
-            // Because this unconstrained function is injected after the contract is processed by the macros, it'll not
-            // be modified by the macros that alter unconstrained functions. As such, we need to manually inject the
-            // unconstrained execution context since it will not be available otherwise.
-            let context = dep::aztec::context::unconstrained_context::UnconstrainedContext::new();
+            unconstrained fn process_log(
+                log_plaintext: BoundedVec<Field, dep::aztec::protocol_types::constants::PRIVATE_LOG_SIZE_IN_FIELDS>,
+                tx_hash: Field,
+                unique_note_hashes_in_tx: BoundedVec<Field, dep::aztec::protocol_types::constants::MAX_NOTE_HASHES_PER_TX>,
+                first_nullifier_in_tx: Field,
+                recipient: aztec::protocol_types::address::AztecAddress,
+            ) {
+                // Because this unconstrained function is injected after the contract is processed by the macros, it'll not
+                // be modified by the macros that alter unconstrained functions. As such, we need to manually inject the
+                // unconstrained execution context since it will not be available otherwise.
+                let context = dep::aztec::context::unconstrained_context::UnconstrainedContext::new();
 
-            dep::aztec::note::discovery::do_process_log(
-                context,
-                log_plaintext,
-                tx_hash,
-                unique_note_hashes_in_tx,
-                first_nullifier_in_tx,
-                recipient,
-                |packed_note: BoundedVec<Field, _>, contract_address, nonce, storage_slot, note_type_id| {
-                    let hashes = $if_note_type_id_match_statements
-                    else {
-                        panic(f"Unknown note type id {note_type_id}")
-                    };
+                dep::aztec::note::discovery::do_process_log(
+                    context,
+                    log_plaintext,
+                    tx_hash,
+                    unique_note_hashes_in_tx,
+                    first_nullifier_in_tx,
+                    recipient,
+                    |packed_note: BoundedVec<Field, _>, contract_address, nonce, storage_slot, note_type_id| {
+                        let hashes = $if_note_type_id_match_statements
+                        else {
+                            panic(f"Unknown note type id {note_type_id}")
+                        };
 
-                    Option::some(
-                        dep::aztec::note::discovery::NoteHashesAndNullifier {
-                            note_hash: hashes[0],
-                            unique_note_hash: hashes[1],
-                            inner_nullifier: hashes[3],
-                        },
-                    )
-                }
-            );
+                        Option::some(
+                            dep::aztec::note::discovery::NoteHashesAndNullifier {
+                                note_hash: hashes[0],
+                                unique_note_hash: hashes[1],
+                                inner_nullifier: hashes[3],
+                            },
+                        )
+                    }
+                );
+            }
         }
     } else {
         quote {
-            panic(f"No notes defined")
-        }
-    };
-
-    quote {
-        unconstrained fn process_log(
-            log_plaintext: BoundedVec<Field, dep::aztec::protocol_types::constants::PRIVATE_LOG_SIZE_IN_FIELDS>,
-            tx_hash: Field,
-            unique_note_hashes_in_tx: BoundedVec<Field, dep::aztec::protocol_types::constants::MAX_NOTE_HASHES_PER_TX>,
-            first_nullifier_in_tx: Field,
-            recipient: aztec::protocol_types::address::AztecAddress,
-        ) {
-            $body
+            unconstrained fn process_log(
+                _log_plaintext: BoundedVec<Field, dep::aztec::protocol_types::constants::PRIVATE_LOG_SIZE_IN_FIELDS>,
+                _tx_hash: Field,
+                _unique_note_hashes_in_tx: BoundedVec<Field, dep::aztec::protocol_types::constants::MAX_NOTE_HASHES_PER_TX>,
+                _first_nullifier_in_tx: Field,
+                _recipient: aztec::protocol_types::address::AztecAddress,
+            ) {
+                panic(f"No notes defined")
+            }
         }
     }
 }

--- a/noir-projects/aztec-nr/aztec/src/macros/mod.nr
+++ b/noir-projects/aztec-nr/aztec/src/macros/mod.nr
@@ -9,7 +9,6 @@ use functions::interfaces::STUBS;
 use notes::{generate_note_export, NOTES};
 use storage::STORAGE_LAYOUT_NAME;
 
-use crate::note::note_interface::NoteInterface;
 use dispatch::generate_public_dispatch;
 use functions::transform_unconstrained;
 use utils::module_has_storage;
@@ -129,8 +128,27 @@ comptime fn generate_compute_note_hash_and_optionally_a_nullifier() -> Quoted {
 
         let mut if_statements_list = &[];
 
+        let note_interface =
+            quote { crate::note::note_interface::NoteInterface }.as_trait_constraint();
+        let packable = quote { crate::protocol_types::traits::Packable<_> }.as_trait_constraint();
+
         for i in 0..notes.len() {
             let (typ, (_, _, _, _)) = notes[i];
+
+            // We get the typed expressions of `get_note_type_id` and `unpack` here rather than directly inlining them
+            // in the quote with `$typ::get_note_type_id()` and `$typ::unpack()`. Direct inlining would result
+            // in missing import warnings in the generated code (specifically, warnings that NoteInterface and
+            // Packable<N> are implemented but not in scope).
+            let get_note_type_id = typ.get_trait_impl(note_interface).unwrap().methods().filter(
+                |m| m.name() == quote { get_note_type_id },
+            )[0]
+                .as_typed_expr();
+
+            let unpack = typ.get_trait_impl(packable).unwrap().methods().filter(|m| {
+                m.name() == quote { unpack }
+            })[0]
+                .as_typed_expr();
+
             let if_or_else_if = if i == 0 {
                 quote { if }
             } else {
@@ -138,8 +156,8 @@ comptime fn generate_compute_note_hash_and_optionally_a_nullifier() -> Quoted {
             };
             if_statements_list = if_statements_list.push_back(
                 quote {
-                $if_or_else_if note_type_id == $typ::get_note_type_id() {
-                    aztec::note::utils::compute_note_hash_and_optionally_a_nullifier($typ::unpack, contract_address, nonce, compute_nullifier, storage_slot, packed_note)
+                $if_or_else_if note_type_id == $get_note_type_id() {
+                    aztec::note::utils::compute_note_hash_and_optionally_a_nullifier($unpack, contract_address, nonce, compute_nullifier, storage_slot, packed_note)
                 }
             },
             );
@@ -213,18 +231,26 @@ comptime fn generate_process_log() -> Quoted {
 
     let notes = NOTES.entries();
 
-    let note_interface = quote { NoteInterface }.as_trait_constraint();
+    let note_interface = quote { crate::note::note_interface::NoteInterface }.as_trait_constraint();
+    let packable = quote { crate::protocol_types::traits::Packable<_> }.as_trait_constraint();
 
     let mut if_note_type_id_match_statements_list = &[];
     for i in 0..notes.len() {
         let (typ, (_, packed_note_length, _, _)) = notes[i];
 
-        // We get the function definition of `get_note_type_id` here rather than directly inlining it in the quote
-        // with `$typ::get_note_type_id()`. Direct inlining would result in missing import warnings in the generated
-        // code (specifically, a warning that NoteInterface is implemented but not in scope).
+        // We get the typed expressions of `get_note_type_id` and `unpack` here rather than directly inlining them
+        // in the quote with `$typ::get_note_type_id()` and `$typ::unpack()`. Direct inlining would result
+        // in missing import warnings in the generated code (specifically, warnings that NoteInterface and
+        // Packable<N> are implemented but not in scope).
         let get_note_type_id = typ.get_trait_impl(note_interface).unwrap().methods().filter(|m| {
             m.name() == quote { get_note_type_id }
-        })[0];
+        })[0]
+            .as_typed_expr();
+
+        let unpack = typ.get_trait_impl(packable).unwrap().methods().filter(|m| {
+            m.name() == quote { unpack }
+        })[0]
+            .as_typed_expr();
 
         let if_or_else_if = if i == 0 {
             quote { if }
@@ -245,7 +271,7 @@ comptime fn generate_process_log() -> Quoted {
                         f"Expected packed note of length {expected_len} but got {actual_len} for note type id {note_type_id}"
                     );
 
-                    aztec::note::utils::compute_note_hash_and_optionally_a_nullifier($typ::unpack, contract_address, nonce, true, storage_slot, packed_note.storage())
+                    aztec::note::utils::compute_note_hash_and_optionally_a_nullifier($unpack, contract_address, nonce, true, storage_slot, packed_note.storage())
                 }
             },
         );

--- a/noir-projects/aztec-nr/aztec/src/macros/utils.nr
+++ b/noir-projects/aztec-nr/aztec/src/macros/utils.nr
@@ -256,9 +256,9 @@ pub(crate) comptime fn is_note(typ: Type) -> bool {
     })
 }
 
-/// We get the typed expressions of a trait method implementation rather than directly inlining them in a quote with
-/// `$typ::target_method()`. Direct inlining would result in missing import warnings in the generated code
-/// (specifically, warnings that `target_trait` is implemented but not in scope).
+/// Returns the typed expression of a trait method implementation. This is preferred over directly inlining with
+/// `$typ::target_method()` in a quote, as direct inlining would result in missing import warnings in the generated
+/// code (specifically, warnings that the trait implementation is not in scope).
 pub(crate) comptime fn get_trait_impl_method(
     typ: Type,
     target_trait: Quoted,

--- a/noir-projects/aztec-nr/aztec/src/macros/utils.nr
+++ b/noir-projects/aztec-nr/aztec/src/macros/utils.nr
@@ -255,3 +255,16 @@ pub(crate) comptime fn is_note(typ: Type) -> bool {
             | def.has_named_attribute("note_custom_interface")
     })
 }
+
+/// We get the typed expressions of a trait method implementation rather than directly inlining them in a quote with
+/// `$typ::target_method()`. Direct inlining would result in missing import warnings in the generated code
+/// (specifically, warnings that `target_trait` is implemented but not in scope).
+pub(crate) comptime fn get_trait_impl_method(
+    typ: Type,
+    target_trait: Quoted,
+    target_method: Quoted,
+) -> TypedExpr {
+    let trait_constraint = target_trait.as_trait_constraint();
+    typ.get_trait_impl(trait_constraint).unwrap().methods().filter(|m| m.name() == target_method)[0]
+        .as_typed_expr()
+}

--- a/noir-projects/aztec-nr/aztec/src/macros/utils.nr
+++ b/noir-projects/aztec-nr/aztec/src/macros/utils.nr
@@ -59,12 +59,16 @@ pub(crate) comptime fn add_to_field_slice(slice_name: Quoted, name: Quoted, typ:
     if typ.is_field() | typ.as_integer().is_some() | typ.is_bool() {
         quote { $slice_name = $slice_name.push_back($name as Field); }
     } else if typ.as_struct().is_some() {
-        quote { $slice_name = $slice_name.append($name.serialize()); }
+        // We invoke serialize as a static trait function rather than calling $name.serialize() directly in the quote
+        // to avoid "trait not in scope" compiler warnings.
+        quote { $slice_name = $slice_name.append(aztec::protocol_types::traits::Serialize::serialize($name)); }
     } else if typ.as_array().is_some() {
         let (element_type, _) = typ.as_array().unwrap();
         let serialized_name = f"{name}_serialized".quoted_contents();
+        // We invoke serialize as a static trait function rather than calling x.serialize() directly in the quote
+        // to avoid "trait not in scope" compiler warnings.
         quote {
-            let $serialized_name = $name.map(|x: $element_type | x.serialize());
+            let $serialized_name = $name.map(|x: $element_type | aztec::protocol_types::traits::Serialize::serialize(x));
             for i in 0..$name.len() {
                 $slice_name = $slice_name.append($serialized_name[i].as_slice());
             }

--- a/noir-projects/noir-contracts/contracts/router_contract/src/main.nr
+++ b/noir-projects/noir-contracts/contracts/router_contract/src/main.nr
@@ -3,8 +3,8 @@ mod utils;
 
 use dep::aztec::macros::aztec;
 
-/// The purpose of this contract is to perform a check in public without revealing what contract enqued the public
-/// call. This is achieved by having a private function on this contract that enques the public call and hence
+/// The purpose of this contract is to perform a check in public without revealing what contract enqueued the public
+/// call. This is achieved by having a private function on this contract that enqueues the public call and hence
 /// the `msg_sender` in the public call is the address of this contract.
 #[aztec]
 pub contract Router {


### PR DESCRIPTION
Fixes #11863