### PR TITLE
fix: update GA runners to ubuntu-latest

### DIFF
--- a/.github/workflows/ci3.yml
+++ b/.github/workflows/ci3.yml
@@ -177,7 +177,7 @@ jobs:
 
   # Necessary as github actions won't allow checks on matrix builds.
   merge-check:
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-latest
     if: always()
     needs:
       - ci

--- a/.github/workflows/nightly-kind-test.yml
+++ b/.github/workflows/nightly-kind-test.yml
@@ -50,7 +50,7 @@ jobs:
 
   test:
     needs: build
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-latest
     strategy:
       matrix:
         test:
@@ -73,7 +73,7 @@ jobs:
 
   proving-test:
     needs: build
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-latest
     timeout-minutes: 90
     steps:
       - uses: actions/checkout@v4
@@ -141,7 +141,7 @@ jobs:
           path: test_kind.log
 
   success-check:
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-latest
     needs:
       - test
       - proving-test
@@ -160,7 +160,7 @@ jobs:
   notify:
     needs:
       - success-check
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-latest
     if: ${{ github.ref == 'refs/heads/master' && failure() }}
     steps:
       - name: Send notification to aztec3-ci channel if workflow failed on master


### PR DESCRIPTION
https://github.blog/changelog/2025-01-15-github-actions-ubuntu-20-runner-image-brownout-dates-and-other-breaking-changes/

I had a look, this should be mostly safe as the steps just defer to docker or run bash