### PR TITLE
fix: remove duplicate 'the' 

### DIFF
--- a/barretenberg/cpp/docs/src/sumcheck-outline.md
+++ b/barretenberg/cpp/docs/src/sumcheck-outline.md
@@ -16,7 +16,7 @@ The implementation consists of several components.
   At the stage of proving their evaluations at the challenge point, the multilinear witness polynomials fed to Sumcheck must not reveal any private information.
   We use a modification of Construction 3 described in <a href=" https://eprint.iacr.org/2019/317">Libra</a> allowing the prover to open a new multilinear polynomial in \f$d\f$ variables, where \f$2^d\f$ is the circuit size, which is derived from the witnesses by adding a product of a random scalar and a public quadratic polynomial in \f$d\f$ variables
 
-- [Total Costs:](#ZKCosts) The effect of adding Libra technique and masking evaluations of multilinear witnesses is assessed, and the theoretical upper bound on prover's work is compared to the implementation costs.
+- [Total Costs:](#ZKCosts) The effect of adding Libra technique and masking evaluations of multilinear witnesses is assessed, and the oretical upper bound on prover's work is compared to the implementation costs.
 
 # Non ZK-Sumcheck Outline {#NonZKSumcheck}
 

--- a/barretenberg/cpp/src/barretenberg/commitment_schemes_recursion/ipa_recursive.test.cpp
+++ b/barretenberg/cpp/src/barretenberg/commitment_schemes_recursion/ipa_recursive.test.cpp
@@ -84,7 +84,7 @@ class IPARecursiveTests : public CommitmentTest<NativeCurve> {
     }
 
     /**
-     * @brief Checks the the IPA Recursive Verifier circuit is fixed no matter the ECCVM trace size.
+     * @brief Checks the IPA Recursive Verifier circuit is fixed no matter the ECCVM trace size.
      * @details Compares the builder blocks and locates which index in which block is different. Also compares the vks
      * to find which commitment is different.
      */

--- a/barretenberg/cpp/src/barretenberg/crypto/merkle_tree/node_store/content_addressed_cache.test.cpp
+++ b/barretenberg/cpp/src/barretenberg/crypto/merkle_tree/node_store/content_addressed_cache.test.cpp
@@ -478,7 +478,7 @@ void test_reverts_remove_all_deeper_commits(uint64_t max_index, uint32_t depth, 
 
     CacheType final_cache = cache;
 
-    // commit everything except the the first checkpoint
+    // commit everything except the first checkpoint
     for (uint64_t i = 1; i < num_levels; i++) {
         cache.commit();
     }

--- a/barretenberg/cpp/src/barretenberg/crypto/merkle_tree/signal.hpp
+++ b/barretenberg/cpp/src/barretenberg/crypto/merkle_tree/signal.hpp
@@ -4,7 +4,7 @@
 
 namespace bb::crypto::merkle_tree {
 /**
- * @brief Used in parallel insertions in the the IndexedTree. Workers signal to other following workes as they move up
+ * @brief Used in parallel insertions in the IndexedTree. Workers signal to other following workes as they move up
  * the level of the tree.
  *
  */

--- a/barretenberg/cpp/src/barretenberg/vm/avm/trace/trace.cpp
+++ b/barretenberg/cpp/src/barretenberg/vm/avm/trace/trace.cpp
@@ -3861,7 +3861,7 @@ AvmError AvmTraceBuilder::constrain_external_call(OpCode opcode,
     auto args_size =
         is_ok(error) ? static_cast<uint32_t>(unconstrained_read_from_memory(resolved_args_size_offset)) : 0;
 
-    // We need to consume the the gas cost of call, and then handle the amount allocated to the call
+    // We need to consume the gas cost of call, and then handle the amount allocated to the call
     // TODO: is cast okay? Should gas be read from memory as u32?
     bool out_of_gas = gas_trace_builder.constrain_gas(clk, opcode, /*dyn_gas_multiplier=*/args_size);
     // NOTE: we don't run out of gas if the gas specified by user code is > gas left.

--- a/docs/docs/protocol-specs/data-publication-and-availability/blobs.md
+++ b/docs/docs/protocol-specs/data-publication-and-availability/blobs.md
@@ -40,7 +40,7 @@ So to prove that we are publishing the correct tx effects, we just do this sum i
 
 Thankfully, there is a more efficient way, already implemented in the [`blob`](https://github.com/AztecProtocol/aztec-packages/tree/master/noir-projects/noir-protocol-circuits/crates/blob) crate in aztec-packages.
 
-Our goal is to efficiently show that our tx effects accumulated in the rollup circuits are the same $d_i$ s in the blob committed to by $C$ on L1. To do this, we can provide an *opening proof* for $C$. In the circuit, we evaluate the polynomial at a challenge value $z$ and return the result: $p(z) = y$. We then construct a [KZG proof](https://dankradfeist.de/ethereum/2020/06/16/kate-polynomial-commitments.html#kate-proofs) in typescript of this opening (which is actually a commitment to the the quotient polynomial $q(x)$), and verify it on L1 using the [point evaluation precompile](https://eips.ethereum.org/EIPS/eip-4844#point-evaluation-precompile) added as part of EIP-4844. It has inputs:
+Our goal is to efficiently show that our tx effects accumulated in the rollup circuits are the same $d_i$ s in the blob committed to by $C$ on L1. To do this, we can provide an *opening proof* for $C$. In the circuit, we evaluate the polynomial at a challenge value $z$ and return the result: $p(z) = y$. We then construct a [KZG proof](https://dankradfeist.de/ethereum/2020/06/16/kate-polynomial-commitments.html#kate-proofs) in typescript of this opening (which is actually a commitment to the quotient polynomial $q(x)$), and verify it on L1 using the [point evaluation precompile](https://eips.ethereum.org/EIPS/eip-4844#point-evaluation-precompile) added as part of EIP-4844. It has inputs:
 
 - `versioned_hash`: The `blobhash` for this $C$
 - `z`: The challenge value

--- a/l1-contracts/bootstrap.sh
+++ b/l1-contracts/bootstrap.sh
@@ -40,7 +40,7 @@ function build {
     # Step 1.5: Output storage information for the rollup contract.
     forge inspect src/core/Rollup.sol:Rollup storage > ./out/Rollup.sol/storage.json
 
-    # Step 2: Build the the generated verifier contract with optimization.
+    # Step 2: Build the generated verifier contract with optimization.
     forge build $(find generated -name '*.sol') \
       --optimize \
       --optimizer-runs 200

--- a/noir-projects/aztec-nr/aztec/src/discovery/private_logs.nr
+++ b/noir-projects/aztec-nr/aztec/src/discovery/private_logs.nr
@@ -36,7 +36,7 @@ pub unconstrained fn fetch_and_process_private_tagged_logs<Env>(
     _compute_note_hash_and_nullifier: ComputeNoteHashAndNullifier<Env>,
 ) {
     // We will eventually fetch tagged logs, decrypt and process them here, but for now we simply call the `syncNotes`
-    // oracle. This has PXE perform tag synchronization, log download, decryption, and finally calls to the the
+    // oracle. This has PXE perform tag synchronization, log download, decryption, and finally calls to the
     // `process_log` contract function with the decrypted payload, which will in turn call `do_process_log` with a
     // decrypted log, letting us continue the work outside of PXE.
     sync_notes();

--- a/noir/noir-repo/compiler/noirc_frontend/src/elaborator/enums.rs
+++ b/noir/noir-repo/compiler/noirc_frontend/src/elaborator/enums.rs
@@ -774,7 +774,7 @@ impl Elaborator<'_> {
         // This is simplified such that the first (consecutive) duplicates
         // we find we move to an else case. Each case afterward is then compared
         // to the else case. This could be improved in a couple ways:
-        // - Instead of the the first consecutive duplicates we find, we could
+        // - Instead of the first consecutive duplicates we find, we could
         //   expand the check to find non-consecutive duplicates as well.
         // - We should also ideally move the most duplicated case to the else
         //   case, not just the first duplicated case we find. I suspect in most


### PR DESCRIPTION
Im read [contributing guidelines](CONTRIBUTING.md) and remove this line. 

________________________________

the theoretical - the oretical `fix typo`
the the - the  `fix duplicate 8x`

________________________________
this is not spam
in this repository there are no more such errors