### PR TITLE
chore(docs): adding redirects for node guide

### DIFF
--- a/docs/netlify.toml
+++ b/docs/netlify.toml
@@ -177,3 +177,7 @@
 [[redirects]]
     from = "/tutorials/codealong/contract_tutorials/token_bridge/*"
     to = "/tutorials/codealong/contract_tutorials/token_bridge"
+
+[[redirects]]
+    from = "/run_node/*"
+    to = "/the_aztec_network/guides/run_nodes"


### PR DESCRIPTION
# Add redirect for run_node to run_nodes

This PR adds a new redirect rule in the Netlify configuration to ensure that URLs starting with `/run_node/` are properly redirected to the `/the_aztec_network/guides/run_nodes` page.