### PR TITLE
chore(archiver): l2proven number not required

### DIFF
--- a/yarn-project/archiver/src/archiver/archiver_store.ts
+++ b/yarn-project/archiver/src/archiver/archiver_store.ts
@@ -175,22 +175,10 @@ export interface ArchiverDataStore {
   getProvenL2BlockNumber(): Promise<number>;
 
   /**
-   * Gets the number of the latest proven L2 epoch.
-   * @returns The number of the latest proven L2 epoch.
-   */
-  getProvenL2EpochNumber(): Promise<number | undefined>;
-
-  /**
    * Stores the number of the latest proven L2 block processed.
    * @param l2BlockNumber - The number of the latest proven L2 block processed.
    */
   setProvenL2BlockNumber(l2BlockNumber: number): Promise<void>;
-
-  /**
-   * Stores the number of the latest proven L2 epoch.
-   * @param l2EpochNumber - The number of the latest proven L2 epoch.
-   */
-  setProvenL2EpochNumber(l2EpochNumber: number): Promise<void>;
 
   /**
    * Stores the l1 block number that blocks have been synched until

--- a/yarn-project/archiver/src/archiver/kv_archiver_store/block_store.ts
+++ b/yarn-project/archiver/src/archiver/kv_archiver_store/block_store.ts
@@ -269,14 +269,6 @@ export class BlockStore {
     return this.#lastProvenL2Block.set(blockNumber);
   }
 
-  getProvenL2EpochNumber(): Promise<number | undefined> {
-    return this.#lastProvenL2Epoch.getAsync();
-  }
-
-  setProvenL2EpochNumber(epochNumber: number) {
-    return this.#lastProvenL2Epoch.set(epochNumber);
-  }
-
   #computeBlockRange(start: number, limit: number): Required<Pick<Range<number>, 'start' | 'limit'>> {
     if (limit < 1) {
       throw new Error(`Invalid limit: ${limit}`);

--- a/yarn-project/archiver/src/archiver/kv_archiver_store/kv_archiver_store.ts
+++ b/yarn-project/archiver/src/archiver/kv_archiver_store/kv_archiver_store.ts
@@ -324,16 +324,8 @@ export class KVArchiverDataStore implements ArchiverDataStore {
     return this.#blockStore.getProvenL2BlockNumber();
   }
 
-  getProvenL2EpochNumber(): Promise<number | undefined> {
-    return this.#blockStore.getProvenL2EpochNumber();
-  }
-
   async setProvenL2BlockNumber(blockNumber: number) {
     await this.#blockStore.setProvenL2BlockNumber(blockNumber);
-  }
-
-  async setProvenL2EpochNumber(epochNumber: number) {
-    await this.#blockStore.setProvenL2EpochNumber(epochNumber);
   }
 
   async setBlockSynchedL1BlockNumber(l1BlockNumber: bigint) {

--- a/yarn-project/archiver/src/archiver/memory_archiver_store/memory_archiver_store.ts
+++ b/yarn-project/archiver/src/archiver/memory_archiver_store/memory_archiver_store.ts
@@ -758,17 +758,8 @@ export class MemoryArchiverStore implements ArchiverDataStore {
     return Promise.resolve(this.lastProvenL2BlockNumber);
   }
 
-  public getProvenL2EpochNumber(): Promise<number | undefined> {
-    return Promise.resolve(this.lastProvenL2EpochNumber);
-  }
-
   public setProvenL2BlockNumber(l2BlockNumber: number): Promise<void> {
     this.lastProvenL2BlockNumber = l2BlockNumber;
-    return Promise.resolve();
-  }
-
-  public setProvenL2EpochNumber(l2EpochNumber: number): Promise<void> {
-    this.lastProvenL2EpochNumber = l2EpochNumber;
     return Promise.resolve();
   }
 

--- a/yarn-project/archiver/src/test/mock_l2_block_source.ts
+++ b/yarn-project/archiver/src/test/mock_l2_block_source.ts
@@ -36,10 +36,6 @@ export class MockL2BlockSource implements L2BlockSource {
     this.log.verbose(`Removed ${numBlocks} blocks from the mock L2 block source`);
   }
 
-  public setProvenBlockNumber(provenBlockNumber: number) {
-    this.provenBlockNumber = provenBlockNumber;
-  }
-
   public setProvenEpochNumber(provenEpochNumber: number) {
     this.provenEpochNumber = provenEpochNumber;
   }
@@ -70,10 +66,6 @@ export class MockL2BlockSource implements L2BlockSource {
 
   public getProvenBlockNumber(): Promise<number> {
     return Promise.resolve(this.provenBlockNumber);
-  }
-
-  public getProvenL2EpochNumber(): Promise<number | undefined> {
-    return Promise.resolve(this.provenEpochNumber);
   }
 
   /**

--- a/yarn-project/archiver/src/test/mock_l2_block_source.ts
+++ b/yarn-project/archiver/src/test/mock_l2_block_source.ts
@@ -11,7 +11,6 @@ import { type BlockHeader, TxHash, TxReceipt, TxStatus } from '@aztec/stdlib/tx'
 export class MockL2BlockSource implements L2BlockSource {
   protected l2Blocks: L2Block[] = [];
 
-  private provenEpochNumber: number = 0;
   private provenBlockNumber: number = 0;
 
   private log = createLogger('archiver:mock_l2_block_source');
@@ -36,8 +35,8 @@ export class MockL2BlockSource implements L2BlockSource {
     this.log.verbose(`Removed ${numBlocks} blocks from the mock L2 block source`);
   }
 
-  public setProvenEpochNumber(provenEpochNumber: number) {
-    this.provenEpochNumber = provenEpochNumber;
+  public setProvenBlockNumber(provenBlockNumber: number) {
+    this.provenBlockNumber = provenBlockNumber;
   }
 
   /**

--- a/yarn-project/p2p/src/client/p2p_client.test.ts
+++ b/yarn-project/p2p/src/client/p2p_client.test.ts
@@ -54,6 +54,7 @@ describe('In-Memory P2P Client', () => {
   });
 
   const advanceToProvenBlock = async (getProvenBlockNumber: number) => {
+    blockSource.setProvenBlockNumber(getProvenBlockNumber);
     await retryUntil(async () => (await client.getSyncedProvenBlockNum()) >= getProvenBlockNumber, 'synced', 10, 0.1);
   };
 

--- a/yarn-project/p2p/src/client/p2p_client.test.ts
+++ b/yarn-project/p2p/src/client/p2p_client.test.ts
@@ -53,9 +53,7 @@ describe('In-Memory P2P Client', () => {
     await kvStore.close();
   });
 
-  const advanceToProvenBlock = async (getProvenBlockNumber: number, provenEpochNumber = getProvenBlockNumber) => {
-    blockSource.setProvenBlockNumber(getProvenBlockNumber);
-    blockSource.setProvenEpochNumber(provenEpochNumber);
+  const advanceToProvenBlock = async (getProvenBlockNumber: number) => {
     await retryUntil(async () => (await client.getSyncedProvenBlockNum()) >= getProvenBlockNumber, 'synced', 10, 0.1);
   };
 

--- a/yarn-project/stdlib/src/block/l2_block_source.ts
+++ b/yarn-project/stdlib/src/block/l2_block_source.ts
@@ -40,12 +40,6 @@ export interface L2BlockSource {
   getProvenBlockNumber(): Promise<number>;
 
   /**
-   * Gets the number of the latest L2 proven epoch seen by the block source implementation.
-   * @returns The number of the latest L2 proven epoch seen by the block source implementation.
-   */
-  getProvenL2EpochNumber(): Promise<number | undefined>;
-
-  /**
    * Gets an l2 block. If a negative number is passed, the block returned is the most recent.
    * @param number - The block number to return (inclusive).
    * @returns The requested L2 block.

--- a/yarn-project/stdlib/src/interfaces/archiver.test.ts
+++ b/yarn-project/stdlib/src/interfaces/archiver.test.ts
@@ -78,11 +78,6 @@ describe('ArchiverApiSchema', () => {
     expect(result).toBe(1);
   });
 
-  it('getProvenL2EpochNumber', async () => {
-    const result = await context.client.getProvenL2EpochNumber();
-    expect(result).toBe(1);
-  });
-
   it('getBlock', async () => {
     const result = await context.client.getBlock(1);
     expect(result).toBeInstanceOf(L2Block);
@@ -268,9 +263,6 @@ class MockArchiver implements ArchiverApi {
     return Promise.resolve(1);
   }
   getProvenBlockNumber(): Promise<number> {
-    return Promise.resolve(1);
-  }
-  getProvenL2EpochNumber(): Promise<number | undefined> {
     return Promise.resolve(1);
   }
   getBlock(number: number): Promise<L2Block | undefined> {

--- a/yarn-project/stdlib/src/interfaces/archiver.ts
+++ b/yarn-project/stdlib/src/interfaces/archiver.ts
@@ -35,7 +35,6 @@ export const ArchiverApiSchema: ApiSchemaFor<ArchiverApi> = {
   getRegistryAddress: z.function().args().returns(schemas.EthAddress),
   getBlockNumber: z.function().args().returns(schemas.Integer),
   getProvenBlockNumber: z.function().args().returns(schemas.Integer),
-  getProvenL2EpochNumber: z.function().args().returns(schemas.Integer.optional()),
   getBlock: z.function().args(schemas.Integer).returns(L2Block.schema.optional()),
   getBlockHeader: z
     .function()


### PR DESCRIPTION
## Overview

After a discussion with @lherskind, it appears that this is not required at all to work out if there have been reorgs, and it
is not used anywhere else.

The proven epoch is stored in the l1 contract, and the check in the archiver where it is used, is not required, as time is encoded
within the archive hash that is compared. 

This pr just removes it
