### PR TITLE
feat: util for computing proposer/forwarder address

### DIFF
--- a/yarn-project/ethereum/package.json
+++ b/yarn-project/ethereum/package.json
@@ -27,7 +27,8 @@
     "formatting:fix": "run -T eslint --fix ./src && run -T prettier -w ./src",
     "start:dev": "tsc-watch -p tsconfig.json --onSuccess 'yarn start'",
     "start": "node ./dest/index.js",
-    "test": "NODE_NO_WARNINGS=1 node --experimental-vm-modules ../node_modules/.bin/jest --passWithNoTests --maxWorkers=${JEST_MAX_WORKERS:-8}"
+    "test": "NODE_NO_WARNINGS=1 node --experimental-vm-modules ../node_modules/.bin/jest --passWithNoTests --maxWorkers=${JEST_MAX_WORKERS:-8}",
+    "proposer-address": "node ./dest/cli/forwarder_address.js"
   },
   "inherits": [
     "../package.common.json"

--- a/yarn-project/ethereum/src/cli/forwarder_address.ts
+++ b/yarn-project/ethereum/src/cli/forwarder_address.ts
@@ -1,0 +1,12 @@
+import { ForwarderContract } from '../contracts/index.js';
+
+const ownerAddress = process.argv[2];
+if (!ownerAddress) {
+  process.stderr.write('Please provide an owner address as an argument\n');
+  process.exit(1);
+}
+
+// Ensure the address starts with 0x
+const formattedAddress = ownerAddress.startsWith('0x') ? ownerAddress : `0x${ownerAddress}`;
+const address = ForwarderContract.expectedAddress(formattedAddress as `0x${string}`);
+process.stdout.write(`${address}\n`);

--- a/yarn-project/ethereum/src/contracts/forwarder.test.ts
+++ b/yarn-project/ethereum/src/contracts/forwarder.test.ts
@@ -135,4 +135,9 @@ describe('Forwarder', () => {
     expect(err).toBeInstanceOf(FormattedViemError);
     expect(err.message).toMatch(/GovernanceProposer__OnlyProposerCanVote/);
   });
+
+  it('gets expected address', () => {
+    const expected = ForwarderContract.expectedAddress('0x8048539a57619864fdcAE35282731809CD1f5E8D');
+    expect(expected).toBe('0xEB416A0f18CEf8Ce5C9dd4BceF4BeFfb771703c6');
+  });
 });

--- a/yarn-project/ethereum/src/contracts/forwarder.ts
+++ b/yarn-project/ethereum/src/contracts/forwarder.ts
@@ -11,7 +11,7 @@ import {
   getContract,
 } from 'viem';
 
-import { deployL1Contract } from '../deploy_l1_contracts.js';
+import { deployL1Contract, getExpectedAddress } from '../deploy_l1_contracts.js';
 import type { L1BlobInputs, L1GasConfig, L1TxRequest, L1TxUtils } from '../l1_tx_utils.js';
 import type { L1Clients, ViemPublicClient, ViemWalletClient } from '../types.js';
 import { RollupContract } from './rollup.js';
@@ -21,6 +21,11 @@ export class ForwarderContract {
 
   constructor(public readonly client: L1Clients['publicClient'], address: Hex, public readonly rollupAddress: Hex) {
     this.forwarder = getContract({ address, abi: ForwarderAbi, client });
+  }
+
+  static expectedAddress(owner: Hex) {
+    const { address } = getExpectedAddress(ForwarderAbi, ForwarderBytecode, [owner], owner);
+    return address;
   }
 
   static async create(


### PR DESCRIPTION
From within `yarn-project/ethereum` you can now
```
yarn proposer-address 0x8048539a57619864fdcAE35282731809CD1f5E8D
```
which returns the proposer address for that attester if they're using the standard forwarder.