### PR TITLE
FIX: Contract class difference error

### DIFF
--- a/yarn-project/end-to-end/src/sample-dapp/contracts.mjs
+++ b/yarn-project/end-to-end/src/sample-dapp/contracts.mjs
@@ -1,14 +1,16 @@
 // docs:start:imports
-import { AztecAddress } from '@aztec/aztec.js';
-import { TokenContract } from '@aztec/noir-contracts.js/Token';
-
+import { AztecAddress, Contract, loadContractArtifact  } from '@aztec/aztec.js';
 import { readFileSync } from 'fs';
+
+import TokenContractJson from "./contracts/token/target/token-Token.json" assert { type: "json" };
 
 // docs:end:imports
 
 // docs:start:get-tokens
+const TokenContractArtifact = loadContractArtifact(TokenContractJson);
+
 export async function getToken(wallet) {
   const addresses = JSON.parse(readFileSync('addresses.json'));
-  return TokenContract.at(AztecAddress.fromString(addresses.token), wallet);
+  return Contract.at(AztecAddress.fromString(addresses.token), TokenContractArtifact, wallet);
 }
 // docs:end:get-tokens


### PR DESCRIPTION
# Description
As per the current [tutorial](https://docs.aztec.network/developers/tutorials/codealong/js_tutorials/simple_dapp/contract_interaction), the deployment of the token contract is being done with the `Contract` class while the instance of it for `getToken` function is created using the `TokenContract` class, and upon executing the script to fetch balance it's throwing the following error:

```bash
Error while retrying JsonRpcClient request pxe_updateContract to http://localhost:8080: Error: Error 500 from server http://localhost:8080 on pxe_updateContract: Could not update contract to a class different from the current one.
    at <anonymous> (/Users/sample_dapp/node_modules/@aztec/foundation/dest/json-rpc/client/fetch.js:59:23)
    at processTicksAndRejections (:12:39) {
  originalLine: 43,
  originalColumn: 22
}
```

# Fix 
Keep the `Contract` class constant for both the deployment and instance creation for the tutorial. 
