### PR TITLE
fix: bb workdir permission issue

### DIFF
--- a/release-image/Dockerfile
+++ b/release-image/Dockerfile
@@ -7,5 +7,5 @@ ENV BB_WORKING_DIRECTORY=/usr/src/bb
 ENV BB_BINARY_PATH=/usr/src/barretenberg/cpp/build/bin/bb
 ENV ACVM_WORKING_DIRECTORY=/usr/src/acvm
 ENV ACVM_BINARY_PATH=/usr/src/noir/noir-repo/target/release/acvm
-RUN mkdir -p $BB_WORKING_DIRECTORY $ACVM_WORKING_DIRECTORY
+RUN mkdir -p $BB_WORKING_DIRECTORY $ACVM_WORKING_DIRECTORY && chmod 777 $BB_WORKING_DIRECTORY $ACVM_WORKING_DIRECTORY
 WORKDIR "/usr/src/yarn-project"


### PR DESCRIPTION
Running PXE with proving enabled is running in to the below error because the configured bb-workdir is not write-able by `bb` process invoked by `node`

```
[Error: EACCES: permission denied, mkdtemp '/usr/src/bb/tmp-ULF1eo']....
```

Setting 777 to the workdirs