### PR TITLE
fix(avm): disable wrong sha skippable

### DIFF
--- a/barretenberg/cpp/pil/vm2/sha256.pil
+++ b/barretenberg/cpp/pil/vm2/sha256.pil
@@ -44,8 +44,12 @@ namespace sha256;
     // Selector for Sha256Compression Operation
     pol commit sel;
     sel * (1 - sel) = 0;
-    #[skippable_if]
-    sel = 0;
+
+    // TODO: This skippable condition makes verification fail.
+    // Re-check after https://github.com/AztecProtocol/aztec-packages/pull/10598 is merged.
+    // #[skippable_if]
+    // sel = 0;
+
     // These are needed while we can't use constant values in lookups.
     // For the XOR lookups
     pol commit xor_sel;
@@ -125,7 +129,7 @@ namespace sha256;
     // The last value is given the currently computed w value
     perform_round * (helper_w15' - w) = 0;
 
-    // Message Schedule Array, in the first row 
+    // Message Schedule Array, in the first row
     pol commit w;
     // These are for rounds > 15
     pol COMPUTED_W = helper_w0 + w_s_0 + helper_w9 + w_s_1;
@@ -134,7 +138,7 @@ namespace sha256;
     perform_round * ((computed_w_lhs * 2**32 + computed_w_rhs) - COMPUTED_W) = 0;
     pol commit is_input_round;// TODO: Constrain this
     perform_round * (w - (is_input_round * helper_w0 + (1 - is_input_round) * computed_w_rhs)) = 0;
-    
+
 
     // ========== Compute w_s0 ===================
     // w[i-15] `rotr` 7
@@ -175,7 +179,7 @@ namespace sha256;
     pol commit rhs_w_17;
     perform_round * (helper_w14 - (lhs_w_17 * 2**17 + rhs_w_17)) = 0;
     perform_round * (w_2_rotr_17 - (rhs_w_17 * 2**15 + lhs_w_17)) = 0;
-    // w[i-2] `rotr` 19 
+    // w[i-2] `rotr` 19
     pol commit w_2_rotr_19;
     pol commit lhs_w_19;
     pol commit rhs_w_19;
@@ -290,13 +294,13 @@ namespace sha256;
     pol commit rhs_a_22;
     perform_round * (a - (lhs_a_22 * 2**22 + rhs_a_22)) = 0;
     perform_round * (a_rotr_22 - (rhs_a_22 * 2**10 + lhs_a_22)) = 0;
-    // (A_0 `rotr` 2) `xor` (A_0 `rotr` 13) 
+    // (A_0 `rotr` 2) `xor` (A_0 `rotr` 13)
     pol commit a_rotr_2_xor_a_rotr_13;
     // #[LOOKUP_S_0_XOR_0]
     // dummy_zero {a_rotr_2, a_rotr_13, a_rotr_2_xor_a_rotr_13, xor_sel}
     // in
     // binary.start {binary.acc_ia, binary.acc_ib, binary.acc_ic, binary.op_id};
-    
+
     pol commit s_0;
     // #[LOOKUP_S_0_XOR_1]
     // dummy_zero {a_rotr_2_xor_a_rotr_13, a_rotr_22, s_0, xor_sel}

--- a/barretenberg/cpp/src/barretenberg/vm2/generated/relations/lookups_bc_decomposition.hpp
+++ b/barretenberg/cpp/src/barretenberg/vm2/generated/relations/lookups_bc_decomposition.hpp
@@ -79,7 +79,7 @@ class lookup_bytecode_bytes_are_bytes_relation
 
     template <typename AllEntities> inline static bool skip(const AllEntities& in)
     {
-        return in.bc_decomposition_sel.is_zero() && in.precomputed_sel_range_8.is_zero();
+        return in.lookup_bytecode_bytes_are_bytes_inv.is_zero();
     }
 
     static std::string get_subrelation_label(size_t index)
@@ -163,7 +163,7 @@ class lookup_bytecode_remaining_abs_diff_u16_relation
 
     template <typename AllEntities> inline static bool skip(const AllEntities& in)
     {
-        return in.bc_decomposition_sel.is_zero() && in.precomputed_sel_range_16.is_zero();
+        return in.lookup_bytecode_remaining_abs_diff_u16_inv.is_zero();
     }
 
     static std::string get_subrelation_label(size_t index)
@@ -251,7 +251,7 @@ class lookup_bytecode_to_read_unary_relation
 
     template <typename AllEntities> inline static bool skip(const AllEntities& in)
     {
-        return in.bc_decomposition_sel.is_zero() && in.precomputed_sel_unary.is_zero();
+        return in.lookup_bytecode_to_read_unary_inv.is_zero();
     }
 
     static std::string get_subrelation_label(size_t index)

--- a/barretenberg/cpp/src/barretenberg/vm2/generated/relations/lookups_bitwise.hpp
+++ b/barretenberg/cpp/src/barretenberg/vm2/generated/relations/lookups_bitwise.hpp
@@ -81,7 +81,7 @@ class lookup_bitw_byte_lengths_relation : public GenericLookupRelation<lookup_bi
 
     template <typename AllEntities> inline static bool skip(const AllEntities& in)
     {
-        return in.bitwise_start.is_zero() && in.precomputed_sel_integral_tag.is_zero();
+        return in.lookup_bitw_byte_lengths_inv.is_zero();
     }
 
     static std::string get_subrelation_label(size_t index)
@@ -175,7 +175,7 @@ class lookup_bitw_byte_operations_relation
 
     template <typename AllEntities> inline static bool skip(const AllEntities& in)
     {
-        return in.bitwise_sel.is_zero() && in.precomputed_sel_bitwise.is_zero();
+        return in.lookup_bitw_byte_operations_inv.is_zero();
     }
 
     static std::string get_subrelation_label(size_t index)

--- a/barretenberg/cpp/src/barretenberg/vm2/generated/relations/lookups_execution.hpp
+++ b/barretenberg/cpp/src/barretenberg/vm2/generated/relations/lookups_execution.hpp
@@ -89,7 +89,7 @@ class lookup_dummy_precomputed_relation : public GenericLookupRelation<lookup_du
 
     template <typename AllEntities> inline static bool skip(const AllEntities& in)
     {
-        return in.execution_sel.is_zero() && in.precomputed_sel_bitwise.is_zero();
+        return in.lookup_dummy_precomputed_inv.is_zero();
     }
 
     static std::string get_subrelation_label(size_t index)
@@ -181,7 +181,7 @@ class lookup_dummy_dynamic_relation : public GenericLookupRelation<lookup_dummy_
 
     template <typename AllEntities> inline static bool skip(const AllEntities& in)
     {
-        return in.execution_sel.is_zero() && in.execution_sel.is_zero();
+        return in.lookup_dummy_dynamic_inv.is_zero();
     }
 
     static std::string get_subrelation_label(size_t index)

--- a/barretenberg/cpp/src/barretenberg/vm2/generated/relations/lookups_poseidon2_hash.hpp
+++ b/barretenberg/cpp/src/barretenberg/vm2/generated/relations/lookups_poseidon2_hash.hpp
@@ -98,7 +98,7 @@ class lookup_pos2_perm_relation : public GenericLookupRelation<lookup_pos2_perm_
 
     template <typename AllEntities> inline static bool skip(const AllEntities& in)
     {
-        return in.poseidon2_hash_sel.is_zero() && in.poseidon2_perm_sel.is_zero();
+        return in.lookup_pos2_perm_inv.is_zero();
     }
 
     static std::string get_subrelation_label(size_t index)

--- a/barretenberg/cpp/src/barretenberg/vm2/generated/relations/lookups_range_check.hpp
+++ b/barretenberg/cpp/src/barretenberg/vm2/generated/relations/lookups_range_check.hpp
@@ -82,7 +82,7 @@ class lookup_rng_chk_pow_2_relation : public GenericLookupRelation<lookup_rng_ch
 
     template <typename AllEntities> inline static bool skip(const AllEntities& in)
     {
-        return in.range_check_sel.is_zero() && in.precomputed_sel_range_8.is_zero();
+        return in.lookup_rng_chk_pow_2_inv.is_zero();
     }
 
     static std::string get_subrelation_label(size_t index)
@@ -164,7 +164,7 @@ class lookup_rng_chk_diff_relation : public GenericLookupRelation<lookup_rng_chk
 
     template <typename AllEntities> inline static bool skip(const AllEntities& in)
     {
-        return in.range_check_sel.is_zero() && in.precomputed_sel_range_16.is_zero();
+        return in.lookup_rng_chk_diff_inv.is_zero();
     }
 
     static std::string get_subrelation_label(size_t index)
@@ -247,7 +247,7 @@ class lookup_rng_chk_is_r0_16_bit_relation
 
     template <typename AllEntities> inline static bool skip(const AllEntities& in)
     {
-        return in.range_check_sel_r0_16_bit_rng_lookup.is_zero() && in.precomputed_sel_range_16.is_zero();
+        return in.lookup_rng_chk_is_r0_16_bit_inv.is_zero();
     }
 
     static std::string get_subrelation_label(size_t index)
@@ -330,7 +330,7 @@ class lookup_rng_chk_is_r1_16_bit_relation
 
     template <typename AllEntities> inline static bool skip(const AllEntities& in)
     {
-        return in.range_check_sel_r1_16_bit_rng_lookup.is_zero() && in.precomputed_sel_range_16.is_zero();
+        return in.lookup_rng_chk_is_r1_16_bit_inv.is_zero();
     }
 
     static std::string get_subrelation_label(size_t index)
@@ -413,7 +413,7 @@ class lookup_rng_chk_is_r2_16_bit_relation
 
     template <typename AllEntities> inline static bool skip(const AllEntities& in)
     {
-        return in.range_check_sel_r2_16_bit_rng_lookup.is_zero() && in.precomputed_sel_range_16.is_zero();
+        return in.lookup_rng_chk_is_r2_16_bit_inv.is_zero();
     }
 
     static std::string get_subrelation_label(size_t index)
@@ -496,7 +496,7 @@ class lookup_rng_chk_is_r3_16_bit_relation
 
     template <typename AllEntities> inline static bool skip(const AllEntities& in)
     {
-        return in.range_check_sel_r3_16_bit_rng_lookup.is_zero() && in.precomputed_sel_range_16.is_zero();
+        return in.lookup_rng_chk_is_r3_16_bit_inv.is_zero();
     }
 
     static std::string get_subrelation_label(size_t index)
@@ -579,7 +579,7 @@ class lookup_rng_chk_is_r4_16_bit_relation
 
     template <typename AllEntities> inline static bool skip(const AllEntities& in)
     {
-        return in.range_check_sel_r4_16_bit_rng_lookup.is_zero() && in.precomputed_sel_range_16.is_zero();
+        return in.lookup_rng_chk_is_r4_16_bit_inv.is_zero();
     }
 
     static std::string get_subrelation_label(size_t index)
@@ -662,7 +662,7 @@ class lookup_rng_chk_is_r5_16_bit_relation
 
     template <typename AllEntities> inline static bool skip(const AllEntities& in)
     {
-        return in.range_check_sel_r5_16_bit_rng_lookup.is_zero() && in.precomputed_sel_range_16.is_zero();
+        return in.lookup_rng_chk_is_r5_16_bit_inv.is_zero();
     }
 
     static std::string get_subrelation_label(size_t index)
@@ -745,7 +745,7 @@ class lookup_rng_chk_is_r6_16_bit_relation
 
     template <typename AllEntities> inline static bool skip(const AllEntities& in)
     {
-        return in.range_check_sel_r6_16_bit_rng_lookup.is_zero() && in.precomputed_sel_range_16.is_zero();
+        return in.lookup_rng_chk_is_r6_16_bit_inv.is_zero();
     }
 
     static std::string get_subrelation_label(size_t index)
@@ -828,7 +828,7 @@ class lookup_rng_chk_is_r7_16_bit_relation
 
     template <typename AllEntities> inline static bool skip(const AllEntities& in)
     {
-        return in.range_check_sel.is_zero() && in.precomputed_sel_range_16.is_zero();
+        return in.lookup_rng_chk_is_r7_16_bit_inv.is_zero();
     }
 
     static std::string get_subrelation_label(size_t index)

--- a/barretenberg/cpp/src/barretenberg/vm2/generated/relations/lookups_sha256.hpp
+++ b/barretenberg/cpp/src/barretenberg/vm2/generated/relations/lookups_sha256.hpp
@@ -84,7 +84,7 @@ class lookup_sha256_round_constant_relation
 
     template <typename AllEntities> inline static bool skip(const AllEntities& in)
     {
-        return in.sha256_sel.is_zero() && in.precomputed_sel_sha256_compression.is_zero();
+        return in.lookup_sha256_round_constant_inv.is_zero();
     }
 
     static std::string get_subrelation_label(size_t index)

--- a/barretenberg/cpp/src/barretenberg/vm2/generated/relations/perms_execution.hpp
+++ b/barretenberg/cpp/src/barretenberg/vm2/generated/relations/perms_execution.hpp
@@ -72,7 +72,7 @@ class perm_dummy_dynamic_relation : public GenericPermutationRelation<perm_dummy
 
     template <typename AllEntities> inline static bool skip(const AllEntities& in)
     {
-        return in.execution_sel.is_zero() && in.execution_sel.is_zero();
+        return in.perm_dummy_dynamic_inv.is_zero();
     }
 
     static std::string get_subrelation_label(size_t index)

--- a/barretenberg/cpp/src/barretenberg/vm2/generated/relations/sha256.hpp
+++ b/barretenberg/cpp/src/barretenberg/vm2/generated/relations/sha256.hpp
@@ -17,12 +17,6 @@ template <typename FF_> class sha256Impl {
         3, 3, 3, 3, 3, 3, 3, 3, 3, 3, 3, 3, 3, 3, 3, 3, 3, 3, 3, 3, 3, 3, 3, 3, 3, 3, 3, 3, 4, 4, 4, 4, 4, 4, 4, 4
     };
 
-    template <typename AllEntities> inline static bool skip(const AllEntities& in)
-    {
-        const auto& new_term = in;
-        return (new_term.sha256_sel).is_zero();
-    }
-
     template <typename ContainerOverSubrelations, typename AllEntities>
     void static accumulate(ContainerOverSubrelations& evals,
                            const AllEntities& new_term,

--- a/bb-pilcom/bb-pil-backend/templates/lookup.hpp.hbs
+++ b/bb-pilcom/bb-pil-backend/templates/lookup.hpp.hbs
@@ -93,7 +93,7 @@ template <typename FF_> class {{lookup_name}}_relation : public GenericLookupRel
         {{! TODO: This is a safe skippable condition, but there might be a better one. --}}
         template <typename AllEntities> inline static bool skip(const AllEntities& in)
         {
-            return in.{{lhs_selector}}.is_zero() && in.{{rhs_selector}}.is_zero();
+            return in.{{inverses_col}}.is_zero();
         }
 
         static std::string get_subrelation_label(size_t index) {

--- a/bb-pilcom/bb-pil-backend/templates/permutation.hpp.hbs
+++ b/bb-pilcom/bb-pil-backend/templates/permutation.hpp.hbs
@@ -59,7 +59,7 @@ template <typename FF_> class {{perm_name}}_relation : public GenericPermutation
         {{! TODO: This is a safe skippable condition, but there might be a better one. --}}
         template <typename AllEntities> inline static bool skip(const AllEntities& in)
         {
-            return in.{{lhs_selector}}.is_zero() && in.{{rhs_selector}}.is_zero();
+            return in.{{inverses_col}}.is_zero();
         }
 
         static std::string get_subrelation_label(size_t index) {


### PR DESCRIPTION
There used to be a long standing BB bug where the verifier was (wrongly) skipping. The branch with the fix (https://github.com/AztecProtocol/aztec-packages/pull/10598) fails with an AVM2 test. I tracked it down to the skippable condition in sha256. I'm disabling it and also updating the lookups skippable to a simpler condition that Kesha had suggested.
