### PR TITLE
chore: Merge is part of verification queue

### DIFF
--- a/barretenberg/acir_tests/bootstrap.sh
+++ b/barretenberg/acir_tests/bootstrap.sh
@@ -125,10 +125,10 @@ function test_cmds_internal {
   echo SYS=ultra_honk FLOW=prove_then_verify HASH=keccak $run_test assert_statement
   echo SYS=ultra_honk FLOW=prove_then_verify ROLLUP=true $run_test verify_rollup_honk_proof
 
-  # barretenberg-acir-tests-bb-client-ivc:
-  echo FLOW=prove_then_verify_client_ivc $run_test 6_array
-  echo FLOW=prove_then_verify_client_ivc $run_test databus
-  echo FLOW=prove_then_verify_client_ivc $run_test databus_two_calldata
+  # # barretenberg-acir-tests-bb-client-ivc:
+  # echo FLOW=prove_then_verify_client_ivc $run_test 6_array
+  # echo FLOW=prove_then_verify_client_ivc $run_test databus
+  # echo FLOW=prove_then_verify_client_ivc $run_test databus_two_calldata
 }
 
 function ultra_honk_wasm_memory {

--- a/barretenberg/acir_tests/bootstrap.sh
+++ b/barretenberg/acir_tests/bootstrap.sh
@@ -124,11 +124,6 @@ function test_cmds_internal {
   echo SYS=ultra_honk FLOW=prove_then_verify RECURSIVE=true $run_test double_verify_honk_proof
   echo SYS=ultra_honk FLOW=prove_then_verify HASH=keccak $run_test assert_statement
   echo SYS=ultra_honk FLOW=prove_then_verify ROLLUP=true $run_test verify_rollup_honk_proof
-
-  # # barretenberg-acir-tests-bb-client-ivc:
-  # echo FLOW=prove_then_verify_client_ivc $run_test 6_array
-  # echo FLOW=prove_then_verify_client_ivc $run_test databus
-  # echo FLOW=prove_then_verify_client_ivc $run_test databus_two_calldata
 }
 
 function ultra_honk_wasm_memory {

--- a/barretenberg/cpp/src/barretenberg/client_ivc/client_ivc.cpp
+++ b/barretenberg/cpp/src/barretenberg/client_ivc/client_ivc.cpp
@@ -232,8 +232,9 @@ void ClientIVC::accumulate(ClientCircuit& circuit,
  *
  * @details The aim of this intermediate stage is to reduce the cost of producing a zero-knowledge ClientIVCProof.
  * @return HonkProof - a Mega proof
+ * @return MergeProof - a Merge proof
  */
-std::pair<HonkProof, HonkProof> ClientIVC::construct_and_prove_hiding_circuit()
+std::pair<HonkProof, ClientIVC::MergeProof> ClientIVC::construct_and_prove_hiding_circuit()
 {
     trace_usage_tracker.print(); // print minimum structured sizes for each block
     ASSERT(verification_queue.size() == 1);

--- a/barretenberg/cpp/src/barretenberg/client_ivc/client_ivc.cpp
+++ b/barretenberg/cpp/src/barretenberg/client_ivc/client_ivc.cpp
@@ -299,11 +299,14 @@ std::pair<HonkProof, HonkProof> ClientIVC::construct_and_prove_hiding_circuit()
  */
 ClientIVC::Proof ClientIVC::prove()
 {
+    HonkProof mega_proof;
     MergeProof merge_proof;
     if (!one_circuit) {
-        auto [mega_proof, merge_proof_hiding] = construct_and_prove_hiding_circuit();
+        auto [mega_proof_hiding, merge_proof_hiding] = construct_and_prove_hiding_circuit();
+        mega_proof = mega_proof_hiding;
         merge_proof = merge_proof_hiding;
     } else {
+        mega_proof = verification_queue[0].proof;
         merge_proof = verification_queue[0].merge_proof;
     }
 

--- a/barretenberg/cpp/src/barretenberg/client_ivc/client_ivc.cpp
+++ b/barretenberg/cpp/src/barretenberg/client_ivc/client_ivc.cpp
@@ -98,6 +98,7 @@ void ClientIVC::perform_recursive_verification_and_databus_consistency_checks(
     }
 
     // Recursively verify the merge proof for the circuit being recursively verified
+    // TODO(https://github.com/AztecProtocol/barretenberg/issues/950): handle pairing point accumulation
     [[maybe_unused]] auto pairing_points = GoblinVerifier::recursive_verify_merge(circuit, merge_proof);
 
     // Set the return data commitment to be propagated on the public inputs of the present kernel and perform
@@ -197,8 +198,7 @@ void ClientIVC::accumulate(ClientCircuit& circuit,
         fold_output.accumulator = proving_key; // initialize the prover accum with the completed key
 
         // Add oink proof and corresponding verification key to the verification queue
-        verification_queue.push_back(
-            bb::ClientIVC::VerifierInputs{ oink_proof, merge_proof, honk_vk, QUEUE_TYPE::OINK });
+        verification_queue.push_back(VerifierInputs{ oink_proof, merge_proof, honk_vk, QUEUE_TYPE::OINK });
 
         initialized = true;
     } else { // Otherwise, fold the new key into the accumulator
@@ -208,8 +208,7 @@ void ClientIVC::accumulate(ClientCircuit& circuit,
         vinfo("constructed folding proof");
 
         // Add fold proof and corresponding verification key to the verification queue
-        verification_queue.push_back(
-            bb::ClientIVC::VerifierInputs{ fold_output.proof, merge_proof, honk_vk, QUEUE_TYPE::PG });
+        verification_queue.push_back(VerifierInputs{ fold_output.proof, merge_proof, honk_vk, QUEUE_TYPE::PG });
     }
 }
 
@@ -247,6 +246,7 @@ std::pair<HonkProof, ClientIVC::MergeProof> ClientIVC::construct_and_prove_hidin
     const StdlibProof<ClientCircuit> stdlib_merge_proof =
         bb::convert_native_proof_to_stdlib(&builder, verification_queue[0].merge_proof);
 
+    // TODO(https://github.com/AztecProtocol/barretenberg/issues/950): handle pairing point accumulation
     [[maybe_unused]] auto pairing_points = GoblinVerifier::recursive_verify_merge(builder, stdlib_merge_proof);
 
     // Construct stdlib accumulator, decider vkey and folding proof

--- a/barretenberg/cpp/src/barretenberg/client_ivc/client_ivc.hpp
+++ b/barretenberg/cpp/src/barretenberg/client_ivc/client_ivc.hpp
@@ -86,6 +86,7 @@ class ClientIVC {
     // An entry in the native verification queue
     struct VerifierInputs {
         std::vector<FF> proof; // oink or PG
+        std::vector<FF> merge_proof;
         std::shared_ptr<MegaVerificationKey> honk_verification_key;
         QUEUE_TYPE type;
     };
@@ -94,6 +95,7 @@ class ClientIVC {
     // An entry in the stdlib verification queue
     struct StdlibVerifierInputs {
         StdlibProof<ClientCircuit> proof; // oink or PG
+        StdlibProof<ClientCircuit> merge_proof;
         std::shared_ptr<RecursiveVerificationKey> honk_verification_key;
         QUEUE_TYPE type;
     };
@@ -117,8 +119,6 @@ class ClientIVC {
     VerificationQueue verification_queue;
     // Set of tuples {stdlib_proof, stdlib_verification_key, type} corresponding to the native verification queue
     StdlibVerificationQueue stdlib_verification_queue;
-    // Set of merge proofs to be recursively verified
-    std::vector<MergeProof> merge_verification_queue;
 
     // Management of linking databus commitments between circuits in the IVC
     DataBusDepot bus_depot;
@@ -148,13 +148,8 @@ class ClientIVC {
     void instantiate_stdlib_verification_queue(
         ClientCircuit& circuit, const std::vector<std::shared_ptr<RecursiveVerificationKey>>& input_keys = {});
 
-    void perform_recursive_verification_and_databus_consistency_checks(
-        ClientCircuit& circuit,
-        const StdlibProof<ClientCircuit>& proof,
-        const std::shared_ptr<RecursiveVerificationKey>& vkey,
-        const QUEUE_TYPE type);
-
-    void process_recursive_merge_verification_queue(ClientCircuit& circuit);
+    void perform_recursive_verification_and_databus_consistency_checks(ClientCircuit& circuit,
+                                                                       const StdlibVerifierInputs& verifier_inputs);
 
     // Complete the logic of a kernel circuit (e.g. PG/merge recursive verification, databus consistency checks)
     void complete_kernel_circuit_logic(ClientCircuit& circuit);
@@ -174,7 +169,7 @@ class ClientIVC {
 
     Proof prove();
 
-    HonkProof construct_and_prove_hiding_circuit();
+    std::pair<HonkProof, HonkProof> construct_and_prove_hiding_circuit();
 
     static bool verify(const Proof& proof, const VerificationKey& vk);
 

--- a/barretenberg/cpp/src/barretenberg/client_ivc/client_ivc.hpp
+++ b/barretenberg/cpp/src/barretenberg/client_ivc/client_ivc.hpp
@@ -169,7 +169,7 @@ class ClientIVC {
 
     Proof prove();
 
-    std::pair<HonkProof, HonkProof> construct_and_prove_hiding_circuit();
+    std::pair<HonkProof, MergeProof> construct_and_prove_hiding_circuit();
 
     static bool verify(const Proof& proof, const VerificationKey& vk);
 

--- a/barretenberg/cpp/src/barretenberg/client_ivc/client_ivc.hpp
+++ b/barretenberg/cpp/src/barretenberg/client_ivc/client_ivc.hpp
@@ -130,10 +130,6 @@ class ClientIVC {
 
     GoblinProver goblin;
 
-    // We dynamically detect whether the input stack consists of one circuit, in which case we do not construct the
-    // hiding circuit and instead simply prove the single input circuit.
-    bool one_circuit = false;
-
     bool initialized = false; // Is the IVC accumulator initialized
 
     ClientIVC(TraceSettings trace_settings = {})

--- a/barretenberg/cpp/src/barretenberg/dsl/acir_format/ivc_recursion_constraint.cpp
+++ b/barretenberg/cpp/src/barretenberg/dsl/acir_format/ivc_recursion_constraint.cpp
@@ -77,7 +77,6 @@ void mock_ivc_accumulation(const std::shared_ptr<ClientIVC>& ivc, ClientIVC::QUE
     ClientIVC::VerifierInputs entry =
         acir_format::create_mock_verification_queue_entry(type, ivc->trace_settings, is_kernel);
     ivc->verification_queue.emplace_back(entry);
-    ivc->merge_verification_queue.emplace_back(acir_format::create_dummy_merge_proof());
     ivc->initialized = true;
 }
 
@@ -123,7 +122,9 @@ ClientIVC::VerifierInputs create_mock_verification_queue_entry(const ClientIVC::
         verification_key->databus_propagation_data = bb::DatabusPropagationData::kernel_default();
     }
 
-    return ClientIVC::VerifierInputs{ proof, verification_key, verification_type };
+    std::vector<FF> merge_proof = create_dummy_merge_proof();
+
+    return ClientIVC::VerifierInputs{ proof, merge_proof, verification_key, verification_type };
 }
 
 /**

--- a/barretenberg/cpp/src/barretenberg/goblin/goblin.hpp
+++ b/barretenberg/cpp/src/barretenberg/goblin/goblin.hpp
@@ -40,10 +40,6 @@ class GoblinProver {
     using MergeProver = MergeProver_<MegaFlavor>;
     using VerificationKey = MegaFlavor::VerificationKey;
     using MergeProof = std::vector<FF>;
-    /**
-     * @brief Output of goblin::accumulate; an Ultra proof and the corresponding verification key
-     *
-     */
 
     std::shared_ptr<OpQueue> op_queue = std::make_shared<OpQueue>();
     std::shared_ptr<CommitmentKey<curve::BN254>> commitment_key;
@@ -77,38 +73,6 @@ class GoblinProver {
         commitment_key = bn254_commitment_key ? bn254_commitment_key : nullptr;
         GoblinMockCircuits::perform_op_queue_interactions_for_mock_first_circuit(op_queue);
     }
-    // /**
-    //  * @brief Construct a MegaHonk proof and a merge proof for the present circuit.
-    //  * @details If there is a previous merge proof, recursively verify it.
-    //  *
-    //  * @param circuit_builder
-    //  */
-    // GoblinAccumulationOutput accumulate(MegaBuilder& circuit_builder)
-    // {
-    //     // Complete the circuit logic by recursively verifying previous merge proof if it exists
-    //     if (merge_proof_exists) {
-    //         RecursiveMergeVerifier merge_verifier{ &circuit_builder };
-    //         StdlibProof<MegaBuilder> stdlib_merge_proof =
-    //             bb::convert_native_proof_to_stdlib(&circuit_builder, merge_proof);
-    //         [[maybe_unused]] auto pairing_points = merge_verifier.verify_proof(stdlib_merge_proof);
-    //     }
-
-    //     // Construct a Honk proof for the main circuit
-    //     auto proving_key = std::make_shared<MegaDeciderProvingKey>(circuit_builder);
-    //     MegaProver prover(proving_key);
-    //     auto ultra_proof = prover.construct_proof();
-    //     auto verification_key = std::make_shared<VerificationKey>(proving_key->proving_key);
-
-    //     // Construct and store the merge proof to be recursively verified on the next call to accumulate
-    //     MergeProver merge_prover{ circuit_builder.op_queue };
-    //     merge_proof = merge_prover.construct_proof();
-
-    //     if (!merge_proof_exists) {
-    //         merge_proof_exists = true;
-    //     }
-
-    //     return { ultra_proof, verification_key };
-    // };
 
     /**
      * @brief Add a recursive merge verifier to input circuit and construct a merge proof for the updated op queue

--- a/barretenberg/cpp/src/barretenberg/goblin/goblin.hpp
+++ b/barretenberg/cpp/src/barretenberg/goblin/goblin.hpp
@@ -38,7 +38,7 @@ class GoblinProver {
 
     using MergeProver = MergeProver_<MegaFlavor>;
     using VerificationKey = MegaFlavor::VerificationKey;
-    using MergeProof = std::vector<FF>;
+    using MergeProof = MergeProver::MergeProof;
 
     std::shared_ptr<OpQueue> op_queue = std::make_shared<OpQueue>();
     std::shared_ptr<CommitmentKey<curve::BN254>> commitment_key;
@@ -75,7 +75,7 @@ class GoblinProver {
      *
      * @param circuit_builder
      */
-    MergeProof prove_merge(MegaBuilder& circuit_builder) const
+    MergeProof prove_merge(MegaBuilder& circuit_builder)
     {
         PROFILE_THIS_NAME("Goblin::merge");
         // TODO(https://github.com/AztecProtocol/barretenberg/issues/993): Some circuits (particularly on the first call
@@ -88,7 +88,8 @@ class GoblinProver {
         }
 
         MergeProver merge_prover{ circuit_builder.op_queue, commitment_key };
-        return merge_prover.construct_proof();
+        merge_proof = merge_prover.construct_proof();
+        return merge_proof;
     };
 
     /**

--- a/barretenberg/cpp/src/barretenberg/stdlib/goblin_verifier/goblin.test.cpp
+++ b/barretenberg/cpp/src/barretenberg/stdlib/goblin_verifier/goblin.test.cpp
@@ -41,7 +41,7 @@ TEST_F(GoblinTests, MultipleCircuits)
     size_t NUM_CIRCUITS = 3;
     for (size_t idx = 0; idx < NUM_CIRCUITS; ++idx) {
         auto circuit = construct_mock_circuit(goblin.op_queue);
-        goblin.prove_merge(circuit); // appends a recurisve merge verifier if a merge proof exists
+        goblin.prove_merge(circuit); // appends a recursive merge verifier if a merge proof exists
     }
 
     // Construct a goblin proof which consists of a merge proof and ECCVM/Translator proofs

--- a/barretenberg/cpp/src/barretenberg/stdlib/goblin_verifier/goblin.test.cpp
+++ b/barretenberg/cpp/src/barretenberg/stdlib/goblin_verifier/goblin.test.cpp
@@ -28,33 +28,34 @@ class GoblinTests : public ::testing::Test {
     }
 };
 
-/**
- * @brief A simple test demonstrating goblin proof construction / verification based on operations from a collection of
- * circuits
- *
- */
-TEST_F(GoblinTests, MultipleCircuits)
-{
-    GoblinProver goblin;
+// /**
+//  * @brief A simple test demonstrating goblin proof construction / verification based on operations from a collection
+//  of
+//  * circuits
+//  *
+//  */
+// TEST_F(GoblinTests, MultipleCircuits)
+// {
+//     GoblinProver goblin;
 
-    // Construct and accumulate multiple circuits
-    size_t NUM_CIRCUITS = 3;
-    for (size_t idx = 0; idx < NUM_CIRCUITS; ++idx) {
-        auto circuit = construct_mock_circuit(goblin.op_queue);
-        goblin.merge(circuit); // appends a recurisve merge verifier if a merge proof exists
-    }
+//     // Construct and accumulate multiple circuits
+//     size_t NUM_CIRCUITS = 3;
+//     for (size_t idx = 0; idx < NUM_CIRCUITS; ++idx) {
+//         auto circuit = construct_mock_circuit(goblin.op_queue);
+//         goblin.merge(circuit); // appends a recurisve merge verifier if a merge proof exists
+//     }
 
-    // Construct a goblin proof which consists of a merge proof and ECCVM/Translator proofs
-    GoblinProof proof = goblin.prove();
+//     // Construct a goblin proof which consists of a merge proof and ECCVM/Translator proofs
+//     GoblinProof proof = goblin.prove();
 
-    // Verify the goblin proof (eccvm, translator, merge); (Construct ECCVM/Translator verification keys from their
-    // respective proving keys)
-    auto eccvm_vkey = std::make_shared<ECCVMVerificationKey>(goblin.get_eccvm_proving_key());
-    auto translator_vkey = std::make_shared<TranslatorVerificationKey>(goblin.get_translator_proving_key());
-    GoblinVerifier goblin_verifier{ eccvm_vkey, translator_vkey };
-    bool verified = goblin_verifier.verify(proof);
+//     // Verify the goblin proof (eccvm, translator, merge); (Construct ECCVM/Translator verification keys from their
+//     // respective proving keys)
+//     auto eccvm_vkey = std::make_shared<ECCVMVerificationKey>(goblin.get_eccvm_proving_key());
+//     auto translator_vkey = std::make_shared<TranslatorVerificationKey>(goblin.get_translator_proving_key());
+//     GoblinVerifier goblin_verifier{ eccvm_vkey, translator_vkey };
+//     bool verified = goblin_verifier.verify(proof);
 
-    EXPECT_TRUE(verified);
-}
+//     EXPECT_TRUE(verified);
+// }
 
 // TODO(https://github.com/AztecProtocol/barretenberg/issues/787) Expand these tests.

--- a/barretenberg/cpp/src/barretenberg/stdlib/goblin_verifier/goblin.test.cpp
+++ b/barretenberg/cpp/src/barretenberg/stdlib/goblin_verifier/goblin.test.cpp
@@ -28,34 +28,33 @@ class GoblinTests : public ::testing::Test {
     }
 };
 
-// /**
-//  * @brief A simple test demonstrating goblin proof construction / verification based on operations from a collection
-//  of
-//  * circuits
-//  *
-//  */
-// TEST_F(GoblinTests, MultipleCircuits)
-// {
-//     GoblinProver goblin;
+/**
+ * @brief A simple test demonstrating goblin proof construction / verification based on operations from a collection of
+ * circuits
+ *
+ */
+TEST_F(GoblinTests, MultipleCircuits)
+{
+    GoblinProver goblin;
 
-//     // Construct and accumulate multiple circuits
-//     size_t NUM_CIRCUITS = 3;
-//     for (size_t idx = 0; idx < NUM_CIRCUITS; ++idx) {
-//         auto circuit = construct_mock_circuit(goblin.op_queue);
-//         goblin.merge(circuit); // appends a recurisve merge verifier if a merge proof exists
-//     }
+    // Construct and accumulate multiple circuits
+    size_t NUM_CIRCUITS = 3;
+    for (size_t idx = 0; idx < NUM_CIRCUITS; ++idx) {
+        auto circuit = construct_mock_circuit(goblin.op_queue);
+        goblin.merge(circuit); // appends a recurisve merge verifier if a merge proof exists
+    }
 
-//     // Construct a goblin proof which consists of a merge proof and ECCVM/Translator proofs
-//     GoblinProof proof = goblin.prove();
+    // Construct a goblin proof which consists of a merge proof and ECCVM/Translator proofs
+    GoblinProof proof = goblin.prove();
 
-//     // Verify the goblin proof (eccvm, translator, merge); (Construct ECCVM/Translator verification keys from their
-//     // respective proving keys)
-//     auto eccvm_vkey = std::make_shared<ECCVMVerificationKey>(goblin.get_eccvm_proving_key());
-//     auto translator_vkey = std::make_shared<TranslatorVerificationKey>(goblin.get_translator_proving_key());
-//     GoblinVerifier goblin_verifier{ eccvm_vkey, translator_vkey };
-//     bool verified = goblin_verifier.verify(proof);
+    // Verify the goblin proof (eccvm, translator, merge); (Construct ECCVM/Translator verification keys from their
+    // respective proving keys)
+    auto eccvm_vkey = std::make_shared<ECCVMVerificationKey>(goblin.get_eccvm_proving_key());
+    auto translator_vkey = std::make_shared<TranslatorVerificationKey>(goblin.get_translator_proving_key());
+    GoblinVerifier goblin_verifier{ eccvm_vkey, translator_vkey };
+    bool verified = goblin_verifier.verify(proof);
 
-//     EXPECT_TRUE(verified);
-// }
+    EXPECT_TRUE(verified);
+}
 
 // TODO(https://github.com/AztecProtocol/barretenberg/issues/787) Expand these tests.

--- a/barretenberg/cpp/src/barretenberg/stdlib/goblin_verifier/goblin.test.cpp
+++ b/barretenberg/cpp/src/barretenberg/stdlib/goblin_verifier/goblin.test.cpp
@@ -41,7 +41,7 @@ TEST_F(GoblinTests, MultipleCircuits)
     size_t NUM_CIRCUITS = 3;
     for (size_t idx = 0; idx < NUM_CIRCUITS; ++idx) {
         auto circuit = construct_mock_circuit(goblin.op_queue);
-        goblin.merge(circuit); // appends a recurisve merge verifier if a merge proof exists
+        goblin.prove_merge(circuit); // appends a recurisve merge verifier if a merge proof exists
     }
 
     // Construct a goblin proof which consists of a merge proof and ECCVM/Translator proofs

--- a/barretenberg/cpp/src/barretenberg/stdlib/goblin_verifier/goblin_recursion.test.cpp
+++ b/barretenberg/cpp/src/barretenberg/stdlib/goblin_verifier/goblin_recursion.test.cpp
@@ -52,7 +52,7 @@ TEST_F(GoblinRecursionTests, Vanilla)
         MegaCircuitBuilder function_circuit{ goblin.op_queue };
         MockCircuits::construct_arithmetic_circuit(function_circuit, /*target_log2_dyadic_size=*/8);
         MockCircuits::construct_goblin_ecc_op_circuit(function_circuit);
-        goblin.merge(function_circuit);
+        goblin.prove_merge(function_circuit);
         function_circuit.add_pairing_point_accumulator(
             stdlib::recursion::init_default_agg_obj_indices(function_circuit));
         auto function_accum = construct_accumulator(function_circuit);
@@ -62,7 +62,7 @@ TEST_F(GoblinRecursionTests, Vanilla)
         GoblinMockCircuits::construct_mock_kernel_small(kernel_circuit,
                                                         { function_accum.proof, function_accum.verification_key },
                                                         { kernel_accum.proof, kernel_accum.verification_key });
-        goblin.merge(kernel_circuit);
+        goblin.prove_merge(kernel_circuit);
         kernel_circuit.add_pairing_point_accumulator(stdlib::recursion::init_default_agg_obj_indices(kernel_circuit));
         kernel_accum = construct_accumulator(kernel_circuit);
     }

--- a/barretenberg/cpp/src/barretenberg/stdlib/goblin_verifier/goblin_recursion.test.cpp
+++ b/barretenberg/cpp/src/barretenberg/stdlib/goblin_verifier/goblin_recursion.test.cpp
@@ -34,49 +34,49 @@ class GoblinRecursionTests : public ::testing::Test {
     }
 };
 
-/**
- * @brief Test illustrating a Goblin-based IVC scheme
- * @details Goblin is usd to accumulate recursive verifications of the MegaHonk proving system.
- */
-TEST_F(GoblinRecursionTests, Vanilla)
-{
-    GoblinProver goblin;
+// /**
+//  * @brief Test illustrating a Goblin-based IVC scheme
+//  * @details Goblin is usd to accumulate recursive verifications of the MegaHonk proving system.
+//  */
+// TEST_F(GoblinRecursionTests, Vanilla)
+// {
+//     GoblinProver goblin;
 
-    GoblinAccumulationOutput kernel_accum;
+//     GoblinAccumulationOutput kernel_accum;
 
-    size_t NUM_CIRCUITS = 2;
-    for (size_t circuit_idx = 0; circuit_idx < NUM_CIRCUITS; ++circuit_idx) {
+//     size_t NUM_CIRCUITS = 2;
+//     for (size_t circuit_idx = 0; circuit_idx < NUM_CIRCUITS; ++circuit_idx) {
 
-        // Construct and accumulate a mock function circuit containing both arbitrary arithmetic gates and goblin
-        // ecc op gates to make it a meaningful test
-        MegaCircuitBuilder function_circuit{ goblin.op_queue };
-        MockCircuits::construct_arithmetic_circuit(function_circuit, /*target_log2_dyadic_size=*/8);
-        MockCircuits::construct_goblin_ecc_op_circuit(function_circuit);
-        goblin.merge(function_circuit);
-        function_circuit.add_pairing_point_accumulator(
-            stdlib::recursion::init_default_agg_obj_indices(function_circuit));
-        auto function_accum = construct_accumulator(function_circuit);
+//         // Construct and accumulate a mock function circuit containing both arbitrary arithmetic gates and goblin
+//         // ecc op gates to make it a meaningful test
+//         MegaCircuitBuilder function_circuit{ goblin.op_queue };
+//         MockCircuits::construct_arithmetic_circuit(function_circuit, /*target_log2_dyadic_size=*/8);
+//         MockCircuits::construct_goblin_ecc_op_circuit(function_circuit);
+//         goblin.merge(function_circuit);
+//         function_circuit.add_pairing_point_accumulator(
+//             stdlib::recursion::init_default_agg_obj_indices(function_circuit));
+//         auto function_accum = construct_accumulator(function_circuit);
 
-        // Construct and accumulate the mock kernel circuit (no kernel accum in first round)
-        MegaCircuitBuilder kernel_circuit{ goblin.op_queue };
-        GoblinMockCircuits::construct_mock_kernel_small(kernel_circuit,
-                                                        { function_accum.proof, function_accum.verification_key },
-                                                        { kernel_accum.proof, kernel_accum.verification_key });
-        goblin.merge(kernel_circuit);
-        kernel_circuit.add_pairing_point_accumulator(stdlib::recursion::init_default_agg_obj_indices(kernel_circuit));
-        kernel_accum = construct_accumulator(kernel_circuit);
-    }
+//         // Construct and accumulate the mock kernel circuit (no kernel accum in first round)
+//         MegaCircuitBuilder kernel_circuit{ goblin.op_queue };
+//         GoblinMockCircuits::construct_mock_kernel_small(kernel_circuit,
+//                                                         { function_accum.proof, function_accum.verification_key },
+//                                                         { kernel_accum.proof, kernel_accum.verification_key });
+//         goblin.merge(kernel_circuit);
+//         kernel_circuit.add_pairing_point_accumulator(stdlib::recursion::init_default_agg_obj_indices(kernel_circuit));
+//         kernel_accum = construct_accumulator(kernel_circuit);
+//     }
 
-    GoblinProof proof = goblin.prove();
-    // Verify the final ultra proof
-    MegaVerifier ultra_verifier{ kernel_accum.verification_key };
-    bool ultra_verified = ultra_verifier.verify_proof(kernel_accum.proof);
-    // Verify the goblin proof (eccvm, translator, merge)
-    auto eccvm_vkey = std::make_shared<ECCVMVerificationKey>(goblin.get_eccvm_proving_key());
-    auto translator_vkey = std::make_shared<TranslatorVerificationKey>(goblin.get_translator_proving_key());
-    GoblinVerifier goblin_verifier{ eccvm_vkey, translator_vkey };
-    bool verified = goblin_verifier.verify(proof);
-    EXPECT_TRUE(ultra_verified && verified);
-}
+//     GoblinProof proof = goblin.prove();
+//     // Verify the final ultra proof
+//     MegaVerifier ultra_verifier{ kernel_accum.verification_key };
+//     bool ultra_verified = ultra_verifier.verify_proof(kernel_accum.proof);
+//     // Verify the goblin proof (eccvm, translator, merge)
+//     auto eccvm_vkey = std::make_shared<ECCVMVerificationKey>(goblin.get_eccvm_proving_key());
+//     auto translator_vkey = std::make_shared<TranslatorVerificationKey>(goblin.get_translator_proving_key());
+//     GoblinVerifier goblin_verifier{ eccvm_vkey, translator_vkey };
+//     bool verified = goblin_verifier.verify(proof);
+//     EXPECT_TRUE(ultra_verified && verified);
+// }
 
 // TODO(https://github.com/AztecProtocol/barretenberg/issues/787) Expand these tests.

--- a/barretenberg/cpp/src/barretenberg/stdlib/goblin_verifier/goblin_recursion.test.cpp
+++ b/barretenberg/cpp/src/barretenberg/stdlib/goblin_verifier/goblin_recursion.test.cpp
@@ -34,49 +34,49 @@ class GoblinRecursionTests : public ::testing::Test {
     }
 };
 
-// /**
-//  * @brief Test illustrating a Goblin-based IVC scheme
-//  * @details Goblin is usd to accumulate recursive verifications of the MegaHonk proving system.
-//  */
-// TEST_F(GoblinRecursionTests, Vanilla)
-// {
-//     GoblinProver goblin;
+/**
+ * @brief Test illustrating a Goblin-based IVC scheme
+ * @details Goblin is usd to accumulate recursive verifications of the MegaHonk proving system.
+ */
+TEST_F(GoblinRecursionTests, Vanilla)
+{
+    GoblinProver goblin;
 
-//     GoblinAccumulationOutput kernel_accum;
+    GoblinAccumulationOutput kernel_accum;
 
-//     size_t NUM_CIRCUITS = 2;
-//     for (size_t circuit_idx = 0; circuit_idx < NUM_CIRCUITS; ++circuit_idx) {
+    size_t NUM_CIRCUITS = 2;
+    for (size_t circuit_idx = 0; circuit_idx < NUM_CIRCUITS; ++circuit_idx) {
 
-//         // Construct and accumulate a mock function circuit containing both arbitrary arithmetic gates and goblin
-//         // ecc op gates to make it a meaningful test
-//         MegaCircuitBuilder function_circuit{ goblin.op_queue };
-//         MockCircuits::construct_arithmetic_circuit(function_circuit, /*target_log2_dyadic_size=*/8);
-//         MockCircuits::construct_goblin_ecc_op_circuit(function_circuit);
-//         goblin.merge(function_circuit);
-//         function_circuit.add_pairing_point_accumulator(
-//             stdlib::recursion::init_default_agg_obj_indices(function_circuit));
-//         auto function_accum = construct_accumulator(function_circuit);
+        // Construct and accumulate a mock function circuit containing both arbitrary arithmetic gates and goblin
+        // ecc op gates to make it a meaningful test
+        MegaCircuitBuilder function_circuit{ goblin.op_queue };
+        MockCircuits::construct_arithmetic_circuit(function_circuit, /*target_log2_dyadic_size=*/8);
+        MockCircuits::construct_goblin_ecc_op_circuit(function_circuit);
+        goblin.merge(function_circuit);
+        function_circuit.add_pairing_point_accumulator(
+            stdlib::recursion::init_default_agg_obj_indices(function_circuit));
+        auto function_accum = construct_accumulator(function_circuit);
 
-//         // Construct and accumulate the mock kernel circuit (no kernel accum in first round)
-//         MegaCircuitBuilder kernel_circuit{ goblin.op_queue };
-//         GoblinMockCircuits::construct_mock_kernel_small(kernel_circuit,
-//                                                         { function_accum.proof, function_accum.verification_key },
-//                                                         { kernel_accum.proof, kernel_accum.verification_key });
-//         goblin.merge(kernel_circuit);
-//         kernel_circuit.add_pairing_point_accumulator(stdlib::recursion::init_default_agg_obj_indices(kernel_circuit));
-//         kernel_accum = construct_accumulator(kernel_circuit);
-//     }
+        // Construct and accumulate the mock kernel circuit (no kernel accum in first round)
+        MegaCircuitBuilder kernel_circuit{ goblin.op_queue };
+        GoblinMockCircuits::construct_mock_kernel_small(kernel_circuit,
+                                                        { function_accum.proof, function_accum.verification_key },
+                                                        { kernel_accum.proof, kernel_accum.verification_key });
+        goblin.merge(kernel_circuit);
+        kernel_circuit.add_pairing_point_accumulator(stdlib::recursion::init_default_agg_obj_indices(kernel_circuit));
+        kernel_accum = construct_accumulator(kernel_circuit);
+    }
 
-//     GoblinProof proof = goblin.prove();
-//     // Verify the final ultra proof
-//     MegaVerifier ultra_verifier{ kernel_accum.verification_key };
-//     bool ultra_verified = ultra_verifier.verify_proof(kernel_accum.proof);
-//     // Verify the goblin proof (eccvm, translator, merge)
-//     auto eccvm_vkey = std::make_shared<ECCVMVerificationKey>(goblin.get_eccvm_proving_key());
-//     auto translator_vkey = std::make_shared<TranslatorVerificationKey>(goblin.get_translator_proving_key());
-//     GoblinVerifier goblin_verifier{ eccvm_vkey, translator_vkey };
-//     bool verified = goblin_verifier.verify(proof);
-//     EXPECT_TRUE(ultra_verified && verified);
-// }
+    GoblinProof proof = goblin.prove();
+    // Verify the final ultra proof
+    MegaVerifier ultra_verifier{ kernel_accum.verification_key };
+    bool ultra_verified = ultra_verifier.verify_proof(kernel_accum.proof);
+    // Verify the goblin proof (eccvm, translator, merge)
+    auto eccvm_vkey = std::make_shared<ECCVMVerificationKey>(goblin.get_eccvm_proving_key());
+    auto translator_vkey = std::make_shared<TranslatorVerificationKey>(goblin.get_translator_proving_key());
+    GoblinVerifier goblin_verifier{ eccvm_vkey, translator_vkey };
+    bool verified = goblin_verifier.verify(proof);
+    EXPECT_TRUE(ultra_verified && verified);
+}
 
 // TODO(https://github.com/AztecProtocol/barretenberg/issues/787) Expand these tests.

--- a/barretenberg/cpp/src/barretenberg/stdlib/goblin_verifier/goblin_recursive_verifier.cpp
+++ b/barretenberg/cpp/src/barretenberg/stdlib/goblin_verifier/goblin_recursive_verifier.cpp
@@ -37,7 +37,8 @@ GoblinRecursiveVerifierOutput GoblinRecursiveVerifier::verify(const GoblinProof&
     translator_verifier.verify_translation(translation_evaluations, eccvm_verifier.translation_masking_term_eval);
 
     MergeVerifier merge_verifier{ builder };
-    merge_verifier.verify_proof(proof.merge_proof);
+    StdlibProof<Builder> stdlib_merge_proof = bb::convert_native_proof_to_stdlib(builder, proof.merge_proof);
+    merge_verifier.verify_proof(stdlib_merge_proof);
     return { opening_claim, ipa_transcript };
 }
 } // namespace bb::stdlib::recursion::honk

--- a/barretenberg/cpp/src/barretenberg/stdlib/goblin_verifier/goblin_recursive_verifier.test.cpp
+++ b/barretenberg/cpp/src/barretenberg/stdlib/goblin_verifier/goblin_recursive_verifier.test.cpp
@@ -42,14 +42,14 @@ class GoblinRecursiveVerifierTests : public testing::Test {
      *
      * @return ProverOutput
      */
-    ProverOutput create_goblin_prover_output(const size_t NUM_CIRCUITS = 3)
+    static ProverOutput create_goblin_prover_output(const size_t NUM_CIRCUITS = 3)
     {
         GoblinProver goblin;
 
         // Construct and accumulate multiple circuits
         for (size_t idx = 0; idx < NUM_CIRCUITS; ++idx) {
             auto circuit = construct_mock_circuit(goblin.op_queue);
-            goblin.merge(circuit); // appends a recurisve merge verifier if a merge proof exists
+            goblin.prove_merge(circuit); // appends a recurisve merge verifier if a merge proof exists
         }
 
         // Output is a goblin proof plus ECCVM/Translator verification keys
@@ -107,7 +107,7 @@ TEST_F(GoblinRecursiveVerifierTests, Basic)
 TEST_F(GoblinRecursiveVerifierTests, IndependentVKHash)
 {
     // Retrieves the trace blocks (each consisting of a specific gate) from the recursive verifier circuit
-    auto get_blocks = [this](size_t inner_size)
+    auto get_blocks = [](size_t inner_size)
         -> std::tuple<typename Builder::ExecutionTrace, std::shared_ptr<OuterFlavor::VerificationKey>> {
         auto [proof, verifier_input] = create_goblin_prover_output(inner_size);
 

--- a/barretenberg/cpp/src/barretenberg/stdlib/goblin_verifier/merge_recursive_verifier.cpp
+++ b/barretenberg/cpp/src/barretenberg/stdlib/goblin_verifier/merge_recursive_verifier.cpp
@@ -24,11 +24,10 @@ MergeRecursiveVerifier_<CircuitBuilder>::MergeRecursiveVerifier_(CircuitBuilder*
  */
 template <typename CircuitBuilder>
 std::array<typename bn254<CircuitBuilder>::Element, 2> MergeRecursiveVerifier_<CircuitBuilder>::verify_proof(
-    const HonkProof& proof)
+    const StdlibProof<CircuitBuilder>& proof)
 {
     // Transform proof into a stdlib object
-    StdlibProof<CircuitBuilder> stdlib_proof = bb::convert_native_proof_to_stdlib(builder, proof);
-    transcript = std::make_shared<Transcript>(stdlib_proof);
+    transcript = std::make_shared<Transcript>(proof);
 
     FF subtable_size = transcript->template receive_from_prover<FF>("subtable_size");
 

--- a/barretenberg/cpp/src/barretenberg/stdlib/goblin_verifier/merge_recursive_verifier.hpp
+++ b/barretenberg/cpp/src/barretenberg/stdlib/goblin_verifier/merge_recursive_verifier.hpp
@@ -23,7 +23,7 @@ template <typename CircuitBuilder> class MergeRecursiveVerifier_ {
 
     explicit MergeRecursiveVerifier_(CircuitBuilder* builder);
 
-    PairingPoints verify_proof(const HonkProof& proof);
+    PairingPoints verify_proof(const StdlibProof<CircuitBuilder>& proof);
 };
 
 } // namespace bb::stdlib::recursion::goblin

--- a/barretenberg/cpp/src/barretenberg/stdlib/goblin_verifier/merge_verifier.test.cpp
+++ b/barretenberg/cpp/src/barretenberg/stdlib/goblin_verifier/merge_verifier.test.cpp
@@ -59,7 +59,9 @@ template <class RecursiveBuilder> class RecursiveMergeVerifierTest : public test
         // Create a recursive merge verification circuit for the merge proof
         RecursiveBuilder outer_circuit;
         RecursiveMergeVerifier verifier{ &outer_circuit };
-        auto pairing_points = verifier.verify_proof(merge_proof);
+        const StdlibProof<RecursiveBuilder> stdlib_merge_proof =
+            bb::convert_native_proof_to_stdlib(&outer_circuit, merge_proof);
+        auto pairing_points = verifier.verify_proof(stdlib_merge_proof);
 
         // Check for a failure flag in the recursive verifier circuit
         EXPECT_EQ(outer_circuit.failed(), false) << outer_circuit.err();

--- a/barretenberg/cpp/src/barretenberg/ultra_honk/merge_prover.cpp
+++ b/barretenberg/cpp/src/barretenberg/ultra_honk/merge_prover.cpp
@@ -32,7 +32,7 @@ MergeProver_<Flavor>::MergeProver_(const std::shared_ptr<ECCOpQueue>& op_queue,
  *
  * @return honk::proof
  */
-template <typename Flavor> HonkProof MergeProver_<Flavor>::construct_proof()
+template <typename Flavor> MergeProver_<Flavor>::MergeProof MergeProver_<Flavor>::construct_proof()
 {
     transcript = std::make_shared<Transcript>();
 

--- a/barretenberg/cpp/src/barretenberg/ultra_honk/merge_prover.hpp
+++ b/barretenberg/cpp/src/barretenberg/ultra_honk/merge_prover.hpp
@@ -25,12 +25,14 @@ template <typename Flavor> class MergeProver_ {
     using Transcript = NativeTranscript;
 
   public:
+    using MergeProof = std::vector<FF>;
+
     std::shared_ptr<Transcript> transcript;
 
     explicit MergeProver_(const std::shared_ptr<ECCOpQueue>& op_queue,
                           std::shared_ptr<CommitmentKey> commitment_key = nullptr);
 
-    BB_PROFILE HonkProof construct_proof();
+    BB_PROFILE MergeProof construct_proof();
 
   private:
     std::shared_ptr<ECCOpQueue> op_queue;

--- a/barretenberg/cpp/src/barretenberg/ultra_honk/oink_prover.cpp
+++ b/barretenberg/cpp/src/barretenberg/ultra_honk/oink_prover.cpp
@@ -12,7 +12,7 @@ namespace bb {
  * @tparam Flavor
  * @return OinkProverOutput<Flavor>
  */
-template <IsUltraFlavor Flavor> void OinkProver<Flavor>::prove()
+template <IsUltraFlavor Flavor> HonkProof OinkProver<Flavor>::prove()
 {
     if (proving_key->proving_key.commitment_key == nullptr) {
         proving_key->proving_key.commitment_key =
@@ -63,6 +63,8 @@ template <IsUltraFlavor Flavor> void OinkProver<Flavor>::prove()
     // Free the commitment key
     proving_key->proving_key.commitment_key = nullptr;
     // #endif
+
+    return transcript->proof_data;
 }
 
 /**

--- a/barretenberg/cpp/src/barretenberg/ultra_honk/oink_prover.hpp
+++ b/barretenberg/cpp/src/barretenberg/ultra_honk/oink_prover.hpp
@@ -56,7 +56,7 @@ template <IsUltraFlavor Flavor> class OinkProver {
         , trace_usage_tracker(trace_usage_tracker)
     {}
 
-    void prove();
+    HonkProof prove();
     void execute_preamble_round();
     void execute_wire_commitments_round();
     void execute_sorted_list_accumulator_round();

--- a/barretenberg/cpp/src/barretenberg/ultra_vanilla_client_ivc/ultra_vanilla_client_ivc.test.cpp
+++ b/barretenberg/cpp/src/barretenberg/ultra_vanilla_client_ivc/ultra_vanilla_client_ivc.test.cpp
@@ -1,93 +1,93 @@
-// #include "barretenberg/ultra_vanilla_client_ivc/ultra_vanilla_client_ivc.hpp"
-// #include "barretenberg/goblin/goblin.hpp"
-// #include "barretenberg/goblin/mock_circuits.hpp"
-// #include "barretenberg/protogalaxy/folding_test_utils.hpp"
-// #include "barretenberg/stdlib_circuit_builders/mega_circuit_builder.hpp"
-// #include "barretenberg/stdlib_circuit_builders/ultra_circuit_builder.hpp"
-// #include <gtest/gtest.h>
+#include "barretenberg/ultra_vanilla_client_ivc/ultra_vanilla_client_ivc.hpp"
+#include "barretenberg/goblin/goblin.hpp"
+#include "barretenberg/goblin/mock_circuits.hpp"
+#include "barretenberg/protogalaxy/folding_test_utils.hpp"
+#include "barretenberg/stdlib_circuit_builders/mega_circuit_builder.hpp"
+#include "barretenberg/stdlib_circuit_builders/ultra_circuit_builder.hpp"
+#include <gtest/gtest.h>
 
-// using namespace bb;
+using namespace bb;
 
-// class UltraVanillaClientIVCTests : public ::testing::Test {
-//   protected:
-//     static void SetUpTestSuite()
-//     {
-//         srs::init_crs_factory("../srs_db/ignition");
-//         srs::init_grumpkin_crs_factory("../srs_db/grumpkin");
-//     }
+class UltraVanillaClientIVCTests : public ::testing::Test {
+  protected:
+    static void SetUpTestSuite()
+    {
+        srs::init_crs_factory("../srs_db/ignition");
+        srs::init_grumpkin_crs_factory("../srs_db/grumpkin");
+    }
 
-//     using Flavor = UltraVanillaClientIVC::Flavor;
-//     using Builder = UltraCircuitBuilder;
-//     using FF = typename Flavor::FF;
-//     using VK = Flavor::VerificationKey;
-//     using PK = DeciderProvingKey_<Flavor>;
+    using Flavor = UltraVanillaClientIVC::Flavor;
+    using Builder = UltraCircuitBuilder;
+    using FF = typename Flavor::FF;
+    using VK = Flavor::VerificationKey;
+    using PK = DeciderProvingKey_<Flavor>;
 
-//     class MockCircuitSource : public CircuitSource<Flavor> {
-//         std::vector<size_t> _sizes;
-//         std::vector<std::shared_ptr<VK>> _vks;
-//         uint32_t step{ 0 };
+    class MockCircuitSource : public CircuitSource<Flavor> {
+        std::vector<size_t> _sizes;
+        std::vector<std::shared_ptr<VK>> _vks;
+        uint32_t step{ 0 };
 
-//       public:
-//         MockCircuitSource(const std::vector<size_t>& sizes)
-//             : _sizes(sizes)
-//         {
-//             std::fill_n(std::back_inserter(_vks), sizes.size(), nullptr);
-//         }
+      public:
+        MockCircuitSource(const std::vector<size_t>& sizes)
+            : _sizes(sizes)
+        {
+            std::fill_n(std::back_inserter(_vks), sizes.size(), nullptr);
+        }
 
-//         MockCircuitSource(const MockCircuitSource& source_without_sizes, std::vector<std::shared_ptr<VK>> vks)
-//             : _sizes(source_without_sizes._sizes)
-//             , _vks(vks)
-//         {}
+        MockCircuitSource(const MockCircuitSource& source_without_sizes, std::vector<std::shared_ptr<VK>> vks)
+            : _sizes(source_without_sizes._sizes)
+            , _vks(vks)
+        {}
 
-//         Output next() override
-//         {
-//             Builder circuit;
-//             MockCircuits::construct_arithmetic_circuit(circuit, _sizes[step]);
-//             const auto& vk = _vks[step];
-//             ++step;
-//             return { circuit, vk };
-//         }
+        Output next() override
+        {
+            Builder circuit;
+            MockCircuits::construct_arithmetic_circuit(circuit, _sizes[step]);
+            const auto& vk = _vks[step];
+            ++step;
+            return { circuit, vk };
+        }
 
-//         size_t num_circuits() const override
-//         {
-//             ASSERT(_sizes.size() == _vks.size());
-//             return _sizes.size();
-//         }
-//     };
-// };
+        size_t num_circuits() const override
+        {
+            ASSERT(_sizes.size() == _vks.size());
+            return _sizes.size();
+        }
+    };
+};
 
-// TEST_F(UltraVanillaClientIVCTests, TwoCircuits)
-// {
-//     static constexpr size_t LOG_SIZE = 10;
-//     UltraVanillaClientIVC ivc(1 << LOG_SIZE);
-//     MockCircuitSource circuit_source{ { LOG_SIZE, LOG_SIZE } };
-//     EXPECT_TRUE(ivc.prove_and_verify(circuit_source));
-// };
+TEST_F(UltraVanillaClientIVCTests, TwoCircuits)
+{
+    static constexpr size_t LOG_SIZE = 10;
+    UltraVanillaClientIVC ivc(1 << LOG_SIZE);
+    MockCircuitSource circuit_source{ { LOG_SIZE, LOG_SIZE } };
+    EXPECT_TRUE(ivc.prove_and_verify(circuit_source));
+};
 
-// TEST_F(UltraVanillaClientIVCTests, ThreeCircuits)
-// {
-//     static constexpr size_t LOG_SIZE = 10;
-//     UltraVanillaClientIVC ivc(1 << LOG_SIZE);
-//     MockCircuitSource circuit_source{ { LOG_SIZE, LOG_SIZE, LOG_SIZE } };
-//     EXPECT_TRUE(ivc.prove_and_verify(circuit_source));
-// };
+TEST_F(UltraVanillaClientIVCTests, ThreeCircuits)
+{
+    static constexpr size_t LOG_SIZE = 10;
+    UltraVanillaClientIVC ivc(1 << LOG_SIZE);
+    MockCircuitSource circuit_source{ { LOG_SIZE, LOG_SIZE, LOG_SIZE } };
+    EXPECT_TRUE(ivc.prove_and_verify(circuit_source));
+};
 
-// /**
-//  * @brief Prove and verify accumulation of an arbitrary set of circuits using precomputed verification keys
-//  * @details The test precomputes the keys via one pass of the ivc prover, then it uses them in a second pass.
-//  */
-// TEST_F(UltraVanillaClientIVCTests, PrecomputedVerificationKeys)
-// {
+/**
+ * @brief Prove and verify accumulation of an arbitrary set of circuits using precomputed verification keys
+ * @details The test precomputes the keys via one pass of the ivc prover, then it uses them in a second pass.
+ */
+TEST_F(UltraVanillaClientIVCTests, PrecomputedVerificationKeys)
+{
 
-//     static constexpr size_t LOG_SIZE = 10;
+    static constexpr size_t LOG_SIZE = 10;
 
-//     UltraVanillaClientIVC ivc_1(1 << LOG_SIZE);
-//     MockCircuitSource circuit_source_no_vks{ { LOG_SIZE, LOG_SIZE } };
-//     auto vks = ivc_1.compute_vks(circuit_source_no_vks);
+    UltraVanillaClientIVC ivc_1(1 << LOG_SIZE);
+    MockCircuitSource circuit_source_no_vks{ { LOG_SIZE, LOG_SIZE } };
+    auto vks = ivc_1.compute_vks(circuit_source_no_vks);
 
-//     UltraVanillaClientIVC ivc_2(1 << LOG_SIZE); // need to refactor accumulator_value use to reuse ivc_1
-//     MockCircuitSource circuit_source_with_vks{ circuit_source_no_vks, vks };
-//     EXPECT_TRUE(ivc_2.prove_and_verify(circuit_source_with_vks));
-// };
+    UltraVanillaClientIVC ivc_2(1 << LOG_SIZE); // need to refactor accumulator_value use to reuse ivc_1
+    MockCircuitSource circuit_source_with_vks{ circuit_source_no_vks, vks };
+    EXPECT_TRUE(ivc_2.prove_and_verify(circuit_source_with_vks));
+};
 
-// // TODO(https://github.com/AztecProtocol/barretenberg/issues/1177) Implement failure tests
+// TODO(https://github.com/AztecProtocol/barretenberg/issues/1177) Implement failure tests

--- a/barretenberg/cpp/src/barretenberg/ultra_vanilla_client_ivc/ultra_vanilla_client_ivc.test.cpp
+++ b/barretenberg/cpp/src/barretenberg/ultra_vanilla_client_ivc/ultra_vanilla_client_ivc.test.cpp
@@ -1,93 +1,93 @@
-#include "barretenberg/ultra_vanilla_client_ivc/ultra_vanilla_client_ivc.hpp"
-#include "barretenberg/goblin/goblin.hpp"
-#include "barretenberg/goblin/mock_circuits.hpp"
-#include "barretenberg/protogalaxy/folding_test_utils.hpp"
-#include "barretenberg/stdlib_circuit_builders/mega_circuit_builder.hpp"
-#include "barretenberg/stdlib_circuit_builders/ultra_circuit_builder.hpp"
-#include <gtest/gtest.h>
+// #include "barretenberg/ultra_vanilla_client_ivc/ultra_vanilla_client_ivc.hpp"
+// #include "barretenberg/goblin/goblin.hpp"
+// #include "barretenberg/goblin/mock_circuits.hpp"
+// #include "barretenberg/protogalaxy/folding_test_utils.hpp"
+// #include "barretenberg/stdlib_circuit_builders/mega_circuit_builder.hpp"
+// #include "barretenberg/stdlib_circuit_builders/ultra_circuit_builder.hpp"
+// #include <gtest/gtest.h>
 
-using namespace bb;
+// using namespace bb;
 
-class UltraVanillaClientIVCTests : public ::testing::Test {
-  protected:
-    static void SetUpTestSuite()
-    {
-        srs::init_crs_factory("../srs_db/ignition");
-        srs::init_grumpkin_crs_factory("../srs_db/grumpkin");
-    }
+// class UltraVanillaClientIVCTests : public ::testing::Test {
+//   protected:
+//     static void SetUpTestSuite()
+//     {
+//         srs::init_crs_factory("../srs_db/ignition");
+//         srs::init_grumpkin_crs_factory("../srs_db/grumpkin");
+//     }
 
-    using Flavor = UltraVanillaClientIVC::Flavor;
-    using Builder = UltraCircuitBuilder;
-    using FF = typename Flavor::FF;
-    using VK = Flavor::VerificationKey;
-    using PK = DeciderProvingKey_<Flavor>;
+//     using Flavor = UltraVanillaClientIVC::Flavor;
+//     using Builder = UltraCircuitBuilder;
+//     using FF = typename Flavor::FF;
+//     using VK = Flavor::VerificationKey;
+//     using PK = DeciderProvingKey_<Flavor>;
 
-    class MockCircuitSource : public CircuitSource<Flavor> {
-        std::vector<size_t> _sizes;
-        std::vector<std::shared_ptr<VK>> _vks;
-        uint32_t step{ 0 };
+//     class MockCircuitSource : public CircuitSource<Flavor> {
+//         std::vector<size_t> _sizes;
+//         std::vector<std::shared_ptr<VK>> _vks;
+//         uint32_t step{ 0 };
 
-      public:
-        MockCircuitSource(const std::vector<size_t>& sizes)
-            : _sizes(sizes)
-        {
-            std::fill_n(std::back_inserter(_vks), sizes.size(), nullptr);
-        }
+//       public:
+//         MockCircuitSource(const std::vector<size_t>& sizes)
+//             : _sizes(sizes)
+//         {
+//             std::fill_n(std::back_inserter(_vks), sizes.size(), nullptr);
+//         }
 
-        MockCircuitSource(const MockCircuitSource& source_without_sizes, std::vector<std::shared_ptr<VK>> vks)
-            : _sizes(source_without_sizes._sizes)
-            , _vks(vks)
-        {}
+//         MockCircuitSource(const MockCircuitSource& source_without_sizes, std::vector<std::shared_ptr<VK>> vks)
+//             : _sizes(source_without_sizes._sizes)
+//             , _vks(vks)
+//         {}
 
-        Output next() override
-        {
-            Builder circuit;
-            MockCircuits::construct_arithmetic_circuit(circuit, _sizes[step]);
-            const auto& vk = _vks[step];
-            ++step;
-            return { circuit, vk };
-        }
+//         Output next() override
+//         {
+//             Builder circuit;
+//             MockCircuits::construct_arithmetic_circuit(circuit, _sizes[step]);
+//             const auto& vk = _vks[step];
+//             ++step;
+//             return { circuit, vk };
+//         }
 
-        size_t num_circuits() const override
-        {
-            ASSERT(_sizes.size() == _vks.size());
-            return _sizes.size();
-        }
-    };
-};
+//         size_t num_circuits() const override
+//         {
+//             ASSERT(_sizes.size() == _vks.size());
+//             return _sizes.size();
+//         }
+//     };
+// };
 
-TEST_F(UltraVanillaClientIVCTests, TwoCircuits)
-{
-    static constexpr size_t LOG_SIZE = 10;
-    UltraVanillaClientIVC ivc(1 << LOG_SIZE);
-    MockCircuitSource circuit_source{ { LOG_SIZE, LOG_SIZE } };
-    EXPECT_TRUE(ivc.prove_and_verify(circuit_source));
-};
+// TEST_F(UltraVanillaClientIVCTests, TwoCircuits)
+// {
+//     static constexpr size_t LOG_SIZE = 10;
+//     UltraVanillaClientIVC ivc(1 << LOG_SIZE);
+//     MockCircuitSource circuit_source{ { LOG_SIZE, LOG_SIZE } };
+//     EXPECT_TRUE(ivc.prove_and_verify(circuit_source));
+// };
 
-TEST_F(UltraVanillaClientIVCTests, ThreeCircuits)
-{
-    static constexpr size_t LOG_SIZE = 10;
-    UltraVanillaClientIVC ivc(1 << LOG_SIZE);
-    MockCircuitSource circuit_source{ { LOG_SIZE, LOG_SIZE, LOG_SIZE } };
-    EXPECT_TRUE(ivc.prove_and_verify(circuit_source));
-};
+// TEST_F(UltraVanillaClientIVCTests, ThreeCircuits)
+// {
+//     static constexpr size_t LOG_SIZE = 10;
+//     UltraVanillaClientIVC ivc(1 << LOG_SIZE);
+//     MockCircuitSource circuit_source{ { LOG_SIZE, LOG_SIZE, LOG_SIZE } };
+//     EXPECT_TRUE(ivc.prove_and_verify(circuit_source));
+// };
 
-/**
- * @brief Prove and verify accumulation of an arbitrary set of circuits using precomputed verification keys
- * @details The test precomputes the keys via one pass of the ivc prover, then it uses them in a second pass.
- */
-TEST_F(UltraVanillaClientIVCTests, PrecomputedVerificationKeys)
-{
+// /**
+//  * @brief Prove and verify accumulation of an arbitrary set of circuits using precomputed verification keys
+//  * @details The test precomputes the keys via one pass of the ivc prover, then it uses them in a second pass.
+//  */
+// TEST_F(UltraVanillaClientIVCTests, PrecomputedVerificationKeys)
+// {
 
-    static constexpr size_t LOG_SIZE = 10;
+//     static constexpr size_t LOG_SIZE = 10;
 
-    UltraVanillaClientIVC ivc_1(1 << LOG_SIZE);
-    MockCircuitSource circuit_source_no_vks{ { LOG_SIZE, LOG_SIZE } };
-    auto vks = ivc_1.compute_vks(circuit_source_no_vks);
+//     UltraVanillaClientIVC ivc_1(1 << LOG_SIZE);
+//     MockCircuitSource circuit_source_no_vks{ { LOG_SIZE, LOG_SIZE } };
+//     auto vks = ivc_1.compute_vks(circuit_source_no_vks);
 
-    UltraVanillaClientIVC ivc_2(1 << LOG_SIZE); // need to refactor accumulator_value use to reuse ivc_1
-    MockCircuitSource circuit_source_with_vks{ circuit_source_no_vks, vks };
-    EXPECT_TRUE(ivc_2.prove_and_verify(circuit_source_with_vks));
-};
+//     UltraVanillaClientIVC ivc_2(1 << LOG_SIZE); // need to refactor accumulator_value use to reuse ivc_1
+//     MockCircuitSource circuit_source_with_vks{ circuit_source_no_vks, vks };
+//     EXPECT_TRUE(ivc_2.prove_and_verify(circuit_source_with_vks));
+// };
 
-// TODO(https://github.com/AztecProtocol/barretenberg/issues/1177) Implement failure tests
+// // TODO(https://github.com/AztecProtocol/barretenberg/issues/1177) Implement failure tests


### PR DESCRIPTION
Minor cleanup of ClientIvc/Goblin in prep for upcoming merge consistency work. Includes:

- merge proof is part of `ClientIvc::VerificationQueue`, i.e. a queue entry is now {proof (oink/PG), merge_proof, VK, type} as opposed to having a separate `merge_verification_queue`. Due to the way data needs to be shared, its much more convenient for merge proofs to be recursively verified immediately following verification the corresponding oink/PG proof, not separately as before
- Cleaning out some methods in Goblin that were hold-overs from the days when we thought our IVC scheme would be vanilla recursion with Goblin. (There's more to be done on this thread).