### PR TITLE
chore: utility func attr without full path in the artifact

### DIFF
--- a/noir-projects/aztec-nr/aztec/src/macros/aztec.nr
+++ b/noir-projects/aztec-nr/aztec/src/macros/aztec.nr
@@ -265,20 +265,16 @@ comptime fn generate_note_exports() -> Quoted {
 }
 
 comptime fn generate_sync_notes() -> Quoted {
-    // TODO(https://github.com/noir-lang/noir/issues/7912): Doing the following unfortunately doesn't work. Once
-    // the issue is fixed uncomment the following and remove the workaround from TS (look for the issue link in the
-    // codebase).
-    // let utility: fn(FunctionDefinition) -> () = crate::macros::functions::utility;
-    // quote {
-    //     #[$utility]
-    //     unconstrained fn sync_notes() {
-    //     }
-    // }
+    // We obtain the `utility` function on the next line instead of directly doing
+    // `#[aztec::macros::functions::utility]` in the returned quote because the latter would result in the function
+    // attribute having the full path in the ABI.
+    let utility: fn(FunctionDefinition) -> () = crate::macros::functions::utility;
 
     // All we need to do here is trigger message discovery, but this is already done by the #[utility] macro - we don't
     // need to do anything extra.
     quote {
-        #[aztec::macros::functions::utility]
-        unconstrained fn sync_notes() { }
+        #[$utility]
+        unconstrained fn sync_notes() {
+        }
     }
 }

--- a/noir-projects/aztec-nr/aztec/src/macros/aztec.nr
+++ b/noir-projects/aztec-nr/aztec/src/macros/aztec.nr
@@ -269,7 +269,7 @@ comptime fn generate_sync_notes() -> Quoted {
     // `#[aztec::macros::functions::utility]` in the returned quote because the latter would result in the function
     // attribute having the full path in the ABI. This is undesirable because we use the information in the ABI only
     // to determine whether a function is `private`, `public`, or `utility`.
-    let utility: fn(FunctionDefinition) -> () = crate::macros::functions::utility;
+    let utility = crate::macros::functions::utility;
 
     // All we need to do here is trigger message discovery, but this is already done by the #[utility] macro - we don't
     // need to do anything extra.

--- a/noir-projects/aztec-nr/aztec/src/macros/aztec.nr
+++ b/noir-projects/aztec-nr/aztec/src/macros/aztec.nr
@@ -267,7 +267,8 @@ comptime fn generate_note_exports() -> Quoted {
 comptime fn generate_sync_notes() -> Quoted {
     // We obtain the `utility` function on the next line instead of directly doing
     // `#[aztec::macros::functions::utility]` in the returned quote because the latter would result in the function
-    // attribute having the full path in the ABI.
+    // attribute having the full path in the ABI. This is undesirable because we use the information in the ABI only
+    // to determine whether a function is `private`, `public`, or `utility`.
     let utility: fn(FunctionDefinition) -> () = crate::macros::functions::utility;
 
     // All we need to do here is trigger message discovery, but this is already done by the #[utility] macro - we don't

--- a/yarn-project/stdlib/src/abi/contract_artifact.ts
+++ b/yarn-project/stdlib/src/abi/contract_artifact.ts
@@ -216,30 +216,16 @@ function generateFunctionArtifact(
 }
 
 function getFunctionType(fn: NoirCompiledContractFunction): FunctionType {
-  if (fn.custom_attributes.some(attr => attr.endsWith(AZTEC_PRIVATE_ATTRIBUTE))) {
+  if (fn.custom_attributes.includes(AZTEC_PRIVATE_ATTRIBUTE)) {
     return FunctionType.PRIVATE;
-  } else if (fn.custom_attributes.some(attr => attr.endsWith(AZTEC_PUBLIC_ATTRIBUTE))) {
+  } else if (fn.custom_attributes.includes(AZTEC_PUBLIC_ATTRIBUTE)) {
     return FunctionType.PUBLIC;
-  } else if (fn.custom_attributes.some(attr => attr.endsWith(AZTEC_UTILITY_ATTRIBUTE))) {
+  } else if (fn.custom_attributes.includes(AZTEC_UTILITY_ATTRIBUTE)) {
     return FunctionType.UTILITY;
   } else {
     throw new Error(`Invalid function type for a noir contract function ${fn.name}`);
   }
 }
-
-// TODO(https://github.com/noir-lang/noir/issues/7912): Replace the above function with this one once the linked issue
-// is fixed.
-// function getFunctionType(fn: NoirCompiledContractFunction): FunctionType {
-//   if (fn.custom_attributes.includes(AZTEC_PRIVATE_ATTRIBUTE)) {
-//     return FunctionType.PRIVATE;
-//   } else if (fn.custom_attributes.includes(AZTEC_PUBLIC_ATTRIBUTE)) {
-//     return FunctionType.PUBLIC;
-//   } else if (fn.custom_attributes.includes(AZTEC_UTILITY_ATTRIBUTE)) {
-//     return FunctionType.UTILITY;
-//   } else {
-//     throw new Error(`Invalid function type for a noir contract function ${fn.name}`);
-//   }
-// }
 
 /**
  * Returns true if the first parameter is kernel function inputs.


### PR DESCRIPTION
With https://github.com/noir-lang/noir/issues/7912 issue now being tackled I remove the original workaround from the codebase. Getting rid of the full path from the ABI makes our TS codebase cleaner.

~Currently blocked by https://github.com/noir-lang/noir/issues/8255~