### PR TITLE
refactor(avm): tx context and PIs

### DIFF
--- a/yarn-project/simulator/src/public/public_tx_simulator/public_tx_context.ts
+++ b/yarn-project/simulator/src/public/public_tx_simulator/public_tx_context.ts
@@ -1,15 +1,16 @@
 import {
+  MAX_ENQUEUED_CALLS_PER_TX,
   MAX_L2_GAS_PER_TX_PUBLIC_PORTION,
   MAX_L2_TO_L1_MSGS_PER_TX,
   MAX_NOTE_HASHES_PER_TX,
   MAX_NULLIFIERS_PER_TX,
+  MAX_PUBLIC_LOGS_PER_TX,
   MAX_TOTAL_PUBLIC_DATA_UPDATE_REQUESTS_PER_TX,
 } from '@aztec/constants';
 import { padArrayEnd } from '@aztec/foundation/collection';
 import { Fr } from '@aztec/foundation/fields';
 import { type Logger, createLogger } from '@aztec/foundation/log';
-import { assertLength } from '@aztec/foundation/serialize';
-import { type AvmCircuitPublicInputs, PublicDataWrite, RevertCode } from '@aztec/stdlib/avm';
+import { AvmAccumulatedData, AvmCircuitPublicInputs, PublicDataWrite, RevertCode } from '@aztec/stdlib/avm';
 import type { AztecAddress } from '@aztec/stdlib/aztec-address';
 import type { SimulationError } from '@aztec/stdlib/errors';
 import { computeTransactionFee } from '@aztec/stdlib/fees';
@@ -22,6 +23,8 @@ import {
   countAccumulatedItems,
   mergeAccumulatedData,
 } from '@aztec/stdlib/kernel';
+import { PublicLog } from '@aztec/stdlib/logs';
+import { ScopedL2ToL1Message } from '@aztec/stdlib/messaging';
 import { MerkleTreeId } from '@aztec/stdlib/trees';
 import {
   type GlobalVariables,
@@ -301,82 +304,113 @@ export class PublicTxContext {
     assert(this.halted, 'Can only get AvmCircuitPublicInputs after tx execution ends');
     const stateManager = this.state.getActiveStateManager();
 
-    // FIXME: We are first creating the PIs with the wrong endTreeSnapshots, then patching them.
-    // This is because we need to know the lengths of the accumulated data arrays to pad them.
-    // We should refactor this to avoid this hack.
-    // We should just get the info we need from the trace, and create the rest of the PIs here.
-    const avmCircuitPublicInputs = this.trace.toAvmCircuitPublicInputs(
-      this.globalVariables,
-      /*startGasUsed=*/ this.gasUsedByPrivate,
-      this.gasSettings,
-      this.feePayer,
-      this.setupCallRequests.map(r => r.request),
-      this.appLogicCallRequests.map(r => r.request),
-      /*teardownCallRequest=*/ this.teardownCallRequests.length
-        ? this.teardownCallRequests[0].request
-        : PublicCallRequest.empty(),
-      /*endTreeSnapshots=*/ TreeSnapshots.empty(), // Will be patched/padded at the end of this fn
-      /*endGasUsed=*/ this.getTotalGasUsed(),
-      /*transactionFee=*/ this.getTransactionFeeUnsafe(),
-      /*reverted=*/ !this.revertCode.isOK(),
-    );
-    avmCircuitPublicInputs.startTreeSnapshots = this.startTreeSnapshots;
+    // We get the side effects from the AVM.
+    // The AVM will already have handled the conditional insertion of most private side-effects.
+    // (depending on the revert code of each stage). Only l2ToL1Msgs and publicLogs still need to be "merged".
+    const {
+      publicDataWrites: avmPublicDataWrites,
+      noteHashes: avmNoteHashes,
+      nullifiers: avmNullifiers,
+      l2ToL1Msgs: avmL2ToL1Msgs,
+      publicLogs: avmPublicLogs,
+    } = this.trace.getSideEffects();
 
+    // We concatenate messages.
+    const msgsFromPrivate = this.revertCode.isOK()
+      ? mergeAccumulatedData(
+          this.nonRevertibleAccumulatedDataFromPrivate.l2ToL1Msgs,
+          this.revertibleAccumulatedDataFromPrivate.l2ToL1Msgs,
+        )
+      : this.nonRevertibleAccumulatedDataFromPrivate.l2ToL1Msgs;
+    const finalL2ToL1Msgs = mergeAccumulatedData(msgsFromPrivate, avmL2ToL1Msgs);
+
+    // Private generates PrivateLogs, and public execution generates PublicLogs.
+    // Since these are two different categories, they should not be merged.
+    const finalPublicLogs = avmPublicLogs;
+
+    // We squash public data writes.
+    // Maps slot to value. Maps in TS are iterable in insertion order, which is exactly what we want for
+    // squashing "to the left", where the first occurrence of a slot uses the value of the last write to it,
+    // and the rest occurrences are omitted.
+    // Note: you can't write public state from private, so we only squash what we got from the AVM.
+    const finalPublicDataWrites = (() => {
+      const squashedPublicDataWrites: Map<bigint, Fr> = new Map();
+      for (const publicDataWrite of avmPublicDataWrites) {
+        squashedPublicDataWrites.set(publicDataWrite.leafSlot.toBigInt(), publicDataWrite.newValue);
+      }
+      return Array.from(squashedPublicDataWrites.entries()).map(
+        ([slot, value]) => new PublicDataWrite(new Fr(slot), value),
+      );
+    })();
+
+    const accumulatedData = new AvmAccumulatedData(
+      /*noteHashes=*/ padArrayEnd(
+        avmNoteHashes.map(n => n.value),
+        Fr.zero(),
+        MAX_NOTE_HASHES_PER_TX,
+      ),
+      /*nullifiers=*/ padArrayEnd(
+        avmNullifiers.map(n => n.value),
+        Fr.zero(),
+        MAX_NULLIFIERS_PER_TX,
+      ),
+      /*l2ToL1Msgs=*/ padArrayEnd(finalL2ToL1Msgs, ScopedL2ToL1Message.empty(), MAX_L2_TO_L1_MSGS_PER_TX),
+      /*publicLogs=*/ padArrayEnd(finalPublicLogs, PublicLog.empty(), MAX_PUBLIC_LOGS_PER_TX),
+      /*publicDataWrites=*/ padArrayEnd(
+        finalPublicDataWrites,
+        PublicDataWrite.empty(),
+        MAX_TOTAL_PUBLIC_DATA_UPDATE_REQUESTS_PER_TX,
+      ),
+    );
+
+    // Now we finally have enough information to pad the trees.
+    // NOTE(fcarreiro): a bit weird that a method that generates the PIs does this,
+    // but we do need the end tree snapshots. We can consider moving things to the caller.
+    const numNoteHashesToPad = MAX_NOTE_HASHES_PER_TX - avmNoteHashes.length;
+    const numNullifiersToPad = MAX_NULLIFIERS_PER_TX - avmNullifiers.length;
+    await stateManager.padTree(MerkleTreeId.NOTE_HASH_TREE, numNoteHashesToPad);
+    await stateManager.padTree(MerkleTreeId.NULLIFIER_TREE, numNullifiersToPad);
+    const endTreeSnapshots = await stateManager.getTreeSnapshots();
+
+    // This converts the private accumulated data to the avm accumulated data format.
+    const convertAccumulatedData = (from: PrivateToPublicAccumulatedData) =>
+      new PrivateToAvmAccumulatedData(from.noteHashes, from.nullifiers, from.l2ToL1Msgs);
     const getArrayLengths = (from: PrivateToPublicAccumulatedData) =>
       new PrivateToAvmAccumulatedDataArrayLengths(
         countAccumulatedItems(from.noteHashes),
         countAccumulatedItems(from.nullifiers),
         countAccumulatedItems(from.l2ToL1Msgs),
       );
-    const convertAccumulatedData = (from: PrivateToPublicAccumulatedData) =>
-      new PrivateToAvmAccumulatedData(from.noteHashes, from.nullifiers, from.l2ToL1Msgs);
-    // Temporary overrides as these entries aren't yet populated in trace
-    avmCircuitPublicInputs.previousNonRevertibleAccumulatedDataArrayLengths = getArrayLengths(
-      this.nonRevertibleAccumulatedDataFromPrivate,
-    );
-    avmCircuitPublicInputs.previousRevertibleAccumulatedDataArrayLengths = getArrayLengths(
-      this.revertibleAccumulatedDataFromPrivate,
-    );
-    avmCircuitPublicInputs.previousNonRevertibleAccumulatedData = convertAccumulatedData(
-      this.nonRevertibleAccumulatedDataFromPrivate,
-    );
-    avmCircuitPublicInputs.previousRevertibleAccumulatedData = convertAccumulatedData(
-      this.revertibleAccumulatedDataFromPrivate,
-    );
 
-    const msgsFromPrivate = this.revertCode.isOK()
-      ? mergeAccumulatedData(
-          avmCircuitPublicInputs.previousNonRevertibleAccumulatedData.l2ToL1Msgs,
-          avmCircuitPublicInputs.previousRevertibleAccumulatedData.l2ToL1Msgs,
-        )
-      : avmCircuitPublicInputs.previousNonRevertibleAccumulatedData.l2ToL1Msgs;
-    avmCircuitPublicInputs.accumulatedData.l2ToL1Msgs = assertLength(
-      mergeAccumulatedData(msgsFromPrivate, avmCircuitPublicInputs.accumulatedData.l2ToL1Msgs),
-      MAX_L2_TO_L1_MSGS_PER_TX,
+    return new AvmCircuitPublicInputs(
+      this.globalVariables,
+      this.startTreeSnapshots,
+      /*startGasUsed=*/ this.gasUsedByPrivate,
+      this.gasSettings,
+      this.feePayer,
+      /*publicSetupCallRequests=*/ padArrayEnd(
+        this.setupCallRequests.map(r => r.request),
+        PublicCallRequest.empty(),
+        MAX_ENQUEUED_CALLS_PER_TX,
+      ),
+      /*publicAppLogicCallRequests=*/ padArrayEnd(
+        this.appLogicCallRequests.map(r => r.request),
+        PublicCallRequest.empty(),
+        MAX_ENQUEUED_CALLS_PER_TX,
+      ),
+      /*publicTeardownCallRequests=*/ this.teardownCallRequests.length > 0
+        ? this.teardownCallRequests[0].request
+        : PublicCallRequest.empty(),
+      getArrayLengths(this.nonRevertibleAccumulatedDataFromPrivate),
+      getArrayLengths(this.revertibleAccumulatedDataFromPrivate),
+      convertAccumulatedData(this.nonRevertibleAccumulatedDataFromPrivate),
+      convertAccumulatedData(this.revertibleAccumulatedDataFromPrivate),
+      endTreeSnapshots,
+      this.getTotalGasUsed(),
+      accumulatedData,
+      /*transactionFee=*/ this.getTransactionFeeUnsafe(),
+      /*isReverted=*/ !this.revertCode.isOK(),
     );
-
-    // Maps slot to value. Maps in TS are iterable in insertion order, which is exactly what we want for
-    // squashing "to the left", where the first occurrence of a slot uses the value of the last write to it,
-    // and the rest occurrences are omitted
-    const squashedPublicDataWrites: Map<bigint, Fr> = new Map();
-    for (const publicDataWrite of avmCircuitPublicInputs.accumulatedData.publicDataWrites) {
-      squashedPublicDataWrites.set(publicDataWrite.leafSlot.toBigInt(), publicDataWrite.value);
-    }
-
-    avmCircuitPublicInputs.accumulatedData.publicDataWrites = padArrayEnd(
-      Array.from(squashedPublicDataWrites.entries()).map(([slot, value]) => new PublicDataWrite(new Fr(slot), value)),
-      PublicDataWrite.empty(),
-      MAX_TOTAL_PUBLIC_DATA_UPDATE_REQUESTS_PER_TX,
-    );
-    const numNoteHashesToPad =
-      MAX_NOTE_HASHES_PER_TX - countAccumulatedItems(avmCircuitPublicInputs.accumulatedData.noteHashes);
-    await stateManager.padTree(MerkleTreeId.NOTE_HASH_TREE, numNoteHashesToPad);
-    const numNullifiersToPad =
-      MAX_NULLIFIERS_PER_TX - countAccumulatedItems(avmCircuitPublicInputs.accumulatedData.nullifiers);
-    await stateManager.padTree(MerkleTreeId.NULLIFIER_TREE, numNullifiersToPad);
-    avmCircuitPublicInputs.endTreeSnapshots = await stateManager.getTreeSnapshots();
-
-    return avmCircuitPublicInputs;
   }
 }
 

--- a/yarn-project/simulator/src/public/public_tx_simulator/public_tx_simulator.ts
+++ b/yarn-project/simulator/src/public/public_tx_simulator/public_tx_simulator.ts
@@ -273,8 +273,6 @@ export class PublicTxSimulator {
 
     const allocatedGas = context.getGasLeftAtPhase(phase);
 
-    stateManager.traceEnqueuedCall(callRequest.request);
-
     const result = await this.simulateEnqueuedCallInternal(
       stateManager,
       callRequest,

--- a/yarn-project/simulator/src/public/side_effect_trace.test.ts
+++ b/yarn-project/simulator/src/public/side_effect_trace.test.ts
@@ -83,14 +83,8 @@ describe('Public Side Effect Trace', () => {
 
     const expectedLog = new PublicLog(address, padArrayEnd(log, Fr.ZERO, PUBLIC_LOG_DATA_SIZE_IN_FIELDS));
 
-    expect(trace.getPublicLogs()).toEqual([expectedLog]);
     expect(trace.getSideEffects().publicLogs).toEqual([expectedLog]);
   });
-
-  // it('Should trace get contract class', async () => {
-  //   trace.traceGetContractClass(/*id=*/ new Fr(44), /*exists=*/ true);
-  //   // FIXME: what here?
-  // });
 
   describe('Maximum accesses', () => {
     it('Should enforce maximum number of user public storage writes', async () => {

--- a/yarn-project/simulator/src/public/side_effect_trace.ts
+++ b/yarn-project/simulator/src/public/side_effect_trace.ts
@@ -1,12 +1,10 @@
 import {
-  MAX_ENQUEUED_CALLS_PER_TX,
   MAX_L2_TO_L1_MSGS_PER_TX,
   MAX_NOTE_HASHES_PER_TX,
   MAX_NULLIFIERS_PER_TX,
   MAX_PUBLIC_CALLS_TO_UNIQUE_CONTRACT_CLASS_IDS,
   MAX_PUBLIC_DATA_UPDATE_REQUESTS_PER_TX,
   MAX_PUBLIC_LOGS_PER_TX,
-  MAX_TOTAL_PUBLIC_DATA_UPDATE_REQUESTS_PER_TX,
   PROTOCOL_PUBLIC_DATA_UPDATE_REQUESTS_PER_TX,
   PUBLIC_LOG_DATA_SIZE_IN_FIELDS,
 } from '@aztec/constants';
@@ -14,25 +12,12 @@ import { padArrayEnd } from '@aztec/foundation/collection';
 import { EthAddress } from '@aztec/foundation/eth-address';
 import { Fr } from '@aztec/foundation/fields';
 import { createLogger } from '@aztec/foundation/log';
-import {
-  AvmAccumulatedData,
-  AvmCircuitPublicInputs,
-  PublicDataUpdateRequest,
-  PublicDataWrite,
-} from '@aztec/stdlib/avm';
+import { PublicDataUpdateRequest } from '@aztec/stdlib/avm';
 import type { AztecAddress } from '@aztec/stdlib/aztec-address';
-import type { Gas, GasSettings } from '@aztec/stdlib/gas';
 import { computePublicDataTreeLeafSlot } from '@aztec/stdlib/hash';
-import {
-  NoteHash,
-  Nullifier,
-  PrivateToAvmAccumulatedData,
-  PrivateToAvmAccumulatedDataArrayLengths,
-  PublicCallRequest,
-} from '@aztec/stdlib/kernel';
+import { NoteHash, Nullifier } from '@aztec/stdlib/kernel';
 import { PublicLog } from '@aztec/stdlib/logs';
 import { L2ToL1Message, ScopedL2ToL1Message } from '@aztec/stdlib/messaging';
-import { type GlobalVariables, TreeSnapshots } from '@aztec/stdlib/tx';
 
 import { strict as assert } from 'assert';
 
@@ -46,7 +31,6 @@ import { UniqueClassIds } from './unique_class_ids.js';
  * This struct is helpful for testing and checking array lengths.
  **/
 export type SideEffects = {
-  enqueuedCalls: PublicCallRequest[];
   publicDataWrites: PublicDataUpdateRequest[];
   noteHashes: NoteHash[];
   nullifiers: Nullifier[];
@@ -78,7 +62,6 @@ export class SideEffectTrace implements PublicSideEffectTraceInterface {
   /** The side effect counter increments with every call to the trace. */
   private sideEffectCounter: number;
 
-  private enqueuedCalls: PublicCallRequest[] = [];
   private publicDataWrites: PublicDataUpdateRequest[] = [];
   private protocolPublicDataWritesLength: number = 0;
   private userPublicDataWritesLength: number = 0;
@@ -127,7 +110,6 @@ export class SideEffectTrace implements PublicSideEffectTraceInterface {
     forkedTrace.alreadyMergedIntoParent = true;
 
     this.sideEffectCounter = forkedTrace.sideEffectCounter;
-    this.enqueuedCalls.push(...forkedTrace.enqueuedCalls);
     this.uniqueClassIds.acceptAndMerge(forkedTrace.uniqueClassIds);
 
     if (!reverted) {
@@ -254,97 +236,13 @@ export class SideEffectTrace implements PublicSideEffectTraceInterface {
     }
   }
 
-  /**
-   * Trace an enqueued call.
-   * Accept some results from a finished call's trace into this one.
-   */
-  public traceEnqueuedCall(publicCallRequest: PublicCallRequest) {
-    // TODO(4805): check if some threshold is reached for max enqueued or nested calls (to unique contracts?)
-    this.enqueuedCalls.push(publicCallRequest);
-  }
-
   public getSideEffects(): SideEffects {
     return {
-      enqueuedCalls: this.enqueuedCalls,
       publicDataWrites: this.publicDataWrites,
       noteHashes: this.noteHashes,
       nullifiers: this.nullifiers,
       l2ToL1Msgs: this.l2ToL1Messages,
       publicLogs: this.publicLogs,
     };
-  }
-
-  public toAvmCircuitPublicInputs(
-    /** Globals. */
-    globalVariables: GlobalVariables,
-    /** Gas used at start of TX. */
-    startGasUsed: Gas,
-    /** How much gas was available for this public execution. */
-    gasLimits: GasSettings,
-    /** Address of the fee payer. */
-    feePayer: AztecAddress,
-    /** Call requests for setup phase. */
-    publicSetupCallRequests: PublicCallRequest[],
-    /** Call requests for app logic phase. */
-    publicAppLogicCallRequests: PublicCallRequest[],
-    /** Call request for teardown phase. */
-    publicTeardownCallRequest: PublicCallRequest,
-    /** End tree snapshots. */
-    endTreeSnapshots: TreeSnapshots,
-    /**
-     * Gas used by the whole transaction, assuming entire teardown limit is used.
-     * This is the gas used when computing transaction fee.
-     */
-    endGasUsed: Gas,
-    /** Transaction fee. */
-    transactionFee: Fr,
-    /** The call's results */
-    reverted: boolean,
-  ): AvmCircuitPublicInputs {
-    return new AvmCircuitPublicInputs(
-      globalVariables,
-      TreeSnapshots.empty(), // will be patched later.
-      startGasUsed,
-      gasLimits,
-      feePayer,
-      padArrayEnd(publicSetupCallRequests, PublicCallRequest.empty(), MAX_ENQUEUED_CALLS_PER_TX),
-      padArrayEnd(publicAppLogicCallRequests, PublicCallRequest.empty(), MAX_ENQUEUED_CALLS_PER_TX),
-      publicTeardownCallRequest,
-      /*previousNonRevertibleAccumulatedDataArrayLengths=*/ PrivateToAvmAccumulatedDataArrayLengths.empty(),
-      /*previousRevertibleAccumulatedDataArrayLengths=*/ PrivateToAvmAccumulatedDataArrayLengths.empty(),
-      /*previousNonRevertibleAccumulatedDataArray=*/ PrivateToAvmAccumulatedData.empty(),
-      /*previousRevertibleAccumulatedDataArray=*/ PrivateToAvmAccumulatedData.empty(),
-      endTreeSnapshots,
-      endGasUsed,
-      /*accumulatedData=*/ this.getAvmAccumulatedData(),
-      transactionFee,
-      reverted,
-    );
-  }
-
-  public getPublicLogs() {
-    return this.publicLogs;
-  }
-
-  private getAvmAccumulatedData() {
-    return new AvmAccumulatedData(
-      padArrayEnd(
-        this.noteHashes.map(n => n.value),
-        Fr.zero(),
-        MAX_NOTE_HASHES_PER_TX,
-      ),
-      padArrayEnd(
-        this.nullifiers.map(n => n.value),
-        Fr.zero(),
-        MAX_NULLIFIERS_PER_TX,
-      ),
-      padArrayEnd(this.l2ToL1Messages, ScopedL2ToL1Message.empty(), MAX_L2_TO_L1_MSGS_PER_TX),
-      padArrayEnd(this.publicLogs, PublicLog.empty(), MAX_PUBLIC_LOGS_PER_TX),
-      padArrayEnd(
-        this.publicDataWrites.map(w => new PublicDataWrite(w.leafSlot, w.newValue)),
-        PublicDataWrite.empty(),
-        MAX_TOTAL_PUBLIC_DATA_UPDATE_REQUESTS_PER_TX,
-      ),
-    );
   }
 }

--- a/yarn-project/simulator/src/public/side_effect_trace_interface.ts
+++ b/yarn-project/simulator/src/public/side_effect_trace_interface.ts
@@ -1,7 +1,5 @@
 import type { Fr } from '@aztec/foundation/fields';
 import type { AztecAddress } from '@aztec/stdlib/aztec-address';
-import type { PublicCallRequest } from '@aztec/stdlib/kernel';
-import type { PublicLog } from '@aztec/stdlib/logs';
 
 export interface PublicSideEffectTraceInterface {
   fork(): PublicSideEffectTraceInterface;
@@ -20,6 +18,4 @@ export interface PublicSideEffectTraceInterface {
   traceNewL2ToL1Message(contractAddress: AztecAddress, recipient: Fr, content: Fr): void;
   tracePublicLog(contractAddress: AztecAddress, log: Fr[]): void;
   traceGetContractClass(contractClassId: Fr, exists: boolean): void;
-  traceEnqueuedCall(publicCallRequest: PublicCallRequest): void;
-  getPublicLogs(): PublicLog[];
 }

--- a/yarn-project/simulator/src/public/state_manager/state_manager.ts
+++ b/yarn-project/simulator/src/public/state_manager/state_manager.ts
@@ -15,7 +15,6 @@ import { AztecAddress } from '@aztec/stdlib/aztec-address';
 import type { ContractClassPublicWithCommitment, ContractInstanceWithAddress } from '@aztec/stdlib/contract';
 import { SerializableContractInstance } from '@aztec/stdlib/contract';
 import { computeNoteHashNonce, computeUniqueNoteHash, siloNoteHash, siloNullifier } from '@aztec/stdlib/hash';
-import type { PublicCallRequest } from '@aztec/stdlib/kernel';
 import { SharedMutableValues, SharedMutableValuesWithHash } from '@aztec/stdlib/shared-mutable';
 import { MerkleTreeId } from '@aztec/stdlib/trees';
 import type { TreeSnapshots } from '@aztec/stdlib/tx';
@@ -458,10 +457,6 @@ export class PublicPersistableStateManager {
     );
 
     return contractClass.packedBytecode;
-  }
-
-  public traceEnqueuedCall(publicCallRequest: PublicCallRequest) {
-    this.trace.traceEnqueuedCall(publicCallRequest);
   }
 
   public async getPublicFunctionDebugName(avmEnvironment: AvmExecutionEnvironment): Promise<string> {


### PR DESCRIPTION
Remove PI generation from side effect trace and unify in TX context.

I'm not sure I like it there, but it's better and more readable.