### PR TITLE
fix: assert import type in lazt artifact imports

### DIFF
--- a/yarn-project/accounts/src/schnorr/lazy.ts
+++ b/yarn-project/accounts/src/schnorr/lazy.ts
@@ -20,7 +20,9 @@ import { SchnorrBaseAccountContract } from './account_contract.js';
  * @returns The contract artifact for the schnorr account contract
  */
 export async function getSchnorrAccountContractArtifact() {
-  const { default: schnorrAccountContractJson } = await import('../../artifacts/SchnorrAccount.json');
+  const { default: schnorrAccountContractJson } = await import('../../artifacts/SchnorrAccount.json', {
+    assert: { type: 'json' },
+  });
   return loadContractArtifact(schnorrAccountContractJson);
 }
 

--- a/yarn-project/accounts/src/single_key/lazy.ts
+++ b/yarn-project/accounts/src/single_key/lazy.ts
@@ -19,7 +19,9 @@ import { SingleKeyBaseAccountContract } from './account_contract.js';
  * @returns The contract artifact for the single key account contract
  */
 export async function getSingleKeyAccountContractArtifact() {
-  const { default: schnorrAccountContractJson } = await import('../../artifacts/SchnorrAccount.json');
+  const { default: schnorrAccountContractJson } = await import('../../artifacts/SchnorrAccount.json', {
+    assert: { type: 'json' },
+  });
   return loadContractArtifact(schnorrAccountContractJson);
 }
 

--- a/yarn-project/protocol-contracts/src/auth-registry/lazy.ts
+++ b/yarn-project/protocol-contracts/src/auth-registry/lazy.ts
@@ -8,7 +8,9 @@ let protocolContractArtifact: ContractArtifact;
 
 export async function getAuthRegistryArtifact(): Promise<ContractArtifact> {
   if (!protocolContractArtifact) {
-    const { default: authRegistryJson } = await import('../../artifacts/AuthRegistry.json');
+    const { default: authRegistryJson } = await import('../../artifacts/AuthRegistry.json', {
+      assert: { type: 'json' },
+    });
     protocolContractArtifact = loadContractArtifact(authRegistryJson);
   }
   return protocolContractArtifact;

--- a/yarn-project/protocol-contracts/src/class-registerer/lazy.ts
+++ b/yarn-project/protocol-contracts/src/class-registerer/lazy.ts
@@ -12,7 +12,9 @@ let protocolContractArtifact: ContractArtifact;
 
 export async function getContractClassRegistererArtifact(): Promise<ContractArtifact> {
   if (!protocolContractArtifact) {
-    const { default: contractClassRegistererJson } = await import('../../artifacts/ContractClassRegisterer.json');
+    const { default: contractClassRegistererJson } = await import('../../artifacts/ContractClassRegisterer.json', {
+      assert: { type: 'json' },
+    });
     protocolContractArtifact = loadContractArtifact(contractClassRegistererJson);
   }
   return protocolContractArtifact;

--- a/yarn-project/protocol-contracts/src/fee-juice/lazy.ts
+++ b/yarn-project/protocol-contracts/src/fee-juice/lazy.ts
@@ -8,7 +8,7 @@ let protocolContractArtifact: ContractArtifact;
 
 export async function getFeeJuiceArtifact(): Promise<ContractArtifact> {
   if (!protocolContractArtifact) {
-    const { default: feeJuiceJson } = await import('../../artifacts/FeeJuice.json');
+    const { default: feeJuiceJson } = await import('../../artifacts/FeeJuice.json', { assert: { type: 'json' } });
     protocolContractArtifact = loadContractArtifact(feeJuiceJson);
   }
   return protocolContractArtifact;

--- a/yarn-project/protocol-contracts/src/instance-deployer/lazy.ts
+++ b/yarn-project/protocol-contracts/src/instance-deployer/lazy.ts
@@ -11,7 +11,9 @@ let protocolContractArtifact: ContractArtifact;
 
 export async function getContractInstanceDeployerArtifact(): Promise<ContractArtifact> {
   if (!protocolContractArtifact) {
-    const { default: contractInstanceDeployerJson } = await import('../../artifacts/ContractInstanceDeployer.json');
+    const { default: contractInstanceDeployerJson } = await import('../../artifacts/ContractInstanceDeployer.json', {
+      assert: { type: 'json' },
+    });
     protocolContractArtifact = loadContractArtifact(contractInstanceDeployerJson);
   }
   return protocolContractArtifact;

--- a/yarn-project/protocol-contracts/src/multi-call-entrypoint/lazy.ts
+++ b/yarn-project/protocol-contracts/src/multi-call-entrypoint/lazy.ts
@@ -8,7 +8,9 @@ let protocolContractArtifact: ContractArtifact;
 
 export async function getMultiCallEntrypointArtifact(): Promise<ContractArtifact> {
   if (!protocolContractArtifact) {
-    const { default: multiCallEntrypointJson } = await import('../../artifacts/MultiCallEntrypoint.json');
+    const { default: multiCallEntrypointJson } = await import('../../artifacts/MultiCallEntrypoint.json', {
+      assert: { type: 'json' },
+    });
     protocolContractArtifact = loadContractArtifact(multiCallEntrypointJson);
   }
   return protocolContractArtifact;

--- a/yarn-project/protocol-contracts/src/router/lazy.ts
+++ b/yarn-project/protocol-contracts/src/router/lazy.ts
@@ -8,7 +8,7 @@ let protocolContractArtifact: ContractArtifact;
 
 export async function getRouterArtifact(): Promise<ContractArtifact> {
   if (!protocolContractArtifact) {
-    const { default: routerJson } = await import('../../artifacts/Router.json');
+    const { default: routerJson } = await import('../../artifacts/Router.json', { assert: { type: 'json' } });
     protocolContractArtifact = loadContractArtifact(routerJson);
   }
   return protocolContractArtifact;


### PR DESCRIPTION
## Overview

This is breaking the bot

<img width="895" alt="image" src="https://github.com/user-attachments/assets/6c594921-58f7-4a2c-95e3-9bb475eebd05" />

