### PR TITLE
fix: omit p2p options from prover & bootstrap nodes - alphanet

### DIFF
--- a/yarn-project/aztec/src/cli/aztec_start_options.ts
+++ b/yarn-project/aztec/src/cli/aztec_start_options.ts
@@ -10,7 +10,7 @@ import {
   isBooleanConfigValue,
   omitConfigMappings,
 } from '@aztec/foundation/config';
-import { bootnodeConfigMappings, p2pConfigMappings } from '@aztec/p2p/config';
+import { type P2PConfig, bootnodeConfigMappings, p2pConfigMappings } from '@aztec/p2p/config';
 import {
   type ProverAgentConfig,
   type ProverBrokerConfig,
@@ -347,6 +347,7 @@ export const aztecStartOptions: { [key: string]: AztecStartOption[] } = {
         ...(Object.keys(archiverConfigMappings) as (keyof ArchiverConfig)[]),
         ...(Object.keys(proverBrokerConfigMappings) as (keyof ProverBrokerConfig)[]),
         ...(Object.keys(proverAgentConfigMappings) as (keyof ProverAgentConfig)[]),
+        ...(Object.keys(p2pConfigMappings) as (keyof P2PConfig)[]),
       ]),
     ),
   ],
@@ -379,7 +380,16 @@ export const aztecStartOptions: { [key: string]: AztecStartOption[] } = {
       defaultValue: undefined,
       envVar: undefined,
     },
-    ...getOptions('p2pBootstrap', bootnodeConfigMappings),
+    ...getOptions(
+      'p2pBootstrap',
+      omitConfigMappings(bootnodeConfigMappings, [
+        'p2pIp',
+        'p2pPort',
+        'peerIdPrivateKey',
+        'bootstrapNodes',
+        'listenAddress',
+      ]),
+    ),
   ],
   BOT: [
     {


### PR DESCRIPTION
We were getting options like `p2pPort` in multiple namespaces & getting them overwriten. we should only get p2p CLI options under the `p2p.` namespace and apply those to whatever infra is starting