### PR TITLE
chore: comprehensive cleanup of translator flavor and use inheritance properly in flavors

### DIFF
--- a/barretenberg/cpp/src/barretenberg/eccvm/eccvm_flavor.hpp
+++ b/barretenberg/cpp/src/barretenberg/eccvm/eccvm_flavor.hpp
@@ -107,7 +107,6 @@ class ECCVMFlavor {
 
     // TODO(https://github.com/AztecProtocol/barretenberg/issues/989): refine access specifiers in flavors, this is
     // public as it is also used in the recursive flavor but the two could possibly me unified eventually
-  public:
     /**
      * @brief A base class labelling precomputed entities and (ordered) subsets of interest.
      * @details Used to build the proving key and verification key.
@@ -353,16 +352,7 @@ class ECCVMFlavor {
                         public WitnessEntities<DataType>,
                         public ShiftedEntities<DataType> {
       public:
-        // Initialize members
-        AllEntities()
-            : PrecomputedEntities<DataType>{}
-            , WitnessEntities<DataType>{}
-            , ShiftedEntities<DataType>{}
-        {}
-        // get_wires is inherited
-
         DEFINE_COMPOUND_GET_ALL(PrecomputedEntities<DataType>, WitnessEntities<DataType>, ShiftedEntities<DataType>)
-        // Gemini-specific getters.
         auto get_unshifted()
         {
             return concatenate(PrecomputedEntities<DataType>::get_all(), WitnessEntities<DataType>::get_all());
@@ -372,7 +362,6 @@ class ECCVMFlavor {
         auto get_precomputed() { return PrecomputedEntities<DataType>::get_all(); };
     };
 
-  public:
     /**
      * @brief A field element for each entity of the flavor.  These entities represent the prover polynomials
      * evaluated at one point.

--- a/barretenberg/cpp/src/barretenberg/stdlib_circuit_builders/mega_flavor.hpp
+++ b/barretenberg/cpp/src/barretenberg/stdlib_circuit_builders/mega_flavor.hpp
@@ -159,9 +159,9 @@ class MegaFlavor {
         }
         auto get_selectors() { return concatenate(get_non_gate_selectors(), get_gate_selectors()); }
 
-        auto get_sigma_polynomials() { return RefArray{ sigma_1, sigma_2, sigma_3, sigma_4 }; };
-        auto get_id_polynomials() { return RefArray{ id_1, id_2, id_3, id_4 }; };
-        auto get_table_polynomials() { return RefArray{ table_1, table_2, table_3, table_4 }; };
+        auto get_sigmas() { return RefArray{ sigma_1, sigma_2, sigma_3, sigma_4 }; };
+        auto get_ids() { return RefArray{ id_1, id_2, id_3, id_4 }; };
+        auto get_tables() { return RefArray{ table_1, table_2, table_3, table_4 }; };
     };
 
     // Mega needs to expose more public classes than most flavors due to MegaRecursive reuse, but these
@@ -297,20 +297,12 @@ class MegaFlavor {
       public:
         DEFINE_COMPOUND_GET_ALL(PrecomputedEntities<DataType>, WitnessEntities<DataType>, ShiftedEntities<DataType>)
 
-        auto get_wires() { return WitnessEntities<DataType>::get_wires(); };
-        auto get_non_gate_selectors() { return PrecomputedEntities<DataType>::get_non_gate_selectors(); }
-        auto get_gate_selectors() { return PrecomputedEntities<DataType>::get_gate_selectors(); }
-        auto get_selectors() { return PrecomputedEntities<DataType>::get_selectors(); }
-        auto get_sigmas() { return PrecomputedEntities<DataType>::get_sigma_polynomials(); };
-        auto get_ids() { return PrecomputedEntities<DataType>::get_id_polynomials(); };
-        auto get_tables() { return PrecomputedEntities<DataType>::get_table_polynomials(); };
         auto get_unshifted()
         {
             return concatenate(PrecomputedEntities<DataType>::get_all(), WitnessEntities<DataType>::get_all());
         };
         auto get_precomputed() { return PrecomputedEntities<DataType>::get_all(); }
         auto get_witness() { return WitnessEntities<DataType>::get_all(); };
-        auto get_to_be_shifted() { return WitnessEntities<DataType>::get_to_be_shifted(); };
         auto get_shifted() { return ShiftedEntities<DataType>::get_all(); };
     };
 
@@ -369,10 +361,10 @@ class MegaFlavor {
         [[nodiscard]] AllValues get_row_for_permutation_arg(size_t row_idx)
         {
             AllValues result;
-            for (auto [result_field, polynomial] : zip_view(result.get_sigma_polynomials(), get_sigma_polynomials())) {
+            for (auto [result_field, polynomial] : zip_view(result.get_sigmas(), get_sigmas())) {
                 result_field = polynomial[row_idx];
             }
-            for (auto [result_field, polynomial] : zip_view(result.get_id_polynomials(), get_id_polynomials())) {
+            for (auto [result_field, polynomial] : zip_view(result.get_ids(), get_ids())) {
                 result_field = polynomial[row_idx];
             }
             for (auto [result_field, polynomial] : zip_view(result.get_wires(), get_wires())) {

--- a/barretenberg/cpp/src/barretenberg/stdlib_circuit_builders/ultra_flavor.hpp
+++ b/barretenberg/cpp/src/barretenberg/stdlib_circuit_builders/ultra_flavor.hpp
@@ -173,9 +173,9 @@ class UltraFlavor {
         }
         auto get_selectors() { return concatenate(get_non_gate_selectors(), get_gate_selectors()); }
 
-        auto get_sigma_polynomials() { return RefArray{ sigma_1, sigma_2, sigma_3, sigma_4 }; };
-        auto get_id_polynomials() { return RefArray{ id_1, id_2, id_3, id_4 }; };
-        auto get_table_polynomials() { return RefArray{ table_1, table_2, table_3, table_4 }; };
+        auto get_sigmas() { return RefArray{ sigma_1, sigma_2, sigma_3, sigma_4 }; };
+        auto get_ids() { return RefArray{ id_1, id_2, id_3, id_4 }; };
+        auto get_tables() { return RefArray{ table_1, table_2, table_3, table_4 }; };
     };
 
     /**
@@ -231,20 +231,12 @@ class UltraFlavor {
       public:
         DEFINE_COMPOUND_GET_ALL(PrecomputedEntities<DataType>, WitnessEntities<DataType>, ShiftedEntities<DataType>)
 
-        auto get_wires() { return WitnessEntities<DataType>::get_wires(); };
-        auto get_non_gate_selectors() { return PrecomputedEntities<DataType>::get_non_gate_selectors(); }
-        auto get_gate_selectors() { return PrecomputedEntities<DataType>::get_gate_selectors(); }
-        auto get_selectors() { return PrecomputedEntities<DataType>::get_selectors(); }
-        auto get_sigmas() { return PrecomputedEntities<DataType>::get_sigma_polynomials(); };
-        auto get_ids() { return PrecomputedEntities<DataType>::get_id_polynomials(); };
-        auto get_tables() { return PrecomputedEntities<DataType>::get_table_polynomials(); };
         auto get_unshifted()
         {
             return concatenate(PrecomputedEntities<DataType>::get_all(), WitnessEntities<DataType>::get_all());
         };
         auto get_precomputed() { return PrecomputedEntities<DataType>::get_all(); }
         auto get_witness() { return WitnessEntities<DataType>::get_all(); };
-        auto get_to_be_shifted() { return WitnessEntities<DataType>::get_to_be_shifted(); };
     };
 
     /**
@@ -302,10 +294,10 @@ class UltraFlavor {
         [[nodiscard]] AllValues get_row_for_permutation_arg(size_t row_idx)
         {
             AllValues result;
-            for (auto [result_field, polynomial] : zip_view(result.get_sigma_polynomials(), get_sigma_polynomials())) {
+            for (auto [result_field, polynomial] : zip_view(result.get_sigmas(), get_sigmas())) {
                 result_field = polynomial[row_idx];
             }
-            for (auto [result_field, polynomial] : zip_view(result.get_id_polynomials(), get_id_polynomials())) {
+            for (auto [result_field, polynomial] : zip_view(result.get_ids(), get_ids())) {
                 result_field = polynomial[row_idx];
             }
             for (auto [result_field, polynomial] : zip_view(result.get_wires(), get_wires())) {

--- a/barretenberg/cpp/src/barretenberg/translator_vm/relation_correctness.test.cpp
+++ b/barretenberg/cpp/src/barretenberg/translator_vm/relation_correctness.test.cpp
@@ -694,7 +694,7 @@ TEST_F(TranslatorRelationCorrectnessTests, ZeroKnowledgePermutation)
 
     // Populate the first 4 ordered polynomials with the random values from the interleaved polynomials
     for (size_t i = 0; i < 4; i++) {
-        auto& ordered = prover_polynomials.get_ordered_constraints()[i];
+        auto& ordered = prover_polynomials.get_ordered_range_constraints()[i];
         auto& interleaved = prover_polynomials.get_interleaved()[i];
         for (size_t j = real_circuit_size; j < full_circuit_size; j++) {
             ordered.at(j) = interleaved.at(j);

--- a/barretenberg/cpp/src/barretenberg/translator_vm/translator_prover.cpp
+++ b/barretenberg/cpp/src/barretenberg/translator_vm/translator_prover.cpp
@@ -63,8 +63,9 @@ void TranslatorProver::execute_wire_and_sorted_constraints_commitments_round()
     }
 
     // The ordered range constraints are of full circuit size.
-    for (const auto& [ordered_range_constraint, label] : zip_view(
-             key->proving_key->polynomials.get_ordered_constraints(), commitment_labels.get_ordered_constraints())) {
+    for (const auto& [ordered_range_constraint, label] :
+         zip_view(key->proving_key->polynomials.get_ordered_range_constraints(),
+                  commitment_labels.get_ordered_range_constraints())) {
         commit_to_witness_polynomial(ordered_range_constraint, label);
     }
 }


### PR DESCRIPTION
Closes https://github.com/AztecProtocol/barretenberg/issues/810.

Clarify getters in the `TranslatorFlavor` and ensure all the existing getters are actually needed. We also were (and I think still are in ECCVM) using inheritance weirdly between entities so cleaned that up as well. There is still work to be done in ECCVM (added to [this](https://github.com/AztecProtocol/barretenberg/issues/939) issue).