### PR TITLE
fix(docs): link noir-docs site

### DIFF
--- a/docs/docusaurus.config.js
+++ b/docs/docusaurus.config.js
@@ -313,7 +313,7 @@ const config = {
                 className: "no-external-icon",
               }] : []),
               {
-                to: "https://noir-lang.org/docs",
+                to: "https://noir-lang.org/docs/",
                 label: "Noir docs",
                 target: "_blank",
                 rel: "noopener noreferrer",


### PR DESCRIPTION
## Motivation
The `Noir docs` reference nav bar menu item was broken. When clicking on it the user was navigated to a Noir page that shows a `Page not found` screen

https://github.com/user-attachments/assets/818bad42-de8a-40d7-82db-d6903ccc91e5

## Changes
The link was pointing to `https://noir-lang.org/docs`. 
This PR changes that so it points to `https://noir-lang.org/docs/`, that's were Noir is actually serving the documentation
