### PR TITLE
chore: Add noinitcheck comment to schnorr account

### DIFF
--- a/noir-projects/noir-contracts/contracts/schnorr_account_contract/src/main.nr
+++ b/noir-projects/noir-contracts/contracts/schnorr_account_contract/src/main.nr
@@ -44,6 +44,7 @@ pub contract SchnorrAccount {
     }
 
     // Note: If you globally change the entrypoint signature don't forget to update account_entrypoint.ts file
+    // using noinitcheck is an optimization, it reduces gates by omitting a check that the contract has been initialized
     #[private]
     #[noinitcheck]
     fn entrypoint(app_payload: AppPayload, fee_payload: FeePayload, cancellable: bool) {


### PR DESCRIPTION
Adds a comment about why `noinitcheck` is used on the Schnorr account entrypoint.