### PR TITLE
chore: remove templating by flavor in merge protocol

### DIFF
--- a/barretenberg/cpp/src/barretenberg/constants.hpp
+++ b/barretenberg/cpp/src/barretenberg/constants.hpp
@@ -13,8 +13,6 @@ static constexpr uint32_t CONST_PG_LOG_N = 20;
 
 static constexpr uint32_t CONST_ECCVM_LOG_N = 16;
 
-static constexpr uint32_t NUM_OP_QUEUE_COLUMNS = 4;
-
 // TODO(https://github.com/AztecProtocol/barretenberg/issues/1193): potentially reenable for better memory performance
 // static constexpr uint32_t MAX_LOOKUP_TABLES_SIZE = 80000;
 

--- a/barretenberg/cpp/src/barretenberg/constants.hpp
+++ b/barretenberg/cpp/src/barretenberg/constants.hpp
@@ -13,6 +13,8 @@ static constexpr uint32_t CONST_PG_LOG_N = 20;
 
 static constexpr uint32_t CONST_ECCVM_LOG_N = 16;
 
+static constexpr uint32_t NUM_OP_QUEUE_COLUMNS = 4;
+
 // TODO(https://github.com/AztecProtocol/barretenberg/issues/1193): potentially reenable for better memory performance
 // static constexpr uint32_t MAX_LOOKUP_TABLES_SIZE = 80000;
 
@@ -21,16 +23,20 @@ static constexpr uint32_t MAX_DATABUS_SIZE = 10000;
 // The number of entries in ProverPolynomials reserved for randomness intended to mask witness commitments, witness
 // evaluation at the sumcheck challenge, and, if necessary, the evaluation of the corresponding shift
 static constexpr uint32_t MASKING_OFFSET = 4;
+
 // For ZK Flavors: the number of the commitments required by Libra and SmallSubgroupIPA.
 static constexpr uint32_t NUM_LIBRA_COMMITMENTS = 3;
+
 // The SmallSubgroupIPA is a sub-protocol used in several Flavors, to prove claimed inner product, the Prover sends 4
 // extra evaluations
 static constexpr uint32_t NUM_SMALL_IPA_EVALUATIONS = 4;
 
 static constexpr uint32_t MERGE_PROOF_SIZE = 65; // used to ensure mock proofs are generated correctly
+
 // There are 5 distinguished wires in ECCVM that have to be opened as univariates to establish the connection between
 // ECCVM and Translator
 static constexpr uint32_t NUM_TRANSLATION_EVALUATIONS = 5;
+
 // Upper bound on the number of claims produced GeminiProver:
 // - Each fold polynomial is opened at two points, the number of resulting claims is bounded by 2*CONST_PROOF_SIZE_LOG_N
 // - The interleaving trick needed for Translator adds 2 extra claims

--- a/barretenberg/cpp/src/barretenberg/goblin/goblin.hpp
+++ b/barretenberg/cpp/src/barretenberg/goblin/goblin.hpp
@@ -36,7 +36,6 @@ class GoblinProver {
     using TranslationEvaluations = ECCVMProver::TranslationEvaluations;
     using TranslatorBuilder = TranslatorCircuitBuilder;
 
-    using MergeProver = MergeProver_<MegaFlavor>;
     using VerificationKey = MegaFlavor::VerificationKey;
     using MergeProof = MergeProver::MergeProof;
 
@@ -170,7 +169,6 @@ class GoblinVerifier {
   public:
     using ECCVMVerificationKey = ECCVMFlavor::VerificationKey;
     using TranslatorVerificationKey = bb::TranslatorFlavor::VerificationKey;
-    using MergeVerifier = bb::MergeVerifier_<MegaFlavor>;
     using Builder = MegaCircuitBuilder;
     using RecursiveMergeVerifier = stdlib::recursion::goblin::MergeRecursiveVerifier_<Builder>;
     using PairingPoints = RecursiveMergeVerifier::PairingPoints;

--- a/barretenberg/cpp/src/barretenberg/goblin/mock_circuits.hpp
+++ b/barretenberg/cpp/src/barretenberg/goblin/mock_circuits.hpp
@@ -53,7 +53,7 @@ class GoblinMockCircuits {
     using RecursiveVerificationKey = RecursiveDeciderVerificationKey::VerificationKey;
     using RecursiveVerifierAccumulator = std::shared_ptr<RecursiveDeciderVerificationKey>;
     using VerificationKey = Flavor::VerificationKey;
-    static constexpr size_t NUM_OP_QUEUE_COLUMNS = Flavor::NUM_WIRES;
+    static constexpr size_t NUM_WIRES = Flavor::NUM_WIRES;
 
     struct KernelInput {
         HonkProof proof;

--- a/barretenberg/cpp/src/barretenberg/stdlib/goblin_verifier/merge_verifier.test.cpp
+++ b/barretenberg/cpp/src/barretenberg/stdlib/goblin_verifier/merge_verifier.test.cpp
@@ -31,8 +31,6 @@ template <class RecursiveBuilder> class RecursiveMergeVerifierTest : public test
     using Commitment = InnerFlavor::Commitment;
     using FF = InnerFlavor::FF;
     using VerifierCommitmentKey = bb::VerifierCommitmentKey<curve::BN254>;
-    using MergeProver = MergeProver_<InnerFlavor>;
-    using MergeVerifier = MergeVerifier_<InnerFlavor>;
 
   public:
     static void SetUpTestSuite() { bb::srs::init_crs_factory(bb::srs::get_ignition_crs_path()); }

--- a/barretenberg/cpp/src/barretenberg/ultra_honk/mega_honk.test.cpp
+++ b/barretenberg/cpp/src/barretenberg/ultra_honk/mega_honk.test.cpp
@@ -27,8 +27,6 @@ template <typename Flavor> class MegaHonkTests : public ::testing::Test {
     using FF = Curve::ScalarField;
     using Point = Curve::AffineElement;
     using CommitmentKey = bb::CommitmentKey<Curve>;
-    using MergeProver = MergeProver_<Flavor>;
-    using MergeVerifier = MergeVerifier_<Flavor>;
     using Prover = UltraProver_<Flavor>;
     using Verifier = UltraVerifier_<Flavor>;
     using VerificationKey = typename Flavor::VerificationKey;
@@ -97,7 +95,6 @@ TYPED_TEST_SUITE(MegaHonkTests, FlavorTypes);
 TYPED_TEST(MegaHonkTests, MergeProofSizeCheck)
 {
     using Flavor = TypeParam;
-    using MergeProver = MergeProver_<Flavor>;
 
     auto builder = typename Flavor::CircuitBuilder{};
     GoblinMockCircuits::construct_simple_circuit(builder);

--- a/barretenberg/cpp/src/barretenberg/ultra_honk/merge_prover.hpp
+++ b/barretenberg/cpp/src/barretenberg/ultra_honk/merge_prover.hpp
@@ -37,6 +37,9 @@ class MergeProver {
   private:
     std::shared_ptr<ECCOpQueue> op_queue;
     std::shared_ptr<CommitmentKey> pcs_commitment_key;
+    // Number of columns that jointly constitute the op_queue, should be the same as the number of wires in the
+    // MegaCircuitBuilder
+    static constexpr size_t NUM_WIRES = MegaExecutionTraceBlocks::NUM_WIRES;
 };
 
 } // namespace bb

--- a/barretenberg/cpp/src/barretenberg/ultra_honk/merge_prover.hpp
+++ b/barretenberg/cpp/src/barretenberg/ultra_honk/merge_prover.hpp
@@ -13,13 +13,13 @@ namespace bb {
  * @brief Prover class for the Goblin ECC op queue transcript merge protocol
  *
  */
-template <typename Flavor> class MergeProver_ {
-    using FF = typename Flavor::FF;
-    using Polynomial = typename Flavor::Polynomial;
-    using CommitmentKey = typename Flavor::CommitmentKey;
-    using Commitment = typename Flavor::Commitment;
-    using PCS = typename Flavor::PCS;
-    using Curve = typename Flavor::Curve;
+class MergeProver {
+    using Curve = curve::BN254;
+    using FF = Curve::ScalarField;
+    using Commitment = Curve::AffineElement;
+    using Polynomial = bb::Polynomial<FF>;
+    using CommitmentKey = bb::CommitmentKey<Curve>;
+    using PCS = KZG<Curve>;
     using OpeningClaim = ProverOpeningClaim<Curve>;
     using OpeningPair = bb::OpeningPair<Curve>;
     using Transcript = NativeTranscript;
@@ -29,15 +29,14 @@ template <typename Flavor> class MergeProver_ {
 
     std::shared_ptr<Transcript> transcript;
 
-    explicit MergeProver_(const std::shared_ptr<ECCOpQueue>& op_queue,
-                          std::shared_ptr<CommitmentKey> commitment_key = nullptr);
+    explicit MergeProver(const std::shared_ptr<ECCOpQueue>& op_queue,
+                         std::shared_ptr<CommitmentKey> commitment_key = nullptr);
 
     BB_PROFILE MergeProof construct_proof();
 
   private:
     std::shared_ptr<ECCOpQueue> op_queue;
     std::shared_ptr<CommitmentKey> pcs_commitment_key;
-    static constexpr size_t NUM_WIRES = MegaFlavor::NUM_WIRES;
 };
 
 } // namespace bb

--- a/barretenberg/cpp/src/barretenberg/ultra_honk/merge_verifier.cpp
+++ b/barretenberg/cpp/src/barretenberg/ultra_honk/merge_verifier.cpp
@@ -4,8 +4,7 @@
 
 namespace bb {
 
-template <typename Flavor>
-MergeVerifier_<Flavor>::MergeVerifier_()
+MergeVerifier::MergeVerifier()
     : transcript(std::make_shared<Transcript>())
     , pcs_verification_key(std::make_unique<VerifierCommitmentKey>()){};
 
@@ -22,17 +21,17 @@ MergeVerifier_<Flavor>::MergeVerifier_()
  * @tparam Flavor
  * @return bool Verification result
  */
-template <typename Flavor> bool MergeVerifier_<Flavor>::verify_proof(const HonkProof& proof)
+bool MergeVerifier::verify_proof(const HonkProof& proof)
 {
     transcript = std::make_shared<Transcript>(proof);
 
     uint32_t subtable_size = transcript->template receive_from_prover<uint32_t>("subtable_size");
 
     // Receive table column polynomial commitments [t_j], [T_{j,prev}], and [T_j], j = 1,2,3,4
-    std::array<Commitment, Flavor::NUM_WIRES> t_commitments;
-    std::array<Commitment, Flavor::NUM_WIRES> T_prev_commitments;
-    std::array<Commitment, Flavor::NUM_WIRES> T_commitments;
-    for (size_t idx = 0; idx < Flavor::NUM_WIRES; ++idx) {
+    std::array<Commitment, NUM_OP_QUEUE_COLUMNS> t_commitments;
+    std::array<Commitment, NUM_OP_QUEUE_COLUMNS> T_prev_commitments;
+    std::array<Commitment, NUM_OP_QUEUE_COLUMNS> T_commitments;
+    for (size_t idx = 0; idx < NUM_OP_QUEUE_COLUMNS; ++idx) {
         std::string suffix = std::to_string(idx);
         t_commitments[idx] = transcript->template receive_from_prover<Commitment>("t_CURRENT_" + suffix);
         T_prev_commitments[idx] = transcript->template receive_from_prover<Commitment>("T_PREV_" + suffix);
@@ -42,22 +41,22 @@ template <typename Flavor> bool MergeVerifier_<Flavor>::verify_proof(const HonkP
     FF kappa = transcript->template get_challenge<FF>("kappa");
 
     // Receive evaluations t_j(\kappa), T_{j,prev}(\kappa), T_j(\kappa), j = 1,2,3,4
-    std::array<FF, Flavor::NUM_WIRES> t_evals;
-    std::array<FF, Flavor::NUM_WIRES> T_prev_evals;
-    std::array<FF, Flavor::NUM_WIRES> T_evals;
-    for (size_t idx = 0; idx < Flavor::NUM_WIRES; ++idx) {
+    std::array<FF, NUM_OP_QUEUE_COLUMNS> t_evals;
+    std::array<FF, NUM_OP_QUEUE_COLUMNS> T_prev_evals;
+    std::array<FF, NUM_OP_QUEUE_COLUMNS> T_evals;
+    for (size_t idx = 0; idx < NUM_OP_QUEUE_COLUMNS; ++idx) {
         t_evals[idx] = transcript->template receive_from_prover<FF>("t_eval_" + std::to_string(idx));
     }
-    for (size_t idx = 0; idx < Flavor::NUM_WIRES; ++idx) {
+    for (size_t idx = 0; idx < NUM_OP_QUEUE_COLUMNS; ++idx) {
         T_prev_evals[idx] = transcript->template receive_from_prover<FF>("T_prev_eval_" + std::to_string(idx));
     }
-    for (size_t idx = 0; idx < NUM_WIRES; ++idx) {
+    for (size_t idx = 0; idx < NUM_OP_QUEUE_COLUMNS; ++idx) {
         T_evals[idx] = transcript->template receive_from_prover<FF>("T_eval_" + std::to_string(idx));
     }
 
     // Check the identity T_j(\kappa) = t_j(\kappa) + \kappa^m * T_{j,prev}(\kappa). If it fails, return false
     bool identity_checked = true;
-    for (size_t idx = 0; idx < NUM_WIRES; ++idx) {
+    for (size_t idx = 0; idx < NUM_OP_QUEUE_COLUMNS; ++idx) {
         FF T_prev_shifted_eval_reconstructed = T_prev_evals[idx] * kappa.pow(subtable_size);
         bool current_check = T_evals[idx] == t_evals[idx] + T_prev_shifted_eval_reconstructed;
         identity_checked = identity_checked && current_check;
@@ -69,17 +68,17 @@ template <typename Flavor> bool MergeVerifier_<Flavor>::verify_proof(const HonkP
     Commitment batched_commitment = t_commitments[0];
     FF batched_eval = t_evals[0];
     auto alpha_pow = alpha;
-    for (size_t idx = 1; idx < NUM_WIRES; ++idx) {
+    for (size_t idx = 1; idx < NUM_OP_QUEUE_COLUMNS; ++idx) {
         batched_commitment = batched_commitment + (t_commitments[idx] * alpha_pow);
         batched_eval += alpha_pow * t_evals[idx];
         alpha_pow *= alpha;
     }
-    for (size_t idx = 0; idx < NUM_WIRES; ++idx) {
+    for (size_t idx = 0; idx < NUM_OP_QUEUE_COLUMNS; ++idx) {
         batched_commitment = batched_commitment + (T_prev_commitments[idx] * alpha_pow);
         batched_eval += alpha_pow * T_prev_evals[idx];
         alpha_pow *= alpha;
     }
-    for (size_t idx = 0; idx < NUM_WIRES; ++idx) {
+    for (size_t idx = 0; idx < NUM_OP_QUEUE_COLUMNS; ++idx) {
         batched_commitment = batched_commitment + (T_commitments[idx] * alpha_pow);
         batched_eval += alpha_pow * T_evals[idx];
         alpha_pow *= alpha;
@@ -91,9 +90,4 @@ template <typename Flavor> bool MergeVerifier_<Flavor>::verify_proof(const HonkP
     auto verified = pcs_verification_key->pairing_check(pairing_points[0], pairing_points[1]);
     return identity_checked && verified;
 }
-
-template class MergeVerifier_<UltraFlavor>;
-template class MergeVerifier_<MegaFlavor>;
-template class MergeVerifier_<MegaZKFlavor>;
-
 } // namespace bb

--- a/barretenberg/cpp/src/barretenberg/ultra_honk/merge_verifier.hpp
+++ b/barretenberg/cpp/src/barretenberg/ultra_honk/merge_verifier.hpp
@@ -30,6 +30,9 @@ class MergeVerifier {
 
   private:
     std::shared_ptr<VerifierCommitmentKey> pcs_verification_key;
+    // Number of columns that jointly constitute the op_queue, should be the same as the number of wires in the
+    // MegaCircuitBuilder
+    static constexpr size_t NUM_WIRES = MegaExecutionTraceBlocks::NUM_WIRES;
 };
 
 } // namespace bb

--- a/barretenberg/cpp/src/barretenberg/ultra_honk/merge_verifier.hpp
+++ b/barretenberg/cpp/src/barretenberg/ultra_honk/merge_verifier.hpp
@@ -13,8 +13,8 @@ namespace bb {
  * @brief Verifier class for the Goblin ECC op queue transcript merge protocol
  *
  */
-template <typename Flavor> class MergeVerifier_ {
-    using Curve = typename Flavor::Curve;
+class MergeVerifier {
+    using Curve = curve::BN254;
     using FF = typename Curve::ScalarField;
     using Commitment = typename Curve::AffineElement;
     using PCS = bb::KZG<Curve>;
@@ -25,12 +25,11 @@ template <typename Flavor> class MergeVerifier_ {
   public:
     std::shared_ptr<Transcript> transcript;
 
-    explicit MergeVerifier_();
+    explicit MergeVerifier();
     bool verify_proof(const HonkProof& proof);
 
   private:
     std::shared_ptr<VerifierCommitmentKey> pcs_verification_key;
-    static constexpr size_t NUM_WIRES = Flavor::NUM_WIRES;
 };
 
 } // namespace bb


### PR DESCRIPTION
The merge protocol never benefited from the structures that are part of Flavor so it makes sense to remove the templating.
