### PR TITLE
chore(spartan): enable pointing at a different metrics instance 

### DIFF
--- a/.github/workflows/network-deploy.yml
+++ b/.github/workflows/network-deploy.yml
@@ -11,6 +11,11 @@ on:
         description: The namespace to deploy to, e.g. smoke
         required: true
         type: string
+      metrics_namespace:
+        description: The namespace of the metrics deployment, e.g. metrics
+        required: false
+        type: string
+        default: metrics
       values_file:
         description: The values file to use, e.g. 1-validators.yaml
         required: true
@@ -66,6 +71,11 @@ on:
       namespace:
         description: The namespace to deploy to, e.g. smoke
         required: true
+      metrics_namespace:
+        description: The namespace of the metrics deployment, e.g. metrics
+        required: false
+        type: string
+        default: metrics
       values_file:
         description: The values file to use, e.g. 1-validators.yaml
         required: true
@@ -112,6 +122,7 @@ jobs:
     env:
       AZTEC_DOCKER_IMAGE: ${{ inputs.aztec_docker_image }}
       NAMESPACE: ${{ inputs.namespace }}
+      METRICS_NAMESPACE: ${{ inputs.metrics_namespace }}
       VALUES_FILE: ${{ inputs.values_file }}
       RESOURCES_FILE: ${{ inputs.resources_file }}
       DEPLOYMENT_MNEMONIC_SECRET_NAME: ${{ inputs.deployment_mnemonic_secret_name }}
@@ -253,6 +264,7 @@ jobs:
               -var="EXTERNAL_ETHEREUM_CONSENSUS_HOST=${{ env.EXTERNAL_ETHEREUM_CONSENSUS_HOST }}" \
               -var="EXTERNAL_ETHEREUM_CONSENSUS_HOST_API_KEY=${{ secrets.GCP_SEPOLIA_API_KEY }}" \
               -var="EXTERNAL_ETHEREUM_CONSENSUS_HOST_API_KEY_HEADER=${{ env.GCP_API_KEY_HEADER }}" \
+              -var="METRICS_NAMESPACE=${{ env.METRICS_NAMESPACE }}" \
               ${{ contains(env.VALUES_FILE, 'devnet') && '-var="EXPOSE_HTTPS_BOOTNODE=true"' || '' }} \
               -out=tfplan \
               -lock=${{ inputs.respect_tf_lock }}
@@ -265,6 +277,7 @@ jobs:
               -var="AZTEC_DOCKER_IMAGE=${{ env.AZTEC_DOCKER_IMAGE }}" \
               -var="L1_DEPLOYMENT_MNEMONIC=${{ steps.get-mnemonic.outputs.mnemonic }}" \
               -var="L1_DEPLOYMENT_SALT=${DEPLOYMENT_SALT:-$RANDOM}" \
+              -var="METRICS_NAMESPACE=${{ env.METRICS_NAMESPACE }}" \
               ${{ contains(env.VALUES_FILE, 'devnet') && '-var="EXPOSE_HTTPS_BOOTNODE=true"' || '' }} \
               -out=tfplan \
               -lock=${{ inputs.respect_tf_lock }}

--- a/spartan/terraform/deploy-metrics/main.tf
+++ b/spartan/terraform/deploy-metrics/main.tf
@@ -23,7 +23,7 @@ provider "google" {
 
 resource "google_compute_address" "grafana_ip" {
   provider     = google
-  name         = "grafana-ip"
+  name         = "grafana-ip-${var.RELEASE_NAME}"
   address_type = "EXTERNAL"
   region       = var.region
 
@@ -34,7 +34,7 @@ resource "google_compute_address" "grafana_ip" {
 
 resource "google_compute_address" "otel_collector_ip" {
   provider     = google
-  name         = "otel-ip"
+  name         = "otel-ip-${var.RELEASE_NAME}"
   address_type = "EXTERNAL"
   region       = var.region
 

--- a/spartan/terraform/deploy-release/main.tf
+++ b/spartan/terraform/deploy-release/main.tf
@@ -34,7 +34,7 @@ data "terraform_remote_state" "metrics" {
   backend = "gcs"
   config = {
     bucket = "aztec-terraform"
-    prefix = "metrics-deploy/us-west1-a/aztec-gke-private/metrics/terraform.tfstate"
+    prefix = "metrics-deploy/us-west1-a/aztec-gke-private/${var.METRICS_NAMESPACE}/terraform.tfstate"
   }
 }
 

--- a/spartan/terraform/deploy-release/variables.tf
+++ b/spartan/terraform/deploy-release/variables.tf
@@ -80,3 +80,9 @@ variable "BOOTNODE_IP_REGION" {
   default = "us-west1"
   type    = string
 }
+
+variable "METRICS_NAMESPACE" {
+  description = "Namespace to deploy the metrics to"
+  type        = string
+  default     = "metrics"
+}


### PR DESCRIPTION
## Overview

Deployments + metrics releases are hardcoded to point at a singluar metrics instance, and deploying others is not possible
This pr rectifies that 
