### PR TITLE
chore: default aztec install and aztec up should pull latest alpha testnet version

### DIFF
--- a/aztec-up/bin/aztec-install
+++ b/aztec-up/bin/aztec-install
@@ -20,8 +20,8 @@ fi
 AZTEC_PATH=$HOME/.aztec
 BIN_PATH=${BIN_PATH:-$AZTEC_PATH/bin}
 
-# Define version if specified, otherwise set to "latest".
-VERSION=${VERSION:-"latest"}
+# Define version if specified, otherwise set to "alpha-testnet".
+VERSION=${VERSION:-"alpha-testnet"}
 INSTALL_URI=${INSTALL_URI:-https://install.aztec.network}
 if [ "$VERSION" != "latest" ]; then
   INSTALL_URI+="/$VERSION"

--- a/aztec-up/bin/aztec-up
+++ b/aztec-up/bin/aztec-up
@@ -38,8 +38,18 @@ fi
 
 if [ -n "$VERSION" ] && [ "$VERSION" != "latest" ]; then
   install_url="$INSTALL_URI/$VERSION/aztec-install"
-else
+elif [ -n "$VERSION" ] && [ "$VERSION" = "latest" ]; then
   install_url="$INSTALL_URI/aztec-install"
+else
+  echo "Installing latest testnet version..."
+
+  # Temporary: We want installs without specifying version to default to alpha-testnet. This will change.
+  install_url="$INSTALL_URI/alpha-testnet/aztec-install"
+  if ! curl --output /dev/null --silent --head --fail "$install_url"; then
+    echo "Testnet version not found... Falling back to latest released version."
+
+    install_url="$INSTALL_URI/aztec-install"
+  fi
 fi
 
 bash <(curl -s $install_url)

--- a/aztec-up/test/amm_flow.sh
+++ b/aztec-up/test/amm_flow.sh
@@ -15,6 +15,7 @@ fi
 export SKIP_PULL=1
 export NO_NEW_SHELL=1
 export INSTALL_URI=file:///home/ubuntu/aztec-packages/aztec-up/bin
+export VERSION=latest
 
 if [ -t 0 ]; then
   bash_args="-i"

--- a/aztec-up/test/basic_install.sh
+++ b/aztec-up/test/basic_install.sh
@@ -15,6 +15,7 @@ fi
 export SKIP_PULL=1
 export NO_NEW_SHELL=1
 export INSTALL_URI=file:///home/ubuntu/aztec-packages/aztec-up/bin
+export VERSION=latest
 
 if [ -t 0 ]; then
   bash_args="-i"

--- a/aztec-up/test/bridge_and_claim.sh
+++ b/aztec-up/test/bridge_and_claim.sh
@@ -15,6 +15,7 @@ fi
 export SKIP_PULL=1
 export NO_NEW_SHELL=1
 export INSTALL_URI=file:///home/ubuntu/aztec-packages/aztec-up/bin
+export VERSION=latest
 
 if [ -t 0 ]; then
   bash_args="-i"

--- a/aztec-up/test/counter_contract.sh
+++ b/aztec-up/test/counter_contract.sh
@@ -15,6 +15,7 @@ fi
 export SKIP_PULL=1
 export NO_NEW_SHELL=1
 export INSTALL_URI=file:///home/ubuntu/aztec-packages/aztec-up/bin
+export VERSION=latest
 
 if [ -t 0 ]; then
   bash_args="-i"


### PR DESCRIPTION
Requested by Rahul on a3

Another possible approach was to put alpha-testnet at root, but I end up opting for this because the goal is to minimize changes in the flow, by having the install pull directly from the new bucket.