### PR TITLE
fix: fetch the correct vk in getSolidityVerifier

### DIFF
--- a/barretenberg/ts/src/barretenberg/backend.ts
+++ b/barretenberg/ts/src/barretenberg/backend.ts
@@ -288,7 +288,7 @@ export class UltraHonkBackend {
   async getSolidityVerifier(vk?: Uint8Array): Promise<string> {
     await this.instantiate();
     const vkBuf =
-      vk ?? (await this.api.acirWriteVkUltraHonk(this.acirUncompressedBytecode, this.circuitOptions.recursive));
+      vk ?? (await this.api.acirWriteVkUltraKeccakHonk(this.acirUncompressedBytecode, this.circuitOptions.recursive));
     return await this.api.acirHonkSolidityVerifier(this.acirUncompressedBytecode, new RawBuffer(vkBuf));
   }
 


### PR DESCRIPTION
Please read [contributing guidelines](CONTRIBUTING.md) and remove this line.
