### PR TITLE
chore: Disable blobscan by default (#13742)

### DIFF
--- a/spartan/aztec-network/templates/blob-sink.yaml
+++ b/spartan/aztec-network/templates/blob-sink.yaml
@@ -99,6 +99,8 @@ spec:
                   fieldPath: metadata.namespace
             - name: BLOB_SINK_PORT
               value: "{{ .Values.blobSink.service.nodePort }}"
+            - name: BLOB_SINK_ARCHIVE_API_URL
+              value: "{{ .Values.blobSink.archiveApiUrl }}"
             - name: LOG_LEVEL
               value: "{{ .Values.blobSink.logLevel }}"
             - name: LOG_JSON

--- a/spartan/aztec-network/values/alpha-testnet.yaml
+++ b/spartan/aztec-network/values/alpha-testnet.yaml
@@ -24,6 +24,7 @@ network:
 
 blobSink:
   enabled: true
+  archiveApiUrl: "https://api.sepolia.blobscan.com"
   dataStoreConfig:
     dataDir: "/data"
     storageSize: "128Gi"

--- a/yarn-project/blob-sink/src/archive/factory.ts
+++ b/yarn-project/blob-sink/src/archive/factory.ts
@@ -7,11 +7,5 @@ export function createBlobArchiveClient(config: BlobSinkConfig): BlobArchiveClie
     return new BlobscanArchiveClient(config.archiveApiUrl);
   }
 
-  if (config.l1ChainId === 1) {
-    return new BlobscanArchiveClient('https://api.blobscan.com');
-  } else if (config.l1ChainId === 11155111) {
-    return new BlobscanArchiveClient('https://api.sepolia.blobscan.com');
-  }
-
   return undefined;
 }


### PR DESCRIPTION
Disables blobscan as blob archive fallback since its API has not been reliable enough. We keep it enabled in k8s config for our blobsink though.

Cherry-pick of #13742 onto alpha-testnet