### PR TITLE
fix: removeNullifiedNotes respecting only synced nullifiers

### DIFF
--- a/yarn-project/pxe/src/pxe_oracle_interface/pxe_oracle_interface.ts
+++ b/yarn-project/pxe/src/pxe_oracle_interface/pxe_oracle_interface.ts
@@ -743,6 +743,12 @@ export class PXEOracleInterface implements ExecutionDataProvider {
 
     for (const recipient of await this.keyStore.getAccounts()) {
       const currentNotesForRecipient = await this.noteDataProvider.getNotes({ contractAddress, recipient });
+
+      if (currentNotesForRecipient.length === 0) {
+        // Save a call to the node if there are no notes for the recipient
+        continue;
+      }
+
       const nullifiersToCheck = currentNotesForRecipient.map(note => note.siloedNullifier);
       const nullifierIndexes = await this.aztecNode.findLeavesIndexes(
         syncedBlockNumber,

--- a/yarn-project/pxe/src/storage/note_data_provider/note_data_provider.ts
+++ b/yarn-project/pxe/src/storage/note_data_provider/note_data_provider.ts
@@ -284,20 +284,18 @@ export class NoteDataProvider implements DataProvider {
         const { data: nullifier, l2BlockNumber: blockNumber } = blockScopedNullifier;
         const noteIndex = await this.#nullifierToNoteId.getAsync(nullifier.toString());
         if (!noteIndex) {
-          continue;
+          throw new Error('Nullifier not found in removeNullifiedNotes');
         }
 
         const noteBuffer = noteIndex ? await this.#notes.getAsync(noteIndex) : undefined;
 
         if (!noteBuffer) {
-          // note doesn't exist. Maybe it got nullified already
-          continue;
+          throw new Error('Note not found in removeNullifiedNotes');
         }
         const noteScopes = (await toArray(this.#notesToScope.getValuesAsync(noteIndex))) ?? [];
         const note = NoteDao.fromBuffer(noteBuffer);
         if (!note.recipient.equals(recipient)) {
-          // tried to nullify someone else's note
-          continue;
+          throw new Error("Tried to nullify someone else's note");
         }
 
         nullifiedNotes.push(note);

--- a/yarn-project/stdlib/src/tx/tx_hash.ts
+++ b/yarn-project/stdlib/src/tx/tx_hash.ts
@@ -12,10 +12,6 @@ export class TxHash {
     public readonly hash: Fr,
   ) {}
 
-  /*
-   * TxHashes are generated from the first nullifier of a transaction, which is a Fr.
-   * @returns A random TxHash.
-   */
   static random() {
     return new TxHash(Fr.random());
   }


### PR DESCRIPTION
As Nico pointed out [here](https://github.com/AztecProtocol/aztec-packages/pull/13323#discussion_r2029421426) we have incorrectly obtained nullifiers at the `latest` block instead of at the synced one in `removeNullifiedNotes` functions. This PR addresses that along with making NoteDataProvider more strict and a minor optimization of `removeNullifiedNotes`.
