### PR TITLE
chore(bb): avoid use of brackets in RefArray/Vector

### DIFF
--- a/barretenberg/cpp/CMakeLists.txt
+++ b/barretenberg/cpp/CMakeLists.txt
@@ -101,7 +101,7 @@ set(CMAKE_CXX_STANDARD_REQUIRED TRUE)
 set(CMAKE_CXX_EXTENSIONS ON)
 
 if(CMAKE_CXX_COMPILER_ID MATCHES "Clang")
-    add_compile_options(-fbracket-depth=4096)
+    add_compile_options(-fbracket-depth=512)
     if(CMAKE_CXX_COMPILER_VERSION VERSION_LESS "14")
         message(WARNING "Clang <14 is not supported")
     endif()

--- a/barretenberg/cpp/src/barretenberg/common/ref_array.hpp
+++ b/barretenberg/cpp/src/barretenberg/common/ref_array.hpp
@@ -28,12 +28,10 @@ template <typename T, std::size_t N> class RefArray {
             storage[i] = ptr_array[i];
         }
     }
-    template <typename... Ts> RefArray(T& ref, Ts&... rest)
-    {
-        storage[0] = &ref;
-        int i = 1;
-        ((storage[i++] = &rest), ...);
-    }
+    template <typename... Ts>
+    RefArray(T& first, Ts&... refs)
+        : storage{ &first, &refs... }
+    {}
 
     T& operator[](std::size_t idx) const
     {

--- a/barretenberg/cpp/src/barretenberg/common/ref_vector.hpp
+++ b/barretenberg/cpp/src/barretenberg/common/ref_vector.hpp
@@ -1,11 +1,13 @@
 #pragma once
-#include "barretenberg/common/assert.hpp"
-#include "barretenberg/common/ref_array.hpp"
+
 #include <cstddef>
 #include <initializer_list>
 #include <iterator>
 #include <stdexcept>
 #include <vector>
+
+#include "barretenberg/common/assert.hpp"
+#include "barretenberg/common/ref_array.hpp"
 
 namespace bb {
 /**
@@ -33,11 +35,10 @@ template <typename T> class RefVector {
         }
     }
 
-    template <typename... Ts> RefVector(T& ref, Ts&... rest)
-    {
-        storage.push_back(&ref);
-        (storage.push_back(&rest), ...);
-    }
+    template <typename... Ts>
+    RefVector(T& first, Ts&... refs)
+        : storage{ &first, &refs... }
+    {}
 
     template <std::size_t N>
     RefVector(const RefArray<T, N>& ref_array)


### PR DESCRIPTION
The use of brackets in Ref{Array,Vector} was the main driver of bracket depth.

There are still other uses of brackets to apply stuff to tuples, but their length seems to be much smaller.
