### PR TITLE
[DO_NOTE_MERGE] feat: print accidentally ignored tests

### DIFF
--- a/yarn-project/end-to-end/src/print_accidentally_ignored_tests.test.ts
+++ b/yarn-project/end-to-end/src/print_accidentally_ignored_tests.test.ts
@@ -1,0 +1,50 @@
+import { readFileSync } from 'fs';
+import { glob } from 'glob';
+import { join } from 'path';
+
+describe('print_accidentally_ignored_tests', () => {
+  it('finds tests that are not explicitly skipped or included in bootstrap.sh', async () => {
+    // Get repo root directory
+    const repoRoot = process.cwd().split('yarn-project')[0];
+
+    // Get all test files in end-to-end directory
+    const testFiles = await glob('**/*.test.ts', {
+      cwd: join(repoRoot, 'yarn-project/end-to-end'),
+      ignore: ['node_modules/**'],
+    });
+
+    // Read skip patterns file
+    const skipPatternsContent = readFileSync(join(repoRoot, '.test_skip_patterns'), 'utf8');
+    const skipPatterns = skipPatternsContent
+      .split('\n')
+      .filter(line => line.trim() && !line.startsWith('#'))
+      .map(pattern => new RegExp(pattern));
+
+    // Read bootstrap.sh to get included tests
+    const bootstrapContent = readFileSync(join(repoRoot, 'yarn-project/end-to-end/bootstrap.sh'), 'utf8');
+    const includedTests = bootstrapContent
+      .split('\n')
+      .filter(line => line.includes('$prefix simple') || line.includes('$prefix compose'))
+      .map(line => {
+        const match = line.match(/(?:simple|compose)\s+(.+?)(?:\s|")/);
+        return match ? match[1] : null;
+      })
+      .filter(Boolean)
+      .map(test => new RegExp(test as string));
+
+    // Filter out skipped and included tests
+    const unaccountedTests = testFiles.filter(testFile => {
+      const isSkipped = skipPatterns.some(pattern => pattern.test(testFile));
+      const isIncluded = includedTests.some(pattern => pattern.test(testFile));
+      return !isSkipped && !isIncluded;
+    });
+
+    if (unaccountedTests.length > 0) {
+      console.log(
+        'Found test files that are neither skipped nor included in bootstrap.sh:\n' + unaccountedTests.join('\n'),
+      );
+    }
+
+    // expect(unaccountedTests).toHaveLength(0);
+  });
+});


### PR DESCRIPTION
As discussed with @spalladino. It's useful to have this script to figure out what tests are ignored by accident.

Not sure if this is robust as I just scripted it with AI but it correctly found the `fee_settings.test.ts` and from a brief look the output looks good so I think it's ok (not worth to spend much time on this).

This is the output:

    Found test files that are neither skipped nor included in bootstrap.sh:
    src/print_accidentally_ignored_tests.test.ts
    src/e2e_simple.test.ts
    src/e2e_pending_note_hashes_contract.test.ts
    src/e2e_new_addresses.test.ts
    src/e2e_contract_updates.test.ts
    src/e2e_block_building.test.ts
    src/spartan/upgrade_governance_proposer.test.ts
    src/spartan/transfer.test.ts
    src/spartan/smoke.test.ts
    src/spartan/reorg.test.ts
    src/spartan/proving.test.ts
    src/spartan/prover-node.test.ts
    src/spartan/gating-passive.test.ts
    src/spartan/4epochs.test.ts
    src/e2e_sequencer/gov_proposal.test.ts
    src/e2e_prover/full.test.ts
    src/e2e_fees/fee_settings.test.ts
    src/e2e_fees/dapp_subscription.test.ts
    src/devnet/e2e_smoke.test.ts
    src/composed/uniswap_trade_on_l1_from_l2.test.ts
    src/composed/integration_proof_verification.test.ts
    src/composed/e2e_persistence.test.ts
    src/bench/bench_build_block.test.ts