### PR TITLE
fix: handling undefined block number in sync data provider txe

### DIFF
--- a/yarn-project/pxe/src/pxe_oracle_interface/pxe_oracle_interface.ts
+++ b/yarn-project/pxe/src/pxe_oracle_interface/pxe_oracle_interface.ts
@@ -718,10 +718,9 @@ export class PXEOracleInterface implements ExecutionDataProvider {
     // Note that while this technically results in historical queries, we perform it at the latest locally synced block
     // number which *should* be recent enough to be available, even for non-archive nodes.
     const syncedBlockNumber = (await this.syncDataProvider.getBlockNumber())!;
-    // TODO (#12559): handle undefined syncedBlockNumber
-    // if (syncedBlockNumber === undefined) {
-    //  throw new Error(`Attempted to deliver a note with an unsynchronized PXE - this should never happen`);
-    //}
+    if (syncedBlockNumber === undefined) {
+      throw new Error(`Attempted to deliver a note with an unsynchronized PXE - this should never happen`);
+    }
 
     // By computing siloed and unique note hashes ourselves we prevent contracts from interfering with the note storage
     // of other contracts, which would constitute a security breach.

--- a/yarn-project/txe/src/oracle/txe_oracle.ts
+++ b/yarn-project/txe/src/oracle/txe_oracle.ts
@@ -780,6 +780,8 @@ export class TXE implements TypedOracle {
     // This essentially commits the state updates to the unforked state and sanity checks the roots.
     await this.nativeWorldStateService.handleL2BlockAndMessages(l2Block, l1ToL2Messages);
 
+    await this.syncDataProvider.setHeader(header);
+
     this.publicDataWrites = [];
     this.privateLogs = [];
     this.publicLogs = [];


### PR DESCRIPTION
With the new PXE refactor, we need to set the header of the newest seen block in the synchronizer.

Resolves #12559.