### PR TITLE
chore: restore method syntax on `get_storage_slot` calls

### DIFF
--- a/noir-projects/noir-contracts/contracts/test_contract/src/main.nr
+++ b/noir-projects/noir-contracts/contracts/test_contract/src/main.nr
@@ -48,6 +48,7 @@ pub contract Test {
             note_interface::NoteType,
             retrieved_note::RetrievedNote,
         },
+        state_vars::storage::Storage as _,
         test::mocks::mock_struct::MockStruct,
     };
     use dep::token_portal_content_hash_lib::{
@@ -139,8 +140,7 @@ pub contract Test {
         storage_slot: Field,
     ) {
         assert(
-            storage_slot
-                != aztec::state_vars::storage::Storage::get_storage_slot(storage.example_constant),
+            storage_slot != storage.example_constant.get_storage_slot(),
             "this storage slot is reserved for example_constant",
         );
 
@@ -156,8 +156,7 @@ pub contract Test {
     #[private]
     fn call_get_notes(storage_slot: Field, active_or_nullified: bool) -> Field {
         assert(
-            storage_slot
-                != aztec::state_vars::storage::Storage::get_storage_slot(storage.example_constant),
+            storage_slot != storage.example_constant.get_storage_slot(),
             "this storage slot is reserved for example_constant",
         );
 
@@ -177,8 +176,7 @@ pub contract Test {
     #[private]
     fn call_get_notes_many(storage_slot: Field, active_or_nullified: bool) -> [Field; 2] {
         assert(
-            storage_slot
-                != aztec::state_vars::storage::Storage::get_storage_slot(storage.example_constant),
+            storage_slot != storage.example_constant.get_storage_slot(),
             "this storage slot is reserved for example_constant",
         );
 
@@ -195,8 +193,7 @@ pub contract Test {
 
     unconstrained fn call_view_notes(storage_slot: Field, active_or_nullified: bool) -> pub Field {
         assert(
-            storage_slot
-                != aztec::state_vars::storage::Storage::get_storage_slot(storage.example_constant),
+            storage_slot != storage.example_constant.get_storage_slot(),
             "this storage slot is reserved for example_constant",
         );
 
@@ -215,8 +212,7 @@ pub contract Test {
         active_or_nullified: bool,
     ) -> pub [Field; 2] {
         assert(
-            storage_slot
-                != aztec::state_vars::storage::Storage::get_storage_slot(storage.example_constant),
+            storage_slot != storage.example_constant.get_storage_slot(),
             "this storage slot is reserved for example_constant",
         );
 
@@ -233,8 +229,7 @@ pub contract Test {
     #[private]
     fn call_destroy_note(storage_slot: Field) {
         assert(
-            storage_slot
-                != aztec::state_vars::storage::Storage::get_storage_slot(storage.example_constant),
+            storage_slot != storage.example_constant.get_storage_slot(),
             "this storage slot is reserved for example_constant",
         );
 
@@ -376,8 +371,7 @@ pub contract Test {
 
     #[private]
     fn emit_encrypted_logs_nested(value: Field, owner: AztecAddress, sender: AztecAddress) {
-        let mut storage_slot =
-            aztec::state_vars::storage::Storage::get_storage_slot(storage.example_constant) + 1;
+        let mut storage_slot = storage.example_constant.get_storage_slot() + 1;
         Test::at(context.this_address()).call_create_note(value, owner, sender, storage_slot).call(
             &mut context,
         );


### PR DESCRIPTION
Addresses a question brought up by @ludamad in slack