### PR TITLE
fix: port_change test + testbench

### DIFF
--- a/yarn-project/bootstrap.sh
+++ b/yarn-project/bootstrap.sh
@@ -104,7 +104,7 @@ function test_cmds {
   for test in {prover-node,p2p,ethereum,aztec}/src/**/*.test.ts; do
     if [[ "$test" =~ testbench ]]; then
       # Testbench runs require more memory and CPU.
-      echo "$hash ISOLATE=1 CPUS=20 MEM=16g yarn-project/scripts/run_test.sh $test"
+      echo "$hash ISOLATE=1 CPUS=10 MEM=10g yarn-project/scripts/run_test.sh $test"
     elif [[ "$test" == p2p/src/client/p2p_client.test.ts || "$test" == p2p/src/services/discv5/discv5_service.test.ts ]]; then
       # Add debug logging for tests that require a bit more info
       echo "$hash ISOLATE=1 LOG_LEVEL=debug yarn-project/scripts/run_test.sh $test"

--- a/yarn-project/p2p/src/services/discv5/discV5_service.ts
+++ b/yarn-project/p2p/src/services/discv5/discV5_service.ts
@@ -140,7 +140,9 @@ export class DiscV5Service extends EventEmitter implements PeerDiscoveryService 
       // Do this conversion once since it involves an async function call
       this.bootstrapNodePeerIds = await Promise.all(this.bootstrapNodeEnrs.map(enr => enr.peerId()));
       this.logger.info(
-        `Adding ${this.bootstrapNodeEnrs.length} bootstrap nodes ENRs: ${this.bootstrapNodeEnrs.join(', ')}`,
+        `Adding ${this.bootstrapNodeEnrs.length} bootstrap nodes ENRs: ${this.bootstrapNodeEnrs
+          .map(enr => enr.encodeTxt())
+          .join(', ')}`,
       );
       for (const enr of this.bootstrapNodeEnrs) {
         try {
@@ -196,16 +198,6 @@ export class DiscV5Service extends EventEmitter implements PeerDiscoveryService 
 
   public isBootstrapPeer(peerId: PeerId): boolean {
     return this.bootstrapNodePeerIds.some(node => node.equals(peerId));
-  }
-
-  public async removeBootstrapPeer(peerId: PeerId): Promise<void> {
-    this.bootstrapNodePeerIds = this.bootstrapNodePeerIds.filter(node => !node.equals(peerId));
-    this.bootstrapNodeEnrs = await Promise.all(
-      this.bootstrapNodeEnrs.filter(async enr => {
-        const peerIdFromEnr = await enr.peerId();
-        return peerIdFromEnr.toString() !== peerId.toString();
-      }),
-    );
   }
 
   public async stop(): Promise<void> {

--- a/yarn-project/p2p/src/services/discv5/discV5_service.ts
+++ b/yarn-project/p2p/src/services/discv5/discV5_service.ts
@@ -117,7 +117,7 @@ export class DiscV5Service extends EventEmitter implements PeerDiscoveryService 
     // We want to update our tcp port to match the udp port
     const multiAddrTcp = multiaddr(convertToMultiaddr(m.nodeAddress().address, this.config.p2pPort, 'tcp'));
     this.enr.setLocationMultiaddr(multiAddrTcp);
-    this.logger.info('Multiaddr updated', { multiaddr: multiaddr.toString() });
+    this.logger.info('Multiaddr updated', { multiaddr: multiAddrTcp.toString() });
   }
 
   public async start(): Promise<void> {

--- a/yarn-project/p2p/src/services/discv5/discV5_service.ts
+++ b/yarn-project/p2p/src/services/discv5/discV5_service.ts
@@ -32,9 +32,8 @@ export class DiscV5Service extends EventEmitter implements PeerDiscoveryService 
 
   private currentState = PeerDiscoveryState.STOPPED;
 
-  public readonly bootstrapNodes: string[] = [];
   private bootstrapNodePeerIds: PeerId[] = [];
-  private bootstrapNodeEnrs: ENR[] = [];
+  public bootstrapNodeEnrs: ENR[] = [];
 
   private startTime = 0;
 
@@ -53,8 +52,7 @@ export class DiscV5Service extends EventEmitter implements PeerDiscoveryService 
   ) {
     super();
     const { p2pIp, p2pPort, bootstrapNodes } = config;
-    this.bootstrapNodes = bootstrapNodes ?? [];
-    this.bootstrapNodeEnrs = this.bootstrapNodes.map(x => ENR.decodeTxt(x));
+    this.bootstrapNodeEnrs = bootstrapNodes.map(x => ENR.decodeTxt(x));
     // create ENR from PeerId
     this.enr = SignableENR.createFromPeerId(peerId);
     // Add aztec identification to ENR
@@ -138,10 +136,12 @@ export class DiscV5Service extends EventEmitter implements PeerDiscoveryService 
     this.currentState = PeerDiscoveryState.RUNNING;
 
     // Add bootnode ENR if provided
-    if (this.bootstrapNodes?.length) {
+    if (this.bootstrapNodeEnrs?.length) {
       // Do this conversion once since it involves an async function call
       this.bootstrapNodePeerIds = await Promise.all(this.bootstrapNodeEnrs.map(enr => enr.peerId()));
-      this.logger.info(`Adding ${this.bootstrapNodes} bootstrap nodes ENRs: ${this.bootstrapNodes.join(', ')}`);
+      this.logger.info(
+        `Adding ${this.bootstrapNodeEnrs.length} bootstrap nodes ENRs: ${this.bootstrapNodeEnrs.join(', ')}`,
+      );
       for (const enr of this.bootstrapNodeEnrs) {
         try {
           if (this.config.bootstrapNodeEnrVersionCheck) {
@@ -196,6 +196,16 @@ export class DiscV5Service extends EventEmitter implements PeerDiscoveryService 
 
   public isBootstrapPeer(peerId: PeerId): boolean {
     return this.bootstrapNodePeerIds.some(node => node.equals(peerId));
+  }
+
+  public async removeBootstrapPeer(peerId: PeerId): Promise<void> {
+    this.bootstrapNodePeerIds = this.bootstrapNodePeerIds.filter(node => !node.equals(peerId));
+    this.bootstrapNodeEnrs = await Promise.all(
+      this.bootstrapNodeEnrs.filter(async enr => {
+        const peerIdFromEnr = await enr.peerId();
+        return peerIdFromEnr.toString() !== peerId.toString();
+      }),
+    );
   }
 
   public async stop(): Promise<void> {

--- a/yarn-project/p2p/src/services/discv5/discv5_service.test.ts
+++ b/yarn-project/p2p/src/services/discv5/discv5_service.test.ts
@@ -15,7 +15,7 @@ import { type BootnodeConfig, type P2PConfig, getP2PDefaultConfig } from '../../
 import { PeerDiscoveryState } from '../service.js';
 import { DiscV5Service } from './discV5_service.js';
 
-const waitForPeers = (node: DiscV5Service, expectedCount: number, timeout = 7_000): Promise<void> => {
+const waitForPeers = (node: DiscV5Service, expectedCount: number, timeout = 15_000): Promise<void> => {
   return new Promise((resolve, reject) => {
     const timeoutId = setTimeout(() => {
       reject(new Error(`Timeout: Failed to connect to ${expectedCount} peers within ${timeout} ms`));
@@ -135,7 +135,7 @@ describe('Discv5Service', () => {
     }
 
     expect(node.getEnr().ip).toEqual(undefined);
-    await Promise.any([
+    await Promise.allSettled([
       waitForPeers(node, extraNodes),
       (async () => {
         await sleep(2000); // wait for peer discovery to be able to start

--- a/yarn-project/p2p/src/services/discv5/discv5_service.test.ts
+++ b/yarn-project/p2p/src/services/discv5/discv5_service.test.ts
@@ -135,7 +135,7 @@ describe('Discv5Service', () => {
     }
 
     expect(node.getEnr().ip).toEqual(undefined);
-    await Promise.all([
+    await Promise.any([
       waitForPeers(node, extraNodes),
       (async () => {
         await sleep(2000); // wait for peer discovery to be able to start

--- a/yarn-project/p2p/src/services/dummy_service.ts
+++ b/yarn-project/p2p/src/services/dummy_service.ts
@@ -2,6 +2,7 @@ import type { PeerInfo } from '@aztec/stdlib/interfaces/server';
 import type { BlockAttestation, BlockProposal, Gossipable } from '@aztec/stdlib/p2p';
 import { TxHash } from '@aztec/stdlib/tx';
 
+import type { ENR } from '@chainsafe/enr';
 import type { PeerId } from '@libp2p/interface';
 import EventEmitter from 'events';
 
@@ -90,7 +91,7 @@ export class DummyP2PService implements P2PService {
  */
 export class DummyPeerDiscoveryService extends EventEmitter implements PeerDiscoveryService {
   private currentState = PeerDiscoveryState.STOPPED;
-  public bootstrapNodes: string[] = [];
+  public bootstrapNodeEnrs: ENR[] = [];
 
   /**
    * Starts the dummy implementation.
@@ -122,6 +123,10 @@ export class DummyPeerDiscoveryService extends EventEmitter implements PeerDisco
 
   public isBootstrapPeer(_: PeerId): boolean {
     return false;
+  }
+
+  public removeBootstrapPeer(_: PeerId): Promise<void> {
+    return Promise.resolve();
   }
 
   public getStatus(): PeerDiscoveryState {

--- a/yarn-project/p2p/src/services/dummy_service.ts
+++ b/yarn-project/p2p/src/services/dummy_service.ts
@@ -125,10 +125,6 @@ export class DummyPeerDiscoveryService extends EventEmitter implements PeerDisco
     return false;
   }
 
-  public removeBootstrapPeer(_: PeerId): Promise<void> {
-    return Promise.resolve();
-  }
-
   public getStatus(): PeerDiscoveryState {
     return this.currentState;
   }

--- a/yarn-project/p2p/src/services/libp2p/libp2p_service.ts
+++ b/yarn-project/p2p/src/services/libp2p/libp2p_service.ts
@@ -187,7 +187,7 @@ export class LibP2PService<T extends P2PClientType = P2PClientType.Full> extends
 
     const otelMetricsAdapter = new OtelMetricsAdapter(telemetry);
 
-    const bootstrapNodes = peerDiscoveryService.bootstrapNodes;
+    const bootstrapNodes = peerDiscoveryService.bootstrapNodeEnrs.map(enr => enr.encodeTxt());
 
     // If trusted peers are provided, also provide them to the p2p service
     bootstrapNodes.push(...config.trustedPeers);

--- a/yarn-project/p2p/src/services/libp2p/libp2p_service.ts
+++ b/yarn-project/p2p/src/services/libp2p/libp2p_service.ts
@@ -86,7 +86,7 @@ type ValidationOutcome = { allPassed: true } | { allPassed: false; failure: Vali
 /**
  * Lib P2P implementation of the P2PService interface.
  */
-export class LibP2PService<T extends P2PClientType> extends WithTracer implements P2PService {
+export class LibP2PService<T extends P2PClientType = P2PClientType.Full> extends WithTracer implements P2PService {
   private jobQueue: SerialQueue = new SerialQueue();
   private peerManager: PeerManager;
   private discoveryRunningPromise?: RunningPromise;
@@ -115,15 +115,15 @@ export class LibP2PService<T extends P2PClientType> extends WithTracer implement
   constructor(
     private clientType: T,
     private config: P2PConfig,
-    private node: PubSubLibp2p,
+    protected node: PubSubLibp2p,
     private peerDiscoveryService: PeerDiscoveryService,
-    private mempools: MemPools<T>,
+    protected mempools: MemPools<T>,
     private archiver: L2BlockSource & ContractDataSource,
     epochCache: EpochCacheInterface,
     private proofVerifier: ClientProtocolCircuitVerifier,
     private worldStateSynchronizer: WorldStateSynchronizer,
     telemetry: TelemetryClient,
-    private logger = createLogger('p2p:libp2p_service'),
+    protected logger = createLogger('p2p:libp2p_service'),
   ) {
     super(telemetry, 'LibP2PService');
 
@@ -482,7 +482,7 @@ export class LibP2PService<T extends P2PClientType> extends WithTracer implement
    * @param topic - The message's topic.
    * @param data - The message data
    */
-  private async handleNewGossipMessage(msg: Message, msgId: string, source: PeerId) {
+  protected async handleNewGossipMessage(msg: Message, msgId: string, source: PeerId) {
     if (msg.topic === Tx.p2pTopic) {
       await this.handleGossipedTx(msg, msgId, source);
     }
@@ -496,7 +496,7 @@ export class LibP2PService<T extends P2PClientType> extends WithTracer implement
     return;
   }
 
-  private async validateReceivedMessage<T>(
+  protected async validateReceivedMessage<T>(
     validationFunc: () => Promise<{ result: boolean; obj: T }>,
     msgId: string,
     source: PeerId,
@@ -516,7 +516,7 @@ export class LibP2PService<T extends P2PClientType> extends WithTracer implement
     return resultAndObj;
   }
 
-  private async handleGossipedTx(msg: Message, msgId: string, source: PeerId) {
+  protected async handleGossipedTx(msg: Message, msgId: string, source: PeerId) {
     const validationFunc = async () => {
       const tx = Tx.fromBuffer(Buffer.from(msg.data));
       const result = await this.validatePropagatedTx(tx, source);

--- a/yarn-project/p2p/src/services/peer-manager/peer_manager.ts
+++ b/yarn-project/p2p/src/services/peer-manager/peer_manager.ts
@@ -49,7 +49,7 @@ export class PeerManager {
     handleConnectedPeerEvent: (e: CustomEvent<PeerId>) => void;
     handleDisconnectedPeerEvent: (e: CustomEvent<PeerId>) => void;
     handleDiscoveredPeer: (enr: ENR) => Promise<void>;
-  } = {} as any;
+  };
 
   constructor(
     private libP2PNode: PubSubLibp2p,
@@ -65,7 +65,11 @@ export class PeerManager {
     // Handle Discovered peers
     this.handlers = {
       handleConnectedPeerEvent: this.handleConnectedPeerEvent.bind(this),
-      handleDisconnectedPeerEvent: this.handleDisconnectedPeerEvent.bind(this),
+      handleDisconnectedPeerEvent: (event: CustomEvent<PeerId>) => {
+        void this.handleDisconnectedPeerEvent(event).catch(e =>
+          this.logger.error('Error handling disconnected peer', e),
+        );
+      },
       handleDiscoveredPeer: (enr: ENR) =>
         this.handleDiscoveredPeer(enr).catch(e => this.logger.error('Error handling discovered peer', e)),
     };
@@ -145,10 +149,11 @@ export class PeerManager {
    * Simply logs the type of disconnected peer.
    * @param e - The disconnected peer event.
    */
-  private handleDisconnectedPeerEvent(e: CustomEvent<PeerId>) {
+  private async handleDisconnectedPeerEvent(e: CustomEvent<PeerId>) {
     const peerId = e.detail;
     if (this.peerDiscoveryService.isBootstrapPeer(peerId)) {
       this.logger.verbose(`Disconnected from bootstrap peer ${peerId.toString()}`);
+      await this.peerDiscoveryService.removeBootstrapPeer(peerId);
     } else {
       this.logger.verbose(`Disconnected from transaction peer ${peerId.toString()}`);
     }

--- a/yarn-project/p2p/src/services/peer-manager/peer_manager.ts
+++ b/yarn-project/p2p/src/services/peer-manager/peer_manager.ts
@@ -65,13 +65,8 @@ export class PeerManager {
     // Handle Discovered peers
     this.handlers = {
       handleConnectedPeerEvent: this.handleConnectedPeerEvent.bind(this),
-      handleDisconnectedPeerEvent: (event: CustomEvent<PeerId>) => {
-        void this.handleDisconnectedPeerEvent(event).catch(e =>
-          this.logger.error('Error handling disconnected peer', e),
-        );
-      },
-      handleDiscoveredPeer: (enr: ENR) =>
-        this.handleDiscoveredPeer(enr).catch(e => this.logger.error('Error handling discovered peer', e)),
+      handleDisconnectedPeerEvent: this.handleDisconnectedPeerEvent.bind(this),
+      handleDiscoveredPeer: this.handleDiscoveredPeer.bind(this),
     };
 
     // Handle new established connections
@@ -149,11 +144,10 @@ export class PeerManager {
    * Simply logs the type of disconnected peer.
    * @param e - The disconnected peer event.
    */
-  private async handleDisconnectedPeerEvent(e: CustomEvent<PeerId>) {
+  private handleDisconnectedPeerEvent(e: CustomEvent<PeerId>) {
     const peerId = e.detail;
     if (this.peerDiscoveryService.isBootstrapPeer(peerId)) {
       this.logger.verbose(`Disconnected from bootstrap peer ${peerId.toString()}`);
-      await this.peerDiscoveryService.removeBootstrapPeer(peerId);
     } else {
       this.logger.verbose(`Disconnected from transaction peer ${peerId.toString()}`);
     }

--- a/yarn-project/p2p/src/services/peer-manager/peer_manager.ts
+++ b/yarn-project/p2p/src/services/peer-manager/peer_manager.ts
@@ -66,7 +66,8 @@ export class PeerManager {
     this.handlers = {
       handleConnectedPeerEvent: this.handleConnectedPeerEvent.bind(this),
       handleDisconnectedPeerEvent: this.handleDisconnectedPeerEvent.bind(this),
-      handleDiscoveredPeer: this.handleDiscoveredPeer.bind(this),
+      handleDiscoveredPeer: (enr: ENR) =>
+        this.handleDiscoveredPeer(enr).catch(e => this.logger.error('Error handling discovered peer', e)),
     };
 
     // Handle new established connections

--- a/yarn-project/p2p/src/services/service.ts
+++ b/yarn-project/p2p/src/services/service.ts
@@ -98,13 +98,6 @@ export interface PeerDiscoveryService extends EventEmitter {
    */
   isBootstrapPeer(peerId: PeerId): boolean;
 
-  // TODO: could be removed by listening for the event within the discovery service??
-  /**
-   * Removes a bootstrap peer.
-   * @param peerId - The peer ID to remove.
-   */
-  removeBootstrapPeer(peerId: PeerId): Promise<void>;
-
   /**
    * Event emitted when a new peer is discovered.
    */

--- a/yarn-project/p2p/src/services/service.ts
+++ b/yarn-project/p2p/src/services/service.ts
@@ -98,6 +98,13 @@ export interface PeerDiscoveryService extends EventEmitter {
    */
   isBootstrapPeer(peerId: PeerId): boolean;
 
+  // TODO: could be removed by listening for the event within the discovery service??
+  /**
+   * Removes a bootstrap peer.
+   * @param peerId - The peer ID to remove.
+   */
+  removeBootstrapPeer(peerId: PeerId): Promise<void>;
+
   /**
    * Event emitted when a new peer is discovered.
    */
@@ -108,5 +115,5 @@ export interface PeerDiscoveryService extends EventEmitter {
 
   getEnr(): ENR | undefined;
 
-  bootstrapNodes: string[];
+  bootstrapNodeEnrs: ENR[];
 }

--- a/yarn-project/p2p/src/testbench/p2p_client_testbench_worker.ts
+++ b/yarn-project/p2p/src/testbench/p2p_client_testbench_worker.ts
@@ -10,17 +10,25 @@ import { createLogger } from '@aztec/foundation/log';
 import { sleep } from '@aztec/foundation/sleep';
 import type { DataStoreConfig } from '@aztec/kv-store/config';
 import { openTmpStore } from '@aztec/kv-store/lmdb-v2';
-import type { WorldStateSynchronizer } from '@aztec/stdlib/interfaces/server';
+import type { L2BlockSource } from '@aztec/stdlib/block';
+import type { ContractDataSource } from '@aztec/stdlib/contract';
+import type { ClientProtocolCircuitVerifier, WorldStateSynchronizer } from '@aztec/stdlib/interfaces/server';
 import { P2PClientType } from '@aztec/stdlib/p2p';
 import { Tx, TxStatus } from '@aztec/stdlib/tx';
+import { type TelemetryClient, getTelemetryClient } from '@aztec/telemetry-client';
 
-import { type Message, type PeerId, TopicValidatorResult } from '@libp2p/interface';
+import type { Message, PeerId } from '@libp2p/interface';
+import { TopicValidatorResult } from '@libp2p/interface';
 
 import type { P2PConfig } from '../config.js';
 import { createP2PClient } from '../index.js';
 import type { AttestationPool } from '../mem_pools/attestation_pool/attestation_pool.js';
+import type { MemPools } from '../mem_pools/interface.js';
 import type { TxPool } from '../mem_pools/tx_pool/index.js';
+import { LibP2PService } from '../services/libp2p/libp2p_service.js';
+import type { PeerDiscoveryService } from '../services/service.js';
 import { AlwaysTrueCircuitVerifier } from '../test-helpers/reqresp-nodes.js';
+import type { PubSubLibp2p } from '../util.js';
 
 // Simple mock implementation
 function mockTxPool(): TxPool {
@@ -69,6 +77,72 @@ function mockEpochCache(): EpochCacheInterface {
   };
 }
 
+class TestLibP2PService<T extends P2PClientType = P2PClientType.Full> extends LibP2PService<T> {
+  private disableTxValidation: boolean;
+  private gossipMessageCount: number = 0;
+
+  constructor(
+    clientType: T,
+    config: P2PConfig,
+    node: PubSubLibp2p,
+    peerDiscoveryService: PeerDiscoveryService,
+    mempools: MemPools<T>,
+    archiver: L2BlockSource & ContractDataSource,
+    epochCache: EpochCacheInterface,
+    proofVerifier: ClientProtocolCircuitVerifier,
+    worldStateSynchronizer: WorldStateSynchronizer,
+    telemetry: TelemetryClient,
+    logger = createLogger('p2p:test:libp2p_service'),
+    disableTxValidation = true,
+  ) {
+    super(
+      clientType,
+      config,
+      node,
+      peerDiscoveryService,
+      mempools,
+      archiver,
+      epochCache,
+      proofVerifier,
+      worldStateSynchronizer,
+      telemetry,
+      logger,
+    );
+    this.disableTxValidation = disableTxValidation;
+  }
+
+  public getGossipMessageCount(): number {
+    return this.gossipMessageCount;
+  }
+
+  public setDisableTxValidation(disable: boolean): void {
+    this.disableTxValidation = disable;
+  }
+
+  protected override async handleGossipedTx(msg: Message, msgId: string, source: PeerId) {
+    if (this.disableTxValidation) {
+      const tx = Tx.fromBuffer(Buffer.from(msg.data));
+      this.node.services.pubsub.reportMessageValidationResult(msgId, source.toString(), TopicValidatorResult.Accept);
+
+      const txHash = await tx.getTxHash();
+      const txHashString = txHash.toString();
+      this.logger.verbose(`Received tx ${txHashString} from external peer ${source.toString()}.`);
+      await this.mempools.txPool.addTxs([tx]);
+    } else {
+      await super.handleGossipedTx(msg, msgId, source);
+    }
+  }
+
+  protected override async handleNewGossipMessage(msg: Message, msgId: string, source: PeerId) {
+    this.gossipMessageCount++;
+    process.send!({
+      type: 'GOSSIP_RECEIVED',
+      count: this.gossipMessageCount,
+    });
+    await super.handleNewGossipMessage(msg, msgId, source);
+  }
+}
+
 // eslint-disable-next-line @typescript-eslint/no-misused-promises
 process.on('message', async msg => {
   const { type, config, clientIndex } = msg as { type: string; config: P2PConfig; clientIndex: number };
@@ -84,6 +158,7 @@ process.on('message', async msg => {
       const proofVerifier = new AlwaysTrueCircuitVerifier();
       const kvStore = await openTmpStore(`test-${clientIndex}`);
       const logger = createLogger(`p2p:${clientIndex}`);
+      const telemetry = getTelemetryClient();
 
       const deps = {
         txPool,
@@ -99,39 +174,30 @@ process.on('message', async msg => {
         proofVerifier,
         worldState,
         epochCache,
-        undefined,
+        telemetry,
         deps,
       );
 
-      // We disable message validation in the testbench
-      // In our case we only deal with txs
-      (client as any).p2pService.handleGossipedTx = async (msg: Message, msgId: string, source: PeerId) => {
-        const tx = Tx.fromBuffer(Buffer.from(msg.data));
-        (client as any).p2pService.node.services.pubsub.reportMessageValidationResult(
-          msgId,
-          source.toString(),
-          TopicValidatorResult.Accept,
-        );
+      const _client = client as any;
 
-        const txHash = await tx.getTxHash();
-        const txHashString = txHash.toString();
-        logger.verbose(`Received tx ${txHashString} from external peer ${source.toString()}.`);
-        await txPool.addTxs([tx]);
-      };
+      // Create test service with validation disabled
+      const testService = new TestLibP2PService(
+        P2PClientType.Full,
+        config,
+        (client as any).p2pService.node,
+        (client as any).p2pService.peerDiscoveryService,
+        (client as any).p2pService.mempools,
+        (client as any).p2pService.archiver,
+        epochCache,
+        proofVerifier,
+        worldState,
+        telemetry,
+        logger,
+        true, // disable validation
+      );
 
-      // Create spy for gossip messages
-      let gossipMessageCount = 0;
-      (client as any).p2pService.handleNewGossipMessage = (msg: Message, msgId: string, source: PeerId) => {
-        gossipMessageCount++;
-        process.send!({
-          type: 'GOSSIP_RECEIVED',
-          count: gossipMessageCount,
-        });
-        return (client as any).p2pService.constructor.prototype.handleNewGossipMessage.apply(
-          (client as any).p2pService,
-          [msg, msgId, source],
-        );
-      };
+      // Replace the existing p2pService with our test version
+      (client as any).p2pService = testService;
 
       await client.start();
       // Wait until the client is ready

--- a/yarn-project/p2p/src/testbench/parse_log_file.ts
+++ b/yarn-project/p2p/src/testbench/parse_log_file.ts
@@ -37,7 +37,7 @@ function getTimestamp(line: string): number | null {
 }
 
 /**
- * Parses a single log line. If the line contains an "rpc.from" event,
+ * Parses a single log line. If the line contains an "Received tx" event,
  * it extracts the timestamp and the peer ID.
  */
 function parseReceivedTx(line: string): LogEvent | null {
@@ -52,9 +52,9 @@ function parseReceivedTx(line: string): LogEvent | null {
     return null;
   }
 
-  // TODO: this is not correct - it is just the tx hash for now
-  // Extract the peer ID after "Received tx"
-  const peerIdMatch = line.match(/p2p:(\d+):/);
+  // Extract the peer ID from the log line
+  // Example format: "module":"p2p:1","msg":"Received tx 0x0feeafa65f25fd8d613fe4aca44fd65fe41c149ef1941e2019d40925c40748f9 from external peer 16Uiu2HAm8w4oxXF3TwDKoGL9U66thMXWqCgPnb2CgkYwmUqFCWbC."
+  const peerIdMatch = line.match(/"module":"p2p:(\d+)"/);
   if (!peerIdMatch) {
     logger.error('No peer Number found in received tx log');
     return null;

--- a/yarn-project/p2p/src/testbench/port_change.test.ts
+++ b/yarn-project/p2p/src/testbench/port_change.test.ts
@@ -3,7 +3,7 @@ import { sleep } from '@aztec/foundation/sleep';
 import { ClientIvcProof } from '@aztec/stdlib/proofs';
 import { mockTx } from '@aztec/stdlib/testing';
 
-import { assert } from 'console';
+import assert from 'assert';
 import getPort from 'get-port';
 import path from 'path';
 import { fileURLToPath } from 'url';

--- a/yarn-project/p2p/src/testbench/port_change.test.ts
+++ b/yarn-project/p2p/src/testbench/port_change.test.ts
@@ -16,7 +16,7 @@ const NODES_TO_CHANGE_PORT = 5;
 const __dirname = path.dirname(fileURLToPath(import.meta.url));
 
 // Test Summary:
-// - Start 20 clients
+// - Start 5 clients
 // - For NUMBER_OF_ITERATIONS iterations:
 //    - Send a tx from a random client
 //    - Allow for it to propagate to all other clients
@@ -26,8 +26,8 @@ describe('Port Change', () => {
   it(
     'should change port and propagate the gossip message correctly',
     async () => {
-      // Use 20 node configuration for this test
-      const configPath = path.join(__dirname, '../../testbench/configurations', 'normal-degree-20-nodes.json');
+      // Use 5 node configuration for this test
+      const configPath = path.join(__dirname, '../../testbench/configurations', 'normal-degree-5-nodes.json');
       const config = await import(configPath, { assert: { type: 'json' } });
       const testConfig = { ...testChainConfig, ...config.default };
       const numberOfClients = config.default.numberOfClients;

--- a/yarn-project/p2p/src/testbench/port_change.test.ts
+++ b/yarn-project/p2p/src/testbench/port_change.test.ts
@@ -1,4 +1,4 @@
-import { createLogger } from '@aztec/foundation/log';
+import { type Logger, createLogger } from '@aztec/foundation/log';
 import { sleep } from '@aztec/foundation/sleep';
 import { ClientIvcProof } from '@aztec/stdlib/proofs';
 import { mockTx } from '@aztec/stdlib/testing';
@@ -8,11 +8,11 @@ import getPort from 'get-port';
 import path from 'path';
 import { fileURLToPath } from 'url';
 
+import type { P2PConfig } from '../config.js';
 import { WorkerClientManager, testChainConfig } from './worker_client_manager.js';
 
-const logger = createLogger('testbench-ports');
 const NUMBER_OF_ITERATIONS = 2;
-const NODES_TO_CHANGE_PORT = 5;
+const NODES_TO_CHANGE_PORT = 1;
 const __dirname = path.dirname(fileURLToPath(import.meta.url));
 
 // Test Summary:
@@ -23,23 +23,37 @@ const __dirname = path.dirname(fileURLToPath(import.meta.url));
 //    - change the port for NODES_TO_CHANGE_PORT random clients
 //    - Wait for two peer manager heartbeats
 describe('Port Change', () => {
+  let workerClientManager: WorkerClientManager;
+  let numberOfClients: number;
+  let testConfig: Partial<P2PConfig>;
+  const logger = createLogger('testbench-ports');
+
+  beforeEach(async () => {
+    logger.info('Starting test setup');
+    // Use 5 node configuration for this test
+    const configPath = path.join(__dirname, '../../testbench/configurations', 'normal-degree-5-nodes.json');
+    logger.info(`Loading config from ${configPath}`);
+    const config = await import(configPath, { assert: { type: 'json' } });
+    testConfig = {
+      ...testChainConfig,
+      ...config.default,
+      boostrapNodeEnrVersionCheck: false,
+      bootstrapNodesAsFullPeers: true,
+    };
+    numberOfClients = config.default.numberOfClients;
+    logger.info(`Creating ${numberOfClients} clients`);
+
+    workerClientManager = new WorkerClientManager(logger, testConfig);
+    await workerClientManager.makeWorkerClients(numberOfClients);
+
+    // wait a bit longer for all peers to be ready
+    await sleep(10000);
+    logger.info('Workers Ready');
+  });
+
   it(
     'should change port and propagate the gossip message correctly',
     async () => {
-      // Use 5 node configuration for this test
-      const configPath = path.join(__dirname, '../../testbench/configurations', 'normal-degree-5-nodes.json');
-      const config = await import(configPath, { assert: { type: 'json' } });
-      const testConfig = { ...testChainConfig, ...config.default };
-      const numberOfClients = config.default.numberOfClients;
-
-      // Setup clients in separate processes
-      const workerClientManager = new WorkerClientManager(logger, testConfig);
-      await workerClientManager.makeWorkerClients(numberOfClients);
-
-      // wait a bit longer for all peers to be ready
-      await sleep(10000);
-      logger.info('Workers Ready');
-
       // Run test multiple times for each client
       for (let i = 0; i < NUMBER_OF_ITERATIONS; i++) {
         // Pick a random client
@@ -54,14 +68,14 @@ describe('Port Change', () => {
         logger.info(`Transaction sent from client ${clientIndex}`);
 
         // Give time for message propagation
-        await sleep(15000);
+        await sleep(10_000); // Hopefully it will never take this long
         logger.info('Checking message propagation results');
 
         // Check message propagation results
         const numberOfClientsThatReceivedMessage = workerClientManager.numberOfClientsThatReceivedMessage();
         logger.info(`Number of clients that received message: ${numberOfClientsThatReceivedMessage}`);
 
-        assert(numberOfClientsThatReceivedMessage === numberOfClients - 1);
+        expect(numberOfClientsThatReceivedMessage).toBe(numberOfClients - 1);
         logger.info('All clients received message');
 
         workerClientManager.purgeMessageReceivedByClient();
@@ -73,17 +87,19 @@ describe('Port Change', () => {
           const clientIndexToChangePort = Math.floor(Math.random() * numberOfClients);
           logger.info(`Changing port for client ${clientIndexToChangePort}`);
           await workerClientManager.changePort(clientIndexToChangePort, await getPort());
-        }
 
-        // wait for two peer manager heartbeats
-        await sleep(config.default.peerCheckIntervalMS * 2);
+          // wait for 4 peer manager heartbeats for discovery
+          await sleep(testConfig.peerCheckIntervalMS * 4);
+        }
       }
 
-      logger.info('Test passed, cleaning up');
-
-      // cleanup
-      await workerClientManager.cleanup();
+      logger.info('Test passed');
     },
     20 * 60 * 1000,
   );
+
+  afterEach(async () => {
+    logger.info('Cleaning up');
+    await workerClientManager.cleanup();
+  });
 });

--- a/yarn-project/p2p/src/testbench/port_change.test.ts
+++ b/yarn-project/p2p/src/testbench/port_change.test.ts
@@ -1,9 +1,8 @@
-import { type Logger, createLogger } from '@aztec/foundation/log';
+import { createLogger } from '@aztec/foundation/log';
 import { sleep } from '@aztec/foundation/sleep';
 import { ClientIvcProof } from '@aztec/stdlib/proofs';
 import { mockTx } from '@aztec/stdlib/testing';
 
-import assert from 'assert';
 import getPort from 'get-port';
 import path from 'path';
 import { fileURLToPath } from 'url';
@@ -25,7 +24,7 @@ const __dirname = path.dirname(fileURLToPath(import.meta.url));
 describe('Port Change', () => {
   let workerClientManager: WorkerClientManager;
   let numberOfClients: number;
-  let testConfig: Partial<P2PConfig>;
+  let testConfig: P2PConfig;
   const logger = createLogger('testbench-ports');
 
   beforeEach(async () => {

--- a/yarn-project/p2p/src/testbench/port_change.test.ts
+++ b/yarn-project/p2p/src/testbench/port_change.test.ts
@@ -48,7 +48,7 @@ describe('Port Change', () => {
     // wait a bit longer for all peers to be ready
     await sleep(10000);
     logger.info('Workers Ready');
-  });
+  }, 30 * 1000);
 
   it(
     'should change port and propagate the gossip message correctly',

--- a/yarn-project/p2p/src/testbench/testbench.ts
+++ b/yarn-project/p2p/src/testbench/testbench.ts
@@ -42,7 +42,7 @@ async function main() {
     logger.info('Transaction sent from client 0');
 
     // Give time for message propagation
-    await sleep(30000);
+    await sleep(10000);
     logger.info('Checking message propagation results');
 
     // Check message propagation results

--- a/yarn-project/p2p/src/testbench/worker_client_manager.ts
+++ b/yarn-project/p2p/src/testbench/worker_client_manager.ts
@@ -244,7 +244,7 @@ class WorkerClientManager {
         } catch (e) {
           this.logger.error(`Error force killing process ${index}:`, e);
         }
-      }, 10000); // 10 second timeout for graceful exit
+      }, 5000); // 5 second timeout for graceful exit
 
       // Listen for process exit
       process.once('exit', () => {
@@ -294,7 +294,7 @@ class WorkerClientManager {
               }
             });
             resolve();
-          }, 30000); // 30 second timeout for all processes
+          }, 10000); // 10 second timeout for all processes
         }),
       ]);
     } catch (error) {

--- a/yarn-project/p2p/src/testbench/worker_client_manager.ts
+++ b/yarn-project/p2p/src/testbench/worker_client_manager.ts
@@ -207,6 +207,8 @@ class WorkerClientManager {
         (_, ind) => ind !== clientIndex && ind < Math.min(this.peerEnrs.length, 10),
       );
 
+      this.logger.info(`Changing port for client ${clientIndex} to ${newPort} with other nodes `, otherNodes);
+
       const config = this.createClientConfig(clientIndex, newPort, otherNodes);
       const [childProcess, readySignal] = this.spawnWorkerProcess(config, clientIndex);
 

--- a/yarn-project/p2p/testbench/configurations/normal-degree-5-nodes.json
+++ b/yarn-project/p2p/testbench/configurations/normal-degree-5-nodes.json
@@ -1,0 +1,14 @@
+{
+  "numberOfClients": 5,
+  "maxPeerCount": 30,
+  "gossipsubFloodPublish": false,
+  "debugDisableColocationPenalty": true,
+  "gossipsubInterval": 700,
+  "gossipsubD": 6,
+  "gossipsubDlo": 4,
+  "gossipsubDhi": 12,
+  "gossipsubDLazy": 6,
+  "peerCheckIntervalMS": 1000,
+  "gossipsubMcacheGossip": 12,
+  "gossipsubMcacheLength": 12
+}


### PR DESCRIPTION
## Overview

A few prs had made this test fall behind, it being a flake left stuff un corrected. 

There are a couple of problems with this test / the testbench. 
**Testbench**
- log out puts had changed, leaving the testbench itself bricked
- Turning off transaction validation as we are producing a dummy transaction

**Port Change**
- reducing node counts so my resource hypothesis can hopefully not be a crutch for me to fallback on
- Treat the bootnodes as full peers so we actually re discover them
