### PR TITLE
fix: pull CRS data ahead of time

### DIFF
--- a/barretenberg/ts/src/crs/net_crs.ts
+++ b/barretenberg/ts/src/crs/net_crs.ts
@@ -102,7 +102,7 @@ export class NetGrumpkinCrs {
     }
 
     const g1Start = 28;
-    const g1End = this.numPoints * 64 - 1;
+    const g1End = g1Start + (this.numPoints * 64 - 1);
 
     const response = await fetch('https://aztec-ignition.s3.amazonaws.com/TEST%20GRUMPKIN/monomial/transcript00.dat', {
       headers: {

--- a/barretenberg/ts/src/crs/node/index.ts
+++ b/barretenberg/ts/src/crs/node/index.ts
@@ -106,6 +106,7 @@ export class GrumpkinCrs {
     const crs = new NetGrumpkinCrs(this.numPoints);
     await crs.init();
     writeFileSync(this.path + '/grumpkin_g1.dat', crs.getG1Data());
+    writeFileSync(this.path + '/grumpkin_size', String(crs.numPoints));
   }
 
   /**

--- a/yarn-project/aztec/package.json
+++ b/yarn-project/aztec/package.json
@@ -35,6 +35,7 @@
     "@aztec/aztec-node": "workspace:^",
     "@aztec/aztec.js": "workspace:^",
     "@aztec/bb-prover": "workspace:^",
+    "@aztec/bb.js": "portal:../../barretenberg/ts",
     "@aztec/blob-sink": "workspace:^",
     "@aztec/bot": "workspace:^",
     "@aztec/builder": "workspace:^",

--- a/yarn-project/aztec/src/cli/cmds/start_node.ts
+++ b/yarn-project/aztec/src/cli/cmds/start_node.ts
@@ -16,7 +16,7 @@ import { mnemonicToAccount, privateKeyToAccount } from 'viem/accounts';
 
 import { createAztecNode, deployContractsToL1 } from '../../sandbox/index.js';
 import { getL1Config } from '../get_l1_config.js';
-import { extractNamespacedOptions, extractRelevantOptions } from '../util.js';
+import { extractNamespacedOptions, extractRelevantOptions, preloadCrsDataForVerifying } from '../util.js';
 
 export async function startNode(
   options: any,
@@ -44,6 +44,8 @@ export async function startNode(
     userLog(`Running a Prover Node within a Node is not yet supported`);
     process.exit(1);
   }
+
+  await preloadCrsDataForVerifying(nodeConfig, userLog);
 
   const initialFundedAccounts = nodeConfig.testAccounts ? await getInitialTestAccounts() : [];
   const { genesisBlockHash, genesisArchiveRoot, prefilledPublicData } = await getGenesisValues(

--- a/yarn-project/aztec/src/cli/cmds/start_prover_agent.ts
+++ b/yarn-project/aztec/src/cli/cmds/start_prover_agent.ts
@@ -13,7 +13,7 @@ import {
 import { getProverNodeAgentConfigFromEnv } from '@aztec/prover-node';
 import { initTelemetryClient, makeTracedFetch, telemetryClientConfigMappings } from '@aztec/telemetry-client';
 
-import { extractRelevantOptions } from '../util.js';
+import { extractRelevantOptions, preloadCrsDataForServerSideProving } from '../util.js';
 import { getVersions } from '../versioning.js';
 
 export async function startProverAgent(
@@ -39,6 +39,8 @@ export async function startProverAgent(
   if (!config.proverBrokerUrl) {
     process.exit(1);
   }
+
+  await preloadCrsDataForServerSideProving(config, userLog);
 
   const fetch = makeTracedFetch([1, 2, 3], false, makeUndiciFetch(new Agent({ connections: 10 })));
   const broker = createProvingJobBrokerClient(config.proverBrokerUrl, getVersions(), fetch);

--- a/yarn-project/aztec/src/cli/cmds/start_prover_node.ts
+++ b/yarn-project/aztec/src/cli/cmds/start_prover_node.ts
@@ -18,7 +18,7 @@ import { getGenesisValues } from '@aztec/world-state/testing';
 import { mnemonicToAccount } from 'viem/accounts';
 
 import { getL1Config } from '../get_l1_config.js';
-import { extractRelevantOptions } from '../util.js';
+import { extractRelevantOptions, preloadCrsDataForVerifying } from '../util.js';
 import { getVersions } from '../versioning.js';
 import { startProverBroker } from './start_prover_broker.js';
 
@@ -98,6 +98,8 @@ export async function startProverNode(
       `Running prover node without local prover agent. Connect one or more prover agents to this node or pass --proverAgent.proverAgentCount`,
     );
   }
+
+  await preloadCrsDataForVerifying(proverConfig, userLog);
 
   const initialFundedAccounts = proverConfig.testAccounts ? await getInitialTestAccounts() : [];
   const { prefilledPublicData } = await getGenesisValues(initialFundedAccounts.map(a => a.address));

--- a/yarn-project/aztec/src/cli/util.ts
+++ b/yarn-project/aztec/src/cli/util.ts
@@ -1,7 +1,9 @@
+import type { AztecNodeConfig } from '@aztec/aztec-node';
 import type { AccountManager, Fr } from '@aztec/aztec.js';
 import type { ConfigMappingsType } from '@aztec/foundation/config';
 import type { LogFn } from '@aztec/foundation/log';
 import type { PXEService } from '@aztec/pxe/server';
+import type { ProverConfig } from '@aztec/stdlib/interfaces/server';
 
 import chalk from 'chalk';
 import type { Command } from 'commander';
@@ -214,3 +216,33 @@ export const extractRelevantOptions = <T>(
 
   return relevantOptions;
 };
+
+/**
+ * Downloads just enough points to be able to verify ClientIVC proofs.
+ * @param opts - Whether proof are to be verifier
+ * @param log - Logging function
+ */
+export async function preloadCrsDataForVerifying(
+  { realProofs }: Pick<AztecNodeConfig, 'realProofs'>,
+  log: LogFn,
+): Promise<void> {
+  if (realProofs) {
+    const { Crs, GrumpkinCrs } = await import('@aztec/bb.js');
+    await Promise.all([Crs.new(2 ** 1, undefined, log), GrumpkinCrs.new(2 ** 16 + 1, undefined, log)]);
+  }
+}
+
+/**
+ * Downloads enough points to be able to prove every server-side circuit
+ * @param opts - Whether real proof are to be generated
+ * @param log - Logging function
+ */
+export async function preloadCrsDataForServerSideProving(
+  { realProofs }: Pick<ProverConfig, 'realProofs'>,
+  log: LogFn,
+): Promise<void> {
+  if (realProofs) {
+    const { Crs, GrumpkinCrs } = await import('@aztec/bb.js');
+    await Promise.all([Crs.new(2 ** 25 - 1, undefined, log), GrumpkinCrs.new(2 ** 18 + 1, undefined, log)]);
+  }
+}

--- a/yarn-project/yarn.lock
+++ b/yarn-project/yarn.lock
@@ -242,6 +242,7 @@ __metadata:
     "@aztec/aztec-node": "workspace:^"
     "@aztec/aztec.js": "workspace:^"
     "@aztec/bb-prover": "workspace:^"
+    "@aztec/bb.js": "portal:../../barretenberg/ts"
     "@aztec/blob-sink": "workspace:^"
     "@aztec/bot": "workspace:^"
     "@aztec/builder": "workspace:^"


### PR DESCRIPTION
Download a bunch of points needed for proof generation/verification.
NOTE: the point files are cached so if the files that exist in the default location already contain enough points this is a noop (a good idea to use docker volumes)
