### PR TITLE
fix: Incorrect p2p config - add listenAddress to bootnode

### DIFF
--- a/iac/network/common/gcp/main.tf
+++ b/iac/network/common/gcp/main.tf
@@ -16,7 +16,6 @@ module "iam" {
 }
 
 module "firewall" {
-  source        = "../../modules/firewall/gcp"
-  p2p_tcp_ports = var.p2p_ports
-  p2p_udp_ports = var.p2p_ports
+  source    = "../../modules/firewall/gcp"
+  p2p_ports = var.p2p_ports
 }

--- a/yarn-project/p2p/src/config.ts
+++ b/yarn-project/p2p/src/config.ts
@@ -371,6 +371,7 @@ export type BootnodeConfig = Pick<
 const bootnodeConfigKeys: (keyof BootnodeConfig)[] = [
   'p2pIp',
   'p2pPort',
+  'listenAddress',
   'peerIdPrivateKey',
   'dataDirectory',
   'dataStoreMapSizeKB',

--- a/yarn-project/p2p/src/util.ts
+++ b/yarn-project/p2p/src/util.ts
@@ -25,13 +25,11 @@ export interface PubSubLibp2p extends Libp2p {
  * Example usage:
  * const tcpAddr = '123.456.7.8:80' -> /ip4/123.456.7.8/tcp/80
  * const udpAddr = '[2001:db8::1]:8080' -> /ip6/2001:db8::1/udp/8080
- * @param address - The address string to convert.
- * @param port - The port to use in the multiaddr string.
+ * @param address - The address string to convert. Has to be in the format <addr>:<port>.
  * @param protocol - The protocol to use in the multiaddr string.
  * @returns A multiaddr compliant string.  */
 export function convertToMultiaddr(address: string, port: number, protocol: 'tcp' | 'udp'): string {
-  const fullAddress = `${address}:${port}`;
-  const multiaddrPrefix = addressToMultiAddressType(fullAddress);
+  const multiaddrPrefix = addressToMultiAddressType(address);
   if (multiaddrPrefix === 'dns') {
     throw new Error('Invalid address format. Expected an IPv4 or IPv6 address.');
   }

--- a/yarn-project/p2p/src/util.ts
+++ b/yarn-project/p2p/src/util.ts
@@ -25,11 +25,13 @@ export interface PubSubLibp2p extends Libp2p {
  * Example usage:
  * const tcpAddr = '123.456.7.8:80' -> /ip4/123.456.7.8/tcp/80
  * const udpAddr = '[2001:db8::1]:8080' -> /ip6/2001:db8::1/udp/8080
- * @param address - The address string to convert. Has to be in the format <addr>:<port>.
+ * @param address - The address string to convert.
+ * @param port - The port to use in the multiaddr string.
  * @param protocol - The protocol to use in the multiaddr string.
  * @returns A multiaddr compliant string.  */
 export function convertToMultiaddr(address: string, port: number, protocol: 'tcp' | 'udp'): string {
-  const multiaddrPrefix = addressToMultiAddressType(address);
+  const fullAddress = `${address}:${port}`;
+  const multiaddrPrefix = addressToMultiAddressType(fullAddress);
   if (multiaddrPrefix === 'dns') {
     throw new Error('Invalid address format. Expected an IPv4 or IPv6 address.');
   }


### PR DESCRIPTION
This PR contains fixes for terraform and multiaddr conversion
