### PR TITLE
fix: boolean config helper for cli args works now (#13110)

### DIFF
--- a/yarn-project/aztec/src/cli/aztec_start_options.ts
+++ b/yarn-project/aztec/src/cli/aztec_start_options.ts
@@ -266,7 +266,7 @@ export const aztecStartOptions: { [key: string]: AztecStartOption[] } = {
   ],
   'P2P SUBSYSTEM': [
     {
-      flag: '--p2p-enabled',
+      flag: '--p2p-enabled [value]',
       description: 'Enable P2P subsystem',
       envVar: 'P2P_ENABLED',
       ...booleanConfigHelper(),

--- a/yarn-project/aztec/src/sandbox/sandbox.ts
+++ b/yarn-project/aztec/src/sandbox/sandbox.ts
@@ -118,12 +118,13 @@ export async function createSandbox(config: Partial<SandboxConfig> = {}, userLog
   }
 
   const initialAccounts = await (async () => {
-    if (config.testAccounts) {
+    if (config.testAccounts === true || config.testAccounts === undefined) {
       if (aztecNodeConfig.p2pEnabled) {
         userLog(`Not setting up test accounts as we are connecting to a network`);
       } else if (config.noPXE) {
         userLog(`Not setting up test accounts as we are not exposing a PXE`);
       } else {
+        userLog(`Setting up test accounts`);
         return await getInitialTestAccounts();
       }
     }


### PR DESCRIPTION
Using `booleanConfigHelper` without `[value]` in the commander flag was resulting in all our boolean cli args either using the default (if no value was provided), or to `false`, because the "value" supplied to the `parse` function was always `undefined`.

This resuled in, e.g. passing `--p2p-enabled` being interpreted as false.

Now the expected behavior reigns: `--p2p-enabled` and `--p2p-enabled=true` and `--p2p-enabled true` all result in the flag being `true`, but `--p2p-enabled=false` and `--p2p-enabled false` result in the flag being `false`.

In the `testAccounts` case, since it was defined as `true` by default for the sandbox, it was picking up that value when parsing for the node, so no matter what it was true.

Please read [contributing guidelines](CONTRIBUTING.md) and remove this line.
