### PR TITLE
feat: persist the bot and enable simulation capturing

### DIFF
--- a/spartan/aztec-network/templates/transaction-bot.yaml
+++ b/spartan/aztec-network/templates/transaction-bot.yaml
@@ -17,7 +17,6 @@ spec:
     matchLabels:
       app: {{- include "aztec-network.selectorLabels" . | nindent 6 }}
       app: bot
-  {{- if not .Values.storage.localSsd }}
   volumeClaimTemplates:
     - metadata:
         name: bot-data
@@ -26,7 +25,6 @@ spec:
         resources:
           requests:
             storage: {{ .Values.bot.storageSize }}
-  {{- end }}
   template:
     metadata:
       labels:
@@ -63,14 +61,9 @@ spec:
             defaultMode: 0755
         - name: scripts-output
           emptyDir: {}
-      {{- if .Values.storage.localSsd }}
-        - name: bot-data
-          emptyDir: {}
-      {{ else }}
         - name: bot-data
           persistentVolumeClaim:
             claimName: bot-data
-      {{- end }}
       terminationGracePeriodSeconds: 5  # default is 30 - speed up initcontainer termination
       initContainers:
         {{- include "aztec-network.combinedAllSetupContainer" . | nindent 8 }}

--- a/spartan/aztec-network/templates/transaction-bot.yaml
+++ b/spartan/aztec-network/templates/transaction-bot.yaml
@@ -17,6 +17,16 @@ spec:
     matchLabels:
       app: {{- include "aztec-network.selectorLabels" . | nindent 6 }}
       app: bot
+  {{- if not .Values.storage.localSsd }}
+  volumeClaimTemplates:
+    - metadata:
+        name: bot-data
+      spec:
+        accessModes: [ "ReadWriteOnce" ]
+        resources:
+          requests:
+            storage: {{ .Values.bot.storageSize }}
+  {{- end }}
   template:
     metadata:
       labels:
@@ -53,6 +63,14 @@ spec:
             defaultMode: 0755
         - name: scripts-output
           emptyDir: {}
+      {{- if .Values.storage.localSsd }}
+        - name: bot-data
+          emptyDir: {}
+      {{ else }}
+        - name: bot-data
+          persistentVolumeClaim:
+            claimName: bot-data
+      {{- end }}
       terminationGracePeriodSeconds: 5  # default is 30 - speed up initcontainer termination
       initContainers:
         {{- include "aztec-network.combinedAllSetupContainer" . | nindent 8 }}
@@ -71,6 +89,8 @@ spec:
               mountPath: /scripts
             - name: config
               mountPath: /shared/config
+            - name: bot-data
+              mountPath: {{ .Values.bot.dataDir }}
           env:
             - name: KEY_INDEX_START
               value: {{ .Values.aztec.botKeyIndexStart | quote }}
@@ -123,6 +143,10 @@ spec:
               echo "AZTEC_NODE_URL=${AZTEC_NODE_URL}"
 
               export BOT_ACCOUNT_SALT=$(echo $K8S_POD_NAME | awk -F'-' '{print $NF+1}') # +1 so that salt is not 0
+
+              # set this to a folder in order to capture simulation recordings for later debug
+              # be sure to set it to a persistent volume
+              export CIRCUIT_RECORD_DIR=""
 
               # a crude way to avoid a race condition that could arise if more than one bot is started:
               # the bots need to register contract classes, if they all start at the same time (or close to it) then multiple of them might try to register the same class leading to failed txs due to duplicate nullifiers
@@ -184,6 +208,8 @@ spec:
               value: "{{ .Values.ethereum.chainId }}"
             - name: TEST_ACCOUNTS
               value: "{{ .Values.aztec.testAccounts }}"
+            - name: DATA_DIRECTORY
+              value: "{{ .Values.bot.dataDir }}"
           ports:
             - name: http
               containerPort: {{ .Values.bot.service.nodePort }}

--- a/spartan/aztec-network/values.yaml
+++ b/spartan/aztec-network/values.yaml
@@ -250,6 +250,8 @@ bot:
   ammTxs: false
   maxErrors: 3
   stopIfUnhealthy: true
+  dataDir: "/data"
+  storageSize: "2Gi"
   service:
     type: ClusterIP
     nodePort: 8082

--- a/yarn-project/pxe/src/entrypoints/server/utils.ts
+++ b/yarn-project/pxe/src/entrypoints/server/utils.ts
@@ -5,6 +5,7 @@ import { createLogger } from '@aztec/foundation/log';
 import { createStore } from '@aztec/kv-store/lmdb-v2';
 import { BundledProtocolContractsProvider } from '@aztec/protocol-contracts/providers/bundle';
 import { type SimulationProvider, WASMSimulator } from '@aztec/simulator/client';
+import { SimulationProviderRecorderWrapper } from '@aztec/simulator/testing';
 import type { AztecNode } from '@aztec/stdlib/interfaces/client';
 
 import type { PXEServiceConfig } from '../../config/index.js';
@@ -25,7 +26,8 @@ export function createPXEService(
   useLogSuffix: string | boolean | undefined = undefined,
 ) {
   const simulationProvider = new WASMSimulator();
-  return createPXEServiceWithSimulationProvider(aztecNode, simulationProvider, config, useLogSuffix);
+  const simulationProviderWithRecorder = new SimulationProviderRecorderWrapper(simulationProvider);
+  return createPXEServiceWithSimulationProvider(aztecNode, simulationProviderWithRecorder, config, useLogSuffix);
 }
 
 /**


### PR DESCRIPTION
The bots did not persist their databases because when we first introduced them the pxe did not have reorg support. This should be fine now :)

Also enables the option of using the recording simulator in the bot's PXE for debugging
