### PR TITLE
fix: port forwarding in upgrade rollup test

### DIFF
--- a/yarn-project/end-to-end/src/spartan/upgrade_rollup_version.test.ts
+++ b/yarn-project/end-to-end/src/spartan/upgrade_rollup_version.test.ts
@@ -287,7 +287,7 @@ describe('spartan_upgrade_rollup_version', () => {
       // Now delete all the pods, forcing them to restart on the new rollup
       await rollAztecPods(config.NAMESPACE);
 
-      // restart the port forward
+      // start a new port forward
       const { process: pxeProcess, port: pxePort } = await startPortForward({
         resource: `svc/${config.INSTANCE_NAME}-aztec-network-pxe`,
         namespace: config.NAMESPACE,


### PR DESCRIPTION
We were connecting using the old port forward, which only sometimes worked.