### PR TITLE
chore: remove pcs vk from vk

### DIFF
--- a/barretenberg/cpp/src/barretenberg/api/api_client_ivc.cpp
+++ b/barretenberg/cpp/src/barretenberg/api/api_client_ivc.cpp
@@ -301,9 +301,6 @@ bool ClientIVCAPI::verify([[maybe_unused]] const Flags& flags,
     const auto proof = ClientIVC::Proof::from_file_msgpack(proof_path);
     const auto vk = from_buffer<ClientIVC::VerificationKey>(read_file(vk_path));
 
-    // TODO(https://github.com/AztecProtocol/barretenberg/issues/1335): Should be able to remove this.
-    vk.mega->pcs_verification_key = std::make_shared<VerifierCommitmentKey<curve::BN254>>();
-
     const bool verified = ClientIVC::verify(proof, vk);
     return verified;
 }

--- a/barretenberg/cpp/src/barretenberg/api/api_ultra_honk.cpp
+++ b/barretenberg/cpp/src/barretenberg/api/api_ultra_honk.cpp
@@ -110,7 +110,6 @@ bool _verify(const bool ipa_accumulation,
     srs::init_crs_factory({}, g2_data);
 
     auto vk = std::make_shared<VerificationKey>(from_buffer<VerificationKey>(read_file(vk_path)));
-    vk->pcs_verification_key = std::make_shared<VerifierCommitmentKey<curve::BN254>>();
     auto public_inputs = many_from_buffer<bb::fr>(read_file(public_inputs_path));
     auto proof = many_from_buffer<bb::fr>(read_file(proof_path));
     // concatenate public inputs and proof

--- a/barretenberg/cpp/src/barretenberg/client_ivc/client_ivc.test.cpp
+++ b/barretenberg/cpp/src/barretenberg/client_ivc/client_ivc.test.cpp
@@ -314,9 +314,7 @@ TEST_F(ClientIVCTests, VKIndependenceTest)
         auto ivc_vk = ivc.get_vk();
 
         // PCS verification keys will not match so set to null before comparing
-        ivc_vk.mega->pcs_verification_key = nullptr;
         ivc_vk.eccvm->pcs_verification_key = nullptr;
-        ivc_vk.translator->pcs_verification_key = nullptr;
 
         return ivc_vk;
     };

--- a/barretenberg/cpp/src/barretenberg/dsl/acir_format/avm2_recursion_constraint.test.cpp
+++ b/barretenberg/cpp/src/barretenberg/dsl/acir_format/avm2_recursion_constraint.test.cpp
@@ -193,10 +193,6 @@ TEST_F(AcirAvm2RecursionConstraint, TestGenerateVKFromConstraintsWithoutWitness)
         actual_vk = std::make_shared<OuterVerificationKey>(prover.proving_key->proving_key);
     }
 
-    // PCS verification key adresses will in general not match so set to null before comparing
-    expected_vk->pcs_verification_key = nullptr;
-    actual_vk->pcs_verification_key = nullptr;
-
     // Compare the VK constructed via running the IVC with the one constructed via mocking
     EXPECT_EQ(*actual_vk.get(), *expected_vk.get());
 }

--- a/barretenberg/cpp/src/barretenberg/dsl/acir_format/ivc_recursion_constraint.test.cpp
+++ b/barretenberg/cpp/src/barretenberg/dsl/acir_format/ivc_recursion_constraint.test.cpp
@@ -316,10 +316,6 @@ TEST_F(IvcRecursionConstraintTest, GenerateVK)
         kernel_vk = std::make_shared<MegaFlavor::VerificationKey>(prover.proving_key->proving_key);
     }
 
-    // PCS verification keys will not match so set to null before comparing
-    kernel_vk->pcs_verification_key = nullptr;
-    expected_kernel_vk->pcs_verification_key = nullptr;
-
     EXPECT_EQ(*kernel_vk.get(), *expected_kernel_vk.get());
 }
 
@@ -357,10 +353,6 @@ TEST_F(IvcRecursionConstraintTest, GenerateInitKernelVKFromConstraints)
 
         kernel_vk = construct_kernel_vk_from_acir_program(program, trace_settings);
     }
-
-    // PCS verification keys will not match so set to null before comparing
-    kernel_vk->pcs_verification_key = nullptr;
-    expected_kernel_vk->pcs_verification_key = nullptr;
 
     // Compare the VK constructed via running the IVc with the one constructed via mocking
     EXPECT_EQ(*kernel_vk.get(), *expected_kernel_vk.get());
@@ -410,10 +402,6 @@ TEST_F(IvcRecursionConstraintTest, GenerateResetKernelVKFromConstraints)
 
         kernel_vk = construct_kernel_vk_from_acir_program(program, trace_settings);
     }
-
-    // PCS verification keys will not match so set to null before comparing
-    kernel_vk->pcs_verification_key = nullptr;
-    expected_kernel_vk->pcs_verification_key = nullptr;
 
     // Compare the VK constructed via running the IVc with the one constructed via mocking
     EXPECT_EQ(*kernel_vk.get(), *expected_kernel_vk.get());
@@ -471,10 +459,6 @@ TEST_F(IvcRecursionConstraintTest, GenerateInnerKernelVKFromConstraints)
 
         kernel_vk = construct_kernel_vk_from_acir_program(program, trace_settings);
     }
-
-    // PCS verification keys will not match so set to null before comparing
-    kernel_vk->pcs_verification_key = nullptr;
-    expected_kernel_vk->pcs_verification_key = nullptr;
 
     // Compare the VK constructed via running the IVc with the one constructed via mocking
     EXPECT_EQ(*kernel_vk.get(), *expected_kernel_vk.get());

--- a/barretenberg/cpp/src/barretenberg/dsl/acir_proofs/c_bind.cpp
+++ b/barretenberg/cpp/src/barretenberg/dsl/acir_proofs/c_bind.cpp
@@ -293,9 +293,6 @@ WASM_EXPORT void acir_verify_aztec_client(uint8_t const* proof_buf, uint8_t cons
     const auto proof = ClientIVC::Proof::from_msgpack_buffer(proof_buf);
     const auto vk = from_buffer<ClientIVC::VerificationKey>(from_buffer<std::vector<uint8_t>>(vk_buf));
 
-    // TODO(https://github.com/AztecProtocol/barretenberg/issues/1335): Should be able to remove this.
-    vk.mega->pcs_verification_key = std::make_shared<VerifierCommitmentKey<curve::BN254>>();
-
     *result = ClientIVC::verify(proof, vk);
 }
 
@@ -337,12 +334,10 @@ WASM_EXPORT void acir_prove_ultra_keccak_honk(uint8_t const* acir_vec, uint8_t c
 WASM_EXPORT void acir_verify_ultra_honk(uint8_t const* proof_buf, uint8_t const* vk_buf, bool* result)
 {
     using VerificationKey = UltraFlavor::VerificationKey;
-    using VerifierCommitmentKey = bb::VerifierCommitmentKey<curve::BN254>;
     using Verifier = UltraVerifier_<UltraFlavor>;
 
     auto proof = many_from_buffer<bb::fr>(from_buffer<std::vector<uint8_t>>(proof_buf));
     auto verification_key = std::make_shared<VerificationKey>(from_buffer<VerificationKey>(vk_buf));
-    verification_key->pcs_verification_key = std::make_shared<VerifierCommitmentKey>();
 
     Verifier verifier{ verification_key };
 
@@ -352,12 +347,10 @@ WASM_EXPORT void acir_verify_ultra_honk(uint8_t const* proof_buf, uint8_t const*
 WASM_EXPORT void acir_verify_ultra_keccak_honk(uint8_t const* proof_buf, uint8_t const* vk_buf, bool* result)
 {
     using VerificationKey = UltraKeccakFlavor::VerificationKey;
-    using VerifierCommitmentKey = bb::VerifierCommitmentKey<curve::BN254>;
     using Verifier = UltraVerifier_<UltraKeccakFlavor>;
 
     auto proof = many_from_buffer<bb::fr>(from_buffer<std::vector<uint8_t>>(proof_buf));
     auto verification_key = std::make_shared<VerificationKey>(from_buffer<VerificationKey>(vk_buf));
-    verification_key->pcs_verification_key = std::make_shared<VerifierCommitmentKey>();
 
     Verifier verifier{ verification_key };
 
@@ -402,11 +395,9 @@ WASM_EXPORT void acir_write_vk_ultra_keccak_honk(uint8_t const* acir_vec, uint8_
 WASM_EXPORT void acir_honk_solidity_verifier(uint8_t const* proof_buf, uint8_t const* vk_buf, uint8_t** out)
 {
     using VerificationKey = UltraKeccakFlavor::VerificationKey;
-    using VerifierCommitmentKey = bb::VerifierCommitmentKey<curve::BN254>;
 
     auto proof = many_from_buffer<bb::fr>(from_buffer<std::vector<uint8_t>>(proof_buf));
     auto verification_key = from_buffer<VerificationKey>(vk_buf);
-    verification_key.pcs_verification_key = std::make_shared<VerifierCommitmentKey>();
 
     auto str = get_honk_solidity_verifier(&verification_key);
     *out = to_heap_buffer(str);

--- a/barretenberg/cpp/src/barretenberg/eccvm/eccvm_flavor.hpp
+++ b/barretenberg/cpp/src/barretenberg/eccvm/eccvm_flavor.hpp
@@ -750,15 +750,15 @@ class ECCVMFlavor {
       public:
         bool operator==(const VerificationKey&) const = default;
 
+        // IPA verification key requires one more point.
+        std::shared_ptr<VerifierCommitmentKey> pcs_verification_key =
+            std::make_shared<VerifierCommitmentKey>(ECCVM_FIXED_SIZE + 1);
+
         // Default construct the fixed VK that results from ECCVM_FIXED_SIZE
         VerificationKey()
             : VerificationKey_(ECCVM_FIXED_SIZE, /*num_public_inputs=*/0)
         {
             this->pub_inputs_offset = 0;
-            // IPA verification key requires one more point.
-            // TODO(https://github.com/AztecProtocol/barretenberg/issues/1025): make it so that PCSs inform the crs of
-            // how many points they need
-            this->pcs_verification_key = std::make_shared<VerifierCommitmentKey>(ECCVM_FIXED_SIZE + 1);
 
             // Populate the commitments of the precomputed polynomials using the fixed VK data
             for (auto [vk_commitment, fixed_commitment] :
@@ -773,10 +773,6 @@ class ECCVMFlavor {
 
         VerificationKey(const std::shared_ptr<ProvingKey>& proving_key)
         {
-            // IPA verification key requires one more point.
-            // TODO(https://github.com/AztecProtocol/barretenberg/issues/1025): make it so that PCSs inform the crs of
-            // how many points they need
-            this->pcs_verification_key = std::make_shared<VerifierCommitmentKey>(ECCVM_FIXED_SIZE + 1);
             this->circuit_size = 1UL << CONST_ECCVM_LOG_N;
             this->log_circuit_size = CONST_ECCVM_LOG_N;
             this->num_public_inputs = proving_key->num_public_inputs;

--- a/barretenberg/cpp/src/barretenberg/flavor/flavor.hpp
+++ b/barretenberg/cpp/src/barretenberg/flavor/flavor.hpp
@@ -163,7 +163,6 @@ class VerificationKey_ : public PrecomputedCommitments {
   public:
     using FF = typename VerifierCommitmentKey::Curve::ScalarField;
     using Commitment = typename VerifierCommitmentKey::Commitment;
-    std::shared_ptr<VerifierCommitmentKey> pcs_verification_key;
     FF_ circuit_size;
     FF_ log_circuit_size;
     FF_ num_public_inputs;

--- a/barretenberg/cpp/src/barretenberg/stdlib/eccvm_verifier/eccvm_recursive_flavor.hpp
+++ b/barretenberg/cpp/src/barretenberg/stdlib/eccvm_verifier/eccvm_recursive_flavor.hpp
@@ -92,6 +92,9 @@ template <typename BuilderType> class ECCVMRecursiveFlavor_ {
     class VerificationKey
         : public VerificationKey_<FF, ECCVMFlavor::PrecomputedEntities<Commitment>, VerifierCommitmentKey> {
       public:
+        // IPA verification key requires one more point.
+        std::shared_ptr<VerifierCommitmentKey> pcs_verification_key;
+
         /**
          * @brief Construct a new Verification Key with stdlib types from a provided native verification
          * key
@@ -99,10 +102,9 @@ template <typename BuilderType> class ECCVMRecursiveFlavor_ {
          * @param builder
          * @param native_key Native verification key from which to extract the precomputed commitments
          */
-
         VerificationKey(CircuitBuilder* builder, const std::shared_ptr<NativeVerificationKey>& native_key)
         {
-            this->pcs_verification_key = std::make_shared<VerifierCommitmentKey>(
+            pcs_verification_key = std::make_shared<VerifierCommitmentKey>(
                 builder, 1UL << CONST_ECCVM_LOG_N, native_key->pcs_verification_key);
             // TODO(https://github.com/AztecProtocol/barretenberg/issues/1324): Remove `circuit_size` and
             // `log_circuit_size` from MSGPACK and the verification key.

--- a/barretenberg/cpp/src/barretenberg/stdlib/eccvm_verifier/eccvm_recursive_flavor.hpp
+++ b/barretenberg/cpp/src/barretenberg/stdlib/eccvm_verifier/eccvm_recursive_flavor.hpp
@@ -92,7 +92,6 @@ template <typename BuilderType> class ECCVMRecursiveFlavor_ {
     class VerificationKey
         : public VerificationKey_<FF, ECCVMFlavor::PrecomputedEntities<Commitment>, VerifierCommitmentKey> {
       public:
-        // IPA verification key requires one more point.
         std::shared_ptr<VerifierCommitmentKey> pcs_verification_key;
 
         /**

--- a/barretenberg/cpp/src/barretenberg/stdlib/honk_verifier/ultra_recursive_verifier.test.cpp
+++ b/barretenberg/cpp/src/barretenberg/stdlib/honk_verifier/ultra_recursive_verifier.test.cpp
@@ -223,11 +223,10 @@ template <typename RecursiveFlavor> class RecursiveVerifierTest : public testing
         } else {
             native_result = native_verifier.verify_proof(inner_proof);
         }
-        auto pcs_verification_key = std::make_shared<typename InnerFlavor::VerifierCommitmentKey>();
-        bool result = pcs_verification_key->pairing_check(pairing_points.P0.get_value(), pairing_points.P1.get_value());
+        auto pcs_vkey = std::make_shared<typename InnerFlavor::VerifierCommitmentKey>();
+        bool result = pcs_vkey->pairing_check(pairing_points.P0.get_value(), pairing_points.P1.get_value());
         info("input pairing points result: ", result);
-        auto recursive_result = native_verifier.verification_key->verification_key->pcs_verification_key->pairing_check(
-            pairing_points.P0.get_value(), pairing_points.P1.get_value());
+        auto recursive_result = pcs_vkey->pairing_check(pairing_points.P0.get_value(), pairing_points.P1.get_value());
         EXPECT_EQ(recursive_result, native_result);
 
         // Check 2: Ensure that the underlying native and recursive verification algorithms agree by ensuring
@@ -292,10 +291,9 @@ template <typename RecursiveFlavor> class RecursiveVerifierTest : public testing
                 EXPECT_FALSE(CircuitChecker::check(outer_circuit));
             } else {
                 EXPECT_TRUE(CircuitChecker::check(outer_circuit));
-                auto pcs_verification_key = std::make_shared<typename InnerFlavor::VerifierCommitmentKey>();
+                auto pcs_vkey = std::make_shared<typename InnerFlavor::VerifierCommitmentKey>();
                 AggState pairing_points = output.agg_obj;
-                bool result =
-                    pcs_verification_key->pairing_check(pairing_points.P0.get_value(), pairing_points.P1.get_value());
+                bool result = pcs_vkey->pairing_check(pairing_points.P0.get_value(), pairing_points.P1.get_value());
                 EXPECT_FALSE(result);
             }
         }

--- a/barretenberg/cpp/src/barretenberg/stdlib/honk_verifier/ultra_recursive_verifier.test.cpp
+++ b/barretenberg/cpp/src/barretenberg/stdlib/honk_verifier/ultra_recursive_verifier.test.cpp
@@ -45,6 +45,7 @@ template <typename RecursiveFlavor> class RecursiveVerifierTest : public testing
 
     using AggState = aggregation_state<OuterBuilder>;
     using VerifierOutput = bb::stdlib::recursion::honk::UltraRecursiveVerifierOutput<OuterBuilder>;
+    using NativeVerifierCommitmentKey = typename InnerFlavor::VerifierCommitmentKey;
     /**
      * @brief Create a non-trivial arbitrary inner circuit, the proof of which will be recursively verified
      *
@@ -223,10 +224,10 @@ template <typename RecursiveFlavor> class RecursiveVerifierTest : public testing
         } else {
             native_result = native_verifier.verify_proof(inner_proof);
         }
-        auto pcs_vkey = std::make_shared<typename InnerFlavor::VerifierCommitmentKey>();
-        bool result = pcs_vkey->pairing_check(pairing_points.P0.get_value(), pairing_points.P1.get_value());
+        NativeVerifierCommitmentKey pcs_vkey{};
+        bool result = pcs_vkey.pairing_check(pairing_points.P0.get_value(), pairing_points.P1.get_value());
         info("input pairing points result: ", result);
-        auto recursive_result = pcs_vkey->pairing_check(pairing_points.P0.get_value(), pairing_points.P1.get_value());
+        auto recursive_result = pcs_vkey.pairing_check(pairing_points.P0.get_value(), pairing_points.P1.get_value());
         EXPECT_EQ(recursive_result, native_result);
 
         // Check 2: Ensure that the underlying native and recursive verification algorithms agree by ensuring
@@ -291,9 +292,9 @@ template <typename RecursiveFlavor> class RecursiveVerifierTest : public testing
                 EXPECT_FALSE(CircuitChecker::check(outer_circuit));
             } else {
                 EXPECT_TRUE(CircuitChecker::check(outer_circuit));
-                auto pcs_vkey = std::make_shared<typename InnerFlavor::VerifierCommitmentKey>();
+                NativeVerifierCommitmentKey pcs_vkey{};
                 AggState pairing_points = output.agg_obj;
-                bool result = pcs_vkey->pairing_check(pairing_points.P0.get_value(), pairing_points.P1.get_value());
+                bool result = pcs_vkey.pairing_check(pairing_points.P0.get_value(), pairing_points.P1.get_value());
                 EXPECT_FALSE(result);
             }
         }

--- a/barretenberg/cpp/src/barretenberg/stdlib/protogalaxy_verifier/protogalaxy_recursive_verifier.test.cpp
+++ b/barretenberg/cpp/src/barretenberg/stdlib/protogalaxy_verifier/protogalaxy_recursive_verifier.test.cpp
@@ -269,6 +269,7 @@ template <typename RecursiveFlavor> class ProtogalaxyRecursiveTests : public tes
      */
     static void test_full_protogalaxy_recursive()
     {
+        using NativeVerifierCommitmentKey = typename InnerFlavor::VerifierCommitmentKey;
         // Create two arbitrary circuits for the first round of folding
         InnerBuilder builder1;
         create_function_circuit(builder1);
@@ -335,8 +336,8 @@ template <typename RecursiveFlavor> class ProtogalaxyRecursiveTests : public tes
         // check that the result agrees.
         InnerDeciderVerifier native_decider_verifier(verifier_accumulator);
         auto native_result = native_decider_verifier.verify_proof(decider_proof);
-        auto pcs_vkey = std::make_shared<typename InnerFlavor::VerifierCommitmentKey>();
-        auto recursive_result = pcs_vkey->pairing_check(pairing_points.P0.get_value(), pairing_points.P1.get_value());
+        NativeVerifierCommitmentKey pcs_vkey{};
+        auto recursive_result = pcs_vkey.pairing_check(pairing_points.P0.get_value(), pairing_points.P1.get_value());
         EXPECT_EQ(native_result, recursive_result);
 
         if constexpr (!IsSimulator<OuterBuilder>) {

--- a/barretenberg/cpp/src/barretenberg/stdlib/protogalaxy_verifier/protogalaxy_recursive_verifier.test.cpp
+++ b/barretenberg/cpp/src/barretenberg/stdlib/protogalaxy_verifier/protogalaxy_recursive_verifier.test.cpp
@@ -335,9 +335,8 @@ template <typename RecursiveFlavor> class ProtogalaxyRecursiveTests : public tes
         // check that the result agrees.
         InnerDeciderVerifier native_decider_verifier(verifier_accumulator);
         auto native_result = native_decider_verifier.verify_proof(decider_proof);
-        auto recursive_result =
-            native_decider_verifier.accumulator->verification_key->pcs_verification_key->pairing_check(
-                pairing_points.P0.get_value(), pairing_points.P1.get_value());
+        auto pcs_vkey = std::make_shared<typename InnerFlavor::VerifierCommitmentKey>();
+        auto recursive_result = pcs_vkey->pairing_check(pairing_points.P0.get_value(), pairing_points.P1.get_value());
         EXPECT_EQ(native_result, recursive_result);
 
         if constexpr (!IsSimulator<OuterBuilder>) {

--- a/barretenberg/cpp/src/barretenberg/stdlib/protogalaxy_verifier/recursive_decider_verification_key.hpp
+++ b/barretenberg/cpp/src/barretenberg/stdlib/protogalaxy_verifier/recursive_decider_verification_key.hpp
@@ -103,9 +103,6 @@ template <IsRecursiveFlavor Flavor> class RecursiveDeciderVerificationKey_ {
         auto native_honk_vk = std::make_shared<NativeVerificationKey>(
             static_cast<uint64_t>(verification_key->circuit_size.get_value()),
             static_cast<uint64_t>(verification_key->num_public_inputs.get_value()));
-        native_honk_vk->pcs_verification_key = verification_key->pcs_verification_key == nullptr
-                                                   ? std::make_shared<VerifierCommitmentKey>()
-                                                   : verification_key->pcs_verification_key;
         native_honk_vk->pub_inputs_offset = static_cast<uint64_t>(verification_key->pub_inputs_offset.get_value());
         native_honk_vk->contains_pairing_point_accumulator = verification_key->contains_pairing_point_accumulator;
         native_honk_vk->pairing_point_accumulator_public_input_indices =

--- a/barretenberg/cpp/src/barretenberg/stdlib/translator_vm_verifier/translator_recursive_flavor.hpp
+++ b/barretenberg/cpp/src/barretenberg/stdlib/translator_vm_verifier/translator_recursive_flavor.hpp
@@ -99,7 +99,6 @@ template <typename BuilderType> class TranslatorRecursiveFlavor_ {
       public:
         VerificationKey(CircuitBuilder* builder, const std::shared_ptr<NativeVerificationKey>& native_key)
         {
-            this->pcs_verification_key = std::make_shared<VerifierCommitmentKey>(); // ?
             // TODO(https://github.com/AztecProtocol/barretenberg/issues/1324): Remove `circuit_size` and
             // `log_circuit_size` from MSGPACK and the verification key.
             this->circuit_size = FF{ 1UL << TranslatorFlavor::CONST_TRANSLATOR_LOG_N };

--- a/barretenberg/cpp/src/barretenberg/stdlib/translator_vm_verifier/translator_recursive_verifier.test.cpp
+++ b/barretenberg/cpp/src/barretenberg/stdlib/translator_vm_verifier/translator_recursive_verifier.test.cpp
@@ -97,8 +97,8 @@ template <typename RecursiveFlavor> class TranslatorRecursiveTests : public ::te
         native_verifier_transcript->template receive_from_prover<InnerBF>("init");
         InnerVerifier native_verifier(verification_key, native_verifier_transcript);
         bool native_result = native_verifier.verify_proof(proof, evaluation_challenge_x, batching_challenge_v);
-        auto recursive_result = native_verifier.key->pcs_verification_key->pairing_check(pairing_points.P0.get_value(),
-                                                                                         pairing_points.P1.get_value());
+        auto pcs_vkey = std::make_shared<typename InnerFlavor::VerifierCommitmentKey>();
+        auto recursive_result = pcs_vkey->pairing_check(pairing_points.P0.get_value(), pairing_points.P1.get_value());
         EXPECT_EQ(recursive_result, native_result);
 
         auto recursive_manifest = verifier.transcript->get_manifest();

--- a/barretenberg/cpp/src/barretenberg/stdlib/translator_vm_verifier/translator_recursive_verifier.test.cpp
+++ b/barretenberg/cpp/src/barretenberg/stdlib/translator_vm_verifier/translator_recursive_verifier.test.cpp
@@ -61,6 +61,7 @@ template <typename RecursiveFlavor> class TranslatorRecursiveTests : public ::te
 
     static void test_recursive_verification()
     {
+        using NativeVerifierCommitmentKey = typename InnerFlavor::VerifierCommitmentKey;
         // Add the same operations to the ECC op queue; the native computation is performed under the hood.
         auto op_queue = create_op_queue(500);
 
@@ -97,8 +98,8 @@ template <typename RecursiveFlavor> class TranslatorRecursiveTests : public ::te
         native_verifier_transcript->template receive_from_prover<InnerBF>("init");
         InnerVerifier native_verifier(verification_key, native_verifier_transcript);
         bool native_result = native_verifier.verify_proof(proof, evaluation_challenge_x, batching_challenge_v);
-        auto pcs_vkey = std::make_shared<typename InnerFlavor::VerifierCommitmentKey>();
-        auto recursive_result = pcs_vkey->pairing_check(pairing_points.P0.get_value(), pairing_points.P1.get_value());
+        NativeVerifierCommitmentKey pcs_vkey{};
+        auto recursive_result = pcs_vkey.pairing_check(pairing_points.P0.get_value(), pairing_points.P1.get_value());
         EXPECT_EQ(recursive_result, native_result);
 
         auto recursive_manifest = verifier.transcript->get_manifest();

--- a/barretenberg/cpp/src/barretenberg/stdlib_circuit_builders/flavor_serialization.test.cpp
+++ b/barretenberg/cpp/src/barretenberg/stdlib_circuit_builders/flavor_serialization.test.cpp
@@ -44,9 +44,6 @@ TYPED_TEST(FlavorSerializationTests, VerificationKeySerialization)
     auto proving_key = std::make_shared<DeciderProvingKey>(builder);
     VerificationKey original_vkey{ proving_key->proving_key };
 
-    // Set the pcs ptr to null since this will not be reconstructed correctly from buffer
-    original_vkey.pcs_verification_key = nullptr;
-
     // Populate some non-zero values in the databus_propagation_data to ensure its being handled
     if constexpr (IsMegaBuilder<Builder>) {
         original_vkey.databus_propagation_data.app_return_data_commitment_pub_input_key =

--- a/barretenberg/cpp/src/barretenberg/stdlib_circuit_builders/mega_flavor.hpp
+++ b/barretenberg/cpp/src/barretenberg/stdlib_circuit_builders/mega_flavor.hpp
@@ -439,7 +439,6 @@ class MegaFlavor {
 
         void set_metadata(const ProvingKey& proving_key)
         {
-            this->pcs_verification_key = std::make_shared<VerifierCommitmentKey>();
             this->circuit_size = proving_key.circuit_size;
             this->log_circuit_size = numeric::get_msb(this->circuit_size);
             this->num_public_inputs = proving_key.num_public_inputs;

--- a/barretenberg/cpp/src/barretenberg/stdlib_circuit_builders/mega_recursive_flavor.hpp
+++ b/barretenberg/cpp/src/barretenberg/stdlib_circuit_builders/mega_recursive_flavor.hpp
@@ -120,7 +120,6 @@ template <typename BuilderType> class MegaRecursiveFlavor_ {
          */
         VerificationKey(CircuitBuilder* builder, const std::shared_ptr<NativeVerificationKey>& native_key)
         {
-            this->pcs_verification_key = native_key->pcs_verification_key;
             this->circuit_size = FF::from_witness(builder, native_key->circuit_size);
             // TODO(https://github.com/AztecProtocol/barretenberg/issues/1283): Use stdlib get_msb.
             this->log_circuit_size = FF::from_witness(builder, numeric::get_msb(native_key->circuit_size));

--- a/barretenberg/cpp/src/barretenberg/stdlib_circuit_builders/ultra_flavor.hpp
+++ b/barretenberg/cpp/src/barretenberg/stdlib_circuit_builders/ultra_flavor.hpp
@@ -360,7 +360,6 @@ class UltraFlavor {
         {}
         VerificationKey(ProvingKey& proving_key)
         {
-            this->pcs_verification_key = std::make_shared<VerifierCommitmentKey>();
             this->circuit_size = proving_key.circuit_size;
             this->log_circuit_size = numeric::get_msb(this->circuit_size);
             this->num_public_inputs = proving_key.num_public_inputs;

--- a/barretenberg/cpp/src/barretenberg/stdlib_circuit_builders/ultra_keccak_flavor.hpp
+++ b/barretenberg/cpp/src/barretenberg/stdlib_circuit_builders/ultra_keccak_flavor.hpp
@@ -44,7 +44,6 @@ class UltraKeccakFlavor : public bb::UltraFlavor {
         {}
         VerificationKey(ProvingKey& proving_key)
         {
-            this->pcs_verification_key = std::make_shared<VerifierCommitmentKey>();
             this->circuit_size = proving_key.circuit_size;
             this->log_circuit_size = numeric::get_msb(this->circuit_size);
             this->num_public_inputs = proving_key.num_public_inputs;

--- a/barretenberg/cpp/src/barretenberg/stdlib_circuit_builders/ultra_recursive_flavor.hpp
+++ b/barretenberg/cpp/src/barretenberg/stdlib_circuit_builders/ultra_recursive_flavor.hpp
@@ -119,7 +119,6 @@ template <typename BuilderType> class UltraRecursiveFlavor_ {
          */
         VerificationKey(CircuitBuilder* builder, const std::shared_ptr<NativeVerificationKey>& native_key)
         {
-            this->pcs_verification_key = native_key->pcs_verification_key;
             this->circuit_size = FF::from_witness(builder, native_key->circuit_size);
             // TODO(https://github.com/AztecProtocol/barretenberg/issues/1283): Use stdlib get_msb.
             this->log_circuit_size = FF::from_witness(builder, numeric::get_msb(native_key->circuit_size));

--- a/barretenberg/cpp/src/barretenberg/stdlib_circuit_builders/ultra_rollup_flavor.hpp
+++ b/barretenberg/cpp/src/barretenberg/stdlib_circuit_builders/ultra_rollup_flavor.hpp
@@ -84,7 +84,6 @@ class UltraRollupFlavor : public bb::UltraFlavor {
             : contains_ipa_claim(proving_key.contains_ipa_claim)
             , ipa_claim_public_input_indices(proving_key.ipa_claim_public_input_indices)
         {
-            this->pcs_verification_key = std::make_shared<VerifierCommitmentKey>();
             this->circuit_size = proving_key.circuit_size;
             this->log_circuit_size = numeric::get_msb(this->circuit_size);
             this->num_public_inputs = proving_key.num_public_inputs;

--- a/barretenberg/cpp/src/barretenberg/stdlib_circuit_builders/ultra_rollup_recursive_flavor.hpp
+++ b/barretenberg/cpp/src/barretenberg/stdlib_circuit_builders/ultra_rollup_recursive_flavor.hpp
@@ -66,7 +66,6 @@ template <typename BuilderType> class UltraRollupRecursiveFlavor_ : public Ultra
             : contains_ipa_claim(native_key->contains_ipa_claim)
             , ipa_claim_public_input_indices(native_key->ipa_claim_public_input_indices)
         {
-            this->pcs_verification_key = native_key->pcs_verification_key;
             this->circuit_size = FF::from_witness(builder, native_key->circuit_size);
             // TODO(https://github.com/AztecProtocol/barretenberg/issues/1283): Use stdlib get_msb.
             this->log_circuit_size = FF::from_witness(builder, numeric::get_msb(native_key->circuit_size));

--- a/barretenberg/cpp/src/barretenberg/translator_vm/translator.test.cpp
+++ b/barretenberg/cpp/src/barretenberg/translator_vm/translator.test.cpp
@@ -96,7 +96,6 @@ TEST_F(TranslatorTests, FixedVK)
 
     // Generate the default fixed VK
     TranslatorFlavor::VerificationKey fixed_vk{};
-    fixed_vk.pcs_verification_key = nullptr;
 
     // Lambda for manually computing a verification key for a given circuit and comparing it to the fixed VK
     auto compare_computed_vk_against_fixed = [&](size_t circuit_size_parameter) {
@@ -105,7 +104,6 @@ TEST_F(TranslatorTests, FixedVK)
         auto proving_key = std::make_shared<TranslatorProvingKey>(circuit_builder);
         TranslatorProver prover{ proving_key, prover_transcript };
         TranslatorFlavor::VerificationKey computed_vk(proving_key->proving_key);
-        computed_vk.pcs_verification_key = nullptr;
 
         EXPECT_EQ(computed_vk, fixed_vk);
     };

--- a/barretenberg/cpp/src/barretenberg/translator_vm/translator_flavor.hpp
+++ b/barretenberg/cpp/src/barretenberg/translator_vm/translator_flavor.hpp
@@ -724,7 +724,6 @@ class TranslatorFlavor {
             : VerificationKey_(1UL << CONST_TRANSLATOR_LOG_N, /*num_public_inputs=*/0)
         {
             this->pub_inputs_offset = 0;
-            this->pcs_verification_key = std::make_shared<VerifierCommitmentKey>();
 
             // Populate the commitments of the precomputed polynomials
             for (auto [vk_commitment, fixed_commitment] :
@@ -738,7 +737,6 @@ class TranslatorFlavor {
         {}
         VerificationKey(const std::shared_ptr<ProvingKey>& proving_key)
         {
-            this->pcs_verification_key = std::make_shared<VerifierCommitmentKey>();
             this->circuit_size = 1UL << TranslatorFlavor::CONST_TRANSLATOR_LOG_N;
             this->log_circuit_size = CONST_TRANSLATOR_LOG_N;
             this->num_public_inputs = proving_key->num_public_inputs;

--- a/barretenberg/cpp/src/barretenberg/translator_vm/translator_verifier.cpp
+++ b/barretenberg/cpp/src/barretenberg/translator_vm/translator_verifier.cpp
@@ -62,6 +62,7 @@ bool TranslatorVerifier::verify_proof(const HonkProof& proof,
     using ClaimBatch = ClaimBatcher::Batch;
     using InterleavedBatch = ClaimBatcher::InterleavedBatch;
     using Sumcheck = SumcheckVerifier<Flavor, Flavor::CONST_TRANSLATOR_LOG_N>;
+    using VerifierCommitmentKey = typename Flavor::VerifierCommitmentKey;
 
     // Load the proof produced by the translator prover
     transcript->load_proof(proof);
@@ -133,8 +134,8 @@ bool TranslatorVerifier::verify_proof(const HonkProof& proof,
                                                sumcheck_output.claimed_libra_evaluation);
     const auto pairing_points = PCS::reduce_verify_batch_opening_claim(opening_claim, transcript);
 
-    auto pcs_vkey = std::make_shared<typename Flavor::VerifierCommitmentKey>();
-    auto verified = pcs_vkey->pairing_check(pairing_points[0], pairing_points[1]);
+    VerifierCommitmentKey pcs_vkey{};
+    auto verified = pcs_vkey.pairing_check(pairing_points[0], pairing_points[1]);
 
     return verified && consistency_checked;
 }

--- a/barretenberg/cpp/src/barretenberg/translator_vm/translator_verifier.cpp
+++ b/barretenberg/cpp/src/barretenberg/translator_vm/translator_verifier.cpp
@@ -133,7 +133,8 @@ bool TranslatorVerifier::verify_proof(const HonkProof& proof,
                                                sumcheck_output.claimed_libra_evaluation);
     const auto pairing_points = PCS::reduce_verify_batch_opening_claim(opening_claim, transcript);
 
-    auto verified = key->pcs_verification_key->pairing_check(pairing_points[0], pairing_points[1]);
+    auto pcs_vkey = std::make_shared<typename Flavor::VerifierCommitmentKey>();
+    auto verified = pcs_vkey->pairing_check(pairing_points[0], pairing_points[1]);
 
     return verified && consistency_checked;
 }

--- a/barretenberg/cpp/src/barretenberg/ultra_honk/decider_verifier.cpp
+++ b/barretenberg/cpp/src/barretenberg/ultra_honk/decider_verifier.cpp
@@ -40,6 +40,7 @@ template <typename Flavor> bool DeciderVerifier_<Flavor>::verify()
     using VerifierCommitments = typename Flavor::VerifierCommitments;
     using ClaimBatcher = ClaimBatcher_<Curve>;
     using ClaimBatch = ClaimBatcher::Batch;
+    using VerifierCommitmentKey = typename Flavor::VerifierCommitmentKey;
 
     VerifierCommitments commitments{ accumulator->verification_key, accumulator->witness_commitments };
 
@@ -81,8 +82,8 @@ template <typename Flavor> bool DeciderVerifier_<Flavor>::verify()
                                                libra_commitments,
                                                sumcheck_output.claimed_libra_evaluation);
     const auto pairing_points = PCS::reduce_verify_batch_opening_claim(opening_claim, transcript);
-    auto pcs_vkey = std::make_shared<typename Flavor::VerifierCommitmentKey>();
-    bool verified = pcs_vkey->pairing_check(pairing_points[0], pairing_points[1]);
+    VerifierCommitmentKey pcs_vkey{};
+    bool verified = pcs_vkey.pairing_check(pairing_points[0], pairing_points[1]);
     return sumcheck_output.verified && verified && consistency_checked;
 }
 

--- a/barretenberg/cpp/src/barretenberg/ultra_honk/decider_verifier.cpp
+++ b/barretenberg/cpp/src/barretenberg/ultra_honk/decider_verifier.cpp
@@ -11,14 +11,12 @@ template <typename Flavor>
 DeciderVerifier_<Flavor>::DeciderVerifier_(const std::shared_ptr<DeciderVerificationKey>& accumulator,
                                            const std::shared_ptr<Transcript>& transcript)
     : accumulator(accumulator)
-    , pcs_verification_key(accumulator->verification_key->pcs_verification_key)
     , transcript(transcript)
 {}
 
 template <typename Flavor>
 DeciderVerifier_<Flavor>::DeciderVerifier_(const std::shared_ptr<DeciderVerificationKey>& accumulator)
     : accumulator(accumulator)
-    , pcs_verification_key(accumulator->verification_key->pcs_verification_key)
 {}
 
 /**
@@ -83,7 +81,8 @@ template <typename Flavor> bool DeciderVerifier_<Flavor>::verify()
                                                libra_commitments,
                                                sumcheck_output.claimed_libra_evaluation);
     const auto pairing_points = PCS::reduce_verify_batch_opening_claim(opening_claim, transcript);
-    bool verified = pcs_verification_key->pairing_check(pairing_points[0], pairing_points[1]);
+    auto pcs_vkey = std::make_shared<typename Flavor::VerifierCommitmentKey>();
+    bool verified = pcs_vkey->pairing_check(pairing_points[0], pairing_points[1]);
     return sumcheck_output.verified && verified && consistency_checked;
 }
 

--- a/barretenberg/cpp/src/barretenberg/ultra_honk/decider_verifier.hpp
+++ b/barretenberg/cpp/src/barretenberg/ultra_honk/decider_verifier.hpp
@@ -33,7 +33,6 @@ template <typename Flavor> class DeciderVerifier_ {
     bool verify();                          // used when transcript that has been initialized with a proof
     std::shared_ptr<VerificationKey> key;
     std::shared_ptr<DeciderVerificationKey> accumulator;
-    std::shared_ptr<VerifierCommitmentKey> pcs_verification_key;
     std::shared_ptr<Transcript> transcript;
 };
 

--- a/barretenberg/cpp/src/barretenberg/ultra_honk/merge_verifier.cpp
+++ b/barretenberg/cpp/src/barretenberg/ultra_honk/merge_verifier.cpp
@@ -86,8 +86,8 @@ bool MergeVerifier::verify_proof(const HonkProof& proof)
     OpeningClaim batched_claim = { { kappa, batched_eval }, batched_commitment };
 
     auto pairing_points = PCS::reduce_verify(batched_claim, transcript);
-    auto pcs_vkey = std::make_shared<VerifierCommitmentKey>();
-    auto verified = pcs_vkey->pairing_check(pairing_points[0], pairing_points[1]);
+    VerifierCommitmentKey pcs_vkey{};
+    auto verified = pcs_vkey.pairing_check(pairing_points[0], pairing_points[1]);
     return identity_checked && verified;
 }
 } // namespace bb

--- a/barretenberg/cpp/src/barretenberg/ultra_honk/merge_verifier.cpp
+++ b/barretenberg/cpp/src/barretenberg/ultra_honk/merge_verifier.cpp
@@ -5,8 +5,7 @@
 namespace bb {
 
 MergeVerifier::MergeVerifier()
-    : transcript(std::make_shared<Transcript>())
-    , pcs_verification_key(std::make_unique<VerifierCommitmentKey>()){};
+    : transcript(std::make_shared<Transcript>()){};
 
 /**
  * @brief Verify proper construction of the aggregate Goblin ECC op queue polynomials T_j, j = 1,2,3,4.
@@ -87,7 +86,8 @@ bool MergeVerifier::verify_proof(const HonkProof& proof)
     OpeningClaim batched_claim = { { kappa, batched_eval }, batched_commitment };
 
     auto pairing_points = PCS::reduce_verify(batched_claim, transcript);
-    auto verified = pcs_verification_key->pairing_check(pairing_points[0], pairing_points[1]);
+    auto pcs_vkey = std::make_shared<VerifierCommitmentKey>();
+    auto verified = pcs_vkey->pairing_check(pairing_points[0], pairing_points[1]);
     return identity_checked && verified;
 }
 } // namespace bb

--- a/barretenberg/cpp/src/barretenberg/ultra_honk/merge_verifier.hpp
+++ b/barretenberg/cpp/src/barretenberg/ultra_honk/merge_verifier.hpp
@@ -29,7 +29,6 @@ class MergeVerifier {
     bool verify_proof(const HonkProof& proof);
 
   private:
-    std::shared_ptr<VerifierCommitmentKey> pcs_verification_key;
     // Number of columns that jointly constitute the op_queue, should be the same as the number of wires in the
     // MegaCircuitBuilder
     static constexpr size_t NUM_WIRES = MegaExecutionTraceBlocks::NUM_WIRES;

--- a/barretenberg/cpp/src/barretenberg/vm2/constraining/flavor.hpp
+++ b/barretenberg/cpp/src/barretenberg/vm2/constraining/flavor.hpp
@@ -243,7 +243,6 @@ class AvmFlavor {
                  zip_view(proving_key->get_precomputed_polynomials(), this->get_all())) {
                 commitment = proving_key->commitment_key->commit(polynomial);
             }
-            pcs_verification_key = std::make_shared<VerifierCommitmentKey>();
         }
 
         VerificationKey(const size_t circuit_size,
@@ -254,7 +253,6 @@ class AvmFlavor {
             for (auto [vk_cmt, cmt] : zip_view(this->get_all(), precomputed_cmts)) {
                 vk_cmt = cmt;
             }
-            pcs_verification_key = std::make_shared<VerifierCommitmentKey>();
         }
 
         std::vector<FF> to_field_elements() const;

--- a/barretenberg/cpp/src/barretenberg/vm2/constraining/recursion/recursive_flavor.hpp
+++ b/barretenberg/cpp/src/barretenberg/vm2/constraining/recursion/recursive_flavor.hpp
@@ -65,7 +65,6 @@ template <typename BuilderType> class AvmRecursiveFlavor_ {
       public:
         VerificationKey(CircuitBuilder* builder, const std::shared_ptr<NativeVerificationKey>& native_key)
         {
-            this->pcs_verification_key = native_key->pcs_verification_key;
             this->circuit_size = FF::from_witness(builder, native_key->circuit_size);
             this->log_circuit_size = FF::from_witness(builder, numeric::get_msb(native_key->circuit_size));
             this->num_public_inputs = FF::from_witness(builder, native_key->num_public_inputs);

--- a/barretenberg/cpp/src/barretenberg/vm2/constraining/recursion/recursive_verifier.test.cpp
+++ b/barretenberg/cpp/src/barretenberg/vm2/constraining/recursion/recursive_verifier.test.cpp
@@ -96,8 +96,8 @@ TEST_F(AvmRecursiveTests, StandardRecursion)
         auto agg_object = AggregationObject::construct_default(outer_circuit);
         auto agg_output = recursive_verifier.verify_proof(proof, public_inputs_cols, agg_object);
 
-        bool agg_output_valid =
-            verification_key->pcs_verification_key->pairing_check(agg_output.P0.get_value(), agg_output.P1.get_value());
+        auto pcs_vkey = std::make_shared<typename RecursiveFlavor::VerifierCommitmentKey>();
+        bool agg_output_valid = pcs_vkey->pairing_check(agg_output.P0.get_value(), agg_output.P1.get_value());
 
         // Check that the output of the recursive verifier is well-formed for aggregation as this pair of points will
         // be aggregated with others.
@@ -205,8 +205,9 @@ TEST_F(AvmRecursiveTests, GoblinRecursion)
     outer_circuit.ipa_proof = convert_stdlib_proof_to_native(verifier_output.ipa_proof);
 
     // Ensure that the pairing check is satisfied on the outputs of the recursive verifier
-    bool agg_output_valid = verification_key->pcs_verification_key->pairing_check(
-        verifier_output.agg_obj.P0.get_value(), verifier_output.agg_obj.P1.get_value());
+    auto pcs_vkey = std::make_shared<typename RecursiveFlavor::VerifierCommitmentKey>();
+    bool agg_output_valid =
+        pcs_vkey->pairing_check(verifier_output.agg_obj.P0.get_value(), verifier_output.agg_obj.P1.get_value());
     ASSERT_TRUE(agg_output_valid) << "Pairing points (aggregation state) are not valid.";
     ASSERT_FALSE(outer_circuit.failed()) << "Outer circuit has failed.";
 

--- a/barretenberg/cpp/src/barretenberg/vm2/constraining/recursion/recursive_verifier.test.cpp
+++ b/barretenberg/cpp/src/barretenberg/vm2/constraining/recursion/recursive_verifier.test.cpp
@@ -76,6 +76,7 @@ TEST_F(AvmRecursiveTests, StandardRecursion)
     using OuterVerifier = UltraVerifier;
     using OuterDeciderProvingKey = DeciderProvingKey_<UltraFlavor>;
     using AggregationObject = stdlib::recursion::aggregation_state<OuterBuilder>;
+    using NativeVerifierCommitmentKey = typename AvmFlavor::VerifierCommitmentKey;
 
     if (testing::skip_slow_tests()) {
         GTEST_SKIP();
@@ -96,8 +97,8 @@ TEST_F(AvmRecursiveTests, StandardRecursion)
         auto agg_object = AggregationObject::construct_default(outer_circuit);
         auto agg_output = recursive_verifier.verify_proof(proof, public_inputs_cols, agg_object);
 
-        auto pcs_vkey = std::make_shared<typename RecursiveFlavor::VerifierCommitmentKey>();
-        bool agg_output_valid = pcs_vkey->pairing_check(agg_output.P0.get_value(), agg_output.P1.get_value());
+        NativeVerifierCommitmentKey pcs_vkey{};
+        bool agg_output_valid = pcs_vkey.pairing_check(agg_output.P0.get_value(), agg_output.P1.get_value());
 
         // Check that the output of the recursive verifier is well-formed for aggregation as this pair of points will
         // be aggregated with others.
@@ -165,6 +166,7 @@ TEST_F(AvmRecursiveTests, GoblinRecursion)
     using UltraFF = UltraRollupRecursiveFlavor::FF;
     using UltraRollupProver = UltraProver_<UltraRollupFlavor>;
     using AggregationObject = stdlib::recursion::aggregation_state<OuterBuilder>;
+    using NativeVerifierCommitmentKey = typename AvmFlavor::VerifierCommitmentKey;
 
     NativeProofResult proof_result;
     ASSERT_NO_FATAL_FAILURE({ create_and_verify_native_proof(proof_result); });
@@ -205,9 +207,9 @@ TEST_F(AvmRecursiveTests, GoblinRecursion)
     outer_circuit.ipa_proof = convert_stdlib_proof_to_native(verifier_output.ipa_proof);
 
     // Ensure that the pairing check is satisfied on the outputs of the recursive verifier
-    auto pcs_vkey = std::make_shared<typename RecursiveFlavor::VerifierCommitmentKey>();
+    NativeVerifierCommitmentKey pcs_vkey{};
     bool agg_output_valid =
-        pcs_vkey->pairing_check(verifier_output.agg_obj.P0.get_value(), verifier_output.agg_obj.P1.get_value());
+        pcs_vkey.pairing_check(verifier_output.agg_obj.P0.get_value(), verifier_output.agg_obj.P1.get_value());
     ASSERT_TRUE(agg_output_valid) << "Pairing points (aggregation state) are not valid.";
     ASSERT_FALSE(outer_circuit.failed()) << "Outer circuit has failed.";
 

--- a/barretenberg/cpp/src/barretenberg/vm2/constraining/verifier.cpp
+++ b/barretenberg/cpp/src/barretenberg/vm2/constraining/verifier.cpp
@@ -47,6 +47,7 @@ bool AvmVerifier::verify_proof(const HonkProof& proof, const std::vector<std::ve
     using Shplemini = ShpleminiVerifier_<Curve, Flavor::USE_PADDING>;
     using ClaimBatcher = ClaimBatcher_<Curve>;
     using ClaimBatch = ClaimBatcher::Batch;
+    using VerifierCommitmentKey = typename Flavor::VerifierCommitmentKey;
 
     RelationParameters<FF> relation_parameters;
 
@@ -111,8 +112,8 @@ bool AvmVerifier::verify_proof(const HonkProof& proof, const std::vector<std::ve
         log_circuit_size, claim_batcher, output.challenge, Commitment::one(), transcript);
 
     const auto pairing_points = PCS::reduce_verify_batch_opening_claim(opening_claim, transcript);
-    auto pcs_vkey = std::make_shared<typename Flavor::VerifierCommitmentKey>();
-    const auto shplemini_verified = pcs_vkey->pairing_check(pairing_points[0], pairing_points[1]);
+    VerifierCommitmentKey pcs_vkey{};
+    const auto shplemini_verified = pcs_vkey.pairing_check(pairing_points[0], pairing_points[1]);
 
     if (!shplemini_verified) {
         vinfo("Shplemini verification failed");

--- a/barretenberg/cpp/src/barretenberg/vm2/constraining/verifier.cpp
+++ b/barretenberg/cpp/src/barretenberg/vm2/constraining/verifier.cpp
@@ -111,7 +111,8 @@ bool AvmVerifier::verify_proof(const HonkProof& proof, const std::vector<std::ve
         log_circuit_size, claim_batcher, output.challenge, Commitment::one(), transcript);
 
     const auto pairing_points = PCS::reduce_verify_batch_opening_claim(opening_claim, transcript);
-    const auto shplemini_verified = key->pcs_verification_key->pairing_check(pairing_points[0], pairing_points[1]);
+    auto pcs_vkey = std::make_shared<typename Flavor::VerifierCommitmentKey>();
+    const auto shplemini_verified = pcs_vkey->pairing_check(pairing_points[0], pairing_points[1]);
 
     if (!shplemini_verified) {
         vinfo("Shplemini verification failed");


### PR DESCRIPTION
The PCS verification key did not need to be part of the VK (except maybe for ECCVM). I've removed it from the base class VerificationKey_ which allows for the removal of a lot of boilerplate and defaulting.

Closes https://github.com/AztecProtocol/barretenberg/issues/1335