### PR TITLE
chore: Fix yarn install immutable issues

### DIFF
--- a/yarn-project/.yarnrc.yml
+++ b/yarn-project/.yarnrc.yml
@@ -10,4 +10,4 @@ nodeLinker: node-modules
 
 # Do not allow 'yarn install' on CI to format package.json files,
 # otherwise it will change their hash and bust the cache
-immutablePatterns: ['**/package.json']
+immutablePatterns: ['package.json', '*/package.json']

--- a/yarn-project/bootstrap.sh
+++ b/yarn-project/bootstrap.sh
@@ -92,7 +92,7 @@ function build {
     # files to yarn immutablePatterns, so if they are also changed, this step will fail.
     denoise "retry yarn install --immutable"
   else
-    denoise "yarn install"
+    denoise "yarn install --no-immutable"
   fi
   denoise "compile_all"
   echo -e "${green}Yarn project successfully built!${reset}"


### PR DESCRIPTION
We introduced two issues in #12125 when adding the immutable patterns to yarn install:

- If `immutablePatterns` is set, yarn sets the `immutable` flag even outside CI (contradicting its documentation). This is fixed by explicitly setting `--no-immutable` on the non-CI branch of install.

- The glob `**/package.json` inadvertently matched package.json files within `node_modules`, so installing them created the new files, which means they were flagged as changed. This is fixed by having a less eager glob.

Fixes #12538
