### PR TITLE
chore: Blob and archiver syncing improvements

### DIFF
--- a/yarn-project/archiver/src/archiver/archiver.test.ts
+++ b/yarn-project/archiver/src/archiver/archiver.test.ts
@@ -1,5 +1,6 @@
 import { Blob } from '@aztec/blob-lib';
 import type { BlobSinkClientInterface } from '@aztec/blob-sink/client';
+import { BlobWithIndex } from '@aztec/blob-sink/types';
 import { GENESIS_ARCHIVE_ROOT } from '@aztec/constants';
 import { DefaultL1ContractsConfig, RollupContract, type ViemPublicClient } from '@aztec/ethereum';
 import { EthAddress } from '@aztec/foundation/eth-address';
@@ -640,5 +641,6 @@ async function makeVersionedBlobHashes(l2Block: L2Block): Promise<`0x${string}`[
  * @returns The blobs.
  */
 async function makeBlobsFromBlock(block: L2Block) {
-  return await Blob.getBlobs(block.body.toBlobFields());
+  const blobs = await Blob.getBlobs(block.body.toBlobFields());
+  return blobs.map((blob, index) => new BlobWithIndex(blob, index));
 }

--- a/yarn-project/archiver/src/archiver/archiver.ts
+++ b/yarn-project/archiver/src/archiver/archiver.ts
@@ -182,6 +182,8 @@ export class Archiver extends EventEmitter implements ArchiveSource, Traceable {
       throw new Error('Archiver is already running');
     }
 
+    await this.blobSinkClient.testSources();
+
     if (blockUntilSynced) {
       while (!(await this.syncSafe(true))) {
         this.log.info(`Retrying initial archiver sync in ${this.config.pollingIntervalMs}ms`);

--- a/yarn-project/archiver/src/archiver/archiver.ts
+++ b/yarn-project/archiver/src/archiver/archiver.ts
@@ -4,6 +4,7 @@ import type { EthAddress } from '@aztec/foundation/eth-address';
 import { Fr } from '@aztec/foundation/fields';
 import { type Logger, createLogger } from '@aztec/foundation/log';
 import { RunningPromise, makeLoggingErrorHandler } from '@aztec/foundation/running-promise';
+import { sleep } from '@aztec/foundation/sleep';
 import { count } from '@aztec/foundation/string';
 import { elapsed } from '@aztec/foundation/timer';
 import { InboxAbi } from '@aztec/l1-artifacts';
@@ -187,6 +188,7 @@ export class Archiver extends EventEmitter implements ArchiveSource, Traceable {
     if (blockUntilSynced) {
       while (!(await this.syncSafe(true))) {
         this.log.info(`Retrying initial archiver sync in ${this.config.pollingIntervalMs}ms`);
+        await sleep(this.config.pollingIntervalMs);
       }
     }
 

--- a/yarn-project/archiver/src/archiver/config.ts
+++ b/yarn-project/archiver/src/archiver/config.ts
@@ -3,6 +3,7 @@ import {
   type L1ContractAddresses,
   type L1ContractsConfig,
   type L1ReaderConfig,
+  l1ContractAddressesMapping,
   l1ContractsConfigMappings,
   l1ReaderConfigMappings,
 } from '@aztec/ethereum';
@@ -88,6 +89,10 @@ export const archiverConfigMappings: ConfigMappingsType<ArchiverConfig> = {
     ...numberConfigHelper(1000),
   },
   ...l1ContractsConfigMappings,
+  l1Contracts: {
+    description: 'The deployed L1 contract addresses',
+    nested: l1ContractAddressesMapping,
+  },
 };
 
 /**

--- a/yarn-project/archiver/src/archiver/data_retrieval.ts
+++ b/yarn-project/archiver/src/archiver/data_retrieval.ts
@@ -248,7 +248,7 @@ async function getBlockFromRollupTx(
 
   let blockFields: Fr[];
   try {
-    blockFields = Blob.toEncodedFields(blobBodies);
+    blockFields = Blob.toEncodedFields(blobBodies.map(b => b.blob));
   } catch (err: any) {
     if (err instanceof BlobDeserializationError) {
       logger.fatal(err.message);

--- a/yarn-project/aztec-node/src/aztec-node/server.ts
+++ b/yarn-project/aztec-node/src/aztec-node/server.ts
@@ -165,7 +165,8 @@ export class AztecNodeService implements AztecNode, AztecNodeAdmin, Traceable {
     const telemetry = deps.telemetry ?? getTelemetryClient();
     const log = deps.logger ?? createLogger('node');
     const dateProvider = deps.dateProvider ?? new DateProvider();
-    const blobSinkClient = deps.blobSinkClient ?? createBlobSinkClient(config);
+    const blobSinkClient =
+      deps.blobSinkClient ?? createBlobSinkClient(config, { logger: createLogger('node:blob-sink:client') });
     const ethereumChain = createEthereumChain(config.l1RpcUrls, config.l1ChainId);
 
     // validate that the actual chain id matches that specified in configuration

--- a/yarn-project/aztec/src/cli/cmds/start_archiver.ts
+++ b/yarn-project/aztec/src/cli/cmds/start_archiver.ts
@@ -52,7 +52,7 @@ export async function startArchiver(
   const archiverStore = new KVArchiverDataStore(store, archiverConfig.maxLogs);
 
   const telemetry = initTelemetryClient(getTelemetryClientConfig());
-  const blobSinkClient = createBlobSinkClient(archiverConfig);
+  const blobSinkClient = createBlobSinkClient(archiverConfig, { logger: createLogger('archiver:blob-sink:client') });
   const archiver = await Archiver.createAndSync(archiverConfig, archiverStore, { telemetry, blobSinkClient }, true);
   services.archiver = [archiver, ArchiverApiSchema];
   signalHandlers.push(archiver.stop);

--- a/yarn-project/aztec/src/cli/cmds/start_archiver.ts
+++ b/yarn-project/aztec/src/cli/cmds/start_archiver.ts
@@ -6,14 +6,9 @@ import {
   getArchiverConfigFromEnv,
 } from '@aztec/archiver';
 import { createLogger } from '@aztec/aztec.js';
-import {
-  type BlobSinkConfig,
-  blobSinkConfigMapping,
-  createBlobSinkClient,
-  getBlobSinkConfigFromEnv,
-} from '@aztec/blob-sink/client';
+import { type BlobSinkConfig, blobSinkConfigMapping, createBlobSinkClient } from '@aztec/blob-sink/client';
 import type { NamespacedApiHandlers } from '@aztec/foundation/json-rpc/server';
-import { type DataStoreConfig, dataConfigMappings, getDataConfigFromEnv } from '@aztec/kv-store/config';
+import { type DataStoreConfig, dataConfigMappings } from '@aztec/kv-store/config';
 import { createStore } from '@aztec/kv-store/lmdb-v2';
 import { ArchiverApiSchema } from '@aztec/stdlib/interfaces/server';
 import { getConfigEnvVars as getTelemetryClientConfig, initTelemetryClient } from '@aztec/telemetry-client';
@@ -29,7 +24,7 @@ export async function startArchiver(
   signalHandlers: (() => Promise<void>)[],
   services: NamespacedApiHandlers,
 ): Promise<{ config: ArchiverConfig & DataStoreConfig }> {
-  const envConfig = { ...getArchiverConfigFromEnv(), ...getDataConfigFromEnv(), ...getBlobSinkConfigFromEnv() };
+  const envConfig = getArchiverConfigFromEnv();
   const cliOptions = extractRelevantOptions<ArchiverConfig & DataStoreConfig & BlobSinkConfig>(
     options,
     { ...archiverConfigMappings, ...dataConfigMappings, ...blobSinkConfigMapping },

--- a/yarn-project/blob-lib/src/blob.test.ts
+++ b/yarn-project/blob-lib/src/blob.test.ts
@@ -140,16 +140,16 @@ describe('blob', () => {
     }
   });
 
-  it('Should serialise and deserialise a blob', async () => {
+  it('should serialise and deserialise a blob', async () => {
     const blob = await Blob.fromFields([Fr.random(), Fr.random(), Fr.random()]);
     const blobBuffer = blob.toBuffer();
     const deserialisedBlob = Blob.fromBuffer(blobBuffer);
     expect(blob.fieldsHash.equals(deserialisedBlob.fieldsHash)).toBe(true);
   });
 
-  it('Should create a blob from a JSON object', async () => {
+  it('should create a blob from a JSON object', async () => {
     const blob = await makeEncodedBlob(3);
-    const blobJson = blob.toJson();
+    const blobJson = blob.toJson(1);
     const deserialisedBlob = await Blob.fromJson(blobJson);
     expect(blob.fieldsHash.equals(deserialisedBlob.fieldsHash)).toBe(true);
   });

--- a/yarn-project/blob-lib/src/blob.ts
+++ b/yarn-project/blob-lib/src/blob.ts
@@ -123,10 +123,10 @@ export class Blob {
    * @param index - optional - The index of the blob in the block.
    * @returns The JSON representation of the blob.
    */
-  toJson(index?: number): BlobJson {
+  toJson(index: number): BlobJson {
     return {
       blob: `0x${Buffer.from(this.data).toString('hex')}`,
-      index,
+      index: index.toString(),
       // eslint-disable-next-line camelcase
       kzg_commitment: `0x${this.commitment.toString('hex')}`,
       // eslint-disable-next-line camelcase

--- a/yarn-project/blob-lib/src/interface.ts
+++ b/yarn-project/blob-lib/src/interface.ts
@@ -3,7 +3,7 @@
  */
 export interface BlobJson {
   blob: string;
-  index?: number;
+  index: string;
   // eslint-disable-next-line camelcase
   kzg_commitment: string;
   // eslint-disable-next-line camelcase

--- a/yarn-project/blob-sink/package.json
+++ b/yarn-project/blob-sink/package.json
@@ -8,7 +8,8 @@
   "exports": {
     "./server": "./dest/server/index.js",
     "./client": "./dest/client/index.js",
-    "./encoding": "./dest/encoding/index.js"
+    "./encoding": "./dest/encoding/index.js",
+    "./types": "./dest/types/index.js"
   },
   "inherits": [
     "../package.common.json"

--- a/yarn-project/blob-sink/src/archive/blobscan_archive_client.ts
+++ b/yarn-project/blob-sink/src/archive/blobscan_archive_client.ts
@@ -44,6 +44,17 @@ export const BlobscanBlockResponseSchema = z
       .map((blob, index) => ({ ...blob, index: index.toString() })),
   ) satisfies ZodFor<BlobJson[]>;
 
+// Response from https://api.blobscan.com/blocks?sort=desc&type=canonical
+export const BlobscanBlocksResponseSchema = z.object({
+  blocks: z.array(
+    z.object({
+      hash: z.string(),
+      slot: z.number().int(),
+      number: z.number().int(),
+    }),
+  ),
+});
+
 export class BlobscanArchiveClient implements BlobArchiveClient {
   private readonly logger = createLogger('blob-sink:blobscan-archive-client');
   private readonly fetchOpts = { headers: { accept: 'application/json' } };
@@ -70,6 +81,30 @@ export class BlobscanArchiveClient implements BlobArchiveClient {
     );
   }
 
+  public async getLatestBlock(): Promise<{ hash: string; number: number; slot: number }> {
+    const url = `https://${this.baseUrl}/blocks?sort=desc&type=canonical&p=1&ps=1`;
+    this.logger.trace(`Fetching latest block from ${url}`);
+    const response = await this.fetch(url, this.fetchOpts);
+
+    if (response.status !== 200) {
+      throw new Error(`Failed to fetch latest block: ${response.statusText} (${response.status})`, {
+        cause: {
+          httpResponse: {
+            status: response.status,
+            body: await response.text().catch(() => 'Failed to read response body'),
+          },
+        },
+      });
+    }
+
+    const parsed = await response.json().then((data: any) => BlobscanBlocksResponseSchema.parse(data));
+    if (parsed.blocks.length === 0) {
+      throw new Error(`No blocks found at ${this.baseUrl}`);
+    }
+
+    return parsed.blocks[0];
+  }
+
   public getBaseUrl(): string {
     return this.baseUrl;
   }
@@ -89,10 +124,7 @@ export class BlobscanArchiveClient implements BlobArchiveClient {
         cause: {
           httpResponse: {
             status: response.status,
-            body: await response.text().catch(err => {
-              this.logger.warn('Failed to read response body', err);
-              return '';
-            }),
+            body: await response.text().catch(() => 'Failed to read response body'),
           },
         },
       });

--- a/yarn-project/blob-sink/src/archive/blobscan_archive_client.ts
+++ b/yarn-project/blob-sink/src/archive/blobscan_archive_client.ts
@@ -31,15 +31,17 @@ export const BlobscanBlockResponseSchema = z
     ),
   })
   .transform(data =>
-    data.transactions.flatMap(tx =>
-      tx.blobs.map(blob => ({
-        blob: blob.data,
-        // eslint-disable-next-line camelcase
-        kzg_commitment: blob.commitment,
-        // eslint-disable-next-line camelcase
-        kzg_proof: blob.proof,
-      })),
-    ),
+    data.transactions
+      .flatMap(tx =>
+        tx.blobs.map(blob => ({
+          blob: blob.data,
+          // eslint-disable-next-line camelcase
+          kzg_commitment: blob.commitment,
+          // eslint-disable-next-line camelcase
+          kzg_proof: blob.proof,
+        })),
+      )
+      .map((blob, index) => ({ ...blob, index: index.toString() })),
   ) satisfies ZodFor<BlobJson[]>;
 
 export class BlobscanArchiveClient implements BlobArchiveClient {

--- a/yarn-project/blob-sink/src/archive/factory.ts
+++ b/yarn-project/blob-sink/src/archive/factory.ts
@@ -8,9 +8,9 @@ export function createBlobArchiveClient(config: BlobSinkConfig): BlobArchiveClie
   }
 
   if (config.l1ChainId === 1) {
-    return new BlobscanArchiveClient('api.blobscan.com');
+    return new BlobscanArchiveClient('https://api.blobscan.com');
   } else if (config.l1ChainId === 11155111) {
-    return new BlobscanArchiveClient('api.sepolia.blobscan.com');
+    return new BlobscanArchiveClient('https://api.sepolia.blobscan.com');
   }
 
   return undefined;

--- a/yarn-project/blob-sink/src/archive/interface.ts
+++ b/yarn-project/blob-sink/src/archive/interface.ts
@@ -4,5 +4,6 @@ import type { BlobJson } from '@aztec/blob-lib';
 export interface BlobArchiveClient {
   getBlobData(id: string): Promise<Buffer | undefined>;
   getBlobsFromBlock(blockId: string): Promise<BlobJson[] | undefined>;
+  getLatestBlock(): Promise<{ hash: string; number: number; slot: number }>;
   getBaseUrl(): string;
 }

--- a/yarn-project/blob-sink/src/client/bin/index.ts
+++ b/yarn-project/blob-sink/src/client/bin/index.ts
@@ -24,7 +24,7 @@ async function main() {
   const blobs = await blobSinkClient.getBlobSidecar(blockHash, blobHashes);
   logger.info(`Got ${blobs.length} blobs`);
   for (const blob of blobs) {
-    console.log(blob.toJson());
+    console.log(blob.toJSON());
   }
 }
 

--- a/yarn-project/blob-sink/src/client/blob-sink-client-tests.ts
+++ b/yarn-project/blob-sink/src/client/blob-sink-client-tests.ts
@@ -33,8 +33,8 @@ export function runBlobSinkClientTests(
 
     const retrievedBlobs = await client.getBlobSidecar(blockId, [blobHash]);
     expect(retrievedBlobs).toHaveLength(1);
-    expect(retrievedBlobs[0].fieldsHash.toString()).toBe(blob.fieldsHash.toString());
-    expect(retrievedBlobs[0].commitment.toString('hex')).toBe(blob.commitment.toString('hex'));
+    expect(retrievedBlobs[0].blob.fieldsHash.toString()).toBe(blob.fieldsHash.toString());
+    expect(retrievedBlobs[0].blob.commitment.toString('hex')).toBe(blob.commitment.toString('hex'));
   });
 
   it('should handle multiple blobs', async () => {
@@ -49,15 +49,15 @@ export function runBlobSinkClientTests(
     expect(retrievedBlobs).toHaveLength(3);
 
     for (let i = 0; i < blobs.length; i++) {
-      expect(retrievedBlobs[i].fieldsHash.toString()).toBe(blobs[i].fieldsHash.toString());
-      expect(retrievedBlobs[i].commitment.toString('hex')).toBe(blobs[i].commitment.toString('hex'));
+      expect(retrievedBlobs[i].blob.fieldsHash.toString()).toBe(blobs[i].fieldsHash.toString());
+      expect(retrievedBlobs[i].blob.commitment.toString('hex')).toBe(blobs[i].commitment.toString('hex'));
     }
 
     // Can request blobs by index
     const retrievedBlobsByIndex = await client.getBlobSidecar(blockId, blobHashes, [0, 2]);
     expect(retrievedBlobsByIndex).toHaveLength(2);
-    expect(retrievedBlobsByIndex[0].fieldsHash.toString()).toBe(blobs[0].fieldsHash.toString());
-    expect(retrievedBlobsByIndex[1].fieldsHash.toString()).toBe(blobs[2].fieldsHash.toString());
+    expect(retrievedBlobsByIndex[0].blob.fieldsHash.toString()).toBe(blobs[0].fieldsHash.toString());
+    expect(retrievedBlobsByIndex[1].blob.fieldsHash.toString()).toBe(blobs[2].fieldsHash.toString());
   });
 
   it('should return empty array for non-existent block', async () => {

--- a/yarn-project/blob-sink/src/client/config.ts
+++ b/yarn-project/blob-sink/src/client/config.ts
@@ -69,3 +69,10 @@ export const blobSinkConfigMapping: ConfigMappingsType<BlobSinkConfig> = {
 export function getBlobSinkConfigFromEnv(): BlobSinkConfig {
   return getConfigFromMappings<BlobSinkConfig>(blobSinkConfigMapping);
 }
+
+/**
+ * Returns whether the given blob sink config has any remote sources defined.
+ */
+export function hasRemoteBlobSinkSources(config: BlobSinkConfig = {}): boolean {
+  return !!(config.blobSinkUrl || config.l1ConsensusHostUrls?.length || config.archiveApiUrl);
+}

--- a/yarn-project/blob-sink/src/client/factory.ts
+++ b/yarn-project/blob-sink/src/client/factory.ts
@@ -1,18 +1,14 @@
 import { type Logger, createLogger } from '@aztec/foundation/log';
 
 import { MemoryBlobStore } from '../blobstore/memory_blob_store.js';
-import type { BlobSinkConfig } from './config.js';
+import { type BlobSinkConfig, hasRemoteBlobSinkSources } from './config.js';
 import { HttpBlobSinkClient } from './http.js';
 import type { BlobSinkClientInterface } from './interface.js';
 import { LocalBlobSinkClient } from './local.js';
 
 export function createBlobSinkClient(config?: BlobSinkConfig, deps?: { logger: Logger }): BlobSinkClientInterface {
   const log = deps?.logger ?? createLogger('blob-sink:client');
-  if (
-    !config?.blobSinkUrl &&
-    (!config?.l1ConsensusHostUrls || config?.l1ConsensusHostUrls?.length == 0) &&
-    !config?.archiveApiUrl
-  ) {
+  if (!hasRemoteBlobSinkSources(config)) {
     log.info(`Creating local blob sink client.`);
     const blobStore = new MemoryBlobStore();
     return new LocalBlobSinkClient(blobStore);

--- a/yarn-project/blob-sink/src/client/factory.ts
+++ b/yarn-project/blob-sink/src/client/factory.ts
@@ -1,18 +1,27 @@
+import { type Logger, createLogger } from '@aztec/foundation/log';
+
 import { MemoryBlobStore } from '../blobstore/memory_blob_store.js';
 import type { BlobSinkConfig } from './config.js';
 import { HttpBlobSinkClient } from './http.js';
 import type { BlobSinkClientInterface } from './interface.js';
 import { LocalBlobSinkClient } from './local.js';
 
-export function createBlobSinkClient(config?: BlobSinkConfig): BlobSinkClientInterface {
+export function createBlobSinkClient(config?: BlobSinkConfig, deps?: { logger: Logger }): BlobSinkClientInterface {
+  const log = deps?.logger ?? createLogger('blob-sink:client');
   if (
     !config?.blobSinkUrl &&
     (!config?.l1ConsensusHostUrls || config?.l1ConsensusHostUrls?.length == 0) &&
     !config?.archiveApiUrl
   ) {
+    log.info(`Creating local blob sink client.`);
     const blobStore = new MemoryBlobStore();
     return new LocalBlobSinkClient(blobStore);
   }
 
-  return new HttpBlobSinkClient(config);
+  log.info(`Creating HTTP blob sink client.`, {
+    blobSinkUrl: config?.blobSinkUrl,
+    l1ConsensusHostUrls: config?.l1ConsensusHostUrls,
+    archiveApiUrl: config?.archiveApiUrl,
+  });
+  return new HttpBlobSinkClient(config, deps);
 }

--- a/yarn-project/blob-sink/src/client/http.test.ts
+++ b/yarn-project/blob-sink/src/client/http.test.ts
@@ -7,6 +7,7 @@ import http from 'http';
 import type { AddressInfo } from 'net';
 
 import { BlobSinkServer } from '../server/server.js';
+import { BlobWithIndex } from '../types/blob_with_index.js';
 import { runBlobSinkClientTests } from './blob-sink-client-tests.js';
 import { HttpBlobSinkClient } from './http.js';
 
@@ -46,6 +47,7 @@ describe('HttpBlobSinkClient', () => {
 
     let testEncodedBlob: Blob;
     let testEncodedBlobHash: Buffer;
+    let testEncodedBlobWithIndex: BlobWithIndex;
 
     let testNonEncodedBlob: Blob;
     let testNonEncodedBlobHash: Buffer;
@@ -67,6 +69,7 @@ describe('HttpBlobSinkClient', () => {
     beforeEach(async () => {
       testEncodedBlob = await makeEncodedBlob(3);
       testEncodedBlobHash = testEncodedBlob.getEthVersionedBlobHash();
+      testEncodedBlobWithIndex = new BlobWithIndex(testEncodedBlob, 0);
 
       testBlobIgnore = await makeEncodedBlob(3);
 
@@ -76,7 +79,7 @@ describe('HttpBlobSinkClient', () => {
       blobData = [
         // Correctly encoded blob
         {
-          index: 0,
+          index: '0',
           blob: `0x${Buffer.from(testEncodedBlob.data).toString('hex')}`,
           // eslint-disable-next-line camelcase
           kzg_commitment: `0x${testEncodedBlob.commitment.toString('hex')}`,
@@ -85,7 +88,7 @@ describe('HttpBlobSinkClient', () => {
         },
         // Correctly encoded blob, but we do not ask for it in the client
         {
-          index: 1,
+          index: '1',
           blob: `0x${Buffer.from(testBlobIgnore.data).toString('hex')}`,
           // eslint-disable-next-line camelcase
           kzg_commitment: `0x${testBlobIgnore.commitment.toString('hex')}`,
@@ -94,7 +97,7 @@ describe('HttpBlobSinkClient', () => {
         },
         // Incorrectly encoded blob
         {
-          index: 2,
+          index: '2',
           blob: `0x${Buffer.from(testNonEncodedBlob.data).toString('hex')}`,
           // eslint-disable-next-line camelcase
           kzg_commitment: `0x${testNonEncodedBlob.commitment.toString('hex')}`,
@@ -194,7 +197,7 @@ describe('HttpBlobSinkClient', () => {
       expect(success).toBe(true);
 
       const retrievedBlobs = await client.getBlobSidecar('0x1234', [testEncodedBlobHash]);
-      expect(retrievedBlobs).toEqual([testEncodedBlob]);
+      expect(retrievedBlobs).toEqual([testEncodedBlobWithIndex]);
 
       // Check that the blob sink was called with the correct block hash and no index
       expect(blobSinkSpy).toHaveBeenCalledWith('0x1234', undefined);
@@ -212,7 +215,7 @@ describe('HttpBlobSinkClient', () => {
       });
 
       const retrievedBlobs = await client.getBlobSidecar('0x1234', [testEncodedBlobHash]);
-      expect(retrievedBlobs).toEqual([testEncodedBlob]);
+      expect(retrievedBlobs).toEqual([testEncodedBlobWithIndex]);
     });
 
     it('should handle when multiple consensus hosts are provided', async () => {
@@ -225,7 +228,7 @@ describe('HttpBlobSinkClient', () => {
       });
 
       const retrievedBlobs = await client.getBlobSidecar('0x1234', [testEncodedBlobHash]);
-      expect(retrievedBlobs).toEqual([testEncodedBlob]);
+      expect(retrievedBlobs).toEqual([testEncodedBlobWithIndex]);
     });
 
     it('should handle API keys without headers', async () => {
@@ -239,7 +242,7 @@ describe('HttpBlobSinkClient', () => {
       });
 
       const retrievedBlobs = await client.getBlobSidecar('0x1234', [testEncodedBlobHash]);
-      expect(retrievedBlobs).toEqual([testEncodedBlob]);
+      expect(retrievedBlobs).toEqual([testEncodedBlobWithIndex]);
 
       const clientWithNoKey = new HttpBlobSinkClient({
         l1RpcUrls: [`http://localhost:${executionHostPort}`],
@@ -272,7 +275,7 @@ describe('HttpBlobSinkClient', () => {
       });
 
       const retrievedBlobs = await client.getBlobSidecar('0x1234', [testEncodedBlobHash]);
-      expect(retrievedBlobs).toEqual([testEncodedBlob]);
+      expect(retrievedBlobs).toEqual([testEncodedBlobWithIndex]);
 
       const clientWithWrongHeader = new HttpBlobSinkClient({
         l1RpcUrls: [`http://localhost:${executionHostPort}`],
@@ -321,7 +324,7 @@ describe('HttpBlobSinkClient', () => {
       });
 
       let retrievedBlobs = await client.getBlobSidecar('0x1234', [testEncodedBlobHash]);
-      expect(retrievedBlobs).toEqual([testEncodedBlob]);
+      expect(retrievedBlobs).toEqual([testEncodedBlobWithIndex]);
 
       // Verify that the second consensus host works when the first host fails
       consensusServer1?.close();
@@ -337,7 +340,7 @@ describe('HttpBlobSinkClient', () => {
       });
 
       retrievedBlobs = await client.getBlobSidecar('0x1234', [testEncodedBlobHash]);
-      expect(retrievedBlobs).toEqual([testEncodedBlob]);
+      expect(retrievedBlobs).toEqual([testEncodedBlobWithIndex]);
 
       // Verify that the third consensus host works when the first and second hosts fail
       consensusServer2?.close();
@@ -353,7 +356,7 @@ describe('HttpBlobSinkClient', () => {
       });
 
       retrievedBlobs = await client.getBlobSidecar('0x1234', [testEncodedBlobHash]);
-      expect(retrievedBlobs).toEqual([testEncodedBlob]);
+      expect(retrievedBlobs).toEqual([testEncodedBlobWithIndex]);
     });
 
     it('even if we ask for non-encoded blobs, we should only get encoded blobs', async () => {
@@ -367,7 +370,7 @@ describe('HttpBlobSinkClient', () => {
 
       const retrievedBlobs = await client.getBlobSidecar('0x1234', [testEncodedBlobHash, testNonEncodedBlobHash]);
       // We should only get the correctly encoded blob
-      expect(retrievedBlobs).toEqual([testEncodedBlob]);
+      expect(retrievedBlobs).toEqual([testEncodedBlobWithIndex]);
     });
 
     it('should handle L1 missed slots', async () => {
@@ -393,7 +396,7 @@ describe('HttpBlobSinkClient', () => {
         0,
       );
 
-      expect(retrievedBlobs).toEqual([testEncodedBlob]);
+      expect(retrievedBlobs).toEqual([testEncodedBlobWithIndex]);
 
       // Verify we hit the 404 for slot 33 before trying slot 34, and that we use the api key header
       // (see issue https://github.com/AztecProtocol/aztec-packages/issues/13415)
@@ -412,7 +415,7 @@ describe('HttpBlobSinkClient', () => {
       const archiveSpy = jest.spyOn(client.getArchiveClient(), 'getBlobsFromBlock').mockResolvedValue(blobData);
 
       const retrievedBlobs = await client.getBlobSidecar('0x1234', [testEncodedBlobHash]);
-      expect(retrievedBlobs).toEqual([testEncodedBlob]);
+      expect(retrievedBlobs).toEqual([testEncodedBlobWithIndex]);
       expect(archiveSpy).toHaveBeenCalledWith('0x1234');
     });
   });

--- a/yarn-project/blob-sink/src/client/http.ts
+++ b/yarn-project/blob-sink/src/client/http.ts
@@ -28,7 +28,7 @@ export class HttpBlobSinkClient implements BlobSinkClientInterface {
   ) {
     this.config = config ?? getBlobSinkConfigFromEnv();
     this.archiveClient = opts.archiveClient ?? createBlobArchiveClient(this.config);
-    this.log = opts.logger ?? createLogger('aztec:blob-sink-client');
+    this.log = opts.logger ?? createLogger('blob-sink:client');
     this.fetch = async (...args: Parameters<typeof fetch>): Promise<Response> => {
       return await retry(
         () => fetch(...args),

--- a/yarn-project/blob-sink/src/client/http.ts
+++ b/yarn-project/blob-sink/src/client/http.ts
@@ -40,6 +40,65 @@ export class HttpBlobSinkClient implements BlobSinkClientInterface {
     };
   }
 
+  public async testSources() {
+    const { blobSinkUrl, l1ConsensusHostUrls } = this.config;
+    const archiveUrl = this.archiveClient?.getBaseUrl();
+    this.log.info(`Testing configured blob sources`, { blobSinkUrl, l1ConsensusHostUrls, archiveUrl });
+
+    if (blobSinkUrl) {
+      try {
+        const res = await this.fetch(`${this.config.blobSinkUrl}/status`, {
+          headers: { 'Content-Type': 'application/json' },
+        });
+        if (res.ok) {
+          this.log.info(`Blob sink is reachable`, { blobSinkUrl });
+        } else {
+          this.log.error(`Failure reaching blob sink: ${res.statusText} (${res.status})`, { blobSinkUrl });
+        }
+      } catch (err) {
+        this.log.error(`Error reaching blob sink`, err, { blobSinkUrl });
+      }
+    } else {
+      this.log.warn('No blob sink url is configured');
+    }
+
+    if (l1ConsensusHostUrls && l1ConsensusHostUrls.length > 0) {
+      for (let l1ConsensusHostIndex = 0; l1ConsensusHostIndex < l1ConsensusHostUrls.length; l1ConsensusHostIndex++) {
+        const l1ConsensusHostUrl = l1ConsensusHostUrls[l1ConsensusHostIndex];
+        try {
+          const { url, ...options } = getBeaconNodeFetchOptions(
+            `${l1ConsensusHostUrl}/eth/v1/beacon/headers`,
+            this.config,
+            l1ConsensusHostIndex,
+          );
+          const res = await this.fetch(url, options);
+          if (res.ok) {
+            this.log.info(`L1 consensus host is reachable`, { l1ConsensusHostUrl });
+          } else {
+            this.log.error(`Failure reaching L1 consensus host: ${res.statusText} (${res.status})`, {
+              l1ConsensusHostUrl,
+            });
+          }
+        } catch (err) {
+          this.log.error(`Error reaching L1 consensus host`, err, { l1ConsensusHostUrl });
+        }
+      }
+    } else {
+      this.log.warn('No L1 consensus host urls configured');
+    }
+
+    if (this.archiveClient) {
+      try {
+        const latest = await this.archiveClient.getLatestBlock();
+        this.log.info(`Archive client is reachable and synced to L1 block ${latest.number}`, { latest, archiveUrl });
+      } catch (err) {
+        this.log.error(`Error reaching archive client`, err, { archiveUrl });
+      }
+    } else {
+      this.log.warn('No archive client configured');
+    }
+  }
+
   public async sendBlobsToBlobSink(blockHash: string, blobs: Blob[]): Promise<boolean> {
     // TODO(md): for now we are assuming the indexes of the blobs will be 0, 1, 2
     // When in reality they will not, but for testing purposes this is fine
@@ -53,9 +112,7 @@ export class HttpBlobSinkClient implements BlobSinkClientInterface {
     try {
       const res = await this.fetch(`${this.config.blobSinkUrl}/blob_sidecar`, {
         method: 'POST',
-        headers: {
-          'Content-Type': 'application/json',
-        },
+        headers: { 'Content-Type': 'application/json' },
         body: JSON.stringify({
           // eslint-disable-next-line camelcase
           block_id: blockHash,

--- a/yarn-project/blob-sink/src/client/http.ts
+++ b/yarn-project/blob-sink/src/client/http.ts
@@ -8,6 +8,7 @@ import { type RpcBlock, createPublicClient, fallback, http } from 'viem';
 import { createBlobArchiveClient } from '../archive/factory.js';
 import type { BlobArchiveClient } from '../archive/interface.js';
 import { outboundTransform } from '../encoding/index.js';
+import { BlobWithIndex } from '../types/blob_with_index.js';
 import { type BlobSinkConfig, getBlobSinkConfigFromEnv } from './config.js';
 import type { BlobSinkClientInterface } from './interface.js';
 
@@ -17,9 +18,12 @@ export class HttpBlobSinkClient implements BlobSinkClientInterface {
   protected readonly archiveClient: BlobArchiveClient | undefined;
   protected readonly fetch: typeof fetch;
 
-  constructor(config?: BlobSinkConfig) {
+  constructor(
+    config?: BlobSinkConfig,
+    private readonly opts: { archiveClient?: BlobArchiveClient; onBlobDeserializationError?: 'warn' | 'debug' } = {},
+  ) {
     this.config = config ?? getBlobSinkConfigFromEnv();
-    this.archiveClient = createBlobArchiveClient(this.config);
+    this.archiveClient = opts.archiveClient ?? createBlobArchiveClient(this.config);
     this.log = createLogger('aztec:blob-sink-client');
     this.fetch = async (...args: Parameters<typeof fetch>): Promise<Response> => {
       return await retry(
@@ -86,8 +90,12 @@ export class HttpBlobSinkClient implements BlobSinkClientInterface {
    * @param indices - The indices of the blobs to get
    * @returns The blobs
    */
-  public async getBlobSidecar(blockHash: `0x${string}`, blobHashes: Buffer[], indices?: number[]): Promise<Blob[]> {
-    let blobs: Blob[] = [];
+  public async getBlobSidecar(
+    blockHash: `0x${string}`,
+    blobHashes: Buffer[] = [],
+    indices?: number[],
+  ): Promise<BlobWithIndex[]> {
+    let blobs: BlobWithIndex[] = [];
 
     const { blobSinkUrl, l1ConsensusHostUrls } = this.config;
     const ctx = { blockHash, blobHashes: blobHashes.map(bufferToHex), indices };
@@ -138,7 +146,7 @@ export class HttpBlobSinkClient implements BlobSinkClientInterface {
         return [];
       }
       this.log.trace(`Got ${allBlobs.length} blobs from archive client before filtering`, archiveCtx);
-      blobs = await getRelevantBlobs(allBlobs, blobHashes, this.log);
+      blobs = await getRelevantBlobs(allBlobs, blobHashes, this.log, this.opts.onBlobDeserializationError);
       this.log.debug(`Got ${blobs.length} blobs from archive client`, archiveCtx);
       if (blobs.length > 0) {
         return blobs;
@@ -152,14 +160,14 @@ export class HttpBlobSinkClient implements BlobSinkClientInterface {
   public async getBlobSidecarFrom(
     hostUrl: string,
     blockHashOrSlot: string | number,
-    blobHashes: Buffer[],
-    indices?: number[],
+    blobHashes: Buffer[] = [],
+    indices: number[] = [],
     maxRetries = 10,
     l1ConsensusHostIndex?: number,
-  ): Promise<Blob[]> {
+  ): Promise<BlobWithIndex[]> {
     try {
       let baseUrl = `${hostUrl}/eth/v1/beacon/blob_sidecars/${blockHashOrSlot}`;
-      if (indices && indices.length > 0) {
+      if (indices.length > 0) {
         baseUrl += `?indices=${indices.join(',')}`;
       }
 
@@ -170,7 +178,7 @@ export class HttpBlobSinkClient implements BlobSinkClientInterface {
 
       if (res.ok) {
         const body = await res.json();
-        const blobs = await getRelevantBlobs(body.data, blobHashes, this.log);
+        const blobs = await getRelevantBlobs(body.data, blobHashes, this.log, this.opts.onBlobDeserializationError);
         return blobs;
       } else if (res.status === 404) {
         // L1 slot may have been missed, try next few
@@ -274,8 +282,13 @@ export class HttpBlobSinkClient implements BlobSinkClientInterface {
   }
 }
 
-async function getRelevantBlobs(data: any, blobHashes: Buffer[], logger: Logger): Promise<Blob[]> {
-  const preFilteredBlobsPromise = data
+async function getRelevantBlobs(
+  data: BlobJson[],
+  blobHashes: Buffer[],
+  logger: Logger,
+  onBlobDeserializationError: 'warn' | 'debug' = 'warn',
+): Promise<BlobWithIndex[]> {
+  const blobsPromise = data
     // Filter out blobs not requested
     .filter((b: BlobJson) => {
       if (blobHashes.length === 0) {
@@ -288,27 +301,22 @@ async function getRelevantBlobs(data: any, blobHashes: Buffer[], logger: Logger)
     })
     // Attempt to deserialise the blob
     // If we cannot decode it, then it is malicious and we should not use it
-    .map(async (b: BlobJson): Promise<Blob | undefined> => {
+    .map(async (b: BlobJson): Promise<BlobWithIndex | undefined> => {
       try {
-        return await Blob.fromJson(b);
+        const blob = await Blob.fromJson(b);
+        return new BlobWithIndex(blob, parseInt(b.index));
       } catch (err) {
         if (err instanceof BlobDeserializationError) {
-          logger.warn(`Failed to deserialise blob`, { commitment: b.kzg_commitment });
+          logger[onBlobDeserializationError](`Failed to deserialise blob`, { commitment: b.kzg_commitment });
           return undefined;
         }
         throw err;
       }
     });
 
-  // Second map is async, so we need to await it
-  const preFilteredBlobs = await Promise.all(preFilteredBlobsPromise);
-
-  // Filter out blobs that did not deserialise
-  const filteredBlobs = preFilteredBlobs.filter((b: Blob | undefined) => {
-    return b !== undefined;
-  });
-
-  return filteredBlobs;
+  // Second map is async, so we need to await it, and filter out blobs that did not deserialise
+  const maybeBlobs = await Promise.all(blobsPromise);
+  return maybeBlobs.filter((b: BlobWithIndex | undefined): b is BlobWithIndex => b !== undefined);
 }
 
 function getBeaconNodeFetchOptions(url: string, config: BlobSinkConfig, l1ConsensusHostIndex?: number) {

--- a/yarn-project/blob-sink/src/client/interface.ts
+++ b/yarn-project/blob-sink/src/client/interface.ts
@@ -1,6 +1,8 @@
 import type { Blob } from '@aztec/blob-lib';
 
+import type { BlobWithIndex } from '../types/blob_with_index.js';
+
 export interface BlobSinkClientInterface {
   sendBlobsToBlobSink(blockId: string, blobs: Blob[]): Promise<boolean>;
-  getBlobSidecar(blockId: string, blobHashes: Buffer[], indices?: number[]): Promise<Blob[]>;
+  getBlobSidecar(blockId: string, blobHashes?: Buffer[], indices?: number[]): Promise<BlobWithIndex[]>;
 }

--- a/yarn-project/blob-sink/src/client/interface.ts
+++ b/yarn-project/blob-sink/src/client/interface.ts
@@ -5,4 +5,6 @@ import type { BlobWithIndex } from '../types/blob_with_index.js';
 export interface BlobSinkClientInterface {
   sendBlobsToBlobSink(blockId: string, blobs: Blob[]): Promise<boolean>;
   getBlobSidecar(blockId: string, blobHashes?: Buffer[], indices?: number[]): Promise<BlobWithIndex[]>;
+  /** Tests all configured blob sources and logs whether they are reachable or not. */
+  testSources(): Promise<void>;
 }

--- a/yarn-project/blob-sink/src/client/local.ts
+++ b/yarn-project/blob-sink/src/client/local.ts
@@ -11,6 +11,10 @@ export class LocalBlobSinkClient implements BlobSinkClientInterface {
     this.blobStore = blobStore;
   }
 
+  public testSources(): Promise<void> {
+    return Promise.resolve();
+  }
+
   public async sendBlobsToBlobSink(blockId: string, blobs: Blob[]): Promise<boolean> {
     await this.blobStore.addBlobSidecars(
       blockId,

--- a/yarn-project/blob-sink/src/client/local.ts
+++ b/yarn-project/blob-sink/src/client/local.ts
@@ -19,16 +19,14 @@ export class LocalBlobSinkClient implements BlobSinkClientInterface {
     return true;
   }
 
-  public async getBlobSidecar(blockId: string, blobHashes: Buffer[], indices?: number[]): Promise<Blob[]> {
+  public async getBlobSidecar(blockId: string, blobHashes: Buffer[], indices?: number[]): Promise<BlobWithIndex[]> {
     const blobSidecars = await this.blobStore.getBlobSidecars(blockId, indices);
     if (!blobSidecars) {
       return [];
     }
-    return blobSidecars
-      .filter(blob => {
-        const blobHash = blob.blob.getEthVersionedBlobHash();
-        return blobHashes.some(hash => hash.equals(blobHash));
-      })
-      .map(blob => blob.blob);
+    return blobSidecars.filter(blob => {
+      const blobHash = blob.blob.getEthVersionedBlobHash();
+      return blobHashes.some(hash => hash.equals(blobHash));
+    });
   }
 }

--- a/yarn-project/blob-sink/src/server/config.ts
+++ b/yarn-project/blob-sink/src/server/config.ts
@@ -3,12 +3,14 @@ import { type ConfigMappingsType, getConfigFromMappings } from '@aztec/foundatio
 import { type DataStoreConfig, dataConfigMappings } from '@aztec/kv-store/config';
 import { type ChainConfig, chainConfigMappings } from '@aztec/stdlib/config';
 
-import { type BlobSinkArchiveApiConfig, blobSinkArchiveApiConfigMappings } from '../archive/config.js';
+import {
+  type BlobSinkConfig as BlobSinkClientConfig,
+  blobSinkConfigMapping as blobSinkClientConfigMapping,
+} from '../client/config.js';
 
 export type BlobSinkConfig = {
   port?: number;
-  archiveApiUrl?: string;
-} & BlobSinkArchiveApiConfig &
+} & Omit<BlobSinkClientConfig, 'blobSinkUrl'> &
   Partial<DataStoreConfig> &
   Partial<L1ReaderConfig> &
   Partial<ChainConfig>;
@@ -18,8 +20,7 @@ export const blobSinkConfigMappings: ConfigMappingsType<BlobSinkConfig> = {
     env: 'BLOB_SINK_PORT',
     description: 'The port to run the blob sink server on',
   },
-
-  ...blobSinkArchiveApiConfigMappings,
+  ...blobSinkClientConfigMapping,
   ...dataConfigMappings,
   ...chainConfigMappings,
   ...l1ReaderConfigMappings,

--- a/yarn-project/blob-sink/src/server/factory.ts
+++ b/yarn-project/blob-sink/src/server/factory.ts
@@ -3,7 +3,7 @@ import type { AztecAsyncKVStore } from '@aztec/kv-store';
 import { createStore } from '@aztec/kv-store/lmdb-v2';
 import type { TelemetryClient } from '@aztec/telemetry-client';
 
-import { createBlobArchiveClient } from '../archive/factory.js';
+import { HttpBlobSinkClient } from '../client/http.js';
 import type { BlobSinkConfig } from './config.js';
 import { BlobSinkServer } from './server.js';
 
@@ -29,9 +29,9 @@ export async function createBlobSinkServer(
   telemetry?: TelemetryClient,
 ): Promise<BlobSinkServer> {
   const store = await getDataStore(config);
-  const archiveClient = createBlobArchiveClient(config);
+  const blobClient = new HttpBlobSinkClient(config, { onBlobDeserializationError: 'debug' });
   const { l1ChainId, l1RpcUrls } = config;
   const l1PublicClient = l1ChainId && l1RpcUrls ? getPublicClient({ l1ChainId, l1RpcUrls }) : undefined;
 
-  return new BlobSinkServer(config, store, archiveClient, l1PublicClient, telemetry);
+  return new BlobSinkServer(config, store, blobClient, l1PublicClient, telemetry);
 }

--- a/yarn-project/blob-sink/src/server/factory.ts
+++ b/yarn-project/blob-sink/src/server/factory.ts
@@ -29,7 +29,7 @@ export async function createBlobSinkServer(
   telemetry?: TelemetryClient,
 ): Promise<BlobSinkServer> {
   const store = await getDataStore(config);
-  const blobClient = new HttpBlobSinkClient(config, { onBlobDeserializationError: 'debug' });
+  const blobClient = new HttpBlobSinkClient(config, { onBlobDeserializationError: 'trace' });
   const { l1ChainId, l1RpcUrls } = config;
   const l1PublicClient = l1ChainId && l1RpcUrls ? getPublicClient({ l1ChainId, l1RpcUrls }) : undefined;
 

--- a/yarn-project/blob-sink/src/server/factory.ts
+++ b/yarn-project/blob-sink/src/server/factory.ts
@@ -4,6 +4,7 @@ import type { AztecAsyncKVStore } from '@aztec/kv-store';
 import { createStore } from '@aztec/kv-store/lmdb-v2';
 import type { TelemetryClient } from '@aztec/telemetry-client';
 
+import { hasRemoteBlobSinkSources } from '../client/config.js';
 import { HttpBlobSinkClient } from '../client/http.js';
 import type { BlobSinkConfig } from './config.js';
 import { BlobSinkServer } from './server.js';
@@ -30,10 +31,12 @@ export async function createBlobSinkServer(
   telemetry?: TelemetryClient,
 ): Promise<BlobSinkServer> {
   const store = await getDataStore(config);
-  const blobClient = new HttpBlobSinkClient(config, {
-    onBlobDeserializationError: 'trace',
-    logger: createLogger('blob-sink:server:http'),
-  });
+  const blobClient = hasRemoteBlobSinkSources(config)
+    ? new HttpBlobSinkClient(config, {
+        onBlobDeserializationError: 'trace',
+        logger: createLogger('blob-sink:server:http'),
+      })
+    : undefined;
   const { l1ChainId, l1RpcUrls } = config;
   const l1PublicClient = l1ChainId && l1RpcUrls ? getPublicClient({ l1ChainId, l1RpcUrls }) : undefined;
 

--- a/yarn-project/blob-sink/src/server/factory.ts
+++ b/yarn-project/blob-sink/src/server/factory.ts
@@ -1,4 +1,5 @@
 import { getPublicClient } from '@aztec/ethereum';
+import { createLogger } from '@aztec/foundation/log';
 import type { AztecAsyncKVStore } from '@aztec/kv-store';
 import { createStore } from '@aztec/kv-store/lmdb-v2';
 import type { TelemetryClient } from '@aztec/telemetry-client';
@@ -29,7 +30,10 @@ export async function createBlobSinkServer(
   telemetry?: TelemetryClient,
 ): Promise<BlobSinkServer> {
   const store = await getDataStore(config);
-  const blobClient = new HttpBlobSinkClient(config, { onBlobDeserializationError: 'trace' });
+  const blobClient = new HttpBlobSinkClient(config, {
+    onBlobDeserializationError: 'trace',
+    logger: createLogger('blob-sink:server:http'),
+  });
   const { l1ChainId, l1RpcUrls } = config;
   const l1PublicClient = l1ChainId && l1RpcUrls ? getPublicClient({ l1ChainId, l1RpcUrls }) : undefined;
 

--- a/yarn-project/blob-sink/src/server/server.ts
+++ b/yarn-project/blob-sink/src/server/server.ts
@@ -35,7 +35,7 @@ export class BlobSinkServer {
   private blobStore: BlobStore;
   private metrics: BlobSinkMetrics;
   private l1PublicClient: ViemPublicClient | undefined;
-  private log: Logger = createLogger('aztec:blob-sink');
+  private log: Logger = createLogger('blob-sink:server');
 
   constructor(
     private config: BlobSinkConfig = {},

--- a/yarn-project/blob-sink/src/server/server.ts
+++ b/yarn-project/blob-sink/src/server/server.ts
@@ -1,4 +1,4 @@
-import { Blob, type BlobJson } from '@aztec/blob-lib';
+import { Blob } from '@aztec/blob-lib';
 import { type ViemPublicClient, getL2BlockProposalEvents } from '@aztec/ethereum';
 import { type Logger, createLogger } from '@aztec/foundation/log';
 import { bufferToHex, pluralize } from '@aztec/foundation/string';
@@ -11,9 +11,9 @@ import type { AddressInfo } from 'net';
 import type { Hex } from 'viem';
 import { z } from 'zod';
 
-import type { BlobArchiveClient } from '../archive/index.js';
 import { type BlobStore, DiskBlobStore } from '../blobstore/index.js';
 import { MemoryBlobStore } from '../blobstore/memory_blob_store.js';
+import type { BlobSinkClientInterface } from '../client/interface.js';
 import { inboundTransform } from '../encoding/index.js';
 import { type PostBlobSidecarRequest, blockIdSchema, indicesSchema } from '../types/api.js';
 import { BlobWithIndex } from '../types/index.js';
@@ -34,13 +34,14 @@ export class BlobSinkServer {
   private server: Server | null = null;
   private blobStore: BlobStore;
   private metrics: BlobSinkMetrics;
-  private log: Logger = createLogger('aztec:blob-sink');
   private l1PublicClient: ViemPublicClient | undefined;
+  private log: Logger = createLogger('aztec:blob-sink');
 
   constructor(
     private config: BlobSinkConfig = {},
     store?: AztecAsyncKVStore,
-    private blobArchiveClient?: BlobArchiveClient,
+    /** Optional client to retrieve blobs from L1 nodes or archive services if not stored locally. */
+    private httpClient?: BlobSinkClientInterface,
     l1PublicClient?: ViemPublicClient,
     telemetry: TelemetryClient = getTelemetryClient(),
   ) {
@@ -52,7 +53,6 @@ export class BlobSinkServer {
 
     this.metrics = new BlobSinkMetrics(telemetry);
     this.l1PublicClient = l1PublicClient;
-
     this.blobStore = store === undefined ? new MemoryBlobStore() : new DiskBlobStore(store);
 
     // Setup routes
@@ -122,8 +122,7 @@ export class BlobSinkServer {
       this.log.trace(`Received blobs request for block ${blockId}`, { blockId, indices });
 
       const blobs =
-        (await this.blobStore.getBlobSidecars(blockId, indices)) ??
-        (await this.tryGetBlobsFromArchive(blockId, indices));
+        (await this.blobStore.getBlobSidecars(blockId, indices)) ?? (await this.tryGetBlobs(blockId, indices));
 
       if (!blobs) {
         this.log.debug(`No blobs found for block ${blockId}`, { blockId, indices });
@@ -153,73 +152,38 @@ export class BlobSinkServer {
     }
   }
 
-  /**
-   * Tries to get blobs for a given block from the archive source (eg blobscan API).
-   * If successful, stores them in the blob store for future use.
-   */
-  private async tryGetBlobsFromArchive(blockId: string, indices?: number[]): Promise<BlobWithIndex[] | undefined> {
-    if (!this.blobArchiveClient) {
+  private async tryGetBlobs(blockId: string, indices?: number[]): Promise<BlobWithIndex[] | undefined> {
+    if (!this.httpClient) {
       return undefined;
     }
 
     try {
-      const blobs = await this.blobArchiveClient.getBlobsFromBlock(blockId);
-      if (!blobs) {
-        return undefined;
-      }
-
-      // We don't get the blob index within the block from blobscan API, we get the blob index
-      // within the tx. Here we assume that the blobs are orderd tx first, and then within tx.
-      // Note that we are not using querying by indices anywhere in the codebase though.
-      const blobsWithIndex = blobs.map((blob, index) => [blob, index] as const);
-      const filteredBlobs = indices ? blobsWithIndex.filter(([, index]) => indices.includes(index)) : blobsWithIndex;
-
-      // Parsing a blob fails if this is not one of our blobs. It's very likely there are blobs
-      // we don't care about in this block, so this is not a high severity log.
-      const tryParseBlob = (blobJson: BlobJson, index: number) =>
-        Blob.fromJson(blobJson)
-          .then(blob => [blob, index] as const)
-          .catch(err => {
-            const severity = err.name === 'BlobDeserializationError' ? 'debug' : 'error';
-            this.log[severity](`Error parsing blob ${index} for block ${blockId}`, err);
-            return [undefined, index] as const;
-          });
-
-      // We keep the blobs that were successfully parsed only.
-      const parsedBlobs = await Promise.all(filteredBlobs.map(([blobJson, index]) => tryParseBlob(blobJson, index)));
-      const validBlobs = parsedBlobs.filter(([blob]) => blob !== undefined) as [Blob, number][];
-      const result = validBlobs.map(([blob, index]) => new BlobWithIndex(blob, index));
-
-      // And save them to the local store so we don't re-fetch again.
-      this.log.verbose(`Storing ${pluralize('blob', result.length)} downloaded from archive for block ${blockId}`);
-      await this.blobStore.addBlobSidecars(blockId, result);
-
-      return result;
+      const blobs = await this.httpClient.getBlobSidecar(blockId);
+      this.log.verbose(`Storing ${pluralize('blob', blobs.length)} downloaded from archive for block ${blockId}`);
+      await this.blobStore.addBlobSidecars(blockId, blobs);
+      return blobs.filter(blob => !indices || indices.length === 0 || indices.includes(blob.index));
     } catch (err) {
-      this.log.error(`Failed to get blobs for block ${blockId} from archive`, err);
+      this.log.error(`Failed to get blobs for block ${blockId} from remote sources`, err);
       return undefined;
     }
   }
 
   private async handlePostBlobSidecar(req: Request, res: Response) {
-    // eslint-disable-next-line camelcase
-    const { block_id, blobs } = req.body;
+    const { block_id: blockId, blobs } = req.body;
+    const { data: parsedBlockId, error } = blockIdSchema.safeParse(blockId);
+    if (error) {
+      res.status(400).json({ error: `Invalid block_id parameter`, details: error.message });
+      return;
+    }
 
-    let parsedBlockId: Hex;
     let blobObjects: BlobWithIndex[];
 
     try {
-      // eslint-disable-next-line camelcase
-      parsedBlockId = blockIdSchema.parse(block_id);
-      if (!parsedBlockId) {
-        res.status(400).json({ error: 'Invalid block_id parameter' });
-        return;
-      }
-
       this.log.info(`Received blob sidecar for block ${parsedBlockId}`);
       blobObjects = this.parseBlobData(blobs);
       await this.validateBlobs(parsedBlockId, blobObjects);
     } catch (error: any) {
+      this.log.warn(`Failed to validate incoming blobs for ${parsedBlockId}`, error);
       res.status(400).json({ error: 'Invalid blob data', details: error.message });
       this.metrics.incStoreBlob(false);
       return;

--- a/yarn-project/blob-sink/src/server/server.ts
+++ b/yarn-project/blob-sink/src/server/server.ts
@@ -159,8 +159,12 @@ export class BlobSinkServer {
 
     try {
       const blobs = await this.httpClient.getBlobSidecar(blockId);
-      this.log.verbose(`Storing ${pluralize('blob', blobs.length)} downloaded from archive for block ${blockId}`);
-      await this.blobStore.addBlobSidecars(blockId, blobs);
+      if (blobs.length > 0) {
+        this.log.verbose(`Storing ${pluralize('blob', blobs.length)} downloaded from remote sources for ${blockId}`);
+        await this.blobStore.addBlobSidecars(blockId, blobs);
+      } else {
+        this.log.debug(`No blobs found for block ${blockId} from remote sources`);
+      }
       return blobs.filter(blob => !indices || indices.length === 0 || indices.includes(blob.index));
     } catch (err) {
       this.log.error(`Failed to get blobs for block ${blockId} from remote sources`, err);

--- a/yarn-project/end-to-end/src/fixtures/utils.ts
+++ b/yarn-project/end-to-end/src/fixtures/utils.ts
@@ -516,7 +516,7 @@ export async function setup(
     }
     config.l1PublishRetryIntervalMS = 100;
 
-    const blobSinkClient = createBlobSinkClient(config);
+    const blobSinkClient = createBlobSinkClient(config, { logger: createLogger('node:blob-sink:client') });
     const aztecNode = await AztecNodeService.createAndSync(
       config,
       { dateProvider, blobSinkClient, telemetry },
@@ -791,7 +791,9 @@ export async function createAndSyncProverNode(
     stop: () => Promise.resolve(),
   };
 
-  const blobSinkClient = createBlobSinkClient(aztecNodeConfig);
+  const blobSinkClient = createBlobSinkClient(aztecNodeConfig, {
+    logger: createLogger('prover-node:blob-sink:client'),
+  });
   // Creating temp store and archiver for simulated prover node
   const archiverConfig = { ...aztecNodeConfig, dataDirectory };
   const archiver = await createArchiver(archiverConfig, blobSinkClient, {

--- a/yarn-project/foundation/src/retry/index.ts
+++ b/yarn-project/foundation/src/retry/index.ts
@@ -1,5 +1,5 @@
 import { TimeoutError } from '../error/index.js';
-import { createLogger } from '../log/index.js';
+import { type Logger, createLogger } from '../log/index.js';
 import { sleep } from '../sleep/index.js';
 import { Timer } from '../timer/index.js';
 
@@ -49,7 +49,7 @@ export async function retry<Result>(
   fn: () => Promise<Result>,
   name = 'Operation',
   backoff = backoffGenerator(),
-  log = createLogger('foundation:retry'),
+  log: Logger = createLogger('foundation:retry'),
   failSilently = false,
 ) {
   while (true) {
@@ -64,8 +64,8 @@ export async function retry<Result>(
       if (s === undefined) {
         throw err;
       }
-      log.verbose(`${name} failed. Will retry in ${s}s...`);
-      !failSilently && log.error(`Error while retrying ${name}`, err);
+      log?.debug(`${name} failed. Will retry in ${s}s...`);
+      !failSilently && log?.error(`Error while retrying ${name}`, err);
       await sleep(s * 1000);
       continue;
     }

--- a/yarn-project/prover-node/src/factory.ts
+++ b/yarn-project/prover-node/src/factory.ts
@@ -37,7 +37,8 @@ export async function createProverNode(
 ) {
   const config = resolveConfig(userConfig);
   const telemetry = deps.telemetry ?? getTelemetryClient();
-  const blobSinkClient = deps.blobSinkClient ?? createBlobSinkClient(config);
+  const blobSinkClient =
+    deps.blobSinkClient ?? createBlobSinkClient(config, { logger: createLogger('prover-node:blob-sink:client') });
   const log = deps.log ?? createLogger('prover-node');
 
   await trySnapshotSync(config, log);

--- a/yarn-project/sequencer-client/src/publisher/sequencer-publisher.ts
+++ b/yarn-project/sequencer-client/src/publisher/sequencer-publisher.ts
@@ -122,7 +122,8 @@ export class SequencerPublisher {
     this.ethereumSlotDuration = BigInt(config.ethereumSlotDuration);
     this.epochCache = deps.epochCache;
 
-    this.blobSinkClient = deps.blobSinkClient ?? createBlobSinkClient(config);
+    this.blobSinkClient =
+      deps.blobSinkClient ?? createBlobSinkClient(config, { logger: createLogger('sequencer:blob-sink:client') });
 
     const telemetry = deps.telemetry ?? getTelemetryClient();
     this.metrics = new SequencerPublisherMetrics(telemetry, 'SequencerPublisher');


### PR DESCRIPTION
This PR includes multiple chores/fixes, each split by commit:
- **[Blob sink server fetches from L1 consensus on blob miss](https://github.com/AztecProtocol/aztec-packages/commit/87569ae175e55dc4bed6ada826d71aa6c2507069)**: The blob sink server, when it was requested a blob it didn't have, would fall back to an archival service (like blobscan) to retrieve it. Now, before falling back to blobscan, it tries with a configured L1 consensus client. This commit includes a refactor of the sink server so it just reuses code from the client, rather than reimplementing much of its logic.
  ```
  [16:18:18.964] TRACE: blob-sink Received blobs request for block 0x29ca78726c02ddb3dc392c915efcccc9963744fe0b6838e9034022fca287adb9 {"blockId":"0x29ca78726c02ddb3dc392c915efcccc9963744fe0b6838e9034022fca287adb9"}
  [16:18:18.965] TRACE: blob-sink-client Attempting to get slot number for block hash {"l1ConsensusHostUrls":["https://lb.drpc.org/rest/KEY/eth-beacon-chain-sepolia"],"blockHash":"0x29ca78726c02ddb3dc392c915efcccc9963744fe0b6838e9034022fca287adb9","blobHashes":[]}
  [16:18:20.014] DEBUG: blob-sink-client Got slot number 7409506 from consensus host for querying blobs {"l1ConsensusHostUrls":["https://lb.drpc.org/rest/KEY/eth-beacon-chain-sepolia"],"blockHash":"0x29ca78726c02ddb3dc392c915efcccc9963744fe0b6838e9034022fca287adb9","blobHashes":[]}
  [16:18:20.014] TRACE: blob-sink-client Attempting to get blobs from consensus host {"slotNumber":7409506,"l1ConsensusHostUrl":"https://lb.drpc.org/rest/KEY/eth-beacon-chain-sepolia","blockHash":"0x29ca78726c02ddb3dc392c915efcccc9963744fe0b6838e9034022fca287adb9","blobHashes":[]}
  [16:18:20.014] DEBUG: blob-sink-client Fetching blob sidecar for 7409506 {"url":"https://lb.drpc.org/rest/KEY/eth-beacon-chain-sepolia/eth/v1/beacon/blob_sidecars/7409506"}
  [16:18:20.337] TRACE: blob-sink-client Failed to deserialise blob {"commitment":"0x84d99a55b6d1020fa0e3c9f912355dc5e6a1ec3e8001bd077e60c8abeb86fa5f8d68a19e1d22de899ce3102ceffbec37"}
  [16:18:20.337] TRACE: blob-sink-client Failed to deserialise blob {"commitment":"0xaa95e1d4f7c0bbaee7b8b81300b039164d9cadf9a0cc965efe7ecfbf0cf5fe583bc31058967241e43cf900f038080d7b"}
  [16:18:20.342] DEBUG: blob-sink-client Got 1 blobs from consensus host {"slotNumber":7409506,"l1ConsensusHostUrl":"https://lb.drpc.org/rest/KEY/eth-beacon-chain-sepolia","blockHash":"0x29ca78726c02ddb3dc392c915efcccc9963744fe0b6838e9034022fca287adb9","blobHashes":[]}
  [16:18:20.342] VERBOSE: blob-sink Storing blob downloaded from archive for block 0x29ca78726c02ddb3dc392c915efcccc9963744fe0b6838e9034022fca287adb9
  [16:18:20.342] DEBUG: blob-sink Returning 1 blobs for block 0x29ca78726c02ddb3dc392c915efcccc9963744fe0b6838e9034022fca287adb9 {"blockId":"0x29ca78726c02ddb3dc392c915efcccc9963744fe0b6838e9034022fca287adb9"}
  ```
- **[Fix default paths to archive API](https://github.com/AztecProtocol/aztec-packages/commit/529bbf25325143786cc100580dd7f613d33ac72b)**: They were missing the protocol, which caused them to fail when doing `new URL(url)` in the telemetry setup.
- **[Tweak logging for blob sink client](https://github.com/AztecProtocol/aztec-packages/commit/dea449f19a09538681336884ff86457cedc18c85)**: Updated logging so errors to fetch blobs are properly logged as warns, and retries are demoted to debug.
  ```
  [16:16:27.287] DEBUG: blob-sink-client Fetching blob sidecar for 0xe79d762e7fdb5171a1d5a1d35e67f253eb409f07597a3a89b4cf17af5706601b {"url":"http://localhost:8090/eth/v1/beacon/blob_sidecars/0xe79d762e7fdb5171a1d5a1d35e67f253eb409f07597a3a89b4cf17af5706601b"}
  [16:16:27.288] DEBUG: blob-sink-client Fetching http://localhost:8090/eth/v1/beacon/blob_sidecars/0xe79d762e7fdb5171a1d5a1d35e67f253eb409f07597a3a89b4cf17af5706601b failed. Will retry in 1s...
  [16:16:28.290] DEBUG: blob-sink-client Fetching http://localhost:8090/eth/v1/beacon/blob_sidecars/0xe79d762e7fdb5171a1d5a1d35e67f253eb409f07597a3a89b4cf17af5706601b failed. Will retry in 1s...
  [16:16:29.291] DEBUG: blob-sink-client Fetching http://localhost:8090/eth/v1/beacon/blob_sidecars/0xe79d762e7fdb5171a1d5a1d35e67f253eb409f07597a3a89b4cf17af5706601b failed. Will retry in 3s...
  [16:16:32.292] WARN: blob-sink-client Error getting blob sidecar from http://localhost:8090: fetch failed
  [16:16:32.292] DEBUG: blob-sink-client Got 0 blobs from blob sink {"blobSinkUrl":"http://localhost:8090","blockHash":"0xe79d762e7fdb5171a1d5a1d35e67f253eb409f07597a3a89b4cf17af5706601b","blobHashes":["0x010657f37554c781402a22917dee2f75def7ab966d7b770905398eba3c444014"]}
  [16:16:32.292] WARN: blob-sink-client Failed to fetch blobs for 0xe79d762e7fdb5171a1d5a1d35e67f253eb409f07597a3a89b4cf17af5706601b from all blob sources {"blobSinkUrl":"http://localhost:8090","l1ConsensusHostUrls":[]}
  ```
- **[Do not finish archiver sync until success](https://github.com/AztecProtocol/aztec-packages/commit/dd851c7c8a8a02eadaf036669c6b904f6e81c94d)**: If there was an error during archiver syncing, the initial `createAndSync` promise would still resolve, and the node would start in a state of incomplete sync. Now the archiver waits until the sync is successful before returning control.
  ```
  [16:16:12.116] INFO: archiver Starting archiver sync to rollup contract 0x2a6eb8e6110ad8e6cc0ba5b8a794740e05ce62a6 from L1 block 8076568 to current L1 block 8118693
  [16:16:26.908] DEBUG: archiver Got 1 L2 block processed logs for L2 blocks 1-1 between L1 blocks 8077379-8077388
  [16:16:27.287] DEBUG: blob-sink-client Fetching blob sidecar for 0xe79d762e7fdb5171a1d5a1d35e67f253eb409f07597a3a89b4cf17af5706601b {"url":"http://localhost:8090/eth/v1/beacon/blob_sidecars/0xe79d762e7fdb5171a1d5a1d35e67f253eb409f07597a3a89b4cf17af5706601b"}
  [16:16:27.288] DEBUG: blob-sink-client Fetching http://localhost:8090/eth/v1/beacon/blob_sidecars/0xe79d762e7fdb5171a1d5a1d35e67f253eb409f07597a3a89b4cf17af5706601b failed. Will retry in 1s...
  [16:16:28.290] DEBUG: blob-sink-client Fetching http://localhost:8090/eth/v1/beacon/blob_sidecars/0xe79d762e7fdb5171a1d5a1d35e67f253eb409f07597a3a89b4cf17af5706601b failed. Will retry in 1s...
  [16:16:29.291] DEBUG: blob-sink-client Fetching http://localhost:8090/eth/v1/beacon/blob_sidecars/0xe79d762e7fdb5171a1d5a1d35e67f253eb409f07597a3a89b4cf17af5706601b failed. Will retry in 3s...
  [16:16:32.292] WARN: blob-sink-client Error getting blob sidecar from http://localhost:8090: fetch failed
  [16:16:32.292] DEBUG: blob-sink-client Got 0 blobs from blob sink {"blobSinkUrl":"http://localhost:8090","blockHash":"0xe79d762e7fdb5171a1d5a1d35e67f253eb409f07597a3a89b4cf17af5706601b","blobHashes":["0x010657f37554c781402a22917dee2f75def7ab966d7b770905398eba3c444014"]}
  [16:16:32.292] WARN: blob-sink-client Failed to fetch blobs for 0xe79d762e7fdb5171a1d5a1d35e67f253eb409f07597a3a89b4cf17af5706601b from all blob sources {"blobSinkUrl":"http://localhost:8090","l1ConsensusHostUrls":[]}
  [16:16:32.292] ERROR: archiver Error syncing archiver: No blob bodies found for block 1
  [16:16:32.292] INFO: archiver Retrying initial archiver sync in 500ms
  [16:16:32.957] INFO: archiver Starting archiver sync to rollup contract 0x2a6eb8e6110ad8e6cc0ba5b8a794740e05ce62a6 from L1 block 8076568 to current L1 block 8118695
  ```
- **[Fix start --archiver command](https://github.com/AztecProtocol/aztec-packages/commit/56b426dd8a02cc2d1ef2ae03c5303c7399255e47)**: Wrong config mappings meant that the archiver was only fetching the rollup contract address from config, and now the registry contract address is the one required.
- **[Test blob sources on archiver startup](https://github.com/AztecProtocol/aztec-packages/commit/cef04b78f2fb7f878cc7b4134085ccf96dc1cb4e)**: Reaches out to every L1 consensus host configured, blob sink, and archive blob service on archiver startup, and logs the result.
  ```
  [16:22:32.054] INFO: blob-sink-client Testing configured blob sources {"blobSinkUrl":"http://localhost:8090","l1ConsensusHostUrls":["https://lb.drpc.org/rest/KEY/eth-beacon-chain-sepolia"],"archiveUrl":"api.sepolia.blobscan.com"}
  [16:22:32.059] INFO: blob-sink-client Blob sink is reachable {"blobSinkUrl":"http://localhost:8090"}
  [16:22:32.584] INFO: blob-sink-client L1 consensus host is reachable {"l1ConsensusHostUrl":"https://lb.drpc.org/rest/KEY/eth-beacon-chain-sepolia"}
  [16:22:35.155] INFO: blob-sink-client Archive client is reachable and synced to L1 block 8088445 {"latest":{"hash":"0x80c3dd67e5d296b3faa880381a17936bc259b33764e5f6c05ab1492c1846785c","slot":7377108,"number":8088445},"archiveUrl":"api.sepolia.blobscan.com"}
  [16:22:35.322] INFO: archiver Starting archiver sync to rollup contract 0x2a6eb8e6110ad8e6cc0ba5b8a794740e05ce62a6 from L1 block 8076568 to current L1 block 8118721
  ```

Fixes #13530 