### PR TITLE
chore(docs): docs versioning nits - round 4

### DIFF
--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -71,10 +71,11 @@ jobs:
       - name: Cut version
         working-directory: ./docs
         run: |
+          COMMIT_TAG=$({{ steps.version.outputs.semver }})
           echo "[]" > versions.json
           yarn
-          yarn build
-          yarn docusaurus docs:version ${{ steps.version.outputs.semver }}
+          COMMIT_TAG=$COMMIT_TAG yarn yarn build
+          COMMIT_TAG=$COMMIT_TAG yarn docusaurus docs:version ${{ steps.version.outputs.semver }}
 
       - name: Filter
         working-directory: ./docs

--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -74,7 +74,7 @@ jobs:
           COMMIT_TAG=$({{ steps.version.outputs.semver }})
           echo "[]" > versions.json
           yarn
-          COMMIT_TAG=$COMMIT_TAG yarn yarn build
+          COMMIT_TAG=$COMMIT_TAG yarn build
           COMMIT_TAG=$COMMIT_TAG yarn docusaurus docs:version ${{ steps.version.outputs.semver }}
 
       - name: Filter


### PR DESCRIPTION
Not technically a nit, but it makes the docs version have the correct expansion for `#include_aztec_version` macros