### PR TITLE
fix: prevent MDB_KEYEXIST error on resending pending transactions

### DIFF
--- a/yarn-project/pxe/src/pxe_service/pxe_service.ts
+++ b/yarn-project/pxe/src/pxe_service/pxe_service.ts
@@ -481,9 +481,13 @@ export class PXEService implements PXE {
 
   public async sendTx(tx: Tx): Promise<TxHash> {
     const txHash = await tx.getTxHash();
-    if (await this.node.getTxEffect(txHash)) {
+    const existingTxEffect = await this.node.getTxEffect(txHash);
+
+    // Only throw if the tx is actually settled
+    if (existingTxEffect?.block) {
       throw new Error(`A settled tx with equal hash ${txHash.toString()} exists.`);
     }
+
     this.log.debug(`Sending transaction ${txHash}`);
     await this.node.sendTx(tx).catch(err => {
       throw this.contextualizeError(err, inspect(tx));


### PR DESCRIPTION
- Only throw "tx exists" error if transaction is actually settled in a block
- Allow resending transactions that are pending or were cancelled
- Fixes issue #12207 where cancelled transactions couldn't be resent