### PR TITLE
fix: broken kind transfer test

### DIFF
--- a/.test_patterns.yml
+++ b/.test_patterns.yml
@@ -41,7 +41,6 @@ tests:
     owners:
       - *tom
 
-
   # noir
   # Something to do with how I run the tests now. Think these are fine in nextest.
   - regex: "noir_lsp-.* notifications::notification_tests::test_caches_open_files"
@@ -161,18 +160,6 @@ tests:
     owners:
       - *leila
 
-  - regex: "spartan/bootstrap.sh test-prod-deployment"
-    owners:
-      - *mitch
-
-  - regex: "spartan/bootstrap.sh test-kind-upgrade-rollup-version"
-    owners:
-      - *mitch
-
-  - regex: "spartan/bootstrap.sh test-kind-transfer"
-    owners:
-      - *phil
-      - *mitch
   - regex: "spartan/bootstrap.sh test-local"
     skip: true
     owners:

--- a/spartan/aztec-network/templates/blob-sink.yaml
+++ b/spartan/aztec-network/templates/blob-sink.yaml
@@ -61,6 +61,8 @@ spec:
           volumeMounts:
             - name: blob-sink-data
               mountPath: {{ .Values.blobSink.dataStoreConfig.dataDir }}
+            - name: config
+              mountPath: /shared/config
           env:
             - name: POD_IP
               valueFrom:
@@ -97,6 +99,12 @@ spec:
           resources:
             {{- toYaml .Values.blobSink.resources | nindent 12 }}
       volumes:
+        - name: scripts
+          configMap:
+            name: {{ include "aztec-network.fullname" . }}-scripts
+            defaultMode: 0755
+        - name: config
+          emptyDir: {}
       {{- if .Values.storage.localSsd }}
         - name: blob-sink-data
           emptyDir: {}


### PR DESCRIPTION
Fixes the misconfigured volumes on the blob sink, hit in the kind transfer test.

Also the flake rate on kind tests is close to zero, so graduating them.