### PR TITLE
fix: add random deployment salt to sandbox

### DIFF
--- a/aztec-up/bin/aztec
+++ b/aztec-up/bin/aztec
@@ -65,8 +65,6 @@ case ${1:-} in
       # We should not have to provide a binary path and working dir.
       # Why is this not just determined and chosen at runtime?
       # In fact almost none of these should not have to be set if we have sensible defaults.
-      export BB_BINARY_PATH=/usr/src/barretenberg/cpp/build/bin/bb
-      export BB_WORKING_DIRECTORY=/tmp/bb
       export L1_CHAIN_ID=31337
       export ARCHIVER_POLLING_INTERVAL_MS=500
       export P2P_BLOCK_CHECK_INTERVAL_MS=500
@@ -75,6 +73,8 @@ case ${1:-} in
       export ARCHIVER_VIEM_POLLING_INTERVAL_MS=500
       export TEST_ACCOUNTS=${TEST_ACCOUNTS:-true}
       export LOG_LEVEL=${LOG_LEVEL:-info}
+      export DEPLOY_AZTEC_CONTRACTS_SALT=${DEPLOY_AZTEC_CONTRACTS_SALT:-$RANDOM}
+
 
       ANVIL_PORT=${ANVIL_PORT:-8545}
       anvil_port_assignment="$ANVIL_PORT:8545"


### PR DESCRIPTION
This PR fixes an issue where the rollup address wouldn't change across sandbox restarts. This caused issues in the wallet since it doesn't clear its database and tries to reference blocks that don't exist in the new sandbox instance. [Slack thread](https://aztecprotocol.slack.com/archives/C02M7VC7TN0/p1742295888239059)

This happens because the codepath that deploys L1 contracts without salt uses `CREATE` which uses the account nonce to determine the deployed address, so if we deploy the same contracts, same bytecode in the same order we'll get the same addresses back.

https://github.com/AztecProtocol/aztec-packages/blob/66a62d070c4873034c32c864f3f2f8ded1999ea4/yarn-project/ethereum/src/deploy_l1_contracts.ts#L930-L962

This PR adds a random salt (by default) to sandbox such that it deploys the rollup to a random address every time. It also removes the `BB_*` env vars because they were added to the image a coupld of weeks ago