### PR TITLE
fix: `PXE::getPrivateEvents(...)` ordering

### DIFF
--- a/noir-projects/aztec-nr/aztec/src/discovery/pending_tagged_log.nr
+++ b/noir-projects/aztec-nr/aztec/src/discovery/pending_tagged_log.nr
@@ -19,6 +19,7 @@ pub(crate) struct PendingTaggedLog {
     pub first_nullifier_in_tx: Field,
     pub recipient: AztecAddress,
     pub log_index_in_tx: Field,
+    pub tx_index_in_block: Field,
 }
 
 mod test {
@@ -33,6 +34,7 @@ mod test {
         let first_nullifier = 6;
         let recipient = AztecAddress::from_field(789);
         let log_index_in_tx = 10;
+        let tx_index_in_block = 11;
         let pending_log = PendingTaggedLog {
             log,
             tx_hash,
@@ -40,6 +42,7 @@ mod test {
             first_nullifier_in_tx: first_nullifier,
             recipient,
             log_index_in_tx,
+            tx_index_in_block,
         };
 
         let serialized = pending_log.serialize();
@@ -135,6 +138,7 @@ mod test {
             0x0000000000000000000000000000000000000000000000000000000000000006,
             0x0000000000000000000000000000000000000000000000000000000000000315,
             0x000000000000000000000000000000000000000000000000000000000000000a,
+            0x000000000000000000000000000000000000000000000000000000000000000b,
         ];
 
         assert_eq(serialized, serialized_pending_tagged_log_from_typescript);

--- a/noir-projects/aztec-nr/aztec/src/discovery/private_logs.nr
+++ b/noir-projects/aztec-nr/aztec/src/discovery/private_logs.nr
@@ -125,6 +125,7 @@ unconstrained fn process_log<Env>(
             msg_content,
             pending_tagged_log.tx_hash,
             pending_tagged_log.log_index_in_tx,
+            pending_tagged_log.tx_index_in_block,
         );
     } else {
         debug_log_format("Unknown msg type id {0}", [msg_type_id as Field]);

--- a/noir-projects/aztec-nr/aztec/src/oracle/logs.nr
+++ b/noir-projects/aztec-nr/aztec/src/oracle/logs.nr
@@ -24,6 +24,7 @@ pub unconstrained fn store_private_event_log(
     msg_content: BoundedVec<Field, MAX_MESSAGE_CONTENT_LEN>,
     tx_hash: Field,
     log_index_in_tx: Field,
+    tx_index_in_block: Field,
 ) {
     store_private_event_log_oracle(
         contract_address,
@@ -32,6 +33,7 @@ pub unconstrained fn store_private_event_log(
         msg_content,
         tx_hash,
         log_index_in_tx,
+        tx_index_in_block,
     )
 }
 
@@ -43,4 +45,5 @@ unconstrained fn store_private_event_log_oracle(
     msg_content: BoundedVec<Field, MAX_MESSAGE_CONTENT_LEN>,
     tx_hash: Field,
     log_index_in_tx: Field,
+    tx_index_in_block: Field,
 ) {}

--- a/yarn-project/pxe/src/pxe_oracle_interface/pxe_oracle_interface.ts
+++ b/yarn-project/pxe/src/pxe_oracle_interface/pxe_oracle_interface.ts
@@ -603,6 +603,7 @@ export class PXEOracleInterface implements ExecutionDataProvider {
           txEffect.data.nullifiers[0],
           recipient,
           scopedLog.logIndexInTx,
+          txEffect.txIndexInBlock,
         );
 
         return pendingTaggedLog.toFields();
@@ -808,6 +809,7 @@ export class PXEOracleInterface implements ExecutionDataProvider {
     msgContent: Fr[],
     txHash: TxHash,
     logIndexInTx: number,
+    txIndexInBlock: number,
   ): Promise<void> {
     const txReceipt = await this.aztecNode.getTxReceipt(txHash);
     const blockNumber = txReceipt.blockNumber;
@@ -827,6 +829,7 @@ export class PXEOracleInterface implements ExecutionDataProvider {
       msgContent,
       txHash,
       logIndexInTx,
+      txIndexInBlock,
       blockNumber,
     );
   }

--- a/yarn-project/pxe/src/storage/private_event_data_provider/private_event_data_provider.test.ts
+++ b/yarn-project/pxe/src/storage/private_event_data_provider/private_event_data_provider.test.ts
@@ -20,6 +20,7 @@ describe('PrivateEventDataProvider', () => {
   let eventSelector: EventSelector;
   let txHash: TxHash;
   let logIndexInTx: number;
+  let txIndexInBlock: number;
 
   beforeEach(async () => {
     const store = await openTmpStore('private_event_data_provider_test');
@@ -31,6 +32,7 @@ describe('PrivateEventDataProvider', () => {
     eventSelector = EventSelector.random();
     txHash = TxHash.random();
     logIndexInTx = randomInt(10);
+    txIndexInBlock = randomInt(10);
   });
 
   it('stores and retrieves private events', async () => {
@@ -41,6 +43,7 @@ describe('PrivateEventDataProvider', () => {
       msgContent,
       txHash,
       logIndexInTx,
+      txIndexInBlock,
       blockNumber,
     );
     const events = await privateEventDataProvider.getPrivateEvents(
@@ -61,6 +64,7 @@ describe('PrivateEventDataProvider', () => {
       msgContent,
       txHash,
       logIndexInTx,
+      txIndexInBlock,
       blockNumber,
     );
     await privateEventDataProvider.storePrivateEventLog(
@@ -70,6 +74,7 @@ describe('PrivateEventDataProvider', () => {
       msgContent,
       txHash,
       logIndexInTx,
+      txIndexInBlock,
       blockNumber,
     );
     const events = await privateEventDataProvider.getPrivateEvents(
@@ -91,6 +96,7 @@ describe('PrivateEventDataProvider', () => {
       msgContent,
       txHash,
       logIndexInTx,
+      txIndexInBlock,
       blockNumber,
     );
     await privateEventDataProvider.storePrivateEventLog(
@@ -100,6 +106,7 @@ describe('PrivateEventDataProvider', () => {
       msgContent,
       otherTxHash,
       logIndexInTx,
+      txIndexInBlock,
       blockNumber,
     );
     const events = await privateEventDataProvider.getPrivateEvents(
@@ -120,6 +127,7 @@ describe('PrivateEventDataProvider', () => {
       getRandomMsgContent(),
       TxHash.random(),
       logIndexInTx,
+      txIndexInBlock,
       100,
     );
     await privateEventDataProvider.storePrivateEventLog(
@@ -129,6 +137,7 @@ describe('PrivateEventDataProvider', () => {
       msgContent,
       TxHash.random(),
       logIndexInTx,
+      txIndexInBlock,
       200,
     );
     await privateEventDataProvider.storePrivateEventLog(
@@ -138,6 +147,7 @@ describe('PrivateEventDataProvider', () => {
       getRandomMsgContent(),
       TxHash.random(),
       logIndexInTx,
+      txIndexInBlock,
       300,
     );
 
@@ -161,6 +171,7 @@ describe('PrivateEventDataProvider', () => {
       msgContent,
       txHash,
       logIndexInTx,
+      txIndexInBlock,
       blockNumber,
     );
     await privateEventDataProvider.storePrivateEventLog(
@@ -170,6 +181,7 @@ describe('PrivateEventDataProvider', () => {
       msgContent,
       TxHash.random(),
       logIndexInTx,
+      txIndexInBlock,
       blockNumber,
     );
 
@@ -204,6 +216,7 @@ describe('PrivateEventDataProvider', () => {
       msgContent,
       txHash,
       logIndexInTx,
+      txIndexInBlock,
       blockNumber,
     );
     expect(await privateEventDataProvider.getSize()).toBe(1);
@@ -215,6 +228,7 @@ describe('PrivateEventDataProvider', () => {
       msgContent,
       txHash,
       logIndexInTx,
+      txIndexInBlock,
       blockNumber,
     );
     expect(await privateEventDataProvider.getSize()).toBe(1); // Duplicate event not stored
@@ -226,6 +240,7 @@ describe('PrivateEventDataProvider', () => {
       msgContent,
       TxHash.random(),
       logIndexInTx,
+      txIndexInBlock,
       blockNumber,
     );
     expect(await privateEventDataProvider.getSize()).toBe(2);

--- a/yarn-project/pxe/src/storage/private_event_data_provider/private_event_data_provider.ts
+++ b/yarn-project/pxe/src/storage/private_event_data_provider/private_event_data_provider.ts
@@ -12,6 +12,7 @@ interface PrivateEventEntry {
   msgContent: Buffer;
   blockNumber: number;
   logIndexInTx: number;
+  txIndexInBlock: number;
 }
 
 /**
@@ -46,6 +47,7 @@ export class PrivateEventDataProvider implements DataProvider {
    * @param msgContent - The content of the event.
    * @param txHash - The transaction hash of the event log.
    * @param logIndexInTx - The index of the log within the transaction.
+   * @param txIndexInBlock - The index of the transaction in which the log was emitted in the block.
    * @param blockNumber - The block number in which the event was emitted.
    */
   storePrivateEventLog(
@@ -55,6 +57,7 @@ export class PrivateEventDataProvider implements DataProvider {
     msgContent: Fr[],
     txHash: TxHash,
     logIndexInTx: number,
+    txIndexInBlock: number,
     blockNumber: number,
   ): Promise<void> {
     return this.#store.transactionAsync(async () => {
@@ -73,7 +76,12 @@ export class PrivateEventDataProvider implements DataProvider {
       this.logger.verbose('storing private event log', { contractAddress, recipient, msgContent, blockNumber });
 
       const index = await this.#eventLogs.lengthAsync();
-      await this.#eventLogs.push({ msgContent: serializeToBuffer(msgContent), blockNumber, logIndexInTx });
+      await this.#eventLogs.push({
+        msgContent: serializeToBuffer(msgContent),
+        blockNumber,
+        logIndexInTx,
+        txIndexInBlock,
+      });
 
       const existingIndices = (await this.#eventLogIndex.getAsync(key)) || [];
       await this.#eventLogIndex.set(key, [...existingIndices, index]);
@@ -99,7 +107,7 @@ export class PrivateEventDataProvider implements DataProvider {
     recipients: AztecAddress[],
     eventSelector: EventSelector,
   ): Promise<Fr[][]> {
-    const events: Array<{ msgContent: Fr[]; blockNumber: number; logIndexInTx: number }> = [];
+    const events: Array<{ msgContent: Fr[]; blockNumber: number; logIndexInTx: number; txIndexInBlock: number }> = [];
 
     for (const recipient of recipients) {
       const key = `${contractAddress.toString()}_${recipient.toString()}_${eventSelector.toString()}`;
@@ -116,14 +124,22 @@ export class PrivateEventDataProvider implements DataProvider {
         const numFields = entry.msgContent.length / Fr.SIZE_IN_BYTES;
         const msgContent = reader.readArray(numFields, Fr);
 
-        events.push({ msgContent, blockNumber: entry.blockNumber, logIndexInTx: entry.logIndexInTx });
+        events.push({
+          msgContent,
+          blockNumber: entry.blockNumber,
+          logIndexInTx: entry.logIndexInTx,
+          txIndexInBlock: entry.txIndexInBlock,
+        });
       }
     }
 
-    // Sort by block number first, then by logIndexInTx (note that we currently don't order by txs within a block)
+    // Sort by block number first, then by txIndexInBlock, then by logIndexInTx
     events.sort((a, b) => {
       if (a.blockNumber !== b.blockNumber) {
         return a.blockNumber - b.blockNumber;
+      }
+      if (a.txIndexInBlock !== b.txIndexInBlock) {
+        return a.txIndexInBlock - b.txIndexInBlock;
       }
       return a.logIndexInTx - b.logIndexInTx;
     });

--- a/yarn-project/simulator/src/private/acvm/oracle/oracle.ts
+++ b/yarn-project/simulator/src/private/acvm/oracle/oracle.ts
@@ -500,6 +500,7 @@ export class Oracle {
     [msgContentLength]: ACVMField[],
     [txHash]: ACVMField[],
     [logIndexInTx]: ACVMField[],
+    [txIndexInBlock]: ACVMField[],
   ) {
     await this.typedOracle.storePrivateEventLog(
       AztecAddress.fromField(Fr.fromString(contractAddress)),
@@ -508,6 +509,7 @@ export class Oracle {
       fromBoundedVec(msgContentBVecStorage, msgContentLength),
       new TxHash(Fr.fromString(txHash)),
       Fr.fromString(logIndexInTx).toNumber(),
+      Fr.fromString(txIndexInBlock).toNumber(),
     );
     return [];
   }

--- a/yarn-project/simulator/src/private/acvm/oracle/typed_oracle.ts
+++ b/yarn-project/simulator/src/private/acvm/oracle/typed_oracle.ts
@@ -266,6 +266,7 @@ export abstract class TypedOracle {
     _logContent: Fr[],
     _txHash: TxHash,
     _logIndexInTx: number,
+    _txIndexInBlock: number,
   ): Promise<void> {
     return Promise.reject(new OracleMethodNotAvailableError('storePrivateEventLog'));
   }

--- a/yarn-project/simulator/src/private/execution_data_provider.ts
+++ b/yarn-project/simulator/src/private/execution_data_provider.ts
@@ -332,6 +332,7 @@ export interface ExecutionDataProvider extends CommitmentsDBInterface {
    * @param msgContent - The content of the private event message.
    * @param txHash - The hash of the transaction that emitted the log.
    * @param logIndexInTx - The index of the log within the transaction.
+   * @param txIndexInBlock - The index of the transaction in which the log was emitted in the block.
    */
   storePrivateEventLog(
     contractAddress: AztecAddress,
@@ -340,5 +341,6 @@ export interface ExecutionDataProvider extends CommitmentsDBInterface {
     msgContent: Fr[],
     txHash: TxHash,
     logIndexInTx: number,
+    txIndexInBlock: number,
   ): Promise<void>;
 }

--- a/yarn-project/simulator/src/private/utility_execution_oracle.ts
+++ b/yarn-project/simulator/src/private/utility_execution_oracle.ts
@@ -373,6 +373,7 @@ export class UtilityExecutionOracle extends TypedOracle {
     msgContent: Fr[],
     txHash: TxHash,
     logIndexInTx: number,
+    txIndexInBlock: number,
   ): Promise<void> {
     return this.executionDataProvider.storePrivateEventLog(
       contractAddress,
@@ -381,6 +382,7 @@ export class UtilityExecutionOracle extends TypedOracle {
       msgContent,
       txHash,
       logIndexInTx,
+      txIndexInBlock,
     );
   }
 }

--- a/yarn-project/stdlib/src/logs/pending_tagged_log.test.ts
+++ b/yarn-project/stdlib/src/logs/pending_tagged_log.test.ts
@@ -13,8 +13,17 @@ describe('PendingTaggedLog', () => {
     const firstNullifier = new Fr(6n);
     const recipient = AztecAddress.fromField(new Fr(789n));
     const logIndexInTx = 10;
+    const txIndexInBlock = 11;
 
-    const pendingLog = new PendingTaggedLog(log, txHash, uniqueNoteHashes, firstNullifier, recipient, logIndexInTx);
+    const pendingLog = new PendingTaggedLog(
+      log,
+      txHash,
+      uniqueNoteHashes,
+      firstNullifier,
+      recipient,
+      logIndexInTx,
+      txIndexInBlock,
+    );
     const serialized = pendingLog.toFields();
 
     // Test against snapshot
@@ -108,6 +117,7 @@ describe('PendingTaggedLog', () => {
         "0x0000000000000000000000000000000000000000000000000000000000000006",
         "0x0000000000000000000000000000000000000000000000000000000000000315",
         "0x000000000000000000000000000000000000000000000000000000000000000a",
+        "0x000000000000000000000000000000000000000000000000000000000000000b",
       ]
     `);
 

--- a/yarn-project/stdlib/src/logs/pending_tagged_log.ts
+++ b/yarn-project/stdlib/src/logs/pending_tagged_log.ts
@@ -16,6 +16,7 @@ export class PendingTaggedLog {
     public firstNullifierInTx: Fr,
     public recipient: AztecAddress,
     public logIndexInTx: number,
+    public txIndexInBlock: number,
   ) {}
 
   toFields(): Fr[] {
@@ -26,6 +27,7 @@ export class PendingTaggedLog {
       this.firstNullifierInTx,
       this.recipient.toField(),
       new Fr(this.logIndexInTx),
+      new Fr(this.txIndexInBlock),
     ];
   }
 }

--- a/yarn-project/txe/src/oracle/txe_oracle.ts
+++ b/yarn-project/txe/src/oracle/txe_oracle.ts
@@ -1258,6 +1258,7 @@ export class TXE implements TypedOracle {
     logContent: Fr[],
     txHash: TxHash,
     logIndexInTx: number,
+    txIndexInBlock: number,
   ): Promise<void> {
     return this.pxeOracleInterface.storePrivateEventLog(
       contractAddress,
@@ -1266,6 +1267,7 @@ export class TXE implements TypedOracle {
       logContent,
       txHash,
       logIndexInTx,
+      txIndexInBlock,
     );
   }
 }

--- a/yarn-project/txe/src/txe_service/txe_service.ts
+++ b/yarn-project/txe/src/txe_service/txe_service.ts
@@ -642,6 +642,7 @@ export class TXEService {
     logContent: ForeignCallArray,
     txHash: ForeignCallSingle,
     logIndexInTx: ForeignCallSingle,
+    txIndexInBlock: ForeignCallSingle,
   ) {
     await this.typedOracle.storePrivateEventLog(
       AztecAddress.fromField(fromSingle(contractAddress)),
@@ -650,6 +651,7 @@ export class TXEService {
       fromArray(logContent),
       new TxHash(fromSingle(txHash)),
       fromSingle(logIndexInTx).toNumber(),
+      fromSingle(txIndexInBlock).toNumber(),
     );
     return toForeignCallResult([]);
   }


### PR DESCRIPTION
Fixes https://github.com/AztecProtocol/aztec-packages/issues/13335

We didn't return events from getPrivateEvents in ordering in which they were emitted because we didn't have txIndexInBlock info before. That info got propagated in a [PR down the stack](https://github.com/AztecProtocol/aztec-packages/pull/13336) and in this PR I am leveraging that to fix the ordering.
