### PR TITLE
fix: increased poseidon gates

### DIFF
--- a/barretenberg/cpp/src/barretenberg/plonk_honk_shared/execution_trace/mega_execution_trace.hpp
+++ b/barretenberg/cpp/src/barretenberg/plonk_honk_shared/execution_trace/mega_execution_trace.hpp
@@ -338,8 +338,8 @@ static constexpr TraceStructure E2E_FULL_TEST_STRUCTURE{ .ecc_op = 1 << 10,
                                                          .delta_range = 25000,
                                                          .elliptic = 80000,
                                                          .aux = 100000,
-                                                         .poseidon2_external = 30128,
-                                                         .poseidon2_internal = 172000,
+                                                         .poseidon2_external = 45192,
+                                                         .poseidon2_internal = 258000,
                                                          .overflow = 0 };
 
 template <typename T>


### PR DESCRIPTION
After this: https://github.com/AztecProtocol/aztec-packages/pull/12061 we were overflowing the trace on contract class registrations. This was not caught by tests due to:

- Insufficient tests with full proving (and the ones we have deploy without proving!)
- Insufficient WASM testing: this overflow caused the overflowing trace to go over 4GB
