### PR TITLE
feat: txIndexInBlock in response of getTxEffect

### DIFF
--- a/yarn-project/archiver/src/archiver/archiver.ts
+++ b/yarn-project/archiver/src/archiver/archiver.ts
@@ -19,7 +19,6 @@ import {
 import type { FunctionSelector } from '@aztec/stdlib/abi';
 import type { AztecAddress } from '@aztec/stdlib/aztec-address';
 import {
-  type InBlock,
   type L2Block,
   type L2BlockId,
   type L2BlockSource,
@@ -48,7 +47,7 @@ import type { GetContractClassLogsResponse, GetPublicLogsResponse } from '@aztec
 import type { L2LogsSource } from '@aztec/stdlib/interfaces/server';
 import { ContractClassLog, type LogFilter, type PrivateLog, type PublicLog, TxScopedL2Log } from '@aztec/stdlib/logs';
 import type { InboxLeaf, L1ToL2MessageSource } from '@aztec/stdlib/messaging';
-import { type BlockHeader, TxEffect, TxHash, TxReceipt } from '@aztec/stdlib/tx';
+import { type BlockHeader, type IndexedTxEffect, TxHash, TxReceipt } from '@aztec/stdlib/tx';
 import { Attributes, type TelemetryClient, type Traceable, type Tracer, trackSpan } from '@aztec/telemetry-client';
 
 import { EventEmitter } from 'events';
@@ -1122,7 +1121,7 @@ class ArchiverStoreHelper
   getBlockHeaders(from: number, limit: number): Promise<BlockHeader[]> {
     return this.store.getBlockHeaders(from, limit);
   }
-  getTxEffect(txHash: TxHash): Promise<(InBlock<TxEffect> & { txIndexInBlock: number }) | undefined> {
+  getTxEffect(txHash: TxHash): Promise<IndexedTxEffect | undefined> {
     return this.store.getTxEffect(txHash);
   }
   getSettledTxReceipt(txHash: TxHash): Promise<TxReceipt | undefined> {

--- a/yarn-project/archiver/src/archiver/archiver.ts
+++ b/yarn-project/archiver/src/archiver/archiver.ts
@@ -1122,7 +1122,7 @@ class ArchiverStoreHelper
   getBlockHeaders(from: number, limit: number): Promise<BlockHeader[]> {
     return this.store.getBlockHeaders(from, limit);
   }
-  getTxEffect(txHash: TxHash): Promise<InBlock<TxEffect> | undefined> {
+  getTxEffect(txHash: TxHash): Promise<(InBlock<TxEffect> & { txIndexInBlock: number }) | undefined> {
     return this.store.getTxEffect(txHash);
   }
   getSettledTxReceipt(txHash: TxHash): Promise<TxReceipt | undefined> {

--- a/yarn-project/archiver/src/archiver/archiver_store.ts
+++ b/yarn-project/archiver/src/archiver/archiver_store.ts
@@ -69,9 +69,9 @@ export interface ArchiverDataStore {
   /**
    * Gets a tx effect.
    * @param txHash - The txHash of the tx corresponding to the tx effect.
-   * @returns The requested tx effect (or undefined if not found).
+   * @returns The requested tx effect (or undefined if not found) along with its index in the block.
    */
-  getTxEffect(txHash: TxHash): Promise<InBlock<TxEffect> | undefined>;
+  getTxEffect(txHash: TxHash): Promise<(InBlock<TxEffect> & { txIndexInBlock: number }) | undefined>;
 
   /**
    * Gets a receipt of a settled tx.

--- a/yarn-project/archiver/src/archiver/archiver_store.ts
+++ b/yarn-project/archiver/src/archiver/archiver_store.ts
@@ -68,7 +68,7 @@ export interface ArchiverDataStore {
 
   /**
    * Gets a tx effect.
-   * @param txHash - The txHash of the tx corresponding to the tx effect.
+   * @param txHash - The hash of the tx corresponding to the tx effect.
    * @returns The requested tx effect (or undefined if not found) along with its index in the block.
    */
   getTxEffect(txHash: TxHash): Promise<(InBlock<TxEffect> & { txIndexInBlock: number }) | undefined>;

--- a/yarn-project/archiver/src/archiver/archiver_store.ts
+++ b/yarn-project/archiver/src/archiver/archiver_store.ts
@@ -1,7 +1,7 @@
 import type { Fr } from '@aztec/foundation/fields';
 import type { FunctionSelector } from '@aztec/stdlib/abi';
 import type { AztecAddress } from '@aztec/stdlib/aztec-address';
-import type { InBlock, L2Block } from '@aztec/stdlib/block';
+import type { L2Block } from '@aztec/stdlib/block';
 import type {
   ContractClassPublic,
   ContractInstanceUpdateWithAddress,
@@ -12,7 +12,7 @@ import type {
 import type { GetContractClassLogsResponse, GetPublicLogsResponse } from '@aztec/stdlib/interfaces/client';
 import type { LogFilter, PrivateLog, TxScopedL2Log } from '@aztec/stdlib/logs';
 import type { InboxLeaf } from '@aztec/stdlib/messaging';
-import { BlockHeader, type TxEffect, type TxHash, type TxReceipt } from '@aztec/stdlib/tx';
+import { BlockHeader, type IndexedTxEffect, type TxHash, type TxReceipt } from '@aztec/stdlib/tx';
 
 import type { DataRetrieval } from './structs/data_retrieval.js';
 import type { PublishedL2Block } from './structs/published.js';
@@ -69,9 +69,9 @@ export interface ArchiverDataStore {
   /**
    * Gets a tx effect.
    * @param txHash - The hash of the tx corresponding to the tx effect.
-   * @returns The requested tx effect (or undefined if not found) along with its index in the block.
+   * @returns The requested tx effect with block info (or undefined if not found).
    */
-  getTxEffect(txHash: TxHash): Promise<(InBlock<TxEffect> & { txIndexInBlock: number }) | undefined>;
+  getTxEffect(txHash: TxHash): Promise<IndexedTxEffect | undefined>;
 
   /**
    * Gets a receipt of a settled tx.

--- a/yarn-project/archiver/src/archiver/archiver_store_test_suite.ts
+++ b/yarn-project/archiver/src/archiver/archiver_store_test_suite.ts
@@ -223,14 +223,20 @@ export function describeArchiverDataStore(
       });
 
       it.each([
-        () => wrapInBlock(blocks[0].block.body.txEffects[0], blocks[0].block),
-        () => wrapInBlock(blocks[9].block.body.txEffects[3], blocks[9].block),
-        () => wrapInBlock(blocks[3].block.body.txEffects[1], blocks[3].block),
-        () => wrapInBlock(blocks[5].block.body.txEffects[2], blocks[5].block),
-        () => wrapInBlock(blocks[1].block.body.txEffects[0], blocks[1].block),
+        () => ({ data: blocks[0].block.body.txEffects[0], block: blocks[0].block, txIndexInBlock: 0 }),
+        () => ({ data: blocks[9].block.body.txEffects[3], block: blocks[9].block, txIndexInBlock: 3 }),
+        () => ({ data: blocks[3].block.body.txEffects[1], block: blocks[3].block, txIndexInBlock: 1 }),
+        () => ({ data: blocks[5].block.body.txEffects[2], block: blocks[5].block, txIndexInBlock: 2 }),
+        () => ({ data: blocks[1].block.body.txEffects[0], block: blocks[1].block, txIndexInBlock: 0 }),
       ])('retrieves a previously stored transaction', async getExpectedTx => {
-        const expectedTx = await getExpectedTx();
-        const actualTx = await store.getTxEffect(expectedTx.data.txHash);
+        const { data, block, txIndexInBlock } = await getExpectedTx();
+        const expectedTx = {
+          data,
+          l2BlockNumber: block.number,
+          l2BlockHash: (await block.hash()).toString(),
+          txIndexInBlock,
+        };
+        const actualTx = await store.getTxEffect(data.txHash);
         expect(actualTx).toEqual(expectedTx);
       });
 

--- a/yarn-project/archiver/src/archiver/archiver_store_test_suite.ts
+++ b/yarn-project/archiver/src/archiver/archiver_store_test_suite.ts
@@ -229,7 +229,7 @@ export function describeArchiverDataStore(
         () => ({ data: blocks[5].block.body.txEffects[2], block: blocks[5].block, txIndexInBlock: 2 }),
         () => ({ data: blocks[1].block.body.txEffects[0], block: blocks[1].block, txIndexInBlock: 0 }),
       ])('retrieves a previously stored transaction', async getExpectedTx => {
-        const { data, block, txIndexInBlock } = await getExpectedTx();
+        const { data, block, txIndexInBlock } = getExpectedTx();
         const expectedTx = {
           data,
           l2BlockNumber: block.number,

--- a/yarn-project/archiver/src/archiver/kv_archiver_store/block_store.ts
+++ b/yarn-project/archiver/src/archiver/kv_archiver_store/block_store.ts
@@ -180,7 +180,7 @@ export class BlockStore {
 
   /**
    * Gets a tx effect.
-   * @param txHash - The txHash of the tx corresponding to the tx effect.
+   * @param txHash - The hash of the tx corresponding to the tx effect.
    * @returns The requested tx effect (or undefined if not found) along with its index in the block.
    */
   async getTxEffect(txHash: TxHash): Promise<(InBlock<TxEffect> & { txIndexInBlock: number }) | undefined> {

--- a/yarn-project/archiver/src/archiver/kv_archiver_store/block_store.ts
+++ b/yarn-project/archiver/src/archiver/kv_archiver_store/block_store.ts
@@ -4,9 +4,9 @@ import { toArray } from '@aztec/foundation/iterable';
 import { createLogger } from '@aztec/foundation/log';
 import type { AztecAsyncKVStore, AztecAsyncMap, AztecAsyncSingleton, Range } from '@aztec/kv-store';
 import type { AztecAddress } from '@aztec/stdlib/aztec-address';
-import { Body, type InBlock, L2Block, L2BlockHash } from '@aztec/stdlib/block';
+import { Body, L2Block, L2BlockHash } from '@aztec/stdlib/block';
 import { AppendOnlyTreeSnapshot } from '@aztec/stdlib/trees';
-import { BlockHeader, TxEffect, TxHash, TxReceipt } from '@aztec/stdlib/tx';
+import { BlockHeader, type IndexedTxEffect, TxHash, TxReceipt } from '@aztec/stdlib/tx';
 
 import type { L1PublishedData, PublishedL2Block } from '../structs/published.js';
 
@@ -181,9 +181,9 @@ export class BlockStore {
   /**
    * Gets a tx effect.
    * @param txHash - The hash of the tx corresponding to the tx effect.
-   * @returns The requested tx effect (or undefined if not found) along with its index in the block.
+   * @returns The requested tx effect with block info (or undefined if not found).
    */
-  async getTxEffect(txHash: TxHash): Promise<(InBlock<TxEffect> & { txIndexInBlock: number }) | undefined> {
+  async getTxEffect(txHash: TxHash): Promise<IndexedTxEffect | undefined> {
     const [blockNumber, txIndex] = (await this.getTxLocation(txHash)) ?? [];
     if (typeof blockNumber !== 'number' || typeof txIndex !== 'number') {
       return undefined;

--- a/yarn-project/archiver/src/archiver/kv_archiver_store/block_store.ts
+++ b/yarn-project/archiver/src/archiver/kv_archiver_store/block_store.ts
@@ -181,9 +181,9 @@ export class BlockStore {
   /**
    * Gets a tx effect.
    * @param txHash - The txHash of the tx corresponding to the tx effect.
-   * @returns The requested tx effect (or undefined if not found).
+   * @returns The requested tx effect (or undefined if not found) along with its index in the block.
    */
-  async getTxEffect(txHash: TxHash): Promise<InBlock<TxEffect> | undefined> {
+  async getTxEffect(txHash: TxHash): Promise<(InBlock<TxEffect> & { txIndexInBlock: number }) | undefined> {
     const [blockNumber, txIndex] = (await this.getTxLocation(txHash)) ?? [];
     if (typeof blockNumber !== 'number' || typeof txIndex !== 'number') {
       return undefined;
@@ -198,6 +198,7 @@ export class BlockStore {
       data: block.block.body.txEffects[txIndex],
       l2BlockNumber: block.block.number,
       l2BlockHash: (await block.block.hash()).toString(),
+      txIndexInBlock: txIndex,
     };
   }
 

--- a/yarn-project/archiver/src/archiver/kv_archiver_store/kv_archiver_store.ts
+++ b/yarn-project/archiver/src/archiver/kv_archiver_store/kv_archiver_store.ts
@@ -197,7 +197,7 @@ export class KVArchiverDataStore implements ArchiverDataStore {
   /**
    * Gets a tx effect.
    * @param txHash - The hash of the tx corresponding to the tx effect.
-   * @returns The requested tx effect (or undefined if not found) along with its index in the block.
+   * @returns The requested tx effect with block info (or undefined if not found).
    */
   getTxEffect(txHash: TxHash) {
     return this.#blockStore.getTxEffect(txHash);

--- a/yarn-project/archiver/src/archiver/kv_archiver_store/kv_archiver_store.ts
+++ b/yarn-project/archiver/src/archiver/kv_archiver_store/kv_archiver_store.ts
@@ -196,7 +196,7 @@ export class KVArchiverDataStore implements ArchiverDataStore {
 
   /**
    * Gets a tx effect.
-   * @param txHash - The txHash of the tx corresponding to the tx effect.
+   * @param txHash - The hash of the tx corresponding to the tx effect.
    * @returns The requested tx effect (or undefined if not found) along with its index in the block.
    */
   getTxEffect(txHash: TxHash) {

--- a/yarn-project/archiver/src/archiver/kv_archiver_store/kv_archiver_store.ts
+++ b/yarn-project/archiver/src/archiver/kv_archiver_store/kv_archiver_store.ts
@@ -197,7 +197,7 @@ export class KVArchiverDataStore implements ArchiverDataStore {
   /**
    * Gets a tx effect.
    * @param txHash - The txHash of the tx corresponding to the tx effect.
-   * @returns The requested tx effect (or undefined if not found).
+   * @returns The requested tx effect (or undefined if not found) along with its index in the block.
    */
   getTxEffect(txHash: TxHash) {
     return this.#blockStore.getTxEffect(txHash);

--- a/yarn-project/archiver/src/test/mock_l2_block_source.ts
+++ b/yarn-project/archiver/src/test/mock_l2_block_source.ts
@@ -129,7 +129,7 @@ export class MockL2BlockSource implements L2BlockSource, ContractDataSource {
   /**
    * Gets a tx effect.
    * @param txHash - The hash of the tx corresponding to the tx effect.
-   * @returns The requested tx effect (or undefined if not found) along with its index in the block.
+   * @returns The requested tx effect with block info (or undefined if not found).
    */
   public async getTxEffect(txHash: TxHash) {
     const match = this.l2Blocks

--- a/yarn-project/archiver/src/test/mock_l2_block_source.ts
+++ b/yarn-project/archiver/src/test/mock_l2_block_source.ts
@@ -1,5 +1,6 @@
 import { DefaultL1ContractsConfig } from '@aztec/ethereum';
 import { Buffer32 } from '@aztec/foundation/buffer';
+import { randomInt } from '@aztec/foundation/crypto';
 import { EthAddress } from '@aztec/foundation/eth-address';
 import type { Fr } from '@aztec/foundation/fields';
 import { createLogger } from '@aztec/foundation/log';
@@ -128,8 +129,8 @@ export class MockL2BlockSource implements L2BlockSource, ContractDataSource {
 
   /**
    * Gets a tx effect.
-   * @param txHash - The hash of a transaction which resulted in the returned tx effect.
-   * @returns The requested tx effect.
+   * @param txHash - The txHash of the tx corresponding to the tx effect.
+   * @returns The requested tx effect (or undefined if not found) along with its index in the block.
    */
   public async getTxEffect(txHash: TxHash) {
     const match = this.l2Blocks
@@ -139,7 +140,12 @@ export class MockL2BlockSource implements L2BlockSource, ContractDataSource {
       return Promise.resolve(undefined);
     }
     const [txEffect, block] = match;
-    return { data: txEffect, l2BlockNumber: block.number, l2BlockHash: (await block.hash()).toString() };
+    return {
+      data: txEffect,
+      l2BlockNumber: block.number,
+      l2BlockHash: (await block.hash()).toString(),
+      txIndexInBlock: randomInt(10),
+    };
   }
 
   /**

--- a/yarn-project/archiver/src/test/mock_l2_block_source.ts
+++ b/yarn-project/archiver/src/test/mock_l2_block_source.ts
@@ -1,6 +1,5 @@
 import { DefaultL1ContractsConfig } from '@aztec/ethereum';
 import { Buffer32 } from '@aztec/foundation/buffer';
-import { randomInt } from '@aztec/foundation/crypto';
 import { EthAddress } from '@aztec/foundation/eth-address';
 import type { Fr } from '@aztec/foundation/fields';
 import { createLogger } from '@aztec/foundation/log';
@@ -129,7 +128,7 @@ export class MockL2BlockSource implements L2BlockSource, ContractDataSource {
 
   /**
    * Gets a tx effect.
-   * @param txHash - The txHash of the tx corresponding to the tx effect.
+   * @param txHash - The hash of the tx corresponding to the tx effect.
    * @returns The requested tx effect (or undefined if not found) along with its index in the block.
    */
   public async getTxEffect(txHash: TxHash) {
@@ -144,7 +143,7 @@ export class MockL2BlockSource implements L2BlockSource, ContractDataSource {
       data: txEffect,
       l2BlockNumber: block.number,
       l2BlockHash: (await block.hash()).toString(),
-      txIndexInBlock: randomInt(10),
+      txIndexInBlock: block.body.txEffects.indexOf(txEffect),
     };
   }
 

--- a/yarn-project/aztec-node/src/aztec-node/server.ts
+++ b/yarn-project/aztec-node/src/aztec-node/server.ts
@@ -67,9 +67,9 @@ import type { NullifierLeafPreimage, PublicDataTreeLeaf, PublicDataTreeLeafPreim
 import { MerkleTreeId, NullifierMembershipWitness, PublicDataWitness } from '@aztec/stdlib/trees';
 import {
   type BlockHeader,
+  type IndexedTxEffect,
   PublicSimulationOutput,
   Tx,
-  TxEffect,
   type TxHash,
   TxReceipt,
   TxStatus,
@@ -501,7 +501,7 @@ export class AztecNodeService implements AztecNode, AztecNodeAdmin, Traceable {
     return txReceipt;
   }
 
-  public getTxEffect(txHash: TxHash): Promise<(InBlock<TxEffect> & { txIndexInBlock: number }) | undefined> {
+  public getTxEffect(txHash: TxHash): Promise<IndexedTxEffect | undefined> {
     return this.blockSource.getTxEffect(txHash);
   }
 

--- a/yarn-project/aztec-node/src/aztec-node/server.ts
+++ b/yarn-project/aztec-node/src/aztec-node/server.ts
@@ -501,7 +501,7 @@ export class AztecNodeService implements AztecNode, AztecNodeAdmin, Traceable {
     return txReceipt;
   }
 
-  getTxEffect(txHash: TxHash): Promise<(InBlock<TxEffect> & { txIndexInBlock: number }) | undefined> {
+  public getTxEffect(txHash: TxHash): Promise<(InBlock<TxEffect> & { txIndexInBlock: number }) | undefined> {
     return this.blockSource.getTxEffect(txHash);
   }
 

--- a/yarn-project/aztec-node/src/aztec-node/server.ts
+++ b/yarn-project/aztec-node/src/aztec-node/server.ts
@@ -501,7 +501,7 @@ export class AztecNodeService implements AztecNode, AztecNodeAdmin, Traceable {
     return txReceipt;
   }
 
-  public getTxEffect(txHash: TxHash): Promise<InBlock<TxEffect> | undefined> {
+  getTxEffect(txHash: TxHash): Promise<(InBlock<TxEffect> & { txIndexInBlock: number }) | undefined> {
     return this.blockSource.getTxEffect(txHash);
   }
 

--- a/yarn-project/p2p/src/services/discv5/discv5_service.test.ts
+++ b/yarn-project/p2p/src/services/discv5/discv5_service.test.ts
@@ -31,7 +31,7 @@ const waitForPeers = (node: DiscV5Service, expectedCount: number, timeout = 15_0
 };
 
 describe('Discv5Service', () => {
-  jest.setTimeout(10_000);
+  jest.setTimeout(20_000);
 
   let store: AztecAsyncKVStore;
   let bootNode: BootstrapNode;

--- a/yarn-project/pxe/src/pxe_oracle_interface/pxe_oracle_interface.test.ts
+++ b/yarn-project/pxe/src/pxe_oracle_interface/pxe_oracle_interface.test.ts
@@ -167,7 +167,10 @@ describe('PXEOracleInterface', () => {
         await taggingDataProvider.addSenderAddress(sender.completeAddress.address);
       }
       aztecNode.getLogsByTags.mockReset();
-      aztecNode.getTxEffect.mockResolvedValue(randomInBlock(await TxEffect.random()));
+      aztecNode.getTxEffect.mockResolvedValue({
+        ...randomInBlock(await TxEffect.random()),
+        txIndexInBlock: 0,
+      });
     });
 
     it('should sync tagged logs', async () => {

--- a/yarn-project/pxe/src/pxe_service/pxe_service.ts
+++ b/yarn-project/pxe/src/pxe_service/pxe_service.ts
@@ -26,7 +26,7 @@ import {
 } from '@aztec/stdlib/abi';
 import type { AuthWitness } from '@aztec/stdlib/auth-witness';
 import type { AztecAddress } from '@aztec/stdlib/aztec-address';
-import type { InBlock, L2Block } from '@aztec/stdlib/block';
+import type { L2Block } from '@aztec/stdlib/block';
 import {
   CompleteAddress,
   type ContractClassWithId,
@@ -54,11 +54,11 @@ import { getNonNullifiedL1ToL2MessageWitness } from '@aztec/stdlib/messaging';
 import { type NotesFilter, UniqueNote } from '@aztec/stdlib/note';
 import { MerkleTreeId } from '@aztec/stdlib/trees';
 import {
+  type IndexedTxEffect,
   PrivateExecutionResult,
   PrivateSimulationResult,
   PublicSimulationOutput,
   Tx,
-  type TxEffect,
   TxExecutionRequest,
   type TxHash,
   TxProfileResult,
@@ -209,7 +209,7 @@ export class PXEService implements PXE {
     return this.node.getTxReceipt(txHash);
   }
 
-  public getTxEffect(txHash: TxHash): Promise<(InBlock<TxEffect> & { txIndexInBlock: number }) | undefined> {
+  public getTxEffect(txHash: TxHash): Promise<IndexedTxEffect | undefined> {
     return this.node.getTxEffect(txHash);
   }
 

--- a/yarn-project/pxe/src/pxe_service/pxe_service.ts
+++ b/yarn-project/pxe/src/pxe_service/pxe_service.ts
@@ -209,7 +209,7 @@ export class PXEService implements PXE {
     return this.node.getTxReceipt(txHash);
   }
 
-  public getTxEffect(txHash: TxHash): Promise<InBlock<TxEffect> | undefined> {
+  public getTxEffect(txHash: TxHash): Promise<(InBlock<TxEffect> & { txIndexInBlock: number }) | undefined> {
     return this.node.getTxEffect(txHash);
   }
 

--- a/yarn-project/pxe/src/test/pxe_service.test.ts
+++ b/yarn-project/pxe/src/test/pxe_service.test.ts
@@ -88,7 +88,10 @@ describe('PXEService', () => {
     const settledTx = await TxEffect.random();
     const duplicateTx = await mockTx();
 
-    node.getTxEffect.mockResolvedValue(randomInBlock(settledTx));
+    node.getTxEffect.mockResolvedValue({
+      ...randomInBlock(settledTx),
+      txIndexInBlock: 0,
+    });
 
     const pxe = await PXEService.create(
       node,

--- a/yarn-project/stdlib/src/block/in_block.ts
+++ b/yarn-project/stdlib/src/block/in_block.ts
@@ -5,6 +5,7 @@ import { type ZodTypeAny, z } from 'zod';
 import { schemas } from '../schemas/index.js';
 import type { L2Block } from './l2_block.js';
 
+// Note: If you expand this type with indexInBlock, then delete `IndexedTxEffect` and use this type instead.
 export type InBlock<T> = {
   l2BlockNumber: number;
   l2BlockHash: string;

--- a/yarn-project/stdlib/src/block/l2_block_source.ts
+++ b/yarn-project/stdlib/src/block/l2_block_source.ts
@@ -68,7 +68,7 @@ export interface L2BlockSource {
 
   /**
    * Gets a tx effect.
-   * @param txHash - The txHash of the tx corresponding to the tx effect.
+   * @param txHash - The hash of the tx corresponding to the tx effect.
    * @returns The requested tx effect (or undefined if not found) along with its index in the block.
    */
   getTxEffect(txHash: TxHash): Promise<(InBlock<TxEffect> & { txIndexInBlock: number }) | undefined>;

--- a/yarn-project/stdlib/src/block/l2_block_source.ts
+++ b/yarn-project/stdlib/src/block/l2_block_source.ts
@@ -68,10 +68,10 @@ export interface L2BlockSource {
 
   /**
    * Gets a tx effect.
-   * @param txHash - The hash of a transaction which resulted in the returned tx effect.
-   * @returns The requested tx effect.
+   * @param txHash - The txHash of the tx corresponding to the tx effect.
+   * @returns The requested tx effect (or undefined if not found) along with its index in the block.
    */
-  getTxEffect(txHash: TxHash): Promise<InBlock<TxEffect> | undefined>;
+  getTxEffect(txHash: TxHash): Promise<(InBlock<TxEffect> & { txIndexInBlock: number }) | undefined>;
 
   /**
    * Gets a receipt of a settled tx.

--- a/yarn-project/stdlib/src/block/l2_block_source.ts
+++ b/yarn-project/stdlib/src/block/l2_block_source.ts
@@ -5,10 +5,9 @@ import { z } from 'zod';
 
 import type { L1RollupConstants } from '../epoch-helpers/index.js';
 import type { BlockHeader } from '../tx/block_header.js';
-import type { TxEffect } from '../tx/tx_effect.js';
+import type { IndexedTxEffect } from '../tx/indexed_tx_effect.js';
 import type { TxHash } from '../tx/tx_hash.js';
 import type { TxReceipt } from '../tx/tx_receipt.js';
-import type { InBlock } from './in_block.js';
 import type { L2Block } from './l2_block.js';
 import type { PublishedL2Block } from './published_l2_block.js';
 
@@ -69,9 +68,9 @@ export interface L2BlockSource {
   /**
    * Gets a tx effect.
    * @param txHash - The hash of the tx corresponding to the tx effect.
-   * @returns The requested tx effect (or undefined if not found) along with its index in the block.
+   * @returns The requested tx effect with block info (or undefined if not found).
    */
-  getTxEffect(txHash: TxHash): Promise<(InBlock<TxEffect> & { txIndexInBlock: number }) | undefined>;
+  getTxEffect(txHash: TxHash): Promise<IndexedTxEffect | undefined>;
 
   /**
    * Gets a receipt of a settled tx.

--- a/yarn-project/stdlib/src/interfaces/archiver.test.ts
+++ b/yarn-project/stdlib/src/interfaces/archiver.test.ts
@@ -9,7 +9,6 @@ import omit from 'lodash.omit';
 import type { ContractArtifact } from '../abi/abi.js';
 import { FunctionSelector } from '../abi/function_selector.js';
 import { AztecAddress } from '../aztec-address/index.js';
-import type { InBlock } from '../block/in_block.js';
 import { L2Block } from '../block/l2_block.js';
 import type { L2Tips } from '../block/l2_block_source.js';
 import type { PublishedL2Block } from '../block/published_l2_block.js';
@@ -28,6 +27,7 @@ import { PrivateLog } from '../logs/private_log.js';
 import { TxScopedL2Log } from '../logs/tx_scoped_l2_log.js';
 import { getTokenContractArtifact } from '../tests/fixtures.js';
 import { BlockHeader } from '../tx/block_header.js';
+import type { IndexedTxEffect } from '../tx/indexed_tx_effect.js';
 import { TxEffect } from '../tx/tx_effect.js';
 import { TxHash } from '../tx/tx_hash.js';
 import { TxReceipt } from '../tx/tx_receipt.js';
@@ -271,7 +271,7 @@ class MockArchiver implements ArchiverApi {
       },
     ];
   }
-  async getTxEffect(_txHash: TxHash): Promise<(InBlock<TxEffect> & { txIndexInBlock: number }) | undefined> {
+  async getTxEffect(_txHash: TxHash): Promise<IndexedTxEffect | undefined> {
     expect(_txHash).toBeInstanceOf(TxHash);
     return { l2BlockNumber: 1, l2BlockHash: '0x12', data: await TxEffect.random(), txIndexInBlock: randomInt(10) };
   }

--- a/yarn-project/stdlib/src/interfaces/archiver.test.ts
+++ b/yarn-project/stdlib/src/interfaces/archiver.test.ts
@@ -1,3 +1,4 @@
+import { randomInt } from '@aztec/foundation/crypto';
 import { EthAddress } from '@aztec/foundation/eth-address';
 import { Signature } from '@aztec/foundation/eth-signature';
 import { Fr } from '@aztec/foundation/fields';
@@ -270,9 +271,9 @@ class MockArchiver implements ArchiverApi {
       },
     ];
   }
-  async getTxEffect(_txHash: TxHash): Promise<InBlock<TxEffect> | undefined> {
+  async getTxEffect(_txHash: TxHash): Promise<(InBlock<TxEffect> & { txIndexInBlock: number }) | undefined> {
     expect(_txHash).toBeInstanceOf(TxHash);
-    return { l2BlockNumber: 1, l2BlockHash: '0x12', data: await TxEffect.random() };
+    return { l2BlockNumber: 1, l2BlockHash: '0x12', data: await TxEffect.random(), txIndexInBlock: randomInt(10) };
   }
   getSettledTxReceipt(txHash: TxHash): Promise<TxReceipt | undefined> {
     expect(txHash).toBeInstanceOf(TxHash);

--- a/yarn-project/stdlib/src/interfaces/archiver.ts
+++ b/yarn-project/stdlib/src/interfaces/archiver.ts
@@ -47,7 +47,10 @@ export const ArchiverApiSchema: ApiSchemaFor<ArchiverApi> = {
     .function()
     .args(schemas.Integer, schemas.Integer, optional(z.boolean()))
     .returns(z.array(PublishedL2BlockSchema)),
-  getTxEffect: z.function().args(TxHash.schema).returns(inBlockSchemaFor(TxEffect.schema).optional()),
+  getTxEffect: z
+    .function()
+    .args(TxHash.schema)
+    .returns(inBlockSchemaFor(TxEffect.schema).extend({ txIndexInBlock: schemas.Integer }).optional()),
   getSettledTxReceipt: z.function().args(TxHash.schema).returns(TxReceipt.schema.optional()),
   getL2SlotNumber: z.function().args().returns(schemas.BigInt),
   getL2EpochNumber: z.function().args().returns(schemas.BigInt),

--- a/yarn-project/stdlib/src/interfaces/archiver.ts
+++ b/yarn-project/stdlib/src/interfaces/archiver.ts
@@ -2,7 +2,6 @@ import type { ApiSchemaFor } from '@aztec/foundation/schemas';
 
 import { z } from 'zod';
 
-import { inBlockSchemaFor } from '../block/in_block.js';
 import { L2Block } from '../block/l2_block.js';
 import { type L2BlockSource, L2TipsSchema } from '../block/l2_block_source.js';
 import { PublishedL2BlockSchema } from '../block/published_l2_block.js';
@@ -18,7 +17,7 @@ import { TxScopedL2Log } from '../logs/tx_scoped_l2_log.js';
 import type { L1ToL2MessageSource } from '../messaging/l1_to_l2_message_source.js';
 import { optional, schemas } from '../schemas/schemas.js';
 import { BlockHeader } from '../tx/block_header.js';
-import { TxEffect } from '../tx/tx_effect.js';
+import { indexedTxSchema } from '../tx/indexed_tx_effect.js';
 import { TxHash } from '../tx/tx_hash.js';
 import { TxReceipt } from '../tx/tx_receipt.js';
 import { GetContractClassLogsResponseSchema, GetPublicLogsResponseSchema } from './get_logs_response.js';
@@ -47,10 +46,7 @@ export const ArchiverApiSchema: ApiSchemaFor<ArchiverApi> = {
     .function()
     .args(schemas.Integer, schemas.Integer, optional(z.boolean()))
     .returns(z.array(PublishedL2BlockSchema)),
-  getTxEffect: z
-    .function()
-    .args(TxHash.schema)
-    .returns(inBlockSchemaFor(TxEffect.schema).extend({ txIndexInBlock: schemas.Integer }).optional()),
+  getTxEffect: z.function().args(TxHash.schema).returns(indexedTxSchema().optional()),
   getSettledTxReceipt: z.function().args(TxHash.schema).returns(TxReceipt.schema.optional()),
   getL2SlotNumber: z.function().args().returns(schemas.BigInt),
   getL2EpochNumber: z.function().args().returns(schemas.BigInt),

--- a/yarn-project/stdlib/src/interfaces/aztec-node.test.ts
+++ b/yarn-project/stdlib/src/interfaces/aztec-node.test.ts
@@ -7,6 +7,7 @@ import {
 } from '@aztec/constants';
 import { type L1ContractAddresses, L1ContractsNames } from '@aztec/ethereum/l1-contract-addresses';
 import { Buffer32 } from '@aztec/foundation/buffer';
+import { randomInt } from '@aztec/foundation/crypto';
 import { memoize } from '@aztec/foundation/decorators';
 import { EthAddress } from '@aztec/foundation/eth-address';
 import { Signature } from '@aztec/foundation/eth-signature';
@@ -537,9 +538,9 @@ class MockAztecNode implements AztecNode {
     expect(txHash).toBeInstanceOf(TxHash);
     return Promise.resolve(TxReceipt.empty());
   }
-  async getTxEffect(txHash: TxHash): Promise<InBlock<TxEffect> | undefined> {
+  async getTxEffect(txHash: TxHash): Promise<(InBlock<TxEffect> & { txIndexInBlock: number }) | undefined> {
     expect(txHash).toBeInstanceOf(TxHash);
-    return { l2BlockNumber: 1, l2BlockHash: '0x12', data: await TxEffect.random() };
+    return { l2BlockNumber: 1, l2BlockHash: '0x12', data: await TxEffect.random(), txIndexInBlock: randomInt(10) };
   }
   async getPendingTxs(): Promise<Tx[]> {
     return [await Tx.random()];

--- a/yarn-project/stdlib/src/interfaces/aztec-node.test.ts
+++ b/yarn-project/stdlib/src/interfaces/aztec-node.test.ts
@@ -43,6 +43,7 @@ import { MerkleTreeId } from '../trees/merkle_tree_id.js';
 import { NullifierMembershipWitness } from '../trees/nullifier_membership_witness.js';
 import { PublicDataWitness } from '../trees/public_data_witness.js';
 import { BlockHeader } from '../tx/block_header.js';
+import type { IndexedTxEffect } from '../tx/indexed_tx_effect.js';
 import { PublicSimulationOutput } from '../tx/public_simulation_output.js';
 import { Tx } from '../tx/tx.js';
 import { TxEffect } from '../tx/tx_effect.js';
@@ -538,7 +539,7 @@ class MockAztecNode implements AztecNode {
     expect(txHash).toBeInstanceOf(TxHash);
     return Promise.resolve(TxReceipt.empty());
   }
-  async getTxEffect(txHash: TxHash): Promise<(InBlock<TxEffect> & { txIndexInBlock: number }) | undefined> {
+  async getTxEffect(txHash: TxHash): Promise<IndexedTxEffect | undefined> {
     expect(txHash).toBeInstanceOf(TxHash);
     return { l2BlockNumber: 1, l2BlockHash: '0x12', data: await TxEffect.random(), txIndexInBlock: randomInt(10) };
   }

--- a/yarn-project/stdlib/src/interfaces/aztec-node.ts
+++ b/yarn-project/stdlib/src/interfaces/aztec-node.ts
@@ -331,7 +331,7 @@ export interface AztecNode
 
   /**
    * Gets a tx effect.
-   * @param txHash - The txHash of the tx corresponding to the tx effect.
+   * @param txHash - The hash of the tx corresponding to the tx effect.
    * @returns The requested tx effect (or undefined if not found) along with its index in the block.
    */
   getTxEffect(txHash: TxHash): Promise<(InBlock<TxEffect> & { txIndexInBlock: number }) | undefined>;

--- a/yarn-project/stdlib/src/interfaces/aztec-node.ts
+++ b/yarn-project/stdlib/src/interfaces/aztec-node.ts
@@ -330,11 +330,11 @@ export interface AztecNode
   getTxReceipt(txHash: TxHash): Promise<TxReceipt>;
 
   /**
-   * Get a tx effect.
-   * @param txHash - The hash of a transaction which resulted in the returned tx effect.
-   * @returns The requested tx effect.
+   * Gets a tx effect.
+   * @param txHash - The txHash of the tx corresponding to the tx effect.
+   * @returns The requested tx effect (or undefined if not found) along with its index in the block.
    */
-  getTxEffect(txHash: TxHash): Promise<InBlock<TxEffect> | undefined>;
+  getTxEffect(txHash: TxHash): Promise<(InBlock<TxEffect> & { txIndexInBlock: number }) | undefined>;
 
   /**
    * Method to retrieve pending txs.
@@ -516,7 +516,10 @@ export const AztecNodeApiSchema: ApiSchemaFor<AztecNode> = {
 
   getTxReceipt: z.function().args(TxHash.schema).returns(TxReceipt.schema),
 
-  getTxEffect: z.function().args(TxHash.schema).returns(inBlockSchemaFor(TxEffect.schema).optional()),
+  getTxEffect: z
+    .function()
+    .args(TxHash.schema)
+    .returns(inBlockSchemaFor(TxEffect.schema).extend({ txIndexInBlock: schemas.Integer }).optional()),
 
   getPendingTxs: z.function().returns(z.array(Tx.schema)),
 

--- a/yarn-project/stdlib/src/interfaces/aztec-node.ts
+++ b/yarn-project/stdlib/src/interfaces/aztec-node.ts
@@ -38,14 +38,15 @@ import { NullifierMembershipWitness } from '../trees/nullifier_membership_witnes
 import { PublicDataWitness } from '../trees/public_data_witness.js';
 import {
   BlockHeader,
+  type IndexedTxEffect,
   PublicSimulationOutput,
   Tx,
   TxHash,
   TxReceipt,
   type TxValidationResult,
   TxValidationResultSchema,
+  indexedTxSchema,
 } from '../tx/index.js';
-import { TxEffect } from '../tx/tx_effect.js';
 import { ValidatorsStatsSchema } from '../validators/schemas.js';
 import type { ValidatorsStats } from '../validators/types.js';
 import { type ComponentsVersions, getVersioningResponseHandler } from '../versioning/index.js';
@@ -332,9 +333,9 @@ export interface AztecNode
   /**
    * Gets a tx effect.
    * @param txHash - The hash of the tx corresponding to the tx effect.
-   * @returns The requested tx effect (or undefined if not found) along with its index in the block.
+   * @returns The requested tx effect with block info (or undefined if not found).
    */
-  getTxEffect(txHash: TxHash): Promise<(InBlock<TxEffect> & { txIndexInBlock: number }) | undefined>;
+  getTxEffect(txHash: TxHash): Promise<IndexedTxEffect | undefined>;
 
   /**
    * Method to retrieve pending txs.
@@ -516,10 +517,7 @@ export const AztecNodeApiSchema: ApiSchemaFor<AztecNode> = {
 
   getTxReceipt: z.function().args(TxHash.schema).returns(TxReceipt.schema),
 
-  getTxEffect: z
-    .function()
-    .args(TxHash.schema)
-    .returns(inBlockSchemaFor(TxEffect.schema).extend({ txIndexInBlock: schemas.Integer }).optional()),
+  getTxEffect: z.function().args(TxHash.schema).returns(indexedTxSchema().optional()),
 
   getPendingTxs: z.function().returns(z.array(Tx.schema)),
 

--- a/yarn-project/stdlib/src/interfaces/pxe.test.ts
+++ b/yarn-project/stdlib/src/interfaces/pxe.test.ts
@@ -16,7 +16,6 @@ import type { AbiDecoded } from '../abi/decoder.js';
 import { EventSelector } from '../abi/event_selector.js';
 import { AuthWitness } from '../auth_witness/auth_witness.js';
 import { AztecAddress } from '../aztec-address/index.js';
-import type { InBlock } from '../block/in_block.js';
 import { L2Block } from '../block/l2_block.js';
 import {
   CompleteAddress,
@@ -36,7 +35,14 @@ import { UniqueNote } from '../note/index.js';
 import type { NotesFilter } from '../note/notes_filter.js';
 import { ClientIvcProof } from '../proofs/client_ivc_proof.js';
 import { getTokenContractArtifact } from '../tests/fixtures.js';
-import { PrivateExecutionResult, Tx, TxHash, TxReceipt, TxSimulationResult } from '../tx/index.js';
+import {
+  type IndexedTxEffect,
+  PrivateExecutionResult,
+  Tx,
+  TxHash,
+  TxReceipt,
+  TxSimulationResult,
+} from '../tx/index.js';
 import { TxProfileResult } from '../tx/profiled_tx.js';
 import { TxProvingResult } from '../tx/proven_tx.js';
 import { TxEffect } from '../tx/tx_effect.js';
@@ -396,7 +402,7 @@ class MockPXE implements PXE {
     expect(txHash).toBeInstanceOf(TxHash);
     return Promise.resolve(TxReceipt.empty());
   }
-  async getTxEffect(txHash: TxHash): Promise<(InBlock<TxEffect> & { txIndexInBlock: number }) | undefined> {
+  async getTxEffect(txHash: TxHash): Promise<IndexedTxEffect | undefined> {
     expect(txHash).toBeInstanceOf(TxHash);
     return {
       data: await TxEffect.random(),

--- a/yarn-project/stdlib/src/interfaces/pxe.test.ts
+++ b/yarn-project/stdlib/src/interfaces/pxe.test.ts
@@ -1,5 +1,6 @@
 import { L1_TO_L2_MSG_TREE_HEIGHT } from '@aztec/constants';
 import { type L1ContractAddresses, L1ContractsNames } from '@aztec/ethereum/l1-contract-addresses';
+import { randomInt } from '@aztec/foundation/crypto';
 import { memoize } from '@aztec/foundation/decorators';
 import { EthAddress } from '@aztec/foundation/eth-address';
 import { Fr } from '@aztec/foundation/fields';
@@ -395,9 +396,14 @@ class MockPXE implements PXE {
     expect(txHash).toBeInstanceOf(TxHash);
     return Promise.resolve(TxReceipt.empty());
   }
-  async getTxEffect(txHash: TxHash): Promise<InBlock<TxEffect> | undefined> {
+  async getTxEffect(txHash: TxHash): Promise<(InBlock<TxEffect> & { txIndexInBlock: number }) | undefined> {
     expect(txHash).toBeInstanceOf(TxHash);
-    return { data: await TxEffect.random(), l2BlockHash: Fr.random().toString(), l2BlockNumber: 1 };
+    return {
+      data: await TxEffect.random(),
+      l2BlockHash: Fr.random().toString(),
+      l2BlockNumber: 1,
+      txIndexInBlock: randomInt(10),
+    };
   }
   getPublicStorageAt(contract: AztecAddress, slot: Fr): Promise<Fr> {
     expect(contract).toBeInstanceOf(AztecAddress);

--- a/yarn-project/stdlib/src/interfaces/pxe.ts
+++ b/yarn-project/stdlib/src/interfaces/pxe.ts
@@ -10,7 +10,6 @@ import type { AbiDecoded } from '../abi/decoder.js';
 import type { EventSelector } from '../abi/event_selector.js';
 import { AuthWitness } from '../auth_witness/auth_witness.js';
 import type { AztecAddress } from '../aztec-address/index.js';
-import { type InBlock, inBlockSchemaFor } from '../block/in_block.js';
 import { L2Block } from '../block/l2_block.js';
 import {
   CompleteAddress,
@@ -29,10 +28,18 @@ import { type LogFilter, LogFilterSchema } from '../logs/log_filter.js';
 import { UniqueNote } from '../note/extended_note.js';
 import { type NotesFilter, NotesFilterSchema } from '../note/notes_filter.js';
 import { AbiDecodedSchema, optional, schemas } from '../schemas/schemas.js';
-import { PrivateExecutionResult, Tx, TxExecutionRequest, TxHash, TxReceipt, TxSimulationResult } from '../tx/index.js';
+import {
+  type IndexedTxEffect,
+  PrivateExecutionResult,
+  Tx,
+  TxExecutionRequest,
+  TxHash,
+  TxReceipt,
+  TxSimulationResult,
+  indexedTxSchema,
+} from '../tx/index.js';
 import { TxProfileResult } from '../tx/profiled_tx.js';
 import { TxProvingResult } from '../tx/proven_tx.js';
-import { TxEffect } from '../tx/tx_effect.js';
 import {
   type GetContractClassLogsResponse,
   GetContractClassLogsResponseSchema,
@@ -204,9 +211,9 @@ export interface PXE {
   /**
    * Gets a tx effect.
    * @param txHash - The hash of the tx corresponding to the tx effect.
-   * @returns The requested tx effect (or undefined if not found) along with its index in the block.
+   * @returns The requested tx effect with block info (or undefined if not found).
    */
-  getTxEffect(txHash: TxHash): Promise<(InBlock<TxEffect> & { txIndexInBlock: number }) | undefined>;
+  getTxEffect(txHash: TxHash): Promise<IndexedTxEffect | undefined>;
 
   /**
    * Gets the storage value at the given contract storage slot.
@@ -470,10 +477,7 @@ export const PXESchema: ApiSchemaFor<PXE> = {
     .returns(TxSimulationResult.schema),
   sendTx: z.function().args(Tx.schema).returns(TxHash.schema),
   getTxReceipt: z.function().args(TxHash.schema).returns(TxReceipt.schema),
-  getTxEffect: z
-    .function()
-    .args(TxHash.schema)
-    .returns(inBlockSchemaFor(TxEffect.schema).extend({ txIndexInBlock: schemas.Integer }).optional()),
+  getTxEffect: z.function().args(TxHash.schema).returns(indexedTxSchema().optional()),
   getPublicStorageAt: z.function().args(schemas.AztecAddress, schemas.Fr).returns(schemas.Fr),
   getNotes: z.function().args(NotesFilterSchema).returns(z.array(UniqueNote.schema)),
   getL1ToL2MembershipWitness: z

--- a/yarn-project/stdlib/src/interfaces/pxe.ts
+++ b/yarn-project/stdlib/src/interfaces/pxe.ts
@@ -202,11 +202,11 @@ export interface PXE {
   getTxReceipt(txHash: TxHash): Promise<TxReceipt>;
 
   /**
-   * Get a tx effect.
-   * @param txHash - The hash of a transaction which resulted in the returned tx effect.
-   * @returns The requested tx effect.
+   * Gets a tx effect.
+   * @param txHash - The txHash of the tx corresponding to the tx effect.
+   * @returns The requested tx effect (or undefined if not found) along with its index in the block.
    */
-  getTxEffect(txHash: TxHash): Promise<InBlock<TxEffect> | undefined>;
+  getTxEffect(txHash: TxHash): Promise<(InBlock<TxEffect> & { txIndexInBlock: number }) | undefined>;
 
   /**
    * Gets the storage value at the given contract storage slot.
@@ -473,7 +473,7 @@ export const PXESchema: ApiSchemaFor<PXE> = {
   getTxEffect: z
     .function()
     .args(TxHash.schema)
-    .returns(z.union([inBlockSchemaFor(TxEffect.schema), z.undefined()])),
+    .returns(inBlockSchemaFor(TxEffect.schema).extend({ txIndexInBlock: schemas.Integer }).optional()),
   getPublicStorageAt: z.function().args(schemas.AztecAddress, schemas.Fr).returns(schemas.Fr),
   getNotes: z.function().args(NotesFilterSchema).returns(z.array(UniqueNote.schema)),
   getL1ToL2MembershipWitness: z

--- a/yarn-project/stdlib/src/interfaces/pxe.ts
+++ b/yarn-project/stdlib/src/interfaces/pxe.ts
@@ -203,7 +203,7 @@ export interface PXE {
 
   /**
    * Gets a tx effect.
-   * @param txHash - The txHash of the tx corresponding to the tx effect.
+   * @param txHash - The hash of the tx corresponding to the tx effect.
    * @returns The requested tx effect (or undefined if not found) along with its index in the block.
    */
   getTxEffect(txHash: TxHash): Promise<(InBlock<TxEffect> & { txIndexInBlock: number }) | undefined>;

--- a/yarn-project/stdlib/src/tx/index.ts
+++ b/yarn-project/stdlib/src/tx/index.ts
@@ -28,3 +28,4 @@ export * from './validator/error_texts.js';
 export * from './capsule.js';
 export * from './global_variable_builder.js';
 export * from './hashed_values.js';
+export * from './indexed_tx_effect.js';

--- a/yarn-project/stdlib/src/tx/indexed_tx_effect.ts
+++ b/yarn-project/stdlib/src/tx/indexed_tx_effect.ts
@@ -1,0 +1,10 @@
+import { schemas } from '@aztec/foundation/schemas';
+
+import { type InBlock, inBlockSchemaFor } from '../block/in_block.js';
+import { TxEffect } from './tx_effect.js';
+
+export type IndexedTxEffect = InBlock<TxEffect> & { txIndexInBlock: number };
+
+export function indexedTxSchema() {
+  return inBlockSchemaFor(TxEffect.schema).extend({ txIndexInBlock: schemas.Integer });
+}

--- a/yarn-project/txe/src/node/txe_node.ts
+++ b/yarn-project/txe/src/node/txe_node.ts
@@ -88,7 +88,7 @@ export class TXENode implements AztecNode {
 
   /**
    * Gets a tx effect.
-   * @param txHash - The txHash of the tx corresponding to the tx effect.
+   * @param txHash - The hash of the tx corresponding to the tx effect.
    * @returns The requested tx effect (or undefined if not found) along with its index in the block.
    */
   getTxEffect(txHash: TxHash): Promise<(InBlock<TxEffect> & { txIndexInBlock: number }) | undefined> {

--- a/yarn-project/txe/src/node/txe_node.ts
+++ b/yarn-project/txe/src/node/txe_node.ts
@@ -44,6 +44,7 @@ import {
 } from '@aztec/stdlib/trees';
 import {
   BlockHeader,
+  type IndexedTxEffect,
   type PublicSimulationOutput,
   type Tx,
   type TxEffect,
@@ -89,9 +90,9 @@ export class TXENode implements AztecNode {
   /**
    * Gets a tx effect.
    * @param txHash - The hash of the tx corresponding to the tx effect.
-   * @returns The requested tx effect (or undefined if not found) along with its index in the block.
+   * @returns The requested tx effect with block info (or undefined if not found).
    */
-  getTxEffect(txHash: TxHash): Promise<(InBlock<TxEffect> & { txIndexInBlock: number }) | undefined> {
+  getTxEffect(txHash: TxHash): Promise<IndexedTxEffect | undefined> {
     const txEffect = this.#txEffectsByTxHash.get(txHash.toString());
 
     return Promise.resolve(txEffect);

--- a/yarn-project/txe/src/node/txe_node.ts
+++ b/yarn-project/txe/src/node/txe_node.ts
@@ -56,7 +56,7 @@ import type { NativeWorldStateService } from '@aztec/world-state';
 
 export class TXENode implements AztecNode {
   #logsByTags = new Map<string, TxScopedL2Log[]>();
-  #txEffectsByTxHash = new Map<string, InBlock<TxEffect>>();
+  #txEffectsByTxHash = new Map<string, InBlock<TxEffect> & { txIndexInBlock: number }>();
   #txReceiptsByTxHash = new Map<string, TxReceipt>();
   #noteIndex = 0;
 
@@ -87,11 +87,11 @@ export class TXENode implements AztecNode {
   }
 
   /**
-   * Get a tx effect.
-   * @param txHash - The hash of a transaction which resulted in the returned tx effect.
-   * @returns The requested tx effect.
+   * Gets a tx effect.
+   * @param txHash - The txHash of the tx corresponding to the tx effect.
+   * @returns The requested tx effect (or undefined if not found) along with its index in the block.
    */
-  getTxEffect(txHash: TxHash): Promise<InBlock<TxEffect> | undefined> {
+  getTxEffect(txHash: TxHash): Promise<(InBlock<TxEffect> & { txIndexInBlock: number }) | undefined> {
     const txEffect = this.#txEffectsByTxHash.get(txHash.toString());
 
     return Promise.resolve(txEffect);
@@ -100,10 +100,11 @@ export class TXENode implements AztecNode {
   /**
    * Processes a tx effect and receipt for a given block number.
    * @param blockNumber - The block number that this tx effect resides.
+   * @param txIndexInBlock - The index of the tx in the block.
    * @param txHash - The transaction hash of the transaction.
    * @param effect - The tx effect to set.
    */
-  async processTxEffect(blockNumber: number, txHash: TxHash, effect: TxEffect) {
+  async processTxEffect(blockNumber: number, txIndexInBlock: number, txHash: TxHash, effect: TxEffect) {
     // We are not creating real blocks on which membership proofs can be constructed - we instead define its hash as
     // simply the hash of the block number.
     const blockHash = await poseidon2Hash([blockNumber]);
@@ -112,6 +113,7 @@ export class TXENode implements AztecNode {
       l2BlockHash: blockHash.toString(),
       l2BlockNumber: blockNumber,
       data: effect,
+      txIndexInBlock,
     });
 
     // We also set the receipt since we want to be able to serve `getTxReceipt` - we don't care about most values here,

--- a/yarn-project/txe/src/oracle/txe_oracle.ts
+++ b/yarn-project/txe/src/oracle/txe_oracle.ts
@@ -772,7 +772,9 @@ export class TXE implements TypedOracle {
       }
     }
 
-    await this.node.processTxEffect(blockNumber, new TxHash(new Fr(blockNumber)), txEffect);
+    // At this point we always have a single tx in the block so we set the tx index to 0.
+    const txIndexInBlock = 0;
+    await this.node.processTxEffect(blockNumber, txIndexInBlock, new TxHash(new Fr(blockNumber)), txEffect);
 
     const stateReference = await fork.getStateReference();
     const archiveInfo = await fork.getTreeInfo(MerkleTreeId.ARCHIVE);


### PR DESCRIPTION
Partially addresses https://github.com/AztecProtocol/aztec-packages/issues/13335

In this PR I add txIndexInBlock to the response of getTxEffect such that in a follow-up PR I can store that info along with an event log which will then allow me to return event logs in an ordered manner.

Unfortunately the return value of getTxEffect became a bit ugly but introducing a new type for it seemed excessive as it would be used only in that one method.