### PR TITLE
refactor: run separate anvils for the l1 cheatcode tests

### DIFF
--- a/yarn-project/end-to-end/src/e2e_cheat_codes.test.ts
+++ b/yarn-project/end-to-end/src/e2e_cheat_codes.test.ts
@@ -1,84 +1,74 @@
 import { AnvilTestWatcher, type AztecAddress, type CheatCodes, EthAddress, Fr, type Wallet } from '@aztec/aztec.js';
-import type { ViemPublicClient, ViemWalletClient } from '@aztec/ethereum';
+import { EthCheatCodes, type ViemPublicClient, type ViemWalletClient, createL1Clients } from '@aztec/ethereum';
 import { RollupContract } from '@aztec/ethereum/contracts';
 import { TokenContract } from '@aztec/noir-contracts.js/Token';
 
+import type { Anvil } from '@viem/anvil';
 import { parseEther } from 'viem';
+import { mnemonicToAccount } from 'viem/accounts';
+import { foundry } from 'viem/chains';
 
+import { MNEMONIC } from './fixtures/fixtures.js';
 import { mintTokensToPrivate } from './fixtures/token_utils.js';
-import { setup } from './fixtures/utils.js';
+import { getLogger, setup, startAnvil } from './fixtures/utils.js';
 
 describe('e2e_cheat_codes', () => {
-  let wallet: Wallet;
-  let admin: AztecAddress;
-  let cc: CheatCodes;
-  let teardown: () => Promise<void>;
-
-  let walletClient: ViemWalletClient;
-  let publicClient: ViemPublicClient;
-  let token: TokenContract;
-  let rollup: RollupContract;
-  let watcher: AnvilTestWatcher | undefined;
-
-  beforeAll(async () => {
-    let deployL1ContractsValues;
-    ({ teardown, wallet, cheatCodes: cc, deployL1ContractsValues, watcher } = await setup());
-
-    walletClient = deployL1ContractsValues.walletClient;
-    publicClient = deployL1ContractsValues.publicClient;
-    admin = wallet.getAddress();
-
-    rollup = RollupContract.getFromL1ContractsValues(deployL1ContractsValues);
-
-    if (watcher) {
-      watcher.setIsMarkingAsProven(false);
-    }
-
-    token = await TokenContract.deploy(wallet, admin, 'TokenName', 'TokenSymbol', 18).send().deployed();
-  });
-
-  afterAll(() => teardown());
-
   describe('L1 cheatcodes', () => {
-    // TODO(#10775): example fail https://github.com/AztecProtocol/aztec-packages/actions/runs/12418969358/job/34674141249
-    describe.skip('mine', () => {
+    let ethCheatCodes: EthCheatCodes;
+
+    let walletClient: ViemWalletClient;
+    let publicClient: ViemPublicClient;
+
+    let anvil: Anvil;
+
+    beforeEach(async () => {
+      const res = await startAnvil();
+      anvil = res.anvil;
+      ethCheatCodes = new EthCheatCodes([res.rpcUrl]);
+      const account = mnemonicToAccount(MNEMONIC, { addressIndex: 0 });
+      ({ walletClient, publicClient } = createL1Clients([res.rpcUrl], account, foundry));
+    });
+
+    afterEach(async () => await anvil?.stop().catch(err => getLogger().error(err)));
+
+    describe('mine', () => {
       it(`mine block`, async () => {
-        const blockNumber = await cc.eth.blockNumber();
-        await cc.eth.mine();
-        expect(await cc.eth.blockNumber()).toBe(blockNumber + 1);
+        const blockNumber = await ethCheatCodes.blockNumber();
+        await ethCheatCodes.mine();
+        expect(await ethCheatCodes.blockNumber()).toBe(blockNumber + 1);
       });
 
-      it.each([10, 42, 99])(`mine blocks`, async increment => {
-        const blockNumber = await cc.eth.blockNumber();
-        await cc.eth.mine(increment);
-        expect(await cc.eth.blockNumber()).toBe(blockNumber + increment);
+      it.each([10, 42, 99])(`mine %i blocks`, async increment => {
+        const blockNumber = await ethCheatCodes.blockNumber();
+        await ethCheatCodes.mine(increment);
+        expect(await ethCheatCodes.blockNumber()).toBe(blockNumber + increment);
       });
     });
 
-    it.each([100, 42, 99])('setNextBlockTimestamp', async increment => {
-      const blockNumber = await cc.eth.blockNumber();
-      const timestamp = await cc.eth.timestamp();
-      await cc.eth.setNextBlockTimestamp(timestamp + increment);
+    it.each([100, 42, 99])(`setNextBlockTimestamp by %i`, async increment => {
+      const blockNumber = await ethCheatCodes.blockNumber();
+      const timestamp = await ethCheatCodes.timestamp();
+      await ethCheatCodes.setNextBlockTimestamp(timestamp + increment);
 
-      expect(await cc.eth.timestamp()).toBe(timestamp);
+      expect(await ethCheatCodes.timestamp()).toBe(timestamp);
 
-      await cc.eth.mine();
+      await ethCheatCodes.mine();
 
-      expect(await cc.eth.blockNumber()).toBe(blockNumber + 1);
-      expect(await cc.eth.timestamp()).toBe(timestamp + increment);
+      expect(await ethCheatCodes.blockNumber()).toBe(blockNumber + 1);
+      expect(await ethCheatCodes.timestamp()).toBe(timestamp + increment);
     });
 
     it('setNextBlockTimestamp to a past timestamp throws', async () => {
-      const timestamp = await cc.eth.timestamp();
+      const timestamp = await ethCheatCodes.timestamp();
       const pastTimestamp = timestamp - 1000;
-      await expect(async () => await cc.eth.setNextBlockTimestamp(pastTimestamp)).rejects.toThrow(
+      await expect(async () => await ethCheatCodes.setNextBlockTimestamp(pastTimestamp)).rejects.toThrow(
         new RegExp(`Details: Timestamp error: ${pastTimestamp} is lower than or equal to previous block's timestamp`),
       );
     });
 
     it('load a value at a particular storage slot', async () => {
       // check that storage slot 0 is empty as expected
-      const res = await cc.eth.load(EthAddress.ZERO, 0n);
+      const res = await ethCheatCodes.load(EthAddress.ZERO, 0n);
       expect(res).toBe(0n);
     });
 
@@ -88,18 +78,18 @@ describe('e2e_cheat_codes', () => {
         const storageSlot = BigInt('0x' + storageSlotInHex);
         const valueToSet = 5n;
         const contractAddress = EthAddress.fromString('0xf39fd6e51aad88f6f4ce6ab8827279cfffb92266');
-        await cc.eth.store(contractAddress, storageSlot, valueToSet);
-        expect(await cc.eth.load(contractAddress, storageSlot)).toBe(valueToSet);
+        await ethCheatCodes.store(contractAddress, storageSlot, valueToSet);
+        expect(await ethCheatCodes.load(contractAddress, storageSlot)).toBe(valueToSet);
         // also test with the keccak value of the slot - can be used to compute storage slots of maps
-        await cc.eth.store(contractAddress, cc.eth.keccak256(0n, storageSlot), valueToSet);
-        expect(await cc.eth.load(contractAddress, cc.eth.keccak256(0n, storageSlot))).toBe(valueToSet);
+        await ethCheatCodes.store(contractAddress, ethCheatCodes.keccak256(0n, storageSlot), valueToSet);
+        expect(await ethCheatCodes.load(contractAddress, ethCheatCodes.keccak256(0n, storageSlot))).toBe(valueToSet);
       },
     );
 
     it('set bytecode correctly', async () => {
       const contractAddress = EthAddress.fromString('0x70997970C51812dc3A010C7d01b50e0d17dc79C8');
-      await cc.eth.etch(contractAddress, '0x1234');
-      expect(await cc.eth.getBytecode(contractAddress)).toBe('0x1234');
+      await ethCheatCodes.etch(contractAddress, '0x1234');
+      expect(await ethCheatCodes.getBytecode(contractAddress)).toBe('0x1234');
     });
 
     it('impersonate', async () => {
@@ -116,7 +106,7 @@ describe('e2e_cheat_codes', () => {
       const beforeBalance = await publicClient.getBalance({ address: randomAddress });
 
       // impersonate random address
-      await cc.eth.startImpersonating(EthAddress.fromString(randomAddress));
+      await ethCheatCodes.startImpersonating(EthAddress.fromString(randomAddress));
       // send funds from random address
       const amountToSend = parseEther('0.1');
       const tx2Hash = await walletClient.sendTransaction({
@@ -129,7 +119,7 @@ describe('e2e_cheat_codes', () => {
       expect(await publicClient.getBalance({ address: randomAddress })).toBe(beforeBalance - amountToSend - feePaid);
 
       // stop impersonating
-      await cc.eth.stopImpersonating(EthAddress.fromString(randomAddress));
+      await ethCheatCodes.stopImpersonating(EthAddress.fromString(randomAddress));
 
       // making calls from random address should not be successful
       try {
@@ -147,6 +137,29 @@ describe('e2e_cheat_codes', () => {
   });
 
   describe('L2 cheatcodes', () => {
+    let wallet: Wallet;
+    let admin: AztecAddress;
+    let cc: CheatCodes;
+    let teardown: () => Promise<void>;
+
+    let token: TokenContract;
+    let rollup: RollupContract;
+    let watcher: AnvilTestWatcher | undefined;
+
+    beforeAll(async () => {
+      let deployL1ContractsValues;
+      ({ teardown, wallet, cheatCodes: cc, deployL1ContractsValues, watcher } = await setup());
+      if (watcher) {
+        watcher.setIsMarkingAsProven(false);
+      }
+
+      admin = wallet.getAddress();
+      rollup = RollupContract.getFromL1ContractsValues(deployL1ContractsValues);
+      token = await TokenContract.deploy(wallet, admin, 'TokenName', 'TokenSymbol', 18).send().deployed();
+    });
+
+    afterAll(() => teardown());
+
     it('load public', async () => {
       expect(await cc.aztec.loadPublic(token.address, 1n)).toEqual(admin.toField());
     });


### PR DESCRIPTION
- Turned on cheatcode tests that was previously turned off. 
- Run an anvil instance for the l1 cheatcode tests individually so time jumps and concurrency don't misbehave