### PR TITLE
fix: dependency cycles in public simulator - part 1 (errors/revertReason)

### DIFF
--- a/yarn-project/simulator/src/public/avm/avm_simulator.ts
+++ b/yarn-project/simulator/src/public/avm/avm_simulator.ts
@@ -14,14 +14,9 @@ import { AvmExecutionEnvironment } from './avm_execution_environment.js';
 import type { Gas } from './avm_gas.js';
 import { AvmMachineState } from './avm_machine_state.js';
 import type { AvmSimulatorInterface } from './avm_simulator_interface.js';
-import {
-  AvmExecutionError,
-  AvmRevertReason,
-  InvalidProgramCounterError,
-  revertReasonFromExceptionalHalt,
-  revertReasonFromExplicitRevert,
-} from './errors.js';
+import { AvmExecutionError, AvmRevertReason, InvalidProgramCounterError } from './errors.js';
 import type { Instruction } from './opcodes/instruction.js';
+import { revertReasonFromExceptionalHalt, revertReasonFromExplicitRevert } from './revert_reason.js';
 import {
   INSTRUCTION_SET,
   type InstructionSet,

--- a/yarn-project/simulator/src/public/avm/errors.ts
+++ b/yarn-project/simulator/src/public/avm/errors.ts
@@ -1,9 +1,8 @@
-import type { Fr, Point } from '@aztec/foundation/fields';
+import type { Point } from '@aztec/foundation/fields';
 import type { AztecAddress } from '@aztec/stdlib/aztec-address';
 import type { FailingFunction, NoirCallStack } from '@aztec/stdlib/errors';
 
 import { ExecutionError } from '../../common/errors.js';
-import type { AvmContext } from './avm_context.js';
 
 /**
  * Avm-specific errors should derive from this
@@ -178,55 +177,4 @@ export class AvmRevertReason extends ExecutionError {
   constructor(message: string, failingFunction: FailingFunction, noirCallStack: NoirCallStack, options?: ErrorOptions) {
     super(message, failingFunction, noirCallStack, options);
   }
-}
-
-async function createRevertReason(message: string, revertData: Fr[], context: AvmContext): Promise<AvmRevertReason> {
-  // We drop the returnPc information.
-  const internalCallStack = context.machineState.internalCallStack.map(entry => entry.callPc);
-
-  // If we are reverting due to the same error that we have been tracking, we use the nested error as the cause.
-  let nestedError = undefined;
-  const revertDataEquals = (a: Fr[], b: Fr[]) => a.length === b.length && a.every((v, i) => v.equals(b[i]));
-  if (
-    context.machineState.collectedRevertInfo &&
-    revertDataEquals(context.machineState.collectedRevertInfo.revertDataRepresentative, revertData)
-  ) {
-    nestedError = context.machineState.collectedRevertInfo.recursiveRevertReason;
-    message = context.machineState.collectedRevertInfo.recursiveRevertReason.message;
-  }
-
-  const fnName = await context.persistableState.getPublicFunctionDebugName(context.environment);
-
-  return new AvmRevertReason(
-    message,
-    /*failingFunction=*/ {
-      contractAddress: context.environment.address,
-      functionName: fnName,
-    },
-    /*noirCallStack=*/ [...internalCallStack, context.machineState.pc].map(pc => `0.${pc}`),
-    /*options=*/ { cause: nestedError },
-  );
-}
-
-/**
- * Create a "revert reason" error for an exceptional halt.
- *
- * @param haltingError - the lower-level error causing the exceptional halt
- * @param context - the context of the AVM execution used to extract the failingFunction and noirCallStack
- */
-export async function revertReasonFromExceptionalHalt(
-  haltingError: AvmExecutionError,
-  context: AvmContext,
-): Promise<AvmRevertReason> {
-  return await createRevertReason(haltingError.message, [], context);
-}
-
-/**
- * Create a "revert reason" error for an explicit revert (a root cause).
- *
- * @param revertData - output data of the explicit REVERT instruction
- * @param context - the context of the AVM execution used to extract the failingFunction and noirCallStack
- */
-export async function revertReasonFromExplicitRevert(revertData: Fr[], context: AvmContext): Promise<AvmRevertReason> {
-  return await createRevertReason('Assertion failed: ', revertData, context);
 }

--- a/yarn-project/simulator/src/public/avm/revert_reason.ts
+++ b/yarn-project/simulator/src/public/avm/revert_reason.ts
@@ -1,0 +1,55 @@
+import type { Fr } from '@aztec/foundation/fields';
+
+import type { AvmContext } from './avm_context.js';
+import { type AvmExecutionError, AvmRevertReason } from './errors.js';
+
+async function createRevertReason(message: string, revertData: Fr[], context: AvmContext): Promise<AvmRevertReason> {
+  // We drop the returnPc information.
+  const internalCallStack = context.machineState.internalCallStack.map(entry => entry.callPc);
+
+  // If we are reverting due to the same error that we have been tracking, we use the nested error as the cause.
+  let nestedError = undefined;
+  const revertDataEquals = (a: Fr[], b: Fr[]) => a.length === b.length && a.every((v, i) => v.equals(b[i]));
+  if (
+    context.machineState.collectedRevertInfo &&
+    revertDataEquals(context.machineState.collectedRevertInfo.revertDataRepresentative, revertData)
+  ) {
+    nestedError = context.machineState.collectedRevertInfo.recursiveRevertReason;
+    message = context.machineState.collectedRevertInfo.recursiveRevertReason.message;
+  }
+
+  const fnName = await context.persistableState.getPublicFunctionDebugName(context.environment);
+
+  return new AvmRevertReason(
+    message,
+    /*failingFunction=*/ {
+      contractAddress: context.environment.address,
+      functionName: fnName,
+    },
+    /*noirCallStack=*/ [...internalCallStack, context.machineState.pc].map(pc => `0.${pc}`),
+    /*options=*/ { cause: nestedError },
+  );
+}
+
+/**
+ * Create a "revert reason" error for an exceptional halt.
+ *
+ * @param haltingError - the lower-level error causing the exceptional halt
+ * @param context - the context of the AVM execution used to extract the failingFunction and noirCallStack
+ */
+export async function revertReasonFromExceptionalHalt(
+  haltingError: AvmExecutionError,
+  context: AvmContext,
+): Promise<AvmRevertReason> {
+  return await createRevertReason(haltingError.message, [], context);
+}
+
+/**
+ * Create a "revert reason" error for an explicit revert (a root cause).
+ *
+ * @param revertData - output data of the explicit REVERT instruction
+ * @param context - the context of the AVM execution used to extract the failingFunction and noirCallStack
+ */
+export async function revertReasonFromExplicitRevert(revertData: Fr[], context: AvmContext): Promise<AvmRevertReason> {
+  return await createRevertReason('Assertion failed: ', revertData, context);
+}


### PR DESCRIPTION
Brings cycles down from 19 to 15 
![image](https://github.com/user-attachments/assets/0321e7e9-3a60-42d9-82ed-1f6cb9f3b307)
