### PR TITLE
fix: Log overflow handling in reset

### DIFF
--- a/yarn-project/end-to-end/bootstrap.sh
+++ b/yarn-project/end-to-end/bootstrap.sh
@@ -93,6 +93,7 @@ function test_cmds {
   echo "$prefix simple e2e_p2p/slashing"
   echo "$prefix simple e2e_p2p/upgrade_governance_proposer"
 
+  echo "$prefix simple e2e_pending_note_hashes_contract"
   echo "$prefix simple e2e_private_voting_contract"
   echo "$prefix simple e2e_pruned_blocks"
   echo "$prefix simple e2e_public_testnet_transfer"


### PR DESCRIPTION
Resolves https://github.com/AztecProtocol/aztec-packages/issues/12295
We were handling overflow in note hashes and nullifiers, but not in logs. I have updated the reset handling code to also trigger cleaning up note hashes because that can clean up logs and avoid the overflow