### PR TITLE
refactor(avm): some fixes and faster tests

### DIFF
--- a/barretenberg/cpp/src/barretenberg/dsl/acir_format/avm2_recursion_constraint.test.cpp
+++ b/barretenberg/cpp/src/barretenberg/dsl/acir_format/avm2_recursion_constraint.test.cpp
@@ -151,7 +151,6 @@ TEST_F(AcirAvm2RecursionConstraint, TestBasicSingleAvm2RecursionConstraint)
  */
 TEST_F(AcirAvm2RecursionConstraint, TestGenerateVKFromConstraintsWithoutWitness)
 {
-
     // Generate AVM proof, verification key and public inputs
     InnerCircuitData avm_prover_output = create_inner_circuit_data();
 

--- a/barretenberg/cpp/src/barretenberg/vm2/constraining/benchmark/relations_acc.bench.cpp
+++ b/barretenberg/cpp/src/barretenberg/vm2/constraining/benchmark/relations_acc.bench.cpp
@@ -16,11 +16,11 @@ using namespace bb::avm2;
 
 namespace {
 
-AvmFullRow<FF> get_random_row()
+AvmFullRow get_random_row()
 {
-    AvmFullRow<FF> row;
+    AvmFullRow row;
     for (size_t i = 0; i < NUM_COLUMNS_WITH_SHIFTS; i++) {
-        row.get_column(static_cast<ColumnAndShifts>(i)) = FF::random_element();
+        row.get(static_cast<ColumnAndShifts>(i)) = FF::random_element();
     }
     return row;
 }

--- a/barretenberg/cpp/src/barretenberg/vm2/constraining/entities.hpp
+++ b/barretenberg/cpp/src/barretenberg/vm2/constraining/entities.hpp
@@ -1,0 +1,20 @@
+#pragma once
+
+#include "barretenberg/vm2/generated/columns.hpp"
+
+namespace bb::avm2 {
+
+// This helper lets us access entities by column.
+// It is critical to achieve performance when calculating lookup inverses.
+// See https://github.com/AztecProtocol/aztec-packages/pull/11605 for more details.
+template <typename Entities> auto& get_entity_by_column(Entities& entities, ColumnAndShifts c)
+{
+    // A statically constructed pointer to members of the class, indexed by column.
+    // This should only be created once per Entities class.
+    static std::array<typename Entities::DataType(Entities::*), NUM_COLUMNS_WITH_SHIFTS> col_ptrs = {
+        AVM2_ALL_ENTITIES_E(&Entities::)
+    };
+    return (entities.*col_ptrs[static_cast<size_t>(c)]);
+}
+
+} // namespace bb::avm2

--- a/barretenberg/cpp/src/barretenberg/vm2/constraining/flavor.hpp
+++ b/barretenberg/cpp/src/barretenberg/vm2/constraining/flavor.hpp
@@ -12,6 +12,7 @@
 #include "barretenberg/transcript/transcript.hpp"
 
 #include "barretenberg/vm2/common/aztec_constants.hpp"
+#include "barretenberg/vm2/constraining/entities.hpp"
 #include "barretenberg/vm2/constraining/flavor_settings.hpp"
 
 #include "barretenberg/vm2/generated/columns.hpp"
@@ -21,19 +22,6 @@
 template <typename... input_t> using tuple_cat_t = decltype(std::tuple_cat(std::declval<input_t>()...));
 
 namespace bb::avm2 {
-
-// This helper lets us access entities by column.
-// It is critical to achieve performance when calculating lookup inverses.
-// See https://github.com/AztecProtocol/aztec-packages/pull/11605 for more details.
-template <typename Entities> auto& get_entity_by_column(Entities& entities, ColumnAndShifts c)
-{
-    // A statically constructed pointer to members of the class, indexed by column.
-    // This should only be created once per Entities class.
-    static std::array<typename Entities::DataType(Entities::*), NUM_COLUMNS_WITH_SHIFTS> col_ptrs = {
-        AVM2_ALL_ENTITIES_E(&Entities::)
-    };
-    return (entities.*col_ptrs[static_cast<size_t>(c)]);
-}
 
 class AvmFlavor {
   public:
@@ -260,19 +248,7 @@ class AvmFlavor {
     };
 
     // Used by sumcheck.
-    class AllValues : public AllEntities<FF> {
-      public:
-        using Base = AllEntities<FF>;
-        using Base::Base;
-    };
-
-    // Only used by VM1 check_circuit. Remove.
-    class AllConstRefValues {
-      public:
-        using BaseDataType = const FF;
-        using DataType = BaseDataType&;
-        DEFINE_FLAVOR_MEMBERS(DataType, AVM2_ALL_ENTITIES)
-    };
+    using AllValues = AllEntities<FF>;
 
     template <typename Polynomials> class PolynomialEntitiesAtFixedRow {
       public:
@@ -281,8 +257,7 @@ class AvmFlavor {
             , pp(pp)
         {}
 
-        // We need both const and non-const versions.
-        auto& get(ColumnAndShifts c) { return pp.get(c)[row_idx]; }
+        // Only const-access is allowed here. That's all that the logderivative library requires.
         const auto& get(ColumnAndShifts c) const { return pp.get(c)[row_idx]; }
 
       private:
@@ -306,14 +281,9 @@ class AvmFlavor {
         ProverPolynomials(ProvingKey& proving_key);
 
         size_t get_polynomial_size() const { return execution_input.size(); }
-        // This is only used in check_circuit. Remove.
-        AllConstRefValues get_standard_row(size_t row_idx) const
-        {
-            return [row_idx](auto&... entities) -> AllConstRefValues {
-                return { entities[row_idx]... };
-            }(AVM2_ALL_ENTITIES);
-        }
-        auto get_row(size_t row_idx) const { return PolynomialEntitiesAtFixedRow<ProverPolynomials>(row_idx, *this); }
+        // Only const-access is allowed here. That's all that the logderivative library requires.
+        // https://github.com/AztecProtocol/aztec-packages/blob/e50d8e0/barretenberg/cpp/src/barretenberg/honk/proof_system/logderivative_library.hpp#L44.
+        PolynomialEntitiesAtFixedRow<ProverPolynomials> get_row(size_t row_idx) const { return { row_idx, *this }; }
     };
 
     class PartiallyEvaluatedMultivariates : public AllEntities<Polynomial> {

--- a/barretenberg/cpp/src/barretenberg/vm2/constraining/full_row.cpp
+++ b/barretenberg/cpp/src/barretenberg/vm2/constraining/full_row.cpp
@@ -1,0 +1,19 @@
+#include "barretenberg/vm2/constraining/full_row.hpp"
+
+namespace bb::avm2 {
+
+FF& AvmFullRow::get(ColumnAndShifts col)
+{
+    return get_entity_by_column(*this, col);
+}
+const FF& AvmFullRow::get(ColumnAndShifts col) const
+{
+    return get_entity_by_column(*this, col);
+}
+
+AvmFullRowConstRef AvmFullRowConstRef::from_full_row(const AvmFullRow& full_row)
+{
+    return { AVM2_ALL_ENTITIES_E(full_row.) };
+}
+
+} // namespace bb::avm2

--- a/barretenberg/cpp/src/barretenberg/vm2/constraining/full_row.hpp
+++ b/barretenberg/cpp/src/barretenberg/vm2/constraining/full_row.hpp
@@ -1,31 +1,27 @@
 #pragma once
 
+#include "barretenberg/vm2/common/field.hpp"
+#include "barretenberg/vm2/constraining/entities.hpp"
 #include "barretenberg/vm2/generated/columns.hpp"
 
 namespace bb::avm2 {
 
-template <typename FF_> struct AvmFullRow {
-    using FF = FF_;
-
+// A bulky full row, mostly for testing purposes.
+struct AvmFullRow {
+    using DataType = FF;
     FF AVM2_ALL_ENTITIES;
 
-    // Risky but oh so efficient.
-    FF& get_column(ColumnAndShifts col)
-    {
-        static_assert(sizeof(*this) == sizeof(FF) * static_cast<size_t>(ColumnAndShifts::SENTINEL_DO_NOT_USE));
-        return reinterpret_cast<FF*>(this)[static_cast<size_t>(col)];
-    }
+    FF& get(ColumnAndShifts col);
+    const FF& get(ColumnAndShifts col) const;
+};
 
-    const FF& get_column(ColumnAndShifts col) const
-    {
-        static_assert(sizeof(*this) == sizeof(FF) * static_cast<size_t>(ColumnAndShifts::SENTINEL_DO_NOT_USE));
-        return reinterpret_cast<const FF*>(this)[static_cast<size_t>(col)];
-    }
+// A full row made up of references to fields.
+// It can be constructed, e.g., from a full row or a trace.
+struct AvmFullRowConstRef {
+    using DataType = const FF;
+    const FF& AVM2_ALL_ENTITIES;
 
-    // These are the names used by AllEntities, etc.
-    // TODO(fcarreiro): Clean up duplication.
-    FF& get(ColumnAndShifts col) { return get_column(col); }
-    const FF& get(ColumnAndShifts col) const { return get_column(col); }
+    static AvmFullRowConstRef from_full_row(const AvmFullRow& full_row);
 };
 
 } // namespace bb::avm2

--- a/barretenberg/cpp/src/barretenberg/vm2/constraining/polynomials.cpp
+++ b/barretenberg/cpp/src/barretenberg/vm2/constraining/polynomials.cpp
@@ -17,17 +17,18 @@ AvmProver::ProverPolynomials compute_polynomials(tracegen::TraceContainer& trace
     AVM_TRACK_TIME("proving/init_polys_to_be_shifted", ({
                        auto to_be_shifted = polys.get_to_be_shifted();
 
-                       // TODO: cannot parallelize because Polynomial construction uses parallelism.
+                       // NOTE: we can't parallelize because Polynomial construction uses parallelism.
                        for (size_t i = 0; i < to_be_shifted.size(); i++) {
                            auto& poly = to_be_shifted[i];
                            // WARNING! Column-Polynomials order matters!
                            Column col = static_cast<Column>(TO_BE_SHIFTED_COLUMNS_ARRAY.at(i));
-                           // We need at least 2 rows for the shifted columns.
-                           uint32_t num_rows = std::max<uint32_t>(trace.get_column_rows(col), 2);
+                           uint32_t num_rows = trace.get_column_rows(col);
+                           // Since we are shifting, we need to allocate one less row.
+                           // The first row is always zero.
+                           uint32_t allocated_size = num_rows > 0 ? num_rows - 1 : 0;
 
                            poly = AvmProver::Polynomial(
-                               /*memory size*/
-                               num_rows - 1,
+                               /*memory size*/ allocated_size,
                                /*largest possible index*/ CIRCUIT_SUBGROUP_SIZE,
                                /*make shiftable with offset*/ 1);
                        }
@@ -43,13 +44,10 @@ AvmProver::ProverPolynomials compute_polynomials(tracegen::TraceContainer& trace
     // think about it and check the formula.
     AVM_TRACK_TIME("proving/init_polys_unshifted", ({
                        auto unshifted = polys.get_unshifted();
-
-                       // Derived polynomials will be empty.
                        bb::parallel_for(unshifted.size(), [&](size_t i) {
                            auto& poly = unshifted[i];
-                           // FIXME: this is a bad way to check if the polynomial is already initialized.
-                           // It could be that it has been initialized, but it's all zeroes.
-                           if (!poly.is_empty()) {
+                           // Some of the polynomials have been initialized above. Skip those.
+                           if (poly.virtual_size() > 0) {
                                // Already initialized above.
                                return;
                            }
@@ -63,7 +61,6 @@ AvmProver::ProverPolynomials compute_polynomials(tracegen::TraceContainer& trace
 
     AVM_TRACK_TIME("proving/set_polys_unshifted", ({
                        auto unshifted = polys.get_unshifted();
-
                        // TODO: We are now visiting per-column. Profile if per-row is better.
                        // This would need changes to the trace container.
                        bb::parallel_for(unshifted.size(), [&](size_t i) {

--- a/barretenberg/cpp/src/barretenberg/vm2/constraining/prover.cpp
+++ b/barretenberg/cpp/src/barretenberg/vm2/constraining/prover.cpp
@@ -134,22 +134,20 @@ HonkProof AvmProver::construct_proof()
     // Add circuit size public input size and public inputs to transcript.
     execute_preamble_round();
 
-    // Compute wire commitments
+    // Compute wire commitments.
     AVM_TRACK_TIME("prove/execute_wire_commitments_round", execute_wire_commitments_round());
 
-    // Compute sorted list accumulator
+    // Compute log derivative inverses.
     AVM_TRACK_TIME("prove/execute_log_derivative_inverse_round", execute_log_derivative_inverse_round());
 
-    // Compute commitments to logderivative inverse polynomials
+    // Compute commitments to logderivative inverse polynomials.
     AVM_TRACK_TIME("prove/execute_log_derivative_inverse_commitments_round",
                    execute_log_derivative_inverse_commitments_round());
 
-    // Fiat-Shamir: alpha
     // Run sumcheck subprotocol.
     AVM_TRACK_TIME("prove/execute_relation_check_rounds", execute_relation_check_rounds());
 
-    // Fiat-Shamir: rho, y, x, z
-    // Execute Shplemini PCS
+    // Execute PCS.
     AVM_TRACK_TIME("prove/execute_pcs_rounds", execute_pcs_rounds());
 
     return export_proof();

--- a/barretenberg/cpp/src/barretenberg/vm2/tooling/debugger.cpp
+++ b/barretenberg/cpp/src/barretenberg/vm2/tooling/debugger.cpp
@@ -139,11 +139,9 @@ void InteractiveDebugger::print_columns(const std::vector<std::string>& regexes)
         std::cout << "Invalid regex: " << e.what() << std::endl;
         return;
     }
-    // We use the full row to have the shifts as well.
-    const auto full_row = tracegen::get_full_row(trace, row);
     for (size_t i = 0; i < COLUMN_NAMES.size(); ++i) {
         if (std::regex_match(COLUMN_NAMES[i], re)) {
-            auto val = full_row.get_column(static_cast<ColumnAndShifts>(i));
+            auto val = trace.get_column_or_shift(static_cast<ColumnAndShifts>(i), row);
             std::cout << COLUMN_NAMES[i] << ": " << field_to_string(val);
             // If the value is small enough, print it as decimal and binary.
             if (val == FF(static_cast<uint64_t>(val))) {
@@ -186,6 +184,7 @@ void InteractiveDebugger::test_relation(const std::string& relation_name, std::o
         }
         found = true;
 
+        // TODO(fcarreiro): use check_relation.
         typename Relation::SumcheckArrayOfValuesOverSubrelations result{};
         Relation::accumulate(result, tracegen::get_full_row(trace, row), {}, 1);
         for (size_t j = 0; j < result.size(); ++j) {

--- a/barretenberg/cpp/src/barretenberg/vm2/tracegen/alu_trace.test.cpp
+++ b/barretenberg/cpp/src/barretenberg/vm2/tracegen/alu_trace.test.cpp
@@ -17,7 +17,6 @@ using testing::ElementsAre;
 using testing::Field;
 
 using R = TestTraceContainer::Row;
-using FF = R::FF;
 
 TEST(AluTraceGenTest, TraceGeneration)
 {

--- a/barretenberg/cpp/src/barretenberg/vm2/tracegen/bitwise_trace.test.cpp
+++ b/barretenberg/cpp/src/barretenberg/vm2/tracegen/bitwise_trace.test.cpp
@@ -17,7 +17,6 @@ using testing::ElementsAre;
 using testing::Field;
 
 using R = TestTraceContainer::Row;
-using FF = R::FF;
 
 TEST(BitwiseTraceGenTest, U1And)
 {

--- a/barretenberg/cpp/src/barretenberg/vm2/tracegen/bytecode_trace.test.cpp
+++ b/barretenberg/cpp/src/barretenberg/vm2/tracegen/bytecode_trace.test.cpp
@@ -22,7 +22,6 @@ namespace {
 using ::testing::Field;
 
 using R = TestTraceContainer::Row;
-using FF = R::FF;
 using C = Column;
 
 using simulation::BytecodeId;

--- a/barretenberg/cpp/src/barretenberg/vm2/tracegen/class_id_derivation_trace.test.cpp
+++ b/barretenberg/cpp/src/barretenberg/vm2/tracegen/class_id_derivation_trace.test.cpp
@@ -16,7 +16,6 @@ using testing::ElementsAre;
 using testing::Field;
 
 using R = TestTraceContainer::Row;
-using FF = R::FF;
 
 TEST(ClassIdDerivationTraceGenTest, TraceGeneration)
 {

--- a/barretenberg/cpp/src/barretenberg/vm2/tracegen/context_stack_trace.test.cpp
+++ b/barretenberg/cpp/src/barretenberg/vm2/tracegen/context_stack_trace.test.cpp
@@ -13,7 +13,6 @@ using testing::ElementsAre;
 using testing::Field;
 
 using R = TestTraceContainer::Row;
-using FF = R::FF;
 
 TEST(ContextStackTraceGenTest, TraceGenerationSnapshot)
 {

--- a/barretenberg/cpp/src/barretenberg/vm2/tracegen/ecc_trace.test.cpp
+++ b/barretenberg/cpp/src/barretenberg/vm2/tracegen/ecc_trace.test.cpp
@@ -13,7 +13,6 @@ using testing::ElementsAre;
 using testing::Field;
 
 using R = TestTraceContainer::Row;
-using FF = R::FF;
 
 TEST(EccTraceGenTest, TraceGenerationAdd)
 {

--- a/barretenberg/cpp/src/barretenberg/vm2/tracegen/execution_trace.test.cpp
+++ b/barretenberg/cpp/src/barretenberg/vm2/tracegen/execution_trace.test.cpp
@@ -23,7 +23,6 @@ using ::testing::Contains;
 using ::testing::Field;
 
 using R = TestTraceContainer::Row;
-using FF = R::FF;
 
 TEST(ExecutionTraceGenTest, RegisterAllocation)
 {

--- a/barretenberg/cpp/src/barretenberg/vm2/tracegen/lib/trace_conversion.hpp
+++ b/barretenberg/cpp/src/barretenberg/vm2/tracegen/lib/trace_conversion.hpp
@@ -12,6 +12,7 @@ bool is_shift(ColumnAndShifts c);
 std::optional<ColumnAndShifts> shift_column(Column c);
 std::optional<Column> unshift_column(ColumnAndShifts c);
 // This is expensive. Only use in debugging and testing.
-AvmFullRow<FF> get_full_row(const class TraceContainer& trace, uint32_t row);
+AvmFullRow get_full_row(const class TraceContainer& trace, uint32_t row);
+AvmFullRowConstRef get_full_row_ref(const class TraceContainer& trace, uint32_t row);
 
 } // namespace bb::avm2::tracegen

--- a/barretenberg/cpp/src/barretenberg/vm2/tracegen/merkle_check_trace.test.cpp
+++ b/barretenberg/cpp/src/barretenberg/vm2/tracegen/merkle_check_trace.test.cpp
@@ -18,7 +18,6 @@ using testing::ElementsAre;
 using testing::Field;
 
 using R = TestTraceContainer::Row;
-using FF = R::FF;
 using Poseidon2 = crypto::Poseidon2<crypto::Poseidon2Bn254ScalarFieldParams>;
 using simulation::MerkleCheckEvent;
 

--- a/barretenberg/cpp/src/barretenberg/vm2/tracegen/range_check_trace.test.cpp
+++ b/barretenberg/cpp/src/barretenberg/vm2/tracegen/range_check_trace.test.cpp
@@ -15,7 +15,6 @@ using testing::ElementsAre;
 using testing::Field;
 
 using R = TestTraceContainer::Row;
-using FF = R::FF;
 
 TEST(RangeCheckTraceGenTest, RangeCheckLte16Bit)
 {

--- a/barretenberg/cpp/src/barretenberg/vm2/tracegen/test_trace_container.cpp
+++ b/barretenberg/cpp/src/barretenberg/vm2/tracegen/test_trace_container.cpp
@@ -13,25 +13,38 @@ TestTraceContainer::TestTraceContainer(const TestTraceContainer& other)
     }
 }
 
-TestTraceContainer TestTraceContainer::from_rows(const RowTraceContainer& rows)
+TestTraceContainer::TestTraceContainer(const std::vector<std::vector<std::pair<Column, FF>>>& values)
+{
+    for (uint32_t row = 0; row < values.size(); ++row) {
+        set(row, values[row]);
+    }
+}
+
+TestTraceContainer TestTraceContainer::from_rows(const std::vector<AvmFullRow>& rows)
 {
     TestTraceContainer container;
     for (uint32_t row = 0; row < rows.size(); ++row) {
         const auto& full_row = rows[row];
         for (size_t i = 0; i < container.num_columns(); ++i) {
             const auto column = static_cast<Column>(i);
-            container.set(column, row, full_row.get_column(static_cast<ColumnAndShifts>(column)));
+            container.set(column, row, full_row.get(static_cast<ColumnAndShifts>(column)));
         }
     }
     return container;
 }
 
-TestTraceContainer::RowTraceContainer TestTraceContainer::as_rows() const
+AvmFullRowConstRef TestTraceContainer::get_row(uint32_t row) const
 {
-    const uint32_t max_rows = get_num_rows();
-    RowTraceContainer full_row_trace(max_rows);
+    return get_full_row_ref(*this, row);
+}
+
+std::vector<AvmFullRowConstRef> TestTraceContainer::as_rows() const
+{
+    uint32_t max_rows = get_num_rows();
+    std::vector<AvmFullRowConstRef> full_row_trace;
+    full_row_trace.reserve(max_rows);
     for (uint32_t i = 0; i < max_rows; ++i) {
-        full_row_trace[i] = get_full_row(*this, i);
+        full_row_trace.push_back(get_row(i));
     }
     return full_row_trace;
 }

--- a/barretenberg/cpp/src/barretenberg/vm2/tracegen/test_trace_container.hpp
+++ b/barretenberg/cpp/src/barretenberg/vm2/tracegen/test_trace_container.hpp
@@ -11,23 +11,19 @@ namespace bb::avm2::tracegen {
 
 class TestTraceContainer : public TraceContainer {
   public:
-    using Row = AvmFullRow<FF>;
-    using RowTraceContainer = std::vector<Row>;
-
-    static TestTraceContainer from_rows(const RowTraceContainer& rows);
+    using Row = AvmFullRowConstRef;
+    static TestTraceContainer from_rows(const std::vector<AvmFullRow>& rows);
 
     TestTraceContainer() = default;
-    TestTraceContainer(const std::vector<std::vector<std::pair<Column, FF>>>& values)
-    {
-        for (uint32_t row = 0; row < values.size(); ++row) {
-            set(row, values[row]);
-        }
-    }
+    TestTraceContainer(const std::vector<std::vector<std::pair<Column, FF>>>& values);
     // Copy constructor. We allow copying for testing purposes.
     TestTraceContainer(const TestTraceContainer&);
 
     // Returns a trace in dense format with properly filled in shifted columns.
-    RowTraceContainer as_rows() const;
+    // The returned rows are lightweight references to the original trace.
+    // Therefore the original trace should outlive the returned rows.
+    AvmFullRowConstRef get_row(uint32_t row) const;
+    std::vector<AvmFullRowConstRef> as_rows() const;
 };
 
 } // namespace bb::avm2::tracegen

--- a/barretenberg/cpp/src/barretenberg/vm2/tracegen/trace_container.cpp
+++ b/barretenberg/cpp/src/barretenberg/vm2/tracegen/trace_container.cpp
@@ -25,6 +25,14 @@ const FF& TraceContainer::get(Column col, uint32_t row) const
     return it == column_data.rows.end() ? zero : it->second;
 }
 
+const FF& TraceContainer::get_column_or_shift(ColumnAndShifts col, uint32_t row) const
+{
+    if (is_shift(col)) {
+        return get(unshift_column(col).value(), row + 1);
+    }
+    return get(static_cast<Column>(col), row);
+}
+
 void TraceContainer::set(Column col, uint32_t row, const FF& value)
 {
     auto& column_data = (*trace)[static_cast<size_t>(col)];

--- a/barretenberg/cpp/src/barretenberg/vm2/tracegen/trace_container.hpp
+++ b/barretenberg/cpp/src/barretenberg/vm2/tracegen/trace_container.hpp
@@ -37,6 +37,8 @@ class TraceContainer {
         }
         return result;
     }
+    // Extended version of get that works with shifted columns. More expensive.
+    const FF& get_column_or_shift(ColumnAndShifts col, uint32_t row) const;
 
     void set(Column col, uint32_t row, const FF& value);
     // Bulk setting for a given row.


### PR DESCRIPTION
This PR does a few things
* Improves the way to check for previously initialized polynomials in `compute_polynomials`.
* Removes `AllConstRefEntities` from the flavor, and also `get_standard_row` from the polys. This is not used in "prod" and was only used for check_circut and other things.
* Creates an equivalent concept of `AvmFullRowConstRef` which is a row of references, similar to what was `AllConstRefEntities`.
* We now use the above directly in check_circuit AND in tests, which avoids creating full rows of fields.
* This allowed some simplifications in `check_relation`.

Some improvements: running all C++ VM2 tests (without goblin):
* Before: 43s
* After: 15s