### PR TITLE
chore(rollup): store genesis state as a struct

### DIFF
--- a/l1-contracts/src/core/Rollup.sol
+++ b/l1-contracts/src/core/Rollup.sol
@@ -19,7 +19,8 @@ import {EpochProofLib} from "./libraries/RollupLibs/EpochProofLib.sol";
 import {ValidatorSelectionLib} from "./libraries/ValidatorSelectionLib/ValidatorSelectionLib.sol";
 import {
   RollupCore,
-  Config,
+  RollupConfig,
+  GenesisState,
   IRewardDistributor,
   IFeeJuicePortal,
   IERC20,
@@ -61,22 +62,16 @@ contract Rollup is IStaking, IValidatorSelection, IRollup, RollupCore {
     IFeeJuicePortal _fpcJuicePortal,
     IRewardDistributor _rewardDistributor,
     IERC20 _stakingAsset,
-    bytes32 _vkTreeRoot,
-    bytes32 _protocolContractTreeRoot,
-    bytes32 _genesisArchiveRoot,
-    bytes32 _genesisBlockHash,
-    address _ares,
-    Config memory _config
+    address _governance,
+    GenesisState memory _genesisState,
+    RollupConfig memory _config
   )
     RollupCore(
       _fpcJuicePortal,
       _rewardDistributor,
       _stakingAsset,
-      _vkTreeRoot,
-      _protocolContractTreeRoot,
-      _genesisArchiveRoot,
-      _genesisBlockHash,
-      _ares,
+      _governance,
+      _genesisState,
       _config
     )
   {}

--- a/l1-contracts/test/MultiProof.t.sol
+++ b/l1-contracts/test/MultiProof.t.sol
@@ -17,7 +17,7 @@ import {
   Timestamp, Slot, Epoch, SlotLib, EpochLib, TimeLib
 } from "@aztec/core/libraries/TimeLib.sol";
 
-import {Rollup, Config} from "@aztec/core/Rollup.sol";
+import {Rollup, RollupConfig, GenesisState} from "@aztec/core/Rollup.sol";
 import {Strings} from "@oz/utils/Strings.sol";
 import {Errors} from "@aztec/core/libraries/Errors.sol";
 
@@ -84,12 +84,14 @@ contract MultiProofTest is RollupBase {
           feeJuicePortal,
           rewardDistributor,
           testERC20,
-          bytes32(0),
-          bytes32(0),
-          bytes32(Constants.GENESIS_ARCHIVE_ROOT),
-          bytes32(Constants.GENESIS_BLOCK_HASH),
           address(this),
-          Config({
+          GenesisState({
+            vkTreeRoot: bytes32(0),
+            protocolContractTreeRoot: bytes32(0),
+            genesisArchiveRoot: bytes32(Constants.GENESIS_ARCHIVE_ROOT),
+            genesisBlockHash: bytes32(Constants.GENESIS_BLOCK_HASH)
+          }),
+          RollupConfig({
             aztecSlotDuration: TestConstants.AZTEC_SLOT_DURATION,
             aztecEpochDuration: TestConstants.AZTEC_EPOCH_DURATION,
             targetCommitteeSize: TestConstants.AZTEC_TARGET_COMMITTEE_SIZE,

--- a/l1-contracts/test/Rollup.t.sol
+++ b/l1-contracts/test/Rollup.t.sol
@@ -94,20 +94,8 @@ contract RollupTest is RollupBase {
     rewardDistributor = new RewardDistributor(testERC20, registry, address(this));
     testERC20.mint(address(rewardDistributor), 1e6 ether);
 
-    rollup = IInstance(
-      address(
-        new Rollup(
-          feeJuicePortal,
-          rewardDistributor,
-          testERC20,
-          bytes32(0),
-          bytes32(0),
-          bytes32(Constants.GENESIS_ARCHIVE_ROOT),
-          bytes32(Constants.GENESIS_BLOCK_HASH),
-          address(this)
-        )
-      )
-    );
+    rollup =
+      IInstance(address(new Rollup(feeJuicePortal, rewardDistributor, testERC20, address(this))));
     inbox = Inbox(address(rollup.getInbox()));
     outbox = Outbox(address(rollup.getOutbox()));
 

--- a/l1-contracts/test/fee_portal/depositToAztecPublic.t.sol
+++ b/l1-contracts/test/fee_portal/depositToAztecPublic.t.sol
@@ -34,16 +34,7 @@ contract DepositToAztecPublic is Test {
     token.mint(address(feeJuicePortal), Constants.FEE_JUICE_INITIAL_MINT);
     feeJuicePortal.initialize();
     rewardDistributor = new RewardDistributor(token, registry, address(this));
-    rollup = new Rollup(
-      feeJuicePortal,
-      rewardDistributor,
-      token,
-      bytes32(0),
-      bytes32(0),
-      bytes32(0),
-      bytes32(0),
-      address(this)
-    );
+    rollup = new Rollup(feeJuicePortal, rewardDistributor, token, address(this));
 
     vm.prank(OWNER);
     registry.upgrade(address(rollup));
@@ -74,16 +65,7 @@ contract DepositToAztecPublic is Test {
 
     uint256 numberOfRollups = bound(_numberOfRollups, 1, 5);
     for (uint256 i = 0; i < numberOfRollups; i++) {
-      Rollup freshRollup = new Rollup(
-        feeJuicePortal,
-        rewardDistributor,
-        token,
-        bytes32(0),
-        bytes32(0),
-        bytes32(0),
-        bytes32(0),
-        address(this)
-      );
+      Rollup freshRollup = new Rollup(feeJuicePortal, rewardDistributor, token, address(this));
       vm.prank(OWNER);
       registry.upgrade(address(freshRollup));
     }

--- a/l1-contracts/test/fee_portal/distributeFees.t.sol
+++ b/l1-contracts/test/fee_portal/distributeFees.t.sol
@@ -33,16 +33,7 @@ contract DistributeFees is Test {
     feeJuicePortal.initialize();
 
     rewardDistributor = new RewardDistributor(token, registry, address(this));
-    rollup = new Rollup(
-      feeJuicePortal,
-      rewardDistributor,
-      token,
-      bytes32(0),
-      bytes32(0),
-      bytes32(0),
-      bytes32(0),
-      address(this)
-    );
+    rollup = new Rollup(feeJuicePortal, rewardDistributor, token, address(this));
 
     vm.prank(OWNER);
     registry.upgrade(address(rollup));
@@ -81,16 +72,7 @@ contract DistributeFees is Test {
 
     uint256 numberOfRollups = bound(_numberOfRollups, 1, 5);
     for (uint256 i = 0; i < numberOfRollups; i++) {
-      Rollup freshRollup = new Rollup(
-        feeJuicePortal,
-        rewardDistributor,
-        token,
-        bytes32(0),
-        bytes32(0),
-        bytes32(0),
-        bytes32(0),
-        address(this)
-      );
+      Rollup freshRollup = new Rollup(feeJuicePortal, rewardDistributor, token, address(this));
       vm.prank(OWNER);
       registry.upgrade(address(freshRollup));
     }

--- a/l1-contracts/test/fees/FeeRollup.t.sol
+++ b/l1-contracts/test/fees/FeeRollup.t.sol
@@ -15,7 +15,7 @@ import {Registry} from "@aztec/governance/Registry.sol";
 import {Inbox} from "@aztec/core/messagebridge/Inbox.sol";
 import {Outbox} from "@aztec/core/messagebridge/Outbox.sol";
 import {Errors} from "@aztec/core/libraries/Errors.sol";
-import {Rollup, Config, BlockLog} from "@aztec/core/Rollup.sol";
+import {Rollup, RollupConfig, GenesisState, BlockLog} from "@aztec/core/Rollup.sol";
 import {
   IRollup, SubmitEpochRootProofArgs, PublicInputArgs
 } from "@aztec/core/interfaces/IRollup.sol";
@@ -133,12 +133,14 @@ contract FeeRollupTest is FeeModelTestPoints, DecoderBase {
       IFeeJuicePortal(address(fakeCanonical)),
       IRewardDistributor(address(fakeCanonical)),
       asset,
-      bytes32(0),
-      bytes32(0),
-      bytes32(Constants.GENESIS_ARCHIVE_ROOT),
-      bytes32(Constants.GENESIS_BLOCK_HASH),
       address(this),
-      Config({
+      GenesisState({
+        vkTreeRoot: bytes32(0),
+        protocolContractTreeRoot: bytes32(0),
+        genesisArchiveRoot: bytes32(Constants.GENESIS_ARCHIVE_ROOT),
+        genesisBlockHash: bytes32(Constants.GENESIS_BLOCK_HASH)
+      }),
+      RollupConfig({
         aztecSlotDuration: SLOT_DURATION,
         aztecEpochDuration: EPOCH_DURATION,
         targetCommitteeSize: 48,

--- a/l1-contracts/test/governance/scenario/UpgradeGovernanceProposerTest.t.sol
+++ b/l1-contracts/test/governance/scenario/UpgradeGovernanceProposerTest.t.sol
@@ -67,16 +67,7 @@ contract UpgradeGovernanceProposerTest is TestBase {
     }
 
     RewardDistributor rewardDistributor = new RewardDistributor(token, registry, address(this));
-    rollup = new Rollup(
-      new MockFeeJuicePortal(),
-      rewardDistributor,
-      token,
-      bytes32(0),
-      bytes32(0),
-      bytes32(0),
-      bytes32(0),
-      address(this)
-    );
+    rollup = new Rollup(new MockFeeJuicePortal(), rewardDistributor, token, address(this));
 
     token.mint(address(this), TestConstants.AZTEC_MINIMUM_STAKE * VALIDATOR_COUNT);
     token.approve(address(rollup), TestConstants.AZTEC_MINIMUM_STAKE * VALIDATOR_COUNT);

--- a/l1-contracts/test/governance/scenario/slashing/Slashing.t.sol
+++ b/l1-contracts/test/governance/scenario/slashing/Slashing.t.sol
@@ -5,7 +5,7 @@ import {TestBase} from "@test/base/Base.sol";
 
 import {Errors} from "@aztec/core/libraries/Errors.sol";
 import {Registry} from "@aztec/governance/Registry.sol";
-import {Rollup, Config} from "@aztec/core/Rollup.sol";
+import {Rollup, RollupConfig, GenesisState} from "@aztec/core/Rollup.sol";
 import {TestERC20} from "@aztec/mock/TestERC20.sol";
 import {MockFeeJuicePortal} from "@aztec/mock/MockFeeJuicePortal.sol";
 import {TestConstants} from "../../../harnesses/TestConstants.sol";
@@ -57,12 +57,14 @@ contract SlashingScenario is TestBase {
       _fpcJuicePortal: new MockFeeJuicePortal(),
       _rewardDistributor: rewardDistributor,
       _stakingAsset: testERC20,
-      _vkTreeRoot: bytes32(0),
-      _protocolContractTreeRoot: bytes32(0),
-      _genesisArchiveRoot: bytes32(0),
-      _genesisBlockHash: bytes32(0),
-      _ares: address(this),
-      _config: Config({
+      _governance: address(this),
+      _genesisState: GenesisState({
+        vkTreeRoot: bytes32(0),
+        protocolContractTreeRoot: bytes32(0),
+        genesisArchiveRoot: bytes32(0),
+        genesisBlockHash: bytes32(0)
+      }),
+      _config: RollupConfig({
         aztecSlotDuration: TestConstants.AZTEC_SLOT_DURATION,
         aztecEpochDuration: TestConstants.AZTEC_EPOCH_DURATION,
         targetCommitteeSize: TestConstants.AZTEC_TARGET_COMMITTEE_SIZE,

--- a/l1-contracts/test/harnesses/Rollup.sol
+++ b/l1-contracts/test/harnesses/Rollup.sol
@@ -4,7 +4,7 @@ pragma solidity >=0.8.27;
 
 import {IFeeJuicePortal} from "@aztec/core/interfaces/IFeeJuicePortal.sol";
 import {IRewardDistributor} from "@aztec/governance/interfaces/IRewardDistributor.sol";
-import {Rollup as RealRollup, Config} from "@aztec/core/Rollup.sol";
+import {Rollup as RealRollup, RollupConfig, GenesisState} from "@aztec/core/Rollup.sol";
 import {TestConstants} from "./TestConstants.sol";
 import {IERC20} from "@oz/token/ERC20/IERC20.sol";
 
@@ -13,22 +13,20 @@ contract Rollup is RealRollup {
     IFeeJuicePortal _fpcJuicePortal,
     IRewardDistributor _rewardDistributor,
     IERC20 _stakingAsset,
-    bytes32 _vkTreeRoot,
-    bytes32 _protocolContractTreeRoot,
-    bytes32 _genesisArchiveRoot,
-    bytes32 _genesisBlockHash,
-    address _ares
+    address _governance
   )
     RealRollup(
       _fpcJuicePortal,
       _rewardDistributor,
       _stakingAsset,
-      _vkTreeRoot,
-      _protocolContractTreeRoot,
-      _genesisArchiveRoot,
-      _genesisBlockHash,
-      _ares,
-      Config({
+      _governance,
+      GenesisState({
+        vkTreeRoot: TestConstants.GENESIS_VK_TREE_ROOT,
+        protocolContractTreeRoot: TestConstants.GENESIS_PROTOCOL_CONTRACT_TREE_ROOT,
+        genesisArchiveRoot: TestConstants.GENESIS_ARCHIVE_ROOT,
+        genesisBlockHash: TestConstants.GENESIS_BLOCK_HASH
+      }),
+      RollupConfig({
         aztecSlotDuration: TestConstants.AZTEC_SLOT_DURATION,
         aztecEpochDuration: TestConstants.AZTEC_EPOCH_DURATION,
         targetCommitteeSize: TestConstants.AZTEC_TARGET_COMMITTEE_SIZE,

--- a/l1-contracts/test/harnesses/TestConstants.sol
+++ b/l1-contracts/test/harnesses/TestConstants.sol
@@ -3,6 +3,8 @@
 
 pragma solidity >=0.8.27;
 
+import {Constants} from "@aztec/core/libraries/ConstantsGen.sol";
+
 library TestConstants {
   uint256 internal constant ETHEREUM_SLOT_DURATION = 12;
   uint256 internal constant AZTEC_SLOT_DURATION = 24;
@@ -12,4 +14,10 @@ library TestConstants {
   uint256 internal constant AZTEC_MINIMUM_STAKE = 100e18;
   uint256 internal constant AZTEC_SLASHING_QUORUM = 6;
   uint256 internal constant AZTEC_SLASHING_ROUND_SIZE = 10;
+
+  // Genesis state
+  bytes32 internal constant GENESIS_ARCHIVE_ROOT = bytes32(Constants.GENESIS_ARCHIVE_ROOT);
+  bytes32 internal constant GENESIS_BLOCK_HASH = bytes32(Constants.GENESIS_BLOCK_HASH);
+  bytes32 internal constant GENESIS_VK_TREE_ROOT = bytes32(0);
+  bytes32 internal constant GENESIS_PROTOCOL_CONTRACT_TREE_ROOT = bytes32(0);
 }

--- a/l1-contracts/test/portals/TokenPortal.t.sol
+++ b/l1-contracts/test/portals/TokenPortal.t.sol
@@ -62,16 +62,7 @@ contract TokenPortalTest is Test {
     registry = new Registry(address(this));
     testERC20 = new TestERC20("test", "TEST", address(this));
     rewardDistributor = new RewardDistributor(testERC20, registry, address(this));
-    rollup = new Rollup(
-      new MockFeeJuicePortal(),
-      rewardDistributor,
-      testERC20,
-      bytes32(0),
-      bytes32(0),
-      bytes32(0),
-      bytes32(0),
-      address(this)
-    );
+    rollup = new Rollup(new MockFeeJuicePortal(), rewardDistributor, testERC20, address(this));
     inbox = rollup.getInbox();
     outbox = rollup.getOutbox();
 

--- a/l1-contracts/test/portals/UniswapPortal.t.sol
+++ b/l1-contracts/test/portals/UniswapPortal.t.sol
@@ -57,16 +57,7 @@ contract UniswapPortalTest is Test {
 
     registry = new Registry(address(this));
     RewardDistributor rewardDistributor = new RewardDistributor(DAI, registry, address(this));
-    rollup = new Rollup(
-      new MockFeeJuicePortal(),
-      rewardDistributor,
-      DAI,
-      bytes32(0),
-      bytes32(0),
-      bytes32(0),
-      bytes32(0),
-      address(this)
-    );
+    rollup = new Rollup(new MockFeeJuicePortal(), rewardDistributor, DAI, address(this));
     registry.upgrade(address(rollup));
 
     daiTokenPortal = new TokenPortal();

--- a/l1-contracts/test/validator-selection/ValidatorSelection.t.sol
+++ b/l1-contracts/test/validator-selection/ValidatorSelection.t.sol
@@ -12,7 +12,7 @@ import {Inbox} from "@aztec/core/messagebridge/Inbox.sol";
 import {Outbox} from "@aztec/core/messagebridge/Outbox.sol";
 import {Errors} from "@aztec/core/libraries/Errors.sol";
 import {Registry} from "@aztec/governance/Registry.sol";
-import {Rollup, Config} from "@aztec/core/Rollup.sol";
+import {Rollup, RollupConfig, GenesisState} from "@aztec/core/Rollup.sol";
 import {NaiveMerkle} from "../merkle/Naive.sol";
 import {MerkleTestUtil} from "../merkle/TestUtil.sol";
 import {TestERC20} from "@aztec/mock/TestERC20.sol";
@@ -102,12 +102,14 @@ contract ValidatorSelectionTest is DecoderBase {
       _fpcJuicePortal: new MockFeeJuicePortal(),
       _rewardDistributor: rewardDistributor,
       _stakingAsset: testERC20,
-      _vkTreeRoot: bytes32(0),
-      _protocolContractTreeRoot: bytes32(0),
-      _genesisArchiveRoot: bytes32(Constants.GENESIS_ARCHIVE_ROOT),
-      _genesisBlockHash: bytes32(Constants.GENESIS_BLOCK_HASH),
-      _ares: address(this),
-      _config: Config({
+      _governance: address(this),
+      _genesisState: GenesisState({
+        vkTreeRoot: bytes32(0),
+        protocolContractTreeRoot: bytes32(0),
+        genesisArchiveRoot: bytes32(Constants.GENESIS_ARCHIVE_ROOT),
+        genesisBlockHash: bytes32(Constants.GENESIS_BLOCK_HASH)
+      }),
+      _config: RollupConfig({
         aztecSlotDuration: TestConstants.AZTEC_SLOT_DURATION,
         aztecEpochDuration: TestConstants.AZTEC_EPOCH_DURATION,
         targetCommitteeSize: TestConstants.AZTEC_TARGET_COMMITTEE_SIZE,

--- a/yarn-project/ethereum/src/deploy_l1_contracts.ts
+++ b/yarn-project/ethereum/src/deploy_l1_contracts.ts
@@ -305,16 +305,19 @@ export const deployRollup = async (
     slashingQuorum: args.slashingQuorum,
     slashingRoundSize: args.slashingRoundSize,
   };
+  const genesisStateArgs = {
+    vkTreeRoot: args.vkTreeRoot.toString(),
+    protocolContractTreeRoot: args.protocolContractTreeRoot.toString(),
+    genesisArchiveRoot: args.genesisArchiveRoot.toString(),
+    genesisBlockHash: args.genesisBlockHash.toString(),
+  };
   logger.verbose(`Rollup config args`, rollupConfigArgs);
   const rollupArgs = [
     addresses.feeJuicePortalAddress.toString(),
     addresses.rewardDistributorAddress.toString(),
     addresses.stakingAssetAddress.toString(),
-    args.vkTreeRoot.toString(),
-    args.protocolContractTreeRoot.toString(),
-    args.genesisArchiveRoot.toString(),
-    args.genesisBlockHash.toString(),
     clients.walletClient.account.address.toString(),
+    genesisStateArgs,
     rollupConfigArgs,
   ];
 


### PR DESCRIPTION
## Overview

Split out from work speeding up kind tests, this is much better suited as a struct as they are set together
