### PR TITLE
chore: use heap buffer methods for civc proof in bbjs

### DIFF
--- a/barretenberg/cpp/src/barretenberg/client_ivc/client_ivc.hpp
+++ b/barretenberg/cpp/src/barretenberg/client_ivc/client_ivc.hpp
@@ -83,19 +83,19 @@ class ClientIVC {
             return buffer;
         }
 
+        /**
+         * @brief Very quirky method to convert a msgpack buffer to a "heap" buffer
+         * @details This method results in a buffer that is double-size-prefixed with the buffer size. This is to mimmic
+         * the original bb.js behavior which did a *out_proof = to_heap_buffer(to_buffer(proof));
+         *
+         * @return uint8_t* Double size-prefixed msgpack buffer
+         */
         uint8_t* to_msgpack_heap_buffer() const
         {
             msgpack::sbuffer buffer = to_msgpack_buffer();
 
             std::vector<uint8_t> buf(buffer.data(), buffer.data() + buffer.size());
-
-            auto heap_buf = to_buffer</*include_size=*/true>(buf);
-            auto* ptr = (uint8_t*)aligned_alloc(64, heap_buf.size()); // NOLINT
-            std::copy(heap_buf.begin(), heap_buf.end(), ptr);
-            return ptr;
-
-            // WORKTODO: not sure why the above can't be replaced with:
-            // return to_heap_buffer(buf);
+            return to_heap_buffer(buf);
         }
 
         class DeserializationError : public std::runtime_error {

--- a/barretenberg/cpp/src/barretenberg/client_ivc/client_ivc.test.cpp
+++ b/barretenberg/cpp/src/barretenberg/client_ivc/client_ivc.test.cpp
@@ -517,6 +517,32 @@ TEST_F(ClientIVCTests, MsgpackProofFromFile)
 };
 
 /**
+ * @brief Test methods for serializing and deserializing a proof to/from a "heap" buffer in msgpack format
+ *
+ */
+TEST_F(ClientIVCTests, MsgpackProofFromBuffer)
+{
+    ClientIVC ivc;
+
+    ClientIVCMockCircuitProducer circuit_producer;
+
+    // Initialize the IVC with an arbitrary circuit
+    Builder circuit_0 = circuit_producer.create_next_circuit(ivc);
+    ivc.accumulate(circuit_0);
+
+    // Create another circuit and accumulate
+    Builder circuit_1 = circuit_producer.create_next_circuit(ivc);
+    ivc.accumulate(circuit_1);
+
+    const auto proof = ivc.prove();
+
+    // Serialize/deserialize proof to/from a heap buffer, check that it verifies
+    uint8_t const* buffer = proof.to_msgpack_heap_buffer();
+    auto proof_deserialized = ClientIVC::Proof::from_msgpack_buffer(buffer);
+    EXPECT_TRUE(ivc.verify(proof_deserialized));
+};
+
+/**
  * @brief Check that a CIVC proof can be serialized and deserialized via msgpack and that attempting to deserialize a
  * random buffer of bytes fails gracefully with a type error
  */

--- a/barretenberg/cpp/src/barretenberg/client_ivc/client_ivc.test.cpp
+++ b/barretenberg/cpp/src/barretenberg/client_ivc/client_ivc.test.cpp
@@ -538,7 +538,9 @@ TEST_F(ClientIVCTests, MsgpackProofFromBuffer)
 
     // Serialize/deserialize proof to/from a heap buffer, check that it verifies
     uint8_t const* buffer = proof.to_msgpack_heap_buffer();
-    auto proof_deserialized = ClientIVC::Proof::from_msgpack_buffer(buffer);
+    auto uint8_buffer = from_buffer<std::vector<uint8_t>>(buffer);
+    uint8_t const* uint8_ptr = uint8_buffer.data();
+    auto proof_deserialized = ClientIVC::Proof::from_msgpack_buffer(uint8_ptr);
     EXPECT_TRUE(ivc.verify(proof_deserialized));
 };
 

--- a/barretenberg/cpp/src/barretenberg/dsl/acir_proofs/c_bind.cpp
+++ b/barretenberg/cpp/src/barretenberg/dsl/acir_proofs/c_bind.cpp
@@ -276,7 +276,7 @@ WASM_EXPORT void acir_prove_aztec_client(uint8_t const* acir_stack,
     vinfo("time to construct, accumulate, prove all circuits: ", diff.count());
 
     start = std::chrono::steady_clock::now();
-    *out_proof = to_heap_buffer(to_buffer(proof));
+    *out_proof = proof.to_msgpack_heap_buffer();
     end = std::chrono::steady_clock::now();
     diff = std::chrono::duration_cast<std::chrono::milliseconds>(end - start);
     vinfo("time to serialize proof: ", diff.count());
@@ -290,7 +290,7 @@ WASM_EXPORT void acir_prove_aztec_client(uint8_t const* acir_stack,
 
 WASM_EXPORT void acir_verify_aztec_client(uint8_t const* proof_buf, uint8_t const* vk_buf, bool* result)
 {
-    const auto proof = from_buffer<ClientIVC::Proof>(from_buffer<std::vector<uint8_t>>(proof_buf));
+    const auto proof = ClientIVC::Proof::from_msgpack_buffer(proof_buf);
     const auto vk = from_buffer<ClientIVC::VerificationKey>(from_buffer<std::vector<uint8_t>>(vk_buf));
 
     // TODO(https://github.com/AztecProtocol/barretenberg/issues/1335): Should be able to remove this.


### PR DESCRIPTION
Add "heap buffer" serialization for CIVC Proof type and use in bbjs methods