### PR TITLE
chore(vscode): remove hardcoded clangd path

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -133,11 +133,6 @@
     "editor.formatOnSave": true
   },
   //
-  // Clangd. Note that this setting may be overridden by user settings
-  // to the default value "clangd".
-  //
-  "clangd.path": "clangd-16",
-  //
   // C/C++ (should be disabled)
   //
   // Make sure all C++ IntelliSense features are disabled


### PR DESCRIPTION
This seemed to interfere with the clangd that comes with vscode that is no longer 16. Not sure this provided benefit.