### PR TITLE
chore: don't dump on fail. click the link instead.

### DIFF
--- a/ci3/denoise
+++ b/ci3/denoise
@@ -87,7 +87,11 @@ publish_log
 
 # Handle non-zero exit status
 if [ "$status" -ne 0 ]; then
-  echo -e ". ${red}failed${reset} ($time)"
+  if [ -t 1 ]; then
+    echo -e "\nCommand exited with status $status. Dumping output:"
+    cat $outfile
+  fi
+  echo -e ". ${red}failed${reset} ($time) ${log_info:-}"
 else
   echo -e ". ${green}done${reset} ($time)"
 fi

--- a/ci3/denoise
+++ b/ci3/denoise
@@ -87,9 +87,7 @@ publish_log
 
 # Handle non-zero exit status
 if [ "$status" -ne 0 ]; then
-  echo -e "\nCommand exited with status $status. Dumping output:"
-  cat $outfile
-  echo -e ". ${red}failed${reset} ($time) ${log_info:-}"
+  echo -e ". ${red}failed${reset} ($time)"
 else
   echo -e ". ${green}done${reset} ($time)"
 fi

--- a/ci3/run_test_cmd
+++ b/ci3/run_test_cmd
@@ -130,6 +130,10 @@ function fail {
   track_test $test_hash "$line"
   track_test "failed_tests" "$line"
   echo -e "$line"
+  if [ -t 1 ]; then
+    cat $tmp_file
+    echo -e "$line"
+  fi
   exit $code
 }
 

--- a/ci3/run_test_cmd
+++ b/ci3/run_test_cmd
@@ -130,8 +130,6 @@ function fail {
   track_test $test_hash "$line"
   track_test "failed_tests" "$line"
   echo -e "$line"
-  cat $tmp_file
-  echo -e "$line"
   exit $code
 }
 


### PR DESCRIPTION
With better logging tooling, the need to dump the logs on fail is reduced.