### PR TITLE
fix: Handle undefined proverCoordinationNodeUrls

### DIFF
--- a/yarn-project/prover-node/src/prover-coordination/config.ts
+++ b/yarn-project/prover-node/src/prover-coordination/config.ts
@@ -9,6 +9,7 @@ export const proverCoordinationConfigMappings: ConfigMappingsType<ProverCoordina
     env: 'PROVER_COORDINATION_NODE_URLS',
     description: 'The URLs of the tx provider nodes',
     parseEnv: (val: string) => val.split(',').map(url => url.trim().replace(/\/$/, '')),
+    defaultValue: [],
   },
 };
 

--- a/yarn-project/prover-node/src/prover-coordination/factory.ts
+++ b/yarn-project/prover-node/src/prover-coordination/factory.ts
@@ -59,7 +59,7 @@ export async function createProverCoordination(
   }
 
   let nodes: AztecNode[] = [];
-  if (config.proverCoordinationNodeUrls.length > 0) {
+  if (config.proverCoordinationNodeUrls && config.proverCoordinationNodeUrls.length > 0) {
     log.info('Using prover coordination via node urls');
     const versions = getComponentsVersionsFromConfig(config, protocolContractTreeRoot, getVKTreeRoot());
     nodes = config.proverCoordinationNodeUrls.map(url =>


### PR DESCRIPTION
Got hit by the following when deploying:

```
TypeError: Cannot read properties of undefined (reading 'length') at createProverCoordination (file:///usr/src/yarn-project/prover-node/dest/prover-coordination/factory.js:35:43) at createProverNode (file:///usr/src/yarn-project/prover-node/dest/factory.js:50:38) at process.processTicksAndRejections (node:internal/process/task_queues:95:5) at async startProverNode (file:///usr/src/yarn-project/aztec/dest/cli/cmds/start_prover_node.js:81:24) at async aztecStart (file:///usr/src/yarn-project/aztec/dest/cli/aztec_start_action.js:54:27) at async Command.<anonymous> (file:///usr/src/yarn-project/aztec/dest/cli/cli.js:17:16) at async Command.parseAsync (/usr/src/yarn-project/node_modules/commander/lib/command.js:1092:5) at async main (file:///usr/src/yarn-project/aztec/dest/bin/index.js:48:5)
```

