### PR TITLE
chore: various small cleanup issues

### DIFF
--- a/yarn-project/accounts/.prettierignore
+++ b/yarn-project/accounts/.prettierignore
@@ -1,1 +1,0 @@
-artifacts/*.json

--- a/yarn-project/accounts/package.json
+++ b/yarn-project/accounts/package.json
@@ -30,8 +30,7 @@
   },
   "scripts": {
     "build": "yarn clean && yarn generate && tsc -b",
-    "generate": "yarn generate:noir-contracts",
-    "generate:noir-contracts": "./scripts/copy-contracts.sh",
+    "generate": "./scripts/copy-contracts.sh",
     "build:dev": "tsc -b --watch",
     "build:ts": "tsc -b",
     "clean": "rm -rf ./dest .tsbuildinfo ./artifacts",

--- a/yarn-project/accounts/package.local.json
+++ b/yarn-project/accounts/package.local.json
@@ -1,8 +1,7 @@
 {
   "scripts": {
     "build": "yarn clean && yarn generate && tsc -b",
-    "generate": "yarn generate:noir-contracts",
-    "generate:noir-contracts": "./scripts/copy-contracts.sh",
+    "generate": "./scripts/copy-contracts.sh",
     "build:dev": "tsc -b --watch",
     "build:ts": "tsc -b",
     "clean": "rm -rf ./dest .tsbuildinfo ./artifacts"

--- a/yarn-project/aztec.js/src/utils/abi_types.ts
+++ b/yarn-project/aztec.js/src/utils/abi_types.ts
@@ -18,8 +18,5 @@ export type FunctionSelectorLike = FieldLike | FunctionSelector;
 /** Any type that can be converted into an EventSelector Aztec.nr struct. */
 export type EventSelectorLike = FieldLike | EventSelector;
 
-/** Any type that can be converted into a U128. */
-export type U128Like = bigint | number;
-
 /** Any type that can be converted into a struct with a single `inner` field. */
 export type WrappedFieldLike = { /** Wrapped value */ inner: FieldLike } | FieldLike;

--- a/yarn-project/aztec.js/src/utils/index.ts
+++ b/yarn-project/aztec.js/src/utils/index.ts
@@ -5,7 +5,6 @@ export {
   type EventSelectorLike,
   type FieldLike,
   type FunctionSelectorLike,
-  type U128Like,
   type WrappedFieldLike,
 } from './abi_types.js';
 export {

--- a/yarn-project/builder/.prettierignore
+++ b/yarn-project/builder/.prettierignore
@@ -1,1 +1,0 @@
-src/fixtures

--- a/yarn-project/builder/src/contract-interface-gen/typescript.ts
+++ b/yarn-project/builder/src/contract-interface-gen/typescript.ts
@@ -344,7 +344,6 @@ import {
   type PublicKey,
   PublicKeys,
   type Wallet,
-  type U128Like,
   type WrappedFieldLike,
 } from '@aztec/aztec.js';
 ${artifactStatement}

--- a/yarn-project/end-to-end/.prettierignore
+++ b/yarn-project/end-to-end/.prettierignore
@@ -1,3 +1,0 @@
-src/e2e_sandbox_example.test.ts
-src/fixtures/dumps/*.json
-src/web/main.js

--- a/yarn-project/ivc-integration/.prettierignore
+++ b/yarn-project/ivc-integration/.prettierignore
@@ -1,2 +1,0 @@
-crates
-artifacts

--- a/yarn-project/l1-artifacts/.prettierignore
+++ b/yarn-project/l1-artifacts/.prettierignore
@@ -1,1 +1,0 @@
-generated

--- a/yarn-project/noir-bb-bench/.prettierignore
+++ b/yarn-project/noir-bb-bench/.prettierignore
@@ -1,2 +1,0 @@
-crates
-artifacts

--- a/yarn-project/noir-contracts.js/package.json
+++ b/yarn-project/noir-contracts.js/package.json
@@ -14,8 +14,7 @@
     "formatting": "run -T prettier --check ./src && run -T eslint ./src",
     "formatting:fix": "run -T eslint --fix ./src && run -T prettier -w ./src",
     "test": "NODE_NO_WARNINGS=1 node --experimental-vm-modules ../node_modules/.bin/jest --passWithNoTests --maxWorkers=${JEST_MAX_WORKERS:-8}",
-    "generate": "yarn generate:noir-contracts",
-    "generate:noir-contracts": "./scripts/generate-types.sh"
+    "generate": "./scripts/generate-types.sh"
   },
   "inherits": [
     "../package.common.json",

--- a/yarn-project/noir-contracts.js/package.local.json
+++ b/yarn-project/noir-contracts.js/package.local.json
@@ -1,8 +1,7 @@
 {
   "scripts": {
     "build": "yarn clean && yarn generate",
-    "generate": "yarn generate:noir-contracts",
-    "generate:noir-contracts": "./scripts/generate-types.sh",
+    "generate": "./scripts/generate-types.sh",
     "clean": "rm -rf ./dest .tsbuildinfo ./artifacts ./src ./codegenCache.json"
   },
   "files": ["dest", "src", "artifacts", "!*.test.*"]

--- a/yarn-project/noir-protocol-circuits-types/.prettierignore
+++ b/yarn-project/noir-protocol-circuits-types/.prettierignore
@@ -1,2 +1,0 @@
-crates
-artifacts

--- a/yarn-project/protocol-contracts/.prettierignore
+++ b/yarn-project/protocol-contracts/.prettierignore
@@ -1,1 +1,0 @@
-artifacts/*.json


### PR DESCRIPTION
When implementing [this PR](https://github.com/AztecProtocol/aztec-packages/pull/12505) I stumbled upon a few minor issues:
1. plenty of commands in package.json were stale,
2. we had a lot of `.prettierignore` files which were ignored as only the one in `yarn-project` is used,
3. removed U128Like type which is no longer used anywhere and I forgot to remove it in [this PR](https://github.com/AztecProtocol/aztec-packages/pull/12213).
