### PR TITLE
testbench: propagation benchmarks

### DIFF
--- a/yarn-project/circuit-types/src/versioning.ts
+++ b/yarn-project/circuit-types/src/versioning.ts
@@ -45,6 +45,7 @@ export function compressComponentVersions(versions: ComponentsVersions): string 
   ) {
     throw new Error(`Component versions are not set: ${jsonStringify(versions)}`);
   }
+
   return [
     '00',
     versions.l1ChainId,

--- a/yarn-project/foundation/src/log/libp2p_logger.ts
+++ b/yarn-project/foundation/src/log/libp2p_logger.ts
@@ -1,6 +1,7 @@
 import { type ComponentLogger, type Logger } from '@libp2p/interface';
 
 import { getLogLevelFromFilters } from './log-filters.js';
+import type { LogLevel } from './log-levels.js';
 import { logFilters, logger } from './pino-logger.js';
 
 /**
@@ -13,36 +14,50 @@ export function createLibp2pComponentLogger(namespace: string): ComponentLogger 
   };
 }
 
+// Lipp2p libraries use arbitrary string substitutions, so we need to replace them with %s, this is slow so avoid doing it unless trace debugging
+function replaceFormatting(message: string) {
+  // Message can sometimes not be a string, e.g. an error object, just return it as is
+  if (!message?.replace) return message;
+
+  return message.replace(/(%p|%a)/g, '%s');
+}
+
 function createLibp2pLogger(component: string): Logger {
   // Create a direct pino logger instance for libp2p that supports string interpolation
   const log = logger.child({ module: component }, { level: getLogLevelFromFilters(logFilters, component) });
 
+  const logIfEnabled = (level: LogLevel, message: string, ...args: unknown[]) => {
+    if (!log.isLevelEnabled(level)) return;
+
+    log[level](replaceFormatting(message), ...args);
+  };
+
   // Default log level is trace as this is super super noisy
   const logFn = (message: string, ...args: unknown[]) => {
-    log.trace(message, ...args);
+    logIfEnabled('trace', message, ...args);
   };
 
   return Object.assign(logFn, {
     enabled: log.isLevelEnabled('debug'),
     error(message: string, ...args: unknown[]) {
       // We write error outputs as debug as they are often expected, e.g. connection errors can happen in happy paths
-      log.debug(message, ...args);
+      logIfEnabled('debug', message, ...args);
     },
 
     debug(message: string, ...args: unknown[]) {
-      log.debug(message, ...args);
+      logIfEnabled('debug', message, ...args);
     },
 
     info(message: string, ...args: unknown[]) {
-      log.info(message, ...args);
+      logIfEnabled('info', message, ...args);
     },
 
     warn(message: string, ...args: unknown[]) {
-      log.warn(message, ...args);
+      logIfEnabled('warn', message, ...args);
     },
 
     trace(message: string, ...args: unknown[]) {
-      log.trace(message, ...args);
+      logIfEnabled('trace', message, ...args);
     },
   });
 }

--- a/yarn-project/p2p/src/testbench/parse_log_file.ts
+++ b/yarn-project/p2p/src/testbench/parse_log_file.ts
@@ -1,0 +1,162 @@
+// TODO:
+// Read in the given log file as input
+// skip to the line in the log file where the sent message is logged
+// Index which peers have which node iDs - readable from their index in the log file
+// Sort each of the rpc events
+// Work out how many nodes received the message on each heartbeat interval
+// get the time for propagation
+import * as fs from 'fs';
+import * as path from 'path';
+
+interface LogEvent {
+  timestamp: number; // in milliseconds (from start of log)
+  peerId: string;
+}
+
+/**
+ * Parses a timestamp string in "HH:MM:SS.mmm" format and returns the
+ * time in milliseconds.
+ */
+function parseTimestamp(timeStr: string): number {
+  const parts = timeStr.split(':');
+  if (parts.length !== 3) {
+    throw new Error(`Invalid time format: ${timeStr}`);
+  }
+  const hours = parseInt(parts[0], 10);
+  const minutes = parseInt(parts[1], 10);
+  const secParts = parts[2].split('.');
+  const seconds = parseInt(secParts[0], 10);
+  const milliseconds = secParts[1] ? parseInt(secParts[1], 10) : 0;
+  return hours * 3600000 + minutes * 60000 + seconds * 1000 + milliseconds;
+}
+
+/**
+ * Parses a single log line. If the line contains an "rpc.from" event,
+ * it extracts the timestamp and the peer ID.
+ */
+function parseReceivedTx(line: string): LogEvent | null {
+  if (!line.includes('Received tx')) {
+    return null;
+  }
+
+  // Extract timestamp from the beginning of the line: e.g. [18:36:00.926]
+  const timestampMatch = line.match(/^\[(.*?)\]/);
+  if (!timestampMatch) {
+    return null;
+  }
+  const timeStr = timestampMatch[1];
+  let timestamp: number;
+  try {
+    timestamp = parseTimestamp(timeStr);
+  } catch (err) {
+    return null;
+  }
+
+  // TODO: this is not correct - it is just the tx hash for now
+  // Extract the peer ID after "Received tx"
+  const peerMatch = line.match(/Received tx\s+(\S+)/);
+  if (!peerMatch) {
+    return null;
+  }
+  const peerId = peerMatch[1];
+
+  return {
+    timestamp,
+    peerId,
+  };
+}
+
+function parseSentMessage(line: string): number | null {
+  if (!line.includes('Sent message')) {
+    return null;
+  }
+
+  // Get the timestamp at which the first message was sent
+  const timestampMatch = line.match(/^\[(.*?)\]/);
+  if (!timestampMatch) {
+    return null;
+  }
+  const timeStr = timestampMatch[1];
+  let timestamp: number;
+  try {
+    timestamp = parseTimestamp(timeStr);
+  } catch (err) {
+    return null;
+  }
+
+  return timestamp;
+}
+
+/**
+ * Processes the given log file, extracts all rpc.from events, computes the
+ * propagation delay for each peer relative to the earliest event, and prints
+ * some benchmark statistics.
+ */
+function processLogFile(logFilePath: string) {
+  const content = fs.readFileSync(logFilePath, 'utf-8');
+  const lines = content.split('\n');
+  const events: LogEvent[] = [];
+  let t0 = 0;
+
+  // We begin our search as soon as we see the Sent message log
+  let messageSent = false;
+  for (const line of lines) {
+    // Look for Sent message log
+    if (line.includes('Sent message')) {
+      messageSent = true;
+      t0 = parseSentMessage(line)!;
+    }
+
+    if (!messageSent) {
+      continue;
+    }
+    // Once we see the sent message log, we begin parsing Received tx logs
+    const event = parseReceivedTx(line);
+    if (event) {
+      events.push(event);
+    }
+  }
+
+  if (events.length === 0) {
+    console.log('No rpc.from events found in log file.');
+    return;
+  }
+
+  // Sort events by timestamp (ascending)
+  events.sort((a, b) => a.timestamp - b.timestamp);
+
+  // Compute delay for each event relative to t0
+  const delays = events.map(e => ({
+    peerId: e.peerId,
+    delay: e.timestamp - t0,
+  }));
+
+  console.log('Propagation delays (in ms) per peer:');
+  for (const d of delays) {
+    console.log(`${d.peerId}: ${d.delay} ms`);
+  }
+
+  // Compute basic statistics
+  const delayValues = delays.map(d => d.delay);
+  const minDelay = Math.min(...delayValues);
+  const maxDelay = Math.max(...delayValues);
+  const sumDelay = delayValues.reduce((sum, val) => sum + val, 0);
+  const avgDelay = sumDelay / delayValues.length;
+  const sortedDelays = delayValues.slice().sort((a, b) => a - b);
+  const medianDelay = sortedDelays[Math.floor(sortedDelays.length / 2)];
+
+  console.log('\nBenchmark Statistics:');
+  console.log(`Min delay: ${minDelay} ms`);
+  console.log(`Max delay: ${maxDelay} ms`);
+  console.log(`Average delay: ${avgDelay.toFixed(2)} ms`);
+  console.log(`Median delay: ${medianDelay} ms`);
+}
+
+// Get the log file path from command-line arguments
+const logFilePath = process.argv[2];
+if (!logFilePath) {
+  console.error('Usage: ts-node parse_log_file.ts <logFilePath>');
+  process.exit(1);
+}
+
+processLogFile(logFilePath);

--- a/yarn-project/p2p/src/testbench/scripts/run_testbench.sh
+++ b/yarn-project/p2p/src/testbench/scripts/run_testbench.sh
@@ -2,4 +2,4 @@
 # Run the testbench and pipe the output into a file
 # Usage: ./run_testbench.sh > outputfile
 
-FORCE_COLOR=1 LOG_LEVEL="debug; trace: .*gossipsub" yarn test testbench.test.ts 2>&1
+LOG_LEVEL="debug; trace: .*gossipsub" yarn test testbench.test.ts 2>&1


### PR DESCRIPTION
## WIP


initial message propagation benchmarks 

right now just shows the intervals at which nodes receive messages 

with a heartbeat interval of 700ms we can see clear clusters in the below output of where and when messages are received

<img width="578" alt="image" src="https://github.com/user-attachments/assets/b955dba4-9f6d-40d9-9236-e6b2e1feb074" />


