### PR TITLE
chore: update governance asset + use l1 utils to wait for L1 block

### DIFF
--- a/yarn-project/ethereum/src/deploy_l1_contracts.ts
+++ b/yarn-project/ethereum/src/deploy_l1_contracts.ts
@@ -537,7 +537,7 @@ export const deployL1Contracts = async (
   // @note @LHerskind the assets are expected to be the same at some point, but for better
   // configurability they are different for now.
   const governanceAddress = await deployer.deploy(l1Artifacts.governance, [
-    feeAssetAddress.toString(),
+    stakingAssetAddress.toString(),
     governanceProposerAddress.toString(),
   ]);
   logger.verbose(`Deployed Governance at ${governanceAddress}`);

--- a/yarn-project/ethereum/src/test/upgrade_utils.ts
+++ b/yarn-project/ethereum/src/test/upgrade_utils.ts
@@ -1,11 +1,12 @@
 import type { Logger } from '@aztec/foundation/log';
 import { GovernanceAbi } from '@aztec/l1-artifacts/GovernanceAbi';
-import { TestERC20Abi as FeeJuiceAbi } from '@aztec/l1-artifacts/TestERC20Abi';
+import { TestERC20Abi as StakingAssetAbi } from '@aztec/l1-artifacts/TestERC20Abi';
 
 import { type GetContractReturnType, type PrivateKeyAccount, getContract } from 'viem';
 
 import { EthCheatCodes } from '../eth_cheat_codes.js';
 import type { L1ContractAddresses } from '../l1_contract_addresses.js';
+import { L1TxUtils } from '../l1_tx_utils.js';
 import type { L1Clients } from '../types.js';
 
 export async function executeGovernanceProposal(
@@ -20,13 +21,12 @@ export async function executeGovernanceProposal(
 ) {
   const proposal = await governance.read.getProposal([proposalId]);
 
+  const l1TxUtils = new L1TxUtils(publicClient, walletClient);
+
   const waitL1Block = async () => {
-    await publicClient.waitForTransactionReceipt({
-      hash: await walletClient.sendTransaction({
-        to: privateKey.address,
-        value: 1n,
-        account: privateKey,
-      }),
+    await l1TxUtils.sendAndMonitorTransaction({
+      to: walletClient.account.address,
+      value: 1n,
     });
   };
 
@@ -62,8 +62,8 @@ export async function createGovernanceProposal(
   logger: Logger,
 ): Promise<{ governance: GetContractReturnType<typeof GovernanceAbi, L1Clients['publicClient']>; voteAmount: bigint }> {
   const token = getContract({
-    address: addresses.feeJuiceAddress.toString(),
-    abi: FeeJuiceAbi,
+    address: addresses.stakingAssetAddress.toString(),
+    abi: StakingAssetAbi,
     client: publicClient,
   });
 


### PR DESCRIPTION
Could recreate an issue once for an underprices function, so have updated it to use the L1Utils when sending the tx to ensure we are in a new L1 block.

Separately also updated the asset used in governance to be the non-freely mintable staking asset.

After the change, could not get it to repeat the flake, but it did not seem horribly stable at that, so will keep it as flakey for now.