### PR TITLE
fix: transformation of unconstrained contract library methods

### DIFF
--- a/noir-projects/aztec-nr/aztec/src/macros/functions/utils.nr
+++ b/noir-projects/aztec-nr/aztec/src/macros/functions/utils.nr
@@ -271,7 +271,42 @@ pub(crate) comptime fn transform_public(f: FunctionDefinition) -> Quoted {
     fn_abi
 }
 
-pub(crate) comptime fn transform_unconstrained(f: FunctionDefinition) {
+pub(crate) comptime fn find_and_transform_top_level_unconstrained_fns(m: Module) {
+    // Top-level unconstrained fns are contract entrypoints, but they're not explicitly designated in any way. They're
+    // the fallback case for a function that matches no other rules.
+    // TODO(#12743): improve this
+
+    // We first find non-standard contract entrypoints, i.e. functions in the `contract` mod that are not private or
+    // public, but which *are* contract entrypoints (i.e. they're not opting out via the #[test] or
+    // #[contract_library_method] attributes). Ideally entrypoints would be explicitly designated instead.
+    let non_private_public_entrypoint_functions = m.functions().filter(|f: FunctionDefinition| {
+        !f.has_named_attribute("private")
+            & !f.has_named_attribute("public")
+            & !f.has_named_attribute("contract_library_method")
+            & !f.has_named_attribute("test")
+    });
+
+    // We don't expect to see any custom constrained entrypoints (i.e. private functions created outside of aztec-nr's
+    // #[private] macro, possibly resulting in a non-standard interface).
+    for f in non_private_public_entrypoint_functions.filter(|f: FunctionDefinition| {
+        !f.is_unconstrained()
+    }) {
+        let name = f.name();
+        println(
+            f"warning: found private contract function '{name}' which does not have the #[private] attribute - make sure you know what you're doing!",
+        );
+    }
+
+    // An unconstrained contract entrypoints is what we call a top-level unconstrained function, to which we apply the
+    // appropriate transformation. Ideally these would be explicitly designated as such instead.
+    for f in non_private_public_entrypoint_functions.filter(|f: FunctionDefinition| {
+        f.is_unconstrained()
+    }) {
+        transform_top_level_unconstrained(f);
+    }
+}
+
+pub(crate) comptime fn transform_top_level_unconstrained(f: FunctionDefinition) {
     let context_creation = quote { let mut context = dep::aztec::context::unconstrained_context::UnconstrainedContext::new(); };
     let module_has_storage = module_has_storage(f.module());
 

--- a/noir-projects/aztec-nr/aztec/src/macros/functions/utils.nr
+++ b/noir-projects/aztec-nr/aztec/src/macros/functions/utils.nr
@@ -286,16 +286,19 @@ pub(crate) comptime fn find_and_transform_top_level_unconstrained_fns(m: Module)
             & !f.has_named_attribute("test")
     });
 
-    // We don't expect to see any custom constrained entrypoints (i.e. private functions created outside of aztec-nr's
-    // #[private] macro, possibly resulting in a non-standard interface).
-    for f in non_private_public_entrypoint_functions.filter(|f: FunctionDefinition| {
-        !f.is_unconstrained()
-    }) {
-        let name = f.name();
-        println(
-            f"warning: found private contract function '{name}' which does not have the #[private] attribute - make sure you know what you're doing!",
-        );
-    }
+    // TODO: uncomment the code below and emit a warning once support for them is added to Noir (tracked in
+    // https://github.com/noir-lang/noir/issues/7714). We can't simply print a message since that'd otherwise break the
+    // output of utils such as `nargo test --list-tests`.
+    // // We don't expect to see any custom constrained entrypoints (i.e. private functions created outside of aztec-nr's
+    // // #[private] macro, possibly resulting in a non-standard interface).
+    // for f in non_private_public_entrypoint_functions.filter(|f: FunctionDefinition| {
+    //     !f.is_unconstrained()
+    // }) {
+    //     let name = f.name();
+    //     warn(
+    //         f"found private contract function '{name}' which does not have the #[private] attribute - make sure you know what you're doing!",
+    //     );
+    // }
 
     // An unconstrained contract entrypoints is what we call a top-level unconstrained function, to which we apply the
     // appropriate transformation. Ideally these would be explicitly designated as such instead.

--- a/noir-projects/aztec-nr/aztec/src/macros/mod.nr
+++ b/noir-projects/aztec-nr/aztec/src/macros/mod.nr
@@ -5,7 +5,10 @@ pub mod notes;
 pub mod storage;
 pub mod events;
 
-use functions::{stub_registry, utils::{create_note_discovery_call, transform_unconstrained}};
+use functions::{
+    stub_registry,
+    utils::{create_note_discovery_call, find_and_transform_top_level_unconstrained_fns},
+};
 use notes::{generate_note_export, NOTES};
 use storage::STORAGE_LAYOUT_NAME;
 
@@ -19,12 +22,8 @@ use crate::discovery::MAX_NOTE_PACKED_LEN;
 /// Note: This is a module annotation, so the returned quote gets injected inside the module (contract) itself.
 pub comptime fn aztec(m: Module) -> Quoted {
     let interface = generate_contract_interface(m);
-    let unconstrained_functions = m.functions().filter(|f: FunctionDefinition| {
-        f.is_unconstrained() & !f.has_named_attribute("test") & !f.has_named_attribute("public")
-    });
-    for f in unconstrained_functions {
-        transform_unconstrained(f);
-    }
+
+    find_and_transform_top_level_unconstrained_fns(m);
 
     let contract_library_method_compute_note_hash_and_nullifier =
         generate_contract_library_method_compute_note_hash_and_nullifier();

--- a/noir-projects/noir-contracts/contracts/avm_test_contract/src/main.nr
+++ b/noir-projects/noir-contracts/contracts/avm_test_contract/src/main.nr
@@ -103,7 +103,13 @@ pub contract AvmTest {
 
     #[public]
     fn add_args_return(arg_a: Field, arg_b: Field) -> Field {
-        arg_a + arg_b
+        add(arg_a, arg_b)
+    }
+
+    // Auxiliary method to test usage of contract library methods in public fns
+    #[contract_library_method]
+    unconstrained fn add(lhs: Field, rhs: Field) -> Field {
+        lhs + rhs
     }
 
     /************************************************************************

--- a/noir-projects/noir-contracts/contracts/avm_test_contract/src/main.nr
+++ b/noir-projects/noir-contracts/contracts/avm_test_contract/src/main.nr
@@ -216,10 +216,13 @@ pub contract AvmTest {
     }
 
     // Helper functions to demonstrate an internal call stack in error messages
+    #[contract_library_method]
     fn inner_helper_with_failed_assertion() {
         let not_true = false;
         assert(not_true == true, "This assertion should fail!");
     }
+
+    #[contract_library_method]
     fn helper_with_failed_assertion() {
         inner_helper_with_failed_assertion();
     }


### PR DESCRIPTION
We were not discarding contract library methods when searching for top-level unconstrained fns, and so any such function would get the `UnconstrainedContext` initialization injected, resulting in the correspoding oracle calls being included. If this were to be called from public, the transpiler would fail due to the unknown oracles, resulting in unconstrained contract library methods being unusable in public (and likely in private too, though this would fail at runtime).

I opened https://github.com/AztecProtocol/aztec-packages/issues/12743 to track the work in formalizing the notion of top-level unconstrained fns (soon to be `#[query]` or `#[app-query]` or `#[application]` or _something_).

Fixes https://github.com/AztecProtocol/aztec-packages/issues/12732