### PR TITLE
refactor: getManaBaseFeeComponentsAt are zeros when not canonical

### DIFF
--- a/l1-contracts/src/core/libraries/Errors.sol
+++ b/l1-contracts/src/core/libraries/Errors.sol
@@ -73,7 +73,6 @@ library Errors {
   error Rollup__TryingToProveNonExistingBlock(); // 0x34ef4954
   error Rollup__UnavailableTxs(bytes32 txsHash); // 0x414906c3
   error Rollup__NonZeroDaFee(); // 0xd9c75f52
-  error Rollup__NonZeroL2Fee(); // 0x7e728abc
   error Rollup__InvalidBasisPointFee(uint256 basisPointFee); // 0x4292d136
   error Rollup__InvalidManaBaseFee(uint256 expected, uint256 actual); // 0x73b6d896
   error Rollup__StartAndEndNotSameEpoch(Epoch start, Epoch end);

--- a/l1-contracts/src/core/libraries/RollupLibs/FeeMath.sol
+++ b/l1-contracts/src/core/libraries/RollupLibs/FeeMath.sol
@@ -22,6 +22,7 @@ uint256 constant CONGESTION_UPDATE_FRACTION = 854700854;
 
 uint256 constant BLOB_GAS_PER_BLOB = 2 ** 17;
 uint256 constant GAS_PER_BLOB_POINT_EVALUATION = 50_000;
+uint256 constant BLOBS_PER_BLOCK = 3;
 
 struct OracleInput {
   int256 feeAssetPriceModifier;
@@ -116,9 +117,11 @@ library FeeMath {
     );
 
     EthValue dataCostPerMana = EthValue.wrap(
-      Math.mulDiv(3 * BLOB_GAS_PER_BLOB, _fees.blobFee, MANA_TARGET, Math.Rounding.Ceil)
+      Math.mulDiv(
+        BLOBS_PER_BLOCK * BLOB_GAS_PER_BLOB, _fees.blobFee, MANA_TARGET, Math.Rounding.Ceil
+      )
     );
-    uint256 gasUsed = L1_GAS_PER_BLOCK_PROPOSED + 3 * GAS_PER_BLOB_POINT_EVALUATION
+    uint256 gasUsed = L1_GAS_PER_BLOCK_PROPOSED + BLOBS_PER_BLOCK * GAS_PER_BLOB_POINT_EVALUATION
       + L1_GAS_PER_EPOCH_VERIFIED / _epochDuration;
     EthValue gasCostPerMana =
       EthValue.wrap(Math.mulDiv(gasUsed, _fees.baseFee, MANA_TARGET, Math.Rounding.Ceil));

--- a/l1-contracts/test/Rollup.t.sol
+++ b/l1-contracts/test/Rollup.t.sol
@@ -335,7 +335,8 @@ contract RollupTest is RollupBase {
 
     skipBlobCheck(address(rollup));
 
-    vm.expectRevert(abi.encodeWithSelector(Errors.Rollup__NonZeroL2Fee.selector));
+    // When not canonical, we expect the fee to be 0
+    vm.expectRevert(abi.encodeWithSelector(Errors.Rollup__InvalidManaBaseFee.selector, 0, 1));
     ProposeArgs memory args = ProposeArgs({
       header: header,
       archive: data.archive,


### PR DESCRIPTION
Fixes #10004 by returning 0's when calling `getManaBaseFeeComponentsAt`, also allowed us to slightly simpler check the header as we don't need the multiple paths then.