### PR TITLE
fix: Fix incorrect usage of stringify.value in prettyPrintNargoToml

### DIFF
--- a/boxes/scripts/utils.js
+++ b/boxes/scripts/utils.js
@@ -154,7 +154,7 @@ export function prettyPrintNargoToml(config) {
   const partialToml = stringify(withoutDependencies);
   const dependenciesToml = Object.entries(config.dependencies).map(
     ([name, dep]) => {
-      const depToml = stringify.value(dep);
+      const depToml = stringify(dep);
       return `${name} = ${depToml}`;
     },
   );


### PR DESCRIPTION
I noticed an issue where `stringify.value` was incorrectly used in the `prettyPrintNargoToml` function. The `stringify` method doesn't have a `value` property, and it should be directly used as `stringify(dep)` to serialize the dependency correctly. I've updated the code to fix this issue.