### PR TITLE
fix: easier description of how to use multiple authwitnesses with cli wallet

### DIFF
--- a/yarn-project/cli-wallet/src/cmds/index.ts
+++ b/yarn-project/cli-wallet/src/cmds/index.ts
@@ -267,7 +267,13 @@ export function injectCommands(
     .addOption(
       createSecretKeyOption("The sender's secret key", !db, sk => aliasedSecretKeyParser(sk, db)).conflicts('account'),
     )
-    .addOption(createAuthwitnessOption('Authorization witness to use for the transaction', !db, db))
+    .addOption(
+      createAuthwitnessOption(
+        'Authorization witness to use for the transaction. If using multiple, pass a comma separated string',
+        !db,
+        db,
+      ),
+    )
     .addOption(createAccountOption('Alias or address of the account to send the transaction from', !db, db))
     .option('--no-wait', 'Print transaction hash without waiting for it to be mined')
     .option('--no-cancel', 'Do not allow the transaction to be cancelled. This makes for cheaper transactions.');
@@ -285,7 +291,7 @@ export function injectCommands(
       secretKey,
       alias,
       cancel,
-      authWitness,
+      authWitness: authWitnessArray,
     } = options;
     const client = pxeWrapper?.getPXE() ?? (await createCompatibleClient(rpcUrl, debugLogger));
     const account = await createOrRetrieveAccount(client, parsedFromAddress, db, secretKey);
@@ -294,7 +300,7 @@ export function injectCommands(
 
     debugLogger.info(`Using wallet with address ${wallet.getCompleteAddress().address.toString()}`);
 
-    const authWitnesses = cleanupAuthWitnesses(authWitness);
+    const authWitnesses = cleanupAuthWitnesses(authWitnessArray);
     const sentTx = await send(
       wallet,
       functionName,

--- a/yarn-project/cli-wallet/src/utils/options/options.ts
+++ b/yarn-project/cli-wallet/src/utils/options/options.ts
@@ -39,14 +39,18 @@ export function aliasedTxHashParser(txHash: string, db?: WalletDB) {
   }
 }
 
-export function aliasedAuthWitParser(witness: string, db?: WalletDB) {
-  try {
-    return AuthWitness.fromString(witness);
-  } catch (err) {
-    const prefixed = witness.includes(':') ? witness : `authwits:${witness}`;
-    const rawAuthWitness = db ? db.tryRetrieveAlias(prefixed) : witness;
-    return AuthWitness.fromString(rawAuthWitness);
-  }
+export function aliasedAuthWitParser(witnesses: string, db?: WalletDB) {
+  const parsedWitnesses = witnesses.split(',').map(witness => {
+    try {
+      return AuthWitness.fromString(witness);
+    } catch (err) {
+      const prefixed = witness.includes(':') ? witness : `authwits:${witness}`;
+      const rawAuthWitness = db ? db.tryRetrieveAlias(prefixed) : witness;
+      return AuthWitness.fromString(rawAuthWitness);
+    }
+  });
+
+  return parsedWitnesses;
 }
 
 export function aliasedAddressParser(defaultPrefix: AliasType, address: string, db?: WalletDB) {
@@ -80,7 +84,7 @@ export function createAccountOption(description: string, hide: boolean, db?: Wal
 }
 
 export function createAuthwitnessOption(description: string, hide: boolean, db?: WalletDB) {
-  return new Option('-aw, --auth-witness <string>', description)
+  return new Option('-aw, --auth-witness <string,...>', description)
     .hideHelp(hide)
     .argParser(witness => aliasedAuthWitParser(witness, db));
 }
@@ -180,7 +184,6 @@ async function contractArtifactFromWorkspace(pkg?: string, contractName?: string
   return `${cwd}/${TARGET_DIR}/${bestMatch[0]}`;
 }
 
-export function cleanupAuthWitnesses(authWitnesses: AuthWitness | AuthWitness[]): AuthWitness[] {
-  const authWitnessArray = Array.isArray(authWitnesses) ? authWitnesses : [authWitnesses];
-  return authWitnessArray.filter(w => w !== undefined);
+export function cleanupAuthWitnesses(authWitnesses: AuthWitness[] | undefined): AuthWitness[] {
+  return authWitnesses?.filter(w => w !== undefined) ?? [];
 }


### PR DESCRIPTION
Was unable to figure out how it worked here from the desc to use multiple authwits in a single tx, so I made it a bit easier to figure out and added it in the desc
