### PR TITLE
fix: Use proof submission window for prover node deadline

### DIFF
--- a/yarn-project/archiver/src/archiver/archiver.test.ts
+++ b/yarn-project/archiver/src/archiver/archiver.test.ts
@@ -112,6 +112,7 @@ describe('Archiver', () => {
       epochDuration: 4,
       slotDuration: 24,
       ethereumSlotDuration: 12,
+      proofSubmissionWindow: 8,
     };
 
     archiver = new Archiver(

--- a/yarn-project/archiver/src/archiver/archiver.ts
+++ b/yarn-project/archiver/src/archiver/archiver.ts
@@ -151,7 +151,12 @@ export class Archiver extends EventEmitter implements ArchiveSource, Traceable {
       rollup.getL1GenesisTime(),
     ] as const);
 
-    const { aztecEpochDuration: epochDuration, aztecSlotDuration: slotDuration, ethereumSlotDuration } = config;
+    const {
+      aztecEpochDuration: epochDuration,
+      aztecSlotDuration: slotDuration,
+      ethereumSlotDuration,
+      aztecProofSubmissionWindow: proofSubmissionWindow,
+    } = config;
 
     const archiver = new Archiver(
       publicClient,
@@ -163,7 +168,7 @@ export class Archiver extends EventEmitter implements ArchiveSource, Traceable {
       },
       deps.blobSinkClient,
       await ArchiverInstrumentation.new(deps.telemetry, () => archiverStore.estimateSize()),
-      { l1StartBlock, l1GenesisTime, epochDuration, slotDuration, ethereumSlotDuration },
+      { l1StartBlock, l1GenesisTime, epochDuration, slotDuration, ethereumSlotDuration, proofSubmissionWindow },
     );
     await archiver.start(blockUntilSynced);
     return archiver;

--- a/yarn-project/aztec-node/src/sentinel/sentinel.test.ts
+++ b/yarn-project/aztec-node/src/sentinel/sentinel.test.ts
@@ -54,6 +54,7 @@ describe('sentinel', () => {
       slotDuration: 24,
       epochDuration: 32,
       ethereumSlotDuration: 12,
+      proofSubmissionWindow: 64,
     };
 
     epochCache.getEpochAndSlotNow.mockReturnValue({ epoch, slot, ts });

--- a/yarn-project/end-to-end/bootstrap.sh
+++ b/yarn-project/end-to-end/bootstrap.sh
@@ -53,6 +53,7 @@ function test_cmds {
   echo "$prefix simple e2e_deploy_contract/private_initialization"
   echo "$prefix simple e2e_double_spend"
   echo "$prefix simple e2e_epochs/epochs_empty_blocks"
+  echo "$prefix simple e2e_epochs/epochs_long_proving_time"
   echo "$prefix simple e2e_epochs/epochs_multi_proof"
   echo "$prefix simple e2e_epochs/epochs_proof_fails"
   echo "$prefix simple e2e_epochs/epochs_sync_after_reorg"

--- a/yarn-project/end-to-end/src/e2e_epochs/epochs_empty_blocks.test.ts
+++ b/yarn-project/end-to-end/src/e2e_epochs/epochs_empty_blocks.test.ts
@@ -6,12 +6,7 @@ import { ChainMonitor } from '@aztec/ethereum/test';
 import { jest } from '@jest/globals';
 
 import type { EndToEndContext } from '../fixtures/utils.js';
-import {
-  EPOCH_DURATION_IN_L2_SLOTS,
-  EpochsTestContext,
-  L1_BLOCK_TIME_IN_S,
-  WORLD_STATE_BLOCK_HISTORY,
-} from './epochs_test.js';
+import { EpochsTestContext, L1_BLOCK_TIME_IN_S, WORLD_STATE_BLOCK_HISTORY } from './epochs_test.js';
 
 jest.setTimeout(1000 * 60 * 10);
 
@@ -49,7 +44,7 @@ describe('e2e_epochs/epochs_empty_blocks', () => {
 
   it('successfully proves multiple epochs', async () => {
     const targetProvenEpochs = process.env.TARGET_PROVEN_EPOCHS ? parseInt(process.env.TARGET_PROVEN_EPOCHS) : 3;
-    const targetProvenBlockNumber = targetProvenEpochs * EPOCH_DURATION_IN_L2_SLOTS;
+    const targetProvenBlockNumber = targetProvenEpochs * test.epochDuration;
 
     let provenBlockNumber = 0;
     let epochNumber = 0;

--- a/yarn-project/end-to-end/src/e2e_epochs/epochs_long_proving_time.test.ts
+++ b/yarn-project/end-to-end/src/e2e_epochs/epochs_long_proving_time.test.ts
@@ -1,0 +1,59 @@
+import { type Logger, sleep } from '@aztec/aztec.js';
+// eslint-disable-next-line no-restricted-imports
+import { ChainMonitor } from '@aztec/ethereum/test';
+
+import { jest } from '@jest/globals';
+
+import { EpochsTestContext, L1_BLOCK_TIME_IN_S, L2_SLOT_DURATION_IN_L1_SLOTS } from './epochs_test.js';
+
+jest.setTimeout(1000 * 60 * 10);
+
+describe('e2e_epochs/epochs_long_proving_time', () => {
+  let logger: Logger;
+  let monitor: ChainMonitor;
+
+  let test: EpochsTestContext;
+
+  beforeEach(async () => {
+    // Given empty blocks and 2-block epochs, the circuits needed for proving an epoch are:
+    //  1) base parity, 2) root parity, 3) empty block, and 4) epoch root.
+    // So we delay proving of each circuit such that each epoch takes 3 epochs to prove.
+    const aztecEpochDuration = 2;
+    const epochDurationInSeconds = L1_BLOCK_TIME_IN_S * L2_SLOT_DURATION_IN_L1_SLOTS * aztecEpochDuration;
+    const proverTestDelayMs = (epochDurationInSeconds * 1000 * 3) / 4;
+    test = await EpochsTestContext.setup({ aztecEpochDuration, aztecProofSubmissionWindow: 16, proverTestDelayMs });
+    ({ logger, monitor } = test);
+    logger.warn(`Initialized with prover delay set to ${proverTestDelayMs}ms (epoch is ${epochDurationInSeconds}s)`);
+  });
+
+  afterEach(async () => {
+    jest.restoreAllMocks();
+    await test.teardown();
+  });
+
+  it('generates proof over multiple epochs', async () => {
+    const targetProvenEpochs = process.env.TARGET_PROVEN_EPOCHS ? parseInt(process.env.TARGET_PROVEN_EPOCHS) : 1;
+    const targetProvenBlockNumber = targetProvenEpochs * test.epochDuration;
+    logger.info(`Waiting for ${targetProvenEpochs} epochs to be proven at ${targetProvenBlockNumber} L2 blocks`);
+
+    // Wait until we hit the target proven block number, and keep an eye on how many proving jobs are run in parallel.
+    let maxJobCount = 0;
+    while (monitor.l2ProvenBlockNumber === undefined || monitor.l2ProvenBlockNumber < targetProvenBlockNumber) {
+      const jobs = await test.proverNodes[0].getJobs();
+      if (jobs.length > maxJobCount) {
+        maxJobCount = jobs.length;
+        logger.info(`Updated max job count to ${maxJobCount}`, jobs);
+      }
+      await sleep((L1_BLOCK_TIME_IN_S * 1000) / 2);
+    }
+
+    // At least 3 epochs should have passed after the proven one (though we add a -1 just in case)
+    expect(monitor.l2BlockNumber).toBeGreaterThanOrEqual(targetProvenEpochs * test.epochDuration * 3 - 1);
+
+    // We expect maxJobCount to equal 1, since the prover node epoch monitor defines an epoch as ready to be proven
+    // only if the previous one has already been proven. We can relax this check if we want to support multiple epochs
+    // to be proven in parallel, in which case we should update the assertion below.
+    expect(maxJobCount).toEqual(1);
+    logger.info(`Test succeeded`);
+  });
+});

--- a/yarn-project/end-to-end/src/e2e_epochs/epochs_multi_proof.test.ts
+++ b/yarn-project/end-to-end/src/e2e_epochs/epochs_multi_proof.test.ts
@@ -7,7 +7,7 @@ import { type L1RollupConstants, getSlotRangeForEpoch } from '@aztec/stdlib/epoc
 import { jest } from '@jest/globals';
 
 import type { EndToEndContext } from '../fixtures/utils.js';
-import { EPOCH_DURATION_IN_L2_SLOTS, EpochsTestContext, L1_BLOCK_TIME_IN_S } from './epochs_test.js';
+import { EpochsTestContext, L1_BLOCK_TIME_IN_S } from './epochs_test.js';
 
 jest.setTimeout(1000 * 60 * 10);
 
@@ -58,7 +58,7 @@ describe('e2e_epochs/epochs_multi_proof', () => {
     await sleep(L1_BLOCK_TIME_IN_S * 1000);
     const [_firstEpochStartSlot, firstEpochEndSlot] = getSlotRangeForEpoch(0n, constants);
     const firstEpochBlocks = await context.aztecNode
-      .getBlocks(1, EPOCH_DURATION_IN_L2_SLOTS)
+      .getBlocks(1, test.epochDuration)
       .then(blocks => blocks.filter(block => block.header.getSlot() <= firstEpochEndSlot));
     const firstEpochLength = firstEpochBlocks.length;
     const firstEpochLastBlockNum = firstEpochBlocks.at(-1)!.number;

--- a/yarn-project/end-to-end/src/e2e_epochs/epochs_proof_fails.test.ts
+++ b/yarn-project/end-to-end/src/e2e_epochs/epochs_proof_fails.test.ts
@@ -12,12 +12,7 @@ import { jest } from '@jest/globals';
 import type { PublicClient } from 'viem';
 
 import type { EndToEndContext } from '../fixtures/utils.js';
-import {
-  EPOCH_DURATION_IN_L2_SLOTS,
-  EpochsTestContext,
-  L1_BLOCK_TIME_IN_S,
-  L2_SLOT_DURATION_IN_L1_SLOTS,
-} from './epochs_test.js';
+import { EpochsTestContext, L1_BLOCK_TIME_IN_S, L2_SLOT_DURATION_IN_L1_SLOTS } from './epochs_test.js';
 
 jest.setTimeout(1000 * 60 * 10);
 
@@ -60,7 +55,7 @@ describe('e2e_epochs/epochs_proof_fails', () => {
     // Wait until the last block of epoch 1 is published and then hold off the sequencer.
     // Note that the tx below will block the sequencer until it times out
     // the txPropagationMaxQueryAttempts until #10824 is fixed.
-    await test.waitUntilL2BlockNumber(blockNumberAtEndOfEpoch0 + EPOCH_DURATION_IN_L2_SLOTS);
+    await test.waitUntilL2BlockNumber(blockNumberAtEndOfEpoch0 + test.epochDuration);
     sequencerDelayer.pauseNextTxUntilTimestamp(epoch2Start + BigInt(L1_BLOCK_TIME_IN_S));
 
     // Next sequencer to publish a block should trigger a rollback to block 1
@@ -88,9 +83,9 @@ describe('e2e_epochs/epochs_proof_fails', () => {
     jest.spyOn(epochProverManager, 'createEpochProver').mockImplementation(() => {
       const prover = originalCreate();
       jest.spyOn(prover, 'finaliseEpoch').mockImplementation(async () => {
-        const seconds = L1_BLOCK_TIME_IN_S * L2_SLOT_DURATION_IN_L1_SLOTS * EPOCH_DURATION_IN_L2_SLOTS;
+        const seconds = L1_BLOCK_TIME_IN_S * L2_SLOT_DURATION_IN_L1_SLOTS * test.epochDuration;
         logger.warn(`Finalise epoch: sleeping ${seconds}s.`);
-        await sleep(L1_BLOCK_TIME_IN_S * L2_SLOT_DURATION_IN_L1_SLOTS * EPOCH_DURATION_IN_L2_SLOTS * 1000);
+        await sleep(L1_BLOCK_TIME_IN_S * L2_SLOT_DURATION_IN_L1_SLOTS * test.epochDuration * 1000);
         logger.warn(`Finalise epoch: returning.`);
         finaliseEpochPromise.resolve();
         return { publicInputs: RootRollupPublicInputs.random(), proof: Proof.empty() };

--- a/yarn-project/epoch-cache/src/config.ts
+++ b/yarn-project/epoch-cache/src/config.ts
@@ -13,6 +13,7 @@ export type EpochCacheConfig = Pick<
   | 'aztecSlotDuration'
   | 'ethereumSlotDuration'
   | 'aztecEpochDuration'
+  | 'aztecProofSubmissionWindow'
 >;
 
 export function getEpochCacheConfigEnvVars(): EpochCacheConfig {

--- a/yarn-project/epoch-cache/src/epoch_cache.test.ts
+++ b/yarn-project/epoch-cache/src/epoch_cache.test.ts
@@ -1,6 +1,7 @@
 import type { RollupContract } from '@aztec/ethereum';
 import { times } from '@aztec/foundation/collection';
 import { EthAddress } from '@aztec/foundation/eth-address';
+import type { L1RollupConstants } from '@aztec/stdlib/epoch-helpers';
 
 import { afterEach, beforeEach, describe, expect, it, jest } from '@jest/globals';
 import { type MockProxy, mock } from 'jest-mock-extended';
@@ -38,12 +39,13 @@ describe('EpochCache', () => {
     jest.useFakeTimers();
 
     // Initialize with test constants
-    const testConstants = {
+    const testConstants: L1RollupConstants = {
       l1StartBlock: 0n,
       l1GenesisTime,
       slotDuration: SLOT_DURATION,
       ethereumSlotDuration: SLOT_DURATION,
       epochDuration: EPOCH_DURATION,
+      proofSubmissionWindow: EPOCH_DURATION * 2,
     };
 
     epochCache = new EpochCache(rollupContract, 0n, testCommittee, 0n, testConstants);

--- a/yarn-project/epoch-cache/src/epoch_cache.ts
+++ b/yarn-project/epoch-cache/src/epoch_cache.ts
@@ -98,6 +98,7 @@ export class EpochCache implements EpochCacheInterface {
     const l1RollupConstants: L1RollupConstants = {
       l1StartBlock,
       l1GenesisTime,
+      proofSubmissionWindow: config.aztecProofSubmissionWindow,
       slotDuration: config.aztecSlotDuration,
       epochDuration: config.aztecEpochDuration,
       ethereumSlotDuration: config.ethereumSlotDuration,

--- a/yarn-project/prover-node/src/job/epoch-proving-job.ts
+++ b/yarn-project/prover-node/src/job/epoch-proving-job.ts
@@ -65,6 +65,10 @@ export class EpochProvingJob implements Traceable {
     return this.epochNumber;
   }
 
+  public getDeadline(): Date | undefined {
+    return this.deadline;
+  }
+
   /**
    * Proves the given epoch and submits the proof to L1.
    */
@@ -214,7 +218,7 @@ export class EpochProvingJob implements Traceable {
 
   /**
    * Kicks off a running promise that queries the archiver for the set of L2 blocks of the current epoch.
-   * If those changed, stops the proving job with a `rerun` state, so the node re-enqueues it.
+   * If those change, stops the proving job with a `rerun` state, so the node re-enqueues it.
    */
   private async scheduleEpochCheck() {
     const intervalMs = Math.ceil((await this.l2BlockSource.getL1Constants()).ethereumSlotDuration / 2) * 1000;

--- a/yarn-project/prover-node/src/prover-node.test.ts
+++ b/yarn-project/prover-node/src/prover-node.test.ts
@@ -38,6 +38,9 @@ describe('prover-node', () => {
   let epochMonitor: MockProxy<EpochMonitor>;
   let config: ProverNodeOptions;
 
+  // L1 genesis time
+  let l1GenesisTime: number;
+
   // Subject under test
   let proverNode: TestProverNode;
 
@@ -112,8 +115,10 @@ describe('prover-node', () => {
         return Promise.resolve([]);
       }
     });
+
+    l1GenesisTime = Math.floor(Date.now() / 1000) - 3600;
+    l2BlockSource.getL1Constants.mockResolvedValue({ ...EmptyL1RollupConstants, l1GenesisTime: BigInt(l1GenesisTime) });
     l2BlockSource.getBlocksForEpoch.mockResolvedValue(blocks);
-    l2BlockSource.getL1Constants.mockResolvedValue(EmptyL1RollupConstants);
     l2BlockSource.getL2Tips.mockResolvedValue({
       latest: { number: blocks.at(-1)!.number, hash: (await blocks.at(-1)!.hash()).toString() },
       proven: { number: 0, hash: undefined },
@@ -139,6 +144,7 @@ describe('prover-node', () => {
   it('starts a proof on a finished epoch', async () => {
     await proverNode.handleEpochReadyToProve(10n);
     expect(jobs[0].epochNumber).toEqual(10n);
+    expect(jobs[0].job.getDeadline()).toEqual(new Date((l1GenesisTime + 10 + 2) * 1000));
     expect(proverNode.totalJobCount).toEqual(1);
   });
 
@@ -186,7 +192,7 @@ describe('prover-node', () => {
 
     protected override doCreateEpochProvingJob(
       epochNumber: bigint,
-      _deadline: Date | undefined,
+      deadline: Date | undefined,
       _blocks: L2Block[],
       _txs: Tx[],
       _publicProcessorFactory: PublicProcessorFactory,
@@ -196,9 +202,10 @@ describe('prover-node', () => {
       const run = this.nextJobRun;
       this.nextJobRun = () => Promise.resolve();
       const job = mock<EpochProvingJob>({
-        getState: () => state,
         run,
+        getState: () => state,
         getEpochNumber: () => epochNumber,
+        getDeadline: () => deadline,
       });
       job.getId.mockReturnValue(jobs.length.toString());
       jobs.push({ epochNumber, job });

--- a/yarn-project/prover-node/src/prover-node.ts
+++ b/yarn-project/prover-node/src/prover-node.ts
@@ -8,7 +8,7 @@ import type { P2P } from '@aztec/p2p';
 import { PublicProcessorFactory } from '@aztec/simulator/server';
 import type { L2Block, L2BlockSource } from '@aztec/stdlib/block';
 import type { ContractDataSource } from '@aztec/stdlib/contract';
-import { getTimestampRangeForEpoch } from '@aztec/stdlib/epoch-helpers';
+import { getProofSubmissionDeadlineTimestamp } from '@aztec/stdlib/epoch-helpers';
 import {
   type EpochProverManager,
   EpochProvingJobTerminalState,
@@ -256,9 +256,8 @@ export class ProverNode implements EpochMonitorHandler, ProverNodeApi, Traceable
       this.telemetryClient,
     );
 
-    const [_, endTimestamp] = getTimestampRangeForEpoch(epochNumber + 1n, await this.getL1Constants());
-    const deadline = new Date(Number(endTimestamp) * 1000);
-
+    const deadlineTs = getProofSubmissionDeadlineTimestamp(epochNumber, await this.getL1Constants());
+    const deadline = new Date(Number(deadlineTs) * 1000);
     const job = this.doCreateEpochProvingJob(epochNumber, deadline, blocks, txs, publicProcessorFactory);
     this.jobs.set(job.getId(), job);
     return job;

--- a/yarn-project/sequencer-client/src/client/sequencer-client.ts
+++ b/yarn-project/sequencer-client/src/client/sequencer-client.ts
@@ -119,6 +119,7 @@ export class SequencerClient {
           aztecSlotDuration: config.aztecSlotDuration,
           ethereumSlotDuration: config.ethereumSlotDuration,
           aztecEpochDuration: config.aztecEpochDuration,
+          aztecProofSubmissionWindow: config.aztecProofSubmissionWindow,
         },
         { dateProvider: deps.dateProvider },
       ));

--- a/yarn-project/sequencer-client/src/config.ts
+++ b/yarn-project/sequencer-client/src/config.ts
@@ -37,7 +37,10 @@ export type SequencerClientConfig = PublisherConfig &
   L1ReaderConfig &
   ChainConfig &
   Pick<P2PConfig, 'txPublicSetupAllowList'> &
-  Pick<L1ContractsConfig, 'ethereumSlotDuration' | 'aztecSlotDuration' | 'aztecEpochDuration'>;
+  Pick<
+    L1ContractsConfig,
+    'ethereumSlotDuration' | 'aztecSlotDuration' | 'aztecEpochDuration' | 'aztecProofSubmissionWindow'
+  >;
 
 export const sequencerConfigMappings: ConfigMappingsType<SequencerConfig> = {
   transactionPollingIntervalMS: {
@@ -115,7 +118,12 @@ export const sequencerClientConfigMappings: ConfigMappingsType<SequencerClientCo
   ...getTxSenderConfigMappings('SEQ'),
   ...getPublisherConfigMappings('SEQ'),
   ...chainConfigMappings,
-  ...pickConfigMappings(l1ContractsConfigMappings, ['ethereumSlotDuration', 'aztecSlotDuration', 'aztecEpochDuration']),
+  ...pickConfigMappings(l1ContractsConfigMappings, [
+    'ethereumSlotDuration',
+    'aztecSlotDuration',
+    'aztecEpochDuration',
+    'aztecProofSubmissionWindow',
+  ]),
 };
 
 /**

--- a/yarn-project/stdlib/src/epoch-helpers/index.test.ts
+++ b/yarn-project/stdlib/src/epoch-helpers/index.test.ts
@@ -1,4 +1,4 @@
-import { type L1RollupConstants, getTimestampRangeForEpoch } from './index.js';
+import { type L1RollupConstants, getProofSubmissionDeadlineTimestamp, getTimestampRangeForEpoch } from './index.js';
 
 describe('EpochHelpers', () => {
   let constants: Omit<L1RollupConstants, 'l1StartBlock'>;
@@ -10,6 +10,7 @@ describe('EpochHelpers', () => {
       epochDuration: 4,
       slotDuration: 24,
       ethereumSlotDuration: 12,
+      proofSubmissionWindow: 8,
     };
   });
 
@@ -23,5 +24,10 @@ describe('EpochHelpers', () => {
     const [start, end] = getTimestampRangeForEpoch(1n, constants);
     expect(start).toEqual(l1GenesisTime + BigInt(24 * 4));
     expect(end).toEqual(l1GenesisTime + BigInt(24 * 4) + BigInt(24 * 3 + 12));
+  });
+
+  it('returns proof submission deadline', () => {
+    const deadline = getProofSubmissionDeadlineTimestamp(3n, constants);
+    expect(deadline).toEqual(l1GenesisTime + BigInt(24 * 4 * 3) + BigInt(24 * 8));
   });
 });


### PR DESCRIPTION
Prover node would abort operations at the end of the following epoch, rather than honoring the proof submission window config.

Fixes #13320
