### PR TITLE
chore: Add logger optional arguments to bb entrypoints

### DIFF
--- a/barretenberg/ts/src/barretenberg/index.ts
+++ b/barretenberg/ts/src/barretenberg/index.ts
@@ -23,6 +23,9 @@ export type BackendOptions = {
 
   /** @description Path to download WASM files */
   wasmPath?: string;
+
+  /** @description Logging function */
+  logger?: (msg: string) => void;
 };
 
 export type CircuitOptions = {
@@ -51,11 +54,11 @@ export class Barretenberg extends BarretenbergApi {
   static async new(options: BackendOptions = {}) {
     const worker = createMainWorker();
     const wasm = getRemoteBarretenbergWasm<BarretenbergWasmMainWorker>(worker);
-    const { module, threads } = await fetchModuleAndThreads(options.threads, options.wasmPath);
+    const { module, threads } = await fetchModuleAndThreads(options.threads, options.wasmPath, options.logger);
     await wasm.init(
       module,
       threads,
-      proxy(createDebug('bb.js:bb_wasm_async')),
+      proxy(options.logger ?? createDebug('bb.js:bb_wasm_async')),
       options.memory?.initial,
       options.memory?.maximum,
     );
@@ -67,7 +70,7 @@ export class Barretenberg extends BarretenbergApi {
   }
 
   async initSRSForCircuitSize(circuitSize: number): Promise<void> {
-    const crs = await Crs.new(circuitSize + 1, this.options.crsPath);
+    const crs = await Crs.new(circuitSize + 1, this.options.crsPath, this.options.logger);
     // TODO(https://github.com/AztecProtocol/barretenberg/issues/1129): Do slab allocator initialization?
     // await this.commonInitSlabAllocator(circuitSize);
     await this.srsInitSrs(new RawBuffer(crs.getG1Data()), crs.numPoints, new RawBuffer(crs.getG2Data()));
@@ -75,8 +78,8 @@ export class Barretenberg extends BarretenbergApi {
 
   async initSRSClientIVC(): Promise<void> {
     // crsPath can be undefined
-    const crs = await Crs.new(2 ** 20 + 1, this.options.crsPath);
-    const grumpkinCrs = await GrumpkinCrs.new(2 ** 16 + 1, this.options.crsPath);
+    const crs = await Crs.new(2 ** 20 + 1, this.options.crsPath, this.options.logger);
+    const grumpkinCrs = await GrumpkinCrs.new(2 ** 16 + 1, this.options.crsPath, this.options.logger);
 
     // Load CRS into wasm global CRS state.
     // TODO: Make RawBuffer be default behavior, and have a specific Vector type for when wanting length prefixed.
@@ -104,16 +107,16 @@ export class BarretenbergSync extends BarretenbergApiSync {
     super(wasm);
   }
 
-  private static async new(wasmPath?: string) {
+  private static async new(wasmPath?: string, logger: (msg: string) => void = createDebug('bb.js:bb_wasm_sync')) {
     const wasm = new BarretenbergWasmMain();
-    const { module, threads } = await fetchModuleAndThreads(1, wasmPath);
-    await wasm.init(module, threads, createDebug('bb.js:bb_wasm_sync'));
+    const { module, threads } = await fetchModuleAndThreads(1, wasmPath, logger);
+    await wasm.init(module, threads, logger);
     return new BarretenbergSync(wasm);
   }
 
-  static async initSingleton(wasmPath?: string) {
+  static async initSingleton(wasmPath?: string, logger: (msg: string) => void = createDebug('bb.js:bb_wasm_sync')) {
     if (!barrentenbergSyncSingletonPromise) {
-      barrentenbergSyncSingletonPromise = BarretenbergSync.new(wasmPath);
+      barrentenbergSyncSingletonPromise = BarretenbergSync.new(wasmPath, logger);
     }
 
     barretenbergSyncSingleton = await barrentenbergSyncSingletonPromise;

--- a/barretenberg/ts/src/barretenberg_api/index.ts
+++ b/barretenberg/ts/src/barretenberg_api/index.ts
@@ -32,8 +32,6 @@ function parseBigEndianU32Array(buffer: Uint8Array, hasSizePrefix = false): numb
 
   return out;
 }
-import createDebug from 'debug';
-const log = createDebug('index-ts');
 
 export class BarretenbergApi {
   constructor(protected wasm: BarretenbergWasmWorker | BarretenbergWasmMain) {}

--- a/barretenberg/ts/src/barretenberg_wasm/barretenberg_wasm_base/index.ts
+++ b/barretenberg/ts/src/barretenberg_wasm/barretenberg_wasm_base/index.ts
@@ -1,8 +1,6 @@
 import createDebug from 'debug';
 import { randomBytes } from '../../random/index.js';
 
-const debug = createDebug('bb.js:bb_wasm_base');
-
 /**
  * Base implementation of BarretenbergWasm.
  * Contains code that is common to the "main thread" implementation and the "child thread" implementation.
@@ -11,7 +9,7 @@ export class BarretenbergWasmBase {
   protected memStore: { [key: string]: Uint8Array } = {};
   protected memory!: WebAssembly.Memory;
   protected instance!: WebAssembly.Instance;
-  protected logger: (msg: string) => void = debug;
+  protected logger: (msg: string) => void = createDebug('bb.js:bb_wasm_base');
 
   protected getImportObj(memory: WebAssembly.Memory) {
     /* eslint-disable camelcase */

--- a/barretenberg/ts/src/barretenberg_wasm/barretenberg_wasm_main/index.ts
+++ b/barretenberg/ts/src/barretenberg_wasm/barretenberg_wasm_main/index.ts
@@ -7,8 +7,6 @@ import { type BarretenbergWasmThreadWorker } from '../barretenberg_wasm_thread/i
 import { BarretenbergWasmBase } from '../barretenberg_wasm_base/index.js';
 import { HeapAllocator } from './heap_allocator.js';
 
-const debug = createDebug('bb.js:bb_wasm');
-
 /**
  * This is the "main thread" implementation of BarretenbergWasm.
  * It spawns a bunch of "child thread" implementations.
@@ -31,7 +29,7 @@ export class BarretenbergWasmMain extends BarretenbergWasmBase {
   public async init(
     module: WebAssembly.Module,
     threads = Math.min(getNumCpu(), BarretenbergWasmMain.MAX_THREADS),
-    logger: (msg: string) => void = debug,
+    logger: (msg: string) => void = createDebug('bb.js:bb_wasm'),
     initial = 32,
     maximum = 2 ** 16,
   ) {
@@ -42,9 +40,9 @@ export class BarretenbergWasmMain extends BarretenbergWasmBase {
     const shared = getSharedMemoryAvailable();
 
     this.logger(
-      `initial mem: ${initial} pages, ${initialMb}MiB. ` +
-        `max mem: ${maximum} pages, ${maxMb}MiB. ` +
-        `threads: ${threads}, shared: ${shared}`,
+      `Initializing bb wasm: initial memory ${initial} pages ${initialMb}MiB; ` +
+        `max memory: ${maximum} pages, ${maxMb}MiB; ` +
+        `threads: ${threads}; shared memory: ${shared}`,
     );
 
     this.memory = new WebAssembly.Memory({ initial, maximum, shared });
@@ -58,7 +56,7 @@ export class BarretenbergWasmMain extends BarretenbergWasmBase {
 
     // Create worker threads. Create 1 less than requested, as main thread counts as a thread.
     if (threads > 1) {
-      this.logger(`creating ${threads} worker threads...`);
+      this.logger(`Creating ${threads} worker threads`);
       this.workers = await Promise.all(Array.from({ length: threads - 1 }).map(createThreadWorker));
       this.remoteWasms = await Promise.all(this.workers.map(getRemoteBarretenbergWasm<BarretenbergWasmThreadWorker>));
       await Promise.all(this.remoteWasms.map(w => w.initThread(module, this.memory)));

--- a/barretenberg/ts/src/barretenberg_wasm/fetch_code/node/index.ts
+++ b/barretenberg/ts/src/barretenberg_wasm/fetch_code/node/index.ts
@@ -15,7 +15,7 @@ function getCurrentDir() {
 
 // eslint-disable-next-line @typescript-eslint/no-unused-vars
 export async function fetchCode(multithreaded: boolean, wasmPath?: string) {
-  const path = getCurrentDir() + '/../../barretenberg-threads.wasm.gz';
+  const path = wasmPath ?? getCurrentDir() + '/../../barretenberg-threads.wasm.gz';
   const compressedData = await readFile(path);
   const decompressedData = pako.ungzip(new Uint8Array(compressedData));
   return decompressedData.buffer;

--- a/barretenberg/ts/src/crs/node/index.ts
+++ b/barretenberg/ts/src/crs/node/index.ts
@@ -4,16 +4,22 @@ import { stat } from 'fs/promises';
 import createDebug from 'debug';
 import { homedir } from 'os';
 
-const debug = createDebug('bb.js:crs');
-
 /**
  * Generic CRS finder utility class.
  */
 export class Crs {
-  constructor(public readonly numPoints: number, public readonly path: string) {}
+  constructor(
+    public readonly numPoints: number,
+    public readonly path: string,
+    private readonly logger: (msg: string) => void = createDebug('bb.js:crs'),
+  ) {}
 
-  static async new(numPoints: number, crsPath = homedir() + '/.bb-crs') {
-    const crs = new Crs(numPoints, crsPath);
+  static async new(
+    numPoints: number,
+    crsPath = homedir() + '/.bb-crs',
+    logger: (msg: string) => void = createDebug('bb.js:crs'),
+  ) {
+    const crs = new Crs(numPoints, crsPath, logger);
     await crs.init();
     return crs;
   }
@@ -29,11 +35,11 @@ export class Crs {
       .catch(() => 0);
 
     if (g1FileSize >= this.numPoints * 64 && g1FileSize % 64 == 0 && g2FileSize == 128) {
-      debug(`using cached crs of size: ${g1FileSize / 64}`);
+      this.logger(`Using cached CRS of size ${g1FileSize / 64}`);
       return;
     }
 
-    debug(`downloading crs of size: ${this.numPoints}`);
+    this.logger(`Downloading CRS of size ${this.numPoints} into ${this.path}`);
     const crs = new NetCrs(this.numPoints);
     await crs.init();
     writeFileSync(this.path + '/bn254_g1.dat', crs.getG1Data());
@@ -68,10 +74,18 @@ export class Crs {
  * Generic Grumpkin CRS finder utility class.
  */
 export class GrumpkinCrs {
-  constructor(public readonly numPoints: number, public readonly path: string) {}
+  constructor(
+    public readonly numPoints: number,
+    public readonly path: string,
+    private readonly logger: (msg: string) => void = createDebug('bb.js:crs'),
+  ) {}
 
-  static async new(numPoints: number, crsPath = homedir() + '/.bb-crs') {
-    const crs = new GrumpkinCrs(numPoints, crsPath);
+  static async new(
+    numPoints: number,
+    crsPath = homedir() + '/.bb-crs',
+    logger: (msg: string) => void = createDebug('bb.js:crs'),
+  ) {
+    const crs = new GrumpkinCrs(numPoints, crsPath, logger);
     await crs.init();
     return crs;
   }
@@ -84,11 +98,11 @@ export class GrumpkinCrs {
       .catch(() => 0);
 
     if (g1FileSize >= this.numPoints * 64 && g1FileSize % 64 == 0) {
-      debug(`using cached crs of size: ${g1FileSize / 64}`);
+      this.logger(`Using cached Grumpkin CRS of size ${g1FileSize / 64}`);
       return;
     }
 
-    debug(`downloading crs of size: ${this.numPoints}`);
+    this.logger(`Downloading Grumpkin CRS of size ${this.numPoints} into ${this.path}`);
     const crs = new NetGrumpkinCrs(this.numPoints);
     await crs.init();
     writeFileSync(this.path + '/grumpkin_g1.dat', crs.getG1Data());


### PR DESCRIPTION
Adds a logger optional argument to bb classes and functions so that the default `debug` logger can be replaced with something else defined by the caller. We can then tweak this from aztec-packages to use the pino logger.

Also cleans up logs in the CLI a bit.

Also ensures the `wasmPath` is actually used for loading the wasm when it is specified.