### PR TITLE
fix: delete deploy hooks after they are applied

### DIFF
--- a/spartan/aztec-network/templates/deploy-l1-verifier.yaml
+++ b/spartan/aztec-network/templates/deploy-l1-verifier.yaml
@@ -8,7 +8,7 @@ metadata:
   annotations:
     "helm.sh/hook": post-install
     "helm.sh/hook-weight": "0"
-    "helm.sh/hook-delete-policy": before-hook-creation
+    "helm.sh/hook-delete-policy": hook-succeeded,hook-failed,before-hook-creation
 
 spec:
   template:

--- a/spartan/aztec-network/templates/setup-l2-contracts.yaml
+++ b/spartan/aztec-network/templates/setup-l2-contracts.yaml
@@ -8,7 +8,7 @@ metadata:
   annotations:
     "helm.sh/hook": post-install
     "helm.sh/hook-weight": "0"
-    "helm.sh/hook-delete-policy": before-hook-creation
+    "helm.sh/hook-delete-policy": hook-succeeded,hook-failed,before-hook-creation
 spec:
   template:
     metadata:


### PR DESCRIPTION
Delete setup-l2-contracts and deploy-l1-verifier after they are applied. This attempts to fix an issue where these jobs do not re-run after a deploymnet. 

`setup-l2-contracts` is idempotent but `deploy-l1-verifier` will deploy a new verifier instance everytime (this should be fine as the code would be the same)

Docs https://helm.sh/docs/topics/charts_hooks/#hook-deletion-policies
