### PR TITLE
chore(aztec-start): fix broken env vars

### DIFF
--- a/aztec-up/bin/aztec
+++ b/aztec-up/bin/aztec
@@ -44,7 +44,7 @@ set -- "${args[@]}"
 
 function get_env_vars {
   docker run --rm --entrypoint /bin/bash aztecprotocol/aztec:$VERSION -c "cat /usr/src/yarn-project/foundation/src/config/env_var.ts" |
-  awk -F"'" '{for(i=2;i<=NF;i+=2) printf $i " "}'
+    awk -F"'" '{for(i=2;i<=NF;i+=2) printf $i " "}'
 }
 
 case ${1:-} in

--- a/aztec-up/bin/aztec
+++ b/aztec-up/bin/aztec
@@ -43,8 +43,8 @@ done
 set -- "${args[@]}"
 
 function get_env_vars {
-  docker run --rm aztecprotocol/aztec:$VERSION cat /usr/src/yarn-project/foundation/src/config/env_var.ts |
-    awk -F"'" '{for(i=2;i<=NF;i+=2) printf $i " "}'
+  docker run --rm --entrypoint /bin/bash aztecprotocol/aztec:$VERSION -c "cat /usr/src/yarn-project/foundation/src/config/env_var.ts" |
+  awk -F"'" '{for(i=2;i<=NF;i+=2) printf $i " "}'
 }
 
 case ${1:-} in


### PR DESCRIPTION
in https://github.com/AztecProtocol/aztec-packages/pull/13517 i broke the env var check as the entrypoint changed thank you @spypsy for pointing out
