### PR TITLE
feat: Store attestations in archiver

### DIFF
--- a/yarn-project/archiver/src/archiver/archiver_store.ts
+++ b/yarn-project/archiver/src/archiver/archiver_store.ts
@@ -15,7 +15,7 @@ import type { InboxLeaf } from '@aztec/stdlib/messaging';
 import { BlockHeader, type TxEffect, type TxHash, type TxReceipt } from '@aztec/stdlib/tx';
 
 import type { DataRetrieval } from './structs/data_retrieval.js';
-import type { L1Published } from './structs/published.js';
+import type { PublishedL2Block } from './structs/published.js';
 
 /**
  * Represents the latest L1 block processed by the archiver for various objects in L2.
@@ -39,7 +39,7 @@ export interface ArchiverDataStore {
    * @param blocks - The L2 blocks to be added to the store and the last processed L1 block.
    * @returns True if the operation is successful.
    */
-  addBlocks(blocks: L1Published<L2Block>[]): Promise<boolean>;
+  addBlocks(blocks: PublishedL2Block[]): Promise<boolean>;
 
   /**
    * Unwinds blocks from the database
@@ -56,7 +56,7 @@ export interface ArchiverDataStore {
    * @param limit - The number of blocks to return.
    * @returns The requested L2 blocks.
    */
-  getBlocks(from: number, limit: number): Promise<L1Published<L2Block>[]>;
+  getBlocks(from: number, limit: number): Promise<PublishedL2Block[]>;
 
   /**
    * Gets up to `limit` amount of L2 block headers starting from `from`.

--- a/yarn-project/archiver/src/archiver/archiver_store_test_suite.ts
+++ b/yarn-project/archiver/src/archiver/archiver_store_test_suite.ts
@@ -7,6 +7,7 @@ import {
 } from '@aztec/constants';
 import { times, timesParallel } from '@aztec/foundation/collection';
 import { randomInt } from '@aztec/foundation/crypto';
+import { Signature } from '@aztec/foundation/eth-signature';
 import { Fr } from '@aztec/foundation/fields';
 import { AztecAddress } from '@aztec/stdlib/aztec-address';
 import { L2Block, wrapInBlock } from '@aztec/stdlib/block';
@@ -27,7 +28,7 @@ import '@aztec/stdlib/testing/jest';
 import { TxEffect, TxHash } from '@aztec/stdlib/tx';
 
 import type { ArchiverDataStore, ArchiverL1SynchPoint } from './archiver_store.js';
-import type { L1Published } from './structs/published.js';
+import type { PublishedL2Block } from './structs/published.js';
 
 /**
  * @param testName - The name of the test suite.
@@ -39,8 +40,9 @@ export function describeArchiverDataStore(
 ) {
   describe(testName, () => {
     let store: ArchiverDataStore;
-    let blocks: L1Published<L2Block>[];
-    const blockTests: [number, number, () => L1Published<L2Block>[]][] = [
+    let blocks: PublishedL2Block[];
+
+    const blockTests: [number, number, () => PublishedL2Block[]][] = [
       [1, 1, () => blocks.slice(0, 1)],
       [10, 1, () => blocks.slice(9, 10)],
       [1, 10, () => blocks.slice(0, 10)],
@@ -48,18 +50,30 @@ export function describeArchiverDataStore(
       [5, 2, () => blocks.slice(4, 6)],
     ];
 
-    const makeL1Published = (block: L2Block, l1BlockNumber: number): L1Published<L2Block> => ({
-      data: block,
+    const makePublished = (block: L2Block, l1BlockNumber: number): PublishedL2Block => ({
+      block: block,
       l1: {
         blockNumber: BigInt(l1BlockNumber),
         blockHash: `0x${l1BlockNumber}`,
         timestamp: BigInt(l1BlockNumber * 1000),
       },
+      signatures: times(3, Signature.random),
     });
+
+    const expectBlocksEqual = (actual: PublishedL2Block[], expected: PublishedL2Block[]) => {
+      expect(actual.length).toEqual(expected.length);
+      for (let i = 0; i < expected.length; i++) {
+        const expectedBlock = expected[i];
+        const actualBlock = actual[i];
+        expect(actualBlock.l1).toEqual(expectedBlock.l1);
+        expect(actualBlock.block.equals(expectedBlock.block)).toBe(true);
+        expect(actualBlock.signatures.every((s, i) => s.equals(expectedBlock.signatures[i]))).toBe(true);
+      }
+    };
 
     beforeEach(async () => {
       store = await getStore();
-      blocks = await timesParallel(10, async i => makeL1Published(await L2Block.random(i + 1), i + 10));
+      blocks = await timesParallel(10, async i => makePublished(await L2Block.random(i + 1), i + 10));
     });
 
     describe('addBlocks', () => {
@@ -78,7 +92,7 @@ export function describeArchiverDataStore(
         await store.addBlocks(blocks);
         const blockNumber = await store.getSynchedL2BlockNumber();
 
-        expect(await store.getBlocks(blockNumber, 1)).toEqual([blocks[blocks.length - 1]]);
+        expectBlocksEqual(await store.getBlocks(blockNumber, 1), [blocks[blocks.length - 1]]);
 
         await store.unwindBlocks(blockNumber, 1);
 
@@ -87,13 +101,13 @@ export function describeArchiverDataStore(
       });
 
       it('can unwind multiple empty blocks', async () => {
-        const emptyBlocks = await timesParallel(10, async i => makeL1Published(await L2Block.random(i + 1, 0), i + 10));
+        const emptyBlocks = await timesParallel(10, async i => makePublished(await L2Block.random(i + 1, 0), i + 10));
         await store.addBlocks(emptyBlocks);
         expect(await store.getSynchedL2BlockNumber()).toBe(10);
 
         await store.unwindBlocks(10, 3);
         expect(await store.getSynchedL2BlockNumber()).toBe(7);
-        expect((await store.getBlocks(1, 10)).map(b => b.data.number)).toEqual([1, 2, 3, 4, 5, 6, 7]);
+        expect((await store.getBlocks(1, 10)).map(b => b.block.number)).toEqual([1, 2, 3, 4, 5, 6, 7]);
       });
 
       it('refuses to unwind blocks if the tip is not the last block', async () => {
@@ -108,7 +122,7 @@ export function describeArchiverDataStore(
       });
 
       it.each(blockTests)('retrieves previously stored blocks', async (start, limit, getExpectedBlocks) => {
-        await expect(store.getBlocks(start, limit)).resolves.toEqual(getExpectedBlocks());
+        expectBlocksEqual(await store.getBlocks(start, limit), getExpectedBlocks());
       });
 
       it('returns an empty array if no blocks are found', async () => {
@@ -131,7 +145,7 @@ export function describeArchiverDataStore(
 
       it("returns the most recently added block's number", async () => {
         await store.addBlocks(blocks);
-        await expect(store.getSynchedL2BlockNumber()).resolves.toEqual(blocks.at(-1)!.data.number);
+        await expect(store.getSynchedL2BlockNumber()).resolves.toEqual(blocks.at(-1)!.block.number);
       });
     });
 
@@ -165,14 +179,14 @@ export function describeArchiverDataStore(
 
     describe('addLogs', () => {
       it('adds private & public logs', async () => {
-        const block = blocks[0].data;
+        const block = blocks[0].block;
         await expect(store.addLogs([block])).resolves.toEqual(true);
       });
     });
 
     describe('deleteLogs', () => {
       it('deletes private & public logs', async () => {
-        const block = blocks[0].data;
+        const block = blocks[0].block;
         await store.addBlocks([blocks[0]]);
         await expect(store.addLogs([block])).resolves.toEqual(true);
 
@@ -193,7 +207,7 @@ export function describeArchiverDataStore(
 
     describe('getPrivateLogs', () => {
       it('gets added private logs', async () => {
-        const block = blocks[0].data;
+        const block = blocks[0].block;
         await store.addBlocks([blocks[0]]);
         await store.addLogs([block]);
 
@@ -204,16 +218,16 @@ export function describeArchiverDataStore(
 
     describe('getTxEffect', () => {
       beforeEach(async () => {
-        await store.addLogs(blocks.map(b => b.data));
+        await store.addLogs(blocks.map(b => b.block));
         await store.addBlocks(blocks);
       });
 
       it.each([
-        () => wrapInBlock(blocks[0].data.body.txEffects[0], blocks[0].data),
-        () => wrapInBlock(blocks[9].data.body.txEffects[3], blocks[9].data),
-        () => wrapInBlock(blocks[3].data.body.txEffects[1], blocks[3].data),
-        () => wrapInBlock(blocks[5].data.body.txEffects[2], blocks[5].data),
-        () => wrapInBlock(blocks[1].data.body.txEffects[0], blocks[1].data),
+        () => wrapInBlock(blocks[0].block.body.txEffects[0], blocks[0].block),
+        () => wrapInBlock(blocks[9].block.body.txEffects[3], blocks[9].block),
+        () => wrapInBlock(blocks[3].block.body.txEffects[1], blocks[3].block),
+        () => wrapInBlock(blocks[5].block.body.txEffects[2], blocks[5].block),
+        () => wrapInBlock(blocks[1].block.body.txEffects[0], blocks[1].block),
       ])('retrieves a previously stored transaction', async getExpectedTx => {
         const expectedTx = await getExpectedTx();
         const actualTx = await store.getTxEffect(expectedTx.data.txHash);
@@ -225,11 +239,11 @@ export function describeArchiverDataStore(
       });
 
       it.each([
-        () => wrapInBlock(blocks[0].data.body.txEffects[0], blocks[0].data),
-        () => wrapInBlock(blocks[9].data.body.txEffects[3], blocks[9].data),
-        () => wrapInBlock(blocks[3].data.body.txEffects[1], blocks[3].data),
-        () => wrapInBlock(blocks[5].data.body.txEffects[2], blocks[5].data),
-        () => wrapInBlock(blocks[1].data.body.txEffects[0], blocks[1].data),
+        () => wrapInBlock(blocks[0].block.body.txEffects[0], blocks[0].block),
+        () => wrapInBlock(blocks[9].block.body.txEffects[3], blocks[9].block),
+        () => wrapInBlock(blocks[3].block.body.txEffects[1], blocks[3].block),
+        () => wrapInBlock(blocks[5].block.body.txEffects[2], blocks[5].block),
+        () => wrapInBlock(blocks[1].block.body.txEffects[0], blocks[1].block),
       ])('tries to retrieves a previously stored transaction after deleted', async getExpectedTx => {
         await store.unwindBlocks(blocks.length, blocks.length);
 
@@ -427,7 +441,7 @@ export function describeArchiverDataStore(
       const numPrivateLogsPerTx = 3;
       const numPublicLogsPerTx = 2;
 
-      let blocks: L1Published<L2Block>[];
+      let blocks: PublishedL2Block[];
 
       const makeTag = (blockNumber: number, txIndex: number, logIndex: number, isPublic = false) =>
         new Fr((blockNumber * 100 + txIndex * 10 + logIndex) * (isPublic ? 123 : 1));
@@ -456,7 +470,7 @@ export function describeArchiverDataStore(
         });
       };
 
-      const mockBlockWithLogs = async (blockNumber: number): Promise<L1Published<L2Block>> => {
+      const mockBlockWithLogs = async (blockNumber: number): Promise<PublishedL2Block> => {
         const block = await L2Block.random(blockNumber);
         block.header.globalVariables.blockNumber = new Fr(blockNumber);
 
@@ -468,7 +482,8 @@ export function describeArchiverDataStore(
         });
 
         return {
-          data: block,
+          block: block,
+          signatures: times(3, Signature.random),
           l1: { blockNumber: BigInt(blockNumber), blockHash: `0x${blockNumber}`, timestamp: BigInt(blockNumber) },
         };
       };
@@ -477,7 +492,7 @@ export function describeArchiverDataStore(
         blocks = await timesParallel(numBlocks, (index: number) => mockBlockWithLogs(index));
 
         await store.addBlocks(blocks);
-        await store.addLogs(blocks.map(b => b.data));
+        await store.addLogs(blocks.map(b => b.block));
       });
 
       it('is possible to batch request private logs via tags', async () => {
@@ -531,11 +546,11 @@ export function describeArchiverDataStore(
         // Create a block containing logs that have the same tag as the blocks before.
         const newBlockNumber = numBlocks;
         const newBlock = await mockBlockWithLogs(newBlockNumber);
-        const newLog = newBlock.data.body.txEffects[1].privateLogs[1];
+        const newLog = newBlock.block.body.txEffects[1].privateLogs[1];
         newLog.fields[0] = tags[0];
-        newBlock.data.body.txEffects[1].privateLogs[1] = newLog;
+        newBlock.block.body.txEffects[1].privateLogs[1] = newLog;
         await store.addBlocks([newBlock]);
-        await store.addLogs([newBlock.data]);
+        await store.addLogs([newBlock.block]);
 
         const logsByTags = await store.getLogsByTags(tags);
 
@@ -580,27 +595,28 @@ export function describeArchiverDataStore(
       const numPublicFunctionCalls = 3;
       const numPublicLogs = 2;
       const numBlocks = 10;
-      let blocks: L1Published<L2Block>[];
+      let blocks: PublishedL2Block[];
 
       beforeEach(async () => {
         blocks = await timesParallel(numBlocks, async (index: number) => ({
-          data: await L2Block.random(index + 1, txsPerBlock, numPublicFunctionCalls, numPublicLogs),
+          block: await L2Block.random(index + 1, txsPerBlock, numPublicFunctionCalls, numPublicLogs),
           l1: { blockNumber: BigInt(index), blockHash: `0x${index}`, timestamp: BigInt(index) },
+          signatures: times(3, Signature.random),
         }));
 
         await store.addBlocks(blocks);
-        await store.addLogs(blocks.map(b => b.data));
+        await store.addLogs(blocks.map(b => b.block));
       });
 
       it('no logs returned if deleted ("txHash" filter param is respected variant)', async () => {
         // get random tx
         const targetBlockIndex = randomInt(numBlocks);
         const targetTxIndex = randomInt(txsPerBlock);
-        const targetTxHash = blocks[targetBlockIndex].data.body.txEffects[targetTxIndex].txHash;
+        const targetTxHash = blocks[targetBlockIndex].block.body.txEffects[targetTxIndex].txHash;
 
         await Promise.all([
           store.unwindBlocks(blocks.length, blocks.length),
-          store.deleteLogs(blocks.map(b => b.data)),
+          store.deleteLogs(blocks.map(b => b.block)),
         ]);
 
         const response = await store.getPublicLogs({ txHash: targetTxHash });
@@ -614,7 +630,7 @@ export function describeArchiverDataStore(
         // get random tx
         const targetBlockIndex = randomInt(numBlocks);
         const targetTxIndex = randomInt(txsPerBlock);
-        const targetTxHash = blocks[targetBlockIndex].data.body.txEffects[targetTxIndex].txHash;
+        const targetTxHash = blocks[targetBlockIndex].block.body.txEffects[targetTxIndex].txHash;
 
         const response = await store.getPublicLogs({ txHash: targetTxHash });
         const logs = response.logs;
@@ -657,7 +673,7 @@ export function describeArchiverDataStore(
         const targetTxIndex = randomInt(txsPerBlock);
         const targetLogIndex = randomInt(numPublicLogs * numPublicFunctionCalls);
         const targetContractAddress =
-          blocks[targetBlockIndex].data.body.txEffects[targetTxIndex].publicLogs[targetLogIndex].contractAddress;
+          blocks[targetBlockIndex].block.body.txEffects[targetTxIndex].publicLogs[targetLogIndex].contractAddress;
 
         const response = await store.getPublicLogs({ contractAddress: targetContractAddress });
 

--- a/yarn-project/archiver/src/archiver/index.ts
+++ b/yarn-project/archiver/src/archiver/index.ts
@@ -1,6 +1,6 @@
 export * from './archiver.js';
 export * from './config.js';
-export { type L1Published, type L1PublishedData } from './structs/published.js';
+export { type PublishedL2Block, type L1PublishedData } from './structs/published.js';
 export { MemoryArchiverStore } from './memory_archiver_store/memory_archiver_store.js';
 export type { ArchiverDataStore } from './archiver_store.js';
 export { KVArchiverDataStore } from './kv_archiver_store/kv_archiver_store.js';

--- a/yarn-project/archiver/src/archiver/kv_archiver_store/kv_archiver_store.ts
+++ b/yarn-project/archiver/src/archiver/kv_archiver_store/kv_archiver_store.ts
@@ -19,7 +19,7 @@ import type { BlockHeader, TxHash, TxReceipt } from '@aztec/stdlib/tx';
 
 import type { ArchiverDataStore, ArchiverL1SynchPoint } from '../archiver_store.js';
 import type { DataRetrieval } from '../structs/data_retrieval.js';
-import type { L1Published } from '../structs/published.js';
+import type { PublishedL2Block } from '../structs/published.js';
 import { BlockStore } from './block_store.js';
 import { ContractClassStore } from './contract_class_store.js';
 import { ContractInstanceStore } from './contract_instance_store.js';
@@ -147,7 +147,7 @@ export class KVArchiverDataStore implements ArchiverDataStore {
    * @param blocks - The L2 blocks to be added to the store and the last processed L1 block.
    * @returns True if the operation is successful.
    */
-  addBlocks(blocks: L1Published<L2Block>[]): Promise<boolean> {
+  addBlocks(blocks: PublishedL2Block[]): Promise<boolean> {
     return this.#blockStore.addBlocks(blocks);
   }
 
@@ -169,7 +169,7 @@ export class KVArchiverDataStore implements ArchiverDataStore {
    * @param limit - The number of blocks to return.
    * @returns The requested L2 blocks
    */
-  getBlocks(start: number, limit: number): Promise<L1Published<L2Block>[]> {
+  getBlocks(start: number, limit: number): Promise<PublishedL2Block[]> {
     return toArray(this.#blockStore.getBlocks(start, limit));
   }
 

--- a/yarn-project/archiver/src/archiver/memory_archiver_store/memory_archiver_store.test.ts
+++ b/yarn-project/archiver/src/archiver/memory_archiver_store/memory_archiver_store.test.ts
@@ -1,4 +1,5 @@
-import { timesParallel } from '@aztec/foundation/collection';
+import { times, timesParallel } from '@aztec/foundation/collection';
+import { Signature } from '@aztec/foundation/eth-signature';
 import { L2Block } from '@aztec/stdlib/block';
 
 import type { ArchiverDataStore } from '../archiver_store.js';
@@ -19,12 +20,13 @@ describe('MemoryArchiverStore', () => {
       const maxLogs = 5;
       archiverStore = new MemoryArchiverStore(maxLogs);
       const blocks = await timesParallel(10, async (index: number) => ({
-        data: await L2Block.random(index + 1, 4, 3, 2),
+        block: await L2Block.random(index + 1, 4, 3, 2),
         l1: { blockNumber: BigInt(index), blockHash: `0x${index}`, timestamp: BigInt(index) },
+        signatures: times(3, Signature.random),
       }));
 
       await archiverStore.addBlocks(blocks);
-      await archiverStore.addLogs(blocks.map(b => b.data));
+      await archiverStore.addLogs(blocks.map(b => b.block));
 
       const response = await archiverStore.getPublicLogs({});
 

--- a/yarn-project/archiver/src/archiver/memory_archiver_store/memory_archiver_store.ts
+++ b/yarn-project/archiver/src/archiver/memory_archiver_store/memory_archiver_store.ts
@@ -28,7 +28,7 @@ import { type BlockHeader, TxEffect, TxHash, TxReceipt } from '@aztec/stdlib/tx'
 
 import type { ArchiverDataStore, ArchiverL1SynchPoint } from '../archiver_store.js';
 import type { DataRetrieval } from '../structs/data_retrieval.js';
-import type { L1Published } from '../structs/published.js';
+import type { PublishedL2Block } from '../structs/published.js';
 import { L1ToL2MessageStore } from './l1_to_l2_message_store.js';
 
 type StoredContractInstanceUpdate = ContractInstanceUpdateWithAddress & { blockNumber: number; logIndex: number };
@@ -40,7 +40,7 @@ export class MemoryArchiverStore implements ArchiverDataStore {
   /**
    * An array containing all the L2 blocks that have been fetched so far.
    */
-  private l2Blocks: L1Published<L2Block>[] = [];
+  private l2Blocks: PublishedL2Block[] = [];
 
   /**
    * An array containing all the tx effects in the L2 blocks that have been fetched so far.
@@ -232,16 +232,16 @@ export class MemoryArchiverStore implements ArchiverDataStore {
    * @param blocks - The L2 blocks to be added to the store and the last processed L1 block.
    * @returns True if the operation is successful.
    */
-  public async addBlocks(blocks: L1Published<L2Block>[]): Promise<boolean> {
+  public async addBlocks(blocks: PublishedL2Block[]): Promise<boolean> {
     if (blocks.length === 0) {
       return Promise.resolve(true);
     }
 
     this.lastL1BlockNewBlocks = blocks[blocks.length - 1].l1.blockNumber;
     this.l2Blocks.push(...blocks);
-    const flatTxEffects = blocks.flatMap(b => b.data.body.txEffects.map(txEffect => ({ block: b, txEffect })));
+    const flatTxEffects = blocks.flatMap(b => b.block.body.txEffects.map(txEffect => ({ block: b, txEffect })));
     const wrappedTxEffects = await Promise.all(
-      flatTxEffects.map(flatTxEffect => wrapInBlock(flatTxEffect.txEffect, flatTxEffect.block.data)),
+      flatTxEffects.map(flatTxEffect => wrapInBlock(flatTxEffect.txEffect, flatTxEffect.block.block)),
     );
     this.txEffects.push(...wrappedTxEffects);
 
@@ -267,7 +267,7 @@ export class MemoryArchiverStore implements ArchiverDataStore {
       if (block == undefined) {
         break;
       }
-      block.data.body.txEffects.forEach(() => this.txEffects.pop());
+      block.block.body.txEffects.forEach(() => this.txEffects.pop());
     }
 
     return Promise.resolve(true);
@@ -433,7 +433,7 @@ export class MemoryArchiverStore implements ArchiverDataStore {
    * @returns The requested L2 blocks.
    * @remarks When "from" is smaller than genesis block number, blocks from the beginning are returned.
    */
-  public getBlocks(from: number, limit: number): Promise<L1Published<L2Block>[]> {
+  public getBlocks(from: number, limit: number): Promise<PublishedL2Block[]> {
     if (limit < 1) {
       return Promise.reject(new Error(`Invalid limit: ${limit}`));
     }
@@ -453,7 +453,7 @@ export class MemoryArchiverStore implements ArchiverDataStore {
 
   public async getBlockHeaders(from: number, limit: number): Promise<BlockHeader[]> {
     const blocks = await this.getBlocks(from, limit);
-    return blocks.map(block => block.data.header);
+    return blocks.map(block => block.block.header);
   }
 
   /**
@@ -473,15 +473,15 @@ export class MemoryArchiverStore implements ArchiverDataStore {
    */
   public async getSettledTxReceipt(txHash: TxHash): Promise<TxReceipt | undefined> {
     for (const block of this.l2Blocks) {
-      for (const txEffect of block.data.body.txEffects) {
+      for (const txEffect of block.block.body.txEffects) {
         if (txEffect.txHash.equals(txHash)) {
           return new TxReceipt(
             txHash,
             TxReceipt.statusFromRevertCode(txEffect.revertCode),
             '',
             txEffect.transactionFee.toBigInt(),
-            L2BlockHash.fromField(await block.data.hash()),
-            block.data.number,
+            L2BlockHash.fromField(await block.block.hash()),
+            block.block.number,
           );
         }
       }
@@ -595,8 +595,8 @@ export class MemoryArchiverStore implements ArchiverDataStore {
       if (blockLogs) {
         for (let logIndex = 0; logIndex < blockLogs.length; logIndex++) {
           const log = blockLogs[logIndex];
-          const thisTxEffect = block.data.body.txEffects.filter(effect => effect.publicLogs.includes(log))[0];
-          const thisTxIndexInBlock = block.data.body.txEffects.indexOf(thisTxEffect);
+          const thisTxEffect = block.block.body.txEffects.filter(effect => effect.publicLogs.includes(log))[0];
+          const thisTxIndexInBlock = block.block.body.txEffects.indexOf(thisTxEffect);
           const thisLogIndexInTx = thisTxEffect.publicLogs.indexOf(log);
           if (
             (!txHash || thisTxEffect.txHash.equals(txHash)) &&
@@ -604,7 +604,7 @@ export class MemoryArchiverStore implements ArchiverDataStore {
             thisTxIndexInBlock >= txIndexInBlock &&
             thisLogIndexInTx >= logIndexInTx
           ) {
-            logs.push(new ExtendedPublicLog(new LogId(block.data.number, thisTxIndexInBlock, thisLogIndexInTx), log));
+            logs.push(new ExtendedPublicLog(new LogId(block.block.number, thisTxIndexInBlock, thisLogIndexInTx), log));
             if (logs.length === this.maxLogs) {
               return Promise.resolve({
                 logs,
@@ -679,8 +679,8 @@ export class MemoryArchiverStore implements ArchiverDataStore {
       if (blockLogs) {
         for (let logIndex = 0; logIndex < blockLogs.length; logIndex++) {
           const log = blockLogs[logIndex];
-          const thisTxEffect = block.data.body.txEffects.filter(effect => effect.contractClassLogs.includes(log))[0];
-          const thisTxIndexInBlock = block.data.body.txEffects.indexOf(thisTxEffect);
+          const thisTxEffect = block.block.body.txEffects.filter(effect => effect.contractClassLogs.includes(log))[0];
+          const thisTxIndexInBlock = block.block.body.txEffects.indexOf(thisTxEffect);
           const thisLogIndexInTx = thisTxEffect.contractClassLogs.indexOf(log);
           if (
             (!txHash || thisTxEffect.txHash.equals(txHash)) &&
@@ -689,7 +689,7 @@ export class MemoryArchiverStore implements ArchiverDataStore {
             thisLogIndexInTx >= logIndexInTx
           ) {
             logs.push(
-              new ExtendedContractClassLog(new LogId(block.data.number, thisTxIndexInBlock, thisLogIndexInTx), log),
+              new ExtendedContractClassLog(new LogId(block.block.number, thisTxIndexInBlock, thisLogIndexInTx), log),
             );
             if (logs.length === this.maxLogs) {
               return Promise.resolve({
@@ -712,7 +712,7 @@ export class MemoryArchiverStore implements ArchiverDataStore {
     if (this.l2Blocks.length === 0) {
       return INITIAL_L2_BLOCK_NUM - 1;
     }
-    return this.l2Blocks[this.l2Blocks.length - 1].data.number;
+    return this.l2Blocks[this.l2Blocks.length - 1].block.number;
   }
 
   /**

--- a/yarn-project/archiver/src/archiver/structs/published.ts
+++ b/yarn-project/archiver/src/archiver/structs/published.ts
@@ -1,11 +1,1 @@
-/** Extends a type with L1 published info (block number, hash, and timestamp) */
-export type L1Published<T> = {
-  data: T;
-  l1: L1PublishedData;
-};
-
-export type L1PublishedData = {
-  blockNumber: bigint;
-  timestamp: bigint;
-  blockHash: string;
-};
+export type { PublishedL2Block, L1PublishedData } from '@aztec/stdlib/block';

--- a/yarn-project/archiver/src/test/mock_l2_block_source.ts
+++ b/yarn-project/archiver/src/test/mock_l2_block_source.ts
@@ -1,4 +1,5 @@
 import { DefaultL1ContractsConfig } from '@aztec/ethereum';
+import { Buffer32 } from '@aztec/foundation/buffer';
 import { EthAddress } from '@aztec/foundation/eth-address';
 import { createLogger } from '@aztec/foundation/log';
 import { L2Block, L2BlockHash, type L2BlockSource, type L2Tips } from '@aztec/stdlib/block';
@@ -88,6 +89,19 @@ export class MockL2BlockSource implements L2BlockSource {
         .slice(from - 1, from - 1 + limit)
         .filter(b => !proven || this.provenBlockNumber === undefined || b.number <= this.provenBlockNumber),
     );
+  }
+
+  public async getPublishedBlocks(from: number, limit: number, proven?: boolean) {
+    const blocks = await this.getBlocks(from, limit, proven);
+    return blocks.map(block => ({
+      block,
+      l1: {
+        blockNumber: BigInt(block.number),
+        blockHash: Buffer32.random().toString(),
+        timestamp: BigInt(block.number),
+      },
+      signatures: [],
+    }));
   }
 
   getBlockHeader(number: number | 'latest'): Promise<BlockHeader | undefined> {

--- a/yarn-project/aztec-node/src/aztec-node/server.ts
+++ b/yarn-project/aztec-node/src/aztec-node/server.ts
@@ -33,7 +33,14 @@ import {
 } from '@aztec/sequencer-client';
 import { PublicProcessorFactory } from '@aztec/simulator/server';
 import { AztecAddress } from '@aztec/stdlib/aztec-address';
-import type { InBlock, L2Block, L2BlockNumber, L2BlockSource, NullifierWithBlockSource } from '@aztec/stdlib/block';
+import type {
+  InBlock,
+  L2Block,
+  L2BlockNumber,
+  L2BlockSource,
+  NullifierWithBlockSource,
+  PublishedL2Block,
+} from '@aztec/stdlib/block';
 import type {
   ContractClassPublic,
   ContractDataSource,
@@ -307,6 +314,10 @@ export class AztecNodeService implements AztecNode, Traceable {
    */
   public async getBlocks(from: number, limit: number): Promise<L2Block[]> {
     return (await this.blockSource.getBlocks(from, limit)) ?? [];
+  }
+
+  public async getPublishedBlocks(from: number, limit: number): Promise<PublishedL2Block[]> {
+    return (await this.blockSource.getPublishedBlocks(from, limit)) ?? [];
   }
 
   /**

--- a/yarn-project/end-to-end/src/composed/integration_l1_publisher.test.ts
+++ b/yarn-project/end-to-end/src/composed/integration_l1_publisher.test.ts
@@ -150,6 +150,20 @@ describe('L1Publisher integration', () => {
       getBlocks(from, limit, _proven) {
         return Promise.resolve(blocks.slice(from - 1, from - 1 + limit));
       },
+      getPublishedBlocks(from, limit, _proven) {
+        return Promise.resolve(
+          blocks.slice(from - 1, from - 1 + limit).map(block => ({
+            signatures: [],
+            block,
+            // Use L2 block number and hash for faking the L1 info
+            l1: {
+              blockNumber: BigInt(block.number),
+              blockHash: block.hash.toString(),
+              timestamp: BigInt(block.number),
+            },
+          })),
+        );
+      },
       getL2Tips(): Promise<L2Tips> {
         const latestBlock = blocks.at(-1);
         const res = latestBlock

--- a/yarn-project/end-to-end/src/e2e_p2p/gossip_network.test.ts
+++ b/yarn-project/end-to-end/src/e2e_p2p/gossip_network.test.ts
@@ -1,5 +1,8 @@
+import type { Archiver } from '@aztec/archiver';
 import type { AztecNodeService } from '@aztec/aztec-node';
 import { sleep } from '@aztec/aztec.js';
+import type { SequencerClient } from '@aztec/sequencer-client';
+import { BlockAttestation, ConsensusPayload } from '@aztec/stdlib/p2p';
 
 import { jest } from '@jest/globals';
 import fs from 'fs';
@@ -115,5 +118,23 @@ describe('e2e_p2p_network', () => {
       ),
     );
     t.logger.info('All transactions mined');
+
+    // Gather signers from attestations downloaded from L1
+    const blockNumber = await contexts[0].txs[0].getReceipt().then(r => r.blockNumber!);
+    const dataStore = ((nodes[0] as AztecNodeService).getBlockSource() as Archiver).dataStore;
+    const [block] = await dataStore.getBlocks(blockNumber, blockNumber);
+    const payload = ConsensusPayload.fromBlock(block.block);
+    const attestations = block.signatures.map(sig => new BlockAttestation(payload, sig));
+    const signers = await Promise.all(attestations.map(att => att.getSender().then(s => s.toString())));
+    t.logger.info(`Attestation signers`, { signers });
+
+    // Check that the signers found are part of the proposer nodes to ensure the archiver fetched them right
+    const validatorAddresses = nodes.map(node =>
+      ((node as AztecNodeService).getSequencer() as SequencerClient).validatorAddress?.toString(),
+    );
+    t.logger.info(`Validator addresses`, { addresses: validatorAddresses });
+    for (const signer of signers) {
+      expect(validatorAddresses).toContain(signer);
+    }
   });
 });

--- a/yarn-project/end-to-end/src/e2e_p2p/reqresp.test.ts
+++ b/yarn-project/end-to-end/src/e2e_p2p/reqresp.test.ts
@@ -1,6 +1,9 @@
+import type { Archiver } from '@aztec/archiver';
 import type { AztecNodeService } from '@aztec/aztec-node';
 import { sleep } from '@aztec/aztec.js';
 import { RollupAbi } from '@aztec/l1-artifacts';
+import type { SequencerClient } from '@aztec/sequencer-client';
+import { BlockAttestation, ConsensusPayload } from '@aztec/stdlib/p2p';
 
 import { jest } from '@jest/globals';
 import fs from 'fs';
@@ -123,6 +126,25 @@ describe('e2e_p2p_reqresp_tx', () => {
       ),
     );
     t.logger.info('All transactions mined');
+
+    // Gather signers from attestations downloaded from L1
+    const blockNumber = await contexts[0].txs[0].getReceipt().then(r => r.blockNumber!);
+    const dataStore = ((nodes[0] as AztecNodeService).getBlockSource() as Archiver).dataStore;
+    const [block] = await dataStore.getBlocks(blockNumber, blockNumber);
+    const attestations = block.signatures.map(
+      sig => new BlockAttestation(ConsensusPayload.fromBlock(block.block), sig),
+    );
+    const signers = await Promise.all(attestations.map(att => att.getSender().then(s => s.toString())));
+    t.logger.info(`Attestation signers`, { signers });
+
+    // Check that the signers found are part of the proposer nodes to ensure the archiver fetched them right
+    const validatorAddresses = nodes.map(node =>
+      ((node as AztecNodeService).getSequencer() as SequencerClient).validatorAddress?.toString(),
+    );
+    t.logger.info(`Validator addresses`, { addresses: validatorAddresses });
+    for (const signer of signers) {
+      expect(validatorAddresses).toContain(signer);
+    }
   });
 
   /**

--- a/yarn-project/end-to-end/src/e2e_p2p/reqresp.test.ts
+++ b/yarn-project/end-to-end/src/e2e_p2p/reqresp.test.ts
@@ -1,9 +1,6 @@
-import type { Archiver } from '@aztec/archiver';
 import type { AztecNodeService } from '@aztec/aztec-node';
 import { sleep } from '@aztec/aztec.js';
 import { RollupAbi } from '@aztec/l1-artifacts';
-import type { SequencerClient } from '@aztec/sequencer-client';
-import { BlockAttestation, ConsensusPayload } from '@aztec/stdlib/p2p';
 
 import { jest } from '@jest/globals';
 import fs from 'fs';
@@ -126,25 +123,6 @@ describe('e2e_p2p_reqresp_tx', () => {
       ),
     );
     t.logger.info('All transactions mined');
-
-    // Gather signers from attestations downloaded from L1
-    const blockNumber = await contexts[0].txs[0].getReceipt().then(r => r.blockNumber!);
-    const dataStore = ((nodes[0] as AztecNodeService).getBlockSource() as Archiver).dataStore;
-    const [block] = await dataStore.getBlocks(blockNumber, blockNumber);
-    const attestations = block.signatures.map(
-      sig => new BlockAttestation(ConsensusPayload.fromBlock(block.block), sig),
-    );
-    const signers = await Promise.all(attestations.map(att => att.getSender().then(s => s.toString())));
-    t.logger.info(`Attestation signers`, { signers });
-
-    // Check that the signers found are part of the proposer nodes to ensure the archiver fetched them right
-    const validatorAddresses = nodes.map(node =>
-      ((node as AztecNodeService).getSequencer() as SequencerClient).validatorAddress?.toString(),
-    );
-    t.logger.info(`Validator addresses`, { addresses: validatorAddresses });
-    for (const signer of signers) {
-      expect(validatorAddresses).toContain(signer);
-    }
   });
 
   /**

--- a/yarn-project/foundation/src/eth-signature/eth_signature.ts
+++ b/yarn-project/foundation/src/eth-signature/eth_signature.ts
@@ -5,10 +5,8 @@ import { z } from 'zod';
 
 import { hasHexPrefix, hexToBuffer } from '../string/index.js';
 
-/**Viem Signature
- *
- * A version of the Signature class that uses `0x${string}` values for r and s rather than
- * Buffer32s
+/**
+ * A version of the Signature class that uses `0x${string}` values for r and s rather than Buffer32s
  */
 export type ViemSignature = {
   r: `0x${string}`;
@@ -18,8 +16,6 @@ export type ViemSignature = {
 };
 
 /**
- * Signature
- *
  * Contains a signature split into it's primary components (r,s,v)
  */
 export class Signature {
@@ -68,6 +64,15 @@ export class Signature {
     const isEmpty = r.isZero() && s.isZero();
 
     return new Signature(r, s, v, isEmpty);
+  }
+
+  static fromViemSignature(sig: ViemSignature): Signature {
+    return new Signature(
+      Buffer32.fromBuffer(hexToBuffer(sig.r)),
+      Buffer32.fromBuffer(hexToBuffer(sig.s)),
+      sig.v,
+      sig.isEmpty,
+    );
   }
 
   static random(): Signature {

--- a/yarn-project/kv-store/src/stores/l2_tips_store.test.ts
+++ b/yarn-project/kv-store/src/stores/l2_tips_store.test.ts
@@ -2,7 +2,7 @@ import { times } from '@aztec/foundation/collection';
 import { Fr } from '@aztec/foundation/fields';
 import type { AztecAsyncKVStore } from '@aztec/kv-store';
 import { openTmpStore } from '@aztec/kv-store/lmdb-v2';
-import type { L2Block } from '@aztec/stdlib/block';
+import type { L2Block, PublishedL2Block } from '@aztec/stdlib/block';
 import type { BlockHeader } from '@aztec/stdlib/tx';
 
 import { expect } from 'chai';
@@ -22,8 +22,11 @@ describe('L2TipsStore', () => {
     await kvStore.delete();
   });
 
-  const makeBlock = (number: number): L2Block =>
-    ({ number, header: { hash: () => Promise.resolve(new Fr(number)) } as BlockHeader } as L2Block);
+  const makeBlock = (number: number): PublishedL2Block => ({
+    block: { number, header: { hash: () => Promise.resolve(new Fr(number)) } as BlockHeader } as L2Block,
+    l1: { blockNumber: BigInt(number), blockHash: `0x${number}`, timestamp: BigInt(number) },
+    signatures: [],
+  });
 
   const makeTip = (number: number) => ({ number, hash: number === 0 ? undefined : new Fr(number).toString() });
 

--- a/yarn-project/kv-store/src/stores/l2_tips_store.ts
+++ b/yarn-project/kv-store/src/stores/l2_tips_store.ts
@@ -47,12 +47,14 @@ export class L2TipsStore implements L2BlockStreamEventHandler, L2BlockStreamLoca
 
   public async handleBlockStreamEvent(event: L2BlockStreamEvent): Promise<void> {
     switch (event.type) {
-      case 'blocks-added':
-        for (const block of event.blocks) {
+      case 'blocks-added': {
+        const blocks = event.blocks.map(b => b.block);
+        for (const block of blocks) {
           await this.l2BlockHashesStore.set(block.number, (await block.header.hash()).toString());
         }
-        await this.l2TipsStore.set('latest', event.blocks.at(-1)!.number);
+        await this.l2TipsStore.set('latest', blocks.at(-1)!.number);
         break;
+      }
       case 'chain-pruned':
         await this.l2TipsStore.set('latest', event.blockNumber);
         break;

--- a/yarn-project/p2p/src/client/p2p_client.test.ts
+++ b/yarn-project/p2p/src/client/p2p_client.test.ts
@@ -4,7 +4,7 @@ import { retryUntil } from '@aztec/foundation/retry';
 import { sleep } from '@aztec/foundation/sleep';
 import type { AztecAsyncKVStore } from '@aztec/kv-store';
 import { openTmpStore } from '@aztec/kv-store/lmdb-v2';
-import { L2Block } from '@aztec/stdlib/block';
+import { L2Block, randomPublishedL2Block } from '@aztec/stdlib/block';
 import { P2PClientType } from '@aztec/stdlib/p2p';
 import { mockTx } from '@aztec/stdlib/testing';
 
@@ -246,6 +246,17 @@ describe('In-Memory P2P Client', () => {
       expect(attestationPool.deleteAttestationsOlderThan).toHaveBeenCalledTimes(1);
       expect(attestationPool.deleteAttestationsOlderThan).toHaveBeenCalledWith(
         BigInt(advanceToProvenBlockNumber - keepAttestationsInPoolFor),
+      );
+    });
+  });
+
+  describe('Block stream events', () => {
+    it('adds attestations to the pool', async () => {
+      await client.start();
+      const block = await randomPublishedL2Block(1);
+      await client.handleBlockStreamEvent({ type: 'blocks-added', blocks: [block] });
+      expect(attestationPool.addAttestations).toHaveBeenCalledWith(
+        block.signatures.map(signature => expect.objectContaining({ signature })),
       );
     });
   });

--- a/yarn-project/p2p/src/client/p2p_client.ts
+++ b/yarn-project/p2p/src/client/p2p_client.ts
@@ -625,9 +625,10 @@ export class P2PClient<T extends P2PClientType = P2PClientType.Full>
   }
 
   private async addAttestationsToPool(blocks: PublishedL2Block[]): Promise<void> {
-    const attestations = blocks.flatMap(block =>
-      block.signatures.map(signature => new BlockAttestation(ConsensusPayload.fromBlock(block.block), signature)),
-    );
+    const attestations = blocks.flatMap(block => {
+      const payload = ConsensusPayload.fromBlock(block.block);
+      return block.signatures.map(signature => new BlockAttestation(payload, signature));
+    });
     await this.attestationPool?.addAttestations(attestations);
     const slots = blocks.map(b => b.block.header.getSlot()).sort((a, b) => Number(a - b));
     this.log.debug(`Added ${attestations.length} attestations for slots ${slots[0]}-${slots.at(-1)} to the pool`);

--- a/yarn-project/p2p/src/client/p2p_client.ts
+++ b/yarn-project/p2p/src/client/p2p_client.ts
@@ -1,9 +1,16 @@
 import { INITIAL_L2_BLOCK_NUM } from '@aztec/constants';
 import { createLogger } from '@aztec/foundation/log';
 import type { AztecAsyncKVStore, AztecAsyncMap, AztecAsyncSingleton } from '@aztec/kv-store';
-import type { L2Block, L2BlockId, L2BlockSource, L2BlockStreamEvent, L2Tips } from '@aztec/stdlib/block';
+import type {
+  L2Block,
+  L2BlockId,
+  L2BlockSource,
+  L2BlockStreamEvent,
+  L2Tips,
+  PublishedL2Block,
+} from '@aztec/stdlib/block';
 import type { P2PApi, PeerInfo, ProverCoordination } from '@aztec/stdlib/interfaces/server';
-import type { BlockAttestation, BlockProposal, P2PClientType } from '@aztec/stdlib/p2p';
+import { BlockAttestation, type BlockProposal, ConsensusPayload, type P2PClientType } from '@aztec/stdlib/p2p';
 import type { Tx, TxHash } from '@aztec/stdlib/tx';
 import {
   Attributes,
@@ -617,6 +624,15 @@ export class P2PClient<T extends P2PClientType = P2PClientType.Full>
     }
   }
 
+  private async addAttestationsToPool(blocks: PublishedL2Block[]): Promise<void> {
+    const attestations = blocks.flatMap(block =>
+      block.signatures.map(signature => new BlockAttestation(ConsensusPayload.fromBlock(block.block), signature)),
+    );
+    await this.attestationPool?.addAttestations(attestations);
+    const slots = blocks.map(b => b.block.header.getSlot()).sort((a, b) => Number(a - b));
+    this.log.debug(`Added ${attestations.length} attestations for slots ${slots[0]}-${slots.at(-1)} to the pool`);
+  }
+
   /**
    * Deletes txs from these blocks.
    * @param blocks - A list of existing blocks with txs that the P2P client needs to ensure the tx pool is reconciled with.
@@ -635,15 +651,16 @@ export class P2PClient<T extends P2PClientType = P2PClientType.Full>
    * @param blocks - A list of existing blocks with txs that the P2P client needs to ensure the tx pool is reconciled with.
    * @returns Empty promise.
    */
-  private async handleLatestL2Blocks(blocks: L2Block[]): Promise<void> {
+  private async handleLatestL2Blocks(blocks: PublishedL2Block[]): Promise<void> {
     if (!blocks.length) {
       return Promise.resolve();
     }
 
-    await this.markTxsAsMinedFromBlocks(blocks);
-    const lastBlockNum = blocks[blocks.length - 1].number;
+    await this.markTxsAsMinedFromBlocks(blocks.map(b => b.block));
+    await this.addAttestationsToPool(blocks);
+    const lastBlockNum = blocks.at(-1)!.block.number;
     await Promise.all(
-      blocks.map(async block => this.synchedBlockHashes.set(block.number, (await block.hash()).toString())),
+      blocks.map(async block => this.synchedBlockHashes.set(block.block.number, (await block.block.hash()).toString())),
     );
     await this.synchedLatestBlockNumber.set(lastBlockNum);
     this.log.verbose(`Synched to latest block ${lastBlockNum}`);

--- a/yarn-project/p2p/src/mem_pools/attestation_pool/attestation_pool_test_suite.ts
+++ b/yarn-project/p2p/src/mem_pools/attestation_pool/attestation_pool_test_suite.ts
@@ -67,7 +67,7 @@ export function describeAttestationPool(getAttestationPool: () => AttestationPoo
     expect(retreivedAttestationsAfterDelete.length).toBe(0);
   });
 
-  it('Should handle duplicate proposals in a slot', async () => {
+  it('should handle duplicate proposals in a slot', async () => {
     const slotNumber = 420;
     const archive = Fr.random();
     const txs = [0, 1, 2, 3, 4, 5].map(() => TxHash.random());
@@ -79,6 +79,7 @@ export function describeAttestationPool(getAttestationPool: () => AttestationPoo
       attestations.push(await mockAttestation(signer, slotNumber, archive, txs));
     }
 
+    // Add them to store and check we end up with only one
     await ap.addAttestations(attestations);
 
     const retreivedAttestations = await ap.getAttestationsForSlot(BigInt(slotNumber), archive.toString());
@@ -86,9 +87,13 @@ export function describeAttestationPool(getAttestationPool: () => AttestationPoo
     expect(retreivedAttestations[0].toBuffer()).toEqual(attestations[0].toBuffer());
     expect(retreivedAttestations[0].payload.txHashes).toEqual(txs);
     expect((await retreivedAttestations[0].getSender()).toString()).toEqual(signer.address.toString());
+
+    // Try adding them on another operation and check they are still not duplicated
+    await ap.addAttestations([attestations[0]]);
+    expect(await ap.getAttestationsForSlot(BigInt(slotNumber), archive.toString())).toHaveLength(1);
   });
 
-  it('Should store attestations by differing slot', async () => {
+  it('should store attestations by differing slot', async () => {
     const slotNumbers = [1, 2, 3, 4];
     const attestations = await Promise.all(signers.map((signer, i) => mockAttestation(signer, slotNumbers[i])));
 
@@ -105,7 +110,7 @@ export function describeAttestationPool(getAttestationPool: () => AttestationPoo
     }
   });
 
-  it('Should store attestations by differing slot and archive', async () => {
+  it('should store attestations by differing slot and archive', async () => {
     const slotNumbers = [1, 1, 2, 3];
     const archives = [Fr.random(), Fr.random(), Fr.random(), Fr.random()];
     const attestations = await Promise.all(
@@ -125,7 +130,7 @@ export function describeAttestationPool(getAttestationPool: () => AttestationPoo
     }
   });
 
-  it('Should delete attestations', async () => {
+  it('should delete attestations', async () => {
     const slotNumber = 420;
     const archive = Fr.random();
     const attestations = await Promise.all(signers.map(signer => mockAttestation(signer, slotNumber, archive)));
@@ -147,7 +152,7 @@ export function describeAttestationPool(getAttestationPool: () => AttestationPoo
     expect(gottenAfterDelete.length).toBe(0);
   });
 
-  it('Should blanket delete attestations per slot', async () => {
+  it('should blanket delete attestations per slot', async () => {
     const slotNumber = 420;
     const archive = Fr.random();
     const attestations = await Promise.all(signers.map(signer => mockAttestation(signer, slotNumber, archive)));
@@ -165,7 +170,7 @@ export function describeAttestationPool(getAttestationPool: () => AttestationPoo
     expect(retreivedAttestationsAfterDelete.length).toBe(0);
   });
 
-  it('Should blanket delete attestations per slot and proposal', async () => {
+  it('should blanket delete attestations per slot and proposal', async () => {
     const slotNumber = 420;
     const archive = Fr.random();
     const attestations = await Promise.all(signers.map(signer => mockAttestation(signer, slotNumber, archive)));
@@ -201,7 +206,7 @@ export function describeAttestationPool(getAttestationPool: () => AttestationPoo
     compareAttestations(retreivedAttestationsAfterDeleteForOtherProposal, attestations2);
   });
 
-  it('Should delete attestations older than a given slot', async () => {
+  it('should delete attestations older than a given slot', async () => {
     const slotNumbers = [1, 2, 3, 69, 72, 74, 88, 420];
     const attestations = (
       await Promise.all(slotNumbers.map(slotNumber => createAttestationsForSlot(slotNumber)))

--- a/yarn-project/pxe/src/synchronizer/synchronizer.test.ts
+++ b/yarn-project/pxe/src/synchronizer/synchronizer.test.ts
@@ -1,7 +1,7 @@
 import { timesParallel } from '@aztec/foundation/collection';
 import { openTmpStore } from '@aztec/kv-store/lmdb-v2';
 import { L2TipsStore } from '@aztec/kv-store/stores';
-import { L2Block, type L2BlockStream } from '@aztec/stdlib/block';
+import { L2Block, type L2BlockStream, randomPublishedL2Block } from '@aztec/stdlib/block';
 import type { AztecNode } from '@aztec/stdlib/interfaces/client';
 
 import { jest } from '@jest/globals';
@@ -39,11 +39,11 @@ describe('Synchronizer', () => {
   });
 
   it('sets header from latest block', async () => {
-    const block = await L2Block.random(1, 4);
+    const block = await randomPublishedL2Block(1);
     await synchronizer.handleBlockStreamEvent({ type: 'blocks-added', blocks: [block] });
 
     const obtainedHeader = await syncDataProvider.getBlockHeader();
-    expect(obtainedHeader).toEqual(block.header);
+    expect(obtainedHeader).toEqual(block.block.header);
   });
 
   it('removes notes from db on a reorg', async () => {
@@ -62,7 +62,7 @@ describe('Synchronizer', () => {
 
     await synchronizer.handleBlockStreamEvent({
       type: 'blocks-added',
-      blocks: await timesParallel(5, i => L2Block.random(i)),
+      blocks: await timesParallel(5, randomPublishedL2Block),
     });
     await synchronizer.handleBlockStreamEvent({ type: 'chain-pruned', blockNumber: 3 });
 

--- a/yarn-project/pxe/src/synchronizer/synchronizer.ts
+++ b/yarn-project/pxe/src/synchronizer/synchronizer.ts
@@ -49,7 +49,7 @@ export class Synchronizer implements L2BlockStreamEventHandler {
 
     switch (event.type) {
       case 'blocks-added': {
-        const lastBlock = event.blocks.at(-1)!;
+        const lastBlock = event.blocks.at(-1)!.block;
         this.log.verbose(`Updated pxe last block to ${lastBlock.number}`, {
           blockHash: lastBlock.hash(),
           archive: lastBlock.archive.root.toString(),

--- a/yarn-project/sequencer-client/src/client/sequencer-client.ts
+++ b/yarn-project/sequencer-client/src/client/sequencer-client.ts
@@ -216,4 +216,8 @@ export class SequencerClient {
   get forwarderAddress(): EthAddress {
     return this.sequencer.getForwarderAddress();
   }
+
+  get validatorAddress(): EthAddress | undefined {
+    return this.sequencer.getValidatorAddress();
+  }
 }

--- a/yarn-project/sequencer-client/src/sequencer/sequencer.ts
+++ b/yarn-project/sequencer-client/src/sequencer/sequencer.ts
@@ -111,6 +111,10 @@ export class Sequencer {
     return this.metrics.tracer;
   }
 
+  public getValidatorAddress() {
+    return this.validatorClient?.getValidatorAddress();
+  }
+
   /**
    * Updates sequencer config.
    * @param config - New parameters.

--- a/yarn-project/stdlib/src/avm/public_data_write.ts
+++ b/yarn-project/stdlib/src/avm/public_data_write.ts
@@ -77,4 +77,8 @@ export class PublicDataWrite {
   isEmpty() {
     return this.leafSlot.isZero() && this.value.isZero();
   }
+
+  equals(other: PublicDataWrite): boolean {
+    return this.leafSlot.equals(other.leafSlot) && this.value.equals(other.value);
+  }
 }

--- a/yarn-project/stdlib/src/block/body.ts
+++ b/yarn-project/stdlib/src/block/body.ts
@@ -18,6 +18,12 @@ export class Body {
     });
   }
 
+  equals(other: Body) {
+    return (
+      this.txEffects.length === other.txEffects.length && this.txEffects.every((te, i) => te.equals(other.txEffects[i]))
+    );
+  }
+
   static get schema(): ZodFor<Body> {
     return z
       .object({

--- a/yarn-project/stdlib/src/block/index.ts
+++ b/yarn-project/stdlib/src/block/index.ts
@@ -6,3 +6,4 @@ export * from './body.js';
 export * from './l2_block_number.js';
 export * from './l2_block_source.js';
 export * from './block_hash.js';
+export * from './published_l2_block.js';

--- a/yarn-project/stdlib/src/block/l2_block.ts
+++ b/yarn-project/stdlib/src/block/l2_block.ts
@@ -202,4 +202,8 @@ export class L2Block {
       ...logsStats,
     };
   }
+
+  equals(other: L2Block) {
+    return this.archive.equals(other.archive) && this.header.equals(other.header) && this.body.equals(other.body);
+  }
 }

--- a/yarn-project/stdlib/src/block/l2_block_downloader/l2_block_stream.test.ts
+++ b/yarn-project/stdlib/src/block/l2_block_downloader/l2_block_stream.test.ts
@@ -7,6 +7,7 @@ import times from 'lodash.times';
 import type { BlockHeader } from '../../tx/block_header.js';
 import type { L2Block } from '../l2_block.js';
 import type { L2BlockSource, L2Tips } from '../l2_block_source.js';
+import type { PublishedL2Block } from '../published_l2_block.js';
 import {
   L2BlockStream,
   type L2BlockStreamEvent,
@@ -34,14 +35,14 @@ describe('L2BlockStream', () => {
     );
 
     // And returns blocks up until what was reported as the latest block
-    blockSource.getBlocks.mockImplementation((from, limit) =>
+    blockSource.getPublishedBlocks.mockImplementation((from, limit) =>
       Promise.resolve(compactArray(times(limit, i => (from + i > latest ? undefined : makeBlock(from + i))))),
     );
 
     blockStream = new TestL2BlockStream(blockSource, localData, handler, undefined, { batchSize: 10 });
   });
 
-  const makeBlock = (number: number) => ({ number } as L2Block);
+  const makeBlock = (number: number) => ({ block: { number } as L2Block } as PublishedL2Block);
 
   const makeHeader = (number: number) =>
     mock<BlockHeader>({ hash: () => Promise.resolve(new Fr(number)) } as BlockHeader);
@@ -71,7 +72,7 @@ describe('L2BlockStream', () => {
       localData.latest.number = 10;
 
       await blockStream.work();
-      expect(blockSource.getBlocks).toHaveBeenCalledWith(11, 5, undefined);
+      expect(blockSource.getPublishedBlocks).toHaveBeenCalledWith(11, 5, undefined);
       expect(handler.events).toEqual([{ type: 'blocks-added', blocks: times(5, i => makeBlock(i + 11)) }]);
     });
 
@@ -79,7 +80,7 @@ describe('L2BlockStream', () => {
       setRemoteTips(45);
 
       await blockStream.work();
-      expect(blockSource.getBlocks).toHaveBeenCalledTimes(5);
+      expect(blockSource.getPublishedBlocks).toHaveBeenCalledTimes(5);
       expect(handler.events).toEqual([
         { type: 'blocks-added', blocks: times(10, i => makeBlock(i + 1)) },
         { type: 'blocks-added', blocks: times(10, i => makeBlock(i + 11)) },
@@ -94,7 +95,7 @@ describe('L2BlockStream', () => {
       blockStream.running = false;
 
       await blockStream.work();
-      expect(blockSource.getBlocks).toHaveBeenCalledTimes(1);
+      expect(blockSource.getPublishedBlocks).toHaveBeenCalledTimes(1);
       expect(handler.events).toEqual([{ type: 'blocks-added', blocks: times(10, i => makeBlock(i + 1)) }]);
     });
 

--- a/yarn-project/stdlib/src/block/l2_block_source.ts
+++ b/yarn-project/stdlib/src/block/l2_block_source.ts
@@ -10,6 +10,7 @@ import type { TxHash } from '../tx/tx_hash.js';
 import type { TxReceipt } from '../tx/tx_receipt.js';
 import type { InBlock } from './in_block.js';
 import type { L2Block } from './l2_block.js';
+import type { PublishedL2Block } from './published_l2_block.js';
 
 /**
  * Interface of classes allowing for the retrieval of L2 blocks.
@@ -61,6 +62,9 @@ export interface L2BlockSource {
    * @returns The requested L2 blocks.
    */
   getBlocks(from: number, limit: number, proven?: boolean): Promise<L2Block[]>;
+
+  /** Equivalent to getBlocks but includes publish data. */
+  getPublishedBlocks(from: number, limit: number, proven?: boolean): Promise<PublishedL2Block[]>;
 
   /**
    * Gets a tx effect.

--- a/yarn-project/stdlib/src/block/published_l2_block.ts
+++ b/yarn-project/stdlib/src/block/published_l2_block.ts
@@ -1,0 +1,40 @@
+import { Buffer32 } from '@aztec/foundation/buffer';
+import { times } from '@aztec/foundation/collection';
+import { Signature } from '@aztec/foundation/eth-signature';
+import { schemas } from '@aztec/foundation/schemas';
+import { L2Block } from '@aztec/stdlib/block';
+
+import { z } from 'zod';
+
+export type L1PublishedData = {
+  blockNumber: bigint;
+  timestamp: bigint;
+  blockHash: string;
+};
+
+export type PublishedL2Block = {
+  block: L2Block;
+  l1: L1PublishedData;
+  signatures: Signature[];
+};
+
+export const PublishedL2BlockSchema = z.object({
+  block: L2Block.schema,
+  l1: z.object({
+    blockNumber: schemas.BigInt,
+    timestamp: schemas.BigInt,
+    blockHash: z.string(),
+  }),
+  signatures: z.array(Signature.schema),
+});
+
+export async function randomPublishedL2Block(l2BlockNumber: number): Promise<PublishedL2Block> {
+  const block = await L2Block.random(l2BlockNumber);
+  const l1 = {
+    blockNumber: BigInt(block.number),
+    timestamp: block.header.globalVariables.timestamp.toBigInt(),
+    blockHash: Buffer32.random().toString(),
+  };
+  const signatures = times(3, Signature.random);
+  return { block, l1, signatures };
+}

--- a/yarn-project/stdlib/src/interfaces/archiver.ts
+++ b/yarn-project/stdlib/src/interfaces/archiver.ts
@@ -6,6 +6,7 @@ import { inBlockSchemaFor } from '../block/in_block.js';
 import { L2Block } from '../block/l2_block.js';
 import { type L2BlockSource, L2TipsSchema } from '../block/l2_block_source.js';
 import type { NullifierWithBlockSource } from '../block/nullifier_with_block_source.js';
+import { PublishedL2BlockSchema } from '../block/published_l2_block.js';
 import {
   ContractClassPublicSchema,
   type ContractDataSource,
@@ -43,6 +44,10 @@ export const ArchiverApiSchema: ApiSchemaFor<ArchiverApi> = {
     .function()
     .args(schemas.Integer, schemas.Integer, optional(z.boolean()))
     .returns(z.array(L2Block.schema)),
+  getPublishedBlocks: z
+    .function()
+    .args(schemas.Integer, schemas.Integer, optional(z.boolean()))
+    .returns(z.array(PublishedL2BlockSchema)),
   getTxEffect: z.function().args(TxHash.schema).returns(inBlockSchemaFor(TxEffect.schema).optional()),
   getSettledTxReceipt: z.function().args(TxHash.schema).returns(TxReceipt.schema.optional()),
   getL2SlotNumber: z.function().args().returns(schemas.BigInt),

--- a/yarn-project/stdlib/src/interfaces/aztec-node.test.ts
+++ b/yarn-project/stdlib/src/interfaces/aztec-node.test.ts
@@ -6,8 +6,10 @@ import {
   PUBLIC_DATA_TREE_HEIGHT,
 } from '@aztec/constants';
 import { type L1ContractAddresses, L1ContractsNames } from '@aztec/ethereum/l1-contract-addresses';
+import { Buffer32 } from '@aztec/foundation/buffer';
 import { memoize } from '@aztec/foundation/decorators';
 import { EthAddress } from '@aztec/foundation/eth-address';
+import { Signature } from '@aztec/foundation/eth-signature';
 import { Fr } from '@aztec/foundation/fields';
 import { type JsonRpcTestContext, createJsonRpcTestSetup } from '@aztec/foundation/json-rpc/test';
 import { SiblingPath } from '@aztec/foundation/trees';
@@ -19,6 +21,7 @@ import { AztecAddress } from '../aztec-address/index.js';
 import { type InBlock, randomInBlock } from '../block/in_block.js';
 import { L2Block } from '../block/l2_block.js';
 import type { L2Tips } from '../block/l2_block_source.js';
+import type { PublishedL2Block } from '../block/published_l2_block.js';
 import {
   type ContractClassPublic,
   type ContractInstanceWithAddress,
@@ -196,6 +199,14 @@ describe('AztecNodeApiSchema', () => {
     const response = await context.client.getBlocks(1, 1);
     expect(response).toHaveLength(1);
     expect(response[0]).toBeInstanceOf(L2Block);
+  });
+
+  it('getPublishedBlocks', async () => {
+    const response = await context.client.getPublishedBlocks(1, 1);
+    expect(response).toHaveLength(1);
+    expect(response[0].block.constructor.name).toEqual('L2Block');
+    expect(response[0].signatures[0]).toBeInstanceOf(Signature);
+    expect(response[0].l1).toBeDefined();
   });
 
   it('getNodeVersion', async () => {
@@ -501,6 +512,17 @@ class MockAztecNode implements AztecNode {
       Array(limit)
         .fill(0)
         .map(i => L2Block.random(from + i)),
+    );
+  }
+  getPublishedBlocks(from: number, limit: number): Promise<PublishedL2Block[]> {
+    return Promise.all(
+      Array(limit)
+        .fill(0)
+        .map(async i => ({
+          block: await L2Block.random(from + i),
+          signatures: [Signature.random()],
+          l1: { blockHash: Buffer32.random().toString(), blockNumber: 1n, timestamp: 1n },
+        })),
     );
   }
   getNodeVersion(): Promise<string> {

--- a/yarn-project/stdlib/src/interfaces/aztec-node.ts
+++ b/yarn-project/stdlib/src/interfaces/aztec-node.ts
@@ -17,6 +17,7 @@ import { type InBlock, inBlockSchemaFor } from '../block/in_block.js';
 import { L2Block } from '../block/l2_block.js';
 import { type L2BlockNumber, L2BlockNumberSchema } from '../block/l2_block_number.js';
 import { type L2BlockSource, type L2Tips, L2TipsSchema } from '../block/l2_block_source.js';
+import { PublishedL2BlockSchema } from '../block/published_l2_block.js';
 import {
   type ContractClassPublic,
   ContractClassPublicSchema,
@@ -63,7 +64,7 @@ import { type WorldStateSyncStatus, WorldStateSyncStatusSchema } from './world_s
  */
 export interface AztecNode
   extends ProverCoordination,
-    Pick<L2BlockSource, 'getBlocks' | 'getBlockHeader' | 'getL2Tips'> {
+    Pick<L2BlockSource, 'getBlocks' | 'getPublishedBlocks' | 'getBlockHeader' | 'getL2Tips'> {
   /**
    * Returns the tips of the L2 chain.
    */
@@ -533,6 +534,8 @@ export const AztecNodeApiSchema: ApiSchemaFor<AztecNode> = {
   getNodeInfo: z.function().returns(NodeInfoSchema),
 
   getBlocks: z.function().args(z.number(), z.number()).returns(z.array(L2Block.schema)),
+
+  getPublishedBlocks: z.function().args(z.number(), z.number()).returns(z.array(PublishedL2BlockSchema)),
 
   getCurrentBaseFees: z.function().returns(GasFees.schema),
 

--- a/yarn-project/stdlib/src/logs/contract_class_log.ts
+++ b/yarn-project/stdlib/src/logs/contract_class_log.ts
@@ -28,6 +28,14 @@ export class ContractClassLog {
     return [this.contractAddress.toField(), ...this.fields];
   }
 
+  equals(other: ContractClassLog) {
+    return (
+      this.contractAddress.equals(other.contractAddress) &&
+      this.fields.length === other.fields.length &&
+      this.fields.every((f, i) => f.equals(other.fields[i]))
+    );
+  }
+
   static fromFields(fields: Fr[] | FieldReader) {
     const reader = FieldReader.asReader(fields);
     // Below line gives error 'Type instantiation is excessively deep and possibly infinite. ts(2589)'

--- a/yarn-project/stdlib/src/logs/private_log.ts
+++ b/yarn-project/stdlib/src/logs/private_log.ts
@@ -61,6 +61,10 @@ export class PrivateLog {
       .transform(({ fields }) => PrivateLog.fromFields(fields));
   }
 
+  equals(other: PrivateLog) {
+    return this.fields.every((field, i) => field.equals(other.fields[i]));
+  }
+
   [inspect.custom](): string {
     return `PrivateLog {
       fields: [${this.fields.map(x => inspect(x)).join(', ')}],

--- a/yarn-project/stdlib/src/p2p/consensus_payload.ts
+++ b/yarn-project/stdlib/src/p2p/consensus_payload.ts
@@ -7,6 +7,7 @@ import type { FieldsOf } from '@aztec/foundation/types';
 import { encodeAbiParameters, parseAbiParameters } from 'viem';
 import { z } from 'zod';
 
+import type { L2Block } from '../block/l2_block.js';
 import { BlockHeader } from '../tx/block_header.js';
 import { TxHash } from '../tx/tx_hash.js';
 import type { Signable, SignatureDomainSeparator } from './signature_utils.js';
@@ -71,6 +72,14 @@ export class ConsensusPayload implements Signable {
 
   static fromFields(fields: FieldsOf<ConsensusPayload>): ConsensusPayload {
     return new ConsensusPayload(fields.header, fields.archive, fields.txHashes);
+  }
+
+  static fromBlock(block: L2Block): ConsensusPayload {
+    return new ConsensusPayload(
+      block.header,
+      block.archive.root,
+      block.body.txEffects.map(tx => tx.txHash),
+    );
   }
 
   static empty(): ConsensusPayload {

--- a/yarn-project/stdlib/src/tx/tx_effect.ts
+++ b/yarn-project/stdlib/src/tx/tx_effect.ts
@@ -158,6 +158,28 @@ export class TxEffect {
     ]);
   }
 
+  equals(other: TxEffect): boolean {
+    return (
+      this.revertCode.equals(other.revertCode) &&
+      this.txHash.equals(other.txHash) &&
+      this.transactionFee.equals(other.transactionFee) &&
+      this.noteHashes.length === other.noteHashes.length &&
+      this.noteHashes.every((h, i) => h.equals(other.noteHashes[i])) &&
+      this.nullifiers.length === other.nullifiers.length &&
+      this.nullifiers.every((h, i) => h.equals(other.nullifiers[i])) &&
+      this.l2ToL1Msgs.length === other.l2ToL1Msgs.length &&
+      this.l2ToL1Msgs.every((h, i) => h.equals(other.l2ToL1Msgs[i])) &&
+      this.publicDataWrites.length === other.publicDataWrites.length &&
+      this.publicDataWrites.every((h, i) => h.equals(other.publicDataWrites[i])) &&
+      this.privateLogs.length === other.privateLogs.length &&
+      this.privateLogs.every((h, i) => h.equals(other.privateLogs[i])) &&
+      this.publicLogs.length === other.publicLogs.length &&
+      this.publicLogs.every((h, i) => h.equals(other.publicLogs[i])) &&
+      this.contractClassLogs.length === other.contractClassLogs.length &&
+      this.contractClassLogs.every((h, i) => h.equals(other.contractClassLogs[i]))
+    );
+  }
+
   /** Returns the size of this tx effect in bytes as serialized onto DA. */
   getDASize() {
     return this.toBlobFields().length * Fr.SIZE_IN_BYTES;

--- a/yarn-project/telemetry-client/src/wrappers/l2_block_stream.ts
+++ b/yarn-project/telemetry-client/src/wrappers/l2_block_stream.ts
@@ -10,7 +10,7 @@ import { type Traceable, type Tracer, trackSpan } from '@aztec/telemetry-client'
 /** Extends an L2BlockStream with a tracer to create a new trace per iteration. */
 export class TraceableL2BlockStream extends L2BlockStream implements Traceable {
   constructor(
-    l2BlockSource: Pick<L2BlockSource, 'getBlocks' | 'getBlockHeader' | 'getL2Tips'>,
+    l2BlockSource: Pick<L2BlockSource, 'getPublishedBlocks' | 'getBlockHeader' | 'getL2Tips'>,
     localData: L2BlockStreamLocalDataProvider,
     handler: L2BlockStreamEventHandler,
     public readonly tracer: Tracer,

--- a/yarn-project/txe/src/node/txe_node.ts
+++ b/yarn-project/txe/src/node/txe_node.ts
@@ -11,7 +11,14 @@ import { Fr } from '@aztec/foundation/fields';
 import { createLogger } from '@aztec/foundation/log';
 import type { SiblingPath } from '@aztec/foundation/trees';
 import { AztecAddress } from '@aztec/stdlib/aztec-address';
-import { type InBlock, L2Block, L2BlockHash, type L2BlockNumber, type L2Tips } from '@aztec/stdlib/block';
+import {
+  type InBlock,
+  L2Block,
+  L2BlockHash,
+  type L2BlockNumber,
+  type L2Tips,
+  type PublishedL2Block,
+} from '@aztec/stdlib/block';
 import type {
   ContractClassPublic,
   ContractInstanceWithAddress,
@@ -426,6 +433,10 @@ export class TXENode implements AztecNode {
    */
   getBlocks(_from: number, _limit: number): Promise<L2Block[]> {
     throw new Error('TXE Node method getBlocks not implemented');
+  }
+
+  getPublishedBlocks(_from: number, _limit: number): Promise<PublishedL2Block[]> {
+    throw new Error('TXE Node method getPublishedBlocks not implemented');
   }
 
   /**

--- a/yarn-project/validator-client/src/validator.ts
+++ b/yarn-project/validator-client/src/validator.ts
@@ -134,6 +134,10 @@ export class ValidatorClient extends WithTracer implements Validator {
     return validator;
   }
 
+  public getValidatorAddress() {
+    return this.keyStore.getAddress();
+  }
+
   public async start() {
     // Sync the committee from the smart contract
     // https://github.com/AztecProtocol/aztec-packages/issues/7962

--- a/yarn-project/world-state/src/synchronizer/server_world_state_synchronizer.test.ts
+++ b/yarn-project/world-state/src/synchronizer/server_world_state_synchronizer.test.ts
@@ -5,7 +5,7 @@ import { Fr } from '@aztec/foundation/fields';
 import { type Logger, createLogger } from '@aztec/foundation/log';
 import { MerkleTreeCalculator } from '@aztec/foundation/trees';
 import { SHA256Trunc } from '@aztec/merkle-tree';
-import { L2Block, type L2BlockSource, type L2BlockStream } from '@aztec/stdlib/block';
+import { L2Block, type L2BlockSource, type L2BlockStream, type PublishedL2Block } from '@aztec/stdlib/block';
 import { type MerkleTreeReadOperations, WorldStateRunningState } from '@aztec/stdlib/interfaces/server';
 import type { L1ToL2MessageSource } from '@aztec/stdlib/messaging';
 import type { BlockHeader } from '@aztec/stdlib/tx';
@@ -95,7 +95,10 @@ describe('ServerWorldStateSynchronizer', () => {
   const pushBlocks = async (from: number, to: number) => {
     await server.handleBlockStreamEvent({
       type: 'blocks-added',
-      blocks: await timesParallel(to - from + 1, i => L2Block.random(i + from, 4, 3, 1, inHash)),
+      blocks: await timesParallel(
+        to - from + 1,
+        async i => ({ block: await L2Block.random(i + from, 4, 3, 1, inHash) } as PublishedL2Block),
+      ),
     });
     server.latest.number = to;
   };

--- a/yarn-project/world-state/src/synchronizer/server_world_state_synchronizer.ts
+++ b/yarn-project/world-state/src/synchronizer/server_world_state_synchronizer.ts
@@ -210,7 +210,7 @@ export class ServerWorldStateSynchronizer
     try {
       switch (event.type) {
         case 'blocks-added':
-          await this.handleL2Blocks(event.blocks);
+          await this.handleL2Blocks(event.blocks.map(b => b.block));
           break;
         case 'chain-pruned':
           await this.handleChainPruned(event.blockNumber);


### PR DESCRIPTION
Downloads attestor signatures from L1 and stores them along with blocks. These are pushed into the attestation pool when new blocks are seen, to guarantee that all attestations are visible in the pool (in case some were missed via p2p).

Introduces a new `PublishedL2Block` type (that replaces the `L1Published` wrapper type), and adds a `getPublishedBlocks` method to both archiver and node. Eventually we could merge this method with `getBlocks`, but I did not want to change every single client of `getBlocks` at this stage.
