### PR TITLE
fix: fix assert_split_transformed_value_arrays conditional access index overflow

### DIFF
--- a/noir-projects/noir-protocol-circuits/crates/types/src/utils/arrays/assert_split_transformed_value_arrays.nr
+++ b/noir-projects/noir-protocol-circuits/crates/types/src/utils/arrays/assert_split_transformed_value_arrays.nr
@@ -14,7 +14,7 @@ where
 {
     if num_non_revertibles != 0 {
         // If num_non_revertibles == 0, then the below can still underflow and cause 'Failed constraint' error,
-        // even though it shouldn't reach here. If statement branches aren't isolated?
+        // even though it shouldn't reach here. See noir issue #7612.
         let is_non_zero = (num_non_revertibles != 0) as u32;
         assert(
             sorted_array[num_non_revertibles - 1].counter() * is_non_zero < split_counter,
@@ -23,7 +23,10 @@ where
     }
 
     if num_non_revertibles != N {
-        let first_revertible_counter = sorted_array[num_non_revertibles].counter();
+        // If num_non_revertibles == N, then the below can still overflow and cause 'Failed constraint' error,
+        // even though it shouldn't reach here. See noir issue #7612.
+        let is_not_n = (num_non_revertibles != N) as u32;
+        let first_revertible_counter = sorted_array[num_non_revertibles].counter() * is_not_n;
         assert(
             (first_revertible_counter == 0) | (first_revertible_counter >= split_counter),
             "counter of first revertible item is not greater than or equal to the split counter",


### PR DESCRIPTION
Fixes exactly the same problem as #12540, but on the following if statement as an index overflow. See that description for more details!

This is being looked into in noir: https://github.com/noir-lang/noir/issues/7612
