### PR TITLE
chore: Fix for e2e gossip network test

### DIFF
--- a/yarn-project/archiver/src/archiver/data_retrieval.ts
+++ b/yarn-project/archiver/src/archiver/data_retrieval.ts
@@ -123,6 +123,12 @@ export async function processL2BlockProposedLogs(
       };
 
       retrievedBlocks.push({ ...block, l1 });
+      logger.trace(`Retrieved L2 block ${l2BlockNumber} from L1 tx ${log.transactionHash}`, {
+        l1BlockNumber: log.blockNumber,
+        l2BlockNumber,
+        archive: archive.toString(),
+        signatures: block.signatures.map(signature => signature.toString()),
+      });
     } else {
       logger.warn(`Ignoring L2 block ${l2BlockNumber} due to archive root mismatch`, {
         actual: archive,

--- a/yarn-project/end-to-end/src/e2e_p2p/gossip_network.test.ts
+++ b/yarn-project/end-to-end/src/e2e_p2p/gossip_network.test.ts
@@ -124,7 +124,7 @@ describe('e2e_p2p_network', () => {
     const dataStore = ((nodes[0] as AztecNodeService).getBlockSource() as Archiver).dataStore;
     const [block] = await dataStore.getBlocks(blockNumber, blockNumber);
     const payload = ConsensusPayload.fromBlock(block.block);
-    const attestations = block.signatures.map(sig => new BlockAttestation(payload, sig));
+    const attestations = block.signatures.filter(s => !s.isEmpty).map(sig => new BlockAttestation(payload, sig));
     const signers = await Promise.all(attestations.map(att => att.getSender().then(s => s.toString())));
     t.logger.info(`Attestation signers`, { signers });
 

--- a/yarn-project/foundation/src/crypto/secp256k1-signer/utils.ts
+++ b/yarn-project/foundation/src/crypto/secp256k1-signer/utils.ts
@@ -49,8 +49,14 @@ export function addressFromPrivateKey(privateKey: Buffer): EthAddress {
  * @returns The address.
  */
 export function recoverAddress(hash: Buffer32, signature: Signature): EthAddress {
-  const publicKey = recoverPublicKey(hash, signature);
-  return publicKeyToAddress(publicKey);
+  try {
+    const publicKey = recoverPublicKey(hash, signature);
+    return publicKeyToAddress(publicKey);
+  } catch (err) {
+    throw new Error(
+      `Error recovering Ethereum address from hash ${hash.toString()} and signature ${signature.toString()}: ${err}`,
+    );
+  }
 }
 
 /**

--- a/yarn-project/p2p/src/mem_pools/attestation_pool/kv_attestation_pool.ts
+++ b/yarn-project/p2p/src/mem_pools/attestation_pool/kv_attestation_pool.ts
@@ -58,7 +58,9 @@ export class KvAttestationPool implements AttestationPool {
           this.getAttestationKey(slotNumber, proposalId, address),
         );
 
-        this.log.verbose(`Added attestation for slot ${slotNumber} from ${address}`);
+        this.log.verbose(`Added attestation for slot ${slotNumber.toBigInt()} from ${address}`, {
+          signature: attestation.signature.toString(),
+        });
       }
     });
 

--- a/yarn-project/p2p/src/mem_pools/attestation_pool/memory_attestation_pool.ts
+++ b/yarn-project/p2p/src/mem_pools/attestation_pool/memory_attestation_pool.ts
@@ -38,7 +38,9 @@ export class InMemoryAttestationPool implements AttestationPool {
       const proposalAttestationMap = getProposalOrDefault(slotAttestationMap, proposalId);
       proposalAttestationMap.set(address.toString(), attestation);
 
-      this.log.verbose(`Added attestation for slot ${slotNumber} from ${address}`);
+      this.log.verbose(`Added attestation for slot ${slotNumber.toBigInt()} from ${address}`, {
+        signature: attestation.signature.toString(),
+      });
     }
 
     // TODO: set these to pending or something ????

--- a/yarn-project/validator-client/src/duties/validation_service.test.ts
+++ b/yarn-project/validator-client/src/duties/validation_service.test.ts
@@ -1,0 +1,33 @@
+import { Buffer32 } from '@aztec/foundation/buffer';
+import { makeBlockProposal } from '@aztec/stdlib/testing';
+
+import { generatePrivateKey } from 'viem/accounts';
+
+import { LocalKeyStore } from '../key_store/local_key_store.js';
+import { ValidationService } from './validation_service.js';
+
+describe('ValidationService', () => {
+  let service: ValidationService;
+  let store: LocalKeyStore;
+  let key: `0x${string}`;
+
+  beforeEach(() => {
+    key = generatePrivateKey();
+    store = new LocalKeyStore(Buffer32.fromString(key));
+    service = new ValidationService(store);
+  });
+
+  it('creates a proposal', async () => {
+    const {
+      payload: { header, archive, txHashes },
+    } = await makeBlockProposal();
+    const proposal = await service.createBlockProposal(header, archive, txHashes);
+    await expect(proposal.getSender()).resolves.toEqual(store.getAddress());
+  });
+
+  it('attests to proposal', async () => {
+    const proposal = await makeBlockProposal();
+    const attestation = await service.attestToProposal(proposal);
+    await expect(attestation.getSender()).resolves.toEqual(store.getAddress());
+  });
+});


### PR DESCRIPTION
This test was [failing](http://ci.aztec-labs.com/80ef02336cf535f1) with an invalid signature:

```
18:06:18   ● e2e_p2p_network › should rollup txs from all peers
18:06:18
18:06:18     r must be 0 < r < CURVE.n
18:06:18
18:06:18       79 |     const { r, s, v } = signature;
18:06:18       80 |     const recoveryBit = toRecoveryBit(v);
18:06:18     > 81 |     const sig = new secp256k1.Signature(r.toBigInt(), s.toBigInt()).addRecoveryBit(recoveryBit);
18:06:18          |                 ^
18:06:18       82 |     const publicKey = sig.recoverPublicKey(hash.buffer).toHex(false);
18:06:18       83 |     return Buffer.from(publicKey, 'hex');
18:06:18       84 | }
18:06:18
18:06:18       at Signature.assertValidity (../../node_modules/@noble/curves/src/abstract/weierstrass.ts:801:46)
18:06:18       at new Signature (../../node_modules/@noble/curves/src/abstract/weierstrass.ts:782:12)
18:06:18       at recoverPublicKey (../../foundation/dest/crypto/secp256k1-signer/utils.js:81:17)
18:06:18       at recoverAddress (../../foundation/dest/crypto/secp256k1-signer/utils.js:44:23)
18:06:18       at BlockAttestation.getSender (../../stdlib/dest/p2p/block_attestation.js:55:27)
18:06:18           at async Promise.all (index 0)
18:06:18       at Object.<anonymous> (e2e_p2p/gossip_network.test.ts:128:21)
18:06:18
```

The cause was that we were trying to recover the signer from an empty signature (all zeroes). This is not typically an issue since the p2p client filters them out (see #12740), but in this test we were reaching directly to the archiver to retrieve them.

This PR filters out empty signatures before recovering signers for them. It also includes some extra logging and a test for the validation service (because why not).


