### PR TITLE
fix: redact boot-node private key

### DIFF
--- a/yarn-project/aztec/src/cli/cmds/start_p2p_bootstrap.ts
+++ b/yarn-project/aztec/src/cli/cmds/start_p2p_bootstrap.ts
@@ -17,7 +17,8 @@ export async function startP2PBootstrap(
 ) {
   // Start a P2P bootstrap node.
   const config = extractRelevantOptions<BootnodeConfig>(options, bootnodeConfigMappings, 'p2p');
-  userLog(`Starting P2P bootstrap node with config: ${jsonStringify(config)}`);
+  const safeConfig = { ...config, peerIdPrivateKey: '<redacted>' };
+  userLog(`Starting P2P bootstrap node with config: ${jsonStringify(safeConfig)}`);
   const telemetryClient = initTelemetryClient(getTelemetryClientConfig());
   const store = await createStore('p2p-bootstrap', 1, config, createLogger('p2p:bootstrap:store'));
   const node = new BootstrapNode(store, telemetryClient);


### PR DESCRIPTION
I'll open up a PR later today to add a `SecretValue` and solve this for good. But for now this unblocks the release. 
