### PR TITLE
fix: Lint after emitting types

### DIFF
--- a/yarn-project/bootstrap.sh
+++ b/yarn-project/bootstrap.sh
@@ -68,10 +68,7 @@ function compile_all {
   cmds=(format)
   if [ "${TYPECHECK:-0}" -eq 1 ] || [ "${CI:-0}" -eq 1 ]; then
     # Fully type check and lint.
-    cmds+=(
-      'yarn tsc -b --emitDeclarationOnly'
-      lint
-    )
+    cmds+=('yarn tsc -b --emitDeclarationOnly && lint')
   else
     # We just need the type declarations required for downstream consumers.
     cmds+=('cd aztec.js && yarn tsc -b --emitDeclarationOnly')


### PR DESCRIPTION
CI was sometimes passing when there were linting errors. This was caused because some eslint rules depend on types for dependent packages being available, and if they are not, they just don't fire. Since lint and emitting types were running concurrently on CI, if the linter was faster than tsc, we would miss certain checks.

See [here](https://github.com/AztecProtocol/aztec-packages/pull/12087/files#diff-db0092fcd12b49df16aec55b2f65ab2b7b25a38821db4721bf3f18fb4e9b2ea6R56) for a missed lint check (missing-await) with a successful CI run.
