### PR TITLE
chore(spartan): bump default kind resources

### DIFF
--- a/spartan/aztec-network/resources/default.yaml
+++ b/spartan/aztec-network/resources/default.yaml
@@ -9,25 +9,25 @@ bootNode:
 validator:
   resources:
     requests:
-      memory: "512Mi"
+      memory: "1Gi"
     limits:
-      memory: "512Mi"
+      memory: "1Gi"
       cpu: "500m"
 
 fullNode:
   resources:
     requests:
-      memory: "512Mi"
+      memory: "1Gi"
     limits:
-      memory: "512Mi"
+      memory: "1Gi"
       cpu: "500m"
 
 proverNode:
   resources:
     requests:
-      memory: "512Mi"
+      memory: "1Gi"
     limits:
-      memory: "512Mi"
+      memory: "1Gi"
       cpu: "500m"
 pxe:
   resources:


### PR DESCRIPTION
I noticed this was required to run the kind tests locally
