### PR TITLE
chore: remove no longer supported extension from vscode/extension.json

### DIFF
--- a/.vscode/extensions.json
+++ b/.vscode/extensions.json
@@ -30,8 +30,6 @@
     // Make sure to select one of the themes suggested
     // (e.g. "Dark+")
     "jeff-hykin.better-cpp-syntax",
-    // Handle CMakeLists.txt editing
-    "twxs.cmake",
     // Integrates LLDB debugger
     "vadimcn.vscode-lldb",
     // Makes the CMake build output slightly prettier.


### PR DESCRIPTION
## Overview

This extension is no longer supported or developed, plus there is the microsoft version of it already listed