### PR TITLE
fix: prerelease alpha testnet versions should get updated

### DIFF
--- a/aztec-up/bootstrap.sh
+++ b/aztec-up/bootstrap.sh
@@ -40,12 +40,12 @@ function release {
   # Read the current version from S3.
   local current_version=$(aws s3 cp s3://install.aztec.network/VERSION - 2>/dev/null || echo "0.0.0")
 
-  if [ $(dist_tag) != latest ]; then
+  # Temporary: while alpha-testnet is the main release, include it (later it should only push to $version)
+  if [[ $(dist_tag) != "latest" && $(dist_tag) != "alpha-testnet" ]]; then
     echo_stderr -e "${yellow}Not uploading aztec-up scripts for dist-tag $(dist_tag). They are expected to still be compatible with latest."
     return
   fi
 
-  # Check if new version is greater than current version.
   if [ $(semver sort "$version" "$current_version" | tail -1) == "$version" ]; then
     echo "Uploading new version: $version"
 
@@ -59,7 +59,7 @@ function release {
   fi
 
   # Always create a version directory and upload files there.
-  do_or_dryrun aws s3 sync ./bin s3://install.aztec.network/$version/
+  do_or_dryrun aws s3 sync ./bin "s3://install.aztec.network/$version/"
 }
 
 case "$cmd" in


### PR DESCRIPTION
This was merged to master but should be in alpha testnet as the release uses this branches bootstrap (i'm simply syncing this file to make future merges easier)