### PR TITLE
fix: make bb mac workaround kick off automatically

### DIFF
--- a/.github/workflows/publish-bb-mac.yml
+++ b/.github/workflows/publish-bb-mac.yml
@@ -1,6 +1,9 @@
 name: Publish Barretenberg Mac
 
 on:
+  push:
+    tags:
+      - "v*"
   workflow_dispatch:
     # Allow pushing a manual nightly release
     inputs:
@@ -31,7 +34,7 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v3
         with:
-          ref: ${{ inputs.tag || env.GITHUB_REF }}
+          ref: ${{ inputs.tag || github.sha }}
 
       - name: Create Mac Build Environment
         run: brew install cmake ninja llvm@16
@@ -39,7 +42,7 @@ jobs:
       - name: Replace version string in main.cpp
         working-directory: barretenberg/cpp
         run: |
-          sed -i.bak "s/00000000\.00000000\.00000000/${{ inputs.ref_name || inputs.tag }}/g" src/barretenberg/bb/main.cpp
+          sed -i.bak "s/00000000\.00000000\.00000000/${{ inputs.ref_name || inputs.tag || github.ref_name }}/g" src/barretenberg/bb/main.cpp
 
       - name: Compile Barretenberg
         working-directory: barretenberg/cpp
@@ -71,7 +74,7 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v3
         with:
-          ref: ${{ inputs.tag || env.GITHUB_REF }}
+          ref: ${{ inputs.tag || github.sha }}
 
       - name: Create Mac Build Environment
         run: brew install cmake ninja
@@ -79,7 +82,7 @@ jobs:
       - name: Replace version string in main.cpp
         working-directory: barretenberg/cpp
         run: |
-          sed -i.bak "s/00000000\.00000000\.00000000/${{ inputs.ref_name || inputs.tag }}/g" src/barretenberg/bb/main.cpp
+          sed -i.bak "s/00000000\.00000000\.00000000/${{ inputs.ref_name || inputs.tag || github.ref_name }}/g" src/barretenberg/bb/main.cpp
 
       - name: Compile Barretenberg
         working-directory: barretenberg/cpp
@@ -123,7 +126,7 @@ jobs:
         uses: actions/checkout@v3
         if: ${{ failure() }}
         with:
-          ref: ${{ inputs.tag || env.GITHUB_REF }}
+          ref: ${{ inputs.tag || github.sha }}
 
       - name: Alert on build failure
         uses: JasonEtco/create-an-issue@1b14a70e4d8dc185e5cc76d3bec9eab20257b2c5
@@ -155,7 +158,7 @@ jobs:
         uses: softprops/action-gh-release@v1
         if: ${{ inputs.publish || github.event_name == 'schedule' }}
         with:
-          tag_name: ${{ inputs.ref_name || inputs.tag || 'nightly' }}
+          tag_name: ${{ inputs.ref_name || inputs.tag || github.ref_name }}
           prerelease: true
           files: |
             barretenberg-amd64-darwin.tar.gz


### PR DESCRIPTION
This will streamline the release process until this is fully done with cross compiles