### PR TITLE
chore: Fix unbound CI variable on release image bootstrap

### DIFF
--- a/release-image/bootstrap.sh
+++ b/release-image/bootstrap.sh
@@ -9,7 +9,7 @@ case "$cmd" in
     cd ..
     denoise "docker build -f release-image/Dockerfile -t aztecprotocol/aztec:$(git rev-parse HEAD) ."
     docker tag aztecprotocol/aztec:$(git rev-parse HEAD) aztecprotocol/aztec:latest
-    if [ "$REF_NAME" == "master" ] && [ "$CI" -eq 1 ]; then
+    if [ "$REF_NAME" == "master" ] && [ "${CI:-0}" -eq 1 ]; then
       docker tag aztecprotocol/aztec:$COMMIT_HASH aztecprotocol/aztec:$COMMIT_HASH-$(arch)
       do_or_dryrun docker push aztecprotocol/aztec:$COMMIT_HASH-$(arch)
     fi
@@ -20,7 +20,7 @@ case "$cmd" in
     do_or_dryrun docker push aztecprotocol/aztec:${REF_NAME}-$(arch)
 
     # If doing a release in CI, update the remote manifest if we're the arm build.
-    if [ "${DRY_RUN:-0}" == 0 ] && [ "$(arch)" == "arm64" ] && [ "$CI" -eq 1 ]; then
+    if [ "${DRY_RUN:-0}" == 0 ] && [ "$(arch)" == "arm64" ] && [ "${CI:-0}" -eq 1 ]; then
       # Wait for amd64 image to be available.
       while ! docker manifest inspect aztecprotocol/aztec:${REFNAME}-$(arch) &>/dev/null; do
         echo "Waiting for amd64 image to be pushed..."


### PR DESCRIPTION
Would fail locally with:
```
release-image/bootstrap.sh: line 12: CI: unbound variable
```
