### PR TITLE
chore: Fix flake in e2e fees failures

### DIFF
--- a/yarn-project/aztec.js/src/test/anvil_test_watcher.ts
+++ b/yarn-project/aztec.js/src/test/anvil_test_watcher.ts
@@ -70,11 +70,11 @@ export class AnvilTestWatcher {
     const isAutoMining = await this.cheatcodes.isAutoMining();
 
     if (isAutoMining) {
-      this.filledRunningPromise = new RunningPromise(() => this.warpTimeIfNeeded(), this.logger, 1000);
+      this.filledRunningPromise = new RunningPromise(() => this.warpTimeIfNeeded(), this.logger, 200);
       this.filledRunningPromise.start();
-      this.mineIfOutdatedPromise = new RunningPromise(() => this.mineIfOutdated(), this.logger, 1000);
+      this.mineIfOutdatedPromise = new RunningPromise(() => this.mineIfOutdated(), this.logger, 200);
       this.mineIfOutdatedPromise.start();
-      this.markingAsProvenRunningPromise = new RunningPromise(() => this.markAsProven(), this.logger, 1000);
+      this.markingAsProvenRunningPromise = new RunningPromise(() => this.markAsProven(), this.logger, 200);
       this.markingAsProvenRunningPromise.start();
       this.logger.info(`Watcher started for rollup at ${this.rollup.address}`);
     } else {
@@ -86,6 +86,12 @@ export class AnvilTestWatcher {
     await this.filledRunningPromise?.stop();
     await this.mineIfOutdatedPromise?.stop();
     await this.markingAsProvenRunningPromise?.stop();
+  }
+
+  async trigger() {
+    await this.filledRunningPromise?.trigger();
+    await this.mineIfOutdatedPromise?.trigger();
+    await this.markingAsProvenRunningPromise?.trigger();
   }
 
   async markAsProven() {

--- a/yarn-project/end-to-end/src/e2e_fees/failures.test.ts
+++ b/yarn-project/end-to-end/src/e2e_fees/failures.test.ts
@@ -34,6 +34,7 @@ describe('e2e_fees failures', () => {
 
     // Prove up until the current state by just marking it as proven.
     // Then turn off the watcher to prevent it from keep proving
+    await t.context.watcher.trigger();
     await t.cheatCodes.rollup.advanceToNextEpoch();
     await t.catchUpProvenChain();
     t.setIsMarkingAsProven(false);
@@ -77,6 +78,7 @@ describe('e2e_fees failures', () => {
     await expectMapping(t.getGasBalanceFn, [aliceAddress, bananaFPC.address], [initialAliceGas, initialFPCGas]);
 
     // We wait until the proven chain is caught up so all previous fees are paid out.
+    await t.context.watcher.trigger();
     await t.cheatCodes.rollup.advanceToNextEpoch();
     await t.catchUpProvenChain();
 
@@ -97,6 +99,7 @@ describe('e2e_fees failures', () => {
 
     // @note There is a potential race condition here if other tests send transactions that get into the same
     // epoch and thereby pays out fees at the same time (when proven).
+    await t.context.watcher.trigger();
     await t.cheatCodes.rollup.advanceToNextEpoch();
     await t.catchUpProvenChain();
 


### PR DESCRIPTION
Attempt at fixing `e2e_fees/failures` [test flake](http://ci.aztec-labs.com/b0b40aa7bab4695f).

Looking at the logs, the culprit seems to be here:

```
22:16:13 [22:16:13.882] INFO: e2e:e2e_fees:failures L1 block 50 mined at 22:31:07 with new L2 block 12 for epoch 2 {"l1Timestamp":1743546667,"l1BlockNumber":50,"l2SlotNumber":34,"l2BlockNumber":12,"l2ProvenBlockNumber":11}
22:16:14 [22:16:14.540] INFO: archiver Downloaded L2 block 12 {"blockHash":{},"blockNumber":12,"txCount":1,"globalVariables":{"chainId":31337,"version":2493758707,"blockNumber":12,"slotNumber":34,"timestamp":1743546667,"coinbase":"0x1f7a267433ab88c7f7d5a7c05bd0cdbe1416d5e4","feeRecipient":"0x1fb7a557b14a492bace6d93ce9b95494fb7bbd9b6233da382c4d233f49880138","feePerDaGas":0,"feePerL2Gas":3180}}
22:16:14 [22:16:14.657] VERBOSE: p2p Synched to latest block 12
22:16:14 [22:16:14.689] VERBOSE: world_state World state updated with L2 block 12 {"eventName":"l2-block-handled","duration":31.29037000000244,"unfinalisedBlockNumber":12,"finalisedBlockNumber":11,"oldestHistoricBlock":1,"txCount":1,"blockNumber":12,"blockTimestamp":1743546667,"privateLogCount":2,"publicLogCount":1,"contractClassLogCount":0,"contractClassLogSize":0}
22:16:14 [22:16:14.711] INFO: ethereum:cheat_codes Calling evm_setNextBlockTimestamp with params: [1743547027] on http://127.0.0.1/:8545
22:16:14 [22:16:14.715] INFO: ethereum:cheat_codes Calling evm_setNextBlockTimestamp with params: [1743546691] on http://127.0.0.1/:8545
22:16:14 [22:16:14.717] INFO: ethereum:cheat_codes Calling hardhat_mine with params: [1] on http://127.0.0.1/:8545
22:16:14 [22:16:14.719] INFO: ethereum:cheat_codes Calling hardhat_mine with params: [1] on http://127.0.0.1/:8545
22:16:14 [22:16:14.720] WARN: aztecjs:cheat_codes Advanced to next epoch
22:16:14 [22:16:14.721] WARN: ethereum:cheat_codes Warped L1 timestamp to 1743546691
22:16:14 [22:16:14.721] INFO: aztecjs:utils:watcher Slot 34 was filled, jumped to next slot
```

Compare this with a correct run:

```
22:16:54 [22:16:54.152] INFO: e2e:e2e_fees:failures L1 block 50 mined at 22:31:47 with new L2 block 12 for epoch 2 {"l1Timestamp":1743546707,"l1BlockNumber":50,"l2SlotNumber":34,"l2BlockNumber":12,"l2ProvenBlockNumber":11}
22:16:54 [22:16:54.883] INFO: ethereum:cheat_codes Calling evm_setNextBlockTimestamp with params: [1743546731] on http://127.0.0.1/:8545
22:16:54 [22:16:54.983] INFO: archiver Downloaded L2 block 12 {"blockHash":{},"blockNumber":12,"txCount":1,"globalVariables":{"chainId":31337,"version":4183907290,"blockNumber":12,"slotNumber":34,"timestamp":1743546707,"coinbase":"0xb102a81ca1c1abe5f5a9136c3f2ab0bd885df835","feeRecipient":"0x1dfd51415677fcb613cf399dada960bf406a57acd021dde51cd7ce40f9baf035","feePerDaGas":0,"feePerL2Gas":3180}}
22:16:54 [22:16:54.989] INFO: ethereum:cheat_codes Calling hardhat_mine with params: [1] on http://127.0.0.1/:8545
22:16:55 [22:16:55.017] WARN: ethereum:cheat_codes Warped L1 timestamp to 1743546731
22:16:55 [22:16:55.018] INFO: aztecjs:utils:watcher Slot 34 was filled, jumped to next slot
22:16:55 [22:16:55.027] INFO: archiver Downloaded L2 block 12 {"blockHash":{},"blockNumber":12,"txCount":1,"globalVariables":{"chainId":31337,"version":4183907290,"blockNumber":12,"slotNumber":34,"timestamp":1743546707,"coinbase":"0xb102a81ca1c1abe5f5a9136c3f2ab0bd885df835","feeRecipient":"0x1dfd51415677fcb613cf399dada960bf406a57acd021dde51cd7ce40f9baf035","feePerDaGas":0,"feePerL2Gas":3180}}
22:16:55 [22:16:55.067] VERBOSE: world_state World state updated with L2 block 12 {"eventName":"l2-block-handled","duration":15.83266499999445,"unfinalisedBlockNumber":12,"finalisedBlockNumber":11,"oldestHistoricBlock":1,"txCount":1,"blockNumber":12,"blockTimestamp":1743546707,"privateLogCount":2,"publicLogCount":1,"contractClassLogCount":0,"contractClassLogSize":0}
22:16:55 [22:16:55.151] VERBOSE: world_state World state updated with L2 block 12 {"eventName":"l2-block-handled","duration":30.628593000001274,"unfinalisedBlockNumber":12,"finalisedBlockNumber":11,"oldestHistoricBlock":1,"txCount":1,"blockNumber":12,"blockTimestamp":1743546707,"privateLogCount":2,"publicLogCount":1,"contractClassLogCount":0,"contractClassLogSize":0}
22:16:55 [22:16:55.177] VERBOSE: p2p Synched to latest block 12
22:16:55 [22:16:55.198] INFO: e2e:e2e_fees:failures L1 block 51 mined at 22:32:11 {"l1Timestamp":1743546731,"l1BlockNumber":51,"l2SlotNumber":35,"l2BlockNumber":12,"l2ProvenBlockNumber":11}
22:16:55 [22:16:55.468] VERBOSE: prover-node Fetching 1 tx hashes for block number 12 from coordination
22:16:55 [22:16:55.510] INFO: ethereum:cheat_codes Calling evm_setNextBlockTimestamp with params: [1743547067] on http://127.0.0.1/:8545
22:16:55 [22:16:55.512] INFO: ethereum:cheat_codes Calling hardhat_mine with params: [1] on http://127.0.0.1/:8545
22:16:55 [22:16:55.514] WARN: aztecjs:cheat_codes Advanced to next epoch
```

What's happening is that the test code is calling `advanceToNextEpoch` to move the timestamp forward, but at the same time the anvil test watcher kicks in and warps the timestamp to that of the next slot that was just mined, which is much lower than the next epoch timestamp. Zooming in on the logs:

```
22:16:14 [22:16:14.711] INFO: ethereum:cheat_codes Calling evm_setNextBlockTimestamp with params: [1743547027] on http://127.0.0.1/:8545
22:16:14 [22:16:14.715] INFO: ethereum:cheat_codes Calling evm_setNextBlockTimestamp with params: [1743546691] on http://127.0.0.1/:8545
22:16:14 [22:16:14.717] INFO: ethereum:cheat_codes Calling hardhat_mine with params: [1] on http://127.0.0.1/:8545
22:16:14 [22:16:14.719] INFO: ethereum:cheat_codes Calling hardhat_mine with params: [1] on http://127.0.0.1/:8545
```

This PR attempts to fix it by running the test watcher more often, which shouldn't be too much of a problem since it should just run against local nodes. And also by forcing a test watcher run _before_ calling the cheat code in that test to advance the epoch.

Fingers crossed.