### PR TITLE
chore: Re-enable mock root rollup circuit in rollup_ivc_integration test

### DIFF
--- a/yarn-project/ivc-integration/src/rollup_ivc_integration.test.ts
+++ b/yarn-project/ivc-integration/src/rollup_ivc_integration.test.ts
@@ -194,5 +194,5 @@ describe('Rollup IVC Integration', () => {
       rootWitnessResult.witness,
       logger,
     );
-  }, 400_000);
+  }, 550_000);
 });

--- a/yarn-project/ivc-integration/src/rollup_ivc_integration.test.ts
+++ b/yarn-project/ivc-integration/src/rollup_ivc_integration.test.ts
@@ -17,6 +17,7 @@ import {
   MockRollupBasePrivateCircuit,
   MockRollupBasePublicCircuit,
   MockRollupMergeCircuit,
+  MockRollupRootCircuit,
   generate3FunctionTestingIVCStack,
   mapAvmProofToNoir,
   mapAvmPublicInputsToNoir,
@@ -29,7 +30,7 @@ import {
   witnessGenMockRollupMergeCircuit,
   witnessGenMockRollupRootCircuit,
 } from './index.js';
-import { proveAvm, proveClientIVC, proveRollupHonk, proveTube } from './prove_native.js';
+import { proveAvm, proveClientIVC, proveKeccakHonk, proveRollupHonk, proveTube } from './prove_native.js';
 import type { KernelPublicInputs } from './types/index.js';
 
 /* eslint-disable camelcase */
@@ -182,15 +183,16 @@ describe('Rollup IVC Integration', () => {
     // Three transactions are aggregated
     expect(rootWitnessResult.publicInputs.accumulated).toEqual('0x03');
 
-    // This step takes something like 4 minutes, since it needs to actually prove and remove the IPA claims.
-    // Commenting it out for now due to CI speed issues.
-    // await proveKeccakHonk(
-    //   'MockRollupRootCircuit',
-    //   bbBinaryPath,
-    //   workingDirectory,
-    //   MockRollupRootCircuit,
-    //   rootWitnessResult.witness,
-    //   logger,
-    // );
-  }, 300_000);
+    // This step takes something like 4 minutes, but is required to properly test the integration
+    // of the AVM recursive verifier in the protocol. Namely, the AVM recursive verifier and
+    // other circuits generate some IPA claims whose validation is deferred to the root rollup.
+    await proveKeccakHonk(
+      'MockRollupRootCircuit',
+      bbBinaryPath,
+      workingDirectory,
+      MockRollupRootCircuit,
+      rootWitnessResult.witness,
+      logger,
+    );
+  }, 400_000);
 });


### PR DESCRIPTION
This test is crucial for sanity checking the integration of the avm recursive verifier in the protocol.
It executes the chain of circuit proving on mock circuits in a similar way as with the protocol circuits. Namely, the mock rollup base public circuit is verifying a tube proof and an AVM proof. Then, a merge mock circuit will merge a private with public mock rollup proofs. Finally, the mock root rollup will validate IPA claims which were deferred by the other circuits such as the AVM recursive verifier. The latter is therefore crucial to be enabled as part of this test in order to confirm that the mechanisms underpinning the integration of the avm recursive verifier are correctly working.

Some measurements on mainframe (not ci) of running time of this test:

master: 110 seconds
PR:        298 seconds

It bumps running time to about 3 minutes (from 2 min. to 5 min.).

On CI runner, it took 512 seconds with this PR while master was 153 seconds.

