### PR TITLE
feat: SMT Verificaiton Module: Data Structures

### DIFF
--- a/barretenberg/cpp/src/barretenberg/smt_verification/README.md
+++ b/barretenberg/cpp/src/barretenberg/smt_verification/README.md
@@ -208,10 +208,10 @@ To store it on the disk just do the following
     ***!Note passing cvc5 native types directly is a little bit advanced compared to the ordinary usage of this module. See the tests***
 
     Create an array from indicies and entrys:
-    `SymArray SymArray<sym_index, sym_entry>(vector<sym_index> indicies, vec<sym_entry> entries, Solver* s, str name = "")`
+    `SymArray SymArray<sym_index, sym_entry>(vector<sym_index> indicies, vec<sym_entry> entries, str name = "")`
 
     Create an integer indexed array from entries:
-    `SymArray SymArray<sym_index, sym_entry>(vec<sym_entry> entries, STerm index_base, Solver* s, str name = "")`
+    `SymArray SymArray<sym_index, sym_entry>(vec<sym_entry> entries, STerm index_base, str name = "")`
 
     **!Note you need to provide an example for the integer like index entry. Most of the time you'll be fine using: `index_base` = `FFConst(1, &slv)`| `FFIConst(1, &slv)`| `IConst(1, &slv)`| `BVConst(1, &slv)`**
 
@@ -240,7 +240,7 @@ To store it on the disk just do the following
     ***!Note passing cvc5 native types directly is a little bit advanced compared to the ordinary usage of this module. See the tests***
 
     Create a set from vector of values:
-    `SymSet SymSet<sym_entry>(vec<sym_entry> entries, Solver* s, str name = "")`
+    `SymSet SymSet<sym_entry>(vec<sym_entry> entries, str name = "")`
 
     After you've created a set you can put elements in it by:
 

--- a/barretenberg/cpp/src/barretenberg/smt_verification/README.md
+++ b/barretenberg/cpp/src/barretenberg/smt_verification/README.md
@@ -189,7 +189,7 @@ To store it on the disk just do the following
 
     Symbolic Tuple type. 
     You can group several items in one term. 
-    **!Note Only compatible with `STerm` class
+    **!Note Only compatible with `STerm` class**
 
     `STuple STuple(vec<STerm>, Solver* slv)`
 

--- a/barretenberg/cpp/src/barretenberg/smt_verification/README.md
+++ b/barretenberg/cpp/src/barretenberg/smt_verification/README.md
@@ -263,7 +263,7 @@ After generating all the constrains you should call `bool res = solver.check()` 
 In case you expected `false` but `true` was returned you can then check what went wrong.
 You have three choices:
 - You can access each of the terms directly by calling `solver[term]`, or `solver.get(term)`
-- You can generate an unordered map with `str->term` values and ask the solver to obtain `unoredered_map<str, str> res = solver.model(unordered_map<str, FFTerm> terms)`.
+- You can generate an unordered map with `str->term` values and ask the solver to obtain `unordered_map<str, str> res = solver.model(unordered_map<str, FFTerm> terms)`.
 - You can generate a vector of terms and pass them to `unordered_map<str, str> res = solver.model(vector<FFTerm> terms)`. In this case the mapping name will be taken directly from solver. Specifically either it's the name that you have set or `var_{i}`.
 
 **!Note that the resulting values are strings and you can't use them to generate further constraints.**

--- a/barretenberg/cpp/src/barretenberg/smt_verification/README.md
+++ b/barretenberg/cpp/src/barretenberg/smt_verification/README.md
@@ -134,6 +134,8 @@ To store it on the disk just do the following
 
 4. Terms creation
 
+    ### Arithmetic Variables
+
     You can initialize symbolic variable via `STerm::Var(str name, &solver, TermType type)` or `STerm::Const(str val, &solver, TermType type, u32 base=16)`
 
     But also you can use `FFVar(str name, &Solver)` or equivalently via `FFIVar` and `BVVar` so you don't have to mess with types.
@@ -162,10 +164,12 @@ To store it on the disk just do the following
     - `STerm::in(cvc5::Term table&)` - simple set inclusion.
     - `static STerm::in_table(std::vector<STerm> entry, cvc5::Term& table)` - lookup table inclusion.
 
-    ---
+    --- 
+
+    ### Boolean Variables
 
 	There is a Bool type:
-	- `Bool Bool(STerm t)` or `Bool Bool(bool b, Solver* s)`
+	- `Bool Bool(STerm t)`, `Bool Bool(bool b, Solver* s)` or `Bool(str name, Solver* s)`
 
 	You can `|, &, ==, !=, !` these variables and also `batch_or`, `batch_and` them.
 	To create a constraint you should call `Bool::assert_term()` method.
@@ -175,13 +179,91 @@ To store it on the disk just do the following
     **!Note that constraint like `(Bool(STerm a) == Bool(STerm b)).assert_term()`, where a has `FFTerm` type and b has `FFITerm` type, won't work, since their types differ.**
     **!Note `Bool(a == b)` won't work since `a==b` will create an equality constraint as I mentioned earlier and the return type of this operation is `void`.**
 
+    --- 
+
+    ### Data Structures
+
+    There're three extra data structures:
+
+    #### STuple
+
+    Symbolic Tuple type. 
+    You can group several items in one term. 
+    **!Note Only compatible with `STerm` class
+
+    `STuple STuple(vec<STerm>, Solver* slv)`
+
+    **!Note that you can not access the element of the tuple by its index after creation**
+
+    #### SymArray
+
+    Symbolic Array type. 
+    You can store symbolic values. And access them by symbolic index.
+
+    Both index and entry can be any of the symbolic types: `STerm`, `Bool`, `STuple`, `SymArray`, `SymSet`
+
+    Create an empty array:
+    `SymArray SymArray<sym_index, sym_entry>(cvc5:Sort idx_sort, TermType idx_type, cvc5::Sort entry_sort, TermType entry_type, Solver* s, str name = "")`
+
+    ***!Note passing cvc5 native types directly is a little bit advanced compared to the ordinary usage of this module. See the tests***
+
+    Create an array from indicies and entrys:
+    `SymArray SymArray<sym_index, sym_entry>(vector<sym_index> indicies, vec<sym_entry> entries, Solver* s, str name = "")`
+
+    Create an integer indexed array from entries:
+    `SymArray SymArray<sym_index, sym_entry>(vec<sym_entry> entries, STerm index_base, Solver* s, str name = "")`
+
+    **!Note you need to provide an example for the integer like index entry. Most of the time you'll be fine using: `index_base` = `FFConst(1, &slv)`| `FFIConst(1, &slv)`| `IConst(1, &slv)`| `BVConst(1, &slv)`**
+
+    After you've created an array you can put/overwrite elements in it by:
+
+    `arr.put(sym_idx, sym_entry)`
+
+    And access them:
+
+    `arr.get(sym_idx)`
+    `arr[sym_idx]`
+
+
+    For debugging purposes there's a `print_trace` method, that will print all the `put` operations
+
+    #### SymSet
+
+    Symbolic Set type. 
+    You can store symbolic values. You can check wheter an element belong to the set or not.
+
+    Entries can be any of the symbolic types: `STerm`, `Bool`, `STuple`, `SymArray`, `SymSet`
+
+    Create an empty set:
+    `SymSet SymSet<sym_entry>(cvc5::Sort entry_sort, TermType entry_type, Solver* s, str name = "")`
+
+    ***!Note passing cvc5 native types directly is a little bit advanced compared to the ordinary usage of this module. See the tests***
+
+    Create a set from vector of values:
+    `SymSet SymSet<sym_entry>(vec<sym_entry> entries, Solver* s, str name = "")`
+
+    After you've created a set you can put elements in it by:
+
+    `set.insert(sym_entry)`
+
+    And add inclusion constraints:
+
+    `set.contains(entry)`
+    `set.not_contains(entry)`
+
+    For debugging purposes there's a `print_trace` method, that will print all the `insert` operations
+
+    ---
+
+    All the types support printing their name in variable case and value in constant case
+
 ## 3. Post model checking
 After generating all the constrains you should call `bool res = solver.check()` and depending on your goal it could be `true` or `false`.
 
 In case you expected `false` but `true` was returned you can then check what went wrong.
 You have three choices:
 - You can access each of the terms directly by calling `solver[term]`, or `solver.get(term)`
-- You can generate an unordered map with `str->term` values and ask the solver to obtain `unordered_map<str, str> res = solver.model(unordered_map<str, FFTerm> terms)`.
+- You can generate an unordered map with `str->term` values and ask the solver to obtain `unoredered_map<str, str> res = solver.model(unordered_map<str, FFTerm> terms)`.
 - You can generate a vector of terms and pass them to `unordered_map<str, str> res = solver.model(vector<FFTerm> terms)`. In this case the mapping name will be taken directly from solver. Specifically either it's the name that you have set or `var_{i}`.
 
 **!Note that the resulting values are strings and you can't use them to generate further constraints.**
@@ -263,6 +345,10 @@ Avalaible test suits in `smt_verification_tests`:
 - `FFITerm*`
 - `ITerm*`
 - `BVTerm*`
+- `SymbolicBool*`
+- `SymbolicTuple*`
+- `SymbolicArray*`
+- `SymbolicSet*`
 ---
 
 - `Subcircuits*`
@@ -402,6 +488,8 @@ void model_variables(SymCircuit& c, Solver* s, FFTerm& evaluation)
 More examples can be found in
 
 - [terms/ffterm.test.cpp](terms/ffterm.test.cpp), [terms/ffiterm.test.cpp](terms/ffiterm.test.cpp), [terms/bvterm.test.cpp](terms/bvterm.test.cpp), [terms/iterm.test.cpp](terms/iterm.test.cpp)
+- [terms/bool.test.cpp](terms/bool.test.cpp)
+- [terms/data_types.test.cpp]
 - [circuit/standard_circuit.test.cpp](circuit/standard_circuit.test.cpp), [circuit/ultra_circuit](circuit/ultra_circuit.test.cpp)
 - [smt_polynomials.test.cpp](smt_polynomials.test.cpp), [smt_examples.test.cpp](smt_examples.test.cpp)
 - [bb_tests](bb_tests)

--- a/barretenberg/cpp/src/barretenberg/smt_verification/circuit/circuit_base.hpp
+++ b/barretenberg/cpp/src/barretenberg/smt_verification/circuit/circuit_base.hpp
@@ -6,6 +6,7 @@
 #include <unordered_map>
 
 #include "barretenberg/smt_verification/terms/bool.hpp"
+#include "barretenberg/smt_verification/terms/data_structures.hpp"
 #include "barretenberg/smt_verification/terms/term.hpp"
 
 #include "subcircuits.hpp"

--- a/barretenberg/cpp/src/barretenberg/smt_verification/circuit/ultra_circuit.cpp
+++ b/barretenberg/cpp/src/barretenberg/smt_verification/circuit/ultra_circuit.cpp
@@ -140,16 +140,18 @@ size_t UltraCircuit::handle_arithmetic_relation(size_t cursor, size_t idx)
 
 void UltraCircuit::process_new_table(uint32_t table_idx)
 {
-    std::vector<std::vector<cvc5::Term>> new_table;
+    std::vector<STuple> new_table;
     bool is_xor = true;
     bool is_and = true;
 
     for (auto table_entry : this->lookup_tables[table_idx]) {
-        std::vector<cvc5::Term> tmp_entry = {
-            STerm(table_entry[0], this->solver, this->type),
-            STerm(table_entry[1], this->solver, this->type),
-            STerm(table_entry[2], this->solver, this->type),
-        };
+        STuple tmp_entry(
+            {
+                STerm(table_entry[0], this->solver, this->type),
+                STerm(table_entry[1], this->solver, this->type),
+                STerm(table_entry[2], this->solver, this->type),
+            },
+            this->solver);
         new_table.push_back(tmp_entry);
 
         is_xor &= (static_cast<uint256_t>(table_entry[0]) ^ static_cast<uint256_t>(table_entry[1])) ==
@@ -157,17 +159,21 @@ void UltraCircuit::process_new_table(uint32_t table_idx)
         is_and &= (static_cast<uint256_t>(table_entry[0]) & static_cast<uint256_t>(table_entry[1])) ==
                   static_cast<uint256_t>(table_entry[2]);
     }
-    this->cached_symbolic_tables.insert({ table_idx, this->solver->create_lookup_table(new_table) });
+    info("Creating lookup table №", this->cached_symbolic_tables.size());
+    std::string table_name;
     if (is_xor) {
+        table_name = "XOR_TABLE_" + std::to_string(new_table.size());
         this->tables_types.insert({ table_idx, TableType::XOR });
-        info("Encountered a XOR table");
     } else if (is_and) {
+        table_name = "AND_TABLE_" + std::to_string(new_table.size());
         this->tables_types.insert({ table_idx, TableType::AND });
-        info("Encountered an AND table");
     } else {
+        table_name = "UNK_TABLE_" + std::to_string(new_table.size());
         this->tables_types.insert({ table_idx, TableType::UNKNOWN });
-        info("Encountered an UNKNOWN table");
     }
+    info(table_name);
+    SymSet<STuple> new_stable(new_table, this->solver, this->tag + table_name);
+    this->cached_symbolic_tables.insert({ table_idx, new_stable });
 }
 
 /**
@@ -213,7 +219,6 @@ size_t UltraCircuit::handle_lookup_relation(size_t cursor, size_t idx)
     STerm first_entry = this->symbolic_vars[w_l_idx] + q_r * this->symbolic_vars[w_l_shift_idx];
     STerm second_entry = this->symbolic_vars[w_r_idx] + q_m * this->symbolic_vars[w_r_shift_idx];
     STerm third_entry = this->symbolic_vars[w_o_idx] + q_c * this->symbolic_vars[w_o_shift_idx];
-    std::vector<STerm> entries = { first_entry, second_entry, third_entry };
 
     if (this->type == TermType::BVTerm && this->enable_optimizations) {
         // Sort of an optimization.
@@ -237,7 +242,8 @@ size_t UltraCircuit::handle_lookup_relation(size_t cursor, size_t idx)
         }
     }
     info("Unknown Table");
-    STerm::in_table(entries, this->cached_symbolic_tables[table_idx]);
+    STuple entries({ first_entry, second_entry, third_entry }, this->solver);
+    this->cached_symbolic_tables[table_idx].contains(entries);
     return cursor + 1;
 }
 
@@ -380,14 +386,16 @@ void UltraCircuit::handle_range_constraints()
             uint64_t range = this->range_tags[tag];
             if (this->type == TermType::FFTerm || !this->enable_optimizations) {
                 if (!this->cached_range_tables.contains(range)) {
-                    std::vector<cvc5::Term> new_range_table;
+                    std::vector<STerm> new_range_table;
                     for (size_t entry = 0; entry < range; entry++) {
                         new_range_table.push_back(STerm(entry, this->solver, this->type));
                     }
-                    this->cached_range_tables.insert({ range, this->solver->create_table(new_range_table) });
+                    std::string table_name = this->tag + "RANGE_" + std::to_string(range);
+                    SymSet<STerm> new_range_stable(new_range_table, this->solver, table_name);
+                    info("Initialized new range: ", table_name);
+                    this->cached_range_tables.insert({ range, new_range_stable });
                 }
-
-                this->symbolic_vars[i].in(this->cached_range_tables[range]);
+                this->cached_range_tables[range].contains(this->symbolic_vars[i]);
             } else {
                 this->symbolic_vars[i] <= range;
             }

--- a/barretenberg/cpp/src/barretenberg/smt_verification/circuit/ultra_circuit.cpp
+++ b/barretenberg/cpp/src/barretenberg/smt_verification/circuit/ultra_circuit.cpp
@@ -145,13 +145,11 @@ void UltraCircuit::process_new_table(uint32_t table_idx)
     bool is_and = true;
 
     for (auto table_entry : this->lookup_tables[table_idx]) {
-        STuple tmp_entry(
-            {
-                STerm(table_entry[0], this->solver, this->type),
-                STerm(table_entry[1], this->solver, this->type),
-                STerm(table_entry[2], this->solver, this->type),
-            },
-            this->solver);
+        STuple tmp_entry({
+            STerm(table_entry[0], this->solver, this->type),
+            STerm(table_entry[1], this->solver, this->type),
+            STerm(table_entry[2], this->solver, this->type),
+        });
         new_table.push_back(tmp_entry);
 
         is_xor &= (static_cast<uint256_t>(table_entry[0]) ^ static_cast<uint256_t>(table_entry[1])) ==
@@ -172,7 +170,7 @@ void UltraCircuit::process_new_table(uint32_t table_idx)
         this->tables_types.insert({ table_idx, TableType::UNKNOWN });
     }
     info(table_name);
-    SymSet<STuple> new_stable(new_table, this->solver, this->tag + table_name);
+    SymSet<STuple> new_stable(new_table, this->tag + table_name);
     this->cached_symbolic_tables.insert({ table_idx, new_stable });
 }
 
@@ -242,7 +240,7 @@ size_t UltraCircuit::handle_lookup_relation(size_t cursor, size_t idx)
         }
     }
     info("Unknown Table");
-    STuple entries({ first_entry, second_entry, third_entry }, this->solver);
+    STuple entries({ first_entry, second_entry, third_entry });
     this->cached_symbolic_tables[table_idx].contains(entries);
     return cursor + 1;
 }
@@ -391,7 +389,7 @@ void UltraCircuit::handle_range_constraints()
                         new_range_table.push_back(STerm(entry, this->solver, this->type));
                     }
                     std::string table_name = this->tag + "RANGE_" + std::to_string(range);
-                    SymSet<STerm> new_range_stable(new_range_table, this->solver, table_name);
+                    SymSet<STerm> new_range_stable(new_range_table, table_name);
                     info("Initialized new range: ", table_name);
                     this->cached_range_tables.insert({ range, new_range_stable });
                 }

--- a/barretenberg/cpp/src/barretenberg/smt_verification/circuit/ultra_circuit.hpp
+++ b/barretenberg/cpp/src/barretenberg/smt_verification/circuit/ultra_circuit.hpp
@@ -23,9 +23,9 @@ class UltraCircuit : public CircuitBase {
     std::vector<std::vector<std::vector<uint32_t>>> wires_idxs; // values of the gates' wires idxs
 
     std::vector<std::vector<std::vector<bb::fr>>> lookup_tables;
-    std::unordered_map<uint32_t, cvc5::Term> cached_symbolic_tables;
+    std::unordered_map<uint32_t, SymSet<STuple>> cached_symbolic_tables;
     std::unordered_map<uint32_t, TableType> tables_types;
-    std::unordered_map<uint64_t, cvc5::Term> cached_range_tables;
+    std::unordered_map<uint64_t, SymSet<STerm>> cached_range_tables;
 
     explicit UltraCircuit(CircuitSchema& circuit_info,
                           Solver* solver,

--- a/barretenberg/cpp/src/barretenberg/smt_verification/solver/solver.cpp
+++ b/barretenberg/cpp/src/barretenberg/smt_verification/solver/solver.cpp
@@ -41,8 +41,7 @@ std::string Solver::get(const cvc5::Term& term) const
         return term.getBitVectorValue();
     }
     if (term.getKind() == cvc5::Kind::CONST_BOOLEAN) {
-        std::vector<std::string> bool_res = { "false", "true" };
-        return bool_res[static_cast<size_t>(term.getBooleanValue())];
+        return std::to_string(static_cast<size_t>(term.getBooleanValue()));
     }
 
     if (!this->checked) {
@@ -60,6 +59,8 @@ std::string Solver::get(const cvc5::Term& term) const
         str_val = val.getFiniteFieldValue();
     } else if (val.isBitVectorValue()) {
         str_val = val.getBitVectorValue();
+    } else if (val.isBooleanValue()) {
+        str_val = std::to_string(static_cast<size_t>(val.getBooleanValue()));
     } else {
         throw std::invalid_argument("Expected Integer or FiniteField sorts. Got: " + val.getSort().toString());
     }
@@ -106,6 +107,103 @@ std::unordered_map<std::string, std::string> Solver::model(std::vector<cvc5::Ter
 }
 
 /**
+ * @brief print the trace of array assigments up to previously printed ones
+ *
+ * @param term array term
+ * @param is_head end of the recursion indicator
+ * @return std::pair<std::string, size_t> pair: array_name, current_depth
+ */
+std::pair<std::string, size_t> Solver::print_array_trace(const cvc5::Term& term, bool is_head)
+{
+    ASSERT(term.getKind() == cvc5::Kind::STORE || (term.getSort().isArray() && term.getKind() == cvc5::Kind::CONSTANT));
+    if (term.getSort().isArray() && term.getKind() == cvc5::Kind::CONSTANT) {
+        std::string arr_name = term.toString();
+        if (!this->cached_array_traces.contains(arr_name)) {
+            this->cached_array_traces.insert({ arr_name, 0 });
+        }
+        return { term.toString(), 1 };
+    }
+    auto [arr_name, cur_depth] = print_array_trace(term[0], /*is_head=*/false);
+    if (this->cached_array_traces[arr_name] < cur_depth) {
+        info(arr_name, "[", stringify_term(term[1]), "] = ", stringify_term(term[2]));
+    }
+    if (is_head) {
+        this->cached_array_traces[arr_name] = cur_depth;
+    }
+    return { arr_name, cur_depth + 1 };
+}
+
+/**
+ * @brief recover the array name from the nested assigments
+ *
+ * @param term array term
+ * @return std::string array name
+ */
+std::string Solver::get_array_name(const cvc5::Term& term)
+{
+    ASSERT(term.getKind() == cvc5::Kind::STORE || (term.getSort().isArray() && term.getKind() == cvc5::Kind::CONSTANT));
+    if (term.getKind() == cvc5::Kind::STORE) {
+        return get_array_name(term[0]);
+    }
+    return term.toString();
+}
+
+/**
+ * @brief print the trace of SET insertions up to previously printed ones
+ *
+ * @param term set term
+ * @param is_head end of the recursion indicator
+ * @return std::pair<std::string, size_t> pair: set_name, current_depth
+ */
+std::pair<std::string, size_t> Solver::print_set_trace(const cvc5::Term& term, bool is_head)
+{
+    ASSERT(term.getKind() == cvc5::Kind::SET_INSERT ||
+           (term.getSort().isSet() && term.getKind() == cvc5::Kind::CONSTANT));
+    if (term.getSort().isSet() && term.getKind() == cvc5::Kind::CONSTANT) {
+        std::string set_name = term.toString();
+        if (!this->cached_set_traces.contains(set_name)) {
+            this->cached_set_traces.insert({ set_name, 0 });
+        }
+        return { term.toString(), 1 };
+    }
+    auto [set_name, cur_depth] = print_set_trace(term[term.getNumChildren() - 1], /*is_head=*/false);
+    if (this->cached_set_traces[set_name] < cur_depth) {
+        std::string res = stringify_term(term[term.getNumChildren() - 1]) + " <- {";
+
+#ifdef SHOW_SYMBOLIC_SET_MEMBERS
+        for (size_t i = 0; i < term.getNumChildren() - 2; i++) {
+            res += stringify_term(term[i]) + ", ";
+        }
+        res += stringify_term(term[term.getNumChildren() - 2]);
+#else
+        res += "TOO MANY VALUES";
+#endif
+        res += "}";
+        info(res);
+    }
+    if (is_head) {
+        this->cached_array_traces[set_name] = cur_depth;
+    }
+    return { set_name, cur_depth + 1 };
+}
+
+/**
+ * @brief recover the set name from the nested assigments
+ *
+ * @param term set term
+ * @return std::string array name
+ */
+std::string Solver::get_set_name(const cvc5::Term& term)
+{
+    ASSERT(term.getKind() == cvc5::Kind::SET_INSERT ||
+           (term.getSort().isSet() && term.getKind() == cvc5::Kind::CONSTANT));
+    if (term.getKind() == cvc5::Kind::SET_INSERT) {
+        return get_set_name(term[term.getNumChildren() - 1]);
+    }
+    return term.toString();
+}
+
+/**
  * A simple recursive function that converts native smt language
  * to somewhat readable by humans.
  *
@@ -118,9 +216,6 @@ std::unordered_map<std::string, std::string> Solver::model(std::vector<cvc5::Ter
  * */
 std::string Solver::stringify_term(const cvc5::Term& term, bool parenthesis)
 {
-    if (term.getKind() == cvc5::Kind::CONSTANT) {
-        return term.toString();
-    }
     if (term.getKind() == cvc5::Kind::CONST_FINITE_FIELD) {
         return term.getFiniteFieldValue();
     }
@@ -135,21 +230,25 @@ std::string Solver::stringify_term(const cvc5::Term& term, bool parenthesis)
         return bool_res[static_cast<size_t>(term.getBooleanValue())];
     }
     // handling tuples
-    if (term.getKind() == cvc5::Kind::APPLY_CONSTRUCTOR) {
+    if (term.getSort().isTuple() && term.getKind() == cvc5::Kind::APPLY_CONSTRUCTOR) {
         std::string res = "(";
-        for (const auto& t : term) {
-            res += stringify_term(t) + ", ";
+        for (size_t i = 1; i < term.getNumChildren() - 1; i++) {
+            res += stringify_term(term[i]) + ", ";
         }
+        res += stringify_term(term[term.getNumChildren() - 1]);
         return res + ")";
-    }
-    if (term.getKind() == cvc5::Kind::INTERNAL_KIND) {
-        return "";
-    }
-    if (term.getKind() == cvc5::Kind::SET_INSERT) {
-        return "set_" + std::to_string(this->tables[term]);
     }
     if (term.getKind() == cvc5::Kind::SET_EMPTY) {
         return "{}";
+    }
+    if (term.getKind() == cvc5::Kind::CONSTANT) {
+        if (term.getSort().isSet()) {
+            return "{" + term.toString() + "}";
+        }
+        if (term.getSort().isArray()) {
+            return "[" + term.toString() + "]";
+        }
+        return term.toString();
     }
 
     std::string res;
@@ -166,7 +265,6 @@ std::string Solver::stringify_term(const cvc5::Term& term, bool parenthesis)
     case cvc5::Kind::SUB:
     case cvc5::Kind::BITVECTOR_SUB:
         op = " - ";
-        child_parenthesis = false;
         break;
     case cvc5::Kind::NEG:
     case cvc5::Kind::FINITE_FIELD_NEG:
@@ -241,26 +339,45 @@ std::string Solver::stringify_term(const cvc5::Term& term, bool parenthesis)
         op = " % ";
         parenthesis = true;
         break;
-    case cvc5::Kind::SET_MEMBER:
-        op = " in ";
-        parenthesis = true;
-        break;
+    case cvc5::Kind::SET_INSERT:
+        // Due to the specifics of sets implementation
+        // We can't print all the INSERTs in place
+        // In such case we will just return the array name
+        return get_set_name(term[term.getNumChildren() - 1]);
+    case cvc5::Kind::SET_MEMBER: {
+        // On the other hand, here I'll be printing the whole trace of the set
+        // initializations up to the previous print
+        ASSERT(term.getNumChildren() == 2);
+        std::string set_name = get_set_name(term[term.getNumChildren() - 1]);
+        print_set_trace(term[term.getNumChildren() - 1]);
+        std::string res = stringify_term(term[1], /*parenthesis=*/true) + " in " + set_name;
+        return res;
+    }
+    case cvc5::Kind::STORE: {
+        // Due to the specifics of arrays implementation
+        // We can't print all the STOREs in place
+        // In such case we will just return the array name
+        return get_array_name(term[0]);
+    }
+    case cvc5::Kind::SELECT: {
+        // On the other hand, here I'll be printing the whole trace of the array
+        // initializations up to the previous print
+        ASSERT(term.getNumChildren() == 2);
+        std::string res = get_array_name(term[0]);
+        print_array_trace(term[0]);
+        res += "[" + stringify_term(term[1]) + "]";
+        return res;
+    }
     default:
-        info("Invalid operand :", term.getKind());
-        info(term);
-        break;
+        info("\033[31m", "Unprocessed operand :", term.getKind(), "\033[0m");
+        info("\033[31m", term, "\033[0m");
+        return "failed to process";
     }
 
-    size_t i = 0;
-    cvc5::Term child;
-    for (const auto& t : term) {
-        if (i == term.getNumChildren() - 1) {
-            child = t;
-            break;
-        }
-        res += stringify_term(t, child_parenthesis) + op;
-        i += 1;
+    for (size_t i = 0; i < term.getNumChildren() - 1; i++) {
+        res += stringify_term(term[i], child_parenthesis) + op;
     }
+    cvc5::Term child = term[term.getNumChildren() - 1];
 
     res = res + stringify_term(child, child_parenthesis);
     if (back) {
@@ -281,46 +398,5 @@ void Solver::print_assertions()
     for (const auto& t : this->solver.getAssertions()) {
         info(this->stringify_term(t));
     }
-}
-
-cvc5::Term Solver::create_lookup_table(std::vector<std::vector<cvc5::Term>>& table)
-{
-    cvc5::Term tmp = table[0][0];
-    cvc5::Sort tuple_sort = this->term_manager.mkTupleSort({ tmp.getSort(), tmp.getSort(), tmp.getSort() });
-    cvc5::Sort relation = this->term_manager.mkSetSort(tuple_sort);
-    cvc5::Term resulting_table = this->term_manager.mkEmptySet(relation);
-
-    std::vector<cvc5::Term> children;
-    children.reserve(table.size() + 1);
-    for (auto& table_entry : table) {
-        cvc5::Term entry = this->term_manager.mkTuple(table_entry);
-        children.push_back(entry);
-    }
-    children.push_back(resulting_table);
-    cvc5::Term res = this->term_manager.mkTerm(cvc5::Kind::SET_INSERT, children);
-    size_t cursize = this->tables.size();
-    info("Creating table for op: ", children.size(), ", № ", cursize);
-    this->tables.insert({ res, cursize });
-    return res;
-}
-
-cvc5::Term Solver::create_table(std::vector<cvc5::Term>& table)
-{
-    cvc5::Term tmp = table[0];
-    cvc5::Sort relation = this->term_manager.mkSetSort(tmp.getSort());
-    cvc5::Term resulting_table = this->term_manager.mkEmptySet(relation);
-
-    std::vector<cvc5::Term> children;
-    children.reserve(table.size() + 1);
-    for (auto& table_entry : table) {
-        children.push_back(table_entry);
-    }
-    children.push_back(resulting_table);
-    cvc5::Term res = this->term_manager.mkTerm(cvc5::Kind::SET_INSERT, children);
-    size_t cursize = this->tables.size();
-    info("Creating table for range: ", children.size(), ", № ", cursize);
-
-    this->tables.insert({ res, cursize });
-    return res;
 }
 }; // namespace smt_solver

--- a/barretenberg/cpp/src/barretenberg/smt_verification/solver/solver.hpp
+++ b/barretenberg/cpp/src/barretenberg/smt_verification/solver/solver.hpp
@@ -5,6 +5,9 @@
 #include <cvc5/cvc5.h>
 
 #include "barretenberg/ecc/curves/bn254/fr.hpp"
+
+#define SHOW_SYMBOLIC_SET_MEMBERS
+
 namespace smt_solver {
 
 /**
@@ -15,6 +18,8 @@ namespace smt_solver {
  * @param debug set verbosity of cvc5: 0, 1, 2.
  *
  * @param ff_elim_disjunctive_bit tells solver to change all ((x = 0) | (x = 1)) to x*x = x.
+ * @param ff_bitsum tells solver to identify bitsums
+ *
  * @param ff_solver tells solver which finite field solver to use: "gb", "split".
  *
  * @param lookup_enabled tells solver to enable sets when we deal with lookups
@@ -25,13 +30,47 @@ struct SolverConfiguration {
     uint32_t debug;
 
     bool ff_elim_disjunctive_bit;
+    bool ff_bitsum;
     std::string ff_solver;
 
     bool lookup_enabled;
 };
 
-const SolverConfiguration default_solver_config = { true, 0, 0, false, "", false };
-const SolverConfiguration ultra_solver_config = { true, 0, 0, false, "", true };
+const SolverConfiguration default_solver_config = {
+    /*produce_models=*/true,
+    /*timeout=*/0,
+    /*debug=*/0,
+    /*ff_elim_disjunctive_bit=*/false,
+    /*ff_bitsum=*/false,
+    /*ff_solver=*/"gb",
+    /*lookup_enabled=*/true
+};
+
+const SolverConfiguration ultra_solver_config = {
+    /*produce_models=*/true,
+    /*timeout=*/0,
+    /*debug=*/0,
+    /*ff_elim_disjunctive_bit=*/false,
+    /*ff_bitsum=*/false,
+    /*ff_solver=*/"gb",
+    /*lookup_enabled=*/true
+};
+
+const SolverConfiguration split_gb_solver_config = {
+    /*produce_models=*/true,          /*timeout=*/0,      /*debug=*/0,
+    /*ff_elim_disjunctive_bit=*/true, /*ff_bitsum=*/true, /*ff_solver=*/"split",
+    /*lookup_enabled=*/true
+};
+
+const SolverConfiguration debug_solver_config = {
+    /*produce_models=*/true,
+    /*timeout=*/0,
+    /*debug=*/2,
+    /*ff_elim_disjunctive_bit=*/false,
+    /*ff_bitsum=*/false,
+    /*ff_solver=*/"gb",
+    /*lookup_enabled=*/true
+};
 
 /**
  * @brief Class for the solver.
@@ -50,8 +89,7 @@ class Solver {
     bool res = false;
     cvc5::Result cvc_result;
     bool checked = false;
-
-    std::unordered_map<cvc5::Term, size_t> tables;
+    bool lookup_enabled = false;
 
     explicit Solver(const std::string& modulus,
                     const SolverConfiguration& config = default_solver_config,
@@ -70,13 +108,19 @@ class Solver {
         }
         if (config.debug >= 1) {
             solver.setOption("verbosity", "5");
+            solver.setOption("stats", "true");
         }
         if (config.debug >= 2) {
+            solver.setOption("output", "inst");
             solver.setOption("output", "learned-lits");
             solver.setOption("output", "subs");
             solver.setOption("output", "post-asserts");
             solver.setOption("output", "trusted-proof-steps");
             solver.setOption("output", "deep-restart");
+            solver.setOption("output", "timout-core-benchmark");
+            solver.setOption("output", "unsat-core-benchmark");
+            solver.setOption("stats-all", "true");
+            solver.setOption("stats-internal", "true");
         }
 
         // Can be useful when split-gb is used as ff-solver.
@@ -95,11 +139,13 @@ class Solver {
             solver.setOption("ff-solver", config.ff_solver);
         }
 
-        if (lookup_enabled) {
+        if (config.lookup_enabled) {
             this->solver.setLogic("ALL");
             this->solver.setOption("finite-model-find", "true");
-            this->solver.setOption("sets-ext", "true");
-            lookup_enabled = true;
+            this->solver.setOption("sets-exp", "true");
+            this->solver.setOption("arrays-exp", "true");
+            this->solver.setOption("arrays-optimize-linear", "true");
+            this->lookup_enabled = true;
         }
 
         solver.setOption("output", "incomplete");
@@ -109,11 +155,6 @@ class Solver {
     Solver(Solver&& other) = delete;
     Solver& operator=(const Solver& other) = delete;
     Solver& operator=(Solver&& other) = delete;
-
-    bool lookup_enabled = false;
-
-    cvc5::Term create_lookup_table(std::vector<std::vector<cvc5::Term>>& table);
-    cvc5::Term create_table(std::vector<cvc5::Term>& table);
 
     void assertFormula(const cvc5::Term& term) const { this->solver.assertFormula(term); }
 
@@ -137,6 +178,16 @@ class Solver {
 
     void print_assertions();
     std::string stringify_term(const cvc5::Term& term, bool parenthesis = false);
+
+    std::string get_array_name(const cvc5::Term& term);
+    // TODO(alex): Keep track of terms names instead of depth. Should cut the recursion
+    std::pair<std::string, size_t> print_array_trace(const cvc5::Term& term, bool is_head = true);
+    std::unordered_map<std::string, size_t> cached_array_traces;
+
+    std::string get_set_name(const cvc5::Term& term);
+    // TODO(alex): Keep track of terms names instead of depth. Should cut the recursion
+    std::pair<std::string, size_t> print_set_trace(const cvc5::Term& term, bool is_head = true);
+    std::unordered_map<std::string, size_t> cached_set_traces;
 
     ~Solver() = default;
 };

--- a/barretenberg/cpp/src/barretenberg/smt_verification/terms/bool.test.cpp
+++ b/barretenberg/cpp/src/barretenberg/smt_verification/terms/bool.test.cpp
@@ -1,0 +1,88 @@
+#include "barretenberg/smt_verification/util/smt_util.hpp"
+#include "term.hpp"
+
+#include <gtest/gtest.h>
+
+namespace {
+auto& engine = bb::numeric::get_randomness();
+}
+
+using namespace bb;
+using namespace smt_terms;
+
+TEST(SymbolicBool, and)
+{
+    Solver slv("30644e72e131a029b85045b68181585d2833e84879b9709143e1f593f0000001");
+    bool a = static_cast<bool>(engine.get_random_uint8() & 1);
+    bool b = static_cast<bool>(engine.get_random_uint8() & 1);
+    bool c = a && b;
+
+    Bool x = Bool(std::string("x"), &slv);
+    Bool y = Bool(std::string("y"), &slv);
+    Bool z = x & y;
+
+    (x == Bool(a, &slv)).assert_term();
+    (y == Bool(b, &slv)).assert_term();
+    ASSERT_TRUE(slv.check());
+
+    bb::fr zvals = string_to_fr(slv[z], /*base=*/10);
+    ASSERT_EQ(bb::fr(c), zvals);
+}
+
+TEST(SymbolicBool, or)
+{
+    Solver slv("30644e72e131a029b85045b68181585d2833e84879b9709143e1f593f0000001");
+    bool a = static_cast<bool>(engine.get_random_uint8() & 1);
+    bool b = static_cast<bool>(engine.get_random_uint8() & 1);
+    bool c = a || b;
+
+    Bool x = Bool(std::string("x"), &slv);
+    Bool y = Bool(std::string("y"), &slv);
+    Bool z = x | y;
+
+    (x == Bool(a, &slv)).assert_term();
+    (y == Bool(b, &slv)).assert_term();
+    ASSERT_TRUE(slv.check());
+
+    bb::fr zvals = string_to_fr(slv[z], /*base=*/10);
+    ASSERT_EQ(bb::fr(c), zvals);
+}
+
+TEST(SymbolicBool, not )
+{
+    Solver slv("30644e72e131a029b85045b68181585d2833e84879b9709143e1f593f0000001");
+    bool a = static_cast<bool>(engine.get_random_uint8() & 1);
+    bool b = !a;
+
+    Bool x = Bool(std::string("x"), &slv);
+    Bool y = !x;
+
+    (y == Bool(b, &slv)).assert_term();
+    ASSERT_TRUE(slv.check());
+
+    bb::fr xvals = string_to_fr(slv[x], /*base=*/10);
+    ASSERT_EQ(bb::fr(a), xvals);
+}
+
+TEST(SymbolicBool, IfElse)
+{
+    Solver slv("30644e72e131a029b85045b68181585d2833e84879b9709143e1f593f0000001");
+
+    STerm x = FFVar("x", &slv);
+    STerm y = FFVar("y", &slv);
+
+    Bool if_ = Bool(x) == Bool(FFConst(1, &slv));
+    if_ &= Bool(y) == Bool(FFConst(7, &slv));
+
+    Bool else_ = Bool(x) != Bool(FFConst(1, &slv));
+    else_ &= Bool(y) == Bool(FFConst(8, &slv));
+
+    (if_ | else_).assert_term();
+
+    ASSERT_TRUE(slv.check());
+
+    bb::fr xval = string_to_fr(slv[x], /*base=*/10);
+    bb::fr yval = string_to_fr(slv[y], /*base=*/10);
+
+    ASSERT_TRUE((xval == 1 && yval == 7) || (xval != 1 && yval == 8));
+}

--- a/barretenberg/cpp/src/barretenberg/smt_verification/terms/data_structures.hpp
+++ b/barretenberg/cpp/src/barretenberg/smt_verification/terms/data_structures.hpp
@@ -1,0 +1,374 @@
+#pragma once
+#include <algorithm>
+#include <concepts>
+#include <iterator>
+
+#include "term.hpp"
+
+namespace smt_terms {
+using namespace smt_solver;
+
+/**
+ * @brief sym Tuple class
+ *
+ * @details allows to group separate STerms in one place
+ */
+class STuple {
+  public:
+    Solver* solver;
+    cvc5::Term term;
+    TermType type = TermType::STuple;
+
+    STuple()
+        : solver(nullptr)
+        , term(cvc5::Term()){};
+
+    STuple(const cvc5::Term& term, Solver* s, TermType type = TermType::STuple)
+        : solver(s)
+        , term(term)
+        , type(type){};
+
+    /**
+     * @brief Construct a new STuple object
+     *
+     * @param terms vector of terms to store in tuple
+     * @param s pointer to solver
+     */
+    STuple(const std::vector<STerm>& terms, Solver* s)
+        : solver(s)
+    {
+        ASSERT(terms.size() > 0);
+        std::vector<cvc5::Term> terms_;
+        terms_.reserve(terms.size());
+        auto map = [](const STerm& t) -> cvc5::Term { return t.term; };
+        std::transform(terms.begin(), terms.end(), std::back_inserter(terms_), map);
+        this->term = this->solver->term_manager.mkTuple(terms_);
+    }
+
+    /**
+     * @brief Get the obtained tuple sort
+     *
+     * @return cvc5::Sort
+     */
+    cvc5::Sort get_sort() const { return this->term.getSort(); }
+
+    operator std::string() const { return this->solver->stringify_term(term); };
+    operator cvc5::Term() const { return term; };
+
+    friend std::ostream& operator<<(std::ostream& out, const STuple& term)
+    {
+        return out << static_cast<std::string>(term);
+    };
+
+    STuple(const STuple& other) = default;
+    STuple(STuple&& other) = default;
+    STuple& operator=(const STuple& right) = default;
+    STuple& operator=(STuple&& right) = default;
+    ~STuple() = default;
+};
+
+template <typename T>
+concept ConstructibleFromTerm = requires(const cvc5::Term& term, Solver* s, TermType type) {
+    T{ term, s, type };
+};
+
+/**
+ * @brief symbolic Array class
+ *
+ * @details allows to group separate STerms in one place
+ * and perform operations over sym indicies
+ * Compatible parameters:
+ * STerm
+ * Bool
+ * STuple
+ * SymArray
+ * SymSet
+ */
+template <typename sym_index, ConstructibleFromTerm sym_entry> class SymArray {
+  private:
+  public:
+    Solver* solver;
+    cvc5::Term term;
+
+    TermType type = TermType::SymArray;
+    TermType ind_type;
+    TermType entry_type;
+
+    SymArray()
+        : solver(nullptr)
+        , term(cvc5::Term())
+        , ind_type(TermType::FFTerm)
+        , entry_type(TermType::FFTerm){};
+
+    SymArray(const cvc5::Term& term, Solver* s, TermType type = TermType::SymArray)
+        : solver(s)
+        , term(term)
+        , type(type)
+    {
+        ASSERT(this->solver->lookup_enabled);
+    };
+
+    /**
+     * @brief Construct an empty Symbolic Array object
+     *
+     * @param index_sort cvc5 Sort of an index
+     * @param index_type type of index Symbolic Term
+     * @param entry_sort cvc5 Sort of an entry
+     * @param entry_type type of entry Symbolic Term
+     * @param s pointer to solver
+     * @param name name of the resulting symbolic variable, defaults to var_{i}
+     */
+    SymArray(const cvc5::Sort& index_sort,
+             const TermType& index_type,
+             const cvc5::Sort& entry_sort,
+             const TermType& entry_type,
+             Solver* s,
+             const std::string& name = "")
+        : solver(s)
+        , ind_type(index_type)
+        , entry_type(entry_type)
+    {
+        cvc5::Sort Array = this->solver->term_manager.mkArraySort(index_sort, entry_sort);
+        if (name.empty()) {
+            this->term = this->solver->term_manager.mkConst(Array);
+        } else {
+            this->term = this->solver->term_manager.mkConst(Array, name);
+        }
+    }
+
+    /**
+     * @brief Construct a new Symbolic Array object
+     *
+     * @param indicies vector of symbolic objects
+     * @param entries vector of symbolic objects
+     * @param s pointer to solver
+     * @param name name of the resulting symbolic variable, defaults to var_{i}
+     */
+    SymArray(const std::vector<sym_index>& indicies,
+             const std::vector<sym_entry>& entries,
+             Solver* s,
+             const std::string& name = "")
+        : solver(s)
+    {
+        ASSERT(this->solver->lookup_enabled);
+        ASSERT(entries.size() > 0);
+        ASSERT(indicies.size() == entries.size());
+
+        this->ind_type = indicies[0].type;
+        this->entry_type = entries[0].type;
+
+        cvc5::Sort ind_sort = indicies[0].term.getSort();
+        cvc5::Sort entry_sort = entries[0].term.getSort();
+        cvc5::Sort Array = this->solver->term_manager.mkArraySort(ind_sort, entry_sort);
+        if (name.empty()) {
+            this->term = this->solver->term_manager.mkConst(Array);
+        } else {
+            this->term = this->solver->term_manager.mkConst(Array, name);
+        }
+
+        for (size_t i = 0; i < indicies.size(); i++) {
+            this->term =
+                this->solver->term_manager.mkTerm(cvc5::Kind::STORE, { this->term, indicies[i].term, entries[i].term });
+        }
+    }
+
+    /**
+     * @brief Construct a new Symbolic Array object
+     *
+     * @details Creates a vector-like array with constant integer indicies
+     *
+     * @param entries vector of symbolic entries
+     * @param index_base example of an index. Needed to extract the sort out of STerm
+     * @param s pointer to solver
+     * @param name name of the resulting symbolic variable, defaults to var_{i}
+     */
+    SymArray(const std::vector<sym_entry>& entries, const STerm& index_base, Solver* s, const std::string& name = "")
+        : solver(s)
+        , ind_type(index_base.type)
+    {
+        ASSERT(this->solver->lookup_enabled);
+        ASSERT(entries.size() > 0);
+
+        this->entry_type = entries[0].type;
+
+        cvc5::Sort ind_sort = index_base.term.getSort();
+        cvc5::Sort entry_sort = entries[0].term.getSort();
+        cvc5::Sort Array = this->solver->term_manager.mkArraySort(ind_sort, entry_sort);
+        if (name.empty()) {
+            this->term = this->solver->term_manager.mkConst(Array);
+        } else {
+            this->term = this->solver->term_manager.mkConst(Array, name);
+        }
+
+        for (size_t i = 0; i < entries.size(); i++) {
+            STerm idx = STerm::Const(i, this->solver, this->ind_type);
+            this->term = this->solver->term_manager.mkTerm(cvc5::Kind::STORE, { this->term, idx, entries[i] });
+        }
+    }
+
+    sym_entry get(const sym_index& ind) const
+    {
+        cvc5::Term res_term = this->solver->term_manager.mkTerm(cvc5::Kind::SELECT, { this->term, ind.term });
+        return { res_term, this->solver, this->entry_type };
+    }
+
+    sym_entry operator[](const sym_index& ind) const { return this->get(ind); }
+
+    void put(const sym_index& ind, const sym_entry& entry)
+    {
+        this->term = this->solver->term_manager.mkTerm(cvc5::Kind::STORE, { this->term, ind.term, entry.term });
+    }
+
+    operator std::string() const { return this->solver->stringify_term(term); };
+    operator cvc5::Term() const { return term; };
+
+    void print_trace() const { this->solver->print_array_trace(this->term); }
+
+    friend std::ostream& operator<<(std::ostream& out, const SymArray& term)
+    {
+        return out << static_cast<std::string>(term);
+    };
+
+    SymArray(const SymArray& other) = default;
+    SymArray(SymArray&& other) = default;
+    SymArray& operator=(const SymArray& right) = default;
+    SymArray& operator=(SymArray&& right) = default;
+    ~SymArray() = default;
+};
+
+/**
+ * @brief symbolic Set class
+ *
+ * @details allows to group separate STerms in one place
+ * and perform inclusion operations
+ * Compatible parameters:
+ * STerm
+ * Bool
+ * STuple
+ * SymArray
+ * SymSet
+ */
+template <ConstructibleFromTerm sym_entry> class SymSet {
+  private:
+  public:
+    Solver* solver;
+    cvc5::Term term;
+
+    TermType type = TermType::SymSet;
+    TermType entry_type;
+
+    SymSet()
+        : solver(nullptr)
+        , term(cvc5::Term())
+        , entry_type(TermType::FFTerm){};
+
+    SymSet(const cvc5::Term& term, Solver* s, TermType type = TermType::SymSet)
+        : solver(s)
+        , term(term)
+        , type(type){};
+
+    /**
+     * @brief Construct a new empty Symbolic Set object
+     *
+     * @param entry_sort cvc5 sort
+     * @param entry_type Symbolic term type
+     * @param s  pointer to solver
+     * @param name name of the resulting symbolic variable, defaults to var_{i}
+     */
+    SymSet(const cvc5::Sort& entry_sort, TermType entry_type, Solver* s, const std::string& name = "")
+        : solver(s)
+        , entry_type(entry_type)
+    {
+        cvc5::Sort Array = this->solver->term_manager.mkSetSort(entry_sort);
+        if (name.empty()) {
+            this->term = this->solver->term_manager.mkConst(Array);
+        } else {
+            this->term = this->solver->term_manager.mkConst(Array, name);
+        }
+    }
+
+    /**
+     * @brief Construct a new Symbolic Set object
+     *
+     * @param entries vector of symbolic entries
+     * @param s  pointer to solver
+     * @param name name of the resulting symbolic variable, defaults to var_{i}
+     */
+    SymSet(const std::vector<sym_entry>& entries, Solver* s, const std::string& name = "")
+        : solver(s)
+    {
+        ASSERT(this->solver->lookup_enabled);
+        ASSERT(entries.size() > 0);
+
+        this->entry_type = entries[0].type;
+
+        cvc5::Sort entry_sort = entries[0].term.getSort();
+        cvc5::Sort SET = this->solver->term_manager.mkSetSort(entry_sort);
+        if (name.empty()) {
+            this->term = this->solver->term_manager.mkConst(SET);
+        } else {
+            this->term = this->solver->term_manager.mkConst(SET, name);
+        }
+
+        std::vector<cvc5::Term> terms_;
+        terms_.reserve(entries.size() + 1);
+        auto map = [](const sym_entry& t) -> cvc5::Term { return t.term; };
+        std::transform(entries.begin(), entries.end(), std::back_inserter(terms_), map);
+
+        terms_.push_back(this->term);
+        this->term = this->solver->term_manager.mkTerm(cvc5::Kind::SET_INSERT, terms_);
+    }
+
+    void insert(const sym_entry& entry)
+    {
+        this->term = this->solver->term_manager.mkTerm(cvc5::Kind::SET_INSERT, { entry.term, this->term });
+    }
+
+    /**
+     * @brief Create an inclusion constraint
+     *
+     * @param entry entry to be checked
+     * @todo (alex) maybe it should return the term value, for bool comaptibility
+     */
+    void contains(const sym_entry& entry) const
+    {
+        // TODO(alex): Should use entry.normalize() here, but didn't come up with any quick solution
+        // other than adding a SymbolicBase class or smth
+        sym_entry left = entry;
+        cvc5::Term inclusion = this->solver->term_manager.mkTerm(cvc5::Kind::SET_MEMBER, { entry.term, this->term });
+        this->solver->assertFormula(inclusion);
+    }
+
+    /**
+     * @brief Create an inclusion constraint
+     *
+     * @param entry entry to be checked
+     */
+    void not_contains(const sym_entry& entry) const
+    {
+        // TODO(alex): Should use entry.normalize() here, but didn't come up with any quick solution
+        // other than adding a SymbolicBase class or smth
+        sym_entry left = entry;
+        cvc5::Term inclusion = this->solver->term_manager.mkTerm(cvc5::Kind::SET_MEMBER, { entry.term, this->term });
+        cvc5::Term not_inclusion = this->solver->term_manager.mkTerm(cvc5::Kind::NOT, { inclusion });
+        this->solver->assertFormula(not_inclusion);
+    }
+
+    operator std::string() const { return this->solver->stringify_term(term); };
+    operator cvc5::Term() const { return term; };
+
+    void print_trace() const { this->solver->print_set_trace(this->term); }
+
+    friend std::ostream& operator<<(std::ostream& out, const SymSet& term)
+    {
+        return out << static_cast<std::string>(term);
+    };
+
+    SymSet(const SymSet& other) = default;
+    SymSet(SymSet&& other) = default;
+    SymSet& operator=(const SymSet& right) = default;
+    SymSet& operator=(SymSet&& right) = default;
+    ~SymSet() = default;
+};
+
+} // namespace smt_terms

--- a/barretenberg/cpp/src/barretenberg/smt_verification/terms/data_structures.hpp
+++ b/barretenberg/cpp/src/barretenberg/smt_verification/terms/data_structures.hpp
@@ -32,12 +32,14 @@ class STuple {
      * @brief Construct a new STuple object
      *
      * @param terms vector of terms to store in tuple
-     * @param s pointer to solver
      */
-    STuple(const std::vector<STerm>& terms, Solver* s)
-        : solver(s)
+    STuple(const std::vector<STerm>& terms)
     {
-        ASSERT(terms.size() > 0);
+        if (terms.size() == 0) {
+            throw std::invalid_argument("Empty vector occured during STuple initialization");
+        }
+        this->solver = terms[0].solver;
+
         std::vector<cvc5::Term> terms_;
         terms_.reserve(terms.size());
         auto map = [](const STerm& t) -> cvc5::Term { return t.term; };
@@ -105,7 +107,9 @@ template <typename sym_index, ConstructibleFromTerm sym_entry> class SymArray {
         , term(term)
         , type(type)
     {
-        ASSERT(this->solver->lookup_enabled);
+        if (!this->solver->lookup_enabled) {
+            throw std::logic_error("You have to enable lookups during Solver initialization");
+        }
     };
 
     /**
@@ -128,6 +132,10 @@ template <typename sym_index, ConstructibleFromTerm sym_entry> class SymArray {
         , ind_type(index_type)
         , entry_type(entry_type)
     {
+        if (!this->solver->lookup_enabled) {
+            throw std::logic_error("You have to enable lookups during Solver initialization");
+        }
+
         cvc5::Sort Array = this->solver->term_manager.mkArraySort(index_sort, entry_sort);
         if (name.empty()) {
             this->term = this->solver->term_manager.mkConst(Array);
@@ -141,18 +149,25 @@ template <typename sym_index, ConstructibleFromTerm sym_entry> class SymArray {
      *
      * @param indicies vector of symbolic objects
      * @param entries vector of symbolic objects
-     * @param s pointer to solver
      * @param name name of the resulting symbolic variable, defaults to var_{i}
      */
     SymArray(const std::vector<sym_index>& indicies,
              const std::vector<sym_entry>& entries,
-             Solver* s,
              const std::string& name = "")
-        : solver(s)
     {
-        ASSERT(this->solver->lookup_enabled);
-        ASSERT(entries.size() > 0);
-        ASSERT(indicies.size() == entries.size());
+        if (entries.size() == 0 || indicies.size() == 0) {
+            throw std::invalid_argument("Empty vector occured during SymArray initialization");
+        }
+
+        if (entries.size() != indicies.size()) {
+            throw std::invalid_argument("Indicies must have the same dimension as entries.");
+        }
+
+        this->solver = entries[0].solver;
+
+        if (!this->solver->lookup_enabled) {
+            throw std::logic_error("You have to enable lookups during Solver initialization");
+        }
 
         this->ind_type = indicies[0].type;
         this->entry_type = entries[0].type;
@@ -179,15 +194,19 @@ template <typename sym_index, ConstructibleFromTerm sym_entry> class SymArray {
      *
      * @param entries vector of symbolic entries
      * @param index_base example of an index. Needed to extract the sort out of STerm
-     * @param s pointer to solver
      * @param name name of the resulting symbolic variable, defaults to var_{i}
      */
-    SymArray(const std::vector<sym_entry>& entries, const STerm& index_base, Solver* s, const std::string& name = "")
-        : solver(s)
-        , ind_type(index_base.type)
+    SymArray(const std::vector<sym_entry>& entries, const STerm& index_base, const std::string& name = "")
+        : ind_type(index_base.type)
     {
-        ASSERT(this->solver->lookup_enabled);
-        ASSERT(entries.size() > 0);
+        if (entries.size() == 0) {
+            throw std::invalid_argument("Empty vector occured during SymArray initialization");
+        }
+        this->solver = entries[0].solver;
+
+        if (!this->solver->lookup_enabled) {
+            throw std::logic_error("You have to enable lookups during Solver initialization");
+        }
 
         this->entry_type = entries[0].type;
 
@@ -279,6 +298,10 @@ template <ConstructibleFromTerm sym_entry> class SymSet {
         : solver(s)
         , entry_type(entry_type)
     {
+        if (!this->solver->lookup_enabled) {
+            throw std::logic_error("You have to enable lookups during Solver initialization");
+        }
+
         cvc5::Sort Array = this->solver->term_manager.mkSetSort(entry_sort);
         if (name.empty()) {
             this->term = this->solver->term_manager.mkConst(Array);
@@ -291,14 +314,18 @@ template <ConstructibleFromTerm sym_entry> class SymSet {
      * @brief Construct a new Symbolic Set object
      *
      * @param entries vector of symbolic entries
-     * @param s  pointer to solver
      * @param name name of the resulting symbolic variable, defaults to var_{i}
      */
-    SymSet(const std::vector<sym_entry>& entries, Solver* s, const std::string& name = "")
-        : solver(s)
+    SymSet(const std::vector<sym_entry>& entries, const std::string& name = "")
     {
-        ASSERT(this->solver->lookup_enabled);
-        ASSERT(entries.size() > 0);
+        if (entries.size() == 0) {
+            throw std::invalid_argument("Empty vector occured during SymSet initialization");
+        }
+
+        this->solver = entries[0].solver;
+        if (!this->solver->lookup_enabled) {
+            throw std::logic_error("You have to enable lookups during Solver initialization");
+        }
 
         this->entry_type = entries[0].type;
 

--- a/barretenberg/cpp/src/barretenberg/smt_verification/terms/data_structures.test.cpp
+++ b/barretenberg/cpp/src/barretenberg/smt_verification/terms/data_structures.test.cpp
@@ -19,7 +19,7 @@ TEST(SymbolicTuple, Initialization)
     STerm x = FFVar("x", &s);
     STerm y = FFVar("y", &s);
     STerm z = x + y;
-    STuple tup({ x, y, z }, &s);
+    STuple tup({ x, y, z });
     info(tup);
     info(tup.get_sort());
 }
@@ -35,7 +35,7 @@ TEST(SymbolicArray, InitMapSTermSTerm)
 
     std::vector<STerm> indicies = { x, q };
     std::vector<STerm> entries = { q, y };
-    SymArray<STerm, STerm> arr(indicies, entries, &s, "Array");
+    SymArray<STerm, STerm> arr(indicies, entries, "Array");
     info(arr);
     arr.print_trace();
 }
@@ -50,7 +50,7 @@ TEST(SymbolicArray, InitVecSTerm)
     STerm q = x * y;
 
     std::vector<STerm> entries = { q, y };
-    SymArray<STerm, STerm> arr(entries, FFConst(1, &s), &s, "Array");
+    SymArray<STerm, STerm> arr(entries, FFConst(1, &s), "Array");
     info(arr);
     arr.print_trace();
 }
@@ -64,14 +64,14 @@ TEST(SymbolicArray, InitMapSTupleSTuple)
     STerm z = x + y;
     STerm q = x * y;
 
-    STuple t1({ x, y }, &s);
-    STuple t2({ z, x }, &s);
-    STuple t3({ q, z }, &s);
-    STuple t4({ q + z, x }, &s);
+    STuple t1({ x, y });
+    STuple t2({ z, x });
+    STuple t3({ q, z });
+    STuple t4({ q + z, x });
 
     std::vector<STuple> indicies = { t1, t2 };
     std::vector<STuple> entries = { t3, t4 };
-    SymArray<STuple, STuple> arr(indicies, entries, &s, /*name=*/"Array");
+    SymArray<STuple, STuple> arr(indicies, entries, /*name=*/"Array");
     info(arr);
     arr.print_trace();
 }
@@ -85,13 +85,13 @@ TEST(SymbolicArray, InitVecSTuple)
     STerm z = x + y;
     STerm q = x * y;
 
-    STuple t1({ x, y }, &s);
-    STuple t2({ z, x }, &s);
-    STuple t3({ q, z }, &s);
-    STuple t4({ q + z, x }, &s);
+    STuple t1({ x, y });
+    STuple t2({ z, x });
+    STuple t3({ q, z });
+    STuple t4({ q + z, x });
 
     std::vector<STuple> entries = { t3, t4 };
-    SymArray<STerm, STuple> arr(entries, IConst(1, &s), &s, "Array");
+    SymArray<STerm, STuple> arr(entries, IConst(1, &s), "Array");
     info(arr);
     arr.print_trace();
 }
@@ -105,14 +105,14 @@ TEST(SymbolicArray, InitMapSTupleSTerm)
     STerm z = x + y;
     STerm q = x * y;
 
-    STuple t1({ x, y }, &s);
-    STuple t2({ z, x }, &s);
-    STuple t3({ q, z }, &s);
-    STuple t4({ q + z, x }, &s);
+    STuple t1({ x, y });
+    STuple t2({ z, x });
+    STuple t3({ q, z });
+    STuple t4({ q + z, x });
 
     std::vector<STuple> indicies = { t3, t4 };
     std::vector<STerm> entries = { q, z };
-    SymArray<STuple, STerm> arr(indicies, entries, &s, "Array");
+    SymArray<STuple, STerm> arr(indicies, entries, "Array");
     info(arr);
     arr.print_trace();
 }
@@ -126,7 +126,7 @@ TEST(SymbolicSet, InitVecSTerm)
     STerm z = x + y;
     STerm q = x * y;
 
-    SymSet<STerm> set({ x, y, z, q }, &s, "Set");
+    SymSet<STerm> set({ x, y, z, q }, "Set");
     info(set);
     set.print_trace();
 }
@@ -140,12 +140,12 @@ TEST(SymbolicSet, InitVecSTuple)
     STerm z = x + y;
     STerm q = x * y;
 
-    STuple t1({ x, y }, &s);
-    STuple t2({ z, x }, &s);
-    STuple t3({ q, z }, &s);
-    STuple t4({ q + z, x }, &s);
+    STuple t1({ x, y });
+    STuple t2({ z, x });
+    STuple t3({ q, z });
+    STuple t4({ q + z, x });
 
-    SymSet<STuple> arr({ t1, t2, t3, t4 }, &s, "Set");
+    SymSet<STuple> arr({ t1, t2, t3, t4 }, "Set");
     info(arr);
     arr.print_trace();
 }
@@ -190,14 +190,14 @@ TEST(SymbolicArray, InitSymArraySTerm)
     STerm z = x + y;
     STerm q = x * y;
 
-    STuple t1({ x, y }, &s);
-    STuple t2({ z, x }, &s);
-    STuple t3({ q, z }, &s);
-    STuple t4({ q + z, x }, &s);
+    STuple t1({ x, y });
+    STuple t2({ z, x });
+    STuple t3({ q, z });
+    STuple t4({ q + z, x });
 
     std::vector<STuple> indicies = { t1, t2, t3 };
     std::vector<STerm> entries = { x, z, q };
-    SymArray<STuple, STerm> arr(indicies, entries, &s, "mini_arr");
+    SymArray<STuple, STerm> arr(indicies, entries, "mini_arr");
 
     cvc5::Sort ind_sort = arr.term.getSort();
     TermType ind_type = arr.type;
@@ -301,17 +301,17 @@ TEST(SymbolicArray, LookupTable)
 {
     Solver slv("30644e72e131a029b85045b68181585d2833e84879b9709143e1f593f0000001");
 
-    STuple table_idx1({ FFConst("1", &slv), FFConst("2", &slv) }, &slv);
+    STuple table_idx1({ FFConst("1", &slv), FFConst("2", &slv) });
     STerm table_entry1 = FFConst("3", &slv);
 
-    STuple table_idx2({ FFConst("4", &slv), FFConst("5", &slv) }, &slv);
+    STuple table_idx2({ FFConst("4", &slv), FFConst("5", &slv) });
     STerm table_entry2 = FFConst("6", &slv);
 
-    SymArray<STuple, STerm> stable({ table_idx1, table_idx2 }, { table_entry1, table_entry2 }, &slv, "guess_next");
+    SymArray<STuple, STerm> stable({ table_idx1, table_idx2 }, { table_entry1, table_entry2 }, "guess_next");
 
     STerm x = FFVar("x", &slv);
     STerm y = FFVar("y", &slv);
-    STuple entry({ x, y }, &slv);
+    STuple entry({ x, y });
 
     STerm z = stable[entry];
     y - x == 1;
@@ -332,14 +332,14 @@ TEST(SymbolicSet, LookupTable)
 {
     Solver slv("30644e72e131a029b85045b68181585d2833e84879b9709143e1f593f0000001");
 
-    STuple table_entry1({ FFConst("1", &slv), FFConst("2", &slv), FFConst("3", &slv) }, &slv);
-    STuple table_entry2({ FFConst("4", &slv), FFConst("5", &slv), FFConst("6", &slv) }, &slv);
-    SymSet<STuple> stable({ table_entry1, table_entry2 }, &slv, "guess_next");
+    STuple table_entry1({ FFConst("1", &slv), FFConst("2", &slv), FFConst("3", &slv) });
+    STuple table_entry2({ FFConst("4", &slv), FFConst("5", &slv), FFConst("6", &slv) });
+    SymSet<STuple> stable({ table_entry1, table_entry2 }, "guess_next");
 
     STerm x = FFVar("x", &slv);
     STerm y = FFVar("y", &slv);
     STerm z = FFVar("z", &slv);
-    STuple entry({ x, y, z }, &slv);
+    STuple entry({ x, y, z });
 
     stable.contains(entry);
     x != 4;

--- a/barretenberg/cpp/src/barretenberg/smt_verification/terms/data_structures.test.cpp
+++ b/barretenberg/cpp/src/barretenberg/smt_verification/terms/data_structures.test.cpp
@@ -1,0 +1,355 @@
+#include "data_structures.hpp"
+#include "barretenberg/smt_verification/util/smt_util.hpp"
+
+#include <gtest/gtest.h>
+
+namespace {
+auto& engine = bb::numeric::get_randomness();
+}
+
+using namespace bb;
+using namespace smt_terms;
+
+// --- Basic initialization tests
+
+// Test that tuple is constructed without any issues
+TEST(SymbolicTuple, Initialization)
+{
+    Solver s("30644e72e131a029b85045b68181585d2833e84879b9709143e1f593f0000001");
+    STerm x = FFVar("x", &s);
+    STerm y = FFVar("y", &s);
+    STerm z = x + y;
+    STuple tup({ x, y, z }, &s);
+    info(tup);
+    info(tup.get_sort());
+}
+
+// Test Array initialization FF -> FF, from unordered_map
+TEST(SymbolicArray, InitMapSTermSTerm)
+{
+    Solver s("30644e72e131a029b85045b68181585d2833e84879b9709143e1f593f0000001");
+    STerm x = FFVar("x", &s);
+    STerm y = FFVar("y", &s);
+    STerm z = x + y;
+    STerm q = x * y;
+
+    std::vector<STerm> indicies = { x, q };
+    std::vector<STerm> entries = { q, y };
+    SymArray<STerm, STerm> arr(indicies, entries, &s, "Array");
+    info(arr);
+    arr.print_trace();
+}
+
+// Test Array initialization FF -> FF, from vector
+TEST(SymbolicArray, InitVecSTerm)
+{
+    Solver s("30644e72e131a029b85045b68181585d2833e84879b9709143e1f593f0000001");
+    STerm x = FFVar("x", &s);
+    STerm y = FFVar("y", &s);
+    STerm z = x + y;
+    STerm q = x * y;
+
+    std::vector<STerm> entries = { q, y };
+    SymArray<STerm, STerm> arr(entries, FFConst(1, &s), &s, "Array");
+    info(arr);
+    arr.print_trace();
+}
+
+// Test Array initialization Tuple<FF> -> Tuple<FF>, from unordered_map
+TEST(SymbolicArray, InitMapSTupleSTuple)
+{
+    Solver s("30644e72e131a029b85045b68181585d2833e84879b9709143e1f593f0000001");
+    STerm x = FFVar("x", &s);
+    STerm y = FFVar("y", &s);
+    STerm z = x + y;
+    STerm q = x * y;
+
+    STuple t1({ x, y }, &s);
+    STuple t2({ z, x }, &s);
+    STuple t3({ q, z }, &s);
+    STuple t4({ q + z, x }, &s);
+
+    std::vector<STuple> indicies = { t1, t2 };
+    std::vector<STuple> entries = { t3, t4 };
+    SymArray<STuple, STuple> arr(indicies, entries, &s, /*name=*/"Array");
+    info(arr);
+    arr.print_trace();
+}
+
+// Test Array initialization Int -> Tuple<FF>, from vector
+TEST(SymbolicArray, InitVecSTuple)
+{
+    Solver s("30644e72e131a029b85045b68181585d2833e84879b9709143e1f593f0000001");
+    STerm x = FFVar("x", &s);
+    STerm y = FFVar("y", &s);
+    STerm z = x + y;
+    STerm q = x * y;
+
+    STuple t1({ x, y }, &s);
+    STuple t2({ z, x }, &s);
+    STuple t3({ q, z }, &s);
+    STuple t4({ q + z, x }, &s);
+
+    std::vector<STuple> entries = { t3, t4 };
+    SymArray<STerm, STuple> arr(entries, IConst(1, &s), &s, "Array");
+    info(arr);
+    arr.print_trace();
+}
+
+// Test Array initialization Tuple<FF> -> FF, from unordered_map
+TEST(SymbolicArray, InitMapSTupleSTerm)
+{
+    Solver s("30644e72e131a029b85045b68181585d2833e84879b9709143e1f593f0000001");
+    STerm x = FFVar("x", &s);
+    STerm y = FFVar("y", &s);
+    STerm z = x + y;
+    STerm q = x * y;
+
+    STuple t1({ x, y }, &s);
+    STuple t2({ z, x }, &s);
+    STuple t3({ q, z }, &s);
+    STuple t4({ q + z, x }, &s);
+
+    std::vector<STuple> indicies = { t3, t4 };
+    std::vector<STerm> entries = { q, z };
+    SymArray<STuple, STerm> arr(indicies, entries, &s, "Array");
+    info(arr);
+    arr.print_trace();
+}
+
+// Test Set initialization { FF }, from vector
+TEST(SymbolicSet, InitVecSTerm)
+{
+    Solver s("30644e72e131a029b85045b68181585d2833e84879b9709143e1f593f0000001");
+    STerm x = FFVar("x", &s);
+    STerm y = FFVar("y", &s);
+    STerm z = x + y;
+    STerm q = x * y;
+
+    SymSet<STerm> set({ x, y, z, q }, &s, "Set");
+    info(set);
+    set.print_trace();
+}
+
+// Test Set initialization { Tuple<FF> }, from vector
+TEST(SymbolicSet, InitVecSTuple)
+{
+    Solver s("30644e72e131a029b85045b68181585d2833e84879b9709143e1f593f0000001");
+    STerm x = FFVar("x", &s);
+    STerm y = FFVar("y", &s);
+    STerm z = x + y;
+    STerm q = x * y;
+
+    STuple t1({ x, y }, &s);
+    STuple t2({ z, x }, &s);
+    STuple t3({ q, z }, &s);
+    STuple t4({ q + z, x }, &s);
+
+    SymSet<STuple> arr({ t1, t2, t3, t4 }, &s, "Set");
+    info(arr);
+    arr.print_trace();
+}
+
+// Test
+// - empty set initialization
+// - Set insert method
+// - Set contains method
+TEST(SymbolicSet, Contains)
+{
+    Solver slv("30644e72e131a029b85045b68181585d2833e84879b9709143e1f593f0000001");
+    STerm x = FFVar("x", &slv);
+    x == 1;
+    STerm y = x + 1;
+
+    SymSet<STerm> set(x.term.getSort(), x.type, &slv, "Set");
+    set.insert(x);
+    set.insert(y);
+
+    STerm z = FFConst(3, &slv);
+    set.not_contains(z);
+
+    STerm q = 2 * x;
+    set.contains(q);
+
+    ASSERT_TRUE(slv.check());
+}
+
+// --- Advanced tests
+
+// Test an empty Array initialization (Tuple<FF> -> FF) -> FF:
+// - we can create an empty array
+// - we can pass Symbolic Array as index for another Symbolic Array
+// - we can put values in Array
+// - we can get vlalues from Array
+// Also test the trigger case for printing an array trace
+TEST(SymbolicArray, InitSymArraySTerm)
+{
+    Solver s("30644e72e131a029b85045b68181585d2833e84879b9709143e1f593f0000001");
+    STerm x = FFVar("x", &s);
+    STerm y = FFVar("y", &s);
+    STerm z = x + y;
+    STerm q = x * y;
+
+    STuple t1({ x, y }, &s);
+    STuple t2({ z, x }, &s);
+    STuple t3({ q, z }, &s);
+    STuple t4({ q + z, x }, &s);
+
+    std::vector<STuple> indicies = { t1, t2, t3 };
+    std::vector<STerm> entries = { x, z, q };
+    SymArray<STuple, STerm> arr(indicies, entries, &s, "mini_arr");
+
+    cvc5::Sort ind_sort = arr.term.getSort();
+    TermType ind_type = arr.type;
+    cvc5::Sort entry_sort = x.term.getSort();
+    TermType entry_type = x.type;
+    SymArray<SymArray<STuple, STerm>, STerm> arrarr(ind_sort, ind_type, entry_sort, entry_type, &s, "BIG_arr");
+
+    arrarr.put(arr, y);
+    // this will not print anything related to `arr`
+    info(arrarr);
+    arrarr.print_trace();
+
+    arrarr.put(arr, arr.get(t1));
+    // this will
+    info(arrarr);
+    arrarr.print_trace();
+}
+
+// Example of a somewhat unordinary array use case
+// Take an array that maps int -> FF
+// Obtain two different solutions to x^2 + y^2 = 50 over integers
+// constrain the array entries so we can have a unique solution
+TEST(SymbolicArray, SimpleUseCase)
+{
+    Solver slv("30644e72e131a029b85045b68181585d2833e84879b9709143e1f593f0000001");
+    STerm x = IVar("x", &slv);
+    STerm y = IVar("y", &slv);
+    x > 0;
+    y > 0;
+    x < y;
+    STerm z = x * x + y * y;
+    STerm q = x * y + y * x;
+
+    STerm a = FFVar("a", &slv);
+    STerm b = FFVar("c", &slv);
+    STerm c = a * a - b;
+    c == 17;
+
+    cvc5::Sort ind_sort = z.term.getSort();
+    TermType ind_type = z.type;
+    cvc5::Sort entry_sort = c.term.getSort();
+    TermType entry_type = c.type;
+    // Indicies are ints and entries are FF!
+    SymArray<STerm, STerm> arr(ind_sort, ind_type, entry_sort, entry_type, &slv, "Int -> FF");
+
+    arr.put(z, b);
+    arr.put(q, a);
+
+    STerm m = IVar("m", &slv);
+    STerm n = IVar("n", &slv);
+    m > 0;
+    n > 0;
+    m <= n;
+
+    STerm k = m * m + n * n;
+    // 50 = 25 + 25 = 1 + 49
+    k == 50;
+    z == 50;
+    m != x;
+    n != y;
+
+    // k was not in the array, but the value is the same
+    STerm result = arr[k];
+    // In this particular system same as b == -1
+    result == bb::fr::neg_one();
+    slv.print_assertions();
+
+    ASSERT_TRUE(slv.check());
+    ASSERT_EQ(string_to_fr(slv[x], /*base=*/10), bb::fr(1));
+    ASSERT_EQ(string_to_fr(slv[y], /*base=*/10), bb::fr(7));
+    ASSERT_EQ(string_to_fr(slv[m], /*base=*/10), bb::fr(5));
+    ASSERT_EQ(string_to_fr(slv[n], /*base=*/10), bb::fr(5));
+    ASSERT_EQ(string_to_fr(slv[a * a], /*base=*/10), bb::fr(16));
+}
+
+// Test that we can successfully overwrite values in the array
+TEST(SymbolicArray, OverWrite)
+{
+    Solver slv("30644e72e131a029b85045b68181585d2833e84879b9709143e1f593f0000001");
+    STerm x = BVVar("x", &slv);
+    STerm y = BVVar("y", &slv);
+
+    STerm a = IConst(3, &slv);
+    STerm b = IConst("4", &slv, /*base=*/10);
+    ;
+
+    SymArray<STerm, STerm> table(x.term.getSort(), x.type, a.term.getSort(), a.type, &slv, /*name=*/"rewrite");
+
+    table.put(x, a);
+    table.put(y, b);
+    x == y;
+
+    STerm z = table[x];
+
+    ASSERT_TRUE(slv.check());
+    ASSERT_EQ(string_to_fr(slv[z], /*base=*/10), bb::fr(4));
+}
+
+// Test that we can mimic lookup tables functionality using arrays
+TEST(SymbolicArray, LookupTable)
+{
+    Solver slv("30644e72e131a029b85045b68181585d2833e84879b9709143e1f593f0000001");
+
+    STuple table_idx1({ FFConst("1", &slv), FFConst("2", &slv) }, &slv);
+    STerm table_entry1 = FFConst("3", &slv);
+
+    STuple table_idx2({ FFConst("4", &slv), FFConst("5", &slv) }, &slv);
+    STerm table_entry2 = FFConst("6", &slv);
+
+    SymArray<STuple, STerm> stable({ table_idx1, table_idx2 }, { table_entry1, table_entry2 }, &slv, "guess_next");
+
+    STerm x = FFVar("x", &slv);
+    STerm y = FFVar("y", &slv);
+    STuple entry({ x, y }, &slv);
+
+    STerm z = stable[entry];
+    y - x == 1;
+    y + x == 3;
+
+    ASSERT_TRUE(slv.check());
+
+    std::string xval = slv[x];
+    ASSERT_EQ(xval, "1");
+    std::string yval = slv[y];
+    ASSERT_EQ(yval, "2");
+    std::string zval = slv[z];
+    ASSERT_EQ(zval, "3");
+}
+
+// Test that we can mimic lookup tables functionality using sets
+TEST(SymbolicSet, LookupTable)
+{
+    Solver slv("30644e72e131a029b85045b68181585d2833e84879b9709143e1f593f0000001");
+
+    STuple table_entry1({ FFConst("1", &slv), FFConst("2", &slv), FFConst("3", &slv) }, &slv);
+    STuple table_entry2({ FFConst("4", &slv), FFConst("5", &slv), FFConst("6", &slv) }, &slv);
+    SymSet<STuple> stable({ table_entry1, table_entry2 }, &slv, "guess_next");
+
+    STerm x = FFVar("x", &slv);
+    STerm y = FFVar("y", &slv);
+    STerm z = FFVar("z", &slv);
+    STuple entry({ x, y, z }, &slv);
+
+    stable.contains(entry);
+    x != 4;
+
+    ASSERT_TRUE(slv.check());
+
+    std::string xval = slv[x];
+    ASSERT_EQ(xval, "1");
+    std::string yval = slv[y];
+    ASSERT_EQ(yval, "2");
+    std::string zval = slv[z];
+    ASSERT_EQ(zval, "3");
+}

--- a/barretenberg/cpp/src/barretenberg/smt_verification/terms/ffterm.test.cpp
+++ b/barretenberg/cpp/src/barretenberg/smt_verification/terms/ffterm.test.cpp
@@ -83,31 +83,6 @@ TEST(FFTerm, division)
     ASSERT_EQ(b, yvals);
 }
 
-TEST(FFTerm, set_inclusion)
-{
-    Solver s("30644e72e131a029b85045b68181585d2833e84879b9709143e1f593f0000001");
-
-    std::vector<std::vector<cvc5::Term>> table = { { FFConst("1", &s), FFConst("2", &s), FFConst("3", &s) },
-                                                   { FFConst("4", &s), FFConst("5", &s), FFConst("6", &s) } };
-    cvc5::Term symbolic_table = s.create_lookup_table(table);
-
-    STerm x = FFVar("x", &s);
-    STerm y = FFVar("y", &s);
-    STerm z = FFVar("z", &s);
-    std::vector<STerm> tmp_vec = { x, y, z };
-    STerm::in_table(tmp_vec, symbolic_table);
-    x != 4;
-
-    ASSERT_TRUE(s.check());
-
-    std::string xval = s[x];
-    ASSERT_EQ(xval, "1");
-    std::string yval = s[y];
-    ASSERT_EQ(yval, "2");
-    std::string zval = s[z];
-    ASSERT_EQ(zval, "3");
-}
-
 // This test aims to check for the absence of unintended
 // behavior. If an unsupported operator is called, an info message appears in stderr
 // and the value is supposed to remain unchanged.

--- a/barretenberg/cpp/src/barretenberg/smt_verification/terms/term.cpp
+++ b/barretenberg/cpp/src/barretenberg/smt_verification/terms/term.cpp
@@ -78,6 +78,10 @@ STerm::STerm(const std::string& t, Solver* slv, bool isconst, uint32_t base, Ter
         case TermType::BVTerm:
             this->term = slv->term_manager.mkConst(slv->bv_sort, t);
             break;
+        default:
+            info("Invalid TermType was provided for STerm constructor. Expected: FFTerm, FFITerm, ITerm, BVTerm. Got: ",
+                 type);
+            abort();
         }
     } else {
         std::string strvalue;
@@ -100,6 +104,10 @@ STerm::STerm(const std::string& t, Solver* slv, bool isconst, uint32_t base, Ter
             strvalue = slv->term_manager.mkFiniteFieldElem(t, slv->ff_sort, base).getFiniteFieldValue();
             this->term = slv->term_manager.mkBitVector(slv->bv_sort.getBitVectorSize(), strvalue, 10);
             break;
+        default:
+            info("Invalid TermType was provided for STerm constructor. Expected: FFTerm, FFITerm, ITerm, BVTerm. Got: ",
+                 type);
+            abort();
         }
     }
 }
@@ -480,19 +488,6 @@ STerm STerm::extract_bit(const uint32_t& bit_index)
     return { res, this->solver, this->type };
 }
 
-/**
- * @brief Create an inclusion constraint
- *
- * @param entry entry to be checked
- * @param table table that consists of elements, ranges mostly
- */
-void STerm::in(const cvc5::Term& table) const
-{
-    STerm left = this->normalize();
-    cvc5::Term inc = this->solver->term_manager.mkTerm(cvc5::Kind::SET_MEMBER, { left.term, table });
-    this->solver->assertFormula(inc);
-}
-
 STerm operator+(const bb::fr& lhs, const STerm& rhs)
 {
     return rhs + lhs;
@@ -552,6 +547,18 @@ std::ostream& operator<<(std::ostream& os, const TermType type)
         break;
     case TermType::ITerm:
         os << "ITerm";
+        break;
+    case TermType::SBool:
+        os << "SBool";
+        break;
+    case TermType::STuple:
+        os << "STuple";
+        break;
+    case TermType::SymArray:
+        os << "SymArray";
+        break;
+    case TermType::SymSet:
+        os << "SymSet";
         break;
     };
     return os;

--- a/barretenberg/cpp/src/barretenberg/smt_verification/terms/term.hpp
+++ b/barretenberg/cpp/src/barretenberg/smt_verification/terms/term.hpp
@@ -201,7 +201,9 @@ class STerm {
 
     static STerm batch_add(const std::vector<STerm>& children)
     {
-        ASSERT(children.size() > 0);
+        if (children.size() == 0) {
+            throw std::invalid_argument("Can't use batch_add on empty vector");
+        }
         Solver* slv = children[0].solver;
         std::vector<cvc5::Term> terms(children.begin(), children.end());
         cvc5::Term res = slv->term_manager.mkTerm(children[0].operations.at(OpType::ADD), terms);
@@ -210,7 +212,9 @@ class STerm {
 
     static STerm batch_mul(const std::vector<STerm>& children)
     {
-        ASSERT(children.size() > 0);
+        if (children.size() == 0) {
+            throw std::invalid_argument("Can't use batch_mul on empty vector");
+        }
         Solver* slv = children[0].solver;
         std::vector<cvc5::Term> terms(children.begin(), children.end());
         cvc5::Term res = slv->term_manager.mkTerm(children[0].operations.at(OpType::MUL), terms);

--- a/barretenberg/cpp/src/barretenberg/smt_verification/terms/term.hpp
+++ b/barretenberg/cpp/src/barretenberg/smt_verification/terms/term.hpp
@@ -12,7 +12,7 @@ using namespace smt_solver;
  * BVTerm - Symbolic Variables acting like bitvectors modulo prime
  *
  */
-enum class TermType { FFTerm, FFITerm, BVTerm, ITerm };
+enum class TermType { FFTerm, FFITerm, BVTerm, ITerm, SBool, STuple, SymArray, SymSet };
 std::ostream& operator<<(std::ostream& os, TermType type);
 
 enum class OpType : int32_t {
@@ -35,7 +35,8 @@ enum class OpType : int32_t {
     ROTL,
     NOT,
     EXTRACT,
-    BITVEC_PAD
+    BITVEC_PAD,
+    BIT_SUM
 };
 
 /**
@@ -188,8 +189,6 @@ class STerm {
      */
     STerm extract_bit(const uint32_t& bit_index);
 
-    void in(const cvc5::Term& table) const;
-
     operator std::string() const { return this->solver->stringify_term(term); };
     operator cvc5::Term() const { return term; };
 
@@ -216,24 +215,6 @@ class STerm {
         std::vector<cvc5::Term> terms(children.begin(), children.end());
         cvc5::Term res = slv->term_manager.mkTerm(children[0].operations.at(OpType::MUL), terms);
         return { res, slv, children[0].type };
-    }
-
-    /**
-     * @brief Create an inclusion constraint
-     *
-     * @param entry the tuple entry to be checked
-     * @param table lookup table that consists of tuples of lenght 3
-     */
-    static void in_table(std::vector<STerm>& entry, cvc5::Term& table)
-    {
-        STerm entry0 = entry[0].normalize();
-        STerm entry1 = entry[1].normalize();
-        STerm entry2 = entry[2].normalize();
-
-        Solver* slv = entry[0].solver;
-        cvc5::Term sym_entry = slv->term_manager.mkTuple({ entry0.term, entry1.term, entry2.term });
-        cvc5::Term inc = slv->term_manager.mkTerm(cvc5::Kind::SET_MEMBER, { sym_entry, table });
-        slv->assertFormula(inc);
     }
 
     // arithmetic compatibility with Fr
@@ -272,6 +253,8 @@ class STerm {
 
     STerm rotr(const uint32_t& n) const;
     STerm rotl(const uint32_t& n) const;
+
+    friend class Bool;
 };
 
 STerm operator+(const bb::fr& lhs, const STerm& rhs);


### PR DESCRIPTION
This pr adds new Symbolic objects: Tuple, Array and Set 

# Data Structures

- Added `STuple`, `SymArray`, `SymSet` classes to ease up lookup tables and ROM/RAM arrays symbolic translation
- Reflected new symbolic objects in `UltraCircuit`, `STerm` and `Solver`

- Added tests for all of the new structures
- Added pretty print for these structures

# Bool

added tests for symbolic bool class

# Solver

- Added a few more default solver configurations to use. 
- Added `ff_bitsum` option to solver config. It allows solver to understand  bitsums (namely constraints of the form  `b0 + 2 * b1 + 4 * b2 + ... == X`) 
- Added few more debug solver options
- Added few options to handle arrays and sets
- Fixed a bug: `lookup_enabled` was not handled properly