### PR TITLE
fix: Restart archiver loop if L1 block falls more than 128 blocks behind

### DIFF
--- a/yarn-project/archiver/src/archiver/archiver.ts
+++ b/yarn-project/archiver/src/archiver/archiver.ts
@@ -1,5 +1,5 @@
 import type { BlobSinkClientInterface } from '@aztec/blob-sink/client';
-import { RollupContract, type ViemPublicClient, createEthereumChain } from '@aztec/ethereum';
+import { BlockTagTooOldError, RollupContract, type ViemPublicClient, createEthereumChain } from '@aztec/ethereum';
 import { maxBigint } from '@aztec/foundation/bigint';
 import type { EthAddress } from '@aztec/foundation/eth-address';
 import { Fr } from '@aztec/foundation/fields';
@@ -226,6 +226,8 @@ export class Archiver extends EventEmitter implements ArchiveSource, Traceable {
     } catch (error) {
       if (error instanceof NoBlobBodiesFoundError) {
         this.log.error(`Error syncing archiver: ${error.message}`);
+      } else if (error instanceof BlockTagTooOldError) {
+        this.log.warn(`Re-running archiver sync: ${error.message}`);
       } else {
         this.log.error('Error during archiver sync', error);
       }

--- a/yarn-project/ethereum/src/contracts/errors.ts
+++ b/yarn-project/ethereum/src/contracts/errors.ts
@@ -1,0 +1,6 @@
+export class BlockTagTooOldError extends Error {
+  constructor(blockTag: bigint | number, latestBlock: bigint | number) {
+    super(`Block tag ${blockTag} is more than 128 blocks behind the latest block ${latestBlock}`);
+    this.name = 'BlockTagTooOldError';
+  }
+}

--- a/yarn-project/ethereum/src/contracts/index.ts
+++ b/yarn-project/ethereum/src/contracts/index.ts
@@ -7,3 +7,4 @@ export * from './governance_proposer.js';
 export * from './registry.js';
 export * from './rollup.js';
 export * from './slashing_proposer.js';
+export * from './errors.js';

--- a/yarn-project/ethereum/src/contracts/rollup.ts
+++ b/yarn-project/ethereum/src/contracts/rollup.ts
@@ -14,6 +14,7 @@ import type { L1ReaderConfig } from '../l1_reader.js';
 import type { ViemClient } from '../types.js';
 import { formatViemError } from '../utils.js';
 import { SlashingProposerContract } from './slashing_proposer.js';
+import { checkBlockTag } from './utils.js';
 
 export type L1RollupContractAddresses = Pick<
   L1ContractAddresses,
@@ -381,11 +382,13 @@ export class RollupContract {
     return this.rollup.read.getSlotAt([timestamp]);
   }
 
-  status(blockNumber: bigint, options?: { blockNumber?: bigint }) {
+  async status(blockNumber: bigint, options?: { blockNumber?: bigint }) {
+    await checkBlockTag(options?.blockNumber, this.client);
     return this.rollup.read.status([blockNumber], options);
   }
 
-  canPruneAtTime(timestamp: bigint, options?: { blockNumber?: bigint }) {
+  async canPruneAtTime(timestamp: bigint, options?: { blockNumber?: bigint }) {
+    await checkBlockTag(options?.blockNumber, this.client);
     return this.rollup.read.canPruneAtTime([timestamp], options);
   }
 

--- a/yarn-project/ethereum/src/contracts/utils.ts
+++ b/yarn-project/ethereum/src/contracts/utils.ts
@@ -1,9 +1,9 @@
-import type { ViemPublicClient } from '../types.js';
+import type { ViemClient } from '../types.js';
 import { BlockTagTooOldError } from './errors.js';
 
 const L1_NON_ARCHIVE_BLOCK_HISTORY_LENGTH = 128n;
 
-export async function checkBlockTag(block: bigint | undefined, publicClient: ViemPublicClient) {
+export async function checkBlockTag(block: bigint | undefined, publicClient: ViemClient) {
   if (block === undefined) {
     return;
   }

--- a/yarn-project/ethereum/src/contracts/utils.ts
+++ b/yarn-project/ethereum/src/contracts/utils.ts
@@ -1,0 +1,14 @@
+import type { ViemPublicClient } from '../types.js';
+import { BlockTagTooOldError } from './errors.js';
+
+const L1_NON_ARCHIVE_BLOCK_HISTORY_LENGTH = 128n;
+
+export async function checkBlockTag(block: bigint | undefined, publicClient: ViemPublicClient) {
+  if (block === undefined) {
+    return;
+  }
+  const latestBlock = await publicClient.getBlockNumber();
+  if (block < latestBlock - L1_NON_ARCHIVE_BLOCK_HISTORY_LENGTH) {
+    throw new BlockTagTooOldError(block, latestBlock);
+  }
+}


### PR DESCRIPTION
If the `currentL1Block` used in the archiver sync loop falls more than 128 blocks behind (eg during a very long sync), then `eth_call` operations that pin the block number (`status`, `canPrune`) may end up querying a block evicted by a non-archive node. If this happens, we just abort the current sync and restart. This should not evict any messages or blocks already downloaded.

Fixes #13596
