### PR TITLE
fix: eq instead of !==

### DIFF
--- a/yarn-project/sequencer-client/src/slasher/slasher_client.ts
+++ b/yarn-project/sequencer-client/src/slasher/slasher_client.ts
@@ -94,7 +94,7 @@ export class SlasherClient extends WithTracer {
   ) {
     super(telemetry, 'slasher');
 
-    if (config.l1Contracts.slashFactoryAddress && config.l1Contracts.slashFactoryAddress !== EthAddress.ZERO) {
+    if (config.l1Contracts.slashFactoryAddress && !config.l1Contracts.slashFactoryAddress.equals(EthAddress.ZERO)) {
       const chain = createEthereumChain(config.l1RpcUrls, config.l1ChainId);
       const publicClient = createPublicClient({
         chain: chain.chainInfo,


### PR DESCRIPTION
Fixes #13160 

Fixes issue in the `slasher_client` where it was using `!==` instead of `!a.equals(b)` for an `EthAddress`.

When `!==` are used between two `EthAddress.ZERO` the result is as expected, but for 

```typescript
  const a = EthAddress.ZERO;
  const b = EthAddress.fromString('0x0000000000000000000000000000000000000000');

  console.log(`a ${a}`); // 0x0000000000000000000000000000000000000000
  console.log(`b ${b}`); // 0x0000000000000000000000000000000000000000
  console.log(`a === b ${a === b}`); // false
  console.log(`a !== b ${a !== b}`); // true
  console.log(`a.equals(b) ${a.equals(b)}`); // true
  console.log(`!a.equals(b) ${!a.equals(b)}`); // false
```


