### PR TITLE
chore: Sanity check block number from archiver before returning it

### DIFF
--- a/yarn-project/stdlib/src/block/l2_block.ts
+++ b/yarn-project/stdlib/src/block/l2_block.ts
@@ -106,7 +106,7 @@ export class L2Block {
   }
 
   get number(): number {
-    return Number(this.header.globalVariables.blockNumber.toBigInt());
+    return this.header.getBlockNumber();
   }
 
   /**

--- a/yarn-project/stdlib/src/tx/block_header.ts
+++ b/yarn-project/stdlib/src/tx/block_header.ts
@@ -64,6 +64,10 @@ export class BlockHeader {
     return this.globalVariables.slotNumber.toBigInt();
   }
 
+  getBlockNumber(): number {
+    return Number(this.globalVariables.blockNumber.toBigInt());
+  }
+
   getSize() {
     return (
       this.lastArchive.getSize() +


### PR DESCRIPTION
We have seen an archiver that stored blocks under the wrong block number, which caused errors in other components. This adds a sanity check before returning them.