### PR TITLE
chore: aztec start should use pxe proving by default

### DIFF
--- a/yarn-project/pxe/src/config/index.ts
+++ b/yarn-project/pxe/src/config/index.ts
@@ -107,6 +107,7 @@ export const allPxeConfigMappings: ConfigMappingsType<CliPXEOptions & PXEService
     parseEnv: (val: string) => parseBooleanEnv(val) || !!process.env.NETWORK,
     description: 'Enable real proofs',
     isBoolean: true,
+    defaultValue: true,
   },
 };
 


### PR DESCRIPTION
Resolves #12677
