### PR TITLE
chore: add hacky faster bootstrap for bb-centric e2e flow

### DIFF
--- a/barretenberg/bootstrap.sh
+++ b/barretenberg/bootstrap.sh
@@ -42,6 +42,15 @@ case "$cmd" in
   bench)
     bench
     ;;
+  bootstrap_e2e_hack)
+    echo "WARNING: This assumes you have only built barretenberg and the rest of the repository is unchanged from master."
+    echo "WARNING: This is only sound if you have not changed VK generation! (or noir-projects VKs will be incorrect)."
+    echo "WARNING: It builds up until yarn-project and allows end-to-end tests (not boxes/playground/release image etc)."
+    merge_base=$(git merge-base HEAD origin/master)
+    for project in noir avm-transpiler noir-projects l1-contracts yarn-project ; do
+      AZTEC_CACHE_COMMIT=$merge_base ../$project/bootstrap.sh
+    done
+    ;;
   *)
     echo "Unknown command: $cmd"
     exit 1

--- a/barretenberg/bootstrap.sh
+++ b/barretenberg/bootstrap.sh
@@ -43,12 +43,16 @@ case "$cmd" in
     bench
     ;;
   bootstrap_e2e_hack)
-    echo "WARNING: This assumes you have built barretenberg and the rest of the repository is unchanged from master."
+    echo "WARNING: This assumes your PR only changes barretenberg and the rest of the repository is unchanged from master."
     echo "WARNING: This is only sound if you have not changed VK generation! (or noir-projects VKs will be incorrect)."
     echo "WARNING: It builds up until yarn-project and allows end-to-end tests (not boxes/playground/release image etc)."
     merge_base=$(git merge-base HEAD origin/master)
-    for project in noir avm-transpiler noir-projects l1-contracts yarn-project ; do
-      AZTEC_CACHE_COMMIT=$merge_base ../$project/bootstrap.sh
+    for project in noir barretenberg avm-transpiler noir-projects l1-contracts yarn-project ; do
+      if [ $project == barretenberg ]; then
+        ./$project/bootstrap.sh # i.e. this script
+      else
+        AZTEC_CACHE_COMMIT=$merge_base ../$project/bootstrap.sh
+      fi
     done
     ;;
   *)

--- a/barretenberg/bootstrap.sh
+++ b/barretenberg/bootstrap.sh
@@ -49,7 +49,7 @@ case "$cmd" in
     merge_base=$(git merge-base HEAD origin/master)
     for project in noir barretenberg avm-transpiler noir-projects l1-contracts yarn-project ; do
       if [ $project == barretenberg ]; then
-        ./$project/bootstrap.sh # i.e. this script
+        ../$project/bootstrap.sh # i.e. this script
       else
         AZTEC_CACHE_COMMIT=$merge_base ../$project/bootstrap.sh
       fi

--- a/barretenberg/bootstrap.sh
+++ b/barretenberg/bootstrap.sh
@@ -43,7 +43,7 @@ case "$cmd" in
     bench
     ;;
   bootstrap_e2e_hack)
-    echo "WARNING: This assumes you have only built barretenberg and the rest of the repository is unchanged from master."
+    echo "WARNING: This assumes you have built barretenberg and the rest of the repository is unchanged from master."
     echo "WARNING: This is only sound if you have not changed VK generation! (or noir-projects VKs will be incorrect)."
     echo "WARNING: It builds up until yarn-project and allows end-to-end tests (not boxes/playground/release image etc)."
     merge_base=$(git merge-base HEAD origin/master)


### PR DESCRIPTION
Right now a bb change will cause noir-projects to rebuild VKs, and other components will conservatively rebuild. This can be used if you are sure you have not changed VK construction. It means the other steps are grabbed from cache - it also skips everything past yarn-project and should be the fastest way to run e2e tests