### PR TITLE
test: replacing remaining use of DocsExampleContract

### DIFF
--- a/noir-projects/noir-contracts/Nargo.toml
+++ b/noir-projects/noir-contracts/Nargo.toml
@@ -38,6 +38,7 @@ members = [
     "contracts/test/child_contract",
     "contracts/test/counter_contract",
     "contracts/test/import_test_contract",
+    "contracts/test/no_constructor_contract",
     "contracts/test/note_getter_contract",
     "contracts/test/parent_contract",
     "contracts/test/pending_note_hashes_contract",

--- a/noir-projects/noir-contracts/Nargo.toml
+++ b/noir-projects/noir-contracts/Nargo.toml
@@ -38,6 +38,7 @@ members = [
     "contracts/test/child_contract",
     "contracts/test/counter_contract",
     "contracts/test/import_test_contract",
+    "contracts/test/invalid_account_contract",
     "contracts/test/no_constructor_contract",
     "contracts/test/note_getter_contract",
     "contracts/test/parent_contract",

--- a/noir-projects/noir-contracts/contracts/docs/docs_example_contract/src/main.nr
+++ b/noir-projects/noir-contracts/contracts/docs/docs_example_contract/src/main.nr
@@ -1,33 +1,20 @@
 mod options;
 mod types;
 
-// Following is a very simple game to show case use of PrivateMutable in as minimalistic way as possible
-// It also serves as an e2e test that you can read and then replace the PrivateMutable in the same call
-// (tests ordering in the circuit)
-
-// you have a card (PrivateMutable). Anyone can create a bigger card. Whoever is bigger will be the leader.
-// it also has dummy methods and other examples used for documentation e.g.
-// how to create custom notes, a custom struct for public state, a custom note that may be unencrypted
-// also has `options.nr` which shows various ways of using `NoteGetterOptions` to query notes
-// it also shows what our macros do behind the scenes!
-
-use dep::aztec::macros::aztec;
+use aztec::macros::aztec;
 
 #[aztec]
 pub contract DocsExample {
     // how to import dependencies defined in your workspace
-    use dep::aztec::{
+    use aztec::{
         encrypted_logs::log_assembly_strategies::default_aes128::note::encode_and_encrypt_note,
-        macros::{
-            functions::{internal, private, public, utility, view},
-            storage::{storage, storage_no_init},
-        },
+        macros::{functions::{private, public, utility}, storage::{storage, storage_no_init}},
         note::note_interface::NoteProperties,
+        prelude::{
+            AztecAddress, Map, NoteViewerOptions, PrivateContext, PrivateImmutable, PrivateMutable,
+            PrivateSet, PublicImmutable, PublicMutable,
+        },
         protocol_types::traits::Hash,
-    };
-    use dep::aztec::prelude::{
-        AztecAddress, Map, NoteViewerOptions, PrivateContext, PrivateImmutable, PrivateMutable,
-        PrivateSet, PublicImmutable, PublicMutable,
     };
 
     // how to import methods from other files/folders within your workspace
@@ -93,72 +80,12 @@ pub contract DocsExample {
         }
     }
 
-    // DO NOT uncomment this and add an initializer in this contract. We specifically need this contract to not have an initializer
-    // because of tests in 'yarn-project/end-to-end/src/e2e_deploy_contract/deploy_method.test.ts'
-    // #[initializer]
-    // #[private]
-    // // We can name our initializer anything we want as long as it's marked as aztec(initializer)
-    // fn initialize() {}
-
     // docs:start:initialize_public_immutable
     #[public]
     fn initialize_public_immutable(points: u8) {
         let mut new_leader = Leader { account: context.msg_sender(), points };
         storage.public_immutable.initialize(new_leader);
         // docs:end:initialize_public_immutable
-    }
-
-    #[private]
-    fn match_public_immutable(account: AztecAddress, points: u8) {
-        let expected = Leader { account, points };
-        let read = storage.public_immutable.read();
-
-        assert(read.account == expected.account, "Invalid account");
-        assert(read.points == expected.points, "Invalid points");
-    }
-
-    #[private]
-    fn get_public_immutable_constrained_private_indirect() -> Leader {
-        // This is a private function that calls another private function
-        // and returns the response.
-        // Used to test that we can retrieve values through calls and
-        // correctly return them in the simulation
-        let mut leader = DocsExample::at(context.this_address())
-            .get_public_immutable_constrained_private()
-            .view(&mut context);
-        leader.points += 1;
-        leader
-    }
-
-    #[public]
-    fn get_public_immutable_constrained_public_indirect() -> Leader {
-        // This is a public function that calls another public function
-        // and returns the response.
-        // Used to test that we can retrieve values through calls and
-        // correctly return them in the simulation
-        let mut leader = DocsExample::at(context.this_address())
-            .get_public_immutable_constrained_public()
-            .view(&mut context);
-        leader.points += 1;
-        leader
-    }
-
-    #[public]
-    #[view]
-    fn get_public_immutable_constrained_public() -> Leader {
-        storage.public_immutable.read()
-    }
-
-    #[public]
-    fn get_public_immutable_constrained_public_multiple() -> [Leader; 5] {
-        let a = storage.public_immutable.read();
-        [a, a, a, a, a]
-    }
-
-    #[private]
-    #[view]
-    fn get_public_immutable_constrained_private() -> Leader {
-        storage.public_immutable.read()
     }
 
     // docs:start:read_public_immutable
@@ -180,19 +107,6 @@ pub contract DocsExample {
         ));
     }
     // docs:end:initialize-private-mutable
-
-    #[private]
-    // msg_sender() is 0 at deploy time. So created another function
-    fn initialize_private(randomness: Field, points: u8) {
-        let legendary_card = CardNote::new(points, randomness, context.msg_sender());
-
-        // create and broadcast note
-        storage.legendary_card.initialize(legendary_card).emit(encode_and_encrypt_note(
-            &mut context,
-            context.msg_sender(),
-            context.msg_sender(),
-        ));
-    }
 
     // docs:start:state_vars-NoteGetterOptionsComparatorExampleNoir
     #[utility]
@@ -219,46 +133,6 @@ pub contract DocsExample {
             context.msg_sender(),
         ));
         // docs:end:state_vars-PrivateMutableReplace
-        DocsExample::at(context.this_address()).update_leader(context.msg_sender(), points).enqueue(
-            &mut context,
-        );
-    }
-
-    #[public]
-    fn emit_public(value: Field) {
-        // docs:start:emit_public
-        context.emit_public_log(/*message=*/ value);
-        context.emit_public_log(/*message=*/ [10, 20, 30]);
-        context.emit_public_log(/*message=*/ "Hello, world!");
-        // docs:end:emit_public
-    }
-
-    #[private]
-    #[view]
-    fn verify_private_authwit(inner_hash: Field) -> Field {
-        1
-    }
-
-    #[public]
-    fn spend_public_authwit(inner_hash: Field) -> Field {
-        1
-    }
-
-    #[public]
-    #[internal]
-    fn update_leader(account: AztecAddress, points: u8) {
-        let new_leader = Leader { account, points };
-        storage.leader.write(new_leader);
-    }
-
-    #[utility]
-    unconstrained fn get_leader() -> Leader {
-        storage.leader.read()
-    }
-
-    #[utility]
-    unconstrained fn get_legendary_card() -> CardNote {
-        storage.legendary_card.view_note()
     }
 
     // docs:start:private_mutable_is_initialized
@@ -275,10 +149,6 @@ pub contract DocsExample {
     }
     // docs:end:get_note-private-immutable
 
-    #[utility]
-    unconstrained fn is_priv_imm_initialized() -> bool {
-        storage.private_immutable.is_initialized()
-    }
     /// Macro equivalence section
     use dep::aztec::protocol_types::abis::private_circuit_public_inputs::PrivateCircuitPublicInputs;
     use dep::aztec::context::inputs::PrivateContextInputs;

--- a/noir-projects/noir-contracts/contracts/docs/docs_example_contract/src/main.nr
+++ b/noir-projects/noir-contracts/contracts/docs/docs_example_contract/src/main.nr
@@ -3,6 +3,7 @@ mod types;
 
 use aztec::macros::aztec;
 
+/// This is a contract with no real functionality. It is only used in documentation to showcase concepts of Aztec.nr.
 #[aztec]
 pub contract DocsExample {
     // how to import dependencies defined in your workspace

--- a/noir-projects/noir-contracts/contracts/test/invalid_account_contract/Nargo.toml
+++ b/noir-projects/noir-contracts/contracts/test/invalid_account_contract/Nargo.toml
@@ -1,0 +1,8 @@
+[package]
+name = "invalid_account_contract"
+authors = [""]
+compiler_version = ">=0.25.0"
+type = "contract"
+
+[dependencies]
+aztec = { path = "../../../../aztec-nr/aztec" }

--- a/noir-projects/noir-contracts/contracts/test/invalid_account_contract/src/main.nr
+++ b/noir-projects/noir-contracts/contracts/test/invalid_account_contract/src/main.nr
@@ -9,6 +9,7 @@ pub contract InvalidAccount {
     #[private]
     #[view]
     fn verify_private_authwit(inner_hash: Field) -> Field {
+        // Any return value that is not IS_VALID_SELECTOR (0x47dacd73) means 'invalid authwit'
         1
     }
 }

--- a/noir-projects/noir-contracts/contracts/test/invalid_account_contract/src/main.nr
+++ b/noir-projects/noir-contracts/contracts/test/invalid_account_contract/src/main.nr
@@ -1,0 +1,13 @@
+use aztec::macros::aztec;
+
+/// Used by token contract tests to test interaction with an invalid account.
+#[aztec]
+pub contract InvalidAccount {
+    use aztec::macros::functions::{private, view};
+
+    #[private]
+    #[view]
+    fn verify_private_authwit(inner_hash: Field) -> Field {
+        1
+    }
+}

--- a/noir-projects/noir-contracts/contracts/test/invalid_account_contract/src/main.nr
+++ b/noir-projects/noir-contracts/contracts/test/invalid_account_contract/src/main.nr
@@ -1,6 +1,7 @@
 use aztec::macros::aztec;
 
-/// Used by token contract tests to test interaction with an invalid account.
+/// Used by token contract tests to test interaction with an invalid account. This is an invalid account because it
+/// doesn't have an account entrypoint function defined (and the `verify_private_authwit` function is also invalid).
 #[aztec]
 pub contract InvalidAccount {
     use aztec::macros::functions::{private, view};

--- a/noir-projects/noir-contracts/contracts/test/no_constructor_contract/Nargo.toml
+++ b/noir-projects/noir-contracts/contracts/test/no_constructor_contract/Nargo.toml
@@ -1,0 +1,9 @@
+[package]
+name = "no_constructor_contract"
+authors = [""]
+compiler_version = ">=0.25.0"
+type = "contract"
+
+[dependencies]
+aztec = { path = "../../../../aztec-nr/aztec" }
+

--- a/noir-projects/noir-contracts/contracts/test/no_constructor_contract/Nargo.toml
+++ b/noir-projects/noir-contracts/contracts/test/no_constructor_contract/Nargo.toml
@@ -6,4 +6,4 @@ type = "contract"
 
 [dependencies]
 aztec = { path = "../../../../aztec-nr/aztec" }
-
+value_note = { path = "../../../../aztec-nr/value-note" }

--- a/noir-projects/noir-contracts/contracts/test/no_constructor_contract/src/main.nr
+++ b/noir-projects/noir-contracts/contracts/test/no_constructor_contract/src/main.nr
@@ -1,13 +1,42 @@
 use aztec::macros::aztec;
 
-/// Used to test deployment of a contract with no constructor in deploy_method.test.ts
+/// Used to test deployment of a contract with no constructor in deploy_method.test.ts and in
+/// private_initialization.test.ts
 #[aztec]
 pub contract NoConstructor {
-    use aztec::macros::functions::public;
+    use aztec::{
+        encrypted_logs::log_assembly_strategies::default_aes128::note::encode_and_encrypt_note,
+        macros::{functions::{private, public, utility}, storage::storage},
+        prelude::PrivateMutable,
+    };
+
+    use value_note::value_note::ValueNote;
+
+    #[storage]
+    struct Storage<Context> {
+        private_mutable: PrivateMutable<ValueNote, Context>,
+    }
 
     #[public]
     fn emit_public(value: Field) {
         context.emit_public_log(/*message=*/ value);
+    }
+
+    #[private]
+    fn initialize_private_mutable(value: Field) {
+        let note = ValueNote::new(value, context.msg_sender());
+
+        // create and broadcast note
+        storage.private_mutable.initialize(note).emit(encode_and_encrypt_note(
+            &mut context,
+            context.msg_sender(),
+            context.msg_sender(),
+        ));
+    }
+
+    #[utility]
+    unconstrained fn is_private_mutable_initialized() -> bool {
+        storage.private_mutable.is_initialized()
     }
 
 }

--- a/noir-projects/noir-contracts/contracts/test/no_constructor_contract/src/main.nr
+++ b/noir-projects/noir-contracts/contracts/test/no_constructor_contract/src/main.nr
@@ -23,7 +23,8 @@ pub contract NoConstructor {
         context.emit_public_log(/*message=*/ value);
     }
 
-    /// Arbitrary function used to test that we can call private functions on an uninitialized contract.
+    /// Arbitrary function used to test that we can call private functions on a contract with
+    /// no constructor/initializer.
     #[private]
     fn initialize_private_mutable(value: Field) {
         let note = ValueNote::new(value, context.msg_sender());

--- a/noir-projects/noir-contracts/contracts/test/no_constructor_contract/src/main.nr
+++ b/noir-projects/noir-contracts/contracts/test/no_constructor_contract/src/main.nr
@@ -17,16 +17,17 @@ pub contract NoConstructor {
         private_mutable: PrivateMutable<ValueNote, Context>,
     }
 
+    /// Arbitrary public method used to test public deployment works for a contract with no constructor.
     #[public]
     fn emit_public(value: Field) {
         context.emit_public_log(/*message=*/ value);
     }
 
+    /// Arbitrary function used to test that we can call private functions on an uninitialized contract.
     #[private]
     fn initialize_private_mutable(value: Field) {
         let note = ValueNote::new(value, context.msg_sender());
 
-        // create and broadcast note
         storage.private_mutable.initialize(note).emit(encode_and_encrypt_note(
             &mut context,
             context.msg_sender(),
@@ -34,6 +35,7 @@ pub contract NoConstructor {
         ));
     }
 
+    /// Helper function used to test that call to `initialize_private_mutable` was successful or not yet performed.
     #[utility]
     unconstrained fn is_private_mutable_initialized() -> bool {
         storage.private_mutable.is_initialized()

--- a/noir-projects/noir-contracts/contracts/test/no_constructor_contract/src/main.nr
+++ b/noir-projects/noir-contracts/contracts/test/no_constructor_contract/src/main.nr
@@ -1,0 +1,13 @@
+use aztec::macros::aztec;
+
+/// Used to test deployment of a contract with no constructor in deploy_method.test.ts
+#[aztec]
+pub contract NoConstructor {
+    use aztec::macros::functions::public;
+
+    #[public]
+    fn emit_public(value: Field) {
+        context.emit_public_log(/*message=*/ value);
+    }
+
+}

--- a/noir-projects/noir-contracts/contracts/test/test_contract/src/main.nr
+++ b/noir-projects/noir-contracts/contracts/test/test_contract/src/main.nr
@@ -4,6 +4,8 @@ mod test_note;
 // A contract used for testing a random hodgepodge of small features from simulator and end-to-end tests.
 use dep::aztec::macros::aztec;
 
+// DEPRECATED: This contract is deprecated now. If you want to test new features, create a simple new contract used
+// to test only that one feature (see NoConstructor contract for example.)
 #[aztec]
 pub contract Test {
     // Note: If you import a new kind of note you will most likely need to update the test_note_type_id test

--- a/noir-projects/noir-contracts/contracts/test/test_contract/src/main.nr
+++ b/noir-projects/noir-contracts/contracts/test/test_contract/src/main.nr
@@ -4,8 +4,8 @@ mod test_note;
 // A contract used for testing a random hodgepodge of small features from simulator and end-to-end tests.
 use dep::aztec::macros::aztec;
 
-// DEPRECATED: This contract is deprecated now. If you want to test new features, create a simple new contract used
-// to test only that one feature (see NoConstructor contract for example.)
+// DEPRECATED: This contract is deprecated. If you want to test new features, create a simple new contract used
+// to test only that one feature. See NoConstructor contract for example.
 #[aztec]
 pub contract Test {
     // Note: If you import a new kind of note you will most likely need to update the test_note_type_id test

--- a/yarn-project/end-to-end/src/e2e_blacklist_token_contract/blacklist_token_contract_test.ts
+++ b/yarn-project/end-to-end/src/e2e_blacklist_token_contract/blacklist_token_contract_test.ts
@@ -119,8 +119,6 @@ export class BlacklistTokenContractTest {
         this.logger.verbose(`Token deployed to ${this.asset.address}`);
 
         this.logger.verbose(`Deploying bad account...`);
-        // We use InvalidAccountContract as a bad account here. Bad account in a sense that it does not implement
-        // an account entry point.
         this.badAccount = await InvalidAccountContract.deploy(this.wallets[0]).send().deployed();
         this.logger.verbose(`Deployed to ${this.badAccount.address}.`);
 

--- a/yarn-project/end-to-end/src/e2e_blacklist_token_contract/blacklist_token_contract_test.ts
+++ b/yarn-project/end-to-end/src/e2e_blacklist_token_contract/blacklist_token_contract_test.ts
@@ -11,7 +11,7 @@ import {
   createLogger,
 } from '@aztec/aztec.js';
 import { MAX_NOTE_HASHES_PER_TX } from '@aztec/constants';
-import { NoConstructorContract } from '@aztec/noir-contracts.js/NoConstructor';
+import { InvalidAccountContract } from '@aztec/noir-contracts.js/InvalidAccount';
 import type { TokenContract } from '@aztec/noir-contracts.js/Token';
 import { TokenBlacklistContract } from '@aztec/noir-contracts.js/TokenBlacklist';
 
@@ -67,7 +67,7 @@ export class BlacklistTokenContractTest {
   accounts: CompleteAddress[] = [];
   asset!: TokenBlacklistContract;
   tokenSim!: TokenSimulator;
-  badAccount!: NoConstructorContract;
+  badAccount!: InvalidAccountContract;
 
   admin!: AccountWallet;
   other!: AccountWallet;
@@ -119,9 +119,9 @@ export class BlacklistTokenContractTest {
         this.logger.verbose(`Token deployed to ${this.asset.address}`);
 
         this.logger.verbose(`Deploying bad account...`);
-        // We use NoConstructorContract as a bad account here. Bad account in a sense that it does not implement
+        // We use InvalidAccountContract as a bad account here. Bad account in a sense that it does not implement
         // an account entry point.
-        this.badAccount = await NoConstructorContract.deploy(this.wallets[0]).send().deployed();
+        this.badAccount = await InvalidAccountContract.deploy(this.wallets[0]).send().deployed();
         this.logger.verbose(`Deployed to ${this.badAccount.address}.`);
 
         await this.mineBlocks();
@@ -140,7 +140,7 @@ export class BlacklistTokenContractTest {
           this.accounts.map(a => a.address),
         );
 
-        this.badAccount = await NoConstructorContract.at(badAccountAddress, this.wallets[0]);
+        this.badAccount = await InvalidAccountContract.at(badAccountAddress, this.wallets[0]);
         this.logger.verbose(`Bad account address: ${this.badAccount.address}`);
 
         expect(await this.asset.methods.get_roles(this.admin.getAddress()).simulate()).toEqual(

--- a/yarn-project/end-to-end/src/e2e_blacklist_token_contract/blacklist_token_contract_test.ts
+++ b/yarn-project/end-to-end/src/e2e_blacklist_token_contract/blacklist_token_contract_test.ts
@@ -11,7 +11,7 @@ import {
   createLogger,
 } from '@aztec/aztec.js';
 import { MAX_NOTE_HASHES_PER_TX } from '@aztec/constants';
-import { DocsExampleContract } from '@aztec/noir-contracts.js/DocsExample';
+import { NoConstructorContract } from '@aztec/noir-contracts.js/NoConstructor';
 import type { TokenContract } from '@aztec/noir-contracts.js/Token';
 import { TokenBlacklistContract } from '@aztec/noir-contracts.js/TokenBlacklist';
 
@@ -67,7 +67,7 @@ export class BlacklistTokenContractTest {
   accounts: CompleteAddress[] = [];
   asset!: TokenBlacklistContract;
   tokenSim!: TokenSimulator;
-  badAccount!: DocsExampleContract;
+  badAccount!: NoConstructorContract;
 
   admin!: AccountWallet;
   other!: AccountWallet;
@@ -119,7 +119,9 @@ export class BlacklistTokenContractTest {
         this.logger.verbose(`Token deployed to ${this.asset.address}`);
 
         this.logger.verbose(`Deploying bad account...`);
-        this.badAccount = await DocsExampleContract.deploy(this.wallets[0]).send().deployed();
+        // We use NoConstructorContract as a bad account here. Bad account in a sense that it does not implement
+        // an account entry point.
+        this.badAccount = await NoConstructorContract.deploy(this.wallets[0]).send().deployed();
         this.logger.verbose(`Deployed to ${this.badAccount.address}.`);
 
         await this.mineBlocks();
@@ -138,7 +140,7 @@ export class BlacklistTokenContractTest {
           this.accounts.map(a => a.address),
         );
 
-        this.badAccount = await DocsExampleContract.at(badAccountAddress, this.wallets[0]);
+        this.badAccount = await NoConstructorContract.at(badAccountAddress, this.wallets[0]);
         this.logger.verbose(`Bad account address: ${this.badAccount.address}`);
 
         expect(await this.asset.methods.get_roles(this.admin.getAddress()).simulate()).toEqual(

--- a/yarn-project/end-to-end/src/e2e_deploy_contract/deploy_method.test.ts
+++ b/yarn-project/end-to-end/src/e2e_deploy_contract/deploy_method.test.ts
@@ -10,7 +10,7 @@ import {
   makeFetch,
 } from '@aztec/aztec.js';
 import { CounterContract } from '@aztec/noir-contracts.js/Counter';
-import { DocsExampleContract } from '@aztec/noir-contracts.js/DocsExample';
+import { NoConstructorContract } from '@aztec/noir-contracts.js/NoConstructor';
 import { StatefulTestContract } from '@aztec/noir-contracts.js/StatefulTest';
 import { TokenContract } from '@aztec/noir-contracts.js/Token';
 import { GasFees } from '@aztec/stdlib/gas';
@@ -99,7 +99,7 @@ describe('e2e_deploy_contract deploy method', () => {
 
   it('publicly deploys a contract with no constructor', async () => {
     logger.debug(`Deploying contract with no constructor`);
-    const contract = await DocsExampleContract.deploy(wallet).send().deployed();
+    const contract = await NoConstructorContract.deploy(wallet).send().deployed();
     const arbitraryValue = 42;
     logger.debug(`Call a public function to check that it was publicly deployed`);
     const receipt = await contract.methods.emit_public(arbitraryValue).send().wait();
@@ -110,7 +110,7 @@ describe('e2e_deploy_contract deploy method', () => {
   it('refuses to deploy a contract with no constructor and no public deployment', async () => {
     logger.debug(`Deploying contract with no constructor and skipping public deploy`);
     const opts = { skipPublicDeployment: true, skipClassRegistration: true };
-    await expect(DocsExampleContract.deploy(wallet).prove(opts)).rejects.toThrow(/no function calls needed/i);
+    await expect(NoConstructorContract.deploy(wallet).prove(opts)).rejects.toThrow(/no function calls needed/i);
   });
 
   it('publicly deploys and calls a public contract in the same batched call', async () => {

--- a/yarn-project/end-to-end/src/e2e_deploy_contract/private_initialization.test.ts
+++ b/yarn-project/end-to-end/src/e2e_deploy_contract/private_initialization.test.ts
@@ -1,5 +1,5 @@
 import { type AztecNode, BatchCall, Fr, type Logger, type Wallet } from '@aztec/aztec.js';
-import { DocsExampleContract } from '@aztec/noir-contracts.js/DocsExample';
+import { NoConstructorContract } from '@aztec/noir-contracts.js/NoConstructor';
 import { StatefulTestContract } from '@aztec/noir-contracts.js/StatefulTest';
 import { TestContract } from '@aztec/noir-contracts.js/Test';
 import { siloNullifier } from '@aztec/stdlib/hash';
@@ -36,10 +36,10 @@ describe('e2e_deploy_contract private initialization', () => {
   // Requires registering the contract artifact and instance locally in the pxe.
   // This contract does not have a constructor, so the fn does not need the noinitcheck flag.
   it('executes a function in a contract without initializer', async () => {
-    const contract = await t.registerContract(wallet, DocsExampleContract);
-    await expect(contract.methods.is_legendary_initialized().simulate()).resolves.toEqual(false);
-    await contract.methods.initialize_private(0, 1).send().wait();
-    await expect(contract.methods.is_legendary_initialized().simulate()).resolves.toEqual(true);
+    const contract = await t.registerContract(wallet, NoConstructorContract);
+    await expect(contract.methods.is_private_mutable_initialized().simulate()).resolves.toEqual(false);
+    await contract.methods.initialize_private_mutable(42).send().wait();
+    await expect(contract.methods.is_private_mutable_initialized().simulate()).resolves.toEqual(true);
   });
 
   // Tests privately initializing an undeployed contract. Also requires pxe registration in advance.

--- a/yarn-project/end-to-end/src/e2e_token_contract/token_contract_test.ts
+++ b/yarn-project/end-to-end/src/e2e_token_contract/token_contract_test.ts
@@ -1,6 +1,6 @@
 import { getSchnorrWallet } from '@aztec/accounts/schnorr';
 import { type AccountWallet, type AztecNode, type CompleteAddress, type Logger, createLogger } from '@aztec/aztec.js';
-import { NoConstructorContract } from '@aztec/noir-contracts.js/NoConstructor';
+import { InvalidAccountContract } from '@aztec/noir-contracts.js/InvalidAccount';
 import { TokenContract } from '@aztec/noir-contracts.js/Token';
 
 import { jest } from '@jest/globals';
@@ -27,7 +27,7 @@ export class TokenContractTest {
   accounts: CompleteAddress[] = [];
   asset!: TokenContract;
   tokenSim!: TokenSimulator;
-  badAccount!: NoConstructorContract;
+  badAccount!: InvalidAccountContract;
   node!: AztecNode;
 
   constructor(testName: string) {
@@ -77,9 +77,9 @@ export class TokenContractTest {
         this.logger.verbose(`Token deployed to ${asset.address}`);
 
         this.logger.verbose(`Deploying bad account...`);
-        // We use NoConstructorContract as a bad account here. Bad account in a sense that it does not implement
+        // We use InvalidAccountContract as a bad account here. Bad account in a sense that it does not implement
         // an account entry point.
-        this.badAccount = await NoConstructorContract.deploy(this.wallets[0]).send().deployed();
+        this.badAccount = await InvalidAccountContract.deploy(this.wallets[0]).send().deployed();
         this.logger.verbose(`Deployed to ${this.badAccount.address}.`);
 
         return { tokenContractAddress: asset.address, badAccountAddress: this.badAccount.address };
@@ -96,7 +96,7 @@ export class TokenContractTest {
           this.accounts.map(a => a.address),
         );
 
-        this.badAccount = await NoConstructorContract.at(badAccountAddress, this.wallets[0]);
+        this.badAccount = await InvalidAccountContract.at(badAccountAddress, this.wallets[0]);
         this.logger.verbose(`Bad account address: ${this.badAccount.address}`);
 
         expect(await this.asset.methods.get_admin().simulate()).toBe(this.accounts[0].address.toBigInt());

--- a/yarn-project/end-to-end/src/e2e_token_contract/token_contract_test.ts
+++ b/yarn-project/end-to-end/src/e2e_token_contract/token_contract_test.ts
@@ -1,6 +1,6 @@
 import { getSchnorrWallet } from '@aztec/accounts/schnorr';
 import { type AccountWallet, type AztecNode, type CompleteAddress, type Logger, createLogger } from '@aztec/aztec.js';
-import { DocsExampleContract } from '@aztec/noir-contracts.js/DocsExample';
+import { NoConstructorContract } from '@aztec/noir-contracts.js/NoConstructor';
 import { TokenContract } from '@aztec/noir-contracts.js/Token';
 
 import { jest } from '@jest/globals';
@@ -27,7 +27,7 @@ export class TokenContractTest {
   accounts: CompleteAddress[] = [];
   asset!: TokenContract;
   tokenSim!: TokenSimulator;
-  badAccount!: DocsExampleContract;
+  badAccount!: NoConstructorContract;
   node!: AztecNode;
 
   constructor(testName: string) {
@@ -77,7 +77,9 @@ export class TokenContractTest {
         this.logger.verbose(`Token deployed to ${asset.address}`);
 
         this.logger.verbose(`Deploying bad account...`);
-        this.badAccount = await DocsExampleContract.deploy(this.wallets[0]).send().deployed();
+        // We use NoConstructorContract as a bad account here. Bad account in a sense that it does not implement
+        // an account entry point.
+        this.badAccount = await NoConstructorContract.deploy(this.wallets[0]).send().deployed();
         this.logger.verbose(`Deployed to ${this.badAccount.address}.`);
 
         return { tokenContractAddress: asset.address, badAccountAddress: this.badAccount.address };
@@ -94,7 +96,7 @@ export class TokenContractTest {
           this.accounts.map(a => a.address),
         );
 
-        this.badAccount = await DocsExampleContract.at(badAccountAddress, this.wallets[0]);
+        this.badAccount = await NoConstructorContract.at(badAccountAddress, this.wallets[0]);
         this.logger.verbose(`Bad account address: ${this.badAccount.address}`);
 
         expect(await this.asset.methods.get_admin().simulate()).toBe(this.accounts[0].address.toBigInt());

--- a/yarn-project/end-to-end/src/e2e_token_contract/token_contract_test.ts
+++ b/yarn-project/end-to-end/src/e2e_token_contract/token_contract_test.ts
@@ -77,8 +77,6 @@ export class TokenContractTest {
         this.logger.verbose(`Token deployed to ${asset.address}`);
 
         this.logger.verbose(`Deploying bad account...`);
-        // We use InvalidAccountContract as a bad account here. Bad account in a sense that it does not implement
-        // an account entry point.
         this.badAccount = await InvalidAccountContract.deploy(this.wallets[0]).send().deployed();
         this.logger.verbose(`Deployed to ${this.badAccount.address}.`);
 


### PR DESCRIPTION
Continuation of https://github.com/AztecProtocol/aztec-packages/pull/13368

This PR is part of a series of PRs in which I clean up our use of test contracts. In this PR I am replacing all the remaining use of DocsExampleContract in `/yarn-project`.

I introduce `NoConstructor` and `InvalidAccount` test contracts.