### PR TITLE
refactor!: `UnsconstrainedContext` --> `UtilityContext`

### DIFF
--- a/docs/docs/migration_notes.md
+++ b/docs/docs/migration_notes.md
@@ -25,6 +25,14 @@ For this reason you need to apply #[utility] macro to functions which were origi
     }
 ```
 
+With this change the `UnconstrainedContext` has been renamed as `UtilityContext`.
+This led us to rename the `unkonstrained` method on `TestEnvironment` as `utility` so you will need to update your tests using that:
+
+```diff
+-     SharedMutable::new(env.unkonstrained(), storage_slot)
++     SharedMutable::new(env.utility(), storage_slot)
+```
+
 ## 0.83.0
 
 ### [aztec.js] AztecNode.getPrivateEvents API change

--- a/noir-projects/aztec-nr/aztec/src/capsules/mod.nr
+++ b/noir-projects/aztec-nr/aztec/src/capsules/mod.nr
@@ -91,7 +91,7 @@ mod test {
     global SLOT: Field = 1230;
 
     unconstrained fn setup() -> AztecAddress {
-        TestEnvironment::new().unkonstrained().this_address()
+        TestEnvironment::new().utility().this_address()
     }
 
     #[test]

--- a/noir-projects/aztec-nr/aztec/src/context/mod.nr
+++ b/noir-projects/aztec-nr/aztec/src/context/mod.nr
@@ -4,7 +4,7 @@ pub mod inputs;
 pub mod returns_hash;
 pub mod private_context;
 pub mod public_context;
-pub mod unconstrained_context;
+pub mod utility_context;
 
 pub mod call_interfaces;
 pub mod gas;
@@ -17,4 +17,4 @@ pub use call_interfaces::{
 pub use private_context::PrivateContext;
 pub use public_context::PublicContext;
 pub use returns_hash::ReturnsHash;
-pub use unconstrained_context::UnconstrainedContext;
+pub use utility_context::UtilityContext;

--- a/noir-projects/aztec-nr/aztec/src/context/utility_context.nr
+++ b/noir-projects/aztec-nr/aztec/src/context/utility_context.nr
@@ -4,18 +4,18 @@ use crate::oracle::{
 };
 use dep::protocol_types::{address::AztecAddress, traits::Packable};
 
-pub struct UnconstrainedContext {
+pub struct UtilityContext {
     block_number: u32,
     contract_address: AztecAddress,
     version: Field,
     chain_id: Field,
 }
 
-impl UnconstrainedContext {
+impl UtilityContext {
     pub unconstrained fn new() -> Self {
         // We could call these oracles on the getters instead of at creation, which makes sense given that they might
         // not even be accessed. However any performance gains are minimal, and we'd rather fail early if a user
-        // incorrectly attempts to create an UnconstrainedContext in an environment in which these oracles are not
+        // incorrectly attempts to create an UtilityContext in an environment in which these oracles are not
         // available.
         let block_number = get_block_number();
         let contract_address = get_contract_address();

--- a/noir-projects/aztec-nr/aztec/src/macros/functions/utils.nr
+++ b/noir-projects/aztec-nr/aztec/src/macros/functions/utils.nr
@@ -282,7 +282,8 @@ pub(crate) comptime fn transform_utility(f: FunctionDefinition) {
     }
 
     // Create utility context
-    let context_creation = quote { let mut context = dep::aztec::context::unconstrained_context::UnconstrainedContext::new(); };
+    let context_creation =
+        quote { let mut context = dep::aztec::context::utility_context::UtilityContext::new(); };
     let module_has_storage = module_has_storage(f.module());
 
     // Initialize Storage if module has storage

--- a/noir-projects/aztec-nr/aztec/src/state_vars/private_immutable.nr
+++ b/noir-projects/aztec-nr/aztec/src/state_vars/private_immutable.nr
@@ -3,7 +3,7 @@ use dep::protocol_types::{
     traits::Packable,
 };
 
-use crate::context::{PrivateContext, UnconstrainedContext};
+use crate::context::{PrivateContext, UtilityContext};
 use crate::note::{
     lifecycle::create_note,
     note_emission::NoteEmission,
@@ -82,7 +82,7 @@ impl<Note> PrivateImmutable<Note, &mut PrivateContext> {
     // docs:end:get_note
 }
 
-impl<Note> PrivateImmutable<Note, UnconstrainedContext>
+impl<Note> PrivateImmutable<Note, UtilityContext>
 where
     Note: NoteType + NoteHash + Eq,
 {

--- a/noir-projects/aztec-nr/aztec/src/state_vars/private_mutable.nr
+++ b/noir-projects/aztec-nr/aztec/src/state_vars/private_mutable.nr
@@ -3,7 +3,7 @@ use dep::protocol_types::{
     traits::Packable,
 };
 
-use crate::context::{PrivateContext, UnconstrainedContext};
+use crate::context::{PrivateContext, UtilityContext};
 use crate::note::{
     lifecycle::{create_note, destroy_note_unsafe},
     note_emission::NoteEmission,
@@ -137,7 +137,7 @@ where
     // docs:end:get_note
 }
 
-impl<Note> PrivateMutable<Note, UnconstrainedContext>
+impl<Note> PrivateMutable<Note, UtilityContext>
 where
     Note: NoteType + NoteHash + Eq,
 {

--- a/noir-projects/aztec-nr/aztec/src/state_vars/private_set.nr
+++ b/noir-projects/aztec-nr/aztec/src/state_vars/private_set.nr
@@ -1,4 +1,4 @@
-use crate::context::{PrivateContext, UnconstrainedContext};
+use crate::context::{PrivateContext, UtilityContext};
 use crate::note::{
     constants::MAX_NOTES_PER_PAGE,
     lifecycle::{create_note, destroy_note_unsafe},
@@ -106,7 +106,7 @@ where
     }
 }
 
-impl<Note> PrivateSet<Note, UnconstrainedContext>
+impl<Note> PrivateSet<Note, UtilityContext>
 where
     Note: NoteType + NoteHash + Eq,
 {

--- a/noir-projects/aztec-nr/aztec/src/state_vars/private_set/test.nr
+++ b/noir-projects/aztec-nr/aztec/src/state_vars/private_set/test.nr
@@ -23,7 +23,7 @@ unconstrained fn in_private(
     PrivateSet::new(&mut env.private(), storage_slot)
 }
 
-unconstrained fn in_unconstrained(env: TestEnvironment) -> PrivateSet<MockNote, UtilityContext> {
+unconstrained fn in_utility(env: TestEnvironment) -> PrivateSet<MockNote, UtilityContext> {
     PrivateSet::new(env.utility(), storage_slot)
 }
 
@@ -43,7 +43,7 @@ unconstrained fn get_empty() {
 unconstrained fn view_empty() {
     let mut env = setup();
 
-    let state_var = in_unconstrained(env);
+    let state_var = in_utility(env);
 
     let notes = state_var.view_notes(NoteViewerOptions::new());
     assert_eq(notes.len(), 0);
@@ -104,7 +104,7 @@ unconstrained fn insert_and_view_pending() {
     let mut env = setup();
     let note = insert_note(&mut env);
 
-    let state_var = in_unconstrained(env);
+    let state_var = in_utility(env);
 
     let notes = state_var.view_notes(NoteViewerOptions::new());
     assert_eq(notes.len(), 1);
@@ -138,7 +138,7 @@ unconstrained fn insert_pop_and_read_again_pending() {
     // Now that we've deleted the note, the oracle should know this and not return them any more.
     assert_eq(state_var.pop_notes(NoteGetterOptions::new()).len(), 0);
     assert_eq(state_var.get_notes(NoteGetterOptions::new()).len(), 0);
-    assert_eq(in_unconstrained(env).view_notes(NoteViewerOptions::new()).len(), 0);
+    assert_eq(in_utility(env).view_notes(NoteViewerOptions::new()).len(), 0);
 }
 
 #[test]
@@ -167,5 +167,5 @@ unconstrained fn insert_remove_and_read_again_pending() {
     // Now that we've deleted the notes, the oracle should know this and not return them any more.
     assert_eq(state_var.pop_notes(NoteGetterOptions::new()).len(), 0);
     assert_eq(state_var.get_notes(NoteGetterOptions::new()).len(), 0);
-    assert_eq(in_unconstrained(env).view_notes(NoteViewerOptions::new()).len(), 0);
+    assert_eq(in_utility(env).view_notes(NoteViewerOptions::new()).len(), 0);
 }

--- a/noir-projects/aztec-nr/aztec/src/state_vars/private_set/test.nr
+++ b/noir-projects/aztec-nr/aztec/src/state_vars/private_set/test.nr
@@ -1,5 +1,5 @@
 use crate::{
-    context::{PrivateContext, UnconstrainedContext},
+    context::{PrivateContext, UtilityContext},
     note::{note_getter_options::NoteGetterOptions, note_viewer_options::NoteViewerOptions},
     oracle::random::random,
     state_vars::private_set::PrivateSet,
@@ -23,10 +23,8 @@ unconstrained fn in_private(
     PrivateSet::new(&mut env.private(), storage_slot)
 }
 
-unconstrained fn in_unconstrained(
-    env: TestEnvironment,
-) -> PrivateSet<MockNote, UnconstrainedContext> {
-    PrivateSet::new(env.unkonstrained(), storage_slot)
+unconstrained fn in_unconstrained(env: TestEnvironment) -> PrivateSet<MockNote, UtilityContext> {
+    PrivateSet::new(env.utility(), storage_slot)
 }
 
 #[test]

--- a/noir-projects/aztec-nr/aztec/src/state_vars/public_immutable.nr
+++ b/noir-projects/aztec-nr/aztec/src/state_vars/public_immutable.nr
@@ -1,5 +1,5 @@
 use crate::{
-    context::{PrivateContext, PublicContext, UnconstrainedContext},
+    context::{PrivateContext, PublicContext, UtilityContext},
     state_vars::storage::Storage,
     utils::with_hash::WithHash,
 };
@@ -92,12 +92,12 @@ impl<T> PublicImmutable<T, &mut PublicContext> {
     // docs:end:public_immutable_struct_read
 }
 
-impl<T> PublicImmutable<T, UnconstrainedContext> {
+impl<T> PublicImmutable<T, UtilityContext> {
     pub unconstrained fn read<let T_PACKED_LEN: u32>(self) -> T
     where
         T: Packable<T_PACKED_LEN> + Eq,
     {
-        WithHash::unconstrained_public_storage_read(self.context, self.storage_slot)
+        WithHash::utility_public_storage_read(self.context, self.storage_slot)
     }
 }
 

--- a/noir-projects/aztec-nr/aztec/src/state_vars/public_mutable.nr
+++ b/noir-projects/aztec-nr/aztec/src/state_vars/public_mutable.nr
@@ -1,4 +1,4 @@
-use crate::context::{PublicContext, UnconstrainedContext};
+use crate::context::{PublicContext, UtilityContext};
 use crate::state_vars::storage::Storage;
 use dep::protocol_types::traits::Packable;
 
@@ -51,7 +51,7 @@ impl<T> PublicMutable<T, &mut PublicContext> {
     // docs:end:public_mutable_struct_write
 }
 
-impl<T> PublicMutable<T, UnconstrainedContext> {
+impl<T> PublicMutable<T, UtilityContext> {
     pub unconstrained fn read<let T_PACKED_LEN: u32>(self) -> T
     where
         T: Packable<T_PACKED_LEN>,

--- a/noir-projects/aztec-nr/aztec/src/state_vars/shared_mutable.nr
+++ b/noir-projects/aztec-nr/aztec/src/state_vars/shared_mutable.nr
@@ -9,7 +9,7 @@ use dep::protocol_types::{
 };
 
 use crate::{
-    context::{PrivateContext, PublicContext, UnconstrainedContext},
+    context::{PrivateContext, PublicContext, UtilityContext},
     state_vars::storage::Storage,
     utils::with_hash::WithHash,
 };
@@ -225,7 +225,7 @@ where
     }
 }
 
-impl<T, let INITIAL_DELAY: u32> SharedMutable<T, INITIAL_DELAY, UnconstrainedContext>
+impl<T, let INITIAL_DELAY: u32> SharedMutable<T, INITIAL_DELAY, UtilityContext>
 where
     T: Eq,
 {
@@ -234,7 +234,7 @@ where
         T: Packable<N>,
     {
         let smv: SharedMutableValues<T, INITIAL_DELAY> =
-            WithHash::unconstrained_public_storage_read(self.context, self.storage_slot);
+            WithHash::utility_public_storage_read(self.context, self.storage_slot);
 
         let block_number = self.context.block_number() as u32;
         smv.svc.get_current_at(block_number)

--- a/noir-projects/aztec-nr/aztec/src/state_vars/shared_mutable/test.nr
+++ b/noir-projects/aztec-nr/aztec/src/state_vars/shared_mutable/test.nr
@@ -1,5 +1,5 @@
 use crate::{
-    context::{PrivateContext, PublicContext, UnconstrainedContext},
+    context::{PrivateContext, PublicContext, UtilityContext},
     state_vars::shared_mutable::SharedMutable,
     test::{helpers::test_environment::TestEnvironment, mocks::mock_struct::MockStruct},
 };
@@ -32,10 +32,10 @@ unconstrained fn in_private(
     SharedMutable::new(&mut env.private_at(historical_block_number), storage_slot)
 }
 
-unconstrained fn in_unconstrained(
+unconstrained fn in_utility(
     env: TestEnvironment,
-) -> SharedMutable<MockStruct, TEST_INITIAL_DELAY, UnconstrainedContext> {
-    SharedMutable::new(env.unkonstrained(), storage_slot)
+) -> SharedMutable<MockStruct, TEST_INITIAL_DELAY, UtilityContext> {
+    SharedMutable::new(env.utility(), storage_slot)
 }
 
 #[test]
@@ -285,15 +285,15 @@ unconstrained fn test_get_current_value_in_private_with_non_initial_delay() {
 }
 
 #[test]
-unconstrained fn test_get_current_value_in_unconstrained_initial() {
+unconstrained fn test_get_current_value_in_utility_initial() {
     let env = setup();
-    let state_var = in_unconstrained(env);
+    let state_var = in_utility(env);
 
     assert_eq(state_var.get_current_value(), zeroed());
 }
 
 #[test]
-unconstrained fn test_get_current_value_in_unconstrained_before_scheduled_change() {
+unconstrained fn test_get_current_value_in_utility_before_scheduled_change() {
     let mut env = setup();
     let state_var_public = in_public(env);
 
@@ -303,7 +303,7 @@ unconstrained fn test_get_current_value_in_unconstrained_before_scheduled_change
 
     let original_value = zeroed();
 
-    let mut state_var_unconstrained = in_unconstrained(env);
+    let mut state_var_unconstrained = in_utility(env);
 
     // The current value has not changed
     assert_eq(state_var_unconstrained.get_current_value(), original_value);
@@ -311,12 +311,12 @@ unconstrained fn test_get_current_value_in_unconstrained_before_scheduled_change
     // The current value still does not change right before the block of change
     env.advance_block_to(block_of_change - 1);
 
-    state_var_unconstrained = in_unconstrained(env);
+    state_var_unconstrained = in_utility(env);
     assert_eq(state_var_unconstrained.get_current_value(), original_value);
 }
 
 #[test]
-unconstrained fn test_get_current_value_in_unconstrained_at_scheduled_change() {
+unconstrained fn test_get_current_value_in_utility_at_scheduled_change() {
     let mut env = setup();
     let state_var_public = in_public(env);
 
@@ -326,12 +326,12 @@ unconstrained fn test_get_current_value_in_unconstrained_at_scheduled_change() {
 
     env.advance_block_to(block_of_change);
 
-    let state_var_unconstrained = in_unconstrained(env);
+    let state_var_unconstrained = in_utility(env);
     assert_eq(state_var_unconstrained.get_current_value(), new_value);
 }
 
 #[test]
-unconstrained fn test_get_current_value_in_unconstrained_after_scheduled_change() {
+unconstrained fn test_get_current_value_in_utility_after_scheduled_change() {
     let mut env = setup();
     let state_var_public = in_public(env);
 
@@ -340,6 +340,6 @@ unconstrained fn test_get_current_value_in_unconstrained_after_scheduled_change(
     let (_, block_of_change) = state_var_public.get_scheduled_value();
 
     env.advance_block_to(block_of_change + 10);
-    let state_var_unconstrained = in_unconstrained(env);
+    let state_var_unconstrained = in_utility(env);
     assert_eq(state_var_unconstrained.get_current_value(), new_value);
 }

--- a/noir-projects/aztec-nr/aztec/src/test/helpers/test_environment.nr
+++ b/noir-projects/aztec-nr/aztec/src/test/helpers/test_environment.nr
@@ -1,8 +1,6 @@
 use dep::protocol_types::{abis::function_selector::FunctionSelector, address::AztecAddress};
 
-use crate::context::{
-    call_interfaces::CallInterface, PrivateContext, PublicContext, UnconstrainedContext,
-};
+use crate::context::{call_interfaces::CallInterface, PrivateContext, PublicContext, UtilityContext};
 use crate::hash::hash_args;
 use crate::test::helpers::{cheatcodes, utils::Deployer};
 
@@ -92,9 +90,8 @@ impl TestEnvironment {
         self.private_at(self.committed_block_number())
     }
 
-    // unconstrained is a key word, so we mis-spell purposefully here, like we do with contrakt
-    pub unconstrained fn unkonstrained(_self: Self) -> UnconstrainedContext {
-        UnconstrainedContext::new()
+    pub unconstrained fn utility(_self: Self) -> UtilityContext {
+        UtilityContext::new()
     }
 
     /// Instantiates a private context at a specific historical block number.

--- a/noir-projects/aztec-nr/aztec/src/utils/with_hash.nr
+++ b/noir-projects/aztec-nr/aztec/src/utils/with_hash.nr
@@ -1,5 +1,5 @@
 use crate::{
-    context::{PublicContext, UnconstrainedContext},
+    context::{PublicContext, UtilityContext},
     history::public_storage::PublicStorageHistoricalRead,
     oracle,
 };
@@ -43,8 +43,8 @@ where
         context.storage_read(storage_slot)
     }
 
-    pub unconstrained fn unconstrained_public_storage_read(
-        context: UnconstrainedContext,
+    pub unconstrained fn utility_public_storage_read(
+        context: UtilityContext,
         storage_slot: Field,
     ) -> T {
         context.storage_read(storage_slot)

--- a/noir-projects/aztec-nr/value-note/src/balance_utils.nr
+++ b/noir-projects/aztec-nr/value-note/src/balance_utils.nr
@@ -1,15 +1,14 @@
 use crate::value_note::ValueNote;
 use dep::aztec::{
-    context::UnconstrainedContext, note::note_viewer_options::NoteViewerOptions,
-    state_vars::PrivateSet,
+    context::UtilityContext, note::note_viewer_options::NoteViewerOptions, state_vars::PrivateSet,
 };
 
-pub unconstrained fn get_balance(set: PrivateSet<ValueNote, UnconstrainedContext>) -> Field {
+pub unconstrained fn get_balance(set: PrivateSet<ValueNote, UtilityContext>) -> Field {
     get_balance_with_offset(set, 0)
 }
 
 pub unconstrained fn get_balance_with_offset(
-    set: PrivateSet<ValueNote, UnconstrainedContext>,
+    set: PrivateSet<ValueNote, UtilityContext>,
     offset: u32,
 ) -> Field {
     let mut balance = 0;

--- a/noir-projects/noir-contracts/contracts/card_game_contract/src/cards.nr
+++ b/noir-projects/noir-contracts/contracts/card_game_contract/src/cards.nr
@@ -1,7 +1,7 @@
 use dep::aztec::prelude::{NoteGetterOptions, NoteViewerOptions, PrivateContext, RetrievedNote};
 
 use dep::aztec::{
-    context::UnconstrainedContext,
+    context::UtilityContext,
     encrypted_logs::log_assembly_strategies::default_aes128::note::encode_and_encrypt_note,
     keys::getters::get_public_keys,
     note::constants::MAX_NOTES_PER_PAGE,
@@ -126,7 +126,7 @@ impl Deck<&mut PrivateContext> {
     }
 }
 
-impl Deck<UnconstrainedContext> {
+impl Deck<UtilityContext> {
     pub unconstrained fn view_cards(self, offset: u32) -> BoundedVec<Card, MAX_NOTES_PER_PAGE> {
         let mut options = NoteViewerOptions::new();
         let notes = self.set.view_notes(options.set_offset(offset));

--- a/noir-projects/noir-contracts/contracts/spam_contract/src/types/balance_set.nr
+++ b/noir-projects/noir-contracts/contracts/spam_contract/src/types/balance_set.nr
@@ -1,7 +1,7 @@
 // This file is copied from the token contract.
 use crate::types::token_note::OwnedNote;
 use dep::aztec::{
-    context::{PrivateContext, UnconstrainedContext},
+    context::{PrivateContext, UtilityContext},
     note::note_emission::OuterNoteEmission,
     protocol_types::{
         address::AztecAddress, constants::MAX_NOTE_HASH_READ_REQUESTS_PER_CALL, traits::Packable,
@@ -23,7 +23,7 @@ impl<Note, Context> BalanceSet<Note, Context> {
     }
 }
 
-impl<Note> BalanceSet<Note, UnconstrainedContext>
+impl<Note> BalanceSet<Note, UtilityContext>
 where
     Note: NoteType + NoteHash + OwnedNote + Packable<N> + Eq,
 {

--- a/noir-projects/noir-contracts/contracts/token_blacklist_contract/src/types/balances_map.nr
+++ b/noir-projects/noir-contracts/contracts/token_blacklist_contract/src/types/balances_map.nr
@@ -1,6 +1,6 @@
 use crate::types::token_note::OwnedNote;
 use dep::aztec::{
-    context::{PrivateContext, UnconstrainedContext},
+    context::{PrivateContext, UtilityContext},
     note::note_emission::OuterNoteEmission,
     protocol_types::{constants::MAX_NOTE_HASH_READ_REQUESTS_PER_CALL, traits::Packable},
 };
@@ -28,7 +28,7 @@ impl<Note, Context> BalancesMap<Note, Context> {
     }
 }
 
-impl<Note> BalancesMap<Note, UnconstrainedContext>
+impl<Note> BalancesMap<Note, UtilityContext>
 where
     Note: NoteType + NoteHash + OwnedNote + Packable<N> + Eq,
 {

--- a/noir-projects/noir-contracts/contracts/token_contract/src/types/balance_set.nr
+++ b/noir-projects/noir-contracts/contracts/token_contract/src/types/balance_set.nr
@@ -1,5 +1,5 @@
 use dep::aztec::{
-    context::{PrivateContext, UnconstrainedContext},
+    context::{PrivateContext, UtilityContext},
     note::{note_emission::OuterNoteEmission, retrieved_note::RetrievedNote},
     protocol_types::{address::AztecAddress, constants::MAX_NOTE_HASH_READ_REQUESTS_PER_CALL},
 };
@@ -18,7 +18,7 @@ impl<Context> BalanceSet<Context> {
     }
 }
 
-impl BalanceSet<UnconstrainedContext> {
+impl BalanceSet<UtilityContext> {
     pub unconstrained fn balance_of(self: Self) -> u128 {
         self.balance_of_with_offset(0)
     }


### PR DESCRIPTION
Partially addresses https://github.com/AztecProtocol/aztec-packages/issues/12743 (partially as the rest will be addressed in PRs up the stacks)

In this PR I only rename `UnconstrainedContext` as `UtilityContext`. The rest of the unconstrained --> utility renaming will be done in PRs up the stack.