### PR TITLE
fix: indexeddb multimap dupes

### DIFF
--- a/.test_patterns.yml
+++ b/.test_patterns.yml
@@ -104,6 +104,10 @@ tests:
     error_regex: "TimeoutError: Timeout awaiting blocks mined"
     owners:
       - *palla
+  - regex: "simple e2e_p2p/reqresp"
+    error_regex: "TimeoutError: Timeout awaiting isMined"
+    owners:
+      - *palla
   - regex: "simple e2e_fees/private_payments"
     owners:
       - *phil

--- a/boxes/boxes/vite/playwright.config.ts
+++ b/boxes/boxes/vite/playwright.config.ts
@@ -6,7 +6,7 @@ export default defineConfig({
   fullyParallel: true,
   retries: 3,
   workers: 1,
-  reporter: [["list", { console: true }]],
+  reporter: "list",
   use: {
     baseURL: "http://127.0.0.1:5173",
     trace: "on-first-retry",

--- a/boxes/boxes/vite/playwright.config.ts
+++ b/boxes/boxes/vite/playwright.config.ts
@@ -6,7 +6,7 @@ export default defineConfig({
   fullyParallel: true,
   retries: 3,
   workers: 1,
-  reporter: "list",
+  reporter: [["list", { console: true }]],
   use: {
     baseURL: "http://127.0.0.1:5173",
     trace: "on-first-retry",

--- a/yarn-project/kv-store/package.json
+++ b/yarn-project/kv-store/package.json
@@ -32,6 +32,7 @@
     "idb": "^8.0.0",
     "lmdb": "^3.2.0",
     "msgpackr": "^1.11.2",
+    "ohash": "^2.0.11",
     "ordered-binary": "^1.5.3"
   },
   "devDependencies": {

--- a/yarn-project/kv-store/src/indexeddb/array.ts
+++ b/yarn-project/kv-store/src/indexeddb/array.ts
@@ -1,12 +1,14 @@
 import type { IDBPDatabase, IDBPObjectStore } from 'idb';
+import { hash } from 'ohash';
 
 import type { AztecAsyncArray } from '../interfaces/array.js';
+import type { Value } from '../interfaces/common.js';
 import type { AztecIDBSchema } from './store.js';
 
 /**
  * A persistent array backed by IndexedDB.
  */
-export class IndexedDBAztecArray<T> implements AztecAsyncArray<T> {
+export class IndexedDBAztecArray<T extends Value> implements AztecAsyncArray<T> {
   #_db?: IDBPObjectStore<AztecIDBSchema, ['data'], 'data', 'readwrite'>;
   #rootDB: IDBPDatabase<AztecIDBSchema>;
   #container: string;
@@ -39,6 +41,7 @@ export class IndexedDBAztecArray<T> implements AztecAsyncArray<T> {
     for (const val of vals) {
       await this.db.put({
         value: val,
+        hash: hash(val),
         container: this.#container,
         key: this.#name,
         keyCount: length + 1,
@@ -86,6 +89,7 @@ export class IndexedDBAztecArray<T> implements AztecAsyncArray<T> {
 
     await this.db.put({
       value: val,
+      hash: hash(val),
       container: this.#container,
       key: this.#name,
       keyCount: index + 1,

--- a/yarn-project/kv-store/src/indexeddb/map.ts
+++ b/yarn-project/kv-store/src/indexeddb/map.ts
@@ -1,13 +1,14 @@
 import type { IDBPDatabase, IDBPObjectStore } from 'idb';
+import { hash } from 'ohash';
 
-import type { Key, Range } from '../interfaces/common.js';
+import type { Key, Range, Value } from '../interfaces/common.js';
 import type { AztecAsyncMap } from '../interfaces/map.js';
 import type { AztecIDBSchema } from './store.js';
 
 /**
  * A map backed by IndexedDB.
  */
-export class IndexedDBAztecMap<K extends Key, V> implements AztecAsyncMap<K, V> {
+export class IndexedDBAztecMap<K extends Key, V extends Value> implements AztecAsyncMap<K, V> {
   protected name: string;
   protected container: string;
 
@@ -41,6 +42,7 @@ export class IndexedDBAztecMap<K extends Key, V> implements AztecAsyncMap<K, V> 
   async set(key: K, val: V): Promise<void> {
     await this.db.put({
       value: val,
+      hash: hash(val),
       container: this.container,
       key: this.normalizeKey(key),
       keyCount: 1,

--- a/yarn-project/kv-store/src/indexeddb/multi_map.ts
+++ b/yarn-project/kv-store/src/indexeddb/multi_map.ts
@@ -1,20 +1,34 @@
-import type { Key } from '../interfaces/common.js';
+import { hash } from 'ohash';
+
+import type { Key, Value } from '../interfaces/common.js';
 import type { AztecAsyncMultiMap } from '../interfaces/multi_map.js';
 import { IndexedDBAztecMap } from './map.js';
 
 /**
  * A multi map backed by IndexedDB.
  */
-export class IndexedDBAztecMultiMap<K extends Key, V>
+export class IndexedDBAztecMultiMap<K extends Key, V extends Value>
   extends IndexedDBAztecMap<K, V>
   implements AztecAsyncMultiMap<K, V>
 {
   override async set(key: K, val: V): Promise<void> {
+    const exists = !!(await this.db
+      .index('hash')
+      .get(
+        IDBKeyRange.bound(
+          [this.container, this.normalizeKey(key), hash(val)],
+          [this.container, this.normalizeKey(key), hash(val)],
+        ),
+      ));
+    if (exists) {
+      return;
+    }
     const count = await this.db
       .index('key')
       .count(IDBKeyRange.bound([this.container, this.normalizeKey(key)], [this.container, this.normalizeKey(key)]));
     await this.db.put({
       value: val,
+      hash: hash(val),
       container: this.container,
       key: this.normalizeKey(key),
       keyCount: count + 1,
@@ -36,18 +50,16 @@ export class IndexedDBAztecMultiMap<K extends Key, V>
   }
 
   async deleteValue(key: K, val: V): Promise<void> {
-    const index = this.db.index('keyCount');
-    const rangeQuery = IDBKeyRange.bound(
-      [this.container, this.normalizeKey(key), 0],
-      [this.container, this.normalizeKey(key), Number.MAX_SAFE_INTEGER],
-      false,
-      false,
-    );
-    for await (const cursor of index.iterate(rangeQuery)) {
-      if (JSON.stringify(cursor.value.value) === JSON.stringify(val)) {
-        await cursor.delete();
-        return;
-      }
+    const fullKey = await this.db
+      .index('hash')
+      .getKey(
+        IDBKeyRange.bound(
+          [this.container, this.normalizeKey(key), hash(val)],
+          [this.container, this.normalizeKey(key), hash(val)],
+        ),
+      );
+    if (fullKey) {
+      await this.db.delete(fullKey);
     }
   }
 }

--- a/yarn-project/kv-store/src/indexeddb/singleton.ts
+++ b/yarn-project/kv-store/src/indexeddb/singleton.ts
@@ -1,12 +1,14 @@
 import type { IDBPDatabase, IDBPObjectStore } from 'idb';
+import { hash } from 'ohash';
 
+import type { Value } from '../interfaces/common.js';
 import type { AztecAsyncSingleton } from '../interfaces/singleton.js';
 import type { AztecIDBSchema } from './store.js';
 
 /**
  * Stores a single value in IndexedDB.
  */
-export class IndexedDBAztecSingleton<T> implements AztecAsyncSingleton<T> {
+export class IndexedDBAztecSingleton<T extends Value> implements AztecAsyncSingleton<T> {
   #_db?: IDBPObjectStore<AztecIDBSchema, ['data'], 'data', 'readwrite'>;
   #rootDB: IDBPDatabase<AztecIDBSchema>;
   #container: string;
@@ -38,6 +40,7 @@ export class IndexedDBAztecSingleton<T> implements AztecAsyncSingleton<T> {
       key: this.#slot,
       keyCount: 1,
       value: val,
+      hash: hash(val),
     });
     return result !== undefined;
   }

--- a/yarn-project/kv-store/src/indexeddb/store.ts
+++ b/yarn-project/kv-store/src/indexeddb/store.ts
@@ -1,7 +1,6 @@
 import type { Logger } from '@aztec/foundation/log';
 
 import { type DBSchema, type IDBPDatabase, deleteDB, openDB } from 'idb';
-import type { NotUndefined } from 'object-hash';
 
 import type { AztecAsyncArray } from '../interfaces/array.js';
 import type { Key, StoreSize, Value } from '../interfaces/common.js';
@@ -17,7 +16,7 @@ import { IndexedDBAztecMultiMap } from './multi_map.js';
 import { IndexedDBAztecSet } from './set.js';
 import { IndexedDBAztecSingleton } from './singleton.js';
 
-export type StoredData<V extends NotUndefined> = {
+export type StoredData<V extends Value> = {
   value: V;
   container: string;
   key: string;

--- a/yarn-project/kv-store/src/interfaces/array.ts
+++ b/yarn-project/kv-store/src/interfaces/array.ts
@@ -1,7 +1,9 @@
+import type { Value } from './common.js';
+
 /**
  * An array backed by a persistent store. Can not have any holes in it.
  */
-interface BaseAztecArray<T> {
+interface BaseAztecArray<T extends Value> {
   /**
    * Pushes values to the end of the array
    * @param vals - The values to push to the end of the array
@@ -27,7 +29,7 @@ interface BaseAztecArray<T> {
 /**
  * An array backed by a persistent store. Can not have any holes in it.
  */
-export interface AztecAsyncArray<T> extends BaseAztecArray<T> {
+export interface AztecAsyncArray<T extends Value> extends BaseAztecArray<T> {
   /**
    * The size of the array
    */
@@ -58,7 +60,7 @@ export interface AztecAsyncArray<T> extends BaseAztecArray<T> {
   [Symbol.asyncIterator](): AsyncIterableIterator<T>;
 }
 
-export interface AztecArray<T> extends BaseAztecArray<T> {
+export interface AztecArray<T extends Value> extends BaseAztecArray<T> {
   /**
    * The size of the array
    */

--- a/yarn-project/kv-store/src/interfaces/common.ts
+++ b/yarn-project/kv-store/src/interfaces/common.ts
@@ -1,5 +1,3 @@
-import type { NotUndefined } from 'object-hash';
-
 /**
  * The key type for use with the kv-store
  */

--- a/yarn-project/kv-store/src/interfaces/common.ts
+++ b/yarn-project/kv-store/src/interfaces/common.ts
@@ -1,7 +1,11 @@
+import type { NotUndefined } from 'object-hash';
+
 /**
  * The key type for use with the kv-store
  */
 export type Key = string | number | Array<string | number>;
+
+export type Value = NonNullable<any>;
 
 /**
  * A range of keys to iterate over.

--- a/yarn-project/kv-store/src/interfaces/map.ts
+++ b/yarn-project/kv-store/src/interfaces/map.ts
@@ -1,9 +1,9 @@
-import type { Key, Range } from './common.js';
+import type { Key, Range, Value } from './common.js';
 
 /**
  * A map backed by a persistent store.
  */
-interface AztecBaseMap<K extends Key, V> {
+interface AztecBaseMap<K extends Key, V extends Value> {
   /**
    * Sets the value at the given key.
    * @param key - The key to set the value at
@@ -24,7 +24,7 @@ interface AztecBaseMap<K extends Key, V> {
    */
   delete(key: K): Promise<void>;
 }
-export interface AztecMap<K extends Key, V> extends AztecBaseMap<K, V> {
+export interface AztecMap<K extends Key, V extends Value> extends AztecBaseMap<K, V> {
   /**
    * Gets the value at the given key.
    * @param key - The key to get the value from
@@ -65,7 +65,7 @@ export interface AztecMap<K extends Key, V> extends AztecBaseMap<K, V> {
 /**
  * A map backed by a persistent store.
  */
-export interface AztecAsyncMap<K extends Key, V> extends AztecBaseMap<K, V> {
+export interface AztecAsyncMap<K extends Key, V extends Value> extends AztecBaseMap<K, V> {
   /**
    * Gets the value at the given key.
    * @param key - The key to get the value from

--- a/yarn-project/kv-store/src/interfaces/multi_map.ts
+++ b/yarn-project/kv-store/src/interfaces/multi_map.ts
@@ -1,10 +1,10 @@
-import type { Key } from './common.js';
+import type { Key, Value } from './common.js';
 import type { AztecAsyncMap, AztecMap } from './map.js';
 
 /**
  * A map backed by a persistent store that can have multiple values for a single key.
  */
-export interface AztecMultiMap<K extends Key, V> extends AztecMap<K, V> {
+export interface AztecMultiMap<K extends Key, V extends Value> extends AztecMap<K, V> {
   /**
    * Gets all the values at the given key.
    * @param key - The key to get the values from
@@ -22,7 +22,7 @@ export interface AztecMultiMap<K extends Key, V> extends AztecMap<K, V> {
 /**
  * A map backed by a persistent store that can have multiple values for a single key.
  */
-export interface AztecAsyncMultiMap<K extends Key, V> extends AztecAsyncMap<K, V> {
+export interface AztecAsyncMultiMap<K extends Key, V extends Value> extends AztecAsyncMap<K, V> {
   /**
    * Gets all the values at the given key.
    * @param key - The key to get the values from

--- a/yarn-project/kv-store/src/interfaces/multi_map_test_suite.ts
+++ b/yarn-project/kv-store/src/interfaces/multi_map_test_suite.ts
@@ -116,6 +116,13 @@ export function describeAztecMultiMap(
       expect(await getValues('foo')).to.deep.equal(['bar', 'baz']);
     });
 
+    it('should ignore multiple identical values', async () => {
+      await multiMap.set('foo', 'bar');
+      await multiMap.set('foo', 'bar');
+
+      expect(await getValues('foo')).to.deep.equal(['bar']);
+    });
+
     it('should be able to delete individual values for a single key', async () => {
       await multiMap.set('foo', 'bar');
       await multiMap.set('foo', 'baz');

--- a/yarn-project/kv-store/src/interfaces/store.ts
+++ b/yarn-project/kv-store/src/interfaces/store.ts
@@ -1,5 +1,5 @@
 import type { AztecArray, AztecAsyncArray } from './array.js';
-import type { Key, StoreSize } from './common.js';
+import type { Key, StoreSize, Value } from './common.js';
 import type { AztecAsyncCounter, AztecCounter } from './counter.js';
 import type { AztecAsyncMap, AztecMap } from './map.js';
 import type { AztecAsyncMultiMap, AztecMultiMap } from './multi_map.js';
@@ -14,7 +14,7 @@ export interface AztecKVStore {
    * @param name - The name of the map
    * @returns The map
    */
-  openMap<K extends Key, V>(name: string): AztecMap<K, V>;
+  openMap<K extends Key, V extends Value>(name: string): AztecMap<K, V>;
 
   /**
    * Creates a new set.
@@ -28,21 +28,21 @@ export interface AztecKVStore {
    * @param name - The name of the multi-map
    * @returns The multi-map
    */
-  openMultiMap<K extends Key, V>(name: string): AztecMultiMap<K, V>;
+  openMultiMap<K extends Key, V extends Value>(name: string): AztecMultiMap<K, V>;
 
   /**
    * Creates a new array.
    * @param name - The name of the array
    * @returns The array
    */
-  openArray<T>(name: string): AztecArray<T>;
+  openArray<T extends Value>(name: string): AztecArray<T>;
 
   /**
    * Creates a new singleton.
    * @param name - The name of the singleton
    * @returns The singleton
    */
-  openSingleton<T>(name: string): AztecSingleton<T>;
+  openSingleton<T extends Value>(name: string): AztecSingleton<T>;
 
   /**
    * Creates a new count map.
@@ -83,7 +83,7 @@ export interface AztecAsyncKVStore {
    * @param name - The name of the map
    * @returns The map
    */
-  openMap<K extends Key, V>(name: string): AztecAsyncMap<K, V>;
+  openMap<K extends Key, V extends Value>(name: string): AztecAsyncMap<K, V>;
 
   /**
    * Creates a new set.
@@ -97,21 +97,21 @@ export interface AztecAsyncKVStore {
    * @param name - The name of the multi-map
    * @returns The multi-map
    */
-  openMultiMap<K extends Key, V>(name: string): AztecAsyncMultiMap<K, V>;
+  openMultiMap<K extends Key, V extends Value>(name: string): AztecAsyncMultiMap<K, V>;
 
   /**
    * Creates a new array.
    * @param name - The name of the array
    * @returns The array
    */
-  openArray<T>(name: string): AztecAsyncArray<T>;
+  openArray<T extends Value>(name: string): AztecAsyncArray<T>;
 
   /**
    * Creates a new singleton.
    * @param name - The name of the singleton
    * @returns The singleton
    */
-  openSingleton<T>(name: string): AztecAsyncSingleton<T>;
+  openSingleton<T extends Value>(name: string): AztecAsyncSingleton<T>;
 
   /**
    * Creates a new count map.

--- a/yarn-project/kv-store/src/lmdb-v2/array.ts
+++ b/yarn-project/kv-store/src/lmdb-v2/array.ts
@@ -1,13 +1,14 @@
 import { Encoder } from 'msgpackr/pack';
 
 import type { AztecAsyncArray } from '../interfaces/array.js';
+import type { Value } from '../interfaces/common.js';
 import type { AztecAsyncSingleton } from '../interfaces/singleton.js';
 import type { ReadTransaction } from './read_transaction.js';
 // eslint-disable-next-line import/no-cycle
 import { AztecLMDBStoreV2, execInReadTx, execInWriteTx } from './store.js';
 import { deserializeKey, serializeKey } from './utils.js';
 
-export class LMDBArray<T> implements AztecAsyncArray<T> {
+export class LMDBArray<T extends Value> implements AztecAsyncArray<T> {
   private length: AztecAsyncSingleton<number>;
   private encoder = new Encoder();
   private prefix: string;

--- a/yarn-project/kv-store/src/lmdb-v2/map.ts
+++ b/yarn-project/kv-store/src/lmdb-v2/map.ts
@@ -1,13 +1,13 @@
 import { Encoder } from 'msgpackr';
 
-import type { Key, Range } from '../interfaces/common.js';
+import type { Key, Range, Value } from '../interfaces/common.js';
 import type { AztecAsyncMap } from '../interfaces/map.js';
 import type { ReadTransaction } from './read_transaction.js';
 // eslint-disable-next-line import/no-cycle
 import { type AztecLMDBStoreV2, execInReadTx, execInWriteTx } from './store.js';
 import { deserializeKey, maxKey, minKey, serializeKey } from './utils.js';
 
-export class LMDBMap<K extends Key, V> implements AztecAsyncMap<K, V> {
+export class LMDBMap<K extends Key, V extends Value> implements AztecAsyncMap<K, V> {
   private prefix: string;
   private encoder = new Encoder();
 

--- a/yarn-project/kv-store/src/lmdb-v2/multi_map.ts
+++ b/yarn-project/kv-store/src/lmdb-v2/multi_map.ts
@@ -1,12 +1,12 @@
 import { Encoder } from 'msgpackr/pack';
 
-import type { Key, Range } from '../interfaces/common.js';
+import type { Key, Range, Value } from '../interfaces/common.js';
 import type { AztecAsyncMultiMap } from '../interfaces/multi_map.js';
 import type { ReadTransaction } from './read_transaction.js';
 import { type AztecLMDBStoreV2, execInReadTx, execInWriteTx } from './store.js';
 import { deserializeKey, maxKey, minKey, serializeKey } from './utils.js';
 
-export class LMDBMultiMap<K extends Key, V> implements AztecAsyncMultiMap<K, V> {
+export class LMDBMultiMap<K extends Key, V extends Value> implements AztecAsyncMultiMap<K, V> {
   private prefix: string;
   private encoder = new Encoder();
   constructor(private store: AztecLMDBStoreV2, name: string) {

--- a/yarn-project/kv-store/src/lmdb-v2/store.ts
+++ b/yarn-project/kv-store/src/lmdb-v2/store.ts
@@ -6,7 +6,7 @@ import { AsyncLocalStorage } from 'async_hooks';
 import { mkdir, rm } from 'fs/promises';
 
 import type { AztecAsyncArray } from '../interfaces/array.js';
-import type { Key, StoreSize } from '../interfaces/common.js';
+import type { Key, StoreSize, Value } from '../interfaces/common.js';
 import type { AztecAsyncCounter } from '../interfaces/counter.js';
 import type { AztecAsyncMap } from '../interfaces/map.js';
 import type { AztecAsyncMultiMap } from '../interfaces/multi_map.js';
@@ -102,19 +102,19 @@ export class AztecLMDBStoreV2 implements AztecAsyncKVStore, LMDBMessageChannel {
     return currentWrite;
   }
 
-  openMap<K extends Key, V>(name: string): AztecAsyncMap<K, V> {
+  openMap<K extends Key, V extends Value>(name: string): AztecAsyncMap<K, V> {
     return new LMDBMap(this, name);
   }
 
-  openMultiMap<K extends Key, V>(name: string): AztecAsyncMultiMap<K, V> {
+  openMultiMap<K extends Key, V extends Value>(name: string): AztecAsyncMultiMap<K, V> {
     return new LMDBMultiMap(this, name);
   }
 
-  openSingleton<T>(name: string): AztecAsyncSingleton<T> {
+  openSingleton<T extends Value>(name: string): AztecAsyncSingleton<T> {
     return new LMDBSingleValue(this, name);
   }
 
-  openArray<T>(name: string): AztecAsyncArray<T> {
+  openArray<T extends Value>(name: string): AztecAsyncArray<T> {
     return new LMDBArray(this, name);
   }
 

--- a/yarn-project/kv-store/src/lmdb/array.ts
+++ b/yarn-project/kv-store/src/lmdb/array.ts
@@ -1,6 +1,7 @@
 import type { Database, Key } from 'lmdb';
 
 import type { AztecArray, AztecAsyncArray } from '../interfaces/array.js';
+import type { Value } from '../interfaces/common.js';
 import { LmdbAztecSingleton } from './singleton.js';
 
 /** The shape of a key that stores a value in an array */
@@ -9,7 +10,7 @@ type ArrayIndexSlot = ['array', string, 'slot', number];
 /**
  * An persistent array backed by LMDB.
  */
-export class LmdbAztecArray<T> implements AztecArray<T>, AztecAsyncArray<T> {
+export class LmdbAztecArray<T extends Value> implements AztecArray<T>, AztecAsyncArray<T> {
   #db: Database<T, ArrayIndexSlot>;
   #name: string;
   #length: LmdbAztecSingleton<number>;

--- a/yarn-project/kv-store/src/lmdb/map.ts
+++ b/yarn-project/kv-store/src/lmdb/map.ts
@@ -1,6 +1,6 @@
 import type { Database, RangeOptions } from 'lmdb';
 
-import type { Key, Range } from '../interfaces/common.js';
+import type { Key, Range, Value } from '../interfaces/common.js';
 import type { AztecAsyncMap, AztecMap } from '../interfaces/map.js';
 
 /** The slot where a key-value entry would be stored */
@@ -9,7 +9,7 @@ type MapValueSlot<K extends Key | Buffer> = ['map', string, 'slot', K];
 /**
  * A map backed by LMDB.
  */
-export class LmdbAztecMap<K extends Key, V> implements AztecMap<K, V>, AztecAsyncMap<K, V> {
+export class LmdbAztecMap<K extends Key, V extends Value> implements AztecMap<K, V>, AztecAsyncMap<K, V> {
   protected db: Database<[K, V], MapValueSlot<K>>;
   protected name: string;
 

--- a/yarn-project/kv-store/src/lmdb/multi_map.ts
+++ b/yarn-project/kv-store/src/lmdb/multi_map.ts
@@ -1,11 +1,11 @@
-import type { Key } from '../interfaces/common.js';
+import type { Key, Value } from '../interfaces/common.js';
 import type { AztecAsyncMultiMap, AztecMultiMap } from '../interfaces/multi_map.js';
 import { LmdbAztecMap } from './map.js';
 
 /**
  * A map backed by LMDB.
  */
-export class LmdbAztecMultiMap<K extends Key, V>
+export class LmdbAztecMultiMap<K extends Key, V extends Value>
   extends LmdbAztecMap<K, V>
   implements AztecMultiMap<K, V>, AztecAsyncMultiMap<K, V>
 {

--- a/yarn-project/kv-store/src/lmdb/store.ts
+++ b/yarn-project/kv-store/src/lmdb/store.ts
@@ -7,7 +7,7 @@ import { tmpdir } from 'os';
 import { join } from 'path';
 
 import type { AztecArray, AztecAsyncArray } from '../interfaces/array.js';
-import type { Key, StoreSize } from '../interfaces/common.js';
+import type { Key, StoreSize, Value } from '../interfaces/common.js';
 import type { AztecAsyncCounter, AztecCounter } from '../interfaces/counter.js';
 import type { AztecAsyncMap, AztecMap } from '../interfaces/map.js';
 import type { AztecAsyncMultiMap, AztecMultiMap } from '../interfaces/multi_map.js';
@@ -80,7 +80,7 @@ export class AztecLmdbStore implements AztecKVStore, AztecAsyncKVStore {
    * @param name - Name of the map
    * @returns A new AztecMap
    */
-  openMap<K extends Key, V>(name: string): AztecMap<K, V> & AztecAsyncMap<K, V> {
+  openMap<K extends Key, V extends Value>(name: string): AztecMap<K, V> & AztecAsyncMap<K, V> {
     return new LmdbAztecMap(this.#data, name);
   }
 
@@ -98,7 +98,7 @@ export class AztecLmdbStore implements AztecKVStore, AztecAsyncKVStore {
    * @param name - Name of the map
    * @returns A new AztecMultiMap
    */
-  openMultiMap<K extends Key, V>(name: string): AztecMultiMap<K, V> & AztecAsyncMultiMap<K, V> {
+  openMultiMap<K extends Key, V extends Value>(name: string): AztecMultiMap<K, V> & AztecAsyncMultiMap<K, V> {
     return new LmdbAztecMultiMap(this.#multiMapData, name);
   }
 
@@ -111,7 +111,7 @@ export class AztecLmdbStore implements AztecKVStore, AztecAsyncKVStore {
    * @param name - Name of the array
    * @returns A new AztecArray
    */
-  openArray<T>(name: string): AztecArray<T> & AztecAsyncArray<T> {
+  openArray<T extends Value>(name: string): AztecArray<T> & AztecAsyncArray<T> {
     return new LmdbAztecArray(this.#data, name);
   }
 

--- a/yarn-project/pxe/src/pxe_oracle_interface/pxe_oracle_interface.ts
+++ b/yarn-project/pxe/src/pxe_oracle_interface/pxe_oracle_interface.ts
@@ -675,9 +675,10 @@ export class PXEOracleInterface implements ExecutionDataProvider {
 
     await this.noteDataProvider.addNotes([noteDao], recipient);
     this.log.verbose('Added note', {
-      contract: noteDao.contractAddress,
-      slot: noteDao.storageSlot,
-      noteHash: noteDao.noteHash,
+      index: noteDao.index,
+      contract: noteDao.contractAddress.toString(),
+      slot: noteDao.storageSlot.toString(),
+      noteHash: noteDao.noteHash.toString(),
       nullifier: noteDao.siloedNullifier.toString(),
     });
 

--- a/yarn-project/yarn.lock
+++ b/yarn-project/yarn.lock
@@ -865,7 +865,6 @@ __metadata:
     "@types/mocha": "npm:^10.0.10"
     "@types/mocha-each": "npm:^2.0.4"
     "@types/node": "npm:^18.7.23"
-    "@types/object-hash": "npm:^3"
     "@types/sinon": "npm:^17.0.3"
     "@web/dev-server-esbuild": "npm:^1.0.3"
     "@web/test-runner": "npm:^0.19.0"
@@ -878,7 +877,6 @@ __metadata:
     mocha: "npm:^10.8.2"
     mocha-each: "npm:^2.0.1"
     msgpackr: "npm:^1.11.2"
-    object-hash: "npm:^3.0.0"
     ohash: "npm:^2.0.11"
     ordered-binary: "npm:^1.5.3"
     sinon: "npm:^19.0.2"
@@ -6297,13 +6295,6 @@ __metadata:
   version: 2.4.4
   resolution: "@types/normalize-package-data@npm:2.4.4"
   checksum: 10/65dff72b543997b7be8b0265eca7ace0e34b75c3e5fee31de11179d08fa7124a7a5587265d53d0409532ecb7f7fba662c2012807963e1f9b059653ec2c83ee05
-  languageName: node
-  linkType: hard
-
-"@types/object-hash@npm:^3":
-  version: 3.0.6
-  resolution: "@types/object-hash@npm:3.0.6"
-  checksum: 10/2c7979d4e540af817b99c09fb4c2fed1c0b0e14342df474d8dcde4165a82c440b038341fd66fe998d9f86acdd5cccc65ba8092315e39e7c2114f945fa70aaa56
   languageName: node
   linkType: hard
 
@@ -17280,13 +17271,6 @@ __metadata:
   version: 4.1.1
   resolution: "object-assign@npm:4.1.1"
   checksum: 10/fcc6e4ea8c7fe48abfbb552578b1c53e0d194086e2e6bbbf59e0a536381a292f39943c6e9628af05b5528aa5e3318bb30d6b2e53cadaf5b8fe9e12c4b69af23f
-  languageName: node
-  linkType: hard
-
-"object-hash@npm:^3.0.0":
-  version: 3.0.0
-  resolution: "object-hash@npm:3.0.0"
-  checksum: 10/f498d456a20512ba7be500cef4cf7b3c183cc72c65372a549c9a0e6dd78ce26f375e9b1315c07592d3fde8f10d5019986eba35970570d477ed9a2a702514432a
   languageName: node
   linkType: hard
 

--- a/yarn-project/yarn.lock
+++ b/yarn-project/yarn.lock
@@ -865,6 +865,7 @@ __metadata:
     "@types/mocha": "npm:^10.0.10"
     "@types/mocha-each": "npm:^2.0.4"
     "@types/node": "npm:^18.7.23"
+    "@types/object-hash": "npm:^3"
     "@types/sinon": "npm:^17.0.3"
     "@web/dev-server-esbuild": "npm:^1.0.3"
     "@web/test-runner": "npm:^0.19.0"
@@ -877,6 +878,8 @@ __metadata:
     mocha: "npm:^10.8.2"
     mocha-each: "npm:^2.0.1"
     msgpackr: "npm:^1.11.2"
+    object-hash: "npm:^3.0.0"
+    ohash: "npm:^2.0.11"
     ordered-binary: "npm:^1.5.3"
     sinon: "npm:^19.0.2"
     ts-node: "npm:^10.9.1"
@@ -6294,6 +6297,13 @@ __metadata:
   version: 2.4.4
   resolution: "@types/normalize-package-data@npm:2.4.4"
   checksum: 10/65dff72b543997b7be8b0265eca7ace0e34b75c3e5fee31de11179d08fa7124a7a5587265d53d0409532ecb7f7fba662c2012807963e1f9b059653ec2c83ee05
+  languageName: node
+  linkType: hard
+
+"@types/object-hash@npm:^3":
+  version: 3.0.6
+  resolution: "@types/object-hash@npm:3.0.6"
+  checksum: 10/2c7979d4e540af817b99c09fb4c2fed1c0b0e14342df474d8dcde4165a82c440b038341fd66fe998d9f86acdd5cccc65ba8092315e39e7c2114f945fa70aaa56
   languageName: node
   linkType: hard
 
@@ -17273,6 +17283,13 @@ __metadata:
   languageName: node
   linkType: hard
 
+"object-hash@npm:^3.0.0":
+  version: 3.0.0
+  resolution: "object-hash@npm:3.0.0"
+  checksum: 10/f498d456a20512ba7be500cef4cf7b3c183cc72c65372a549c9a0e6dd78ce26f375e9b1315c07592d3fde8f10d5019986eba35970570d477ed9a2a702514432a
+  languageName: node
+  linkType: hard
+
 "object-inspect@npm:^1.13.1":
   version: 1.13.1
   resolution: "object-inspect@npm:1.13.1"
@@ -17344,6 +17361,13 @@ __metadata:
   version: 1.1.2
   resolution: "obuf@npm:1.1.2"
   checksum: 10/53ff4ab3a13cc33ba6c856cf281f2965c0aec9720967af450e8fd06cfd50aceeefc791986a16bcefa14e7898b3ca9acdfcf15b9d9a1b9c7e1366581a8ad6e65e
+  languageName: node
+  linkType: hard
+
+"ohash@npm:^2.0.11":
+  version: 2.0.11
+  resolution: "ohash@npm:2.0.11"
+  checksum: 10/6b0423f42cc95c3d643f390a88364aac824178b7788dccb4e8c64e2124463d0069e60d4d90bad88ed9823808368d051e088aa27058ca4722b1397a201ffbfa4b
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
https://github.com/AztecProtocol/aztec-packages/pull/13107 uncovered a bug in the indexeddb kv store implementation that would generate duplicates when using multimaps. This takes care of it, fixing the boxes tests in the process