### PR TITLE
chore: Validate blobs posted to sink belong to our L2

### DIFF
--- a/spartan/aztec-network/templates/blob-sink.yaml
+++ b/spartan/aztec-network/templates/blob-sink.yaml
@@ -32,6 +32,8 @@ spec:
       {{- include "aztec-network.gcpLocalSsd" . | nindent 6 }}
       {{- end }}
       dnsPolicy: ClusterFirstWithHostNet
+      initContainers:
+        {{- include "aztec-network.serviceAddressSetupContainer" . | nindent 8 }}
       containers:
         - name: blob-sink
           {{- include "aztec-network.image" . | nindent 10 }}
@@ -39,6 +41,7 @@ spec:
             - /bin/bash
             - -c
             - |
+              source /shared/config/service-addresses && \
               env && \
               node --no-warnings /usr/src/yarn-project/aztec/dest/bin/index.js start --blob-sink
           startupProbe:
@@ -87,6 +90,8 @@ spec:
               value: "{{ .Values.blobSink.dataStoreConfig.dataStoreMapSize }}"
             - name: USE_GCLOUD_LOGGING
               value: "{{ .Values.telemetry.useGcloudLogging }}"
+            - name: L1_CHAIN_ID
+              value: "{{ .Values.ethereum.chainId }}"
           ports:
             - containerPort: {{ .Values.blobSink.service.nodePort }}
           resources:

--- a/yarn-project/blob-sink/package.json
+++ b/yarn-project/blob-sink/package.json
@@ -53,6 +53,7 @@
   },
   "dependencies": {
     "@aztec/blob-lib": "workspace:^",
+    "@aztec/ethereum": "workspace:^",
     "@aztec/foundation": "workspace:^",
     "@aztec/kv-store": "workspace:*",
     "@aztec/stdlib": "workspace:^",

--- a/yarn-project/blob-sink/src/server/config.ts
+++ b/yarn-project/blob-sink/src/server/config.ts
@@ -1,14 +1,17 @@
-import { type ConfigMappingsType, getConfigFromMappings } from '@aztec/foundation/config';
-import { pickConfigMappings } from '@aztec/foundation/config';
+import {
+  type L1ContractAddresses,
+  type L1ReaderConfig,
+  l1ContractAddressesMapping,
+  l1ReaderConfigMappings,
+} from '@aztec/ethereum';
+import { type ConfigMappingsType, getConfigFromMappings, pickConfigMappings } from '@aztec/foundation/config';
 import { type DataStoreConfig, dataConfigMappings } from '@aztec/kv-store/config';
-import type { ChainConfig } from '@aztec/stdlib/config';
-import { chainConfigMappings } from '@aztec/stdlib/config';
 
 export type BlobSinkConfig = {
   port?: number;
   archiveApiUrl?: string;
   dataStoreConfig?: DataStoreConfig;
-} & Partial<Pick<ChainConfig, 'l1ChainId'>>;
+} & Partial<Pick<L1ReaderConfig, 'l1ChainId' | 'l1RpcUrls'> & Pick<L1ContractAddresses, 'rollupAddress'>>;
 
 export const blobSinkConfigMappings: ConfigMappingsType<BlobSinkConfig> = {
   port: {
@@ -23,7 +26,8 @@ export const blobSinkConfigMappings: ConfigMappingsType<BlobSinkConfig> = {
     env: 'BLOB_SINK_ARCHIVE_API_URL',
     description: 'The URL of the archive API',
   },
-  ...pickConfigMappings(chainConfigMappings, ['l1ChainId']),
+  ...pickConfigMappings(l1ReaderConfigMappings, ['l1ChainId', 'l1RpcUrls']),
+  ...pickConfigMappings(l1ContractAddressesMapping, ['rollupAddress']),
 };
 
 /**

--- a/yarn-project/blob-sink/src/server/factory.ts
+++ b/yarn-project/blob-sink/src/server/factory.ts
@@ -1,3 +1,4 @@
+import { getPublicClient } from '@aztec/ethereum';
 import type { AztecAsyncKVStore } from '@aztec/kv-store';
 import { createStore } from '@aztec/kv-store/lmdb-v2';
 import type { TelemetryClient } from '@aztec/telemetry-client';
@@ -19,11 +20,13 @@ async function getDataStoreConfig(config?: BlobSinkConfig): Promise<AztecAsyncKV
  * Creates a blob sink service from the provided config.
  */
 export async function createBlobSinkServer(
-  config?: BlobSinkConfig,
+  config: BlobSinkConfig = {},
   telemetry?: TelemetryClient,
 ): Promise<BlobSinkServer> {
   const store = await getDataStoreConfig(config);
   const archiveClient = createBlobArchiveClient(config);
+  const { l1ChainId, l1RpcUrls } = config;
+  const l1PublicClient = l1ChainId && l1RpcUrls ? getPublicClient({ l1ChainId, l1RpcUrls }) : undefined;
 
-  return new BlobSinkServer(config, store, archiveClient, telemetry);
+  return new BlobSinkServer(config, store, archiveClient, l1PublicClient, telemetry);
 }

--- a/yarn-project/blob-sink/src/types/api.ts
+++ b/yarn-project/blob-sink/src/types/api.ts
@@ -1,3 +1,4 @@
+import type { Hex } from 'viem';
 import { z } from 'zod';
 
 export interface PostBlobSidecarRequest {
@@ -15,7 +16,9 @@ export interface PostBlobSidecarRequest {
 export const blockRootSchema = z
   .string()
   .regex(/^0x[0-9a-fA-F]{0,64}$/)
-  .max(66);
+  .max(66)
+  .transform(str => str as Hex);
+
 export const slotSchema = z.number().int().positive();
 
 // Define the Zod schema for an array of numbers
@@ -28,11 +31,11 @@ export const indicesSchema = z.optional(
     .transform(str => str.split(',').map(Number)),
 ); // Convert to an array of numbers
 
-// Validation schemas
-// Block identifier. Can be one of: <slot>, <hex encoded blockRoot with 0x prefix>.
-// Note the spec https://ethereum.github.io/beacon-APIs/?urls.primaryName=dev#/Beacon/getBlobSidecars does allows for "head", "genesis", "finalized" as valid block ids,
-// but we explicitly do not support these values.
-export const blockIdSchema = blockRootSchema.or(slotSchema);
+/**
+ * Block identifier. The spec allows for <hex encoded blockRoot with 0x prefix>, <slot>, "head", "genesis", "finalized", but we only support the block root.
+ * See https://ethereum.github.io/beacon-APIs/?urls.primaryName=dev#/Beacon/getBlobSidecars.
+ */
+export const blockIdSchema = blockRootSchema;
 
 export const postBlobSidecarSchema = z.object({
   // eslint-disable-next-line camelcase

--- a/yarn-project/blob-sink/tsconfig.json
+++ b/yarn-project/blob-sink/tsconfig.json
@@ -10,6 +10,9 @@
       "path": "../blob-lib"
     },
     {
+      "path": "../ethereum"
+    },
+    {
       "path": "../foundation"
     },
     {

--- a/yarn-project/end-to-end/src/fixtures/snapshot_manager.ts
+++ b/yarn-project/end-to-end/src/fixtures/snapshot_manager.ts
@@ -306,16 +306,6 @@ async function setupFromFresh(
   }
   aztecNodeConfig.blobSinkUrl = `http://localhost:${blobSinkPort}`;
 
-  // Setup blob sink service
-  const blobSink = await createBlobSinkServer({
-    port: blobSinkPort,
-    dataStoreConfig: {
-      dataDirectory: aztecNodeConfig.dataDirectory,
-      dataStoreMapSizeKB: aztecNodeConfig.dataStoreMapSizeKB,
-    },
-  });
-  await blobSink.start();
-
   // Start anvil. We go via a wrapper script to ensure if the parent dies, anvil dies.
   logger.verbose('Starting anvil...');
   const res = await startAnvil({ l1BlockTime: opts.ethereumSlotDuration });
@@ -401,6 +391,22 @@ async function setupFromFresh(
 
   const telemetry = getEndToEndTestTelemetryClient(opts.metricsPort);
 
+  // Setup blob sink service
+  const blobSink = await createBlobSinkServer(
+    {
+      l1ChainId: aztecNodeConfig.l1ChainId,
+      l1RpcUrls: aztecNodeConfig.l1RpcUrls,
+      rollupAddress: aztecNodeConfig.l1Contracts.rollupAddress,
+      port: blobSinkPort,
+      dataStoreConfig: {
+        dataDirectory: aztecNodeConfig.dataDirectory,
+        dataStoreMapSizeKB: aztecNodeConfig.dataStoreMapSizeKB,
+      },
+    },
+    telemetry,
+  );
+  await blobSink.start();
+
   logger.verbose('Creating and synching an aztec node...');
   const dateProvider = new TestDateProvider();
   const aztecNode = await AztecNodeService.createAndSync(
@@ -475,15 +481,6 @@ async function setupFromState(statePath: string, logger: Logger): Promise<Subsys
     JSON.parse(readFileSync(`${statePath}/accounts.json`, 'utf-8'), reviver) || [];
   const { prefilledPublicData } = await getGenesisValues(initialFundedAccounts.map(a => a.address));
 
-  const blobSink = await createBlobSinkServer({
-    port: blobSinkPort,
-    dataStoreConfig: {
-      dataDirectory: statePath,
-      dataStoreMapSizeKB: aztecNodeConfig.dataStoreMapSizeKB,
-    },
-  });
-  await blobSink.start();
-
   // Start anvil. We go via a wrapper script to ensure if the parent dies, anvil dies.
   const { anvil, rpcUrl } = await startAnvil();
   aztecNodeConfig.l1RpcUrls = [rpcUrl];
@@ -515,9 +512,24 @@ async function setupFromState(statePath: string, logger: Logger): Promise<Subsys
   );
   await watcher.start();
 
-  logger.verbose('Creating aztec node...');
   const telemetry = initTelemetryClient(getTelemetryConfig());
   const dateProvider = new TestDateProvider();
+  const blobSink = await createBlobSinkServer(
+    {
+      l1ChainId: aztecNodeConfig.l1ChainId,
+      l1RpcUrls: aztecNodeConfig.l1RpcUrls,
+      rollupAddress: aztecNodeConfig.l1Contracts.rollupAddress,
+      port: blobSinkPort,
+      dataStoreConfig: {
+        dataDirectory: statePath,
+        dataStoreMapSizeKB: aztecNodeConfig.dataStoreMapSizeKB,
+      },
+    },
+    telemetry,
+  );
+  await blobSink.start();
+
+  logger.verbose('Creating aztec node...');
   const aztecNode = await AztecNodeService.createAndSync(
     aztecNodeConfig,
     { telemetry, dateProvider },

--- a/yarn-project/ethereum/src/queries.ts
+++ b/yarn-project/ethereum/src/queries.ts
@@ -1,4 +1,7 @@
 import type { EthAddress } from '@aztec/foundation/eth-address';
+import { RollupAbi } from '@aztec/l1-artifacts/RollupAbi';
+
+import type { Hex } from 'viem';
 
 import type { L1ContractsConfig } from './config.js';
 import { GovernanceContract } from './contracts/governance.js';
@@ -55,4 +58,26 @@ export async function getL1ContractsConfig(
     slashingQuorum: Number(slashingQuorum),
     slashingRoundSize: Number(slashingRoundSize),
   };
+}
+
+export type L2BlockProposedEvent = {
+  versionedBlobHashes: readonly Hex[];
+  archive: Hex;
+  blockNumber: bigint;
+};
+
+export async function getL2BlockProposalEvents(
+  client: ViemPublicClient,
+  blockId: Hex,
+  rollupAddress?: EthAddress,
+): Promise<L2BlockProposedEvent[]> {
+  return (
+    await client.getContractEvents({
+      abi: RollupAbi,
+      address: rollupAddress?.toString(),
+      blockHash: blockId,
+      eventName: 'L2BlockProposed',
+      strict: true,
+    })
+  ).map(log => log.args);
 }

--- a/yarn-project/yarn.lock
+++ b/yarn-project/yarn.lock
@@ -384,6 +384,7 @@ __metadata:
   resolution: "@aztec/blob-sink@workspace:blob-sink"
   dependencies:
     "@aztec/blob-lib": "workspace:^"
+    "@aztec/ethereum": "workspace:^"
     "@aztec/foundation": "workspace:^"
     "@aztec/kv-store": "workspace:*"
     "@aztec/stdlib": "workspace:^"
@@ -22017,8 +22018,8 @@ __metadata:
   linkType: hard
 
 "viem@npm:^2.23.5":
-  version: 2.23.5
-  resolution: "viem@npm:2.23.5"
+  version: 2.23.7
+  resolution: "viem@npm:2.23.7"
   dependencies:
     "@noble/curves": "npm:1.8.1"
     "@noble/hashes": "npm:1.7.1"
@@ -22033,7 +22034,7 @@ __metadata:
   peerDependenciesMeta:
     typescript:
       optional: true
-  checksum: 10/80db013d510688386c37500442c29d85b9adda3035c3a3644156828830cf856f95d6c228dd4fe97d21f270bde9b63bfb98ebf2538bbd1831d40b38918ed07787
+  checksum: 10/bf1618f39ca3645082323776342c0f87fa37f60bcca0476a7db0f6fbb9d1b6db7ab1e434a57463e8486bea29f97c5ab01e95b6139190a008d6f9a30194b7b081
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
Adds an optional L1 execution rpc url to the blob sink. When set, any incoming blobs are checked against the rollup contract `L2BlockPublished` events for the given block. If not set, the post is discarded.

Fixes #12497
