### PR TITLE
chore: Remove scope interpolation from env vars

### DIFF
--- a/yarn-project/sequencer-client/src/publisher/config.ts
+++ b/yarn-project/sequencer-client/src/publisher/config.ts
@@ -46,7 +46,7 @@ export const getTxSenderConfigMappings: (
     defaultValue: EthAddress.ZERO,
   },
   publisherPrivateKey: {
-    env: `${scope}_PUBLISHER_PRIVATE_KEY`,
+    env: scope === 'PROVER' ? `PROVER_PUBLISHER_PRIVATE_KEY` : `SEQ_PUBLISHER_PRIVATE_KEY`,
     description: 'The private key to be used by the publisher.',
     parseEnv: (val: string) => (val ? `0x${val.replace('0x', '')}` : NULL_KEY),
     defaultValue: NULL_KEY,
@@ -61,7 +61,7 @@ export const getPublisherConfigMappings: (
   scope: 'PROVER' | 'SEQ',
 ) => ConfigMappingsType<PublisherConfig & L1TxUtilsConfig> = scope => ({
   l1PublishRetryIntervalMS: {
-    env: `${scope}_PUBLISH_RETRY_INTERVAL_MS`,
+    env: scope === `PROVER` ? `PROVER_PUBLISH_RETRY_INTERVAL_MS` : `SEQ_PUBLISH_RETRY_INTERVAL_MS`,
     parseEnv: (val: string) => +val,
     defaultValue: 1000,
     description: 'The interval to wait between publish retries.',


### PR DESCRIPTION
Makes them easier to find in the codebase.
