### PR TITLE
fix(bb/cmake): LMDB build is NOT the father

### DIFF
--- a/barretenberg/cpp/cmake/lmdb.cmake
+++ b/barretenberg/cpp/cmake/lmdb.cmake
@@ -16,7 +16,7 @@ ExternalProject_Add(
     BUILD_COMMAND make -C libraries/liblmdb -e XCFLAGS=-fPIC liblmdb.a
     INSTALL_COMMAND ""
     UPDATE_COMMAND "" # No update step
-    BUILD_BYPRODUCTS ${LMDB_LIB} ${LMDB_HEADER}
+    BUILD_BYPRODUCTS ${LMDB_LIB}
 )
 
 add_library(lmdb STATIC IMPORTED GLOBAL)


### PR DESCRIPTION
When it comes to the lmdb.h file from lmdb dependency, the build has nothing to do with it. I got into wrong thinking assuming that @alexghr added this because it was a generated header. This explains why this was seemingly pattern-following yet caused issues. Adding this line only encouraged cmake to clean this up thinking lmdb would build it - when instead it failed, complaining about it missing

(We had not hit the issue in a while, then Kesha said he was hitting it consistently, which let us confirm this as a fix)