### PR TITLE
fix: give the first bot dibs on registering contract classes

### DIFF
--- a/spartan/aztec-network/templates/transaction-bot.yaml
+++ b/spartan/aztec-network/templates/transaction-bot.yaml
@@ -123,6 +123,17 @@ spec:
               echo "AZTEC_NODE_URL=${AZTEC_NODE_URL}"
 
               export BOT_ACCOUNT_SALT=$(echo $K8S_POD_NAME | awk -F'-' '{print $NF+1}') # +1 so that salt is not 0
+
+              # a crude way to avoid a race condition that could arise if more than one bot is started:
+              # the bots need to register contract classes, if they all start at the same time (or close to it) then multiple of them might try to register the same class leading to failed txs due to duplicate nullifiers
+              # instead lets allow the first bot to start immediately giving it the responsibility to register the classes
+              # every other bot after that will sleep at least a slot before starting up
+              if [[ "$BOT_ACCOUNT_SALT" != "1" ]]; then
+                sleep_duration=$(({{ .Values.aztec.slotDuration }} + ($RANDOM % 10)))
+                echo "Sleeping for $sleep_duration seconds"
+                sleep $sleep_duration
+              fi
+
               node --no-warnings /usr/src/yarn-project/aztec/dest/bin/index.js start --pxe --bot
           env:
             - name: K8S_POD_UID


### PR DESCRIPTION
We noticed some of the initial txs send by the bot would be rejected due to duplicate nullifiers. We realised the bots were all racing to register the Token contract class so naturally one would win and the others would have invalid txs.

This PR adds a small delay to the startup time of every bot past the first one so that the first bot gets the right to register the contract class.
