### PR TITLE
fix: mass tag push scenario

### DIFF
--- a/.github/workflows/ci3.yml
+++ b/.github/workflows/ci3.yml
@@ -14,9 +14,12 @@ on:
   merge_group: {}
 
 concurrency:
-  # On PR's the group id is the ref_name so only 1 can run at a time.
+  # If we are pushing a tag, we are doing a release - we should only ever have one of those at a time, globally!
+  # On PR's the group id is the ref_name so only 1 can run at a time per PR.
   group: |
-    ci3-${{ github.event_name == 'pull_request' && github.ref_name || github.run_id }}
+    ci3-${{ startsWith(github.ref, 'refs/tags/') && 'release' 
+                                                 || (github.event_name == 'pull_request' && github.ref_name 
+                                                                                         || github.run_id) }}
   cancel-in-progress: true
 
 jobs:

--- a/.github/workflows/ci3.yml
+++ b/.github/workflows/ci3.yml
@@ -18,8 +18,8 @@ concurrency:
   # On PR's the group id is the ref_name so only 1 can run at a time per PR.
   group: |
     ci3-${{ startsWith(github.ref, 'refs/tags/v') && 'release' 
-                                                 || (github.event_name == 'pull_request' && github.ref_name 
-                                                                                         || github.run_id) }}
+                                                  || (github.event_name == 'pull_request' && github.ref_name 
+                                                                                          || github.run_id) }}
   cancel-in-progress: true
 
 jobs:

--- a/.github/workflows/ci3.yml
+++ b/.github/workflows/ci3.yml
@@ -14,7 +14,7 @@ on:
   merge_group: {}
 
 concurrency:
-  # If we are pushing a tag, we are doing a release - we should only ever have one of those at a time, globally!
+  # If we are pushing a tag, we are doing a release - we should only ever have 1 of those at a time, globally!
   # On PR's the group id is the ref_name so only 1 can run at a time per PR.
   group: |
     ci3-${{ startsWith(github.ref, 'refs/tags/v') && 'release' 

--- a/.github/workflows/ci3.yml
+++ b/.github/workflows/ci3.yml
@@ -17,7 +17,7 @@ concurrency:
   # If we are pushing a tag, we are doing a release - we should only ever have one of those at a time, globally!
   # On PR's the group id is the ref_name so only 1 can run at a time per PR.
   group: |
-    ci3-${{ startsWith(github.ref, 'refs/tags/') && 'release' 
+    ci3-${{ startsWith(github.ref, 'refs/tags/v') && 'release' 
                                                  || (github.event_name == 'pull_request' && github.ref_name 
                                                                                          || github.run_id) }}
   cancel-in-progress: true


### PR DESCRIPTION
After mass-deleting some tags (which is generally not recommended, but I thought I'd clean up recent work if possible) I realized that this could cause someone to mass re-push the tags, as git doesn't delete them locally after a pull.

Instead, if we are on a git tag starting with 'v', assume we are doing a release and only allow one to go through.

PS: I recommend this setting if doing manual releases:

```
git config fetch.pruneTags true
```