### PR TITLE
fix: Stop blockstream on world-state sync error

### DIFF
--- a/yarn-project/stdlib/src/block/l2_block_downloader/l2_block_stream.ts
+++ b/yarn-project/stdlib/src/block/l2_block_downloader/l2_block_stream.ts
@@ -93,8 +93,6 @@ export class L2BlockStream {
       }
 
       // Update the proven and finalized tips.
-      // TODO(palla/reorg): Should we emit this before passing the new blocks? This would allow world-state to skip
-      // building the data structures for the pending chain if it's unneeded.
       if (localTips.proven !== undefined && sourceTips.proven.number !== localTips.proven.number) {
         await this.emitEvent({ type: 'chain-proven', blockNumber: sourceTips.proven.number });
       }

--- a/yarn-project/world-state/src/synchronizer/server_world_state_synchronizer.test.ts
+++ b/yarn-project/world-state/src/synchronizer/server_world_state_synchronizer.test.ts
@@ -209,6 +209,12 @@ describe('ServerWorldStateSynchronizer', () => {
   it('throws if you try to immediate sync when not running', async () => {
     await expect(server.syncImmediate(3)).rejects.toThrow(/is not running/i);
   });
+
+  it('throws if handling blocks fails', async () => {
+    void server.start();
+    merkleTreeDb.handleL2BlockAndMessages.mockRejectedValue(new Error('Test error'));
+    await expect(pushBlocks(1, 5)).rejects.toThrow(/Test error/i);
+  });
 });
 
 class TestWorldStateSynchronizer extends ServerWorldStateSynchronizer {

--- a/yarn-project/world-state/src/synchronizer/server_world_state_synchronizer.ts
+++ b/yarn-project/world-state/src/synchronizer/server_world_state_synchronizer.ts
@@ -207,23 +207,19 @@ export class ServerWorldStateSynchronizer
 
   /** Handles an event emitted by the block stream. */
   public async handleBlockStreamEvent(event: L2BlockStreamEvent): Promise<void> {
-    try {
-      switch (event.type) {
-        case 'blocks-added':
-          await this.handleL2Blocks(event.blocks.map(b => b.block));
-          break;
-        case 'chain-pruned':
-          await this.handleChainPruned(event.blockNumber);
-          break;
-        case 'chain-proven':
-          await this.handleChainProven(event.blockNumber);
-          break;
-        case 'chain-finalized':
-          await this.handleChainFinalized(event.blockNumber);
-          break;
-      }
-    } catch (err) {
-      this.log.error('Error processing block stream', err);
+    switch (event.type) {
+      case 'blocks-added':
+        await this.handleL2Blocks(event.blocks.map(b => b.block));
+        break;
+      case 'chain-pruned':
+        await this.handleChainPruned(event.blockNumber);
+        break;
+      case 'chain-proven':
+        await this.handleChainProven(event.blockNumber);
+        break;
+      case 'chain-finalized':
+        await this.handleChainFinalized(event.blockNumber);
+        break;
     }
   }
 


### PR DESCRIPTION
If world state failed during synchronization, we were not throwing an exception up into it the block-stream, which means we would keep pushing blocks into world state.

Example run as reported by @PhilWindle:

```
aztec-prover-node    | [16:02:02.265] DEBUG: world-state:block_stream Emitting blocks-added (20)
aztec-prover-node    | [16:02:02.265] TRACE: world_state Handling L2 blocks 1 to 20
aztec-prover-node    | [16:02:02.271] DEBUG: p2p:l2-block-stream Emitting blocks-added (20)
aztec-prover-node    | [16:02:02.271] DEBUG: p2p Handling block stream event blocks-added
aztec-prover-node    | [16:02:02.289] TRACE: world_state Pushing L2 block 1 to merkle tree db  {"blockNumber":1,"blockHash":"0x0f112802525d5a771f6faf3545fd5dddee5db815463be6e5d4af28de38dc3d96","l1ToL2Messages":[]}
aztec-prover-node    | [16:02:02.292] ERROR: world-state:database Call SYNC_BLOCK failed: Error: Can't synch block: block state does not match world state: [Error: Can't synch block: block state does not match world state] {"blockNumber":1,"blockHeaderHash":"0x0x0f112802525d5a771f6faf3545fd5dddee5db815463be6e5d4af28de38dc3d96","notesCount":0,"nullifiersCount":0,"l1ToL2MessagesCount":16,"publicDataWritesCount":0}
aztec-prover-node    | [16:02:02.293] ERROR: world_state Error processing block stream: [Error: Can't synch block: block state does not match world state]
aztec-prover-node    | [16:02:02.293] TRACE: world-state:block_stream Requesting blocks from 21 limit 20 proven=false
aztec-prover-node    | [16:02:02.302] DEBUG: world-state:block_stream Emitting blocks-added (20)
aztec-prover-node    | [16:02:02.302] TRACE: world_state Handling L2 blocks 21 to 40
aztec-prover-node    | [16:02:02.308] TRACE: world_state Pushing L2 block 21 to merkle tree db  {"blockNumber":21,"blockHash":"0x124ddde709a40f471e5e98e87a8f3ae4b05e56987f633b1876b53e92319bda01","l1ToL2Messages":[]}
aztec-prover-node    | [16:02:02.309] ERROR: world-state:database Call SYNC_BLOCK failed: Error: Can't synch block: block state does not match world state: [Error: Can't synch block: block state does not match world state] {"blockNumber":21,"blockHeaderHash":"0x0x124ddde709a40f471e5e98e87a8f3ae4b05e56987f633b1876b53e92319bda01","notesCount":0,"nullifiersCount":0,"l1ToL2MessagesCount":16,"publicDataWritesCount":0}
aztec-prover-node    | [16:02:02.310] ERROR: world_state Error processing block stream: [Error: Can't synch block: block state does not match world state]
aztec-prover-node    | [16:02:02.310] TRACE: world-state:block_stream Requesting blocks from 41 limit 20 proven=false
aztec-prover-node    | [16:02:02.322] DEBUG: world-state:block_stream Emitting blocks-added (20)
aztec-prover-node    | [16:02:02.322] TRACE: world_state Handling L2 blocks 41 to 60
aztec-prover-node    | [16:02:02.333] TRACE: world_state Pushing L2 block 41 to merkle tree db  {"blockNumber":41,"blockHash":"0x04d719c058c2289e494df6babf93637c8d1190f2f8c3357601beb3f399e993e0","l1ToL2Messages":[]}
```

By throwing, we instruct the stream to stop pushing blocks into the world-state, and wait until the next iteration to try again.

Please read [contributing guidelines](CONTRIBUTING.md) and remove this line.
