### PR TITLE
chore(avm): remove check_interaction from tests

### DIFF
--- a/barretenberg/cpp/src/barretenberg/vm2/constraining/relations/address_derivation.test.cpp
+++ b/barretenberg/cpp/src/barretenberg/vm2/constraining/relations/address_derivation.test.cpp
@@ -157,17 +157,6 @@ TEST(AddressDerivationConstrainingTest, WithInteractions)
     LookupIntoDynamicTableSequential<lookup_address_ecadd::Settings>().process(trace);
 
     check_relation<address_derivation_relation>(trace);
-    check_interaction<lookup_salted_initialization_hash_poseidon2_0>(trace);
-    check_interaction<lookup_salted_initialization_hash_poseidon2_1>(trace);
-    check_interaction<lookup_partial_address_poseidon2>(trace);
-    check_interaction<lookup_public_keys_hash_poseidon2_0>(trace);
-    check_interaction<lookup_public_keys_hash_poseidon2_1>(trace);
-    check_interaction<lookup_public_keys_hash_poseidon2_2>(trace);
-    check_interaction<lookup_public_keys_hash_poseidon2_3>(trace);
-    check_interaction<lookup_public_keys_hash_poseidon2_4>(trace);
-    check_interaction<lookup_public_preaddress_poseidon2>(trace);
-    check_interaction<lookup_public_preaddress_scalar_mul>(trace);
-    check_interaction<lookup_address_ecadd>(trace);
 }
 
 } // namespace

--- a/barretenberg/cpp/src/barretenberg/vm2/constraining/relations/bc_hashing.test.cpp
+++ b/barretenberg/cpp/src/barretenberg/vm2/constraining/relations/bc_hashing.test.cpp
@@ -97,7 +97,6 @@ TEST(BytecodeHashingConstrainingTest, PoseidonInteractions)
     tracegen::LookupIntoDynamicTableSequential<bc_hashing_lookup_relation::Settings>().process(trace);
 
     check_relation<bc_hashing>(trace);
-    check_interaction<bc_hashing_lookup_relation>(trace);
 }
 
 TEST(BytecodeHashingConstrainingTest, BytecodeInteractions)
@@ -118,8 +117,6 @@ TEST(BytecodeHashingConstrainingTest, BytecodeInteractions)
     tracegen::LookupIntoDynamicTableSequential<length_iv_relation::Settings>().process(trace);
 
     check_relation<bc_hashing>(trace);
-    check_interaction<bc_decomp_lookup_relation>(trace);
-    check_interaction<length_iv_relation>(trace);
 }
 
 TEST(BytecodeHashingConstrainingTest, NegativeInvalidStartAfterLatch)

--- a/barretenberg/cpp/src/barretenberg/vm2/constraining/relations/bitwise.test.cpp
+++ b/barretenberg/cpp/src/barretenberg/vm2/constraining/relations/bitwise.test.cpp
@@ -350,8 +350,6 @@ TEST(BitwiseConstrainingTest, MixedOperationsInteractions)
     LookupIntoIndexedByClk<lookup_bitwise_integral_tag_length::Settings>().process(trace);
 
     check_relation<bitwise>(trace);
-    check_interaction<lookup_bitwise_byte_operations>(trace);
-    check_interaction<lookup_bitwise_integral_tag_length>(trace);
 }
 
 } // namespace

--- a/barretenberg/cpp/src/barretenberg/vm2/constraining/relations/class_id_derivation.test.cpp
+++ b/barretenberg/cpp/src/barretenberg/vm2/constraining/relations/class_id_derivation.test.cpp
@@ -99,9 +99,6 @@ TEST(ClassIdDerivationConstrainingTest, WithHashInteraction)
 
     LookupIntoDynamicTableSequential<lookup_poseidon2_hash_0::Settings>().process(trace);
     LookupIntoDynamicTableSequential<lookup_poseidon2_hash_1::Settings>().process(trace);
-
-    check_interaction<lookup_poseidon2_hash_0>(trace);
-    check_interaction<lookup_poseidon2_hash_1>(trace);
 }
 
 // TODO: This should probably be refined and moved to bc_retrieval test file once that exists
@@ -139,7 +136,6 @@ TEST(ClassIdDerivationConstrainingTest, WithRetrievalInteraction)
                                        trace);
 
     LookupIntoDynamicTableSequential<lookup_bc_retrieval::Settings>().process(trace);
-    check_interaction<lookup_bc_retrieval>(trace);
 }
 
 } // namespace

--- a/barretenberg/cpp/src/barretenberg/vm2/constraining/relations/ecc.test.cpp
+++ b/barretenberg/cpp/src/barretenberg/vm2/constraining/relations/ecc.test.cpp
@@ -564,12 +564,6 @@ TEST(ScalarMulConstrainingTest, MulInteractions)
     LookupIntoDynamicTableGeneric<lookup_scalar_mul_double_relation::Settings>().process(trace);
     LookupIntoDynamicTableGeneric<lookup_scalar_mul_add_relation::Settings>().process(trace);
     LookupIntoDynamicTableGeneric<lookup_scalar_mul_to_radix_relation::Settings>().process(trace);
-
-    check_relation<scalar_mul>(trace);
-    check_relation<ecc>(trace);
-    check_interaction<lookup_scalar_mul_double_relation>(trace);
-    check_interaction<lookup_scalar_mul_add_relation>(trace);
-    check_interaction<lookup_scalar_mul_to_radix_relation>(trace);
 }
 
 TEST(ScalarMulConstrainingTest, MulAddInteractionsInfinity)
@@ -597,8 +591,6 @@ TEST(ScalarMulConstrainingTest, MulAddInteractionsInfinity)
 
     check_relation<scalar_mul>(trace);
     check_relation<ecc>(trace);
-    check_interaction<lookup_scalar_mul_double_relation>(trace);
-    check_interaction<lookup_scalar_mul_add_relation>(trace);
 }
 
 TEST(ScalarMulConstrainingTest, NegativeMulAddInteractions)
@@ -625,12 +617,6 @@ TEST(ScalarMulConstrainingTest, NegativeMulAddInteractions)
         "Failed.*SCALAR_MUL_DOUBLE. Could not find tuple in destination.");
     EXPECT_THROW_WITH_MESSAGE(LookupIntoDynamicTableGeneric<lookup_scalar_mul_add_relation::Settings>().process(trace),
                               "Failed.*SCALAR_MUL_ADD. Could not find tuple in destination.");
-
-    check_relation<scalar_mul>(trace);
-    EXPECT_THROW_WITH_MESSAGE(check_interaction<lookup_scalar_mul_double_relation>(trace),
-                              "Relation.*SCALAR_MUL_DOUBLE.* ACCUMULATION.* is non-zero");
-    EXPECT_THROW_WITH_MESSAGE(check_interaction<lookup_scalar_mul_add_relation>(trace),
-                              "Relation.*SCALAR_MUL_ADD.* ACCUMULATION.* is non-zero");
 }
 
 TEST(ScalarMulConstrainingTest, NegativeMulRadixInteractions)
@@ -657,8 +643,6 @@ TEST(ScalarMulConstrainingTest, NegativeMulRadixInteractions)
         "Failed.*SCALAR_MUL_TO_RADIX. Could not find tuple in destination.");
 
     check_relation<scalar_mul>(trace);
-    EXPECT_THROW_WITH_MESSAGE(check_interaction<lookup_scalar_mul_to_radix_relation>(trace),
-                              "Relation.*SCALAR_MUL_TO_RADIX.* ACCUMULATION.* is non-zero");
 }
 
 TEST(ScalarMulConstrainingTest, NegativeDisableSel)

--- a/barretenberg/cpp/src/barretenberg/vm2/constraining/relations/field_gt.test.cpp
+++ b/barretenberg/cpp/src/barretenberg/vm2/constraining/relations/field_gt.test.cpp
@@ -121,8 +121,6 @@ TEST_P(InteractionsTests, InteractionsWithRangeCheck)
     LookupIntoDynamicTableSequential<lookup_a_lo_range::Settings>().process(trace);
 
     check_relation<ff_gt>(trace);
-    check_interaction<lookup_a_hi_range>(trace);
-    check_interaction<lookup_a_lo_range>(trace);
 }
 
 INSTANTIATE_TEST_SUITE_P(FieldGreaterThanConstrainingTest, InteractionsTests, ::testing::ValuesIn(comparison_tests));

--- a/barretenberg/cpp/src/barretenberg/vm2/constraining/relations/merkle_check.test.cpp
+++ b/barretenberg/cpp/src/barretenberg/vm2/constraining/relations/merkle_check.test.cpp
@@ -581,8 +581,6 @@ TEST(MerkleCheckConstrainingTest, ReadWithInteractions)
     LookupIntoDynamicTableSequential<lookup_poseidon2_read_hash::Settings>().process(trace);
     LookupIntoDynamicTableSequential<lookup_poseidon2_write_hash::Settings>().process(trace);
 
-    check_interaction<lookup_poseidon2_read_hash>(trace);
-    check_interaction<lookup_poseidon2_write_hash>(trace);
     check_relation<merkle_check>(trace);
 
     // Negative test - now corrupt the trace and verify it fails
@@ -590,10 +588,7 @@ TEST(MerkleCheckConstrainingTest, ReadWithInteractions)
 
     EXPECT_THROW_WITH_MESSAGE(LookupIntoDynamicTableSequential<lookup_poseidon2_read_hash::Settings>().process(trace),
                               "Failed.*LOOKUP_MERKLE_CHECK_MERKLE_POSEIDON2.* Could not find tuple in destination");
-    EXPECT_THROW_WITH_MESSAGE(check_interaction<lookup_poseidon2_read_hash>(trace),
-                              "Relation.*LOOKUP_MERKLE_CHECK_MERKLE_POSEIDON2.* ACCUMULATION.* is non-zero");
     LookupIntoDynamicTableSequential<lookup_poseidon2_write_hash::Settings>().process(trace);
-    check_interaction<lookup_poseidon2_write_hash>(trace);
 }
 
 TEST(MerkleCheckConstrainingTest, WriteWithInteractions)
@@ -626,8 +621,6 @@ TEST(MerkleCheckConstrainingTest, WriteWithInteractions)
     LookupIntoDynamicTableSequential<lookup_poseidon2_read_hash::Settings>().process(trace);
     LookupIntoDynamicTableSequential<lookup_poseidon2_write_hash::Settings>().process(trace);
 
-    check_interaction<lookup_poseidon2_read_hash>(trace);
-    check_interaction<lookup_poseidon2_write_hash>(trace);
     check_relation<merkle_check>(trace);
 
     // Negative test - now corrupt the trace and verify it fails
@@ -637,14 +630,10 @@ TEST(MerkleCheckConstrainingTest, WriteWithInteractions)
     EXPECT_THROW_WITH_MESSAGE(
         LookupIntoDynamicTableSequential<lookup_poseidon2_read_hash::Settings>().process(trace),
         "Failed.*LOOKUP_MERKLE_CHECK_MERKLE_POSEIDON2_READ.* Could not find tuple in destination");
-    EXPECT_THROW_WITH_MESSAGE(check_interaction<lookup_poseidon2_read_hash>(trace),
-                              "Relation.*LOOKUP_MERKLE_CHECK_MERKLE_POSEIDON2_READ.* ACCUMULATION.* is non-zero");
 
-    EXPECT_THROW_WITH_MESSAGE(
-        LookupIntoDynamicTableSequential<lookup_poseidon2_write_hash::Settings>().process(trace),
-        "Failed.*LOOKUP_MERKLE_CHECK_MERKLE_POSEIDON2_WRITE.* Could not find tuple in destination");
-    EXPECT_THROW_WITH_MESSAGE(check_interaction<lookup_poseidon2_write_hash>(trace),
-                              "Relation.*LOOKUP_MERKLE_CHECK_MERKLE_POSEIDON2_WRITE.* ACCUMULATION.* is non-zero");
+    EXPECT_THROW_WITH_MESSAGE(LookupIntoDynamicTableSequential<lookup_poseidon2_write_hash::Settings>().process(trace),
+                              "Failed.*LOOKUP_MERKLE_CHECK_MERKLE_POSEIDON2_WRITE.* Could not find tuple in "
+                              "destination");
 }
 
 TEST(MerkleCheckConstrainingTest, MultipleWithTracegen)
@@ -738,8 +727,6 @@ TEST(MerkleCheckConstrainingTest, MultipleWithInteractions)
 
     LookupIntoDynamicTableSequential<lookup_poseidon2_read_hash::Settings>().process(trace);
     LookupIntoDynamicTableSequential<lookup_poseidon2_write_hash::Settings>().process(trace);
-    check_interaction<lookup_poseidon2_read_hash>(trace);
-    check_interaction<lookup_poseidon2_write_hash>(trace);
 
     check_relation<merkle_check>(trace);
 }

--- a/barretenberg/cpp/src/barretenberg/vm2/constraining/relations/poseidon2.test.cpp
+++ b/barretenberg/cpp/src/barretenberg/vm2/constraining/relations/poseidon2.test.cpp
@@ -185,7 +185,6 @@ TEST(Poseidon2ConstrainingTest, HashPermInteractions)
 
     check_relation<poseidon2_hash>(trace);
     check_relation<poseidon2_perm>(trace);
-    check_interaction<lookup_poseidon2_perm_relation>(trace);
 }
 
 TEST(Poseidon2ConstrainingTest, NegativeHashPermInteractions)
@@ -215,8 +214,6 @@ TEST(Poseidon2ConstrainingTest, NegativeHashPermInteractions)
     EXPECT_EQ(trace.get_num_rows(), /*start_row=*/1 + /*first_invocation=*/2);
 
     check_relation<poseidon2_hash>(trace);
-    EXPECT_THROW_WITH_MESSAGE(check_interaction<lookup_poseidon2_perm_relation>(trace),
-                              "Relation.*POSEIDON2_PERM.* ACCUMULATION.* is non-zero");
 }
 
 } // namespace bb::avm2::constraining

--- a/barretenberg/cpp/src/barretenberg/vm2/constraining/relations/sha256.test.cpp
+++ b/barretenberg/cpp/src/barretenberg/vm2/constraining/relations/sha256.test.cpp
@@ -123,7 +123,6 @@ TEST(Sha256ConstrainingTest, Interaction)
     LookupIntoIndexedByClk<lookup_sha256_round_relation::Settings>().process(trace);
 
     check_relation<sha256>(trace);
-    check_interaction<lookup_sha256_round_relation>(trace);
 }
 
 } // namespace

--- a/barretenberg/cpp/src/barretenberg/vm2/constraining/relations/to_radix.test.cpp
+++ b/barretenberg/cpp/src/barretenberg/vm2/constraining/relations/to_radix.test.cpp
@@ -240,11 +240,6 @@ TEST(ToRadixConstrainingTest, ToLeBitsInteractions)
     LookupIntoIndexedByClk<lookup_limb_p_diff_range::Settings>().process(trace);
 
     check_relation<to_radix>(trace);
-    check_interaction<lookup_limb_range>(trace);
-    check_interaction<lookup_limb_less_than_radix_range>(trace);
-    check_interaction<lookup_fetch_safe_limbs>(trace);
-    check_interaction<lookup_fetch_p_limb>(trace);
-    check_interaction<lookup_limb_p_diff_range>(trace);
 }
 
 TEST(ToRadixConstrainingTest, ToLeRadixInteractions)
@@ -275,11 +270,6 @@ TEST(ToRadixConstrainingTest, ToLeRadixInteractions)
     LookupIntoIndexedByClk<lookup_limb_p_diff_range::Settings>().process(trace);
 
     check_relation<to_radix>(trace);
-    check_interaction<lookup_limb_range>(trace);
-    check_interaction<lookup_limb_less_than_radix_range>(trace);
-    check_interaction<lookup_fetch_safe_limbs>(trace);
-    check_interaction<lookup_fetch_p_limb>(trace);
-    check_interaction<lookup_limb_p_diff_range>(trace);
 }
 
 TEST(ToRadixConstrainingTest, NegativeOverflowCheck)


### PR DESCRIPTION
We think this gets sufficiently tested with the lookup builders (once https://github.com/AztecProtocol/aztec-packages/issues/13140 is solved).
