### PR TITLE
feat: expose bb_wasm_path in foundation and bb-prover

### DIFF
--- a/barretenberg/ts/src/barretenberg_wasm/fetch_code/browser/index.ts
+++ b/barretenberg/ts/src/barretenberg_wasm/fetch_code/browser/index.ts
@@ -6,7 +6,10 @@ export async function fetchCode(multithreaded: boolean, wasmPath?: string) {
   let url: string;
   if (wasmPath) {
     const suffix = multithreaded ? '-threads' : '';
-    url = `${wasmPath}/barretenberg${suffix}.wasm.gz`;
+    const filePath = wasmPath.split('/').slice(0, -1).join('/');
+    const fileNameWithExtensions = wasmPath.split('/').pop();
+    const [fileName, ...extensions] = fileNameWithExtensions!.split('.');
+    url = `${filePath}/${fileName}${suffix}.${extensions.join('.')}`;
   } else {
     url = multithreaded
       ? (await import(/* webpackIgnore: true */ './barretenberg-threads.js')).default

--- a/boxes/boxes/react/src/config.ts
+++ b/boxes/boxes/react/src/config.ts
@@ -1,5 +1,4 @@
 import { createPXEClient, PXE } from '@aztec/aztec.js';
-import { BoxReactContractArtifact } from '../artifacts/BoxReact';
 import { getDeployedTestAccountsWallets } from '@aztec/accounts/testing/lazy';
 
 export class PrivateEnv {
@@ -22,6 +21,3 @@ export class PrivateEnv {
 }
 
 export const deployerEnv = await PrivateEnv.create(process.env.PXE_URL || 'http://localhost:8080');
-
-const IGNORE_FUNCTIONS = ['constructor'];
-export const filteredInterface = BoxReactContractArtifact.functions.filter(f => !IGNORE_FUNCTIONS.includes(f.name));

--- a/boxes/boxes/react/src/hooks/useContract.tsx
+++ b/boxes/boxes/react/src/hooks/useContract.tsx
@@ -2,7 +2,6 @@ import { useState } from 'react';
 import { deployerEnv } from '../config';
 
 import { Contract, Fr } from '@aztec/aztec.js';
-import { BoxReactContract } from '../../artifacts/BoxReact';
 import { toast } from 'react-toastify';
 
 export function useContract() {
@@ -16,11 +15,9 @@ export function useContract() {
     const wallet = await deployerEnv.getWallet();
     const salt = Fr.random();
 
-    const tx = await BoxReactContract.deploy(
-      wallet,
-      Fr.random(),
-      wallet.getCompleteAddress().address,
-    ).send({
+    const { BoxReactContract } = await import('../../artifacts/BoxReact');
+
+    const tx = await BoxReactContract.deploy(wallet, Fr.random(), wallet.getCompleteAddress().address).send({
       contractAddressSalt: salt,
     });
     const contract = await toast.promise(tx.deployed(), {

--- a/boxes/boxes/react/src/pages/contract.tsx
+++ b/boxes/boxes/react/src/pages/contract.tsx
@@ -1,11 +1,14 @@
 import { useState } from 'react';
 import { Contract } from '@aztec/aztec.js';
 import { useNumber } from '../hooks/useNumber';
-import { filteredInterface } from '../config';
+
+const IGNORE_FUNCTIONS = ['constructor', 'process_log', 'sync_notes'];
 
 export function ContractComponent({ contract }: { contract: Contract }) {
   const [showInput, setShowInput] = useState(true);
   const { wait, getNumber, setNumber } = useNumber({ contract });
+
+  const filteredInterface = contract.artifact.functions.filter(f => !IGNORE_FUNCTIONS.includes(f.name));
 
   return (
     <div>

--- a/boxes/boxes/vite/playwright.config.ts
+++ b/boxes/boxes/vite/playwright.config.ts
@@ -5,7 +5,7 @@ export default defineConfig({
   testMatch: "**.spec.ts",
   fullyParallel: true,
   retries: 3,
-  workers: process.env.CI ? 1 : 3,
+  workers: 1,
   reporter: "list",
   use: {
     baseURL: "http://127.0.0.1:5173",

--- a/boxes/boxes/vite/src/config.ts
+++ b/boxes/boxes/vite/src/config.ts
@@ -13,7 +13,6 @@ import { PXEServiceConfig, getPXEServiceConfig } from "@aztec/pxe/config";
 import { KVPxeDatabase } from "@aztec/pxe/database";
 import { PXEService } from "@aztec/pxe/service";
 import { WASMSimulator } from "@aztec/simulator/client";
-import { BoxReactContractArtifact } from "../artifacts/BoxReact";
 import { LazyProtocolContractsProvider } from "@aztec/protocol-contracts/providers/lazy";
 
 export class PrivateEnv {
@@ -31,7 +30,7 @@ export class PrivateEnv {
     const simulationProvider = new WASMSimulator();
     const proofCreator = new BBWASMLazyPrivateKernelProver(
       simulationProvider,
-      16
+      16,
     );
     const l1Contracts = await aztecNode.getL1ContractAddresses();
     const configWithContracts = {
@@ -42,7 +41,7 @@ export class PrivateEnv {
     const store = await createStore(
       "pxe_data",
       configWithContracts,
-      createLogger("pxe:data:idb")
+      createLogger("pxe:data:idb"),
     );
 
     const keyStore = new KeyStore(store);
@@ -60,7 +59,7 @@ export class PrivateEnv {
       proofCreator,
       simulationProvider,
       protocolContractsProvider,
-      config
+      config,
     );
     await this.pxe.init();
     const [accountData] = await getInitialTestAccounts();
@@ -68,7 +67,7 @@ export class PrivateEnv {
       this.pxe,
       accountData.secret,
       accountData.signingKey,
-      accountData.salt
+      accountData.salt,
     );
     await account.register();
     this.wallet = await account.getWallet();
@@ -80,8 +79,3 @@ export class PrivateEnv {
 }
 
 export const deployerEnv = new PrivateEnv();
-
-const IGNORE_FUNCTIONS = ["constructor", "process_log", "sync_notes"];
-export const filteredInterface = BoxReactContractArtifact.functions.filter(
-  (f) => !IGNORE_FUNCTIONS.includes(f.name)
-);

--- a/boxes/boxes/vite/src/hooks/useContract.tsx
+++ b/boxes/boxes/vite/src/hooks/useContract.tsx
@@ -2,7 +2,6 @@ import { useState } from "react";
 import { deployerEnv } from "../config";
 
 import { Contract, Fr } from "@aztec/aztec.js";
-import { BoxReactContract } from "../../artifacts/BoxReact";
 import { toast } from "react-toastify";
 
 export function useContract() {
@@ -16,6 +15,8 @@ export function useContract() {
     await deployerEnv.init();
     const wallet = await deployerEnv.getWallet();
     const salt = Fr.random();
+
+    const { BoxReactContract } = await import("../../artifacts/BoxReact");
 
     const tx = await BoxReactContract.deploy(
       wallet,

--- a/boxes/boxes/vite/src/pages/contract.tsx
+++ b/boxes/boxes/vite/src/pages/contract.tsx
@@ -1,11 +1,16 @@
-import { useState } from 'react';
-import { Contract } from '@aztec/aztec.js';
-import { useNumber } from '../hooks/useNumber';
-import { filteredInterface } from '../config';
+import { useState } from "react";
+import { Contract } from "@aztec/aztec.js";
+import { useNumber } from "../hooks/useNumber";
+
+const IGNORE_FUNCTIONS = ["constructor", "process_log", "sync_notes"];
 
 export function ContractComponent({ contract }: { contract: Contract }) {
   const [showInput, setShowInput] = useState(true);
   const { wait, getNumber, setNumber } = useNumber({ contract });
+
+  const filteredInterface = contract.artifact.functions.filter(
+    (f) => !IGNORE_FUNCTIONS.includes(f.name),
+  );
 
   return (
     <div>
@@ -15,7 +20,7 @@ export function ContractComponent({ contract }: { contract: Contract }) {
         <select name="viewFunctions" id="viewFunctions">
           {filteredInterface.map(
             (fn, index) =>
-              fn.functionType === 'unconstrained' && (
+              fn.functionType === "unconstrained" && (
                 <option key={index} value={index}>
                   {fn.name}
                 </option>
@@ -29,17 +34,26 @@ export function ContractComponent({ contract }: { contract: Contract }) {
 
       <form onSubmit={setNumber}>
         <label htmlFor="functions">Functions:</label>
-        <select name="functions" id="functions" onChange={() => setShowInput(true)}>
+        <select
+          name="functions"
+          id="functions"
+          onChange={() => setShowInput(true)}
+        >
           {filteredInterface.map(
             (fn, index) =>
-              fn.functionType !== 'unconstrained' && (
+              fn.functionType !== "unconstrained" && (
                 <option key={index} value={index}>
                   {fn.name}
                 </option>
               ),
           )}
         </select>
-        <input type="number" name="numberToSet" id="numberToSet" hidden={!showInput} />
+        <input
+          type="number"
+          name="numberToSet"
+          id="numberToSet"
+          hidden={!showInput}
+        />
         <button type="submit" disabled={wait}>
           Write
         </button>

--- a/boxes/boxes/vite/vite.config.ts
+++ b/boxes/boxes/vite/vite.config.ts
@@ -24,7 +24,7 @@ const nodePolyfillsFix = (options?: PolyfillOptions | undefined): Plugin => {
 
 // https://vite.dev/config/
 export default defineConfig({
-  logLevel: "error",
+  //logLevel: "error",
   server: {
     // Headers needed for bb WASM to work in multithreaded mode
     headers: {

--- a/playground/.env
+++ b/playground/.env
@@ -1,2 +1,4 @@
-VITE_AZTEC_NODE_URL=http://localhost:8080
-VITE_LOG_LEVEL=debug
+AZTEC_NODE_URL=http://localhost:8080
+LOG_LEVEL=verbose
+# Uncomment to provide a custom barretenberg.wasm file
+#BB_WASM_PATH='/assets/barretenberg.wasm.gz'

--- a/playground/package.json
+++ b/playground/package.json
@@ -46,6 +46,7 @@
     "typescript": "~5.7.3",
     "typescript-eslint": "^8.11.0",
     "vite": "^6.0.11",
-    "vite-plugin-node-polyfills": "^0.23.0"
+    "vite-plugin-node-polyfills": "^0.23.0",
+    "vite-plugin-static-copy": "^2.2.0"
   }
 }

--- a/playground/src/aztecEnv.ts
+++ b/playground/src/aztecEnv.ts
@@ -12,19 +12,11 @@ import { L2TipsStore } from "@aztec/kv-store/stores";
 import { createStore } from "@aztec/kv-store/indexeddb";
 import { BBWASMLazyPrivateKernelProver } from "@aztec/bb-prover/wasm/lazy";
 import { WASMSimulator } from "@aztec/simulator/client";
-import { debug } from "debug";
 import { createContext } from "react";
 import { NetworkDB, WalletDB } from "./utils/storage";
 import { type ContractFunctionInteractionTx } from "./utils/txs";
 import { type Logger, createLogger } from "@aztec/aztec.js/log";
 import { LazyProtocolContractsProvider } from "@aztec/protocol-contracts/providers/lazy";
-
-process.env = Object.keys(import.meta.env).reduce((acc, key) => {
-  acc[key.replace("VITE_", "")] = import.meta.env[key];
-  return acc;
-}, {});
-
-debug.enable("*");
 
 const logLevel = [
   "silent",

--- a/playground/vite.config.ts
+++ b/playground/vite.config.ts
@@ -1,6 +1,7 @@
-import { defineConfig, searchForWorkspaceRoot } from "vite";
+import { defineConfig, loadEnv, searchForWorkspaceRoot } from "vite";
 import react from "@vitejs/plugin-react-swc";
 import { PolyfillOptions, nodePolyfills } from "vite-plugin-node-polyfills";
+// import { viteStaticCopy } from "vite-plugin-static-copy";
 
 // Unfortunate, but needed due to https://github.com/davidmyersdev/vite-plugin-node-polyfills/issues/81
 // Suspected to be because of the yarn workspace setup, but not sure
@@ -21,27 +22,51 @@ const nodePolyfillsFix = (options?: PolyfillOptions | undefined): Plugin => {
 };
 
 // https://vite.dev/config/
-export default defineConfig({
-  server: {
-    // Headers needed for bb WASM to work in multithreaded mode
-    headers: {
-      "Cross-Origin-Opener-Policy": "same-origin",
-      "Cross-Origin-Embedder-Policy": "require-corp",
+export default defineConfig(({ mode }) => {
+  const env = loadEnv(mode, process.cwd(), "");
+  return {
+    server: {
+      // Headers needed for bb WASM to work in multithreaded mode
+      headers: {
+        "Cross-Origin-Opener-Policy": "same-origin",
+        "Cross-Origin-Embedder-Policy": "require-corp",
+      },
+      // Allow vite to serve files from these directories, since they are symlinked
+      // These are the protocol circuit artifacts and noir WASMs.
+      fs: {
+        allow: [
+          searchForWorkspaceRoot(process.cwd()),
+          "../yarn-project/noir-protocol-circuits-types/artifacts",
+          "../noir/packages/noirc_abi/web",
+          "../noir/packages/acvm_js/web",
+          "../barretenberg/ts/dest/browser",
+        ],
+      },
     },
-    // Allow vite to serve files from these directories, since they are symlinked
-    // These are the protocol circuit artifacts and noir WASMs.
-    fs: {
-      allow: [
-        searchForWorkspaceRoot(process.cwd()),
-        "../yarn-project/noir-protocol-circuits-types/artifacts",
-        "../noir/packages/noirc_abi/web",
-        "../noir/packages/acvm_js/web",
-        "../barretenberg/ts/dest/browser",
-      ],
+    plugins: [
+      react({ jsxImportSource: "@emotion/react" }),
+      nodePolyfillsFix({ include: ["buffer", "path"] }),
+      // This is unnecessary unless BB_WASM_PATH is defined (default would be /assets/barretenberg.wasm.gz)
+      // Left as an example of how to use a different bb wasm file than the default lazily loaded one
+      // viteStaticCopy({
+      //   targets: [
+      //     {
+      //       src: "../barretenberg/ts/dest/node/barretenberg_wasm/*.gz",
+      //       dest: "assets/",
+      //     },
+      //   ],
+      // }),
+    ],
+    define: {
+      "process.env": JSON.stringify({
+        LOG_LEVEL: env.LOG_LEVEL,
+        AZTEC_NODE_URL: env.AZTEC_NODE_URL,
+        // The path to a custom WASM file for bb.js.
+        // Only the single-threaded file name is needed, the multithreaded file name will be inferred
+        // by adding the -threads suffix: e.g: /assets/barretenberg.wasm.gz -> /assets/barretenberg-threads.wasm.gz
+        // Files can be compressed or uncompressed, but must be gzipped if compressed.
+        BB_WASM_PATH: env.BB_WASM_PATH,
+      }),
     },
-  },
-  plugins: [
-    react({ jsxImportSource: "@emotion/react" }),
-    nodePolyfillsFix({ include: ["buffer", "process", "path"] }),
-  ],
+  };
 });

--- a/playground/yarn.lock
+++ b/playground/yarn.lock
@@ -1490,6 +1490,16 @@ __metadata:
   languageName: node
   linkType: hard
 
+"anymatch@npm:~3.1.2":
+  version: 3.1.3
+  resolution: "anymatch@npm:3.1.3"
+  dependencies:
+    normalize-path: "npm:^3.0.0"
+    picomatch: "npm:^2.0.4"
+  checksum: 10c0/57b06ae984bc32a0d22592c87384cd88fe4511b1dd7581497831c56d41939c8a001b28e7b853e1450f2bf61992dfcaa8ae2d0d161a0a90c4fb631ef07098fbac
+  languageName: node
+  linkType: hard
+
 "argparse@npm:^2.0.1":
   version: 2.0.1
   resolution: "argparse@npm:2.0.1"
@@ -1562,6 +1572,13 @@ __metadata:
   languageName: node
   linkType: hard
 
+"binary-extensions@npm:^2.0.0":
+  version: 2.3.0
+  resolution: "binary-extensions@npm:2.3.0"
+  checksum: 10c0/75a59cafc10fb12a11d510e77110c6c7ae3f4ca22463d52487709ca7f18f69d886aa387557cc9864fbdb10153d0bdb4caacabf11541f55e89ed6e18d12ece2b5
+  languageName: node
+  linkType: hard
+
 "bn.js@npm:^4.0.0, bn.js@npm:^4.1.0, bn.js@npm:^4.11.9":
   version: 4.12.1
   resolution: "bn.js@npm:4.12.1"
@@ -1595,7 +1612,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"braces@npm:^3.0.3":
+"braces@npm:^3.0.3, braces@npm:~3.0.2":
   version: 3.0.3
   resolution: "braces@npm:3.0.3"
   dependencies:
@@ -1785,6 +1802,25 @@ __metadata:
     ansi-styles: "npm:^4.1.0"
     supports-color: "npm:^7.1.0"
   checksum: 10c0/4a3fef5cc34975c898ffe77141450f679721df9dde00f6c304353fa9c8b571929123b26a0e4617bde5018977eb655b31970c297b91b63ee83bb82aeb04666880
+  languageName: node
+  linkType: hard
+
+"chokidar@npm:^3.5.3":
+  version: 3.6.0
+  resolution: "chokidar@npm:3.6.0"
+  dependencies:
+    anymatch: "npm:~3.1.2"
+    braces: "npm:~3.0.2"
+    fsevents: "npm:~2.3.2"
+    glob-parent: "npm:~5.1.2"
+    is-binary-path: "npm:~2.1.0"
+    is-glob: "npm:~4.0.1"
+    normalize-path: "npm:~3.0.0"
+    readdirp: "npm:~3.6.0"
+  dependenciesMeta:
+    fsevents:
+      optional: true
+  checksum: 10c0/8361dcd013f2ddbe260eacb1f3cb2f2c6f2b0ad118708a343a5ed8158941a39cb8fb1d272e0f389712e74ee90ce8ba864eece9e0e62b9705cb468a2f6d917462
   languageName: node
   linkType: hard
 
@@ -2415,7 +2451,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"fast-glob@npm:^3.3.2":
+"fast-glob@npm:^3.2.11, fast-glob@npm:^3.3.2":
   version: 3.3.3
   resolution: "fast-glob@npm:3.3.3"
   dependencies:
@@ -2531,6 +2567,17 @@ __metadata:
   languageName: node
   linkType: hard
 
+"fs-extra@npm:^11.1.0":
+  version: 11.3.0
+  resolution: "fs-extra@npm:11.3.0"
+  dependencies:
+    graceful-fs: "npm:^4.2.0"
+    jsonfile: "npm:^6.0.1"
+    universalify: "npm:^2.0.0"
+  checksum: 10c0/5f95e996186ff45463059feb115a22fb048bdaf7e487ecee8a8646c78ed8fdca63630e3077d4c16ce677051f5e60d3355a06f3cd61f3ca43f48cc58822a44d0a
+  languageName: node
+  linkType: hard
+
 "fs-minipass@npm:^3.0.0":
   version: 3.0.3
   resolution: "fs-minipass@npm:3.0.3"
@@ -2594,7 +2641,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"glob-parent@npm:^5.1.2":
+"glob-parent@npm:^5.1.2, glob-parent@npm:~5.1.2":
   version: 5.1.2
   resolution: "glob-parent@npm:5.1.2"
   dependencies:
@@ -2656,7 +2703,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"graceful-fs@npm:^4.2.6":
+"graceful-fs@npm:^4.1.6, graceful-fs@npm:^4.2.0, graceful-fs@npm:^4.2.6":
   version: 4.2.11
   resolution: "graceful-fs@npm:4.2.11"
   checksum: 10c0/386d011a553e02bc594ac2ca0bd6d9e4c22d7fa8cfbfc448a6d148c59ea881b092db9dbe3547ae4b88e55f1b01f7c4a2ecc53b310c042793e63aa44cf6c257f2
@@ -2877,6 +2924,15 @@ __metadata:
   languageName: node
   linkType: hard
 
+"is-binary-path@npm:~2.1.0":
+  version: 2.1.0
+  resolution: "is-binary-path@npm:2.1.0"
+  dependencies:
+    binary-extensions: "npm:^2.0.0"
+  checksum: 10c0/a16eaee59ae2b315ba36fad5c5dcaf8e49c3e27318f8ab8fa3cdb8772bf559c8d1ba750a589c2ccb096113bb64497084361a25960899cb6172a6925ab6123d38
+  languageName: node
+  linkType: hard
+
 "is-callable@npm:^1.2.7":
   version: 1.2.7
   resolution: "is-callable@npm:1.2.7"
@@ -2919,7 +2975,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"is-glob@npm:^4.0.0, is-glob@npm:^4.0.1, is-glob@npm:^4.0.3":
+"is-glob@npm:^4.0.0, is-glob@npm:^4.0.1, is-glob@npm:^4.0.3, is-glob@npm:~4.0.1":
   version: 4.0.3
   resolution: "is-glob@npm:4.0.3"
   dependencies:
@@ -3073,6 +3129,19 @@ __metadata:
   version: 1.0.1
   resolution: "json-stable-stringify-without-jsonify@npm:1.0.1"
   checksum: 10c0/cb168b61fd4de83e58d09aaa6425ef71001bae30d260e2c57e7d09a5fd82223e2f22a042dedaab8db23b7d9ae46854b08bb1f91675a8be11c5cffebef5fb66a5
+  languageName: node
+  linkType: hard
+
+"jsonfile@npm:^6.0.1":
+  version: 6.1.0
+  resolution: "jsonfile@npm:6.1.0"
+  dependencies:
+    graceful-fs: "npm:^4.1.6"
+    universalify: "npm:^2.0.0"
+  dependenciesMeta:
+    graceful-fs:
+      optional: true
+  checksum: 10c0/4f95b5e8a5622b1e9e8f33c96b7ef3158122f595998114d1e7f03985649ea99cb3cd99ce1ed1831ae94c8c8543ab45ebd044207612f31a56fd08462140e46865
   languageName: node
   linkType: hard
 
@@ -3511,6 +3580,13 @@ __metadata:
   languageName: node
   linkType: hard
 
+"normalize-path@npm:^3.0.0, normalize-path@npm:~3.0.0":
+  version: 3.0.0
+  resolution: "normalize-path@npm:3.0.0"
+  checksum: 10c0/e008c8142bcc335b5e38cf0d63cfd39d6cf2d97480af9abdbe9a439221fd4d749763bab492a8ee708ce7a194bb00c9da6d0a115018672310850489137b3da046
+  languageName: node
+  linkType: hard
+
 "nosleep.js@npm:^0.12.0":
   version: 0.12.0
   resolution: "nosleep.js@npm:0.12.0"
@@ -3723,7 +3799,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"picomatch@npm:^2.3.1":
+"picomatch@npm:^2.0.4, picomatch@npm:^2.2.1, picomatch@npm:^2.3.1":
   version: 2.3.1
   resolution: "picomatch@npm:2.3.1"
   checksum: 10c0/26c02b8d06f03206fc2ab8d16f19960f2ff9e81a658f831ecb656d8f17d9edc799e8364b1f4a7873e89d9702dff96204be0fa26fe4181f6843f040f819dac4be
@@ -3783,6 +3859,7 @@ __metadata:
     typescript-eslint: "npm:^8.11.0"
     vite: "npm:^6.0.11"
     vite-plugin-node-polyfills: "npm:^0.23.0"
+    vite-plugin-static-copy: "npm:^2.2.0"
   languageName: unknown
   linkType: soft
 
@@ -4009,6 +4086,15 @@ __metadata:
     string_decoder: "npm:^1.1.1"
     util-deprecate: "npm:^1.0.1"
   checksum: 10c0/e37be5c79c376fdd088a45fa31ea2e423e5d48854be7a22a58869b4e84d25047b193f6acb54f1012331e1bcd667ffb569c01b99d36b0bd59658fb33f513511b7
+  languageName: node
+  linkType: hard
+
+"readdirp@npm:~3.6.0":
+  version: 3.6.0
+  resolution: "readdirp@npm:3.6.0"
+  dependencies:
+    picomatch: "npm:^2.2.1"
+  checksum: 10c0/6fa848cf63d1b82ab4e985f4cf72bd55b7dcfd8e0a376905804e48c3634b7e749170940ba77b32804d5fe93b3cc521aa95a8d7e7d725f830da6d93f3669ce66b
   languageName: node
   linkType: hard
 
@@ -4620,6 +4706,13 @@ __metadata:
   languageName: node
   linkType: hard
 
+"universalify@npm:^2.0.0":
+  version: 2.0.1
+  resolution: "universalify@npm:2.0.1"
+  checksum: 10c0/73e8ee3809041ca8b818efb141801a1004e3fc0002727f1531f4de613ea281b494a40909596dae4a042a4fb6cd385af5d4db2e137b1362e0e91384b828effd3a
+  languageName: node
+  linkType: hard
+
 "uri-js@npm:^4.2.2":
   version: 4.4.1
   resolution: "uri-js@npm:4.4.1"
@@ -4668,6 +4761,20 @@ __metadata:
   peerDependencies:
     vite: ^2.0.0 || ^3.0.0 || ^4.0.0 || ^5.0.0 || ^6.0.0
   checksum: 10c0/439088aa71852737433f360fe5e99f246884885afb11715106b2e4c3c4f0dfc162037831b6b5a2ab4be30faafe5db6a3af37bbdf7eda5788dae2fdb9a44e029e
+  languageName: node
+  linkType: hard
+
+"vite-plugin-static-copy@npm:^2.2.0":
+  version: 2.2.0
+  resolution: "vite-plugin-static-copy@npm:2.2.0"
+  dependencies:
+    chokidar: "npm:^3.5.3"
+    fast-glob: "npm:^3.2.11"
+    fs-extra: "npm:^11.1.0"
+    picocolors: "npm:^1.0.0"
+  peerDependencies:
+    vite: ^5.0.0 || ^6.0.0
+  checksum: 10c0/c5174926d66776697bfe8aa3013bfea62a48868c683784973b9b329c43b57a915685031047d397a9c0ae8dd1fd734bde37438af3939d395f9b82ada341b4fff7
   languageName: node
   linkType: hard
 

--- a/yarn-project/bb-prover/src/wasm/bb_wasm_private_kernel_prover.ts
+++ b/yarn-project/bb-prover/src/wasm/bb_wasm_private_kernel_prover.ts
@@ -26,7 +26,7 @@ export abstract class BBWASMPrivateKernelProver extends BBPrivateKernelProver {
     this.log.info(`Generating ClientIVC proof...`);
     const backend = new AztecClientBackend(
       acirs.map(acir => ungzip(acir)),
-      { threads: this.threads },
+      { threads: this.threads, logger: this.log.verbose, wasmPath: process.env.BB_WASM_PATH },
     );
 
     const [proof, vk] = await backend.prove(witnessStack.map(witnessMap => ungzip(serializeWitness(witnessMap))));

--- a/yarn-project/foundation/src/crypto/aes128/index.ts
+++ b/yarn-project/foundation/src/crypto/aes128/index.ts
@@ -22,7 +22,7 @@ export class Aes128 {
     paddingBuffer.fill(numPaddingBytes);
     const input = Buffer.concat([data, paddingBuffer]);
 
-    const api = await BarretenbergSync.initSingleton();
+    const api = await BarretenbergSync.initSingleton(process.env.BB_WASM_PATH);
     return Buffer.from(
       api.aesEncryptBufferCbc(new RawBuffer(input), new RawBuffer(iv), new RawBuffer(key), input.length),
     );
@@ -37,7 +37,7 @@ export class Aes128 {
    * @returns Decrypted data.
    */
   public async decryptBufferCBCKeepPadding(data: Uint8Array, iv: Uint8Array, key: Uint8Array): Promise<Buffer> {
-    const api = await BarretenbergSync.initSingleton();
+    const api = await BarretenbergSync.initSingleton(process.env.BB_WASM_PATH);
     const paddedBuffer = Buffer.from(
       api.aesDecryptBufferCbc(new RawBuffer(data), new RawBuffer(iv), new RawBuffer(key), data.length),
     );

--- a/yarn-project/foundation/src/crypto/ecdsa/index.ts
+++ b/yarn-project/foundation/src/crypto/ecdsa/index.ts
@@ -17,7 +17,7 @@ export class Ecdsa {
    * @returns A secp256k1 public key.
    */
   public async computePublicKey(privateKey: Buffer): Promise<Buffer> {
-    const api = await BarretenbergSync.initSingleton();
+    const api = await BarretenbergSync.initSingleton(process.env.BB_WASM_PATH);
     const [result] = api.getWasm().callWasmExport('ecdsa__compute_public_key', [privateKey], [64]);
     return Buffer.from(result);
   }
@@ -29,7 +29,7 @@ export class Ecdsa {
    * @returns An ECDSA signature of the form (r, s, v).
    */
   public async constructSignature(msg: Uint8Array, privateKey: Buffer) {
-    const api = await BarretenbergSync.initSingleton();
+    const api = await BarretenbergSync.initSingleton(process.env.BB_WASM_PATH);
     const messageArray = concatenateUint8Arrays([numToInt32BE(msg.length), msg]);
     const [r, s, v] = api
       .getWasm()
@@ -44,7 +44,7 @@ export class Ecdsa {
    * @returns The secp256k1 public key of the signer.
    */
   public async recoverPublicKey(msg: Uint8Array, sig: EcdsaSignature): Promise<Buffer> {
-    const api = await BarretenbergSync.initSingleton();
+    const api = await BarretenbergSync.initSingleton(process.env.BB_WASM_PATH);
     const messageArray = concatenateUint8Arrays([numToInt32BE(msg.length), msg]);
     const [result] = api
       .getWasm()
@@ -60,7 +60,7 @@ export class Ecdsa {
    * @returns True or false.
    */
   public async verifySignature(msg: Uint8Array, pubKey: Buffer, sig: EcdsaSignature) {
-    const api = await BarretenbergSync.initSingleton();
+    const api = await BarretenbergSync.initSingleton(process.env.BB_WASM_PATH);
     const messageArray = concatenateUint8Arrays([numToInt32BE(msg.length), msg]);
     const [result] = api
       .getWasm()

--- a/yarn-project/foundation/src/crypto/grumpkin/index.ts
+++ b/yarn-project/foundation/src/crypto/grumpkin/index.ts
@@ -28,7 +28,7 @@ export class Grumpkin {
    * @returns Result of the multiplication.
    */
   public async mul(point: Point, scalar: GrumpkinScalar): Promise<Point> {
-    const api = await BarretenbergSync.initSingleton();
+    const api = await BarretenbergSync.initSingleton(process.env.BB_WASM_PATH);
     const [result] = api.getWasm().callWasmExport('ecc_grumpkin__mul', [point.toBuffer(), scalar.toBuffer()], [64]);
     return Point.fromBuffer(Buffer.from(result));
   }
@@ -40,7 +40,7 @@ export class Grumpkin {
    * @returns Result of the addition.
    */
   public async add(a: Point, b: Point): Promise<Point> {
-    const api = await BarretenbergSync.initSingleton();
+    const api = await BarretenbergSync.initSingleton(process.env.BB_WASM_PATH);
     const [result] = api.getWasm().callWasmExport('ecc_grumpkin__add', [a.toBuffer(), b.toBuffer()], [64]);
     return Point.fromBuffer(Buffer.from(result));
   }
@@ -56,7 +56,7 @@ export class Grumpkin {
 
     const pointsByteLength = points.length * Point.SIZE_IN_BYTES;
 
-    const api = await BarretenbergSync.initSingleton();
+    const api = await BarretenbergSync.initSingleton(process.env.BB_WASM_PATH);
     const [result] = api
       .getWasm()
       .callWasmExport(
@@ -77,7 +77,7 @@ export class Grumpkin {
    * @returns Random field element.
    */
   public async getRandomFr(): Promise<Fr> {
-    const api = await BarretenbergSync.initSingleton();
+    const api = await BarretenbergSync.initSingleton(process.env.BB_WASM_PATH);
     const [result] = api.getWasm().callWasmExport('ecc_grumpkin__get_random_scalar_mod_circuit_modulus', [], [32]);
     return Fr.fromBuffer(Buffer.from(result));
   }
@@ -88,7 +88,7 @@ export class Grumpkin {
    * @returns Buffer representation of the field element.
    */
   public async reduce512BufferToFr(uint512Buf: Buffer): Promise<Fr> {
-    const api = await BarretenbergSync.initSingleton();
+    const api = await BarretenbergSync.initSingleton(process.env.BB_WASM_PATH);
     const [result] = api
       .getWasm()
       .callWasmExport('ecc_grumpkin__reduce512_buffer_mod_circuit_modulus', [uint512Buf], [32]);

--- a/yarn-project/foundation/src/crypto/keys/index.ts
+++ b/yarn-project/foundation/src/crypto/keys/index.ts
@@ -3,7 +3,7 @@ import { BarretenbergSync, RawBuffer } from '@aztec/bb.js';
 import { Fr } from '../../fields/fields.js';
 
 export async function vkAsFieldsMegaHonk(input: Buffer): Promise<Fr[]> {
-  const api = await BarretenbergSync.initSingleton();
+  const api = await BarretenbergSync.initSingleton(process.env.BB_WASM_PATH);
   const result = api.acirVkAsFieldsMegaHonk(new RawBuffer(input));
 
   return result.map(bbFr => Fr.fromBuffer(Buffer.from(bbFr.toBuffer()))); // TODO(#4189): remove this conversion

--- a/yarn-project/foundation/src/crypto/pedersen/pedersen.wasm.ts
+++ b/yarn-project/foundation/src/crypto/pedersen/pedersen.wasm.ts
@@ -12,7 +12,7 @@ export async function pedersenCommit(input: Buffer[], offset = 0) {
     throw new Error('All Pedersen Commit input buffers must be <= 32 bytes.');
   }
   input = input.map(i => (i.length < 32 ? Buffer.concat([Buffer.alloc(32 - i.length, 0), i]) : i));
-  const api = await BarretenbergSync.initSingleton();
+  const api = await BarretenbergSync.initSingleton(process.env.BB_WASM_PATH);
   const point = api.pedersenCommit(
     input.map(i => new FrBarretenberg(i)),
     offset,
@@ -30,7 +30,7 @@ export async function pedersenCommit(input: Buffer[], offset = 0) {
  */
 export async function pedersenHash(input: Fieldable[], index = 0): Promise<Fr> {
   const inputFields = serializeToFields(input);
-  const api = await BarretenbergSync.initSingleton();
+  const api = await BarretenbergSync.initSingleton(process.env.BB_WASM_PATH);
   const hash = api.pedersenHash(
     inputFields.map(i => new FrBarretenberg(i.toBuffer())), // TODO(#4189): remove this stupid conversion
     index,
@@ -42,7 +42,7 @@ export async function pedersenHash(input: Fieldable[], index = 0): Promise<Fr> {
  * Create a pedersen hash from an arbitrary length buffer.
  */
 export async function pedersenHashBuffer(input: Buffer, index = 0) {
-  const api = await BarretenbergSync.initSingleton();
+  const api = await BarretenbergSync.initSingleton(process.env.BB_WASM_PATH);
   const result = api.pedersenHashBuffer(input, index);
   return Buffer.from(result.toBuffer());
 }

--- a/yarn-project/foundation/src/crypto/poseidon/index.ts
+++ b/yarn-project/foundation/src/crypto/poseidon/index.ts
@@ -10,7 +10,7 @@ import { type Fieldable, serializeToFields } from '../../serialize/serialize.js'
  */
 export async function poseidon2Hash(input: Fieldable[]): Promise<Fr> {
   const inputFields = serializeToFields(input);
-  const api = await BarretenbergSync.initSingleton();
+  const api = await BarretenbergSync.initSingleton(process.env.BB_WASM_PATH);
   const hash = api.poseidon2Hash(
     inputFields.map(i => new FrBarretenberg(i.toBuffer())), // TODO(#4189): remove this stupid conversion
   );
@@ -26,7 +26,7 @@ export async function poseidon2Hash(input: Fieldable[]): Promise<Fr> {
 export async function poseidon2HashWithSeparator(input: Fieldable[], separator: number): Promise<Fr> {
   const inputFields = serializeToFields(input);
   inputFields.unshift(new Fr(separator));
-  const api = await BarretenbergSync.initSingleton();
+  const api = await BarretenbergSync.initSingleton(process.env.BB_WASM_PATH);
 
   const hash = api.poseidon2Hash(
     inputFields.map(i => new FrBarretenberg(i.toBuffer())), // TODO(#4189): remove this stupid conversion
@@ -36,7 +36,7 @@ export async function poseidon2HashWithSeparator(input: Fieldable[], separator: 
 
 export async function poseidon2HashAccumulate(input: Fieldable[]): Promise<Fr> {
   const inputFields = serializeToFields(input);
-  const api = await BarretenbergSync.initSingleton();
+  const api = await BarretenbergSync.initSingleton(process.env.BB_WASM_PATH);
   const result = api.poseidon2HashAccumulate(inputFields.map(i => new FrBarretenberg(i.toBuffer())));
   return Fr.fromBuffer(Buffer.from(result.toBuffer()));
 }
@@ -50,7 +50,7 @@ export async function poseidon2Permutation(input: Fieldable[]): Promise<Fr[]> {
   const inputFields = serializeToFields(input);
   // We'd like this assertion but it's not possible to use it in the browser.
   // assert(input.length === 4, 'Input state must be of size 4');
-  const api = await BarretenbergSync.initSingleton();
+  const api = await BarretenbergSync.initSingleton(process.env.BB_WASM_PATH);
   const res = api.poseidon2Permutation(inputFields.map(i => new FrBarretenberg(i.toBuffer())));
   // We'd like this assertion but it's not possible to use it in the browser.
   // assert(res.length === 4, 'Output state must be of size 4');
@@ -68,7 +68,7 @@ export async function poseidon2HashBytes(input: Buffer): Promise<Fr> {
     inputFields.push(Fr.fromBuffer(fieldBytes));
   }
 
-  const api = await BarretenbergSync.initSingleton();
+  const api = await BarretenbergSync.initSingleton(process.env.BB_WASM_PATH);
   const res = api.poseidon2Hash(
     inputFields.map(i => new FrBarretenberg(i.toBuffer())), // TODO(#4189): remove this stupid conversion
   );

--- a/yarn-project/foundation/src/crypto/schnorr/index.ts
+++ b/yarn-project/foundation/src/crypto/schnorr/index.ts
@@ -17,7 +17,7 @@ export class Schnorr {
    * @returns A grumpkin public key.
    */
   public async computePublicKey(privateKey: GrumpkinScalar): Promise<Point> {
-    const api = await BarretenbergSync.initSingleton();
+    const api = await BarretenbergSync.initSingleton(process.env.BB_WASM_PATH);
     const [result] = api.getWasm().callWasmExport('schnorr_compute_public_key', [privateKey.toBuffer()], [64]);
     return Point.fromBuffer(Buffer.from(result));
   }
@@ -29,7 +29,7 @@ export class Schnorr {
    * @returns A Schnorr signature of the form (s, e).
    */
   public async constructSignature(msg: Uint8Array, privateKey: GrumpkinScalar) {
-    const api = await BarretenbergSync.initSingleton();
+    const api = await BarretenbergSync.initSingleton(process.env.BB_WASM_PATH);
     const messageArray = concatenateUint8Arrays([numToInt32BE(msg.length), msg]);
     const [s, e] = api
       .getWasm()
@@ -45,7 +45,7 @@ export class Schnorr {
    * @returns True or false.
    */
   public async verifySignature(msg: Uint8Array, pubKey: Point, sig: SchnorrSignature) {
-    const api = await BarretenbergSync.initSingleton();
+    const api = await BarretenbergSync.initSingleton(process.env.BB_WASM_PATH);
     const messageArray = concatenateUint8Arrays([numToInt32BE(msg.length), msg]);
     const [result] = api
       .getWasm()

--- a/yarn-project/foundation/src/crypto/secp256k1/index.ts
+++ b/yarn-project/foundation/src/crypto/secp256k1/index.ts
@@ -27,7 +27,7 @@ export class Secp256k1 {
    * @returns Result of the multiplication.
    */
   public async mul(point: Uint8Array, scalar: Uint8Array) {
-    const api = await BarretenbergSync.initSingleton();
+    const api = await BarretenbergSync.initSingleton(process.env.BB_WASM_PATH);
     const [result] = api.getWasm().callWasmExport('ecc_secp256k1__mul', [point, scalar], [64]);
     return Buffer.from(result);
   }
@@ -37,7 +37,7 @@ export class Secp256k1 {
    * @returns Random field element.
    */
   public async getRandomFr() {
-    const api = await BarretenbergSync.initSingleton();
+    const api = await BarretenbergSync.initSingleton(process.env.BB_WASM_PATH);
     const [result] = api.getWasm().callWasmExport('ecc_secp256k1__get_random_scalar_mod_circuit_modulus', [], [32]);
     return Buffer.from(result);
   }
@@ -48,7 +48,7 @@ export class Secp256k1 {
    * @returns Buffer representation of the field element.
    */
   public async reduce512BufferToFr(uint512Buf: Buffer) {
-    const api = await BarretenbergSync.initSingleton();
+    const api = await BarretenbergSync.initSingleton(process.env.BB_WASM_PATH);
     const [result] = api
       .getWasm()
       .callWasmExport('ecc_secp256k1__reduce512_buffer_mod_circuit_modulus', [uint512Buf], [32]);

--- a/yarn-project/foundation/src/crypto/sync/index.ts
+++ b/yarn-project/foundation/src/crypto/sync/index.ts
@@ -3,4 +3,4 @@ import { BarretenbergSync } from '@aztec/bb.js';
 export * from './poseidon/index.js';
 export * from './pedersen/index.js';
 
-await BarretenbergSync.initSingleton();
+await BarretenbergSync.initSingleton(process.env.BB_WASM_PATH);

--- a/yarn-project/foundation/src/crypto/sync/pedersen/index.test.ts
+++ b/yarn-project/foundation/src/crypto/sync/pedersen/index.test.ts
@@ -6,7 +6,7 @@ import { pedersenCommit, pedersenHash, pedersenHashBuffer } from './index.js';
 
 describe('pedersen', () => {
   beforeAll(async () => {
-    await BarretenbergSync.initSingleton();
+    await BarretenbergSync.initSingleton(process.env.BB_WASM_PATH);
     setupCustomSnapshotSerializers(expect);
   });
 

--- a/yarn-project/foundation/src/crypto/sync/poseidon/index.test.ts
+++ b/yarn-project/foundation/src/crypto/sync/poseidon/index.test.ts
@@ -5,7 +5,7 @@ import { poseidon2Permutation } from './index.js';
 
 describe('poseidon2Permutation', () => {
   beforeAll(async () => {
-    await BarretenbergSync.initSingleton();
+    await BarretenbergSync.initSingleton(process.env.BB_WASM_PATH);
   });
   it('test vectors from cpp should match', () => {
     const init = [0, 1, 2, 3];

--- a/yarn-project/foundation/src/fields/fields.ts
+++ b/yarn-project/foundation/src/fields/fields.ts
@@ -319,7 +319,8 @@ export class Fr extends BaseField {
    * @returns A square root of the field element (null if it does not exist).
    */
   async sqrt(): Promise<Fr | null> {
-    const wasm = (await BarretenbergSync.initSingleton()).getWasm();
+    const api = await BarretenbergSync.initSingleton(process.env.BB_WASM_PATH);
+    const wasm = api.getWasm();
     const [buf] = wasm.callWasmExport('bn254_fr_sqrt', [this.toBuffer()], [Fr.SIZE_IN_BYTES + 1]);
     const isSqrt = buf[0] === 1;
     if (!isSqrt) {


### PR DESCRIPTION
Allows alternative `.wasms` file to be loaded into `bb.js` from both `foundation` (and thus, `aztec.js`) and `bb-prover`. 

This is useful in itself, but the aim of this PR is solving https://github.com/AztecProtocol/aztec-packages/issues/11963 by allowing bypassing the lazy loading of bb wasms (disguised as js files)

This PR also prepares boxes and playground for strict size limits by ensuring no artifacts are included in main bundles.