### PR TITLE
chore(docs): Update versions-updating.md

### DIFF
--- a/docs/docs/developers/guides/local_env/versions-updating.md
+++ b/docs/docs/developers/guides/local_env/versions-updating.md
@@ -79,10 +79,12 @@ This can present confusion when opening older contracts (and dependencies) writt
 aztec-up
 ```
 
-To set `VERSION` for a particular git tag, eg for [v**0.77.0**](https://github.com/AztecProtocol/aztec-packages/tree/v0.77.0)
+To update to a specific version, pass the version number after the `aztec-up` command, or set `VERSION` for a particular git tag, eg for [v**0.77.0**](https://github.com/AztecProtocol/aztec-packages/tree/v0.77.0)
 
 ```shell
-VERSION=0.35.0 aztec-up
+aztec-up 0.77.0
+# or
+VERSION=0.77.0 aztec-up
 ```
 
 2. Update Aztec.nr and individual @aztec dependencies:
@@ -153,21 +155,3 @@ To update Aztec.js packages, go to your `package.json` and replace the versions 
 -"@aztec/noir-contracts.js": "0.35.1",
 +"@aztec/accounts": "#include_aztec_short_version",
 ```
-
-## Updating `aztec-nargo`
-
-As mentioned in the tl;dr, `aztec-nargo` is updated as part of updating the whole sandbox via:
-
-```bash
-aztec-up
-```
-
-The version of aztec-nargo that comes with a particular version of the Aztec sandbox can be seen in the monorepo. Eg tag: v0.35.0 contains aztec-nargo [v0.27.0 (GitHub link)](https://github.com/AztecProtocol/aztec-packages/blob/v0.35.0/noir/noir-repo/Cargo.toml#L44).
-
-Set VERSION to specify the desired Aztec sandbox version, eg monorepo tag suffix [0.35.0 (GitHub link)](https://github.com/AztecProtocol/aztec-packages/tree/v0.35.0) (to have `aztec-nargo` v0.27.0).
-
-```bash
-VERSION=<tag-suffix> aztec-up
-```
-
-Note: Being under highly active development it is NOT recommended to specify, `master`, due to the increased effort to align tooling, dependencies, and example code syntax.


### PR DESCRIPTION
- Adds info about passing the version number to update to after `aztec-up`. 
- Removes details about installing a specific version of `aztec-nargo` as I dont think this is needed 