### PR TITLE
chore: clean up portal managers and bridge-fee-juice cli

### DIFF
--- a/docs/docs/developers/reference/environment_reference/cli_wallet_reference.md
+++ b/docs/docs/developers/reference/environment_reference/cli_wallet_reference.md
@@ -218,10 +218,10 @@ Using the sandbox, there's already a Fee Juice contract that manages this enshri
 
 #### Example
 
-This example mints and bridges 1000 units of fee juice and bridges it to the `master_yoda` recipient on L2.
+This example mints and bridges fee juice to the `master_yoda` recipient on L2.
 
 ```bash
-aztec-wallet bridge-fee-juice --mint 1000 master_yoda
+aztec-wallet bridge-fee-juice master_yoda
 ```
 
 ## Proving

--- a/yarn-project/aztec.js/src/ethereum/portal_manager.ts
+++ b/yarn-project/aztec.js/src/ethereum/portal_manager.ts
@@ -63,11 +63,11 @@ export class L1TokenManager {
   public constructor(
     /** Address of the ERC20 contract. */
     public readonly tokenAddress: EthAddress,
-    /** Address of the handler/faucet contract. */
-    public readonly handlerAddress: EthAddress | undefined,
     private publicClient: ViemPublicClient,
     private walletClient: ViemWalletClient,
     private logger: Logger,
+    /** Address of the handler/faucet contract. */
+    public readonly handlerAddress: EthAddress | undefined = undefined,
   ) {
     this.contract = getContract({
       address: this.tokenAddress.toString(),
@@ -103,17 +103,27 @@ export class L1TokenManager {
 
   /**
    * Mints a fixed amount of tokens for the given address. Returns once the tx has been mined.
+   * @param amount - Amount to mint. Only used if a handler is not provided.
    * @param address - Address to mint the tokens for.
    * @param addressName - Optional name of the address for logging.
+   * @returns The amount of tokens minted.
    */
-  public async mint(address: Hex, addressName?: string) {
-    if (!this.handler) {
-      throw new Error('Minting handler was not provided');
+  public async mint(amount: bigint | undefined, address: Hex, addressName?: string) {
+    if (this.handler) {
+      if (amount) {
+        this.logger.warn('Amount provided but handler is provided, ignoring amount');
+      }
+      const mintAmount = await this.getMintAmount();
+      this.logger.info(`Minting ${mintAmount} tokens for ${stringifyEthAddress(address, addressName)}`);
+      await this.handler.write.mint([address]);
+      return mintAmount;
+    } else if (amount) {
+      this.logger.info(`Minting ${amount} tokens for ${stringifyEthAddress(address, addressName)}`);
+      await this.contract.write.mint([address, amount]);
+      return amount;
+    } else {
+      throw new Error('Amount must be provided if no handler is provided');
     }
-    const mintAmount = await this.getMintAmount();
-    this.logger.info(`Minting ${mintAmount} tokens for ${stringifyEthAddress(address, addressName)}`);
-    // NOTE: the handler mints a fixed amount.
-    await this.handler.write.mint([address]);
   }
 
   /**
@@ -138,12 +148,12 @@ export class L1FeeJuicePortalManager {
   constructor(
     portalAddress: EthAddress,
     tokenAddress: EthAddress,
-    handlerAddress: EthAddress,
     private readonly publicClient: ViemPublicClient,
     private readonly walletClient: ViemWalletClient,
     private readonly logger: Logger,
+    handlerAddress: EthAddress | undefined = undefined,
   ) {
-    this.tokenManager = new L1TokenManager(tokenAddress, handlerAddress, publicClient, walletClient, logger);
+    this.tokenManager = new L1TokenManager(tokenAddress, publicClient, walletClient, logger, handlerAddress);
     this.contract = getContract({
       address: portalAddress.toString(),
       abi: FeeJuicePortalAbi,
@@ -156,27 +166,11 @@ export class L1FeeJuicePortalManager {
     return this.tokenManager;
   }
 
-  /**
-   * Bridges fee juice from L1 to L2 publicly. Handles L1 ERC20 approvals. Returns once the tx has been mined.
-   * @param to - Address to send the tokens to on L2.
-   * @param amount - Amount of tokens to send.
-   * @param mint - Whether to mint the tokens before sending (only during testing).
-   */
-  public async bridgeTokensPublic(to: AztecAddress, amount: bigint | undefined, mint = false): Promise<L2AmountClaim> {
-    const [claimSecret, claimSecretHash] = await generateClaimSecret();
-    const mintableAmount = await this.tokenManager.getMintAmount();
-    const amountToBridge = amount ?? mintableAmount;
-    if (mint) {
-      if (amountToBridge !== mintableAmount) {
-        throw new Error(`Minting amount must be ${mintableAmount}`);
-      }
-      await this.tokenManager.mint(this.walletClient.account.address);
-    }
-
-    await this.tokenManager.approve(amountToBridge, this.contract.address, 'FeeJuice Portal');
+  private async bridgeTokens(to: AztecAddress, amount: bigint, claimSecret: Fr, claimSecretHash: Fr) {
+    await this.tokenManager.approve(amount, this.contract.address, 'FeeJuice Portal');
 
     this.logger.info('Sending L1 Fee Juice to L2 to be claimed publicly');
-    const args = [to.toString(), amountToBridge, claimSecretHash.toString()] as const;
+    const args = [to.toString(), amount, claimSecretHash.toString()] as const;
 
     await this.contract.simulate.depositToAztecPublic(args);
 
@@ -193,18 +187,49 @@ export class L1FeeJuicePortalManager {
       'DepositToAztecPublic',
       log =>
         log.args.secretHash === claimSecretHash.toString() &&
-        log.args.amount === amountToBridge &&
+        log.args.amount === amount &&
         log.args.to === to.toString(),
       this.logger,
     );
 
     return {
-      claimAmount: amountToBridge,
+      claimAmount: amount,
       claimSecret,
       claimSecretHash,
       messageHash: log.args.key,
       messageLeafIndex: log.args.index,
     };
+  }
+
+  /**
+   * Bridges tokens to L2 after minting from the faucet on L1.
+   * @param to - Address to send the tokens to on L2.
+   */
+  public async bridgeTokensFromFaucet(to: AztecAddress) {
+    const [claimSecret, claimSecretHash] = await generateClaimSecret();
+
+    const amountToBridge = await this.tokenManager.mint(undefined, this.walletClient.account.address);
+    if (!amountToBridge) {
+      throw new Error('Amount must be provided if not minting');
+    }
+
+    return this.bridgeTokens(to, amountToBridge, claimSecret, claimSecretHash);
+  }
+
+  /**
+   * Bridges tokens to L2 after minting directly from the L1 ERC20.
+   * @param to - Address to send the tokens to on L2.
+   * @param amount - Amount of tokens to mint and bridge.
+   */
+  public async bridgeTokensAsMinter(to: AztecAddress, amount: bigint) {
+    const [claimSecret, claimSecretHash] = await generateClaimSecret();
+
+    const amountToBridge = await this.tokenManager.mint(amount, this.walletClient.account.address);
+    if (!amountToBridge) {
+      throw new Error('Amount must be provided if not minting');
+    }
+
+    return this.bridgeTokens(to, amountToBridge, claimSecret, claimSecretHash);
   }
 
   /**
@@ -227,17 +252,14 @@ export class L1FeeJuicePortalManager {
     if (feeJuiceAddress.isZero() || feeJuicePortalAddress.isZero()) {
       throw new Error('Portal or token not deployed on L1');
     }
-    if (!feeAssetHandlerAddress || feeAssetHandlerAddress.isZero()) {
-      throw new Error('Handler not deployed on L1, or handler address is zero');
-    }
 
     return new L1FeeJuicePortalManager(
       feeJuicePortalAddress,
       feeJuiceAddress,
-      feeAssetHandlerAddress,
       publicClient,
       walletClient,
       logger,
+      feeAssetHandlerAddress,
     );
   }
 }
@@ -250,12 +272,12 @@ export class L1ToL2TokenPortalManager {
   constructor(
     portalAddress: EthAddress,
     tokenAddress: EthAddress,
-    handlerAddress: EthAddress | undefined,
     protected publicClient: ViemPublicClient,
     protected walletClient: ViemWalletClient,
     protected logger: Logger,
+    handlerAddress: EthAddress | undefined = undefined,
   ) {
-    this.tokenManager = new L1TokenManager(tokenAddress, handlerAddress, publicClient, walletClient, logger);
+    this.tokenManager = new L1TokenManager(tokenAddress, publicClient, walletClient, logger, handlerAddress);
     this.portal = getContract({
       address: portalAddress.toString(),
       abi: TokenPortalAbi,
@@ -356,11 +378,7 @@ export class L1ToL2TokenPortalManager {
 
   private async bridgeSetup(amount: bigint, mint: boolean) {
     if (mint) {
-      const mintableAmount = await this.tokenManager.getMintAmount();
-      if (amount !== mintableAmount) {
-        throw new Error(`Minting amount must be ${mintableAmount} for testing`);
-      }
-      await this.tokenManager.mint(this.walletClient.account.address);
+      await this.tokenManager.mint(amount, this.walletClient.account.address);
     }
     await this.tokenManager.approve(amount, this.portal.address, 'TokenPortal');
     return generateClaimSecret();
@@ -374,13 +392,12 @@ export class L1TokenPortalManager extends L1ToL2TokenPortalManager {
   constructor(
     portalAddress: EthAddress,
     tokenAddress: EthAddress,
-    handlerAddress: EthAddress | undefined,
     outboxAddress: EthAddress,
     publicClient: ViemPublicClient,
     walletClient: ViemWalletClient,
     logger: Logger,
   ) {
-    super(portalAddress, tokenAddress, handlerAddress, publicClient, walletClient, logger);
+    super(portalAddress, tokenAddress, publicClient, walletClient, logger, undefined);
     this.outbox = getContract({
       address: outboxAddress.toString(),
       abi: OutboxAbi,

--- a/yarn-project/bot/src/factory.ts
+++ b/yarn-project/bot/src/factory.ts
@@ -348,13 +348,12 @@ export class BotFactory {
     const { publicClient, walletClient } = createL1Clients(chain.rpcUrls, mnemonicOrPrivateKey, chain.chainInfo);
 
     const portal = await L1FeeJuicePortalManager.new(this.pxe, publicClient, walletClient, this.log);
-    const mintAmount = await portal.getTokenManager().getMintAmount();
-    const claim = await portal.bridgeTokensPublic(recipient, mintAmount, true /* mint */);
+    const claim = await portal.bridgeTokensFromFaucet(recipient);
 
     const isSynced = async () => await this.pxe.isL1ToL2MessageSynced(Fr.fromHexString(claim.messageHash));
     await retryUntil(isSynced, `message ${claim.messageHash} sync`, 24, 1);
 
-    this.log.info(`Created a claim for ${mintAmount} L1 fee juice to ${recipient}.`, claim);
+    this.log.info(`Created a claim for ${claim.claimAmount} L1 fee juice to ${recipient}.`, claim);
 
     // Progress by 2 L2 blocks so that the l1ToL2Message added above will be available to use on L2.
     await this.advanceL2Block();

--- a/yarn-project/cli-wallet/src/cmds/bridge_fee_juice.ts
+++ b/yarn-project/cli-wallet/src/cmds/bridge_fee_juice.ts
@@ -6,14 +6,12 @@ import type { LogFn, Logger } from '@aztec/foundation/log';
 import type { AztecAddress } from '@aztec/stdlib/aztec-address';
 
 export async function bridgeL1FeeJuice(
-  amount: bigint,
   recipient: AztecAddress,
   pxe: PXE,
   l1RpcUrls: string[],
   chainId: number,
   privateKey: string | undefined,
   mnemonic: string,
-  mint: boolean,
   json: boolean,
   wait: boolean,
   interval = 60_000,
@@ -30,11 +28,7 @@ export async function bridgeL1FeeJuice(
 
   // Setup portal manager
   const portal = await L1FeeJuicePortalManager.new(pxe, publicClient, walletClient, debugLogger);
-  const { claimAmount, claimSecret, messageHash, messageLeafIndex } = await portal.bridgeTokensPublic(
-    recipient,
-    amount,
-    mint,
-  );
+  const { claimAmount, claimSecret, messageHash, messageLeafIndex } = await portal.bridgeTokensFromFaucet(recipient);
 
   if (json) {
     const out = {
@@ -44,11 +38,7 @@ export async function bridgeL1FeeJuice(
     };
     log(prettyPrintJSON(out));
   } else {
-    if (mint) {
-      log(`Minted ${claimAmount} fee juice on L1 and pushed to L2 portal`);
-    } else {
-      log(`Bridged ${claimAmount} fee juice to L2 portal`);
-    }
+    log(`Minted ${claimAmount} fee juice on L1 and pushed to L2 portal`);
     log(
       `claimAmount=${claimAmount},claimSecret=${claimSecret},messageHash=${messageHash},messageLeafIndex=${messageLeafIndex}\n`,
     );
@@ -84,5 +74,5 @@ export async function bridgeL1FeeJuice(
     }
   }
 
-  return [claimSecret, messageLeafIndex] as const;
+  return [claimSecret, messageLeafIndex, claimAmount] as const;
 }

--- a/yarn-project/cli-wallet/src/cmds/index.ts
+++ b/yarn-project/cli-wallet/src/cmds/index.ts
@@ -435,7 +435,7 @@ export function injectCommands(
         debugLogger,
       );
       if (db) {
-        await db.pushBridgedFeeJuice(recipient, secret, messageLeafIndex, claimAmount, log);
+        await db.pushBridgedFeeJuice(recipient, secret, claimAmount, messageLeafIndex, log);
       }
     });
 

--- a/yarn-project/cli-wallet/src/cmds/index.ts
+++ b/yarn-project/cli-wallet/src/cmds/index.ts
@@ -8,7 +8,6 @@ import {
   createSecretKeyOption,
   l1ChainIdOption,
   logJson,
-  parseBigint,
   parseFieldFromHexString,
   parsePublicKey,
   pxeOption,
@@ -391,7 +390,6 @@ export function injectCommands(
   program
     .command('bridge-fee-juice')
     .description('Mints L1 Fee Juice and pushes them to L2.')
-    .argument('<amount>', 'The amount of Fee Juice to mint and bridge.', parseBigint)
     .argument('<recipient>', 'Aztec address of the recipient.', address =>
       aliasedAddressParser('accounts', address, db),
     )
@@ -406,7 +404,6 @@ export function injectCommands(
       'The mnemonic to use for deriving the Ethereum address that will mint and bridge',
       'test test test test test test test test test test test junk',
     )
-    .option('--mint', 'Mint the tokens on L1', false)
     .option('--l1-private-key <string>', 'The private key to the eth account bridging', PRIVATE_KEY)
     .addOption(pxeOption)
     .addOption(l1ChainIdOption)
@@ -419,21 +416,18 @@ export function injectCommands(
         .default('60')
         .conflicts('wait'),
     )
-    .action(async (amount, recipient, options) => {
+    .action(async (recipient, options) => {
       const { bridgeL1FeeJuice } = await import('./bridge_fee_juice.js');
-      const { rpcUrl, l1ChainId, l1RpcUrls, l1PrivateKey, mnemonic, mint, json, wait, interval: intervalS } = options;
+      const { rpcUrl, l1ChainId, l1RpcUrls, l1PrivateKey, mnemonic, json, wait, interval: intervalS } = options;
       const client = pxeWrapper?.getPXE() ?? (await createCompatibleClient(rpcUrl, debugLogger));
-      log(`Minting ${amount} fee juice on L1 and pushing to L2`);
 
-      const [secret, messageLeafIndex] = await bridgeL1FeeJuice(
-        amount,
+      const [secret, messageLeafIndex, claimAmount] = await bridgeL1FeeJuice(
         recipient,
         client,
         l1RpcUrls,
         l1ChainId,
         l1PrivateKey,
         mnemonic,
-        mint,
         json,
         wait,
         intervalS * 1000,
@@ -441,7 +435,7 @@ export function injectCommands(
         debugLogger,
       );
       if (db) {
-        await db.pushBridgedFeeJuice(recipient, secret, amount, messageLeafIndex, log);
+        await db.pushBridgedFeeJuice(recipient, secret, messageLeafIndex, claimAmount, log);
       }
     });
 

--- a/yarn-project/cli-wallet/test/flows/create_account_pay_native.sh
+++ b/yarn-project/cli-wallet/test/flows/create_account_pay_native.sh
@@ -7,7 +7,7 @@ test_title "Create an account and deploy using native fee payment with bridging"
 
 # docs:start:bridge-fee-juice
 aztec-wallet create-account -a main --register-only
-aztec-wallet bridge-fee-juice 1000000000000000000 main --mint --no-wait
+aztec-wallet bridge-fee-juice main --no-wait
 # docs:end:bridge-fee-juice
 
 

--- a/yarn-project/cli-wallet/test/flows/shared/create_funded_account.sh
+++ b/yarn-project/cli-wallet/test/flows/shared/create_funded_account.sh
@@ -3,7 +3,7 @@ ALIAS=$1
 section "Creating a funded account (alias: $ALIAS)"
 
 aztec-wallet create-account -a $ALIAS --register-only
-aztec-wallet bridge-fee-juice 1000000000000000000 $ALIAS --mint --no-wait
+aztec-wallet bridge-fee-juice $ALIAS --no-wait
 
 # The following produces two blocks, allowing the claim to be used in the next block.
 source $flows/shared/deploy_token.sh tmp-token-$ALIAS $ALIAS

--- a/yarn-project/cli-wallet/test/flows/shared/deploy_main_account_and_token.sh
+++ b/yarn-project/cli-wallet/test/flows/shared/deploy_main_account_and_token.sh
@@ -4,7 +4,7 @@ ACCOUNT_ALIAS=main
 section "Deploying token contract (alias: $TOKEN_ALIAS) and creating a funded account (alias: $ACCOUNT_ALIAS)"
 
 aztec-wallet create-account -a $ACCOUNT_ALIAS --register-only
-aztec-wallet bridge-fee-juice 1000000000000000000 $ACCOUNT_ALIAS --mint --no-wait
+aztec-wallet bridge-fee-juice $ACCOUNT_ALIAS --no-wait
 
 # Deploy token contract and set the main account as a minter.
 # The following produces two blocks, allowing the claim to be used in the next block.

--- a/yarn-project/cli-wallet/test/flows/shared/deploy_sponsored_fpc_and_token.sh
+++ b/yarn-project/cli-wallet/test/flows/shared/deploy_sponsored_fpc_and_token.sh
@@ -6,7 +6,7 @@ section "Deploying token contract (alias: $TOKEN_ALIAS) and creating a sponsored
 aztec-wallet import-test-accounts
 aztec-wallet deploy sponsored_fpc_contract@SponsoredFPC -f test0 -a $FPC_ALIAS --no-init
 
-CLAIM=$(aztec-wallet bridge-fee-juice 1000000000000000000 contracts:$FPC_ALIAS --mint --no-wait --json)
+CLAIM=$(aztec-wallet bridge-fee-juice contracts:$FPC_ALIAS --no-wait --json)
 
 retrieve () {
   echo "$CLAIM" | grep "\"$1\"" | awk -F ': ' '{print $2}' | tr -d '",'

--- a/yarn-project/cli/src/cmds/devnet/bootstrap_network.ts
+++ b/yarn-project/cli/src/cmds/devnet/bootstrap_network.ts
@@ -13,6 +13,7 @@ import {
   retryUntil,
   waitForProven,
 } from '@aztec/aztec.js';
+import { FEE_FUNDING_FOR_TESTER_ACCOUNT } from '@aztec/constants';
 import {
   type ContractArtifacts,
   type L1Clients,
@@ -295,10 +296,9 @@ async function fundFPC(
     debugLog,
   );
 
-  const { claimAmount, claimSecret, messageLeafIndex, messageHash } = await feeJuicePortal.bridgeTokensPublic(
+  const { claimAmount, claimSecret, messageLeafIndex, messageHash } = await feeJuicePortal.bridgeTokensAsMinter(
     fpcAddress,
-    undefined,
-    true,
+    FEE_FUNDING_FOR_TESTER_ACCOUNT,
   );
 
   await retryUntil(async () => await pxe.isL1ToL2MessageSynced(Fr.fromHexString(messageHash)), 'message sync', 600, 1);

--- a/yarn-project/cli/src/cmds/l1/bridge_erc20.ts
+++ b/yarn-project/cli/src/cmds/l1/bridge_erc20.ts
@@ -12,7 +12,6 @@ export async function bridgeERC20(
   privateKey: string | undefined,
   mnemonic: string,
   tokenAddress: EthAddress,
-  handlerAddress: EthAddress | undefined,
   portalAddress: EthAddress,
   privateTransfer: boolean,
   mint: boolean,
@@ -25,14 +24,7 @@ export async function bridgeERC20(
   const { publicClient, walletClient } = createL1Clients(chain.rpcUrls, privateKey ?? mnemonic, chain.chainInfo);
 
   // Setup portal manager
-  const manager = new L1ToL2TokenPortalManager(
-    portalAddress,
-    tokenAddress,
-    handlerAddress,
-    publicClient,
-    walletClient,
-    debugLogger,
-  );
+  const manager = new L1ToL2TokenPortalManager(portalAddress, tokenAddress, publicClient, walletClient, debugLogger);
   let claimSecret: Fr;
   let messageHash: `0x${string}`;
   if (privateTransfer) {

--- a/yarn-project/cli/src/cmds/l1/index.ts
+++ b/yarn-project/cli/src/cmds/l1/index.ts
@@ -459,7 +459,6 @@ export function injectCommands(program: Command, log: LogFn, debugLogger: Logger
     .addOption(l1ChainIdOption)
     .requiredOption('-t, --token <string>', 'The address of the token to bridge', parseEthereumAddress)
     .requiredOption('-p, --portal <string>', 'The address of the portal contract', parseEthereumAddress)
-    .option('-f, --faucet <string>', 'The address of the faucet contract (only used if minting)', parseEthereumAddress)
     .option('--l1-private-key <string>', 'The private key to use for deployment', PRIVATE_KEY)
     .option('--json', 'Output the claim in JSON format')
     .action(async (amount, recipient, options) => {
@@ -472,7 +471,6 @@ export function injectCommands(program: Command, log: LogFn, debugLogger: Logger
         options.l1PrivateKey,
         options.mnemonic,
         options.token,
-        options.faucet,
         options.portal,
         options.private,
         options.mint,

--- a/yarn-project/end-to-end/src/e2e_token_bridge_tutorial_test.test.ts
+++ b/yarn-project/end-to-end/src/e2e_token_bridge_tutorial_test.test.ts
@@ -11,14 +11,7 @@ import {
   waitForPXE,
 } from '@aztec/aztec.js';
 import { createL1Clients, deployL1Contract } from '@aztec/ethereum';
-import {
-  FeeAssetHandlerAbi,
-  FeeAssetHandlerBytecode,
-  TestERC20Abi,
-  TestERC20Bytecode,
-  TokenPortalAbi,
-  TokenPortalBytecode,
-} from '@aztec/l1-artifacts';
+import { TestERC20Abi, TestERC20Bytecode, TokenPortalAbi, TokenPortalBytecode } from '@aztec/l1-artifacts';
 import { TokenContract } from '@aztec/noir-contracts.js/Token';
 import { TokenBridgeContract } from '@aztec/noir-contracts.js/TokenBridge';
 
@@ -31,8 +24,6 @@ const { ETHEREUM_HOSTS = 'http://localhost:8545' } = process.env;
 
 const { walletClient, publicClient } = createL1Clients(ETHEREUM_HOSTS.split(','), MNEMONIC);
 const ownerEthAddress = walletClient.account.address;
-
-const MINT_AMOUNT = BigInt(1e15);
 
 const setupSandbox = async () => {
   const { PXE_URL = 'http://localhost:8080' } = process.env;
@@ -50,37 +41,19 @@ async function deployTestERC20(): Promise<EthAddress> {
   );
 }
 
-async function deployFeeAssetHandler(l1TokenContract: EthAddress): Promise<EthAddress> {
-  const constructorArgs = [walletClient.account.address, l1TokenContract.toString(), MINT_AMOUNT];
-  return await deployL1Contract(
-    walletClient,
-    publicClient,
-    FeeAssetHandlerAbi,
-    FeeAssetHandlerBytecode,
-    constructorArgs,
-  ).then(({ address }) => address);
-}
-
 async function deployTokenPortal(): Promise<EthAddress> {
   return await deployL1Contract(walletClient, publicClient, TokenPortalAbi, TokenPortalBytecode, []).then(
     ({ address }) => address,
   );
 }
 
-async function addMinter(l1TokenContract: EthAddress, l1TokenHandler: EthAddress) {
-  const contract = getContract({
-    address: l1TokenContract.toString(),
-    abi: TestERC20Abi,
-    client: walletClient,
-  });
-  await contract.write.addMinter([l1TokenHandler.toString()]);
-}
 // docs:end:utils
 
 describe('e2e_cross_chain_messaging token_bridge_tutorial_test', () => {
   it('Deploys tokens & bridges to L1 & L2, mints & publicly bridges tokens', async () => {
     // docs:start:setup
     const logger = createLogger('aztec:token-bridge-tutorial');
+    const amount = BigInt(100);
     const pxe = await setupSandbox();
     const wallets = await getInitialTestAccountsWallets(pxe);
     const ownerWallet = wallets[0];
@@ -106,10 +79,7 @@ describe('e2e_cross_chain_messaging token_bridge_tutorial_test', () => {
     const l1TokenContract = await deployTestERC20();
     logger.info('erc20 contract deployed');
 
-    const feeAssetHandler = await deployFeeAssetHandler(l1TokenContract);
-    await addMinter(l1TokenContract, feeAssetHandler);
-
-    const l1TokenManager = new L1TokenManager(l1TokenContract, feeAssetHandler, publicClient, walletClient, logger);
+    const l1TokenManager = new L1TokenManager(l1TokenContract, publicClient, walletClient, logger);
     // docs:end:deploy-l1-token
 
     // Deploy L1 portal contract
@@ -151,7 +121,6 @@ describe('e2e_cross_chain_messaging token_bridge_tutorial_test', () => {
     const l1PortalManager = new L1TokenPortalManager(
       l1PortalContractAddress,
       l1TokenContract,
-      feeAssetHandler,
       l1ContractAddresses.outboxAddress,
       publicClient,
       walletClient,
@@ -160,7 +129,7 @@ describe('e2e_cross_chain_messaging token_bridge_tutorial_test', () => {
     // docs:end:setup-portal
 
     // docs:start:l1-bridge-public
-    const claim = await l1PortalManager.bridgeTokensPublic(ownerAztecAddress, MINT_AMOUNT, true);
+    const claim = await l1PortalManager.bridgeTokensPublic(ownerAztecAddress, amount, true);
 
     // Do 2 unrleated actions because
     // https://github.com/AztecProtocol/aztec-packages/blob/7e9e2681e314145237f95f79ffdc95ad25a0e319/yarn-project/end-to-end/src/shared/cross_chain_test_harness.ts#L354-L355
@@ -171,7 +140,7 @@ describe('e2e_cross_chain_messaging token_bridge_tutorial_test', () => {
     // Claim tokens publicly on L2
     // docs:start:claim
     await l2BridgeContract.methods
-      .claim_public(ownerAztecAddress, MINT_AMOUNT, claim.claimSecret, claim.messageLeafIndex)
+      .claim_public(ownerAztecAddress, amount, claim.claimSecret, claim.messageLeafIndex)
       .send()
       .wait();
     const balance = await l2TokenContract.methods.balance_of_public(ownerAztecAddress).simulate();

--- a/yarn-project/end-to-end/src/shared/cross_chain_test_harness.ts
+++ b/yarn-project/end-to-end/src/shared/cross_chain_test_harness.ts
@@ -216,7 +216,6 @@ export class CrossChainTestHarness {
     this.l1TokenPortalManager = new L1TokenPortalManager(
       this.tokenPortalAddress,
       this.underlyingERC20Address,
-      this.l1ContractAddresses.feeAssetHandlerAddress,
       this.l1ContractAddresses.outboxAddress,
       this.publicClient,
       this.walletClient,
@@ -227,12 +226,7 @@ export class CrossChainTestHarness {
   }
 
   async mintTokensOnL1(amount: bigint) {
-    const contract = getContract({
-      abi: TestERC20Abi,
-      address: this.l1TokenManager.tokenAddress.toString(),
-      client: this.walletClient,
-    });
-    await contract.write.mint([this.ethAccount.toString(), amount]);
+    await this.l1TokenManager.mint(amount, this.ethAccount.toString());
     expect(await this.l1TokenManager.getL1TokenBalance(this.ethAccount.toString())).toEqual(amount);
   }
 

--- a/yarn-project/end-to-end/src/spartan/setup_test_wallets.ts
+++ b/yarn-project/end-to-end/src/spartan/setup_test_wallets.ts
@@ -108,7 +108,7 @@ async function bridgeL1FeeJuice(
 
   // docs:start:bridge_fee_juice
   const portal = await L1FeeJuicePortalManager.new(pxe, publicClient, walletClient, log);
-  const claim = await portal.bridgeTokensPublic(recipient, amount, true /* mint */);
+  const claim = await portal.bridgeTokensFromFaucet(recipient);
   // docs:end:bridge_fee_juice
 
   const isSynced = async () => await pxe.isL1ToL2MessageSynced(Fr.fromHexString(claim.messageHash));


### PR DESCRIPTION
The FeeJuicePortalManager now can be used either as someone who is a "minter" on the underlying token, or as a regular use. They can use `bridgeTokensAsMinter` or `bridgeTokensFromFaucet` respectively. 

Use of a handler is now optional in the L1TokenManager, and the other portal managers- in the `mint` function, if a handler is provided, it will be used. Else, admin/minting rights are assumed (caller beware). 

The bridging tutorial test was updated to remove any notion of a handler, since it is more generic than fee juice. 

Also, the `bridge-fee-juice` cli was streamlined to support the case where (non-admin) users are trying to mint/bridge fee juice. So it mints by default, and an "amount" is not accepted as an arg, since it is determined by the handler.