### PR TITLE
fix: allow empty blocks in aztec chart

### DIFF
--- a/spartan/aztec-network/values.yaml
+++ b/spartan/aztec-network/values.yaml
@@ -72,7 +72,7 @@ bootNode:
   coinbaseAddress: "0xaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"
   sequencer:
     maxSecondsBetweenBlocks: 0
-    minTxsPerBlock: 1
+    minTxsPerBlock: 0
   validator:
     disabled: true
   p2p:
@@ -114,7 +114,7 @@ validator:
   logLevel: "debug; info: aztec:simulator, json-rpc"
   sequencer:
     maxSecondsBetweenBlocks: 0
-    minTxsPerBlock: 1
+    minTxsPerBlock: 0
     maxTxsPerBlock: 4
     enforceTimeTable: true
   validator:


### PR DESCRIPTION
Un-bricks aztec network deployments which had been bricked with the following while deploying the bot:

![Screenshot 2025-02-19 at 14.49.19.png](https://graphite-user-uploaded-assets-prod.s3.amazonaws.com/RJpsSZ0TcXRNQxCJ6yLa/556c579d-4ab1-4283-a004-923800b5d852.png)

