### PR TITLE
fix: patch the kubeconfig in ci for kind cluster

### DIFF
--- a/spartan/bootstrap.sh
+++ b/spartan/bootstrap.sh
@@ -79,7 +79,9 @@ case "$cmd" in
       # Sometimes, kubectl does not have our kind context yet kind registers it as existing
       # Ensure our context exists in kubectl
       # As well if kind-control-plane has been killed, just recreate the cluster
-      flock scripts/logs/kind-boot.lock bash -c "kind delete cluster; kind create cluster --config scripts/kind-config.yaml --api-server-address '127.0.0.1'"
+      flock scripts/logs/kind-boot.lock bash -c "kind delete cluster; kind create cluster --config scripts/kind-config.yaml"
+      # Patch the kubeconfig to replace any invalid API server address (0.0.0.0) with 127.0.0.1
+      sed -i 's/https:\/\/0\.0\.0\.0:/https:\/\/127.0.0.1:/' "$HOME/.kube/config"
     fi
     kubectl config use-context kind-kind >/dev/null || true
     docker update --restart=no kind-control-plane >/dev/null || true

--- a/spartan/bootstrap.sh
+++ b/spartan/bootstrap.sh
@@ -79,7 +79,7 @@ case "$cmd" in
       # Sometimes, kubectl does not have our kind context yet kind registers it as existing
       # Ensure our context exists in kubectl
       # As well if kind-control-plane has been killed, just recreate the cluster
-      flock scripts/logs/kind-boot.lock bash -c "kind delete cluster; kind create cluster --config scripts/kind-config.yaml"
+      flock scripts/logs/kind-boot.lock bash -c "kind delete cluster; kind create cluster --config scripts/kind-config.yaml --api-server-address '127.0.0.1'"
     fi
     kubectl config use-context kind-kind >/dev/null || true
     docker update --restart=no kind-control-plane >/dev/null || true


### PR DESCRIPTION
Sometimes kubeconfigs get generated with 0.0.0.0 as the address for the `kind-kind` cluster, which sometimes breaks with the TLS config. 

