### PR TITLE
fix: SharedMutable compilation warnings

### DIFF
--- a/noir-projects/noir-protocol-circuits/crates/types/src/shared_mutable/scheduled_delay_change/test.nr
+++ b/noir-projects/noir-protocol-circuits/crates/types/src/shared_mutable/scheduled_delay_change/test.nr
@@ -1,4 +1,4 @@
-use crate::shared_mutable::scheduled_delay_change::ScheduledDelayChange;
+use crate::{shared_mutable::scheduled_delay_change::ScheduledDelayChange, traits::Packable};
 
 global TEST_INITIAL_DELAY: u32 = 13;
 

--- a/noir-projects/noir-protocol-circuits/crates/types/src/shared_mutable/scheduled_value_change.nr
+++ b/noir-projects/noir-protocol-circuits/crates/types/src/shared_mutable/scheduled_value_change.nr
@@ -1,4 +1,4 @@
-use crate::{traits::{Empty, Packable}, utils::arrays};
+use crate::{traits::{Empty, Packable, ToField}, utils::arrays};
 use std::cmp::min;
 
 mod test;

--- a/noir-projects/noir-protocol-circuits/crates/types/src/shared_mutable/scheduled_value_change/test.nr
+++ b/noir-projects/noir-protocol-circuits/crates/types/src/shared_mutable/scheduled_value_change/test.nr
@@ -1,4 +1,4 @@
-use crate::shared_mutable::scheduled_value_change::ScheduledValueChange;
+use crate::{shared_mutable::scheduled_value_change::ScheduledValueChange, traits::Packable};
 
 global TEST_DELAY: u32 = 200;
 


### PR DESCRIPTION
Fixed Noir compilation warnings in SharedMutable as [requested](https://github.com/AztecProtocol/aztec-packages/pull/11136#issuecomment-2666745846) by Tom.
