### PR TITLE
fix: get L1 tx utils config from env

### DIFF
--- a/yarn-project/ethereum/src/deploy_l1_contracts.ts
+++ b/yarn-project/ethereum/src/deploy_l1_contracts.ts
@@ -67,6 +67,7 @@ import {
   L1TxUtils,
   type L1TxUtilsConfig,
   defaultL1TxUtilsConfig,
+  getL1TxUtilsConfigEnvVars,
 } from './l1_tx_utils.js';
 import type { L1Clients, ViemPublicClient, ViemWalletClient } from './types.js';
 
@@ -438,7 +439,7 @@ export const deployL1Contracts = async (
   chain: Chain,
   logger: Logger,
   args: DeployL1ContractsArgs,
-  txUtilsConfig: L1TxUtilsConfig = defaultL1TxUtilsConfig,
+  txUtilsConfig: L1TxUtilsConfig = getL1TxUtilsConfigEnvVars(),
 ): Promise<DeployL1ContractsReturnType> => {
   const clients = createL1Clients(rpcUrls, account, chain);
   const { walletClient, publicClient } = clients;
@@ -809,7 +810,8 @@ export async function deployL1Contract(
   let resultingAddress: Hex | null | undefined = undefined;
 
   if (!l1TxUtils) {
-    l1TxUtils = new L1TxUtils(publicClient, walletClient, logger, undefined, acceleratedTestDeployments);
+    const config = getL1TxUtilsConfigEnvVars();
+    l1TxUtils = new L1TxUtils(publicClient, walletClient, logger, config, acceleratedTestDeployments);
   }
 
   if (libraries) {

--- a/yarn-project/ethereum/src/deploy_l1_contracts.ts
+++ b/yarn-project/ethereum/src/deploy_l1_contracts.ts
@@ -66,7 +66,6 @@ import {
   type L1TxRequest,
   L1TxUtils,
   type L1TxUtilsConfig,
-  defaultL1TxUtilsConfig,
   getL1TxUtilsConfigEnvVars,
 } from './l1_tx_utils.js';
 import type { L1Clients, ViemPublicClient, ViemWalletClient } from './types.js';

--- a/yarn-project/ethereum/src/l1_tx_utils.ts
+++ b/yarn-project/ethereum/src/l1_tx_utils.ts
@@ -2,6 +2,7 @@ import { compactArray, times } from '@aztec/foundation/collection';
 import {
   type ConfigMappingsType,
   bigintConfigHelper,
+  getConfigFromMappings,
   getDefaultConfig,
   numberConfigHelper,
 } from '@aztec/foundation/config';
@@ -157,6 +158,10 @@ export const l1TxUtilsConfigMappings: ConfigMappingsType<L1TxUtilsConfig> = {
 };
 
 export const defaultL1TxUtilsConfig = getDefaultConfig<L1TxUtilsConfig>(l1TxUtilsConfigMappings);
+
+export function getL1TxUtilsConfigEnvVars(): L1TxUtilsConfig {
+  return getConfigFromMappings(l1TxUtilsConfigMappings);
+}
 
 export interface L1TxRequest {
   to: Address | null;


### PR DESCRIPTION
ensure l1 tx utils config is taken from env when deploying any L1 contracts