### PR TITLE
test: `e2e_state_vars ` not using `DocsExampleContract`

### DIFF
--- a/noir-projects/noir-contracts/Nargo.toml
+++ b/noir-projects/noir-contracts/Nargo.toml
@@ -42,6 +42,7 @@ members = [
     "contracts/test/parent_contract",
     "contracts/test/pending_note_hashes_contract",
     "contracts/test/spam_contract",
+    "contracts/test/state_vars_contract",
     "contracts/test/stateful_test_contract",
     "contracts/test/static_child_contract",
     "contracts/test/static_parent_contract",

--- a/noir-projects/noir-contracts/contracts/docs/docs_example_contract/src/main.nr
+++ b/noir-projects/noir-contracts/contracts/docs/docs_example_contract/src/main.nr
@@ -276,11 +276,6 @@ pub contract DocsExample {
     // docs:end:get_note-private-immutable
 
     #[utility]
-    unconstrained fn view_imm_card() -> CardNote {
-        storage.private_immutable.view_note()
-    }
-
-    #[utility]
     unconstrained fn is_priv_imm_initialized() -> bool {
         storage.private_immutable.is_initialized()
     }

--- a/noir-projects/noir-contracts/contracts/docs/docs_example_contract/src/main.nr
+++ b/noir-projects/noir-contracts/contracts/docs/docs_example_contract/src/main.nr
@@ -203,19 +203,6 @@ pub contract DocsExample {
     // docs:end:state_vars-NoteGetterOptionsComparatorExampleNoir
 
     #[private]
-    fn update_legendary_card(randomness: Field, points: u8) {
-        let new_card = CardNote::new(points, randomness, context.msg_sender());
-
-        storage.legendary_card.replace(new_card).emit(encode_and_encrypt_note(
-            &mut context,
-            context.msg_sender(),
-            context.msg_sender(),
-        ));
-        DocsExample::at(context.this_address()).update_leader(context.msg_sender(), points).enqueue(
-            &mut context,
-        );
-    }
-    #[private]
     fn increase_legendary_points() {
         // Ensure `points` > current value
         // Also serves as a e2e test that you can `get_note()` and then `replace()`

--- a/noir-projects/noir-contracts/contracts/test/state_vars_contract/Nargo.toml
+++ b/noir-projects/noir-contracts/contracts/test/state_vars_contract/Nargo.toml
@@ -1,0 +1,9 @@
+[package]
+name = "state_vars_contract"
+authors = [""]
+compiler_version = ">=0.25.0"
+type = "contract"
+
+[dependencies]
+aztec = { path = "../../../../aztec-nr/aztec" }
+value_note = { path = "../../../../aztec-nr/value-note" }

--- a/noir-projects/noir-contracts/contracts/test/state_vars_contract/src/main.nr
+++ b/noir-projects/noir-contracts/contracts/test/state_vars_contract/src/main.nr
@@ -1,0 +1,171 @@
+use aztec::macros::aztec;
+
+/// Used to test state vars in e2e_state_vars.test.ts
+#[aztec]
+pub contract StateVars {
+    use aztec::{
+        encrypted_logs::log_assembly_strategies::default_aes128::note::encode_and_encrypt_note,
+        macros::{functions::{private, public, utility, view}, storage::{storage, storage_no_init}},
+        prelude::{AztecAddress, PrivateImmutable, PrivateMutable, PublicImmutable, PublicMutable},
+        protocol_types::traits::{Deserialize, Packable, Serialize},
+    };
+
+    use value_note::value_note::ValueNote;
+
+    #[derive(Deserialize, Eq, Packable, Serialize)]
+    pub struct MockStruct {
+        account: AztecAddress,
+        value: u8,
+    }
+
+    #[storage_no_init]
+    struct Storage<Context> {
+        mock_struct: PublicMutable<MockStruct, Context>,
+        private_mutable: PrivateMutable<ValueNote, Context>,
+        private_immutable: PrivateImmutable<ValueNote, Context>,
+        public_immutable: PublicImmutable<MockStruct, Context>,
+    }
+
+    impl<Context> Storage<Context> {
+        fn init(context: Context) -> Self {
+            Storage {
+                mock_struct: PublicMutable::new(context, 1),
+                private_mutable: PrivateMutable::new(context, 3),
+                private_immutable: PrivateImmutable::new(context, 6),
+                public_immutable: PublicImmutable::new(context, 7),
+            }
+        }
+    }
+
+    #[public]
+    fn initialize_public_immutable(value: u8) {
+        let mut new_mock_struct = MockStruct { account: context.msg_sender(), value };
+        storage.public_immutable.initialize(new_mock_struct);
+    }
+
+    #[private]
+    fn match_public_immutable(account: AztecAddress, value: u8) {
+        let expected = MockStruct { account, value };
+        let read = storage.public_immutable.read();
+
+        assert(read.account == expected.account, "Invalid account");
+        assert(read.value == expected.value, "Invalid value");
+    }
+
+    #[private]
+    fn get_public_immutable_constrained_private_indirect() -> MockStruct {
+        let mut mock_struct = StateVars::at(context.this_address())
+            .get_public_immutable_constrained_private()
+            .view(&mut context);
+        mock_struct.value += 1;
+        mock_struct
+    }
+
+    #[public]
+    fn get_public_immutable_constrained_public_indirect() -> MockStruct {
+        // This is a public function that calls another public function
+        // and returns the response.
+        // Used to test that we can retrieve values through calls and
+        // correctly return them in the simulation
+        let mut mock_struct = StateVars::at(context.this_address())
+            .get_public_immutable_constrained_public()
+            .view(&mut context);
+        mock_struct.value += 1;
+        mock_struct
+    }
+
+    #[public]
+    #[view]
+    fn get_public_immutable_constrained_public() -> MockStruct {
+        storage.public_immutable.read()
+    }
+
+    #[public]
+    fn get_public_immutable_constrained_public_multiple() -> [MockStruct; 5] {
+        let a = storage.public_immutable.read();
+        [a, a, a, a, a]
+    }
+
+    #[private]
+    #[view]
+    fn get_public_immutable_constrained_private() -> MockStruct {
+        storage.public_immutable.read()
+    }
+
+    #[utility]
+    unconstrained fn get_public_immutable() -> MockStruct {
+        storage.public_immutable.read()
+    }
+
+    #[private]
+    fn initialize_private_immutable(randomness: Field, value: Field) {
+        let new_card = ValueNote::new(value, context.msg_sender());
+
+        storage.private_immutable.initialize(new_card).emit(encode_and_encrypt_note(
+            &mut context,
+            context.msg_sender(),
+            context.msg_sender(),
+        ));
+    }
+
+    #[private]
+    fn initialize_private(randomness: Field, value: Field) {
+        let private_mutable = ValueNote::new(value, context.msg_sender());
+
+        storage.private_mutable.initialize(private_mutable).emit(encode_and_encrypt_note(
+            &mut context,
+            context.msg_sender(),
+            context.msg_sender(),
+        ));
+    }
+
+    #[private]
+    fn update_private_mutable(randomness: Field, value: Field) {
+        let new_note = ValueNote::new(value, context.msg_sender());
+
+        storage.private_mutable.replace(new_note).emit(encode_and_encrypt_note(
+            &mut context,
+            context.msg_sender(),
+            context.msg_sender(),
+        ));
+    }
+
+    #[private]
+    fn increase_private_value() {
+        // Get current value from private mutable storage
+        let current = storage.private_mutable.get_note().note;
+
+        // Increment value by 1
+        let new_value = current.value + 1;
+
+        // Create new note with incremented value
+        let new_note = ValueNote::new(new_value, context.msg_sender());
+
+        // Replace existing note with new note
+        storage.private_mutable.replace(new_note).emit(encode_and_encrypt_note(
+            &mut context,
+            context.msg_sender(),
+            context.msg_sender(),
+        ));
+    }
+
+    #[utility]
+    unconstrained fn get_private_mutable() -> ValueNote {
+        storage.private_mutable.view_note()
+    }
+
+    #[utility]
+    unconstrained fn is_private_mutable_initialized() -> bool {
+        storage.private_mutable.is_initialized()
+    }
+
+    #[utility]
+    unconstrained fn view_imm_card() -> ValueNote {
+        storage.private_immutable.view_note()
+    }
+
+    #[utility]
+    unconstrained fn is_priv_imm_initialized() -> bool {
+        storage.private_immutable.is_initialized()
+    }
+}

--- a/noir-projects/noir-contracts/contracts/test/state_vars_contract/src/main.nr
+++ b/noir-projects/noir-contracts/contracts/test/state_vars_contract/src/main.nr
@@ -99,9 +99,9 @@ pub contract StateVars {
 
     #[private]
     fn initialize_private_immutable(randomness: Field, value: Field) {
-        let new_card = ValueNote::new(value, context.msg_sender());
+        let new_note = ValueNote::new(value, context.msg_sender());
 
-        storage.private_immutable.initialize(new_card).emit(encode_and_encrypt_note(
+        storage.private_immutable.initialize(new_note).emit(encode_and_encrypt_note(
             &mut context,
             context.msg_sender(),
             context.msg_sender(),
@@ -160,7 +160,7 @@ pub contract StateVars {
     }
 
     #[utility]
-    unconstrained fn view_imm_card() -> ValueNote {
+    unconstrained fn view_private_immutable() -> ValueNote {
         storage.private_immutable.view_note()
     }
 

--- a/yarn-project/end-to-end/src/e2e_state_vars.test.ts
+++ b/yarn-project/end-to-end/src/e2e_state_vars.test.ts
@@ -17,7 +17,7 @@ describe('e2e_state_vars', () => {
   let teardown: () => Promise<void>;
   let contract: StateVarsContract;
 
-  const VALUE = 1n;
+  const VALUE = 2n;
   const RANDOMNESS = 2n;
 
   beforeAll(async () => {
@@ -126,9 +126,9 @@ describe('e2e_state_vars', () => {
 
     it('read initialized PrivateMutable', async () => {
       expect(await contract.methods.is_private_mutable_initialized().simulate()).toEqual(true);
-      const { value, randomness } = await contract.methods.get_private_mutable().simulate();
+      const { value, owner } = await contract.methods.get_private_mutable().simulate();
       expect(value).toEqual(VALUE);
-      expect(randomness).toEqual(RANDOMNESS);
+      expect(owner).toEqual(wallet.getAddress());
     });
 
     it('replace with same value', async () => {
@@ -146,7 +146,6 @@ describe('e2e_state_vars', () => {
 
       expect(noteBefore.owner).toEqual(noteAfter.owner);
       expect(noteBefore.value).toEqual(noteAfter.value);
-      expect(noteBefore.randomness).toEqual(noteAfter.randomness);
     });
 
     it('replace PrivateMutable with other values', async () => {
@@ -162,9 +161,9 @@ describe('e2e_state_vars', () => {
       // 1 for the tx, another for the nullifier of the previous note
       expect(txEffects?.data.nullifiers.length).toEqual(2);
 
-      const { value, randomness } = await contract.methods.get_private_mutable().simulate();
+      const { value, owner } = await contract.methods.get_private_mutable().simulate();
       expect(value).toEqual(VALUE + 1n);
-      expect(randomness).toEqual(RANDOMNESS + 2n);
+      expect(owner).toEqual(wallet.getAddress());
     });
 
     it('replace PrivateMutable dependent on prior value', async () => {
@@ -178,16 +177,16 @@ describe('e2e_state_vars', () => {
       // 1 for the tx, another for the nullifier of the previous note
       expect(txEffects?.data.nullifiers.length).toEqual(2);
 
-      const { value, randomness } = await contract.methods.get_private_mutable().simulate();
+      const { value, owner } = await contract.methods.get_private_mutable().simulate();
       expect(value).toEqual(noteBefore.value + 1n);
-      expect(randomness).toEqual(noteBefore.randomness);
+      expect(owner).toEqual(wallet.getAddress());
     });
   });
 
   describe('PrivateImmutable', () => {
     it('fail to read uninitialized PrivateImmutable', async () => {
       expect(await contract.methods.is_priv_imm_initialized().simulate()).toEqual(false);
-      await expect(contract.methods.view_imm_card().simulate()).rejects.toThrow();
+      await expect(contract.methods.view_private_immutable().simulate()).rejects.toThrow();
     });
 
     it('initialize PrivateImmutable', async () => {
@@ -210,9 +209,9 @@ describe('e2e_state_vars', () => {
 
     it('read initialized PrivateImmutable', async () => {
       expect(await contract.methods.is_priv_imm_initialized().simulate()).toEqual(true);
-      const { value, randomness } = await contract.methods.view_imm_card().simulate();
+      const { value, owner } = await contract.methods.view_private_immutable().simulate();
       expect(value).toEqual(VALUE);
-      expect(randomness).toEqual(RANDOMNESS);
+      expect(owner).toEqual(wallet.getAddress());
     });
   });
 

--- a/yarn-project/end-to-end/src/e2e_state_vars.test.ts
+++ b/yarn-project/end-to-end/src/e2e_state_vars.test.ts
@@ -1,6 +1,6 @@
 import { BatchCall, Fr, type PXE, type Wallet } from '@aztec/aztec.js';
 import { AuthContract } from '@aztec/noir-contracts.js/Auth';
-import { DocsExampleContract } from '@aztec/noir-contracts.js/DocsExample';
+import { StateVarsContract } from '@aztec/noir-contracts.js/StateVars';
 
 import { jest } from '@jest/globals';
 
@@ -15,14 +15,14 @@ describe('e2e_state_vars', () => {
   let wallet: Wallet;
 
   let teardown: () => Promise<void>;
-  let contract: DocsExampleContract;
+  let contract: StateVarsContract;
 
-  const POINTS = 1n;
+  const VALUE = 1n;
   const RANDOMNESS = 2n;
 
   beforeAll(async () => {
     ({ teardown, wallet, pxe } = await setup(2));
-    contract = await DocsExampleContract.deploy(wallet).send().deployed();
+    contract = await StateVarsContract.deploy(wallet).send().deployed();
   });
 
   afterAll(() => teardown());
@@ -32,7 +32,7 @@ describe('e2e_state_vars', () => {
       const s = await contract.methods.get_public_immutable().simulate();
 
       // Send the transaction and wait for it to be mined (wait function throws if the tx is not mined)
-      await contract.methods.match_public_immutable(s.account, s.points).send().wait();
+      await contract.methods.match_public_immutable(s.account, s.value).send().wait();
     });
 
     it('initialize and read PublicImmutable', async () => {
@@ -43,7 +43,7 @@ describe('e2e_state_vars', () => {
 
       const read = await contract.methods.get_public_immutable().simulate();
 
-      expect(read).toEqual({ account: wallet.getAddress(), points: read.points });
+      expect(read).toEqual({ account: wallet.getAddress(), value: read.value });
     });
 
     it('private read of PublicImmutable', async () => {
@@ -59,8 +59,8 @@ describe('e2e_state_vars', () => {
       ]).simulate();
 
       expect(a).toEqual(c);
-      expect(b).toEqual({ account: c.account, points: c.points + 1n });
-      await contract.methods.match_public_immutable(c.account, c.points).send().wait();
+      expect(b).toEqual({ account: c.account, value: c.value + 1n });
+      await contract.methods.match_public_immutable(c.account, c.value).send().wait();
     });
 
     it('public read of PublicImmutable', async () => {
@@ -76,9 +76,9 @@ describe('e2e_state_vars', () => {
       ]).simulate();
 
       expect(a).toEqual(c);
-      expect(b).toEqual({ account: c.account, points: c.points + 1n });
+      expect(b).toEqual({ account: c.account, value: c.value + 1n });
 
-      await contract.methods.match_public_immutable(c.account, c.points).send().wait();
+      await contract.methods.match_public_immutable(c.account, c.value).send().wait();
     });
 
     it('public multiread of PublicImmutable', async () => {
@@ -102,39 +102,39 @@ describe('e2e_state_vars', () => {
 
   describe('PrivateMutable', () => {
     it('fail to read uninitialized PrivateMutable', async () => {
-      expect(await contract.methods.is_legendary_initialized().simulate()).toEqual(false);
-      await expect(contract.methods.get_legendary_card().simulate()).rejects.toThrow();
+      expect(await contract.methods.is_private_mutable_initialized().simulate()).toEqual(false);
+      await expect(contract.methods.get_private_mutable().simulate()).rejects.toThrow();
     });
 
     it('initialize PrivateMutable', async () => {
-      expect(await contract.methods.is_legendary_initialized().simulate()).toEqual(false);
+      expect(await contract.methods.is_private_mutable_initialized().simulate()).toEqual(false);
       // Send the transaction and wait for it to be mined (wait function throws if the tx is not mined)
-      const receipt = await contract.methods.initialize_private(RANDOMNESS, POINTS).send().wait();
+      const receipt = await contract.methods.initialize_private(RANDOMNESS, VALUE).send().wait();
 
       const txEffects = await pxe.getTxEffect(receipt.txHash);
 
       // 1 for the tx, another for the initializer
       expect(txEffects?.data.nullifiers.length).toEqual(2);
-      expect(await contract.methods.is_legendary_initialized().simulate()).toEqual(true);
+      expect(await contract.methods.is_private_mutable_initialized().simulate()).toEqual(true);
     });
 
     it('fail to reinitialize', async () => {
-      expect(await contract.methods.is_legendary_initialized().simulate()).toEqual(true);
-      await expect(contract.methods.initialize_private(RANDOMNESS, POINTS).send().wait()).rejects.toThrow();
-      expect(await contract.methods.is_legendary_initialized().simulate()).toEqual(true);
+      expect(await contract.methods.is_private_mutable_initialized().simulate()).toEqual(true);
+      await expect(contract.methods.initialize_private(RANDOMNESS, VALUE).send().wait()).rejects.toThrow();
+      expect(await contract.methods.is_private_mutable_initialized().simulate()).toEqual(true);
     });
 
     it('read initialized PrivateMutable', async () => {
-      expect(await contract.methods.is_legendary_initialized().simulate()).toEqual(true);
-      const { points, randomness } = await contract.methods.get_legendary_card().simulate();
-      expect(points).toEqual(POINTS);
+      expect(await contract.methods.is_private_mutable_initialized().simulate()).toEqual(true);
+      const { value, randomness } = await contract.methods.get_private_mutable().simulate();
+      expect(value).toEqual(VALUE);
       expect(randomness).toEqual(RANDOMNESS);
     });
 
     it('replace with same value', async () => {
-      expect(await contract.methods.is_legendary_initialized().simulate()).toEqual(true);
-      const noteBefore = await contract.methods.get_legendary_card().simulate();
-      const receipt = await contract.methods.update_legendary_card(RANDOMNESS, POINTS).send().wait();
+      expect(await contract.methods.is_private_mutable_initialized().simulate()).toEqual(true);
+      const noteBefore = await contract.methods.get_private_mutable().simulate();
+      const receipt = await contract.methods.update_private_mutable(RANDOMNESS, VALUE).send().wait();
 
       const txEffects = await pxe.getTxEffect(receipt.txHash);
 
@@ -142,17 +142,17 @@ describe('e2e_state_vars', () => {
       // 1 for the tx, another for the nullifier of the previous note
       expect(txEffects?.data.nullifiers.length).toEqual(2);
 
-      const noteAfter = await contract.methods.get_legendary_card().simulate();
+      const noteAfter = await contract.methods.get_private_mutable().simulate();
 
       expect(noteBefore.owner).toEqual(noteAfter.owner);
-      expect(noteBefore.points).toEqual(noteAfter.points);
+      expect(noteBefore.value).toEqual(noteAfter.value);
       expect(noteBefore.randomness).toEqual(noteAfter.randomness);
     });
 
     it('replace PrivateMutable with other values', async () => {
-      expect(await contract.methods.is_legendary_initialized().simulate()).toEqual(true);
+      expect(await contract.methods.is_private_mutable_initialized().simulate()).toEqual(true);
       const receipt = await contract.methods
-        .update_legendary_card(RANDOMNESS + 2n, POINTS + 1n)
+        .update_private_mutable(RANDOMNESS + 2n, VALUE + 1n)
         .send()
         .wait();
 
@@ -162,15 +162,15 @@ describe('e2e_state_vars', () => {
       // 1 for the tx, another for the nullifier of the previous note
       expect(txEffects?.data.nullifiers.length).toEqual(2);
 
-      const { points, randomness } = await contract.methods.get_legendary_card().simulate();
-      expect(points).toEqual(POINTS + 1n);
+      const { value, randomness } = await contract.methods.get_private_mutable().simulate();
+      expect(value).toEqual(VALUE + 1n);
       expect(randomness).toEqual(RANDOMNESS + 2n);
     });
 
     it('replace PrivateMutable dependent on prior value', async () => {
-      expect(await contract.methods.is_legendary_initialized().simulate()).toEqual(true);
-      const noteBefore = await contract.methods.get_legendary_card().simulate();
-      const receipt = await contract.methods.increase_legendary_points().send().wait();
+      expect(await contract.methods.is_private_mutable_initialized().simulate()).toEqual(true);
+      const noteBefore = await contract.methods.get_private_mutable().simulate();
+      const receipt = await contract.methods.increase_private_value().send().wait();
 
       const txEffects = await pxe.getTxEffect(receipt.txHash);
 
@@ -178,8 +178,8 @@ describe('e2e_state_vars', () => {
       // 1 for the tx, another for the nullifier of the previous note
       expect(txEffects?.data.nullifiers.length).toEqual(2);
 
-      const { points, randomness } = await contract.methods.get_legendary_card().simulate();
-      expect(points).toEqual(noteBefore.points + 1n);
+      const { value, randomness } = await contract.methods.get_private_mutable().simulate();
+      expect(value).toEqual(noteBefore.value + 1n);
       expect(randomness).toEqual(noteBefore.randomness);
     });
   });
@@ -192,7 +192,7 @@ describe('e2e_state_vars', () => {
 
     it('initialize PrivateImmutable', async () => {
       expect(await contract.methods.is_priv_imm_initialized().simulate()).toEqual(false);
-      const receipt = await contract.methods.initialize_private_immutable(RANDOMNESS, POINTS).send().wait();
+      const receipt = await contract.methods.initialize_private_immutable(RANDOMNESS, VALUE).send().wait();
 
       const txEffects = await pxe.getTxEffect(receipt.txHash);
 
@@ -204,14 +204,14 @@ describe('e2e_state_vars', () => {
 
     it('fail to reinitialize', async () => {
       expect(await contract.methods.is_priv_imm_initialized().simulate()).toEqual(true);
-      await expect(contract.methods.initialize_private_immutable(RANDOMNESS, POINTS).send().wait()).rejects.toThrow();
+      await expect(contract.methods.initialize_private_immutable(RANDOMNESS, VALUE).send().wait()).rejects.toThrow();
       expect(await contract.methods.is_priv_imm_initialized().simulate()).toEqual(true);
     });
 
     it('read initialized PrivateImmutable', async () => {
       expect(await contract.methods.is_priv_imm_initialized().simulate()).toEqual(true);
-      const { points, randomness } = await contract.methods.view_imm_card().simulate();
-      expect(points).toEqual(POINTS);
+      const { value, randomness } = await contract.methods.view_imm_card().simulate();
+      expect(value).toEqual(VALUE);
       expect(randomness).toEqual(RANDOMNESS);
     });
   });


### PR DESCRIPTION
This PR is part of a series of PRs in which I clean up our use of test contracts. In this case I am replacing the use of DocsExampleContract in e2e_state_vars.test.ts with the goal of eventually not using DocsExampleContract in /yarn-project at all.

I introduce a new StateVars contract.