### PR TITLE
fix: incorrect blocknumber in syncTaggedLogs

### DIFF
--- a/yarn-project/pxe/src/pxe_oracle_interface/pxe_oracle_interface.test.ts
+++ b/yarn-project/pxe/src/pxe_oracle_interface/pxe_oracle_interface.test.ts
@@ -76,7 +76,7 @@ describe('PXEOracleInterface', () => {
 
     // PXEOracleInterface.syncTagLogFunction(...) syncs log up to the block number up to which PXE synced. We set
     // as sufficiently high sync number here to not interfere with the tests.
-    setSyncedBlockNumber(100);
+    await setSyncedBlockNumber(100);
 
     pxeOracleInterface = new PXEOracleInterface(
       aztecNode,
@@ -409,11 +409,10 @@ describe('PXEOracleInterface', () => {
 
     it('should not sync tagged logs with a blockNumber > maxBlockNumber', async () => {
       const maxBlockNumber = 1;
+      await setSyncedBlockNumber(maxBlockNumber);
+
       const tagIndex = 0;
       await generateMockLogs(tagIndex);
-
-      setSyncedBlockNumber(maxBlockNumber);
-
       const syncedLogs = await pxeOracleInterface.syncTaggedLogs(contractAddress);
 
       // Only NUM_SENDERS + 1 logs should be synched, since the rest have blockNumber > 1
@@ -510,7 +509,7 @@ describe('PXEOracleInterface', () => {
   });
 
   const setSyncedBlockNumber = (blockNumber: number) => {
-    syncDataProvider.setHeader(
+    return syncDataProvider.setHeader(
       BlockHeader.empty({
         globalVariables: GlobalVariables.empty({ blockNumber: new Fr(blockNumber) }),
       }),

--- a/yarn-project/pxe/src/pxe_oracle_interface/pxe_oracle_interface.test.ts
+++ b/yarn-project/pxe/src/pxe_oracle_interface/pxe_oracle_interface.test.ts
@@ -74,7 +74,7 @@ describe('PXEOracleInterface', () => {
     keyStore = new KeyStore(store);
     simulationProvider = new WASMSimulator();
 
-    // PXEOracleInterface.syncTagLogFunction(...) syncs log up to the block number up to which PXE synced. We set
+    // PXEOracleInterface.syncTaggedLogs(...) function syncs logs up to the block number up to which PXE synced. We set
     // as sufficiently high sync number here to not interfere with the tests.
     await setSyncedBlockNumber(100);
 

--- a/yarn-project/pxe/src/pxe_oracle_interface/pxe_oracle_interface.test.ts
+++ b/yarn-project/pxe/src/pxe_oracle_interface/pxe_oracle_interface.test.ts
@@ -78,11 +78,6 @@ describe('PXEOracleInterface', () => {
     capsuleDataProvider = new CapsuleDataProvider(store);
     keyStore = new KeyStore(store);
     simulationProvider = new WASMSimulator();
-
-    // PXEOracleInterface.syncTaggedLogs(...) function syncs logs up to the block number up to which PXE synced. We set
-    // the synced block number to that of the last emitted log to receive all the logs by default.
-    await setSyncedBlockNumber(MAX_BLOCK_NUMBER_OF_A_LOG);
-
     pxeOracleInterface = new PXEOracleInterface(
       aztecNode,
       keyStore,
@@ -99,6 +94,10 @@ describe('PXEOracleInterface', () => {
     // Set up recipient account
     recipient = await keyStore.addAccount(new Fr(69), Fr.random());
     await addressDataProvider.addCompleteAddress(recipient);
+
+    // PXEOracleInterface.syncTaggedLogs(...) function syncs logs up to the block number up to which PXE synced. We set
+    // the synced block number to that of the last emitted log to receive all the logs by default.
+    await setSyncedBlockNumber(MAX_BLOCK_NUMBER_OF_A_LOG);
   });
 
   describe('sync tagged logs', () => {

--- a/yarn-project/pxe/src/pxe_oracle_interface/pxe_oracle_interface.test.ts
+++ b/yarn-project/pxe/src/pxe_oracle_interface/pxe_oracle_interface.test.ts
@@ -164,7 +164,7 @@ describe('PXEOracleInterface', () => {
     it('should sync tagged logs', async () => {
       const tagIndex = 0;
       await generateMockLogs(tagIndex);
-      const syncedLogs = await pxeOracleInterface.syncTaggedLogs(contractAddress, 3);
+      const syncedLogs = await pxeOracleInterface.syncTaggedLogs(contractAddress);
       // We expect to have all logs intended for the recipient, one per sender + 1 with a duplicated tag for the first
       // one + half of the logs for the second index
       expect(syncedLogs.get(recipient.address.toString())).toHaveLength(NUM_SENDERS + 1 + NUM_SENDERS / 2);
@@ -260,7 +260,7 @@ describe('PXEOracleInterface', () => {
     it('should sync tagged logs with a sender index offset', async () => {
       const tagIndex = 5;
       await generateMockLogs(tagIndex);
-      const syncedLogs = await pxeOracleInterface.syncTaggedLogs(contractAddress, 3);
+      const syncedLogs = await pxeOracleInterface.syncTaggedLogs(contractAddress);
       // We expect to have all logs intended for the recipient, one per sender + 1 with a duplicated tag for the first one + half of the logs for the second index
       expect(syncedLogs.get(recipient.address.toString())).toHaveLength(NUM_SENDERS + 1 + NUM_SENDERS / 2);
 
@@ -303,7 +303,7 @@ describe('PXEOracleInterface', () => {
         recipient.address,
       );
 
-      const syncedLogs = await pxeOracleInterface.syncTaggedLogs(contractAddress, 3);
+      const syncedLogs = await pxeOracleInterface.syncTaggedLogs(contractAddress);
 
       // Even if our index as recipient is higher than what the sender sent, we should be able to find the logs
       // since the window starts at Math.max(0, 2 - window_size) = 0
@@ -342,7 +342,7 @@ describe('PXEOracleInterface', () => {
         recipient.address,
       );
 
-      const syncedLogs = await pxeOracleInterface.syncTaggedLogs(contractAddress, 3);
+      const syncedLogs = await pxeOracleInterface.syncTaggedLogs(contractAddress);
 
       // Only half of the logs should be synced since we start from index 1 = (11 - window_size), the other half should be skipped
       expect(syncedLogs.get(recipient.address.toString())).toHaveLength(NUM_SENDERS / 2);
@@ -374,7 +374,7 @@ describe('PXEOracleInterface', () => {
         recipient.address,
       );
 
-      let syncedLogs = await pxeOracleInterface.syncTaggedLogs(contractAddress, 3);
+      let syncedLogs = await pxeOracleInterface.syncTaggedLogs(contractAddress);
 
       // No logs should be synced since we start from index 2 = 12 - window_size
       expect(syncedLogs.get(recipient.address.toString())).toHaveLength(0);
@@ -387,7 +387,7 @@ describe('PXEOracleInterface', () => {
       // Wipe the database
       await taggingDataProvider.resetNoteSyncData();
 
-      syncedLogs = await pxeOracleInterface.syncTaggedLogs(contractAddress, 3);
+      syncedLogs = await pxeOracleInterface.syncTaggedLogs(contractAddress);
 
       // First sender should have 2 logs, but keep index 1 since they were built using the same tag
       // Next 4 senders should also have index 1 = offset + 1
@@ -405,7 +405,7 @@ describe('PXEOracleInterface', () => {
     it('should not sync tagged logs with a blockNumber > maxBlockNumber', async () => {
       const tagIndex = 0;
       await generateMockLogs(tagIndex);
-      const syncedLogs = await pxeOracleInterface.syncTaggedLogs(contractAddress, 1);
+      const syncedLogs = await pxeOracleInterface.syncTaggedLogs(contractAddress);
 
       // Only NUM_SENDERS + 1 logs should be synched, since the rest have blockNumber > 1
       expect(syncedLogs.get(recipient.address.toString())).toHaveLength(NUM_SENDERS + 1);
@@ -427,7 +427,7 @@ describe('PXEOracleInterface', () => {
       aztecNode.getLogsByTags.mockImplementation(tags => {
         return Promise.resolve(tags.map(tag => logs[tag.toString()] ?? []));
       });
-      const syncedLogs = await pxeOracleInterface.syncTaggedLogs(contractAddress, 1);
+      const syncedLogs = await pxeOracleInterface.syncTaggedLogs(contractAddress);
 
       // We expect the above log to be discarded, and so none to be synced
       expect(syncedLogs.get(recipient.address.toString())).toHaveLength(0);

--- a/yarn-project/pxe/src/pxe_oracle_interface/pxe_oracle_interface.ts
+++ b/yarn-project/pxe/src/pxe_oracle_interface/pxe_oracle_interface.ts
@@ -432,19 +432,19 @@ export class PXEOracleInterface implements ExecutionDataProvider {
   }
 
   /**
-   * Synchronizes the logs tagged with scoped addresses and all the senders in the address book.
-   * Returns the unsynched logs and updates the indexes of the secrets used to tag them until there are no more logs
-   * to sync.
+   * Synchronizes the logs tagged with scoped addresses and all the senders in the address book. Returns the found logs
+   * and updates the indexes of the secrets used to tag them until there are no more logs to sync.
    * @param contractAddress - The address of the contract that the logs are tagged for
-   * @param recipient - The address of the recipient
-   * @returns A list of encrypted logs tagged with the recipient's address
+   * @param scopes - The scoped addresses to sync logs for. If not provided, all accounts in the address book will be synced.
+   * @returns A map of recipient addresses to a list of encrypted logs.
    */
   public async syncTaggedLogs(
     contractAddress: AztecAddress,
-    maxBlockNumber: number,
     scopes?: AztecAddress[],
   ): Promise<Map<string, TxScopedL2Log[]>> {
     this.log.verbose('Searching for tagged logs', { contract: contractAddress });
+
+    const maxBlockNumber = await this.syncDataProvider.getBlockNumber();
 
     // Ideally this algorithm would be implemented in noir, exposing its building blocks as oracles.
     // However it is impossible at the moment due to the language not supporting nested slices.

--- a/yarn-project/pxe/src/pxe_oracle_interface/pxe_oracle_interface.ts
+++ b/yarn-project/pxe/src/pxe_oracle_interface/pxe_oracle_interface.ts
@@ -435,7 +435,8 @@ export class PXEOracleInterface implements ExecutionDataProvider {
    * Synchronizes the logs tagged with scoped addresses and all the senders in the address book. Returns the found logs
    * and updates the indexes of the secrets used to tag them until there are no more logs to sync.
    * @param contractAddress - The address of the contract that the logs are tagged for
-   * @param scopes - The scoped addresses to sync logs for. If not provided, all accounts in the address book will be synced.
+   * @param scopes - The scoped addresses to sync logs for. If not provided, all accounts in the address book will be
+   * synced.
    * @returns A map of recipient addresses to a list of encrypted logs.
    */
   public async syncTaggedLogs(

--- a/yarn-project/simulator/src/private/execution_data_provider.ts
+++ b/yarn-project/simulator/src/private/execution_data_provider.ts
@@ -229,6 +229,8 @@ export interface ExecutionDataProvider extends CommitmentsDBInterface {
    * Synchronizes the logs tagged with scoped addresses and all the senders in the address book. Returns the found logs
    * and updates the indexes of the secrets used to tag them until there are no more logs to sync.
    * @param contractAddress - The address of the contract that the logs are tagged for
+   * @param scopes - The scoped addresses to sync logs for. If not provided, all accounts in the address book will be
+   * synced.
    * @returns A map of recipient addresses to a list of encrypted logs.
    */
   syncTaggedLogs(contractAddress: AztecAddress, scopes?: AztecAddress[]): Promise<Map<string, TxScopedL2Log[]>>;

--- a/yarn-project/simulator/src/private/execution_data_provider.ts
+++ b/yarn-project/simulator/src/private/execution_data_provider.ts
@@ -226,17 +226,12 @@ export interface ExecutionDataProvider extends CommitmentsDBInterface {
   ): Promise<void>;
 
   /**
-   * Synchronizes the logs tagged with the recipient's address and all the senders in the address book.
-   * Returns the unsynched logs and updates the indexes of the secrets used to tag them until there are no more logs to sync.
+   * Synchronizes the logs tagged with scoped addresses and all the senders in the address book. Returns the found logs
+   * and updates the indexes of the secrets used to tag them until there are no more logs to sync.
    * @param contractAddress - The address of the contract that the logs are tagged for
-   * @param recipient - The address of the recipient
-   * @returns A list of encrypted logs tagged with the recipient's address
+   * @returns A map of recipient addresses to a list of encrypted logs.
    */
-  syncTaggedLogs(
-    contractAddress: AztecAddress,
-    maxBlockNumber: number,
-    scopes?: AztecAddress[],
-  ): Promise<Map<string, TxScopedL2Log[]>>;
+  syncTaggedLogs(contractAddress: AztecAddress, scopes?: AztecAddress[]): Promise<Map<string, TxScopedL2Log[]>>;
 
   /**
    * Processes the tagged logs returned by syncTaggedLogs by decrypting them and storing them in the database.

--- a/yarn-project/simulator/src/private/private_execution.test.ts
+++ b/yarn-project/simulator/src/private/private_execution.test.ts
@@ -298,7 +298,7 @@ describe('Private Execution test suite', () => {
       return Promise.resolve(artifact);
     });
 
-    executionDataProvider.syncTaggedLogs.mockImplementation((_, __, ___) =>
+    executionDataProvider.syncTaggedLogs.mockImplementation((_, __) =>
       Promise.resolve(new Map<string, TxScopedL2Log[]>()),
     );
     executionDataProvider.loadCapsule.mockImplementation((_, __) => Promise.resolve(null));

--- a/yarn-project/simulator/src/private/private_execution_oracle.ts
+++ b/yarn-project/simulator/src/private/private_execution_oracle.ts
@@ -501,11 +501,7 @@ export class PrivateExecutionOracle extends UnconstrainedExecutionOracle {
   }
 
   public override async syncNotes() {
-    const taggedLogsByRecipient = await this.executionDataProvider.syncTaggedLogs(
-      this.contractAddress,
-      this.historicalHeader.globalVariables.blockNumber.toNumber(),
-      this.scopes,
-    );
+    const taggedLogsByRecipient = await this.executionDataProvider.syncTaggedLogs(this.contractAddress, this.scopes);
     for (const [recipient, taggedLogs] of taggedLogsByRecipient.entries()) {
       await this.executionDataProvider.processTaggedLogs(
         this.contractAddress,

--- a/yarn-project/simulator/src/private/unconstrained_execution.test.ts
+++ b/yarn-project/simulator/src/private/unconstrained_execution.test.ts
@@ -82,7 +82,7 @@ describe('Unconstrained Execution test suite', () => {
         })),
       );
 
-      executionDataProvider.syncTaggedLogs.mockImplementation((_, __, ___) =>
+      executionDataProvider.syncTaggedLogs.mockImplementation((_, __) =>
         Promise.resolve(new Map<string, TxScopedL2Log[]>()),
       );
       executionDataProvider.loadCapsule.mockImplementation((_, __) => Promise.resolve(null));

--- a/yarn-project/simulator/src/private/unconstrained_execution_oracle.ts
+++ b/yarn-project/simulator/src/private/unconstrained_execution_oracle.ts
@@ -279,11 +279,7 @@ export class UnconstrainedExecutionOracle extends TypedOracle {
   }
 
   public override async syncNotes() {
-    const taggedLogsByRecipient = await this.executionDataProvider.syncTaggedLogs(
-      this.contractAddress,
-      await this.executionDataProvider.getBlockNumber(),
-      this.scopes,
-    );
+    const taggedLogsByRecipient = await this.executionDataProvider.syncTaggedLogs(this.contractAddress, this.scopes);
 
     for (const [recipient, taggedLogs] of taggedLogsByRecipient.entries()) {
       await this.executionDataProvider.processTaggedLogs(

--- a/yarn-project/txe/src/oracle/txe_oracle.ts
+++ b/yarn-project/txe/src/oracle/txe_oracle.ts
@@ -1083,11 +1083,7 @@ export class TXE implements TypedOracle {
   }
 
   async syncNotes() {
-    const taggedLogsByRecipient = await this.pxeOracleInterface.syncTaggedLogs(
-      this.contractAddress,
-      await this.getBlockNumber(),
-      undefined,
-    );
+    const taggedLogsByRecipient = await this.pxeOracleInterface.syncTaggedLogs(this.contractAddress, undefined);
 
     for (const [recipient, taggedLogs] of taggedLogsByRecipient.entries()) {
       await this.pxeOracleInterface.processTaggedLogs(


### PR DESCRIPTION
In syncTaggedLog we used the block number from AztecNode instead of the one up to which PXE was synced.
