### PR TITLE
fix: Wait for L1 mint tx on cross chain test harness

### DIFF
--- a/yarn-project/end-to-end/src/shared/cross_chain_test_harness.ts
+++ b/yarn-project/end-to-end/src/shared/cross_chain_test_harness.ts
@@ -232,8 +232,10 @@ export class CrossChainTestHarness {
       address: this.l1TokenManager.tokenAddress.toString(),
       client: this.walletClient,
     });
-    await contract.write.mint([this.ethAccount.toString(), amount]);
-    expect(await this.l1TokenManager.getL1TokenBalance(this.ethAccount.toString())).toEqual(amount);
+    const balanceBefore = await this.l1TokenManager.getL1TokenBalance(this.ethAccount.toString());
+    const hash = await contract.write.mint([this.ethAccount.toString(), amount]);
+    await this.publicClient.waitForTransactionReceipt({ hash });
+    expect(await this.l1TokenManager.getL1TokenBalance(this.ethAccount.toString())).toEqual(balanceBefore + amount);
   }
 
   getL1BalanceOf(address: EthAddress) {


### PR DESCRIPTION
Attempt at fixing flakes where the balance expectation failed:

```
18:22:41   ● e2e_cross_chain_messaging token_bridge_public › Publicly deposit funds from L1 -> L2 and withdraw back to L1
18:22:41
18:22:41     expect(received).toEqual(expected) // deep equality
18:22:41
18:22:41     Expected: 1000000n
18:22:41     Received: 0n
18:22:41
18:22:41       234 |     });
18:22:41       235 |     await contract.write.mint([this.ethAccount.toString(), amount]);
18:22:41     > 236 |     expect(await this.l1TokenManager.getL1TokenBalance(this.ethAccount.toString())).toEqual(amount);
18:22:41           |                                                                                     ^
18:22:41       237 |   }
18:22:41       238 |
18:22:41       239 |   getL1BalanceOf(address: EthAddress) {
18:22:41
18:22:41       at CrossChainTestHarness.toEqual [as mintTokensOnL1] (shared/cross_chain_test_harness.ts:236:85)
18:22:41       at Object.<anonymous> (e2e_cross_chain_messaging/token_bridge_public.test.ts:46:5)
```