### PR TITLE
test: `e2e_note_getter` not using `DocsExampleContract`

### DIFF
--- a/noir-projects/noir-contracts/Nargo.toml
+++ b/noir-projects/noir-contracts/Nargo.toml
@@ -38,6 +38,7 @@ members = [
     "contracts/test/child_contract",
     "contracts/test/counter_contract",
     "contracts/test/import_test_contract",
+    "contracts/test/note_getter_contract",
     "contracts/test/parent_contract",
     "contracts/test/pending_note_hashes_contract",
     "contracts/test/spam_contract",

--- a/noir-projects/noir-contracts/contracts/docs/docs_example_contract/src/main.nr
+++ b/noir-projects/noir-contracts/contracts/docs/docs_example_contract/src/main.nr
@@ -194,28 +194,6 @@ pub contract DocsExample {
         ));
     }
 
-    #[private]
-    fn insert_notes(amounts: [u8; 3]) {
-        for i in 0..amounts.len() {
-            let note = CardNote::new(amounts[i], 1, context.msg_sender());
-            storage.set.insert(note).emit(encode_and_encrypt_note(
-                &mut context,
-                context.msg_sender(),
-                context.msg_sender(),
-            ));
-        }
-    }
-    #[private]
-    fn insert_note(amount: u8, randomness: Field) {
-        let note = CardNote::new(amount, randomness, context.msg_sender());
-
-        storage.set.insert(note).emit(encode_and_encrypt_note(
-            &mut context,
-            context.msg_sender(),
-            context.msg_sender(),
-        ));
-    }
-
     // docs:start:state_vars-NoteGetterOptionsComparatorExampleNoir
     #[utility]
     unconstrained fn read_note(comparator: u8, amount: Field) -> BoundedVec<CardNote, 10> {

--- a/noir-projects/noir-contracts/contracts/test/note_getter_contract/Nargo.toml
+++ b/noir-projects/noir-contracts/contracts/test/note_getter_contract/Nargo.toml
@@ -1,0 +1,9 @@
+[package]
+name = "note_getter_contract"
+authors = [""]
+compiler_version = ">=0.25.0"
+type = "contract"
+
+[dependencies]
+aztec = { path = "../../../../aztec-nr/aztec" }
+value_note = { path = "../../../../aztec-nr/value-note" }

--- a/noir-projects/noir-contracts/contracts/test/note_getter_contract/src/main.nr
+++ b/noir-projects/noir-contracts/contracts/test/note_getter_contract/src/main.nr
@@ -1,6 +1,6 @@
 use aztec::macros::aztec;
 
-/// Used to test note getter functionality
+/// Used to test note getter in e2e_note_getter.test.ts
 #[aztec]
 pub contract NoteGetter {
     use aztec::{

--- a/noir-projects/noir-contracts/contracts/test/note_getter_contract/src/main.nr
+++ b/noir-projects/noir-contracts/contracts/test/note_getter_contract/src/main.nr
@@ -31,18 +31,6 @@ pub contract NoteGetter {
         ));
     }
 
-    #[private]
-    fn insert_notes(values: [Field; 3]) {
-        for i in 0..values.len() {
-            let note = ValueNote::new(values[i], context.msg_sender());
-            storage.set.insert(note).emit(encode_and_encrypt_note(
-                &mut context,
-                context.msg_sender(),
-                context.msg_sender(),
-            ));
-        }
-    }
-
     #[utility]
     unconstrained fn read_note_values(comparator: u8, value: Field) -> BoundedVec<Field, 10> {
         let mut options = NoteViewerOptions::new();

--- a/noir-projects/noir-contracts/contracts/test/note_getter_contract/src/main.nr
+++ b/noir-projects/noir-contracts/contracts/test/note_getter_contract/src/main.nr
@@ -44,8 +44,13 @@ pub contract NoteGetter {
     }
 
     #[utility]
-    unconstrained fn read_note(comparator: u8, value: Field) -> BoundedVec<ValueNote, 10> {
+    unconstrained fn read_note_values(comparator: u8, value: Field) -> BoundedVec<Field, 10> {
         let mut options = NoteViewerOptions::new();
-        storage.set.view_notes(options.select(ValueNote::properties().value, comparator, value))
+        let notes = storage.set.view_notes(options.select(
+            ValueNote::properties().value,
+            comparator,
+            value,
+        ));
+        notes.map(|note| note.value())
     }
 }

--- a/noir-projects/noir-contracts/contracts/test/note_getter_contract/src/main.nr
+++ b/noir-projects/noir-contracts/contracts/test/note_getter_contract/src/main.nr
@@ -33,8 +33,7 @@ pub contract NoteGetter {
 
     #[utility]
     unconstrained fn read_note_values(comparator: u8, value: Field) -> BoundedVec<Field, 10> {
-        let mut options = NoteViewerOptions::new();
-        let notes = storage.set.view_notes(options.select(
+        let notes = storage.set.view_notes(NoteViewerOptions::new().select(
             ValueNote::properties().value,
             comparator,
             value,

--- a/noir-projects/noir-contracts/contracts/test/note_getter_contract/src/main.nr
+++ b/noir-projects/noir-contracts/contracts/test/note_getter_contract/src/main.nr
@@ -1,0 +1,51 @@
+use aztec::macros::aztec;
+
+/// Used to test note getter functionality
+#[aztec]
+pub contract NoteGetter {
+    use aztec::{
+        // Core functionality
+        encrypted_logs::log_assembly_strategies::default_aes128::note::encode_and_encrypt_note,
+        note::note_interface::NoteProperties,
+        // Macros
+        macros::{functions::{private, utility}, storage::storage},
+        // Prelude types
+        prelude::{NoteViewerOptions, PrivateSet},
+    };
+
+    use value_note::value_note::ValueNote;
+
+    #[storage]
+    struct Storage<Context> {
+        set: PrivateSet<ValueNote, Context>,
+    }
+
+    #[private]
+    fn insert_note(value: Field) {
+        let note = ValueNote::new(value, context.msg_sender());
+
+        storage.set.insert(note).emit(encode_and_encrypt_note(
+            &mut context,
+            context.msg_sender(),
+            context.msg_sender(),
+        ));
+    }
+
+    #[private]
+    fn insert_notes(values: [Field; 3]) {
+        for i in 0..values.len() {
+            let note = ValueNote::new(values[i], context.msg_sender());
+            storage.set.insert(note).emit(encode_and_encrypt_note(
+                &mut context,
+                context.msg_sender(),
+                context.msg_sender(),
+            ));
+        }
+    }
+
+    #[utility]
+    unconstrained fn read_note(comparator: u8, value: Field) -> BoundedVec<ValueNote, 10> {
+        let mut options = NoteViewerOptions::new();
+        storage.set.view_notes(options.select(ValueNote::properties().value, comparator, value))
+    }
+}

--- a/yarn-project/end-to-end/src/e2e_note_getter.test.ts
+++ b/yarn-project/end-to-end/src/e2e_note_getter.test.ts
@@ -1,4 +1,4 @@
-import { type AztecAddress, Comparator, Fr, type Wallet } from '@aztec/aztec.js';
+import { type AztecAddress, Comparator, type Wallet } from '@aztec/aztec.js';
 import { NoteGetterContract } from '@aztec/noir-contracts.js/NoteGetter';
 import { TestContract } from '@aztec/noir-contracts.js/Test';
 
@@ -12,9 +12,6 @@ interface NoirBoundedVec<T> {
 function boundedVecToArray<T>(boundedVec: NoirBoundedVec<T>): T[] {
   return boundedVec.storage.slice(0, Number(boundedVec.len));
 }
-
-const sortFunc = (a: any, b: any) =>
-  a.points > b.points ? 1 : a.points < b.points ? -1 : a.randomness > b.randomness ? 1 : -1;
 
 describe('e2e_note_getter', () => {
   let wallet: Wallet;
@@ -50,102 +47,27 @@ describe('e2e_note_getter', () => {
       await contract.methods.insert_note(5).send().wait();
 
       const [returnEq, returnNeq, returnLt, returnGt, returnLte, returnGte] = await Promise.all([
-        contract.methods.read_note(Comparator.EQ, 5).simulate(),
-        contract.methods.read_note(Comparator.NEQ, 5).simulate(),
-        contract.methods.read_note(Comparator.LT, 5).simulate(),
-        contract.methods.read_note(Comparator.GT, 5).simulate(),
-        contract.methods.read_note(Comparator.LTE, 5).simulate(),
+        contract.methods.read_note_values(Comparator.EQ, 5).simulate(),
+        contract.methods.read_note_values(Comparator.NEQ, 5).simulate(),
+        contract.methods.read_note_values(Comparator.LT, 5).simulate(),
+        contract.methods.read_note_values(Comparator.GT, 5).simulate(),
+        contract.methods.read_note_values(Comparator.LTE, 5).simulate(),
         // docs:start:state_vars-NoteGetterOptionsComparatorExampleTs
-        contract.methods.read_note(Comparator.GTE, 5).simulate(),
+        contract.methods.read_note_values(Comparator.GTE, 5).simulate(),
         // docs:end:state_vars-NoteGetterOptionsComparatorExampleTs
       ]);
 
-      expect(
-        boundedVecToArray(returnEq)
-          .map(({ points, randomness }: any) => ({ points, randomness }))
-          .sort(sortFunc),
-      ).toStrictEqual(
-        [
-          { points: 5n, randomness: 1n },
-          { points: 5n, randomness: 0n },
-        ].sort(sortFunc),
-      );
+      expect(boundedVecToArray(returnEq).sort()).toStrictEqual([5n, 5n].sort());
 
-      expect(
-        boundedVecToArray(returnNeq)
-          .map(({ points, randomness }: any) => ({ points, randomness }))
-          .sort(sortFunc),
-      ).toStrictEqual(
-        [
-          { points: 0n, randomness: 1n },
-          { points: 1n, randomness: 1n },
-          { points: 7n, randomness: 1n },
-          { points: 9n, randomness: 1n },
-          { points: 2n, randomness: 1n },
-          { points: 6n, randomness: 1n },
-          { points: 8n, randomness: 1n },
-          { points: 4n, randomness: 1n },
-          { points: 3n, randomness: 1n },
-        ].sort(sortFunc),
-      );
+      expect(boundedVecToArray(returnNeq).sort()).toStrictEqual([0n, 1n, 2n, 3n, 4n, 6n, 7n, 8n, 9n].sort());
 
-      expect(
-        boundedVecToArray(returnLt)
-          .map(({ points, randomness }: any) => ({ points, randomness }))
-          .sort(sortFunc),
-      ).toStrictEqual(
-        [
-          { points: 0n, randomness: 1n },
-          { points: 1n, randomness: 1n },
-          { points: 2n, randomness: 1n },
-          { points: 4n, randomness: 1n },
-          { points: 3n, randomness: 1n },
-        ].sort(sortFunc),
-      );
+      expect(boundedVecToArray(returnLt).sort()).toStrictEqual([0n, 1n, 2n, 3n, 4n].sort());
 
-      expect(
-        boundedVecToArray(returnGt)
-          .map(({ points, randomness }: any) => ({ points, randomness }))
-          .sort(sortFunc),
-      ).toStrictEqual(
-        [
-          { points: 7n, randomness: 1n },
-          { points: 9n, randomness: 1n },
-          { points: 6n, randomness: 1n },
-          { points: 8n, randomness: 1n },
-        ].sort(sortFunc),
-      );
+      expect(boundedVecToArray(returnGt).sort()).toStrictEqual([6n, 7n, 8n, 9n].sort());
 
-      expect(
-        boundedVecToArray(returnLte)
-          .map(({ points, randomness }: any) => ({ points, randomness }))
-          .sort(sortFunc),
-      ).toStrictEqual(
-        [
-          { points: 5n, randomness: 1n },
-          { points: 5n, randomness: 0n },
-          { points: 0n, randomness: 1n },
-          { points: 1n, randomness: 1n },
-          { points: 2n, randomness: 1n },
-          { points: 4n, randomness: 1n },
-          { points: 3n, randomness: 1n },
-        ].sort(sortFunc),
-      );
+      expect(boundedVecToArray(returnLte).sort()).toStrictEqual([0n, 1n, 2n, 3n, 4n, 5n, 5n].sort());
 
-      expect(
-        boundedVecToArray(returnGte)
-          .map(({ points, randomness }: any) => ({ points, randomness }))
-          .sort(sortFunc),
-      ).toStrictEqual(
-        [
-          { points: 5n, randomness: 0n },
-          { points: 5n, randomness: 1n },
-          { points: 7n, randomness: 1n },
-          { points: 9n, randomness: 1n },
-          { points: 6n, randomness: 1n },
-          { points: 8n, randomness: 1n },
-        ].sort(sortFunc),
-      );
+      expect(boundedVecToArray(returnGte).sort()).toStrictEqual([5n, 5n, 6n, 7n, 8n, 9n].sort());
     });
   });
 

--- a/yarn-project/end-to-end/src/e2e_note_getter.test.ts
+++ b/yarn-project/end-to-end/src/e2e_note_getter.test.ts
@@ -31,17 +31,13 @@ describe('e2e_note_getter', () => {
     });
 
     it('inserts notes from 0-9, then makes multiple queries specifying the total suite of comparators', async () => {
-      // ISSUE #4243
-      // Calling this function does not work like this
-      // const numbers = [...Array(10).keys()];
-      // await Promise.all(numbers.map(number => contract.methods.insert_note(number).send().wait()));
-      // It causes a race condition complaining about root mismatch
+      await Promise.all(
+        Array(10)
+          .fill(0)
+          .map((_, i) => contract.methods.insert_note(i).send().wait()),
+      );
 
-      // Note: Separated the below into calls of 3 to avoid reaching logs per call limit
-      await contract.methods.insert_notes([0, 1, 2]).send().wait();
-      await contract.methods.insert_notes([3, 4, 5]).send().wait();
-      await contract.methods.insert_notes([6, 7, 8]).send().wait();
-      await contract.methods.insert_note(9).send().wait();
+      // We insert a note with value 5 twice to better test the comparators
       await contract.methods.insert_note(5).send().wait();
 
       const [returnEq, returnNeq, returnLt, returnGt, returnLte, returnGte] = await Promise.all([

--- a/yarn-project/end-to-end/src/e2e_note_getter.test.ts
+++ b/yarn-project/end-to-end/src/e2e_note_getter.test.ts
@@ -28,8 +28,6 @@ describe('e2e_note_getter', () => {
 
     beforeAll(async () => {
       contract = await NoteGetterContract.deploy(wallet).send().deployed();
-      // sets card value to 1 and leader to sender.
-      // await contract.methods.initialize_private(Fr.random(), 1).send().wait();
     });
 
     it('inserts notes from 0-9, then makes multiple queries specifying the total suite of comparators', async () => {

--- a/yarn-project/end-to-end/src/e2e_note_getter.test.ts
+++ b/yarn-project/end-to-end/src/e2e_note_getter.test.ts
@@ -1,5 +1,5 @@
 import { type AztecAddress, Comparator, Fr, type Wallet } from '@aztec/aztec.js';
-import { DocsExampleContract } from '@aztec/noir-contracts.js/DocsExample';
+import { NoteGetterContract } from '@aztec/noir-contracts.js/NoteGetter';
 import { TestContract } from '@aztec/noir-contracts.js/Test';
 
 import { setup } from './fixtures/utils.js';
@@ -27,12 +27,12 @@ describe('e2e_note_getter', () => {
   afterAll(() => teardown());
 
   describe('comparators', () => {
-    let contract: DocsExampleContract;
+    let contract: NoteGetterContract;
 
     beforeAll(async () => {
-      contract = await DocsExampleContract.deploy(wallet).send().deployed();
+      contract = await NoteGetterContract.deploy(wallet).send().deployed();
       // sets card value to 1 and leader to sender.
-      await contract.methods.initialize_private(Fr.random(), 1).send().wait();
+      // await contract.methods.initialize_private(Fr.random(), 1).send().wait();
     });
 
     it('inserts notes from 0-9, then makes multiple queries specifying the total suite of comparators', async () => {
@@ -46,8 +46,8 @@ describe('e2e_note_getter', () => {
       await contract.methods.insert_notes([0, 1, 2]).send().wait();
       await contract.methods.insert_notes([3, 4, 5]).send().wait();
       await contract.methods.insert_notes([6, 7, 8]).send().wait();
-      await contract.methods.insert_note(9, new Fr(1n)).send().wait();
-      await contract.methods.insert_note(5, Fr.ZERO).send().wait();
+      await contract.methods.insert_note(9).send().wait();
+      await contract.methods.insert_note(5).send().wait();
 
       const [returnEq, returnNeq, returnLt, returnGt, returnLte, returnGte] = await Promise.all([
         contract.methods.read_note(Comparator.EQ, 5).simulate(),


### PR DESCRIPTION
This PR is a piece of a series of PRs in which I clean up our use of test contracts. In this case I am replacing the use of DocsExampleContract in `e2e_note_getter.test.ts` with the goal of eventually not using `DocsExampleContract` in `/yarn-project` at all.

I introduce a new NoteGetter test contract.