### PR TITLE
refactor: minor `CommitmentsDB` cleanup

### DIFF
--- a/yarn-project/pxe/src/pxe_oracle_interface/pxe_oracle_interface.ts
+++ b/yarn-project/pxe/src/pxe_oracle_interface/pxe_oracle_interface.ts
@@ -150,21 +150,12 @@ export class PXEOracleInterface implements ExecutionDataProvider {
   }
 
   // Only used in public.
-  public getL1ToL2LeafValue(_leafIndex: bigint): Promise<Fr | undefined> {
+  public getL1ToL2MessageHash(_leafIndex: bigint): Promise<Fr | undefined> {
     throw new Error('Unimplemented in private!');
   }
 
-  /**
-   * Gets the index of a commitment in the note hash tree.
-   * @param commitment - The commitment.
-   * @returns - The index of the commitment. Undefined if it does not exist in the tree.
-   */
-  async getCommitmentIndex(commitment: Fr) {
-    return await this.#findLeafIndex('latest', MerkleTreeId.NOTE_HASH_TREE, commitment);
-  }
-
   // We need this in public as part of the EXISTS calls - but isn't used in private
-  public getCommitmentValue(_leafIndex: bigint): Promise<Fr | undefined> {
+  public getNoteHash(_leafIndex: bigint): Promise<Fr | undefined> {
     throw new Error('Unimplemented in private!');
   }
 

--- a/yarn-project/simulator/src/common/db_interfaces.ts
+++ b/yarn-project/simulator/src/common/db_interfaces.ts
@@ -63,7 +63,7 @@ export interface PublicContractsDBInterface {
   getDebugFunctionName(contractAddress: AztecAddress, selector: FunctionSelector): Promise<string | undefined>;
 }
 
-/** Database interface for providing access to commitment tree, l1 to l2 message tree, and nullifier tree. */
+/** Database interface for providing access to note hash tree, l1 to l2 message tree, and nullifier tree. */
 export interface CommitmentsDBInterface {
   /**
    * Fetches a message from the db, given its key.
@@ -81,23 +81,16 @@ export interface CommitmentsDBInterface {
 
   /**
    * @param leafIndex the leaf to look up
-   * @returns The l1 to l2 leaf value or undefined if not found.
+   * @returns The l1 to l2 leaf message hash or undefined if not found.
    */
-  getL1ToL2LeafValue(leafIndex: bigint): Promise<Fr | undefined>;
+  getL1ToL2MessageHash(leafIndex: bigint): Promise<Fr | undefined>;
 
   /**
-   * Gets the index of a commitment in the note hash tree.
-   * @param commitment - The commitment.
-   * @returns - The index of the commitment. Undefined if it does not exist in the tree.
-   */
-  getCommitmentIndex(commitment: Fr): Promise<bigint | undefined>;
-
-  /**
-   * Gets commitment in the note hash tree given a leaf index.
+   * Gets note hash in the note hash tree at the given leaf index.
    * @param leafIndex - the leaf to look up.
-   * @returns - The commitment at that index. Undefined if leaf index is not found.
+   * @returns - The note hash at that index. Undefined if leaf index is not found.
    */
-  getCommitmentValue(leafIndex: bigint): Promise<Fr | undefined>;
+  getNoteHash(leafIndex: bigint): Promise<Fr | undefined>;
 
   /**
    * Gets the index of a nullifier in the nullifier tree.

--- a/yarn-project/simulator/src/public/avm/journal/journal.ts
+++ b/yarn-project/simulator/src/public/avm/journal/journal.ts
@@ -194,7 +194,7 @@ export class AvmPersistableStateManager {
    * @returns true if the note hash exists at the given leaf index, false otherwise
    */
   public async checkNoteHashExists(contractAddress: AztecAddress, noteHash: Fr, leafIndex: Fr): Promise<boolean> {
-    const gotLeafValue = (await this.treesDB.getCommitmentValue(leafIndex.toBigInt())) ?? Fr.ZERO;
+    const gotLeafValue = (await this.treesDB.getNoteHash(leafIndex.toBigInt())) ?? Fr.ZERO;
     const exists = gotLeafValue.equals(noteHash);
     this.log.trace(
       `noteHashes(${contractAddress})@${noteHash} ?? leafIndex: ${leafIndex} | gotLeafValue: ${gotLeafValue}, exists: ${exists}.`,

--- a/yarn-project/simulator/src/public/avm/test_utils.ts
+++ b/yarn-project/simulator/src/public/avm/test_utils.ts
@@ -28,7 +28,7 @@ export function mockStorageReadWithMap(worldStateDB: PublicTreesDB, mockedStorag
 }
 
 export function mockNoteHashExists(worldStateDB: PublicTreesDB, _leafIndex: Fr, value?: Fr) {
-  (worldStateDB as jest.Mocked<PublicTreesDB>).getCommitmentValue.mockImplementation((index: bigint) => {
+  (worldStateDB as jest.Mocked<PublicTreesDB>).getNoteHash.mockImplementation((index: bigint) => {
     if (index == _leafIndex.toBigInt()) {
       return Promise.resolve(value);
     } else {

--- a/yarn-project/simulator/src/public/public_db_sources.ts
+++ b/yarn-project/simulator/src/public/public_db_sources.ts
@@ -431,13 +431,13 @@ export class PublicTreesDB extends ForwardMerkleTree implements PublicStateDBInt
     return leafValue;
   }
 
-  public async getCommitmentValue(leafIndex: bigint): Promise<Fr | undefined> {
+  public async getNoteHash(leafIndex: bigint): Promise<Fr | undefined> {
     const timer = new Timer();
     const leafValue = await this.db.getLeafValue(MerkleTreeId.NOTE_HASH_TREE, leafIndex);
-    this.logger.debug(`[DB] Fetched commitment leaf value`, {
+    this.logger.debug(`[DB] Fetched note hash leaf value`, {
       eventName: 'public-db-access',
       duration: timer.ms(),
-      operation: 'get-commitment-leaf-value',
+      operation: 'get-note-hash',
     } satisfies PublicDBAccessStats);
     return leafValue;
   }


### PR DESCRIPTION
The naming made me sad + no reason to keep around unused and badly named getCommitmentIndex functionality.