### PR TITLE
refactor: function macros cleanup

### DIFF
--- a/noir-projects/aztec-nr/aztec/src/context/call_interfaces.nr
+++ b/noir-projects/aztec-nr/aztec/src/context/call_interfaces.nr
@@ -16,16 +16,28 @@ pub trait CallInterface<let N: u32> {
 }
 
 pub struct PrivateCallInterface<let N: u32, T> {
-    pub target_contract: AztecAddress,
-    pub selector: FunctionSelector,
-    pub name: str<N>,
-    pub args_hash: Field,
-    pub args: [Field],
-    pub return_type: T,
-    pub is_static: bool,
+    target_contract: AztecAddress,
+    selector: FunctionSelector,
+    name: str<N>,
+    args_hash: Field,
+    args: [Field],
+    return_type: T,
+    is_static: bool,
 }
 
 impl<let N: u32, T> PrivateCallInterface<N, T> {
+    pub fn new(
+        target_contract: AztecAddress,
+        selector: FunctionSelector,
+        name: str<N>,
+        args: [Field],
+        return_type: T,
+        is_static: bool,
+    ) -> Self {
+        let args_hash = hash_args(args);
+        Self { target_contract, selector, name, args_hash, args, return_type, is_static }
+    }
+
     pub fn call<let M: u32>(self, context: &mut PrivateContext) -> T
     where
         T: Deserialize<M>,
@@ -79,16 +91,27 @@ impl<let N: u32> CallInterface<N> for PrivateVoidCallInterface<N> {
 }
 
 pub struct PrivateVoidCallInterface<let N: u32> {
-    pub target_contract: AztecAddress,
-    pub selector: FunctionSelector,
-    pub name: str<N>,
-    pub args_hash: Field,
-    pub args: [Field],
-    pub return_type: (),
-    pub is_static: bool,
+    target_contract: AztecAddress,
+    selector: FunctionSelector,
+    name: str<N>,
+    args_hash: Field,
+    args: [Field],
+    return_type: (), // Unit type () indicates this interface is for functions that return nothing (void)
+    is_static: bool,
 }
 
 impl<let N: u32> PrivateVoidCallInterface<N> {
+    pub fn new(
+        target_contract: AztecAddress,
+        selector: FunctionSelector,
+        name: str<N>,
+        args: [Field],
+        is_static: bool,
+    ) -> Self {
+        let args_hash = hash_args(args);
+        Self { target_contract, selector, name, args_hash, args, return_type: (), is_static }
+    }
+
     pub fn call(self, context: &mut PrivateContext) {
         execution_cache::store(self.args);
         context
@@ -137,16 +160,27 @@ impl<let N: u32, T> CallInterface<N> for PrivateStaticCallInterface<N, T> {
 }
 
 pub struct PrivateStaticCallInterface<let N: u32, T> {
-    pub target_contract: AztecAddress,
-    pub selector: FunctionSelector,
-    pub name: str<N>,
-    pub args_hash: Field,
-    pub args: [Field],
-    pub return_type: T,
-    pub is_static: bool,
+    target_contract: AztecAddress,
+    selector: FunctionSelector,
+    name: str<N>,
+    args_hash: Field,
+    args: [Field],
+    return_type: T,
+    is_static: bool,
 }
 
 impl<let N: u32, T> PrivateStaticCallInterface<N, T> {
+    pub fn new(
+        target_contract: AztecAddress,
+        selector: FunctionSelector,
+        name: str<N>,
+        args: [Field],
+        return_type: T,
+    ) -> Self {
+        let args_hash = hash_args(args);
+        Self { target_contract, selector, name, args_hash, args, return_type, is_static: true }
+    }
+
     pub fn view<let M: u32>(self, context: &mut PrivateContext) -> T
     where
         T: Deserialize<M>,
@@ -185,16 +219,26 @@ impl<let N: u32> CallInterface<N> for PrivateStaticVoidCallInterface<N> {
 }
 
 pub struct PrivateStaticVoidCallInterface<let N: u32> {
-    pub target_contract: AztecAddress,
-    pub selector: FunctionSelector,
-    pub name: str<N>,
-    pub args_hash: Field,
-    pub args: [Field],
-    pub return_type: (),
-    pub is_static: bool,
+    target_contract: AztecAddress,
+    selector: FunctionSelector,
+    name: str<N>,
+    args_hash: Field,
+    args: [Field],
+    return_type: (), // Unit type () indicates this interface is for functions that return nothing (void)
+    is_static: bool,
 }
 
 impl<let N: u32> PrivateStaticVoidCallInterface<N> {
+    pub fn new(
+        target_contract: AztecAddress,
+        selector: FunctionSelector,
+        name: str<N>,
+        args: [Field],
+    ) -> Self {
+        let args_hash = hash_args(args);
+        Self { target_contract, selector, name, args_hash, args, return_type: (), is_static: true }
+    }
+
     pub fn view(self, context: &mut PrivateContext) {
         execution_cache::store(self.args);
         context
@@ -231,16 +275,35 @@ impl<let N: u32, T> CallInterface<N> for PublicCallInterface<N, T> {
 }
 
 pub struct PublicCallInterface<let N: u32, T> {
-    pub target_contract: AztecAddress,
-    pub selector: FunctionSelector,
-    pub name: str<N>,
-    pub args: [Field],
-    pub gas_opts: GasOpts,
-    pub return_type: T,
-    pub is_static: bool,
+    target_contract: AztecAddress,
+    selector: FunctionSelector,
+    name: str<N>,
+    args: [Field],
+    gas_opts: GasOpts,
+    return_type: T,
+    is_static: bool,
 }
 
 impl<let N: u32, T> PublicCallInterface<N, T> {
+    pub fn new(
+        target_contract: AztecAddress,
+        selector: FunctionSelector,
+        name: str<N>,
+        args: [Field],
+        return_type: T,
+        is_static: bool,
+    ) -> Self {
+        Self {
+            target_contract,
+            selector,
+            name,
+            args,
+            gas_opts: GasOpts::default(),
+            return_type,
+            is_static,
+        }
+    }
+
     pub fn with_gas(self: &mut Self, gas_opts: GasOpts) -> &mut Self {
         self.gas_opts = gas_opts;
         self
@@ -320,16 +383,27 @@ impl<let N: u32> CallInterface<N> for PublicVoidCallInterface<N> {
 }
 
 pub struct PublicVoidCallInterface<let N: u32> {
-    pub target_contract: AztecAddress,
-    pub selector: FunctionSelector,
-    pub name: str<N>,
-    pub args: [Field],
-    pub return_type: (),
-    pub is_static: bool,
-    pub gas_opts: GasOpts,
+    target_contract: AztecAddress,
+    selector: FunctionSelector,
+    name: str<N>,
+    args: [Field],
+    return_type: (), // Unit type () indicates this interface is for functions that return nothing (void)
+    is_static: bool,
+    gas_opts: GasOpts,
 }
 
 impl<let N: u32> PublicVoidCallInterface<N> {
+    pub fn new(
+        target_contract: AztecAddress,
+        selector: FunctionSelector,
+        name: str<N>,
+        args: [Field],
+        is_static: bool,
+        gas_opts: GasOpts,
+    ) -> Self {
+        Self { target_contract, selector, name, args, return_type: (), is_static, gas_opts }
+    }
+
     pub fn with_gas(self: &mut Self, gas_opts: GasOpts) -> &mut Self {
         self.gas_opts = gas_opts;
         self
@@ -403,16 +477,34 @@ impl<let N: u32, T> CallInterface<N> for PublicStaticCallInterface<N, T> {
 }
 
 pub struct PublicStaticCallInterface<let N: u32, T> {
-    pub target_contract: AztecAddress,
-    pub selector: FunctionSelector,
-    pub name: str<N>,
-    pub args: [Field],
-    pub return_type: T,
-    pub is_static: bool,
-    pub gas_opts: GasOpts,
+    target_contract: AztecAddress,
+    selector: FunctionSelector,
+    name: str<N>,
+    args: [Field],
+    return_type: T,
+    is_static: bool,
+    gas_opts: GasOpts,
 }
 
 impl<let N: u32, T> PublicStaticCallInterface<N, T> {
+    pub fn new(
+        target_contract: AztecAddress,
+        selector: FunctionSelector,
+        name: str<N>,
+        args: [Field],
+        return_type: T,
+    ) -> Self {
+        Self {
+            target_contract,
+            selector,
+            name,
+            args,
+            return_type,
+            is_static: true,
+            gas_opts: GasOpts::default(),
+        }
+    }
+
     pub fn with_gas(self: &mut Self, gas_opts: GasOpts) -> &mut Self {
         self.gas_opts = gas_opts;
         self
@@ -467,16 +559,33 @@ impl<let N: u32> CallInterface<N> for PublicStaticVoidCallInterface<N> {
 }
 
 pub struct PublicStaticVoidCallInterface<let N: u32> {
-    pub target_contract: AztecAddress,
-    pub selector: FunctionSelector,
-    pub name: str<N>,
-    pub args: [Field],
-    pub return_type: (),
-    pub is_static: bool,
-    pub gas_opts: GasOpts,
+    target_contract: AztecAddress,
+    selector: FunctionSelector,
+    name: str<N>,
+    args: [Field],
+    return_type: (), // Unit type () indicates this interface is for functions that return nothing (void)
+    is_static: bool,
+    gas_opts: GasOpts,
 }
 
 impl<let N: u32> PublicStaticVoidCallInterface<N> {
+    pub fn new(
+        target_contract: AztecAddress,
+        selector: FunctionSelector,
+        name: str<N>,
+        args: [Field],
+    ) -> Self {
+        Self {
+            target_contract,
+            selector,
+            name,
+            args,
+            return_type: (),
+            is_static: true,
+            gas_opts: GasOpts::default(),
+        }
+    }
+
     pub fn with_gas(self: &mut Self, gas_opts: GasOpts) -> &mut Self {
         self.gas_opts = gas_opts;
         self

--- a/noir-projects/aztec-nr/aztec/src/context/call_interfaces.nr
+++ b/noir-projects/aztec-nr/aztec/src/context/call_interfaces.nr
@@ -31,11 +31,18 @@ impl<let N: u32, T> PrivateCallInterface<N, T> {
         selector: FunctionSelector,
         name: str<N>,
         args: [Field],
-        return_type: T,
         is_static: bool,
     ) -> Self {
         let args_hash = hash_args(args);
-        Self { target_contract, selector, name, args_hash, args, return_type, is_static }
+        Self {
+            target_contract,
+            selector,
+            name,
+            args_hash,
+            args,
+            return_type: std::mem::zeroed(),
+            is_static,
+        }
     }
 
     pub fn call<let M: u32>(self, context: &mut PrivateContext) -> T
@@ -175,10 +182,17 @@ impl<let N: u32, T> PrivateStaticCallInterface<N, T> {
         selector: FunctionSelector,
         name: str<N>,
         args: [Field],
-        return_type: T,
     ) -> Self {
         let args_hash = hash_args(args);
-        Self { target_contract, selector, name, args_hash, args, return_type, is_static: true }
+        Self {
+            target_contract,
+            selector,
+            name,
+            args_hash,
+            args,
+            return_type: std::mem::zeroed(),
+            is_static: true,
+        }
     }
 
     pub fn view<let M: u32>(self, context: &mut PrivateContext) -> T
@@ -290,7 +304,6 @@ impl<let N: u32, T> PublicCallInterface<N, T> {
         selector: FunctionSelector,
         name: str<N>,
         args: [Field],
-        return_type: T,
         is_static: bool,
     ) -> Self {
         Self {
@@ -299,7 +312,7 @@ impl<let N: u32, T> PublicCallInterface<N, T> {
             name,
             args,
             gas_opts: GasOpts::default(),
-            return_type,
+            return_type: std::mem::zeroed(),
             is_static,
         }
     }
@@ -399,9 +412,16 @@ impl<let N: u32> PublicVoidCallInterface<N> {
         name: str<N>,
         args: [Field],
         is_static: bool,
-        gas_opts: GasOpts,
     ) -> Self {
-        Self { target_contract, selector, name, args, return_type: (), is_static, gas_opts }
+        Self {
+            target_contract,
+            selector,
+            name,
+            args,
+            return_type: (),
+            is_static,
+            gas_opts: GasOpts::default(),
+        }
     }
 
     pub fn with_gas(self: &mut Self, gas_opts: GasOpts) -> &mut Self {
@@ -492,14 +512,13 @@ impl<let N: u32, T> PublicStaticCallInterface<N, T> {
         selector: FunctionSelector,
         name: str<N>,
         args: [Field],
-        return_type: T,
     ) -> Self {
         Self {
             target_contract,
             selector,
             name,
             args,
-            return_type,
+            return_type: std::mem::zeroed(),
             is_static: true,
             gas_opts: GasOpts::default(),
         }

--- a/noir-projects/aztec-nr/aztec/src/macros/functions/abi_export.nr
+++ b/noir-projects/aztec-nr/aztec/src/macros/functions/abi_export.nr
@@ -1,0 +1,35 @@
+use std::meta::type_of;
+
+pub(crate) comptime fn create_fn_abi_export(f: FunctionDefinition) -> Quoted {
+    let name = f.name();
+    let mut parameters =
+        f.parameters().map(|(name, typ): (Quoted, Type)| quote { pub $name: $typ }).join(quote {,});
+
+    let parameters_struct_name = f"{name}_parameters".quoted_contents();
+    let parameters = quote {
+        pub struct $parameters_struct_name {
+            $parameters
+        }
+    };
+
+    let return_value_type = f.return_type();
+    let return_type = if return_value_type != type_of(()) {
+        quote { return_type: $return_value_type }
+    } else {
+        quote {}
+    };
+
+    let abi_struct_name = f"{name}_abi".quoted_contents();
+
+    let result = quote {
+
+        $parameters
+
+        #[abi(functions)]
+        pub struct $abi_struct_name {
+            parameters: $parameters_struct_name,
+            $return_type
+        }
+    };
+    result
+}

--- a/noir-projects/aztec-nr/aztec/src/macros/functions/call_interface_stubs.nr
+++ b/noir-projects/aztec-nr/aztec/src/macros/functions/call_interface_stubs.nr
@@ -1,5 +1,6 @@
 use crate::macros::utils::{
-    add_to_field_slice, AsStrQuote, compute_fn_selector, get_trait_impl_method, is_fn_private, is_fn_view,
+    add_to_field_slice, AsStrQuote, compute_fn_selector, get_trait_impl_method, is_fn_private,
+    is_fn_view,
 };
 use std::meta::{type_of, unquote};
 

--- a/noir-projects/aztec-nr/aztec/src/macros/functions/call_interface_stubs.nr
+++ b/noir-projects/aztec-nr/aztec/src/macros/functions/call_interface_stubs.nr
@@ -50,6 +50,7 @@ pub comptime fn stub_fn(f: FunctionDefinition) -> Quoted {
     }
 }
 
+/// Utility function creating stubs used by all the stub functions in this file.
 comptime fn create_stub_base(
     f: FunctionDefinition,
 ) -> (Quoted, Quoted, Quoted, Quoted, u32, Field) {

--- a/noir-projects/aztec-nr/aztec/src/macros/functions/call_interface_stubs.nr
+++ b/noir-projects/aztec-nr/aztec/src/macros/functions/call_interface_stubs.nr
@@ -75,7 +75,6 @@ comptime fn create_stub_base(
             quote {
                 $args
                 $arg_to_append
-                l
             }
         },
     );

--- a/noir-projects/aztec-nr/aztec/src/macros/functions/interfaces.nr
+++ b/noir-projects/aztec-nr/aztec/src/macros/functions/interfaces.nr
@@ -8,63 +8,58 @@ use std::{
     meta::{type_of, unquote},
 };
 
-pub comptime mut global STUBS: UHashMap<Module, [Quoted], BuildHasherDefault<Poseidon2Hasher>> =
-    UHashMap::default();
-
-pub(crate) comptime fn create_fn_abi_export(f: FunctionDefinition) -> Quoted {
-    let name = f.name();
-    let mut parameters =
-        f.parameters().map(|(name, typ): (Quoted, Type)| quote { pub $name: $typ }).join(quote {,});
-
-    let parameters_struct_name = f"{name}_parameters".quoted_contents();
-    let parameters = quote {
-        pub struct $parameters_struct_name {
-            $parameters
-        }
-    };
-
-    let return_value_type = f.return_type();
-    let return_type = if return_value_type != type_of(()) {
-        quote { return_type: $return_value_type }
-    } else {
-        quote {}
-    };
-
-    let abi_struct_name = f"{name}_abi".quoted_contents();
-
-    let result = quote {
-
-        $parameters
-
-        #[abi(functions)]
-        pub struct $abi_struct_name {
-            parameters: $parameters_struct_name,
-            $return_type
-        }
-    };
-    result
-}
+comptime global FROM_FIELD: TypedExpr = {
+    let from_field_trait = quote { protocol_types::traits::FromField }.as_trait_constraint();
+    let function_selector_typ =
+        quote { protocol_types::abis::function_selector::FunctionSelector }.as_type();
+    function_selector_typ.get_trait_impl(from_field_trait).unwrap().methods().filter(|m| {
+        m.name() == quote { from_field }
+    })[0]
+        .as_typed_expr()
+};
 
 pub comptime fn stub_fn(f: FunctionDefinition) -> Quoted {
+    let is_static_call = is_fn_view(f);
+    let is_void = f.return_type() == type_of(());
+
+    if is_fn_private(f) {
+        if is_static_call {
+            if is_void {
+                create_private_static_void_stub(f)
+            } else {
+                create_private_static_stub(f)
+            }
+        } else {
+            if is_void {
+                create_private_void_stub(f)
+            } else {
+                create_private_stub(f)
+            }
+        }
+    } else {
+        if is_static_call {
+            if is_void {
+                create_public_static_void_stub(f)
+            } else {
+                create_public_static_stub(f)
+            }
+        } else {
+            if is_void {
+                create_public_void_stub(f)
+            } else {
+                create_public_stub(f)
+            }
+        }
+    }
+}
+
+comptime fn create_stub_base(
+    f: FunctionDefinition,
+) -> (Quoted, Quoted, Quoted, Quoted, u32, Field) {
     let fn_name = f.name();
     let fn_parameters = f.parameters();
-    let fn_return_type = f.return_type();
-
-    let fn_visibility = get_fn_visibility(f);
-    let is_static_call = is_fn_view(f);
-    let is_void = fn_return_type == type_of(());
-
-    let fn_visibility_capitalized = if is_fn_private(f) {
-        quote { Private }
-    } else {
-        quote { Public }
-    };
-    let is_static_call_capitalized = if is_static_call {
-        quote { Static }
-    } else {
-        quote { }
-    };
-    let is_void_capitalized = if is_void { quote { Void } } else { quote { } };
+    let fn_parameters_list =
+        fn_parameters.map(|(name, typ): (Quoted, Type)| quote { $name: $typ }).join(quote {,});
 
     let args_acc_name = quote { args_acc };
     let args_acc = fn_parameters.fold(
@@ -81,84 +76,167 @@ pub comptime fn stub_fn(f: FunctionDefinition) -> Quoted {
         },
     );
 
-    let args_hash_name = if fn_visibility == quote { private } {
-        quote { args_hash }
-    } else {
-        quote {}
-    };
-
-    let args = if fn_visibility == quote { private } {
-        quote {
-            $args_acc
-            let $args_hash_name = dep::aztec::hash::hash_args($args_acc_name);
-        }
-    } else {
-        args_acc
-    };
-
-    let fn_parameters_list =
-        fn_parameters.map(|(name, typ): (Quoted, Type)| quote { $name: $typ }).join(quote {,});
-
     let (fn_name_str, _) = fn_name.as_str_quote();
-
     let fn_name_len: u32 = unquote!(quote { $fn_name_str.as_bytes().len()});
-
-    let call_interface_generics = if is_void {
-        quote { $fn_name_len }
-    } else {
-        quote { $fn_name_len, $fn_return_type }
-    };
-
-    let call_interface_name = f"dep::aztec::context::call_interfaces::{fn_visibility_capitalized}{is_static_call_capitalized}{is_void_capitalized}CallInterface"
-        .quoted_contents();
-
     let fn_selector: Field = compute_fn_selector(f);
 
-    let gas_opts = if is_fn_public(f) {
-        quote { gas_opts: dep::aztec::context::gas::GasOpts::default() }
-    } else {
-        quote {}
-    };
+    (fn_name, fn_parameters_list, args_acc, fn_name_str, fn_name_len, fn_selector)
+}
 
-    let args_hash = if fn_visibility == quote { private } {
-        quote { $args_hash_name, }
-    } else {
-        quote {}
-    };
-
-    let function_selector_typ =
-        quote { protocol_types::abis::function_selector::FunctionSelector }.as_type();
-    let from_field = get_trait_impl_method(
-        function_selector_typ,
-        quote { protocol_types::traits::FromField },
-        quote { from_field },
-    );
+comptime fn create_private_stub(f: FunctionDefinition) -> Quoted {
+    let (fn_name, fn_parameters_list, args_acc, fn_name_str, fn_name_len, fn_selector) =
+        create_stub_base(f);
+    let fn_return_type = f.return_type();
 
     quote {
-        pub fn $fn_name(self, $fn_parameters_list) -> $call_interface_name<$call_interface_generics> {
-            $args
-            let selector = $from_field($fn_selector);
-            $call_interface_name {
-                target_contract: self.target_contract,
+        pub fn $fn_name(self, $fn_parameters_list) -> dep::aztec::context::call_interfaces::PrivateCallInterface<$fn_name_len, $fn_return_type> {
+            $args_acc
+            let selector = $FROM_FIELD($fn_selector);
+            dep::aztec::context::call_interfaces::PrivateCallInterface::new(
+                self.target_contract,
                 selector,
-                name: $fn_name_str,
-                $args_hash
-                args: $args_acc_name,
-                return_type: std::mem::zeroed(),
-                is_static: $is_static_call,
-                $gas_opts
-            }
+                $fn_name_str,
+                args_acc,
+                std::mem::zeroed(),
+                false
+            )
         }
     }
 }
 
-/// Registers a function stub created via `stub_fn` as part of a module,
-pub(crate) comptime fn register_stub(m: Module, stub: Quoted) {
-    let current_stubs = STUBS.get(m);
-    let stubs_to_insert = if current_stubs.is_some() {
-        current_stubs.unwrap().push_back(stub)
-    } else {
-        &[stub]
-    };
-    STUBS.insert(m, stubs_to_insert);
+comptime fn create_private_static_stub(f: FunctionDefinition) -> Quoted {
+    let (fn_name, fn_parameters_list, args_acc, fn_name_str, fn_name_len, fn_selector) =
+        create_stub_base(f);
+    let fn_return_type = f.return_type();
+
+    quote {
+        pub fn $fn_name(self, $fn_parameters_list) -> dep::aztec::context::call_interfaces::PrivateStaticCallInterface<$fn_name_len, $fn_return_type> {
+            $args_acc
+            let selector = $FROM_FIELD($fn_selector);
+            dep::aztec::context::call_interfaces::PrivateStaticCallInterface::new(
+                self.target_contract,
+                selector,
+                $fn_name_str,
+                args_acc,
+                std::mem::zeroed()
+            )
+        }
+    }
 }
+
+comptime fn create_private_void_stub(f: FunctionDefinition) -> Quoted {
+    let (fn_name, fn_parameters_list, args_acc, fn_name_str, fn_name_len, fn_selector) =
+        create_stub_base(f);
+
+    quote {
+        pub fn $fn_name(self, $fn_parameters_list) -> dep::aztec::context::call_interfaces::PrivateVoidCallInterface<$fn_name_len> {
+            $args_acc
+            let selector = $FROM_FIELD($fn_selector);
+            dep::aztec::context::call_interfaces::PrivateVoidCallInterface::new(
+                self.target_contract,
+                selector,
+                $fn_name_str,
+                args_acc,
+                false
+            )
+        }
+    }
+}
+
+comptime fn create_private_static_void_stub(f: FunctionDefinition) -> Quoted {
+    let (fn_name, fn_parameters_list, args_acc, fn_name_str, fn_name_len, fn_selector) =
+        create_stub_base(f);
+
+    quote {
+        pub fn $fn_name(self, $fn_parameters_list) -> dep::aztec::context::call_interfaces::PrivateStaticVoidCallInterface<$fn_name_len> {
+            $args_acc
+            let selector = $FROM_FIELD($fn_selector);
+            dep::aztec::context::call_interfaces::PrivateStaticVoidCallInterface::new(
+                self.target_contract,
+                selector,
+                $fn_name_str,
+                args_acc
+            )
+        }
+    }
+}
+
+comptime fn create_public_stub(f: FunctionDefinition) -> Quoted {
+    let (fn_name, fn_parameters_list, args_acc, fn_name_str, fn_name_len, fn_selector) =
+        create_stub_base(f);
+    let fn_return_type = f.return_type();
+
+    quote {
+        pub fn $fn_name(self, $fn_parameters_list) -> dep::aztec::context::call_interfaces::PublicCallInterface<$fn_name_len, $fn_return_type> {
+            $args_acc
+            let selector = $FROM_FIELD($fn_selector);
+            dep::aztec::context::call_interfaces::PublicCallInterface::new(
+                self.target_contract,
+                selector,
+                $fn_name_str,
+                args_acc,
+                std::mem::zeroed(),
+                false
+            )
+        }
+    }
+}
+
+comptime fn create_public_static_stub(f: FunctionDefinition) -> Quoted {
+    let (fn_name, fn_parameters_list, args_acc, fn_name_str, fn_name_len, fn_selector) =
+        create_stub_base(f);
+    let fn_return_type = f.return_type();
+
+    quote {
+        pub fn $fn_name(self, $fn_parameters_list) -> dep::aztec::context::call_interfaces::PublicStaticCallInterface<$fn_name_len, $fn_return_type> {
+            $args_acc
+            let selector = $FROM_FIELD($fn_selector);
+            dep::aztec::context::call_interfaces::PublicStaticCallInterface::new(
+                self.target_contract,
+                selector,
+                $fn_name_str,
+                args_acc,
+                std::mem::zeroed()
+            )
+        }
+    }
+}
+
+comptime fn create_public_void_stub(f: FunctionDefinition) -> Quoted {
+    let (fn_name, fn_parameters_list, args_acc, fn_name_str, fn_name_len, fn_selector) =
+        create_stub_base(f);
+
+    quote {
+        pub fn $fn_name(self, $fn_parameters_list) -> dep::aztec::context::call_interfaces::PublicVoidCallInterface<$fn_name_len> {
+            $args_acc
+            let selector = $FROM_FIELD($fn_selector);
+            dep::aztec::context::call_interfaces::PublicVoidCallInterface::new(
+                self.target_contract,
+                selector,
+                $fn_name_str,
+                args_acc,
+                false,
+                dep::aztec::context::gas::GasOpts::default()
+            )
+        }
+    }
+}
+
+comptime fn create_public_static_void_stub(f: FunctionDefinition) -> Quoted {
+    let (fn_name, fn_parameters_list, args_acc, fn_name_str, fn_name_len, fn_selector) =
+        create_stub_base(f);
+
+    quote {
+        pub fn $fn_name(self, $fn_parameters_list) -> dep::aztec::context::call_interfaces::PublicStaticVoidCallInterface<$fn_name_len> {
+            $args_acc
+            let selector = $FROM_FIELD($fn_selector);
+            dep::aztec::context::call_interfaces::PublicStaticVoidCallInterface::new(
+                self.target_contract,
+                selector,
+                $fn_name_str,
+                args_acc
+            )
+        }
+    }
+}
+

--- a/noir-projects/aztec-nr/aztec/src/macros/functions/interfaces.nr
+++ b/noir-projects/aztec-nr/aztec/src/macros/functions/interfaces.nr
@@ -1,12 +1,5 @@
-use crate::macros::utils::{
-    add_to_field_slice, compute_fn_selector, get_fn_visibility, get_trait_impl_method,
-    is_fn_private, is_fn_public, is_fn_view,
-};
-use std::{
-    collections::umap::UHashMap,
-    hash::{BuildHasherDefault, poseidon2::Poseidon2Hasher},
-    meta::{type_of, unquote},
-};
+use crate::macros::utils::{add_to_field_slice, compute_fn_selector, get_trait_impl_method, is_fn_private, is_fn_view};
+use std::meta::{type_of, unquote};
 
 comptime global FROM_FIELD: TypedExpr = {
     let from_field_trait = quote { protocol_types::traits::FromField }.as_trait_constraint();
@@ -97,7 +90,6 @@ comptime fn create_private_stub(f: FunctionDefinition) -> Quoted {
                 selector,
                 $fn_name_str,
                 args_acc,
-                std::mem::zeroed(),
                 false
             )
         }
@@ -118,7 +110,6 @@ comptime fn create_private_static_stub(f: FunctionDefinition) -> Quoted {
                 selector,
                 $fn_name_str,
                 args_acc,
-                std::mem::zeroed()
             )
         }
     }
@@ -175,7 +166,6 @@ comptime fn create_public_stub(f: FunctionDefinition) -> Quoted {
                 selector,
                 $fn_name_str,
                 args_acc,
-                std::mem::zeroed(),
                 false
             )
         }
@@ -196,7 +186,6 @@ comptime fn create_public_static_stub(f: FunctionDefinition) -> Quoted {
                 selector,
                 $fn_name_str,
                 args_acc,
-                std::mem::zeroed()
             )
         }
     }
@@ -215,8 +204,7 @@ comptime fn create_public_void_stub(f: FunctionDefinition) -> Quoted {
                 selector,
                 $fn_name_str,
                 args_acc,
-                false,
-                dep::aztec::context::gas::GasOpts::default()
+                false
             )
         }
     }

--- a/noir-projects/aztec-nr/aztec/src/macros/functions/interfaces.nr
+++ b/noir-projects/aztec-nr/aztec/src/macros/functions/interfaces.nr
@@ -1,4 +1,6 @@
-use crate::macros::utils::{add_to_field_slice, compute_fn_selector, get_trait_impl_method, is_fn_private, is_fn_view};
+use crate::macros::utils::{
+    add_to_field_slice, AsStrQuote, compute_fn_selector, get_trait_impl_method, is_fn_private, is_fn_view,
+};
 use std::meta::{type_of, unquote};
 
 comptime global FROM_FIELD: TypedExpr = {
@@ -10,6 +12,8 @@ comptime global FROM_FIELD: TypedExpr = {
     })[0]
         .as_typed_expr()
 };
+
+comptime global SERIALIZED_ARGS_SLICE_NAME: Quoted = quote { serialized_args };
 
 pub comptime fn stub_fn(f: FunctionDefinition) -> Quoted {
     let is_static_call = is_fn_view(f);
@@ -54,17 +58,24 @@ comptime fn create_stub_base(
     let fn_parameters_list =
         fn_parameters.map(|(name, typ): (Quoted, Type)| quote { $name: $typ }).join(quote {,});
 
-    let args_acc_name = quote { args_acc };
-    let args_acc = fn_parameters.fold(
+    // Example of what the fold(...) below will generate for `target_address` and `fee_juice_limit_per_tx` function
+    // parameters:
+    // ```
+    // let mut serialized_args =  &[];
+    // serialized_args = serialized_args.append(aztec::protocol_types::traits::Serialize::serialize(target_address));
+    // serialized_args = serialized_args.push_back(fee_juice_limit_per_tx as Field);
+    // ```
+    let serialized_args_slice_construction = fn_parameters.fold(
         quote {
-            let mut $args_acc_name = &[];
+            let mut $SERIALIZED_ARGS_SLICE_NAME = &[];
         },
-        |args_hasher, param: (Quoted, Type)| {
+        |args, param: (Quoted, Type)| {
             let (name, typ) = param;
-            let appended_arg = add_to_field_slice(args_acc_name, name, typ);
+            let arg_to_append = add_to_field_slice(SERIALIZED_ARGS_SLICE_NAME, name, typ);
             quote {
-                $args_hasher
-                $appended_arg
+                $args
+                $arg_to_append
+                l
             }
         },
     );
@@ -73,23 +84,26 @@ comptime fn create_stub_base(
     let fn_name_len: u32 = unquote!(quote { $fn_name_str.as_bytes().len()});
     let fn_selector: Field = compute_fn_selector(f);
 
-    (fn_name, fn_parameters_list, args_acc, fn_name_str, fn_name_len, fn_selector)
+    (
+        fn_name, fn_parameters_list, serialized_args_slice_construction, fn_name_str, fn_name_len,
+        fn_selector,
+    )
 }
 
 comptime fn create_private_stub(f: FunctionDefinition) -> Quoted {
-    let (fn_name, fn_parameters_list, args_acc, fn_name_str, fn_name_len, fn_selector) =
+    let (fn_name, fn_parameters_list, serialized_args_slice_construction, fn_name_str, fn_name_len, fn_selector) =
         create_stub_base(f);
     let fn_return_type = f.return_type();
 
     quote {
         pub fn $fn_name(self, $fn_parameters_list) -> dep::aztec::context::call_interfaces::PrivateCallInterface<$fn_name_len, $fn_return_type> {
-            $args_acc
+            $serialized_args_slice_construction
             let selector = $FROM_FIELD($fn_selector);
             dep::aztec::context::call_interfaces::PrivateCallInterface::new(
                 self.target_contract,
                 selector,
                 $fn_name_str,
-                args_acc,
+                $SERIALIZED_ARGS_SLICE_NAME,
                 false
             )
         }
@@ -97,37 +111,37 @@ comptime fn create_private_stub(f: FunctionDefinition) -> Quoted {
 }
 
 comptime fn create_private_static_stub(f: FunctionDefinition) -> Quoted {
-    let (fn_name, fn_parameters_list, args_acc, fn_name_str, fn_name_len, fn_selector) =
+    let (fn_name, fn_parameters_list, serialized_args_slice_construction, fn_name_str, fn_name_len, fn_selector) =
         create_stub_base(f);
     let fn_return_type = f.return_type();
 
     quote {
         pub fn $fn_name(self, $fn_parameters_list) -> dep::aztec::context::call_interfaces::PrivateStaticCallInterface<$fn_name_len, $fn_return_type> {
-            $args_acc
+            $serialized_args_slice_construction
             let selector = $FROM_FIELD($fn_selector);
             dep::aztec::context::call_interfaces::PrivateStaticCallInterface::new(
                 self.target_contract,
                 selector,
                 $fn_name_str,
-                args_acc,
+                $SERIALIZED_ARGS_SLICE_NAME,
             )
         }
     }
 }
 
 comptime fn create_private_void_stub(f: FunctionDefinition) -> Quoted {
-    let (fn_name, fn_parameters_list, args_acc, fn_name_str, fn_name_len, fn_selector) =
+    let (fn_name, fn_parameters_list, serialized_args_slice_construction, fn_name_str, fn_name_len, fn_selector) =
         create_stub_base(f);
 
     quote {
         pub fn $fn_name(self, $fn_parameters_list) -> dep::aztec::context::call_interfaces::PrivateVoidCallInterface<$fn_name_len> {
-            $args_acc
+            $serialized_args_slice_construction
             let selector = $FROM_FIELD($fn_selector);
             dep::aztec::context::call_interfaces::PrivateVoidCallInterface::new(
                 self.target_contract,
                 selector,
                 $fn_name_str,
-                args_acc,
+                $SERIALIZED_ARGS_SLICE_NAME,
                 false
             )
         }
@@ -135,37 +149,37 @@ comptime fn create_private_void_stub(f: FunctionDefinition) -> Quoted {
 }
 
 comptime fn create_private_static_void_stub(f: FunctionDefinition) -> Quoted {
-    let (fn_name, fn_parameters_list, args_acc, fn_name_str, fn_name_len, fn_selector) =
+    let (fn_name, fn_parameters_list, serialized_args_slice_construction, fn_name_str, fn_name_len, fn_selector) =
         create_stub_base(f);
 
     quote {
         pub fn $fn_name(self, $fn_parameters_list) -> dep::aztec::context::call_interfaces::PrivateStaticVoidCallInterface<$fn_name_len> {
-            $args_acc
+            $serialized_args_slice_construction
             let selector = $FROM_FIELD($fn_selector);
             dep::aztec::context::call_interfaces::PrivateStaticVoidCallInterface::new(
                 self.target_contract,
                 selector,
                 $fn_name_str,
-                args_acc
+                serialized_args
             )
         }
     }
 }
 
 comptime fn create_public_stub(f: FunctionDefinition) -> Quoted {
-    let (fn_name, fn_parameters_list, args_acc, fn_name_str, fn_name_len, fn_selector) =
+    let (fn_name, fn_parameters_list, serialized_args_slice_construction, fn_name_str, fn_name_len, fn_selector) =
         create_stub_base(f);
     let fn_return_type = f.return_type();
 
     quote {
         pub fn $fn_name(self, $fn_parameters_list) -> dep::aztec::context::call_interfaces::PublicCallInterface<$fn_name_len, $fn_return_type> {
-            $args_acc
+            $serialized_args_slice_construction
             let selector = $FROM_FIELD($fn_selector);
             dep::aztec::context::call_interfaces::PublicCallInterface::new(
                 self.target_contract,
                 selector,
                 $fn_name_str,
-                args_acc,
+                $SERIALIZED_ARGS_SLICE_NAME,
                 false
             )
         }
@@ -173,37 +187,37 @@ comptime fn create_public_stub(f: FunctionDefinition) -> Quoted {
 }
 
 comptime fn create_public_static_stub(f: FunctionDefinition) -> Quoted {
-    let (fn_name, fn_parameters_list, args_acc, fn_name_str, fn_name_len, fn_selector) =
+    let (fn_name, fn_parameters_list, serialized_args_slice_construction, fn_name_str, fn_name_len, fn_selector) =
         create_stub_base(f);
     let fn_return_type = f.return_type();
 
     quote {
         pub fn $fn_name(self, $fn_parameters_list) -> dep::aztec::context::call_interfaces::PublicStaticCallInterface<$fn_name_len, $fn_return_type> {
-            $args_acc
+            $serialized_args_slice_construction
             let selector = $FROM_FIELD($fn_selector);
             dep::aztec::context::call_interfaces::PublicStaticCallInterface::new(
                 self.target_contract,
                 selector,
                 $fn_name_str,
-                args_acc,
+                $SERIALIZED_ARGS_SLICE_NAME,
             )
         }
     }
 }
 
 comptime fn create_public_void_stub(f: FunctionDefinition) -> Quoted {
-    let (fn_name, fn_parameters_list, args_acc, fn_name_str, fn_name_len, fn_selector) =
+    let (fn_name, fn_parameters_list, serialized_args_slice_construction, fn_name_str, fn_name_len, fn_selector) =
         create_stub_base(f);
 
     quote {
         pub fn $fn_name(self, $fn_parameters_list) -> dep::aztec::context::call_interfaces::PublicVoidCallInterface<$fn_name_len> {
-            $args_acc
+            $serialized_args_slice_construction
             let selector = $FROM_FIELD($fn_selector);
             dep::aztec::context::call_interfaces::PublicVoidCallInterface::new(
                 self.target_contract,
                 selector,
                 $fn_name_str,
-                args_acc,
+                $SERIALIZED_ARGS_SLICE_NAME,
                 false
             )
         }
@@ -211,18 +225,18 @@ comptime fn create_public_void_stub(f: FunctionDefinition) -> Quoted {
 }
 
 comptime fn create_public_static_void_stub(f: FunctionDefinition) -> Quoted {
-    let (fn_name, fn_parameters_list, args_acc, fn_name_str, fn_name_len, fn_selector) =
+    let (fn_name, fn_parameters_list, serialized_args_slice_construction, fn_name_str, fn_name_len, fn_selector) =
         create_stub_base(f);
 
     quote {
         pub fn $fn_name(self, $fn_parameters_list) -> dep::aztec::context::call_interfaces::PublicStaticVoidCallInterface<$fn_name_len> {
-            $args_acc
+            $serialized_args_slice_construction
             let selector = $FROM_FIELD($fn_selector);
             dep::aztec::context::call_interfaces::PublicStaticVoidCallInterface::new(
                 self.target_contract,
                 selector,
                 $fn_name_str,
-                args_acc
+                serialized_args
             )
         }
     }

--- a/noir-projects/aztec-nr/aztec/src/macros/functions/mod.nr
+++ b/noir-projects/aztec-nr/aztec/src/macros/functions/mod.nr
@@ -1,17 +1,10 @@
-mod abi_export;
-mod call_interface_stubs;
-pub mod initialization_utils;
-pub mod stub_registry;
+pub(crate) mod abi_export;
+pub(crate) mod call_interface_stubs;
+pub(crate) mod initialization_utils;
+pub(crate) mod stub_registry;
+pub(crate) mod utils;
 
-use super::utils::{
-    add_to_hasher, fn_has_noinitcheck, get_fn_visibility, is_fn_initializer, is_fn_internal,
-    is_fn_private, is_fn_view, modify_fn_body, module_has_initializer, module_has_storage,
-};
-use protocol_types::meta::generate_serialize_to_fields;
-use std::meta::type_of;
-
-use abi_export::create_fn_abi_export;
-use call_interface_stubs::stub_fn;
+use utils::{transform_private, transform_public};
 
 // Functions can have multiple attributes applied to them, e.g. a single function can have #[public], #[view] and
 // #[internal]. However. the order in which this will be evaluated is unknown, which makes combining them tricky.
@@ -24,34 +17,6 @@ use call_interface_stubs::stub_fn;
 // private function in question also has the `internal` attribute applied. `#[internal]` itself does nothing - it is
 // what we call a 'marker' attribute, that only exists for `#[private]` or `#[public]` to check if it's been applied.
 // Therefore, the execution order of `#[internal]` and `#[private]` is irrelevant.
-
-/// Internal functions can only be called by the contract itself, typically from private into public.
-pub comptime fn internal(_f: FunctionDefinition) {
-    // Marker attribute
-}
-
-comptime fn create_internal_check(f: FunctionDefinition) -> Quoted {
-    let name = f.name();
-    let assertion_message = f"Function {name} can only be called internally";
-    quote { assert(context.msg_sender() == context.this_address(), $assertion_message); }
-}
-
-/// View functions can only be called in a static execution context.
-pub comptime fn view(_f: FunctionDefinition) {
-    // Marker attribute
-}
-
-comptime fn create_view_check(f: FunctionDefinition) -> Quoted {
-    let name = f.name();
-    let assertion_message = f"Function {name} can only be called statically";
-    if is_fn_private(f) {
-        // Here `context` is of type context::PrivateContext
-        quote { assert(context.inputs.call_context.is_static_call == true, $assertion_message); }
-    } else {
-        // Here `context` is of type context::PublicContext
-        quote { assert(context.is_static_call(), $assertion_message); }
-    }
-}
 
 /// An initializer function is similar to a constructor:
 ///  - it can only be called once
@@ -66,178 +31,19 @@ pub comptime fn noinitcheck(_f: FunctionDefinition) {
     // Marker attribute
 }
 
-comptime fn create_assert_correct_initializer_args(f: FunctionDefinition) -> Quoted {
-    let fn_visibility = get_fn_visibility(f);
-    f"dep::aztec::macros::functions::initialization_utils::assert_initialization_matches_address_preimage_{fn_visibility}(context);"
-        .quoted_contents()
+/// Internal functions can only be called by the contract itself, typically from private into public.
+pub comptime fn internal(_f: FunctionDefinition) {
+    // Marker attribute
 }
 
-comptime fn create_mark_as_initialized(f: FunctionDefinition) -> Quoted {
-    let fn_visibility = get_fn_visibility(f);
-    f"dep::aztec::macros::functions::initialization_utils::mark_as_initialized_{fn_visibility}(&mut context);"
-        .quoted_contents()
-}
-
-comptime fn create_init_check(f: FunctionDefinition) -> Quoted {
-    let fn_visibility = get_fn_visibility(f);
-    f"dep::aztec::macros::functions::initialization_utils::assert_is_initialized_{fn_visibility}(&mut context);"
-        .quoted_contents()
+/// View functions can only be called in a static execution context.
+pub comptime fn view(_f: FunctionDefinition) {
+    // Marker attribute
 }
 
 /// Private functions are executed client-side and preserve privacy.
 pub comptime fn private(f: FunctionDefinition) -> Quoted {
-    let fn_abi = create_fn_abi_export(f);
-    let fn_stub = stub_fn(f);
-    stub_registry::register(f.module(), fn_stub);
-
-    // If a function is further modified as unconstrained, we throw an error
-    if f.is_unconstrained() {
-        let name = f.name();
-        panic(
-            f"Function {name} is annotated with #[private] but marked as unconstrained, remove unconstrained keyword",
-        );
-    }
-
-    let module_has_initializer = module_has_initializer(f.module());
-    let module_has_storage = module_has_storage(f.module());
-
-    // Private functions undergo a lot of transformations from their Aztec.nr form into a circuit that can be fed to the
-    // Private Kernel Circuit.
-    // First we change the function signature so that it also receives `PrivateContextInputs`, which contain information
-    // about the execution context (e.g. the caller).
-    let original_params = f.parameters();
-    f.set_parameters(&[(
-        quote { inputs },
-        quote { crate::context::inputs::private_context_inputs::PrivateContextInputs }.as_type(),
-    )]
-        .append(original_params));
-
-    let mut body = f.body().as_block().unwrap();
-
-    // The original params are hashed and passed to the `context` object, so that the kernel can verify we've received
-    // the correct values.
-    // TODO: Optimize args_hasher for small number of arguments
-    let args_hasher_name = quote { args_hasher };
-    let args_hasher = original_params.fold(
-        quote {
-            let mut $args_hasher_name = dep::aztec::hash::ArgsHasher::new();
-        },
-        |args_hasher, param: (Quoted, Type)| {
-            let (name, typ) = param;
-            let appended_arg = add_to_hasher(args_hasher_name, name, typ);
-            quote {
-                $args_hasher
-                $appended_arg
-            }
-        },
-    );
-
-    let context_creation = quote { let mut context = dep::aztec::context::private_context::PrivateContext::new(inputs, args_hasher.hash()); };
-
-    // Modifications introduced by the different marker attributes.
-    let internal_check = if is_fn_internal(f) {
-        create_internal_check(f)
-    } else {
-        quote {}
-    };
-
-    let view_check = if is_fn_view(f) {
-        create_view_check(f)
-    } else {
-        quote {}
-    };
-
-    let (assert_initializer, mark_as_initialized) = if is_fn_initializer(f) {
-        (create_assert_correct_initializer_args(f), create_mark_as_initialized(f))
-    } else {
-        (quote {}, quote {})
-    };
-
-    let storage_init = if module_has_storage {
-        quote {
-            // Some functions don't access storage, but it'd be quite difficult to only inject this variable if it is
-            // referenced. We instead ignore 'unused variable' warnings for it.
-            #[allow(unused_variables)]
-            let storage = Storage::init(&mut context);
-        }
-    } else {
-        quote {}
-    };
-
-    // Initialization checks are not included in contracts that don't have initializers.
-    let init_check = if module_has_initializer & !is_fn_initializer(f) & !fn_has_noinitcheck(f) {
-        create_init_check(f)
-    } else {
-        quote {}
-    };
-
-    // Finally, we need to change the return type to be `PrivateCircuitPublicInputs`, which is what the Private Kernel
-    // circuit expects.
-    let return_value_var_name = quote { macro__returned__values };
-
-    let return_value_type = f.return_type();
-    let return_value = if body.len() == 0 {
-        quote {}
-    } else if return_value_type != type_of(()) {
-        // The original return value is passed to a second args hasher which the context receives.
-        let (body_without_return, last_body_expr) = body.pop_back();
-        let return_value = last_body_expr.quoted();
-        let return_value_assignment =
-            quote { let $return_value_var_name: $return_value_type = $return_value; };
-        let return_hasher_name = quote { return_hasher };
-        let return_value_into_hasher =
-            add_to_hasher(return_hasher_name, return_value_var_name, return_value_type);
-
-        body = body_without_return;
-
-        quote {
-            let mut $return_hasher_name = dep::aztec::hash::ArgsHasher::new();
-            $return_value_assignment
-            $return_value_into_hasher
-            context.set_return_hash($return_hasher_name);
-        }
-    } else {
-        let (body_without_return, last_body_expr) = body.pop_back();
-        if !last_body_expr.has_semicolon()
-            & last_body_expr.as_for().is_none()
-            & last_body_expr.as_assert().is_none()
-            & last_body_expr.as_for_range().is_none()
-            & last_body_expr.as_assert_eq().is_none()
-            & last_body_expr.as_let().is_none() {
-            let unused_return_value_name = f"_{return_value_var_name}".quoted_contents();
-            body = body_without_return.push_back(
-                quote { let $unused_return_value_name = $last_body_expr; }.as_expr().unwrap(),
-            );
-        }
-        quote {}
-    };
-
-    let context_finish = quote { context.finish() };
-
-    let to_prepend = quote {
-        $args_hasher
-        $context_creation
-        $assert_initializer
-        $init_check
-        $internal_check
-        $view_check
-        $storage_init
-    };
-
-    let to_append = quote {
-        $return_value
-        $mark_as_initialized
-        $context_finish
-    };
-    let modified_body = modify_fn_body(body, to_prepend, to_append);
-    f.set_body(modified_body);
-    f.set_return_type(
-        quote { dep::protocol_types::abis::private_circuit_public_inputs::PrivateCircuitPublicInputs }
-            .as_type(),
-    );
-    f.set_return_data();
-
-    fn_abi
+    transform_private(f)
 }
 
 /// Public functions are executed sequencer-side and do not preserve privacy, similar to the EVM.
@@ -248,124 +54,4 @@ pub comptime fn public(f: FunctionDefinition) -> Quoted {
     } else {
         transform_public(f)
     }
-}
-
-comptime fn transform_public(f: FunctionDefinition) -> Quoted {
-    let fn_abi = create_fn_abi_export(f);
-    let fn_stub = stub_fn(f);
-    stub_registry::register(f.module(), fn_stub);
-
-    // If a function is further modified as unconstrained, we throw an error
-    if f.is_unconstrained() {
-        let name = f.name();
-        panic(
-            f"Function {name} is annotated with #[public] but marked as unconstrained, remove unconstrained keyword",
-        );
-    }
-
-    let module_has_initializer = module_has_initializer(f.module());
-    let module_has_storage = module_has_storage(f.module());
-
-    // Public functions undergo a lot of transformations from their Aztec.nr form.
-    let original_params = f.parameters();
-    let args_len = original_params
-        .map(|(name, typ): (Quoted, Type)| {
-            generate_serialize_to_fields(name, typ, &[], false).0.len()
-        })
-        .fold(0, |acc: u32, val: u32| acc + val);
-
-    // Unlike in the private case, in public the `context` does not need to receive the hash of the original params.
-    let context_creation = quote {
-        let mut context = dep::aztec::context::public_context::PublicContext::new(|| {
-        // We start from 1 because we skip the selector for the dispatch function.
-        let serialized_args : [Field; $args_len] = dep::aztec::context::public_context::calldata_copy(1, $args_len);
-        dep::aztec::hash::hash_args_array(serialized_args)
-        });
-    };
-
-    // Modifications introduced by the different marker attributes.
-    let internal_check = if is_fn_internal(f) {
-        create_internal_check(f)
-    } else {
-        quote {}
-    };
-
-    let view_check = if is_fn_view(f) {
-        create_view_check(f)
-    } else {
-        quote {}
-    };
-
-    let (assert_initializer, mark_as_initialized) = if is_fn_initializer(f) {
-        (create_assert_correct_initializer_args(f), create_mark_as_initialized(f))
-    } else {
-        (quote {}, quote {})
-    };
-
-    let storage_init = if module_has_storage {
-        // Some functions don't access storage, but it'd be quite difficult to only inject this variable if it is
-        // referenced. We instead ignore 'unused variable' warnings for it.
-        quote {
-            #[allow(unused_variables)]
-            let storage = Storage::init(&mut context);
-        }
-    } else {
-        quote {}
-    };
-
-    // Initialization checks are not included in contracts that don't have initializers.
-    let init_check = if module_has_initializer & !fn_has_noinitcheck(f) & !is_fn_initializer(f) {
-        create_init_check(f)
-    } else {
-        quote {}
-    };
-
-    let to_prepend = quote {
-        $context_creation
-        $assert_initializer
-        $init_check
-        $internal_check
-        $view_check
-        $storage_init
-    };
-
-    let to_append = quote {
-        $mark_as_initialized
-    };
-
-    let body = f.body().as_block().unwrap();
-    let modified_body = modify_fn_body(body, to_prepend, to_append);
-    f.set_body(modified_body);
-
-    // All public functions are automatically made unconstrained, even if they were not marked as such. This is because
-    // instead of compiling into a circuit, they will compile to bytecode that will be later transpiled into AVM
-    // bytecode.
-    f.set_unconstrained(true);
-    f.set_return_public(true);
-
-    fn_abi
-}
-
-pub comptime fn transform_unconstrained(f: FunctionDefinition) {
-    let context_creation = quote { let mut context = dep::aztec::context::unconstrained_context::UnconstrainedContext::new(); };
-    let module_has_storage = module_has_storage(f.module());
-
-    let storage_init = if module_has_storage {
-        quote {
-            // Some functions don't access storage, but it'd be quite difficult to only inject this variable if it is
-            // referenced. We instead ignore 'unused variable' warnings for it.
-            #[allow(unused_variables)]
-            let storage = Storage::init(context);
-        }
-    } else {
-        quote {}
-    };
-    let to_prepend = quote {
-        $context_creation
-        $storage_init
-    };
-    let body = f.body().as_block().unwrap();
-    let modified_body = modify_fn_body(body, to_prepend, quote {});
-    f.set_return_public(true);
-    f.set_body(modified_body);
 }

--- a/noir-projects/aztec-nr/aztec/src/macros/functions/mod.nr
+++ b/noir-projects/aztec-nr/aztec/src/macros/functions/mod.nr
@@ -1,5 +1,7 @@
+pub mod abi_export;
 pub mod interfaces;
 pub mod initialization_utils;
+pub mod stub_registry;
 
 use super::utils::{
     add_to_hasher, fn_has_noinitcheck, get_fn_visibility, is_fn_initializer, is_fn_internal,
@@ -8,7 +10,8 @@ use super::utils::{
 use protocol_types::meta::generate_serialize_to_fields;
 use std::meta::type_of;
 
-use interfaces::{create_fn_abi_export, register_stub, stub_fn};
+use abi_export::create_fn_abi_export;
+use interfaces::stub_fn;
 
 // Functions can have multiple attributes applied to them, e.g. a single function can have #[public], #[view] and
 // #[internal]. However. the order in which this will be evaluated is unknown, which makes combining them tricky.
@@ -85,7 +88,7 @@ comptime fn create_init_check(f: FunctionDefinition) -> Quoted {
 pub comptime fn private(f: FunctionDefinition) -> Quoted {
     let fn_abi = create_fn_abi_export(f);
     let fn_stub = stub_fn(f);
-    register_stub(f.module(), fn_stub);
+    stub_registry::register(f.module(), fn_stub);
 
     // If a function is further modified as unconstrained, we throw an error
     if f.is_unconstrained() {
@@ -250,7 +253,7 @@ pub comptime fn public(f: FunctionDefinition) -> Quoted {
 comptime fn transform_public(f: FunctionDefinition) -> Quoted {
     let fn_abi = create_fn_abi_export(f);
     let fn_stub = stub_fn(f);
-    register_stub(f.module(), fn_stub);
+    stub_registry::register(f.module(), fn_stub);
 
     // If a function is further modified as unconstrained, we throw an error
     if f.is_unconstrained() {

--- a/noir-projects/aztec-nr/aztec/src/macros/functions/mod.nr
+++ b/noir-projects/aztec-nr/aztec/src/macros/functions/mod.nr
@@ -1,5 +1,5 @@
-pub mod abi_export;
-pub mod interfaces;
+mod abi_export;
+mod call_interface_stubs;
 pub mod initialization_utils;
 pub mod stub_registry;
 
@@ -11,7 +11,7 @@ use protocol_types::meta::generate_serialize_to_fields;
 use std::meta::type_of;
 
 use abi_export::create_fn_abi_export;
-use interfaces::stub_fn;
+use call_interface_stubs::stub_fn;
 
 // Functions can have multiple attributes applied to them, e.g. a single function can have #[public], #[view] and
 // #[internal]. However. the order in which this will be evaluated is unknown, which makes combining them tricky.

--- a/noir-projects/aztec-nr/aztec/src/macros/functions/stub_registry.nr
+++ b/noir-projects/aztec-nr/aztec/src/macros/functions/stub_registry.nr
@@ -1,0 +1,19 @@
+use std::{collections::umap::UHashMap, hash::{BuildHasherDefault, poseidon2::Poseidon2Hasher}};
+
+comptime mut global STUBS: UHashMap<Module, [Quoted], BuildHasherDefault<Poseidon2Hasher>> =
+    UHashMap::default();
+
+/// Registers a function stub created via `stub_fn` as part of a module,
+pub(crate) comptime fn register(m: Module, stub: Quoted) {
+    let current_stubs = STUBS.get(m);
+    let stubs_to_insert = if current_stubs.is_some() {
+        current_stubs.unwrap().push_back(stub)
+    } else {
+        &[stub]
+    };
+    STUBS.insert(m, stubs_to_insert);
+}
+
+pub comptime fn get(m: Module) -> Option<[Quoted]> {
+    STUBS.get(m)
+}

--- a/noir-projects/aztec-nr/aztec/src/macros/functions/utils.nr
+++ b/noir-projects/aztec-nr/aztec/src/macros/functions/utils.nr
@@ -1,0 +1,320 @@
+use crate::macros::{
+    functions::{abi_export::create_fn_abi_export, call_interface_stubs::stub_fn, stub_registry},
+    utils::{
+        add_to_hasher, fn_has_noinitcheck, get_fn_visibility, is_fn_initializer, is_fn_internal,
+        is_fn_private, is_fn_view, modify_fn_body, module_has_initializer, module_has_storage,
+    },
+};
+use protocol_types::meta::generate_serialize_to_fields;
+use std::meta::type_of;
+
+pub(crate) comptime fn transform_private(f: FunctionDefinition) -> Quoted {
+    let fn_abi = create_fn_abi_export(f);
+    let fn_stub = stub_fn(f);
+    stub_registry::register(f.module(), fn_stub);
+
+    // If a function is further modified as unconstrained, we throw an error
+    if f.is_unconstrained() {
+        let name = f.name();
+        panic(
+            f"Function {name} is annotated with #[private] but marked as unconstrained, remove unconstrained keyword",
+        );
+    }
+
+    let module_has_initializer = module_has_initializer(f.module());
+    let module_has_storage = module_has_storage(f.module());
+
+    // Private functions undergo a lot of transformations from their Aztec.nr form into a circuit that can be fed to the
+    // Private Kernel Circuit.
+    // First we change the function signature so that it also receives `PrivateContextInputs`, which contain information
+    // about the execution context (e.g. the caller).
+    let original_params = f.parameters();
+    f.set_parameters(&[(
+        quote { inputs },
+        quote { crate::context::inputs::private_context_inputs::PrivateContextInputs }.as_type(),
+    )]
+        .append(original_params));
+
+    let mut body = f.body().as_block().unwrap();
+
+    // The original params are hashed and passed to the `context` object, so that the kernel can verify we've received
+    // the correct values.
+    // TODO: Optimize args_hasher for small number of arguments
+    let args_hasher_name = quote { args_hasher };
+    let args_hasher = original_params.fold(
+        quote {
+            let mut $args_hasher_name = dep::aztec::hash::ArgsHasher::new();
+        },
+        |args_hasher, param: (Quoted, Type)| {
+            let (name, typ) = param;
+            let appended_arg = add_to_hasher(args_hasher_name, name, typ);
+            quote {
+                $args_hasher
+                $appended_arg
+            }
+        },
+    );
+
+    let context_creation = quote { let mut context = dep::aztec::context::private_context::PrivateContext::new(inputs, args_hasher.hash()); };
+
+    // Modifications introduced by the different marker attributes.
+    let internal_check = if is_fn_internal(f) {
+        create_internal_check(f)
+    } else {
+        quote {}
+    };
+
+    let view_check = if is_fn_view(f) {
+        create_view_check(f)
+    } else {
+        quote {}
+    };
+
+    let (assert_initializer, mark_as_initialized) = if is_fn_initializer(f) {
+        (create_assert_correct_initializer_args(f), create_mark_as_initialized(f))
+    } else {
+        (quote {}, quote {})
+    };
+
+    let storage_init = if module_has_storage {
+        quote {
+            // Some functions don't access storage, but it'd be quite difficult to only inject this variable if it is
+            // referenced. We instead ignore 'unused variable' warnings for it.
+            #[allow(unused_variables)]
+            let storage = Storage::init(&mut context);
+        }
+    } else {
+        quote {}
+    };
+
+    // Initialization checks are not included in contracts that don't have initializers.
+    let init_check = if module_has_initializer & !is_fn_initializer(f) & !fn_has_noinitcheck(f) {
+        create_init_check(f)
+    } else {
+        quote {}
+    };
+
+    // Finally, we need to change the return type to be `PrivateCircuitPublicInputs`, which is what the Private Kernel
+    // circuit expects.
+    let return_value_var_name = quote { macro__returned__values };
+
+    let return_value_type = f.return_type();
+    let return_value = if body.len() == 0 {
+        quote {}
+    } else if return_value_type != type_of(()) {
+        // The original return value is passed to a second args hasher which the context receives.
+        let (body_without_return, last_body_expr) = body.pop_back();
+        let return_value = last_body_expr.quoted();
+        let return_value_assignment =
+            quote { let $return_value_var_name: $return_value_type = $return_value; };
+        let return_hasher_name = quote { return_hasher };
+        let return_value_into_hasher =
+            add_to_hasher(return_hasher_name, return_value_var_name, return_value_type);
+
+        body = body_without_return;
+
+        quote {
+            let mut $return_hasher_name = dep::aztec::hash::ArgsHasher::new();
+            $return_value_assignment
+            $return_value_into_hasher
+            context.set_return_hash($return_hasher_name);
+        }
+    } else {
+        let (body_without_return, last_body_expr) = body.pop_back();
+        if !last_body_expr.has_semicolon()
+            & last_body_expr.as_for().is_none()
+            & last_body_expr.as_assert().is_none()
+            & last_body_expr.as_for_range().is_none()
+            & last_body_expr.as_assert_eq().is_none()
+            & last_body_expr.as_let().is_none() {
+            let unused_return_value_name = f"_{return_value_var_name}".quoted_contents();
+            body = body_without_return.push_back(
+                quote { let $unused_return_value_name = $last_body_expr; }.as_expr().unwrap(),
+            );
+        }
+        quote {}
+    };
+
+    let context_finish = quote { context.finish() };
+
+    let to_prepend = quote {
+        $args_hasher
+        $context_creation
+        $assert_initializer
+        $init_check
+        $internal_check
+        $view_check
+        $storage_init
+    };
+
+    let to_append = quote {
+        $return_value
+        $mark_as_initialized
+        $context_finish
+    };
+    let modified_body = modify_fn_body(body, to_prepend, to_append);
+    f.set_body(modified_body);
+    f.set_return_type(
+        quote { dep::protocol_types::abis::private_circuit_public_inputs::PrivateCircuitPublicInputs }
+            .as_type(),
+    );
+    f.set_return_data();
+
+    fn_abi
+}
+
+pub(crate) comptime fn transform_public(f: FunctionDefinition) -> Quoted {
+    let fn_abi = create_fn_abi_export(f);
+    let fn_stub = stub_fn(f);
+    stub_registry::register(f.module(), fn_stub);
+
+    // If a function is further modified as unconstrained, we throw an error
+    if f.is_unconstrained() {
+        let name = f.name();
+        panic(
+            f"Function {name} is annotated with #[public] but marked as unconstrained, remove unconstrained keyword",
+        );
+    }
+
+    let module_has_initializer = module_has_initializer(f.module());
+    let module_has_storage = module_has_storage(f.module());
+
+    // Public functions undergo a lot of transformations from their Aztec.nr form.
+    let original_params = f.parameters();
+    let args_len = original_params
+        .map(|(name, typ): (Quoted, Type)| {
+            generate_serialize_to_fields(name, typ, &[], false).0.len()
+        })
+        .fold(0, |acc: u32, val: u32| acc + val);
+
+    // Unlike in the private case, in public the `context` does not need to receive the hash of the original params.
+    let context_creation = quote {
+        let mut context = dep::aztec::context::public_context::PublicContext::new(|| {
+        // We start from 1 because we skip the selector for the dispatch function.
+        let serialized_args : [Field; $args_len] = dep::aztec::context::public_context::calldata_copy(1, $args_len);
+        dep::aztec::hash::hash_args_array(serialized_args)
+        });
+    };
+
+    // Modifications introduced by the different marker attributes.
+    let internal_check = if is_fn_internal(f) {
+        create_internal_check(f)
+    } else {
+        quote {}
+    };
+
+    let view_check = if is_fn_view(f) {
+        create_view_check(f)
+    } else {
+        quote {}
+    };
+
+    let (assert_initializer, mark_as_initialized) = if is_fn_initializer(f) {
+        (create_assert_correct_initializer_args(f), create_mark_as_initialized(f))
+    } else {
+        (quote {}, quote {})
+    };
+
+    let storage_init = if module_has_storage {
+        // Some functions don't access storage, but it'd be quite difficult to only inject this variable if it is
+        // referenced. We instead ignore 'unused variable' warnings for it.
+        quote {
+            #[allow(unused_variables)]
+            let storage = Storage::init(&mut context);
+        }
+    } else {
+        quote {}
+    };
+
+    // Initialization checks are not included in contracts that don't have initializers.
+    let init_check = if module_has_initializer & !fn_has_noinitcheck(f) & !is_fn_initializer(f) {
+        create_init_check(f)
+    } else {
+        quote {}
+    };
+
+    let to_prepend = quote {
+        $context_creation
+        $assert_initializer
+        $init_check
+        $internal_check
+        $view_check
+        $storage_init
+    };
+
+    let to_append = quote {
+        $mark_as_initialized
+    };
+
+    let body = f.body().as_block().unwrap();
+    let modified_body = modify_fn_body(body, to_prepend, to_append);
+    f.set_body(modified_body);
+
+    // All public functions are automatically made unconstrained, even if they were not marked as such. This is because
+    // instead of compiling into a circuit, they will compile to bytecode that will be later transpiled into AVM
+    // bytecode.
+    f.set_unconstrained(true);
+    f.set_return_public(true);
+
+    fn_abi
+}
+
+pub(crate) comptime fn transform_unconstrained(f: FunctionDefinition) {
+    let context_creation = quote { let mut context = dep::aztec::context::unconstrained_context::UnconstrainedContext::new(); };
+    let module_has_storage = module_has_storage(f.module());
+
+    let storage_init = if module_has_storage {
+        quote {
+            // Some functions don't access storage, but it'd be quite difficult to only inject this variable if it is
+            // referenced. We instead ignore 'unused variable' warnings for it.
+            #[allow(unused_variables)]
+            let storage = Storage::init(context);
+        }
+    } else {
+        quote {}
+    };
+    let to_prepend = quote {
+        $context_creation
+        $storage_init
+    };
+    let body = f.body().as_block().unwrap();
+    let modified_body = modify_fn_body(body, to_prepend, quote {});
+    f.set_return_public(true);
+    f.set_body(modified_body);
+}
+
+comptime fn create_internal_check(f: FunctionDefinition) -> Quoted {
+    let name = f.name();
+    let assertion_message = f"Function {name} can only be called internally";
+    quote { assert(context.msg_sender() == context.this_address(), $assertion_message); }
+}
+
+comptime fn create_view_check(f: FunctionDefinition) -> Quoted {
+    let name = f.name();
+    let assertion_message = f"Function {name} can only be called statically";
+    if is_fn_private(f) {
+        // Here `context` is of type context::PrivateContext
+        quote { assert(context.inputs.call_context.is_static_call == true, $assertion_message); }
+    } else {
+        // Here `context` is of type context::PublicContext
+        quote { assert(context.is_static_call(), $assertion_message); }
+    }
+}
+
+comptime fn create_assert_correct_initializer_args(f: FunctionDefinition) -> Quoted {
+    let fn_visibility = get_fn_visibility(f);
+    f"dep::aztec::macros::functions::initialization_utils::assert_initialization_matches_address_preimage_{fn_visibility}(context);"
+        .quoted_contents()
+}
+
+comptime fn create_mark_as_initialized(f: FunctionDefinition) -> Quoted {
+    let fn_visibility = get_fn_visibility(f);
+    f"dep::aztec::macros::functions::initialization_utils::mark_as_initialized_{fn_visibility}(&mut context);"
+        .quoted_contents()
+}
+
+comptime fn create_init_check(f: FunctionDefinition) -> Quoted {
+    let fn_visibility = get_fn_visibility(f);
+    f"dep::aztec::macros::functions::initialization_utils::assert_is_initialized_{fn_visibility}(&mut context);"
+        .quoted_contents()
+}

--- a/noir-projects/aztec-nr/aztec/src/macros/mod.nr
+++ b/noir-projects/aztec-nr/aztec/src/macros/mod.nr
@@ -10,12 +10,10 @@ use notes::{generate_note_export, NOTES};
 use storage::STORAGE_LAYOUT_NAME;
 
 use dispatch::generate_public_dispatch;
-use functions::transform_unconstrained;
 use utils::{get_trait_impl_method, module_has_storage};
 
 /// Marks a contract as an Aztec contract, generating the interfaces for its functions and notes, as well as injecting
 /// the `compute_note_hash_and_optionally_a_nullifier` function PXE requires in order to validate notes.
-///
 /// Note: This is a module annotation, so the returned quote gets injected inside the module (contract) itself.
 pub comptime fn aztec(m: Module) -> Quoted {
     let interface = generate_contract_interface(m);

--- a/noir-projects/aztec-nr/aztec/src/macros/mod.nr
+++ b/noir-projects/aztec-nr/aztec/src/macros/mod.nr
@@ -5,7 +5,7 @@ pub mod notes;
 pub mod storage;
 pub mod events;
 
-use functions::interfaces::STUBS;
+use functions::stub_registry;
 use notes::{generate_note_export, NOTES};
 use storage::STORAGE_LAYOUT_NAME;
 
@@ -45,7 +45,7 @@ pub comptime fn aztec(m: Module) -> Quoted {
 
 comptime fn generate_contract_interface(m: Module) -> Quoted {
     let module_name = m.name();
-    let contract_stubs = STUBS.get(m);
+    let contract_stubs = stub_registry::get(m);
     let fn_stubs_quote = if contract_stubs.is_some() {
         contract_stubs.unwrap().join(quote {})
     } else {

--- a/noir-projects/aztec-nr/aztec/src/macros/mod.nr
+++ b/noir-projects/aztec-nr/aztec/src/macros/mod.nr
@@ -5,7 +5,7 @@ pub mod notes;
 pub mod storage;
 pub mod events;
 
-use functions::stub_registry;
+use functions::{stub_registry, utils::transform_unconstrained};
 use notes::{generate_note_export, NOTES};
 use storage::STORAGE_LAYOUT_NAME;
 

--- a/noir-projects/aztec-nr/aztec/src/macros/utils.nr
+++ b/noir-projects/aztec-nr/aztec/src/macros/utils.nr
@@ -148,7 +148,7 @@ comptime fn signature_of_type(typ: Type) -> Quoted {
     }
 }
 
-trait AsStrQuote {
+pub(crate) trait AsStrQuote {
     fn as_str_quote(self) -> (Self, u32);
 }
 


### PR DESCRIPTION
- Cleans up CallInterfaces by adding a "new(...)" function and hiding struct fields.
- Attempts making `stub_fn` readable.