### PR TITLE
fix: consensus URL as CLI config

### DIFF
--- a/yarn-project/aztec/src/cli/aztec_start_options.ts
+++ b/yarn-project/aztec/src/cli/aztec_start_options.ts
@@ -53,7 +53,16 @@ export const getOptions = (namespace: string, configMappings: Record<string, Con
 };
 
 // These are options used by multiple modules so should be inputted once
-export const universalOptions = ['l1RpcUrls', 'l1ChainId', 'l1Contracts', 'p2pEnabled', 'dataDirectory'];
+export const universalOptions = [
+  'l1RpcUrls',
+  'l1ConsensusHostUrl',
+  'l1ConsensusHostApiKey',
+  'l1ConsensusHostApiKeyHeader',
+  'l1ChainId',
+  'l1Contracts',
+  'p2pEnabled',
+  'dataDirectory',
+];
 
 // Define categories and options
 export const aztecStartOptions: { [key: string]: AztecStartOption[] } = {
@@ -120,6 +129,25 @@ export const aztecStartOptions: { [key: string]: AztecStartOption[] } = {
       description: 'Mnemonic for L1 accounts. Will be used if no publisher private keys are provided',
       defaultValue: DefaultMnemonic,
       envVar: 'MNEMONIC',
+    },
+    {
+      flag: '--l1-consensus-host-url <value>',
+      description: 'URL of the Ethereum consensus node that services will connect to',
+      defaultValue: undefined,
+      envVar: 'L1_CONSENSUS_HOST_URL',
+    },
+    {
+      flag: '--l1-consensus-host-api-key <value>',
+      description: 'API key for the Ethereum consensus node',
+      defaultValue: undefined,
+      envVar: 'L1_CONSENSUS_HOST_API_KEY',
+    },
+    {
+      flag: '--l1-consensus-host-api-key-header <value>',
+      description:
+        'API key header for the Ethereum consensus node. If not set, the api key will be appended to the URL as ?key=<api-key>',
+      defaultValue: undefined,
+      envVar: 'L1_CONSENSUS_HOST_API_KEY_HEADER',
     },
   ],
   'L1 CONTRACT ADDRESSES': [


### PR DESCRIPTION
Fixes #12787 

'promotes' consensus URL options to top-level CLI options, instead of  e.g. `--sequencer.l1ConsensusHostUrl`
