### PR TITLE
fix(docs): Fix link to source code after code snippets

### DIFF
--- a/docs/bootstrap.sh
+++ b/docs/bootstrap.sh
@@ -91,23 +91,23 @@ function release {
 }
 
 case "$cmd" in
-"clean")
-  git clean -fdx
-  ;;
-"" | "full" | "fast")
-  build_and_preview
-  ;;
-"hash")
-  echo "$hash"
-  ;;
-"release-preview")
-  release_preview
-  ;;
-"release")
-  release
-  ;;
-*)
-  echo "Unknown command: $cmd"
-  exit 1
-  ;;
+  "clean")
+    git clean -fdx
+    ;;
+  "" | "full" | "fast")
+    build_and_preview
+    ;;
+  "hash")
+    echo "$hash"
+    ;;
+  "release-preview")
+    release_preview
+    ;;
+  "release")
+    release
+    ;;
+  *)
+    echo "Unknown command: $cmd"
+    exit 1
+    ;;
 esac

--- a/docs/bootstrap.sh
+++ b/docs/bootstrap.sh
@@ -8,7 +8,7 @@ cmd=${1:-}
 hash=$(
   cache_content_hash \
     .rebuild_patterns \
-    $(find docs -type f -name "*.md" -exec grep '^#include_code' {} \; |
+    $(find docs -type f -name "*.md" -exec grep '^#include_code' {} \; | \
       awk '{ gsub("^/", "", $3); print "^" $3 }' | sort -u)
 )
 
@@ -94,7 +94,7 @@ case "$cmd" in
   "clean")
     git clean -fdx
     ;;
-  "" | "full" | "fast")
+  ""|"full"|"fast")
     build_and_preview
     ;;
   "hash")
@@ -109,5 +109,4 @@ case "$cmd" in
   *)
     echo "Unknown command: $cmd"
     exit 1
-    ;;
 esac

--- a/docs/src/preprocess/include_code.js
+++ b/docs/src/preprocess/include_code.js
@@ -256,9 +256,7 @@ async function preprocessIncludeCode(markdownContent, filePath, rootDir) {
         .resolve(rootDir, codeFilePath)
         .replace(/^\//, "");
       const urlText = `${relativeCodeFilePath}#L${startLine}-L${endLine}`;
-      const tag = process.env.COMMIT_TAG
-        ? `${process.env.COMMIT_TAG}`
-        : "master";
+      const tag = process.env.REF_NAME ? `${process.env.REF_NAME}` : "master";
       const url = `https://github.com/AztecProtocol/aztec-packages/blob/${tag}/${urlText}`;
 
       const title = noTitle ? "" : `title="${identifier}"`;

--- a/docs/src/preprocess/include_code.js
+++ b/docs/src/preprocess/include_code.js
@@ -259,7 +259,6 @@ async function preprocessIncludeCode(markdownContent, filePath, rootDir) {
       const tag = process.env.COMMIT_TAG
         ? `${process.env.COMMIT_TAG}`
         : "master";
-
       const url = `https://github.com/AztecProtocol/aztec-packages/blob/${tag}/${urlText}`;
 
       const title = noTitle ? "" : `title="${identifier}"`;

--- a/docs/src/preprocess/include_code.js
+++ b/docs/src/preprocess/include_code.js
@@ -256,7 +256,10 @@ async function preprocessIncludeCode(markdownContent, filePath, rootDir) {
         .resolve(rootDir, codeFilePath)
         .replace(/^\//, "");
       const urlText = `${relativeCodeFilePath}#L${startLine}-L${endLine}`;
-      const tag = process.env.REF_NAME ? `${process.env.REF_NAME}` : "master";
+      const tag = process.env.COMMIT_TAG
+        ? `${process.env.COMMIT_TAG}`
+        : "master";
+
       const url = `https://github.com/AztecProtocol/aztec-packages/blob/${tag}/${urlText}`;
 
       const title = noTitle ? "" : `title="${identifier}"`;


### PR DESCRIPTION
It was linking to the fallback (master). This should link to the correct version url