### PR TITLE
chore: Do not set CI_FULL outside CI

### DIFF
--- a/ci3/source_refname
+++ b/ci3/source_refname
@@ -30,7 +30,9 @@ if [ -z "${REF_NAME:-}" ]; then
 fi
 
 if [ -z "${CI_FULL:-}" ]; then
-  if semver check "$REF_NAME"; then
+  if [ ${CI:-0} -lt 1 ]; then
+    export CI_FULL=0
+  elif semver check "$REF_NAME"; then
     export CI_FULL=1
   elif [ "$REF_NAME" == "master" ]; then
     export CI_FULL=1


### PR DESCRIPTION
Do not set the CI_FULL env var if running outside CI