### PR TITLE
fix: config ordering

### DIFF
--- a/yarn-project/aztec-node/src/aztec-node/config.ts
+++ b/yarn-project/aztec-node/src/aztec-node/config.ts
@@ -31,13 +31,13 @@ export type AztecNodeConfig = ArchiverConfig &
   };
 
 export const aztecNodeConfigMappings: ConfigMappingsType<AztecNodeConfig> = {
+  ...dataConfigMappings,
   ...archiverConfigMappings,
   ...sequencerClientConfigMappings,
   ...validatorClientConfigMappings,
   ...proverClientConfigMappings,
   ...worldStateConfigMappings,
   ...p2pConfigMappings,
-  ...dataConfigMappings,
   disableValidator: {
     env: 'VALIDATOR_DISABLED',
     description: 'Whether the validator is disabled for this node.',

--- a/yarn-project/prover-client/src/proving_broker/config.ts
+++ b/yarn-project/prover-client/src/proving_broker/config.ts
@@ -71,8 +71,8 @@ export const proverBrokerConfigMappings: ConfigMappingsType<ProverBrokerConfig> 
     parseEnv: (val: string | undefined) => (val ? +val : undefined),
     description: "The size of the prover broker's database. Will override the dataStoreMapSizeKB if set.",
   },
-  ...l1ReaderConfigMappings,
   ...dataConfigMappings,
+  ...l1ReaderConfigMappings,
 };
 
 export const defaultProverBrokerConfig: ProverBrokerConfig = getDefaultConfig(proverBrokerConfigMappings);


### PR DESCRIPTION
https://github.com/AztecProtocol/aztec-packages/pull/12853 broke the kind smoke test.
[Logs](http://ci.aztec-labs.com/e4f1db4df1b97da2)

You can see
```
17:24:33 Logs from smoke-aztec-network-boot-node-0:
17:24:33             ^
17:24:33 
17:24:33 Error: L1 registry address is required to start Aztec Node without --deploy-aztec-contracts option
17:24:33     at startNode (file:///usr/src/yarn-project/aztec/dest/cli/cmds/start_node.js:49:19)
17:24:33     at async aztecStart (file:///usr/src/yarn-project/aztec/dest/cli/aztec_start_action.js:51:27)
17:24:33     at async Command.<anonymous> (file:///usr/src/yarn-project/aztec/dest/cli/cli.js:17:16)
17:24:33     at async Command.parseAsync (/usr/src/yarn-project/node_modules/commander/lib/command.js:1092:5)
17:24:33     at async main (file:///usr/src/yarn-project/aztec/dest/bin/index.js:35:5)
```