### PR TITLE
fix: force anvil/blob networking to ipv4 on localhost. attempt to fix port flakes

### DIFF
--- a/yarn-project/end-to-end/src/fixtures/snapshot_manager.ts
+++ b/yarn-project/end-to-end/src/fixtures/snapshot_manager.ts
@@ -317,7 +317,7 @@ async function setupFromFresh(
   } else {
     aztecNodeConfig.dataDirectory = statePath;
   }
-  aztecNodeConfig.blobSinkUrl = `http://localhost:${blobSinkPort}`;
+  aztecNodeConfig.blobSinkUrl = `http://127.0.0.1:${blobSinkPort}`;
 
   // Start anvil. We go via a wrapper script to ensure if the parent dies, anvil dies.
   logger.verbose('Starting anvil...');

--- a/yarn-project/end-to-end/src/fixtures/snapshot_manager.ts
+++ b/yarn-project/end-to-end/src/fixtures/snapshot_manager.ts
@@ -308,6 +308,7 @@ async function setupFromFresh(
   aztecNodeConfig.peerCheckIntervalMS = TEST_PEER_CHECK_INTERVAL_MS;
   // Only enable proving if specifically requested.
   aztecNodeConfig.realProofs = !!opts.realProofs;
+  aztecNodeConfig.listenAddress = '127.0.0.1';
 
   // Create a temp directory for all ephemeral state and cleanup afterwards
   const directoryToCleanup = path.join(tmpdir(), randomBytes(8).toString('hex'));
@@ -490,6 +491,7 @@ async function setupFromState(statePath: string, logger: Logger): Promise<Subsys
   );
   aztecNodeConfig.dataDirectory = statePath;
   aztecNodeConfig.blobSinkUrl = `http://127.0.0.1:${blobSinkPort}`;
+  aztecNodeConfig.listenAddress = '127.0.0.1';
 
   const initialFundedAccounts: InitialAccountData[] =
     JSON.parse(readFileSync(`${statePath}/accounts.json`, 'utf-8'), reviver) || [];

--- a/yarn-project/ethereum/src/test/start_anvil.ts
+++ b/yarn-project/ethereum/src/test/start_anvil.ts
@@ -22,6 +22,7 @@ export async function startAnvil(
     async () => {
       const anvil = createAnvil({
         anvilBinary,
+        host: '127.0.0.1',
         port: 0,
         blockTime: opts.l1BlockTime,
         stopTimeout: 1000,


### PR DESCRIPTION
We occasionally get "port in use" or "unable to find available port" issues in tests that use the network stack.
When I was facing these with TXE startups, I think I eventually "resolved" it by ensuring we bind explicitly to the loopback interface using only ipv4 by directly specifying `127.0.0.1`.
If you provide `localhost` you might bind on ipv6, and some of our defaults are `0.0.0.0` which attempts to bind on all available interfaces - and I think that may actually be where the problem lies.

This is a bit of a wing - we can see if it works.