### PR TITLE
fix: ci.sh gh-bench logic

### DIFF
--- a/.github/workflows/ci3.yml
+++ b/.github/workflows/ci3.yml
@@ -48,6 +48,8 @@ jobs:
         with:
           # The commit to checkout. We want our actual commit, and not the result of merging the PR to the target.
           ref: ${{ github.event.pull_request.head.sha || github.sha }}
+          # Include previous commit for master history comparisons.
+          fetch-depth: 2
 
       - name: Fail If Draft
         if: github.event.pull_request.draft && (github.event.action != 'labeled' || github.event.label.name != 'trigger-workflow')

--- a/ci.sh
+++ b/ci.sh
@@ -260,8 +260,6 @@ case "$cmd" in
       echo "SKIP_BB_BENCH=true" >> $GITHUB_ENV
     else
       cache_download barretenberg-bench-results-$bb_hash.tar.gz
-      seven_days=$((7 * 24 * 60 * 60)) # in seconds
-      echo "$bb_hash" | redis_setexz last-publish-hash-bb $seven_days
     fi
 
     # yarn-project benchmarks.
@@ -272,7 +270,6 @@ case "$cmd" in
       cache_download yarn-project-bench-results-$yp_hash.tar.gz
       # TODO reenable
       # ./cache_download yarn-project-p2p-bench-results-$(git rev-parse HEAD).tar.gz
-      echo "$bb_hash" | redis_setexz last-publish-hashs-bb $seven_days
     fi
     ;;
   "uncached-tests")

--- a/ci.sh
+++ b/ci.sh
@@ -244,7 +244,6 @@ case "$cmd" in
     # Run benchmark logic for github actions.
     bb_hash=$(barretenberg/bootstrap.sh hash)
     yp_hash=$(yarn-project/bootstrap.sh hash)
-    seven_days=$((7 * 24 * 60 * 60)) # in seconds
 
     if [ "$bb_hash" == disabled-cache ] || [ "$yp_hash" == disabled-cache ]; then
       echo "Error, can't publish benchmarks due to unstaged changes."
@@ -252,8 +251,11 @@ case "$cmd" in
       exit 1
     fi
 
+    prev_bb_hash=$(AZTEC_CACHE_COMMIT=HEAD^ barretenberg/bootstrap.sh hash)
+    prev_yp_hash=$(AZTEC_CACHE_COMMIT=HEAD^ yarn-project/bootstrap.sh hash)
+
     # barretenberg benchmarks.
-    if [ "$(redis_getz last-publish-hash-bb)" == "$bb_hash" ]; then
+    if [ "$bb_hash" == "$prev_bb_hash" ]; then
       echo "No changes since last master, skipping barretenberg benchmark publishing."
       echo "SKIP_BB_BENCH=true" >> $GITHUB_ENV
     else
@@ -263,7 +265,7 @@ case "$cmd" in
     fi
 
     # yarn-project benchmarks.
-    if [ "$(redis_getz last-publish-hash-yp)" == "$yp_hash" ]; then
+    if [ "$yp_hash" == "$prev_yp_hash" ]; then
       echo "No changes since last master, skipping yarn-project benchmark publishing."
       echo "SKIP_YP_BENCH=true" >> $GITHUB_ENV
     else

--- a/ci3/run_test_cmd
+++ b/ci3/run_test_cmd
@@ -103,9 +103,6 @@ EOF
       -H "Authorization: Bearer $SLACK_BOT_TOKEN" \
       -H "Content-type: application/json" \
       --data "$data" &>/dev/null
-  else
-    # If we can't post to slack, print to console
-    echo -e "${red}FLAKED${reset}${log_info:-}: $test_cmd (${SECONDS}s) (code: $code)"
   fi
   exit
 }


### PR DESCRIPTION
github action runner does not have redis, workaround (probably more elegant anyway)