### PR TITLE
chore: bump time to notice prune to 1s in slasher_client test

### DIFF
--- a/yarn-project/sequencer-client/src/slasher/slasher_client.test.ts
+++ b/yarn-project/sequencer-client/src/slasher/slasher_client.test.ts
@@ -88,6 +88,8 @@ describe('In-Memory Slasher Client', () => {
 
   describe('Chain prunes', () => {
     it('moves the tips on a chain reorg', async () => {
+      const timeToReact = 1000;
+
       blockSource.setProvenBlockNumber(0);
       await client.start();
 
@@ -102,7 +104,7 @@ describe('In-Memory Slasher Client', () => {
       blockSource.removeBlocks(10);
 
       // give the client a chance to react to the reorg
-      await sleep(100);
+      await sleep(timeToReact);
 
       await expect(client.getL2Tips()).resolves.toEqual({
         latest: { number: 90, hash: expect.any(String) },
@@ -113,7 +115,7 @@ describe('In-Memory Slasher Client', () => {
       blockSource.addBlocks([await L2Block.random(91), await L2Block.random(92)]);
 
       // give the client a chance to react to the new blocks
-      await sleep(100);
+      await sleep(timeToReact);
 
       await expect(client.getL2Tips()).resolves.toEqual({
         latest: { number: 92, hash: expect.any(String) },


### PR DESCRIPTION
Sometimes when the slasher_client was running in ci, it did not have sufficient time to react. Bumping the value for the test up to 1 second. 

To recreate the issue reduce the time to 10 ms and run locally.