### PR TITLE
feat: Do not deserialize Brillig even with bincode

### DIFF
--- a/barretenberg/cpp/src/barretenberg/dsl/acir_format/acir_to_constraint_buf.cpp
+++ b/barretenberg/cpp/src/barretenberg/dsl/acir_format/acir_to_constraint_buf.cpp
@@ -83,7 +83,7 @@ Acir::Program deserialize_program(std::vector<uint8_t> const& buf)
 {
     return deserialize_any_format<Acir::Program>(
         buf,
-        [](auto o) -> Acir::Program {
+        [](auto o) {
             Acir::Program program;
             try {
                 // Deserialize into a partial structure that ignores the Brillig parts,
@@ -97,7 +97,12 @@ Acir::Program deserialize_program(std::vector<uint8_t> const& buf)
             }
             return program;
         },
-        &Acir::Program::bincodeDeserialize);
+        [](auto buf) {
+            auto program_wob = Acir::ProgramWithoutBrillig::bincodeDeserialize(buf);
+            Acir::Program program;
+            program.functions = program_wob.functions;
+            return program;
+        });
 }
 
 /**


### PR DESCRIPTION
Followup for https://github.com/AztecProtocol/aztec-packages/pull/12841

I missed this opportunity: we don't need the Brillig parts in Barretenberg, and I _think_ it's okay to ignore the last field in the struct with `bincode`. 

### Nope 

Unfortunately this doesn't work:

```
17:30:59 command failed: /home/aztec-dev/aztec-packages/barretenberg/cpp/build/bin/bb prove --scheme ultra_honk --init_kzg_accumulator  --output_format fields --write_vk -o /tmp/tmp.nateEgQBpw -b ./target/program.json -w ./target/witness.gz (exit: 1)
17:30:59 --- stdout ---
17:30:59 --- stderr ---
17:30:59 Scheme is: ultra_honk
17:30:59 Some input bytes were not read
```

That means if we want to ignore the brillig part we have to use msgpack, or add another kind of format to `nargo` which is binpack without brillig 😞 

Or we have to have a multi-stage serialization scheme where we treat the brillig part as opaque bytes, and don't further deserialise in Barretenberg.
