### PR TITLE
chore: simplify note getter oracle

### DIFF
--- a/noir-projects/aztec-nr/aztec/src/note/note_getter.nr
+++ b/noir-projects/aztec-nr/aztec/src/note/note_getter.nr
@@ -187,7 +187,6 @@ where
 {
     let placeholder_note = [Option::none()];
     let placeholder_fields = [0; GET_NOTE_ORACLE_RETURN_LENGTH];
-    let placeholder_note_length = [0; N];
     oracle::notes::get_notes(
         storage_slot,
         0,
@@ -205,7 +204,6 @@ where
         NoteStatus.ACTIVE,
         placeholder_note,
         placeholder_fields,
-        placeholder_note_length,
     )[0]
         .expect(f"Failed to get a note") // Notice: we don't allow dummies to be returned from get_note (singular).
 }
@@ -222,7 +220,6 @@ where
         flatten_options(options.selects, options.sorts);
     let placeholder_opt_notes = [Option::none(); MAX_NOTE_HASH_READ_REQUESTS_PER_CALL];
     let placeholder_fields = [0; GET_NOTES_ORACLE_RETURN_LENGTH];
-    let placeholder_note_length = [0; N];
 
     let opt_notes = oracle::notes::get_notes(
         storage_slot,
@@ -241,7 +238,6 @@ where
         options.status,
         placeholder_opt_notes,
         placeholder_fields,
-        placeholder_note_length,
     );
 
     apply_preprocessor(opt_notes, options.preprocessor, options.preprocessor_args)
@@ -258,7 +254,6 @@ where
         flatten_options(options.selects, options.sorts);
     let placeholder_opt_notes = [Option::none(); MAX_NOTES_PER_PAGE];
     let placeholder_fields = [0; VIEW_NOTE_ORACLE_RETURN_LENGTH];
-    let placeholder_note_length = [0; N];
 
     let notes_array = oracle::notes::get_notes(
         storage_slot,
@@ -277,7 +272,6 @@ where
         options.status,
         placeholder_opt_notes,
         placeholder_fields,
-        placeholder_note_length,
     );
 
     let mut notes = BoundedVec::new();

--- a/noir-projects/aztec-nr/aztec/src/note/note_getter.nr
+++ b/noir-projects/aztec-nr/aztec/src/note/note_getter.nr
@@ -140,9 +140,8 @@ where
     let filter_args = options.filter_args;
     let filtered_notes = filter_fn(opt_notes, filter_args);
 
-    let notes: BoundedVec<RetrievedNote<Note>, 16> = crate::utils::array::collapse(filtered_notes);
-    let mut note_hashes: BoundedVec<Field, MAX_NOTE_HASH_READ_REQUESTS_PER_CALL> =
-        BoundedVec::new();
+    let notes = crate::utils::array::collapse(filtered_notes);
+    let mut note_hashes = BoundedVec::new();
 
     // We have now collapsed the sparse array of Options into a BoundedVec. This is a more ergonomic type and also
     // results in reduced gate counts when setting a limit value, since we guarantee that the limit is an upper bound
@@ -185,9 +184,8 @@ unconstrained fn get_note_internal<Note, let N: u32>(storage_slot: Field) -> Ret
 where
     Note: NoteType + Packable<N>,
 {
-    let placeholder_note = [Option::none()];
     let placeholder_fields = [0; GET_NOTE_ORACLE_RETURN_LENGTH];
-    oracle::notes::get_notes(
+    let opt_notes: [_; 1] = oracle::notes::get_notes(
         storage_slot,
         0,
         [],
@@ -202,10 +200,10 @@ where
         1, // limit
         0, // offset
         NoteStatus.ACTIVE,
-        placeholder_note,
         placeholder_fields,
-    )[0]
-        .expect(f"Failed to get a note") // Notice: we don't allow dummies to be returned from get_note (singular).
+    );
+
+    opt_notes[0].expect(f"Failed to get a note") // Notice: we don't allow dummies to be returned from get_note (singular).
 }
 
 unconstrained fn get_notes_internal<Note, let N: u32, PREPROCESSOR_ARGS, FILTER_ARGS>(
@@ -218,7 +216,6 @@ where
     // This function simply performs some transformations from NoteGetterOptions into the types required by the oracle.
     let (num_selects, select_by_indexes, select_by_offsets, select_by_lengths, select_values, select_comparators, sort_by_indexes, sort_by_offsets, sort_by_lengths, sort_order) =
         flatten_options(options.selects, options.sorts);
-    let placeholder_opt_notes = [Option::none(); MAX_NOTE_HASH_READ_REQUESTS_PER_CALL];
     let placeholder_fields = [0; GET_NOTES_ORACLE_RETURN_LENGTH];
 
     let opt_notes = oracle::notes::get_notes(
@@ -236,7 +233,6 @@ where
         options.limit,
         options.offset,
         options.status,
-        placeholder_opt_notes,
         placeholder_fields,
     );
 
@@ -252,10 +248,9 @@ where
 {
     let (num_selects, select_by_indexes, select_by_offsets, select_by_lengths, select_values, select_comparators, sort_by_indexes, sort_by_offsets, sort_by_lengths, sort_order) =
         flatten_options(options.selects, options.sorts);
-    let placeholder_opt_notes = [Option::none(); MAX_NOTES_PER_PAGE];
     let placeholder_fields = [0; VIEW_NOTE_ORACLE_RETURN_LENGTH];
 
-    let notes_array = oracle::notes::get_notes(
+    let notes_array: [_; MAX_NOTES_PER_PAGE] = oracle::notes::get_notes(
         storage_slot,
         num_selects,
         select_by_indexes,
@@ -270,7 +265,6 @@ where
         options.limit,
         options.offset,
         options.status,
-        placeholder_opt_notes,
         placeholder_fields,
     );
 

--- a/noir-projects/aztec-nr/aztec/src/oracle/notes.nr
+++ b/noir-projects/aztec-nr/aztec/src/oracle/notes.nr
@@ -163,7 +163,6 @@ pub unconstrained fn get_notes<Note, let N: u32, let M: u32, let S: u32, let NS:
     status: u8,
     mut placeholder_opt_notes: [Option<RetrievedNote<Note>>; S], // TODO: Remove it and use `limit` to initialize the note array.
     placeholder_fields: [Field; NS], // TODO: Remove it and use `limit` to initialize the note array.
-    _placeholder_note_length: [Field; N], // Turbofish hack? Compiler breaks calculating read_offset unless we add this parameter TODO(benesjan): try removing this.
 ) -> [Option<RetrievedNote<Note>>; S]
 where
     Note: NoteType + Packable<N>,

--- a/noir-projects/aztec-nr/aztec/src/oracle/notes.nr
+++ b/noir-projects/aztec-nr/aztec/src/oracle/notes.nr
@@ -105,46 +105,7 @@ unconstrained fn get_notes_oracle<let N: u32, let S: u32>(
     _offset: u32,
     _status: u8,
     _return_size: u32,
-    _placeholder_fields: [Field; S],
 ) -> [Field; S] {}
-
-unconstrained fn get_notes_oracle_wrapper<let N: u32, let S: u32>(
-    storage_slot: Field,
-    num_selects: u8,
-    select_by_indexes: [u8; N],
-    select_by_offsets: [u8; N],
-    select_by_lengths: [u8; N],
-    select_values: [Field; N],
-    select_comparators: [u8; N],
-    sort_by_indexes: [u8; N],
-    sort_by_offsets: [u8; N],
-    sort_by_lengths: [u8; N],
-    sort_order: [u8; N],
-    limit: u32,
-    offset: u32,
-    status: u8,
-    mut placeholder_fields: [Field; S],
-) -> [Field; S] {
-    let return_size = placeholder_fields.len() as u32;
-    get_notes_oracle(
-        storage_slot,
-        num_selects,
-        select_by_indexes,
-        select_by_offsets,
-        select_by_lengths,
-        select_values,
-        select_comparators,
-        sort_by_indexes,
-        sort_by_offsets,
-        sort_by_lengths,
-        sort_order,
-        limit,
-        offset,
-        status,
-        return_size,
-        placeholder_fields,
-    )
-}
 
 pub unconstrained fn get_notes<Note, let N: u32, let M: u32, let S: u32, let NS: u32>(
     storage_slot: Field,
@@ -167,7 +128,7 @@ pub unconstrained fn get_notes<Note, let N: u32, let M: u32, let S: u32, let NS:
 where
     Note: NoteType + Packable<N>,
 {
-    let fields = get_notes_oracle_wrapper(
+    let fields: [Field; NS] = get_notes_oracle(
         storage_slot,
         num_selects,
         select_by_indexes,
@@ -182,7 +143,7 @@ where
         limit,
         offset,
         status,
-        placeholder_fields,
+        placeholder_fields.len(),
     );
     let num_notes = fields[0] as u32;
     let contract_address = AztecAddress::from_field(fields[1]);

--- a/noir-projects/aztec-nr/aztec/src/oracle/notes.nr
+++ b/noir-projects/aztec-nr/aztec/src/oracle/notes.nr
@@ -164,7 +164,7 @@ pub unconstrained fn get_notes<Note, let N: u32, let M: u32, let MAX_NOTES: u32,
 where
     Note: NoteType + Packable<N>,
 {
-    let fields: [Field; ORACLE_RETURN_FIELD_LENGTH] = get_notes_oracle_wrapper(
+    let fields: [_; ORACLE_RETURN_FIELD_LENGTH] = get_notes_oracle_wrapper(
         storage_slot,
         num_selects,
         select_by_indexes,

--- a/noir-projects/aztec-nr/aztec/src/oracle/notes.nr
+++ b/noir-projects/aztec-nr/aztec/src/oracle/notes.nr
@@ -159,7 +159,7 @@ pub unconstrained fn get_notes<Note, let N: u32, let M: u32, let MAX_NOTES: u32,
     limit: u32,
     offset: u32,
     status: u8,
-    _placeholder_fields: [Field; ORACLE_RETURN_FIELD_LENGTH], // TODO: Compute this value automatically from S
+    _placeholder_fields: [Field; ORACLE_RETURN_FIELD_LENGTH], // TODO: Compute this value automatically from MAX_NOTES
 ) -> [Option<RetrievedNote<Note>>; MAX_NOTES]
 where
     Note: NoteType + Packable<N>,

--- a/noir-projects/aztec-nr/aztec/src/oracle/notes.nr
+++ b/noir-projects/aztec-nr/aztec/src/oracle/notes.nr
@@ -89,7 +89,7 @@ unconstrained fn notify_created_nullifier_oracle_wrapper(nullifier: Field) {
 unconstrained fn notify_created_nullifier_oracle(_nullifier: Field) -> Field {}
 
 #[oracle(getNotes)]
-unconstrained fn get_notes_oracle<let N: u32, let S: u32>(
+unconstrained fn get_notes_oracle<let N: u32, let ORACLE_RETURN_FIELD_LENGTH: u32>(
     _storage_slot: Field,
     _num_selects: u8,
     _select_by_indexes: [u8; N],
@@ -105,30 +105,27 @@ unconstrained fn get_notes_oracle<let N: u32, let S: u32>(
     _offset: u32,
     _status: u8,
     _return_size: u32,
-) -> [Field; S] {}
+) -> [Field; ORACLE_RETURN_FIELD_LENGTH] {}
 
-pub unconstrained fn get_notes<Note, let N: u32, let M: u32, let S: u32, let NS: u32>(
+unconstrained fn get_notes_oracle_wrapper<let N: u32, let ORACLE_RETURN_FIELD_LENGTH: u32>(
     storage_slot: Field,
     num_selects: u8,
-    select_by_indexes: [u8; M],
-    select_by_offsets: [u8; M],
-    select_by_lengths: [u8; M],
-    select_values: [Field; M],
-    select_comparators: [u8; M],
-    sort_by_indexes: [u8; M],
-    sort_by_offsets: [u8; M],
-    sort_by_lengths: [u8; M],
-    sort_order: [u8; M],
+    select_by_indexes: [u8; N],
+    select_by_offsets: [u8; N],
+    select_by_lengths: [u8; N],
+    select_values: [Field; N],
+    select_comparators: [u8; N],
+    sort_by_indexes: [u8; N],
+    sort_by_offsets: [u8; N],
+    sort_by_lengths: [u8; N],
+    sort_order: [u8; N],
     limit: u32,
     offset: u32,
     status: u8,
-    mut placeholder_opt_notes: [Option<RetrievedNote<Note>>; S], // TODO: Remove it and use `limit` to initialize the note array.
-    placeholder_fields: [Field; NS], // TODO: Remove it and use `limit` to initialize the note array.
-) -> [Option<RetrievedNote<Note>>; S]
-where
-    Note: NoteType + Packable<N>,
-{
-    let fields: [Field; NS] = get_notes_oracle(
+) -> [Field; ORACLE_RETURN_FIELD_LENGTH] {
+    // This wrapper exists to extract the ORACLE_RETURN_FIELD_LENGTH generic numeric param into a value and pass it to
+    // the oracle, so that it knows how big the return array must be.
+    get_notes_oracle(
         storage_slot,
         num_selects,
         select_by_indexes,
@@ -143,11 +140,51 @@ where
         limit,
         offset,
         status,
-        placeholder_fields.len(),
+        ORACLE_RETURN_FIELD_LENGTH,
+    )
+}
+
+pub unconstrained fn get_notes<Note, let N: u32, let M: u32, let MAX_NOTES: u32, let ORACLE_RETURN_FIELD_LENGTH: u32>(
+    storage_slot: Field,
+    num_selects: u8,
+    select_by_indexes: [u8; M],
+    select_by_offsets: [u8; M],
+    select_by_lengths: [u8; M],
+    select_values: [Field; M],
+    select_comparators: [u8; M],
+    sort_by_indexes: [u8; M],
+    sort_by_offsets: [u8; M],
+    sort_by_lengths: [u8; M],
+    sort_order: [u8; M],
+    limit: u32,
+    offset: u32,
+    status: u8,
+    _placeholder_fields: [Field; ORACLE_RETURN_FIELD_LENGTH], // TODO: Compute this value automatically from S
+) -> [Option<RetrievedNote<Note>>; MAX_NOTES]
+where
+    Note: NoteType + Packable<N>,
+{
+    let fields: [Field; ORACLE_RETURN_FIELD_LENGTH] = get_notes_oracle_wrapper(
+        storage_slot,
+        num_selects,
+        select_by_indexes,
+        select_by_offsets,
+        select_by_lengths,
+        select_values,
+        select_comparators,
+        sort_by_indexes,
+        sort_by_offsets,
+        sort_by_lengths,
+        sort_order,
+        limit,
+        offset,
+        status,
     );
     let num_notes = fields[0] as u32;
     let contract_address = AztecAddress::from_field(fields[1]);
-    for i in 0..placeholder_opt_notes.len() {
+
+    let mut opt_notes = [Option::none(); MAX_NOTES];
+    for i in 0..opt_notes.len() {
         if i < num_notes {
             // lengths named as per typescript.
             let return_header_length: u32 = 2; // num_notes & contract_address.
@@ -165,10 +202,10 @@ where
                 metadata: NoteMetadata::from_raw_data(maybe_note_hash_counter != 0, maybe_nonce),
             };
 
-            placeholder_opt_notes[i] = Option::some(retrieved_note);
+            opt_notes[i] = Option::some(retrieved_note);
         };
     }
-    placeholder_opt_notes
+    opt_notes
 }
 
 /// Returns true if the nullifier exists. Note that a `true` value can be constrained by proving existence of the


### PR DESCRIPTION
The `get_notes` oracle is extremely messy, not maintained and not documented. I intend to simplify it a bit, use generics and structs to better convey what is going on, etc., so that we are able to actually work with it in the future (e.g. to extract a note's randomness from its contents). This is just an initial pass removing some of the superfluous array lengths and unnecessary redundant type bindings that made the thing just more difficult to read.