### PR TITLE
feat: making SyncDataProvider throw before sync

### DIFF
--- a/yarn-project/pxe/src/pxe_oracle_interface/pxe_oracle_interface.ts
+++ b/yarn-project/pxe/src/pxe_oracle_interface/pxe_oracle_interface.ts
@@ -649,10 +649,7 @@ export class PXEOracleInterface implements ExecutionDataProvider {
     // in time of the locally synced state.
     // Note that while this technically results in historical queries, we perform it at the latest locally synced block
     // number which *should* be recent enough to be available, even for non-archive nodes.
-    const syncedBlockNumber = (await this.syncDataProvider.getBlockNumber())!;
-    if (syncedBlockNumber === undefined) {
-      throw new Error(`Attempted to deliver a note with an unsynchronized PXE - this should never happen`);
-    }
+    const syncedBlockNumber = await this.syncDataProvider.getBlockNumber();
 
     // By computing siloed and unique note hashes ourselves we prevent contracts from interfering with the note storage
     // of other contracts, which would constitute a security breach.

--- a/yarn-project/pxe/src/storage/sync_data_provider/sync_data_provider.ts
+++ b/yarn-project/pxe/src/storage/sync_data_provider/sync_data_provider.ts
@@ -16,10 +16,10 @@ export class SyncDataProvider implements DataProvider {
     await this.#synchronizedHeader.set(header.toBuffer());
   }
 
-  async getBlockNumber(): Promise<number | undefined> {
+  async getBlockNumber(): Promise<number> {
     const headerBuffer = await this.#synchronizedHeader.getAsync();
     if (!headerBuffer) {
-      return undefined;
+      throw new Error(`Trying to get block number with a not-yet-synchronized PXE - this should never happen`);
     }
 
     return Number(BlockHeader.fromBuffer(headerBuffer).globalVariables.blockNumber.toBigInt());

--- a/yarn-project/pxe/src/synchronizer/synchronizer.ts
+++ b/yarn-project/pxe/src/synchronizer/synchronizer.ts
@@ -1,4 +1,3 @@
-import { INITIAL_L2_BLOCK_NUM } from '@aztec/constants';
 import { type Logger, createLogger } from '@aztec/foundation/log';
 import type { L2TipsKVStore } from '@aztec/kv-store/stores';
 import { L2BlockStream, type L2BlockStreamEvent, type L2BlockStreamEventHandler } from '@aztec/stdlib/block';
@@ -10,13 +9,11 @@ import type { SyncDataProvider } from '../storage/sync_data_provider/sync_data_p
 import type { TaggingDataProvider } from '../storage/tagging_data_provider/tagging_data_provider.js';
 
 /**
- * The Synchronizer class manages the synchronization with the aztec node, allowing PXE to retrieve the
- * latest block header and handle reorgs.
- * It provides methods to trigger a sync and get the block number we are syncec to
- * details, and fetch transactions by hash.
+ * The Synchronizer class orchestrates synchronization between the PXE and Aztec node, maintaining an up-to-date
+ * view of the L2 chain state. It handles block header retrieval, chain reorganizations, and provides an interface
+ * for querying sync status.
  */
 export class Synchronizer implements L2BlockStreamEventHandler {
-  private initialSyncBlockNumber = INITIAL_L2_BLOCK_NUM - 1;
   private log: Logger;
   private isSyncing: Promise<void> | undefined;
   protected readonly blockStream: L2BlockStream;
@@ -80,7 +77,7 @@ export class Synchronizer implements L2BlockStreamEventHandler {
   }
 
   /**
-   * Syncs PXE and the node by dowloading the metadata of the latest blocks, allowing simulations to use
+   * Syncs PXE and the node by downloading the metadata of the latest blocks, allowing simulations to use
    * recent data (e.g. notes), and handling any reorgs that might have occurred.
    */
   public async sync() {
@@ -115,7 +112,7 @@ export class Synchronizer implements L2BlockStreamEventHandler {
     await this.blockStream.sync();
   }
 
-  public async getSynchedBlockNumber() {
-    return (await this.syncDataProvider.getBlockNumber()) ?? this.initialSyncBlockNumber;
+  public getSynchedBlockNumber() {
+    return this.syncDataProvider.getBlockNumber();
   }
 }


### PR DESCRIPTION
Having the getBlockNumber return undefined clutters the rest of the code with error handlers. Hence this change.
