### PR TITLE
fix: Bump tsc target

### DIFF
--- a/yarn-project/merkle-tree/src/standard_indexed_tree/standard_indexed_tree.ts
+++ b/yarn-project/merkle-tree/src/standard_indexed_tree/standard_indexed_tree.ts
@@ -60,7 +60,7 @@ export const noopDeserializer: FromBuffer<Buffer> = {
  * Standard implementation of an indexed tree.
  */
 export class StandardIndexedTree extends TreeBase<Buffer> implements IndexedTree {
-  #snapshotBuilder = new IndexedTreeSnapshotBuilder(this.store, this, this.leafPreimageFactory);
+  #snapshotBuilder: IndexedTreeSnapshotBuilder;
 
   protected cachedLeafPreimages: { [key: string]: IndexedTreeLeafPreimage } = {};
   protected leaves: AztecMap<ReturnType<typeof buildDbKeyForPreimage>, Buffer>;
@@ -79,6 +79,7 @@ export class StandardIndexedTree extends TreeBase<Buffer> implements IndexedTree
     super(store, hasher, name, depth, size, noopDeserializer, root);
     this.leaves = store.openMap(`tree_${name}_leaves`);
     this.leafIndex = store.openMap(`tree_${name}_leaf_index`);
+    this.#snapshotBuilder = new IndexedTreeSnapshotBuilder(this.store, this, this.leafPreimageFactory);
   }
 
   /**

--- a/yarn-project/prover-node/src/test/index.ts
+++ b/yarn-project/prover-node/src/test/index.ts
@@ -4,8 +4,8 @@ import type { ProverNodePublisher } from '../prover-node-publisher.js';
 import { ProverNode } from '../prover-node.js';
 
 class TestProverNode_ extends ProverNode {
-  public override prover!: EpochProverManager;
-  public override publisher!: ProverNodePublisher;
+  public declare prover: EpochProverManager;
+  public declare publisher: ProverNodePublisher;
 }
 
 export type TestProverNode = TestProverNode_;

--- a/yarn-project/sequencer-client/src/test/index.ts
+++ b/yarn-project/sequencer-client/src/test/index.ts
@@ -6,15 +6,15 @@ import { Sequencer } from '../sequencer/sequencer.js';
 import type { SequencerTimetable } from '../sequencer/timetable.js';
 
 class TestSequencer_ extends Sequencer {
-  public override publicProcessorFactory!: PublicProcessorFactory;
-  public override timetable!: SequencerTimetable;
-  public override publisher!: SequencerPublisher;
+  public declare publicProcessorFactory: PublicProcessorFactory;
+  public declare timetable: SequencerTimetable;
+  public declare publisher: SequencerPublisher;
 }
 
 export type TestSequencer = TestSequencer_;
 
 class TestSequencerClient_ extends SequencerClient {
-  public override sequencer!: TestSequencer;
+  public declare sequencer: TestSequencer;
 }
 
 export type TestSequencerClient = TestSequencerClient_;

--- a/yarn-project/tsconfig.json
+++ b/yarn-project/tsconfig.json
@@ -1,6 +1,6 @@
 {
   "compilerOptions": {
-    "target": "es2020",
+    "target": "es2022",
     "lib": ["dom", "esnext", "es2017.object"],
     "module": "NodeNext",
     "moduleResolution": "NodeNext",


### PR DESCRIPTION
We were using different targets for tsc and swc (es2020 vs es2022). This PR updates tsc target so it matches the swc one, to minimize incompatibilities between code built with either tool.
