### PR TITLE
feat: Expose bot address in API

### DIFF
--- a/yarn-project/bot/src/interface.ts
+++ b/yarn-project/bot/src/interface.ts
@@ -1,8 +1,15 @@
+import { AztecAddress } from '@aztec/aztec.js';
 import type { ApiSchemaFor } from '@aztec/stdlib/schemas';
 
 import { z } from 'zod';
 
 import { type BotConfig, BotConfigSchema } from './config.js';
+
+export const BotInfoSchema = z.object({
+  botAddress: AztecAddress.schema,
+});
+
+export type BotInfo = z.infer<typeof BotInfoSchema>;
 
 export interface BotRunnerApi {
   start(): Promise<void>;
@@ -10,6 +17,7 @@ export interface BotRunnerApi {
   run(): Promise<void>;
   setup(): Promise<void>;
   getConfig(): Promise<BotConfig>;
+  getInfo(): Promise<BotInfo>;
   update(config: BotConfig): Promise<void>;
 }
 
@@ -18,6 +26,7 @@ export const BotRunnerApiSchema: ApiSchemaFor<BotRunnerApi> = {
   stop: z.function().args().returns(z.void()),
   run: z.function().args().returns(z.void()),
   setup: z.function().args().returns(z.void()),
+  getInfo: z.function().args().returns(BotInfoSchema),
   getConfig: z.function().args().returns(BotConfigSchema),
   update: z.function().args(BotConfigSchema).returns(z.void()),
 };


### PR DESCRIPTION
Adds a `getInfo` method to the bot api to get its address.

Related to #13788 