### PR TITLE
chore: remove aztec.js from txe, sequencer-client, e2e

### DIFF
--- a/yarn-project/end-to-end/package.json
+++ b/yarn-project/end-to-end/package.json
@@ -30,7 +30,6 @@
     "@aztec/archiver": "workspace:^",
     "@aztec/aztec": "workspace:^",
     "@aztec/aztec-node": "workspace:^",
-    "@aztec/aztec.js": "workspace:^",
     "@aztec/bb-prover": "workspace:^",
     "@aztec/blob-lib": "workspace:^",
     "@aztec/blob-sink": "workspace:^",

--- a/yarn-project/sequencer-client/package.json
+++ b/yarn-project/sequencer-client/package.json
@@ -28,7 +28,6 @@
     "test:integration:run": "NODE_NO_WARNINGS=1 node --experimental-vm-modules $(yarn bin jest) --no-cache --config jest.integration.config.json"
   },
   "dependencies": {
-    "@aztec/aztec.js": "workspace:^",
     "@aztec/bb-prover": "workspace:^",
     "@aztec/blob-lib": "workspace:^",
     "@aztec/blob-sink": "workspace:^",

--- a/yarn-project/txe/package.json
+++ b/yarn-project/txe/package.json
@@ -60,7 +60,6 @@
   },
   "dependencies": {
     "@aztec/accounts": "workspace:^",
-    "@aztec/aztec.js": "workspace:^",
     "@aztec/constants": "workspace:^",
     "@aztec/foundation": "workspace:^",
     "@aztec/key-store": "workspace:^",


### PR DESCRIPTION
closes #12275 