### PR TITLE
feat: stream crs data to disk

### DIFF
--- a/barretenberg/ts/src/crs/net_crs.ts
+++ b/barretenberg/ts/src/crs/net_crs.ts
@@ -21,25 +21,24 @@ export class NetCrs {
     await this.downloadG2Data();
   }
 
+  /**
+   * Opens up a ReadableStream to the points data
+   */
+  async streamG1Data(): Promise<ReadableStream<Uint8Array>> {
+    const response = await this.fetchG1Data();
+    return response.body!;
+  }
+
+  /**
+   * Opens up a ReadableStream to the points data
+   */
+  async streamG2Data(): Promise<ReadableStream<Uint8Array>> {
+    const response = await this.fetchG2Data();
+    return response.body!;
+  }
+
   async downloadG1Data() {
-    // Skip the download if numPoints is 0 (would download the entire file due to bad range header otherwise)
-    if (this.numPoints === 0) {
-      return (this.data = new Uint8Array([]));
-    }
-
-    const g1End = this.numPoints * 64 - 1;
-
-    const response = await retry(
-      () =>
-        fetch('https://aztec-ignition.s3.amazonaws.com/MAIN%20IGNITION/flat/g1.dat', {
-          headers: {
-            Range: `bytes=0-${g1End}`,
-          },
-          cache: 'force-cache',
-        }),
-      makeBackoff([5, 5, 5]),
-    );
-
+    const response = await this.fetchG1Data();
     return (this.data = new Uint8Array(await response.arrayBuffer()));
   }
 
@@ -47,14 +46,7 @@ export class NetCrs {
    * Download the G2 points data.
    */
   async downloadG2Data() {
-    const response2 = await retry(
-      () =>
-        fetch('https://aztec-ignition.s3.amazonaws.com/MAIN%20IGNITION/flat/g2.dat', {
-          cache: 'force-cache',
-        }),
-      makeBackoff([5, 5, 5]),
-    );
-
+    const response2 = await this.fetchG2Data();
     return (this.g2Data = new Uint8Array(await response2.arrayBuffer()));
   }
 
@@ -72,6 +64,41 @@ export class NetCrs {
    */
   getG2Data(): Uint8Array {
     return this.g2Data;
+  }
+
+  /**
+   * Fetches the appropriate range of points from a remote source
+   */
+  private async fetchG1Data(): Promise<Response> {
+    // Skip the download if numPoints is 0 (would download the entire file due to bad range header otherwise)
+    if (this.numPoints === 0) {
+      return new Response(new Uint8Array([]));
+    }
+
+    const g1End = this.numPoints * 64 - 1;
+    return await retry(
+      () =>
+        fetch('https://aztec-ignition.s3.amazonaws.com/MAIN%20IGNITION/flat/g1.dat', {
+          headers: {
+            Range: `bytes=0-${g1End}`,
+          },
+          cache: 'force-cache',
+        }),
+      makeBackoff([5, 5, 5]),
+    );
+  }
+
+  /**
+   * Fetches the appropriate range of points from a remote source
+   */
+  private async fetchG2Data(): Promise<Response> {
+    return await retry(
+      () =>
+        fetch('https://aztec-ignition.s3.amazonaws.com/MAIN%20IGNITION/flat/g2.dat', {
+          cache: 'force-cache',
+        }),
+      makeBackoff([5, 5, 5]),
+    );
   }
 }
 
@@ -96,22 +123,16 @@ export class NetGrumpkinCrs {
   }
 
   async downloadG1Data() {
-    // Skip the download if numPoints is 0 (would download the entire file due to bad range header otherwise)
-    if (this.numPoints === 0) {
-      return (this.data = new Uint8Array([]));
-    }
-
-    const g1Start = 28;
-    const g1End = g1Start + (this.numPoints * 64 - 1);
-
-    const response = await fetch('https://aztec-ignition.s3.amazonaws.com/TEST%20GRUMPKIN/monomial/transcript00.dat', {
-      headers: {
-        Range: `bytes=${g1Start}-${g1End}`,
-      },
-      cache: 'force-cache',
-    });
-
+    const response = await this.fetchG1Data();
     return (this.data = new Uint8Array(await response.arrayBuffer()));
+  }
+
+  /**
+   * Opens up a ReadableStream to the points data
+   */
+  async streamG1Data(): Promise<ReadableStream<Uint8Array>> {
+    const response = await this.fetchG1Data();
+    return response.body!;
   }
 
   /**
@@ -120,5 +141,25 @@ export class NetGrumpkinCrs {
    */
   getG1Data(): Uint8Array {
     return this.data;
+  }
+
+  /**
+   * Fetches the appropriate range of points from a remote source
+   */
+  private async fetchG1Data(): Promise<Response> {
+    // Skip the download if numPoints is 0 (would download the entire file due to bad range header otherwise)
+    if (this.numPoints === 0) {
+      return new Response(new Uint8Array([]));
+    }
+
+    const g1Start = 28;
+    const g1End = g1Start + (this.numPoints * 64 - 1);
+
+    return await fetch('https://aztec-ignition.s3.amazonaws.com/TEST%20GRUMPKIN/monomial/transcript00.dat', {
+      headers: {
+        Range: `bytes=${g1Start}-${g1End}`,
+      },
+      cache: 'force-cache',
+    });
   }
 }


### PR DESCRIPTION
This PR adds a streaming method to bb's CRS class so that the points data is piped directly to disk instead of loaded into memory first.

Fix #12948 
