### PR TITLE
chore(release): give aztec release image sensible default entrypoint

### DIFF
--- a/aztec-up/bin/.aztec-run
+++ b/aztec-up/bin/.aztec-run
@@ -141,6 +141,7 @@ function run {
     ${arg_env_vars:-} \
     ${arg_host_binds:-} \
     ${arg_user:-} \
+    --entrypoint ""  \
     aztecprotocol/aztec:$VERSION "${args[@]}"
 }
 

--- a/release-image/Dockerfile
+++ b/release-image/Dockerfile
@@ -9,3 +9,4 @@ ENV ACVM_WORKING_DIRECTORY=/usr/src/acvm
 ENV ACVM_BINARY_PATH=/usr/src/noir/noir-repo/target/release/acvm
 RUN mkdir -p $BB_WORKING_DIRECTORY $ACVM_WORKING_DIRECTORY && chmod 777 $BB_WORKING_DIRECTORY $ACVM_WORKING_DIRECTORY
 WORKDIR "/usr/src/yarn-project"
+ENTRYPOINT ["/bin/bash", "-c", "node --no-warnings /usr/src/yarn-project/aztec/dest/bin/index.js"]

--- a/release-image/README.md
+++ b/release-image/README.md
@@ -27,6 +27,5 @@ We then manually install our required version of node, and a handful of require 
 
 # Entrypoint
 
-The entrypoint is just the default bash shell.
-This means when running the container, you should pass as arguments the desired entrypoint and arguments.
-This could be nargo, aztec-wallet, aztec cli, anvil, etc.
+The entrypoint will the aztec cli, you should pass as arguments the desired entrypoint and arguments.
+When wanting to run nargo, aztec-wallet, aztec cli, anvil, etc, update the entrypoint to just be bash before executing.


### PR DESCRIPTION
Default entrypoint to make alpha test net docker composes simpler to write
