### PR TITLE
feat: Validator waits for archiver sync

### DIFF
--- a/yarn-project/archiver/src/archiver/archiver.ts
+++ b/yarn-project/archiver/src/archiver/archiver.ts
@@ -201,6 +201,13 @@ export class Archiver extends EventEmitter implements ArchiveSource, Traceable {
     this.runningPromise.start();
   }
 
+  public syncImmediate() {
+    if (!this.runningPromise) {
+      throw new Error('Archiver is not running');
+    }
+    return this.runningPromise.trigger();
+  }
+
   private async syncSafe(initialRun: boolean) {
     try {
       await this.sync(initialRun);

--- a/yarn-project/archiver/src/test/mock_l2_block_source.ts
+++ b/yarn-project/archiver/src/test/mock_l2_block_source.ts
@@ -254,4 +254,8 @@ export class MockL2BlockSource implements L2BlockSource, ContractDataSource {
   registerContractFunctionSignatures(_address: AztecAddress, _signatures: string[]): Promise<void> {
     return Promise.resolve();
   }
+
+  syncImmediate(): Promise<void> {
+    return Promise.resolve();
+  }
 }

--- a/yarn-project/sequencer-client/src/sequencer/sequencer.test.ts
+++ b/yarn-project/sequencer-client/src/sequencer/sequencer.test.ts
@@ -193,6 +193,7 @@ describe('sequencer', () => {
     });
     worldState = mock<WorldStateSynchronizer>({
       fork: () => Promise.resolve(fork),
+      syncImmediate: () => Promise.resolve(lastBlockNumber),
       getCommitted: () => merkleTreeOps,
       status: mockFn().mockResolvedValue({
         state: WorldStateRunningState.IDLE,

--- a/yarn-project/sequencer-client/src/sequencer/timetable.ts
+++ b/yarn-project/sequencer-client/src/sequencer/timetable.ts
@@ -57,7 +57,7 @@ export class SequencerTimetable {
     return this.attestationPropagationTime + this.l1PublishingTime;
   }
 
-  public getValidatorReexecTimeEnd(secondsIntoSlot: number): number {
+  public getValidatorReexecTimeEnd(secondsIntoSlot?: number): number {
     // We need to leave for `afterBlockReexecTimeNeeded` seconds available.
     const validationTimeEnd = this.aztecSlotDuration - this.afterBlockReexecTimeNeeded;
     this.log.debug(`Validator re-execution time deadline is ${validationTimeEnd}`, {

--- a/yarn-project/stdlib/src/block/l2_block_source.ts
+++ b/yarn-project/stdlib/src/block/l2_block_source.ts
@@ -118,6 +118,9 @@ export interface L2BlockSource {
    * Returns the rollup constants for the current chain.
    */
   getL1Constants(): Promise<L1RollupConstants>;
+
+  /** Force a sync. */
+  syncImmediate(): Promise<void>;
 }
 
 /**

--- a/yarn-project/stdlib/src/interfaces/archiver.test.ts
+++ b/yarn-project/stdlib/src/interfaces/archiver.test.ts
@@ -236,11 +236,18 @@ describe('ArchiverApiSchema', () => {
     const result = await context.client.getL1Constants();
     expect(result).toEqual(EmptyL1RollupConstants);
   });
+
+  it('syncImmediate', async () => {
+    await context.client.syncImmediate();
+  });
 });
 
 class MockArchiver implements ArchiverApi {
   constructor(private artifact: ContractArtifact) {}
 
+  syncImmediate() {
+    return Promise.resolve();
+  }
   getRollupAddress(): Promise<EthAddress> {
     return Promise.resolve(EthAddress.random());
   }

--- a/yarn-project/stdlib/src/interfaces/archiver.ts
+++ b/yarn-project/stdlib/src/interfaces/archiver.ts
@@ -73,4 +73,5 @@ export const ArchiverApiSchema: ApiSchemaFor<ArchiverApi> = {
   getL1ToL2MessageIndex: z.function().args(schemas.Fr).returns(schemas.BigInt.optional()),
   getDebugFunctionName: z.function().args(schemas.AztecAddress, schemas.FunctionSelector).returns(optional(z.string())),
   getL1Constants: z.function().args().returns(L1RollupConstantsSchema),
+  syncImmediate: z.function().args().returns(z.void()),
 };

--- a/yarn-project/stdlib/src/interfaces/world_state.ts
+++ b/yarn-project/stdlib/src/interfaces/world_state.ts
@@ -68,10 +68,11 @@ export interface WorldStateSynchronizer extends ForkMerkleTreeOperations {
 
   /**
    * Forces an immediate sync to an optionally provided minimum block number
-   * @param minBlockNumber - The minimum block number that we must sync to (may sync further)
+   * @param targetBlockNumber - The target block number that we must sync to. Will download unproven blocks if needed to reach it.
+   * @param skipThrowIfTargetNotReached - Whether to skip throwing if the target block number is not reached.
    * @returns A promise that resolves with the block number the world state was synced to
    */
-  syncImmediate(minBlockNumber?: number): Promise<number>;
+  syncImmediate(minBlockNumber?: number, skipThrowIfTargetNotReached?: boolean): Promise<number>;
 
   /** Returns an instance of MerkleTreeAdminOperations that will not include uncommitted data. */
   getCommitted(): MerkleTreeReadOperations;

--- a/yarn-project/world-state/src/synchronizer/server_world_state_synchronizer.ts
+++ b/yarn-project/world-state/src/synchronizer/server_world_state_synchronizer.ts
@@ -171,10 +171,11 @@ export class ServerWorldStateSynchronizer
 
   /**
    * Forces an immediate sync.
-   * @param targetBlockNumber - The target block number that we must sync to. Will download unproven blocks if needed to reach it. Throws if cannot be reached.
+   * @param targetBlockNumber - The target block number that we must sync to. Will download unproven blocks if needed to reach it.
+   * @param skipThrowIfTargetNotReached - Whether to skip throwing if the target block number is not reached.
    * @returns A promise that resolves with the block number the world state was synced to
    */
-  public async syncImmediate(targetBlockNumber?: number): Promise<number> {
+  public async syncImmediate(targetBlockNumber?: number, skipThrowIfTargetNotReached?: boolean): Promise<number> {
     if (this.currentState !== WorldStateRunningState.RUNNING || this.blockStream === undefined) {
       throw new Error(`World State is not running. Unable to perform sync.`);
     }
@@ -186,12 +187,21 @@ export class ServerWorldStateSynchronizer
     }
     this.log.debug(`World State at ${currentBlockNumber} told to sync to ${targetBlockNumber ?? 'latest'}`);
 
+    // If the archiver is behind the target block, force an archiver sync
+    if (targetBlockNumber) {
+      const archiverLatestBlock = await this.l2BlockSource.getBlockNumber();
+      if (archiverLatestBlock < targetBlockNumber) {
+        this.log.debug(`Archiver is at ${archiverLatestBlock} behind target block ${targetBlockNumber}.`);
+        await this.l2BlockSource.syncImmediate();
+      }
+    }
+
     // Force the block stream to sync against the archiver now
     await this.blockStream.sync();
 
     // If we have been given a block number to sync to and we have not reached that number then fail
     const updatedBlockNumber = await this.getLatestBlockNumber();
-    if (targetBlockNumber !== undefined && targetBlockNumber > updatedBlockNumber) {
+    if (!skipThrowIfTargetNotReached && targetBlockNumber !== undefined && targetBlockNumber > updatedBlockNumber) {
       throw new Error(`Unable to sync to block number ${targetBlockNumber} (last synced is ${updatedBlockNumber})`);
     }
 


### PR DESCRIPTION
Slow validators may receive a proposal to attest to before their archiver has synced to the block immediately before. Example log:

```
[18:02:27.581] ERROR: validator Failed to attest to proposal: Error: Unable to sync to block number 4811 (last synced is 4810)
    at ServerWorldStateSynchronizer.syncImmediate (file:///usr/src/yarn-project/world-state/dest/synchronizer/server_world_state_synchronizer.js:145:19)
    at async Sequencer.buildBlock (file:///usr/src/yarn-project/sequencer-client/dest/sequencer/sequencer.js:351:9)
    at async ValidatorClient.reExecuteTransactions (file:///usr/src/yarn-project/validator-client/dest/validator.js:161:41)
    at async ValidatorClient.attestToProposal (file:///usr/src/yarn-project/validator-client/dest/validator.js:127:17)
    at async LibP2PService.processValidBlockProposal (file:///usr/src/yarn-project/p2p/dest/services/libp2p/libp2p_service.js:451:29)
    at async LibP2PService.processBlockFromPeer (file:///usr/src/yarn-project/p2p/dest/services/libp2p/libp2p_service.js:441:9)
    at async LibP2PService.handleNewGossipMessage (file:///usr/src/yarn-project/p2p/dest/services/libp2p/libp2p_service.js:355:13)
    at async safeJob (file:///usr/src/yarn-project/p2p/dest/services/libp2p/libp2p_service.js:285:17) {"slotNumber":7976,"blockNumber":4812,"archive":"0x1f26b22cdad7132d0bb06461300a27b12fde92b633633550e37764d810304cb4","txCount":0,"txHashes":[]}
[18:02:29.560] INFO: archiver Downloaded L2 block 4811 {"blockHash":{},"blockNumber":4811,"txCount":0,"globalVariables":{"chainId":11155111,"version":3538330213,"blockNumber":4811,"slotNumber":7975,"timestamp":1744394520,"coinbase":"0x2b64d6efab183a85f0b37e02b1975cd9f2d98068","feeRecipient":"0x0000000000000000000000000000000000000000000000000000000000000000","feePerDaGas":0,"feePerL2Gas":0}}
```

This PR has the validator keep retrying to sync to the target block until the reexecution deadline, rather than giving up immediately.