### PR TITLE
chore: fix all aztec-nr warnings and add check to CI

### DIFF
--- a/noir-projects/aztec-nr/aztec/src/encrypted_logs/encrypt/aes128.nr
+++ b/noir-projects/aztec-nr/aztec/src/encrypted_logs/encrypt/aes128.nr
@@ -1,5 +1,3 @@
-use std::hash::from_field_unsafe as fr_to_fq_unsafe;
-
 use dep::protocol_types::{
     constants::{GENERATOR_INDEX__SYMMETRIC_KEY, GENERATOR_INDEX__SYMMETRIC_KEY_2},
     hash::poseidon2_hash_with_separator,

--- a/noir-projects/aztec-nr/aztec/src/encrypted_logs/encrypt/poseidon2.nr
+++ b/noir-projects/aztec-nr/aztec/src/encrypted_logs/encrypt/poseidon2.nr
@@ -143,21 +143,18 @@ pub fn poseidon2_decrypt<let L: u32>(
 
 mod test {
     use super::{poseidon2_decrypt, poseidon2_encrypt, TWO_POW_128};
-    use std::{
-        embedded_curve_ops::{fixed_base_scalar_mul, multi_scalar_mul},
-        hash::from_field_unsafe as fr_to_fq_unsafe,
-    };
+    use std::embedded_curve_ops::{EmbeddedCurveScalar, fixed_base_scalar_mul, multi_scalar_mul};
 
     // Helper function that allows us to test encryption, then decryption, for various sizes of message.
     fn encrypt_then_decrypt<let N: u32>(msg: [Field; N]) {
         // Alice encrypting to Bob:
 
         let bob_sk = 0x2345; // Obviously, Alice doesn't know this.
-        let bob_pk = fixed_base_scalar_mul(fr_to_fq_unsafe(bob_sk));
+        let bob_pk = fixed_base_scalar_mul(EmbeddedCurveScalar::from_field(bob_sk));
 
         let eph_sk = 0x5678;
-        let eph_pk = fixed_base_scalar_mul(fr_to_fq_unsafe(eph_sk));
-        let shared_secret = multi_scalar_mul([bob_pk], [fr_to_fq_unsafe(eph_sk)]);
+        let eph_pk = fixed_base_scalar_mul(EmbeddedCurveScalar::from_field(eph_sk));
+        let shared_secret = multi_scalar_mul([bob_pk], [EmbeddedCurveScalar::from_field(eph_sk)]);
 
         let nonce = 3; // TODO. Can even be a timestamp. Why is this even needed?
 
@@ -167,7 +164,7 @@ mod test {
 
         // Bob sees: [Epk, ciphertext, nonce]:
 
-        let shared_secret = multi_scalar_mul([eph_pk], [fr_to_fq_unsafe(bob_sk)]);
+        let shared_secret = multi_scalar_mul([eph_pk], [EmbeddedCurveScalar::from_field(bob_sk)]);
 
         let result = poseidon2_decrypt(ciphertext, shared_secret, nonce);
 
@@ -194,11 +191,11 @@ mod test {
         // Alice encrypting to Bob:
 
         let bob_sk = 0x2345; // Obviously, Alice doesn't know this.
-        let bob_pk = fixed_base_scalar_mul(fr_to_fq_unsafe(bob_sk));
+        let bob_pk = fixed_base_scalar_mul(EmbeddedCurveScalar::from_field(bob_sk));
 
         let eph_sk = 0x5678;
-        let eph_pk = fixed_base_scalar_mul(fr_to_fq_unsafe(eph_sk));
-        let shared_secret = multi_scalar_mul([bob_pk], [fr_to_fq_unsafe(eph_sk)]);
+        let eph_pk = fixed_base_scalar_mul(EmbeddedCurveScalar::from_field(eph_sk));
+        let shared_secret = multi_scalar_mul([bob_pk], [EmbeddedCurveScalar::from_field(eph_sk)]);
 
         let msg = [1, 2, 3, 4, 5, 6, 7, 8, 9, 10];
 
@@ -210,7 +207,8 @@ mod test {
 
         // Bob sees: [Epk, ciphertext, nonce]:
 
-        let mut shared_secret = multi_scalar_mul([eph_pk], [fr_to_fq_unsafe(bob_sk)]);
+        let mut shared_secret =
+            multi_scalar_mul([eph_pk], [EmbeddedCurveScalar::from_field(bob_sk)]);
         // Let's intentionally corrupt the shared secret, so that decryption should fail
         shared_secret.x += 1;
 
@@ -224,10 +222,10 @@ mod test {
         // Alice encrypting to Bob:
 
         let bob_sk = 0x2345; // Obviously, Alice doesn't know this.
-        let bob_pk = fixed_base_scalar_mul(fr_to_fq_unsafe(bob_sk));
+        let bob_pk = fixed_base_scalar_mul(EmbeddedCurveScalar::from_field(bob_sk));
 
         let eph_sk = 0x5678;
-        let shared_secret = multi_scalar_mul([bob_pk], [fr_to_fq_unsafe(eph_sk)]);
+        let shared_secret = multi_scalar_mul([bob_pk], [EmbeddedCurveScalar::from_field(eph_sk)]);
 
         let nonce = 3; // TODO. Can even be a timestamp. Why is this even needed?
 

--- a/noir-projects/aztec-nr/aztec/src/encrypted_logs/log_assembly_strategies/default_aes128/note/encryption.nr
+++ b/noir-projects/aztec-nr/aztec/src/encrypted_logs/log_assembly_strategies/default_aes128/note/encryption.nr
@@ -303,7 +303,7 @@ mod test {
     };
     use super::{decrypt_log, encrypt_log, PRIVATE_LOG_PLAINTEXT_SIZE_IN_FIELDS};
     use protocol_types::{address::AztecAddress, traits::{FromField, Serialize}};
-    use std::test::OracleMock;
+    use std::{embedded_curve_ops::EmbeddedCurveScalar, test::OracleMock};
 
     #[test]
     unconstrained fn test_encrypt_decrypt_log() {
@@ -341,7 +341,7 @@ mod test {
 
         // Mock shared secret for deterministic test
         let shared_secret = derive_ecdh_shared_secret_using_aztec_address(
-            std::hash::from_field_unsafe(eph_sk),
+            EmbeddedCurveScalar::from_field(eph_sk),
             recipient,
         );
         let _ = OracleMock::mock("getSharedSecret").returns(shared_secret.serialize());

--- a/noir-projects/aztec-nr/aztec/src/encrypted_logs/log_assembly_strategies/default_aes128/note/note.nr
+++ b/noir-projects/aztec-nr/aztec/src/encrypted_logs/log_assembly_strategies/default_aes128/note/note.nr
@@ -2,7 +2,6 @@ use crate::{
     context::PrivateContext,
     encrypted_logs::log_assembly_strategies::default_aes128::note::encryption::encrypt_log,
     note::{note_emission::NoteEmission, note_interface::NoteType},
-    utils::conversion::bytes_to_fields::bytes_to_fields,
 };
 use dep::protocol_types::{
     abis::note_hash::NoteHash, address::AztecAddress, constants::PRIVATE_LOG_SIZE_IN_FIELDS,
@@ -163,9 +162,8 @@ where
     compute_log(context, note, storage_slot, recipient, sender)
 }
 
-// This function seems to be affected by the following Noir bug:
-// https://github.com/noir-lang/noir/issues/5771
-// If you get weird behavior it might be because of it.
+/// Sends an encrypted message to `recipient` with the content of the note, which they will discover when processing
+/// private logs.
 pub fn encode_and_encrypt_note<Note, let N: u32>(
     context: &mut PrivateContext,
     recipient: AztecAddress,
@@ -186,9 +184,11 @@ where
     }
 }
 
-// Important note: this function -- although called "unconstrained" -- the
-// function is not labelled as `unconstrained`, because we pass a reference to the
-// context.
+/// Same as `encode_and_encrypt_note`, except encryption is unconstrained. This means that the sender is free to make
+/// the log contents be whatever they wish, potentially resulting in scenarios in which the recipient is unable to
+/// decrypt and process the payload, **leading to the note being lost**.
+///
+/// Only use this function in scenarios where the recipient not receiving the note is an acceptable outcome.
 pub fn encode_and_encrypt_note_unconstrained<Note, let N: u32>(
     context: &mut PrivateContext,
     recipient: AztecAddress,
@@ -205,16 +205,7 @@ where
 
         assert_note_exists(*context, note_hash_counter);
 
-        //   Unconstrained logs have both their content and encryption unconstrained - it could occur that the
-        // recipient is unable to decrypt the payload.
-        //   Regarding the note hash counter, this is used for squashing. The kernel assumes that a given note can have
-        // more than one log and removes all of the matching ones, so all a malicious sender could do is either: cause
-        // for the log to be deleted when it shouldn't have (which is fine - they can already make the content be
-        // whatever), or cause for the log to not be deleted when it should have (which is also fine - it'll be a log
-        // for a note that doesn't exist).
-        //   It's important here that we do not
-        // return the log from this function to the app, otherwise it could try to do stuff with it and then that might
-        // be wrong.
+        // Safety: this function does not constrain the encryption of the log, as explainted on its description.
         let encrypted_log =
             unsafe { compute_log_unconstrained(*context, note, storage_slot, recipient, sender) };
         context.emit_raw_note_log(encrypted_log, note_hash_counter);

--- a/noir-projects/aztec-nr/aztec/src/keys/ephemeral.nr
+++ b/noir-projects/aztec-nr/aztec/src/keys/ephemeral.nr
@@ -1,4 +1,4 @@
-use std::{embedded_curve_ops::fixed_base_scalar_mul, hash::from_field_unsafe as fr_to_fq_unsafe};
+use std::embedded_curve_ops::{EmbeddedCurveScalar, fixed_base_scalar_mul};
 
 use dep::protocol_types::{point::Point, scalar::Scalar};
 
@@ -13,9 +13,9 @@ pub fn generate_ephemeral_key_pair() -> (Scalar, Point) {
     // sender will cooperate in the random value generation.
     let randomness = unsafe { random() };
 
-    // We use the unsafe version of `fr_to_fq` because fixed_base_scalar_mul (called by derive_public_key) will constrain
-    // the scalars.
-    let eph_sk = fr_to_fq_unsafe(randomness);
+    // TODO(#12757): compute the key pair without constraining eph_sk twice (once in from_field, once in the black box
+    // called by fixed_base_scalar_mul).
+    let eph_sk = EmbeddedCurveScalar::from_field(randomness);
     let eph_pk = fixed_base_scalar_mul(eph_sk);
 
     (eph_sk, eph_pk)

--- a/noir-projects/aztec-nr/aztec/src/macros/functions/utils.nr
+++ b/noir-projects/aztec-nr/aztec/src/macros/functions/utils.nr
@@ -3,7 +3,8 @@ use crate::macros::{
     notes::NOTES,
     utils::{
         add_to_hasher, fn_has_noinitcheck, get_fn_visibility, is_fn_initializer, is_fn_internal,
-        is_fn_private, is_fn_view, modify_fn_body, module_has_initializer, module_has_storage,
+        is_fn_private, is_fn_public, is_fn_view, modify_fn_body, module_has_initializer,
+        module_has_storage,
     },
 };
 use protocol_types::meta::generate_serialize_to_fields;
@@ -280,8 +281,8 @@ pub(crate) comptime fn find_and_transform_top_level_unconstrained_fns(m: Module)
     // public, but which *are* contract entrypoints (i.e. they're not opting out via the #[test] or
     // #[contract_library_method] attributes). Ideally entrypoints would be explicitly designated instead.
     let non_private_public_entrypoint_functions = m.functions().filter(|f: FunctionDefinition| {
-        !f.has_named_attribute("private")
-            & !f.has_named_attribute("public")
+        !is_fn_private(f)
+            & !is_fn_public(f)
             & !f.has_named_attribute("contract_library_method")
             & !f.has_named_attribute("test")
     });

--- a/noir-projects/aztec-nr/aztec/src/macros/mod.nr
+++ b/noir-projects/aztec-nr/aztec/src/macros/mod.nr
@@ -13,7 +13,7 @@ use notes::{generate_note_export, NOTES};
 use storage::STORAGE_LAYOUT_NAME;
 
 use dispatch::generate_public_dispatch;
-use utils::{get_trait_impl_method, is_fn_public, module_has_storage};
+use utils::{get_trait_impl_method, module_has_storage};
 
 use crate::discovery::MAX_NOTE_PACKED_LEN;
 

--- a/noir-projects/aztec-nr/bootstrap.sh
+++ b/noir-projects/aztec-nr/bootstrap.sh
@@ -12,7 +12,7 @@ function build {
   # Being a library, aztec-nr does not technically need to be built. But we can still run nargo check to find any type
   # errors and prevent warnings
   echo_stderr "Checking aztec-nr for warnings..."
-  nargo check --deny-warnings
+  $NARGO check --deny-warnings
 }
 
 function test_cmds {

--- a/noir-projects/aztec-nr/bootstrap.sh
+++ b/noir-projects/aztec-nr/bootstrap.sh
@@ -8,6 +8,13 @@ export HARDWARE_CONCURRENCY=${HARDWARE_CONCURRENCY:-16}
 export NARGO=${NARGO:-../../noir/noir-repo/target/release/nargo}
 hash=$(cache_content_hash "^noir-projects/aztec-nr")
 
+function build {
+  # Being a library, aztec-nr does not technically need to be built. But we can still run nargo check to find any type
+  # errors and prevent warnings
+  echo_stderr "Checking aztec-nr for warnings..."
+  nargo check --deny-warnings
+}
+
 function test_cmds {
   i=0
   $NARGO test --list-tests --silence-warnings | sort | while read -r package test; do
@@ -32,7 +39,11 @@ function test {
 }
 
 case "$cmd" in
+  ""|"fast"|"full")
+    build
+    ;;
   "ci")
+    build
     test
     ;;
   test|test_cmds)

--- a/noir-projects/aztec-nr/value-note/src/utils.nr
+++ b/noir-projects/aztec-nr/value-note/src/utils.nr
@@ -71,7 +71,7 @@ pub fn decrement_by_at_most(
     for i in 0..options.limit {
         if i < notes.len() {
             let note = notes.get_unchecked(i);
-            decremented += note.value;
+            decremented += note.value();
         }
     }
 

--- a/noir-projects/bootstrap.sh
+++ b/noir-projects/bootstrap.sh
@@ -23,7 +23,8 @@ function build {
   parallel --tag --line-buffered --joblog joblog.txt --halt now,fail=1 denoise "'./{}/bootstrap.sh $cmd'" ::: \
     mock-protocol-circuits \
     noir-protocol-circuits \
-    noir-contracts
+    noir-contracts \
+    aztec-nr
 }
 
 function test_cmds {


### PR DESCRIPTION
Follow up of #12727, removes all remaining aztec-nr warnings and adds a CI check to prevent us from having any further ones. Warnings are still allowed in contracts.

Warnings would typically be found while building, but we don't build aztec-nr because it being a library there's nothing to build. I added a build command regardless to follow the same pattern we have everywhere else in the boostrap scripts, and made it run `nargo check --deny-warnings`, which will error out if aztec-nr contains build errors or warnings, mirroring part of the build behavior from other packages.