### PR TITLE
fix: ci3-external concurrency bug, reduce grind set

### DIFF
--- a/.github/workflows/ci3-external.yml
+++ b/.github/workflows/ci3-external.yml
@@ -9,7 +9,7 @@ on:
     types: [opened, synchronize, reopened, ready_for_review, labeled]
 
 concurrency:
-  # Only allow one run per <forked-repo>/<branch>.
+  # Only allow one run per <forked-repo>/<branch> and full concurrency on merge queue.
   group: |
     ci3-external-${{ github.event_name == 'pull_request' && format('{0}/{1}', github.event.pull_request.head.repo.full_name, github.head_ref)
                                                          || github.run_id} }

--- a/.github/workflows/ci3-external.yml
+++ b/.github/workflows/ci3-external.yml
@@ -11,7 +11,8 @@ on:
 concurrency:
   # Only allow one run per <forked-repo>/<branch>.
   group: |
-    ci3-external-${{format('{0}/{1}', github.event.pull_request.head.repo.full_name, github.head_ref)}}
+    ci3-external-${{ github.event_name == 'pull_request' && format('{0}/{1}', github.event.pull_request.head.repo.full_name, github.head_ref)
+                                                         || github.run_id} }
   cancel-in-progress: true
 
 jobs:

--- a/.github/workflows/ci3.yml
+++ b/.github/workflows/ci3.yml
@@ -183,7 +183,7 @@ jobs:
     if: github.event_name == 'merge_group'
     strategy:
       matrix:
-        number: [1, 2, 3, 4, 5]
+        number: [1, 2]
       fail-fast: false
     steps:
       #############


### PR DESCRIPTION
- fix issue where merge queue jobs could cancel external ci on one another
- reduce grind set to 2 machines