### PR TITLE
chore: deflake the kind smoke test

### DIFF
--- a/.test_patterns.yml
+++ b/.test_patterns.yml
@@ -189,10 +189,6 @@ tests:
     owners:
       - *adam
 
-  - regex: "spartan/bootstrap.sh test-kind-smoke"
-    owners:
-      - *adam
-
   - regex: "spartan/bootstrap.sh test-kind-transfer"
     owners:
       - *adam

--- a/.test_patterns.yml
+++ b/.test_patterns.yml
@@ -189,6 +189,10 @@ tests:
     owners:
       - *adam
 
+  - regex: "spartan/bootstrap.sh test-kind-smoke"
+    owners:
+      - *mitch
+
   - regex: "spartan/bootstrap.sh test-kind-transfer"
     owners:
       - *adam

--- a/spartan/aztec-network/templates/pxe.yaml
+++ b/spartan/aztec-network/templates/pxe.yaml
@@ -51,12 +51,10 @@ spec:
               source /shared/config/service-addresses
               cat /shared/config/service-addresses
 
-              {{- if .Values.network.public }}
-              # If the network is public, we need to use the boot node URL
-              export AZTEC_NODE_URL=${BOOT_NODE_HOST}
+              {{- if .Values.pxe.nodeUrl }}
+              export AZTEC_NODE_URL={{ .Values.pxe.nodeUrl }}
               {{- else }}
-              # If the network is not public, we can use the validator URL
-              export AZTEC_NODE_URL={{ include "aztec-network.validatorUrl" . }}
+              export AZTEC_NODE_URL=${BOOT_NODE_HOST}
               {{- end }}
 
               until curl --head --silent ${AZTEC_NODE_URL}/status; do
@@ -79,12 +77,10 @@ spec:
             - |
               source /shared/config/service-addresses
               cat /shared/config/service-addresses
-              {{- if .Values.network.public }}
-              # If the network is public, we need to use the boot node URL
-              export AZTEC_NODE_URL=${BOOT_NODE_HOST}
+              {{- if .Values.pxe.nodeUrl }}
+              export AZTEC_NODE_URL={{ .Values.pxe.nodeUrl }}
               {{- else }}
-              # If the network is not public, we can use the validator URL
-              export AZTEC_NODE_URL={{ include "aztec-network.validatorUrl" . }}
+              export AZTEC_NODE_URL=${BOOT_NODE_HOST}
               {{- end }}
               echo "AZTEC_NODE_URL=${AZTEC_NODE_URL}"
               node --no-warnings /usr/src/yarn-project/aztec/dest/bin/index.js start --pxe

--- a/spartan/aztec-network/templates/setup-l2-contracts.yaml
+++ b/spartan/aztec-network/templates/setup-l2-contracts.yaml
@@ -8,7 +8,7 @@ metadata:
   annotations:
     "helm.sh/hook": post-install
     "helm.sh/hook-weight": "0"
-    "helm.sh/hook-delete-policy": hook-succeeded,hook-failed,before-hook-creation
+    "helm.sh/hook-delete-policy": before-hook-creation
 spec:
   template:
     metadata:

--- a/spartan/aztec-network/templates/setup-l2-contracts.yaml
+++ b/spartan/aztec-network/templates/setup-l2-contracts.yaml
@@ -8,7 +8,7 @@ metadata:
   annotations:
     "helm.sh/hook": post-install
     "helm.sh/hook-weight": "0"
-    "helm.sh/hook-delete-policy": before-hook-creation
+    "helm.sh/hook-delete-policy": hook-succeeded,before-hook-creation
 spec:
   template:
     metadata:

--- a/spartan/aztec-network/templates/transaction-bot.yaml
+++ b/spartan/aztec-network/templates/transaction-bot.yaml
@@ -91,10 +91,8 @@ spec:
               cat /shared/config/service-addresses
               {{- if .Values.bot.nodeUrl }}
               export AZTEC_NODE_URL={{ .Values.bot.nodeUrl }}
-              {{- else if .Values.network.public }}
-              export AZTEC_NODE_URL=${BOOT_NODE_HOST}
               {{- else }}
-              export AZTEC_NODE_URL={{ include "aztec-network.validatorUrl" . }}
+              export AZTEC_NODE_URL=${BOOT_NODE_HOST}
               {{- end }}
               echo "AZTEC_NODE_URL=${AZTEC_NODE_URL}"
               until curl -s ${AZTEC_NODE_URL}/status; do echo waiting for aztec-node; sleep 2; done
@@ -119,10 +117,8 @@ spec:
               source /shared/config/otel-resource
               {{- if .Values.bot.nodeUrl }}
               export AZTEC_NODE_URL={{ .Values.bot.nodeUrl }}
-              {{- else if .Values.network.public }}
-              export AZTEC_NODE_URL=${BOOT_NODE_HOST}
               {{- else }}
-              export AZTEC_NODE_URL={{ include "aztec-network.validatorUrl" . }}
+              export AZTEC_NODE_URL=${BOOT_NODE_HOST}
               {{- end }}
               echo "AZTEC_NODE_URL=${AZTEC_NODE_URL}"
 

--- a/spartan/aztec-network/values.yaml
+++ b/spartan/aztec-network/values.yaml
@@ -211,6 +211,7 @@ proverNode:
 
 pxe:
   enabled: true
+  nodeUrl: ""
   logLevel: "debug; info: aztec:simulator, json-rpc"
   replicas: 1
   service:
@@ -221,6 +222,7 @@ pxe:
     timeoutSeconds: 5
     successThreshold: 1
     failureThreshold: 3
+  resources: {}
 
 bot:
   enabled: true
@@ -250,6 +252,7 @@ bot:
   gke:
     spotEnabled: true
   maxOldSpaceSize: "4608"
+  resources: {}
 
 ethereum:
   acceleratedTestDeployments: false

--- a/spartan/aztec-network/values/1-validators.yaml
+++ b/spartan/aztec-network/values/1-validators.yaml
@@ -1,5 +1,13 @@
+bot:
+  enabled: false
+
 telemetry:
   enabled: true
+
+aztec:
+  slotDuration: 24
+  epochDuration: 4
+  proofSubmissionWindow: 8
 
 validator:
   replicas: 1
@@ -9,9 +17,11 @@ validator:
     disabled: false
 
 ethereum:
+  blockTime: 6
+  acceleratedTestDeployments: true
   execution:
-    storageSize: "10Gi"
+    storageSize: "1Gi"
   beacon:
-    storageSize: "10Gi"
+    storageSize: "1Gi"
   validator:
-    storageSize: "10Gi"
+    storageSize: "1Gi"

--- a/spartan/bootstrap.sh
+++ b/spartan/bootstrap.sh
@@ -120,8 +120,9 @@ case "$cmd" in
     $cmd
     ;;
   "test-kind-smoke")
+    OVERRIDES="telemetry.enabled=false,bot.enabled=false" \
     FRESH_INSTALL=${FRESH_INSTALL:-true} INSTALL_METRICS=false \
-      ./scripts/test_kind.sh src/spartan/smoke.test.ts ci-smoke.yaml smoke${NAME_POSTFIX:-}
+      ./scripts/test_kind.sh src/spartan/smoke.test.ts 1-validators.yaml smoke${NAME_POSTFIX:-}
     ;;
   "test-kind-4epochs")
     # TODO(#12163) reenable bot once not conflicting with transfer

--- a/spartan/scripts/deploy_kind.sh
+++ b/spartan/scripts/deploy_kind.sh
@@ -157,7 +157,7 @@ helm upgrade --install "$helm_instance" ../aztec-network \
   --wait-for-jobs=true \
   --timeout="$install_timeout"
 
-kubectl wait pod -l app==pxe -l app.kubernetes.io/instance="$helm_instance" --for=condition=Ready -n "$namespace" --timeout=10m
+kubectl wait pod -l app==pxe --for=condition=Ready -n "$namespace" --timeout=10m
 
 if [ -n "$chaos_values" ]; then
   ../bootstrap.sh chaos-mesh

--- a/yarn-project/end-to-end/scripts/deflaker.sh
+++ b/yarn-project/end-to-end/scripts/deflaker.sh
@@ -1,12 +1,13 @@
 #!/bin/bash
 
-testname=$1
+exe="FRESH_INSTALL=true INSTALL_METRICS=false ~/aztec-clones/alpha/spartan/scripts/test_kind.sh src/spartan/smoke.test.ts 1-validators.yaml smoke"
 script_dir=$(dirname "$0")
+
 
 for i in {1..100}
 do
   echo "Run #$i"
-  if ! yarn test $1 > $script_dir/deflaker.log 2>&1; then
+  if ! (eval $exe) > $script_dir/deflaker.log 2>&1; then
     echo "failed"
     exit 1
   fi

--- a/yarn-project/end-to-end/scripts/deflaker.sh
+++ b/yarn-project/end-to-end/scripts/deflaker.sh
@@ -1,8 +1,12 @@
 #!/bin/bash
 
-exe="FRESH_INSTALL=true INSTALL_METRICS=false ~/aztec-clones/alpha/spartan/scripts/test_kind.sh src/spartan/smoke.test.ts 1-validators.yaml smoke"
-script_dir=$(dirname "$0")
+if [ $# -eq 0 ]; then
+  echo "Usage: $0 <command to run repeatedly>"
+  exit 1
+fi
 
+exe="$@"
+script_dir=$(dirname "$0")
 
 for i in {1..100}
 do

--- a/yarn-project/pxe/src/pxe_oracle_interface/pxe_oracle_interface.ts
+++ b/yarn-project/pxe/src/pxe_oracle_interface/pxe_oracle_interface.ts
@@ -747,11 +747,13 @@ export class PXEOracleInterface implements ExecutionDataProvider {
     for (const recipient of await this.keyStore.getAccounts()) {
       const currentNotesForRecipient = await this.noteDataProvider.getNotes({ contractAddress, recipient });
       const nullifiersToCheck = currentNotesForRecipient.map(note => note.siloedNullifier);
+      this.log.debug(`Checking ${nullifiersToCheck.length} nullifiers for recipient ${recipient}`);
       const nullifierIndexes = await this.aztecNode.findLeavesIndexes(
         'latest',
         MerkleTreeId.NULLIFIER_TREE,
         nullifiersToCheck,
       );
+      this.log.debug(`Found ${nullifierIndexes.length} nullifiers for recipient ${recipient}`);
 
       const foundNullifiers = nullifiersToCheck
         .map((nullifier, i) => {
@@ -761,7 +763,9 @@ export class PXEOracleInterface implements ExecutionDataProvider {
         })
         .filter(nullifier => nullifier !== undefined) as InBlock<Fr>[];
 
+      this.log.debug(`Removing ${foundNullifiers.length} nullifiers for recipient ${recipient}`);
       const nullifiedNotes = await this.noteDataProvider.removeNullifiedNotes(foundNullifiers, recipient);
+
       nullifiedNotes.forEach(noteDao => {
         this.log.verbose(`Removed note for contract ${noteDao.contractAddress} at slot ${noteDao.storageSlot}`, {
           contract: noteDao.contractAddress,

--- a/yarn-project/pxe/src/pxe_oracle_interface/pxe_oracle_interface.ts
+++ b/yarn-project/pxe/src/pxe_oracle_interface/pxe_oracle_interface.ts
@@ -747,13 +747,11 @@ export class PXEOracleInterface implements ExecutionDataProvider {
     for (const recipient of await this.keyStore.getAccounts()) {
       const currentNotesForRecipient = await this.noteDataProvider.getNotes({ contractAddress, recipient });
       const nullifiersToCheck = currentNotesForRecipient.map(note => note.siloedNullifier);
-      this.log.debug(`Checking ${nullifiersToCheck.length} nullifiers for recipient ${recipient}`);
       const nullifierIndexes = await this.aztecNode.findLeavesIndexes(
         'latest',
         MerkleTreeId.NULLIFIER_TREE,
         nullifiersToCheck,
       );
-      this.log.debug(`Found ${nullifierIndexes.length} nullifiers for recipient ${recipient}`);
 
       const foundNullifiers = nullifiersToCheck
         .map((nullifier, i) => {
@@ -763,7 +761,6 @@ export class PXEOracleInterface implements ExecutionDataProvider {
         })
         .filter(nullifier => nullifier !== undefined) as InBlock<Fr>[];
 
-      this.log.debug(`Removing ${foundNullifiers.length} nullifiers for recipient ${recipient}`);
       const nullifiedNotes = await this.noteDataProvider.removeNullifiedNotes(foundNullifiers, recipient);
 
       nullifiedNotes.forEach(noteDao => {

--- a/yarn-project/pxe/src/pxe_oracle_interface/pxe_oracle_interface.ts
+++ b/yarn-project/pxe/src/pxe_oracle_interface/pxe_oracle_interface.ts
@@ -762,7 +762,6 @@ export class PXEOracleInterface implements ExecutionDataProvider {
         .filter(nullifier => nullifier !== undefined) as InBlock<Fr>[];
 
       const nullifiedNotes = await this.noteDataProvider.removeNullifiedNotes(foundNullifiers, recipient);
-
       nullifiedNotes.forEach(noteDao => {
         this.log.verbose(`Removed note for contract ${noteDao.contractAddress} at slot ${noteDao.storageSlot}`, {
           contract: noteDao.contractAddress,


### PR DESCRIPTION
Smoke test runs in just under 5 minutes in ci now (just under 3 minutes locally).
It has ran through the deflaker (locally) 100 times with no error; i.e.

```
./yarn-project/end-to-end/scripts/deflaker.sh ./spartan/bootstrap.sh test-kind-smoke
```

However, it did flake when I was running it on mainframe, so updating myself to receive slack notifications.

See [passing CI run](http://ci.aztec-labs.com/5ffc13f772a79c68)

changes:
- have the pxe and bot just connect to the boot node
- retain the setup l2 contracts job if it fails
- make the 1-validators yaml lighter/faster
- use 1-validators in the smoke test in CI
- fix the kubectl await to only await the pxe
- make the deflaker support bootstrap scripts

Fix #11177 