### PR TITLE
fix: add missing callinterface

### DIFF
--- a/noir-projects/aztec-nr/aztec/src/context/call_interfaces.nr
+++ b/noir-projects/aztec-nr/aztec/src/context/call_interfaces.nr
@@ -15,6 +15,8 @@ pub trait CallInterface<let N: u32> {
     fn get_is_static(self) -> bool;
 }
 
+// PrivateCallInterface
+
 pub struct PrivateCallInterface<let N: u32, T> {
     target_contract: AztecAddress,
     selector: FunctionSelector,
@@ -75,7 +77,7 @@ impl<let N: u32, T> PrivateCallInterface<N, T> {
     }
 }
 
-impl<let N: u32> CallInterface<N> for PrivateVoidCallInterface<N> {
+impl<let N: u32, T> CallInterface<N> for PrivateCallInterface<N, T> {
     fn get_args(self) -> [Field] {
         self.args
     }
@@ -96,6 +98,8 @@ impl<let N: u32> CallInterface<N> for PrivateVoidCallInterface<N> {
         self.is_static
     }
 }
+
+// PrivateVoidCallInterface
 
 pub struct PrivateVoidCallInterface<let N: u32> {
     target_contract: AztecAddress,
@@ -144,7 +148,7 @@ impl<let N: u32> PrivateVoidCallInterface<N> {
     }
 }
 
-impl<let N: u32, T> CallInterface<N> for PrivateStaticCallInterface<N, T> {
+impl<let N: u32> CallInterface<N> for PrivateVoidCallInterface<N> {
     fn get_args(self) -> [Field] {
         self.args
     }
@@ -165,6 +169,8 @@ impl<let N: u32, T> CallInterface<N> for PrivateStaticCallInterface<N, T> {
         self.is_static
     }
 }
+
+// PrivateStaticCallInterface
 
 pub struct PrivateStaticCallInterface<let N: u32, T> {
     target_contract: AztecAddress,
@@ -210,7 +216,7 @@ impl<let N: u32, T> PrivateStaticCallInterface<N, T> {
     }
 }
 
-impl<let N: u32> CallInterface<N> for PrivateStaticVoidCallInterface<N> {
+impl<let N: u32, T> CallInterface<N> for PrivateStaticCallInterface<N, T> {
     fn get_args(self) -> [Field] {
         self.args
     }
@@ -231,6 +237,8 @@ impl<let N: u32> CallInterface<N> for PrivateStaticVoidCallInterface<N> {
         self.is_static
     }
 }
+
+// PrivateStaticVoidCallInterface
 
 pub struct PrivateStaticVoidCallInterface<let N: u32> {
     target_contract: AztecAddress,
@@ -266,7 +274,7 @@ impl<let N: u32> PrivateStaticVoidCallInterface<N> {
     }
 }
 
-impl<let N: u32, T> CallInterface<N> for PublicCallInterface<N, T> {
+impl<let N: u32> CallInterface<N> for PrivateStaticVoidCallInterface<N> {
     fn get_args(self) -> [Field] {
         self.args
     }
@@ -287,6 +295,8 @@ impl<let N: u32, T> CallInterface<N> for PublicCallInterface<N, T> {
         self.is_static
     }
 }
+
+// PublicCallInterface
 
 pub struct PublicCallInterface<let N: u32, T> {
     target_contract: AztecAddress,
@@ -373,7 +383,7 @@ impl<let N: u32, T> PublicCallInterface<N, T> {
     }
 }
 
-impl<let N: u32> CallInterface<N> for PublicVoidCallInterface<N> {
+impl<let N: u32, T> CallInterface<N> for PublicCallInterface<N, T> {
     fn get_args(self) -> [Field] {
         self.args
     }
@@ -394,6 +404,8 @@ impl<let N: u32> CallInterface<N> for PublicVoidCallInterface<N> {
         self.is_static
     }
 }
+
+// PublicVoidCallInterface
 
 pub struct PublicVoidCallInterface<let N: u32> {
     target_contract: AztecAddress,
@@ -474,7 +486,7 @@ impl<let N: u32> PublicVoidCallInterface<N> {
     }
 }
 
-impl<let N: u32, T> CallInterface<N> for PublicStaticCallInterface<N, T> {
+impl<let N: u32> CallInterface<N> for PublicVoidCallInterface<N> {
     fn get_args(self) -> [Field] {
         self.args
     }
@@ -495,6 +507,8 @@ impl<let N: u32, T> CallInterface<N> for PublicStaticCallInterface<N, T> {
         self.is_static
     }
 }
+
+// PublicStaticCallInterface
 
 pub struct PublicStaticCallInterface<let N: u32, T> {
     target_contract: AztecAddress,
@@ -555,7 +569,7 @@ impl<let N: u32, T> PublicStaticCallInterface<N, T> {
     }
 }
 
-impl<let N: u32> CallInterface<N> for PublicStaticVoidCallInterface<N> {
+impl<let N: u32, T> CallInterface<N> for PublicStaticCallInterface<N, T> {
     fn get_args(self) -> [Field] {
         self.args
     }
@@ -576,6 +590,8 @@ impl<let N: u32> CallInterface<N> for PublicStaticVoidCallInterface<N> {
         self.is_static
     }
 }
+
+// PublicStaticVoidCallInterface
 
 pub struct PublicStaticVoidCallInterface<let N: u32> {
     target_contract: AztecAddress,
@@ -630,5 +646,27 @@ impl<let N: u32> PublicStaticVoidCallInterface<N> {
             /*static=*/
             true,
         )
+    }
+}
+
+impl<let N: u32> CallInterface<N> for PublicStaticVoidCallInterface<N> {
+    fn get_args(self) -> [Field] {
+        self.args
+    }
+
+    fn get_selector(self) -> FunctionSelector {
+        self.selector
+    }
+
+    fn get_name(self) -> str<N> {
+        self.name
+    }
+
+    fn get_contract_address(self) -> AztecAddress {
+        self.target_contract
+    }
+
+    fn get_is_static(self) -> bool {
+        self.is_static
     }
 }


### PR DESCRIPTION
Closes https://github.com/AztecProtocol/aztec-packages/issues/12430

Also reorganizes the file so all the interfaces have the same structure (struc def, struc impl, trait impl) and a comment on top.