### PR TITLE
chore: Fix MEMORY argument to yarn project test run

### DIFF
--- a/yarn-project/bootstrap.sh
+++ b/yarn-project/bootstrap.sh
@@ -106,7 +106,7 @@ function test_cmds {
       echo "$hash ISOLATE=1 yarn-project/scripts/run_test.sh $test"
     else
       # Testbench runs require more memory and CPU.
-      echo "$hash ISOLATE=1 CPUS=18 MEMORY=12g yarn-project/scripts/run_test.sh $test"
+      echo "$hash ISOLATE=1 CPUS=18 MEM=12g yarn-project/scripts/run_test.sh $test"
     fi
 
   done

--- a/yarn-project/scripts/run_test.sh
+++ b/yarn-project/scripts/run_test.sh
@@ -10,7 +10,7 @@ dir=${test%%/*}
 
 # Default to 2 CPUs and 4GB of memory when running with ISOLATE=1.
 CPUS=${CPUS:-2}
-MEMORY=${MEMORY:-4g}
+MEM=${MEM:-4g}
 
 if [ "${ISOLATE:-0}" -eq 1 ]; then
   # Strip leading non alpha numerics and replace / with _ for the container name.
@@ -21,7 +21,7 @@ if [ "${ISOLATE:-0}" -eq 1 ]; then
   docker run --rm \
     ${name_arg:-} \
     --cpus=$CPUS \
-    --memory $MEMORY \
+    --memory $MEM \
     -v$(git rev-parse --show-toplevel):/root/aztec-packages \
     -v$HOME/.bb-crs:/root/.bb-crs \
     --workdir /root/aztec-packages/yarn-project/$dir \


### PR DESCRIPTION
[Here](https://github.com/AztecProtocol/aztec-packages/pull/12283/files#diff-d4325b1e4d1032ba0c018e993395c3f8ceed45001f4ced5388977b2c90c26618) the argument for setting max memory for a yarn project test was changed from MEM to MEMORY, which broke tests that dependend on it.

This PR rolls it back to MEM, for consistency with other scripts.
