### PR TITLE
fix: Restart proving job if epoch content changes

### DIFF
--- a/yarn-project/archiver/src/test/mock_l2_block_source.ts
+++ b/yarn-project/archiver/src/test/mock_l2_block_source.ts
@@ -104,6 +104,10 @@ export class MockL2BlockSource implements L2BlockSource {
     return Promise.resolve(blocks);
   }
 
+  getBlockHeadersForEpoch(epochNumber: bigint): Promise<BlockHeader[]> {
+    return this.getBlocksForEpoch(epochNumber).then(blocks => blocks.map(b => b.header));
+  }
+
   /**
    * Gets a tx effect.
    * @param txHash - The hash of a transaction which resulted in the returned tx effect.

--- a/yarn-project/foundation/src/promise/running-promise.ts
+++ b/yarn-project/foundation/src/promise/running-promise.ts
@@ -73,6 +73,7 @@ export class RunningPromise {
       }
     };
     this.runningPromise = poll();
+    return this;
   }
 
   /**

--- a/yarn-project/foundation/src/retry/index.ts
+++ b/yarn-project/foundation/src/retry/index.ts
@@ -83,7 +83,12 @@ export async function retry<Result>(
  * @param interval - The optional interval, in seconds, between retry attempts. Defaults to 1 second.
  * @returns A Promise that resolves with the successful (truthy) result of the provided function, or rejects if timeout is exceeded.
  */
-export async function retryUntil<T>(fn: () => Promise<T | undefined>, name = '', timeout = 0, interval = 1) {
+export async function retryUntil<T>(
+  fn: () => (T | undefined) | Promise<T | undefined>,
+  name = '',
+  timeout = 0,
+  interval = 1,
+) {
   const timer = new Timer();
   while (true) {
     const result = await fn();

--- a/yarn-project/prover-node/src/job/epoch-proving-job.test.ts
+++ b/yarn-project/prover-node/src/job/epoch-proving-job.test.ts
@@ -3,6 +3,7 @@ import { toArray } from '@aztec/foundation/iterable';
 import { sleep } from '@aztec/foundation/sleep';
 import type { PublicProcessor, PublicProcessorFactory } from '@aztec/simulator/server';
 import { L2Block, type L2BlockSource } from '@aztec/stdlib/block';
+import type { L1RollupConstants } from '@aztec/stdlib/epoch-helpers';
 import type { EpochProver, MerkleTreeWriteOperations, WorldStateSynchronizer } from '@aztec/stdlib/interfaces/server';
 import type { L1ToL2MessageSource } from '@aztec/stdlib/messaging';
 import { Proof } from '@aztec/stdlib/proofs';
@@ -85,6 +86,7 @@ describe('epoch-proving-job', () => {
 
     l1ToL2MessageSource.getL1ToL2Messages.mockResolvedValue([]);
     l2BlockSource.getBlockHeader.mockResolvedValue(initialHeader);
+    l2BlockSource.getL1Constants.mockResolvedValue({ ethereumSlotDuration: 36 } as L1RollupConstants);
     publicProcessorFactory.create.mockReturnValue(publicProcessor);
     db.getInitialHeader.mockReturnValue(initialHeader);
     worldState.fork.mockResolvedValue(db);
@@ -154,5 +156,19 @@ describe('epoch-proving-job', () => {
 
     expect(job.getState()).toEqual('stopped');
     expect(publisher.submitEpochProof).not.toHaveBeenCalled();
+  });
+
+  it('halts if a new block for the epoch is found', async () => {
+    const newBlocks = await timesParallel(NUM_BLOCKS + 1, i => L2Block.random(i + 1, TXS_PER_BLOCK));
+    prover.startNewBlock.mockImplementation(() => sleep(200));
+    l2BlockSource.getBlockHeadersForEpoch.mockResolvedValue(newBlocks.map(b => b.header));
+    l2BlockSource.getL1Constants.mockResolvedValue({ ethereumSlotDuration: 0.1 } as L1RollupConstants);
+
+    const job = createJob();
+    await job.run();
+
+    expect(job.getState()).toEqual('reorg');
+    expect(publisher.submitEpochProof).not.toHaveBeenCalled();
+    expect(prover.cancel).toHaveBeenCalled();
   });
 });

--- a/yarn-project/prover-node/src/job/epoch-proving-job.ts
+++ b/yarn-project/prover-node/src/job/epoch-proving-job.ts
@@ -223,7 +223,10 @@ export class EpochProvingJob implements Traceable {
         const blocks = await this.l2BlockSource.getBlockHeadersForEpoch(this.epochNumber);
         const blockHashes = await Promise.all(blocks.map(block => block.hash()));
         const thisBlockHashes = await Promise.all(this.blocks.map(block => block.hash()));
-        if (blocks.length !== this.blocks.length || !blockHashes.every((block, i) => block === thisBlockHashes[i])) {
+        if (
+          blocks.length !== this.blocks.length ||
+          !blockHashes.every((block, i) => block.equals(thisBlockHashes[i]))
+        ) {
           this.log.warn('Epoch blocks changed underfoot', {
             uuid: this.uuid,
             epochNumber: this.epochNumber,

--- a/yarn-project/prover-node/src/job/epoch-proving-job.ts
+++ b/yarn-project/prover-node/src/job/epoch-proving-job.ts
@@ -1,6 +1,6 @@
 import { asyncPool } from '@aztec/foundation/async-pool';
 import { createLogger } from '@aztec/foundation/log';
-import { promiseWithResolvers } from '@aztec/foundation/promise';
+import { RunningPromise, promiseWithResolvers } from '@aztec/foundation/promise';
 import { Timer } from '@aztec/foundation/timer';
 import type { PublicProcessor, PublicProcessorFactory } from '@aztec/simulator/server';
 import type { L2Block, L2BlockSource } from '@aztec/stdlib/block';
@@ -30,6 +30,7 @@ export class EpochProvingJob implements Traceable {
   private uuid: string;
 
   private runPromise: Promise<void> | undefined;
+  private epochCheckPromise: RunningPromise | undefined;
   private deadlineTimeoutHandler: NodeJS.Timeout | undefined;
 
   public readonly tracer: Tracer;
@@ -47,7 +48,6 @@ export class EpochProvingJob implements Traceable {
     private metrics: ProverNodeMetrics,
     private deadline: Date | undefined,
     private config: { parallelBlockLimit: number } = { parallelBlockLimit: 32 },
-    private cleanUp: (job: EpochProvingJob) => Promise<void> = () => Promise.resolve(),
   ) {
     this.uuid = crypto.randomUUID();
     this.tracer = metrics.client.getTracer('EpochProvingJob');
@@ -73,6 +73,7 @@ export class EpochProvingJob implements Traceable {
   })
   public async run() {
     this.scheduleDeadlineStop();
+    await this.scheduleEpochCheck();
 
     const epochNumber = Number(this.epochNumber);
     const epochSizeBlocks = this.blocks.length;
@@ -154,14 +155,18 @@ export class EpochProvingJob implements Traceable {
       this.metrics.recordProvingJob(executionTime, timer.ms(), epochSizeBlocks, epochSizeTxs);
     } catch (err: any) {
       if (err && err.name === 'HaltExecutionError') {
-        this.log.warn(`Halted execution of epoch ${epochNumber} prover job`, { uuid: this.uuid, epochNumber });
+        this.log.warn(`Halted execution of epoch ${epochNumber} prover job`, {
+          uuid: this.uuid,
+          epochNumber,
+          details: err.message,
+        });
         return;
       }
       this.log.error(`Error running epoch ${epochNumber} prover job`, err, { uuid: this.uuid, epochNumber });
       this.state = 'failed';
     } finally {
       clearTimeout(this.deadlineTimeoutHandler);
-      await this.cleanUp(this);
+      await this.epochCheckPromise?.stop();
       await this.prover.stop();
       resolve();
     }
@@ -173,12 +178,12 @@ export class EpochProvingJob implements Traceable {
   }
 
   private checkState() {
-    if (this.state === 'timed-out' || this.state === 'stopped' || this.state === 'failed') {
+    if (this.state === 'timed-out' || this.state === 'stopped' || this.state === 'failed' || this.state === 'reorg') {
       throw new HaltExecutionError(this.state);
     }
   }
 
-  public async stop(state: EpochProvingJobState = 'stopped') {
+  public async stop(state: EpochProvingJobTerminalState = 'stopped') {
     this.state = state;
     this.prover.cancel();
     // TODO(palla/prover): Stop the publisher as well
@@ -205,6 +210,33 @@ export class EpochProvingJob implements Traceable {
         });
       }, timeout);
     }
+  }
+
+  /**
+   * Kicks off a running promise that queries the archiver for the set of L2 blocks of the current epoch.
+   * If those changed, stops the proving job with a `rerun` state, so the node re-enqueues it.
+   */
+  private async scheduleEpochCheck() {
+    const intervalMs = Math.ceil((await this.l2BlockSource.getL1Constants()).ethereumSlotDuration / 2) * 1000;
+    this.epochCheckPromise = new RunningPromise(
+      async () => {
+        const blocks = await this.l2BlockSource.getBlockHeadersForEpoch(this.epochNumber);
+        const blockHashes = await Promise.all(blocks.map(block => block.hash()));
+        const thisBlockHashes = await Promise.all(this.blocks.map(block => block.hash()));
+        if (blocks.length !== this.blocks.length || !blockHashes.every((block, i) => block === thisBlockHashes[i])) {
+          this.log.warn('Epoch blocks changed underfoot', {
+            uuid: this.uuid,
+            epochNumber: this.epochNumber,
+            oldBlockHashes: thisBlockHashes,
+            newBlockHashes: blockHashes,
+          });
+          void this.stop('reorg');
+        }
+      },
+      this.log,
+      intervalMs,
+    ).start();
+    this.log.verbose(`Scheduled epoch check for epoch ${this.epochNumber} every ${intervalMs}ms`);
   }
 
   /* Returns the header for the given block number, or the genesis block for block zero. */
@@ -246,7 +278,7 @@ export class EpochProvingJob implements Traceable {
 }
 
 class HaltExecutionError extends Error {
-  constructor(state: EpochProvingJobState) {
+  constructor(public readonly state: EpochProvingJobState) {
     super(`Halted execution due to state ${state}`);
     this.name = 'HaltExecutionError';
   }

--- a/yarn-project/prover-node/src/prover-node.test.ts
+++ b/yarn-project/prover-node/src/prover-node.test.ts
@@ -1,5 +1,7 @@
 import { timesParallel } from '@aztec/foundation/collection';
 import { EthAddress } from '@aztec/foundation/eth-address';
+import { retryUntil } from '@aztec/foundation/retry';
+import { sleep } from '@aztec/foundation/sleep';
 import type { PublicProcessorFactory } from '@aztec/simulator/server';
 import { L2Block, type L2BlockSource } from '@aztec/stdlib/block';
 import type { ContractDataSource } from '@aztec/stdlib/contract';
@@ -45,11 +47,7 @@ describe('prover-node', () => {
   let address: EthAddress;
 
   // List of all jobs ever created by the test prover node and their dependencies
-  let jobs: {
-    job: MockProxy<EpochProvingJob>;
-    cleanUp: (job: EpochProvingJob) => Promise<void>;
-    epochNumber: bigint;
-  }[];
+  let jobs: { job: MockProxy<EpochProvingJob>; epochNumber: bigint }[];
 
   const createProverNode = () =>
     new TestProverNode(
@@ -140,39 +138,63 @@ describe('prover-node', () => {
   it('starts a proof on a finished epoch', async () => {
     await proverNode.handleEpochReadyToProve(10n);
     expect(jobs[0].epochNumber).toEqual(10n);
+    expect(proverNode.totalJobCount).toEqual(1);
   });
 
   it('does not start a proof if there are no blocks in the epoch', async () => {
     l2BlockSource.getBlocksForEpoch.mockResolvedValue([]);
     await proverNode.handleEpochReadyToProve(10n);
-    expect(jobs.length).toEqual(0);
+    expect(proverNode.totalJobCount).toEqual(0);
   });
 
   it('does not start a proof if there is a tx missing from coordinator', async () => {
     mockCoordination.getTxsByHash.mockResolvedValue([]);
     await proverNode.handleEpochReadyToProve(10n);
-    expect(jobs.length).toEqual(0);
+    expect(proverNode.totalJobCount).toEqual(0);
   });
 
   it('does not prove the same epoch twice', async () => {
     await proverNode.handleEpochReadyToProve(10n);
     await proverNode.handleEpochReadyToProve(10n);
 
-    expect(jobs.length).toEqual(1);
+    expect(proverNode.totalJobCount).toEqual(1);
+  });
+
+  it('restarts a proof on a reorg', async () => {
+    proverNode.nextJobState = 'reorg';
+    await proverNode.handleEpochReadyToProve(10n);
+    await retryUntil(() => proverNode.totalJobCount === 2, 'job retried', 5);
+    expect(proverNode.totalJobCount).toEqual(2);
+  });
+
+  it('does not restart a proof on an error', async () => {
+    proverNode.nextJobState = 'failed';
+    await proverNode.handleEpochReadyToProve(10n);
+    await sleep(1000);
+    expect(proverNode.totalJobCount).toEqual(1);
   });
 
   class TestProverNode extends ProverNode {
+    public totalJobCount = 0;
+    public nextJobState: EpochProvingJobState = 'completed';
+
     protected override doCreateEpochProvingJob(
       epochNumber: bigint,
       _deadline: Date | undefined,
       _blocks: L2Block[],
       _txs: Tx[],
       _publicProcessorFactory: PublicProcessorFactory,
-      cleanUp: (job: EpochProvingJob) => Promise<void>,
     ): EpochProvingJob {
-      const job = mock<EpochProvingJob>({ getState: () => 'processing', run: () => Promise.resolve() });
+      const state = this.nextJobState;
+      this.nextJobState = 'completed';
+      const job = mock<EpochProvingJob>({
+        getState: () => state,
+        run: () => Promise.resolve(),
+        getEpochNumber: () => epochNumber,
+      });
       job.getId.mockReturnValue(jobs.length.toString());
-      jobs.push({ epochNumber, job, cleanUp });
+      jobs.push({ epochNumber, job });
+      this.totalJobCount++;
       return job;
     }
 

--- a/yarn-project/prover-node/src/prover-node.ts
+++ b/yarn-project/prover-node/src/prover-node.ts
@@ -108,10 +108,14 @@ export class ProverNode implements EpochMonitorHandler, ProverNodeApi, Traceable
    */
   async handleEpochReadyToProve(epochNumber: bigint): Promise<void> {
     try {
-      this.log.debug('jobs', JSON.stringify(this.jobs, null, 2));
+      this.log.debug(`Running jobs as ${epochNumber} is ready to prove`, {
+        jobs: Array.from(this.jobs.values()).map(job => `${job.getEpochNumber()}:${job.getId()}`),
+      });
       const activeJobs = await this.getActiveJobsForEpoch(epochNumber);
       if (activeJobs.length > 0) {
-        this.log.info(`Not starting proof for ${epochNumber} since there are active jobs`);
+        this.log.warn(`Not starting proof for ${epochNumber} since there are active jobs for the epoch`, {
+          activeJobs: activeJobs.map(job => job.uuid),
+        });
         return;
       }
       await this.startProof(epochNumber);

--- a/yarn-project/prover-node/src/prover-node.ts
+++ b/yarn-project/prover-node/src/prover-node.ts
@@ -54,9 +54,7 @@ export class ProverNode implements EpochMonitorHandler, ProverNodeApi, Traceable
   private log = createLogger('prover-node');
   private dateProvider = new DateProvider();
 
-  private latestEpochWeAreProving: bigint | undefined;
   private jobs: Map<string, EpochProvingJob> = new Map();
-  private cachedEpochData: { epochNumber: bigint; blocks: L2Block[]; txs: Tx[] } | undefined = undefined;
   private options: ProverNodeOptions;
   private metrics: ProverNodeMetrics;
 
@@ -116,7 +114,6 @@ export class ProverNode implements EpochMonitorHandler, ProverNodeApi, Traceable
         this.log.info(`Not starting proof for ${epochNumber} since there are active jobs`);
         return;
       }
-      // TODO: we probably want to skip starting a proof if we are too far into the current epoch
       await this.startProof(epochNumber);
     } catch (err) {
       if (err instanceof EmptyEpochError) {
@@ -155,19 +152,29 @@ export class ProverNode implements EpochMonitorHandler, ProverNodeApi, Traceable
   }
 
   /**
-   * Creates a proof for a block range. Returns once the proof has been submitted to L1.
-   */
-  public async prove(epochNumber: number | bigint) {
-    const job = await this.createProvingJob(BigInt(epochNumber));
-    return job.run();
-  }
-
-  /**
    * Starts a proving process and returns immediately.
    */
   public async startProof(epochNumber: number | bigint) {
     const job = await this.createProvingJob(BigInt(epochNumber));
-    void job.run().catch(err => this.log.error(`Error proving epoch ${epochNumber}`, err));
+    void this.runJob(job);
+  }
+
+  private async runJob(job: EpochProvingJob) {
+    const ctx = { id: job.getId(), epochNumber: job.getEpochNumber() };
+    try {
+      await job.run();
+      const state = job.getState();
+      if (state === 'reorg') {
+        this.log.warn(`Running new job for epoch ${job.getEpochNumber()} due to reorg`, ctx);
+        await this.createProvingJob(job.getEpochNumber());
+      } else {
+        this.log.verbose(`Job for ${job.getEpochNumber()} exited with state ${state}`, ctx);
+      }
+    } catch (err) {
+      this.log.error(`Error proving epoch ${job.getEpochNumber()}`, err, ctx);
+    } finally {
+      this.jobs.delete(job.getId());
+    }
   }
 
   /**
@@ -210,8 +217,7 @@ export class ProverNode implements EpochMonitorHandler, ProverNodeApi, Traceable
     }
 
     // Gather blocks for this epoch
-    const cachedEpochData = this.cachedEpochData?.epochNumber === epochNumber ? this.cachedEpochData : undefined;
-    const { blocks, txs } = cachedEpochData ?? (await this.gatherEpochData(epochNumber));
+    const { blocks, txs } = await this.gatherEpochData(epochNumber);
 
     const fromBlock = blocks[0].number;
     const toBlock = blocks.at(-1)!.number;
@@ -227,15 +233,10 @@ export class ProverNode implements EpochMonitorHandler, ProverNodeApi, Traceable
       this.telemetryClient,
     );
 
-    const cleanUp = () => {
-      this.jobs.delete(job.getId());
-      return Promise.resolve();
-    };
-
     const [_, endTimestamp] = getTimestampRangeForEpoch(epochNumber + 1n, await this.getL1Constants());
     const deadline = new Date(Number(endTimestamp) * 1000);
 
-    const job = this.doCreateEpochProvingJob(epochNumber, deadline, blocks, txs, publicProcessorFactory, cleanUp);
+    const job = this.doCreateEpochProvingJob(epochNumber, deadline, blocks, txs, publicProcessorFactory);
     this.jobs.set(job.getId(), job);
     return job;
   }
@@ -302,7 +303,6 @@ export class ProverNode implements EpochMonitorHandler, ProverNodeApi, Traceable
     blocks: L2Block[],
     txs: Tx[],
     publicProcessorFactory: PublicProcessorFactory,
-    cleanUp: () => Promise<void>,
   ) {
     return new EpochProvingJob(
       this.worldState,
@@ -317,7 +317,6 @@ export class ProverNode implements EpochMonitorHandler, ProverNodeApi, Traceable
       this.metrics,
       deadline,
       { parallelBlockLimit: this.options.maxParallelBlocksPerEpoch },
-      cleanUp,
     );
   }
 

--- a/yarn-project/stdlib/src/block/l2_block_source.ts
+++ b/yarn-project/stdlib/src/block/l2_block_source.ts
@@ -94,6 +94,13 @@ export interface L2BlockSource {
   getBlocksForEpoch(epochNumber: bigint): Promise<L2Block[]>;
 
   /**
+   * Returns all block headers for a given epoch.
+   * @dev Use this method only with recent epochs, since it walks the block list backwards.
+   * @param epochNumber - The epoch number to return headers for.
+   */
+  getBlockHeadersForEpoch(epochNumber: bigint): Promise<BlockHeader[]>;
+
+  /**
    * Returns whether the given epoch is completed on L1, based on the current L1 and L2 block numbers.
    * @param epochNumber - The epoch number to check.
    */

--- a/yarn-project/stdlib/src/interfaces/archiver.test.ts
+++ b/yarn-project/stdlib/src/interfaces/archiver.test.ts
@@ -118,6 +118,11 @@ describe('ArchiverApiSchema', () => {
     expect(result).toEqual([expect.any(L2Block)]);
   });
 
+  it('getBlockHeadersForEpoch', async () => {
+    const result = await context.client.getBlockHeadersForEpoch(1n);
+    expect(result).toEqual([expect.any(BlockHeader)]);
+  });
+
   it('isEpochComplete', async () => {
     const result = await context.client.isEpochComplete(1n);
     expect(result).toBe(true);
@@ -291,6 +296,11 @@ class MockArchiver implements ArchiverApi {
   async getBlocksForEpoch(epochNumber: bigint): Promise<L2Block[]> {
     expect(epochNumber).toEqual(1n);
     return [await L2Block.random(Number(epochNumber))];
+  }
+  async getBlockHeadersForEpoch(epochNumber: bigint): Promise<BlockHeader[]> {
+    expect(epochNumber).toEqual(1n);
+    const { header } = await L2Block.random(Number(epochNumber));
+    return [header];
   }
   isEpochComplete(epochNumber: bigint): Promise<boolean> {
     expect(epochNumber).toEqual(1n);

--- a/yarn-project/stdlib/src/interfaces/archiver.ts
+++ b/yarn-project/stdlib/src/interfaces/archiver.ts
@@ -49,6 +49,7 @@ export const ArchiverApiSchema: ApiSchemaFor<ArchiverApi> = {
   getL2SlotNumber: z.function().args().returns(schemas.BigInt),
   getL2EpochNumber: z.function().args().returns(schemas.BigInt),
   getBlocksForEpoch: z.function().args(schemas.BigInt).returns(z.array(L2Block.schema)),
+  getBlockHeadersForEpoch: z.function().args(schemas.BigInt).returns(z.array(BlockHeader.schema)),
   isEpochComplete: z.function().args(schemas.BigInt).returns(z.boolean()),
   getL2Tips: z.function().args().returns(L2TipsSchema),
   getPrivateLogs: z.function().args(z.number(), z.number()).returns(z.array(PrivateLog.schema)),

--- a/yarn-project/stdlib/src/interfaces/prover-node.test.ts
+++ b/yarn-project/stdlib/src/interfaces/prover-node.test.ts
@@ -32,10 +32,6 @@ describe('ProvingNodeApiSchema', () => {
   it('startProof', async () => {
     await context.client.startProof(1);
   });
-
-  it('prove', async () => {
-    await context.client.prove(1);
-  });
 });
 
 class MockProverNode implements ProverNodeApi {
@@ -50,10 +46,6 @@ class MockProverNode implements ProverNodeApi {
     ]);
   }
   startProof(epochNumber: number): Promise<void> {
-    expect(typeof epochNumber).toBe('number');
-    return Promise.resolve();
-  }
-  prove(epochNumber: number): Promise<void> {
     expect(typeof epochNumber).toBe('number');
     return Promise.resolve();
   }

--- a/yarn-project/stdlib/src/interfaces/prover-node.ts
+++ b/yarn-project/stdlib/src/interfaces/prover-node.ts
@@ -11,6 +11,7 @@ const EpochProvingJobState = [
   'failed',
   'stopped',
   'timed-out',
+  'reorg',
 ] as const;
 
 export type EpochProvingJobState = (typeof EpochProvingJobState)[number];
@@ -20,6 +21,7 @@ export const EpochProvingJobTerminalState: EpochProvingJobState[] = [
   'failed',
   'stopped',
   'timed-out',
+  'reorg',
 ] as const;
 
 export type EpochProvingJobTerminalState = (typeof EpochProvingJobTerminalState)[number];
@@ -29,8 +31,6 @@ export interface ProverNodeApi {
   getJobs(): Promise<{ uuid: string; status: EpochProvingJobState; epochNumber: number }[]>;
 
   startProof(epochNumber: number): Promise<void>;
-
-  prove(epochNumber: number): Promise<void>;
 }
 
 /** Schemas for prover node API functions. */
@@ -41,6 +41,4 @@ export const ProverNodeApiSchema: ApiSchemaFor<ProverNodeApi> = {
     .returns(z.array(z.object({ uuid: z.string(), status: z.enum(EpochProvingJobState), epochNumber: z.number() }))),
 
   startProof: z.function().args(schemas.Integer).returns(z.void()),
-
-  prove: z.function().args(schemas.Integer).returns(z.void()),
 };


### PR DESCRIPTION
As another fix for #12625, adds a recurring check on the epoch's block headers to the proving job. If a mismatch is found, the job is aborted and restarted with fresh data.

Also removes the unused `prove` call on the prover-node.

See also #12638
