### PR TITLE
chore(node): return correct node version

### DIFF
--- a/yarn-project/aztec-node/src/aztec-node/config.ts
+++ b/yarn-project/aztec-node/src/aztec-node/config.ts
@@ -59,10 +59,13 @@ export function getConfigEnvVars(): AztecNodeConfig {
 }
 
 /**
- * Returns package name and version.
+ * Returns package version.
  */
-export function getPackageInfo() {
-  const packageJsonPath = resolve(dirname(fileURLToPath(import.meta.url)), '../../package.json');
-  const { version, name } = JSON.parse(readFileSync(packageJsonPath).toString());
-  return { version, name };
+export function getPackageVersion() {
+  const releasePleaseManifestPath = resolve(
+    dirname(fileURLToPath(import.meta.url)),
+    '../../../../.release-please-manifest.json',
+  );
+  const version = JSON.parse(readFileSync(releasePleaseManifestPath).toString());
+  return version['.'];
 }

--- a/yarn-project/aztec-node/src/aztec-node/server.test.ts
+++ b/yarn-project/aztec-node/src/aztec-node/server.test.ts
@@ -16,7 +16,10 @@ import { mockTx } from '@aztec/stdlib/testing';
 import { MerkleTreeId, PublicDataTreeLeafPreimage } from '@aztec/stdlib/trees';
 import { BlockHeader, GlobalVariables, MaxBlockNumber } from '@aztec/stdlib/tx';
 
+import { readFileSync } from 'fs';
 import { type MockProxy, mock } from 'jest-mock-extended';
+import { dirname, resolve } from 'path';
+import { fileURLToPath } from 'url';
 
 import { type AztecNodeConfig, getConfigEnvVars } from './config.js';
 import { AztecNodeService } from './server.js';
@@ -201,6 +204,18 @@ describe('aztec node', () => {
       });
       // Tx with max block number >= current block number should be valid
       expect(await node.isValidTx(validMaxBlockNumberMetadata)).toEqual({ result: 'valid' });
+    });
+  });
+
+  describe('Node Info', () => {
+    it('returns the correct node version', async () => {
+      const releasePleaseVersionFile = readFileSync(
+        resolve(dirname(fileURLToPath(import.meta.url)), '../../../../.release-please-manifest.json'),
+      ).toString();
+      const releasePleaseVersion = JSON.parse(releasePleaseVersionFile)['.'];
+
+      const nodeInfo = await node.getNodeInfo();
+      expect(nodeInfo.nodeVersion).toBe(releasePleaseVersion);
     });
   });
 

--- a/yarn-project/aztec-node/src/aztec-node/server.ts
+++ b/yarn-project/aztec-node/src/aztec-node/server.ts
@@ -80,7 +80,7 @@ import {
 import { createValidatorClient } from '@aztec/validator-client';
 import { createWorldStateSynchronizer } from '@aztec/world-state';
 
-import { type AztecNodeConfig, getPackageInfo } from './config.js';
+import { type AztecNodeConfig, getPackageVersion } from './config.js';
 import { NodeMetrics } from './node_metrics.js';
 
 /**
@@ -109,10 +109,11 @@ export class AztecNodeService implements AztecNode, Traceable {
     private telemetry: TelemetryClient = getTelemetryClient(),
     private log = createLogger('node'),
   ) {
-    this.packageVersion = getPackageInfo().version;
+    this.packageVersion = getPackageVersion();
     this.metrics = new NodeMetrics(telemetry, 'AztecNodeService');
     this.tracer = telemetry.getTracer('AztecNodeService');
 
+    this.log.info(`Aztec Node version: ${this.packageVersion}`);
     this.log.info(`Aztec Node started on chain 0x${l1ChainId.toString(16)}`, config.l1Contracts);
   }
 


### PR DESCRIPTION
## Overview

Return version from release-please-manifest, which is now included within the container

fixes: https://github.com/AztecProtocol/aztec-packages/issues/11565
