### PR TITLE
refactor: using Txhash type

### DIFF
--- a/yarn-project/protocol-contracts/src/auth-registry/index.ts
+++ b/yarn-project/protocol-contracts/src/auth-registry/index.ts
@@ -1,4 +1,4 @@
-import { loadContractArtifact } from '@aztec/stdlib/abi';
+import { type ContractArtifact, loadContractArtifact } from '@aztec/stdlib/abi';
 import type { NoirCompiledContract } from '@aztec/stdlib/noir';
 
 import AuthRegistryJson from '../../artifacts/AuthRegistry.json' assert { type: 'json' };
@@ -7,7 +7,7 @@ import type { ProtocolContract } from '../protocol_contract.js';
 
 let protocolContract: ProtocolContract;
 
-export const AuthRegistryArtifact = loadContractArtifact(AuthRegistryJson as NoirCompiledContract);
+export const AuthRegistryArtifact: ContractArtifact = loadContractArtifact(AuthRegistryJson as NoirCompiledContract);
 
 /** Returns the canonical deployment of the auth registry. */
 export async function getCanonicalAuthRegistry(): Promise<ProtocolContract> {

--- a/yarn-project/pxe/src/pxe_oracle_interface/pxe_oracle_interface.ts
+++ b/yarn-project/pxe/src/pxe_oracle_interface/pxe_oracle_interface.ts
@@ -619,7 +619,7 @@ export class PXEOracleInterface implements ExecutionDataProvider {
     content: Fr[],
     noteHash: Fr,
     nullifier: Fr,
-    txHash: Fr,
+    txHash: TxHash,
     recipient: AztecAddress,
   ): Promise<void> {
     // We are going to store the new note in the NoteDataProvider, which will let us later return it via `getNotes`.
@@ -666,7 +666,7 @@ export class PXEOracleInterface implements ExecutionDataProvider {
       nonce,
       noteHash,
       siloedNullifier,
-      new TxHash(txHash),
+      txHash,
       uniqueNoteHashTreeIndexInBlock?.l2BlockNumber,
       uniqueNoteHashTreeIndexInBlock?.l2BlockHash,
       uniqueNoteHashTreeIndexInBlock?.data,

--- a/yarn-project/pxe/src/pxe_oracle_interface/pxe_oracle_interface.ts
+++ b/yarn-project/pxe/src/pxe_oracle_interface/pxe_oracle_interface.ts
@@ -598,7 +598,7 @@ export class PXEOracleInterface implements ExecutionDataProvider {
 
         const pendingTaggedLog = new PendingTaggedLog(
           scopedLog.log.toFields(),
-          scopedLog.txHash.hash,
+          scopedLog.txHash,
           txEffect.data.noteHashes,
           txEffect.data.nullifiers[0],
           recipient,
@@ -729,7 +729,7 @@ export class PXEOracleInterface implements ExecutionDataProvider {
     // TODO(#11636): use the actual log length.
     const trimmedLog = scopedLog.log.toFields().filter(x => !x.isZero());
 
-    return new LogWithTxData(trimmedLog, scopedLog.txHash.hash, txEffect.data.noteHashes, txEffect.data.nullifiers[0]);
+    return new LogWithTxData(trimmedLog, scopedLog.txHash, txEffect.data.noteHashes, txEffect.data.nullifiers[0]);
   }
 
   // TODO(#12553): nuke this as part of tackling that issue. This function is no longer unit tested as I had to remove

--- a/yarn-project/simulator/src/private/acvm/oracle/oracle.ts
+++ b/yarn-project/simulator/src/private/acvm/oracle/oracle.ts
@@ -398,7 +398,7 @@ export class Oracle {
       fromBoundedVec(content, contentLength),
       Fr.fromString(noteHash),
       Fr.fromString(nullifier),
-      Fr.fromString(txHash),
+      TxHash.fromString(txHash),
       AztecAddress.fromString(recipient),
     );
 

--- a/yarn-project/simulator/src/private/acvm/oracle/typed_oracle.ts
+++ b/yarn-project/simulator/src/private/acvm/oracle/typed_oracle.ts
@@ -225,7 +225,7 @@ export abstract class TypedOracle {
     _content: Fr[],
     _noteHash: Fr,
     _nullifier: Fr,
-    _txHash: Fr,
+    _txHash: TxHash,
     _recipient: AztecAddress,
   ): Promise<void> {
     return Promise.reject(new OracleMethodNotAvailableError('deliverNote'));

--- a/yarn-project/simulator/src/private/execution_data_provider.ts
+++ b/yarn-project/simulator/src/private/execution_data_provider.ts
@@ -259,7 +259,7 @@ export interface ExecutionDataProvider extends CommitmentsDBInterface {
     content: Fr[],
     noteHash: Fr,
     nullifier: Fr,
-    txHash: Fr,
+    txHash: TxHash,
     recipient: AztecAddress,
   ): Promise<void>;
 

--- a/yarn-project/simulator/src/private/utility_execution_oracle.ts
+++ b/yarn-project/simulator/src/private/utility_execution_oracle.ts
@@ -291,7 +291,7 @@ export class UtilityExecutionOracle extends TypedOracle {
     content: Fr[],
     noteHash: Fr,
     nullifier: Fr,
-    txHash: Fr,
+    txHash: TxHash,
     recipient: AztecAddress,
   ) {
     // TODO(#10727): allow other contracts to deliver notes

--- a/yarn-project/stdlib/src/logs/log_with_tx_data.ts
+++ b/yarn-project/stdlib/src/logs/log_with_tx_data.ts
@@ -1,12 +1,13 @@
 import { MAX_NOTE_HASHES_PER_TX, PUBLIC_LOG_DATA_SIZE_IN_FIELDS } from '@aztec/constants';
 import { Fr } from '@aztec/foundation/fields';
+import { TxHash } from '@aztec/stdlib/tx';
 
 // TypeScript representation of the Noir aztec::oracle::message_discovery::LogWithTxData struct. This is used as a
 // response for PXE's custom getLogByTag oracle.
 export class LogWithTxData {
   constructor(
     public logContent: Fr[],
-    public txHash: Fr,
+    public txHash: TxHash,
     public uniqueNoteHashesInTx: Fr[],
     public firstNullifierInTx: Fr,
   ) {}
@@ -14,14 +15,14 @@ export class LogWithTxData {
   toNoirSerialization(): (Fr | Fr[])[] {
     return [
       ...toBoundedVecSerialization(this.logContent, PUBLIC_LOG_DATA_SIZE_IN_FIELDS),
-      this.txHash,
+      this.txHash.hash,
       ...toBoundedVecSerialization(this.uniqueNoteHashesInTx, MAX_NOTE_HASHES_PER_TX),
       this.firstNullifierInTx,
     ];
   }
 
   static noirSerializationOfEmpty(): (Fr | Fr[])[] {
-    return new LogWithTxData([], new Fr(0), [], new Fr(0)).toNoirSerialization();
+    return new LogWithTxData([], TxHash.zero(), [], new Fr(0)).toNoirSerialization();
   }
 }
 

--- a/yarn-project/stdlib/src/logs/pending_tagged_log.test.ts
+++ b/yarn-project/stdlib/src/logs/pending_tagged_log.test.ts
@@ -2,12 +2,13 @@ import { Fr } from '@aztec/foundation/fields';
 import { updateInlineTestData } from '@aztec/foundation/testing/files';
 
 import { AztecAddress } from '../aztec-address/index.js';
+import { TxHash } from '../tx/tx_hash.js';
 import { PendingTaggedLog } from './pending_tagged_log.js';
 
 describe('PendingTaggedLog', () => {
   it('serialization matches snapshots and output of Noir serialization', () => {
     const log = [new Fr(1n), new Fr(2n), new Fr(3n)];
-    const txHash = new Fr(123n);
+    const txHash = new TxHash(new Fr(123n));
     const uniqueNoteHashes = [new Fr(4n), new Fr(5n)];
     const firstNullifier = new Fr(6n);
     const recipient = AztecAddress.fromField(new Fr(789n));

--- a/yarn-project/stdlib/src/logs/pending_tagged_log.ts
+++ b/yarn-project/stdlib/src/logs/pending_tagged_log.ts
@@ -2,6 +2,7 @@ import { MAX_NOTE_HASHES_PER_TX, PRIVATE_LOG_SIZE_IN_FIELDS } from '@aztec/const
 import { Fr } from '@aztec/foundation/fields';
 
 import type { AztecAddress } from '../aztec-address/index.js';
+import type { TxHash } from '../tx/tx_hash.js';
 
 /**
  * Represents a pending tagged log as it is stored in the pending tagged log array to which the syncNotes oracle
@@ -10,7 +11,7 @@ import type { AztecAddress } from '../aztec-address/index.js';
 export class PendingTaggedLog {
   constructor(
     public log: Fr[],
-    public txHash: Fr,
+    public txHash: TxHash,
     public uniqueNoteHashesInTx: Fr[],
     public firstNullifierInTx: Fr,
     public recipient: AztecAddress,
@@ -20,7 +21,7 @@ export class PendingTaggedLog {
   toFields(): Fr[] {
     return [
       ...serializeBoundedVec(this.log, PRIVATE_LOG_SIZE_IN_FIELDS),
-      this.txHash,
+      this.txHash.hash,
       ...serializeBoundedVec(this.uniqueNoteHashesInTx, MAX_NOTE_HASHES_PER_TX),
       this.firstNullifierInTx,
       this.recipient.toField(),

--- a/yarn-project/txe/src/oracle/txe_oracle.ts
+++ b/yarn-project/txe/src/oracle/txe_oracle.ts
@@ -1096,7 +1096,7 @@ export class TXE implements TypedOracle {
     content: Fr[],
     noteHash: Fr,
     nullifier: Fr,
-    txHash: Fr,
+    txHash: TxHash,
     recipient: AztecAddress,
   ): Promise<void> {
     await this.pxeOracleInterface.deliverNote(

--- a/yarn-project/txe/src/txe_service/txe_service.ts
+++ b/yarn-project/txe/src/txe_service/txe_service.ts
@@ -539,7 +539,7 @@ export class TXEService {
       fromArray(content.slice(0, Number(BigInt(contentLength)))),
       fromSingle(noteHash),
       fromSingle(nullifier),
-      fromSingle(txHash),
+      new TxHash(fromSingle(txHash)),
       AztecAddress.fromField(fromSingle(recipient)),
     );
 


### PR DESCRIPTION
In plenty of the places we didn't use the TxHash type for no apparent reason.
