### PR TITLE
fix: native ivc benches not publishing

### DIFF
--- a/barretenberg/scripts/combine_benchmarks.py
+++ b/barretenberg/scripts/combine_benchmarks.py
@@ -61,7 +61,7 @@ def modify_benchmark_data(file_paths):
             prefix = "wasm"
         elif "release" in file_path:
             prefix = "native"
-        elif "-ivc.json" in file_path:
+        elif "ivc-" in file_path:
             prefix = "ivc-"
         if file_path.endswith(".txt"):
             # Process text files to extract memory data.


### PR DESCRIPTION
This script needs to be made more elegant in a future pass, probably along with a big cleanup of the benchmark names (most of the reason it is ugly is for backwards-compatibility)
