### PR TITLE
fix: aws_handle_evict recovery

### DIFF
--- a/ci3/aws_handle_evict
+++ b/ci3/aws_handle_evict
@@ -1,7 +1,3 @@
-#!/bin/bash
-# Capture initial PIDs using our stdio before running the command.
-initial_stdio_pids=$(fuser /dev/stdin /dev/stdout 2>/dev/null)
-
 # Gracefully signals eviction status with a 155 exit code.
 # Runs the given command in the background and waits on it while polling for eviction status.
 bash -c "$1" &
@@ -9,33 +5,22 @@ child_pid=$!
 
 token=$(curl -sX PUT "http://169.254.169.254/latest/api/token" -H "X-aws-ec2-metadata-token-ttl-seconds: 21600")
 
-function terminate_stdio_attached_processes {
-  # Identify new PIDs not present initially and force kill them.
-  current_stdio_pids=$(fuser /dev/stdin /dev/stdout 2>/dev/null)
-  comm -13 \
-    <(echo "$initial_stdio_pids" | tr ' ' '\n' | sort) \
-    <(echo "$current_stdio_pids" | tr ' ' '\n' | sort) | \
-    xargs -r kill -9
-}
-
 # Poll until the child finishes or a termination notice is detected
 while true; do
-  # Wait for process to come up, makes check below happen every 5 seconds.
+  # Wait for process to come up, makes check below happen every 5 seconds
   for i in {1..5}; do
     if ! kill -0 "$child_pid" 2>/dev/null; then
       wait "$child_pid"
-      terminate_stdio_attached_processes
       exit $?
     fi
     sleep 1
   done
-
-  # Check for imminent spot termination.
-  if curl -fs -H "X-aws-ec2-metadata-token: $token" \
-         http://169.254.169.254/latest/meta-data/spot/termination-time &>/dev/null; then
+  # Check for imminent spot termination
+  if curl -fs -H "X-aws-ec2-metadata-token: $token" http://169.254.169.254/latest/meta-data/spot/termination-time &>/dev/null; then
+    # Termination notice found, exit with 155.
     echo "Spot will be terminated! Exiting early."
-    terminate_stdio_attached_processes
-    # Exit with 155 to signal wrapper to restart with on-demand.
+    pids=$(fuser /dev/stdin /dev/stdout 2>/dev/null)
+    echo "$pids" | tr -s ' ' '\n' | grep -v $$ | xargs -r kill -9
     exit 155
   fi
 done

--- a/ci3/aws_handle_evict
+++ b/ci3/aws_handle_evict
@@ -1,3 +1,7 @@
+#!/bin/bash
+# Capture initial PIDs using our stdio before running the command.
+initial_stdio_pids=$(fuser /dev/stdin /dev/stdout /dev/stderr 2>/dev/null | tr -s ' ' '\n')
+
 # Gracefully signals eviction status with a 155 exit code.
 # Runs the given command in the background and waits on it while polling for eviction status.
 bash -c "$1" &
@@ -5,21 +9,30 @@ child_pid=$!
 
 token=$(curl -sX PUT "http://169.254.169.254/latest/api/token" -H "X-aws-ec2-metadata-token-ttl-seconds: 21600")
 
+function terminate_stdio_attached_processes {
+  # Get current PIDs using stdio and kill those that were not present at startup.
+  fuser /dev/stdin /dev/stdout /dev/stderr 2>/dev/null | tr -s ' ' '\n' \
+    | grep -vFxf <(echo "$initial_stdio_pids") \
+    | xargs -r kill -9
+}
+
 # Poll until the child finishes or a termination notice is detected
 while true; do
-  # Wait for process to come up, makes check below happen every 5 seconds
+  # Wait for process to come up, makes check below happen every 5 seconds.
   for i in {1..5}; do
     if ! kill -0 "$child_pid" 2>/dev/null; then
       wait "$child_pid"
+      terminate_stdio_attached_processes
       exit $?
     fi
     sleep 1
   done
-  # Check for imminent spot termination
-  if curl -fs -H "X-aws-ec2-metadata-token: $token" http://169.254.169.254/latest/meta-data/spot/termination-time &>/dev/null; then
-    # Termination notice found, exit with 155.
+
+  # Check for imminent spot termination.
+  if curl -fs -H "X-aws-ec2-metadata-token: $token" \
+         http://169.254.169.254/latest/meta-data/spot/termination-time &>/dev/null; then
     echo "Spot will be terminated! Exiting early."
-    fuser /dev/stdin /dev/stdout /dev/stderr 2>/dev/null | tr -s ' ' '\n' | grep -v $$ | xargs -r kill -9
+    terminate_stdio_attached_processes
     exit 155
   fi
 done

--- a/ci3/aws_handle_evict
+++ b/ci3/aws_handle_evict
@@ -33,6 +33,7 @@ while true; do
          http://169.254.169.254/latest/meta-data/spot/termination-time &>/dev/null; then
     echo "Spot will be terminated! Exiting early."
     terminate_stdio_attached_processes
+    # Exit with 155 to signal wrapper to restart with on-demand.
     exit 155
   fi
 done

--- a/ci3/aws_handle_evict
+++ b/ci3/aws_handle_evict
@@ -1,6 +1,6 @@
 #!/bin/bash
 # Capture initial PIDs using our stdio before running the command.
-initial_stdio_pids=$(fuser /dev/stdin /dev/stdout /dev/stderr 2>/dev/null | tr -s ' ' '\n')
+initial_stdio_pids=$(fuser /dev/stdin /dev/stdout 2>/dev/null)
 
 # Gracefully signals eviction status with a 155 exit code.
 # Runs the given command in the background and waits on it while polling for eviction status.
@@ -10,10 +10,12 @@ child_pid=$!
 token=$(curl -sX PUT "http://169.254.169.254/latest/api/token" -H "X-aws-ec2-metadata-token-ttl-seconds: 21600")
 
 function terminate_stdio_attached_processes {
-  # Get current PIDs using stdio and kill those that were not present at startup.
-  fuser /dev/stdin /dev/stdout /dev/stderr 2>/dev/null | tr -s ' ' '\n' \
-    | grep -vFxf <(echo "$initial_stdio_pids") \
-    | xargs -r kill -9
+  # Identify new PIDs not present initially and force kill them.
+  current_stdio_pids=$(fuser /dev/stdin /dev/stdout 2>/dev/null)
+  comm -13 \
+    <(echo "$initial_stdio_pids" | tr ' ' '\n' | sort) \
+    <(echo "$current_stdio_pids" | tr ' ' '\n' | sort) | \
+    xargs -r kill -9
 }
 
 # Poll until the child finishes or a termination notice is detected


### PR DESCRIPTION
This should fix gracefully handling a spot evict message
we were fetching a bunch of processes due to fuser having pipes on stderr and stdout. Drop stderr checking, don't evaluate in a pipe