### PR TITLE
chore: Increase timeout for prover full

### DIFF
--- a/yarn-project/end-to-end/bootstrap.sh
+++ b/yarn-project/end-to-end/bootstrap.sh
@@ -10,7 +10,7 @@ function test_cmds {
   local prefix="$hash $run_test_script"
 
   if [ "$CI_FULL" -eq 1 ]; then
-    echo "$hash timeout -v 900s bash -c 'CPUS=16 MEM=96g $run_test_script simple e2e_prover/full real'"
+    echo "$hash timeout -v 1200s bash -c 'CPUS=16 MEM=96g $run_test_script simple e2e_prover/full real'"
   else
     echo "$hash FAKE_PROOFS=1 $run_test_script simple e2e_prover/full fake"
   fi


### PR DESCRIPTION
Fix the timeout by giving it more time. On mainframe this runs in 650s:

```
 PASS  src/e2e_prover/full.test.ts (651.028 s)
  full_prover
    ✓ makes both public and private transfers (541783 ms)
    ✓ generates sample Prover.toml files if generate test data is on (3428 ms)
    ✓ rejects txs with invalid proofs (65437 ms)
```

Let's see if it works for CI.