### PR TITLE
chore: remove catch-all branch from opcode match in transpiler

### DIFF
--- a/avm-transpiler/src/transpile.rs
+++ b/avm-transpiler/src/transpile.rs
@@ -440,9 +440,8 @@ pub fn brillig_to_avm(brillig_bytecode: &[BrilligOpcode<FieldElement>]) -> (Vec<
                     &mut unresolved_jumps,
                 );
             }
-            _ => panic!(
-                "Transpiler doesn't know how to process {:?} brillig instruction",
-                brillig_instr
+            BrilligOpcode::JumpIfNot { .. } => panic!(
+                "Transpiler doesn't know how to process `BrilligOpcode::JumpIfNot` brillig instruction",
             ),
         }
 


### PR DESCRIPTION
To flush out any mismatches between brillig and the transpiler, I've removed the wildcard match from the transpiler so that it needs to enumerate how it handles all brillig opcodes.

It seems like there's a `JumpNotIf` opcode which is not supported either (although I'm pretty confident that we never emit this.

@sirasistant @dbanks12 