### PR TITLE
feat: add anvil port configuration option for sandbox

### DIFF
--- a/yarn-project/aztec/src/cli/aztec_start_action.ts
+++ b/yarn-project/aztec/src/cli/aztec_start_action.ts
@@ -37,6 +37,7 @@ export async function aztecStart(options: any, userLog: LogFn, debugLogger: Logg
         l1Salt: nodeOptions.deployAztecContractsSalt,
         noPXE: sandboxOptions.noPXE,
         testAccounts: sandboxOptions.testAccounts,
+        anvilPort: sandboxOptions.anvilPort,
       },
       userLog,
     );

--- a/yarn-project/aztec/src/cli/aztec_start_options.ts
+++ b/yarn-project/aztec/src/cli/aztec_start_options.ts
@@ -94,6 +94,13 @@ export const aztecStartOptions: { [key: string]: AztecStartOption[] } = {
       envVar: 'NO_PXE',
       ...booleanConfigHelper(),
     },
+    {
+      flag: '--sandbox.anvilPort <value>',
+      description: 'Port for anvil to listen on. If not specified, a random port will be used.',
+      envVar: 'ANVIL_PORT',
+      defaultValue: undefined,
+      parseVal: val => parseInt(val, 10),
+    },
   ],
   API: [
     {

--- a/yarn-project/ethereum/src/test/start_anvil.ts
+++ b/yarn-project/ethereum/src/test/start_anvil.ts
@@ -10,11 +10,12 @@ import { dirname, resolve } from 'path';
 export async function startAnvil(
   opts: {
     l1BlockTime?: number;
+    port?: number;
   } = {},
 ): Promise<{ anvil: Anvil; rpcUrl: string; stop: () => Promise<void> }> {
   const anvilBinary = resolve(dirname(fileURLToPath(import.meta.url)), '../../', 'scripts/anvil_kill_wrapper.sh');
 
-  let port: number | undefined;
+  let assignedPort: number | undefined;
 
   // Start anvil.
   // We go via a wrapper script to ensure if the parent dies, anvil dies.
@@ -22,15 +23,15 @@ export async function startAnvil(
     async () => {
       const anvil = createAnvil({
         anvilBinary,
-        port: 0,
+        port: opts.port || 0, // Use specified port or let OS assign one
         blockTime: opts.l1BlockTime,
         stopTimeout: 1000,
       });
 
       // Listen to the anvil output to get the port.
       const removeHandler = anvil.on('message', (message: string) => {
-        if (port === undefined && message.includes('Listening on')) {
-          port = parseInt(message.match(/Listening on ([^:]+):(\d+)/)![2]);
+        if (assignedPort === undefined && message.includes('Listening on')) {
+          assignedPort = parseInt(message.match(/Listening on ([^:]+):(\d+)/)![2]);
         }
       });
       await anvil.start();
@@ -42,11 +43,11 @@ export async function startAnvil(
     makeBackoff([5, 5, 5]),
   );
 
-  if (!port) {
+  if (!assignedPort) {
     throw new Error('Failed to start anvil');
   }
 
   // Monkeypatch the anvil instance to include the actually assigned port
-  Object.defineProperty(anvil, 'port', { value: port, writable: false });
-  return { anvil, stop: () => anvil.stop(), rpcUrl: `http://127.0.0.1:${port}` };
+  Object.defineProperty(anvil, 'port', { value: assignedPort, writable: false });
+  return { anvil, stop: () => anvil.stop(), rpcUrl: `http://127.0.0.1:${assignedPort}` };
 }


### PR DESCRIPTION
Fixes #12888

It should enable running anvil independently and prevent port conflicts.

Usage:
```bash
# Via CLI
aztec start --sandbox --sandbox.anvilPort 8546

# Via environment variable
ANVIL_PORT=8546 aztec start --sandbox
```
