### PR TITLE
chore: move a couple of `SharedMutableValues` functions outside of impl

### DIFF
--- a/noir-projects/aztec-nr/aztec/src/state_vars/shared_mutable.nr
+++ b/noir-projects/aztec-nr/aztec/src/state_vars/shared_mutable.nr
@@ -1,5 +1,10 @@
 use dep::protocol_types::{
-    shared_mutable::{ScheduledDelayChange, ScheduledValueChange, SharedMutableValues},
+    shared_mutable::{
+        ScheduledDelayChange,
+        ScheduledValueChange,
+        shared_mutable_values::{unpack_delay_change, unpack_value_change},
+        SharedMutableValues,
+    },
     traits::Packable,
 };
 
@@ -130,7 +135,7 @@ where
         // We don't read ScheduledValueChange directly by having it implement Packable because ScheduledValueChange
         // and ScheduledDelayChange are packed together (sdc and svc.block_of_change are stored in the same slot).
         let packed = self.context.storage_read(self.storage_slot);
-        SharedMutableValues::unpack_value_change(packed)
+        unpack_value_change::<T, N>(packed)
     }
 
     fn read_delay_change<let N: u32>(self) -> ScheduledDelayChange<INITIAL_DELAY>
@@ -145,7 +150,7 @@ where
         // ScheduledValueChange and ScheduledDelayChange are packed together (sdc and svc.block_of_change are
         // stored in the same slot).
         let packed = self.context.storage_read(self.storage_slot);
-        SharedMutableValues::<T, INITIAL_DELAY>::unpack_delay_change(packed)
+        unpack_delay_change::<INITIAL_DELAY>(packed)
     }
 
     fn write<let N: u32>(

--- a/noir-projects/noir-protocol-circuits/crates/types/src/shared_mutable/shared_mutable_values.nr
+++ b/noir-projects/noir-protocol-circuits/crates/types/src/shared_mutable/shared_mutable_values.nr
@@ -29,53 +29,55 @@ impl<T, let INITIAL_DELAY: u32> SharedMutableValues<T, INITIAL_DELAY> {
     pub fn new(svc: ScheduledValueChange<T>, sdc: ScheduledDelayChange<INITIAL_DELAY>) -> Self {
         SharedMutableValues { svc, sdc }
     }
+}
 
-    pub fn unpack_value_change<let N: u32>(packed: [Field; 2 * N + 1]) -> ScheduledValueChange<T>
-    where
-        T: Packable<N>,
-    {
-        let svc_pre_packed = arrays::subarray(packed, 1);
-        let svc_post_packed = arrays::subarray(packed, N + 1);
-        ScheduledValueChange::new(
-            T::unpack(svc_pre_packed),
-            T::unpack(svc_post_packed),
-            packed[0] as u32,
-        )
-    }
+pub fn unpack_value_change<T, let N: u32>(packed: [Field; 2 * N + 1]) -> ScheduledValueChange<T>
+where
+    T: Packable<N>,
+{
+    let svc_pre_packed = arrays::subarray(packed, 1);
+    let svc_post_packed = arrays::subarray(packed, N + 1);
+    ScheduledValueChange::new(
+        T::unpack(svc_pre_packed),
+        T::unpack(svc_post_packed),
+        packed[0] as u32,
+    )
+}
 
-    pub fn unpack_delay_change(packed: Field) -> ScheduledDelayChange<INITIAL_DELAY> {
-        // This function expects to be called with just the first field of the packed representation, which contains sdc
-        // and svc block_of_change. We'll discard the svc component.
-        let svc_block_of_change = packed as u32;
+pub fn unpack_delay_change<let INITIAL_DELAY: u32>(
+    packed: Field,
+) -> ScheduledDelayChange<INITIAL_DELAY> {
+    // This function expects to be called with just the first field of the packed representation, which contains sdc
+    // and svc block_of_change. We'll discard the svc component.
+    let svc_block_of_change = packed as u32;
 
-        let mut tmp = (packed - svc_block_of_change as Field) / TWO_POW_32;
-        let sdc_block_of_change = tmp as u32;
+    let mut tmp = (packed - svc_block_of_change as Field) / TWO_POW_32;
+    let sdc_block_of_change = tmp as u32;
 
-        tmp = (tmp - sdc_block_of_change as Field) / TWO_POW_32;
-        let sdc_post_is_some = tmp as bool;
+    tmp = (tmp - sdc_block_of_change as Field) / TWO_POW_32;
+    let sdc_post_is_some = tmp as bool;
 
-        tmp = (tmp - sdc_post_is_some as Field) / TWO_POW_8;
-        let sdc_post_inner = tmp as u32;
+    tmp = (tmp - sdc_post_is_some as Field) / TWO_POW_8;
+    let sdc_post_inner = tmp as u32;
 
-        tmp = (tmp - sdc_post_inner as Field) / TWO_POW_32;
-        let sdc_pre_is_some = tmp as bool;
+    tmp = (tmp - sdc_post_inner as Field) / TWO_POW_32;
+    let sdc_pre_is_some = tmp as bool;
 
-        tmp = (tmp - sdc_pre_is_some as Field) / TWO_POW_8;
-        let sdc_pre_inner = tmp as u32;
+    tmp = (tmp - sdc_pre_is_some as Field) / TWO_POW_8;
+    let sdc_pre_inner = tmp as u32;
 
-        ScheduledDelayChange {
-            pre: if sdc_pre_is_some {
-                Option::some(sdc_pre_inner)
-            } else {
-                Option::none()
-            },
-            post: if sdc_post_is_some {
-                Option::some(sdc_post_inner)
-            } else {
-                Option::none()
-            },
-            block_of_change: sdc_block_of_change,
-        }
+    ScheduledDelayChange {
+        pre: if sdc_pre_is_some {
+            Option::some(sdc_pre_inner)
+        } else {
+            Option::none()
+        },
+        post: if sdc_post_is_some {
+            Option::some(sdc_post_inner)
+        } else {
+            Option::none()
+        },
+        block_of_change: sdc_block_of_change,
     }
 }
 
@@ -111,8 +113,8 @@ where
     }
 
     fn unpack(fields: [Field; 2 * N + 1]) -> Self {
-        let svc = Self::unpack_value_change(fields);
-        let sdc = SharedMutableValues::<T, INITIAL_DELAY>::unpack_delay_change(fields[0]);
+        let svc = unpack_value_change::<T, N>(fields);
+        let sdc = unpack_delay_change::<INITIAL_DELAY>(fields[0]);
         Self::new(svc, sdc)
     }
 }


### PR DESCRIPTION
This was discussed a bit over slack, but here's some context.

In Rust this gives an error:

```rust
pub struct Foo<T> {
    x: T,
}

impl<T> Foo<T> {
    fn one(x: T) {
        Bar::two(x); // Cannot infer the value of const parameter U
    }
}

struct Bar<T, const U: usize> {
    x: T,
}

impl<T, const U: usize> Bar<T, U> {
    fn two(x: T) -> Foo<T> {
        Foo { x }
    }
}

fn main() {
    Foo::<i32>::one(1);
}
```

In the call `Bar::two` Rust needs to know what is the value of `U`. It can be solved by doing `Bar::<T, 1234>::two(x)` or using any numeric value... because the numeric value isn't used in that impl function... which probably means that it doesn't need to "belong" to `Bar`.

In this [Noir PR](https://github.com/noir-lang/noir/pull/7843) gets merged that's what will happen. We have a similar case in this codebase where `SharedMutableValues` has two methods:
- `unpack_value_change`: doesn't refer to `INITIAL_DELAY`
- `unpack_delay_change`: doesn't refer to `T`

So, this PR moves those two methods outside of the impl, only specifying the generics that are needed.