### PR TITLE
feat: Prover id defaults to publisher address

### DIFF
--- a/yarn-project/aztec-node/src/aztec-node/config.ts
+++ b/yarn-project/aztec-node/src/aztec-node/config.ts
@@ -9,7 +9,7 @@ import { type ConfigMappingsType, booleanConfigHelper, getConfigFromMappings } f
 import { type DataStoreConfig, dataConfigMappings } from '@aztec/kv-store/config';
 import { type SharedNodeConfig, sharedNodeConfigMappings } from '@aztec/node-lib/config';
 import { type P2PConfig, p2pConfigMappings } from '@aztec/p2p/config';
-import { type ProverClientConfig, proverClientConfigMappings } from '@aztec/prover-client/config';
+import { type ProverClientUserConfig, proverClientConfigMappings } from '@aztec/prover-client/config';
 import { type SequencerClientConfig, sequencerClientConfigMappings } from '@aztec/sequencer-client/config';
 import { type ValidatorClientConfig, validatorClientConfigMappings } from '@aztec/validator-client/config';
 import { type WorldStateConfig, worldStateConfigMappings } from '@aztec/world-state/config';
@@ -28,9 +28,9 @@ export { sequencerClientConfigMappings, type SequencerClientConfig };
 export type AztecNodeConfig = ArchiverConfig &
   SequencerClientConfig &
   ValidatorClientConfig &
-  ProverClientConfig &
+  ProverClientUserConfig &
   WorldStateConfig &
-  Pick<ProverClientConfig, 'bbBinaryPath' | 'bbWorkingDirectory' | 'realProofs'> &
+  Pick<ProverClientUserConfig, 'bbBinaryPath' | 'bbWorkingDirectory' | 'realProofs'> &
   P2PConfig &
   DataStoreConfig &
   SentinelConfig &

--- a/yarn-project/ethereum/src/account.ts
+++ b/yarn-project/ethereum/src/account.ts
@@ -1,0 +1,5 @@
+import { privateKeyToAccount } from 'viem/accounts';
+
+export function getAddressFromPrivateKey(privateKey: `0x${string}`): `0x${string}` {
+  return privateKeyToAccount(privateKey).address;
+}

--- a/yarn-project/ethereum/src/index.ts
+++ b/yarn-project/ethereum/src/index.ts
@@ -11,3 +11,4 @@ export * from './types.js';
 export * from './contracts/index.js';
 export * from './queries.js';
 export * from './client.js';
+export * from './account.js';

--- a/yarn-project/protocol-contracts/src/protocol_contract_data_2.ts
+++ b/yarn-project/protocol-contracts/src/protocol_contract_data_2.ts
@@ -1,0 +1,61 @@
+// GENERATED FILE - DO NOT EDIT. RUN `yarn generate` or `yarn generate:data`
+import { Fr } from '@aztec/foundation/fields';
+import { AztecAddress } from '@aztec/stdlib/aztec-address';
+
+export const protocolContractNames = [
+  'AuthRegistry',
+  'ContractInstanceDeployer',
+  'ContractClassRegisterer',
+  'MultiCallEntrypoint',
+  'FeeJuice',
+  'Router',
+] as const;
+
+export type ProtocolContractName = (typeof protocolContractNames)[number];
+
+export const ProtocolContractSalt: Record<ProtocolContractName, Fr> = {
+  AuthRegistry: new Fr(1),
+  ContractInstanceDeployer: new Fr(1),
+  ContractClassRegisterer: new Fr(1),
+  MultiCallEntrypoint: new Fr(1),
+  FeeJuice: new Fr(1),
+  Router: new Fr(1),
+};
+
+export const ProtocolContractAddress: Record<ProtocolContractName, AztecAddress> = {
+  AuthRegistry: AztecAddress.fromBigInt(1n),
+  ContractInstanceDeployer: AztecAddress.fromBigInt(2n),
+  ContractClassRegisterer: AztecAddress.fromBigInt(3n),
+  MultiCallEntrypoint: AztecAddress.fromBigInt(4n),
+  FeeJuice: AztecAddress.fromBigInt(5n),
+  Router: AztecAddress.fromBigInt(6n),
+};
+
+export const ProtocolContractLeaves = {
+  AuthRegistry: Fr.fromHexString('0x0807ac7ed9aae595efff561f39373a321811ed9bb69d9104fe3035b487ade50a'),
+  ContractInstanceDeployer: Fr.fromHexString('0x28c3aee0c74e02b17f1ebf7bcd2c2874d4dce88b2ededf487e07d4b1912303ab'),
+  ContractClassRegisterer: Fr.fromHexString('0x1f73d3d99860b24a5e8c4e4a6cadbb097370984293495d4c0bbfd809b690c49f'),
+  MultiCallEntrypoint: Fr.fromHexString('0x2182bf9eb009655d81599ac098f641ee5095519f5bb4b30658c61807d4a83ae7'),
+  FeeJuice: Fr.fromHexString('0x27e36a350de1027f4c9847e9fbe67585aacd2cb4b8d3edde5e33ba73d5d3c686'),
+  Router: Fr.fromHexString('0x292db7e4209a217067fa7c1fcd2e8b98bb94a2fe1e564accda7d1b361bbd7c12'),
+};
+
+export const protocolContractTreeRoot = Fr.fromHexString(
+  '0x0d728eb2ee21a9484e34312160bec66dd5995c80bb6cfb51e86528a7dae92870',
+);
+
+export const REGISTERER_CONTRACT_CLASS_REGISTERED_TAG = Fr.fromHexString(
+  '0x20cd27645f65c15a38720ca984aef936592f3938a705db706d068ad13fc58ae9',
+);
+export const REGISTERER_PRIVATE_FUNCTION_BROADCASTED_TAG = Fr.fromHexString(
+  '0x0abf338154e355442d9916d630da0491036d5a7b23c42b477c1395ba3bf9b42d',
+);
+export const REGISTERER_UNCONSTRAINED_FUNCTION_BROADCASTED_TAG = Fr.fromHexString(
+  '0x27774539896271d6dbe0c1de45ddc44709d1e8d9a9fb686ca3c105d87c417bb8',
+);
+export const DEPLOYER_CONTRACT_INSTANCE_DEPLOYED_TAG = Fr.fromHexString(
+  '0x2ec28b91a5f838506d6042915005ff55cf7a0a5f889a83b11faed33a31b486f2',
+);
+export const DEPLOYER_CONTRACT_INSTANCE_UPDATED_TAG = new Fr(
+  1534834688047131268740281708431107902615560100979874281215533519862n,
+);

--- a/yarn-project/prover-client/src/config.ts
+++ b/yarn-project/prover-client/src/config.ts
@@ -9,10 +9,11 @@ import {
   proverBrokerConfigMappings,
 } from './proving_broker/config.js';
 
-/**
- * The prover configuration.
- */
-export type ProverClientConfig = ProverConfig & ProverAgentConfig & ProverBrokerConfig & BBConfig & ACVMConfig;
+/** The prover configuration as defined by the user. */
+export type ProverClientUserConfig = ProverConfig & ProverAgentConfig & ProverBrokerConfig & BBConfig & ACVMConfig;
+
+/** The prover configuration with all missing fields resolved. */
+export type ProverClientConfig = ProverClientUserConfig & Required<Pick<ProverClientUserConfig, 'proverId'>>;
 
 export const bbConfigMappings: ConfigMappingsType<BBConfig & ACVMConfig> = {
   acvmWorkingDirectory: {
@@ -38,7 +39,7 @@ export const bbConfigMappings: ConfigMappingsType<BBConfig & ACVMConfig> = {
   },
 };
 
-export const proverClientConfigMappings: ConfigMappingsType<ProverClientConfig> = {
+export const proverClientConfigMappings: ConfigMappingsType<ProverClientUserConfig> = {
   ...bbConfigMappings,
   ...proverConfigMappings,
   ...proverAgentConfigMappings,
@@ -50,6 +51,6 @@ export const proverClientConfigMappings: ConfigMappingsType<ProverClientConfig> 
  * Note: If an environment variable is not set, the default value is used.
  * @returns The prover configuration.
  */
-export function getProverEnvVars(): ProverClientConfig {
-  return getConfigFromMappings<ProverClientConfig>(proverClientConfigMappings);
+export function getProverEnvVars(): ProverClientUserConfig {
+  return getConfigFromMappings<ProverClientUserConfig>(proverClientConfigMappings);
 }

--- a/yarn-project/prover-client/src/orchestrator/orchestrator.ts
+++ b/yarn-project/prover-client/src/orchestrator/orchestrator.ts
@@ -90,7 +90,7 @@ export class ProvingOrchestrator implements EpochProver {
   constructor(
     private dbProvider: ForkMerkleTreeOperations,
     private prover: ServerCircuitProver,
-    private readonly proverId: Fr = Fr.ZERO,
+    private readonly proverId: Fr,
     telemetryClient: TelemetryClient = getTelemetryClient(),
   ) {
     this.metrics = new ProvingOrchestratorMetrics(telemetryClient, 'ProvingOrchestrator');

--- a/yarn-project/prover-client/src/orchestrator/orchestrator_lifecycle.test.ts
+++ b/yarn-project/prover-client/src/orchestrator/orchestrator_lifecycle.test.ts
@@ -1,4 +1,5 @@
 import { NUM_BASE_PARITY_PER_ROOT_PARITY } from '@aztec/constants';
+import { Fr } from '@aztec/foundation/fields';
 import { createLogger } from '@aztec/foundation/log';
 import { type PromiseWithResolvers, promiseWithResolvers } from '@aztec/foundation/promise';
 import { sleep } from '@aztec/foundation/sleep';
@@ -28,7 +29,7 @@ describe('prover/orchestrator/lifecycle', () => {
   describe('lifecycle', () => {
     it('cancels proving requests', async () => {
       const prover: ServerCircuitProver = new TestCircuitProver();
-      const orchestrator = new ProvingOrchestrator(context.worldState, prover);
+      const orchestrator = new ProvingOrchestrator(context.worldState, prover, Fr.ONE);
 
       const spy = jest.spyOn(prover, 'getBaseParityProof');
       const deferredPromises: PromiseWithResolvers<any>[] = [];

--- a/yarn-project/prover-client/src/prover-client/prover-client.ts
+++ b/yarn-project/prover-client/src/prover-client/prover-client.ts
@@ -49,7 +49,7 @@ export class ProverClient implements EpochProverManager {
   }
 
   public getProverId(): Fr {
-    return this.config.proverId ?? Fr.ZERO;
+    return this.config.proverId;
   }
 
   async updateProverConfig(config: Partial<ProverClientConfig>): Promise<void> {

--- a/yarn-project/prover-node/src/config.ts
+++ b/yarn-project/prover-node/src/config.ts
@@ -6,7 +6,6 @@ import { Fr } from '@aztec/foundation/fields';
 import { type DataStoreConfig, dataConfigMappings } from '@aztec/kv-store/config';
 import { type SharedNodeConfig, sharedNodeConfigMappings } from '@aztec/node-lib/config';
 import { type P2PConfig, p2pConfigMappings } from '@aztec/p2p/config';
-import type { ProverClient } from '@aztec/prover-client';
 import {
   type ProverAgentConfig,
   type ProverBrokerConfig,

--- a/yarn-project/prover-node/src/config.ts
+++ b/yarn-project/prover-node/src/config.ts
@@ -1,17 +1,24 @@
 import { type ArchiverConfig, archiverConfigMappings } from '@aztec/archiver/config';
 import type { ACVMConfig, BBConfig } from '@aztec/bb-prover/config';
-import { type GenesisStateConfig, genesisStateConfigMappings } from '@aztec/ethereum';
+import { type GenesisStateConfig, genesisStateConfigMappings, getAddressFromPrivateKey } from '@aztec/ethereum';
 import { type ConfigMappingsType, getConfigFromMappings, numberConfigHelper } from '@aztec/foundation/config';
+import { Fr } from '@aztec/foundation/fields';
 import { type DataStoreConfig, dataConfigMappings } from '@aztec/kv-store/config';
 import { type SharedNodeConfig, sharedNodeConfigMappings } from '@aztec/node-lib/config';
 import { type P2PConfig, p2pConfigMappings } from '@aztec/p2p/config';
+import type { ProverClient } from '@aztec/prover-client';
 import {
   type ProverAgentConfig,
   type ProverBrokerConfig,
   proverAgentConfigMappings,
   proverBrokerConfigMappings,
 } from '@aztec/prover-client/broker';
-import { type ProverClientConfig, bbConfigMappings, proverClientConfigMappings } from '@aztec/prover-client/config';
+import {
+  type ProverClientConfig,
+  type ProverClientUserConfig,
+  bbConfigMappings,
+  proverClientConfigMappings,
+} from '@aztec/prover-client/config';
 import {
   type PublisherConfig,
   type TxSenderConfig,
@@ -23,7 +30,7 @@ import { type WorldStateConfig, worldStateConfigMappings } from '@aztec/world-st
 import { type ProverCoordinationConfig, proverCoordinationConfigMappings } from './prover-coordination/config.js';
 
 export type ProverNodeConfig = ArchiverConfig &
-  ProverClientConfig &
+  ProverClientUserConfig &
   P2PConfig &
   WorldStateConfig &
   PublisherConfig &
@@ -105,4 +112,12 @@ export function getProverNodeAgentConfigFromEnv(): ProverAgentConfig & BBConfig 
     ...getConfigFromMappings(proverAgentConfigMappings),
     ...getConfigFromMappings(bbConfigMappings),
   };
+}
+
+export function resolveConfig(userConfig: ProverNodeConfig): ProverNodeConfig & ProverClientConfig {
+  const proverId =
+    userConfig.proverId && !userConfig.proverId.isZero()
+      ? userConfig.proverId
+      : Fr.fromHexString(getAddressFromPrivateKey(userConfig.publisherPrivateKey));
+  return { ...userConfig, proverId };
 }

--- a/yarn-project/prover-node/src/factory.ts
+++ b/yarn-project/prover-node/src/factory.ts
@@ -12,7 +12,7 @@ import type { PublicDataTreeLeaf } from '@aztec/stdlib/trees';
 import { type TelemetryClient, getTelemetryClient } from '@aztec/telemetry-client';
 import { createWorldStateSynchronizer } from '@aztec/world-state';
 
-import type { ProverNodeConfig } from './config.js';
+import { type ProverNodeConfig, resolveConfig } from './config.js';
 import { EpochMonitor } from './monitors/epoch-monitor.js';
 import { createProverCoordination } from './prover-coordination/factory.js';
 import { ProverNodePublisher } from './prover-node-publisher.js';
@@ -20,7 +20,7 @@ import { ProverNode, type ProverNodeOptions } from './prover-node.js';
 
 /** Creates a new prover node given a config. */
 export async function createProverNode(
-  config: ProverNodeConfig & DataStoreConfig,
+  userConfig: ProverNodeConfig & DataStoreConfig,
   deps: {
     telemetry?: TelemetryClient;
     log?: Logger;
@@ -35,6 +35,7 @@ export async function createProverNode(
     prefilledPublicData?: PublicDataTreeLeaf[];
   } = {},
 ) {
+  const config = resolveConfig(userConfig);
   const telemetry = deps.telemetry ?? getTelemetryClient();
   const blobSinkClient = deps.blobSinkClient ?? createBlobSinkClient(config);
   const log = deps.log ?? createLogger('prover-node');

--- a/yarn-project/prover-node/src/prover-node.ts
+++ b/yarn-project/prover-node/src/prover-node.ts
@@ -143,7 +143,7 @@ export class ProverNode implements EpochMonitorHandler, ProverNodeApi, Traceable
     this.txFetcher.start();
     this.epochsMonitor.start(this);
     this.l1Metrics.start();
-    this.log.info('Started ProverNode', this.options);
+    this.log.info(`Started Prover Node with prover id ${this.prover.getProverId().toString()}`, this.options);
   }
 
   /**

--- a/yarn-project/stdlib/src/interfaces/prover-client.ts
+++ b/yarn-project/stdlib/src/interfaces/prover-client.ts
@@ -56,7 +56,7 @@ export const proverConfigMappings: ConfigMappingsType<ProverConfig> = {
   proverId: {
     env: 'PROVER_ID',
     parseEnv: (val?: string) => parseProverId(val),
-    description: 'Identifier of the prover. Defaults to the address used for submitting proofs if not set.',
+    description: 'Hex value that identifies the prover. Defaults to the address used for submitting proofs if not set.',
   },
   proverTestDelayType: {
     env: 'PROVER_TEST_DELAY_TYPE',

--- a/yarn-project/stdlib/src/interfaces/prover-client.ts
+++ b/yarn-project/stdlib/src/interfaces/prover-client.ts
@@ -26,7 +26,7 @@ export type ProverConfig = ActualProverConfig & {
   /** The URL to the Aztec node to take proving jobs from */
   nodeUrl?: string;
   /** Identifier of the prover */
-  proverId: Fr;
+  proverId?: Fr;
   /** Number of proving agents to start within the prover. */
   proverAgentCount: number;
   /** Store for failed proof inputs. */
@@ -36,7 +36,7 @@ export type ProverConfig = ActualProverConfig & {
 export const ProverConfigSchema = z.object({
   nodeUrl: z.string().optional(),
   realProofs: z.boolean(),
-  proverId: schemas.Fr,
+  proverId: schemas.Fr.optional(),
   proverTestDelayType: z.enum(['fixed', 'realistic']),
   proverTestDelayMs: z.number(),
   proverTestDelayFactor: z.number(),
@@ -55,9 +55,8 @@ export const proverConfigMappings: ConfigMappingsType<ProverConfig> = {
   },
   proverId: {
     env: 'PROVER_ID',
-    parseEnv: (val: string) => parseProverId(val),
-    description: 'Identifier of the prover',
-    defaultValue: Fr.ZERO,
+    parseEnv: (val?: string) => parseProverId(val),
+    description: 'Identifier of the prover. Defaults to the address used for submitting proofs if not set.',
   },
   proverTestDelayType: {
     env: 'PROVER_TEST_DELAY_TYPE',
@@ -85,8 +84,11 @@ export const proverConfigMappings: ConfigMappingsType<ProverConfig> = {
   },
 };
 
-function parseProverId(str: string) {
-  return Fr.fromHexString(str.startsWith('0x') ? str : Buffer.from(str, 'utf8').toString('hex'));
+function parseProverId(str?: string) {
+  if (!str) {
+    return undefined;
+  }
+  return Fr.fromHexString(str);
 }
 
 /**


### PR DESCRIPTION
If `PROVER_ID` is unset, instead of defaulting to zero, it computes the ethereum address that corresponds to the `PROVER_PUBLISHER_PRIVATE_KEY` and uses that as prover id.

**Slightly breaking**: It also changes the parsing of `PROVER_ID` when set. Before, if it had no 0x prefix, it was assumed to be a plain string. So setting `PROVER_ID=5` would result in a prover id of `0x35` (the ascii code for the character 5). Now we assume it's always a hex-encoded value.

Example local run:

```
$ PROVER_REAL_PROOFS=false PROVER_AGENT_COUNT=0 AZTEC_EPOCH_DURATION=4 ETHEREUM_SLOT_DURATION=4 AZTEC_SLOT_DURATION=8 NODE_NO_WARNINGS=1 LOG_LEVEL='verbose' AZTEC_NODE_URL=http://localhost:8085 PROVER_COORDINATION_NODE_URL=http://localhost:8085 AZTEC_PORT=8084 PROVER_BROKER_HOST=http://localhost:8088 yarn aztec start --prover-node --archiver

...

[10:15:15.362] INFO: prover-node Started Prover Node with prover id 0x000000000000000000000000f39fd6e51aad88f6f4ce6ab8827279cfffb92266 {"pollingIntervalMs":1000,"maxPendingJobs":10,"maxParallelBlocksPerEpoch":32,"txGatheringTimeoutMs":60000,"txGatheringIntervalMs":1000,"txGatheringMaxParallelRequests":100}
```
