### PR TITLE
feat(alpha-testnet): https full node

### DIFF
--- a/spartan/aztec-network/templates/full-node.yaml
+++ b/spartan/aztec-network/templates/full-node.yaml
@@ -276,6 +276,7 @@ metadata:
   name: {{ include "aztec-network.fullname" . }}-full-node-cert
 spec:
   domains:
+  # Note: A record must be added in this domain to point at  {{ .Values.fullNode.fixedStaticIpName }}
   - {{ .Values.fullNode.staticIpUrl }}
 ---
 apiVersion: networking.k8s.io/v1

--- a/spartan/aztec-network/templates/full-node.yaml
+++ b/spartan/aztec-network/templates/full-node.yaml
@@ -258,7 +258,7 @@ metadata:
   name: {{ include "aztec-network.fullname" . }}-full-node-cert
 spec:
   domains:
-  - aztec.network
+  - full-node.alpha-testnet.aztec.network
 ---
 apiVersion: networking.k8s.io/v1
 kind: Ingress
@@ -271,7 +271,7 @@ metadata:
     kubernetes.io/ingress.allow-http: "false"
 spec:
   rules:
-  - host: aztec.network
+  - host: full-node.alpha-testnet.aztec.network
     http:
       paths:
       - path: /

--- a/spartan/aztec-network/templates/full-node.yaml
+++ b/spartan/aztec-network/templates/full-node.yaml
@@ -276,7 +276,7 @@ metadata:
   name: {{ include "aztec-network.fullname" . }}-full-node-cert
 spec:
   domains:
-  - full-node.alpha-testnet.aztec.network
+  - {{ .Values.fullNode.staticIpUrl }}
 ---
 apiVersion: networking.k8s.io/v1
 kind: Ingress
@@ -291,7 +291,7 @@ metadata:
     cloud.google.com/healthcheck-path: "/status"
 spec:
   rules:
-  - host: full-node.alpha-testnet.aztec.network
+  - host: {{ .Values.fullNode.staticIpUrl }}
     http:
       paths:
       - path: /

--- a/spartan/aztec-network/templates/full-node.yaml
+++ b/spartan/aztec-network/templates/full-node.yaml
@@ -252,7 +252,7 @@ spec:
       name: admin
 ---
 {{- if hasKey .Values.fullNode "fixedExternalIP" }}
-apiVersion: networking.gke.io/v1beta2
+apiVersion: networking.gke.io/v1
 kind: ManagedCertificate
 metadata:
   name: {{ include "aztec-network.fullname" . }}-full-node-cert
@@ -267,13 +267,15 @@ metadata:
   annotations:
     kubernetes.io/ingress.class: "gce"
     networking.gke.io/managed-certificates: {{ include "aztec-network.fullname" . }}-full-node-cert
+    kubernetes.io/ingress.global-static-ip-name: {{ .Values.fullNode.fixedStaticIpName }}
+    kubernetes.io/ingress.allow-http: "false"
 spec:
   rules:
   - host: aztecprotocol.com
     http:
       paths:
-      - path: /*
-        pathType: ImplementationSpecific
+      - path: /
+        pathType: Prefix
         backend:
           service:
             name: {{ include "aztec-network.fullname" . }}-full-node

--- a/spartan/aztec-network/templates/full-node.yaml
+++ b/spartan/aztec-network/templates/full-node.yaml
@@ -206,13 +206,16 @@ metadata:
   labels:
     {{- include "aztec-network.labels" . | nindent 4 }}
     app: full-node
+  annotations:
+    {{- if .Values.network.public }}
+    {{- if hasKey .Values.fullNode "fixedStaticIpName" }}
+    cloud.google.com/backend-config: '{"default": "{{ include "aztec-network.fullname" . }}-full-node-backend-config"}'
+    {{- end }}
+    {{- end }}
 spec:
   # If this is a public network, we want to expose the fulls node as a LoadBalancer
   {{- if .Values.network.public }}
   type: LoadBalancer
-  {{- if hasKey .Values.fullNode "fixedExternalIP" }}
-  loadBalancerIP: {{ .Values.fullNode.fixedExternalIP }}
-  {{- end}}
   {{- else }}
   type: ClusterIP
   clusterIP: None
@@ -251,7 +254,22 @@ spec:
       targetPort: {{ .Values.fullNode.service.adminPort }}
       name: admin
 ---
-{{- if hasKey .Values.fullNode "fixedExternalIP" }}
+{{- if hasKey .Values.fullNode "fixedStaticIpName" }}
+apiVersion: cloud.google.com/v1
+kind: BackendConfig
+metadata:
+  name: {{ include "aztec-network.fullname" . }}-full-node-backend-config
+  namespace: {{ .Release.Namespace }}
+spec:
+  healthCheck:
+    checkIntervalSec: 15
+    timeoutSec: 5
+    healthyThreshold: 2
+    unhealthyThreshold: 2
+    type: HTTP
+    requestPath: /status
+    port: 8080
+---
 apiVersion: networking.gke.io/v1
 kind: ManagedCertificate
 metadata:
@@ -269,6 +287,8 @@ metadata:
     networking.gke.io/managed-certificates: {{ include "aztec-network.fullname" . }}-full-node-cert
     kubernetes.io/ingress.global-static-ip-name: {{ .Values.fullNode.fixedStaticIpName }}
     kubernetes.io/ingress.allow-http: "false"
+    cloud.google.com/health-check-port: "8080"
+    cloud.google.com/healthcheck-path: "/status"
 spec:
   rules:
   - host: full-node.alpha-testnet.aztec.network

--- a/spartan/aztec-network/templates/full-node.yaml
+++ b/spartan/aztec-network/templates/full-node.yaml
@@ -258,7 +258,7 @@ metadata:
   name: {{ include "aztec-network.fullname" . }}-full-node-cert
 spec:
   domains:
-  - aztecprotocol.com
+  - aztec.network
 ---
 apiVersion: networking.k8s.io/v1
 kind: Ingress
@@ -271,7 +271,7 @@ metadata:
     kubernetes.io/ingress.allow-http: "false"
 spec:
   rules:
-  - host: aztecprotocol.com
+  - host: aztec.network
     http:
       paths:
       - path: /

--- a/spartan/aztec-network/templates/full-node.yaml
+++ b/spartan/aztec-network/templates/full-node.yaml
@@ -207,10 +207,8 @@ metadata:
     {{- include "aztec-network.labels" . | nindent 4 }}
     app: full-node
   annotations:
-    {{- if .Values.network.public }}
     {{- if hasKey .Values.fullNode "fixedStaticIpName" }}
     cloud.google.com/backend-config: '{"default": "{{ include "aztec-network.fullname" . }}-full-node-backend-config"}'
-    {{- end }}
     {{- end }}
 spec:
   # If this is a public network, we want to expose the fulls node as a LoadBalancer

--- a/spartan/aztec-network/values/alpha-testnet.yaml
+++ b/spartan/aztec-network/values/alpha-testnet.yaml
@@ -45,7 +45,6 @@ bootNode:
   externalHost: "http://localhost:8080"
 
 fullNode:
-  fixedExternalIP: "34.111.170.103"
   fixedStaticIpName: "alpha-testnet-full-node-ip"
   enabled: true
   replicas: 1

--- a/spartan/aztec-network/values/alpha-testnet.yaml
+++ b/spartan/aztec-network/values/alpha-testnet.yaml
@@ -45,6 +45,8 @@ bootNode:
   externalHost: "http://localhost:8080"
 
 fullNode:
+  fixedExternalIP: "34.111.170.103"
+  fixedStaticIpName: "alpha-testnet-full-node-ip"
   enabled: true
   replicas: 1
   maxOldSpaceSize: "8192"

--- a/spartan/aztec-network/values/alpha-testnet.yaml
+++ b/spartan/aztec-network/values/alpha-testnet.yaml
@@ -46,6 +46,7 @@ bootNode:
 
 fullNode:
   fixedStaticIpName: "alpha-testnet-full-node-ip"
+  staticIpUrl: full-node.alpha-testnet.aztec.network
   enabled: true
   replicas: 1
   maxOldSpaceSize: "8192"

--- a/spartan/terraform/gke-cluster/alpha-testnet-static-ip.tf
+++ b/spartan/terraform/gke-cluster/alpha-testnet-static-ip.tf
@@ -1,0 +1,7 @@
+resource "google_compute_global_address" "alpha_testnet_full_node_ip" {
+  name = "alpha-testnet-full-node-ip"
+}
+
+output "alpha_testnet_full_node_ip" {
+  value = google_compute_global_address.alpha_testnet_full_node_ip.address
+}

--- a/spartan/terraform/gke-cluster/alpha-testnet-static-ip.tf
+++ b/spartan/terraform/gke-cluster/alpha-testnet-static-ip.tf
@@ -1,5 +1,9 @@
 resource "google_compute_global_address" "alpha_testnet_full_node_ip" {
   name = "alpha-testnet-full-node-ip"
+
+  lifecycle {
+    prevent_destroy = true
+  }
 }
 
 output "alpha_testnet_full_node_ip" {


### PR DESCRIPTION
Adds an optional static fullnode ip
Added a route53 record on aztec.network domain

this is up and running and applied in the alpha-testnet namespace
