### PR TITLE
fix: post-checkout hook installation to include `$@`

### DIFF
--- a/bootstrap.sh
+++ b/bootstrap.sh
@@ -114,7 +114,7 @@ function install_hooks {
   echo "./noir-projects/precommit.sh" >>$hooks_dir/pre-commit
   echo "./yarn-project/constants/precommit.sh" >>$hooks_dir/pre-commit
   chmod +x $hooks_dir/pre-commit
-  echo "(cd noir && ./postcheckout.sh $@)" >$hooks_dir/post-checkout
+  echo "(cd noir && ./postcheckout.sh \$@)" >$hooks_dir/post-checkout
   chmod +x $hooks_dir/post-checkout
 }
 


### PR DESCRIPTION
The command to install the `post-checkout` hook interpreted `$@` as empty string instead of echoing it into the file verbatim, causing the following error after a checkout:

```console
% git checkout .                                                                                                                                                                                    ...
...
./postcheckout.sh: line 8: $3: unbound variable
% cat .git/hooks/post-checkout                                    
(cd noir && ./postcheckout.sh )
```