### PR TITLE
fix: txe node should not use base fork for find_leaves_indexes

### DIFF
--- a/.test_patterns.yml
+++ b/.test_patterns.yml
@@ -25,6 +25,7 @@ names:
   - sergei: &sergei "U05RR81391B"
   - spyros: &spyros "U03FCET0DQE"
   - jan: &jan "U03FGA0BWNR"
+  - esau: &esau "U067FJ9A4Q1"
 
 tests:
   # barretenberg
@@ -183,6 +184,11 @@ tests:
     error_regex: "Test timeout of 90000ms exceeded."
     owners:
       - *grego
+
+  - regex: "boxes/scripts/run_test.sh"
+    error_regex: "expect(locator).toBeVisible()"
+    owners:
+      - *esau
 
   # kind tests
   - regex: "spartan/bootstrap.sh"

--- a/yarn-project/txe/src/node/txe_node.ts
+++ b/yarn-project/txe/src/node/txe_node.ts
@@ -201,10 +201,22 @@ export class TXENode implements AztecNode {
     // hold a reference to them.
     // We should likely migrate this so that the trees are owned by the node.
 
-    // TODO: blockNumber is being passed as undefined, figure out why
+    if (blockNumber === undefined) {
+      throw new Error(
+        `This error should never happen. We are trying to 'findLeavesIndexes' in the TXe node with an undefined block number.`,
+      );
+    }
+
+    if (blockNumber === (await this.getBlockNumber())) {
+      throw new Error(
+        `The node is being requested for state that is currently being built (not committed). Note that in the TXe, the blockNumber is not the latest committed block. It's the current pending one.
+        Current block number is: ${blockNumber}.`,
+      );
+    }
+
     const db: MerkleTreeReadOperations =
-      blockNumber === (await this.getBlockNumber()) || blockNumber === 'latest' || blockNumber === undefined
-        ? this.baseFork
+      blockNumber === 'latest'
+        ? this.nativeWorldStateService.getCommitted()
         : this.nativeWorldStateService.getSnapshot(blockNumber);
 
     const maybeIndices = await db.findLeafIndices(


### PR DESCRIPTION
This is a change to unblock defi-wonderland as they're running into some issues after moving more log processing to noir. This will be more or less refactored in a imminent txe rework / cleanup.

The crux of this fix was that `this.baseFork` does not include any block metadata, because it is not checkpointed by `handleL2BlocksAndMessages`. We need to specifically fetch for the `lastCommitted` state, or from `getSnapshot`