### PR TITLE
chore: devnet change address upload bucket

### DIFF
--- a/.github/workflows/devnet-deploy.yml
+++ b/.github/workflows/devnet-deploy.yml
@@ -45,11 +45,12 @@ concurrency:
 env:
   AWS_ACCESS_KEY_ID: ${{ secrets.AWS_ACCESS_KEY_ID }}
   AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
-  CONTRACT_S3_BUCKET: s3://static.aztec.network
   CLUSTER_NAME: ${{ inputs.cluster }}
   REGION: us-west1-a
   NAMESPACE: ${{ inputs.namespace }}
   AZTEC_DOCKER_IMAGE: ${{ inputs.aztec_docker_image }}
+  # This is a workaround because the runner does not have perms to upload files anywhere else
+  CONTRACT_S3_BUCKET: s3://aztec-ci-artifacts
 
 jobs:
   deploy-network:
@@ -158,7 +159,7 @@ jobs:
             --address-index "$ADDRESS_INDEX" \
             --json | tee ./basic_contracts.json
 
-          aws s3 cp ./basic_contracts.json ${{ env.CONTRACT_S3_BUCKET }}/devnet/basic_contracts.json
+          aws s3 cp ./basic_contracts.json ${{ env.CONTRACT_S3_BUCKET }}/devnet-basic-contracts.json
 
           DEVCOIN_L1_ADDRESS=$(jq -r .devCoinL1 ./basic_contracts.json)
           DEVCOIN_DRIP_AMOUNT=1000000000


### PR DESCRIPTION
Due to permissions changes, the runner no longer has access to the old bucket, this is a stopgap to upload addresses to s3 without addressing the underlying issue.