### PR TITLE
refactor(Barretenberg): rollback fix in shplemini

### DIFF
--- a/barretenberg/cpp/src/barretenberg/boomerang_value_detection/graph_description_ultra_recursive_verifier.test.cpp
+++ b/barretenberg/cpp/src/barretenberg/boomerang_value_detection/graph_description_ultra_recursive_verifier.test.cpp
@@ -109,6 +109,8 @@ template <typename RecursiveFlavor> class BoomerangRecursiveVerifierTest : publi
         // Create a recursive verification circuit for the proof of the inner circuit
         OuterBuilder outer_circuit;
         RecursiveVerifier verifier{ &outer_circuit, verification_key };
+        verifier.key->num_public_inputs.fix_witness();
+        verifier.key->pub_inputs_offset.fix_witness();
 
         VerifierOutput output = verifier.verify_proof(inner_proof);
         PairingObject pairing_points = output.points_accumulator;

--- a/barretenberg/cpp/src/barretenberg/stdlib_circuit_builders/ultra_recursive_flavor.hpp
+++ b/barretenberg/cpp/src/barretenberg/stdlib_circuit_builders/ultra_recursive_flavor.hpp
@@ -128,11 +128,9 @@ template <typename BuilderType> class UltraRecursiveFlavor_ {
             this->circuit_size = FF::from_witness(builder, native_key->circuit_size);
             // TODO(https://github.com/AztecProtocol/barretenberg/issues/1283): Use stdlib get_msb.
             this->log_circuit_size = FF::from_witness(builder, numeric::get_msb(native_key->circuit_size));
-            this->num_public_inputs =
-                stdlib::witness_t<CircuitBuilder>::create_constant_witness(builder, native_key->num_public_inputs);
-            this->pub_inputs_offset =
-                stdlib::witness_t<CircuitBuilder>::create_constant_witness(builder, native_key->pub_inputs_offset);
             this->pairing_inputs_public_input_key = native_key->pairing_inputs_public_input_key;
+            this->num_public_inputs = FF::from_witness(builder, native_key->num_public_inputs);
+            this->pub_inputs_offset = FF::from_witness(builder, native_key->pub_inputs_offset);
 
             // Generate stdlib commitments (biggroup) from the native counterparts
             for (auto [commitment, native_commitment] : zip_view(this->get_all(), native_key->get_all())) {


### PR DESCRIPTION
In previous PR about Shplemini were 2 variables from verification key that were in one gate: num_public_inputs and pub_inputs_offset. 

After additional review became clear that there's no need to constrain them additionally using function create_constant_witness, because there's a probability that it will break something in the future. It will be better to fix them using fix_witness in a test for ultra_recursive_verifier.