### PR TITLE
fix: update join split test hash

### DIFF
--- a/barretenberg/cpp/src/barretenberg/examples/join_split/join_split.test.cpp
+++ b/barretenberg/cpp/src/barretenberg/examples/join_split/join_split.test.cpp
@@ -703,7 +703,7 @@ TEST_F(join_split_tests, test_0_input_notes_and_detect_circuit_change)
     // The below part detects any changes in the join-split circuit
     constexpr size_t DYADIC_CIRCUIT_SIZE = 1 << 16;
 
-    constexpr uint256_t CIRCUIT_HASH("0x103eeb052dd7c2f8ebf531bdfadb7d3cee0ab95371289f6d507beaa24b210fba");
+    constexpr uint256_t CIRCUIT_HASH("0xee0f4a847920b66af0bcc00e760348e97612c947237834e6967be430ae54b53c");
 
     const uint256_t circuit_hash = circuit.hash_circuit();
     // circuit is finalized now


### PR DESCRIPTION
Update the circuit hash in a join split test. This changes all the time but the test is currently skipped on CI so whoever pushed the PR that changed it wasn't alerted. May wind up deleting these altogether at some point soon.