### PR TITLE
chore: provide hash function in `noir-protocol-circuits`

### DIFF
--- a/.github/workflows/ci3.yml
+++ b/.github/workflows/ci3.yml
@@ -126,7 +126,7 @@ jobs:
           max-items-in-chart: 50
 
       - name: Store protocol circuit benchmark result
-        if: matrix.settings.arch == 'amd64' && github.event_name == 'push' && github.ref_name == 'master' && env.SKIP_NPC_BENCH != 'true'
+        if: matrix.settings.arch == 'amd64' && github.event_name == 'push' && github.ref_name == 'master'
         uses: benchmark-action/github-action-benchmark@4de1bed97a47495fc4c5404952da0499e31f5c29
         with:
           name: Protocol Circuit Gate Counts

--- a/ci.sh
+++ b/ci.sh
@@ -250,7 +250,8 @@ case "$cmd" in
     git config --global user.name "AztecBot"
     # Run benchmark logic for github actions.
     bb_hash=$(barretenberg/bootstrap.sh hash)
-    npc_hash=$(noir-projects/noir-protocol-circuits/bootstrap.sh hash)
+    # Protocol circuit benchmarks are published on each commit
+    npc_hash=$(git rev-list -n 1 ${AZTEC_CACHE_COMMIT:-HEAD})
     yp_hash=$(yarn-project/bootstrap.sh hash)
 
     if [ "$bb_hash" == disabled-cache ] || [ "$yp_hash" == disabled-cache ]; then
@@ -260,7 +261,6 @@ case "$cmd" in
     fi
 
     prev_bb_hash=$(AZTEC_CACHE_COMMIT=HEAD^ barretenberg/bootstrap.sh hash)
-    prev_npc_hash=$(AZTEC_CACHE_COMMIT=HEAD^ noir-projects/noir-protocol-circuits/bootstrap.sh hash)
     prev_yp_hash=$(AZTEC_CACHE_COMMIT=HEAD^ yarn-project/bootstrap.sh hash)
 
     # barretenberg benchmarks.
@@ -272,12 +272,7 @@ case "$cmd" in
     fi
 
     # noir-protocol-circuits benchmarks.
-    if [ "$npc_hash" == "$prev_npc_hash" ]; then
-      echo "No changes since last master, skipping noir-protocol-circuits benchmark publishing."
-      echo "SKIP_NPC_BENCH=true" >> $GITHUB_ENV
-    else
-      cache_download noir-protocol-circuits-bench-results-$npc_hash.tar.gz
-    fi
+    cache_download noir-protocol-circuits-bench-results-$npc_hash.tar.gz
 
     # yarn-project benchmarks.
     if [ "$yp_hash" == "$prev_yp_hash" ]; then

--- a/noir-projects/noir-protocol-circuits/bootstrap.sh
+++ b/noir-projects/noir-protocol-circuits/bootstrap.sh
@@ -201,12 +201,16 @@ function test {
   test_cmds | filter_test_cmds | parallelise
 }
 
+function hash {
+  # We don't have a good global content hash for the protocol circuits so we use the git commit.
+  git rev-list -n 1 ${AZTEC_CACHE_COMMIT:-HEAD}
+}
+
 function bench {
   # We assume that the caller has bb installed and all of the protocol circuit artifacts are in `./target`
 
   rm -rf bench-out && mkdir -p bench-out
-  # Here we just cache based off of the git commit
-  local hash=$(git rev-list -n 1 ${AZTEC_CACHE_COMMIT:-HEAD})
+  local hash=$(hash)
   if cache_download noir-protocol-circuits-bench-results-$hash.tar.gz; then
     return
   fi
@@ -257,6 +261,9 @@ function bench {
 }
 
 case "$cmd" in
+  "hash")
+    hash
+    ;;
   "bench")
     bench
     ;;

--- a/noir-projects/noir-protocol-circuits/bootstrap.sh
+++ b/noir-projects/noir-protocol-circuits/bootstrap.sh
@@ -201,16 +201,12 @@ function test {
   test_cmds | filter_test_cmds | parallelise
 }
 
-function hash {
-  # We don't have a good global content hash for the protocol circuits so we use the git commit.
-  git rev-list -n 1 ${AZTEC_CACHE_COMMIT:-HEAD}
-}
-
 function bench {
   # We assume that the caller has bb installed and all of the protocol circuit artifacts are in `./target`
 
   rm -rf bench-out && mkdir -p bench-out
-  local hash=$(hash)
+   # We don't have a good global content hash for the protocol circuits so we use the git commit.
+  local hash=$(git rev-list -n 1 ${AZTEC_CACHE_COMMIT:-HEAD})
   if cache_download noir-protocol-circuits-bench-results-$hash.tar.gz; then
     return
   fi
@@ -261,9 +257,6 @@ function bench {
 }
 
 case "$cmd" in
-  "hash")
-    hash
-    ;;
   "bench")
     bench
     ;;


### PR DESCRIPTION
This fixes `./ci.sh gh-bench`  as it's trying to call the `hash` function within `noir-protocol-circuits` which doesn't exist.