### PR TITLE
fix: filter for empty attestations when pulling from block

### DIFF
--- a/yarn-project/end-to-end/src/e2e_p2p/reqresp.test.ts
+++ b/yarn-project/end-to-end/src/e2e_p2p/reqresp.test.ts
@@ -1,6 +1,9 @@
+import type { Archiver } from '@aztec/archiver';
 import type { AztecNodeService } from '@aztec/aztec-node';
 import { sleep } from '@aztec/aztec.js';
 import { RollupAbi } from '@aztec/l1-artifacts';
+import type { SequencerClient } from '@aztec/sequencer-client';
+import { BlockAttestation, ConsensusPayload } from '@aztec/stdlib/p2p';
 
 import { jest } from '@jest/globals';
 import fs from 'fs';
@@ -123,6 +126,25 @@ describe('e2e_p2p_reqresp_tx', () => {
       ),
     );
     t.logger.info('All transactions mined');
+
+    // Gather signers from attestations downloaded from L1
+    const blockNumber = await contexts[0].txs[0].getReceipt().then(r => r.blockNumber!);
+    const dataStore = ((nodes[0] as AztecNodeService).getBlockSource() as Archiver).dataStore;
+    const [block] = await dataStore.getBlocks(blockNumber, blockNumber);
+    const attestations = block.signatures.map(
+      sig => new BlockAttestation(ConsensusPayload.fromBlock(block.block), sig),
+    );
+    const signers = await Promise.all(attestations.map(att => att.getSender().then(s => s.toString())));
+    t.logger.info(`Attestation signers`, { signers });
+
+    // Check that the signers found are part of the proposer nodes to ensure the archiver fetched them right
+    const validatorAddresses = nodes.map(node =>
+      ((node as AztecNodeService).getSequencer() as SequencerClient).validatorAddress?.toString(),
+    );
+    t.logger.info(`Validator addresses`, { addresses: validatorAddresses });
+    for (const signer of signers) {
+      expect(validatorAddresses).toContain(signer);
+    }
   });
 
   /**

--- a/yarn-project/end-to-end/src/e2e_p2p/reqresp.test.ts
+++ b/yarn-project/end-to-end/src/e2e_p2p/reqresp.test.ts
@@ -1,9 +1,6 @@
-import type { Archiver } from '@aztec/archiver';
 import type { AztecNodeService } from '@aztec/aztec-node';
 import { sleep } from '@aztec/aztec.js';
 import { RollupAbi } from '@aztec/l1-artifacts';
-import type { SequencerClient } from '@aztec/sequencer-client';
-import { BlockAttestation, ConsensusPayload } from '@aztec/stdlib/p2p';
 
 import { jest } from '@jest/globals';
 import fs from 'fs';
@@ -126,25 +123,6 @@ describe('e2e_p2p_reqresp_tx', () => {
       ),
     );
     t.logger.info('All transactions mined');
-
-    // Gather signers from attestations downloaded from L1
-    const blockNumber = await contexts[0].txs[0].getReceipt().then(r => r.blockNumber!);
-    const dataStore = ((nodes[0] as AztecNodeService).getBlockSource() as Archiver).dataStore;
-    const [block] = await dataStore.getBlocks(blockNumber, blockNumber);
-    const attestations = block.signatures.map(
-      sig => new BlockAttestation(ConsensusPayload.fromBlock(block.block), sig),
-    );
-    const signers = await Promise.all(attestations.map(att => att.getSender().then(s => s.toString())));
-    t.logger.info(`Attestation signers`, { signers });
-
-    // Check that the signers found are part of the proposer nodes to ensure the archiver fetched them right
-    const validatorAddresses = nodes.map(node =>
-      ((node as AztecNodeService).getSequencer() as SequencerClient).validatorAddress?.toString(),
-    );
-    t.logger.info(`Validator addresses`, { addresses: validatorAddresses });
-    for (const signer of signers) {
-      expect(validatorAddresses).toContain(signer);
-    }
   });
 
   /**

--- a/yarn-project/p2p/src/client/p2p_client.test.ts
+++ b/yarn-project/p2p/src/client/p2p_client.test.ts
@@ -1,4 +1,5 @@
 import { MockL2BlockSource } from '@aztec/archiver/test';
+import { Signature } from '@aztec/foundation/eth-signature';
 import { Fr } from '@aztec/foundation/fields';
 import { retryUntil } from '@aztec/foundation/retry';
 import { sleep } from '@aztec/foundation/sleep';
@@ -258,6 +259,14 @@ describe('In-Memory P2P Client', () => {
       expect(attestationPool.addAttestations).toHaveBeenCalledWith(
         block.signatures.map(signature => expect.objectContaining({ signature })),
       );
+    });
+
+    it('handles empty signatures in block stream events', async () => {
+      await client.start();
+      const block = await randomPublishedL2Block(1);
+      block.signatures[0] = Signature.empty();
+      await client.handleBlockStreamEvent({ type: 'blocks-added', blocks: [block] });
+      expect(attestationPool.addAttestations).toHaveBeenCalledWith([]);
     });
   });
 });

--- a/yarn-project/p2p/src/client/p2p_client.test.ts
+++ b/yarn-project/p2p/src/client/p2p_client.test.ts
@@ -237,15 +237,17 @@ describe('In-Memory P2P Client', () => {
       const advanceToProvenBlockNumber = 20;
       const keepAttestationsInPoolFor = 12;
 
+      const deleteAttestationsOlderThanSpy = jest.spyOn(attestationPool, 'deleteAttestationsOlderThan');
+
       blockSource.setProvenBlockNumber(0);
       (client as any).keepAttestationsInPoolFor = keepAttestationsInPoolFor;
       await client.start();
-      expect(attestationPool.deleteAttestationsOlderThan).not.toHaveBeenCalled();
+      expect(deleteAttestationsOlderThanSpy).not.toHaveBeenCalled();
 
       await advanceToProvenBlock(advanceToProvenBlockNumber);
 
-      expect(attestationPool.deleteAttestationsOlderThan).toHaveBeenCalledTimes(1);
-      expect(attestationPool.deleteAttestationsOlderThan).toHaveBeenCalledWith(
+      expect(deleteAttestationsOlderThanSpy).toHaveBeenCalledTimes(1);
+      expect(deleteAttestationsOlderThanSpy).toHaveBeenCalledWith(
         BigInt(advanceToProvenBlockNumber - keepAttestationsInPoolFor),
       );
     });

--- a/yarn-project/p2p/src/client/p2p_client.ts
+++ b/yarn-project/p2p/src/client/p2p_client.ts
@@ -627,7 +627,7 @@ export class P2PClient<T extends P2PClientType = P2PClientType.Full>
   private async addAttestationsToPool(blocks: PublishedL2Block[]): Promise<void> {
     const attestations = blocks.flatMap(block => {
       const payload = ConsensusPayload.fromBlock(block.block);
-      return block.signatures.map(signature => new BlockAttestation(payload, signature));
+      return block.signatures.filter(sig => !sig.isEmpty).map(signature => new BlockAttestation(payload, signature));
     });
     await this.attestationPool?.addAttestations(attestations);
     const slots = blocks.map(b => b.block.header.getSlot()).sort((a, b) => Number(a - b));

--- a/yarn-project/stdlib/src/block/published_l2_block.ts
+++ b/yarn-project/stdlib/src/block/published_l2_block.ts
@@ -1,5 +1,6 @@
 import { Buffer32 } from '@aztec/foundation/buffer';
 import { times } from '@aztec/foundation/collection';
+import { Secp256k1Signer } from '@aztec/foundation/crypto';
 import { Signature } from '@aztec/foundation/eth-signature';
 import { schemas } from '@aztec/foundation/schemas';
 import { L2Block } from '@aztec/stdlib/block';
@@ -35,6 +36,10 @@ export async function randomPublishedL2Block(l2BlockNumber: number): Promise<Pub
     timestamp: block.header.globalVariables.timestamp.toBigInt(),
     blockHash: Buffer32.random().toString(),
   };
-  const signatures = times(3, Signature.random);
+  // Create valid signatures
+  const signers = times(3, () => Secp256k1Signer.random());
+  const signatures = await Promise.all(
+    times(3, async i => signers[i].signMessage(Buffer32.fromField(await block.hash()))),
+  );
   return { block, l1, signatures };
 }


### PR DESCRIPTION
## Overview

Attestations can be empty if not received, filter them before pulling from block
