### PR TITLE
fix: override bb path in cli-wallet PXE config

### DIFF
--- a/yarn-project/cli-wallet/src/bin/index.ts
+++ b/yarn-project/cli-wallet/src/bin/index.ts
@@ -2,6 +2,7 @@ import { Fr, computeSecretHash, fileURLToPath } from '@aztec/aztec.js';
 import { LOCALHOST } from '@aztec/cli/cli-utils';
 import { type LogFn, createConsoleLogger, createLogger } from '@aztec/foundation/log';
 import { openStoreAt } from '@aztec/kv-store/lmdb-v2';
+import type { PXEServiceConfig } from '@aztec/pxe/config';
 
 import { Argument, Command, Option } from 'commander';
 import { mkdirSync, readFileSync } from 'fs';
@@ -94,18 +95,22 @@ async function main() {
       if (!remotePxe) {
         debugLogger.info('Using local PXE service');
 
+        const proverEnabled = prover !== 'none';
+
         const bbBinaryPath =
           prover === 'native'
             ? resolve(dirname(fileURLToPath(import.meta.url)), '../../../../barretenberg/cpp/build/bin/bb')
             : undefined;
         const bbWorkingDirectory = dataDir + '/bb';
-        const proverEnabled = prover !== 'none';
-
         mkdirSync(bbWorkingDirectory, { recursive: true });
 
-        await pxeWrapper.init(nodeUrl, join(dataDir, 'pxe'), {
-          ...(proverEnabled && { proverEnabled, bbBinaryPath, bbWorkingDirectory }), // only override if we're profiling
-        });
+        const overridePXEConfig: Partial<PXEServiceConfig> = {
+          proverEnabled,
+          bbBinaryPath: prover === 'native' ? bbBinaryPath : undefined,
+          bbWorkingDirectory: prover === 'native' ? bbWorkingDirectory : undefined,
+        };
+
+        await pxeWrapper.init(nodeUrl, join(dataDir, 'pxe'), overridePXEConfig);
       }
       await db.init(await openStoreAt(dataDir));
     });


### PR DESCRIPTION
Set `bbBinaryPath` and `bbWorkingDirectory` only when `PXE_PROVER=native`

cli-wallet sets its own bbPath and bbWorkdir when `PXE_PROVER=native`, but PXE also read these values from env even when `PXE_PROVER=none`. This is happening in release image as we now [set these ENVs ](https://github.com/AztecProtocol/aztec-packages/blob/master/release-image/Dockerfile#L35-L36)in Dockerfile.
This PR overrides the values from ENV and unset them if proving is not needed.

(This is only a patch. Need to refactor later)