### PR TITLE
feat: Increase CIVC depth with no rollup cost

### DIFF
--- a/barretenberg/cpp/src/barretenberg/client_ivc/client_ivc.cpp
+++ b/barretenberg/cpp/src/barretenberg/client_ivc/client_ivc.cpp
@@ -156,10 +156,9 @@ void ClientIVC::accumulate(ClientCircuit& circuit,
     // Construct the proving key for circuit
     std::shared_ptr<DeciderProvingKey> proving_key = std::make_shared<DeciderProvingKey>(circuit, trace_settings);
 
-    // The commitment key is initialised with the number of points determined by the trace_settings' dyadic size. If a
-    // circuit overflows past the dyadic size the commitment key will not have enough points so we need to increase it
-    // WORKTODO: we need to check that the size we set here is also enough to commit to the polynomials in translator
-    if (proving_key->proving_key.circuit_size > trace_settings.dyadic_size()) {
+    // If the current circuit overflows past the current size of the commitment key, reinitialize accordingly.
+    // WORKTODO: Make issue to set once and for all. Also, having to reset the goblin key is brittle.
+    if (proving_key->proving_key.circuit_size > bn254_commitment_key->dyadic_size) {
         bn254_commitment_key = std::make_shared<CommitmentKey<curve::BN254>>(proving_key->proving_key.circuit_size);
         goblin.commitment_key = bn254_commitment_key;
     }

--- a/barretenberg/cpp/src/barretenberg/client_ivc/client_ivc.cpp
+++ b/barretenberg/cpp/src/barretenberg/client_ivc/client_ivc.cpp
@@ -157,7 +157,7 @@ void ClientIVC::accumulate(ClientCircuit& circuit,
     std::shared_ptr<DeciderProvingKey> proving_key = std::make_shared<DeciderProvingKey>(circuit, trace_settings);
 
     // If the current circuit overflows past the current size of the commitment key, reinitialize accordingly.
-    // WORKTODO: Make issue to set once and for all. Also, having to reset the goblin key is brittle.
+    // TODO(https://github.com/AztecProtocol/barretenberg/issues/1319)
     if (proving_key->proving_key.circuit_size > bn254_commitment_key->dyadic_size) {
         bn254_commitment_key = std::make_shared<CommitmentKey<curve::BN254>>(proving_key->proving_key.circuit_size);
         goblin.commitment_key = bn254_commitment_key;

--- a/barretenberg/cpp/src/barretenberg/client_ivc/client_ivc.cpp
+++ b/barretenberg/cpp/src/barretenberg/client_ivc/client_ivc.cpp
@@ -158,6 +158,7 @@ void ClientIVC::accumulate(ClientCircuit& circuit,
 
     // The commitment key is initialised with the number of points determined by the trace_settings' dyadic size. If a
     // circuit overflows past the dyadic size the commitment key will not have enough points so we need to increase it
+    // WORKTODO: we need to check that the size we set here is also enough to commit to the polynomials in translator
     if (proving_key->proving_key.circuit_size > trace_settings.dyadic_size()) {
         bn254_commitment_key = std::make_shared<CommitmentKey<curve::BN254>>(proving_key->proving_key.circuit_size);
         goblin.commitment_key = bn254_commitment_key;

--- a/barretenberg/cpp/src/barretenberg/client_ivc/client_ivc.hpp
+++ b/barretenberg/cpp/src/barretenberg/client_ivc/client_ivc.hpp
@@ -191,11 +191,17 @@ class ClientIVC {
     ClientIVC(TraceSettings trace_settings = {})
         : trace_usage_tracker(trace_settings)
         , trace_settings(trace_settings)
-        , bn254_commitment_key(trace_settings.structure.has_value()
-                                   ? std::make_shared<CommitmentKey<curve::BN254>>(trace_settings.dyadic_size())
-                                   : nullptr)
         , goblin(bn254_commitment_key)
-    {}
+    {
+        // Allocate BN254 commitment key based on the max dyadic Mega structured trace size and translator circuit size.
+        // WORKTODO: I'm accounting for the Translator here because things were breaking otherwise but it may make sense
+        // to only account for the translator once we're actually IN the translator.
+        size_t commitment_key_size =
+            std::max(trace_settings.dyadic_size(),
+                     TranslatorFlavor::TRANSLATOR_VM_FIXED_SIZE * TranslatorFlavor::INTERLEAVING_GROUP_SIZE);
+        info("BN254 commitment key size: ", commitment_key_size);
+        bn254_commitment_key = std::make_shared<CommitmentKey<curve::BN254>>(commitment_key_size);
+    }
 
     void instantiate_stdlib_verification_queue(
         ClientCircuit& circuit, const std::vector<std::shared_ptr<RecursiveVerificationKey>>& input_keys = {});

--- a/barretenberg/cpp/src/barretenberg/client_ivc/client_ivc.hpp
+++ b/barretenberg/cpp/src/barretenberg/client_ivc/client_ivc.hpp
@@ -194,8 +194,7 @@ class ClientIVC {
         , goblin(bn254_commitment_key)
     {
         // Allocate BN254 commitment key based on the max dyadic Mega structured trace size and translator circuit size.
-        // WORKTODO: I'm accounting for the Translator here because things were breaking otherwise but it may make sense
-        // to only account for the translator once we're actually IN the translator.
+        // https://github.com/AztecProtocol/barretenberg/issues/1319): Account for Translator only when it's necessary
         size_t commitment_key_size =
             std::max(trace_settings.dyadic_size(),
                      TranslatorFlavor::TRANSLATOR_VM_FIXED_SIZE * TranslatorFlavor::INTERLEAVING_GROUP_SIZE);

--- a/barretenberg/cpp/src/barretenberg/eccvm/eccvm_flavor.hpp
+++ b/barretenberg/cpp/src/barretenberg/eccvm/eccvm_flavor.hpp
@@ -46,6 +46,8 @@ class ECCVMFlavor {
     // Indicates that this flavor runs with ZK Sumcheck.
     static constexpr bool HasZK = true;
     // Fixed size of the ECCVM circuits used in ClientIVC
+    // Important: these constants cannot be  arbitrarily changes - please consult with a member of the Crypto team if
+    // they become too small.
     static constexpr size_t ECCVM_FIXED_SIZE = 1UL << CONST_ECCVM_LOG_N;
 
     static constexpr size_t NUM_WIRES = 85;

--- a/barretenberg/cpp/src/barretenberg/eccvm/eccvm_flavor.hpp
+++ b/barretenberg/cpp/src/barretenberg/eccvm/eccvm_flavor.hpp
@@ -527,8 +527,7 @@ class ECCVMFlavor {
             size_t dyadic_num_rows = 1UL << (log_num_rows + (1UL << log_num_rows == num_rows ? 0 : 1));
 
             if ((fixed_size) && (ECCVM_FIXED_SIZE < dyadic_num_rows)) {
-                info("The ECCVM circuit size has exceeded the fixed upper bound");
-                ASSERT(false);
+                throw_or_abort("The ECCVM circuit size has exceeded the fixed upper bound");
             }
 
             dyadic_num_rows = fixed_size ? ECCVM_FIXED_SIZE : dyadic_num_rows;

--- a/barretenberg/cpp/src/barretenberg/goblin/goblin.hpp
+++ b/barretenberg/cpp/src/barretenberg/goblin/goblin.hpp
@@ -149,6 +149,8 @@ class GoblinProver {
 
         PROFILE_THIS_NAME("Goblin::prove");
 
+        info("Constructing a Goblin proof with num ultra ops = ", op_queue->get_ultra_ops_table_num_rows());
+
         goblin_proof.merge_proof = merge_proof_in.empty() ? std::move(merge_proof) : std::move(merge_proof_in);
         {
             PROFILE_THIS_NAME("prove_eccvm");

--- a/barretenberg/cpp/src/barretenberg/relations/translator_vm/translator_permutation_relation.hpp
+++ b/barretenberg/cpp/src/barretenberg/relations/translator_vm/translator_permutation_relation.hpp
@@ -14,6 +14,17 @@ template <typename FF_> class TranslatorPermutationRelationImpl {
         3  // left-shiftable polynomial sub-relation
     };
 
+    /**
+     * @brief Returns true if the contribution from all subrelations for the provided inputs is identically zero
+     *
+     */
+    template <typename AllEntities> inline static bool skip(const AllEntities& in)
+    {
+        // If z_perm == z_perm_shift, this implies that none of the wire values for the present input are involved in
+        // non-trivial copy constraints.
+        return (in.z_perm - in.z_perm_shift).is_zero();
+    }
+
     inline static auto& get_grand_product_polynomial(auto& in) { return in.z_perm; }
     inline static auto& get_shifted_grand_product_polynomial(auto& in) { return in.z_perm_shift; }
 

--- a/barretenberg/cpp/src/barretenberg/translator_vm/translator_flavor.hpp
+++ b/barretenberg/cpp/src/barretenberg/translator_vm/translator_flavor.hpp
@@ -341,6 +341,8 @@ class TranslatorFlavor {
                                DerivedWitnessEntities<DataType>::get_all());
         };
 
+        auto get_wires_to_be_shifted() { return WireToBeShiftedEntities<DataType>::get_all(); };
+
         /**
          * @brief Get the entities constructed by interleaving.
          */
@@ -595,39 +597,61 @@ class TranslatorFlavor {
       public:
         // Define all operations as default, except copy construction/assignment
         ProverPolynomials() = default;
-        // Constructor to init all unshifted polys to the zero polynomial and set the shifted poly data
-        ProverPolynomials(size_t mini_circuit_size)
+
+        /**
+         * @brief ProverPolynomials constructor
+         * @details Attempts to initialize polynomials efficiently by using the actual size of the mini circuit rather
+         * than the fixed dydaic size.
+         *
+         * @param actual_mini_circuit_size Actual number of rows in the mini circuit.
+         */
+        ProverPolynomials(size_t actual_mini_circuit_size)
         {
-            size_t circuit_size = mini_circuit_size * INTERLEAVING_GROUP_SIZE;
+            const size_t mini_circuit_size = TRANSLATOR_VM_FIXED_SIZE;
+            const size_t circuit_size = TRANSLATOR_VM_FIXED_SIZE * INTERLEAVING_GROUP_SIZE;
+
+            // WORKTODO: these are currently fully dense in the full circuit size but I'm guessing that doesnt need to
+            // be the case..
             for (auto& ordered_range_constraint : get_ordered_range_constraints()) {
                 ordered_range_constraint = Polynomial{ /*size*/ circuit_size - 1,
-                                                       /*largest possible index*/ circuit_size,
+                                                       /*virtual_size*/ circuit_size,
                                                        1 };
             }
 
-            for (auto& interleaved : get_interleaved()) {
-                interleaved = Polynomial{ /*size*/ circuit_size, circuit_size };
-            }
             z_perm = Polynomial{ /*size*/ circuit_size - 1,
                                  /*virtual_size*/ circuit_size,
                                  /*start_index*/ 1 };
 
-            // All to_be_shifted witnesses except the ordered range constraints and z_perm are only non-zero in the mini
-            // circuit
-            for (auto& poly : get_to_be_shifted()) {
-                if (poly.is_empty()) {
-                    poly = Polynomial{ /*size*/ mini_circuit_size - 1,
-                                       /*virtual_size*/ circuit_size,
-                                       /*start_index*/ 1 };
-                }
+            // Initialize to be shifted wires based on actual size of the mini circuit
+            for (auto& poly : get_wires_to_be_shifted()) {
+                poly = Polynomial{ /*size*/ actual_mini_circuit_size - 1,
+                                   /*virtual_size*/ circuit_size,
+                                   /*start_index*/ 1 };
             }
 
+            // Initialize interleaved polys based on actual mini circuit size times number of polys to be interleaved
+            const size_t actual_circuit_size = actual_mini_circuit_size * INTERLEAVING_GROUP_SIZE;
+            for (auto& poly : get_interleaved()) {
+                poly = Polynomial{ actual_circuit_size, circuit_size };
+            }
+
+            // Initialize some one-off polys with special structure
+            lagrange_first = Polynomial{ /*size*/ 1, /*virtual_size*/ circuit_size };
+            lagrange_second = Polynomial{ /*size*/ 2, /*virtual_size*/ circuit_size };
+            lagrange_even_in_minicircuit = Polynomial{ /*size*/ mini_circuit_size, /*virtual_size*/ circuit_size };
+            lagrange_odd_in_minicircuit = Polynomial{ /*size*/ mini_circuit_size, /*virtual_size*/ circuit_size };
+
+            // WORKTODO: why does limiting this to actual_mini_circuit_size not work?
+            op = Polynomial{ circuit_size }; // Polynomial{ actual_mini_circuit_size, circuit_size };
+
+            // Catch-all for the rest of the polynomials
+            // WORKTODO: determine what exactly falls in here and be more specific (just the remaining precomputed?)
             for (auto& poly : get_unshifted()) {
-                if (poly.is_empty()) {
-                    // Not set above
+                if (poly.is_empty()) { // Only set those polys which were not already set above
                     poly = Polynomial{ circuit_size };
                 }
             }
+            // Set all shifted polynomials based on their unshifted counterpart
             set_shifted();
         }
         ProverPolynomials& operator=(const ProverPolynomials&) = delete;
@@ -671,9 +695,17 @@ class TranslatorFlavor {
         using Base::Base;
 
         ProvingKey() = default;
-        ProvingKey(const size_t dyadic_circuit_size, std::shared_ptr<CommitmentKey> commitment_key = nullptr)
-            : Base(dyadic_circuit_size, 0, std::move(commitment_key))
+        // WORKTODO: this is a constructor used only in tests. We should get rid of it or make it a test-only method.
+        ProvingKey(const size_t dyadic_circuit_size)
+            : Base(dyadic_circuit_size, 0)
             , polynomials(this->circuit_size)
+        {}
+
+        ProvingKey(const size_t dyadic_circuit_size,
+                   std::shared_ptr<CommitmentKey> commitment_key,
+                   const size_t actual_mini_circuit_size)
+            : Base(dyadic_circuit_size, 0, std::move(commitment_key))
+            , polynomials(actual_mini_circuit_size)
         {}
     };
 

--- a/barretenberg/cpp/src/barretenberg/translator_vm/translator_flavor.hpp
+++ b/barretenberg/cpp/src/barretenberg/translator_vm/translator_flavor.hpp
@@ -304,6 +304,8 @@ class TranslatorFlavor {
                                WireToBeShiftedEntities<DataType>::get_all());
         };
 
+        auto get_wires_to_be_shifted() { return WireToBeShiftedEntities<DataType>::get_all(); };
+
         /**
          * @brief Witness Entities to which the prover commits and do not require challenges (i.e. not derived).
          */
@@ -340,8 +342,6 @@ class TranslatorFlavor {
                                OrderedRangeConstraints<DataType>::get_all(),
                                DerivedWitnessEntities<DataType>::get_all());
         };
-
-        auto get_wires_to_be_shifted() { return WireToBeShiftedEntities<DataType>::get_all(); };
 
         /**
          * @brief Get the entities constructed by interleaving.
@@ -603,15 +603,14 @@ class TranslatorFlavor {
          * @details Attempts to initialize polynomials efficiently by using the actual size of the mini circuit rather
          * than the fixed dydaic size.
          *
-         * @param actual_mini_circuit_size Actual number of rows in the mini circuit.
+         * @param actual_mini_circuit_size Actual number of rows in the Translator circuit.
          */
+        // TODO(https://github.com/AztecProtocol/barretenberg/issues/1318)
         ProverPolynomials(size_t actual_mini_circuit_size)
         {
             const size_t mini_circuit_size = TRANSLATOR_VM_FIXED_SIZE;
             const size_t circuit_size = TRANSLATOR_VM_FIXED_SIZE * INTERLEAVING_GROUP_SIZE;
 
-            // WORKTODO: these are currently fully dense in the full circuit size but I'm guessing that doesnt need to
-            // be the case..
             for (auto& ordered_range_constraint : get_ordered_range_constraints()) {
                 ordered_range_constraint = Polynomial{ /*size*/ circuit_size - 1,
                                                        /*virtual_size*/ circuit_size,
@@ -696,9 +695,9 @@ class TranslatorFlavor {
 
         ProvingKey() = default;
         // WORKTODO: this is a constructor used only in tests. We should get rid of it or make it a test-only method.
-        ProvingKey(const size_t dyadic_circuit_size)
+        ProvingKey(const size_t dyadic_circuit_size, const size_t actual_mini_circuit_size)
             : Base(dyadic_circuit_size, 0)
-            , polynomials(this->circuit_size)
+            , polynomials(actual_mini_circuit_size)
         {}
 
         ProvingKey(const size_t dyadic_circuit_size,

--- a/barretenberg/cpp/src/barretenberg/translator_vm/translator_flavor.hpp
+++ b/barretenberg/cpp/src/barretenberg/translator_vm/translator_flavor.hpp
@@ -44,7 +44,7 @@ class TranslatorFlavor {
     // A minicircuit of such size allows for 10 rounds of folding (i.e. 20 circuits).
     // Lowest possible size for the translator circuit (this sets the mini_circuit_size)
     static constexpr size_t MINIMUM_MINI_CIRCUIT_SIZE = 2048;
-    static constexpr size_t TRANSLATOR_VM_FIXED_SIZE = 8192;
+    static constexpr size_t TRANSLATOR_VM_FIXED_SIZE = 16384;
     static_assert(TRANSLATOR_VM_FIXED_SIZE >= MINIMUM_MINI_CIRCUIT_SIZE);
 
     // The size of the circuit which is filled with non-zero values for most polynomials. Most relations (everything

--- a/barretenberg/cpp/src/barretenberg/translator_vm/translator_flavor.hpp
+++ b/barretenberg/cpp/src/barretenberg/translator_vm/translator_flavor.hpp
@@ -43,6 +43,8 @@ class TranslatorFlavor {
 
     // A minicircuit of such size allows for 10 rounds of folding (i.e. 20 circuits).
     // Lowest possible size for the translator circuit (this sets the mini_circuit_size)
+    // Important: these constants cannot be  arbitrarily changes - please consult with a member of the Crypto team if
+    // they become too small.
     static constexpr size_t MINIMUM_MINI_CIRCUIT_SIZE = 2048;
     static constexpr size_t TRANSLATOR_VM_FIXED_SIZE = 16384;
     static_assert(TRANSLATOR_VM_FIXED_SIZE >= MINIMUM_MINI_CIRCUIT_SIZE);

--- a/barretenberg/cpp/src/barretenberg/translator_vm/translator_prover.cpp
+++ b/barretenberg/cpp/src/barretenberg/translator_vm/translator_prover.cpp
@@ -125,6 +125,20 @@ void TranslatorProver::execute_grand_product_computation_round()
  */
 void TranslatorProver::execute_relation_check_rounds()
 {
+    // // DEBUG: Print actual size, size, and virtual size of polynomials
+    // for (auto& interleaved_poly : key->proving_key->polynomials.get_unshifted()) {
+    //     // for (auto& interleaved_poly : key->proving_key->polynomials.get_all()) {
+    //     size_t last_non_zero_index = 0;
+    //     for (size_t i = 0; i < interleaved_poly.size(); i++) {
+    //         if (interleaved_poly[i] != 0) {
+    //             last_non_zero_index = i;
+    //         }
+    //     }
+    //     // printing the last non-zero index of each polynomial vs virtual size of polynomial
+    //     std::cout << "Actual size: " << last_non_zero_index + 1 << " vs size_: " << interleaved_poly.size()
+    //               << " vs virtual_size_: " << interleaved_poly.virtual_size() << std::endl;
+    // }
+
     using Sumcheck = SumcheckProver<Flavor>;
 
     auto sumcheck = Sumcheck(key->proving_key->circuit_size, transcript);
@@ -134,14 +148,15 @@ void TranslatorProver::execute_relation_check_rounds()
         gate_challenges[idx] = transcript->template get_challenge<FF>("Sumcheck:gate_challenge_" + std::to_string(idx));
     }
 
-    const size_t log_subgroup_size = static_cast<size_t>(numeric::get_msb(Flavor::Curve::SUBGROUP_SIZE));
-    // Create a temporary commitment key that is only used to initialise the ZKSumcheckData
-    // If proving in WASM, the commitment key that is part of the Translator proving key remains deallocated
-    //  until we enter the PCS round
-    auto ck = std::make_shared<CommitmentKey>(1 << (log_subgroup_size + 1));
+    // const size_t log_subgroup_size = static_cast<size_t>(numeric::get_msb(Flavor::Curve::SUBGROUP_SIZE));
+    // // Create a temporary commitment key that is only used to initialise the ZKSumcheckData
+    // // If proving in WASM, the commitment key that is part of the Translator proving key remains deallocated
+    // //  until we enter the PCS round
+    // auto ck = std::make_shared<CommitmentKey>(1 << (log_subgroup_size + 1));
 
     // // create masking polynomials for sumcheck round univariates and auxiliary data
-    zk_sumcheck_data = ZKData(key->proving_key->log_circuit_size, transcript, ck);
+    zk_sumcheck_data = ZKData(key->proving_key->log_circuit_size, transcript, key->proving_key->commitment_key);
+    // zk_sumcheck_data = ZKData(key->proving_key->log_circuit_size, transcript, ck);
 
     sumcheck_output =
         sumcheck.prove(key->proving_key->polynomials, relation_parameters, alpha, gate_challenges, zk_sumcheck_data);
@@ -205,10 +220,11 @@ HonkProof TranslatorProver::construct_proof()
     // Compute grand product(s) and commitments.
     execute_grand_product_computation_round();
 
-    // #ifndef __wasm__
-    // Free the commitment key
-    key->proving_key->commitment_key = nullptr;
-    // #endif
+    // WORKTODO: figure out how to make this work. (shouldn't be excluded in WASM!)
+    // // #ifndef __wasm__
+    // // Free the commitment key
+    // key->proving_key->commitment_key = nullptr;
+    // // #endif
 
     // Fiat-Shamir: alpha
     // Run sumcheck subprotocol.

--- a/barretenberg/cpp/src/barretenberg/translator_vm/translator_prover.cpp
+++ b/barretenberg/cpp/src/barretenberg/translator_vm/translator_prover.cpp
@@ -218,11 +218,6 @@ HonkProof TranslatorProver::construct_proof()
     // Execute Shplemini PCS
     execute_pcs_rounds();
     vinfo("computed opening proof");
-    // #ifndef __wasm__
-    // Free the commitment key
-    key->proving_key->commitment_key = nullptr;
-    // #endif
-
     return export_proof();
 }
 

--- a/barretenberg/cpp/src/barretenberg/translator_vm/translator_prover.cpp
+++ b/barretenberg/cpp/src/barretenberg/translator_vm/translator_prover.cpp
@@ -134,8 +134,14 @@ void TranslatorProver::execute_relation_check_rounds()
         gate_challenges[idx] = transcript->template get_challenge<FF>("Sumcheck:gate_challenge_" + std::to_string(idx));
     }
 
+    const size_t log_subgroup_size = static_cast<size_t>(numeric::get_msb(Flavor::Curve::SUBGROUP_SIZE));
+    // Create a temporary commitment key that is only used to initialise the ZKSumcheckData
+    // If proving in WASM, the commitment key that is part of the Translator proving key remains deallocated
+    //  until we enter the PCS round
+    auto ck = std::make_shared<CommitmentKey>(1 << (log_subgroup_size + 1));
+
     // // create masking polynomials for sumcheck round univariates and auxiliary data
-    zk_sumcheck_data = ZKData(key->proving_key->log_circuit_size, transcript, key->proving_key->commitment_key);
+    zk_sumcheck_data = ZKData(key->proving_key->log_circuit_size, transcript, ck);
 
     sumcheck_output =
         sumcheck.prove(key->proving_key->polynomials, relation_parameters, alpha, gate_challenges, zk_sumcheck_data);
@@ -154,11 +160,12 @@ void TranslatorProver::execute_pcs_rounds()
     using SmallSubgroupIPA = SmallSubgroupIPAProver<Flavor>;
     using PolynomialBatcher = GeminiProver_<Curve>::PolynomialBatcher;
 
-    SmallSubgroupIPA small_subgroup_ipa_prover(zk_sumcheck_data,
-                                               sumcheck_output.challenge,
-                                               sumcheck_output.claimed_libra_evaluation,
-                                               transcript,
-                                               key->proving_key->commitment_key);
+    // Check whether the commitment key has been deallocated and reinitialise it if necessary
+    auto& ck = key->proving_key->commitment_key;
+    ck = ck ? ck : std::make_shared<CommitmentKey>(key->proving_key->circuit_size);
+
+    SmallSubgroupIPA small_subgroup_ipa_prover(
+        zk_sumcheck_data, sumcheck_output.challenge, sumcheck_output.claimed_libra_evaluation, transcript, ck);
     small_subgroup_ipa_prover.prove();
 
     PolynomialBatcher polynomial_batcher(key->proving_key->circuit_size);
@@ -171,11 +178,11 @@ void TranslatorProver::execute_pcs_rounds()
         ShpleminiProver_<Curve>::prove(key->proving_key->circuit_size,
                                        polynomial_batcher,
                                        sumcheck_output.challenge,
-                                       key->proving_key->commitment_key,
+                                       ck,
                                        transcript,
                                        small_subgroup_ipa_prover.get_witness_polynomials());
 
-    PCS::compute_opening_proof(key->proving_key->commitment_key, prover_opening_claim, transcript);
+    PCS::compute_opening_proof(ck, prover_opening_claim, transcript);
 }
 
 HonkProof TranslatorProver::export_proof()
@@ -198,6 +205,11 @@ HonkProof TranslatorProver::construct_proof()
     // Compute grand product(s) and commitments.
     execute_grand_product_computation_round();
 
+    // #ifndef __wasm__
+    // Free the commitment key
+    key->proving_key->commitment_key = nullptr;
+    // #endif
+
     // Fiat-Shamir: alpha
     // Run sumcheck subprotocol.
     execute_relation_check_rounds();
@@ -206,6 +218,10 @@ HonkProof TranslatorProver::construct_proof()
     // Execute Shplemini PCS
     execute_pcs_rounds();
     vinfo("computed opening proof");
+    // #ifndef __wasm__
+    // Free the commitment key
+    key->proving_key->commitment_key = nullptr;
+    // #endif
 
     return export_proof();
 }

--- a/barretenberg/cpp/src/barretenberg/translator_vm/translator_proving_key.hpp
+++ b/barretenberg/cpp/src/barretenberg/translator_vm/translator_proving_key.hpp
@@ -3,7 +3,7 @@
 
 #include "barretenberg/translator_vm/translator_flavor.hpp"
 namespace bb {
-// WORKTODO: This class likely should not exist. Any reason not to use the ProvingKey in the flavor?
+// TODO(https://github.com/AztecProtocol/barretenberg/issues/1317)
 class TranslatorProvingKey {
   public:
     using Flavor = TranslatorFlavor;
@@ -24,13 +24,11 @@ class TranslatorProvingKey {
 
     TranslatorProvingKey() = default;
 
-    TranslatorProvingKey(size_t mini_circuit_dyadic_size)
-        : mini_circuit_dyadic_size(mini_circuit_dyadic_size)
-        , dyadic_circuit_size(mini_circuit_dyadic_size * Flavor::INTERLEAVING_GROUP_SIZE)
-        , proving_key(std::make_shared<ProvingKey>(dyadic_circuit_size))
-
+    TranslatorProvingKey(size_t actual_mini_circuit_size)
     {
-        proving_key->polynomials = Flavor::ProverPolynomials(mini_circuit_dyadic_size);
+        compute_mini_circuit_dyadic_size(actual_mini_circuit_size);
+        compute_dyadic_circuit_size();
+        proving_key = std::make_shared<ProvingKey>(dyadic_circuit_size, actual_mini_circuit_size);
     }
 
     TranslatorProvingKey(const Circuit& circuit, std::shared_ptr<CommitmentKey> commitment_key = nullptr)
@@ -41,16 +39,17 @@ class TranslatorProvingKey {
 
         // WORKTODO: the methods below just set the constant values TRANSLATOR_VM_FIXED_SIZE and
         // TRANSLATOR_VM_FIXED_SIZE * INTERLEAVING_GROUP_SIZE
-        compute_mini_circuit_dyadic_size(circuit);
+        compute_mini_circuit_dyadic_size(circuit.num_gates);
         compute_dyadic_circuit_size();
 
         proving_key = std::make_shared<ProvingKey>(
-            dyadic_circuit_size, std::move(commitment_key), /*actual_mini_circuit_size=*/circuit.num_gates);
+            dyadic_circuit_size, std::move(commitment_key), /*actual_mini_ circuit_size=*/circuit.num_gates);
 
         // Populate the wire polynomials from the wire vectors in the circuit
         for (auto [wire_poly_, wire_] : zip_view(proving_key->polynomials.get_wires(), circuit.wires)) {
             auto& wire_poly = wire_poly_;
             const auto& wire = wire_;
+            // WORKTODO: I think we should share memory here in the same way we do in the `DeciderProvingKey` class.
             parallel_for_range(circuit.num_gates, [&](size_t start, size_t end) {
                 for (size_t i = start; i < end; i++) {
                     if (i >= wire_poly.start_index() && i < wire_poly.end_index()) {
@@ -92,11 +91,11 @@ class TranslatorProvingKey {
         dyadic_circuit_size = mini_circuit_dyadic_size * Flavor::INTERLEAVING_GROUP_SIZE;
     }
 
-    inline void compute_mini_circuit_dyadic_size(const Circuit& circuit)
+    inline void compute_mini_circuit_dyadic_size(size_t num_gates)
     {
         // Check that the Translator Circuit does not exceed the fixed upper bound, the current value 8192 corresponds
         // to 10 rounds of folding (i.e. 20 circuits)
-        if (circuit.num_gates > Flavor::TRANSLATOR_VM_FIXED_SIZE) {
+        if (num_gates > Flavor::TRANSLATOR_VM_FIXED_SIZE) {
             throw_or_abort("The Translator circuit size has exceeded the fixed upper bound");
         }
         mini_circuit_dyadic_size = Flavor::TRANSLATOR_VM_FIXED_SIZE;

--- a/barretenberg/cpp/src/barretenberg/translator_vm/translator_proving_key.hpp
+++ b/barretenberg/cpp/src/barretenberg/translator_vm/translator_proving_key.hpp
@@ -3,6 +3,7 @@
 
 #include "barretenberg/translator_vm/translator_flavor.hpp"
 namespace bb {
+// WORKTODO: This class likely should not exist. Any reason not to use the ProvingKey in the flavor?
 class TranslatorProvingKey {
   public:
     using Flavor = TranslatorFlavor;
@@ -38,10 +39,13 @@ class TranslatorProvingKey {
     {
         PROFILE_THIS_NAME("TranslatorProvingKey(TranslatorCircuit&)");
 
+        // WORKTODO: the methods below just set the constant values TRANSLATOR_VM_FIXED_SIZE and
+        // TRANSLATOR_VM_FIXED_SIZE * INTERLEAVING_GROUP_SIZE
         compute_mini_circuit_dyadic_size(circuit);
         compute_dyadic_circuit_size();
-        proving_key = std::make_shared<ProvingKey>(dyadic_circuit_size, std::move(commitment_key));
-        proving_key->polynomials = Flavor::ProverPolynomials(mini_circuit_dyadic_size);
+
+        proving_key = std::make_shared<ProvingKey>(
+            dyadic_circuit_size, std::move(commitment_key), /*actual_mini_circuit_size=*/circuit.num_gates);
 
         // Populate the wire polynomials from the wire vectors in the circuit
         for (auto [wire_poly_, wire_] : zip_view(proving_key->polynomials.get_wires(), circuit.wires)) {


### PR DESCRIPTION
Doubles the Translator capacity to allow for 17 (mocked) kernel executions. ECCVM capacity currently blocks doing 18. This is recorded in tests. The tests are slower than I would like, but my attempts to use a smaller trace structure failed in a variety of ways.

To ensure Translator RAM costs doesn't blow up WASM we allocated and deallocated the commitment key as necessary and tweaked ProverPolynomials to only be initialised on the actual circuit size (this creates friction with ZK but will be handled in a follow-on). 
