### PR TITLE
feat(DRAFT): Protobuf bindings in Barretenberg

### DIFF
--- a/barretenberg/cpp/.gitignore
+++ b/barretenberg/cpp/.gitignore
@@ -13,4 +13,5 @@ go*.tar.gz
 barretenberg_modules.dot
 barretenberg_modules.png
 src/barretenberg/bb/config.hpp
+src/barretenberg/dsl/acir_format/proto
 bench-out

--- a/barretenberg/cpp/CMakeLists.txt
+++ b/barretenberg/cpp/CMakeLists.txt
@@ -161,7 +161,7 @@ include(cmake/benchmark.cmake)
 include(cmake/module.cmake)
 include(cmake/msgpack.cmake)
 include(cmake/lmdb.cmake)
-#include(cmake/protobuf.cmake)
+include(cmake/protobuf.cmake)
 
 # We do not need to bloat barretenberg.wasm with gzip functionality in a browser context as the browser can do this
 if (NOT WASM)

--- a/barretenberg/cpp/CMakeLists.txt
+++ b/barretenberg/cpp/CMakeLists.txt
@@ -161,6 +161,7 @@ include(cmake/benchmark.cmake)
 include(cmake/module.cmake)
 include(cmake/msgpack.cmake)
 include(cmake/lmdb.cmake)
+include(cmake/protobuf.cmake)
 
 # We do not need to bloat barretenberg.wasm with gzip functionality in a browser context as the browser can do this
 if (NOT WASM)

--- a/barretenberg/cpp/CMakeLists.txt
+++ b/barretenberg/cpp/CMakeLists.txt
@@ -161,7 +161,7 @@ include(cmake/benchmark.cmake)
 include(cmake/module.cmake)
 include(cmake/msgpack.cmake)
 include(cmake/lmdb.cmake)
-include(cmake/protobuf.cmake)
+#include(cmake/protobuf.cmake)
 
 # We do not need to bloat barretenberg.wasm with gzip functionality in a browser context as the browser can do this
 if (NOT WASM)

--- a/barretenberg/cpp/bootstrap.sh
+++ b/barretenberg/cpp/bootstrap.sh
@@ -143,6 +143,9 @@ export -f build_native build_darwin build_nodejs_module build_wasm build_wasm_th
 
 function build {
   echo_header "bb cpp build"
+
+  ./scripts/codegen_dsl.sh
+
   builds=(
     build_native
     build_nodejs_module

--- a/barretenberg/cpp/cmake/protobuf.cmake
+++ b/barretenberg/cpp/cmake/protobuf.cmake
@@ -4,10 +4,19 @@
 # See docs at https://cmake.org/cmake/help/latest/module/FindProtobuf.html
 # See source at https://fossies.org/linux/cmake/Modules/FindProtobuf.cmake or /usr/share/cmake-3.28/Modules/FindProtobuf.cmake
 
-# include(FindProtobuf)
+
+FetchContent_Declare(protobuf
+  GIT_REPOSITORY https://github.com/protocolbuffers/protobuf.git
+  GIT_TAG        v29.3
+  SOURCE_SUBDIR  cmake
+  FIND_PACKAGE_ARGS NAMES protobuf
+)
+FetchContent_MakeAvailable(protobuf)
+
+include(FindProtobuf)
 
 #list(APPEND CMAKE_PREFIX_PATH "/usr/local/lib/cmake/protobuf")
-set(Protobuf_DIR "/usr/local/lib/cmake/protobuf")
+#set(Protobuf_DIR "/usr/local/lib/cmake/protobuf")
 
 # TODO: This errors saying it cannot find `Protobuf_INCLUDE_DIR`, unless we build protobuf from source.
 # find_package(Protobuf REQUIRED)
@@ -21,6 +30,11 @@ message("   --> PROTOBUF INCLUDE: ${PROTOBUF_INCLUDE_DIRS}")
 # set(Protobuf_INCLUDE_DIR "/usr/include/google/protobuf")
 # set(Protobuf_INCLUDE_DIRS "/usr/include/google/protobuf")
 include_directories(${Protobuf_INCLUDE_DIRS})
+
+#include_directories("/usr/local/include")
+#include_directories("/usr/local/include/absl")
+#include_directories("/usr/include")
+
 
 # Add this to what needs to use protobuf:
 # target_link_libraries(<bin or lib> ${Protobuf_LIBRARIES})

--- a/barretenberg/cpp/cmake/protobuf.cmake
+++ b/barretenberg/cpp/cmake/protobuf.cmake
@@ -4,8 +4,22 @@
 # See docs at https://cmake.org/cmake/help/latest/module/FindProtobuf.html
 # See source at https://fossies.org/linux/cmake/Modules/FindProtobuf.cmake or /usr/share/cmake-3.28/Modules/FindProtobuf.cmake
 
-include(FindProtobuf)
-find_package(Protobuf REQUIRED)
+# include(FindProtobuf)
+
+#list(APPEND CMAKE_PREFIX_PATH "/usr/local/lib/cmake/protobuf")
+set(Protobuf_DIR "/usr/local/lib/cmake/protobuf")
+
+# TODO: This errors saying it cannot find `Protobuf_INCLUDE_DIR`, unless we build protobuf from source.
+# find_package(Protobuf REQUIRED)
+find_package(Protobuf CONFIG REQUIRED)
+
+message("   --> PROTOBUF Found: ${Protobuf_FOUND}")
+message("   --> PROTOBUF VERSION: ${Protobuf_VERSION}")
+message("   --> PROTOBUF LIB: ${PROTOBUF_LIBRARIES}")
+message("   --> PROTOBUF INCLUDE: ${PROTOBUF_INCLUDE_DIRS}")
+
+# set(Protobuf_INCLUDE_DIR "/usr/include/google/protobuf")
+# set(Protobuf_INCLUDE_DIRS "/usr/include/google/protobuf")
 include_directories(${Protobuf_INCLUDE_DIRS})
 
 # Add this to what needs to use protobuf:

--- a/barretenberg/cpp/cmake/protobuf.cmake
+++ b/barretenberg/cpp/cmake/protobuf.cmake
@@ -1,0 +1,15 @@
+# The protobuf compiler should be installed on the builder machine;
+# the job here is to find where its C libraries are located, e.g.
+# under /usr/include/google/protobuf, so that we can include their headers.
+# See docs at https://cmake.org/cmake/help/latest/module/FindProtobuf.html
+# See source at https://fossies.org/linux/cmake/Modules/FindProtobuf.cmake or /usr/share/cmake-3.28/Modules/FindProtobuf.cmake
+
+include(FindProtobuf)
+find_package(Protobuf REQUIRED)
+include_directories(${Protobuf_INCLUDE_DIRS})
+
+# Add this to what needs to use protobuf:
+# target_link_libraries(<bin or lib> ${Protobuf_LIBRARIES})
+
+# TODO: We should be able to generate .pb.h and .pb.cc files from the .proto files
+# using the `protobuf_generate_cpp` command, instead of using `cpp/scripts/codegen_dsl.sh`

--- a/barretenberg/cpp/scripts/codegen_dsl.sh
+++ b/barretenberg/cpp/scripts/codegen_dsl.sh
@@ -1,0 +1,6 @@
+#!/usr/bin/env bash
+set -eu
+
+cd $(dirname $0)/..
+
+make -C src/barretenberg/dsl --no-print-directory

--- a/barretenberg/cpp/src/CMakeLists.txt
+++ b/barretenberg/cpp/src/CMakeLists.txt
@@ -259,9 +259,4 @@ if(WASM)
             -ldw -lelf
         )
     endif()
-
-    target_link_libraries(
-        barretenberg.wasm,
-        ${Protobuf_LIBRARIES}
-    )
 endif()

--- a/barretenberg/cpp/src/CMakeLists.txt
+++ b/barretenberg/cpp/src/CMakeLists.txt
@@ -259,4 +259,9 @@ if(WASM)
             -ldw -lelf
         )
     endif()
+
+    target_link_libraries(
+        barretenberg.wasm,
+        ${Protobuf_LIBRARIES}
+    )
 endif()

--- a/barretenberg/cpp/src/barretenberg/bb/CMakeLists.txt
+++ b/barretenberg/cpp/src/barretenberg/bb/CMakeLists.txt
@@ -12,7 +12,6 @@ if (NOT(FUZZING) AND NOT(WASM))
         circuit_checker
         ${TRACY_LIBS}
         libdeflate::libdeflate_static
-        ${Protobuf_LIBRARIES}
     )
     if(CHECK_CIRCUIT_STACKTRACES)
         target_link_libraries(

--- a/barretenberg/cpp/src/barretenberg/bb/CMakeLists.txt
+++ b/barretenberg/cpp/src/barretenberg/bb/CMakeLists.txt
@@ -12,6 +12,7 @@ if (NOT(FUZZING) AND NOT(WASM))
         circuit_checker
         ${TRACY_LIBS}
         libdeflate::libdeflate_static
+        ${Protobuf_LIBRARIES}
     )
     if(CHECK_CIRCUIT_STACKTRACES)
         target_link_libraries(

--- a/barretenberg/cpp/src/barretenberg/dsl/Makefile
+++ b/barretenberg/cpp/src/barretenberg/dsl/Makefile
@@ -1,0 +1,33 @@
+PROTO_SRC_DIR := ../../../../../noir/noir-repo/acvm-repo/acir/src/proto
+PROTO_DST_DIR := ./acir_format/proto
+
+# Using acir/program.proto instead of the top level program.proto so that we don't deserialize the Brillig part.
+PROTO_SCHEMAS += \
+	acir/program.proto \
+	acir/witness.proto \
+	acir/circuit.proto \
+	acir/native.proto
+
+PROTO_CPP := $(PROTO_SCHEMAS:.proto=.pb.h)
+PROTO_DST := $(patsubst %, $(PROTO_DST_DIR)/%, $(PROTO_CPP))
+
+.PHONY: all
+all: $(PROTO_DST)
+
+
+test:
+	@echo $(PROTO_DST)
+
+# Compile an ACIR protobuf schema to C++
+$(PROTO_DST_DIR)/%.pb.h: $(PROTO_SRC_DIR)/%.proto $(PROTO_DST_DIR) | .protoc
+	protoc --cpp_out $(PROTO_DST_DIR) -I $(PROTO_SRC_DIR) $<
+
+$(PROTO_DST_DIR):
+	mkdir -p $@
+
+.PHONY: .protoc
+.protoc:
+	@if [ -z "$$(which protoc)" ]; then \
+		echo "Please install the protobuf compiler"; \
+		exit 1; \
+	fi

--- a/barretenberg/cpp/src/barretenberg/dsl/Makefile
+++ b/barretenberg/cpp/src/barretenberg/dsl/Makefile
@@ -17,6 +17,7 @@ all: $(PROTO_DST)
 # Compile an ACIR protobuf schema to C++
 $(PROTO_DST_DIR)/%.pb.h: $(PROTO_SRC_DIR)/%.proto $(PROTO_DST_DIR) | .protoc
 	protoc --cpp_out $(PROTO_DST_DIR) -I $(PROTO_SRC_DIR) $<
+	sed -i 's/#include "acir\//#include "barretenberg\/dsl\/acir_format\/proto\/acir\//g' $(PROTO_DST_DIR)/$*.pb.*
 
 $(PROTO_DST_DIR):
 	mkdir -p $@

--- a/barretenberg/cpp/src/barretenberg/dsl/Makefile
+++ b/barretenberg/cpp/src/barretenberg/dsl/Makefile
@@ -14,10 +14,6 @@ PROTO_DST := $(patsubst %, $(PROTO_DST_DIR)/%, $(PROTO_CPP))
 .PHONY: all
 all: $(PROTO_DST)
 
-
-test:
-	@echo $(PROTO_DST)
-
 # Compile an ACIR protobuf schema to C++
 $(PROTO_DST_DIR)/%.pb.h: $(PROTO_SRC_DIR)/%.proto $(PROTO_DST_DIR) | .protoc
 	protoc --cpp_out $(PROTO_DST_DIR) -I $(PROTO_SRC_DIR) $<

--- a/barretenberg/cpp/src/barretenberg/dsl/README.md
+++ b/barretenberg/cpp/src/barretenberg/dsl/README.md
@@ -47,7 +47,7 @@ and witness stack. The schemas are [defined](https://github.com/noir-lang/noir/t
 and the C++ code is generated for them here by running the following command:
 
 ```shell
-make -C barretenberg/cpp/src/barretenberg/dsl --no-print-directory
+barretenberg/cpp/scripts/codegen_dsl.sh
 ```
 
 The resulting `.pb.c` and `.pb.h` files are written to `./acir_format/proto/acir` but aren't checked into source control.
@@ -55,7 +55,7 @@ The resulting `.pb.c` and `.pb.h` files are written to `./acir_format/proto/acir
 For example:
 
 ```console
-% make -C barretenberg/cpp/src/barretenberg/dsl --no-print-directory                                                                                                                                ~/aztec-packages af/bb-dsl-acir-proto+ akosh-box
+% barretenberg/cpp/scripts/codegen_dsl.sh
 mkdir -p acir_format/proto
 protoc --cpp_out ./acir_format/proto -I ../../../../../noir/noir-repo/acvm-repo/acir/src/proto ../../../../../noir/noir-repo/acvm-repo/acir/src/proto/acir/program.proto
 protoc --cpp_out ./acir_format/proto -I ../../../../../noir/noir-repo/acvm-repo/acir/src/proto ../../../../../noir/noir-repo/acvm-repo/acir/src/proto/acir/witness.proto

--- a/barretenberg/cpp/src/barretenberg/dsl/README.md
+++ b/barretenberg/cpp/src/barretenberg/dsl/README.md
@@ -64,3 +64,19 @@ protoc --cpp_out ./acir_format/proto -I ../../../../../noir/noir-repo/acvm-repo/
 % ls barretenberg/cpp/src/barretenberg/dsl/acir_format/proto/acir
 circuit.pb.cc  circuit.pb.h  native.pb.cc  native.pb.h  program.pb.cc  program.pb.h  witness.pb.cc  witness.pb.h
 ```
+
+#### Installing Protobuf
+
+We need to install protobuf from source to work well with `cmake`:
+
+```
+# instead of `apt install libprotobuf-dev protobuf-compiler`
+# https://github.com/protocolbuffers/protobuf/blob/v29.3/cmake/README.md
+# using the same version as the Rust build
+git clone --branch v29.3 https://github.com/protocolbuffers/protobuf.git
+cd protobuf
+git submodule update --init --recursive
+cmake .
+cmake --build . --parallel 10
+sudo cmake --install .
+```

--- a/barretenberg/cpp/src/barretenberg/dsl/acir_format/acir_to_constraint_buf.hpp
+++ b/barretenberg/cpp/src/barretenberg/dsl/acir_format/acir_to_constraint_buf.hpp
@@ -1,5 +1,6 @@
 #pragma once
 #include "acir_format.hpp"
+#include "convert/proto_to_serde.hpp"
 #include "serde/index.hpp"
 
 namespace acir_format {

--- a/barretenberg/cpp/src/barretenberg/dsl/acir_format/convert/proto_to_serde.hpp
+++ b/barretenberg/cpp/src/barretenberg/dsl/acir_format/convert/proto_to_serde.hpp
@@ -1,0 +1,5 @@
+#include "../proto/acir/circuit.pb.h"
+#include "../proto/acir/native.pb.h"
+#include "../proto/acir/program.pb.h"
+#include "../proto/acir/witness.pb.h"
+#include "../serde/index.hpp"

--- a/bootstrap.sh
+++ b/bootstrap.sh
@@ -24,7 +24,7 @@ function encourage_dev_container {
 # Developers should probably use the dev container in /build-images to ensure the smoothest experience.
 function check_toolchains {
   # Check for various required utilities.
-  for util in jq parallel awk git curl; do
+  for util in jq parallel awk git curl protoc; do
     if ! command -v $util > /dev/null; then
       encourage_dev_container
       echo "Utility $util not found."


### PR DESCRIPTION
Add support for protobuf serialisation introduced in https://github.com/noir-lang/noir/issues/7511

- [x] Add scripts to generate C++ bindings for the Protobuf schemas in Noir
- [x] Add `protoc` to the `devbox` image used by EC2 to run the build in https://github.com/AztecProtocol/aztec-packages/pull/12644
- [x] Generate bindings during the build
- [ ] Map the protobuf DTOs to the existing classes generated from `serde` 
- [ ] Deserialise the data with a fallback to the old format

Unlike with the `serde` based approach, code generation is done on the `aztec-packages` side instead of Noir (see https://github.com/noir-lang/noir/pull/7590), but we still keep the `serde` based classes as well as they are what we actually work with in Rust, whereas the protobuf are just DTOs for backwards compatibility.


# WIP

Currently `./barretenberg/cpp/bootstrap.sh` will generate the bindings, but it can be done explicitly with `./barretenberg/cpp/scripts/codegen_dsl.sh` as well. 

After that _think_ the native build succeeds:

```console
% ./bootstrap.sh build_native                                                                        
Not using cache for barretenberg-release-disabled-cache.tar.gz due to uncommitted changes/files.
./src/barretenberg/dsl/acir_format/acir_to_constraint_buf.hpp:2:1: error: code should be clang-formatted [-Wclang-format-violations]
#include "acir_format.hpp"
^
./src/barretenberg/dsl/acir_format/convert/proto_to_serde.hpp:1:1: error: code should be clang-formatted [-Wclang-format-violations]
#include "../serde/index.hpp"
^
```
I think these are just warnings, as the first one was already like it is. 

The WASM build fails:
```
% ./bootstrap.sh build_wasm                                                                     
...
[2/44] Building CXX object src/barretenberg/dsl/CMakeFiles/dsl_objects.dir/acir_format/acir_to_constraint_buf.cpp.obj
FAILED: src/barretenberg/dsl/CMakeFiles/dsl_objects.dir/acir_format/acir_to_constraint_buf.cpp.obj 
/opt/wasi-sdk/bin/clang++ --sysroot=/opt/wasi-sdk/share/wasi-sysroot -DDISABLE_ASM=1 -DDISABLE_AZTEC_VM=1 -DNO_MULTITHREADING -DNO_PAR_ALGOS -D_WASI_EMULATED_PROCESS_CLOCKS=1 -I/mnt/user-data/akosh/aztec-packages/barretenberg/cpp/src -I/mnt/user-data/akosh/aztec-packages/barretenberg/cpp/build-wasm/_deps/msgpack-c/src/msgpack-c/include -I/mnt/user-data/akosh/aztec-packages/barretenberg/cpp/build-wasm/_deps/tracy-src/public -I/mnt/user-data/akosh/aztec-packages/barretenberg/cpp/build-wasm/_deps/lmdb/src/lmdb_repo/libraries/liblmdb -DBB_VERBOSE -Oz -DNDEBUG -std=gnu++20 -fbracket-depth=1024 -fno-exceptions -fno-slp-vectorize -Werror -Wall -Wextra -Wconversion -Wsign-conversion -Wfatal-errors -fcolor-diagnostics -fconstexpr-steps=100000000 -Wno-vla-cxx-extension -Wno-missing-field-initializers -MD -MT src/barretenberg/dsl/CMakeFiles/dsl_objects.dir/acir_format/acir_to_constraint_buf.cpp.obj -MF src/barretenberg/dsl/CMakeFiles/dsl_objects.dir/acir_format/acir_to_constraint_buf.cpp.obj.d -o src/barretenberg/dsl/CMakeFiles/dsl_objects.dir/acir_format/acir_to_constraint_buf.cpp.obj -c /mnt/user-data/akosh/aztec-packages/barretenberg/cpp/src/barretenberg/dsl/acir_format/acir_to_constraint_buf.cpp
In file included from /mnt/user-data/akosh/aztec-packages/barretenberg/cpp/src/barretenberg/dsl/acir_format/acir_to_constraint_buf.cpp:1:
In file included from /mnt/user-data/akosh/aztec-packages/barretenberg/cpp/src/barretenberg/dsl/acir_format/acir_to_constraint_buf.hpp:4:
In file included from /mnt/user-data/akosh/aztec-packages/barretenberg/cpp/src/barretenberg/dsl/acir_format/convert/proto_to_serde.hpp:2:
/mnt/user-data/akosh/aztec-packages/barretenberg/cpp/src/barretenberg/dsl/acir_format/convert/../proto/acir/native.pb.h:10:10: fatal error: 'google/protobuf/port_def.inc' file not found
   10 | #include <google/protobuf/port_def.inc>
      |          ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
1 error generated.
[32/44] Building CXX object src/barretenberg/stdlib/honk_verifier/CMakeFiles/stdlib_honk_verifier_objects.dir/ultra_recursive_verifier.cpp.objgit st^C
ninja: build stopped: interrupted by user.
```

The files it's looking for should be there after `apt install protobuf-compiler`, but maybe for wasm they are not included:
```console
% ls /usr/include/google/protobuf                                                                                                                                                                    ~/aztec-packages af/bb-dsl-acir-proto akosh-box
any.h          arenaz_sampler.h       empty.pb.h                field_mask.proto                  has_bits.h               map_field_inl.h     port.h                 service.h             timestamp.proto      wrappers.proto
any.pb.h       descriptor.h           empty.proto               generated_enum_reflection.h       implicit_weak_message.h  map_field_lite.h    port_def.inc           source_context.pb.h   type.pb.h
any.proto      descriptor.pb.h        endian.h                  generated_enum_util.h             inlined_string_field.h   map_type_handler.h  port_undef.inc         source_context.proto  type.proto
api.pb.h       descriptor.proto       explicitly_constructed.h  generated_message_bases.h         io                       message.h           reflection.h           struct.pb.h           unknown_field_set.h
api.proto      descriptor_database.h  extension_set.h           generated_message_reflection.h    map.h                    message_lite.h      reflection_internal.h  struct.proto          util
arena.h        duration.pb.h          extension_set_inl.h       generated_message_tctable_decl.h  map_entry.h              metadata.h          reflection_ops.h       stubs                 wire_format.h
arena_impl.h   duration.proto         field_access_listener.h   generated_message_tctable_impl.h  map_entry_lite.h         metadata_lite.h     repeated_field.h       text_format.h         wire_format_lite.h
arenastring.h  dynamic_message.h      field_mask.pb.h           generated_message_util.h          map_field.h              parse_context.h     repeated_ptr_field.h   timestamp.pb.h        wrappers.pb.h
```

I tried to instruct `cmake` to use the `FindProtobuf` module to set the variables, needed for inclusion, but it doesn't work. Some suggest that's because I did not install Protobuf from source, so I tried to do that like so:

```shell
# instead of `apt install libprotobuf-dev protobuf-compiler`
# https://github.com/protocolbuffers/protobuf/blob/v29.3/cmake/README.md
# using the same version as the Rust build
git clone --branch v29.3 https://github.com/protocolbuffers/protobuf.git
cd protobuf
git submodule update --init --recursive
cmake . 
cmake --build . --parallel 10
sudo cmake --install .
```

And using this `protobuf.cmake`:
```
#list(APPEND CMAKE_PREFIX_PATH "/usr/local/lib/cmake/protobuf")
set(Protobuf_DIR "/usr/local/lib/cmake/protobuf")
find_package(Protobuf 29.3.0 EXACT CONFIG REQUIRED)
include_directories(${Protobuf_INCLUDE_DIRS})
```
Unfortunately it looks like the version I installed can't be used by Wasm because of 32bit vs 64bit arch:
```console
% ./barretenberg/cpp/bootstrap.sh build_wasm 
...
-- Could NOT find Protobuf (missing: Protobuf_LIBRARIES Protobuf_INCLUDE_DIR) 
CMake Error at cmake/protobuf.cmake:13 (find_package):
  Could not find a configuration file for package "Protobuf" that exactly
  matches requested version "29.3.0".

  The following configuration files were considered but not accepted:

    /usr/local/lib/cmake/protobuf/protobuf-config.cmake, version: 29.3.0 (64bit)

Call Stack (most recent call first):
  CMakeLists.txt:164 (include)
```