### PR TITLE
chore: Provide defaults for bb and acvm in release image

### DIFF
--- a/release-image/Dockerfile
+++ b/release-image/Dockerfile
@@ -30,4 +30,12 @@ COPY --from=build /opt/foundry /opt/foundry
 ENV PATH="/opt/foundry/bin:$PATH"
 # Copy in project files.
 COPY --from=build /usr/src /usr/src
+
+# Provide paths to bb and acvm for use in yarn-project, also create default working directories for each
+ENV BB_WORKING_DIRECTORY=/usr/src/bb
+ENV BB_BINARY_PATH=/usr/src/barretenberg/cpp/build/bin/bb
+ENV ACVM_WORKING_DIRECTORY=/usr/src/acvm
+ENV ACVM_BINARY_PATH=/usr/src/noir/noir-repo/target/release/acvm
+RUN mkdir -p $BB_WORKING_DIRECTORY $ACVM_WORKING_DIRECTORY
+
 WORKDIR "/usr/src/yarn-project"


### PR DESCRIPTION
This PR attempts to fix deployments by re-instating defaults env vars for bb and acvm in yarn project.
