### PR TITLE
chore: apply #13666 to alpha-testnet

### DIFF
--- a/yarn-project/p2p/src/services/libp2p/libp2p_service.ts
+++ b/yarn-project/p2p/src/services/libp2p/libp2p_service.ts
@@ -434,7 +434,7 @@ export class LibP2PService<T extends P2PClientType = P2PClientType.Full> extends
   sendBatchRequest<SubProtocol extends ReqRespSubProtocol>(
     protocol: SubProtocol,
     requests: InstanceType<SubProtocolMap[SubProtocol]['request']>[],
-  ): Promise<InstanceType<SubProtocolMap[SubProtocol]['response']>[] | undefined> {
+  ): Promise<(InstanceType<SubProtocolMap[SubProtocol]['response']> | undefined)[]> {
     return this.reqresp.sendBatchRequest(protocol, requests);
   }
 

--- a/yarn-project/p2p/src/services/reqresp/reqresp.ts
+++ b/yarn-project/p2p/src/services/reqresp/reqresp.ts
@@ -264,9 +264,9 @@ export class ReqResp {
     timeoutMs = 10000,
     maxPeers = Math.min(10, requests.length),
     maxRetryAttempts = 3,
-  ): Promise<InstanceType<SubProtocolMap[SubProtocol]['response']>[]> {
+  ): Promise<(InstanceType<SubProtocolMap[SubProtocol]['response']> | undefined)[]> {
     const responseValidator = this.subProtocolValidators[subProtocol];
-    const responses: InstanceType<SubProtocolMap[SubProtocol]['response']>[] = new Array(requests.length);
+    const responses: (InstanceType<SubProtocolMap[SubProtocol]['response']> | undefined)[] = new Array(requests.length);
     const requestBuffers = requests.map(req => req.toBuffer());
 
     const requestFunction = async () => {
@@ -378,7 +378,7 @@ export class ReqResp {
     };
 
     try {
-      return await executeTimeout<InstanceType<SubProtocolMap[SubProtocol]['response']>[]>(
+      return await executeTimeout<(InstanceType<SubProtocolMap[SubProtocol]['response']> | undefined)[]>(
         requestFunction,
         timeoutMs,
         () => new CollectiveReqRespTimeoutError(),

--- a/yarn-project/p2p/src/services/service.ts
+++ b/yarn-project/p2p/src/services/service.ts
@@ -56,7 +56,7 @@ export interface P2PService {
   sendBatchRequest<Protocol extends ReqRespSubProtocol>(
     protocol: Protocol,
     requests: InstanceType<SubProtocolMap[Protocol]['request']>[],
-  ): Promise<InstanceType<SubProtocolMap[Protocol]['response']>[] | undefined>;
+  ): Promise<(InstanceType<SubProtocolMap[Protocol]['response']> | undefined)[]>;
 
   // Leaky abstraction: fix https://github.com/AztecProtocol/aztec-packages/issues/7963
   registerBlockReceivedCallback(callback: (block: BlockProposal) => Promise<BlockAttestation | undefined>): void;

--- a/yarn-project/stdlib/src/interfaces/prover-coordination.ts
+++ b/yarn-project/stdlib/src/interfaces/prover-coordination.ts
@@ -16,7 +16,7 @@ export interface ProverCoordination {
   /**
    * Returns a set of transactions given their hashes if available.
    * @param txHashes - The hashes of the transactions, used as an ID.
-   * @returns The transactions, if found, 'undefined' otherwise.
+   * @returns The transactions found, no necessarily in the same order as the hashes.
    */
   getTxsByHash(txHashes: TxHash[]): Promise<Tx[]>;
 }


### PR DESCRIPTION
## Overview

Incorrect typing in the reqresp module lead undefined results to NOT be filtered when being added to the tx pool
