### PR TITLE
chore: add get canonical sponsored fpc and cleanup fee opts in cli wallet

### DIFF
--- a/yarn-project/cli-wallet/src/utils/options/fees.ts
+++ b/yarn-project/cli-wallet/src/utils/options/fees.ts
@@ -77,7 +77,11 @@ function printOptionParams(params: OptionParams) {
       params[name].default ? `Default: ${params[name].default}` : '',
     ].join(' '),
   );
-  return descriptionList.length ? `\n   Parameters:\n${descriptionList.join('\n')}` : '';
+  return descriptionList.length
+    ? `\n   Parameters:\n${descriptionList.join('\n')}\nFormat: --payment ${Object.keys(params)
+        .slice(0, 3)
+        .map(name => `${name}=${params[name].type}`)} ${Object.keys(params).length > 3 ? '...' : ''}`
+    : '';
 }
 
 function getFeePaymentMethodParams(allowCustomFeePayer: boolean): OptionParams {
@@ -122,11 +126,7 @@ function getFeePaymentMethodParams(allowCustomFeePayer: boolean): OptionParams {
 
 function getPaymentMethodOption(allowCustomFeePayer: boolean) {
   const params = getFeePaymentMethodParams(allowCustomFeePayer);
-  const paramList = Object.keys(params).map(name => `${name}=${params[name].type}`);
-  return new Option(
-    `--payment <${paramList.join(',')}>`,
-    `Fee payment method and arguments.${printOptionParams(params)}`,
-  );
+  return new Option(`--payment <options>`, `Fee payment method and arguments.${printOptionParams(params)}`);
 }
 
 function getFeeOptions(allowCustomFeePayer: boolean) {

--- a/yarn-project/cli/src/cmds/misc/get_canonical_sponsored_fpc_address.ts
+++ b/yarn-project/cli/src/cmds/misc/get_canonical_sponsored_fpc_address.ts
@@ -1,0 +1,7 @@
+import type { LogFn } from '@aztec/foundation/log';
+
+import { getSponsoredFPCAddress } from '../../utils/setup_contracts.js';
+
+export async function getCanonicalSponsoredFPCAddress(log: LogFn) {
+  log(`Canonical SponsoredFPC Address: ${(await getSponsoredFPCAddress()).toString()}`);
+}

--- a/yarn-project/cli/src/cmds/misc/index.ts
+++ b/yarn-project/cli/src/cmds/misc/index.ts
@@ -78,6 +78,14 @@ export function injectCommands(program: Command, log: LogFn) {
     });
 
   program
+    .command('get-canonical-sponsored-fpc-address')
+    .description('Gets the canonical SponsoredFPC address for this any testnet running on the same version as this CLI')
+    .action(async () => {
+      const { getCanonicalSponsoredFPCAddress } = await import('./get_canonical_sponsored_fpc_address.js');
+      await getCanonicalSponsoredFPCAddress(log);
+    });
+
+  program
     .command('update')
     .description('Updates Nodejs and Noir dependencies')
     .argument('[projectPath]', 'Path to the project directory', process.cwd())


### PR DESCRIPTION
Some quick fixes requested by dev-rel

1. exposing the canonical SponsoredFPC address to the cli
2. cleaning up some printing of fee opts in the cli wallet