### PR TITLE
chore: Log containers if failed cid not found

### DIFF
--- a/ci3/bootstrap_ec2
+++ b/ci3/bootstrap_ec2
@@ -217,9 +217,10 @@ function run {
             else
                 pid=\$(docker inspect -f '{{.State.Pid}}' \$cid)
                 if [[ -z \"\$pid\" ]]; then
-                    echo \"Container \$cid not found, skipping netstat dump.\" >> \$filename;
+                    echo \"Container \$cid not found at \$(date), skipping netstat dump.\" >> \$filename;
+                    docker ps --no-trunc >> \$filename;
                 else
-                  sudo nsenter -t \$(docker inspect -f '{{.State.Pid}}' \$cid) -n netstat -tulnp >> \$filename;
+                  sudo nsenter -t \$pid -n netstat -tulnp >> \$filename;
                 fi
             fi
             echo \"End netstat dump for container \$cid at \$timestamp\" >> \$filename


### PR DESCRIPTION
Logs whatever containers are available if we dont find the one reported by sysdig on an EADDRINUSE error, so we get more info for errors like:

```
Begin netstat dump for container b0862a58f72f at 13:53:16.014750291
Container b0862a58f72f not found, skipping netstat dump.
End netstat dump for container b0862a58f72f at 13:53:16.014750291
```

See [this run](http://ci.aztec-labs.com/c206feaaabe652ac).
