### PR TITLE
fix: disable proving on vite box

### DIFF
--- a/boxes/boxes/vite/src/config.ts
+++ b/boxes/boxes/vite/src/config.ts
@@ -23,6 +23,7 @@ export class PrivateEnv {
     const aztecNode = await createAztecNodeClient(nodeURL);
     const config = getPXEServiceConfig();
     config.dataDirectory = "pxe";
+    config.proverEnabled = false;
     const l1Contracts = await aztecNode.getL1ContractAddresses();
     const configWithContracts = {
       ...config,

--- a/boxes/package.json
+++ b/boxes/package.json
@@ -44,6 +44,7 @@
     "vitest": "^2.0.5"
   },
   "devDependencies": {
-    "@playwright/test": "1.49.0"
+    "@playwright/test": "1.49.0",
+    "webpack-dev-server": "^5.2.0"
   }
 }

--- a/boxes/yarn.lock
+++ b/boxes/yarn.lock
@@ -3611,6 +3611,7 @@ __metadata:
     pino-pretty: "npm:^10.3.1"
     tiged: "npm:^2.12.6"
     vitest: "npm:^2.0.5"
+    webpack-dev-server: "npm:^5.2.0"
   bin:
     aztec-app: bin.js
   languageName: unknown


### PR DESCRIPTION
After https://github.com/AztecProtocol/aztec-packages/pull/12964, proving was enabled on the box. For the time being, let's deactivate it since: 

- Tests are more "smoky", and we will properly test/benchmark the wasm prover elsewhere.
- WASM proving is currently broken, it goes over 4GB limit when deploying a simple contract.