### PR TITLE
fix: remove first nullifier emitted in txe

### DIFF
--- a/cspell.json
+++ b/cspell.json
@@ -307,6 +307,7 @@
     "unnullify",
     "unpadded",
     "unprefixed",
+    "unsiloed",
     "unshift",
     "unshifted",
     "unsynched",

--- a/noir-projects/aztec-nr/aztec/src/history/nullifier_inclusion/test.nr
+++ b/noir-projects/aztec-nr/aztec/src/history/nullifier_inclusion/test.nr
@@ -1,6 +1,10 @@
 use crate::history::{nullifier_inclusion::{ProveNoteIsNullified, ProveNullifierInclusion}, test};
-use crate::oracle::random::random;
-use crate::test::helpers::test_environment::FIRST_NULLIFIER_EMITTED_IN_TXE;
+use crate::oracle::{notes::notify_created_nullifier, random::random};
+use crate::test::helpers::test_environment::TestEnvironment;
+use dep::protocol_types::{
+    constants::GENERATOR_INDEX__OUTER_NULLIFIER, hash::poseidon2_hash_with_separator,
+    traits::ToField,
+};
 
 // In these tests, we create a note in one block and nullify it in the next.
 
@@ -32,23 +36,36 @@ unconstrained fn note_is_not_nullified() {
     );
 }
 
-// In this test, we prove the inclusion of an existing nullifier in state. We use know FIRST_NULLIFIER_EMITTED_IN_TXE exists
-// because the TXe creates deterministic first nullifiers if no side-effects are emitted.
+// In this test, we create a nullifier and confirm that it was siloed and added to state.
 #[test]
 unconstrained fn nullifier_inclusion() {
-    let (env) = test::create_note_and_nullify_it();
+    let mut env = TestEnvironment::new();
 
-    let context = &mut env.private();
+    let unsiloed_nullifier = 42069;
+
+    // We need to create the siloed nullifier so we can check for its inclusion in state.
+    let siloed_nullifier = poseidon2_hash_with_separator(
+        [env.contract_address().to_field(), unsiloed_nullifier],
+        GENERATOR_INDEX__OUTER_NULLIFIER,
+    );
+
+    notify_created_nullifier(unsiloed_nullifier);
+
+    let nullifier_created_at = env.pending_block_number();
+
+    env.advance_block_by(1);
+
+    let context = &mut env.private_at(nullifier_created_at);
 
     // docs:start:prove_nullifier_inclusion
-    context.historical_header.prove_nullifier_inclusion(FIRST_NULLIFIER_EMITTED_IN_TXE);
+    context.historical_header.prove_nullifier_inclusion(siloed_nullifier);
     // docs:end:prove_nullifier_inclusion
 }
 
 // In this test, we fail to prove the inclusion of an arbitrary nullifier in state.
 #[test(should_fail_with = "Nullifier membership witness not found")]
 unconstrained fn nullifier_inclusion_fails() {
-    let (env) = test::create_note_and_nullify_it();
+    let mut env = TestEnvironment::new();
 
     let context = &mut env.private();
     context.historical_header.prove_nullifier_inclusion(random());

--- a/noir-projects/aztec-nr/aztec/src/history/nullifier_non_inclusion/test.nr
+++ b/noir-projects/aztec-nr/aztec/src/history/nullifier_non_inclusion/test.nr
@@ -1,8 +1,13 @@
-use crate::history::nullifier_non_inclusion::{ProveNoteNotNullified, ProveNullifierNonInclusion};
-use crate::oracle::random::random;
-
-use crate::history::test;
-use crate::test::helpers::test_environment::FIRST_NULLIFIER_EMITTED_IN_TXE;
+use crate::history::{
+    nullifier_non_inclusion::{ProveNoteNotNullified, ProveNullifierNonInclusion},
+    test,
+};
+use crate::oracle::{notes::notify_created_nullifier, random::random};
+use crate::test::helpers::test_environment::TestEnvironment;
+use dep::protocol_types::{
+    constants::GENERATOR_INDEX__OUTER_NULLIFIER, hash::poseidon2_hash_with_separator,
+    traits::ToField,
+};
 
 // In these tests, we create a note in one block and nullify it in the next.
 
@@ -36,20 +41,34 @@ unconstrained fn note_not_nullified_fails() {
 // In this test, we prove the absence of an arbitrary nullifier in state.
 #[test]
 unconstrained fn nullifier_non_inclusion() {
-    let (env) = test::create_note_and_nullify_it();
+    let mut env = TestEnvironment::new();
 
     let context = &mut env.private();
 
     context.historical_header.prove_nullifier_non_inclusion(random());
 }
 
-// In this test, we fail to prove the absence of an existing nullifier in state. We use know FIRST_NULLIFIER_EMITTED_IN_TXE exists
-// because the TXe creates deterministic first nullifiers if no side-effects are emitted.
+// In this test, we create a nullifier and fail to prove its absence in state (we are checking the
+// siloed version of it because that is what is actually pushed to state).
 #[test(should_fail_with = "Proving nullifier non-inclusion failed")]
 unconstrained fn nullifier_non_inclusion_fails() {
-    let (env) = test::create_note_and_nullify_it();
+    let mut env = TestEnvironment::new();
 
-    let context = &mut env.private();
+    let unsiloed_nullifier = 42069;
 
-    context.historical_header.prove_nullifier_non_inclusion(FIRST_NULLIFIER_EMITTED_IN_TXE);
+    // We need to create the siloed nullifier so we can check for its inclusion in state.
+    let siloed_nullifier = poseidon2_hash_with_separator(
+        [env.contract_address().to_field(), unsiloed_nullifier],
+        GENERATOR_INDEX__OUTER_NULLIFIER,
+    );
+
+    notify_created_nullifier(unsiloed_nullifier);
+
+    let nullifier_created_at = env.pending_block_number();
+
+    env.advance_block_by(1);
+
+    let context = &mut env.private_at(nullifier_created_at);
+
+    context.historical_header.prove_nullifier_non_inclusion(siloed_nullifier);
 }

--- a/noir-projects/aztec-nr/aztec/src/test/helpers/test_environment.nr
+++ b/noir-projects/aztec-nr/aztec/src/test/helpers/test_environment.nr
@@ -14,13 +14,6 @@ use crate::oracle::{
 use protocol_types::constants::PUBLIC_DISPATCH_SELECTOR;
 use protocol_types::traits::Packable;
 
-// This is the first nullifier emitted from the TXe. It is an arbitrary number assigned in the TXe that is
-// larger than the first prefilled subtree of the nullifier tree. We know FIRST_NULLIFIER_EMITTED_IN_TXE exists
-// because the TXe creates a deterministic first nullifier for each block if no side-effects are emitted in said block.
-// The TXe automatically builds an empty block upon initialization and therefore we know this nullifier is inserted.
-// TODO(#12226): REMOVE THIS
-pub global FIRST_NULLIFIER_EMITTED_IN_TXE: Field = 6969 + 1;
-
 pub struct TestEnvironment {}
 
 impl TestEnvironment {


### PR DESCRIPTION
As @benesjan pointed out in #12215, the approach to use a deterministic nullifier emitted by the TXe was extremely brittle, and should be changed. I looked and found it was actually possible to emit an arbitrary nullifier (albeit through a bit obscure of an oracle), and have adapted the tests to use this oracle.