### PR TITLE
fix: Node getBlockHeader returns undefined for non-existent blocks

### DIFF
--- a/yarn-project/aztec-node/src/aztec-node/server.test.ts
+++ b/yarn-project/aztec-node/src/aztec-node/server.test.ts
@@ -13,7 +13,7 @@ import type { ContractDataSource } from '@aztec/circuits.js/contract';
 import { GasFees } from '@aztec/circuits.js/gas';
 import { RollupValidationRequests } from '@aztec/circuits.js/kernel';
 import { MerkleTreeId, PublicDataTreeLeafPreimage } from '@aztec/circuits.js/trees';
-import { MaxBlockNumber } from '@aztec/circuits.js/tx';
+import { BlockHeader, GlobalVariables, MaxBlockNumber } from '@aztec/circuits.js/tx';
 import { EthAddress } from '@aztec/foundation/eth-address';
 import { Fr } from '@aztec/foundation/fields';
 import { type P2P } from '@aztec/p2p';
@@ -29,6 +29,7 @@ describe('aztec node', () => {
   let p2p: MockProxy<P2P>;
   let globalVariablesBuilder: MockProxy<GlobalVariableBuilder>;
   let merkleTreeOps: MockProxy<MerkleTreeReadOperations>;
+  let l2BlockSource: MockProxy<L2BlockSource>;
   let lastBlockNumber: number;
   let node: AztecNode;
   let feePayer: AztecAddress;
@@ -85,9 +86,8 @@ describe('aztec node', () => {
       getCommitted: () => merkleTreeOps,
     });
 
-    const l2BlockSource = mock<L2BlockSource>({
-      getBlockNumber: () => Promise.resolve(lastBlockNumber),
-    });
+    l2BlockSource = mock<L2BlockSource>();
+    l2BlockSource.getBlockNumber.mockImplementation(() => Promise.resolve(lastBlockNumber));
 
     const l2LogsSource = mock<L2LogsSource>();
 
@@ -205,6 +205,47 @@ describe('aztec node', () => {
       });
       // Tx with max block number >= current block number should be valid
       expect(await node.isValidTx(validMaxBlockNumberMetadata)).toEqual({ result: 'valid' });
+    });
+  });
+
+  describe('getters', () => {
+    describe('getBlockHeader', () => {
+      let initialHeader: BlockHeader;
+      let header1: BlockHeader;
+      let header2: BlockHeader;
+
+      beforeEach(() => {
+        initialHeader = BlockHeader.empty({ globalVariables: GlobalVariables.empty({ blockNumber: new Fr(0) }) });
+        header1 = BlockHeader.empty({ globalVariables: GlobalVariables.empty({ blockNumber: new Fr(1) }) });
+        header2 = BlockHeader.empty({ globalVariables: GlobalVariables.empty({ blockNumber: new Fr(2) }) });
+
+        merkleTreeOps.getInitialHeader.mockReturnValue(initialHeader);
+        l2BlockSource.getBlockNumber.mockResolvedValue(2);
+      });
+
+      it('returns requested block number', async () => {
+        l2BlockSource.getBlockHeader.mockResolvedValue(header1);
+        expect(await node.getBlockHeader(1)).toEqual(header1);
+      });
+
+      it('returns latest', async () => {
+        l2BlockSource.getBlockHeader.mockResolvedValue(header2);
+        expect(await node.getBlockHeader('latest')).toEqual(header2);
+      });
+
+      it('returns initial header on zero', async () => {
+        expect(await node.getBlockHeader(0)).toEqual(initialHeader);
+      });
+
+      it('returns initial header if no blocks mined', async () => {
+        l2BlockSource.getBlockNumber.mockResolvedValue(0);
+        expect(await node.getBlockHeader('latest')).toEqual(initialHeader);
+      });
+
+      it('returns undefined for non-existent block', async () => {
+        l2BlockSource.getBlockHeader.mockResolvedValue(undefined);
+        expect(await node.getBlockHeader(3)).toEqual(undefined);
+      });
     });
   });
 });

--- a/yarn-project/aztec-node/src/aztec-node/server.ts
+++ b/yarn-project/aztec-node/src/aztec-node/server.ts
@@ -198,6 +198,7 @@ export class AztecNodeService implements AztecNode, Traceable {
 
     // start both and wait for them to sync from the block source
     await Promise.all([p2pClient.start(), worldStateSynchronizer.start(), slasherClient.start()]);
+    log.verbose(`All Aztec Node subsystems synced`);
 
     const validatorClient = createValidatorClient(config, { p2pClient, telemetry, dateProvider, epochCache });
 
@@ -844,11 +845,10 @@ export class AztecNodeService implements AztecNode, Traceable {
    * Returns the currently committed block header, or the initial header if no blocks have been produced.
    * @returns The current committed block header.
    */
-  public async getBlockHeader(blockNumber: L2BlockNumber = 'latest'): Promise<BlockHeader> {
-    return (
-      (await this.getBlock(blockNumber === 'latest' ? -1 : blockNumber))?.header ??
-      this.worldStateSynchronizer.getCommitted().getInitialHeader()
-    );
+  public async getBlockHeader(blockNumber: L2BlockNumber = 'latest'): Promise<BlockHeader | undefined> {
+    return blockNumber === 0 || (blockNumber === 'latest' && (await this.blockSource.getBlockNumber()) === 0)
+      ? this.worldStateSynchronizer.getCommitted().getInitialHeader()
+      : this.blockSource.getBlockHeader(blockNumber);
   }
 
   /**

--- a/yarn-project/circuit-types/src/interfaces/aztec-node.ts
+++ b/yarn-project/circuit-types/src/interfaces/aztec-node.ts
@@ -402,7 +402,7 @@ export interface AztecNode
    * Returns the currently committed block header.
    * @returns The current committed block header.
    */
-  getBlockHeader(blockNumber?: L2BlockNumber): Promise<BlockHeader>;
+  getBlockHeader(blockNumber?: L2BlockNumber): Promise<BlockHeader | undefined>;
 
   /**
    * Simulates the public part of a transaction with the current state.
@@ -575,7 +575,7 @@ export const AztecNodeApiSchema: ApiSchemaFor<AztecNode> = {
 
   getPublicStorageAt: z.function().args(schemas.AztecAddress, schemas.Fr, L2BlockNumberSchema).returns(schemas.Fr),
 
-  getBlockHeader: z.function().args(optional(L2BlockNumberSchema)).returns(BlockHeader.schema),
+  getBlockHeader: z.function().args(optional(L2BlockNumberSchema)).returns(BlockHeader.schema.optional()),
 
   simulatePublicCalls: z.function().args(Tx.schema, optional(z.boolean())).returns(PublicSimulationOutput.schema),
 

--- a/yarn-project/circuits.js/src/tx/global_variables.ts
+++ b/yarn-project/circuits.js/src/tx/global_variables.ts
@@ -58,17 +58,18 @@ export class GlobalVariables {
     return new GlobalVariables(...GlobalVariables.getFields(fields));
   }
 
-  static empty(): GlobalVariables {
-    return new GlobalVariables(
-      Fr.ZERO,
-      Fr.ZERO,
-      Fr.ZERO,
-      Fr.ZERO,
-      Fr.ZERO,
-      EthAddress.ZERO,
-      AztecAddress.ZERO,
-      GasFees.empty(),
-    );
+  static empty(fields: Partial<FieldsOf<GlobalVariables>> = {}): GlobalVariables {
+    return GlobalVariables.from({
+      blockNumber: Fr.ZERO,
+      slotNumber: Fr.ZERO,
+      timestamp: Fr.ZERO,
+      chainId: Fr.ZERO,
+      version: Fr.ZERO,
+      coinbase: EthAddress.ZERO,
+      feeRecipient: AztecAddress.ZERO,
+      gasFees: GasFees.empty(),
+      ...fields,
+    });
   }
 
   static fromBuffer(buffer: Buffer | BufferReader): GlobalVariables {

--- a/yarn-project/pxe/src/kernel_oracle/index.ts
+++ b/yarn-project/pxe/src/kernel_oracle/index.ts
@@ -69,6 +69,9 @@ export class KernelOracle implements ProvingDataOracle {
 
   async getNoteHashTreeRoot(): Promise<Fr> {
     const header = await this.node.getBlockHeader(this.blockNumber);
+    if (!header) {
+      throw new Error(`No block header found for block number ${this.blockNumber}`);
+    }
     return header.state.partial.noteHashTree.root;
   }
 

--- a/yarn-project/pxe/src/synchronizer/synchronizer.ts
+++ b/yarn-project/pxe/src/synchronizer/synchronizer.ts
@@ -62,7 +62,12 @@ export class Synchronizer implements L2BlockStreamEventHandler {
         // block number in which each index is used it's all we can do.
         await this.db.resetNoteSyncData();
         // Update the header to the last block.
-        await this.db.setHeader(await this.node.getBlockHeader(event.blockNumber));
+        const newHeader = await this.node.getBlockHeader(event.blockNumber);
+        if (!newHeader) {
+          this.log.error(`Block header not found for block number ${event.blockNumber} during chain prune`);
+        } else {
+          await this.db.setHeader(newHeader);
+        }
         break;
       }
     }
@@ -82,7 +87,7 @@ export class Synchronizer implements L2BlockStreamEventHandler {
     }
     if (!currentHeader) {
       // REFACTOR: We should know the header of the genesis block without having to request it from the node.
-      await this.db.setHeader(await this.node.getBlockHeader(0));
+      await this.db.setHeader((await this.node.getBlockHeader(0))!);
     }
     await this.blockStream.sync();
   }


### PR DESCRIPTION
Aztec node's `getBlockHeader` returned the initial genesis header when queried for a non-existing block.
