### PR TITLE
fix: only clear trailing zeros on logs

### DIFF
--- a/yarn-project/pxe/src/pxe_oracle_interface/pxe_oracle_interface.test.ts
+++ b/yarn-project/pxe/src/pxe_oracle_interface/pxe_oracle_interface.test.ts
@@ -27,7 +27,7 @@ import { NoteDataProvider } from '../storage/note_data_provider/note_data_provid
 import { PrivateEventDataProvider } from '../storage/private_event_data_provider/private_event_data_provider.js';
 import { SyncDataProvider } from '../storage/sync_data_provider/sync_data_provider.js';
 import { TaggingDataProvider } from '../storage/tagging_data_provider/tagging_data_provider.js';
-import { PXEOracleInterface } from './pxe_oracle_interface.js';
+import { PXEOracleInterface, trimTrailingZeros } from './pxe_oracle_interface.js';
 import { WINDOW_HALF_SIZE } from './tagging_utils.js';
 
 jest.setTimeout(30_000);
@@ -830,4 +830,34 @@ describe('PXEOracleInterface', () => {
       }),
     );
   };
+
+  describe('trimTrailingZeros', () => {
+    function toFr(arr: number[]): Fr[] {
+      return arr.map(x => new Fr(x));
+    }
+
+    it('does not modify arrays with no zeros', () => {
+      expect(trimTrailingZeros(toFr([1, 2, 3]))).toEqual(toFr([1, 2, 3]));
+    });
+
+    it('removes zeros at the end', () => {
+      expect(trimTrailingZeros(toFr([1, 2, 3, 0, 0]))).toEqual(toFr([1, 2, 3]));
+    });
+
+    it('does not remove zeros not at the end', () => {
+      expect(trimTrailingZeros(toFr([1, 0, 2, 3, 0, 0]))).toEqual(toFr([1, 0, 2, 3]));
+    });
+
+    it('does not modify the original array', () => {
+      const original = toFr([1, 0, 2, 3, 0, 0]);
+      const result = trimTrailingZeros(original);
+
+      expect(result.length != original.length);
+      expect(original).toEqual(toFr([1, 0, 2, 3, 0, 0]));
+    });
+
+    it('works on an empty array', () => {
+      expect(trimTrailingZeros(toFr([]))).toEqual(toFr([]));
+    });
+  });
 });

--- a/yarn-project/pxe/src/pxe_oracle_interface/pxe_oracle_interface.ts
+++ b/yarn-project/pxe/src/pxe_oracle_interface/pxe_oracle_interface.ts
@@ -725,10 +725,9 @@ export class PXEOracleInterface implements ExecutionDataProvider {
     }
 
     // Public logs always take up all available fields by padding with zeroes, and the length of the originally emitted
-    // log is lost. Until this is improved, we simply remove all of the zero elements (which are expected to be at the
-    // end).
+    // log is lost. Until this is improved, we simply remove all of the zero elements we find at the end.
     // TODO(#11636): use the actual log length.
-    const trimmedLog = scopedLog.log.toFields().filter(x => !x.isZero());
+    const trimmedLog = trimTrailingZeros(scopedLog.log.toFields());
 
     return new LogWithTxData(trimmedLog, scopedLog.txHash, txEffect.data.noteHashes, txEffect.data.nullifiers[0]);
   }
@@ -833,4 +832,16 @@ export class PXEOracleInterface implements ExecutionDataProvider {
       blockNumber,
     );
   }
+}
+
+// TODO(#11636): remove once we have the actual log length and we don't need to trim it anymore
+export function trimTrailingZeros(array: Fr[]): Fr[] {
+  // Make a copy to avoid modifying the original one
+  const toReturn = [...array];
+
+  while (toReturn.length > 0 && toReturn[toReturn.length - 1].isZero()) {
+    toReturn.pop();
+  }
+
+  return toReturn;
 }


### PR DESCRIPTION
We used to assume we'd only ever see zeros in a log due to padding, but we now have scenarios were users put structs in a log that have some zero fields, e.g. a bignum value with multiple limbs for which some of them are zero when completing a partial note. If we knew the log length as per #11636 this would be a non-issue, but for now we need to only remove zeros _at the end_ of the array so that we can tell users that their logs will be fine as long as it has a non-zero field at the end.