### PR TITLE
chore: use a deployment instead of a replicaset for agents

### DIFF
--- a/spartan/aztec-network/templates/prover-agent.yaml
+++ b/spartan/aztec-network/templates/prover-agent.yaml
@@ -1,6 +1,6 @@
 {{- if .Values.proverAgent.enabled }}
 apiVersion: apps/v1
-kind: ReplicaSet
+kind: Deployment
 metadata:
   name: {{ include "aztec-network.fullname" . }}-prover-agent
   labels:


### PR DESCRIPTION
Deployments should be preferred over replica sets. Not sure how I forgot about this when I wrote this template :grimacing: 