### PR TITLE
refactor: `getIndexedTaggingSecretAsSender` oracle cleanup

### DIFF
--- a/noir-projects/aztec-nr/aztec/src/encrypted_logs/log_assembly_strategies/default_aes128/aes128.nr
+++ b/noir-projects/aztec-nr/aztec/src/encrypted_logs/log_assembly_strategies/default_aes128/aes128.nr
@@ -249,7 +249,11 @@ mod test {
         test::helpers::test_environment::TestEnvironment,
     };
     use super::AES128;
-    use protocol_types::{address::AztecAddress, traits::FromField};
+    use protocol_types::{
+        address::AztecAddress,
+        indexed_tagging_secret::IndexedTaggingSecret,
+        traits::{Deserialize, FromField},
+    };
     use std::{embedded_curve_ops::EmbeddedCurveScalar, test::OracleMock};
 
     #[test]
@@ -271,7 +275,9 @@ mod test {
         let randomness = 0x0101010101010101010101010101010101010101010101010101010101010101;
         let _ = OracleMock::mock("getRandomField").returns(randomness).times(1000000);
 
-        let _ = OracleMock::mock("getIndexedTaggingSecretAsSender").returns([69420, 1337]);
+        let _ = OracleMock::mock("getIndexedTaggingSecretAsSender").returns(
+            IndexedTaggingSecret::deserialize([69420, 1337]),
+        );
         let _ = OracleMock::mock("incrementAppTaggingSecretIndexAsSender").returns(());
 
         // Encrypt the log

--- a/noir-projects/aztec-nr/aztec/src/encrypted_logs/log_assembly_strategies/default_aes128/note.nr
+++ b/noir-projects/aztec-nr/aztec/src/encrypted_logs/log_assembly_strategies/default_aes128/note.nr
@@ -192,7 +192,7 @@ mod test {
     use protocol_types::{
         address::AztecAddress,
         indexed_tagging_secret::IndexedTaggingSecret,
-        traits::{Deserialize, FromField, Serialize},
+        traits::{Deserialize, FromField},
     };
     use std::test::OracleMock;
 
@@ -209,8 +209,7 @@ mod test {
         let indexed_tagging_secret = IndexedTaggingSecret::deserialize([app_tagging_secret, index]);
 
         // Mock the tagging oracles
-        let _ = OracleMock::mock("getIndexedTaggingSecretAsSender").returns(indexed_tagging_secret
-            .serialize());
+        let _ = OracleMock::mock("getIndexedTaggingSecretAsSender").returns(indexed_tagging_secret);
         let _ = OracleMock::mock("incrementAppTaggingSecretIndexAsSender").returns(());
 
         let log_without_tag = [1, 2, 3];

--- a/noir-projects/aztec-nr/aztec/src/oracle/notes.nr
+++ b/noir-projects/aztec-nr/aztec/src/oracle/notes.nr
@@ -5,8 +5,8 @@ use crate::{
 
 use dep::protocol_types::{
     address::AztecAddress,
-    indexed_tagging_secret::{INDEXED_TAGGING_SECRET_LENGTH, IndexedTaggingSecret},
-    traits::{Deserialize, FromField, Packable},
+    indexed_tagging_secret::IndexedTaggingSecret,
+    traits::{FromField, Packable},
 };
 
 /// Notifies the simulator that a note has been created, so that it can be returned in future read requests in the same
@@ -215,28 +215,17 @@ pub unconstrained fn check_nullifier_exists(inner_nullifier: Field) -> bool {
 #[oracle(checkNullifierExists)]
 unconstrained fn check_nullifier_exists_oracle(_inner_nullifier: Field) -> bool {}
 
-/// Same as `get_indexed_tagging_secret_as_sender`, except it returns the derived tag, ready to be included in a log.
+/// Returns the derived app tagging secret ready to be included in a log for a given sender and recipient pair,
+/// siloed for the current contract address.
 pub unconstrained fn get_app_tag_as_sender(sender: AztecAddress, recipient: AztecAddress) -> Field {
-    get_indexed_tagging_secret_as_sender(sender, recipient).compute_tag(recipient)
-}
-
-/// Returns the tagging secret for a given sender and recipient pair, siloed for the current contract address.
-/// Includes the last known index used to send a note tagged with this secret.
-/// For this to work, PXE must know the ivsk_m of the sender.
-/// For the recipient's side, only the address is needed.
-pub unconstrained fn get_indexed_tagging_secret_as_sender(
-    sender: AztecAddress,
-    recipient: AztecAddress,
-) -> IndexedTaggingSecret {
-    let result = get_indexed_tagging_secret_as_sender_oracle(sender, recipient);
-    IndexedTaggingSecret::deserialize(result)
+    get_indexed_tagging_secret_as_sender_oracle(sender, recipient).compute_tag(recipient)
 }
 
 #[oracle(getIndexedTaggingSecretAsSender)]
 unconstrained fn get_indexed_tagging_secret_as_sender_oracle(
     _sender: AztecAddress,
     _recipient: AztecAddress,
-) -> [Field; INDEXED_TAGGING_SECRET_LENGTH] {}
+) -> IndexedTaggingSecret {}
 
 /// Notifies the simulator that a tag has been used in a note, and to therefore increment the associated index so that
 /// future notes get a different tag and can be discovered by the recipient.

--- a/yarn-project/simulator/src/private/acvm/oracle/oracle.ts
+++ b/yarn-project/simulator/src/private/acvm/oracle/oracle.ts
@@ -355,12 +355,12 @@ export class Oracle {
     return Promise.resolve([]);
   }
 
-  async getIndexedTaggingSecretAsSender([sender]: ACVMField[], [recipient]: ACVMField[]): Promise<ACVMField[][]> {
+  async getIndexedTaggingSecretAsSender([sender]: ACVMField[], [recipient]: ACVMField[]): Promise<ACVMField[]> {
     const taggingSecret = await this.typedOracle.getIndexedTaggingSecretAsSender(
       AztecAddress.fromString(sender),
       AztecAddress.fromString(recipient),
     );
-    return [taggingSecret.toFields().map(toACVMField)];
+    return taggingSecret.toFields().map(toACVMField);
   }
 
   async incrementAppTaggingSecretIndexAsSender([sender]: ACVMField[], [recipient]: ACVMField[]): Promise<ACVMField[]> {

--- a/yarn-project/txe/src/txe_service/txe_service.ts
+++ b/yarn-project/txe/src/txe_service/txe_service.ts
@@ -513,7 +513,7 @@ export class TXEService {
       AztecAddress.fromField(fromSingle(sender)),
       AztecAddress.fromField(fromSingle(recipient)),
     );
-    return toForeignCallResult([toArray(secret.toFields())]);
+    return toForeignCallResult(secret.toFields().map(toSingle));
   }
 
   async syncNotes() {


### PR DESCRIPTION
I stumbled upon 2 minor issues with getIndexedTaggingSecretAsSender oracle:
1. We were returning array instead of having it return IndexedTaggingSecret directly (forgot to address this in my [oracle cleanup PR](https://github.com/AztecProtocol/aztec-packages/pull/12864),
2. the `get_indexed_tagging_secret_as_sender` function was exposed but was not used anywhere. i think it makes sense to just not have that exposed as it makes the code nicer to read and it's always easy to re-expose if needed.
