### PR TITLE
refactor: Simplify port forwarding and process management in kind tests

### DIFF
--- a/spartan/scripts/test_kind.sh
+++ b/spartan/scripts/test_kind.sh
@@ -87,17 +87,6 @@ if [ "$fresh_install" != "no-deploy" ]; then
   deploy_result=$(OVERRIDES="$OVERRIDES" ./deploy_kind.sh $namespace $values_file $sepolia_run $helm_instance)
 fi
 
-# Find 6 free ports between 9000 and 10000
-free_ports="$(find_ports 6)"
-
-# Extract the free ports from the list
-forwarded_pxe_port=$(echo $free_ports | awk '{print $1}')
-forwarded_anvil_port=$(echo $free_ports | awk '{print $2}')
-forwarded_metrics_port=$(echo $free_ports | awk '{print $3}')
-forwarded_node_port=$(echo $free_ports | awk '{print $4}')
-forwarded_sequencer_port=$(echo $free_ports | awk '{print $5}')
-forwarded_prover_node_port=$(echo $free_ports | awk '{print $6}')
-
 if [ "$install_metrics" = "true" ]; then
   grafana_password=$(kubectl get secrets -n metrics metrics-grafana -o jsonpath='{.data.admin-password}' | base64 --decode)
 else
@@ -128,17 +117,11 @@ export K8S="local"
 export INSTANCE_NAME="$helm_instance"
 export SPARTAN_DIR="$(pwd)/.."
 export NAMESPACE="$namespace"
-export HOST_PXE_PORT="$forwarded_pxe_port"
 export CONTAINER_PXE_PORT="8081"
-export HOST_ETHEREUM_PORT="$forwarded_anvil_port"
 export CONTAINER_ETHEREUM_PORT="8545"
-export HOST_NODE_PORT="$forwarded_node_port"
 export CONTAINER_NODE_PORT="8080"
-export HOST_SEQUENCER_PORT=$forwarded_sequencer_port
 export CONTAINER_SEQUENCER_PORT="8080"
-export HOST_PROVER_NODE_PORT=$forwarded_prover_node_port
 export CONTAINER_PROVER_NODE_PORT="8080"
-export HOST_METRICS_PORT="$forwarded_metrics_port"
 export CONTAINER_METRICS_PORT="80"
 export GRAFANA_PASSWORD="$grafana_password"
 export DEBUG="${DEBUG:-""}"

--- a/yarn-project/end-to-end/src/spartan/gating-passive.test.ts
+++ b/yarn-project/end-to-end/src/spartan/gating-passive.test.ts
@@ -4,6 +4,7 @@ import { EthCheatCodesWithState } from '@aztec/ethereum/test';
 import { createLogger } from '@aztec/foundation/log';
 
 import { expect, jest } from '@jest/globals';
+import type { ChildProcess } from 'child_process';
 
 import type { AlertConfig } from '../quality_of_service/alert_checker.js';
 import {
@@ -41,46 +42,37 @@ const config = setupEnvironment(process.env);
 if (!isK8sConfig(config)) {
   throw new Error('This test must be run in a k8s environment');
 }
-const {
-  NAMESPACE,
-  HOST_PXE_PORT,
-  HOST_ETHEREUM_PORT,
-  CONTAINER_PXE_PORT,
-  CONTAINER_ETHEREUM_PORT,
-  SPARTAN_DIR,
-  INSTANCE_NAME,
-} = config;
+const { NAMESPACE, CONTAINER_PXE_PORT, CONTAINER_ETHEREUM_PORT, SPARTAN_DIR, INSTANCE_NAME } = config;
 const debugLogger = createLogger('e2e:spartan-test:gating-passive');
 
 describe('a test that passively observes the network in the presence of network chaos', () => {
   jest.setTimeout(60 * 60 * 1000); // 60 minutes
 
-  const ETHEREUM_HOST = `http://127.0.0.1:${HOST_ETHEREUM_PORT}`;
-  const PXE_URL = `http://127.0.0.1:${HOST_PXE_PORT}`;
+  let ETHEREUM_HOST: string;
+  let PXE_URL: string;
+  const forwardProcesses: ChildProcess[] = [];
 
   afterAll(async () => {
-    await startPortForward({
-      resource: `svc/metrics-grafana`,
-      namespace: 'metrics',
-      containerPort: config.CONTAINER_METRICS_PORT,
-      hostPort: config.HOST_METRICS_PORT,
-    });
     await runAlertCheck(config, qosAlerts, debugLogger);
+    forwardProcesses.forEach(p => p.kill());
   });
 
   it('survives network chaos', async () => {
-    await startPortForward({
+    const { process: pxeProcess, port: pxePort } = await startPortForward({
       resource: `svc/${config.INSTANCE_NAME}-aztec-network-pxe`,
       namespace: NAMESPACE,
       containerPort: CONTAINER_PXE_PORT,
-      hostPort: HOST_PXE_PORT,
     });
-    await startPortForward({
+    forwardProcesses.push(pxeProcess);
+    PXE_URL = `http://127.0.0.1:${pxePort}`;
+
+    const { process: ethProcess, port: ethPort } = await startPortForward({
       resource: `svc/${config.INSTANCE_NAME}-aztec-network-eth-execution`,
       namespace: NAMESPACE,
       containerPort: CONTAINER_ETHEREUM_PORT,
-      hostPort: HOST_ETHEREUM_PORT,
     });
+    forwardProcesses.push(ethProcess);
+    ETHEREUM_HOST = `http://127.0.0.1:${ethPort}`;
 
     const client = await createCompatibleClient(PXE_URL, debugLogger);
     const ethCheatCodes = new EthCheatCodesWithState([ETHEREUM_HOST]);

--- a/yarn-project/end-to-end/src/spartan/prover-node.test.ts
+++ b/yarn-project/end-to-end/src/spartan/prover-node.test.ts
@@ -1,6 +1,8 @@
 import { retryUntil } from '@aztec/aztec.js';
 import { createLogger } from '@aztec/foundation/log';
 
+import type { ChildProcess } from 'child_process';
+
 import { AlertTriggeredError } from '../quality_of_service/alert_checker.js';
 import {
   applyProverBrokerKill,
@@ -53,13 +55,18 @@ const enqueuedRootRollupJobs = {
 };
 
 describe('prover node recovery', () => {
+  const forwardProcesses: ChildProcess[] = [];
   beforeAll(async () => {
-    await startPortForward({
+    const { process } = await startPortForward({
       resource: `svc/metrics-grafana`,
       namespace: 'metrics',
       containerPort: config.CONTAINER_METRICS_PORT,
-      hostPort: config.HOST_METRICS_PORT,
     });
+    forwardProcesses.push(process);
+  });
+
+  afterAll(() => {
+    forwardProcesses.forEach(p => p.kill());
   });
 
   it('should recover after a crash', async () => {

--- a/yarn-project/end-to-end/src/spartan/proving.test.ts
+++ b/yarn-project/end-to-end/src/spartan/proving.test.ts
@@ -14,17 +14,17 @@ const SLEEP_MS = 1000;
 
 describe('proving test', () => {
   let pxe: PXE;
-  let proc: ChildProcess | undefined;
+  const forwardProcesses: ChildProcess[] = [];
   beforeAll(async () => {
     let PXE_URL;
     if (isK8sConfig(config)) {
-      proc = await startPortForward({
+      const { process, port } = await startPortForward({
         resource: `svc/${config.INSTANCE_NAME}-aztec-network-pxe`,
         namespace: config.NAMESPACE,
         containerPort: config.CONTAINER_PXE_PORT,
-        hostPort: config.HOST_PXE_PORT,
       });
-      PXE_URL = `http://127.0.0.1:${config.HOST_PXE_PORT}`;
+      forwardProcesses.push(process);
+      PXE_URL = `http://127.0.0.1:${port}`;
     } else {
       PXE_URL = config.PXE_URL;
     }
@@ -32,7 +32,7 @@ describe('proving test', () => {
   });
 
   afterAll(() => {
-    proc?.kill('SIGKILL');
+    forwardProcesses.forEach(p => p.kill());
   });
 
   it('advances the proven chain', async () => {

--- a/yarn-project/end-to-end/src/spartan/reorg.test.ts
+++ b/yarn-project/end-to-end/src/spartan/reorg.test.ts
@@ -4,6 +4,7 @@ import { EthCheatCodesWithState } from '@aztec/ethereum/test';
 import { createLogger } from '@aztec/foundation/log';
 
 import { expect, jest } from '@jest/globals';
+import type { ChildProcess } from 'child_process';
 
 import { type TestWallets, performTransfers, setupTestWalletsWithTokens } from './setup_test_wallets.js';
 import {
@@ -19,8 +20,7 @@ const config = setupEnvironment(process.env);
 if (!isK8sConfig(config)) {
   throw new Error('This test must be run in a k8s environment');
 }
-const { NAMESPACE, HOST_PXE_PORT, HOST_ETHEREUM_PORT, CONTAINER_PXE_PORT, CONTAINER_ETHEREUM_PORT, SPARTAN_DIR } =
-  config;
+const { NAMESPACE, CONTAINER_PXE_PORT, CONTAINER_ETHEREUM_PORT, SPARTAN_DIR } = config;
 const debugLogger = createLogger('e2e:spartan-test:reorg');
 
 async function checkBalances(testWallets: TestWallets, mintAmount: bigint, totalAmountTransferred: bigint) {
@@ -41,24 +41,32 @@ describe('reorg test', () => {
   const MINT_AMOUNT = 2_000_000n;
   const SETUP_EPOCHS = 2;
   const TRANSFER_AMOUNT = 1n;
-  const ETHEREUM_HOSTS = `http://127.0.0.1:${HOST_ETHEREUM_PORT}`;
-  const PXE_URL = `http://127.0.0.1:${HOST_PXE_PORT}`;
+  let ETHEREUM_HOSTS: string;
+  let PXE_URL: string;
+  const forwardProcesses: ChildProcess[] = [];
 
   let testWallets: TestWallets;
 
+  afterAll(() => {
+    forwardProcesses.forEach(p => p.kill());
+  });
+
   it('survives a reorg', async () => {
-    await startPortForward({
+    const { process: pxeProcess, port: pxePort } = await startPortForward({
       resource: `svc/${config.INSTANCE_NAME}-aztec-network-pxe`,
       namespace: NAMESPACE,
       containerPort: CONTAINER_PXE_PORT,
-      hostPort: HOST_PXE_PORT,
     });
-    await startPortForward({
+    forwardProcesses.push(pxeProcess);
+    PXE_URL = `http://127.0.0.1:${pxePort}`;
+
+    const { process: ethProcess, port: ethPort } = await startPortForward({
       resource: `svc/${config.INSTANCE_NAME}-aztec-network-eth-execution`,
       namespace: NAMESPACE,
       containerPort: CONTAINER_ETHEREUM_PORT,
-      hostPort: HOST_ETHEREUM_PORT,
     });
+    forwardProcesses.push(ethProcess);
+    ETHEREUM_HOSTS = `http://127.0.0.1:${ethPort}`;
     testWallets = await setupTestWalletsWithTokens(PXE_URL, MINT_AMOUNT, debugLogger);
     const rollupCheatCodes = new RollupCheatCodes(
       new EthCheatCodesWithState([ETHEREUM_HOSTS]),
@@ -102,8 +110,9 @@ describe('reorg test', () => {
       resource: `svc/${config.INSTANCE_NAME}-aztec-network-pxe`,
       namespace: NAMESPACE,
       containerPort: CONTAINER_PXE_PORT,
-      hostPort: HOST_PXE_PORT,
     });
+    forwardProcesses.push(pxeProcess);
+    PXE_URL = `http://127.0.0.1:${pxePort}`;
     testWallets = await setupTestWalletsWithTokens(PXE_URL, MINT_AMOUNT, debugLogger);
     // TODO(#9327): end delete
 

--- a/yarn-project/end-to-end/src/spartan/transfer.test.ts
+++ b/yarn-project/end-to-end/src/spartan/transfer.test.ts
@@ -3,6 +3,7 @@ import { createLogger } from '@aztec/foundation/log';
 import { TokenContract } from '@aztec/noir-contracts.js/Token';
 
 import { jest } from '@jest/globals';
+import type { ChildProcess } from 'child_process';
 
 import { type TestWallets, deployTestWalletWithTokens, setupTestWalletsWithTokens } from './setup_test_wallets.js';
 import { isK8sConfig, setupEnvironment, startPortForward } from './utils.js';
@@ -18,33 +19,39 @@ describe('token transfer test', () => {
   const ROUNDS = 1n;
 
   let testWallets: TestWallets;
+  let PXE_URL: string;
+  let ETHEREUM_HOSTS: string;
+  const forwardProcesses: ChildProcess[] = [];
+
+  afterAll(() => {
+    forwardProcesses.forEach(p => p.kill());
+  });
 
   beforeAll(async () => {
-    let PXE_URL;
     if (isK8sConfig(config)) {
-      await startPortForward({
+      const { process: pxeProcess, port: pxePort } = await startPortForward({
         resource: `svc/${config.INSTANCE_NAME}-aztec-network-pxe`,
         namespace: config.NAMESPACE,
         containerPort: config.CONTAINER_PXE_PORT,
-        hostPort: config.HOST_PXE_PORT,
       });
-      PXE_URL = `http://127.0.0.1:${config.HOST_PXE_PORT}`;
+      forwardProcesses.push(pxeProcess);
+      PXE_URL = `http://127.0.0.1:${pxePort}`;
 
-      await startPortForward({
+      const { process: ethProcess, port: ethPort } = await startPortForward({
         resource: `svc/${config.INSTANCE_NAME}-aztec-network-eth-execution`,
         namespace: config.NAMESPACE,
         containerPort: config.CONTAINER_ETHEREUM_PORT,
-        hostPort: config.HOST_ETHEREUM_PORT,
       });
-      const ETHEREUM_HOSTS = `http://127.0.0.1:${config.HOST_ETHEREUM_PORT}`;
+      forwardProcesses.push(ethProcess);
+      ETHEREUM_HOSTS = `http://127.0.0.1:${ethPort}`;
 
-      await startPortForward({
+      const { process: sequencerProcess, port: sequencerPort } = await startPortForward({
         resource: `svc/${config.INSTANCE_NAME}-aztec-network-validator`,
         namespace: config.NAMESPACE,
         containerPort: config.CONTAINER_SEQUENCER_PORT,
-        hostPort: config.HOST_SEQUENCER_PORT,
       });
-      const NODE_URL = `http://127.0.0.1:${config.HOST_SEQUENCER_PORT}`;
+      forwardProcesses.push(sequencerProcess);
+      const NODE_URL = `http://127.0.0.1:${sequencerPort}`;
 
       const L1_ACCOUNT_MNEMONIC = config.L1_ACCOUNT_MNEMONIC;
 

--- a/yarn-project/end-to-end/src/spartan/upgrade_rollup_version.test.ts
+++ b/yarn-project/end-to-end/src/spartan/upgrade_rollup_version.test.ts
@@ -18,6 +18,7 @@ import { getVKTreeRoot } from '@aztec/noir-protocol-circuits-types/vk-tree';
 import { ProtocolContractAddress, protocolContractTreeRoot } from '@aztec/protocol-contracts';
 import { getGenesisValues } from '@aztec/world-state/testing';
 
+import type { ChildProcess } from 'child_process';
 import omit from 'lodash.omit';
 import { getContract } from 'viem';
 import { stringify } from 'viem/utils';
@@ -36,22 +37,29 @@ describe('spartan_upgrade_rollup_version', () => {
   let nodeInfo: NodeInfo;
   let ETHEREUM_HOSTS: string[];
   let originalL1ContractAddresses: L1ContractAddresses;
+  const forwardProcesses: ChildProcess[] = [];
+
+  afterAll(() => {
+    forwardProcesses.forEach(p => p.kill());
+  });
+
   beforeAll(async () => {
-    await startPortForward({
+    const { process: pxeProcess, port: pxePort } = await startPortForward({
       resource: `svc/${config.INSTANCE_NAME}-aztec-network-pxe`,
       namespace: config.NAMESPACE,
       containerPort: config.CONTAINER_PXE_PORT,
-      hostPort: config.HOST_PXE_PORT,
     });
-    await startPortForward({
+    forwardProcesses.push(pxeProcess);
+    const PXE_URL = `http://127.0.0.1:${pxePort}`;
+
+    const { process: ethProcess, port: ethPort } = await startPortForward({
       resource: `svc/${config.INSTANCE_NAME}-aztec-network-eth-execution`,
       namespace: config.NAMESPACE,
       containerPort: config.CONTAINER_ETHEREUM_PORT,
-      hostPort: config.HOST_ETHEREUM_PORT,
     });
-    ETHEREUM_HOSTS = [`http://127.0.0.1:${config.HOST_ETHEREUM_PORT}`];
+    forwardProcesses.push(ethProcess);
+    ETHEREUM_HOSTS = [`http://127.0.0.1:${ethPort}`];
 
-    const PXE_URL = `http://127.0.0.1:${config.HOST_PXE_PORT}`;
     pxe = await createCompatibleClient(PXE_URL, debugLogger);
     nodeInfo = await pxe.getNodeInfo();
     originalL1ContractAddresses = omit(nodeInfo.l1ContractAddresses, 'slashFactoryAddress');
@@ -280,12 +288,12 @@ describe('spartan_upgrade_rollup_version', () => {
       await rollAztecPods(config.NAMESPACE);
 
       // restart the port forward
-      await startPortForward({
+      const { process: pxeProcess } = await startPortForward({
         resource: `svc/${config.INSTANCE_NAME}-aztec-network-pxe`,
         namespace: config.NAMESPACE,
         containerPort: config.CONTAINER_PXE_PORT,
-        hostPort: config.HOST_PXE_PORT,
       });
+      forwardProcesses.push(pxeProcess);
 
       const newNodeInfo = await pxe.getNodeInfo();
       expect(newNodeInfo.l1ContractAddresses.rollupAddress).toEqual(newCanonicalAddresses.rollupAddress);


### PR DESCRIPTION
This change updates the port forwarding utility to dynamically allocate ports and improve process management across multiple end-to-end tests. Key modifications include:

- Removing hardcoded host port configurations
- Dynamically allocating ports during port forwarding
- Centralizing process tracking with a `forwardProcesses` array
- Adding `afterAll` hooks to kill port forward processes
- Improving error handling and logging in port forward utility

The root cause was discovered by @spalladino. The time between a port being assigned in bash and then it being used was causing mismatches: two different services were trying to use the same port.

Also, not cleaning up ports behind ourselves was causing there to be an artificially low pool of ports to choose from.
