### PR TITLE
chore: Handle docker-in-docker when netstatting via nsenter

### DIFF
--- a/ci3/bootstrap_ec2
+++ b/ci3/bootstrap_ec2
@@ -212,14 +212,44 @@ function run {
             filename=\"/tmp/netfile-\${timestamp//[:.]/}\"
 
             echo \"Begin netstat dump for container \$cid at \$timestamp\" > \$filename
-            if [[ \"\$cid\" = \"host\" ]]; then
+            if [[ \"\$cid\" = \"host\" ]] || [[ -z \"\$cid\" ]]; then
+                # If sysdig reports no container id or the host, run netstat.
                 sudo netstat -tulnp | grep LISTEN >> \$filename;
+
             else
+                # Otherwise, we get the container pid and use nsenter to inspect it with netstat
+                # We use nsenter to run netstat in the container namespace, without having to install it there
                 pid=\$(docker inspect -f '{{.State.Pid}}' \$cid)
+
                 if [[ -z \"\$pid\" ]]; then
-                    echo \"Container \$cid not found at \$(date), skipping netstat dump.\" >> \$filename;
-                    docker ps --no-trunc >> \$filename;
+                    # But we sometimes run docker-in-docker. So the host docker does not know anything about this
+                    # container id, and we need to ask a docker container for it. But the container returns the pid
+                    # from its own process namespace, so we need to manually tell nsenter the namespace to use.
+
+                    echo \"Container \$cid not found at \$(date). Trying nested container.\" >> \$filename;
+                    host_container_id=\$(docker ps | grep aztecprotocol/devbox:3.0 | awk '{print \$1}')
+                    if [[ -z \"\$host_container_id\" ]]; then
+                      echo \"Host container not found. Giving up.\" >> \$filename;
+                      docker ps --no-trunc >> \$filename;
+                      continue;
+                    fi
+
+                    # Get the host container pid and the inner container pid.
+                    host_container_pid=\$(docker inspect -f '{{.State.Pid}}' \$host_container_id)
+                    inner_container_pid=\$(docker exec \$host_container_id docker inspect -f {{.State.Pid}} \$cid)
+                    if [[ -z \"\$host_container_pid\" ]] || [[ -z \"\$inner_container_pid\" ]]; then
+                      echo \"Host or inner container pid not found. Giving up.\" >> \$filename;
+                      continue;
+                    fi
+
+                    # Now run netstat with nsenter using the nested process ids
+                    # This would be easier if I knew a way of mapping the nested pid to the host process namespace, but I didn't manage to do it.
+                    ns_path=/proc/\$host_container_pid/root/proc/\$inner_container_pid/ns;
+                    echo \"Netstat output for container \$cid in container \$host_container_id retrieved from \$ns_path\" >> \$filename;
+                    sudo nsenter --pid=\$ns_path/pid --net=\$ns_path/net netstat -tulnp >> \$filename;
+
                 else
+                  # We found the container pid, just nsenter to it and run netstat.
                   sudo nsenter -t \$pid -n netstat -tulnp >> \$filename;
                 fi
             fi


### PR DESCRIPTION
In #13396 we started tailing the sysdig log for EADDRINUSE errors, so we could run `netstat` in the container where the error happened, to know what process was taking up the port we needed. To avoid installing `netstat` in the container, we used `nsenter` to enter the container namespace and inspect its network stack from the host.

However, that didn't work for e2e tests. These tests run in a docker container inside the devbox docker container. So when sysdig reports the container id, it reports a container only visible to the devbox container. Running a `docker ps` at the time of the EADDRINUSE error shows that the only container alive is the main devbox:

```
Begin netstat dump for container 53005afe8d91 at 20:12:50.846819986
Container 53005afe8d91 not found at Fri Apr 11 20:12:51 UTC 2025, skipping netstat dump.
CONTAINER ID                                                       IMAGE                      COMMAND                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                       CREATED         STATUS         PORTS     NAMES
3c9e39b3867c17713e5d0c690b45364395b868a68669616c3884d5b0b83633a9   aztecprotocol/devbox:3.0   "/entrypoint.sh bash -c '  set -euo pipefail\n  # When restarting the container, just hang around.\n  # Note we use the \"ci-started\" file to determine if we're running on a CI machine in some cases (e.g. npm cache).\n  while [ -f ci-started ]; do sleep 999; done\n  touch ci-started\n  sudo chown aztec-dev:aztec-dev aztec-packages\n  # Set up preferred commit attribution (used during releases).\n  git config --global user.email \"tech@aztecprotocol.com\"\n  git config --global user.name \"AztecBot\"\n  cd aztec-packages\n  git config --global advice.detachedHead false\n  git init . &>/dev/null\n  git remote add origin https://github.com/aztecprotocol/aztec-packages\n  git fetch --depth 1 origin 927e80d8e69672b3ebd44414dcea502c4aac0151\n  git checkout FETCH_HEAD\n  git checkout -b $REF_NAME\n  source ci3/source\n  source ci3/source_refname\n  source ci3/source_redis\n  ci_log_id=$(log_ci_run)\n  export PARENT_LOG_URL=http://ci.aztec-labs.com/$ci_log_id\n\n  # Heartbeat.\n  while true; do redis_cli SETEX hb-$ci_log_id 60 1 &>/dev/null || true; sleep 30; done &\n\n  function run {\n    echo \"env: REF_NAME=$REF_NAME COMMIT_HASH=$COMMIT_HASH CURRENT_VERSION=$CURRENT_VERSION CI=$CI CI_FULL=$CI_FULL CI_NIGHTLY=$CI_NIGHTLY DRY_RUN=${DRY_RUN:-0}\"\n    if semver check \"$REF_NAME\"; then\n      echo \"Performing a release because $REF_NAME is a semver.\"\n    fi\n\n    set +e\n    set -x\n    ./bootstrap.sh ci\n    local code=${PIPESTATUS[0]}\n    set +x\n    sudo dmesg 2>&1 | cache_log 'dmesg'\n    sudo cat /tmp/netfile* | cache_log 'netfile'\n    sudo cat /tmp/cpufile | cache_log 'cpufile'\n    sudo cat /tmp/memfile | cache_log 'memfile'\n    return $code\n  }\n  export -f run\n\n  set +e\n  set -x\n  ci3/aws_handle_evict run 2>&1 | ci3/add_timestamps | DUP=1 ci3/cache_log 'CI run' $ci_log_id\n  code=${PIPESTATUS[0]}\n\n  case $code in\n    155) ;;\n    0) log_ci_run PASSED $ci_log_id ;;\n    *) log_ci_run FAILED $ci_log_id ;;\n  esac\n  exit $code'"   5 minutes ago   Up 5 minutes             aztec_build
End netstat dump for container 53005afe8d91 at 20:12:50.846819986
```

This PR changes the script so that, if the container reported by sysdig is not found, it looks for a container named `devbox`. If found, it moves into it with `docker exec`, and uses `docker inspect` to get the pid of the container reported by sydig. Using that pid and the devbox pid, it constructs the full path to the network namespace of the container, and passes it to nsenter so we can run netstat in it.

I tested this by running two python http servers on the same python container within a devbox container on my machine, so that I'd hit a EADDRINUSE in the nested container. I got:
```
$ cat /tmp/netfile-190154600221970
Begin netstat dump for container def0c672c204 at 19:01:54.600221970
Container def0c672c204 not found at Fri 11 Apr 19:01:54 -03 2025. Trying nested container.
Netstat output for container def0c672c204 in container e127b3f7594c retrieved from /proc/133596/root/proc/877/ns
Active Internet connections (only servers)
Proto Recv-Q Send-Q Local Address           Foreign Address         State       PID/Program name    
tcp        0      0 0.0.0.0:8000            0.0.0.0:*               LISTEN      141935/python       
End netstat dump for container def0c672c204 at 19:01:54.600221970
```

The alternative is to install netstat in the devbox, so we can just do:
```
docker exec $devbox_container_id nsenter -t $(docker inspect -f {{.State.Pid }}) -n netstat -tulnp
```

