### PR TITLE
chore: Assign bb test flake

### DIFF
--- a/.test_patterns.yml
+++ b/.test_patterns.yml
@@ -48,6 +48,10 @@ tests:
     error_regex: "Sumcheck verification failed."
     owners:
       - *luke
+  - regex: "barretenberg/acir_tests/scripts/run_test_browser.sh verify_honk_proof"
+    error_regex: "verified: false"
+    owners:
+      - *sergei
 
   # Sumcheck is failing for some reason
   - regex: "barretenberg/acir_tests/scripts/run_test.sh ram_blowup_regression"


### PR DESCRIPTION
Example failing run: http://ci.aztec-labs.com/e19fd0255f1c1e9b

```
Command: b5c3a1f0966bd14e BROWSER=webkit THREAD_MODEL=mt barretenberg/acir_tests/scripts/run_test_browser.sh verify_honk_proof
Commit: https://github.com/AztecProtocol/aztec-packages/commit/afde85121e40dec4be98312928b243a8e25bc630
Env: REF_NAME=master CURRENT_VERSION=0.82.2 CI_FULL=1
Date: Thu Mar 27 19:35:35 UTC 2025
Sys: ARCH=amd64 CPUS=192 MEM=740Gi HOSTNAME=afde85121e40dec4be98312928b243a8e25bc630_amd64
History: http://ci.aztec-labs.com/list/c3c4b6b7993d9d87

19:35:42 Testing ./target/program.json in webkit...
19:35:44 browser-test-app starting test... +0ms
19:35:44 bb.js:fetch_mat Fetching bb wasm from default location +0ms
19:35:44 bb.js:fetch_mat Compiling bb wasm of 12947924 bytes +520ms
19:35:45 bb.js:fetch_mat Compilation of bb wasm complete +482ms
19:35:45 bb.js:bb_wasm_async Initializing bb wasm: initial memory 32 pages 2MiB; max memory: 65536 pages, 4096MiB; threads: 8; shared memory: true +0ms
19:35:45 bb.js:bb_wasm_async Creating 8 worker threads +218ms
19:35:50 bb.js:bb_wasm_async created circuit (mem: 444.44MiB) +5s
19:35:55 bb.js:bb_wasm_async Initialized BN254 prover CRS from memory with num points = 1048577 (mem: 644.44MiB) +5s
19:35:58 bb.js:bb_wasm_async created circuit (mem: 644.44MiB) +3s
19:35:58 bb.js:bb_wasm_async Constructing DeciderProvingKey (mem: 644.44MiB) +1ms
19:35:58 bb.js:bb_wasm_async Finalized circuit size: 727289 (mem: 713.44MiB) +387ms
19:35:58 bb.js:bb_wasm_async allocating polynomials object in proving key... (mem: 713.44MiB) +9ms
19:35:59 bb.js:bb_wasm_async populating trace... (mem: 1599.19MiB) +624ms
19:36:00 bb.js:bb_wasm_async time to construct proving key: 1687 ms. (mem: 1696.31MiB) +670ms
19:36:04 bb.js:bb_wasm_async created oink proof (mem: 2208.31MiB) +5s
19:36:07 bb.js:bb_wasm_async starting sumcheck rounds... (mem: 2208.31MiB) +2s
19:36:10 bb.js:bb_wasm_async completed 20 rounds of sumcheck (mem: 2208.31MiB) +3s
19:36:14 bb.js:bb_wasm_async executed multivariate-to-univariate reduction (mem: 2216.31MiB) +4s
19:36:15 bb.js:bb_wasm_async computed opening proof (mem: 2216.31MiB) +1s
19:36:18 bb.js:bb_wasm_async created circuit (mem: 2216.31MiB) +2s
19:36:18 bb.js:bb_wasm_async Constructing DeciderProvingKey (mem: 2216.31MiB) +0ms
19:36:18 bb.js:bb_wasm_async Finalized circuit size: 727289 (mem: 2216.31MiB) +288ms
19:36:18 bb.js:bb_wasm_async allocating polynomials object in proving key... (mem: 2216.31MiB) +1ms
19:36:18 bb.js:bb_wasm_async populating trace... (mem: 2216.31MiB) +164ms
19:36:18 bb.js:bb_wasm_async time to construct proving key: 780 ms. (mem: 2216.31MiB) +328ms
19:36:23 bb.js:bb_wasm_async Constructed UltraHonk verification key (mem: 2216.31MiB) +5s
19:36:23 browser-test-app getting the verification key... +39s
19:36:25 bb.js:bb_wasm_async created circuit (mem: 2216.31MiB) +2s
19:36:25 bb.js:bb_wasm_async Constructing DeciderProvingKey (mem: 2216.31MiB) +1ms
19:36:26 bb.js:bb_wasm_async Finalized circuit size: 727289 (mem: 2216.31MiB) +273ms
19:36:26 bb.js:bb_wasm_async allocating polynomials object in proving key... (mem: 2216.31MiB) +1ms
19:36:26 bb.js:bb_wasm_async populating trace... (mem: 2216.31MiB) +27ms
19:36:26 bb.js:bb_wasm_async time to construct proving key: 620 ms. (mem: 2216.31MiB) +320ms
19:36:31 bb.js:bb_wasm_async Constructed UltraHonk verification key (mem: 2216.31MiB) +5s
19:36:31 browser-test-app destroying the backend... +8s
19:36:31 browser-test-app verifying... +3ms
19:36:31 bb.js:fetch_mat Fetching bb wasm from default location +0ms
19:36:31 bb.js:fetch_mat Compiling bb wasm of 12947924 bytes +152ms
19:36:31 bb.js:fetch_mat Compilation of bb wasm complete +121ms
19:36:31 bb.js:bb_wasm_async Initializing bb wasm: initial memory 32 pages 2MiB; max memory: 65536 pages, 4096MiB; threads: 1; shared memory: true +0ms
19:36:32 bb.js:bb_wasm_async Initialized BN254 prover CRS from memory with num points = 1 (mem: 68.00MiB) +849ms
19:36:32 browser-test-app verified: false +1s
19:36:32 browser-test-app test complete. +1ms
19:36:32 FAILED (51s)
```