### PR TITLE
feat: Reorg cheat codes

### DIFF
--- a/yarn-project/ethereum/src/eth_cheat_codes.test.ts
+++ b/yarn-project/ethereum/src/eth_cheat_codes.test.ts
@@ -1,0 +1,164 @@
+import { Blob } from '@aztec/blob-lib';
+import { times, timesAsync } from '@aztec/foundation/collection';
+import { EthAddress } from '@aztec/foundation/eth-address';
+import { type Logger, createLogger } from '@aztec/foundation/log';
+import { sleep } from '@aztec/foundation/sleep';
+import { TestERC20Abi, TestERC20Bytecode } from '@aztec/l1-artifacts';
+
+import type { Anvil } from '@viem/anvil';
+import {
+  type Abi,
+  type GetContractReturnType,
+  type Hex,
+  createPublicClient,
+  createWalletClient,
+  encodeFunctionData,
+  fallback,
+  getContract,
+  http,
+} from 'viem';
+import { mnemonicToAccount, privateKeyToAccount } from 'viem/accounts';
+import { foundry } from 'viem/chains';
+
+import { deployL1Contract } from './deploy_l1_contracts.js';
+import { EthCheatCodes } from './eth_cheat_codes.js';
+import { defaultL1TxUtilsConfig } from './l1_tx_utils.js';
+import { L1TxUtilsWithBlobs } from './l1_tx_utils_with_blobs.js';
+import { startAnvil } from './test/start_anvil.js';
+import type { SimpleViemWalletClient, ViemPublicClient } from './types.js';
+import { formatViemError } from './utils.js';
+
+const MNEMONIC = 'test test test test test test test test test test test junk';
+const WEI_CONST = 1_000_000_000n;
+
+describe('EthCheatCodes', () => {
+  let walletClient: SimpleViemWalletClient;
+  let publicClient: ViemPublicClient;
+  let anvil: Anvil;
+  let cheatCodes: EthCheatCodes;
+  let logger: Logger;
+  let sender: Hex;
+
+  beforeAll(async () => {
+    const { anvil: anvilInstance, rpcUrl } = await startAnvil();
+    logger = createLogger('ethereum:test:eth_cheat_codes');
+    anvil = anvilInstance;
+    cheatCodes = new EthCheatCodes([rpcUrl]);
+
+    const hdAccount = mnemonicToAccount(MNEMONIC, { addressIndex: 0 });
+    const privKeyRaw = hdAccount.getHdKey().privateKey!;
+    const privKey = Buffer.from(privKeyRaw).toString('hex');
+    const account = privateKeyToAccount(`0x${privKey}`);
+
+    publicClient = createPublicClient({ transport: fallback([http(rpcUrl)]), chain: foundry });
+    walletClient = createWalletClient({ transport: fallback([http(rpcUrl)]), chain: foundry, account });
+    sender = account.address;
+  });
+
+  afterAll(async () => {
+    await cheatCodes?.setIntervalMining(0); // Disable interval mining
+    await anvil?.stop().catch(err => logger?.error(err));
+  }, 5_000);
+
+  describe('reorgs', () => {
+    const deployToken = async () => {
+      const { address, txHash } = await deployL1Contract(walletClient, publicClient, TestERC20Abi, TestERC20Bytecode, [
+        'Test Token',
+        'TEST',
+        sender,
+      ]);
+      await publicClient.waitForTransactionReceipt({ hash: txHash! });
+      return getContract({ address: address.toString(), abi: TestERC20Abi, client: walletClient });
+    };
+
+    const mint = async (token: Awaited<ReturnType<typeof deployToken>>, amount: bigint) => {
+      const hash = await token.write.mint([sender, amount]);
+      const receipt = await publicClient.waitForTransactionReceipt({ hash });
+      expect(receipt.status).toEqual('success');
+    };
+
+    const getEvents = (token: Awaited<ReturnType<typeof deployToken>>) =>
+      publicClient.getContractEvents({
+        address: token.address,
+        abi: TestERC20Abi,
+        eventName: 'Transfer',
+        fromBlock: 1n,
+        toBlock: 'latest',
+      });
+
+    it('reorgs back to before deployment', async () => {
+      const token = await deployToken();
+      await expect(token.read.name()).resolves.toEqual('Test Token');
+      const blockNumberBefore = await publicClient.getBlockNumber();
+      await cheatCodes.reorg(1);
+      await expect(token.read.name()).rejects.toThrow(/returned no data/);
+      await expect(publicClient.getBlockNumber({ cacheTime: 0 })).resolves.toEqual(blockNumberBefore - 1n);
+    });
+
+    it('rollbacks events and state on reorg', async () => {
+      const token = await deployToken();
+      await mint(token, 100n);
+      await expect(token.read.balanceOf([sender])).resolves.toEqual(100n);
+      await expect(getEvents(token)).resolves.toHaveLength(1);
+
+      await cheatCodes.reorg(1);
+      await expect(token.read.balanceOf([sender])).resolves.toEqual(0n);
+      await expect(getEvents(token)).resolves.toHaveLength(0);
+    });
+
+    it('reorgs multiple blocks', async () => {
+      const token = await deployToken();
+      await timesAsync(4, () => mint(token, 100n));
+
+      await expect(token.read.balanceOf([sender])).resolves.toEqual(400n);
+      await expect(getEvents(token)).resolves.toHaveLength(4);
+
+      const blockNumberBefore = await publicClient.getBlockNumber();
+      await cheatCodes.reorg(3);
+      await expect(token.read.balanceOf([sender])).resolves.toEqual(100n);
+      await expect(getEvents(token)).resolves.toHaveLength(1);
+      await expect(publicClient.getBlockNumber({ cacheTime: 0 })).resolves.toEqual(blockNumberBefore - 3n);
+    });
+
+    it('reorgs with new empty blocks as replacement', async () => {
+      const token = await deployToken();
+      await timesAsync(4, () => mint(token, 100n));
+
+      await expect(token.read.balanceOf([sender])).resolves.toEqual(400n);
+      await expect(getEvents(token)).resolves.toHaveLength(4);
+
+      const blockNumberBefore = await publicClient.getBlockNumber();
+      await cheatCodes.reorgWithReplacement(3);
+      await expect(token.read.balanceOf([sender])).resolves.toEqual(100n);
+      await expect(getEvents(token)).resolves.toHaveLength(1);
+      await expect(publicClient.getBlockNumber({ cacheTime: 0 })).resolves.toEqual(blockNumberBefore);
+    });
+
+    it('reorgs with blocks with replacement txs', async () => {
+      const token = await deployToken();
+      await timesAsync(4, () => mint(token, 100n));
+
+      await expect(token.read.balanceOf([sender])).resolves.toEqual(400n);
+      await expect(getEvents(token)).resolves.toHaveLength(4);
+
+      const data = encodeFunctionData({ abi: TestERC20Abi, functionName: 'mint', args: [sender, 1000n] });
+      const newTx = { data, to: token.address, from: sender, value: 0n };
+
+      const blockNumber = await publicClient.getBlockNumber();
+      await cheatCodes.reorgWithReplacement(3, [[newTx, newTx, newTx], [], [newTx]]);
+      await expect(token.read.balanceOf([sender])).resolves.toEqual(4100n);
+      await expect(getEvents(token)).resolves.toHaveLength(5);
+      await expect(publicClient.getBlockNumber({ cacheTime: 0 })).resolves.toEqual(blockNumber);
+
+      await expect(
+        Promise.all(
+          times(3, i =>
+            publicClient
+              .getBlock({ blockNumber: blockNumber - 2n + BigInt(i) })
+              .then(block => block.transactions.length),
+          ),
+        ),
+      ).resolves.toEqual([3, 0, 1]);
+    });
+  });
+});

--- a/yarn-project/ethereum/src/eth_cheat_codes.test.ts
+++ b/yarn-project/ethereum/src/eth_cheat_codes.test.ts
@@ -1,6 +1,5 @@
 import { times, timesAsync } from '@aztec/foundation/collection';
 import { type Logger, createLogger } from '@aztec/foundation/log';
-import { sleep } from '@aztec/foundation/sleep';
 import { TestERC20Abi, TestERC20Bytecode } from '@aztec/l1-artifacts';
 
 import type { Anvil } from '@viem/anvil';

--- a/yarn-project/ethereum/src/eth_cheat_codes.test.ts
+++ b/yarn-project/ethereum/src/eth_cheat_codes.test.ts
@@ -1,5 +1,6 @@
 import { times, timesAsync } from '@aztec/foundation/collection';
 import { type Logger, createLogger } from '@aztec/foundation/log';
+import { sleep } from '@aztec/foundation/sleep';
 import { TestERC20Abi, TestERC20Bytecode } from '@aztec/l1-artifacts';
 
 import type { Anvil } from '@viem/anvil';
@@ -122,7 +123,7 @@ describe('EthCheatCodes', () => {
       await cheatCodes.reorgWithReplacement(3);
       await expect(token.read.balanceOf([sender])).resolves.toEqual(100n);
       await expect(getEvents(token)).resolves.toHaveLength(1);
-      await expect(publicClient.getBlockNumber({ cacheTime: 0 })).resolves.toEqual(blockNumberBefore);
+      await expect(publicClient.getBlockNumber({ cacheTime: 0 })).resolves.toBeGreaterThanOrEqual(blockNumberBefore);
     });
 
     it('reorgs with blocks with replacement txs', async () => {
@@ -139,7 +140,7 @@ describe('EthCheatCodes', () => {
       await cheatCodes.reorgWithReplacement(3, [[newTx, newTx, newTx], [], [newTx]]);
       await expect(token.read.balanceOf([sender])).resolves.toEqual(4100n);
       await expect(getEvents(token)).resolves.toHaveLength(5);
-      await expect(publicClient.getBlockNumber({ cacheTime: 0 })).resolves.toEqual(blockNumber);
+      await expect(publicClient.getBlockNumber({ cacheTime: 0 })).resolves.toBeGreaterThanOrEqual(blockNumber);
 
       await expect(
         Promise.all(

--- a/yarn-project/ethereum/src/eth_cheat_codes.test.ts
+++ b/yarn-project/ethereum/src/eth_cheat_codes.test.ts
@@ -1,14 +1,9 @@
-import { Blob } from '@aztec/blob-lib';
 import { times, timesAsync } from '@aztec/foundation/collection';
-import { EthAddress } from '@aztec/foundation/eth-address';
 import { type Logger, createLogger } from '@aztec/foundation/log';
-import { sleep } from '@aztec/foundation/sleep';
 import { TestERC20Abi, TestERC20Bytecode } from '@aztec/l1-artifacts';
 
 import type { Anvil } from '@viem/anvil';
 import {
-  type Abi,
-  type GetContractReturnType,
   type Hex,
   createPublicClient,
   createWalletClient,
@@ -22,14 +17,10 @@ import { foundry } from 'viem/chains';
 
 import { deployL1Contract } from './deploy_l1_contracts.js';
 import { EthCheatCodes } from './eth_cheat_codes.js';
-import { defaultL1TxUtilsConfig } from './l1_tx_utils.js';
-import { L1TxUtilsWithBlobs } from './l1_tx_utils_with_blobs.js';
 import { startAnvil } from './test/start_anvil.js';
 import type { SimpleViemWalletClient, ViemPublicClient } from './types.js';
-import { formatViemError } from './utils.js';
 
 const MNEMONIC = 'test test test test test test test test test test test junk';
-const WEI_CONST = 1_000_000_000n;
 
 describe('EthCheatCodes', () => {
   let walletClient: SimpleViemWalletClient;

--- a/yarn-project/ethereum/src/eth_cheat_codes.ts
+++ b/yarn-project/ethereum/src/eth_cheat_codes.ts
@@ -1,6 +1,7 @@
 import { toBigIntBE, toHex } from '@aztec/foundation/bigint-buffer';
 import { keccak256 } from '@aztec/foundation/crypto';
 import type { EthAddress } from '@aztec/foundation/eth-address';
+import { jsonStringify } from '@aztec/foundation/json-rpc';
 import { createLogger } from '@aztec/foundation/log';
 
 import { type Hex, createPublicClient, fallback, http } from 'viem';
@@ -28,7 +29,7 @@ export class EthCheatCodes {
   }
 
   async rpcCall(method: string, params: any[]) {
-    const paramsString = JSON.stringify(params);
+    const paramsString = jsonStringify(params);
     this.logger.info(`Calling ${method} with params: ${paramsString} on ${this.rpcUrls.join(', ')}`);
     return (await this.publicClient.transport.request({
       method,
@@ -310,5 +311,39 @@ export class EthCheatCodes {
   public async getRawTransaction(txHash: Hex): Promise<`0x${string}`> {
     const res = await this.rpcCall('debug_getRawTransaction', [txHash]);
     return res;
+  }
+
+  /**
+   * Triggers a reorg of the given depth, removing those blocks from the chain.
+   * @param depth - The depth of the reorg
+   */
+  public async reorg(depth: number): Promise<void> {
+    try {
+      await this.rpcCall('anvil_rollback', [depth]);
+    } catch (err) {
+      throw new Error(`Error rolling back: ${err}`);
+    }
+    this.logger.warn(`Rolled back L1 chain with depth ${depth}`);
+  }
+
+  /**
+   * Triggers a reorg of the given depth, optionally replacing it with new blocks.
+   * The resulting block height will be the same as the original chain.
+   * @param depth - The depth of the reorg
+   * @param newBlocks - The blocks to replace the old ones with, each represented as a list of txs.
+   */
+  public async reorgWithReplacement(
+    depth: number,
+    newBlocks: (Hex | { to: EthAddress | Hex; input?: Hex; from?: EthAddress | Hex; value?: number | bigint })[][] = [],
+  ): Promise<void> {
+    try {
+      await this.rpcCall('anvil_reorg', [
+        depth,
+        newBlocks.flatMap((txs, index) => txs.map(tx => [typeof tx === 'string' ? tx : { value: 0, ...tx }, index])),
+      ]);
+    } catch (err) {
+      throw new Error(`Error reorging: ${err}`);
+    }
+    this.logger.warn(`Reorged L1 chain with depth ${depth} and ${newBlocks.length} new blocks`, { depth, newBlocks });
   }
 }


### PR DESCRIPTION
Leverages [`anvil_reorg` and `anvil_rollback`](https://github.com/foundry-rs/foundry/discussions/10267) to simulate reorgs in EthCheatCodes.

Requires foundry `nightly-fe92e7ef225c6380e657e49452ce931871ae56bc` (2025-01-31T00:20:44.300723007Z) or later.
