### PR TITLE
fix: title and external check need to run in merge queue

### DIFF
--- a/.github/workflows/ci3-external.yml
+++ b/.github/workflows/ci3-external.yml
@@ -2,6 +2,8 @@
 name: CI3 (External)
 
 on:
+  # This check is skipped in merge queue, but we need it to run (even skipped) for status checks.
+  merge_group:
   # For external devs. Workflow file edits won't take effect in the PR.
   pull_request_target:
     types: [opened, synchronize, reopened, ready_for_review, labeled]

--- a/.github/workflows/pull-request-title.yml
+++ b/.github/workflows/pull-request-title.yml
@@ -1,6 +1,8 @@
-name: Pull Request
+name: Pull Request Title
 
 on:
+  # This check is skipped in merge queue, but we need it to run (even skipped) for status checks.
+  merge_group:
   pull_request:
     types:
       - opened


### PR DESCRIPTION
They need to run, even if skipped, to appease github check system