### PR TITLE
refactor: metric attributes

### DIFF
--- a/yarn-project/bb-prover/src/instrumentation.ts
+++ b/yarn-project/bb-prover/src/instrumentation.ts
@@ -92,7 +92,6 @@ export class ProverInstrumentation {
     const s = typeof timerOrMS === 'number' ? timerOrMS / 1000 : timerOrMS.s();
     this[metric].record(s, {
       [Attributes.PROTOCOL_CIRCUIT_NAME]: circuitName,
-      [Attributes.PROTOCOL_CIRCUIT_TYPE]: 'server',
     });
   }
 
@@ -122,7 +121,6 @@ export class ProverInstrumentation {
   ) {
     this[metric].record(Math.ceil(size), {
       [Attributes.PROTOCOL_CIRCUIT_NAME]: circuitName,
-      [Attributes.PROTOCOL_CIRCUIT_TYPE]: 'server',
     });
   }
 

--- a/yarn-project/prover-client/src/orchestrator/orchestrator.ts
+++ b/yarn-project/prover-client/src/orchestrator/orchestrator.ts
@@ -531,7 +531,6 @@ export class ProvingOrchestrator implements EpochProver {
         }`,
         {
           [Attributes.TX_HASH]: processedTx.hash.toString(),
-          [Attributes.PROTOCOL_CIRCUIT_TYPE]: 'server',
           [Attributes.PROTOCOL_CIRCUIT_NAME]: rollupType,
         },
         signal => {
@@ -601,7 +600,6 @@ export class ProvingOrchestrator implements EpochProver {
         'ProvingOrchestrator.prover.getTubeProof',
         {
           [Attributes.TX_HASH]: txHash,
-          [Attributes.PROTOCOL_CIRCUIT_TYPE]: 'server',
           [Attributes.PROTOCOL_CIRCUIT_NAME]: 'tube-circuit' satisfies CircuitName,
         },
         signal => this.prover.getTubeProof(inputs, signal, this.provingState!.epochNumber),
@@ -626,7 +624,6 @@ export class ProvingOrchestrator implements EpochProver {
         this.tracer,
         'ProvingOrchestrator.prover.getMergeRollupProof',
         {
-          [Attributes.PROTOCOL_CIRCUIT_TYPE]: 'server',
           [Attributes.PROTOCOL_CIRCUIT_NAME]: 'merge-rollup' satisfies CircuitName,
         },
         signal => this.prover.getMergeRollupProof(inputs, signal, provingState.epochNumber),
@@ -659,7 +656,6 @@ export class ProvingOrchestrator implements EpochProver {
         this.tracer,
         'ProvingOrchestrator.prover.getBlockRootRollupProof',
         {
-          [Attributes.PROTOCOL_CIRCUIT_TYPE]: 'server',
           [Attributes.PROTOCOL_CIRCUIT_NAME]: rollupType,
         },
         signal => {
@@ -710,7 +706,6 @@ export class ProvingOrchestrator implements EpochProver {
         this.tracer,
         'ProvingOrchestrator.prover.getBaseParityProof',
         {
-          [Attributes.PROTOCOL_CIRCUIT_TYPE]: 'server',
           [Attributes.PROTOCOL_CIRCUIT_NAME]: 'base-parity' satisfies CircuitName,
         },
         signal => this.prover.getBaseParityProof(inputs, signal, provingState.epochNumber),
@@ -746,7 +741,6 @@ export class ProvingOrchestrator implements EpochProver {
         this.tracer,
         'ProvingOrchestrator.prover.getRootParityProof',
         {
-          [Attributes.PROTOCOL_CIRCUIT_TYPE]: 'server',
           [Attributes.PROTOCOL_CIRCUIT_NAME]: 'root-parity' satisfies CircuitName,
         },
         signal => this.prover.getRootParityProof(inputs, signal, provingState.epochNumber),
@@ -774,7 +768,6 @@ export class ProvingOrchestrator implements EpochProver {
         this.tracer,
         'ProvingOrchestrator.prover.getBlockMergeRollupProof',
         {
-          [Attributes.PROTOCOL_CIRCUIT_TYPE]: 'server',
           [Attributes.PROTOCOL_CIRCUIT_NAME]: 'block-merge-rollup' satisfies CircuitName,
         },
         signal => this.prover.getBlockMergeRollupProof(inputs, signal, provingState.epochNumber),
@@ -802,7 +795,6 @@ export class ProvingOrchestrator implements EpochProver {
         this.tracer,
         'ProvingOrchestrator.prover.getEmptyBlockRootRollupProof',
         {
-          [Attributes.PROTOCOL_CIRCUIT_TYPE]: 'server',
           [Attributes.PROTOCOL_CIRCUIT_NAME]: 'empty-block-root-rollup' satisfies CircuitName,
         },
         signal => this.prover.getEmptyBlockRootRollupProof(inputs, signal, provingState.epochNumber),
@@ -832,7 +824,6 @@ export class ProvingOrchestrator implements EpochProver {
         this.tracer,
         'ProvingOrchestrator.prover.getRootRollupProof',
         {
-          [Attributes.PROTOCOL_CIRCUIT_TYPE]: 'server',
           [Attributes.PROTOCOL_CIRCUIT_NAME]: 'root-rollup' satisfies CircuitName,
         },
         signal => this.prover.getRootRollupProof(inputs, signal, provingState.epochNumber),

--- a/yarn-project/telemetry-client/src/attributes.ts
+++ b/yarn-project/telemetry-client/src/attributes.ts
@@ -24,19 +24,9 @@ export const NETWORK_NAME = 'aztec.network_name';
 export const PROTOCOL_CIRCUIT_NAME = 'aztec.circuit.protocol_circuit_name';
 
 /**
- * The type of protocol circuit being run: server or client
- */
-export const PROTOCOL_CIRCUIT_TYPE = 'aztec.circuit.protocol_circuit_type';
-
-/**
  * For an app circuit, the contract:function being run (e.g. Token:transfer)
  */
 export const APP_CIRCUIT_NAME = 'aztec.circuit.app_circuit_name';
-
-/**
- * The type of app circuit being run: server or client
- */
-export const APP_CIRCUIT_TYPE = 'aztec.circuit.app_circuit_type';
 
 /** The block archive */
 export const BLOCK_ARCHIVE = 'aztec.block.archive';

--- a/yarn-project/telemetry-client/src/telemetry.ts
+++ b/yarn-project/telemetry-client/src/telemetry.ts
@@ -24,21 +24,49 @@ export { type Span, SpanStatusCode, ValueType } from '@opentelemetry/api';
 
 type ValuesOf<T> = T extends Record<string, infer U> ? U : never;
 
+type AttributeNames = ValuesOf<typeof Attributes>;
+
+/**
+ * This is a set of attributes that could lead to high cardinality in the metrics.
+ * If you find youself wanting to capture this data in a metric consider if it makes sense to capture
+ * as the metric value instead of an attribute or consider logging instead.
+ *
+ * Think twice before removing an attribute from this list.
+ */
+type BannedMetricAttributeNames = (typeof Attributes)[
+  | 'BLOCK_NUMBER'
+  | 'BLOCK_ARCHIVE'
+  | 'SLOT_NUMBER'
+  | 'BLOCK_PARENT'
+  | 'BLOCK_CANDIDATE_TXS_COUNT'
+  | 'BLOCK_TXS_COUNT'
+  | 'BLOCK_SIZE'
+  | 'EPOCH_SIZE'
+  | 'EPOCH_NUMBER'
+  | 'TX_HASH'
+  | 'PROVING_JOB_ID'
+  | 'P2P_ID'
+  | 'P2P_REQ_RESP_BATCH_REQUESTS_COUNT'
+  | 'TARGET_ADDRESS'
+  | 'MANA_USED'
+  | 'TOTAL_INSTRUCTIONS'];
+
 /** Global registry of attributes */
-type AttributesType = Partial<Record<ValuesOf<typeof Attributes>, AttributeValue>>;
-export type { AttributesType };
+export type AttributesType = Partial<Record<AttributeNames, AttributeValue>>;
+
+/** Subset of attributes allowed to be added to metrics */
+export type MetricAttributesType = Partial<Record<Exclude<AttributeNames, BannedMetricAttributeNames>, AttributeValue>>;
 
 /** Global registry of metrics */
-type MetricsType = (typeof Metrics)[keyof typeof Metrics];
-export type { MetricsType };
+export type MetricsType = (typeof Metrics)[keyof typeof Metrics];
 
-export type Gauge = OtelGauge<AttributesType>;
-export type Histogram = OtelHistogram<AttributesType>;
-export type UpDownCounter = OtelUpDownCounter<AttributesType>;
-export type ObservableGauge = OtelObservableGauge<AttributesType>;
-export type ObservableUpDownCounter = OtelObservableUpDownCounter<AttributesType>;
-export type ObservableResult = OtelObservableResult<AttributesType>;
-export type BatchObservableResult = OtelBatchObservableResult<AttributesType>;
+export type Gauge = OtelGauge<MetricAttributesType>;
+export type Histogram = OtelHistogram<MetricAttributesType>;
+export type UpDownCounter = OtelUpDownCounter<MetricAttributesType>;
+export type ObservableGauge = OtelObservableGauge<MetricAttributesType>;
+export type ObservableUpDownCounter = OtelObservableUpDownCounter<MetricAttributesType>;
+export type ObservableResult = OtelObservableResult<MetricAttributesType>;
+export type BatchObservableResult = OtelBatchObservableResult<MetricAttributesType>;
 
 export type { Tracer };
 

--- a/yarn-project/validator-client/src/metrics.ts
+++ b/yarn-project/validator-client/src/metrics.ts
@@ -43,7 +43,6 @@ export class ValidatorMetrics {
   public async recordFailedReexecution(proposal: BlockProposal) {
     this.failedReexecutionCounter.add(1, {
       [Attributes.STATUS]: 'failed',
-      [Attributes.BLOCK_NUMBER]: proposal.payload.header.globalVariables.blockNumber.toString(),
       [Attributes.BLOCK_PROPOSER]: (await proposal.getSender())?.toString(),
     });
   }


### PR DESCRIPTION
Disallow attributes in metrics that could lead to high cardinality at compile time.

![image](https://github.com/user-attachments/assets/1bf57ecc-6530-4779-8582-bae47b90c6c9)


Fix #13063 
