### PR TITLE
chore: add encode/decode fns

### DIFF
--- a/noir-projects/aztec-nr/aztec/src/discovery/mod.nr
+++ b/noir-projects/aztec-nr/aztec/src/discovery/mod.nr
@@ -1,4 +1,3 @@
-use crate::encrypted_logs::log_encryption::PRIVATE_LOG_PLAINTEXT_SIZE_IN_FIELDS;
 use protocol_types::{address::AztecAddress, debug_log::debug_log};
 
 pub mod nonce_discovery;
@@ -6,13 +5,6 @@ pub mod partial_notes;
 pub mod pending_tagged_log;
 pub mod private_logs;
 pub mod private_notes;
-
-/// The expanded message metadata takes up a single field.
-global PRIVATE_MESSAGE_EXPANDED_METADATA_LEN: u32 = 1;
-
-/// The maximum length of a message's content, i.e. not including the expanded message metadata.
-pub global MAX_MESSAGE_CONTENT_LEN: u32 =
-    PRIVATE_LOG_PLAINTEXT_SIZE_IN_FIELDS - PRIVATE_MESSAGE_EXPANDED_METADATA_LEN;
 
 use private_notes::MAX_NOTE_PACKED_LEN;
 

--- a/noir-projects/aztec-nr/aztec/src/discovery/partial_notes.nr
+++ b/noir-projects/aztec-nr/aztec/src/discovery/partial_notes.nr
@@ -2,9 +2,9 @@ use crate::{
     capsules::CapsuleArray,
     discovery::{
         ComputeNoteHashAndNullifier,
-        MAX_MESSAGE_CONTENT_LEN,
         nonce_discovery::{attempt_note_nonce_discovery, DiscoveredNoteInfo},
     },
+    encrypted_logs::encoding::MAX_MESSAGE_CONTENT_LEN,
     oracle::message_discovery::{deliver_note, get_log_by_tag},
     utils::array,
 };

--- a/noir-projects/aztec-nr/aztec/src/discovery/private_logs.nr
+++ b/noir-projects/aztec-nr/aztec/src/discovery/private_logs.nr
@@ -2,14 +2,12 @@ use crate::{
     capsules::CapsuleArray,
     discovery::{
         ComputeNoteHashAndNullifier,
-        MAX_MESSAGE_CONTENT_LEN,
         partial_notes::process_partial_note_private_msg,
         pending_tagged_log::{PENDING_TAGGED_LOG_ARRAY_BASE_SLOT, PendingTaggedLog},
-        PRIVATE_MESSAGE_EXPANDED_METADATA_LEN,
         private_notes::process_private_note_msg,
     },
     encrypted_logs::{
-        encoding::from_expanded_metadata,
+        encoding::decode_message,
         encrypt::aes128::AES128,
         log_encryption::LogEncryption,
         msg_type::{
@@ -26,9 +24,6 @@ use protocol_types::{
     debug_log::{debug_log, debug_log_format},
     traits::FromField,
 };
-
-// TODO(#12750): don't make these values assume we're using AES.
-use crate::encrypted_logs::log_encryption::PRIVATE_LOG_PLAINTEXT_SIZE_IN_FIELDS;
 
 /// Searches for private logs that signal new private notes that are then delivered to PXE, or new partial notes that
 /// are stored in the PXE capsules so that `fetch_and_process_public_partial_note_completion_logs` can later search for
@@ -88,7 +83,7 @@ unconstrained fn process_log<Env>(
     // The first thing to do after decrypting the log is to determine what type of private log we're processing. We
     // have 3 log types: private note logs, partial note logs and event logs.
 
-    let (msg_type_id, msg_metadata, msg_content) = decode_log_plaintext(log_plaintext);
+    let (msg_type_id, msg_metadata, msg_content) = decode_message(log_plaintext);
 
     if msg_type_id == PRIVATE_NOTE_MSG_TYPE_ID {
         debug_log("Processing private note msg");
@@ -129,49 +124,4 @@ unconstrained fn process_log<Env>(
     } else {
         debug_log_format("Unknown msg type id {0}", [msg_type_id as Field]);
     }
-}
-
-/// Decodes a log's plaintext following aztec-nr's standard log encoding.
-///
-/// The standard private log layout is composed of:
-///  - an initial field called the 'expanded metadata'
-///  - an arbitrary number of fields following that called the 'log content'
-///
-/// ```
-/// log_plaintext: [ msg_expanded_metadata, ...msg_content ]
-/// ```
-///
-/// The expanded metadata itself is interpreted as a u128, of which:
-///  - the upper 64 bits are the log type id
-///  - the lower 64 bits are called the 'log metadata'
-///
-/// ```
-/// msg_expanded_metadata: [  msg_type_id    |  msg_metadata  ]
-///                        <---  64 bits --->|<--- 64 bits --->
-/// ```
-///
-/// The meaning of the log metadata and log content depend on the value of the log type id. Note that there is
-/// nothing special about the log metadata, it _can_ be considered part of the content. It just has a different name
-/// to make it distinct from the log content given that it is not a full field.
-unconstrained fn decode_log_plaintext(
-    log_plaintext: BoundedVec<Field, PRIVATE_LOG_PLAINTEXT_SIZE_IN_FIELDS>,
-) -> (u64, u64, BoundedVec<Field, MAX_MESSAGE_CONTENT_LEN>) {
-    assert(
-        log_plaintext.len() >= PRIVATE_MESSAGE_EXPANDED_METADATA_LEN,
-        f"Invalid log plaintext: all logs must be decrypted into at least {PRIVATE_MESSAGE_EXPANDED_METADATA_LEN} fields",
-    );
-
-    // If PRIVATE_LOG_EXPANDED_METADATA_LEN is changed, causing the assertion below to fail, then the destructuring of
-    // the log encoding below must be updated as well.
-    std::static_assert(
-        PRIVATE_MESSAGE_EXPANDED_METADATA_LEN == 1,
-        "unexpected value for PRIVATE_LOG_EXPANDED_METADATA_LEN",
-    );
-
-    // See the documentation of this function for a description of the log layout
-    let msg_expanded_metadata = log_plaintext.get(0);
-    let (msg_type_id, msg_metadata) = from_expanded_metadata(msg_expanded_metadata);
-    let msg_content = array::subbvec(log_plaintext, PRIVATE_MESSAGE_EXPANDED_METADATA_LEN);
-
-    (msg_type_id, msg_metadata, msg_content)
 }

--- a/noir-projects/aztec-nr/aztec/src/discovery/private_notes.nr
+++ b/noir-projects/aztec-nr/aztec/src/discovery/private_notes.nr
@@ -1,9 +1,9 @@
 use crate::{
     discovery::{
         ComputeNoteHashAndNullifier,
-        MAX_MESSAGE_CONTENT_LEN,
         nonce_discovery::{attempt_note_nonce_discovery, DiscoveredNoteInfo},
     },
+    encrypted_logs::encoding::MAX_MESSAGE_CONTENT_LEN,
     oracle,
     utils::array,
 };

--- a/noir-projects/aztec-nr/aztec/src/encrypted_logs/encoding.nr
+++ b/noir-projects/aztec-nr/aztec/src/encrypted_logs/encoding.nr
@@ -3,34 +3,72 @@ use crate::{encrypted_logs::log_encryption::PRIVATE_LOG_PLAINTEXT_SIZE_IN_FIELDS
 
 global MAX_MESSAGE_LEN: u32 = PRIVATE_LOG_PLAINTEXT_SIZE_IN_FIELDS;
 
-/// The expanded message metadata takes up a single field.
 global MESSAGE_EXPANDED_METADATA_LEN: u32 = 1;
+
+// The standard message layout is composed of:
+//  - an initial field called the 'expanded metadata'
+//  - an arbitrary number of fields following that called the 'message content'
+//
+// ```
+// message: [ msg_expanded_metadata, ...msg_content ]
+// ```
+//
+// The expanded metadata itself is interpreted as a u128, of which:
+//  - the upper 64 bits are the message type id
+//  - the lower 64 bits are called the 'message metadata'
+//
+// ```
+// msg_expanded_metadata: [  msg_type_id    |  msg_metadata  ]
+//                        <---  64 bits --->|<--- 64 bits --->
+// ```
+//
+// The meaning of the message metadata and message content depend on the value of the message type id. Note that there
+// is nothing special about the message metadata, it _can_ be considered part of the content. It just has a different
+// name to make it distinct from the message content given that it is not a full field.
 
 /// The maximum length of a message's content, i.e. not including the expanded message metadata.
 pub global MAX_MESSAGE_CONTENT_LEN: u32 = MAX_MESSAGE_LEN - MESSAGE_EXPANDED_METADATA_LEN;
 
-/// Decodes a message following aztec-nr's standard message encoding.
+/// Encodes a message following aztec-nr's standard message encoding. This message can later be decoded with
+/// `decode_message` to retrieve the original values.
 ///
-/// The standard message layout is composed of:
-///  - an initial field called the 'expanded metadata'
-///  - an arbitrary number of fields following that called the 'message content'
+/// - The `msg_type` is an identifier that groups types of messages that are all processed the same way, e.g. private
+/// notes or events. Possible values are defined in `aztec::encrypted_logs::msg_type`.
+/// - The `msg_metadata` and `msg_content` are the values stored in the message, whose meaning depends on the
+///  `msg_type`. The only special thing about `msg_metadata` that separates it from `msg_content` is that it is a u64
+/// instead of a full Field (due to details of how messages are encoded), allowing applications that can fit values into
+/// this smaller variable to achieve higher data efficiency.
+pub fn encode_message<let N: u32>(
+    msg_type: u64,
+    msg_metadata: u64,
+    msg_content: [Field; N],
+) -> [Field; (N + MESSAGE_EXPANDED_METADATA_LEN)] {
+    std::static_assert(
+        msg_content.len() <= MAX_MESSAGE_CONTENT_LEN,
+        "Invalid message content: it must have a length of at most MAX_MESSAGE_CONTENT_LEN",
+    );
+
+    // If MESSAGE_EXPANDED_METADATA_LEN is changed, causing the assertion below to fail, then the destructuring of
+    // the message encoding below must be updated as well.
+    std::static_assert(
+        MESSAGE_EXPANDED_METADATA_LEN == 1,
+        "unexpected value for MESSAGE_EXPANDED_METADATA_LEN",
+    );
+    let mut message: [Field; (N + MESSAGE_EXPANDED_METADATA_LEN)] = std::mem::zeroed();
+
+    message[0] = to_expanded_metadata(msg_type, msg_metadata);
+    for i in 0..msg_content.len() {
+        message[MESSAGE_EXPANDED_METADATA_LEN + i] = msg_content[i];
+    }
+
+    message
+}
+
+/// Decodes a standard aztec-nr message, e.g. one created via `encode_message`, returning the original encoded values.
 ///
-/// ```
-/// message: [ msg_expanded_metadata, ...msg_content ]
-/// ```
-///
-/// The expanded metadata itself is interpreted as a u128, of which:
-///  - the upper 64 bits are the message type id
-///  - the lower 64 bits are called the 'message metadata'
-///
-/// ```
-/// msg_expanded_metadata: [  msg_type_id    |  msg_metadata  ]
-///                        <---  64 bits --->|<--- 64 bits --->
-/// ```
-///
-/// The meaning of the message metadata and message content depend on the value of the message type id. Note that there
-/// is nothing special about the message metadata, it _can_ be considered part of the content. It just has a different
-/// name to make it distinct from the message content given that it is not a full field.
+/// Note that `encode_message` returns a fixed size array while this function takes a `BoundedVec`: this is because
+/// prior to decoding the message type is unknown, and consequentially not known at compile time. If working with
+/// fixed-size messages, consider using `BoundedVec::from_array` to convert them.
 pub unconstrained fn decode_message(
     message: BoundedVec<Field, MAX_MESSAGE_LEN>,
 ) -> (u64, u64, BoundedVec<Field, MAX_MESSAGE_CONTENT_LEN>) {
@@ -55,7 +93,7 @@ pub unconstrained fn decode_message(
 
 global U64_SHIFT_MULTIPLIER: Field = 2.pow_32(64);
 
-pub fn to_expanded_metadata(msg_type: u64, msg_metadata: u64) -> Field {
+fn to_expanded_metadata(msg_type: u64, msg_metadata: u64) -> Field {
     // We use multiplication instead of bit shifting operations to shift the type bits as bit shift operations are
     // expensive in circuits.
     let type_field: Field = (msg_type as Field) * U64_SHIFT_MULTIPLIER;
@@ -73,13 +111,60 @@ fn from_expanded_metadata(input: Field) -> (u64, u64) {
 }
 
 mod tests {
-    use super::{from_expanded_metadata, to_expanded_metadata};
+    use crate::utils::array::subarray::subarray;
+    use super::{
+        decode_message, encode_message, from_expanded_metadata, MAX_MESSAGE_CONTENT_LEN,
+        to_expanded_metadata,
+    };
 
     global U64_MAX: u64 = (2.pow_32(64) - 1) as u64;
     global U128_MAX: Field = (2.pow_32(128) - 1);
 
     #[test]
-    fn packing_metadata() {
+    unconstrained fn encode_decode_empty_message(msg_type: u64, msg_metadata: u64) {
+        let encoded = encode_message(msg_type, msg_metadata, []);
+        let (decoded_msg_type, decoded_msg_metadata, decoded_msg_content) =
+            decode_message(BoundedVec::from_array(encoded));
+
+        assert_eq(decoded_msg_type, msg_type);
+        assert_eq(decoded_msg_metadata, msg_metadata);
+        assert_eq(decoded_msg_content.len(), 0);
+    }
+
+    #[test]
+    unconstrained fn encode_decode_short_message(
+        msg_type: u64,
+        msg_metadata: u64,
+        msg_content: [Field; MAX_MESSAGE_CONTENT_LEN / 2],
+    ) {
+        let encoded = encode_message(msg_type, msg_metadata, msg_content);
+        let (decoded_msg_type, decoded_msg_metadata, decoded_msg_content) =
+            decode_message(BoundedVec::from_array(encoded));
+
+        assert_eq(decoded_msg_type, msg_type);
+        assert_eq(decoded_msg_metadata, msg_metadata);
+        assert_eq(decoded_msg_content.len(), msg_content.len());
+        assert_eq(subarray(decoded_msg_content.storage(), 0), msg_content);
+    }
+
+    #[test]
+    unconstrained fn encode_decode_full_message(
+        msg_type: u64,
+        msg_metadata: u64,
+        msg_content: [Field; MAX_MESSAGE_CONTENT_LEN],
+    ) {
+        let encoded = encode_message(msg_type, msg_metadata, msg_content);
+        let (decoded_msg_type, decoded_msg_metadata, decoded_msg_content) =
+            decode_message(BoundedVec::from_array(encoded));
+
+        assert_eq(decoded_msg_type, msg_type);
+        assert_eq(decoded_msg_metadata, msg_metadata);
+        assert_eq(decoded_msg_content.len(), msg_content.len());
+        assert_eq(subarray(decoded_msg_content.storage(), 0), msg_content);
+    }
+
+    #[test]
+    unconstrained fn to_expanded_metadata_packing() {
         // Test case 1: All bits set
         let packed = to_expanded_metadata(U64_MAX, U64_MAX);
         let (msg_type, msg_metadata) = from_expanded_metadata(packed);
@@ -106,7 +191,7 @@ mod tests {
     }
 
     #[test]
-    fn unpacking_metadata() {
+    unconstrained fn from_expanded_metadata_packing() {
         // Test case 1: All bits set
         let input = U128_MAX as Field;
         let (msg_type, msg_metadata) = from_expanded_metadata(input);
@@ -133,7 +218,7 @@ mod tests {
     }
 
     #[test]
-    fn roundtrip_metadata(original_msg_type: u64, original_msg_metadata: u64) {
+    unconstrained fn to_from_expanded_metadata(original_msg_type: u64, original_msg_metadata: u64) {
         let packed = to_expanded_metadata(original_msg_type, original_msg_metadata);
         let (unpacked_msg_type, unpacked_msg_metadata) = from_expanded_metadata(packed);
 

--- a/noir-projects/aztec-nr/aztec/src/encrypted_logs/encoding.nr
+++ b/noir-projects/aztec-nr/aztec/src/encrypted_logs/encoding.nr
@@ -64,7 +64,7 @@ pub fn encode_message<let N: u32>(
     message
 }
 
-/// Decodes a standard aztec-nr message, e.g. one created via `encode_message`, returning the original encoded values.
+/// Decodes a standard aztec-nr message, i.e. one created via `encode_message`, returning the original encoded values.
 ///
 /// Note that `encode_message` returns a fixed size array while this function takes a `BoundedVec`: this is because
 /// prior to decoding the message type is unknown, and consequentially not known at compile time. If working with

--- a/noir-projects/aztec-nr/aztec/src/encrypted_logs/encoding.nr
+++ b/noir-projects/aztec-nr/aztec/src/encrypted_logs/encoding.nr
@@ -74,7 +74,7 @@ pub unconstrained fn decode_message(
 ) -> (u64, u64, BoundedVec<Field, MAX_MESSAGE_CONTENT_LEN>) {
     assert(
         message.len() >= MESSAGE_EXPANDED_METADATA_LEN,
-        f"Invalid message: it must have least {MESSAGE_EXPANDED_METADATA_LEN} fields",
+        f"Invalid message: it must have at least {MESSAGE_EXPANDED_METADATA_LEN} fields",
     );
 
     // If MESSAGE_EXPANDED_METADATA_LEN is changed, causing the assertion below to fail, then the destructuring of

--- a/noir-projects/aztec-nr/aztec/src/encrypted_logs/encoding.nr
+++ b/noir-projects/aztec-nr/aztec/src/encrypted_logs/encoding.nr
@@ -1,3 +1,58 @@
+// TODO(#12750): don't make these values assume we're using AES.
+use crate::{encrypted_logs::log_encryption::PRIVATE_LOG_PLAINTEXT_SIZE_IN_FIELDS, utils::array};
+
+global MAX_MESSAGE_LEN: u32 = PRIVATE_LOG_PLAINTEXT_SIZE_IN_FIELDS;
+
+/// The expanded message metadata takes up a single field.
+global MESSAGE_EXPANDED_METADATA_LEN: u32 = 1;
+
+/// The maximum length of a message's content, i.e. not including the expanded message metadata.
+pub global MAX_MESSAGE_CONTENT_LEN: u32 = MAX_MESSAGE_LEN - MESSAGE_EXPANDED_METADATA_LEN;
+
+/// Decodes a message following aztec-nr's standard message encoding.
+///
+/// The standard message layout is composed of:
+///  - an initial field called the 'expanded metadata'
+///  - an arbitrary number of fields following that called the 'message content'
+///
+/// ```
+/// message: [ msg_expanded_metadata, ...msg_content ]
+/// ```
+///
+/// The expanded metadata itself is interpreted as a u128, of which:
+///  - the upper 64 bits are the message type id
+///  - the lower 64 bits are called the 'message metadata'
+///
+/// ```
+/// msg_expanded_metadata: [  msg_type_id    |  msg_metadata  ]
+///                        <---  64 bits --->|<--- 64 bits --->
+/// ```
+///
+/// The meaning of the message metadata and message content depend on the value of the message type id. Note that there
+/// is nothing special about the message metadata, it _can_ be considered part of the content. It just has a different
+/// name to make it distinct from the message content given that it is not a full field.
+pub unconstrained fn decode_message(
+    message: BoundedVec<Field, MAX_MESSAGE_LEN>,
+) -> (u64, u64, BoundedVec<Field, MAX_MESSAGE_CONTENT_LEN>) {
+    assert(
+        message.len() >= MESSAGE_EXPANDED_METADATA_LEN,
+        f"Invalid message: it must have least {MESSAGE_EXPANDED_METADATA_LEN} fields",
+    );
+
+    // If MESSAGE_EXPANDED_METADATA_LEN is changed, causing the assertion below to fail, then the destructuring of
+    // the message encoding below must be updated as well.
+    std::static_assert(
+        MESSAGE_EXPANDED_METADATA_LEN == 1,
+        "unexpected value for MESSAGE_EXPANDED_METADATA_LEN",
+    );
+
+    let msg_expanded_metadata = message.get(0);
+    let (msg_type_id, msg_metadata) = from_expanded_metadata(msg_expanded_metadata);
+    let msg_content = array::subbvec(message, MESSAGE_EXPANDED_METADATA_LEN);
+
+    (msg_type_id, msg_metadata, msg_content)
+}
+
 global U64_SHIFT_MULTIPLIER: Field = 2.pow_32(64);
 
 pub fn to_expanded_metadata(msg_type: u64, msg_metadata: u64) -> Field {
@@ -9,7 +64,7 @@ pub fn to_expanded_metadata(msg_type: u64, msg_metadata: u64) -> Field {
     type_field + msg_metadata_field
 }
 
-pub fn from_expanded_metadata(input: Field) -> (u64, u64) {
+fn from_expanded_metadata(input: Field) -> (u64, u64) {
     input.assert_max_bit_size::<128>();
     let msg_metadata = (input as u64);
     let msg_type = ((input - (msg_metadata as Field)) / U64_SHIFT_MULTIPLIER) as u64;

--- a/noir-projects/aztec-nr/aztec/src/encrypted_logs/log_assembly_strategies/default_aes128/event.nr
+++ b/noir-projects/aztec-nr/aztec/src/encrypted_logs/log_assembly_strategies/default_aes128/event.nr
@@ -1,7 +1,7 @@
 use crate::{
     context::PrivateContext,
     encrypted_logs::{
-        encoding::to_expanded_metadata, encrypt::aes128::AES128,
+        encoding::encode_message, encrypt::aes128::AES128,
         log_assembly_strategies::default_aes128::utils::prefix_with_tag,
         log_encryption::LogEncryption, msg_type::PRIVATE_EVENT_MSG_TYPE_ID,
     },
@@ -9,28 +9,6 @@ use crate::{
     prelude::AztecAddress,
 };
 use protocol_types::{constants::PRIVATE_LOG_SIZE_IN_FIELDS, traits::{Serialize, ToField}};
-
-fn compute_event_plaintext_for_this_strategy<Event, let N: u32>(event: Event) -> [Field; N + 1]
-where
-    Event: EventInterface<N>,
-{
-    // TODO(#11571): with decryption happening in Noir we can now use the Packable trait instead.
-    let serialized_event = Serialize::<N>::serialize(event);
-
-    let mut fields = [0; N + 1];
-
-    // We pack message type id and message metadata into the first field. Search for `decode_log_plaintext` function to
-    // see where the value gets decoded.
-    fields[0] = to_expanded_metadata(
-        PRIVATE_EVENT_MSG_TYPE_ID,
-        Event::get_event_type_id().to_field() as u64,
-    );
-    for i in 0..serialized_event.len() {
-        fields[i + 1] = serialized_event[i];
-    }
-
-    fields
-}
 
 fn compute_log<Event, let N: u32>(
     event: Event,
@@ -40,7 +18,12 @@ fn compute_log<Event, let N: u32>(
 where
     Event: EventInterface<N>,
 {
-    let plaintext = compute_event_plaintext_for_this_strategy(event);
+    // TODO(#11571): with decryption happening in Noir we can now use the Packable trait instead.
+    let plaintext = encode_message(
+        PRIVATE_EVENT_MSG_TYPE_ID,
+        Event::get_event_type_id().to_field() as u64,
+        Serialize::<N>::serialize(event),
+    );
 
     let ciphertext = AES128::encrypt_log(plaintext, recipient);
 

--- a/noir-projects/aztec-nr/aztec/src/encrypted_logs/log_assembly_strategies/default_aes128/note.nr
+++ b/noir-projects/aztec-nr/aztec/src/encrypted_logs/log_assembly_strategies/default_aes128/note.nr
@@ -1,7 +1,7 @@
 use crate::{
     context::PrivateContext,
     encrypted_logs::{
-        encoding::to_expanded_metadata,
+        encoding::encode_message,
         encrypt::aes128::AES128,
         log_assembly_strategies::default_aes128::utils::prefix_with_tag,
         log_encryption::LogEncryption,
@@ -20,33 +20,6 @@ fn assert_note_exists<let N: u32>(context: PrivateContext, note_hash_counter: u3
     let note_exists =
         context.note_hashes.storage().any(|n: NoteHash| n.counter == note_hash_counter);
     assert(note_exists, "Can only emit a note log for an existing note.");
-}
-
-/// This particular log assembly strategy (AES 128) requires the note (and the
-/// note_id and the storage_slot) to be converted into bytes, because the aes function
-/// operates on bytes; not fields.
-/// NB: The "2" in "N + 2" is for the note_id and the storage_slot of the note:
-fn compute_note_plaintext_for_this_strategy<Note, let N: u32>(
-    note: Note,
-    storage_slot: Field,
-    msg_type_id: u64,
-) -> [Field; (N + 2)]
-where
-    Note: NoteType + Packable<N>,
-{
-    let packed_note = note.pack();
-
-    let mut fields = [0; N + 2];
-
-    // We pack log type id and log metadata into the first field. Search for `decode_log_plaintext` function to see
-    // where the value gets decoded.
-    fields[0] = to_expanded_metadata(msg_type_id, Note::get_id() as u64);
-    fields[1] = storage_slot;
-    for i in 0..packed_note.len() {
-        fields[i + 2] = packed_note[i];
-    }
-
-    fields
 }
 
 pub fn compute_note_log<Note, let N: u32>(
@@ -90,12 +63,22 @@ fn compute_log<Note, let N: u32>(
     storage_slot: Field,
     recipient: AztecAddress,
     sender: AztecAddress,
-    msg_type_id: u64,
+    msg_type: u64,
 ) -> [Field; PRIVATE_LOG_SIZE_IN_FIELDS]
 where
     Note: NoteType + Packable<N>,
 {
-    let plaintext = compute_note_plaintext_for_this_strategy(note, storage_slot, msg_type_id);
+    let packed_note = note.pack();
+
+    // A note message's content is the storage slot followed by the packed note representation
+    let mut msg_content: [Field; N + 1] = std::mem::zeroed();
+    msg_content[0] = storage_slot;
+    for i in 0..packed_note.len() {
+        msg_content[1 + i] = packed_note[i];
+    }
+
+    // Notes use the note type id for metadata
+    let plaintext = encode_message(msg_type, Note::get_id() as u64, msg_content);
 
     let ciphertext = AES128::encrypt_log(plaintext, recipient);
 

--- a/noir-projects/aztec-nr/aztec/src/oracle/logs.nr
+++ b/noir-projects/aztec-nr/aztec/src/oracle/logs.nr
@@ -1,4 +1,4 @@
-use crate::discovery::MAX_MESSAGE_CONTENT_LEN;
+use crate::encrypted_logs::encoding::MAX_MESSAGE_CONTENT_LEN;
 use protocol_types::{abis::event_selector::EventSelector, address::AztecAddress};
 
 /// The below only exists to broadcast the raw log, so we can provide it to the base rollup later to be constrained.


### PR DESCRIPTION
Hopefully the last step for a while in our msg encode/decode adventures. This creates `encoding::{encode_message, decode_message}`, which are functions that already existed in other modules but were not yet a core concept. I also added some tests.