### PR TITLE
fix(spartan): each tx bot replica gets its own l1 private key

### DIFF
--- a/.github/workflows/network-deploy.yml
+++ b/.github/workflows/network-deploy.yml
@@ -195,7 +195,6 @@ jobs:
               -var="AZTEC_DOCKER_IMAGE=${{ env.AZTEC_DOCKER_IMAGE }}" \
               -var="L1_DEPLOYMENT_PRIVATE_KEY=${{ secrets.SEPOLIA_L1_DEPLOYMENT_PRIVATE_KEY }}" \
               -var="L1_DEPLOYMENT_MNEMONIC=$L1_DEPLOYMENT_MNEMONIC" \
-              -var="BOT_L1_MNEMONIC=$L1_DEPLOYMENT_MNEMONIC" \
               -var="EXTERNAL_ETHEREUM_HOST=${{ env.EXTERNAL_ETHEREUM_HOST }}" \
               -var="EXTERNAL_ETHEREUM_CONSENSUS_HOST=${{ env.EXTERNAL_ETHEREUM_CONSENSUS_HOST }}" \
               -var="EXTERNAL_ETHEREUM_CONSENSUS_HOST_API_KEY=${{ secrets.SEPOLIA_API_KEY }}" \
@@ -208,7 +207,6 @@ jobs:
               -var="GKE_CLUSTER_CONTEXT=${{ env.GKE_CLUSTER_CONTEXT }}" \
               -var="AZTEC_DOCKER_IMAGE=${{ env.AZTEC_DOCKER_IMAGE }}" \
               -var="L1_DEPLOYMENT_MNEMONIC=${{ steps.get-mnemonic.outputs.mnemonic }}" \
-              -var="BOT_L1_MNEMONIC=$L1_DEPLOYMENT_MNEMONIC" \
               -lock=${{ inputs.respect_tf_lock }}
           fi
 
@@ -224,7 +222,6 @@ jobs:
               -var="AZTEC_DOCKER_IMAGE=${{ env.AZTEC_DOCKER_IMAGE }}" \
               -var="L1_DEPLOYMENT_PRIVATE_KEY=${{ secrets.SEPOLIA_L1_DEPLOYMENT_PRIVATE_KEY }}" \
               -var="L1_DEPLOYMENT_MNEMONIC=$L1_DEPLOYMENT_MNEMONIC" \
-              -var="BOT_L1_MNEMONIC=$L1_DEPLOYMENT_MNEMONIC" \
               -var="L1_DEPLOYMENT_SALT=${DEPLOYMENT_SALT:-$RANDOM}" \
               -var="EXTERNAL_ETHEREUM_HOST=${{ env.EXTERNAL_ETHEREUM_HOST }}" \
               -var="EXTERNAL_ETHEREUM_CONSENSUS_HOST=${{ env.EXTERNAL_ETHEREUM_CONSENSUS_HOST }}" \
@@ -240,7 +237,6 @@ jobs:
               -var="AZTEC_DOCKER_IMAGE=${{ env.AZTEC_DOCKER_IMAGE }}" \
               -var="L1_DEPLOYMENT_MNEMONIC=${{ steps.get-mnemonic.outputs.mnemonic }}" \
               -var="L1_DEPLOYMENT_SALT=${DEPLOYMENT_SALT:-$RANDOM}" \
-              -var="BOT_L1_MNEMONIC=$L1_DEPLOYMENT_MNEMONIC" \
               -out=tfplan \
               -lock=${{ inputs.respect_tf_lock }}
           fi

--- a/spartan/aztec-network/files/config/get-private-key.sh
+++ b/spartan/aztec-network/files/config/get-private-key.sh
@@ -20,6 +20,7 @@ export VALIDATOR_PRIVATE_KEY=$private_key
 export L1_PRIVATE_KEY=$private_key
 export SEQ_PUBLISHER_PRIVATE_KEY=$private_key
 export PROVER_PUBLISHER_PRIVATE_KEY=$private_key
+export BOT_L1_PRIVATE_KEY=$private_key
 EOF
 
 cat /shared/config/keys.env

--- a/spartan/aztec-network/templates/transaction-bot.yaml
+++ b/spartan/aztec-network/templates/transaction-bot.yaml
@@ -45,6 +45,29 @@ spec:
           emptyDir: {}
       initContainers:
         {{- include "aztec-network.serviceAddressSetupContainer" . | nindent 8 }}
+        - name: get-private-key
+          image: {{ .Values.images.foundry.image }}
+          imagePullPolicy: {{ .Values.images.foundry.pullPolicy }}
+          command:
+            - "/bin/sh"
+            - "-c"
+            - |
+              source /scripts/get-private-key.sh
+          volumeMounts:
+            - name: scripts
+              mountPath: /scripts
+            - name: config
+              mountPath: /shared/config
+          env:
+            - name: KEY_INDEX_START
+              value: {{ .Values.aztec.botKeyIndexStart | quote }}
+            - name: MNEMONIC
+              value: {{ .Values.aztec.l1DeploymentMnemonic }}
+            - name: POD_NAME
+              valueFrom:
+                fieldRef:
+                  fieldPath: metadata.name
+
         - name: wait-for-aztec-node
           image: "{{ .Values.images.curl.image }}"
           command:
@@ -79,6 +102,7 @@ spec:
             - |
               source /shared/config/service-addresses
               cat /shared/config/service-addresses
+              source /shared/config/keys.env
               {{- if .Values.bot.nodeUrl }}
               export AZTEC_NODE_URL={{ .Values.bot.nodeUrl }}
               {{- else if .Values.network.public }}
@@ -109,8 +133,6 @@ spec:
               value: "1"
             - name: LOG_LEVEL
               value: "{{ .Values.bot.logLevel }}"
-            - name: BOT_L1_MNEMONIC
-              value: "{{ .Values.aztec.l1DeploymentMnemonic }}"
             - name: BOT_PRIVATE_KEY
               value: "{{ .Values.bot.botPrivateKey }}"
             - name: BOT_TX_INTERVAL_SECONDS

--- a/spartan/aztec-network/templates/transaction-bot.yaml
+++ b/spartan/aztec-network/templates/transaction-bot.yaml
@@ -110,7 +110,7 @@ spec:
             - name: LOG_LEVEL
               value: "{{ .Values.bot.logLevel }}"
             - name: BOT_L1_MNEMONIC
-              value: "{{ .Values.bot.l1Mnemonic }}"
+              value: "{{ .Values.aztec.l1DeploymentMnemonic }}"
             - name: BOT_PRIVATE_KEY
               value: "{{ .Values.bot.botPrivateKey }}"
             - name: BOT_TX_INTERVAL_SECONDS

--- a/spartan/aztec-network/templates/transaction-bot.yaml
+++ b/spartan/aztec-network/templates/transaction-bot.yaml
@@ -1,6 +1,6 @@
 {{- if .Values.bot.enabled }}
 apiVersion: apps/v1
-kind: Deployment
+kind: StatefulSet
 metadata:
   name: {{ include "aztec-network.fullname" . }}-bot
   labels:

--- a/spartan/aztec-network/values.yaml
+++ b/spartan/aztec-network/values.yaml
@@ -58,6 +58,8 @@ aztec:
   ## The number of extra accounts to prefund
   extraAccountsStartIndex: 2000
   extraAccounts: 10
+
+  botKeyIndexStart: 3000
   l1Salt: "" # leave empty for random salt
 
 bootNode:

--- a/spartan/aztec-network/values.yaml
+++ b/spartan/aztec-network/values.yaml
@@ -204,7 +204,6 @@ bot:
   logLevel: "debug; info: aztec:simulator, json-rpc"
   replicas: 1
   botPrivateKey: "0xcafe"
-  l1Mnemonic: "test test test test test test test test test test test junk"
   txIntervalSeconds: 24
   privateTransfersPerTx: 0
   publicTransfersPerTx: 1

--- a/spartan/scripts/generate_devnet_config.sh
+++ b/spartan/scripts/generate_devnet_config.sh
@@ -13,6 +13,9 @@ export EXTRA_ACCOUNTS_START_INDEX=$(./read_value.sh "aztec.extraAccountsStartInd
 export NUMBER_OF_PROVER_KEYS=$(./read_value.sh "proverNode.replicas" $value_yamls)
 export PROVER_KEY_START_INDEX=$(./read_value.sh "aztec.proverKeyIndexStart" $value_yamls)
 
+export NUMBER_OF_BOT_KEYS=$(./read_value.sh "bot.replicas" $value_yamls)
+export BOT_KEY_START_INDEX=$(./read_value.sh "aztec.botKeyIndexStart" $value_yamls)
+
 export MNEMONIC=${MNEMONIC:-$(./read_value.sh "aztec.l1DeploymentMnemonic" $value_yamls)}
 export BLOCK_TIME=$(./read_value.sh "ethereum.blockTime" $value_yamls)
 export GAS_LIMIT=$(./read_value.sh "ethereum.gasLimit" $value_yamls)
@@ -21,8 +24,9 @@ export CHAIN_ID=$(./read_value.sh "ethereum.chainId" $value_yamls)
 VALIDATOR_KEY_INDICES=$(seq $VALIDATOR_KEY_START_INDEX $((VALIDATOR_KEY_START_INDEX + NUMBER_OF_VALIDATOR_KEYS - 1)))
 EXTRA_ACCOUNTS_INDICES=$(seq $EXTRA_ACCOUNTS_START_INDEX $((EXTRA_ACCOUNTS_START_INDEX + EXTRA_ACCOUNTS - 1)))
 PROVER_KEY_INDICES=$(seq $PROVER_KEY_START_INDEX $((PROVER_KEY_START_INDEX + NUMBER_OF_PROVER_KEYS - 1)))
+BOT_KEY_INDICES=$(seq $BOT_KEY_START_INDEX $((BOT_KEY_START_INDEX + NUMBER_OF_BOT_KEYS - 1)))
 
-export PREFUNDED_MNEMONIC_INDICES=$(echo "$VALIDATOR_KEY_INDICES $EXTRA_ACCOUNTS_INDICES $PROVER_KEY_INDICES" | tr ' ' '\n' | sort -u | tr '\n' ',' | sed 's/,$//')
+export PREFUNDED_MNEMONIC_INDICES=$(echo "$VALIDATOR_KEY_INDICES $EXTRA_ACCOUNTS_INDICES $PROVER_KEY_INDICES $BOT_KEY_INDICES" | tr ' ' '\n' | sort -u | tr '\n' ',' | sed 's/,$//')
 
 echo "Generating eth devnet config..."
 echo "PREFUNDED_MNEMONIC_INDICES: $PREFUNDED_MNEMONIC_INDICES"

--- a/spartan/scripts/test_kind.sh
+++ b/spartan/scripts/test_kind.sh
@@ -139,6 +139,5 @@ export AZTEC_SLOT_DURATION="$aztec_slot_duration"
 export AZTEC_EPOCH_DURATION="$aztec_epoch_duration"
 export AZTEC_PROOF_SUBMISSION_WINDOW="$aztec_proof_submission_window"
 export L1_ACCOUNT_MNEMONIC="$l1_account_mnemonic"
-export BOT_L1_MNEMONIC="$l1_account_mnemonic"
 
 yarn --cwd ../../yarn-project/end-to-end test --forceExit "$test"

--- a/spartan/terraform/deploy-release/variables.tf
+++ b/spartan/terraform/deploy-release/variables.tf
@@ -26,11 +26,6 @@ variable "L1_DEPLOYMENT_MNEMONIC" {
   default     = ""
 }
 
-variable "BOT_L1_MNEMONIC" {
-  type    = string
-  default = "test test test test test test test test test test test junk"
-}
-
 variable "L1_DEPLOYMENT_PRIVATE_KEY" {
   description = "Private key to use for the L1 contract deployments"
   type        = string

--- a/yarn-project/aztec/terraform/bot/main.tf
+++ b/yarn-project/aztec/terraform/bot/main.tf
@@ -159,7 +159,6 @@ resource "aws_ecs_task_definition" "aztec-bot" {
       ]
       environment = [
         { name = "BOT_L1_PRIVATE_KEY", value = var.BOT_L1_PRIVATE_KEY },
-        { name = "BOT_L1_MNEMONIC", value = var.BOT_L1_MNEMONIC },
         { name = "BOT_PRIVATE_KEY", value = var.BOT_PRIVATE_KEY },
         { name = "BOT_NO_START", value = var.BOT_NO_START },
         { name = "BOT_TX_INTERVAL_SECONDS", value = var.BOT_TX_INTERVAL_SECONDS },

--- a/yarn-project/aztec/terraform/bot/variables.tf
+++ b/yarn-project/aztec/terraform/bot/variables.tf
@@ -19,11 +19,6 @@ variable "BOT_L1_PRIVATE_KEY" {
   default = ""
 }
 
-variable "BOT_L1_MNEMONIC" {
-  type    = string
-  default = "test test test test test test test test test test test junk"
-}
-
 variable "BOT_PRIVATE_KEY" {
   type = string
 }

--- a/yarn-project/bot/src/factory.ts
+++ b/yarn-project/bot/src/factory.ts
@@ -213,7 +213,7 @@ export class BotFactory {
     if (!l1RpcUrl) {
       throw new Error('L1 Rpc url is required to bridge the fee juice to fund the deployment of the account.');
     }
-    const mnemonicOrPrivateKey = this.config.l1Mnemonic || this.config.l1PrivateKey;
+    const mnemonicOrPrivateKey = this.config.l1PrivateKey || this.config.l1Mnemonic;
     if (!mnemonicOrPrivateKey) {
       throw new Error(
         'Either a mnemonic or private key of an L1 account is required to bridge the fee juice to fund the deployment of the account.',


### PR DESCRIPTION
## Overview

Bot was using it's own l1 mnemonic to fund itself with fees, use the l1DeploymentMnemonic so it is funded

network deploy in gke
https://github.com/AztecProtocol/aztec-packages/actions/runs/13497815287/job/37708959120