### PR TITLE
chore: BoundedVec::for_each

### DIFF
--- a/cspell.json
+++ b/cspell.json
@@ -96,6 +96,7 @@
     "dockerized",
     "doesnt",
     "dont",
+    "eachi",
     "ecdh",
     "ecdsasecp",
     "elif",

--- a/noir-projects/aztec-nr/aztec/src/discovery/nonce_discovery.nr
+++ b/noir-projects/aztec-nr/aztec/src/discovery/nonce_discovery.nr
@@ -1,7 +1,4 @@
-use crate::{
-    discovery::{ComputeNoteHashAndNullifier, private_notes::MAX_NOTE_PACKED_LEN},
-    utils::array,
-};
+use crate::discovery::{ComputeNoteHashAndNullifier, private_notes::MAX_NOTE_PACKED_LEN};
 
 use dep::protocol_types::{
     address::AztecAddress,
@@ -44,49 +41,46 @@ pub unconstrained fn attempt_note_nonce_discovery<Env>(
 
     // We need to find nonces (typically just one) that result in a note hash that, once siloed into a unique note hash,
     // is one of the note hashes created by the transaction.
-    array::for_each_in_bounded_vec(
-        unique_note_hashes_in_tx,
-        |expected_unique_note_hash, i| {
-            // Nonces are computed by hashing the first nullifier in the transaction with the index of the note in the
-            // new note hashes array. We therefore know for each note in every transaction what its nonce is.
-            let candidate_nonce = compute_note_hash_nonce(first_nullifier_in_tx, i);
+    unique_note_hashes_in_tx.for_eachi(|i, expected_unique_note_hash| {
+        // Nonces are computed by hashing the first nullifier in the transaction with the index of the note in the
+        // new note hashes array. We therefore know for each note in every transaction what its nonce is.
+        let candidate_nonce = compute_note_hash_nonce(first_nullifier_in_tx, i);
 
-            // Given nonce, note content and metadata, we can compute the note hash and silo it to check if it matches
-            // the note hash at the array index we're currently processing.
-            // TODO(#11157): handle failed note_hash_and_nullifier computation
-            let hashes = compute_note_hash_and_nullifier(
-                packed_note,
-                storage_slot,
-                note_type_id,
-                contract_address,
-                candidate_nonce,
-            )
-                .expect(f"Failed to compute a note hash for note type {note_type_id}");
+        // Given nonce, note content and metadata, we can compute the note hash and silo it to check if it matches
+        // the note hash at the array index we're currently processing.
+        // TODO(#11157): handle failed note_hash_and_nullifier computation
+        let hashes = compute_note_hash_and_nullifier(
+            packed_note,
+            storage_slot,
+            note_type_id,
+            contract_address,
+            candidate_nonce,
+        )
+            .expect(f"Failed to compute a note hash for note type {note_type_id}");
 
-            let siloed_note_hash = compute_siloed_note_hash(contract_address, hashes.note_hash);
-            let unique_note_hash = compute_unique_note_hash(candidate_nonce, siloed_note_hash);
+        let siloed_note_hash = compute_siloed_note_hash(contract_address, hashes.note_hash);
+        let unique_note_hash = compute_unique_note_hash(candidate_nonce, siloed_note_hash);
 
-            if unique_note_hash == expected_unique_note_hash {
-                // Note that while we did check that the note hash is the preimage of the expected unique note hash, we
-                // perform no validations on the nullifier - we fundamentally cannot, since only the application knows
-                // how to compute nullifiers. We simply trust it to have provided the correct one: if it hasn't, then
-                // PXE may fail to realize that a given note has been nullified already, and calls to the application
-                // could result in invalid transactions (with duplicate nullifiers). This is not a concern because an
-                // application already has more direct means of making a call to it fail the transaction.
-                discovered_notes.push(
-                    DiscoveredNoteInfo {
-                        nonce: candidate_nonce,
-                        note_hash: hashes.note_hash,
-                        inner_nullifier: hashes.inner_nullifier,
-                    },
-                );
+        if unique_note_hash == expected_unique_note_hash {
+            // Note that while we did check that the note hash is the preimage of the expected unique note hash, we
+            // perform no validations on the nullifier - we fundamentally cannot, since only the application knows
+            // how to compute nullifiers. We simply trust it to have provided the correct one: if it hasn't, then
+            // PXE may fail to realize that a given note has been nullified already, and calls to the application
+            // could result in invalid transactions (with duplicate nullifiers). This is not a concern because an
+            // application already has more direct means of making a call to it fail the transaction.
+            discovered_notes.push(
+                DiscoveredNoteInfo {
+                    nonce: candidate_nonce,
+                    note_hash: hashes.note_hash,
+                    inner_nullifier: hashes.inner_nullifier,
+                },
+            );
 
-                // We don't exit the loop - it is possible (though rare) for the exact same note content to be present
-                // multiple times in the same transaction with different nonces. This typically doesn't happen due to
-                // notes containing random values in order to hide their contents.
-            }
-        },
-    );
+            // We don't exit the loop - it is possible (though rare) for the exact same note content to be present
+            // multiple times in the same transaction with different nonces. This typically doesn't happen due to
+            // notes containing random values in order to hide their contents.
+        }
+    });
 
     debug_log_format(
         "Discovered a total of {0} notes",

--- a/noir-projects/aztec-nr/aztec/src/discovery/partial_notes.nr
+++ b/noir-projects/aztec-nr/aztec/src/discovery/partial_notes.nr
@@ -1,9 +1,6 @@
 use crate::{
     capsules::CapsuleArray,
-    discovery::{
-        ComputeNoteHashAndNullifier,
-        nonce_discovery::{attempt_note_nonce_discovery, DiscoveredNoteInfo},
-    },
+    discovery::{ComputeNoteHashAndNullifier, nonce_discovery::attempt_note_nonce_discovery},
     encrypted_logs::encoding::MAX_MESSAGE_CONTENT_LEN,
     oracle::message_discovery::{deliver_note, get_log_by_tag},
     utils::array,
@@ -148,26 +145,23 @@ pub unconstrained fn fetch_and_process_public_partial_note_completion_logs<Env>(
                 [discovered_notes.len() as Field, pending_partial_note.note_completion_log_tag],
             );
 
-            array::for_each_in_bounded_vec(
-                discovered_notes,
-                |discovered_note: DiscoveredNoteInfo, _| {
-                    // TODO:(#10728): decide how to handle notes that fail delivery. This could be due to e.g. a
-                    // temporary node connectivity issue - is simply throwing good enough here?
-                    assert(
-                        deliver_note(
-                            contract_address,
-                            pending_partial_note.storage_slot,
-                            discovered_note.nonce,
-                            complete_packed_note,
-                            discovered_note.note_hash,
-                            discovered_note.inner_nullifier,
-                            log.tx_hash,
-                            pending_partial_note.recipient,
-                        ),
-                        "Failed to deliver note",
-                    );
-                },
-            );
+            discovered_notes.for_each(|discovered_note| {
+                // TODO:(#10728): decide how to handle notes that fail delivery. This could be due to e.g. a
+                // temporary node connectivity issue - is simply throwing good enough here?
+                assert(
+                    deliver_note(
+                        contract_address,
+                        pending_partial_note.storage_slot,
+                        discovered_note.nonce,
+                        complete_packed_note,
+                        discovered_note.note_hash,
+                        discovered_note.inner_nullifier,
+                        log.tx_hash,
+                        pending_partial_note.recipient,
+                    ),
+                    "Failed to deliver note",
+                );
+            });
 
             // Because there is only a single log for a given tag, once we've processed the tagged log then we
             // simply delete the pending work entry, regardless of whether it was actually completed or not.

--- a/noir-projects/aztec-nr/aztec/src/discovery/private_notes.nr
+++ b/noir-projects/aztec-nr/aztec/src/discovery/private_notes.nr
@@ -1,8 +1,5 @@
 use crate::{
-    discovery::{
-        ComputeNoteHashAndNullifier,
-        nonce_discovery::{attempt_note_nonce_discovery, DiscoveredNoteInfo},
-    },
+    discovery::{ComputeNoteHashAndNullifier, nonce_discovery::attempt_note_nonce_discovery},
     encrypted_logs::encoding::MAX_MESSAGE_CONTENT_LEN,
     oracle,
     utils::array,
@@ -73,26 +70,23 @@ pub unconstrained fn attempt_note_discovery<Env>(
         [discovered_notes.len() as Field],
     );
 
-    array::for_each_in_bounded_vec(
-        discovered_notes,
-        |discovered_note: DiscoveredNoteInfo, _| {
-            // TODO:(#10728): handle notes that fail delivery. This could be due to e.g. a temporary node connectivity
-            // issue, and we should perhaps not have marked the tag index as taken.
-            assert(
-                oracle::message_discovery::deliver_note(
-                    contract_address,
-                    storage_slot,
-                    discovered_note.nonce,
-                    packed_note,
-                    discovered_note.note_hash,
-                    discovered_note.inner_nullifier,
-                    tx_hash,
-                    recipient,
-                ),
-                "Failed to deliver note",
-            );
-        },
-    );
+    discovered_notes.for_each(|discovered_note| {
+        // TODO:(#10728): handle notes that fail delivery. This could be due to e.g. a temporary node connectivity
+        // issue, and we should perhaps not have marked the tag index as taken.
+        assert(
+            oracle::message_discovery::deliver_note(
+                contract_address,
+                storage_slot,
+                discovered_note.nonce,
+                packed_note,
+                discovered_note.note_hash,
+                discovered_note.inner_nullifier,
+                tx_hash,
+                recipient,
+            ),
+            "Failed to deliver note",
+        );
+    });
 }
 
 fn decode_private_note_msg(

--- a/noir-projects/aztec-nr/aztec/src/utils/array/mod.nr
+++ b/noir-projects/aztec-nr/aztec/src/utils/array/mod.nr
@@ -7,13 +7,3 @@ pub use append::append;
 pub use collapse::collapse;
 pub use subarray::subarray;
 pub use subbvec::subbvec;
-
-// This will eventually be replaced by `BoundedVec::for_each`, once that's implemented.
-pub unconstrained fn for_each_in_bounded_vec<T, let MaxLen: u32, Env>(
-    vec: BoundedVec<T, MaxLen>,
-    f: fn[Env](T, u32) -> (),
-) {
-    for i in 0..vec.len() {
-        f(vec.get_unchecked(i), i);
-    }
-}


### PR DESCRIPTION
Now that this exists in the stdlib we can get rid of our homemade replacement function.