### PR TITLE
chore: complete updates to build-images from msrv bump

### DIFF
--- a/bootstrap.sh
+++ b/bootstrap.sh
@@ -48,11 +48,12 @@ function check_toolchains {
     exit 1
   fi
   # Check rust version.
-  if ! rustup show | grep "1.75" > /dev/null; then
+  local rust_version="1.85.0"
+  if ! rustup show | grep $rust_version > /dev/null; then
     encourage_dev_container
-    echo "Rust version 1.75 not installed."
+    echo "Rust version $rust_version not installed."
     echo "Installation:"
-    echo "  curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh -s -- -y --default-toolchain 1.85.0"
+    echo "  curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh -s -- -y --default-toolchain $rust_version"
     exit 1
   fi
   # Check wasi-sdk version.

--- a/bootstrap.sh
+++ b/bootstrap.sh
@@ -47,14 +47,19 @@ function check_toolchains {
     echo "Installation: sudo apt install clang-16"
     exit 1
   fi
-  # Check rust version.
+  # Check rustup installed.
   local rust_version=$(yq '.toolchain.channel' ./noir/noir-repo/rust-toolchain.toml)
-  if ! rustup show | grep $rust_version > /dev/null; then
+  if ! command -v rustup > /dev/null; then
     encourage_dev_container
-    echo "Rust version $rust_version not installed."
+    echo "Rustup not installed."
     echo "Installation:"
     echo "  curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh -s -- -y --default-toolchain $rust_version"
     exit 1
+  fi
+  if ! rustup show | grep $rust_version > /dev/null; then
+    # Cargo will download necessary version of rust at runtime but warn to alert that an update to the build-image
+    # is desirable.
+    echo -e "${bold}${yellow}WARN: Rust ${rust_version} is not installed. Performance will be degraded.${reset}"
   fi
   # Check wasi-sdk version.
   if ! cat /opt/wasi-sdk/VERSION 2> /dev/null | grep 22.0 > /dev/null; then

--- a/bootstrap.sh
+++ b/bootstrap.sh
@@ -48,7 +48,7 @@ function check_toolchains {
     exit 1
   fi
   # Check rust version.
-  local rust_version="1.85.0"
+  local rust_version=$(yq '.toolchain.channel' ./noir/noir-repo/rust-toolchain.toml)
   if ! rustup show | grep $rust_version > /dev/null; then
     encourage_dev_container
     echo "Rust version $rust_version not installed."

--- a/build-images/src/Dockerfile
+++ b/build-images/src/Dockerfile
@@ -150,7 +150,7 @@ ENV RUSTUP_HOME=/opt/rust/rustup
 ENV CARGO_HOME=/opt/rust/cargo
 ENV PATH="/opt/rust/cargo/bin:$PATH"
 RUN curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh -s -- -y --default-toolchain 1.85.0 && \
-    rustup target add wasm32-unknown-unknown wasm32-wasi aarch64-apple-darwin && \
+    rustup target add wasm32-unknown-unknown wasm32-wasip1 aarch64-apple-darwin && \
     chmod -R a+w /opt/rust
 
 # Install corepack and yarn.


### PR DESCRIPTION
The rust MSRV got bumped in https://github.com/AztecProtocol/aztec-packages/pull/12298 but we didn't catch that we're still using a stale devbox image due to the check in `bootstrap.sh` not being updated properly. CI's passing due to cargo automatically installing the proper toolchain at runtime.

I've completed the relevant changes to fix the build image / `./bootstrap.sh check` in this PR but I'm not up to date on how pushing an update to devbox should be done (or if CI still automatically pushes to dockerhub anymore).

@charlielye @ludamad Could one of you help me with fixing this?