### PR TITLE
chore(avm): disconnect VM1

### DIFF
--- a/barretenberg/cpp/src/barretenberg/api/api_avm.cpp
+++ b/barretenberg/cpp/src/barretenberg/api/api_avm.cpp
@@ -31,9 +31,10 @@ void print_avm_stats()
  * @param public_inputs_path Path to the file containing the serialised avm public inputs
  * @param hints_path Path to the file containing the serialised avm circuit hints
  */
-void avm_check_circuit(const std::filesystem::path& public_inputs_path, const std::filesystem::path& hints_path)
+void avm_check_circuit(const std::filesystem::path&, const std::filesystem::path&)
 {
-
+    info("!!! VM1 is deprecated. Quitting !!!");
+    /*
     const auto avm_public_inputs = AvmPublicInputs::from(read_file(public_inputs_path));
     const auto avm_hints = bb::avm_trace::ExecutionHints::from(read_file(hints_path));
     avm_hints.print_sizes();
@@ -44,6 +45,7 @@ void avm_check_circuit(const std::filesystem::path& public_inputs_path, const st
     avm_trace::Execution::check_circuit(avm_public_inputs, avm_hints);
 
     print_avm_stats();
+    */
 }
 
 /**
@@ -56,11 +58,10 @@ void avm_check_circuit(const std::filesystem::path& public_inputs_path, const st
  * @param hints_path Path to the file containing the serialised avm circuit hints
  * @param output_path Path (directory) to write the output proof and verification keys
  */
-void avm_prove(const std::filesystem::path& public_inputs_path,
-               const std::filesystem::path& hints_path,
-               const std::filesystem::path& output_path)
+void avm_prove(const std::filesystem::path&, const std::filesystem::path&, const std::filesystem::path& output_path)
 {
-
+    info("!!! VM1 is deprecated. Sleeping 60s and generating fake outputs !!!");
+    /*
     const auto avm_public_inputs = AvmPublicInputs::from(read_file(public_inputs_path));
     const auto avm_hints = bb::avm_trace::ExecutionHints::from(read_file(hints_path));
     avm_hints.print_sizes();
@@ -71,6 +72,10 @@ void avm_prove(const std::filesystem::path& public_inputs_path,
     // Prove execution and return vk
     auto const [verification_key, proof] =
         AVM_TRACK_TIME_V("prove/all", avm_trace::Execution::prove(avm_public_inputs, avm_hints));
+    */
+    bb::avm::AvmFlavor::VerificationKey verification_key;
+    bb::HonkProof proof(AVM_PROOF_LENGTH_IN_FIELDS * 32);
+    sleep(60);
 
     std::vector<fr> vk_as_fields = verification_key.to_field_elements();
 
@@ -135,8 +140,11 @@ void avm2_check_circuit(const std::filesystem::path& inputs_path)
  * @return true If the proof is valid
  * @return false If the proof is invalid
  */
-bool avm_verify(const std::filesystem::path& proof_path, const std::filesystem::path& vk_path)
+bool avm_verify(const std::filesystem::path&, const std::filesystem::path&)
 {
+    info("!!! VM1 is deprecated. Saying yes !!!");
+    return true;
+    /*
     using Commitment = bb::avm::AvmFlavorSettings::Commitment;
     std::vector<fr> const proof = many_from_buffer<fr>(read_file(proof_path));
     std::vector<uint8_t> vk_bytes = read_file(vk_path);
@@ -175,6 +183,7 @@ bool avm_verify(const std::filesystem::path& proof_path, const std::filesystem::
 
     print_avm_stats();
     return verified;
+    */
 }
 
 // NOTE: The proof should NOT include the public inputs.

--- a/yarn-project/bb-prover/src/avm_proving_tests/avm_contract_updates.test.ts
+++ b/yarn-project/bb-prover/src/avm_proving_tests/avm_contract_updates.test.ts
@@ -10,7 +10,7 @@ import { AvmProvingTester } from './avm_proving_tester.js';
 
 const TIMEOUT = 300_000;
 
-describe('AVM WitGen & Circuit - contract updates', () => {
+describe.skip('AVM WitGen & Circuit - contract updates', () => {
   const sender = AztecAddress.fromNumber(42);
 
   const avmTestContractClassSeed = 0;

--- a/yarn-project/bb-prover/src/bb/execute.ts
+++ b/yarn-project/bb-prover/src/bb/execute.ts
@@ -435,7 +435,7 @@ export async function generateAvmProofV2(
 export async function generateAvmProof(
   pathToBB: string,
   workingDirectory: string,
-  input: AvmCircuitInputs,
+  _input: AvmCircuitInputs,
   logger: Logger,
   checkCircuitOnly: boolean = false,
 ): Promise<BBFailure | BBSuccess> {
@@ -467,15 +467,16 @@ export async function generateAvmProof(
   try {
     // Write the inputs to the working directory.
 
-    await fs.writeFile(publicInputsPath, input.publicInputs.toBuffer());
-    if (!(await filePresent(publicInputsPath))) {
-      return { status: BB_RESULT.FAILURE, reason: `Could not write publicInputs at ${publicInputsPath}` };
-    }
+    // WARNING: Not writing the inputs since VM1 is disabled!
+    // await fs.writeFile(publicInputsPath, input.publicInputs.toBuffer());
+    // if (!(await filePresent(publicInputsPath))) {
+    //   return { status: BB_RESULT.FAILURE, reason: `Could not write publicInputs at ${publicInputsPath}` };
+    // }
 
-    await fs.writeFile(avmHintsPath, input.avmHints.toBuffer());
-    if (!(await filePresent(avmHintsPath))) {
-      return { status: BB_RESULT.FAILURE, reason: `Could not write avmHints at ${avmHintsPath}` };
-    }
+    // await fs.writeFile(avmHintsPath, input.avmHints.toBuffer());
+    // if (!(await filePresent(avmHintsPath))) {
+    //   return { status: BB_RESULT.FAILURE, reason: `Could not write avmHints at ${avmHintsPath}` };
+    // }
 
     const args = ['--avm-public-inputs', publicInputsPath, '--avm-hints', avmHintsPath, '-o', outputPath];
     const loggingArg =


### PR DESCRIPTION
![unnamed-1.png](https://graphite-user-uploaded-assets-prod.s3.amazonaws.com/mO08Q17TCoHzVKYudUJh/bb553009-1c23-4bc3-a5de-bcf2b886652a.png)

We are currently working on VM2 and having to maintain backwards compatibility with VM1 has reached a tipping point. This PR disconnects VM1 from the native BB binary and makes it always report success.

As a result
* `bb-prover` tests don't mean a thing (except the v2 one)
* the proving part of e2e_full_proving becomes meaningless
* **We will not be proving in any dev/testnet until we connect vm2!**
* This doesn't change recursive verification in the base rollup because we were already not doing that (too expensive until Goblinized).

However, this should let us move faster and we should be able to connect vm2 "soon".

Having VM1 connected is currently blocking work on changing the hinting schema etc.