### PR TITLE
fix: Archiver can sync from scratch with pruneable blocks

### DIFF
--- a/yarn-project/archiver/src/archiver/data_retrieval.ts
+++ b/yarn-project/archiver/src/archiver/data_retrieval.ts
@@ -80,7 +80,9 @@ export async function retrieveBlocksFromRollup(
     retrievedBlocks.push(...newBlocks);
     searchStartBlock = lastLog.blockNumber! + 1n;
   } while (searchStartBlock <= searchEndBlock);
-  return retrievedBlocks;
+
+  // The asyncpool from processL2BlockProposedLogs will not necessarily return the blocks in order, so we sort them before returning.
+  return retrievedBlocks.sort((a, b) => Number(a.l1.blockNumber - b.l1.blockNumber));
 }
 
 /**

--- a/yarn-project/archiver/src/archiver/kv_archiver_store/block_store.ts
+++ b/yarn-project/archiver/src/archiver/kv_archiver_store/block_store.ts
@@ -106,7 +106,8 @@ export class BlockStore {
         const block = await this.getBlock(blockNumber);
 
         if (block === undefined) {
-          throw new Error(`Cannot remove block ${blockNumber} from the store, we don't have it`);
+          this.#log.warn(`Cannot remove block ${blockNumber} from the store since we don't have it`);
+          continue;
         }
         await this.#blocks.delete(block.data.number);
         await Promise.all(block.data.body.txEffects.map(tx => this.#txIndex.delete(tx.txHash.toString())));

--- a/yarn-project/end-to-end/bootstrap.sh
+++ b/yarn-project/end-to-end/bootstrap.sh
@@ -52,6 +52,7 @@ function test_cmds {
   echo "$prefix simple e2e_epochs/epochs_empty_blocks"
   echo "$prefix simple e2e_epochs/epochs_multi_proof"
   echo "$prefix simple e2e_epochs/epochs_proof_fails"
+  echo "$prefix simple e2e_epochs/epochs_sync_after_reorg"
   echo "$prefix simple e2e_escrow_contract"
   echo "$prefix simple e2e_event_logs"
 

--- a/yarn-project/end-to-end/src/e2e_epochs/epochs_sync_after_reorg.test.ts
+++ b/yarn-project/end-to-end/src/e2e_epochs/epochs_sync_after_reorg.test.ts
@@ -1,0 +1,47 @@
+import type { AztecNodeService } from '@aztec/aztec-node';
+import { type Logger } from '@aztec/aztec.js';
+import { executeTimeout } from '@aztec/foundation/timer';
+
+import { jest } from '@jest/globals';
+
+import { type EndToEndContext } from '../fixtures/utils.js';
+import { EpochsTestContext, L1_BLOCK_TIME_IN_S, L2_SLOT_DURATION_IN_L1_SLOTS } from './epochs_test.js';
+
+jest.setTimeout(1000 * 60 * 10);
+
+describe('e2e_epochs/epochs_sync_after_reorg', () => {
+  let context: EndToEndContext;
+  let logger: Logger;
+
+  let test: EpochsTestContext;
+
+  beforeEach(async () => {
+    test = await EpochsTestContext.setup({ startProverNode: false }); // no prover!
+    ({ context, logger } = test);
+  });
+
+  afterEach(async () => {
+    jest.restoreAllMocks();
+    await test.teardown();
+  });
+
+  // Regression for https://github.com/AztecProtocol/aztec-packages/issues/12206
+  it('new node can sync world-state after unpruned reorg', async () => {
+    // Wait until there are a few blocks in there
+    await test.waitUntilL2BlockNumber(5, L2_SLOT_DURATION_IN_L1_SLOTS * L1_BLOCK_TIME_IN_S * 5 + 30);
+
+    // Stop the node generating blocks
+    logger.warn(`Stopping the main node`);
+    await (context.aztecNode as AztecNodeService).stop();
+
+    // Wait for an extra epoch, so a reorg would invalidate these blocks
+    await test.waitUntilEpochStarts(2);
+
+    // Add a new node and watch it sync
+    // We add a timeout since the archiver never finishes syncing and this promise does not resolve is the bug is not fixed
+    logger.warn(`Syncing new node`);
+    const node = await executeTimeout(() => test.createNonValidatorNode(), 10_000, `new node sync`);
+    expect(await node.getBlockNumber()).toEqual(0);
+    logger.info(`Test succeeded`);
+  });
+});

--- a/yarn-project/stdlib/src/block/l2_block_downloader/l2_block_stream.ts
+++ b/yarn-project/stdlib/src/block/l2_block_downloader/l2_block_stream.ts
@@ -76,6 +76,7 @@ export class L2BlockStream {
       // If we are just starting, use the starting block number from the options.
       if (latestBlockNumber === 0 && this.opts.startingBlock !== undefined) {
         latestBlockNumber = Math.max(this.opts.startingBlock - 1, 0);
+        this.log.verbose(`Starting sync from block number ${latestBlockNumber}`);
       }
 
       // Request new blocks from the source.


### PR DESCRIPTION
Archiver was unable to sync successfully when there were blocks awaiting to be pruned. This was caused by:

- An error when fetching blocks, that caused them to be returned and processed out-of-order. This caused the "last processed L1 mark" to be incorrect, leading to the same L1 blocks to be downloaded more than once in subsequent archiver iterations. This is now fixed.

- An overzealous block store, that blew up when requesting it to unwind a block it didn't have. It now just warns.

- The archiver downloading blocks that are unwound immediately after, since the check for pruning is done after blocks download. This is not fixed in this PR, since naively adding a check for pruning _before_ blocks are downloaded would mean significant more calls to `Rollup.status`, since it would get called every time and not just when there are new blocks. Not fixing this means that, in an initial sync, some additional blocks (up to 2 epochs worth) get downloaded. Not too much of an issue.

Fixes #12206
