### PR TITLE
chore: AVM TS - move tag validation outside of instruction constructors

### DIFF
--- a/yarn-project/simulator/src/public/avm/avm_memory_types.ts
+++ b/yarn-project/simulator/src/public/avm/avm_memory_types.ts
@@ -329,10 +329,8 @@ export class TaggedMemory implements TaggedMemoryInterface {
     }
   }
 
-  public static checkIsValidTag(tagNumber: number) {
-    if (!VALID_TAGS.has(tagNumber)) {
-      throw new InvalidTagValueError(tagNumber);
-    }
+  public static checkIsValidTag(tagNumber: number): boolean {
+    return VALID_TAGS.has(tagNumber);
   }
 
   /**

--- a/yarn-project/simulator/src/public/avm/avm_memory_types.ts
+++ b/yarn-project/simulator/src/public/avm/avm_memory_types.ts
@@ -329,8 +329,10 @@ export class TaggedMemory implements TaggedMemoryInterface {
     }
   }
 
-  public static checkIsValidTag(tagNumber: number): boolean {
-    return VALID_TAGS.has(tagNumber);
+  public static checkIsValidTag(tagNumber: number) {
+    if (!VALID_TAGS.has(tagNumber)) {
+      throw new InvalidTagValueError(tagNumber);
+    }
   }
 
   /**

--- a/yarn-project/simulator/src/public/avm/opcodes/memory.ts
+++ b/yarn-project/simulator/src/public/avm/opcodes/memory.ts
@@ -13,42 +13,42 @@ export class Set extends Instruction {
     OperandType.UINT8, // opcode
     OperandType.UINT8, // indirect
     OperandType.UINT8, // dstOffset
-    OperandType.UINT8, // tag
+    OperandType.TAG, // tag
     OperandType.UINT8, // const (value)
   ];
   public static readonly wireFormat16: OperandType[] = [
     OperandType.UINT8, // opcode
     OperandType.UINT8, // indirect
     OperandType.UINT16, // dstOffset
-    OperandType.UINT8, // tag
+    OperandType.TAG, // tag
     OperandType.UINT16, // const (value)
   ];
   public static readonly wireFormat32: OperandType[] = [
     OperandType.UINT8, // opcode
     OperandType.UINT8, // indirect
     OperandType.UINT16, // dstOffset
-    OperandType.UINT8, // tag
+    OperandType.TAG, // tag
     OperandType.UINT32, // const (value)
   ];
   public static readonly wireFormat64: OperandType[] = [
     OperandType.UINT8, // opcode
     OperandType.UINT8, // indirect
     OperandType.UINT16, // dstOffset
-    OperandType.UINT8, // tag
+    OperandType.TAG, // tag
     OperandType.UINT64, // const (value)
   ];
   public static readonly wireFormat128: OperandType[] = [
     OperandType.UINT8, // opcode
     OperandType.UINT8, // indirect
     OperandType.UINT16, // dstOffset
-    OperandType.UINT8, // tag
+    OperandType.TAG, // tag
     OperandType.UINT128, // const (value)
   ];
   public static readonly wireFormatFF: OperandType[] = [
     OperandType.UINT8, // opcode
     OperandType.UINT8, // indirect
     OperandType.UINT16, // dstOffset
-    OperandType.UINT8, // tag
+    OperandType.TAG, // tag
     OperandType.FF, // const (value)
   ];
 
@@ -59,7 +59,6 @@ export class Set extends Instruction {
     private value: bigint | number,
   ) {
     super();
-    TaggedMemory.checkIsValidTag(inTag);
   }
 
   public async execute(context: AvmContext): Promise<void> {
@@ -85,19 +84,18 @@ export class Cast extends Instruction {
     OperandType.UINT8,
     OperandType.UINT8,
     OperandType.UINT8,
-    OperandType.UINT8,
+    OperandType.TAG,
   ];
   static readonly wireFormat16 = [
     OperandType.UINT8,
     OperandType.UINT8,
     OperandType.UINT16,
     OperandType.UINT16,
-    OperandType.UINT8,
+    OperandType.TAG,
   ];
 
   constructor(private indirect: number, private srcOffset: number, private dstOffset: number, private dstTag: number) {
     super();
-    TaggedMemory.checkIsValidTag(dstTag);
   }
 
   public async execute(context: AvmContext): Promise<void> {

--- a/yarn-project/simulator/src/public/avm/serialization/bytecode_serialization.test.ts
+++ b/yarn-project/simulator/src/public/avm/serialization/bytecode_serialization.test.ts
@@ -179,6 +179,22 @@ describe('Bytecode Serialization', () => {
     }
   });
 
+  it('Should throw an AvmParsingError while deserializing an incomplete instruction and a wrong tag value', () => {
+    const decodeIncomplete = (truncated: Buffer) => {
+      return () => decodeFromBytecode(truncated);
+    };
+
+    const bufSet16Truncated = Buffer.from([
+      Opcode.SET_16, //opcode
+      0x02, // indirect
+      ...Buffer.from('3456', 'hex'), // dstOffset
+      0x09, //tag (invalid)
+      // We should have a 16-bit value here (truncation)
+    ]);
+
+    expect(decodeIncomplete(bufSet16Truncated)).toThrow(AvmParsingError);
+  });
+
   it('Should throw an InvalidTagValueError while deserializing a tag value out of range', () => {
     const decodeInvalidTag = (buf: Buffer) => {
       return () => decodeFromBytecode(buf);

--- a/yarn-project/simulator/src/public/avm/serialization/instruction_serialization.ts
+++ b/yarn-project/simulator/src/public/avm/serialization/instruction_serialization.ts
@@ -108,7 +108,7 @@ export enum OperandType {
 }
 
 // Define a type that represents the possible types of the deserialized values.
-export type DeserializedValue = number | bigint;
+type DeserializedValue = number | bigint;
 
 type OperandNativeType = number | bigint;
 type OperandWriter = (value: any) => void;
@@ -186,7 +186,7 @@ export function deserialize(cursor: BufferCursor | Buffer, operands: OperandType
     if (operands[i] === OperandType.TAG) {
       // We parsed a single byte (readUInt8()) and therefore value is of number type (not bigint)
       // We need to cast to number because checkIsValidTag expects a number.
-      TaggedMemory.checkIsValidTag(argValues[i] as number);
+      TaggedMemory.checkIsValidTag(Number(argValues[i]) ?? 0);
     }
   }
 


### PR DESCRIPTION
Resolves #12934