### PR TITLE
refactor(Barretenberg): Static analyzer optimization

### DIFF
--- a/barretenberg/cpp/src/barretenberg/boomerang_value_detection/graph.cpp
+++ b/barretenberg/cpp/src/barretenberg/boomerang_value_detection/graph.cpp
@@ -639,7 +639,7 @@ bool Graph_<FF>::check_is_not_constant_variable(bb::UltraCircuitBuilder& ultra_c
                                                 const uint32_t& variable_index)
 {
     bool is_not_constant = true;
-    auto constant_variable_indices = ultra_circuit_builder.constant_variable_indices;
+    const auto& constant_variable_indices = ultra_circuit_builder.constant_variable_indices;
     for (const auto& pair : constant_variable_indices) {
         if (pair.second == ultra_circuit_builder.real_variable_index[variable_index]) {
             is_not_constant = false;
@@ -1028,9 +1028,7 @@ inline void Graph_<FF>::remove_unnecessary_sha256_plookup_variables(std::unorder
  */
 
 template <typename FF>
-inline void Graph_<FF>::process_current_plookup_gate(bb::UltraCircuitBuilder& ultra_circuit_builder,
-                                                     std::unordered_set<uint32_t>& variables_in_one_gate,
-                                                     size_t gate_index)
+inline void Graph_<FF>::process_current_plookup_gate(bb::UltraCircuitBuilder& ultra_circuit_builder, size_t gate_index)
 {
     auto find_position = [&](uint32_t real_variable_index) {
         return variables_in_one_gate.contains(real_variable_index);
@@ -1040,9 +1038,9 @@ inline void Graph_<FF>::process_current_plookup_gate(bb::UltraCircuitBuilder& ul
     auto table_index = static_cast<size_t>(lookup_block.q_3()[gate_index]);
     for (const auto& table : lookup_tables) {
         if (table.table_index == table_index) {
-            std::set<bb::fr> column_1(table.column_1.begin(), table.column_1.end());
-            std::set<bb::fr> column_2(table.column_2.begin(), table.column_2.end());
-            std::set<bb::fr> column_3(table.column_3.begin(), table.column_3.end());
+            std::unordered_set<bb::fr> column_1(table.column_1.begin(), table.column_1.end());
+            std::unordered_set<bb::fr> column_2(table.column_2.begin(), table.column_2.end());
+            std::unordered_set<bb::fr> column_3(table.column_3.begin(), table.column_3.end());
             bb::plookup::BasicTableId table_id = table.id;
             // false cases for AES
             this->remove_unnecessary_aes_plookup_variables(
@@ -1086,13 +1084,12 @@ inline void Graph_<FF>::process_current_plookup_gate(bb::UltraCircuitBuilder& ul
  */
 
 template <typename FF>
-inline void Graph_<FF>::remove_unnecessary_plookup_variables(bb::UltraCircuitBuilder& ultra_circuit_builder,
-                                                             std::unordered_set<uint32_t>& variables_in_one_gate)
+inline void Graph_<FF>::remove_unnecessary_plookup_variables(bb::UltraCircuitBuilder& ultra_circuit_builder)
 {
     auto& lookup_block = ultra_circuit_builder.blocks.lookup;
     if (lookup_block.size() > 0) {
         for (size_t i = 0; i < lookup_block.size(); i++) {
-            this->process_current_plookup_gate(ultra_circuit_builder, variables_in_one_gate, i);
+            this->process_current_plookup_gate(ultra_circuit_builder, i);
         }
     }
 }
@@ -1168,7 +1165,7 @@ std::unordered_set<uint32_t> Graph_<FF>::show_variables_in_one_gate(bb::UltraCir
     }
     this->remove_unnecessary_decompose_variables(
         ultra_circuit_builder, this->variables_in_one_gate, decompose_varialbes);
-    this->remove_unnecessary_plookup_variables(ultra_circuit_builder, this->variables_in_one_gate);
+    this->remove_unnecessary_plookup_variables(ultra_circuit_builder);
     this->remove_unnecessary_range_constrains_variables(ultra_circuit_builder);
     for (const auto& elem : this->fixed_variables) {
         this->variables_in_one_gate.erase(elem);

--- a/barretenberg/cpp/src/barretenberg/boomerang_value_detection/graph.hpp
+++ b/barretenberg/cpp/src/barretenberg/boomerang_value_detection/graph.hpp
@@ -143,14 +143,11 @@ template <typename FF> class Graph_ {
     size_t process_current_decompose_chain(bb::UltraCircuitBuilder& ultra_circuit_constructor,
                                            std::unordered_set<uint32_t>& variables_in_one_gate,
                                            size_t index);
-    void process_current_plookup_gate(bb::UltraCircuitBuilder& ultra_circuit_builder,
-                                      std::unordered_set<uint32_t>& variables_in_one_gate,
-                                      size_t gate_index);
+    void process_current_plookup_gate(bb::UltraCircuitBuilder& ultra_circuit_builder, size_t gate_index);
     void remove_unnecessary_decompose_variables(bb::UltraCircuitBuilder& ultra_circuit_builder,
                                                 std::unordered_set<uint32_t>& variables_in_on_gate,
                                                 const std::unordered_set<uint32_t>& decompose_variables);
-    void remove_unnecessary_plookup_variables(bb::UltraCircuitBuilder& ultra_circuit_builder,
-                                              std::unordered_set<uint32_t>& variables_in_on_gate);
+    void remove_unnecessary_plookup_variables(bb::UltraCircuitBuilder& ultra_circuit_builder);
     void remove_unnecessary_range_constrains_variables(bb::UltraCircuitBuilder& ultra_builder);
     std::unordered_set<uint32_t> show_variables_in_one_gate(bb::UltraCircuitBuilder& ultra_circuit_builder);
 


### PR DESCRIPTION
There are fixes in the code which accelerated constructor of static analyzer.

During testing, we noticed that graph creation was slow in some cases(SHA256 NIST vector five & join split circuit). Using perf utility we found that some parts of the code were ineffective. 

SHA256 NIST vector five test case showed that the most time-consuming part was transformation lookup tables columns in std::set, which was unnecessary, because we didn't need to order elements, we just wanted to get the amount of unique elements in the columns, so it would be better to use std::unordered_set in this case. No this test works ~90 secs(93 secs and 87.30, so approximately 90 seconds).

Join Split Circuit Test showed that the most time-consuming part was checking that variable wasn't constant and the problem was getting constant_variable_indices from Ultra Circuit Builder, because there wasn't reference for this object. Now test with all removing parts works 97 seconds whereas it works 2 minutes and 26 seconds before.  

 