### PR TITLE
fix: Run aztec-up tests as ubuntu not root.

### DIFF
--- a/aztec-up/bin/aztec-install
+++ b/aztec-up/bin/aztec-install
@@ -97,7 +97,7 @@ function update_path_env_var {
     SHELL_PROFILE=""
     case $SHELL in
     */bash)
-      SHELL_PROFILE="$HOME/.bashrc"
+      SHELL_PROFILE="$HOME/.bash_profile"
       ;;
     */zsh)
       SHELL_PROFILE="$HOME/.zshrc"

--- a/aztec-up/scripts/run_test.sh
+++ b/aztec-up/scripts/run_test.sh
@@ -7,12 +7,13 @@ docker run --rm \
   -d \
   --privileged \
   --name $1 \
-  -v$(git rev-parse --show-toplevel):/root/aztec-packages:ro \
-  -v$HOME/.bb-crs:/root/.bb-crs \
+  -v$(git rev-parse --show-toplevel):/home/ubuntu/aztec-packages:ro \
+  -v$HOME/.bb-crs:/home/ubuntu/.bb-crs \
   --mount type=tmpfs,target=/var/lib/docker,tmpfs-size=4g \
   aztecprotocol/dind \
   bash -c "
     /usr/local/share/docker-init.sh &>/dev/null
+    chmod 777 /var/run/docker.sock
     tail -f /dev/null
   " >/dev/null
 
@@ -28,7 +29,7 @@ if [ -t 0 ]; then
   fail_shell="|| exec bash"
 fi
 
-docker exec ${args:-} -w/root $1 \
+docker exec ${args:-} -w/home/ubuntu --user ubuntu:ubuntu $1 \
   bash -c "
     ./aztec-packages/aztec-up/test/$1.sh ${fail_shell:-}
   "

--- a/aztec-up/test/basic_install.sh
+++ b/aztec-up/test/basic_install.sh
@@ -7,9 +7,14 @@ if [ ! -f /aztec_release_test_container ]; then
   exit 1
 fi
 
+if [ "$(whoami)" != "ubuntu" ]; then
+  echo "Not running as ubuntu. Exiting."
+  exit 1
+fi
+
 export SKIP_PULL=1
 export NO_NEW_SHELL=1
-export INSTALL_URI=file:///root/aztec-packages/aztec-up/bin
+export INSTALL_URI=file:///home/ubuntu/aztec-packages/aztec-up/bin
 
 if [ -t 0 ]; then
   bash_args="-i"
@@ -21,7 +26,7 @@ bash ${bash_args:-} <(curl -s $INSTALL_URI/aztec-install)
 
 # We can't create a new shell for this test, so just re-source our modified .bashrc to get updated PATH.
 set +eu
-PS1=" " source ~/.bashrc
+PS1=" " source ~/.bash_profile
 set -eu
 
 # aztec-nargo -V

--- a/aztec-up/test/counter_contract.sh
+++ b/aztec-up/test/counter_contract.sh
@@ -7,9 +7,14 @@ if [ ! -f /aztec_release_test_container ]; then
   exit 1
 fi
 
+if [ "$(whoami)" != "ubuntu" ]; then
+  echo "Not running as ubuntu. Exiting."
+  exit 1
+fi
+
 export SKIP_PULL=1
 export NO_NEW_SHELL=1
-export INSTALL_URI=file:///root/aztec-packages/aztec-up/bin
+export INSTALL_URI=file:///home/ubuntu/aztec-packages/aztec-up/bin
 
 if [ -t 0 ]; then
   bash_args="-i"
@@ -21,7 +26,7 @@ bash ${bash_args:-} <(curl -s $INSTALL_URI/aztec-install)
 
 # We can't create a new shell for this test, so just re-source our modified .bashrc to get updated PATH.
 set +eu
-PS1=" " source ~/.bashrc
+PS1=" " source ~/.bash_profile
 set -eu
 
 export LOG_LEVEL=silent
@@ -39,10 +44,16 @@ if [ ! -f counter_contract/Nargo.toml ] || [ ! -f counter_contract/src/main.nr ]
   exit 1
 fi
 
+# Check counter_contract dir is owned by aztec-dev.
+if [ "$(stat -c %U counter_contract)" != "ubuntu" ]; then
+  echo "counter_contract dir is not owned by ubuntu."
+  exit 1
+fi
+
 # "Write" our contract.
-cp -Rf /root/aztec-packages/noir-projects/noir-contracts/contracts/counter_contract .
+cp -Rf ./aztec-packages/noir-projects/noir-contracts/contracts/counter_contract .
 cd counter_contract
-sed -i 's|\.\./\.\./\.\./|/root/aztec-packages/noir-projects/|g' Nargo.toml
+sed -i 's|\.\./\.\./\.\./|/home/ubuntu/aztec-packages/noir-projects/|g' Nargo.toml
 
 # Compile and codegen.
 aztec-nargo compile

--- a/ci3/npm_install_deps
+++ b/ci3/npm_install_deps
@@ -10,9 +10,10 @@ if [ ! -f yarn.lock ]; then
 fi
 
 yarn_lock_path=$(realpath yarn.lock --relative-to=$root)
+package_json_path=$(realpath package.json --relative-to=$root)
 
 if [ "$CI" -eq 1 ]; then
-  nm_hash=$(cache_content_hash "^$yarn_lock_path")
+  nm_hash=$(cache_content_hash "^$yarn_lock_path" "^$package_json_path")
   if ! cache_download node-modules-$nm_hash.zst; then
     denoise "retry 'yarn install --immutable'"
     cache_upload node-modules-$nm_hash.zst node_modules

--- a/noir/bootstrap.sh
+++ b/noir/bootstrap.sh
@@ -24,8 +24,8 @@ export RUSTFLAGS="-Dwarnings"
 
 # Update the noir-repo and compute hashes.
 function noir_sync {
-  # The sync.sh script strives not to send anything to `stdout`, so as not to interfere with `test_cmds` and `hash`.
-  DENOISE=0 denoise "scripts/sync.sh init && scripts/sync.sh update"
+  # Don't send anything to `stdout`, so as not to interfere with `test_cmds` and `hash`.
+  denoise "scripts/sync.sh init && scripts/sync.sh update" >&2
 }
 
 # Calculate the content hash for caching, taking into account that `noir-repo`


### PR DESCRIPTION
* Regressions appeared r.e. files created as root. We now run these tests as ubuntu and check the files get the right owner.
* Also sneaking in package.json in node_modules cache hash.
