### PR TITLE
perf: replace string interpolation with pino substitution in TXE

### DIFF
--- a/yarn-project/txe/src/bin/index.ts
+++ b/yarn-project/txe/src/bin/index.ts
@@ -21,7 +21,7 @@ async function main() {
   });
 
   const logger = createLogger('txe:service');
-  logger.info(`Setting up TXE...`);
+  logger.info('Setting up TXE...');
 
   const txeServer = createTXERpcServer(logger);
   const { port } = await startHttpRpcServer(txeServer, {
@@ -30,7 +30,7 @@ async function main() {
     timeoutMs: 1e3 * 60 * 5,
   });
 
-  logger.info(`TXE listening on port ${port}`);
+  logger.info('TXE listening on port %s', port);
 }
 
 main().catch(err => {

--- a/yarn-project/txe/src/index.ts
+++ b/yarn-project/txe/src/index.ts
@@ -65,7 +65,7 @@ class TXEDispatcher {
 
   constructor(private logger: Logger) {}
 
-  async #processDeployInputs({ inputs, root_path: rootPath, package_name: packageName }: TXEForeignCallInput) {
+  private async processDeployInputs({ inputs, root_path: rootPath, package_name: packageName }: TXEForeignCallInput) {
     const [pathStr, contractName, initializer] = inputs.slice(0, 3).map(input =>
       fromArray(input as ForeignCallArray)
         .map(char => String.fromCharCode(char.toNumber()))
@@ -85,7 +85,7 @@ class TXEDispatcher {
     let instance;
 
     if (TXEArtifactsCache.has(cacheKey)) {
-      this.logger.debug({ cacheKey }, 'Using cached artifact');
+      this.logger.debug('Using cached artifact for %s', cacheKey);
       ({ artifact, instance } = TXEArtifactsCache.get(cacheKey)!);
     } else {
       let artifactPath = '';
@@ -99,26 +99,24 @@ class TXEDispatcher {
         if (pathStr.includes('@')) {
           const [workspace, pkg] = pathStr.split('@');
           const targetPath = join(rootPath, workspace, './target');
-          this.logger.debug({ targetPath }, 'Looking for compiled artifact in workspace');
+          this.logger.debug('Looking for compiled artifact in workspace %s', targetPath);
           artifactPath = join(targetPath, `${pkg}-${contractName}.json`);
         } else {
           // We're deploying a standalone contract
           // env.deploy("../path/to/contract/root", "contractName")
           const targetPath = join(rootPath, pathStr, './target');
-          this.logger.debug({ targetPath }, 'Looking for compiled artifact');
-          [artifactPath] = (await readdir(targetPath)).filter(file => file.endsWith(`-${contractName}.json`));
+          this.logger.debug('Looking for compiled artifact in %s', targetPath);
+          [artifactPath] = (await readdir(targetPath)).filter((file: string) => file.endsWith(`-${contractName}.json`));
         }
       }
-      this.logger.debug({ artifactPath }, 'Loading compiled artifact');
+      this.logger.debug('Loading compiled artifact %s', artifactPath);
       artifact = loadContractArtifact(JSON.parse(await readFile(artifactPath, 'utf-8')));
       this.logger.debug(
-        {
-          name: artifact.name,
-          initializer,
-          args: decodedArgs.map(arg => arg.toString()).join('-'),
-          publicKeysHash: publicKeysHash.toString()
-        },
-        'Deploy contract'
+        'Deploy %s with initializer %s(%s) and public keys hash %s',
+        artifact.name,
+        initializer,
+        decodedArgs.map(arg => arg.toString()).join('-'),
+        publicKeysHash.toString()
       );
       instance = await getContractInstanceFromDeployParams(artifact, {
         constructorArgs: decodedArgs,
@@ -134,7 +132,7 @@ class TXEDispatcher {
     inputs.splice(0, 2, artifact, instance, toSingle(secret));
   }
 
-  async #processAddAccountInputs({ inputs }: TXEForeignCallInput) {
+  private async processAddAccountInputs({ inputs }: TXEForeignCallInput) {
     const secret = fromSingle(inputs[0] as ForeignCallSingle);
 
     const cacheKey = `SchnorrAccountContract-${secret}`;
@@ -143,7 +141,7 @@ class TXEDispatcher {
     let instance;
 
     if (TXEArtifactsCache.has(cacheKey)) {
-      this.logger.debug({ cacheKey }, 'Using cached artifact');
+      this.logger.debug('Using cached artifact for %s', cacheKey);
       ({ artifact, instance } = TXEArtifactsCache.get(cacheKey)!);
     } else {
       const keys = await deriveKeys(secret);
@@ -166,13 +164,13 @@ class TXEDispatcher {
   // eslint-disable-next-line camelcase
   async resolve_foreign_call(callData: TXEForeignCallInput): Promise<ForeignCallResult> {
     const { session_id: sessionId, function: functionName, inputs } = callData;
-    this.logger.debug({ functionName, sessionId }, 'Calling function on session');
+    this.logger.debug('Calling %s on session %s', functionName, sessionId);
 
     if (!TXESessions.has(sessionId) && functionName != 'reset') {
-      this.logger.debug({ sessionId }, 'Creating new session');
+      this.logger.debug('Creating new session %s', sessionId);
       if (!this.protocolContracts) {
         this.protocolContracts = await Promise.all(
-          protocolContractNames.map(name => new BundledProtocolContractsProvider().getProtocolContractArtifact(name)),
+          protocolContractNames.map((name: string) => new BundledProtocolContractsProvider().getProtocolContractArtifact(name)),
         );
       }
       TXESessions.set(sessionId, await TXEService.init(this.logger, this.protocolContracts));
@@ -181,15 +179,15 @@ class TXEDispatcher {
     switch (functionName) {
       case 'reset': {
         TXESessions.delete(sessionId) &&
-          this.logger.debug({ sessionId }, 'Called reset on session, yeeting it out of existence');
+          this.logger.debug('Called reset on session %s, yeeting it out of existence', sessionId);
         return toForeignCallResult([]);
       }
       case 'deploy': {
-        await this.#processDeployInputs(callData);
+        await this.processDeployInputs(callData);
         break;
       }
       case 'addAccount': {
-        await this.#processAddAccountInputs(callData);
+        await this.processAddAccountInputs(callData);
         break;
       }
     }

--- a/yarn-project/txe/src/index.ts
+++ b/yarn-project/txe/src/index.ts
@@ -65,7 +65,7 @@ class TXEDispatcher {
 
   constructor(private logger: Logger) {}
 
-  async №processDeployInputs({ inputs, root_path: rootPath, package_name: packageName }: TXEForeignCallInput) {
+  async #processDeployInputs({ inputs, root_path: rootPath, package_name: packageName }: TXEForeignCallInput) {
     const [pathStr, contractName, initializer] = inputs.slice(0, 3).map(input =>
       fromArray(input as ForeignCallArray)
         .map(char => String.fromCharCode(char.toNumber()))

--- a/yarn-project/txe/src/index.ts
+++ b/yarn-project/txe/src/index.ts
@@ -85,7 +85,7 @@ class TXEDispatcher {
     let instance;
 
     if (TXEArtifactsCache.has(cacheKey)) {
-      this.logger.debug('Using cached artifact for %s', cacheKey);
+      this.logger.debug({ cacheKey }, 'Using cached artifact');
       ({ artifact, instance } = TXEArtifactsCache.get(cacheKey)!);
     } else {
       let artifactPath = '';
@@ -99,24 +99,26 @@ class TXEDispatcher {
         if (pathStr.includes('@')) {
           const [workspace, pkg] = pathStr.split('@');
           const targetPath = join(rootPath, workspace, './target');
-          this.logger.debug('Looking for compiled artifact in workspace %s', targetPath);
+          this.logger.debug({ targetPath }, 'Looking for compiled artifact in workspace');
           artifactPath = join(targetPath, `${pkg}-${contractName}.json`);
         } else {
           // We're deploying a standalone contract
           // env.deploy("../path/to/contract/root", "contractName")
           const targetPath = join(rootPath, pathStr, './target');
-          this.logger.debug('Looking for compiled artifact in %s', targetPath);
+          this.logger.debug({ targetPath }, 'Looking for compiled artifact');
           [artifactPath] = (await readdir(targetPath)).filter(file => file.endsWith(`-${contractName}.json`));
         }
       }
-      this.logger.debug('Loading compiled artifact %s', artifactPath);
+      this.logger.debug({ artifactPath }, 'Loading compiled artifact');
       artifact = loadContractArtifact(JSON.parse(await readFile(artifactPath, 'utf-8')));
       this.logger.debug(
-        'Deploy %s with initializer %s(%s) and public keys hash %s',
-        artifact.name,
-        initializer,
-        decodedArgs.map(arg => arg.toString()).join('-'),
-        publicKeysHash.toString(),
+        {
+          name: artifact.name,
+          initializer,
+          args: decodedArgs.map(arg => arg.toString()).join('-'),
+          publicKeysHash: publicKeysHash.toString()
+        },
+        'Deploy contract'
       );
       instance = await getContractInstanceFromDeployParams(artifact, {
         constructorArgs: decodedArgs,
@@ -141,7 +143,7 @@ class TXEDispatcher {
     let instance;
 
     if (TXEArtifactsCache.has(cacheKey)) {
-      this.logger.debug(`Using cached artifact for ${cacheKey}`);
+      this.logger.debug({ cacheKey }, 'Using cached artifact');
       ({ artifact, instance } = TXEArtifactsCache.get(cacheKey)!);
     } else {
       const keys = await deriveKeys(secret);
@@ -164,10 +166,10 @@ class TXEDispatcher {
   // eslint-disable-next-line camelcase
   async resolve_foreign_call(callData: TXEForeignCallInput): Promise<ForeignCallResult> {
     const { session_id: sessionId, function: functionName, inputs } = callData;
-    this.logger.debug('Calling %s on session %s', functionName, sessionId);
+    this.logger.debug({ functionName, sessionId }, 'Calling function on session');
 
     if (!TXESessions.has(sessionId) && functionName != 'reset') {
-      this.logger.debug('Creating new session %s', sessionId);
+      this.logger.debug({ sessionId }, 'Creating new session');
       if (!this.protocolContracts) {
         this.protocolContracts = await Promise.all(
           protocolContractNames.map(name => new BundledProtocolContractsProvider().getProtocolContractArtifact(name)),
@@ -179,7 +181,7 @@ class TXEDispatcher {
     switch (functionName) {
       case 'reset': {
         TXESessions.delete(sessionId) &&
-          this.logger.debug('Called reset on session %s, yeeting it out of existence', sessionId);
+          this.logger.debug({ sessionId }, 'Called reset on session, yeeting it out of existence');
         return toForeignCallResult([]);
       }
       case 'deploy': {

--- a/yarn-project/txe/src/index.ts
+++ b/yarn-project/txe/src/index.ts
@@ -85,7 +85,7 @@ class TXEDispatcher {
     let instance;
 
     if (TXEArtifactsCache.has(cacheKey)) {
-      this.logger.debug(`Using cached artifact for ${cacheKey}`);
+      this.logger.debug('Using cached artifact for %s', cacheKey);
       ({ artifact, instance } = TXEArtifactsCache.get(cacheKey)!);
     } else {
       let artifactPath = '';
@@ -99,22 +99,24 @@ class TXEDispatcher {
         if (pathStr.includes('@')) {
           const [workspace, pkg] = pathStr.split('@');
           const targetPath = join(rootPath, workspace, './target');
-          this.logger.debug(`Looking for compiled artifact in workspace ${targetPath}`);
+          this.logger.debug('Looking for compiled artifact in workspace %s', targetPath);
           artifactPath = join(targetPath, `${pkg}-${contractName}.json`);
         } else {
           // We're deploying a standalone contract
           // env.deploy("../path/to/contract/root", "contractName")
           const targetPath = join(rootPath, pathStr, './target');
-          this.logger.debug(`Looking for compiled artifact in ${targetPath}`);
+          this.logger.debug('Looking for compiled artifact in %s', targetPath);
           [artifactPath] = (await readdir(targetPath)).filter(file => file.endsWith(`-${contractName}.json`));
         }
       }
-      this.logger.debug(`Loading compiled artifact ${artifactPath}`);
+      this.logger.debug('Loading compiled artifact %s', artifactPath);
       artifact = loadContractArtifact(JSON.parse(await readFile(artifactPath, 'utf-8')));
       this.logger.debug(
-        `Deploy ${
-          artifact.name
-        } with initializer ${initializer}(${decodedArgs}) and public keys hash ${publicKeysHash.toString()}`,
+        'Deploy %s with initializer %s(%s) and public keys hash %s',
+        artifact.name,
+        initializer,
+        decodedArgs.map(arg => arg.toString()).join('-'),
+        publicKeysHash.toString(),
       );
       instance = await getContractInstanceFromDeployParams(artifact, {
         constructorArgs: decodedArgs,
@@ -162,10 +164,10 @@ class TXEDispatcher {
   // eslint-disable-next-line camelcase
   async resolve_foreign_call(callData: TXEForeignCallInput): Promise<ForeignCallResult> {
     const { session_id: sessionId, function: functionName, inputs } = callData;
-    this.logger.debug(`Calling ${functionName} on session ${sessionId}`);
+    this.logger.debug('Calling %s on session %s', functionName, sessionId);
 
     if (!TXESessions.has(sessionId) && functionName != 'reset') {
-      this.logger.debug(`Creating new session ${sessionId}`);
+      this.logger.debug('Creating new session %s', sessionId);
       if (!this.protocolContracts) {
         this.protocolContracts = await Promise.all(
           protocolContractNames.map(name => new BundledProtocolContractsProvider().getProtocolContractArtifact(name)),
@@ -177,7 +179,7 @@ class TXEDispatcher {
     switch (functionName) {
       case 'reset': {
         TXESessions.delete(sessionId) &&
-          this.logger.debug(`Called reset on session ${sessionId}, yeeting it out of existence`);
+          this.logger.debug('Called reset on session %s, yeeting it out of existence', sessionId);
         return toForeignCallResult([]);
       }
       case 'deploy': {

--- a/yarn-project/txe/src/node/txe_node.ts
+++ b/yarn-project/txe/src/node/txe_node.ts
@@ -137,7 +137,7 @@ export class TXENode implements AztecNode {
   addPrivateLogsByTags(blockNumber: number, privateLogs: PrivateLog[]) {
     privateLogs.forEach(log => {
       const tag = log.fields[0];
-      this.#logger.verbose(`Found private log with tag ${tag.toString()} in block ${this.getBlockNumber()}`);
+      this.#logger.verbose('Found private log with tag %s in block %s', tag.toString(), this.getBlockNumber());
 
       const currentLogs = this.#logsByTags.get(tag.toString()) ?? [];
       const scopedLog = new TxScopedL2Log(new TxHash(new Fr(blockNumber)), this.#noteIndex, blockNumber, log);
@@ -156,7 +156,7 @@ export class TXENode implements AztecNode {
   addPublicLogsByTags(blockNumber: number, publicLogs: PublicLog[]) {
     publicLogs.forEach(log => {
       const tag = log.log[0];
-      this.#logger.verbose(`Found public log with tag ${tag.toString()} in block ${this.getBlockNumber()}`);
+      this.#logger.verbose('Found public log with tag %s in block %s', tag.toString(), this.getBlockNumber());
 
       const currentLogs = this.#logsByTags.get(tag.toString()) ?? [];
       const scopedLog = new TxScopedL2Log(new TxHash(new Fr(blockNumber)), this.#noteIndex, blockNumber, log);

--- a/yarn-project/txe/src/txe_service/txe_service.ts
+++ b/yarn-project/txe/src/txe_service/txe_service.ts
@@ -53,7 +53,7 @@ export class TXEService {
 
   async advanceBlocksBy(blocks: ForeignCallSingle) {
     const nBlocks = fromSingle(blocks).toNumber();
-    this.logger.debug('time traveling %s blocks', nBlocks);
+    this.logger.debug({ blocks: nBlocks }, 'Time traveling blocks');
 
     for (let i = 0; i < nBlocks; i++) {
       const blockNumber = await this.typedOracle.getBlockNumber();
@@ -85,7 +85,7 @@ export class TXEService {
     } else {
       await (this.typedOracle as TXE).addContractInstance(instance);
       await (this.typedOracle as TXE).addContractArtifact(instance.currentContractClassId, artifact);
-      this.logger.debug('Deployed %s at %s', artifact.name, instance.address);
+      this.logger.debug({ name: artifact.name, address: instance.address.toString() }, 'Deployed contract');
     }
 
     return toForeignCallResult([
@@ -111,14 +111,14 @@ export class TXEService {
     const publicDataWrites = await Promise.all(
       valuesFr.map(async (value, i) => {
         const storageSlot = startStorageSlotFr.add(new Fr(i));
-        this.logger.debug('Oracle storage write: slot=%s value=%s', storageSlot.toString(), value);
+        this.logger.debug({ slot: storageSlot.toString(), value: value.toString() }, 'Oracle storage write');
         return new PublicDataWrite(await computePublicDataTreeLeafSlot(contractAddressFr, storageSlot), value);
       }),
     );
 
     await (this.typedOracle as TXE).addPublicDataWrites(publicDataWrites);
 
-    return toForeignCallResult([toArray(publicDataWrites.map((write: PublicDataWrite) => write.value))]);
+    return toForeignCallResult([toArray(publicDataWrites.map(write => write.value))]);
   }
 
   async createAccount(secret: ForeignCallSingle) {
@@ -130,7 +130,7 @@ export class TXEService {
     await accountDataProvider.setAccount(completeAddress.address, completeAddress);
     const addressDataProvider = (this.typedOracle as TXE).getAddressDataProvider();
     await addressDataProvider.addCompleteAddress(completeAddress);
-    this.logger.debug('Created account %s', completeAddress.address);
+    this.logger.debug({ address: completeAddress.address.toString() }, 'Created account');
     return toForeignCallResult([
       toSingle(completeAddress.address),
       ...completeAddress.publicKeys.toFields().map(toSingle),
@@ -138,7 +138,7 @@ export class TXEService {
   }
 
   async addAccount(artifact: ContractArtifact, instance: ContractInstanceWithAddress, secret: ForeignCallSingle) {
-    this.logger.debug('Deployed %s at %s', artifact.name, instance.address);
+    this.logger.debug({ name: artifact.name, address: instance.address.toString() }, 'Deployed contract');
     await (this.typedOracle as TXE).addContractInstance(instance);
     await (this.typedOracle as TXE).addContractArtifact(instance.currentContractClassId, artifact);
 
@@ -148,7 +148,7 @@ export class TXEService {
     await accountDataProvider.setAccount(completeAddress.address, completeAddress);
     const addressDataProvider = (this.typedOracle as TXE).getAddressDataProvider();
     await addressDataProvider.addCompleteAddress(completeAddress);
-    this.logger.debug('Created account %s', completeAddress.address);
+    this.logger.debug({ address: completeAddress.address.toString() }, 'Created account');
     return toForeignCallResult([
       toSingle(completeAddress.address),
       ...completeAddress.publicKeys.toFields().map(toSingle),
@@ -308,7 +308,7 @@ export class TXEService {
       fromSingle(status).toNumber(),
     );
     const noteLength = noteDatas?.[0]?.note.items.length ?? 0;
-    if (!noteDatas.every(({ note }: { note: { items: unknown[] } }) => noteLength === note.items.length)) {
+    if (!noteDatas.every(({ note }) => noteLength === note.items.length)) {
       throw new Error('Notes should all be the same length.');
     }
 
@@ -319,7 +319,7 @@ export class TXEService {
       isSettled: new Fr(0),
       isTransient: new Fr(1),
     };
-    const flattenData = noteDatas.flatMap(({ nonce, note, index }: { nonce: Fr; note: { items: Fr[] }; index?: number }) => [
+    const flattenData = noteDatas.flatMap(({ nonce, note, index }) => [
       nonce,
       index === undefined ? noteTypes.isTransient : noteTypes.isSettled,
       ...note.items,

--- a/yarn-project/txe/src/txe_service/txe_service.ts
+++ b/yarn-project/txe/src/txe_service/txe_service.ts
@@ -513,7 +513,7 @@ export class TXEService {
       AztecAddress.fromField(fromSingle(sender)),
       AztecAddress.fromField(fromSingle(recipient)),
     );
-    return toForeignCallResult([toArray(secret.toFields())]);
+    return toForeignCallResult(secret.toFields().map(toSingle));
   }
 
   async syncNotes() {

--- a/yarn-project/txe/src/txe_service/txe_service.ts
+++ b/yarn-project/txe/src/txe_service/txe_service.ts
@@ -36,7 +36,7 @@ export class TXEService {
   constructor(private logger: Logger, private typedOracle: TypedOracle) {}
 
   static async init(logger: Logger, protocolContracts: ProtocolContract[]) {
-    logger.debug(`TXE service initialized`);
+    logger.debug('TXE service initialized');
     const store = await openTmpStore('test');
     const txe = await TXE.create(logger, store, protocolContracts);
     const service = new TXEService(logger, txe);
@@ -53,7 +53,7 @@ export class TXEService {
 
   async advanceBlocksBy(blocks: ForeignCallSingle) {
     const nBlocks = fromSingle(blocks).toNumber();
-    this.logger.debug(`time traveling ${nBlocks} blocks`);
+    this.logger.debug('time traveling %s blocks', nBlocks);
 
     for (let i = 0; i < nBlocks; i++) {
       const blockNumber = await this.typedOracle.getBlockNumber();
@@ -85,7 +85,7 @@ export class TXEService {
     } else {
       await (this.typedOracle as TXE).addContractInstance(instance);
       await (this.typedOracle as TXE).addContractArtifact(instance.currentContractClassId, artifact);
-      this.logger.debug(`Deployed ${artifact.name} at ${instance.address}`);
+      this.logger.debug('Deployed %s at %s', artifact.name, instance.address);
     }
 
     return toForeignCallResult([
@@ -111,7 +111,7 @@ export class TXEService {
     const publicDataWrites = await Promise.all(
       valuesFr.map(async (value, i) => {
         const storageSlot = startStorageSlotFr.add(new Fr(i));
-        this.logger.debug(`Oracle storage write: slot=${storageSlot.toString()} value=${value}`);
+        this.logger.debug('Oracle storage write: slot=%s value=%s', storageSlot.toString(), value);
         return new PublicDataWrite(await computePublicDataTreeLeafSlot(contractAddressFr, storageSlot), value);
       }),
     );
@@ -130,7 +130,7 @@ export class TXEService {
     await accountDataProvider.setAccount(completeAddress.address, completeAddress);
     const addressDataProvider = (this.typedOracle as TXE).getAddressDataProvider();
     await addressDataProvider.addCompleteAddress(completeAddress);
-    this.logger.debug(`Created account ${completeAddress.address}`);
+    this.logger.debug('Created account %s', completeAddress.address);
     return toForeignCallResult([
       toSingle(completeAddress.address),
       ...completeAddress.publicKeys.toFields().map(toSingle),
@@ -138,7 +138,7 @@ export class TXEService {
   }
 
   async addAccount(artifact: ContractArtifact, instance: ContractInstanceWithAddress, secret: ForeignCallSingle) {
-    this.logger.debug(`Deployed ${artifact.name} at ${instance.address}`);
+    this.logger.debug('Deployed %s at %s', artifact.name, instance.address);
     await (this.typedOracle as TXE).addContractInstance(instance);
     await (this.typedOracle as TXE).addContractArtifact(instance.currentContractClassId, artifact);
 
@@ -148,7 +148,7 @@ export class TXEService {
     await accountDataProvider.setAccount(completeAddress.address, completeAddress);
     const addressDataProvider = (this.typedOracle as TXE).getAddressDataProvider();
     await addressDataProvider.addCompleteAddress(completeAddress);
-    this.logger.debug(`Created account ${completeAddress.address}`);
+    this.logger.debug('Created account %s', completeAddress.address);
     return toForeignCallResult([
       toSingle(completeAddress.address),
       ...completeAddress.publicKeys.toFields().map(toSingle),
@@ -513,7 +513,7 @@ export class TXEService {
       AztecAddress.fromField(fromSingle(sender)),
       AztecAddress.fromField(fromSingle(recipient)),
     );
-    return toForeignCallResult(secret.toFields().map(toSingle));
+    return toForeignCallResult([toArray(secret.toFields())]);
   }
 
   async syncNotes() {


### PR DESCRIPTION
Started migrating TXE module logs from template literals to pino's substitution patterns (%s). 

Fixed:
- yarn-project/txe/src/bin/index.ts
- yarn-project/txe/src/index.ts
- yarn-project/txe/src/node/txe_node.ts
- yarn-project/txe/src/txe_service/txe_service.ts

Part of #13035