### PR TITLE
chore: fix error in oracle definition

### DIFF
--- a/noir-projects/noir-protocol-circuits/crates/types/src/debug.nr
+++ b/noir-projects/noir-protocol-circuits/crates/types/src/debug.nr
@@ -2,7 +2,7 @@
 // and https://github.com/noir-lang/noir/issues/7192
 
 #[oracle(noOp)]
-fn no_op_oracle<T>(value: T) {}
+unconstrained fn no_op_oracle<T>(value: T) {}
 
 unconstrained fn no_op_oracle_wrapper<T>(value: T) {
     no_op_oracle(value);


### PR DESCRIPTION
This is breaking a compiler check that we're wanting to promote to an error.