### PR TITLE
chore: Bump l1 tx utils check interval from 10s to 1s

### DIFF
--- a/yarn-project/ethereum/src/l1_tx_utils.ts
+++ b/yarn-project/ethereum/src/l1_tx_utils.ts
@@ -146,7 +146,7 @@ export const l1TxUtilsConfigMappings: ConfigMappingsType<L1TxUtilsConfig> = {
   checkIntervalMs: {
     description: 'How often to check tx status',
     env: 'L1_TX_MONITOR_CHECK_INTERVAL_MS',
-    ...numberConfigHelper(10_000),
+    ...numberConfigHelper(1_000),
   },
   stallTimeMs: {
     description: 'How long before considering tx stalled',


### PR DESCRIPTION
Bumps the default interval in which L1 tx utils checks for a tx to be mined to 1s instead of 10s. Rationale is that, even though L1 slots are 12s, if our check lands immediately before the L1 block with our tx is mined, we'll have an almost 10s delay until we find out.

However, the real reason for this change is a flakey test. We had a failure in `e2e_block_building publishes two empty blocks` [here](http://ci.aztec-labs.com/51729a6d17479ea2):

```
19:01:51 [19:01:51.451] INFO: sequencer Built block 1 for slot 4 with 0 txs and 0 messages. 0 mana/s {"blockHash":"0x1212702ec583b94cbf4686cf5007fa294eb434c48f82fea510b2529e97353138","globalVariables":{"chainId":31337,"version":1,"blockNumber":1,"slotNumber":4,"timestamp":1740596737,"coinbase":"0x0000000000000000000000000000000000000000","feeRecipient":"0x0000000000000000000000000000000000000000000000000000000000000000","feePerDaGas":0,"feePerL2Gas":36251010},"txHashes":[],"eventName":"l2-block-built","creator":"0xf39fd6e51aad88f6f4ce6ab8827279cfffb92266","duration":428.95071100001223,"publicProcessDuration":0.5802530000219122,"rollupCircuitsDuration":30.97739500005264,"txCount":0,"blockNumber":1,"blockTimestamp":1740596737,"privateLogCount":0,"publicLogCount":0,"contractClassLogCount":0,"contractClassLogSize":0}
19:01:51 [19:01:51.454] VERBOSE: sequencer Attesting committee is empty
19:01:51 [19:01:51.663] WARN: sequencer-client Node does not support eth_simulateV1 API. Using fallback gas estimate: 12000000
19:01:51 [19:01:51.717] VERBOSE: ethereum:tx_delayer Sent tx immediately 0x5c5b4eb455f3f153d3f15c78301bb334f2153fec54053ea39d0bf276cbeda982
19:01:51 [19:01:51.717] VERBOSE: sequencer-client Sent L1 transaction 0x5c5b4eb455f3f153d3f15c78301bb334f2153fec54053ea39d0bf276cbeda982 {"gasLimit":14521879,"maxFeePerGas":"1.613205837","maxPriorityFeePerGas":"1.44","maxFeePerBlobGas":"0.000000001"}
19:01:51 [19:01:51.906] VERBOSE: blob-sink-client No blob sources available
19:01:52 [19:01:52.275] INFO: ethereum:cheat_codes Calling eth_getBlockByNumber with params: ["latest",true] on http://127.0.0.1/:43223
19:01:52 [19:01:52.280] INFO: ethereum:cheat_codes Calling hardhat_setStorageAt with params: ["0x610178da211fef7d417bc0e6fed39f05609ad788","0x0958201b72d64259285941dffd868dac55267471fcc73e8a06e1fd9cf8706362","0x0000000000000000000000000000000000000000000000000000000000000001"] on http://127.0.0.1/:43223
19:01:52 [19:01:52.282] WARN: ethereum:cheat_codes Set L1 storage for contract 0x610178da211fef7d417bc0e6fed39f05609ad788 at 4226519774845294989066245638914502055781420935494253450203740607592046551906 to 1
19:01:52 [19:01:52.285] INFO: aztecjs:cheat_codes Proven tip moved: 0 -> 1. Pending tip: 1.
19:01:52 [19:01:52.426] INFO: ethereum:cheat_codes Calling evm_setNextBlockTimestamp with params: [1740596761] on http://127.0.0.1/:43223
19:01:52 [19:01:52.429] INFO: ethereum:cheat_codes Calling hardhat_mine with params: [1] on http://127.0.0.1/:43223
19:01:52 [19:01:52.437] WARN: ethereum:cheat_codes Warped L1 timestamp to 1740596761
19:01:52 [19:01:52.438] WARN: foundation:test-date-provider Time set to 2025-02-26T19:06:01.000Z {"offset":248562,"timeMs":1740596761000}
19:01:52 [19:01:52.438] INFO: aztecjs:utils:watcher Slot 4 was filled, jumped to next slot
19:01:52 [19:01:52.440] VERBOSE: blob-sink-client No blob sources available
19:01:52 [19:01:52.962] VERBOSE: blob-sink-client No blob sources available
19:01:53 [19:01:53.280] INFO: ethereum:cheat_codes Calling eth_getBlockByNumber with params: ["latest",true] on http://127.0.0.1/:43223
19:01:53 [19:01:53.287] WARN: aztecjs:cheat_codes Block 1 is already proven
19:01:53 [19:01:53.363] WARN: sequencer Error closing forks for block processing {"generatedMessage":false,"code":"ERR_ASSERTION","actual":false,"expected":true,"operator":"=="}
19:01:53 [19:01:53.475] VERBOSE: blob-sink-client No blob sources available
19:01:53 [19:01:53.992] VERBOSE: blob-sink-client No blob sources available
19:01:54 [19:01:54.283] INFO: ethereum:cheat_codes Calling eth_getBlockByNumber with params: ["latest",true] on http://127.0.0.1/:43223
19:01:54 [19:01:54.290] WARN: aztecjs:cheat_codes Block 1 is already proven
19:01:54 [19:01:54.507] VERBOSE: blob-sink-client No blob sources available
19:01:55 [19:01:55.022] VERBOSE: blob-sink-client No blob sources available
19:01:55 [19:01:55.285] INFO: ethereum:cheat_codes Calling eth_getBlockByNumber with params: ["latest",true] on http://127.0.0.1/:43223
19:01:55 [19:01:55.294] WARN: aztecjs:cheat_codes Block 1 is already proven
19:01:55 [19:01:55.538] VERBOSE: blob-sink-client No blob sources available
19:01:56 [19:01:56.064] VERBOSE: blob-sink-client No blob sources available
19:01:56 [19:01:56.287] INFO: ethereum:cheat_codes Calling eth_getBlockByNumber with params: ["latest",true] on http://127.0.0.1/:43223
19:01:56 [19:01:56.296] WARN: aztecjs:cheat_codes Block 1 is already proven
19:01:56 [19:01:56.583] VERBOSE: blob-sink-client No blob sources available
19:01:57 [19:01:57.098] VERBOSE: blob-sink-client No blob sources available
19:01:57 [19:01:57.290] INFO: ethereum:cheat_codes Calling eth_getBlockByNumber with params: ["latest",true] on http://127.0.0.1/:43223
19:01:57 [19:01:57.299] WARN: aztecjs:cheat_codes Block 1 is already proven
19:01:57 [19:01:57.616] VERBOSE: blob-sink-client No blob sources available
19:01:58 [19:01:58.133] VERBOSE: blob-sink-client No blob sources available
19:01:58 [19:01:58.293] INFO: ethereum:cheat_codes Calling eth_getBlockByNumber with params: ["latest",true] on http://127.0.0.1/:43223
19:01:58 [19:01:58.302] WARN: aztecjs:cheat_codes Block 1 is already proven
19:01:58 [19:01:58.656] VERBOSE: blob-sink-client No blob sources available
19:01:59 [19:01:59.180] VERBOSE: blob-sink-client No blob sources available
19:01:59 [19:01:59.296] INFO: ethereum:cheat_codes Calling eth_getBlockByNumber with params: ["latest",true] on http://127.0.0.1/:43223
19:01:59 [19:01:59.306] WARN: aztecjs:cheat_codes Block 1 is already proven
19:01:59 [19:01:59.698] VERBOSE: blob-sink-client No blob sources available
19:02:00 [19:02:00.216] VERBOSE: blob-sink-client No blob sources available
19:02:00 [19:02:00.299] INFO: ethereum:cheat_codes Calling eth_getBlockByNumber with params: ["latest",true] on http://127.0.0.1/:43223
19:02:00 [19:02:00.309] WARN: aztecjs:cheat_codes Block 1 is already proven
19:02:00 [19:02:00.732] VERBOSE: blob-sink-client No blob sources available
19:02:01 [19:02:01.250] VERBOSE: blob-sink-client No blob sources available
19:02:01 [19:02:01.301] INFO: ethereum:cheat_codes Calling eth_getBlockByNumber with params: ["latest",true] on http://127.0.0.1/:43223
19:02:01 [19:02:01.313] WARN: aztecjs:cheat_codes Block 1 is already proven
19:02:01 [19:02:01.420] INFO: node Stopping
19:02:01 [19:02:01.746] INFO: sequencer:publisher Bundled [propose] transaction [succeeded]
```

This test runs with anvil automine, so it has an aggressive timeout (10s). However, here there was a 10s delay between the sequencer sending the tx, and it acknowledging that it was actually mined and proceeding. It does not happen locally. My hunch is that anvil failed to mine the tx immediately due to contention issues, so l1-tx-utils did not immediately report back (as it usually does with automine), and that triggered the 10s delay.

If we don't want to change this default, we can tweak the value in the test `setup` so that, if we're in automine, we check much more aggressively, or we pick a value based on the L1 slot time used in tests, something like:

```ts
    // Tweak tx-l1-utils so its check interval matches our custom L1 slot duration, unless caller specified a value
    // If there is no slot duration, we're running in automine, so check aggressively (say, every 200ms)
    if (!opts.checkIntervalMs) {
      config.checkIntervalMs = opts.ethereumSlotDuration ? (opts.ethereumSlotDuration * 1000) / 10 : 200;
    }
```