### PR TITLE
fix: import right assert

### DIFF
--- a/yarn-project/bb-prover/src/prover/bb_prover.ts
+++ b/yarn-project/bb-prover/src/prover/bb_prover.ts
@@ -69,7 +69,7 @@ import type { CircuitProvingStats, CircuitWitnessGenerationStats } from '@aztec/
 import type { VerificationKeyData } from '@aztec/stdlib/vks';
 import { Attributes, type TelemetryClient, getTelemetryClient, trackSpan } from '@aztec/telemetry-client';
 
-import { assert } from 'console';
+import assert from 'assert';
 import crypto from 'crypto';
 import { promises as fs } from 'fs';
 import * as path from 'path';

--- a/yarn-project/bb-prover/src/prover/bb_prover.ts
+++ b/yarn-project/bb-prover/src/prover/bb_prover.ts
@@ -746,21 +746,27 @@ export class BBNativeRollupProver implements ServerCircuitProver {
     const json = JSON.parse(proofString);
 
     let numPublicInputs = vkData.numPublicInputs - AGGREGATION_OBJECT_LENGTH;
+    assert(
+      proofLength == NESTED_RECURSIVE_PROOF_LENGTH || proofLength == NESTED_RECURSIVE_ROLLUP_HONK_PROOF_LENGTH,
+      `Proof length must be one of the expected proof lengths, received ${proofLength}`,
+    );
     if (proofLength == NESTED_RECURSIVE_ROLLUP_HONK_PROOF_LENGTH) {
       numPublicInputs -= IPA_CLAIM_LENGTH;
     }
 
-    assert(json.length == proofLength, 'Proof length mismatch');
+    assert(json.length == proofLength, `Proof length mismatch: ${json.length} != ${proofLength}`);
 
     const fieldsWithoutPublicInputs = json.map(Fr.fromHexString);
 
     // Concat binary public inputs and binary proof
     // This buffer will have the form: [binary public inputs, binary proof]
     const binaryProofWithPublicInputs = Buffer.concat([binaryPublicInputs, binaryProof]);
-    // TODO(https://github.com/AztecProtocol/barretenberg/issues/1312): Get rid of if possible.
-    assert(binaryProofWithPublicInputs.length == numPublicInputs * 32 + NESTED_RECURSIVE_PROOF_LENGTH * 32);
     logger.debug(
       `Circuit path: ${filePath}, complete proof length: ${json.length}, num public inputs: ${numPublicInputs}, circuit size: ${vkData.circuitSize}, is recursive: ${vkData.isRecursive}, raw length: ${binaryProofWithPublicInputs.length}`,
+    );
+    assert(
+      binaryProofWithPublicInputs.length == numPublicInputs * 32 + proofLength * 32,
+      `Proof length mismatch: ${binaryProofWithPublicInputs.length} != ${numPublicInputs * 32 + proofLength * 32}`,
     );
     return new RecursiveProof(
       fieldsWithoutPublicInputs,


### PR DESCRIPTION
We had assertions that only printed to the console instead of crashing the process. This PR fixes that
