### PR TITLE
feat: add extra attributes to target_info

### DIFF
--- a/spartan/aztec-network/files/config/get-private-key.sh
+++ b/spartan/aztec-network/files/config/get-private-key.sh
@@ -13,6 +13,7 @@ echo "MNEMONIC: $(echo $MNEMONIC | cut -d' ' -f1-2)..."
 
 # Get the private key from the mnemonic
 private_key=$(cast wallet private-key "$MNEMONIC" --mnemonic-index $PRIVATE_KEY_INDEX)
+address=$(cast wallet address "$private_key")
 
 # Note, currently writing keys for all services for convenience
 cat <<EOF >/shared/config/keys.env
@@ -22,5 +23,10 @@ export SEQ_PUBLISHER_PRIVATE_KEY=$private_key
 export PROVER_PUBLISHER_PRIVATE_KEY=$private_key
 export BOT_L1_PRIVATE_KEY=$private_key
 EOF
+
+if [[ -f "/shared/config/otel-resource" ]]; then
+  # rewrite the resource attributes
+  echo "export OTEL_RESOURCE_ATTRIBUTES=\"\$OTEL_RESOURCE_ATTRIBUTES,aztec.l1.address=$address\"" >>/shared/config/otel-resource
+fi
 
 cat /shared/config/keys.env

--- a/spartan/aztec-network/files/config/setup-otel-resource.sh
+++ b/spartan/aztec-network/files/config/setup-otel-resource.sh
@@ -24,6 +24,9 @@ attrs_map["k8s.pod.name"]="${K8S_POD_NAME:-}"
 attrs_map["k8s.pod.uid"]="${K8S_POD_UID:-}"
 attrs_map["k8s.namespace.name"]="${K8S_NAMESPACE_NAME:-}"
 
+attrs_map["aztec.l2.slot_duration_seconds"]="${AZTEC_SLOT_DURATION:-}"
+attrs_map["aztec.l2.epoch_duration_slots"]="${AZTEC_EPOCH_DURATION:-}"
+
 # format the attribute map to comma-separated string
 set +x
 otel_attrs=""

--- a/spartan/aztec-network/templates/_helpers.tpl
+++ b/spartan/aztec-network/templates/_helpers.tpl
@@ -181,6 +181,10 @@ Sets up the OpenTelemetry resource attributes for a service
       value: "{{ $serviceName }}"
     - name: OTEL_RESOURCE_ATTRIBUTES
       value: 'service.namespace={{ .Release.Namespace }},environment={{ .Values.environment | default "production" }}'
+    - name: AZTEC_SLOT_DURATION
+      value: "{{ .Values.aztec.slotDuration }}"
+    - name: AZTEC_EPOCH_DURATION
+      value: "{{ .Values.aztec.epochDuration }}"
   volumeMounts:
     - name: scripts
       mountPath: /scripts
@@ -342,6 +346,10 @@ Combined P2P, Service Address, and OpenTelemetry Setup Container
       value: "{{ .Values.proverBroker.service.nodePort }}"
     - name: USE_GCLOUD_LOGGING
       value: "{{ .Values.telemetry.useGcloudLogging }}"
+    - name: AZTEC_SLOT_DURATION
+      value: "{{ .Values.aztec.slotDuration }}"
+    - name: AZTEC_EPOCH_DURATION
+      value: "{{ .Values.aztec.epochDuration }}"
     - name: SERVICE_NAME
       value: {{ include "aztec-network.fullname" . }}
     - name: POD_IP


### PR DESCRIPTION
This PR adds slot duration (in seconds), epoch size (in slots) and the l1 address (if it exists) to `target_info` metric.
