### PR TITLE
fix: Do not trigger multiple pxe syncs simultaneously

### DIFF
--- a/yarn-project/end-to-end/src/shared/submit-transactions.ts
+++ b/yarn-project/end-to-end/src/shared/submit-transactions.ts
@@ -1,5 +1,6 @@
 import { getSchnorrAccount } from '@aztec/accounts/schnorr';
 import { Fr, GrumpkinScalar, type Logger, type SentTx, TxStatus, type Wallet } from '@aztec/aztec.js';
+import { times } from '@aztec/foundation/collection';
 import type { PXEService } from '@aztec/pxe';
 
 // submits a set of transactions to the provided Private eXecution Environment (PXE)
@@ -10,21 +11,23 @@ export const submitTxsTo = async (
   logger: Logger,
 ): Promise<SentTx[]> => {
   const txs: SentTx[] = [];
-  for (let i = 0; i < numTxs; i++) {
-    const accountManager = await getSchnorrAccount(pxe, Fr.random(), GrumpkinScalar.random(), Fr.random());
-    const tx = accountManager.deploy({ deployWallet: wallet });
-    const txHash = await tx.getTxHash();
+  await Promise.all(
+    times(numTxs, async () => {
+      const accountManager = await getSchnorrAccount(pxe, Fr.random(), GrumpkinScalar.random(), Fr.random());
+      const tx = accountManager.deploy({ deployWallet: wallet });
+      const txHash = await tx.getTxHash();
 
-    logger.info(`Tx sent with hash ${txHash}`);
-    const receipt = await tx.getReceipt();
-    expect(receipt).toEqual(
-      expect.objectContaining({
-        status: TxStatus.PENDING,
-        error: '',
-      }),
-    );
-    logger.info(`Receipt received for ${txHash}`);
-    txs.push(tx);
-  }
+      logger.info(`Tx sent with hash ${txHash}`);
+      const receipt = await tx.getReceipt();
+      expect(receipt).toEqual(
+        expect.objectContaining({
+          status: TxStatus.PENDING,
+          error: '',
+        }),
+      );
+      logger.info(`Receipt received for ${txHash}`);
+      txs.push(tx);
+    }),
+  );
   return txs;
 };

--- a/yarn-project/pxe/src/synchronizer/synchronizer.ts
+++ b/yarn-project/pxe/src/synchronizer/synchronizer.ts
@@ -16,6 +16,7 @@ import type { PxeDatabase } from '../database/index.js';
 export class Synchronizer implements L2BlockStreamEventHandler {
   private initialSyncBlockNumber = INITIAL_L2_BLOCK_NUM - 1;
   private log: Logger;
+  private isSyncing: Promise<void> | undefined;
   protected readonly blockStream: L2BlockStream;
 
   constructor(
@@ -78,6 +79,23 @@ export class Synchronizer implements L2BlockStreamEventHandler {
    * recent data (e.g. notes), and handling any reorgs that might have occurred.
    */
   public async sync() {
+    if (this.isSyncing !== undefined) {
+      this.log.debug(`Waiting for the ongoing sync to finish`);
+      await this.isSyncing;
+      return;
+    }
+
+    this.log.debug(`Syncing PXE with the node`);
+    const isSyncing = this.doSync();
+    this.isSyncing = isSyncing;
+    try {
+      await isSyncing;
+    } finally {
+      this.isSyncing = undefined;
+    }
+  }
+
+  private async doSync() {
     let currentHeader;
 
     try {


### PR DESCRIPTION
Attempt at fixing #12227. I had repro'd the issue with @LeilaWang's help by making `submitTxsTo` parallel (as changed in this PR) and running the `e2e_l1_with_wall_time` e2e test on revision `0c937238e1`. 

I added a bunch of logs there to find out what was happening, and found that, in the cases where the pxe failed to retrieve the expected note, the synchronizer was retrieving the logs from the node successfully but it was **not** emitting an `Updated pxe last block to 2` log. 

The odd thing is that each of the `Updated pxe last block to 2` corresponded to an event emitted by the `block-source`, which was emitting the same block multiple times. I tracked this to the synchronizer triggering multiple parallel syncs, which should not be needed. I assume the failing syncs were caused by some race condition. So I made this change in the synchronizer, so only one sync happens at a time.

I'm copying the relevant logs here, note that some of these logs do not actually exist in the codebase, I just added them for debugging. Note that there are 8 txs sent, but only 6 `Updated pxe last block to 2` entries, plus two failures.

```
[09:57:32.613] INFO: pxe:service Simulating transaction execution request to 0x27e740b2 at 0x2937d1c5726c22fd037fc2a174a97a9f367e25e4aa46c14ea1c3110da80eb2ad {"origin":"0x2937d1c5726c22fd037fc2a174a97a9f367e25e4aa46c14ea1c3110da80eb2ad","functionSelector":"0x27e740b2","simulatePublic":true,"chainId":"0x0000000000000000000000000000000000000000000000000000000000007a69","version":"0x0000000000000000000000000000000000000000000000000000000000000001","authWitnesses":["0x0a4b04f84257a585ae2d9929580abeca33fcdddaf2bb7a7ecb9cac8c6836541c"]}
[09:57:32.622] INFO: pxe:service Simulating transaction execution request to 0x27e740b2 at 0x2937d1c5726c22fd037fc2a174a97a9f367e25e4aa46c14ea1c3110da80eb2ad {"origin":"0x2937d1c5726c22fd037fc2a174a97a9f367e25e4aa46c14ea1c3110da80eb2ad","functionSelector":"0x27e740b2","simulatePublic":true,"chainId":"0x0000000000000000000000000000000000000000000000000000000000007a69","version":"0x0000000000000000000000000000000000000000000000000000000000000001","authWitnesses":["0x131e978a8fe8f12c3e5fc6ff0696ae7f89ec62b09728b8e7f7f6050fd008ac4c"]}
[09:57:32.630] INFO: pxe:service Simulating transaction execution request to 0x27e740b2 at 0x2937d1c5726c22fd037fc2a174a97a9f367e25e4aa46c14ea1c3110da80eb2ad {"origin":"0x2937d1c5726c22fd037fc2a174a97a9f367e25e4aa46c14ea1c3110da80eb2ad","functionSelector":"0x27e740b2","simulatePublic":true,"chainId":"0x0000000000000000000000000000000000000000000000000000000000007a69","version":"0x0000000000000000000000000000000000000000000000000000000000000001","authWitnesses":["0x09bfa54c9a4aa8171b240d6756e3ef7e25356107b1789f4ee5390419e4a041ba"]}
[09:57:32.634] INFO: pxe:service Simulating transaction execution request to 0x27e740b2 at 0x2937d1c5726c22fd037fc2a174a97a9f367e25e4aa46c14ea1c3110da80eb2ad {"origin":"0x2937d1c5726c22fd037fc2a174a97a9f367e25e4aa46c14ea1c3110da80eb2ad","functionSelector":"0x27e740b2","simulatePublic":true,"chainId":"0x0000000000000000000000000000000000000000000000000000000000007a69","version":"0x0000000000000000000000000000000000000000000000000000000000000001","authWitnesses":["0x2ab642bf06c7b93d1cd94d7dc40aec02b2efd5ddcc765d28de2452c469712db2"]}
[09:57:32.639] INFO: pxe:service Simulating transaction execution request to 0x27e740b2 at 0x2937d1c5726c22fd037fc2a174a97a9f367e25e4aa46c14ea1c3110da80eb2ad {"origin":"0x2937d1c5726c22fd037fc2a174a97a9f367e25e4aa46c14ea1c3110da80eb2ad","functionSelector":"0x27e740b2","simulatePublic":true,"chainId":"0x0000000000000000000000000000000000000000000000000000000000007a69","version":"0x0000000000000000000000000000000000000000000000000000000000000001","authWitnesses":["0x0cafa72ea141bb82c34e3656ae718b5a0c14722aefffd0fbcc3faf64e7cd7a67"]}
[09:57:32.642] DEBUG: pxe:block_stream Emitting blocks-added (1)
[09:57:32.646] INFO: pxe:service Simulating transaction execution request to 0x27e740b2 at 0x2937d1c5726c22fd037fc2a174a97a9f367e25e4aa46c14ea1c3110da80eb2ad {"origin":"0x2937d1c5726c22fd037fc2a174a97a9f367e25e4aa46c14ea1c3110da80eb2ad","functionSelector":"0x27e740b2","simulatePublic":true,"chainId":"0x0000000000000000000000000000000000000000000000000000000000007a69","version":"0x0000000000000000000000000000000000000000000000000000000000000001","authWitnesses":["0x305b53b9c18abfbaf7e0656f0ff85e9012e727edb0ed8e01edb067bfd7ed08d4"]}
[09:57:32.652] INFO: pxe:service Simulating transaction execution request to 0x27e740b2 at 0x2937d1c5726c22fd037fc2a174a97a9f367e25e4aa46c14ea1c3110da80eb2ad {"origin":"0x2937d1c5726c22fd037fc2a174a97a9f367e25e4aa46c14ea1c3110da80eb2ad","functionSelector":"0x27e740b2","simulatePublic":true,"chainId":"0x0000000000000000000000000000000000000000000000000000000000007a69","version":"0x0000000000000000000000000000000000000000000000000000000000000001","authWitnesses":["0x22f04449b6030d172c30bde940c79c87d95b08153de970326366230d1515e4b2"]}
[09:57:32.653] DEBUG: pxe:block_stream Emitting blocks-added (1)
[09:57:32.683] VERBOSE: pxe:simulator_oracle 2: Searching for tagged logs {"contract":"0x2937d1c5726c22fd037fc2a174a97a9f367e25e4aa46c14ea1c3110da80eb2ad"}
[09:57:32.700] DEBUG: pxe:simulator_oracle 2: Tags for logs for recipient 0x2937d1c5726c22fd037fc2a174a97a9f367e25e4aa46c14ea1c3110da80eb2ad are 0x1d74072159cf8b01ba9cd138b3923fc79defbdaed10b6dd29d2af518750ec28c, 0x1725020bedf6964284d9cfdd0a93ff3400ddd30bc9796a342e87396047407de4, 0x23b8a5964d37043f193c8cf5a01a5868c4aebe5c79606822fea6fb4f3c2e818c, 0x26b479c5ad5f5704ffd23a2185579be1a19d96438b98784a8af7301c67dda648, 0x2f16e4a75e1e2a2dcadc7ea8b4812a7ab5eb7a0806445c9c5f2b83161294faf3, 0x059e00a02ea7e0097cb4aa3307b769c39a4a1cdb21782b36f301d9331d556b99, ...
[09:57:32.703] DEBUG: pxe:block_stream Emitting blocks-added (1)
[09:57:32.704] DEBUG: pxe:block_stream Emitting blocks-added (1)
[09:57:32.705] DEBUG: pxe:simulator_oracle 2: Logs are 2:0x1407ab1c7da4c6fb162a40d5129b9450f9fb388bc43ba1a19b47432785ef03aa:2d469f6347383e99108516e097ee5463
[09:57:32.705] DEBUG: pxe:simulator_oracle Found 1 logs as recipient 0x2937d1c5726c22fd037fc2a174a97a9f367e25e4aa46c14ea1c3110da80eb2ad {"recipient":"0x2937d1c5726c22fd037fc2a174a97a9f367e25e4aa46c14ea1c3110da80eb2ad","secret":"0x13fed814943ea5899102fd49351174e5ed09fb609fa10e42ac38b550cf9df0b7","contractName":"SchnorrAccount","contractAddress":"0x2937d1c5726c22fd037fc2a174a97a9f367e25e4aa46c14ea1c3110da80eb2ad"}
[09:57:32.705] DEBUG: pxe:simulator_oracle Incrementing index to 1 at contract SchnorrAccount(0x2937d1c5726c22fd037fc2a174a97a9f367e25e4aa46c14ea1c3110da80eb2ad)
[09:57:32.706] DEBUG: pxe:simulator_oracle 2: Tags for logs for recipient 0x2937d1c5726c22fd037fc2a174a97a9f367e25e4aa46c14ea1c3110da80eb2ad are 0x0e94ada8a8ab837b1088d3e2180bc9ca0b76c893975271b11618f63baae2d32e, 0x04d174f6c151cd5d10123c1c9fc3609d6a0b08f9001cae21fa25ca24c471b3a4, 0x080f03369d6c071128c3006b2c904e16084ffcf65f1f8845fd6048e7eb8da162, 0x042c727dce7b237086d3c9af2c9e83b117708031fc45434a8341a2028b7d52cb, 0x2f21aa916374a002e4880c9e1d9e6be0f4d444439feeff1090da2b0f032cd59b, 0x1e7505e6252f102d22fc752b28c94c60a9c101948bee0c6083f4e9905a7e4db3, ...
[09:57:32.710] INFO: pxe:service Simulating transaction execution request to 0x27e740b2 at 0x2937d1c5726c22fd037fc2a174a97a9f367e25e4aa46c14ea1c3110da80eb2ad {"origin":"0x2937d1c5726c22fd037fc2a174a97a9f367e25e4aa46c14ea1c3110da80eb2ad","functionSelector":"0x27e740b2","simulatePublic":true,"chainId":"0x0000000000000000000000000000000000000000000000000000000000007a69","version":"0x0000000000000000000000000000000000000000000000000000000000000001","authWitnesses":["0x11d59768a2e2f8013b86917756a54f5cc70f93b493b6fdf65787746601711275"]}
[09:57:32.711] DEBUG: pxe:block_stream Emitting blocks-added (1)
[09:57:32.711] DEBUG: pxe:simulator_oracle 2: Logs are 
[09:57:32.713] VERBOSE: pxe:synchronizer Updated pxe last block to 2 {"blockHash":{},"archive":"0x141bbb155ab23274a878a79f9a4539d0adfe2182a4df18dc48c3532af607d3cf","header":{"contentCommitment":{"blobsHash":"0x00e6ff05b65e82e7bbc5c991ecf47f6f9dbc81105632c775186a0dc4ccf4bf62","inHash":"0x00089a9d421a82c4a25f7acbebe69e638d5b064fa8a60e018793dcb0be53752c","numTxs":1,"outHash":"0x0000000000000000000000000000000000000000000000000000000000000000"},"globalVariables":{"blockNumber":2,"chainId":31337,"coinbase":"0x0000000000000000000000000000000000000000","feePerDaGas":0,"feePerL2Gas":36251010,"feeRecipient":"0x0000000000000000000000000000000000000000000000000000000000000000","slotNumber":3,"timestamp":1740574630,"version":1},"lastArchive":"0x138402e0a69870ea1ad13a3b50e5b56ab906952b1f312d5e6c08bc09b17b6f12","state":{"l1ToL2MessageTree":"0x2e33ee2008411c04b99c24b313513d097a0d21a5040b6193d1f978b8226892d6","noteHashTree":"0x127c437cf51bf7e6dd17296c5e6843b252260d404a5ffb7b08684c148f92a0c3","nullifierTree":"0x23ce69c87937fa36b03b8c87905a93f1ba693589642c87f0fbfaaba16e61be03","publicDataTree":"0x0acdbf01c62e42c092a984363e50c34333347b96931a7a5a08faf1a5fe3f3581"},"totalFees":14690649300480,"totalManaUsed":405248}}
[09:57:32.713] DEBUG: pxe:block_stream Emitting blocks-added (1)
[09:57:32.741] VERBOSE: pxe:simulator_oracle 3: Searching for tagged logs {"contract":"0x2937d1c5726c22fd037fc2a174a97a9f367e25e4aa46c14ea1c3110da80eb2ad"}
[09:57:32.755] DEBUG: pxe:simulator_oracle 3: Tags for logs for recipient 0x2937d1c5726c22fd037fc2a174a97a9f367e25e4aa46c14ea1c3110da80eb2ad are 0x1d74072159cf8b01ba9cd138b3923fc79defbdaed10b6dd29d2af518750ec28c, 0x1725020bedf6964284d9cfdd0a93ff3400ddd30bc9796a342e87396047407de4, 0x23b8a5964d37043f193c8cf5a01a5868c4aebe5c79606822fea6fb4f3c2e818c, 0x26b479c5ad5f5704ffd23a2185579be1a19d96438b98784a8af7301c67dda648, 0x2f16e4a75e1e2a2dcadc7ea8b4812a7ab5eb7a0806445c9c5f2b83161294faf3, 0x059e00a02ea7e0097cb4aa3307b769c39a4a1cdb21782b36f301d9331d556b99, ...
[09:57:32.761] VERBOSE: pxe:simulator_oracle Removing nullified notes {"contract":"0x2937d1c5726c22fd037fc2a174a97a9f367e25e4aa46c14ea1c3110da80eb2ad"}
[09:57:32.763] DEBUG: pxe:simulator_oracle 3: Logs are 2:0x1407ab1c7da4c6fb162a40d5129b9450f9fb388bc43ba1a19b47432785ef03aa:2d469f6347383e99108516e097ee5463
[09:57:32.763] DEBUG: pxe:simulator_oracle Found 1 logs as recipient 0x2937d1c5726c22fd037fc2a174a97a9f367e25e4aa46c14ea1c3110da80eb2ad {"recipient":"0x2937d1c5726c22fd037fc2a174a97a9f367e25e4aa46c14ea1c3110da80eb2ad","secret":"0x13fed814943ea5899102fd49351174e5ed09fb609fa10e42ac38b550cf9df0b7","contractName":"SchnorrAccount","contractAddress":"0x2937d1c5726c22fd037fc2a174a97a9f367e25e4aa46c14ea1c3110da80eb2ad"}
[09:57:32.764] VERBOSE: pxe:simulator_oracle Removing nullified notes {"contract":"0x2937d1c5726c22fd037fc2a174a97a9f367e25e4aa46c14ea1c3110da80eb2ad"}
[09:57:32.766] VERBOSE: pxe:synchronizer Updated pxe last block to 2 {"blockHash":{},"archive":"0x141bbb155ab23274a878a79f9a4539d0adfe2182a4df18dc48c3532af607d3cf","header":{"contentCommitment":{"blobsHash":"0x00e6ff05b65e82e7bbc5c991ecf47f6f9dbc81105632c775186a0dc4ccf4bf62","inHash":"0x00089a9d421a82c4a25f7acbebe69e638d5b064fa8a60e018793dcb0be53752c","numTxs":1,"outHash":"0x0000000000000000000000000000000000000000000000000000000000000000"},"globalVariables":{"blockNumber":2,"chainId":31337,"coinbase":"0x0000000000000000000000000000000000000000","feePerDaGas":0,"feePerL2Gas":36251010,"feeRecipient":"0x0000000000000000000000000000000000000000000000000000000000000000","slotNumber":3,"timestamp":1740574630,"version":1},"lastArchive":"0x138402e0a69870ea1ad13a3b50e5b56ab906952b1f312d5e6c08bc09b17b6f12","state":{"l1ToL2MessageTree":"0x2e33ee2008411c04b99c24b313513d097a0d21a5040b6193d1f978b8226892d6","noteHashTree":"0x127c437cf51bf7e6dd17296c5e6843b252260d404a5ffb7b08684c148f92a0c3","nullifierTree":"0x23ce69c87937fa36b03b8c87905a93f1ba693589642c87f0fbfaaba16e61be03","publicDataTree":"0x0acdbf01c62e42c092a984363e50c34333347b96931a7a5a08faf1a5fe3f3581"},"totalFees":14690649300480,"totalManaUsed":405248}}
[09:57:32.792] VERBOSE: pxe:simulator_oracle 4: Searching for tagged logs {"contract":"0x2937d1c5726c22fd037fc2a174a97a9f367e25e4aa46c14ea1c3110da80eb2ad"}
[09:57:32.807] DEBUG: pxe:simulator_oracle 4: Tags for logs for recipient 0x2937d1c5726c22fd037fc2a174a97a9f367e25e4aa46c14ea1c3110da80eb2ad are 0x1d74072159cf8b01ba9cd138b3923fc79defbdaed10b6dd29d2af518750ec28c, 0x1725020bedf6964284d9cfdd0a93ff3400ddd30bc9796a342e87396047407de4, 0x23b8a5964d37043f193c8cf5a01a5868c4aebe5c79606822fea6fb4f3c2e818c, 0x26b479c5ad5f5704ffd23a2185579be1a19d96438b98784a8af7301c67dda648, 0x2f16e4a75e1e2a2dcadc7ea8b4812a7ab5eb7a0806445c9c5f2b83161294faf3, 0x059e00a02ea7e0097cb4aa3307b769c39a4a1cdb21782b36f301d9331d556b99, ...
[09:57:32.810] VERBOSE: pxe:synchronizer Updated pxe last block to 2 {"blockHash":{},"archive":"0x141bbb155ab23274a878a79f9a4539d0adfe2182a4df18dc48c3532af607d3cf","header":{"contentCommitment":{"blobsHash":"0x00e6ff05b65e82e7bbc5c991ecf47f6f9dbc81105632c775186a0dc4ccf4bf62","inHash":"0x00089a9d421a82c4a25f7acbebe69e638d5b064fa8a60e018793dcb0be53752c","numTxs":1,"outHash":"0x0000000000000000000000000000000000000000000000000000000000000000"},"globalVariables":{"blockNumber":2,"chainId":31337,"coinbase":"0x0000000000000000000000000000000000000000","feePerDaGas":0,"feePerL2Gas":36251010,"feeRecipient":"0x0000000000000000000000000000000000000000000000000000000000000000","slotNumber":3,"timestamp":1740574630,"version":1},"lastArchive":"0x138402e0a69870ea1ad13a3b50e5b56ab906952b1f312d5e6c08bc09b17b6f12","state":{"l1ToL2MessageTree":"0x2e33ee2008411c04b99c24b313513d097a0d21a5040b6193d1f978b8226892d6","noteHashTree":"0x127c437cf51bf7e6dd17296c5e6843b252260d404a5ffb7b08684c148f92a0c3","nullifierTree":"0x23ce69c87937fa36b03b8c87905a93f1ba693589642c87f0fbfaaba16e61be03","publicDataTree":"0x0acdbf01c62e42c092a984363e50c34333347b96931a7a5a08faf1a5fe3f3581"},"totalFees":14690649300480,"totalManaUsed":405248}}
[09:57:32.810] VERBOSE: pxe:synchronizer Updated pxe last block to 2 {"blockHash":{},"archive":"0x141bbb155ab23274a878a79f9a4539d0adfe2182a4df18dc48c3532af607d3cf","header":{"contentCommitment":{"blobsHash":"0x00e6ff05b65e82e7bbc5c991ecf47f6f9dbc81105632c775186a0dc4ccf4bf62","inHash":"0x00089a9d421a82c4a25f7acbebe69e638d5b064fa8a60e018793dcb0be53752c","numTxs":1,"outHash":"0x0000000000000000000000000000000000000000000000000000000000000000"},"globalVariables":{"blockNumber":2,"chainId":31337,"coinbase":"0x0000000000000000000000000000000000000000","feePerDaGas":0,"feePerL2Gas":36251010,"feeRecipient":"0x0000000000000000000000000000000000000000000000000000000000000000","slotNumber":3,"timestamp":1740574630,"version":1},"lastArchive":"0x138402e0a69870ea1ad13a3b50e5b56ab906952b1f312d5e6c08bc09b17b6f12","state":{"l1ToL2MessageTree":"0x2e33ee2008411c04b99c24b313513d097a0d21a5040b6193d1f978b8226892d6","noteHashTree":"0x127c437cf51bf7e6dd17296c5e6843b252260d404a5ffb7b08684c148f92a0c3","nullifierTree":"0x23ce69c87937fa36b03b8c87905a93f1ba693589642c87f0fbfaaba16e61be03","publicDataTree":"0x0acdbf01c62e42c092a984363e50c34333347b96931a7a5a08faf1a5fe3f3581"},"totalFees":14690649300480,"totalManaUsed":405248}}
[09:57:32.810] VERBOSE: pxe:synchronizer Updated pxe last block to 2 {"blockHash":{},"archive":"0x141bbb155ab23274a878a79f9a4539d0adfe2182a4df18dc48c3532af607d3cf","header":{"contentCommitment":{"blobsHash":"0x00e6ff05b65e82e7bbc5c991ecf47f6f9dbc81105632c775186a0dc4ccf4bf62","inHash":"0x00089a9d421a82c4a25f7acbebe69e638d5b064fa8a60e018793dcb0be53752c","numTxs":1,"outHash":"0x0000000000000000000000000000000000000000000000000000000000000000"},"globalVariables":{"blockNumber":2,"chainId":31337,"coinbase":"0x0000000000000000000000000000000000000000","feePerDaGas":0,"feePerL2Gas":36251010,"feeRecipient":"0x0000000000000000000000000000000000000000000000000000000000000000","slotNumber":3,"timestamp":1740574630,"version":1},"lastArchive":"0x138402e0a69870ea1ad13a3b50e5b56ab906952b1f312d5e6c08bc09b17b6f12","state":{"l1ToL2MessageTree":"0x2e33ee2008411c04b99c24b313513d097a0d21a5040b6193d1f978b8226892d6","noteHashTree":"0x127c437cf51bf7e6dd17296c5e6843b252260d404a5ffb7b08684c148f92a0c3","nullifierTree":"0x23ce69c87937fa36b03b8c87905a93f1ba693589642c87f0fbfaaba16e61be03","publicDataTree":"0x0acdbf01c62e42c092a984363e50c34333347b96931a7a5a08faf1a5fe3f3581"},"totalFees":14690649300480,"totalManaUsed":405248}}
[09:57:32.812] DEBUG: pxe:simulator_oracle 4: Logs are 2:0x1407ab1c7da4c6fb162a40d5129b9450f9fb388bc43ba1a19b47432785ef03aa:2d469f6347383e99108516e097ee5463
[09:57:32.812] DEBUG: pxe:simulator_oracle Found 1 logs as recipient 0x2937d1c5726c22fd037fc2a174a97a9f367e25e4aa46c14ea1c3110da80eb2ad {"recipient":"0x2937d1c5726c22fd037fc2a174a97a9f367e25e4aa46c14ea1c3110da80eb2ad","secret":"0x13fed814943ea5899102fd49351174e5ed09fb609fa10e42ac38b550cf9df0b7","contractName":"SchnorrAccount","contractAddress":"0x2937d1c5726c22fd037fc2a174a97a9f367e25e4aa46c14ea1c3110da80eb2ad"}
[09:57:32.817] VERBOSE: pxe:synchronizer Updated pxe last block to 2 {"blockHash":{},"archive":"0x141bbb155ab23274a878a79f9a4539d0adfe2182a4df18dc48c3532af607d3cf","header":{"contentCommitment":{"blobsHash":"0x00e6ff05b65e82e7bbc5c991ecf47f6f9dbc81105632c775186a0dc4ccf4bf62","inHash":"0x00089a9d421a82c4a25f7acbebe69e638d5b064fa8a60e018793dcb0be53752c","numTxs":1,"outHash":"0x0000000000000000000000000000000000000000000000000000000000000000"},"globalVariables":{"blockNumber":2,"chainId":31337,"coinbase":"0x0000000000000000000000000000000000000000","feePerDaGas":0,"feePerL2Gas":36251010,"feeRecipient":"0x0000000000000000000000000000000000000000000000000000000000000000","slotNumber":3,"timestamp":1740574630,"version":1},"lastArchive":"0x138402e0a69870ea1ad13a3b50e5b56ab906952b1f312d5e6c08bc09b17b6f12","state":{"l1ToL2MessageTree":"0x2e33ee2008411c04b99c24b313513d097a0d21a5040b6193d1f978b8226892d6","noteHashTree":"0x127c437cf51bf7e6dd17296c5e6843b252260d404a5ffb7b08684c148f92a0c3","nullifierTree":"0x23ce69c87937fa36b03b8c87905a93f1ba693589642c87f0fbfaaba16e61be03","publicDataTree":"0x0acdbf01c62e42c092a984363e50c34333347b96931a7a5a08faf1a5fe3f3581"},"totalFees":14690649300480,"totalManaUsed":405248}}
[09:57:32.844] VERBOSE: pxe:simulator_oracle 5: Searching for tagged logs {"contract":"0x2937d1c5726c22fd037fc2a174a97a9f367e25e4aa46c14ea1c3110da80eb2ad"}
[09:57:32.858] DEBUG: pxe:simulator_oracle 5: Tags for logs for recipient 0x2937d1c5726c22fd037fc2a174a97a9f367e25e4aa46c14ea1c3110da80eb2ad are 0x1d74072159cf8b01ba9cd138b3923fc79defbdaed10b6dd29d2af518750ec28c, 0x1725020bedf6964284d9cfdd0a93ff3400ddd30bc9796a342e87396047407de4, 0x23b8a5964d37043f193c8cf5a01a5868c4aebe5c79606822fea6fb4f3c2e818c, 0x26b479c5ad5f5704ffd23a2185579be1a19d96438b98784a8af7301c67dda648, 0x2f16e4a75e1e2a2dcadc7ea8b4812a7ab5eb7a0806445c9c5f2b83161294faf3, 0x059e00a02ea7e0097cb4aa3307b769c39a4a1cdb21782b36f301d9331d556b99, ...
[09:57:32.919] VERBOSE: pxe:simulator_oracle 6: Searching for tagged logs {"contract":"0x2937d1c5726c22fd037fc2a174a97a9f367e25e4aa46c14ea1c3110da80eb2ad"}
[09:57:32.934] VERBOSE: pxe:simulator_oracle 7: Searching for tagged logs {"contract":"0x2937d1c5726c22fd037fc2a174a97a9f367e25e4aa46c14ea1c3110da80eb2ad"}
[09:57:32.949] VERBOSE: pxe:simulator_oracle 8: Searching for tagged logs {"contract":"0x2937d1c5726c22fd037fc2a174a97a9f367e25e4aa46c14ea1c3110da80eb2ad"}
[09:57:33.007] DEBUG: pxe:simulator_oracle 6: Tags for logs for recipient 0x2937d1c5726c22fd037fc2a174a97a9f367e25e4aa46c14ea1c3110da80eb2ad are 0x1d74072159cf8b01ba9cd138b3923fc79defbdaed10b6dd29d2af518750ec28c, 0x1725020bedf6964284d9cfdd0a93ff3400ddd30bc9796a342e87396047407de4, 0x23b8a5964d37043f193c8cf5a01a5868c4aebe5c79606822fea6fb4f3c2e818c, 0x26b479c5ad5f5704ffd23a2185579be1a19d96438b98784a8af7301c67dda648, 0x2f16e4a75e1e2a2dcadc7ea8b4812a7ab5eb7a0806445c9c5f2b83161294faf3, 0x059e00a02ea7e0097cb4aa3307b769c39a4a1cdb21782b36f301d9331d556b99, ...
[09:57:33.009] DEBUG: pxe:simulator_oracle 7: Tags for logs for recipient 0x2937d1c5726c22fd037fc2a174a97a9f367e25e4aa46c14ea1c3110da80eb2ad are 0x1d74072159cf8b01ba9cd138b3923fc79defbdaed10b6dd29d2af518750ec28c, 0x1725020bedf6964284d9cfdd0a93ff3400ddd30bc9796a342e87396047407de4, 0x23b8a5964d37043f193c8cf5a01a5868c4aebe5c79606822fea6fb4f3c2e818c, 0x26b479c5ad5f5704ffd23a2185579be1a19d96438b98784a8af7301c67dda648, 0x2f16e4a75e1e2a2dcadc7ea8b4812a7ab5eb7a0806445c9c5f2b83161294faf3, 0x059e00a02ea7e0097cb4aa3307b769c39a4a1cdb21782b36f301d9331d556b99, ...
[09:57:33.011] DEBUG: pxe:simulator_oracle 8: Tags for logs for recipient 0x2937d1c5726c22fd037fc2a174a97a9f367e25e4aa46c14ea1c3110da80eb2ad are 0x1d74072159cf8b01ba9cd138b3923fc79defbdaed10b6dd29d2af518750ec28c, 0x1725020bedf6964284d9cfdd0a93ff3400ddd30bc9796a342e87396047407de4, 0x23b8a5964d37043f193c8cf5a01a5868c4aebe5c79606822fea6fb4f3c2e818c, 0x26b479c5ad5f5704ffd23a2185579be1a19d96438b98784a8af7301c67dda648, 0x2f16e4a75e1e2a2dcadc7ea8b4812a7ab5eb7a0806445c9c5f2b83161294faf3, 0x059e00a02ea7e0097cb4aa3307b769c39a4a1cdb21782b36f301d9331d556b99, ...
[09:57:33.013] DEBUG: pxe:simulator_oracle 5: Logs are 2:0x1407ab1c7da4c6fb162a40d5129b9450f9fb388bc43ba1a19b47432785ef03aa:2d469f6347383e99108516e097ee5463
[09:57:33.014] DEBUG: pxe:simulator_oracle Found 1 logs as recipient 0x2937d1c5726c22fd037fc2a174a97a9f367e25e4aa46c14ea1c3110da80eb2ad {"recipient":"0x2937d1c5726c22fd037fc2a174a97a9f367e25e4aa46c14ea1c3110da80eb2ad","secret":"0x13fed814943ea5899102fd49351174e5ed09fb609fa10e42ac38b550cf9df0b7","contractName":"SchnorrAccount","contractAddress":"0x2937d1c5726c22fd037fc2a174a97a9f367e25e4aa46c14ea1c3110da80eb2ad"}
[09:57:33.051] VERBOSE: pxe:simulator_oracle 9: Searching for tagged logs {"contract":"0x2937d1c5726c22fd037fc2a174a97a9f367e25e4aa46c14ea1c3110da80eb2ad"}
[09:57:33.067] DEBUG: pxe:simulator_oracle 9: Tags for logs for recipient 0x2937d1c5726c22fd037fc2a174a97a9f367e25e4aa46c14ea1c3110da80eb2ad are 0x1d74072159cf8b01ba9cd138b3923fc79defbdaed10b6dd29d2af518750ec28c, 0x1725020bedf6964284d9cfdd0a93ff3400ddd30bc9796a342e87396047407de4, 0x23b8a5964d37043f193c8cf5a01a5868c4aebe5c79606822fea6fb4f3c2e818c, 0x26b479c5ad5f5704ffd23a2185579be1a19d96438b98784a8af7301c67dda648, 0x2f16e4a75e1e2a2dcadc7ea8b4812a7ab5eb7a0806445c9c5f2b83161294faf3, 0x059e00a02ea7e0097cb4aa3307b769c39a4a1cdb21782b36f301d9331d556b99, ...
[09:57:33.070] DEBUG: pxe:simulator_oracle 6: Logs are 2:0x1407ab1c7da4c6fb162a40d5129b9450f9fb388bc43ba1a19b47432785ef03aa:2d469f6347383e99108516e097ee5463
[09:57:33.070] DEBUG: pxe:simulator_oracle Found 1 logs as recipient 0x2937d1c5726c22fd037fc2a174a97a9f367e25e4aa46c14ea1c3110da80eb2ad {"recipient":"0x2937d1c5726c22fd037fc2a174a97a9f367e25e4aa46c14ea1c3110da80eb2ad","secret":"0x13fed814943ea5899102fd49351174e5ed09fb609fa10e42ac38b550cf9df0b7","contractName":"SchnorrAccount","contractAddress":"0x2937d1c5726c22fd037fc2a174a97a9f367e25e4aa46c14ea1c3110da80eb2ad"}
[09:57:33.072] DEBUG: pxe:simulator_oracle 7: Logs are 2:0x1407ab1c7da4c6fb162a40d5129b9450f9fb388bc43ba1a19b47432785ef03aa:2d469f6347383e99108516e097ee5463
[09:57:33.072] DEBUG: pxe:simulator_oracle Found 1 logs as recipient 0x2937d1c5726c22fd037fc2a174a97a9f367e25e4aa46c14ea1c3110da80eb2ad {"recipient":"0x2937d1c5726c22fd037fc2a174a97a9f367e25e4aa46c14ea1c3110da80eb2ad","secret":"0x13fed814943ea5899102fd49351174e5ed09fb609fa10e42ac38b550cf9df0b7","contractName":"SchnorrAccount","contractAddress":"0x2937d1c5726c22fd037fc2a174a97a9f367e25e4aa46c14ea1c3110da80eb2ad"}
[09:57:33.074] DEBUG: pxe:simulator_oracle 8: Logs are 2:0x1407ab1c7da4c6fb162a40d5129b9450f9fb388bc43ba1a19b47432785ef03aa:2d469f6347383e99108516e097ee5463
[09:57:33.074] DEBUG: pxe:simulator_oracle Found 1 logs as recipient 0x2937d1c5726c22fd037fc2a174a97a9f367e25e4aa46c14ea1c3110da80eb2ad {"recipient":"0x2937d1c5726c22fd037fc2a174a97a9f367e25e4aa46c14ea1c3110da80eb2ad","secret":"0x13fed814943ea5899102fd49351174e5ed09fb609fa10e42ac38b550cf9df0b7","contractName":"SchnorrAccount","contractAddress":"0x2937d1c5726c22fd037fc2a174a97a9f367e25e4aa46c14ea1c3110da80eb2ad"}
[09:57:33.100] DEBUG: pxe:simulator_oracle 9: Logs are 2:0x1407ab1c7da4c6fb162a40d5129b9450f9fb388bc43ba1a19b47432785ef03aa:2d469f6347383e99108516e097ee5463
[09:57:33.100] DEBUG: pxe:simulator_oracle Found 1 logs as recipient 0x2937d1c5726c22fd037fc2a174a97a9f367e25e4aa46c14ea1c3110da80eb2ad {"recipient":"0x2937d1c5726c22fd037fc2a174a97a9f367e25e4aa46c14ea1c3110da80eb2ad","secret":"0x13fed814943ea5899102fd49351174e5ed09fb609fa10e42ac38b550cf9df0b7","contractName":"SchnorrAccount","contractAddress":"0x2937d1c5726c22fd037fc2a174a97a9f367e25e4aa46c14ea1c3110da80eb2ad"}
[09:57:33.294] WARN: pxe:service Could not find function artifact in contract SchnorrAccount for function '' when enriching error callstack
[09:57:33.312] WARN: pxe:service Could not find function artifact in contract SchnorrAccount for function '' when enriching error callstack
[09:57:33.347] INFO: node Stopping
```

Fixes #12227 (maybe)