### PR TITLE
fix: Ensure a clean LMDB wrapper shutdown

### DIFF
--- a/barretenberg/cpp/src/barretenberg/messaging/dispatcher.hpp
+++ b/barretenberg/cpp/src/barretenberg/messaging/dispatcher.hpp
@@ -2,39 +2,55 @@
 
 #include "barretenberg/messaging/header.hpp"
 #include "barretenberg/serialize/cbind.hpp"
+#include <atomic>
 #include <cstdint>
 #include <functional>
+#include <mutex>
+#include <shared_mutex>
 #include <stdexcept>
+#include <thread>
 #include <utility>
 #include <vector>
 
 namespace bb::messaging {
 
 using message_handler = std::function<bool(msgpack::object&, msgpack::sbuffer&)>;
+struct MessageHandler {
+    bool unique;
+    message_handler handler;
+};
 
 class MessageDispatcher {
   private:
-    std::unordered_map<uint32_t, message_handler> messageHandlers;
+    std::unordered_map<uint32_t, MessageHandler> message_handlers;
+    mutable std::shared_mutex mutex;
 
   public:
     MessageDispatcher() = default;
 
-    bool onNewData(msgpack::object& obj, msgpack::sbuffer& buffer) const
+    bool on_new_data(msgpack::object& obj, msgpack::sbuffer& buffer) const
     {
         bb::messaging::HeaderOnlyMessage header;
         obj.convert(header);
 
-        auto iter = messageHandlers.find(header.msgType);
-        if (iter == messageHandlers.end()) {
+        auto iter = message_handlers.find(header.msgType);
+        if (iter == message_handlers.end()) {
             throw std::runtime_error("No registered handler for message of type " + std::to_string(header.msgType));
         }
 
-        return (iter->second)(obj, buffer);
+        // If the msg type has been marked as 'unique' then we need to give it exclusive execution context
+        if (iter->second.unique) {
+            std::unique_lock<std::shared_mutex> lock(mutex);
+            return (iter->second.handler)(obj, buffer);
+        }
+        std::shared_lock<std::shared_mutex> lock(mutex);
+        return (iter->second.handler)(obj, buffer);
     }
 
-    void registerTarget(uint32_t msgType, const message_handler& handler)
+    void register_target(uint32_t msgType, const message_handler& handler, bool unique = false)
     {
-        messageHandlers.insert({ msgType, handler });
+        MessageHandler msg_handler{ unique, handler };
+        message_handlers.insert({ msgType, msg_handler });
     }
 };
 

--- a/barretenberg/cpp/src/barretenberg/nodejs_module/lmdb_store/lmdb_store_wrapper.hpp
+++ b/barretenberg/cpp/src/barretenberg/nodejs_module/lmdb_store/lmdb_store_wrapper.hpp
@@ -40,6 +40,8 @@ class LMDBStoreWrapper : public Napi::ObjectWrap<LMDBStoreWrapper> {
 
     bb::nodejs::AsyncMessageProcessor _msg_processor;
 
+    void verify_store() const;
+
     BoolResponse open_database(const OpenDatabaseRequest& req);
 
     GetResponse get(const GetRequest& req);

--- a/barretenberg/cpp/src/barretenberg/nodejs_module/world_state/world_state.cpp
+++ b/barretenberg/cpp/src/barretenberg/nodejs_module/world_state/world_state.cpp
@@ -127,105 +127,105 @@ WorldStateWrapper::WorldStateWrapper(const Napi::CallbackInfo& info)
     _ws = std::make_unique<WorldState>(
         thread_pool_size, data_dir, map_size, tree_height, tree_prefill, initial_header_generator_point);
 
-    _dispatcher.registerTarget(
+    _dispatcher.register_target(
         WorldStateMessageType::GET_TREE_INFO,
         [this](msgpack::object& obj, msgpack::sbuffer& buffer) { return get_tree_info(obj, buffer); });
 
-    _dispatcher.registerTarget(
+    _dispatcher.register_target(
         WorldStateMessageType::GET_STATE_REFERENCE,
         [this](msgpack::object& obj, msgpack::sbuffer& buffer) { return get_state_reference(obj, buffer); });
 
-    _dispatcher.registerTarget(
+    _dispatcher.register_target(
         WorldStateMessageType::GET_INITIAL_STATE_REFERENCE,
         [this](msgpack::object& obj, msgpack::sbuffer& buffer) { return get_initial_state_reference(obj, buffer); });
 
-    _dispatcher.registerTarget(
+    _dispatcher.register_target(
         WorldStateMessageType::GET_LEAF_VALUE,
         [this](msgpack::object& obj, msgpack::sbuffer& buffer) { return get_leaf_value(obj, buffer); });
 
-    _dispatcher.registerTarget(
+    _dispatcher.register_target(
         WorldStateMessageType::GET_LEAF_PREIMAGE,
         [this](msgpack::object& obj, msgpack::sbuffer& buffer) { return get_leaf_preimage(obj, buffer); });
 
-    _dispatcher.registerTarget(
+    _dispatcher.register_target(
         WorldStateMessageType::GET_SIBLING_PATH,
         [this](msgpack::object& obj, msgpack::sbuffer& buffer) { return get_sibling_path(obj, buffer); });
 
-    _dispatcher.registerTarget(WorldStateMessageType::GET_BLOCK_NUMBERS_FOR_LEAF_INDICES,
-                               [this](msgpack::object& obj, msgpack::sbuffer& buffer) {
-                                   return get_block_numbers_for_leaf_indices(obj, buffer);
-                               });
+    _dispatcher.register_target(WorldStateMessageType::GET_BLOCK_NUMBERS_FOR_LEAF_INDICES,
+                                [this](msgpack::object& obj, msgpack::sbuffer& buffer) {
+                                    return get_block_numbers_for_leaf_indices(obj, buffer);
+                                });
 
-    _dispatcher.registerTarget(
+    _dispatcher.register_target(
         WorldStateMessageType::FIND_LEAF_INDICES,
         [this](msgpack::object& obj, msgpack::sbuffer& buffer) { return find_leaf_indices(obj, buffer); });
 
-    _dispatcher.registerTarget(
+    _dispatcher.register_target(
         WorldStateMessageType::FIND_LOW_LEAF,
         [this](msgpack::object& obj, msgpack::sbuffer& buffer) { return find_low_leaf(obj, buffer); });
 
-    _dispatcher.registerTarget(
+    _dispatcher.register_target(
         WorldStateMessageType::APPEND_LEAVES,
         [this](msgpack::object& obj, msgpack::sbuffer& buffer) { return append_leaves(obj, buffer); });
 
-    _dispatcher.registerTarget(
+    _dispatcher.register_target(
         WorldStateMessageType::BATCH_INSERT,
         [this](msgpack::object& obj, msgpack::sbuffer& buffer) { return batch_insert(obj, buffer); });
 
-    _dispatcher.registerTarget(
+    _dispatcher.register_target(
         WorldStateMessageType::SEQUENTIAL_INSERT,
         [this](msgpack::object& obj, msgpack::sbuffer& buffer) { return sequential_insert(obj, buffer); });
 
-    _dispatcher.registerTarget(
+    _dispatcher.register_target(
         WorldStateMessageType::UPDATE_ARCHIVE,
         [this](msgpack::object& obj, msgpack::sbuffer& buffer) { return update_archive(obj, buffer); });
 
-    _dispatcher.registerTarget(WorldStateMessageType::COMMIT,
-                               [this](msgpack::object& obj, msgpack::sbuffer& buffer) { return commit(obj, buffer); });
+    _dispatcher.register_target(WorldStateMessageType::COMMIT,
+                                [this](msgpack::object& obj, msgpack::sbuffer& buffer) { return commit(obj, buffer); });
 
-    _dispatcher.registerTarget(WorldStateMessageType::ROLLBACK, [this](msgpack::object& obj, msgpack::sbuffer& buffer) {
-        return rollback(obj, buffer);
-    });
+    _dispatcher.register_target(
+        WorldStateMessageType::ROLLBACK,
+        [this](msgpack::object& obj, msgpack::sbuffer& buffer) { return rollback(obj, buffer); });
 
-    _dispatcher.registerTarget(
+    _dispatcher.register_target(
         WorldStateMessageType::SYNC_BLOCK,
         [this](msgpack::object& obj, msgpack::sbuffer& buffer) { return sync_block(obj, buffer); });
 
-    _dispatcher.registerTarget(
+    _dispatcher.register_target(
         WorldStateMessageType::CREATE_FORK,
         [this](msgpack::object& obj, msgpack::sbuffer& buffer) { return create_fork(obj, buffer); });
 
-    _dispatcher.registerTarget(
+    _dispatcher.register_target(
         WorldStateMessageType::DELETE_FORK,
         [this](msgpack::object& obj, msgpack::sbuffer& buffer) { return delete_fork(obj, buffer); });
 
-    _dispatcher.registerTarget(
+    _dispatcher.register_target(
         WorldStateMessageType::FINALISE_BLOCKS,
         [this](msgpack::object& obj, msgpack::sbuffer& buffer) { return set_finalised(obj, buffer); });
 
-    _dispatcher.registerTarget(WorldStateMessageType::UNWIND_BLOCKS,
-                               [this](msgpack::object& obj, msgpack::sbuffer& buffer) { return unwind(obj, buffer); });
+    _dispatcher.register_target(WorldStateMessageType::UNWIND_BLOCKS,
+                                [this](msgpack::object& obj, msgpack::sbuffer& buffer) { return unwind(obj, buffer); });
 
-    _dispatcher.registerTarget(
+    _dispatcher.register_target(
         WorldStateMessageType::REMOVE_HISTORICAL_BLOCKS,
         [this](msgpack::object& obj, msgpack::sbuffer& buffer) { return remove_historical(obj, buffer); });
 
-    _dispatcher.registerTarget(
+    _dispatcher.register_target(
         WorldStateMessageType::GET_STATUS,
         [this](msgpack::object& obj, msgpack::sbuffer& buffer) { return get_status(obj, buffer); });
 
-    _dispatcher.registerTarget(WorldStateMessageType::CLOSE,
-                               [this](msgpack::object& obj, msgpack::sbuffer& buffer) { return close(obj, buffer); });
+    _dispatcher.register_target(WorldStateMessageType::CLOSE,
+                                [this](msgpack::object& obj, msgpack::sbuffer& buffer) { return close(obj, buffer); });
 
-    _dispatcher.registerTarget(
+    _dispatcher.register_target(
         WorldStateMessageType::CREATE_CHECKPOINT,
         [this](msgpack::object& obj, msgpack::sbuffer& buffer) { return checkpoint(obj, buffer); });
 
-    _dispatcher.registerTarget(
+    _dispatcher.register_target(
         WorldStateMessageType::COMMIT_CHECKPOINT,
         [this](msgpack::object& obj, msgpack::sbuffer& buffer) { return commit_checkpoint(obj, buffer); });
 
-    _dispatcher.registerTarget(
+    _dispatcher.register_target(
         WorldStateMessageType::REVERT_CHECKPOINT,
         [this](msgpack::object& obj, msgpack::sbuffer& buffer) { return revert_checkpoint(obj, buffer); });
 }
@@ -255,7 +255,7 @@ Napi::Value WorldStateWrapper::call(const Napi::CallbackInfo& info)
         auto* op = new AsyncOperation(env, deferred, [=, this](msgpack::sbuffer& buf) {
             msgpack::object_handle obj_handle = msgpack::unpack(data->data(), length);
             msgpack::object obj = obj_handle.get();
-            _dispatcher.onNewData(obj, buf);
+            _dispatcher.on_new_data(obj, buf);
         });
 
         // Napi is now responsible for destroying this object

--- a/yarn-project/kv-store/src/lmdb-v2/close.test.ts
+++ b/yarn-project/kv-store/src/lmdb-v2/close.test.ts
@@ -1,0 +1,58 @@
+import { randomBytes } from '@aztec/foundation/crypto';
+
+import { expect } from 'chai';
+
+import type { AztecAsyncMap } from '../interfaces/map.js';
+import { openTmpStore } from './factory.js';
+import { AztecLMDBStoreV2 } from './store.js';
+import type { WriteTransaction } from './write_transaction.js';
+
+describe('Clean shutdown', () => {
+  let store: AztecLMDBStoreV2;
+  let map: AztecAsyncMap<string, string>;
+
+  beforeEach(async () => {
+    store = await openTmpStore('test');
+    map = store.openMap<string, string>('test');
+  });
+
+  it('Ensures clean closing of the database', async () => {
+    const numValues = 1000;
+    await store.transactionAsync(async (_: WriteTransaction) => {
+      for (let i = 0; i < numValues; i++) {
+        const key = i.toString();
+        const value = randomBytes(16).toString('hex');
+        await map.set(key, value);
+      }
+    });
+
+    // Queue up 2 lots of reads with a close in the middle, there should be no unrecoverable errors
+    // though not all reads will complete
+    const reads = Array.from({ length: numValues }).map((_, index) =>
+      map
+        .getAsync((index % numValues).toString())
+        .then(_ => true)
+        .catch(_ => false),
+    );
+
+    const close = store
+      .delete()
+      .then(_ => true)
+      .catch(_ => false);
+
+    const reads2 = Array.from({ length: numValues }).map((_, index) =>
+      map
+        .getAsync((index % numValues).toString())
+        .then(_ => true)
+        .catch(_ => false),
+    );
+
+    const numSuccessfulReads = (await Promise.all(reads.concat(reads2))).filter(x => x).length;
+    const closeSuccess = await close;
+
+    // The fact that we are here suggests that everything completed success fully. There were no unrecoverable errors within the NAPI module
+    expect(numSuccessfulReads).greaterThanOrEqual(0);
+    expect(numSuccessfulReads).lessThanOrEqual(reads.length + reads2.length);
+    expect(closeSuccess).to.equal(true);
+  });
+});


### PR DESCRIPTION
This PR introduces additional synchronisation into the NAPI module to ensure a clean LMDB wrapper shutdown.
