### PR TITLE
fix(spartan): eth-execution logging

### DIFF
--- a/spartan/aztec-network/eth-devnet/entrypoints/eth-execution.sh
+++ b/spartan/aztec-network/eth-devnet/entrypoints/eth-execution.sh
@@ -1,6 +1,6 @@
 #! /bin/bash
 
-exec reth node \
+reth node \
     --http \
     --http.port=${HTTP_PORT} \
     --http.addr="0.0.0.0" \
@@ -22,4 +22,4 @@ exec reth node \
     --chain="/genesis/genesis.json" \
     --datadir="/data" \
     --log.stdout.format=json \
-    -vv
+    -vvv


### PR DESCRIPTION
## Overview

We are not getting execution client logs in kubernetes, this appears to fix that 
