### PR TITLE
chore: shorter ci links

### DIFF
--- a/ci3/filter_cached_test_cmd
+++ b/ci3/filter_cached_test_cmd
@@ -22,7 +22,7 @@ function process_batch {
     if [ -z "${results[$i]}" ]; then
       echo "${lines[$i]}"
     else
-      echo -e "${blue}SKIPPED${reset} (${yellow}http://ci.aztec-labs.com/${results[$i]}${reset}): ${lines[$i]}" >&3
+      echo -e "${blue}SKIPPED${reset} (${yellow}$(ci_term_link ${results[$i]})${reset}): ${lines[$i]}" >&3
     fi
   done
 }

--- a/ci3/run_test_cmd
+++ b/ci3/run_test_cmd
@@ -18,7 +18,7 @@ test_hash=$(hash_str_orig "$test_cmd")
 if [ "$USE_TEST_CACHE" -eq 1 ]; then
   log_key=$(redis_cli GET $key)
   if [ -n "$log_key" ]; then
-    log_info=" (${yellow}${link_open}http://ci.aztec-labs.com/$log_key${link_close}$log_key${link_open}${link_close}${reset})"
+    log_info=" (${yellow}$(ci_term_link $log_key)${reset})"
     echo -e "${blue}SKIPPED${reset}${log_info:-}: $cmd"
     exit 0
   fi
@@ -63,7 +63,7 @@ function live_publish_log {
 
 if [ "$CI_REDIS_AVAILABLE" -eq 1 ]; then
   log_key=$(uuid)
-  log_info=" (${yellow}${link_open}http://ci.aztec-labs.com/$log_key${link_close}$log_key${link_open}${link_close}${reset})"
+  log_info=" (${yellow}$(ci_term_link $log_key)${reset})"
 
   if [ "$CI" -eq 1 ]; then
     # If we're in CI, we want to publish the log live.

--- a/ci3/run_test_cmd
+++ b/ci3/run_test_cmd
@@ -18,7 +18,7 @@ test_hash=$(hash_str_orig "$test_cmd")
 if [ "$USE_TEST_CACHE" -eq 1 ]; then
   log_key=$(redis_cli GET $key)
   if [ -n "$log_key" ]; then
-    log_info=" (${yellow}http://ci.aztec-labs.com/$log_key${reset})"
+    log_info=" (${yellow}${link_open}http://ci.aztec-labs.com/$log_key${link_close}$log_key${link_open}${link_close}${reset})"
     echo -e "${blue}SKIPPED${reset}${log_info:-}: $cmd"
     exit 0
   fi
@@ -63,7 +63,7 @@ function live_publish_log {
 
 if [ "$CI_REDIS_AVAILABLE" -eq 1 ]; then
   log_key=$(uuid)
-  log_info=" (${yellow}http://ci.aztec-labs.com/$log_key${reset})"
+  log_info=" (${yellow}${link_open}http://ci.aztec-labs.com/$log_key${link_close}$log_key${link_open}${link_close}${reset})"
 
   if [ "$CI" -eq 1 ]; then
     # If we're in CI, we want to publish the log live.

--- a/ci3/source_color
+++ b/ci3/source_color
@@ -35,6 +35,7 @@ function term_link {
 function ci_term_link {
   term_link "http://ci.aztec-labs.com/$1" "$1"
 }
+export -f term_link ci_term_link
 
 # We always want color.
 export FORCE_COLOR=true

--- a/ci3/source_color
+++ b/ci3/source_color
@@ -28,5 +28,13 @@ export reset="\033[0m"
 export link_open='\033]8;;'
 export link_close='\x07'
 
+function term_link {
+  echo -e "${link_open}$1${link_close}$2${link_open}${link_close}"
+}
+
+function ci_term_link {
+  term_link "http://ci.aztec-labs.com/$1" "$1"
+}
+
 # We always want color.
 export FORCE_COLOR=true


### PR DESCRIPTION
GA cant handle term links.
We no longer spam GA with fail logs however, so only need full links at root.
Thus denoise still needs it, but our test runs statuses can be shortened.