### PR TITLE
feat: nullify just-added notes

### DIFF
--- a/yarn-project/pxe/src/pxe_oracle_interface/index.ts
+++ b/yarn-project/pxe/src/pxe_oracle_interface/index.ts
@@ -717,10 +717,11 @@ export class PXEOracleInterface implements ExecutionDataProvider {
     // in time of the locally synced state.
     // Note that while this technically results in historical queries, we perform it at the latest locally synced block
     // number which *should* be recent enough to be available, even for non-archive nodes.
-    const syncedBlockNumber = await this.syncDataProvider.getBlockNumber();
-    if (syncedBlockNumber === undefined) {
-      throw new Error(`Attempted to deliver a note with an unsynchronized PXE - this should never happen`);
-    }
+    const syncedBlockNumber = (await this.syncDataProvider.getBlockNumber())!;
+    // TODO (#12559): handle undefined syncedBlockNumber
+    // if (syncedBlockNumber === undefined) {
+    //  throw new Error(`Attempted to deliver a note with an unsynchronized PXE - this should never happen`);
+    //}
 
     // By computing siloed and unique note hashes ourselves we prevent contracts from interfering with the note storage
     // of other contracts, which would constitute a security breach.


### PR DESCRIPTION
Back when PXE was a service processing all blocks, we'd remove nullified notes as we saw their nullifiers. This later got changed, and as of https://github.com/AztecProtocol/aztec-packages/pull/10722 we remove all nullified notes whenever we 'sync' notes. However, note syncing is becoming less and less a part of PXE, and as of https://github.com/AztecProtocol/aztec-packages/pull/12391 we even deliver notes _outside_ of the PXE-led note syncing process (whenever we complete partial note). This causes problems because we end up adding notes, failing to realize they've been nullified and then returning them via `get_notes` (which is what causes some tests in https://github.com/AztecProtocol/aztec-packages/pull/12391 to fail). The next time a contract function is run we'll do note syncing again and they'll be then removed, but we did have a full fn call in which they were available.

This PR makes it so we always check if newly-added notes have been nullified, and remove them if so. I also added some explanations re. why we're doing things this way, created some follow-up issues (mostly #12550 and https://github.com/AztecProtocol/aztec-packages/issues/12553), and inlined `produceNoteDaos` to have the whole thing happen in a single place. I think it's now more readable but potentially slightly large - perhaps this will improve as we split `PxeOracleInterface` in multiple files or modules.