### PR TITLE
chore: Do not allow changes to package json during CI yarn install

### DIFF
--- a/yarn-project/.yarnrc.yml
+++ b/yarn-project/.yarnrc.yml
@@ -7,3 +7,7 @@ logFilters:
     level: discard
 
 nodeLinker: node-modules
+
+# Do not allow 'yarn install' on CI to format package.json files,
+# otherwise it will change their hash and bust the cache
+immutablePatterns: ['**/package.json']

--- a/yarn-project/bootstrap.sh
+++ b/yarn-project/bootstrap.sh
@@ -93,8 +93,10 @@ function build {
   echo_header "yarn-project build"
   denoise "./bootstrap.sh clean-lite"
   if [ "${CI:-0}" = 1 ]; then
-    # If in CI mode, retry as bcrypto can sometimes fail mysteriously and we don't expect actual yarn install errors.
-    denoise "retry yarn install"
+    # If in CI mode, retry as bcrypto can sometimes fail mysteriously.
+    # We set immutable since we don't expect the yarn.lock to change. Note that we have also added all package.json
+    # files to yarn immutablePatterns, so if they are also changed, this step will fail.
+    denoise "retry yarn install --immutable"
   else
     denoise "yarn install"
   fi


### PR DESCRIPTION
Running `yarn install` will format the package.json for all packages in the workspace. This will cause `cache_content_hash` to fail on CI due to changed files, which (before #12124) caused the build to terminate abruptly (see [here](https://github.com/AztecProtocol/aztec-packages/actions/runs/13422411604/job/37497960586?pr=12096#step:7:109) for an example).

This PR adds all package.json files to yarn's `immutablePatterns`, so if it detects that the install process changed them it, it will fail with `The checksum for **/package.json has been modified by this install, which is explicitly forbidden.` and a nice exit code, which should be visible on the CI run. This only applies to CI runs.
