### PR TITLE
refactor: bespoke export for client native prover / PXE server store lazy load

### DIFF
--- a/yarn-project/bb-prover/package.json
+++ b/yarn-project/bb-prover/package.json
@@ -4,9 +4,9 @@
   "type": "module",
   "exports": {
     ".": "./dest/index.js",
-    "./wasm/bundle": "./dest/wasm/bundle.js",
-    "./wasm/lazy": "./dest/wasm/lazy.js",
-    "./prover": "./dest/prover/index.js",
+    "./client/wasm/bundle": "./dest/prover/client/wasm/bundle.js",
+    "./client/wasm/lazy": "./dest/prover/client/wasm/lazy.js",
+    "./client/native": "./dest/prover/client/native/bb_native_private_kernel_prover.js",
     "./verifier": "./dest/verifier/index.js",
     "./test": "./dest/test/index.js",
     "./config": "./dest/config.js"

--- a/yarn-project/bb-prover/src/prover/client/bb_private_kernel_prover.ts
+++ b/yarn-project/bb-prover/src/prover/client/bb_private_kernel_prover.ts
@@ -32,7 +32,7 @@ import type { NoirCompiledCircuitWithName } from '@aztec/stdlib/noir';
 import type { ClientIvcProof } from '@aztec/stdlib/proofs';
 import type { CircuitSimulationStats, CircuitWitnessGenerationStats } from '@aztec/stdlib/stats';
 
-import { mapProtocolArtifactNameToCircuitName } from '../stats.js';
+import { mapProtocolArtifactNameToCircuitName } from '../../stats.js';
 
 export abstract class BBPrivateKernelProver implements PrivateKernelProver {
   constructor(

--- a/yarn-project/bb-prover/src/prover/client/native/bb_native_private_kernel_prover.ts
+++ b/yarn-project/bb-prover/src/prover/client/native/bb_native_private_kernel_prover.ts
@@ -8,10 +8,10 @@ import type { ClientIvcProof } from '@aztec/stdlib/proofs';
 import { promises as fs } from 'fs';
 import path from 'path';
 
-import { BB_RESULT, computeGateCountForCircuit, executeBbClientIvcProof } from '../bb/execute.js';
-import type { BBConfig } from '../config.js';
-import { BBPrivateKernelProver } from './bb_private_kernel_prover.js';
-import { readClientIVCProofFromOutputDirectory } from './proof_utils.js';
+import { BB_RESULT, computeGateCountForCircuit, executeBbClientIvcProof } from '../../../bb/execute.js';
+import type { BBConfig } from '../../../config.js';
+import { readClientIVCProofFromOutputDirectory } from '../../proof_utils.js';
+import { BBPrivateKernelProver } from '../bb_private_kernel_prover.js';
 
 /**
  * This proof creator implementation uses the native bb binary.

--- a/yarn-project/bb-prover/src/prover/client/wasm/bb_wasm_private_kernel_prover.ts
+++ b/yarn-project/bb-prover/src/prover/client/wasm/bb_wasm_private_kernel_prover.ts
@@ -9,7 +9,7 @@ import { ClientIvcProof } from '@aztec/stdlib/proofs';
 
 import { ungzip } from 'pako';
 
-import { BBPrivateKernelProver } from '../prover/bb_private_kernel_prover.js';
+import { BBPrivateKernelProver } from '../bb_private_kernel_prover.js';
 
 export abstract class BBWASMPrivateKernelProver extends BBPrivateKernelProver {
   constructor(

--- a/yarn-project/bb-prover/src/prover/client/wasm/bundle.ts
+++ b/yarn-project/bb-prover/src/prover/client/wasm/bundle.ts
@@ -5,7 +5,7 @@ import type { SimulationProvider } from '@aztec/simulator/client';
 import { BBWASMPrivateKernelProver } from './bb_wasm_private_kernel_prover.js';
 
 export class BBWASMBundlePrivateKernelProver extends BBWASMPrivateKernelProver {
-  constructor(simulationProvider: SimulationProvider, threads = 1, log = createLogger('bb-prover:wasm:bundle')) {
+  constructor(simulationProvider: SimulationProvider, threads = 16, log = createLogger('bb-prover:wasm:bundle')) {
     super(new BundleArtifactProvider(), simulationProvider, threads, log);
   }
 }

--- a/yarn-project/bb-prover/src/prover/client/wasm/lazy.ts
+++ b/yarn-project/bb-prover/src/prover/client/wasm/lazy.ts
@@ -5,7 +5,7 @@ import type { SimulationProvider } from '@aztec/simulator/client';
 import { BBWASMPrivateKernelProver } from './bb_wasm_private_kernel_prover.js';
 
 export class BBWASMLazyPrivateKernelProver extends BBWASMPrivateKernelProver {
-  constructor(simulationProvider: SimulationProvider, threads = 1, log = createLogger('bb-prover:wasm:lazy')) {
+  constructor(simulationProvider: SimulationProvider, threads = 16, log = createLogger('bb-prover:wasm:lazy')) {
     super(new LazyArtifactProvider(), simulationProvider, threads, log);
   }
 }

--- a/yarn-project/bb-prover/src/prover/index.ts
+++ b/yarn-project/bb-prover/src/prover/index.ts
@@ -1,3 +1,2 @@
-export * from './bb_prover.js';
-export * from './bb_native_private_kernel_prover.js';
+export * from './server/bb_prover.js';
 export * from './proof_utils.js';

--- a/yarn-project/bb-prover/src/prover/server/bb_prover.ts
+++ b/yarn-project/bb-prover/src/prover/server/bb_prover.ts
@@ -83,14 +83,14 @@ import {
   generateTubeProof,
   verifyAvmProof,
   verifyProof,
-} from '../bb/execute.js';
-import type { ACVMConfig, BBConfig } from '../config.js';
-import { type UltraHonkFlavor, getUltraHonkFlavorForCircuit } from '../honk.js';
-import { ProverInstrumentation } from '../instrumentation.js';
-import { mapProtocolArtifactNameToCircuitName } from '../stats.js';
-import { extractAvmVkData, extractVkData } from '../verification_key/verification_key_data.js';
-import { PRIVATE_TAIL_CIVC_VK, PUBLIC_TAIL_CIVC_VK } from '../verifier/bb_verifier.js';
-import { readProofAsFields, writeClientIVCProofToOutputDirectory } from './proof_utils.js';
+} from '../../bb/execute.js';
+import type { ACVMConfig, BBConfig } from '../../config.js';
+import { type UltraHonkFlavor, getUltraHonkFlavorForCircuit } from '../../honk.js';
+import { ProverInstrumentation } from '../../instrumentation.js';
+import { mapProtocolArtifactNameToCircuitName } from '../../stats.js';
+import { extractAvmVkData, extractVkData } from '../../verification_key/verification_key_data.js';
+import { PRIVATE_TAIL_CIVC_VK, PUBLIC_TAIL_CIVC_VK } from '../../verifier/bb_verifier.js';
+import { readProofAsFields, writeClientIVCProofToOutputDirectory } from '../proof_utils.js';
 
 const logger = createLogger('bb-prover');
 

--- a/yarn-project/end-to-end/src/bench/client_flows/data_extractor.ts
+++ b/yarn-project/end-to-end/src/bench/client_flows/data_extractor.ts
@@ -1,6 +1,6 @@
 import type { Logger } from '@aztec/aztec.js';
-import { BBNativePrivateKernelProver } from '@aztec/bb-prover';
-import { BBWASMBundlePrivateKernelProver } from '@aztec/bb-prover/wasm/bundle';
+import { BBNativePrivateKernelProver } from '@aztec/bb-prover/client/native';
+import { BBWASMBundlePrivateKernelProver } from '@aztec/bb-prover/client/wasm/bundle';
 import { createLogger, logger } from '@aztec/foundation/log';
 import { WASMSimulator } from '@aztec/simulator/client';
 import type { PrivateExecutionStep } from '@aztec/stdlib/kernel';

--- a/yarn-project/pxe/src/entrypoints/client/bundle/utils.ts
+++ b/yarn-project/pxe/src/entrypoints/client/bundle/utils.ts
@@ -1,4 +1,4 @@
-import { BBWASMBundlePrivateKernelProver } from '@aztec/bb-prover/wasm/bundle';
+import { BBWASMBundlePrivateKernelProver } from '@aztec/bb-prover/client/wasm/bundle';
 import { createLogger } from '@aztec/foundation/log';
 import { createStore } from '@aztec/kv-store/indexeddb';
 import { BundledProtocolContractsProvider } from '@aztec/protocol-contracts/providers/bundle';

--- a/yarn-project/pxe/src/entrypoints/client/lazy/utils.ts
+++ b/yarn-project/pxe/src/entrypoints/client/lazy/utils.ts
@@ -1,4 +1,4 @@
-import { BBWASMLazyPrivateKernelProver } from '@aztec/bb-prover/wasm/lazy';
+import { BBWASMLazyPrivateKernelProver } from '@aztec/bb-prover/client/wasm/lazy';
 import { createLogger } from '@aztec/foundation/log';
 import { createStore } from '@aztec/kv-store/indexeddb';
 import { LazyProtocolContractsProvider } from '@aztec/protocol-contracts/providers/lazy';

--- a/yarn-project/pxe/src/entrypoints/server/utils.ts
+++ b/yarn-project/pxe/src/entrypoints/server/utils.ts
@@ -2,7 +2,7 @@ import { BBNativePrivateKernelProver } from '@aztec/bb-prover/client/native';
 import { BBWASMBundlePrivateKernelProver } from '@aztec/bb-prover/client/wasm/bundle';
 import { randomBytes } from '@aztec/foundation/crypto';
 import { createLogger } from '@aztec/foundation/log';
-import { createStore } from '@aztec/kv-store/lmdb-v2';
+import type { AztecAsyncKVStore } from '@aztec/kv-store';
 import { BundledProtocolContractsProvider } from '@aztec/protocol-contracts/providers/bundle';
 import { type SimulationProvider, WASMSimulator } from '@aztec/simulator/client';
 import { SimulationProviderRecorderWrapper } from '@aztec/simulator/testing';
@@ -24,10 +24,11 @@ export function createPXEService(
   aztecNode: AztecNode,
   config: PXEServiceConfig,
   useLogSuffix: string | boolean | undefined = undefined,
+  store?: AztecAsyncKVStore,
 ) {
   const simulationProvider = new WASMSimulator();
   const simulationProviderWithRecorder = new SimulationProviderRecorderWrapper(simulationProvider);
-  return createPXEServiceWithSimulationProvider(aztecNode, simulationProviderWithRecorder, config, useLogSuffix);
+  return createPXEServiceWithSimulationProvider(aztecNode, simulationProviderWithRecorder, config, useLogSuffix, store);
 }
 
 /**
@@ -44,6 +45,7 @@ export async function createPXEServiceWithSimulationProvider(
   simulationProvider: SimulationProvider,
   config: PXEServiceConfig,
   useLogSuffix: string | boolean | undefined = undefined,
+  store?: AztecAsyncKVStore,
 ) {
   const logSuffix =
     typeof useLogSuffix === 'boolean' ? (useLogSuffix ? randomBytes(3).toString('hex') : undefined) : useLogSuffix;
@@ -55,12 +57,12 @@ export async function createPXEServiceWithSimulationProvider(
     l2BlockBatchSize: 200,
   } as PXEServiceConfig;
 
-  const store = await createStore(
-    'pxe_data',
-    PXE_DATA_SCHEMA_VERSION,
-    configWithContracts,
-    createLogger('pxe:data:lmdb'),
-  );
+  if (!store) {
+    // TODO once https://github.com/AztecProtocol/aztec-packages/issues/13656 is fixed, we can remove this and always
+    // import the lmdb-v2 version
+    const { createStore } = await import('@aztec/kv-store/lmdb-v2');
+    store = await createStore('pxe_data', PXE_DATA_SCHEMA_VERSION, configWithContracts, createLogger('pxe:data:lmdb'));
+  }
 
   const prover = await createProver(config, simulationProvider, logSuffix);
   const protocolContractsProvider = new BundledProtocolContractsProvider();

--- a/yarn-project/pxe/src/entrypoints/server/utils.ts
+++ b/yarn-project/pxe/src/entrypoints/server/utils.ts
@@ -1,5 +1,5 @@
-import { BBNativePrivateKernelProver } from '@aztec/bb-prover';
-import { BBWASMBundlePrivateKernelProver } from '@aztec/bb-prover/wasm/bundle';
+import { BBNativePrivateKernelProver } from '@aztec/bb-prover/client/native';
+import { BBWASMBundlePrivateKernelProver } from '@aztec/bb-prover/client/wasm/bundle';
 import { randomBytes } from '@aztec/foundation/crypto';
 import { createLogger } from '@aztec/foundation/log';
 import { createStore } from '@aztec/kv-store/lmdb-v2';

--- a/yarn-project/pxe/src/test/pxe_service.test.ts
+++ b/yarn-project/pxe/src/test/pxe_service.test.ts
@@ -1,4 +1,4 @@
-import { BBWASMBundlePrivateKernelProver } from '@aztec/bb-prover/wasm/bundle';
+import { BBWASMBundlePrivateKernelProver } from '@aztec/bb-prover/client/wasm/bundle';
 import type { L1ContractAddresses } from '@aztec/ethereum/l1-contract-addresses';
 import { EthAddress } from '@aztec/foundation/eth-address';
 import type { AztecAsyncKVStore } from '@aztec/kv-store';


### PR DESCRIPTION
Fixes: https://github.com/AztecProtocol/aztec-packages/issues/13656 (or more like avoids the problematic import)

Creates specific (and more descriptive) exports for `bb-prover`, focusing on where the code should run (client/server) rather than the task at hand (prover/verifier). This mimics the behavior of other packages with similar issues.

We still have to figure out publishing of native packages.
