### PR TITLE
chore: upload aztec-up nightly

### DIFF
--- a/aztec-up/bootstrap.sh
+++ b/aztec-up/bootstrap.sh
@@ -41,7 +41,7 @@ function release {
   local current_version=$(aws s3 cp s3://install.aztec.network/VERSION - 2>/dev/null || echo "0.0.0")
 
   # Temporary: while alpha-testnet is the main release, include it (later it should only push to $version)
-  if [[ $(dist_tag) != "latest" && $(dist_tag) != "alpha-testnet" ]]; then
+  if [[ $(dist_tag) != "latest" && $(dist_tag) != "alpha-testnet" && $(dist_tag) != "nightly" ]]; then
     echo_stderr -e "${yellow}Not uploading aztec-up scripts for dist-tag $(dist_tag). They are expected to still be compatible with latest."
     return
   fi
@@ -60,6 +60,11 @@ function release {
 
   # Always create a version directory and upload files there.
   do_or_dryrun aws s3 sync ./bin "s3://install.aztec.network/$version/"
+
+  if [[ $(dist_tag) != "latest" ]]; then
+    # Also upload to a $dist_tag directory, if not latest.
+    do_or_dryrun aws s3 sync ./bin "s3://install.aztec.network/$(dist_tag)/$version/"
+  fi
 }
 
 case "$cmd" in

--- a/aztec-up/bootstrap.sh
+++ b/aztec-up/bootstrap.sh
@@ -63,7 +63,7 @@ function release {
 
   if [[ $(dist_tag) != "latest" ]]; then
     # Also upload to a $dist_tag directory, if not latest.
-    do_or_dryrun aws s3 sync ./bin "s3://install.aztec.network/$(dist_tag)/$version/"
+    do_or_dryrun aws s3 sync ./bin "s3://install.aztec.network/$(dist_tag)/"
   fi
 }
 


### PR DESCRIPTION
- doesn't ignore `nightly` dist tag & uploads to install.aztec.network
- Create new folders for `nightly` & `alpha-testnet` tags, so users can do e.g.: `VERSION=nightly aztec-up`