### PR TITLE
fix: separator in pending partial notes capsule array slot

### DIFF
--- a/noir-projects/aztec-nr/aztec/src/discovery/partial_notes.nr
+++ b/noir-projects/aztec-nr/aztec/src/discovery/partial_notes.nr
@@ -26,7 +26,7 @@ pub global MAX_PARTIAL_NOTE_PRIVATE_PACKED_LEN: u32 =
 
 /// The slot in the PXE capsules where we store a `CapsuleArray` of `DeliveredPendingPartialNote`.
 pub global DELIVERED_PENDING_PARTIAL_NOTE_ARRAY_LENGTH_CAPSULES_SLOT: Field = sha256_to_field(
-    "DELIVERED_PENDING_PARTIAL_NOTE_ARRAY_LENGTH_CAPSULES_SLOT".as_bytes(),
+    "AZTEC_NR::DELIVERED_PENDING_PARTIAL_NOTE_ARRAY_LENGTH_CAPSULES_SLOT".as_bytes(),
 );
 
 /// Public logs contain an extra field at the beginning with the address of the contract that emitted them, and partial


### PR DESCRIPTION
As @nventuro pointed out [here](https://github.com/AztecProtocol/aztec-packages/pull/13102#discussion_r2019390557) we should have a separator such that devs under no situation can derive the same slot. If they use the `AZTEC_NR` separator as well then that is not our problem.