### PR TITLE
fix(ci): don't have checks go green immediately

### DIFF
--- a/.github/workflows/ci3-external.yml
+++ b/.github/workflows/ci3-external.yml
@@ -47,10 +47,6 @@ jobs:
             echo "Error: External PRs can't contain CI changes (forbidden files: $forbidden_changes)."
             exit 1
           fi
-          if [ ${{ github.event.pull_request.base.ref }} != "master" ]; then
-            echo "Error: External PRs can only target master, targeted: ${{ github.event.pull_request.base.ref }}."
-            exit 1
-          fi
           labeled="${{contains(github.event.pull_request.labels.*.name, 'ci-external') || contains(github.event.pull_request.labels.*.name, 'ci-external-once')}}""
           if [ "$labeled" == 'false' ]; then
             echo "External PRs need the 'ci-external' or 'ci-external-once' labels to run."

--- a/.github/workflows/ci3-external.yml
+++ b/.github/workflows/ci3-external.yml
@@ -5,6 +5,9 @@ on:
   # For external devs. Workflow file edits won't take effect in the PR.
   pull_request_target:
     types: [opened, synchronize, reopened, ready_for_review, labeled]
+    branches:
+      - master
+      - ad/fix/ci3-workflow
 
 concurrency:
   # Only allow one run per <forked-repo>/<branch>.

--- a/.github/workflows/ci3-external.yml
+++ b/.github/workflows/ci3-external.yml
@@ -80,6 +80,7 @@ jobs:
           # creds for being able to upload to cache.
           AWS_ACCESS_KEY_ID: ${{ secrets.AWS_ACCESS_KEY_ID }}
           AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
+          REF_NAME: repo-fork/${{ github.repository }}/${{ github.head_ref }}
           # We only test on amd64.
           ARCH: amd64
           LOG_ID: ${{ github.run_id }}

--- a/.github/workflows/ci3-external.yml
+++ b/.github/workflows/ci3-external.yml
@@ -48,7 +48,8 @@ jobs:
             echo "Error: External PRs can only target master, targeted: ${{ github.event.pull_request.base.ref }}."
             exit 1
           fi
-          if ${{contains(github.event.pull_request.labels.*.name, 'ci-external') || contains(github.event.pull_request.labels.*.name, 'ci-external-once')}}; then
+          labeled="${{contains(github.event.pull_request.labels.*.name, 'ci-external') || contains(github.event.pull_request.labels.*.name, 'ci-external-once')}}"
+          if [ "$labeled" = false ]; then
             echo "External PRs need the 'ci-external' or 'ci-external-once' labels to run."
             exit 1
           fi

--- a/.github/workflows/ci3-external.yml
+++ b/.github/workflows/ci3-external.yml
@@ -41,13 +41,13 @@ jobs:
           github.event.pull_request.head.repo.full_name != github.repository
         run: |
           set -o pipefail
-          git fetch origin ${{ github.event.pull_request.base.ref }} --depth=1
+          git fetch origin ${{ github.event.pull_request.base.ref }} --depth=1 &>/dev/null
           forbidden_changes=$(git diff --name-only origin/${{ github.event.pull_request.base.ref }} HEAD -- ci3 .github ci.sh)
           if echo "$forbidden_changes" | grep -q .; then
             echo "Error: External PRs can't contain CI changes (forbidden files: $forbidden_changes)."
             exit 1
           fi
-          labeled="${{contains(github.event.pull_request.labels.*.name, 'ci-external') || contains(github.event.pull_request.labels.*.name, 'ci-external-once')}}""
+          labeled="${{contains(github.event.pull_request.labels.*.name, 'ci-external') || contains(github.event.pull_request.labels.*.name, 'ci-external-once')}}"
           if [ "$labeled" == 'false' ]; then
             echo "External PRs need the 'ci-external' or 'ci-external-once' labels to run."
             exit 1

--- a/.github/workflows/ci3-external.yml
+++ b/.github/workflows/ci3-external.yml
@@ -1,0 +1,87 @@
+# CI for external Aztec contributors. Like ci3.yml, but more locked down.
+name: CI3 (External)
+
+on:
+  # For external devs. Workflow file edits won't take effect in the PR.
+  pull_request_target:
+    types: [opened, synchronize, reopened, ready_for_review, labeled]
+
+concurrency:
+  # Only allow one run per <forked-repo>/<branch>.
+  group: |
+    ci3-external-${{format('{0}/{1}', github.event.pull_request.head.repo.full_name, github.head_ref)}}
+  cancel-in-progress: true
+
+jobs:
+  ci-external:
+    runs-on: ubuntu-latest
+    # exclusive with ci3.yml, only run on forks.
+    if: github.event.pull_request.head.repo.full_name != github.repository
+    steps:
+      #############
+      # Prepare Env
+      #############
+      - name: Checkout
+        uses: actions/checkout@v4
+        with:
+          # The commit to checkout.  We want our actual commit, and not the result of merging the PR to the target.
+          ref: ${{ github.event.pull_request.head.sha || github.sha }}
+
+      - name: Fail If Draft
+        if: github.event.pull_request.draft && (github.event.action != 'labeled' || github.event.label.name != 'trigger-workflow')
+        run: echo "CI is not run on drafts." && exit 1
+
+      - name: External Contributor Checks
+        # Run only if a pull request event type and we have a forked repository origin.
+        if: |
+          (github.event_name == 'pull_request' || github.event_name == 'pull_request_target') &&
+          github.event.pull_request.head.repo.full_name != github.repository
+        run: |
+          set -o pipefail
+          git fetch origin ${{ github.event.pull_request.base.ref }} --depth=1
+          forbidden_changes=$(git diff --name-only origin/${{ github.event.pull_request.base.ref }} HEAD -- ci3 .github ci.sh)
+          if echo "$forbidden_changes" | grep -q .; then
+            echo "Error: External PRs can't contain CI changes (forbidden files: $forbidden_changes)."
+            exit 1
+          fi
+          if [ ${{ github.event.pull_request.base.ref }} != "master" ]; then
+            echo "Error: External PRs can only target master, targeted: ${{ github.event.pull_request.base.ref }}."
+            exit 1
+          fi
+          labeled="${{contains(github.event.pull_request.labels.*.name, 'ci-external') || contains(github.event.pull_request.labels.*.name, 'ci-external-once')}}""
+          if [ "$labeled" == 'false' ]; then
+            echo "External PRs need the 'ci-external' or 'ci-external-once' labels to run."
+            exit 1
+          fi
+          # Remove any ci-external-once labels.
+          GITHUB_TOKEN=${{ secrets.AZTEC_BOT_GITHUB_TOKEN }} gh pr edit ${{ github.event.pull_request.number }} --remove-label "ci-external-once"
+
+      - name: CI Full Override
+        # TODO consolidate legacy labels to just ci-full.
+        if: |
+          contains(github.event.pull_request.labels.*.name, 'e2e-all') ||
+          contains(github.event.pull_request.labels.*.name, 'network-all') ||
+          contains(github.event.pull_request.labels.*.name, 'ci-full')
+        run: echo "CI_FULL=1" >> $GITHUB_ENV
+
+      - name: Setup
+        run: |
+          # Ensure we can SSH into the spot instances we request.
+          mkdir -p ~/.ssh
+          echo ${{ secrets.BUILD_INSTANCE_SSH_KEY }} | base64 --decode > ~/.ssh/build_instance_key
+          chmod 600 ~/.ssh/build_instance_key
+
+      #############
+      # Run
+      #############
+      - name: Run
+        env:
+          # We need to pass these creds to start the AWS ec2 instance.
+          # They are not injected into that instance. Instead, it has minimal
+          # creds for being able to upload to cache.
+          AWS_ACCESS_KEY_ID: ${{ secrets.AWS_ACCESS_KEY_ID }}
+          AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
+          ARCH: ${{ matrix.settings.arch }}
+          LOG_ID: ${{ github.run_id }}
+        run: |
+          ./ci.sh ec2

--- a/.github/workflows/ci3-external.yml
+++ b/.github/workflows/ci3-external.yml
@@ -80,7 +80,8 @@ jobs:
           # creds for being able to upload to cache.
           AWS_ACCESS_KEY_ID: ${{ secrets.AWS_ACCESS_KEY_ID }}
           AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
-          ARCH: ${{ matrix.settings.arch }}
+          # We only test on amd64.
+          ARCH: amd64
           LOG_ID: ${{ github.run_id }}
         run: |
           ./ci.sh ec2

--- a/.github/workflows/ci3-external.yml
+++ b/.github/workflows/ci3-external.yml
@@ -44,7 +44,7 @@ jobs:
             echo "Error: External PRs can't contain CI changes (forbidden files: $forbidden_changes)."
             exit 1
           fi
-          if [ ${{ github.event.pull_request.base.ref }} != "ad/fix/ci3-workflow" ]; then
+          if [ ${{ github.event.pull_request.base.ref }} != "master" ]; then
             echo "Error: External PRs can only target master, targeted: ${{ github.event.pull_request.base.ref }}."
             exit 1
           fi

--- a/.github/workflows/ci3-external.yml
+++ b/.github/workflows/ci3-external.yml
@@ -5,9 +5,6 @@ on:
   # For external devs. Workflow file edits won't take effect in the PR.
   pull_request_target:
     types: [opened, synchronize, reopened, ready_for_review, labeled]
-    branches:
-      - master
-      - ad/fix/ci3-workflow
 
 concurrency:
   # Only allow one run per <forked-repo>/<branch>.
@@ -47,8 +44,11 @@ jobs:
             echo "Error: External PRs can't contain CI changes (forbidden files: $forbidden_changes)."
             exit 1
           fi
-          labeled="${{contains(github.event.pull_request.labels.*.name, 'ci-external') || contains(github.event.pull_request.labels.*.name, 'ci-external-once')}}"
-          if [ "$labeled" == 'false' ]; then
+          if [ ${{ github.event.pull_request.base.ref }} != "ad/fix/ci3-workflow" ]; then
+            echo "Error: External PRs can only target master, targeted: ${{ github.event.pull_request.base.ref }}."
+            exit 1
+          fi
+          if ${{contains(github.event.pull_request.labels.*.name, 'ci-external') || contains(github.event.pull_request.labels.*.name, 'ci-external-once')}}; then
             echo "External PRs need the 'ci-external' or 'ci-external-once' labels to run."
             exit 1
           fi

--- a/.github/workflows/ci3.yml
+++ b/.github/workflows/ci3.yml
@@ -8,12 +8,21 @@ on:
       - master
     tags:
       - "v*"
-  # For internal devs.
+  # Internal devs only: Ran when changes DO include CI configuration files.
+  # If an external dev ever runs this, it won't have secrets. We warn them about the offending files they edited.
   pull_request:
     types: [opened, synchronize, reopened, ready_for_review, labeled]
-  # For external devs. Workflow file edits won't take effect in the PR.
+    paths:
+      - 'ci3/**'
+      - '.github/**'
+      - 'ci.sh'
+  # For all cases where ci files not touched. Workflow file edits won't take effect in the PR.
   pull_request_target:
     types: [opened, synchronize, reopened, ready_for_review, labeled]
+    paths-ignore:
+      - 'ci3/**'
+      - '.github/**'
+      - 'ci.sh'
 
 concurrency:
   # On master or workflow_dispatch (checked via event_name) the group id is the unique run_id so we get parallel runs.
@@ -29,12 +38,6 @@ concurrency:
 jobs:
   ci:
     runs-on: ubuntu-latest
-    # Always allow 'push' and 'workflow_dispatch' jobs. Otherwise, only run pull_request events on internal PRs and pull_request_target on external PRs.
-    if: |
-      github.event_name == 'push' ||
-      github.event_name == 'workflow_dispatch' ||
-      (github.event_name == 'pull_request' && github.event.pull_request.head.repo.full_name == github.repository) ||
-      (github.event_name == 'pull_request_target' && github.event.pull_request.head.repo.full_name != github.repository)
     strategy:
       fail-fast: false
       matrix:
@@ -56,25 +59,27 @@ jobs:
 
       - name: Fail If Draft
         if: github.event.pull_request.draft && (github.event.action != 'labeled' || github.event.label.name != 'trigger-workflow')
-        run: echo "CI is not run on drafts." && exit 1
+        run: echo "CI is not run on drafts (unless ./ci.sh trigger-workflow is used)." && exit 1
 
-      - name: External Contributor Labels and Target
+      - name: External Contributor Checks
+        # Run only if a pull request event type and we have a forked repository origin.
         if: |
-          github.event_name == 'pull_request_target' &&
-          contains(github.event.pull_request.labels.*.name, 'ci-external') == false &&
-          contains(github.event.pull_request.labels.*.name, 'ci-external-once') == false
-        run: echo "External PRs need the 'ci-external' or 'ci-external-once' labels to run." && exit 1
-
-      - name: External Contributor Changes
-        if: github.event_name == 'pull_request_target'
+          (github.event_name == 'pull_request' || github.event_name == 'pull_request_target') &&
+          github.event.pull_request.head.repo.full_name != github.repository
         run: |
           set -o pipefail
           git fetch origin ${{ github.event.pull_request.base.ref }} --depth=1
           if git diff --name-only origin/${{ github.event.pull_request.base.ref }} HEAD -- ci3 .github ci.sh | grep -q .; then
-            echo "Error: External PRs can't contain CI changes." && exit 1
+            echo "Error: External PRs can't contain CI changes."
+            exit 1
           fi
           if [ ${{ github.event.pull_request.base.ref }} != "master" ]; then
-            echo "Error: External PRs can only target master, targeted: ${{ github.event.pull_request.base.ref }}." && exit 1
+            echo "Error: External PRs can only target master, targeted: ${{ github.event.pull_request.base.ref }}."
+            exit 1
+          fi
+          if [ ${{ contains(github.event.pull_request.labels.*.name, 'ci-external') || contains(github.event.pull_request.labels.*.name, 'ci-external-once')}} == 'false' ]; then
+            echo "External PRs need the 'ci-external' or 'ci-external-once' labels to run."
+            exit 1
           fi
           # Remove any ci-external-once labels.
           GITHUB_TOKEN=${{ secrets.AZTEC_BOT_GITHUB_TOKEN }} gh pr edit ${{ github.event.pull_request.number }} --remove-label "ci-external-once"
@@ -88,6 +93,8 @@ jobs:
         run: echo "CI_FULL=1" >> $GITHUB_ENV
 
       - name: Setup
+        env:
+          GITHUB_TOKEN: ${{ secrets.AZTEC_BOT_GITHUB_TOKEN }}
         run: |
           # Ensure we can SSH into the spot instances we request.
           mkdir -p ~/.ssh

--- a/.github/workflows/ci3.yml
+++ b/.github/workflows/ci3.yml
@@ -14,13 +14,9 @@ on:
 
 concurrency:
   # On master or workflow_dispatch (checked via event_name) the group id is the unique run_id so we get parallel runs.
-  # On PR's the group id is the ref_name so only 1 can run at a time. Include the repo in case it is an external PR.
+  # On PR's the group id is the ref_name so only 1 can run at a time.
   group: |
-    ci3-${{
-      (github.event_name == 'push' || github.event_name == 'workflow_dispatch') &&
-      github.run_id ||
-      github.head_ref
-    }}
+    ci3-${{(github.event_name == 'push' || github.event_name == 'workflow_dispatch') && github.run_id || github.head_ref }}
   cancel-in-progress: true
 
 jobs:

--- a/.github/workflows/ci3.yml
+++ b/.github/workflows/ci3.yml
@@ -1,4 +1,5 @@
 # CI for Aztec. At a high-level, runs ./bootstrap.sh ci in root. See root README.md for more details.
+# Only for internal devs. For external devs, see ci3-external.yml.
 name: CI3
 
 on:
@@ -8,36 +9,25 @@ on:
       - master
     tags:
       - "v*"
-  # Internal devs only: Ran when changes DO include CI configuration files.
-  # If an external dev ever runs this, it won't have secrets. We warn them about the offending files they edited.
   pull_request:
     types: [opened, synchronize, reopened, ready_for_review, labeled]
-    paths:
-      - 'ci3/**'
-      - '.github/**'
-      - 'ci.sh'
-  # For all cases where ci files not touched. We run additional checks for forked repository origins.
-  pull_request_target:
-    types: [opened, synchronize, reopened, ready_for_review, labeled]
-    paths-ignore:
-      - 'ci3/**'
-      - '.github/**'
-      - 'ci.sh'
 
 concurrency:
   # On master or workflow_dispatch (checked via event_name) the group id is the unique run_id so we get parallel runs.
   # On PR's the group id is the ref_name so only 1 can run at a time. Include the repo in case it is an external PR.
   group: |
-    ci3-${{ github.event_name }}-${{
+    ci3-${{
       (github.event_name == 'push' || github.event_name == 'workflow_dispatch') &&
       github.run_id ||
-      format('{0}/{1}', github.event.pull_request.head.repo.full_name, github.head_ref)
+      github.head_ref
     }}
   cancel-in-progress: true
 
 jobs:
   ci:
     runs-on: ubuntu-latest
+    # exclusive with ci3-external.yml: if it is a pull request target only run if it is NOT a fork.
+    if: github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name == github.repository
     strategy:
       fail-fast: false
       matrix:
@@ -59,31 +49,7 @@ jobs:
 
       - name: Fail If Draft
         if: github.event.pull_request.draft && (github.event.action != 'labeled' || github.event.label.name != 'trigger-workflow')
-        run: echo "CI is not run on drafts (unless ./ci.sh trigger is used)." && exit 1
-
-      - name: External Contributor Checks
-        # Run only if a pull request event type and we have a forked repository origin.
-        if: |
-          (github.event_name == 'pull_request' || github.event_name == 'pull_request_target') &&
-          github.event.pull_request.head.repo.full_name != github.repository
-        run: |
-          set -o pipefail
-          git fetch origin ${{ github.event.pull_request.base.ref }} --depth=1
-          if git diff --name-only origin/${{ github.event.pull_request.base.ref }} HEAD -- ci3 .github ci.sh | grep -q .; then
-            echo "Error: External PRs can't contain CI changes."
-            exit 1
-          fi
-          if [ ${{ github.event.pull_request.base.ref }} != "master" ]; then
-            echo "Error: External PRs can only target master, targeted: ${{ github.event.pull_request.base.ref }}."
-            exit 1
-          fi
-          labeled="${{contains(github.event.pull_request.labels.*.name, 'ci-external') || contains(github.event.pull_request.labels.*.name, 'ci-external-once')}}""
-          if [ "$labeled" == 'false' ]; then
-            echo "External PRs need the 'ci-external' or 'ci-external-once' labels to run."
-            exit 1
-          fi
-          # Remove any ci-external-once labels.
-          GITHUB_TOKEN=${{ secrets.AZTEC_BOT_GITHUB_TOKEN }} gh pr edit ${{ github.event.pull_request.number }} --remove-label "ci-external-once"
+        run: echo "CI is not run on drafts." && exit 1
 
       - name: CI Full Override
         # TODO consolidate legacy labels to just ci-full.
@@ -107,17 +73,13 @@ jobs:
         env:
           AWS_ACCESS_KEY_ID: ${{ secrets.AWS_ACCESS_KEY_ID }}
           AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
+          GITHUB_TOKEN: ${{ secrets.AZTEC_BOT_GITHUB_TOKEN }}
           ARCH: ${{ matrix.settings.arch }}
           LOG_ID: ${{ github.run_id }}
+          NETLIFY_SITE_ID: ${{ secrets.NETLIFY_SITE_ID }}
+          NETLIFY_AUTH_TOKEN: ${{ secrets.NETLIFY_AUTH_TOKEN }}
+          DOCKERHUB_PASSWORD: ${{ secrets.DOCKERHUB_PASSWORD }}
         run: |
-          # AWS access keys are used to create the ec2. Enough credentials exist in the AMI to push cache objects.
-          # We take care to not pass any additional secrets here.
-          if ${{ github.event_name != 'pull_request_target' && github.event.pull_request.head.repo.full_name != github.repository }}; then
-            export NETLIFY_SITE_ID=${{ secrets.NETLIFY_SITE_ID }}
-            export NETLIFY_AUTH_TOKEN=${{ secrets.NETLIFY_AUTH_TOKEN }}
-            export DOCKERHUB_PASSWORD=${{ secrets.DOCKERHUB_PASSWORD }}
-            export GITHUB_TOKEN=${{ secrets.AZTEC_BOT_GITHUB_TOKEN }}
-          fi
           ./ci.sh ec2
 
       - name: Download benchmarks
@@ -161,7 +123,7 @@ jobs:
 
   ci-grind:
     runs-on: ubuntu-latest
-    if: github.event_name == 'push' && !startsWith(github.ref, 'refs/tags/') && github.repository.fork == false
+    if: github.event_name == 'push' && !startsWith(github.ref, 'refs/tags/')
     strategy:
       matrix:
         number: [1, 2, 3, 4, 5]
@@ -198,7 +160,7 @@ jobs:
 
   notify:
     runs-on: ubuntu-latest
-    if: github.event_name == 'push' && failure() && github.repository.fork == false
+    if: github.event_name == 'push' && failure()
     needs:
       - ci
       - ci-grind

--- a/.github/workflows/ci3.yml
+++ b/.github/workflows/ci3.yml
@@ -69,8 +69,9 @@ jobs:
         run: |
           set -o pipefail
           git fetch origin ${{ github.event.pull_request.base.ref }} --depth=1
-          if git diff --name-only origin/${{ github.event.pull_request.base.ref }} HEAD -- ci3 .github ci.sh | grep -q .; then
-            echo "Error: External PRs can't contain CI changes."
+          forbidden_changes=$(git diff --name-only origin/${{ github.event.pull_request.base.ref }} HEAD -- ci3 .github ci.sh)
+          if echo "$forbidden_changes" | grep -q .; then
+            echo "Error: External PRs can't contain CI changes (forbidden files: $forbidden_changes)."
             exit 1
           fi
           if [ ${{ github.event.pull_request.base.ref }} != "master" ]; then

--- a/.github/workflows/ci3.yml
+++ b/.github/workflows/ci3.yml
@@ -77,7 +77,8 @@ jobs:
             echo "Error: External PRs can only target master, targeted: ${{ github.event.pull_request.base.ref }}."
             exit 1
           fi
-          if [ ${{ contains(github.event.pull_request.labels.*.name, 'ci-external') || contains(github.event.pull_request.labels.*.name, 'ci-external-once')}} == 'false' ]; then
+          labeled="${{ contains(github.event.pull_request.labels.*.name, 'ci-external') || contains(github.event.pull_request.labels.*.name, 'ci-external-once')}}""
+          if [ "$labeled" == 'false' ]; then
             echo "External PRs need the 'ci-external' or 'ci-external-once' labels to run."
             exit 1
           fi

--- a/.github/workflows/ci3.yml
+++ b/.github/workflows/ci3.yml
@@ -59,7 +59,7 @@ jobs:
 
       - name: Fail If Draft
         if: github.event.pull_request.draft && (github.event.action != 'labeled' || github.event.label.name != 'trigger-workflow')
-        run: echo "CI is not run on drafts (unless ./ci.sh trigger-workflow is used)." && exit 1
+        run: echo "CI is not run on drafts (unless ./ci.sh trigger is used)." && exit 1
 
       - name: External Contributor Checks
         # Run only if a pull request event type and we have a forked repository origin.

--- a/.github/workflows/ci3.yml
+++ b/.github/workflows/ci3.yml
@@ -110,7 +110,7 @@ jobs:
           ARCH: ${{ matrix.settings.arch }}
           LOG_ID: ${{ github.run_id }}
         run: |
-          # AWS access keys are used to create the ec2. Enough credentials exist in the AMI to push cache objects.
+          # AWS access keys are used to create the ec2. Enough credentials exist in the AMI only to push cache objects.
           # We take care to not pass any additional secrets here.
           if ${{ github.event_name != 'pull_request_target' && github.event.pull_request.head.repo.full_name != github.repository }}; then
             export NETLIFY_SITE_ID=${{ secrets.NETLIFY_SITE_ID }}

--- a/.github/workflows/ci3.yml
+++ b/.github/workflows/ci3.yml
@@ -107,13 +107,17 @@ jobs:
         env:
           AWS_ACCESS_KEY_ID: ${{ secrets.AWS_ACCESS_KEY_ID }}
           AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
-          GITHUB_TOKEN: ${{ secrets.AZTEC_BOT_GITHUB_TOKEN }}
           ARCH: ${{ matrix.settings.arch }}
           LOG_ID: ${{ github.run_id }}
-          NETLIFY_SITE_ID: ${{ secrets.NETLIFY_SITE_ID }}
-          NETLIFY_AUTH_TOKEN: ${{ secrets.NETLIFY_AUTH_TOKEN }}
-          DOCKERHUB_PASSWORD: ${{ secrets.DOCKERHUB_PASSWORD }}
         run: |
+          # AWS access keys are used to create the ec2. Enough credentials exist in the AMI to push cache objects.
+          # We take care to not pass any additional secrets here.
+          if ${{ github.event_name != 'pull_request_target' && github.event.pull_request.head.repo.full_name != github.repository }}; then
+            export NETLIFY_SITE_ID=${{ secrets.NETLIFY_SITE_ID }}
+            export NETLIFY_AUTH_TOKEN=${{ secrets.NETLIFY_AUTH_TOKEN }}
+            export DOCKERHUB_PASSWORD=${{ secrets.DOCKERHUB_PASSWORD }}
+            export GITHUB_TOKEN=${{ secrets.AZTEC_BOT_GITHUB_TOKEN }}
+          fi
           ./ci.sh ec2
 
       - name: Download benchmarks

--- a/.github/workflows/ci3.yml
+++ b/.github/workflows/ci3.yml
@@ -93,8 +93,6 @@ jobs:
         run: echo "CI_FULL=1" >> $GITHUB_ENV
 
       - name: Setup
-        env:
-          GITHUB_TOKEN: ${{ secrets.AZTEC_BOT_GITHUB_TOKEN }}
         run: |
           # Ensure we can SSH into the spot instances we request.
           mkdir -p ~/.ssh

--- a/.github/workflows/ci3.yml
+++ b/.github/workflows/ci3.yml
@@ -16,7 +16,7 @@ on:
       - 'ci3/**'
       - '.github/**'
       - 'ci.sh'
-  # For all cases where ci files not touched. Workflow file edits won't take effect in the PR.
+  # For all cases where ci files not touched. We run additional checks for forked repository origins.
   pull_request_target:
     types: [opened, synchronize, reopened, ready_for_review, labeled]
     paths-ignore:
@@ -77,7 +77,7 @@ jobs:
             echo "Error: External PRs can only target master, targeted: ${{ github.event.pull_request.base.ref }}."
             exit 1
           fi
-          labeled="${{ contains(github.event.pull_request.labels.*.name, 'ci-external') || contains(github.event.pull_request.labels.*.name, 'ci-external-once')}}""
+          labeled="${{contains(github.event.pull_request.labels.*.name, 'ci-external') || contains(github.event.pull_request.labels.*.name, 'ci-external-once')}}""
           if [ "$labeled" == 'false' ]; then
             echo "External PRs need the 'ci-external' or 'ci-external-once' labels to run."
             exit 1

--- a/ci3/bootstrap_ec2
+++ b/ci3/bootstrap_ec2
@@ -102,7 +102,7 @@ container_script=$(cat <<EOF
   export DRY_RUN=${DRY_RUN:-0}
   source ci3/source
 
-  if [ -n "${DOCKERHUB_PASSWORD:-}" ] && ([ "$REF_NAME" == "master" ] || semver check "$REF_NAME"); then
+  if [ -n "${DOCKERHUB_PASSWORD:-}" ]; then
     echo ${DOCKERHUB_PASSWORD:-} | docker login -u aztecprotocolci --password-stdin
   fi
   echo "env: REF_NAME=$REF_NAME COMMIT_HASH=$COMMIT_HASH CURRENT_VERSION=$CURRENT_VERSION CI_FULL=$CI_FULL DRY_RUN=${DRY_RUN:-0}"

--- a/docs/bootstrap.sh
+++ b/docs/bootstrap.sh
@@ -37,6 +37,7 @@ function build_and_preview {
 # If we're an AMD64 CI run and have a PR, do a preview release.
 function release_preview {
   if [ -z "${NETLIFY_SITE_ID:-}" ] || [ -z "${NETLIFY_AUTH_TOKEN:-}" ]; then
+    echo "No netlify credentials available, skipping release preview."
     return
   fi
 


### PR DESCRIPTION
We can't have overlapping check names here. We have to split this out to its own repo. This is probably a good separation of concerns, too, to prevent people just leaking secrets without stopping to think.