### PR TITLE
fix(p2p): better batch connection sampling

### DIFF
--- a/yarn-project/p2p/src/services/reqresp/connection-sampler/batch_connection_sampler.test.ts
+++ b/yarn-project/p2p/src/services/reqresp/connection-sampler/batch_connection_sampler.test.ts
@@ -22,7 +22,7 @@ describe('BatchConnectionSampler', () => {
 
     // Mock libp2p to return our test peers
     libp2p = {
-      getPeers: jest.fn().mockReturnValue(peers),
+      getPeers: jest.fn().mockImplementation(() => [...peers]),
     } as unknown as jest.Mocked<Libp2p>;
 
     // Create a real connection sampler with mocked random sampling
@@ -45,8 +45,7 @@ describe('BatchConnectionSampler', () => {
 
   it('assigns requests to peers deterministically with wraparound', () => {
     // Mock to return first two peers
-    let callCount = 0;
-    mockRandomSampler.random.mockImplementation(() => callCount++ % 2);
+    mockRandomSampler.random.mockImplementation(() => 0);
 
     // With 5 requests and 2 peers:
     // floor(5/2) = 2 requests per peer
@@ -66,9 +65,7 @@ describe('BatchConnectionSampler', () => {
   });
 
   it('handles peer removal and replacement', () => {
-    mockRandomSampler.random.mockImplementation(_ => {
-      return 2; // Return index 2 for replacement peer
-    });
+    mockRandomSampler.random.mockImplementation(_ => 0);
 
     // With 4 requests and 2 peers:
     // floor(4/2) = 2 requests per peer
@@ -80,6 +77,8 @@ describe('BatchConnectionSampler', () => {
     const initialPeer = sampler.getPeerForRequest(0);
     expect(initialPeer).toBe(peers[0]);
 
+    // Mock random to return the third peer
+    mockRandomSampler.random.mockImplementation(_ => 2);
     sampler.removePeerAndReplace(peers[0]);
 
     // After replacement:
@@ -94,7 +93,7 @@ describe('BatchConnectionSampler', () => {
   });
 
   it('handles peer removal and replacement - no replacement available', () => {
-    mockRandomSampler.random.mockImplementation(() => 2);
+    mockRandomSampler.random.mockImplementation(() => 0);
     const sampler = new BatchConnectionSampler(connectionSampler, /* batchSize */ 4, /* maxPeers */ 2);
 
     expect(sampler.activePeerCount).toBe(2);
@@ -112,13 +111,7 @@ describe('BatchConnectionSampler', () => {
   });
 
   it('distributes requests according to documentation example', () => {
-    let callCount = 0;
-    mockRandomSampler.random.mockImplementation(() => {
-      if (callCount < 3) {
-        return callCount++;
-      }
-      return 0;
-    });
+    mockRandomSampler.random.mockImplementation(() => 0);
 
     // Example from doc comment:
     // Peers:    [P1]      [P2]     [P3]
@@ -146,8 +139,7 @@ describe('BatchConnectionSampler', () => {
   });
 
   it('same number of requests per peers', () => {
-    let callCount = 0;
-    mockRandomSampler.random.mockImplementation(() => callCount++ % 2);
+    mockRandomSampler.random.mockImplementation(() => 0);
 
     const sampler = new BatchConnectionSampler(connectionSampler, /* batchSize */ 2, /* maxPeers */ 2);
     expect(sampler.requestsPerBucket).toBe(1);
@@ -165,10 +157,9 @@ describe('BatchConnectionSampler', () => {
     expect(sampler.activePeerCount).toBe(0);
     expect(sampler.getPeerForRequest(0)).toBeUndefined();
 
-    let i = 0;
-    mockRandomSampler.random.mockImplementation(() => i++ % 3);
+    mockRandomSampler.random.mockImplementation(() => 0);
 
-    libp2p.getPeers.mockReturnValue(peers);
+    libp2p.getPeers.mockImplementation(() => [...peers]);
     const samplerWithMorePeers = new BatchConnectionSampler(connectionSampler, /* batchSize */ 2, /* maxPeers */ 3);
     expect(samplerWithMorePeers.requestsPerBucket).toBe(1); // floor(2/3) = 0
     // First two requests go to first two peers

--- a/yarn-project/p2p/src/services/reqresp/connection-sampler/batch_connection_sampler.ts
+++ b/yarn-project/p2p/src/services/reqresp/connection-sampler/batch_connection_sampler.ts
@@ -50,9 +50,6 @@ export class BatchConnectionSampler {
 
     // Calculate which peer bucket this index belongs to
     const peerIndex = Math.floor(index / this.requestsPerPeer) % this.batch.length;
-
-    this.logger.debug('Peer index', { peerIndex, index, requestsPerPeer: this.requestsPerPeer });
-    this.logger.debug('Batch', { batch: this.batch });
     return this.batch[peerIndex];
   }
 

--- a/yarn-project/p2p/src/services/reqresp/connection-sampler/batch_connection_sampler.ts
+++ b/yarn-project/p2p/src/services/reqresp/connection-sampler/batch_connection_sampler.ts
@@ -50,6 +50,9 @@ export class BatchConnectionSampler {
 
     // Calculate which peer bucket this index belongs to
     const peerIndex = Math.floor(index / this.requestsPerPeer) % this.batch.length;
+
+    this.logger.debug('Peer index', { peerIndex, index, requestsPerPeer: this.requestsPerPeer });
+    this.logger.debug('Batch', { batch: this.batch });
     return this.batch[peerIndex];
   }
 
@@ -70,11 +73,11 @@ export class BatchConnectionSampler {
 
     if (newPeer) {
       this.batch[index] = newPeer;
-      this.logger.trace(`Replaced peer ${peerId} with ${newPeer}`, { peerId, newPeer });
+      this.logger.trace('Replaced peer', { peerId, newPeer });
     } else {
       // If we couldn't get a replacement, remove the peer and compact the array
       this.batch.splice(index, 1);
-      this.logger.trace(`Removed peer ${peerId}`, { peerId });
+      this.logger.trace('Removed peer', { peerId });
     }
   }
 

--- a/yarn-project/p2p/src/services/reqresp/connection-sampler/connection_sampler.test.ts
+++ b/yarn-project/p2p/src/services/reqresp/connection-sampler/connection_sampler.test.ts
@@ -20,7 +20,7 @@ describe('ConnectionSampler', () => {
 
     // Mock libp2p
     mockLibp2p = {
-      getPeers: jest.fn().mockReturnValue([...peers]),
+      getPeers: jest.fn().mockImplementation(() => [...peers]),
       dialProtocol: jest.fn(),
     };
 
@@ -196,15 +196,22 @@ describe('ConnectionSampler', () => {
 
       // Mock libp2p
       mockLibp2p = {
-        getPeers: jest.fn().mockReturnValue(peers),
+        getPeers: jest.fn().mockImplementation(() => [...peers]),
         dialProtocol: jest.fn(),
       };
 
       mockRandomSampler = mock<RandomSampler>();
+      mockRandomSampler.random.mockReturnValue(0);
       sampler = new ConnectionSampler(mockLibp2p, 1000, mockRandomSampler);
     });
 
     it('prioritizes peers without active connections', () => {
+      mockRandomSampler.random
+        // Will pick the peers with active connections
+        .mockReturnValueOnce(3)
+        .mockReturnValueOnce(3)
+        .mockReturnValue(0);
+
       // Set up some peers with active connections
       sampler['activeConnectionsCount'].set(peers[3], 1);
       sampler['activeConnectionsCount'].set(peers[4], 2);
@@ -248,7 +255,8 @@ describe('ConnectionSampler', () => {
       const sampledPeers = sampler.samplePeersBatch(3);
 
       expect(sampledPeers).toHaveLength(3);
-      expect(sampledPeers).toEqual(expect.arrayContaining([peers[0], peers[1], peers[2]]));
+      // The last one will be picked first, then the first one, then the second one
+      expect(sampledPeers).toEqual(expect.arrayContaining([peers[4], peers[0], peers[1]]));
     });
 
     it('handles case when fewer peers available than requested', () => {

--- a/yarn-project/p2p/src/services/reqresp/connection-sampler/connection_sampler.test.ts
+++ b/yarn-project/p2p/src/services/reqresp/connection-sampler/connection_sampler.test.ts
@@ -205,6 +205,12 @@ describe('ConnectionSampler', () => {
       sampler = new ConnectionSampler(mockLibp2p, 1000, mockRandomSampler);
     });
 
+    it('should only return samples as many peers as available', () => {
+      const sampledPeers = sampler.samplePeersBatch(100);
+
+      expect(sampledPeers).toHaveLength(peers.length);
+    });
+
     it('prioritizes peers without active connections', () => {
       mockRandomSampler.random
         // Will pick the peers with active connections

--- a/yarn-project/p2p/src/services/reqresp/connection-sampler/connection_sampler.ts
+++ b/yarn-project/p2p/src/services/reqresp/connection-sampler/connection_sampler.ts
@@ -141,6 +141,9 @@ export class ConnectionSampler {
     const peers = this.libp2p.getPeers();
     this.logger.debug('Sampling peers batch', { numberToSample, peers });
 
+    // Only sample as many peers as we have available
+    numberToSample = Math.min(numberToSample, peers.length);
+
     const batch: PeerId[] = [];
     const withActiveConnections: Set<PeerId> = new Set();
     for (let i = 0; i < numberToSample; i++) {

--- a/yarn-project/p2p/src/services/reqresp/connection-sampler/connection_sampler.ts
+++ b/yarn-project/p2p/src/services/reqresp/connection-sampler/connection_sampler.ts
@@ -17,7 +17,7 @@ export class RandomSampler {
 }
 
 /**
- * A class that samples peers from the libp2p node and returns a peer that we don't already have a connection open to.
+ * A class that samples peers from the libp2p node and returns a peer that we don't already have a reqresp connection open to.
  * If we already have a connection open, we try to sample a different peer.
  * We do this MAX_SAMPLE_ATTEMPTS times, if we still don't find a peer we just go for it.
  *
@@ -74,7 +74,7 @@ export class ConnectionSampler {
   }
 
   /**
-   * Samples a peer from a list of peers, excluding those that have active connections or are in the exclusion list
+   * Samples a peer from a list of peers, excluding those that have active (reqresp) connections or are in the exclusion list
    *
    * @param peers - The list of peers to sample from
    * @param excluding - The peers to exclude from the sampling
@@ -108,7 +108,6 @@ export class ConnectionSampler {
       peers.splice(randomIndex, 1);
 
       // If peer is suitable (no active connections and not excluded), return it
-      // If we don't retry active connections, we only respect the not excluded condition
       if (!hasActiveConnections && !isExcluded) {
         this.logger.trace('Sampled peer', {
           attempts,
@@ -117,7 +116,7 @@ export class ConnectionSampler {
         return { peer, sampledPeers };
       }
 
-      // Keep track of peers that have active connections
+      // Keep track of peers that have active reqresp channels, batch sampling will use these to resample
       sampledPeers.push(peer);
     }
 

--- a/yarn-project/p2p/src/services/reqresp/reqresp.ts
+++ b/yarn-project/p2p/src/services/reqresp/reqresp.ts
@@ -196,7 +196,7 @@ export class ReqResp {
         this.logger.trace(`Sending request to peer: ${peer.toString()}`);
         const response = await this.sendRequestToPeer(peer, subProtocol, requestBuffer);
 
-        if (response && response.status !== ReqRespStatus.SUCCESS) {
+        if (response.status !== ReqRespStatus.SUCCESS) {
           this.logger.debug(
             `Request to peer ${peer.toString()} failed with status ${prettyPrintReqRespStatus(response.status)}`,
           );
@@ -442,7 +442,7 @@ export class ReqResp {
 
       // If there is an exception, we return an unknown response
       return {
-        status: ReqRespStatus.UNKNOWN,
+        status: ReqRespStatus.FAILURE,
         data: Buffer.from([]),
       };
     } finally {

--- a/yarn-project/p2p/src/services/reqresp/reqresp.ts
+++ b/yarn-project/p2p/src/services/reqresp/reqresp.ts
@@ -325,7 +325,7 @@ export class ReqResp {
                 const response = await this.sendRequestToPeer(peer, subProtocol, requestBuffers[index]);
 
                 // Check the status of the response buffer
-                if (response && response.status !== ReqRespStatus.SUCCESS) {
+                if (response.status !== ReqRespStatus.SUCCESS) {
                   this.logger.debug(
                     `Request to peer ${peer.toString()} failed with status ${prettyPrintReqRespStatus(
                       response.status,
@@ -421,7 +421,7 @@ export class ReqResp {
     peerId: PeerId,
     subProtocol: ReqRespSubProtocol,
     payload: Buffer,
-  ): Promise<ReqRespResponse | undefined> {
+  ): Promise<ReqRespResponse> {
     let stream: Stream | undefined;
     try {
       this.metrics.recordRequestSent(subProtocol);
@@ -439,6 +439,12 @@ export class ReqResp {
     } catch (e: any) {
       this.metrics.recordRequestError(subProtocol);
       this.handleResponseError(e, peerId, subProtocol);
+
+      // If there is an exception, we return an unknown response
+      return {
+        status: ReqRespStatus.UNKNOWN,
+        data: Buffer.from([]),
+      };
     } finally {
       // Only close the stream if we created it
       if (stream) {

--- a/yarn-project/p2p/src/services/reqresp/status.ts
+++ b/yarn-project/p2p/src/services/reqresp/status.ts
@@ -5,6 +5,7 @@ export enum ReqRespStatus {
   SUCCESS = 0,
   RATE_LIMIT_EXCEEDED = 1,
   BADLY_FORMED_REQUEST = 2,
+  FAILURE = 126,
   UNKNOWN = 127,
 }
 
@@ -53,6 +54,8 @@ export function prettyPrintReqRespStatus(status: ReqRespStatus) {
       return 'RATE_LIMIT_EXCEEDED';
     case ReqRespStatus.BADLY_FORMED_REQUEST:
       return 'BADLY_FORMED_REQUEST';
+    case ReqRespStatus.FAILURE:
+      return 'FAILURE';
     case ReqRespStatus.UNKNOWN:
       return 'UNKNOWN';
   }


### PR DESCRIPTION
## Overview

Improves batch connection sampling such that we can increase the retry attempts for prover nodes requesting 
transaction information from their peers.

### Core improvements
**Previously**
When making a batch request, we requested the peer list, iterated through it until we found a peer without an reqresp active connection and used those. This meant that we were commonly only using the first 3-4 peers in the peer list.

Now it will do random sampling without replacement to peers without already active reqresp connections. If there are non available, then we will just sample from peers already servicing requests. 

