### PR TITLE
fix(cli): fix tag resolution for `aztec update --contract`

### DIFF
--- a/playground/src/components/contract/components/deployContractDialog.tsx
+++ b/playground/src/components/contract/components/deployContractDialog.tsx
@@ -21,7 +21,6 @@ import {
 } from '@aztec/stdlib/abi';
 import { AztecContext } from '../../../aztecEnv';
 import { FunctionParameter } from '../../common/fnParameter';
-import { GITHUB_TAG_PREFIX } from '../../../utils/constants';
 
 const creationForm = css({
   display: 'flex',
@@ -65,7 +64,7 @@ export function DeployContractDialog({
     setLogsOpen(true);
 
     const nodeInfo = await wallet.getNodeInfo();
-    const expectedAztecNrVersion = `${GITHUB_TAG_PREFIX}-v${nodeInfo.nodeVersion}`;
+    const expectedAztecNrVersion = `v${nodeInfo.nodeVersion}`;
     if (contractArtifact.aztecNrVersion && contractArtifact.aztecNrVersion !== expectedAztecNrVersion) {
       throw new Error(
         `Contract was compiled with a different version of Aztec.nr: ${contractArtifact.aztecNrVersion}. Consider updating Aztec.nr to ${expectedAztecNrVersion}`,

--- a/playground/src/components/contract/components/registerContractDialog.tsx
+++ b/playground/src/components/contract/components/registerContractDialog.tsx
@@ -10,7 +10,6 @@ import Typography from '@mui/material/Typography';
 import { css } from '@mui/styled-engine';
 import { useContext, useState } from 'react';
 import { AztecContext } from '../../../aztecEnv';
-import { GITHUB_TAG_PREFIX } from '../../../utils/constants';
 
 const creationForm = css({
   display: 'flex',
@@ -43,7 +42,7 @@ export function RegisterContractDialog({
     setRegistering(true);
 
     const nodeInfo = await wallet.getNodeInfo();
-    const expectedAztecNrVersion = `${GITHUB_TAG_PREFIX}-v${nodeInfo.nodeVersion}`;
+    const expectedAztecNrVersion = `v${nodeInfo.nodeVersion}`;
     if (contractArtifact.aztecNrVersion && contractArtifact.aztecNrVersion !== expectedAztecNrVersion) {
       throw new Error(
         `Contract was compiled with a different version of Aztec.nr: ${contractArtifact.aztecNrVersion}. Consider updating Aztec.nr to ${expectedAztecNrVersion}`,

--- a/playground/src/utils/constants.ts
+++ b/playground/src/utils/constants.ts
@@ -1,1 +1,0 @@
-export const GITHUB_TAG_PREFIX = 'aztec-packages';

--- a/yarn-project/cli-wallet/src/cmds/deploy.ts
+++ b/yarn-project/cli-wallet/src/cmds/deploy.ts
@@ -1,5 +1,5 @@
 import { type AccountWalletWithSecretKey, ContractDeployer, type DeployMethod, Fr, type PXE } from '@aztec/aztec.js';
-import { GITHUB_TAG_PREFIX, encodeArgs, getContractArtifact } from '@aztec/cli/utils';
+import { encodeArgs, getContractArtifact } from '@aztec/cli/utils';
 import type { LogFn, Logger } from '@aztec/foundation/log';
 import { getInitializer } from '@aztec/stdlib/abi';
 import { PublicKeys } from '@aztec/stdlib/keys';
@@ -30,7 +30,7 @@ export async function deploy(
   const constructorArtifact = getInitializer(contractArtifact, initializer);
 
   const nodeInfo = await client.getNodeInfo();
-  const expectedAztecNrVersion = `${GITHUB_TAG_PREFIX}-v${nodeInfo.nodeVersion}`;
+  const expectedAztecNrVersion = `$v${nodeInfo.nodeVersion}`;
   if (contractArtifact.aztecNrVersion && contractArtifact.aztecNrVersion !== expectedAztecNrVersion) {
     log(
       `\nWarning: Contract was compiled with a different version of Aztec.nr: ${contractArtifact.aztecNrVersion}. Consider updating Aztec.nr to ${expectedAztecNrVersion}\n`,

--- a/yarn-project/cli/src/cmds/misc/update.ts
+++ b/yarn-project/cli/src/cmds/misc/update.ts
@@ -5,7 +5,6 @@ import { relative, resolve } from 'path';
 import { parse } from 'semver';
 
 import type { DependencyChanges } from './update/common.js';
-import { GITHUB_TAG_PREFIX } from './update/github.js';
 import { updateAztecNr } from './update/noir.js';
 import { getNewestVersion, updateAztecDeps, updateLockfile } from './update/npm.js';
 
@@ -44,11 +43,7 @@ export async function updateProject(
   for (const contract of contracts) {
     try {
       projectDependencyChanges.push(
-        await updateAztecNr(
-          resolve(process.cwd(), projectPath, contract),
-          `v${targetAztecVersion.version}`,
-          log,
-        ),
+        await updateAztecNr(resolve(process.cwd(), projectPath, contract), `v${targetAztecVersion.version}`, log),
       );
     } catch (err) {
       if (err instanceof Error && 'code' in err && err.code === 'ENOENT') {

--- a/yarn-project/cli/src/cmds/misc/update.ts
+++ b/yarn-project/cli/src/cmds/misc/update.ts
@@ -46,7 +46,7 @@ export async function updateProject(
       projectDependencyChanges.push(
         await updateAztecNr(
           resolve(process.cwd(), projectPath, contract),
-          `${GITHUB_TAG_PREFIX}-v${targetAztecVersion.version}`,
+          `v${targetAztecVersion.version}`,
           log,
         ),
       );

--- a/yarn-project/cli/src/cmds/misc/update/github.ts
+++ b/yarn-project/cli/src/cmds/misc/update/github.ts
@@ -1,3 +1,2 @@
 export const GITHUB_OWNER = 'AztecProtocol';
 export const GITHUB_REPO = 'aztec-packages';
-export const GITHUB_TAG_PREFIX = 'aztec-packages';

--- a/yarn-project/cli/src/utils/github.ts
+++ b/yarn-project/cli/src/utils/github.ts
@@ -1,3 +1,2 @@
 export const GITHUB_OWNER = 'AztecProtocol';
 export const GITHUB_REPO = 'aztec-packages';
-export const GITHUB_TAG_PREFIX = 'aztec-packages';


### PR DESCRIPTION
`aztec update --contract` is adding `aztec-packages-v0.79.0` to the `tag` instead of `v0.79.0`

Edit:
Found `GITHUB_TAG_PREFIX` in the playground, so removed those as well.