### PR TITLE
fix: Might fix some npm install issues.

### DIFF
--- a/barretenberg/ts/bootstrap.sh
+++ b/barretenberg/ts/bootstrap.sh
@@ -7,7 +7,7 @@ hash=$(cache_content_hash ../cpp/.rebuild_patterns .rebuild_patterns)
 
 function build {
   echo_header "bb.js build"
-  yarn install
+  npm_install_deps
 
   if ! cache_download bb.js-$hash.tar.gz; then
     find . -exec touch -d "@0" {} + 2>/dev/null || true

--- a/bootstrap.sh
+++ b/bootstrap.sh
@@ -6,7 +6,6 @@
 #   clean: Force a complete clean of the repo. Erases untracked files, be careful!
 # Use ci3 script base.
 source $(git rev-parse --show-toplevel)/ci3/source_bootstrap
-source $ci3/source_redis
 
 # Enable abbreviated output by default.
 export DENOISE=${DENOISE:-1}

--- a/ci3/npm_install_deps
+++ b/ci3/npm_install_deps
@@ -22,7 +22,7 @@ package_json_path=$(realpath package.json --relative-to=$REPO_PATH)
 if [ "$CI" -eq 1 ] && [ -f $HOME/ci-started ]; then
   nm_hash=$(cache_content_hash "^$yarn_lock_path" "^$package_json_path")
   if ! cache_download node-modules-$nm_hash.zst; then
-    denoise "retry 'yarn install --immutable'"
+    denoise "retry 'find . -type d -iname node_modules -not -path "*/node_modules/*" | xargs rm -rf && yarn install --immutable'"
     cache_upload node-modules-$nm_hash.zst $(find . -type d -iname node_modules -not -path "*/node_modules/*")
   fi
 else

--- a/ci3/parallelise
+++ b/ci3/parallelise
@@ -17,7 +17,7 @@ echo "Starting test run with max $jobs jobs..."
 # Otherwise use denoise to display dots and save output to redis.
 if [ -t 1 ]; then
   set +e
-  output=$(parallel $parallel_args --bar "run_test_cmd {}" | DUP=1 cache_log "Test run"; exit ${PIPESTATUS[0]})
+  output=$(parallel $parallel_args --bar "DUMP_FAIL=1 run_test_cmd {}" | DUP=1 cache_log "Test run"; exit ${PIPESTATUS[0]})
   code=$?
   if [ "$code" -ne 0 ]; then
     echo -e "$output"

--- a/ci3/run_test_cmd
+++ b/ci3/run_test_cmd
@@ -135,7 +135,7 @@ function fail {
   track_test $test_hash "$line"
   track_test "failed_tests" "$line"
   echo -e "$line"
-  if [ -t 1 ]; then
+  if [ "${DUMP_FAIL:-0}" -eq 1 ]; then
     cat $tmp_file
     echo -e "$line"
   fi

--- a/ci3/source_bootstrap
+++ b/ci3/source_bootstrap
@@ -2,6 +2,7 @@
 # Usage: source $(git rev-parse --show-toplevel)/ci3/source_bootstrap
 source $(git rev-parse --show-toplevel)/ci3/source
 source $ci3/source_refname
+source $ci3/source_redis
 
 # Filters any test cmd that marked to skip in the .test_patterns.yml file.
 # Then filter through cache to remove previously successfully run tests.


### PR DESCRIPTION
Deletes any node_modules folders before performing yarn installs.
Working theory is that if the download from the cache failed halfway, you might have a half install node_modules folder.
The failure would look like "cache not available" so we then proceed to call yarn install on top of half a node_modules folder.
I suspect this might leave it in an undefined state, even on success, and that could result in a corrupt nm folder then being uploaded to cache and breaking everyone.

Also allows DUMP_FAIL env var which is set when running tests in terminal.
Also fixes redis not being sourced early enough, resulting in parallel attempts to connect.