### PR TITLE
fix(node): drop log level of handler not registered

### DIFF
--- a/yarn-project/p2p/src/services/libp2p/libp2p_service.ts
+++ b/yarn-project/p2p/src/services/libp2p/libp2p_service.ts
@@ -137,7 +137,7 @@ export class LibP2PService<T extends P2PClientType> extends WithTracer implement
     this.blockProposalValidator = new BlockProposalValidator(epochCache);
 
     this.blockReceivedCallback = async (block: BlockProposal): Promise<BlockAttestation | undefined> => {
-      this.logger.warn(
+      this.logger.debug(
         `Handler not yet registered: Block received callback not set. Received block for slot ${block.slotNumber.toNumber()} from peer.`,
         { p2pMessageIdentifier: await block.p2pMessageIdentifier() },
       );


### PR DESCRIPTION
## Overview

Responding to block proposals is done by the validator client adding a callback into the p2p service.

When running a full node e.g. aztec start without the --sequencer flag this issues warnings everytime there is a block proposal

This change removes these warnings
