### PR TITLE
chore: Re-re-enable fee settings test

### DIFF
--- a/yarn-project/end-to-end/bootstrap.sh
+++ b/yarn-project/end-to-end/bootstrap.sh
@@ -62,6 +62,7 @@ function test_cmds {
   echo "$prefix simple e2e_fees/dapp_subscription"
   echo "$prefix simple e2e_fees/failures"
   echo "$prefix simple e2e_fees/fee_juice_payments"
+  echo "$prefix simple e2e_fees/fee_settings"
   echo "$prefix simple e2e_fees/gas_estimation"
   echo "$prefix simple e2e_fees/private_payments"
   echo "$prefix simple e2e_fees/public_payments"

--- a/yarn-project/end-to-end/src/e2e_fees/fee_settings.test.ts
+++ b/yarn-project/end-to-end/src/e2e_fees/fee_settings.test.ts
@@ -4,6 +4,7 @@ import {
   type AztecNode,
   type CheatCodes,
   FeeJuicePaymentMethod,
+  retryUntil,
 } from '@aztec/aztec.js';
 import { Fr } from '@aztec/foundation/fields';
 import { TestContract } from '@aztec/noir-contracts.js/Test';
@@ -41,23 +42,21 @@ describe('e2e_fees fee settings', () => {
   describe('setting max fee per gas', () => {
     const bumpL2Fees = async () => {
       const before = await aztecNode.getCurrentBaseFees();
-      t.logger.info(`Initial L2 base fees are ${inspect(before)}`, { baseFees: before });
-
-      // Bumps L1 base fee, updates the L1 fee oracle, and advances slots to update L2 base fees.
-      // Do we need all these advance and upgrade calls? Probably not, but these calls are blazing fast,
-      // so it's not big deal if we're throwing some unnecessary calls. We just want higher L2 base fees.
-      t.logger.info(`Bumping L1 base fee per gas`);
-      await cheatCodes.rollup.updateL1GasFeeOracle();
-      await cheatCodes.eth.setNextBlockBaseFeePerGas(1e11);
-      await cheatCodes.eth.mine();
-      await cheatCodes.rollup.advanceSlots(6);
-      await cheatCodes.rollup.updateL1GasFeeOracle();
-      await cheatCodes.rollup.advanceSlots(6);
-      await cheatCodes.rollup.updateL1GasFeeOracle();
-
-      const after = await aztecNode.getCurrentBaseFees();
-      t.logger.info(`L2 base fees after L1 gas spike are ${inspect(after)}`, { baseFees: after });
-      expect(after.feePerL2Gas.toBigInt()).toBeGreaterThan(before.feePerL2Gas.toBigInt());
+      t.logger.info(`Initial L2 base fees are ${inspect(before)}`, { baseFees: before.toInspect() });
+      await cheatCodes.rollup.bumpProvingCostPerMana(current => (current * 120n) / 100n);
+      await retryUntil(
+        async () => {
+          const after = await aztecNode.getCurrentBaseFees();
+          t.logger.info(`L2 base fees are now ${inspect(after)}`, {
+            baseFeesBefore: before.toInspect(),
+            baseFeesAfter: after.toInspect(),
+          });
+          return after.feePerL2Gas.toBigInt() > before.feePerL2Gas.toBigInt();
+        },
+        'L2 base fee increase',
+        5,
+        1,
+      );
     };
 
     const sendTx = async (baseFeePadding: number | undefined) => {
@@ -66,12 +65,11 @@ describe('e2e_fees fee settings', () => {
         .emit_nullifier_public(Fr.random())
         .prove({ fee: { gasSettings, paymentMethod, baseFeePadding } });
       const { maxFeesPerGas } = tx.data.constants.txContext.gasSettings;
-      t.logger.info(`Tx with hash ${tx.getTxHash()} ready with max fees ${inspect(maxFeesPerGas)}`);
+      t.logger.info(`Tx with hash ${await tx.getTxHash()} ready with max fees ${inspect(maxFeesPerGas)}`);
       return tx;
     };
 
-    // TODO(#12258): This test is currently broken on master. Fix it.
-    it.skip('handles base fee spikes with default padding', async () => {
+    it('handles base fee spikes with default padding', async () => {
       // Prepare two txs using the current L2 base fees: one with no padding and one with default padding
       const txWithNoPadding = await sendTx(0);
       const txWithDefaultPadding = await sendTx(undefined);

--- a/yarn-project/sequencer-client/src/tx_validator/gas_validator.ts
+++ b/yarn-project/sequencer-client/src/tx_validator/gas_validator.ts
@@ -24,8 +24,8 @@ export class GasTxValidator implements TxValidator<Tx> {
     this.#gasFees = gasFees;
   }
 
-  validateTx(tx: Tx): Promise<TxValidationResult> {
-    if (this.#shouldSkip(tx)) {
+  async validateTx(tx: Tx): Promise<TxValidationResult> {
+    if (await this.#shouldSkip(tx)) {
       return Promise.resolve({ result: 'skipped', reason: ['Insufficient fee per gas'] });
     }
     return this.#validateTxFee(tx);
@@ -37,7 +37,7 @@ export class GasTxValidator implements TxValidator<Tx> {
    * Note that circuits check max fees even if fee payer is unset, so we
    * keep this validation even if the tx does not pay fees.
    */
-  #shouldSkip(tx: Tx): boolean {
+  async #shouldSkip(tx: Tx): Promise<boolean> {
     const gasSettings = tx.data.constants.txContext.gasSettings;
 
     // Skip the tx if its max fees are not enough for the current block's gas fees.
@@ -47,7 +47,10 @@ export class GasTxValidator implements TxValidator<Tx> {
       maxFeesPerGas.feePerL2Gas.lt(this.#gasFees.feePerL2Gas);
 
     if (notEnoughMaxFees) {
-      this.#log.warn(`Skipping transaction ${tx.getTxHash()} due to insufficient fee per gas`);
+      this.#log.warn(`Skipping transaction ${await tx.getTxHash()} due to insufficient fee per gas`, {
+        txMaxFeesPerGas: maxFeesPerGas.toInspect(),
+        currentGasFees: this.#gasFees.toInspect(),
+      });
     }
     return notEnoughMaxFees;
   }

--- a/yarn-project/stdlib/src/gas/gas_fees.ts
+++ b/yarn-project/stdlib/src/gas/gas_fees.ts
@@ -91,7 +91,14 @@ export class GasFees {
     return serializeToFields(this.feePerDaGas, this.feePerL2Gas);
   }
 
+  toInspect() {
+    return {
+      feePerDaGas: this.feePerDaGas.toNumberUnsafe(),
+      feePerL2Gas: this.feePerL2Gas.toNumberUnsafe(),
+    };
+  }
+
   [inspect.custom]() {
-    return `GasFees { feePerDaGas=${this.feePerDaGas} feePerL2Gas=${this.feePerL2Gas} }`;
+    return `GasFees { feePerDaGas=${this.feePerDaGas.toBigInt()} feePerL2Gas=${this.feePerL2Gas.toBigInt()} }`;
   }
 }


### PR DESCRIPTION
Second iteration of https://github.com/AztecProtocol/aztec-packages/pull/12302. This passed a local grind with:
```
seq 1 10 | parallel --bar --halt now,fail=1 "yarn-project/end-to-end/scripts/run_test.sh simple e2e_fees/fee_settings >/dev/null"
```

Fixes #12258 