### PR TITLE
chore: drop unused CLI options

### DIFF
--- a/yarn-project/cli/src/cmds/l1/deploy_l1_verifier.ts
+++ b/yarn-project/cli/src/cmds/l1/deploy_l1_verifier.ts
@@ -13,15 +13,9 @@ export async function deployUltraHonkVerifier(
   privateKey: string | undefined,
   mnemonic: string,
   pxeRpcUrl: string,
-  bbBinaryPath: string,
-  bbWorkingDirectory: string,
   log: LogFn,
   debugLogger: Logger,
 ) {
-  if (!bbBinaryPath || !bbWorkingDirectory) {
-    throw new InvalidOptionArgumentError('Missing path to bb binary and working directory');
-  }
-
   const { publicClient, walletClient } = createL1Clients(
     ethRpcUrls,
     privateKey ?? mnemonic,

--- a/yarn-project/cli/src/cmds/l1/index.ts
+++ b/yarn-project/cli/src/cmds/l1/index.ts
@@ -24,8 +24,6 @@ const l1RpcUrlsOption = new Option(
   .argParser((arg: string) => arg.split(',').map(url => url.trim()));
 
 export function injectCommands(program: Command, log: LogFn, debugLogger: Logger) {
-  const { BB_BINARY_PATH, BB_WORKING_DIRECTORY } = process.env;
-
   program
     .command('deploy-l1-contracts')
     .description('Deploys all necessary Ethereum contracts for Aztec.')
@@ -412,8 +410,6 @@ export function injectCommands(program: Command, log: LogFn, debugLogger: Logger
       'test test test test test test test test test test test junk',
     )
     .requiredOption('--verifier <verifier>', 'Either mock or real', 'real')
-    .option('--bb <path>', 'Path to bb binary', BB_BINARY_PATH)
-    .option('--bb-working-dir <path>', 'Path to bb working directory', BB_WORKING_DIRECTORY)
     .action(async options => {
       const { deployMockVerifier, deployUltraHonkVerifier } = await import('./deploy_l1_verifier.js');
       if (options.verifier === 'mock') {
@@ -435,8 +431,6 @@ export function injectCommands(program: Command, log: LogFn, debugLogger: Logger
           options.l1PrivateKey,
           options.mnemonic,
           options.rpcUrl,
-          options.bb,
-          options.bbWorkingDir,
           log,
           debugLogger,
         );


### PR DESCRIPTION
Drops the unused bb options from the `deploys-l1-verifier` command. The verifier contract is  built by bootstrap ever since ci3 so that command just uses that artifact.
