### PR TITLE
chore(p2p): run testbench with 200kb transactions

### DIFF
--- a/yarn-project/circuit-types/src/tx/tx.ts
+++ b/yarn-project/circuit-types/src/tx/tx.ts
@@ -278,10 +278,15 @@ export class Tx extends Gossipable {
     return clonedTx;
   }
 
-  static async random() {
+  /**
+   * Creates a random tx.
+   * @param randomProof - Whether to create a random proof - this will be random bytes of the full size.
+   * @returns A random tx.
+   */
+  static async random(randomProof = false) {
     return new Tx(
       PrivateKernelTailCircuitPublicInputs.emptyWithNullifier(),
-      ClientIvcProof.empty(),
+      randomProof ? ClientIvcProof.random() : ClientIvcProof.empty(),
       await ContractClassTxL2Logs.random(1, 1),
       [await PublicExecutionRequest.random()],
       await PublicExecutionRequest.random(),

--- a/yarn-project/p2p/src/testbench/testbench.ts
+++ b/yarn-project/p2p/src/testbench/testbench.ts
@@ -1,6 +1,5 @@
 import { Tx } from '@aztec/circuit-types';
 import { type ChainConfig } from '@aztec/circuit-types/config';
-import { mockTx } from '@aztec/circuit-types/testing';
 import { EthAddress } from '@aztec/foundation/eth-address';
 import { createLogger } from '@aztec/foundation/log';
 import { sleep } from '@aztec/foundation/sleep';

--- a/yarn-project/p2p/src/testbench/testbench.ts
+++ b/yarn-project/p2p/src/testbench/testbench.ts
@@ -1,3 +1,4 @@
+import { Tx } from '@aztec/circuit-types';
 import { type ChainConfig } from '@aztec/circuit-types/config';
 import { mockTx } from '@aztec/circuit-types/testing';
 import { EthAddress } from '@aztec/foundation/eth-address';
@@ -132,7 +133,7 @@ async function main() {
     logger.info('Workers Ready');
 
     // Send tx from client 0
-    const tx = await mockTx();
+    const tx = await Tx.random(/* randomProof */ true);
     processes[0].send({ type: 'SEND_TX', tx: tx.toBuffer() });
     logger.info('Transaction sent from client 0');
 


### PR DESCRIPTION
## Overview

Bumps transactions size use random ClientIVC proofs in testbench 

```
const CLIENT_IVC_PROOF_LENGTH = 172052;
const CLIENT_IVC_VK_LENGTH = 2730;
```
