### PR TITLE
chore(p2p): fix gas message validator

### DIFF
--- a/yarn-project/p2p/src/services/libp2p/libp2p_service.ts
+++ b/yarn-project/p2p/src/services/libp2p/libp2p_service.ts
@@ -792,7 +792,7 @@ export class LibP2PService<T extends P2PClientType> extends WithTracer implement
   ): Promise<ValidationOutcome> {
     const validationPromises = Object.entries(messageValidators).map(async ([name, { validator, severity }]) => {
       const { result } = await validator.validateTx(tx);
-      return { name, isValid: result === 'valid', severity };
+      return { name, isValid: result !== 'invalid', severity };
     });
 
     // A promise that resolves when all validations have been run


### PR DESCRIPTION
## Overview

Some new flakes have appeared after https://github.com/AztecProtocol/aztec-packages/pull/13154 as the message validation logic was unaware of the skipped state. This resulted peers dropping transactions with too low gas fees, that could become valid later.

example failing log:
```
08:06:17 [08:06:17.334] INFO: pxe:service:f4e6b4 Sent transaction 0x290aafc7b7c9c57f409dfb23dff0a42f126e157c640716eb9b56ead6276ab572
08:06:17 [08:06:17.339] INFO: e2e:e2e_p2p:e2e_p2p_rediscovery Tx sent with hash 0x290aafc7b7c9c57f409dfb23dff0a42f126e157c640716eb9b56ead6276ab572
08:06:17 [08:06:17.797] INFO: e2e:e2e_p2p:e2e_p2p_rediscovery Receipt received for 0x290aafc7b7c9c57f409dfb23dff0a42f126e157c640716eb9b56ead6276ab572
08:06:17 [08:06:17.839] WARN: sequencer:tx_validator:tx_gas Skipping transaction 0x290aafc7b7c9c57f409dfb23dff0a42f126e157c640716eb9b56ead6276ab572 due to insufficient fee per gas {"txMaxFeesPerGas":{"feePerDaGas":0,"feePerL2Gas":28890},"currentGasFees":{"feePerDaGas":0,"feePerL2Gas":270010}}
08:06:17 [08:06:17.842] VERBOSE: p2p:peer-scoring Penalizing peer 16Uiu2HAmVSN83RZZYAXjTVvjF1SdcKEnovXNd7wK1SzVRngiwFB4 with HighToleranceError (new score is -2)
08:06:17 [08:06:17.875] WARN: sequencer:tx_validator:tx_gas Skipping transaction 0x290aafc7b7c9c57f409dfb23dff0a42f126e157c640716eb9b56ead6276ab572 due to insufficient fee per gas {"txMaxFeesPerGas":{"feePerDaGas":0,"feePerL2Gas":28890},"currentGasFees":{"feePerDaGas":0,"feePerL2Gas":270010}}
08:06:17 [08:06:17.876] VERBOSE: p2p:peer-scoring Penalizing peer 16Uiu2HAmVSN83RZZYAXjTVvjF1SdcKEnovXNd7wK1SzVRngiwFB4 with HighToleranceError (new score is -2)
08:06:18 [08:06:18.020] WARN: sequencer:tx_validator:tx_gas Skipping transaction 0x290aafc7b7c9c57f409dfb23dff0a42f126e157c640716eb9b56ead6276ab572 due to insufficient fee per gas {"txMaxFeesPerGas":{"feePerDaGas":0,"feePerL2Gas":28890},"currentGasFees":{"feePerDaGas":0,"feePerL2Gas":270010}}
08:06:18 [08:06:18.022] VERBOSE: p2p:peer-scoring Penalizing peer 16Uiu2HAmVSN83RZZYAXjTVvjF1SdcKEnovXNd7wK1SzVRngiwFB4 with HighToleranceError (new score is -2)

```
