### PR TITLE
feat: more tests for pairing point object

### DIFF
--- a/barretenberg/cpp/src/barretenberg/dsl/acir_format/ivc_recursion_constraint.test.cpp
+++ b/barretenberg/cpp/src/barretenberg/dsl/acir_format/ivc_recursion_constraint.test.cpp
@@ -40,6 +40,69 @@ class IvcRecursionConstraintTest : public ::testing::Test {
         return circuit;
     }
 
+    static UltraCircuitBuilder create_inner_circuit(size_t log_num_gates = 10)
+    {
+        using InnerAggState = bb::stdlib::recursion::aggregation_state<UltraCircuitBuilder>;
+
+        UltraCircuitBuilder builder;
+
+        // Create 2^log_n many add gates based on input log num gates
+        const size_t num_gates = (1 << log_num_gates);
+        for (size_t i = 0; i < num_gates; ++i) {
+            fr a = fr::random_element();
+            uint32_t a_idx = builder.add_variable(a);
+
+            fr b = fr::random_element();
+            fr c = fr::random_element();
+            fr d = a + b + c;
+            uint32_t b_idx = builder.add_variable(b);
+            uint32_t c_idx = builder.add_variable(c);
+            uint32_t d_idx = builder.add_variable(d);
+
+            builder.create_big_add_gate({ a_idx, b_idx, c_idx, d_idx, fr(1), fr(1), fr(1), fr(-1), fr(0) });
+        }
+
+        InnerAggState::add_default_pairing_points_to_public_inputs(builder);
+        return builder;
+    }
+
+    /**
+     * @brief Constuct a mock app circuit with a UH recursive verifier
+     *
+     */
+    static Builder construct_mock_UH_recursion_app_circuit(const std::shared_ptr<ClientIVC>& ivc)
+    {
+        AcirProgram program;
+        std::vector<RecursionConstraint> recursion_constraints;
+
+        Builder circuit{ ivc->goblin.op_queue };
+        GoblinMockCircuits::add_some_ecc_op_gates(circuit);
+        MockCircuits::add_arithmetic_gates(circuit);
+
+        {
+            using RecursiveFlavor = UltraRecursiveFlavor_<Builder>;
+            using VerifierOutput = bb::stdlib::recursion::honk::UltraRecursiveVerifierOutput<RecursiveFlavor>;
+            using OuterAggState = bb::stdlib::recursion::aggregation_state<Builder>;
+
+            // Create an arbitrary inner circuit
+            auto inner_circuit = create_inner_circuit();
+
+            // Compute native verification key
+            auto proving_key = std::make_shared<DeciderProvingKey_<UltraFlavor>>(inner_circuit);
+            UltraProver prover(proving_key); // A prerequisite for computing VK
+            auto honk_vk = std::make_shared<UltraFlavor::VerificationKey>(proving_key->proving_key);
+            auto inner_proof = prover.construct_proof();
+
+            // Instantiate the recursive verifier using the native verification key
+            stdlib::recursion::honk::UltraRecursiveVerifier_<RecursiveFlavor> verifier(&circuit, honk_vk);
+
+            VerifierOutput output = verifier.verify_proof(inner_proof, OuterAggState::construct_default(circuit));
+            output.agg_obj.set_public(); // useless for now but just checking if it breaks anything
+        }
+
+        return circuit;
+    }
+
     /**
      * @brief Create an ACIR RecursionConstraint given the corresponding verifier inputs
      * @brief In practice such constraints are created via a call to verify_proof(...) in noir
@@ -410,4 +473,31 @@ TEST_F(IvcRecursionConstraintTest, GenerateInnerKernelVKFromConstraints)
 
     // Compare the VK constructed via running the IVc with the one constructed via mocking
     EXPECT_EQ(*kernel_vk.get(), *expected_kernel_vk.get());
+}
+
+/**
+ * @brief Test IVC accumulation of a one app and one kernel. The app includes a UltraHonk Recursive Verifier.
+ * This test was copied from the AccumulateTwo test.
+ */
+TEST_F(IvcRecursionConstraintTest, RecursiveVerifierAppCircuitTest)
+{
+    TraceSettings trace_settings{ SMALL_TEST_STRUCTURE };
+    auto ivc = std::make_shared<ClientIVC>(trace_settings);
+
+    // construct a mock app_circuit
+    Builder app_circuit = construct_mock_app_circuit(ivc);
+
+    // Complete instance and generate an oink proof
+    ivc->accumulate(app_circuit);
+
+    // Construct kernel consisting only of the kernel completion logic
+    AcirProgram program = construct_mock_kernel_program(ivc->verification_queue);
+
+    const ProgramMetadata metadata{ ivc };
+    Builder kernel = acir_format::create_circuit<Builder>(program, metadata);
+
+    EXPECT_TRUE(CircuitChecker::check(kernel));
+    ivc->accumulate(kernel);
+
+    EXPECT_TRUE(ivc->prove_and_verify());
 }

--- a/barretenberg/cpp/src/barretenberg/stdlib/honk_verifier/ultra_recursive_verifier.test.cpp
+++ b/barretenberg/cpp/src/barretenberg/stdlib/honk_verifier/ultra_recursive_verifier.test.cpp
@@ -27,7 +27,6 @@ template <typename RecursiveFlavor> class RecursiveVerifierTest : public testing
     using InnerVerifier = UltraVerifier_<InnerFlavor>;
     using InnerBuilder = typename InnerFlavor::CircuitBuilder;
     using InnerDeciderProvingKey = DeciderProvingKey_<InnerFlavor>;
-    using InnerCurve = bn254<InnerBuilder>;
     using InnerCommitment = InnerFlavor::Commitment;
     using InnerFF = InnerFlavor::FF;
 
@@ -56,7 +55,6 @@ template <typename RecursiveFlavor> class RecursiveVerifierTest : public testing
     static InnerBuilder create_inner_circuit(size_t log_num_gates = 10)
     {
         using AggState = aggregation_state<InnerBuilder>;
-        using fr = typename InnerCurve::ScalarFieldNative;
 
         InnerBuilder builder;
 
@@ -85,7 +83,7 @@ template <typename RecursiveFlavor> class RecursiveVerifierTest : public testing
             builder.ipa_proof = ipa_proof;
         }
         return builder;
-    };
+    }
 
   public:
     static void SetUpTestSuite()


### PR DESCRIPTION
Adds integration tests to test that CIVC pass with HonkRecursionConstraints, and that tampering with the VK doesn't cause things to fail (yet).