### PR TITLE
chore: Setup helm config for alpha testnet

### DIFF
--- a/spartan/aztec-network/templates/boot-node.yaml
+++ b/spartan/aztec-network/templates/boot-node.yaml
@@ -89,6 +89,8 @@ spec:
               value: "{{ .Values.ethereum.acceleratedTestDeployments }}"
             - name: TEST_ACCOUNTS
               value: "{{ .Values.aztec.testAccounts }}"
+            - name: SPONSORED_FPC
+              value: "{{ .Values.aztec.sponsoredFPC }}"
             - name: REGISTRY_CONTRACT_ADDRESS
               value: "{{ .Values.bootNode.contracts.registryAddress }}"
             - name: TELEMETRY
@@ -230,6 +232,8 @@ spec:
               value: "{{ .Values.telemetry.excludeMetrics }}"
             - name: TEST_ACCOUNTS
               value: "{{ .Values.aztec.testAccounts }}"
+            - name: SPONSORED_FPC
+              value: "{{ .Values.aztec.sponsoredFPC }}"
             {{- if .Values.blobSink.enabled }}
             - name: BLOB_SINK_URL
               value: {{ include "aztec-network.blobSinkUrl" . }}

--- a/spartan/aztec-network/templates/full-node.yaml
+++ b/spartan/aztec-network/templates/full-node.yaml
@@ -154,6 +154,8 @@ spec:
               value: "{{ .Values.network.p2pBootstrapNodesAsFullPeers }}"
             - name: TEST_ACCOUNTS
               value: "{{ .Values.aztec.testAccounts }}"
+            - name: SPONSORED_FPC
+              value: "{{ .Values.aztec.sponsoredFPC }}"
             {{- if .Values.blobSink.enabled }}
             - name: BLOB_SINK_URL
               value: {{ include "aztec-network.blobSinkUrl" . }}

--- a/spartan/aztec-network/templates/prover-node.yaml
+++ b/spartan/aztec-network/templates/prover-node.yaml
@@ -234,6 +234,8 @@ spec:
               value: "{{ .Values.telemetry.excludeMetrics }}"
             - name: TEST_ACCOUNTS
               value: "{{ .Values.aztec.testAccounts }}"
+            - name: SPONSORED_FPC
+              value: "{{ .Values.aztec.sponsoredFPC }}"
             {{- if .Values.blobSink.enabled }}
             - name: BLOB_SINK_URL
               value: {{ include "aztec-network.blobSinkUrl" . }}

--- a/spartan/aztec-network/templates/validator.yaml
+++ b/spartan/aztec-network/templates/validator.yaml
@@ -187,6 +187,8 @@ spec:
               value: "{{ .Values.telemetry.excludeMetrics }}"
             - name: TEST_ACCOUNTS
               value: "{{ .Values.aztec.testAccounts }}"
+            - name: SPONSORED_FPC
+              value: "{{ .Values.aztec.sponsoredFPC }}"
             - name: P2P_BOOTSTRAP_NODES_AS_FULL_PEERS
               value: "{{ .Values.network.p2pBootstrapNodesAsFullPeers }}"
             {{- if .Values.blobSink.enabled }}

--- a/spartan/aztec-network/values.yaml
+++ b/spartan/aztec-network/values.yaml
@@ -59,6 +59,7 @@ aztec:
 
   l1Salt: "" # leave empty for random salt
   testAccounts: true
+  sponsoredFPC: false
   l1DeploymentMnemonic: "test test test test test test test test test test test junk" # the mnemonic used when deploying contracts
   manaTarget: "" # use default value
 

--- a/spartan/aztec-network/values/alpha-testnet.yaml
+++ b/spartan/aztec-network/values/alpha-testnet.yaml
@@ -18,6 +18,10 @@ network:
 
 blobSink:
   enabled: true
+  dataStoreConfig:
+    dataDir: "/data"
+    storageSize: "128Gi"
+    dataStoreMapSize: "134217728" # 128 GB
 
 bot:
   enabled: false
@@ -37,6 +41,8 @@ proverNode:
   l1FixedPriorityFeePerGas: 3
   l1GasLimitBufferPercentage: 15
   l1GasPriceMax: 1000
+  maxOldSpaceSize: "8192"
+  storageSize: "512Gi"
   resources:
     requests:
       cpu: "3"
@@ -47,11 +53,13 @@ validator:
   l1FixedPriorityFeePerGas: 3
   l1GasLimitBufferPercentage: 15
   l1GasPriceMax: 1000
+  storageSize: "512Gi"
   sequencer:
     minTxsPerBlock: 0
     maxTxsPerBlock: 4
   validator:
     disabled: false
+  maxOldSpaceSize: "8192"
   resources:
     requests:
       cpu: "3"

--- a/spartan/aztec-network/values/alpha-testnet.yaml
+++ b/spartan/aztec-network/values/alpha-testnet.yaml
@@ -1,0 +1,78 @@
+telemetry:
+  enabled: true
+
+aztec:
+  realProofs: true
+  numberOfDefaultAccounts: 0
+  testAccounts: true
+  sponsoredFPC: true
+  bootstrapENRs: "enr:-LO4QLbJddVpePYjaiCftOBY-L7O6Mfj_43TAn5Q1Y-5qQ_OWmSFc7bTKWHzw5xmdVIqXUiizum_kIRniXdPnWHHcwEEhWF6dGVjqDAwLTExMTU1MTExLTAwMDAwMDAwLTAtMTgwNmEwMjgtMWE1MzBmM2KCaWSCdjSCaXCEI8nh9YlzZWNwMjU2azGhA-_dX6aFcXP1DLk91negbXL2a0mNYGXH4hrMvb2i92I0g3VkcIKd0A,enr:-LO4QN4WF8kFyV3sQVX0C_y_03Eepxk5Wac70l9QJcIDRYwKS6aRst1YcfbTDdvovXdRfKf-WSXNVWViGLhDA-dUz2MEhWF6dGVjqDAwLTExMTU1MTExLTAwMDAwMDAwLTAtMTgwNmEwMjgtMWE1MzBmM2KCaWSCdjSCaXCEIicTHolzZWNwMjU2azGhAsz7aFFYRnP5xjTux5UW-HyEQcW_EJrZMT1CNm79N4g-g3VkcIKd0A,enr:-LO4QFrGfkRaCk_iFTeUjR5ESwo45Eov9hx_T1-BLdoT-iHzFgCiHMT4V1KBtdFp8D0ajLSe5HcNYrhalmdJXgv6NTUEhWF6dGVjqDAwLTExMTU1MTExLTAwMDAwMDAwLTAtMTgwNmEwMjgtMWE1MzBmM2KCaWSCdjSCaXCEIlICt4lzZWNwMjU2azGhAlC6nKB3iDtRFqWKWqxf_t-P9hc-SZ6VFBJV4y3bTZBQg3VkcIKd0A"
+  contracts:
+    registryAddress: "0x290667b79dd73ce03cd2fc901b905e7f1b001d18"
+    slashFactoryAddress: "0xc5aceadbb626630e854ffd6cb39105e9c541fa34"
+
+network:
+  public: true
+  setupL2Contracts: false
+  p2pBootstrapNodesAsFullPeers: false
+
+blobSink:
+  enabled: true
+
+bot:
+  enabled: false
+
+pxe:
+  enabled: false
+
+faucet:
+  enabled: false
+
+bootNode:
+  enabled: false
+  # unused.
+  externalHost: "http://localhost:8080"
+
+proverNode:
+  l1FixedPriorityFeePerGas: 3
+  l1GasLimitBufferPercentage: 15
+  l1GasPriceMax: 1000
+  resources:
+    requests:
+      cpu: "3"
+      memory: "10Gi"
+
+validator:
+  replicas: 3
+  l1FixedPriorityFeePerGas: 3
+  l1GasLimitBufferPercentage: 15
+  l1GasPriceMax: 1000
+  sequencer:
+    minTxsPerBlock: 0
+    maxTxsPerBlock: 4
+  validator:
+    disabled: false
+  resources:
+    requests:
+      cpu: "3"
+      memory: "10Gi"
+
+proverAgent:
+  replicas: 32
+  bb:
+    hardwareConcurrency: 31
+  gke:
+    spotEnabled: true
+  resources:
+    requests:
+      memory: "116Gi"
+      cpu: "31"
+
+ethereum:
+  chainId: "11155111"
+  l1GasPriceMax: 1000
+  l1FixedPriorityFeePerGas: 3
+
+jobs:
+  deployL1Verifier:
+    enable: false

--- a/spartan/terraform/gke-cluster/cluster/main.tf
+++ b/spartan/terraform/gke-cluster/cluster/main.tf
@@ -103,6 +103,42 @@ resource "google_container_node_pool" "aztec_nodes-2core" {
   }
 }
 
+# Create 4 core node pool no ssd
+resource "google_container_node_pool" "aztec_nodes-4core" {
+  name     = "${var.cluster_name}-4core"
+  location = var.zone
+  cluster  = var.cluster_name
+  version  = var.node_version
+  # Enable autoscaling
+  autoscaling {
+    min_node_count = 0
+    max_node_count = 8
+  }
+
+  # Node configuration
+  node_config {
+    machine_type = "t2d-standard-4"
+
+    service_account = var.service_account
+    oauth_scopes = [
+      "https://www.googleapis.com/auth/cloud-platform"
+    ]
+
+    labels = {
+      env       = "production"
+      local-ssd = "false"
+      node-type = "network"
+    }
+    tags = ["aztec-gke-node", "aztec"]
+  }
+
+  # Management configuration
+  management {
+    auto_repair  = true
+    auto_upgrade = false
+  }
+}
+
 # Create spot instance node pool with autoscaling
 resource "google_container_node_pool" "spot_nodes_32core" {
   name     = "${var.cluster_name}-32core-spot"

--- a/spartan/terraform/gke-cluster/cluster/main.tf
+++ b/spartan/terraform/gke-cluster/cluster/main.tf
@@ -25,6 +25,15 @@ resource "google_container_cluster" "primary" {
       issue_client_certificate = false
     }
   }
+
+  resource_usage_export_config {
+    enable_network_egress_metering       = true
+    enable_resource_consumption_metering = true
+
+    bigquery_destination {
+      dataset_id = "egress_consumption"
+    }
+  }
 }
 
 # Create 2 core node pool with local ssd
@@ -112,7 +121,7 @@ resource "google_container_node_pool" "aztec_nodes-4core" {
   # Enable autoscaling
   autoscaling {
     min_node_count = 0
-    max_node_count = 8
+    max_node_count = 16
   }
 
   # Node configuration

--- a/spartan/terraform/gke-cluster/main.tf
+++ b/spartan/terraform/gke-cluster/main.tf
@@ -1,8 +1,7 @@
 terraform {
-  backend "s3" {
+  backend "gcs" {
     bucket = "aztec-terraform"
-    key    = "aztec-gke-cluster/terraform.tfstate"
-    region = "eu-west-2"
+    prefix = "terraform/state/gke-cluster"
   }
   required_providers {
     google = {

--- a/yarn-project/aztec/src/cli/cmds/start_node.ts
+++ b/yarn-project/aztec/src/cli/cmds/start_node.ts
@@ -50,7 +50,7 @@ export async function startNode(
 
   const testAccounts = nodeConfig.testAccounts ? (await getInitialTestAccounts()).map(a => a.address) : [];
   const sponsoredFPCAccounts = nodeConfig.sponsoredFPC ? [await getSponsoredFPCAddress()] : [];
-  const initialFundedAccounts = [...testAccounts, ...sponsoredFPCAccounts];
+  const initialFundedAccounts = testAccounts.concat(sponsoredFPCAccounts);
 
   const { genesisBlockHash, genesisArchiveRoot, prefilledPublicData } = await getGenesisValues(initialFundedAccounts);
 

--- a/yarn-project/aztec/src/cli/cmds/start_prover_node.ts
+++ b/yarn-project/aztec/src/cli/cmds/start_prover_node.ts
@@ -104,7 +104,7 @@ export async function startProverNode(
 
   const testAccounts = proverConfig.testAccounts ? (await getInitialTestAccounts()).map(a => a.address) : [];
   const sponsoredFPCAccounts = proverConfig.sponsoredFPC ? [await getSponsoredFPCAddress()] : [];
-  const initialFundedAccounts = [...testAccounts, ...sponsoredFPCAccounts];
+  const initialFundedAccounts = testAccounts.concat(sponsoredFPCAccounts);
   const { prefilledPublicData } = await getGenesisValues(initialFundedAccounts);
 
   const proverNode = await createProverNode(proverConfig, { telemetry, broker }, { prefilledPublicData });


### PR DESCRIPTION
This PR sets up helm config for alpha-testnet in K8s. It also moves the tf state to GCS
