### PR TITLE
fix: Skip p2p sync from initial block on snap sync

### DIFF
--- a/yarn-project/node-lib/src/actions/snapshot-sync.ts
+++ b/yarn-project/node-lib/src/actions/snapshot-sync.ts
@@ -5,6 +5,7 @@ import type { EthAddress } from '@aztec/foundation/eth-address';
 import { tryRmDir } from '@aztec/foundation/fs';
 import type { Logger } from '@aztec/foundation/log';
 import type { DataStoreConfig } from '@aztec/kv-store/config';
+import { P2P_STORE_NAME } from '@aztec/p2p';
 import type { ChainConfig } from '@aztec/stdlib/config';
 import { DatabaseVersionManager } from '@aztec/stdlib/database-version';
 import { type ReadOnlyFileStore, createReadOnlyFileStore } from '@aztec/stdlib/file-store';
@@ -211,6 +212,11 @@ export async function snapshotSync(
         rollupAddress,
       });
     }
+
+    // And clear the p2p db altogether
+    const p2pPath = join(dataDirectory, P2P_STORE_NAME);
+    await tryRmDir(p2pPath, log);
+    log.info(`P2P database cleared`, { path: p2pPath });
   } finally {
     if (downloadDir) {
       await tryRmDir(downloadDir, log);

--- a/yarn-project/p2p/src/client/factory.ts
+++ b/yarn-project/p2p/src/client/factory.ts
@@ -27,6 +27,9 @@ type P2PClientDeps<T extends P2PClientType> = {
   logger?: Logger;
 };
 
+export const P2P_STORE_NAME = 'p2p';
+export const P2P_ARCHIVE_STORE_NAME = 'p2p-archive';
+
 export const createP2PClient = async <T extends P2PClientType>(
   clientType: T,
   _config: P2PConfig & DataStoreConfig,
@@ -39,8 +42,8 @@ export const createP2PClient = async <T extends P2PClientType>(
 ) => {
   let config = { ..._config, dataStoreMapSizeKB: _config.p2pStoreMapSizeKb ?? _config.dataStoreMapSizeKB };
   const logger = deps.logger ?? createLogger('p2p');
-  const store = deps.store ?? (await createStore('p2p', 1, config, createLogger('p2p:lmdb-v2')));
-  const archive = await createStore('p2p-archive', 1, config, createLogger('p2p-archive:lmdb-v2'));
+  const store = deps.store ?? (await createStore(P2P_STORE_NAME, 1, config, createLogger('p2p:lmdb-v2')));
+  const archive = await createStore(P2P_ARCHIVE_STORE_NAME, 1, config, createLogger('p2p-archive:lmdb-v2'));
 
   const mempools: MemPools<T> = {
     txPool:

--- a/yarn-project/p2p/src/client/index.ts
+++ b/yarn-project/p2p/src/client/index.ts
@@ -1,2 +1,3 @@
 export * from './p2p_client.js';
 export * from './factory.js';
+export * from './interface.js';

--- a/yarn-project/p2p/src/client/interface.ts
+++ b/yarn-project/p2p/src/client/interface.ts
@@ -1,0 +1,174 @@
+import type { L2BlockId } from '@aztec/stdlib/block';
+import type { P2PApi } from '@aztec/stdlib/interfaces/server';
+import { BlockAttestation, type BlockProposal, type P2PClientType } from '@aztec/stdlib/p2p';
+import type { Tx, TxHash } from '@aztec/stdlib/tx';
+
+import type { ENR } from '@chainsafe/enr';
+
+import type { P2PConfig } from '../config.js';
+
+/**
+ * Enum defining the possible states of the p2p client.
+ */
+export enum P2PClientState {
+  IDLE,
+  SYNCHING,
+  RUNNING,
+  STOPPED,
+}
+
+/**
+ * The synchronization status of the P2P client.
+ */
+export interface P2PSyncState {
+  /**
+   * The current state of the p2p client.
+   */
+  state: P2PClientState;
+  /**
+   * The block number that the p2p client is synced to.
+   */
+  syncedToL2Block: L2BlockId;
+}
+
+/**
+ * Interface of a P2P client.
+ **/
+export type P2P<T extends P2PClientType = P2PClientType.Full> = P2PApi<T> & {
+  /**
+   * Broadcasts a block proposal to other peers.
+   *
+   * @param proposal - the block proposal
+   */
+  broadcastProposal(proposal: BlockProposal): void;
+
+  /**
+   * Registers a callback from the validator client that determines how to behave when
+   * foreign block proposals are received
+   *
+   * @param handler - A function taking a received block proposal and producing an attestation
+   */
+  // REVIEW: https://github.com/AztecProtocol/aztec-packages/issues/7963
+  // ^ This pattern is not my favorite (md)
+  registerBlockProposalHandler(handler: (block: BlockProposal) => Promise<BlockAttestation | undefined>): void;
+
+  /**
+   * Request a list of transactions from another peer by their tx hashes.
+   * @param txHashes - Hashes of the txs to query.
+   * @returns A list of transactions or undefined if the transactions are not found.
+   */
+  requestTxs(txHashes: TxHash[]): Promise<(Tx | undefined)[]>;
+
+  /**
+   * Request a transaction from another peer by its tx hash.
+   * @param txHash - Hash of the tx to query.
+   */
+  requestTxByHash(txHash: TxHash): Promise<Tx | undefined>;
+
+  /**
+   * Verifies the 'tx' and, if valid, adds it to local tx pool and forwards it to other peers.
+   * @param tx - The transaction.
+   **/
+  sendTx(tx: Tx): Promise<void>;
+
+  /**
+   * Adds transactions to the pool. Does not send to peers or validate the tx.
+   * @param txs - The transactions.
+   **/
+  addTxs(txs: Tx[]): Promise<void>;
+
+  /**
+   * Deletes 'txs' from the pool, given hashes.
+   * NOT used if we use sendTx as reconcileTxPool will handle this.
+   * @param txHashes - Hashes to check.
+   **/
+  deleteTxs(txHashes: TxHash[]): Promise<void>;
+
+  /**
+   * Returns a transaction in the transaction pool by its hash.
+   * @param txHash  - Hash of tx to return.
+   * @returns A single tx or undefined.
+   */
+  getTxByHashFromPool(txHash: TxHash): Promise<Tx | undefined>;
+
+  /**
+   * Returns transactions in the transaction pool by hash.
+   * @param txHashes  - Hashes of txs to return.
+   * @returns An array of txs or undefined.
+   */
+  getTxsByHashFromPool(txHashes: TxHash[]): Promise<(Tx | undefined)[]>;
+
+  /**
+   * Checks if transactions exist in the pool
+   * @param txHashes - The hashes of the transactions to check for
+   * @returns True or False for each hash
+   */
+  hasTxsInPool(txHashes: TxHash[]): Promise<boolean[]>;
+
+  /**
+   * Returns a transaction in the transaction pool by its hash, requesting it from the network if it is not found.
+   * @param txHash  - Hash of tx to return.
+   * @returns A single tx or undefined.
+   */
+  getTxByHash(txHash: TxHash): Promise<Tx | undefined>;
+
+  /**
+   * Returns transactions in the transaction pool by hash, requesting from the network if not found.
+   * @param txHashes  - Hashes of tx to return.
+   * @returns An array of tx or undefined.
+   */
+  getTxsByHash(txHashes: TxHash[]): Promise<(Tx | undefined)[]>;
+
+  /**
+   * Returns an archived transaction from the transaction pool by its hash.
+   * @param txHash  - Hash of tx to return.
+   * @returns A single tx or undefined.
+   */
+  getArchivedTxByHash(txHash: TxHash): Promise<Tx | undefined>;
+
+  /**
+   * Returns whether the given tx hash is flagged as pending or mined.
+   * @param txHash - Hash of the tx to query.
+   * @returns Pending or mined depending on its status, or undefined if not found.
+   */
+  getTxStatus(txHash: TxHash): Promise<'pending' | 'mined' | undefined>;
+
+  /** Returns an iterator over pending txs on the mempool. */
+  iteratePendingTxs(): AsyncIterableIterator<Tx>;
+
+  /** Returns the number of pending txs in the mempool. */
+  getPendingTxCount(): Promise<number>;
+
+  /**
+   * Starts the p2p client.
+   * @returns A promise signalling the completion of the block sync.
+   */
+  start(): Promise<void>;
+
+  /**
+   * Stops the p2p client.
+   * @returns A promise signalling the completion of the stop process.
+   */
+  stop(): Promise<void>;
+
+  /**
+   * Indicates if the p2p client is ready for transaction submission.
+   * @returns A boolean flag indicating readiness.
+   */
+  isReady(): boolean;
+
+  /**
+   * Returns the current status of the p2p client.
+   */
+  getStatus(): Promise<P2PSyncState>;
+
+  /**
+   * Returns the ENR of this node, if any.
+   */
+  getEnr(): ENR | undefined;
+
+  /** Identifies a p2p client. */
+  isP2PClient(): true;
+
+  updateP2PConfig(config: Partial<P2PConfig>): Promise<void>;
+};

--- a/yarn-project/p2p/src/client/p2p_client.test.ts
+++ b/yarn-project/p2p/src/client/p2p_client.test.ts
@@ -318,7 +318,7 @@ describe('In-Memory P2P Client', () => {
       const deleteAttestationsOlderThanSpy = jest.spyOn(attestationPool, 'deleteAttestationsOlderThan');
 
       blockSource.setProvenBlockNumber(0);
-      (client as any).keepAttestationsInPoolFor = keepAttestationsInPoolFor;
+      (client as any).config.keepAttestationsInPoolFor = keepAttestationsInPoolFor;
       await client.start();
       expect(deleteAttestationsOlderThanSpy).not.toHaveBeenCalled();
 

--- a/yarn-project/p2p/src/client/p2p_client.ts
+++ b/yarn-project/p2p/src/client/p2p_client.ts
@@ -3,14 +3,14 @@ import { createLogger } from '@aztec/foundation/log';
 import type { AztecAsyncKVStore, AztecAsyncMap, AztecAsyncSingleton } from '@aztec/kv-store';
 import type {
   L2Block,
-  L2BlockId,
   L2BlockSource,
+  L2BlockStream,
   L2BlockStreamEvent,
   L2Tips,
   PublishedL2Block,
 } from '@aztec/stdlib/block';
 import type { ContractDataSource } from '@aztec/stdlib/contract';
-import type { P2PApi, PeerInfo } from '@aztec/stdlib/interfaces/server';
+import type { PeerInfo } from '@aztec/stdlib/interfaces/server';
 import { BlockAttestation, type BlockProposal, ConsensusPayload, type P2PClientType } from '@aztec/stdlib/p2p';
 import type { Tx, TxHash } from '@aztec/stdlib/tx';
 import {
@@ -30,172 +30,7 @@ import type { MemPools } from '../mem_pools/interface.js';
 import type { TxPool } from '../mem_pools/tx_pool/index.js';
 import { ReqRespSubProtocol } from '../services/reqresp/interface.js';
 import type { P2PService } from '../services/service.js';
-
-/**
- * Enum defining the possible states of the p2p client.
- */
-export enum P2PClientState {
-  IDLE,
-  SYNCHING,
-  RUNNING,
-  STOPPED,
-}
-
-/**
- * The synchronization status of the P2P client.
- */
-export interface P2PSyncState {
-  /**
-   * The current state of the p2p client.
-   */
-  state: P2PClientState;
-  /**
-   * The block number that the p2p client is synced to.
-   */
-  syncedToL2Block: L2BlockId;
-}
-
-/**
- * Interface of a P2P client.
- **/
-export type P2P<T extends P2PClientType = P2PClientType.Full> = P2PApi<T> & {
-  /**
-   * Broadcasts a block proposal to other peers.
-   *
-   * @param proposal - the block proposal
-   */
-  broadcastProposal(proposal: BlockProposal): void;
-
-  /**
-   * Registers a callback from the validator client that determines how to behave when
-   * foreign block proposals are received
-   *
-   * @param handler - A function taking a received block proposal and producing an attestation
-   */
-  // REVIEW: https://github.com/AztecProtocol/aztec-packages/issues/7963
-  // ^ This pattern is not my favorite (md)
-  registerBlockProposalHandler(handler: (block: BlockProposal) => Promise<BlockAttestation | undefined>): void;
-
-  /**
-   * Request a list of transactions from another peer by their tx hashes.
-   * @param txHashes - Hashes of the txs to query.
-   * @returns A list of transactions or undefined if the transactions are not found.
-   */
-  requestTxs(txHashes: TxHash[]): Promise<(Tx | undefined)[]>;
-
-  /**
-   * Request a transaction from another peer by its tx hash.
-   * @param txHash - Hash of the tx to query.
-   */
-  requestTxByHash(txHash: TxHash): Promise<Tx | undefined>;
-
-  /**
-   * Verifies the 'tx' and, if valid, adds it to local tx pool and forwards it to other peers.
-   * @param tx - The transaction.
-   **/
-  sendTx(tx: Tx): Promise<void>;
-
-  /**
-   * Adds transactions to the pool. Does not send to peers or validate the tx.
-   * @param txs - The transactions.
-   **/
-  addTxs(txs: Tx[]): Promise<void>;
-
-  /**
-   * Deletes 'txs' from the pool, given hashes.
-   * NOT used if we use sendTx as reconcileTxPool will handle this.
-   * @param txHashes - Hashes to check.
-   **/
-  deleteTxs(txHashes: TxHash[]): Promise<void>;
-
-  /**
-   * Returns a transaction in the transaction pool by its hash.
-   * @param txHash  - Hash of tx to return.
-   * @returns A single tx or undefined.
-   */
-  getTxByHashFromPool(txHash: TxHash): Promise<Tx | undefined>;
-
-  /**
-   * Returns transactions in the transaction pool by hash.
-   * @param txHashes  - Hashes of txs to return.
-   * @returns An array of txs or undefined.
-   */
-  getTxsByHashFromPool(txHashes: TxHash[]): Promise<(Tx | undefined)[]>;
-
-  /**
-   * Checks if transactions exist in the pool
-   * @param txHashes - The hashes of the transactions to check for
-   * @returns True or False for each hash
-   */
-  hasTxsInPool(txHashes: TxHash[]): Promise<boolean[]>;
-
-  /**
-   * Returns a transaction in the transaction pool by its hash, requesting it from the network if it is not found.
-   * @param txHash  - Hash of tx to return.
-   * @returns A single tx or undefined.
-   */
-  getTxByHash(txHash: TxHash): Promise<Tx | undefined>;
-
-  /**
-   * Returns transactions in the transaction pool by hash, requesting from the network if not found.
-   * @param txHashes  - Hashes of tx to return.
-   * @returns An array of tx or undefined.
-   */
-  getTxsByHash(txHashes: TxHash[]): Promise<(Tx | undefined)[]>;
-
-  /**
-   * Returns an archived transaction from the transaction pool by its hash.
-   * @param txHash  - Hash of tx to return.
-   * @returns A single tx or undefined.
-   */
-  getArchivedTxByHash(txHash: TxHash): Promise<Tx | undefined>;
-
-  /**
-   * Returns whether the given tx hash is flagged as pending or mined.
-   * @param txHash - Hash of the tx to query.
-   * @returns Pending or mined depending on its status, or undefined if not found.
-   */
-  getTxStatus(txHash: TxHash): Promise<'pending' | 'mined' | undefined>;
-
-  /** Returns an iterator over pending txs on the mempool. */
-  iteratePendingTxs(): AsyncIterableIterator<Tx>;
-
-  /** Returns the number of pending txs in the mempool. */
-  getPendingTxCount(): Promise<number>;
-
-  /**
-   * Starts the p2p client.
-   * @returns A promise signalling the completion of the block sync.
-   */
-  start(): Promise<void>;
-
-  /**
-   * Stops the p2p client.
-   * @returns A promise signalling the completion of the stop process.
-   */
-  stop(): Promise<void>;
-
-  /**
-   * Indicates if the p2p client is ready for transaction submission.
-   * @returns A boolean flag indicating readiness.
-   */
-  isReady(): boolean;
-
-  /**
-   * Returns the current status of the p2p client.
-   */
-  getStatus(): Promise<P2PSyncState>;
-
-  /**
-   * Returns the ENR of this node, if any.
-   */
-  getEnr(): ENR | undefined;
-
-  /** Identifies a p2p client. */
-  isP2PClient(): true;
-
-  updateP2PConfig(config: Partial<P2PConfig>): Promise<void>;
-};
+import { type P2P, P2PClientState, type P2PSyncState } from './interface.js';
 
 /**
  * The P2P client implementation.
@@ -221,14 +56,9 @@ export class P2PClient<T extends P2PClientType = P2PClientType.Full>
   private txPool: TxPool;
   private attestationPool: T extends P2PClientType.Full ? AttestationPool : undefined;
 
-  /** How many slots to keep attestations for. */
-  private keepAttestationsInPoolFor: number;
-  /** How many slots to keep proven txs for. */
-  private keepProvenTxsFor: number;
-
-  private blockStream;
-
   private config: P2PConfig;
+
+  private blockStream: L2BlockStream | undefined;
 
   /**
    * In-memory P2P client constructor.
@@ -236,7 +66,6 @@ export class P2PClient<T extends P2PClientType = P2PClientType.Full>
    * @param l2BlockSource - P2P client's source for fetching existing blocks.
    * @param txPool - The client's instance of a transaction pool. Defaults to in-memory implementation.
    * @param p2pService - The concrete instance of p2p networking to use.
-   * @param keepProvenTxsFor - How many blocks have to pass after a block is proven before its txs are deleted (zero to delete immediately once proven).
    * @param log - A logger.
    */
   constructor(
@@ -246,35 +75,20 @@ export class P2PClient<T extends P2PClientType = P2PClientType.Full>
     mempools: MemPools<T>,
     private p2pService: P2PService,
     config: Partial<P2PConfig> = {},
-    telemetry: TelemetryClient = getTelemetryClient(),
+    private telemetry: TelemetryClient = getTelemetryClient(),
     private log = createLogger('p2p'),
   ) {
     super(telemetry, 'P2PClient');
 
-    this.config = {
-      ...getP2PDefaultConfig(),
-      ...config,
-    };
+    this.config = { ...getP2PDefaultConfig(), ...config };
+    this.txPool = mempools.txPool;
+    this.attestationPool = mempools.attestationPool!;
 
-    const { keepProvenTxsInPoolFor, blockCheckIntervalMS, blockRequestBatchSize, keepAttestationsInPoolFor } =
-      this.config;
-    this.keepProvenTxsFor = keepProvenTxsInPoolFor;
-    this.keepAttestationsInPoolFor = keepAttestationsInPoolFor;
-
-    const tracer = telemetry.getTracer('P2PL2BlockStream');
-    const logger = createLogger('p2p:l2-block-stream');
-    this.blockStream = new TraceableL2BlockStream(l2BlockSource, this, this, tracer, 'P2PL2BlockStream', logger, {
-      batchSize: blockRequestBatchSize,
-      pollIntervalMS: blockCheckIntervalMS,
-    });
-
+    // REFACTOR: Try replacing these with an L2TipsStore
     this.synchedBlockHashes = store.openMap('p2p_pool_block_hashes');
     this.synchedLatestBlockNumber = store.openSingleton('p2p_pool_last_l2_block');
     this.synchedProvenBlockNumber = store.openSingleton('p2p_pool_last_proven_l2_block');
     this.synchedLatestSlot = store.openSingleton('p2p_pool_last_l2_slot');
-
-    this.txPool = mempools.txPool;
-    this.attestationPool = mempools.attestationPool!;
   }
 
   public isP2PClient(): true {
@@ -376,25 +190,54 @@ export class P2PClient<T extends P2PClientType = P2PClientType.Full>
     const syncedLatestBlock = (await this.getSyncedLatestBlockNum()) + 1;
     const syncedProvenBlock = (await this.getSyncedProvenBlockNum()) + 1;
 
-    // if there are blocks to be retrieved, go to a synching state
-    if (syncedLatestBlock <= this.latestBlockNumberAtStart || syncedProvenBlock <= this.provenBlockNumberAtStart) {
+    if (
+      (await this.txPool.isEmpty()) &&
+      (this.attestationPool === undefined || (await this.attestationPool?.isEmpty()))
+    ) {
+      // if mempools are empty, we don't care about syncing prior blocks
+      this.initBlockStream(this.latestBlockNumberAtStart);
+      this.setCurrentState(P2PClientState.RUNNING);
+      this.syncPromise = Promise.resolve();
+      await this.p2pService.start();
+      this.log.info(`Starting p2p client from block ${this.latestBlockNumberAtStart} with empty mempools`);
+    } else if (
+      syncedLatestBlock <= this.latestBlockNumberAtStart ||
+      syncedProvenBlock <= this.provenBlockNumberAtStart
+    ) {
+      // if there are blocks to be retrieved, go to a synching state
+      // this gets resolved on `startServiceIfSynched`
+      this.initBlockStream();
       this.setCurrentState(P2PClientState.SYNCHING);
       this.syncPromise = new Promise(resolve => {
         this.syncResolve = resolve;
       });
-      this.log.verbose(`Starting sync from ${syncedLatestBlock} (last proven ${syncedProvenBlock})`);
+      this.log.verbose(`Initiating p2p sync from ${syncedLatestBlock}`, { syncedLatestBlock, syncedProvenBlock });
     } else {
       // if no blocks to be retrieved, go straight to running
+      this.initBlockStream();
       this.setCurrentState(P2PClientState.RUNNING);
       this.syncPromise = Promise.resolve();
       await this.p2pService.start();
-      this.log.debug(`Block ${syncedLatestBlock} (proven ${syncedProvenBlock}) already beyond current block`);
+      this.log.info(`Starting P2P client synced to ${syncedLatestBlock}`, { syncedLatestBlock, syncedProvenBlock });
     }
 
-    this.blockStream.start();
-    this.log.verbose(`Started block downloader from block ${syncedLatestBlock}`);
-
+    this.blockStream!.start();
     return this.syncPromise;
+  }
+
+  private initBlockStream(startingBlock?: number) {
+    if (!this.blockStream) {
+      const { blockRequestBatchSize: batchSize, blockCheckIntervalMS: pollIntervalMS } = this.config;
+      this.blockStream = new TraceableL2BlockStream(
+        this.l2BlockSource,
+        this,
+        this,
+        this.telemetry.getTracer('P2PL2BlockStream'),
+        'P2PL2BlockStream',
+        createLogger('p2p:l2-block-stream'),
+        { batchSize, pollIntervalMS, startingBlock },
+      );
+    }
   }
 
   /**
@@ -405,7 +248,7 @@ export class P2PClient<T extends P2PClientType = P2PClientType.Full>
     this.log.debug('Stopping p2p client...');
     await this.p2pService.stop();
     this.log.debug('Stopped p2p service');
-    await this.blockStream.stop();
+    await this.blockStream?.stop();
     this.log.debug('Stopped block downloader');
     await this.runningPromise;
     this.setCurrentState(P2PClientState.STOPPED);
@@ -414,7 +257,8 @@ export class P2PClient<T extends P2PClientType = P2PClientType.Full>
 
   /** Triggers a sync to the archiver. Used for testing. */
   public async sync() {
-    await this.blockStream.sync();
+    this.initBlockStream();
+    await this.blockStream!.sync();
   }
 
   @trackSpan('p2pClient.broadcastProposal', async proposal => ({
@@ -769,23 +613,25 @@ export class P2PClient<T extends P2PClientType = P2PClientType.Full>
       return Promise.resolve();
     }
 
+    const { keepAttestationsInPoolFor, keepProvenTxsInPoolFor: keepProvenTxsFor } = this.config;
+
     const firstBlockNum = blocks[0].number;
     const lastBlockNum = blocks[blocks.length - 1].number;
     const lastBlockSlot = blocks[blocks.length - 1].header.globalVariables.slotNumber.toBigInt();
 
     // If keepProvenTxsFor is 0, we delete all txs from all proven blocks.
-    if (this.keepProvenTxsFor === 0) {
+    if (keepProvenTxsFor === 0) {
       await this.deleteTxsFromBlocks(blocks);
-    } else if (lastBlockNum - this.keepProvenTxsFor >= INITIAL_L2_BLOCK_NUM) {
-      const fromBlock = Math.max(INITIAL_L2_BLOCK_NUM, firstBlockNum - this.keepProvenTxsFor);
-      const toBlock = lastBlockNum - this.keepProvenTxsFor;
+    } else if (lastBlockNum - keepProvenTxsFor >= INITIAL_L2_BLOCK_NUM) {
+      const fromBlock = Math.max(INITIAL_L2_BLOCK_NUM, firstBlockNum - keepProvenTxsFor);
+      const toBlock = lastBlockNum - keepProvenTxsFor;
       const limit = toBlock - fromBlock + 1;
       const blocksToDeleteTxsFrom = await this.l2BlockSource.getBlocks(fromBlock, limit, true);
       await this.deleteTxsFromBlocks(blocksToDeleteTxsFrom);
     }
 
     // We delete attestations older than the last block slot minus the number of slots we want to keep in the pool.
-    const lastBlockSlotMinusKeepAttestationsInPoolFor = lastBlockSlot - BigInt(this.keepAttestationsInPoolFor);
+    const lastBlockSlotMinusKeepAttestationsInPoolFor = lastBlockSlot - BigInt(keepAttestationsInPoolFor);
     if (lastBlockSlotMinusKeepAttestationsInPoolFor >= BigInt(INITIAL_L2_BLOCK_NUM)) {
       await this.attestationPool?.deleteAttestationsOlderThan(lastBlockSlotMinusKeepAttestationsInPoolFor);
     }
@@ -851,12 +697,17 @@ export class P2PClient<T extends P2PClientType = P2PClientType.Full>
   }
 
   private async startServiceIfSynched() {
-    if (
-      this.currentState === P2PClientState.SYNCHING &&
-      (await this.getSyncedLatestBlockNum()) >= this.latestBlockNumberAtStart &&
-      (await this.getSyncedProvenBlockNum()) >= this.provenBlockNumberAtStart
-    ) {
-      this.log.debug(`Synched to blocks at start`);
+    if (this.currentState !== P2PClientState.SYNCHING) {
+      return;
+    }
+    const syncedProvenBlock = await this.getSyncedProvenBlockNum();
+    const syncedLatestBlock = await this.getSyncedLatestBlockNum();
+
+    if (syncedLatestBlock >= this.latestBlockNumberAtStart && syncedProvenBlock >= this.provenBlockNumberAtStart) {
+      this.log.info(`Completed P2P client sync to block ${syncedLatestBlock}. Starting service.`, {
+        syncedLatestBlock,
+        syncedProvenBlock,
+      });
       this.setCurrentState(P2PClientState.RUNNING);
       if (this.syncResolve !== undefined) {
         this.syncResolve();

--- a/yarn-project/p2p/src/mem_pools/attestation_pool/attestation_pool.ts
+++ b/yarn-project/p2p/src/mem_pools/attestation_pool/attestation_pool.ts
@@ -69,4 +69,7 @@ export interface AttestationPool {
    * @return BlockAttestations
    */
   getAttestationsForSlotAndProposal(slot: bigint, proposalId: string): Promise<BlockAttestation[]>;
+
+  /** Returns whether the pool is empty. */
+  isEmpty(): Promise<boolean>;
 }

--- a/yarn-project/p2p/src/mem_pools/attestation_pool/kv_attestation_pool.ts
+++ b/yarn-project/p2p/src/mem_pools/attestation_pool/kv_attestation_pool.ts
@@ -27,6 +27,13 @@ export class KvAttestationPool implements AttestationPool {
     this.metrics = new PoolInstrumentation(telemetry, PoolName.ATTESTATION_POOL);
   }
 
+  public async isEmpty(): Promise<boolean> {
+    for await (const _ of this.attestations.entriesAsync()) {
+      return false;
+    }
+    return true;
+  }
+
   private getProposalKey(slot: number | bigint | Fr | string, proposalId: Fr | string | Buffer): string {
     const slotStr = typeof slot === 'string' ? slot : new Fr(slot).toString();
     const proposalIdStr =

--- a/yarn-project/p2p/src/mem_pools/attestation_pool/memory_attestation_pool.ts
+++ b/yarn-project/p2p/src/mem_pools/attestation_pool/memory_attestation_pool.ts
@@ -15,6 +15,10 @@ export class InMemoryAttestationPool implements AttestationPool {
     this.metrics = new PoolInstrumentation(telemetry, PoolName.ATTESTATION_POOL);
   }
 
+  public isEmpty(): Promise<boolean> {
+    return Promise.resolve(this.attestations.size === 0);
+  }
+
   public getAttestationsForSlot(slot: bigint): Promise<BlockAttestation[]> {
     return Promise.resolve(
       Array.from(this.attestations.get(slot)?.values() ?? []).flatMap(proposalAttestationMap =>

--- a/yarn-project/p2p/src/mem_pools/tx_pool/aztec_kv_tx_pool.ts
+++ b/yarn-project/p2p/src/mem_pools/tx_pool/aztec_kv_tx_pool.ts
@@ -105,6 +105,13 @@ export class AztecKVTxPool implements TxPool {
     this.#metrics = new PoolInstrumentation(telemetry, PoolName.TX_POOL, () => store.estimateSize());
   }
 
+  public async isEmpty(): Promise<boolean> {
+    for await (const _ of this.#txs.entriesAsync()) {
+      return false;
+    }
+    return true;
+  }
+
   public markAsMined(txHashes: TxHash[], blockNumber: number): Promise<void> {
     if (txHashes.length === 0) {
       return Promise.resolve();

--- a/yarn-project/p2p/src/mem_pools/tx_pool/memory_tx_pool.ts
+++ b/yarn-project/p2p/src/mem_pools/tx_pool/memory_tx_pool.ts
@@ -31,6 +31,10 @@ export class InMemoryTxPool implements TxPool {
     this.metrics = new PoolInstrumentation(telemetry, PoolName.TX_POOL);
   }
 
+  public isEmpty(): Promise<boolean> {
+    return Promise.resolve(this.txs.size === 0);
+  }
+
   public markAsMined(txHashes: TxHash[], blockNumber: number): Promise<void> {
     const keys = txHashes.map(x => x.toBigInt());
     for (const key of keys) {

--- a/yarn-project/p2p/src/mem_pools/tx_pool/tx_pool.ts
+++ b/yarn-project/p2p/src/mem_pools/tx_pool/tx_pool.ts
@@ -93,4 +93,7 @@ export interface TxPool {
    * @param maxSizeBytes - The maximum size in bytes of the mempool. Set to undefined to disable it
    */
   setMaxTxPoolSize(maxSizeBytes: number | undefined): Promise<void>;
+
+  /** Returns whether the pool is empty. */
+  isEmpty(): Promise<boolean>;
 }

--- a/yarn-project/p2p/src/testbench/p2p_client_testbench_worker.ts
+++ b/yarn-project/p2p/src/testbench/p2p_client_testbench_worker.ts
@@ -34,6 +34,7 @@ import type { PubSubLibp2p } from '../util.js';
 function mockTxPool(): TxPool {
   // Mock all methods
   return {
+    isEmpty: () => Promise.resolve(false),
     addTxs: () => Promise.resolve(),
     getTxByHash: () => Promise.resolve(undefined),
     getArchivedTxByHash: () => Promise.resolve(undefined),
@@ -53,6 +54,7 @@ function mockTxPool(): TxPool {
 
 function mockAttestationPool(): AttestationPool {
   return {
+    isEmpty: () => Promise.resolve(false),
     addAttestations: () => Promise.resolve(),
     deleteAttestations: () => Promise.resolve(),
     deleteAttestationsOlderThan: () => Promise.resolve(),


### PR DESCRIPTION
Tested against a cherry-pick of this PR against `alpha-testnet` and running a node from scratch. Node downloads world-state and archiver snapshots, syncs archiver and world-state for the remaining blocks, and then skips any p2p sync:

```
[18:05:10.531] INFO: p2p:libp2p_service Started P2P service {"listen":"0.0.0.0","port":40400,"announce":"/ip4/152.170.117.29/tcp/40400","peerId":"16Uiu2HAm7BZDiwQ5ZwCvVo5Ztufce9ddP5NYios4RJc2nqvJ4nwV"}
[18:05:10.531] INFO: p2p Starting p2p client from block 10986 with empty mempools
[18:05:10.531] VERBOSE: p2p:l2-block-stream Starting L2 block stream {"batchSize":20,"pollIntervalMS":100,"startingBlock":10986}
```

Fixes #13603