### PR TITLE
feat: prod network deployments

### DIFF
--- a/spartan/aztec-network/files/config/config-full-node-env.sh
+++ b/spartan/aztec-network/files/config/config-full-node-env.sh
@@ -1,6 +1,16 @@
 #!/bin/bash
 set -eu
 
+# if the registry address is already set and the bootstrap nodes are set, then we don't need to wait for the services
+if [ -n "$REGISTRY_CONTRACT_ADDRESS" ] && [ -n "$BOOTSTRAP_NODES" ]; then
+  cat <<EOF >/shared/contracts/contracts.env
+export BOOTSTRAP_NODES=$BOOTSTRAP_NODES
+export REGISTRY_CONTRACT_ADDRESS=$REGISTRY_CONTRACT_ADDRESS
+EOF
+  cat /shared/contracts/contracts.env
+  exit 0
+fi
+
 # Pass a PXE url as an argument
 # Ask the PXE's node for l1 contract addresses
 output=$(node --no-warnings /usr/src/yarn-project/aztec/dest/bin/index.js get-node-info -u $1)
@@ -12,34 +22,12 @@ if [ "$P2P_ENABLED" = "true" ]; then
   # Only look for boot node ENR if P2P is enabled
   boot_node_enr=$(echo "$output" | grep -oP 'Node ENR: \Kenr:[a-zA-Z0-9\-\_\.]+')
 fi
-rollup_address=$(echo "$output" | grep -oP 'Rollup Address: \K0x[a-fA-F0-9]{40}')
 registry_address=$(echo "$output" | grep -oP 'Registry Address: \K0x[a-fA-F0-9]{40}')
-inbox_address=$(echo "$output" | grep -oP 'L1 -> L2 Inbox Address: \K0x[a-fA-F0-9]{40}')
-outbox_address=$(echo "$output" | grep -oP 'L2 -> L1 Outbox Address: \K0x[a-fA-F0-9]{40}')
-fee_juice_address=$(echo "$output" | grep -oP 'Fee Juice Address: \K0x[a-fA-F0-9]{40}')
-staking_asset_address=$(echo "$output" | grep -oP 'Staking Asset Address: \K0x[a-fA-F0-9]{40}')
-fee_juice_portal_address=$(echo "$output" | grep -oP 'Fee Juice Portal Address: \K0x[a-fA-F0-9]{40}')
-coin_issuer_address=$(echo "$output" | grep -oP 'CoinIssuer Address: \K0x[a-fA-F0-9]{40}')
-reward_distributor_address=$(echo "$output" | grep -oP 'RewardDistributor Address: \K0x[a-fA-F0-9]{40}')
-governance_proposer_address=$(echo "$output" | grep -oP 'GovernanceProposer Address: \K0x[a-fA-F0-9]{40}')
-governance_address=$(echo "$output" | grep -oP 'Governance Address: \K0x[a-fA-F0-9]{40}')
-slash_factory_address=$(echo "$output" | grep -oP 'SlashFactory Address: \K0x[a-fA-F0-9]{40}')
 
 # Write the addresses to a file in the shared volume
 cat <<EOF >/shared/contracts/contracts.env
 export BOOTSTRAP_NODES=$boot_node_enr
-export ROLLUP_CONTRACT_ADDRESS=$rollup_address
 export REGISTRY_CONTRACT_ADDRESS=$registry_address
-export INBOX_CONTRACT_ADDRESS=$inbox_address
-export OUTBOX_CONTRACT_ADDRESS=$outbox_address
-export FEE_JUICE_CONTRACT_ADDRESS=$fee_juice_address
-export STAKING_ASSET_CONTRACT_ADDRESS=$staking_asset_address
-export FEE_JUICE_PORTAL_CONTRACT_ADDRESS=$fee_juice_portal_address
-export COIN_ISSUER_CONTRACT_ADDRESS=$coin_issuer_address
-export REWARD_DISTRIBUTOR_CONTRACT_ADDRESS=$reward_distributor_address
-export GOVERNANCE_PROPOSER_CONTRACT_ADDRESS=$governance_proposer_address
-export GOVERNANCE_CONTRACT_ADDRESS=$governance_address
-export SLASH_FACTORY_CONTRACT_ADDRESS=$slash_factory_address
 EOF
 
 cat /shared/contracts/contracts.env

--- a/spartan/aztec-network/files/config/config-prover-env.sh
+++ b/spartan/aztec-network/files/config/config-prover-env.sh
@@ -1,6 +1,17 @@
 #!/bin/bash
 set -eu
 
+# if the registry address is already set and the bootstrap nodes are set, then we don't need to wait for the services
+if [ -n "$REGISTRY_CONTRACT_ADDRESS" ] && [ -n "$BOOTSTRAP_NODES" ]; then
+  cat <<EOF >/shared/contracts/contracts.env
+export BOOTSTRAP_NODES=$BOOTSTRAP_NODES
+export REGISTRY_CONTRACT_ADDRESS=$REGISTRY_CONTRACT_ADDRESS
+EOF
+  cat /shared/contracts/contracts.env
+  exit 0
+fi
+
+
 # Pass the bootnode url as an argument
 # Ask the bootnode for l1 contract addresses
 output=$(node --no-warnings /usr/src/yarn-project/aztec/dest/bin/index.js get-node-info --node-url $1)
@@ -12,32 +23,12 @@ if [ "$P2P_ENABLED" = "true" ]; then
   # Only look for boot node ENR if P2P is enabled
   boot_node_enr=$(echo "$output" | grep -oP 'Node ENR: \Kenr:[a-zA-Z0-9\-\_\.]+')
 fi
-rollup_address=$(echo "$output" | grep -oP 'Rollup Address: \K0x[a-fA-F0-9]{40}')
 registry_address=$(echo "$output" | grep -oP 'Registry Address: \K0x[a-fA-F0-9]{40}')
-inbox_address=$(echo "$output" | grep -oP 'L1 -> L2 Inbox Address: \K0x[a-fA-F0-9]{40}')
-outbox_address=$(echo "$output" | grep -oP 'L2 -> L1 Outbox Address: \K0x[a-fA-F0-9]{40}')
-fee_juice_address=$(echo "$output" | grep -oP 'Fee Juice Address: \K0x[a-fA-F0-9]{40}')
-staking_asset_address=$(echo "$output" | grep -oP 'Staking Asset Address: \K0x[a-fA-F0-9]{40}')
-fee_juice_portal_address=$(echo "$output" | grep -oP 'Fee Juice Portal Address: \K0x[a-fA-F0-9]{40}')
-coin_issuer_address=$(echo "$output" | grep -oP 'CoinIssuer Address: \K0x[a-fA-F0-9]{40}')
-reward_distributor_address=$(echo "$output" | grep -oP 'RewardDistributor Address: \K0x[a-fA-F0-9]{40}')
-governance_proposer_address=$(echo "$output" | grep -oP 'GovernanceProposer Address: \K0x[a-fA-F0-9]{40}')
-governance_address=$(echo "$output" | grep -oP 'Governance Address: \K0x[a-fA-F0-9]{40}')
 
 # Write the addresses to a file in the shared volume
 cat <<EOF >/shared/contracts/contracts.env
 export BOOTSTRAP_NODES=$boot_node_enr
-export ROLLUP_CONTRACT_ADDRESS=$rollup_address
 export REGISTRY_CONTRACT_ADDRESS=$registry_address
-export INBOX_CONTRACT_ADDRESS=$inbox_address
-export OUTBOX_CONTRACT_ADDRESS=$outbox_address
-export FEE_JUICE_CONTRACT_ADDRESS=$fee_juice_address
-export STAKING_ASSET_CONTRACT_ADDRESS=$staking_asset_address
-export FEE_JUICE_PORTAL_CONTRACT_ADDRESS=$fee_juice_portal_address
-export COIN_ISSUER_CONTRACT_ADDRESS=$coin_issuer_address
-export REWARD_DISTRIBUTOR_CONTRACT_ADDRESS=$reward_distributor_address
-export GOVERNANCE_PROPOSER_CONTRACT_ADDRESS=$governance_proposer_address
-export GOVERNANCE_CONTRACT_ADDRESS=$governance_address
 EOF
 
 cat /shared/contracts/contracts.env

--- a/spartan/aztec-network/files/config/setup-service-addresses.sh
+++ b/spartan/aztec-network/files/config/setup-service-addresses.sh
@@ -99,8 +99,8 @@ else
 fi
 
 # Configure Boot Node address
-if [ "${BOOT_NODE_EXTERNAL_HOST}" != "" ]; then
-  BOOT_NODE_ADDR="${BOOT_NODE_EXTERNAL_HOST}"
+if [ "${EXTERNAL_BOOT_NODE_HOST}" != "" ]; then
+  BOOT_NODE_ADDR="${EXTERNAL_BOOT_NODE_HOST}"
 elif [ "${NETWORK_PUBLIC}" = "true" ]; then
   BOOT_NODE_ADDR=$(get_service_address "boot-node" "${BOOT_NODE_PORT}")
 else

--- a/spartan/aztec-network/templates/boot-node.yaml
+++ b/spartan/aztec-network/templates/boot-node.yaml
@@ -1,3 +1,4 @@
+{{- if .Values.bootNode.enabled }}
 apiVersion: apps/v1
 kind: StatefulSet
 metadata:
@@ -337,4 +338,5 @@ spec:
             name: {{ include "aztec-network.fullname" . }}-boot-node
             port:
               number: {{ .Values.bootNode.service.nodePort }}
+{{- end }}
 {{- end }}

--- a/spartan/aztec-network/templates/eth/eth-entrypoint-configmap.yaml
+++ b/spartan/aztec-network/templates/eth/eth-entrypoint-configmap.yaml
@@ -1,3 +1,4 @@
+{{- if not .Values.ethereum.beacon.externalHost }}
 apiVersion: v1
 kind: ConfigMap
 metadata:
@@ -8,3 +9,4 @@ data:
   eth-validator.sh: {{ .Files.Get "eth-devnet/entrypoints/eth-validator.sh" | quote }}
   eth-beacon.sh: {{ .Files.Get "eth-devnet/entrypoints/eth-beacon.sh" | quote }}
   eth-execution.sh: {{ .Files.Get "eth-devnet/entrypoints/eth-execution.sh" | quote }}
+{{- end }}

--- a/spartan/aztec-network/templates/full-node.yaml
+++ b/spartan/aztec-network/templates/full-node.yaml
@@ -94,6 +94,10 @@ spec:
           env:
             - name: P2P_ENABLED
               value: "{{ .Values.fullNode.p2p.enabled }}"
+            - name: BOOTSTRAP_NODES
+              value: "{{ .Values.aztec.bootstrapENRs }}"
+            - name: REGISTRY_CONTRACT_ADDRESS
+              value: "{{ .Values.aztec.contracts.registryAddress }}"
 
         - name: wait-for-ethereum
           {{- include "aztec-network.image" . | nindent 10 }}

--- a/spartan/aztec-network/templates/prover-node.yaml
+++ b/spartan/aztec-network/templates/prover-node.yaml
@@ -73,7 +73,6 @@ spec:
             - |
               source /shared/config/service-addresses
               cat /shared/config/service-addresses
-              {{- include "aztec-network.waitForEthereum" . | nindent 14 }}
 
               if [ "${PROVER_BROKER_ENABLED}" == "false" ]; then
                 until curl -s -X POST ${PROVER_BROKER_HOST}/status; do
@@ -84,6 +83,15 @@ spec:
               else
                 echo "Using built-in job broker"
               fi
+
+              # If we already have a registry address, and the bootstrap nodes are set, then we don't need to wait for the services
+              if [ -n "{{ .Values.aztec.contracts.registryAddress }}" ] && [ -n "{{ .Values.aztec.bootstrapENRs }}" ]; then
+                echo "Registry address and bootstrap nodes already set, skipping wait for services"
+                exit 0
+              fi
+
+              {{- include "aztec-network.waitForEthereum" . | nindent 14 }}
+
 
               until curl --head --silent $BOOT_NODE_HOST/status; do
                 echo "Waiting for boot node..."
@@ -116,6 +124,10 @@ spec:
           env:
             - name: P2P_ENABLED
               value: "{{ .Values.proverNode.p2p.enabled }}"
+            - name: BOOTSTRAP_NODES
+              value: "{{ .Values.aztec.bootstrapENRs }}"
+            - name: REGISTRY_CONTRACT_ADDRESS
+              value: "{{ .Values.aztec.contracts.registryAddress }}"
 
       containers:
         - name: prover-node

--- a/spartan/aztec-network/templates/validator.yaml
+++ b/spartan/aztec-network/templates/validator.yaml
@@ -75,6 +75,13 @@ spec:
             - /bin/bash
             - -c
             - |
+              # If we already have a registry address, and the bootstrap nodes are set, then we don't need to wait for the services
+              if [ -n "{{ .Values.aztec.contracts.registryAddress }}" ] && [ -n "{{ .Values.aztec.bootstrapENRs }}" ]; then
+                echo "Registry address and bootstrap nodes already set, skipping wait for services"
+                echo "{{ include "aztec-network.pxeUrl" . }}" > /shared/pxe/pxe_url
+                exit 0
+              fi
+
               source /shared/config/service-addresses
               cat /shared/config/service-addresses
               {{- include "aztec-network.waitForEthereum" . | nindent 14 }}
@@ -120,6 +127,12 @@ spec:
           env:
             - name: P2P_ENABLED
               value: "{{ .Values.validator.p2p.enabled }}"
+            - name: BOOTSTRAP_NODES
+              value: "{{ .Values.aztec.bootstrapENRs }}"
+            - name: REGISTRY_CONTRACT_ADDRESS
+              value: "{{ .Values.aztec.contracts.registryAddress }}"
+            - name: SLASH_FACTORY_CONTRACT_ADDRESS
+              value: "{{ .Values.aztec.contracts.slashFactoryAddress }}"
       containers:
         - name: validator
           {{- include "aztec-network.image" . | nindent 10 }}

--- a/spartan/aztec-network/values.yaml
+++ b/spartan/aztec-network/values.yaml
@@ -47,6 +47,11 @@ images:
     pullPolicy: IfNotPresent
 
 aztec:
+  bootstrapENRs: ""
+  contracts:
+    registryAddress: ""
+    slashFactoryAddress: ""
+
   slotDuration: 36 # in seconds, aka L2 slot duration. Must be a multiple of {{ ethereum.blockTime }}
   epochDuration: 32 # how many L2 slots in an epoch
   proofSubmissionWindow: 64 # in L2 slots, from the start of the epoch to be proven
@@ -67,6 +72,7 @@ aztec:
   botKeyIndexStart: 3000
 
 bootNode:
+  enabled: true
   peerIdPrivateKey: ""
   externalHost: ""
   replicas: 1

--- a/spartan/aztec-network/values/slim.yaml
+++ b/spartan/aztec-network/values/slim.yaml
@@ -1,0 +1,28 @@
+telemetry:
+  enabled: true
+
+network:
+  setupL2Contracts: false
+
+validator:
+  replicas: 1
+  sequencer:
+    minTxsPerBlock: 0
+  validator:
+    disabled: false
+
+pxe:
+  enabled: true
+  resources:
+    requests:
+      memory: "1Gi"
+      cpu: "1000m"
+
+bootNode:
+  enabled: false
+
+bot:
+  enabled: false
+
+faucet:
+  enabled: false

--- a/spartan/bootstrap.sh
+++ b/spartan/bootstrap.sh
@@ -61,6 +61,7 @@ function test_cmds {
     echo "$hash timeout -v 20m ./spartan/bootstrap.sh test-kind-transfer"
     echo "$hash timeout -v 30m ./spartan/bootstrap.sh test-kind-4epochs"
     echo "$hash timeout -v 30m ./spartan/bootstrap.sh test-kind-upgrade-rollup-version"
+    echo "$hash timeout -v 30m ./spartan/bootstrap.sh test-prod-deployment"
   fi
 }
 
@@ -130,6 +131,9 @@ case "$cmd" in
     OVERRIDES="bot.enabled=false" \
     FRESH_INSTALL=${FRESH_INSTALL:-true} INSTALL_METRICS=false \
       ./scripts/test_kind.sh src/spartan/upgrade_rollup_version.test.ts ci.yaml upgrade-rollup-version${NAME_POSTFIX:-}
+    ;;
+  "test-prod-deployment")
+    FRESH_INSTALL=false INSTALL_METRICS=false ./scripts/test_prod_deployment.sh
     ;;
   "test-local")
     # Isolate network stack in docker.

--- a/spartan/scripts/deploy_kind.sh
+++ b/spartan/scripts/deploy_kind.sh
@@ -133,7 +133,7 @@ helm upgrade --install "$helm_instance" ../aztec-network \
   --wait-for-jobs=true \
   --timeout="$install_timeout"
 
-kubectl wait pod -l app==pxe --for=condition=Ready -n "$namespace" --timeout=10m
+kubectl wait pod -l app==pxe -l app.kubernetes.io/instance="$helm_instance" --for=condition=Ready -n "$namespace" --timeout=10m
 
 if [ -n "$chaos_values" ]; then
   ../bootstrap.sh chaos-mesh

--- a/spartan/scripts/test_prod_deployment.sh
+++ b/spartan/scripts/test_prod_deployment.sh
@@ -1,0 +1,132 @@
+#!/bin/bash
+
+# Test Production Deployment Script
+# ================================
+#
+# This script tests a production-like deployment scenario by simulating a rolling upgrade
+# process across two releases. The test follows these steps:
+#
+# 1. Initial Setup:
+#    - Deploys a full cluster ("original" release) with all components using 1-validators.yaml
+#    - Runs initial smoke tests to verify deployment
+#
+# 2. Partial Teardown:
+#    - Removes specific components from the original deployment while preserving:
+#      * Boot node
+#      * Ethereum nodes
+#      * Any full nodes
+#
+# 3. Bridge Configuration:
+#    - Sets up port forwarding to the boot node
+#    - Retrieves critical network information:
+#      * Bootstrap ENR (Ethereum Node Record)
+#      * Registry contract address
+#      * Slash factory contract address
+#
+# 4. Secondary Deployment:
+#    - Deploys a new "offshoot" release using slim.yaml, which only has a pxe, a validator, and prover infrastructure
+#    - Configures the new deployment to use existing network components/rollup
+#    - Points new validator/prover nodes to the original boot node enr for p2p bootstrapping
+#    - Connects to existing Ethereum services
+#
+# 5. Final Verification:
+#    - Runs smoke tests against the new deployment to ensure functionality
+#
+# This test validates that the network can maintain functionality during a staged upgrade
+# process where some components are replaced while others remain operational.
+
+source $(git rev-parse --show-toplevel)/ci3/source
+
+export NAMESPACE=${NAMESPACE:-prod}
+release=original
+offshoot="$release-offshoot"
+original_values_file=1-validators.yaml
+offshoot_values_file=slim.yaml
+
+kubectl delete namespace $NAMESPACE --ignore-not-found=true
+
+HELM_INSTANCE=$release ./test_kind.sh src/spartan/smoke.test.ts $original_values_file $NAMESPACE
+
+# Delete stuff in the original namespace, we'll recreate it in the offshoot
+kubectl delete statefulset $release-aztec-network-validator -n $NAMESPACE --wait=true
+kubectl delete service $release-aztec-network-validator -n $NAMESPACE --wait=true
+
+kubectl delete statefulset $release-aztec-network-prover-node -n $NAMESPACE --wait=true
+kubectl delete service $release-aztec-network-prover-node -n $NAMESPACE --wait=true
+
+kubectl delete statefulset $release-aztec-network-prover-broker -n $NAMESPACE --wait=true
+kubectl delete service $release-aztec-network-prover-broker -n $NAMESPACE --wait=true
+
+kubectl delete replicaset $release-aztec-network-prover-agent -n $NAMESPACE --wait=true
+
+kubectl delete deployment $release-aztec-network-pxe -n $NAMESPACE --wait=true
+kubectl delete service $release-aztec-network-pxe -n $NAMESPACE --wait=true
+
+kubectl delete statefulset $release-aztec-network-bot -n $NAMESPACE --wait=true
+kubectl delete service $release-aztec-network-bot -n $NAMESPACE --wait=true
+
+# At this point, the namespace should just have a boot node and ethereum nodes
+
+tmpfile=$(mktemp)
+
+# Set up cleanup for both the temp file and background processes
+trap 'kill $(jobs -p); rm -f "$tmpfile"' EXIT
+
+# Start port-forward in the background and tee its output to a file in order to capture the port number
+kubectl -n "$NAMESPACE" port-forward svc/"$release-aztec-network-boot-node" :8080 2>&1 | tee "$tmpfile" &
+pf_pid=$!
+
+# Wait until the forwarding message appears, with a 10-second timeout
+timeout=10
+start_time=$(date +%s)
+while ! grep -q "Forwarding from" "$tmpfile"; do
+  current_time=$(date +%s)
+  if [ $((current_time - start_time)) -ge $timeout ]; then
+    echo "Timeout waiting for port-forward after $timeout seconds"
+    kill $pf_pid
+    exit 1
+  fi
+  sleep 0.1
+done
+
+# Extract the local port number from the message.
+forwarded_port=$(grep "Forwarding from" "$tmpfile" | sed -nE 's/.*127\.0\.0\.1:([0-9]+).*/\1/p')
+echo "Port assigned: $forwarded_port"
+
+# Point the PXE at the first validator
+# Note: this is just for the PXE that we're going to spin up.
+# It looks for a "boot node" in its startup scripts when the network is public,
+# and we do set it to be a validator service when the network is not public.
+# So in this case, by explicitly setting the external bootnode host,
+# we save ourselves from trying to reach out to a "boot node" (which won't be there) in both cases.
+boot_node_host="http://$offshoot-aztec-network-validator-0.$offshoot-aztec-network-validator.$NAMESPACE.svc.cluster.local:8080"
+
+# Point ethereum clients at the external services
+ethereum_execution="http://$release-aztec-network-eth-execution.$NAMESPACE:8545"
+ethereum_beacon="http://$release-aztec-network-eth-beacon.$NAMESPACE:5052"
+
+node_info=$(curl -s -X POST -H 'Content-Type: application/json' \
+        -d '{"jsonrpc":"2.0","method":"node_getNodeInfo","params":[],"id":42}' \
+        "http://localhost:$forwarded_port")
+
+enr=$(jq -r '.result.enr' <<< "$node_info")
+registry_address=$(jq -r '.result.l1ContractAddresses.registryAddress' <<< "$node_info")
+slash_factory_address=$(jq -r '.result.l1ContractAddresses.slashFactoryAddress' <<< "$node_info")
+
+echo "Boot node host: $boot_node_host"
+echo "Ethereum execution: $ethereum_execution"
+echo "Ethereum beacon: $ethereum_beacon"
+echo "ENR: $enr"
+echo "Registry address: $registry_address"
+echo "Slash factory address: $slash_factory_address"
+
+export OVERRIDES="bootNode.externalHost=$boot_node_host,ethereum.execution.externalHosts=$ethereum_execution,ethereum.beacon.externalHost=$ethereum_beacon,aztec.contracts.registryAddress=$registry_address,aztec.contracts.slashFactoryAddress=$slash_factory_address,aztec.bootstrapENRs=$enr"
+
+echo "OVERRIDES: $OVERRIDES"
+
+FRESH_INSTALL=false INSTALL_METRICS=false HELM_INSTANCE=$offshoot ./test_kind.sh src/spartan/smoke.test.ts $offshoot_values_file $NAMESPACE
+
+
+
+
+


### PR DESCRIPTION
Adds support in the aztec-network chart to make use of external boot nodes and ethereum nodes while only deploying:
- validators
- prover infra
- pxe

This change enables rolling upgrades by allowing nodes to connect to existing boot nodes and contract addresses rather than requiring a full deployment.

Key changes:

- Adds configuration options for external boot node host and contract addresses
- Adds logic to skip waiting for services when registry address and bootstrap nodes are already set
- Reduces required contract addresses to only those needed for node operation
- Adds new slim.yaml configuration for minimal deployments
- Adds test script to validate rolling upgrade scenarios
