### PR TITLE
feat!: `#[utility]` function

### DIFF
--- a/boxes/boxes/react/src/contracts/src/main.nr
+++ b/boxes/boxes/react/src/contracts/src/main.nr
@@ -40,7 +40,7 @@ contract BoxReact {
     }
 
     #[utility]
-    unconstrained fn getNumber(owner: AztecAddress) -> pub ValueNote {
+    unconstrained fn getNumber(owner: AztecAddress) -> ValueNote {
         let numbers = storage.numbers;
         numbers.at(owner).view_note()
     }

--- a/boxes/boxes/react/src/contracts/src/main.nr
+++ b/boxes/boxes/react/src/contracts/src/main.nr
@@ -4,7 +4,7 @@ use dep::aztec::macros::aztec;
 contract BoxReact {
     use dep::aztec::{
         encrypted_logs::log_assembly_strategies::default_aes128::note::encode_and_encrypt_note,
-        macros::{functions::{initializer, private}, storage::storage},
+        macros::{functions::{initializer, private, utility}, storage::storage},
         prelude::{AztecAddress, Map, PrivateMutable},
     };
     use dep::value_note::value_note::ValueNote;
@@ -39,6 +39,7 @@ contract BoxReact {
         ));
     }
 
+    #[utility]
     unconstrained fn getNumber(owner: AztecAddress) -> pub ValueNote {
         let numbers = storage.numbers;
         numbers.at(owner).view_note()

--- a/boxes/boxes/vanilla/src/contracts/src/main.nr
+++ b/boxes/boxes/vanilla/src/contracts/src/main.nr
@@ -40,7 +40,7 @@ contract Vanilla {
     }
 
     #[utility]
-    unconstrained fn getNumber(owner: AztecAddress) -> pub ValueNote {
+    unconstrained fn getNumber(owner: AztecAddress) -> ValueNote {
         let numbers = storage.numbers;
         numbers.at(owner).view_note()
     }

--- a/boxes/boxes/vanilla/src/contracts/src/main.nr
+++ b/boxes/boxes/vanilla/src/contracts/src/main.nr
@@ -4,7 +4,7 @@ use dep::aztec::macros::aztec;
 contract Vanilla {
     use dep::aztec::{
         encrypted_logs::log_assembly_strategies::default_aes128::note::encode_and_encrypt_note,
-        macros::{functions::{initializer, private}, storage::storage},
+        macros::{functions::{initializer, private, utility}, storage::storage},
         prelude::{AztecAddress, Map, PrivateMutable},
     };
     use dep::value_note::value_note::ValueNote;
@@ -39,6 +39,7 @@ contract Vanilla {
         ));
     }
 
+    #[utility]
     unconstrained fn getNumber(owner: AztecAddress) -> pub ValueNote {
         let numbers = storage.numbers;
         numbers.at(owner).view_note()

--- a/boxes/boxes/vite/src/contracts/src/main.nr
+++ b/boxes/boxes/vite/src/contracts/src/main.nr
@@ -40,7 +40,7 @@ contract BoxReact {
     }
 
     #[utility]
-    unconstrained fn getNumber(owner: AztecAddress) -> pub ValueNote {
+    unconstrained fn getNumber(owner: AztecAddress) -> ValueNote {
         let numbers = storage.numbers;
         numbers.at(owner).view_note()
     }

--- a/boxes/boxes/vite/src/contracts/src/main.nr
+++ b/boxes/boxes/vite/src/contracts/src/main.nr
@@ -4,7 +4,7 @@ use dep::aztec::macros::aztec;
 contract BoxReact {
     use dep::aztec::{
         encrypted_logs::log_assembly_strategies::default_aes128::note::encode_and_encrypt_note,
-        macros::{functions::{initializer, private}, storage::storage},
+        macros::{functions::{initializer, private, utility}, storage::storage},
         prelude::{AztecAddress, Map, PrivateMutable},
     };
     use dep::value_note::value_note::ValueNote;
@@ -39,6 +39,7 @@ contract BoxReact {
         ));
     }
 
+    #[utility]
     unconstrained fn getNumber(owner: AztecAddress) -> pub ValueNote {
         let numbers = storage.numbers;
         numbers.at(owner).view_note()

--- a/cspell.json
+++ b/cspell.json
@@ -155,6 +155,7 @@
     "libp",
     "linkability",
     "lmdb",
+    "macroified",
     "maddiaa",
     "mcache",
     "memdown",

--- a/docs/docs/migration_notes.md
+++ b/docs/docs/migration_notes.md
@@ -8,6 +8,23 @@ Aztec is in full-speed development. Literally every version breaks compatibility
 
 ## 0.83.0
 
+### [Aztec.nr] #[utility] functions
+
+We've introduced a new type of contract function macro called #[utility].
+Utility functions are standalone unconstrained functions that cannot be called from another function in a contract.
+They are typically used either to obtain some information from the contract (e.g. token balance of a user) or to modify internal contract-related state of PXE (e.g. processing logs in Aztec.nr during sync).
+These function were originally referred to as top-level unconstrained.
+
+Now all the contract functions has to be marked as one of these: #[private], #[public], #[utility], #[contract_library_method], or #[test].
+For this reason you need to apply #[utility] macro to functions which were originally macro-free:
+
+```diff
++    #[utility]
+    unconstrained fn balance_of_private(owner: AztecAddress) -> pub u128 {
+        storage.balances.at(owner).balance_of()
+    }
+```
+
 ### [aztec.js] AztecNode.getPrivateEvents API change
 
 The `getPrivateEvents` method signature has changed to require an address of a contract that emitted the event and use recipient addresses instead of viewing public keys:

--- a/docs/docs/migration_notes.md
+++ b/docs/docs/migration_notes.md
@@ -6,7 +6,7 @@ keywords: [sandbox, aztec, notes, migration, updating, upgrading]
 
 Aztec is in full-speed development. Literally every version breaks compatibility with the previous ones. This page attempts to target errors and difficulties you might encounter when upgrading, and how to resolve them.
 
-## 0.83.0
+## TBD
 
 ### [Aztec.nr] #[utility] functions
 
@@ -20,10 +20,12 @@ For this reason you need to apply #[utility] macro to functions which were origi
 
 ```diff
 +    #[utility]
-    unconstrained fn balance_of_private(owner: AztecAddress) -> pub u128 {
+    unconstrained fn balance_of_private(owner: AztecAddress) -> u128 {
         storage.balances.at(owner).balance_of()
     }
 ```
+
+## 0.83.0
 
 ### [aztec.js] AztecNode.getPrivateEvents API change
 

--- a/docs/docs/migration_notes.md
+++ b/docs/docs/migration_notes.md
@@ -15,7 +15,7 @@ Utility functions are standalone unconstrained functions that cannot be called f
 They are typically used either to obtain some information from the contract (e.g. token balance of a user) or to modify internal contract-related state of PXE (e.g. processing logs in Aztec.nr during sync).
 These function were originally referred to as top-level unconstrained.
 
-Now all the contract functions has to be marked as one of these: #[private], #[public], #[utility], #[contract_library_method], or #[test].
+Now all the contract functions have to be marked as one of these: #[private], #[public], #[utility], #[contract_library_method], or #[test].
 For this reason you need to apply #[utility] macro to functions which were originally macro-free:
 
 ```diff

--- a/noir-projects/aztec-nr/aztec/src/macros/aztec.nr
+++ b/noir-projects/aztec-nr/aztec/src/macros/aztec.nr
@@ -13,7 +13,7 @@ use crate::{
 };
 
 /// Marks a contract as an Aztec contract, generating the interfaces for its functions and notes, as well as injecting
-/// the `process_log` and `sync_notes` functions PXE requires in order to discover notes.
+/// the `sync_notes` function PXE requires in order to discover notes.
 /// Note: This is a module annotation, so the returned quote gets injected inside the module (contract) itself.
 pub comptime fn aztec(m: Module) -> Quoted {
     let interface = generate_contract_interface(m);

--- a/noir-projects/aztec-nr/aztec/src/macros/aztec.nr
+++ b/noir-projects/aztec-nr/aztec/src/macros/aztec.nr
@@ -4,7 +4,7 @@ use crate::{
         dispatch::generate_public_dispatch,
         functions::{
             stub_registry,
-            utils::{create_message_discovery_call, find_and_transform_top_level_unconstrained_fns},
+            utils::{check_each_fn_macroified, create_message_discovery_call},
         },
         notes::{generate_note_export, NOTES},
         storage::STORAGE_LAYOUT_NAME,
@@ -18,7 +18,9 @@ use crate::{
 pub comptime fn aztec(m: Module) -> Quoted {
     let interface = generate_contract_interface(m);
 
-    find_and_transform_top_level_unconstrained_fns(m);
+    // Functions that don't have #[private], #[public], #[utility], #[contract_library_method], or #[test] are not
+    //allowed in contracts.
+    check_each_fn_macroified(m);
 
     let contract_library_method_compute_note_hash_and_nullifier =
         generate_contract_library_method_compute_note_hash_and_nullifier();

--- a/noir-projects/aztec-nr/aztec/src/macros/aztec.nr
+++ b/noir-projects/aztec-nr/aztec/src/macros/aztec.nr
@@ -13,7 +13,7 @@ use crate::{
 };
 
 /// Marks a contract as an Aztec contract, generating the interfaces for its functions and notes, as well as injecting
-/// the `sync_notes` function PXE requires in order to discover notes.
+/// the `sync_notes` utility function PXE requires in order to discover notes.
 /// Note: This is a module annotation, so the returned quote gets injected inside the module (contract) itself.
 pub comptime fn aztec(m: Module) -> Quoted {
     let interface = generate_contract_interface(m);

--- a/noir-projects/aztec-nr/aztec/src/macros/aztec.nr
+++ b/noir-projects/aztec-nr/aztec/src/macros/aztec.nr
@@ -270,12 +270,8 @@ comptime fn generate_note_exports() -> Quoted {
 comptime fn generate_sync_notes() -> Quoted {
     let message_discovery_call = create_message_discovery_call();
     quote {
+        #[aztec::macros::functions::utility]
         unconstrained fn sync_notes() {
-            // Because this unconstrained function is injected after the contract is processed by the macros, it'll not
-            // be modified by the macros that alter unconstrained functions. As such, we need to manually inject the
-            // unconstrained execution context since it will not be available otherwise.
-            let context = dep::aztec::context::unconstrained_context::UnconstrainedContext::new();
-
             $message_discovery_call
         }
     }

--- a/noir-projects/aztec-nr/aztec/src/macros/aztec.nr
+++ b/noir-projects/aztec-nr/aztec/src/macros/aztec.nr
@@ -269,6 +269,18 @@ comptime fn generate_note_exports() -> Quoted {
 
 comptime fn generate_sync_notes() -> Quoted {
     let message_discovery_call = create_message_discovery_call();
+
+    // TODO(https://github.com/noir-lang/noir/issues/7912): Doing the following unfortunately doesn't work. Once
+    // the issue is fixed uncomment the following and remove the workaround from TS (look for the issue link in the
+    // codebase).
+    // let utility: fn(FunctionDefinition) -> () = crate::macros::functions::utility;
+    // quote {
+    //     #[$utility]
+    //     unconstrained fn sync_notes() {
+    //         $message_discovery_call
+    //     }
+    // }
+
     quote {
         #[aztec::macros::functions::utility]
         unconstrained fn sync_notes() {

--- a/noir-projects/aztec-nr/aztec/src/macros/aztec.nr
+++ b/noir-projects/aztec-nr/aztec/src/macros/aztec.nr
@@ -19,7 +19,7 @@ pub comptime fn aztec(m: Module) -> Quoted {
     let interface = generate_contract_interface(m);
 
     // Functions that don't have #[private], #[public], #[utility], #[contract_library_method], or #[test] are not
-    //allowed in contracts.
+    // allowed in contracts.
     check_each_fn_macroified(m);
 
     let contract_library_method_compute_note_hash_and_nullifier =

--- a/noir-projects/aztec-nr/aztec/src/macros/functions/mod.nr
+++ b/noir-projects/aztec-nr/aztec/src/macros/functions/mod.nr
@@ -56,9 +56,9 @@ pub comptime fn public(f: FunctionDefinition) -> Quoted {
     }
 }
 
-/// Utility functions are standalone unconstrained functions that cannot be called from within a contract. They are
-/// typically used either to obtain some information from the contract (e.g. token balance of a user) or to modify
-/// internal contract-related state of PXE (e,g, processing logs in Aztec.nr during sync).
+/// Utility functions are standalone unconstrained functions that cannot be called from another function in a contract.
+/// They are typically used either to obtain some information from the contract (e.g. token balance of a user) or to
+/// modify internal contract-related state of PXE (e.g. processing logs in Aztec.nr during sync).
 pub comptime fn utility(f: FunctionDefinition) {
     transform_utility(f);
 }

--- a/noir-projects/aztec-nr/aztec/src/macros/functions/mod.nr
+++ b/noir-projects/aztec-nr/aztec/src/macros/functions/mod.nr
@@ -4,7 +4,7 @@ pub(crate) mod initialization_utils;
 pub(crate) mod stub_registry;
 pub(crate) mod utils;
 
-use utils::{transform_private, transform_public};
+use utils::{transform_private, transform_public, transform_utility};
 
 // Functions can have multiple attributes applied to them, e.g. a single function can have #[public], #[view] and
 // #[internal]. However. the order in which this will be evaluated is unknown, which makes combining them tricky.
@@ -54,4 +54,11 @@ pub comptime fn public(f: FunctionDefinition) -> Quoted {
     } else {
         transform_public(f)
     }
+}
+
+/// Utility functions are standalone unconstrained functions that cannot be called from within a contract. They are
+/// typically used either to obtain some information from the contract (e.g. token balance of a user) or to modify
+/// internal contract-related state of PXE (e,g, processing logs in Aztec.nr during sync).
+pub comptime fn utility(f: FunctionDefinition) {
+    transform_utility(f);
 }

--- a/noir-projects/aztec-nr/aztec/src/macros/functions/utils.nr
+++ b/noir-projects/aztec-nr/aztec/src/macros/functions/utils.nr
@@ -273,9 +273,19 @@ pub(crate) comptime fn transform_public(f: FunctionDefinition) -> Quoted {
 }
 
 pub(crate) comptime fn transform_utility(f: FunctionDefinition) {
+    // Check if function is marked as unconstrained
+    if !f.is_unconstrained() {
+        let name = f.name();
+        panic(
+            f"Function {name} is annotated with #[utility] but not marked as unconstrained, add unconstrained keyword",
+        );
+    }
+
+    // Create utility context
     let context_creation = quote { let mut context = dep::aztec::context::unconstrained_context::UnconstrainedContext::new(); };
     let module_has_storage = module_has_storage(f.module());
 
+    // Initialize Storage if module has storage
     let storage_init = if module_has_storage {
         quote {
             // Some functions don't access storage, but it'd be quite difficult to only inject this variable if it is
@@ -287,7 +297,7 @@ pub(crate) comptime fn transform_utility(f: FunctionDefinition) {
         quote {}
     };
 
-    // All unconstrained functions perform message discovery, since they may need to access private notes that would be
+    // All utility functions perform message discovery, since they may need to access private notes that would be
     // found during this process. This is slightly inefficient and could be improved by only doing it once we actually
     // attempt to read any.
     let message_discovery_call = if NOTES.len() > 0 {
@@ -296,6 +306,8 @@ pub(crate) comptime fn transform_utility(f: FunctionDefinition) {
         quote {}
     };
 
+    // Inject context creation, storage initialization, and message discovery call at the beginning of the function
+    // body.
     let to_prepend = quote {
         $context_creation
         $storage_init
@@ -303,8 +315,9 @@ pub(crate) comptime fn transform_utility(f: FunctionDefinition) {
     };
     let body = f.body().as_block().unwrap();
     let modified_body = modify_fn_body(body, to_prepend, quote {});
-    f.set_return_public(true);
     f.set_body(modified_body);
+
+    f.set_return_public(true);
 }
 
 comptime fn create_internal_check(f: FunctionDefinition) -> Quoted {

--- a/noir-projects/aztec-nr/aztec/src/macros/functions/utils.nr
+++ b/noir-projects/aztec-nr/aztec/src/macros/functions/utils.nr
@@ -2,9 +2,9 @@ use crate::macros::{
     functions::{abi_export::create_fn_abi_export, call_interface_stubs::stub_fn, stub_registry},
     notes::NOTES,
     utils::{
-        add_to_hasher, fn_has_noinitcheck, get_fn_visibility, is_fn_initializer, is_fn_internal,
-        is_fn_private, is_fn_public, is_fn_view, modify_fn_body, module_has_initializer,
-        module_has_storage,
+        add_to_hasher, fn_has_noinitcheck, get_fn_visibility, is_fn_contract_library_method,
+        is_fn_initializer, is_fn_internal, is_fn_private, is_fn_public, is_fn_test, is_fn_utility,
+        is_fn_view, modify_fn_body, module_has_initializer, module_has_storage,
     },
 };
 use protocol_types::meta::generate_serialize_to_fields;
@@ -272,45 +272,7 @@ pub(crate) comptime fn transform_public(f: FunctionDefinition) -> Quoted {
     fn_abi
 }
 
-pub(crate) comptime fn find_and_transform_top_level_unconstrained_fns(m: Module) {
-    // Top-level unconstrained fns are contract entrypoints, but they're not explicitly designated in any way. They're
-    // the fallback case for a function that matches no other rules.
-    // TODO(#12743): improve this
-
-    // We first find non-standard contract entrypoints, i.e. functions in the `contract` mod that are not private or
-    // public, but which *are* contract entrypoints (i.e. they're not opting out via the #[test] or
-    // #[contract_library_method] attributes). Ideally entrypoints would be explicitly designated instead.
-    let non_private_public_entrypoint_functions = m.functions().filter(|f: FunctionDefinition| {
-        !is_fn_private(f)
-            & !is_fn_public(f)
-            & !f.has_named_attribute("contract_library_method")
-            & !f.has_named_attribute("test")
-    });
-
-    // TODO: uncomment the code below and emit a warning once support for them is added to Noir (tracked in
-    // https://github.com/noir-lang/noir/issues/7714). We can't simply print a message since that'd otherwise break the
-    // output of utils such as `nargo test --list-tests`.
-    // // We don't expect to see any custom constrained entrypoints (i.e. private functions created outside of aztec-nr's
-    // // #[private] macro, possibly resulting in a non-standard interface).
-    // for f in non_private_public_entrypoint_functions.filter(|f: FunctionDefinition| {
-    //     !f.is_unconstrained()
-    // }) {
-    //     let name = f.name();
-    //     warn(
-    //         f"found private contract function '{name}' which does not have the #[private] attribute - make sure you know what you're doing!",
-    //     );
-    // }
-
-    // An unconstrained contract entrypoints is what we call a top-level unconstrained function, to which we apply the
-    // appropriate transformation. Ideally these would be explicitly designated as such instead.
-    for f in non_private_public_entrypoint_functions.filter(|f: FunctionDefinition| {
-        f.is_unconstrained()
-    }) {
-        transform_top_level_unconstrained(f);
-    }
-}
-
-pub(crate) comptime fn transform_top_level_unconstrained(f: FunctionDefinition) {
+pub(crate) comptime fn transform_utility(f: FunctionDefinition) {
     let context_creation = quote { let mut context = dep::aztec::context::unconstrained_context::UnconstrainedContext::new(); };
     let module_has_storage = module_has_storage(f.module());
 
@@ -393,5 +355,22 @@ pub(crate) comptime fn create_message_discovery_call() -> Quoted {
                 _compute_note_hash_and_nullifier,
             );
         };
+    }
+}
+
+/// Checks if each function in the module is marked with either #[private], #[public], #[utility],
+/// #[contract_library_method], or #[test]. Non-macroified functions are not allowed in contracts.
+pub(crate) comptime fn check_each_fn_macroified(m: Module) {
+    for f in m.functions() {
+        let name = f.name();
+        if !is_fn_private(f)
+            & !is_fn_public(f)
+            & !is_fn_utility(f)
+            & !is_fn_contract_library_method(f)
+            & !is_fn_test(f) {
+            panic(
+                f"Function {name} must be marked as either #[private], #[public], #[utility], #[contract_library_method], or #[test]",
+            );
+        }
     }
 }

--- a/noir-projects/aztec-nr/aztec/src/macros/utils.nr
+++ b/noir-projects/aztec-nr/aztec/src/macros/utils.nr
@@ -18,6 +18,18 @@ pub(crate) comptime fn is_fn_public(f: FunctionDefinition) -> bool {
     f.has_named_attribute("public")
 }
 
+pub(crate) comptime fn is_fn_utility(f: FunctionDefinition) -> bool {
+    f.has_named_attribute("utility")
+}
+
+pub(crate) comptime fn is_fn_contract_library_method(f: FunctionDefinition) -> bool {
+    f.has_named_attribute("contract_library_method")
+}
+
+pub(crate) comptime fn is_fn_test(f: FunctionDefinition) -> bool {
+    f.has_named_attribute("test")
+}
+
 pub(crate) comptime fn is_fn_view(f: FunctionDefinition) -> bool {
     f.has_named_attribute("view")
 }

--- a/noir-projects/noir-contracts/contracts/amm_contract/src/main.nr
+++ b/noir-projects/noir-contracts/contracts/amm_contract/src/main.nr
@@ -39,7 +39,7 @@ pub contract AMM {
         lib::{get_amount_in, get_amount_out, get_amounts_on_remove, get_amounts_to_add},
     };
     use dep::aztec::{
-        macros::{functions::{initializer, internal, private, public}, storage::storage},
+        macros::{functions::{initializer, internal, private, public, utility}, storage::storage},
         prelude::{AztecAddress, PublicImmutable},
     };
 
@@ -461,6 +461,7 @@ pub contract AMM {
         );
     }
 
+    #[utility]
     unconstrained fn get_amount_out_for_exact_in(
         balance_in: u128,
         balance_out: u128,
@@ -470,6 +471,7 @@ pub contract AMM {
         get_amount_out(amount_in, balance_in, balance_out)
     }
 
+    #[utility]
     unconstrained fn get_amount_in_for_exact_out(
         balance_in: u128,
         balance_out: u128,

--- a/noir-projects/noir-contracts/contracts/app_subscription_contract/src/main.nr
+++ b/noir-projects/noir-contracts/contracts/app_subscription_contract/src/main.nr
@@ -11,7 +11,7 @@ pub contract AppSubscription {
     use authwit::auth::assert_current_call_valid_authwit;
     use aztec::{
         encrypted_logs::log_assembly_strategies::default_aes128::note::encode_and_encrypt_note,
-        macros::{functions::{initializer, private, public}, storage::storage},
+        macros::{functions::{initializer, private, public, utility}, storage::storage},
         prelude::{AztecAddress, Map, PrivateMutable, PublicImmutable},
         protocol_types::{constants::MAX_FIELD_VALUE, traits::ToField},
         utils::comparison::Comparator,
@@ -115,6 +115,7 @@ pub contract AppSubscription {
         );
     }
 
+    #[utility]
     unconstrained fn is_initialized(subscriber: AztecAddress) -> pub bool {
         storage.subscriptions.at(subscriber).is_initialized()
     }

--- a/noir-projects/noir-contracts/contracts/app_subscription_contract/src/main.nr
+++ b/noir-projects/noir-contracts/contracts/app_subscription_contract/src/main.nr
@@ -116,7 +116,7 @@ pub contract AppSubscription {
     }
 
     #[utility]
-    unconstrained fn is_initialized(subscriber: AztecAddress) -> pub bool {
+    unconstrained fn is_initialized(subscriber: AztecAddress) -> bool {
         storage.subscriptions.at(subscriber).is_initialized()
     }
 }

--- a/noir-projects/noir-contracts/contracts/auth_registry_contract/src/main.nr
+++ b/noir-projects/noir-contracts/contracts/auth_registry_contract/src/main.nr
@@ -132,7 +132,7 @@ pub contract AuthRegistry {
     unconstrained fn unconstrained_is_consumable(
         on_behalf_of: AztecAddress,
         message_hash: Field,
-    ) -> pub bool {
+    ) -> bool {
         storage.approved_actions.at(on_behalf_of).at(message_hash).read()
     }
 }

--- a/noir-projects/noir-contracts/contracts/auth_registry_contract/src/main.nr
+++ b/noir-projects/noir-contracts/contracts/auth_registry_contract/src/main.nr
@@ -6,7 +6,7 @@ pub contract AuthRegistry {
         assert_current_call_valid_authwit, compute_authwit_message_hash, IS_VALID_SELECTOR,
     };
     use dep::aztec::{
-        macros::{functions::{internal, private, public, view}, storage::storage},
+        macros::{functions::{internal, private, public, utility, view}, storage::storage},
         protocol_types::address::AztecAddress,
         state_vars::{Map, PublicMutable},
     };
@@ -128,6 +128,7 @@ pub contract AuthRegistry {
         storage.approved_actions.at(on_behalf_of).at(message_hash).read()
     }
 
+    #[utility]
     unconstrained fn unconstrained_is_consumable(
         on_behalf_of: AztecAddress,
         message_hash: Field,

--- a/noir-projects/noir-contracts/contracts/card_game_contract/src/main.nr
+++ b/noir-projects/noir-contracts/contracts/card_game_contract/src/main.nr
@@ -12,7 +12,7 @@ pub contract CardGame {
 
     use crate::cards::{Card, compute_deck_strength, Deck, get_pack_cards};
     use crate::game::{Game, PLAYABLE_CARDS, PlayerEntry};
-    use dep::aztec::macros::{functions::{internal, private, public}, storage::storage};
+    use dep::aztec::macros::{functions::{internal, private, public, utility}, storage::storage};
 
     use dep::aztec::protocol_types::traits::{FromField, ToField};
 
@@ -134,6 +134,7 @@ pub contract CardGame {
         game_storage.write(game_data);
     }
 
+    #[utility]
     unconstrained fn view_collection_cards(
         owner: AztecAddress,
         offset: u32,
@@ -142,6 +143,7 @@ pub contract CardGame {
         collection.view_cards(offset)
     }
 
+    #[utility]
     unconstrained fn view_game_cards(
         game: u32,
         player: AztecAddress,
@@ -152,6 +154,7 @@ pub contract CardGame {
         game_deck.view_cards(offset)
     }
 
+    #[utility]
     unconstrained fn view_game(game: u32) -> pub Game {
         storage.games.at(game as Field).read()
     }

--- a/noir-projects/noir-contracts/contracts/card_game_contract/src/main.nr
+++ b/noir-projects/noir-contracts/contracts/card_game_contract/src/main.nr
@@ -138,7 +138,7 @@ pub contract CardGame {
     unconstrained fn view_collection_cards(
         owner: AztecAddress,
         offset: u32,
-    ) -> pub BoundedVec<Card, MAX_NOTES_PER_PAGE> {
+    ) -> BoundedVec<Card, MAX_NOTES_PER_PAGE> {
         let collection = storage.collections.at(owner);
         collection.view_cards(offset)
     }
@@ -148,14 +148,14 @@ pub contract CardGame {
         game: u32,
         player: AztecAddress,
         offset: u32,
-    ) -> pub BoundedVec<Card, MAX_NOTES_PER_PAGE> {
+    ) -> BoundedVec<Card, MAX_NOTES_PER_PAGE> {
         let game_deck = storage.game_decks.at(game as Field).at(player);
 
         game_deck.view_cards(offset)
     }
 
     #[utility]
-    unconstrained fn view_game(game: u32) -> pub Game {
+    unconstrained fn view_game(game: u32) -> Game {
         storage.games.at(game as Field).read()
     }
 }

--- a/noir-projects/noir-contracts/contracts/counter_contract/src/main.nr
+++ b/noir-projects/noir-contracts/contracts/counter_contract/src/main.nr
@@ -6,7 +6,7 @@ use dep::aztec::macros::aztec;
 pub contract Counter {
     // docs:end:setup
     // docs:start:imports
-    use aztec::macros::{functions::{initializer, private}, storage::storage};
+    use aztec::macros::{functions::{initializer, private, utility}, storage::storage};
     use aztec::prelude::{AztecAddress, Map};
     use aztec::protocol_types::traits::{FromField, ToField};
     use easy_private_state::EasyPrivateUint;
@@ -83,6 +83,7 @@ pub contract Counter {
     }
 
     // docs:start:get_counter
+    #[utility]
     unconstrained fn get_counter(owner: AztecAddress) -> pub Field {
         let counters = storage.counters;
         balance_utils::get_balance(counters.at(owner).set)

--- a/noir-projects/noir-contracts/contracts/counter_contract/src/main.nr
+++ b/noir-projects/noir-contracts/contracts/counter_contract/src/main.nr
@@ -84,7 +84,7 @@ pub contract Counter {
 
     // docs:start:get_counter
     #[utility]
-    unconstrained fn get_counter(owner: AztecAddress) -> pub Field {
+    unconstrained fn get_counter(owner: AztecAddress) -> Field {
         let counters = storage.counters;
         balance_utils::get_balance(counters.at(owner).set)
     }

--- a/noir-projects/noir-contracts/contracts/docs_example_contract/src/main.nr
+++ b/noir-projects/noir-contracts/contracts/docs_example_contract/src/main.nr
@@ -18,7 +18,10 @@ pub contract DocsExample {
     // how to import dependencies defined in your workspace
     use dep::aztec::{
         encrypted_logs::log_assembly_strategies::default_aes128::note::encode_and_encrypt_note,
-        macros::{functions::{internal, private, public, view}, storage::{storage, storage_no_init}},
+        macros::{
+            functions::{internal, private, public, utility, view},
+            storage::{storage, storage_no_init},
+        },
         note::note_interface::NoteProperties,
         protocol_types::traits::Hash,
     };
@@ -159,6 +162,7 @@ pub contract DocsExample {
     }
 
     // docs:start:read_public_immutable
+    #[utility]
     unconstrained fn get_public_immutable() -> Leader {
         storage.public_immutable.read()
         // docs:end:read_public_immutable
@@ -211,12 +215,15 @@ pub contract DocsExample {
             context.msg_sender(),
         ));
     }
+
     // docs:start:state_vars-NoteGetterOptionsComparatorExampleNoir
+    #[utility]
     unconstrained fn read_note(comparator: u8, amount: Field) -> BoundedVec<CardNote, 10> {
         let mut options = NoteViewerOptions::new();
         storage.set.view_notes(options.select(CardNote::properties().points, comparator, amount))
     }
     // docs:end:state_vars-NoteGetterOptionsComparatorExampleNoir
+
     #[private]
     fn update_legendary_card(randomness: Field, points: u8) {
         let new_card = CardNote::new(points, randomness, context.msg_sender());
@@ -278,26 +285,37 @@ pub contract DocsExample {
         let new_leader = Leader { account, points };
         storage.leader.write(new_leader);
     }
+
+    #[utility]
     unconstrained fn get_leader() -> Leader {
         storage.leader.read()
     }
+
+    #[utility]
     unconstrained fn get_legendary_card() -> CardNote {
         storage.legendary_card.view_note()
     }
+
     // docs:start:private_mutable_is_initialized
+    #[utility]
     unconstrained fn is_legendary_initialized() -> bool {
         storage.legendary_card.is_initialized()
     }
     // docs:end:private_mutable_is_initialized
+
     // docs:start:get_note-private-immutable
     #[private]
     fn get_imm_card() -> CardNote {
         storage.private_immutable.get_note()
     }
     // docs:end:get_note-private-immutable
+
+    #[utility]
     unconstrained fn view_imm_card() -> CardNote {
         storage.private_immutable.view_note()
     }
+
+    #[utility]
     unconstrained fn is_priv_imm_initialized() -> bool {
         storage.private_immutable.is_initialized()
     }
@@ -310,6 +328,11 @@ pub contract DocsExample {
         a + b
     }
     // docs:end:simple_macro_example
+
+    // We mark the following function as a contract library method because it is mandatory that a contract function has
+    // a macro applied to it. Since this function is not used and is only for documentation purposes, we mark it as a
+    // contract library method to avoid compilation error.
+    #[contract_library_method]
     // docs:start:simple_macro_example_expanded
     fn simple_macro_example_expanded(
         // ************************************************************
@@ -323,7 +346,7 @@ pub contract DocsExample {
         b: Field, // The actual return type of our circuit is the PrivateCircuitPublicInputs struct, this will be the
         // input to our kernel!
         // docs:start:context-example-return
-    ) -> pub PrivateCircuitPublicInputs {
+    ) -> PrivateCircuitPublicInputs {
         // docs:end:context-example-return
         // ************************************************************
         // The hasher is a structure used to generate a hash of the circuits inputs.

--- a/noir-projects/noir-contracts/contracts/easy_private_token_contract/src/main.nr
+++ b/noir-projects/noir-contracts/contracts/easy_private_token_contract/src/main.nr
@@ -43,7 +43,7 @@ pub contract EasyPrivateToken {
 
     // Helper function to get the balance of a user.
     #[utility]
-    unconstrained fn get_balance(owner: AztecAddress) -> pub Field {
+    unconstrained fn get_balance(owner: AztecAddress) -> Field {
         let balances = storage.balances;
 
         // Return the sum of all notes in the set.

--- a/noir-projects/noir-contracts/contracts/easy_private_token_contract/src/main.nr
+++ b/noir-projects/noir-contracts/contracts/easy_private_token_contract/src/main.nr
@@ -3,7 +3,7 @@ use dep::aztec::macros::aztec;
 
 #[aztec]
 pub contract EasyPrivateToken {
-    use dep::aztec::macros::{functions::{initializer, private}, storage::storage};
+    use dep::aztec::macros::{functions::{initializer, private, utility}, storage::storage};
     use dep::aztec::prelude::{AztecAddress, Map};
     use dep::easy_private_state::EasyPrivateUint;
     use dep::value_note::balance_utils;
@@ -41,7 +41,8 @@ pub contract EasyPrivateToken {
         balances.at(recipient).add(amount, recipient, sender);
     }
 
-    // Helper function to get the balance of a user ("unconstrained" is a Noir alternative of Solidity's "view" function).
+    // Helper function to get the balance of a user.
+    #[utility]
     unconstrained fn get_balance(owner: AztecAddress) -> pub Field {
         let balances = storage.balances;
 

--- a/noir-projects/noir-contracts/contracts/easy_private_voting_contract/src/main.nr
+++ b/noir-projects/noir-contracts/contracts/easy_private_voting_contract/src/main.nr
@@ -69,7 +69,7 @@ pub contract EasyPrivateVoting {
     // docs:end:end_vote
     // docs:start:get_vote
     #[utility]
-    unconstrained fn get_vote(candidate: Field) -> pub Field {
+    unconstrained fn get_vote(candidate: Field) -> Field {
         storage.tally.at(candidate).read()
     }
     // docs:end:get_vote

--- a/noir-projects/noir-contracts/contracts/easy_private_voting_contract/src/main.nr
+++ b/noir-projects/noir-contracts/contracts/easy_private_voting_contract/src/main.nr
@@ -8,7 +8,7 @@ pub contract EasyPrivateVoting {
     // docs:start:imports
     use dep::aztec::{
         keys::getters::get_public_keys,
-        macros::{functions::{initializer, internal, private, public}, storage::storage},
+        macros::{functions::{initializer, internal, private, public, utility}, storage::storage},
     };
     use dep::aztec::prelude::{AztecAddress, Map, PublicImmutable, PublicMutable};
     use dep::aztec::protocol_types::traits::{Hash, ToField};
@@ -68,6 +68,7 @@ pub contract EasyPrivateVoting {
     }
     // docs:end:end_vote
     // docs:start:get_vote
+    #[utility]
     unconstrained fn get_vote(candidate: Field) -> pub Field {
         storage.tally.at(candidate).read()
     }

--- a/noir-projects/noir-contracts/contracts/nft_contract/src/main.nr
+++ b/noir-projects/noir-contracts/contracts/nft_contract/src/main.nr
@@ -17,7 +17,7 @@ pub contract NFT {
         encrypted_logs::log_assembly_strategies::default_aes128::note::encode_and_encrypt_note,
         macros::{
             events::event,
-            functions::{initializer, internal, private, public, view},
+            functions::{initializer, internal, private, public, utility, view},
             storage::storage,
         },
         note::{constants::MAX_NOTES_PER_PAGE, note_interface::NoteProperties},
@@ -343,6 +343,7 @@ pub contract NFT {
     /// reached. Starts getting the notes from page with index `page_index`. Zero values in the array are placeholder
     /// values for non-existing notes.
     // docs:start:get_private_nfts
+    #[utility]
     unconstrained fn get_private_nfts(
         owner: AztecAddress,
         page_index: u32,

--- a/noir-projects/noir-contracts/contracts/nft_contract/src/main.nr
+++ b/noir-projects/noir-contracts/contracts/nft_contract/src/main.nr
@@ -347,7 +347,7 @@ pub contract NFT {
     unconstrained fn get_private_nfts(
         owner: AztecAddress,
         page_index: u32,
-    ) -> pub ([Field; MAX_NOTES_PER_PAGE], bool) {
+    ) -> ([Field; MAX_NOTES_PER_PAGE], bool) {
         let offset = page_index * MAX_NOTES_PER_PAGE;
         let mut options = NoteViewerOptions::new();
         let notes = storage.private_nfts.at(owner).view_notes(options.set_offset(offset));

--- a/noir-projects/noir-contracts/contracts/schnorr_account_contract/src/main.nr
+++ b/noir-projects/noir-contracts/contracts/schnorr_account_contract/src/main.nr
@@ -93,7 +93,7 @@ pub contract SchnorrAccount {
     * @return True if the message_hash can be consumed, false otherwise
     */
     #[utility]
-    unconstrained fn lookup_validity(consumer: AztecAddress, inner_hash: Field) -> pub bool {
+    unconstrained fn lookup_validity(consumer: AztecAddress, inner_hash: Field) -> bool {
         let public_key = storage.signing_public_key.view_note();
 
         let message_hash = compute_authwit_message_hash(

--- a/noir-projects/noir-contracts/contracts/schnorr_account_contract/src/main.nr
+++ b/noir-projects/noir-contracts/contracts/schnorr_account_contract/src/main.nr
@@ -15,7 +15,7 @@ pub contract SchnorrAccount {
     use dep::aztec::encrypted_logs::log_assembly_strategies::default_aes128::note::encode_and_encrypt_note;
     use dep::aztec::hash::compute_siloed_nullifier;
     use dep::aztec::macros::{
-        functions::{initializer, noinitcheck, private, view},
+        functions::{initializer, noinitcheck, private, utility, view},
         storage::storage,
     };
     use dep::aztec::oracle::get_nullifier_membership_witness::get_low_nullifier_membership_witness;
@@ -92,6 +92,7 @@ pub contract SchnorrAccount {
     * @param message_hash The message hash of the message to check the validity
     * @return True if the message_hash can be consumed, false otherwise
     */
+    #[utility]
     unconstrained fn lookup_validity(consumer: AztecAddress, inner_hash: Field) -> pub bool {
         let public_key = storage.signing_public_key.view_note();
 

--- a/noir-projects/noir-contracts/contracts/stateful_test_contract/src/main.nr
+++ b/noir-projects/noir-contracts/contracts/stateful_test_contract/src/main.nr
@@ -99,7 +99,7 @@ pub contract StatefulTest {
     }
 
     #[utility]
-    unconstrained fn summed_values(owner: AztecAddress) -> pub Field {
+    unconstrained fn summed_values(owner: AztecAddress) -> Field {
         let owner_balance = storage.notes.at(owner);
 
         // docs:start:get_balance

--- a/noir-projects/noir-contracts/contracts/stateful_test_contract/src/main.nr
+++ b/noir-projects/noir-contracts/contracts/stateful_test_contract/src/main.nr
@@ -6,7 +6,7 @@ pub contract StatefulTest {
     use dep::aztec::macros::{
         functions::{
             initialization_utils::assert_is_initialized_private, initializer, noinitcheck, private,
-            public, view,
+            public, utility, view,
         },
         storage::storage,
     };
@@ -98,6 +98,7 @@ pub contract StatefulTest {
         loc.write(loc.read() + value);
     }
 
+    #[utility]
     unconstrained fn summed_values(owner: AztecAddress) -> pub Field {
         let owner_balance = storage.notes.at(owner);
 

--- a/noir-projects/noir-contracts/contracts/test_contract/src/main.nr
+++ b/noir-projects/noir-contracts/contracts/test_contract/src/main.nr
@@ -38,7 +38,7 @@ pub contract Test {
         history::note_inclusion::ProveNoteInclusion,
         macros::{
             events::event,
-            functions::{initializer, internal, noinitcheck, private, public},
+            functions::{initializer, internal, noinitcheck, private, public, utility},
             storage::storage,
         },
         note::{
@@ -193,6 +193,7 @@ pub contract Test {
         [retrieved_notes.get(0).note.value, retrieved_notes.get(1).note.value]
     }
 
+    #[utility]
     unconstrained fn call_view_notes(storage_slot: Field, active_or_nullified: bool) -> pub Field {
         assert(
             storage_slot
@@ -210,6 +211,7 @@ pub contract Test {
         notes.get(0).value
     }
 
+    #[utility]
     unconstrained fn call_view_notes_many(
         storage_slot: Field,
         active_or_nullified: bool,
@@ -453,6 +455,7 @@ pub contract Test {
         storage.example_constant.initialize(note).discard();
     }
 
+    #[utility]
     unconstrained fn deliver_note(
         contract_address: AztecAddress,
         value: Field,
@@ -518,6 +521,7 @@ pub contract Test {
         aztec_deploy_contract(&mut context, target);
     }
 
+    #[utility]
     unconstrained fn get_constant() -> pub Field {
         let constant = storage.example_constant.view_note();
         constant.get_value()

--- a/noir-projects/noir-contracts/contracts/test_contract/src/main.nr
+++ b/noir-projects/noir-contracts/contracts/test_contract/src/main.nr
@@ -194,7 +194,7 @@ pub contract Test {
     }
 
     #[utility]
-    unconstrained fn call_view_notes(storage_slot: Field, active_or_nullified: bool) -> pub Field {
+    unconstrained fn call_view_notes(storage_slot: Field, active_or_nullified: bool) -> Field {
         assert(
             storage_slot
                 != aztec::state_vars::storage::Storage::get_storage_slot(storage.example_constant),
@@ -215,7 +215,7 @@ pub contract Test {
     unconstrained fn call_view_notes_many(
         storage_slot: Field,
         active_or_nullified: bool,
-    ) -> pub [Field; 2] {
+    ) -> [Field; 2] {
         assert(
             storage_slot
                 != aztec::state_vars::storage::Storage::get_storage_slot(storage.example_constant),
@@ -522,7 +522,7 @@ pub contract Test {
     }
 
     #[utility]
-    unconstrained fn get_constant() -> pub Field {
+    unconstrained fn get_constant() -> Field {
         let constant = storage.example_constant.view_note();
         constant.get_value()
     }

--- a/noir-projects/noir-contracts/contracts/token_blacklist_contract/src/main.nr
+++ b/noir-projects/noir-contracts/contracts/token_blacklist_contract/src/main.nr
@@ -23,7 +23,10 @@ pub contract TokenBlacklist {
             encode_and_encrypt_note, encode_and_encrypt_note_unconstrained,
         },
         hash::compute_secret_hash,
-        macros::{functions::{initializer, internal, private, public, view}, storage::storage},
+        macros::{
+            functions::{initializer, internal, private, public, utility, view},
+            storage::storage,
+        },
         prelude::{AztecAddress, Map, NoteGetterOptions, PrivateSet, PublicMutable, SharedMutable},
         utils::comparison::Comparator,
     };
@@ -293,12 +296,13 @@ pub contract TokenBlacklist {
         storage.total_supply.write(new_supply);
     }
 
-    /// Unconstrained ///
+    #[utility]
     unconstrained fn balance_of_private(owner: AztecAddress) -> pub Field {
         storage.balances.balance_of(owner).to_field()
     }
 
     // docs:start:deliver_note_contract_method
+    #[utility]
     unconstrained fn deliver_transparent_note(
         contract_address: AztecAddress,
         amount: u128,

--- a/noir-projects/noir-contracts/contracts/token_blacklist_contract/src/main.nr
+++ b/noir-projects/noir-contracts/contracts/token_blacklist_contract/src/main.nr
@@ -297,7 +297,7 @@ pub contract TokenBlacklist {
     }
 
     #[utility]
-    unconstrained fn balance_of_private(owner: AztecAddress) -> pub Field {
+    unconstrained fn balance_of_private(owner: AztecAddress) -> Field {
         storage.balances.balance_of(owner).to_field()
     }
 

--- a/noir-projects/noir-contracts/contracts/token_contract/src/main.nr
+++ b/noir-projects/noir-contracts/contracts/token_contract/src/main.nr
@@ -620,7 +620,7 @@ pub contract Token {
 
     // docs:start:balance_of_private
     #[utility]
-    pub(crate) unconstrained fn balance_of_private(owner: AztecAddress) -> pub u128 {
+    pub(crate) unconstrained fn balance_of_private(owner: AztecAddress) -> u128 {
         storage.balances.at(owner).balance_of()
     }
     // docs:end:balance_of_private

--- a/noir-projects/noir-contracts/contracts/token_contract/src/main.nr
+++ b/noir-projects/noir-contracts/contracts/token_contract/src/main.nr
@@ -27,7 +27,7 @@ pub contract Token {
         event::event_interface::EventInterface,
         macros::{
             events::event,
-            functions::{initializer, internal, private, public, view},
+            functions::{initializer, internal, private, public, utility, view},
             storage::storage,
         },
         prelude::{AztecAddress, Map, PublicContext, PublicImmutable, PublicMutable},
@@ -618,8 +618,8 @@ pub contract Token {
     }
     // docs:end:reduce_total_supply
 
-    /// Unconstrained ///
     // docs:start:balance_of_private
+    #[utility]
     pub(crate) unconstrained fn balance_of_private(owner: AztecAddress) -> pub u128 {
         storage.balances.at(owner).balance_of()
     }

--- a/noir-projects/noir-contracts/contracts/updatable_contract/src/main.nr
+++ b/noir-projects/noir-contracts/contracts/updatable_contract/src/main.nr
@@ -3,7 +3,7 @@ use dep::aztec::macros::aztec;
 #[aztec]
 contract Updatable {
     use aztec::encrypted_logs::log_assembly_strategies::default_aes128::note::encode_and_encrypt_note;
-    use aztec::macros::{functions::{initializer, private, public}, storage::storage};
+    use aztec::macros::{functions::{initializer, private, public, utility}, storage::storage};
     use aztec::prelude::{PrivateMutable, PublicMutable};
 
     use aztec::protocol_types::{
@@ -55,10 +55,12 @@ contract Updatable {
         ContractInstanceDeployer::at(DEPLOYER_CONTRACT_ADDRESS).get_update_delay().view(&mut context)
     }
 
+    #[utility]
     unconstrained fn get_private_value() -> pub Field {
         storage.private_value.view_note().value
     }
 
+    #[utility]
     unconstrained fn get_public_value() -> pub Field {
         storage.public_value.read()
     }

--- a/noir-projects/noir-contracts/contracts/updatable_contract/src/main.nr
+++ b/noir-projects/noir-contracts/contracts/updatable_contract/src/main.nr
@@ -56,12 +56,12 @@ contract Updatable {
     }
 
     #[utility]
-    unconstrained fn get_private_value() -> pub Field {
+    unconstrained fn get_private_value() -> Field {
         storage.private_value.view_note().value
     }
 
     #[utility]
-    unconstrained fn get_public_value() -> pub Field {
+    unconstrained fn get_public_value() -> Field {
         storage.public_value.read()
     }
 

--- a/noir-projects/noir-contracts/contracts/updated_contract/src/main.nr
+++ b/noir-projects/noir-contracts/contracts/updated_contract/src/main.nr
@@ -3,7 +3,7 @@ use dep::aztec::macros::aztec;
 #[aztec]
 contract Updated {
     use aztec::encrypted_logs::log_assembly_strategies::default_aes128::note::encode_and_encrypt_note;
-    use aztec::macros::{functions::{private, public}, storage::storage};
+    use aztec::macros::{functions::{private, public, utility}, storage::storage};
     use aztec::prelude::{PrivateMutable, PublicMutable};
 
     use aztec::protocol_types::constants::DEPLOYER_CONTRACT_ADDRESS;
@@ -37,10 +37,12 @@ contract Updated {
         ContractInstanceDeployer::at(DEPLOYER_CONTRACT_ADDRESS).get_update_delay().view(&mut context)
     }
 
+    #[utility]
     unconstrained fn get_private_value() -> pub Field {
         storage.private_value.view_note().value
     }
 
+    #[utility]
     unconstrained fn get_public_value() -> pub Field {
         storage.public_value.read()
     }

--- a/noir-projects/noir-contracts/contracts/updated_contract/src/main.nr
+++ b/noir-projects/noir-contracts/contracts/updated_contract/src/main.nr
@@ -38,12 +38,12 @@ contract Updated {
     }
 
     #[utility]
-    unconstrained fn get_private_value() -> pub Field {
+    unconstrained fn get_private_value() -> Field {
         storage.private_value.view_note().value
     }
 
     #[utility]
-    unconstrained fn get_public_value() -> pub Field {
+    unconstrained fn get_public_value() -> Field {
         storage.public_value.read()
     }
 


### PR DESCRIPTION
Partially addresses https://github.com/AztecProtocol/aztec-packages/issues/12743 (partially as the rest will be addressed in PRs up the stacks)

Introduces a `#[utility]` macro for top-level unconstrained functions and applies it to all the relevant functions.