### PR TITLE
chore: downgrade undici so its engine spec is compatible

### DIFF
--- a/yarn-project/foundation/package.json
+++ b/yarn-project/foundation/package.json
@@ -126,7 +126,7 @@
     "pino": "^9.5.0",
     "pino-pretty": "^13.0.0",
     "sha3": "^2.1.4",
-    "undici": "^7.3.0",
+    "undici": "^5.28.5",
     "zod": "^3.23.8"
   },
   "devDependencies": {

--- a/yarn-project/foundation/src/json-rpc/client/undici.ts
+++ b/yarn-project/foundation/src/json-rpc/client/undici.ts
@@ -19,9 +19,9 @@ export function makeUndiciFetch(client = new Agent()): JsonRpcFetch {
     noRetry = false,
   ) => {
     log.trace(`JsonRpcClient.fetch: ${host} ${rpcMethod}`, { host, rpcMethod, body });
-    let resp: Dispatcher.ResponseData<string>;
+    let resp: Dispatcher.ResponseData;
     try {
-      resp = await client.request<string>({
+      resp = await client.request({
         method: 'POST',
         origin: new URL(host),
         path: useApiEndpoints ? rpcMethod : '/',

--- a/yarn-project/yarn.lock
+++ b/yarn-project/yarn.lock
@@ -766,7 +766,7 @@ __metadata:
     supertest: "npm:^6.3.3"
     ts-node: "npm:^10.9.1"
     typescript: "npm:^5.0.4"
-    undici: "npm:^7.3.0"
+    undici: "npm:^5.28.5"
     viem: "npm:2.23.7"
     zod: "npm:^3.23.8"
   languageName: unknown
@@ -2490,6 +2490,13 @@ __metadata:
   version: 8.57.0
   resolution: "@eslint/js@npm:8.57.0"
   checksum: 10/3c501ce8a997cf6cbbaf4ed358af5492875e3550c19b9621413b82caa9ae5382c584b0efa79835639e6e0ddaa568caf3499318e5bdab68643ef4199dce5eb0a0
+  languageName: node
+  linkType: hard
+
+"@fastify/busboy@npm:^2.0.0":
+  version: 2.1.1
+  resolution: "@fastify/busboy@npm:2.1.1"
+  checksum: 10/2bb8a7eca8289ed14c9eb15239bc1019797454624e769b39a0b90ed204d032403adc0f8ed0d2aef8a18c772205fa7808cf5a1b91f21c7bfc7b6032150b1062c5
   languageName: node
   linkType: hard
 
@@ -21676,10 +21683,12 @@ __metadata:
   languageName: node
   linkType: hard
 
-"undici@npm:^7.3.0":
-  version: 7.3.0
-  resolution: "undici@npm:7.3.0"
-  checksum: 10/8165c3a18cd045c70b009db006bee1784c5ba405634e8d2017107f65220a23190e2dfbbcb314bec71add1e43cabcd7515cd29b655c819f22e59b5e2e7025db20
+"undici@npm:^5.28.5":
+  version: 5.28.5
+  resolution: "undici@npm:5.28.5"
+  dependencies:
+    "@fastify/busboy": "npm:^2.0.0"
+  checksum: 10/459cd84ab75fe90d696fa2634a8b5b23f9e1080b27236c6809bd74e51862be85df6d95b4a8fed3ee42554495008cb3c05f1bc9d4a1807478f433cca567003d70
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
Downgrade undici so its node engine specification is compatible with Node 18 (LTS).

Ref https://undici.nodejs.org/#/?id=long-term-support

Fix #12645 