### PR TITLE
feat: register private-only contracts in cli-wallet and misc improvements

### DIFF
--- a/yarn-project/cli-wallet/src/bin/index.ts
+++ b/yarn-project/cli-wallet/src/bin/index.ts
@@ -1,4 +1,4 @@
-import { Fr, computeSecretHash, fileURLToPath } from '@aztec/aztec.js';
+import { Fr, computeSecretHash, createCompatibleClient, fileURLToPath } from '@aztec/aztec.js';
 import { LOCALHOST } from '@aztec/cli/cli-utils';
 import { type LogFn, createConsoleLogger, createLogger } from '@aztec/foundation/log';
 import { openStoreAt } from '@aztec/kv-store/lmdb-v2';
@@ -90,7 +90,7 @@ async function main() {
         .default(`http://${LOCALHOST}:8080`),
     )
     .hook('preSubcommand', async command => {
-      const { dataDir, remotePxe, nodeUrl, prover } = command.optsWithGlobals();
+      const { dataDir, remotePxe, nodeUrl, prover, rpcUrl } = command.optsWithGlobals();
 
       if (!remotePxe) {
         debugLogger.info('Using local PXE service');
@@ -113,6 +113,25 @@ async function main() {
         await pxeWrapper.init(nodeUrl, join(dataDir, 'pxe'), overridePXEConfig);
       }
       await db.init(await openStoreAt(dataDir));
+      let protocolContractsRegistered;
+      try {
+        protocolContractsRegistered = !!(await db.retrieveAlias('contracts:classRegisterer'));
+        // eslint-disable-next-line no-empty
+      } catch {}
+      if (!protocolContractsRegistered) {
+        userLog('Registering protocol contract aliases...');
+        const client = pxeWrapper?.getPXE() ?? (await createCompatibleClient(rpcUrl, debugLogger));
+        const { protocolContractAddresses } = await client.getPXEInfo();
+        for (const [name, address] of Object.entries(protocolContractAddresses)) {
+          await db.storeAlias('contracts', name, Buffer.from(address.toString()), userLog);
+          await db.storeAlias(
+            'artifacts',
+            address.toString(),
+            Buffer.from(`${name.slice(0, 1).toUpperCase()}${name.slice(1)}`),
+            userLog,
+          );
+        }
+      }
     });
 
   injectCommands(program, userLog, debugLogger, db, pxeWrapper);

--- a/yarn-project/cli-wallet/src/cmds/deploy.ts
+++ b/yarn-project/cli-wallet/src/cmds/deploy.ts
@@ -1,13 +1,12 @@
 import { type AccountWalletWithSecretKey, ContractDeployer, type DeployOptions, Fr, type PXE } from '@aztec/aztec.js';
 import { encodeArgs, getContractArtifact } from '@aztec/cli/utils';
 import type { LogFn, Logger } from '@aztec/foundation/log';
-import { getInitializer } from '@aztec/stdlib/abi';
+import { getAllFunctionAbis, getInitializer } from '@aztec/stdlib/abi';
 import { PublicKeys } from '@aztec/stdlib/keys';
 
 import { type IFeeOpts, printGasEstimates } from '../utils/options/fees.js';
 
 export async function deploy(
-  client: PXE,
   wallet: AccountWalletWithSecretKey,
   artifactPath: string,
   json: boolean,
@@ -27,7 +26,8 @@ export async function deploy(
 ) {
   salt ??= Fr.random();
   const contractArtifact = await getContractArtifact(artifactPath, log);
-  const constructorArtifact = getInitializer(contractArtifact, initializer);
+  const hasInitializer = getAllFunctionAbis(contractArtifact).some(fn => fn.isInitializer);
+  const constructorArtifact = hasInitializer ? getInitializer(contractArtifact, initializer) : undefined;
 
   // TODO(#12081): Add contractArtifact.noirVersion and check here (via Noir.lock)?
 

--- a/yarn-project/cli-wallet/src/cmds/deploy.ts
+++ b/yarn-project/cli-wallet/src/cmds/deploy.ts
@@ -1,4 +1,4 @@
-import { type AccountWalletWithSecretKey, ContractDeployer, type DeployOptions, Fr, type PXE } from '@aztec/aztec.js';
+import { type AccountWalletWithSecretKey, ContractDeployer, type DeployOptions, Fr } from '@aztec/aztec.js';
 import { encodeArgs, getContractArtifact } from '@aztec/cli/utils';
 import type { LogFn, Logger } from '@aztec/foundation/log';
 import { getAllFunctionAbis, getInitializer } from '@aztec/stdlib/abi';

--- a/yarn-project/cli-wallet/src/cmds/register_contract.ts
+++ b/yarn-project/cli-wallet/src/cmds/register_contract.ts
@@ -1,6 +1,14 @@
-import type { AccountWalletWithSecretKey, AztecAddress, AztecNode } from '@aztec/aztec.js';
+import {
+  type AccountWalletWithSecretKey,
+  type AztecAddress,
+  type AztecNode,
+  type Fr,
+  PublicKeys,
+  getContractInstanceFromDeployParams,
+} from '@aztec/aztec.js';
 import { getContractArtifact } from '@aztec/cli/cli-utils';
-import type { LogFn } from '@aztec/foundation/log';
+import { type LogFn } from '@aztec/foundation/log';
+import { getAllFunctionAbis, getInitializer } from '@aztec/stdlib/abi';
 
 export async function registerContract(
   wallet: AccountWalletWithSecretKey,
@@ -8,11 +16,28 @@ export async function registerContract(
   address: AztecAddress,
   artifactPath: string,
   log: LogFn,
+  initializer?: string,
+  publicKeys?: PublicKeys,
+  rawArgs?: any[],
+  salt?: Fr,
+  deployer?: AztecAddress | undefined,
 ) {
   const contractArtifact = await getContractArtifact(artifactPath, log);
-  const contractInstance = await node.getContract(address);
+  const hasInitializer = getAllFunctionAbis(contractArtifact).some(fn => fn.isInitializer);
+  const constructorArtifact = hasInitializer ? getInitializer(contractArtifact, initializer) : undefined;
+  let contractInstance = await node.getContract(address);
   if (!contractInstance) {
-    throw new Error(`Contract not found at address: ${address}`);
+    log(`Contract not found in the node at ${address}. Computing instance locally...`);
+    contractInstance = await getContractInstanceFromDeployParams(contractArtifact, {
+      constructorArtifact,
+      publicKeys: publicKeys ?? PublicKeys.default(),
+      constructorArgs: rawArgs,
+      salt,
+      deployer,
+    });
+  }
+  if (!contractInstance.address.equals(address)) {
+    throw new Error(`Contract address mismatch: expected ${address}, got ${contractInstance.address}`);
   }
   await wallet.registerContract({ instance: contractInstance, artifact: contractArtifact });
   log(`Contract registered: at ${contractInstance.address}`);

--- a/yarn-project/cli-wallet/src/cmds/register_contract.ts
+++ b/yarn-project/cli-wallet/src/cmds/register_contract.ts
@@ -7,7 +7,7 @@ import {
   getContractInstanceFromDeployParams,
 } from '@aztec/aztec.js';
 import { getContractArtifact } from '@aztec/cli/cli-utils';
-import { type LogFn } from '@aztec/foundation/log';
+import type { LogFn } from '@aztec/foundation/log';
 import { getAllFunctionAbis, getInitializer } from '@aztec/stdlib/abi';
 
 export async function registerContract(


### PR DESCRIPTION
In order to support the new paradigm of not deploying sponsoredFPC in networks but having their address prefunded, this PR adds the ability to the wallet to register private-only contracts (that are not publicly deployed and available in a node)

Also includes some misc fixes and improvements such as allowing deployment/registration of contracts with no initializer, or automatically loading protocol contracts as aliases on startup
