### PR TITLE
refactor: proving cost in fee header

### DIFF
--- a/l1-contracts/src/core/Rollup.sol
+++ b/l1-contracts/src/core/Rollup.sol
@@ -11,6 +11,7 @@ import {
   EnumerableSet
 } from "@aztec/core/interfaces/IStaking.sol";
 import {IValidatorSelection} from "@aztec/core/interfaces/IValidatorSelection.sol";
+import {FeeAssetValue} from "@aztec/core/libraries/RollupLibs/FeeMath.sol";
 
 // We allow the unused imports here as they make it much simpler to import the Rollup later
 // solhint-disable no-unused-import
@@ -39,7 +40,6 @@ import {
   EpochRewards,
   FeeAssetPerEthE9,
   EthValue,
-  FeeAssetValue,
   PriceLib
 } from "./RollupCore.sol";
 // solhint-enable no-unused-import

--- a/l1-contracts/src/core/libraries/RollupLibs/FeeMath.sol
+++ b/l1-contracts/src/core/libraries/RollupLibs/FeeMath.sol
@@ -37,9 +37,10 @@ struct ManaBaseFeeComponents {
 
 struct FeeHeader {
   uint256 excessMana;
-  uint256 feeAssetPriceNumerator;
   uint256 manaUsed;
+  uint256 feeAssetPriceNumerator;
   uint256 congestionCost;
+  uint256 provingCost;
 }
 
 struct L1FeeData {

--- a/l1-contracts/test/Rollup.t.sol
+++ b/l1-contracts/test/Rollup.t.sol
@@ -346,6 +346,28 @@ contract RollupTest is RollupBase {
     rollup.propose(args, signatures, data.body, data.blobInputs);
   }
 
+  function testProvingFeeUpdates() public setUpFor("mixed_block_1") {
+    rollup.setProvingCostPerMana(EthValue.wrap(1000));
+    _proposeBlock("mixed_block_1", 1, 1e6);
+
+    rollup.setProvingCostPerMana(EthValue.wrap(2000));
+    _proposeBlock("mixed_block_2", 2, 1e6);
+
+    // At this point in time, we have had different proving costs for the two blocks. When we prove them
+    // in the same epoch, we want to see that the correct fee is taken for each block.
+    _proveBlocks("mixed_block_", 1, 2, address(this));
+
+    // 1e6 mana at 1000 and 2000 cost per manage multiplied by 10 for the price conversion to fee asset.
+    uint256 provingFees = 1e6 * (1000 + 2000) * 10;
+    uint256 expectedProverRewards = rewardDistributor.BLOCK_REWARD() / 2 * 2 + provingFees;
+
+    assertEq(
+      rollup.getCollectiveProverRewardsForEpoch(Epoch.wrap(0)),
+      expectedProverRewards,
+      "invalid prover rewards"
+    );
+  }
+
   struct TestBlockFeeStruct {
     EthValue provingCostPerManaInEth;
     FeeAssetValue provingCostPerManaInFeeAsset;

--- a/l1-contracts/test/fees/MinimalFeeModel.sol
+++ b/l1-contracts/test/fees/MinimalFeeModel.sol
@@ -56,7 +56,7 @@ contract MinimalFeeModel {
   EthValue public provingCost = EthValue.wrap(100);
 
   constructor(uint256 _slotDuration, uint256 _epochDuration) {
-    feeHeaders[0] = FeeHeader(0, 0, 0, 0);
+    feeHeaders[0] = FeeHeader(0, 0, 0, 0, 0);
 
     l1BaseFees.pre = L1FeesModel({base_fee: 1 gwei, blob_fee: 1});
     l1BaseFees.post = L1FeesModel({base_fee: block.basefee, blob_fee: _getBlobBaseFee()});
@@ -127,7 +127,8 @@ contract MinimalFeeModel {
       ),
       manaUsed: _manaUsed,
       excessMana: excessMana,
-      congestionCost: 0
+      congestionCost: 0,
+      provingCost: 0
     });
   }
 

--- a/yarn-project/aztec.js/src/api/ethereum/cheat_codes.ts
+++ b/yarn-project/aztec.js/src/api/ethereum/cheat_codes.ts
@@ -143,7 +143,7 @@ export class RollupCheatCodes {
 
     const tipsAfter = await this.getTips();
     this.logger.info(
-      `Proven tip moved: ${tipsBefore.proven} -> ${tipsAfter.proven}. Pending tip moved: ${tipsBefore.pending} -> ${tipsAfter.pending}`,
+      `Proven tip moved: ${tipsBefore.proven} -> ${tipsAfter.proven}. Pending tip: ${tipsAfter.pending}.`,
     );
   }
 


### PR DESCRIPTION
Fixes #11941. Takes the simplest approach, store the value so we can just reuse it. Alternatively we would be doing a few re-computations, so with the plan that we can do a bit of storage packing this should turn out being the cheapest of the solutions.