### PR TITLE
chore(discv): improve flakey self update ip test

### DIFF
--- a/yarn-project/p2p/src/services/discv5/discV5_service.ts
+++ b/yarn-project/p2p/src/services/discv5/discV5_service.ts
@@ -117,7 +117,7 @@ export class DiscV5Service extends EventEmitter implements PeerDiscoveryService 
     // We want to update our tcp port to match the udp port
     const multiAddrTcp = multiaddr(convertToMultiaddr(m.nodeAddress().address, this.config.p2pPort, 'tcp'));
     this.enr.setLocationMultiaddr(multiAddrTcp);
-    this.logger.info('Multiaddr updated', { multiaddr: multiaddr.toString() });
+    this.logger.info('Multiaddr updated', { multiaddr: multiAddrTcp.toString() });
   }
 
   public async start(): Promise<void> {

--- a/yarn-project/p2p/src/services/discv5/discv5_service.test.ts
+++ b/yarn-project/p2p/src/services/discv5/discv5_service.test.ts
@@ -15,7 +15,7 @@ import { type BootnodeConfig, type P2PConfig, getP2PDefaultConfig } from '../../
 import { PeerDiscoveryState } from '../service.js';
 import { DiscV5Service } from './discV5_service.js';
 
-const waitForPeers = (node: DiscV5Service, expectedCount: number, timeout = 7_000): Promise<void> => {
+const waitForPeers = (node: DiscV5Service, expectedCount: number, timeout = 15_000): Promise<void> => {
   return new Promise((resolve, reject) => {
     const timeoutId = setTimeout(() => {
       reject(new Error(`Timeout: Failed to connect to ${expectedCount} peers within ${timeout} ms`));
@@ -135,7 +135,7 @@ describe('Discv5Service', () => {
     }
 
     expect(node.getEnr().ip).toEqual(undefined);
-    await Promise.any([
+    await Promise.allSettled([
       waitForPeers(node, extraNodes),
       (async () => {
         await sleep(2000); // wait for peer discovery to be able to start

--- a/yarn-project/p2p/src/services/discv5/discv5_service.test.ts
+++ b/yarn-project/p2p/src/services/discv5/discv5_service.test.ts
@@ -135,7 +135,7 @@ describe('Discv5Service', () => {
     }
 
     expect(node.getEnr().ip).toEqual(undefined);
-    await Promise.all([
+    await Promise.any([
       waitForPeers(node, extraNodes),
       (async () => {
         await sleep(2000); // wait for peer discovery to be able to start

--- a/yarn-project/p2p/src/services/libp2p/libp2p_service.ts
+++ b/yarn-project/p2p/src/services/libp2p/libp2p_service.ts
@@ -86,7 +86,7 @@ type ValidationOutcome = { allPassed: true } | { allPassed: false; failure: Vali
 /**
  * Lib P2P implementation of the P2PService interface.
  */
-export class LibP2PService<T extends P2PClientType> extends WithTracer implements P2PService {
+export class LibP2PService<T extends P2PClientType = P2PClientType.Full> extends WithTracer implements P2PService {
   private jobQueue: SerialQueue = new SerialQueue();
   private peerManager: PeerManager;
   private discoveryRunningPromise?: RunningPromise;
@@ -115,15 +115,15 @@ export class LibP2PService<T extends P2PClientType> extends WithTracer implement
   constructor(
     private clientType: T,
     private config: P2PConfig,
-    private node: PubSubLibp2p,
+    protected node: PubSubLibp2p,
     private peerDiscoveryService: PeerDiscoveryService,
-    private mempools: MemPools<T>,
+    protected mempools: MemPools<T>,
     private archiver: L2BlockSource & ContractDataSource,
     epochCache: EpochCacheInterface,
     private proofVerifier: ClientProtocolCircuitVerifier,
     private worldStateSynchronizer: WorldStateSynchronizer,
     telemetry: TelemetryClient,
-    private logger = createLogger('p2p:libp2p_service'),
+    protected logger = createLogger('p2p:libp2p_service'),
   ) {
     super(telemetry, 'LibP2PService');
 
@@ -482,7 +482,7 @@ export class LibP2PService<T extends P2PClientType> extends WithTracer implement
    * @param topic - The message's topic.
    * @param data - The message data
    */
-  private async handleNewGossipMessage(msg: Message, msgId: string, source: PeerId) {
+  protected async handleNewGossipMessage(msg: Message, msgId: string, source: PeerId) {
     if (msg.topic === Tx.p2pTopic) {
       await this.handleGossipedTx(msg, msgId, source);
     }
@@ -496,7 +496,7 @@ export class LibP2PService<T extends P2PClientType> extends WithTracer implement
     return;
   }
 
-  private async validateReceivedMessage<T>(
+  protected async validateReceivedMessage<T>(
     validationFunc: () => Promise<{ result: boolean; obj: T }>,
     msgId: string,
     source: PeerId,
@@ -516,7 +516,7 @@ export class LibP2PService<T extends P2PClientType> extends WithTracer implement
     return resultAndObj;
   }
 
-  private async handleGossipedTx(msg: Message, msgId: string, source: PeerId) {
+  protected async handleGossipedTx(msg: Message, msgId: string, source: PeerId) {
     const validationFunc = async () => {
       const tx = Tx.fromBuffer(Buffer.from(msg.data));
       const result = await this.validatePropagatedTx(tx, source);

--- a/yarn-project/p2p/src/testbench/p2p_client_testbench_worker.ts
+++ b/yarn-project/p2p/src/testbench/p2p_client_testbench_worker.ts
@@ -10,17 +10,25 @@ import { createLogger } from '@aztec/foundation/log';
 import { sleep } from '@aztec/foundation/sleep';
 import type { DataStoreConfig } from '@aztec/kv-store/config';
 import { openTmpStore } from '@aztec/kv-store/lmdb-v2';
-import type { WorldStateSynchronizer } from '@aztec/stdlib/interfaces/server';
+import type { L2BlockSource } from '@aztec/stdlib/block';
+import type { ContractDataSource } from '@aztec/stdlib/contract';
+import type { ClientProtocolCircuitVerifier, WorldStateSynchronizer } from '@aztec/stdlib/interfaces/server';
 import { P2PClientType } from '@aztec/stdlib/p2p';
 import { Tx, TxStatus } from '@aztec/stdlib/tx';
+import { type TelemetryClient, getTelemetryClient } from '@aztec/telemetry-client';
 
-import { type Message, type PeerId, TopicValidatorResult } from '@libp2p/interface';
+import type { Message, PeerId } from '@libp2p/interface';
+import { TopicValidatorResult } from '@libp2p/interface';
 
 import type { P2PConfig } from '../config.js';
 import { createP2PClient } from '../index.js';
 import type { AttestationPool } from '../mem_pools/attestation_pool/attestation_pool.js';
+import type { MemPools } from '../mem_pools/interface.js';
 import type { TxPool } from '../mem_pools/tx_pool/index.js';
+import { LibP2PService } from '../services/libp2p/libp2p_service.js';
+import type { PeerDiscoveryService } from '../services/service.js';
 import { AlwaysTrueCircuitVerifier } from '../test-helpers/reqresp-nodes.js';
+import type { PubSubLibp2p } from '../util.js';
 
 // Simple mock implementation
 function mockTxPool(): TxPool {
@@ -69,6 +77,72 @@ function mockEpochCache(): EpochCacheInterface {
   };
 }
 
+class TestLibP2PService<T extends P2PClientType = P2PClientType.Full> extends LibP2PService<T> {
+  private disableTxValidation: boolean;
+  private gossipMessageCount: number = 0;
+
+  constructor(
+    clientType: T,
+    config: P2PConfig,
+    node: PubSubLibp2p,
+    peerDiscoveryService: PeerDiscoveryService,
+    mempools: MemPools<T>,
+    archiver: L2BlockSource & ContractDataSource,
+    epochCache: EpochCacheInterface,
+    proofVerifier: ClientProtocolCircuitVerifier,
+    worldStateSynchronizer: WorldStateSynchronizer,
+    telemetry: TelemetryClient,
+    logger = createLogger('p2p:test:libp2p_service'),
+    disableTxValidation = true,
+  ) {
+    super(
+      clientType,
+      config,
+      node,
+      peerDiscoveryService,
+      mempools,
+      archiver,
+      epochCache,
+      proofVerifier,
+      worldStateSynchronizer,
+      telemetry,
+      logger,
+    );
+    this.disableTxValidation = disableTxValidation;
+  }
+
+  public getGossipMessageCount(): number {
+    return this.gossipMessageCount;
+  }
+
+  public setDisableTxValidation(disable: boolean): void {
+    this.disableTxValidation = disable;
+  }
+
+  protected override async handleGossipedTx(msg: Message, msgId: string, source: PeerId) {
+    if (this.disableTxValidation) {
+      const tx = Tx.fromBuffer(Buffer.from(msg.data));
+      this.node.services.pubsub.reportMessageValidationResult(msgId, source.toString(), TopicValidatorResult.Accept);
+
+      const txHash = await tx.getTxHash();
+      const txHashString = txHash.toString();
+      this.logger.verbose(`Received tx ${txHashString} from external peer ${source.toString()}.`);
+      await this.mempools.txPool.addTxs([tx]);
+    } else {
+      await super.handleGossipedTx(msg, msgId, source);
+    }
+  }
+
+  protected override async handleNewGossipMessage(msg: Message, msgId: string, source: PeerId) {
+    this.gossipMessageCount++;
+    process.send!({
+      type: 'GOSSIP_RECEIVED',
+      count: this.gossipMessageCount,
+    });
+    await super.handleNewGossipMessage(msg, msgId, source);
+  }
+}
+
 // eslint-disable-next-line @typescript-eslint/no-misused-promises
 process.on('message', async msg => {
   const { type, config, clientIndex } = msg as { type: string; config: P2PConfig; clientIndex: number };
@@ -84,6 +158,7 @@ process.on('message', async msg => {
       const proofVerifier = new AlwaysTrueCircuitVerifier();
       const kvStore = await openTmpStore(`test-${clientIndex}`);
       const logger = createLogger(`p2p:${clientIndex}`);
+      const telemetry = getTelemetryClient();
 
       const deps = {
         txPool,
@@ -99,39 +174,30 @@ process.on('message', async msg => {
         proofVerifier,
         worldState,
         epochCache,
-        undefined,
+        telemetry,
         deps,
       );
 
-      // We disable message validation in the testbench
-      // In our case we only deal with txs
-      (client as any).p2pService.handleGossipedTx = async (msg: Message, msgId: string, source: PeerId) => {
-        const tx = Tx.fromBuffer(Buffer.from(msg.data));
-        (client as any).p2pService.node.services.pubsub.reportMessageValidationResult(
-          msgId,
-          source.toString(),
-          TopicValidatorResult.Accept,
-        );
+      const _client = client as any;
 
-        const txHash = await tx.getTxHash();
-        const txHashString = txHash.toString();
-        logger.verbose(`Received tx ${txHashString} from external peer ${source.toString()}.`);
-        await txPool.addTxs([tx]);
-      };
+      // Create test service with validation disabled
+      const testService = new TestLibP2PService(
+        P2PClientType.Full,
+        config,
+        (client as any).p2pService.node,
+        (client as any).p2pService.peerDiscoveryService,
+        (client as any).p2pService.mempools,
+        (client as any).p2pService.archiver,
+        epochCache,
+        proofVerifier,
+        worldState,
+        telemetry,
+        logger,
+        true, // disable validation
+      );
 
-      // Create spy for gossip messages
-      let gossipMessageCount = 0;
-      (client as any).p2pService.handleNewGossipMessage = (msg: Message, msgId: string, source: PeerId) => {
-        gossipMessageCount++;
-        process.send!({
-          type: 'GOSSIP_RECEIVED',
-          count: gossipMessageCount,
-        });
-        return (client as any).p2pService.constructor.prototype.handleNewGossipMessage.apply(
-          (client as any).p2pService,
-          [msg, msgId, source],
-        );
-      };
+      // Replace the existing p2pService with our test version
+      (client as any).p2pService = testService;
 
       await client.start();
       // Wait until the client is ready

--- a/yarn-project/p2p/src/testbench/parse_log_file.ts
+++ b/yarn-project/p2p/src/testbench/parse_log_file.ts
@@ -37,7 +37,7 @@ function getTimestamp(line: string): number | null {
 }
 
 /**
- * Parses a single log line. If the line contains an "rpc.from" event,
+ * Parses a single log line. If the line contains an "Received tx" event,
  * it extracts the timestamp and the peer ID.
  */
 function parseReceivedTx(line: string): LogEvent | null {
@@ -52,9 +52,9 @@ function parseReceivedTx(line: string): LogEvent | null {
     return null;
   }
 
-  // TODO: this is not correct - it is just the tx hash for now
-  // Extract the peer ID after "Received tx"
-  const peerIdMatch = line.match(/p2p:(\d+):/);
+  // Extract the peer ID from the log line
+  // Example format: "module":"p2p:1","msg":"Received tx 0x0feeafa65f25fd8d613fe4aca44fd65fe41c149ef1941e2019d40925c40748f9 from external peer 16Uiu2HAm8w4oxXF3TwDKoGL9U66thMXWqCgPnb2CgkYwmUqFCWbC."
+  const peerIdMatch = line.match(/"module":"p2p:(\d+)"/);
   if (!peerIdMatch) {
     logger.error('No peer Number found in received tx log');
     return null;

--- a/yarn-project/p2p/src/testbench/testbench.ts
+++ b/yarn-project/p2p/src/testbench/testbench.ts
@@ -42,7 +42,7 @@ async function main() {
     logger.info('Transaction sent from client 0');
 
     // Give time for message propagation
-    await sleep(30000);
+    await sleep(10000);
     logger.info('Checking message propagation results');
 
     // Check message propagation results

--- a/yarn-project/p2p/src/testbench/worker_client_manager.ts
+++ b/yarn-project/p2p/src/testbench/worker_client_manager.ts
@@ -244,7 +244,7 @@ class WorkerClientManager {
         } catch (e) {
           this.logger.error(`Error force killing process ${index}:`, e);
         }
-      }, 10000); // 10 second timeout for graceful exit
+      }, 5000); // 5 second timeout for graceful exit
 
       // Listen for process exit
       process.once('exit', () => {
@@ -294,7 +294,7 @@ class WorkerClientManager {
               }
             });
             resolve();
-          }, 30000); // 30 second timeout for all processes
+          }, 10000); // 10 second timeout for all processes
         }),
       ]);
     } catch (error) {


### PR DESCRIPTION
## Overview


in http://ci.aztec-labs.com/c3954cbd813c6468 we see that 

INFO: p2p:discv5_service:7894 Multiaddr updated

Which is our success case, even thought the test fails. 

Swapping Promise.all to Promise.allSettled as we do not care if we reject if we end up with our IP updated
