### PR TITLE
fix: Removed logged config object in L1 Tx Utils

### DIFF
--- a/yarn-project/aztec/terraform/node/main.tf
+++ b/yarn-project/aztec/terraform/node/main.tf
@@ -289,14 +289,6 @@ resource "aws_ecs_task_definition" "aztec-node" {
           value = var.SEQ_MIN_TX_PER_BLOCK
         },
         {
-          name  = "SEQ_MAX_SECONDS_BETWEEN_BLOCKS"
-          value = var.SEQ_MAX_SECONDS_BETWEEN_BLOCKS
-        },
-        {
-          name  = "SEQ_MIN_SECONDS_BETWEEN_BLOCKS"
-          value = var.SEQ_MIN_SECONDS_BETWEEN_BLOCKS
-        },
-        {
           name  = "SEQ_PUBLISHER_PRIVATE_KEY"
           value = local.sequencer_private_keys[count.index]
         },

--- a/yarn-project/aztec/terraform/node/variables.tf
+++ b/yarn-project/aztec/terraform/node/variables.tf
@@ -55,16 +55,6 @@ variable "SEQ_MIN_TX_PER_BLOCK" {
   default = 2
 }
 
-variable "SEQ_MAX_SECONDS_BETWEEN_BLOCKS" {
-  type    = string
-  default = 0
-}
-
-variable "SEQ_MIN_SECONDS_BETWEEN_BLOCKS" {
-  type    = string
-  default = 0
-}
-
 variable "P2P_MAX_PEERS" {
   type    = string
   default = 100

--- a/yarn-project/ethereum/src/l1_tx_utils.ts
+++ b/yarn-project/ethereum/src/l1_tx_utils.ts
@@ -209,7 +209,6 @@ export class L1TxUtils {
       ...defaultL1TxUtilsConfig,
       ...(config || {}),
     };
-    this.logger?.debug('Initializing L1 TX utils with config', { config: this.config });
   }
 
   public interrupt() {


### PR DESCRIPTION
This PR primarily removes another place where config objects were being logged.

It also cleans up some dead TF vars
