### PR TITLE
chore: Log prover publisher address on creation

### DIFF
--- a/yarn-project/end-to-end/src/fixtures/utils.ts
+++ b/yarn-project/end-to-end/src/fixtures/utils.ts
@@ -810,6 +810,7 @@ export async function createAndSyncProverNode(
     },
     { prefilledPublicData },
   );
+  getLogger().info(`Created and synced prover node`, { publisherAddress: l1TxUtils.walletClient.account.address });
   proverNode.start();
   return proverNode;
 }


### PR DESCRIPTION
To help identify flake on multi-proofs test.
