### PR TITLE
fix(playground): add await to get the proper metadata in `retrieveAccountMetadata`

### DIFF
--- a/playground/src/utils/storage.ts
+++ b/playground/src/utils/storage.ts
@@ -226,7 +226,7 @@ export class WalletDB {
 
   async retrieveAccountMetadata(aliasOrAddress: AztecAddress | string, metadataKey: string) {
     const { address } = await this.retrieveAccount(aliasOrAddress);
-    const result = this.#accounts.getAsync(`${address.toString()}:${metadataKey}`);
+    const result = await this.#accounts.getAsync(`${address.toString()}:${metadataKey}`);
     if (!result) {
       throw new Error(`Could not find metadata with key ${metadataKey} for account ${aliasOrAddress}`);
     }


### PR DESCRIPTION
## Description

This PR fixes a bug in `playground/src/utils/storage.ts` where `retrieveAccountMetadata` did not `await` the asynchronous `getAsync`. Without `await`, the method returned a `Promise` instead of the actual metadata so `!result` always returned true even if it could not find the metadata. 

### Changes

```diff
  async retrieveAccountMetadata(aliasOrAddress: AztecAddress | string, metadataKey: string) {
    const { address } = await this.retrieveAccount(aliasOrAddress);
-    const result = this.#accounts.getAsync(`${address.toString()}:${metadataKey}`);
+    const result = await this.#accounts.getAsync(`${address.toString()}:${metadataKey}`);
    if (!result) {
      throw new Error(`Could not find metadata with key ${metadataKey} for account ${aliasOrAddress}`);
    }
```


