### PR TITLE
feat: gas benchmark for "normal usage"

### DIFF
--- a/l1-contracts/.gitignore
+++ b/l1-contracts/.gitignore
@@ -27,3 +27,6 @@ serve/
 
 gas_report.new.*
 gas_report.diff
+
+gas_benchmark.new.*
+gas_benchmark.diff

--- a/l1-contracts/gas_benchmark.md
+++ b/l1-contracts/gas_benchmark.md
@@ -1,26 +1,26 @@
-| src/core/Rollup.sol:Rollup contract |                 |         |         |         |         |
-|-------------------------------------|-----------------|---------|---------|---------|---------|
-| Deployment Cost                     | Deployment Size |         |         |         |         |
-| 7944840                             | 38653           |         |         |         |         |
-| Function Name                       | min             | avg     | median  | max     | # calls |
-| cheat__InitialiseValidatorSet       | 7084560         | 7084560 | 7084560 | 7084560 | 1       |
-| getBlock                            | 1230            | 1230    | 1230    | 1230    | 12      |
-| getBurnAddress                      | 369             | 369     | 369     | 369     | 1       |
-| getCurrentEpoch                     | 1017            | 1017    | 1017    | 1017    | 397     |
-| getCurrentProposer                  | 139908          | 140204  | 140137  | 144742  | 200     |
-| getCurrentSlot                      | 823             | 833     | 823     | 4823    | 397     |
-| getEpochCommittee                   | 135768          | 135904  | 135780  | 140057  | 100     |
-| getEpochForBlock                    | 1016            | 1016    | 1016    | 1016    | 196     |
-| getFeeHeader                        | 1457            | 1457    | 1457    | 1457    | 95      |
-| getManaBaseFeeAt                    | 20442           | 26863   | 27182   | 34313   | 195     |
-| getPendingBlockNumber               | 507             | 511     | 507     | 2507    | 401     |
-| getProvenBlockNumber                | 490             | 490     | 490     | 490     | 3       |
-| getTimestampForSlot                 | 887             | 887     | 887     | 887     | 195     |
-| setProvingCostPerMana               | 25915           | 25942   | 25915   | 28715   | 101     |
-| submitEpochRootProof                | 771062          | 783900  | 771086  | 809552  | 3       |
+| src/core/Rollup.sol:Rollup contract |                 |          |          |          |         |
+|-------------------------------------|-----------------|----------|----------|----------|---------|
+| Deployment Cost                     | Deployment Size |          |          |          |         |
+| 7944840                             | 38653           |          |          |          |         |
+| Function Name                       | min             | avg      | median   | max      | # calls |
+| cheat__InitialiseValidatorSet       | 13524835        | 13524835 | 13524835 | 13524835 | 1       |
+| getBlock                            | 1230            | 1230     | 1230     | 1230     | 12      |
+| getBurnAddress                      | 369             | 369      | 369      | 369      | 1       |
+| getCurrentEpoch                     | 1017            | 1017     | 1017     | 1017     | 397     |
+| getCurrentProposer                  | 139908          | 143780   | 140137   | 263958   | 200     |
+| getCurrentSlot                      | 823             | 833      | 823      | 4823     | 397     |
+| getEpochCommittee                   | 135768          | 139483   | 135780   | 259358   | 100     |
+| getEpochForBlock                    | 1016            | 1016     | 1016     | 1016     | 196     |
+| getFeeHeader                        | 1457            | 1457     | 1457     | 1457     | 95      |
+| getManaBaseFeeAt                    | 20442           | 26863    | 27182    | 34313    | 195     |
+| getPendingBlockNumber               | 507             | 511      | 507      | 2507     | 401     |
+| getProvenBlockNumber                | 490             | 490      | 490      | 490      | 3       |
+| getTimestampForSlot                 | 887             | 887      | 887      | 887      | 195     |
+| setProvingCostPerMana               | 25915           | 25942    | 25915    | 28715    | 101     |
+| submitEpochRootProof                | 771062          | 783900   | 771086   | 809552   | 3       |
 | src/periphery/Forwarder.sol:Forwarder contract |                 |        |        |         |         |
 |------------------------------------------------|-----------------|--------|--------|---------|---------|
 | Deployment Cost                                | Deployment Size |        |        |         |         |
 | 358690                                         | 1553            |        |        |         |         |
 | Function Name                                  | min             | avg    | median | max     | # calls |
-| forward                                        | 634776          | 681399 | 645791 | 1795917 | 100     |
+| forward                                        | 634788          | 685012 | 645781 | 1916159 | 100     |

--- a/l1-contracts/gas_benchmark.md
+++ b/l1-contracts/gas_benchmark.md
@@ -3,7 +3,7 @@
 | Deployment Cost                     | Deployment Size |         |         |         |         |
 | 7944840                             | 38653           |         |         |         |         |
 | Function Name                       | min             | avg     | median  | max     | # calls |
-| cheat__InitialiseValidatorSet       | 7084584         | 7084584 | 7084584 | 7084584 | 1       |
+| cheat__InitialiseValidatorSet       | 7084560         | 7084560 | 7084560 | 7084560 | 1       |
 | getBlock                            | 1230            | 1230    | 1230    | 1230    | 12      |
 | getBurnAddress                      | 369             | 369     | 369     | 369     | 1       |
 | getCurrentEpoch                     | 1017            | 1017    | 1017    | 1017    | 397     |
@@ -16,6 +16,11 @@
 | getPendingBlockNumber               | 507             | 511     | 507     | 2507    | 401     |
 | getProvenBlockNumber                | 490             | 490     | 490     | 490     | 3       |
 | getTimestampForSlot                 | 887             | 887     | 887     | 887     | 195     |
-| propose                             | 623371          | 670034  | 634412  | 1784572 | 100     |
 | setProvingCostPerMana               | 25915           | 25942   | 25915   | 28715   | 101     |
 | submitEpochRootProof                | 771062          | 783900  | 771086  | 809552  | 3       |
+| src/periphery/Forwarder.sol:Forwarder contract |                 |        |        |         |         |
+|------------------------------------------------|-----------------|--------|--------|---------|---------|
+| Deployment Cost                                | Deployment Size |        |        |         |         |
+| 358690                                         | 1553            |        |        |         |         |
+| Function Name                                  | min             | avg    | median | max     | # calls |
+| forward                                        | 634776          | 681399 | 645791 | 1795917 | 100     |

--- a/l1-contracts/gas_benchmark.md
+++ b/l1-contracts/gas_benchmark.md
@@ -1,19 +1,21 @@
-| src/core/Rollup.sol:Rollup contract |                 |        |        |        |         |
-|-------------------------------------|-----------------|--------|--------|--------|---------|
-| Deployment Cost                     | Deployment Size |        |        |        |         |
-| 7965416                             | 38750           |        |        |        |         |
-| Function Name                       | min             | avg    | median | max    | # calls |
-| getBlock                            | 1230            | 1230   | 1230   | 1230   | 84      |
-| getBurnAddress                      | 369             | 369    | 369    | 369    | 1       |
-| getCurrentEpoch                     | 1017            | 1017   | 1017   | 1017   | 2001    |
-| getCurrentProposer                  | 32671           | 32672  | 32671  | 32721  | 672     |
-| getCurrentSlot                      | 823             | 824    | 823    | 4823   | 2673    |
-| getEpochForBlock                    | 1016            | 1016   | 1016   | 1016   | 1384    |
-| getFeeHeader                        | 1457            | 1457   | 1457   | 1457   | 671     |
-| getManaBaseFeeAt                    | 20442           | 27905  | 28056  | 34313  | 1343    |
-| getPendingBlockNumber               | 507             | 509    | 507    | 2507   | 693     |
-| getProvenBlockNumber                | 490             | 490    | 490    | 490    | 21      |
-| getTimestampForSlot                 | 887             | 887    | 887    | 887    | 1343    |
-| propose                             | 291892          | 307341 | 303905 | 368100 | 672     |
-| setProvingCostPerMana               | 25915           | 25919  | 25915  | 28715  | 673     |
-| submitEpochRootProof                | 771050          | 774540 | 771074 | 843752 | 21      |
+| src/core/Rollup.sol:Rollup contract |                 |         |         |         |         |
+|-------------------------------------|-----------------|---------|---------|---------|---------|
+| Deployment Cost                     | Deployment Size |         |         |         |         |
+| 7944840                             | 38653           |         |         |         |         |
+| Function Name                       | min             | avg     | median  | max     | # calls |
+| cheat__InitialiseValidatorSet       | 7084584         | 7084584 | 7084584 | 7084584 | 1       |
+| getBlock                            | 1230            | 1230    | 1230    | 1230    | 12      |
+| getBurnAddress                      | 369             | 369     | 369     | 369     | 1       |
+| getCurrentEpoch                     | 1017            | 1017    | 1017    | 1017    | 397     |
+| getCurrentProposer                  | 139908          | 140204  | 140137  | 144742  | 200     |
+| getCurrentSlot                      | 823             | 833     | 823     | 4823    | 397     |
+| getEpochCommittee                   | 135768          | 135904  | 135780  | 140057  | 100     |
+| getEpochForBlock                    | 1016            | 1016    | 1016    | 1016    | 196     |
+| getFeeHeader                        | 1457            | 1457    | 1457    | 1457    | 95      |
+| getManaBaseFeeAt                    | 20442           | 26863   | 27182   | 34313   | 195     |
+| getPendingBlockNumber               | 507             | 511     | 507     | 2507    | 401     |
+| getProvenBlockNumber                | 490             | 490     | 490     | 490     | 3       |
+| getTimestampForSlot                 | 887             | 887     | 887     | 887     | 195     |
+| propose                             | 623371          | 670034  | 634412  | 1784572 | 100     |
+| setProvingCostPerMana               | 25915           | 25942   | 25915   | 28715   | 101     |
+| submitEpochRootProof                | 771062          | 783900  | 771086  | 809552  | 3       |

--- a/l1-contracts/gas_benchmark.md
+++ b/l1-contracts/gas_benchmark.md
@@ -1,0 +1,19 @@
+| src/core/Rollup.sol:Rollup contract |                 |        |        |        |         |
+|-------------------------------------|-----------------|--------|--------|--------|---------|
+| Deployment Cost                     | Deployment Size |        |        |        |         |
+| 7965416                             | 38750           |        |        |        |         |
+| Function Name                       | min             | avg    | median | max    | # calls |
+| getBlock                            | 1230            | 1230   | 1230   | 1230   | 84      |
+| getBurnAddress                      | 369             | 369    | 369    | 369    | 1       |
+| getCurrentEpoch                     | 1017            | 1017   | 1017   | 1017   | 2001    |
+| getCurrentProposer                  | 32671           | 32672  | 32671  | 32721  | 672     |
+| getCurrentSlot                      | 823             | 824    | 823    | 4823   | 2673    |
+| getEpochForBlock                    | 1016            | 1016   | 1016   | 1016   | 1384    |
+| getFeeHeader                        | 1457            | 1457   | 1457   | 1457   | 671     |
+| getManaBaseFeeAt                    | 20442           | 27905  | 28056  | 34313  | 1343    |
+| getPendingBlockNumber               | 507             | 509    | 507    | 2507   | 693     |
+| getProvenBlockNumber                | 490             | 490    | 490    | 490    | 21      |
+| getTimestampForSlot                 | 887             | 887    | 887    | 887    | 1343    |
+| propose                             | 291892          | 307341 | 303905 | 368100 | 672     |
+| setProvingCostPerMana               | 25915           | 25919  | 25915  | 28715  | 673     |
+| submitEpochRootProof                | 771050          | 774540 | 771074 | 843752 | 21      |

--- a/l1-contracts/src/core/Rollup.sol
+++ b/l1-contracts/src/core/Rollup.sol
@@ -131,6 +131,23 @@ contract Rollup is IStaking, IValidatorSelection, IRollup, RollupCore {
   }
 
   /**
+   * @notice  Get the validator set for a given epoch
+   *
+   * @dev     Consider removing this to replace with a `size` and individual getter.
+   *
+   * @param _epoch The epoch number to get the validator set for
+   *
+   * @return The validator set for the given epoch
+   */
+  function getEpochCommittee(Epoch _epoch)
+    external
+    override(IValidatorSelection)
+    returns (address[] memory)
+  {
+    return ValidatorSelectionLib.getCommitteeAt(StakingLib.getStorage(), _epoch);
+  }
+
+  /**
    * @notice  Get the committee for a given timestamp
    *
    * @param _ts - The timestamp to get the committee for
@@ -392,24 +409,6 @@ contract Rollup is IStaking, IValidatorSelection, IRollup, RollupCore {
     address attester = StakingLib.getStorage().attesters.at(_index);
     return
       OperatorInfo({proposer: StakingLib.getStorage().info[attester].proposer, attester: attester});
-  }
-
-  /**
-   * @notice  Get the validator set for a given epoch
-   *
-   * @dev     Consider removing this to replace with a `size` and individual getter.
-   *
-   * @param _epoch The epoch number to get the validator set for
-   *
-   * @return The validator set for the given epoch
-   */
-  function getEpochCommittee(Epoch _epoch)
-    external
-    view
-    override(IValidatorSelection)
-    returns (address[] memory)
-  {
-    return ValidatorSelectionLib.getStorage().epochs[_epoch].committee;
   }
 
   /**

--- a/l1-contracts/src/core/interfaces/IValidatorSelection.sol
+++ b/l1-contracts/src/core/interfaces/IValidatorSelection.sol
@@ -36,6 +36,7 @@ interface IValidatorSelection is IValidatorSelectionCore {
   // Non view as uses transient storage
   function getCurrentEpochCommittee() external returns (address[] memory);
   function getCommitteeAt(Timestamp _ts) external returns (address[] memory);
+  function getEpochCommittee(Epoch _epoch) external returns (address[] memory);
 
   // Stable
   function getCurrentEpoch() external view returns (Epoch);
@@ -46,7 +47,6 @@ interface IValidatorSelection is IValidatorSelectionCore {
 
   // Likely removal of these to replace with a size and indiviual getter
   // Get the current epoch committee
-  function getEpochCommittee(Epoch _epoch) external view returns (address[] memory);
   function getAttesters() external view returns (address[] memory);
 
   function getSampleSeedAt(Timestamp _ts) external view returns (uint256);

--- a/l1-contracts/src/periphery/SlashPayload.sol
+++ b/l1-contracts/src/periphery/SlashPayload.sol
@@ -15,14 +15,20 @@ contract SlashPayload is IPayload {
   IValidatorSelection public immutable VALIDATOR_SELECTION;
   uint256 public immutable AMOUNT;
 
+  address[] public attesters;
+
   constructor(Epoch _epoch, IValidatorSelection _validatorSelection, uint256 _amount) {
     EPOCH = _epoch;
     VALIDATOR_SELECTION = _validatorSelection;
     AMOUNT = _amount;
+
+    address[] memory attesters_ = IValidatorSelection(VALIDATOR_SELECTION).getEpochCommittee(EPOCH);
+    for (uint256 i = 0; i < attesters_.length; i++) {
+      attesters.push(attesters_[i]);
+    }
   }
 
   function getActions() external view override(IPayload) returns (IPayload.Action[] memory) {
-    address[] memory attesters = IValidatorSelection(VALIDATOR_SELECTION).getEpochCommittee(EPOCH);
     IPayload.Action[] memory actions = new IPayload.Action[](attesters.length);
 
     for (uint256 i = 0; i < attesters.length; i++) {

--- a/l1-contracts/test/benchmark/happy.t.sol
+++ b/l1-contracts/test/benchmark/happy.t.sol
@@ -58,7 +58,7 @@ import {Forwarder} from "@aztec/periphery/Forwarder.sol";
 // solhint-disable comprehensive-interface
 
 uint256 constant MANA_TARGET = 100000000;
-uint256 constant VALIDATOR_COUNT = 48;
+uint256 constant VALIDATOR_COUNT = 100;
 
 contract FakeCanonical is IRewardDistributor {
   uint256 public constant BLOCK_REWARD = 50e18;

--- a/l1-contracts/test/benchmark/happy.t.sol
+++ b/l1-contracts/test/benchmark/happy.t.sol
@@ -1,0 +1,351 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright 2024 Aztec Labs.
+pragma solidity >=0.8.27;
+
+import {DecoderBase} from "../base/DecoderBase.sol";
+
+import {stdStorage, StdStorage} from "forge-std/StdStorage.sol";
+
+import {DataStructures} from "@aztec/core/libraries/DataStructures.sol";
+import {Constants} from "@aztec/core/libraries/ConstantsGen.sol";
+import {SignatureLib, Signature} from "@aztec/core/libraries/crypto/SignatureLib.sol";
+import {Math} from "@oz/utils/math/Math.sol";
+
+import {Registry} from "@aztec/governance/Registry.sol";
+import {Inbox} from "@aztec/core/messagebridge/Inbox.sol";
+import {Outbox} from "@aztec/core/messagebridge/Outbox.sol";
+import {Errors} from "@aztec/core/libraries/Errors.sol";
+import {Rollup, BlockLog} from "@aztec/core/Rollup.sol";
+import {
+  IRollup,
+  SubmitEpochRootProofArgs,
+  PublicInputArgs,
+  RollupConfigInput
+} from "@aztec/core/interfaces/IRollup.sol";
+import {FeeJuicePortal} from "@aztec/core/FeeJuicePortal.sol";
+import {NaiveMerkle} from "../merkle/Naive.sol";
+import {MerkleTestUtil} from "../merkle/TestUtil.sol";
+import {TestERC20} from "@aztec/mock/TestERC20.sol";
+import {TestConstants} from "../harnesses/TestConstants.sol";
+import {RewardDistributor} from "@aztec/governance/RewardDistributor.sol";
+import {IERC20Errors} from "@oz/interfaces/draft-IERC6093.sol";
+import {IFeeJuicePortal} from "@aztec/core/interfaces/IFeeJuicePortal.sol";
+import {IRewardDistributor, IRegistry} from "@aztec/governance/interfaces/IRewardDistributor.sol";
+import {ProposeArgs, OracleInput, ProposeLib} from "@aztec/core/libraries/rollup/ProposeLib.sol";
+import {IERC20} from "@oz/token/ERC20/IERC20.sol";
+import {
+  FeeLib,
+  FeeAssetPerEthE9,
+  EthValue,
+  FeeHeader,
+  L1FeeData,
+  ManaBaseFeeComponents
+} from "@aztec/core/libraries/rollup/FeeLib.sol";
+
+import {
+  FeeModelTestPoints,
+  TestPoint,
+  FeeHeaderModel,
+  ManaBaseFeeComponentsModel
+} from "test/fees/FeeModelTestPoints.t.sol";
+
+import {
+  Timestamp, Slot, Epoch, SlotLib, EpochLib, TimeLib
+} from "@aztec/core/libraries/TimeLib.sol";
+
+// solhint-disable comprehensive-interface
+
+uint256 constant MANA_TARGET = 100000000;
+
+contract FakeCanonical is IRewardDistributor {
+  uint256 public constant BLOCK_REWARD = 50e18;
+  IERC20 public immutable UNDERLYING;
+
+  address public canonicalRollup;
+
+  constructor(IERC20 _asset) {
+    UNDERLYING = _asset;
+  }
+
+  function setCanonicalRollup(address _rollup) external {
+    canonicalRollup = _rollup;
+  }
+
+  function claim(address _recipient) external returns (uint256) {
+    TestERC20(address(UNDERLYING)).mint(_recipient, BLOCK_REWARD);
+    return BLOCK_REWARD;
+  }
+
+  function claimBlockRewards(address _recipient, uint256 _blocks) external returns (uint256) {
+    TestERC20(address(UNDERLYING)).mint(_recipient, _blocks * BLOCK_REWARD);
+    return _blocks * BLOCK_REWARD;
+  }
+
+  function distributeFees(address _recipient, uint256 _amount) external {
+    TestERC20(address(UNDERLYING)).mint(_recipient, _amount);
+  }
+
+  function updateRegistry(IRegistry _registry) external {}
+}
+
+contract BenchmarkRollupTest is FeeModelTestPoints, DecoderBase {
+  using stdStorage for StdStorage;
+  using TimeLib for Slot;
+
+  using SlotLib for Slot;
+  using EpochLib for Epoch;
+  using FeeLib for uint256;
+  using FeeLib for ManaBaseFeeComponents;
+  // We need to build a block that we can submit. We will be using some values from
+  // the empty blocks, but otherwise populate using the fee model test points.
+
+  struct Block {
+    bytes32 archive;
+    bytes32 blockHash;
+    bytes header;
+    bytes body;
+    bytes blobInputs;
+    bytes32[] txHashes;
+    Signature[] signatures;
+  }
+
+  DecoderBase.Full full = load("empty_block_1");
+
+  uint256 internal constant SLOT_DURATION = 36;
+  uint256 internal constant EPOCH_DURATION = 32;
+
+  Rollup internal rollup;
+
+  address internal coinbase = address(bytes20("MONEY MAKER"));
+  TestERC20 internal asset;
+  FakeCanonical internal fakeCanonical;
+
+  constructor() {
+    FeeLib.initialize(MANA_TARGET, EthValue.wrap(100));
+  }
+
+  function setUp() public {
+    // We deploy a the rollup and sets the time and all to
+    vm.warp(l1Metadata[0].timestamp - SLOT_DURATION);
+
+    asset = new TestERC20("test", "TEST", address(this));
+
+    fakeCanonical = new FakeCanonical(IERC20(address(asset)));
+    asset.transferOwnership(address(fakeCanonical));
+
+    rollup = new Rollup(
+      IFeeJuicePortal(address(fakeCanonical)),
+      IRewardDistributor(address(fakeCanonical)),
+      asset,
+      address(this),
+      TestConstants.getGenesisState(),
+      RollupConfigInput({
+        aztecSlotDuration: SLOT_DURATION,
+        aztecEpochDuration: EPOCH_DURATION,
+        targetCommitteeSize: 48,
+        aztecProofSubmissionWindow: EPOCH_DURATION * 2 - 1,
+        minimumStake: TestConstants.AZTEC_MINIMUM_STAKE,
+        slashingQuorum: TestConstants.AZTEC_SLASHING_QUORUM,
+        slashingRoundSize: TestConstants.AZTEC_SLASHING_ROUND_SIZE,
+        manaTarget: MANA_TARGET,
+        provingCostPerMana: TestConstants.AZTEC_PROVING_COST_PER_MANA
+      })
+    );
+    fakeCanonical.setCanonicalRollup(address(rollup));
+
+    vm.label(coinbase, "coinbase");
+    vm.label(address(rollup), "ROLLUP");
+    vm.label(address(fakeCanonical), "FAKE CANONICAL");
+    vm.label(address(asset), "ASSET");
+    vm.label(rollup.getBurnAddress(), "BURN_ADDRESS");
+  }
+
+  function _loadL1Metadata(uint256 index) internal {
+    vm.roll(l1Metadata[index].block_number);
+    vm.warp(l1Metadata[index].timestamp);
+  }
+
+  /**
+   * @notice Constructs a fake block that is not possible to prove, but passes the L1 checks.
+   */
+  function getBlock() internal returns (Block memory) {
+    // We will be using the genesis for both before and after. This will be impossible
+    // to prove, but we don't need to prove anything here.
+    bytes32 archiveRoot = bytes32(Constants.GENESIS_ARCHIVE_ROOT);
+
+    bytes32[] memory txHashes = new bytes32[](0);
+    Signature[] memory signatures = new Signature[](0);
+
+    bytes memory body = full.block.body;
+    bytes memory header = full.block.header;
+
+    Slot slotNumber = rollup.getCurrentSlot();
+    TestPoint memory point = points[slotNumber.unwrap() - 1];
+
+    Timestamp ts = rollup.getTimestampForSlot(slotNumber);
+    uint256 bn = rollup.getPendingBlockNumber() + 1;
+
+    uint256 manaBaseFee = rollup.getManaBaseFeeAt(Timestamp.wrap(block.timestamp), true);
+    uint256 manaSpent = point.block_header.mana_spent;
+
+    address proposer = rollup.getCurrentProposer();
+
+    // Updating the header with important information!
+    assembly {
+      let headerRef := add(header, 0x20)
+
+      mstore(add(headerRef, 0x0000), archiveRoot)
+      // Load the full word at 0x20 (which contains lastArchive.nextAvailableLeafIndex and start of numTxs)
+      let word := mload(add(headerRef, 0x20))
+      // Clear just the first 4 bytes from the left (most significant bytes)
+      word := and(word, 0x00000000ffffffffffffffffffffffffffffffffffffffffffffffffffffffff)
+      // Set the new value for nextAvailableLeafIndex (bn) in the first 4 bytes from left
+      word := or(word, shl(224, bn))
+      // Store the modified word back
+      mstore(add(headerRef, 0x20), word)
+
+      mstore(add(headerRef, 0x0174), bn)
+      mstore(add(headerRef, 0x0194), slotNumber)
+      mstore(add(headerRef, 0x01b4), ts)
+      mstore(add(headerRef, 0x01d4), proposer) // coinbase
+      mstore(add(headerRef, 0x01e8), 0) // fee recipient
+      mstore(add(headerRef, 0x0208), 0) // fee per da gas
+      mstore(add(headerRef, 0x0228), manaBaseFee) // fee per l2 gas
+      mstore(add(headerRef, 0x0268), manaSpent) // total mana used
+    }
+
+    return Block({
+      archive: archiveRoot,
+      blockHash: bytes32(Constants.GENESIS_BLOCK_HASH),
+      header: header,
+      body: body,
+      blobInputs: full.block.blobInputs,
+      txHashes: txHashes,
+      signatures: signatures
+    });
+  }
+
+  function test_Benchmarking() public {
+    Slot nextSlot = Slot.wrap(1);
+    Epoch nextEpoch = Epoch.wrap(1);
+
+    rollup.setProvingCostPerMana(
+      EthValue.wrap(points[0].outputs.mana_base_fee_components_in_wei.proving_cost)
+    );
+
+    // Loop through all of the L1 metadata
+    for (uint256 i = 0; i < l1Metadata.length; i++) {
+      _loadL1Metadata(i);
+
+      // For every "new" slot we encounter, we construct a block using current L1 Data
+      // and part of the `empty_block_1.json` file. The block cannot be proven, but it
+      // will be accepted as a proposal so very useful for testing a long range of blocks.
+      if (rollup.getCurrentSlot() == nextSlot) {
+        TestPoint memory point = points[nextSlot.unwrap() - 1];
+        rollup.setProvingCostPerMana(
+          EthValue.wrap(point.outputs.mana_base_fee_components_in_wei.proving_cost)
+        );
+
+        Block memory b = getBlock();
+
+        skipBlobCheck(address(rollup));
+        rollup.propose(
+          ProposeArgs({
+            header: b.header,
+            archive: b.archive,
+            blockHash: b.blockHash,
+            oracleInput: OracleInput({
+              feeAssetPriceModifier: point.oracle_input.fee_asset_price_modifier
+            }),
+            txHashes: b.txHashes
+          }),
+          b.signatures,
+          b.blobInputs
+        );
+
+        nextSlot = nextSlot + Slot.wrap(1);
+      }
+
+      // If we are entering a new epoch, we will post a proof
+      // Ensure that the fees are split correctly between sequencers and burns etc.
+      if (rollup.getCurrentEpoch() == nextEpoch) {
+        nextEpoch = nextEpoch + Epoch.wrap(1);
+        uint256 pendingBlockNumber = rollup.getPendingBlockNumber();
+        uint256 start = rollup.getProvenBlockNumber() + 1;
+        uint256 epochSize = 0;
+        while (
+          start + epochSize <= pendingBlockNumber
+            && rollup.getEpochForBlock(start) == rollup.getEpochForBlock(start + epochSize)
+        ) {
+          epochSize++;
+        }
+
+        bytes32[] memory fees = new bytes32[](Constants.AZTEC_MAX_EPOCH_DURATION * 2);
+
+        for (uint256 feeIndex = 0; feeIndex < epochSize; feeIndex++) {
+          // we need the basefee, and we cannot just take it from the point. Because it is different
+          Timestamp ts = rollup.getTimestampForSlot(Slot.wrap(start + feeIndex));
+          uint256 manaBaseFee = rollup.getManaBaseFeeAt(ts, true);
+          uint256 fee = rollup.getFeeHeader(start + feeIndex).manaUsed * manaBaseFee;
+
+          fees[feeIndex * 2] = bytes32(uint256(uint160(bytes20(coinbase))));
+          fees[feeIndex * 2 + 1] = bytes32(fee);
+        }
+
+        PublicInputArgs memory args = PublicInputArgs({
+          previousArchive: rollup.getBlock(start).archive,
+          endArchive: rollup.getBlock(start + epochSize - 1).archive,
+          previousBlockHash: rollup.getBlock(start).blockHash,
+          endBlockHash: rollup.getBlock(start + epochSize - 1).blockHash,
+          endTimestamp: Timestamp.wrap(0),
+          outHash: bytes32(0),
+          proverId: address(0)
+        });
+
+        bytes memory blobPublicInputs;
+        for (uint256 j = 0; j < epochSize; j++) {
+          // For each block in the epoch, add its blob public inputs
+          // Since we are reusing the same block, they are the same
+          blobPublicInputs =
+            abi.encodePacked(blobPublicInputs, this.getBlobPublicInputs(full.block.blobInputs));
+        }
+
+        {
+          rollup.submitEpochRootProof(
+            SubmitEpochRootProofArgs({
+              start: start,
+              end: start + epochSize - 1,
+              args: args,
+              fees: fees,
+              blobPublicInputs: blobPublicInputs,
+              aggregationObject: "",
+              proof: ""
+            })
+          );
+        }
+      }
+    }
+  }
+
+  // This is duplicated from Rollup.t.sol because we need to call it as this.getBlobPublicInputs
+  // so it accepts the input as calldata
+  function getBlobPublicInputs(bytes calldata _blobsInput)
+    public
+    pure
+    returns (bytes memory blobPublicInputs)
+  {
+    uint8 numBlobs = uint8(_blobsInput[0]);
+    blobPublicInputs = abi.encodePacked(numBlobs, blobPublicInputs);
+    for (uint256 i = 0; i < numBlobs; i++) {
+      // Add 1 for the numBlobs prefix
+      uint256 blobInputStart = i * 192 + 1;
+      // We want to extract the bytes we use for public inputs:
+      //  * input[32:64]   - z
+      //  * input[64:96]   - y
+      //  * input[96:144]  - commitment C
+      // Out of 192 bytes per blob.
+      blobPublicInputs =
+        abi.encodePacked(blobPublicInputs, _blobsInput[blobInputStart + 32:blobInputStart + 144]);
+    }
+  }
+}

--- a/l1-contracts/test/validator-selection/ValidatorSelection.t.sol
+++ b/l1-contracts/test/validator-selection/ValidatorSelection.t.sol
@@ -164,6 +164,24 @@ contract ValidatorSelectionTest is DecoderBase {
     assertEq(expectedProposer, actualProposer, "Invalid proposer");
   }
 
+  function testCommitteeForNonSetupEpoch(uint8 _epochsToJump) public setup(4) {
+    Epoch pre = rollup.getCurrentEpoch();
+    vm.warp(
+      block.timestamp
+        + uint256(_epochsToJump) * rollup.getEpochDuration() * rollup.getSlotDuration()
+    );
+
+    Epoch post = rollup.getCurrentEpoch();
+
+    uint256 validatorSetSize = rollup.getAttesters().length;
+    uint256 targetCommitteeSize = rollup.getTargetCommitteeSize();
+    uint256 expectedSize =
+      validatorSetSize > targetCommitteeSize ? targetCommitteeSize : validatorSetSize;
+
+    assertEq(rollup.getEpochCommittee(pre).length, expectedSize, "Invalid committee size");
+    assertEq(rollup.getEpochCommittee(post).length, expectedSize, "Invalid committee size");
+  }
+
   function testValidatorSetLargerThanCommittee(bool _insufficientSigs) public setup(100) {
     assertGt(rollup.getAttesters().length, rollup.getTargetCommitteeSize(), "Not enough validators");
     uint256 committeeSize = rollup.getTargetCommitteeSize() * 2 / 3 + (_insufficientSigs ? 0 : 1);

--- a/yarn-project/ethereum/src/contracts/rollup.ts
+++ b/yarn-project/ethereum/src/contracts/rollup.ts
@@ -218,6 +218,17 @@ export class RollupContract {
     return result;
   }
 
+  async getEpochCommittee(epoch: bigint) {
+    const { result } = await this.client.simulateContract({
+      address: this.address,
+      abi: RollupAbi,
+      functionName: 'getEpochCommittee',
+      args: [epoch],
+    });
+
+    return result;
+  }
+
   getBlock(blockNumber: bigint) {
     return this.rollup.read.getBlock([blockNumber]);
   }
@@ -389,10 +400,6 @@ export class RollupContract {
 
   getAttesters() {
     return this.rollup.read.getAttesters();
-  }
-
-  getEpochCommittee(epoch: bigint) {
-    return this.rollup.read.getEpochCommittee([epoch]);
   }
 
   getInfo(address: Hex | EthAddress) {


### PR DESCRIPTION
Fixed #13075

Creating explicit benchmarking test for gas such that there is something that is:
1) convenient to check against for optimisations
2) gives a somewhat correct view instead of having all the failure cases in the mix 

The test runs with a validator set of 100 entities, that each have a forwarder contract. We then ram through time and submit and fake proof 100 blocks to collect data.

Notice, that if you bump up the numbers of entities or blocks foundry is probably going to explode if you don't also change the gas limits because that is a lot of things being loaded in 🤷 

Todo: Talk to @Maddiaa0 @just-mitch and @aminsammara on which numbers are missing and what should make its way into the fancy benchmark graphs that charlie setup. Most should be in #12615