### PR TITLE
chore: rm unused methods

### DIFF
--- a/yarn-project/pxe/src/storage/note_data_provider/note_data_provider.test.ts
+++ b/yarn-project/pxe/src/storage/note_data_provider/note_data_provider.test.ts
@@ -85,20 +85,9 @@ describe('NoteDataProvider', () => {
     }
   });
 
-  it.each(filteringTests)('stores notes in bulk and retrieves notes', async (getFilter, getExpected) => {
+  it.each(filteringTests)('stores notes and retrieves notes', async (getFilter, getExpected) => {
     await noteDataProvider.addNotes(notes);
     const returnedNotes = await noteDataProvider.getNotes(await getFilter());
-    const expected = await getExpected();
-    expect(returnedNotes.sort()).toEqual(expected.sort());
-  });
-
-  it.each(filteringTests)('stores notes one by one and retrieves notes', async (getFilter, getExpected) => {
-    for (const note of notes) {
-      await noteDataProvider.addNote(note);
-    }
-
-    const returnedNotes = await noteDataProvider.getNotes(await getFilter());
-
     const expected = await getExpected();
     expect(returnedNotes.sort()).toEqual(expected.sort());
   });
@@ -188,14 +177,10 @@ describe('NoteDataProvider', () => {
     expect(result.sort()).toEqual([...notes].sort());
   });
 
-  it('stores notes one by one and retrieves notes with siloed account', async () => {
-    for (const note of notes.slice(0, 5)) {
-      await noteDataProvider.addNote(note, owners[0].address);
-    }
+  it('stores notes and retrieves notes with siloed account', async () => {
+    await noteDataProvider.addNotes(notes, owners[0].address);
 
-    for (const note of notes.slice(5)) {
-      await noteDataProvider.addNote(note, owners[1].address);
-    }
+    await noteDataProvider.addNotes(notes.slice(5), owners[1].address);
 
     const owner0Notes = await noteDataProvider.getNotes({
       scopes: [owners[0].address],
@@ -217,8 +202,8 @@ describe('NoteDataProvider', () => {
   });
 
   it('a nullified note removes notes from all accounts in the pxe', async () => {
-    await noteDataProvider.addNote(notes[0], owners[0].address);
-    await noteDataProvider.addNote(notes[0], owners[1].address);
+    await noteDataProvider.addNotes([notes[0]], owners[0].address);
+    await noteDataProvider.addNotes([notes[0]], owners[1].address);
 
     await expect(
       noteDataProvider.getNotes({

--- a/yarn-project/pxe/src/storage/note_data_provider/note_data_provider.test.ts
+++ b/yarn-project/pxe/src/storage/note_data_provider/note_data_provider.test.ts
@@ -178,7 +178,7 @@ describe('NoteDataProvider', () => {
   });
 
   it('stores notes and retrieves notes with siloed account', async () => {
-    await noteDataProvider.addNotes(notes, owners[0].address);
+    await noteDataProvider.addNotes(notes.slice(0, 5), owners[0].address);
 
     await noteDataProvider.addNotes(notes.slice(5), owners[1].address);
 

--- a/yarn-project/pxe/src/storage/note_data_provider/note_data_provider.ts
+++ b/yarn-project/pxe/src/storage/note_data_provider/note_data_provider.ts
@@ -84,10 +84,6 @@ export class NoteDataProvider implements DataProvider {
     return true;
   }
 
-  async addNote(note: NoteDao, scope?: AztecAddress): Promise<void> {
-    await this.addNotes([note], scope);
-  }
-
   async addNotes(notes: NoteDao[], scope: AztecAddress = AztecAddress.ZERO): Promise<void> {
     if (!(await this.#scopes.hasAsync(scope.toString()))) {
       await this.addScope(scope);
@@ -341,16 +337,6 @@ export class NoteDataProvider implements DataProvider {
       }
       return nullifiedNotes;
     });
-  }
-
-  async addNullifiedNote(note: NoteDao): Promise<void> {
-    const noteIndex = toBufferBE(note.index, 32).toString('hex');
-
-    await this.#nullifiedNotes.set(noteIndex, note.toBuffer());
-    await this.#nullifiedNotesByContract.set(note.contractAddress.toString(), noteIndex);
-    await this.#nullifiedNotesByStorageSlot.set(note.storageSlot.toString(), noteIndex);
-    await this.#nullifiedNotesByTxHash.set(note.txHash.toString(), noteIndex);
-    await this.#nullifiedNotesByAddressPoint.set(note.addressPoint.toString(), noteIndex);
   }
 
   async getSize() {


### PR DESCRIPTION
We got rid of `addNullifiedNote` in https://github.com/AztecProtocol/aztec-packages/pull/11822, I imagine it accidentally came back in the recent refactors.

I also got rid of `addNote` since we always use `addNotes` anyway.