### PR TITLE
chore: Fix block building bench

### DIFF
--- a/yarn-project/end-to-end/src/bench/utils.ts
+++ b/yarn-project/end-to-end/src/bench/utils.ts
@@ -36,6 +36,9 @@ export async function benchmarkSetup(
     await telemetry.flush();
     const data = telemetry.getMeters();
     const formatted = formatMetricsForGithubBenchmarkAction(data, opts.metrics);
+    if (formatted.length === 0) {
+      throw new Error(`No benchmark data generated. Please review your test setup.`);
+    }
     const benchOutput = opts.benchOutput ?? process.env.BENCH_OUTPUT ?? 'bench.json';
     writeFileSync(benchOutput, JSON.stringify(formatted));
     context.logger.info(`Wrote ${data.length} metrics to ${benchOutput}`);

--- a/yarn-project/end-to-end/src/fixtures/utils.ts
+++ b/yarn-project/end-to-end/src/fixtures/utils.ts
@@ -502,10 +502,7 @@ export async function setup(
   const blobSinkClient = createBlobSinkClient(config);
   const aztecNode = await AztecNodeService.createAndSync(
     config,
-    {
-      dateProvider,
-      blobSinkClient,
-    },
+    { dateProvider, blobSinkClient, telemetry },
     { prefilledPublicData },
   );
   const sequencer = aztecNode.getSequencer();

--- a/yarn-project/telemetry-client/src/bench.ts
+++ b/yarn-project/telemetry-client/src/bench.ts
@@ -1,3 +1,5 @@
+import { createLogger } from '@aztec/foundation/log';
+
 import type { BatchObservableCallback, Context, MetricOptions, Observable, ValueType } from '@opentelemetry/api';
 
 import { NoopTracer } from './noop.js';
@@ -28,6 +30,11 @@ export type BenchmarkMetricsType = {
 
 export class BenchmarkTelemetryClient implements TelemetryClient {
   private meters: InMemoryPlainMeter[] = [];
+
+  constructor() {
+    const log = createLogger('telemetry:client');
+    log.info(`Using benchmark telemetry client`);
+  }
 
   getMeter(name: string): Meter {
     const meter = new InMemoryPlainMeter(name);


### PR DESCRIPTION
Due to a change in setup, we were not injecting the benchmark telemetry client into the sequencer, which means no benchmark data was being generated.

Props to @dbanks12 for noticing. Shame on the rest of us for not.
