### PR TITLE
chore: assert on bad public component key

### DIFF
--- a/barretenberg/cpp/src/barretenberg/stdlib/primitives/public_input_component/public_input_component.hpp
+++ b/barretenberg/cpp/src/barretenberg/stdlib/primitives/public_input_component/public_input_component.hpp
@@ -65,6 +65,8 @@ class PublicInputComponent {
         }
 
         // Use the provided key to extract the limbs of the component from the public inputs then reconstruct it
+        ASSERT(key.start_idx + COMPONENT_SIZE <= public_inputs.size() &&
+               "PublicInputComponent cannot be reconstructed - PublicInputComponentKey start_idx out of bounds");
         std::span<const Fr, COMPONENT_SIZE> limbs{ public_inputs.data() + key.start_idx, COMPONENT_SIZE };
         return ComponentType::reconstruct_from_public(limbs);
     }


### PR DESCRIPTION
Abort when attempting to reconstruct a PublicInputComponent with a key that leads to overreading the public inputs.

Closes https://github.com/AztecProtocol/barretenberg/issues/1372