### PR TITLE
chore: Do not close store before stopping p2p client in tests

### DIFF
--- a/yarn-project/archiver/src/test/mock_l2_block_source.ts
+++ b/yarn-project/archiver/src/test/mock_l2_block_source.ts
@@ -209,6 +209,7 @@ export class MockL2BlockSource implements L2BlockSource {
    * @returns A promise that signals the initialization of the l2 block source on completion.
    */
   public start(): Promise<void> {
+    this.log.verbose('Starting mock L2 block source');
     return Promise.resolve();
   }
 
@@ -217,6 +218,7 @@ export class MockL2BlockSource implements L2BlockSource {
    * @returns A promise that signals the l2 block source is now stopped.
    */
   public stop(): Promise<void> {
+    this.log.verbose('Stopping mock L2 block source');
     return Promise.resolve();
   }
 }

--- a/yarn-project/p2p/src/client/p2p_client.test.ts
+++ b/yarn-project/p2p/src/client/p2p_client.test.ts
@@ -50,10 +50,6 @@ describe('In-Memory P2P Client', () => {
     client = new P2PClient(P2PClientType.Full, kvStore, blockSource, mempools, p2pService);
   });
 
-  afterEach(async () => {
-    await kvStore.close();
-  });
-
   const advanceToProvenBlock = async (getProvenBlockNumber: number) => {
     blockSource.setProvenBlockNumber(getProvenBlockNumber);
     await retryUntil(async () => (await client.getSyncedProvenBlockNum()) >= getProvenBlockNumber, 'synced', 10, 0.1);
@@ -63,6 +59,7 @@ describe('In-Memory P2P Client', () => {
     if (client.isReady()) {
       await client.stop();
     }
+    await kvStore.close();
   });
 
   it('can start & stop', async () => {


### PR DESCRIPTION
Try and fix afterEach hook hanging (see [here](http://ci.aztec-labs.com/298d82ba28bfe134)).
