### PR TITLE
fix: prover-node start

### DIFF
--- a/spartan/aztec-network/templates/prover-node.yaml
+++ b/spartan/aztec-network/templates/prover-node.yaml
@@ -77,14 +77,16 @@ spec:
             - /bin/bash
             - -c
             - |
-              source /shared/config/service-addresses && \
-              source /scripts/configure-prover-env.sh ${BOOT_NODE_HOST} && \
-              source /scripts/get-private-key.sh && \
-              source /shared/config/keys.env && \
-              source /shared/contracts/contracts.env && \
-              source /shared/config/p2p-addresses && \
-              source /shared/config/otel-resource && \
-              env && \
+              source /shared/config/service-addresses
+              /scripts/configure-prover-env.sh ${BOOT_NODE_HOST:-}
+              source /scripts/get-private-key.sh
+              source /shared/config/keys.env
+              source /shared/contracts/contracts.env
+              source /shared/config/p2p-addresses
+              source /shared/config/otel-resource
+
+              env
+
               node --no-warnings /usr/src/yarn-project/aztec/dest/bin/index.js start --prover-node --archiver
           volumeMounts:
             - name: contracts-env


### PR DESCRIPTION
`source` was having trouble with the passed argument to `config-prover-env.sh`
