### PR TITLE
fix: Shorten the name of a cron job to please terraform

### DIFF
--- a/spartan/aztec-network/templates/create-snapshot.yaml
+++ b/spartan/aztec-network/templates/create-snapshot.yaml
@@ -3,7 +3,7 @@
 apiVersion: batch/v1
 kind: CronJob
 metadata:
-  name: {{ include "aztec-network.fullname" . }}-upload-snapshots-cron-job
+  name: {{ include "aztec-network.fullname" . }}-snapshots-cron-job
   labels:
     {{- include "aztec-network.labels" . | nindent 4 }}
 spec:


### PR DESCRIPTION
This PR simply shortens the name of a cron job.
