### PR TITLE
fix: make vk metadata actual witnesses

### DIFF
--- a/barretenberg/cpp/src/barretenberg/eccvm/eccvm_flavor.hpp
+++ b/barretenberg/cpp/src/barretenberg/eccvm/eccvm_flavor.hpp
@@ -746,7 +746,7 @@ class ECCVMFlavor {
      * resolve that, and split out separate PrecomputedPolynomials/Commitments data for clarity but also for
      * portability of our circuits.
      */
-    class VerificationKey : public VerificationKey_<PrecomputedEntities<Commitment>, VerifierCommitmentKey> {
+    class VerificationKey : public VerificationKey_<uint64_t, PrecomputedEntities<Commitment>, VerifierCommitmentKey> {
       public:
         VerificationKey() = default;
         VerificationKey(const size_t circuit_size, const size_t num_public_inputs)

--- a/barretenberg/cpp/src/barretenberg/eccvm/eccvm_flavor.hpp
+++ b/barretenberg/cpp/src/barretenberg/eccvm/eccvm_flavor.hpp
@@ -110,6 +110,7 @@ class ECCVMFlavor {
      */
     template <typename DataType_> class PrecomputedEntities {
       public:
+        bool operator==(const PrecomputedEntities& other) const = default;
         using DataType = DataType_;
         DEFINE_FLAVOR_MEMBERS(DataType,
                               lagrange_first,  // column 0
@@ -748,6 +749,7 @@ class ECCVMFlavor {
      */
     class VerificationKey : public VerificationKey_<uint64_t, PrecomputedEntities<Commitment>, VerifierCommitmentKey> {
       public:
+        bool operator==(const VerificationKey&) const = default;
         VerificationKey() = default;
         VerificationKey(const size_t circuit_size, const size_t num_public_inputs)
             : VerificationKey_(circuit_size, num_public_inputs)

--- a/barretenberg/cpp/src/barretenberg/eccvm/eccvm_flavor.hpp
+++ b/barretenberg/cpp/src/barretenberg/eccvm/eccvm_flavor.hpp
@@ -108,7 +108,7 @@ class ECCVMFlavor {
      * @brief A base class labelling precomputed entities and (ordered) subsets of interest.
      * @details Used to build the proving key and verification key.
      */
-    template <typename DataType_> class PrecomputedEntities : public PrecomputedEntitiesBase {
+    template <typename DataType_> class PrecomputedEntities {
       public:
         using DataType = DataType_;
         DEFINE_FLAVOR_MEMBERS(DataType,

--- a/barretenberg/cpp/src/barretenberg/flavor/flavor.hpp
+++ b/barretenberg/cpp/src/barretenberg/flavor/flavor.hpp
@@ -88,15 +88,15 @@
 namespace bb {
 
 /**
- * @brief Base class template containing circuit-specifying data.
+ * @brief Base class template for VericationKey containing circuit-specifying data.
  *
  */
-class PrecomputedEntitiesBase {
+template <typename FF> class VerificationKeyBase {
   public:
-    bool operator==(const PrecomputedEntitiesBase& other) const = default;
-    uint64_t circuit_size;
-    uint64_t log_circuit_size;
-    uint64_t num_public_inputs;
+    bool operator==(const VerificationKeyBase& other) const = default;
+    FF circuit_size;
+    FF log_circuit_size;
+    FF num_public_inputs;
 };
 // Specifies the regions of the execution trace containing non-trivial wire values
 struct ActiveRegionData {
@@ -168,7 +168,7 @@ template <typename FF, typename CommitmentKey_> class ProvingKey_ {
  * @tparam VerifierCommitmentKey The PCS verification key
  */
 template <typename PrecomputedCommitments, typename VerifierCommitmentKey>
-class VerificationKey_ : public PrecomputedCommitments {
+class VerificationKey_ : public PrecomputedCommitments, public VerificationKeyBase<uint64_t> {
   public:
     using FF = typename VerifierCommitmentKey::Curve::ScalarField;
     using Commitment = typename VerifierCommitmentKey::Commitment;

--- a/barretenberg/cpp/src/barretenberg/flavor/flavor.hpp
+++ b/barretenberg/cpp/src/barretenberg/flavor/flavor.hpp
@@ -91,12 +91,13 @@ namespace bb {
  * @brief Base class template for VericationKey containing circuit-specifying data.
  *
  */
-template <typename FF> class VerificationKeyBase {
+template <typename FF_> class VerificationKeyBase {
   public:
     bool operator==(const VerificationKeyBase& other) const = default;
-    FF circuit_size;
-    FF log_circuit_size;
-    FF num_public_inputs;
+    FF_ circuit_size;
+    FF_ log_circuit_size;
+    FF_ num_public_inputs;
+    FF_ pub_inputs_offset = 0;
 };
 // Specifies the regions of the execution trace containing non-trivial wire values
 struct ActiveRegionData {
@@ -164,18 +165,19 @@ template <typename FF, typename CommitmentKey_> class ProvingKey_ {
 /**
  * @brief Base verification key class.
  *
+ * @tparam FF_, the type that we will represent our VK metadata (circuit_size, log_circuit_size, num_public_inputs,
+ * pub_inputs_offset). It will either be uint64_t or a stdlib field type.
  * @tparam PrecomputedEntities An instance of PrecomputedEntities_ with affine_element data type and handle type.
  * @tparam VerifierCommitmentKey The PCS verification key
  */
-template <typename PrecomputedCommitments, typename VerifierCommitmentKey>
-class VerificationKey_ : public PrecomputedCommitments, public VerificationKeyBase<uint64_t> {
+template <typename FF_, typename PrecomputedCommitments, typename VerifierCommitmentKey>
+class VerificationKey_ : public PrecomputedCommitments, public VerificationKeyBase<FF_> {
   public:
     using FF = typename VerifierCommitmentKey::Curve::ScalarField;
     using Commitment = typename VerifierCommitmentKey::Commitment;
     std::shared_ptr<VerifierCommitmentKey> pcs_verification_key;
     bool contains_pairing_point_accumulator = false;
     PairingPointAccumulatorPubInputIndices pairing_point_accumulator_public_input_indices = {};
-    uint64_t pub_inputs_offset = 0;
 
     bool operator==(const VerificationKey_&) const = default;
     VerificationKey_() = default;

--- a/barretenberg/cpp/src/barretenberg/flavor/flavor.hpp
+++ b/barretenberg/cpp/src/barretenberg/flavor/flavor.hpp
@@ -87,18 +87,6 @@
 
 namespace bb {
 
-/**
- * @brief Base class template for VericationKey containing circuit-specifying data.
- *
- */
-template <typename FF_> class VerificationKeyBase {
-  public:
-    bool operator==(const VerificationKeyBase& other) const = default;
-    FF_ circuit_size;
-    FF_ log_circuit_size;
-    FF_ num_public_inputs;
-    FF_ pub_inputs_offset = 0;
-};
 // Specifies the regions of the execution trace containing non-trivial wire values
 struct ActiveRegionData {
     void add_range(const size_t start, const size_t end)
@@ -171,12 +159,16 @@ template <typename FF, typename CommitmentKey_> class ProvingKey_ {
  * @tparam VerifierCommitmentKey The PCS verification key
  */
 template <typename FF_, typename PrecomputedCommitments, typename VerifierCommitmentKey>
-class VerificationKey_ : public PrecomputedCommitments, public VerificationKeyBase<FF_> {
+class VerificationKey_ : public PrecomputedCommitments {
   public:
     using FF = typename VerifierCommitmentKey::Curve::ScalarField;
     using Commitment = typename VerifierCommitmentKey::Commitment;
     std::shared_ptr<VerifierCommitmentKey> pcs_verification_key;
-    FF_ contains_pairing_point_accumulator = false;
+    FF_ circuit_size;
+    FF_ log_circuit_size;
+    FF_ num_public_inputs;
+    FF_ pub_inputs_offset = 0;
+    bool contains_pairing_point_accumulator = false;
     PairingPointAccumulatorPubInputIndices pairing_point_accumulator_public_input_indices = {};
 
     bool operator==(const VerificationKey_&) const = default;

--- a/barretenberg/cpp/src/barretenberg/flavor/flavor.hpp
+++ b/barretenberg/cpp/src/barretenberg/flavor/flavor.hpp
@@ -176,7 +176,7 @@ class VerificationKey_ : public PrecomputedCommitments, public VerificationKeyBa
     using FF = typename VerifierCommitmentKey::Curve::ScalarField;
     using Commitment = typename VerifierCommitmentKey::Commitment;
     std::shared_ptr<VerifierCommitmentKey> pcs_verification_key;
-    bool contains_pairing_point_accumulator = false;
+    FF_ contains_pairing_point_accumulator = false;
     PairingPointAccumulatorPubInputIndices pairing_point_accumulator_public_input_indices = {};
 
     bool operator==(const VerificationKey_&) const = default;

--- a/barretenberg/cpp/src/barretenberg/stdlib/eccvm_verifier/eccvm_recursive_flavor.hpp
+++ b/barretenberg/cpp/src/barretenberg/stdlib/eccvm_verifier/eccvm_recursive_flavor.hpp
@@ -108,10 +108,11 @@ template <typename BuilderType> class ECCVMRecursiveFlavor_ {
         {
             this->pcs_verification_key = std::make_shared<VerifierCommitmentKey>(
                 builder, native_key->circuit_size, native_key->pcs_verification_key);
-            this->circuit_size = native_key->circuit_size;
-            this->log_circuit_size = numeric::get_msb(this->circuit_size);
-            this->num_public_inputs = native_key->num_public_inputs;
-            this->pub_inputs_offset = native_key->pub_inputs_offset;
+            this->circuit_size = FF::from_witness(builder, native_key->circuit_size);
+            // TODO(https://github.com/AztecProtocol/barretenberg/issues/1283): Use stdlib get_msb.
+            this->log_circuit_size = FF::from_witness(builder, numeric::get_msb(native_key->circuit_size));
+            this->num_public_inputs = FF::from_witness(builder, native_key->num_public_inputs);
+            this->pub_inputs_offset = FF::from_witness(builder, native_key->pub_inputs_offset);
 
             for (auto [native_commitment, commitment] : zip_view(native_key->get_all(), this->get_all())) {
                 commitment = Commitment::from_witness(builder, native_commitment);

--- a/barretenberg/cpp/src/barretenberg/stdlib/eccvm_verifier/eccvm_recursive_flavor.hpp
+++ b/barretenberg/cpp/src/barretenberg/stdlib/eccvm_verifier/eccvm_recursive_flavor.hpp
@@ -87,7 +87,7 @@ template <typename BuilderType> class ECCVMRecursiveFlavor_ {
      * portability of our circuits.
      */
     class VerificationKey
-        : public VerificationKey_<ECCVMFlavor::PrecomputedEntities<Commitment>, VerifierCommitmentKey> {
+        : public VerificationKey_<FF, ECCVMFlavor::PrecomputedEntities<Commitment>, VerifierCommitmentKey> {
       public:
         VerificationKey(const size_t circuit_size, const size_t num_public_inputs)
         {

--- a/barretenberg/cpp/src/barretenberg/stdlib/eccvm_verifier/eccvm_recursive_verifier.cpp
+++ b/barretenberg/cpp/src/barretenberg/stdlib/eccvm_verifier/eccvm_recursive_verifier.cpp
@@ -68,6 +68,7 @@ ECCVMRecursiveVerifier_<Flavor>::verify_proof(const ECCVMProof& proof)
     commitments.z_perm = transcript->template receive_from_prover<Commitment>(commitment_labels.z_perm);
 
     // Execute Sumcheck Verifier
+    // TODO(https://github.com/AztecProtocol/barretenberg/issues/1283): Suspicious get_value().
     const size_t log_circuit_size = numeric::get_msb(static_cast<uint32_t>(circuit_size.get_value()));
     auto sumcheck = SumcheckVerifier<Flavor>(log_circuit_size, transcript);
     const FF alpha = transcript->template get_challenge<FF>("Sumcheck:alpha");

--- a/barretenberg/cpp/src/barretenberg/stdlib/eccvm_verifier/eccvm_recursive_verifier.test.cpp
+++ b/barretenberg/cpp/src/barretenberg/stdlib/eccvm_verifier/eccvm_recursive_verifier.test.cpp
@@ -110,9 +110,11 @@ template <typename RecursiveFlavor> class ECCVMRecursiveTests : public ::testing
         }
 
         // Ensure verification key is the same
-        EXPECT_EQ(verifier.key->circuit_size, verification_key->circuit_size);
-        EXPECT_EQ(verifier.key->log_circuit_size, verification_key->log_circuit_size);
-        EXPECT_EQ(verifier.key->num_public_inputs, verification_key->num_public_inputs);
+        EXPECT_EQ(static_cast<uint64_t>(verifier.key->circuit_size.get_value()), verification_key->circuit_size);
+        EXPECT_EQ(static_cast<uint64_t>(verifier.key->log_circuit_size.get_value()),
+                  verification_key->log_circuit_size);
+        EXPECT_EQ(static_cast<uint64_t>(verifier.key->num_public_inputs.get_value()),
+                  verification_key->num_public_inputs);
         for (auto [vk_poly, native_vk_poly] : zip_view(verifier.key->get_all(), verification_key->get_all())) {
             EXPECT_EQ(vk_poly.get_value(), native_vk_poly);
         }

--- a/barretenberg/cpp/src/barretenberg/stdlib/honk_verifier/decider_recursive_verifier.cpp
+++ b/barretenberg/cpp/src/barretenberg/stdlib/honk_verifier/decider_recursive_verifier.cpp
@@ -27,7 +27,7 @@ std::array<typename Flavor::GroupElement, 2> DeciderRecursiveVerifier_<Flavor>::
     VerifierCommitments commitments{ accumulator->verification_key, accumulator->witness_commitments };
 
     // TODO(https://github.com/AztecProtocol/barretenberg/issues/1283): fix log_circuit_size usage in stdlib cases.
-    auto sumcheck = Sumcheck(static_cast<size_t>(accumulator->verification_key->log_circuit_size.get_value()),
+    auto sumcheck = Sumcheck(static_cast<uint32_t>(accumulator->verification_key->log_circuit_size.get_value()),
                              transcript,
                              accumulator->target_sum);
 

--- a/barretenberg/cpp/src/barretenberg/stdlib/honk_verifier/decider_recursive_verifier.cpp
+++ b/barretenberg/cpp/src/barretenberg/stdlib/honk_verifier/decider_recursive_verifier.cpp
@@ -26,8 +26,10 @@ std::array<typename Flavor::GroupElement, 2> DeciderRecursiveVerifier_<Flavor>::
 
     VerifierCommitments commitments{ accumulator->verification_key, accumulator->witness_commitments };
 
-    auto sumcheck = Sumcheck(
-        static_cast<size_t>(accumulator->verification_key->log_circuit_size), transcript, accumulator->target_sum);
+    // TODO(https://github.com/AztecProtocol/barretenberg/issues/1283): fix log_circuit_size usage in stdlib cases.
+    auto sumcheck = Sumcheck(static_cast<size_t>(accumulator->verification_key->log_circuit_size.get_value()),
+                             transcript,
+                             accumulator->target_sum);
 
     SumcheckOutput<Flavor> output =
         sumcheck.verify(accumulator->relation_parameters, accumulator->alphas, accumulator->gate_challenges);

--- a/barretenberg/cpp/src/barretenberg/stdlib/honk_verifier/oink_recursive_verifier.cpp
+++ b/barretenberg/cpp/src/barretenberg/stdlib/honk_verifier/oink_recursive_verifier.cpp
@@ -48,7 +48,7 @@ template <typename Flavor> void OinkRecursiveVerifier_<Flavor>::verify()
     transcript->template receive_from_prover<FF>(domain_separator + "pub_inputs_offset");
 
     std::vector<FF> public_inputs;
-    for (size_t i = 0; i < static_cast<size_t>(public_input_size.get_value()); ++i) {
+    for (size_t i = 0; i < static_cast<size_t>(static_cast<uint32_t>(public_input_size.get_value())); ++i) {
         public_inputs.emplace_back(
             transcript->template receive_from_prover<FF>(domain_separator + "public_input_" + std::to_string(i)));
     }
@@ -95,6 +95,7 @@ template <typename Flavor> void OinkRecursiveVerifier_<Flavor>::verify()
         }
     }
 
+    // TODO(https://github.com/AztecProtocol/barretenberg/issues/1283): Suspicious get_value().
     const FF public_input_delta = compute_public_input_delta<Flavor>(
         public_inputs,
         beta,

--- a/barretenberg/cpp/src/barretenberg/stdlib/honk_verifier/oink_recursive_verifier.cpp
+++ b/barretenberg/cpp/src/barretenberg/stdlib/honk_verifier/oink_recursive_verifier.cpp
@@ -45,7 +45,26 @@ template <typename Flavor> void OinkRecursiveVerifier_<Flavor>::verify()
 
     FF circuit_size = transcript->template receive_from_prover<FF>(domain_separator + "circuit_size");
     FF public_input_size = transcript->template receive_from_prover<FF>(domain_separator + "public_input_size");
-    transcript->template receive_from_prover<FF>(domain_separator + "pub_inputs_offset");
+    FF pub_inputs_offset = transcript->template receive_from_prover<FF>(domain_separator + "pub_inputs_offset");
+
+    if (static_cast<uint32_t>(circuit_size.get_value()) !=
+        static_cast<uint32_t>(verification_key->verification_key->circuit_size.get_value())) {
+        throw_or_abort("OinkRecursiveVerifier::verify: proof circuit size does not match verification key");
+    }
+    if (static_cast<uint32_t>(public_input_size.get_value()) !=
+        static_cast<uint32_t>(verification_key->verification_key->num_public_inputs.get_value())) {
+        const std::string message =
+            "OinkRecursiveVerifier::verify: proof public input size (" +
+            std::to_string(static_cast<uint32_t>(public_input_size.get_value())) +
+            ") does not match verification key public input size (" +
+            std::to_string(static_cast<uint32_t>(verification_key->verification_key->num_public_inputs.get_value())) +
+            ")";
+        throw_or_abort(message);
+    }
+    if (static_cast<uint32_t>(pub_inputs_offset.get_value()) !=
+        static_cast<uint32_t>(verification_key->verification_key->pub_inputs_offset.get_value())) {
+        throw_or_abort("OinkRecursiveVerifier::verify: proof public input offset does not match verification key");
+    }
 
     std::vector<FF> public_inputs;
     for (size_t i = 0; i < static_cast<size_t>(static_cast<uint32_t>(public_input_size.get_value())); ++i) {

--- a/barretenberg/cpp/src/barretenberg/stdlib/honk_verifier/oink_recursive_verifier.cpp
+++ b/barretenberg/cpp/src/barretenberg/stdlib/honk_verifier/oink_recursive_verifier.cpp
@@ -45,24 +45,10 @@ template <typename Flavor> void OinkRecursiveVerifier_<Flavor>::verify()
 
     FF circuit_size = transcript->template receive_from_prover<FF>(domain_separator + "circuit_size");
     FF public_input_size = transcript->template receive_from_prover<FF>(domain_separator + "public_input_size");
-    FF pub_inputs_offset = transcript->template receive_from_prover<FF>(domain_separator + "pub_inputs_offset");
-
-    if (static_cast<uint32_t>(circuit_size.get_value()) != verification_key->verification_key->circuit_size) {
-        throw_or_abort("OinkRecursiveVerifier::verify: proof circuit size does not match verification key");
-    }
-    if (static_cast<uint32_t>(public_input_size.get_value()) != verification_key->verification_key->num_public_inputs) {
-        const std::string message = "OinkRecursiveVerifier::verify: proof public input size (" +
-                                    std::to_string(static_cast<uint32_t>(public_input_size.get_value())) +
-                                    ") does not match verification key public input size (" +
-                                    std::to_string(verification_key->verification_key->num_public_inputs) + ")";
-        throw_or_abort(message);
-    }
-    if (static_cast<uint32_t>(pub_inputs_offset.get_value()) != verification_key->verification_key->pub_inputs_offset) {
-        throw_or_abort("OinkRecursiveVerifier::verify: proof public input offset does not match verification key");
-    }
+    transcript->template receive_from_prover<FF>(domain_separator + "pub_inputs_offset");
 
     std::vector<FF> public_inputs;
-    for (size_t i = 0; i < verification_key->verification_key->num_public_inputs; ++i) {
+    for (size_t i = 0; i < static_cast<size_t>(public_input_size.get_value()); ++i) {
         public_inputs.emplace_back(
             transcript->template receive_from_prover<FF>(domain_separator + "public_input_" + std::to_string(i)));
     }
@@ -114,7 +100,7 @@ template <typename Flavor> void OinkRecursiveVerifier_<Flavor>::verify()
         beta,
         gamma,
         circuit_size,
-        static_cast<uint32_t>(verification_key->verification_key->pub_inputs_offset));
+        static_cast<uint32_t>(verification_key->verification_key->pub_inputs_offset.get_value()));
 
     // Get commitment to permutation and lookup grand products
     commitments.z_perm = transcript->template receive_from_prover<Commitment>(domain_separator + labels.z_perm);

--- a/barretenberg/cpp/src/barretenberg/stdlib/honk_verifier/ultra_recursive_verifier.cpp
+++ b/barretenberg/cpp/src/barretenberg/stdlib/honk_verifier/ultra_recursive_verifier.cpp
@@ -104,6 +104,7 @@ UltraRecursiveVerifier_<Flavor>::Output UltraRecursiveVerifier_<Flavor>::verify_
 
     // Execute Sumcheck Verifier and extract multivariate opening point u = (u_0, ..., u_{d-1}) and purported
     // multivariate evaluations at u
+    // TODO(https://github.com/AztecProtocol/barretenberg/issues/1283): Suspicious get_value().
     const size_t log_circuit_size = numeric::get_msb(static_cast<uint32_t>(key->circuit_size.get_value()));
     auto sumcheck = Sumcheck(log_circuit_size, transcript);
 

--- a/barretenberg/cpp/src/barretenberg/stdlib/honk_verifier/ultra_recursive_verifier.cpp
+++ b/barretenberg/cpp/src/barretenberg/stdlib/honk_verifier/ultra_recursive_verifier.cpp
@@ -104,7 +104,7 @@ UltraRecursiveVerifier_<Flavor>::Output UltraRecursiveVerifier_<Flavor>::verify_
 
     // Execute Sumcheck Verifier and extract multivariate opening point u = (u_0, ..., u_{d-1}) and purported
     // multivariate evaluations at u
-    const size_t log_circuit_size = numeric::get_msb(static_cast<uint32_t>(key->circuit_size));
+    const size_t log_circuit_size = numeric::get_msb(static_cast<uint32_t>(key->circuit_size.get_value()));
     auto sumcheck = Sumcheck(log_circuit_size, transcript);
 
     // Receive commitments to Libra masking polynomials

--- a/barretenberg/cpp/src/barretenberg/stdlib/honk_verifier/ultra_recursive_verifier.test.cpp
+++ b/barretenberg/cpp/src/barretenberg/stdlib/honk_verifier/ultra_recursive_verifier.test.cpp
@@ -128,9 +128,9 @@ template <typename RecursiveFlavor> class RecursiveVerifierTest : public testing
         RecursiveVerifier verifier{ &outer_circuit, honk_vk };
 
         // Spot check some values in the recursive VK to ensure it was constructed correctly
-        EXPECT_EQ(verifier.key->circuit_size, honk_vk->circuit_size);
-        EXPECT_EQ(verifier.key->log_circuit_size, honk_vk->log_circuit_size);
-        EXPECT_EQ(verifier.key->num_public_inputs, honk_vk->num_public_inputs);
+        EXPECT_EQ(static_cast<uint64_t>(verifier.key->circuit_size.get_value()), honk_vk->circuit_size);
+        EXPECT_EQ(static_cast<uint64_t>(verifier.key->log_circuit_size.get_value()), honk_vk->log_circuit_size);
+        EXPECT_EQ(static_cast<uint64_t>(verifier.key->num_public_inputs.get_value()), honk_vk->num_public_inputs);
         for (auto [vk_poly, native_vk_poly] : zip_view(verifier.key->get_all(), honk_vk->get_all())) {
             EXPECT_EQ(vk_poly.get_value(), native_vk_poly);
         }

--- a/barretenberg/cpp/src/barretenberg/stdlib/protogalaxy_verifier/recursive_decider_verification_key.hpp
+++ b/barretenberg/cpp/src/barretenberg/stdlib/protogalaxy_verifier/recursive_decider_verification_key.hpp
@@ -122,8 +122,8 @@ template <IsRecursiveFlavor Flavor> class RecursiveDeciderVerificationKey_ {
         DeciderVerificationKey decider_vk(native_honk_vk);
         decider_vk.is_accumulator = is_accumulator;
 
-        decider_vk.public_inputs =
-            std::vector<NativeFF>(static_cast<size_t>(verification_key->num_public_inputs.get_value()));
+        decider_vk.public_inputs = std::vector<NativeFF>(
+            static_cast<size_t>(static_cast<uint32_t>(verification_key->num_public_inputs.get_value())));
         for (auto [public_input, inst_public_input] : zip_view(public_inputs, decider_vk.public_inputs)) {
             inst_public_input = public_input.get_value();
         }

--- a/barretenberg/cpp/src/barretenberg/stdlib/protogalaxy_verifier/recursive_decider_verification_key.hpp
+++ b/barretenberg/cpp/src/barretenberg/stdlib/protogalaxy_verifier/recursive_decider_verification_key.hpp
@@ -107,8 +107,7 @@ template <IsRecursiveFlavor Flavor> class RecursiveDeciderVerificationKey_ {
                                                    ? std::make_shared<VerifierCommitmentKey>()
                                                    : verification_key->pcs_verification_key;
         native_honk_vk->pub_inputs_offset = static_cast<uint64_t>(verification_key->pub_inputs_offset.get_value());
-        native_honk_vk->contains_pairing_point_accumulator =
-            static_cast<bool>(verification_key->contains_pairing_point_accumulator.get_value());
+        native_honk_vk->contains_pairing_point_accumulator = verification_key->contains_pairing_point_accumulator;
         native_honk_vk->pairing_point_accumulator_public_input_indices =
             verification_key->pairing_point_accumulator_public_input_indices;
         if constexpr (IsMegaFlavor<Flavor>) {

--- a/barretenberg/cpp/src/barretenberg/stdlib/protogalaxy_verifier/recursive_decider_verification_key.hpp
+++ b/barretenberg/cpp/src/barretenberg/stdlib/protogalaxy_verifier/recursive_decider_verification_key.hpp
@@ -100,13 +100,15 @@ template <IsRecursiveFlavor Flavor> class RecursiveDeciderVerificationKey_ {
      */
     DeciderVerificationKey get_value()
     {
-        auto native_honk_vk = std::make_shared<NativeVerificationKey>(verification_key->circuit_size,
-                                                                      verification_key->num_public_inputs);
+        auto native_honk_vk = std::make_shared<NativeVerificationKey>(
+            static_cast<uint64_t>(verification_key->circuit_size.get_value()),
+            static_cast<uint64_t>(verification_key->num_public_inputs.get_value()));
         native_honk_vk->pcs_verification_key = verification_key->pcs_verification_key == nullptr
                                                    ? std::make_shared<VerifierCommitmentKey>()
                                                    : verification_key->pcs_verification_key;
-        native_honk_vk->pub_inputs_offset = verification_key->pub_inputs_offset;
-        native_honk_vk->contains_pairing_point_accumulator = verification_key->contains_pairing_point_accumulator;
+        native_honk_vk->pub_inputs_offset = static_cast<uint64_t>(verification_key->pub_inputs_offset.get_value());
+        native_honk_vk->contains_pairing_point_accumulator =
+            static_cast<bool>(verification_key->contains_pairing_point_accumulator.get_value());
         native_honk_vk->pairing_point_accumulator_public_input_indices =
             verification_key->pairing_point_accumulator_public_input_indices;
         if constexpr (IsMegaFlavor<Flavor>) {
@@ -120,7 +122,8 @@ template <IsRecursiveFlavor Flavor> class RecursiveDeciderVerificationKey_ {
         DeciderVerificationKey decider_vk(native_honk_vk);
         decider_vk.is_accumulator = is_accumulator;
 
-        decider_vk.public_inputs = std::vector<NativeFF>(static_cast<size_t>(verification_key->num_public_inputs));
+        decider_vk.public_inputs =
+            std::vector<NativeFF>(static_cast<size_t>(verification_key->num_public_inputs.get_value()));
         for (auto [public_input, inst_public_input] : zip_view(public_inputs, decider_vk.public_inputs)) {
             inst_public_input = public_input.get_value();
         }

--- a/barretenberg/cpp/src/barretenberg/stdlib/protogalaxy_verifier/recursive_decider_verification_keys.hpp
+++ b/barretenberg/cpp/src/barretenberg/stdlib/protogalaxy_verifier/recursive_decider_verification_keys.hpp
@@ -45,6 +45,7 @@ template <IsRecursiveFlavor Flavor_, size_t NUM_> struct RecursiveDeciderVerific
     {
         size_t max_log_circuit_size{ 0 };
         for (auto key : _data) {
+            // TODO(https://github.com/AztecProtocol/barretenberg/issues/1283): Suspicious get_value.
             max_log_circuit_size = std::max(
                 max_log_circuit_size,
                 static_cast<size_t>(static_cast<uint32_t>(key->verification_key->log_circuit_size.get_value())));

--- a/barretenberg/cpp/src/barretenberg/stdlib/protogalaxy_verifier/recursive_decider_verification_keys.hpp
+++ b/barretenberg/cpp/src/barretenberg/stdlib/protogalaxy_verifier/recursive_decider_verification_keys.hpp
@@ -45,8 +45,8 @@ template <IsRecursiveFlavor Flavor_, size_t NUM_> struct RecursiveDeciderVerific
     {
         size_t max_log_circuit_size{ 0 };
         for (auto key : _data) {
-            max_log_circuit_size =
-                std::max(max_log_circuit_size, static_cast<size_t>(key->verification_key->log_circuit_size));
+            max_log_circuit_size = std::max(max_log_circuit_size,
+                                            static_cast<size_t>(key->verification_key->log_circuit_size.get_value()));
         }
         return max_log_circuit_size;
     }

--- a/barretenberg/cpp/src/barretenberg/stdlib/protogalaxy_verifier/recursive_decider_verification_keys.hpp
+++ b/barretenberg/cpp/src/barretenberg/stdlib/protogalaxy_verifier/recursive_decider_verification_keys.hpp
@@ -45,8 +45,9 @@ template <IsRecursiveFlavor Flavor_, size_t NUM_> struct RecursiveDeciderVerific
     {
         size_t max_log_circuit_size{ 0 };
         for (auto key : _data) {
-            max_log_circuit_size = std::max(max_log_circuit_size,
-                                            static_cast<size_t>(key->verification_key->log_circuit_size.get_value()));
+            max_log_circuit_size = std::max(
+                max_log_circuit_size,
+                static_cast<size_t>(static_cast<uint32_t>(key->verification_key->log_circuit_size.get_value())));
         }
         return max_log_circuit_size;
     }

--- a/barretenberg/cpp/src/barretenberg/stdlib/translator_vm_verifier/translator_recursive_flavor.hpp
+++ b/barretenberg/cpp/src/barretenberg/stdlib/translator_vm_verifier/translator_recursive_flavor.hpp
@@ -105,10 +105,11 @@ template <typename BuilderType> class TranslatorRecursiveFlavor_ {
         VerificationKey(CircuitBuilder* builder, const std::shared_ptr<NativeVerificationKey>& native_key)
         {
             this->pcs_verification_key = std::make_shared<VerifierCommitmentKey>(); // ?
-            this->circuit_size = native_key->circuit_size;
-            this->log_circuit_size = numeric::get_msb(this->circuit_size);
-            this->num_public_inputs = native_key->num_public_inputs;
-            this->pub_inputs_offset = native_key->pub_inputs_offset;
+            this->circuit_size = FF::from_witness(builder, native_key->circuit_size);
+            // TODO(https://github.com/AztecProtocol/barretenberg/issues/1283): Use stdlib get_msb.
+            this->log_circuit_size = numeric::get_msb(native_key->circuit_size);
+            this->num_public_inputs = FF::from_witness(builder, native_key->num_public_inputs);
+            this->pub_inputs_offset = FF::from_witness(builder, native_key->pub_inputs_offset);
 
             for (auto [native_comm, comm] : zip_view(native_key->get_all(), this->get_all())) {
                 comm = Commitment::from_witness(builder, native_comm);

--- a/barretenberg/cpp/src/barretenberg/stdlib/translator_vm_verifier/translator_recursive_flavor.hpp
+++ b/barretenberg/cpp/src/barretenberg/stdlib/translator_vm_verifier/translator_recursive_flavor.hpp
@@ -93,7 +93,7 @@ template <typename BuilderType> class TranslatorRecursiveFlavor_ {
      * portability of our circuits.
      */
     class VerificationKey
-        : public VerificationKey_<TranslatorFlavor::PrecomputedEntities<Commitment>, VerifierCommitmentKey> {
+        : public VerificationKey_<FF, TranslatorFlavor::PrecomputedEntities<Commitment>, VerifierCommitmentKey> {
       public:
         VerificationKey(const size_t circuit_size, const size_t num_public_inputs)
         {

--- a/barretenberg/cpp/src/barretenberg/stdlib/translator_vm_verifier/translator_recursive_verifier.cpp
+++ b/barretenberg/cpp/src/barretenberg/stdlib/translator_vm_verifier/translator_recursive_verifier.cpp
@@ -76,7 +76,7 @@ std::array<typename Flavor::GroupElement, 2> TranslatorRecursiveVerifier_<Flavor
     CommitmentLabels commitment_labels;
 
     const FF circuit_size = transcript->template receive_from_prover<FF>("circuit_size");
-    if (static_cast<uint32_t>(circuit_size.get_value()) != key->circuit_size) {
+    if (static_cast<uint32_t>(circuit_size.get_value()) != static_cast<uint32_t>(key->circuit_size.get_value())) {
         throw_or_abort(
             "TranslatorRecursiveVerifier::verify_proof: proof circuit size does not match verification key!");
     }

--- a/barretenberg/cpp/src/barretenberg/stdlib/translator_vm_verifier/translator_recursive_verifier.cpp
+++ b/barretenberg/cpp/src/barretenberg/stdlib/translator_vm_verifier/translator_recursive_verifier.cpp
@@ -103,6 +103,7 @@ std::array<typename Flavor::GroupElement, 2> TranslatorRecursiveVerifier_<Flavor
     commitments.z_perm = transcript->template receive_from_prover<Commitment>(commitment_labels.z_perm);
 
     // Execute Sumcheck Verifier
+    // TODO(https://github.com/AztecProtocol/barretenberg/issues/1283): Suspicious get_value().
     const size_t log_circuit_size = numeric::get_msb(static_cast<uint32_t>(circuit_size.get_value()));
     auto sumcheck = Sumcheck(log_circuit_size, transcript);
     FF alpha = transcript->template get_challenge<FF>("Sumcheck:alpha");

--- a/barretenberg/cpp/src/barretenberg/stdlib/translator_vm_verifier/translator_recursive_verifier.test.cpp
+++ b/barretenberg/cpp/src/barretenberg/stdlib/translator_vm_verifier/translator_recursive_verifier.test.cpp
@@ -108,9 +108,11 @@ template <typename RecursiveFlavor> class TranslatorRecursiveTests : public ::te
                 << "Recursive Verifier/Verifier manifest discrepency in round " << i;
         }
 
-        EXPECT_EQ(verifier.key->circuit_size, verification_key->circuit_size);
-        EXPECT_EQ(verifier.key->log_circuit_size, verification_key->log_circuit_size);
-        EXPECT_EQ(verifier.key->num_public_inputs, verification_key->num_public_inputs);
+        EXPECT_EQ(static_cast<uint64_t>(verifier.key->circuit_size.get_value()), verification_key->circuit_size);
+        EXPECT_EQ(static_cast<uint64_t>(verifier.key->log_circuit_size.get_value()),
+                  verification_key->log_circuit_size);
+        EXPECT_EQ(static_cast<uint64_t>(verifier.key->num_public_inputs.get_value()),
+                  verification_key->num_public_inputs);
         for (auto [vk_poly, native_vk_poly] : zip_view(verifier.key->get_all(), verification_key->get_all())) {
             EXPECT_EQ(vk_poly.get_value(), native_vk_poly);
         }

--- a/barretenberg/cpp/src/barretenberg/stdlib_circuit_builders/mega_flavor.hpp
+++ b/barretenberg/cpp/src/barretenberg/stdlib_circuit_builders/mega_flavor.hpp
@@ -103,7 +103,7 @@ class MegaFlavor {
      * @brief A base class labelling precomputed entities and (ordered) subsets of interest.
      * @details Used to build the proving key and verification key.
      */
-    template <typename DataType_> class PrecomputedEntities : public PrecomputedEntitiesBase {
+    template <typename DataType_> class PrecomputedEntities {
       public:
         bool operator==(const PrecomputedEntities&) const = default;
         using DataType = DataType_;

--- a/barretenberg/cpp/src/barretenberg/stdlib_circuit_builders/mega_flavor.hpp
+++ b/barretenberg/cpp/src/barretenberg/stdlib_circuit_builders/mega_flavor.hpp
@@ -429,7 +429,7 @@ class MegaFlavor {
      * circuits.
      * @todo TODO(https://github.com/AztecProtocol/barretenberg/issues/876)
      */
-    class VerificationKey : public VerificationKey_<PrecomputedEntities<Commitment>, VerifierCommitmentKey> {
+    class VerificationKey : public VerificationKey_<uint64_t, PrecomputedEntities<Commitment>, VerifierCommitmentKey> {
       public:
         // Data pertaining to transfer of databus return data via public inputs of the proof being recursively verified
         DatabusPropagationData databus_propagation_data;

--- a/barretenberg/cpp/src/barretenberg/stdlib_circuit_builders/mega_recursive_flavor.hpp
+++ b/barretenberg/cpp/src/barretenberg/stdlib_circuit_builders/mega_recursive_flavor.hpp
@@ -103,7 +103,7 @@ template <typename BuilderType> class MegaRecursiveFlavor_ {
      * This differs from Mega in how we construct the commitments.
      */
     class VerificationKey
-        : public VerificationKey_<MegaFlavor::PrecomputedEntities<Commitment>, VerifierCommitmentKey> {
+        : public VerificationKey_<FF, MegaFlavor::PrecomputedEntities<Commitment>, VerifierCommitmentKey> {
       public:
         // Data pertaining to transfer of databus return data via public inputs of the proof
         DatabusPropagationData databus_propagation_data;
@@ -125,11 +125,13 @@ template <typename BuilderType> class MegaRecursiveFlavor_ {
         VerificationKey(CircuitBuilder* builder, const std::shared_ptr<NativeVerificationKey>& native_key)
         {
             this->pcs_verification_key = native_key->pcs_verification_key;
-            this->circuit_size = native_key->circuit_size;
-            this->log_circuit_size = numeric::get_msb(this->circuit_size);
-            this->num_public_inputs = native_key->num_public_inputs;
-            this->pub_inputs_offset = native_key->pub_inputs_offset;
-            this->contains_pairing_point_accumulator = native_key->contains_pairing_point_accumulator;
+            this->circuit_size = FF::from_witness(builder, native_key->circuit_size);
+            // TODO(https://github.com/AztecProtocol/barretenberg/issues/1283): Use stdlib get_msb.
+            this->log_circuit_size = FF::from_witness(builder, numeric::get_msb(native_key->circuit_size));
+            this->num_public_inputs = FF::from_witness(builder, native_key->num_public_inputs);
+            this->pub_inputs_offset = FF::from_witness(builder, native_key->pub_inputs_offset);
+            this->contains_pairing_point_accumulator =
+                FF::from_witness(builder, native_key->contains_pairing_point_accumulator);
             this->pairing_point_accumulator_public_input_indices =
                 native_key->pairing_point_accumulator_public_input_indices;
             this->databus_propagation_data = native_key->databus_propagation_data;
@@ -152,12 +154,12 @@ template <typename BuilderType> class MegaRecursiveFlavor_ {
 
             size_t num_frs_read = 0;
 
-            this->circuit_size = uint64_t(deserialize_from_frs<FF>(builder, elements, num_frs_read).get_value());
-            this->log_circuit_size = numeric::get_msb(this->circuit_size);
-            this->num_public_inputs = uint64_t(deserialize_from_frs<FF>(builder, elements, num_frs_read).get_value());
-            this->pub_inputs_offset = uint64_t(deserialize_from_frs<FF>(builder, elements, num_frs_read).get_value());
-            this->contains_pairing_point_accumulator =
-                bool(deserialize_from_frs<FF>(builder, elements, num_frs_read).get_value());
+            this->circuit_size = deserialize_from_frs<FF>(builder, elements, num_frs_read);
+            // TODO(https://github.com/AztecProtocol/barretenberg/issues/1283): Use stdlib get_msb.
+            this->log_circuit_size = numeric::get_msb(static_cast<uint32_t>(this->circuit_size.get_value()));
+            this->num_public_inputs = deserialize_from_frs<FF>(builder, elements, num_frs_read);
+            this->pub_inputs_offset = deserialize_from_frs<FF>(builder, elements, num_frs_read);
+            this->contains_pairing_point_accumulator = deserialize_from_frs<FF>(builder, elements, num_frs_read);
 
             for (uint32_t& idx : this->pairing_point_accumulator_public_input_indices) {
                 idx = uint32_t(deserialize_from_frs<FF>(builder, elements, num_frs_read).get_value());

--- a/barretenberg/cpp/src/barretenberg/stdlib_circuit_builders/mega_recursive_flavor.hpp
+++ b/barretenberg/cpp/src/barretenberg/stdlib_circuit_builders/mega_recursive_flavor.hpp
@@ -130,8 +130,7 @@ template <typename BuilderType> class MegaRecursiveFlavor_ {
             this->log_circuit_size = FF::from_witness(builder, numeric::get_msb(native_key->circuit_size));
             this->num_public_inputs = FF::from_witness(builder, native_key->num_public_inputs);
             this->pub_inputs_offset = FF::from_witness(builder, native_key->pub_inputs_offset);
-            this->contains_pairing_point_accumulator =
-                FF::from_witness(builder, native_key->contains_pairing_point_accumulator);
+            this->contains_pairing_point_accumulator = native_key->contains_pairing_point_accumulator;
             this->pairing_point_accumulator_public_input_indices =
                 native_key->pairing_point_accumulator_public_input_indices;
             this->databus_propagation_data = native_key->databus_propagation_data;
@@ -159,7 +158,8 @@ template <typename BuilderType> class MegaRecursiveFlavor_ {
             this->log_circuit_size = numeric::get_msb(static_cast<uint32_t>(this->circuit_size.get_value()));
             this->num_public_inputs = deserialize_from_frs<FF>(builder, elements, num_frs_read);
             this->pub_inputs_offset = deserialize_from_frs<FF>(builder, elements, num_frs_read);
-            this->contains_pairing_point_accumulator = deserialize_from_frs<FF>(builder, elements, num_frs_read);
+            this->contains_pairing_point_accumulator =
+                bool(deserialize_from_frs<FF>(builder, elements, num_frs_read).get_value());
 
             for (uint32_t& idx : this->pairing_point_accumulator_public_input_indices) {
                 idx = uint32_t(deserialize_from_frs<FF>(builder, elements, num_frs_read).get_value());

--- a/barretenberg/cpp/src/barretenberg/stdlib_circuit_builders/ultra_flavor.hpp
+++ b/barretenberg/cpp/src/barretenberg/stdlib_circuit_builders/ultra_flavor.hpp
@@ -130,7 +130,7 @@ class UltraFlavor {
      * @brief A base class labelling precomputed entities and (ordered) subsets of interest.
      * @details Used to build the proving key and verification key.
      */
-    template <typename DataType_> class PrecomputedEntities : public PrecomputedEntitiesBase {
+    template <typename DataType_> class PrecomputedEntities {
       public:
         bool operator==(const PrecomputedEntities&) const = default;
         using DataType = DataType_;

--- a/barretenberg/cpp/src/barretenberg/stdlib_circuit_builders/ultra_flavor.hpp
+++ b/barretenberg/cpp/src/barretenberg/stdlib_circuit_builders/ultra_flavor.hpp
@@ -357,7 +357,7 @@ class UltraFlavor {
      * that, and split out separate PrecomputedPolynomials/Commitments data for clarity but also for portability of our
      * circuits.
      */
-    class VerificationKey : public VerificationKey_<PrecomputedEntities<Commitment>, VerifierCommitmentKey> {
+    class VerificationKey : public VerificationKey_<uint64_t, PrecomputedEntities<Commitment>, VerifierCommitmentKey> {
       public:
         bool operator==(const VerificationKey&) const = default;
         VerificationKey() = default;

--- a/barretenberg/cpp/src/barretenberg/stdlib_circuit_builders/ultra_keccak_flavor.hpp
+++ b/barretenberg/cpp/src/barretenberg/stdlib_circuit_builders/ultra_keccak_flavor.hpp
@@ -36,7 +36,7 @@ class UltraKeccakFlavor : public bb::UltraFlavor {
      */
     // TODO(https://github.com/AztecProtocol/barretenberg/issues/1094): Add aggregation to the verifier contract so the
     // VerificationKey from UltraFlavor can be used
-    class VerificationKey : public VerificationKey_<PrecomputedEntities<Commitment>, VerifierCommitmentKey> {
+    class VerificationKey : public VerificationKey_<uint64_t, PrecomputedEntities<Commitment>, VerifierCommitmentKey> {
       public:
         VerificationKey() = default;
         VerificationKey(const size_t circuit_size, const size_t num_public_inputs)

--- a/barretenberg/cpp/src/barretenberg/stdlib_circuit_builders/ultra_recursive_flavor.hpp
+++ b/barretenberg/cpp/src/barretenberg/stdlib_circuit_builders/ultra_recursive_flavor.hpp
@@ -106,7 +106,7 @@ template <typename BuilderType> class UltraRecursiveFlavor_ {
      * circuits.
      */
     class VerificationKey
-        : public VerificationKey_<UltraFlavor::PrecomputedEntities<Commitment>, VerifierCommitmentKey> {
+        : public VerificationKey_<FF, UltraFlavor::PrecomputedEntities<Commitment>, VerifierCommitmentKey> {
       public:
         VerificationKey(const size_t circuit_size, const size_t num_public_inputs)
         {
@@ -124,11 +124,13 @@ template <typename BuilderType> class UltraRecursiveFlavor_ {
         VerificationKey(CircuitBuilder* builder, const std::shared_ptr<NativeVerificationKey>& native_key)
         {
             this->pcs_verification_key = native_key->pcs_verification_key;
-            this->circuit_size = native_key->circuit_size;
-            this->log_circuit_size = numeric::get_msb(this->circuit_size);
-            this->num_public_inputs = native_key->num_public_inputs;
-            this->pub_inputs_offset = native_key->pub_inputs_offset;
-            this->contains_pairing_point_accumulator = native_key->contains_pairing_point_accumulator;
+            this->circuit_size = FF::from_witness(builder, native_key->circuit_size);
+            // TODO(https://github.com/AztecProtocol/barretenberg/issues/1283): Use stdlib get_msb.
+            this->log_circuit_size = FF::from_witness(builder, numeric::get_msb(native_key->circuit_size));
+            this->num_public_inputs = FF::from_witness(builder, native_key->num_public_inputs);
+            this->pub_inputs_offset = FF::from_witness(builder, native_key->pub_inputs_offset);
+            this->contains_pairing_point_accumulator =
+                FF::from_witness(builder, native_key->contains_pairing_point_accumulator);
             this->pairing_point_accumulator_public_input_indices =
                 native_key->pairing_point_accumulator_public_input_indices;
 
@@ -150,11 +152,10 @@ template <typename BuilderType> class UltraRecursiveFlavor_ {
 
             size_t num_frs_read = 0;
 
-            this->circuit_size = uint64_t(deserialize_from_frs<FF>(builder, elements, num_frs_read).get_value());
-            this->num_public_inputs = uint64_t(deserialize_from_frs<FF>(builder, elements, num_frs_read).get_value());
-            this->pub_inputs_offset = uint64_t(deserialize_from_frs<FF>(builder, elements, num_frs_read).get_value());
-            this->contains_pairing_point_accumulator =
-                bool(deserialize_from_frs<FF>(builder, elements, num_frs_read).get_value());
+            this->circuit_size = deserialize_from_frs<FF>(builder, elements, num_frs_read);
+            this->num_public_inputs = deserialize_from_frs<FF>(builder, elements, num_frs_read);
+            this->pub_inputs_offset = deserialize_from_frs<FF>(builder, elements, num_frs_read);
+            this->contains_pairing_point_accumulator = deserialize_from_frs<FF>(builder, elements, num_frs_read);
 
             for (uint32_t& idx : this->pairing_point_accumulator_public_input_indices) {
                 idx = uint32_t(deserialize_from_frs<FF>(builder, elements, num_frs_read).get_value());

--- a/barretenberg/cpp/src/barretenberg/stdlib_circuit_builders/ultra_recursive_flavor.hpp
+++ b/barretenberg/cpp/src/barretenberg/stdlib_circuit_builders/ultra_recursive_flavor.hpp
@@ -129,8 +129,7 @@ template <typename BuilderType> class UltraRecursiveFlavor_ {
             this->log_circuit_size = FF::from_witness(builder, numeric::get_msb(native_key->circuit_size));
             this->num_public_inputs = FF::from_witness(builder, native_key->num_public_inputs);
             this->pub_inputs_offset = FF::from_witness(builder, native_key->pub_inputs_offset);
-            this->contains_pairing_point_accumulator =
-                FF::from_witness(builder, native_key->contains_pairing_point_accumulator);
+            this->contains_pairing_point_accumulator = native_key->contains_pairing_point_accumulator;
             this->pairing_point_accumulator_public_input_indices =
                 native_key->pairing_point_accumulator_public_input_indices;
 
@@ -155,7 +154,8 @@ template <typename BuilderType> class UltraRecursiveFlavor_ {
             this->circuit_size = deserialize_from_frs<FF>(builder, elements, num_frs_read);
             this->num_public_inputs = deserialize_from_frs<FF>(builder, elements, num_frs_read);
             this->pub_inputs_offset = deserialize_from_frs<FF>(builder, elements, num_frs_read);
-            this->contains_pairing_point_accumulator = deserialize_from_frs<FF>(builder, elements, num_frs_read);
+            this->contains_pairing_point_accumulator =
+                bool(deserialize_from_frs<FF>(builder, elements, num_frs_read).get_value());
 
             for (uint32_t& idx : this->pairing_point_accumulator_public_input_indices) {
                 idx = uint32_t(deserialize_from_frs<FF>(builder, elements, num_frs_read).get_value());

--- a/barretenberg/cpp/src/barretenberg/stdlib_circuit_builders/ultra_rollup_flavor.hpp
+++ b/barretenberg/cpp/src/barretenberg/stdlib_circuit_builders/ultra_rollup_flavor.hpp
@@ -38,7 +38,7 @@ class UltraRollupFlavor : public bb::UltraFlavor {
      * that, and split out separate PrecomputedPolynomials/Commitments data for clarity but also for portability of our
      * circuits.
      */
-    class VerificationKey : public VerificationKey_<PrecomputedEntities<Commitment>, VerifierCommitmentKey> {
+    class VerificationKey : public VerificationKey_<uint64_t, PrecomputedEntities<Commitment>, VerifierCommitmentKey> {
       public:
         virtual ~VerificationKey() = default;
         bool contains_ipa_claim;

--- a/barretenberg/cpp/src/barretenberg/stdlib_circuit_builders/ultra_rollup_recursive_flavor.hpp
+++ b/barretenberg/cpp/src/barretenberg/stdlib_circuit_builders/ultra_rollup_recursive_flavor.hpp
@@ -51,7 +51,7 @@ template <typename BuilderType> class UltraRollupRecursiveFlavor_ : public Ultra
      * circuits.
      */
     class VerificationKey
-        : public VerificationKey_<UltraFlavor::PrecomputedEntities<Commitment>, VerifierCommitmentKey> {
+        : public VerificationKey_<FF, UltraFlavor::PrecomputedEntities<Commitment>, VerifierCommitmentKey> {
       public:
         bool contains_ipa_claim;                                // needs to be a circuit constant
         IPAClaimPubInputIndices ipa_claim_public_input_indices; // needs to be a circuit constant
@@ -74,11 +74,13 @@ template <typename BuilderType> class UltraRollupRecursiveFlavor_ : public Ultra
             , ipa_claim_public_input_indices(native_key->ipa_claim_public_input_indices)
         {
             this->pcs_verification_key = native_key->pcs_verification_key;
-            this->circuit_size = native_key->circuit_size;
-            this->log_circuit_size = numeric::get_msb(this->circuit_size);
-            this->num_public_inputs = native_key->num_public_inputs;
-            this->pub_inputs_offset = native_key->pub_inputs_offset;
-            this->contains_pairing_point_accumulator = native_key->contains_pairing_point_accumulator;
+            this->circuit_size = FF::from_witness(builder, native_key->circuit_size);
+            // TODO(https://github.com/AztecProtocol/barretenberg/issues/1283): Use stdlib get_msb.
+            this->log_circuit_size = FF::from_witness(builder, numeric::get_msb(native_key->circuit_size));
+            this->num_public_inputs = FF::from_witness(builder, native_key->num_public_inputs);
+            this->pub_inputs_offset = FF::from_witness(builder, native_key->pub_inputs_offset);
+            this->contains_pairing_point_accumulator =
+                FF::from_witness(builder, native_key->contains_pairing_point_accumulator);
             this->pairing_point_accumulator_public_input_indices =
                 native_key->pairing_point_accumulator_public_input_indices;
 
@@ -100,11 +102,10 @@ template <typename BuilderType> class UltraRollupRecursiveFlavor_ : public Ultra
 
             size_t num_frs_read = 0;
 
-            this->circuit_size = uint64_t(deserialize_from_frs<FF>(builder, elements, num_frs_read).get_value());
-            this->num_public_inputs = uint64_t(deserialize_from_frs<FF>(builder, elements, num_frs_read).get_value());
-            this->pub_inputs_offset = uint64_t(deserialize_from_frs<FF>(builder, elements, num_frs_read).get_value());
-            this->contains_pairing_point_accumulator =
-                bool(deserialize_from_frs<FF>(builder, elements, num_frs_read).get_value());
+            this->circuit_size = deserialize_from_frs<FF>(builder, elements, num_frs_read);
+            this->num_public_inputs = deserialize_from_frs<FF>(builder, elements, num_frs_read);
+            this->pub_inputs_offset = deserialize_from_frs<FF>(builder, elements, num_frs_read);
+            this->contains_pairing_point_accumulator = deserialize_from_frs<FF>(builder, elements, num_frs_read);
             for (uint32_t& idx : this->pairing_point_accumulator_public_input_indices) {
                 idx = uint32_t(deserialize_from_frs<FF>(builder, elements, num_frs_read).get_value());
             }

--- a/barretenberg/cpp/src/barretenberg/stdlib_circuit_builders/ultra_rollup_recursive_flavor.hpp
+++ b/barretenberg/cpp/src/barretenberg/stdlib_circuit_builders/ultra_rollup_recursive_flavor.hpp
@@ -79,8 +79,7 @@ template <typename BuilderType> class UltraRollupRecursiveFlavor_ : public Ultra
             this->log_circuit_size = FF::from_witness(builder, numeric::get_msb(native_key->circuit_size));
             this->num_public_inputs = FF::from_witness(builder, native_key->num_public_inputs);
             this->pub_inputs_offset = FF::from_witness(builder, native_key->pub_inputs_offset);
-            this->contains_pairing_point_accumulator =
-                FF::from_witness(builder, native_key->contains_pairing_point_accumulator);
+            this->contains_pairing_point_accumulator = native_key->contains_pairing_point_accumulator;
             this->pairing_point_accumulator_public_input_indices =
                 native_key->pairing_point_accumulator_public_input_indices;
 
@@ -105,7 +104,8 @@ template <typename BuilderType> class UltraRollupRecursiveFlavor_ : public Ultra
             this->circuit_size = deserialize_from_frs<FF>(builder, elements, num_frs_read);
             this->num_public_inputs = deserialize_from_frs<FF>(builder, elements, num_frs_read);
             this->pub_inputs_offset = deserialize_from_frs<FF>(builder, elements, num_frs_read);
-            this->contains_pairing_point_accumulator = deserialize_from_frs<FF>(builder, elements, num_frs_read);
+            this->contains_pairing_point_accumulator =
+                bool(deserialize_from_frs<FF>(builder, elements, num_frs_read).get_value());
             for (uint32_t& idx : this->pairing_point_accumulator_public_input_indices) {
                 idx = uint32_t(deserialize_from_frs<FF>(builder, elements, num_frs_read).get_value());
             }

--- a/barretenberg/cpp/src/barretenberg/translator_vm/translator_flavor.hpp
+++ b/barretenberg/cpp/src/barretenberg/translator_vm/translator_flavor.hpp
@@ -693,7 +693,7 @@ class TranslatorFlavor {
      * resolve that, and split out separate PrecomputedPolynomials/Commitments data for clarity but also for
      * portability of our circuits.
      */
-    class VerificationKey : public VerificationKey_<PrecomputedEntities<Commitment>, VerifierCommitmentKey> {
+    class VerificationKey : public VerificationKey_<uint64_t, PrecomputedEntities<Commitment>, VerifierCommitmentKey> {
       public:
         VerificationKey() = default;
         VerificationKey(const size_t circuit_size, const size_t num_public_inputs)

--- a/barretenberg/cpp/src/barretenberg/translator_vm/translator_flavor.hpp
+++ b/barretenberg/cpp/src/barretenberg/translator_vm/translator_flavor.hpp
@@ -140,7 +140,7 @@ class TranslatorFlavor {
      * @brief A base class labelling precomputed entities and (ordered) subsets of interest.
      * @details Used to build the proving key and verification key.
      */
-    template <typename DataType_> class PrecomputedEntities : public PrecomputedEntitiesBase {
+    template <typename DataType_> class PrecomputedEntities {
       public:
         using DataType = DataType_;
         DEFINE_FLAVOR_MEMBERS(DataType,

--- a/barretenberg/cpp/src/barretenberg/translator_vm/translator_flavor.hpp
+++ b/barretenberg/cpp/src/barretenberg/translator_vm/translator_flavor.hpp
@@ -142,6 +142,7 @@ class TranslatorFlavor {
      */
     template <typename DataType_> class PrecomputedEntities {
       public:
+        bool operator==(const PrecomputedEntities& other) const = default;
         using DataType = DataType_;
         DEFINE_FLAVOR_MEMBERS(DataType,
                               ordered_extra_range_constraints_numerator, // column 0

--- a/barretenberg/cpp/src/barretenberg/vm/avm/generated/flavor.cpp
+++ b/barretenberg/cpp/src/barretenberg/vm/avm/generated/flavor.cpp
@@ -87,16 +87,13 @@ AvmFlavor::PartiallyEvaluatedMultivariates::PartiallyEvaluatedMultivariates(cons
 
 AvmFlavor::ProvingKey::ProvingKey(const size_t circuit_size, const size_t num_public_inputs)
     : circuit_size(circuit_size)
+    , log_circuit_size(numeric::get_msb(circuit_size))
+    , num_public_inputs(num_public_inputs)
     , evaluation_domain(bb::EvaluationDomain<FF>(circuit_size, circuit_size))
-    , commitment_key(std::make_shared<CommitmentKey>(circuit_size + 1))
-{
-    // TODO: These come from PrecomputedEntitiesBase, ideal we'd just call that class's constructor.
-    this->log_circuit_size = numeric::get_msb(circuit_size);
-    this->num_public_inputs = num_public_inputs;
-
-    // The proving key's polynomials are not allocated here because they are later overwritten
-    // AvmComposer::compute_witness(). We should probably refactor this flow.
-};
+    , commitment_key(std::make_shared<CommitmentKey>(circuit_size + 1)){
+        // The proving key's polynomials are not allocated here because they are later overwritten
+        // AvmComposer::compute_witness(). We should probably refactor this flow.
+    };
 
 /**
  * @brief Serialize verification key to field elements

--- a/barretenberg/cpp/src/barretenberg/vm/avm/generated/flavor.hpp
+++ b/barretenberg/cpp/src/barretenberg/vm/avm/generated/flavor.hpp
@@ -222,7 +222,7 @@ class AvmFlavor {
                   "AVM circuit. In this case, modify AVM_VERIFICATION_LENGTH_IN_FIELDS \n"
                   "in constants.nr accordingly.");
 
-    template <typename DataType> class PrecomputedEntities : public PrecomputedEntitiesBase {
+    template <typename DataType> class PrecomputedEntities {
       public:
         DEFINE_FLAVOR_MEMBERS(DataType, AVM_PRECOMPUTED_ENTITIES)
         DEFINE_GETTERS(DEFAULT_GETTERS, AVM_PRECOMPUTED_ENTITIES)
@@ -297,6 +297,8 @@ class AvmFlavor {
         ProvingKey(const size_t circuit_size, const size_t num_public_inputs);
 
         size_t circuit_size;
+        size_t log_circuit_size;
+        size_t num_public_inputs;
         bb::EvaluationDomain<FF> evaluation_domain;
         std::shared_ptr<CommitmentKey> commitment_key;
 
@@ -313,7 +315,7 @@ class AvmFlavor {
         auto get_to_be_shifted() { return AvmFlavor::get_to_be_shifted<Polynomial>(*this); }
     };
 
-    class VerificationKey : public VerificationKey_<PrecomputedEntities<Commitment>, VerifierCommitmentKey> {
+    class VerificationKey : public VerificationKey_<uint64_t, PrecomputedEntities<Commitment>, VerifierCommitmentKey> {
       public:
         using FF = VerificationKey_::FF;
         static constexpr size_t NUM_PRECOMPUTED_COMMITMENTS = NUM_PRECOMPUTED_ENTITIES;

--- a/barretenberg/cpp/src/barretenberg/vm/avm/generated/recursive_verifier.cpp
+++ b/barretenberg/cpp/src/barretenberg/vm/avm/generated/recursive_verifier.cpp
@@ -34,7 +34,8 @@ Flavor::FF AvmRecursiveVerifier_<Flavor>::evaluate_public_input_column(const std
     auto coefficients = SharedShiftedVirtualZeroesArray<FF>{
         .start_ = 0,
         .end_ = points.size(),
-        .virtual_size_ = key->circuit_size, // NOLINTNEXTLINE(cppcoreguidelines-avoid-c-arrays)
+        .virtual_size_ =
+            static_cast<uint32_t>(key->circuit_size.get_value()), // NOLINTNEXTLINE(cppcoreguidelines-avoid-c-arrays)
         .backing_memory_ = std::static_pointer_cast<FF[]>(get_mem_slab(sizeof(FF) * points.size())),
     };
 
@@ -87,7 +88,7 @@ AvmRecursiveVerifier_<Flavor>::AggregationObject AvmRecursiveVerifier_<Flavor>::
     VerifierCommitments commitments{ key };
 
     const auto circuit_size = transcript->template receive_from_prover<FF>("circuit_size");
-    if (static_cast<uint32_t>(circuit_size.get_value()) != key->circuit_size) {
+    if (static_cast<uint32_t>(circuit_size.get_value()) != static_cast<uint32_t>(key->circuit_size.get_value())) {
         throw_or_abort("AvmRecursiveVerifier::verify_proof: proof circuit size does not match verification key!");
     }
 

--- a/barretenberg/cpp/src/barretenberg/vm/avm/recursion/recursive_flavor.hpp
+++ b/barretenberg/cpp/src/barretenberg/vm/avm/recursion/recursive_flavor.hpp
@@ -55,7 +55,7 @@ template <typename BuilderType> class AvmRecursiveFlavor_ {
     };
 
     class VerificationKey
-        : public VerificationKey_<bb::avm::AvmFlavor::PrecomputedEntities<Commitment>, VerifierCommitmentKey> {
+        : public VerificationKey_<FF, bb::avm::AvmFlavor::PrecomputedEntities<Commitment>, VerifierCommitmentKey> {
       public:
         VerificationKey(CircuitBuilder* builder, const std::shared_ptr<NativeVerificationKey>& native_key)
         {

--- a/barretenberg/cpp/src/barretenberg/vm/avm/recursion/recursive_flavor.hpp
+++ b/barretenberg/cpp/src/barretenberg/vm/avm/recursion/recursive_flavor.hpp
@@ -60,9 +60,9 @@ template <typename BuilderType> class AvmRecursiveFlavor_ {
         VerificationKey(CircuitBuilder* builder, const std::shared_ptr<NativeVerificationKey>& native_key)
         {
             this->pcs_verification_key = native_key->pcs_verification_key;
-            this->circuit_size = native_key->circuit_size;
-            this->log_circuit_size = numeric::get_msb(this->circuit_size);
-            this->num_public_inputs = native_key->num_public_inputs;
+            this->circuit_size = FF::from_witness(builder, native_key->circuit_size);
+            this->log_circuit_size = FF::from_witness(builder, numeric::get_msb(native_key->circuit_size));
+            this->num_public_inputs = FF::from_witness(builder, native_key->num_public_inputs);
 
             for (auto [native_comm, comm] : zip_view(native_key->get_all(), this->get_all())) {
                 comm = Commitment::from_witness(builder, native_comm);

--- a/barretenberg/cpp/src/barretenberg/vm/avm/tests/recursive_verifier.test.cpp
+++ b/barretenberg/cpp/src/barretenberg/vm/avm/tests/recursive_verifier.test.cpp
@@ -131,8 +131,9 @@ TEST_F(AvmRecursiveTests, recursion)
         EXPECT_EQ(key_el, rec_key_el.get_value());
     }
 
-    EXPECT_EQ(verifier.key->circuit_size, recursive_verifier.key->circuit_size);
-    EXPECT_EQ(verifier.key->num_public_inputs, recursive_verifier.key->num_public_inputs);
+    EXPECT_EQ(verifier.key->circuit_size, static_cast<uint64_t>(recursive_verifier.key->circuit_size.get_value()));
+    EXPECT_EQ(verifier.key->num_public_inputs,
+              static_cast<uint64_t>(recursive_verifier.key->num_public_inputs.get_value()));
 
     // Make a proof of the verification of an AVM proof
     const size_t srs_size = 1 << 23;

--- a/barretenberg/cpp/src/barretenberg/vm2/generated/flavor.cpp
+++ b/barretenberg/cpp/src/barretenberg/vm2/generated/flavor.cpp
@@ -87,16 +87,13 @@ AvmFlavor::PartiallyEvaluatedMultivariates::PartiallyEvaluatedMultivariates(cons
 
 AvmFlavor::ProvingKey::ProvingKey(const size_t circuit_size, const size_t num_public_inputs)
     : circuit_size(circuit_size)
+    , log_circuit_size(numeric::get_msb(circuit_size))
+    , num_public_inputs(num_public_inputs)
     , evaluation_domain(bb::EvaluationDomain<FF>(circuit_size, circuit_size))
-    , commitment_key(std::make_shared<CommitmentKey>(circuit_size + 1))
-{
-    // TODO: These come from PrecomputedEntitiesBase, ideal we'd just call that class's constructor.
-    this->log_circuit_size = numeric::get_msb(circuit_size);
-    this->num_public_inputs = num_public_inputs;
-
-    // The proving key's polynomials are not allocated here because they are later overwritten
-    // AvmComposer::compute_witness(). We should probably refactor this flow.
-};
+    , commitment_key(std::make_shared<CommitmentKey>(circuit_size + 1)){
+        // The proving key's polynomials are not allocated here because they are later overwritten
+        // AvmComposer::compute_witness(). We should probably refactor this flow.
+    };
 
 /**
  * @brief Serialize verification key to field elements

--- a/barretenberg/cpp/src/barretenberg/vm2/generated/flavor.hpp
+++ b/barretenberg/cpp/src/barretenberg/vm2/generated/flavor.hpp
@@ -268,7 +268,7 @@ class AvmFlavor {
         auto get_to_be_shifted() { return AvmFlavor::get_to_be_shifted<Polynomial>(*this); }
     };
 
-    class VerificationKey : public VerificationKey_<PrecomputedEntities<Commitment>, VerifierCommitmentKey> {
+    class VerificationKey : public VerificationKey_<uint64_t, PrecomputedEntities<Commitment>, VerifierCommitmentKey> {
       public:
         using FF = VerificationKey_::FF;
         static constexpr size_t NUM_PRECOMPUTED_COMMITMENTS = NUM_PRECOMPUTED_ENTITIES;

--- a/barretenberg/cpp/src/barretenberg/vm2/generated/flavor.hpp
+++ b/barretenberg/cpp/src/barretenberg/vm2/generated/flavor.hpp
@@ -175,7 +175,7 @@ class AvmFlavor {
         (NUM_WITNESS_ENTITIES + 1) * NUM_FRS_COM + (NUM_ALL_ENTITIES + 1) * NUM_FRS_FR +
         CONST_PROOF_SIZE_LOG_N * (NUM_FRS_COM + NUM_FRS_FR * (BATCHED_RELATION_PARTIAL_LENGTH + 1));
 
-    template <typename DataType> class PrecomputedEntities : public PrecomputedEntitiesBase {
+    template <typename DataType> class PrecomputedEntities {
       public:
         DEFINE_FLAVOR_MEMBERS(DataType, AVM2_PRECOMPUTED_ENTITIES)
         DEFINE_GETTERS(DEFAULT_GETTERS, AVM2_PRECOMPUTED_ENTITIES)
@@ -250,6 +250,8 @@ class AvmFlavor {
         ProvingKey(const size_t circuit_size, const size_t num_public_inputs);
 
         size_t circuit_size;
+        size_t log_circuit_size;
+        size_t num_public_inputs;
         bb::EvaluationDomain<FF> evaluation_domain;
         std::shared_ptr<CommitmentKey> commitment_key;
 

--- a/bb-pilcom/bb-pil-backend/templates/flavor.cpp.hbs
+++ b/bb-pilcom/bb-pil-backend/templates/flavor.cpp.hbs
@@ -86,13 +86,11 @@ AvmFlavor::PartiallyEvaluatedMultivariates::PartiallyEvaluatedMultivariates(cons
 
 AvmFlavor::ProvingKey::ProvingKey(const size_t circuit_size, const size_t num_public_inputs)
     : circuit_size(circuit_size)
+    , log_circuit_size(numeric::get_msb(circuit_size))
+    , num_public_inputs(num_public_inputs)
     , evaluation_domain(bb::EvaluationDomain<FF>(circuit_size, circuit_size))
     , commitment_key(std::make_shared<CommitmentKey>(circuit_size + 1))
 {
-    // TODO: These come from PrecomputedEntitiesBase, ideal we'd just call that class's constructor.
-    this->log_circuit_size = numeric::get_msb(circuit_size);
-    this->num_public_inputs = num_public_inputs;
-
     // The proving key's polynomials are not allocated here because they are later overwritten
     // AvmComposer::compute_witness(). We should probably refactor this flow.
 };

--- a/bb-pilcom/bb-pil-backend/templates/flavor.hpp.hbs
+++ b/bb-pilcom/bb-pil-backend/templates/flavor.hpp.hbs
@@ -135,7 +135,7 @@ class AvmFlavor {
                   "in constants.nr accordingly.");
     {{/if}}
 
-    template <typename DataType> class PrecomputedEntities : public PrecomputedEntitiesBase {
+    template <typename DataType> class PrecomputedEntities {
       public:
         DEFINE_FLAVOR_MEMBERS(DataType, {{shoutySnakeCase name}}_PRECOMPUTED_ENTITIES)
         DEFINE_GETTERS(DEFAULT_GETTERS, {{shoutySnakeCase name}}_PRECOMPUTED_ENTITIES)
@@ -212,6 +212,8 @@ class AvmFlavor {
         ProvingKey(const size_t circuit_size, const size_t num_public_inputs);
 
         size_t circuit_size;
+        size_t log_circuit_size;
+        size_t num_public_inputs;
         bb::EvaluationDomain<FF> evaluation_domain;
         std::shared_ptr<CommitmentKey> commitment_key;
 
@@ -228,7 +230,7 @@ class AvmFlavor {
         auto get_to_be_shifted() { return AvmFlavor::get_to_be_shifted<Polynomial>(*this); }
     };
 
-    class VerificationKey : public VerificationKey_<PrecomputedEntities<Commitment>, VerifierCommitmentKey> {
+    class VerificationKey : public VerificationKey_<uint64_t, PrecomputedEntities<Commitment>, VerifierCommitmentKey> {
       public:
        using FF = VerificationKey_::FF;
        static constexpr size_t NUM_PRECOMPUTED_COMMITMENTS = NUM_PRECOMPUTED_ENTITIES;


### PR DESCRIPTION
Closes https://github.com/AztecProtocol/barretenberg/issues/983.

Makes the vk metadata witnesses instead of native types. I think only circuit_size actually needs to be a witness, but its fine to make them all witnesses. Still a lot of security concerns around this area since there's missing constraints with these witnesses.