### PR TITLE
fix: invalid getCommittee function

### DIFF
--- a/l1-contracts/src/core/Rollup.sol
+++ b/l1-contracts/src/core/Rollup.sol
@@ -131,6 +131,23 @@ contract Rollup is IStaking, IValidatorSelection, IRollup, RollupCore {
   }
 
   /**
+   * @notice  Get the validator set for a given epoch
+   *
+   * @dev     Consider removing this to replace with a `size` and individual getter.
+   *
+   * @param _epoch The epoch number to get the validator set for
+   *
+   * @return The validator set for the given epoch
+   */
+  function getEpochCommittee(Epoch _epoch)
+    external
+    override(IValidatorSelection)
+    returns (address[] memory)
+  {
+    return ValidatorSelectionLib.getCommitteeAt(StakingLib.getStorage(), _epoch);
+  }
+
+  /**
    * @notice  Get the committee for a given timestamp
    *
    * @param _ts - The timestamp to get the committee for
@@ -392,24 +409,6 @@ contract Rollup is IStaking, IValidatorSelection, IRollup, RollupCore {
     address attester = StakingLib.getStorage().attesters.at(_index);
     return
       OperatorInfo({proposer: StakingLib.getStorage().info[attester].proposer, attester: attester});
-  }
-
-  /**
-   * @notice  Get the validator set for a given epoch
-   *
-   * @dev     Consider removing this to replace with a `size` and individual getter.
-   *
-   * @param _epoch The epoch number to get the validator set for
-   *
-   * @return The validator set for the given epoch
-   */
-  function getEpochCommittee(Epoch _epoch)
-    external
-    view
-    override(IValidatorSelection)
-    returns (address[] memory)
-  {
-    return ValidatorSelectionLib.getStorage().epochs[_epoch].committee;
   }
 
   /**

--- a/l1-contracts/src/core/interfaces/IValidatorSelection.sol
+++ b/l1-contracts/src/core/interfaces/IValidatorSelection.sol
@@ -36,6 +36,7 @@ interface IValidatorSelection is IValidatorSelectionCore {
   // Non view as uses transient storage
   function getCurrentEpochCommittee() external returns (address[] memory);
   function getCommitteeAt(Timestamp _ts) external returns (address[] memory);
+  function getEpochCommittee(Epoch _epoch) external returns (address[] memory);
 
   // Stable
   function getCurrentEpoch() external view returns (Epoch);
@@ -46,7 +47,6 @@ interface IValidatorSelection is IValidatorSelectionCore {
 
   // Likely removal of these to replace with a size and indiviual getter
   // Get the current epoch committee
-  function getEpochCommittee(Epoch _epoch) external view returns (address[] memory);
   function getAttesters() external view returns (address[] memory);
 
   function getSampleSeedAt(Timestamp _ts) external view returns (uint256);

--- a/l1-contracts/src/periphery/SlashPayload.sol
+++ b/l1-contracts/src/periphery/SlashPayload.sol
@@ -15,14 +15,20 @@ contract SlashPayload is IPayload {
   IValidatorSelection public immutable VALIDATOR_SELECTION;
   uint256 public immutable AMOUNT;
 
+  address[] public attesters;
+
   constructor(Epoch _epoch, IValidatorSelection _validatorSelection, uint256 _amount) {
     EPOCH = _epoch;
     VALIDATOR_SELECTION = _validatorSelection;
     AMOUNT = _amount;
+
+    address[] memory attesters_ = IValidatorSelection(VALIDATOR_SELECTION).getEpochCommittee(EPOCH);
+    for (uint256 i = 0; i < attesters_.length; i++) {
+      attesters.push(attesters_[i]);
+    }
   }
 
   function getActions() external view override(IPayload) returns (IPayload.Action[] memory) {
-    address[] memory attesters = IValidatorSelection(VALIDATOR_SELECTION).getEpochCommittee(EPOCH);
     IPayload.Action[] memory actions = new IPayload.Action[](attesters.length);
 
     for (uint256 i = 0; i < attesters.length; i++) {

--- a/l1-contracts/test/validator-selection/ValidatorSelection.t.sol
+++ b/l1-contracts/test/validator-selection/ValidatorSelection.t.sol
@@ -164,6 +164,24 @@ contract ValidatorSelectionTest is DecoderBase {
     assertEq(expectedProposer, actualProposer, "Invalid proposer");
   }
 
+  function testCommitteeForNonSetupEpoch(uint8 _epochsToJump) public setup(4) {
+    Epoch pre = rollup.getCurrentEpoch();
+    vm.warp(
+      block.timestamp
+        + uint256(_epochsToJump) * rollup.getEpochDuration() * rollup.getSlotDuration()
+    );
+
+    Epoch post = rollup.getCurrentEpoch();
+
+    uint256 validatorSetSize = rollup.getAttesters().length;
+    uint256 targetCommitteeSize = rollup.getTargetCommitteeSize();
+    uint256 expectedSize =
+      validatorSetSize > targetCommitteeSize ? targetCommitteeSize : validatorSetSize;
+
+    assertEq(rollup.getEpochCommittee(pre).length, expectedSize, "Invalid committee size");
+    assertEq(rollup.getEpochCommittee(post).length, expectedSize, "Invalid committee size");
+  }
+
   function testValidatorSetLargerThanCommittee(bool _insufficientSigs) public setup(100) {
     assertGt(rollup.getAttesters().length, rollup.getTargetCommitteeSize(), "Not enough validators");
     uint256 committeeSize = rollup.getTargetCommitteeSize() * 2 / 3 + (_insufficientSigs ? 0 : 1);

--- a/yarn-project/ethereum/src/contracts/rollup.ts
+++ b/yarn-project/ethereum/src/contracts/rollup.ts
@@ -218,6 +218,17 @@ export class RollupContract {
     return result;
   }
 
+  async getEpochCommittee(epoch: bigint) {
+    const { result } = await this.client.simulateContract({
+      address: this.address,
+      abi: RollupAbi,
+      functionName: 'getEpochCommittee',
+      args: [epoch],
+    });
+
+    return result;
+  }
+
   getBlock(blockNumber: bigint) {
     return this.rollup.read.getBlock([blockNumber]);
   }
@@ -389,10 +400,6 @@ export class RollupContract {
 
   getAttesters() {
     return this.rollup.read.getAttesters();
-  }
-
-  getEpochCommittee(epoch: bigint) {
-    return this.rollup.read.getEpochCommittee([epoch]);
   }
 
   getInfo(address: Hex | EthAddress) {


### PR DESCRIPTION
The implementation of the rollup currently have a plethora of functions to get the same value for getting a committee, mainly different in what input type they are requiring. This is only realy something we got to make simulation simpler atm, so we should get back to it, but one of them were reading from storage and not making the sampling if needed. Causing a case where if you read the next epoch committee with the "wrong" function it would be empty while it is in reality could be with 48 members.