### PR TITLE
fix: Nondeterminism in constant allocation

### DIFF
--- a/noir/noir-repo.patch
+++ b/noir/noir-repo.patch
@@ -1,14 +1,14 @@
-From b36a50c9cb3cf1c18ae545596a60ff0291e65389 Mon Sep 17 00:00:00 2001
+From 133d79dfc55b53f12f98ff04d5e6e570a880ea94 Mon Sep 17 00:00:00 2001
 From: TomAFrench <tom@tomfren.ch>
 Date: Sat, 15 Mar 2025 15:36:12 +0000
-Subject: [PATCH 2/4] chore: turn on `skipLibCheck`
+Subject: [PATCH 1/4] chore: turn on `skipLibCheck`
 
 ---
  tooling/noir_codegen/tsconfig.json | 1 +
  1 file changed, 1 insertion(+)
 
 diff --git a/tooling/noir_codegen/tsconfig.json b/tooling/noir_codegen/tsconfig.json
-index 30dd2a7e..a2712fd7 100644
+index 30dd2a7..a2712fd 100644
 --- a/tooling/noir_codegen/tsconfig.json
 +++ b/tooling/noir_codegen/tsconfig.json
 @@ -10,6 +10,7 @@
@@ -19,13 +19,13 @@ index 30dd2a7e..a2712fd7 100644
    },
    "include": [
      "src/**/*.ts"
---
+-- 
 2.43.0
 
-From fd8f444eba5db51bee2173d7c2f66bebaa693d30 Mon Sep 17 00:00:00 2001
+From ee8c3e8be962996922078637aaea70fccbadeb5c Mon Sep 17 00:00:00 2001
 From: aakoshh <akosh@aztecprotocol.com>
 Date: Mon, 17 Mar 2025 12:10:58 +0000
-Subject: [PATCH 4/4] Ignore package.tgz
+Subject: [PATCH 2/4] Ignore package.tgz
 
 ---
  .gitignore | 3 +++
@@ -36,11 +36,103 @@ index 3349018..c93fe8e 100644
 --- a/.gitignore
 +++ b/.gitignore
 @@ -59,3 +59,6 @@ codegen
-
+ 
  mutants.out
  mutants.out.old
 +
 +# Artifacts created by `noir/bootstrap.sh build_packages`
 +**/package.tgz
---
+-- 
 2.43.0
+
+From 81a04bb4f515684349084bb20fc24a0f39434aa4 Mon Sep 17 00:00:00 2001
+From: sirasistant <sirasistant@gmail.com>
+Date: Sat, 5 Apr 2025 14:57:05 +0000
+Subject: [PATCH 4/4] nondeterminism fix?
+
+---
+ .../brillig_gen/constant_allocation.rs        | 25 ++++++++++---------
+ 1 file changed, 13 insertions(+), 12 deletions(-)
+
+diff --git a/compiler/noirc_evaluator/src/brillig/brillig_gen/constant_allocation.rs b/compiler/noirc_evaluator/src/brillig/brillig_gen/constant_allocation.rs
+index d49876e..d244b6a 100644
+--- a/compiler/noirc_evaluator/src/brillig/brillig_gen/constant_allocation.rs
++++ b/compiler/noirc_evaluator/src/brillig/brillig_gen/constant_allocation.rs
+@@ -1,7 +1,8 @@
+ //! This module analyzes the usage of constants in a given function and decides an allocation point for them.
+ //! The allocation point will be the common dominator of all the places where the constant is used.
+ //! By allocating in the common dominator, we can cache the constants for all subsequent uses.
+-use fxhash::{FxHashMap as HashMap, FxHashSet as HashSet};
++
++use std::collections::{BTreeMap, BTreeSet};
+ 
+ use crate::ssa::ir::{
+     basic_block::BasicBlockId,
+@@ -16,7 +17,7 @@ use crate::ssa::ir::{
+ 
+ use super::variable_liveness::{collect_variables_of_value, variables_used_in_instruction};
+ 
+-#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
++#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, PartialOrd, Ord)]
+ pub(crate) enum InstructionLocation {
+     Instruction(InstructionId),
+     Terminator,
+@@ -24,10 +25,10 @@ pub(crate) enum InstructionLocation {
+ 
+ #[derive(Default)]
+ pub(crate) struct ConstantAllocation {
+-    constant_usage: HashMap<ValueId, HashMap<BasicBlockId, Vec<InstructionLocation>>>,
+-    allocation_points: HashMap<BasicBlockId, HashMap<InstructionLocation, Vec<ValueId>>>,
++    constant_usage: BTreeMap<ValueId, BTreeMap<BasicBlockId, Vec<InstructionLocation>>>,
++    allocation_points: BTreeMap<BasicBlockId, BTreeMap<InstructionLocation, Vec<ValueId>>>,
+     dominator_tree: DominatorTree,
+-    blocks_within_loops: HashSet<BasicBlockId>,
++    blocks_within_loops: BTreeSet<BasicBlockId>,
+ }
+ 
+ impl ConstantAllocation {
+@@ -37,8 +38,8 @@ impl ConstantAllocation {
+         let mut dominator_tree = DominatorTree::with_cfg_and_post_order(&cfg, &post_order);
+         let blocks_within_loops = find_all_blocks_within_loops(func, &cfg, &mut dominator_tree);
+         let mut instance = ConstantAllocation {
+-            constant_usage: HashMap::default(),
+-            allocation_points: HashMap::default(),
++            constant_usage: BTreeMap::default(),
++            allocation_points: BTreeMap::default(),
+             dominator_tree,
+             blocks_within_loops,
+         };
+@@ -164,7 +165,7 @@ impl ConstantAllocation {
+         current_block
+     }
+ 
+-    pub(crate) fn get_constants(&self) -> HashSet<ValueId> {
++    pub(crate) fn get_constants(&self) -> BTreeSet<ValueId> {
+         self.constant_usage.keys().copied().collect()
+     }
+ }
+@@ -178,8 +179,8 @@ fn find_all_blocks_within_loops(
+     func: &Function,
+     cfg: &ControlFlowGraph,
+     dominator_tree: &mut DominatorTree,
+-) -> HashSet<BasicBlockId> {
+-    let mut blocks_in_loops = HashSet::default();
++) -> BTreeSet<BasicBlockId> {
++    let mut blocks_in_loops = BTreeSet::default();
+     for block_id in func.reachable_blocks() {
+         let block = &func.dfg[block_id];
+         let successors = block.successors();
+@@ -199,8 +200,8 @@ fn find_blocks_in_loop(
+     header: BasicBlockId,
+     back_edge_start: BasicBlockId,
+     cfg: &ControlFlowGraph,
+-) -> HashSet<BasicBlockId> {
+-    let mut blocks = HashSet::default();
++) -> BTreeSet<BasicBlockId> {
++    let mut blocks = BTreeSet::default();
+     blocks.insert(header);
+ 
+     let mut insert = |block, stack: &mut Vec<BasicBlockId>| {
+-- 
+2.43.0
+


### PR DESCRIPTION
Quick fix to an issue discovered in testnet. We were having nondeterministic contract builds between aarch64 and amd64 builds of the noir compiler, reproduced locally. The iterators generated from the FxHashMaps/FxHashSets used in constant_allocation were yielding differently ordered items. I did log the insertions and the input was in the same order (if the insertion ordering was nondeterministic the iteration order is expected to be nondeterministic) so I have no idea what was creating the nondeterminism there. Switched to a BTreeMap/BTreeSet in that file and nondeterminism is gone.