### PR TITLE
chore: update slashing test port

### DIFF
--- a/yarn-project/end-to-end/src/e2e_p2p/slashing.test.ts
+++ b/yarn-project/end-to-end/src/e2e_p2p/slashing.test.ts
@@ -18,7 +18,7 @@ jest.setTimeout(1000000);
 
 // Don't set this to a higher value than 9 because each node will use a different L1 publisher account and anvil seeds
 const NUM_NODES = 4;
-const BOOT_NODE_UDP_PORT = 40600;
+const BOOT_NODE_UDP_PORT = 41000;
 
 const DATA_DIR = fs.mkdtempSync(path.join(os.tmpdir(), 'slashing-'));
 


### PR DESCRIPTION
## Overview

Was using the same port as the gossip test, could likely cause contention
