### PR TITLE
chore: Don't spam logs when peers don't have an aztec key set

### DIFF
--- a/yarn-project/p2p/src/services/discv5/discV5_service.ts
+++ b/yarn-project/p2p/src/services/discv5/discV5_service.ts
@@ -246,7 +246,7 @@ export class DiscV5Service extends EventEmitter implements PeerDiscoveryService 
     // Check the peer is an aztec peer
     const value = enr.kvs.get(AZTEC_ENR_KEY);
     if (!value) {
-      this.logger.warn(`Peer node ${enr.nodeId} does not have aztec key in ENR`);
+      this.logger.debug(`Peer node ${enr.nodeId} does not have aztec key in ENR`);
       return false;
     }
 


### PR DESCRIPTION
When other peers don't have an aztec key set we shouldn't keep spamming the logs
