### PR TITLE
chore: update gov and proposer configs

### DIFF
--- a/l1-contracts/src/governance/Governance.sol
+++ b/l1-contracts/src/governance/Governance.sol
@@ -48,13 +48,13 @@ contract Governance is IGovernance {
 
     configuration = DataStructures.Configuration({
       proposeConfig: DataStructures.ProposeConfiguration({
-        lockDelay: Timestamp.wrap(60),
-        lockAmount: 1000e18
+        lockDelay: Timestamp.wrap(60 * 60 * 24 * 30),
+        lockAmount: 1e24
       }),
       votingDelay: Timestamp.wrap(60),
-      votingDuration: Timestamp.wrap(60),
+      votingDuration: Timestamp.wrap(60 * 60),
       executionDelay: Timestamp.wrap(60),
-      gracePeriod: Timestamp.wrap(60),
+      gracePeriod: Timestamp.wrap(60 * 60 * 24 * 7),
       quorum: 0.1e18,
       voteDifferential: 0.04e18,
       minimumVotes: 1000e18

--- a/yarn-project/end-to-end/src/e2e_p2p/upgrade_governance_proposer.test.ts
+++ b/yarn-project/end-to-end/src/e2e_p2p/upgrade_governance_proposer.test.ts
@@ -48,6 +48,8 @@ describe('e2e_p2p_governance_proposer', () => {
       initialConfig: {
         ...SHORTENED_BLOCK_TIME_CONFIG,
         listenAddress: '127.0.0.1',
+        governanceProposerQuorum: 6,
+        governanceProposerRoundSize: 10,
       },
     });
 
@@ -77,6 +79,8 @@ describe('e2e_p2p_governance_proposer', () => {
       client: t.ctx.deployL1ContractsValues.publicClient,
     });
 
+    const roundSize = await governanceProposer.read.M();
+
     const governance = getContract({
       address: getAddress(t.ctx.deployL1ContractsValues.l1ContractAddresses.governanceAddress.toString()),
       abi: GovernanceAbi,
@@ -95,7 +99,9 @@ describe('e2e_p2p_governance_proposer', () => {
       });
     };
 
-    const nextRoundTimestamp = await rollup.getTimestampForSlot(((await rollup.getSlotNumber()) / 10n) * 10n + 10n);
+    const nextRoundTimestamp = await rollup.getTimestampForSlot(
+      ((await rollup.getSlotNumber()) / roundSize) * roundSize + roundSize,
+    );
     await t.ctx.cheatCodes.eth.warp(Number(nextRoundTimestamp));
 
     const { address: newPayloadAddress } = await deployL1Contract(
@@ -163,7 +169,9 @@ describe('e2e_p2p_governance_proposer', () => {
 
     expect(govData.leaderVotes).toBeGreaterThan(govBefore.leaderVotes);
 
-    const nextRoundTimestamp2 = await rollup.getTimestampForSlot(((await rollup.getSlotNumber()) / 10n) * 10n + 10n);
+    const nextRoundTimestamp2 = await rollup.getTimestampForSlot(
+      ((await rollup.getSlotNumber()) / roundSize) * roundSize + roundSize,
+    );
     t.logger.info(`Warpping to ${nextRoundTimestamp2}`);
     await t.ctx.cheatCodes.eth.warp(Number(nextRoundTimestamp2));
 

--- a/yarn-project/ethereum/src/config.ts
+++ b/yarn-project/ethereum/src/config.ts
@@ -51,8 +51,8 @@ export const DefaultL1ContractsConfig = {
   minimumStake: BigInt(100e18),
   slashingQuorum: 6,
   slashingRoundSize: 10,
-  governanceProposerQuorum: 6,
-  governanceProposerRoundSize: 10,
+  governanceProposerQuorum: 51,
+  governanceProposerRoundSize: 100,
   manaTarget: BigInt(1e10),
   provingCostPerMana: BigInt(100),
 } satisfies L1ContractsConfig;


### PR DESCRIPTION
Updates the default values for the `governanceProposerQuorum` and `governanceProposerRoundSize` to be 51 and 100. Also updates the time settings in the governance.