### PR TITLE
chore: Add `protoc` to the devbox image

### DIFF
--- a/build-images/src/Dockerfile
+++ b/build-images/src/Dockerfile
@@ -226,6 +226,7 @@ RUN apt update && \
         vim \
         zsh \
         inotify-tools \
+        protobuf-compiler \
     && rm -rf /var/lib/apt/lists/* /tmp/* /var/tmp/*
 
 # Install osxcross. Requires developer to mount SDK from their mac host.

--- a/build-images/src/Dockerfile
+++ b/build-images/src/Dockerfile
@@ -227,6 +227,7 @@ RUN apt update && \
         zsh \
         inotify-tools \
         protobuf-compiler \
+        libprotobuf-dev \
     && rm -rf /var/lib/apt/lists/* /tmp/* /var/tmp/*
 
 # Install osxcross. Requires developer to mount SDK from their mac host.


### PR DESCRIPTION
Add the `protobuf-compiler` to the `devbox` image used to run CI on EC2, in preparation for https://github.com/AztecProtocol/aztec-packages/pull/12640

As I understand someone in possession of the `DOCKERHUB_PASSWORD` will have to run `./build-images/bootstrap.sh deploy` to actually make these available on Docker Hub, with all the right architectures. FWIW I ran `./build-images/bootstrap.sh` and it succeeded in building the image.

DRAFT: I'm still looking for a way to actually use the installed library from `cmake`...