### PR TITLE
chore(kind): add control pane logging

### DIFF
--- a/spartan/scripts/monitor_k8s_deployment.sh
+++ b/spartan/scripts/monitor_k8s_deployment.sh
@@ -31,6 +31,9 @@ for i in {1..100}; do
   echo "--- Pod status ---"
   kubectl get pods -n "$namespace" || true
 
+  echo -e "\n--- Control Pane Node Description ---"
+  kubectl describe node kind-control-plane || true
+
   echo -e "\n--- Recent Pod Events ---"
   kubectl get events -n "$namespace" --sort-by='.lastTimestamp' | tail -10 || true
 


### PR DESCRIPTION
## Overview

Adds useful information such as the total number of pods allowed, and the pods that are currently running - their limits and how
much resources they have requessted 

```bash
Name:               kind-control-plane                                                                                                                                                                                                               
Roles:              control-plane                                                                                                                                                                                                                    
Labels:             beta.kubernetes.io/arch=amd64                                                                                                                                                                                                    
                    beta.kubernetes.io/os=linux                                                                                                                                                                                                      
                    kubernetes.io/arch=amd64                                                                                                                                                                                                         
                    kubernetes.io/hostname=kind-control-plane                                                                                                                                                                                        
                    kubernetes.io/os=linux                                                                                                                                                                                                           
                    node-role.kubernetes.io/control-plane=
Annotations:        kubeadm.alpha.kubernetes.io/cri-socket: unix:///run/containerd/containerd.sock
                    node.alpha.kubernetes.io/ttl: 0
                    volumes.kubernetes.io/controller-managed-attach-detach: true
CreationTimestamp:  Thu, 03 Apr 2025 10:38:04 +0000
Taints:             <none>
Unschedulable:      false
Lease:
  HolderIdentity:  kind-control-plane
  AcquireTime:     <unset>
  RenewTime:       Thu, 03 Apr 2025 17:09:07 +0000
Conditions:
  Type             Status  LastHeartbeatTime                 LastTransitionTime                Reason                       Message
  ----             ------  -----------------                 ------------------                ------                       -------
  MemoryPressure   False   Thu, 03 Apr 2025 17:07:13 +0000   Thu, 03 Apr 2025 10:38:02 +0000   KubeletHasSufficientMemory   kubelet has sufficient memory available
  DiskPressure     False   Thu, 03 Apr 2025 17:07:13 +0000   Thu, 03 Apr 2025 10:38:02 +0000   KubeletHasNoDiskPressure     kubelet has no disk pressure
  PIDPressure      False   Thu, 03 Apr 2025 17:07:13 +0000   Thu, 03 Apr 2025 10:38:02 +0000   KubeletHasSufficientPID      kubelet has sufficient PID available
  Ready            True    Thu, 03 Apr 2025 17:07:13 +0000   Thu, 03 Apr 2025 10:38:28 +0000   KubeletReady                 kubelet is posting ready status
Addresses:
  InternalIP:  172.18.0.2
  Hostname:    kind-control-plane
Capacity:
  cpu:                192
  ephemeral-storage:  8191750Mi
  hugepages-1Gi:      0
  hugepages-2Mi:      0
  memory:             775959072Ki
  pods:               110
Allocatable:
  cpu:                192
  ephemeral-storage:  8191750Mi
  hugepages-1Gi:      0
  hugepages-2Mi:      0
  memory:             775959072Ki
  pods:               110
System Info:
  Machine ID:                 c10942a62f1041baa313e870748b41c5
  System UUID:                8fad1c37-71e6-4beb-9c1e-b2c5180ebc56
  Boot ID:                    ecdc9c67-73f9-4545-9c14-3d908541b5e0
  Kernel Version:             6.8.0-1026-aws
  OS Image:                   Debian GNU/Linux 12 (bookworm)
  Operating System:           linux
  Architecture:               amd64
  Container Runtime Version:  containerd://1.7.15
  Kubelet Version:            v1.30.0
  Kube-Proxy Version:         v1.30.0
PodCIDR:                      10.244.0.0/24
PodCIDRs:                     10.244.0.0/24
ProviderID:                   kind://docker/kind/kind-control-plane
Non-terminated Pods:          (20 in total)
  Namespace                   Name                                                  CPU Requests  CPU Limits  Memory Requests  Memory Limits  Age
  ---------                   ----                                                  ------------  ----------  ---------------  -------------  ---
  kube-system                 coredns-7db6d8ff4d-mlv6k                              100m (0%)     0 (0%)      70Mi (0%)        170Mi (0%)     6h30m
  kube-system                 coredns-7db6d8ff4d-v7mgd                              100m (0%)     0 (0%)      70Mi (0%)        170Mi (0%)     6h30m
  kube-system                 etcd-kind-control-plane                               100m (0%)     0 (0%)      100Mi (0%)       0 (0%)         6h31m
  kube-system                 kindnet-s5nwx                                         100m (0%)     100m (0%)   50Mi (0%)        50Mi (0%)      6h30m
  kube-system                 kube-apiserver-kind-control-plane                     250m (0%)     0 (0%)      0 (0%)           0 (0%)         6h31m
  kube-system                 kube-controller-manager-kind-control-plane            200m (0%)     0 (0%)      0 (0%)           0 (0%)         6h31m
  kube-system                 kube-proxy-cghsk                                      0 (0%)        0 (0%)      0 (0%)           0 (0%)         6h30m
  kube-system                 kube-scheduler-kind-control-plane                     100m (0%)     0 (0%)      0 (0%)           0 (0%)         6h31m
  local-path-storage          local-path-provisioner-988d74bc-qltjv                 0 (0%)        0 (0%)      0 (0%)           0 (0%)         6h30m
  smoke                       smoke-aztec-network-boot-node-0                       500m (0%)     500m (0%)   512Ki (0%)       1Gi (0%)       2m14s
  smoke                       smoke-aztec-network-eth-beacon-8c6889b9c-7z2bl        500m (0%)     500m (0%)   1Gi (0%)         1Gi (0%)       2m14s
  smoke                       smoke-aztec-network-eth-execution-564fbf65c9-lwtnb    500m (0%)     500m (0%)   1Gi (0%)         1Gi (0%)       2m14s
  smoke                       smoke-aztec-network-eth-validator-67f78d7989-pmfqv    500m (0%)     500m (0%)   1Gi (0%)         1Gi (0%)       2m14s
  smoke                       smoke-aztec-network-faucet-5879c78f67-v4gqk           200m (0%)     200m (0%)   512Mi (0%)       512Mi (0%)     2m14s
  smoke                       smoke-aztec-network-full-node-0                       500m (0%)     500m (0%)   512Mi (0%)       512Mi (0%)     2m14s
  smoke                       smoke-aztec-network-prover-agent-gqrwh                500m (0%)     500m (0%)   512Mi (0%)       512Mi (0%)     2m14s
  smoke                       smoke-aztec-network-prover-broker-0                   500m (0%)     500m (0%)   512Mi (0%)       512Mi (0%)     2m14s
  smoke                       smoke-aztec-network-prover-node-0                     500m (0%)     500m (0%)   512Mi (0%)       512Mi (0%)     2m14s
  smoke                       smoke-aztec-network-pxe-678c9d5689-2g62g              500m (0%)     500m (0%)   1Gi (0%)         1Gi (0%)       2m14s
  smoke                       smoke-aztec-network-validator-0                       500m (0%)     500m (0%)   512Mi (0%)       512Mi (0%)     2m14s
Allocated resources:
  (Total limits may be over 100 percent, i.e., overcommitted.)
  Resource           Requests        Limits
  --------           --------        ------
  cpu                6150m (3%)      5300m (2%)
  memory             7637504Ki (0%)  8582Mi (1%)
  ephemeral-storage  0 (0%)          0 (0%)
  hugepages-1Gi      0 (0%)          0 (0%)
  hugepages-2Mi      0 (0%)          0 (0%)
Events:              <none>

--- Recent Pod Events ---
28s         Normal    Started                 pod/smoke-aztec-network-validator-0                                            Started container validator
24s         Normal    Created                 pod/smoke-aztec-network-prover-node-0                                          Created container prover-node
24s         Normal    Pulled                  pod/smoke-aztec-network-prover-node-0                                          Container image "aztecprotocol/aztec:62c32eb0064c0d95527286882b1ec798fd2c3932" already present on machine
23s         Normal    Started                 pod/smoke-aztec-network-prover-node-0                                          Started container prover-node
23s         Warning   Unhealthy               pod/smoke-aztec-network-pxe-678c9d5689-2g62g                                   Readiness probe failed:
11s         Warning   Unhealthy               pod/smoke-aztec-network-full-node-0                                            Startup probe failed: Get "http://10.244.0.77:8080/status": dial tcp 10.244.0.77:8080: connect: connection refused
8s          Normal    Created                 pod/smoke-aztec-network-prover-agent-gqrwh                                     Created container prover-agent
8s          Normal    Pulled                  pod/smoke-aztec-network-prover-agent-gqrwh                                     Container image "aztecprotocol/aztec:62c32eb0064c0d95527286882b1ec798fd2c3932" already present on machine
7s          Normal    Started                 pod/smoke-aztec-network-prover-agent-gqrwh                                     Started container prover-agent
1s          Warning   Unhealthy               pod/smoke-aztec-network-validator-0                                            Startup probe failed: Get "http://10.244.0.78:8080/status": dial tcp 10.244.0.78:8080: connect: connection refused```