### PR TITLE
fix: Only use debug logging for ENR mismatch

### DIFF
--- a/yarn-project/p2p/src/services/discv5/discV5_service.ts
+++ b/yarn-project/p2p/src/services/discv5/discV5_service.ts
@@ -243,7 +243,7 @@ export class DiscV5Service extends EventEmitter implements PeerDiscoveryService 
       return true;
     } catch (err: any) {
       if (err.name === 'ComponentsVersionsError') {
-        this.logger.warn(`Peer node ${enr.nodeId} has incorrect version: ${err.message}`, {
+        this.logger.debug(`Peer node ${enr.nodeId} has incorrect version: ${err.message}`, {
           compressedVersion,
           expected: this.versions,
         });


### PR DESCRIPTION
Use debug level logging when notifying about ENR version mismatch.
