### PR TITLE
chore: Deflake p2p client unit test

### DIFF
--- a/yarn-project/p2p/src/client/p2p_client.test.ts
+++ b/yarn-project/p2p/src/client/p2p_client.test.ts
@@ -2,7 +2,6 @@ import { MockL2BlockSource } from '@aztec/archiver/test';
 import { Signature } from '@aztec/foundation/eth-signature';
 import { Fr } from '@aztec/foundation/fields';
 import { retryUntil } from '@aztec/foundation/retry';
-import { sleep } from '@aztec/foundation/sleep';
 import type { AztecAsyncKVStore } from '@aztec/kv-store';
 import { openTmpStore } from '@aztec/kv-store/lmdb-v2';
 import { L2Block, randomPublishedL2Block } from '@aztec/stdlib/block';
@@ -150,8 +149,7 @@ describe('In-Memory P2P Client', () => {
 
       blockSource.removeBlocks(10);
 
-      // give the client a chance to react to the reorg
-      await sleep(1000);
+      await client.sync();
 
       await expect(client.getL2Tips()).resolves.toEqual({
         latest: { number: 90, hash: expect.any(String) },
@@ -161,8 +159,7 @@ describe('In-Memory P2P Client', () => {
 
       blockSource.addBlocks([await L2Block.random(91), await L2Block.random(92)]);
 
-      // give the client a chance to react to the new blocks
-      await sleep(1000);
+      await client.sync();
 
       await expect(client.getL2Tips()).resolves.toEqual({
         latest: { number: 92, hash: expect.any(String) },
@@ -190,7 +187,7 @@ describe('In-Memory P2P Client', () => {
       txPool.getAllTxs.mockResolvedValue([goodTx, badTx]);
 
       blockSource.removeBlocks(10);
-      await sleep(150);
+      await client.sync();
       expect(txPool.deleteTxs).toHaveBeenCalledWith([await badTx.getTxHash()]);
       await client.stop();
     });
@@ -221,9 +218,8 @@ describe('In-Memory P2P Client', () => {
       ]);
 
       blockSource.removeBlocks(10);
-      await sleep(150);
+      await client.sync();
       expect(txPool.deleteTxs).toHaveBeenCalledWith([await badTx.getTxHash()]);
-      await sleep(150);
       expect(txPool.markMinedAsPending).toHaveBeenCalledWith([await goodTx.getTxHash()]);
       await client.stop();
     });

--- a/yarn-project/p2p/src/client/p2p_client.ts
+++ b/yarn-project/p2p/src/client/p2p_client.ts
@@ -372,6 +372,11 @@ export class P2PClient<T extends P2PClientType = P2PClientType.Full>
     this.log.info('P2P client stopped.');
   }
 
+  /** Triggers a sync to the archiver. Used for testing. */
+  public async sync() {
+    await this.blockStream.sync();
+  }
+
   @trackSpan('p2pClient.broadcastProposal', async proposal => ({
     [Attributes.BLOCK_NUMBER]: proposal.blockNumber.toNumber(),
     [Attributes.SLOT_NUMBER]: proposal.slotNumber.toNumber(),


### PR DESCRIPTION
Removes sleeps in favor of forced syncs.

Fixes flakes like [this one](http://ci.aztec-labs.com/8be3f58c163e887d).
