### PR TITLE
fix: load two more points

### DIFF
--- a/yarn-project/aztec/src/cli/util.ts
+++ b/yarn-project/aztec/src/cli/util.ts
@@ -243,6 +243,6 @@ export async function preloadCrsDataForServerSideProving(
 ): Promise<void> {
   if (realProofs) {
     const { Crs, GrumpkinCrs } = await import('@aztec/bb.js');
-    await Promise.all([Crs.new(2 ** 25 - 1, undefined, log), GrumpkinCrs.new(2 ** 18 + 1, undefined, log)]);
+    await Promise.all([Crs.new(2 ** 25 + 1, undefined, log), GrumpkinCrs.new(2 ** 18 + 1, undefined, log)]);
   }
 }


### PR DESCRIPTION
@PhilWindle noticed that the prover agents had to download the CRS again in order to prove a root rollup. Looking at the files it seems they needed two more points added to the initial preload (this is possible now that the files are streamed, see #12996)
