### PR TITLE
chore: Cron snapshot upload in spartan

### DIFF
--- a/spartan/aztec-network/templates/_helpers.tpl
+++ b/spartan/aztec-network/templates/_helpers.tpl
@@ -80,6 +80,10 @@ http://{{ include "aztec-network.fullname" . }}-blob-sink.{{ .Release.Namespace 
 http://{{ include "aztec-network.fullname" . }}-metrics.{{ .Release.Namespace }}
 {{- end -}}
 
+{{- define "aztec-network.fullNodeAdminUrl" -}}
+http://{{ include "aztec-network.fullname" . }}-full-node-admin.{{ .Release.Namespace }}.svc.cluster.local:{{ .Values.fullNode.service.adminPort }}
+{{- end -}}
+
 {{- define "helpers.flag" -}}
 {{- $name := index . 0 -}}
 {{- $value := index . 1 -}}

--- a/spartan/aztec-network/templates/create-snapshot.yaml
+++ b/spartan/aztec-network/templates/create-snapshot.yaml
@@ -1,0 +1,33 @@
+{{- if and (.Values.snapshots.uploadLocation) (.Values.snapshots.frequency) (gt (int .Values.fullNode.replicas) 0) }}
+# Cronjob for creating and uploading database snapshots to a public location
+apiVersion: batch/v1
+kind: CronJob
+metadata:
+  name: {{ include "aztec-network.fullname" . }}-upload-snapshots-cron-job
+  labels:
+    {{- include "aztec-network.labels" . | nindent 4 }}
+spec:
+  schedule: "{{ .Values.snapshots.frequency }}"
+  jobTemplate:
+    spec:
+      template:
+        metadata:
+          labels:
+            {{- include "aztec-network.selectorLabels" . | nindent 12 }}
+            app: request-upload-snapshot
+        spec:
+          restartPolicy: Never
+          {{- if .Values.network.public }}
+          serviceAccountName: {{ include "aztec-network.fullname" . }}-node
+          {{- end }}
+          containers:
+            - name: request-upload-snapshot
+              image: {{ .Values.images.curl.image }}
+              command:
+                - /bin/sh
+                - -c
+                - |
+                  set -ex
+                  echo "Starting snapshot upload to {{ .Values.snapshots.uploadLocation }} via {{ include "aztec-network.fullNodeAdminUrl" . }}"
+                  curl -XPOST {{ include "aztec-network.fullNodeAdminUrl" . }} -d '{"method": "nodeAdmin_startSnapshotUpload", "params": ["{{ .Values.snapshots.uploadLocation }}"], "id": 1, "jsonrpc": "2.0"}' -H 'Content-Type: application/json'
+{{- end }}

--- a/spartan/aztec-network/templates/full-node.yaml
+++ b/spartan/aztec-network/templates/full-node.yaml
@@ -241,6 +241,7 @@ spec:
   selector:
     {{- include "aztec-network.selectorLabels" . | nindent 4 }}
     app: full-node
+  # The admin port is restricted from public access thanks to terraform/gke-cluster/firewall.tf
   ports:
     - port: {{ .Values.fullNode.service.adminPort }}
       targetPort: {{ .Values.fullNode.service.adminPort }}

--- a/spartan/aztec-network/templates/full-node.yaml
+++ b/spartan/aztec-network/templates/full-node.yaml
@@ -102,6 +102,8 @@ spec:
               value: "--max-old-space-size={{ .Values.fullNode.maxOldSpaceSize}}"
             - name: AZTEC_PORT
               value: "{{ .Values.fullNode.service.nodePort }}"
+            - name: AZTEC_ADMIN_PORT
+              value: "{{ .Values.fullNode.service.adminPort }}"
             - name: LOG_LEVEL
               value: "{{ .Values.fullNode.logLevel }}"
             - name: LOG_JSON
@@ -156,12 +158,15 @@ spec:
               value: "{{ .Values.aztec.testAccounts }}"
             - name: SPONSORED_FPC
               value: "{{ .Values.aztec.sponsoredFPC }}"
+            - name: SYNC_SNAPSHOTS_URL
+              value: "{{ .Values.snapshots.syncUrl }}"
             {{- if .Values.blobSink.enabled }}
             - name: BLOB_SINK_URL
               value: {{ include "aztec-network.blobSinkUrl" . }}
             {{- end }}
           ports:
             - containerPort: {{ .Values.fullNode.service.nodePort }}
+            - containerPort: {{ .Values.fullNode.service.adminPort }}
             - containerPort: {{ .Values.fullNode.service.p2pPort }}
             - containerPort: {{ .Values.fullNode.service.p2pPort }}
               protocol: UDP
@@ -222,6 +227,24 @@ spec:
     {{- end }}
     - port: {{ .Values.fullNode.service.nodePort }}
       name: node
+---
+# Internal service for accessing the admin port
+apiVersion: v1
+kind: Service
+metadata:
+  name: {{ include "aztec-network.fullname" . }}-full-node-admin
+  labels:
+    {{- include "aztec-network.labels" . | nindent 4 }}
+    app: full-node
+spec:
+  type: ClusterIP
+  selector:
+    {{- include "aztec-network.selectorLabels" . | nindent 4 }}
+    app: full-node
+  ports:
+    - port: {{ .Values.fullNode.service.adminPort }}
+      targetPort: {{ .Values.fullNode.service.adminPort }}
+      name: admin
 ---
 {{- if hasKey .Values.fullNode "fixedExternalIP" }}
 apiVersion: networking.gke.io/v1beta2

--- a/spartan/aztec-network/templates/prover-node.yaml
+++ b/spartan/aztec-network/templates/prover-node.yaml
@@ -242,6 +242,8 @@ spec:
             {{- end }}
             - name: P2P_BOOTSTRAP_NODES_AS_FULL_PEERS
               value: "{{ .Values.network.p2pBootstrapNodesAsFullPeers }}"
+            - name: SYNC_SNAPSHOTS_URL
+              value: "{{ .Values.snapshots.syncUrl }}"
           ports:
             - containerPort: {{ .Values.proverNode.service.nodePort }}
             - containerPort: {{ .Values.proverNode.service.p2pPort }}

--- a/spartan/aztec-network/templates/validator.yaml
+++ b/spartan/aztec-network/templates/validator.yaml
@@ -191,6 +191,8 @@ spec:
               value: "{{ .Values.aztec.sponsoredFPC }}"
             - name: P2P_BOOTSTRAP_NODES_AS_FULL_PEERS
               value: "{{ .Values.network.p2pBootstrapNodesAsFullPeers }}"
+            - name: SYNC_SNAPSHOTS_URL
+              value: "{{ .Values.snapshots.syncUrl }}"
             {{- if .Values.blobSink.enabled }}
             - name: BLOB_SINK_URL
               value: {{ include "aztec-network.blobSinkUrl" . }}

--- a/spartan/aztec-network/values.yaml
+++ b/spartan/aztec-network/values.yaml
@@ -30,9 +30,9 @@ telemetry:
   excludeMetrics: ""
 
 snapshots:
-  uploadLocation: "gs://aztec-testnet/snapshots/"
-  syncUrl: "https://storage.googleapis.com/aztec-testnet/snapshots/"
-  frequency: "" # Disable uploads by default
+  uploadLocation:
+  syncUrl:
+  frequency:
 
 images:
   aztec:

--- a/spartan/aztec-network/values.yaml
+++ b/spartan/aztec-network/values.yaml
@@ -29,6 +29,11 @@ telemetry:
   useGcloudLogging: true
   excludeMetrics: ""
 
+snapshots:
+  uploadLocation: "gs://aztec-testnet/snapshots/"
+  syncUrl: "https://storage.googleapis.com/aztec-testnet/snapshots/"
+  frequency: "" # Disable uploads by default
+
 images:
   aztec:
     image: aztecprotocol/aztec
@@ -116,6 +121,7 @@ fullNode:
   service:
     p2pPort: 40400
     nodePort: 8080
+    adminPort: 8880
   logLevel: "debug; info: aztec:simulator, json-rpc"
   p2p:
     enabled: "true"

--- a/spartan/aztec-network/values/alpha-testnet.yaml
+++ b/spartan/aztec-network/values/alpha-testnet.yaml
@@ -2,6 +2,8 @@ telemetry:
   enabled: true
 
 snapshots:
+  uploadLocation: "gs://aztec-testnet/snapshots/"
+  syncUrl: "https://storage.googleapis.com/aztec-testnet/snapshots/"
   frequency: "0 0 * * *" # daily uploads at midnight
 
 aztec:

--- a/spartan/aztec-network/values/alpha-testnet.yaml
+++ b/spartan/aztec-network/values/alpha-testnet.yaml
@@ -1,6 +1,9 @@
 telemetry:
   enabled: true
 
+snapshots:
+  frequency: "0 0 * * *" # daily uploads at midnight
+
 aztec:
   realProofs: true
   numberOfDefaultAccounts: 0

--- a/yarn-project/aztec/src/cli/chain_l2_config.ts
+++ b/yarn-project/aztec/src/cli/chain_l2_config.ts
@@ -20,6 +20,7 @@ export type L2ChainConfig = {
   seqMinTxsPerBlock: number;
   seqMaxTxsPerBlock: number;
   realProofs: boolean;
+  snapshotsUrl: string;
 };
 
 export const testnetIgnitionL2ChainConfig: L2ChainConfig = {
@@ -38,6 +39,7 @@ export const testnetIgnitionL2ChainConfig: L2ChainConfig = {
   seqMinTxsPerBlock: 0,
   seqMaxTxsPerBlock: 0,
   realProofs: true,
+  snapshotsUrl: 'https://storage.googleapis.com/aztec-testnet/snapshots/',
 };
 
 export const alphaTestnetL2ChainConfig: L2ChainConfig = {
@@ -56,6 +58,7 @@ export const alphaTestnetL2ChainConfig: L2ChainConfig = {
   seqMinTxsPerBlock: 0,
   seqMaxTxsPerBlock: 4,
   realProofs: true,
+  snapshotsUrl: 'https://storage.googleapis.com/aztec-testnet/snapshots/',
 };
 
 export async function getBootnodes(networkName: NetworkNames) {
@@ -114,4 +117,5 @@ export async function enrichEnvironmentWithChainConfig(networkName: NetworkNames
   enrichVar('DATA_DIRECTORY', path.join(process.env.HOME || '~', '.aztec', networkName, 'data'));
   enrichVar('PROVER_REAL_PROOFS', config.realProofs.toString());
   enrichVar('PXE_PROVER_ENABLED', config.realProofs.toString());
+  enrichVar('SYNC_SNAPSHOTS_URL', config.snapshotsUrl);
 }


### PR DESCRIPTION
Adds a cronjob to the spartan templates that curls the full node and instructs it to start a snapshot upload to a gcs bucket. The admin api is exposed via a new service defined on the full node, which should not get exposed to the outside world based on the firewall rules we have defined in terraform.
