### PR TITLE
fix: use version from registry for rollup instead of config

### DIFF
--- a/yarn-project/aztec-node/package.json
+++ b/yarn-project/aztec-node/package.json
@@ -71,6 +71,7 @@
     "@aztec/ethereum": "workspace:^",
     "@aztec/foundation": "workspace:^",
     "@aztec/kv-store": "workspace:^",
+    "@aztec/l1-artifacts": "workspace:^",
     "@aztec/merkle-tree": "workspace:^",
     "@aztec/node-lib": "workspace:^",
     "@aztec/p2p": "workspace:^",
@@ -84,7 +85,8 @@
     "@aztec/world-state": "workspace:^",
     "koa": "^2.14.2",
     "koa-router": "^12.0.0",
-    "tslib": "^2.4.0"
+    "tslib": "^2.4.0",
+    "viem": "2.23.7"
   },
   "devDependencies": {
     "@jest/globals": "^29.5.0",

--- a/yarn-project/aztec-node/tsconfig.json
+++ b/yarn-project/aztec-node/tsconfig.json
@@ -31,6 +31,9 @@
       "path": "../kv-store"
     },
     {
+      "path": "../l1-artifacts"
+    },
+    {
       "path": "../merkle-tree"
     },
     {

--- a/yarn-project/end-to-end/src/composed/integration_l1_publisher.test.ts
+++ b/yarn-project/end-to-end/src/composed/integration_l1_publisher.test.ts
@@ -100,6 +100,7 @@ describe('L1Publisher integration', () => {
 
   let coinbase: EthAddress;
   let feeRecipient: AztecAddress;
+  let version: number;
 
   let ethCheatCodes: EthCheatCodesWithState;
   let worldStateSynchronizer: ServerWorldStateSynchronizer;
@@ -231,6 +232,7 @@ describe('L1Publisher integration', () => {
 
     coinbase = config.coinbase || EthAddress.random();
     feeRecipient = config.feeRecipient || (await AztecAddress.random());
+    version = config.version ?? 1;
 
     const fork = await worldStateSynchronizer.fork();
 
@@ -253,7 +255,7 @@ describe('L1Publisher integration', () => {
     makeBloatedProcessedTx({
       header: prevHeader,
       chainId: fr(chainId),
-      version: fr(config.version),
+      version: fr(version),
       vkTreeRoot: getVKTreeRoot(),
       gasSettings: GasSettings.default({ maxFeesPerGas: baseFee }),
       protocolContractTreeRoot,
@@ -422,7 +424,7 @@ describe('L1Publisher integration', () => {
 
         const globalVariables = new GlobalVariables(
           new Fr(chainId),
-          new Fr(config.version),
+          new Fr(version),
           new Fr(1 + i),
           new Fr(slot),
           new Fr(timestamp),
@@ -559,7 +561,7 @@ describe('L1Publisher integration', () => {
       const timestamp = await rollup.getTimestampForSlot(slot);
       const globalVariables = new GlobalVariables(
         new Fr(chainId),
-        new Fr(config.version),
+        new Fr(version),
         new Fr(1),
         new Fr(slot),
         new Fr(timestamp),

--- a/yarn-project/stdlib/src/config/config.ts
+++ b/yarn-project/stdlib/src/config/config.ts
@@ -1,5 +1,5 @@
 import { l1ContractAddressesMapping } from '@aztec/ethereum/l1-contract-addresses';
-import { type ConfigMappingsType, numberConfigHelper } from '@aztec/foundation/config';
+import type { ConfigMappingsType } from '@aztec/foundation/config';
 import { EthAddress } from '@aztec/foundation/eth-address';
 
 export { type AllowedElement, type SequencerConfig, SequencerConfigSchema } from '../interfaces/configs.js';
@@ -20,7 +20,7 @@ export const chainConfigMappings: ConfigMappingsType<ChainConfig> = {
   version: {
     env: 'VERSION',
     description: 'The version of the rollup.',
-    ...numberConfigHelper(1),
+    parseEnv: (val: string) => (Number.isSafeInteger(parseInt(val, 10)) ? parseInt(val, 10) : undefined),
   },
   l1Contracts: {
     description: 'The deployed L1 contract addresses',

--- a/yarn-project/yarn.lock
+++ b/yarn-project/yarn.lock
@@ -155,6 +155,7 @@ __metadata:
     "@aztec/ethereum": "workspace:^"
     "@aztec/foundation": "workspace:^"
     "@aztec/kv-store": "workspace:^"
+    "@aztec/l1-artifacts": "workspace:^"
     "@aztec/merkle-tree": "workspace:^"
     "@aztec/node-lib": "workspace:^"
     "@aztec/p2p": "workspace:^"
@@ -176,6 +177,7 @@ __metadata:
     ts-node: "npm:^10.9.1"
     tslib: "npm:^2.4.0"
     typescript: "npm:^5.0.4"
+    viem: "npm:2.23.7"
   bin:
     aztec-node: ./dest/bin/index.js
   languageName: unknown


### PR DESCRIPTION
This ensures that we use rollup / registry from the version passed in, and the version is now optional and not preset to 1. I'm not removing any config though to keep this individual change small, as the cleanup will be bigger and may want to be thought out a bit more.