### PR TITLE
fix: Allow use of local blob sink client

### DIFF
--- a/yarn-project/blob-sink/src/client/factory.ts
+++ b/yarn-project/blob-sink/src/client/factory.ts
@@ -5,7 +5,7 @@ import type { BlobSinkClientInterface } from './interface.js';
 import { LocalBlobSinkClient } from './local.js';
 
 export function createBlobSinkClient(config?: BlobSinkConfig): BlobSinkClientInterface {
-  if (!config?.blobSinkUrl && !config?.l1ConsensusHostUrl && !config?.archiveApiUrl && !config?.l1ChainId) {
+  if (!config?.blobSinkUrl && !config?.l1ConsensusHostUrl && !config?.archiveApiUrl) {
     const blobStore = new MemoryBlobStore();
     return new LocalBlobSinkClient(blobStore);
   }


### PR DESCRIPTION
In #12857 an irresponsible developer changed the blob sink client factory so that the remote `HttpBlobSinkClient` was used if there was a blob archive API defined or even an L1 chain id, since we have a method for inferring an archive API just by using the L1 chain id.

This has the unintended effect of using the `HttpBlobSinkClient` pretty much always, since L1 chain id is pretty much always defined. Even when running locally against anvil. Which means the archiver no longer works when running locally, since we end up with no local blob sink.

This commit removes the check for L1 chain id when deciding whether to use a local client or an http one. We assume that, if working in a "real" environment, we have an L1 consensus host url, given we hit the archive API just as a fallback.