### PR TITLE
fix: archiver prune issue and slasher flake

### DIFF
--- a/.test_patterns.yml
+++ b/.test_patterns.yml
@@ -93,7 +93,6 @@ tests:
     owners:
       - *sean
   - regex: "simple e2e_p2p/slashing"
-    skip: true
     owners:
       - *lasse
   - regex: "simple e2e_p2p/validators_sentinel"

--- a/.test_patterns.yml
+++ b/.test_patterns.yml
@@ -92,9 +92,6 @@ tests:
     error_regex: "Received promise resolved instead of rejected"
     owners:
       - *sean
-  - regex: "simple e2e_p2p/slashing"
-    owners:
-      - *lasse
   - regex: "simple e2e_p2p/validators_sentinel"
     error_regex: "TimeoutError: Timeout awaiting blocks mined"
     owners:

--- a/yarn-project/archiver/src/archiver/archiver.ts
+++ b/yarn-project/archiver/src/archiver/archiver.ts
@@ -320,15 +320,15 @@ export class Archiver extends EventEmitter implements ArchiveSource, Traceable {
         throw new Error(`Missing block header ${pruneFrom}`);
       }
 
-      const localPendingSlotNumber = header.globalVariables.slotNumber.toBigInt();
-      const localPendingEpochNumber = getEpochAtSlot(localPendingSlotNumber, this.l1constants);
+      const pruneFromSlotNumber = header.globalVariables.slotNumber.toBigInt();
+      const pruneFromEpochNumber = getEpochAtSlot(pruneFromSlotNumber, this.l1constants);
 
       // Emit an event for listening services to react to the chain prune
       this.emit(L2BlockSourceEvents.L2PruneDetected, {
         type: L2BlockSourceEvents.L2PruneDetected,
         blockNumber: pruneFrom,
-        slotNumber: localPendingSlotNumber,
-        epochNumber: localPendingEpochNumber,
+        slotNumber: pruneFromSlotNumber,
+        epochNumber: pruneFromEpochNumber,
       });
 
       const blocksToUnwind = localPendingBlockNumber - provenBlockNumber;

--- a/yarn-project/end-to-end/src/e2e_p2p/p2p_network.ts
+++ b/yarn-project/end-to-end/src/e2e_p2p/p2p_network.ts
@@ -100,6 +100,7 @@ export class P2PNetworkTest {
         numberOfInitialFundedAccounts: 2,
       },
       {
+        ...initialValidatorConfig,
         aztecEpochDuration: initialValidatorConfig.aztecEpochDuration ?? l1ContractsConfig.aztecEpochDuration,
         ethereumSlotDuration: initialValidatorConfig.ethereumSlotDuration ?? l1ContractsConfig.ethereumSlotDuration,
         aztecSlotDuration: initialValidatorConfig.aztecSlotDuration ?? l1ContractsConfig.aztecSlotDuration,

--- a/yarn-project/end-to-end/src/e2e_p2p/slashing.test.ts
+++ b/yarn-project/end-to-end/src/e2e_p2p/slashing.test.ts
@@ -1,6 +1,6 @@
 import type { AztecNodeService } from '@aztec/aztec-node';
 import { sleep } from '@aztec/aztec.js';
-import { RollupContract } from '@aztec/ethereum';
+import { L1TxUtils, RollupContract } from '@aztec/ethereum';
 import { jsonStringify } from '@aztec/foundation/json-rpc';
 import { RollupAbi, SlashFactoryAbi, SlasherAbi, SlashingProposerAbi } from '@aztec/l1-artifacts';
 
@@ -8,7 +8,7 @@ import { jest } from '@jest/globals';
 import fs from 'fs';
 import os from 'os';
 import path from 'path';
-import { getAddress, getContract, parseEventLogs } from 'viem';
+import { encodeFunctionData, getAddress, getContract, parseEventLogs } from 'viem';
 
 import { shouldCollectMetrics } from '../fixtures/fixtures.js';
 import { createNodes } from '../fixtures/setup_p2p_test.js';
@@ -27,9 +27,11 @@ const DATA_DIR = fs.mkdtempSync(path.join(os.tmpdir(), 'slashing-'));
 describe('e2e_p2p_slashing', () => {
   let t: P2PNetworkTest;
   let nodes: AztecNodeService[];
+  let l1TxUtils: L1TxUtils;
 
   const slashingQuorum = 3;
   const slashingRoundSize = 5;
+  const slashingAmount = 1n;
 
   beforeEach(async () => {
     t = await P2PNetworkTest.create({
@@ -52,6 +54,8 @@ describe('e2e_p2p_slashing', () => {
     await t.applyBaseSnapshots();
     await t.setup();
     await t.removeInitialNode();
+
+    l1TxUtils = new L1TxUtils(t.ctx.deployL1ContractsValues.publicClient, t.ctx.deployL1ContractsValues.walletClient);
   });
 
   afterEach(async () => {
@@ -91,13 +95,22 @@ describe('e2e_p2p_slashing', () => {
       client: t.ctx.deployL1ContractsValues.publicClient,
     });
 
-    const slashingInfo = async () => {
-      const bn = await t.ctx.cheatCodes.eth.blockNumber();
+    const getRoundAndSlotNumber = async () => {
       const slotNumber = await rollup.getSlotNumber();
-      const roundNumber = await slashingProposer.read.computeRound([slotNumber]);
+      return { roundNumber: await slashingProposer.read.computeRound([slotNumber]), slotNumber };
+    };
+
+    /**
+     * Get the slashing info for a given round number.
+     * @param roundNumber - The round number to get the slashing info for.
+     * @returns The current block number, current slot number and the slashing info.
+     */
+    const slashingInfo = async (roundNumber: bigint) => {
       const instanceAddress = t.ctx.deployL1ContractsValues.l1ContractAddresses.rollupAddress.toString();
       const info = await slashingProposer.read.rounds([instanceAddress, roundNumber]);
       const leaderVotes = await slashingProposer.read.yeaCount([instanceAddress, roundNumber, info[1]]);
+      const bn = await t.ctx.cheatCodes.eth.blockNumber();
+      const slotNumber = await rollup.getSlotNumber();
       return { bn, slotNumber, roundNumber, info, leaderVotes };
     };
 
@@ -139,13 +152,11 @@ describe('e2e_p2p_slashing', () => {
       }
       const sequencer = (seqClient as any).sequencer;
       const slasher = (sequencer as any).slasherClient;
-      slasher.slashingAmount = 1n;
+      slasher.slashingAmount = slashingAmount;
     }
 
     // wait a bit for peers to discover each other
     await sleep(4000);
-
-    let sInfo = await slashingInfo();
 
     const votesNeeded = await slashingProposer.read.N();
 
@@ -187,6 +198,10 @@ describe('e2e_p2p_slashing', () => {
     expect(slashEvents.length).toBeGreaterThan(0);
     await waitUntilNextRound();
 
+    // Get the round number where we expect to be seeing a bunch of votes.
+    const { roundNumber, slotNumber } = await getRoundAndSlotNumber();
+    let sInfo = await slashingInfo(roundNumber);
+
     // For the next round we will try to cast votes.
     // Stop early if we have enough votes.
     t.logger.info(`Waiting for votes to be cast`);
@@ -197,7 +212,7 @@ describe('e2e_p2p_slashing', () => {
         await sleep(1000);
       }
 
-      sInfo = await slashingInfo();
+      sInfo = await slashingInfo(roundNumber);
       t.logger.info(`We have ${sInfo.leaderVotes} votes in round ${sInfo.roundNumber} on ${sInfo.info[1]}`);
       if (sInfo.leaderVotes >= votesNeeded) {
         t.logger.info(`We have sufficient votes`);
@@ -205,19 +220,37 @@ describe('e2e_p2p_slashing', () => {
       }
     }
 
-    const slashEvent = slashEvents[0];
-    await t.ctx.deployL1ContractsValues.publicClient.waitForTransactionReceipt({
-      hash: await slashFactory.write.createSlashPayload([slashEvent.epoch, slashEvent.amount], {
-        account: t.ctx.deployL1ContractsValues.walletClient.account,
+    // Because of race-conditions when we start we cannot ACTUALLY rely on just the first slash event
+    // of the first node, since the nodes might get online at different times and don't agree on this.
+    // e.g., the first slash could happen before the second node even got online.
+    // Therefore we derive what we are actually looking for based on what people voted on.
+    // Normally, one of the agents voting should be making the slash happen, but right now,
+    // we don't have that in place.
+    const targetAddress = sInfo.info[1];
+
+    let targetEpoch = 0n;
+    for (let i = 0; i <= slotNumber; i++) {
+      const epoch = await rollup.getEpochNumberForSlotNumber(BigInt(i));
+      const [address, isDeployed] = await slashFactory.read.getAddressAndIsDeployed([epoch, slashingAmount]);
+      if (address === targetAddress && !isDeployed) {
+        targetEpoch = epoch;
+        t.logger.info(`Target epoch found: ${targetEpoch}`);
+        break;
+      }
+    }
+
+    await l1TxUtils.sendAndMonitorTransaction({
+      to: slashFactory.address,
+      data: encodeFunctionData({
+        abi: SlashFactoryAbi,
+        functionName: 'createSlashPayload',
+        args: [targetEpoch, slashingAmount],
       }),
     });
-    const [address, isDeployed] = await slashFactory.read.getAddressAndIsDeployed([
-      slashEvent.epoch,
-      slashEvent.amount,
-    ]);
-    t.logger.info(`Slash payload for ${slashEvent.epoch}, ${slashEvent.amount} deployed at ${address} ${isDeployed}`);
+
+    t.logger.info(`Slash payload for ${targetEpoch}, ${slashingAmount} deployed at ${targetAddress}`);
     t.logger.info(
-      `Committee for epoch ${slashEvent.epoch}: ${(await rollup.getEpochCommittee(slashEvent.epoch)).map(addr =>
+      `Committee for epoch ${targetEpoch}: ${(await rollup.getEpochCommittee(targetEpoch)).map(addr =>
         addr.toLowerCase(),
       )}`,
     );
@@ -242,12 +275,15 @@ describe('e2e_p2p_slashing', () => {
     });
     t.logger.info(`Result: `, result);
 
-    const tx = await slashingProposer.write.executeProposal([sInfo.roundNumber], {
-      account: t.ctx.deployL1ContractsValues.walletClient.account,
+    const { receipt } = await l1TxUtils.sendAndMonitorTransaction({
+      to: slashingProposer.address,
+      data: encodeFunctionData({
+        abi: SlashingProposerAbi,
+        functionName: 'executeProposal',
+        args: [sInfo.roundNumber],
+      }),
     });
-    const receipt = await t.ctx.deployL1ContractsValues.publicClient.waitForTransactionReceipt({
-      hash: tx,
-    });
+
     t.logger.info(`Performed slash in ${receipt.transactionHash}`);
 
     const slashingEvents = parseEventLogs({
@@ -281,7 +317,7 @@ describe('e2e_p2p_slashing', () => {
       // Check that status is Living
       expect(attesterInfo.status).toEqual(2);
     }
-    const committee = await rollup.getEpochCommittee(slashEvent.epoch);
+    const committee = await rollup.getEpochCommittee(targetEpoch);
     expect(attestersPre.length).toBe(committee.length);
     expect(attestersPost.length).toBe(0);
   }, 1_000_000);

--- a/yarn-project/ethereum/src/contracts/rollup.ts
+++ b/yarn-project/ethereum/src/contracts/rollup.ts
@@ -190,6 +190,10 @@ export class RollupContract {
     return this.rollup.read.getCurrentSampleSeed();
   }
 
+  getCurrentEpoch() {
+    return this.rollup.read.getCurrentEpoch();
+  }
+
   async getCurrentEpochCommittee() {
     const { result } = await this.client.simulateContract({
       address: this.address,

--- a/yarn-project/sequencer-client/src/publisher/sequencer-publisher.ts
+++ b/yarn-project/sequencer-client/src/publisher/sequencer-publisher.ts
@@ -336,15 +336,17 @@ export class SequencerPublisher {
     const cachedLastVote = this.myLastVotes[voteType];
     this.myLastVotes[voteType] = slotNumber;
 
+    const action = voteType === VoteType.GOVERNANCE ? 'governance-vote' : 'slashing-vote';
+
     this.addRequest({
-      action: voteType === VoteType.GOVERNANCE ? 'governance-vote' : 'slashing-vote',
+      action,
       request: base.createVoteRequest(payload.toString()),
       lastValidL2Slot: slotNumber,
       onResult: (_request, result) => {
         if (!result || result.receipt.status !== 'success') {
           this.myLastVotes[voteType] = cachedLastVote;
         } else {
-          this.log.info(`Cast [${voteType}] vote for slot ${slotNumber}`);
+          this.log.info(`Voting in [${action}] for ${payload} at slot ${slotNumber} in round ${round}`);
         }
       },
     });

--- a/yarn-project/sequencer-client/src/slasher/slasher_client.ts
+++ b/yarn-project/sequencer-client/src/slasher/slasher_client.ts
@@ -175,10 +175,14 @@ export class SlasherClient extends WithTracer {
     this.log.info('Slasher client stopped.');
   }
 
-  // I need to get the slot number from the block that was just pruned
   private handlePruneL2Blocks(event: L2BlockSourceEvent): void {
+    // We do not try to slash if the penalty is 0
+    if (this.slashingAmount == 0n) {
+      return;
+    }
+
     const { slotNumber, epochNumber } = event;
-    this.log.info(`Detected chain prune. Punishing the validators at epoch ${epochNumber})`, event);
+    this.log.info(`Detected chain prune. Punishing the validators at epoch ${epochNumber}`, event);
 
     // Set the lifetime such that we have a full round that we could vote throughout.
     const slotsIntoRound = slotNumber % BigInt(this.config.slashingRoundSize);

--- a/yarn-project/sequencer-client/src/slasher/slasher_client.ts
+++ b/yarn-project/sequencer-client/src/slasher/slasher_client.ts
@@ -144,7 +144,9 @@ export class SlasherClient extends WithTracer {
 
     if (!isDeployed) {
       // The proposal cannot be executed until it is deployed
-      this.log.verbose(`Voting on not yet deployed payload: ${payloadAddress}`);
+      this.log.verbose(
+        `Voting on not yet deployed payload for epoch ${slashEvent.epoch} and amount ${slashEvent.amount} at: ${payloadAddress}`,
+      );
     }
 
     return EthAddress.fromString(payloadAddress);
@@ -176,7 +178,7 @@ export class SlasherClient extends WithTracer {
   // I need to get the slot number from the block that was just pruned
   private handlePruneL2Blocks(event: L2BlockSourceEvent): void {
     const { slotNumber, epochNumber } = event;
-    this.log.info(`Detected chain prune. Punishing the validators at epoch ${epochNumber}`);
+    this.log.info(`Detected chain prune. Punishing the validators at epoch ${epochNumber})`, event);
 
     // Set the lifetime such that we have a full round that we could vote throughout.
     const slotsIntoRound = slotNumber % BigInt(this.config.slashingRoundSize);


### PR DESCRIPTION
Fixes #13065.

- Fix a problem in the archiver that caused the slashing test to consistently fail.
- Fix the flake, by handling a race-condition

Should make the slasher consistently run without flakes, at least when trying it locally for 32 parallel runs multiple times. 

Keeping it in the flake for now, but will look at removing it from flakes if no failures in the next week from it.