### PR TITLE
fix: dependency cycles in public simulator part 2 (serializable bytecode)

### DIFF
--- a/yarn-project/simulator/src/public/avm/opcodes/accrued_substate.test.ts
+++ b/yarn-project/simulator/src/public/avm/opcodes/accrued_substate.test.ts
@@ -72,8 +72,8 @@ describe('Accrued Substate', () => {
         /*existsOffset=*/ 0x4567,
       );
 
-      expect(NoteHashExists.deserialize(buf)).toEqual(inst);
-      expect(inst.serialize()).toEqual(buf);
+      expect(NoteHashExists.fromBuffer(buf)).toEqual(inst);
+      expect(inst.toBuffer()).toEqual(buf);
     });
 
     // Will check existence at leafIndex, but nothing may be found there and/or something may be found at mockAtLeafIndex
@@ -117,8 +117,8 @@ describe('Accrued Substate', () => {
       ]);
       const inst = new EmitNoteHash(/*indirect=*/ 0x01, /*offset=*/ 0x1234);
 
-      expect(EmitNoteHash.deserialize(buf)).toEqual(inst);
-      expect(inst.serialize()).toEqual(buf);
+      expect(EmitNoteHash.fromBuffer(buf)).toEqual(inst);
+      expect(inst.toBuffer()).toEqual(buf);
     });
 
     it('Should append a new note hash correctly', async () => {
@@ -149,8 +149,8 @@ describe('Accrued Substate', () => {
         /*existsOffset=*/ 0x4567,
       );
 
-      expect(NullifierExists.deserialize(buf)).toEqual(inst);
-      expect(inst.serialize()).toEqual(buf);
+      expect(NullifierExists.fromBuffer(buf)).toEqual(inst);
+      expect(inst.toBuffer()).toEqual(buf);
     });
 
     describe.each([[/*exists=*/ false], [/*exists=*/ true]])('Nullifier checks', (exists: boolean) => {
@@ -186,8 +186,8 @@ describe('Accrued Substate', () => {
       ]);
       const inst = new EmitNullifier(/*indirect=*/ 0x01, /*offset=*/ 0x1234);
 
-      expect(EmitNullifier.deserialize(buf)).toEqual(inst);
-      expect(inst.serialize()).toEqual(buf);
+      expect(EmitNullifier.fromBuffer(buf)).toEqual(inst);
+      expect(inst.toBuffer()).toEqual(buf);
     });
 
     it('Should append a new nullifier correctly', async () => {
@@ -237,8 +237,8 @@ describe('Accrued Substate', () => {
         /*existsOffset=*/ 0xcdef,
       );
 
-      expect(L1ToL2MessageExists.deserialize(buf)).toEqual(inst);
-      expect(inst.serialize()).toEqual(buf);
+      expect(L1ToL2MessageExists.fromBuffer(buf)).toEqual(inst);
+      expect(inst.toBuffer()).toEqual(buf);
     });
 
     // Will check existence at leafIndex, but nothing may be found there and/or something may be found at mockAtLeafIndex
@@ -284,8 +284,8 @@ describe('Accrued Substate', () => {
       ]);
       const inst = new EmitUnencryptedLog(/*indirect=*/ 0x01, /*offset=*/ 0x1234, /*lengthOffset=*/ 0xa234);
 
-      expect(EmitUnencryptedLog.deserialize(buf)).toEqual(inst);
-      expect(inst.serialize()).toEqual(buf);
+      expect(EmitUnencryptedLog.fromBuffer(buf)).toEqual(inst);
+      expect(inst.toBuffer()).toEqual(buf);
     });
 
     it('Should append public logs correctly', async () => {
@@ -316,8 +316,8 @@ describe('Accrued Substate', () => {
       ]);
       const inst = new SendL2ToL1Message(/*indirect=*/ 0x01, /*recipientOffset=*/ 0x1234, /*contentOffset=*/ 0xa234);
 
-      expect(SendL2ToL1Message.deserialize(buf)).toEqual(inst);
-      expect(inst.serialize()).toEqual(buf);
+      expect(SendL2ToL1Message.fromBuffer(buf)).toEqual(inst);
+      expect(inst.toBuffer()).toEqual(buf);
     });
 
     it('Should append l2 to l1 message correctly', async () => {

--- a/yarn-project/simulator/src/public/avm/opcodes/arithmetic.test.ts
+++ b/yarn-project/simulator/src/public/avm/opcodes/arithmetic.test.ts
@@ -26,8 +26,8 @@ describe('Arithmetic Instructions', () => {
         Add.wireFormat16,
       );
 
-      expect(Add.as(Add.wireFormat16).deserialize(buf)).toEqual(inst);
-      expect(inst.serialize()).toEqual(buf);
+      expect(Add.as(Add.wireFormat16).fromBuffer(buf)).toEqual(inst);
+      expect(inst.toBuffer()).toEqual(buf);
     });
 
     describe.each([
@@ -107,8 +107,8 @@ describe('Arithmetic Instructions', () => {
         Sub.wireFormat16,
       );
 
-      expect(Sub.as(Sub.wireFormat16).deserialize(buf)).toEqual(inst);
-      expect(inst.serialize()).toEqual(buf);
+      expect(Sub.as(Sub.wireFormat16).fromBuffer(buf)).toEqual(inst);
+      expect(inst.toBuffer()).toEqual(buf);
     });
 
     describe.each([
@@ -169,8 +169,8 @@ describe('Arithmetic Instructions', () => {
         Mul.wireFormat16,
       );
 
-      expect(Mul.as(Mul.wireFormat16).deserialize(buf)).toEqual(inst);
-      expect(inst.serialize()).toEqual(buf);
+      expect(Mul.as(Mul.wireFormat16).fromBuffer(buf)).toEqual(inst);
+      expect(inst.toBuffer()).toEqual(buf);
     });
 
     describe.each([
@@ -226,8 +226,8 @@ describe('Arithmetic Instructions', () => {
         Div.wireFormat16,
       );
 
-      expect(Div.as(Div.wireFormat16).deserialize(buf)).toEqual(inst);
-      expect(inst.serialize()).toEqual(buf);
+      expect(Div.as(Div.wireFormat16).fromBuffer(buf)).toEqual(inst);
+      expect(inst.toBuffer()).toEqual(buf);
     });
 
     describe.each([
@@ -263,8 +263,8 @@ describe('Arithmetic Instructions', () => {
         FieldDiv.wireFormat16,
       );
 
-      expect(FieldDiv.as(FieldDiv.wireFormat16).deserialize(buf)).toEqual(inst);
-      expect(inst.serialize()).toEqual(buf);
+      expect(FieldDiv.as(FieldDiv.wireFormat16).fromBuffer(buf)).toEqual(inst);
+      expect(inst.toBuffer()).toEqual(buf);
     });
 
     it('Should perform field division', async () => {

--- a/yarn-project/simulator/src/public/avm/opcodes/bitwise.test.ts
+++ b/yarn-project/simulator/src/public/avm/opcodes/bitwise.test.ts
@@ -25,8 +25,8 @@ describe('Bitwise instructions', () => {
         And.wireFormat16,
       );
 
-      expect(And.as(And.wireFormat16).deserialize(buf)).toEqual(inst);
-      expect(inst.serialize()).toEqual(buf);
+      expect(And.as(And.wireFormat16).fromBuffer(buf)).toEqual(inst);
+      expect(inst.toBuffer()).toEqual(buf);
     });
 
     it('Should AND correctly over integral types', async () => {
@@ -54,8 +54,8 @@ describe('Bitwise instructions', () => {
         Or.wireFormat16,
       );
 
-      expect(Or.as(Or.wireFormat16).deserialize(buf)).toEqual(inst);
-      expect(inst.serialize()).toEqual(buf);
+      expect(Or.as(Or.wireFormat16).fromBuffer(buf)).toEqual(inst);
+      expect(inst.toBuffer()).toEqual(buf);
     });
 
     it('Should OR correctly over integral types', async () => {
@@ -87,8 +87,8 @@ describe('Bitwise instructions', () => {
         Xor.wireFormat16,
       );
 
-      expect(Xor.as(Xor.wireFormat16).deserialize(buf)).toEqual(inst);
-      expect(inst.serialize()).toEqual(buf);
+      expect(Xor.as(Xor.wireFormat16).fromBuffer(buf)).toEqual(inst);
+      expect(inst.toBuffer()).toEqual(buf);
     });
 
     it('Should XOR correctly over integral types', async () => {
@@ -120,8 +120,8 @@ describe('Bitwise instructions', () => {
         Shr.wireFormat16,
       );
 
-      expect(Shr.as(Shr.wireFormat16).deserialize(buf)).toEqual(inst);
-      expect(inst.serialize()).toEqual(buf);
+      expect(Shr.as(Shr.wireFormat16).fromBuffer(buf)).toEqual(inst);
+      expect(inst.toBuffer()).toEqual(buf);
     });
 
     it('Should require shift amount to be U8', async () => {
@@ -193,8 +193,8 @@ describe('Bitwise instructions', () => {
         Shl.wireFormat16,
       );
 
-      expect(Shl.as(Shl.wireFormat16).deserialize(buf)).toEqual(inst);
-      expect(inst.serialize()).toEqual(buf);
+      expect(Shl.as(Shl.wireFormat16).fromBuffer(buf)).toEqual(inst);
+      expect(inst.toBuffer()).toEqual(buf);
     });
 
     it('Should require shift amount to be U8', async () => {
@@ -279,8 +279,8 @@ describe('Bitwise instructions', () => {
         Not.wireFormat16,
       );
 
-      expect(Not.as(Not.wireFormat16).deserialize(buf)).toEqual(inst);
-      expect(inst.serialize()).toEqual(buf);
+      expect(Not.as(Not.wireFormat16).fromBuffer(buf)).toEqual(inst);
+      expect(inst.toBuffer()).toEqual(buf);
     });
 
     it('Should NOT correctly over integral types', async () => {

--- a/yarn-project/simulator/src/public/avm/opcodes/comparators.test.ts
+++ b/yarn-project/simulator/src/public/avm/opcodes/comparators.test.ts
@@ -26,8 +26,8 @@ describe('Comparators', () => {
         Eq.wireFormat16,
       );
 
-      expect(Eq.as(Eq.wireFormat16).deserialize(buf)).toEqual(inst);
-      expect(inst.serialize()).toEqual(buf);
+      expect(Eq.as(Eq.wireFormat16).fromBuffer(buf)).toEqual(inst);
+      expect(inst.toBuffer()).toEqual(buf);
     });
 
     it('Works on integral types', async () => {
@@ -93,8 +93,8 @@ describe('Comparators', () => {
         Lt.wireFormat16,
       );
 
-      expect(Lt.as(Lt.wireFormat16).deserialize(buf)).toEqual(inst);
-      expect(inst.serialize()).toEqual(buf);
+      expect(Lt.as(Lt.wireFormat16).fromBuffer(buf)).toEqual(inst);
+      expect(inst.toBuffer()).toEqual(buf);
     });
 
     it('Works on integral types', async () => {
@@ -160,8 +160,8 @@ describe('Comparators', () => {
         Lte.wireFormat16,
       );
 
-      expect(Lte.as(Lte.wireFormat16).deserialize(buf)).toEqual(inst);
-      expect(inst.serialize()).toEqual(buf);
+      expect(Lte.as(Lte.wireFormat16).fromBuffer(buf)).toEqual(inst);
+      expect(inst.toBuffer()).toEqual(buf);
     });
 
     it('Works on integral types', async () => {

--- a/yarn-project/simulator/src/public/avm/opcodes/contract.test.ts
+++ b/yarn-project/simulator/src/public/avm/opcodes/contract.test.ts
@@ -48,8 +48,8 @@ describe('Contract opcodes', () => {
         /*memberEnum=*/ 0x02,
       );
 
-      expect(GetContractInstance.deserialize(buf)).toEqual(inst);
-      expect(inst.serialize()).toEqual(buf);
+      expect(GetContractInstance.fromBuffer(buf)).toEqual(inst);
+      expect(inst.toBuffer()).toEqual(buf);
     });
 
     describe.each([

--- a/yarn-project/simulator/src/public/avm/opcodes/control_flow.test.ts
+++ b/yarn-project/simulator/src/public/avm/opcodes/control_flow.test.ts
@@ -19,8 +19,8 @@ describe('Control Flow Opcodes', () => {
       ]);
       const inst = new Jump(/*loc=*/ 0x12340000);
 
-      expect(Jump.deserialize(buf)).toEqual(inst);
-      expect(inst.serialize()).toEqual(buf);
+      expect(Jump.fromBuffer(buf)).toEqual(inst);
+      expect(inst.toBuffer()).toEqual(buf);
     });
 
     it('Should implement JUMP', async () => {
@@ -44,8 +44,8 @@ describe('Control Flow Opcodes', () => {
       ]);
       const inst = new JumpI(/*indirect=*/ 1, /*condOffset=*/ 0xa234, /*loc=*/ 0x12340000);
 
-      expect(JumpI.deserialize(buf)).toEqual(inst);
-      expect(inst.serialize()).toEqual(buf);
+      expect(JumpI.fromBuffer(buf)).toEqual(inst);
+      expect(inst.toBuffer()).toEqual(buf);
     });
 
     it('Should implement JUMPI - truthy', async () => {
@@ -89,8 +89,8 @@ describe('Control Flow Opcodes', () => {
       ]);
       const inst = new InternalCall(/*loc=*/ 0x12340000);
 
-      expect(InternalCall.deserialize(buf)).toEqual(inst);
-      expect(inst.serialize()).toEqual(buf);
+      expect(InternalCall.fromBuffer(buf)).toEqual(inst);
+      expect(inst.toBuffer()).toEqual(buf);
     });
 
     it('Should implement Internal Call and Return', async () => {

--- a/yarn-project/simulator/src/public/avm/opcodes/conversion.test.ts
+++ b/yarn-project/simulator/src/public/avm/opcodes/conversion.test.ts
@@ -32,8 +32,8 @@ describe('Conversion Opcodes', () => {
         /*dstOffset=*/ 0x5678,
       );
 
-      expect(ToRadixBE.deserialize(buf)).toEqual(inst);
-      expect(inst.serialize()).toEqual(buf);
+      expect(ToRadixBE.fromBuffer(buf)).toEqual(inst);
+      expect(inst.toBuffer()).toEqual(buf);
     });
 
     it('Should decompose correctly to bytes - direct', async () => {

--- a/yarn-project/simulator/src/public/avm/opcodes/ec_add.test.ts
+++ b/yarn-project/simulator/src/public/avm/opcodes/ec_add.test.ts
@@ -40,8 +40,8 @@ describe('EC Instructions', () => {
         /*dstOffset=*/ 0x1239,
       );
 
-      expect(EcAdd.deserialize(buf)).toEqual(inst);
-      expect(inst.serialize()).toEqual(buf);
+      expect(EcAdd.fromBuffer(buf)).toEqual(inst);
+      expect(inst.toBuffer()).toEqual(buf);
     });
 
     it(`Should double correctly`, async () => {

--- a/yarn-project/simulator/src/public/avm/opcodes/environment_getters.test.ts
+++ b/yarn-project/simulator/src/public/avm/opcodes/environment_getters.test.ts
@@ -54,8 +54,8 @@ describe('Environment getters', () => {
       GetEnvVar.wireFormat16,
     );
 
-    expect(GetEnvVar.as(GetEnvVar.wireFormat16).deserialize(buf)).toEqual(instr);
-    expect(instr.serialize()).toEqual(buf);
+    expect(GetEnvVar.as(GetEnvVar.wireFormat16).fromBuffer(buf)).toEqual(instr);
+    expect(instr.toBuffer()).toEqual(buf);
   });
 
   describe.each([

--- a/yarn-project/simulator/src/public/avm/opcodes/external_calls.test.ts
+++ b/yarn-project/simulator/src/public/avm/opcodes/external_calls.test.ts
@@ -59,8 +59,8 @@ describe('External Calls', () => {
         /*argsSizeOffset=*/ 0xc234,
       );
 
-      expect(Call.deserialize(buf)).toEqual(inst);
-      expect(inst.serialize()).toEqual(buf);
+      expect(Call.fromBuffer(buf)).toEqual(inst);
+      expect(inst.toBuffer()).toEqual(buf);
     });
 
     it('Call to non-existent bytecode returns failure', async () => {
@@ -227,8 +227,8 @@ describe('External Calls', () => {
         /*argsSizeOffset=*/ 0xc234,
       );
 
-      expect(StaticCall.deserialize(buf)).toEqual(inst);
-      expect(inst.serialize()).toEqual(buf);
+      expect(StaticCall.fromBuffer(buf)).toEqual(inst);
+      expect(inst.toBuffer()).toEqual(buf);
     });
 
     it('Should fail if a static call attempts to touch storage', async () => {
@@ -279,8 +279,8 @@ describe('External Calls', () => {
       ]);
       const inst = new Return(/*indirect=*/ 0x01, /*returnOffset=*/ 0x1234, /*copySize=*/ 0xa234);
 
-      expect(Return.deserialize(buf)).toEqual(inst);
-      expect(inst.serialize()).toEqual(buf);
+      expect(Return.fromBuffer(buf)).toEqual(inst);
+      expect(inst.toBuffer()).toEqual(buf);
     });
 
     it('Should return data from the return opcode', async () => {
@@ -313,8 +313,8 @@ describe('External Calls', () => {
         Revert.wireFormat16,
       );
 
-      expect(Revert.as(Revert.wireFormat16).deserialize(buf)).toEqual(inst);
-      expect(inst.serialize()).toEqual(buf);
+      expect(Revert.as(Revert.wireFormat16).fromBuffer(buf)).toEqual(inst);
+      expect(inst.toBuffer()).toEqual(buf);
     });
 
     it('Should return data and revert from the revert opcode', async () => {
@@ -342,8 +342,8 @@ describe('External Calls', () => {
       ]);
       const inst = new SuccessCopy(/*indirect=*/ 0x12, /*dstOffset=*/ 0x5678);
 
-      expect(SuccessCopy.deserialize(buf)).toEqual(inst);
-      expect(inst.serialize()).toEqual(buf);
+      expect(SuccessCopy.fromBuffer(buf)).toEqual(inst);
+      expect(inst.toBuffer()).toEqual(buf);
     });
 
     it('Should correctly copy success state for a successful call', async () => {

--- a/yarn-project/simulator/src/public/avm/opcodes/hashing.test.ts
+++ b/yarn-project/simulator/src/public/avm/opcodes/hashing.test.ts
@@ -24,8 +24,8 @@ describe('Hashing Opcodes', () => {
       ]);
       const inst = new Poseidon2(/*indirect=*/ 1, /*dstOffset=*/ 0x1234, /*messageOffset=*/ 0x2345);
 
-      expect(Poseidon2.deserialize(buf)).toEqual(inst);
-      expect(inst.serialize()).toEqual(buf);
+      expect(Poseidon2.fromBuffer(buf)).toEqual(inst);
+      expect(inst.toBuffer()).toEqual(buf);
     });
 
     it('Should hash correctly - direct', async () => {
@@ -98,8 +98,8 @@ describe('Hashing Opcodes', () => {
       ]);
       const inst = new KeccakF1600(/*indirect=*/ 1, /*dstOffset=*/ 0x1234, /*inputOffset=*/ 0x2345);
 
-      expect(KeccakF1600.deserialize(buf)).toEqual(inst);
-      expect(inst.serialize()).toEqual(buf);
+      expect(KeccakF1600.fromBuffer(buf)).toEqual(inst);
+      expect(inst.toBuffer()).toEqual(buf);
     });
 
     it('Should permute correctly - direct', async () => {
@@ -156,8 +156,8 @@ describe('Hashing Opcodes', () => {
         /*inputsOffset=*/ 0x4567,
       );
 
-      expect(Sha256Compression.deserialize(buf)).toEqual(inst);
-      expect(inst.serialize()).toEqual(buf);
+      expect(Sha256Compression.fromBuffer(buf)).toEqual(inst);
+      expect(inst.toBuffer()).toEqual(buf);
     });
 
     it('Should hash correctly - direct', async () => {

--- a/yarn-project/simulator/src/public/avm/opcodes/instruction.ts
+++ b/yarn-project/simulator/src/public/avm/opcodes/instruction.ts
@@ -1,9 +1,10 @@
+import type { Bufferable } from '@aztec/foundation/serialize';
+
 import { strict as assert } from 'assert';
 
 import type { AvmContext } from '../avm_context.js';
 import { type Gas, getBaseGasCost, getDynamicGasCost, mulGas, sumGas } from '../avm_gas.js';
 import type { BufferCursor } from '../serialization/buffer_cursor.js';
-import type { Serializable } from '../serialization/bytecode_serialization.js';
 import { Opcode, type OperandType, deserialize, serializeAs } from '../serialization/instruction_serialization.js';
 
 type InstructionConstructor = {
@@ -44,19 +45,19 @@ export abstract class Instruction {
   }
 
   // Default deserialization which uses Class.opcode and Class.wireFormat.
-  public static deserialize(
+  public static fromBuffer(
     this: InstructionConstructor & { wireFormat: OperandType[]; as: any },
     buf: BufferCursor | Buffer,
   ): Instruction {
-    return this.as(this.wireFormat).deserialize(buf);
+    return this.as(this.wireFormat).fromBuffer(buf);
   }
 
   // Default serialization which uses Class.opcode and Class.wireFormat.
-  public serialize(): Buffer {
+  public toBuffer(): Buffer {
     const klass = this.constructor as any;
     assert(klass.opcode !== undefined && klass.opcode !== null);
     assert(klass.wireFormat !== undefined && klass.wireFormat !== null);
-    return this.as(klass.opcode, klass.wireFormat).serialize();
+    return this.as(klass.opcode, klass.wireFormat).toBuffer();
   }
 
   /**
@@ -65,8 +66,8 @@ export abstract class Instruction {
    * @param wireFormat The wire format of the instruction.
    * @returns The new instruction instance.
    */
-  public as(opcode: Opcode, wireFormat: OperandType[]): Instruction & Serializable {
-    return Object.defineProperty(this, 'serialize', {
+  public as(opcode: Opcode, wireFormat: OperandType[]): Instruction & Bufferable {
+    return Object.defineProperty(this, 'toBuffer', {
       value: (): Buffer => {
         return serializeAs(wireFormat, opcode, this);
       },
@@ -82,7 +83,7 @@ export abstract class Instruction {
    */
   public static as(this: InstructionConstructor, wireFormat: OperandType[]) {
     return Object.assign(this, {
-      deserialize: (buf: BufferCursor | Buffer): Instruction => {
+      fromBuffer: (buf: BufferCursor | Buffer): Instruction => {
         const res = deserialize(buf, wireFormat);
         const args = res.slice(1); // Remove opcode.
         return new this(...args);

--- a/yarn-project/simulator/src/public/avm/opcodes/memory.test.ts
+++ b/yarn-project/simulator/src/public/avm/opcodes/memory.test.ts
@@ -29,8 +29,8 @@ describe('Memory instructions', () => {
         Set.wireFormat8,
       );
 
-      expect(Set.as(Set.wireFormat8).deserialize(buf)).toEqual(inst);
-      expect(inst.serialize()).toEqual(buf);
+      expect(Set.as(Set.wireFormat8).fromBuffer(buf)).toEqual(inst);
+      expect(inst.toBuffer()).toEqual(buf);
     });
 
     it('Should (de)serialize correctly [tag=u16]', () => {
@@ -46,8 +46,8 @@ describe('Memory instructions', () => {
         Set.wireFormat16,
       );
 
-      expect(Set.as(Set.wireFormat16).deserialize(buf)).toEqual(inst);
-      expect(inst.serialize()).toEqual(buf);
+      expect(Set.as(Set.wireFormat16).fromBuffer(buf)).toEqual(inst);
+      expect(inst.toBuffer()).toEqual(buf);
     });
 
     it('Should (de)serialize correctly [tag=u32]', () => {
@@ -65,8 +65,8 @@ describe('Memory instructions', () => {
         /*value=*/ 0x12345678,
       ).as(Opcode.SET_32, Set.wireFormat32);
 
-      expect(Set.as(Set.wireFormat32).deserialize(buf)).toEqual(inst);
-      expect(inst.serialize()).toEqual(buf);
+      expect(Set.as(Set.wireFormat32).fromBuffer(buf)).toEqual(inst);
+      expect(inst.toBuffer()).toEqual(buf);
     });
 
     it('Should (de)serialize correctly [tag=u64]', () => {
@@ -84,8 +84,8 @@ describe('Memory instructions', () => {
         /*value=*/ 0x1234567812345678n,
       ).as(Opcode.SET_64, Set.wireFormat64);
 
-      expect(Set.as(Set.wireFormat64).deserialize(buf)).toEqual(inst);
-      expect(inst.serialize()).toEqual(buf);
+      expect(Set.as(Set.wireFormat64).fromBuffer(buf)).toEqual(inst);
+      expect(inst.toBuffer()).toEqual(buf);
     });
 
     it('Should (de)serialize correctly [tag=u128]', () => {
@@ -103,8 +103,8 @@ describe('Memory instructions', () => {
         /*value=*/ 0x12345678123456781234567812345678n,
       ).as(Opcode.SET_128, Set.wireFormat128);
 
-      expect(Set.as(Set.wireFormat128).deserialize(buf)).toEqual(inst);
-      expect(inst.serialize()).toEqual(buf);
+      expect(Set.as(Set.wireFormat128).fromBuffer(buf)).toEqual(inst);
+      expect(inst.toBuffer()).toEqual(buf);
     });
 
     it('Should (de)serialize correctly [tag=ff]', () => {
@@ -122,8 +122,8 @@ describe('Memory instructions', () => {
         /*value=*/ 0x1234567890abcdef1234567890abcdef1234567890abcdef1234567890abcdefn,
       ).as(Opcode.SET_FF, Set.wireFormatFF);
 
-      expect(Set.as(Set.wireFormatFF).deserialize(buf)).toEqual(inst);
-      expect(inst.serialize()).toEqual(buf);
+      expect(Set.as(Set.wireFormatFF).fromBuffer(buf)).toEqual(inst);
+      expect(inst.toBuffer()).toEqual(buf);
     });
 
     it('should correctly set value and tag (uninitialized)', async () => {
@@ -175,8 +175,8 @@ describe('Memory instructions', () => {
         /*dstTag=*/ TypeTag.FIELD,
       ).as(Opcode.CAST_16, Cast.wireFormat16);
 
-      expect(Cast.as(Cast.wireFormat16).deserialize(buf)).toEqual(inst);
-      expect(inst.serialize()).toEqual(buf);
+      expect(Cast.as(Cast.wireFormat16).fromBuffer(buf)).toEqual(inst);
+      expect(inst.toBuffer()).toEqual(buf);
     });
 
     it('Should upcast between integral types', async () => {
@@ -328,8 +328,8 @@ describe('Memory instructions', () => {
         Mov.wireFormat8,
       );
 
-      expect(Mov.as(Mov.wireFormat8).deserialize(buf)).toEqual(inst);
-      expect(inst.serialize()).toEqual(buf);
+      expect(Mov.as(Mov.wireFormat8).fromBuffer(buf)).toEqual(inst);
+      expect(inst.toBuffer()).toEqual(buf);
     });
 
     it('Should move integrals on different memory cells', async () => {
@@ -381,8 +381,8 @@ describe('Memory instructions', () => {
         /*dstOffset=*/ 0x3456,
       );
 
-      expect(CalldataCopy.deserialize(buf)).toEqual(inst);
-      expect(inst.serialize()).toEqual(buf);
+      expect(CalldataCopy.fromBuffer(buf)).toEqual(inst);
+      expect(inst.toBuffer()).toEqual(buf);
     });
 
     it('Writes nothing if size is 0', async () => {
@@ -462,8 +462,8 @@ describe('Memory instructions', () => {
       ]);
       const inst = new ReturndataSize(/*indirect=*/ 0x01, /*dstOffset=*/ 0x3456);
 
-      expect(ReturndataSize.deserialize(buf)).toEqual(inst);
-      expect(inst.serialize()).toEqual(buf);
+      expect(ReturndataSize.fromBuffer(buf)).toEqual(inst);
+      expect(inst.toBuffer()).toEqual(buf);
     });
 
     it('Writes size', async () => {
@@ -493,8 +493,8 @@ describe('Memory instructions', () => {
         /*dstOffset=*/ 0x3456,
       );
 
-      expect(ReturndataCopy.deserialize(buf)).toEqual(inst);
-      expect(inst.serialize()).toEqual(buf);
+      expect(ReturndataCopy.fromBuffer(buf)).toEqual(inst);
+      expect(inst.toBuffer()).toEqual(buf);
     });
 
     it('Writes nothing if size is 0', async () => {

--- a/yarn-project/simulator/src/public/avm/opcodes/storage.test.ts
+++ b/yarn-project/simulator/src/public/avm/opcodes/storage.test.ts
@@ -34,8 +34,8 @@ describe('Storage Instructions', () => {
       ]);
       const inst = new SStore(/*indirect=*/ 0x01, /*srcOffset=*/ 0x1234, /*slotOffset=*/ 0x3456);
 
-      expect(SStore.deserialize(buf)).toEqual(inst);
-      expect(inst.serialize()).toEqual(buf);
+      expect(SStore.fromBuffer(buf)).toEqual(inst);
+      expect(inst.toBuffer()).toEqual(buf);
     });
 
     it('Sstore should Write into storage', async () => {
@@ -77,8 +77,8 @@ describe('Storage Instructions', () => {
       ]);
       const inst = new SLoad(/*indirect=*/ 0x01, /*slotOffset=*/ 0x1234, /*dstOffset=*/ 0x3456);
 
-      expect(SLoad.deserialize(buf)).toEqual(inst);
-      expect(inst.serialize()).toEqual(buf);
+      expect(SLoad.fromBuffer(buf)).toEqual(inst);
+      expect(inst.toBuffer()).toEqual(buf);
     });
 
     it('Sload should Read into storage', async () => {

--- a/yarn-project/simulator/src/public/avm/serialization/bytecode_serialization.test.ts
+++ b/yarn-project/simulator/src/public/avm/serialization/bytecode_serialization.test.ts
@@ -11,14 +11,14 @@ class InstA {
   static readonly opcode: number = 1;
 
   // Expects opcode.
-  public static deserialize(buf: BufferCursor): InstA {
+  public static fromBuffer(buf: BufferCursor): InstA {
     const opcode: number = buf.readUint8();
     assert(opcode == InstA.opcode);
     return new InstA(buf.readUint16BE());
   }
 
   // Includes opcode.
-  public serialize(): Buffer {
+  public toBuffer(): Buffer {
     const buf = Buffer.alloc(1 + 2);
     buf.writeUint8(InstA.opcode);
     buf.writeUint16BE(this.n, 1);
@@ -38,7 +38,7 @@ class InstB {
   }
 
   // Includes opcode.
-  public serialize(): Buffer {
+  public toBuffer(): Buffer {
     const buf = Buffer.alloc(1 + 8);
     buf.writeUint8(InstB.opcode);
     buf.writeBigInt64BE(this.n, 1);
@@ -49,12 +49,12 @@ class InstB {
 describe('Bytecode Serialization', () => {
   it('Should deserialize using instruction set', () => {
     const instructionSet: InstructionSet = new Map<Opcode, any>([
-      [InstA.opcode, InstA.deserialize],
+      [InstA.opcode, InstA.fromBuffer],
       [InstB.opcode, InstB.deserialize],
     ]);
     const a = new InstA(0x1234);
     const b = new InstB(0x5678n);
-    const bytecode = Buffer.concat([a.serialize(), b.serialize()]);
+    const bytecode = Buffer.concat([a.toBuffer(), b.toBuffer()]);
 
     const actual = decodeFromBytecode(bytecode, instructionSet);
 
@@ -67,7 +67,7 @@ describe('Bytecode Serialization', () => {
 
     const actual = encodeToBytecode([a, b]);
 
-    const expected = Buffer.concat([a.serialize(), b.serialize()]);
+    const expected = Buffer.concat([a.toBuffer(), b.toBuffer()]);
     expect(actual).toEqual(expected);
   });
 
@@ -94,7 +94,7 @@ describe('Bytecode Serialization', () => {
         /*argsSize=*/ 0xc234,
       ),
     ];
-    const bytecode = Buffer.concat(instructions.map(i => i.serialize()));
+    const bytecode = Buffer.concat(instructions.map(i => i.toBuffer()));
 
     const actual = decodeFromBytecode(bytecode);
 
@@ -127,7 +127,7 @@ describe('Bytecode Serialization', () => {
 
     const actual = encodeToBytecode(instructions);
 
-    const expected = Buffer.concat(instructions.map(i => i.serialize()));
+    const expected = Buffer.concat(instructions.map(i => i.toBuffer()));
     expect(actual).toEqual(expected);
   });
 
@@ -145,7 +145,7 @@ describe('Bytecode Serialization', () => {
   it('Should throw an InvalidOpcodeError while deserializing an opcode value not in instruction set', () => {
     const decodeInvalid = () => {
       const instructionSet: InstructionSet = new Map<Opcode, any>([
-        [InstA.opcode, InstA.deserialize],
+        [InstA.opcode, InstA.fromBuffer],
         [InstB.opcode, InstB.deserialize],
       ]);
       const buf = Buffer.alloc(1);

--- a/yarn-project/simulator/src/public/avm/serialization/bytecode_serialization.ts
+++ b/yarn-project/simulator/src/public/avm/serialization/bytecode_serialization.ts
@@ -1,3 +1,5 @@
+import { type Bufferable, serializeToBuffer } from '@aztec/foundation/serialize';
+
 import { AvmExecutionError, AvmParsingError, InvalidOpcodeError, InvalidProgramCounterError } from '../errors.js';
 import {
   Add,
@@ -53,106 +55,102 @@ import { MAX_OPCODE_VALUE, Opcode } from './instruction_serialization.js';
 
 export type InstructionDeserializer = (buf: BufferCursor | Buffer) => Instruction;
 
-export interface Serializable {
-  serialize(): Buffer;
-}
-
 export interface Deserializable {
   deserialize: InstructionDeserializer;
 }
 
 export type InstructionSet = Map<Opcode, InstructionDeserializer>;
 export const INSTRUCTION_SET = new Map<Opcode, InstructionDeserializer>([
-  [Opcode.ADD_8, Add.as(Add.wireFormat8).deserialize],
-  [Opcode.ADD_16, Add.as(Add.wireFormat16).deserialize],
-  [Opcode.SUB_8, Sub.as(Sub.wireFormat8).deserialize],
-  [Opcode.SUB_16, Sub.as(Sub.wireFormat16).deserialize],
-  [Opcode.MUL_8, Mul.as(Mul.wireFormat8).deserialize],
-  [Opcode.MUL_16, Mul.as(Mul.wireFormat16).deserialize],
-  [Opcode.DIV_8, Div.as(Div.wireFormat8).deserialize],
-  [Opcode.DIV_16, Div.as(Div.wireFormat16).deserialize],
-  [Opcode.FDIV_8, FieldDiv.as(FieldDiv.wireFormat8).deserialize],
-  [Opcode.FDIV_16, FieldDiv.as(FieldDiv.wireFormat16).deserialize],
-  [Opcode.EQ_8, Eq.as(Eq.wireFormat8).deserialize],
-  [Opcode.EQ_16, Eq.as(Eq.wireFormat16).deserialize],
-  [Opcode.LT_8, Lt.as(Lt.wireFormat8).deserialize],
-  [Opcode.LT_16, Lt.as(Lt.wireFormat16).deserialize],
-  [Opcode.LTE_8, Lte.as(Lte.wireFormat8).deserialize],
-  [Opcode.LTE_16, Lte.as(Lte.wireFormat16).deserialize],
-  [Opcode.AND_8, And.as(And.wireFormat8).deserialize],
-  [Opcode.AND_16, And.as(And.wireFormat16).deserialize],
-  [Opcode.OR_8, Or.as(Or.wireFormat8).deserialize],
-  [Opcode.OR_16, Or.as(Or.wireFormat16).deserialize],
-  [Opcode.XOR_8, Xor.as(Xor.wireFormat8).deserialize],
-  [Opcode.XOR_16, Xor.as(Xor.wireFormat16).deserialize],
-  [Opcode.NOT_8, Not.as(Not.wireFormat8).deserialize],
-  [Opcode.NOT_16, Not.as(Not.wireFormat16).deserialize],
-  [Opcode.SHL_8, Shl.as(Shl.wireFormat8).deserialize],
-  [Opcode.SHL_16, Shl.as(Shl.wireFormat16).deserialize],
-  [Opcode.SHR_8, Shr.as(Shr.wireFormat8).deserialize],
-  [Opcode.SHR_16, Shr.as(Shr.wireFormat16).deserialize],
-  [Opcode.CAST_8, Cast.as(Cast.wireFormat8).deserialize],
-  [Opcode.CAST_16, Cast.as(Cast.wireFormat16).deserialize],
+  [Opcode.ADD_8, Add.as(Add.wireFormat8).fromBuffer],
+  [Opcode.ADD_16, Add.as(Add.wireFormat16).fromBuffer],
+  [Opcode.SUB_8, Sub.as(Sub.wireFormat8).fromBuffer],
+  [Opcode.SUB_16, Sub.as(Sub.wireFormat16).fromBuffer],
+  [Opcode.MUL_8, Mul.as(Mul.wireFormat8).fromBuffer],
+  [Opcode.MUL_16, Mul.as(Mul.wireFormat16).fromBuffer],
+  [Opcode.DIV_8, Div.as(Div.wireFormat8).fromBuffer],
+  [Opcode.DIV_16, Div.as(Div.wireFormat16).fromBuffer],
+  [Opcode.FDIV_8, FieldDiv.as(FieldDiv.wireFormat8).fromBuffer],
+  [Opcode.FDIV_16, FieldDiv.as(FieldDiv.wireFormat16).fromBuffer],
+  [Opcode.EQ_8, Eq.as(Eq.wireFormat8).fromBuffer],
+  [Opcode.EQ_16, Eq.as(Eq.wireFormat16).fromBuffer],
+  [Opcode.LT_8, Lt.as(Lt.wireFormat8).fromBuffer],
+  [Opcode.LT_16, Lt.as(Lt.wireFormat16).fromBuffer],
+  [Opcode.LTE_8, Lte.as(Lte.wireFormat8).fromBuffer],
+  [Opcode.LTE_16, Lte.as(Lte.wireFormat16).fromBuffer],
+  [Opcode.AND_8, And.as(And.wireFormat8).fromBuffer],
+  [Opcode.AND_16, And.as(And.wireFormat16).fromBuffer],
+  [Opcode.OR_8, Or.as(Or.wireFormat8).fromBuffer],
+  [Opcode.OR_16, Or.as(Or.wireFormat16).fromBuffer],
+  [Opcode.XOR_8, Xor.as(Xor.wireFormat8).fromBuffer],
+  [Opcode.XOR_16, Xor.as(Xor.wireFormat16).fromBuffer],
+  [Opcode.NOT_8, Not.as(Not.wireFormat8).fromBuffer],
+  [Opcode.NOT_16, Not.as(Not.wireFormat16).fromBuffer],
+  [Opcode.SHL_8, Shl.as(Shl.wireFormat8).fromBuffer],
+  [Opcode.SHL_16, Shl.as(Shl.wireFormat16).fromBuffer],
+  [Opcode.SHR_8, Shr.as(Shr.wireFormat8).fromBuffer],
+  [Opcode.SHR_16, Shr.as(Shr.wireFormat16).fromBuffer],
+  [Opcode.CAST_8, Cast.as(Cast.wireFormat8).fromBuffer],
+  [Opcode.CAST_16, Cast.as(Cast.wireFormat16).fromBuffer],
   // Execution Environment
-  [Opcode.GETENVVAR_16, GetEnvVar.as(GetEnvVar.wireFormat16).deserialize],
-  [CalldataCopy.opcode, Instruction.deserialize.bind(CalldataCopy)],
-  [SuccessCopy.opcode, Instruction.deserialize.bind(SuccessCopy)],
-  [Opcode.RETURNDATASIZE, Instruction.deserialize.bind(ReturndataSize)],
-  [Opcode.RETURNDATACOPY, Instruction.deserialize.bind(ReturndataCopy)],
+  [Opcode.GETENVVAR_16, GetEnvVar.as(GetEnvVar.wireFormat16).fromBuffer],
+  [CalldataCopy.opcode, Instruction.fromBuffer.bind(CalldataCopy)],
+  [SuccessCopy.opcode, Instruction.fromBuffer.bind(SuccessCopy)],
+  [Opcode.RETURNDATASIZE, Instruction.fromBuffer.bind(ReturndataSize)],
+  [Opcode.RETURNDATACOPY, Instruction.fromBuffer.bind(ReturndataCopy)],
 
   // Machine State - Internal Control Flow
-  [Jump.opcode, Instruction.deserialize.bind(Jump)],
-  [JumpI.opcode, Instruction.deserialize.bind(JumpI)],
-  [InternalCall.opcode, Instruction.deserialize.bind(InternalCall)],
-  [InternalReturn.opcode, Instruction.deserialize.bind(InternalReturn)],
-  [Opcode.SET_8, Set.as(Set.wireFormat8).deserialize],
-  [Opcode.SET_16, Set.as(Set.wireFormat16).deserialize],
-  [Opcode.SET_32, Set.as(Set.wireFormat32).deserialize],
-  [Opcode.SET_64, Set.as(Set.wireFormat64).deserialize],
-  [Opcode.SET_128, Set.as(Set.wireFormat128).deserialize],
-  [Opcode.SET_FF, Set.as(Set.wireFormatFF).deserialize],
-  [Opcode.MOV_8, Mov.as(Mov.wireFormat8).deserialize],
-  [Opcode.MOV_16, Mov.as(Mov.wireFormat16).deserialize],
+  [Jump.opcode, Instruction.fromBuffer.bind(Jump)],
+  [JumpI.opcode, Instruction.fromBuffer.bind(JumpI)],
+  [InternalCall.opcode, Instruction.fromBuffer.bind(InternalCall)],
+  [InternalReturn.opcode, Instruction.fromBuffer.bind(InternalReturn)],
+  [Opcode.SET_8, Set.as(Set.wireFormat8).fromBuffer],
+  [Opcode.SET_16, Set.as(Set.wireFormat16).fromBuffer],
+  [Opcode.SET_32, Set.as(Set.wireFormat32).fromBuffer],
+  [Opcode.SET_64, Set.as(Set.wireFormat64).fromBuffer],
+  [Opcode.SET_128, Set.as(Set.wireFormat128).fromBuffer],
+  [Opcode.SET_FF, Set.as(Set.wireFormatFF).fromBuffer],
+  [Opcode.MOV_8, Mov.as(Mov.wireFormat8).fromBuffer],
+  [Opcode.MOV_16, Mov.as(Mov.wireFormat16).fromBuffer],
 
   // World State
-  [SLoad.opcode, Instruction.deserialize.bind(SLoad)], // Public Storage
-  [SStore.opcode, Instruction.deserialize.bind(SStore)], // Public Storage
-  [NoteHashExists.opcode, Instruction.deserialize.bind(NoteHashExists)], // Notes & Nullifiers
-  [EmitNoteHash.opcode, Instruction.deserialize.bind(EmitNoteHash)], // Notes & Nullifiers
-  [NullifierExists.opcode, Instruction.deserialize.bind(NullifierExists)], // Notes & Nullifiers
-  [EmitNullifier.opcode, Instruction.deserialize.bind(EmitNullifier)], // Notes & Nullifiers
-  [L1ToL2MessageExists.opcode, Instruction.deserialize.bind(L1ToL2MessageExists)], // Messages
+  [SLoad.opcode, Instruction.fromBuffer.bind(SLoad)], // Public Storage
+  [SStore.opcode, Instruction.fromBuffer.bind(SStore)], // Public Storage
+  [NoteHashExists.opcode, Instruction.fromBuffer.bind(NoteHashExists)], // Notes & Nullifiers
+  [EmitNoteHash.opcode, Instruction.fromBuffer.bind(EmitNoteHash)], // Notes & Nullifiers
+  [NullifierExists.opcode, Instruction.fromBuffer.bind(NullifierExists)], // Notes & Nullifiers
+  [EmitNullifier.opcode, Instruction.fromBuffer.bind(EmitNullifier)], // Notes & Nullifiers
+  [L1ToL2MessageExists.opcode, Instruction.fromBuffer.bind(L1ToL2MessageExists)], // Messages
 
   // Accrued Substate
-  [EmitUnencryptedLog.opcode, Instruction.deserialize.bind(EmitUnencryptedLog)],
-  [SendL2ToL1Message.opcode, Instruction.deserialize.bind(SendL2ToL1Message)],
-  [GetContractInstance.opcode, Instruction.deserialize.bind(GetContractInstance)],
+  [EmitUnencryptedLog.opcode, Instruction.fromBuffer.bind(EmitUnencryptedLog)],
+  [SendL2ToL1Message.opcode, Instruction.fromBuffer.bind(SendL2ToL1Message)],
+  [GetContractInstance.opcode, Instruction.fromBuffer.bind(GetContractInstance)],
 
   // Control Flow - Contract Calls
-  [Call.opcode, Instruction.deserialize.bind(Call)],
-  [StaticCall.opcode, Instruction.deserialize.bind(StaticCall)],
-  [Return.opcode, Instruction.deserialize.bind(Return)],
-  [Opcode.REVERT_8, Revert.as(Revert.wireFormat8).deserialize],
-  [Opcode.REVERT_16, Revert.as(Revert.wireFormat16).deserialize],
+  [Call.opcode, Instruction.fromBuffer.bind(Call)],
+  [StaticCall.opcode, Instruction.fromBuffer.bind(StaticCall)],
+  [Return.opcode, Instruction.fromBuffer.bind(Return)],
+  [Opcode.REVERT_8, Revert.as(Revert.wireFormat8).fromBuffer],
+  [Opcode.REVERT_16, Revert.as(Revert.wireFormat16).fromBuffer],
 
   // Misc
-  [DebugLog.opcode, Instruction.deserialize.bind(DebugLog)],
+  [DebugLog.opcode, Instruction.fromBuffer.bind(DebugLog)],
 
   // Gadgets
-  [EcAdd.opcode, Instruction.deserialize.bind(EcAdd)],
-  [Poseidon2.opcode, Instruction.deserialize.bind(Poseidon2)],
-  [Sha256Compression.opcode, Instruction.deserialize.bind(Sha256Compression)],
-  [KeccakF1600.opcode, Instruction.deserialize.bind(KeccakF1600)],
+  [EcAdd.opcode, Instruction.fromBuffer.bind(EcAdd)],
+  [Poseidon2.opcode, Instruction.fromBuffer.bind(Poseidon2)],
+  [Sha256Compression.opcode, Instruction.fromBuffer.bind(Sha256Compression)],
+  [KeccakF1600.opcode, Instruction.fromBuffer.bind(KeccakF1600)],
 
   // Conversions
-  [ToRadixBE.opcode, Instruction.deserialize.bind(ToRadixBE)],
+  [ToRadixBE.opcode, Instruction.fromBuffer.bind(ToRadixBE)],
 ]);
 
 /**
  * Serializes an array of instructions to bytecode.
  */
-export function encodeToBytecode(instructions: Serializable[]): Buffer {
-  return Buffer.concat(instructions.map(i => i.serialize()));
+export function encodeToBytecode(instructions: Bufferable[]): Buffer {
+  return serializeToBuffer(instructions);
 }
 
 // For testing only


### PR DESCRIPTION
Down to 1 cycle now: `private_execution.ts -> private_execution_oracle.ts`
