### PR TITLE
chore: Fetch rollup address using version as index

### DIFF
--- a/yarn-project/ethereum/src/contracts/registry.test.ts
+++ b/yarn-project/ethereum/src/contracts/registry.test.ts
@@ -81,6 +81,10 @@ describe('Registry', () => {
       const address = await registry.getRollupAddress(deployedVersion);
       expect(address).toEqual(rollupAddress);
     }
+    {
+      const address = await registry.getRollupAddress(0);
+      expect(address).toEqual(rollupAddress);
+    }
   });
 
   it('handles non-existent versions', async () => {

--- a/yarn-project/ethereum/src/contracts/registry.ts
+++ b/yarn-project/ethereum/src/contracts/registry.ts
@@ -1,4 +1,5 @@
 import { EthAddress } from '@aztec/foundation/eth-address';
+import { createLogger } from '@aztec/foundation/log';
 import { RegistryAbi } from '@aztec/l1-artifacts/RegistryAbi';
 import { TestERC20Abi } from '@aztec/l1-artifacts/TestERC20Abi';
 
@@ -18,6 +19,8 @@ import { RollupContract } from './rollup.js';
 
 export class RegistryContract {
   public address: EthAddress;
+
+  private readonly log = createLogger('ethereum:contracts:registry');
   private readonly registry: GetContractReturnType<typeof RegistryAbi, PublicClient<HttpTransport, Chain>>;
 
   constructor(public readonly client: L1Clients['publicClient'], address: Hex | EthAddress) {
@@ -44,6 +47,14 @@ export class RegistryContract {
 
     try {
       return EthAddress.fromString(await this.registry.read.getRollup([version]));
+    } catch (e) {
+      this.log.warn(`Failed fetching rollup address for version ${version}. Retrying as index.`);
+    }
+
+    try {
+      const actualVersion = await this.registry.read.getVersion([version]);
+      const rollupAddress = await this.registry.read.getRollup([actualVersion]);
+      return EthAddress.fromString(rollupAddress);
     } catch (e) {
       throw new Error('Rollup address is undefined');
     }


### PR DESCRIPTION
If fetching the rollup address given a version identifier fails, it tries again using it as an index instead.