### PR TITLE
fix: ASSERTS that should throw

### DIFF
--- a/barretenberg/cpp/src/barretenberg/api/api_ultra_honk.cpp
+++ b/barretenberg/cpp/src/barretenberg/api/api_ultra_honk.cpp
@@ -197,7 +197,7 @@ void UltraHonkAPI::write_vk(const Flags& flags,
 void UltraHonkAPI::gates([[maybe_unused]] const Flags& flags,
                          [[maybe_unused]] const std::filesystem::path& bytecode_path)
 {
-    ASSERT("API function not implemented");
+    throw_or_abort("API function not implemented");
 }
 
 void UltraHonkAPI::write_contract(const Flags& flags,

--- a/barretenberg/cpp/src/barretenberg/api/write_prover_output.hpp
+++ b/barretenberg/cpp/src/barretenberg/api/write_prover_output.hpp
@@ -29,7 +29,6 @@ void write(const ProverOutput& prover_output,
     const auto write_bytes = [&](const ObjectToWrite& obj) {
         switch (obj) {
         case ObjectToWrite::PROOF: {
-            info("case ObjectToWrite::PROOF: ");
             const auto buf = to_buffer</*include_size*/ true>(prover_output.proof);
             if (output_to_stdout) {
                 write_bytes_to_stdout(buf);
@@ -39,7 +38,6 @@ void write(const ProverOutput& prover_output,
             break;
         }
         case ObjectToWrite::VK: {
-            info("case ObjectToWrite::VK: ");
             const auto buf = to_buffer(prover_output.key);
             if (output_to_stdout) {
                 write_bytes_to_stdout(buf);
@@ -54,23 +52,19 @@ void write(const ProverOutput& prover_output,
     const auto write_fields = [&](const ObjectToWrite& obj) {
         switch (obj) {
         case ObjectToWrite::PROOF: {
-            info("case ObjectToWrite::PROOF: ");
             const std::string proof_json = to_json(prover_output.proof);
             if (output_to_stdout) {
                 std::cout << proof_json;
             } else {
-                info("writing proof as fields to ", output_dir / "proof_fields.json");
                 write_file(output_dir / "proof_fields.json", { proof_json.begin(), proof_json.end() });
             }
             break;
         }
         case ObjectToWrite::VK: {
-            info("case ObjectToWrite::VK: ");
             const std::string vk_json = to_json(prover_output.key->to_field_elements());
             if (output_to_stdout) {
                 std::cout << vk_json;
             } else {
-                info("writing vk as fields to ", output_dir / "vk_fields.json");
                 write_file(output_dir / "vk_fields.json", { vk_json.begin(), vk_json.end() });
             }
             break;
@@ -80,13 +74,10 @@ void write(const ProverOutput& prover_output,
 
     if (output_content == "proof") {
         if (output_data_type == "bytes") {
-            info("case bytes: ");
             write_bytes(ObjectToWrite::PROOF);
         } else if (output_data_type == "fields") {
-            info("case fields: ");
             write_fields(ObjectToWrite::PROOF);
         } else if (output_data_type == "bytes_and_fields") {
-            info("case bytes_and_fields: ");
             write_bytes(ObjectToWrite::PROOF);
             write_fields(ObjectToWrite::PROOF);
         } else {
@@ -94,13 +85,10 @@ void write(const ProverOutput& prover_output,
         }
     } else if (output_content == "vk") {
         if (output_data_type == "bytes") {
-            info("case bytes: ");
             write_bytes(ObjectToWrite::VK);
         } else if (output_data_type == "fields") {
-            info("case fields: ");
             write_fields(ObjectToWrite::VK);
         } else if (output_data_type == "bytes_and_fields") {
-            info("case bytes_and_fields: ");
             write_bytes(ObjectToWrite::VK);
             write_fields(ObjectToWrite::VK);
         } else {
@@ -108,15 +96,12 @@ void write(const ProverOutput& prover_output,
         }
     } else if (output_content == "proof_and_vk") {
         if (output_data_type == "bytes") {
-            info("case bytes: ");
             write_bytes(ObjectToWrite::PROOF);
             write_bytes(ObjectToWrite::VK);
         } else if (output_data_type == "fields") {
-            info("case fields: ");
             write_fields(ObjectToWrite::PROOF);
             write_fields(ObjectToWrite::VK);
         } else if (output_data_type == "bytes_and_fields") {
-            info("case bytes_and_fields: ");
             write_bytes(ObjectToWrite::PROOF);
             write_fields(ObjectToWrite::PROOF);
             write_bytes(ObjectToWrite::VK);

--- a/barretenberg/cpp/src/barretenberg/api/write_prover_output.hpp
+++ b/barretenberg/cpp/src/barretenberg/api/write_prover_output.hpp
@@ -90,7 +90,7 @@ void write(const ProverOutput& prover_output,
             write_bytes(ObjectToWrite::PROOF);
             write_fields(ObjectToWrite::PROOF);
         } else {
-            ASSERT("Invalid std::string for PROOF");
+            throw_or_abort("Invalid output_data_type for output_content proof");
         }
     } else if (output_content == "vk") {
         if (output_data_type == "bytes") {
@@ -104,7 +104,7 @@ void write(const ProverOutput& prover_output,
             write_bytes(ObjectToWrite::VK);
             write_fields(ObjectToWrite::VK);
         } else {
-            ASSERT("Invalid std::string for VK");
+            throw_or_abort("Invalid output_data_type for output_content vk");
         }
     } else if (output_content == "proof_and_vk") {
         if (output_data_type == "bytes") {
@@ -122,7 +122,7 @@ void write(const ProverOutput& prover_output,
             write_bytes(ObjectToWrite::VK);
             write_fields(ObjectToWrite::VK);
         } else {
-            throw_or_abort("Invalid std::string for PROOF_AND_VK");
+            throw_or_abort("Invalid output_data_type for output_content proof_and_vk");
         }
     } else {
         throw_or_abort("Invalid std::string");


### PR DESCRIPTION
I did e2e and e2e_all in https://github.com/AztecProtocol/aztec-packages/pull/11459 and the darwin builds didn't fail there, but they fail in master. This is basically a typo fix.