### PR TITLE
chore: Sumcheck optimizations

### DIFF
--- a/barretenberg/cpp/src/barretenberg/eccvm/eccvm_flavor.hpp
+++ b/barretenberg/cpp/src/barretenberg/eccvm/eccvm_flavor.hpp
@@ -716,7 +716,7 @@ class ECCVMFlavor {
         {
             for (auto [poly, full_poly] : zip_view(get_all(), full_polynomials.get_all())) {
                 // After the initial sumcheck round, the new size is CEIL(size/2).
-                size_t desired_size = std::min(full_poly.end_index() / 2 + full_poly.end_index() % 2, circuit_size / 2);
+                size_t desired_size = full_poly.end_index() / 2 + full_poly.end_index() % 2;
                 poly = Polynomial(desired_size, circuit_size / 2);
             }
         }

--- a/barretenberg/cpp/src/barretenberg/eccvm/eccvm_flavor.hpp
+++ b/barretenberg/cpp/src/barretenberg/eccvm/eccvm_flavor.hpp
@@ -715,7 +715,8 @@ class ECCVMFlavor {
         PartiallyEvaluatedMultivariates(const ProverPolynomials& full_polynomials, size_t circuit_size)
         {
             for (auto [poly, full_poly] : zip_view(get_all(), full_polynomials.get_all())) {
-                size_t desired_size = std::min(full_poly.end_index(), circuit_size / 2);
+                // After the initial sumcheck round, the new size is CEIL(size/2).
+                size_t desired_size = std::min(full_poly.end_index() / 2 + full_poly.end_index() % 2, circuit_size / 2);
                 poly = Polynomial(desired_size, circuit_size / 2);
             }
         }

--- a/barretenberg/cpp/src/barretenberg/polynomials/polynomial.cpp
+++ b/barretenberg/cpp/src/barretenberg/polynomials/polynomial.cpp
@@ -311,6 +311,12 @@ Polynomial<Fr> Polynomial<Fr>::expand(const size_t new_start_index, const size_t
     return result;
 }
 
+template <typename Fr> void Polynomial<Fr>::shrink(const size_t new_end_index)
+{
+    ASSERT(new_end_index <= end_index());
+    coefficients_.end_ = new_end_index;
+}
+
 template <typename Fr> Polynomial<Fr> Polynomial<Fr>::full() const
 {
     Polynomial result = *this;

--- a/barretenberg/cpp/src/barretenberg/polynomials/polynomial.cpp
+++ b/barretenberg/cpp/src/barretenberg/polynomials/polynomial.cpp
@@ -311,7 +311,7 @@ Polynomial<Fr> Polynomial<Fr>::expand(const size_t new_start_index, const size_t
     return result;
 }
 
-template <typename Fr> void Polynomial<Fr>::shrink(const size_t new_end_index)
+template <typename Fr> void Polynomial<Fr>::shrink_end_index(const size_t new_end_index)
 {
     ASSERT(new_end_index <= end_index());
     coefficients_.end_ = new_end_index;

--- a/barretenberg/cpp/src/barretenberg/polynomials/polynomial.hpp
+++ b/barretenberg/cpp/src/barretenberg/polynomials/polynomial.hpp
@@ -326,6 +326,13 @@ template <typename Fr> class Polynomial {
     Polynomial expand(const size_t new_start_index, const size_t new_end_index) const;
 
     /**
+     * @brief The end_index of the polynomial is decreased without any memory de-allocation.
+     *        This is a very fast way to zeroize the polynomial tail from new_end_index to the
+     *        end. It also means that the new end_index might be smaller than the backed memory.
+     */
+    void shrink(const size_t new_end_index);
+
+    /**
      * @brief Copys the polynomial, but with the whole address space usable.
      * The value of the polynomial remains the same, but defined memory region differs.
      *

--- a/barretenberg/cpp/src/barretenberg/polynomials/polynomial.hpp
+++ b/barretenberg/cpp/src/barretenberg/polynomials/polynomial.hpp
@@ -330,7 +330,7 @@ template <typename Fr> class Polynomial {
      *        This is a very fast way to zeroize the polynomial tail from new_end_index to the
      *        end. It also means that the new end_index might be smaller than the backed memory.
      */
-    void shrink(const size_t new_end_index);
+    void shrink_end_index(const size_t new_end_index);
 
     /**
      * @brief Copys the polynomial, but with the whole address space usable.

--- a/barretenberg/cpp/src/barretenberg/polynomials/shared_shifted_virtual_zeroes_array.hpp
+++ b/barretenberg/cpp/src/barretenberg/polynomials/shared_shifted_virtual_zeroes_array.hpp
@@ -115,7 +115,7 @@ template <typename T> struct SharedShiftedVirtualZeroesArray {
      *
      * Represents the first index after `start_` that is not backed by actual memory. Note however that
      * the backed memory might extend beyond end_ index but will not be accessed anymore. Namely, any
-     * access after after end_ returns zero. (Happens after Polynomial::shrink() call).
+     * access after after end_ returns zero. (Happens after Polynomial::shrink_end_index() call).
      */
     size_t end_ = 0;
 

--- a/barretenberg/cpp/src/barretenberg/polynomials/shared_shifted_virtual_zeroes_array.hpp
+++ b/barretenberg/cpp/src/barretenberg/polynomials/shared_shifted_virtual_zeroes_array.hpp
@@ -113,7 +113,9 @@ template <typename T> struct SharedShiftedVirtualZeroesArray {
     /**
      * @brief The ending index of the memory-backed range.
      *
-     * Represents the first index after `start_` that is not backed by actual memory.
+     * Represents the first index after `start_` that is not backed by actual memory. Note however that
+     * the backed memory might extend beyond end_ index but will not be accessed anymore. Namely, any
+     * access after after end_ returns zero. (Happens after Polynomial::shrink() call).
      */
     size_t end_ = 0;
 
@@ -128,7 +130,7 @@ template <typename T> struct SharedShiftedVirtualZeroesArray {
     /**
      * @brief Shared pointer to the underlying memory array.
      *
-     * The memory is allocated for the range [start_, end_). It is shared across instances to allow
+     * The memory is allocated for at least the range [start_, end_). It is shared across instances to allow
      * for efficient memory use when arrays are shifted or otherwise manipulated.
      */
     // NOLINTNEXTLINE(cppcoreguidelines-avoid-c-arrays)

--- a/barretenberg/cpp/src/barretenberg/stdlib_circuit_builders/mega_flavor.hpp
+++ b/barretenberg/cpp/src/barretenberg/stdlib_circuit_builders/mega_flavor.hpp
@@ -634,7 +634,8 @@ class MegaFlavor {
         PartiallyEvaluatedMultivariates(const ProverPolynomials& full_polynomials, size_t circuit_size)
         {
             for (auto [poly, full_poly] : zip_view(get_all(), full_polynomials.get_all())) {
-                size_t desired_size = std::min(full_poly.end_index(), circuit_size / 2);
+                // After the initial sumcheck round, the new size is CEIL(size/2).
+                size_t desired_size = std::min(full_poly.end_index() / 2 + full_poly.end_index() % 2, circuit_size / 2);
                 poly = Polynomial(desired_size, circuit_size / 2);
             }
         }

--- a/barretenberg/cpp/src/barretenberg/stdlib_circuit_builders/mega_flavor.hpp
+++ b/barretenberg/cpp/src/barretenberg/stdlib_circuit_builders/mega_flavor.hpp
@@ -635,7 +635,7 @@ class MegaFlavor {
         {
             for (auto [poly, full_poly] : zip_view(get_all(), full_polynomials.get_all())) {
                 // After the initial sumcheck round, the new size is CEIL(size/2).
-                size_t desired_size = std::min(full_poly.end_index() / 2 + full_poly.end_index() % 2, circuit_size / 2);
+                size_t desired_size = full_poly.end_index() / 2 + full_poly.end_index() % 2;
                 poly = Polynomial(desired_size, circuit_size / 2);
             }
         }

--- a/barretenberg/cpp/src/barretenberg/stdlib_circuit_builders/ultra_flavor.hpp
+++ b/barretenberg/cpp/src/barretenberg/stdlib_circuit_builders/ultra_flavor.hpp
@@ -509,7 +509,7 @@ class UltraFlavor {
             PROFILE_THIS_NAME("PartiallyEvaluatedMultivariates constructor");
             for (auto [poly, full_poly] : zip_view(get_all(), full_polynomials.get_all())) {
                 // After the initial sumcheck round, the new size is CEIL(size/2).
-                size_t desired_size = std::min(full_poly.end_index() / 2 + full_poly.end_index() % 2, circuit_size / 2);
+                size_t desired_size = full_poly.end_index() / 2 + full_poly.end_index() % 2;
                 poly = Polynomial(desired_size, circuit_size / 2);
             }
         }

--- a/barretenberg/cpp/src/barretenberg/stdlib_circuit_builders/ultra_flavor.hpp
+++ b/barretenberg/cpp/src/barretenberg/stdlib_circuit_builders/ultra_flavor.hpp
@@ -508,7 +508,8 @@ class UltraFlavor {
         {
             PROFILE_THIS_NAME("PartiallyEvaluatedMultivariates constructor");
             for (auto [poly, full_poly] : zip_view(get_all(), full_polynomials.get_all())) {
-                size_t desired_size = std::min(full_poly.end_index(), circuit_size / 2);
+                // After the initial sumcheck round, the new size is CEIL(size/2).
+                size_t desired_size = std::min(full_poly.end_index() / 2 + full_poly.end_index() % 2, circuit_size / 2);
                 poly = Polynomial(desired_size, circuit_size / 2);
             }
         }

--- a/barretenberg/cpp/src/barretenberg/sumcheck/partial_evaluation.test.cpp
+++ b/barretenberg/cpp/src/barretenberg/sumcheck/partial_evaluation.test.cpp
@@ -69,7 +69,7 @@ TYPED_TEST(PartialEvaluationTests, TwoRoundsSpecial)
     FF expected_hi = v01 * (FF(1) - round_challenge_0) + v11 * round_challenge_0;
 
     sumcheck.partially_evaluated_polynomials = typename Flavor::PartiallyEvaluatedMultivariates(multivariate_n);
-    sumcheck.partially_evaluate(full_polynomials, multivariate_n, round_challenge_0);
+    sumcheck.partially_evaluate(full_polynomials, round_challenge_0);
 
     auto& first_polynomial = sumcheck.partially_evaluated_polynomials.get_all()[0];
     EXPECT_EQ(first_polynomial[0], round_challenge_0);
@@ -78,7 +78,7 @@ TYPED_TEST(PartialEvaluationTests, TwoRoundsSpecial)
     FF round_challenge_1 = 2;
     FF expected_val = expected_lo * (FF(1) - round_challenge_1) + expected_hi * round_challenge_1;
 
-    sumcheck.partially_evaluate(sumcheck.partially_evaluated_polynomials, multivariate_n >> 1, round_challenge_1);
+    sumcheck.partially_evaluate(sumcheck.partially_evaluated_polynomials, round_challenge_1);
     EXPECT_EQ(first_polynomial[0], expected_val);
 }
 
@@ -109,7 +109,7 @@ TYPED_TEST(PartialEvaluationTests, TwoRoundsGeneric)
     FF expected_hi = v01 * (FF(1) - round_challenge_0) + v11 * round_challenge_0;
 
     sumcheck.partially_evaluated_polynomials = typename Flavor::PartiallyEvaluatedMultivariates(multivariate_n);
-    sumcheck.partially_evaluate(full_polynomials, multivariate_n, round_challenge_0);
+    sumcheck.partially_evaluate(full_polynomials, round_challenge_0);
     auto& first_polynomial = sumcheck.partially_evaluated_polynomials.get_all()[0];
 
     EXPECT_EQ(first_polynomial[0], expected_lo);
@@ -117,7 +117,7 @@ TYPED_TEST(PartialEvaluationTests, TwoRoundsGeneric)
 
     FF round_challenge_1 = FF::random_element();
     FF expected_val = expected_lo * (FF(1) - round_challenge_1) + expected_hi * round_challenge_1;
-    sumcheck.partially_evaluate(sumcheck.partially_evaluated_polynomials, multivariate_n >> 1, round_challenge_1);
+    sumcheck.partially_evaluate(sumcheck.partially_evaluated_polynomials, round_challenge_1);
     EXPECT_EQ(first_polynomial[0], expected_val);
 }
 
@@ -176,7 +176,7 @@ TYPED_TEST(PartialEvaluationTests, ThreeRoundsSpecial)
     FF expected_q4 = v011 * (FF(1) - round_challenge_0) + v111 * round_challenge_0; // 8
 
     sumcheck.partially_evaluated_polynomials = typename Flavor::PartiallyEvaluatedMultivariates(multivariate_n);
-    sumcheck.partially_evaluate(full_polynomials, multivariate_n, round_challenge_0);
+    sumcheck.partially_evaluate(full_polynomials, round_challenge_0);
 
     auto& first_polynomial = sumcheck.partially_evaluated_polynomials.get_all()[0];
     EXPECT_EQ(first_polynomial[0], expected_q1);
@@ -188,13 +188,13 @@ TYPED_TEST(PartialEvaluationTests, ThreeRoundsSpecial)
     FF expected_lo = expected_q1 * (FF(1) - round_challenge_1) + expected_q2 * round_challenge_1; // 6
     FF expected_hi = expected_q3 * (FF(1) - round_challenge_1) + expected_q4 * round_challenge_1; // 10
 
-    sumcheck.partially_evaluate(sumcheck.partially_evaluated_polynomials, multivariate_n >> 1, round_challenge_1);
+    sumcheck.partially_evaluate(sumcheck.partially_evaluated_polynomials, round_challenge_1);
     EXPECT_EQ(first_polynomial[0], expected_lo);
     EXPECT_EQ(first_polynomial[1], expected_hi);
 
     FF round_challenge_2 = 3;
     FF expected_val = expected_lo * (FF(1) - round_challenge_2) + expected_hi * round_challenge_2; // 18
-    sumcheck.partially_evaluate(sumcheck.partially_evaluated_polynomials, multivariate_n >> 2, round_challenge_2);
+    sumcheck.partially_evaluate(sumcheck.partially_evaluated_polynomials, round_challenge_2);
     EXPECT_EQ(first_polynomial[0], expected_val);
 }
 
@@ -232,7 +232,7 @@ TYPED_TEST(PartialEvaluationTests, ThreeRoundsGeneric)
 
     sumcheck.partially_evaluated_polynomials = typename Flavor::PartiallyEvaluatedMultivariates(multivariate_n);
     auto& first_polynomial = sumcheck.partially_evaluated_polynomials.get_all()[0];
-    sumcheck.partially_evaluate(full_polynomials, multivariate_n, round_challenge_0);
+    sumcheck.partially_evaluate(full_polynomials, round_challenge_0);
 
     EXPECT_EQ(first_polynomial[0], expected_q1);
     EXPECT_EQ(first_polynomial[1], expected_q2);
@@ -243,13 +243,13 @@ TYPED_TEST(PartialEvaluationTests, ThreeRoundsGeneric)
     FF expected_lo = expected_q1 * (FF(1) - round_challenge_1) + expected_q2 * round_challenge_1;
     FF expected_hi = expected_q3 * (FF(1) - round_challenge_1) + expected_q4 * round_challenge_1;
 
-    sumcheck.partially_evaluate(sumcheck.partially_evaluated_polynomials, multivariate_n >> 1, round_challenge_1);
+    sumcheck.partially_evaluate(sumcheck.partially_evaluated_polynomials, round_challenge_1);
     EXPECT_EQ(first_polynomial[0], expected_lo);
     EXPECT_EQ(first_polynomial[1], expected_hi);
 
     FF round_challenge_2 = FF::random_element();
     FF expected_val = expected_lo * (FF(1) - round_challenge_2) + expected_hi * round_challenge_2;
-    sumcheck.partially_evaluate(sumcheck.partially_evaluated_polynomials, multivariate_n >> 2, round_challenge_2);
+    sumcheck.partially_evaluate(sumcheck.partially_evaluated_polynomials, round_challenge_2);
     EXPECT_EQ(first_polynomial[0], expected_val);
 }
 
@@ -303,7 +303,7 @@ TYPED_TEST(PartialEvaluationTests, ThreeRoundsGenericMultiplePolys)
     }
 
     sumcheck.partially_evaluated_polynomials = typename Flavor::PartiallyEvaluatedMultivariates(multivariate_n);
-    sumcheck.partially_evaluate(full_polynomials, multivariate_n, round_challenge_0);
+    sumcheck.partially_evaluate(full_polynomials, round_challenge_0);
     auto polynomial_get_all = sumcheck.partially_evaluated_polynomials.get_all();
     for (size_t i = 0; i < 3; i++) {
         EXPECT_EQ((polynomial_get_all[i])[0], expected_q1[i]);
@@ -319,7 +319,7 @@ TYPED_TEST(PartialEvaluationTests, ThreeRoundsGenericMultiplePolys)
         expected_lo[i] = expected_q1[i] * (FF(1) - round_challenge_1) + expected_q2[i] * round_challenge_1;
         expected_hi[i] = expected_q3[i] * (FF(1) - round_challenge_1) + expected_q4[i] * round_challenge_1;
     }
-    sumcheck.partially_evaluate(sumcheck.partially_evaluated_polynomials, multivariate_n >> 1, round_challenge_1);
+    sumcheck.partially_evaluate(sumcheck.partially_evaluated_polynomials, round_challenge_1);
     for (size_t i = 0; i < 3; i++) {
         EXPECT_EQ((polynomial_get_all[i])[0], expected_lo[i]);
         EXPECT_EQ((polynomial_get_all[i])[1], expected_hi[i]);
@@ -329,7 +329,7 @@ TYPED_TEST(PartialEvaluationTests, ThreeRoundsGenericMultiplePolys)
     for (size_t i = 0; i < 3; i++) {
         expected_val[i] = expected_lo[i] * (FF(1) - round_challenge_2) + expected_hi[i] * round_challenge_2;
     }
-    sumcheck.partially_evaluate(sumcheck.partially_evaluated_polynomials, multivariate_n >> 2, round_challenge_2);
+    sumcheck.partially_evaluate(sumcheck.partially_evaluated_polynomials, round_challenge_2);
     for (size_t i = 0; i < 3; i++) {
         EXPECT_EQ((polynomial_get_all[i])[0], expected_val[i]);
     }

--- a/barretenberg/cpp/src/barretenberg/sumcheck/sumcheck.hpp
+++ b/barretenberg/cpp/src/barretenberg/sumcheck/sumcheck.hpp
@@ -208,7 +208,7 @@ template <typename Flavor> class SumcheckProver {
             FF round_challenge = transcript->template get_challenge<FF>("Sumcheck:u_0");
             multivariate_challenge.emplace_back(round_challenge);
             // Prepare sumcheck book-keeping table for the next round
-            partially_evaluate(full_polynomials, multivariate_n, round_challenge);
+            partially_evaluate(full_polynomials, round_challenge);
             gate_separators.partially_evaluate(round_challenge);
             round.round_size = round.round_size >> 1; // TODO(#224)(Cody): Maybe partially_evaluate should do this and
             // release memory?        // All but final round
@@ -225,7 +225,7 @@ template <typename Flavor> class SumcheckProver {
             FF round_challenge = transcript->template get_challenge<FF>("Sumcheck:u_" + std::to_string(round_idx));
             multivariate_challenge.emplace_back(round_challenge);
             // Prepare sumcheck book-keeping table for the next round.
-            partially_evaluate(partially_evaluated_polynomials, multivariate_n >> round_idx, round_challenge);
+            partially_evaluate(partially_evaluated_polynomials, round_challenge);
             gate_separators.partially_evaluate(round_challenge);
             round.round_size = round.round_size >> 1;
         }
@@ -319,7 +319,7 @@ template <typename Flavor> class SumcheckProver {
 
             multivariate_challenge.emplace_back(round_challenge);
             // Prepare sumcheck book-keeping table for the next round
-            partially_evaluate(full_polynomials, multivariate_n, round_challenge);
+            partially_evaluate(full_polynomials, round_challenge);
             // Prepare ZK Sumcheck data for the next round
             zk_sumcheck_data.update_zk_sumcheck_data(round_challenge, round_idx);
             row_disabling_polynomial.update_evaluations(round_challenge, round_idx);
@@ -354,7 +354,7 @@ template <typename Flavor> class SumcheckProver {
                 transcript->template get_challenge<FF>("Sumcheck:u_" + std::to_string(round_idx));
             multivariate_challenge.emplace_back(round_challenge);
             // Prepare sumcheck book-keeping table for the next round.
-            partially_evaluate(partially_evaluated_polynomials, multivariate_n >> round_idx, round_challenge);
+            partially_evaluate(partially_evaluated_polynomials, round_challenge);
             // Prepare evaluation masking and libra structures for the next round (for ZK Flavors)
             zk_sumcheck_data.update_zk_sumcheck_data(round_challenge, round_idx);
             row_disabling_polynomial.update_evaluations(round_challenge, round_idx);
@@ -447,15 +447,15 @@ template <typename Flavor> class SumcheckProver {
      * @param round_size \f$2^{d-i}\f$
      * @param round_challenge \f$u_i\f$
      */
-    void partially_evaluate(auto& polynomials, size_t round_size, FF round_challenge)
+    void partially_evaluate(auto& polynomials, FF round_challenge)
     {
         auto pep_view = partially_evaluated_polynomials.get_all();
         auto poly_view = polynomials.get_all();
         // after the first round, operate in place on partially_evaluated_polynomials
         parallel_for(poly_view.size(), [&](size_t j) {
             const auto& poly = poly_view[j];
-            // If the polynomial is shorter than the round size, we do a little optimization.
-            size_t limit = std::min(poly.end_index(), round_size);
+            // The polynomial is shorter than the round size.
+            size_t limit = poly.end_index();
             for (size_t i = 0; i < limit; i += 2) {
                 pep_view[j].at(i >> 1) = poly[i] + round_challenge * (poly[i + 1] - poly[i]);
             }
@@ -473,14 +473,14 @@ template <typename Flavor> class SumcheckProver {
      * Specialization for array, see \ref bb::SumcheckProver<Flavor>::partially_evaluate "generic version".
      */
     template <typename PolynomialT, std::size_t N>
-    void partially_evaluate(std::array<PolynomialT, N>& polynomials, size_t round_size, FF round_challenge)
+    void partially_evaluate(std::array<PolynomialT, N>& polynomials, FF round_challenge)
     {
         auto pep_view = partially_evaluated_polynomials.get_all();
         // after the first round, operate in place on partially_evaluated_polynomials
         parallel_for(polynomials.size(), [&](size_t j) {
             const auto& poly = polynomials[j];
-            // If the polynomial is shorter than the round size, we do a little optimization.
-            size_t limit = std::min(poly.end_index(), round_size);
+            // The polynomial is shorter than the round size.
+            size_t limit = poly.end_index();
             for (size_t i = 0; i < limit; i += 2) {
                 pep_view[j].at(i >> 1) = poly[i] + round_challenge * (poly[i + 1] - poly[i]);
             }

--- a/barretenberg/cpp/src/barretenberg/sumcheck/sumcheck.hpp
+++ b/barretenberg/cpp/src/barretenberg/sumcheck/sumcheck.hpp
@@ -465,7 +465,7 @@ template <typename Flavor> class SumcheckProver {
             // virtually zeroize any leftover values beyond the limit (in-place computation).
             // This is important to zeroize leftover values to not mess up with compute_univariate().
             // Note that the virtual size of pep_view[j] remains unchanged.
-            pep_view[j].shrink(limit / 2 + limit % 2);
+            pep_view[j].shrink_end_index(limit / 2 + limit % 2);
         });
     };
     /**
@@ -490,7 +490,7 @@ template <typename Flavor> class SumcheckProver {
             // virtually zeroize any leftover values beyond the limit (in-place computation).
             // This is important to zeroize leftover values to not mess up with compute_univariate().
             // Note that the virtual size of pep_view[j] remains unchanged.
-            pep_view[j].shrink(limit / 2 + limit % 2);
+            pep_view[j].shrink_end_index(limit / 2 + limit % 2);
         });
     };
 

--- a/barretenberg/cpp/src/barretenberg/sumcheck/sumcheck.hpp
+++ b/barretenberg/cpp/src/barretenberg/sumcheck/sumcheck.hpp
@@ -459,6 +459,13 @@ template <typename Flavor> class SumcheckProver {
             for (size_t i = 0; i < limit; i += 2) {
                 pep_view[j].at(i >> 1) = poly[i] + round_challenge * (poly[i + 1] - poly[i]);
             }
+
+            // We resize pep_view[j] to have the exact size required for the next round which is
+            // CEIL(limit/2). This has the effect to reduce the limit in next round and also to
+            // virtually zeroize any leftover values beyond the limit (in-place computation).
+            // This is important to zeroize leftover values to not mess up with compute_univariate().
+            // Note that the virtual size of pep_view[j] remains unchanged.
+            pep_view[j].shrink(limit / 2 + limit % 2);
         });
     };
     /**
@@ -477,6 +484,13 @@ template <typename Flavor> class SumcheckProver {
             for (size_t i = 0; i < limit; i += 2) {
                 pep_view[j].at(i >> 1) = poly[i] + round_challenge * (poly[i + 1] - poly[i]);
             }
+
+            // We resize pep_view[j] to have the exact size required for the next round which is
+            // CEIL(limit/2). This has the effect to reduce the limit in next round and also to
+            // virtually zeroize any leftover values beyond the limit (in-place computation).
+            // This is important to zeroize leftover values to not mess up with compute_univariate().
+            // Note that the virtual size of pep_view[j] remains unchanged.
+            pep_view[j].shrink(limit / 2 + limit % 2);
         });
     };
 

--- a/barretenberg/cpp/src/barretenberg/translator_vm/translator_flavor.hpp
+++ b/barretenberg/cpp/src/barretenberg/translator_vm/translator_flavor.hpp
@@ -744,7 +744,8 @@ class TranslatorFlavor {
         PartiallyEvaluatedMultivariates(const ProverPolynomials& full_polynomials, size_t circuit_size)
         {
             for (auto [poly, full_poly] : zip_view(get_all(), full_polynomials.get_all())) {
-                size_t desired_size = std::min(full_poly.end_index(), circuit_size / 2);
+                // After the initial sumcheck round, the new size is CEIL(size/2).
+                size_t desired_size = std::min(full_poly.end_index() / 2 + full_poly.end_index() % 2, circuit_size / 2);
                 poly = Polynomial(desired_size, circuit_size / 2);
             }
         }

--- a/barretenberg/cpp/src/barretenberg/translator_vm/translator_flavor.hpp
+++ b/barretenberg/cpp/src/barretenberg/translator_vm/translator_flavor.hpp
@@ -745,7 +745,7 @@ class TranslatorFlavor {
         {
             for (auto [poly, full_poly] : zip_view(get_all(), full_polynomials.get_all())) {
                 // After the initial sumcheck round, the new size is CEIL(size/2).
-                size_t desired_size = std::min(full_poly.end_index() / 2 + full_poly.end_index() % 2, circuit_size / 2);
+                size_t desired_size = full_poly.end_index() / 2 + full_poly.end_index() % 2;
                 poly = Polynomial(desired_size, circuit_size / 2);
             }
         }

--- a/barretenberg/cpp/src/barretenberg/vm/avm/generated/flavor.hpp
+++ b/barretenberg/cpp/src/barretenberg/vm/avm/generated/flavor.hpp
@@ -405,7 +405,8 @@ class AvmFlavor {
         PartiallyEvaluatedMultivariates(const ProverPolynomials& full_polynomials, size_t circuit_size)
         {
             for (auto [poly, full_poly] : zip_view(get_all(), full_polynomials.get_all())) {
-                size_t desired_size = std::min(full_poly.end_index(), circuit_size / 2);
+                // After the initial sumcheck round, the new size is CEIL(size/2).
+                size_t desired_size = std::min(full_poly.end_index() / 2 + full_poly.end_index() % 2, circuit_size / 2);
                 poly = Polynomial(desired_size, circuit_size / 2);
             }
         }

--- a/barretenberg/cpp/src/barretenberg/vm/avm/generated/flavor.hpp
+++ b/barretenberg/cpp/src/barretenberg/vm/avm/generated/flavor.hpp
@@ -406,7 +406,7 @@ class AvmFlavor {
         {
             for (auto [poly, full_poly] : zip_view(get_all(), full_polynomials.get_all())) {
                 // After the initial sumcheck round, the new size is CEIL(size/2).
-                size_t desired_size = std::min(full_poly.end_index() / 2 + full_poly.end_index() % 2, circuit_size / 2);
+                size_t desired_size = full_poly.end_index() / 2 + full_poly.end_index() % 2;
                 poly = Polynomial(desired_size, circuit_size / 2);
             }
         }

--- a/barretenberg/cpp/src/barretenberg/vm2/generated/flavor.cpp
+++ b/barretenberg/cpp/src/barretenberg/vm2/generated/flavor.cpp
@@ -89,7 +89,8 @@ AvmFlavor::PartiallyEvaluatedMultivariates::PartiallyEvaluatedMultivariates(cons
                                                                             size_t circuit_size)
 {
     for (auto [poly, full_poly] : zip_view(get_all(), full_polynomials.get_all())) {
-        size_t desired_size = std::min(full_poly.end_index(), circuit_size / 2);
+        // After the initial sumcheck round, the new size is CEIL(size/2).
+        size_t desired_size = std::min(full_poly.end_index() / 2 + full_poly.end_index() % 2, circuit_size / 2);
         poly = Polynomial(desired_size, circuit_size / 2);
     }
 }

--- a/barretenberg/cpp/src/barretenberg/vm2/generated/flavor.cpp
+++ b/barretenberg/cpp/src/barretenberg/vm2/generated/flavor.cpp
@@ -90,7 +90,7 @@ AvmFlavor::PartiallyEvaluatedMultivariates::PartiallyEvaluatedMultivariates(cons
 {
     for (auto [poly, full_poly] : zip_view(get_all(), full_polynomials.get_all())) {
         // After the initial sumcheck round, the new size is CEIL(size/2).
-        size_t desired_size = std::min(full_poly.end_index() / 2 + full_poly.end_index() % 2, circuit_size / 2);
+        size_t desired_size = full_poly.end_index() / 2 + full_poly.end_index() % 2;
         poly = Polynomial(desired_size, circuit_size / 2);
     }
 }

--- a/bb-pilcom/bb-pil-backend/templates/flavor.cpp.hbs
+++ b/bb-pilcom/bb-pil-backend/templates/flavor.cpp.hbs
@@ -88,7 +88,8 @@ AvmFlavor::PartiallyEvaluatedMultivariates::PartiallyEvaluatedMultivariates(cons
                                                                             size_t circuit_size)
 {
     for (auto [poly, full_poly] : zip_view(get_all(), full_polynomials.get_all())) {
-        size_t desired_size = std::min(full_poly.end_index(), circuit_size / 2);
+        // After the initial sumcheck round, the new size is CEIL(size/2).
+        size_t desired_size = std::min(full_poly.end_index() / 2 + full_poly.end_index() % 2, circuit_size / 2);
         poly = Polynomial(desired_size, circuit_size / 2);
     }
 }


### PR DESCRIPTION
Compared to master for 16 cores, sumcheck of bulk test AVM V2 takes 2.5% less time and ca. 5% less memory.

master: 16.22 seconds
this pr:  15.80 seconds

Average of 5 measurements on each branch.
Memory peak in proving: No change for bulk test, it remains at 4.32 GB maximum resident size
Memory impact during sumcheck: reduce from 2831 MB to 2677 MB (measured with Tracy on bulk test v2)


Closes https://github.com/AztecProtocol/barretenberg/issues/1120.