### PR TITLE
fix: IVC integration native

### DIFF
--- a/barretenberg/cpp/src/barretenberg/api/api_client_ivc.cpp
+++ b/barretenberg/cpp/src/barretenberg/api/api_client_ivc.cpp
@@ -283,6 +283,11 @@ void ClientIVCAPI::prove(const Flags& flags,
     };
 
     write_proof();
+
+    if (flags.write_vk) {
+        vinfo("writing ClientIVC vk in directory ", output_dir);
+        write_vk_for_ivc(bytecode_path, output_dir);
+    }
 }
 
 bool ClientIVCAPI::verify([[maybe_unused]] const Flags& flags,

--- a/yarn-project/bb-prover/src/bb/execute.ts
+++ b/yarn-project/bb-prover/src/bb/execute.ts
@@ -123,6 +123,7 @@ export async function executeBbClientIvcProof(
   bytecodeStackPath: string,
   witnessStackPath: string,
   log: LogFn,
+  writeVk = false,
 ): Promise<BBFailure | BBSuccess> {
   // Check that the working directory exists
   try {
@@ -158,8 +159,10 @@ export async function executeBbClientIvcProof(
       'client_ivc',
       '--input_type',
       'runtime_stack',
-      '--write_vk',
     ];
+    if (writeVk) {
+      args.push('--write_vk');
+    }
 
     const timer = new Timer();
     const logFunction = (message: string) => {

--- a/yarn-project/ivc-integration/src/native_client_ivc_integration.test.ts
+++ b/yarn-project/ivc-integration/src/native_client_ivc_integration.test.ts
@@ -46,6 +46,7 @@ describe('Client IVC Integration', () => {
       path.join(bbWorkingDirectory, 'acir.msgpack'),
       path.join(bbWorkingDirectory, 'witnesses.msgpack'),
       logger.info,
+      true,
     );
 
     if (provingResult.status === BB_RESULT.FAILURE) {
@@ -59,7 +60,7 @@ describe('Client IVC Integration', () => {
   // 1. Run a mock app that creates two commitments
   // 2. Run the init kernel to process the app run
   // 3. Run the tail kernel to finish the client IVC chain.
-  it.skip('Should generate a verifiable client IVC proof from a simple mock tx', async () => {
+  it('Should generate a verifiable client IVC proof from a simple mock tx', async () => {
     const [bytecodes, witnessStack] = await generate3FunctionTestingIVCStack();
 
     // TODO(https://github.com/AztecProtocol/barretenberg/issues/1296)
@@ -83,7 +84,7 @@ describe('Client IVC Integration', () => {
   // 4. Run the inner kernel to process the second app run
   // 5. Run the reset kernel to process the read request emitted by the reader app
   // 6. Run the tail kernel to finish the client IVC chain
-  it.skip('Should generate a verifiable client IVC proof from a complex mock tx', async () => {
+  it('Should generate a verifiable client IVC proof from a complex mock tx', async () => {
     const [bytecodes, witnessStack] = await generate6FunctionTestingIVCStack();
 
     // TODO(https://github.com/AztecProtocol/barretenberg/issues/1296)


### PR DESCRIPTION
This test suite was broken with the changes to use a hardcoded VK for CIVC verification. This PR fixes the --write-vk flag in CIVC api so we can write the VK in the mock protocol circuits testing. By default write-vk is false.