### PR TITLE
feat(noir): Allow missing optional fields in msgpack

### DIFF
--- a/barretenberg/cpp/src/barretenberg/dsl/acir_format/acir_to_constraint_buf.cpp
+++ b/barretenberg/cpp/src/barretenberg/dsl/acir_format/acir_to_constraint_buf.cpp
@@ -32,7 +32,7 @@ using namespace bb;
 template <typename T>
 T deserialize_any_format(std::vector<uint8_t> const& buf,
                          std::function<T(msgpack::object const&)> decode_msgpack,
-                         std::function<T(std::vector<uint8_t>)> decode_binpack)
+                         std::function<T(std::vector<uint8_t>)> decode_bincode)
 {
     // We can't rely on exceptions to try to deserialize binpack, falling back to
     // msgpack if it fails, because exceptions are (or were) not supported in Wasm
@@ -67,12 +67,12 @@ T deserialize_any_format(std::vector<uint8_t> const& buf,
                 }
             }
         }
-        // `buf[0] == 0` would indicate bincode starting with a format byte,
+        // `buf[0] == 1` would indicate bincode starting with a format byte,
         // but if it's a coincidence and it fails to parse then we can't recover
         // from it, so let's just acknowledge that for now we don't want to
         // exercise this code path and treat the whole data as bincode.
     }
-    return decode_binpack(buf);
+    return decode_bincode(buf);
 }
 
 /**

--- a/barretenberg/cpp/src/barretenberg/dsl/acir_format/serde/witness_stack.hpp
+++ b/barretenberg/cpp/src/barretenberg/dsl/acir_format/serde/witness_stack.hpp
@@ -5,6 +5,47 @@
 #include "serde.hpp"
 
 namespace Witnesses {
+struct Helpers {
+    static std::map<std::string, msgpack::object const*> make_kvmap(msgpack::object const& o, std::string const& name)
+    {
+        if (o.type != msgpack::type::MAP) {
+            std::cerr << o << std::endl;
+            throw_or_abort("expected MAP for " + name);
+        }
+        std::map<std::string, msgpack::object const*> kvmap;
+        for (uint32_t i = 0; i < o.via.map.size; ++i) {
+            if (o.via.map.ptr[i].key.type != msgpack::type::STR) {
+                std::cerr << o << std::endl;
+                throw_or_abort("expected STR for keys of " + name);
+            }
+            kvmap.emplace(std::string(o.via.map.ptr[i].key.via.str.ptr, o.via.map.ptr[i].key.via.str.size),
+                          &o.via.map.ptr[i].val);
+        }
+        return kvmap;
+    }
+    template <typename T>
+    static void conv_fld_from_kvmap(std::map<std::string, msgpack::object const*> const& kvmap,
+                                    std::string const& struct_name,
+                                    std::string const& field_name,
+                                    T& field,
+                                    bool is_optional)
+    {
+        auto it = kvmap.find(field_name);
+        if (it != kvmap.end()) {
+            try {
+                it->second->convert(field);
+            } catch (const msgpack::type_error&) {
+                std::cerr << *it->second << std::endl;
+                throw_or_abort("error converting into field " + struct_name + "::" + field_name);
+            }
+        } else if (!is_optional) {
+            throw_or_abort("missing field: " + struct_name + "::" + field_name);
+        }
+    }
+};
+} // namespace Witnesses
+
+namespace Witnesses {
 
 struct Witness {
     uint32_t value;
@@ -55,7 +96,20 @@ struct StackItem {
     std::vector<uint8_t> bincodeSerialize() const;
     static StackItem bincodeDeserialize(std::vector<uint8_t>);
 
-    MSGPACK_FIELDS(index, witness);
+    void msgpack_pack(auto& packer) const
+    {
+        packer.pack_map(2);
+        packer.pack(std::make_pair("index", index));
+        packer.pack(std::make_pair("witness", witness));
+    }
+
+    void msgpack_unpack(msgpack::object const& o)
+    {
+        auto name = "StackItem";
+        auto kvmap = Helpers::make_kvmap(o, name);
+        Helpers::conv_fld_from_kvmap(kvmap, name, "index", index, false);
+        Helpers::conv_fld_from_kvmap(kvmap, name, "witness", witness, false);
+    }
 };
 
 struct WitnessStack {
@@ -65,7 +119,18 @@ struct WitnessStack {
     std::vector<uint8_t> bincodeSerialize() const;
     static WitnessStack bincodeDeserialize(std::vector<uint8_t>);
 
-    MSGPACK_FIELDS(stack);
+    void msgpack_pack(auto& packer) const
+    {
+        packer.pack_map(1);
+        packer.pack(std::make_pair("stack", stack));
+    }
+
+    void msgpack_unpack(msgpack::object const& o)
+    {
+        auto name = "WitnessStack";
+        auto kvmap = Helpers::make_kvmap(o, name);
+        Helpers::conv_fld_from_kvmap(kvmap, name, "stack", stack, false);
+    }
 };
 
 } // end of namespace Witnesses


### PR DESCRIPTION
Followup for https://github.com/AztecProtocol/aztec-packages/pull/12841

Changes code generation for msgpack so that it doesn't throw an error if an optional field of a `struct` is not present in the data. This is to allow @TomAFrench and @asterite to delete `Opcode::MemoryOp::predicate` which is an optional field that we no longer use. Removing such a field should be a non-breaking change, as the field was optional to begin with, so while even if it's present in C++ it should already handle it being empty. 

Unfortunately the `msgpack-c` library as far as I can see [would throw an error](https://github.com/AztecProtocol/msgpack-c/blob/54e9865b84bbdc73cfbf8d1d437dbf769b64e386/include/msgpack/v1/adaptor/detail/cpp11_define_map.hpp#L33-L45) if the optional field would not be present in the data as NIL. 

For this to work the PR re-introduces the `Helpers` and enumerates fields explicitly, instead of using `MSGPACK_FIELDS`. I changed the unmerged https://github.com/noir-lang/noir/pull/7716 to do codegen with this change.

I rebased https://github.com/AztecProtocol/aztec-packages/pull/13021 on top of this PR to see if it works when msgpack is actually in use.

### Note for future migration path

@ludamad reached out that while the bytecode size increase shown in https://github.com/noir-lang/noir/pull/7690 doesn't seem too bad, and compression compensates for the inclusion of string field names, it's still wasteful to have to parse them, and it would be better to use arrays. 

I established in [tests](https://github.com/noir-lang/noir/pull/7690/files#diff-2d66028e5a8966511a76d1740d752be294c0b6a46e0a567bc2959f91d9ce224bR169-R176) that we what we call `msgpack-compact` format uses arrays for structs, but still tags enums with types. We use a lot of enums, so there is still quite a few strings. Ostensibly we could use [serde attributes](https://serde.rs/container-attrs.html) to shorten names, but it would probably be a nightmare and ugly. 

Nevertheless if we generated C++ code to deal with arrays, we could save some space. 

And if we want to stick to `bincode`, we can use `NOIR_SERIALIZATION_FORMAT=bincode`, which I back ported to the Noir codegen PR, to generate `bincode` with a format byte marker. There is also `bincode-legacy`, but unfortunately we only have one shot at deserialising bincode in C++: if it fails, we can't catch the exception. Therefore the path to be able to use the bincode format marker is:
1. Release `bb` which can handle the `msgpack` format (which has a probe, doesn't have to throw)
2. Start producing msgpack data from `nargo` 
3. Stop accepting unmarked bincode in `bb` and look for format byte == 1 to show that bincode is in use
4. Tell `nargo` which format to use

EDIT: Unfortunately if we use `binpack` with today's data types it forces us to parse the Brillig part, as established by https://github.com/AztecProtocol/aztec-packages/pull/13143 which would mean the Noir team can't make any changes to Brillig opcodes without breaking `bb`. We would need to change the format again to use two tier encoding, or use msgpack arrays.

