### PR TITLE
chore: run ethereum nodes on larger instances in gcloud

### DIFF
--- a/spartan/aztec-network/resources/gcloud.yaml
+++ b/spartan/aztec-network/resources/gcloud.yaml
@@ -57,16 +57,19 @@ ethereum:
   execution:
     resources:
       requests:
-        memory: "5Gi"
-    storageSize: "80Gi"
+        memory: "13Gi"
+        cpu: "3"
+    storageSize: "90Gi"
   beacon:
     resources:
       requests:
-        memory: "5Gi"
-    storageSize: "80Gi"
+        memory: "13Gi"
+        cpu: "3"
+    storageSize: "90Gi"
   validator:
     resources:
       requests:
-        memory: "5Gi"
+        memory: "13Gi"
+        cpu: "3"
 
 


### PR DESCRIPTION
## Overview

Should run ethereum subchart on t2d-standard-4 core machines
