### PR TITLE
fix: Specify block number when fetching instances 

### DIFF
--- a/yarn-project/archiver/src/archiver/archiver.ts
+++ b/yarn-project/archiver/src/archiver/archiver.ts
@@ -32,7 +32,6 @@ import {
   type ContractDataSource,
   type ContractInstanceWithAddress,
   type ExecutablePrivateFunctionWithMembershipProof,
-  type PublicFunction,
   type UnconstrainedFunctionWithMembershipProof,
   computePublicBytecodeCommitment,
   isValidPrivateFunctionMembershipProof,
@@ -692,29 +691,6 @@ export class Archiver extends EventEmitter implements ArchiveSource, Traceable {
   }
 
   /**
-   * Gets the public function data for a contract.
-   * @param address - The contract address containing the function to fetch.
-   * @param selector - The function selector of the function to fetch.
-   * @returns The public function data (if found).
-   */
-  public async getPublicFunction(
-    address: AztecAddress,
-    selector: FunctionSelector,
-  ): Promise<PublicFunction | undefined> {
-    const instance = await this.getContract(address);
-    if (!instance) {
-      throw new Error(`Contract ${address.toString()} not found`);
-    }
-    const contractClass = await this.getContractClass(instance.currentContractClassId);
-    if (!contractClass) {
-      throw new Error(
-        `Contract class ${instance.currentContractClassId.toString()} for ${address.toString()} not found`,
-      );
-    }
-    return contractClass.publicFunctions.find(f => f.selector.equals(selector));
-  }
-
-  /**
    * Retrieves all private logs from up to `limit` blocks, starting from the block number `from`.
    * @param from - The block number from which to begin retrieving logs.
    * @param limit - The maximum number of blocks to retrieve logs from.
@@ -788,8 +764,11 @@ export class Archiver extends EventEmitter implements ArchiveSource, Traceable {
     return this.store.getBytecodeCommitment(id);
   }
 
-  public getContract(address: AztecAddress): Promise<ContractInstanceWithAddress | undefined> {
-    return this.store.getContractInstance(address);
+  public async getContract(
+    address: AztecAddress,
+    blockNumber?: number,
+  ): Promise<ContractInstanceWithAddress | undefined> {
+    return this.store.getContractInstance(address, blockNumber ?? (await this.getBlockNumber()));
   }
 
   /**
@@ -1166,8 +1145,8 @@ class ArchiverStoreHelper
   getBytecodeCommitment(contractClassId: Fr): Promise<Fr | undefined> {
     return this.store.getBytecodeCommitment(contractClassId);
   }
-  getContractInstance(address: AztecAddress): Promise<ContractInstanceWithAddress | undefined> {
-    return this.store.getContractInstance(address);
+  getContractInstance(address: AztecAddress, blockNumber: number): Promise<ContractInstanceWithAddress | undefined> {
+    return this.store.getContractInstance(address, blockNumber);
   }
   getContractClassIds(): Promise<Fr[]> {
     return this.store.getContractClassIds();

--- a/yarn-project/archiver/src/archiver/archiver_store.ts
+++ b/yarn-project/archiver/src/archiver/archiver_store.ts
@@ -244,8 +244,9 @@ export interface ArchiverDataStore {
   /**
    * Returns a contract instance given its address and the given block number, or undefined if not exists.
    * @param address - Address of the contract.
+   * @param blockNumber - Block number to get the contract instance at. Contract updates might change the instance at a given block.
    */
-  getContractInstance(address: AztecAddress): Promise<ContractInstanceWithAddress | undefined>;
+  getContractInstance(address: AztecAddress, blockNumber: number): Promise<ContractInstanceWithAddress | undefined>;
 
   /** Returns the list of all class ids known by the archiver. */
   getContractClassIds(): Promise<Fr[]>;

--- a/yarn-project/archiver/src/archiver/archiver_store_test_suite.ts
+++ b/yarn-project/archiver/src/archiver/archiver_store_test_suite.ts
@@ -292,16 +292,18 @@ export function describeArchiverDataStore(
       });
 
       it('returns previously stored contract instances', async () => {
-        await expect(store.getContractInstance(contractInstance.address)).resolves.toMatchObject(contractInstance);
+        await expect(store.getContractInstance(contractInstance.address, blockNum)).resolves.toMatchObject(
+          contractInstance,
+        );
       });
 
       it('returns undefined if contract instance is not found', async () => {
-        await expect(store.getContractInstance(await AztecAddress.random())).resolves.toBeUndefined();
+        await expect(store.getContractInstance(await AztecAddress.random(), blockNum)).resolves.toBeUndefined();
       });
 
       it('returns undefined if previously stored contract instances was deleted', async () => {
         await store.deleteContractInstances([contractInstance], blockNum);
-        await expect(store.getContractInstance(contractInstance.address)).resolves.toBeUndefined();
+        await expect(store.getContractInstance(contractInstance.address, blockNum)).resolves.toBeUndefined();
       });
     });
 

--- a/yarn-project/archiver/src/archiver/kv_archiver_store/kv_archiver_store.ts
+++ b/yarn-project/archiver/src/archiver/kv_archiver_store/kv_archiver_store.ts
@@ -78,9 +78,8 @@ export class KVArchiverDataStore implements ArchiverDataStore {
     return this.#contractClassStore.getContractClassIds();
   }
 
-  async getContractInstance(address: AztecAddress): Promise<ContractInstanceWithAddress | undefined> {
-    const contract = this.#contractInstanceStore.getContractInstance(address, await this.getSynchedL2BlockNumber());
-    return contract;
+  getContractInstance(address: AztecAddress, blockNumber: number): Promise<ContractInstanceWithAddress | undefined> {
+    return this.#contractInstanceStore.getContractInstance(address, blockNumber);
   }
 
   async addContractClasses(

--- a/yarn-project/archiver/src/archiver/memory_archiver_store/memory_archiver_store.ts
+++ b/yarn-project/archiver/src/archiver/memory_archiver_store/memory_archiver_store.ts
@@ -112,7 +112,10 @@ export class MemoryArchiverStore implements ArchiverDataStore {
     return Promise.resolve(Array.from(this.contractClasses.keys()).map(key => Fr.fromHexString(key)));
   }
 
-  public getContractInstance(address: AztecAddress): Promise<ContractInstanceWithAddress | undefined> {
+  public getContractInstance(
+    address: AztecAddress,
+    blockNumber: number,
+  ): Promise<ContractInstanceWithAddress | undefined> {
     const instance = this.contractInstances.get(address.toString());
     if (!instance) {
       return Promise.resolve(undefined);
@@ -120,8 +123,7 @@ export class MemoryArchiverStore implements ArchiverDataStore {
     const updates = this.contractInstanceUpdates.get(address.toString()) || [];
     if (updates.length > 0) {
       const lastUpdate = updates[0];
-      const currentBlockNumber = this.getLastBlockNumber();
-      if (currentBlockNumber >= lastUpdate.blockOfChange) {
+      if (blockNumber >= lastUpdate.blockOfChange) {
         instance.currentContractClassId = lastUpdate.newContractClassId;
       } else if (!lastUpdate.prevContractClassId.isZero()) {
         instance.currentContractClassId = lastUpdate.prevContractClassId;

--- a/yarn-project/bb-prover/src/avm_proving_tests/avm_check_circuit1.test.ts
+++ b/yarn-project/bb-prover/src/avm_proving_tests/avm_check_circuit1.test.ts
@@ -19,7 +19,7 @@ describe('AVM WitGen & Circuit – check circuit', () => {
   let tester: AvmProvingTester;
 
   beforeEach(async () => {
-    tester = await AvmProvingTester.create(/* blockNumber */ undefined, /*checkCircuitOnly*/ true);
+    tester = await AvmProvingTester.create(/* globals */ undefined, /*checkCircuitOnly*/ true);
     avmTestContractInstance = await tester.registerAndDeployContract(
       /*constructorArgs=*/ [],
       /*deployer=*/ AztecAddress.fromNumber(420),

--- a/yarn-project/bb-prover/src/avm_proving_tests/avm_check_circuit1.test.ts
+++ b/yarn-project/bb-prover/src/avm_proving_tests/avm_check_circuit1.test.ts
@@ -19,7 +19,9 @@ describe('AVM WitGen & Circuit – check circuit', () => {
   let tester: AvmProvingTester;
 
   beforeEach(async () => {
-    tester = await AvmProvingTester.create(/* globals */ undefined, /*checkCircuitOnly*/ true);
+    tester = await AvmProvingTester.create({
+      checkCircuitOnly: true,
+    });
     avmTestContractInstance = await tester.registerAndDeployContract(
       /*constructorArgs=*/ [],
       /*deployer=*/ AztecAddress.fromNumber(420),

--- a/yarn-project/bb-prover/src/avm_proving_tests/avm_check_circuit1.test.ts
+++ b/yarn-project/bb-prover/src/avm_proving_tests/avm_check_circuit1.test.ts
@@ -19,7 +19,7 @@ describe('AVM WitGen & Circuit – check circuit', () => {
   let tester: AvmProvingTester;
 
   beforeEach(async () => {
-    tester = await AvmProvingTester.create(/*checkCircuitOnly*/ true);
+    tester = await AvmProvingTester.create(/* blockNumber */ undefined, /*checkCircuitOnly*/ true);
     avmTestContractInstance = await tester.registerAndDeployContract(
       /*constructorArgs=*/ [],
       /*deployer=*/ AztecAddress.fromNumber(420),

--- a/yarn-project/bb-prover/src/avm_proving_tests/avm_check_circuit2.test.ts
+++ b/yarn-project/bb-prover/src/avm_proving_tests/avm_check_circuit2.test.ts
@@ -13,7 +13,7 @@ describe('AVM WitGen & Circuit – check circuit', () => {
   let tester: AvmProvingTester;
 
   beforeEach(async () => {
-    tester = await AvmProvingTester.create(/*checkCircuitOnly*/ true);
+    tester = await AvmProvingTester.create(/* blockNumber */ undefined, /*checkCircuitOnly*/ true);
     avmTestContractInstance = await tester.registerAndDeployContract(
       /*constructorArgs=*/ [],
       /*deployer=*/ AztecAddress.fromNumber(420),
@@ -44,7 +44,7 @@ describe('AVM WitGen & Circuit – check circuit', () => {
   // FIXME(dbanks12): fails with "Lookup PERM_MAIN_ALU failed."
   it.skip('top-level exceptional halts due to a non-existent contract in app-logic and teardown', async () => {
     // don't insert contracts into trees, and make sure retrieval fails
-    const tester = await AvmProvingTester.create(/*checkCircuitOnly=*/ true);
+    const tester = await AvmProvingTester.create(/* blockNumber */ undefined, /*checkCircuitOnly=*/ true);
     await tester.simProveVerify(
       sender,
       /*setupCalls=*/ [],

--- a/yarn-project/bb-prover/src/avm_proving_tests/avm_check_circuit2.test.ts
+++ b/yarn-project/bb-prover/src/avm_proving_tests/avm_check_circuit2.test.ts
@@ -13,7 +13,7 @@ describe('AVM WitGen & Circuit – check circuit', () => {
   let tester: AvmProvingTester;
 
   beforeEach(async () => {
-    tester = await AvmProvingTester.create(/* blockNumber */ undefined, /*checkCircuitOnly*/ true);
+    tester = await AvmProvingTester.create(/* globals */ undefined, /*checkCircuitOnly*/ true);
     avmTestContractInstance = await tester.registerAndDeployContract(
       /*constructorArgs=*/ [],
       /*deployer=*/ AztecAddress.fromNumber(420),
@@ -44,7 +44,7 @@ describe('AVM WitGen & Circuit – check circuit', () => {
   // FIXME(dbanks12): fails with "Lookup PERM_MAIN_ALU failed."
   it.skip('top-level exceptional halts due to a non-existent contract in app-logic and teardown', async () => {
     // don't insert contracts into trees, and make sure retrieval fails
-    const tester = await AvmProvingTester.create(/* blockNumber */ undefined, /*checkCircuitOnly=*/ true);
+    const tester = await AvmProvingTester.create(/* globals */ undefined, /*checkCircuitOnly=*/ true);
     await tester.simProveVerify(
       sender,
       /*setupCalls=*/ [],

--- a/yarn-project/bb-prover/src/avm_proving_tests/avm_check_circuit2.test.ts
+++ b/yarn-project/bb-prover/src/avm_proving_tests/avm_check_circuit2.test.ts
@@ -13,7 +13,9 @@ describe('AVM WitGen & Circuit – check circuit', () => {
   let tester: AvmProvingTester;
 
   beforeEach(async () => {
-    tester = await AvmProvingTester.create(/* globals */ undefined, /*checkCircuitOnly*/ true);
+    tester = await AvmProvingTester.create({
+      checkCircuitOnly: true,
+    });
     avmTestContractInstance = await tester.registerAndDeployContract(
       /*constructorArgs=*/ [],
       /*deployer=*/ AztecAddress.fromNumber(420),
@@ -44,7 +46,9 @@ describe('AVM WitGen & Circuit – check circuit', () => {
   // FIXME(dbanks12): fails with "Lookup PERM_MAIN_ALU failed."
   it.skip('top-level exceptional halts due to a non-existent contract in app-logic and teardown', async () => {
     // don't insert contracts into trees, and make sure retrieval fails
-    const tester = await AvmProvingTester.create(/* globals */ undefined, /*checkCircuitOnly=*/ true);
+    const tester = await AvmProvingTester.create({
+      checkCircuitOnly: true,
+    });
     await tester.simProveVerify(
       sender,
       /*setupCalls=*/ [],

--- a/yarn-project/bb-prover/src/avm_proving_tests/avm_check_circuit3.test.ts
+++ b/yarn-project/bb-prover/src/avm_proving_tests/avm_check_circuit3.test.ts
@@ -13,7 +13,7 @@ describe('AVM WitGen & Circuit – check circuit', () => {
   let tester: AvmProvingTester;
 
   beforeEach(async () => {
-    tester = await AvmProvingTester.create(/* blockNumber */ undefined, /*checkCircuitOnly*/ true);
+    tester = await AvmProvingTester.create(/* globals */ undefined, /*checkCircuitOnly*/ true);
     avmTestContractInstance = await tester.registerAndDeployContract(
       /*constructorArgs=*/ [],
       /*deployer=*/ AztecAddress.fromNumber(420),

--- a/yarn-project/bb-prover/src/avm_proving_tests/avm_check_circuit3.test.ts
+++ b/yarn-project/bb-prover/src/avm_proving_tests/avm_check_circuit3.test.ts
@@ -13,7 +13,7 @@ describe('AVM WitGen & Circuit – check circuit', () => {
   let tester: AvmProvingTester;
 
   beforeEach(async () => {
-    tester = await AvmProvingTester.create(/*checkCircuitOnly*/ true);
+    tester = await AvmProvingTester.create(/* blockNumber */ undefined, /*checkCircuitOnly*/ true);
     avmTestContractInstance = await tester.registerAndDeployContract(
       /*constructorArgs=*/ [],
       /*deployer=*/ AztecAddress.fromNumber(420),

--- a/yarn-project/bb-prover/src/avm_proving_tests/avm_check_circuit3.test.ts
+++ b/yarn-project/bb-prover/src/avm_proving_tests/avm_check_circuit3.test.ts
@@ -13,7 +13,9 @@ describe('AVM WitGen & Circuit – check circuit', () => {
   let tester: AvmProvingTester;
 
   beforeEach(async () => {
-    tester = await AvmProvingTester.create(/* globals */ undefined, /*checkCircuitOnly*/ true);
+    tester = await AvmProvingTester.create({
+      checkCircuitOnly: true,
+    });
     avmTestContractInstance = await tester.registerAndDeployContract(
       /*constructorArgs=*/ [],
       /*deployer=*/ AztecAddress.fromNumber(420),

--- a/yarn-project/bb-prover/src/avm_proving_tests/avm_contract_class_limits.test.ts
+++ b/yarn-project/bb-prover/src/avm_proving_tests/avm_contract_class_limits.test.ts
@@ -15,7 +15,7 @@ describe('AVM WitGen & Circuit – check circuit - contract class limits', () =>
   let avmTestContractAddress: AztecAddress;
 
   beforeEach(async () => {
-    tester = await AvmProvingTester.create(/* blockNumber */ undefined, /*checkCircuitOnly=*/ true);
+    tester = await AvmProvingTester.create(/* globals */ undefined, /*checkCircuitOnly=*/ true);
     // create enough unique contract classes to hit the limit
     instances = [];
     for (let i = 0; i <= MAX_PUBLIC_CALLS_TO_UNIQUE_CONTRACT_CLASS_IDS; i++) {

--- a/yarn-project/bb-prover/src/avm_proving_tests/avm_contract_class_limits.test.ts
+++ b/yarn-project/bb-prover/src/avm_proving_tests/avm_contract_class_limits.test.ts
@@ -15,7 +15,9 @@ describe('AVM WitGen & Circuit – check circuit - contract class limits', () =>
   let avmTestContractAddress: AztecAddress;
 
   beforeEach(async () => {
-    tester = await AvmProvingTester.create(/* globals */ undefined, /*checkCircuitOnly=*/ true);
+    tester = await AvmProvingTester.create({
+      checkCircuitOnly: true,
+    });
     // create enough unique contract classes to hit the limit
     instances = [];
     for (let i = 0; i <= MAX_PUBLIC_CALLS_TO_UNIQUE_CONTRACT_CLASS_IDS; i++) {

--- a/yarn-project/bb-prover/src/avm_proving_tests/avm_contract_class_limits.test.ts
+++ b/yarn-project/bb-prover/src/avm_proving_tests/avm_contract_class_limits.test.ts
@@ -15,7 +15,7 @@ describe('AVM WitGen & Circuit – check circuit - contract class limits', () =>
   let avmTestContractAddress: AztecAddress;
 
   beforeEach(async () => {
-    tester = await AvmProvingTester.create(/*checkCircuitOnly=*/ true);
+    tester = await AvmProvingTester.create(/* blockNumber */ undefined, /*checkCircuitOnly=*/ true);
     // create enough unique contract classes to hit the limit
     instances = [];
     for (let i = 0; i <= MAX_PUBLIC_CALLS_TO_UNIQUE_CONTRACT_CLASS_IDS; i++) {

--- a/yarn-project/bb-prover/src/avm_proving_tests/avm_contract_updates.test.ts
+++ b/yarn-project/bb-prover/src/avm_proving_tests/avm_contract_updates.test.ts
@@ -43,7 +43,9 @@ describe.skip('AVM WitGen & Circuit - contract updates', () => {
     async () => {
       // Contract was not originally the avmTestContract
       const originalClassId = new Fr(27);
-      const tester = await AvmProvingTester.create(/* globals */ undefined, /*checkCircuitOnly*/ true);
+      const tester = await AvmProvingTester.create({
+        checkCircuitOnly: true,
+      });
 
       avmTestContractInstance = await tester.registerAndDeployContract(
         /*constructorArgs=*/ [],
@@ -81,7 +83,9 @@ describe.skip('AVM WitGen & Circuit - contract updates', () => {
       // Contract was not originally the avmTestContract
       const originalClassId = new Fr(27);
 
-      const tester = await AvmProvingTester.create(/* globals */ undefined, /*checkCircuitOnly*/ true);
+      const tester = await AvmProvingTester.create({
+        checkCircuitOnly: true,
+      });
       avmTestContractInstance = await tester.registerAndDeployContract(
         /*constructorArgs=*/ [],
         sender,
@@ -120,7 +124,9 @@ describe.skip('AVM WitGen & Circuit - contract updates', () => {
       // Contract was not originally the avmTestContract
       const newClassId = new Fr(27);
 
-      const tester = await AvmProvingTester.create(/* globals */ undefined, /*checkCircuitOnly*/ true);
+      const tester = await AvmProvingTester.create({
+        checkCircuitOnly: true,
+      });
       avmTestContractInstance = await tester.registerAndDeployContract(
         /*constructorArgs=*/ [],
         sender,
@@ -156,7 +162,9 @@ describe.skip('AVM WitGen & Circuit - contract updates', () => {
       // Contract was not originally the avmTestContract
       const newClassId = new Fr(27);
 
-      const tester = await AvmProvingTester.create(/* globals */ undefined, /*checkCircuitOnly*/ true);
+      const tester = await AvmProvingTester.create({
+        checkCircuitOnly: true,
+      });
       avmTestContractInstance = await tester.registerAndDeployContract(
         /*constructorArgs=*/ [],
         sender,

--- a/yarn-project/bb-prover/src/avm_proving_tests/avm_contract_updates.test.ts
+++ b/yarn-project/bb-prover/src/avm_proving_tests/avm_contract_updates.test.ts
@@ -43,7 +43,7 @@ describe.skip('AVM WitGen & Circuit - contract updates', () => {
     async () => {
       // Contract was not originally the avmTestContract
       const originalClassId = new Fr(27);
-      const tester = await AvmProvingTester.create(DEFAULT_BLOCK_NUMBER, /*checkCircuitOnly*/ true);
+      const tester = await AvmProvingTester.create(/* globals */ undefined, /*checkCircuitOnly*/ true);
 
       avmTestContractInstance = await tester.registerAndDeployContract(
         /*constructorArgs=*/ [],
@@ -81,7 +81,7 @@ describe.skip('AVM WitGen & Circuit - contract updates', () => {
       // Contract was not originally the avmTestContract
       const originalClassId = new Fr(27);
 
-      const tester = await AvmProvingTester.create(DEFAULT_BLOCK_NUMBER, /*checkCircuitOnly*/ true);
+      const tester = await AvmProvingTester.create(/* globals */ undefined, /*checkCircuitOnly*/ true);
       avmTestContractInstance = await tester.registerAndDeployContract(
         /*constructorArgs=*/ [],
         sender,
@@ -120,7 +120,7 @@ describe.skip('AVM WitGen & Circuit - contract updates', () => {
       // Contract was not originally the avmTestContract
       const newClassId = new Fr(27);
 
-      const tester = await AvmProvingTester.create(DEFAULT_BLOCK_NUMBER, /*checkCircuitOnly*/ true);
+      const tester = await AvmProvingTester.create(/* globals */ undefined, /*checkCircuitOnly*/ true);
       avmTestContractInstance = await tester.registerAndDeployContract(
         /*constructorArgs=*/ [],
         sender,
@@ -156,7 +156,7 @@ describe.skip('AVM WitGen & Circuit - contract updates', () => {
       // Contract was not originally the avmTestContract
       const newClassId = new Fr(27);
 
-      const tester = await AvmProvingTester.create(DEFAULT_BLOCK_NUMBER, /*checkCircuitOnly*/ true);
+      const tester = await AvmProvingTester.create(/* globals */ undefined, /*checkCircuitOnly*/ true);
       avmTestContractInstance = await tester.registerAndDeployContract(
         /*constructorArgs=*/ [],
         sender,

--- a/yarn-project/bb-prover/src/avm_proving_tests/avm_contract_updates.test.ts
+++ b/yarn-project/bb-prover/src/avm_proving_tests/avm_contract_updates.test.ts
@@ -43,7 +43,7 @@ describe.skip('AVM WitGen & Circuit - contract updates', () => {
     async () => {
       // Contract was not originally the avmTestContract
       const originalClassId = new Fr(27);
-      const tester = await AvmProvingTester.create(/*checkCircuitOnly*/ true);
+      const tester = await AvmProvingTester.create(DEFAULT_BLOCK_NUMBER, /*checkCircuitOnly*/ true);
 
       avmTestContractInstance = await tester.registerAndDeployContract(
         /*constructorArgs=*/ [],
@@ -81,7 +81,7 @@ describe.skip('AVM WitGen & Circuit - contract updates', () => {
       // Contract was not originally the avmTestContract
       const originalClassId = new Fr(27);
 
-      const tester = await AvmProvingTester.create(/*checkCircuitOnly*/ true);
+      const tester = await AvmProvingTester.create(DEFAULT_BLOCK_NUMBER, /*checkCircuitOnly*/ true);
       avmTestContractInstance = await tester.registerAndDeployContract(
         /*constructorArgs=*/ [],
         sender,
@@ -120,7 +120,7 @@ describe.skip('AVM WitGen & Circuit - contract updates', () => {
       // Contract was not originally the avmTestContract
       const newClassId = new Fr(27);
 
-      const tester = await AvmProvingTester.create(/*checkCircuitOnly*/ true);
+      const tester = await AvmProvingTester.create(DEFAULT_BLOCK_NUMBER, /*checkCircuitOnly*/ true);
       avmTestContractInstance = await tester.registerAndDeployContract(
         /*constructorArgs=*/ [],
         sender,
@@ -156,7 +156,7 @@ describe.skip('AVM WitGen & Circuit - contract updates', () => {
       // Contract was not originally the avmTestContract
       const newClassId = new Fr(27);
 
-      const tester = await AvmProvingTester.create(/*checkCircuitOnly*/ true);
+      const tester = await AvmProvingTester.create(DEFAULT_BLOCK_NUMBER, /*checkCircuitOnly*/ true);
       avmTestContractInstance = await tester.registerAndDeployContract(
         /*constructorArgs=*/ [],
         sender,

--- a/yarn-project/bb-prover/src/avm_proving_tests/avm_proven_amm.test.ts
+++ b/yarn-project/bb-prover/src/avm_proving_tests/avm_proven_amm.test.ts
@@ -25,7 +25,7 @@ describe('AVM Witgen & Circuit apps tests: AMM', () => {
   let tester: AvmProvingTester;
 
   beforeEach(async () => {
-    tester = await AvmProvingTester.create(/*checkCircuitOnly*/ true);
+    tester = await AvmProvingTester.create(/* blockNumber */ undefined, /*checkCircuitOnly*/ true);
   });
 
   // TODO(dbanks12): add tester support for authwit and finish implementing this test

--- a/yarn-project/bb-prover/src/avm_proving_tests/avm_proven_amm.test.ts
+++ b/yarn-project/bb-prover/src/avm_proving_tests/avm_proven_amm.test.ts
@@ -25,7 +25,9 @@ describe('AVM Witgen & Circuit apps tests: AMM', () => {
   let tester: AvmProvingTester;
 
   beforeEach(async () => {
-    tester = await AvmProvingTester.create(/* globals */ undefined, /*checkCircuitOnly*/ true);
+    tester = await AvmProvingTester.create({
+      checkCircuitOnly: true,
+    });
   });
 
   // TODO(dbanks12): add tester support for authwit and finish implementing this test

--- a/yarn-project/bb-prover/src/avm_proving_tests/avm_proven_amm.test.ts
+++ b/yarn-project/bb-prover/src/avm_proving_tests/avm_proven_amm.test.ts
@@ -25,7 +25,7 @@ describe('AVM Witgen & Circuit apps tests: AMM', () => {
   let tester: AvmProvingTester;
 
   beforeEach(async () => {
-    tester = await AvmProvingTester.create(/* blockNumber */ undefined, /*checkCircuitOnly*/ true);
+    tester = await AvmProvingTester.create(/* globals */ undefined, /*checkCircuitOnly*/ true);
   });
 
   // TODO(dbanks12): add tester support for authwit and finish implementing this test

--- a/yarn-project/bb-prover/src/avm_proving_tests/avm_proven_token.test.ts
+++ b/yarn-project/bb-prover/src/avm_proving_tests/avm_proven_token.test.ts
@@ -20,7 +20,7 @@ describe('AVM Witgen & Circuit apps tests: TokenContract', () => {
   let tester: AvmProvingTester;
 
   beforeEach(async () => {
-    tester = await AvmProvingTester.create(/* blockNumber */ undefined, /*checkCircuitOnly*/ true);
+    tester = await AvmProvingTester.create(/* globals */ undefined, /*checkCircuitOnly*/ true);
 
     const constructorArgs = [admin, /*name=*/ 'Token', /*symbol=*/ 'TOK', /*decimals=*/ new Fr(18)];
     token = await tester.registerAndDeployContract(constructorArgs, /*deployer=*/ admin, TokenContractArtifact);

--- a/yarn-project/bb-prover/src/avm_proving_tests/avm_proven_token.test.ts
+++ b/yarn-project/bb-prover/src/avm_proving_tests/avm_proven_token.test.ts
@@ -20,7 +20,9 @@ describe('AVM Witgen & Circuit apps tests: TokenContract', () => {
   let tester: AvmProvingTester;
 
   beforeEach(async () => {
-    tester = await AvmProvingTester.create(/* globals */ undefined, /*checkCircuitOnly*/ true);
+    tester = await AvmProvingTester.create({
+      checkCircuitOnly: true,
+    });
 
     const constructorArgs = [admin, /*name=*/ 'Token', /*symbol=*/ 'TOK', /*decimals=*/ new Fr(18)];
     token = await tester.registerAndDeployContract(constructorArgs, /*deployer=*/ admin, TokenContractArtifact);

--- a/yarn-project/bb-prover/src/avm_proving_tests/avm_proven_token.test.ts
+++ b/yarn-project/bb-prover/src/avm_proving_tests/avm_proven_token.test.ts
@@ -20,7 +20,7 @@ describe('AVM Witgen & Circuit apps tests: TokenContract', () => {
   let tester: AvmProvingTester;
 
   beforeEach(async () => {
-    tester = await AvmProvingTester.create(/*checkCircuitOnly*/ true);
+    tester = await AvmProvingTester.create(/* blockNumber */ undefined, /*checkCircuitOnly*/ true);
 
     const constructorArgs = [admin, /*name=*/ 'Token', /*symbol=*/ 'TOK', /*decimals=*/ new Fr(18)];
     token = await tester.registerAndDeployContract(constructorArgs, /*deployer=*/ admin, TokenContractArtifact);

--- a/yarn-project/bb-prover/src/avm_proving_tests/avm_proving_and_verification.test.ts
+++ b/yarn-project/bb-prover/src/avm_proving_tests/avm_proving_and_verification.test.ts
@@ -12,7 +12,9 @@ describe('AVM WitGen & Circuit – proving and verification', () => {
   let tester: AvmProvingTester;
 
   beforeEach(async () => {
-    tester = await AvmProvingTester.create(/* globals */ undefined, /*checkCircuitOnly*/ false);
+    tester = await AvmProvingTester.create({
+      checkCircuitOnly: true,
+    });
     avmTestContractInstance = await tester.registerAndDeployContract(
       /*constructorArgs=*/ [],
       /*deployer=*/ AztecAddress.fromNumber(420),

--- a/yarn-project/bb-prover/src/avm_proving_tests/avm_proving_and_verification.test.ts
+++ b/yarn-project/bb-prover/src/avm_proving_tests/avm_proving_and_verification.test.ts
@@ -12,7 +12,7 @@ describe('AVM WitGen & Circuit – proving and verification', () => {
   let tester: AvmProvingTester;
 
   beforeEach(async () => {
-    tester = await AvmProvingTester.create(/* blockNumber */ undefined, /*checkCircuitOnly*/ false);
+    tester = await AvmProvingTester.create(/* globals */ undefined, /*checkCircuitOnly*/ false);
     avmTestContractInstance = await tester.registerAndDeployContract(
       /*constructorArgs=*/ [],
       /*deployer=*/ AztecAddress.fromNumber(420),

--- a/yarn-project/bb-prover/src/avm_proving_tests/avm_proving_and_verification.test.ts
+++ b/yarn-project/bb-prover/src/avm_proving_tests/avm_proving_and_verification.test.ts
@@ -12,7 +12,7 @@ describe('AVM WitGen & Circuit – proving and verification', () => {
   let tester: AvmProvingTester;
 
   beforeEach(async () => {
-    tester = await AvmProvingTester.create(/*checkCircuitOnly*/ false);
+    tester = await AvmProvingTester.create(/* blockNumber */ undefined, /*checkCircuitOnly*/ false);
     avmTestContractInstance = await tester.registerAndDeployContract(
       /*constructorArgs=*/ [],
       /*deployer=*/ AztecAddress.fromNumber(420),

--- a/yarn-project/bb-prover/src/avm_proving_tests/avm_proving_tester.ts
+++ b/yarn-project/bb-prover/src/avm_proving_tests/avm_proving_tester.ts
@@ -1,4 +1,8 @@
-import { PublicTxSimulationTester, type TestEnqueuedCall } from '@aztec/simulator/public/fixtures';
+import {
+  DEFAULT_BLOCK_NUMBER,
+  PublicTxSimulationTester,
+  type TestEnqueuedCall,
+} from '@aztec/simulator/public/fixtures';
 import { SimpleContractDataSource, WorldStateDB } from '@aztec/simulator/server';
 import type { AvmCircuitInputs } from '@aztec/stdlib/avm';
 import { AztecAddress } from '@aztec/stdlib/aztec-address';
@@ -35,12 +39,12 @@ export class AvmProvingTester extends PublicTxSimulationTester {
     super(worldStateDB, contractDataSource, merkleTrees);
   }
 
-  static override async create(checkCircuitOnly: boolean = false) {
+  static override async create(blockNumber = DEFAULT_BLOCK_NUMBER, checkCircuitOnly: boolean = false) {
     const bbWorkingDirectory = await fs.mkdtemp(path.join(tmpdir(), 'bb-'));
 
     const contractDataSource = new SimpleContractDataSource();
     const merkleTrees = await (await NativeWorldStateService.tmp()).fork();
-    const worldStateDB = new WorldStateDB(merkleTrees, contractDataSource);
+    const worldStateDB = new WorldStateDB(merkleTrees, contractDataSource, blockNumber);
     return new AvmProvingTester(bbWorkingDirectory, checkCircuitOnly, worldStateDB, contractDataSource, merkleTrees);
   }
 
@@ -115,12 +119,12 @@ export class AvmProvingTesterV2 extends PublicTxSimulationTester {
     super(worldStateDB, contractDataSource, merkleTrees);
   }
 
-  static override async create() {
+  static override async create(blockNumber = DEFAULT_BLOCK_NUMBER) {
     const bbWorkingDirectory = await fs.mkdtemp(path.join(tmpdir(), 'bb-'));
 
     const contractDataSource = new SimpleContractDataSource();
     const merkleTrees = await (await NativeWorldStateService.tmp()).fork();
-    const worldStateDB = new WorldStateDB(merkleTrees, contractDataSource);
+    const worldStateDB = new WorldStateDB(merkleTrees, contractDataSource, blockNumber);
     return new AvmProvingTesterV2(bbWorkingDirectory, worldStateDB, contractDataSource, merkleTrees);
   }
 

--- a/yarn-project/bb-prover/src/avm_proving_tests/avm_proving_tester.ts
+++ b/yarn-project/bb-prover/src/avm_proving_tests/avm_proving_tester.ts
@@ -37,7 +37,7 @@ export class AvmProvingTester extends PublicTxSimulationTester {
     super(worldStateDB, globals, contractDataSource, merkleTrees);
   }
 
-  static override async create(globals = defaultGlobals(), checkCircuitOnly: boolean = false) {
+  static override async create({ globals = defaultGlobals(), checkCircuitOnly = false }) {
     const bbWorkingDirectory = await fs.mkdtemp(path.join(tmpdir(), 'bb-'));
 
     const contractDataSource = new SimpleContractDataSource();
@@ -125,7 +125,7 @@ export class AvmProvingTesterV2 extends PublicTxSimulationTester {
     super(worldStateDB, globals, contractDataSource, merkleTrees);
   }
 
-  static override async create(globals = defaultGlobals()) {
+  static override async create({ globals = defaultGlobals() }) {
     const bbWorkingDirectory = await fs.mkdtemp(path.join(tmpdir(), 'bb-'));
 
     const contractDataSource = new SimpleContractDataSource();

--- a/yarn-project/bb-prover/src/avm_proving_tests/avm_public_fee_payment.test.ts
+++ b/yarn-project/bb-prover/src/avm_proving_tests/avm_public_fee_payment.test.ts
@@ -16,7 +16,7 @@ describe('AVM WitGen & Circuit – public fee payment', () => {
   let tester: AvmProvingTester;
 
   beforeEach(async () => {
-    tester = await AvmProvingTester.create(/* blockNumber */ undefined, /*checkCircuitOnly*/ true);
+    tester = await AvmProvingTester.create(/* globals */ undefined, /*checkCircuitOnly*/ true);
 
     await tester.registerFeeJuiceContract();
     await tester.setFeePayerBalance(feePayer, initialFeeJuiceBalance);

--- a/yarn-project/bb-prover/src/avm_proving_tests/avm_public_fee_payment.test.ts
+++ b/yarn-project/bb-prover/src/avm_proving_tests/avm_public_fee_payment.test.ts
@@ -16,7 +16,7 @@ describe('AVM WitGen & Circuit – public fee payment', () => {
   let tester: AvmProvingTester;
 
   beforeEach(async () => {
-    tester = await AvmProvingTester.create(/*checkCircuitOnly*/ true);
+    tester = await AvmProvingTester.create(/* blockNumber */ undefined, /*checkCircuitOnly*/ true);
 
     await tester.registerFeeJuiceContract();
     await tester.setFeePayerBalance(feePayer, initialFeeJuiceBalance);

--- a/yarn-project/bb-prover/src/avm_proving_tests/avm_public_fee_payment.test.ts
+++ b/yarn-project/bb-prover/src/avm_proving_tests/avm_public_fee_payment.test.ts
@@ -16,7 +16,9 @@ describe('AVM WitGen & Circuit – public fee payment', () => {
   let tester: AvmProvingTester;
 
   beforeEach(async () => {
-    tester = await AvmProvingTester.create(/* globals */ undefined, /*checkCircuitOnly*/ true);
+    tester = await AvmProvingTester.create({
+      checkCircuitOnly: true,
+    });
 
     await tester.registerFeeJuiceContract();
     await tester.setFeePayerBalance(feePayer, initialFeeJuiceBalance);

--- a/yarn-project/bb-prover/src/avm_proving_tests/avm_v2.test.ts
+++ b/yarn-project/bb-prover/src/avm_proving_tests/avm_v2.test.ts
@@ -11,7 +11,7 @@ describe('AVM v2', () => {
   let tester: AvmProvingTesterV2;
 
   beforeEach(async () => {
-    tester = await AvmProvingTesterV2.create();
+    tester = await AvmProvingTesterV2.create({});
     avmTestContractInstance = await tester.registerAndDeployContract(
       /*constructorArgs=*/ [],
       /*deployer=*/ AztecAddress.fromNumber(420),

--- a/yarn-project/ivc-integration/src/avm_integration.test.ts
+++ b/yarn-project/ivc-integration/src/avm_integration.test.ts
@@ -43,7 +43,7 @@ describe('AVM Integration', () => {
     bbWorkingDirectory = await fs.mkdtemp(path.join(os.tmpdir(), 'bb-avm-integration-'));
     bbBinaryPath = path.join(path.dirname(fileURLToPath(import.meta.url)), '../../../barretenberg/cpp/build/bin', 'bb');
 
-    simTester = await PublicTxSimulationTester.create();
+    simTester = await PublicTxSimulationTester.create({});
     avmTestContractInstance = await simTester.registerAndDeployContract(
       /*constructorArgs=*/ [],
       /*deployer=*/ AztecAddress.fromNumber(420),

--- a/yarn-project/prover-client/src/mocks/test_context.ts
+++ b/yarn-project/prover-client/src/mocks/test_context.ts
@@ -83,7 +83,7 @@ export class TestContext {
     const publicDb = await ws.fork();
 
     const contractDataSource = new SimpleContractDataSource();
-    const worldStateDB = new WorldStateDB(publicDb, contractDataSource);
+    const worldStateDB = new WorldStateDB(publicDb, contractDataSource, blockNumber);
 
     const tester = new PublicTxSimulationTester(worldStateDB, contractDataSource, publicDb);
 

--- a/yarn-project/prover-client/src/mocks/test_context.ts
+++ b/yarn-project/prover-client/src/mocks/test_context.ts
@@ -85,7 +85,7 @@ export class TestContext {
     const contractDataSource = new SimpleContractDataSource();
     const worldStateDB = new WorldStateDB(publicDb, contractDataSource, blockNumber);
 
-    const tester = new PublicTxSimulationTester(worldStateDB, contractDataSource, publicDb);
+    const tester = new PublicTxSimulationTester(worldStateDB, globalVariables, contractDataSource, publicDb);
 
     const publicTxSimulator = new PublicTxSimulator(publicDb, worldStateDB, globalVariables, true);
     const processor = new PublicProcessor(

--- a/yarn-project/sequencer-client/src/tx_validator/phases_validator.test.ts
+++ b/yarn-project/sequencer-client/src/tx_validator/phases_validator.test.ts
@@ -11,6 +11,7 @@ import { PhasesTxValidator } from './phases_validator.js';
 import { patchNonRevertibleFn } from './test_utils.js';
 
 describe('PhasesTxValidator', () => {
+  const blockNumber = 27;
   let contractDataSource: MockProxy<ContractDataSource>;
   let txValidator: PhasesTxValidator;
   let allowedContractClass: Fr;
@@ -33,7 +34,10 @@ describe('PhasesTxValidator', () => {
     allowedSetupSelector2 = makeSelector(2);
 
     contractDataSource = mock<ContractDataSource>({
-      getContract: mockFn().mockImplementation(() => {
+      getContract: mockFn().mockImplementation((_address, atBlockNumber) => {
+        if (blockNumber !== atBlockNumber) {
+          throw new Error('Unexpected block number');
+        }
         return {
           currentContractClassId: Fr.random(),
           originalContractClassId: Fr.random(),
@@ -41,24 +45,28 @@ describe('PhasesTxValidator', () => {
       }),
     });
 
-    txValidator = new PhasesTxValidator(contractDataSource, [
-      {
-        classId: allowedContractClass,
-        selector: allowedSetupSelector1,
-      },
-      {
-        address: allowedContract,
-        selector: allowedSetupSelector1,
-      },
-      {
-        classId: allowedContractClass,
-        selector: allowedSetupSelector2,
-      },
-      {
-        address: allowedContract,
-        selector: allowedSetupSelector2,
-      },
-    ]);
+    txValidator = new PhasesTxValidator(
+      contractDataSource,
+      [
+        {
+          classId: allowedContractClass,
+          selector: allowedSetupSelector1,
+        },
+        {
+          address: allowedContract,
+          selector: allowedSetupSelector1,
+        },
+        {
+          classId: allowedContractClass,
+          selector: allowedSetupSelector2,
+        },
+        {
+          address: allowedContract,
+          selector: allowedSetupSelector2,
+        },
+      ],
+      blockNumber,
+    );
   });
 
   it('allows setup functions on the contracts allow list', async () => {
@@ -72,7 +80,10 @@ describe('PhasesTxValidator', () => {
     const tx = await mockTx(1, { numberOfNonRevertiblePublicCallRequests: 1 });
     const { address } = await patchNonRevertibleFn(tx, 0, { selector: allowedSetupSelector1 });
 
-    contractDataSource.getContract.mockImplementationOnce(contractAddress => {
+    contractDataSource.getContract.mockImplementationOnce((contractAddress, atBlockNumber) => {
+      if (blockNumber !== atBlockNumber) {
+        throw new Error('Unexpected block number');
+      }
       if (address.equals(contractAddress)) {
         return Promise.resolve({
           currentContractClassId: allowedContractClass,
@@ -96,7 +107,10 @@ describe('PhasesTxValidator', () => {
     const tx = await mockTx(1, { numberOfNonRevertiblePublicCallRequests: 1 });
     // good selector, bad contract class
     const { address } = await patchNonRevertibleFn(tx, 0, { selector: allowedSetupSelector1 });
-    contractDataSource.getContract.mockImplementationOnce(contractAddress => {
+    contractDataSource.getContract.mockImplementationOnce((contractAddress, atBlockNumber) => {
+      if (blockNumber !== atBlockNumber) {
+        throw new Error('Unexpected block number');
+      }
       if (address.equals(contractAddress)) {
         return Promise.resolve({
           currentContractClassId: Fr.random(),

--- a/yarn-project/sequencer-client/src/tx_validator/phases_validator.ts
+++ b/yarn-project/sequencer-client/src/tx_validator/phases_validator.ts
@@ -14,8 +14,8 @@ export class PhasesTxValidator implements TxValidator<Tx> {
   #log = createLogger('sequencer:tx_validator:tx_phases');
   private contractDataSource: ContractsDataSourcePublicDB;
 
-  constructor(contracts: ContractDataSource, private setupAllowList: AllowedElement[]) {
-    this.contractDataSource = new ContractsDataSourcePublicDB(contracts);
+  constructor(contracts: ContractDataSource, private setupAllowList: AllowedElement[], private blockNumber: number) {
+    this.contractDataSource = new ContractsDataSourcePublicDB(contracts, blockNumber);
   }
 
   async validateTx(tx: Tx): Promise<TxValidationResult> {

--- a/yarn-project/sequencer-client/src/tx_validator/tx_validator_factory.ts
+++ b/yarn-project/sequencer-client/src/tx_validator/tx_validator_factory.ts
@@ -46,7 +46,7 @@ export function createValidatorForAcceptingTxs(
     new DataTxValidator(),
     new MetadataTxValidator(new Fr(l1ChainId), new Fr(blockNumber)),
     new DoubleSpendTxValidator(new NullifierCache(db)),
-    new PhasesTxValidator(contractDataSource, setupAllowList),
+    new PhasesTxValidator(contractDataSource, setupAllowList, blockNumber),
     new BlockHeaderTxValidator(new ArchiveCache(db)),
   ];
 
@@ -109,7 +109,7 @@ function preprocessValidator(
   return new AggregateTxValidator(
     new MetadataTxValidator(globalVariables.chainId, globalVariables.blockNumber),
     new DoubleSpendTxValidator(nullifierCache),
-    new PhasesTxValidator(contractDataSource, setupAllowList),
+    new PhasesTxValidator(contractDataSource, setupAllowList, globalVariables.blockNumber.toNumber()),
     new GasTxValidator(publicStateSource, ProtocolContractAddress.FeeJuice, globalVariables.gasFees),
     new BlockHeaderTxValidator(archiveCache),
   );

--- a/yarn-project/simulator/src/public/avm/avm_simulator.test.ts
+++ b/yarn-project/simulator/src/public/avm/avm_simulator.test.ts
@@ -34,6 +34,7 @@ import { mock } from 'jest-mock-extended';
 
 import { SideEffectTrace } from '../../public/side_effect_trace.js';
 import type { PublicSideEffectTraceInterface } from '../../public/side_effect_trace_interface.js';
+import { DEFAULT_BLOCK_NUMBER } from '../fixtures/public_tx_simulation_tester.js';
 import { WorldStateDB } from '../public_db_sources.js';
 import type { AvmContext } from './avm_context.js';
 import type { AvmExecutionEnvironment } from './avm_execution_environment.js';
@@ -1184,7 +1185,7 @@ describe('AVM simulator: transpiled Noir contracts', () => {
 
       const contractDataSource = new SimpleContractDataSource();
       merkleTrees = await (await NativeWorldStateService.tmp()).fork();
-      const worldStateDB = new WorldStateDB(merkleTrees, contractDataSource, 0);
+      const worldStateDB = new WorldStateDB(merkleTrees, contractDataSource, DEFAULT_BLOCK_NUMBER);
 
       persistableState = initPersistableStateManager({
         worldStateDB,

--- a/yarn-project/simulator/src/public/avm/avm_simulator.test.ts
+++ b/yarn-project/simulator/src/public/avm/avm_simulator.test.ts
@@ -1184,7 +1184,7 @@ describe('AVM simulator: transpiled Noir contracts', () => {
 
       const contractDataSource = new SimpleContractDataSource();
       merkleTrees = await (await NativeWorldStateService.tmp()).fork();
-      const worldStateDB = new WorldStateDB(merkleTrees, contractDataSource);
+      const worldStateDB = new WorldStateDB(merkleTrees, contractDataSource, 0);
 
       persistableState = initPersistableStateManager({
         worldStateDB,

--- a/yarn-project/simulator/src/public/avm/fixtures/avm_simulation_tester.ts
+++ b/yarn-project/simulator/src/public/avm/fixtures/avm_simulation_tester.ts
@@ -16,6 +16,7 @@ import {
   resolveContractAssertionMessage,
 } from '../../avm/fixtures/index.js';
 import { AvmPersistableStateManager } from '../../avm/journal/journal.js';
+import { DEFAULT_BLOCK_NUMBER } from '../../fixtures/public_tx_simulation_tester.js';
 import { WorldStateDB } from '../../public_db_sources.js';
 import { AvmSimulator } from '../avm_simulator.js';
 import { BaseAvmSimulationTester } from './base_avm_simulation_tester.js';
@@ -38,10 +39,10 @@ export class AvmSimulationTester extends BaseAvmSimulationTester {
     super(contractDataSource, merkleTrees);
   }
 
-  static async create(): Promise<AvmSimulationTester> {
+  static async create(blockNumber = DEFAULT_BLOCK_NUMBER): Promise<AvmSimulationTester> {
     const contractDataSource = new SimpleContractDataSource();
     const merkleTrees = await (await NativeWorldStateService.tmp()).fork();
-    const worldStateDB = new WorldStateDB(merkleTrees, contractDataSource);
+    const worldStateDB = new WorldStateDB(merkleTrees, contractDataSource, blockNumber);
     const trace = new SideEffectTrace();
     const firstNullifier = new Fr(420000);
     // FIXME: merkle ops should work, but I'm seeing frequent (but inconsistent) bytecode retrieval

--- a/yarn-project/simulator/src/public/avm/fixtures/simple_contract_data_source.ts
+++ b/yarn-project/simulator/src/public/avm/fixtures/simple_contract_data_source.ts
@@ -2,12 +2,7 @@ import type { Fr } from '@aztec/foundation/fields';
 import { createLogger } from '@aztec/foundation/log';
 import { type ContractArtifact, FunctionSelector } from '@aztec/stdlib/abi';
 import type { AztecAddress } from '@aztec/stdlib/aztec-address';
-import type {
-  ContractClassPublic,
-  ContractDataSource,
-  ContractInstanceWithAddress,
-  PublicFunction,
-} from '@aztec/stdlib/contract';
+import type { ContractClassPublic, ContractDataSource, ContractInstanceWithAddress } from '@aztec/stdlib/contract';
 
 import { PUBLIC_DISPATCH_FN_NAME } from './index.js';
 
@@ -50,10 +45,6 @@ export class SimpleContractDataSource implements ContractDataSource {
 
   /////////////////////////////////////////////////////////////
   // ContractDataSource function implementations
-  getPublicFunction(_address: AztecAddress, _selector: FunctionSelector): Promise<PublicFunction> {
-    throw new Error('Method not implemented.');
-  }
-
   getBlockNumber(): Promise<number> {
     throw new Error('Method not implemented.');
   }

--- a/yarn-project/simulator/src/public/fixtures/public_tx_simulation_tester.ts
+++ b/yarn-project/simulator/src/public/fixtures/public_tx_simulation_tester.ts
@@ -43,10 +43,10 @@ export class PublicTxSimulationTester extends BaseAvmSimulationTester {
     super(contractDataSource, merkleTrees);
   }
 
-  public static async create(): Promise<PublicTxSimulationTester> {
+  public static async create(blockNumber = DEFAULT_BLOCK_NUMBER): Promise<PublicTxSimulationTester> {
     const contractDataSource = new SimpleContractDataSource();
     const merkleTrees = await (await NativeWorldStateService.tmp()).fork();
-    const worldStateDB = new WorldStateDB(merkleTrees, contractDataSource);
+    const worldStateDB = new WorldStateDB(merkleTrees, contractDataSource, blockNumber);
     return new PublicTxSimulationTester(worldStateDB, contractDataSource, merkleTrees);
   }
 

--- a/yarn-project/simulator/src/public/fixtures/public_tx_simulation_tester.ts
+++ b/yarn-project/simulator/src/public/fixtures/public_tx_simulation_tester.ts
@@ -37,17 +37,18 @@ export class PublicTxSimulationTester extends BaseAvmSimulationTester {
 
   constructor(
     private worldStateDB: WorldStateDB,
+    private globals: GlobalVariables,
     contractDataSource: SimpleContractDataSource,
     merkleTrees: MerkleTreeWriteOperations,
   ) {
     super(contractDataSource, merkleTrees);
   }
 
-  public static async create(blockNumber = DEFAULT_BLOCK_NUMBER): Promise<PublicTxSimulationTester> {
+  public static async create(globals = defaultGlobals()): Promise<PublicTxSimulationTester> {
     const contractDataSource = new SimpleContractDataSource();
     const merkleTrees = await (await NativeWorldStateService.tmp()).fork();
-    const worldStateDB = new WorldStateDB(merkleTrees, contractDataSource, blockNumber);
-    return new PublicTxSimulationTester(worldStateDB, contractDataSource, merkleTrees);
+    const worldStateDB = new WorldStateDB(merkleTrees, contractDataSource, globals.blockNumber.toNumber());
+    return new PublicTxSimulationTester(worldStateDB, globals, contractDataSource, merkleTrees);
   }
 
   public async createTx(
@@ -131,13 +132,17 @@ export class PublicTxSimulationTester extends BaseAvmSimulationTester {
     feePayer: AztecAddress = sender,
     /* need some unique first nullifier for note-nonce computations */
     firstNullifier = new Fr(420000 + this.txCount++),
-    globals = defaultGlobals(),
   ): Promise<PublicTxResult> {
     const tx = await this.createTx(sender, setupCalls, appCalls, teardownCall, feePayer, firstNullifier);
 
     await this.setFeePayerBalance(feePayer);
 
-    const simulator = new PublicTxSimulator(this.merkleTrees, this.worldStateDB, globals, /*doMerkleOperations=*/ true);
+    const simulator = new PublicTxSimulator(
+      this.merkleTrees,
+      this.worldStateDB,
+      this.globals,
+      /*doMerkleOperations=*/ true,
+    );
 
     const startTime = performance.now();
     const avmResult = await simulator.simulate(tx);
@@ -170,7 +175,7 @@ async function executionRequestForCall(
   return new PublicExecutionRequest(callContext, calldata);
 }
 
-function defaultGlobals() {
+export function defaultGlobals() {
   const globals = GlobalVariables.empty();
   globals.timestamp = TIMESTAMP;
   globals.gasFees = DEFAULT_GAS_FEES; // apply some nonzero default gas fees

--- a/yarn-project/simulator/src/public/fixtures/public_tx_simulation_tester.ts
+++ b/yarn-project/simulator/src/public/fixtures/public_tx_simulation_tester.ts
@@ -44,7 +44,7 @@ export class PublicTxSimulationTester extends BaseAvmSimulationTester {
     super(contractDataSource, merkleTrees);
   }
 
-  public static async create(globals = defaultGlobals()): Promise<PublicTxSimulationTester> {
+  public static async create({ globals = defaultGlobals() }): Promise<PublicTxSimulationTester> {
     const contractDataSource = new SimpleContractDataSource();
     const merkleTrees = await (await NativeWorldStateService.tmp()).fork();
     const worldStateDB = new WorldStateDB(merkleTrees, contractDataSource, globals.blockNumber.toNumber());

--- a/yarn-project/simulator/src/public/public_db_sources.ts
+++ b/yarn-project/simulator/src/public/public_db_sources.ts
@@ -48,7 +48,7 @@ export class ContractsDataSourcePublicDB implements PublicContractsDB {
 
   private log = createLogger('simulator:contracts-data-source');
 
-  constructor(private dataSource: ContractDataSource) {}
+  constructor(private dataSource: ContractDataSource, private blockNumber: number) {}
 
   /**
    * Add new contracts from a transaction
@@ -216,7 +216,7 @@ export class ContractsDataSourcePublicDB implements PublicContractsDB {
       this.currentTxRevertibleCache.getInstance(address) ??
       this.currentTxNonRevertibleCache.getInstance(address) ??
       this.blockCache.getInstance(address) ??
-      (await this.dataSource.getContract(address))
+      (await this.dataSource.getContract(address, this.blockNumber))
     );
   }
 
@@ -266,8 +266,8 @@ export class ContractsDataSourcePublicDB implements PublicContractsDB {
 export class WorldStateDB extends ContractsDataSourcePublicDB implements PublicStateDB, MerkleTreeCheckpointOperations {
   private logger = createLogger('simulator:world-state-db');
 
-  constructor(public db: MerkleTreeWriteOperations, dataSource: ContractDataSource) {
-    super(dataSource);
+  constructor(public db: MerkleTreeWriteOperations, dataSource: ContractDataSource, blockNumber: number) {
+    super(dataSource, blockNumber);
   }
 
   /**

--- a/yarn-project/simulator/src/public/public_processor/apps_tests/deployments.test.ts
+++ b/yarn-project/simulator/src/public/public_processor/apps_tests/deployments.test.ts
@@ -45,7 +45,7 @@ describe('Public processor contract registration/deployment tests', () => {
       getTelemetryClient(),
     );
 
-    tester = new PublicTxSimulationTester(worldStateDB, contractDataSource, merkleTrees);
+    tester = new PublicTxSimulationTester(worldStateDB, globals, contractDataSource, merkleTrees);
 
     // make sure tx senders have fee balance
     await tester.setFeePayerBalance(admin);

--- a/yarn-project/simulator/src/public/public_processor/apps_tests/deployments.test.ts
+++ b/yarn-project/simulator/src/public/public_processor/apps_tests/deployments.test.ts
@@ -33,7 +33,7 @@ describe('Public processor contract registration/deployment tests', () => {
 
     const contractDataSource = new SimpleContractDataSource();
     const merkleTrees = await (await NativeWorldStateService.tmp()).fork();
-    worldStateDB = new WorldStateDB(merkleTrees, contractDataSource);
+    worldStateDB = new WorldStateDB(merkleTrees, contractDataSource, globals.blockNumber.toNumber());
     const simulator = new PublicTxSimulator(merkleTrees, worldStateDB, globals, /*doMerkleOperations=*/ true);
 
     processor = new PublicProcessor(

--- a/yarn-project/simulator/src/public/public_processor/apps_tests/token.test.ts
+++ b/yarn-project/simulator/src/public/public_processor/apps_tests/token.test.ts
@@ -45,7 +45,7 @@ describe('Public Processor app tests: TokenContract', () => {
       getTelemetryClient(),
     );
 
-    tester = new PublicTxSimulationTester(worldStateDB, contractDataSource, merkleTrees);
+    tester = new PublicTxSimulationTester(worldStateDB, globals, contractDataSource, merkleTrees);
 
     // make sure tx senders have fee balance
     await tester.setFeePayerBalance(admin);

--- a/yarn-project/simulator/src/public/public_processor/apps_tests/token.test.ts
+++ b/yarn-project/simulator/src/public/public_processor/apps_tests/token.test.ts
@@ -33,7 +33,7 @@ describe('Public Processor app tests: TokenContract', () => {
 
     const contractDataSource = new SimpleContractDataSource();
     const merkleTrees = await (await NativeWorldStateService.tmp()).fork();
-    worldStateDB = new WorldStateDB(merkleTrees, contractDataSource);
+    worldStateDB = new WorldStateDB(merkleTrees, contractDataSource, globals.blockNumber.toNumber());
     const simulator = new PublicTxSimulator(merkleTrees, worldStateDB, globals, /*doMerkleOperations=*/ true);
 
     processor = new PublicProcessor(

--- a/yarn-project/simulator/src/public/public_processor/public_processor.ts
+++ b/yarn-project/simulator/src/public/public_processor/public_processor.ts
@@ -59,7 +59,7 @@ export class PublicProcessorFactory {
     globalVariables: GlobalVariables,
     skipFeeEnforcement: boolean,
   ): PublicProcessor {
-    const worldStateDB = new WorldStateDB(merkleTree, this.contractDataSource);
+    const worldStateDB = new WorldStateDB(merkleTree, this.contractDataSource, globalVariables.blockNumber.toNumber());
     const publicTxSimulator = this.createPublicTxSimulator(
       merkleTree,
       worldStateDB,

--- a/yarn-project/simulator/src/public/public_tx_simulator/apps_tests/avm_test.test.ts
+++ b/yarn-project/simulator/src/public/public_tx_simulator/apps_tests/avm_test.test.ts
@@ -12,7 +12,7 @@ describe('Public TX simulator apps tests: AvmTestContract', () => {
   let simTester: PublicTxSimulationTester;
 
   beforeEach(async () => {
-    simTester = await PublicTxSimulationTester.create();
+    simTester = await PublicTxSimulationTester.create({});
 
     avmTestContract = await simTester.registerAndDeployContract(
       /*constructorArgs=*/ [],

--- a/yarn-project/simulator/src/public/public_tx_simulator/apps_tests/token.test.ts
+++ b/yarn-project/simulator/src/public/public_tx_simulator/apps_tests/token.test.ts
@@ -17,7 +17,7 @@ describe('Public TX simulator apps tests: TokenContract', () => {
   let simTester: PublicTxSimulationTester;
 
   beforeEach(async () => {
-    simTester = await PublicTxSimulationTester.create();
+    simTester = await PublicTxSimulationTester.create({});
     const constructorArgs = [admin, /*name=*/ 'Token', /*symbol=*/ 'TOK', /*decimals=*/ new Fr(18)];
     token = await simTester.registerAndDeployContract(constructorArgs, /*deployer=*/ admin, TokenContractArtifact);
 

--- a/yarn-project/simulator/src/public/public_tx_simulator/public_tx_simulator.test.ts
+++ b/yarn-project/simulator/src/public/public_tx_simulator/public_tx_simulator.test.ts
@@ -39,6 +39,7 @@ import { mock } from 'jest-mock-extended';
 import { AvmFinalizedCallResult } from '../avm/avm_contract_call_result.js';
 import { AvmPersistableStateManager } from '../avm/journal/journal.js';
 import type { InstructionSet } from '../avm/serialization/bytecode_serialization.js';
+import { DEFAULT_BLOCK_NUMBER } from '../fixtures/public_tx_simulation_tester.js';
 import { WorldStateDB } from '../public_db_sources.js';
 import { type PublicTxResult, PublicTxSimulator } from './public_tx_simulator.js';
 
@@ -280,7 +281,7 @@ describe('public_tx_simulator', () => {
   beforeEach(async () => {
     db = await (await NativeWorldStateService.tmp()).fork();
     dbCopy = await (await NativeWorldStateService.tmp()).fork();
-    worldStateDB = new WorldStateDB(db, mock<ContractDataSource>(), 0);
+    worldStateDB = new WorldStateDB(db, mock<ContractDataSource>(), DEFAULT_BLOCK_NUMBER);
 
     treeStore = openTmpStore();
 

--- a/yarn-project/simulator/src/public/public_tx_simulator/public_tx_simulator.test.ts
+++ b/yarn-project/simulator/src/public/public_tx_simulator/public_tx_simulator.test.ts
@@ -280,7 +280,7 @@ describe('public_tx_simulator', () => {
   beforeEach(async () => {
     db = await (await NativeWorldStateService.tmp()).fork();
     dbCopy = await (await NativeWorldStateService.tmp()).fork();
-    worldStateDB = new WorldStateDB(db, mock<ContractDataSource>());
+    worldStateDB = new WorldStateDB(db, mock<ContractDataSource>(), 0);
 
     treeStore = openTmpStore();
 

--- a/yarn-project/stdlib/src/contract/interfaces/contract_data_source.ts
+++ b/yarn-project/stdlib/src/contract/interfaces/contract_data_source.ts
@@ -2,18 +2,10 @@ import type { Fr } from '@aztec/foundation/fields';
 
 import { FunctionSelector } from '../../abi/index.js';
 import type { AztecAddress } from '../../aztec-address/index.js';
-import type { ContractClassPublic, PublicFunction } from './contract_class.js';
+import type { ContractClassPublic } from './contract_class.js';
 import type { ContractInstanceWithAddress } from './contract_instance.js';
 
 export interface ContractDataSource {
-  /**
-   * Returns a contract's encoded public function, given its function selector.
-   * @param address - The contract aztec address.
-   * @param selector - The function's selector.
-   * @returns The function's data.
-   */
-  getPublicFunction(address: AztecAddress, selector: FunctionSelector): Promise<PublicFunction | undefined>;
-
   /**
    * Gets the number of the latest L2 block processed by the implementation.
    * @returns The number of the latest L2 block processed by the implementation.
@@ -38,7 +30,7 @@ export interface ContractDataSource {
    * Returns a publicly deployed contract instance given its address.
    * @param address - Address of the deployed contract.
    */
-  getContract(address: AztecAddress): Promise<ContractInstanceWithAddress | undefined>;
+  getContract(address: AztecAddress, blockNumber?: number): Promise<ContractInstanceWithAddress | undefined>;
 
   /**
    * Returns the list of all class ids known.

--- a/yarn-project/stdlib/src/contract/interfaces/contract_data_source.ts
+++ b/yarn-project/stdlib/src/contract/interfaces/contract_data_source.ts
@@ -29,6 +29,7 @@ export interface ContractDataSource {
   /**
    * Returns a publicly deployed contract instance given its address.
    * @param address - Address of the deployed contract.
+   * @param blockNumber - Block number at which to retrieve the contract instance.
    */
   getContract(address: AztecAddress, blockNumber?: number): Promise<ContractInstanceWithAddress | undefined>;
 

--- a/yarn-project/stdlib/src/contract/interfaces/contract_data_source.ts
+++ b/yarn-project/stdlib/src/contract/interfaces/contract_data_source.ts
@@ -29,7 +29,7 @@ export interface ContractDataSource {
   /**
    * Returns a publicly deployed contract instance given its address.
    * @param address - Address of the deployed contract.
-   * @param blockNumber - Block number at which to retrieve the contract instance.
+   * @param blockNumber - Block number at which to retrieve the contract instance. If not provided, the latest block should be used.
    */
   getContract(address: AztecAddress, blockNumber?: number): Promise<ContractInstanceWithAddress | undefined>;
 

--- a/yarn-project/stdlib/src/interfaces/archiver.test.ts
+++ b/yarn-project/stdlib/src/interfaces/archiver.test.ts
@@ -14,7 +14,6 @@ import { getContractClassFromArtifact } from '../contract/contract_class.js';
 import {
   type ContractClassPublic,
   type ContractInstanceWithAddress,
-  type PublicFunction,
   computePublicBytecodeCommitment,
 } from '../contract/index.js';
 import { EmptyL1RollupConstants, type L1RollupConstants } from '../epoch-helpers/index.js';
@@ -170,12 +169,6 @@ describe('ArchiverApiSchema', () => {
     expect(result).toEqual({ logs: [expect.any(ExtendedContractClassLog)], maxLogsHit: true });
   });
 
-  it('getPublicFunction', async () => {
-    const selector = FunctionSelector.random();
-    const result = await context.client.getPublicFunction(await AztecAddress.random(), selector);
-    expect(result).toEqual({ selector, bytecode: Buffer.alloc(10, 10) });
-  });
-
   it('getContractClass', async () => {
     const contractClass = await getContractClassFromArtifact(artifact);
     const result = await context.client.getContractClass(Fr.random());
@@ -222,7 +215,7 @@ describe('ArchiverApiSchema', () => {
 
   it('getContract', async () => {
     const address = await AztecAddress.random();
-    const result = await context.client.getContract(address);
+    const result = await context.client.getContract(address, 27);
     expect(result).toEqual({
       address,
       currentContractClassId: expect.any(Fr),
@@ -330,11 +323,6 @@ class MockArchiver implements ArchiverApi {
     expect(filter.txHash).toBeInstanceOf(TxHash);
     expect(filter.contractAddress).toBeInstanceOf(AztecAddress);
     return Promise.resolve({ logs: [await ExtendedContractClassLog.random()], maxLogsHit: true });
-  }
-  getPublicFunction(address: AztecAddress, selector: FunctionSelector): Promise<PublicFunction | undefined> {
-    expect(address).toBeInstanceOf(AztecAddress);
-    expect(selector).toBeInstanceOf(FunctionSelector);
-    return Promise.resolve({ selector, bytecode: Buffer.alloc(10, 10) });
   }
   async getContractClass(id: Fr): Promise<ContractClassPublic | undefined> {
     expect(id).toBeInstanceOf(Fr);

--- a/yarn-project/stdlib/src/interfaces/archiver.test.ts
+++ b/yarn-project/stdlib/src/interfaces/archiver.test.ts
@@ -345,7 +345,8 @@ class MockArchiver implements ArchiverApi {
     );
     return functionsAndSelectors.find(f => f.selector.equals(selector))?.name;
   }
-  async getContract(address: AztecAddress): Promise<ContractInstanceWithAddress | undefined> {
+  async getContract(address: AztecAddress, blockNumber?: number): Promise<ContractInstanceWithAddress | undefined> {
+    expect(blockNumber).toEqual(27);
     return {
       address,
       currentContractClassId: Fr.random(),

--- a/yarn-project/stdlib/src/interfaces/archiver.ts
+++ b/yarn-project/stdlib/src/interfaces/archiver.ts
@@ -10,7 +10,6 @@ import {
   ContractClassPublicSchema,
   type ContractDataSource,
   ContractInstanceWithAddressSchema,
-  PublicFunctionSchema,
 } from '../contract/index.js';
 import { L1RollupConstantsSchema } from '../epoch-helpers/index.js';
 import { LogFilterSchema } from '../logs/log_filter.js';
@@ -62,13 +61,12 @@ export const ArchiverApiSchema: ApiSchemaFor<ArchiverApi> = {
     .returns(z.array(optional(inBlockSchemaFor(schemas.BigInt)))),
   getPublicLogs: z.function().args(LogFilterSchema).returns(GetPublicLogsResponseSchema),
   getContractClassLogs: z.function().args(LogFilterSchema).returns(GetContractClassLogsResponseSchema),
-  getPublicFunction: z
-    .function()
-    .args(schemas.AztecAddress, schemas.FunctionSelector)
-    .returns(PublicFunctionSchema.optional()),
   getContractClass: z.function().args(schemas.Fr).returns(ContractClassPublicSchema.optional()),
   getBytecodeCommitment: z.function().args(schemas.Fr).returns(schemas.Fr),
-  getContract: z.function().args(schemas.AztecAddress).returns(ContractInstanceWithAddressSchema.optional()),
+  getContract: z
+    .function()
+    .args(schemas.AztecAddress, optional(schemas.Integer))
+    .returns(ContractInstanceWithAddressSchema.optional()),
   getContractClassIds: z.function().args().returns(z.array(schemas.Fr)),
   registerContractFunctionSignatures: z.function().args(schemas.AztecAddress, z.array(z.string())).returns(z.void()),
   getL1ToL2Messages: z.function().args(schemas.BigInt).returns(z.array(schemas.Fr)),

--- a/yarn-project/txe/src/oracle/txe_oracle.ts
+++ b/yarn-project/txe/src/oracle/txe_oracle.ts
@@ -937,7 +937,7 @@ export class TXE implements TypedOracle {
     try {
       const simulator = new PublicTxSimulator(
         db,
-        new TXEWorldStateDB(db, new TXEPublicContractDataSource(this), this),
+        new TXEWorldStateDB(db, new TXEPublicContractDataSource(this), this, this.blockNumber),
         globalVariables,
         /*doMerkleOperations=*/ true,
       );

--- a/yarn-project/txe/src/util/txe_public_contract_data_source.ts
+++ b/yarn-project/txe/src/util/txe_public_contract_data_source.ts
@@ -16,14 +16,6 @@ import type { TXE } from '../oracle/txe_oracle.js';
 export class TXEPublicContractDataSource implements ContractDataSource {
   constructor(private txeOracle: TXE) {}
 
-  async getPublicFunction(address: AztecAddress, selector: FunctionSelector): Promise<PublicFunction | undefined> {
-    const bytecode = await this.txeOracle.getContractDataProvider().getBytecode(address, selector);
-    if (!bytecode) {
-      return undefined;
-    }
-    return { bytecode, selector };
-  }
-
   getBlockNumber(): Promise<number> {
     return this.txeOracle.getBlockNumber();
   }

--- a/yarn-project/txe/src/util/txe_world_state_db.ts
+++ b/yarn-project/txe/src/util/txe_world_state_db.ts
@@ -10,8 +10,13 @@ import { MerkleTreeId, type PublicDataTreeLeafPreimage } from '@aztec/stdlib/tre
 import type { TXE } from '../oracle/txe_oracle.js';
 
 export class TXEWorldStateDB extends WorldStateDB {
-  constructor(private merkleDb: MerkleTreeWriteOperations, dataSource: ContractDataSource, private txe: TXE) {
-    super(merkleDb, dataSource);
+  constructor(
+    private merkleDb: MerkleTreeWriteOperations,
+    dataSource: ContractDataSource,
+    private txe: TXE,
+    blockNumber: number,
+  ) {
+    super(merkleDb, dataSource, blockNumber);
   }
 
   override async storageRead(contract: AztecAddress, slot: Fr): Promise<Fr> {


### PR DESCRIPTION
We need to specify a block number when fetching contract instances since during block building, we want to fetch what the instance will be for the blocknumber being built, not the one currently synced.