### PR TITLE
chore: cli calls staking handler

### DIFF
--- a/yarn-project/cli/src/cmds/l1/update_l1_validators.ts
+++ b/yarn-project/cli/src/cmds/l1/update_l1_validators.ts
@@ -8,7 +8,7 @@ import {
 } from '@aztec/ethereum';
 import type { EthAddress } from '@aztec/foundation/eth-address';
 import type { LogFn, Logger } from '@aztec/foundation/log';
-import { ForwarderAbi, ForwarderBytecode, RollupAbi, TestERC20Abi } from '@aztec/l1-artifacts';
+import { ForwarderAbi, ForwarderBytecode, RollupAbi, StakingAssetHandlerAbi } from '@aztec/l1-artifacts';
 
 import { createPublicClient, createWalletClient, fallback, getContract, http } from 'viem';
 import { generatePrivateKey, mnemonicToAccount, privateKeyToAccount } from 'viem/accounts';
@@ -19,7 +19,7 @@ export interface RollupCommandArgs {
   privateKey?: string;
   mnemonic?: string;
   rollupAddress: EthAddress;
-  withdrawerAddress?: EthAddress;
+  stakingAssetHandlerAddress: EthAddress;
 }
 
 export interface LoggerArgs {
@@ -43,8 +43,7 @@ export async function addL1Validator({
   privateKey,
   mnemonic,
   validatorAddress,
-  rollupAddress,
-  withdrawerAddress,
+  stakingAssetHandlerAddress,
   log,
   debugLogger,
 }: RollupCommandArgs & LoggerArgs & { validatorAddress: EthAddress }) {
@@ -52,33 +51,18 @@ export async function addL1Validator({
   const dualLog = makeDualLog(log, debugLogger);
   const publicClient = getPublicClient(rpcUrls, chainId);
   const walletClient = getWalletClient(rpcUrls, chainId, privateKey, mnemonic);
-  const rollup = getContract({
-    address: rollupAddress.toString(),
-    abi: RollupAbi,
+  const stakingAssetHandler = getContract({
+    address: stakingAssetHandlerAddress.toString(),
+    abi: StakingAssetHandlerAbi,
     client: walletClient,
   });
 
-  const stakingAsset = getContract({
-    address: await rollup.read.getStakingAsset(),
-    abi: TestERC20Abi,
-    client: walletClient,
-  });
-
-  await Promise.all(
-    [
-      await stakingAsset.write.mint([walletClient.account.address, config.minimumStake], {} as any),
-      await stakingAsset.write.approve([rollupAddress.toString(), config.minimumStake], {} as any),
-    ].map(txHash => publicClient.waitForTransactionReceipt({ hash: txHash })),
-  );
-
-  dualLog(`Adding validator ${validatorAddress.toString()} to rollup ${rollupAddress.toString()}`);
-  const txHash = await rollup.write.deposit([
+  dualLog(`Adding validator ${validatorAddress.toString()} to rollup`);
+  const txHash = await stakingAssetHandler.write.addValidator([
     validatorAddress.toString(),
     // TODO(#11451): custom forwarders
     getExpectedAddress(ForwarderAbi, ForwarderBytecode, [validatorAddress.toString()], validatorAddress.toString())
       .address,
-    withdrawerAddress?.toString() ?? validatorAddress.toString(),
-    config.minimumStake,
   ]);
   dualLog(`Transaction hash: ${txHash}`);
   await publicClient.waitForTransactionReceipt({ hash: txHash });


### PR DESCRIPTION
In add-l1-validator cli command, we go through the staking asset handler contract instead of directly via the rollup. 