### PR TITLE
chore(testnet): default data dir for testnet

### DIFF
--- a/yarn-project/aztec/src/cli/chain_l2_config.ts
+++ b/yarn-project/aztec/src/cli/chain_l2_config.ts
@@ -1,3 +1,5 @@
+import path from 'path';
+
 export type NetworkNames = 'testnet-ignition';
 
 export type L2ChainConfig = {
@@ -71,4 +73,5 @@ export async function enrichEnvironmentWithChainConfig(networkName: NetworkNames
   enrichVar('REGISTRY_CONTRACT_ADDRESS', config.registryAddress);
   enrichVar('SEQ_MIN_TX_PER_BLOCK', config.seqMinTxsPerBlock.toString());
   enrichVar('SEQ_MAX_TX_PER_BLOCK', config.seqMaxTxsPerBlock.toString());
+  enrichVar('DATA_DIR', path.join(process.env.HOME || '~', '.aztec', 'testnet', 'data'));
 }

--- a/yarn-project/aztec/src/cli/chain_l2_config.ts
+++ b/yarn-project/aztec/src/cli/chain_l2_config.ts
@@ -73,5 +73,5 @@ export async function enrichEnvironmentWithChainConfig(networkName: NetworkNames
   enrichVar('REGISTRY_CONTRACT_ADDRESS', config.registryAddress);
   enrichVar('SEQ_MIN_TX_PER_BLOCK', config.seqMinTxsPerBlock.toString());
   enrichVar('SEQ_MAX_TX_PER_BLOCK', config.seqMaxTxsPerBlock.toString());
-  enrichVar('DATA_DIR', path.join(process.env.HOME || '~', '.aztec', 'testnet', 'data'));
+  enrichVar('DATA_DIR', path.join(process.env.HOME || '~', '.aztec', networkName, 'data'));
 }

--- a/yarn-project/aztec/src/cli/chain_l2_config.ts
+++ b/yarn-project/aztec/src/cli/chain_l2_config.ts
@@ -73,5 +73,5 @@ export async function enrichEnvironmentWithChainConfig(networkName: NetworkNames
   enrichVar('REGISTRY_CONTRACT_ADDRESS', config.registryAddress);
   enrichVar('SEQ_MIN_TX_PER_BLOCK', config.seqMinTxsPerBlock.toString());
   enrichVar('SEQ_MAX_TX_PER_BLOCK', config.seqMaxTxsPerBlock.toString());
-  enrichVar('DATA_DIR', path.join(process.env.HOME || '~', '.aztec', networkName, 'data'));
+  enrichVar('DATA_DIRECTORY', path.join(process.env.HOME || '~', '.aztec', networkName, 'data'));
 }

--- a/yarn-project/aztec/src/cli/chain_l2_config.ts
+++ b/yarn-project/aztec/src/cli/chain_l2_config.ts
@@ -1,3 +1,5 @@
+import type { EnvVar } from '@aztec/foundation/config';
+
 import path from 'path';
 
 export type NetworkNames = 'testnet-ignition';
@@ -49,7 +51,7 @@ export async function getL2ChainConfig(networkName: NetworkNames): Promise<L2Cha
   return undefined;
 }
 
-function enrichVar(envVar: string, value: string) {
+function enrichVar(envVar: EnvVar, value: string) {
   // Don't override
   if (process.env[envVar]) {
     return;
@@ -66,7 +68,7 @@ export async function enrichEnvironmentWithChainConfig(networkName: NetworkNames
   enrichVar('AZTEC_SLOT_DURATION', config.aztecSlotDuration.toString());
   enrichVar('AZTEC_EPOCH_DURATION', config.aztecEpochDuration.toString());
   enrichVar('AZTEC_PROOF_SUBMISSION_WINDOW', config.aztecProofSubmissionWindow.toString());
-  enrichVar('P2P_BOOTSTRAP_NODES', config.p2pBootstrapNodes.join(','));
+  enrichVar('BOOTSTRAP_NODES', config.p2pBootstrapNodes.join(','));
   enrichVar('TEST_ACCOUNTS', config.testAccounts.toString());
   enrichVar('P2P_ENABLED', config.p2pEnabled.toString());
   enrichVar('L1_CHAIN_ID', config.l1ChainId.toString());


### PR DESCRIPTION
## Overview

As part of https://github.com/AztecProtocol/aztec-packages/issues/12452

When combined with https://github.com/AztecProtocol/aztec-packages/pull/12589 (awaiting clarification from phil) 

We should be able to have people join testnet with only these 3 config values:

- l1 consensus host
- l1 host
- validator private key

Everything else is now a default
