### PR TITLE
fix: aztec test args not being parsed correctly

### DIFF
--- a/aztec-up/bin/aztec
+++ b/aztec-up/bin/aztec
@@ -56,12 +56,16 @@ case ${1:-} in
     shift
     # Should this just be aztec-test? It's like, a new command that doesn't exist on aztec cli.
     # Or just make this a first class command on aztec cli?
+
+    # Properly escape all arguments
+    args_str=$(printf '%q ' "$@")
+
     # TODO: Need to force ipv4 here with 127.0.0.1 for some reason. TXE's not on ipv6?
     exec $(dirname $0)/.aztec-run "" bash -c "
       node --no-warnings /usr/src/yarn-project/aztec/dest/bin/index.js start --txe --port 8081 &
       while ! nc -z 127.0.0.1 8081 &>/dev/null; do sleep 0.2; done
       export NARGO_FOREIGN_CALL_TIMEOUT=300000
-      /usr/src/noir/noir-repo/target/release/nargo test --silence-warnings --oracle-resolver http://127.0.0.1:8081 $@
+      /usr/src/noir/noir-repo/target/release/nargo test --silence-warnings --oracle-resolver http://127.0.0.1:8081 $args_str
     "
     ;;
   start)


### PR DESCRIPTION
From Zorzal:

LOG_LEVEL=debug aztec test mint_to_private_s --show-output
Did not work (specifically passing a test name and --show-output)

This fixes that
