### PR TITLE
fix(docs): Escape $ in notes page

### DIFF
--- a/docs/docs/aztec/concepts/storage/notes.md
+++ b/docs/docs/aztec/concepts/storage/notes.md
@@ -18,7 +18,7 @@ When a note is updated, Aztec nullifies the original commitment in the note hash
 
 <Image img={require("/img/public-and-private-state-diagram.png")} />
 
-Notes are comparable to cash, with some slight differences. When you want to spend $3.50 USD in real life, you give your $5 note to a cashier who will keep $3.50 and give you separate notes that add up to $1.50. Using private notes on Aztec, when you want to spend a $5 note, you nullify it and create a $1.5 note with yourself as the owner and a $3.5 note with the recipient as the owner. Only you and the recipient are aware of $3.5 transaction, they are not aware that you "split" the $5 note.
+Notes are comparable to cash, with some slight differences. When you want to spend \$3.50 USD in real life, you give your \$5 note to a cashier who will keep \$3.50 and give you separate notes that add up to \$1.50. Using private notes on Aztec, when you want to spend a \$5 note, you nullify it and create a \$1.5 note with yourself as the owner and a \$3.5 note with the recipient as the owner. Only you and the recipient are aware of \$3.5 transaction, they are not aware that you "split" the \$5 note.
 
 ## Sending notes
 


### PR DESCRIPTION
Fixes a formatting error. Now renders properly:

![image](https://github.com/user-attachments/assets/0925e93e-edaa-45ad-8e2b-ab650720169b)
