### PR TITLE
feat: preload CRS files once in GKE

### DIFF
--- a/spartan/aztec-network/templates/prover-agent.yaml
+++ b/spartan/aztec-network/templates/prover-agent.yaml
@@ -44,6 +44,14 @@ spec:
           configMap:
             name: {{ include "aztec-network.fullname" . }}-scripts
             defaultMode: 0755
+        - name: crs
+          {{- if .Values.network.gke }}
+          persistentVolumeClaim:
+            claimName: {{ include "aztec-network.fullname" . }}-shared-crs-ro-pvc
+            readOnly: true
+          {{- else }}
+          emptyDir: {}
+          {{- end }}
       initContainers:
         {{- include "aztec-network.combinedAllSetupContainer" . | nindent 8 }}
         {{- include "aztec-network.otelResourceSetupContainer" . | nindent 8 }}
@@ -69,6 +77,8 @@ spec:
           volumeMounts:
             - name: config
               mountPath: /shared/config
+            - name: crs
+              mountPath: /root/.bb-crs
           command:
             - "/bin/bash"
             - "-c"
@@ -115,4 +125,86 @@ spec:
               value: "{{ .Values.telemetry.excludeMetrics }}"
           resources:
             {{- toYaml .Values.proverAgent.resources | nindent 12 }}
+---
+{{- if .Values.network.gke }}
+# In GKE download the CRS file once and share a readonly volume between the agents
+apiVersion: v1
+kind: PersistentVolumeClaim
+metadata:
+  name: {{ include "aztec-network.fullname" . }}-shared-crs-pvc
+  labels:
+    {{- include "aztec-network.labels" . | nindent 4 }}
+  annotations:
+    "helm.sh/hook": pre-install,pre-upgrade
+    "helm.sh/hook-weight": "-6"
+spec:
+  accessModes: ["ReadWriteOnce"] 
+  storageClassName: standard-rwo
+  resources:
+    requests:
+      storage: 3Gi  # Adjust based on file size plus overhead
+---
+# Next, create a pre-install hook job to populate the data
+apiVersion: batch/v1
+kind: Job
+metadata:
+  name: {{ include "aztec-network.fullname" . }}-preload-crs
+  labels:
+    {{- include "aztec-network.labels" . | nindent 4 }}
+  annotations:
+    "helm.sh/hook": pre-install,pre-upgrade
+    "helm.sh/hook-weight": "-5"
+    "helm.sh/hook-delete-policy": hook-succeeded
+spec:
+  backoffLimit: 3
+  template:
+    metadata:
+      labels:
+        {{- include "aztec-network.labels" . | nindent 8 }}
+    spec:
+      volumes:
+        - name: crs
+          persistentVolumeClaim:
+            claimName: {{ include "aztec-network.fullname" . }}-shared-crs-pvc
+      containers:
+        - name: data-downloader
+          {{- include "aztec-network.image" . | nindent 10 }}
+          command:
+            - /bin/bash
+            - -c
+            - |
+              if [ "$PROVER_REAL_PROOFS" = "true" ]; then
+                node --no-warnings /usr/src/yarn-project/aztec/dest/bin/index.js preload-crs
+              else
+                echo "Skipping CRS preloading because proving is disabled"
+              fi
+          env:
+            - name: PROVER_REAL_PROOFS
+              value: "{{ .Values.aztec.realProofs }}"
+          volumeMounts:
+            - name: crs
+              mountPath: /root/.bb-crs
+      restartPolicy: Never
+---
+# Copy the CRS files to a readonly volume
+apiVersion: v1
+kind: PersistentVolumeClaim
+metadata:
+  name: {{ include "aztec-network.fullname" . }}-shared-crs-ro-pvc
+  labels:
+    {{- include "aztec-network.labels" . | nindent 4 }}
+  annotations:
+    "helm.sh/hook": pre-install,pre-upgrade
+    "helm.sh/hook-weight": "-4"
+spec:
+  accessModes: ["ReadOnlyMany"]
+  dataSource:
+    kind: PersistentVolumeClaim
+    name: {{ include "aztec-network.fullname" . }}-shared-crs-pvc
+  storageClassName: standard-rwo
+  resources:
+    requests:
+      storage: 3Gi
+---
+{{- end }}
 {{- end }}

--- a/yarn-project/aztec/src/cli/cli.ts
+++ b/yarn-project/aztec/src/cli/cli.ts
@@ -44,5 +44,13 @@ export function injectAztecCommands(program: Command, userLog: LogFn, debugLogge
     `,
   );
 
+  program
+    .command('preload-crs')
+    .description('Preload the points data needed for proving and verifying')
+    .action(async options => {
+      const { preloadCrs } = await import('./preload_crs.js');
+      return await preloadCrs(options, userLog, debugLogger);
+    });
+
   return program;
 }

--- a/yarn-project/aztec/src/cli/preload_crs.ts
+++ b/yarn-project/aztec/src/cli/preload_crs.ts
@@ -1,0 +1,7 @@
+import type { LogFn, Logger } from '@aztec/foundation/log';
+
+import { preloadCrsDataForServerSideProving } from './util.js';
+
+export async function preloadCrs(_options: any, userLog: LogFn, _debugLogger: Logger) {
+  await preloadCrsDataForServerSideProving({ realProofs: true }, userLog);
+}


### PR DESCRIPTION
This PR downloads the CRS file to a volume using a pre-install helm job that then gets cloned into a `ReadOnlyMany` shared volume for all the agents
