### PR TITLE
fix: Cl/fix arm anvil

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -7,6 +7,7 @@
 **/bootstrap.sh @charlielye
 **/run_test.sh @charlielye
 /release-please-config @charlielye
+/.test_patterns.yml @charlielye
 
 # Notify the Noir team of any changes to ACIR serialization
 /noir/noir-repo/acvm-repo/acir/codegen/* @TomAFrench @vezenovm @guipublic

--- a/aztec-up/bin/aztec
+++ b/aztec-up/bin/aztec
@@ -31,7 +31,7 @@ set -- "${args[@]}"
 
 function get_env_vars {
   docker run --rm aztecprotocol/aztec cat /usr/src/yarn-project/foundation/src/config/env_var.ts |
-    grep -oP "'\K[^']+(?=')" | tr '\n' ' '
+    awk -F"'" '{for(i=2;i<=NF;i+=2) printf $i " "}'
 }
 
 case ${1:-} in

--- a/build-images/bootstrap.sh
+++ b/build-images/bootstrap.sh
@@ -45,8 +45,8 @@ function build_ec2 {
 
   # Request new instance.
   instance_name=build_image_$(echo -n "$branch" | tr -c 'a-zA-Z0-9-' '_')_$arch
-  ip_sir=$(aws_request_instance $instance_name $cpus $arch)
-  parts=(${ip_sir//:/ })
+  ip_sir=$(NO_SPOT=1 aws_request_instance $instance_name $cpus $arch)
+  IFS=':' read -r -a parts <<< "$ip_sir"
   ip="${parts[0]}"
   sir="${parts[1]}"
   iid="${parts[2]}"

--- a/build-images/src/Dockerfile
+++ b/build-images/src/Dockerfile
@@ -79,6 +79,7 @@ ENV FOUNDRY_BIN_DIR="/root/.foundry/bin"
 ENV RUSTUP_HOME=/opt/rust/rustup
 ENV CARGO_HOME=/opt/rust/cargo
 ENV PATH="/opt/rust/cargo/bin:$PATH"
+ENV RUSTFLAGS="-C target-cpu=generic"
 RUN curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh -s -- -y
 RUN curl -L https://foundry.paradigm.xyz | bash \
     && $FOUNDRY_BIN_DIR/foundryup -b nightly-$FOUNDRY_TAG \
@@ -88,7 +89,6 @@ RUN curl -L https://foundry.paradigm.xyz | bash \
         strip /opt/foundry/bin/$t; \
     done \
     && rm -rf $FOUNDRY_BIN_DIR
-ENV PATH="/opt/foundry/bin:$PATH"
 
 
 ########################################################################################################################

--- a/ci3/aws/ami_id_amd64
+++ b/ci3/aws/ami_id_amd64
@@ -1,1 +1,1 @@
-ami-08860b157b4c6adae
+ami-0fa0399e5c50f8d6e

--- a/ci3/aws/ami_id_arm64
+++ b/ci3/aws/ami_id_arm64
@@ -1,1 +1,1 @@
-ami-0b1ebceab02515cfb
+ami-0dcef976575ae8dba


### PR DESCRIPTION
Fixes the grep that didn't work on mac, for extracting env vars.
Uses new amis in CI that have new build of dev container that has an anvil that targets generic arm.