### PR TITLE
fix: validators verify tx proofs

### DIFF
--- a/spartan/aztec-network/templates/validator.yaml
+++ b/spartan/aztec-network/templates/validator.yaml
@@ -125,6 +125,8 @@ spec:
               valueFrom:
                 fieldRef:
                   fieldPath: metadata.namespace
+            - name: PROVER_REAL_PROOFS
+              value: "{{ .Values.aztec.realProofs }}"
             - name: NODE_OPTIONS
               value: "--max-old-space-size={{ .Values.validator.maxOldSpaceSize}}"
             - name: AZTEC_PORT


### PR DESCRIPTION
This was missing from the validator's template file so tx proofs weren't actually verified.
