### PR TITLE
chore: delete ns after running tf destroy

### DIFF
--- a/.github/workflows/network-deploy.yml
+++ b/.github/workflows/network-deploy.yml
@@ -233,6 +233,8 @@ jobs:
               -lock=${{ inputs.respect_tf_lock }}
           fi
 
+          kubectl delete ns ${{env.NAMESPACE}}
+
       - name: Terraform Plan
         working-directory: ./spartan/terraform/deploy-release
         run: |


### PR DESCRIPTION
Delete the ns after running tf destroy to make sure everything gets cleaned up before attempting to deploy again.