### PR TITLE
chore: Add logging to isolated prover client tests and bump CPUs

### DIFF
--- a/yarn-project/bootstrap.sh
+++ b/yarn-project/bootstrap.sh
@@ -108,7 +108,7 @@ function test_cmds {
   # Enable real proofs in prover-client integration tests only on CI full
   for test in prover-client/src/test/*.test.ts; do
     if [ "$CI_FULL" -eq 1 ]; then
-      echo "$hash ISOLATE=1 LOG_LEVEL=verbose CPUS=4 MEM=96g yarn-project/scripts/run_test.sh $test"
+      echo "$hash ISOLATE=1 LOG_LEVEL=verbose CPUS=16 MEM=96g yarn-project/scripts/run_test.sh $test"
     else
       echo "$hash FAKE_PROOFS=1 yarn-project/scripts/run_test.sh $test"
     fi

--- a/yarn-project/bootstrap.sh
+++ b/yarn-project/bootstrap.sh
@@ -108,7 +108,7 @@ function test_cmds {
   # Enable real proofs in prover-client integration tests only on CI full
   for test in prover-client/src/test/*.test.ts; do
     if [ "$CI_FULL" -eq 1 ]; then
-      echo "$hash ISOLATE=1 CPUS=4 MEM=96g yarn-project/scripts/run_test.sh $test"
+      echo "$hash ISOLATE=1 LOG_LEVEL=verbose CPUS=4 MEM=96g yarn-project/scripts/run_test.sh $test"
     else
       echo "$hash FAKE_PROOFS=1 yarn-project/scripts/run_test.sh $test"
     fi

--- a/yarn-project/end-to-end/bootstrap.sh
+++ b/yarn-project/end-to-end/bootstrap.sh
@@ -10,7 +10,7 @@ function test_cmds {
   local prefix="$hash $run_test_script"
 
   if [ "$CI_FULL" -eq 1 ]; then
-    echo "$hash timeout -v 1200s bash -c 'CPUS=16 MEM=96g $run_test_script simple e2e_prover/full real'"
+    echo "$hash timeout -v 900s bash -c 'CPUS=16 MEM=96g $run_test_script simple e2e_prover/full real'"
   else
     echo "$hash FAKE_PROOFS=1 $run_test_script simple e2e_prover/full fake"
   fi

--- a/yarn-project/scripts/run_test.sh
+++ b/yarn-project/scripts/run_test.sh
@@ -24,6 +24,7 @@ if [ "${ISOLATE:-0}" -eq 1 ]; then
     -e FORCE_COLOR=true \
     -e FAKE_PROOFS \
     -e NODE_OPTIONS="--no-warnings --experimental-vm-modules --loader @swc-node/register" \
+    -e LOG_LEVEL \
     aztecprotocol/build:3.0 \
       node ../node_modules/.bin/jest --forceExit --runInBand $test
 else


### PR DESCRIPTION
Test was taking 900+ seconds with 4 CPUs, 600 with 8 CPUs (and 200s with unbounded CPUs on mainframe). Bumping CPUs from 4 to 16 (as the e2e prover full test uses) should keep this under control.

Also rollbacks increased timeout for e2e prover full.
