### PR TITLE
chore: move the validator key index start to 2000

### DIFF
--- a/spartan/aztec-network/values.yaml
+++ b/spartan/aztec-network/values.yaml
@@ -48,19 +48,20 @@ aztec:
   epochDuration: 32 # how many L2 slots in an epoch
   proofSubmissionWindow: 64 # in L2 slots, from the start of the epoch to be proven
   realProofs: false
-  l1DeploymentMnemonic: "test test test test test test test test test test test junk" # the mnemonic used when deploying contracts
-  # The derivation path of the calcualted private keys
-  # Starting from this index, the number of keys is equal to the number of replicas for the given service
-  validatorKeyIndexStart: 0
-  proverKeyIndexStart: 1000
 
-  ## The number of extra accounts to prefund
-  extraAccountsStartIndex: 2000
-  extraAccounts: 10
-
-  botKeyIndexStart: 3000
   l1Salt: "42" # leave empty for random salt
   testAccounts: true
+  l1DeploymentMnemonic: "test test test test test test test test test test test junk" # the mnemonic used when deploying contracts
+
+  # The derivation path of the calcualted private keys
+  # Starting from this index, the number of keys is equal to the number of replicas for the given service
+  # Set the "extraAccounts" to start at 0 so that just using the default mnemonic won't clash with validator, prover, and bot accounts
+  extraAccountsStartIndex: 0
+  ## The number of extra accounts to prefund
+  extraAccounts: 10
+  proverKeyIndexStart: 1000
+  validatorKeyIndexStart: 2000
+  botKeyIndexStart: 3000
 
 bootNode:
   peerIdPrivateKey: ""

--- a/yarn-project/end-to-end/src/spartan/upgrade_rollup_version.test.ts
+++ b/yarn-project/end-to-end/src/spartan/upgrade_rollup_version.test.ts
@@ -85,8 +85,6 @@ describe('spartan_upgrade_rollup_version', () => {
         ETHEREUM_HOSTS,
         config.L1_ACCOUNT_MNEMONIC,
         chain.chainInfo,
-        // TODO(#12301): magic number
-        2000,
       );
       debugLogger.info(`l1WalletClient: ${l1WalletClient.account.address}`);
       const initialTestAccounts = await getInitialTestAccounts();


### PR DESCRIPTION
No more "address reserved".

Services in tests were using account index 0, which is what the validators also use.