### PR TITLE
feat: send votes even if out of sync

### DIFF
--- a/.test_patterns.yml
+++ b/.test_patterns.yml
@@ -84,7 +84,8 @@ tests:
 
   - regex: "simple e2e_p2p/slashing"
     owners:
-      - *sean
+      - *lasse
+
   - regex: "simple e2e_p2p/reqresp"
     error_regex: "TimeoutError"
     owners:

--- a/l1-contracts/src/core/interfaces/IRollup.sol
+++ b/l1-contracts/src/core/interfaces/IRollup.sol
@@ -170,7 +170,7 @@ interface IRollup is IRollupCore {
     BlockHeaderValidationFlags memory _flags
   ) external;
 
-  function canProposeAtTime(Timestamp _ts, bytes32 _archive) external returns (Slot, uint256);
+  function canProposeAtTime(Timestamp _ts) external returns (Slot, Timestamp, uint256, bytes32);
 
   function getTips() external view returns (ChainTips memory);
 

--- a/yarn-project/ethereum/src/contracts/rollup.ts
+++ b/yarn-project/ethereum/src/contracts/rollup.ts
@@ -307,31 +307,28 @@ export class RollupContract {
    *
    * @dev     Throws if unable to propose
    *
-   * @param archive - The archive that we expect to be current state
-   * @return [slot, blockNumber] - If you can propose, the L2 slot number and L2 block number of the next Ethereum block,
+   * @param account - The account to check
+   * @param timestamp - The timestamp to check at
+   *
+   * @return [slot, slotTimestamp, blockNumber, tipArchive] - If you can propose, the L2 slot number, the L2 slot timestamp, the L2 block number and the tip archive,
    * @throws otherwise
    */
-  public async canProposeAtNextEthBlock(
-    archive: Buffer,
+  public async canProposeAtTime(
     account: `0x${string}` | Account,
-    slotDuration: bigint | number,
-  ): Promise<[bigint, bigint]> {
-    if (typeof slotDuration === 'number') {
-      slotDuration = BigInt(slotDuration);
-    }
-    const timeOfNextL1Slot = (await this.client.getBlock()).timestamp + slotDuration;
+    timestamp: bigint,
+  ): Promise<[bigint, bigint, bigint, `0x${string}`]> {
     try {
       const {
-        result: [slot, blockNumber],
+        result: [slot, slotTimestamp, blockNumber, tipArchive],
       } = await this.client.simulateContract({
         address: this.address,
         abi: RollupAbi,
         functionName: 'canProposeAtTime',
-        args: [timeOfNextL1Slot, `0x${archive.toString('hex')}`],
+        args: [timestamp],
         account,
       });
 
-      return [slot, blockNumber];
+      return [slot, slotTimestamp, blockNumber, tipArchive];
     } catch (err: unknown) {
       throw formatViemError(err);
     }

--- a/yarn-project/sequencer-client/src/global_variable_builder/global_builder.ts
+++ b/yarn-project/sequencer-client/src/global_variable_builder/global_builder.ts
@@ -71,6 +71,7 @@ export class GlobalVariableBuilder implements GlobalVariableBuilderInterface {
     coinbase: EthAddress,
     feeRecipient: AztecAddress,
     slotNumber?: bigint,
+    timestamp?: bigint,
   ): Promise<GlobalVariables> {
     const version = new Fr(await this.rollupContract.getVersion());
     const chainId = new Fr(this.publicClient.chain.id);
@@ -80,7 +81,9 @@ export class GlobalVariableBuilder implements GlobalVariableBuilderInterface {
       slotNumber = await this.rollupContract.getSlotAt(ts);
     }
 
-    const timestamp = await this.rollupContract.getTimestampForSlot(slotNumber);
+    if (timestamp === undefined) {
+      timestamp = await this.rollupContract.getTimestampForSlot(slotNumber);
+    }
 
     const slotFr = new Fr(slotNumber);
     const timestampFr = new Fr(timestamp);

--- a/yarn-project/sequencer-client/src/publisher/sequencer-publisher.ts
+++ b/yarn-project/sequencer-client/src/publisher/sequencer-publisher.ts
@@ -250,22 +250,20 @@ export class SequencerPublisher {
   }
 
   /**
-   * @notice  Will call `canProposeAtNextEthBlock` to make sure that it is possible to propose
-   * @param tipArchive - The archive to check
-   * @returns The slot and block number if it is possible to propose, undefined otherwise
+   * @notice  Will call `canProposeAtNextEthBlock` with the forwarder address to make sure that it can propose
+   * @returns The slot, slotTimestamp, block number and tip archive if it is possible to propose, undefined otherwise
    */
-  public canProposeAtNextEthBlock(tipArchive: Buffer) {
-    const ignoredErrors = ['SlotAlreadyInChain', 'InvalidProposer', 'InvalidArchive'];
-    return this.rollupContract
-      .canProposeAtNextEthBlock(tipArchive, this.getForwarderAddress().toString(), this.ethereumSlotDuration)
-      .catch(err => {
-        if (err instanceof FormattedViemError && ignoredErrors.find(e => err.message.includes(e))) {
-          this.log.debug(err.message);
-        } else {
-          this.log.error(err.name, err);
-        }
-        return undefined;
-      });
+  public async canProposeAtNextEthBlock() {
+    const timestamp = (await this.l1TxUtils.getBlock()).timestamp + this.ethereumSlotDuration;
+    const ignoredErrors = ['SlotAlreadyInChain', 'InvalidProposer'];
+    return this.rollupContract.canProposeAtTime(this.getForwarderAddress().toString(), timestamp).catch(err => {
+      if (err instanceof FormattedViemError && ignoredErrors.find(e => err.message.includes(e))) {
+        this.log.debug(err.message);
+      } else {
+        this.log.error(err.name, err);
+      }
+      return undefined;
+    });
   }
 
   /**


### PR DESCRIPTION
Fixes #12177

Alters the way that the validators figures out if it is the proposer such that it don't fail if the archive is out of date, but instead provide it with sufficient information to decide that itself. If it is then out of sync it will skip the block building, but still votes as needed. 

This also means that we are not throwing an error anymore if out of sync here, but instead logging a warning that we are out of sync
```ts
const msg = `Sequencer state mismatch. Local (block_number: ${newBlockNumber}, archive: ${chainTipArchive}), L1 (block_number: ${blockNumber}, archive: ${tipArchive}).`;
```