### PR TITLE
chore: decrease bytecode size for sol honk verifier

### DIFF
--- a/barretenberg/acir_tests/sol-test/src/index.js
+++ b/barretenberg/acir_tests/sol-test/src/index.js
@@ -74,7 +74,11 @@ export const compilationInput = {
     // we require the optimizer
     optimizer: {
       enabled: true,
-      runs: 200,
+      runs: 1,
+    },
+    metadata: {
+      appendCBOR: false,
+      bytecodeHash: "none",
     },
     outputSelection: {
       "*": {

--- a/barretenberg/sol/foundry.toml
+++ b/barretenberg/sol/foundry.toml
@@ -3,13 +3,15 @@ src = 'src'
 out = 'out'
 libs = ['lib']
 ffi = true
-optimizer_runs = 500
+optimizer_runs = 1
 gas_limit = 900000000000000000
+bytecode_hash = "none"
 
 [fuzz]
 runs = 1
 
 
-solc = "0.8.21"
+solc = "0.8.29"
+
 
 # See more config options https://github.com/foundry-rs/foundry/tree/master/config

--- a/l1-contracts/bootstrap.sh
+++ b/l1-contracts/bootstrap.sh
@@ -43,7 +43,8 @@ function build {
     # Step 2: Build the the generated verifier contract with optimization.
     forge build $(find generated -name '*.sol') \
       --optimize \
-      --optimizer-runs 200
+      --optimizer-runs 1 \
+      --no-metadata
 
     cache_upload $artifact out
   fi


### PR DESCRIPTION
Change optimizer run settings so the Honk Verifier contract can be more bytecode-efficient at the expense of gas. This trade-off is fine for development purposes to stay within the allowed bytecode size. Once the contract is feature-complete, we'll focus on both gas and bytecode efficiency by switching to a variant in assembly.