### PR TITLE
feat: restore system metrics

### DIFF
--- a/spartan/aztec-network/values.yaml
+++ b/spartan/aztec-network/values.yaml
@@ -27,7 +27,7 @@ telemetry:
   enabled: false
   otelCollectorEndpoint:
   useGcloudLogging: true
-  excludeMetrics: "system"
+  excludeMetrics: ""
 
 images:
   aztec:

--- a/spartan/metrics/values/kind.yaml
+++ b/spartan/metrics/values/kind.yaml
@@ -15,6 +15,17 @@ opentelemetry-collector:
           datapoint:
             - metric.type == METRIC_DATA_TYPE_HISTOGRAM and Len(explicit_bounds) > 20
 
+      metricstransform:
+        transforms:
+          - include: 'system.cpu.utilization'
+            match_type: strict
+            action: combine
+            new_name: 'system.cpu.utilization_combined'
+            operations:
+              - action: aggregate_labels
+                label_set: [ system.cpu.state ]
+                aggregation_type: mean
+
       transform/promote_resource_attributes:
         metric_statements:
           - context: datapoint
@@ -62,6 +73,7 @@ opentelemetry-collector:
           processors:
             - memory_limiter
             - filter/large_histograms
+            - metricstransform
             - transform/promote_resource_attributes
             - batch
           exporters:

--- a/spartan/metrics/values/prod.yaml
+++ b/spartan/metrics/values/prod.yaml
@@ -40,6 +40,17 @@ opentelemetry-collector:
             - set(attributes["k8s.namespace.name"], resource.attributes["k8s.namespace.name"])
             - set(attributes["k8s.pod.name"], resource.attributes["k8s.pod.name"])
 
+      metricstransform:
+        transforms:
+          - include: 'system.cpu.utilization'
+            match_type: strict
+            action: combine
+            new_name: 'system.cpu.utilization_combined'
+            operations:
+              - action: aggregate_labels
+                label_set: [ system.cpu.state ]
+                aggregation_type: mean
+
     exporters:
       prometheus:
         endpoint: ${env:MY_POD_IP}:8889
@@ -54,6 +65,7 @@ opentelemetry-collector:
           processors:
             - memory_limiter
             - filter/large_histograms
+            - metricstransform
             - transform/promote_resource_attributes
             - batch
           exporters:


### PR DESCRIPTION
This restores the disabled `system.*` metrics and aggregates the cpu metric to avoid big jumps in cardinality
