### PR TITLE
chore: remove `examples` from testing of noir

### DIFF
--- a/noir/bootstrap.sh
+++ b/noir/bootstrap.sh
@@ -144,11 +144,6 @@ function test_cmds {
   echo "$test_hash cd noir/noir-repo && GIT_COMMIT=$GIT_COMMIT NARGO=$PWD/target/release/nargo yarn workspaces foreach --parallel --topological-dev --verbose $js_include run test"
   # This is a test as it runs over our test programs (format is usually considered a build step).
   echo "$test_hash noir/bootstrap.sh format --check"
-  # We need to include these as they will go out of date otherwise and externals use these examples.
-  local example_test_hash=$(hash_str $test_hash-$(../../barretenberg/cpp/bootstrap.sh hash))
-  echo "$example_test_hash noir/bootstrap.sh test_example codegen_verifier"
-  echo "$example_test_hash noir/bootstrap.sh test_example prove_and_verify"
-  echo "$example_test_hash noir/bootstrap.sh test_example recursion"
 }
 
 function format {


### PR DESCRIPTION
Testing Noir's examples inside of the monorepo is just going to cause pain and patches piling up.

These should only be updated once a new version of bb is released and used in the noir repository and if we need examples of usage against the bleeding edge of bb then this should be maintained within the barretenberg directory to avoid having to block these changes from being synced out.