### PR TITLE
fix: Wait for L1 to L2 msg sync before claiming

### DIFF
--- a/yarn-project/aztec.js/src/api/ethereum/chain_monitor.ts
+++ b/yarn-project/aztec.js/src/api/ethereum/chain_monitor.ts
@@ -14,6 +14,10 @@ export class ChainMonitor {
   public l2BlockNumber!: number;
   /** Current L2 proven block number */
   public l2ProvenBlockNumber!: number;
+  /** L1 timestamp for the current L2 block */
+  public l2BlockTimestamp!: bigint;
+  /** L1 timestamp for the proven L2 block */
+  public l2ProvenBlockTimestamp!: bigint;
 
   constructor(
     private readonly rollup: RollupContract,
@@ -28,6 +32,7 @@ export class ChainMonitor {
       throw new Error('Chain monitor already started');
     }
     this.handle = setInterval(this.safeRun.bind(this), this.intervalMs);
+    return this;
   }
 
   stop() {
@@ -61,6 +66,7 @@ export class ChainMonitor {
       const epochNumber = await this.rollup.getEpochNumber(BigInt(newL2BlockNumber));
       msg += ` with new L2 block ${newL2BlockNumber} for epoch ${epochNumber}`;
       this.l2BlockNumber = newL2BlockNumber;
+      this.l2BlockTimestamp = timestamp;
     }
 
     const newL2ProvenBlockNumber = Number(await this.rollup.getProvenBlockNumber());
@@ -68,6 +74,7 @@ export class ChainMonitor {
       const epochNumber = await this.rollup.getEpochNumber(BigInt(newL2ProvenBlockNumber));
       msg += ` with proof up to L2 block ${newL2ProvenBlockNumber} for epoch ${epochNumber}`;
       this.l2ProvenBlockNumber = newL2ProvenBlockNumber;
+      this.l2ProvenBlockTimestamp = timestamp;
     }
 
     this.logger.info(msg, {

--- a/yarn-project/bot/src/factory.ts
+++ b/yarn-project/bot/src/factory.ts
@@ -227,7 +227,11 @@ export class BotFactory {
 
     const portal = await L1FeeJuicePortalManager.new(this.pxe, publicClient, walletClient, this.log);
     const claim = await portal.bridgeTokensPublic(recipient, amount, true /* mint */);
-    this.log.info('Created a claim for L1 fee juice.');
+
+    const isSynced = async () => await this.pxe.isL1ToL2MessageSynced(Fr.fromHexString(claim.messageHash));
+    await retryUntil(isSynced, `message ${claim.messageHash} sync`, 24, 1);
+
+    this.log.info(`Created a claim for ${amount} L1 fee juice to ${recipient}.`, claim);
 
     // Progress by 2 L2 blocks so that the l1ToL2Message added above will be available to use on L2.
     await this.advanceL2Block();

--- a/yarn-project/end-to-end/src/e2e_epochs/epochs_test.ts
+++ b/yarn-project/end-to-end/src/e2e_epochs/epochs_test.ts
@@ -92,8 +92,7 @@ export class EpochsTestContext {
     this.rollup = RollupContract.getFromConfig(context.config);
 
     // Loop that tracks L1 and L2 block numbers and logs whenever there's a new one.
-    this.monitor = new ChainMonitor(this.rollup, this.logger);
-    this.monitor.start();
+    this.monitor = new ChainMonitor(this.rollup, this.logger).start();
 
     // This is hideous.
     // We ought to have a definite reference to the l1TxUtils that we're using in both places, provided by the test context.

--- a/yarn-project/end-to-end/src/e2e_fees/bridging_race.test.ts
+++ b/yarn-project/end-to-end/src/e2e_fees/bridging_race.test.ts
@@ -1,0 +1,74 @@
+import { getSchnorrAccount } from '@aztec/accounts/schnorr';
+import { Fr, type Logger, type PXE, sleep } from '@aztec/aztec.js';
+import { FEE_FUNDING_FOR_TESTER_ACCOUNT } from '@aztec/constants';
+import { Fq } from '@aztec/foundation/fields';
+import type { AztecAddress } from '@aztec/stdlib/aztec-address';
+
+import { jest } from '@jest/globals';
+import type { Hex } from 'viem';
+
+import { FeesTest } from './fees_test.js';
+
+jest.setTimeout(300_000);
+
+// Regression for https://github.com/AztecProtocol/aztec-packages/issues/12366
+// Similar to e2e_fees/account_init but with no automine
+describe('e2e_fees bridging_race', () => {
+  const ETHEREUM_SLOT_DURATION = 4;
+  const AZTEC_SLOT_DURATION = ETHEREUM_SLOT_DURATION * 2;
+
+  const t = new FeesTest('bridging_race', 1, {
+    ethereumSlotDuration: ETHEREUM_SLOT_DURATION,
+    aztecSlotDuration: AZTEC_SLOT_DURATION,
+    minTxsPerBlock: 0,
+  });
+
+  beforeAll(async () => {
+    await t.applyInitialAccountsSnapshot();
+    await t.applyPublicDeployAccountsSnapshot();
+    await t.applySetupFeeJuiceSnapshot();
+
+    ({ pxe, logger } = await t.setup());
+  });
+
+  afterAll(async () => {
+    await t.teardown();
+  });
+
+  let logger: Logger;
+  let pxe: PXE;
+  let bobsAddress: AztecAddress;
+
+  beforeEach(async () => {
+    const bobsSecretKey = Fr.random();
+    const bobsPrivateSigningKey = Fq.random();
+    const bobsAccountManager = await getSchnorrAccount(pxe, bobsSecretKey, bobsPrivateSigningKey, Fr.random());
+    const bobsCompleteAddress = await bobsAccountManager.getCompleteAddress();
+    bobsAddress = bobsCompleteAddress.address;
+    await bobsAccountManager.getWallet();
+    await bobsAccountManager.register();
+  });
+
+  it('Alice bridges funds to Bob', async () => {
+    // Tweak the token manager so the bridging happens immediately before the end of the current L2 slot
+    // This caused the message to be "not in state" when tried to be used
+    const l1TokenManager = t.feeJuiceBridgeTestHarness.l1TokenManager;
+    const origApprove = l1TokenManager.approve.bind(l1TokenManager);
+    l1TokenManager.approve = async (amount: bigint, address: Hex, addressName = '') => {
+      await origApprove(amount, address, addressName);
+      const sleepTime = (Number(t.chainMonitor.l2BlockTimestamp) + AZTEC_SLOT_DURATION) * 1000 - Date.now() - 500;
+      logger.info(`Sleeping for ${sleepTime}ms until near end of L2 slot before sending L1 fee juice to L2 inbox`);
+      await sleep(sleepTime);
+    };
+
+    // Waiting for the archiver to sync the message _before_ waiting for the mandatory 2 L2 blocks to pass fixed it
+    // This was added everywhere we wait for two blocks, which is spread across three different places in the codebase
+    // Yes, we need to REFACTOR it at some point
+    const amount = FEE_FUNDING_FOR_TESTER_ACCOUNT;
+    const claim = await t.feeJuiceBridgeTestHarness.prepareTokensOnL1(amount, bobsAddress);
+    const { claimSecret: secret, messageLeafIndex: index } = claim;
+    await t.feeJuiceContract.methods.claim(bobsAddress, amount, secret, index).send().wait();
+    const [balance] = await t.getGasBalanceFn(bobsAddress);
+    expect(balance).toEqual(amount);
+  });
+});

--- a/yarn-project/end-to-end/src/e2e_fees/fees_test.ts
+++ b/yarn-project/end-to-end/src/e2e_fees/fees_test.ts
@@ -3,6 +3,7 @@ import {
   type AccountWallet,
   type AztecAddress,
   type AztecNode,
+  ChainMonitor,
   CheatCodes,
   type Logger,
   type PXE,
@@ -10,7 +11,7 @@ import {
   sleep,
 } from '@aztec/aztec.js';
 import { FEE_FUNDING_FOR_TESTER_ACCOUNT } from '@aztec/constants';
-import { createL1Clients } from '@aztec/ethereum';
+import { type DeployL1ContractsArgs, RollupContract, createL1Clients } from '@aztec/ethereum';
 import { EthAddress } from '@aztec/foundation/eth-address';
 import { RollupAbi, TestERC20Abi } from '@aztec/l1-artifacts';
 import { AppSubscriptionContract } from '@aztec/noir-contracts.js/AppSubscription';
@@ -35,6 +36,7 @@ import {
 import { mintTokensToPrivate } from '../fixtures/token_utils.js';
 import {
   type BalancesFn,
+  type SetupOptions,
   ensureAccountsPubliclyDeployed,
   getBalancesFn,
   setupCanonicalFeeJuice,
@@ -80,6 +82,7 @@ export class FeesTest {
   public feeJuiceBridgeTestHarness!: GasBridgingTestHarness;
 
   public context!: SubsystemsContext;
+  public chainMonitor!: ChainMonitor;
 
   public getCoinbaseBalance!: () => Promise<bigint>;
   public getCoinbaseSequencerRewards!: () => Promise<bigint>;
@@ -92,7 +95,11 @@ export class FeesTest {
   public readonly SUBSCRIPTION_AMOUNT = BigInt(1e19);
   public readonly APP_SPONSORED_TX_GAS_LIMIT = BigInt(10e9);
 
-  constructor(testName: string, private numberOfAccounts = 3) {
+  constructor(
+    testName: string,
+    private numberOfAccounts = 3,
+    setupOptions: Partial<SetupOptions & DeployL1ContractsArgs> = {},
+  ) {
     if (!numberOfAccounts) {
       throw new Error('There must be at least 1 initial account.');
     }
@@ -100,20 +107,23 @@ export class FeesTest {
     this.snapshotManager = createSnapshotManager(
       `e2e_fees/${testName}-${numberOfAccounts}`,
       dataPath,
-      {
-        startProverNode: true,
-      },
-      {},
+      { startProverNode: true, ...setupOptions },
+      { ...setupOptions },
     );
   }
 
   async setup() {
     const context = await this.snapshotManager.setup();
     await context.aztecNode.setConfig({ feeRecipient: this.sequencerAddress, coinbase: this.coinbase });
+
+    const rollupContract = RollupContract.getFromConfig(context.aztecNodeConfig);
+    this.chainMonitor = new ChainMonitor(rollupContract, this.logger, 200).start();
+
     return this;
   }
 
   async teardown() {
+    this.chainMonitor.stop();
     await this.snapshotManager.teardown();
   }
 

--- a/yarn-project/end-to-end/src/e2e_p2p/p2p_network.ts
+++ b/yarn-project/end-to-end/src/e2e_p2p/p2p_network.ts
@@ -340,8 +340,7 @@ export class P2PNetworkTest {
       },
     );
 
-    this.monitor = new ChainMonitor(RollupContract.getFromL1ContractsValues(this.ctx.deployL1ContractsValues));
-    this.monitor.start();
+    this.monitor = new ChainMonitor(RollupContract.getFromL1ContractsValues(this.ctx.deployL1ContractsValues)).start();
   }
 
   async stopNodes(nodes: AztecNodeService[]) {

--- a/yarn-project/end-to-end/src/shared/gas_portal_test_harness.ts
+++ b/yarn-project/end-to-end/src/shared/gas_portal_test_harness.ts
@@ -2,6 +2,7 @@ import {
   type AztecAddress,
   type AztecNode,
   EthAddress,
+  Fr,
   L1FeeJuicePortalManager,
   type L1TokenManager,
   type L2AmountClaim,
@@ -74,8 +75,8 @@ export class FeeJuicePortalTestingHarnessFactory {
  * shared between cross chain tests.
  */
 export class GasBridgingTestHarness implements IGasBridgingTestHarness {
-  private readonly l1TokenManager: L1TokenManager;
-  private readonly feeJuicePortalManager: L1FeeJuicePortalManager;
+  public readonly l1TokenManager: L1TokenManager;
+  public readonly feeJuicePortalManager: L1FeeJuicePortalManager;
 
   constructor(
     /** Aztec node */
@@ -142,6 +143,9 @@ export class GasBridgingTestHarness implements IGasBridgingTestHarness {
 
   async prepareTokensOnL1(bridgeAmount: bigint, owner: AztecAddress) {
     const claim = await this.sendTokensToPortalPublic(bridgeAmount, owner, true);
+
+    const isSynced = async () => await this.aztecNode.isL1ToL2MessageSynced(Fr.fromHexString(claim.messageHash));
+    await retryUntil(isSynced, `message ${claim.messageHash} sync`, 24, 1);
 
     // Progress by 2 L2 blocks so that the l1ToL2Message added above will be available to use on L2.
     await this.advanceL2Block();

--- a/yarn-project/end-to-end/src/spartan/setup_test_wallets.ts
+++ b/yarn-project/end-to-end/src/spartan/setup_test_wallets.ts
@@ -5,6 +5,7 @@ import {
   type AztecAddress,
   type AztecNode,
   FeeJuicePaymentMethodWithClaim,
+  Fr,
   L1FeeJuicePortalManager,
   type PXE,
   createAztecNodeClient,
@@ -109,8 +110,11 @@ async function bridgeL1FeeJuice(
 
   const portal = await L1FeeJuicePortalManager.new(pxe, publicClient, walletClient, log);
   const claim = await portal.bridgeTokensPublic(recipient, amount, true /* mint */);
-  log.info('Created a claim for L1 fee juice.');
 
+  const isSynced = async () => await pxe.isL1ToL2MessageSynced(Fr.fromHexString(claim.messageHash));
+  await retryUntil(isSynced, `message ${claim.messageHash} sync`, 24, 0.5);
+
+  log.info(`Created a claim for ${amount} L1 fee juice to ${recipient}.`, claim);
   return claim;
 }
 

--- a/yarn-project/prover-node/src/prover-node.ts
+++ b/yarn-project/prover-node/src/prover-node.ts
@@ -255,7 +255,7 @@ export class ProverNode implements EpochMonitorHandler, ProverNodeApi, Traceable
         return;
       }
       const txHashes = block.body.txEffects.map(tx => tx.txHash);
-      this.log.verbose(`Fetching ${txHashes.length} for block number ${blockNumber} from coordination`);
+      this.log.verbose(`Fetching ${txHashes.length} tx hashes for block number ${blockNumber} from coordination`);
       await this.coordination.getTxsByHash(txHashes); // This stores the txs in the tx pool, no need to persist them here
       this.lastBlockNumber = blockNumber;
     }


### PR DESCRIPTION
In order to claim an L1 to L2 msg on L2, we need to wait 2 L2 blocks to be mined _after the archiver has synced the msg_. We were waiting 2 L2 blocks since the message was sent L1, so if this happened right before the end of an L2 slot, the archiver would not get to sync it in time, so waiting for 2 blocks meant we only waited for **one** block after it got synced.

This adds a wait for the msg to be synced in the node before waiting for the two L2 blocks. The code that waited for the L2 blocks was repeated in three different places, and I didnt attempt to refactor it here, so the fix is also repeated three times.

Fixes #12366
