### PR TITLE
feat(config): add fallbacks

### DIFF
--- a/yarn-project/aztec/src/cli/cmds/start_node.ts
+++ b/yarn-project/aztec/src/cli/cmds/start_node.ts
@@ -26,10 +26,17 @@ export async function startNode(
 ): Promise<{ config: AztecNodeConfig }> {
   // options specifically namespaced with --node.<option>
   const nodeSpecificOptions = extractNamespacedOptions(options, 'node');
+
+  // All options set from environment variables
+  const configFromEnvVars = getConfigEnvVars();
+
+  // Extract relevant options from command line arguments
+  const relevantOptions = extractRelevantOptions(options, aztecNodeConfigMappings, 'node');
+
   // All options that are relevant to the Aztec Node
   let nodeConfig: AztecNodeConfig = {
-    ...getConfigEnvVars(),
-    ...extractRelevantOptions(options, aztecNodeConfigMappings, 'node'),
+    ...configFromEnvVars,
+    ...relevantOptions,
   };
 
   if (options.proverNode) {
@@ -96,10 +103,15 @@ export async function startNode(
   if (!options.sequencer) {
     nodeConfig.disableValidator = true;
   } else {
-    const sequencerConfig = extractNamespacedOptions(options, 'sequencer');
+    const sequencerConfig = {
+      ...configFromEnvVars,
+      ...extractNamespacedOptions(options, 'sequencer'),
+    };
     let account;
     if (!sequencerConfig.publisherPrivateKey || sequencerConfig.publisherPrivateKey === NULL_KEY) {
-      if (!options.l1Mnemonic) {
+      if (sequencerConfig.validatorPrivateKey) {
+        sequencerConfig.publisherPrivateKey = sequencerConfig.validatorPrivateKey as `0x${string}`;
+      } else if (!options.l1Mnemonic) {
         userLog(
           '--sequencer.publisherPrivateKey or --l1-mnemonic is required to start Aztec Node with --sequencer option',
         );
@@ -107,11 +119,10 @@ export async function startNode(
       } else {
         account = mnemonicToAccount(options.l1Mnemonic);
         const privKey = account.getHdKey().privateKey;
-        nodeConfig.publisherPrivateKey = `0x${Buffer.from(privKey!).toString('hex')}`;
+        sequencerConfig.publisherPrivateKey = `0x${Buffer.from(privKey!).toString('hex')}`;
       }
-    } else {
-      nodeConfig.publisherPrivateKey = sequencerConfig.publisherPrivateKey;
     }
+    nodeConfig.publisherPrivateKey = sequencerConfig.publisherPrivateKey;
   }
 
   if (nodeConfig.p2pEnabled) {

--- a/yarn-project/end-to-end/scripts/native-network/validator.sh
+++ b/yarn-project/end-to-end/scripts/native-network/validator.sh
@@ -1,5 +1,5 @@
 #!/bin/bash
-set -eu
+# set -eu
 
 # Get the name of the script without the path and extension
 SCRIPT_NAME=$(basename "$0" .sh)
@@ -51,11 +51,9 @@ if [ -z "${VALIDATOR_PRIVATE_KEY:-}" ] || [ -z "${ADDRESS:-}" ]; then
   echo "Generating new L1 Validator account..."
   json_account=$(node --no-warnings "$REPO"/yarn-project/aztec/dest/bin/index.js generate-l1-account)
   export ADDRESS=$(echo $json_account | jq -r '.address')
-  export VALIDATOR_PRIVATE_KEY=$(echo $json_account | jq -r '.privateKey')
+  validator_private_key=$(echo $json_account | jq -r '.privateKey')
 fi
 
-export L1_PRIVATE_KEY=$VALIDATOR_PRIVATE_KEY
-export SEQ_PUBLISHER_PRIVATE_KEY=$VALIDATOR_PRIVATE_KEY
 export DEBUG=${DEBUG:-""}
 export LOG_LEVEL=${LOG_LEVEL:-"verbose"}
 export L1_CONSENSUS_HOST_URL=${L1_CONSENSUS_HOST_URL:-}
@@ -90,4 +88,4 @@ else
 fi
 
 # Start the Validator Node with the sequencer and archiver
-node --no-warnings "$REPO"/yarn-project/aztec/dest/bin/index.js start --port="$PORT" --node --archiver --sequencer
+node --no-warnings "$REPO"/yarn-project/aztec/dest/bin/index.js start --port="$PORT" --node --archiver --sequencer --sequencer.validatorPrivateKey="$validator_private_key"

--- a/yarn-project/end-to-end/scripts/native-network/validator.sh
+++ b/yarn-project/end-to-end/scripts/native-network/validator.sh
@@ -1,5 +1,5 @@
 #!/bin/bash
-# set -eu
+set -eu
 
 # Get the name of the script without the path and extension
 SCRIPT_NAME=$(basename "$0" .sh)
@@ -11,7 +11,7 @@ exec > >(tee -a "$(dirname $0)/logs/${SCRIPT_NAME}.log") 2> >(tee -a "$(dirname 
 PORT="$1"
 P2P_PORT="$2"
 ADDRESS="${3:-${ADDRESS:-}}"
-export VALIDATOR_PRIVATE_KEY="${4:-${VALIDATOR_PRIVATE_KEY:-}}"
+validator_private_key="${4:-${VALIDATOR_PRIVATE_KEY:-}}"
 
 # Starts the Validator Node
 REPO=$(git rev-parse --show-toplevel)
@@ -47,12 +47,15 @@ export BOOTSTRAP_NODES=$(echo "$output" | grep -oP 'Node ENR: \K.*')
 echo "BOOTSTRAP_NODES: $BOOTSTRAP_NODES"
 
 # Generate a private key for the validator only if not already set
-if [ -z "${VALIDATOR_PRIVATE_KEY:-}" ] || [ -z "${ADDRESS:-}" ]; then
+if [ -z "${validator_private_key:-}" ] || [ -z "${ADDRESS:-}" ]; then
   echo "Generating new L1 Validator account..."
   json_account=$(node --no-warnings "$REPO"/yarn-project/aztec/dest/bin/index.js generate-l1-account)
   export ADDRESS=$(echo $json_account | jq -r '.address')
   validator_private_key=$(echo $json_account | jq -r '.privateKey')
 fi
+
+## We want to use the private key from the cli
+unset VALIDATOR_PRIVATE_KEY
 
 export DEBUG=${DEBUG:-""}
 export LOG_LEVEL=${LOG_LEVEL:-"verbose"}

--- a/yarn-project/sequencer-client/src/config.ts
+++ b/yarn-project/sequencer-client/src/config.ts
@@ -16,6 +16,7 @@ import { Fr } from '@aztec/foundation/fields';
 import { FunctionSelector } from '@aztec/stdlib/abi';
 import { AztecAddress } from '@aztec/stdlib/aztec-address';
 import { type AllowedElement, type ChainConfig, type SequencerConfig, chainConfigMappings } from '@aztec/stdlib/config';
+import { type ValidatorClientConfig, validatorClientConfigMappings } from '@aztec/validator-client';
 
 import {
   type PublisherConfig,
@@ -31,6 +32,7 @@ export type { SequencerConfig };
  * Configuration settings for the SequencerClient.
  */
 export type SequencerClientConfig = PublisherConfig &
+  ValidatorClientConfig &
   TxSenderConfig &
   SequencerConfig &
   L1ReaderConfig &
@@ -113,6 +115,7 @@ export const sequencerConfigMappings: ConfigMappingsType<SequencerConfig> = {
 };
 
 export const sequencerClientConfigMappings: ConfigMappingsType<SequencerClientConfig> = {
+  ...validatorClientConfigMappings,
   ...sequencerConfigMappings,
   ...l1ReaderConfigMappings,
   ...getTxSenderConfigMappings('SEQ'),

--- a/yarn-project/sequencer-client/src/publisher/config.ts
+++ b/yarn-project/sequencer-client/src/publisher/config.ts
@@ -50,6 +50,7 @@ export const getTxSenderConfigMappings: (
     description: 'The private key to be used by the publisher.',
     parseEnv: (val: string) => (val ? `0x${val.replace('0x', '')}` : NULL_KEY),
     defaultValue: NULL_KEY,
+    fallback: ['VALIDATOR_PRIVATE_KEY'],
   },
 });
 


### PR DESCRIPTION
## Overview

Again like https://github.com/AztecProtocol/aztec-packages/pull/12589 this is added after a chat with
charlie where we want to remove the need for a complex script. 

https://github.com/AztecProtocol/aztec-packages/pull/12566 asks the user for a private key as it needs 
to set two env vars to the same key. 

This pr introduces the notion of a fallback, such that a config variable will also check a list of fallbacks before
using the default value.

In this case, if `VALIDATOR_PRIVATE_KEY` is set, then `SEQ_PUBLISHER_PRIVATE_KEY`` does not need to be set, removing the
need for it in the script.
