### PR TITLE
chore(docs): moving netlify action

### DIFF
--- a/.github/workflows/docs-deploy.yml
+++ b/.github/workflows/docs-deploy.yml
@@ -44,8 +44,17 @@ jobs:
 
       # Making the bash script here so we don't accidentally deploy
       - name: Deploy docs
+        working-directory: ./docs
         run: |
-          ./docs/bootstrap.sh release
+          echo "deploying docs to prod"
+          yarn install
+          yarn build
+
+          if ! deploy_output=$(yarn netlify deploy --site aztec-docs-dev --prod 2>&1); then
+            echo "Netlify deploy failed with error:"
+            echo "$deploy_output"
+            exit 1
+          fi
 
       - name: Reindex with Typesense docsearch-scraper
         run: |

--- a/docs/bootstrap.sh
+++ b/docs/bootstrap.sh
@@ -32,18 +32,6 @@ function build_docs {
   cache_upload docs-$hash.tar.gz build
 }
 
-function release_docs {
-  echo "deploying docs to prod"
-  yarn install
-  yarn build
-
-  if ! deploy_output=$(yarn netlify deploy --site aztec-docs-dev --prod 2>&1); then
-    echo "Netlify deploy failed with error:"
-    echo "$deploy_output"
-    exit 1
-  fi
-}
-
 case "$cmd" in
   "clean")
     git clean -fdx
@@ -53,9 +41,6 @@ case "$cmd" in
     ;;
   "hash")
     echo "$hash"
-    ;;
-  "release")
-    release_docs
     ;;
   *)
     echo "Unknown command: $cmd"


### PR DESCRIPTION
# Refactor docs deployment process

This PR moves the docs deployment logic from `bootstrap.sh` to the GitHub workflow file directly. The `release_docs` function has been removed from the bootstrap script and its contents have been integrated into the `docs-deploy.yml` workflow.

The deployment process now runs with the working directory set to `./docs`, which ensures all commands execute in the correct context.