### PR TITLE
fix: disable unbuffered output

### DIFF
--- a/spartan/scripts/monitor_k8s_deployment.sh
+++ b/spartan/scripts/monitor_k8s_deployment.sh
@@ -21,9 +21,6 @@ fi
 
 # Disable strict mode inside the monitoring function
 
-# Redirect all output to /dev/tty to force unbuffered output directly to terminal
-exec >/dev/tty 2>/dev/tty
-
 # Function to handle cleanup on exit
 function cleanup {
   echo -e "\n==== Deployment monitoring complete. ====\n"


### PR DESCRIPTION
Maybe a fix for the kind-smoke flake, maybe it'll give us more output :pray:. Fix for:
```
16:24:09 ./monitor_k8s_deployment.sh: line 25: /dev/tty: No such device or address
```
