### PR TITLE
feat!: vk changes (kernels + apps)

### DIFF
--- a/barretenberg/cpp/src/barretenberg/client_ivc/client_ivc.cpp
+++ b/barretenberg/cpp/src/barretenberg/client_ivc/client_ivc.cpp
@@ -178,11 +178,11 @@ void ClientIVC::accumulate(ClientCircuit& circuit,
                            const std::shared_ptr<MegaVerificationKey>& precomputed_vk,
                            const bool mock_vk)
 {
-    // Construct merge proof for the present circuit and add to merge verification queue
-    MergeProof merge_proof = goblin.prove_merge(circuit);
-
     // Construct the proving key for circuit
     std::shared_ptr<DeciderProvingKey> proving_key = std::make_shared<DeciderProvingKey>(circuit, trace_settings);
+
+    // Construct merge proof for the present circuit
+    MergeProof merge_proof = goblin.prove_merge();
 
     // If the current circuit overflows past the current size of the commitment key, reinitialize accordingly.
     // TODO(https://github.com/AztecProtocol/barretenberg/issues/1319)
@@ -288,8 +288,8 @@ std::pair<std::shared_ptr<ClientIVC::DeciderZKProvingKey>, ClientIVC::MergeProof
 
     AggregationObject::add_default_pairing_points_to_public_inputs(builder);
 
-    // Construct the last merge proof for the present circuit and add to merge verification queue
-    MergeProof merge_proof = goblin.prove_merge(builder);
+    // Construct the last merge proof for the present circuit
+    MergeProof merge_proof = goblin.prove_merge();
 
     auto decider_pk = std::make_shared<DeciderZKProvingKey>(builder, TraceSettings(), bn254_commitment_key);
     honk_vk = std::make_shared<MegaZKVerificationKey>(decider_pk->proving_key);

--- a/barretenberg/cpp/src/barretenberg/dsl/acir_format/ivc_recursion_constraint.cpp
+++ b/barretenberg/cpp/src/barretenberg/dsl/acir_format/ivc_recursion_constraint.cpp
@@ -290,7 +290,7 @@ void populate_dummy_vk_in_constraint(MegaCircuitBuilder& builder,
 
     // Add the fields to the witness and set the key witness indices accordingly
     for (auto [witness_idx, value] : zip_view(key_witness_indices, mock_vk_fields)) {
-        witness_idx = builder.add_variable(value);
+        builder.assert_equal(builder.add_variable(value), witness_idx);
     }
 }
 

--- a/barretenberg/cpp/src/barretenberg/goblin/goblin.cpp
+++ b/barretenberg/cpp/src/barretenberg/goblin/goblin.cpp
@@ -18,19 +18,10 @@ Goblin::Goblin(const std::shared_ptr<CommitmentKey<curve::BN254>>& bn254_commitm
     : commitment_key(bn254_commitment_key)
 {}
 
-Goblin::MergeProof Goblin::prove_merge(MegaBuilder& circuit_builder)
+Goblin::MergeProof Goblin::prove_merge()
 {
     PROFILE_THIS_NAME("Goblin::merge");
-    // TODO(https://github.com/AztecProtocol/barretenberg/issues/993): Some circuits (particularly on the first call
-    // to accumulate) may not have any goblin ecc ops prior to the call to merge(), so the commitment to the new
-    // contribution (C_t_shift) in the merge prover will be the point at infinity. (Note: Some dummy ops are added
-    // in 'add_gates_to_ensure...' but not until proving_key construction which comes later). See issue for ideas
-    // about how to resolve.
-    if (circuit_builder.blocks.ecc_op.size() == 0) {
-        MockCircuits::construct_goblin_ecc_op_circuit(circuit_builder);
-    }
-
-    MergeProver merge_prover{ circuit_builder.op_queue, commitment_key };
+    MergeProver merge_prover{ op_queue, commitment_key };
     merge_proof = merge_prover.construct_proof();
     return merge_proof;
 }

--- a/barretenberg/cpp/src/barretenberg/goblin/goblin.hpp
+++ b/barretenberg/cpp/src/barretenberg/goblin/goblin.hpp
@@ -59,7 +59,7 @@ class Goblin {
      *
      * @param circuit_builder
      */
-    MergeProof prove_merge(MegaBuilder& circuit_builder);
+    MergeProof prove_merge();
 
     /**
      * @brief Construct an ECCVM proof and the translation polynomial evaluations

--- a/barretenberg/cpp/src/barretenberg/stdlib/goblin_verifier/goblin.test.cpp
+++ b/barretenberg/cpp/src/barretenberg/stdlib/goblin_verifier/goblin.test.cpp
@@ -41,7 +41,7 @@ TEST_F(GoblinTests, MultipleCircuits)
     size_t NUM_CIRCUITS = 3;
     for (size_t idx = 0; idx < NUM_CIRCUITS; ++idx) {
         auto circuit = construct_mock_circuit(goblin.op_queue);
-        goblin.prove_merge(circuit); // appends a recursive merge verifier if a merge proof exists
+        goblin.prove_merge();
     }
 
     // Construct a goblin proof which consists of a merge proof and ECCVM/Translator proofs

--- a/barretenberg/cpp/src/barretenberg/stdlib/goblin_verifier/goblin_recursion.test.cpp
+++ b/barretenberg/cpp/src/barretenberg/stdlib/goblin_verifier/goblin_recursion.test.cpp
@@ -56,7 +56,7 @@ TEST_F(GoblinRecursionTests, Vanilla)
         Builder function_circuit{ goblin.op_queue };
         MockCircuits::construct_arithmetic_circuit(function_circuit, /*target_log2_dyadic_size=*/8);
         MockCircuits::construct_goblin_ecc_op_circuit(function_circuit);
-        goblin.prove_merge(function_circuit);
+        goblin.prove_merge();
         AggregationObject::add_default_pairing_points_to_public_inputs(function_circuit);
         auto function_accum = construct_accumulator(function_circuit);
 
@@ -66,7 +66,7 @@ TEST_F(GoblinRecursionTests, Vanilla)
                                                         { function_accum.proof, function_accum.verification_key },
                                                         { kernel_accum.proof, kernel_accum.verification_key });
         AggregationObject::add_default_pairing_points_to_public_inputs(kernel_circuit);
-        goblin.prove_merge(kernel_circuit);
+        goblin.prove_merge();
         kernel_accum = construct_accumulator(kernel_circuit);
     }
 

--- a/barretenberg/cpp/src/barretenberg/stdlib/goblin_verifier/goblin_recursive_verifier.test.cpp
+++ b/barretenberg/cpp/src/barretenberg/stdlib/goblin_verifier/goblin_recursive_verifier.test.cpp
@@ -50,7 +50,7 @@ class GoblinRecursiveVerifierTests : public testing::Test {
         // Construct and accumulate multiple circuits
         for (size_t idx = 0; idx < NUM_CIRCUITS; ++idx) {
             auto circuit = construct_mock_circuit(goblin.op_queue);
-            goblin.prove_merge(circuit); // appends a recurisve merge verifier if a merge proof exists
+            goblin.prove_merge();
         }
 
         // Output is a goblin proof plus ECCVM/Translator verification keys

--- a/barretenberg/cpp/src/barretenberg/vm2/constraining/recursion/goblin_avm_recursive_verifier.hpp
+++ b/barretenberg/cpp/src/barretenberg/vm2/constraining/recursion/goblin_avm_recursive_verifier.hpp
@@ -220,7 +220,7 @@ class AvmGoblinRecursiveVerifier {
         HonkProof mega_proof = mega_prover.construct_proof();
 
         // Construct corresponding Goblin proof \pi_G (includes Merge, ECCVM, and Translator proofs)
-        goblin.prove_merge(mega_builder);
+        goblin.prove_merge();
         GoblinProof goblin_proof = goblin.prove();
 
         // Recursively verify the goblin proof in the Ultra circuit


### PR DESCRIPTION
NOTE: This PR changes the VKs of most/all "app" and kernel circuits!

Specifically:
- remove unnecessary addition of dummy ecc ops in `Goblin::prove_merge`
- correctly maintain copy cycles in dummy VK construction using assert_equal rather than directly updating witness indices