### PR TITLE
fix: Do not try flushing txs in bot setup if not set

### DIFF
--- a/yarn-project/bot/src/factory.ts
+++ b/yarn-project/bot/src/factory.ts
@@ -97,10 +97,7 @@ export class BotFactory {
       const sentTx = account.deploy({ fee: { paymentMethod } });
       const txHash = await sentTx.getTxHash();
       this.log.info(`Sent tx with hash ${txHash.toString()}`);
-      if (this.config.flushSetupTransactions) {
-        this.log.verbose('Flushing transactions');
-        await this.node!.flushTxs();
-      }
+      await this.tryFlushTxs();
       this.log.verbose('Waiting for account deployment to settle');
       await sentTx.wait({ timeout: this.config.txMinedWaitSeconds });
       this.log.info(`Account deployed at ${address}`);
@@ -159,10 +156,7 @@ export class BotFactory {
       const sentTx = deploy.send(deployOpts);
       const txHash = await sentTx.getTxHash();
       this.log.info(`Sent tx with hash ${txHash.toString()}`);
-      if (this.config.flushSetupTransactions) {
-        this.log.verbose('Flushing transactions');
-        await this.node!.flushTxs();
-      }
+      await this.tryFlushTxs();
       this.log.verbose('Waiting for token setup to settle');
       return sentTx.deployed({ timeout: this.config.txMinedWaitSeconds });
     }
@@ -206,10 +200,7 @@ export class BotFactory {
     const sentTx = new BatchCall(token.wallet, calls).send();
     const txHash = await sentTx.getTxHash();
     this.log.info(`Sent tx with hash ${txHash.toString()}`);
-    if (this.config.flushSetupTransactions) {
-      this.log.verbose('Flushing transactions');
-      await this.node!.flushTxs();
-    }
+    await this.tryFlushTxs();
     this.log.verbose('Waiting for token mint to settle');
     await sentTx.wait({ timeout: this.config.txMinedWaitSeconds });
   }
@@ -243,7 +234,18 @@ export class BotFactory {
 
   private async advanceL2Block() {
     const initialBlockNumber = await this.node!.getBlockNumber();
-    await this.node!.flushTxs();
+    await this.tryFlushTxs();
     await retryUntil(async () => (await this.node!.getBlockNumber()) >= initialBlockNumber + 1);
+  }
+
+  private async tryFlushTxs() {
+    if (this.config.flushSetupTransactions) {
+      this.log.verbose('Flushing transactions');
+      try {
+        await this.node!.flushTxs();
+      } catch (err) {
+        this.log.error(`Failed to flush transactions: ${err}`);
+      }
+    }
   }
 }


### PR DESCRIPTION
Adds a missing guard to flush txs that caused the bot to fail setup in public networks, accidentally introduced in #11480.