### PR TITLE
refactor(avm): less codegen for lookups

### DIFF
--- a/barretenberg/cpp/src/barretenberg/vm2/constraining/flavor.hpp
+++ b/barretenberg/cpp/src/barretenberg/vm2/constraining/flavor.hpp
@@ -167,6 +167,7 @@ class AvmFlavor {
     class WitnessEntities : public WireEntities<DataType>, public DerivedWitnessEntities<DataType> {
       public:
         DEFINE_COMPOUND_GET_ALL(WireEntities<DataType>, DerivedWitnessEntities<DataType>)
+
         auto get_wires() { return WireEntities<DataType>::get_all(); }
         static const auto& get_wires_labels() { return WireEntities<DataType>::get_labels(); }
         auto get_derived() { return DerivedWitnessEntities<DataType>::get_all(); }
@@ -305,7 +306,7 @@ class AvmFlavor {
         ProverPolynomials(ProvingKey& proving_key);
 
         size_t get_polynomial_size() const { return execution_input.size(); }
-        // This is only used in VM1 check_circuit. Remove.
+        // This is only used in check_circuit. Remove.
         AllConstRefValues get_standard_row(size_t row_idx) const
         {
             return [row_idx](auto&... entities) -> AllConstRefValues {

--- a/barretenberg/cpp/src/barretenberg/vm2/constraining/relations/interactions_base.hpp
+++ b/barretenberg/cpp/src/barretenberg/vm2/constraining/relations/interactions_base.hpp
@@ -1,0 +1,84 @@
+#pragma once
+
+#include <cstddef>
+
+#include "barretenberg/relations/generic_lookup/generic_lookup_relation.hpp"
+#include "barretenberg/vm2/generated/columns.hpp"
+
+namespace bb::avm2 {
+
+template <typename Settings_> struct lookup_settings : public Settings_ {
+    static constexpr size_t READ_TERMS = 1;
+    static constexpr size_t WRITE_TERMS = 1;
+    static constexpr size_t READ_TERM_TYPES[READ_TERMS] = { 0 };
+    static constexpr size_t WRITE_TERM_TYPES[WRITE_TERMS] = { 0 };
+    static constexpr size_t INVERSE_EXISTS_POLYNOMIAL_DEGREE = 4;
+    static constexpr size_t READ_TERM_DEGREE = 0;
+    static constexpr size_t WRITE_TERM_DEGREE = 0;
+
+    template <typename AllEntities> static inline auto inverse_polynomial_is_computed_at_row(const AllEntities& in)
+    {
+        return (in.get(static_cast<ColumnAndShifts>(Settings_::SRC_SELECTOR)) == 1 ||
+                in.get(static_cast<ColumnAndShifts>(Settings_::DST_SELECTOR)) == 1);
+    }
+
+    template <typename Accumulator, typename AllEntities>
+    static inline auto compute_inverse_exists(const AllEntities& in)
+    {
+        using View = typename Accumulator::View;
+        const auto is_operation = View(in.get(static_cast<ColumnAndShifts>(Settings_::SRC_SELECTOR)));
+        const auto is_table_entry = View(in.get(static_cast<ColumnAndShifts>(Settings_::DST_SELECTOR)));
+        return (is_operation + is_table_entry - is_operation * is_table_entry);
+    }
+
+    template <typename AllEntities> static inline auto get_entities(AllEntities&& in)
+    {
+        return []<size_t... ISource, size_t... IDest>(
+                   AllEntities&& in, std::index_sequence<ISource...>, std::index_sequence<IDest...>) {
+            return std::forward_as_tuple(in.get(static_cast<ColumnAndShifts>(Settings_::INVERSES)),
+                                         in.get(static_cast<ColumnAndShifts>(Settings_::COUNTS)),
+                                         in.get(static_cast<ColumnAndShifts>(Settings_::SRC_SELECTOR)),
+                                         in.get(static_cast<ColumnAndShifts>(Settings_::DST_SELECTOR)),
+                                         in.get(Settings_::SRC_COLUMNS[ISource])...,
+                                         in.get(Settings_::DST_COLUMNS[IDest])...);
+        }(std::forward<AllEntities>(in),
+               std::make_index_sequence<Settings_::SRC_COLUMNS.size()>{},
+               std::make_index_sequence<Settings_::DST_COLUMNS.size()>{});
+    }
+
+    template <typename AllEntities> static inline auto get_const_entities(const AllEntities& in)
+    {
+        return get_entities(in);
+    }
+
+    template <typename AllEntities> static inline auto get_nonconst_entities(AllEntities& in)
+    {
+        return get_entities(in);
+    }
+};
+
+template <typename FF_, typename Settings_> struct lookup_relation_base : public GenericLookupRelation<Settings_, FF_> {
+    using Settings = Settings_;
+    static constexpr std::string_view NAME = Settings::NAME;
+    static constexpr std::string_view RELATION_NAME = Settings::RELATION_NAME;
+
+    template <typename AllEntities> inline static bool skip(const AllEntities& in)
+    {
+        auto inverse = std::get<0>(Settings::get_entities(in));
+        return inverse.is_zero();
+    }
+
+    static std::string get_subrelation_label(size_t index)
+    {
+        switch (index) {
+        case 0:
+            return "INVERSES_ARE_CORRECT";
+        case 1:
+            return "ACCUMULATION_IS_CORRECT";
+        default:
+            return std::to_string(index);
+        }
+    }
+};
+
+} // namespace bb::avm2

--- a/barretenberg/cpp/src/barretenberg/vm2/generated/relations/lookups_address_derivation.hpp
+++ b/barretenberg/cpp/src/barretenberg/vm2/generated/relations/lookups_address_derivation.hpp
@@ -3,6 +3,7 @@
 
 #include "../columns.hpp"
 #include "barretenberg/relations/generic_lookup/generic_lookup_relation.hpp"
+#include "barretenberg/vm2/constraining/relations/interactions_base.hpp"
 
 #include <cstddef>
 #include <string_view>
@@ -12,21 +13,10 @@ namespace bb::avm2 {
 
 /////////////////// lookup_address_derivation_salted_initialization_hash_poseidon2_0 ///////////////////
 
-class lookup_address_derivation_salted_initialization_hash_poseidon2_0_settings {
-  public:
+struct lookup_address_derivation_salted_initialization_hash_poseidon2_0_settings_ {
     static constexpr std::string_view NAME = "LOOKUP_ADDRESS_DERIVATION_SALTED_INITIALIZATION_HASH_POSEIDON2_0";
     static constexpr std::string_view RELATION_NAME = "address_derivation";
-
-    static constexpr size_t READ_TERMS = 1;
-    static constexpr size_t WRITE_TERMS = 1;
-    static constexpr size_t READ_TERM_TYPES[READ_TERMS] = { 0 };
-    static constexpr size_t WRITE_TERM_TYPES[WRITE_TERMS] = { 0 };
     static constexpr size_t LOOKUP_TUPLE_SIZE = 4;
-    static constexpr size_t INVERSE_EXISTS_POLYNOMIAL_DEGREE = 4;
-    static constexpr size_t READ_TERM_DEGREE = 0;
-    static constexpr size_t WRITE_TERM_DEGREE = 0;
-
-    // Columns using the Column enum.
     static constexpr Column SRC_SELECTOR = Column::address_derivation_sel;
     static constexpr Column DST_SELECTOR = Column::poseidon2_hash_start;
     static constexpr Column COUNTS = Column::lookup_address_derivation_salted_initialization_hash_poseidon2_0_counts;
@@ -43,93 +33,20 @@ class lookup_address_derivation_salted_initialization_hash_poseidon2_0_settings 
         ColumnAndShifts::poseidon2_hash_input_2,
         ColumnAndShifts::poseidon2_hash_output
     };
-
-    template <typename AllEntities> static inline auto inverse_polynomial_is_computed_at_row(const AllEntities& in)
-    {
-        return (in.get(ColumnAndShifts::address_derivation_sel) == 1 ||
-                in.get(ColumnAndShifts::poseidon2_hash_start) == 1);
-    }
-
-    template <typename Accumulator, typename AllEntities>
-    static inline auto compute_inverse_exists(const AllEntities& in)
-    {
-        using View = typename Accumulator::View;
-        const auto is_operation = View(in.get(ColumnAndShifts::address_derivation_sel));
-        const auto is_table_entry = View(in.get(ColumnAndShifts::poseidon2_hash_start));
-        return (is_operation + is_table_entry - is_operation * is_table_entry);
-    }
-
-    template <typename AllEntities> static inline auto get_const_entities(const AllEntities& in)
-    {
-        return get_entities(in);
-    }
-
-    template <typename AllEntities> static inline auto get_nonconst_entities(AllEntities& in)
-    {
-        return get_entities(in);
-    }
-
-    template <typename AllEntities> static inline auto get_entities(AllEntities&& in)
-    {
-        return std::forward_as_tuple(
-            in.get(ColumnAndShifts::lookup_address_derivation_salted_initialization_hash_poseidon2_0_inv),
-            in.get(ColumnAndShifts::lookup_address_derivation_salted_initialization_hash_poseidon2_0_counts),
-            in.get(ColumnAndShifts::address_derivation_sel),
-            in.get(ColumnAndShifts::poseidon2_hash_start),
-            in.get(ColumnAndShifts::address_derivation_partial_address_domain_separator),
-            in.get(ColumnAndShifts::address_derivation_salt),
-            in.get(ColumnAndShifts::address_derivation_init_hash),
-            in.get(ColumnAndShifts::address_derivation_salted_init_hash),
-            in.get(ColumnAndShifts::poseidon2_hash_input_0),
-            in.get(ColumnAndShifts::poseidon2_hash_input_1),
-            in.get(ColumnAndShifts::poseidon2_hash_input_2),
-            in.get(ColumnAndShifts::poseidon2_hash_output));
-    }
 };
 
+using lookup_address_derivation_salted_initialization_hash_poseidon2_0_settings =
+    lookup_settings<lookup_address_derivation_salted_initialization_hash_poseidon2_0_settings_>;
 template <typename FF_>
-class lookup_address_derivation_salted_initialization_hash_poseidon2_0_relation
-    : public GenericLookupRelation<lookup_address_derivation_salted_initialization_hash_poseidon2_0_settings, FF_> {
-  public:
-    using Settings = lookup_address_derivation_salted_initialization_hash_poseidon2_0_settings;
-    static constexpr std::string_view NAME =
-        lookup_address_derivation_salted_initialization_hash_poseidon2_0_settings::NAME;
-    static constexpr std::string_view RELATION_NAME =
-        lookup_address_derivation_salted_initialization_hash_poseidon2_0_settings::RELATION_NAME;
-
-    template <typename AllEntities> inline static bool skip(const AllEntities& in)
-    {
-        return in.lookup_address_derivation_salted_initialization_hash_poseidon2_0_inv.is_zero();
-    }
-
-    static std::string get_subrelation_label(size_t index)
-    {
-        if (index == 0) {
-            return "INVERSES_ARE_CORRECT";
-        } else if (index == 1) {
-            return "ACCUMULATION_IS_CORRECT";
-        }
-        return std::to_string(index);
-    }
-};
+using lookup_address_derivation_salted_initialization_hash_poseidon2_0_relation =
+    lookup_relation_base<FF_, lookup_address_derivation_salted_initialization_hash_poseidon2_0_settings>;
 
 /////////////////// lookup_address_derivation_salted_initialization_hash_poseidon2_1 ///////////////////
 
-class lookup_address_derivation_salted_initialization_hash_poseidon2_1_settings {
-  public:
+struct lookup_address_derivation_salted_initialization_hash_poseidon2_1_settings_ {
     static constexpr std::string_view NAME = "LOOKUP_ADDRESS_DERIVATION_SALTED_INITIALIZATION_HASH_POSEIDON2_1";
     static constexpr std::string_view RELATION_NAME = "address_derivation";
-
-    static constexpr size_t READ_TERMS = 1;
-    static constexpr size_t WRITE_TERMS = 1;
-    static constexpr size_t READ_TERM_TYPES[READ_TERMS] = { 0 };
-    static constexpr size_t WRITE_TERM_TYPES[WRITE_TERMS] = { 0 };
     static constexpr size_t LOOKUP_TUPLE_SIZE = 4;
-    static constexpr size_t INVERSE_EXISTS_POLYNOMIAL_DEGREE = 4;
-    static constexpr size_t READ_TERM_DEGREE = 0;
-    static constexpr size_t WRITE_TERM_DEGREE = 0;
-
-    // Columns using the Column enum.
     static constexpr Column SRC_SELECTOR = Column::address_derivation_sel;
     static constexpr Column DST_SELECTOR = Column::poseidon2_hash_end;
     static constexpr Column COUNTS = Column::lookup_address_derivation_salted_initialization_hash_poseidon2_1_counts;
@@ -146,93 +63,20 @@ class lookup_address_derivation_salted_initialization_hash_poseidon2_1_settings 
         ColumnAndShifts::poseidon2_hash_input_2,
         ColumnAndShifts::poseidon2_hash_output
     };
-
-    template <typename AllEntities> static inline auto inverse_polynomial_is_computed_at_row(const AllEntities& in)
-    {
-        return (in.get(ColumnAndShifts::address_derivation_sel) == 1 ||
-                in.get(ColumnAndShifts::poseidon2_hash_end) == 1);
-    }
-
-    template <typename Accumulator, typename AllEntities>
-    static inline auto compute_inverse_exists(const AllEntities& in)
-    {
-        using View = typename Accumulator::View;
-        const auto is_operation = View(in.get(ColumnAndShifts::address_derivation_sel));
-        const auto is_table_entry = View(in.get(ColumnAndShifts::poseidon2_hash_end));
-        return (is_operation + is_table_entry - is_operation * is_table_entry);
-    }
-
-    template <typename AllEntities> static inline auto get_const_entities(const AllEntities& in)
-    {
-        return get_entities(in);
-    }
-
-    template <typename AllEntities> static inline auto get_nonconst_entities(AllEntities& in)
-    {
-        return get_entities(in);
-    }
-
-    template <typename AllEntities> static inline auto get_entities(AllEntities&& in)
-    {
-        return std::forward_as_tuple(
-            in.get(ColumnAndShifts::lookup_address_derivation_salted_initialization_hash_poseidon2_1_inv),
-            in.get(ColumnAndShifts::lookup_address_derivation_salted_initialization_hash_poseidon2_1_counts),
-            in.get(ColumnAndShifts::address_derivation_sel),
-            in.get(ColumnAndShifts::poseidon2_hash_end),
-            in.get(ColumnAndShifts::address_derivation_deployer_addr),
-            in.get(ColumnAndShifts::precomputed_zero),
-            in.get(ColumnAndShifts::precomputed_zero),
-            in.get(ColumnAndShifts::address_derivation_salted_init_hash),
-            in.get(ColumnAndShifts::poseidon2_hash_input_0),
-            in.get(ColumnAndShifts::poseidon2_hash_input_1),
-            in.get(ColumnAndShifts::poseidon2_hash_input_2),
-            in.get(ColumnAndShifts::poseidon2_hash_output));
-    }
 };
 
+using lookup_address_derivation_salted_initialization_hash_poseidon2_1_settings =
+    lookup_settings<lookup_address_derivation_salted_initialization_hash_poseidon2_1_settings_>;
 template <typename FF_>
-class lookup_address_derivation_salted_initialization_hash_poseidon2_1_relation
-    : public GenericLookupRelation<lookup_address_derivation_salted_initialization_hash_poseidon2_1_settings, FF_> {
-  public:
-    using Settings = lookup_address_derivation_salted_initialization_hash_poseidon2_1_settings;
-    static constexpr std::string_view NAME =
-        lookup_address_derivation_salted_initialization_hash_poseidon2_1_settings::NAME;
-    static constexpr std::string_view RELATION_NAME =
-        lookup_address_derivation_salted_initialization_hash_poseidon2_1_settings::RELATION_NAME;
-
-    template <typename AllEntities> inline static bool skip(const AllEntities& in)
-    {
-        return in.lookup_address_derivation_salted_initialization_hash_poseidon2_1_inv.is_zero();
-    }
-
-    static std::string get_subrelation_label(size_t index)
-    {
-        if (index == 0) {
-            return "INVERSES_ARE_CORRECT";
-        } else if (index == 1) {
-            return "ACCUMULATION_IS_CORRECT";
-        }
-        return std::to_string(index);
-    }
-};
+using lookup_address_derivation_salted_initialization_hash_poseidon2_1_relation =
+    lookup_relation_base<FF_, lookup_address_derivation_salted_initialization_hash_poseidon2_1_settings>;
 
 /////////////////// lookup_address_derivation_partial_address_poseidon2 ///////////////////
 
-class lookup_address_derivation_partial_address_poseidon2_settings {
-  public:
+struct lookup_address_derivation_partial_address_poseidon2_settings_ {
     static constexpr std::string_view NAME = "LOOKUP_ADDRESS_DERIVATION_PARTIAL_ADDRESS_POSEIDON2";
     static constexpr std::string_view RELATION_NAME = "address_derivation";
-
-    static constexpr size_t READ_TERMS = 1;
-    static constexpr size_t WRITE_TERMS = 1;
-    static constexpr size_t READ_TERM_TYPES[READ_TERMS] = { 0 };
-    static constexpr size_t WRITE_TERM_TYPES[WRITE_TERMS] = { 0 };
     static constexpr size_t LOOKUP_TUPLE_SIZE = 4;
-    static constexpr size_t INVERSE_EXISTS_POLYNOMIAL_DEGREE = 4;
-    static constexpr size_t READ_TERM_DEGREE = 0;
-    static constexpr size_t WRITE_TERM_DEGREE = 0;
-
-    // Columns using the Column enum.
     static constexpr Column SRC_SELECTOR = Column::address_derivation_sel;
     static constexpr Column DST_SELECTOR = Column::poseidon2_hash_end;
     static constexpr Column COUNTS = Column::lookup_address_derivation_partial_address_poseidon2_counts;
@@ -249,92 +93,20 @@ class lookup_address_derivation_partial_address_poseidon2_settings {
         ColumnAndShifts::poseidon2_hash_input_2,
         ColumnAndShifts::poseidon2_hash_output
     };
-
-    template <typename AllEntities> static inline auto inverse_polynomial_is_computed_at_row(const AllEntities& in)
-    {
-        return (in.get(ColumnAndShifts::address_derivation_sel) == 1 ||
-                in.get(ColumnAndShifts::poseidon2_hash_end) == 1);
-    }
-
-    template <typename Accumulator, typename AllEntities>
-    static inline auto compute_inverse_exists(const AllEntities& in)
-    {
-        using View = typename Accumulator::View;
-        const auto is_operation = View(in.get(ColumnAndShifts::address_derivation_sel));
-        const auto is_table_entry = View(in.get(ColumnAndShifts::poseidon2_hash_end));
-        return (is_operation + is_table_entry - is_operation * is_table_entry);
-    }
-
-    template <typename AllEntities> static inline auto get_const_entities(const AllEntities& in)
-    {
-        return get_entities(in);
-    }
-
-    template <typename AllEntities> static inline auto get_nonconst_entities(AllEntities& in)
-    {
-        return get_entities(in);
-    }
-
-    template <typename AllEntities> static inline auto get_entities(AllEntities&& in)
-    {
-        return std::forward_as_tuple(
-            in.get(ColumnAndShifts::lookup_address_derivation_partial_address_poseidon2_inv),
-            in.get(ColumnAndShifts::lookup_address_derivation_partial_address_poseidon2_counts),
-            in.get(ColumnAndShifts::address_derivation_sel),
-            in.get(ColumnAndShifts::poseidon2_hash_end),
-            in.get(ColumnAndShifts::address_derivation_partial_address_domain_separator),
-            in.get(ColumnAndShifts::address_derivation_class_id),
-            in.get(ColumnAndShifts::address_derivation_salted_init_hash),
-            in.get(ColumnAndShifts::address_derivation_partial_address),
-            in.get(ColumnAndShifts::poseidon2_hash_input_0),
-            in.get(ColumnAndShifts::poseidon2_hash_input_1),
-            in.get(ColumnAndShifts::poseidon2_hash_input_2),
-            in.get(ColumnAndShifts::poseidon2_hash_output));
-    }
 };
 
+using lookup_address_derivation_partial_address_poseidon2_settings =
+    lookup_settings<lookup_address_derivation_partial_address_poseidon2_settings_>;
 template <typename FF_>
-class lookup_address_derivation_partial_address_poseidon2_relation
-    : public GenericLookupRelation<lookup_address_derivation_partial_address_poseidon2_settings, FF_> {
-  public:
-    using Settings = lookup_address_derivation_partial_address_poseidon2_settings;
-    static constexpr std::string_view NAME = lookup_address_derivation_partial_address_poseidon2_settings::NAME;
-    static constexpr std::string_view RELATION_NAME =
-        lookup_address_derivation_partial_address_poseidon2_settings::RELATION_NAME;
-
-    template <typename AllEntities> inline static bool skip(const AllEntities& in)
-    {
-        return in.lookup_address_derivation_partial_address_poseidon2_inv.is_zero();
-    }
-
-    static std::string get_subrelation_label(size_t index)
-    {
-        if (index == 0) {
-            return "INVERSES_ARE_CORRECT";
-        } else if (index == 1) {
-            return "ACCUMULATION_IS_CORRECT";
-        }
-        return std::to_string(index);
-    }
-};
+using lookup_address_derivation_partial_address_poseidon2_relation =
+    lookup_relation_base<FF_, lookup_address_derivation_partial_address_poseidon2_settings>;
 
 /////////////////// lookup_address_derivation_public_keys_hash_poseidon2_0 ///////////////////
 
-class lookup_address_derivation_public_keys_hash_poseidon2_0_settings {
-  public:
+struct lookup_address_derivation_public_keys_hash_poseidon2_0_settings_ {
     static constexpr std::string_view NAME = "LOOKUP_ADDRESS_DERIVATION_PUBLIC_KEYS_HASH_POSEIDON2_0";
     static constexpr std::string_view RELATION_NAME = "address_derivation";
-
-    static constexpr size_t READ_TERMS = 1;
-    static constexpr size_t WRITE_TERMS = 1;
-    static constexpr size_t READ_TERM_TYPES[READ_TERMS] = { 0 };
-    static constexpr size_t WRITE_TERM_TYPES[WRITE_TERMS] = { 0 };
     static constexpr size_t LOOKUP_TUPLE_SIZE = 4;
-    static constexpr size_t INVERSE_EXISTS_POLYNOMIAL_DEGREE = 4;
-    static constexpr size_t READ_TERM_DEGREE = 0;
-    static constexpr size_t WRITE_TERM_DEGREE = 0;
-
-    // Columns using the Column enum.
     static constexpr Column SRC_SELECTOR = Column::address_derivation_sel;
     static constexpr Column DST_SELECTOR = Column::poseidon2_hash_start;
     static constexpr Column COUNTS = Column::lookup_address_derivation_public_keys_hash_poseidon2_0_counts;
@@ -351,92 +123,20 @@ class lookup_address_derivation_public_keys_hash_poseidon2_0_settings {
         ColumnAndShifts::poseidon2_hash_input_2,
         ColumnAndShifts::poseidon2_hash_output
     };
-
-    template <typename AllEntities> static inline auto inverse_polynomial_is_computed_at_row(const AllEntities& in)
-    {
-        return (in.get(ColumnAndShifts::address_derivation_sel) == 1 ||
-                in.get(ColumnAndShifts::poseidon2_hash_start) == 1);
-    }
-
-    template <typename Accumulator, typename AllEntities>
-    static inline auto compute_inverse_exists(const AllEntities& in)
-    {
-        using View = typename Accumulator::View;
-        const auto is_operation = View(in.get(ColumnAndShifts::address_derivation_sel));
-        const auto is_table_entry = View(in.get(ColumnAndShifts::poseidon2_hash_start));
-        return (is_operation + is_table_entry - is_operation * is_table_entry);
-    }
-
-    template <typename AllEntities> static inline auto get_const_entities(const AllEntities& in)
-    {
-        return get_entities(in);
-    }
-
-    template <typename AllEntities> static inline auto get_nonconst_entities(AllEntities& in)
-    {
-        return get_entities(in);
-    }
-
-    template <typename AllEntities> static inline auto get_entities(AllEntities&& in)
-    {
-        return std::forward_as_tuple(
-            in.get(ColumnAndShifts::lookup_address_derivation_public_keys_hash_poseidon2_0_inv),
-            in.get(ColumnAndShifts::lookup_address_derivation_public_keys_hash_poseidon2_0_counts),
-            in.get(ColumnAndShifts::address_derivation_sel),
-            in.get(ColumnAndShifts::poseidon2_hash_start),
-            in.get(ColumnAndShifts::address_derivation_public_keys_hash_domain_separator),
-            in.get(ColumnAndShifts::address_derivation_nullifier_key_x),
-            in.get(ColumnAndShifts::address_derivation_nullifier_key_y),
-            in.get(ColumnAndShifts::address_derivation_public_keys_hash),
-            in.get(ColumnAndShifts::poseidon2_hash_input_0),
-            in.get(ColumnAndShifts::poseidon2_hash_input_1),
-            in.get(ColumnAndShifts::poseidon2_hash_input_2),
-            in.get(ColumnAndShifts::poseidon2_hash_output));
-    }
 };
 
+using lookup_address_derivation_public_keys_hash_poseidon2_0_settings =
+    lookup_settings<lookup_address_derivation_public_keys_hash_poseidon2_0_settings_>;
 template <typename FF_>
-class lookup_address_derivation_public_keys_hash_poseidon2_0_relation
-    : public GenericLookupRelation<lookup_address_derivation_public_keys_hash_poseidon2_0_settings, FF_> {
-  public:
-    using Settings = lookup_address_derivation_public_keys_hash_poseidon2_0_settings;
-    static constexpr std::string_view NAME = lookup_address_derivation_public_keys_hash_poseidon2_0_settings::NAME;
-    static constexpr std::string_view RELATION_NAME =
-        lookup_address_derivation_public_keys_hash_poseidon2_0_settings::RELATION_NAME;
-
-    template <typename AllEntities> inline static bool skip(const AllEntities& in)
-    {
-        return in.lookup_address_derivation_public_keys_hash_poseidon2_0_inv.is_zero();
-    }
-
-    static std::string get_subrelation_label(size_t index)
-    {
-        if (index == 0) {
-            return "INVERSES_ARE_CORRECT";
-        } else if (index == 1) {
-            return "ACCUMULATION_IS_CORRECT";
-        }
-        return std::to_string(index);
-    }
-};
+using lookup_address_derivation_public_keys_hash_poseidon2_0_relation =
+    lookup_relation_base<FF_, lookup_address_derivation_public_keys_hash_poseidon2_0_settings>;
 
 /////////////////// lookup_address_derivation_public_keys_hash_poseidon2_1 ///////////////////
 
-class lookup_address_derivation_public_keys_hash_poseidon2_1_settings {
-  public:
+struct lookup_address_derivation_public_keys_hash_poseidon2_1_settings_ {
     static constexpr std::string_view NAME = "LOOKUP_ADDRESS_DERIVATION_PUBLIC_KEYS_HASH_POSEIDON2_1";
     static constexpr std::string_view RELATION_NAME = "address_derivation";
-
-    static constexpr size_t READ_TERMS = 1;
-    static constexpr size_t WRITE_TERMS = 1;
-    static constexpr size_t READ_TERM_TYPES[READ_TERMS] = { 0 };
-    static constexpr size_t WRITE_TERM_TYPES[WRITE_TERMS] = { 0 };
     static constexpr size_t LOOKUP_TUPLE_SIZE = 4;
-    static constexpr size_t INVERSE_EXISTS_POLYNOMIAL_DEGREE = 4;
-    static constexpr size_t READ_TERM_DEGREE = 0;
-    static constexpr size_t WRITE_TERM_DEGREE = 0;
-
-    // Columns using the Column enum.
     static constexpr Column SRC_SELECTOR = Column::address_derivation_sel;
     static constexpr Column DST_SELECTOR = Column::poseidon2_hash_sel;
     static constexpr Column COUNTS = Column::lookup_address_derivation_public_keys_hash_poseidon2_1_counts;
@@ -453,92 +153,20 @@ class lookup_address_derivation_public_keys_hash_poseidon2_1_settings {
         ColumnAndShifts::poseidon2_hash_input_2,
         ColumnAndShifts::poseidon2_hash_output
     };
-
-    template <typename AllEntities> static inline auto inverse_polynomial_is_computed_at_row(const AllEntities& in)
-    {
-        return (in.get(ColumnAndShifts::address_derivation_sel) == 1 ||
-                in.get(ColumnAndShifts::poseidon2_hash_sel) == 1);
-    }
-
-    template <typename Accumulator, typename AllEntities>
-    static inline auto compute_inverse_exists(const AllEntities& in)
-    {
-        using View = typename Accumulator::View;
-        const auto is_operation = View(in.get(ColumnAndShifts::address_derivation_sel));
-        const auto is_table_entry = View(in.get(ColumnAndShifts::poseidon2_hash_sel));
-        return (is_operation + is_table_entry - is_operation * is_table_entry);
-    }
-
-    template <typename AllEntities> static inline auto get_const_entities(const AllEntities& in)
-    {
-        return get_entities(in);
-    }
-
-    template <typename AllEntities> static inline auto get_nonconst_entities(AllEntities& in)
-    {
-        return get_entities(in);
-    }
-
-    template <typename AllEntities> static inline auto get_entities(AllEntities&& in)
-    {
-        return std::forward_as_tuple(
-            in.get(ColumnAndShifts::lookup_address_derivation_public_keys_hash_poseidon2_1_inv),
-            in.get(ColumnAndShifts::lookup_address_derivation_public_keys_hash_poseidon2_1_counts),
-            in.get(ColumnAndShifts::address_derivation_sel),
-            in.get(ColumnAndShifts::poseidon2_hash_sel),
-            in.get(ColumnAndShifts::precomputed_zero),
-            in.get(ColumnAndShifts::address_derivation_incoming_viewing_key_x),
-            in.get(ColumnAndShifts::address_derivation_incoming_viewing_key_y),
-            in.get(ColumnAndShifts::address_derivation_public_keys_hash),
-            in.get(ColumnAndShifts::poseidon2_hash_input_0),
-            in.get(ColumnAndShifts::poseidon2_hash_input_1),
-            in.get(ColumnAndShifts::poseidon2_hash_input_2),
-            in.get(ColumnAndShifts::poseidon2_hash_output));
-    }
 };
 
+using lookup_address_derivation_public_keys_hash_poseidon2_1_settings =
+    lookup_settings<lookup_address_derivation_public_keys_hash_poseidon2_1_settings_>;
 template <typename FF_>
-class lookup_address_derivation_public_keys_hash_poseidon2_1_relation
-    : public GenericLookupRelation<lookup_address_derivation_public_keys_hash_poseidon2_1_settings, FF_> {
-  public:
-    using Settings = lookup_address_derivation_public_keys_hash_poseidon2_1_settings;
-    static constexpr std::string_view NAME = lookup_address_derivation_public_keys_hash_poseidon2_1_settings::NAME;
-    static constexpr std::string_view RELATION_NAME =
-        lookup_address_derivation_public_keys_hash_poseidon2_1_settings::RELATION_NAME;
-
-    template <typename AllEntities> inline static bool skip(const AllEntities& in)
-    {
-        return in.lookup_address_derivation_public_keys_hash_poseidon2_1_inv.is_zero();
-    }
-
-    static std::string get_subrelation_label(size_t index)
-    {
-        if (index == 0) {
-            return "INVERSES_ARE_CORRECT";
-        } else if (index == 1) {
-            return "ACCUMULATION_IS_CORRECT";
-        }
-        return std::to_string(index);
-    }
-};
+using lookup_address_derivation_public_keys_hash_poseidon2_1_relation =
+    lookup_relation_base<FF_, lookup_address_derivation_public_keys_hash_poseidon2_1_settings>;
 
 /////////////////// lookup_address_derivation_public_keys_hash_poseidon2_2 ///////////////////
 
-class lookup_address_derivation_public_keys_hash_poseidon2_2_settings {
-  public:
+struct lookup_address_derivation_public_keys_hash_poseidon2_2_settings_ {
     static constexpr std::string_view NAME = "LOOKUP_ADDRESS_DERIVATION_PUBLIC_KEYS_HASH_POSEIDON2_2";
     static constexpr std::string_view RELATION_NAME = "address_derivation";
-
-    static constexpr size_t READ_TERMS = 1;
-    static constexpr size_t WRITE_TERMS = 1;
-    static constexpr size_t READ_TERM_TYPES[READ_TERMS] = { 0 };
-    static constexpr size_t WRITE_TERM_TYPES[WRITE_TERMS] = { 0 };
     static constexpr size_t LOOKUP_TUPLE_SIZE = 4;
-    static constexpr size_t INVERSE_EXISTS_POLYNOMIAL_DEGREE = 4;
-    static constexpr size_t READ_TERM_DEGREE = 0;
-    static constexpr size_t WRITE_TERM_DEGREE = 0;
-
-    // Columns using the Column enum.
     static constexpr Column SRC_SELECTOR = Column::address_derivation_sel;
     static constexpr Column DST_SELECTOR = Column::poseidon2_hash_sel;
     static constexpr Column COUNTS = Column::lookup_address_derivation_public_keys_hash_poseidon2_2_counts;
@@ -555,92 +183,20 @@ class lookup_address_derivation_public_keys_hash_poseidon2_2_settings {
         ColumnAndShifts::poseidon2_hash_input_2,
         ColumnAndShifts::poseidon2_hash_output
     };
-
-    template <typename AllEntities> static inline auto inverse_polynomial_is_computed_at_row(const AllEntities& in)
-    {
-        return (in.get(ColumnAndShifts::address_derivation_sel) == 1 ||
-                in.get(ColumnAndShifts::poseidon2_hash_sel) == 1);
-    }
-
-    template <typename Accumulator, typename AllEntities>
-    static inline auto compute_inverse_exists(const AllEntities& in)
-    {
-        using View = typename Accumulator::View;
-        const auto is_operation = View(in.get(ColumnAndShifts::address_derivation_sel));
-        const auto is_table_entry = View(in.get(ColumnAndShifts::poseidon2_hash_sel));
-        return (is_operation + is_table_entry - is_operation * is_table_entry);
-    }
-
-    template <typename AllEntities> static inline auto get_const_entities(const AllEntities& in)
-    {
-        return get_entities(in);
-    }
-
-    template <typename AllEntities> static inline auto get_nonconst_entities(AllEntities& in)
-    {
-        return get_entities(in);
-    }
-
-    template <typename AllEntities> static inline auto get_entities(AllEntities&& in)
-    {
-        return std::forward_as_tuple(
-            in.get(ColumnAndShifts::lookup_address_derivation_public_keys_hash_poseidon2_2_inv),
-            in.get(ColumnAndShifts::lookup_address_derivation_public_keys_hash_poseidon2_2_counts),
-            in.get(ColumnAndShifts::address_derivation_sel),
-            in.get(ColumnAndShifts::poseidon2_hash_sel),
-            in.get(ColumnAndShifts::precomputed_zero),
-            in.get(ColumnAndShifts::address_derivation_outgoing_viewing_key_x),
-            in.get(ColumnAndShifts::address_derivation_outgoing_viewing_key_y),
-            in.get(ColumnAndShifts::address_derivation_public_keys_hash),
-            in.get(ColumnAndShifts::poseidon2_hash_input_0),
-            in.get(ColumnAndShifts::poseidon2_hash_input_1),
-            in.get(ColumnAndShifts::poseidon2_hash_input_2),
-            in.get(ColumnAndShifts::poseidon2_hash_output));
-    }
 };
 
+using lookup_address_derivation_public_keys_hash_poseidon2_2_settings =
+    lookup_settings<lookup_address_derivation_public_keys_hash_poseidon2_2_settings_>;
 template <typename FF_>
-class lookup_address_derivation_public_keys_hash_poseidon2_2_relation
-    : public GenericLookupRelation<lookup_address_derivation_public_keys_hash_poseidon2_2_settings, FF_> {
-  public:
-    using Settings = lookup_address_derivation_public_keys_hash_poseidon2_2_settings;
-    static constexpr std::string_view NAME = lookup_address_derivation_public_keys_hash_poseidon2_2_settings::NAME;
-    static constexpr std::string_view RELATION_NAME =
-        lookup_address_derivation_public_keys_hash_poseidon2_2_settings::RELATION_NAME;
-
-    template <typename AllEntities> inline static bool skip(const AllEntities& in)
-    {
-        return in.lookup_address_derivation_public_keys_hash_poseidon2_2_inv.is_zero();
-    }
-
-    static std::string get_subrelation_label(size_t index)
-    {
-        if (index == 0) {
-            return "INVERSES_ARE_CORRECT";
-        } else if (index == 1) {
-            return "ACCUMULATION_IS_CORRECT";
-        }
-        return std::to_string(index);
-    }
-};
+using lookup_address_derivation_public_keys_hash_poseidon2_2_relation =
+    lookup_relation_base<FF_, lookup_address_derivation_public_keys_hash_poseidon2_2_settings>;
 
 /////////////////// lookup_address_derivation_public_keys_hash_poseidon2_3 ///////////////////
 
-class lookup_address_derivation_public_keys_hash_poseidon2_3_settings {
-  public:
+struct lookup_address_derivation_public_keys_hash_poseidon2_3_settings_ {
     static constexpr std::string_view NAME = "LOOKUP_ADDRESS_DERIVATION_PUBLIC_KEYS_HASH_POSEIDON2_3";
     static constexpr std::string_view RELATION_NAME = "address_derivation";
-
-    static constexpr size_t READ_TERMS = 1;
-    static constexpr size_t WRITE_TERMS = 1;
-    static constexpr size_t READ_TERM_TYPES[READ_TERMS] = { 0 };
-    static constexpr size_t WRITE_TERM_TYPES[WRITE_TERMS] = { 0 };
     static constexpr size_t LOOKUP_TUPLE_SIZE = 4;
-    static constexpr size_t INVERSE_EXISTS_POLYNOMIAL_DEGREE = 4;
-    static constexpr size_t READ_TERM_DEGREE = 0;
-    static constexpr size_t WRITE_TERM_DEGREE = 0;
-
-    // Columns using the Column enum.
     static constexpr Column SRC_SELECTOR = Column::address_derivation_sel;
     static constexpr Column DST_SELECTOR = Column::poseidon2_hash_sel;
     static constexpr Column COUNTS = Column::lookup_address_derivation_public_keys_hash_poseidon2_3_counts;
@@ -657,92 +213,20 @@ class lookup_address_derivation_public_keys_hash_poseidon2_3_settings {
         ColumnAndShifts::poseidon2_hash_input_2,
         ColumnAndShifts::poseidon2_hash_output
     };
-
-    template <typename AllEntities> static inline auto inverse_polynomial_is_computed_at_row(const AllEntities& in)
-    {
-        return (in.get(ColumnAndShifts::address_derivation_sel) == 1 ||
-                in.get(ColumnAndShifts::poseidon2_hash_sel) == 1);
-    }
-
-    template <typename Accumulator, typename AllEntities>
-    static inline auto compute_inverse_exists(const AllEntities& in)
-    {
-        using View = typename Accumulator::View;
-        const auto is_operation = View(in.get(ColumnAndShifts::address_derivation_sel));
-        const auto is_table_entry = View(in.get(ColumnAndShifts::poseidon2_hash_sel));
-        return (is_operation + is_table_entry - is_operation * is_table_entry);
-    }
-
-    template <typename AllEntities> static inline auto get_const_entities(const AllEntities& in)
-    {
-        return get_entities(in);
-    }
-
-    template <typename AllEntities> static inline auto get_nonconst_entities(AllEntities& in)
-    {
-        return get_entities(in);
-    }
-
-    template <typename AllEntities> static inline auto get_entities(AllEntities&& in)
-    {
-        return std::forward_as_tuple(
-            in.get(ColumnAndShifts::lookup_address_derivation_public_keys_hash_poseidon2_3_inv),
-            in.get(ColumnAndShifts::lookup_address_derivation_public_keys_hash_poseidon2_3_counts),
-            in.get(ColumnAndShifts::address_derivation_sel),
-            in.get(ColumnAndShifts::poseidon2_hash_sel),
-            in.get(ColumnAndShifts::precomputed_zero),
-            in.get(ColumnAndShifts::address_derivation_tagging_key_x),
-            in.get(ColumnAndShifts::address_derivation_tagging_key_y),
-            in.get(ColumnAndShifts::address_derivation_public_keys_hash),
-            in.get(ColumnAndShifts::poseidon2_hash_input_0),
-            in.get(ColumnAndShifts::poseidon2_hash_input_1),
-            in.get(ColumnAndShifts::poseidon2_hash_input_2),
-            in.get(ColumnAndShifts::poseidon2_hash_output));
-    }
 };
 
+using lookup_address_derivation_public_keys_hash_poseidon2_3_settings =
+    lookup_settings<lookup_address_derivation_public_keys_hash_poseidon2_3_settings_>;
 template <typename FF_>
-class lookup_address_derivation_public_keys_hash_poseidon2_3_relation
-    : public GenericLookupRelation<lookup_address_derivation_public_keys_hash_poseidon2_3_settings, FF_> {
-  public:
-    using Settings = lookup_address_derivation_public_keys_hash_poseidon2_3_settings;
-    static constexpr std::string_view NAME = lookup_address_derivation_public_keys_hash_poseidon2_3_settings::NAME;
-    static constexpr std::string_view RELATION_NAME =
-        lookup_address_derivation_public_keys_hash_poseidon2_3_settings::RELATION_NAME;
-
-    template <typename AllEntities> inline static bool skip(const AllEntities& in)
-    {
-        return in.lookup_address_derivation_public_keys_hash_poseidon2_3_inv.is_zero();
-    }
-
-    static std::string get_subrelation_label(size_t index)
-    {
-        if (index == 0) {
-            return "INVERSES_ARE_CORRECT";
-        } else if (index == 1) {
-            return "ACCUMULATION_IS_CORRECT";
-        }
-        return std::to_string(index);
-    }
-};
+using lookup_address_derivation_public_keys_hash_poseidon2_3_relation =
+    lookup_relation_base<FF_, lookup_address_derivation_public_keys_hash_poseidon2_3_settings>;
 
 /////////////////// lookup_address_derivation_public_keys_hash_poseidon2_4 ///////////////////
 
-class lookup_address_derivation_public_keys_hash_poseidon2_4_settings {
-  public:
+struct lookup_address_derivation_public_keys_hash_poseidon2_4_settings_ {
     static constexpr std::string_view NAME = "LOOKUP_ADDRESS_DERIVATION_PUBLIC_KEYS_HASH_POSEIDON2_4";
     static constexpr std::string_view RELATION_NAME = "address_derivation";
-
-    static constexpr size_t READ_TERMS = 1;
-    static constexpr size_t WRITE_TERMS = 1;
-    static constexpr size_t READ_TERM_TYPES[READ_TERMS] = { 0 };
-    static constexpr size_t WRITE_TERM_TYPES[WRITE_TERMS] = { 0 };
     static constexpr size_t LOOKUP_TUPLE_SIZE = 4;
-    static constexpr size_t INVERSE_EXISTS_POLYNOMIAL_DEGREE = 4;
-    static constexpr size_t READ_TERM_DEGREE = 0;
-    static constexpr size_t WRITE_TERM_DEGREE = 0;
-
-    // Columns using the Column enum.
     static constexpr Column SRC_SELECTOR = Column::address_derivation_sel;
     static constexpr Column DST_SELECTOR = Column::poseidon2_hash_end;
     static constexpr Column COUNTS = Column::lookup_address_derivation_public_keys_hash_poseidon2_4_counts;
@@ -759,92 +243,20 @@ class lookup_address_derivation_public_keys_hash_poseidon2_4_settings {
         ColumnAndShifts::poseidon2_hash_input_2,
         ColumnAndShifts::poseidon2_hash_output
     };
-
-    template <typename AllEntities> static inline auto inverse_polynomial_is_computed_at_row(const AllEntities& in)
-    {
-        return (in.get(ColumnAndShifts::address_derivation_sel) == 1 ||
-                in.get(ColumnAndShifts::poseidon2_hash_end) == 1);
-    }
-
-    template <typename Accumulator, typename AllEntities>
-    static inline auto compute_inverse_exists(const AllEntities& in)
-    {
-        using View = typename Accumulator::View;
-        const auto is_operation = View(in.get(ColumnAndShifts::address_derivation_sel));
-        const auto is_table_entry = View(in.get(ColumnAndShifts::poseidon2_hash_end));
-        return (is_operation + is_table_entry - is_operation * is_table_entry);
-    }
-
-    template <typename AllEntities> static inline auto get_const_entities(const AllEntities& in)
-    {
-        return get_entities(in);
-    }
-
-    template <typename AllEntities> static inline auto get_nonconst_entities(AllEntities& in)
-    {
-        return get_entities(in);
-    }
-
-    template <typename AllEntities> static inline auto get_entities(AllEntities&& in)
-    {
-        return std::forward_as_tuple(
-            in.get(ColumnAndShifts::lookup_address_derivation_public_keys_hash_poseidon2_4_inv),
-            in.get(ColumnAndShifts::lookup_address_derivation_public_keys_hash_poseidon2_4_counts),
-            in.get(ColumnAndShifts::address_derivation_sel),
-            in.get(ColumnAndShifts::poseidon2_hash_end),
-            in.get(ColumnAndShifts::precomputed_zero),
-            in.get(ColumnAndShifts::precomputed_zero),
-            in.get(ColumnAndShifts::precomputed_zero),
-            in.get(ColumnAndShifts::address_derivation_public_keys_hash),
-            in.get(ColumnAndShifts::poseidon2_hash_input_0),
-            in.get(ColumnAndShifts::poseidon2_hash_input_1),
-            in.get(ColumnAndShifts::poseidon2_hash_input_2),
-            in.get(ColumnAndShifts::poseidon2_hash_output));
-    }
 };
 
+using lookup_address_derivation_public_keys_hash_poseidon2_4_settings =
+    lookup_settings<lookup_address_derivation_public_keys_hash_poseidon2_4_settings_>;
 template <typename FF_>
-class lookup_address_derivation_public_keys_hash_poseidon2_4_relation
-    : public GenericLookupRelation<lookup_address_derivation_public_keys_hash_poseidon2_4_settings, FF_> {
-  public:
-    using Settings = lookup_address_derivation_public_keys_hash_poseidon2_4_settings;
-    static constexpr std::string_view NAME = lookup_address_derivation_public_keys_hash_poseidon2_4_settings::NAME;
-    static constexpr std::string_view RELATION_NAME =
-        lookup_address_derivation_public_keys_hash_poseidon2_4_settings::RELATION_NAME;
-
-    template <typename AllEntities> inline static bool skip(const AllEntities& in)
-    {
-        return in.lookup_address_derivation_public_keys_hash_poseidon2_4_inv.is_zero();
-    }
-
-    static std::string get_subrelation_label(size_t index)
-    {
-        if (index == 0) {
-            return "INVERSES_ARE_CORRECT";
-        } else if (index == 1) {
-            return "ACCUMULATION_IS_CORRECT";
-        }
-        return std::to_string(index);
-    }
-};
+using lookup_address_derivation_public_keys_hash_poseidon2_4_relation =
+    lookup_relation_base<FF_, lookup_address_derivation_public_keys_hash_poseidon2_4_settings>;
 
 /////////////////// lookup_address_derivation_preaddress_poseidon2 ///////////////////
 
-class lookup_address_derivation_preaddress_poseidon2_settings {
-  public:
+struct lookup_address_derivation_preaddress_poseidon2_settings_ {
     static constexpr std::string_view NAME = "LOOKUP_ADDRESS_DERIVATION_PREADDRESS_POSEIDON2";
     static constexpr std::string_view RELATION_NAME = "address_derivation";
-
-    static constexpr size_t READ_TERMS = 1;
-    static constexpr size_t WRITE_TERMS = 1;
-    static constexpr size_t READ_TERM_TYPES[READ_TERMS] = { 0 };
-    static constexpr size_t WRITE_TERM_TYPES[WRITE_TERMS] = { 0 };
     static constexpr size_t LOOKUP_TUPLE_SIZE = 4;
-    static constexpr size_t INVERSE_EXISTS_POLYNOMIAL_DEGREE = 4;
-    static constexpr size_t READ_TERM_DEGREE = 0;
-    static constexpr size_t WRITE_TERM_DEGREE = 0;
-
-    // Columns using the Column enum.
     static constexpr Column SRC_SELECTOR = Column::address_derivation_sel;
     static constexpr Column DST_SELECTOR = Column::poseidon2_hash_end;
     static constexpr Column COUNTS = Column::lookup_address_derivation_preaddress_poseidon2_counts;
@@ -861,91 +273,20 @@ class lookup_address_derivation_preaddress_poseidon2_settings {
         ColumnAndShifts::poseidon2_hash_input_2,
         ColumnAndShifts::poseidon2_hash_output
     };
-
-    template <typename AllEntities> static inline auto inverse_polynomial_is_computed_at_row(const AllEntities& in)
-    {
-        return (in.get(ColumnAndShifts::address_derivation_sel) == 1 ||
-                in.get(ColumnAndShifts::poseidon2_hash_end) == 1);
-    }
-
-    template <typename Accumulator, typename AllEntities>
-    static inline auto compute_inverse_exists(const AllEntities& in)
-    {
-        using View = typename Accumulator::View;
-        const auto is_operation = View(in.get(ColumnAndShifts::address_derivation_sel));
-        const auto is_table_entry = View(in.get(ColumnAndShifts::poseidon2_hash_end));
-        return (is_operation + is_table_entry - is_operation * is_table_entry);
-    }
-
-    template <typename AllEntities> static inline auto get_const_entities(const AllEntities& in)
-    {
-        return get_entities(in);
-    }
-
-    template <typename AllEntities> static inline auto get_nonconst_entities(AllEntities& in)
-    {
-        return get_entities(in);
-    }
-
-    template <typename AllEntities> static inline auto get_entities(AllEntities&& in)
-    {
-        return std::forward_as_tuple(in.get(ColumnAndShifts::lookup_address_derivation_preaddress_poseidon2_inv),
-                                     in.get(ColumnAndShifts::lookup_address_derivation_preaddress_poseidon2_counts),
-                                     in.get(ColumnAndShifts::address_derivation_sel),
-                                     in.get(ColumnAndShifts::poseidon2_hash_end),
-                                     in.get(ColumnAndShifts::address_derivation_preaddress_domain_separator),
-                                     in.get(ColumnAndShifts::address_derivation_public_keys_hash),
-                                     in.get(ColumnAndShifts::address_derivation_partial_address),
-                                     in.get(ColumnAndShifts::address_derivation_preaddress),
-                                     in.get(ColumnAndShifts::poseidon2_hash_input_0),
-                                     in.get(ColumnAndShifts::poseidon2_hash_input_1),
-                                     in.get(ColumnAndShifts::poseidon2_hash_input_2),
-                                     in.get(ColumnAndShifts::poseidon2_hash_output));
-    }
 };
 
+using lookup_address_derivation_preaddress_poseidon2_settings =
+    lookup_settings<lookup_address_derivation_preaddress_poseidon2_settings_>;
 template <typename FF_>
-class lookup_address_derivation_preaddress_poseidon2_relation
-    : public GenericLookupRelation<lookup_address_derivation_preaddress_poseidon2_settings, FF_> {
-  public:
-    using Settings = lookup_address_derivation_preaddress_poseidon2_settings;
-    static constexpr std::string_view NAME = lookup_address_derivation_preaddress_poseidon2_settings::NAME;
-    static constexpr std::string_view RELATION_NAME =
-        lookup_address_derivation_preaddress_poseidon2_settings::RELATION_NAME;
-
-    template <typename AllEntities> inline static bool skip(const AllEntities& in)
-    {
-        return in.lookup_address_derivation_preaddress_poseidon2_inv.is_zero();
-    }
-
-    static std::string get_subrelation_label(size_t index)
-    {
-        if (index == 0) {
-            return "INVERSES_ARE_CORRECT";
-        } else if (index == 1) {
-            return "ACCUMULATION_IS_CORRECT";
-        }
-        return std::to_string(index);
-    }
-};
+using lookup_address_derivation_preaddress_poseidon2_relation =
+    lookup_relation_base<FF_, lookup_address_derivation_preaddress_poseidon2_settings>;
 
 /////////////////// lookup_address_derivation_preaddress_scalar_mul ///////////////////
 
-class lookup_address_derivation_preaddress_scalar_mul_settings {
-  public:
+struct lookup_address_derivation_preaddress_scalar_mul_settings_ {
     static constexpr std::string_view NAME = "LOOKUP_ADDRESS_DERIVATION_PREADDRESS_SCALAR_MUL";
     static constexpr std::string_view RELATION_NAME = "address_derivation";
-
-    static constexpr size_t READ_TERMS = 1;
-    static constexpr size_t WRITE_TERMS = 1;
-    static constexpr size_t READ_TERM_TYPES[READ_TERMS] = { 0 };
-    static constexpr size_t WRITE_TERM_TYPES[WRITE_TERMS] = { 0 };
     static constexpr size_t LOOKUP_TUPLE_SIZE = 7;
-    static constexpr size_t INVERSE_EXISTS_POLYNOMIAL_DEGREE = 4;
-    static constexpr size_t READ_TERM_DEGREE = 0;
-    static constexpr size_t WRITE_TERM_DEGREE = 0;
-
-    // Columns using the Column enum.
     static constexpr Column SRC_SELECTOR = Column::address_derivation_sel;
     static constexpr Column DST_SELECTOR = Column::scalar_mul_start;
     static constexpr Column COUNTS = Column::lookup_address_derivation_preaddress_scalar_mul_counts;
@@ -964,96 +305,20 @@ class lookup_address_derivation_preaddress_scalar_mul_settings {
         ColumnAndShifts::scalar_mul_point_inf, ColumnAndShifts::scalar_mul_res_x,   ColumnAndShifts::scalar_mul_res_y,
         ColumnAndShifts::scalar_mul_res_inf
     };
-
-    template <typename AllEntities> static inline auto inverse_polynomial_is_computed_at_row(const AllEntities& in)
-    {
-        return (in.get(ColumnAndShifts::address_derivation_sel) == 1 || in.get(ColumnAndShifts::scalar_mul_start) == 1);
-    }
-
-    template <typename Accumulator, typename AllEntities>
-    static inline auto compute_inverse_exists(const AllEntities& in)
-    {
-        using View = typename Accumulator::View;
-        const auto is_operation = View(in.get(ColumnAndShifts::address_derivation_sel));
-        const auto is_table_entry = View(in.get(ColumnAndShifts::scalar_mul_start));
-        return (is_operation + is_table_entry - is_operation * is_table_entry);
-    }
-
-    template <typename AllEntities> static inline auto get_const_entities(const AllEntities& in)
-    {
-        return get_entities(in);
-    }
-
-    template <typename AllEntities> static inline auto get_nonconst_entities(AllEntities& in)
-    {
-        return get_entities(in);
-    }
-
-    template <typename AllEntities> static inline auto get_entities(AllEntities&& in)
-    {
-        return std::forward_as_tuple(in.get(ColumnAndShifts::lookup_address_derivation_preaddress_scalar_mul_inv),
-                                     in.get(ColumnAndShifts::lookup_address_derivation_preaddress_scalar_mul_counts),
-                                     in.get(ColumnAndShifts::address_derivation_sel),
-                                     in.get(ColumnAndShifts::scalar_mul_start),
-                                     in.get(ColumnAndShifts::address_derivation_preaddress),
-                                     in.get(ColumnAndShifts::address_derivation_g1_x),
-                                     in.get(ColumnAndShifts::address_derivation_g1_y),
-                                     in.get(ColumnAndShifts::precomputed_zero),
-                                     in.get(ColumnAndShifts::address_derivation_preaddress_public_key_x),
-                                     in.get(ColumnAndShifts::address_derivation_preaddress_public_key_y),
-                                     in.get(ColumnAndShifts::precomputed_zero),
-                                     in.get(ColumnAndShifts::scalar_mul_scalar),
-                                     in.get(ColumnAndShifts::scalar_mul_point_x),
-                                     in.get(ColumnAndShifts::scalar_mul_point_y),
-                                     in.get(ColumnAndShifts::scalar_mul_point_inf),
-                                     in.get(ColumnAndShifts::scalar_mul_res_x),
-                                     in.get(ColumnAndShifts::scalar_mul_res_y),
-                                     in.get(ColumnAndShifts::scalar_mul_res_inf));
-    }
 };
 
+using lookup_address_derivation_preaddress_scalar_mul_settings =
+    lookup_settings<lookup_address_derivation_preaddress_scalar_mul_settings_>;
 template <typename FF_>
-class lookup_address_derivation_preaddress_scalar_mul_relation
-    : public GenericLookupRelation<lookup_address_derivation_preaddress_scalar_mul_settings, FF_> {
-  public:
-    using Settings = lookup_address_derivation_preaddress_scalar_mul_settings;
-    static constexpr std::string_view NAME = lookup_address_derivation_preaddress_scalar_mul_settings::NAME;
-    static constexpr std::string_view RELATION_NAME =
-        lookup_address_derivation_preaddress_scalar_mul_settings::RELATION_NAME;
-
-    template <typename AllEntities> inline static bool skip(const AllEntities& in)
-    {
-        return in.lookup_address_derivation_preaddress_scalar_mul_inv.is_zero();
-    }
-
-    static std::string get_subrelation_label(size_t index)
-    {
-        if (index == 0) {
-            return "INVERSES_ARE_CORRECT";
-        } else if (index == 1) {
-            return "ACCUMULATION_IS_CORRECT";
-        }
-        return std::to_string(index);
-    }
-};
+using lookup_address_derivation_preaddress_scalar_mul_relation =
+    lookup_relation_base<FF_, lookup_address_derivation_preaddress_scalar_mul_settings>;
 
 /////////////////// lookup_address_derivation_address_ecadd ///////////////////
 
-class lookup_address_derivation_address_ecadd_settings {
-  public:
+struct lookup_address_derivation_address_ecadd_settings_ {
     static constexpr std::string_view NAME = "LOOKUP_ADDRESS_DERIVATION_ADDRESS_ECADD";
     static constexpr std::string_view RELATION_NAME = "address_derivation";
-
-    static constexpr size_t READ_TERMS = 1;
-    static constexpr size_t WRITE_TERMS = 1;
-    static constexpr size_t READ_TERM_TYPES[READ_TERMS] = { 0 };
-    static constexpr size_t WRITE_TERM_TYPES[WRITE_TERMS] = { 0 };
     static constexpr size_t LOOKUP_TUPLE_SIZE = 9;
-    static constexpr size_t INVERSE_EXISTS_POLYNOMIAL_DEGREE = 4;
-    static constexpr size_t READ_TERM_DEGREE = 0;
-    static constexpr size_t WRITE_TERM_DEGREE = 0;
-
-    // Columns using the Column enum.
     static constexpr Column SRC_SELECTOR = Column::address_derivation_sel;
     static constexpr Column DST_SELECTOR = Column::ecc_sel;
     static constexpr Column COUNTS = Column::lookup_address_derivation_address_ecadd_counts;
@@ -1074,80 +339,12 @@ class lookup_address_derivation_address_ecadd_settings {
         ColumnAndShifts::ecc_q_x, ColumnAndShifts::ecc_q_y, ColumnAndShifts::ecc_q_is_inf,
         ColumnAndShifts::ecc_r_x, ColumnAndShifts::ecc_r_y, ColumnAndShifts::ecc_r_is_inf
     };
-
-    template <typename AllEntities> static inline auto inverse_polynomial_is_computed_at_row(const AllEntities& in)
-    {
-        return (in.get(ColumnAndShifts::address_derivation_sel) == 1 || in.get(ColumnAndShifts::ecc_sel) == 1);
-    }
-
-    template <typename Accumulator, typename AllEntities>
-    static inline auto compute_inverse_exists(const AllEntities& in)
-    {
-        using View = typename Accumulator::View;
-        const auto is_operation = View(in.get(ColumnAndShifts::address_derivation_sel));
-        const auto is_table_entry = View(in.get(ColumnAndShifts::ecc_sel));
-        return (is_operation + is_table_entry - is_operation * is_table_entry);
-    }
-
-    template <typename AllEntities> static inline auto get_const_entities(const AllEntities& in)
-    {
-        return get_entities(in);
-    }
-
-    template <typename AllEntities> static inline auto get_nonconst_entities(AllEntities& in)
-    {
-        return get_entities(in);
-    }
-
-    template <typename AllEntities> static inline auto get_entities(AllEntities&& in)
-    {
-        return std::forward_as_tuple(in.get(ColumnAndShifts::lookup_address_derivation_address_ecadd_inv),
-                                     in.get(ColumnAndShifts::lookup_address_derivation_address_ecadd_counts),
-                                     in.get(ColumnAndShifts::address_derivation_sel),
-                                     in.get(ColumnAndShifts::ecc_sel),
-                                     in.get(ColumnAndShifts::address_derivation_preaddress_public_key_x),
-                                     in.get(ColumnAndShifts::address_derivation_preaddress_public_key_y),
-                                     in.get(ColumnAndShifts::precomputed_zero),
-                                     in.get(ColumnAndShifts::address_derivation_incoming_viewing_key_x),
-                                     in.get(ColumnAndShifts::address_derivation_incoming_viewing_key_y),
-                                     in.get(ColumnAndShifts::precomputed_zero),
-                                     in.get(ColumnAndShifts::address_derivation_address),
-                                     in.get(ColumnAndShifts::address_derivation_address_y),
-                                     in.get(ColumnAndShifts::precomputed_zero),
-                                     in.get(ColumnAndShifts::ecc_p_x),
-                                     in.get(ColumnAndShifts::ecc_p_y),
-                                     in.get(ColumnAndShifts::ecc_p_is_inf),
-                                     in.get(ColumnAndShifts::ecc_q_x),
-                                     in.get(ColumnAndShifts::ecc_q_y),
-                                     in.get(ColumnAndShifts::ecc_q_is_inf),
-                                     in.get(ColumnAndShifts::ecc_r_x),
-                                     in.get(ColumnAndShifts::ecc_r_y),
-                                     in.get(ColumnAndShifts::ecc_r_is_inf));
-    }
 };
 
+using lookup_address_derivation_address_ecadd_settings =
+    lookup_settings<lookup_address_derivation_address_ecadd_settings_>;
 template <typename FF_>
-class lookup_address_derivation_address_ecadd_relation
-    : public GenericLookupRelation<lookup_address_derivation_address_ecadd_settings, FF_> {
-  public:
-    using Settings = lookup_address_derivation_address_ecadd_settings;
-    static constexpr std::string_view NAME = lookup_address_derivation_address_ecadd_settings::NAME;
-    static constexpr std::string_view RELATION_NAME = lookup_address_derivation_address_ecadd_settings::RELATION_NAME;
-
-    template <typename AllEntities> inline static bool skip(const AllEntities& in)
-    {
-        return in.lookup_address_derivation_address_ecadd_inv.is_zero();
-    }
-
-    static std::string get_subrelation_label(size_t index)
-    {
-        if (index == 0) {
-            return "INVERSES_ARE_CORRECT";
-        } else if (index == 1) {
-            return "ACCUMULATION_IS_CORRECT";
-        }
-        return std::to_string(index);
-    }
-};
+using lookup_address_derivation_address_ecadd_relation =
+    lookup_relation_base<FF_, lookup_address_derivation_address_ecadd_settings>;
 
 } // namespace bb::avm2

--- a/barretenberg/cpp/src/barretenberg/vm2/generated/relations/lookups_bc_decomposition.hpp
+++ b/barretenberg/cpp/src/barretenberg/vm2/generated/relations/lookups_bc_decomposition.hpp
@@ -3,6 +3,7 @@
 
 #include "../columns.hpp"
 #include "barretenberg/relations/generic_lookup/generic_lookup_relation.hpp"
+#include "barretenberg/vm2/constraining/relations/interactions_base.hpp"
 
 #include <cstddef>
 #include <string_view>
@@ -12,21 +13,10 @@ namespace bb::avm2 {
 
 /////////////////// lookup_bc_decomposition_bytes_are_bytes ///////////////////
 
-class lookup_bc_decomposition_bytes_are_bytes_settings {
-  public:
+struct lookup_bc_decomposition_bytes_are_bytes_settings_ {
     static constexpr std::string_view NAME = "LOOKUP_BC_DECOMPOSITION_BYTES_ARE_BYTES";
     static constexpr std::string_view RELATION_NAME = "bc_decomposition";
-
-    static constexpr size_t READ_TERMS = 1;
-    static constexpr size_t WRITE_TERMS = 1;
-    static constexpr size_t READ_TERM_TYPES[READ_TERMS] = { 0 };
-    static constexpr size_t WRITE_TERM_TYPES[WRITE_TERMS] = { 0 };
     static constexpr size_t LOOKUP_TUPLE_SIZE = 1;
-    static constexpr size_t INVERSE_EXISTS_POLYNOMIAL_DEGREE = 4;
-    static constexpr size_t READ_TERM_DEGREE = 0;
-    static constexpr size_t WRITE_TERM_DEGREE = 0;
-
-    // Columns using the Column enum.
     static constexpr Column SRC_SELECTOR = Column::bc_decomposition_sel;
     static constexpr Column DST_SELECTOR = Column::precomputed_sel_range_8;
     static constexpr Column COUNTS = Column::lookup_bc_decomposition_bytes_are_bytes_counts;
@@ -35,84 +25,20 @@ class lookup_bc_decomposition_bytes_are_bytes_settings {
         ColumnAndShifts::bc_decomposition_bytes
     };
     static constexpr std::array<ColumnAndShifts, LOOKUP_TUPLE_SIZE> DST_COLUMNS = { ColumnAndShifts::precomputed_clk };
-
-    template <typename AllEntities> static inline auto inverse_polynomial_is_computed_at_row(const AllEntities& in)
-    {
-        return (in.get(ColumnAndShifts::bc_decomposition_sel) == 1 ||
-                in.get(ColumnAndShifts::precomputed_sel_range_8) == 1);
-    }
-
-    template <typename Accumulator, typename AllEntities>
-    static inline auto compute_inverse_exists(const AllEntities& in)
-    {
-        using View = typename Accumulator::View;
-        const auto is_operation = View(in.get(ColumnAndShifts::bc_decomposition_sel));
-        const auto is_table_entry = View(in.get(ColumnAndShifts::precomputed_sel_range_8));
-        return (is_operation + is_table_entry - is_operation * is_table_entry);
-    }
-
-    template <typename AllEntities> static inline auto get_const_entities(const AllEntities& in)
-    {
-        return get_entities(in);
-    }
-
-    template <typename AllEntities> static inline auto get_nonconst_entities(AllEntities& in)
-    {
-        return get_entities(in);
-    }
-
-    template <typename AllEntities> static inline auto get_entities(AllEntities&& in)
-    {
-        return std::forward_as_tuple(in.get(ColumnAndShifts::lookup_bc_decomposition_bytes_are_bytes_inv),
-                                     in.get(ColumnAndShifts::lookup_bc_decomposition_bytes_are_bytes_counts),
-                                     in.get(ColumnAndShifts::bc_decomposition_sel),
-                                     in.get(ColumnAndShifts::precomputed_sel_range_8),
-                                     in.get(ColumnAndShifts::bc_decomposition_bytes),
-                                     in.get(ColumnAndShifts::precomputed_clk));
-    }
 };
 
+using lookup_bc_decomposition_bytes_are_bytes_settings =
+    lookup_settings<lookup_bc_decomposition_bytes_are_bytes_settings_>;
 template <typename FF_>
-class lookup_bc_decomposition_bytes_are_bytes_relation
-    : public GenericLookupRelation<lookup_bc_decomposition_bytes_are_bytes_settings, FF_> {
-  public:
-    using Settings = lookup_bc_decomposition_bytes_are_bytes_settings;
-    static constexpr std::string_view NAME = lookup_bc_decomposition_bytes_are_bytes_settings::NAME;
-    static constexpr std::string_view RELATION_NAME = lookup_bc_decomposition_bytes_are_bytes_settings::RELATION_NAME;
-
-    template <typename AllEntities> inline static bool skip(const AllEntities& in)
-    {
-        return in.lookup_bc_decomposition_bytes_are_bytes_inv.is_zero();
-    }
-
-    static std::string get_subrelation_label(size_t index)
-    {
-        if (index == 0) {
-            return "INVERSES_ARE_CORRECT";
-        } else if (index == 1) {
-            return "ACCUMULATION_IS_CORRECT";
-        }
-        return std::to_string(index);
-    }
-};
+using lookup_bc_decomposition_bytes_are_bytes_relation =
+    lookup_relation_base<FF_, lookup_bc_decomposition_bytes_are_bytes_settings>;
 
 /////////////////// lookup_bc_decomposition_abs_diff_is_u16 ///////////////////
 
-class lookup_bc_decomposition_abs_diff_is_u16_settings {
-  public:
+struct lookup_bc_decomposition_abs_diff_is_u16_settings_ {
     static constexpr std::string_view NAME = "LOOKUP_BC_DECOMPOSITION_ABS_DIFF_IS_U16";
     static constexpr std::string_view RELATION_NAME = "bc_decomposition";
-
-    static constexpr size_t READ_TERMS = 1;
-    static constexpr size_t WRITE_TERMS = 1;
-    static constexpr size_t READ_TERM_TYPES[READ_TERMS] = { 0 };
-    static constexpr size_t WRITE_TERM_TYPES[WRITE_TERMS] = { 0 };
     static constexpr size_t LOOKUP_TUPLE_SIZE = 1;
-    static constexpr size_t INVERSE_EXISTS_POLYNOMIAL_DEGREE = 4;
-    static constexpr size_t READ_TERM_DEGREE = 0;
-    static constexpr size_t WRITE_TERM_DEGREE = 0;
-
-    // Columns using the Column enum.
     static constexpr Column SRC_SELECTOR = Column::bc_decomposition_sel;
     static constexpr Column DST_SELECTOR = Column::precomputed_sel_range_16;
     static constexpr Column COUNTS = Column::lookup_bc_decomposition_abs_diff_is_u16_counts;
@@ -121,65 +47,12 @@ class lookup_bc_decomposition_abs_diff_is_u16_settings {
         ColumnAndShifts::bc_decomposition_abs_diff
     };
     static constexpr std::array<ColumnAndShifts, LOOKUP_TUPLE_SIZE> DST_COLUMNS = { ColumnAndShifts::precomputed_clk };
-
-    template <typename AllEntities> static inline auto inverse_polynomial_is_computed_at_row(const AllEntities& in)
-    {
-        return (in.get(ColumnAndShifts::bc_decomposition_sel) == 1 ||
-                in.get(ColumnAndShifts::precomputed_sel_range_16) == 1);
-    }
-
-    template <typename Accumulator, typename AllEntities>
-    static inline auto compute_inverse_exists(const AllEntities& in)
-    {
-        using View = typename Accumulator::View;
-        const auto is_operation = View(in.get(ColumnAndShifts::bc_decomposition_sel));
-        const auto is_table_entry = View(in.get(ColumnAndShifts::precomputed_sel_range_16));
-        return (is_operation + is_table_entry - is_operation * is_table_entry);
-    }
-
-    template <typename AllEntities> static inline auto get_const_entities(const AllEntities& in)
-    {
-        return get_entities(in);
-    }
-
-    template <typename AllEntities> static inline auto get_nonconst_entities(AllEntities& in)
-    {
-        return get_entities(in);
-    }
-
-    template <typename AllEntities> static inline auto get_entities(AllEntities&& in)
-    {
-        return std::forward_as_tuple(in.get(ColumnAndShifts::lookup_bc_decomposition_abs_diff_is_u16_inv),
-                                     in.get(ColumnAndShifts::lookup_bc_decomposition_abs_diff_is_u16_counts),
-                                     in.get(ColumnAndShifts::bc_decomposition_sel),
-                                     in.get(ColumnAndShifts::precomputed_sel_range_16),
-                                     in.get(ColumnAndShifts::bc_decomposition_abs_diff),
-                                     in.get(ColumnAndShifts::precomputed_clk));
-    }
 };
 
+using lookup_bc_decomposition_abs_diff_is_u16_settings =
+    lookup_settings<lookup_bc_decomposition_abs_diff_is_u16_settings_>;
 template <typename FF_>
-class lookup_bc_decomposition_abs_diff_is_u16_relation
-    : public GenericLookupRelation<lookup_bc_decomposition_abs_diff_is_u16_settings, FF_> {
-  public:
-    using Settings = lookup_bc_decomposition_abs_diff_is_u16_settings;
-    static constexpr std::string_view NAME = lookup_bc_decomposition_abs_diff_is_u16_settings::NAME;
-    static constexpr std::string_view RELATION_NAME = lookup_bc_decomposition_abs_diff_is_u16_settings::RELATION_NAME;
-
-    template <typename AllEntities> inline static bool skip(const AllEntities& in)
-    {
-        return in.lookup_bc_decomposition_abs_diff_is_u16_inv.is_zero();
-    }
-
-    static std::string get_subrelation_label(size_t index)
-    {
-        if (index == 0) {
-            return "INVERSES_ARE_CORRECT";
-        } else if (index == 1) {
-            return "ACCUMULATION_IS_CORRECT";
-        }
-        return std::to_string(index);
-    }
-};
+using lookup_bc_decomposition_abs_diff_is_u16_relation =
+    lookup_relation_base<FF_, lookup_bc_decomposition_abs_diff_is_u16_settings>;
 
 } // namespace bb::avm2

--- a/barretenberg/cpp/src/barretenberg/vm2/generated/relations/lookups_bc_hashing.hpp
+++ b/barretenberg/cpp/src/barretenberg/vm2/generated/relations/lookups_bc_hashing.hpp
@@ -3,6 +3,7 @@
 
 #include "../columns.hpp"
 #include "barretenberg/relations/generic_lookup/generic_lookup_relation.hpp"
+#include "barretenberg/vm2/constraining/relations/interactions_base.hpp"
 
 #include <cstddef>
 #include <string_view>
@@ -12,21 +13,10 @@ namespace bb::avm2 {
 
 /////////////////// lookup_bc_hashing_get_packed_field ///////////////////
 
-class lookup_bc_hashing_get_packed_field_settings {
-  public:
+struct lookup_bc_hashing_get_packed_field_settings_ {
     static constexpr std::string_view NAME = "LOOKUP_BC_HASHING_GET_PACKED_FIELD";
     static constexpr std::string_view RELATION_NAME = "bc_hashing";
-
-    static constexpr size_t READ_TERMS = 1;
-    static constexpr size_t WRITE_TERMS = 1;
-    static constexpr size_t READ_TERM_TYPES[READ_TERMS] = { 0 };
-    static constexpr size_t WRITE_TERM_TYPES[WRITE_TERMS] = { 0 };
     static constexpr size_t LOOKUP_TUPLE_SIZE = 3;
-    static constexpr size_t INVERSE_EXISTS_POLYNOMIAL_DEGREE = 4;
-    static constexpr size_t READ_TERM_DEGREE = 0;
-    static constexpr size_t WRITE_TERM_DEGREE = 0;
-
-    // Columns using the Column enum.
     static constexpr Column SRC_SELECTOR = Column::bc_hashing_sel;
     static constexpr Column DST_SELECTOR = Column::bc_decomposition_sel_packed;
     static constexpr Column COUNTS = Column::lookup_bc_hashing_get_packed_field_counts;
@@ -41,88 +31,19 @@ class lookup_bc_hashing_get_packed_field_settings {
         ColumnAndShifts::bc_decomposition_id,
         ColumnAndShifts::bc_decomposition_packed_field
     };
-
-    template <typename AllEntities> static inline auto inverse_polynomial_is_computed_at_row(const AllEntities& in)
-    {
-        return (in.get(ColumnAndShifts::bc_hashing_sel) == 1 ||
-                in.get(ColumnAndShifts::bc_decomposition_sel_packed) == 1);
-    }
-
-    template <typename Accumulator, typename AllEntities>
-    static inline auto compute_inverse_exists(const AllEntities& in)
-    {
-        using View = typename Accumulator::View;
-        const auto is_operation = View(in.get(ColumnAndShifts::bc_hashing_sel));
-        const auto is_table_entry = View(in.get(ColumnAndShifts::bc_decomposition_sel_packed));
-        return (is_operation + is_table_entry - is_operation * is_table_entry);
-    }
-
-    template <typename AllEntities> static inline auto get_const_entities(const AllEntities& in)
-    {
-        return get_entities(in);
-    }
-
-    template <typename AllEntities> static inline auto get_nonconst_entities(AllEntities& in)
-    {
-        return get_entities(in);
-    }
-
-    template <typename AllEntities> static inline auto get_entities(AllEntities&& in)
-    {
-        return std::forward_as_tuple(in.get(ColumnAndShifts::lookup_bc_hashing_get_packed_field_inv),
-                                     in.get(ColumnAndShifts::lookup_bc_hashing_get_packed_field_counts),
-                                     in.get(ColumnAndShifts::bc_hashing_sel),
-                                     in.get(ColumnAndShifts::bc_decomposition_sel_packed),
-                                     in.get(ColumnAndShifts::bc_hashing_pc_index),
-                                     in.get(ColumnAndShifts::bc_hashing_bytecode_id),
-                                     in.get(ColumnAndShifts::bc_hashing_packed_field),
-                                     in.get(ColumnAndShifts::bc_decomposition_pc),
-                                     in.get(ColumnAndShifts::bc_decomposition_id),
-                                     in.get(ColumnAndShifts::bc_decomposition_packed_field));
-    }
 };
 
+using lookup_bc_hashing_get_packed_field_settings = lookup_settings<lookup_bc_hashing_get_packed_field_settings_>;
 template <typename FF_>
-class lookup_bc_hashing_get_packed_field_relation
-    : public GenericLookupRelation<lookup_bc_hashing_get_packed_field_settings, FF_> {
-  public:
-    using Settings = lookup_bc_hashing_get_packed_field_settings;
-    static constexpr std::string_view NAME = lookup_bc_hashing_get_packed_field_settings::NAME;
-    static constexpr std::string_view RELATION_NAME = lookup_bc_hashing_get_packed_field_settings::RELATION_NAME;
-
-    template <typename AllEntities> inline static bool skip(const AllEntities& in)
-    {
-        return in.lookup_bc_hashing_get_packed_field_inv.is_zero();
-    }
-
-    static std::string get_subrelation_label(size_t index)
-    {
-        if (index == 0) {
-            return "INVERSES_ARE_CORRECT";
-        } else if (index == 1) {
-            return "ACCUMULATION_IS_CORRECT";
-        }
-        return std::to_string(index);
-    }
-};
+using lookup_bc_hashing_get_packed_field_relation =
+    lookup_relation_base<FF_, lookup_bc_hashing_get_packed_field_settings>;
 
 /////////////////// lookup_bc_hashing_iv_is_len ///////////////////
 
-class lookup_bc_hashing_iv_is_len_settings {
-  public:
+struct lookup_bc_hashing_iv_is_len_settings_ {
     static constexpr std::string_view NAME = "LOOKUP_BC_HASHING_IV_IS_LEN";
     static constexpr std::string_view RELATION_NAME = "bc_hashing";
-
-    static constexpr size_t READ_TERMS = 1;
-    static constexpr size_t WRITE_TERMS = 1;
-    static constexpr size_t READ_TERM_TYPES[READ_TERMS] = { 0 };
-    static constexpr size_t WRITE_TERM_TYPES[WRITE_TERMS] = { 0 };
     static constexpr size_t LOOKUP_TUPLE_SIZE = 3;
-    static constexpr size_t INVERSE_EXISTS_POLYNOMIAL_DEGREE = 4;
-    static constexpr size_t READ_TERM_DEGREE = 0;
-    static constexpr size_t WRITE_TERM_DEGREE = 0;
-
-    // Columns using the Column enum.
     static constexpr Column SRC_SELECTOR = Column::bc_hashing_start;
     static constexpr Column DST_SELECTOR = Column::bc_decomposition_sel_packed;
     static constexpr Column COUNTS = Column::lookup_bc_hashing_iv_is_len_counts;
@@ -137,87 +58,18 @@ class lookup_bc_hashing_iv_is_len_settings {
         ColumnAndShifts::bc_decomposition_id,
         ColumnAndShifts::bc_decomposition_bytes_remaining
     };
-
-    template <typename AllEntities> static inline auto inverse_polynomial_is_computed_at_row(const AllEntities& in)
-    {
-        return (in.get(ColumnAndShifts::bc_hashing_start) == 1 ||
-                in.get(ColumnAndShifts::bc_decomposition_sel_packed) == 1);
-    }
-
-    template <typename Accumulator, typename AllEntities>
-    static inline auto compute_inverse_exists(const AllEntities& in)
-    {
-        using View = typename Accumulator::View;
-        const auto is_operation = View(in.get(ColumnAndShifts::bc_hashing_start));
-        const auto is_table_entry = View(in.get(ColumnAndShifts::bc_decomposition_sel_packed));
-        return (is_operation + is_table_entry - is_operation * is_table_entry);
-    }
-
-    template <typename AllEntities> static inline auto get_const_entities(const AllEntities& in)
-    {
-        return get_entities(in);
-    }
-
-    template <typename AllEntities> static inline auto get_nonconst_entities(AllEntities& in)
-    {
-        return get_entities(in);
-    }
-
-    template <typename AllEntities> static inline auto get_entities(AllEntities&& in)
-    {
-        return std::forward_as_tuple(in.get(ColumnAndShifts::lookup_bc_hashing_iv_is_len_inv),
-                                     in.get(ColumnAndShifts::lookup_bc_hashing_iv_is_len_counts),
-                                     in.get(ColumnAndShifts::bc_hashing_start),
-                                     in.get(ColumnAndShifts::bc_decomposition_sel_packed),
-                                     in.get(ColumnAndShifts::bc_hashing_pc_index),
-                                     in.get(ColumnAndShifts::bc_hashing_bytecode_id),
-                                     in.get(ColumnAndShifts::bc_hashing_incremental_hash),
-                                     in.get(ColumnAndShifts::bc_decomposition_pc),
-                                     in.get(ColumnAndShifts::bc_decomposition_id),
-                                     in.get(ColumnAndShifts::bc_decomposition_bytes_remaining));
-    }
 };
 
+using lookup_bc_hashing_iv_is_len_settings = lookup_settings<lookup_bc_hashing_iv_is_len_settings_>;
 template <typename FF_>
-class lookup_bc_hashing_iv_is_len_relation : public GenericLookupRelation<lookup_bc_hashing_iv_is_len_settings, FF_> {
-  public:
-    using Settings = lookup_bc_hashing_iv_is_len_settings;
-    static constexpr std::string_view NAME = lookup_bc_hashing_iv_is_len_settings::NAME;
-    static constexpr std::string_view RELATION_NAME = lookup_bc_hashing_iv_is_len_settings::RELATION_NAME;
-
-    template <typename AllEntities> inline static bool skip(const AllEntities& in)
-    {
-        return in.lookup_bc_hashing_iv_is_len_inv.is_zero();
-    }
-
-    static std::string get_subrelation_label(size_t index)
-    {
-        if (index == 0) {
-            return "INVERSES_ARE_CORRECT";
-        } else if (index == 1) {
-            return "ACCUMULATION_IS_CORRECT";
-        }
-        return std::to_string(index);
-    }
-};
+using lookup_bc_hashing_iv_is_len_relation = lookup_relation_base<FF_, lookup_bc_hashing_iv_is_len_settings>;
 
 /////////////////// lookup_bc_hashing_poseidon2_hash ///////////////////
 
-class lookup_bc_hashing_poseidon2_hash_settings {
-  public:
+struct lookup_bc_hashing_poseidon2_hash_settings_ {
     static constexpr std::string_view NAME = "LOOKUP_BC_HASHING_POSEIDON2_HASH";
     static constexpr std::string_view RELATION_NAME = "bc_hashing";
-
-    static constexpr size_t READ_TERMS = 1;
-    static constexpr size_t WRITE_TERMS = 1;
-    static constexpr size_t READ_TERM_TYPES[READ_TERMS] = { 0 };
-    static constexpr size_t WRITE_TERM_TYPES[WRITE_TERMS] = { 0 };
     static constexpr size_t LOOKUP_TUPLE_SIZE = 3;
-    static constexpr size_t INVERSE_EXISTS_POLYNOMIAL_DEGREE = 4;
-    static constexpr size_t READ_TERM_DEGREE = 0;
-    static constexpr size_t WRITE_TERM_DEGREE = 0;
-
-    // Columns using the Column enum.
     static constexpr Column SRC_SELECTOR = Column::bc_hashing_sel;
     static constexpr Column DST_SELECTOR = Column::poseidon2_hash_sel;
     static constexpr Column COUNTS = Column::lookup_bc_hashing_poseidon2_hash_counts;
@@ -232,68 +84,10 @@ class lookup_bc_hashing_poseidon2_hash_settings {
         ColumnAndShifts::poseidon2_hash_input_1,
         ColumnAndShifts::poseidon2_hash_output
     };
-
-    template <typename AllEntities> static inline auto inverse_polynomial_is_computed_at_row(const AllEntities& in)
-    {
-        return (in.get(ColumnAndShifts::bc_hashing_sel) == 1 || in.get(ColumnAndShifts::poseidon2_hash_sel) == 1);
-    }
-
-    template <typename Accumulator, typename AllEntities>
-    static inline auto compute_inverse_exists(const AllEntities& in)
-    {
-        using View = typename Accumulator::View;
-        const auto is_operation = View(in.get(ColumnAndShifts::bc_hashing_sel));
-        const auto is_table_entry = View(in.get(ColumnAndShifts::poseidon2_hash_sel));
-        return (is_operation + is_table_entry - is_operation * is_table_entry);
-    }
-
-    template <typename AllEntities> static inline auto get_const_entities(const AllEntities& in)
-    {
-        return get_entities(in);
-    }
-
-    template <typename AllEntities> static inline auto get_nonconst_entities(AllEntities& in)
-    {
-        return get_entities(in);
-    }
-
-    template <typename AllEntities> static inline auto get_entities(AllEntities&& in)
-    {
-        return std::forward_as_tuple(in.get(ColumnAndShifts::lookup_bc_hashing_poseidon2_hash_inv),
-                                     in.get(ColumnAndShifts::lookup_bc_hashing_poseidon2_hash_counts),
-                                     in.get(ColumnAndShifts::bc_hashing_sel),
-                                     in.get(ColumnAndShifts::poseidon2_hash_sel),
-                                     in.get(ColumnAndShifts::bc_hashing_packed_field),
-                                     in.get(ColumnAndShifts::bc_hashing_incremental_hash),
-                                     in.get(ColumnAndShifts::bc_hashing_output_hash),
-                                     in.get(ColumnAndShifts::poseidon2_hash_input_0),
-                                     in.get(ColumnAndShifts::poseidon2_hash_input_1),
-                                     in.get(ColumnAndShifts::poseidon2_hash_output));
-    }
 };
 
+using lookup_bc_hashing_poseidon2_hash_settings = lookup_settings<lookup_bc_hashing_poseidon2_hash_settings_>;
 template <typename FF_>
-class lookup_bc_hashing_poseidon2_hash_relation
-    : public GenericLookupRelation<lookup_bc_hashing_poseidon2_hash_settings, FF_> {
-  public:
-    using Settings = lookup_bc_hashing_poseidon2_hash_settings;
-    static constexpr std::string_view NAME = lookup_bc_hashing_poseidon2_hash_settings::NAME;
-    static constexpr std::string_view RELATION_NAME = lookup_bc_hashing_poseidon2_hash_settings::RELATION_NAME;
-
-    template <typename AllEntities> inline static bool skip(const AllEntities& in)
-    {
-        return in.lookup_bc_hashing_poseidon2_hash_inv.is_zero();
-    }
-
-    static std::string get_subrelation_label(size_t index)
-    {
-        if (index == 0) {
-            return "INVERSES_ARE_CORRECT";
-        } else if (index == 1) {
-            return "ACCUMULATION_IS_CORRECT";
-        }
-        return std::to_string(index);
-    }
-};
+using lookup_bc_hashing_poseidon2_hash_relation = lookup_relation_base<FF_, lookup_bc_hashing_poseidon2_hash_settings>;
 
 } // namespace bb::avm2

--- a/barretenberg/cpp/src/barretenberg/vm2/generated/relations/lookups_bc_retrieval.hpp
+++ b/barretenberg/cpp/src/barretenberg/vm2/generated/relations/lookups_bc_retrieval.hpp
@@ -3,6 +3,7 @@
 
 #include "../columns.hpp"
 #include "barretenberg/relations/generic_lookup/generic_lookup_relation.hpp"
+#include "barretenberg/vm2/constraining/relations/interactions_base.hpp"
 
 #include <cstddef>
 #include <string_view>
@@ -12,21 +13,10 @@ namespace bb::avm2 {
 
 /////////////////// lookup_bc_retrieval_silo_deployment_nullifier_poseidon2 ///////////////////
 
-class lookup_bc_retrieval_silo_deployment_nullifier_poseidon2_settings {
-  public:
+struct lookup_bc_retrieval_silo_deployment_nullifier_poseidon2_settings_ {
     static constexpr std::string_view NAME = "LOOKUP_BC_RETRIEVAL_SILO_DEPLOYMENT_NULLIFIER_POSEIDON2";
     static constexpr std::string_view RELATION_NAME = "bc_retrieval";
-
-    static constexpr size_t READ_TERMS = 1;
-    static constexpr size_t WRITE_TERMS = 1;
-    static constexpr size_t READ_TERM_TYPES[READ_TERMS] = { 0 };
-    static constexpr size_t WRITE_TERM_TYPES[WRITE_TERMS] = { 0 };
     static constexpr size_t LOOKUP_TUPLE_SIZE = 4;
-    static constexpr size_t INVERSE_EXISTS_POLYNOMIAL_DEGREE = 4;
-    static constexpr size_t READ_TERM_DEGREE = 0;
-    static constexpr size_t WRITE_TERM_DEGREE = 0;
-
-    // Columns using the Column enum.
     static constexpr Column SRC_SELECTOR = Column::bc_retrieval_sel;
     static constexpr Column DST_SELECTOR = Column::poseidon2_hash_end;
     static constexpr Column COUNTS = Column::lookup_bc_retrieval_silo_deployment_nullifier_poseidon2_counts;
@@ -43,91 +33,20 @@ class lookup_bc_retrieval_silo_deployment_nullifier_poseidon2_settings {
         ColumnAndShifts::poseidon2_hash_input_2,
         ColumnAndShifts::poseidon2_hash_output
     };
-
-    template <typename AllEntities> static inline auto inverse_polynomial_is_computed_at_row(const AllEntities& in)
-    {
-        return (in.get(ColumnAndShifts::bc_retrieval_sel) == 1 || in.get(ColumnAndShifts::poseidon2_hash_end) == 1);
-    }
-
-    template <typename Accumulator, typename AllEntities>
-    static inline auto compute_inverse_exists(const AllEntities& in)
-    {
-        using View = typename Accumulator::View;
-        const auto is_operation = View(in.get(ColumnAndShifts::bc_retrieval_sel));
-        const auto is_table_entry = View(in.get(ColumnAndShifts::poseidon2_hash_end));
-        return (is_operation + is_table_entry - is_operation * is_table_entry);
-    }
-
-    template <typename AllEntities> static inline auto get_const_entities(const AllEntities& in)
-    {
-        return get_entities(in);
-    }
-
-    template <typename AllEntities> static inline auto get_nonconst_entities(AllEntities& in)
-    {
-        return get_entities(in);
-    }
-
-    template <typename AllEntities> static inline auto get_entities(AllEntities&& in)
-    {
-        return std::forward_as_tuple(
-            in.get(ColumnAndShifts::lookup_bc_retrieval_silo_deployment_nullifier_poseidon2_inv),
-            in.get(ColumnAndShifts::lookup_bc_retrieval_silo_deployment_nullifier_poseidon2_counts),
-            in.get(ColumnAndShifts::bc_retrieval_sel),
-            in.get(ColumnAndShifts::poseidon2_hash_end),
-            in.get(ColumnAndShifts::bc_retrieval_outer_nullifier_domain_separator),
-            in.get(ColumnAndShifts::bc_retrieval_deployer_protocol_contract_address),
-            in.get(ColumnAndShifts::bc_retrieval_address),
-            in.get(ColumnAndShifts::bc_retrieval_siloed_address),
-            in.get(ColumnAndShifts::poseidon2_hash_input_0),
-            in.get(ColumnAndShifts::poseidon2_hash_input_1),
-            in.get(ColumnAndShifts::poseidon2_hash_input_2),
-            in.get(ColumnAndShifts::poseidon2_hash_output));
-    }
 };
 
+using lookup_bc_retrieval_silo_deployment_nullifier_poseidon2_settings =
+    lookup_settings<lookup_bc_retrieval_silo_deployment_nullifier_poseidon2_settings_>;
 template <typename FF_>
-class lookup_bc_retrieval_silo_deployment_nullifier_poseidon2_relation
-    : public GenericLookupRelation<lookup_bc_retrieval_silo_deployment_nullifier_poseidon2_settings, FF_> {
-  public:
-    using Settings = lookup_bc_retrieval_silo_deployment_nullifier_poseidon2_settings;
-    static constexpr std::string_view NAME = lookup_bc_retrieval_silo_deployment_nullifier_poseidon2_settings::NAME;
-    static constexpr std::string_view RELATION_NAME =
-        lookup_bc_retrieval_silo_deployment_nullifier_poseidon2_settings::RELATION_NAME;
-
-    template <typename AllEntities> inline static bool skip(const AllEntities& in)
-    {
-        return in.lookup_bc_retrieval_silo_deployment_nullifier_poseidon2_inv.is_zero();
-    }
-
-    static std::string get_subrelation_label(size_t index)
-    {
-        if (index == 0) {
-            return "INVERSES_ARE_CORRECT";
-        } else if (index == 1) {
-            return "ACCUMULATION_IS_CORRECT";
-        }
-        return std::to_string(index);
-    }
-};
+using lookup_bc_retrieval_silo_deployment_nullifier_poseidon2_relation =
+    lookup_relation_base<FF_, lookup_bc_retrieval_silo_deployment_nullifier_poseidon2_settings>;
 
 /////////////////// lookup_bc_retrieval_deployment_nullifier_read ///////////////////
 
-class lookup_bc_retrieval_deployment_nullifier_read_settings {
-  public:
+struct lookup_bc_retrieval_deployment_nullifier_read_settings_ {
     static constexpr std::string_view NAME = "LOOKUP_BC_RETRIEVAL_DEPLOYMENT_NULLIFIER_READ";
     static constexpr std::string_view RELATION_NAME = "bc_retrieval";
-
-    static constexpr size_t READ_TERMS = 1;
-    static constexpr size_t WRITE_TERMS = 1;
-    static constexpr size_t READ_TERM_TYPES[READ_TERMS] = { 0 };
-    static constexpr size_t WRITE_TERM_TYPES[WRITE_TERMS] = { 0 };
     static constexpr size_t LOOKUP_TUPLE_SIZE = 3;
-    static constexpr size_t INVERSE_EXISTS_POLYNOMIAL_DEGREE = 4;
-    static constexpr size_t READ_TERM_DEGREE = 0;
-    static constexpr size_t WRITE_TERM_DEGREE = 0;
-
-    // Columns using the Column enum.
     static constexpr Column SRC_SELECTOR = Column::bc_retrieval_sel;
     static constexpr Column DST_SELECTOR = Column::nullifier_check_sel;
     static constexpr Column COUNTS = Column::lookup_bc_retrieval_deployment_nullifier_read_counts;
@@ -142,88 +61,20 @@ class lookup_bc_retrieval_deployment_nullifier_read_settings {
         ColumnAndShifts::nullifier_check_nullifier,
         ColumnAndShifts::nullifier_check_root
     };
-
-    template <typename AllEntities> static inline auto inverse_polynomial_is_computed_at_row(const AllEntities& in)
-    {
-        return (in.get(ColumnAndShifts::bc_retrieval_sel) == 1 || in.get(ColumnAndShifts::nullifier_check_sel) == 1);
-    }
-
-    template <typename Accumulator, typename AllEntities>
-    static inline auto compute_inverse_exists(const AllEntities& in)
-    {
-        using View = typename Accumulator::View;
-        const auto is_operation = View(in.get(ColumnAndShifts::bc_retrieval_sel));
-        const auto is_table_entry = View(in.get(ColumnAndShifts::nullifier_check_sel));
-        return (is_operation + is_table_entry - is_operation * is_table_entry);
-    }
-
-    template <typename AllEntities> static inline auto get_const_entities(const AllEntities& in)
-    {
-        return get_entities(in);
-    }
-
-    template <typename AllEntities> static inline auto get_nonconst_entities(AllEntities& in)
-    {
-        return get_entities(in);
-    }
-
-    template <typename AllEntities> static inline auto get_entities(AllEntities&& in)
-    {
-        return std::forward_as_tuple(in.get(ColumnAndShifts::lookup_bc_retrieval_deployment_nullifier_read_inv),
-                                     in.get(ColumnAndShifts::lookup_bc_retrieval_deployment_nullifier_read_counts),
-                                     in.get(ColumnAndShifts::bc_retrieval_sel),
-                                     in.get(ColumnAndShifts::nullifier_check_sel),
-                                     in.get(ColumnAndShifts::bc_retrieval_nullifier_exists),
-                                     in.get(ColumnAndShifts::bc_retrieval_siloed_address),
-                                     in.get(ColumnAndShifts::bc_retrieval_nullifier_tree_root),
-                                     in.get(ColumnAndShifts::nullifier_check_exists),
-                                     in.get(ColumnAndShifts::nullifier_check_nullifier),
-                                     in.get(ColumnAndShifts::nullifier_check_root));
-    }
 };
 
+using lookup_bc_retrieval_deployment_nullifier_read_settings =
+    lookup_settings<lookup_bc_retrieval_deployment_nullifier_read_settings_>;
 template <typename FF_>
-class lookup_bc_retrieval_deployment_nullifier_read_relation
-    : public GenericLookupRelation<lookup_bc_retrieval_deployment_nullifier_read_settings, FF_> {
-  public:
-    using Settings = lookup_bc_retrieval_deployment_nullifier_read_settings;
-    static constexpr std::string_view NAME = lookup_bc_retrieval_deployment_nullifier_read_settings::NAME;
-    static constexpr std::string_view RELATION_NAME =
-        lookup_bc_retrieval_deployment_nullifier_read_settings::RELATION_NAME;
-
-    template <typename AllEntities> inline static bool skip(const AllEntities& in)
-    {
-        return in.lookup_bc_retrieval_deployment_nullifier_read_inv.is_zero();
-    }
-
-    static std::string get_subrelation_label(size_t index)
-    {
-        if (index == 0) {
-            return "INVERSES_ARE_CORRECT";
-        } else if (index == 1) {
-            return "ACCUMULATION_IS_CORRECT";
-        }
-        return std::to_string(index);
-    }
-};
+using lookup_bc_retrieval_deployment_nullifier_read_relation =
+    lookup_relation_base<FF_, lookup_bc_retrieval_deployment_nullifier_read_settings>;
 
 /////////////////// lookup_bc_retrieval_address_derivation ///////////////////
 
-class lookup_bc_retrieval_address_derivation_settings {
-  public:
+struct lookup_bc_retrieval_address_derivation_settings_ {
     static constexpr std::string_view NAME = "LOOKUP_BC_RETRIEVAL_ADDRESS_DERIVATION";
     static constexpr std::string_view RELATION_NAME = "bc_retrieval";
-
-    static constexpr size_t READ_TERMS = 1;
-    static constexpr size_t WRITE_TERMS = 1;
-    static constexpr size_t READ_TERM_TYPES[READ_TERMS] = { 0 };
-    static constexpr size_t WRITE_TERM_TYPES[WRITE_TERMS] = { 0 };
     static constexpr size_t LOOKUP_TUPLE_SIZE = 13;
-    static constexpr size_t INVERSE_EXISTS_POLYNOMIAL_DEGREE = 4;
-    static constexpr size_t READ_TERM_DEGREE = 0;
-    static constexpr size_t WRITE_TERM_DEGREE = 0;
-
-    // Columns using the Column enum.
     static constexpr Column SRC_SELECTOR = Column::bc_retrieval_sel;
     static constexpr Column DST_SELECTOR = Column::address_derivation_sel;
     static constexpr Column COUNTS = Column::lookup_bc_retrieval_address_derivation_counts;
@@ -258,107 +109,20 @@ class lookup_bc_retrieval_address_derivation_settings {
         ColumnAndShifts::address_derivation_tagging_key_x,
         ColumnAndShifts::address_derivation_tagging_key_y
     };
-
-    template <typename AllEntities> static inline auto inverse_polynomial_is_computed_at_row(const AllEntities& in)
-    {
-        return (in.get(ColumnAndShifts::bc_retrieval_sel) == 1 || in.get(ColumnAndShifts::address_derivation_sel) == 1);
-    }
-
-    template <typename Accumulator, typename AllEntities>
-    static inline auto compute_inverse_exists(const AllEntities& in)
-    {
-        using View = typename Accumulator::View;
-        const auto is_operation = View(in.get(ColumnAndShifts::bc_retrieval_sel));
-        const auto is_table_entry = View(in.get(ColumnAndShifts::address_derivation_sel));
-        return (is_operation + is_table_entry - is_operation * is_table_entry);
-    }
-
-    template <typename AllEntities> static inline auto get_const_entities(const AllEntities& in)
-    {
-        return get_entities(in);
-    }
-
-    template <typename AllEntities> static inline auto get_nonconst_entities(AllEntities& in)
-    {
-        return get_entities(in);
-    }
-
-    template <typename AllEntities> static inline auto get_entities(AllEntities&& in)
-    {
-        return std::forward_as_tuple(in.get(ColumnAndShifts::lookup_bc_retrieval_address_derivation_inv),
-                                     in.get(ColumnAndShifts::lookup_bc_retrieval_address_derivation_counts),
-                                     in.get(ColumnAndShifts::bc_retrieval_sel),
-                                     in.get(ColumnAndShifts::address_derivation_sel),
-                                     in.get(ColumnAndShifts::bc_retrieval_address),
-                                     in.get(ColumnAndShifts::bc_retrieval_salt),
-                                     in.get(ColumnAndShifts::bc_retrieval_deployer_addr),
-                                     in.get(ColumnAndShifts::bc_retrieval_original_class_id),
-                                     in.get(ColumnAndShifts::bc_retrieval_init_hash),
-                                     in.get(ColumnAndShifts::bc_retrieval_nullifier_key_x),
-                                     in.get(ColumnAndShifts::bc_retrieval_nullifier_key_y),
-                                     in.get(ColumnAndShifts::bc_retrieval_incoming_viewing_key_x),
-                                     in.get(ColumnAndShifts::bc_retrieval_incoming_viewing_key_y),
-                                     in.get(ColumnAndShifts::bc_retrieval_outgoing_viewing_key_x),
-                                     in.get(ColumnAndShifts::bc_retrieval_outgoing_viewing_key_y),
-                                     in.get(ColumnAndShifts::bc_retrieval_tagging_key_x),
-                                     in.get(ColumnAndShifts::bc_retrieval_tagging_key_y),
-                                     in.get(ColumnAndShifts::address_derivation_address),
-                                     in.get(ColumnAndShifts::address_derivation_salt),
-                                     in.get(ColumnAndShifts::address_derivation_deployer_addr),
-                                     in.get(ColumnAndShifts::address_derivation_class_id),
-                                     in.get(ColumnAndShifts::address_derivation_init_hash),
-                                     in.get(ColumnAndShifts::address_derivation_nullifier_key_x),
-                                     in.get(ColumnAndShifts::address_derivation_nullifier_key_y),
-                                     in.get(ColumnAndShifts::address_derivation_incoming_viewing_key_x),
-                                     in.get(ColumnAndShifts::address_derivation_incoming_viewing_key_y),
-                                     in.get(ColumnAndShifts::address_derivation_outgoing_viewing_key_x),
-                                     in.get(ColumnAndShifts::address_derivation_outgoing_viewing_key_y),
-                                     in.get(ColumnAndShifts::address_derivation_tagging_key_x),
-                                     in.get(ColumnAndShifts::address_derivation_tagging_key_y));
-    }
 };
 
+using lookup_bc_retrieval_address_derivation_settings =
+    lookup_settings<lookup_bc_retrieval_address_derivation_settings_>;
 template <typename FF_>
-class lookup_bc_retrieval_address_derivation_relation
-    : public GenericLookupRelation<lookup_bc_retrieval_address_derivation_settings, FF_> {
-  public:
-    using Settings = lookup_bc_retrieval_address_derivation_settings;
-    static constexpr std::string_view NAME = lookup_bc_retrieval_address_derivation_settings::NAME;
-    static constexpr std::string_view RELATION_NAME = lookup_bc_retrieval_address_derivation_settings::RELATION_NAME;
-
-    template <typename AllEntities> inline static bool skip(const AllEntities& in)
-    {
-        return in.lookup_bc_retrieval_address_derivation_inv.is_zero();
-    }
-
-    static std::string get_subrelation_label(size_t index)
-    {
-        if (index == 0) {
-            return "INVERSES_ARE_CORRECT";
-        } else if (index == 1) {
-            return "ACCUMULATION_IS_CORRECT";
-        }
-        return std::to_string(index);
-    }
-};
+using lookup_bc_retrieval_address_derivation_relation =
+    lookup_relation_base<FF_, lookup_bc_retrieval_address_derivation_settings>;
 
 /////////////////// lookup_bc_retrieval_update_check ///////////////////
 
-class lookup_bc_retrieval_update_check_settings {
-  public:
+struct lookup_bc_retrieval_update_check_settings_ {
     static constexpr std::string_view NAME = "LOOKUP_BC_RETRIEVAL_UPDATE_CHECK";
     static constexpr std::string_view RELATION_NAME = "bc_retrieval";
-
-    static constexpr size_t READ_TERMS = 1;
-    static constexpr size_t WRITE_TERMS = 1;
-    static constexpr size_t READ_TERM_TYPES[READ_TERMS] = { 0 };
-    static constexpr size_t WRITE_TERM_TYPES[WRITE_TERMS] = { 0 };
     static constexpr size_t LOOKUP_TUPLE_SIZE = 5;
-    static constexpr size_t INVERSE_EXISTS_POLYNOMIAL_DEGREE = 4;
-    static constexpr size_t READ_TERM_DEGREE = 0;
-    static constexpr size_t WRITE_TERM_DEGREE = 0;
-
-    // Columns using the Column enum.
     static constexpr Column SRC_SELECTOR = Column::bc_retrieval_sel;
     static constexpr Column DST_SELECTOR = Column::update_check_sel;
     static constexpr Column COUNTS = Column::lookup_bc_retrieval_update_check_counts;
@@ -377,91 +141,18 @@ class lookup_bc_retrieval_update_check_settings {
         ColumnAndShifts::update_check_public_data_tree_root,
         ColumnAndShifts::update_check_block_number
     };
-
-    template <typename AllEntities> static inline auto inverse_polynomial_is_computed_at_row(const AllEntities& in)
-    {
-        return (in.get(ColumnAndShifts::bc_retrieval_sel) == 1 || in.get(ColumnAndShifts::update_check_sel) == 1);
-    }
-
-    template <typename Accumulator, typename AllEntities>
-    static inline auto compute_inverse_exists(const AllEntities& in)
-    {
-        using View = typename Accumulator::View;
-        const auto is_operation = View(in.get(ColumnAndShifts::bc_retrieval_sel));
-        const auto is_table_entry = View(in.get(ColumnAndShifts::update_check_sel));
-        return (is_operation + is_table_entry - is_operation * is_table_entry);
-    }
-
-    template <typename AllEntities> static inline auto get_const_entities(const AllEntities& in)
-    {
-        return get_entities(in);
-    }
-
-    template <typename AllEntities> static inline auto get_nonconst_entities(AllEntities& in)
-    {
-        return get_entities(in);
-    }
-
-    template <typename AllEntities> static inline auto get_entities(AllEntities&& in)
-    {
-        return std::forward_as_tuple(in.get(ColumnAndShifts::lookup_bc_retrieval_update_check_inv),
-                                     in.get(ColumnAndShifts::lookup_bc_retrieval_update_check_counts),
-                                     in.get(ColumnAndShifts::bc_retrieval_sel),
-                                     in.get(ColumnAndShifts::update_check_sel),
-                                     in.get(ColumnAndShifts::bc_retrieval_address),
-                                     in.get(ColumnAndShifts::bc_retrieval_current_class_id),
-                                     in.get(ColumnAndShifts::bc_retrieval_original_class_id),
-                                     in.get(ColumnAndShifts::bc_retrieval_public_data_tree_root),
-                                     in.get(ColumnAndShifts::bc_retrieval_block_number),
-                                     in.get(ColumnAndShifts::update_check_address),
-                                     in.get(ColumnAndShifts::update_check_current_class_id),
-                                     in.get(ColumnAndShifts::update_check_original_class_id),
-                                     in.get(ColumnAndShifts::update_check_public_data_tree_root),
-                                     in.get(ColumnAndShifts::update_check_block_number));
-    }
 };
 
+using lookup_bc_retrieval_update_check_settings = lookup_settings<lookup_bc_retrieval_update_check_settings_>;
 template <typename FF_>
-class lookup_bc_retrieval_update_check_relation
-    : public GenericLookupRelation<lookup_bc_retrieval_update_check_settings, FF_> {
-  public:
-    using Settings = lookup_bc_retrieval_update_check_settings;
-    static constexpr std::string_view NAME = lookup_bc_retrieval_update_check_settings::NAME;
-    static constexpr std::string_view RELATION_NAME = lookup_bc_retrieval_update_check_settings::RELATION_NAME;
-
-    template <typename AllEntities> inline static bool skip(const AllEntities& in)
-    {
-        return in.lookup_bc_retrieval_update_check_inv.is_zero();
-    }
-
-    static std::string get_subrelation_label(size_t index)
-    {
-        if (index == 0) {
-            return "INVERSES_ARE_CORRECT";
-        } else if (index == 1) {
-            return "ACCUMULATION_IS_CORRECT";
-        }
-        return std::to_string(index);
-    }
-};
+using lookup_bc_retrieval_update_check_relation = lookup_relation_base<FF_, lookup_bc_retrieval_update_check_settings>;
 
 /////////////////// lookup_bc_retrieval_class_id_derivation ///////////////////
 
-class lookup_bc_retrieval_class_id_derivation_settings {
-  public:
+struct lookup_bc_retrieval_class_id_derivation_settings_ {
     static constexpr std::string_view NAME = "LOOKUP_BC_RETRIEVAL_CLASS_ID_DERIVATION";
     static constexpr std::string_view RELATION_NAME = "bc_retrieval";
-
-    static constexpr size_t READ_TERMS = 1;
-    static constexpr size_t WRITE_TERMS = 1;
-    static constexpr size_t READ_TERM_TYPES[READ_TERMS] = { 0 };
-    static constexpr size_t WRITE_TERM_TYPES[WRITE_TERMS] = { 0 };
     static constexpr size_t LOOKUP_TUPLE_SIZE = 4;
-    static constexpr size_t INVERSE_EXISTS_POLYNOMIAL_DEGREE = 4;
-    static constexpr size_t READ_TERM_DEGREE = 0;
-    static constexpr size_t WRITE_TERM_DEGREE = 0;
-
-    // Columns using the Column enum.
     static constexpr Column SRC_SELECTOR = Column::bc_retrieval_sel;
     static constexpr Column DST_SELECTOR = Column::class_id_derivation_sel;
     static constexpr Column COUNTS = Column::lookup_bc_retrieval_class_id_derivation_counts;
@@ -478,90 +169,20 @@ class lookup_bc_retrieval_class_id_derivation_settings {
         ColumnAndShifts::class_id_derivation_private_function_root,
         ColumnAndShifts::class_id_derivation_public_bytecode_commitment
     };
-
-    template <typename AllEntities> static inline auto inverse_polynomial_is_computed_at_row(const AllEntities& in)
-    {
-        return (in.get(ColumnAndShifts::bc_retrieval_sel) == 1 ||
-                in.get(ColumnAndShifts::class_id_derivation_sel) == 1);
-    }
-
-    template <typename Accumulator, typename AllEntities>
-    static inline auto compute_inverse_exists(const AllEntities& in)
-    {
-        using View = typename Accumulator::View;
-        const auto is_operation = View(in.get(ColumnAndShifts::bc_retrieval_sel));
-        const auto is_table_entry = View(in.get(ColumnAndShifts::class_id_derivation_sel));
-        return (is_operation + is_table_entry - is_operation * is_table_entry);
-    }
-
-    template <typename AllEntities> static inline auto get_const_entities(const AllEntities& in)
-    {
-        return get_entities(in);
-    }
-
-    template <typename AllEntities> static inline auto get_nonconst_entities(AllEntities& in)
-    {
-        return get_entities(in);
-    }
-
-    template <typename AllEntities> static inline auto get_entities(AllEntities&& in)
-    {
-        return std::forward_as_tuple(in.get(ColumnAndShifts::lookup_bc_retrieval_class_id_derivation_inv),
-                                     in.get(ColumnAndShifts::lookup_bc_retrieval_class_id_derivation_counts),
-                                     in.get(ColumnAndShifts::bc_retrieval_sel),
-                                     in.get(ColumnAndShifts::class_id_derivation_sel),
-                                     in.get(ColumnAndShifts::bc_retrieval_current_class_id),
-                                     in.get(ColumnAndShifts::bc_retrieval_artifact_hash),
-                                     in.get(ColumnAndShifts::bc_retrieval_private_function_root),
-                                     in.get(ColumnAndShifts::bc_retrieval_public_bytecode_commitment),
-                                     in.get(ColumnAndShifts::class_id_derivation_class_id),
-                                     in.get(ColumnAndShifts::class_id_derivation_artifact_hash),
-                                     in.get(ColumnAndShifts::class_id_derivation_private_function_root),
-                                     in.get(ColumnAndShifts::class_id_derivation_public_bytecode_commitment));
-    }
 };
 
+using lookup_bc_retrieval_class_id_derivation_settings =
+    lookup_settings<lookup_bc_retrieval_class_id_derivation_settings_>;
 template <typename FF_>
-class lookup_bc_retrieval_class_id_derivation_relation
-    : public GenericLookupRelation<lookup_bc_retrieval_class_id_derivation_settings, FF_> {
-  public:
-    using Settings = lookup_bc_retrieval_class_id_derivation_settings;
-    static constexpr std::string_view NAME = lookup_bc_retrieval_class_id_derivation_settings::NAME;
-    static constexpr std::string_view RELATION_NAME = lookup_bc_retrieval_class_id_derivation_settings::RELATION_NAME;
-
-    template <typename AllEntities> inline static bool skip(const AllEntities& in)
-    {
-        return in.lookup_bc_retrieval_class_id_derivation_inv.is_zero();
-    }
-
-    static std::string get_subrelation_label(size_t index)
-    {
-        if (index == 0) {
-            return "INVERSES_ARE_CORRECT";
-        } else if (index == 1) {
-            return "ACCUMULATION_IS_CORRECT";
-        }
-        return std::to_string(index);
-    }
-};
+using lookup_bc_retrieval_class_id_derivation_relation =
+    lookup_relation_base<FF_, lookup_bc_retrieval_class_id_derivation_settings>;
 
 /////////////////// lookup_bc_retrieval_bytecode_hash_is_correct ///////////////////
 
-class lookup_bc_retrieval_bytecode_hash_is_correct_settings {
-  public:
+struct lookup_bc_retrieval_bytecode_hash_is_correct_settings_ {
     static constexpr std::string_view NAME = "LOOKUP_BC_RETRIEVAL_BYTECODE_HASH_IS_CORRECT";
     static constexpr std::string_view RELATION_NAME = "bc_retrieval";
-
-    static constexpr size_t READ_TERMS = 1;
-    static constexpr size_t WRITE_TERMS = 1;
-    static constexpr size_t READ_TERM_TYPES[READ_TERMS] = { 0 };
-    static constexpr size_t WRITE_TERM_TYPES[WRITE_TERMS] = { 0 };
     static constexpr size_t LOOKUP_TUPLE_SIZE = 2;
-    static constexpr size_t INVERSE_EXISTS_POLYNOMIAL_DEGREE = 4;
-    static constexpr size_t READ_TERM_DEGREE = 0;
-    static constexpr size_t WRITE_TERM_DEGREE = 0;
-
-    // Columns using the Column enum.
     static constexpr Column SRC_SELECTOR = Column::bc_retrieval_sel;
     static constexpr Column DST_SELECTOR = Column::bc_hashing_latch;
     static constexpr Column COUNTS = Column::lookup_bc_retrieval_bytecode_hash_is_correct_counts;
@@ -572,67 +193,12 @@ class lookup_bc_retrieval_bytecode_hash_is_correct_settings {
     static constexpr std::array<ColumnAndShifts, LOOKUP_TUPLE_SIZE> DST_COLUMNS = {
         ColumnAndShifts::bc_hashing_bytecode_id, ColumnAndShifts::bc_hashing_output_hash
     };
-
-    template <typename AllEntities> static inline auto inverse_polynomial_is_computed_at_row(const AllEntities& in)
-    {
-        return (in.get(ColumnAndShifts::bc_retrieval_sel) == 1 || in.get(ColumnAndShifts::bc_hashing_latch) == 1);
-    }
-
-    template <typename Accumulator, typename AllEntities>
-    static inline auto compute_inverse_exists(const AllEntities& in)
-    {
-        using View = typename Accumulator::View;
-        const auto is_operation = View(in.get(ColumnAndShifts::bc_retrieval_sel));
-        const auto is_table_entry = View(in.get(ColumnAndShifts::bc_hashing_latch));
-        return (is_operation + is_table_entry - is_operation * is_table_entry);
-    }
-
-    template <typename AllEntities> static inline auto get_const_entities(const AllEntities& in)
-    {
-        return get_entities(in);
-    }
-
-    template <typename AllEntities> static inline auto get_nonconst_entities(AllEntities& in)
-    {
-        return get_entities(in);
-    }
-
-    template <typename AllEntities> static inline auto get_entities(AllEntities&& in)
-    {
-        return std::forward_as_tuple(in.get(ColumnAndShifts::lookup_bc_retrieval_bytecode_hash_is_correct_inv),
-                                     in.get(ColumnAndShifts::lookup_bc_retrieval_bytecode_hash_is_correct_counts),
-                                     in.get(ColumnAndShifts::bc_retrieval_sel),
-                                     in.get(ColumnAndShifts::bc_hashing_latch),
-                                     in.get(ColumnAndShifts::bc_retrieval_bytecode_id),
-                                     in.get(ColumnAndShifts::bc_retrieval_public_bytecode_commitment),
-                                     in.get(ColumnAndShifts::bc_hashing_bytecode_id),
-                                     in.get(ColumnAndShifts::bc_hashing_output_hash));
-    }
 };
 
+using lookup_bc_retrieval_bytecode_hash_is_correct_settings =
+    lookup_settings<lookup_bc_retrieval_bytecode_hash_is_correct_settings_>;
 template <typename FF_>
-class lookup_bc_retrieval_bytecode_hash_is_correct_relation
-    : public GenericLookupRelation<lookup_bc_retrieval_bytecode_hash_is_correct_settings, FF_> {
-  public:
-    using Settings = lookup_bc_retrieval_bytecode_hash_is_correct_settings;
-    static constexpr std::string_view NAME = lookup_bc_retrieval_bytecode_hash_is_correct_settings::NAME;
-    static constexpr std::string_view RELATION_NAME =
-        lookup_bc_retrieval_bytecode_hash_is_correct_settings::RELATION_NAME;
-
-    template <typename AllEntities> inline static bool skip(const AllEntities& in)
-    {
-        return in.lookup_bc_retrieval_bytecode_hash_is_correct_inv.is_zero();
-    }
-
-    static std::string get_subrelation_label(size_t index)
-    {
-        if (index == 0) {
-            return "INVERSES_ARE_CORRECT";
-        } else if (index == 1) {
-            return "ACCUMULATION_IS_CORRECT";
-        }
-        return std::to_string(index);
-    }
-};
+using lookup_bc_retrieval_bytecode_hash_is_correct_relation =
+    lookup_relation_base<FF_, lookup_bc_retrieval_bytecode_hash_is_correct_settings>;
 
 } // namespace bb::avm2

--- a/barretenberg/cpp/src/barretenberg/vm2/generated/relations/lookups_bitwise.hpp
+++ b/barretenberg/cpp/src/barretenberg/vm2/generated/relations/lookups_bitwise.hpp
@@ -3,6 +3,7 @@
 
 #include "../columns.hpp"
 #include "barretenberg/relations/generic_lookup/generic_lookup_relation.hpp"
+#include "barretenberg/vm2/constraining/relations/interactions_base.hpp"
 
 #include <cstddef>
 #include <string_view>
@@ -12,21 +13,10 @@ namespace bb::avm2 {
 
 /////////////////// lookup_bitwise_integral_tag_length ///////////////////
 
-class lookup_bitwise_integral_tag_length_settings {
-  public:
+struct lookup_bitwise_integral_tag_length_settings_ {
     static constexpr std::string_view NAME = "LOOKUP_BITWISE_INTEGRAL_TAG_LENGTH";
     static constexpr std::string_view RELATION_NAME = "bitwise";
-
-    static constexpr size_t READ_TERMS = 1;
-    static constexpr size_t WRITE_TERMS = 1;
-    static constexpr size_t READ_TERM_TYPES[READ_TERMS] = { 0 };
-    static constexpr size_t WRITE_TERM_TYPES[WRITE_TERMS] = { 0 };
     static constexpr size_t LOOKUP_TUPLE_SIZE = 2;
-    static constexpr size_t INVERSE_EXISTS_POLYNOMIAL_DEGREE = 4;
-    static constexpr size_t READ_TERM_DEGREE = 0;
-    static constexpr size_t WRITE_TERM_DEGREE = 0;
-
-    // Columns using the Column enum.
     static constexpr Column SRC_SELECTOR = Column::bitwise_start;
     static constexpr Column DST_SELECTOR = Column::precomputed_sel_integral_tag;
     static constexpr Column COUNTS = Column::lookup_bitwise_integral_tag_length_counts;
@@ -36,86 +26,19 @@ class lookup_bitwise_integral_tag_length_settings {
     static constexpr std::array<ColumnAndShifts, LOOKUP_TUPLE_SIZE> DST_COLUMNS = {
         ColumnAndShifts::precomputed_clk, ColumnAndShifts::precomputed_integral_tag_length
     };
-
-    template <typename AllEntities> static inline auto inverse_polynomial_is_computed_at_row(const AllEntities& in)
-    {
-        return (in.get(ColumnAndShifts::bitwise_start) == 1 ||
-                in.get(ColumnAndShifts::precomputed_sel_integral_tag) == 1);
-    }
-
-    template <typename Accumulator, typename AllEntities>
-    static inline auto compute_inverse_exists(const AllEntities& in)
-    {
-        using View = typename Accumulator::View;
-        const auto is_operation = View(in.get(ColumnAndShifts::bitwise_start));
-        const auto is_table_entry = View(in.get(ColumnAndShifts::precomputed_sel_integral_tag));
-        return (is_operation + is_table_entry - is_operation * is_table_entry);
-    }
-
-    template <typename AllEntities> static inline auto get_const_entities(const AllEntities& in)
-    {
-        return get_entities(in);
-    }
-
-    template <typename AllEntities> static inline auto get_nonconst_entities(AllEntities& in)
-    {
-        return get_entities(in);
-    }
-
-    template <typename AllEntities> static inline auto get_entities(AllEntities&& in)
-    {
-        return std::forward_as_tuple(in.get(ColumnAndShifts::lookup_bitwise_integral_tag_length_inv),
-                                     in.get(ColumnAndShifts::lookup_bitwise_integral_tag_length_counts),
-                                     in.get(ColumnAndShifts::bitwise_start),
-                                     in.get(ColumnAndShifts::precomputed_sel_integral_tag),
-                                     in.get(ColumnAndShifts::bitwise_tag),
-                                     in.get(ColumnAndShifts::bitwise_ctr),
-                                     in.get(ColumnAndShifts::precomputed_clk),
-                                     in.get(ColumnAndShifts::precomputed_integral_tag_length));
-    }
 };
 
+using lookup_bitwise_integral_tag_length_settings = lookup_settings<lookup_bitwise_integral_tag_length_settings_>;
 template <typename FF_>
-class lookup_bitwise_integral_tag_length_relation
-    : public GenericLookupRelation<lookup_bitwise_integral_tag_length_settings, FF_> {
-  public:
-    using Settings = lookup_bitwise_integral_tag_length_settings;
-    static constexpr std::string_view NAME = lookup_bitwise_integral_tag_length_settings::NAME;
-    static constexpr std::string_view RELATION_NAME = lookup_bitwise_integral_tag_length_settings::RELATION_NAME;
-
-    template <typename AllEntities> inline static bool skip(const AllEntities& in)
-    {
-        return in.lookup_bitwise_integral_tag_length_inv.is_zero();
-    }
-
-    static std::string get_subrelation_label(size_t index)
-    {
-        if (index == 0) {
-            return "INVERSES_ARE_CORRECT";
-        } else if (index == 1) {
-            return "ACCUMULATION_IS_CORRECT";
-        }
-        return std::to_string(index);
-    }
-};
+using lookup_bitwise_integral_tag_length_relation =
+    lookup_relation_base<FF_, lookup_bitwise_integral_tag_length_settings>;
 
 /////////////////// lookup_bitwise_byte_operations ///////////////////
 
-class lookup_bitwise_byte_operations_settings {
-  public:
+struct lookup_bitwise_byte_operations_settings_ {
     static constexpr std::string_view NAME = "LOOKUP_BITWISE_BYTE_OPERATIONS";
     static constexpr std::string_view RELATION_NAME = "bitwise";
-
-    static constexpr size_t READ_TERMS = 1;
-    static constexpr size_t WRITE_TERMS = 1;
-    static constexpr size_t READ_TERM_TYPES[READ_TERMS] = { 0 };
-    static constexpr size_t WRITE_TERM_TYPES[WRITE_TERMS] = { 0 };
     static constexpr size_t LOOKUP_TUPLE_SIZE = 4;
-    static constexpr size_t INVERSE_EXISTS_POLYNOMIAL_DEGREE = 4;
-    static constexpr size_t READ_TERM_DEGREE = 0;
-    static constexpr size_t WRITE_TERM_DEGREE = 0;
-
-    // Columns using the Column enum.
     static constexpr Column SRC_SELECTOR = Column::bitwise_sel;
     static constexpr Column DST_SELECTOR = Column::precomputed_sel_bitwise;
     static constexpr Column COUNTS = Column::lookup_bitwise_byte_operations_counts;
@@ -130,70 +53,10 @@ class lookup_bitwise_byte_operations_settings {
         ColumnAndShifts::precomputed_bitwise_input_b,
         ColumnAndShifts::precomputed_bitwise_output
     };
-
-    template <typename AllEntities> static inline auto inverse_polynomial_is_computed_at_row(const AllEntities& in)
-    {
-        return (in.get(ColumnAndShifts::bitwise_sel) == 1 || in.get(ColumnAndShifts::precomputed_sel_bitwise) == 1);
-    }
-
-    template <typename Accumulator, typename AllEntities>
-    static inline auto compute_inverse_exists(const AllEntities& in)
-    {
-        using View = typename Accumulator::View;
-        const auto is_operation = View(in.get(ColumnAndShifts::bitwise_sel));
-        const auto is_table_entry = View(in.get(ColumnAndShifts::precomputed_sel_bitwise));
-        return (is_operation + is_table_entry - is_operation * is_table_entry);
-    }
-
-    template <typename AllEntities> static inline auto get_const_entities(const AllEntities& in)
-    {
-        return get_entities(in);
-    }
-
-    template <typename AllEntities> static inline auto get_nonconst_entities(AllEntities& in)
-    {
-        return get_entities(in);
-    }
-
-    template <typename AllEntities> static inline auto get_entities(AllEntities&& in)
-    {
-        return std::forward_as_tuple(in.get(ColumnAndShifts::lookup_bitwise_byte_operations_inv),
-                                     in.get(ColumnAndShifts::lookup_bitwise_byte_operations_counts),
-                                     in.get(ColumnAndShifts::bitwise_sel),
-                                     in.get(ColumnAndShifts::precomputed_sel_bitwise),
-                                     in.get(ColumnAndShifts::bitwise_op_id),
-                                     in.get(ColumnAndShifts::bitwise_ia_byte),
-                                     in.get(ColumnAndShifts::bitwise_ib_byte),
-                                     in.get(ColumnAndShifts::bitwise_ic_byte),
-                                     in.get(ColumnAndShifts::precomputed_bitwise_op_id),
-                                     in.get(ColumnAndShifts::precomputed_bitwise_input_a),
-                                     in.get(ColumnAndShifts::precomputed_bitwise_input_b),
-                                     in.get(ColumnAndShifts::precomputed_bitwise_output));
-    }
 };
 
+using lookup_bitwise_byte_operations_settings = lookup_settings<lookup_bitwise_byte_operations_settings_>;
 template <typename FF_>
-class lookup_bitwise_byte_operations_relation
-    : public GenericLookupRelation<lookup_bitwise_byte_operations_settings, FF_> {
-  public:
-    using Settings = lookup_bitwise_byte_operations_settings;
-    static constexpr std::string_view NAME = lookup_bitwise_byte_operations_settings::NAME;
-    static constexpr std::string_view RELATION_NAME = lookup_bitwise_byte_operations_settings::RELATION_NAME;
-
-    template <typename AllEntities> inline static bool skip(const AllEntities& in)
-    {
-        return in.lookup_bitwise_byte_operations_inv.is_zero();
-    }
-
-    static std::string get_subrelation_label(size_t index)
-    {
-        if (index == 0) {
-            return "INVERSES_ARE_CORRECT";
-        } else if (index == 1) {
-            return "ACCUMULATION_IS_CORRECT";
-        }
-        return std::to_string(index);
-    }
-};
+using lookup_bitwise_byte_operations_relation = lookup_relation_base<FF_, lookup_bitwise_byte_operations_settings>;
 
 } // namespace bb::avm2

--- a/barretenberg/cpp/src/barretenberg/vm2/generated/relations/lookups_class_id_derivation.hpp
+++ b/barretenberg/cpp/src/barretenberg/vm2/generated/relations/lookups_class_id_derivation.hpp
@@ -3,6 +3,7 @@
 
 #include "../columns.hpp"
 #include "barretenberg/relations/generic_lookup/generic_lookup_relation.hpp"
+#include "barretenberg/vm2/constraining/relations/interactions_base.hpp"
 
 #include <cstddef>
 #include <string_view>
@@ -12,21 +13,10 @@ namespace bb::avm2 {
 
 /////////////////// lookup_class_id_derivation_class_id_poseidon2_0 ///////////////////
 
-class lookup_class_id_derivation_class_id_poseidon2_0_settings {
-  public:
+struct lookup_class_id_derivation_class_id_poseidon2_0_settings_ {
     static constexpr std::string_view NAME = "LOOKUP_CLASS_ID_DERIVATION_CLASS_ID_POSEIDON2_0";
     static constexpr std::string_view RELATION_NAME = "class_id_derivation";
-
-    static constexpr size_t READ_TERMS = 1;
-    static constexpr size_t WRITE_TERMS = 1;
-    static constexpr size_t READ_TERM_TYPES[READ_TERMS] = { 0 };
-    static constexpr size_t WRITE_TERM_TYPES[WRITE_TERMS] = { 0 };
     static constexpr size_t LOOKUP_TUPLE_SIZE = 4;
-    static constexpr size_t INVERSE_EXISTS_POLYNOMIAL_DEGREE = 4;
-    static constexpr size_t READ_TERM_DEGREE = 0;
-    static constexpr size_t WRITE_TERM_DEGREE = 0;
-
-    // Columns using the Column enum.
     static constexpr Column SRC_SELECTOR = Column::class_id_derivation_sel;
     static constexpr Column DST_SELECTOR = Column::poseidon2_hash_start;
     static constexpr Column COUNTS = Column::lookup_class_id_derivation_class_id_poseidon2_0_counts;
@@ -43,91 +33,20 @@ class lookup_class_id_derivation_class_id_poseidon2_0_settings {
         ColumnAndShifts::poseidon2_hash_input_2,
         ColumnAndShifts::poseidon2_hash_output
     };
-
-    template <typename AllEntities> static inline auto inverse_polynomial_is_computed_at_row(const AllEntities& in)
-    {
-        return (in.get(ColumnAndShifts::class_id_derivation_sel) == 1 ||
-                in.get(ColumnAndShifts::poseidon2_hash_start) == 1);
-    }
-
-    template <typename Accumulator, typename AllEntities>
-    static inline auto compute_inverse_exists(const AllEntities& in)
-    {
-        using View = typename Accumulator::View;
-        const auto is_operation = View(in.get(ColumnAndShifts::class_id_derivation_sel));
-        const auto is_table_entry = View(in.get(ColumnAndShifts::poseidon2_hash_start));
-        return (is_operation + is_table_entry - is_operation * is_table_entry);
-    }
-
-    template <typename AllEntities> static inline auto get_const_entities(const AllEntities& in)
-    {
-        return get_entities(in);
-    }
-
-    template <typename AllEntities> static inline auto get_nonconst_entities(AllEntities& in)
-    {
-        return get_entities(in);
-    }
-
-    template <typename AllEntities> static inline auto get_entities(AllEntities&& in)
-    {
-        return std::forward_as_tuple(in.get(ColumnAndShifts::lookup_class_id_derivation_class_id_poseidon2_0_inv),
-                                     in.get(ColumnAndShifts::lookup_class_id_derivation_class_id_poseidon2_0_counts),
-                                     in.get(ColumnAndShifts::class_id_derivation_sel),
-                                     in.get(ColumnAndShifts::poseidon2_hash_start),
-                                     in.get(ColumnAndShifts::class_id_derivation_temp_constant_for_lookup),
-                                     in.get(ColumnAndShifts::class_id_derivation_artifact_hash),
-                                     in.get(ColumnAndShifts::class_id_derivation_private_function_root),
-                                     in.get(ColumnAndShifts::class_id_derivation_class_id),
-                                     in.get(ColumnAndShifts::poseidon2_hash_input_0),
-                                     in.get(ColumnAndShifts::poseidon2_hash_input_1),
-                                     in.get(ColumnAndShifts::poseidon2_hash_input_2),
-                                     in.get(ColumnAndShifts::poseidon2_hash_output));
-    }
 };
 
+using lookup_class_id_derivation_class_id_poseidon2_0_settings =
+    lookup_settings<lookup_class_id_derivation_class_id_poseidon2_0_settings_>;
 template <typename FF_>
-class lookup_class_id_derivation_class_id_poseidon2_0_relation
-    : public GenericLookupRelation<lookup_class_id_derivation_class_id_poseidon2_0_settings, FF_> {
-  public:
-    using Settings = lookup_class_id_derivation_class_id_poseidon2_0_settings;
-    static constexpr std::string_view NAME = lookup_class_id_derivation_class_id_poseidon2_0_settings::NAME;
-    static constexpr std::string_view RELATION_NAME =
-        lookup_class_id_derivation_class_id_poseidon2_0_settings::RELATION_NAME;
-
-    template <typename AllEntities> inline static bool skip(const AllEntities& in)
-    {
-        return in.lookup_class_id_derivation_class_id_poseidon2_0_inv.is_zero();
-    }
-
-    static std::string get_subrelation_label(size_t index)
-    {
-        if (index == 0) {
-            return "INVERSES_ARE_CORRECT";
-        } else if (index == 1) {
-            return "ACCUMULATION_IS_CORRECT";
-        }
-        return std::to_string(index);
-    }
-};
+using lookup_class_id_derivation_class_id_poseidon2_0_relation =
+    lookup_relation_base<FF_, lookup_class_id_derivation_class_id_poseidon2_0_settings>;
 
 /////////////////// lookup_class_id_derivation_class_id_poseidon2_1 ///////////////////
 
-class lookup_class_id_derivation_class_id_poseidon2_1_settings {
-  public:
+struct lookup_class_id_derivation_class_id_poseidon2_1_settings_ {
     static constexpr std::string_view NAME = "LOOKUP_CLASS_ID_DERIVATION_CLASS_ID_POSEIDON2_1";
     static constexpr std::string_view RELATION_NAME = "class_id_derivation";
-
-    static constexpr size_t READ_TERMS = 1;
-    static constexpr size_t WRITE_TERMS = 1;
-    static constexpr size_t READ_TERM_TYPES[READ_TERMS] = { 0 };
-    static constexpr size_t WRITE_TERM_TYPES[WRITE_TERMS] = { 0 };
     static constexpr size_t LOOKUP_TUPLE_SIZE = 4;
-    static constexpr size_t INVERSE_EXISTS_POLYNOMIAL_DEGREE = 4;
-    static constexpr size_t READ_TERM_DEGREE = 0;
-    static constexpr size_t WRITE_TERM_DEGREE = 0;
-
-    // Columns using the Column enum.
     static constexpr Column SRC_SELECTOR = Column::class_id_derivation_sel;
     static constexpr Column DST_SELECTOR = Column::poseidon2_hash_end;
     static constexpr Column COUNTS = Column::lookup_class_id_derivation_class_id_poseidon2_1_counts;
@@ -144,72 +63,12 @@ class lookup_class_id_derivation_class_id_poseidon2_1_settings {
         ColumnAndShifts::poseidon2_hash_input_2,
         ColumnAndShifts::poseidon2_hash_output
     };
-
-    template <typename AllEntities> static inline auto inverse_polynomial_is_computed_at_row(const AllEntities& in)
-    {
-        return (in.get(ColumnAndShifts::class_id_derivation_sel) == 1 ||
-                in.get(ColumnAndShifts::poseidon2_hash_end) == 1);
-    }
-
-    template <typename Accumulator, typename AllEntities>
-    static inline auto compute_inverse_exists(const AllEntities& in)
-    {
-        using View = typename Accumulator::View;
-        const auto is_operation = View(in.get(ColumnAndShifts::class_id_derivation_sel));
-        const auto is_table_entry = View(in.get(ColumnAndShifts::poseidon2_hash_end));
-        return (is_operation + is_table_entry - is_operation * is_table_entry);
-    }
-
-    template <typename AllEntities> static inline auto get_const_entities(const AllEntities& in)
-    {
-        return get_entities(in);
-    }
-
-    template <typename AllEntities> static inline auto get_nonconst_entities(AllEntities& in)
-    {
-        return get_entities(in);
-    }
-
-    template <typename AllEntities> static inline auto get_entities(AllEntities&& in)
-    {
-        return std::forward_as_tuple(in.get(ColumnAndShifts::lookup_class_id_derivation_class_id_poseidon2_1_inv),
-                                     in.get(ColumnAndShifts::lookup_class_id_derivation_class_id_poseidon2_1_counts),
-                                     in.get(ColumnAndShifts::class_id_derivation_sel),
-                                     in.get(ColumnAndShifts::poseidon2_hash_end),
-                                     in.get(ColumnAndShifts::class_id_derivation_public_bytecode_commitment),
-                                     in.get(ColumnAndShifts::precomputed_zero),
-                                     in.get(ColumnAndShifts::precomputed_zero),
-                                     in.get(ColumnAndShifts::class_id_derivation_class_id),
-                                     in.get(ColumnAndShifts::poseidon2_hash_input_0),
-                                     in.get(ColumnAndShifts::poseidon2_hash_input_1),
-                                     in.get(ColumnAndShifts::poseidon2_hash_input_2),
-                                     in.get(ColumnAndShifts::poseidon2_hash_output));
-    }
 };
 
+using lookup_class_id_derivation_class_id_poseidon2_1_settings =
+    lookup_settings<lookup_class_id_derivation_class_id_poseidon2_1_settings_>;
 template <typename FF_>
-class lookup_class_id_derivation_class_id_poseidon2_1_relation
-    : public GenericLookupRelation<lookup_class_id_derivation_class_id_poseidon2_1_settings, FF_> {
-  public:
-    using Settings = lookup_class_id_derivation_class_id_poseidon2_1_settings;
-    static constexpr std::string_view NAME = lookup_class_id_derivation_class_id_poseidon2_1_settings::NAME;
-    static constexpr std::string_view RELATION_NAME =
-        lookup_class_id_derivation_class_id_poseidon2_1_settings::RELATION_NAME;
-
-    template <typename AllEntities> inline static bool skip(const AllEntities& in)
-    {
-        return in.lookup_class_id_derivation_class_id_poseidon2_1_inv.is_zero();
-    }
-
-    static std::string get_subrelation_label(size_t index)
-    {
-        if (index == 0) {
-            return "INVERSES_ARE_CORRECT";
-        } else if (index == 1) {
-            return "ACCUMULATION_IS_CORRECT";
-        }
-        return std::to_string(index);
-    }
-};
+using lookup_class_id_derivation_class_id_poseidon2_1_relation =
+    lookup_relation_base<FF_, lookup_class_id_derivation_class_id_poseidon2_1_settings>;
 
 } // namespace bb::avm2

--- a/barretenberg/cpp/src/barretenberg/vm2/generated/relations/lookups_ff_gt.hpp
+++ b/barretenberg/cpp/src/barretenberg/vm2/generated/relations/lookups_ff_gt.hpp
@@ -3,6 +3,7 @@
 
 #include "../columns.hpp"
 #include "barretenberg/relations/generic_lookup/generic_lookup_relation.hpp"
+#include "barretenberg/vm2/constraining/relations/interactions_base.hpp"
 
 #include <cstddef>
 #include <string_view>
@@ -12,21 +13,10 @@ namespace bb::avm2 {
 
 /////////////////// lookup_ff_gt_a_lo_range ///////////////////
 
-class lookup_ff_gt_a_lo_range_settings {
-  public:
+struct lookup_ff_gt_a_lo_range_settings_ {
     static constexpr std::string_view NAME = "LOOKUP_FF_GT_A_LO_RANGE";
     static constexpr std::string_view RELATION_NAME = "ff_gt";
-
-    static constexpr size_t READ_TERMS = 1;
-    static constexpr size_t WRITE_TERMS = 1;
-    static constexpr size_t READ_TERM_TYPES[READ_TERMS] = { 0 };
-    static constexpr size_t WRITE_TERM_TYPES[WRITE_TERMS] = { 0 };
     static constexpr size_t LOOKUP_TUPLE_SIZE = 2;
-    static constexpr size_t INVERSE_EXISTS_POLYNOMIAL_DEGREE = 4;
-    static constexpr size_t READ_TERM_DEGREE = 0;
-    static constexpr size_t WRITE_TERM_DEGREE = 0;
-
-    // Columns using the Column enum.
     static constexpr Column SRC_SELECTOR = Column::ff_gt_sel;
     static constexpr Column DST_SELECTOR = Column::range_check_sel;
     static constexpr Column COUNTS = Column::lookup_ff_gt_a_lo_range_counts;
@@ -37,84 +27,18 @@ class lookup_ff_gt_a_lo_range_settings {
     static constexpr std::array<ColumnAndShifts, LOOKUP_TUPLE_SIZE> DST_COLUMNS = {
         ColumnAndShifts::range_check_value, ColumnAndShifts::range_check_rng_chk_bits
     };
-
-    template <typename AllEntities> static inline auto inverse_polynomial_is_computed_at_row(const AllEntities& in)
-    {
-        return (in.get(ColumnAndShifts::ff_gt_sel) == 1 || in.get(ColumnAndShifts::range_check_sel) == 1);
-    }
-
-    template <typename Accumulator, typename AllEntities>
-    static inline auto compute_inverse_exists(const AllEntities& in)
-    {
-        using View = typename Accumulator::View;
-        const auto is_operation = View(in.get(ColumnAndShifts::ff_gt_sel));
-        const auto is_table_entry = View(in.get(ColumnAndShifts::range_check_sel));
-        return (is_operation + is_table_entry - is_operation * is_table_entry);
-    }
-
-    template <typename AllEntities> static inline auto get_const_entities(const AllEntities& in)
-    {
-        return get_entities(in);
-    }
-
-    template <typename AllEntities> static inline auto get_nonconst_entities(AllEntities& in)
-    {
-        return get_entities(in);
-    }
-
-    template <typename AllEntities> static inline auto get_entities(AllEntities&& in)
-    {
-        return std::forward_as_tuple(in.get(ColumnAndShifts::lookup_ff_gt_a_lo_range_inv),
-                                     in.get(ColumnAndShifts::lookup_ff_gt_a_lo_range_counts),
-                                     in.get(ColumnAndShifts::ff_gt_sel),
-                                     in.get(ColumnAndShifts::range_check_sel),
-                                     in.get(ColumnAndShifts::ff_gt_a_lo),
-                                     in.get(ColumnAndShifts::ff_gt_constant_128),
-                                     in.get(ColumnAndShifts::range_check_value),
-                                     in.get(ColumnAndShifts::range_check_rng_chk_bits));
-    }
 };
 
+using lookup_ff_gt_a_lo_range_settings = lookup_settings<lookup_ff_gt_a_lo_range_settings_>;
 template <typename FF_>
-class lookup_ff_gt_a_lo_range_relation : public GenericLookupRelation<lookup_ff_gt_a_lo_range_settings, FF_> {
-  public:
-    using Settings = lookup_ff_gt_a_lo_range_settings;
-    static constexpr std::string_view NAME = lookup_ff_gt_a_lo_range_settings::NAME;
-    static constexpr std::string_view RELATION_NAME = lookup_ff_gt_a_lo_range_settings::RELATION_NAME;
-
-    template <typename AllEntities> inline static bool skip(const AllEntities& in)
-    {
-        return in.lookup_ff_gt_a_lo_range_inv.is_zero();
-    }
-
-    static std::string get_subrelation_label(size_t index)
-    {
-        if (index == 0) {
-            return "INVERSES_ARE_CORRECT";
-        } else if (index == 1) {
-            return "ACCUMULATION_IS_CORRECT";
-        }
-        return std::to_string(index);
-    }
-};
+using lookup_ff_gt_a_lo_range_relation = lookup_relation_base<FF_, lookup_ff_gt_a_lo_range_settings>;
 
 /////////////////// lookup_ff_gt_a_hi_range ///////////////////
 
-class lookup_ff_gt_a_hi_range_settings {
-  public:
+struct lookup_ff_gt_a_hi_range_settings_ {
     static constexpr std::string_view NAME = "LOOKUP_FF_GT_A_HI_RANGE";
     static constexpr std::string_view RELATION_NAME = "ff_gt";
-
-    static constexpr size_t READ_TERMS = 1;
-    static constexpr size_t WRITE_TERMS = 1;
-    static constexpr size_t READ_TERM_TYPES[READ_TERMS] = { 0 };
-    static constexpr size_t WRITE_TERM_TYPES[WRITE_TERMS] = { 0 };
     static constexpr size_t LOOKUP_TUPLE_SIZE = 2;
-    static constexpr size_t INVERSE_EXISTS_POLYNOMIAL_DEGREE = 4;
-    static constexpr size_t READ_TERM_DEGREE = 0;
-    static constexpr size_t WRITE_TERM_DEGREE = 0;
-
-    // Columns using the Column enum.
     static constexpr Column SRC_SELECTOR = Column::ff_gt_sel;
     static constexpr Column DST_SELECTOR = Column::range_check_sel;
     static constexpr Column COUNTS = Column::lookup_ff_gt_a_hi_range_counts;
@@ -125,65 +49,10 @@ class lookup_ff_gt_a_hi_range_settings {
     static constexpr std::array<ColumnAndShifts, LOOKUP_TUPLE_SIZE> DST_COLUMNS = {
         ColumnAndShifts::range_check_value, ColumnAndShifts::range_check_rng_chk_bits
     };
-
-    template <typename AllEntities> static inline auto inverse_polynomial_is_computed_at_row(const AllEntities& in)
-    {
-        return (in.get(ColumnAndShifts::ff_gt_sel) == 1 || in.get(ColumnAndShifts::range_check_sel) == 1);
-    }
-
-    template <typename Accumulator, typename AllEntities>
-    static inline auto compute_inverse_exists(const AllEntities& in)
-    {
-        using View = typename Accumulator::View;
-        const auto is_operation = View(in.get(ColumnAndShifts::ff_gt_sel));
-        const auto is_table_entry = View(in.get(ColumnAndShifts::range_check_sel));
-        return (is_operation + is_table_entry - is_operation * is_table_entry);
-    }
-
-    template <typename AllEntities> static inline auto get_const_entities(const AllEntities& in)
-    {
-        return get_entities(in);
-    }
-
-    template <typename AllEntities> static inline auto get_nonconst_entities(AllEntities& in)
-    {
-        return get_entities(in);
-    }
-
-    template <typename AllEntities> static inline auto get_entities(AllEntities&& in)
-    {
-        return std::forward_as_tuple(in.get(ColumnAndShifts::lookup_ff_gt_a_hi_range_inv),
-                                     in.get(ColumnAndShifts::lookup_ff_gt_a_hi_range_counts),
-                                     in.get(ColumnAndShifts::ff_gt_sel),
-                                     in.get(ColumnAndShifts::range_check_sel),
-                                     in.get(ColumnAndShifts::ff_gt_a_hi),
-                                     in.get(ColumnAndShifts::ff_gt_constant_128),
-                                     in.get(ColumnAndShifts::range_check_value),
-                                     in.get(ColumnAndShifts::range_check_rng_chk_bits));
-    }
 };
 
+using lookup_ff_gt_a_hi_range_settings = lookup_settings<lookup_ff_gt_a_hi_range_settings_>;
 template <typename FF_>
-class lookup_ff_gt_a_hi_range_relation : public GenericLookupRelation<lookup_ff_gt_a_hi_range_settings, FF_> {
-  public:
-    using Settings = lookup_ff_gt_a_hi_range_settings;
-    static constexpr std::string_view NAME = lookup_ff_gt_a_hi_range_settings::NAME;
-    static constexpr std::string_view RELATION_NAME = lookup_ff_gt_a_hi_range_settings::RELATION_NAME;
-
-    template <typename AllEntities> inline static bool skip(const AllEntities& in)
-    {
-        return in.lookup_ff_gt_a_hi_range_inv.is_zero();
-    }
-
-    static std::string get_subrelation_label(size_t index)
-    {
-        if (index == 0) {
-            return "INVERSES_ARE_CORRECT";
-        } else if (index == 1) {
-            return "ACCUMULATION_IS_CORRECT";
-        }
-        return std::to_string(index);
-    }
-};
+using lookup_ff_gt_a_hi_range_relation = lookup_relation_base<FF_, lookup_ff_gt_a_hi_range_settings>;
 
 } // namespace bb::avm2

--- a/barretenberg/cpp/src/barretenberg/vm2/generated/relations/lookups_instr_fetching.hpp
+++ b/barretenberg/cpp/src/barretenberg/vm2/generated/relations/lookups_instr_fetching.hpp
@@ -3,6 +3,7 @@
 
 #include "../columns.hpp"
 #include "barretenberg/relations/generic_lookup/generic_lookup_relation.hpp"
+#include "barretenberg/vm2/constraining/relations/interactions_base.hpp"
 
 #include <cstddef>
 #include <string_view>
@@ -12,21 +13,10 @@ namespace bb::avm2 {
 
 /////////////////// lookup_instr_fetching_pc_abs_diff_positive ///////////////////
 
-class lookup_instr_fetching_pc_abs_diff_positive_settings {
-  public:
+struct lookup_instr_fetching_pc_abs_diff_positive_settings_ {
     static constexpr std::string_view NAME = "LOOKUP_INSTR_FETCHING_PC_ABS_DIFF_POSITIVE";
     static constexpr std::string_view RELATION_NAME = "instr_fetching";
-
-    static constexpr size_t READ_TERMS = 1;
-    static constexpr size_t WRITE_TERMS = 1;
-    static constexpr size_t READ_TERM_TYPES[READ_TERMS] = { 0 };
-    static constexpr size_t WRITE_TERM_TYPES[WRITE_TERMS] = { 0 };
     static constexpr size_t LOOKUP_TUPLE_SIZE = 2;
-    static constexpr size_t INVERSE_EXISTS_POLYNOMIAL_DEGREE = 4;
-    static constexpr size_t READ_TERM_DEGREE = 0;
-    static constexpr size_t WRITE_TERM_DEGREE = 0;
-
-    // Columns using the Column enum.
     static constexpr Column SRC_SELECTOR = Column::instr_fetching_sel;
     static constexpr Column DST_SELECTOR = Column::range_check_sel;
     static constexpr Column COUNTS = Column::lookup_instr_fetching_pc_abs_diff_positive_counts;
@@ -37,86 +27,20 @@ class lookup_instr_fetching_pc_abs_diff_positive_settings {
     static constexpr std::array<ColumnAndShifts, LOOKUP_TUPLE_SIZE> DST_COLUMNS = {
         ColumnAndShifts::range_check_value, ColumnAndShifts::range_check_rng_chk_bits
     };
-
-    template <typename AllEntities> static inline auto inverse_polynomial_is_computed_at_row(const AllEntities& in)
-    {
-        return (in.get(ColumnAndShifts::instr_fetching_sel) == 1 || in.get(ColumnAndShifts::range_check_sel) == 1);
-    }
-
-    template <typename Accumulator, typename AllEntities>
-    static inline auto compute_inverse_exists(const AllEntities& in)
-    {
-        using View = typename Accumulator::View;
-        const auto is_operation = View(in.get(ColumnAndShifts::instr_fetching_sel));
-        const auto is_table_entry = View(in.get(ColumnAndShifts::range_check_sel));
-        return (is_operation + is_table_entry - is_operation * is_table_entry);
-    }
-
-    template <typename AllEntities> static inline auto get_const_entities(const AllEntities& in)
-    {
-        return get_entities(in);
-    }
-
-    template <typename AllEntities> static inline auto get_nonconst_entities(AllEntities& in)
-    {
-        return get_entities(in);
-    }
-
-    template <typename AllEntities> static inline auto get_entities(AllEntities&& in)
-    {
-        return std::forward_as_tuple(in.get(ColumnAndShifts::lookup_instr_fetching_pc_abs_diff_positive_inv),
-                                     in.get(ColumnAndShifts::lookup_instr_fetching_pc_abs_diff_positive_counts),
-                                     in.get(ColumnAndShifts::instr_fetching_sel),
-                                     in.get(ColumnAndShifts::range_check_sel),
-                                     in.get(ColumnAndShifts::instr_fetching_pc_abs_diff),
-                                     in.get(ColumnAndShifts::instr_fetching_pc_size_in_bits),
-                                     in.get(ColumnAndShifts::range_check_value),
-                                     in.get(ColumnAndShifts::range_check_rng_chk_bits));
-    }
 };
 
+using lookup_instr_fetching_pc_abs_diff_positive_settings =
+    lookup_settings<lookup_instr_fetching_pc_abs_diff_positive_settings_>;
 template <typename FF_>
-class lookup_instr_fetching_pc_abs_diff_positive_relation
-    : public GenericLookupRelation<lookup_instr_fetching_pc_abs_diff_positive_settings, FF_> {
-  public:
-    using Settings = lookup_instr_fetching_pc_abs_diff_positive_settings;
-    static constexpr std::string_view NAME = lookup_instr_fetching_pc_abs_diff_positive_settings::NAME;
-    static constexpr std::string_view RELATION_NAME =
-        lookup_instr_fetching_pc_abs_diff_positive_settings::RELATION_NAME;
-
-    template <typename AllEntities> inline static bool skip(const AllEntities& in)
-    {
-        return in.lookup_instr_fetching_pc_abs_diff_positive_inv.is_zero();
-    }
-
-    static std::string get_subrelation_label(size_t index)
-    {
-        if (index == 0) {
-            return "INVERSES_ARE_CORRECT";
-        } else if (index == 1) {
-            return "ACCUMULATION_IS_CORRECT";
-        }
-        return std::to_string(index);
-    }
-};
+using lookup_instr_fetching_pc_abs_diff_positive_relation =
+    lookup_relation_base<FF_, lookup_instr_fetching_pc_abs_diff_positive_settings>;
 
 /////////////////// lookup_instr_fetching_instr_abs_diff_positive ///////////////////
 
-class lookup_instr_fetching_instr_abs_diff_positive_settings {
-  public:
+struct lookup_instr_fetching_instr_abs_diff_positive_settings_ {
     static constexpr std::string_view NAME = "LOOKUP_INSTR_FETCHING_INSTR_ABS_DIFF_POSITIVE";
     static constexpr std::string_view RELATION_NAME = "instr_fetching";
-
-    static constexpr size_t READ_TERMS = 1;
-    static constexpr size_t WRITE_TERMS = 1;
-    static constexpr size_t READ_TERM_TYPES[READ_TERMS] = { 0 };
-    static constexpr size_t WRITE_TERM_TYPES[WRITE_TERMS] = { 0 };
     static constexpr size_t LOOKUP_TUPLE_SIZE = 1;
-    static constexpr size_t INVERSE_EXISTS_POLYNOMIAL_DEGREE = 4;
-    static constexpr size_t READ_TERM_DEGREE = 0;
-    static constexpr size_t WRITE_TERM_DEGREE = 0;
-
-    // Columns using the Column enum.
     static constexpr Column SRC_SELECTOR = Column::instr_fetching_sel;
     static constexpr Column DST_SELECTOR = Column::precomputed_sel_range_8;
     static constexpr Column COUNTS = Column::lookup_instr_fetching_instr_abs_diff_positive_counts;
@@ -125,85 +49,20 @@ class lookup_instr_fetching_instr_abs_diff_positive_settings {
         ColumnAndShifts::instr_fetching_instr_abs_diff
     };
     static constexpr std::array<ColumnAndShifts, LOOKUP_TUPLE_SIZE> DST_COLUMNS = { ColumnAndShifts::precomputed_clk };
-
-    template <typename AllEntities> static inline auto inverse_polynomial_is_computed_at_row(const AllEntities& in)
-    {
-        return (in.get(ColumnAndShifts::instr_fetching_sel) == 1 ||
-                in.get(ColumnAndShifts::precomputed_sel_range_8) == 1);
-    }
-
-    template <typename Accumulator, typename AllEntities>
-    static inline auto compute_inverse_exists(const AllEntities& in)
-    {
-        using View = typename Accumulator::View;
-        const auto is_operation = View(in.get(ColumnAndShifts::instr_fetching_sel));
-        const auto is_table_entry = View(in.get(ColumnAndShifts::precomputed_sel_range_8));
-        return (is_operation + is_table_entry - is_operation * is_table_entry);
-    }
-
-    template <typename AllEntities> static inline auto get_const_entities(const AllEntities& in)
-    {
-        return get_entities(in);
-    }
-
-    template <typename AllEntities> static inline auto get_nonconst_entities(AllEntities& in)
-    {
-        return get_entities(in);
-    }
-
-    template <typename AllEntities> static inline auto get_entities(AllEntities&& in)
-    {
-        return std::forward_as_tuple(in.get(ColumnAndShifts::lookup_instr_fetching_instr_abs_diff_positive_inv),
-                                     in.get(ColumnAndShifts::lookup_instr_fetching_instr_abs_diff_positive_counts),
-                                     in.get(ColumnAndShifts::instr_fetching_sel),
-                                     in.get(ColumnAndShifts::precomputed_sel_range_8),
-                                     in.get(ColumnAndShifts::instr_fetching_instr_abs_diff),
-                                     in.get(ColumnAndShifts::precomputed_clk));
-    }
 };
 
+using lookup_instr_fetching_instr_abs_diff_positive_settings =
+    lookup_settings<lookup_instr_fetching_instr_abs_diff_positive_settings_>;
 template <typename FF_>
-class lookup_instr_fetching_instr_abs_diff_positive_relation
-    : public GenericLookupRelation<lookup_instr_fetching_instr_abs_diff_positive_settings, FF_> {
-  public:
-    using Settings = lookup_instr_fetching_instr_abs_diff_positive_settings;
-    static constexpr std::string_view NAME = lookup_instr_fetching_instr_abs_diff_positive_settings::NAME;
-    static constexpr std::string_view RELATION_NAME =
-        lookup_instr_fetching_instr_abs_diff_positive_settings::RELATION_NAME;
-
-    template <typename AllEntities> inline static bool skip(const AllEntities& in)
-    {
-        return in.lookup_instr_fetching_instr_abs_diff_positive_inv.is_zero();
-    }
-
-    static std::string get_subrelation_label(size_t index)
-    {
-        if (index == 0) {
-            return "INVERSES_ARE_CORRECT";
-        } else if (index == 1) {
-            return "ACCUMULATION_IS_CORRECT";
-        }
-        return std::to_string(index);
-    }
-};
+using lookup_instr_fetching_instr_abs_diff_positive_relation =
+    lookup_relation_base<FF_, lookup_instr_fetching_instr_abs_diff_positive_settings>;
 
 /////////////////// lookup_instr_fetching_tag_value_validation ///////////////////
 
-class lookup_instr_fetching_tag_value_validation_settings {
-  public:
+struct lookup_instr_fetching_tag_value_validation_settings_ {
     static constexpr std::string_view NAME = "LOOKUP_INSTR_FETCHING_TAG_VALUE_VALIDATION";
     static constexpr std::string_view RELATION_NAME = "instr_fetching";
-
-    static constexpr size_t READ_TERMS = 1;
-    static constexpr size_t WRITE_TERMS = 1;
-    static constexpr size_t READ_TERM_TYPES[READ_TERMS] = { 0 };
-    static constexpr size_t WRITE_TERM_TYPES[WRITE_TERMS] = { 0 };
     static constexpr size_t LOOKUP_TUPLE_SIZE = 2;
-    static constexpr size_t INVERSE_EXISTS_POLYNOMIAL_DEGREE = 4;
-    static constexpr size_t READ_TERM_DEGREE = 0;
-    static constexpr size_t WRITE_TERM_DEGREE = 0;
-
-    // Columns using the Column enum.
     static constexpr Column SRC_SELECTOR = Column::instr_fetching_sel_has_tag;
     static constexpr Column DST_SELECTOR = Column::precomputed_sel_range_8;
     static constexpr Column COUNTS = Column::lookup_instr_fetching_tag_value_validation_counts;
@@ -214,87 +73,20 @@ class lookup_instr_fetching_tag_value_validation_settings {
     static constexpr std::array<ColumnAndShifts, LOOKUP_TUPLE_SIZE> DST_COLUMNS = {
         ColumnAndShifts::precomputed_clk, ColumnAndShifts::precomputed_sel_mem_tag_out_of_range
     };
-
-    template <typename AllEntities> static inline auto inverse_polynomial_is_computed_at_row(const AllEntities& in)
-    {
-        return (in.get(ColumnAndShifts::instr_fetching_sel_has_tag) == 1 ||
-                in.get(ColumnAndShifts::precomputed_sel_range_8) == 1);
-    }
-
-    template <typename Accumulator, typename AllEntities>
-    static inline auto compute_inverse_exists(const AllEntities& in)
-    {
-        using View = typename Accumulator::View;
-        const auto is_operation = View(in.get(ColumnAndShifts::instr_fetching_sel_has_tag));
-        const auto is_table_entry = View(in.get(ColumnAndShifts::precomputed_sel_range_8));
-        return (is_operation + is_table_entry - is_operation * is_table_entry);
-    }
-
-    template <typename AllEntities> static inline auto get_const_entities(const AllEntities& in)
-    {
-        return get_entities(in);
-    }
-
-    template <typename AllEntities> static inline auto get_nonconst_entities(AllEntities& in)
-    {
-        return get_entities(in);
-    }
-
-    template <typename AllEntities> static inline auto get_entities(AllEntities&& in)
-    {
-        return std::forward_as_tuple(in.get(ColumnAndShifts::lookup_instr_fetching_tag_value_validation_inv),
-                                     in.get(ColumnAndShifts::lookup_instr_fetching_tag_value_validation_counts),
-                                     in.get(ColumnAndShifts::instr_fetching_sel_has_tag),
-                                     in.get(ColumnAndShifts::precomputed_sel_range_8),
-                                     in.get(ColumnAndShifts::instr_fetching_tag_value),
-                                     in.get(ColumnAndShifts::instr_fetching_tag_out_of_range),
-                                     in.get(ColumnAndShifts::precomputed_clk),
-                                     in.get(ColumnAndShifts::precomputed_sel_mem_tag_out_of_range));
-    }
 };
 
+using lookup_instr_fetching_tag_value_validation_settings =
+    lookup_settings<lookup_instr_fetching_tag_value_validation_settings_>;
 template <typename FF_>
-class lookup_instr_fetching_tag_value_validation_relation
-    : public GenericLookupRelation<lookup_instr_fetching_tag_value_validation_settings, FF_> {
-  public:
-    using Settings = lookup_instr_fetching_tag_value_validation_settings;
-    static constexpr std::string_view NAME = lookup_instr_fetching_tag_value_validation_settings::NAME;
-    static constexpr std::string_view RELATION_NAME =
-        lookup_instr_fetching_tag_value_validation_settings::RELATION_NAME;
-
-    template <typename AllEntities> inline static bool skip(const AllEntities& in)
-    {
-        return in.lookup_instr_fetching_tag_value_validation_inv.is_zero();
-    }
-
-    static std::string get_subrelation_label(size_t index)
-    {
-        if (index == 0) {
-            return "INVERSES_ARE_CORRECT";
-        } else if (index == 1) {
-            return "ACCUMULATION_IS_CORRECT";
-        }
-        return std::to_string(index);
-    }
-};
+using lookup_instr_fetching_tag_value_validation_relation =
+    lookup_relation_base<FF_, lookup_instr_fetching_tag_value_validation_settings>;
 
 /////////////////// lookup_instr_fetching_bytecode_size_from_bc_dec ///////////////////
 
-class lookup_instr_fetching_bytecode_size_from_bc_dec_settings {
-  public:
+struct lookup_instr_fetching_bytecode_size_from_bc_dec_settings_ {
     static constexpr std::string_view NAME = "LOOKUP_INSTR_FETCHING_BYTECODE_SIZE_FROM_BC_DEC";
     static constexpr std::string_view RELATION_NAME = "instr_fetching";
-
-    static constexpr size_t READ_TERMS = 1;
-    static constexpr size_t WRITE_TERMS = 1;
-    static constexpr size_t READ_TERM_TYPES[READ_TERMS] = { 0 };
-    static constexpr size_t WRITE_TERM_TYPES[WRITE_TERMS] = { 0 };
     static constexpr size_t LOOKUP_TUPLE_SIZE = 3;
-    static constexpr size_t INVERSE_EXISTS_POLYNOMIAL_DEGREE = 4;
-    static constexpr size_t READ_TERM_DEGREE = 0;
-    static constexpr size_t WRITE_TERM_DEGREE = 0;
-
-    // Columns using the Column enum.
     static constexpr Column SRC_SELECTOR = Column::instr_fetching_sel;
     static constexpr Column DST_SELECTOR = Column::bc_decomposition_sel;
     static constexpr Column COUNTS = Column::lookup_instr_fetching_bytecode_size_from_bc_dec_counts;
@@ -309,88 +101,20 @@ class lookup_instr_fetching_bytecode_size_from_bc_dec_settings {
         ColumnAndShifts::bc_decomposition_pc,
         ColumnAndShifts::bc_decomposition_bytes_remaining
     };
-
-    template <typename AllEntities> static inline auto inverse_polynomial_is_computed_at_row(const AllEntities& in)
-    {
-        return (in.get(ColumnAndShifts::instr_fetching_sel) == 1 || in.get(ColumnAndShifts::bc_decomposition_sel) == 1);
-    }
-
-    template <typename Accumulator, typename AllEntities>
-    static inline auto compute_inverse_exists(const AllEntities& in)
-    {
-        using View = typename Accumulator::View;
-        const auto is_operation = View(in.get(ColumnAndShifts::instr_fetching_sel));
-        const auto is_table_entry = View(in.get(ColumnAndShifts::bc_decomposition_sel));
-        return (is_operation + is_table_entry - is_operation * is_table_entry);
-    }
-
-    template <typename AllEntities> static inline auto get_const_entities(const AllEntities& in)
-    {
-        return get_entities(in);
-    }
-
-    template <typename AllEntities> static inline auto get_nonconst_entities(AllEntities& in)
-    {
-        return get_entities(in);
-    }
-
-    template <typename AllEntities> static inline auto get_entities(AllEntities&& in)
-    {
-        return std::forward_as_tuple(in.get(ColumnAndShifts::lookup_instr_fetching_bytecode_size_from_bc_dec_inv),
-                                     in.get(ColumnAndShifts::lookup_instr_fetching_bytecode_size_from_bc_dec_counts),
-                                     in.get(ColumnAndShifts::instr_fetching_sel),
-                                     in.get(ColumnAndShifts::bc_decomposition_sel),
-                                     in.get(ColumnAndShifts::instr_fetching_bytecode_id),
-                                     in.get(ColumnAndShifts::precomputed_zero),
-                                     in.get(ColumnAndShifts::instr_fetching_bytecode_size),
-                                     in.get(ColumnAndShifts::bc_decomposition_id),
-                                     in.get(ColumnAndShifts::bc_decomposition_pc),
-                                     in.get(ColumnAndShifts::bc_decomposition_bytes_remaining));
-    }
 };
 
+using lookup_instr_fetching_bytecode_size_from_bc_dec_settings =
+    lookup_settings<lookup_instr_fetching_bytecode_size_from_bc_dec_settings_>;
 template <typename FF_>
-class lookup_instr_fetching_bytecode_size_from_bc_dec_relation
-    : public GenericLookupRelation<lookup_instr_fetching_bytecode_size_from_bc_dec_settings, FF_> {
-  public:
-    using Settings = lookup_instr_fetching_bytecode_size_from_bc_dec_settings;
-    static constexpr std::string_view NAME = lookup_instr_fetching_bytecode_size_from_bc_dec_settings::NAME;
-    static constexpr std::string_view RELATION_NAME =
-        lookup_instr_fetching_bytecode_size_from_bc_dec_settings::RELATION_NAME;
-
-    template <typename AllEntities> inline static bool skip(const AllEntities& in)
-    {
-        return in.lookup_instr_fetching_bytecode_size_from_bc_dec_inv.is_zero();
-    }
-
-    static std::string get_subrelation_label(size_t index)
-    {
-        if (index == 0) {
-            return "INVERSES_ARE_CORRECT";
-        } else if (index == 1) {
-            return "ACCUMULATION_IS_CORRECT";
-        }
-        return std::to_string(index);
-    }
-};
+using lookup_instr_fetching_bytecode_size_from_bc_dec_relation =
+    lookup_relation_base<FF_, lookup_instr_fetching_bytecode_size_from_bc_dec_settings>;
 
 /////////////////// lookup_instr_fetching_bytes_from_bc_dec ///////////////////
 
-class lookup_instr_fetching_bytes_from_bc_dec_settings {
-  public:
+struct lookup_instr_fetching_bytes_from_bc_dec_settings_ {
     static constexpr std::string_view NAME = "LOOKUP_INSTR_FETCHING_BYTES_FROM_BC_DEC";
     static constexpr std::string_view RELATION_NAME = "instr_fetching";
-
-    static constexpr size_t READ_TERMS = 1;
-    static constexpr size_t WRITE_TERMS = 1;
-    static constexpr size_t READ_TERM_TYPES[READ_TERMS] = { 0 };
-    static constexpr size_t WRITE_TERM_TYPES[WRITE_TERMS] = { 0 };
     static constexpr size_t LOOKUP_TUPLE_SIZE = 40;
-    static constexpr size_t INVERSE_EXISTS_POLYNOMIAL_DEGREE = 4;
-    static constexpr size_t READ_TERM_DEGREE = 0;
-    static constexpr size_t WRITE_TERM_DEGREE = 0;
-
-    // Columns using the Column enum.
     static constexpr Column SRC_SELECTOR = Column::instr_fetching_sel_pc_in_range;
     static constexpr Column DST_SELECTOR = Column::bc_decomposition_sel;
     static constexpr Column COUNTS = Column::lookup_instr_fetching_bytes_from_bc_dec_counts;
@@ -459,162 +183,20 @@ class lookup_instr_fetching_bytes_from_bc_dec_settings {
         ColumnAndShifts::bc_decomposition_bytes_pc_plus_35,
         ColumnAndShifts::bc_decomposition_bytes_pc_plus_36
     };
-
-    template <typename AllEntities> static inline auto inverse_polynomial_is_computed_at_row(const AllEntities& in)
-    {
-        return (in.get(ColumnAndShifts::instr_fetching_sel_pc_in_range) == 1 ||
-                in.get(ColumnAndShifts::bc_decomposition_sel) == 1);
-    }
-
-    template <typename Accumulator, typename AllEntities>
-    static inline auto compute_inverse_exists(const AllEntities& in)
-    {
-        using View = typename Accumulator::View;
-        const auto is_operation = View(in.get(ColumnAndShifts::instr_fetching_sel_pc_in_range));
-        const auto is_table_entry = View(in.get(ColumnAndShifts::bc_decomposition_sel));
-        return (is_operation + is_table_entry - is_operation * is_table_entry);
-    }
-
-    template <typename AllEntities> static inline auto get_const_entities(const AllEntities& in)
-    {
-        return get_entities(in);
-    }
-
-    template <typename AllEntities> static inline auto get_nonconst_entities(AllEntities& in)
-    {
-        return get_entities(in);
-    }
-
-    template <typename AllEntities> static inline auto get_entities(AllEntities&& in)
-    {
-        return std::forward_as_tuple(in.get(ColumnAndShifts::lookup_instr_fetching_bytes_from_bc_dec_inv),
-                                     in.get(ColumnAndShifts::lookup_instr_fetching_bytes_from_bc_dec_counts),
-                                     in.get(ColumnAndShifts::instr_fetching_sel_pc_in_range),
-                                     in.get(ColumnAndShifts::bc_decomposition_sel),
-                                     in.get(ColumnAndShifts::instr_fetching_bytecode_id),
-                                     in.get(ColumnAndShifts::instr_fetching_pc),
-                                     in.get(ColumnAndShifts::instr_fetching_bytes_to_read),
-                                     in.get(ColumnAndShifts::instr_fetching_bd0),
-                                     in.get(ColumnAndShifts::instr_fetching_bd1),
-                                     in.get(ColumnAndShifts::instr_fetching_bd2),
-                                     in.get(ColumnAndShifts::instr_fetching_bd3),
-                                     in.get(ColumnAndShifts::instr_fetching_bd4),
-                                     in.get(ColumnAndShifts::instr_fetching_bd5),
-                                     in.get(ColumnAndShifts::instr_fetching_bd6),
-                                     in.get(ColumnAndShifts::instr_fetching_bd7),
-                                     in.get(ColumnAndShifts::instr_fetching_bd8),
-                                     in.get(ColumnAndShifts::instr_fetching_bd9),
-                                     in.get(ColumnAndShifts::instr_fetching_bd10),
-                                     in.get(ColumnAndShifts::instr_fetching_bd11),
-                                     in.get(ColumnAndShifts::instr_fetching_bd12),
-                                     in.get(ColumnAndShifts::instr_fetching_bd13),
-                                     in.get(ColumnAndShifts::instr_fetching_bd14),
-                                     in.get(ColumnAndShifts::instr_fetching_bd15),
-                                     in.get(ColumnAndShifts::instr_fetching_bd16),
-                                     in.get(ColumnAndShifts::instr_fetching_bd17),
-                                     in.get(ColumnAndShifts::instr_fetching_bd18),
-                                     in.get(ColumnAndShifts::instr_fetching_bd19),
-                                     in.get(ColumnAndShifts::instr_fetching_bd20),
-                                     in.get(ColumnAndShifts::instr_fetching_bd21),
-                                     in.get(ColumnAndShifts::instr_fetching_bd22),
-                                     in.get(ColumnAndShifts::instr_fetching_bd23),
-                                     in.get(ColumnAndShifts::instr_fetching_bd24),
-                                     in.get(ColumnAndShifts::instr_fetching_bd25),
-                                     in.get(ColumnAndShifts::instr_fetching_bd26),
-                                     in.get(ColumnAndShifts::instr_fetching_bd27),
-                                     in.get(ColumnAndShifts::instr_fetching_bd28),
-                                     in.get(ColumnAndShifts::instr_fetching_bd29),
-                                     in.get(ColumnAndShifts::instr_fetching_bd30),
-                                     in.get(ColumnAndShifts::instr_fetching_bd31),
-                                     in.get(ColumnAndShifts::instr_fetching_bd32),
-                                     in.get(ColumnAndShifts::instr_fetching_bd33),
-                                     in.get(ColumnAndShifts::instr_fetching_bd34),
-                                     in.get(ColumnAndShifts::instr_fetching_bd35),
-                                     in.get(ColumnAndShifts::instr_fetching_bd36),
-                                     in.get(ColumnAndShifts::bc_decomposition_id),
-                                     in.get(ColumnAndShifts::bc_decomposition_pc),
-                                     in.get(ColumnAndShifts::bc_decomposition_bytes_to_read),
-                                     in.get(ColumnAndShifts::bc_decomposition_bytes),
-                                     in.get(ColumnAndShifts::bc_decomposition_bytes_pc_plus_1),
-                                     in.get(ColumnAndShifts::bc_decomposition_bytes_pc_plus_2),
-                                     in.get(ColumnAndShifts::bc_decomposition_bytes_pc_plus_3),
-                                     in.get(ColumnAndShifts::bc_decomposition_bytes_pc_plus_4),
-                                     in.get(ColumnAndShifts::bc_decomposition_bytes_pc_plus_5),
-                                     in.get(ColumnAndShifts::bc_decomposition_bytes_pc_plus_6),
-                                     in.get(ColumnAndShifts::bc_decomposition_bytes_pc_plus_7),
-                                     in.get(ColumnAndShifts::bc_decomposition_bytes_pc_plus_8),
-                                     in.get(ColumnAndShifts::bc_decomposition_bytes_pc_plus_9),
-                                     in.get(ColumnAndShifts::bc_decomposition_bytes_pc_plus_10),
-                                     in.get(ColumnAndShifts::bc_decomposition_bytes_pc_plus_11),
-                                     in.get(ColumnAndShifts::bc_decomposition_bytes_pc_plus_12),
-                                     in.get(ColumnAndShifts::bc_decomposition_bytes_pc_plus_13),
-                                     in.get(ColumnAndShifts::bc_decomposition_bytes_pc_plus_14),
-                                     in.get(ColumnAndShifts::bc_decomposition_bytes_pc_plus_15),
-                                     in.get(ColumnAndShifts::bc_decomposition_bytes_pc_plus_16),
-                                     in.get(ColumnAndShifts::bc_decomposition_bytes_pc_plus_17),
-                                     in.get(ColumnAndShifts::bc_decomposition_bytes_pc_plus_18),
-                                     in.get(ColumnAndShifts::bc_decomposition_bytes_pc_plus_19),
-                                     in.get(ColumnAndShifts::bc_decomposition_bytes_pc_plus_20),
-                                     in.get(ColumnAndShifts::bc_decomposition_bytes_pc_plus_21),
-                                     in.get(ColumnAndShifts::bc_decomposition_bytes_pc_plus_22),
-                                     in.get(ColumnAndShifts::bc_decomposition_bytes_pc_plus_23),
-                                     in.get(ColumnAndShifts::bc_decomposition_bytes_pc_plus_24),
-                                     in.get(ColumnAndShifts::bc_decomposition_bytes_pc_plus_25),
-                                     in.get(ColumnAndShifts::bc_decomposition_bytes_pc_plus_26),
-                                     in.get(ColumnAndShifts::bc_decomposition_bytes_pc_plus_27),
-                                     in.get(ColumnAndShifts::bc_decomposition_bytes_pc_plus_28),
-                                     in.get(ColumnAndShifts::bc_decomposition_bytes_pc_plus_29),
-                                     in.get(ColumnAndShifts::bc_decomposition_bytes_pc_plus_30),
-                                     in.get(ColumnAndShifts::bc_decomposition_bytes_pc_plus_31),
-                                     in.get(ColumnAndShifts::bc_decomposition_bytes_pc_plus_32),
-                                     in.get(ColumnAndShifts::bc_decomposition_bytes_pc_plus_33),
-                                     in.get(ColumnAndShifts::bc_decomposition_bytes_pc_plus_34),
-                                     in.get(ColumnAndShifts::bc_decomposition_bytes_pc_plus_35),
-                                     in.get(ColumnAndShifts::bc_decomposition_bytes_pc_plus_36));
-    }
 };
 
+using lookup_instr_fetching_bytes_from_bc_dec_settings =
+    lookup_settings<lookup_instr_fetching_bytes_from_bc_dec_settings_>;
 template <typename FF_>
-class lookup_instr_fetching_bytes_from_bc_dec_relation
-    : public GenericLookupRelation<lookup_instr_fetching_bytes_from_bc_dec_settings, FF_> {
-  public:
-    using Settings = lookup_instr_fetching_bytes_from_bc_dec_settings;
-    static constexpr std::string_view NAME = lookup_instr_fetching_bytes_from_bc_dec_settings::NAME;
-    static constexpr std::string_view RELATION_NAME = lookup_instr_fetching_bytes_from_bc_dec_settings::RELATION_NAME;
-
-    template <typename AllEntities> inline static bool skip(const AllEntities& in)
-    {
-        return in.lookup_instr_fetching_bytes_from_bc_dec_inv.is_zero();
-    }
-
-    static std::string get_subrelation_label(size_t index)
-    {
-        if (index == 0) {
-            return "INVERSES_ARE_CORRECT";
-        } else if (index == 1) {
-            return "ACCUMULATION_IS_CORRECT";
-        }
-        return std::to_string(index);
-    }
-};
+using lookup_instr_fetching_bytes_from_bc_dec_relation =
+    lookup_relation_base<FF_, lookup_instr_fetching_bytes_from_bc_dec_settings>;
 
 /////////////////// lookup_instr_fetching_wire_instruction_info ///////////////////
 
-class lookup_instr_fetching_wire_instruction_info_settings {
-  public:
+struct lookup_instr_fetching_wire_instruction_info_settings_ {
     static constexpr std::string_view NAME = "LOOKUP_INSTR_FETCHING_WIRE_INSTRUCTION_INFO";
     static constexpr std::string_view RELATION_NAME = "instr_fetching";
-
-    static constexpr size_t READ_TERMS = 1;
-    static constexpr size_t WRITE_TERMS = 1;
-    static constexpr size_t READ_TERM_TYPES[READ_TERMS] = { 0 };
-    static constexpr size_t WRITE_TERM_TYPES[WRITE_TERMS] = { 0 };
     static constexpr size_t LOOKUP_TUPLE_SIZE = 24;
-    static constexpr size_t INVERSE_EXISTS_POLYNOMIAL_DEGREE = 4;
-    static constexpr size_t READ_TERM_DEGREE = 0;
-    static constexpr size_t WRITE_TERM_DEGREE = 0;
-
-    // Columns using the Column enum.
     static constexpr Column SRC_SELECTOR = Column::instr_fetching_sel_pc_in_range;
     static constexpr Column DST_SELECTOR = Column::precomputed_sel_range_8;
     static constexpr Column COUNTS = Column::lookup_instr_fetching_wire_instruction_info_counts;
@@ -647,112 +229,12 @@ class lookup_instr_fetching_wire_instruction_info_settings {
         ColumnAndShifts::precomputed_sel_op_dc_14, ColumnAndShifts::precomputed_sel_op_dc_15,
         ColumnAndShifts::precomputed_sel_op_dc_16, ColumnAndShifts::precomputed_sel_op_dc_17
     };
-
-    template <typename AllEntities> static inline auto inverse_polynomial_is_computed_at_row(const AllEntities& in)
-    {
-        return (in.get(ColumnAndShifts::instr_fetching_sel_pc_in_range) == 1 ||
-                in.get(ColumnAndShifts::precomputed_sel_range_8) == 1);
-    }
-
-    template <typename Accumulator, typename AllEntities>
-    static inline auto compute_inverse_exists(const AllEntities& in)
-    {
-        using View = typename Accumulator::View;
-        const auto is_operation = View(in.get(ColumnAndShifts::instr_fetching_sel_pc_in_range));
-        const auto is_table_entry = View(in.get(ColumnAndShifts::precomputed_sel_range_8));
-        return (is_operation + is_table_entry - is_operation * is_table_entry);
-    }
-
-    template <typename AllEntities> static inline auto get_const_entities(const AllEntities& in)
-    {
-        return get_entities(in);
-    }
-
-    template <typename AllEntities> static inline auto get_nonconst_entities(AllEntities& in)
-    {
-        return get_entities(in);
-    }
-
-    template <typename AllEntities> static inline auto get_entities(AllEntities&& in)
-    {
-        return std::forward_as_tuple(in.get(ColumnAndShifts::lookup_instr_fetching_wire_instruction_info_inv),
-                                     in.get(ColumnAndShifts::lookup_instr_fetching_wire_instruction_info_counts),
-                                     in.get(ColumnAndShifts::instr_fetching_sel_pc_in_range),
-                                     in.get(ColumnAndShifts::precomputed_sel_range_8),
-                                     in.get(ColumnAndShifts::instr_fetching_bd0),
-                                     in.get(ColumnAndShifts::instr_fetching_opcode_out_of_range),
-                                     in.get(ColumnAndShifts::instr_fetching_exec_opcode),
-                                     in.get(ColumnAndShifts::instr_fetching_instr_size),
-                                     in.get(ColumnAndShifts::instr_fetching_sel_has_tag),
-                                     in.get(ColumnAndShifts::instr_fetching_sel_tag_is_op2),
-                                     in.get(ColumnAndShifts::instr_fetching_sel_op_dc_0),
-                                     in.get(ColumnAndShifts::instr_fetching_sel_op_dc_1),
-                                     in.get(ColumnAndShifts::instr_fetching_sel_op_dc_2),
-                                     in.get(ColumnAndShifts::instr_fetching_sel_op_dc_3),
-                                     in.get(ColumnAndShifts::instr_fetching_sel_op_dc_4),
-                                     in.get(ColumnAndShifts::instr_fetching_sel_op_dc_5),
-                                     in.get(ColumnAndShifts::instr_fetching_sel_op_dc_6),
-                                     in.get(ColumnAndShifts::instr_fetching_sel_op_dc_7),
-                                     in.get(ColumnAndShifts::instr_fetching_sel_op_dc_8),
-                                     in.get(ColumnAndShifts::instr_fetching_sel_op_dc_9),
-                                     in.get(ColumnAndShifts::instr_fetching_sel_op_dc_10),
-                                     in.get(ColumnAndShifts::instr_fetching_sel_op_dc_11),
-                                     in.get(ColumnAndShifts::instr_fetching_sel_op_dc_12),
-                                     in.get(ColumnAndShifts::instr_fetching_sel_op_dc_13),
-                                     in.get(ColumnAndShifts::instr_fetching_sel_op_dc_14),
-                                     in.get(ColumnAndShifts::instr_fetching_sel_op_dc_15),
-                                     in.get(ColumnAndShifts::instr_fetching_sel_op_dc_16),
-                                     in.get(ColumnAndShifts::instr_fetching_sel_op_dc_17),
-                                     in.get(ColumnAndShifts::precomputed_clk),
-                                     in.get(ColumnAndShifts::precomputed_opcode_out_of_range),
-                                     in.get(ColumnAndShifts::precomputed_exec_opcode),
-                                     in.get(ColumnAndShifts::precomputed_instr_size),
-                                     in.get(ColumnAndShifts::precomputed_sel_has_tag),
-                                     in.get(ColumnAndShifts::precomputed_sel_tag_is_op2),
-                                     in.get(ColumnAndShifts::precomputed_sel_op_dc_0),
-                                     in.get(ColumnAndShifts::precomputed_sel_op_dc_1),
-                                     in.get(ColumnAndShifts::precomputed_sel_op_dc_2),
-                                     in.get(ColumnAndShifts::precomputed_sel_op_dc_3),
-                                     in.get(ColumnAndShifts::precomputed_sel_op_dc_4),
-                                     in.get(ColumnAndShifts::precomputed_sel_op_dc_5),
-                                     in.get(ColumnAndShifts::precomputed_sel_op_dc_6),
-                                     in.get(ColumnAndShifts::precomputed_sel_op_dc_7),
-                                     in.get(ColumnAndShifts::precomputed_sel_op_dc_8),
-                                     in.get(ColumnAndShifts::precomputed_sel_op_dc_9),
-                                     in.get(ColumnAndShifts::precomputed_sel_op_dc_10),
-                                     in.get(ColumnAndShifts::precomputed_sel_op_dc_11),
-                                     in.get(ColumnAndShifts::precomputed_sel_op_dc_12),
-                                     in.get(ColumnAndShifts::precomputed_sel_op_dc_13),
-                                     in.get(ColumnAndShifts::precomputed_sel_op_dc_14),
-                                     in.get(ColumnAndShifts::precomputed_sel_op_dc_15),
-                                     in.get(ColumnAndShifts::precomputed_sel_op_dc_16),
-                                     in.get(ColumnAndShifts::precomputed_sel_op_dc_17));
-    }
 };
 
+using lookup_instr_fetching_wire_instruction_info_settings =
+    lookup_settings<lookup_instr_fetching_wire_instruction_info_settings_>;
 template <typename FF_>
-class lookup_instr_fetching_wire_instruction_info_relation
-    : public GenericLookupRelation<lookup_instr_fetching_wire_instruction_info_settings, FF_> {
-  public:
-    using Settings = lookup_instr_fetching_wire_instruction_info_settings;
-    static constexpr std::string_view NAME = lookup_instr_fetching_wire_instruction_info_settings::NAME;
-    static constexpr std::string_view RELATION_NAME =
-        lookup_instr_fetching_wire_instruction_info_settings::RELATION_NAME;
-
-    template <typename AllEntities> inline static bool skip(const AllEntities& in)
-    {
-        return in.lookup_instr_fetching_wire_instruction_info_inv.is_zero();
-    }
-
-    static std::string get_subrelation_label(size_t index)
-    {
-        if (index == 0) {
-            return "INVERSES_ARE_CORRECT";
-        } else if (index == 1) {
-            return "ACCUMULATION_IS_CORRECT";
-        }
-        return std::to_string(index);
-    }
-};
+using lookup_instr_fetching_wire_instruction_info_relation =
+    lookup_relation_base<FF_, lookup_instr_fetching_wire_instruction_info_settings>;
 
 } // namespace bb::avm2

--- a/barretenberg/cpp/src/barretenberg/vm2/generated/relations/lookups_merkle_check.hpp
+++ b/barretenberg/cpp/src/barretenberg/vm2/generated/relations/lookups_merkle_check.hpp
@@ -3,6 +3,7 @@
 
 #include "../columns.hpp"
 #include "barretenberg/relations/generic_lookup/generic_lookup_relation.hpp"
+#include "barretenberg/vm2/constraining/relations/interactions_base.hpp"
 
 #include <cstddef>
 #include <string_view>
@@ -12,21 +13,10 @@ namespace bb::avm2 {
 
 /////////////////// lookup_merkle_check_merkle_poseidon2_read ///////////////////
 
-class lookup_merkle_check_merkle_poseidon2_read_settings {
-  public:
+struct lookup_merkle_check_merkle_poseidon2_read_settings_ {
     static constexpr std::string_view NAME = "LOOKUP_MERKLE_CHECK_MERKLE_POSEIDON2_READ";
     static constexpr std::string_view RELATION_NAME = "merkle_check";
-
-    static constexpr size_t READ_TERMS = 1;
-    static constexpr size_t WRITE_TERMS = 1;
-    static constexpr size_t READ_TERM_TYPES[READ_TERMS] = { 0 };
-    static constexpr size_t WRITE_TERM_TYPES[WRITE_TERMS] = { 0 };
     static constexpr size_t LOOKUP_TUPLE_SIZE = 5;
-    static constexpr size_t INVERSE_EXISTS_POLYNOMIAL_DEGREE = 4;
-    static constexpr size_t READ_TERM_DEGREE = 0;
-    static constexpr size_t WRITE_TERM_DEGREE = 0;
-
-    // Columns using the Column enum.
     static constexpr Column SRC_SELECTOR = Column::merkle_check_sel;
     static constexpr Column DST_SELECTOR = Column::poseidon2_hash_end;
     static constexpr Column COUNTS = Column::lookup_merkle_check_merkle_poseidon2_read_counts;
@@ -45,91 +35,20 @@ class lookup_merkle_check_merkle_poseidon2_read_settings {
         ColumnAndShifts::poseidon2_hash_input_len,
         ColumnAndShifts::poseidon2_hash_output
     };
-
-    template <typename AllEntities> static inline auto inverse_polynomial_is_computed_at_row(const AllEntities& in)
-    {
-        return (in.get(ColumnAndShifts::merkle_check_sel) == 1 || in.get(ColumnAndShifts::poseidon2_hash_end) == 1);
-    }
-
-    template <typename Accumulator, typename AllEntities>
-    static inline auto compute_inverse_exists(const AllEntities& in)
-    {
-        using View = typename Accumulator::View;
-        const auto is_operation = View(in.get(ColumnAndShifts::merkle_check_sel));
-        const auto is_table_entry = View(in.get(ColumnAndShifts::poseidon2_hash_end));
-        return (is_operation + is_table_entry - is_operation * is_table_entry);
-    }
-
-    template <typename AllEntities> static inline auto get_const_entities(const AllEntities& in)
-    {
-        return get_entities(in);
-    }
-
-    template <typename AllEntities> static inline auto get_nonconst_entities(AllEntities& in)
-    {
-        return get_entities(in);
-    }
-
-    template <typename AllEntities> static inline auto get_entities(AllEntities&& in)
-    {
-        return std::forward_as_tuple(in.get(ColumnAndShifts::lookup_merkle_check_merkle_poseidon2_read_inv),
-                                     in.get(ColumnAndShifts::lookup_merkle_check_merkle_poseidon2_read_counts),
-                                     in.get(ColumnAndShifts::merkle_check_sel),
-                                     in.get(ColumnAndShifts::poseidon2_hash_end),
-                                     in.get(ColumnAndShifts::merkle_check_read_left_node),
-                                     in.get(ColumnAndShifts::merkle_check_read_right_node),
-                                     in.get(ColumnAndShifts::precomputed_zero),
-                                     in.get(ColumnAndShifts::merkle_check_constant_2),
-                                     in.get(ColumnAndShifts::merkle_check_read_output_hash),
-                                     in.get(ColumnAndShifts::poseidon2_hash_input_0),
-                                     in.get(ColumnAndShifts::poseidon2_hash_input_1),
-                                     in.get(ColumnAndShifts::poseidon2_hash_input_2),
-                                     in.get(ColumnAndShifts::poseidon2_hash_input_len),
-                                     in.get(ColumnAndShifts::poseidon2_hash_output));
-    }
 };
 
+using lookup_merkle_check_merkle_poseidon2_read_settings =
+    lookup_settings<lookup_merkle_check_merkle_poseidon2_read_settings_>;
 template <typename FF_>
-class lookup_merkle_check_merkle_poseidon2_read_relation
-    : public GenericLookupRelation<lookup_merkle_check_merkle_poseidon2_read_settings, FF_> {
-  public:
-    using Settings = lookup_merkle_check_merkle_poseidon2_read_settings;
-    static constexpr std::string_view NAME = lookup_merkle_check_merkle_poseidon2_read_settings::NAME;
-    static constexpr std::string_view RELATION_NAME = lookup_merkle_check_merkle_poseidon2_read_settings::RELATION_NAME;
-
-    template <typename AllEntities> inline static bool skip(const AllEntities& in)
-    {
-        return in.lookup_merkle_check_merkle_poseidon2_read_inv.is_zero();
-    }
-
-    static std::string get_subrelation_label(size_t index)
-    {
-        if (index == 0) {
-            return "INVERSES_ARE_CORRECT";
-        } else if (index == 1) {
-            return "ACCUMULATION_IS_CORRECT";
-        }
-        return std::to_string(index);
-    }
-};
+using lookup_merkle_check_merkle_poseidon2_read_relation =
+    lookup_relation_base<FF_, lookup_merkle_check_merkle_poseidon2_read_settings>;
 
 /////////////////// lookup_merkle_check_merkle_poseidon2_write ///////////////////
 
-class lookup_merkle_check_merkle_poseidon2_write_settings {
-  public:
+struct lookup_merkle_check_merkle_poseidon2_write_settings_ {
     static constexpr std::string_view NAME = "LOOKUP_MERKLE_CHECK_MERKLE_POSEIDON2_WRITE";
     static constexpr std::string_view RELATION_NAME = "merkle_check";
-
-    static constexpr size_t READ_TERMS = 1;
-    static constexpr size_t WRITE_TERMS = 1;
-    static constexpr size_t READ_TERM_TYPES[READ_TERMS] = { 0 };
-    static constexpr size_t WRITE_TERM_TYPES[WRITE_TERMS] = { 0 };
     static constexpr size_t LOOKUP_TUPLE_SIZE = 5;
-    static constexpr size_t INVERSE_EXISTS_POLYNOMIAL_DEGREE = 4;
-    static constexpr size_t READ_TERM_DEGREE = 0;
-    static constexpr size_t WRITE_TERM_DEGREE = 0;
-
-    // Columns using the Column enum.
     static constexpr Column SRC_SELECTOR = Column::merkle_check_write;
     static constexpr Column DST_SELECTOR = Column::poseidon2_hash_end;
     static constexpr Column COUNTS = Column::lookup_merkle_check_merkle_poseidon2_write_counts;
@@ -148,73 +67,12 @@ class lookup_merkle_check_merkle_poseidon2_write_settings {
         ColumnAndShifts::poseidon2_hash_input_len,
         ColumnAndShifts::poseidon2_hash_output
     };
-
-    template <typename AllEntities> static inline auto inverse_polynomial_is_computed_at_row(const AllEntities& in)
-    {
-        return (in.get(ColumnAndShifts::merkle_check_write) == 1 || in.get(ColumnAndShifts::poseidon2_hash_end) == 1);
-    }
-
-    template <typename Accumulator, typename AllEntities>
-    static inline auto compute_inverse_exists(const AllEntities& in)
-    {
-        using View = typename Accumulator::View;
-        const auto is_operation = View(in.get(ColumnAndShifts::merkle_check_write));
-        const auto is_table_entry = View(in.get(ColumnAndShifts::poseidon2_hash_end));
-        return (is_operation + is_table_entry - is_operation * is_table_entry);
-    }
-
-    template <typename AllEntities> static inline auto get_const_entities(const AllEntities& in)
-    {
-        return get_entities(in);
-    }
-
-    template <typename AllEntities> static inline auto get_nonconst_entities(AllEntities& in)
-    {
-        return get_entities(in);
-    }
-
-    template <typename AllEntities> static inline auto get_entities(AllEntities&& in)
-    {
-        return std::forward_as_tuple(in.get(ColumnAndShifts::lookup_merkle_check_merkle_poseidon2_write_inv),
-                                     in.get(ColumnAndShifts::lookup_merkle_check_merkle_poseidon2_write_counts),
-                                     in.get(ColumnAndShifts::merkle_check_write),
-                                     in.get(ColumnAndShifts::poseidon2_hash_end),
-                                     in.get(ColumnAndShifts::merkle_check_write_left_node),
-                                     in.get(ColumnAndShifts::merkle_check_write_right_node),
-                                     in.get(ColumnAndShifts::precomputed_zero),
-                                     in.get(ColumnAndShifts::merkle_check_constant_2),
-                                     in.get(ColumnAndShifts::merkle_check_write_output_hash),
-                                     in.get(ColumnAndShifts::poseidon2_hash_input_0),
-                                     in.get(ColumnAndShifts::poseidon2_hash_input_1),
-                                     in.get(ColumnAndShifts::poseidon2_hash_input_2),
-                                     in.get(ColumnAndShifts::poseidon2_hash_input_len),
-                                     in.get(ColumnAndShifts::poseidon2_hash_output));
-    }
 };
 
+using lookup_merkle_check_merkle_poseidon2_write_settings =
+    lookup_settings<lookup_merkle_check_merkle_poseidon2_write_settings_>;
 template <typename FF_>
-class lookup_merkle_check_merkle_poseidon2_write_relation
-    : public GenericLookupRelation<lookup_merkle_check_merkle_poseidon2_write_settings, FF_> {
-  public:
-    using Settings = lookup_merkle_check_merkle_poseidon2_write_settings;
-    static constexpr std::string_view NAME = lookup_merkle_check_merkle_poseidon2_write_settings::NAME;
-    static constexpr std::string_view RELATION_NAME =
-        lookup_merkle_check_merkle_poseidon2_write_settings::RELATION_NAME;
-
-    template <typename AllEntities> inline static bool skip(const AllEntities& in)
-    {
-        return in.lookup_merkle_check_merkle_poseidon2_write_inv.is_zero();
-    }
-
-    static std::string get_subrelation_label(size_t index)
-    {
-        if (index == 0) {
-            return "INVERSES_ARE_CORRECT";
-        } else if (index == 1) {
-            return "ACCUMULATION_IS_CORRECT";
-        }
-        return std::to_string(index);
-    }
-};
+using lookup_merkle_check_merkle_poseidon2_write_relation =
+    lookup_relation_base<FF_, lookup_merkle_check_merkle_poseidon2_write_settings>;
 
 } // namespace bb::avm2

--- a/barretenberg/cpp/src/barretenberg/vm2/generated/relations/lookups_nullifier_check.hpp
+++ b/barretenberg/cpp/src/barretenberg/vm2/generated/relations/lookups_nullifier_check.hpp
@@ -3,6 +3,7 @@
 
 #include "../columns.hpp"
 #include "barretenberg/relations/generic_lookup/generic_lookup_relation.hpp"
+#include "barretenberg/vm2/constraining/relations/interactions_base.hpp"
 
 #include <cstddef>
 #include <string_view>
@@ -12,21 +13,10 @@ namespace bb::avm2 {
 
 /////////////////// lookup_nullifier_check_low_leaf_poseidon2 ///////////////////
 
-class lookup_nullifier_check_low_leaf_poseidon2_settings {
-  public:
+struct lookup_nullifier_check_low_leaf_poseidon2_settings_ {
     static constexpr std::string_view NAME = "LOOKUP_NULLIFIER_CHECK_LOW_LEAF_POSEIDON2";
     static constexpr std::string_view RELATION_NAME = "nullifier_check";
-
-    static constexpr size_t READ_TERMS = 1;
-    static constexpr size_t WRITE_TERMS = 1;
-    static constexpr size_t READ_TERM_TYPES[READ_TERMS] = { 0 };
-    static constexpr size_t WRITE_TERM_TYPES[WRITE_TERMS] = { 0 };
     static constexpr size_t LOOKUP_TUPLE_SIZE = 4;
-    static constexpr size_t INVERSE_EXISTS_POLYNOMIAL_DEGREE = 4;
-    static constexpr size_t READ_TERM_DEGREE = 0;
-    static constexpr size_t WRITE_TERM_DEGREE = 0;
-
-    // Columns using the Column enum.
     static constexpr Column SRC_SELECTOR = Column::nullifier_check_sel;
     static constexpr Column DST_SELECTOR = Column::poseidon2_hash_end;
     static constexpr Column COUNTS = Column::lookup_nullifier_check_low_leaf_poseidon2_counts;
@@ -43,89 +33,20 @@ class lookup_nullifier_check_low_leaf_poseidon2_settings {
         ColumnAndShifts::poseidon2_hash_input_2,
         ColumnAndShifts::poseidon2_hash_output
     };
-
-    template <typename AllEntities> static inline auto inverse_polynomial_is_computed_at_row(const AllEntities& in)
-    {
-        return (in.get(ColumnAndShifts::nullifier_check_sel) == 1 || in.get(ColumnAndShifts::poseidon2_hash_end) == 1);
-    }
-
-    template <typename Accumulator, typename AllEntities>
-    static inline auto compute_inverse_exists(const AllEntities& in)
-    {
-        using View = typename Accumulator::View;
-        const auto is_operation = View(in.get(ColumnAndShifts::nullifier_check_sel));
-        const auto is_table_entry = View(in.get(ColumnAndShifts::poseidon2_hash_end));
-        return (is_operation + is_table_entry - is_operation * is_table_entry);
-    }
-
-    template <typename AllEntities> static inline auto get_const_entities(const AllEntities& in)
-    {
-        return get_entities(in);
-    }
-
-    template <typename AllEntities> static inline auto get_nonconst_entities(AllEntities& in)
-    {
-        return get_entities(in);
-    }
-
-    template <typename AllEntities> static inline auto get_entities(AllEntities&& in)
-    {
-        return std::forward_as_tuple(in.get(ColumnAndShifts::lookup_nullifier_check_low_leaf_poseidon2_inv),
-                                     in.get(ColumnAndShifts::lookup_nullifier_check_low_leaf_poseidon2_counts),
-                                     in.get(ColumnAndShifts::nullifier_check_sel),
-                                     in.get(ColumnAndShifts::poseidon2_hash_end),
-                                     in.get(ColumnAndShifts::nullifier_check_low_leaf_nullifier),
-                                     in.get(ColumnAndShifts::nullifier_check_low_leaf_next_nullifier),
-                                     in.get(ColumnAndShifts::nullifier_check_low_leaf_next_index),
-                                     in.get(ColumnAndShifts::nullifier_check_low_leaf_hash),
-                                     in.get(ColumnAndShifts::poseidon2_hash_input_0),
-                                     in.get(ColumnAndShifts::poseidon2_hash_input_1),
-                                     in.get(ColumnAndShifts::poseidon2_hash_input_2),
-                                     in.get(ColumnAndShifts::poseidon2_hash_output));
-    }
 };
 
+using lookup_nullifier_check_low_leaf_poseidon2_settings =
+    lookup_settings<lookup_nullifier_check_low_leaf_poseidon2_settings_>;
 template <typename FF_>
-class lookup_nullifier_check_low_leaf_poseidon2_relation
-    : public GenericLookupRelation<lookup_nullifier_check_low_leaf_poseidon2_settings, FF_> {
-  public:
-    using Settings = lookup_nullifier_check_low_leaf_poseidon2_settings;
-    static constexpr std::string_view NAME = lookup_nullifier_check_low_leaf_poseidon2_settings::NAME;
-    static constexpr std::string_view RELATION_NAME = lookup_nullifier_check_low_leaf_poseidon2_settings::RELATION_NAME;
-
-    template <typename AllEntities> inline static bool skip(const AllEntities& in)
-    {
-        return in.lookup_nullifier_check_low_leaf_poseidon2_inv.is_zero();
-    }
-
-    static std::string get_subrelation_label(size_t index)
-    {
-        if (index == 0) {
-            return "INVERSES_ARE_CORRECT";
-        } else if (index == 1) {
-            return "ACCUMULATION_IS_CORRECT";
-        }
-        return std::to_string(index);
-    }
-};
+using lookup_nullifier_check_low_leaf_poseidon2_relation =
+    lookup_relation_base<FF_, lookup_nullifier_check_low_leaf_poseidon2_settings>;
 
 /////////////////// lookup_nullifier_check_updated_low_leaf_poseidon2 ///////////////////
 
-class lookup_nullifier_check_updated_low_leaf_poseidon2_settings {
-  public:
+struct lookup_nullifier_check_updated_low_leaf_poseidon2_settings_ {
     static constexpr std::string_view NAME = "LOOKUP_NULLIFIER_CHECK_UPDATED_LOW_LEAF_POSEIDON2";
     static constexpr std::string_view RELATION_NAME = "nullifier_check";
-
-    static constexpr size_t READ_TERMS = 1;
-    static constexpr size_t WRITE_TERMS = 1;
-    static constexpr size_t READ_TERM_TYPES[READ_TERMS] = { 0 };
-    static constexpr size_t WRITE_TERM_TYPES[WRITE_TERMS] = { 0 };
     static constexpr size_t LOOKUP_TUPLE_SIZE = 4;
-    static constexpr size_t INVERSE_EXISTS_POLYNOMIAL_DEGREE = 4;
-    static constexpr size_t READ_TERM_DEGREE = 0;
-    static constexpr size_t WRITE_TERM_DEGREE = 0;
-
-    // Columns using the Column enum.
     static constexpr Column SRC_SELECTOR = Column::nullifier_check_write;
     static constexpr Column DST_SELECTOR = Column::poseidon2_hash_end;
     static constexpr Column COUNTS = Column::lookup_nullifier_check_updated_low_leaf_poseidon2_counts;
@@ -142,91 +63,20 @@ class lookup_nullifier_check_updated_low_leaf_poseidon2_settings {
         ColumnAndShifts::poseidon2_hash_input_2,
         ColumnAndShifts::poseidon2_hash_output
     };
-
-    template <typename AllEntities> static inline auto inverse_polynomial_is_computed_at_row(const AllEntities& in)
-    {
-        return (in.get(ColumnAndShifts::nullifier_check_write) == 1 ||
-                in.get(ColumnAndShifts::poseidon2_hash_end) == 1);
-    }
-
-    template <typename Accumulator, typename AllEntities>
-    static inline auto compute_inverse_exists(const AllEntities& in)
-    {
-        using View = typename Accumulator::View;
-        const auto is_operation = View(in.get(ColumnAndShifts::nullifier_check_write));
-        const auto is_table_entry = View(in.get(ColumnAndShifts::poseidon2_hash_end));
-        return (is_operation + is_table_entry - is_operation * is_table_entry);
-    }
-
-    template <typename AllEntities> static inline auto get_const_entities(const AllEntities& in)
-    {
-        return get_entities(in);
-    }
-
-    template <typename AllEntities> static inline auto get_nonconst_entities(AllEntities& in)
-    {
-        return get_entities(in);
-    }
-
-    template <typename AllEntities> static inline auto get_entities(AllEntities&& in)
-    {
-        return std::forward_as_tuple(in.get(ColumnAndShifts::lookup_nullifier_check_updated_low_leaf_poseidon2_inv),
-                                     in.get(ColumnAndShifts::lookup_nullifier_check_updated_low_leaf_poseidon2_counts),
-                                     in.get(ColumnAndShifts::nullifier_check_write),
-                                     in.get(ColumnAndShifts::poseidon2_hash_end),
-                                     in.get(ColumnAndShifts::nullifier_check_low_leaf_nullifier),
-                                     in.get(ColumnAndShifts::nullifier_check_write_low_leaf_next_nullifier),
-                                     in.get(ColumnAndShifts::nullifier_check_write_low_leaf_next_index),
-                                     in.get(ColumnAndShifts::nullifier_check_updated_low_leaf_hash),
-                                     in.get(ColumnAndShifts::poseidon2_hash_input_0),
-                                     in.get(ColumnAndShifts::poseidon2_hash_input_1),
-                                     in.get(ColumnAndShifts::poseidon2_hash_input_2),
-                                     in.get(ColumnAndShifts::poseidon2_hash_output));
-    }
 };
 
+using lookup_nullifier_check_updated_low_leaf_poseidon2_settings =
+    lookup_settings<lookup_nullifier_check_updated_low_leaf_poseidon2_settings_>;
 template <typename FF_>
-class lookup_nullifier_check_updated_low_leaf_poseidon2_relation
-    : public GenericLookupRelation<lookup_nullifier_check_updated_low_leaf_poseidon2_settings, FF_> {
-  public:
-    using Settings = lookup_nullifier_check_updated_low_leaf_poseidon2_settings;
-    static constexpr std::string_view NAME = lookup_nullifier_check_updated_low_leaf_poseidon2_settings::NAME;
-    static constexpr std::string_view RELATION_NAME =
-        lookup_nullifier_check_updated_low_leaf_poseidon2_settings::RELATION_NAME;
-
-    template <typename AllEntities> inline static bool skip(const AllEntities& in)
-    {
-        return in.lookup_nullifier_check_updated_low_leaf_poseidon2_inv.is_zero();
-    }
-
-    static std::string get_subrelation_label(size_t index)
-    {
-        if (index == 0) {
-            return "INVERSES_ARE_CORRECT";
-        } else if (index == 1) {
-            return "ACCUMULATION_IS_CORRECT";
-        }
-        return std::to_string(index);
-    }
-};
+using lookup_nullifier_check_updated_low_leaf_poseidon2_relation =
+    lookup_relation_base<FF_, lookup_nullifier_check_updated_low_leaf_poseidon2_settings>;
 
 /////////////////// lookup_nullifier_check_low_leaf_merkle_check ///////////////////
 
-class lookup_nullifier_check_low_leaf_merkle_check_settings {
-  public:
+struct lookup_nullifier_check_low_leaf_merkle_check_settings_ {
     static constexpr std::string_view NAME = "LOOKUP_NULLIFIER_CHECK_LOW_LEAF_MERKLE_CHECK";
     static constexpr std::string_view RELATION_NAME = "nullifier_check";
-
-    static constexpr size_t READ_TERMS = 1;
-    static constexpr size_t WRITE_TERMS = 1;
-    static constexpr size_t READ_TERM_TYPES[READ_TERMS] = { 0 };
-    static constexpr size_t WRITE_TERM_TYPES[WRITE_TERMS] = { 0 };
     static constexpr size_t LOOKUP_TUPLE_SIZE = 7;
-    static constexpr size_t INVERSE_EXISTS_POLYNOMIAL_DEGREE = 4;
-    static constexpr size_t READ_TERM_DEGREE = 0;
-    static constexpr size_t WRITE_TERM_DEGREE = 0;
-
-    // Columns using the Column enum.
     static constexpr Column SRC_SELECTOR = Column::nullifier_check_sel;
     static constexpr Column DST_SELECTOR = Column::merkle_check_start;
     static constexpr Column COUNTS = Column::lookup_nullifier_check_low_leaf_merkle_check_counts;
@@ -246,96 +96,20 @@ class lookup_nullifier_check_low_leaf_merkle_check_settings {
         ColumnAndShifts::merkle_check_path_len,   ColumnAndShifts::merkle_check_read_root,
         ColumnAndShifts::merkle_check_write_root
     };
-
-    template <typename AllEntities> static inline auto inverse_polynomial_is_computed_at_row(const AllEntities& in)
-    {
-        return (in.get(ColumnAndShifts::nullifier_check_sel) == 1 || in.get(ColumnAndShifts::merkle_check_start) == 1);
-    }
-
-    template <typename Accumulator, typename AllEntities>
-    static inline auto compute_inverse_exists(const AllEntities& in)
-    {
-        using View = typename Accumulator::View;
-        const auto is_operation = View(in.get(ColumnAndShifts::nullifier_check_sel));
-        const auto is_table_entry = View(in.get(ColumnAndShifts::merkle_check_start));
-        return (is_operation + is_table_entry - is_operation * is_table_entry);
-    }
-
-    template <typename AllEntities> static inline auto get_const_entities(const AllEntities& in)
-    {
-        return get_entities(in);
-    }
-
-    template <typename AllEntities> static inline auto get_nonconst_entities(AllEntities& in)
-    {
-        return get_entities(in);
-    }
-
-    template <typename AllEntities> static inline auto get_entities(AllEntities&& in)
-    {
-        return std::forward_as_tuple(in.get(ColumnAndShifts::lookup_nullifier_check_low_leaf_merkle_check_inv),
-                                     in.get(ColumnAndShifts::lookup_nullifier_check_low_leaf_merkle_check_counts),
-                                     in.get(ColumnAndShifts::nullifier_check_sel),
-                                     in.get(ColumnAndShifts::merkle_check_start),
-                                     in.get(ColumnAndShifts::nullifier_check_write),
-                                     in.get(ColumnAndShifts::nullifier_check_low_leaf_hash),
-                                     in.get(ColumnAndShifts::nullifier_check_updated_low_leaf_hash),
-                                     in.get(ColumnAndShifts::nullifier_check_low_leaf_index),
-                                     in.get(ColumnAndShifts::nullifier_check_tree_height),
-                                     in.get(ColumnAndShifts::nullifier_check_root),
-                                     in.get(ColumnAndShifts::nullifier_check_intermediate_root),
-                                     in.get(ColumnAndShifts::merkle_check_write),
-                                     in.get(ColumnAndShifts::merkle_check_read_node),
-                                     in.get(ColumnAndShifts::merkle_check_write_node),
-                                     in.get(ColumnAndShifts::merkle_check_index),
-                                     in.get(ColumnAndShifts::merkle_check_path_len),
-                                     in.get(ColumnAndShifts::merkle_check_read_root),
-                                     in.get(ColumnAndShifts::merkle_check_write_root));
-    }
 };
 
+using lookup_nullifier_check_low_leaf_merkle_check_settings =
+    lookup_settings<lookup_nullifier_check_low_leaf_merkle_check_settings_>;
 template <typename FF_>
-class lookup_nullifier_check_low_leaf_merkle_check_relation
-    : public GenericLookupRelation<lookup_nullifier_check_low_leaf_merkle_check_settings, FF_> {
-  public:
-    using Settings = lookup_nullifier_check_low_leaf_merkle_check_settings;
-    static constexpr std::string_view NAME = lookup_nullifier_check_low_leaf_merkle_check_settings::NAME;
-    static constexpr std::string_view RELATION_NAME =
-        lookup_nullifier_check_low_leaf_merkle_check_settings::RELATION_NAME;
-
-    template <typename AllEntities> inline static bool skip(const AllEntities& in)
-    {
-        return in.lookup_nullifier_check_low_leaf_merkle_check_inv.is_zero();
-    }
-
-    static std::string get_subrelation_label(size_t index)
-    {
-        if (index == 0) {
-            return "INVERSES_ARE_CORRECT";
-        } else if (index == 1) {
-            return "ACCUMULATION_IS_CORRECT";
-        }
-        return std::to_string(index);
-    }
-};
+using lookup_nullifier_check_low_leaf_merkle_check_relation =
+    lookup_relation_base<FF_, lookup_nullifier_check_low_leaf_merkle_check_settings>;
 
 /////////////////// lookup_nullifier_check_low_leaf_nullifier_validation ///////////////////
 
-class lookup_nullifier_check_low_leaf_nullifier_validation_settings {
-  public:
+struct lookup_nullifier_check_low_leaf_nullifier_validation_settings_ {
     static constexpr std::string_view NAME = "LOOKUP_NULLIFIER_CHECK_LOW_LEAF_NULLIFIER_VALIDATION";
     static constexpr std::string_view RELATION_NAME = "nullifier_check";
-
-    static constexpr size_t READ_TERMS = 1;
-    static constexpr size_t WRITE_TERMS = 1;
-    static constexpr size_t READ_TERM_TYPES[READ_TERMS] = { 0 };
-    static constexpr size_t WRITE_TERM_TYPES[WRITE_TERMS] = { 0 };
     static constexpr size_t LOOKUP_TUPLE_SIZE = 3;
-    static constexpr size_t INVERSE_EXISTS_POLYNOMIAL_DEGREE = 4;
-    static constexpr size_t READ_TERM_DEGREE = 0;
-    static constexpr size_t WRITE_TERM_DEGREE = 0;
-
-    // Columns using the Column enum.
     static constexpr Column SRC_SELECTOR = Column::nullifier_check_leaf_not_exists;
     static constexpr Column DST_SELECTOR = Column::ff_gt_sel_gt;
     static constexpr Column COUNTS = Column::lookup_nullifier_check_low_leaf_nullifier_validation_counts;
@@ -348,90 +122,20 @@ class lookup_nullifier_check_low_leaf_nullifier_validation_settings {
     static constexpr std::array<ColumnAndShifts, LOOKUP_TUPLE_SIZE> DST_COLUMNS = { ColumnAndShifts::ff_gt_a,
                                                                                     ColumnAndShifts::ff_gt_b,
                                                                                     ColumnAndShifts::ff_gt_result };
-
-    template <typename AllEntities> static inline auto inverse_polynomial_is_computed_at_row(const AllEntities& in)
-    {
-        return (in.get(ColumnAndShifts::nullifier_check_leaf_not_exists) == 1 ||
-                in.get(ColumnAndShifts::ff_gt_sel_gt) == 1);
-    }
-
-    template <typename Accumulator, typename AllEntities>
-    static inline auto compute_inverse_exists(const AllEntities& in)
-    {
-        using View = typename Accumulator::View;
-        const auto is_operation = View(in.get(ColumnAndShifts::nullifier_check_leaf_not_exists));
-        const auto is_table_entry = View(in.get(ColumnAndShifts::ff_gt_sel_gt));
-        return (is_operation + is_table_entry - is_operation * is_table_entry);
-    }
-
-    template <typename AllEntities> static inline auto get_const_entities(const AllEntities& in)
-    {
-        return get_entities(in);
-    }
-
-    template <typename AllEntities> static inline auto get_nonconst_entities(AllEntities& in)
-    {
-        return get_entities(in);
-    }
-
-    template <typename AllEntities> static inline auto get_entities(AllEntities&& in)
-    {
-        return std::forward_as_tuple(
-            in.get(ColumnAndShifts::lookup_nullifier_check_low_leaf_nullifier_validation_inv),
-            in.get(ColumnAndShifts::lookup_nullifier_check_low_leaf_nullifier_validation_counts),
-            in.get(ColumnAndShifts::nullifier_check_leaf_not_exists),
-            in.get(ColumnAndShifts::ff_gt_sel_gt),
-            in.get(ColumnAndShifts::nullifier_check_nullifier),
-            in.get(ColumnAndShifts::nullifier_check_low_leaf_nullifier),
-            in.get(ColumnAndShifts::nullifier_check_one),
-            in.get(ColumnAndShifts::ff_gt_a),
-            in.get(ColumnAndShifts::ff_gt_b),
-            in.get(ColumnAndShifts::ff_gt_result));
-    }
 };
 
+using lookup_nullifier_check_low_leaf_nullifier_validation_settings =
+    lookup_settings<lookup_nullifier_check_low_leaf_nullifier_validation_settings_>;
 template <typename FF_>
-class lookup_nullifier_check_low_leaf_nullifier_validation_relation
-    : public GenericLookupRelation<lookup_nullifier_check_low_leaf_nullifier_validation_settings, FF_> {
-  public:
-    using Settings = lookup_nullifier_check_low_leaf_nullifier_validation_settings;
-    static constexpr std::string_view NAME = lookup_nullifier_check_low_leaf_nullifier_validation_settings::NAME;
-    static constexpr std::string_view RELATION_NAME =
-        lookup_nullifier_check_low_leaf_nullifier_validation_settings::RELATION_NAME;
-
-    template <typename AllEntities> inline static bool skip(const AllEntities& in)
-    {
-        return in.lookup_nullifier_check_low_leaf_nullifier_validation_inv.is_zero();
-    }
-
-    static std::string get_subrelation_label(size_t index)
-    {
-        if (index == 0) {
-            return "INVERSES_ARE_CORRECT";
-        } else if (index == 1) {
-            return "ACCUMULATION_IS_CORRECT";
-        }
-        return std::to_string(index);
-    }
-};
+using lookup_nullifier_check_low_leaf_nullifier_validation_relation =
+    lookup_relation_base<FF_, lookup_nullifier_check_low_leaf_nullifier_validation_settings>;
 
 /////////////////// lookup_nullifier_check_low_leaf_next_nullifier_validation ///////////////////
 
-class lookup_nullifier_check_low_leaf_next_nullifier_validation_settings {
-  public:
+struct lookup_nullifier_check_low_leaf_next_nullifier_validation_settings_ {
     static constexpr std::string_view NAME = "LOOKUP_NULLIFIER_CHECK_LOW_LEAF_NEXT_NULLIFIER_VALIDATION";
     static constexpr std::string_view RELATION_NAME = "nullifier_check";
-
-    static constexpr size_t READ_TERMS = 1;
-    static constexpr size_t WRITE_TERMS = 1;
-    static constexpr size_t READ_TERM_TYPES[READ_TERMS] = { 0 };
-    static constexpr size_t WRITE_TERM_TYPES[WRITE_TERMS] = { 0 };
     static constexpr size_t LOOKUP_TUPLE_SIZE = 3;
-    static constexpr size_t INVERSE_EXISTS_POLYNOMIAL_DEGREE = 4;
-    static constexpr size_t READ_TERM_DEGREE = 0;
-    static constexpr size_t WRITE_TERM_DEGREE = 0;
-
-    // Columns using the Column enum.
     static constexpr Column SRC_SELECTOR = Column::nullifier_check_next_nullifier_is_nonzero;
     static constexpr Column DST_SELECTOR = Column::ff_gt_sel_gt;
     static constexpr Column COUNTS = Column::lookup_nullifier_check_low_leaf_next_nullifier_validation_counts;
@@ -444,90 +148,20 @@ class lookup_nullifier_check_low_leaf_next_nullifier_validation_settings {
     static constexpr std::array<ColumnAndShifts, LOOKUP_TUPLE_SIZE> DST_COLUMNS = { ColumnAndShifts::ff_gt_a,
                                                                                     ColumnAndShifts::ff_gt_b,
                                                                                     ColumnAndShifts::ff_gt_result };
-
-    template <typename AllEntities> static inline auto inverse_polynomial_is_computed_at_row(const AllEntities& in)
-    {
-        return (in.get(ColumnAndShifts::nullifier_check_next_nullifier_is_nonzero) == 1 ||
-                in.get(ColumnAndShifts::ff_gt_sel_gt) == 1);
-    }
-
-    template <typename Accumulator, typename AllEntities>
-    static inline auto compute_inverse_exists(const AllEntities& in)
-    {
-        using View = typename Accumulator::View;
-        const auto is_operation = View(in.get(ColumnAndShifts::nullifier_check_next_nullifier_is_nonzero));
-        const auto is_table_entry = View(in.get(ColumnAndShifts::ff_gt_sel_gt));
-        return (is_operation + is_table_entry - is_operation * is_table_entry);
-    }
-
-    template <typename AllEntities> static inline auto get_const_entities(const AllEntities& in)
-    {
-        return get_entities(in);
-    }
-
-    template <typename AllEntities> static inline auto get_nonconst_entities(AllEntities& in)
-    {
-        return get_entities(in);
-    }
-
-    template <typename AllEntities> static inline auto get_entities(AllEntities&& in)
-    {
-        return std::forward_as_tuple(
-            in.get(ColumnAndShifts::lookup_nullifier_check_low_leaf_next_nullifier_validation_inv),
-            in.get(ColumnAndShifts::lookup_nullifier_check_low_leaf_next_nullifier_validation_counts),
-            in.get(ColumnAndShifts::nullifier_check_next_nullifier_is_nonzero),
-            in.get(ColumnAndShifts::ff_gt_sel_gt),
-            in.get(ColumnAndShifts::nullifier_check_low_leaf_next_nullifier),
-            in.get(ColumnAndShifts::nullifier_check_nullifier),
-            in.get(ColumnAndShifts::nullifier_check_one),
-            in.get(ColumnAndShifts::ff_gt_a),
-            in.get(ColumnAndShifts::ff_gt_b),
-            in.get(ColumnAndShifts::ff_gt_result));
-    }
 };
 
+using lookup_nullifier_check_low_leaf_next_nullifier_validation_settings =
+    lookup_settings<lookup_nullifier_check_low_leaf_next_nullifier_validation_settings_>;
 template <typename FF_>
-class lookup_nullifier_check_low_leaf_next_nullifier_validation_relation
-    : public GenericLookupRelation<lookup_nullifier_check_low_leaf_next_nullifier_validation_settings, FF_> {
-  public:
-    using Settings = lookup_nullifier_check_low_leaf_next_nullifier_validation_settings;
-    static constexpr std::string_view NAME = lookup_nullifier_check_low_leaf_next_nullifier_validation_settings::NAME;
-    static constexpr std::string_view RELATION_NAME =
-        lookup_nullifier_check_low_leaf_next_nullifier_validation_settings::RELATION_NAME;
-
-    template <typename AllEntities> inline static bool skip(const AllEntities& in)
-    {
-        return in.lookup_nullifier_check_low_leaf_next_nullifier_validation_inv.is_zero();
-    }
-
-    static std::string get_subrelation_label(size_t index)
-    {
-        if (index == 0) {
-            return "INVERSES_ARE_CORRECT";
-        } else if (index == 1) {
-            return "ACCUMULATION_IS_CORRECT";
-        }
-        return std::to_string(index);
-    }
-};
+using lookup_nullifier_check_low_leaf_next_nullifier_validation_relation =
+    lookup_relation_base<FF_, lookup_nullifier_check_low_leaf_next_nullifier_validation_settings>;
 
 /////////////////// lookup_nullifier_check_new_leaf_poseidon2 ///////////////////
 
-class lookup_nullifier_check_new_leaf_poseidon2_settings {
-  public:
+struct lookup_nullifier_check_new_leaf_poseidon2_settings_ {
     static constexpr std::string_view NAME = "LOOKUP_NULLIFIER_CHECK_NEW_LEAF_POSEIDON2";
     static constexpr std::string_view RELATION_NAME = "nullifier_check";
-
-    static constexpr size_t READ_TERMS = 1;
-    static constexpr size_t WRITE_TERMS = 1;
-    static constexpr size_t READ_TERM_TYPES[READ_TERMS] = { 0 };
-    static constexpr size_t WRITE_TERM_TYPES[WRITE_TERMS] = { 0 };
     static constexpr size_t LOOKUP_TUPLE_SIZE = 4;
-    static constexpr size_t INVERSE_EXISTS_POLYNOMIAL_DEGREE = 4;
-    static constexpr size_t READ_TERM_DEGREE = 0;
-    static constexpr size_t WRITE_TERM_DEGREE = 0;
-
-    // Columns using the Column enum.
     static constexpr Column SRC_SELECTOR = Column::nullifier_check_write;
     static constexpr Column DST_SELECTOR = Column::poseidon2_hash_end;
     static constexpr Column COUNTS = Column::lookup_nullifier_check_new_leaf_poseidon2_counts;
@@ -544,90 +178,20 @@ class lookup_nullifier_check_new_leaf_poseidon2_settings {
         ColumnAndShifts::poseidon2_hash_input_2,
         ColumnAndShifts::poseidon2_hash_output
     };
-
-    template <typename AllEntities> static inline auto inverse_polynomial_is_computed_at_row(const AllEntities& in)
-    {
-        return (in.get(ColumnAndShifts::nullifier_check_write) == 1 ||
-                in.get(ColumnAndShifts::poseidon2_hash_end) == 1);
-    }
-
-    template <typename Accumulator, typename AllEntities>
-    static inline auto compute_inverse_exists(const AllEntities& in)
-    {
-        using View = typename Accumulator::View;
-        const auto is_operation = View(in.get(ColumnAndShifts::nullifier_check_write));
-        const auto is_table_entry = View(in.get(ColumnAndShifts::poseidon2_hash_end));
-        return (is_operation + is_table_entry - is_operation * is_table_entry);
-    }
-
-    template <typename AllEntities> static inline auto get_const_entities(const AllEntities& in)
-    {
-        return get_entities(in);
-    }
-
-    template <typename AllEntities> static inline auto get_nonconst_entities(AllEntities& in)
-    {
-        return get_entities(in);
-    }
-
-    template <typename AllEntities> static inline auto get_entities(AllEntities&& in)
-    {
-        return std::forward_as_tuple(in.get(ColumnAndShifts::lookup_nullifier_check_new_leaf_poseidon2_inv),
-                                     in.get(ColumnAndShifts::lookup_nullifier_check_new_leaf_poseidon2_counts),
-                                     in.get(ColumnAndShifts::nullifier_check_write),
-                                     in.get(ColumnAndShifts::poseidon2_hash_end),
-                                     in.get(ColumnAndShifts::nullifier_check_nullifier),
-                                     in.get(ColumnAndShifts::nullifier_check_low_leaf_next_nullifier),
-                                     in.get(ColumnAndShifts::nullifier_check_low_leaf_next_index),
-                                     in.get(ColumnAndShifts::nullifier_check_new_leaf_hash),
-                                     in.get(ColumnAndShifts::poseidon2_hash_input_0),
-                                     in.get(ColumnAndShifts::poseidon2_hash_input_1),
-                                     in.get(ColumnAndShifts::poseidon2_hash_input_2),
-                                     in.get(ColumnAndShifts::poseidon2_hash_output));
-    }
 };
 
+using lookup_nullifier_check_new_leaf_poseidon2_settings =
+    lookup_settings<lookup_nullifier_check_new_leaf_poseidon2_settings_>;
 template <typename FF_>
-class lookup_nullifier_check_new_leaf_poseidon2_relation
-    : public GenericLookupRelation<lookup_nullifier_check_new_leaf_poseidon2_settings, FF_> {
-  public:
-    using Settings = lookup_nullifier_check_new_leaf_poseidon2_settings;
-    static constexpr std::string_view NAME = lookup_nullifier_check_new_leaf_poseidon2_settings::NAME;
-    static constexpr std::string_view RELATION_NAME = lookup_nullifier_check_new_leaf_poseidon2_settings::RELATION_NAME;
-
-    template <typename AllEntities> inline static bool skip(const AllEntities& in)
-    {
-        return in.lookup_nullifier_check_new_leaf_poseidon2_inv.is_zero();
-    }
-
-    static std::string get_subrelation_label(size_t index)
-    {
-        if (index == 0) {
-            return "INVERSES_ARE_CORRECT";
-        } else if (index == 1) {
-            return "ACCUMULATION_IS_CORRECT";
-        }
-        return std::to_string(index);
-    }
-};
+using lookup_nullifier_check_new_leaf_poseidon2_relation =
+    lookup_relation_base<FF_, lookup_nullifier_check_new_leaf_poseidon2_settings>;
 
 /////////////////// lookup_nullifier_check_new_leaf_merkle_check ///////////////////
 
-class lookup_nullifier_check_new_leaf_merkle_check_settings {
-  public:
+struct lookup_nullifier_check_new_leaf_merkle_check_settings_ {
     static constexpr std::string_view NAME = "LOOKUP_NULLIFIER_CHECK_NEW_LEAF_MERKLE_CHECK";
     static constexpr std::string_view RELATION_NAME = "nullifier_check";
-
-    static constexpr size_t READ_TERMS = 1;
-    static constexpr size_t WRITE_TERMS = 1;
-    static constexpr size_t READ_TERM_TYPES[READ_TERMS] = { 0 };
-    static constexpr size_t WRITE_TERM_TYPES[WRITE_TERMS] = { 0 };
     static constexpr size_t LOOKUP_TUPLE_SIZE = 7;
-    static constexpr size_t INVERSE_EXISTS_POLYNOMIAL_DEGREE = 4;
-    static constexpr size_t READ_TERM_DEGREE = 0;
-    static constexpr size_t WRITE_TERM_DEGREE = 0;
-
-    // Columns using the Column enum.
     static constexpr Column SRC_SELECTOR = Column::nullifier_check_write;
     static constexpr Column DST_SELECTOR = Column::merkle_check_start;
     static constexpr Column COUNTS = Column::lookup_nullifier_check_new_leaf_merkle_check_counts;
@@ -644,78 +208,12 @@ class lookup_nullifier_check_new_leaf_merkle_check_settings {
         ColumnAndShifts::merkle_check_path_len,   ColumnAndShifts::merkle_check_read_root,
         ColumnAndShifts::merkle_check_write_root
     };
-
-    template <typename AllEntities> static inline auto inverse_polynomial_is_computed_at_row(const AllEntities& in)
-    {
-        return (in.get(ColumnAndShifts::nullifier_check_write) == 1 ||
-                in.get(ColumnAndShifts::merkle_check_start) == 1);
-    }
-
-    template <typename Accumulator, typename AllEntities>
-    static inline auto compute_inverse_exists(const AllEntities& in)
-    {
-        using View = typename Accumulator::View;
-        const auto is_operation = View(in.get(ColumnAndShifts::nullifier_check_write));
-        const auto is_table_entry = View(in.get(ColumnAndShifts::merkle_check_start));
-        return (is_operation + is_table_entry - is_operation * is_table_entry);
-    }
-
-    template <typename AllEntities> static inline auto get_const_entities(const AllEntities& in)
-    {
-        return get_entities(in);
-    }
-
-    template <typename AllEntities> static inline auto get_nonconst_entities(AllEntities& in)
-    {
-        return get_entities(in);
-    }
-
-    template <typename AllEntities> static inline auto get_entities(AllEntities&& in)
-    {
-        return std::forward_as_tuple(in.get(ColumnAndShifts::lookup_nullifier_check_new_leaf_merkle_check_inv),
-                                     in.get(ColumnAndShifts::lookup_nullifier_check_new_leaf_merkle_check_counts),
-                                     in.get(ColumnAndShifts::nullifier_check_write),
-                                     in.get(ColumnAndShifts::merkle_check_start),
-                                     in.get(ColumnAndShifts::nullifier_check_one),
-                                     in.get(ColumnAndShifts::precomputed_zero),
-                                     in.get(ColumnAndShifts::nullifier_check_new_leaf_hash),
-                                     in.get(ColumnAndShifts::nullifier_check_tree_size_before_write),
-                                     in.get(ColumnAndShifts::nullifier_check_tree_height),
-                                     in.get(ColumnAndShifts::nullifier_check_intermediate_root),
-                                     in.get(ColumnAndShifts::nullifier_check_write_root),
-                                     in.get(ColumnAndShifts::merkle_check_write),
-                                     in.get(ColumnAndShifts::merkle_check_read_node),
-                                     in.get(ColumnAndShifts::merkle_check_write_node),
-                                     in.get(ColumnAndShifts::merkle_check_index),
-                                     in.get(ColumnAndShifts::merkle_check_path_len),
-                                     in.get(ColumnAndShifts::merkle_check_read_root),
-                                     in.get(ColumnAndShifts::merkle_check_write_root));
-    }
 };
 
+using lookup_nullifier_check_new_leaf_merkle_check_settings =
+    lookup_settings<lookup_nullifier_check_new_leaf_merkle_check_settings_>;
 template <typename FF_>
-class lookup_nullifier_check_new_leaf_merkle_check_relation
-    : public GenericLookupRelation<lookup_nullifier_check_new_leaf_merkle_check_settings, FF_> {
-  public:
-    using Settings = lookup_nullifier_check_new_leaf_merkle_check_settings;
-    static constexpr std::string_view NAME = lookup_nullifier_check_new_leaf_merkle_check_settings::NAME;
-    static constexpr std::string_view RELATION_NAME =
-        lookup_nullifier_check_new_leaf_merkle_check_settings::RELATION_NAME;
-
-    template <typename AllEntities> inline static bool skip(const AllEntities& in)
-    {
-        return in.lookup_nullifier_check_new_leaf_merkle_check_inv.is_zero();
-    }
-
-    static std::string get_subrelation_label(size_t index)
-    {
-        if (index == 0) {
-            return "INVERSES_ARE_CORRECT";
-        } else if (index == 1) {
-            return "ACCUMULATION_IS_CORRECT";
-        }
-        return std::to_string(index);
-    }
-};
+using lookup_nullifier_check_new_leaf_merkle_check_relation =
+    lookup_relation_base<FF_, lookup_nullifier_check_new_leaf_merkle_check_settings>;
 
 } // namespace bb::avm2

--- a/barretenberg/cpp/src/barretenberg/vm2/generated/relations/lookups_poseidon2_hash.hpp
+++ b/barretenberg/cpp/src/barretenberg/vm2/generated/relations/lookups_poseidon2_hash.hpp
@@ -3,6 +3,7 @@
 
 #include "../columns.hpp"
 #include "barretenberg/relations/generic_lookup/generic_lookup_relation.hpp"
+#include "barretenberg/vm2/constraining/relations/interactions_base.hpp"
 
 #include <cstddef>
 #include <string_view>
@@ -12,21 +13,10 @@ namespace bb::avm2 {
 
 /////////////////// lookup_poseidon2_hash_poseidon2_perm ///////////////////
 
-class lookup_poseidon2_hash_poseidon2_perm_settings {
-  public:
+struct lookup_poseidon2_hash_poseidon2_perm_settings_ {
     static constexpr std::string_view NAME = "LOOKUP_POSEIDON2_HASH_POSEIDON2_PERM";
     static constexpr std::string_view RELATION_NAME = "poseidon2_hash";
-
-    static constexpr size_t READ_TERMS = 1;
-    static constexpr size_t WRITE_TERMS = 1;
-    static constexpr size_t READ_TERM_TYPES[READ_TERMS] = { 0 };
-    static constexpr size_t WRITE_TERM_TYPES[WRITE_TERMS] = { 0 };
     static constexpr size_t LOOKUP_TUPLE_SIZE = 8;
-    static constexpr size_t INVERSE_EXISTS_POLYNOMIAL_DEGREE = 4;
-    static constexpr size_t READ_TERM_DEGREE = 0;
-    static constexpr size_t WRITE_TERM_DEGREE = 0;
-
-    // Columns using the Column enum.
     static constexpr Column SRC_SELECTOR = Column::poseidon2_hash_sel;
     static constexpr Column DST_SELECTOR = Column::poseidon2_perm_sel;
     static constexpr Column COUNTS = Column::lookup_poseidon2_hash_poseidon2_perm_counts;
@@ -41,78 +31,11 @@ class lookup_poseidon2_hash_poseidon2_perm_settings {
         ColumnAndShifts::poseidon2_perm_a_3, ColumnAndShifts::poseidon2_perm_b_0, ColumnAndShifts::poseidon2_perm_b_1,
         ColumnAndShifts::poseidon2_perm_b_2, ColumnAndShifts::poseidon2_perm_b_3
     };
-
-    template <typename AllEntities> static inline auto inverse_polynomial_is_computed_at_row(const AllEntities& in)
-    {
-        return (in.get(ColumnAndShifts::poseidon2_hash_sel) == 1 || in.get(ColumnAndShifts::poseidon2_perm_sel) == 1);
-    }
-
-    template <typename Accumulator, typename AllEntities>
-    static inline auto compute_inverse_exists(const AllEntities& in)
-    {
-        using View = typename Accumulator::View;
-        const auto is_operation = View(in.get(ColumnAndShifts::poseidon2_hash_sel));
-        const auto is_table_entry = View(in.get(ColumnAndShifts::poseidon2_perm_sel));
-        return (is_operation + is_table_entry - is_operation * is_table_entry);
-    }
-
-    template <typename AllEntities> static inline auto get_const_entities(const AllEntities& in)
-    {
-        return get_entities(in);
-    }
-
-    template <typename AllEntities> static inline auto get_nonconst_entities(AllEntities& in)
-    {
-        return get_entities(in);
-    }
-
-    template <typename AllEntities> static inline auto get_entities(AllEntities&& in)
-    {
-        return std::forward_as_tuple(in.get(ColumnAndShifts::lookup_poseidon2_hash_poseidon2_perm_inv),
-                                     in.get(ColumnAndShifts::lookup_poseidon2_hash_poseidon2_perm_counts),
-                                     in.get(ColumnAndShifts::poseidon2_hash_sel),
-                                     in.get(ColumnAndShifts::poseidon2_perm_sel),
-                                     in.get(ColumnAndShifts::poseidon2_hash_a_0),
-                                     in.get(ColumnAndShifts::poseidon2_hash_a_1),
-                                     in.get(ColumnAndShifts::poseidon2_hash_a_2),
-                                     in.get(ColumnAndShifts::poseidon2_hash_a_3),
-                                     in.get(ColumnAndShifts::poseidon2_hash_b_0),
-                                     in.get(ColumnAndShifts::poseidon2_hash_b_1),
-                                     in.get(ColumnAndShifts::poseidon2_hash_b_2),
-                                     in.get(ColumnAndShifts::poseidon2_hash_b_3),
-                                     in.get(ColumnAndShifts::poseidon2_perm_a_0),
-                                     in.get(ColumnAndShifts::poseidon2_perm_a_1),
-                                     in.get(ColumnAndShifts::poseidon2_perm_a_2),
-                                     in.get(ColumnAndShifts::poseidon2_perm_a_3),
-                                     in.get(ColumnAndShifts::poseidon2_perm_b_0),
-                                     in.get(ColumnAndShifts::poseidon2_perm_b_1),
-                                     in.get(ColumnAndShifts::poseidon2_perm_b_2),
-                                     in.get(ColumnAndShifts::poseidon2_perm_b_3));
-    }
 };
 
+using lookup_poseidon2_hash_poseidon2_perm_settings = lookup_settings<lookup_poseidon2_hash_poseidon2_perm_settings_>;
 template <typename FF_>
-class lookup_poseidon2_hash_poseidon2_perm_relation
-    : public GenericLookupRelation<lookup_poseidon2_hash_poseidon2_perm_settings, FF_> {
-  public:
-    using Settings = lookup_poseidon2_hash_poseidon2_perm_settings;
-    static constexpr std::string_view NAME = lookup_poseidon2_hash_poseidon2_perm_settings::NAME;
-    static constexpr std::string_view RELATION_NAME = lookup_poseidon2_hash_poseidon2_perm_settings::RELATION_NAME;
-
-    template <typename AllEntities> inline static bool skip(const AllEntities& in)
-    {
-        return in.lookup_poseidon2_hash_poseidon2_perm_inv.is_zero();
-    }
-
-    static std::string get_subrelation_label(size_t index)
-    {
-        if (index == 0) {
-            return "INVERSES_ARE_CORRECT";
-        } else if (index == 1) {
-            return "ACCUMULATION_IS_CORRECT";
-        }
-        return std::to_string(index);
-    }
-};
+using lookup_poseidon2_hash_poseidon2_perm_relation =
+    lookup_relation_base<FF_, lookup_poseidon2_hash_poseidon2_perm_settings>;
 
 } // namespace bb::avm2

--- a/barretenberg/cpp/src/barretenberg/vm2/generated/relations/lookups_public_data_read.hpp
+++ b/barretenberg/cpp/src/barretenberg/vm2/generated/relations/lookups_public_data_read.hpp
@@ -3,6 +3,7 @@
 
 #include "../columns.hpp"
 #include "barretenberg/relations/generic_lookup/generic_lookup_relation.hpp"
+#include "barretenberg/vm2/constraining/relations/interactions_base.hpp"
 
 #include <cstddef>
 #include <string_view>
@@ -12,21 +13,10 @@ namespace bb::avm2 {
 
 /////////////////// lookup_public_data_read_low_leaf_poseidon2_0 ///////////////////
 
-class lookup_public_data_read_low_leaf_poseidon2_0_settings {
-  public:
+struct lookup_public_data_read_low_leaf_poseidon2_0_settings_ {
     static constexpr std::string_view NAME = "LOOKUP_PUBLIC_DATA_READ_LOW_LEAF_POSEIDON2_0";
     static constexpr std::string_view RELATION_NAME = "public_data_read";
-
-    static constexpr size_t READ_TERMS = 1;
-    static constexpr size_t WRITE_TERMS = 1;
-    static constexpr size_t READ_TERM_TYPES[READ_TERMS] = { 0 };
-    static constexpr size_t WRITE_TERM_TYPES[WRITE_TERMS] = { 0 };
     static constexpr size_t LOOKUP_TUPLE_SIZE = 4;
-    static constexpr size_t INVERSE_EXISTS_POLYNOMIAL_DEGREE = 4;
-    static constexpr size_t READ_TERM_DEGREE = 0;
-    static constexpr size_t WRITE_TERM_DEGREE = 0;
-
-    // Columns using the Column enum.
     static constexpr Column SRC_SELECTOR = Column::public_data_read_sel;
     static constexpr Column DST_SELECTOR = Column::poseidon2_hash_start;
     static constexpr Column COUNTS = Column::lookup_public_data_read_low_leaf_poseidon2_0_counts;
@@ -43,91 +33,20 @@ class lookup_public_data_read_low_leaf_poseidon2_0_settings {
         ColumnAndShifts::poseidon2_hash_input_2,
         ColumnAndShifts::poseidon2_hash_output
     };
-
-    template <typename AllEntities> static inline auto inverse_polynomial_is_computed_at_row(const AllEntities& in)
-    {
-        return (in.get(ColumnAndShifts::public_data_read_sel) == 1 ||
-                in.get(ColumnAndShifts::poseidon2_hash_start) == 1);
-    }
-
-    template <typename Accumulator, typename AllEntities>
-    static inline auto compute_inverse_exists(const AllEntities& in)
-    {
-        using View = typename Accumulator::View;
-        const auto is_operation = View(in.get(ColumnAndShifts::public_data_read_sel));
-        const auto is_table_entry = View(in.get(ColumnAndShifts::poseidon2_hash_start));
-        return (is_operation + is_table_entry - is_operation * is_table_entry);
-    }
-
-    template <typename AllEntities> static inline auto get_const_entities(const AllEntities& in)
-    {
-        return get_entities(in);
-    }
-
-    template <typename AllEntities> static inline auto get_nonconst_entities(AllEntities& in)
-    {
-        return get_entities(in);
-    }
-
-    template <typename AllEntities> static inline auto get_entities(AllEntities&& in)
-    {
-        return std::forward_as_tuple(in.get(ColumnAndShifts::lookup_public_data_read_low_leaf_poseidon2_0_inv),
-                                     in.get(ColumnAndShifts::lookup_public_data_read_low_leaf_poseidon2_0_counts),
-                                     in.get(ColumnAndShifts::public_data_read_sel),
-                                     in.get(ColumnAndShifts::poseidon2_hash_start),
-                                     in.get(ColumnAndShifts::public_data_read_low_leaf_slot),
-                                     in.get(ColumnAndShifts::public_data_read_low_leaf_value),
-                                     in.get(ColumnAndShifts::public_data_read_low_leaf_next_index),
-                                     in.get(ColumnAndShifts::public_data_read_low_leaf_hash),
-                                     in.get(ColumnAndShifts::poseidon2_hash_input_0),
-                                     in.get(ColumnAndShifts::poseidon2_hash_input_1),
-                                     in.get(ColumnAndShifts::poseidon2_hash_input_2),
-                                     in.get(ColumnAndShifts::poseidon2_hash_output));
-    }
 };
 
+using lookup_public_data_read_low_leaf_poseidon2_0_settings =
+    lookup_settings<lookup_public_data_read_low_leaf_poseidon2_0_settings_>;
 template <typename FF_>
-class lookup_public_data_read_low_leaf_poseidon2_0_relation
-    : public GenericLookupRelation<lookup_public_data_read_low_leaf_poseidon2_0_settings, FF_> {
-  public:
-    using Settings = lookup_public_data_read_low_leaf_poseidon2_0_settings;
-    static constexpr std::string_view NAME = lookup_public_data_read_low_leaf_poseidon2_0_settings::NAME;
-    static constexpr std::string_view RELATION_NAME =
-        lookup_public_data_read_low_leaf_poseidon2_0_settings::RELATION_NAME;
-
-    template <typename AllEntities> inline static bool skip(const AllEntities& in)
-    {
-        return in.lookup_public_data_read_low_leaf_poseidon2_0_inv.is_zero();
-    }
-
-    static std::string get_subrelation_label(size_t index)
-    {
-        if (index == 0) {
-            return "INVERSES_ARE_CORRECT";
-        } else if (index == 1) {
-            return "ACCUMULATION_IS_CORRECT";
-        }
-        return std::to_string(index);
-    }
-};
+using lookup_public_data_read_low_leaf_poseidon2_0_relation =
+    lookup_relation_base<FF_, lookup_public_data_read_low_leaf_poseidon2_0_settings>;
 
 /////////////////// lookup_public_data_read_low_leaf_poseidon2_1 ///////////////////
 
-class lookup_public_data_read_low_leaf_poseidon2_1_settings {
-  public:
+struct lookup_public_data_read_low_leaf_poseidon2_1_settings_ {
     static constexpr std::string_view NAME = "LOOKUP_PUBLIC_DATA_READ_LOW_LEAF_POSEIDON2_1";
     static constexpr std::string_view RELATION_NAME = "public_data_read";
-
-    static constexpr size_t READ_TERMS = 1;
-    static constexpr size_t WRITE_TERMS = 1;
-    static constexpr size_t READ_TERM_TYPES[READ_TERMS] = { 0 };
-    static constexpr size_t WRITE_TERM_TYPES[WRITE_TERMS] = { 0 };
     static constexpr size_t LOOKUP_TUPLE_SIZE = 4;
-    static constexpr size_t INVERSE_EXISTS_POLYNOMIAL_DEGREE = 4;
-    static constexpr size_t READ_TERM_DEGREE = 0;
-    static constexpr size_t WRITE_TERM_DEGREE = 0;
-
-    // Columns using the Column enum.
     static constexpr Column SRC_SELECTOR = Column::public_data_read_sel;
     static constexpr Column DST_SELECTOR = Column::poseidon2_hash_end;
     static constexpr Column COUNTS = Column::lookup_public_data_read_low_leaf_poseidon2_1_counts;
@@ -144,90 +63,20 @@ class lookup_public_data_read_low_leaf_poseidon2_1_settings {
         ColumnAndShifts::poseidon2_hash_input_2,
         ColumnAndShifts::poseidon2_hash_output
     };
-
-    template <typename AllEntities> static inline auto inverse_polynomial_is_computed_at_row(const AllEntities& in)
-    {
-        return (in.get(ColumnAndShifts::public_data_read_sel) == 1 || in.get(ColumnAndShifts::poseidon2_hash_end) == 1);
-    }
-
-    template <typename Accumulator, typename AllEntities>
-    static inline auto compute_inverse_exists(const AllEntities& in)
-    {
-        using View = typename Accumulator::View;
-        const auto is_operation = View(in.get(ColumnAndShifts::public_data_read_sel));
-        const auto is_table_entry = View(in.get(ColumnAndShifts::poseidon2_hash_end));
-        return (is_operation + is_table_entry - is_operation * is_table_entry);
-    }
-
-    template <typename AllEntities> static inline auto get_const_entities(const AllEntities& in)
-    {
-        return get_entities(in);
-    }
-
-    template <typename AllEntities> static inline auto get_nonconst_entities(AllEntities& in)
-    {
-        return get_entities(in);
-    }
-
-    template <typename AllEntities> static inline auto get_entities(AllEntities&& in)
-    {
-        return std::forward_as_tuple(in.get(ColumnAndShifts::lookup_public_data_read_low_leaf_poseidon2_1_inv),
-                                     in.get(ColumnAndShifts::lookup_public_data_read_low_leaf_poseidon2_1_counts),
-                                     in.get(ColumnAndShifts::public_data_read_sel),
-                                     in.get(ColumnAndShifts::poseidon2_hash_end),
-                                     in.get(ColumnAndShifts::public_data_read_low_leaf_next_slot),
-                                     in.get(ColumnAndShifts::precomputed_zero),
-                                     in.get(ColumnAndShifts::precomputed_zero),
-                                     in.get(ColumnAndShifts::public_data_read_low_leaf_hash),
-                                     in.get(ColumnAndShifts::poseidon2_hash_input_0),
-                                     in.get(ColumnAndShifts::poseidon2_hash_input_1),
-                                     in.get(ColumnAndShifts::poseidon2_hash_input_2),
-                                     in.get(ColumnAndShifts::poseidon2_hash_output));
-    }
 };
 
+using lookup_public_data_read_low_leaf_poseidon2_1_settings =
+    lookup_settings<lookup_public_data_read_low_leaf_poseidon2_1_settings_>;
 template <typename FF_>
-class lookup_public_data_read_low_leaf_poseidon2_1_relation
-    : public GenericLookupRelation<lookup_public_data_read_low_leaf_poseidon2_1_settings, FF_> {
-  public:
-    using Settings = lookup_public_data_read_low_leaf_poseidon2_1_settings;
-    static constexpr std::string_view NAME = lookup_public_data_read_low_leaf_poseidon2_1_settings::NAME;
-    static constexpr std::string_view RELATION_NAME =
-        lookup_public_data_read_low_leaf_poseidon2_1_settings::RELATION_NAME;
-
-    template <typename AllEntities> inline static bool skip(const AllEntities& in)
-    {
-        return in.lookup_public_data_read_low_leaf_poseidon2_1_inv.is_zero();
-    }
-
-    static std::string get_subrelation_label(size_t index)
-    {
-        if (index == 0) {
-            return "INVERSES_ARE_CORRECT";
-        } else if (index == 1) {
-            return "ACCUMULATION_IS_CORRECT";
-        }
-        return std::to_string(index);
-    }
-};
+using lookup_public_data_read_low_leaf_poseidon2_1_relation =
+    lookup_relation_base<FF_, lookup_public_data_read_low_leaf_poseidon2_1_settings>;
 
 /////////////////// lookup_public_data_read_low_leaf_membership ///////////////////
 
-class lookup_public_data_read_low_leaf_membership_settings {
-  public:
+struct lookup_public_data_read_low_leaf_membership_settings_ {
     static constexpr std::string_view NAME = "LOOKUP_PUBLIC_DATA_READ_LOW_LEAF_MEMBERSHIP";
     static constexpr std::string_view RELATION_NAME = "public_data_read";
-
-    static constexpr size_t READ_TERMS = 1;
-    static constexpr size_t WRITE_TERMS = 1;
-    static constexpr size_t READ_TERM_TYPES[READ_TERMS] = { 0 };
-    static constexpr size_t WRITE_TERM_TYPES[WRITE_TERMS] = { 0 };
     static constexpr size_t LOOKUP_TUPLE_SIZE = 4;
-    static constexpr size_t INVERSE_EXISTS_POLYNOMIAL_DEGREE = 4;
-    static constexpr size_t READ_TERM_DEGREE = 0;
-    static constexpr size_t WRITE_TERM_DEGREE = 0;
-
-    // Columns using the Column enum.
     static constexpr Column SRC_SELECTOR = Column::public_data_read_sel;
     static constexpr Column DST_SELECTOR = Column::merkle_check_start;
     static constexpr Column COUNTS = Column::lookup_public_data_read_low_leaf_membership_counts;
@@ -244,90 +93,20 @@ class lookup_public_data_read_low_leaf_membership_settings {
         ColumnAndShifts::merkle_check_path_len,
         ColumnAndShifts::merkle_check_read_root
     };
-
-    template <typename AllEntities> static inline auto inverse_polynomial_is_computed_at_row(const AllEntities& in)
-    {
-        return (in.get(ColumnAndShifts::public_data_read_sel) == 1 || in.get(ColumnAndShifts::merkle_check_start) == 1);
-    }
-
-    template <typename Accumulator, typename AllEntities>
-    static inline auto compute_inverse_exists(const AllEntities& in)
-    {
-        using View = typename Accumulator::View;
-        const auto is_operation = View(in.get(ColumnAndShifts::public_data_read_sel));
-        const auto is_table_entry = View(in.get(ColumnAndShifts::merkle_check_start));
-        return (is_operation + is_table_entry - is_operation * is_table_entry);
-    }
-
-    template <typename AllEntities> static inline auto get_const_entities(const AllEntities& in)
-    {
-        return get_entities(in);
-    }
-
-    template <typename AllEntities> static inline auto get_nonconst_entities(AllEntities& in)
-    {
-        return get_entities(in);
-    }
-
-    template <typename AllEntities> static inline auto get_entities(AllEntities&& in)
-    {
-        return std::forward_as_tuple(in.get(ColumnAndShifts::lookup_public_data_read_low_leaf_membership_inv),
-                                     in.get(ColumnAndShifts::lookup_public_data_read_low_leaf_membership_counts),
-                                     in.get(ColumnAndShifts::public_data_read_sel),
-                                     in.get(ColumnAndShifts::merkle_check_start),
-                                     in.get(ColumnAndShifts::public_data_read_low_leaf_hash),
-                                     in.get(ColumnAndShifts::public_data_read_low_leaf_index),
-                                     in.get(ColumnAndShifts::public_data_read_tree_height),
-                                     in.get(ColumnAndShifts::public_data_read_root),
-                                     in.get(ColumnAndShifts::merkle_check_read_node),
-                                     in.get(ColumnAndShifts::merkle_check_index),
-                                     in.get(ColumnAndShifts::merkle_check_path_len),
-                                     in.get(ColumnAndShifts::merkle_check_read_root));
-    }
 };
 
+using lookup_public_data_read_low_leaf_membership_settings =
+    lookup_settings<lookup_public_data_read_low_leaf_membership_settings_>;
 template <typename FF_>
-class lookup_public_data_read_low_leaf_membership_relation
-    : public GenericLookupRelation<lookup_public_data_read_low_leaf_membership_settings, FF_> {
-  public:
-    using Settings = lookup_public_data_read_low_leaf_membership_settings;
-    static constexpr std::string_view NAME = lookup_public_data_read_low_leaf_membership_settings::NAME;
-    static constexpr std::string_view RELATION_NAME =
-        lookup_public_data_read_low_leaf_membership_settings::RELATION_NAME;
-
-    template <typename AllEntities> inline static bool skip(const AllEntities& in)
-    {
-        return in.lookup_public_data_read_low_leaf_membership_inv.is_zero();
-    }
-
-    static std::string get_subrelation_label(size_t index)
-    {
-        if (index == 0) {
-            return "INVERSES_ARE_CORRECT";
-        } else if (index == 1) {
-            return "ACCUMULATION_IS_CORRECT";
-        }
-        return std::to_string(index);
-    }
-};
+using lookup_public_data_read_low_leaf_membership_relation =
+    lookup_relation_base<FF_, lookup_public_data_read_low_leaf_membership_settings>;
 
 /////////////////// lookup_public_data_read_low_leaf_slot_validation ///////////////////
 
-class lookup_public_data_read_low_leaf_slot_validation_settings {
-  public:
+struct lookup_public_data_read_low_leaf_slot_validation_settings_ {
     static constexpr std::string_view NAME = "LOOKUP_PUBLIC_DATA_READ_LOW_LEAF_SLOT_VALIDATION";
     static constexpr std::string_view RELATION_NAME = "public_data_read";
-
-    static constexpr size_t READ_TERMS = 1;
-    static constexpr size_t WRITE_TERMS = 1;
-    static constexpr size_t READ_TERM_TYPES[READ_TERMS] = { 0 };
-    static constexpr size_t WRITE_TERM_TYPES[WRITE_TERMS] = { 0 };
     static constexpr size_t LOOKUP_TUPLE_SIZE = 3;
-    static constexpr size_t INVERSE_EXISTS_POLYNOMIAL_DEGREE = 4;
-    static constexpr size_t READ_TERM_DEGREE = 0;
-    static constexpr size_t WRITE_TERM_DEGREE = 0;
-
-    // Columns using the Column enum.
     static constexpr Column SRC_SELECTOR = Column::public_data_read_leaf_not_exists;
     static constexpr Column DST_SELECTOR = Column::ff_gt_sel_gt;
     static constexpr Column COUNTS = Column::lookup_public_data_read_low_leaf_slot_validation_counts;
@@ -340,89 +119,20 @@ class lookup_public_data_read_low_leaf_slot_validation_settings {
     static constexpr std::array<ColumnAndShifts, LOOKUP_TUPLE_SIZE> DST_COLUMNS = { ColumnAndShifts::ff_gt_a,
                                                                                     ColumnAndShifts::ff_gt_b,
                                                                                     ColumnAndShifts::ff_gt_result };
-
-    template <typename AllEntities> static inline auto inverse_polynomial_is_computed_at_row(const AllEntities& in)
-    {
-        return (in.get(ColumnAndShifts::public_data_read_leaf_not_exists) == 1 ||
-                in.get(ColumnAndShifts::ff_gt_sel_gt) == 1);
-    }
-
-    template <typename Accumulator, typename AllEntities>
-    static inline auto compute_inverse_exists(const AllEntities& in)
-    {
-        using View = typename Accumulator::View;
-        const auto is_operation = View(in.get(ColumnAndShifts::public_data_read_leaf_not_exists));
-        const auto is_table_entry = View(in.get(ColumnAndShifts::ff_gt_sel_gt));
-        return (is_operation + is_table_entry - is_operation * is_table_entry);
-    }
-
-    template <typename AllEntities> static inline auto get_const_entities(const AllEntities& in)
-    {
-        return get_entities(in);
-    }
-
-    template <typename AllEntities> static inline auto get_nonconst_entities(AllEntities& in)
-    {
-        return get_entities(in);
-    }
-
-    template <typename AllEntities> static inline auto get_entities(AllEntities&& in)
-    {
-        return std::forward_as_tuple(in.get(ColumnAndShifts::lookup_public_data_read_low_leaf_slot_validation_inv),
-                                     in.get(ColumnAndShifts::lookup_public_data_read_low_leaf_slot_validation_counts),
-                                     in.get(ColumnAndShifts::public_data_read_leaf_not_exists),
-                                     in.get(ColumnAndShifts::ff_gt_sel_gt),
-                                     in.get(ColumnAndShifts::public_data_read_slot),
-                                     in.get(ColumnAndShifts::public_data_read_low_leaf_slot),
-                                     in.get(ColumnAndShifts::public_data_read_one),
-                                     in.get(ColumnAndShifts::ff_gt_a),
-                                     in.get(ColumnAndShifts::ff_gt_b),
-                                     in.get(ColumnAndShifts::ff_gt_result));
-    }
 };
 
+using lookup_public_data_read_low_leaf_slot_validation_settings =
+    lookup_settings<lookup_public_data_read_low_leaf_slot_validation_settings_>;
 template <typename FF_>
-class lookup_public_data_read_low_leaf_slot_validation_relation
-    : public GenericLookupRelation<lookup_public_data_read_low_leaf_slot_validation_settings, FF_> {
-  public:
-    using Settings = lookup_public_data_read_low_leaf_slot_validation_settings;
-    static constexpr std::string_view NAME = lookup_public_data_read_low_leaf_slot_validation_settings::NAME;
-    static constexpr std::string_view RELATION_NAME =
-        lookup_public_data_read_low_leaf_slot_validation_settings::RELATION_NAME;
-
-    template <typename AllEntities> inline static bool skip(const AllEntities& in)
-    {
-        return in.lookup_public_data_read_low_leaf_slot_validation_inv.is_zero();
-    }
-
-    static std::string get_subrelation_label(size_t index)
-    {
-        if (index == 0) {
-            return "INVERSES_ARE_CORRECT";
-        } else if (index == 1) {
-            return "ACCUMULATION_IS_CORRECT";
-        }
-        return std::to_string(index);
-    }
-};
+using lookup_public_data_read_low_leaf_slot_validation_relation =
+    lookup_relation_base<FF_, lookup_public_data_read_low_leaf_slot_validation_settings>;
 
 /////////////////// lookup_public_data_read_low_leaf_next_slot_validation ///////////////////
 
-class lookup_public_data_read_low_leaf_next_slot_validation_settings {
-  public:
+struct lookup_public_data_read_low_leaf_next_slot_validation_settings_ {
     static constexpr std::string_view NAME = "LOOKUP_PUBLIC_DATA_READ_LOW_LEAF_NEXT_SLOT_VALIDATION";
     static constexpr std::string_view RELATION_NAME = "public_data_read";
-
-    static constexpr size_t READ_TERMS = 1;
-    static constexpr size_t WRITE_TERMS = 1;
-    static constexpr size_t READ_TERM_TYPES[READ_TERMS] = { 0 };
-    static constexpr size_t WRITE_TERM_TYPES[WRITE_TERMS] = { 0 };
     static constexpr size_t LOOKUP_TUPLE_SIZE = 3;
-    static constexpr size_t INVERSE_EXISTS_POLYNOMIAL_DEGREE = 4;
-    static constexpr size_t READ_TERM_DEGREE = 0;
-    static constexpr size_t WRITE_TERM_DEGREE = 0;
-
-    // Columns using the Column enum.
     static constexpr Column SRC_SELECTOR = Column::public_data_read_next_slot_is_nonzero;
     static constexpr Column DST_SELECTOR = Column::ff_gt_sel_gt;
     static constexpr Column COUNTS = Column::lookup_public_data_read_low_leaf_next_slot_validation_counts;
@@ -435,71 +145,12 @@ class lookup_public_data_read_low_leaf_next_slot_validation_settings {
     static constexpr std::array<ColumnAndShifts, LOOKUP_TUPLE_SIZE> DST_COLUMNS = { ColumnAndShifts::ff_gt_a,
                                                                                     ColumnAndShifts::ff_gt_b,
                                                                                     ColumnAndShifts::ff_gt_result };
-
-    template <typename AllEntities> static inline auto inverse_polynomial_is_computed_at_row(const AllEntities& in)
-    {
-        return (in.get(ColumnAndShifts::public_data_read_next_slot_is_nonzero) == 1 ||
-                in.get(ColumnAndShifts::ff_gt_sel_gt) == 1);
-    }
-
-    template <typename Accumulator, typename AllEntities>
-    static inline auto compute_inverse_exists(const AllEntities& in)
-    {
-        using View = typename Accumulator::View;
-        const auto is_operation = View(in.get(ColumnAndShifts::public_data_read_next_slot_is_nonzero));
-        const auto is_table_entry = View(in.get(ColumnAndShifts::ff_gt_sel_gt));
-        return (is_operation + is_table_entry - is_operation * is_table_entry);
-    }
-
-    template <typename AllEntities> static inline auto get_const_entities(const AllEntities& in)
-    {
-        return get_entities(in);
-    }
-
-    template <typename AllEntities> static inline auto get_nonconst_entities(AllEntities& in)
-    {
-        return get_entities(in);
-    }
-
-    template <typename AllEntities> static inline auto get_entities(AllEntities&& in)
-    {
-        return std::forward_as_tuple(
-            in.get(ColumnAndShifts::lookup_public_data_read_low_leaf_next_slot_validation_inv),
-            in.get(ColumnAndShifts::lookup_public_data_read_low_leaf_next_slot_validation_counts),
-            in.get(ColumnAndShifts::public_data_read_next_slot_is_nonzero),
-            in.get(ColumnAndShifts::ff_gt_sel_gt),
-            in.get(ColumnAndShifts::public_data_read_low_leaf_next_slot),
-            in.get(ColumnAndShifts::public_data_read_slot),
-            in.get(ColumnAndShifts::public_data_read_one),
-            in.get(ColumnAndShifts::ff_gt_a),
-            in.get(ColumnAndShifts::ff_gt_b),
-            in.get(ColumnAndShifts::ff_gt_result));
-    }
 };
 
+using lookup_public_data_read_low_leaf_next_slot_validation_settings =
+    lookup_settings<lookup_public_data_read_low_leaf_next_slot_validation_settings_>;
 template <typename FF_>
-class lookup_public_data_read_low_leaf_next_slot_validation_relation
-    : public GenericLookupRelation<lookup_public_data_read_low_leaf_next_slot_validation_settings, FF_> {
-  public:
-    using Settings = lookup_public_data_read_low_leaf_next_slot_validation_settings;
-    static constexpr std::string_view NAME = lookup_public_data_read_low_leaf_next_slot_validation_settings::NAME;
-    static constexpr std::string_view RELATION_NAME =
-        lookup_public_data_read_low_leaf_next_slot_validation_settings::RELATION_NAME;
-
-    template <typename AllEntities> inline static bool skip(const AllEntities& in)
-    {
-        return in.lookup_public_data_read_low_leaf_next_slot_validation_inv.is_zero();
-    }
-
-    static std::string get_subrelation_label(size_t index)
-    {
-        if (index == 0) {
-            return "INVERSES_ARE_CORRECT";
-        } else if (index == 1) {
-            return "ACCUMULATION_IS_CORRECT";
-        }
-        return std::to_string(index);
-    }
-};
+using lookup_public_data_read_low_leaf_next_slot_validation_relation =
+    lookup_relation_base<FF_, lookup_public_data_read_low_leaf_next_slot_validation_settings>;
 
 } // namespace bb::avm2

--- a/barretenberg/cpp/src/barretenberg/vm2/generated/relations/lookups_range_check.hpp
+++ b/barretenberg/cpp/src/barretenberg/vm2/generated/relations/lookups_range_check.hpp
@@ -3,6 +3,7 @@
 
 #include "../columns.hpp"
 #include "barretenberg/relations/generic_lookup/generic_lookup_relation.hpp"
+#include "barretenberg/vm2/constraining/relations/interactions_base.hpp"
 
 #include <cstddef>
 #include <string_view>
@@ -12,21 +13,10 @@ namespace bb::avm2 {
 
 /////////////////// lookup_range_check_dyn_rng_chk_pow_2 ///////////////////
 
-class lookup_range_check_dyn_rng_chk_pow_2_settings {
-  public:
+struct lookup_range_check_dyn_rng_chk_pow_2_settings_ {
     static constexpr std::string_view NAME = "LOOKUP_RANGE_CHECK_DYN_RNG_CHK_POW_2";
     static constexpr std::string_view RELATION_NAME = "range_check";
-
-    static constexpr size_t READ_TERMS = 1;
-    static constexpr size_t WRITE_TERMS = 1;
-    static constexpr size_t READ_TERM_TYPES[READ_TERMS] = { 0 };
-    static constexpr size_t WRITE_TERM_TYPES[WRITE_TERMS] = { 0 };
     static constexpr size_t LOOKUP_TUPLE_SIZE = 2;
-    static constexpr size_t INVERSE_EXISTS_POLYNOMIAL_DEGREE = 4;
-    static constexpr size_t READ_TERM_DEGREE = 0;
-    static constexpr size_t WRITE_TERM_DEGREE = 0;
-
-    // Columns using the Column enum.
     static constexpr Column SRC_SELECTOR = Column::range_check_sel;
     static constexpr Column DST_SELECTOR = Column::precomputed_sel_range_8;
     static constexpr Column COUNTS = Column::lookup_range_check_dyn_rng_chk_pow_2_counts;
@@ -37,85 +27,19 @@ class lookup_range_check_dyn_rng_chk_pow_2_settings {
     static constexpr std::array<ColumnAndShifts, LOOKUP_TUPLE_SIZE> DST_COLUMNS = {
         ColumnAndShifts::precomputed_clk, ColumnAndShifts::precomputed_power_of_2
     };
-
-    template <typename AllEntities> static inline auto inverse_polynomial_is_computed_at_row(const AllEntities& in)
-    {
-        return (in.get(ColumnAndShifts::range_check_sel) == 1 || in.get(ColumnAndShifts::precomputed_sel_range_8) == 1);
-    }
-
-    template <typename Accumulator, typename AllEntities>
-    static inline auto compute_inverse_exists(const AllEntities& in)
-    {
-        using View = typename Accumulator::View;
-        const auto is_operation = View(in.get(ColumnAndShifts::range_check_sel));
-        const auto is_table_entry = View(in.get(ColumnAndShifts::precomputed_sel_range_8));
-        return (is_operation + is_table_entry - is_operation * is_table_entry);
-    }
-
-    template <typename AllEntities> static inline auto get_const_entities(const AllEntities& in)
-    {
-        return get_entities(in);
-    }
-
-    template <typename AllEntities> static inline auto get_nonconst_entities(AllEntities& in)
-    {
-        return get_entities(in);
-    }
-
-    template <typename AllEntities> static inline auto get_entities(AllEntities&& in)
-    {
-        return std::forward_as_tuple(in.get(ColumnAndShifts::lookup_range_check_dyn_rng_chk_pow_2_inv),
-                                     in.get(ColumnAndShifts::lookup_range_check_dyn_rng_chk_pow_2_counts),
-                                     in.get(ColumnAndShifts::range_check_sel),
-                                     in.get(ColumnAndShifts::precomputed_sel_range_8),
-                                     in.get(ColumnAndShifts::range_check_dyn_rng_chk_bits),
-                                     in.get(ColumnAndShifts::range_check_dyn_rng_chk_pow_2),
-                                     in.get(ColumnAndShifts::precomputed_clk),
-                                     in.get(ColumnAndShifts::precomputed_power_of_2));
-    }
 };
 
+using lookup_range_check_dyn_rng_chk_pow_2_settings = lookup_settings<lookup_range_check_dyn_rng_chk_pow_2_settings_>;
 template <typename FF_>
-class lookup_range_check_dyn_rng_chk_pow_2_relation
-    : public GenericLookupRelation<lookup_range_check_dyn_rng_chk_pow_2_settings, FF_> {
-  public:
-    using Settings = lookup_range_check_dyn_rng_chk_pow_2_settings;
-    static constexpr std::string_view NAME = lookup_range_check_dyn_rng_chk_pow_2_settings::NAME;
-    static constexpr std::string_view RELATION_NAME = lookup_range_check_dyn_rng_chk_pow_2_settings::RELATION_NAME;
-
-    template <typename AllEntities> inline static bool skip(const AllEntities& in)
-    {
-        return in.lookup_range_check_dyn_rng_chk_pow_2_inv.is_zero();
-    }
-
-    static std::string get_subrelation_label(size_t index)
-    {
-        if (index == 0) {
-            return "INVERSES_ARE_CORRECT";
-        } else if (index == 1) {
-            return "ACCUMULATION_IS_CORRECT";
-        }
-        return std::to_string(index);
-    }
-};
+using lookup_range_check_dyn_rng_chk_pow_2_relation =
+    lookup_relation_base<FF_, lookup_range_check_dyn_rng_chk_pow_2_settings>;
 
 /////////////////// lookup_range_check_dyn_diff_is_u16 ///////////////////
 
-class lookup_range_check_dyn_diff_is_u16_settings {
-  public:
+struct lookup_range_check_dyn_diff_is_u16_settings_ {
     static constexpr std::string_view NAME = "LOOKUP_RANGE_CHECK_DYN_DIFF_IS_U16";
     static constexpr std::string_view RELATION_NAME = "range_check";
-
-    static constexpr size_t READ_TERMS = 1;
-    static constexpr size_t WRITE_TERMS = 1;
-    static constexpr size_t READ_TERM_TYPES[READ_TERMS] = { 0 };
-    static constexpr size_t WRITE_TERM_TYPES[WRITE_TERMS] = { 0 };
     static constexpr size_t LOOKUP_TUPLE_SIZE = 1;
-    static constexpr size_t INVERSE_EXISTS_POLYNOMIAL_DEGREE = 4;
-    static constexpr size_t READ_TERM_DEGREE = 0;
-    static constexpr size_t WRITE_TERM_DEGREE = 0;
-
-    // Columns using the Column enum.
     static constexpr Column SRC_SELECTOR = Column::range_check_sel;
     static constexpr Column DST_SELECTOR = Column::precomputed_sel_range_16;
     static constexpr Column COUNTS = Column::lookup_range_check_dyn_diff_is_u16_counts;
@@ -124,84 +48,19 @@ class lookup_range_check_dyn_diff_is_u16_settings {
         ColumnAndShifts::range_check_dyn_diff
     };
     static constexpr std::array<ColumnAndShifts, LOOKUP_TUPLE_SIZE> DST_COLUMNS = { ColumnAndShifts::precomputed_clk };
-
-    template <typename AllEntities> static inline auto inverse_polynomial_is_computed_at_row(const AllEntities& in)
-    {
-        return (in.get(ColumnAndShifts::range_check_sel) == 1 ||
-                in.get(ColumnAndShifts::precomputed_sel_range_16) == 1);
-    }
-
-    template <typename Accumulator, typename AllEntities>
-    static inline auto compute_inverse_exists(const AllEntities& in)
-    {
-        using View = typename Accumulator::View;
-        const auto is_operation = View(in.get(ColumnAndShifts::range_check_sel));
-        const auto is_table_entry = View(in.get(ColumnAndShifts::precomputed_sel_range_16));
-        return (is_operation + is_table_entry - is_operation * is_table_entry);
-    }
-
-    template <typename AllEntities> static inline auto get_const_entities(const AllEntities& in)
-    {
-        return get_entities(in);
-    }
-
-    template <typename AllEntities> static inline auto get_nonconst_entities(AllEntities& in)
-    {
-        return get_entities(in);
-    }
-
-    template <typename AllEntities> static inline auto get_entities(AllEntities&& in)
-    {
-        return std::forward_as_tuple(in.get(ColumnAndShifts::lookup_range_check_dyn_diff_is_u16_inv),
-                                     in.get(ColumnAndShifts::lookup_range_check_dyn_diff_is_u16_counts),
-                                     in.get(ColumnAndShifts::range_check_sel),
-                                     in.get(ColumnAndShifts::precomputed_sel_range_16),
-                                     in.get(ColumnAndShifts::range_check_dyn_diff),
-                                     in.get(ColumnAndShifts::precomputed_clk));
-    }
 };
 
+using lookup_range_check_dyn_diff_is_u16_settings = lookup_settings<lookup_range_check_dyn_diff_is_u16_settings_>;
 template <typename FF_>
-class lookup_range_check_dyn_diff_is_u16_relation
-    : public GenericLookupRelation<lookup_range_check_dyn_diff_is_u16_settings, FF_> {
-  public:
-    using Settings = lookup_range_check_dyn_diff_is_u16_settings;
-    static constexpr std::string_view NAME = lookup_range_check_dyn_diff_is_u16_settings::NAME;
-    static constexpr std::string_view RELATION_NAME = lookup_range_check_dyn_diff_is_u16_settings::RELATION_NAME;
-
-    template <typename AllEntities> inline static bool skip(const AllEntities& in)
-    {
-        return in.lookup_range_check_dyn_diff_is_u16_inv.is_zero();
-    }
-
-    static std::string get_subrelation_label(size_t index)
-    {
-        if (index == 0) {
-            return "INVERSES_ARE_CORRECT";
-        } else if (index == 1) {
-            return "ACCUMULATION_IS_CORRECT";
-        }
-        return std::to_string(index);
-    }
-};
+using lookup_range_check_dyn_diff_is_u16_relation =
+    lookup_relation_base<FF_, lookup_range_check_dyn_diff_is_u16_settings>;
 
 /////////////////// lookup_range_check_r0_is_u16 ///////////////////
 
-class lookup_range_check_r0_is_u16_settings {
-  public:
+struct lookup_range_check_r0_is_u16_settings_ {
     static constexpr std::string_view NAME = "LOOKUP_RANGE_CHECK_R0_IS_U16";
     static constexpr std::string_view RELATION_NAME = "range_check";
-
-    static constexpr size_t READ_TERMS = 1;
-    static constexpr size_t WRITE_TERMS = 1;
-    static constexpr size_t READ_TERM_TYPES[READ_TERMS] = { 0 };
-    static constexpr size_t WRITE_TERM_TYPES[WRITE_TERMS] = { 0 };
     static constexpr size_t LOOKUP_TUPLE_SIZE = 1;
-    static constexpr size_t INVERSE_EXISTS_POLYNOMIAL_DEGREE = 4;
-    static constexpr size_t READ_TERM_DEGREE = 0;
-    static constexpr size_t WRITE_TERM_DEGREE = 0;
-
-    // Columns using the Column enum.
     static constexpr Column SRC_SELECTOR = Column::range_check_sel_r0_16_bit_rng_lookup;
     static constexpr Column DST_SELECTOR = Column::precomputed_sel_range_16;
     static constexpr Column COUNTS = Column::lookup_range_check_r0_is_u16_counts;
@@ -210,83 +69,18 @@ class lookup_range_check_r0_is_u16_settings {
         ColumnAndShifts::range_check_u16_r0
     };
     static constexpr std::array<ColumnAndShifts, LOOKUP_TUPLE_SIZE> DST_COLUMNS = { ColumnAndShifts::precomputed_clk };
-
-    template <typename AllEntities> static inline auto inverse_polynomial_is_computed_at_row(const AllEntities& in)
-    {
-        return (in.get(ColumnAndShifts::range_check_sel_r0_16_bit_rng_lookup) == 1 ||
-                in.get(ColumnAndShifts::precomputed_sel_range_16) == 1);
-    }
-
-    template <typename Accumulator, typename AllEntities>
-    static inline auto compute_inverse_exists(const AllEntities& in)
-    {
-        using View = typename Accumulator::View;
-        const auto is_operation = View(in.get(ColumnAndShifts::range_check_sel_r0_16_bit_rng_lookup));
-        const auto is_table_entry = View(in.get(ColumnAndShifts::precomputed_sel_range_16));
-        return (is_operation + is_table_entry - is_operation * is_table_entry);
-    }
-
-    template <typename AllEntities> static inline auto get_const_entities(const AllEntities& in)
-    {
-        return get_entities(in);
-    }
-
-    template <typename AllEntities> static inline auto get_nonconst_entities(AllEntities& in)
-    {
-        return get_entities(in);
-    }
-
-    template <typename AllEntities> static inline auto get_entities(AllEntities&& in)
-    {
-        return std::forward_as_tuple(in.get(ColumnAndShifts::lookup_range_check_r0_is_u16_inv),
-                                     in.get(ColumnAndShifts::lookup_range_check_r0_is_u16_counts),
-                                     in.get(ColumnAndShifts::range_check_sel_r0_16_bit_rng_lookup),
-                                     in.get(ColumnAndShifts::precomputed_sel_range_16),
-                                     in.get(ColumnAndShifts::range_check_u16_r0),
-                                     in.get(ColumnAndShifts::precomputed_clk));
-    }
 };
 
+using lookup_range_check_r0_is_u16_settings = lookup_settings<lookup_range_check_r0_is_u16_settings_>;
 template <typename FF_>
-class lookup_range_check_r0_is_u16_relation : public GenericLookupRelation<lookup_range_check_r0_is_u16_settings, FF_> {
-  public:
-    using Settings = lookup_range_check_r0_is_u16_settings;
-    static constexpr std::string_view NAME = lookup_range_check_r0_is_u16_settings::NAME;
-    static constexpr std::string_view RELATION_NAME = lookup_range_check_r0_is_u16_settings::RELATION_NAME;
-
-    template <typename AllEntities> inline static bool skip(const AllEntities& in)
-    {
-        return in.lookup_range_check_r0_is_u16_inv.is_zero();
-    }
-
-    static std::string get_subrelation_label(size_t index)
-    {
-        if (index == 0) {
-            return "INVERSES_ARE_CORRECT";
-        } else if (index == 1) {
-            return "ACCUMULATION_IS_CORRECT";
-        }
-        return std::to_string(index);
-    }
-};
+using lookup_range_check_r0_is_u16_relation = lookup_relation_base<FF_, lookup_range_check_r0_is_u16_settings>;
 
 /////////////////// lookup_range_check_r1_is_u16 ///////////////////
 
-class lookup_range_check_r1_is_u16_settings {
-  public:
+struct lookup_range_check_r1_is_u16_settings_ {
     static constexpr std::string_view NAME = "LOOKUP_RANGE_CHECK_R1_IS_U16";
     static constexpr std::string_view RELATION_NAME = "range_check";
-
-    static constexpr size_t READ_TERMS = 1;
-    static constexpr size_t WRITE_TERMS = 1;
-    static constexpr size_t READ_TERM_TYPES[READ_TERMS] = { 0 };
-    static constexpr size_t WRITE_TERM_TYPES[WRITE_TERMS] = { 0 };
     static constexpr size_t LOOKUP_TUPLE_SIZE = 1;
-    static constexpr size_t INVERSE_EXISTS_POLYNOMIAL_DEGREE = 4;
-    static constexpr size_t READ_TERM_DEGREE = 0;
-    static constexpr size_t WRITE_TERM_DEGREE = 0;
-
-    // Columns using the Column enum.
     static constexpr Column SRC_SELECTOR = Column::range_check_sel_r1_16_bit_rng_lookup;
     static constexpr Column DST_SELECTOR = Column::precomputed_sel_range_16;
     static constexpr Column COUNTS = Column::lookup_range_check_r1_is_u16_counts;
@@ -295,83 +89,18 @@ class lookup_range_check_r1_is_u16_settings {
         ColumnAndShifts::range_check_u16_r1
     };
     static constexpr std::array<ColumnAndShifts, LOOKUP_TUPLE_SIZE> DST_COLUMNS = { ColumnAndShifts::precomputed_clk };
-
-    template <typename AllEntities> static inline auto inverse_polynomial_is_computed_at_row(const AllEntities& in)
-    {
-        return (in.get(ColumnAndShifts::range_check_sel_r1_16_bit_rng_lookup) == 1 ||
-                in.get(ColumnAndShifts::precomputed_sel_range_16) == 1);
-    }
-
-    template <typename Accumulator, typename AllEntities>
-    static inline auto compute_inverse_exists(const AllEntities& in)
-    {
-        using View = typename Accumulator::View;
-        const auto is_operation = View(in.get(ColumnAndShifts::range_check_sel_r1_16_bit_rng_lookup));
-        const auto is_table_entry = View(in.get(ColumnAndShifts::precomputed_sel_range_16));
-        return (is_operation + is_table_entry - is_operation * is_table_entry);
-    }
-
-    template <typename AllEntities> static inline auto get_const_entities(const AllEntities& in)
-    {
-        return get_entities(in);
-    }
-
-    template <typename AllEntities> static inline auto get_nonconst_entities(AllEntities& in)
-    {
-        return get_entities(in);
-    }
-
-    template <typename AllEntities> static inline auto get_entities(AllEntities&& in)
-    {
-        return std::forward_as_tuple(in.get(ColumnAndShifts::lookup_range_check_r1_is_u16_inv),
-                                     in.get(ColumnAndShifts::lookup_range_check_r1_is_u16_counts),
-                                     in.get(ColumnAndShifts::range_check_sel_r1_16_bit_rng_lookup),
-                                     in.get(ColumnAndShifts::precomputed_sel_range_16),
-                                     in.get(ColumnAndShifts::range_check_u16_r1),
-                                     in.get(ColumnAndShifts::precomputed_clk));
-    }
 };
 
+using lookup_range_check_r1_is_u16_settings = lookup_settings<lookup_range_check_r1_is_u16_settings_>;
 template <typename FF_>
-class lookup_range_check_r1_is_u16_relation : public GenericLookupRelation<lookup_range_check_r1_is_u16_settings, FF_> {
-  public:
-    using Settings = lookup_range_check_r1_is_u16_settings;
-    static constexpr std::string_view NAME = lookup_range_check_r1_is_u16_settings::NAME;
-    static constexpr std::string_view RELATION_NAME = lookup_range_check_r1_is_u16_settings::RELATION_NAME;
-
-    template <typename AllEntities> inline static bool skip(const AllEntities& in)
-    {
-        return in.lookup_range_check_r1_is_u16_inv.is_zero();
-    }
-
-    static std::string get_subrelation_label(size_t index)
-    {
-        if (index == 0) {
-            return "INVERSES_ARE_CORRECT";
-        } else if (index == 1) {
-            return "ACCUMULATION_IS_CORRECT";
-        }
-        return std::to_string(index);
-    }
-};
+using lookup_range_check_r1_is_u16_relation = lookup_relation_base<FF_, lookup_range_check_r1_is_u16_settings>;
 
 /////////////////// lookup_range_check_r2_is_u16 ///////////////////
 
-class lookup_range_check_r2_is_u16_settings {
-  public:
+struct lookup_range_check_r2_is_u16_settings_ {
     static constexpr std::string_view NAME = "LOOKUP_RANGE_CHECK_R2_IS_U16";
     static constexpr std::string_view RELATION_NAME = "range_check";
-
-    static constexpr size_t READ_TERMS = 1;
-    static constexpr size_t WRITE_TERMS = 1;
-    static constexpr size_t READ_TERM_TYPES[READ_TERMS] = { 0 };
-    static constexpr size_t WRITE_TERM_TYPES[WRITE_TERMS] = { 0 };
     static constexpr size_t LOOKUP_TUPLE_SIZE = 1;
-    static constexpr size_t INVERSE_EXISTS_POLYNOMIAL_DEGREE = 4;
-    static constexpr size_t READ_TERM_DEGREE = 0;
-    static constexpr size_t WRITE_TERM_DEGREE = 0;
-
-    // Columns using the Column enum.
     static constexpr Column SRC_SELECTOR = Column::range_check_sel_r2_16_bit_rng_lookup;
     static constexpr Column DST_SELECTOR = Column::precomputed_sel_range_16;
     static constexpr Column COUNTS = Column::lookup_range_check_r2_is_u16_counts;
@@ -380,83 +109,18 @@ class lookup_range_check_r2_is_u16_settings {
         ColumnAndShifts::range_check_u16_r2
     };
     static constexpr std::array<ColumnAndShifts, LOOKUP_TUPLE_SIZE> DST_COLUMNS = { ColumnAndShifts::precomputed_clk };
-
-    template <typename AllEntities> static inline auto inverse_polynomial_is_computed_at_row(const AllEntities& in)
-    {
-        return (in.get(ColumnAndShifts::range_check_sel_r2_16_bit_rng_lookup) == 1 ||
-                in.get(ColumnAndShifts::precomputed_sel_range_16) == 1);
-    }
-
-    template <typename Accumulator, typename AllEntities>
-    static inline auto compute_inverse_exists(const AllEntities& in)
-    {
-        using View = typename Accumulator::View;
-        const auto is_operation = View(in.get(ColumnAndShifts::range_check_sel_r2_16_bit_rng_lookup));
-        const auto is_table_entry = View(in.get(ColumnAndShifts::precomputed_sel_range_16));
-        return (is_operation + is_table_entry - is_operation * is_table_entry);
-    }
-
-    template <typename AllEntities> static inline auto get_const_entities(const AllEntities& in)
-    {
-        return get_entities(in);
-    }
-
-    template <typename AllEntities> static inline auto get_nonconst_entities(AllEntities& in)
-    {
-        return get_entities(in);
-    }
-
-    template <typename AllEntities> static inline auto get_entities(AllEntities&& in)
-    {
-        return std::forward_as_tuple(in.get(ColumnAndShifts::lookup_range_check_r2_is_u16_inv),
-                                     in.get(ColumnAndShifts::lookup_range_check_r2_is_u16_counts),
-                                     in.get(ColumnAndShifts::range_check_sel_r2_16_bit_rng_lookup),
-                                     in.get(ColumnAndShifts::precomputed_sel_range_16),
-                                     in.get(ColumnAndShifts::range_check_u16_r2),
-                                     in.get(ColumnAndShifts::precomputed_clk));
-    }
 };
 
+using lookup_range_check_r2_is_u16_settings = lookup_settings<lookup_range_check_r2_is_u16_settings_>;
 template <typename FF_>
-class lookup_range_check_r2_is_u16_relation : public GenericLookupRelation<lookup_range_check_r2_is_u16_settings, FF_> {
-  public:
-    using Settings = lookup_range_check_r2_is_u16_settings;
-    static constexpr std::string_view NAME = lookup_range_check_r2_is_u16_settings::NAME;
-    static constexpr std::string_view RELATION_NAME = lookup_range_check_r2_is_u16_settings::RELATION_NAME;
-
-    template <typename AllEntities> inline static bool skip(const AllEntities& in)
-    {
-        return in.lookup_range_check_r2_is_u16_inv.is_zero();
-    }
-
-    static std::string get_subrelation_label(size_t index)
-    {
-        if (index == 0) {
-            return "INVERSES_ARE_CORRECT";
-        } else if (index == 1) {
-            return "ACCUMULATION_IS_CORRECT";
-        }
-        return std::to_string(index);
-    }
-};
+using lookup_range_check_r2_is_u16_relation = lookup_relation_base<FF_, lookup_range_check_r2_is_u16_settings>;
 
 /////////////////// lookup_range_check_r3_is_u16 ///////////////////
 
-class lookup_range_check_r3_is_u16_settings {
-  public:
+struct lookup_range_check_r3_is_u16_settings_ {
     static constexpr std::string_view NAME = "LOOKUP_RANGE_CHECK_R3_IS_U16";
     static constexpr std::string_view RELATION_NAME = "range_check";
-
-    static constexpr size_t READ_TERMS = 1;
-    static constexpr size_t WRITE_TERMS = 1;
-    static constexpr size_t READ_TERM_TYPES[READ_TERMS] = { 0 };
-    static constexpr size_t WRITE_TERM_TYPES[WRITE_TERMS] = { 0 };
     static constexpr size_t LOOKUP_TUPLE_SIZE = 1;
-    static constexpr size_t INVERSE_EXISTS_POLYNOMIAL_DEGREE = 4;
-    static constexpr size_t READ_TERM_DEGREE = 0;
-    static constexpr size_t WRITE_TERM_DEGREE = 0;
-
-    // Columns using the Column enum.
     static constexpr Column SRC_SELECTOR = Column::range_check_sel_r3_16_bit_rng_lookup;
     static constexpr Column DST_SELECTOR = Column::precomputed_sel_range_16;
     static constexpr Column COUNTS = Column::lookup_range_check_r3_is_u16_counts;
@@ -465,83 +129,18 @@ class lookup_range_check_r3_is_u16_settings {
         ColumnAndShifts::range_check_u16_r3
     };
     static constexpr std::array<ColumnAndShifts, LOOKUP_TUPLE_SIZE> DST_COLUMNS = { ColumnAndShifts::precomputed_clk };
-
-    template <typename AllEntities> static inline auto inverse_polynomial_is_computed_at_row(const AllEntities& in)
-    {
-        return (in.get(ColumnAndShifts::range_check_sel_r3_16_bit_rng_lookup) == 1 ||
-                in.get(ColumnAndShifts::precomputed_sel_range_16) == 1);
-    }
-
-    template <typename Accumulator, typename AllEntities>
-    static inline auto compute_inverse_exists(const AllEntities& in)
-    {
-        using View = typename Accumulator::View;
-        const auto is_operation = View(in.get(ColumnAndShifts::range_check_sel_r3_16_bit_rng_lookup));
-        const auto is_table_entry = View(in.get(ColumnAndShifts::precomputed_sel_range_16));
-        return (is_operation + is_table_entry - is_operation * is_table_entry);
-    }
-
-    template <typename AllEntities> static inline auto get_const_entities(const AllEntities& in)
-    {
-        return get_entities(in);
-    }
-
-    template <typename AllEntities> static inline auto get_nonconst_entities(AllEntities& in)
-    {
-        return get_entities(in);
-    }
-
-    template <typename AllEntities> static inline auto get_entities(AllEntities&& in)
-    {
-        return std::forward_as_tuple(in.get(ColumnAndShifts::lookup_range_check_r3_is_u16_inv),
-                                     in.get(ColumnAndShifts::lookup_range_check_r3_is_u16_counts),
-                                     in.get(ColumnAndShifts::range_check_sel_r3_16_bit_rng_lookup),
-                                     in.get(ColumnAndShifts::precomputed_sel_range_16),
-                                     in.get(ColumnAndShifts::range_check_u16_r3),
-                                     in.get(ColumnAndShifts::precomputed_clk));
-    }
 };
 
+using lookup_range_check_r3_is_u16_settings = lookup_settings<lookup_range_check_r3_is_u16_settings_>;
 template <typename FF_>
-class lookup_range_check_r3_is_u16_relation : public GenericLookupRelation<lookup_range_check_r3_is_u16_settings, FF_> {
-  public:
-    using Settings = lookup_range_check_r3_is_u16_settings;
-    static constexpr std::string_view NAME = lookup_range_check_r3_is_u16_settings::NAME;
-    static constexpr std::string_view RELATION_NAME = lookup_range_check_r3_is_u16_settings::RELATION_NAME;
-
-    template <typename AllEntities> inline static bool skip(const AllEntities& in)
-    {
-        return in.lookup_range_check_r3_is_u16_inv.is_zero();
-    }
-
-    static std::string get_subrelation_label(size_t index)
-    {
-        if (index == 0) {
-            return "INVERSES_ARE_CORRECT";
-        } else if (index == 1) {
-            return "ACCUMULATION_IS_CORRECT";
-        }
-        return std::to_string(index);
-    }
-};
+using lookup_range_check_r3_is_u16_relation = lookup_relation_base<FF_, lookup_range_check_r3_is_u16_settings>;
 
 /////////////////// lookup_range_check_r4_is_u16 ///////////////////
 
-class lookup_range_check_r4_is_u16_settings {
-  public:
+struct lookup_range_check_r4_is_u16_settings_ {
     static constexpr std::string_view NAME = "LOOKUP_RANGE_CHECK_R4_IS_U16";
     static constexpr std::string_view RELATION_NAME = "range_check";
-
-    static constexpr size_t READ_TERMS = 1;
-    static constexpr size_t WRITE_TERMS = 1;
-    static constexpr size_t READ_TERM_TYPES[READ_TERMS] = { 0 };
-    static constexpr size_t WRITE_TERM_TYPES[WRITE_TERMS] = { 0 };
     static constexpr size_t LOOKUP_TUPLE_SIZE = 1;
-    static constexpr size_t INVERSE_EXISTS_POLYNOMIAL_DEGREE = 4;
-    static constexpr size_t READ_TERM_DEGREE = 0;
-    static constexpr size_t WRITE_TERM_DEGREE = 0;
-
-    // Columns using the Column enum.
     static constexpr Column SRC_SELECTOR = Column::range_check_sel_r4_16_bit_rng_lookup;
     static constexpr Column DST_SELECTOR = Column::precomputed_sel_range_16;
     static constexpr Column COUNTS = Column::lookup_range_check_r4_is_u16_counts;
@@ -550,83 +149,18 @@ class lookup_range_check_r4_is_u16_settings {
         ColumnAndShifts::range_check_u16_r4
     };
     static constexpr std::array<ColumnAndShifts, LOOKUP_TUPLE_SIZE> DST_COLUMNS = { ColumnAndShifts::precomputed_clk };
-
-    template <typename AllEntities> static inline auto inverse_polynomial_is_computed_at_row(const AllEntities& in)
-    {
-        return (in.get(ColumnAndShifts::range_check_sel_r4_16_bit_rng_lookup) == 1 ||
-                in.get(ColumnAndShifts::precomputed_sel_range_16) == 1);
-    }
-
-    template <typename Accumulator, typename AllEntities>
-    static inline auto compute_inverse_exists(const AllEntities& in)
-    {
-        using View = typename Accumulator::View;
-        const auto is_operation = View(in.get(ColumnAndShifts::range_check_sel_r4_16_bit_rng_lookup));
-        const auto is_table_entry = View(in.get(ColumnAndShifts::precomputed_sel_range_16));
-        return (is_operation + is_table_entry - is_operation * is_table_entry);
-    }
-
-    template <typename AllEntities> static inline auto get_const_entities(const AllEntities& in)
-    {
-        return get_entities(in);
-    }
-
-    template <typename AllEntities> static inline auto get_nonconst_entities(AllEntities& in)
-    {
-        return get_entities(in);
-    }
-
-    template <typename AllEntities> static inline auto get_entities(AllEntities&& in)
-    {
-        return std::forward_as_tuple(in.get(ColumnAndShifts::lookup_range_check_r4_is_u16_inv),
-                                     in.get(ColumnAndShifts::lookup_range_check_r4_is_u16_counts),
-                                     in.get(ColumnAndShifts::range_check_sel_r4_16_bit_rng_lookup),
-                                     in.get(ColumnAndShifts::precomputed_sel_range_16),
-                                     in.get(ColumnAndShifts::range_check_u16_r4),
-                                     in.get(ColumnAndShifts::precomputed_clk));
-    }
 };
 
+using lookup_range_check_r4_is_u16_settings = lookup_settings<lookup_range_check_r4_is_u16_settings_>;
 template <typename FF_>
-class lookup_range_check_r4_is_u16_relation : public GenericLookupRelation<lookup_range_check_r4_is_u16_settings, FF_> {
-  public:
-    using Settings = lookup_range_check_r4_is_u16_settings;
-    static constexpr std::string_view NAME = lookup_range_check_r4_is_u16_settings::NAME;
-    static constexpr std::string_view RELATION_NAME = lookup_range_check_r4_is_u16_settings::RELATION_NAME;
-
-    template <typename AllEntities> inline static bool skip(const AllEntities& in)
-    {
-        return in.lookup_range_check_r4_is_u16_inv.is_zero();
-    }
-
-    static std::string get_subrelation_label(size_t index)
-    {
-        if (index == 0) {
-            return "INVERSES_ARE_CORRECT";
-        } else if (index == 1) {
-            return "ACCUMULATION_IS_CORRECT";
-        }
-        return std::to_string(index);
-    }
-};
+using lookup_range_check_r4_is_u16_relation = lookup_relation_base<FF_, lookup_range_check_r4_is_u16_settings>;
 
 /////////////////// lookup_range_check_r5_is_u16 ///////////////////
 
-class lookup_range_check_r5_is_u16_settings {
-  public:
+struct lookup_range_check_r5_is_u16_settings_ {
     static constexpr std::string_view NAME = "LOOKUP_RANGE_CHECK_R5_IS_U16";
     static constexpr std::string_view RELATION_NAME = "range_check";
-
-    static constexpr size_t READ_TERMS = 1;
-    static constexpr size_t WRITE_TERMS = 1;
-    static constexpr size_t READ_TERM_TYPES[READ_TERMS] = { 0 };
-    static constexpr size_t WRITE_TERM_TYPES[WRITE_TERMS] = { 0 };
     static constexpr size_t LOOKUP_TUPLE_SIZE = 1;
-    static constexpr size_t INVERSE_EXISTS_POLYNOMIAL_DEGREE = 4;
-    static constexpr size_t READ_TERM_DEGREE = 0;
-    static constexpr size_t WRITE_TERM_DEGREE = 0;
-
-    // Columns using the Column enum.
     static constexpr Column SRC_SELECTOR = Column::range_check_sel_r5_16_bit_rng_lookup;
     static constexpr Column DST_SELECTOR = Column::precomputed_sel_range_16;
     static constexpr Column COUNTS = Column::lookup_range_check_r5_is_u16_counts;
@@ -635,83 +169,18 @@ class lookup_range_check_r5_is_u16_settings {
         ColumnAndShifts::range_check_u16_r5
     };
     static constexpr std::array<ColumnAndShifts, LOOKUP_TUPLE_SIZE> DST_COLUMNS = { ColumnAndShifts::precomputed_clk };
-
-    template <typename AllEntities> static inline auto inverse_polynomial_is_computed_at_row(const AllEntities& in)
-    {
-        return (in.get(ColumnAndShifts::range_check_sel_r5_16_bit_rng_lookup) == 1 ||
-                in.get(ColumnAndShifts::precomputed_sel_range_16) == 1);
-    }
-
-    template <typename Accumulator, typename AllEntities>
-    static inline auto compute_inverse_exists(const AllEntities& in)
-    {
-        using View = typename Accumulator::View;
-        const auto is_operation = View(in.get(ColumnAndShifts::range_check_sel_r5_16_bit_rng_lookup));
-        const auto is_table_entry = View(in.get(ColumnAndShifts::precomputed_sel_range_16));
-        return (is_operation + is_table_entry - is_operation * is_table_entry);
-    }
-
-    template <typename AllEntities> static inline auto get_const_entities(const AllEntities& in)
-    {
-        return get_entities(in);
-    }
-
-    template <typename AllEntities> static inline auto get_nonconst_entities(AllEntities& in)
-    {
-        return get_entities(in);
-    }
-
-    template <typename AllEntities> static inline auto get_entities(AllEntities&& in)
-    {
-        return std::forward_as_tuple(in.get(ColumnAndShifts::lookup_range_check_r5_is_u16_inv),
-                                     in.get(ColumnAndShifts::lookup_range_check_r5_is_u16_counts),
-                                     in.get(ColumnAndShifts::range_check_sel_r5_16_bit_rng_lookup),
-                                     in.get(ColumnAndShifts::precomputed_sel_range_16),
-                                     in.get(ColumnAndShifts::range_check_u16_r5),
-                                     in.get(ColumnAndShifts::precomputed_clk));
-    }
 };
 
+using lookup_range_check_r5_is_u16_settings = lookup_settings<lookup_range_check_r5_is_u16_settings_>;
 template <typename FF_>
-class lookup_range_check_r5_is_u16_relation : public GenericLookupRelation<lookup_range_check_r5_is_u16_settings, FF_> {
-  public:
-    using Settings = lookup_range_check_r5_is_u16_settings;
-    static constexpr std::string_view NAME = lookup_range_check_r5_is_u16_settings::NAME;
-    static constexpr std::string_view RELATION_NAME = lookup_range_check_r5_is_u16_settings::RELATION_NAME;
-
-    template <typename AllEntities> inline static bool skip(const AllEntities& in)
-    {
-        return in.lookup_range_check_r5_is_u16_inv.is_zero();
-    }
-
-    static std::string get_subrelation_label(size_t index)
-    {
-        if (index == 0) {
-            return "INVERSES_ARE_CORRECT";
-        } else if (index == 1) {
-            return "ACCUMULATION_IS_CORRECT";
-        }
-        return std::to_string(index);
-    }
-};
+using lookup_range_check_r5_is_u16_relation = lookup_relation_base<FF_, lookup_range_check_r5_is_u16_settings>;
 
 /////////////////// lookup_range_check_r6_is_u16 ///////////////////
 
-class lookup_range_check_r6_is_u16_settings {
-  public:
+struct lookup_range_check_r6_is_u16_settings_ {
     static constexpr std::string_view NAME = "LOOKUP_RANGE_CHECK_R6_IS_U16";
     static constexpr std::string_view RELATION_NAME = "range_check";
-
-    static constexpr size_t READ_TERMS = 1;
-    static constexpr size_t WRITE_TERMS = 1;
-    static constexpr size_t READ_TERM_TYPES[READ_TERMS] = { 0 };
-    static constexpr size_t WRITE_TERM_TYPES[WRITE_TERMS] = { 0 };
     static constexpr size_t LOOKUP_TUPLE_SIZE = 1;
-    static constexpr size_t INVERSE_EXISTS_POLYNOMIAL_DEGREE = 4;
-    static constexpr size_t READ_TERM_DEGREE = 0;
-    static constexpr size_t WRITE_TERM_DEGREE = 0;
-
-    // Columns using the Column enum.
     static constexpr Column SRC_SELECTOR = Column::range_check_sel_r6_16_bit_rng_lookup;
     static constexpr Column DST_SELECTOR = Column::precomputed_sel_range_16;
     static constexpr Column COUNTS = Column::lookup_range_check_r6_is_u16_counts;
@@ -720,83 +189,18 @@ class lookup_range_check_r6_is_u16_settings {
         ColumnAndShifts::range_check_u16_r6
     };
     static constexpr std::array<ColumnAndShifts, LOOKUP_TUPLE_SIZE> DST_COLUMNS = { ColumnAndShifts::precomputed_clk };
-
-    template <typename AllEntities> static inline auto inverse_polynomial_is_computed_at_row(const AllEntities& in)
-    {
-        return (in.get(ColumnAndShifts::range_check_sel_r6_16_bit_rng_lookup) == 1 ||
-                in.get(ColumnAndShifts::precomputed_sel_range_16) == 1);
-    }
-
-    template <typename Accumulator, typename AllEntities>
-    static inline auto compute_inverse_exists(const AllEntities& in)
-    {
-        using View = typename Accumulator::View;
-        const auto is_operation = View(in.get(ColumnAndShifts::range_check_sel_r6_16_bit_rng_lookup));
-        const auto is_table_entry = View(in.get(ColumnAndShifts::precomputed_sel_range_16));
-        return (is_operation + is_table_entry - is_operation * is_table_entry);
-    }
-
-    template <typename AllEntities> static inline auto get_const_entities(const AllEntities& in)
-    {
-        return get_entities(in);
-    }
-
-    template <typename AllEntities> static inline auto get_nonconst_entities(AllEntities& in)
-    {
-        return get_entities(in);
-    }
-
-    template <typename AllEntities> static inline auto get_entities(AllEntities&& in)
-    {
-        return std::forward_as_tuple(in.get(ColumnAndShifts::lookup_range_check_r6_is_u16_inv),
-                                     in.get(ColumnAndShifts::lookup_range_check_r6_is_u16_counts),
-                                     in.get(ColumnAndShifts::range_check_sel_r6_16_bit_rng_lookup),
-                                     in.get(ColumnAndShifts::precomputed_sel_range_16),
-                                     in.get(ColumnAndShifts::range_check_u16_r6),
-                                     in.get(ColumnAndShifts::precomputed_clk));
-    }
 };
 
+using lookup_range_check_r6_is_u16_settings = lookup_settings<lookup_range_check_r6_is_u16_settings_>;
 template <typename FF_>
-class lookup_range_check_r6_is_u16_relation : public GenericLookupRelation<lookup_range_check_r6_is_u16_settings, FF_> {
-  public:
-    using Settings = lookup_range_check_r6_is_u16_settings;
-    static constexpr std::string_view NAME = lookup_range_check_r6_is_u16_settings::NAME;
-    static constexpr std::string_view RELATION_NAME = lookup_range_check_r6_is_u16_settings::RELATION_NAME;
-
-    template <typename AllEntities> inline static bool skip(const AllEntities& in)
-    {
-        return in.lookup_range_check_r6_is_u16_inv.is_zero();
-    }
-
-    static std::string get_subrelation_label(size_t index)
-    {
-        if (index == 0) {
-            return "INVERSES_ARE_CORRECT";
-        } else if (index == 1) {
-            return "ACCUMULATION_IS_CORRECT";
-        }
-        return std::to_string(index);
-    }
-};
+using lookup_range_check_r6_is_u16_relation = lookup_relation_base<FF_, lookup_range_check_r6_is_u16_settings>;
 
 /////////////////// lookup_range_check_r7_is_u16 ///////////////////
 
-class lookup_range_check_r7_is_u16_settings {
-  public:
+struct lookup_range_check_r7_is_u16_settings_ {
     static constexpr std::string_view NAME = "LOOKUP_RANGE_CHECK_R7_IS_U16";
     static constexpr std::string_view RELATION_NAME = "range_check";
-
-    static constexpr size_t READ_TERMS = 1;
-    static constexpr size_t WRITE_TERMS = 1;
-    static constexpr size_t READ_TERM_TYPES[READ_TERMS] = { 0 };
-    static constexpr size_t WRITE_TERM_TYPES[WRITE_TERMS] = { 0 };
     static constexpr size_t LOOKUP_TUPLE_SIZE = 1;
-    static constexpr size_t INVERSE_EXISTS_POLYNOMIAL_DEGREE = 4;
-    static constexpr size_t READ_TERM_DEGREE = 0;
-    static constexpr size_t WRITE_TERM_DEGREE = 0;
-
-    // Columns using the Column enum.
     static constexpr Column SRC_SELECTOR = Column::range_check_sel;
     static constexpr Column DST_SELECTOR = Column::precomputed_sel_range_16;
     static constexpr Column COUNTS = Column::lookup_range_check_r7_is_u16_counts;
@@ -805,64 +209,10 @@ class lookup_range_check_r7_is_u16_settings {
         ColumnAndShifts::range_check_u16_r7
     };
     static constexpr std::array<ColumnAndShifts, LOOKUP_TUPLE_SIZE> DST_COLUMNS = { ColumnAndShifts::precomputed_clk };
-
-    template <typename AllEntities> static inline auto inverse_polynomial_is_computed_at_row(const AllEntities& in)
-    {
-        return (in.get(ColumnAndShifts::range_check_sel) == 1 ||
-                in.get(ColumnAndShifts::precomputed_sel_range_16) == 1);
-    }
-
-    template <typename Accumulator, typename AllEntities>
-    static inline auto compute_inverse_exists(const AllEntities& in)
-    {
-        using View = typename Accumulator::View;
-        const auto is_operation = View(in.get(ColumnAndShifts::range_check_sel));
-        const auto is_table_entry = View(in.get(ColumnAndShifts::precomputed_sel_range_16));
-        return (is_operation + is_table_entry - is_operation * is_table_entry);
-    }
-
-    template <typename AllEntities> static inline auto get_const_entities(const AllEntities& in)
-    {
-        return get_entities(in);
-    }
-
-    template <typename AllEntities> static inline auto get_nonconst_entities(AllEntities& in)
-    {
-        return get_entities(in);
-    }
-
-    template <typename AllEntities> static inline auto get_entities(AllEntities&& in)
-    {
-        return std::forward_as_tuple(in.get(ColumnAndShifts::lookup_range_check_r7_is_u16_inv),
-                                     in.get(ColumnAndShifts::lookup_range_check_r7_is_u16_counts),
-                                     in.get(ColumnAndShifts::range_check_sel),
-                                     in.get(ColumnAndShifts::precomputed_sel_range_16),
-                                     in.get(ColumnAndShifts::range_check_u16_r7),
-                                     in.get(ColumnAndShifts::precomputed_clk));
-    }
 };
 
+using lookup_range_check_r7_is_u16_settings = lookup_settings<lookup_range_check_r7_is_u16_settings_>;
 template <typename FF_>
-class lookup_range_check_r7_is_u16_relation : public GenericLookupRelation<lookup_range_check_r7_is_u16_settings, FF_> {
-  public:
-    using Settings = lookup_range_check_r7_is_u16_settings;
-    static constexpr std::string_view NAME = lookup_range_check_r7_is_u16_settings::NAME;
-    static constexpr std::string_view RELATION_NAME = lookup_range_check_r7_is_u16_settings::RELATION_NAME;
-
-    template <typename AllEntities> inline static bool skip(const AllEntities& in)
-    {
-        return in.lookup_range_check_r7_is_u16_inv.is_zero();
-    }
-
-    static std::string get_subrelation_label(size_t index)
-    {
-        if (index == 0) {
-            return "INVERSES_ARE_CORRECT";
-        } else if (index == 1) {
-            return "ACCUMULATION_IS_CORRECT";
-        }
-        return std::to_string(index);
-    }
-};
+using lookup_range_check_r7_is_u16_relation = lookup_relation_base<FF_, lookup_range_check_r7_is_u16_settings>;
 
 } // namespace bb::avm2

--- a/barretenberg/cpp/src/barretenberg/vm2/generated/relations/lookups_scalar_mul.hpp
+++ b/barretenberg/cpp/src/barretenberg/vm2/generated/relations/lookups_scalar_mul.hpp
@@ -3,6 +3,7 @@
 
 #include "../columns.hpp"
 #include "barretenberg/relations/generic_lookup/generic_lookup_relation.hpp"
+#include "barretenberg/vm2/constraining/relations/interactions_base.hpp"
 
 #include <cstddef>
 #include <string_view>
@@ -12,21 +13,10 @@ namespace bb::avm2 {
 
 /////////////////// lookup_scalar_mul_to_radix ///////////////////
 
-class lookup_scalar_mul_to_radix_settings {
-  public:
+struct lookup_scalar_mul_to_radix_settings_ {
     static constexpr std::string_view NAME = "LOOKUP_SCALAR_MUL_TO_RADIX";
     static constexpr std::string_view RELATION_NAME = "scalar_mul";
-
-    static constexpr size_t READ_TERMS = 1;
-    static constexpr size_t WRITE_TERMS = 1;
-    static constexpr size_t READ_TERM_TYPES[READ_TERMS] = { 0 };
-    static constexpr size_t WRITE_TERM_TYPES[WRITE_TERMS] = { 0 };
     static constexpr size_t LOOKUP_TUPLE_SIZE = 4;
-    static constexpr size_t INVERSE_EXISTS_POLYNOMIAL_DEGREE = 4;
-    static constexpr size_t READ_TERM_DEGREE = 0;
-    static constexpr size_t WRITE_TERM_DEGREE = 0;
-
-    // Columns using the Column enum.
     static constexpr Column SRC_SELECTOR = Column::scalar_mul_sel;
     static constexpr Column DST_SELECTOR = Column::to_radix_sel;
     static constexpr Column COUNTS = Column::lookup_scalar_mul_to_radix_counts;
@@ -43,88 +33,18 @@ class lookup_scalar_mul_to_radix_settings {
         ColumnAndShifts::to_radix_limb_index,
         ColumnAndShifts::to_radix_radix
     };
-
-    template <typename AllEntities> static inline auto inverse_polynomial_is_computed_at_row(const AllEntities& in)
-    {
-        return (in.get(ColumnAndShifts::scalar_mul_sel) == 1 || in.get(ColumnAndShifts::to_radix_sel) == 1);
-    }
-
-    template <typename Accumulator, typename AllEntities>
-    static inline auto compute_inverse_exists(const AllEntities& in)
-    {
-        using View = typename Accumulator::View;
-        const auto is_operation = View(in.get(ColumnAndShifts::scalar_mul_sel));
-        const auto is_table_entry = View(in.get(ColumnAndShifts::to_radix_sel));
-        return (is_operation + is_table_entry - is_operation * is_table_entry);
-    }
-
-    template <typename AllEntities> static inline auto get_const_entities(const AllEntities& in)
-    {
-        return get_entities(in);
-    }
-
-    template <typename AllEntities> static inline auto get_nonconst_entities(AllEntities& in)
-    {
-        return get_entities(in);
-    }
-
-    template <typename AllEntities> static inline auto get_entities(AllEntities&& in)
-    {
-        return std::forward_as_tuple(in.get(ColumnAndShifts::lookup_scalar_mul_to_radix_inv),
-                                     in.get(ColumnAndShifts::lookup_scalar_mul_to_radix_counts),
-                                     in.get(ColumnAndShifts::scalar_mul_sel),
-                                     in.get(ColumnAndShifts::to_radix_sel),
-                                     in.get(ColumnAndShifts::scalar_mul_scalar),
-                                     in.get(ColumnAndShifts::scalar_mul_bit),
-                                     in.get(ColumnAndShifts::scalar_mul_bit_idx),
-                                     in.get(ColumnAndShifts::scalar_mul_bit_radix),
-                                     in.get(ColumnAndShifts::to_radix_value),
-                                     in.get(ColumnAndShifts::to_radix_limb),
-                                     in.get(ColumnAndShifts::to_radix_limb_index),
-                                     in.get(ColumnAndShifts::to_radix_radix));
-    }
 };
 
+using lookup_scalar_mul_to_radix_settings = lookup_settings<lookup_scalar_mul_to_radix_settings_>;
 template <typename FF_>
-class lookup_scalar_mul_to_radix_relation : public GenericLookupRelation<lookup_scalar_mul_to_radix_settings, FF_> {
-  public:
-    using Settings = lookup_scalar_mul_to_radix_settings;
-    static constexpr std::string_view NAME = lookup_scalar_mul_to_radix_settings::NAME;
-    static constexpr std::string_view RELATION_NAME = lookup_scalar_mul_to_radix_settings::RELATION_NAME;
-
-    template <typename AllEntities> inline static bool skip(const AllEntities& in)
-    {
-        return in.lookup_scalar_mul_to_radix_inv.is_zero();
-    }
-
-    static std::string get_subrelation_label(size_t index)
-    {
-        if (index == 0) {
-            return "INVERSES_ARE_CORRECT";
-        } else if (index == 1) {
-            return "ACCUMULATION_IS_CORRECT";
-        }
-        return std::to_string(index);
-    }
-};
+using lookup_scalar_mul_to_radix_relation = lookup_relation_base<FF_, lookup_scalar_mul_to_radix_settings>;
 
 /////////////////// lookup_scalar_mul_double ///////////////////
 
-class lookup_scalar_mul_double_settings {
-  public:
+struct lookup_scalar_mul_double_settings_ {
     static constexpr std::string_view NAME = "LOOKUP_SCALAR_MUL_DOUBLE";
     static constexpr std::string_view RELATION_NAME = "scalar_mul";
-
-    static constexpr size_t READ_TERMS = 1;
-    static constexpr size_t WRITE_TERMS = 1;
-    static constexpr size_t READ_TERM_TYPES[READ_TERMS] = { 0 };
-    static constexpr size_t WRITE_TERM_TYPES[WRITE_TERMS] = { 0 };
     static constexpr size_t LOOKUP_TUPLE_SIZE = 9;
-    static constexpr size_t INVERSE_EXISTS_POLYNOMIAL_DEGREE = 4;
-    static constexpr size_t READ_TERM_DEGREE = 0;
-    static constexpr size_t WRITE_TERM_DEGREE = 0;
-
-    // Columns using the Column enum.
     static constexpr Column SRC_SELECTOR = Column::scalar_mul_not_end;
     static constexpr Column DST_SELECTOR = Column::ecc_sel;
     static constexpr Column COUNTS = Column::lookup_scalar_mul_double_counts;
@@ -141,98 +61,18 @@ class lookup_scalar_mul_double_settings {
         ColumnAndShifts::ecc_p_x, ColumnAndShifts::ecc_p_y, ColumnAndShifts::ecc_p_is_inf,
         ColumnAndShifts::ecc_q_x, ColumnAndShifts::ecc_q_y, ColumnAndShifts::ecc_q_is_inf
     };
-
-    template <typename AllEntities> static inline auto inverse_polynomial_is_computed_at_row(const AllEntities& in)
-    {
-        return (in.get(ColumnAndShifts::scalar_mul_not_end) == 1 || in.get(ColumnAndShifts::ecc_sel) == 1);
-    }
-
-    template <typename Accumulator, typename AllEntities>
-    static inline auto compute_inverse_exists(const AllEntities& in)
-    {
-        using View = typename Accumulator::View;
-        const auto is_operation = View(in.get(ColumnAndShifts::scalar_mul_not_end));
-        const auto is_table_entry = View(in.get(ColumnAndShifts::ecc_sel));
-        return (is_operation + is_table_entry - is_operation * is_table_entry);
-    }
-
-    template <typename AllEntities> static inline auto get_const_entities(const AllEntities& in)
-    {
-        return get_entities(in);
-    }
-
-    template <typename AllEntities> static inline auto get_nonconst_entities(AllEntities& in)
-    {
-        return get_entities(in);
-    }
-
-    template <typename AllEntities> static inline auto get_entities(AllEntities&& in)
-    {
-        return std::forward_as_tuple(in.get(ColumnAndShifts::lookup_scalar_mul_double_inv),
-                                     in.get(ColumnAndShifts::lookup_scalar_mul_double_counts),
-                                     in.get(ColumnAndShifts::scalar_mul_not_end),
-                                     in.get(ColumnAndShifts::ecc_sel),
-                                     in.get(ColumnAndShifts::scalar_mul_temp_x),
-                                     in.get(ColumnAndShifts::scalar_mul_temp_y),
-                                     in.get(ColumnAndShifts::scalar_mul_temp_inf),
-                                     in.get(ColumnAndShifts::scalar_mul_temp_x_shift),
-                                     in.get(ColumnAndShifts::scalar_mul_temp_y_shift),
-                                     in.get(ColumnAndShifts::scalar_mul_temp_inf_shift),
-                                     in.get(ColumnAndShifts::scalar_mul_temp_x_shift),
-                                     in.get(ColumnAndShifts::scalar_mul_temp_y_shift),
-                                     in.get(ColumnAndShifts::scalar_mul_temp_inf_shift),
-                                     in.get(ColumnAndShifts::ecc_r_x),
-                                     in.get(ColumnAndShifts::ecc_r_y),
-                                     in.get(ColumnAndShifts::ecc_r_is_inf),
-                                     in.get(ColumnAndShifts::ecc_p_x),
-                                     in.get(ColumnAndShifts::ecc_p_y),
-                                     in.get(ColumnAndShifts::ecc_p_is_inf),
-                                     in.get(ColumnAndShifts::ecc_q_x),
-                                     in.get(ColumnAndShifts::ecc_q_y),
-                                     in.get(ColumnAndShifts::ecc_q_is_inf));
-    }
 };
 
+using lookup_scalar_mul_double_settings = lookup_settings<lookup_scalar_mul_double_settings_>;
 template <typename FF_>
-class lookup_scalar_mul_double_relation : public GenericLookupRelation<lookup_scalar_mul_double_settings, FF_> {
-  public:
-    using Settings = lookup_scalar_mul_double_settings;
-    static constexpr std::string_view NAME = lookup_scalar_mul_double_settings::NAME;
-    static constexpr std::string_view RELATION_NAME = lookup_scalar_mul_double_settings::RELATION_NAME;
-
-    template <typename AllEntities> inline static bool skip(const AllEntities& in)
-    {
-        return in.lookup_scalar_mul_double_inv.is_zero();
-    }
-
-    static std::string get_subrelation_label(size_t index)
-    {
-        if (index == 0) {
-            return "INVERSES_ARE_CORRECT";
-        } else if (index == 1) {
-            return "ACCUMULATION_IS_CORRECT";
-        }
-        return std::to_string(index);
-    }
-};
+using lookup_scalar_mul_double_relation = lookup_relation_base<FF_, lookup_scalar_mul_double_settings>;
 
 /////////////////// lookup_scalar_mul_add ///////////////////
 
-class lookup_scalar_mul_add_settings {
-  public:
+struct lookup_scalar_mul_add_settings_ {
     static constexpr std::string_view NAME = "LOOKUP_SCALAR_MUL_ADD";
     static constexpr std::string_view RELATION_NAME = "scalar_mul";
-
-    static constexpr size_t READ_TERMS = 1;
-    static constexpr size_t WRITE_TERMS = 1;
-    static constexpr size_t READ_TERM_TYPES[READ_TERMS] = { 0 };
-    static constexpr size_t WRITE_TERM_TYPES[WRITE_TERMS] = { 0 };
     static constexpr size_t LOOKUP_TUPLE_SIZE = 9;
-    static constexpr size_t INVERSE_EXISTS_POLYNOMIAL_DEGREE = 4;
-    static constexpr size_t READ_TERM_DEGREE = 0;
-    static constexpr size_t WRITE_TERM_DEGREE = 0;
-
-    // Columns using the Column enum.
     static constexpr Column SRC_SELECTOR = Column::scalar_mul_should_add;
     static constexpr Column DST_SELECTOR = Column::ecc_sel;
     static constexpr Column COUNTS = Column::lookup_scalar_mul_add_counts;
@@ -249,79 +89,10 @@ class lookup_scalar_mul_add_settings {
         ColumnAndShifts::ecc_p_x, ColumnAndShifts::ecc_p_y, ColumnAndShifts::ecc_p_is_inf,
         ColumnAndShifts::ecc_q_x, ColumnAndShifts::ecc_q_y, ColumnAndShifts::ecc_q_is_inf
     };
-
-    template <typename AllEntities> static inline auto inverse_polynomial_is_computed_at_row(const AllEntities& in)
-    {
-        return (in.get(ColumnAndShifts::scalar_mul_should_add) == 1 || in.get(ColumnAndShifts::ecc_sel) == 1);
-    }
-
-    template <typename Accumulator, typename AllEntities>
-    static inline auto compute_inverse_exists(const AllEntities& in)
-    {
-        using View = typename Accumulator::View;
-        const auto is_operation = View(in.get(ColumnAndShifts::scalar_mul_should_add));
-        const auto is_table_entry = View(in.get(ColumnAndShifts::ecc_sel));
-        return (is_operation + is_table_entry - is_operation * is_table_entry);
-    }
-
-    template <typename AllEntities> static inline auto get_const_entities(const AllEntities& in)
-    {
-        return get_entities(in);
-    }
-
-    template <typename AllEntities> static inline auto get_nonconst_entities(AllEntities& in)
-    {
-        return get_entities(in);
-    }
-
-    template <typename AllEntities> static inline auto get_entities(AllEntities&& in)
-    {
-        return std::forward_as_tuple(in.get(ColumnAndShifts::lookup_scalar_mul_add_inv),
-                                     in.get(ColumnAndShifts::lookup_scalar_mul_add_counts),
-                                     in.get(ColumnAndShifts::scalar_mul_should_add),
-                                     in.get(ColumnAndShifts::ecc_sel),
-                                     in.get(ColumnAndShifts::scalar_mul_res_x),
-                                     in.get(ColumnAndShifts::scalar_mul_res_y),
-                                     in.get(ColumnAndShifts::scalar_mul_res_inf),
-                                     in.get(ColumnAndShifts::scalar_mul_res_x_shift),
-                                     in.get(ColumnAndShifts::scalar_mul_res_y_shift),
-                                     in.get(ColumnAndShifts::scalar_mul_res_inf_shift),
-                                     in.get(ColumnAndShifts::scalar_mul_temp_x),
-                                     in.get(ColumnAndShifts::scalar_mul_temp_y),
-                                     in.get(ColumnAndShifts::scalar_mul_temp_inf),
-                                     in.get(ColumnAndShifts::ecc_r_x),
-                                     in.get(ColumnAndShifts::ecc_r_y),
-                                     in.get(ColumnAndShifts::ecc_r_is_inf),
-                                     in.get(ColumnAndShifts::ecc_p_x),
-                                     in.get(ColumnAndShifts::ecc_p_y),
-                                     in.get(ColumnAndShifts::ecc_p_is_inf),
-                                     in.get(ColumnAndShifts::ecc_q_x),
-                                     in.get(ColumnAndShifts::ecc_q_y),
-                                     in.get(ColumnAndShifts::ecc_q_is_inf));
-    }
 };
 
+using lookup_scalar_mul_add_settings = lookup_settings<lookup_scalar_mul_add_settings_>;
 template <typename FF_>
-class lookup_scalar_mul_add_relation : public GenericLookupRelation<lookup_scalar_mul_add_settings, FF_> {
-  public:
-    using Settings = lookup_scalar_mul_add_settings;
-    static constexpr std::string_view NAME = lookup_scalar_mul_add_settings::NAME;
-    static constexpr std::string_view RELATION_NAME = lookup_scalar_mul_add_settings::RELATION_NAME;
-
-    template <typename AllEntities> inline static bool skip(const AllEntities& in)
-    {
-        return in.lookup_scalar_mul_add_inv.is_zero();
-    }
-
-    static std::string get_subrelation_label(size_t index)
-    {
-        if (index == 0) {
-            return "INVERSES_ARE_CORRECT";
-        } else if (index == 1) {
-            return "ACCUMULATION_IS_CORRECT";
-        }
-        return std::to_string(index);
-    }
-};
+using lookup_scalar_mul_add_relation = lookup_relation_base<FF_, lookup_scalar_mul_add_settings>;
 
 } // namespace bb::avm2

--- a/barretenberg/cpp/src/barretenberg/vm2/generated/relations/lookups_sha256.hpp
+++ b/barretenberg/cpp/src/barretenberg/vm2/generated/relations/lookups_sha256.hpp
@@ -3,6 +3,7 @@
 
 #include "../columns.hpp"
 #include "barretenberg/relations/generic_lookup/generic_lookup_relation.hpp"
+#include "barretenberg/vm2/constraining/relations/interactions_base.hpp"
 
 #include <cstddef>
 #include <string_view>
@@ -12,21 +13,10 @@ namespace bb::avm2 {
 
 /////////////////// lookup_sha256_round_constant ///////////////////
 
-class lookup_sha256_round_constant_settings {
-  public:
+struct lookup_sha256_round_constant_settings_ {
     static constexpr std::string_view NAME = "LOOKUP_SHA256_ROUND_CONSTANT";
     static constexpr std::string_view RELATION_NAME = "sha256";
-
-    static constexpr size_t READ_TERMS = 1;
-    static constexpr size_t WRITE_TERMS = 1;
-    static constexpr size_t READ_TERM_TYPES[READ_TERMS] = { 0 };
-    static constexpr size_t WRITE_TERM_TYPES[WRITE_TERMS] = { 0 };
     static constexpr size_t LOOKUP_TUPLE_SIZE = 2;
-    static constexpr size_t INVERSE_EXISTS_POLYNOMIAL_DEGREE = 4;
-    static constexpr size_t READ_TERM_DEGREE = 0;
-    static constexpr size_t WRITE_TERM_DEGREE = 0;
-
-    // Columns using the Column enum.
     static constexpr Column SRC_SELECTOR = Column::sha256_perform_round;
     static constexpr Column DST_SELECTOR = Column::precomputed_sel_sha256_compression;
     static constexpr Column COUNTS = Column::lookup_sha256_round_constant_counts;
@@ -37,66 +27,10 @@ class lookup_sha256_round_constant_settings {
     static constexpr std::array<ColumnAndShifts, LOOKUP_TUPLE_SIZE> DST_COLUMNS = {
         ColumnAndShifts::precomputed_clk, ColumnAndShifts::precomputed_sha256_compression_round_constant
     };
-
-    template <typename AllEntities> static inline auto inverse_polynomial_is_computed_at_row(const AllEntities& in)
-    {
-        return (in.get(ColumnAndShifts::sha256_perform_round) == 1 ||
-                in.get(ColumnAndShifts::precomputed_sel_sha256_compression) == 1);
-    }
-
-    template <typename Accumulator, typename AllEntities>
-    static inline auto compute_inverse_exists(const AllEntities& in)
-    {
-        using View = typename Accumulator::View;
-        const auto is_operation = View(in.get(ColumnAndShifts::sha256_perform_round));
-        const auto is_table_entry = View(in.get(ColumnAndShifts::precomputed_sel_sha256_compression));
-        return (is_operation + is_table_entry - is_operation * is_table_entry);
-    }
-
-    template <typename AllEntities> static inline auto get_const_entities(const AllEntities& in)
-    {
-        return get_entities(in);
-    }
-
-    template <typename AllEntities> static inline auto get_nonconst_entities(AllEntities& in)
-    {
-        return get_entities(in);
-    }
-
-    template <typename AllEntities> static inline auto get_entities(AllEntities&& in)
-    {
-        return std::forward_as_tuple(in.get(ColumnAndShifts::lookup_sha256_round_constant_inv),
-                                     in.get(ColumnAndShifts::lookup_sha256_round_constant_counts),
-                                     in.get(ColumnAndShifts::sha256_perform_round),
-                                     in.get(ColumnAndShifts::precomputed_sel_sha256_compression),
-                                     in.get(ColumnAndShifts::sha256_round_count),
-                                     in.get(ColumnAndShifts::sha256_round_constant),
-                                     in.get(ColumnAndShifts::precomputed_clk),
-                                     in.get(ColumnAndShifts::precomputed_sha256_compression_round_constant));
-    }
 };
 
+using lookup_sha256_round_constant_settings = lookup_settings<lookup_sha256_round_constant_settings_>;
 template <typename FF_>
-class lookup_sha256_round_constant_relation : public GenericLookupRelation<lookup_sha256_round_constant_settings, FF_> {
-  public:
-    using Settings = lookup_sha256_round_constant_settings;
-    static constexpr std::string_view NAME = lookup_sha256_round_constant_settings::NAME;
-    static constexpr std::string_view RELATION_NAME = lookup_sha256_round_constant_settings::RELATION_NAME;
-
-    template <typename AllEntities> inline static bool skip(const AllEntities& in)
-    {
-        return in.lookup_sha256_round_constant_inv.is_zero();
-    }
-
-    static std::string get_subrelation_label(size_t index)
-    {
-        if (index == 0) {
-            return "INVERSES_ARE_CORRECT";
-        } else if (index == 1) {
-            return "ACCUMULATION_IS_CORRECT";
-        }
-        return std::to_string(index);
-    }
-};
+using lookup_sha256_round_constant_relation = lookup_relation_base<FF_, lookup_sha256_round_constant_settings>;
 
 } // namespace bb::avm2

--- a/barretenberg/cpp/src/barretenberg/vm2/generated/relations/lookups_to_radix.hpp
+++ b/barretenberg/cpp/src/barretenberg/vm2/generated/relations/lookups_to_radix.hpp
@@ -3,6 +3,7 @@
 
 #include "../columns.hpp"
 #include "barretenberg/relations/generic_lookup/generic_lookup_relation.hpp"
+#include "barretenberg/vm2/constraining/relations/interactions_base.hpp"
 
 #include <cstddef>
 #include <string_view>
@@ -12,103 +13,28 @@ namespace bb::avm2 {
 
 /////////////////// lookup_to_radix_limb_range ///////////////////
 
-class lookup_to_radix_limb_range_settings {
-  public:
+struct lookup_to_radix_limb_range_settings_ {
     static constexpr std::string_view NAME = "LOOKUP_TO_RADIX_LIMB_RANGE";
     static constexpr std::string_view RELATION_NAME = "to_radix";
-
-    static constexpr size_t READ_TERMS = 1;
-    static constexpr size_t WRITE_TERMS = 1;
-    static constexpr size_t READ_TERM_TYPES[READ_TERMS] = { 0 };
-    static constexpr size_t WRITE_TERM_TYPES[WRITE_TERMS] = { 0 };
     static constexpr size_t LOOKUP_TUPLE_SIZE = 1;
-    static constexpr size_t INVERSE_EXISTS_POLYNOMIAL_DEGREE = 4;
-    static constexpr size_t READ_TERM_DEGREE = 0;
-    static constexpr size_t WRITE_TERM_DEGREE = 0;
-
-    // Columns using the Column enum.
     static constexpr Column SRC_SELECTOR = Column::to_radix_sel;
     static constexpr Column DST_SELECTOR = Column::precomputed_sel_range_8;
     static constexpr Column COUNTS = Column::lookup_to_radix_limb_range_counts;
     static constexpr Column INVERSES = Column::lookup_to_radix_limb_range_inv;
     static constexpr std::array<ColumnAndShifts, LOOKUP_TUPLE_SIZE> SRC_COLUMNS = { ColumnAndShifts::to_radix_limb };
     static constexpr std::array<ColumnAndShifts, LOOKUP_TUPLE_SIZE> DST_COLUMNS = { ColumnAndShifts::precomputed_clk };
-
-    template <typename AllEntities> static inline auto inverse_polynomial_is_computed_at_row(const AllEntities& in)
-    {
-        return (in.get(ColumnAndShifts::to_radix_sel) == 1 || in.get(ColumnAndShifts::precomputed_sel_range_8) == 1);
-    }
-
-    template <typename Accumulator, typename AllEntities>
-    static inline auto compute_inverse_exists(const AllEntities& in)
-    {
-        using View = typename Accumulator::View;
-        const auto is_operation = View(in.get(ColumnAndShifts::to_radix_sel));
-        const auto is_table_entry = View(in.get(ColumnAndShifts::precomputed_sel_range_8));
-        return (is_operation + is_table_entry - is_operation * is_table_entry);
-    }
-
-    template <typename AllEntities> static inline auto get_const_entities(const AllEntities& in)
-    {
-        return get_entities(in);
-    }
-
-    template <typename AllEntities> static inline auto get_nonconst_entities(AllEntities& in)
-    {
-        return get_entities(in);
-    }
-
-    template <typename AllEntities> static inline auto get_entities(AllEntities&& in)
-    {
-        return std::forward_as_tuple(in.get(ColumnAndShifts::lookup_to_radix_limb_range_inv),
-                                     in.get(ColumnAndShifts::lookup_to_radix_limb_range_counts),
-                                     in.get(ColumnAndShifts::to_radix_sel),
-                                     in.get(ColumnAndShifts::precomputed_sel_range_8),
-                                     in.get(ColumnAndShifts::to_radix_limb),
-                                     in.get(ColumnAndShifts::precomputed_clk));
-    }
 };
 
+using lookup_to_radix_limb_range_settings = lookup_settings<lookup_to_radix_limb_range_settings_>;
 template <typename FF_>
-class lookup_to_radix_limb_range_relation : public GenericLookupRelation<lookup_to_radix_limb_range_settings, FF_> {
-  public:
-    using Settings = lookup_to_radix_limb_range_settings;
-    static constexpr std::string_view NAME = lookup_to_radix_limb_range_settings::NAME;
-    static constexpr std::string_view RELATION_NAME = lookup_to_radix_limb_range_settings::RELATION_NAME;
-
-    template <typename AllEntities> inline static bool skip(const AllEntities& in)
-    {
-        return in.lookup_to_radix_limb_range_inv.is_zero();
-    }
-
-    static std::string get_subrelation_label(size_t index)
-    {
-        if (index == 0) {
-            return "INVERSES_ARE_CORRECT";
-        } else if (index == 1) {
-            return "ACCUMULATION_IS_CORRECT";
-        }
-        return std::to_string(index);
-    }
-};
+using lookup_to_radix_limb_range_relation = lookup_relation_base<FF_, lookup_to_radix_limb_range_settings>;
 
 /////////////////// lookup_to_radix_limb_less_than_radix_range ///////////////////
 
-class lookup_to_radix_limb_less_than_radix_range_settings {
-  public:
+struct lookup_to_radix_limb_less_than_radix_range_settings_ {
     static constexpr std::string_view NAME = "LOOKUP_TO_RADIX_LIMB_LESS_THAN_RADIX_RANGE";
     static constexpr std::string_view RELATION_NAME = "to_radix";
-
-    static constexpr size_t READ_TERMS = 1;
-    static constexpr size_t WRITE_TERMS = 1;
-    static constexpr size_t READ_TERM_TYPES[READ_TERMS] = { 0 };
-    static constexpr size_t WRITE_TERM_TYPES[WRITE_TERMS] = { 0 };
     static constexpr size_t LOOKUP_TUPLE_SIZE = 1;
-    static constexpr size_t INVERSE_EXISTS_POLYNOMIAL_DEGREE = 4;
-    static constexpr size_t READ_TERM_DEGREE = 0;
-    static constexpr size_t WRITE_TERM_DEGREE = 0;
-
-    // Columns using the Column enum.
     static constexpr Column SRC_SELECTOR = Column::to_radix_sel;
     static constexpr Column DST_SELECTOR = Column::precomputed_sel_range_8;
     static constexpr Column COUNTS = Column::lookup_to_radix_limb_less_than_radix_range_counts;
@@ -117,84 +43,20 @@ class lookup_to_radix_limb_less_than_radix_range_settings {
         ColumnAndShifts::to_radix_limb_radix_diff
     };
     static constexpr std::array<ColumnAndShifts, LOOKUP_TUPLE_SIZE> DST_COLUMNS = { ColumnAndShifts::precomputed_clk };
-
-    template <typename AllEntities> static inline auto inverse_polynomial_is_computed_at_row(const AllEntities& in)
-    {
-        return (in.get(ColumnAndShifts::to_radix_sel) == 1 || in.get(ColumnAndShifts::precomputed_sel_range_8) == 1);
-    }
-
-    template <typename Accumulator, typename AllEntities>
-    static inline auto compute_inverse_exists(const AllEntities& in)
-    {
-        using View = typename Accumulator::View;
-        const auto is_operation = View(in.get(ColumnAndShifts::to_radix_sel));
-        const auto is_table_entry = View(in.get(ColumnAndShifts::precomputed_sel_range_8));
-        return (is_operation + is_table_entry - is_operation * is_table_entry);
-    }
-
-    template <typename AllEntities> static inline auto get_const_entities(const AllEntities& in)
-    {
-        return get_entities(in);
-    }
-
-    template <typename AllEntities> static inline auto get_nonconst_entities(AllEntities& in)
-    {
-        return get_entities(in);
-    }
-
-    template <typename AllEntities> static inline auto get_entities(AllEntities&& in)
-    {
-        return std::forward_as_tuple(in.get(ColumnAndShifts::lookup_to_radix_limb_less_than_radix_range_inv),
-                                     in.get(ColumnAndShifts::lookup_to_radix_limb_less_than_radix_range_counts),
-                                     in.get(ColumnAndShifts::to_radix_sel),
-                                     in.get(ColumnAndShifts::precomputed_sel_range_8),
-                                     in.get(ColumnAndShifts::to_radix_limb_radix_diff),
-                                     in.get(ColumnAndShifts::precomputed_clk));
-    }
 };
 
+using lookup_to_radix_limb_less_than_radix_range_settings =
+    lookup_settings<lookup_to_radix_limb_less_than_radix_range_settings_>;
 template <typename FF_>
-class lookup_to_radix_limb_less_than_radix_range_relation
-    : public GenericLookupRelation<lookup_to_radix_limb_less_than_radix_range_settings, FF_> {
-  public:
-    using Settings = lookup_to_radix_limb_less_than_radix_range_settings;
-    static constexpr std::string_view NAME = lookup_to_radix_limb_less_than_radix_range_settings::NAME;
-    static constexpr std::string_view RELATION_NAME =
-        lookup_to_radix_limb_less_than_radix_range_settings::RELATION_NAME;
-
-    template <typename AllEntities> inline static bool skip(const AllEntities& in)
-    {
-        return in.lookup_to_radix_limb_less_than_radix_range_inv.is_zero();
-    }
-
-    static std::string get_subrelation_label(size_t index)
-    {
-        if (index == 0) {
-            return "INVERSES_ARE_CORRECT";
-        } else if (index == 1) {
-            return "ACCUMULATION_IS_CORRECT";
-        }
-        return std::to_string(index);
-    }
-};
+using lookup_to_radix_limb_less_than_radix_range_relation =
+    lookup_relation_base<FF_, lookup_to_radix_limb_less_than_radix_range_settings>;
 
 /////////////////// lookup_to_radix_fetch_safe_limbs ///////////////////
 
-class lookup_to_radix_fetch_safe_limbs_settings {
-  public:
+struct lookup_to_radix_fetch_safe_limbs_settings_ {
     static constexpr std::string_view NAME = "LOOKUP_TO_RADIX_FETCH_SAFE_LIMBS";
     static constexpr std::string_view RELATION_NAME = "to_radix";
-
-    static constexpr size_t READ_TERMS = 1;
-    static constexpr size_t WRITE_TERMS = 1;
-    static constexpr size_t READ_TERM_TYPES[READ_TERMS] = { 0 };
-    static constexpr size_t WRITE_TERM_TYPES[WRITE_TERMS] = { 0 };
     static constexpr size_t LOOKUP_TUPLE_SIZE = 2;
-    static constexpr size_t INVERSE_EXISTS_POLYNOMIAL_DEGREE = 4;
-    static constexpr size_t READ_TERM_DEGREE = 0;
-    static constexpr size_t WRITE_TERM_DEGREE = 0;
-
-    // Columns using the Column enum.
     static constexpr Column SRC_SELECTOR = Column::to_radix_start;
     static constexpr Column DST_SELECTOR = Column::precomputed_sel_to_radix_safe_limbs;
     static constexpr Column COUNTS = Column::lookup_to_radix_fetch_safe_limbs_counts;
@@ -205,86 +67,18 @@ class lookup_to_radix_fetch_safe_limbs_settings {
     static constexpr std::array<ColumnAndShifts, LOOKUP_TUPLE_SIZE> DST_COLUMNS = {
         ColumnAndShifts::precomputed_clk, ColumnAndShifts::precomputed_to_radix_safe_limbs
     };
-
-    template <typename AllEntities> static inline auto inverse_polynomial_is_computed_at_row(const AllEntities& in)
-    {
-        return (in.get(ColumnAndShifts::to_radix_start) == 1 ||
-                in.get(ColumnAndShifts::precomputed_sel_to_radix_safe_limbs) == 1);
-    }
-
-    template <typename Accumulator, typename AllEntities>
-    static inline auto compute_inverse_exists(const AllEntities& in)
-    {
-        using View = typename Accumulator::View;
-        const auto is_operation = View(in.get(ColumnAndShifts::to_radix_start));
-        const auto is_table_entry = View(in.get(ColumnAndShifts::precomputed_sel_to_radix_safe_limbs));
-        return (is_operation + is_table_entry - is_operation * is_table_entry);
-    }
-
-    template <typename AllEntities> static inline auto get_const_entities(const AllEntities& in)
-    {
-        return get_entities(in);
-    }
-
-    template <typename AllEntities> static inline auto get_nonconst_entities(AllEntities& in)
-    {
-        return get_entities(in);
-    }
-
-    template <typename AllEntities> static inline auto get_entities(AllEntities&& in)
-    {
-        return std::forward_as_tuple(in.get(ColumnAndShifts::lookup_to_radix_fetch_safe_limbs_inv),
-                                     in.get(ColumnAndShifts::lookup_to_radix_fetch_safe_limbs_counts),
-                                     in.get(ColumnAndShifts::to_radix_start),
-                                     in.get(ColumnAndShifts::precomputed_sel_to_radix_safe_limbs),
-                                     in.get(ColumnAndShifts::to_radix_radix),
-                                     in.get(ColumnAndShifts::to_radix_safe_limbs),
-                                     in.get(ColumnAndShifts::precomputed_clk),
-                                     in.get(ColumnAndShifts::precomputed_to_radix_safe_limbs));
-    }
 };
 
+using lookup_to_radix_fetch_safe_limbs_settings = lookup_settings<lookup_to_radix_fetch_safe_limbs_settings_>;
 template <typename FF_>
-class lookup_to_radix_fetch_safe_limbs_relation
-    : public GenericLookupRelation<lookup_to_radix_fetch_safe_limbs_settings, FF_> {
-  public:
-    using Settings = lookup_to_radix_fetch_safe_limbs_settings;
-    static constexpr std::string_view NAME = lookup_to_radix_fetch_safe_limbs_settings::NAME;
-    static constexpr std::string_view RELATION_NAME = lookup_to_radix_fetch_safe_limbs_settings::RELATION_NAME;
-
-    template <typename AllEntities> inline static bool skip(const AllEntities& in)
-    {
-        return in.lookup_to_radix_fetch_safe_limbs_inv.is_zero();
-    }
-
-    static std::string get_subrelation_label(size_t index)
-    {
-        if (index == 0) {
-            return "INVERSES_ARE_CORRECT";
-        } else if (index == 1) {
-            return "ACCUMULATION_IS_CORRECT";
-        }
-        return std::to_string(index);
-    }
-};
+using lookup_to_radix_fetch_safe_limbs_relation = lookup_relation_base<FF_, lookup_to_radix_fetch_safe_limbs_settings>;
 
 /////////////////// lookup_to_radix_fetch_p_limb ///////////////////
 
-class lookup_to_radix_fetch_p_limb_settings {
-  public:
+struct lookup_to_radix_fetch_p_limb_settings_ {
     static constexpr std::string_view NAME = "LOOKUP_TO_RADIX_FETCH_P_LIMB";
     static constexpr std::string_view RELATION_NAME = "to_radix";
-
-    static constexpr size_t READ_TERMS = 1;
-    static constexpr size_t WRITE_TERMS = 1;
-    static constexpr size_t READ_TERM_TYPES[READ_TERMS] = { 0 };
-    static constexpr size_t WRITE_TERM_TYPES[WRITE_TERMS] = { 0 };
     static constexpr size_t LOOKUP_TUPLE_SIZE = 3;
-    static constexpr size_t INVERSE_EXISTS_POLYNOMIAL_DEGREE = 4;
-    static constexpr size_t READ_TERM_DEGREE = 0;
-    static constexpr size_t WRITE_TERM_DEGREE = 0;
-
-    // Columns using the Column enum.
     static constexpr Column SRC_SELECTOR = Column::to_radix_not_padding_limb;
     static constexpr Column DST_SELECTOR = Column::precomputed_sel_p_decomposition;
     static constexpr Column COUNTS = Column::lookup_to_radix_fetch_p_limb_counts;
@@ -297,87 +91,18 @@ class lookup_to_radix_fetch_p_limb_settings {
         ColumnAndShifts::precomputed_p_decomposition_limb_index,
         ColumnAndShifts::precomputed_p_decomposition_limb
     };
-
-    template <typename AllEntities> static inline auto inverse_polynomial_is_computed_at_row(const AllEntities& in)
-    {
-        return (in.get(ColumnAndShifts::to_radix_not_padding_limb) == 1 ||
-                in.get(ColumnAndShifts::precomputed_sel_p_decomposition) == 1);
-    }
-
-    template <typename Accumulator, typename AllEntities>
-    static inline auto compute_inverse_exists(const AllEntities& in)
-    {
-        using View = typename Accumulator::View;
-        const auto is_operation = View(in.get(ColumnAndShifts::to_radix_not_padding_limb));
-        const auto is_table_entry = View(in.get(ColumnAndShifts::precomputed_sel_p_decomposition));
-        return (is_operation + is_table_entry - is_operation * is_table_entry);
-    }
-
-    template <typename AllEntities> static inline auto get_const_entities(const AllEntities& in)
-    {
-        return get_entities(in);
-    }
-
-    template <typename AllEntities> static inline auto get_nonconst_entities(AllEntities& in)
-    {
-        return get_entities(in);
-    }
-
-    template <typename AllEntities> static inline auto get_entities(AllEntities&& in)
-    {
-        return std::forward_as_tuple(in.get(ColumnAndShifts::lookup_to_radix_fetch_p_limb_inv),
-                                     in.get(ColumnAndShifts::lookup_to_radix_fetch_p_limb_counts),
-                                     in.get(ColumnAndShifts::to_radix_not_padding_limb),
-                                     in.get(ColumnAndShifts::precomputed_sel_p_decomposition),
-                                     in.get(ColumnAndShifts::to_radix_radix),
-                                     in.get(ColumnAndShifts::to_radix_limb_index),
-                                     in.get(ColumnAndShifts::to_radix_p_limb),
-                                     in.get(ColumnAndShifts::precomputed_p_decomposition_radix),
-                                     in.get(ColumnAndShifts::precomputed_p_decomposition_limb_index),
-                                     in.get(ColumnAndShifts::precomputed_p_decomposition_limb));
-    }
 };
 
+using lookup_to_radix_fetch_p_limb_settings = lookup_settings<lookup_to_radix_fetch_p_limb_settings_>;
 template <typename FF_>
-class lookup_to_radix_fetch_p_limb_relation : public GenericLookupRelation<lookup_to_radix_fetch_p_limb_settings, FF_> {
-  public:
-    using Settings = lookup_to_radix_fetch_p_limb_settings;
-    static constexpr std::string_view NAME = lookup_to_radix_fetch_p_limb_settings::NAME;
-    static constexpr std::string_view RELATION_NAME = lookup_to_radix_fetch_p_limb_settings::RELATION_NAME;
-
-    template <typename AllEntities> inline static bool skip(const AllEntities& in)
-    {
-        return in.lookup_to_radix_fetch_p_limb_inv.is_zero();
-    }
-
-    static std::string get_subrelation_label(size_t index)
-    {
-        if (index == 0) {
-            return "INVERSES_ARE_CORRECT";
-        } else if (index == 1) {
-            return "ACCUMULATION_IS_CORRECT";
-        }
-        return std::to_string(index);
-    }
-};
+using lookup_to_radix_fetch_p_limb_relation = lookup_relation_base<FF_, lookup_to_radix_fetch_p_limb_settings>;
 
 /////////////////// lookup_to_radix_limb_p_diff_range ///////////////////
 
-class lookup_to_radix_limb_p_diff_range_settings {
-  public:
+struct lookup_to_radix_limb_p_diff_range_settings_ {
     static constexpr std::string_view NAME = "LOOKUP_TO_RADIX_LIMB_P_DIFF_RANGE";
     static constexpr std::string_view RELATION_NAME = "to_radix";
-
-    static constexpr size_t READ_TERMS = 1;
-    static constexpr size_t WRITE_TERMS = 1;
-    static constexpr size_t READ_TERM_TYPES[READ_TERMS] = { 0 };
-    static constexpr size_t WRITE_TERM_TYPES[WRITE_TERMS] = { 0 };
     static constexpr size_t LOOKUP_TUPLE_SIZE = 1;
-    static constexpr size_t INVERSE_EXISTS_POLYNOMIAL_DEGREE = 4;
-    static constexpr size_t READ_TERM_DEGREE = 0;
-    static constexpr size_t WRITE_TERM_DEGREE = 0;
-
-    // Columns using the Column enum.
     static constexpr Column SRC_SELECTOR = Column::to_radix_not_padding_limb;
     static constexpr Column DST_SELECTOR = Column::precomputed_sel_range_8;
     static constexpr Column COUNTS = Column::lookup_to_radix_limb_p_diff_range_counts;
@@ -386,65 +111,11 @@ class lookup_to_radix_limb_p_diff_range_settings {
         ColumnAndShifts::to_radix_limb_p_diff
     };
     static constexpr std::array<ColumnAndShifts, LOOKUP_TUPLE_SIZE> DST_COLUMNS = { ColumnAndShifts::precomputed_clk };
-
-    template <typename AllEntities> static inline auto inverse_polynomial_is_computed_at_row(const AllEntities& in)
-    {
-        return (in.get(ColumnAndShifts::to_radix_not_padding_limb) == 1 ||
-                in.get(ColumnAndShifts::precomputed_sel_range_8) == 1);
-    }
-
-    template <typename Accumulator, typename AllEntities>
-    static inline auto compute_inverse_exists(const AllEntities& in)
-    {
-        using View = typename Accumulator::View;
-        const auto is_operation = View(in.get(ColumnAndShifts::to_radix_not_padding_limb));
-        const auto is_table_entry = View(in.get(ColumnAndShifts::precomputed_sel_range_8));
-        return (is_operation + is_table_entry - is_operation * is_table_entry);
-    }
-
-    template <typename AllEntities> static inline auto get_const_entities(const AllEntities& in)
-    {
-        return get_entities(in);
-    }
-
-    template <typename AllEntities> static inline auto get_nonconst_entities(AllEntities& in)
-    {
-        return get_entities(in);
-    }
-
-    template <typename AllEntities> static inline auto get_entities(AllEntities&& in)
-    {
-        return std::forward_as_tuple(in.get(ColumnAndShifts::lookup_to_radix_limb_p_diff_range_inv),
-                                     in.get(ColumnAndShifts::lookup_to_radix_limb_p_diff_range_counts),
-                                     in.get(ColumnAndShifts::to_radix_not_padding_limb),
-                                     in.get(ColumnAndShifts::precomputed_sel_range_8),
-                                     in.get(ColumnAndShifts::to_radix_limb_p_diff),
-                                     in.get(ColumnAndShifts::precomputed_clk));
-    }
 };
 
+using lookup_to_radix_limb_p_diff_range_settings = lookup_settings<lookup_to_radix_limb_p_diff_range_settings_>;
 template <typename FF_>
-class lookup_to_radix_limb_p_diff_range_relation
-    : public GenericLookupRelation<lookup_to_radix_limb_p_diff_range_settings, FF_> {
-  public:
-    using Settings = lookup_to_radix_limb_p_diff_range_settings;
-    static constexpr std::string_view NAME = lookup_to_radix_limb_p_diff_range_settings::NAME;
-    static constexpr std::string_view RELATION_NAME = lookup_to_radix_limb_p_diff_range_settings::RELATION_NAME;
-
-    template <typename AllEntities> inline static bool skip(const AllEntities& in)
-    {
-        return in.lookup_to_radix_limb_p_diff_range_inv.is_zero();
-    }
-
-    static std::string get_subrelation_label(size_t index)
-    {
-        if (index == 0) {
-            return "INVERSES_ARE_CORRECT";
-        } else if (index == 1) {
-            return "ACCUMULATION_IS_CORRECT";
-        }
-        return std::to_string(index);
-    }
-};
+using lookup_to_radix_limb_p_diff_range_relation =
+    lookup_relation_base<FF_, lookup_to_radix_limb_p_diff_range_settings>;
 
 } // namespace bb::avm2

--- a/barretenberg/cpp/src/barretenberg/vm2/generated/relations/lookups_update_check.hpp
+++ b/barretenberg/cpp/src/barretenberg/vm2/generated/relations/lookups_update_check.hpp
@@ -3,6 +3,7 @@
 
 #include "../columns.hpp"
 #include "barretenberg/relations/generic_lookup/generic_lookup_relation.hpp"
+#include "barretenberg/vm2/constraining/relations/interactions_base.hpp"
 
 #include <cstddef>
 #include <string_view>
@@ -12,21 +13,10 @@ namespace bb::avm2 {
 
 /////////////////// lookup_update_check_shared_mutable_slot_poseidon2 ///////////////////
 
-class lookup_update_check_shared_mutable_slot_poseidon2_settings {
-  public:
+struct lookup_update_check_shared_mutable_slot_poseidon2_settings_ {
     static constexpr std::string_view NAME = "LOOKUP_UPDATE_CHECK_SHARED_MUTABLE_SLOT_POSEIDON2";
     static constexpr std::string_view RELATION_NAME = "update_check";
-
-    static constexpr size_t READ_TERMS = 1;
-    static constexpr size_t WRITE_TERMS = 1;
-    static constexpr size_t READ_TERM_TYPES[READ_TERMS] = { 0 };
-    static constexpr size_t WRITE_TERM_TYPES[WRITE_TERMS] = { 0 };
     static constexpr size_t LOOKUP_TUPLE_SIZE = 4;
-    static constexpr size_t INVERSE_EXISTS_POLYNOMIAL_DEGREE = 4;
-    static constexpr size_t READ_TERM_DEGREE = 0;
-    static constexpr size_t WRITE_TERM_DEGREE = 0;
-
-    // Columns using the Column enum.
     static constexpr Column SRC_SELECTOR = Column::update_check_sel;
     static constexpr Column DST_SELECTOR = Column::poseidon2_hash_end;
     static constexpr Column COUNTS = Column::lookup_update_check_shared_mutable_slot_poseidon2_counts;
@@ -43,90 +33,20 @@ class lookup_update_check_shared_mutable_slot_poseidon2_settings {
         ColumnAndShifts::poseidon2_hash_input_2,
         ColumnAndShifts::poseidon2_hash_output
     };
-
-    template <typename AllEntities> static inline auto inverse_polynomial_is_computed_at_row(const AllEntities& in)
-    {
-        return (in.get(ColumnAndShifts::update_check_sel) == 1 || in.get(ColumnAndShifts::poseidon2_hash_end) == 1);
-    }
-
-    template <typename Accumulator, typename AllEntities>
-    static inline auto compute_inverse_exists(const AllEntities& in)
-    {
-        using View = typename Accumulator::View;
-        const auto is_operation = View(in.get(ColumnAndShifts::update_check_sel));
-        const auto is_table_entry = View(in.get(ColumnAndShifts::poseidon2_hash_end));
-        return (is_operation + is_table_entry - is_operation * is_table_entry);
-    }
-
-    template <typename AllEntities> static inline auto get_const_entities(const AllEntities& in)
-    {
-        return get_entities(in);
-    }
-
-    template <typename AllEntities> static inline auto get_nonconst_entities(AllEntities& in)
-    {
-        return get_entities(in);
-    }
-
-    template <typename AllEntities> static inline auto get_entities(AllEntities&& in)
-    {
-        return std::forward_as_tuple(in.get(ColumnAndShifts::lookup_update_check_shared_mutable_slot_poseidon2_inv),
-                                     in.get(ColumnAndShifts::lookup_update_check_shared_mutable_slot_poseidon2_counts),
-                                     in.get(ColumnAndShifts::update_check_sel),
-                                     in.get(ColumnAndShifts::poseidon2_hash_end),
-                                     in.get(ColumnAndShifts::update_check_updated_class_ids_slot),
-                                     in.get(ColumnAndShifts::update_check_address),
-                                     in.get(ColumnAndShifts::precomputed_zero),
-                                     in.get(ColumnAndShifts::update_check_shared_mutable_slot),
-                                     in.get(ColumnAndShifts::poseidon2_hash_input_0),
-                                     in.get(ColumnAndShifts::poseidon2_hash_input_1),
-                                     in.get(ColumnAndShifts::poseidon2_hash_input_2),
-                                     in.get(ColumnAndShifts::poseidon2_hash_output));
-    }
 };
 
+using lookup_update_check_shared_mutable_slot_poseidon2_settings =
+    lookup_settings<lookup_update_check_shared_mutable_slot_poseidon2_settings_>;
 template <typename FF_>
-class lookup_update_check_shared_mutable_slot_poseidon2_relation
-    : public GenericLookupRelation<lookup_update_check_shared_mutable_slot_poseidon2_settings, FF_> {
-  public:
-    using Settings = lookup_update_check_shared_mutable_slot_poseidon2_settings;
-    static constexpr std::string_view NAME = lookup_update_check_shared_mutable_slot_poseidon2_settings::NAME;
-    static constexpr std::string_view RELATION_NAME =
-        lookup_update_check_shared_mutable_slot_poseidon2_settings::RELATION_NAME;
-
-    template <typename AllEntities> inline static bool skip(const AllEntities& in)
-    {
-        return in.lookup_update_check_shared_mutable_slot_poseidon2_inv.is_zero();
-    }
-
-    static std::string get_subrelation_label(size_t index)
-    {
-        if (index == 0) {
-            return "INVERSES_ARE_CORRECT";
-        } else if (index == 1) {
-            return "ACCUMULATION_IS_CORRECT";
-        }
-        return std::to_string(index);
-    }
-};
+using lookup_update_check_shared_mutable_slot_poseidon2_relation =
+    lookup_relation_base<FF_, lookup_update_check_shared_mutable_slot_poseidon2_settings>;
 
 /////////////////// lookup_update_check_shared_mutable_leaf_slot_poseidon2 ///////////////////
 
-class lookup_update_check_shared_mutable_leaf_slot_poseidon2_settings {
-  public:
+struct lookup_update_check_shared_mutable_leaf_slot_poseidon2_settings_ {
     static constexpr std::string_view NAME = "LOOKUP_UPDATE_CHECK_SHARED_MUTABLE_LEAF_SLOT_POSEIDON2";
     static constexpr std::string_view RELATION_NAME = "update_check";
-
-    static constexpr size_t READ_TERMS = 1;
-    static constexpr size_t WRITE_TERMS = 1;
-    static constexpr size_t READ_TERM_TYPES[READ_TERMS] = { 0 };
-    static constexpr size_t WRITE_TERM_TYPES[WRITE_TERMS] = { 0 };
     static constexpr size_t LOOKUP_TUPLE_SIZE = 4;
-    static constexpr size_t INVERSE_EXISTS_POLYNOMIAL_DEGREE = 4;
-    static constexpr size_t READ_TERM_DEGREE = 0;
-    static constexpr size_t WRITE_TERM_DEGREE = 0;
-
-    // Columns using the Column enum.
     static constexpr Column SRC_SELECTOR = Column::update_check_sel;
     static constexpr Column DST_SELECTOR = Column::poseidon2_hash_end;
     static constexpr Column COUNTS = Column::lookup_update_check_shared_mutable_leaf_slot_poseidon2_counts;
@@ -143,91 +63,20 @@ class lookup_update_check_shared_mutable_leaf_slot_poseidon2_settings {
         ColumnAndShifts::poseidon2_hash_input_2,
         ColumnAndShifts::poseidon2_hash_output
     };
-
-    template <typename AllEntities> static inline auto inverse_polynomial_is_computed_at_row(const AllEntities& in)
-    {
-        return (in.get(ColumnAndShifts::update_check_sel) == 1 || in.get(ColumnAndShifts::poseidon2_hash_end) == 1);
-    }
-
-    template <typename Accumulator, typename AllEntities>
-    static inline auto compute_inverse_exists(const AllEntities& in)
-    {
-        using View = typename Accumulator::View;
-        const auto is_operation = View(in.get(ColumnAndShifts::update_check_sel));
-        const auto is_table_entry = View(in.get(ColumnAndShifts::poseidon2_hash_end));
-        return (is_operation + is_table_entry - is_operation * is_table_entry);
-    }
-
-    template <typename AllEntities> static inline auto get_const_entities(const AllEntities& in)
-    {
-        return get_entities(in);
-    }
-
-    template <typename AllEntities> static inline auto get_nonconst_entities(AllEntities& in)
-    {
-        return get_entities(in);
-    }
-
-    template <typename AllEntities> static inline auto get_entities(AllEntities&& in)
-    {
-        return std::forward_as_tuple(
-            in.get(ColumnAndShifts::lookup_update_check_shared_mutable_leaf_slot_poseidon2_inv),
-            in.get(ColumnAndShifts::lookup_update_check_shared_mutable_leaf_slot_poseidon2_counts),
-            in.get(ColumnAndShifts::update_check_sel),
-            in.get(ColumnAndShifts::poseidon2_hash_end),
-            in.get(ColumnAndShifts::update_check_public_leaf_index_domain_separator),
-            in.get(ColumnAndShifts::update_check_deployer_protocol_contract_address),
-            in.get(ColumnAndShifts::update_check_shared_mutable_hash_slot),
-            in.get(ColumnAndShifts::update_check_shared_mutable_leaf_slot),
-            in.get(ColumnAndShifts::poseidon2_hash_input_0),
-            in.get(ColumnAndShifts::poseidon2_hash_input_1),
-            in.get(ColumnAndShifts::poseidon2_hash_input_2),
-            in.get(ColumnAndShifts::poseidon2_hash_output));
-    }
 };
 
+using lookup_update_check_shared_mutable_leaf_slot_poseidon2_settings =
+    lookup_settings<lookup_update_check_shared_mutable_leaf_slot_poseidon2_settings_>;
 template <typename FF_>
-class lookup_update_check_shared_mutable_leaf_slot_poseidon2_relation
-    : public GenericLookupRelation<lookup_update_check_shared_mutable_leaf_slot_poseidon2_settings, FF_> {
-  public:
-    using Settings = lookup_update_check_shared_mutable_leaf_slot_poseidon2_settings;
-    static constexpr std::string_view NAME = lookup_update_check_shared_mutable_leaf_slot_poseidon2_settings::NAME;
-    static constexpr std::string_view RELATION_NAME =
-        lookup_update_check_shared_mutable_leaf_slot_poseidon2_settings::RELATION_NAME;
-
-    template <typename AllEntities> inline static bool skip(const AllEntities& in)
-    {
-        return in.lookup_update_check_shared_mutable_leaf_slot_poseidon2_inv.is_zero();
-    }
-
-    static std::string get_subrelation_label(size_t index)
-    {
-        if (index == 0) {
-            return "INVERSES_ARE_CORRECT";
-        } else if (index == 1) {
-            return "ACCUMULATION_IS_CORRECT";
-        }
-        return std::to_string(index);
-    }
-};
+using lookup_update_check_shared_mutable_leaf_slot_poseidon2_relation =
+    lookup_relation_base<FF_, lookup_update_check_shared_mutable_leaf_slot_poseidon2_settings>;
 
 /////////////////// lookup_update_check_update_hash_public_data_read ///////////////////
 
-class lookup_update_check_update_hash_public_data_read_settings {
-  public:
+struct lookup_update_check_update_hash_public_data_read_settings_ {
     static constexpr std::string_view NAME = "LOOKUP_UPDATE_CHECK_UPDATE_HASH_PUBLIC_DATA_READ";
     static constexpr std::string_view RELATION_NAME = "update_check";
-
-    static constexpr size_t READ_TERMS = 1;
-    static constexpr size_t WRITE_TERMS = 1;
-    static constexpr size_t READ_TERM_TYPES[READ_TERMS] = { 0 };
-    static constexpr size_t WRITE_TERM_TYPES[WRITE_TERMS] = { 0 };
     static constexpr size_t LOOKUP_TUPLE_SIZE = 3;
-    static constexpr size_t INVERSE_EXISTS_POLYNOMIAL_DEGREE = 4;
-    static constexpr size_t READ_TERM_DEGREE = 0;
-    static constexpr size_t WRITE_TERM_DEGREE = 0;
-
-    // Columns using the Column enum.
     static constexpr Column SRC_SELECTOR = Column::update_check_sel;
     static constexpr Column DST_SELECTOR = Column::public_data_read_sel;
     static constexpr Column COUNTS = Column::lookup_update_check_update_hash_public_data_read_counts;
@@ -242,88 +91,20 @@ class lookup_update_check_update_hash_public_data_read_settings {
         ColumnAndShifts::public_data_read_slot,
         ColumnAndShifts::public_data_read_root
     };
-
-    template <typename AllEntities> static inline auto inverse_polynomial_is_computed_at_row(const AllEntities& in)
-    {
-        return (in.get(ColumnAndShifts::update_check_sel) == 1 || in.get(ColumnAndShifts::public_data_read_sel) == 1);
-    }
-
-    template <typename Accumulator, typename AllEntities>
-    static inline auto compute_inverse_exists(const AllEntities& in)
-    {
-        using View = typename Accumulator::View;
-        const auto is_operation = View(in.get(ColumnAndShifts::update_check_sel));
-        const auto is_table_entry = View(in.get(ColumnAndShifts::public_data_read_sel));
-        return (is_operation + is_table_entry - is_operation * is_table_entry);
-    }
-
-    template <typename AllEntities> static inline auto get_const_entities(const AllEntities& in)
-    {
-        return get_entities(in);
-    }
-
-    template <typename AllEntities> static inline auto get_nonconst_entities(AllEntities& in)
-    {
-        return get_entities(in);
-    }
-
-    template <typename AllEntities> static inline auto get_entities(AllEntities&& in)
-    {
-        return std::forward_as_tuple(in.get(ColumnAndShifts::lookup_update_check_update_hash_public_data_read_inv),
-                                     in.get(ColumnAndShifts::lookup_update_check_update_hash_public_data_read_counts),
-                                     in.get(ColumnAndShifts::update_check_sel),
-                                     in.get(ColumnAndShifts::public_data_read_sel),
-                                     in.get(ColumnAndShifts::update_check_update_hash),
-                                     in.get(ColumnAndShifts::update_check_shared_mutable_leaf_slot),
-                                     in.get(ColumnAndShifts::update_check_public_data_tree_root),
-                                     in.get(ColumnAndShifts::public_data_read_value),
-                                     in.get(ColumnAndShifts::public_data_read_slot),
-                                     in.get(ColumnAndShifts::public_data_read_root));
-    }
 };
 
+using lookup_update_check_update_hash_public_data_read_settings =
+    lookup_settings<lookup_update_check_update_hash_public_data_read_settings_>;
 template <typename FF_>
-class lookup_update_check_update_hash_public_data_read_relation
-    : public GenericLookupRelation<lookup_update_check_update_hash_public_data_read_settings, FF_> {
-  public:
-    using Settings = lookup_update_check_update_hash_public_data_read_settings;
-    static constexpr std::string_view NAME = lookup_update_check_update_hash_public_data_read_settings::NAME;
-    static constexpr std::string_view RELATION_NAME =
-        lookup_update_check_update_hash_public_data_read_settings::RELATION_NAME;
-
-    template <typename AllEntities> inline static bool skip(const AllEntities& in)
-    {
-        return in.lookup_update_check_update_hash_public_data_read_inv.is_zero();
-    }
-
-    static std::string get_subrelation_label(size_t index)
-    {
-        if (index == 0) {
-            return "INVERSES_ARE_CORRECT";
-        } else if (index == 1) {
-            return "ACCUMULATION_IS_CORRECT";
-        }
-        return std::to_string(index);
-    }
-};
+using lookup_update_check_update_hash_public_data_read_relation =
+    lookup_relation_base<FF_, lookup_update_check_update_hash_public_data_read_settings>;
 
 /////////////////// lookup_update_check_update_hash_poseidon2 ///////////////////
 
-class lookup_update_check_update_hash_poseidon2_settings {
-  public:
+struct lookup_update_check_update_hash_poseidon2_settings_ {
     static constexpr std::string_view NAME = "LOOKUP_UPDATE_CHECK_UPDATE_HASH_POSEIDON2";
     static constexpr std::string_view RELATION_NAME = "update_check";
-
-    static constexpr size_t READ_TERMS = 1;
-    static constexpr size_t WRITE_TERMS = 1;
-    static constexpr size_t READ_TERM_TYPES[READ_TERMS] = { 0 };
-    static constexpr size_t WRITE_TERM_TYPES[WRITE_TERMS] = { 0 };
     static constexpr size_t LOOKUP_TUPLE_SIZE = 4;
-    static constexpr size_t INVERSE_EXISTS_POLYNOMIAL_DEGREE = 4;
-    static constexpr size_t READ_TERM_DEGREE = 0;
-    static constexpr size_t WRITE_TERM_DEGREE = 0;
-
-    // Columns using the Column enum.
     static constexpr Column SRC_SELECTOR = Column::update_check_hash_not_zero;
     static constexpr Column DST_SELECTOR = Column::poseidon2_hash_end;
     static constexpr Column COUNTS = Column::lookup_update_check_update_hash_poseidon2_counts;
@@ -340,90 +121,20 @@ class lookup_update_check_update_hash_poseidon2_settings {
         ColumnAndShifts::poseidon2_hash_input_2,
         ColumnAndShifts::poseidon2_hash_output
     };
-
-    template <typename AllEntities> static inline auto inverse_polynomial_is_computed_at_row(const AllEntities& in)
-    {
-        return (in.get(ColumnAndShifts::update_check_hash_not_zero) == 1 ||
-                in.get(ColumnAndShifts::poseidon2_hash_end) == 1);
-    }
-
-    template <typename Accumulator, typename AllEntities>
-    static inline auto compute_inverse_exists(const AllEntities& in)
-    {
-        using View = typename Accumulator::View;
-        const auto is_operation = View(in.get(ColumnAndShifts::update_check_hash_not_zero));
-        const auto is_table_entry = View(in.get(ColumnAndShifts::poseidon2_hash_end));
-        return (is_operation + is_table_entry - is_operation * is_table_entry);
-    }
-
-    template <typename AllEntities> static inline auto get_const_entities(const AllEntities& in)
-    {
-        return get_entities(in);
-    }
-
-    template <typename AllEntities> static inline auto get_nonconst_entities(AllEntities& in)
-    {
-        return get_entities(in);
-    }
-
-    template <typename AllEntities> static inline auto get_entities(AllEntities&& in)
-    {
-        return std::forward_as_tuple(in.get(ColumnAndShifts::lookup_update_check_update_hash_poseidon2_inv),
-                                     in.get(ColumnAndShifts::lookup_update_check_update_hash_poseidon2_counts),
-                                     in.get(ColumnAndShifts::update_check_hash_not_zero),
-                                     in.get(ColumnAndShifts::poseidon2_hash_end),
-                                     in.get(ColumnAndShifts::update_check_update_preimage_metadata),
-                                     in.get(ColumnAndShifts::update_check_update_preimage_pre_class_id),
-                                     in.get(ColumnAndShifts::update_check_update_preimage_post_class_id),
-                                     in.get(ColumnAndShifts::update_check_update_hash),
-                                     in.get(ColumnAndShifts::poseidon2_hash_input_0),
-                                     in.get(ColumnAndShifts::poseidon2_hash_input_1),
-                                     in.get(ColumnAndShifts::poseidon2_hash_input_2),
-                                     in.get(ColumnAndShifts::poseidon2_hash_output));
-    }
 };
 
+using lookup_update_check_update_hash_poseidon2_settings =
+    lookup_settings<lookup_update_check_update_hash_poseidon2_settings_>;
 template <typename FF_>
-class lookup_update_check_update_hash_poseidon2_relation
-    : public GenericLookupRelation<lookup_update_check_update_hash_poseidon2_settings, FF_> {
-  public:
-    using Settings = lookup_update_check_update_hash_poseidon2_settings;
-    static constexpr std::string_view NAME = lookup_update_check_update_hash_poseidon2_settings::NAME;
-    static constexpr std::string_view RELATION_NAME = lookup_update_check_update_hash_poseidon2_settings::RELATION_NAME;
-
-    template <typename AllEntities> inline static bool skip(const AllEntities& in)
-    {
-        return in.lookup_update_check_update_hash_poseidon2_inv.is_zero();
-    }
-
-    static std::string get_subrelation_label(size_t index)
-    {
-        if (index == 0) {
-            return "INVERSES_ARE_CORRECT";
-        } else if (index == 1) {
-            return "ACCUMULATION_IS_CORRECT";
-        }
-        return std::to_string(index);
-    }
-};
+using lookup_update_check_update_hash_poseidon2_relation =
+    lookup_relation_base<FF_, lookup_update_check_update_hash_poseidon2_settings>;
 
 /////////////////// lookup_update_check_update_hi_metadata_range ///////////////////
 
-class lookup_update_check_update_hi_metadata_range_settings {
-  public:
+struct lookup_update_check_update_hi_metadata_range_settings_ {
     static constexpr std::string_view NAME = "LOOKUP_UPDATE_CHECK_UPDATE_HI_METADATA_RANGE";
     static constexpr std::string_view RELATION_NAME = "update_check";
-
-    static constexpr size_t READ_TERMS = 1;
-    static constexpr size_t WRITE_TERMS = 1;
-    static constexpr size_t READ_TERM_TYPES[READ_TERMS] = { 0 };
-    static constexpr size_t WRITE_TERM_TYPES[WRITE_TERMS] = { 0 };
     static constexpr size_t LOOKUP_TUPLE_SIZE = 2;
-    static constexpr size_t INVERSE_EXISTS_POLYNOMIAL_DEGREE = 4;
-    static constexpr size_t READ_TERM_DEGREE = 0;
-    static constexpr size_t WRITE_TERM_DEGREE = 0;
-
-    // Columns using the Column enum.
     static constexpr Column SRC_SELECTOR = Column::update_check_hash_not_zero;
     static constexpr Column DST_SELECTOR = Column::range_check_sel;
     static constexpr Column COUNTS = Column::lookup_update_check_update_hi_metadata_range_counts;
@@ -434,87 +145,20 @@ class lookup_update_check_update_hi_metadata_range_settings {
     static constexpr std::array<ColumnAndShifts, LOOKUP_TUPLE_SIZE> DST_COLUMNS = {
         ColumnAndShifts::range_check_value, ColumnAndShifts::range_check_rng_chk_bits
     };
-
-    template <typename AllEntities> static inline auto inverse_polynomial_is_computed_at_row(const AllEntities& in)
-    {
-        return (in.get(ColumnAndShifts::update_check_hash_not_zero) == 1 ||
-                in.get(ColumnAndShifts::range_check_sel) == 1);
-    }
-
-    template <typename Accumulator, typename AllEntities>
-    static inline auto compute_inverse_exists(const AllEntities& in)
-    {
-        using View = typename Accumulator::View;
-        const auto is_operation = View(in.get(ColumnAndShifts::update_check_hash_not_zero));
-        const auto is_table_entry = View(in.get(ColumnAndShifts::range_check_sel));
-        return (is_operation + is_table_entry - is_operation * is_table_entry);
-    }
-
-    template <typename AllEntities> static inline auto get_const_entities(const AllEntities& in)
-    {
-        return get_entities(in);
-    }
-
-    template <typename AllEntities> static inline auto get_nonconst_entities(AllEntities& in)
-    {
-        return get_entities(in);
-    }
-
-    template <typename AllEntities> static inline auto get_entities(AllEntities&& in)
-    {
-        return std::forward_as_tuple(in.get(ColumnAndShifts::lookup_update_check_update_hi_metadata_range_inv),
-                                     in.get(ColumnAndShifts::lookup_update_check_update_hi_metadata_range_counts),
-                                     in.get(ColumnAndShifts::update_check_hash_not_zero),
-                                     in.get(ColumnAndShifts::range_check_sel),
-                                     in.get(ColumnAndShifts::update_check_update_hi_metadata),
-                                     in.get(ColumnAndShifts::update_check_update_hi_metadata_bit_size),
-                                     in.get(ColumnAndShifts::range_check_value),
-                                     in.get(ColumnAndShifts::range_check_rng_chk_bits));
-    }
 };
 
+using lookup_update_check_update_hi_metadata_range_settings =
+    lookup_settings<lookup_update_check_update_hi_metadata_range_settings_>;
 template <typename FF_>
-class lookup_update_check_update_hi_metadata_range_relation
-    : public GenericLookupRelation<lookup_update_check_update_hi_metadata_range_settings, FF_> {
-  public:
-    using Settings = lookup_update_check_update_hi_metadata_range_settings;
-    static constexpr std::string_view NAME = lookup_update_check_update_hi_metadata_range_settings::NAME;
-    static constexpr std::string_view RELATION_NAME =
-        lookup_update_check_update_hi_metadata_range_settings::RELATION_NAME;
-
-    template <typename AllEntities> inline static bool skip(const AllEntities& in)
-    {
-        return in.lookup_update_check_update_hi_metadata_range_inv.is_zero();
-    }
-
-    static std::string get_subrelation_label(size_t index)
-    {
-        if (index == 0) {
-            return "INVERSES_ARE_CORRECT";
-        } else if (index == 1) {
-            return "ACCUMULATION_IS_CORRECT";
-        }
-        return std::to_string(index);
-    }
-};
+using lookup_update_check_update_hi_metadata_range_relation =
+    lookup_relation_base<FF_, lookup_update_check_update_hi_metadata_range_settings>;
 
 /////////////////// lookup_update_check_update_lo_metadata_range ///////////////////
 
-class lookup_update_check_update_lo_metadata_range_settings {
-  public:
+struct lookup_update_check_update_lo_metadata_range_settings_ {
     static constexpr std::string_view NAME = "LOOKUP_UPDATE_CHECK_UPDATE_LO_METADATA_RANGE";
     static constexpr std::string_view RELATION_NAME = "update_check";
-
-    static constexpr size_t READ_TERMS = 1;
-    static constexpr size_t WRITE_TERMS = 1;
-    static constexpr size_t READ_TERM_TYPES[READ_TERMS] = { 0 };
-    static constexpr size_t WRITE_TERM_TYPES[WRITE_TERMS] = { 0 };
     static constexpr size_t LOOKUP_TUPLE_SIZE = 2;
-    static constexpr size_t INVERSE_EXISTS_POLYNOMIAL_DEGREE = 4;
-    static constexpr size_t READ_TERM_DEGREE = 0;
-    static constexpr size_t WRITE_TERM_DEGREE = 0;
-
-    // Columns using the Column enum.
     static constexpr Column SRC_SELECTOR = Column::update_check_hash_not_zero;
     static constexpr Column DST_SELECTOR = Column::range_check_sel;
     static constexpr Column COUNTS = Column::lookup_update_check_update_lo_metadata_range_counts;
@@ -525,87 +169,20 @@ class lookup_update_check_update_lo_metadata_range_settings {
     static constexpr std::array<ColumnAndShifts, LOOKUP_TUPLE_SIZE> DST_COLUMNS = {
         ColumnAndShifts::range_check_value, ColumnAndShifts::range_check_rng_chk_bits
     };
-
-    template <typename AllEntities> static inline auto inverse_polynomial_is_computed_at_row(const AllEntities& in)
-    {
-        return (in.get(ColumnAndShifts::update_check_hash_not_zero) == 1 ||
-                in.get(ColumnAndShifts::range_check_sel) == 1);
-    }
-
-    template <typename Accumulator, typename AllEntities>
-    static inline auto compute_inverse_exists(const AllEntities& in)
-    {
-        using View = typename Accumulator::View;
-        const auto is_operation = View(in.get(ColumnAndShifts::update_check_hash_not_zero));
-        const auto is_table_entry = View(in.get(ColumnAndShifts::range_check_sel));
-        return (is_operation + is_table_entry - is_operation * is_table_entry);
-    }
-
-    template <typename AllEntities> static inline auto get_const_entities(const AllEntities& in)
-    {
-        return get_entities(in);
-    }
-
-    template <typename AllEntities> static inline auto get_nonconst_entities(AllEntities& in)
-    {
-        return get_entities(in);
-    }
-
-    template <typename AllEntities> static inline auto get_entities(AllEntities&& in)
-    {
-        return std::forward_as_tuple(in.get(ColumnAndShifts::lookup_update_check_update_lo_metadata_range_inv),
-                                     in.get(ColumnAndShifts::lookup_update_check_update_lo_metadata_range_counts),
-                                     in.get(ColumnAndShifts::update_check_hash_not_zero),
-                                     in.get(ColumnAndShifts::range_check_sel),
-                                     in.get(ColumnAndShifts::update_check_update_block_of_change),
-                                     in.get(ColumnAndShifts::update_check_block_number_bit_size),
-                                     in.get(ColumnAndShifts::range_check_value),
-                                     in.get(ColumnAndShifts::range_check_rng_chk_bits));
-    }
 };
 
+using lookup_update_check_update_lo_metadata_range_settings =
+    lookup_settings<lookup_update_check_update_lo_metadata_range_settings_>;
 template <typename FF_>
-class lookup_update_check_update_lo_metadata_range_relation
-    : public GenericLookupRelation<lookup_update_check_update_lo_metadata_range_settings, FF_> {
-  public:
-    using Settings = lookup_update_check_update_lo_metadata_range_settings;
-    static constexpr std::string_view NAME = lookup_update_check_update_lo_metadata_range_settings::NAME;
-    static constexpr std::string_view RELATION_NAME =
-        lookup_update_check_update_lo_metadata_range_settings::RELATION_NAME;
-
-    template <typename AllEntities> inline static bool skip(const AllEntities& in)
-    {
-        return in.lookup_update_check_update_lo_metadata_range_inv.is_zero();
-    }
-
-    static std::string get_subrelation_label(size_t index)
-    {
-        if (index == 0) {
-            return "INVERSES_ARE_CORRECT";
-        } else if (index == 1) {
-            return "ACCUMULATION_IS_CORRECT";
-        }
-        return std::to_string(index);
-    }
-};
+using lookup_update_check_update_lo_metadata_range_relation =
+    lookup_relation_base<FF_, lookup_update_check_update_lo_metadata_range_settings>;
 
 /////////////////// lookup_update_check_block_of_change_cmp_range ///////////////////
 
-class lookup_update_check_block_of_change_cmp_range_settings {
-  public:
+struct lookup_update_check_block_of_change_cmp_range_settings_ {
     static constexpr std::string_view NAME = "LOOKUP_UPDATE_CHECK_BLOCK_OF_CHANGE_CMP_RANGE";
     static constexpr std::string_view RELATION_NAME = "update_check";
-
-    static constexpr size_t READ_TERMS = 1;
-    static constexpr size_t WRITE_TERMS = 1;
-    static constexpr size_t READ_TERM_TYPES[READ_TERMS] = { 0 };
-    static constexpr size_t WRITE_TERM_TYPES[WRITE_TERMS] = { 0 };
     static constexpr size_t LOOKUP_TUPLE_SIZE = 2;
-    static constexpr size_t INVERSE_EXISTS_POLYNOMIAL_DEGREE = 4;
-    static constexpr size_t READ_TERM_DEGREE = 0;
-    static constexpr size_t WRITE_TERM_DEGREE = 0;
-
-    // Columns using the Column enum.
     static constexpr Column SRC_SELECTOR = Column::update_check_hash_not_zero;
     static constexpr Column DST_SELECTOR = Column::range_check_sel;
     static constexpr Column COUNTS = Column::lookup_update_check_block_of_change_cmp_range_counts;
@@ -616,68 +193,12 @@ class lookup_update_check_block_of_change_cmp_range_settings {
     static constexpr std::array<ColumnAndShifts, LOOKUP_TUPLE_SIZE> DST_COLUMNS = {
         ColumnAndShifts::range_check_value, ColumnAndShifts::range_check_rng_chk_bits
     };
-
-    template <typename AllEntities> static inline auto inverse_polynomial_is_computed_at_row(const AllEntities& in)
-    {
-        return (in.get(ColumnAndShifts::update_check_hash_not_zero) == 1 ||
-                in.get(ColumnAndShifts::range_check_sel) == 1);
-    }
-
-    template <typename Accumulator, typename AllEntities>
-    static inline auto compute_inverse_exists(const AllEntities& in)
-    {
-        using View = typename Accumulator::View;
-        const auto is_operation = View(in.get(ColumnAndShifts::update_check_hash_not_zero));
-        const auto is_table_entry = View(in.get(ColumnAndShifts::range_check_sel));
-        return (is_operation + is_table_entry - is_operation * is_table_entry);
-    }
-
-    template <typename AllEntities> static inline auto get_const_entities(const AllEntities& in)
-    {
-        return get_entities(in);
-    }
-
-    template <typename AllEntities> static inline auto get_nonconst_entities(AllEntities& in)
-    {
-        return get_entities(in);
-    }
-
-    template <typename AllEntities> static inline auto get_entities(AllEntities&& in)
-    {
-        return std::forward_as_tuple(in.get(ColumnAndShifts::lookup_update_check_block_of_change_cmp_range_inv),
-                                     in.get(ColumnAndShifts::lookup_update_check_block_of_change_cmp_range_counts),
-                                     in.get(ColumnAndShifts::update_check_hash_not_zero),
-                                     in.get(ColumnAndShifts::range_check_sel),
-                                     in.get(ColumnAndShifts::update_check_block_of_change_subtraction),
-                                     in.get(ColumnAndShifts::update_check_block_number_bit_size),
-                                     in.get(ColumnAndShifts::range_check_value),
-                                     in.get(ColumnAndShifts::range_check_rng_chk_bits));
-    }
 };
 
+using lookup_update_check_block_of_change_cmp_range_settings =
+    lookup_settings<lookup_update_check_block_of_change_cmp_range_settings_>;
 template <typename FF_>
-class lookup_update_check_block_of_change_cmp_range_relation
-    : public GenericLookupRelation<lookup_update_check_block_of_change_cmp_range_settings, FF_> {
-  public:
-    using Settings = lookup_update_check_block_of_change_cmp_range_settings;
-    static constexpr std::string_view NAME = lookup_update_check_block_of_change_cmp_range_settings::NAME;
-    static constexpr std::string_view RELATION_NAME =
-        lookup_update_check_block_of_change_cmp_range_settings::RELATION_NAME;
-
-    template <typename AllEntities> inline static bool skip(const AllEntities& in)
-    {
-        return in.lookup_update_check_block_of_change_cmp_range_inv.is_zero();
-    }
-
-    static std::string get_subrelation_label(size_t index)
-    {
-        if (index == 0) {
-            return "INVERSES_ARE_CORRECT";
-        } else if (index == 1) {
-            return "ACCUMULATION_IS_CORRECT";
-        }
-        return std::to_string(index);
-    }
-};
+using lookup_update_check_block_of_change_cmp_range_relation =
+    lookup_relation_base<FF_, lookup_update_check_block_of_change_cmp_range_settings>;
 
 } // namespace bb::avm2

--- a/bb-pilcom/bb-pil-backend/templates/lookup.hpp.hbs
+++ b/bb-pilcom/bb-pil-backend/templates/lookup.hpp.hbs
@@ -3,6 +3,7 @@
 
 #include "../columns.hpp"
 #include "barretenberg/relations/generic_lookup/generic_lookup_relation.hpp"
+#include "barretenberg/vm2/constraining/relations/interactions_base.hpp"
 
 #include <cstddef>
 #include <tuple>
@@ -13,21 +14,10 @@ namespace bb::{{snakeCase root_name}} {
 {{#each lookups as |current_lookup|}}{{#with current_lookup}}
 /////////////////// {{lookup_name}} ///////////////////
 
-class {{lookup_name}}_settings {
-  public:
+struct {{lookup_name}}_settings_ {
     static constexpr std::string_view NAME = "{{shoutySnakeCase lookup_name}}";
     static constexpr std::string_view RELATION_NAME = "{{relation_name}}";
-
-    static constexpr size_t READ_TERMS = {{read_terms}};
-    static constexpr size_t WRITE_TERMS = {{write_terms}};
-    static constexpr size_t READ_TERM_TYPES[READ_TERMS] = {{read_term_types}};
-    static constexpr size_t WRITE_TERM_TYPES[WRITE_TERMS] = {{write_term_types}};
     static constexpr size_t LOOKUP_TUPLE_SIZE = {{lookup_tuple_size}};
-    static constexpr size_t INVERSE_EXISTS_POLYNOMIAL_DEGREE = {{inverse_degree}};
-    static constexpr size_t READ_TERM_DEGREE = {{read_term_degree}};
-    static constexpr size_t WRITE_TERM_DEGREE = {{write_term_degree}};
-
-    // Columns using the Column enum.
     static constexpr Column SRC_SELECTOR = Column::{{lhs_selector}};
     static constexpr Column DST_SELECTOR = Column::{{rhs_selector}};
     static constexpr Column COUNTS = Column::{{counts_col}};
@@ -42,70 +32,10 @@ class {{lookup_name}}_settings {
         ColumnAndShifts::{{col}}{{#unless @last}},{{/unless}}
         {{/each}}
     };
-
-    template <typename AllEntities> static inline auto inverse_polynomial_is_computed_at_row(const AllEntities& in)
-    {
-        return (in.get(ColumnAndShifts::{{lhs_selector}}) == 1 || in.get(ColumnAndShifts::{{rhs_selector}}) == 1);
-    }
-
-    template <typename Accumulator, typename AllEntities>
-    static inline auto compute_inverse_exists(const AllEntities& in)
-    {
-        using View = typename Accumulator::View;
-        const auto is_operation = View(in.get(ColumnAndShifts::{{lhs_selector}}));
-        const auto is_table_entry = View(in.get(ColumnAndShifts::{{rhs_selector}}));
-        return (is_operation + is_table_entry - is_operation * is_table_entry);
-    }
-
-    template <typename AllEntities> static inline auto get_const_entities(const AllEntities& in)
-    {
-        return get_entities(in);
-    }
-
-    template <typename AllEntities> static inline auto get_nonconst_entities(AllEntities& in)
-    {
-        return get_entities(in);
-    }
-
-    template <typename AllEntities> static inline auto get_entities(AllEntities&& in)
-    {
-        return std::forward_as_tuple(
-            in.get(ColumnAndShifts::{{inverses_col}}),
-            in.get(ColumnAndShifts::{{counts_col}}),
-            in.get(ColumnAndShifts::{{lhs_selector}}),
-            in.get(ColumnAndShifts::{{rhs_selector}}),
-            {{#each lhs_cols as |col|}}
-            in.get(ColumnAndShifts::{{col}}){{#unless @last}},{{/unless}}
-            {{/each}},
-            {{#each rhs_cols as |col|}}
-            in.get(ColumnAndShifts::{{col}}){{#unless @last}},{{/unless}}
-            {{/each}}
-        );
-    }
 };
 
-template <typename FF_> class {{lookup_name}}_relation : public GenericLookupRelation<{{lookup_name}}_settings, FF_> {
-    public:
-        using Settings = {{lookup_name}}_settings;
-        static constexpr std::string_view NAME = {{lookup_name}}_settings::NAME;
-        static constexpr std::string_view RELATION_NAME = {{lookup_name}}_settings::RELATION_NAME;
-
-        {{! TODO: This is a safe skippable condition, but there might be a better one. --}}
-        template <typename AllEntities> inline static bool skip(const AllEntities& in)
-        {
-            return in.{{inverses_col}}.is_zero();
-        }
-
-        static std::string get_subrelation_label(size_t index) {
-            {{! from generic_lookup_relation.hpp }}
-            if (index == 0) {
-                return "INVERSES_ARE_CORRECT";
-            } else if (index == 1) {
-                return "ACCUMULATION_IS_CORRECT";
-            }
-            return std::to_string(index);
-        }
-};
+using {{lookup_name}}_settings = lookup_settings<{{lookup_name}}_settings_>;
+template <typename FF_> using {{lookup_name}}_relation = lookup_relation_base<FF_, {{lookup_name}}_settings>;
 
 {{/with}}{{/each}}
 } // namespace bb::{{snakeCase root_name}}


### PR DESCRIPTION
Create some reasonable base class to avoid lots of codegen.