### PR TITLE
Update README.md

### DIFF
--- a/.devcontainer/dev/docker-in-docker/README.md
+++ b/.devcontainer/dev/docker-in-docker/README.md
@@ -1,4 +1,4 @@
-# Docker (Docker-in-Docker) (docker-in-docker)
+# Docker (Docker-in-Docker)
 
 **FORKED HERE TO SUPPORT NOBLE**
 
@@ -23,7 +23,7 @@ Create child containers _inside_ a container, independent from the host's docker
 | azureDnsAutoDetection      | Allow automatically setting the dockerd DNS server when the installation script detects it is running in Azure                                                                                                                 | boolean | true          |
 | dockerDefaultAddressPool   | Define default address pools for Docker networks. e.g. base=192.168.0.0/16,size=24                                                                                                                                             | string  | -             |
 | installDockerBuildx        | Install Docker Buildx                                                                                                                                                                                                          | boolean | true          |
-| installDockerComposeSwitch | Install Compose Switch (provided docker compose is available) which is a replacement to the Compose V1 docker-compose (python) executable. It translates the command line into Compose V2 docker compose then runs the latter. | boolean | true          |
+| installDockerComposeSwitch | Install Compose Switch (provided docker compose is available) which is a replacement for the Compose V1 docker-compose (python) executable. It translates the command line into Compose V2 docker compose then runs the latter. | boolean | true          |
 
 ## Customizations
 


### PR DESCRIPTION
Hi, I have two suggestions for this doc.

1. Title repetition. No need to repeat both capitalized and lowercase versions.

2. In sentence: "which is a replacement to the Compose V1 docker-compose (python) executable"

I replaced "to", with “for" for grammatical correctness.

Thanks.

Please read [contributing guidelines](CONTRIBUTING.md) and remove this line.
