### PR TITLE
chore: always verify clientivc

### DIFF
--- a/barretenberg/cpp/src/barretenberg/dsl/acir_proofs/c_bind.cpp
+++ b/barretenberg/cpp/src/barretenberg/dsl/acir_proofs/c_bind.cpp
@@ -299,7 +299,6 @@ WASM_EXPORT void acir_prove_aztec_client(uint8_t const* acir_stack,
 
 WASM_EXPORT void acir_verify_aztec_client(uint8_t const* proof_buf, uint8_t const* vk_buf, bool* result)
 {
-
     const auto proof = from_buffer<ClientIVC::Proof>(from_buffer<std::vector<uint8_t>>(proof_buf));
     const auto vk = from_buffer<ClientIVC::VerificationKey>(from_buffer<std::vector<uint8_t>>(vk_buf));
 

--- a/barretenberg/ts/src/barretenberg/backend.ts
+++ b/barretenberg/ts/src/barretenberg/backend.ts
@@ -386,7 +386,7 @@ export class AztecClientBackend {
     await this.instantiate();
     const proofAndVk = await this.api.acirProveAztecClient(this.acirMsgpack, witnessMsgpack);
     const [proof, vk] = proofAndVk;
-    if (await this.api.acirVerifyAztecClient(proof, vk)) {
+    if (!await this.verify(proof, vk)) {
       throw new AztecClientBackendError("Failed to verify the private (ClientIVC) transaction proof!");
     }
     return proofAndVk;

--- a/barretenberg/ts/src/barretenberg/backend.ts
+++ b/barretenberg/ts/src/barretenberg/backend.ts
@@ -10,6 +10,12 @@ import {
   reconstructUltraPlonkProof,
 } from '../proof/index.js';
 
+export class AztecClientBackendError extends Error {
+  constructor(message: string) {
+    super(message);
+  }
+}
+
 export class UltraPlonkBackend {
   // These type assertions are used so that we don't
   // have to initialize `api` and `acirComposer` in the constructor.
@@ -378,7 +384,12 @@ export class AztecClientBackend {
 
   async prove(witnessMsgpack: Uint8Array[]): Promise<[Uint8Array, Uint8Array]> {
     await this.instantiate();
-    return this.api.acirProveAztecClient(this.acirMsgpack, witnessMsgpack);
+    const proofAndVk = await this.api.acirProveAztecClient(this.acirMsgpack, witnessMsgpack);
+    const [proof, vk] = proofAndVk;
+    if (await this.api.acirVerifyAztecClient(proof, vk)) {
+      throw new AztecClientBackendError("Failed to verify the private (ClientIVC) transaction proof!");
+    }
+    return proofAndVk;
   }
 
   async verify(proof: Uint8Array, vk: Uint8Array): Promise<boolean> {

--- a/yarn-project/stdlib/src/proofs/client_ivc_proof.ts
+++ b/yarn-project/stdlib/src/proofs/client_ivc_proof.ts
@@ -6,7 +6,7 @@ const CLIENT_IVC_PROOF_LENGTH = 172052;
 const CLIENT_IVC_VK_LENGTH = 2730;
 
 /**
- * TODO(https://github.com/AztecProtocol/aztec-packages/issues/7370) refactory this to
+ * TODO(https://github.com/AztecProtocol/aztec-packages/issues/7370) refactor this to
  * eventually we read all these VKs from the data tree instead of passing them
  */
 export class ClientIvcProof {


### PR DESCRIPTION
This prevents confusion around why the rollup would fail to verify an IVC proof. The cost is around 100ms and worth it at least until things are very stable, as this sanity checks issues with our proving.