### PR TITLE
Fix critical overflow in curve scalar multiplication

### DIFF
--- a/barretenberg/cpp/src/barretenberg/ecc/groups/element_impl.hpp
+++ b/barretenberg/cpp/src/barretenberg/ecc/groups/element_impl.hpp
@@ -607,7 +607,7 @@ element<Fq, Fr, T> element<Fq, Fr, T>::mul_without_endomorphism(const Fr& scalar
     const uint64_t maximum_set_bit = converted_scalar.get_msb();
     // This is simpler and doublings of infinity should be fast. We should think if we want to defend against the
     // timing leak here (if used with ECDSA it can sometimes lead to private key compromise)
-    for (uint64_t i = maximum_set_bit - 1; i < maximum_set_bit; --i) {
+    for (int64_t i = maximum_set_bit - 1; i >= 0; --i) {
         accumulator.self_dbl();
         if (converted_scalar.get_bit(i)) {
             accumulator += *this;


### PR DESCRIPTION
Fixed a critical bug in element::mul_without_endomorphism where an unsigned integer underflow could occur in the loop condition. Changed the loop variable type from uint64_t to int64_t and corrected the loop termination condition from 'i < maximum_set_bit' to 'i >= 0'. This prevents potential infinite loops or cryptographic calculation errors that could lead to security vulnerabilities.