### PR TITLE
fix: Don't log config

### DIFF
--- a/yarn-project/aztec/src/sandbox/sandbox.ts
+++ b/yarn-project/aztec/src/sandbox/sandbox.ts
@@ -208,7 +208,6 @@ export async function createAztecNode(
     ...config,
     l1Contracts: { ...l1Contracts, ...config.l1Contracts },
   };
-  logger.info('createAztecNode', aztecNodeConfig);
   const node = await AztecNodeService.createAndSync(aztecNodeConfig, deps, options);
   return node;
 }


### PR DESCRIPTION
We shouldn't just log out the complete node configuration. It may contain sensitive data.
