### PR TITLE
chore: rename invalid block num to invalid max block num

### DIFF
--- a/yarn-project/aztec-node/src/aztec-node/server.test.ts
+++ b/yarn-project/aztec-node/src/aztec-node/server.test.ts
@@ -24,7 +24,7 @@ import {
   TX_ERROR_DUPLICATE_NULLIFIER_IN_TX,
   TX_ERROR_INCORRECT_L1_CHAIN_ID,
   TX_ERROR_INCORRECT_ROLLUP_VERSION,
-  TX_ERROR_INVALID_BLOCK_NUMBER,
+  TX_ERROR_INVALID_MAX_BLOCK_NUMBER,
 } from '@aztec/stdlib/tx';
 import { getPackageVersion } from '@aztec/stdlib/update-checker';
 
@@ -224,7 +224,7 @@ describe('aztec node', () => {
       // Tx with max block number < current block number should be invalid
       expect(await node.isValidTx(invalidMaxBlockNumberMetadata)).toEqual({
         result: 'invalid',
-        reason: [TX_ERROR_INVALID_BLOCK_NUMBER],
+        reason: [TX_ERROR_INVALID_MAX_BLOCK_NUMBER],
       });
       // Tx with max block number >= current block number should be valid
       expect(await node.isValidTx(validMaxBlockNumberMetadata)).toEqual({ result: 'valid' });

--- a/yarn-project/end-to-end/src/e2e_max_block_number.test.ts
+++ b/yarn-project/end-to-end/src/e2e_max_block_number.test.ts
@@ -1,6 +1,6 @@
 import { Fr, type PXE, type Wallet } from '@aztec/aztec.js';
 import { TestContract } from '@aztec/noir-test-contracts.js/Test';
-import { TX_ERROR_INVALID_BLOCK_NUMBER } from '@aztec/stdlib/tx';
+import { TX_ERROR_INVALID_MAX_BLOCK_NUMBER } from '@aztec/stdlib/tx';
 
 import { setup } from './fixtures/utils.js';
 
@@ -73,7 +73,7 @@ describe('e2e_max_block_number', () => {
       it('invalidates the transaction', async () => {
         await expect(
           contract.methods.set_tx_max_block_number(maxBlockNumber, enqueuePublicCall).send().wait(),
-        ).rejects.toThrow(TX_ERROR_INVALID_BLOCK_NUMBER);
+        ).rejects.toThrow(TX_ERROR_INVALID_MAX_BLOCK_NUMBER);
       });
     });
 
@@ -89,7 +89,7 @@ describe('e2e_max_block_number', () => {
       it('invalidates the transaction', async () => {
         await expect(
           contract.methods.set_tx_max_block_number(maxBlockNumber, enqueuePublicCall).send().wait(),
-        ).rejects.toThrow(TX_ERROR_INVALID_BLOCK_NUMBER);
+        ).rejects.toThrow(TX_ERROR_INVALID_MAX_BLOCK_NUMBER);
       });
     });
   });

--- a/yarn-project/p2p/src/msg_validators/tx_validator/metadata_validator.test.ts
+++ b/yarn-project/p2p/src/msg_validators/tx_validator/metadata_validator.test.ts
@@ -7,7 +7,7 @@ import {
   TX_ERROR_INCORRECT_PROTOCOL_CONTRACT_TREE_ROOT,
   TX_ERROR_INCORRECT_ROLLUP_VERSION,
   TX_ERROR_INCORRECT_VK_TREE_ROOT,
-  TX_ERROR_INVALID_BLOCK_NUMBER,
+  TX_ERROR_INVALID_MAX_BLOCK_NUMBER,
 } from '@aztec/stdlib/tx';
 
 import { MetadataTxValidator } from './metadata_validator.js';
@@ -112,6 +112,6 @@ describe('MetadataTxValidator', () => {
     const [badTx] = await makeTxs();
     badTx.data.rollupValidationRequests.maxBlockNumber = new MaxBlockNumber(true, blockNumber.sub(new Fr(1)));
 
-    await expectInvalid(badTx, TX_ERROR_INVALID_BLOCK_NUMBER);
+    await expectInvalid(badTx, TX_ERROR_INVALID_MAX_BLOCK_NUMBER);
   });
 });

--- a/yarn-project/p2p/src/msg_validators/tx_validator/metadata_validator.ts
+++ b/yarn-project/p2p/src/msg_validators/tx_validator/metadata_validator.ts
@@ -6,7 +6,7 @@ import {
   TX_ERROR_INCORRECT_PROTOCOL_CONTRACT_TREE_ROOT,
   TX_ERROR_INCORRECT_ROLLUP_VERSION,
   TX_ERROR_INCORRECT_VK_TREE_ROOT,
-  TX_ERROR_INVALID_BLOCK_NUMBER,
+  TX_ERROR_INVALID_MAX_BLOCK_NUMBER,
   Tx,
   type TxValidationResult,
   type TxValidator,
@@ -28,7 +28,7 @@ export class MetadataTxValidator<T extends AnyTx> implements TxValidator<T> {
       errors.push(TX_ERROR_INCORRECT_ROLLUP_VERSION);
     }
     if (!(await this.#isValidForBlockNumber(tx))) {
-      errors.push(TX_ERROR_INVALID_BLOCK_NUMBER);
+      errors.push(TX_ERROR_INVALID_MAX_BLOCK_NUMBER);
     }
     if (!(await this.#hasCorrectVkTreeRoot(tx))) {
       errors.push(TX_ERROR_INCORRECT_VK_TREE_ROOT);

--- a/yarn-project/stdlib/src/tx/validator/error_texts.ts
+++ b/yarn-project/stdlib/src/tx/validator/error_texts.ts
@@ -11,7 +11,7 @@ export const TX_ERROR_DUPLICATE_NULLIFIER_IN_TX = 'Duplicate nullifier in tx';
 export const TX_ERROR_EXISTING_NULLIFIER = 'Existing nullifier';
 
 // Metadata
-export const TX_ERROR_INVALID_BLOCK_NUMBER = 'Invalid block number';
+export const TX_ERROR_INVALID_MAX_BLOCK_NUMBER = 'Invalid max block number';
 export const TX_ERROR_INCORRECT_L1_CHAIN_ID = 'Incorrect L1 chain id';
 export const TX_ERROR_INCORRECT_ROLLUP_VERSION = 'Incorrect rollup version';
 export const TX_ERROR_INCORRECT_VK_TREE_ROOT = 'Incorrect protocol circuits tree root';


### PR DESCRIPTION
We currently error out with 'invalid block number' when we detect a tx's _max_ block number as being invalid, I updated the error message to clarify this. I assume we don't consider this a breaking change.

Closes https://github.com/AztecProtocol/aztec-packages/issues/13622