### PR TITLE
test(DO NOT MERGE): Try running integration tests with `msgpack`

### DIFF
--- a/avm-transpiler/Cargo.lock
+++ b/avm-transpiler/Cargo.lock
@@ -13,9 +13,11 @@ dependencies = [
  "color-eyre",
  "flate2",
  "noir_protobuf",
+ "num_enum",
  "prost",
  "prost-build",
  "protoc-prebuilt",
+ "rmp-serde",
  "serde",
  "serde-big-array",
  "strum",
@@ -1490,6 +1492,27 @@ dependencies = [
 ]
 
 [[package]]
+name = "num_enum"
+version = "0.7.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4e613fc340b2220f734a8595782c551f1250e969d87d3be1ae0579e8d4065179"
+dependencies = [
+ "num_enum_derive",
+]
+
+[[package]]
+name = "num_enum_derive"
+version = "0.7.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "af1844ef2428cc3e1cb900be36181049ef3d3193c63e43026cfe202983b27a56"
+dependencies = [
+ "proc-macro-crate",
+ "proc-macro2",
+ "quote",
+ "syn 2.0.87",
+]
+
+[[package]]
 name = "object"
 version = "0.32.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1589,6 +1612,15 @@ checksum = "64d1ec885c64d0457d564db4ec299b2dae3f9c02808b8ad9c3a089c591b18033"
 dependencies = [
  "proc-macro2",
  "syn 2.0.87",
+]
+
+[[package]]
+name = "proc-macro-crate"
+version = "3.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "edce586971a4dfaa28950c6f18ed55e0406c1ab88bbce2c6f6293a7aaba73d35"
+dependencies = [
+ "toml_edit 0.22.24",
 ]
 
 [[package]]
@@ -1787,6 +1819,28 @@ dependencies = [
  "libc",
  "untrusted",
  "windows-sys 0.52.0",
+]
+
+[[package]]
+name = "rmp"
+version = "0.8.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "228ed7c16fa39782c3b3468e974aec2795e9089153cd08ee2e9aefb3613334c4"
+dependencies = [
+ "byteorder",
+ "num-traits",
+ "paste",
+]
+
+[[package]]
+name = "rmp-serde"
+version = "1.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "52e599a477cf9840e92f2cde9a7189e67b42c57532749bf90aea6ec10facd4db"
+dependencies = [
+ "byteorder",
+ "rmp",
+ "serde",
 ]
 
 [[package]]
@@ -2212,7 +2266,7 @@ dependencies = [
  "serde",
  "serde_spanned",
  "toml_datetime",
- "toml_edit",
+ "toml_edit 0.19.15",
 ]
 
 [[package]]
@@ -2234,7 +2288,18 @@ dependencies = [
  "serde",
  "serde_spanned",
  "toml_datetime",
- "winnow",
+ "winnow 0.5.40",
+]
+
+[[package]]
+name = "toml_edit"
+version = "0.22.24"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "17b4795ff5edd201c7cd6dca065ae59972ce77d1b80fa0a84d94950ece7d1474"
+dependencies = [
+ "indexmap 2.8.0",
+ "toml_datetime",
+ "winnow 0.7.4",
 ]
 
 [[package]]
@@ -2559,6 +2624,15 @@ name = "winnow"
 version = "0.5.40"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f593a95398737aeed53e489c785df13f3618e41dbcd6718c6addbf1395aa6876"
+dependencies = [
+ "memchr",
+]
+
+[[package]]
+name = "winnow"
+version = "0.7.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0e97b544156e9bebe1a0ffbc03484fc1ffe3100cbce3ffb17eac35f7cdd7ab36"
 dependencies = [
  "memchr",
 ]

--- a/bootstrap.sh
+++ b/bootstrap.sh
@@ -13,6 +13,9 @@ export DENOISE=${DENOISE:-1}
 # Number of TXE servers to run when testing.
 export NUM_TXES=8
 
+# Use msgpack with Noir artifacts
+export NOIR_SERIALIZATION_FORMAT=msgpack
+
 cmd=${1:-}
 [ -n "$cmd" ] && shift
 

--- a/bootstrap.sh
+++ b/bootstrap.sh
@@ -13,9 +13,6 @@ export DENOISE=${DENOISE:-1}
 # Number of TXE servers to run when testing.
 export NUM_TXES=8
 
-# Use msgpack with Noir artifacts
-export NOIR_SERIALIZATION_FORMAT=msgpack
-
 cmd=${1:-}
 [ -n "$cmd" ] && shift
 

--- a/noir/noir-repo-ref
+++ b/noir/noir-repo-ref
@@ -1,1 +1,1 @@
-nightly-2025-04-01
+af/msgpack-codegen

--- a/noir/noir-repo-ref
+++ b/noir/noir-repo-ref
@@ -1,1 +1,1 @@
-af/msgpack-codegen
+af/msgpack-default

--- a/noir/noir-repo.patch
+++ b/noir/noir-repo.patch
@@ -21,26 +21,3 @@ index 30dd2a7e..a2712fd7 100644
      "src/**/*.ts"
 --
 2.43.0
-
-From fd8f444eba5db51bee2173d7c2f66bebaa693d30 Mon Sep 17 00:00:00 2001
-From: aakoshh <akosh@aztecprotocol.com>
-Date: Mon, 17 Mar 2025 12:10:58 +0000
-Subject: [PATCH 4/4] Ignore package.tgz
-
----
- .gitignore | 3 +++
- 1 file changed, 3 insertions(+)
-
-diff --git a/.gitignore b/.gitignore
-index 3349018..c93fe8e 100644
---- a/.gitignore
-+++ b/.gitignore
-@@ -59,3 +59,6 @@ codegen
-
- mutants.out
- mutants.out.old
-+
-+# Artifacts created by `noir/bootstrap.sh build_packages`
-+**/package.tgz
---
-2.43.0


### PR DESCRIPTION
Testing the version of `bb` that can handle `msgpack` encoded Noir artefacts with a `nargo` that actually produces them, instead of the default `bincode`.

We could tell `nargo` to use `msgpack` by setting the `NOIR_SERIALIZATION_FORMAT` env var in `bootstrap.sh`, but then some of the Noir tests would fail, so we build against https://github.com/noir-lang/noir/pull/7810 instead.

We don't have to merge this PR, it's just here to check whether it's safe to start using `msgpack` in `nargo` by default, once https://github.com/AztecProtocol/aztec-packages/pull/12841 is in. Then, the changes on the Noir side will be part of the `nightly` updates.