### PR TITLE
chore: add default native proving for cli-wallet

### DIFF
--- a/aztec-up/test/basic_install.sh
+++ b/aztec-up/test/basic_install.sh
@@ -45,6 +45,7 @@ echo "LSP check passed."
 # aztec-wallet -V
 
 export LOG_LEVEL=silent
+export PXE_PROVER=none
 
 # Start sandbox and wait for port to open.
 aztec start --sandbox &

--- a/yarn-project/cli-wallet/src/bin/index.ts
+++ b/yarn-project/cli-wallet/src/bin/index.ts
@@ -17,7 +17,7 @@ import { PXEWrapper } from '../utils/pxe_wrapper.js';
 const userLog = createConsoleLogger();
 const debugLogger = createLogger('wallet');
 
-const { WALLET_DATA_DIRECTORY = join(homedir(), '.aztec/wallet'), PXE_PROVER = 'none' } = process.env;
+const { WALLET_DATA_DIRECTORY = join(homedir(), '.aztec/wallet') } = process.env;
 
 function injectInternalCommands(program: Command, log: LogFn, db: WalletDB) {
   program
@@ -77,7 +77,12 @@ async function main() {
     .description('Aztec wallet')
     .version(walletVersion)
     .option('-d, --data-dir <string>', 'Storage directory for wallet data', WALLET_DATA_DIRECTORY)
-    .option('-p, --prover <string>', 'wasm|native|none', PXE_PROVER)
+    .addOption(
+      new Option('-p, --prover <string>', 'The type of prover the wallet uses (only applies if not using a remote PXE)')
+        .choices(['wasm', 'native', 'none'])
+        .env('PXE_PROVER')
+        .default('native'),
+    )
     .addOption(
       new Option('--remote-pxe', 'Connect to an external PXE RPC server, instead of the local one')
         .env('REMOTE_PXE')

--- a/yarn-project/cli-wallet/test/flows/shared/setup.sh
+++ b/yarn-project/cli-wallet/test/flows/shared/setup.sh
@@ -14,6 +14,8 @@ command="${COMMAND:-"node --no-warnings $root/yarn-project/cli-wallet/dest/bin/i
 flows=$(pwd)
 cd $root/noir-projects/noir-contracts
 
+export PXE_PROVER="none"
+
 function aztec-wallet {
   echo_header aztec-wallet "$@"
   $command "$@"

--- a/yarn-project/cli-wallet/test/test.sh
+++ b/yarn-project/cli-wallet/test/test.sh
@@ -33,6 +33,7 @@ done
 set -- "${POSITIONAL_ARGS[@]}" # restore positional parameters
 
 export WALLET_DATA_DIRECTORY="${LOCATION}/data"
+export PXE_PROVER="none"
 
 rm -rf $WALLET_DATA_DIRECTORY
 mkdir -p $WALLET_DATA_DIRECTORY

--- a/yarn-project/end-to-end/src/guides/up_quick_start.sh
+++ b/yarn-project/end-to-end/src/guides/up_quick_start.sh
@@ -4,6 +4,7 @@
 set -eux
 
 export WALLET_DATA_DIRECTORY=$(mktemp -d)/up_quick_start
+export PXE_PROVER="none"
 
 function on_exit {
   echo "Cleaning up $WALLET_DATA_DIRECTORY..."


### PR DESCRIPTION
Okay so I've verified [here](http://ci.aztec-labs.com/e393f86bd02275e7), that none of the cli-wallet tests in 

cli-wallet/tests/flows or
aztec-up/test or
end-to-end/src/guides

are running with prover.

I have also verified [here](https://github.com/AztecProtocol/aztec-packages/actions/runs/14263826827/job/39981104620#step:7:156), that none of the tests above 5 minutes are due to this change.

 It turns out we needed to export the var (instead of just defining it) in each location as the command was being called and not inheriting a non-exported env var.
