### PR TITLE
chore(civc): Rename e2e trace to aztec trace

### DIFF
--- a/barretenberg/cpp/src/barretenberg/api/api_client_ivc.cpp
+++ b/barretenberg/cpp/src/barretenberg/api/api_client_ivc.cpp
@@ -110,7 +110,7 @@ void write_standalone_vk(const std::string& output_data_type,
     Program program{ get_constraint_system(bytecode_path, /*honk_recursion=*/0), /*witness=*/{} };
     auto& ivc_constraints = program.constraints.ivc_recursion_constraints;
 
-    TraceSettings trace_settings{ E2E_FULL_TEST_STRUCTURE };
+    TraceSettings trace_settings{ AZTEC_TRACE_STRUCTURE };
 
     const ProgramMetadata metadata{ .ivc = ivc_constraints.empty()
                                                ? nullptr
@@ -151,7 +151,7 @@ void write_vk_for_ivc(const std::string& bytecode_path, const std::filesystem::p
     // MAGIC_NUMBER is bb::PAIRING_POINT_ACCUMULATOR_SIZE or bb::PROPAGATED_DATABUS_COMMITMENTS_SIZE
     static constexpr size_t MAGIC_NUMBER = 16;
 
-    ClientIVC ivc{ { E2E_FULL_TEST_STRUCTURE } };
+    ClientIVC ivc{ { AZTEC_TRACE_STRUCTURE } };
     ClientIVCMockCircuitProducer circuit_producer;
 
     // Initialize the IVC with an arbitrary circuit
@@ -227,7 +227,7 @@ std::shared_ptr<ClientIVC> _accumulate(std::vector<acir_format::AcirProgram>& fo
     using Program = acir_format::AcirProgram;
     using namespace acir_format;
 
-    TraceSettings trace_settings{ E2E_FULL_TEST_STRUCTURE };
+    TraceSettings trace_settings{ AZTEC_TRACE_STRUCTURE };
     auto ivc = std::make_shared<ClientIVC>(trace_settings);
 
     const ProgramMetadata metadata{ ivc };
@@ -375,7 +375,7 @@ void gate_count_for_ivc(const std::string& bytecode_path, bool include_gates_per
     // Initialize an SRS to make the ClientIVC constructor happy
     init_bn254_crs(1 << CONST_PG_LOG_N);
     init_grumpkin_crs(1 << CONST_ECCVM_LOG_N);
-    TraceSettings trace_settings{ E2E_FULL_TEST_STRUCTURE };
+    TraceSettings trace_settings{ AZTEC_TRACE_STRUCTURE };
 
     size_t i = 0;
     for (const auto& constraint_system : constraint_systems) {

--- a/barretenberg/cpp/src/barretenberg/benchmark/client_ivc_bench/client_ivc.bench.cpp
+++ b/barretenberg/cpp/src/barretenberg/benchmark/client_ivc_bench/client_ivc.bench.cpp
@@ -51,7 +51,7 @@ BENCHMARK_DEFINE_F(ClientIVCBench, Full)(benchmark::State& state)
  */
 BENCHMARK_DEFINE_F(ClientIVCBench, Ambient_17_in_20)(benchmark::State& state)
 {
-    ClientIVC ivc{ { E2E_FULL_TEST_STRUCTURE } };
+    ClientIVC ivc{ { AZTEC_TRACE_STRUCTURE } };
 
     auto total_num_circuits = 2 * static_cast<size_t>(state.range(0)); // 2x accounts for kernel circuits
     auto mocked_vkeys = mock_verification_keys(total_num_circuits);

--- a/barretenberg/cpp/src/barretenberg/benchmark/mega_memory_bench/mega_memory.bench.cpp
+++ b/barretenberg/cpp/src/barretenberg/benchmark/mega_memory_bench/mega_memory.bench.cpp
@@ -323,7 +323,7 @@ void fill_trace_client_ivc_bench(State& state)
 
 void fill_trace_e2e_full_test(State& state)
 {
-    fill_trace(state, { E2E_FULL_TEST_STRUCTURE });
+    fill_trace(state, { AZTEC_TRACE_STRUCTURE });
 }
 
 static void pk_mem(State& state, void (*test_circuit_function)(State&)) noexcept

--- a/barretenberg/cpp/src/barretenberg/dsl/acir_proofs/c_bind.cpp
+++ b/barretenberg/cpp/src/barretenberg/dsl/acir_proofs/c_bind.cpp
@@ -195,7 +195,7 @@ WASM_EXPORT void acir_prove_and_verify_aztec_client(uint8_t const* acir_stack,
         folding_stack.push_back(Program{ constraints, witness });
     }
     // TODO(#7371) dedupe this with the rest of the similar code
-    TraceSettings trace_settings{ E2E_FULL_TEST_STRUCTURE };
+    TraceSettings trace_settings{ AZTEC_TRACE_STRUCTURE };
     auto ivc = std::make_shared<ClientIVC>(trace_settings);
 
     const acir_format::ProgramMetadata metadata{ ivc };
@@ -249,7 +249,7 @@ WASM_EXPORT void acir_prove_aztec_client(uint8_t const* acir_stack,
         acir_format::AcirFormat constraints = acir_format::circuit_buf_to_acir_format(bincode, /*honk_recursion=*/0);
         folding_stack.push_back(Program{ constraints, witness });
     }
-    TraceSettings trace_settings{ E2E_FULL_TEST_STRUCTURE };
+    TraceSettings trace_settings{ AZTEC_TRACE_STRUCTURE };
     auto ivc = std::make_shared<ClientIVC>(trace_settings);
 
     const acir_format::ProgramMetadata metadata{ ivc };
@@ -446,7 +446,7 @@ WASM_EXPORT void acir_gates_aztec_client(uint8_t const* acir_stack, uint8_t** ou
     std::vector<std::vector<uint8_t>> acirs = from_buffer<std::vector<std::vector<uint8_t>>>(acir_stack);
     std::vector<uint32_t> totals;
 
-    TraceSettings trace_settings{ E2E_FULL_TEST_STRUCTURE };
+    TraceSettings trace_settings{ AZTEC_TRACE_STRUCTURE };
     for (auto& bincode : acirs) {
         const acir_format::AcirFormat constraint_system =
             acir_format::circuit_buf_to_acir_format(bincode, /*honk_recursion=*/0);

--- a/barretenberg/cpp/src/barretenberg/goblin/mock_circuits_pinning.test.cpp
+++ b/barretenberg/cpp/src/barretenberg/goblin/mock_circuits_pinning.test.cpp
@@ -76,7 +76,7 @@ TEST_F(MegaMockCircuitsPinning, E2EStructuredCircuitSize)
 {
     GoblinProver goblin;
     MegaCircuitBuilder app_circuit{ goblin.op_queue };
-    TraceSettings trace_settings{ E2E_FULL_TEST_STRUCTURE };
+    TraceSettings trace_settings{ AZTEC_TRACE_STRUCTURE };
     auto proving_key = std::make_shared<DeciderProvingKey>(app_circuit, trace_settings);
     EXPECT_EQ(proving_key->proving_key.log_circuit_size, 18);
 }

--- a/barretenberg/cpp/src/barretenberg/plonk_honk_shared/execution_trace/mega_execution_trace.hpp
+++ b/barretenberg/cpp/src/barretenberg/plonk_honk_shared/execution_trace/mega_execution_trace.hpp
@@ -330,17 +330,17 @@ static constexpr TraceStructure EXAMPLE_20{ .ecc_op = 1 << 11,
 /**
  * @brief Structuring tailored to the full e2e TS test (Currently optimized for five key testnet transactions)
  */
-static constexpr TraceStructure E2E_FULL_TEST_STRUCTURE{ .ecc_op = 1 << 10,
-                                                         .busread = 6000,
-                                                         .lookup = 15000,
-                                                         .pub_inputs = 5000,
-                                                         .arithmetic = 56000,
-                                                         .delta_range = 18000,
-                                                         .elliptic = 6000,
-                                                         .aux = 26000,
-                                                         .poseidon2_external = 17000,
-                                                         .poseidon2_internal = 92000,
-                                                         .overflow = 0 };
+static constexpr TraceStructure AZTEC_TRACE_STRUCTURE{ .ecc_op = 1 << 10,
+                                                       .busread = 6000,
+                                                       .lookup = 15000,
+                                                       .pub_inputs = 5000,
+                                                       .arithmetic = 56000,
+                                                       .delta_range = 18000,
+                                                       .elliptic = 6000,
+                                                       .aux = 26000,
+                                                       .poseidon2_external = 17000,
+                                                       .poseidon2_internal = 92000,
+                                                       .overflow = 0 };
 
 template <typename T>
 concept HasAdditionalSelectors = IsAnyOf<T, MegaExecutionTraceBlocks>;


### PR DESCRIPTION
Client IVC tech debt, this is now 'the' trace not just 'a trace optimized for e2e test'