### PR TITLE
fix(e2ep2p): excessive discovery warnings in e2e test

### DIFF
--- a/yarn-project/end-to-end/src/e2e_p2p/p2p_network.ts
+++ b/yarn-project/end-to-end/src/e2e_p2p/p2p_network.ts
@@ -10,6 +10,7 @@ import { EthCheatCodesWithState } from '@aztec/ethereum/test';
 import { type Logger, createLogger } from '@aztec/foundation/log';
 import { ForwarderAbi, ForwarderBytecode, RollupAbi, TestERC20Abi } from '@aztec/l1-artifacts';
 import { SpamContract } from '@aztec/noir-contracts.js/Spam';
+import type { BootstrapNode } from '@aztec/p2p/bootstrap';
 import { createBootstrapNodeFromPrivateKey, getBootstrapNodeEnr } from '@aztec/p2p/test-helpers';
 import { getGenesisValues } from '@aztec/world-state/testing';
 
@@ -55,6 +56,8 @@ export class P2PNetworkTest {
   // The re-execution test needs a wallet and a spam contract
   public wallet?: AccountWalletWithSecretKey;
   public spamContract?: SpamContract;
+
+  public bootstrapNode?: BootstrapNode;
 
   private cleanupInterval: NodeJS.Timeout | undefined = undefined;
 
@@ -170,14 +173,14 @@ export class P2PNetworkTest {
   async applyBaseSnapshots() {
     await this.snapshotManager.snapshot('add-bootstrap-node', async ({ aztecNodeConfig }) => {
       const telemetry = getEndToEndTestTelemetryClient(this.metricsPort);
-      const bootstrapNode = await createBootstrapNodeFromPrivateKey(
+      this.bootstrapNode = await createBootstrapNodeFromPrivateKey(
         BOOTSTRAP_NODE_PRIVATE_KEY,
         this.bootNodePort,
         telemetry,
         aztecNodeConfig,
       );
       // Overwrite enr with updated info
-      this.bootstrapNodeEnr = bootstrapNode.getENR().encodeTxt();
+      this.bootstrapNodeEnr = this.bootstrapNode.getENR().encodeTxt();
     });
 
     await this.snapshotManager.snapshot(
@@ -357,7 +360,7 @@ export class P2PNetworkTest {
 
   async teardown() {
     this.monitor.stop();
-    await this.bootstrapNode.stop();
+    await this.bootstrapNode?.stop();
     await this.snapshotManager.teardown();
     if (this.cleanupInterval) {
       clearInterval(this.cleanupInterval);

--- a/yarn-project/end-to-end/src/e2e_p2p/p2p_network.ts
+++ b/yarn-project/end-to-end/src/e2e_p2p/p2p_network.ts
@@ -7,11 +7,9 @@ import { type PublicDataTreeLeaf } from '@aztec/circuits.js';
 import { RollupContract, getExpectedAddress, getL1ContractsConfigEnvVars } from '@aztec/ethereum';
 import { L1TxUtilsWithBlobs } from '@aztec/ethereum/l1-tx-utils-with-blobs';
 import { EthCheatCodesWithState } from '@aztec/ethereum/test';
-import { EthAddress } from '@aztec/foundation/eth-address';
 import { type Logger, createLogger } from '@aztec/foundation/log';
 import { ForwarderAbi, ForwarderBytecode, RollupAbi, TestERC20Abi } from '@aztec/l1-artifacts';
 import { SpamContract } from '@aztec/noir-contracts.js/Spam';
-import { type BootstrapNode } from '@aztec/p2p';
 import { createBootstrapNodeFromPrivateKey, getBootstrapNodeEnr } from '@aztec/p2p/test-helpers';
 import { getGenesisValues } from '@aztec/world-state/testing';
 

--- a/yarn-project/end-to-end/src/e2e_p2p/rediscovery.test.ts
+++ b/yarn-project/end-to-end/src/e2e_p2p/rediscovery.test.ts
@@ -61,7 +61,7 @@ describe('e2e_p2p_rediscovery', () => {
     await sleep(3000);
 
     // stop bootstrap node
-    await t.bootstrapNode.stop();
+    await t.bootstrapNode?.stop();
 
     // create new nodes from datadir
     const newNodes: AztecNodeService[] = [];


### PR DESCRIPTION
## Overview

Since the versioning check had gone in, the bootnode was not configured correctly with versions so it was emitting noisy logs each time it was discovered

- moved bootstrap node creation until after the contracts have been deployed such that the correct version information is available
