### PR TITLE
fix: Don't throw if sequencer gas limit higher than L1

### DIFF
--- a/yarn-project/end-to-end/src/e2e_sequencer_config.test.ts
+++ b/yarn-project/end-to-end/src/e2e_sequencer_config.test.ts
@@ -23,19 +23,6 @@ describe('e2e_sequencer_config', () => {
     jest.restoreAllMocks();
   });
 
-  describe('bad config', () => {
-    it('fails to create sequencer if maxL2BlockGas is less than manaTarget', async () => {
-      const manaTarget = 21e18;
-      await expect(
-        setup(1, {
-          manaTarget: BigInt(manaTarget),
-          // The max is defined as 2x the manaTarget
-          maxL2BlockGas: manaTarget * 3,
-        }),
-      ).rejects.toThrow(/provided maxL2BlockGas of \d+ is greater than the maximum allowed by the L1 \(\d+\)/);
-    });
-  });
-
   describe('Sequencer config', () => {
     const manaTarget = 21e18;
     beforeAll(async () => {

--- a/yarn-project/sequencer-client/src/client/sequencer-client.ts
+++ b/yarn-project/sequencer-client/src/client/sequencer-client.ts
@@ -141,12 +141,13 @@ export class SequencerClient {
 
     const ethereumSlotDuration = config.ethereumSlotDuration;
 
-    const rollupManaLimit = await rollupContract.getManaLimit();
-    const sequencerManaLimit = config.maxL2BlockGas ?? Number(rollupManaLimit);
-    if (sequencerManaLimit > Number(rollupManaLimit)) {
-      throw new Error(
-        `provided maxL2BlockGas of ${sequencerManaLimit} is greater than the maximum allowed by the L1 (${rollupManaLimit})`,
+    const rollupManaLimit = Number(await rollupContract.getManaLimit());
+    let sequencerManaLimit = config.maxL2BlockGas ?? rollupManaLimit;
+    if (sequencerManaLimit > rollupManaLimit) {
+      log.warn(
+        `Provided maxL2BlockGas of ${sequencerManaLimit} is greater than the maximum allowed by the L1 (${rollupManaLimit}), setting limit to ${rollupManaLimit}`,
       );
+      sequencerManaLimit = rollupManaLimit;
     }
 
     // When running in anvil, assume we can post a tx up until the very last second of an L1 slot.


### PR DESCRIPTION
We no longer throw if the sequener's configured gas limit is higher than L1. We simply log a warning
