### PR TITLE
chore: make debugging ivc integration tests easier

### DIFF
--- a/yarn-project/ivc-integration/src/native_client_ivc_integration.test.ts
+++ b/yarn-project/ivc-integration/src/native_client_ivc_integration.test.ts
@@ -9,6 +9,7 @@ import { fileURLToPath } from 'url';
 
 import { generate3FunctionTestingIVCStack, generate6FunctionTestingIVCStack } from './index.js';
 import { proveClientIVC } from './prove_native.js';
+import { getWorkingDirectory } from './bb_working_directory.js';
 
 /* eslint-disable camelcase */
 
@@ -22,7 +23,7 @@ describe('Client IVC Integration', () => {
 
   beforeEach(async () => {
     // Create a temp working dir
-    bbWorkingDirectory = await fs.mkdtemp(path.join(os.tmpdir(), 'bb-client-ivc-integration-'));
+    bbWorkingDirectory = await getWorkingDirectory('bb-client-ivc-integration-');
     bbBinaryPath = path.join(path.dirname(fileURLToPath(import.meta.url)), '../../../barretenberg/cpp/build/bin', 'bb');
   });
 

--- a/yarn-project/ivc-integration/src/native_client_ivc_integration.test.ts
+++ b/yarn-project/ivc-integration/src/native_client_ivc_integration.test.ts
@@ -7,9 +7,9 @@ import os from 'os';
 import path from 'path';
 import { fileURLToPath } from 'url';
 
+import { getWorkingDirectory } from './bb_working_directory.js';
 import { generate3FunctionTestingIVCStack, generate6FunctionTestingIVCStack } from './index.js';
 import { proveClientIVC } from './prove_native.js';
-import { getWorkingDirectory } from './bb_working_directory.js';
 
 /* eslint-disable camelcase */
 

--- a/yarn-project/ivc-integration/src/rollup_ivc_integration.test.ts
+++ b/yarn-project/ivc-integration/src/rollup_ivc_integration.test.ts
@@ -32,6 +32,7 @@ import {
 } from './index.js';
 import { proveAvm, proveClientIVC, proveRollupHonk, proveTube } from './prove_native.js';
 import type { KernelPublicInputs } from './types/index.js';
+import { getWorkingDirectory } from './bb_working_directory.js';
 
 /* eslint-disable camelcase */
 
@@ -54,7 +55,7 @@ describe('Rollup IVC Integration', () => {
     bbBinaryPath = path.join(path.dirname(fileURLToPath(import.meta.url)), '../../../barretenberg/cpp/build/bin', 'bb');
 
     // Create a client IVC proof
-    const clientIVCWorkingDirectory = await fs.mkdtemp(path.join(os.tmpdir(), 'bb-rollup-ivc-integration-client-ivc-'));
+    const clientIVCWorkingDirectory = await getWorkingDirectory('bb-rollup-ivc-integration-client-ivc-');
 
     const [bytecodes, witnessStack, tailPublicInputs] = await generate3FunctionTestingIVCStack();
     clientIVCPublicInputs = tailPublicInputs;
@@ -71,7 +72,7 @@ describe('Rollup IVC Integration', () => {
     tubeProof = await proveTube(bbBinaryPath, clientIVCWorkingDirectory, logger);
 
     // Create an AVM proof
-    const avmWorkingDirectory = await fs.mkdtemp(path.join(os.tmpdir(), 'bb-rollup-ivc-integration-avm-'));
+    const avmWorkingDirectory = await getWorkingDirectory('bb-rollup-ivc-integration-avm-');
 
     const simTester = await PublicTxSimulationTester.create();
     const avmTestContractInstance = await simTester.registerAndDeployContract(
@@ -90,7 +91,7 @@ describe('Rollup IVC Integration', () => {
   });
 
   beforeEach(async () => {
-    workingDirectory = await fs.mkdtemp(path.join(os.tmpdir(), 'bb-rollup-ivc-integration-'));
+    workingDirectory = await getWorkingDirectory('bb-rollup-ivc-integration-');
   });
 
   it('Should be able to generate a proof of a 3 transaction rollup', async () => {

--- a/yarn-project/ivc-integration/src/rollup_ivc_integration.test.ts
+++ b/yarn-project/ivc-integration/src/rollup_ivc_integration.test.ts
@@ -14,6 +14,7 @@ import os from 'os';
 import path from 'path';
 import { fileURLToPath } from 'url';
 
+import { getWorkingDirectory } from './bb_working_directory.js';
 import {
   MockRollupBasePrivateCircuit,
   MockRollupBasePublicCircuit,
@@ -32,7 +33,6 @@ import {
 } from './index.js';
 import { proveAvm, proveClientIVC, proveRollupHonk, proveTube } from './prove_native.js';
 import type { KernelPublicInputs } from './types/index.js';
-import { getWorkingDirectory } from './bb_working_directory.js';
 
 /* eslint-disable camelcase */
 

--- a/yarn-project/scripts/run_test.sh
+++ b/yarn-project/scripts/run_test.sh
@@ -34,6 +34,7 @@ if [ "${ISOLATE:-0}" -eq 1 ]; then
   wait $!
 else
   export NODE_OPTIONS="--no-warnings --experimental-vm-modules --loader @swc-node/register"
+  export LOG_LEVEL=${LOG_LEVEL:-info}
   cd ../$dir
   node ../node_modules/.bin/jest --forceExit --runInBand $test
 fi


### PR DESCRIPTION
- dont hide test info by default
- allow passing BB_WORKING_DIRECTORY env var and keeping outputs around like in e2e