### PR TITLE
chore: Fix flake in reqresp p2p test

### DIFF
--- a/yarn-project/end-to-end/src/e2e_p2p/reqresp.test.ts
+++ b/yarn-project/end-to-end/src/e2e_p2p/reqresp.test.ts
@@ -1,6 +1,7 @@
 import type { AztecNodeService } from '@aztec/aztec-node';
 import { sleep } from '@aztec/aztec.js';
 import { RollupContract } from '@aztec/ethereum';
+import { timesAsync } from '@aztec/foundation/collection';
 
 import { jest } from '@jest/globals';
 import fs from 'fs';
@@ -8,9 +9,9 @@ import os from 'os';
 import path from 'path';
 
 import { shouldCollectMetrics } from '../fixtures/fixtures.js';
-import { type NodeContext, createNodes } from '../fixtures/setup_p2p_test.js';
+import { createNodes } from '../fixtures/setup_p2p_test.js';
 import { P2PNetworkTest, SHORTENED_BLOCK_TIME_CONFIG, WAIT_FOR_TX_TIMEOUT } from './p2p_network.js';
-import { createPXEServiceAndSubmitTransactions } from './shared.js';
+import { createPXEServiceAndPrepareTransactions } from './shared.js';
 
 // Don't set this to a higher value than 9 because each node will use a different L1 publisher account and anvil seeds
 const NUM_NODES = 6;
@@ -33,6 +34,7 @@ describe('e2e_p2p_reqresp_tx', () => {
       initialConfig: {
         ...SHORTENED_BLOCK_TIME_CONFIG,
         listenAddress: '127.0.0.1',
+        aztecEpochDuration: 48, // no reorgs please
       },
     });
     await t.setupAccount();
@@ -79,11 +81,18 @@ describe('e2e_p2p_reqresp_tx', () => {
       shouldCollectMetrics(),
     );
 
-    // wait a bit for peers to discover each other
+    t.logger.info('Sleeping to allow nodes to connect');
     await sleep(4000);
 
-    const { proposerIndexes, nodesToTurnOffTxGossip } = await getProposerIndexes();
+    t.logger.info('Preparing transactions to send');
+    const contexts = await timesAsync(2, i =>
+      createPXEServiceAndPrepareTransactions(t.logger, nodes[i], NUM_TXS_PER_NODE, t.fundedAccount),
+    );
 
+    t.logger.info('Starting fresh slot');
+    await t.ctx.cheatCodes.rollup.advanceToNextSlot();
+
+    const { proposerIndexes, nodesToTurnOffTxGossip } = await getProposerIndexes();
     t.logger.info(`Turning off tx gossip for nodes: ${nodesToTurnOffTxGossip}`);
     t.logger.info(`Sending txs to proposer nodes: ${proposerIndexes}`);
 
@@ -93,39 +102,23 @@ describe('e2e_p2p_reqresp_tx', () => {
     for (const nodeIndex of nodesToTurnOffTxGossip) {
       jest
         .spyOn((nodes[nodeIndex] as any).p2pClient.p2pService, 'handleGossipedTx')
-        .mockImplementation((): Promise<void> => {
-          return Promise.resolve();
-        });
+        .mockImplementation(() => Promise.resolve());
     }
 
-    t.logger.info('Submitting transactions');
+    t.logger.info('Sending transactions');
+    const sentTxs = contexts.map(c => c.txs.map(tx => tx.send()));
 
-    const contextPromises: Promise<NodeContext>[] = [];
-    // Send to the first two proposers
-    for (const nodeIndex of proposerIndexes.slice(0, 2)) {
-      const context = createPXEServiceAndSubmitTransactions(
-        t.logger,
-        nodes[nodeIndex],
-        NUM_TXS_PER_NODE,
-        t.fundedAccount,
-      );
-      contextPromises.push(context);
-    }
-    const contexts: NodeContext[] = await Promise.all(contextPromises);
-
-    // Wait for transactions to be sent
-
-    t.logger.info('Waiting for transactions to be mined');
+    t.logger.info('Waiting for all transactions to be mined');
     await Promise.all(
-      contexts.flatMap((context, i) =>
-        context.txs.map(async (tx, j) => {
-          t.logger.info(`Waiting for tx ${i}-${j}: ${await tx.getTxHash()} to be mined`);
+      sentTxs.flatMap((txs, i) =>
+        txs.map(async (tx, j) => {
+          t.logger.info(`Waiting for tx ${i}-${j} ${await tx.getTxHash()} to be mined`);
           await tx.wait({ timeout: WAIT_FOR_TX_TIMEOUT * 1.5 }); // more transactions in this test so allow more time
-          t.logger.info(`Tx ${i}-${j}: ${await tx.getTxHash()} has been mined`);
-          return await tx.getTxHash();
+          t.logger.info(`Tx ${i}-${j} ${await tx.getTxHash()} has been mined`);
         }),
       ),
     );
+
     t.logger.info('All transactions mined');
   });
 
@@ -156,8 +149,6 @@ describe('e2e_p2p_reqresp_tx', () => {
     }
     // Get the indexes of the nodes that are responsible for the next two slots
     const proposerIndexes = proposers.map(proposer => mappedProposers.indexOf(proposer as `0x${string}`));
-
-    t.logger.info('proposerIndexes: ' + proposerIndexes.join(', '));
 
     const nodesToTurnOffTxGossip = Array.from({ length: NUM_NODES }, (_, i) => i).filter(
       i => !proposerIndexes.includes(i),

--- a/yarn-project/end-to-end/src/e2e_p2p/shared.ts
+++ b/yarn-project/end-to-end/src/e2e_p2p/shared.ts
@@ -1,9 +1,11 @@
 import { getSchnorrAccount } from '@aztec/accounts/schnorr';
 import type { InitialAccountData } from '@aztec/accounts/testing';
 import type { AztecNodeService } from '@aztec/aztec-node';
-import { type Logger, type SentTx, TxStatus } from '@aztec/aztec.js';
+import { Fr, type Logger, ProvenTx, type SentTx, TxStatus, getContractInstanceFromDeployParams } from '@aztec/aztec.js';
+import { times } from '@aztec/foundation/collection';
 import type { SpamContract } from '@aztec/noir-contracts.js/Spam';
-import { createPXEService, getPXEServiceConfig as getRpcConfig } from '@aztec/pxe/server';
+import { TestContract, TestContractArtifact } from '@aztec/noir-contracts.js/Test';
+import { PXEService, createPXEService, getPXEServiceConfig as getRpcConfig } from '@aztec/pxe/server';
 
 import type { NodeContext } from '../fixtures/setup_p2p_test.js';
 import { submitTxsTo } from '../shared/submit-transactions.js';
@@ -60,9 +62,35 @@ export const createPXEServiceAndSubmitTransactions = async (
   const wallet = await account.getWallet();
 
   const txs = await submitTxsTo(pxeService, numTxs, wallet, logger);
-  return {
-    txs,
-    pxeService,
-    node,
-  };
+  return { txs, pxeService, node };
 };
+
+export async function createPXEServiceAndPrepareTransactions(
+  logger: Logger,
+  node: AztecNodeService,
+  numTxs: number,
+  fundedAccount: InitialAccountData,
+): Promise<{ pxeService: PXEService; txs: ProvenTx[]; node: AztecNodeService }> {
+  const rpcConfig = getRpcConfig();
+  rpcConfig.proverEnabled = false;
+  const pxe = await createPXEService(node, rpcConfig, true);
+
+  const account = await getSchnorrAccount(pxe, fundedAccount.secret, fundedAccount.signingKey, fundedAccount.salt);
+  await account.register();
+  const wallet = await account.getWallet();
+
+  const testContractInstance = await getContractInstanceFromDeployParams(TestContractArtifact, {});
+  await wallet.registerContract({ instance: testContractInstance, artifact: TestContractArtifact });
+  const contract = await TestContract.at(testContractInstance.address, wallet);
+
+  const txs = await Promise.all(
+    times(numTxs, async () => {
+      const tx = await contract.methods.emit_nullifier(Fr.random()).prove({ skipPublicSimulation: true });
+      const txHash = await tx.getTxHash();
+      logger.info(`Tx prepared with hash ${txHash}`);
+      return tx;
+    }),
+  );
+
+  return { txs, pxeService: pxe, node };
+}

--- a/yarn-project/p2p/src/client/p2p_client.ts
+++ b/yarn-project/p2p/src/client/p2p_client.ts
@@ -738,7 +738,7 @@ export class P2PClient<T extends P2PClientType = P2PClientType.Full>
     this.log.info(
       `Detected chain prune. Removing invalid txs count=${
         txsToDelete.length
-      } newLatestBlock=${latestBlock} previousLatestBlock=${this.getSyncedLatestBlockNum()}`,
+      } newLatestBlock=${latestBlock} previousLatestBlock=${await this.getSyncedLatestBlockNum()}`,
     );
 
     // delete invalid txs (both pending and mined)

--- a/yarn-project/sequencer-client/src/sequencer/sequencer.ts
+++ b/yarn-project/sequencer-client/src/sequencer/sequencer.ts
@@ -292,7 +292,7 @@ export class Sequencer {
     );
 
     this.setState(SequencerState.INITIALIZING_PROPOSAL, slot);
-    this.log.verbose(`Preparing proposal for block ${newBlockNumber} at slot ${slot}`, {
+    this.log.debug(`Preparing proposal for block ${newBlockNumber} at slot ${slot}`, {
       chainTipArchive,
       blockNumber: newBlockNumber,
       slot,
@@ -320,8 +320,9 @@ export class Sequencer {
       });
       finishedFlushing = true;
     } else {
-      this.log.debug(
-        `Not enough txs to build block ${newBlockNumber} at slot ${slot}: got ${pendingTxCount} txs, need ${this.minTxsPerBlock}`,
+      this.log.verbose(
+        `Not enough txs to build block ${newBlockNumber} at slot ${slot} (got ${pendingTxCount} txs, need ${this.minTxsPerBlock})`,
+        { chainTipArchive, blockNumber: newBlockNumber, slot },
       );
     }
 


### PR DESCRIPTION
Issue seems to be that the txs get sent to the first proposer with little time for it to build the block, so it misses its shot, and then that tx never reaches other nodes (since p2p gossip was disabled). This attempts to fix it.

WIP: currently running into a `Assertion failed: Failed to get a note 'self.is_some()'`
