### PR TITLE
fix: squash nightly foundry warning

### DIFF
--- a/release-image/Dockerfile.base
+++ b/release-image/Dockerfile.base
@@ -26,7 +26,7 @@ RUN apt update && apt install -y \
 # Install anvil.
 COPY --from=build /opt/foundry/bin/anvil /opt/foundry/bin/anvil
 COPY --from=build /opt/foundry/bin/cast /opt/foundry/bin/cast
-ENV PATH="/opt/foundry/bin:$PATH"
+ENV PATH="/opt/foundry/bin:$PATH" FOUNDRY_DISABLE_NIGHTLY_WARNING="1"
 # Copy in production dependencies.
 COPY --from=build /usr/src/yarn-project/node_modules /usr/src/yarn-project/node_modules
 # We install a symlink to yarn-project's node_modules at a location that all portalled packages can find as they


### PR DESCRIPTION
Squashes this message that shows up in our logs:

```
Warning: This is a nightly build of Foundry. It is recommended to use the latest stable version. Visit https://book.getfoundry.sh/announcements for more information.
```