### PR TITLE
chore: enable sentinel in sentinel test

### DIFF
--- a/yarn-project/end-to-end/src/e2e_p2p/validators_sentinel.test.ts
+++ b/yarn-project/end-to-end/src/e2e_p2p/validators_sentinel.test.ts
@@ -35,6 +35,7 @@ describe('e2e_p2p_validators_sentinel', () => {
         minTxsPerBlock: 0,
         aztecEpochDuration: 48,
         validatorReexecute: false,
+        sentinelEnabled: true,
       },
     });
 


### PR DESCRIPTION
With the default config being that sentinel were off, we need to explicitly turn it on for the sentinel test.