### PR TITLE
chore: log out the slash factory when a new rollup is deployed

### DIFF
--- a/yarn-project/cli/src/cmds/l1/deploy_new_rollup.ts
+++ b/yarn-project/cli/src/cmds/l1/deploy_new_rollup.ts
@@ -25,7 +25,7 @@ export async function deployNewRollup(
   const initialFundedAccounts = testAccounts ? await getInitialTestAccounts() : [];
   const { genesisBlockHash, genesisArchiveRoot } = await getGenesisValues(initialFundedAccounts.map(a => a.address));
 
-  const { payloadAddress, rollup } = await deployNewRollupContracts(
+  const { payloadAddress, rollup, slashFactoryAddress } = await deployNewRollupContracts(
     registryAddress,
     rpcUrls,
     chainId,
@@ -46,6 +46,7 @@ export async function deployNewRollup(
         {
           payloadAddress: payloadAddress.toString(),
           rollupAddress: rollup.address,
+          slashFactoryAddress: slashFactoryAddress.toString(),
         },
         null,
         2,
@@ -54,5 +55,6 @@ export async function deployNewRollup(
   } else {
     log(`Payload Address: ${payloadAddress.toString()}`);
     log(`Rollup Address: ${rollup.address}`);
+    log(`Slash Factory Address: ${slashFactoryAddress.toString()}`);
   }
 }

--- a/yarn-project/cli/src/utils/aztec.ts
+++ b/yarn-project/cli/src/utils/aztec.ts
@@ -96,7 +96,7 @@ export async function deployNewRollupContracts(
   genesisBlockHash: Fr,
   config: L1ContractsConfig,
   logger: Logger,
-): Promise<{ payloadAddress: EthAddress; rollup: RollupContract }> {
+): Promise<{ payloadAddress: EthAddress; rollup: RollupContract; slashFactoryAddress: EthAddress }> {
   const { createEthereumChain, deployRollupForUpgrade, createL1Clients } = await import('@aztec/ethereum');
   const { mnemonicToAccount, privateKeyToAccount } = await import('viem/accounts');
   const { getVKTreeRoot } = await import('@aztec/noir-protocol-circuits-types/vk-tree');
@@ -107,7 +107,7 @@ export async function deployNewRollupContracts(
   const chain = createEthereumChain(rpcUrls, chainId);
   const clients = createL1Clients(rpcUrls, account, chain.chainInfo, mnemonicIndex);
 
-  const { payloadAddress, rollup } = await deployRollupForUpgrade(
+  const { payloadAddress, rollup, slashFactoryAddress } = await deployRollupForUpgrade(
     clients,
     {
       salt,
@@ -124,7 +124,7 @@ export async function deployNewRollupContracts(
     config,
   );
 
-  return { payloadAddress, rollup };
+  return { payloadAddress, rollup, slashFactoryAddress };
 }
 
 /**


### PR DESCRIPTION
Unfortunately we don't have the ability to grep logs in the TS wrapping tests of the CLI to ensure this "actually worked". 