### PR TITLE
chore: Dump container netstat on address in use

### DIFF
--- a/.github/workflows/ci3.yml
+++ b/.github/workflows/ci3.yml
@@ -63,11 +63,10 @@ jobs:
 
       - name: CI Full Override
         # TODO consolidate legacy labels to just ci-full.
-        if: |
-          contains(github.event.pull_request.labels.*.name, 'e2e-all') ||
-          contains(github.event.pull_request.labels.*.name, 'network-all') ||
-          contains(github.event.pull_request.labels.*.name, 'ci-full')
-        run: echo "CI_FULL=1" >> $GITHUB_ENV
+        if: contains(github.event.pull_request.labels.*.name, 'ci-full')
+        run: |
+          echo "CI_FULL=1" >> $GITHUB_ENV
+          echo "USE_TEST_CACHE=0" >> $GITHUB_ENV
 
       - name: CI Nightly Check
         if: contains(github.ref, '-nightly.')

--- a/ci.sh
+++ b/ci.sh
@@ -71,7 +71,7 @@ function tail_live_instance {
 case "$cmd" in
   "ec2")
     # Spin up ec2 instance and ci bootstrap with shell on failure.
-    export USE_TEST_CACHE=1
+    export USE_TEST_CACHE=${USE_TEST_CACHE:-1}
     exec bootstrap_ec2
     ;;
   "ec2-no-cache")

--- a/ci3/bootstrap_ec2
+++ b/ci3/bootstrap_ec2
@@ -200,7 +200,7 @@ function run {
     # Capture net status.
     echo Installing and starting sysdig...
     sudo apt-get update &>/dev/null
-    sudo apt-get install -y sysdig &>/dev/null
+    sudo apt-get install -y sysdig net-tools &>/dev/null
     sudo sysdig -p '%evt.time (cid: %container.id) (event: %evt.dir %evt.type) (args: %evt.args): %proc.cmdline' 'evt.type=bind or evt.type=listen' > /tmp/netfile &
     netfile_pid=\$!
 

--- a/ci3/bootstrap_ec2
+++ b/ci3/bootstrap_ec2
@@ -151,7 +151,7 @@ container_script=$(cat <<EOF
     local code=\${PIPESTATUS[0]}
     set +x
     sudo dmesg 2>&1 | cache_log 'dmesg'
-    sudo cat /tmp/netfile | cache_log 'netfile'
+    sudo cat /tmp/netfile* | cache_log 'netfile'
     sudo cat /tmp/cpufile | cache_log 'cpufile'
     sudo cat /tmp/memfile | cache_log 'memfile'
     return \$code
@@ -197,18 +197,46 @@ function run {
     sudo cp -r \$HOME/.bb-crs/* /mnt/bb-crs
     echo Done in \$SECONDS seconds.
 
+    # Capture net status.
     echo Installing and starting sysdig...
     sudo apt-get update &>/dev/null
     sudo apt-get install -y sysdig &>/dev/null
     sudo sysdig -p '%evt.time (cid: %container.id) (event: %evt.dir %evt.type) (args: %evt.args): %proc.cmdline' 'evt.type=bind or evt.type=listen' > /tmp/netfile &
     netfile_pid=\$!
+
+    # Tail the sysdig log and watch for "Address already in use" errors.
+    tail -F /tmp/netfile | while read -r line; do
+        if echo \"\$line\" | grep -q EADDRINUSE; then
+            timestamp=\$(echo \"\$line\" | awk '{print \$1}')
+            cid=\$(echo \"\$line\" | grep -oP '(?<=\(cid: )[^\)]+')
+            filename=\"/tmp/netfile-\${timestamp//[:.]/}\"
+
+            echo \"Begin netstat dump for container \$cid at \$timestamp\" > \$filename
+            if [[ \"\$cid\" = \"host\" ]]; then
+                sudo netstat -tulnp | grep LISTEN >> \$filename;
+            else
+                pid=\$(docker inspect -f '{{.State.Pid}}' \$cid)
+                if [[ -z \"\$pid\" ]]; then
+                    echo \"Container \$cid not found, skipping netstat dump.\" >> \$filename;
+                else
+                  sudo nsenter -t \$(docker inspect -f '{{.State.Pid}}' \$cid) -n netstat -tulnp >> \$filename;
+                fi
+            fi
+            echo \"End netstat dump for container \$cid at \$timestamp\" >> \$filename
+        fi
+    done &
+    netstat_pid=\$!
+
     # Capture cpu load.
     mpstat 2 &> /tmp/cpufile &
     cpufile_pid=\$!
+
     # Capture mem load.
     vmstat -w -S M 2 &> /tmp/memfile &
     memfile_pid=\$!
-    trap 'sudo kill \$netfile_pid \$cpufile_pid \$memfile_pid' EXIT
+
+    # Kill monitoring processes on exit
+    trap 'sudo kill \$netstat_pid \$netfile_pid \$cpufile_pid \$memfile_pid' EXIT
 
     echo Starting devbox...
     docker run --privileged ${docker_args:-} \


### PR DESCRIPTION
Adds a tail to the netfile log that looks for errors "address already in use". When found, it runs `netstat` on the container that threw the error, and outputs it to a tmp file.

When uploading the netfile contents to ci, we upload all the netstat dumps as well.

Tested locally, and the result is:

```$ cat /tmp/netfile-*
Begin netstat dump for container host at 14:20:16.326383038
tcp        0      0 127.0.0.1:631           0.0.0.0:*               LISTEN      2091/cupsd          
tcp        0      0 127.0.0.1:40255         0.0.0.0:*               LISTEN      4787/kbfsfuse       
tcp        0      0 127.0.0.1:40741         0.0.0.0:*               LISTEN      5354/expressvpn-bro 
tcp        0      0 127.0.0.1:40529         0.0.0.0:*               LISTEN      4431/expressvpn-age 
tcp        0      0 127.0.0.1:6379          0.0.0.0:*               LISTEN      12528/ssh           
tcp        0      0 127.0.0.1:8545          0.0.0.0:*               LISTEN      190938/anvil        
tcp        0      0 127.0.0.53:53           0.0.0.0:*               LISTEN      1262/systemd-resolv 
tcp        0      0 127.0.0.1:17576         0.0.0.0:*               LISTEN      4720/keybase        
tcp        0      0 127.0.0.1:17600         0.0.0.0:*               LISTEN      4483/dropbox        
tcp        0      0 127.0.0.1:17603         0.0.0.0:*               LISTEN      4483/dropbox        
tcp        0      0 0.0.0.0:17500           0.0.0.0:*               LISTEN      4483/dropbox        
tcp        0      0 127.0.0.54:53           0.0.0.0:*               LISTEN      1262/systemd-resolv 
tcp6       0      0 ::1:631                 :::*                    LISTEN      2091/cupsd          
tcp6       0      0 ::1:6379                :::*                    LISTEN      12528/ssh           
tcp6       0      0 :::17500                :::*                    LISTEN      4483/dropbox        
End netstat dump for container host at 14:20:16.326383038
Begin netstat dump for container 9a2a4eb609d7 at 14:23:58.387620081
Active Internet connections (only servers)
Proto Recv-Q Send-Q Local Address           Foreign Address         State       PID/Program name    
tcp        0      0 127.0.0.1:8545          0.0.0.0:*               LISTEN      399185/anvil        
End netstat dump for container 9a2a4eb609d7 at 14:23:58.387620081
```

Tested this by starting two anvils on the same port in my machine, and then by doing the same on a container with `docker run --rm ghcr.io/foundry-rs/foundry:latest "anvil -p 8545 & anvil -p 8545 & sleep 10"`.
