### PR TITLE
feat: add success & error messages for bb prove/verify with --quiet flag

### DIFF
--- a/barretenberg/cpp/src/barretenberg/api/api.hpp
+++ b/barretenberg/cpp/src/barretenberg/api/api.hpp
@@ -24,6 +24,7 @@ class API {
                                    // recursive verifier) or is it for an ivc verifier?
         bool write_vk{ false };    // should we addditionally write the verification key when writing the proof
         bool include_gates_per_opcode{ false }; // should we include gates_per_opcode in the gates command output
+        bool quiet{ false };       // suppress success and error messages
 
         friend std::ostream& operator<<(std::ostream& os, const Flags& flags)
         {
@@ -43,6 +44,7 @@ class API {
                << "  verifier_type: " << flags.verifier_type << "\n"
                << "  write_vk " << flags.write_vk << "\n"
                << "  include_gates_per_opcode " << flags.include_gates_per_opcode << "\n"
+               << "  quiet " << flags.quiet << "\n"
                << "]" << std::endl;
             return os;
         }


### PR DESCRIPTION
Noticed that prove/verify only returns a code without any feedback, so I added proper output messages when running these commands. Also added a --quiet flag for when you need the original behavior.
- New quiet flag in the API::Flags struct
- Verification shows clear success/failure message
- Proof generation reports success or shows the error
- Added to all command variants for consistency
- Default is verbose, use --quiet for silent operation

Fixes #8171