### PR TITLE
chore: skip hinting for tree padding

### DIFF
--- a/yarn-project/simulator/src/public/hinting_db_sources.ts
+++ b/yarn-project/simulator/src/public/hinting_db_sources.ts
@@ -284,8 +284,15 @@ export class HintingMerkleWriteOperations implements MerkleTreeWriteOperations {
 
     // We need to process each leaf individually because we need the sibling path after insertion, to be able to constraint the insertion.
     // TODO(https://github.com/AztecProtocol/aztec-packages/issues/13380): This can be changed if the world state appendLeaves returns the sibling paths.
-    for (const leaf of leaves) {
-      await this.appendLeafInternal(treeId, leaf);
+    if (leaves.length === 1) {
+      await this.appendLeafInternal(treeId, leaves[0]);
+      return;
+    } else {
+      // TODO(dbanks12): NON-HINTING! We skip hinting here for now because:
+      // 1. We only ever append multiple leaves (for now) when padding (all empty leaves).
+      // 2. We don't need hints per-item when padding.
+      // 3. In order to get per-item hints today, you need to append one-at-a-time (mentioned above), which is VERY slow.
+      await this.db.appendLeaves<ID>(treeId, leaves);
     }
   }
 


### PR DESCRIPTION
Before
![image](https://github.com/user-attachments/assets/2933fef3-a1b5-45e4-882a-b6374d1682dc)

After
![image](https://github.com/user-attachments/assets/6e1b2db9-7e9d-49d5-acdf-810f1901c210)
