### PR TITLE
refactor: type check config read from env

### DIFF
--- a/yarn-project/aztec-faucet/src/config.ts
+++ b/yarn-project/aztec-faucet/src/config.ts
@@ -39,7 +39,7 @@ export const faucetConfigMapping: ConfigMappingsType<FaucetConfig> = {
   l1Assets: {
     env: 'FAUCET_L1_ASSETS',
     description: 'Which other L1 assets the faucet is able to drip',
-    defaultValue: '',
+    defaultValue: [],
     parseEnv(val): L1AssetConfig[] {
       const assetConfigs = val.split(',');
       return assetConfigs.flatMap(assetConfig => {

--- a/yarn-project/blob-sink/src/archive/config.ts
+++ b/yarn-project/blob-sink/src/archive/config.ts
@@ -3,7 +3,7 @@ import { type ConfigMappingsType, pickConfigMappings } from '@aztec/foundation/c
 
 export type BlobSinkArchiveApiConfig = {
   archiveApiUrl?: string;
-} & Partial<Pick<L1ReaderConfig, 'l1ChainId'>>;
+} & Pick<L1ReaderConfig, 'l1ChainId'>;
 
 export const blobSinkArchiveApiConfigMappings: ConfigMappingsType<BlobSinkArchiveApiConfig> = {
   archiveApiUrl: {

--- a/yarn-project/blob-sink/src/archive/factory.ts
+++ b/yarn-project/blob-sink/src/archive/factory.ts
@@ -3,15 +3,15 @@ import { BlobscanArchiveClient } from './blobscan_archive_client.js';
 import type { BlobArchiveClient } from './interface.js';
 
 export function createBlobArchiveClient(
-  config: Pick<BlobSinkConfig, 'archiveApiUrl' | 'l1ChainId'> = {},
+  config?: Pick<BlobSinkConfig, 'archiveApiUrl' | 'l1ChainId'>,
 ): BlobArchiveClient | undefined {
-  if (config.archiveApiUrl) {
+  if (config?.archiveApiUrl) {
     return new BlobscanArchiveClient(config.archiveApiUrl);
   }
 
-  if (config.l1ChainId === 1) {
+  if (config?.l1ChainId === 1) {
     return new BlobscanArchiveClient('api.blobscan.com');
-  } else if (config.l1ChainId === 11155111) {
+  } else if (config?.l1ChainId === 11155111) {
     return new BlobscanArchiveClient('api.sepolia.blobscan.com');
   }
 

--- a/yarn-project/blob-sink/src/client/config.ts
+++ b/yarn-project/blob-sink/src/client/config.ts
@@ -14,7 +14,7 @@ export interface BlobSinkConfig extends BlobSinkArchiveApiConfig {
   /**
    * List of URLs for L1 RPC Execution clients
    */
-  l1RpcUrls?: string[];
+  l1RpcUrls: string[];
 
   /**
    * The URL of the L1 consensus client
@@ -41,6 +41,7 @@ export const blobSinkConfigMapping: ConfigMappingsType<BlobSinkConfig> = {
     env: 'ETHEREUM_HOSTS',
     description: 'List of URLs for L1 RPC Execution clients',
     parseEnv: (val: string) => val.split(',').map(url => url.trim()),
+    defaultValue: [],
   },
   l1ConsensusHostUrl: {
     env: 'L1_CONSENSUS_HOST_URL',

--- a/yarn-project/blob-sink/src/client/http.test.ts
+++ b/yarn-project/blob-sink/src/client/http.test.ts
@@ -19,6 +19,7 @@ describe('HttpBlobSinkClient', () => {
         l1RpcUrls: [],
         rollupAddress: EthAddress.ZERO,
         port: 0,
+        l1ChainId: 31337,
       },
       new MemoryBlobStore(),
     );
@@ -26,6 +27,8 @@ describe('HttpBlobSinkClient', () => {
 
     const client = new HttpBlobSinkClient({
       blobSinkUrl: `http://localhost:${server.port}`,
+      l1RpcUrls: [],
+      l1ChainId: 31337,
     });
 
     return {
@@ -37,7 +40,7 @@ describe('HttpBlobSinkClient', () => {
   });
 
   it('should handle server connection errors gracefully', async () => {
-    const client = new HttpBlobSinkClient({ blobSinkUrl: 'http://localhost:12345' }); // Invalid port
+    const client = new HttpBlobSinkClient({ blobSinkUrl: 'http://localhost:12345', l1RpcUrls: [], l1ChainId: 31337 }); // Invalid port
     const blob = await Blob.fromFields([Fr.random()]);
     const blobHash = blob.getEthVersionedBlobHash();
 
@@ -169,6 +172,7 @@ describe('HttpBlobSinkClient', () => {
           port: 0,
           l1RpcUrls: [],
           rollupAddress: EthAddress.ZERO,
+          l1ChainId: 31337,
         },
         new MemoryBlobStore(),
       );
@@ -181,6 +185,7 @@ describe('HttpBlobSinkClient', () => {
       const client = new HttpBlobSinkClient({
         blobSinkUrl: `http://localhost:${blobSinkServer.port}`,
         l1RpcUrls: [`http://localhost:${executionHostPort}`],
+        l1ChainId: 31337,
       });
 
       const success = await client.sendBlobsToBlobSink('0x1234', [testEncodedBlob]);
@@ -202,6 +207,7 @@ describe('HttpBlobSinkClient', () => {
       const client = new HttpBlobSinkClient({
         l1RpcUrls: [`http://localhost:${executionHostPort}`],
         l1ConsensusHostUrl: `http://localhost:${consensusHostPort}`,
+        l1ChainId: 31337,
       });
 
       const retrievedBlobs = await client.getBlobSidecar('0x1234', [testEncodedBlobHash]);
@@ -215,6 +221,7 @@ describe('HttpBlobSinkClient', () => {
       const client = new HttpBlobSinkClient({
         l1RpcUrls: [`http://localhost:${executionHostPort}`],
         l1ConsensusHostUrl: `http://localhost:${consensusHostPort}`,
+        l1ChainId: 31337,
       });
 
       const retrievedBlobs = await client.getBlobSidecar('0x1234', [testEncodedBlobHash, testNonEncodedBlobHash]);
@@ -229,6 +236,7 @@ describe('HttpBlobSinkClient', () => {
       const client = new HttpBlobSinkClient({
         l1RpcUrls: [`http://localhost:${executionHostPort}`],
         l1ConsensusHostUrl: `http://localhost:${consensusHostPort}`,
+        l1ChainId: 31337,
       });
 
       // Add spy on the fetch method
@@ -252,7 +260,11 @@ describe('HttpBlobSinkClient', () => {
     });
 
     it('should fall back to archive client', async () => {
-      const client = new TestHttpBlobSinkClient({ archiveApiUrl: `http://api.blobscan.com` });
+      const client = new TestHttpBlobSinkClient({
+        archiveApiUrl: `http://api.blobscan.com`,
+        l1RpcUrls: [],
+        l1ChainId: 31337,
+      });
       const archiveSpy = jest.spyOn(client.getArchiveClient(), 'getBlobsFromBlock').mockResolvedValue(blobData);
 
       const retrievedBlobs = await client.getBlobSidecar('0x1234', [testEncodedBlobHash]);

--- a/yarn-project/blob-sink/src/client/http.test.ts
+++ b/yarn-project/blob-sink/src/client/http.test.ts
@@ -1,20 +1,27 @@
 import { Blob, type BlobJson } from '@aztec/blob-lib';
 import { makeEncodedBlob, makeUnencodedBlob } from '@aztec/blob-lib/testing';
+import { EthAddress } from '@aztec/foundation/eth-address';
 import { Fr } from '@aztec/foundation/fields';
 
 import { jest } from '@jest/globals';
 import http from 'http';
 import type { AddressInfo } from 'net';
 
+import { MemoryBlobStore } from '../blobstore/memory_blob_store.js';
 import { BlobSinkServer } from '../server/server.js';
 import { runBlobSinkClientTests } from './blob-sink-client-tests.js';
 import { HttpBlobSinkClient } from './http.js';
 
 describe('HttpBlobSinkClient', () => {
   runBlobSinkClientTests(async () => {
-    const server = new BlobSinkServer({
-      port: 0,
-    });
+    const server = new BlobSinkServer(
+      {
+        l1RpcUrls: [],
+        rollupAddress: EthAddress.ZERO,
+        port: 0,
+      },
+      new MemoryBlobStore(),
+    );
     await server.start();
 
     const client = new HttpBlobSinkClient({
@@ -157,9 +164,14 @@ describe('HttpBlobSinkClient', () => {
 
     // When the consensus host is not responding, we should still be able to request blobs with the block hash
     it('should handle no consensus host', async () => {
-      blobSinkServer = new BlobSinkServer({
-        port: 0,
-      });
+      blobSinkServer = new BlobSinkServer(
+        {
+          port: 0,
+          l1RpcUrls: [],
+          rollupAddress: EthAddress.ZERO,
+        },
+        new MemoryBlobStore(),
+      );
       await blobSinkServer.start();
 
       const blobSinkSpy = jest.spyOn((blobSinkServer as any).blobStore, 'getBlobSidecars');

--- a/yarn-project/blob-sink/src/server/config.ts
+++ b/yarn-project/blob-sink/src/server/config.ts
@@ -13,7 +13,8 @@ export type BlobSinkConfig = {
   port?: number;
   archiveApiUrl?: string;
 } & BlobSinkArchiveApiConfig &
-  Partial<Pick<L1ReaderConfig, 'l1RpcUrls'> & Pick<L1ContractAddresses, 'rollupAddress'>> &
+  Pick<L1ReaderConfig, 'l1RpcUrls'> &
+  Pick<L1ContractAddresses, 'rollupAddress'> &
   Partial<DataStoreConfig>;
 
 export const blobSinkConfigMappings: ConfigMappingsType<BlobSinkConfig> = {
@@ -22,10 +23,10 @@ export const blobSinkConfigMappings: ConfigMappingsType<BlobSinkConfig> = {
     description: 'The port to run the blob sink server on',
   },
 
+  ...dataConfigMappings,
   ...blobSinkArchiveApiConfigMappings,
   ...pickConfigMappings(l1ReaderConfigMappings, ['l1RpcUrls']),
   ...pickConfigMappings(l1ContractAddressesMapping, ['rollupAddress']),
-  ...dataConfigMappings,
 };
 
 /**

--- a/yarn-project/blob-sink/src/server/factory.ts
+++ b/yarn-project/blob-sink/src/server/factory.ts
@@ -1,24 +1,28 @@
 import { getPublicClient } from '@aztec/ethereum';
-import type { AztecAsyncKVStore } from '@aztec/kv-store';
 import { createStore } from '@aztec/kv-store/lmdb-v2';
 import type { TelemetryClient } from '@aztec/telemetry-client';
 
 import { createBlobArchiveClient } from '../archive/factory.js';
+import { DiskBlobStore } from '../blobstore/disk_blob_store.js';
+import type { BlobStore } from '../blobstore/interface.js';
+import { MemoryBlobStore } from '../blobstore/memory_blob_store.js';
 import type { BlobSinkConfig } from './config.js';
 import { BlobSinkServer } from './server.js';
 
 // If data store settings are provided, the store is created and returned.
 // Otherwise, undefined is returned and an in memory store will be used.
-async function getDataStore(config?: BlobSinkConfig): Promise<AztecAsyncKVStore | undefined> {
+async function getDataStore(config: BlobSinkConfig): Promise<BlobStore> {
   if (!config?.dataDirectory || !config?.dataStoreMapSizeKB) {
-    return undefined;
+    return new MemoryBlobStore();
   }
-  return await createStore('blob-sink', 1, {
-    ...config,
-    // re-assigning to make TypeScript happy
+
+  const db = await createStore('blob-sink', 1, {
+    l1Contracts: config.l1Contracts ?? {},
     dataDirectory: config.dataDirectory,
     dataStoreMapSizeKB: config.dataStoreMapSizeKB,
   });
+
+  return new DiskBlobStore(db);
 }
 
 /**

--- a/yarn-project/blob-sink/src/server/server.test.ts
+++ b/yarn-project/blob-sink/src/server/server.test.ts
@@ -25,7 +25,7 @@ describe('BlobSinkService', () => {
     config: Partial<BlobSinkConfig & { blobArchiveClient: BlobArchiveClient; l1Client: ViemPublicClient }> = {},
   ) => {
     service = new BlobSinkServer(
-      { ...config, l1RpcUrls: [], rollupAddress: EthAddress.ZERO, port: 0 },
+      { ...config, l1RpcUrls: [], rollupAddress: EthAddress.ZERO, port: 0, l1ChainId: 31337 },
       new MemoryBlobStore(),
       config.blobArchiveClient,
       config.l1Client,

--- a/yarn-project/blob-sink/src/server/server.test.ts
+++ b/yarn-project/blob-sink/src/server/server.test.ts
@@ -1,6 +1,7 @@
 import { Blob } from '@aztec/blob-lib';
 import { makeEncodedBlob } from '@aztec/blob-lib/testing';
 import type { L2BlockProposedEvent, ViemPublicClient } from '@aztec/ethereum';
+import { EthAddress } from '@aztec/foundation/eth-address';
 import { bufferToHex, hexToBuffer } from '@aztec/foundation/string';
 import { fileURLToPath } from '@aztec/foundation/url';
 
@@ -11,6 +12,7 @@ import request from 'supertest';
 
 import { BlobscanBlockResponseSchema } from '../archive/blobscan_archive_client.js';
 import type { BlobArchiveClient } from '../archive/interface.js';
+import { MemoryBlobStore } from '../blobstore/memory_blob_store.js';
 import { outboundTransform } from '../encoding/index.js';
 import { BlobWithIndex } from '../types/blob_with_index.js';
 import type { BlobSinkConfig } from './config.js';
@@ -22,7 +24,12 @@ describe('BlobSinkService', () => {
   const startServer = async (
     config: Partial<BlobSinkConfig & { blobArchiveClient: BlobArchiveClient; l1Client: ViemPublicClient }> = {},
   ) => {
-    service = new BlobSinkServer({ ...config, port: 0 }, undefined, config.blobArchiveClient, config.l1Client);
+    service = new BlobSinkServer(
+      { ...config, l1RpcUrls: [], rollupAddress: EthAddress.ZERO, port: 0 },
+      new MemoryBlobStore(),
+      config.blobArchiveClient,
+      config.l1Client,
+    );
     await service.start();
   };
 

--- a/yarn-project/blob-sink/src/server/server.ts
+++ b/yarn-project/blob-sink/src/server/server.ts
@@ -11,7 +11,7 @@ import type { Hex } from 'viem';
 import { z } from 'zod';
 
 import type { BlobArchiveClient } from '../archive/index.js';
-import { type BlobStore } from '../blobstore/index.js';
+import type { BlobStore } from '../blobstore/index.js';
 import { inboundTransform } from '../encoding/index.js';
 import { type PostBlobSidecarRequest, blockIdSchema, indicesSchema } from '../types/api.js';
 import { BlobWithIndex } from '../types/index.js';

--- a/yarn-project/bot/src/config.ts
+++ b/yarn-project/bot/src/config.ts
@@ -30,7 +30,7 @@ export type BotConfig = {
   /** URL to the PXE for sending txs, or undefined if an in-proc PXE is used. */
   pxeUrl: string | undefined;
   /** Url of the ethereum host. */
-  l1RpcUrls: string[] | undefined;
+  l1RpcUrls: string[];
   /** The mnemonic for the account to bridge fee juice from L1. */
   l1Mnemonic: string | undefined;
   /** The private key for the account to bridge fee juice from L1. */
@@ -82,7 +82,7 @@ export const BotConfigSchema = z
     nodeUrl: z.string().optional(),
     nodeAdminUrl: z.string().optional(),
     pxeUrl: z.string().optional(),
-    l1RpcUrls: z.array(z.string()).optional(),
+    l1RpcUrls: z.array(z.string()),
     l1Mnemonic: z.string().optional(),
     l1PrivateKey: z.string().optional(),
     senderPrivateKey: schemas.Fr.optional(),
@@ -110,7 +110,6 @@ export const BotConfigSchema = z
     nodeUrl: undefined,
     nodeAdminUrl: undefined,
     pxeUrl: undefined,
-    l1RpcUrls: undefined,
     l1Mnemonic: undefined,
     l1PrivateKey: undefined,
     senderPrivateKey: undefined,

--- a/yarn-project/ethereum/src/l1_reader.ts
+++ b/yarn-project/ethereum/src/l1_reader.ts
@@ -19,6 +19,7 @@ export const l1ReaderConfigMappings: ConfigMappingsType<L1ReaderConfig> = {
     env: 'ETHEREUM_HOSTS',
     description: 'The RPC Url of the ethereum host.',
     parseEnv: (val: string) => val.split(',').map(url => url.trim()),
+    defaultValue: [],
   },
   l1ChainId: {
     env: 'L1_CHAIN_ID',

--- a/yarn-project/foundation/src/config/config.test.ts
+++ b/yarn-project/foundation/src/config/config.test.ts
@@ -1,0 +1,31 @@
+import { safeParsePositiveInteger } from './index.js';
+
+describe('config', () => {
+  describe('safeParsePositiveInteger', () => {
+    it('should return the parsed value for valid positive integers', () => {
+      expect(safeParsePositiveInteger('123')).toBe(123);
+      expect(safeParsePositiveInteger('1')).toBe(1);
+      expect(safeParsePositiveInteger('999999')).toBe(999999);
+    });
+
+    it('should throw an error when no default value is provided for invalid input', () => {
+      expect(() => safeParsePositiveInteger('-1')).toThrow('Value must be a positive integer: -1');
+      expect(() => safeParsePositiveInteger('abc')).toThrow('Value must be a positive integer: abc');
+    });
+
+    it('should throw and error when no default value is provided for invalid input', () => {
+      expect(() => safeParsePositiveInteger('-1', 42)).toThrow('Value must be a positive integer: -1');
+      expect(() => safeParsePositiveInteger('abc', 42)).toThrow('Value must be a positive integer: abc');
+    });
+
+    it('should throw error for non-numeric input', () => {
+      expect(() => safeParsePositiveInteger('abc')).toThrow('Value must be a positive integer: abc');
+      expect(() => safeParsePositiveInteger('123abc')).toThrow('Value must be a positive integer: 123abc');
+      expect(() => safeParsePositiveInteger('abc123')).toThrow('Value must be a positive integer: abc123');
+    });
+
+    it('should handle empty string', () => {
+      expect(() => safeParsePositiveInteger('')).toThrow('Value must be a positive integer: ');
+    });
+  });
+});

--- a/yarn-project/foundation/src/config/index.ts
+++ b/yarn-project/foundation/src/config/index.ts
@@ -180,6 +180,24 @@ function safeParseNumber(value: string, defaultValue: number): number {
 }
 
 /**
+ * Safely parses a positive integer from a string.
+ * If the value is not a number or is not a safe integer, the default value is returned.
+ * @param value - The string value to parse
+ * @param defaultValue - The default value to return
+ * @returns Either parsed value or default value
+ */
+export function safeParsePositiveInteger(value: string): number;
+export function safeParsePositiveInteger(value: string, defaultValue: number): number;
+export function safeParsePositiveInteger(value: string, defaultValue?: number): number | undefined {
+  // Check value has no non-numeric characters
+  if (!/^\d+$/.test(value)) {
+    throw new Error('Value must be a positive integer: ' + value);
+  }
+  const parsedValue = parseInt(value, 10);
+  return Number.isSafeInteger(parsedValue) && parsedValue > 0 ? parsedValue : defaultValue;
+}
+
+/**
  * Picks specific keys from the given configuration mappings.
  *
  * @template T - The type of the full configuration object.

--- a/yarn-project/kv-store/src/config.ts
+++ b/yarn-project/kv-store/src/config.ts
@@ -5,7 +5,7 @@ import type { EthAddress } from '@aztec/foundation/eth-address';
 export type DataStoreConfig = {
   dataDirectory: string | undefined;
   dataStoreMapSizeKB: number;
-  l1Contracts?: { rollupAddress: EthAddress };
+  l1Contracts: { rollupAddress?: EthAddress };
 };
 
 export const dataConfigMappings: ConfigMappingsType<DataStoreConfig> = {

--- a/yarn-project/kv-store/src/lmdb-v2/factory.ts
+++ b/yarn-project/kv-store/src/lmdb-v2/factory.ts
@@ -25,7 +25,7 @@ export async function createStore(
     const subDir = join(dataDirectory, name);
     await mkdir(subDir, { recursive: true });
 
-    const rollupAddress = l1Contracts ? l1Contracts.rollupAddress : EthAddress.ZERO;
+    const rollupAddress = l1Contracts.rollupAddress ?? EthAddress.ZERO;
 
     // Create a version manager
     const versionManager = new DatabaseVersionManager(schemaVersion, rollupAddress, subDir, dbDirectory =>

--- a/yarn-project/node-lib/src/actions/snapshot-sync.ts
+++ b/yarn-project/node-lib/src/actions/snapshot-sync.ts
@@ -32,9 +32,9 @@ import type { SharedNodeConfig } from '../config/index.js';
 const MIN_L1_BLOCKS_TO_TRIGGER_REPLACE = 86400 / 2 / 12;
 
 type SnapshotSyncConfig = Pick<SharedNodeConfig, 'syncMode' | 'snapshotsUrl'> &
+  Required<DataStoreConfig> &
   Pick<ChainConfig, 'l1ChainId' | 'version'> &
   Pick<ArchiverConfig, 'archiverStoreMapSizeKb' | 'maxLogs'> &
-  Required<DataStoreConfig> &
   EthereumClientConfig & {
     minL1BlocksToTriggerReplace?: number;
   };
@@ -57,6 +57,11 @@ export async function trySnapshotSync(config: SnapshotSyncConfig, log: Logger) {
 
     if (!dataDirectory) {
       log.verbose('Snapshot sync is disabled. No local data directory defined.');
+      return false;
+    }
+
+    if (!l1Contracts.rollupAddress) {
+      log.error('Snapshot sync is disabled. No rollup address available.');
       return false;
     }
 

--- a/yarn-project/p2p-bootstrap/src/index.ts
+++ b/yarn-project/p2p-bootstrap/src/index.ts
@@ -1,3 +1,4 @@
+import { EthAddress } from '@aztec/foundation/eth-address';
 import { createLogger } from '@aztec/foundation/log';
 import { createStore } from '@aztec/kv-store/lmdb-v2';
 import { type BootnodeConfig, BootstrapNode } from '@aztec/p2p';
@@ -18,7 +19,18 @@ async function main(
   telemetryClient: TelemetryClient = getTelemetryClient(),
   logger = debugLogger,
 ) {
-  const store = await createStore('p2p-bootstrap', 1, config, logger);
+  const store = await createStore(
+    'p2p-bootstrap',
+    1,
+    {
+      dataStoreMapSizeKB: config.dataStoreMapSizeKB,
+      dataDirectory: config.dataDirectory,
+      l1Contracts: {
+        rollupAddress: EthAddress.ZERO,
+      },
+    },
+    logger,
+  );
 
   const bootstrapNode = new BootstrapNode(store, telemetryClient, logger);
   await bootstrapNode.start(config);

--- a/yarn-project/p2p/src/services/reqresp/config.ts
+++ b/yarn-project/p2p/src/services/reqresp/config.ts
@@ -1,4 +1,4 @@
-import { type ConfigMapping, numberConfigHelper } from '@aztec/foundation/config';
+import { type ConfigMappingsType, numberConfigHelper } from '@aztec/foundation/config';
 
 export const DEFAULT_INDIVIDUAL_REQUEST_TIMEOUT_MS = 2000;
 export const DEFAULT_OVERALL_REQUEST_TIMEOUT_MS = 4000;
@@ -21,7 +21,7 @@ export interface P2PReqRespConfig {
   individualRequestTimeoutMs: number;
 }
 
-export const p2pReqRespConfigMappings: Record<keyof P2PReqRespConfig, ConfigMapping> = {
+export const p2pReqRespConfigMappings: ConfigMappingsType<P2PReqRespConfig> = {
   overallRequestTimeoutMs: {
     env: 'P2P_REQRESP_OVERALL_REQUEST_TIMEOUT_MS',
     description: 'The overall timeout for a request response operation.',

--- a/yarn-project/prover-client/src/proving_broker/config.ts
+++ b/yarn-project/prover-client/src/proving_broker/config.ts
@@ -115,8 +115,10 @@ export const proverAgentConfigMappings: ConfigMappingsType<ProverAgentConfig> = 
     parseEnv: (val: string) =>
       val
         .split(',')
-        .map(v => ProvingRequestType[v as any])
-        .filter(v => typeof v === 'number'),
+        // need to cast V because it's a string and the reverse mapping the TS creates assumes you want to go from a number to its name
+        // and the value needs to be cast back to a value of the enum because of the reason (the reverse map goes from number to string, we don't want the string, but the value)
+        .map(v => ProvingRequestType[v as any] as unknown as ProvingRequestType | undefined)
+        .filter((v): v is ProvingRequestType => typeof v !== 'undefined'),
   },
   proverBrokerUrl: {
     env: 'PROVER_BROKER_HOST',

--- a/yarn-project/pxe/src/config/index.ts
+++ b/yarn-project/pxe/src/config/index.ts
@@ -99,9 +99,9 @@ export const pxeCliConfigMappings: ConfigMappingsType<CliPXEOptions> = {
 };
 
 export const allPxeConfigMappings: ConfigMappingsType<CliPXEOptions & PXEServiceConfig> = {
+  ...dataConfigMappings,
   ...pxeConfigMappings,
   ...pxeCliConfigMappings,
-  ...dataConfigMappings,
   proverEnabled: {
     env: 'PXE_PROVER_ENABLED',
     parseEnv: (val: string) => parseBooleanEnv(val) || !!process.env.NETWORK,

--- a/yarn-project/sequencer-client/src/config.ts
+++ b/yarn-project/sequencer-client/src/config.ts
@@ -117,10 +117,10 @@ export const sequencerConfigMappings: ConfigMappingsType<SequencerConfig> = {
 export const sequencerClientConfigMappings: ConfigMappingsType<SequencerClientConfig> = {
   ...validatorClientConfigMappings,
   ...sequencerConfigMappings,
+  ...chainConfigMappings,
   ...l1ReaderConfigMappings,
   ...getTxSenderConfigMappings('SEQ'),
   ...getPublisherConfigMappings('SEQ'),
-  ...chainConfigMappings,
   ...pickConfigMappings(l1ContractsConfigMappings, ['ethereumSlotDuration', 'aztecSlotDuration', 'aztecEpochDuration']),
 };
 

--- a/yarn-project/sequencer-client/src/publisher/sequencer-publisher.test.ts
+++ b/yarn-project/sequencer-client/src/publisher/sequencer-publisher.test.ts
@@ -55,10 +55,11 @@ describe('SequencerPublisher', () => {
   let publisher: SequencerPublisher;
 
   const GAS_GUESS = 300_000n;
+  const l1RpcUrls = [`http://127.0.0.1:8545`];
 
   beforeEach(async () => {
     mockBlobSinkServer = undefined;
-    blobSinkClient = new HttpBlobSinkClient({ blobSinkUrl: BLOB_SINK_URL });
+    blobSinkClient = new HttpBlobSinkClient({ blobSinkUrl: BLOB_SINK_URL, l1RpcUrls, l1ChainId: 31337 });
 
     l2Block = await L2Block.random(42);
 
@@ -80,7 +81,7 @@ describe('SequencerPublisher', () => {
     l1TxUtils.getBlockNumber.mockResolvedValue(1n);
     const config = {
       blobSinkUrl: BLOB_SINK_URL,
-      l1RpcUrls: [`http://127.0.0.1:8545`],
+      l1RpcUrls,
       l1ChainId: 1,
       publisherPrivateKey: `0xac0974bec39a17e36ba4a6b4d238ff944bacb478cbed5efcae784d7bf4f2ff80`,
       l1Contracts: {

--- a/yarn-project/stdlib/src/config/config.ts
+++ b/yarn-project/stdlib/src/config/config.ts
@@ -1,5 +1,5 @@
 import { l1ContractAddressesMapping } from '@aztec/ethereum/l1-contract-addresses';
-import type { ConfigMappingsType } from '@aztec/foundation/config';
+import { type ConfigMappingsType, safeParsePositiveInteger } from '@aztec/foundation/config';
 import { EthAddress } from '@aztec/foundation/eth-address';
 
 export { type AllowedElement, type SequencerConfig, SequencerConfigSchema } from '../interfaces/configs.js';
@@ -20,13 +20,7 @@ export const chainConfigMappings: ConfigMappingsType<ChainConfig> = {
   version: {
     env: 'VERSION',
     description: 'The version of the rollup.',
-    parseEnv: (val: string) => {
-      const parsed = parseInt(val, 10);
-      if (Number.isSafeInteger(parsed)) {
-        return parsed;
-      }
-      throw new Error('VERSION must be a number: ' + val);
-    },
+    parseEnv: (val: string) => safeParsePositiveInteger(val),
   },
   l1Contracts: {
     description: 'The deployed L1 contract addresses',

--- a/yarn-project/stdlib/src/config/config.ts
+++ b/yarn-project/stdlib/src/config/config.ts
@@ -25,7 +25,7 @@ export const chainConfigMappings: ConfigMappingsType<ChainConfig> = {
       if (Number.isSafeInteger(parsed)) {
         return parsed;
       }
-      throw new Error('Hey, not a number: ' + val);
+      throw new Error('VERSION must be a number: ' + val);
     },
   },
   l1Contracts: {

--- a/yarn-project/stdlib/src/config/config.ts
+++ b/yarn-project/stdlib/src/config/config.ts
@@ -20,7 +20,13 @@ export const chainConfigMappings: ConfigMappingsType<ChainConfig> = {
   version: {
     env: 'VERSION',
     description: 'The version of the rollup.',
-    parseEnv: (val: string) => (Number.isSafeInteger(parseInt(val, 10)) ? parseInt(val, 10) : undefined),
+    parseEnv: (val: string) => {
+      const parsed = parseInt(val, 10);
+      if (Number.isSafeInteger(parsed)) {
+        return parsed;
+      }
+      throw new Error('Hey, not a number: ' + val);
+    },
   },
   l1Contracts: {
     description: 'The deployed L1 contract addresses',

--- a/yarn-project/telemetry-client/src/config.ts
+++ b/yarn-project/telemetry-client/src/config.ts
@@ -13,17 +13,17 @@ export const telemetryClientConfigMappings: ConfigMappingsType<TelemetryClientCo
   metricsCollectorUrl: {
     env: 'OTEL_EXPORTER_OTLP_METRICS_ENDPOINT',
     description: 'The URL of the telemetry collector for metrics',
-    parseEnv: (val: string) => val && new URL(val),
+    parseEnv: (val: string) => (val ? new URL(val) : undefined),
   },
   tracesCollectorUrl: {
     env: 'OTEL_EXPORTER_OTLP_TRACES_ENDPOINT',
     description: 'The URL of the telemetry collector for traces',
-    parseEnv: (val: string) => val && new URL(val),
+    parseEnv: (val: string) => (val ? new URL(val) : undefined),
   },
   logsCollectorUrl: {
     env: 'OTEL_EXPORTER_OTLP_LOGS_ENDPOINT',
     description: 'The URL of the telemetry collector for logs',
-    parseEnv: (val: string) => val && new URL(val),
+    parseEnv: (val: string) => (val ? new URL(val) : undefined),
   },
   otelCollectIntervalMs: {
     env: 'OTEL_COLLECT_INTERVAL_MS',


### PR DESCRIPTION
This should fix the discv5 errors we've been seeing in master-rc-1 and also type checks the whole config read from env vars.
