### PR TITLE
fix: Network option was not being intercepted early enough

### DIFF
--- a/yarn-project/aztec/src/cli/aztec_start_action.ts
+++ b/yarn-project/aztec/src/cli/aztec_start_action.ts
@@ -51,10 +51,6 @@ export async function aztecStart(options: any, userLog: LogFn, debugLogger: Logg
       userLog(`Not exposing PXE API through JSON-RPC server`);
     }
   } else {
-    // If a network is specified, enrich the environment with the chain config
-    if (options.network) {
-      await enrichEnvironmentWithChainConfig(options.network);
-    }
     if (options.node) {
       const { startNode } = await import('./cmds/start_node.js');
       ({ config } = await startNode(options, signalHandlers, services, adminServices, userLog));

--- a/yarn-project/aztec/src/cli/aztec_start_action.ts
+++ b/yarn-project/aztec/src/cli/aztec_start_action.ts
@@ -11,7 +11,6 @@ import { getOtelJsonRpcPropagationMiddleware } from '@aztec/telemetry-client';
 
 import { createSandbox } from '../sandbox/index.js';
 import { github, splash } from '../splash.js';
-import { enrichEnvironmentWithChainConfig } from './chain_l2_config.js';
 import { getCliVersion } from './release_version.js';
 import { extractNamespacedOptions, installSignalHandlers } from './util.js';
 import { getVersions } from './versioning.js';

--- a/yarn-project/aztec/src/cli/aztec_start_options.ts
+++ b/yarn-project/aztec/src/cli/aztec_start_options.ts
@@ -65,11 +65,13 @@ export const universalOptions = [
   'dataStoreMapSizeKb',
 ];
 
+export const NETWORK_FLAG = 'network';
+
 // Define categories and options
 export const aztecStartOptions: { [key: string]: AztecStartOption[] } = {
   NETWORK: [
     {
-      flag: '--network <value>',
+      flag: `--${NETWORK_FLAG} <value>`,
       description: 'Network to run Aztec on',
       defaultValue: undefined,
       envVar: 'NETWORK',

--- a/yarn-project/aztec/src/cli/chain_l2_config.ts
+++ b/yarn-project/aztec/src/cli/chain_l2_config.ts
@@ -47,7 +47,7 @@ export const alphaTestnetL2ChainConfig: L2ChainConfig = {
   aztecEpochDuration: 32,
   aztecProofSubmissionWindow: 64,
   testAccounts: true,
-  sponsoredFPC: true,
+  sponsoredFPC: false,
   p2pEnabled: true,
   p2pBootstrapNodes: [],
   registryAddress: '0xad85d55a4bbef35e95396191c22903aa717edf1c',


### PR DESCRIPTION
This PR intercepts the `--network` option earlier in the argument parsing.
