### PR TITLE
feat: use public processor for txe private calls part 1

### DIFF
--- a/noir-projects/aztec-nr/aztec/src/test/helpers/cheatcodes.nr
+++ b/noir-projects/aztec-nr/aztec/src/test/helpers/cheatcodes.nr
@@ -3,7 +3,7 @@ use crate::test::helpers::utils::TestAccount;
 use dep::protocol_types::{
     abis::function_selector::FunctionSelector, address::AztecAddress,
     constants::CONTRACT_INSTANCE_LENGTH, contract_instance::ContractInstance,
-    public_keys::PublicKeys, traits::Deserialize,
+    public_keys::PublicKeys, traits::Deserialize, utils::reader::Reader,
 };
 
 pub unconstrained fn reset() {
@@ -87,6 +87,28 @@ pub unconstrained fn assert_private_call_fails(
     )
 }
 
+pub unconstrained fn private_call_new_flow(
+    contract_address: AztecAddress,
+    function_selector: FunctionSelector,
+    args_hash: Field,
+    start_side_effect_counter: u32,
+    is_static_call: bool,
+) -> (u32, Field) {
+    let fields = oracle_private_call_new_flow(
+        contract_address,
+        function_selector,
+        args_hash,
+        start_side_effect_counter,
+        is_static_call,
+    );
+
+    let mut reader = Reader::new(fields);
+    let end_side_effect_counter = reader.read_u32();
+    let returns_hash = reader.read();
+
+    (end_side_effect_counter, returns_hash)
+}
+
 #[oracle(reset)]
 unconstrained fn oracle_reset() {}
 
@@ -147,3 +169,12 @@ unconstrained fn oracle_assert_private_call_fails(
     sideEffectsCounter: Field,
     isStaticCall: bool,
 ) {}
+
+#[oracle(privateCallNewFlow)]
+unconstrained fn oracle_private_call_new_flow(
+    _contract_address: AztecAddress,
+    _function_selector: FunctionSelector,
+    _args_hash: Field,
+    _start_side_effect_counter: u32,
+    _is_static_call: bool,
+) -> [Field; 2] {}

--- a/noir-projects/aztec-nr/aztec/src/test/helpers/test_environment.nr
+++ b/noir-projects/aztec-nr/aztec/src/test/helpers/test_environment.nr
@@ -1,18 +1,22 @@
 use dep::protocol_types::{abis::function_selector::FunctionSelector, address::AztecAddress};
 
 use crate::context::{
-    call_interfaces::CallInterface, PrivateContext, PublicContext, UnconstrainedContext,
+    call_interfaces::CallInterface, PrivateContext, PublicContext, returns_hash::ReturnsHash,
+    UnconstrainedContext,
 };
 use crate::hash::hash_args;
 use crate::test::helpers::{cheatcodes, utils::Deployer};
 
+use crate::context::call_interfaces::PrivateCallInterface;
+use crate::context::call_interfaces::PrivateVoidCallInterface;
 use crate::note::note_interface::{NoteHash, NoteType};
 use crate::oracle::{
     execution::{get_block_number, get_contract_address},
+    execution_cache,
     notes::notify_created_note,
 };
 use protocol_types::constants::PUBLIC_DISPATCH_SELECTOR;
-use protocol_types::traits::{FromField, Packable, ToField};
+use protocol_types::traits::{Deserialize, FromField, Packable, ToField};
 
 pub struct TestEnvironment {}
 
@@ -183,6 +187,46 @@ impl TestEnvironment {
             cheatcodes::get_side_effects_counter() as Field,
             call_interface.get_is_static(),
         );
+    }
+
+    pub unconstrained fn call_private_new_flow<T, let M: u32>(
+        _self: Self,
+        call_interface: PrivateCallInterface<M, T>,
+    ) -> T
+    where
+        T: Deserialize<M>,
+    {
+        execution_cache::store(call_interface.get_args());
+        let start_side_effect_counter = cheatcodes::get_side_effects_counter();
+
+        let (_end_side_effect_counter, returns_hash) = cheatcodes::private_call_new_flow(
+            call_interface.get_contract_address(),
+            call_interface.get_selector(),
+            hash_args(call_interface.get_args()),
+            start_side_effect_counter,
+            call_interface.get_is_static(),
+        );
+
+        let returns: T = ReturnsHash::new(returns_hash).get_preimage();
+        returns
+    }
+
+    pub unconstrained fn call_private_void_new_flow<let M: u32>(
+        _self: Self,
+        call_interface: PrivateVoidCallInterface<M>,
+    ) {
+        execution_cache::store(call_interface.get_args());
+        let start_side_effect_counter = cheatcodes::get_side_effects_counter();
+
+        let (_end_side_effect_counter, returns_hash) = cheatcodes::private_call_new_flow(
+            call_interface.get_contract_address(),
+            call_interface.get_selector(),
+            hash_args(call_interface.get_args()),
+            start_side_effect_counter,
+            call_interface.get_is_static(),
+        );
+
+        ReturnsHash::new(returns_hash).assert_empty();
     }
 
     /// Manually adds a note to TXE. This needs to be called if you want to work with a note in your test with the note

--- a/noir-projects/noir-contracts/contracts/test_contract/src/test.nr
+++ b/noir-projects/noir-contracts/contracts/test_contract/src/test.nr
@@ -180,3 +180,12 @@ unconstrained fn proving_contract_non_initialization_fails() {
 
     context.historical_header.prove_contract_non_initialization(contract_address);
 }
+
+#[test]
+unconstrained fn private_call_new_flow() {
+    let (env, contract_address, owner) = setup();
+
+    env.call_private_void_new_flow(Test::at(contract_address).call_create_note(2, owner, owner, 2));
+    env.call_private_void_new_flow(Test::at(contract_address).call_create_note(3, owner, owner, 3));
+    env.call_private_void_new_flow(Test::at(contract_address).call_create_note(4, owner, owner, 4));
+}

--- a/yarn-project/txe/package.json
+++ b/yarn-project/txe/package.json
@@ -69,6 +69,7 @@
     "@aztec/pxe": "workspace:^",
     "@aztec/simulator": "workspace:^",
     "@aztec/stdlib": "workspace:^",
+    "@aztec/telemetry-client": "workspace:^",
     "@aztec/world-state": "workspace:^",
     "zod": "^3.23.8"
   },

--- a/yarn-project/txe/src/txe_service/txe_service.ts
+++ b/yarn-project/txe/src/txe_service/txe_service.ts
@@ -416,6 +416,23 @@ export class TXEService {
     return toForeignCallResult([toArray([result.endSideEffectCounter, result.returnsHash])]);
   }
 
+  async privateCallNewFlow(
+    targetContractAddress: ForeignCallSingle,
+    functionSelector: ForeignCallSingle,
+    argsHash: ForeignCallSingle,
+    sideEffectCounter: ForeignCallSingle,
+    isStaticCall: ForeignCallSingle,
+  ) {
+    const result = await (this.typedOracle as TXE).privateCallNewFlow(
+      addressFromSingle(targetContractAddress),
+      FunctionSelector.fromField(fromSingle(functionSelector)),
+      fromSingle(argsHash),
+      fromSingle(sideEffectCounter).toNumber(),
+      fromSingle(isStaticCall).toBool(),
+    );
+    return toForeignCallResult([toArray([result.endSideEffectCounter, result.returnsHash])]);
+  }
+
   async getNullifierMembershipWitness(blockNumber: ForeignCallSingle, nullifier: ForeignCallSingle) {
     const parsedBlockNumber = fromSingle(blockNumber).toNumber();
     const witness = await this.typedOracle.getNullifierMembershipWitness(parsedBlockNumber, fromSingle(nullifier));

--- a/yarn-project/txe/tsconfig.json
+++ b/yarn-project/txe/tsconfig.json
@@ -37,6 +37,9 @@
       "path": "../stdlib"
     },
     {
+      "path": "../telemetry-client"
+    },
+    {
       "path": "../world-state"
     }
   ],

--- a/yarn-project/yarn.lock
+++ b/yarn-project/yarn.lock
@@ -1419,6 +1419,7 @@ __metadata:
     "@aztec/pxe": "workspace:^"
     "@aztec/simulator": "workspace:^"
     "@aztec/stdlib": "workspace:^"
+    "@aztec/telemetry-client": "workspace:^"
     "@aztec/world-state": "workspace:^"
     "@jest/globals": "npm:^29.5.0"
     "@types/jest": "npm:^29.5.0"


### PR DESCRIPTION
This PR is currently in **draft** and looking for feedback, but shows how we can use the public processor to handle state and put the TXe even closer to a real execution model. This is a purely additive change, and implements a new endpoint on the `test_environment` as well as a cheatcode to make a private call with this new method.

Currently when we enqueue a public function call, we execute it right away. Also, we do not run the teardown function as the final call. Also, we are forced to manually add side-effects to trees and build a block. (This is currently extremely brittle with how public side-effects are handled). With this change we will correctly run functions in order, also we are letting the processor handle all the side effect management, which cuts down on the complexity by a lot and further lets us explore using a real node to process TXe transactions. 

There is one remaining outstanding issue:

- More robust note hash and nullifier management will have to be implemented, which will include cases of private function calling an external private function which emits side effects.
