### PR TITLE
chore: bump retries for request tx by hash

### DIFF
--- a/yarn-project/p2p/src/client/p2p_client.ts
+++ b/yarn-project/p2p/src/client/p2p_client.ts
@@ -333,7 +333,7 @@ export class P2PClient<T extends P2PClientType = P2PClientType.Full>
    */
   public async requestTxsByHash(txHashes: TxHash[]): Promise<(Tx | undefined)[]> {
     // Set collective timeout based on the number of txs we are requesting
-    const timeoutMs = Math.min(8000, txHashes.length * 100);
+    const timeoutMs = Math.min(8000, Math.max(2000, txHashes.length * 100));
     const maxPeers = Math.min(Math.ceil(txHashes.length / 3), 10);
     const maxRetryAttempts = 10; // Keep retrying within the timeout
 

--- a/yarn-project/p2p/src/client/p2p_client.ts
+++ b/yarn-project/p2p/src/client/p2p_client.ts
@@ -332,8 +332,7 @@ export class P2PClient<T extends P2PClientType = P2PClientType.Full>
    * Uses the batched Request Response protocol to request a set of transactions from the network.
    */
   public async requestTxsByHash(txHashes: TxHash[]): Promise<(Tx | undefined)[]> {
-    // Set collective timeout based on the number of txs we are requesting
-    const timeoutMs = Math.min(8000, Math.max(2000, txHashes.length * 100));
+    const timeoutMs = 8000; // Longer timeout for now
     const maxPeers = Math.min(Math.ceil(txHashes.length / 3), 10);
     const maxRetryAttempts = 10; // Keep retrying within the timeout
 

--- a/yarn-project/p2p/src/services/reqresp/reqresp.ts
+++ b/yarn-project/p2p/src/services/reqresp/reqresp.ts
@@ -262,7 +262,7 @@ export class ReqResp {
     subProtocol: SubProtocol,
     requests: InstanceType<SubProtocolMap[SubProtocol]['request']>[],
     timeoutMs = 10000,
-    maxPeers = Math.min(10, requests.length),
+    maxPeers = Math.max(10, Math.ceil(requests.length / 3)),
     maxRetryAttempts = 3,
   ): Promise<(InstanceType<SubProtocolMap[SubProtocol]['response']> | undefined)[]> {
     const responseValidator = this.subProtocolValidators[subProtocol];

--- a/yarn-project/p2p/src/services/service.ts
+++ b/yarn-project/p2p/src/services/service.ts
@@ -56,6 +56,9 @@ export interface P2PService {
   sendBatchRequest<Protocol extends ReqRespSubProtocol>(
     protocol: Protocol,
     requests: InstanceType<SubProtocolMap[Protocol]['request']>[],
+    timeoutMs?: number,
+    maxPeers?: number,
+    maxRetryAttempts?: number,
   ): Promise<(InstanceType<SubProtocolMap[Protocol]['response']> | undefined)[]>;
 
   // Leaky abstraction: fix https://github.com/AztecProtocol/aztec-packages/issues/7963


### PR DESCRIPTION
## Overview

With better sampling logic, we can more safetly bump the retries for the tx requests 
