### PR TITLE
chore: use rollup.ts more consistenty

### DIFF
--- a/yarn-project/cli/src/cmds/infrastructure/sequencers.ts
+++ b/yarn-project/cli/src/cmds/infrastructure/sequencers.ts
@@ -1,5 +1,5 @@
 import { createCompatibleClient } from '@aztec/aztec.js';
-import { createEthereumChain, getL1ContractsConfigEnvVars } from '@aztec/ethereum';
+import { RollupContract, createEthereumChain, getL1ContractsConfigEnvVars } from '@aztec/ethereum';
 import type { LogFn, Logger } from '@aztec/foundation/log';
 import { RollupAbi, TestERC20Abi } from '@aztec/l1-artifacts';
 
@@ -35,11 +35,7 @@ export async function sequencers(opts: {
       })
     : undefined;
 
-  const rollup = getContract({
-    address: l1ContractAddresses.rollupAddress.toString(),
-    abi: RollupAbi,
-    client: publicClient,
-  });
+  const rollup = new RollupContract(publicClient, l1ContractAddresses.rollupAddress);
 
   const writeableRollup = walletClient
     ? getContract({
@@ -52,7 +48,7 @@ export async function sequencers(opts: {
   const who = (maybeWho as `0x{string}`) ?? walletClient?.account.address.toString();
 
   if (command === 'list') {
-    const sequencers = await rollup.read.getAttesters();
+    const sequencers = await rollup.getAttesters();
     if (sequencers.length === 0) {
       log(`No sequencers registered on rollup`);
     } else {
@@ -69,7 +65,7 @@ export async function sequencers(opts: {
     log(`Adding ${who} as sequencer`);
 
     const stakingAsset = getContract({
-      address: await rollup.read.getStakingAsset(),
+      address: await rollup.getStakingAsset(),
       abi: TestERC20Abi,
       client: walletClient,
     });
@@ -95,7 +91,7 @@ export async function sequencers(opts: {
     await publicClient.waitForTransactionReceipt({ hash });
     log(`Removed in tx ${hash}`);
   } else if (command === 'who-next') {
-    const next = await rollup.read.getCurrentProposer();
+    const next = await rollup.getCurrentProposer();
     log(`Sequencer expected to build is ${next}`);
   } else {
     throw new Error(`Unknown command ${command}`);

--- a/yarn-project/cli/src/cmds/l1/update_l1_validators.ts
+++ b/yarn-project/cli/src/cmds/l1/update_l1_validators.ts
@@ -1,5 +1,6 @@
 import {
   EthCheatCodes,
+  RollupContract,
   createEthereumChain,
   getExpectedAddress,
   getL1ContractsConfigEnvVars,
@@ -181,30 +182,26 @@ export async function fastForwardEpochs({
 export async function debugRollup({ rpcUrls, chainId, rollupAddress, log }: RollupCommandArgs & LoggerArgs) {
   const config = getL1ContractsConfigEnvVars();
   const publicClient = getPublicClient(rpcUrls, chainId);
-  const rollup = getContract({
-    address: rollupAddress.toString(),
-    abi: RollupAbi,
-    client: publicClient,
-  });
+  const rollup = new RollupContract(publicClient, rollupAddress);
 
-  const pendingNum = await rollup.read.getPendingBlockNumber();
+  const pendingNum = await rollup.getBlockNumber();
   log(`Pending block num: ${pendingNum}`);
-  const provenNum = await rollup.read.getProvenBlockNumber();
+  const provenNum = await rollup.getProvenBlockNumber();
   log(`Proven block num: ${provenNum}`);
-  const validators = await rollup.read.getAttesters();
+  const validators = await rollup.getAttesters();
   log(`Validators: ${validators.map(v => v.toString()).join(', ')}`);
-  const committee = await rollup.read.getCurrentEpochCommittee();
+  const committee = await rollup.getCurrentEpochCommittee();
   log(`Committee: ${committee.map(v => v.toString()).join(', ')}`);
-  const archive = await rollup.read.archive();
+  const archive = await rollup.archive();
   log(`Archive: ${archive}`);
-  const epochNum = await rollup.read.getCurrentEpoch();
+  const epochNum = await rollup.getEpochNumber();
   log(`Current epoch: ${epochNum}`);
-  const slot = await rollup.read.getCurrentSlot();
+  const slot = await rollup.getSlotNumber();
   log(`Current slot: ${slot}`);
-  const proposerDuringPrevL1Block = await rollup.read.getCurrentProposer();
+  const proposerDuringPrevL1Block = await rollup.getCurrentProposer();
   log(`Proposer during previous L1 block: ${proposerDuringPrevL1Block}`);
   const nextBlockTS = BigInt((await publicClient.getBlock()).timestamp + BigInt(config.ethereumSlotDuration));
-  const proposer = await rollup.read.getProposerAt([nextBlockTS]);
+  const proposer = await rollup.getProposerAt(nextBlockTS);
   log(`Proposer NOW: ${proposer.toString()}`);
 }
 

--- a/yarn-project/end-to-end/src/composed/integration_l1_publisher.test.ts
+++ b/yarn-project/end-to-end/src/composed/integration_l1_publisher.test.ts
@@ -81,7 +81,7 @@ describe('L1Publisher integration', () => {
   let rollupAddress: Address;
   let outboxAddress: Address;
 
-  let rollup: GetContractReturnType<typeof RollupAbi, ViemPublicClient>;
+  let rollup: RollupContract;
   let outbox: GetContractReturnType<typeof OutboxAbi, ViemPublicClient>;
 
   let publisher: SequencerPublisher;
@@ -111,8 +111,8 @@ describe('L1Publisher integration', () => {
 
   const progressTimeBySlot = async (slotsToJump = 1n) => {
     const currentTime = (await publicClient.getBlock()).timestamp;
-    const currentSlot = await rollup.read.getCurrentSlot();
-    const timestamp = await rollup.read.getTimestampForSlot([currentSlot + slotsToJump]);
+    const currentSlot = await rollup.getSlotNumber();
+    const timestamp = await rollup.getTimestampForSlot(currentSlot + slotsToJump);
     if (timestamp > currentTime) {
       await ethCheatCodes.warp(Number(timestamp));
     }
@@ -133,11 +133,7 @@ describe('L1Publisher integration', () => {
     outboxAddress = getAddress(l1ContractAddresses.outboxAddress.toString());
 
     // Set up contract instances
-    rollup = getContract({
-      address: rollupAddress,
-      abi: RollupAbi,
-      client: publicClient,
-    });
+    rollup = new RollupContract(publicClient, l1ContractAddresses.rollupAddress);
     outbox = getContract({
       address: outboxAddress,
       abi: OutboxAbi,
@@ -242,10 +238,10 @@ describe('L1Publisher integration', () => {
     await fork.close();
 
     const ts = (await publicClient.getBlock()).timestamp;
-    baseFee = new GasFees(0, await rollup.read.getManaBaseFeeAt([ts, true]));
+    baseFee = new GasFees(0, await rollup.getManaBaseFeeAt(ts, true));
 
     // We jump to the next epoch such that the committee can be setup.
-    const timeToJump = await rollup.read.getEpochDuration();
+    const timeToJump = await rollup.getEpochDuration();
     await progressTimeBySlot(timeToJump);
   });
 
@@ -394,7 +390,7 @@ describe('L1Publisher integration', () => {
     };
 
     const buildAndPublishBlock = async (numTxs: number, jsonFileNamePrefix: string) => {
-      const archiveInRollup_ = await rollup.read.archive();
+      const archiveInRollup_ = await rollup.archive();
       expect(hexStringToBuffer(archiveInRollup_.toString())).toEqual(new Fr(GENESIS_ARCHIVE_ROOT).toBuffer());
 
       const blockNumber = await publicClient.getBlockNumber();
@@ -421,8 +417,8 @@ describe('L1Publisher integration', () => {
         );
 
         const ts = (await publicClient.getBlock()).timestamp;
-        const slot = await rollup.read.getSlotAt([ts + BigInt(config.ethereumSlotDuration)]);
-        const timestamp = await rollup.read.getTimestampForSlot([slot]);
+        const slot = await rollup.getSlotAt(ts + BigInt(config.ethereumSlotDuration));
+        const timestamp = await rollup.getTimestampForSlot(slot);
 
         const globalVariables = new GlobalVariables(
           new Fr(chainId),
@@ -432,7 +428,7 @@ describe('L1Publisher integration', () => {
           new Fr(timestamp),
           coinbase,
           feeRecipient,
-          new GasFees(Fr.ZERO, new Fr(await rollup.read.getManaBaseFeeAt([timestamp, true]))),
+          new GasFees(Fr.ZERO, new Fr(await rollup.getManaBaseFeeAt(timestamp, true))),
         );
 
         const block = await buildBlock(globalVariables, txs, currentL1ToL2Messages);
@@ -482,7 +478,7 @@ describe('L1Publisher integration', () => {
           hash: logs[i].transactionHash!,
         });
 
-        const blobPublicInputsHash = await rollup.read.getBlobPublicInputsHash([BigInt(i + 1)]);
+        const blobPublicInputsHash = await rollup.getBlobPublicInputsHash(BigInt(i + 1));
         const expectedHash = sha256(Buffer.from(BlockBlobPublicInputs.fromBlobs(blobs).toString().substring(2), 'hex'));
         expect(blobPublicInputsHash).toEqual(`0x${expectedHash.toString('hex')}`);
 
@@ -549,7 +545,7 @@ describe('L1Publisher integration', () => {
 
     it(`shows propose custom errors if tx reverts`, async () => {
       // REFACTOR: code below is duplicated from "builds blocks of 2 empty txs building on each other"
-      const archiveInRollup_ = await rollup.read.archive();
+      const archiveInRollup_ = await rollup.archive();
       expect(hexStringToBuffer(archiveInRollup_.toString())).toEqual(new Fr(GENESIS_ARCHIVE_ROOT).toBuffer());
 
       // Set up different l1-to-l2 messages than the ones on the inbox, so this submission reverts
@@ -559,8 +555,8 @@ describe('L1Publisher integration', () => {
 
       const txs = await Promise.all([makeProcessedTx(0x1000), makeProcessedTx(0x2000)]);
       const ts = (await publicClient.getBlock()).timestamp;
-      const slot = await rollup.read.getSlotAt([ts + BigInt(config.ethereumSlotDuration)]);
-      const timestamp = await rollup.read.getTimestampForSlot([slot]);
+      const slot = await rollup.getSlotAt(ts + BigInt(config.ethereumSlotDuration));
+      const timestamp = await rollup.getTimestampForSlot(slot);
       const globalVariables = new GlobalVariables(
         new Fr(chainId),
         new Fr(config.version),
@@ -569,7 +565,7 @@ describe('L1Publisher integration', () => {
         new Fr(timestamp),
         coinbase,
         feeRecipient,
-        new GasFees(Fr.ZERO, new Fr(await rollup.read.getManaBaseFeeAt([timestamp, true]))),
+        new GasFees(Fr.ZERO, new Fr(await rollup.getManaBaseFeeAt(timestamp, true))),
       );
       const block = await buildBlock(globalVariables, txs, l1ToL2Messages);
       prevHeader = block.header;

--- a/yarn-project/end-to-end/src/e2e_cross_chain_messaging/cross_chain_messaging_test.ts
+++ b/yarn-project/end-to-end/src/e2e_cross_chain_messaging/cross_chain_messaging_test.ts
@@ -12,7 +12,7 @@ import {
 } from '@aztec/aztec.js';
 import { CheatCodes } from '@aztec/aztec.js/testing';
 import { type ViemPublicClient, createL1Clients, deployL1Contract } from '@aztec/ethereum';
-import { InboxAbi, OutboxAbi, RollupAbi, TestERC20Abi, TestERC20Bytecode } from '@aztec/l1-artifacts';
+import { InboxAbi, OutboxAbi, TestERC20Abi, TestERC20Bytecode } from '@aztec/l1-artifacts';
 import { TokenContract } from '@aztec/noir-contracts.js/Token';
 import { TokenBridgeContract } from '@aztec/noir-contracts.js/TokenBridge';
 
@@ -49,7 +49,6 @@ export class CrossChainMessagingTest {
   l2Token!: TokenContract;
   l2Bridge!: TokenBridgeContract;
 
-  rollup!: any; // GetContractReturnType<typeof RollupAbi> | undefined;
   inbox!: any; // GetContractReturnType<typeof InboxAbi> | undefined;
   outbox!: any; // GetContractReturnType<typeof OutboxAbi> | undefined;
   cheatcodes!: CheatCodes;
@@ -60,7 +59,7 @@ export class CrossChainMessagingTest {
   }
 
   async assumeProven() {
-    await this.cheatcodes.rollup.markAsProven(await this.rollup.read.getPendingBlockNumber());
+    await this.cheatcodes.rollup.markAsProven();
   }
 
   async setup() {
@@ -88,16 +87,10 @@ export class CrossChainMessagingTest {
     await this.snapshotManager.snapshot(
       '3_accounts',
       deployAccounts(3, this.logger),
-      async ({ deployedAccounts }, { pxe, aztecNodeConfig, aztecNode, deployL1ContractsValues }) => {
+      async ({ deployedAccounts }, { pxe, aztecNodeConfig, aztecNode }) => {
         this.wallets = await Promise.all(deployedAccounts.map(a => getSchnorrWallet(pxe, a.address, a.signingKey)));
         this.accounts = this.wallets.map(w => w.getCompleteAddress());
         this.wallets.forEach((w, i) => this.logger.verbose(`Wallet ${i} address: ${w.getAddress()}`));
-
-        this.rollup = getContract({
-          address: deployL1ContractsValues.l1ContractAddresses.rollupAddress.toString(),
-          abi: RollupAbi,
-          client: deployL1ContractsValues.walletClient,
-        });
 
         this.user1Wallet = this.wallets[0];
         this.user2Wallet = this.wallets[1];

--- a/yarn-project/end-to-end/src/e2e_cross_chain_messaging/token_bridge_private.test.ts
+++ b/yarn-project/end-to-end/src/e2e_cross_chain_messaging/token_bridge_private.test.ts
@@ -1,8 +1,6 @@
 import { Fr } from '@aztec/aztec.js';
 import { CheatCodes } from '@aztec/aztec.js/testing';
-import { RollupAbi } from '@aztec/l1-artifacts';
-
-import { getContract } from 'viem';
+import { RollupContract } from '@aztec/ethereum';
 
 import { CrossChainMessagingTest } from './cross_chain_messaging_test.js';
 
@@ -19,8 +17,8 @@ describe('e2e_cross_chain_messaging token_bridge_private', () => {
     l2Token,
     user1Wallet,
     user2Wallet,
-    rollup,
   } = t;
+  let rollup: RollupContract;
   let cheatCodes: CheatCodes;
 
   beforeEach(async () => {
@@ -35,11 +33,10 @@ describe('e2e_cross_chain_messaging token_bridge_private', () => {
     ownerAddress = crossChainTestHarness.ownerAddress;
     l2Bridge = crossChainTestHarness.l2Bridge;
     l2Token = crossChainTestHarness.l2Token;
-    rollup = getContract({
-      address: crossChainTestHarness.l1ContractAddresses.rollupAddress.toString(),
-      abi: RollupAbi,
-      client: crossChainTestHarness.walletClient,
-    });
+    rollup = new RollupContract(
+      crossChainTestHarness!.publicClient,
+      crossChainTestHarness!.l1ContractAddresses.rollupAddress,
+    );
 
     cheatCodes = await CheatCodes.create(t.aztecNodeConfig.l1RpcUrls, t.pxe);
   }, 300_000);
@@ -91,7 +88,7 @@ describe('e2e_cross_chain_messaging token_bridge_private', () => {
     );
 
     // Since the outbox is only consumable when the block is proven, we need to set the block to be proven
-    await cheatCodes.rollup.markAsProven(await rollup.read.getPendingBlockNumber());
+    await cheatCodes.rollup.markAsProven(await rollup.getBlockNumber());
 
     // Check balance before and after exit.
     expect(await crossChainTestHarness.getL1BalanceOf(ethAccount)).toBe(l1TokenBalance - bridgeAmount);

--- a/yarn-project/end-to-end/src/e2e_fees/fees_test.ts
+++ b/yarn-project/end-to-end/src/e2e_fees/fees_test.ts
@@ -10,10 +10,10 @@ import {
 } from '@aztec/aztec.js';
 import { CheatCodes } from '@aztec/aztec.js/testing';
 import { FEE_FUNDING_FOR_TESTER_ACCOUNT } from '@aztec/constants';
-import { type DeployL1ContractsArgs, RollupContract, createL1Clients } from '@aztec/ethereum';
+import { type DeployL1ContractsArgs, RollupContract, createL1Clients, getPublicClient } from '@aztec/ethereum';
 import { ChainMonitor } from '@aztec/ethereum/test';
 import { EthAddress } from '@aztec/foundation/eth-address';
-import { RollupAbi, TestERC20Abi } from '@aztec/l1-artifacts';
+import { TestERC20Abi } from '@aztec/l1-artifacts';
 import { AppSubscriptionContract } from '@aztec/noir-contracts.js/AppSubscription';
 import { CounterContract } from '@aztec/noir-contracts.js/Counter';
 import { FPCContract } from '@aztec/noir-contracts.js/FPC';
@@ -290,25 +290,22 @@ export class FeesTest {
         };
 
         this.getCoinbaseSequencerRewards = async () => {
-          const { walletClient } = createL1Clients(context.aztecNodeConfig.l1RpcUrls, MNEMONIC);
-          const rollup = getContract({
-            address: data.rollupAddress.toString(),
-            abi: RollupAbi,
-            client: walletClient,
+          const publicClient = getPublicClient({
+            l1RpcUrls: context.aztecNodeConfig.l1RpcUrls,
+            l1ChainId: context.aztecNodeConfig.l1ChainId,
           });
-
-          return await rollup.read.getSequencerRewards([this.coinbase.toString()]);
+          const rollup = new RollupContract(publicClient, data.rollupAddress);
+          return await rollup.getSequencerRewards(this.coinbase);
         };
 
         this.getProverFee = async (blockNumber: number) => {
-          const { walletClient } = createL1Clients(context.aztecNodeConfig.l1RpcUrls, MNEMONIC);
-          const rollup = getContract({
-            address: data.rollupAddress.toString(),
-            abi: RollupAbi,
-            client: walletClient,
+          const publicClient = getPublicClient({
+            l1RpcUrls: context.aztecNodeConfig.l1RpcUrls,
+            l1ChainId: context.aztecNodeConfig.l1ChainId,
           });
+          const rollup = new RollupContract(publicClient, data.rollupAddress);
 
-          const provingCostPerMana = await rollup.read.getProvingCostPerManaInFeeAsset();
+          const provingCostPerMana = await rollup.getProvingCostPerManaInFeeAsset();
 
           const block = await this.pxe.getBlock(blockNumber);
           const mana = block!.header.totalManaUsed.toBigInt();

--- a/yarn-project/end-to-end/src/e2e_lending_contract.test.ts
+++ b/yarn-project/end-to-end/src/e2e_lending_contract.test.ts
@@ -1,14 +1,12 @@
 import { type AccountWallet, Fr, type Logger } from '@aztec/aztec.js';
 import { CheatCodes } from '@aztec/aztec.js/testing';
-import type { DeployL1ContractsReturnType } from '@aztec/ethereum';
+import { type DeployL1ContractsReturnType, RollupContract } from '@aztec/ethereum';
 import type { TestDateProvider } from '@aztec/foundation/timer';
-import { RollupAbi } from '@aztec/l1-artifacts';
 import { LendingContract } from '@aztec/noir-contracts.js/Lending';
 import { PriceFeedContract } from '@aztec/noir-contracts.js/PriceFeed';
 import { TokenContract } from '@aztec/noir-contracts.js/Token';
 
 import { afterAll, jest } from '@jest/globals';
-import { getContract } from 'viem';
 
 import { mintTokensToPrivate } from './fixtures/token_utils.js';
 import { ensureAccountsPubliclyDeployed, setup } from './fixtures/utils.js';
@@ -67,11 +65,10 @@ describe('e2e_lending_contract', () => {
     ({ lendingContract, priceFeedContract, collateralAsset, stableCoin } = await deployContracts());
     await ensureAccountsPubliclyDeployed(wallet, [wallet]);
 
-    const rollup = getContract({
-      address: deployL1ContractsValues.l1ContractAddresses.rollupAddress.toString(),
-      abi: RollupAbi,
-      client: deployL1ContractsValues.walletClient,
-    });
+    const rollup = new RollupContract(
+      deployL1ContractsValues.publicClient,
+      deployL1ContractsValues.l1ContractAddresses.rollupAddress,
+    );
 
     lendingAccount = new LendingAccount(wallet.getAddress(), new Fr(42));
 

--- a/yarn-project/end-to-end/src/e2e_p2p/reqresp.test.ts
+++ b/yarn-project/end-to-end/src/e2e_p2p/reqresp.test.ts
@@ -1,12 +1,11 @@
 import type { AztecNodeService } from '@aztec/aztec-node';
 import { sleep } from '@aztec/aztec.js';
-import { RollupAbi } from '@aztec/l1-artifacts';
+import { RollupContract } from '@aztec/ethereum';
 
 import { jest } from '@jest/globals';
 import fs from 'fs';
 import os from 'os';
 import path from 'path';
-import { getContract } from 'viem';
 
 import { shouldCollectMetrics } from '../fixtures/fixtures.js';
 import { type NodeContext, createNodes } from '../fixtures/setup_p2p_test.js';
@@ -130,25 +129,24 @@ describe('e2e_p2p_reqresp_tx', () => {
    */
   async function getProposerIndexes() {
     // Get the nodes for the next set of slots
-    const rollupContract = getContract({
-      address: t.ctx.deployL1ContractsValues.l1ContractAddresses.rollupAddress.toString(),
-      abi: RollupAbi,
-      client: t.ctx.deployL1ContractsValues.publicClient,
-    });
+    const rollupContract = new RollupContract(
+      t.ctx.deployL1ContractsValues.publicClient,
+      t.ctx.deployL1ContractsValues.l1ContractAddresses.rollupAddress,
+    );
 
-    const attesters = await rollupContract.read.getAttesters();
+    const attesters = await rollupContract.getAttesters();
     const mappedProposers = await Promise.all(
-      attesters.map(async attester => await rollupContract.read.getProposerForAttester([attester])),
+      attesters.map(async attester => await rollupContract.getProposerForAttester(attester)),
     );
 
     const currentTime = await t.ctx.cheatCodes.eth.timestamp();
-    const slotDuration = await rollupContract.read.getSlotDuration();
+    const slotDuration = await rollupContract.getSlotDuration();
 
     const proposers = [];
 
     for (let i = 0; i < 3; i++) {
       const nextSlot = BigInt(currentTime) + BigInt(i) * BigInt(slotDuration);
-      const proposer = await rollupContract.read.getProposerAt([nextSlot]);
+      const proposer = await rollupContract.getProposerAt(nextSlot);
       proposers.push(proposer);
     }
     // Get the indexes of the nodes that are responsible for the next two slots

--- a/yarn-project/end-to-end/src/e2e_prover/full.test.ts
+++ b/yarn-project/end-to-end/src/e2e_prover/full.test.ts
@@ -1,8 +1,9 @@
 import { type AztecAddress, EthAddress, waitForProven } from '@aztec/aztec.js';
+import { RollupContract } from '@aztec/ethereum';
 import { parseBooleanEnv } from '@aztec/foundation/config';
 import { getTestData, isGenerateTestDataEnabled } from '@aztec/foundation/testing';
 import { updateProtocolCircuitSampleInputs } from '@aztec/foundation/testing/files';
-import { FeeJuicePortalAbi, RewardDistributorAbi, RollupAbi, TestERC20Abi } from '@aztec/l1-artifacts';
+import { FeeJuicePortalAbi, RewardDistributorAbi, TestERC20Abi } from '@aztec/l1-artifacts';
 
 import TOML from '@iarna/toml';
 import '@jest/globals';
@@ -25,7 +26,7 @@ describe('full_prover', () => {
   let sender: AztecAddress;
   let recipient: AztecAddress;
 
-  let rollup: GetContractReturnType<typeof RollupAbi, PublicClient<HttpTransport, Chain>>;
+  let rollup: RollupContract;
   let rewardDistributor: GetContractReturnType<typeof RewardDistributorAbi, PublicClient<HttpTransport, Chain>>;
   let feeJuiceToken: GetContractReturnType<typeof TestERC20Abi, PublicClient<HttpTransport, Chain>>;
   let feeJuicePortal: GetContractReturnType<typeof FeeJuicePortalAbi, PublicClient<HttpTransport, Chain>>;
@@ -41,11 +42,7 @@ describe('full_prover', () => {
     ({ provenAssets, accounts, tokenSim, logger, cheatCodes } = t);
     [sender, recipient] = accounts.map(a => a.address);
 
-    rollup = getContract({
-      abi: RollupAbi,
-      address: t.l1Contracts.l1ContractAddresses.rollupAddress.toString(),
-      client: t.l1Contracts.publicClient,
-    });
+    rollup = new RollupContract(t.l1Contracts.publicClient, t.l1Contracts.l1ContractAddresses.rollupAddress);
 
     rewardDistributor = getContract({
       abi: RewardDistributorAbi,
@@ -136,12 +133,9 @@ describe('full_prover', () => {
       logger.info(`Advancing from epoch ${epoch} to next epoch`);
       await cheatCodes.rollup.advanceToNextEpoch();
 
-      const rewardsBeforeCoinbase = await rollup.read.getSequencerRewards([COINBASE_ADDRESS.toString()]);
-      const rewardsBeforeProver = await rollup.read.getSpecificProverRewardsForEpoch([
-        epoch,
-        t.proverAddress.toString(),
-      ]);
-      const oldProvenBlockNumber = await rollup.read.getProvenBlockNumber();
+      const rewardsBeforeCoinbase = await rollup.getSequencerRewards(COINBASE_ADDRESS);
+      const rewardsBeforeProver = await rollup.getSpecificProverRewardsForEpoch(epoch, t.proverAddress);
+      const oldProvenBlockNumber = await rollup.getProvenBlockNumber();
 
       // And wait for the first pair of txs to be proven
       logger.info(`Awaiting proof for the previous epoch`);
@@ -152,18 +146,15 @@ describe('full_prover', () => {
         }),
       );
 
-      const newProvenBlockNumber = await rollup.read.getProvenBlockNumber();
+      const newProvenBlockNumber = await rollup.getProvenBlockNumber();
       expect(newProvenBlockNumber).toBeGreaterThan(oldProvenBlockNumber);
-      expect(await rollup.read.getPendingBlockNumber()).toBe(newProvenBlockNumber);
+      expect(await rollup.getBlockNumber()).toBe(newProvenBlockNumber);
 
       logger.info(`checking rewards for coinbase: ${COINBASE_ADDRESS.toString()}`);
-      const rewardsAfterCoinbase = await rollup.read.getSequencerRewards([COINBASE_ADDRESS.toString()]);
+      const rewardsAfterCoinbase = await rollup.getSequencerRewards(COINBASE_ADDRESS);
       expect(rewardsAfterCoinbase).toBeGreaterThan(rewardsBeforeCoinbase);
 
-      const rewardsAfterProver = await rollup.read.getSpecificProverRewardsForEpoch([
-        epoch,
-        t.proverAddress.toString(),
-      ]);
+      const rewardsAfterProver = await rollup.getSpecificProverRewardsForEpoch(epoch, t.proverAddress);
       expect(rewardsAfterProver).toBeGreaterThan(rewardsBeforeProver);
 
       const blockReward = (await rewardDistributor.read.BLOCK_REWARD()) as bigint;

--- a/yarn-project/end-to-end/src/simulators/lending_simulator.ts
+++ b/yarn-project/end-to-end/src/simulators/lending_simulator.ts
@@ -1,13 +1,10 @@
 // Convenience struct to hold an account's address and secret that can easily be passed around.
 import { AztecAddress, Fr } from '@aztec/aztec.js';
 import { CheatCodes } from '@aztec/aztec.js/testing';
+import type { RollupContract } from '@aztec/ethereum';
 import { pedersenHash } from '@aztec/foundation/crypto';
 import type { TestDateProvider } from '@aztec/foundation/timer';
-import type { RollupAbi } from '@aztec/l1-artifacts';
 import type { LendingContract } from '@aztec/noir-contracts.js/Lending';
-
-import type { Account, GetContractReturnType, HttpTransport, WalletClient } from 'viem';
-import type * as chains from 'viem/chains';
 
 import type { TokenSimulator } from './token_simulator.js';
 
@@ -84,7 +81,7 @@ export class LendingSimulator {
     private rate: bigint,
     private ethereumSlotDuration: number,
     /** the rollup contract */
-    public rollup: GetContractReturnType<typeof RollupAbi, WalletClient<HttpTransport, chains.Chain, Account>>,
+    public rollup: RollupContract,
     /** the lending contract */
     public lendingContract: LendingContract,
     /** the collateral asset used in the lending contract */
@@ -95,10 +92,8 @@ export class LendingSimulator {
 
   async prepare() {
     this.accumulator = BASE;
-    const slot = await this.rollup.read.getSlotAt([
-      BigInt(await this.cc.eth.timestamp()) + BigInt(this.ethereumSlotDuration),
-    ]);
-    this.time = Number(await this.rollup.read.getTimestampForSlot([slot]));
+    const slot = await this.rollup.getSlotAt(BigInt(await this.cc.eth.timestamp()) + BigInt(this.ethereumSlotDuration));
+    this.time = Number(await this.rollup.getTimestampForSlot(slot));
   }
 
   async progressSlots(diff: number, dateProvider?: TestDateProvider) {
@@ -106,8 +101,8 @@ export class LendingSimulator {
       return;
     }
 
-    const slot = await this.rollup.read.getSlotAt([BigInt(await this.cc.eth.timestamp())]);
-    const ts = Number(await this.rollup.read.getTimestampForSlot([slot + BigInt(diff)]));
+    const slot = await this.rollup.getSlotAt(BigInt(await this.cc.eth.timestamp()));
+    const ts = Number(await this.rollup.getTimestampForSlot(slot + BigInt(diff)));
     const timeDiff = ts - this.time;
     this.time = ts;
 
@@ -116,7 +111,7 @@ export class LendingSimulator {
     if (dateProvider) {
       dateProvider.setTime(this.time * 1000);
     }
-    await this.cc.rollup.markAsProven(await this.rollup.read.getPendingBlockNumber());
+    await this.cc.rollup.markAsProven(await this.rollup.getBlockNumber());
     this.accumulator = muldivDown(this.accumulator, computeMultiplier(this.rate, BigInt(timeDiff)), BASE);
   }
 

--- a/yarn-project/end-to-end/src/spartan/smoke.test.ts
+++ b/yarn-project/end-to-end/src/spartan/smoke.test.ts
@@ -1,9 +1,8 @@
 import { type PXE, createCompatibleClient } from '@aztec/aztec.js';
+import { RollupContract, getPublicClient } from '@aztec/ethereum';
 import { createLogger } from '@aztec/foundation/log';
-import { RollupAbi } from '@aztec/l1-artifacts';
 
 import type { ChildProcess } from 'child_process';
-import { createPublicClient, getAddress, getContract, http } from 'viem';
 import { foundry } from 'viem/chains';
 
 import { isK8sConfig, setupEnvironment, startPortForward } from './utils.js';
@@ -49,20 +48,16 @@ describe('smoke test', () => {
 
   it.skip('should be able to get rollup info', async () => {
     const info = await pxe.getNodeInfo();
-    const publicClient = createPublicClient({
-      chain: foundry,
-      transport: http('http://localhost:8545'),
+    const publicClient = getPublicClient({
+      l1RpcUrls: ['http://localhost:8545'],
+      l1ChainId: foundry.id,
     });
 
-    const rollupContract = getContract({
-      address: getAddress(info.l1ContractAddresses.rollupAddress.toString()),
-      abi: RollupAbi,
-      client: publicClient,
-    });
+    const rollupContract = new RollupContract(publicClient, info.l1ContractAddresses.rollupAddress);
 
     // eslint-disable-next-line @typescript-eslint/no-unused-vars
     const [pendingBlockNum, pendingArchive, provenBlockNum, provenArchive, myArchive, provenEpochNumber] =
-      await rollupContract.read.status([60n]);
+      await rollupContract.status(60n);
     // console.log('pendingBlockNum', pendingBlockNum.toString());
     // console.log('pendingArchive', pendingArchive.toString());
     // console.log('provenBlockNum', provenBlockNum.toString());

--- a/yarn-project/ethereum/src/contracts/rollup.ts
+++ b/yarn-project/ethereum/src/contracts/rollup.ts
@@ -73,6 +73,10 @@ export class RollupContract {
     return this.rollup.address;
   }
 
+  getContract(): GetContractReturnType<typeof RollupAbi, ViemPublicClient> {
+    return this.rollup;
+  }
+
   @memoize
   public async getSlashingProposer() {
     const slasherAddress = await this.rollup.read.getSlasher();
@@ -127,12 +131,21 @@ export class RollupContract {
   }
 
   @memoize
+  getProvingCostPerManaInFeeAsset() {
+    return this.rollup.read.getProvingCostPerManaInFeeAsset();
+  }
+
+  @memoize
   getManaLimit() {
     return this.rollup.read.getManaLimit();
   }
 
+  getSlasher() {
+    return this.rollup.read.getSlasher();
+  }
+
   public async getSlashingProposerAddress() {
-    const slasherAddress = await this.rollup.read.getSlasher();
+    const slasherAddress = await this.getSlasher();
     const slasher = getContract({
       address: getAddress(slasherAddress.toString()),
       abi: SlasherAbi,
@@ -285,7 +298,82 @@ export class RollupContract {
   }
 
   /** Calls getHasSubmitted directly. Returns whether the given prover has submitted a proof with the given length for the given epoch. */
-  public getHasSubmittedProof(epochNumber: number, numberOfBlocksInEpoch: number, prover: EthAddress) {
-    return this.rollup.read.getHasSubmitted([BigInt(epochNumber), BigInt(numberOfBlocksInEpoch), prover.toString()]);
+  public getHasSubmittedProof(epochNumber: number, numberOfBlocksInEpoch: number, prover: Hex | EthAddress) {
+    if (prover instanceof EthAddress) {
+      prover = prover.toString();
+    }
+    return this.rollup.read.getHasSubmitted([BigInt(epochNumber), BigInt(numberOfBlocksInEpoch), prover]);
+  }
+
+  getManaBaseFeeAt(timestamp: bigint, inFeeAsset: boolean) {
+    return this.rollup.read.getManaBaseFeeAt([timestamp, inFeeAsset]);
+  }
+
+  getVersion() {
+    return this.rollup.read.getVersion();
+  }
+
+  getSlotAt(timestamp: bigint) {
+    return this.rollup.read.getSlotAt([timestamp]);
+  }
+
+  status(blockNumber: bigint, options?: { blockNumber?: bigint }) {
+    return this.rollup.read.status([blockNumber], options);
+  }
+
+  canPruneAtTime(timestamp: bigint, options?: { blockNumber?: bigint }) {
+    return this.rollup.read.canPruneAtTime([timestamp], options);
+  }
+
+  archive() {
+    return this.rollup.read.archive();
+  }
+
+  archiveAt(blockNumber: bigint) {
+    return this.rollup.read.archiveAt([blockNumber]);
+  }
+
+  getSequencerRewards(address: Hex | EthAddress) {
+    if (address instanceof EthAddress) {
+      address = address.toString();
+    }
+    return this.rollup.read.getSequencerRewards([address]);
+  }
+
+  getSpecificProverRewardsForEpoch(epoch: bigint, prover: Hex | EthAddress) {
+    if (prover instanceof EthAddress) {
+      prover = prover.toString();
+    }
+    return this.rollup.read.getSpecificProverRewardsForEpoch([epoch, prover]);
+  }
+
+  getAttesters() {
+    return this.rollup.read.getAttesters();
+  }
+
+  getEpochCommittee(epoch: bigint) {
+    return this.rollup.read.getEpochCommittee([epoch]);
+  }
+
+  getInfo(address: Hex | EthAddress) {
+    if (address instanceof EthAddress) {
+      address = address.toString();
+    }
+    return this.rollup.read.getInfo([address]);
+  }
+
+  getBlobPublicInputsHash(blockNumber: bigint) {
+    return this.rollup.read.getBlobPublicInputsHash([blockNumber]);
+  }
+
+  getStakingAsset() {
+    return this.rollup.read.getStakingAsset();
+  }
+
+  getProposerForAttester(attester: Hex | EthAddress) {
+    if (attester instanceof EthAddress) {
+      attester = attester.toString();
+    }
+    return this.rollup.read.getProposerForAttester([attester]);
   }
 }

--- a/yarn-project/ethereum/src/deploy_l1_contracts.test.ts
+++ b/yarn-project/ethereum/src/deploy_l1_contracts.test.ts
@@ -2,13 +2,12 @@ import { times } from '@aztec/foundation/collection';
 import { EthAddress } from '@aztec/foundation/eth-address';
 import { Fr } from '@aztec/foundation/fields';
 import { type Logger, createLogger } from '@aztec/foundation/log';
-import { RollupAbi } from '@aztec/l1-artifacts/RollupAbi';
 
-import { getContract } from 'viem';
 import { type PrivateKeyAccount, privateKeyToAccount } from 'viem/accounts';
 
 import { createEthereumChain } from './chain.js';
 import { DefaultL1ContractsConfig } from './config.js';
+import { RollupContract } from './contracts/rollup.js';
 import { type DeployL1ContractsArgs, deployL1Contracts } from './deploy_l1_contracts.js';
 import { startAnvil } from './test/start_anvil.js';
 
@@ -70,11 +69,7 @@ describe('deploy_l1_contracts', () => {
     });
 
   const getRollup = (deployed: Awaited<ReturnType<typeof deploy>>) =>
-    getContract({
-      address: deployed.l1ContractAddresses.rollupAddress.toString(),
-      abi: RollupAbi,
-      client: deployed.publicClient,
-    });
+    new RollupContract(deployed.publicClient, deployed.l1ContractAddresses.rollupAddress);
 
   it('deploys without salt', async () => {
     await deploy();
@@ -84,7 +79,7 @@ describe('deploy_l1_contracts', () => {
     const deployed = await deploy({ initialValidators });
     const rollup = getRollup(deployed);
     for (const validator of initialValidators) {
-      const { status } = await rollup.read.getInfo([validator.toString()]);
+      const { status } = await rollup.getInfo(validator);
       expect(status).toBeGreaterThan(0);
     }
   });
@@ -111,7 +106,7 @@ describe('deploy_l1_contracts', () => {
 
     const rollup = getRollup(first);
     for (const validator of initialValidators) {
-      const { status } = await rollup.read.getInfo([validator.toString()]);
+      const { status } = await rollup.getInfo(validator);
       expect(status).toBeGreaterThan(0);
     }
   });

--- a/yarn-project/ethereum/src/deploy_l1_contracts.ts
+++ b/yarn-project/ethereum/src/deploy_l1_contracts.ts
@@ -390,19 +390,15 @@ export const cheat_initializeValidatorSet = async (
   acceleratedTestDeployments: boolean | undefined,
   logger: Logger,
 ) => {
-  const rollup = getContract({
-    address: getAddress(rollupAddress.toString()),
-    abi: l1Artifacts.rollup.contractAbi,
-    client: clients.walletClient,
-  });
-  const minimumStake = await rollup.read.getMinimumStake();
+  const rollup = new RollupContract(clients.publicClient, rollupAddress);
+  const minimumStake = await rollup.getMinimumStake();
   if (validators && validators.length > 0) {
     // Check if some of the initial validators are already registered, so we support idempotent deployments
     if (!acceleratedTestDeployments) {
       const validatorsInfo = await Promise.all(
         validators.map(async address => ({
           address,
-          ...(await rollup.read.getInfo([address])),
+          ...(await rollup.getInfo(address)),
         })),
       );
       const existingValidators = validatorsInfo.filter(v => v.status !== 0);


### PR DESCRIPTION
To ease the work in #12753, we have done a bunch of refactoring in this one to use the `rollup.ts` more throughout the code base. This will make it simpler to alter the code for simualtion as viem is not happy about doing a `read` for a function that is not `view` and we need to fiddle a bit there.