### PR TITLE
fix: installing dependencies for linux

### DIFF
--- a/spartan/scripts/install_deps.sh
+++ b/spartan/scripts/install_deps.sh
@@ -3,16 +3,23 @@ source $(git rev-parse --show-toplevel)/ci3/source
 
 os=$(uname | awk '{print tolower($0)}')
 
+# normalise architecture
+case "$(uname -m)" in
+  x86_64) arch="amd64"  ;;
+  aarch64|arm64) arch="arm64" ;;
+  *)       arch="$(uname -m)" ;;
+esac
+
 # if kubectl is not installed, install it
 if ! command -v kubectl &> /dev/null; then
-  curl -LO "https://dl.k8s.io/release/$(curl -L -s https://dl.k8s.io/release/stable.txt)/bin/${os}/$(arch)/kubectl"
+  curl -LO "https://dl.k8s.io/release/$(curl -L -s https://dl.k8s.io/release/stable.txt)/bin/${os}/${arch}/kubectl"
   chmod +x kubectl
   sudo mv kubectl /usr/local/bin/kubectl
 fi
 
 # Install kind if it is not installed
 if ! command -v kind &> /dev/null; then
-  curl -Lo ./kind https://github.com/kubernetes-sigs/kind/releases/download/v0.23.0/kind-${os}-$(arch)
+  curl -Lo ./kind https://github.com/kubernetes-sigs/kind/releases/download/v0.23.0/kind-${os}-${arch}
   chmod +x ./kind
   sudo mv ./kind /usr/local/bin/kind
 fi
@@ -27,7 +34,7 @@ fi
 
 if ! command -v stern &> /dev/null; then
   # Download Stern
-  curl -Lo stern.tar.gz https://github.com/stern/stern/releases/download/v1.31.0/stern_1.31.0_${os}_$(arch).tar.gz
+  curl -Lo stern.tar.gz https://github.com/stern/stern/releases/download/v1.31.0/stern_1.31.0_${os}_${arch}.tar.gz
 
   # Extract the binary
   tar -xzf stern.tar.gz


### PR DESCRIPTION
### Description:

This PR fixes the `spartan/scripts/install_deps.sh` script so that it installs the dependencies on linux. The script now maps the `uname -m` result `x86_64` to the expected `amd64`, which is the required string for downloading the dependencies.
