### PR TITLE
feat(bb): extend_edges optimization for zero values past end_index

### DIFF
--- a/barretenberg/cpp/src/barretenberg/sumcheck/sumcheck_round.hpp
+++ b/barretenberg/cpp/src/barretenberg/sumcheck/sumcheck_round.hpp
@@ -119,7 +119,12 @@ template <typename Flavor> class SumcheckProverRound {
             if constexpr (Flavor::USE_SHORT_MONOMIALS) {
                 extended_edge = edge;
             } else {
-                extended_edge = edge.template extend_to<MAX_PARTIAL_RELATION_LENGTH>();
+                if (multivariate.end_index() < edge_idx) {
+                    extended_edge =
+                        bb::Univariate<FF, MAX_PARTIAL_RELATION_LENGTH>(std::array<FF, MAX_PARTIAL_RELATION_LENGTH>{});
+                } else {
+                    extended_edge = edge.template extend_to<MAX_PARTIAL_RELATION_LENGTH>();
+                }
             }
         }
     }

--- a/barretenberg/cpp/src/barretenberg/sumcheck/sumcheck_round.hpp
+++ b/barretenberg/cpp/src/barretenberg/sumcheck/sumcheck_round.hpp
@@ -114,7 +114,6 @@ template <typename Flavor> class SumcheckProverRound {
                       const ProverPolynomialsOrPartiallyEvaluatedMultivariates& multivariates,
                       const size_t edge_idx)
     {
-
         for (auto [extended_edge, multivariate] : zip_view(extended_edges.get_all(), multivariates.get_all())) {
             bb::Univariate<FF, 2> edge({ multivariate[edge_idx], multivariate[edge_idx + 1] });
             if constexpr (Flavor::USE_SHORT_MONOMIALS) {

--- a/barretenberg/cpp/src/barretenberg/sumcheck/sumcheck_round.hpp
+++ b/barretenberg/cpp/src/barretenberg/sumcheck/sumcheck_round.hpp
@@ -114,14 +114,15 @@ template <typename Flavor> class SumcheckProverRound {
                       const ProverPolynomialsOrPartiallyEvaluatedMultivariates& multivariates,
                       const size_t edge_idx)
     {
+
         for (auto [extended_edge, multivariate] : zip_view(extended_edges.get_all(), multivariates.get_all())) {
             bb::Univariate<FF, 2> edge({ multivariate[edge_idx], multivariate[edge_idx + 1] });
             if constexpr (Flavor::USE_SHORT_MONOMIALS) {
                 extended_edge = edge;
             } else {
                 if (multivariate.end_index() < edge_idx) {
-                    extended_edge =
-                        bb::Univariate<FF, MAX_PARTIAL_RELATION_LENGTH>(std::array<FF, MAX_PARTIAL_RELATION_LENGTH>{});
+                    static const auto zero_univariate = bb::Univariate<FF, MAX_PARTIAL_RELATION_LENGTH>::zero();
+                    extended_edge = zero_univariate;
                 } else {
                     extended_edge = edge.template extend_to<MAX_PARTIAL_RELATION_LENGTH>();
                 }

--- a/bb-pilcom/bb-pil-backend/templates/flavor.cpp.hbs
+++ b/bb-pilcom/bb-pil-backend/templates/flavor.cpp.hbs
@@ -89,7 +89,7 @@ AvmFlavor::PartiallyEvaluatedMultivariates::PartiallyEvaluatedMultivariates(cons
 {
     for (auto [poly, full_poly] : zip_view(get_all(), full_polynomials.get_all())) {
         // After the initial sumcheck round, the new size is CEIL(size/2).
-        size_t desired_size = std::min(full_poly.end_index() / 2 + full_poly.end_index() % 2, circuit_size / 2);
+        size_t desired_size = full_poly.end_index() / 2 + full_poly.end_index() % 2;
         poly = Polynomial(desired_size, circuit_size / 2);
     }
 }


### PR DESCRIPTION
On 16 cores, avm bulk test v2, sumcheck time improves from 16 seconds to 8.5 seconds.