### PR TITLE
fix: boolean config helper for cli args works now

### DIFF
--- a/yarn-project/aztec/src/cli/aztec_start_options.ts
+++ b/yarn-project/aztec/src/cli/aztec_start_options.ts
@@ -83,13 +83,13 @@ export const aztecStartOptions: { [key: string]: AztecStartOption[] } = {
       envVar: undefined,
     },
     {
-      flag: '--sandbox.testAccounts',
+      flag: '--sandbox.testAccounts [value]',
       description: 'Deploy test accounts on sandbox start',
       envVar: 'TEST_ACCOUNTS',
-      ...booleanConfigHelper(true),
+      ...booleanConfigHelper(),
     },
     {
-      flag: '--sandbox.noPXE',
+      flag: '--sandbox.noPXE [value]',
       description: 'Do not expose PXE service on sandbox start',
       envVar: 'NO_PXE',
       ...booleanConfigHelper(),
@@ -268,7 +268,7 @@ export const aztecStartOptions: { [key: string]: AztecStartOption[] } = {
       parseVal: val => parseInt(val, 10),
     },
     {
-      flag: '--node.testAccounts',
+      flag: '--node.testAccounts [value]',
       description: 'Populate genesis state with initial fee juice for test accounts',
       envVar: 'TEST_ACCOUNTS',
       ...booleanConfigHelper(),
@@ -289,7 +289,7 @@ export const aztecStartOptions: { [key: string]: AztecStartOption[] } = {
   ],
   'P2P SUBSYSTEM': [
     {
-      flag: '--p2p-enabled',
+      flag: '--p2p-enabled [value]',
       description: 'Enable P2P subsystem',
       envVar: 'P2P_ENABLED',
       ...booleanConfigHelper(),

--- a/yarn-project/aztec/src/sandbox/sandbox.ts
+++ b/yarn-project/aztec/src/sandbox/sandbox.ts
@@ -118,10 +118,11 @@ export async function createSandbox(config: Partial<SandboxConfig> = {}, userLog
   }
 
   const initialAccounts = await (async () => {
-    if (config.testAccounts) {
+    if (config.testAccounts === true || config.testAccounts === undefined) {
       if (aztecNodeConfig.p2pEnabled) {
         userLog(`Not setting up test accounts as we are connecting to a network`);
       } else {
+        userLog(`Setting up test accounts`);
         return await getInitialTestAccounts();
       }
     }


### PR DESCRIPTION
Using `booleanConfigHelper` without `[value]` in the commander flag was resulting in all our boolean cli args either using the default (if no value was provided), or to `false`, because the "value" supplied to the `parse` function was always `undefined`.

This resuled in, e.g. passing `--p2p-enabled` being interpreted as false.

Now the expected behavior reigns: `--p2p-enabled` and `--p2p-enabled=true` and `--p2p-enabled true` all result in the flag being `true`, but `--p2p-enabled=false` and `--p2p-enabled false` result in the flag being `false`.

In the `testAccounts` case, since it was defined as `true` by default for the sandbox, it was picking up that value when parsing for the node, so no matter what it was true.
