### PR TITLE
chore: Run prover test with fake proofs when requested

### DIFF
--- a/.test_skip_patterns
+++ b/.test_skip_patterns
@@ -66,9 +66,6 @@ simple e2e_p2p/reex
 simple e2e_p2p/slashing
 simple e2e_p2p/upgrade_governance_proposer
 
-# Started failing with some AVM proof error...
-e2e_prover/full fake
-
 # FAIL  ./flakey_e2e_inclusion_proofs_contract.test.ts
 # ● e2e_inclusion_proofs_contract › contract inclusion › proves public deployment of a contract
 #

--- a/yarn-project/end-to-end/scripts/run_test.sh
+++ b/yarn-project/end-to-end/scripts/run_test.sh
@@ -31,6 +31,7 @@ case "$type" in
       --mount type=tmpfs,target=/tmp,tmpfs-size=1g \
       --mount type=tmpfs,target=/tmp-jest,tmpfs-size=512m \
       -e JEST_CACHE_DIR=/tmp-jest \
+      -e FAKE_PROOFS \
       --workdir /root/aztec-packages/yarn-project/end-to-end \
       aztecprotocol/build:3.0 ./scripts/test_simple.sh $TEST
   ;;

--- a/yarn-project/end-to-end/src/e2e_prover/full.test.ts
+++ b/yarn-project/end-to-end/src/e2e_prover/full.test.ts
@@ -29,6 +29,8 @@ describe('full_prover', () => {
   let feeJuicePortal: GetContractReturnType<typeof FeeJuicePortalAbi, PublicClient<HttpTransport, Chain>>;
 
   beforeAll(async () => {
+    t.logger.warn(`Running suite with ${realProofs ? 'real' : 'fake'} proofs`);
+
     await t.applyBaseSnapshots();
     await t.applyMintSnapshot();
     await t.setup();


### PR DESCRIPTION
The env var FAKE_PROOFS was not forwarded to the docker container in the `run_test` e2e script, which caused the prover full test to always run with real proofs enabled.

This commit also removes it from the skip patterns.
