### PR TITLE
refactor(public/avm): from hints to the end of the world

### DIFF
--- a/yarn-project/end-to-end/src/e2e_block_building.test.ts
+++ b/yarn-project/end-to-end/src/e2e_block_building.test.ts
@@ -26,14 +26,9 @@ import { TestContract } from '@aztec/noir-contracts.js/Test';
 import { TokenContract } from '@aztec/noir-contracts.js/Token';
 import type { SequencerClient } from '@aztec/sequencer-client';
 import type { TestSequencerClient } from '@aztec/sequencer-client/test';
-import {
-  PublicContractsDB,
-  PublicProcessorFactory,
-  type PublicTreesDB,
-  type PublicTxResult,
-  TelemetryPublicTxSimulator,
-} from '@aztec/simulator/server';
+import { type PublicContractsDB, PublicProcessorFactory, TelemetryPublicTxSimulator } from '@aztec/simulator/server';
 import type { AztecNodeAdmin } from '@aztec/stdlib/interfaces/client';
+import type { MerkleTreeWriteOperations } from '@aztec/stdlib/trees';
 import { TX_ERROR_EXISTING_NULLIFIER, type Tx } from '@aztec/stdlib/tx';
 
 import { jest } from '@jest/globals';
@@ -631,19 +626,19 @@ async function sendAndWait(calls: ContractFunctionInteraction[]) {
 const TEST_PUBLIC_TX_SIMULATION_DELAY_MS = 300;
 
 class TestPublicTxSimulator extends TelemetryPublicTxSimulator {
-  public override async simulate(tx: Tx): Promise<PublicTxResult> {
+  public override async simulate(tx: Tx) {
     await sleep(TEST_PUBLIC_TX_SIMULATION_DELAY_MS);
     return super.simulate(tx);
   }
 }
 class TestPublicProcessorFactory extends PublicProcessorFactory {
   protected override createPublicTxSimulator(
-    treesDB: PublicTreesDB,
+    merkleTree: MerkleTreeWriteOperations,
     contractsDB: PublicContractsDB,
     globalVariables: GlobalVariables,
     doMerkleOperations: boolean,
     skipFeeEnforcement: boolean,
   ) {
-    return new TestPublicTxSimulator(treesDB, contractsDB, globalVariables, doMerkleOperations, skipFeeEnforcement);
+    return new TestPublicTxSimulator(merkleTree, contractsDB, globalVariables, doMerkleOperations, skipFeeEnforcement);
   }
 }

--- a/yarn-project/prover-client/src/mocks/test_context.ts
+++ b/yarn-project/prover-client/src/mocks/test_context.ts
@@ -7,11 +7,9 @@ import { getVKTreeRoot } from '@aztec/noir-protocol-circuits-types/vk-tree';
 import { protocolContractTreeRoot } from '@aztec/protocol-contracts';
 import { computeFeePayerBalanceLeafSlot } from '@aztec/protocol-contracts/fee-juice';
 import {
-  PublicContractsDB,
   PublicProcessor,
-  PublicTreesDB,
+  PublicProcessorFactory,
   PublicTxSimulationTester,
-  PublicTxSimulator,
   SimpleContractDataSource,
 } from '@aztec/simulator/server';
 import { PublicDataWrite } from '@aztec/stdlib/avm';
@@ -40,7 +38,6 @@ export class TestContext {
   private feePayerBalance: Fr;
 
   constructor(
-    public publicTxSimulator: PublicTxSimulator,
     public worldState: MerkleTreeAdminDatabase,
     public publicProcessor: PublicProcessor,
     public globalVariables: GlobalVariables,
@@ -79,26 +76,17 @@ export class TestContext {
 
     // Separated dbs for public processor and prover - see public_processor for context
     const ws = await NativeWorldStateService.tmp(
-      undefined /* rollupAddress */,
-      true /* cleanupTmpDir */,
+      /*rollupAddress=*/ undefined,
+      /*cleanupTmpDir=*/ true,
       prefilledPublicData,
     );
     const merkleTrees = await ws.fork();
 
     const contractDataSource = new SimpleContractDataSource();
-    const treesDB = new PublicTreesDB(merkleTrees);
-    const contractsDB = new PublicContractsDB(contractDataSource);
-
     const tester = new PublicTxSimulationTester(merkleTrees, contractDataSource);
 
-    const publicTxSimulator = new PublicTxSimulator(treesDB, contractsDB, globalVariables, true);
-    const processor = new PublicProcessor(
-      globalVariables,
-      treesDB,
-      contractsDB,
-      publicTxSimulator,
-      new TestDateProvider(),
-    );
+    const processorFactory = new PublicProcessorFactory(contractDataSource, new TestDateProvider());
+    const processor = processorFactory.create(merkleTrees, globalVariables, /*skipFeeEnforcement=*/ false);
 
     let localProver: ServerCircuitProver;
     const config = await getEnvironmentConfig(logger);
@@ -127,7 +115,6 @@ export class TestContext {
     facade.start();
 
     return new this(
-      publicTxSimulator,
       ws,
       processor,
       globalVariables,

--- a/yarn-project/simulator/src/public/avm/avm_simulator.test.ts
+++ b/yarn-project/simulator/src/public/avm/avm_simulator.test.ts
@@ -12,13 +12,11 @@ import { Fq, Fr, Point } from '@aztec/foundation/fields';
 import type { Fieldable } from '@aztec/foundation/serialize';
 import { CounterContract } from '@aztec/noir-contracts.js/Counter';
 import { type FunctionArtifact, FunctionSelector } from '@aztec/stdlib/abi';
-import { PublicDataWrite } from '@aztec/stdlib/avm';
 import { AztecAddress } from '@aztec/stdlib/aztec-address';
 import { SerializableContractInstance, computePublicBytecodeCommitment } from '@aztec/stdlib/contract';
 import { GasFees } from '@aztec/stdlib/gas';
 import {
   computeNoteHashNonce,
-  computePublicDataTreeLeafSlot,
   computeUniqueNoteHash,
   computeVarArgsHash,
   siloNoteHash,
@@ -26,7 +24,6 @@ import {
 } from '@aztec/stdlib/hash';
 import { PublicKeys } from '@aztec/stdlib/keys';
 import { makeContractClassPublic, makeContractInstanceFromClassId } from '@aztec/stdlib/testing';
-import { MerkleTreeId } from '@aztec/stdlib/trees';
 import { NativeWorldStateService } from '@aztec/world-state';
 
 import { strict as assert } from 'assert';
@@ -35,6 +32,7 @@ import { mock } from 'jest-mock-extended';
 
 import { SideEffectTrace } from '../../public/side_effect_trace.js';
 import type { PublicSideEffectTraceInterface } from '../../public/side_effect_trace_interface.js';
+import { SimpleContractDataSource } from '../fixtures/simple_contract_data_source.js';
 import { PublicContractsDB, PublicTreesDB } from '../public_db_sources.js';
 import type { PublicPersistableStateManager } from '../state_manager/state_manager.js';
 import type { AvmContext } from './avm_context.js';
@@ -57,7 +55,6 @@ import {
   resolveAvmTestContractAssertionMessage,
   resolveContractAssertionMessage,
 } from './fixtures/index.js';
-import { SimpleContractDataSource } from './fixtures/simple_contract_data_source.js';
 import {
   Add,
   CalldataCopy,
@@ -1112,10 +1109,7 @@ describe('AVM simulator: transpiled Noir contracts', () => {
     let trace: PublicSideEffectTraceInterface;
     let persistableState: PublicPersistableStateManager;
 
-    let leafSlot0: Fr;
-
     beforeAll(async () => {
-      leafSlot0 = await computePublicDataTreeLeafSlot(address, slot0);
       siloedNullifier0 = await siloNullifier(address, value0);
       const siloedNoteHash0 = await siloNoteHash(address, value0);
       const nonce = await computeNoteHashNonce(firstNullifier, noteHashIndexInTx);
@@ -1161,8 +1155,7 @@ describe('AVM simulator: transpiled Noir contracts', () => {
         expect(trace.traceNewNoteHash).toHaveBeenCalledWith(uniqueNoteHash0);
       });
       it('Note hash check properly returns exists=false', async () => {
-        const treeInfo = await treesDB.getTreeInfo(MerkleTreeId.NOTE_HASH_TREE);
-        const leafIndex = treeInfo.size;
+        const leafIndex = (await treesDB.getTreeSnapshots()).noteHashTree.nextAvailableLeafIndex;
 
         const calldata = [uniqueNoteHash0, new Fr(leafIndex)];
         const context = createContext(calldata);
@@ -1173,9 +1166,8 @@ describe('AVM simulator: transpiled Noir contracts', () => {
         expect(results.output).toEqual([/*exists=*/ Fr.ZERO]);
       });
       it('Note hash check properly returns exists=true', async () => {
-        const treeInfo = await treesDB.getTreeInfo(MerkleTreeId.NOTE_HASH_TREE);
-        const leafIndex = treeInfo.size;
-        await treesDB.appendLeaves(MerkleTreeId.NOTE_HASH_TREE, [uniqueNoteHash0]);
+        const leafIndex = (await treesDB.getTreeSnapshots()).noteHashTree.nextAvailableLeafIndex;
+        await treesDB.writeNoteHash(uniqueNoteHash0);
 
         const calldata = [uniqueNoteHash0, new Fr(leafIndex)];
         const context = createContext(calldata);
@@ -1210,7 +1202,7 @@ describe('AVM simulator: transpiled Noir contracts', () => {
       });
       it('Nullifier check properly returns exists=true', async () => {
         const calldata = [value0];
-        await treesDB.sequentialInsert(MerkleTreeId.NULLIFIER_TREE, [siloedNullifier0.toBuffer()]);
+        await treesDB.writeNullifier(siloedNullifier0);
         const context = createContext(calldata);
         const bytecode = getAvmTestContractBytecode('nullifier_exists');
 
@@ -1245,8 +1237,7 @@ describe('AVM simulator: transpiled Noir contracts', () => {
 
       it('Should read value in storage (single) - written before, leaf exists', async () => {
         const context = createContext();
-        const publicDataWrite = new PublicDataWrite(leafSlot0, value0);
-        await treesDB.sequentialInsert(MerkleTreeId.PUBLIC_DATA_TREE, [publicDataWrite.toBuffer()]);
+        await treesDB.storageWrite(context.environment.address, slot0, value0);
 
         const bytecode = getAvmTestContractBytecode('read_storage_single');
 

--- a/yarn-project/simulator/src/public/avm/fixtures/avm_simulation_tester.ts
+++ b/yarn-project/simulator/src/public/avm/fixtures/avm_simulation_tester.ts
@@ -16,11 +16,11 @@ import {
   initExecutionEnvironment,
   resolveContractAssertionMessage,
 } from '../../avm/fixtures/index.js';
+import { SimpleContractDataSource } from '../../fixtures/simple_contract_data_source.js';
 import { PublicContractsDB, PublicTreesDB } from '../../public_db_sources.js';
 import { PublicPersistableStateManager } from '../../state_manager/state_manager.js';
 import { AvmSimulator } from '../avm_simulator.js';
 import { BaseAvmSimulationTester } from './base_avm_simulation_tester.js';
-import { SimpleContractDataSource } from './simple_contract_data_source.js';
 
 const TIMESTAMP = new Fr(99833);
 const DEFAULT_GAS_FEES = new GasFees(2, 3);

--- a/yarn-project/simulator/src/public/avm/fixtures/base_avm_simulation_tester.ts
+++ b/yarn-project/simulator/src/public/avm/fixtures/base_avm_simulation_tester.ts
@@ -11,8 +11,8 @@ import { computePublicDataTreeLeafSlot, siloNullifier } from '@aztec/stdlib/hash
 import type { MerkleTreeWriteOperations } from '@aztec/stdlib/interfaces/server';
 import { MerkleTreeId } from '@aztec/stdlib/trees';
 
+import type { SimpleContractDataSource } from '../../fixtures/simple_contract_data_source.js';
 import { createContractClassAndInstance } from './index.js';
-import type { SimpleContractDataSource } from './simple_contract_data_source.js';
 
 /**
  * An abstract test class that enables tests of real apps in the AVM without requiring e2e tests.

--- a/yarn-project/simulator/src/public/avm/index.ts
+++ b/yarn-project/simulator/src/public/avm/index.ts
@@ -1,2 +1,2 @@
 export * from './avm_simulator.js';
-export * from './fixtures/simple_contract_data_source.js';
+export * from '../fixtures/simple_contract_data_source.js';

--- a/yarn-project/simulator/src/public/avm/opcodes/accrued_substate.ts
+++ b/yarn-project/simulator/src/public/avm/opcodes/accrued_substate.ts
@@ -181,11 +181,7 @@ export class L1ToL2MessageExists extends Instruction {
 
     const msgHash = memory.get(msgHashOffset).toFr();
     const msgLeafIndex = memory.get(msgLeafIndexOffset).toFr();
-    const exists = await context.persistableState.checkL1ToL2MessageExists(
-      context.environment.address,
-      msgHash,
-      msgLeafIndex,
-    );
+    const exists = await context.persistableState.checkL1ToL2MessageExists(msgHash, msgLeafIndex);
     memory.set(existsOffset, exists ? new Uint1(1) : new Uint1(0));
   }
 }

--- a/yarn-project/simulator/src/public/debug_fn_name.ts
+++ b/yarn-project/simulator/src/public/debug_fn_name.ts
@@ -2,7 +2,7 @@ import type { Fr } from '@aztec/foundation/fields';
 import { FunctionSelector } from '@aztec/stdlib/abi';
 import type { AztecAddress } from '@aztec/stdlib/aztec-address';
 
-import type { PublicContractsDBInterface } from '../public/db_interfaces.js';
+import type { PublicContractsDBInterface } from './db_interfaces.js';
 
 export async function getPublicFunctionDebugName(
   db: PublicContractsDBInterface,

--- a/yarn-project/simulator/src/public/fixtures/index.ts
+++ b/yarn-project/simulator/src/public/fixtures/index.ts
@@ -1,2 +1,3 @@
 export * from './public_tx_simulation_tester.js';
 export * from './utils.js';
+export * from './simple_contract_data_source.js';

--- a/yarn-project/simulator/src/public/fixtures/public_tx_simulation_tester.ts
+++ b/yarn-project/simulator/src/public/fixtures/public_tx_simulation_tester.ts
@@ -10,11 +10,11 @@ import { NativeWorldStateService } from '@aztec/world-state';
 
 import { BaseAvmSimulationTester } from '../avm/fixtures/base_avm_simulation_tester.js';
 import { DEFAULT_BLOCK_NUMBER, getContractFunctionAbi, getFunctionSelector } from '../avm/fixtures/index.js';
-import { SimpleContractDataSource } from '../avm/fixtures/simple_contract_data_source.js';
-import { PublicContractsDB, PublicTreesDB } from '../public_db_sources.js';
+import { PublicContractsDB } from '../public_db_sources.js';
 import { MeasuredPublicTxSimulator } from '../public_tx_simulator/measured_public_tx_simulator.js';
 import type { PublicTxResult } from '../public_tx_simulator/public_tx_simulator.js';
 import { TestExecutorMetrics } from '../test_executor_metrics.js';
+import { SimpleContractDataSource } from './simple_contract_data_source.js';
 import { createTxForPublicCalls } from './utils.js';
 
 const TIMESTAMP = new Fr(99833);
@@ -47,11 +47,9 @@ export class PublicTxSimulationTester extends BaseAvmSimulationTester {
   ) {
     super(contractDataSource, merkleTree);
 
-    const treesDB = new PublicTreesDB(merkleTree);
     const contractsDB = new PublicContractsDB(contractDataSource);
-
     this.simulator = new MeasuredPublicTxSimulator(
-      treesDB,
+      merkleTree,
       contractsDB,
       globals,
       /*doMerkleOperations=*/ true,

--- a/yarn-project/simulator/src/public/fixtures/simple_contract_data_source.ts
+++ b/yarn-project/simulator/src/public/fixtures/simple_contract_data_source.ts
@@ -4,7 +4,7 @@ import type { ContractArtifact, FunctionSelector } from '@aztec/stdlib/abi';
 import type { AztecAddress } from '@aztec/stdlib/aztec-address';
 import type { ContractClassPublic, ContractDataSource, ContractInstanceWithAddress } from '@aztec/stdlib/contract';
 
-import { getFunctionSelector } from './index.js';
+import { getFunctionSelector } from '../avm/fixtures/index.js';
 
 /**
  * This class is used during public/avm testing to function as a database of

--- a/yarn-project/simulator/src/public/index.ts
+++ b/yarn-project/simulator/src/public/index.ts
@@ -1,8 +1,6 @@
-export * from './db_interfaces.js';
-export * from './public_tx_simulator/index.js';
-export * from './public_db_sources.js';
+export { PublicContractsDB } from './public_db_sources.js';
+export { type PublicTxResult, PublicTxSimulator, TelemetryPublicTxSimulator } from './public_tx_simulator/index.js';
 export { PublicProcessor, PublicProcessorFactory } from './public_processor/public_processor.js';
-export { SideEffectTrace } from './side_effect_trace.js';
 export { PublicTxSimulationTester } from './fixtures/index.js';
-export * from './avm/index.js';
 export { getCallRequestsWithCalldataByPhase } from './utils.js';
+export { SimpleContractDataSource } from './fixtures/simple_contract_data_source.js';

--- a/yarn-project/simulator/src/public/public_db_sources.ts
+++ b/yarn-project/simulator/src/public/public_db_sources.ts
@@ -2,7 +2,6 @@ import { NULLIFIER_SUBTREE_HEIGHT, PUBLIC_DATA_SUBTREE_HEIGHT } from '@aztec/con
 import { Fr } from '@aztec/foundation/fields';
 import { createLogger } from '@aztec/foundation/log';
 import { Timer } from '@aztec/foundation/timer';
-import type { IndexedTreeLeafPreimage, SiblingPath } from '@aztec/foundation/trees';
 import { ContractClassRegisteredEvent } from '@aztec/protocol-contracts/class-registerer';
 import { ContractInstanceDeployedEvent } from '@aztec/protocol-contracts/instance-deployer';
 import type { FunctionSelector } from '@aztec/stdlib/abi';
@@ -15,18 +14,11 @@ import {
   computePublicBytecodeCommitment,
 } from '@aztec/stdlib/contract';
 import { computePublicDataTreeLeafSlot } from '@aztec/stdlib/hash';
-import type {
-  BatchInsertionResult,
-  IndexedTreeId,
-  MerkleTreeLeafType,
-  MerkleTreeWriteOperations,
-  SequentialInsertionResult,
-  TreeInfo,
-} from '@aztec/stdlib/interfaces/server';
+import type { MerkleTreeWriteOperations } from '@aztec/stdlib/interfaces/server';
 import { ContractClassLog, PrivateLog } from '@aztec/stdlib/logs';
 import type { PublicDBAccessStats } from '@aztec/stdlib/stats';
 import { MerkleTreeId, NullifierLeaf, PublicDataTreeLeaf, type PublicDataTreeLeafPreimage } from '@aztec/stdlib/trees';
-import type { BlockHeader, StateReference, Tx } from '@aztec/stdlib/tx';
+import { TreeSnapshots, type Tx } from '@aztec/stdlib/tx';
 
 import type { PublicContractsDBInterface, PublicStateDBInterface } from './db_interfaces.js';
 import { TxContractCache } from './tx_contract_cache.js';
@@ -276,145 +268,34 @@ export class PublicContractsDB implements PublicContractsDBInterface {
 }
 
 /**
- * Proxy class that forwards all merkle tree operations to the underlying object.
+ * A high-level class that provides access to the merkle trees.
  *
- * NOTE: It might be possible to prune this to just the methods used in public.
- * Then we'd need to define a new interface, instead of MerkleTreeWriteOperations,
- * to be used by all our classes (that could be PublicStateDBInterface).
+ * This class is just a helper wrapper around a merkle db. Anything that you can do with it
+ * can also be done directly with the merkle db. This class should NOT be exposed or used
+ * outside of `simulator/src/public`.
+ *
+ * NOTE: This class is currently written in such a way that it would generate the
+ * necessary hints if used with a hinting merkle db. This is a bit of a leak of concepts.
+ * Eventually we can have everything depend on a config/factory at the TxSimulator level
+ * to decide whether to use hints or not (same with tracing, etc).
  */
-class ForwardMerkleTree implements MerkleTreeWriteOperations {
-  constructor(private readonly operations: MerkleTreeWriteOperations) {}
-
-  getTreeInfo(treeId: MerkleTreeId): Promise<TreeInfo> {
-    return this.operations.getTreeInfo(treeId);
-  }
-
-  getStateReference(): Promise<StateReference> {
-    return this.operations.getStateReference();
-  }
-
-  getInitialHeader(): BlockHeader {
-    return this.operations.getInitialHeader();
-  }
-
-  getSiblingPath<N extends number>(treeId: MerkleTreeId, index: bigint): Promise<SiblingPath<N>> {
-    return this.operations.getSiblingPath(treeId, index);
-  }
-
-  getPreviousValueIndex<ID extends IndexedTreeId>(
-    treeId: ID,
-    value: bigint,
-  ): Promise<
-    | {
-        index: bigint;
-        alreadyPresent: boolean;
-      }
-    | undefined
-  > {
-    return this.operations.getPreviousValueIndex(treeId, value);
-  }
-
-  getLeafPreimage<ID extends IndexedTreeId>(treeId: ID, index: bigint): Promise<IndexedTreeLeafPreimage | undefined> {
-    return this.operations.getLeafPreimage(treeId, index);
-  }
-
-  findLeafIndices<ID extends MerkleTreeId>(
-    treeId: ID,
-    values: MerkleTreeLeafType<ID>[],
-  ): Promise<(bigint | undefined)[]> {
-    return this.operations.findLeafIndices(treeId, values);
-  }
-
-  findLeafIndicesAfter<ID extends MerkleTreeId>(
-    treeId: ID,
-    values: MerkleTreeLeafType<ID>[],
-    startIndex: bigint,
-  ): Promise<(bigint | undefined)[]> {
-    return this.operations.findLeafIndicesAfter(treeId, values, startIndex);
-  }
-
-  getLeafValue<ID extends MerkleTreeId>(
-    treeId: ID,
-    index: bigint,
-  ): Promise<MerkleTreeLeafType<typeof treeId> | undefined> {
-    return this.operations.getLeafValue(treeId, index);
-  }
-
-  getBlockNumbersForLeafIndices<ID extends MerkleTreeId>(
-    treeId: ID,
-    leafIndices: bigint[],
-  ): Promise<(bigint | undefined)[]> {
-    return this.operations.getBlockNumbersForLeafIndices(treeId, leafIndices);
-  }
-
-  createCheckpoint(): Promise<void> {
-    return this.operations.createCheckpoint();
-  }
-
-  commitCheckpoint(): Promise<void> {
-    return this.operations.commitCheckpoint();
-  }
-
-  revertCheckpoint(): Promise<void> {
-    return this.operations.revertCheckpoint();
-  }
-
-  appendLeaves<ID extends MerkleTreeId>(treeId: ID, leaves: MerkleTreeLeafType<ID>[]): Promise<void> {
-    return this.operations.appendLeaves(treeId, leaves);
-  }
-
-  updateArchive(header: BlockHeader): Promise<void> {
-    return this.operations.updateArchive(header);
-  }
-
-  batchInsert<TreeHeight extends number, SubtreeSiblingPathHeight extends number, ID extends IndexedTreeId>(
-    treeId: ID,
-    leaves: Buffer[],
-    subtreeHeight: number,
-  ): Promise<BatchInsertionResult<TreeHeight, SubtreeSiblingPathHeight>> {
-    return this.operations.batchInsert(treeId, leaves, subtreeHeight);
-  }
-
-  sequentialInsert<TreeHeight extends number, ID extends IndexedTreeId>(
-    treeId: ID,
-    leaves: Buffer[],
-  ): Promise<SequentialInsertionResult<TreeHeight>> {
-    return this.operations.sequentialInsert(treeId, leaves);
-  }
-
-  close(): Promise<void> {
-    return this.operations.close();
-  }
-}
-
-/**
- * A class that provides access to the merkle trees, and other helper methods.
- */
-export class PublicTreesDB extends ForwardMerkleTree implements PublicStateDBInterface {
+export class PublicTreesDB implements PublicStateDBInterface {
   private logger = createLogger('simulator:public-trees-db');
 
-  constructor(db: MerkleTreeWriteOperations) {
-    super(db);
-  }
+  constructor(private readonly db: MerkleTreeWriteOperations) {}
 
-  /**
-   * Reads a value from public storage, returning zero if none.
-   * @param contract - Owner of the storage.
-   * @param slot - Slot to read in the contract storage.
-   * @returns The current value in the storage slot.
-   */
   public async storageRead(contract: AztecAddress, slot: Fr): Promise<Fr> {
     const leafSlot = (await computePublicDataTreeLeafSlot(contract, slot)).toBigInt();
 
-    const lowLeafResult = await this.getPreviousValueIndex(MerkleTreeId.PUBLIC_DATA_TREE, leafSlot);
+    const lowLeafResult = await this.db.getPreviousValueIndex(MerkleTreeId.PUBLIC_DATA_TREE, leafSlot);
     if (!lowLeafResult) {
       throw new Error('Low leaf not found');
     }
 
-    // TODO(fcarreiro): We need this for the hints. Might move it to the hinting layer.
-    await this.getSiblingPath(MerkleTreeId.PUBLIC_DATA_TREE, lowLeafResult.index);
+    // TODO: We need this for the hints. See class comment for more details.
+    await this.db.getSiblingPath(MerkleTreeId.PUBLIC_DATA_TREE, lowLeafResult.index);
     // Unconditionally fetching the preimage for the hints. Move it to the hinting layer?
-    const preimage = (await this.getLeafPreimage(
+    const preimage = (await this.db.getLeafPreimage(
       MerkleTreeId.PUBLIC_DATA_TREE,
       lowLeafResult.index,
     )) as PublicDataTreeLeafPreimage;
@@ -422,24 +303,17 @@ export class PublicTreesDB extends ForwardMerkleTree implements PublicStateDBInt
     return lowLeafResult.alreadyPresent ? preimage.leaf.value : Fr.ZERO;
   }
 
-  /**
-   * Records a write to public storage.
-   * @param contract - Owner of the storage.
-   * @param slot - Slot to read in the contract storage.
-   * @param newValue - The new value to store.
-   * @returns The slot of the written leaf in the public data tree.
-   */
   public async storageWrite(contract: AztecAddress, slot: Fr, newValue: Fr): Promise<void> {
     const leafSlot = await computePublicDataTreeLeafSlot(contract, slot);
     const publicDataWrite = new PublicDataWrite(leafSlot, newValue);
-    await this.sequentialInsert(MerkleTreeId.PUBLIC_DATA_TREE, [publicDataWrite.toBuffer()]);
+    await this.db.sequentialInsert(MerkleTreeId.PUBLIC_DATA_TREE, [publicDataWrite.toBuffer()]);
   }
 
   public async getL1ToL2LeafValue(leafIndex: bigint): Promise<Fr | undefined> {
     const timer = new Timer();
-    const leafValue = await this.getLeafValue(MerkleTreeId.L1_TO_L2_MESSAGE_TREE, leafIndex);
-    // TODO(fcarreiro): We need this for the hints. Might move it to the hinting layer.
-    await this.getSiblingPath(MerkleTreeId.L1_TO_L2_MESSAGE_TREE, leafIndex);
+    const leafValue = await this.db.getLeafValue(MerkleTreeId.L1_TO_L2_MESSAGE_TREE, leafIndex);
+    // TODO: We need this for the hints. See class comment for more details.
+    await this.db.getSiblingPath(MerkleTreeId.L1_TO_L2_MESSAGE_TREE, leafIndex);
 
     this.logger.debug(`[DB] Fetched L1 to L2 message leaf value`, {
       eventName: 'public-db-access',
@@ -451,9 +325,9 @@ export class PublicTreesDB extends ForwardMerkleTree implements PublicStateDBInt
 
   public async getNoteHash(leafIndex: bigint): Promise<Fr | undefined> {
     const timer = new Timer();
-    const leafValue = await this.getLeafValue(MerkleTreeId.NOTE_HASH_TREE, leafIndex);
-    // TODO(fcarreiro): We need this for the hints. Might move it to the hinting layer.
-    await this.getSiblingPath(MerkleTreeId.NOTE_HASH_TREE, leafIndex);
+    const leafValue = await this.db.getLeafValue(MerkleTreeId.NOTE_HASH_TREE, leafIndex);
+    // TODO: We need this for the hints. See class comment for more details.
+    await this.db.getSiblingPath(MerkleTreeId.NOTE_HASH_TREE, leafIndex);
 
     this.logger.debug(`[DB] Fetched note hash leaf value`, {
       eventName: 'public-db-access',
@@ -463,16 +337,20 @@ export class PublicTreesDB extends ForwardMerkleTree implements PublicStateDBInt
     return leafValue;
   }
 
+  public async writeNoteHash(noteHash: Fr): Promise<void> {
+    await this.db.appendLeaves(MerkleTreeId.NOTE_HASH_TREE, [noteHash]);
+  }
+
   public async checkNullifierExists(nullifier: Fr): Promise<boolean> {
     const timer = new Timer();
-    const lowLeafResult = await this.getPreviousValueIndex(MerkleTreeId.NULLIFIER_TREE, nullifier.toBigInt());
+    const lowLeafResult = await this.db.getPreviousValueIndex(MerkleTreeId.NULLIFIER_TREE, nullifier.toBigInt());
     if (!lowLeafResult) {
       throw new Error('Low leaf not found');
     }
-    // TODO(fcarreiro): We need this for the hints. Might move it to the hinting layer.
-    await this.getSiblingPath(MerkleTreeId.NULLIFIER_TREE, lowLeafResult.index);
-    // TODO(fcarreiro): We need this for the hints. Might move it to the hinting layer.
-    await this.getLeafPreimage(MerkleTreeId.NULLIFIER_TREE, lowLeafResult.index);
+    // TODO: We need this for the hints. See class comment for more details.
+    await this.db.getSiblingPath(MerkleTreeId.NULLIFIER_TREE, lowLeafResult.index);
+    // TODO: We need this for the hints. See class comment for more details.
+    await this.db.getLeafPreimage(MerkleTreeId.NULLIFIER_TREE, lowLeafResult.index);
     const exists = lowLeafResult.alreadyPresent;
 
     this.logger.debug(`[DB] Checked nullifier exists`, {
@@ -483,30 +361,56 @@ export class PublicTreesDB extends ForwardMerkleTree implements PublicStateDBInt
     return exists;
   }
 
+  public async writeNullifier(siloedNullifier: Fr): Promise<void> {
+    await this.db.sequentialInsert(MerkleTreeId.NULLIFIER_TREE, [siloedNullifier.toBuffer()]);
+  }
+
   public async padTree(treeId: MerkleTreeId, leavesToInsert: number): Promise<void> {
     switch (treeId) {
       // Indexed trees.
       case MerkleTreeId.NULLIFIER_TREE:
-        await this.batchInsert(
+        await this.db.batchInsert(
           treeId,
           Array(leavesToInsert).fill(NullifierLeaf.empty().toBuffer()),
           NULLIFIER_SUBTREE_HEIGHT,
         );
         break;
       case MerkleTreeId.PUBLIC_DATA_TREE:
-        await this.batchInsert(
+        await this.db.batchInsert(
           treeId,
           Array(leavesToInsert).fill(PublicDataTreeLeaf.empty().toBuffer()),
           PUBLIC_DATA_SUBTREE_HEIGHT,
         );
         break;
-      // Non-indexed trees.
+      // Append-only trees.
       case MerkleTreeId.L1_TO_L2_MESSAGE_TREE:
       case MerkleTreeId.NOTE_HASH_TREE:
-        await this.appendLeaves(treeId, Array(leavesToInsert).fill(Fr.ZERO));
+        await this.db.appendLeaves(treeId, Array(leavesToInsert).fill(Fr.ZERO));
         break;
       default:
         throw new Error(`Padding not supported for tree ${treeId}`);
     }
+  }
+
+  public async createCheckpoint(): Promise<void> {
+    await this.db.createCheckpoint();
+  }
+
+  public async commitCheckpoint(): Promise<void> {
+    await this.db.commitCheckpoint();
+  }
+
+  public async revertCheckpoint(): Promise<void> {
+    await this.db.revertCheckpoint();
+  }
+
+  public async getTreeSnapshots(): Promise<TreeSnapshots> {
+    const stateReference = await this.db.getStateReference();
+    return new TreeSnapshots(
+      stateReference.l1ToL2MessageTree,
+      stateReference.partial.noteHashTree,
+      stateReference.partial.nullifierTree,
+      stateReference.partial.publicDataTree,
+    );
   }
 }

--- a/yarn-project/simulator/src/public/public_processor/apps_tests/deployments.test.ts
+++ b/yarn-project/simulator/src/public/public_processor/apps_tests/deployments.test.ts
@@ -9,13 +9,9 @@ import { GlobalVariables } from '@aztec/stdlib/tx';
 import { getTelemetryClient } from '@aztec/telemetry-client';
 import { NativeWorldStateService } from '@aztec/world-state';
 
-import {
-  PublicContractsDB,
-  PublicTreesDB,
-  PublicTxSimulationTester,
-  SimpleContractDataSource,
-} from '../../../server.js';
+import { PublicContractsDB, PublicTxSimulationTester } from '../../../server.js';
 import { createContractClassAndInstance } from '../../avm/fixtures/index.js';
+import { SimpleContractDataSource } from '../../fixtures/simple_contract_data_source.js';
 import { addNewContractClassToTx, addNewContractInstanceToTx, createTxForPrivateOnly } from '../../fixtures/utils.js';
 import { PublicTxSimulator } from '../../public_tx_simulator/public_tx_simulator.js';
 import { PublicProcessor } from '../public_processor.js';
@@ -24,7 +20,6 @@ describe('Public processor contract registration/deployment tests', () => {
   const admin = AztecAddress.fromNumber(42);
   const sender = AztecAddress.fromNumber(111);
 
-  let treesDB: PublicTreesDB;
   let contractsDB: PublicContractsDB;
   let tester: PublicTxSimulationTester;
   let processor: PublicProcessor;
@@ -36,13 +31,12 @@ describe('Public processor contract registration/deployment tests', () => {
 
     const contractDataSource = new SimpleContractDataSource();
     const merkleTrees = await (await NativeWorldStateService.tmp()).fork();
-    treesDB = new PublicTreesDB(merkleTrees);
     contractsDB = new PublicContractsDB(contractDataSource);
-    const simulator = new PublicTxSimulator(treesDB, contractsDB, globals, /*doMerkleOperations=*/ true);
+    const simulator = new PublicTxSimulator(merkleTrees, contractsDB, globals, /*doMerkleOperations=*/ true);
 
     processor = new PublicProcessor(
       globals,
-      treesDB,
+      merkleTrees,
       contractsDB,
       simulator,
       new TestDateProvider(),

--- a/yarn-project/simulator/src/public/public_processor/apps_tests/token.test.ts
+++ b/yarn-project/simulator/src/public/public_processor/apps_tests/token.test.ts
@@ -9,8 +9,9 @@ import { GlobalVariables } from '@aztec/stdlib/tx';
 import { getTelemetryClient } from '@aztec/telemetry-client';
 import { NativeWorldStateService } from '@aztec/world-state';
 
-import { PublicTxSimulationTester, SimpleContractDataSource } from '../../../server.js';
-import { PublicContractsDB, PublicTreesDB } from '../../public_db_sources.js';
+import { PublicTxSimulationTester } from '../../../server.js';
+import { SimpleContractDataSource } from '../../fixtures/simple_contract_data_source.js';
+import { PublicContractsDB } from '../../public_db_sources.js';
 import { PublicTxSimulator } from '../../public_tx_simulator/public_tx_simulator.js';
 import { PublicProcessor } from '../public_processor.js';
 
@@ -22,7 +23,6 @@ describe('Public Processor app tests: TokenContract', () => {
   const sender = AztecAddress.fromNumber(111);
 
   let token: ContractInstanceWithAddress;
-  let treesDB: PublicTreesDB;
   let contractsDB: PublicContractsDB;
   let tester: PublicTxSimulationTester;
   let processor: PublicProcessor;
@@ -34,13 +34,12 @@ describe('Public Processor app tests: TokenContract', () => {
 
     const contractDataSource = new SimpleContractDataSource();
     const merkleTrees = await (await NativeWorldStateService.tmp()).fork();
-    treesDB = new PublicTreesDB(merkleTrees);
     contractsDB = new PublicContractsDB(contractDataSource);
-    const simulator = new PublicTxSimulator(treesDB, contractsDB, globals, /*doMerkleOperations=*/ true);
+    const simulator = new PublicTxSimulator(merkleTrees, contractsDB, globals, /*doMerkleOperations=*/ true);
 
     processor = new PublicProcessor(
       globals,
-      treesDB,
+      merkleTrees,
       contractsDB,
       simulator,
       new TestDateProvider(),

--- a/yarn-project/simulator/src/public/public_processor/public_processor.test.ts
+++ b/yarn-project/simulator/src/public/public_processor/public_processor.test.ts
@@ -7,24 +7,23 @@ import { AvmCircuitInputs, PublicDataWrite, RevertCode } from '@aztec/stdlib/avm
 import { AztecAddress } from '@aztec/stdlib/aztec-address';
 import { SimulationError } from '@aztec/stdlib/errors';
 import { Gas, GasFees } from '@aztec/stdlib/gas';
-import type { TreeInfo } from '@aztec/stdlib/interfaces/server';
 import { ProvingRequestType } from '@aztec/stdlib/proofs';
 import { mockTx } from '@aztec/stdlib/testing';
+import { type MerkleTreeWriteOperations, PublicDataTreeLeaf, PublicDataTreeLeafPreimage } from '@aztec/stdlib/trees';
 import { GlobalVariables, Tx, type TxValidator } from '@aztec/stdlib/tx';
 import { getTelemetryClient } from '@aztec/telemetry-client';
 
 import { type MockProxy, mock } from 'jest-mock-extended';
 
-import { PublicContractsDB, PublicTreesDB } from '../public_db_sources.js';
+import { PublicContractsDB } from '../public_db_sources.js';
 import type { PublicTxResult, PublicTxSimulator } from '../public_tx_simulator/public_tx_simulator.js';
 import { PublicProcessor } from './public_processor.js';
 
 describe('public_processor', () => {
-  let treesDB: MockProxy<PublicTreesDB>;
+  let merkleTree: MockProxy<MerkleTreeWriteOperations>;
   let contractsDB: MockProxy<PublicContractsDB>;
   let publicTxSimulator: MockProxy<PublicTxSimulator>;
 
-  let root: Buffer;
   let mockedEnqueuedCallsResult: PublicTxResult;
 
   let processor: PublicProcessor;
@@ -39,11 +38,9 @@ describe('public_processor', () => {
     mockTx(seed, { numberOfNonRevertiblePublicCallRequests: 1, numberOfRevertiblePublicCallRequests: 1, feePayer });
 
   beforeEach(() => {
-    treesDB = mock<PublicTreesDB>();
+    merkleTree = mock<MerkleTreeWriteOperations>();
     contractsDB = mock<PublicContractsDB>();
     publicTxSimulator = mock();
-
-    root = Buffer.alloc(32, 5);
 
     const avmCircuitInputs = AvmCircuitInputs.empty();
     mockedEnqueuedCallsResult = {
@@ -61,8 +58,13 @@ describe('public_processor', () => {
       processedPhases: [],
     };
 
-    treesDB.getTreeInfo.mockResolvedValue({ root } as TreeInfo);
-    treesDB.storageRead.mockResolvedValue(Fr.ZERO);
+    merkleTree.getPreviousValueIndex.mockResolvedValue({
+      index: 0n,
+      alreadyPresent: true,
+    });
+    merkleTree.getLeafPreimage.mockResolvedValue(
+      new PublicDataTreeLeafPreimage(new PublicDataTreeLeaf(Fr.ZERO, Fr.ZERO), /*nextKey=*/ Fr.ZERO, /*nextIndex=*/ 0n),
+    );
 
     publicTxSimulator.simulate.mockImplementation(() => {
       return Promise.resolve(mockedEnqueuedCallsResult);
@@ -70,7 +72,7 @@ describe('public_processor', () => {
 
     processor = new PublicProcessor(
       globalVariables,
-      treesDB,
+      merkleTree,
       contractsDB,
       publicTxSimulator,
       new TestDateProvider(),
@@ -100,7 +102,7 @@ describe('public_processor', () => {
       expect(processed[0].data).toEqual(tx.data);
       expect(failed).toEqual([]);
 
-      expect(treesDB.commitCheckpoint).toHaveBeenCalledTimes(1);
+      expect(merkleTree.commitCheckpoint).toHaveBeenCalledTimes(1);
     });
 
     it('runs a tx with reverted enqueued public calls', async function () {
@@ -115,7 +117,7 @@ describe('public_processor', () => {
       expect(processed[0].hash).toEqual(await tx.getTxHash());
       expect(failed).toEqual([]);
 
-      expect(treesDB.commitCheckpoint).toHaveBeenCalledTimes(1);
+      expect(merkleTree.commitCheckpoint).toHaveBeenCalledTimes(1);
     });
 
     it('returns failed txs without aborting entire operation', async function () {
@@ -129,8 +131,8 @@ describe('public_processor', () => {
       expect(failed[0].tx).toEqual(tx);
       expect(failed[0].error).toEqual(new SimulationError(`Failed`, []));
 
-      expect(treesDB.commitCheckpoint).toHaveBeenCalledTimes(0);
-      expect(treesDB.revertCheckpoint).toHaveBeenCalledTimes(1);
+      expect(merkleTree.commitCheckpoint).toHaveBeenCalledTimes(0);
+      expect(merkleTree.revertCheckpoint).toHaveBeenCalledTimes(1);
     });
 
     it('does not attempt to overfill a block', async function () {
@@ -175,7 +177,7 @@ describe('public_processor', () => {
       expect(processed[0].hash).toEqual(await txs[0].getTxHash());
       expect(processed[1].hash).toEqual(await txs[1].getTxHash());
       expect(failed).toEqual([]);
-      expect(treesDB.commitCheckpoint).toHaveBeenCalledTimes(2);
+      expect(merkleTree.commitCheckpoint).toHaveBeenCalledTimes(2);
     });
   });
 
@@ -183,8 +185,14 @@ describe('public_processor', () => {
     const feePayer = AztecAddress.fromBigInt(123123n);
     const initialBalance = new Fr(1000);
 
-    beforeEach(() => {
-      treesDB.storageRead.mockResolvedValue(initialBalance);
+    beforeEach(async () => {
+      merkleTree.getLeafPreimage.mockResolvedValue(
+        new PublicDataTreeLeafPreimage(
+          new PublicDataTreeLeaf(await computeFeePayerBalanceLeafSlot(feePayer), initialBalance),
+          /*nextKey=*/ Fr.ZERO,
+          /*nextIndex=*/ 0n,
+        ),
+      );
     });
 
     it('injects balance update with no public calls', async function () {
@@ -206,7 +214,7 @@ describe('public_processor', () => {
       );
       expect(failed).toEqual([]);
 
-      expect(treesDB.storageWrite).toHaveBeenCalledTimes(1);
+      expect(merkleTree.sequentialInsert).toHaveBeenCalledTimes(1);
     });
 
     it('rejects tx if fee payer has not enough balance', async function () {
@@ -226,9 +234,9 @@ describe('public_processor', () => {
       expect(failed).toHaveLength(1);
       expect(failed[0].error.message).toMatch(/Not enough balance/i);
 
-      expect(treesDB.commitCheckpoint).toHaveBeenCalledTimes(0);
-      expect(treesDB.revertCheckpoint).toHaveBeenCalledTimes(1);
-      expect(treesDB.storageWrite).toHaveBeenCalledTimes(0);
+      expect(merkleTree.commitCheckpoint).toHaveBeenCalledTimes(0);
+      expect(merkleTree.revertCheckpoint).toHaveBeenCalledTimes(1);
+      expect(merkleTree.sequentialInsert).toHaveBeenCalledTimes(0);
     });
   });
 });

--- a/yarn-project/simulator/src/public/public_tx_simulator/measured_public_tx_simulator.ts
+++ b/yarn-project/simulator/src/public/public_tx_simulator/measured_public_tx_simulator.ts
@@ -2,11 +2,12 @@ import type { Fr } from '@aztec/foundation/fields';
 import { Timer } from '@aztec/foundation/timer';
 import type { Gas } from '@aztec/stdlib/gas';
 import type { AvmSimulationStats } from '@aztec/stdlib/stats';
+import type { MerkleTreeWriteOperations } from '@aztec/stdlib/trees';
 import { type GlobalVariables, PublicCallRequestWithCalldata, Tx, TxExecutionPhase } from '@aztec/stdlib/tx';
 
 import type { AvmFinalizedCallResult } from '../avm/avm_contract_call_result.js';
 import type { ExecutorMetricsInterface } from '../executor_metrics_interface.js';
-import type { PublicContractsDB, PublicTreesDB } from '../public_db_sources.js';
+import type { PublicContractsDB } from '../public_db_sources.js';
 import type { PublicPersistableStateManager } from '../state_manager/state_manager.js';
 import { PublicTxContext } from './public_tx_context.js';
 import { type ProcessedPhase, type PublicTxResult, PublicTxSimulator } from './public_tx_simulator.js';
@@ -16,14 +17,14 @@ import { type ProcessedPhase, type PublicTxResult, PublicTxSimulator } from './p
  */
 export class MeasuredPublicTxSimulator extends PublicTxSimulator {
   constructor(
-    treesDB: PublicTreesDB,
+    merkleTree: MerkleTreeWriteOperations,
     contractsDB: PublicContractsDB,
     globalVariables: GlobalVariables,
     doMerkleOperations: boolean = false,
     skipFeeEnforcement: boolean = false,
     protected readonly metrics: ExecutorMetricsInterface,
   ) {
-    super(treesDB, contractsDB, globalVariables, doMerkleOperations, skipFeeEnforcement);
+    super(merkleTree, contractsDB, globalVariables, doMerkleOperations, skipFeeEnforcement);
   }
 
   public override async simulate(tx: Tx, txLabel: string = 'unlabeledTx'): Promise<PublicTxResult> {

--- a/yarn-project/simulator/src/public/public_tx_simulator/public_tx_simulator.test.ts
+++ b/yarn-project/simulator/src/public/public_tx_simulator/public_tx_simulator.test.ts
@@ -38,7 +38,7 @@ import { mock } from 'jest-mock-extended';
 
 import { AvmFinalizedCallResult } from '../avm/avm_contract_call_result.js';
 import type { InstructionSet } from '../avm/serialization/bytecode_serialization.js';
-import { PublicContractsDB, PublicTreesDB } from '../public_db_sources.js';
+import { PublicContractsDB } from '../public_db_sources.js';
 import { PublicPersistableStateManager } from '../state_manager/state_manager.js';
 import { type PublicTxResult, PublicTxSimulator } from './public_tx_simulator.js';
 
@@ -60,7 +60,6 @@ describe('public_tx_simulator', () => {
 
   let merkleTrees: MerkleTreeWriteOperations;
   let merkleTreesCopy: MerkleTreeWriteOperations;
-  let treesDB: PublicTreesDB;
   let contractsDB: PublicContractsDB;
 
   let publicDataTree: AppendOnlyTree<Fr>;
@@ -243,7 +242,7 @@ describe('public_tx_simulator', () => {
     skipFeeEnforcement?: boolean;
   }) => {
     const simulator = new PublicTxSimulator(
-      treesDB,
+      merkleTrees,
       contractsDB,
       GlobalVariables.from({ ...GlobalVariables.empty(), gasFees }),
       doMerkleOperations,
@@ -279,7 +278,6 @@ describe('public_tx_simulator', () => {
   beforeEach(async () => {
     merkleTrees = await (await NativeWorldStateService.tmp()).fork();
     merkleTreesCopy = await (await NativeWorldStateService.tmp()).fork();
-    treesDB = new PublicTreesDB(merkleTrees);
     contractsDB = new PublicContractsDB(mock<ContractDataSource>());
 
     treeStore = openTmpStore();

--- a/yarn-project/simulator/src/public/public_tx_simulator/public_tx_simulator.ts
+++ b/yarn-project/simulator/src/public/public_tx_simulator/public_tx_simulator.ts
@@ -7,11 +7,13 @@ import {
   AvmCircuitPublicInputs,
   AvmExecutionHints,
   type AvmProvingRequest,
+  AvmTxHint,
   type RevertCode,
 } from '@aztec/stdlib/avm';
 import { SimulationError } from '@aztec/stdlib/errors';
 import type { Gas, GasUsed } from '@aztec/stdlib/gas';
 import { ProvingRequestType } from '@aztec/stdlib/proofs';
+import type { MerkleTreeWriteOperations } from '@aztec/stdlib/trees';
 import {
   type GlobalVariables,
   NestedProcessReturnValues,
@@ -22,10 +24,11 @@ import {
 
 import { strict as assert } from 'assert';
 
-import { getPublicFunctionDebugName } from '../../common/debug_fn_name.js';
 import type { AvmFinalizedCallResult } from '../avm/avm_contract_call_result.js';
 import { AvmSimulator } from '../avm/index.js';
-import type { PublicContractsDB, PublicTreesDB } from '../public_db_sources.js';
+import { getPublicFunctionDebugName } from '../debug_fn_name.js';
+import { HintingMerkleWriteOperations, HintingPublicContractsDB } from '../hinting_db_sources.js';
+import { type PublicContractsDB, PublicTreesDB } from '../public_db_sources.js';
 import { NullifierCollisionError } from '../state_manager/nullifiers.js';
 import type { PublicPersistableStateManager } from '../state_manager/state_manager.js';
 import { PublicTxContext } from './public_tx_context.js';
@@ -52,8 +55,8 @@ export class PublicTxSimulator {
   protected log: Logger;
 
   constructor(
-    private treesDB: PublicTreesDB,
-    protected contractsDB: PublicContractsDB,
+    private merkleTree: MerkleTreeWriteOperations,
+    private contractsDB: PublicContractsDB,
     private globalVariables: GlobalVariables,
     private doMerkleOperations: boolean = false,
     private skipFeeEnforcement: boolean = false,
@@ -71,9 +74,15 @@ export class PublicTxSimulator {
       const txHash = await this.computeTxHash(tx);
       this.log.debug(`Simulating ${tx.publicFunctionCalldata.length} public calls for tx ${txHash}`, { txHash });
 
+      // Create hinting DBs.
+      const hints = new AvmExecutionHints(await AvmTxHint.fromTx(tx));
+      const hintingMerkleTree = await HintingMerkleWriteOperations.create(this.merkleTree, hints);
+      const hintingTreesDB = new PublicTreesDB(hintingMerkleTree);
+      const hintingContractsDB = new HintingPublicContractsDB(this.contractsDB, hints);
+
       const context = await PublicTxContext.create(
-        this.treesDB,
-        this.contractsDB,
+        hintingTreesDB,
+        hintingContractsDB,
         tx,
         this.globalVariables,
         this.doMerkleOperations,
@@ -107,7 +116,7 @@ export class PublicTxSimulator {
       await this.payFee(context);
 
       const publicInputs = await context.generateAvmCircuitPublicInputs();
-      const avmProvingRequest = PublicTxSimulator.generateProvingRequest(publicInputs, context.hints);
+      const avmProvingRequest = PublicTxSimulator.generateProvingRequest(publicInputs, hints);
 
       const revertCode = context.getFinalRevertCode();
 
@@ -267,7 +276,7 @@ export class PublicTxSimulator {
     stateManager.traceEnqueuedCall(callRequest.request);
 
     const result = await this.simulateEnqueuedCallInternal(
-      context.state.getActiveStateManager(),
+      stateManager,
       callRequest,
       allocatedGas,
       /*transactionFee=*/ context.getTransactionFee(phase),

--- a/yarn-project/simulator/src/public/public_tx_simulator/public_tx_simulator.ts
+++ b/yarn-project/simulator/src/public/public_tx_simulator/public_tx_simulator.ts
@@ -344,7 +344,11 @@ export class PublicTxSimulator {
   protected async insertNonRevertiblesFromPrivate(context: PublicTxContext, tx: Tx) {
     const stateManager = context.state.getActiveStateManager();
     try {
-      await stateManager.writeSiloedNullifiersFromPrivate(context.nonRevertibleAccumulatedDataFromPrivate.nullifiers);
+      for (const siloedNullifier of context.nonRevertibleAccumulatedDataFromPrivate.nullifiers.filter(
+        n => !n.isEmpty(),
+      )) {
+        await stateManager.writeSiloedNullifier(siloedNullifier);
+      }
     } catch (e) {
       if (e instanceof NullifierCollisionError) {
         throw new NullifierCollisionError(
@@ -373,7 +377,9 @@ export class PublicTxSimulator {
     await context.state.fork();
     const stateManager = context.state.getActiveStateManager();
     try {
-      await stateManager.writeSiloedNullifiersFromPrivate(context.revertibleAccumulatedDataFromPrivate.nullifiers);
+      for (const siloedNullifier of context.revertibleAccumulatedDataFromPrivate.nullifiers.filter(n => !n.isEmpty())) {
+        await stateManager.writeSiloedNullifier(siloedNullifier);
+      }
     } catch (e) {
       if (e instanceof NullifierCollisionError) {
         // Instead of throwing, revert the app_logic phase

--- a/yarn-project/simulator/src/public/public_tx_simulator/telemetry_public_tx_simulator.ts
+++ b/yarn-project/simulator/src/public/public_tx_simulator/telemetry_public_tx_simulator.ts
@@ -1,11 +1,12 @@
 import type { Fr } from '@aztec/foundation/fields';
 import type { Gas } from '@aztec/stdlib/gas';
+import type { MerkleTreeWriteOperations } from '@aztec/stdlib/trees';
 import { type GlobalVariables, PublicCallRequestWithCalldata, TxExecutionPhase } from '@aztec/stdlib/tx';
 import { Attributes, type TelemetryClient, type Tracer, getTelemetryClient, trackSpan } from '@aztec/telemetry-client';
 
 import type { AvmFinalizedCallResult } from '../avm/avm_contract_call_result.js';
 import { ExecutorMetrics } from '../executor_metrics.js';
-import type { PublicContractsDB, PublicTreesDB } from '../public_db_sources.js';
+import type { PublicContractsDB } from '../public_db_sources.js';
 import type { PublicPersistableStateManager } from '../state_manager/state_manager.js';
 import { MeasuredPublicTxSimulator } from './measured_public_tx_simulator.js';
 import { PublicTxContext } from './public_tx_context.js';
@@ -18,7 +19,7 @@ export class TelemetryPublicTxSimulator extends MeasuredPublicTxSimulator {
   public readonly tracer: Tracer;
 
   constructor(
-    treesDB: PublicTreesDB,
+    merkleTree: MerkleTreeWriteOperations,
     contractsDB: PublicContractsDB,
     globalVariables: GlobalVariables,
     doMerkleOperations: boolean = false,
@@ -26,7 +27,7 @@ export class TelemetryPublicTxSimulator extends MeasuredPublicTxSimulator {
     telemetryClient: TelemetryClient = getTelemetryClient(),
   ) {
     const metrics = new ExecutorMetrics(telemetryClient, 'PublicTxSimulator');
-    super(treesDB, contractsDB, globalVariables, doMerkleOperations, skipFeeEnforcement, metrics);
+    super(merkleTree, contractsDB, globalVariables, doMerkleOperations, skipFeeEnforcement, metrics);
     this.tracer = metrics.tracer;
   }
 

--- a/yarn-project/simulator/src/public/side_effect_trace.ts
+++ b/yarn-project/simulator/src/public/side_effect_trace.ts
@@ -32,7 +32,7 @@ import {
 } from '@aztec/stdlib/kernel';
 import { PublicLog } from '@aztec/stdlib/logs';
 import { L2ToL1Message, ScopedL2ToL1Message } from '@aztec/stdlib/messaging';
-import type { GlobalVariables, TreeSnapshots } from '@aztec/stdlib/tx';
+import { type GlobalVariables, TreeSnapshots } from '@aztec/stdlib/tx';
 
 import { strict as assert } from 'assert';
 
@@ -277,8 +277,6 @@ export class SideEffectTrace implements PublicSideEffectTraceInterface {
   public toAvmCircuitPublicInputs(
     /** Globals. */
     globalVariables: GlobalVariables,
-    /** Start tree snapshots. */
-    startTreeSnapshots: TreeSnapshots,
     /** Gas used at start of TX. */
     startGasUsed: Gas,
     /** How much gas was available for this public execution. */
@@ -305,7 +303,7 @@ export class SideEffectTrace implements PublicSideEffectTraceInterface {
   ): AvmCircuitPublicInputs {
     return new AvmCircuitPublicInputs(
       globalVariables,
-      startTreeSnapshots,
+      TreeSnapshots.empty(), // will be patched later.
       startGasUsed,
       gasLimits,
       feePayer,

--- a/yarn-project/simulator/src/public/state_manager/state_manager.test.ts
+++ b/yarn-project/simulator/src/public/state_manager/state_manager.test.ts
@@ -105,13 +105,13 @@ describe('state_manager', () => {
     });
 
     it('checkL1ToL2MessageExists works for missing message', async () => {
-      const exists = await persistableState.checkL1ToL2MessageExists(address, utxo, leafIndex);
+      const exists = await persistableState.checkL1ToL2MessageExists(utxo, leafIndex);
       expect(exists).toEqual(false);
     });
 
     it('checkL1ToL2MessageExists works for existing message', async () => {
       mockL1ToL2MessageExists(treesDB, leafIndex, utxo);
-      const exists = await persistableState.checkL1ToL2MessageExists(address, utxo, leafIndex);
+      const exists = await persistableState.checkL1ToL2MessageExists(utxo, leafIndex);
       expect(exists).toEqual(true);
     });
 

--- a/yarn-project/simulator/src/public/state_manager/state_manager.ts
+++ b/yarn-project/simulator/src/public/state_manager/state_manager.ts
@@ -11,26 +11,20 @@ import { Fr } from '@aztec/foundation/fields';
 import { jsonStringify } from '@aztec/foundation/json-rpc';
 import { createLogger } from '@aztec/foundation/log';
 import { ProtocolContractAddress } from '@aztec/protocol-contracts';
-import { PublicDataWrite } from '@aztec/stdlib/avm';
 import { AztecAddress } from '@aztec/stdlib/aztec-address';
 import type { ContractClassPublicWithCommitment, ContractInstanceWithAddress } from '@aztec/stdlib/contract';
 import { SerializableContractInstance } from '@aztec/stdlib/contract';
-import {
-  computeNoteHashNonce,
-  computePublicDataTreeLeafSlot,
-  computeUniqueNoteHash,
-  siloNoteHash,
-  siloNullifier,
-} from '@aztec/stdlib/hash';
+import { computeNoteHashNonce, computeUniqueNoteHash, siloNoteHash, siloNullifier } from '@aztec/stdlib/hash';
 import type { PublicCallRequest } from '@aztec/stdlib/kernel';
 import { SharedMutableValues, SharedMutableValuesWithHash } from '@aztec/stdlib/shared-mutable';
 import { MerkleTreeId } from '@aztec/stdlib/trees';
+import type { TreeSnapshots } from '@aztec/stdlib/tx';
 
 import { strict as assert } from 'assert';
 
-import { getPublicFunctionDebugName } from '../../common/debug_fn_name.js';
-import type { PublicContractsDBInterface } from '../../server.js';
 import type { AvmExecutionEnvironment } from '../avm/avm_execution_environment.js';
+import type { PublicContractsDBInterface } from '../db_interfaces.js';
+import { getPublicFunctionDebugName } from '../debug_fn_name.js';
 import type { PublicTreesDB } from '../public_db_sources.js';
 import type { PublicSideEffectTraceInterface } from '../side_effect_trace_interface.js';
 import { NullifierCollisionError, NullifierManager } from './nullifiers.js';
@@ -83,12 +77,6 @@ export class PublicPersistableStateManager {
     );
   }
 
-  // DO NOT USE!
-  // FIXME(fcarreiro): refactor and remove this.
-  public deprecatedGetTreesForPIGeneration() {
-    return this.treesDB;
-  }
-
   /**
    * Create a new state manager forked from this one
    */
@@ -131,14 +119,8 @@ export class PublicPersistableStateManager {
     this.nullifiers.acceptAndMerge(forkedState.nullifiers);
     this.trace.merge(forkedState.trace, reverted);
     if (reverted) {
+      this.log.trace('Reverting forked state...');
       await this.treesDB.revertCheckpoint();
-      if (this.doMerkleOperations) {
-        this.log.trace(
-          `Rolled back nullifier tree to root ${new Fr(
-            (await this.treesDB.getTreeInfo(MerkleTreeId.NULLIFIER_TREE)).root,
-          )}`,
-        );
-      }
     } else {
       this.log.trace('Merging forked state into parent...');
       await this.treesDB.commitCheckpoint();
@@ -153,15 +135,11 @@ export class PublicPersistableStateManager {
    * @param value - the value being written to the slot
    */
   public async writeStorage(contractAddress: AztecAddress, slot: Fr, value: Fr, protocolWrite = false): Promise<void> {
-    const leafSlot = await computePublicDataTreeLeafSlot(contractAddress, slot);
-    this.log.trace(`Storage write (address=${contractAddress}, slot=${slot}): value=${value}, leafSlot=${leafSlot}`);
+    this.log.trace(`Storage write (address=${contractAddress}, slot=${slot}): value=${value}`);
 
     if (this.doMerkleOperations) {
       // write to native merkle trees
-      const publicDataWrite = new PublicDataWrite(leafSlot, value);
-      const result = await this.treesDB.sequentialInsert(MerkleTreeId.PUBLIC_DATA_TREE, [publicDataWrite.toBuffer()]);
-      assert(result !== undefined, 'Public data tree insertion error. You might want to disable doMerkleOperations.');
-      this.log.trace(`Inserted public data tree leaf at leafSlot ${leafSlot}, value: ${value}`);
+      await this.treesDB.storageWrite(contractAddress, slot, value);
     } else {
       // Cache storage writes for later reference/reads
       this.publicStorage.write(contractAddress, slot, value);
@@ -179,8 +157,7 @@ export class PublicPersistableStateManager {
    */
   public async readStorage(contractAddress: AztecAddress, slot: Fr): Promise<Fr> {
     if (this.doMerkleOperations) {
-      const value = await this.treesDB.storageRead(contractAddress, slot);
-      return value;
+      return await this.treesDB.storageRead(contractAddress, slot);
     } else {
       // TODO(fcarreiro): I don't get this. PublicStorage CAN end up reading the tree. Why is it in the "dont do merkle operations" branch?
       const read = await this.publicStorage.read(contractAddress, slot);
@@ -201,8 +178,8 @@ export class PublicPersistableStateManager {
    * @returns true if the note hash exists at the given leaf index, false otherwise
    */
   public async checkNoteHashExists(contractAddress: AztecAddress, noteHash: Fr, leafIndex: Fr): Promise<boolean> {
-    const gotLeafValue = (await this.treesDB.getNoteHash(leafIndex.toBigInt())) ?? Fr.ZERO;
-    const exists = gotLeafValue.equals(noteHash);
+    const gotLeafValue = await this.treesDB.getNoteHash(leafIndex.toBigInt());
+    const exists = gotLeafValue !== undefined && gotLeafValue.equals(noteHash);
     this.log.trace(
       `noteHashes(${contractAddress})@${noteHash} ?? leafIndex: ${leafIndex} | gotLeafValue: ${gotLeafValue}, exists: ${exists}.`,
     );
@@ -236,7 +213,7 @@ export class PublicPersistableStateManager {
   public async writeUniqueNoteHash(uniqueNoteHash: Fr): Promise<void> {
     this.log.trace(`noteHashes += @${uniqueNoteHash}.`);
     if (this.doMerkleOperations) {
-      await this.treesDB.appendLeaves(MerkleTreeId.NOTE_HASH_TREE, [uniqueNoteHash]);
+      await this.treesDB.writeNoteHash(uniqueNoteHash);
     }
     this.trace.traceNewNoteHash(uniqueNoteHash);
   }
@@ -290,7 +267,7 @@ export class PublicPersistableStateManager {
           `Siloed nullifier ${siloedNullifier} already exists in parent cache or host.`,
         );
       } else {
-        await this.treesDB.sequentialInsert(MerkleTreeId.NULLIFIER_TREE, [siloedNullifier.toBuffer()]);
+        await this.treesDB.writeNullifier(siloedNullifier);
       }
     } else {
       // Cache pending nullifiers for later access
@@ -312,13 +289,9 @@ export class PublicPersistableStateManager {
    * @param msgLeafIndex - the message leaf index to use in the check
    * @returns exists - whether the message exists in the L1 to L2 Messages tree
    */
-  public async checkL1ToL2MessageExists(
-    contractAddress: AztecAddress,
-    msgHash: Fr,
-    msgLeafIndex: Fr,
-  ): Promise<boolean> {
-    const valueAtIndex = (await this.treesDB.getL1ToL2LeafValue(msgLeafIndex.toBigInt())) ?? Fr.ZERO;
-    const exists = valueAtIndex.equals(msgHash);
+  public async checkL1ToL2MessageExists(msgHash: Fr, msgLeafIndex: Fr): Promise<boolean> {
+    const valueAtIndex = await this.treesDB.getL1ToL2LeafValue(msgLeafIndex.toBigInt());
+    const exists = valueAtIndex !== undefined && valueAtIndex.equals(msgHash);
     this.log.trace(
       `l1ToL2Messages(@${msgLeafIndex}) ?? exists: ${exists}, expected: ${msgHash}, found: ${valueAtIndex}.`,
     );
@@ -500,6 +473,14 @@ export class PublicPersistableStateManager {
 
   public async getPublicFunctionDebugName(avmEnvironment: AvmExecutionEnvironment): Promise<string> {
     return await getPublicFunctionDebugName(this.contractsDB, avmEnvironment.address, avmEnvironment.calldata);
+  }
+
+  public async padTree(treeId: MerkleTreeId, leavesToInsert: number): Promise<void> {
+    await this.treesDB.padTree(treeId, leavesToInsert);
+  }
+
+  public async getTreeSnapshots(): Promise<TreeSnapshots> {
+    return await this.treesDB.getTreeSnapshots();
   }
 }
 

--- a/yarn-project/simulator/src/public/state_manager/state_manager.ts
+++ b/yarn-project/simulator/src/public/state_manager/state_manager.ts
@@ -233,7 +233,6 @@ export class PublicPersistableStateManager {
       this.log.trace(`Checked siloed nullifier ${siloedNullifier} (exists=${exists})`);
       return Promise.resolve(exists);
     } else {
-      // TODO: same here, this CAN hit the db.
       const { exists, cacheHit } = await this.nullifiers.checkExists(siloedNullifier);
       this.log.trace(`Checked siloed nullifier ${siloedNullifier} (exists=${exists}), cacheHit=${cacheHit}`);
       return Promise.resolve(exists);
@@ -275,12 +274,6 @@ export class PublicPersistableStateManager {
     }
 
     this.trace.traceNewNullifier(siloedNullifier);
-  }
-
-  public async writeSiloedNullifiersFromPrivate(siloedNullifiers: Fr[]) {
-    for (const siloedNullifier of siloedNullifiers.filter(n => !n.isEmpty())) {
-      await this.writeSiloedNullifier(siloedNullifier);
-    }
   }
 
   /**
@@ -348,7 +341,7 @@ export class PublicPersistableStateManager {
     );
     assert(
       exists == nullifierExistsInTree,
-      'treesDB contains contract instance, but nullifier tree does not contain contract address (or vice versa).... This is a bug!',
+      `Contract instance for address ${contractAddress} in DB: ${exists} != nullifier tree: ${nullifierExistsInTree}. This is a bug!`,
     );
 
     // All that is left is tocheck that the contract updatability information is correct.

--- a/yarn-project/txe/src/oracle/txe_oracle.ts
+++ b/yarn-project/txe/src/oracle/txe_oracle.ts
@@ -46,7 +46,6 @@ import { createTxForPublicCalls } from '@aztec/simulator/public/fixtures';
 import {
   ExecutionError,
   PublicContractsDB,
-  PublicTreesDB,
   type PublicTxResult,
   PublicTxSimulator,
   createSimulationError,
@@ -945,9 +944,13 @@ export class TXE implements TypedOracle {
     // See note at revert below.
     const checkpoint = await ForkCheckpoint.new(db);
     try {
-      const treesDB = new PublicTreesDB(db);
       const contractsDB = new PublicContractsDB(new TXEPublicContractDataSource(this));
-      const simulator = new PublicTxSimulator(treesDB, contractsDB, globalVariables, /*doMerkleOperations=*/ true);
+      const simulator = new PublicTxSimulator(
+        this.baseFork,
+        contractsDB,
+        globalVariables,
+        /*doMerkleOperations=*/ false,
+      );
 
       const { usedTxRequestHashForNonces } = this.noteCache.finish();
       const firstNullifier = usedTxRequestHashForNonces


### PR DESCRIPTION
I had a few design goals with this PR
1. Move the merkle hinting layer to the merkle db directly (from the PublicContractsDB)
1. Make hinting a TxSimulator concept
1. Divide the tree accesses into low level and high level (like we do in C++).
1. Tighten our exports
1. Some cleanups

I'm satisfied with the result, but there are some things worth noting
* Now the TxSimulator wraps the merkle db into a hinting merkle db. This means that the hints will _always_ be generated and the caller has no control. However, reexecution and the TXE could benefit from a model where no hinting (or tracing) is done. I had a version of this PR where this was done via an extra PublicTreesDBFactory that was passed to the TxSimulator, but I found it too much for the moment. I think at some point we can consider having a more flexible factory type for the PublicProcessor and the TxSimulator where we can specify, e.g., merkle ops, tracing, hinting, etc and have a "Proving" factory and a "Simulation-only" factory.

## AI generated description

This PR refactors the public processor and simulator components to use `MerkleTreeWriteOperations` directly instead of going through the `PublicTreesDB` abstraction. Key changes include:

- Changed `PublicTxSimulator` to accept a `MerkleTreeWriteOperations` instead of `PublicTreesDB`
- Moved `PublicTreesDB` to be an internal implementation detail rather than a public API
- Refactored `HintingPublicTreesDB` to `HintingMerkleWriteOperations` to work directly with the merkle tree interface
- Moved `SimpleContractDataSource` from `avm/fixtures` to `public/fixtures` for better organization
- Added high-level methods to `PublicTreesDB` for writing note hashes and nullifiers
- Simplified tree operations in `PublicPersistableStateManager` by using the new high-level methods
- Updated `checkL1ToL2MessageExists` to no longer require a contract address parameter

This change simplifies the codebase by reducing unnecessary abstractions and making the component dependencies more explicit.