### PR TITLE
feat(avm): use entity getters in relations

### DIFF
--- a/barretenberg/cpp/src/barretenberg/vm2/constraining/check_circuit.cpp
+++ b/barretenberg/cpp/src/barretenberg/vm2/constraining/check_circuit.cpp
@@ -10,23 +10,9 @@
 #include "barretenberg/common/thread.hpp"
 #include "barretenberg/honk/proof_system/logderivative_library.hpp"
 #include "barretenberg/relations/relation_parameters.hpp"
-#include "barretenberg/vm2/constraining/full_row.hpp"
 #include "barretenberg/vm2/generated/columns.hpp"
 
 namespace bb::avm2::constraining {
-
-namespace {
-
-// Creates a lightweight row from any class that can provide a get(col) method.
-template <typename RowWithGetters> AvmFullRowConstRef to_full_row_const_ref(const RowWithGetters& row)
-{
-    constexpr std::array<ColumnAndShifts, NUM_COLUMNS_WITH_SHIFTS> columns = { AVM2_ALL_ENTITIES_E(ColumnAndShifts::) };
-    return [&]<size_t... Is>(std::index_sequence<Is...>) {
-        return AvmFullRowConstRef{ row.get(columns[Is])... };
-    }(std::make_index_sequence<NUM_COLUMNS_WITH_SHIFTS>{});
-}
-
-} // namespace
 
 void run_check_circuit(AvmFlavor::ProverPolynomials& polys, size_t num_rows)
 {
@@ -51,8 +37,7 @@ void run_check_circuit(AvmFlavor::ProverPolynomials& polys, size_t num_rows)
             typename Relation::SumcheckArrayOfValuesOverSubrelations result{};
 
             for (size_t r = 0; r < num_rows; ++r) {
-                auto lightweight_row = to_full_row_const_ref(polys.get_row(r));
-                Relation::accumulate(result, lightweight_row, {}, 1);
+                Relation::accumulate(result, polys.get_row(r), {}, 1);
                 for (size_t j = 0; j < result.size(); ++j) {
                     if (!result[j].is_zero()) {
                         throw std::runtime_error(format("Relation ",

--- a/barretenberg/cpp/src/barretenberg/vm2/constraining/full_row.cpp
+++ b/barretenberg/cpp/src/barretenberg/vm2/constraining/full_row.cpp
@@ -1,4 +1,6 @@
 #include "barretenberg/vm2/constraining/full_row.hpp"
+#include "barretenberg/vm2/generated/columns.hpp"
+#include "barretenberg/vm2/tracegen/trace_container.hpp"
 
 namespace bb::avm2 {
 
@@ -11,9 +13,9 @@ const FF& AvmFullRow::get(ColumnAndShifts col) const
     return get_entity_by_column(*this, col);
 }
 
-AvmFullRowConstRef AvmFullRowConstRef::from_full_row(const AvmFullRow& full_row)
+const FF& AvmFullRowProxy::get(ColumnAndShifts col) const
 {
-    return { AVM2_ALL_ENTITIES_E(full_row.) };
+    return trace.get_column_or_shift(col, row_index);
 }
 
 } // namespace bb::avm2

--- a/barretenberg/cpp/src/barretenberg/vm2/constraining/full_row.hpp
+++ b/barretenberg/cpp/src/barretenberg/vm2/constraining/full_row.hpp
@@ -1,10 +1,16 @@
 #pragma once
 
+#include <cstdint>
+
 #include "barretenberg/vm2/common/field.hpp"
 #include "barretenberg/vm2/constraining/entities.hpp"
 #include "barretenberg/vm2/generated/columns.hpp"
 
 namespace bb::avm2 {
+namespace tracegen {
+// Forward declaration.
+class TraceContainer;
+} // namespace tracegen
 
 // A bulky full row, mostly for testing purposes.
 struct AvmFullRow {
@@ -16,12 +22,18 @@ struct AvmFullRow {
 };
 
 // A full row made up of references to fields.
-// It can be constructed, e.g., from a full row or a trace.
+// Currently only used in tracegen tests via trace.as_rows().
+// Getters are not supported (however, they could be added).
 struct AvmFullRowConstRef {
     using DataType = const FF;
     const FF& AVM2_ALL_ENTITIES;
+};
 
-    static AvmFullRowConstRef from_full_row(const AvmFullRow& full_row);
+// A cheap proxy for a full row, which holds just a reference to a trace.
+struct AvmFullRowProxy {
+    const FF& get(ColumnAndShifts col) const;
+    uint32_t row_index;
+    const tracegen::TraceContainer& trace;
 };
 
 } // namespace bb::avm2

--- a/barretenberg/cpp/src/barretenberg/vm2/constraining/relations/merkle_check.test.cpp
+++ b/barretenberg/cpp/src/barretenberg/vm2/constraining/relations/merkle_check.test.cpp
@@ -516,9 +516,9 @@ TEST(MerkleCheckConstrainingTest, ReadWithTracegen)
     check_relation<merkle_check>(trace);
 
     // Negative test - now corrupt the trace and verify it fails
-    auto rows = trace.as_rows();
+    uint32_t last_row = static_cast<uint32_t>(trace.get_num_rows() - 1);
     // Corrupt the last row
-    trace.set(C::merkle_check_path_len, static_cast<uint32_t>(rows.size() - 1), 66);
+    trace.set(C::merkle_check_path_len, last_row, 66);
 
     EXPECT_THROW_WITH_MESSAGE(check_relation<merkle_check>(trace), "Relation merkle_check");
 }

--- a/barretenberg/cpp/src/barretenberg/vm2/generated/relations/address_derivation.hpp
+++ b/barretenberg/cpp/src/barretenberg/vm2/generated/relations/address_derivation.hpp
@@ -5,6 +5,7 @@
 
 #include "barretenberg/relations/relation_parameters.hpp"
 #include "barretenberg/relations/relation_types.hpp"
+#include "barretenberg/vm2/generated/columns.hpp"
 
 namespace bb::avm2 {
 
@@ -16,16 +17,18 @@ template <typename FF_> class address_derivationImpl {
 
     template <typename AllEntities> inline static bool skip(const AllEntities& in)
     {
-        const auto& new_term = in;
-        return (new_term.address_derivation_sel).is_zero();
+        using C = ColumnAndShifts;
+        return (in.get(C::address_derivation_sel)).is_zero();
     }
 
     template <typename ContainerOverSubrelations, typename AllEntities>
     void static accumulate(ContainerOverSubrelations& evals,
-                           const AllEntities& new_term,
+                           const AllEntities& in,
                            [[maybe_unused]] const RelationParameters<FF>&,
                            [[maybe_unused]] const FF& scaling_factor)
     {
+        using C = ColumnAndShifts;
+
         const auto constants_GRUMPKIN_ONE_X = FF(1);
         const auto constants_GRUMPKIN_ONE_Y =
             FF(uint256_t{ 9457493854555940652UL, 3253583849847263892UL, 14921373847124204899UL, 2UL });
@@ -35,41 +38,44 @@ template <typename FF_> class address_derivationImpl {
 
         {
             using Accumulator = typename std::tuple_element_t<0, ContainerOverSubrelations>;
-            auto tmp = new_term.address_derivation_sel * (FF(1) - new_term.address_derivation_sel);
+            auto tmp = in.get(C::address_derivation_sel) * (FF(1) - in.get(C::address_derivation_sel));
             tmp *= scaling_factor;
             std::get<0>(evals) += typename Accumulator::View(tmp);
         }
         {
             using Accumulator = typename std::tuple_element_t<1, ContainerOverSubrelations>;
-            auto tmp = new_term.address_derivation_sel * (new_term.address_derivation_partial_address_domain_separator -
-                                                          constants_GENERATOR_INDEX__PARTIAL_ADDRESS);
+            auto tmp =
+                in.get(C::address_derivation_sel) * (in.get(C::address_derivation_partial_address_domain_separator) -
+                                                     constants_GENERATOR_INDEX__PARTIAL_ADDRESS);
             tmp *= scaling_factor;
             std::get<1>(evals) += typename Accumulator::View(tmp);
         }
         {
             using Accumulator = typename std::tuple_element_t<2, ContainerOverSubrelations>;
             auto tmp =
-                new_term.address_derivation_sel * (new_term.address_derivation_public_keys_hash_domain_separator -
-                                                   constants_GENERATOR_INDEX__PUBLIC_KEYS_HASH);
+                in.get(C::address_derivation_sel) * (in.get(C::address_derivation_public_keys_hash_domain_separator) -
+                                                     constants_GENERATOR_INDEX__PUBLIC_KEYS_HASH);
             tmp *= scaling_factor;
             std::get<2>(evals) += typename Accumulator::View(tmp);
         }
         {
             using Accumulator = typename std::tuple_element_t<3, ContainerOverSubrelations>;
-            auto tmp = new_term.address_derivation_sel * (new_term.address_derivation_preaddress_domain_separator -
-                                                          constants_GENERATOR_INDEX__CONTRACT_ADDRESS_V1);
+            auto tmp = in.get(C::address_derivation_sel) * (in.get(C::address_derivation_preaddress_domain_separator) -
+                                                            constants_GENERATOR_INDEX__CONTRACT_ADDRESS_V1);
             tmp *= scaling_factor;
             std::get<3>(evals) += typename Accumulator::View(tmp);
         }
         {
             using Accumulator = typename std::tuple_element_t<4, ContainerOverSubrelations>;
-            auto tmp = new_term.address_derivation_sel * (new_term.address_derivation_g1_x - constants_GRUMPKIN_ONE_X);
+            auto tmp =
+                in.get(C::address_derivation_sel) * (in.get(C::address_derivation_g1_x) - constants_GRUMPKIN_ONE_X);
             tmp *= scaling_factor;
             std::get<4>(evals) += typename Accumulator::View(tmp);
         }
         {
             using Accumulator = typename std::tuple_element_t<5, ContainerOverSubrelations>;
-            auto tmp = new_term.address_derivation_sel * (new_term.address_derivation_g1_y - constants_GRUMPKIN_ONE_Y);
+            auto tmp =
+                in.get(C::address_derivation_sel) * (in.get(C::address_derivation_g1_y) - constants_GRUMPKIN_ONE_Y);
             tmp *= scaling_factor;
             std::get<5>(evals) += typename Accumulator::View(tmp);
         }

--- a/barretenberg/cpp/src/barretenberg/vm2/generated/relations/alu.hpp
+++ b/barretenberg/cpp/src/barretenberg/vm2/generated/relations/alu.hpp
@@ -5,6 +5,7 @@
 
 #include "barretenberg/relations/relation_parameters.hpp"
 #include "barretenberg/relations/relation_types.hpp"
+#include "barretenberg/vm2/generated/columns.hpp"
 
 namespace bb::avm2 {
 
@@ -16,20 +17,21 @@ template <typename FF_> class aluImpl {
 
     template <typename ContainerOverSubrelations, typename AllEntities>
     void static accumulate(ContainerOverSubrelations& evals,
-                           const AllEntities& new_term,
+                           const AllEntities& in,
                            [[maybe_unused]] const RelationParameters<FF>&,
                            [[maybe_unused]] const FF& scaling_factor)
     {
+        using C = ColumnAndShifts;
 
         { // SEL_ADD_BINARY
             using Accumulator = typename std::tuple_element_t<0, ContainerOverSubrelations>;
-            auto tmp = new_term.alu_sel_op_add * (FF(1) - new_term.alu_sel_op_add);
+            auto tmp = in.get(C::alu_sel_op_add) * (FF(1) - in.get(C::alu_sel_op_add));
             tmp *= scaling_factor;
             std::get<0>(evals) += typename Accumulator::View(tmp);
         }
         { // ALU_ADD
             using Accumulator = typename std::tuple_element_t<1, ContainerOverSubrelations>;
-            auto tmp = ((new_term.alu_ia + new_term.alu_ib) - new_term.alu_ic);
+            auto tmp = ((in.get(C::alu_ia) + in.get(C::alu_ib)) - in.get(C::alu_ic));
             tmp *= scaling_factor;
             std::get<1>(evals) += typename Accumulator::View(tmp);
         }

--- a/barretenberg/cpp/src/barretenberg/vm2/generated/relations/bc_decomposition.hpp
+++ b/barretenberg/cpp/src/barretenberg/vm2/generated/relations/bc_decomposition.hpp
@@ -5,6 +5,7 @@
 
 #include "barretenberg/relations/relation_parameters.hpp"
 #include "barretenberg/relations/relation_types.hpp"
+#include "barretenberg/vm2/generated/columns.hpp"
 
 namespace bb::avm2 {
 
@@ -19,453 +20,456 @@ template <typename FF_> class bc_decompositionImpl {
 
     template <typename AllEntities> inline static bool skip(const AllEntities& in)
     {
-        const auto& new_term = in;
-        return (new_term.bc_decomposition_sel).is_zero();
+        using C = ColumnAndShifts;
+        return (in.get(C::bc_decomposition_sel)).is_zero();
     }
 
     template <typename ContainerOverSubrelations, typename AllEntities>
     void static accumulate(ContainerOverSubrelations& evals,
-                           const AllEntities& new_term,
+                           const AllEntities& in,
                            [[maybe_unused]] const RelationParameters<FF>&,
                            [[maybe_unused]] const FF& scaling_factor)
     {
+        using C = ColumnAndShifts;
+
         const auto bc_decomposition_WINDOW_SIZE = FF(37);
         const auto bc_decomposition_FIRST_OR_LAST_CONTRACT =
-            new_term.precomputed_first_row + new_term.bc_decomposition_last_of_contract;
+            in.get(C::precomputed_first_row) + in.get(C::bc_decomposition_last_of_contract);
 
         {
             using Accumulator = typename std::tuple_element_t<0, ContainerOverSubrelations>;
-            auto tmp = new_term.bc_decomposition_sel * (FF(1) - new_term.bc_decomposition_sel);
+            auto tmp = in.get(C::bc_decomposition_sel) * (FF(1) - in.get(C::bc_decomposition_sel));
             tmp *= scaling_factor;
             std::get<0>(evals) += typename Accumulator::View(tmp);
         }
         {
             using Accumulator = typename std::tuple_element_t<1, ContainerOverSubrelations>;
             auto tmp =
-                new_term.bc_decomposition_last_of_contract * (FF(1) - new_term.bc_decomposition_last_of_contract);
+                in.get(C::bc_decomposition_last_of_contract) * (FF(1) - in.get(C::bc_decomposition_last_of_contract));
             tmp *= scaling_factor;
             std::get<1>(evals) += typename Accumulator::View(tmp);
         }
         { // BC_DEC_SEL_BYTES_REM_NON_ZERO
             using Accumulator = typename std::tuple_element_t<2, ContainerOverSubrelations>;
             auto tmp =
-                (new_term.bc_decomposition_bytes_remaining *
-                     ((FF(1) - new_term.bc_decomposition_sel) * (FF(1) - new_term.bc_decomposition_bytes_rem_inv) +
-                      new_term.bc_decomposition_bytes_rem_inv) -
-                 new_term.bc_decomposition_sel);
+                (in.get(C::bc_decomposition_bytes_remaining) *
+                     ((FF(1) - in.get(C::bc_decomposition_sel)) * (FF(1) - in.get(C::bc_decomposition_bytes_rem_inv)) +
+                      in.get(C::bc_decomposition_bytes_rem_inv)) -
+                 in.get(C::bc_decomposition_sel));
             tmp *= scaling_factor;
             std::get<2>(evals) += typename Accumulator::View(tmp);
         }
         { // TRACE_CONTINUITY
             using Accumulator = typename std::tuple_element_t<3, ContainerOverSubrelations>;
-            auto tmp = (FF(1) - new_term.precomputed_first_row) * (FF(1) - new_term.bc_decomposition_sel) *
-                       new_term.bc_decomposition_sel_shift;
+            auto tmp = (FF(1) - in.get(C::precomputed_first_row)) * (FF(1) - in.get(C::bc_decomposition_sel)) *
+                       in.get(C::bc_decomposition_sel_shift);
             tmp *= scaling_factor;
             std::get<3>(evals) += typename Accumulator::View(tmp);
         }
         { // BC_DEC_LAST_CONTRACT_BYTES_REM_ONE
             using Accumulator = typename std::tuple_element_t<4, ContainerOverSubrelations>;
-            auto tmp =
-                new_term.bc_decomposition_sel * (((new_term.bc_decomposition_bytes_remaining - FF(1)) *
-                                                      (new_term.bc_decomposition_last_of_contract *
-                                                           (FF(1) - new_term.bc_decomposition_bytes_rem_min_one_inv) +
-                                                       new_term.bc_decomposition_bytes_rem_min_one_inv) +
-                                                  new_term.bc_decomposition_last_of_contract) -
-                                                 FF(1));
+            auto tmp = in.get(C::bc_decomposition_sel) *
+                       (((in.get(C::bc_decomposition_bytes_remaining) - FF(1)) *
+                             (in.get(C::bc_decomposition_last_of_contract) *
+                                  (FF(1) - in.get(C::bc_decomposition_bytes_rem_min_one_inv)) +
+                              in.get(C::bc_decomposition_bytes_rem_min_one_inv)) +
+                         in.get(C::bc_decomposition_last_of_contract)) -
+                        FF(1));
             tmp *= scaling_factor;
             std::get<4>(evals) += typename Accumulator::View(tmp);
         }
         { // BC_DEC_PC_ZERO_INITIALIZATION
             using Accumulator = typename std::tuple_element_t<5, ContainerOverSubrelations>;
-            auto tmp = bc_decomposition_FIRST_OR_LAST_CONTRACT * new_term.bc_decomposition_pc_shift;
+            auto tmp = bc_decomposition_FIRST_OR_LAST_CONTRACT * in.get(C::bc_decomposition_pc_shift);
             tmp *= scaling_factor;
             std::get<5>(evals) += typename Accumulator::View(tmp);
         }
         { // BC_DEC_PC_INCREMENT
             using Accumulator = typename std::tuple_element_t<6, ContainerOverSubrelations>;
-            auto tmp = new_term.bc_decomposition_sel * (FF(1) - new_term.bc_decomposition_last_of_contract) *
-                       ((new_term.bc_decomposition_pc_shift - new_term.bc_decomposition_pc) - FF(1));
+            auto tmp = in.get(C::bc_decomposition_sel) * (FF(1) - in.get(C::bc_decomposition_last_of_contract)) *
+                       ((in.get(C::bc_decomposition_pc_shift) - in.get(C::bc_decomposition_pc)) - FF(1));
             tmp *= scaling_factor;
             std::get<6>(evals) += typename Accumulator::View(tmp);
         }
         { // BC_DEC_BYTES_REMAINING_DECREMENT
             using Accumulator = typename std::tuple_element_t<7, ContainerOverSubrelations>;
             auto tmp =
-                new_term.bc_decomposition_sel * (FF(1) - new_term.bc_decomposition_last_of_contract) *
-                ((new_term.bc_decomposition_bytes_remaining_shift - new_term.bc_decomposition_bytes_remaining) + FF(1));
+                in.get(C::bc_decomposition_sel) * (FF(1) - in.get(C::bc_decomposition_last_of_contract)) *
+                ((in.get(C::bc_decomposition_bytes_remaining_shift) - in.get(C::bc_decomposition_bytes_remaining)) +
+                 FF(1));
             tmp *= scaling_factor;
             std::get<7>(evals) += typename Accumulator::View(tmp);
         }
         { // BC_DEC_ID_CONSTANT
             using Accumulator = typename std::tuple_element_t<8, ContainerOverSubrelations>;
             auto tmp = (FF(1) - bc_decomposition_FIRST_OR_LAST_CONTRACT) *
-                       (new_term.bc_decomposition_id_shift - new_term.bc_decomposition_id);
+                       (in.get(C::bc_decomposition_id_shift) - in.get(C::bc_decomposition_id));
             tmp *= scaling_factor;
             std::get<8>(evals) += typename Accumulator::View(tmp);
         }
         {
             using Accumulator = typename std::tuple_element_t<9, ContainerOverSubrelations>;
-            auto tmp = new_term.bc_decomposition_sel_overflow_correction_needed *
-                       (FF(1) - new_term.bc_decomposition_sel_overflow_correction_needed);
+            auto tmp = in.get(C::bc_decomposition_sel_overflow_correction_needed) *
+                       (FF(1) - in.get(C::bc_decomposition_sel_overflow_correction_needed));
             tmp *= scaling_factor;
             std::get<9>(evals) += typename Accumulator::View(tmp);
         }
         { // BC_DEC_ABS_DIFF
             using Accumulator = typename std::tuple_element_t<10, ContainerOverSubrelations>;
-            auto tmp = new_term.bc_decomposition_sel *
-                       (((FF(2) * new_term.bc_decomposition_sel_overflow_correction_needed *
-                              (bc_decomposition_WINDOW_SIZE - new_term.bc_decomposition_bytes_remaining) -
+            auto tmp = in.get(C::bc_decomposition_sel) *
+                       (((FF(2) * in.get(C::bc_decomposition_sel_overflow_correction_needed) *
+                              (bc_decomposition_WINDOW_SIZE - in.get(C::bc_decomposition_bytes_remaining)) -
                           bc_decomposition_WINDOW_SIZE) +
-                         new_term.bc_decomposition_bytes_remaining) -
-                        new_term.bc_decomposition_abs_diff);
+                         in.get(C::bc_decomposition_bytes_remaining)) -
+                        in.get(C::bc_decomposition_abs_diff));
             tmp *= scaling_factor;
             std::get<10>(evals) += typename Accumulator::View(tmp);
         }
         { // BC_DEC_OVERFLOW_CORRECTION_VALUE
             using Accumulator = typename std::tuple_element_t<11, ContainerOverSubrelations>;
-            auto tmp = new_term.bc_decomposition_sel *
-                       ((FF(1) - new_term.bc_decomposition_sel_overflow_correction_needed) *
-                            (new_term.bc_decomposition_bytes_to_read - bc_decomposition_WINDOW_SIZE) +
-                        new_term.bc_decomposition_sel_overflow_correction_needed *
-                            (new_term.bc_decomposition_bytes_to_read - new_term.bc_decomposition_bytes_remaining));
+            auto tmp = in.get(C::bc_decomposition_sel) *
+                       ((FF(1) - in.get(C::bc_decomposition_sel_overflow_correction_needed)) *
+                            (in.get(C::bc_decomposition_bytes_to_read) - bc_decomposition_WINDOW_SIZE) +
+                        in.get(C::bc_decomposition_sel_overflow_correction_needed) *
+                            (in.get(C::bc_decomposition_bytes_to_read) - in.get(C::bc_decomposition_bytes_remaining)));
             tmp *= scaling_factor;
             std::get<11>(evals) += typename Accumulator::View(tmp);
         }
         {
             using Accumulator = typename std::tuple_element_t<12, ContainerOverSubrelations>;
-            auto tmp = (new_term.bc_decomposition_bytes_pc_plus_1 -
-                        (FF(1) - bc_decomposition_FIRST_OR_LAST_CONTRACT) * new_term.bc_decomposition_bytes_shift);
+            auto tmp = (in.get(C::bc_decomposition_bytes_pc_plus_1) -
+                        (FF(1) - bc_decomposition_FIRST_OR_LAST_CONTRACT) * in.get(C::bc_decomposition_bytes_shift));
             tmp *= scaling_factor;
             std::get<12>(evals) += typename Accumulator::View(tmp);
         }
         {
             using Accumulator = typename std::tuple_element_t<13, ContainerOverSubrelations>;
             auto tmp =
-                (new_term.bc_decomposition_bytes_pc_plus_2 -
-                 (FF(1) - bc_decomposition_FIRST_OR_LAST_CONTRACT) * new_term.bc_decomposition_bytes_pc_plus_1_shift);
+                (in.get(C::bc_decomposition_bytes_pc_plus_2) -
+                 (FF(1) - bc_decomposition_FIRST_OR_LAST_CONTRACT) * in.get(C::bc_decomposition_bytes_pc_plus_1_shift));
             tmp *= scaling_factor;
             std::get<13>(evals) += typename Accumulator::View(tmp);
         }
         {
             using Accumulator = typename std::tuple_element_t<14, ContainerOverSubrelations>;
             auto tmp =
-                (new_term.bc_decomposition_bytes_pc_plus_3 -
-                 (FF(1) - bc_decomposition_FIRST_OR_LAST_CONTRACT) * new_term.bc_decomposition_bytes_pc_plus_2_shift);
+                (in.get(C::bc_decomposition_bytes_pc_plus_3) -
+                 (FF(1) - bc_decomposition_FIRST_OR_LAST_CONTRACT) * in.get(C::bc_decomposition_bytes_pc_plus_2_shift));
             tmp *= scaling_factor;
             std::get<14>(evals) += typename Accumulator::View(tmp);
         }
         {
             using Accumulator = typename std::tuple_element_t<15, ContainerOverSubrelations>;
             auto tmp =
-                (new_term.bc_decomposition_bytes_pc_plus_4 -
-                 (FF(1) - bc_decomposition_FIRST_OR_LAST_CONTRACT) * new_term.bc_decomposition_bytes_pc_plus_3_shift);
+                (in.get(C::bc_decomposition_bytes_pc_plus_4) -
+                 (FF(1) - bc_decomposition_FIRST_OR_LAST_CONTRACT) * in.get(C::bc_decomposition_bytes_pc_plus_3_shift));
             tmp *= scaling_factor;
             std::get<15>(evals) += typename Accumulator::View(tmp);
         }
         {
             using Accumulator = typename std::tuple_element_t<16, ContainerOverSubrelations>;
             auto tmp =
-                (new_term.bc_decomposition_bytes_pc_plus_5 -
-                 (FF(1) - bc_decomposition_FIRST_OR_LAST_CONTRACT) * new_term.bc_decomposition_bytes_pc_plus_4_shift);
+                (in.get(C::bc_decomposition_bytes_pc_plus_5) -
+                 (FF(1) - bc_decomposition_FIRST_OR_LAST_CONTRACT) * in.get(C::bc_decomposition_bytes_pc_plus_4_shift));
             tmp *= scaling_factor;
             std::get<16>(evals) += typename Accumulator::View(tmp);
         }
         {
             using Accumulator = typename std::tuple_element_t<17, ContainerOverSubrelations>;
             auto tmp =
-                (new_term.bc_decomposition_bytes_pc_plus_6 -
-                 (FF(1) - bc_decomposition_FIRST_OR_LAST_CONTRACT) * new_term.bc_decomposition_bytes_pc_plus_5_shift);
+                (in.get(C::bc_decomposition_bytes_pc_plus_6) -
+                 (FF(1) - bc_decomposition_FIRST_OR_LAST_CONTRACT) * in.get(C::bc_decomposition_bytes_pc_plus_5_shift));
             tmp *= scaling_factor;
             std::get<17>(evals) += typename Accumulator::View(tmp);
         }
         {
             using Accumulator = typename std::tuple_element_t<18, ContainerOverSubrelations>;
             auto tmp =
-                (new_term.bc_decomposition_bytes_pc_plus_7 -
-                 (FF(1) - bc_decomposition_FIRST_OR_LAST_CONTRACT) * new_term.bc_decomposition_bytes_pc_plus_6_shift);
+                (in.get(C::bc_decomposition_bytes_pc_plus_7) -
+                 (FF(1) - bc_decomposition_FIRST_OR_LAST_CONTRACT) * in.get(C::bc_decomposition_bytes_pc_plus_6_shift));
             tmp *= scaling_factor;
             std::get<18>(evals) += typename Accumulator::View(tmp);
         }
         {
             using Accumulator = typename std::tuple_element_t<19, ContainerOverSubrelations>;
             auto tmp =
-                (new_term.bc_decomposition_bytes_pc_plus_8 -
-                 (FF(1) - bc_decomposition_FIRST_OR_LAST_CONTRACT) * new_term.bc_decomposition_bytes_pc_plus_7_shift);
+                (in.get(C::bc_decomposition_bytes_pc_plus_8) -
+                 (FF(1) - bc_decomposition_FIRST_OR_LAST_CONTRACT) * in.get(C::bc_decomposition_bytes_pc_plus_7_shift));
             tmp *= scaling_factor;
             std::get<19>(evals) += typename Accumulator::View(tmp);
         }
         {
             using Accumulator = typename std::tuple_element_t<20, ContainerOverSubrelations>;
             auto tmp =
-                (new_term.bc_decomposition_bytes_pc_plus_9 -
-                 (FF(1) - bc_decomposition_FIRST_OR_LAST_CONTRACT) * new_term.bc_decomposition_bytes_pc_plus_8_shift);
+                (in.get(C::bc_decomposition_bytes_pc_plus_9) -
+                 (FF(1) - bc_decomposition_FIRST_OR_LAST_CONTRACT) * in.get(C::bc_decomposition_bytes_pc_plus_8_shift));
             tmp *= scaling_factor;
             std::get<20>(evals) += typename Accumulator::View(tmp);
         }
         {
             using Accumulator = typename std::tuple_element_t<21, ContainerOverSubrelations>;
             auto tmp =
-                (new_term.bc_decomposition_bytes_pc_plus_10 -
-                 (FF(1) - bc_decomposition_FIRST_OR_LAST_CONTRACT) * new_term.bc_decomposition_bytes_pc_plus_9_shift);
+                (in.get(C::bc_decomposition_bytes_pc_plus_10) -
+                 (FF(1) - bc_decomposition_FIRST_OR_LAST_CONTRACT) * in.get(C::bc_decomposition_bytes_pc_plus_9_shift));
             tmp *= scaling_factor;
             std::get<21>(evals) += typename Accumulator::View(tmp);
         }
         {
             using Accumulator = typename std::tuple_element_t<22, ContainerOverSubrelations>;
             auto tmp =
-                (new_term.bc_decomposition_bytes_pc_plus_11 -
-                 (FF(1) - bc_decomposition_FIRST_OR_LAST_CONTRACT) * new_term.bc_decomposition_bytes_pc_plus_10_shift);
+                (in.get(C::bc_decomposition_bytes_pc_plus_11) - (FF(1) - bc_decomposition_FIRST_OR_LAST_CONTRACT) *
+                                                                    in.get(C::bc_decomposition_bytes_pc_plus_10_shift));
             tmp *= scaling_factor;
             std::get<22>(evals) += typename Accumulator::View(tmp);
         }
         {
             using Accumulator = typename std::tuple_element_t<23, ContainerOverSubrelations>;
             auto tmp =
-                (new_term.bc_decomposition_bytes_pc_plus_12 -
-                 (FF(1) - bc_decomposition_FIRST_OR_LAST_CONTRACT) * new_term.bc_decomposition_bytes_pc_plus_11_shift);
+                (in.get(C::bc_decomposition_bytes_pc_plus_12) - (FF(1) - bc_decomposition_FIRST_OR_LAST_CONTRACT) *
+                                                                    in.get(C::bc_decomposition_bytes_pc_plus_11_shift));
             tmp *= scaling_factor;
             std::get<23>(evals) += typename Accumulator::View(tmp);
         }
         {
             using Accumulator = typename std::tuple_element_t<24, ContainerOverSubrelations>;
             auto tmp =
-                (new_term.bc_decomposition_bytes_pc_plus_13 -
-                 (FF(1) - bc_decomposition_FIRST_OR_LAST_CONTRACT) * new_term.bc_decomposition_bytes_pc_plus_12_shift);
+                (in.get(C::bc_decomposition_bytes_pc_plus_13) - (FF(1) - bc_decomposition_FIRST_OR_LAST_CONTRACT) *
+                                                                    in.get(C::bc_decomposition_bytes_pc_plus_12_shift));
             tmp *= scaling_factor;
             std::get<24>(evals) += typename Accumulator::View(tmp);
         }
         {
             using Accumulator = typename std::tuple_element_t<25, ContainerOverSubrelations>;
             auto tmp =
-                (new_term.bc_decomposition_bytes_pc_plus_14 -
-                 (FF(1) - bc_decomposition_FIRST_OR_LAST_CONTRACT) * new_term.bc_decomposition_bytes_pc_plus_13_shift);
+                (in.get(C::bc_decomposition_bytes_pc_plus_14) - (FF(1) - bc_decomposition_FIRST_OR_LAST_CONTRACT) *
+                                                                    in.get(C::bc_decomposition_bytes_pc_plus_13_shift));
             tmp *= scaling_factor;
             std::get<25>(evals) += typename Accumulator::View(tmp);
         }
         {
             using Accumulator = typename std::tuple_element_t<26, ContainerOverSubrelations>;
             auto tmp =
-                (new_term.bc_decomposition_bytes_pc_plus_15 -
-                 (FF(1) - bc_decomposition_FIRST_OR_LAST_CONTRACT) * new_term.bc_decomposition_bytes_pc_plus_14_shift);
+                (in.get(C::bc_decomposition_bytes_pc_plus_15) - (FF(1) - bc_decomposition_FIRST_OR_LAST_CONTRACT) *
+                                                                    in.get(C::bc_decomposition_bytes_pc_plus_14_shift));
             tmp *= scaling_factor;
             std::get<26>(evals) += typename Accumulator::View(tmp);
         }
         {
             using Accumulator = typename std::tuple_element_t<27, ContainerOverSubrelations>;
             auto tmp =
-                (new_term.bc_decomposition_bytes_pc_plus_16 -
-                 (FF(1) - bc_decomposition_FIRST_OR_LAST_CONTRACT) * new_term.bc_decomposition_bytes_pc_plus_15_shift);
+                (in.get(C::bc_decomposition_bytes_pc_plus_16) - (FF(1) - bc_decomposition_FIRST_OR_LAST_CONTRACT) *
+                                                                    in.get(C::bc_decomposition_bytes_pc_plus_15_shift));
             tmp *= scaling_factor;
             std::get<27>(evals) += typename Accumulator::View(tmp);
         }
         {
             using Accumulator = typename std::tuple_element_t<28, ContainerOverSubrelations>;
             auto tmp =
-                (new_term.bc_decomposition_bytes_pc_plus_17 -
-                 (FF(1) - bc_decomposition_FIRST_OR_LAST_CONTRACT) * new_term.bc_decomposition_bytes_pc_plus_16_shift);
+                (in.get(C::bc_decomposition_bytes_pc_plus_17) - (FF(1) - bc_decomposition_FIRST_OR_LAST_CONTRACT) *
+                                                                    in.get(C::bc_decomposition_bytes_pc_plus_16_shift));
             tmp *= scaling_factor;
             std::get<28>(evals) += typename Accumulator::View(tmp);
         }
         {
             using Accumulator = typename std::tuple_element_t<29, ContainerOverSubrelations>;
             auto tmp =
-                (new_term.bc_decomposition_bytes_pc_plus_18 -
-                 (FF(1) - bc_decomposition_FIRST_OR_LAST_CONTRACT) * new_term.bc_decomposition_bytes_pc_plus_17_shift);
+                (in.get(C::bc_decomposition_bytes_pc_plus_18) - (FF(1) - bc_decomposition_FIRST_OR_LAST_CONTRACT) *
+                                                                    in.get(C::bc_decomposition_bytes_pc_plus_17_shift));
             tmp *= scaling_factor;
             std::get<29>(evals) += typename Accumulator::View(tmp);
         }
         {
             using Accumulator = typename std::tuple_element_t<30, ContainerOverSubrelations>;
             auto tmp =
-                (new_term.bc_decomposition_bytes_pc_plus_19 -
-                 (FF(1) - bc_decomposition_FIRST_OR_LAST_CONTRACT) * new_term.bc_decomposition_bytes_pc_plus_18_shift);
+                (in.get(C::bc_decomposition_bytes_pc_plus_19) - (FF(1) - bc_decomposition_FIRST_OR_LAST_CONTRACT) *
+                                                                    in.get(C::bc_decomposition_bytes_pc_plus_18_shift));
             tmp *= scaling_factor;
             std::get<30>(evals) += typename Accumulator::View(tmp);
         }
         {
             using Accumulator = typename std::tuple_element_t<31, ContainerOverSubrelations>;
             auto tmp =
-                (new_term.bc_decomposition_bytes_pc_plus_20 -
-                 (FF(1) - bc_decomposition_FIRST_OR_LAST_CONTRACT) * new_term.bc_decomposition_bytes_pc_plus_19_shift);
+                (in.get(C::bc_decomposition_bytes_pc_plus_20) - (FF(1) - bc_decomposition_FIRST_OR_LAST_CONTRACT) *
+                                                                    in.get(C::bc_decomposition_bytes_pc_plus_19_shift));
             tmp *= scaling_factor;
             std::get<31>(evals) += typename Accumulator::View(tmp);
         }
         {
             using Accumulator = typename std::tuple_element_t<32, ContainerOverSubrelations>;
             auto tmp =
-                (new_term.bc_decomposition_bytes_pc_plus_21 -
-                 (FF(1) - bc_decomposition_FIRST_OR_LAST_CONTRACT) * new_term.bc_decomposition_bytes_pc_plus_20_shift);
+                (in.get(C::bc_decomposition_bytes_pc_plus_21) - (FF(1) - bc_decomposition_FIRST_OR_LAST_CONTRACT) *
+                                                                    in.get(C::bc_decomposition_bytes_pc_plus_20_shift));
             tmp *= scaling_factor;
             std::get<32>(evals) += typename Accumulator::View(tmp);
         }
         {
             using Accumulator = typename std::tuple_element_t<33, ContainerOverSubrelations>;
             auto tmp =
-                (new_term.bc_decomposition_bytes_pc_plus_22 -
-                 (FF(1) - bc_decomposition_FIRST_OR_LAST_CONTRACT) * new_term.bc_decomposition_bytes_pc_plus_21_shift);
+                (in.get(C::bc_decomposition_bytes_pc_plus_22) - (FF(1) - bc_decomposition_FIRST_OR_LAST_CONTRACT) *
+                                                                    in.get(C::bc_decomposition_bytes_pc_plus_21_shift));
             tmp *= scaling_factor;
             std::get<33>(evals) += typename Accumulator::View(tmp);
         }
         {
             using Accumulator = typename std::tuple_element_t<34, ContainerOverSubrelations>;
             auto tmp =
-                (new_term.bc_decomposition_bytes_pc_plus_23 -
-                 (FF(1) - bc_decomposition_FIRST_OR_LAST_CONTRACT) * new_term.bc_decomposition_bytes_pc_plus_22_shift);
+                (in.get(C::bc_decomposition_bytes_pc_plus_23) - (FF(1) - bc_decomposition_FIRST_OR_LAST_CONTRACT) *
+                                                                    in.get(C::bc_decomposition_bytes_pc_plus_22_shift));
             tmp *= scaling_factor;
             std::get<34>(evals) += typename Accumulator::View(tmp);
         }
         {
             using Accumulator = typename std::tuple_element_t<35, ContainerOverSubrelations>;
             auto tmp =
-                (new_term.bc_decomposition_bytes_pc_plus_24 -
-                 (FF(1) - bc_decomposition_FIRST_OR_LAST_CONTRACT) * new_term.bc_decomposition_bytes_pc_plus_23_shift);
+                (in.get(C::bc_decomposition_bytes_pc_plus_24) - (FF(1) - bc_decomposition_FIRST_OR_LAST_CONTRACT) *
+                                                                    in.get(C::bc_decomposition_bytes_pc_plus_23_shift));
             tmp *= scaling_factor;
             std::get<35>(evals) += typename Accumulator::View(tmp);
         }
         {
             using Accumulator = typename std::tuple_element_t<36, ContainerOverSubrelations>;
             auto tmp =
-                (new_term.bc_decomposition_bytes_pc_plus_25 -
-                 (FF(1) - bc_decomposition_FIRST_OR_LAST_CONTRACT) * new_term.bc_decomposition_bytes_pc_plus_24_shift);
+                (in.get(C::bc_decomposition_bytes_pc_plus_25) - (FF(1) - bc_decomposition_FIRST_OR_LAST_CONTRACT) *
+                                                                    in.get(C::bc_decomposition_bytes_pc_plus_24_shift));
             tmp *= scaling_factor;
             std::get<36>(evals) += typename Accumulator::View(tmp);
         }
         {
             using Accumulator = typename std::tuple_element_t<37, ContainerOverSubrelations>;
             auto tmp =
-                (new_term.bc_decomposition_bytes_pc_plus_26 -
-                 (FF(1) - bc_decomposition_FIRST_OR_LAST_CONTRACT) * new_term.bc_decomposition_bytes_pc_plus_25_shift);
+                (in.get(C::bc_decomposition_bytes_pc_plus_26) - (FF(1) - bc_decomposition_FIRST_OR_LAST_CONTRACT) *
+                                                                    in.get(C::bc_decomposition_bytes_pc_plus_25_shift));
             tmp *= scaling_factor;
             std::get<37>(evals) += typename Accumulator::View(tmp);
         }
         {
             using Accumulator = typename std::tuple_element_t<38, ContainerOverSubrelations>;
             auto tmp =
-                (new_term.bc_decomposition_bytes_pc_plus_27 -
-                 (FF(1) - bc_decomposition_FIRST_OR_LAST_CONTRACT) * new_term.bc_decomposition_bytes_pc_plus_26_shift);
+                (in.get(C::bc_decomposition_bytes_pc_plus_27) - (FF(1) - bc_decomposition_FIRST_OR_LAST_CONTRACT) *
+                                                                    in.get(C::bc_decomposition_bytes_pc_plus_26_shift));
             tmp *= scaling_factor;
             std::get<38>(evals) += typename Accumulator::View(tmp);
         }
         {
             using Accumulator = typename std::tuple_element_t<39, ContainerOverSubrelations>;
             auto tmp =
-                (new_term.bc_decomposition_bytes_pc_plus_28 -
-                 (FF(1) - bc_decomposition_FIRST_OR_LAST_CONTRACT) * new_term.bc_decomposition_bytes_pc_plus_27_shift);
+                (in.get(C::bc_decomposition_bytes_pc_plus_28) - (FF(1) - bc_decomposition_FIRST_OR_LAST_CONTRACT) *
+                                                                    in.get(C::bc_decomposition_bytes_pc_plus_27_shift));
             tmp *= scaling_factor;
             std::get<39>(evals) += typename Accumulator::View(tmp);
         }
         {
             using Accumulator = typename std::tuple_element_t<40, ContainerOverSubrelations>;
             auto tmp =
-                (new_term.bc_decomposition_bytes_pc_plus_29 -
-                 (FF(1) - bc_decomposition_FIRST_OR_LAST_CONTRACT) * new_term.bc_decomposition_bytes_pc_plus_28_shift);
+                (in.get(C::bc_decomposition_bytes_pc_plus_29) - (FF(1) - bc_decomposition_FIRST_OR_LAST_CONTRACT) *
+                                                                    in.get(C::bc_decomposition_bytes_pc_plus_28_shift));
             tmp *= scaling_factor;
             std::get<40>(evals) += typename Accumulator::View(tmp);
         }
         {
             using Accumulator = typename std::tuple_element_t<41, ContainerOverSubrelations>;
             auto tmp =
-                (new_term.bc_decomposition_bytes_pc_plus_30 -
-                 (FF(1) - bc_decomposition_FIRST_OR_LAST_CONTRACT) * new_term.bc_decomposition_bytes_pc_plus_29_shift);
+                (in.get(C::bc_decomposition_bytes_pc_plus_30) - (FF(1) - bc_decomposition_FIRST_OR_LAST_CONTRACT) *
+                                                                    in.get(C::bc_decomposition_bytes_pc_plus_29_shift));
             tmp *= scaling_factor;
             std::get<41>(evals) += typename Accumulator::View(tmp);
         }
         {
             using Accumulator = typename std::tuple_element_t<42, ContainerOverSubrelations>;
             auto tmp =
-                (new_term.bc_decomposition_bytes_pc_plus_31 -
-                 (FF(1) - bc_decomposition_FIRST_OR_LAST_CONTRACT) * new_term.bc_decomposition_bytes_pc_plus_30_shift);
+                (in.get(C::bc_decomposition_bytes_pc_plus_31) - (FF(1) - bc_decomposition_FIRST_OR_LAST_CONTRACT) *
+                                                                    in.get(C::bc_decomposition_bytes_pc_plus_30_shift));
             tmp *= scaling_factor;
             std::get<42>(evals) += typename Accumulator::View(tmp);
         }
         {
             using Accumulator = typename std::tuple_element_t<43, ContainerOverSubrelations>;
             auto tmp =
-                (new_term.bc_decomposition_bytes_pc_plus_32 -
-                 (FF(1) - bc_decomposition_FIRST_OR_LAST_CONTRACT) * new_term.bc_decomposition_bytes_pc_plus_31_shift);
+                (in.get(C::bc_decomposition_bytes_pc_plus_32) - (FF(1) - bc_decomposition_FIRST_OR_LAST_CONTRACT) *
+                                                                    in.get(C::bc_decomposition_bytes_pc_plus_31_shift));
             tmp *= scaling_factor;
             std::get<43>(evals) += typename Accumulator::View(tmp);
         }
         {
             using Accumulator = typename std::tuple_element_t<44, ContainerOverSubrelations>;
             auto tmp =
-                (new_term.bc_decomposition_bytes_pc_plus_33 -
-                 (FF(1) - bc_decomposition_FIRST_OR_LAST_CONTRACT) * new_term.bc_decomposition_bytes_pc_plus_32_shift);
+                (in.get(C::bc_decomposition_bytes_pc_plus_33) - (FF(1) - bc_decomposition_FIRST_OR_LAST_CONTRACT) *
+                                                                    in.get(C::bc_decomposition_bytes_pc_plus_32_shift));
             tmp *= scaling_factor;
             std::get<44>(evals) += typename Accumulator::View(tmp);
         }
         {
             using Accumulator = typename std::tuple_element_t<45, ContainerOverSubrelations>;
             auto tmp =
-                (new_term.bc_decomposition_bytes_pc_plus_34 -
-                 (FF(1) - bc_decomposition_FIRST_OR_LAST_CONTRACT) * new_term.bc_decomposition_bytes_pc_plus_33_shift);
+                (in.get(C::bc_decomposition_bytes_pc_plus_34) - (FF(1) - bc_decomposition_FIRST_OR_LAST_CONTRACT) *
+                                                                    in.get(C::bc_decomposition_bytes_pc_plus_33_shift));
             tmp *= scaling_factor;
             std::get<45>(evals) += typename Accumulator::View(tmp);
         }
         {
             using Accumulator = typename std::tuple_element_t<46, ContainerOverSubrelations>;
             auto tmp =
-                (new_term.bc_decomposition_bytes_pc_plus_35 -
-                 (FF(1) - bc_decomposition_FIRST_OR_LAST_CONTRACT) * new_term.bc_decomposition_bytes_pc_plus_34_shift);
+                (in.get(C::bc_decomposition_bytes_pc_plus_35) - (FF(1) - bc_decomposition_FIRST_OR_LAST_CONTRACT) *
+                                                                    in.get(C::bc_decomposition_bytes_pc_plus_34_shift));
             tmp *= scaling_factor;
             std::get<46>(evals) += typename Accumulator::View(tmp);
         }
         {
             using Accumulator = typename std::tuple_element_t<47, ContainerOverSubrelations>;
             auto tmp =
-                (new_term.bc_decomposition_bytes_pc_plus_36 -
-                 (FF(1) - bc_decomposition_FIRST_OR_LAST_CONTRACT) * new_term.bc_decomposition_bytes_pc_plus_35_shift);
+                (in.get(C::bc_decomposition_bytes_pc_plus_36) - (FF(1) - bc_decomposition_FIRST_OR_LAST_CONTRACT) *
+                                                                    in.get(C::bc_decomposition_bytes_pc_plus_35_shift));
             tmp *= scaling_factor;
             std::get<47>(evals) += typename Accumulator::View(tmp);
         }
         {
             using Accumulator = typename std::tuple_element_t<48, ContainerOverSubrelations>;
-            auto tmp = new_term.bc_decomposition_sel_packed * (FF(1) - new_term.bc_decomposition_sel_packed);
+            auto tmp = in.get(C::bc_decomposition_sel_packed) * (FF(1) - in.get(C::bc_decomposition_sel_packed));
             tmp *= scaling_factor;
             std::get<48>(evals) += typename Accumulator::View(tmp);
         }
         { // SEL_TOGGLED_AT_PACKED
             using Accumulator = typename std::tuple_element_t<49, ContainerOverSubrelations>;
-            auto tmp = new_term.bc_decomposition_sel_packed * (FF(1) - new_term.bc_decomposition_sel);
+            auto tmp = in.get(C::bc_decomposition_sel_packed) * (FF(1) - in.get(C::bc_decomposition_sel));
             tmp *= scaling_factor;
             std::get<49>(evals) += typename Accumulator::View(tmp);
         }
         { // BC_DECOMPOSITION_REPACKING
             using Accumulator = typename std::tuple_element_t<50, ContainerOverSubrelations>;
             auto tmp =
-                new_term.bc_decomposition_sel_packed *
-                ((FF(1) * new_term.bc_decomposition_bytes_pc_plus_30 +
-                  FF(256) * new_term.bc_decomposition_bytes_pc_plus_29 +
-                  FF(65536) * new_term.bc_decomposition_bytes_pc_plus_28 +
-                  FF(16777216) * new_term.bc_decomposition_bytes_pc_plus_27 +
-                  FF(4294967296UL) * new_term.bc_decomposition_bytes_pc_plus_26 +
-                  FF(1099511627776UL) * new_term.bc_decomposition_bytes_pc_plus_25 +
-                  FF(281474976710656UL) * new_term.bc_decomposition_bytes_pc_plus_24 +
-                  FF(72057594037927936UL) * new_term.bc_decomposition_bytes_pc_plus_23 +
-                  FF(uint256_t{ 0UL, 1UL, 0UL, 0UL }) * new_term.bc_decomposition_bytes_pc_plus_22 +
-                  FF(uint256_t{ 0UL, 256UL, 0UL, 0UL }) * new_term.bc_decomposition_bytes_pc_plus_21 +
-                  FF(uint256_t{ 0UL, 65536UL, 0UL, 0UL }) * new_term.bc_decomposition_bytes_pc_plus_20 +
-                  FF(uint256_t{ 0UL, 16777216UL, 0UL, 0UL }) * new_term.bc_decomposition_bytes_pc_plus_19 +
-                  FF(uint256_t{ 0UL, 4294967296UL, 0UL, 0UL }) * new_term.bc_decomposition_bytes_pc_plus_18 +
-                  FF(uint256_t{ 0UL, 1099511627776UL, 0UL, 0UL }) * new_term.bc_decomposition_bytes_pc_plus_17 +
-                  FF(uint256_t{ 0UL, 281474976710656UL, 0UL, 0UL }) * new_term.bc_decomposition_bytes_pc_plus_16 +
-                  FF(uint256_t{ 0UL, 72057594037927936UL, 0UL, 0UL }) * new_term.bc_decomposition_bytes_pc_plus_15 +
-                  FF(uint256_t{ 0UL, 0UL, 1UL, 0UL }) * new_term.bc_decomposition_bytes_pc_plus_14 +
-                  FF(uint256_t{ 0UL, 0UL, 256UL, 0UL }) * new_term.bc_decomposition_bytes_pc_plus_13 +
-                  FF(uint256_t{ 0UL, 0UL, 65536UL, 0UL }) * new_term.bc_decomposition_bytes_pc_plus_12 +
-                  FF(uint256_t{ 0UL, 0UL, 16777216UL, 0UL }) * new_term.bc_decomposition_bytes_pc_plus_11 +
-                  FF(uint256_t{ 0UL, 0UL, 4294967296UL, 0UL }) * new_term.bc_decomposition_bytes_pc_plus_10 +
-                  FF(uint256_t{ 0UL, 0UL, 1099511627776UL, 0UL }) * new_term.bc_decomposition_bytes_pc_plus_9 +
-                  FF(uint256_t{ 0UL, 0UL, 281474976710656UL, 0UL }) * new_term.bc_decomposition_bytes_pc_plus_8 +
-                  FF(uint256_t{ 0UL, 0UL, 72057594037927936UL, 0UL }) * new_term.bc_decomposition_bytes_pc_plus_7 +
-                  FF(uint256_t{ 0UL, 0UL, 0UL, 1UL }) * new_term.bc_decomposition_bytes_pc_plus_6 +
-                  FF(uint256_t{ 0UL, 0UL, 0UL, 256UL }) * new_term.bc_decomposition_bytes_pc_plus_5 +
-                  FF(uint256_t{ 0UL, 0UL, 0UL, 65536UL }) * new_term.bc_decomposition_bytes_pc_plus_4 +
-                  FF(uint256_t{ 0UL, 0UL, 0UL, 16777216UL }) * new_term.bc_decomposition_bytes_pc_plus_3 +
-                  FF(uint256_t{ 0UL, 0UL, 0UL, 4294967296UL }) * new_term.bc_decomposition_bytes_pc_plus_2 +
-                  FF(uint256_t{ 0UL, 0UL, 0UL, 1099511627776UL }) * new_term.bc_decomposition_bytes_pc_plus_1 +
-                  FF(uint256_t{ 0UL, 0UL, 0UL, 281474976710656UL }) * new_term.bc_decomposition_bytes) -
-                 new_term.bc_decomposition_packed_field);
+                in.get(C::bc_decomposition_sel_packed) *
+                ((FF(1) * in.get(C::bc_decomposition_bytes_pc_plus_30) +
+                  FF(256) * in.get(C::bc_decomposition_bytes_pc_plus_29) +
+                  FF(65536) * in.get(C::bc_decomposition_bytes_pc_plus_28) +
+                  FF(16777216) * in.get(C::bc_decomposition_bytes_pc_plus_27) +
+                  FF(4294967296UL) * in.get(C::bc_decomposition_bytes_pc_plus_26) +
+                  FF(1099511627776UL) * in.get(C::bc_decomposition_bytes_pc_plus_25) +
+                  FF(281474976710656UL) * in.get(C::bc_decomposition_bytes_pc_plus_24) +
+                  FF(72057594037927936UL) * in.get(C::bc_decomposition_bytes_pc_plus_23) +
+                  FF(uint256_t{ 0UL, 1UL, 0UL, 0UL }) * in.get(C::bc_decomposition_bytes_pc_plus_22) +
+                  FF(uint256_t{ 0UL, 256UL, 0UL, 0UL }) * in.get(C::bc_decomposition_bytes_pc_plus_21) +
+                  FF(uint256_t{ 0UL, 65536UL, 0UL, 0UL }) * in.get(C::bc_decomposition_bytes_pc_plus_20) +
+                  FF(uint256_t{ 0UL, 16777216UL, 0UL, 0UL }) * in.get(C::bc_decomposition_bytes_pc_plus_19) +
+                  FF(uint256_t{ 0UL, 4294967296UL, 0UL, 0UL }) * in.get(C::bc_decomposition_bytes_pc_plus_18) +
+                  FF(uint256_t{ 0UL, 1099511627776UL, 0UL, 0UL }) * in.get(C::bc_decomposition_bytes_pc_plus_17) +
+                  FF(uint256_t{ 0UL, 281474976710656UL, 0UL, 0UL }) * in.get(C::bc_decomposition_bytes_pc_plus_16) +
+                  FF(uint256_t{ 0UL, 72057594037927936UL, 0UL, 0UL }) * in.get(C::bc_decomposition_bytes_pc_plus_15) +
+                  FF(uint256_t{ 0UL, 0UL, 1UL, 0UL }) * in.get(C::bc_decomposition_bytes_pc_plus_14) +
+                  FF(uint256_t{ 0UL, 0UL, 256UL, 0UL }) * in.get(C::bc_decomposition_bytes_pc_plus_13) +
+                  FF(uint256_t{ 0UL, 0UL, 65536UL, 0UL }) * in.get(C::bc_decomposition_bytes_pc_plus_12) +
+                  FF(uint256_t{ 0UL, 0UL, 16777216UL, 0UL }) * in.get(C::bc_decomposition_bytes_pc_plus_11) +
+                  FF(uint256_t{ 0UL, 0UL, 4294967296UL, 0UL }) * in.get(C::bc_decomposition_bytes_pc_plus_10) +
+                  FF(uint256_t{ 0UL, 0UL, 1099511627776UL, 0UL }) * in.get(C::bc_decomposition_bytes_pc_plus_9) +
+                  FF(uint256_t{ 0UL, 0UL, 281474976710656UL, 0UL }) * in.get(C::bc_decomposition_bytes_pc_plus_8) +
+                  FF(uint256_t{ 0UL, 0UL, 72057594037927936UL, 0UL }) * in.get(C::bc_decomposition_bytes_pc_plus_7) +
+                  FF(uint256_t{ 0UL, 0UL, 0UL, 1UL }) * in.get(C::bc_decomposition_bytes_pc_plus_6) +
+                  FF(uint256_t{ 0UL, 0UL, 0UL, 256UL }) * in.get(C::bc_decomposition_bytes_pc_plus_5) +
+                  FF(uint256_t{ 0UL, 0UL, 0UL, 65536UL }) * in.get(C::bc_decomposition_bytes_pc_plus_4) +
+                  FF(uint256_t{ 0UL, 0UL, 0UL, 16777216UL }) * in.get(C::bc_decomposition_bytes_pc_plus_3) +
+                  FF(uint256_t{ 0UL, 0UL, 0UL, 4294967296UL }) * in.get(C::bc_decomposition_bytes_pc_plus_2) +
+                  FF(uint256_t{ 0UL, 0UL, 0UL, 1099511627776UL }) * in.get(C::bc_decomposition_bytes_pc_plus_1) +
+                  FF(uint256_t{ 0UL, 0UL, 0UL, 281474976710656UL }) * in.get(C::bc_decomposition_bytes)) -
+                 in.get(C::bc_decomposition_packed_field));
             tmp *= scaling_factor;
             std::get<50>(evals) += typename Accumulator::View(tmp);
         }

--- a/barretenberg/cpp/src/barretenberg/vm2/generated/relations/bc_hashing.hpp
+++ b/barretenberg/cpp/src/barretenberg/vm2/generated/relations/bc_hashing.hpp
@@ -5,6 +5,7 @@
 
 #include "barretenberg/relations/relation_parameters.hpp"
 #include "barretenberg/relations/relation_types.hpp"
+#include "barretenberg/vm2/generated/columns.hpp"
 
 namespace bb::avm2 {
 
@@ -16,74 +17,77 @@ template <typename FF_> class bc_hashingImpl {
 
     template <typename AllEntities> inline static bool skip(const AllEntities& in)
     {
-        const auto& new_term = in;
-        return (new_term.bc_hashing_sel).is_zero();
+        using C = ColumnAndShifts;
+        return (in.get(C::bc_hashing_sel)).is_zero();
     }
 
     template <typename ContainerOverSubrelations, typename AllEntities>
     void static accumulate(ContainerOverSubrelations& evals,
-                           const AllEntities& new_term,
+                           const AllEntities& in,
                            [[maybe_unused]] const RelationParameters<FF>&,
                            [[maybe_unused]] const FF& scaling_factor)
     {
-        const auto bc_hashing_LATCH_CONDITION = new_term.bc_hashing_latch + new_term.precomputed_first_row;
+        using C = ColumnAndShifts;
+
+        const auto bc_hashing_LATCH_CONDITION = in.get(C::bc_hashing_latch) + in.get(C::precomputed_first_row);
 
         {
             using Accumulator = typename std::tuple_element_t<0, ContainerOverSubrelations>;
-            auto tmp = new_term.bc_hashing_sel * (FF(1) - new_term.bc_hashing_sel);
+            auto tmp = in.get(C::bc_hashing_sel) * (FF(1) - in.get(C::bc_hashing_sel));
             tmp *= scaling_factor;
             std::get<0>(evals) += typename Accumulator::View(tmp);
         }
         { // TRACE_CONTINUITY
             using Accumulator = typename std::tuple_element_t<1, ContainerOverSubrelations>;
-            auto tmp = (FF(1) - new_term.precomputed_first_row) * (FF(1) - new_term.bc_hashing_sel) *
-                       new_term.bc_hashing_sel_shift;
+            auto tmp = (FF(1) - in.get(C::precomputed_first_row)) * (FF(1) - in.get(C::bc_hashing_sel)) *
+                       in.get(C::bc_hashing_sel_shift);
             tmp *= scaling_factor;
             std::get<1>(evals) += typename Accumulator::View(tmp);
         }
         {
             using Accumulator = typename std::tuple_element_t<2, ContainerOverSubrelations>;
-            auto tmp = new_term.bc_hashing_latch * (FF(1) - new_term.bc_hashing_latch);
+            auto tmp = in.get(C::bc_hashing_latch) * (FF(1) - in.get(C::bc_hashing_latch));
             tmp *= scaling_factor;
             std::get<2>(evals) += typename Accumulator::View(tmp);
         }
         { // SEL_TOGGLED_AT_LATCH
             using Accumulator = typename std::tuple_element_t<3, ContainerOverSubrelations>;
-            auto tmp = new_term.bc_hashing_latch * (FF(1) - new_term.bc_hashing_sel);
+            auto tmp = in.get(C::bc_hashing_latch) * (FF(1) - in.get(C::bc_hashing_sel));
             tmp *= scaling_factor;
             std::get<3>(evals) += typename Accumulator::View(tmp);
         }
         {
             using Accumulator = typename std::tuple_element_t<4, ContainerOverSubrelations>;
-            auto tmp = new_term.bc_hashing_start * (FF(1) - new_term.bc_hashing_start);
+            auto tmp = in.get(C::bc_hashing_start) * (FF(1) - in.get(C::bc_hashing_start));
             tmp *= scaling_factor;
             std::get<4>(evals) += typename Accumulator::View(tmp);
         }
         { // START_AFTER_LATCH
             using Accumulator = typename std::tuple_element_t<5, ContainerOverSubrelations>;
-            auto tmp = new_term.bc_hashing_sel_shift * (new_term.bc_hashing_start_shift - bc_hashing_LATCH_CONDITION);
+            auto tmp =
+                in.get(C::bc_hashing_sel_shift) * (in.get(C::bc_hashing_start_shift) - bc_hashing_LATCH_CONDITION);
             tmp *= scaling_factor;
             std::get<5>(evals) += typename Accumulator::View(tmp);
         }
         { // PC_INCREMENTS
             using Accumulator = typename std::tuple_element_t<6, ContainerOverSubrelations>;
-            auto tmp = new_term.bc_hashing_sel *
-                       (new_term.bc_hashing_pc_index_shift -
-                        (FF(1) - bc_hashing_LATCH_CONDITION) * (FF(31) + new_term.bc_hashing_pc_index));
+            auto tmp = in.get(C::bc_hashing_sel) *
+                       (in.get(C::bc_hashing_pc_index_shift) -
+                        (FF(1) - bc_hashing_LATCH_CONDITION) * (FF(31) + in.get(C::bc_hashing_pc_index)));
             tmp *= scaling_factor;
             std::get<6>(evals) += typename Accumulator::View(tmp);
         }
         { // ID_CONSISTENCY
             using Accumulator = typename std::tuple_element_t<7, ContainerOverSubrelations>;
             auto tmp = (FF(1) - bc_hashing_LATCH_CONDITION) *
-                       (new_term.bc_hashing_bytecode_id_shift - new_term.bc_hashing_bytecode_id);
+                       (in.get(C::bc_hashing_bytecode_id_shift) - in.get(C::bc_hashing_bytecode_id));
             tmp *= scaling_factor;
             std::get<7>(evals) += typename Accumulator::View(tmp);
         }
         { // CHAIN_OUTPUT_TO_INCR
             using Accumulator = typename std::tuple_element_t<8, ContainerOverSubrelations>;
             auto tmp = (FF(1) - bc_hashing_LATCH_CONDITION) *
-                       (new_term.bc_hashing_incremental_hash_shift - new_term.bc_hashing_output_hash);
+                       (in.get(C::bc_hashing_incremental_hash_shift) - in.get(C::bc_hashing_output_hash));
             tmp *= scaling_factor;
             std::get<8>(evals) += typename Accumulator::View(tmp);
         }

--- a/barretenberg/cpp/src/barretenberg/vm2/generated/relations/bc_retrieval.hpp
+++ b/barretenberg/cpp/src/barretenberg/vm2/generated/relations/bc_retrieval.hpp
@@ -5,6 +5,7 @@
 
 #include "barretenberg/relations/relation_parameters.hpp"
 #include "barretenberg/relations/relation_types.hpp"
+#include "barretenberg/vm2/generated/columns.hpp"
 
 namespace bb::avm2 {
 
@@ -16,36 +17,38 @@ template <typename FF_> class bc_retrievalImpl {
 
     template <typename AllEntities> inline static bool skip(const AllEntities& in)
     {
-        const auto& new_term = in;
-        return (new_term.bc_retrieval_sel).is_zero();
+        using C = ColumnAndShifts;
+        return (in.get(C::bc_retrieval_sel)).is_zero();
     }
 
     template <typename ContainerOverSubrelations, typename AllEntities>
     void static accumulate(ContainerOverSubrelations& evals,
-                           const AllEntities& new_term,
+                           const AllEntities& in,
                            [[maybe_unused]] const RelationParameters<FF>&,
                            [[maybe_unused]] const FF& scaling_factor)
     {
+        using C = ColumnAndShifts;
+
         const auto constants_DEPLOYER_CONTRACT_ADDRESS = FF(2);
         const auto constants_GENERATOR_INDEX__OUTER_NULLIFIER = FF(7);
 
         {
             using Accumulator = typename std::tuple_element_t<0, ContainerOverSubrelations>;
-            auto tmp = new_term.bc_retrieval_sel * (constants_GENERATOR_INDEX__OUTER_NULLIFIER -
-                                                    new_term.bc_retrieval_outer_nullifier_domain_separator);
+            auto tmp = in.get(C::bc_retrieval_sel) * (constants_GENERATOR_INDEX__OUTER_NULLIFIER -
+                                                      in.get(C::bc_retrieval_outer_nullifier_domain_separator));
             tmp *= scaling_factor;
             std::get<0>(evals) += typename Accumulator::View(tmp);
         }
         {
             using Accumulator = typename std::tuple_element_t<1, ContainerOverSubrelations>;
-            auto tmp = new_term.bc_retrieval_sel *
-                       (constants_DEPLOYER_CONTRACT_ADDRESS - new_term.bc_retrieval_deployer_protocol_contract_address);
+            auto tmp = in.get(C::bc_retrieval_sel) * (constants_DEPLOYER_CONTRACT_ADDRESS -
+                                                      in.get(C::bc_retrieval_deployer_protocol_contract_address));
             tmp *= scaling_factor;
             std::get<1>(evals) += typename Accumulator::View(tmp);
         }
         {
             using Accumulator = typename std::tuple_element_t<2, ContainerOverSubrelations>;
-            auto tmp = (new_term.bc_retrieval_sel - new_term.bc_retrieval_sel);
+            auto tmp = (in.get(C::bc_retrieval_sel) - in.get(C::bc_retrieval_sel));
             tmp *= scaling_factor;
             std::get<2>(evals) += typename Accumulator::View(tmp);
         }

--- a/barretenberg/cpp/src/barretenberg/vm2/generated/relations/bitwise.hpp
+++ b/barretenberg/cpp/src/barretenberg/vm2/generated/relations/bitwise.hpp
@@ -5,6 +5,7 @@
 
 #include "barretenberg/relations/relation_parameters.hpp"
 #include "barretenberg/relations/relation_types.hpp"
+#include "barretenberg/vm2/generated/columns.hpp"
 
 namespace bb::avm2 {
 
@@ -16,106 +17,108 @@ template <typename FF_> class bitwiseImpl {
 
     template <typename AllEntities> inline static bool skip(const AllEntities& in)
     {
-        const auto& new_term = in;
-        return ((new_term.bitwise_sel + new_term.bitwise_last)).is_zero();
+        using C = ColumnAndShifts;
+        return ((in.get(C::bitwise_sel) + in.get(C::bitwise_last))).is_zero();
     }
 
     template <typename ContainerOverSubrelations, typename AllEntities>
     void static accumulate(ContainerOverSubrelations& evals,
-                           const AllEntities& new_term,
+                           const AllEntities& in,
                            [[maybe_unused]] const RelationParameters<FF>&,
                            [[maybe_unused]] const FF& scaling_factor)
     {
+        using C = ColumnAndShifts;
 
         {
             using Accumulator = typename std::tuple_element_t<0, ContainerOverSubrelations>;
-            auto tmp = new_term.bitwise_sel * (FF(1) - new_term.bitwise_sel);
+            auto tmp = in.get(C::bitwise_sel) * (FF(1) - in.get(C::bitwise_sel));
             tmp *= scaling_factor;
             std::get<0>(evals) += typename Accumulator::View(tmp);
         }
         {
             using Accumulator = typename std::tuple_element_t<1, ContainerOverSubrelations>;
-            auto tmp = new_term.bitwise_start * (FF(1) - new_term.bitwise_start);
+            auto tmp = in.get(C::bitwise_start) * (FF(1) - in.get(C::bitwise_start));
             tmp *= scaling_factor;
             std::get<1>(evals) += typename Accumulator::View(tmp);
         }
         {
             using Accumulator = typename std::tuple_element_t<2, ContainerOverSubrelations>;
-            auto tmp = new_term.bitwise_last * (FF(1) - new_term.bitwise_last);
+            auto tmp = in.get(C::bitwise_last) * (FF(1) - in.get(C::bitwise_last));
             tmp *= scaling_factor;
             std::get<2>(evals) += typename Accumulator::View(tmp);
         }
         { // BITW_OP_ID_REL
             using Accumulator = typename std::tuple_element_t<3, ContainerOverSubrelations>;
-            auto tmp = (new_term.bitwise_op_id_shift - new_term.bitwise_op_id) * (FF(1) - new_term.bitwise_last);
+            auto tmp = (in.get(C::bitwise_op_id_shift) - in.get(C::bitwise_op_id)) * (FF(1) - in.get(C::bitwise_last));
             tmp *= scaling_factor;
             std::get<3>(evals) += typename Accumulator::View(tmp);
         }
         { // BITW_CTR_DECREMENT
             using Accumulator = typename std::tuple_element_t<4, ContainerOverSubrelations>;
-            auto tmp = new_term.bitwise_sel * ((new_term.bitwise_ctr_shift - new_term.bitwise_ctr) + FF(1)) *
-                       (FF(1) - new_term.bitwise_last);
+            auto tmp = in.get(C::bitwise_sel) * ((in.get(C::bitwise_ctr_shift) - in.get(C::bitwise_ctr)) + FF(1)) *
+                       (FF(1) - in.get(C::bitwise_last));
             tmp *= scaling_factor;
             std::get<4>(evals) += typename Accumulator::View(tmp);
         }
         { // BITW_SEL_CTR_NON_ZERO
             using Accumulator = typename std::tuple_element_t<5, ContainerOverSubrelations>;
-            auto tmp = (new_term.bitwise_ctr * ((FF(1) - new_term.bitwise_sel) * (FF(1) - new_term.bitwise_ctr_inv) +
-                                                new_term.bitwise_ctr_inv) -
-                        new_term.bitwise_sel);
+            auto tmp =
+                (in.get(C::bitwise_ctr) * ((FF(1) - in.get(C::bitwise_sel)) * (FF(1) - in.get(C::bitwise_ctr_inv)) +
+                                           in.get(C::bitwise_ctr_inv)) -
+                 in.get(C::bitwise_sel));
             tmp *= scaling_factor;
             std::get<5>(evals) += typename Accumulator::View(tmp);
         }
         { // BITW_LAST_FOR_CTR_ONE
             using Accumulator = typename std::tuple_element_t<6, ContainerOverSubrelations>;
             auto tmp =
-                new_term.bitwise_sel *
-                (((new_term.bitwise_ctr - FF(1)) * (new_term.bitwise_last * (FF(1) - new_term.bitwise_ctr_min_one_inv) +
-                                                    new_term.bitwise_ctr_min_one_inv) +
-                  new_term.bitwise_last) -
-                 FF(1));
+                in.get(C::bitwise_sel) * (((in.get(C::bitwise_ctr) - FF(1)) *
+                                               (in.get(C::bitwise_last) * (FF(1) - in.get(C::bitwise_ctr_min_one_inv)) +
+                                                in.get(C::bitwise_ctr_min_one_inv)) +
+                                           in.get(C::bitwise_last)) -
+                                          FF(1));
             tmp *= scaling_factor;
             std::get<6>(evals) += typename Accumulator::View(tmp);
         }
         { // BITW_INIT_A
             using Accumulator = typename std::tuple_element_t<7, ContainerOverSubrelations>;
-            auto tmp = new_term.bitwise_last * (new_term.bitwise_acc_ia - new_term.bitwise_ia_byte);
+            auto tmp = in.get(C::bitwise_last) * (in.get(C::bitwise_acc_ia) - in.get(C::bitwise_ia_byte));
             tmp *= scaling_factor;
             std::get<7>(evals) += typename Accumulator::View(tmp);
         }
         { // BITW_INIT_B
             using Accumulator = typename std::tuple_element_t<8, ContainerOverSubrelations>;
-            auto tmp = new_term.bitwise_last * (new_term.bitwise_acc_ib - new_term.bitwise_ib_byte);
+            auto tmp = in.get(C::bitwise_last) * (in.get(C::bitwise_acc_ib) - in.get(C::bitwise_ib_byte));
             tmp *= scaling_factor;
             std::get<8>(evals) += typename Accumulator::View(tmp);
         }
         { // BITW_INIT_C
             using Accumulator = typename std::tuple_element_t<9, ContainerOverSubrelations>;
-            auto tmp = new_term.bitwise_last * (new_term.bitwise_acc_ic - new_term.bitwise_ic_byte);
+            auto tmp = in.get(C::bitwise_last) * (in.get(C::bitwise_acc_ic) - in.get(C::bitwise_ic_byte));
             tmp *= scaling_factor;
             std::get<9>(evals) += typename Accumulator::View(tmp);
         }
         { // BITW_ACC_REL_A
             using Accumulator = typename std::tuple_element_t<10, ContainerOverSubrelations>;
             auto tmp =
-                ((new_term.bitwise_acc_ia - new_term.bitwise_ia_byte) - FF(256) * new_term.bitwise_acc_ia_shift) *
-                (FF(1) - new_term.bitwise_last);
+                ((in.get(C::bitwise_acc_ia) - in.get(C::bitwise_ia_byte)) - FF(256) * in.get(C::bitwise_acc_ia_shift)) *
+                (FF(1) - in.get(C::bitwise_last));
             tmp *= scaling_factor;
             std::get<10>(evals) += typename Accumulator::View(tmp);
         }
         { // BITW_ACC_REL_B
             using Accumulator = typename std::tuple_element_t<11, ContainerOverSubrelations>;
             auto tmp =
-                ((new_term.bitwise_acc_ib - new_term.bitwise_ib_byte) - FF(256) * new_term.bitwise_acc_ib_shift) *
-                (FF(1) - new_term.bitwise_last);
+                ((in.get(C::bitwise_acc_ib) - in.get(C::bitwise_ib_byte)) - FF(256) * in.get(C::bitwise_acc_ib_shift)) *
+                (FF(1) - in.get(C::bitwise_last));
             tmp *= scaling_factor;
             std::get<11>(evals) += typename Accumulator::View(tmp);
         }
         { // BITW_ACC_REL_C
             using Accumulator = typename std::tuple_element_t<12, ContainerOverSubrelations>;
             auto tmp =
-                ((new_term.bitwise_acc_ic - new_term.bitwise_ic_byte) - FF(256) * new_term.bitwise_acc_ic_shift) *
-                (FF(1) - new_term.bitwise_last);
+                ((in.get(C::bitwise_acc_ic) - in.get(C::bitwise_ic_byte)) - FF(256) * in.get(C::bitwise_acc_ic_shift)) *
+                (FF(1) - in.get(C::bitwise_last));
             tmp *= scaling_factor;
             std::get<12>(evals) += typename Accumulator::View(tmp);
         }

--- a/barretenberg/cpp/src/barretenberg/vm2/generated/relations/class_id_derivation.hpp
+++ b/barretenberg/cpp/src/barretenberg/vm2/generated/relations/class_id_derivation.hpp
@@ -5,6 +5,7 @@
 
 #include "barretenberg/relations/relation_parameters.hpp"
 #include "barretenberg/relations/relation_types.hpp"
+#include "barretenberg/vm2/generated/columns.hpp"
 
 namespace bb::avm2 {
 
@@ -16,28 +17,30 @@ template <typename FF_> class class_id_derivationImpl {
 
     template <typename AllEntities> inline static bool skip(const AllEntities& in)
     {
-        const auto& new_term = in;
-        return (new_term.class_id_derivation_sel).is_zero();
+        using C = ColumnAndShifts;
+        return (in.get(C::class_id_derivation_sel)).is_zero();
     }
 
     template <typename ContainerOverSubrelations, typename AllEntities>
     void static accumulate(ContainerOverSubrelations& evals,
-                           const AllEntities& new_term,
+                           const AllEntities& in,
                            [[maybe_unused]] const RelationParameters<FF>&,
                            [[maybe_unused]] const FF& scaling_factor)
     {
+        using C = ColumnAndShifts;
+
         const auto constants_GENERATOR_INDEX__CONTRACT_LEAF = FF(16);
 
         {
             using Accumulator = typename std::tuple_element_t<0, ContainerOverSubrelations>;
-            auto tmp = new_term.class_id_derivation_sel * (FF(1) - new_term.class_id_derivation_sel);
+            auto tmp = in.get(C::class_id_derivation_sel) * (FF(1) - in.get(C::class_id_derivation_sel));
             tmp *= scaling_factor;
             std::get<0>(evals) += typename Accumulator::View(tmp);
         }
         {
             using Accumulator = typename std::tuple_element_t<1, ContainerOverSubrelations>;
-            auto tmp = new_term.class_id_derivation_sel * (new_term.class_id_derivation_temp_constant_for_lookup -
-                                                           constants_GENERATOR_INDEX__CONTRACT_LEAF);
+            auto tmp = in.get(C::class_id_derivation_sel) * (in.get(C::class_id_derivation_temp_constant_for_lookup) -
+                                                             constants_GENERATOR_INDEX__CONTRACT_LEAF);
             tmp *= scaling_factor;
             std::get<1>(evals) += typename Accumulator::View(tmp);
         }

--- a/barretenberg/cpp/src/barretenberg/vm2/generated/relations/context.hpp
+++ b/barretenberg/cpp/src/barretenberg/vm2/generated/relations/context.hpp
@@ -5,6 +5,7 @@
 
 #include "barretenberg/relations/relation_parameters.hpp"
 #include "barretenberg/relations/relation_types.hpp"
+#include "barretenberg/vm2/generated/columns.hpp"
 
 namespace bb::avm2 {
 
@@ -16,100 +17,104 @@ template <typename FF_> class contextImpl {
 
     template <typename AllEntities> inline static bool skip(const AllEntities& in)
     {
-        const auto& new_term = in;
-        return (new_term.execution_sel).is_zero();
+        using C = ColumnAndShifts;
+        return (in.get(C::execution_sel)).is_zero();
     }
 
     template <typename ContainerOverSubrelations, typename AllEntities>
     void static accumulate(ContainerOverSubrelations& evals,
-                           const AllEntities& new_term,
+                           const AllEntities& in,
                            [[maybe_unused]] const RelationParameters<FF>&,
                            [[maybe_unused]] const FF& scaling_factor)
     {
-        const auto execution_CALL = new_term.execution_sel_call + new_term.execution_sel_static_call;
-        const auto execution_NOT_FIRST = (FF(1) - new_term.precomputed_first_row);
+        using C = ColumnAndShifts;
+
+        const auto execution_CALL = in.get(C::execution_sel_call) + in.get(C::execution_sel_static_call);
+        const auto execution_NOT_FIRST = (FF(1) - in.get(C::precomputed_first_row));
 
         {
             using Accumulator = typename std::tuple_element_t<0, ContainerOverSubrelations>;
-            auto tmp = execution_CALL * new_term.precomputed_first_row;
+            auto tmp = execution_CALL * in.get(C::precomputed_first_row);
             tmp *= scaling_factor;
             std::get<0>(evals) += typename Accumulator::View(tmp);
         }
         { // INCR_CONTEXT_ID
             using Accumulator = typename std::tuple_element_t<1, ContainerOverSubrelations>;
             auto tmp =
-                execution_NOT_FIRST * new_term.execution_sel_shift *
-                (new_term.execution_next_context_id_shift - (new_term.execution_next_context_id + execution_CALL));
+                execution_NOT_FIRST * in.get(C::execution_sel_shift) *
+                (in.get(C::execution_next_context_id_shift) - (in.get(C::execution_next_context_id) + execution_CALL));
             tmp *= scaling_factor;
             std::get<1>(evals) += typename Accumulator::View(tmp);
         }
         { // NEXT_CONTEXT_ID
             using Accumulator = typename std::tuple_element_t<2, ContainerOverSubrelations>;
-            auto tmp = execution_NOT_FIRST * new_term.execution_sel_shift *
-                       (((new_term.execution_next_context_id - new_term.execution_context_id) * execution_CALL +
-                         new_term.execution_context_id + new_term.precomputed_first_row) -
-                        new_term.execution_context_id_shift);
+            auto tmp = execution_NOT_FIRST * in.get(C::execution_sel_shift) *
+                       (((in.get(C::execution_next_context_id) - in.get(C::execution_context_id)) * execution_CALL +
+                         in.get(C::execution_context_id) + in.get(C::precomputed_first_row)) -
+                        in.get(C::execution_context_id_shift));
             tmp *= scaling_factor;
             std::get<2>(evals) += typename Accumulator::View(tmp);
         }
         { // NEXT_PARENT_ID
             using Accumulator = typename std::tuple_element_t<3, ContainerOverSubrelations>;
-            auto tmp = execution_NOT_FIRST * new_term.execution_sel_shift *
-                       (((new_term.execution_context_id - new_term.execution_parent_id) *
-                             (execution_CALL + new_term.precomputed_first_row) +
-                         new_term.execution_parent_id) -
-                        new_term.execution_parent_id_shift);
+            auto tmp = execution_NOT_FIRST * in.get(C::execution_sel_shift) *
+                       (((in.get(C::execution_context_id) - in.get(C::execution_parent_id)) *
+                             (execution_CALL + in.get(C::precomputed_first_row)) +
+                         in.get(C::execution_parent_id)) -
+                        in.get(C::execution_parent_id_shift));
             tmp *= scaling_factor;
             std::get<3>(evals) += typename Accumulator::View(tmp);
         }
         { // NEXT_PC
             using Accumulator = typename std::tuple_element_t<4, ContainerOverSubrelations>;
-            auto tmp = execution_NOT_FIRST * new_term.execution_sel_shift *
-                       (new_term.execution_pc_shift - (FF(1) - execution_CALL) * new_term.execution_next_pc);
+            auto tmp = execution_NOT_FIRST * in.get(C::execution_sel_shift) *
+                       (in.get(C::execution_pc_shift) - (FF(1) - execution_CALL) * in.get(C::execution_next_pc));
             tmp *= scaling_factor;
             std::get<4>(evals) += typename Accumulator::View(tmp);
         }
         { // NEXT_MSG_SENDER
             using Accumulator = typename std::tuple_element_t<5, ContainerOverSubrelations>;
-            auto tmp = execution_NOT_FIRST * new_term.execution_sel_shift *
-                       (((new_term.execution_contract_address - new_term.execution_msg_sender) * execution_CALL +
-                         new_term.execution_msg_sender) -
-                        new_term.execution_msg_sender_shift);
+            auto tmp = execution_NOT_FIRST * in.get(C::execution_sel_shift) *
+                       (((in.get(C::execution_contract_address) - in.get(C::execution_msg_sender)) * execution_CALL +
+                         in.get(C::execution_msg_sender)) -
+                        in.get(C::execution_msg_sender_shift));
             tmp *= scaling_factor;
             std::get<5>(evals) += typename Accumulator::View(tmp);
         }
         { // NEXT_CONTRACT_ADDR
             using Accumulator = typename std::tuple_element_t<6, ContainerOverSubrelations>;
-            auto tmp = execution_NOT_FIRST * new_term.execution_sel_shift *
-                       (((new_term.execution_reg3 - new_term.execution_contract_address) * execution_CALL +
-                         new_term.execution_contract_address) -
-                        new_term.execution_contract_address_shift);
+            auto tmp = execution_NOT_FIRST * in.get(C::execution_sel_shift) *
+                       (((in.get(C::execution_reg3) - in.get(C::execution_contract_address)) * execution_CALL +
+                         in.get(C::execution_contract_address)) -
+                        in.get(C::execution_contract_address_shift));
             tmp *= scaling_factor;
             std::get<6>(evals) += typename Accumulator::View(tmp);
         }
         { // NEXT_IS_STATIC
             using Accumulator = typename std::tuple_element_t<7, ContainerOverSubrelations>;
-            auto tmp = execution_NOT_FIRST * new_term.execution_sel_shift *
-                       (new_term.execution_is_static_shift -
-                        (new_term.execution_sel_static_call + (FF(1) - execution_CALL) * new_term.execution_is_static));
+            auto tmp =
+                execution_NOT_FIRST * in.get(C::execution_sel_shift) *
+                (in.get(C::execution_is_static_shift) -
+                 (in.get(C::execution_sel_static_call) + (FF(1) - execution_CALL) * in.get(C::execution_is_static)));
             tmp *= scaling_factor;
             std::get<7>(evals) += typename Accumulator::View(tmp);
         }
         { // NEXT_CD_OFFSET
             using Accumulator = typename std::tuple_element_t<8, ContainerOverSubrelations>;
-            auto tmp = execution_NOT_FIRST * new_term.execution_sel_shift *
-                       (((new_term.execution_rop4 - new_term.execution_parent_calldata_offset_addr) * execution_CALL +
-                         new_term.execution_parent_calldata_offset_addr) -
-                        new_term.execution_parent_calldata_offset_addr_shift);
+            auto tmp =
+                execution_NOT_FIRST * in.get(C::execution_sel_shift) *
+                (((in.get(C::execution_rop4) - in.get(C::execution_parent_calldata_offset_addr)) * execution_CALL +
+                  in.get(C::execution_parent_calldata_offset_addr)) -
+                 in.get(C::execution_parent_calldata_offset_addr_shift));
             tmp *= scaling_factor;
             std::get<8>(evals) += typename Accumulator::View(tmp);
         }
         { // NEXT_CD_SIZE
             using Accumulator = typename std::tuple_element_t<9, ContainerOverSubrelations>;
-            auto tmp = execution_NOT_FIRST * new_term.execution_sel_shift *
-                       (((new_term.execution_rop5 - new_term.execution_parent_calldata_size_addr) * execution_CALL +
-                         new_term.execution_parent_calldata_size_addr) -
-                        new_term.execution_parent_calldata_size_addr_shift);
+            auto tmp = execution_NOT_FIRST * in.get(C::execution_sel_shift) *
+                       (((in.get(C::execution_rop5) - in.get(C::execution_parent_calldata_size_addr)) * execution_CALL +
+                         in.get(C::execution_parent_calldata_size_addr)) -
+                        in.get(C::execution_parent_calldata_size_addr_shift));
             tmp *= scaling_factor;
             std::get<9>(evals) += typename Accumulator::View(tmp);
         }

--- a/barretenberg/cpp/src/barretenberg/vm2/generated/relations/ecc.hpp
+++ b/barretenberg/cpp/src/barretenberg/vm2/generated/relations/ecc.hpp
@@ -5,6 +5,7 @@
 
 #include "barretenberg/relations/relation_parameters.hpp"
 #include "barretenberg/relations/relation_types.hpp"
+#include "barretenberg/vm2/generated/columns.hpp"
 
 namespace bb::avm2 {
 
@@ -17,156 +18,159 @@ template <typename FF_> class eccImpl {
 
     template <typename AllEntities> inline static bool skip(const AllEntities& in)
     {
-        const auto& new_term = in;
-        return (new_term.ecc_sel).is_zero();
+        using C = ColumnAndShifts;
+        return (in.get(C::ecc_sel)).is_zero();
     }
 
     template <typename ContainerOverSubrelations, typename AllEntities>
     void static accumulate(ContainerOverSubrelations& evals,
-                           const AllEntities& new_term,
+                           const AllEntities& in,
                            [[maybe_unused]] const RelationParameters<FF>&,
                            [[maybe_unused]] const FF& scaling_factor)
     {
+        using C = ColumnAndShifts;
+
         const auto ecc_INFINITY_X = FF(0);
         const auto ecc_INFINITY_Y = FF(0);
-        const auto ecc_X_DIFF = (new_term.ecc_q_x - new_term.ecc_p_x);
-        const auto ecc_Y_DIFF = (new_term.ecc_q_y - new_term.ecc_p_y);
-        const auto ecc_INFINITY_PRED = new_term.ecc_x_match * (FF(1) - new_term.ecc_y_match);
-        const auto ecc_BOTH_INF = new_term.ecc_p_is_inf * new_term.ecc_q_is_inf;
-        const auto ecc_BOTH_NON_INF = (FF(1) - new_term.ecc_p_is_inf) * (FF(1) - new_term.ecc_q_is_inf);
+        const auto ecc_X_DIFF = (in.get(C::ecc_q_x) - in.get(C::ecc_p_x));
+        const auto ecc_Y_DIFF = (in.get(C::ecc_q_y) - in.get(C::ecc_p_y));
+        const auto ecc_INFINITY_PRED = in.get(C::ecc_x_match) * (FF(1) - in.get(C::ecc_y_match));
+        const auto ecc_BOTH_INF = in.get(C::ecc_p_is_inf) * in.get(C::ecc_q_is_inf);
+        const auto ecc_BOTH_NON_INF = (FF(1) - in.get(C::ecc_p_is_inf)) * (FF(1) - in.get(C::ecc_q_is_inf));
         const auto ecc_COMPUTED_R_X =
-            ((new_term.ecc_lambda * new_term.ecc_lambda - new_term.ecc_p_x) - new_term.ecc_q_x);
-        const auto ecc_COMPUTED_R_Y = (new_term.ecc_lambda * (new_term.ecc_p_x - new_term.ecc_r_x) - new_term.ecc_p_y);
-        const auto ecc_EITHER_INF = ((new_term.ecc_p_is_inf + new_term.ecc_q_is_inf) - FF(2) * ecc_BOTH_INF);
+            ((in.get(C::ecc_lambda) * in.get(C::ecc_lambda) - in.get(C::ecc_p_x)) - in.get(C::ecc_q_x));
+        const auto ecc_COMPUTED_R_Y =
+            (in.get(C::ecc_lambda) * (in.get(C::ecc_p_x) - in.get(C::ecc_r_x)) - in.get(C::ecc_p_y));
+        const auto ecc_EITHER_INF = ((in.get(C::ecc_p_is_inf) + in.get(C::ecc_q_is_inf)) - FF(2) * ecc_BOTH_INF);
         const auto ecc_USE_COMPUTED_RESULT =
-            (FF(1) - new_term.ecc_p_is_inf) * (FF(1) - new_term.ecc_q_is_inf) * (FF(1) - ecc_INFINITY_PRED);
+            (FF(1) - in.get(C::ecc_p_is_inf)) * (FF(1) - in.get(C::ecc_q_is_inf)) * (FF(1) - ecc_INFINITY_PRED);
 
         {
             using Accumulator = typename std::tuple_element_t<0, ContainerOverSubrelations>;
-            auto tmp = new_term.ecc_sel * (FF(1) - new_term.ecc_sel);
+            auto tmp = in.get(C::ecc_sel) * (FF(1) - in.get(C::ecc_sel));
             tmp *= scaling_factor;
             std::get<0>(evals) += typename Accumulator::View(tmp);
         }
         {
             using Accumulator = typename std::tuple_element_t<1, ContainerOverSubrelations>;
-            auto tmp = new_term.ecc_double_op * (FF(1) - new_term.ecc_double_op);
+            auto tmp = in.get(C::ecc_double_op) * (FF(1) - in.get(C::ecc_double_op));
             tmp *= scaling_factor;
             std::get<1>(evals) += typename Accumulator::View(tmp);
         }
         {
             using Accumulator = typename std::tuple_element_t<2, ContainerOverSubrelations>;
-            auto tmp = new_term.ecc_add_op * (FF(1) - new_term.ecc_add_op);
+            auto tmp = in.get(C::ecc_add_op) * (FF(1) - in.get(C::ecc_add_op));
             tmp *= scaling_factor;
             std::get<2>(evals) += typename Accumulator::View(tmp);
         }
         {
             using Accumulator = typename std::tuple_element_t<3, ContainerOverSubrelations>;
-            auto tmp = (new_term.ecc_sel - (new_term.ecc_double_op + new_term.ecc_add_op + ecc_INFINITY_PRED));
+            auto tmp = (in.get(C::ecc_sel) - (in.get(C::ecc_double_op) + in.get(C::ecc_add_op) + ecc_INFINITY_PRED));
             tmp *= scaling_factor;
             std::get<3>(evals) += typename Accumulator::View(tmp);
         }
         {
             using Accumulator = typename std::tuple_element_t<4, ContainerOverSubrelations>;
-            auto tmp = new_term.ecc_p_is_inf * (FF(1) - new_term.ecc_p_is_inf);
+            auto tmp = in.get(C::ecc_p_is_inf) * (FF(1) - in.get(C::ecc_p_is_inf));
             tmp *= scaling_factor;
             std::get<4>(evals) += typename Accumulator::View(tmp);
         }
         {
             using Accumulator = typename std::tuple_element_t<5, ContainerOverSubrelations>;
-            auto tmp = new_term.ecc_q_is_inf * (FF(1) - new_term.ecc_q_is_inf);
+            auto tmp = in.get(C::ecc_q_is_inf) * (FF(1) - in.get(C::ecc_q_is_inf));
             tmp *= scaling_factor;
             std::get<5>(evals) += typename Accumulator::View(tmp);
         }
         {
             using Accumulator = typename std::tuple_element_t<6, ContainerOverSubrelations>;
-            auto tmp = new_term.ecc_r_is_inf * (FF(1) - new_term.ecc_r_is_inf);
+            auto tmp = in.get(C::ecc_r_is_inf) * (FF(1) - in.get(C::ecc_r_is_inf));
             tmp *= scaling_factor;
             std::get<6>(evals) += typename Accumulator::View(tmp);
         }
         {
             using Accumulator = typename std::tuple_element_t<7, ContainerOverSubrelations>;
-            auto tmp = new_term.ecc_x_match * (FF(1) - new_term.ecc_x_match);
+            auto tmp = in.get(C::ecc_x_match) * (FF(1) - in.get(C::ecc_x_match));
             tmp *= scaling_factor;
             std::get<7>(evals) += typename Accumulator::View(tmp);
         }
         {
             using Accumulator = typename std::tuple_element_t<8, ContainerOverSubrelations>;
             auto tmp =
-                new_term.ecc_sel *
-                ((ecc_X_DIFF * (new_term.ecc_x_match * (FF(1) - new_term.ecc_inv_x_diff) + new_term.ecc_inv_x_diff) -
-                  FF(1)) +
-                 new_term.ecc_x_match);
+                in.get(C::ecc_sel) * ((ecc_X_DIFF * (in.get(C::ecc_x_match) * (FF(1) - in.get(C::ecc_inv_x_diff)) +
+                                                     in.get(C::ecc_inv_x_diff)) -
+                                       FF(1)) +
+                                      in.get(C::ecc_x_match));
             tmp *= scaling_factor;
             std::get<8>(evals) += typename Accumulator::View(tmp);
         }
         {
             using Accumulator = typename std::tuple_element_t<9, ContainerOverSubrelations>;
-            auto tmp = new_term.ecc_y_match * (FF(1) - new_term.ecc_y_match);
+            auto tmp = in.get(C::ecc_y_match) * (FF(1) - in.get(C::ecc_y_match));
             tmp *= scaling_factor;
             std::get<9>(evals) += typename Accumulator::View(tmp);
         }
         {
             using Accumulator = typename std::tuple_element_t<10, ContainerOverSubrelations>;
             auto tmp =
-                new_term.ecc_sel *
-                ((ecc_Y_DIFF * (new_term.ecc_y_match * (FF(1) - new_term.ecc_inv_y_diff) + new_term.ecc_inv_y_diff) -
-                  FF(1)) +
-                 new_term.ecc_y_match);
+                in.get(C::ecc_sel) * ((ecc_Y_DIFF * (in.get(C::ecc_y_match) * (FF(1) - in.get(C::ecc_inv_y_diff)) +
+                                                     in.get(C::ecc_inv_y_diff)) -
+                                       FF(1)) +
+                                      in.get(C::ecc_y_match));
             tmp *= scaling_factor;
             std::get<10>(evals) += typename Accumulator::View(tmp);
         }
         { // DOUBLE_PRED
             using Accumulator = typename std::tuple_element_t<11, ContainerOverSubrelations>;
-            auto tmp = (new_term.ecc_double_op - new_term.ecc_x_match * new_term.ecc_y_match);
+            auto tmp = (in.get(C::ecc_double_op) - in.get(C::ecc_x_match) * in.get(C::ecc_y_match));
             tmp *= scaling_factor;
             std::get<11>(evals) += typename Accumulator::View(tmp);
         }
         { // INFINITY_RESULT
             using Accumulator = typename std::tuple_element_t<12, ContainerOverSubrelations>;
-            auto tmp = new_term.ecc_sel *
-                       (new_term.ecc_result_infinity - (ecc_INFINITY_PRED * ecc_BOTH_NON_INF + ecc_BOTH_INF));
+            auto tmp = in.get(C::ecc_sel) *
+                       (in.get(C::ecc_result_infinity) - (ecc_INFINITY_PRED * ecc_BOTH_NON_INF + ecc_BOTH_INF));
             tmp *= scaling_factor;
             std::get<12>(evals) += typename Accumulator::View(tmp);
         }
         {
             using Accumulator = typename std::tuple_element_t<13, ContainerOverSubrelations>;
-            auto tmp = (FF(1) - new_term.ecc_result_infinity) * new_term.ecc_double_op *
-                       (FF(2) * new_term.ecc_p_y * new_term.ecc_inv_2_p_y - FF(1));
+            auto tmp = (FF(1) - in.get(C::ecc_result_infinity)) * in.get(C::ecc_double_op) *
+                       (FF(2) * in.get(C::ecc_p_y) * in.get(C::ecc_inv_2_p_y) - FF(1));
             tmp *= scaling_factor;
             std::get<13>(evals) += typename Accumulator::View(tmp);
         }
         { // COMPUTED_LAMBDA
             using Accumulator = typename std::tuple_element_t<14, ContainerOverSubrelations>;
-            auto tmp = new_term.ecc_sel *
-                       (new_term.ecc_lambda -
-                        (new_term.ecc_double_op * FF(3) * new_term.ecc_p_x * new_term.ecc_p_x * new_term.ecc_inv_2_p_y +
-                         new_term.ecc_add_op * ecc_Y_DIFF * new_term.ecc_inv_x_diff));
+            auto tmp = in.get(C::ecc_sel) *
+                       (in.get(C::ecc_lambda) - (in.get(C::ecc_double_op) * FF(3) * in.get(C::ecc_p_x) *
+                                                     in.get(C::ecc_p_x) * in.get(C::ecc_inv_2_p_y) +
+                                                 in.get(C::ecc_add_op) * ecc_Y_DIFF * in.get(C::ecc_inv_x_diff)));
             tmp *= scaling_factor;
             std::get<14>(evals) += typename Accumulator::View(tmp);
         }
         { // OUTPUT_X_COORD
             using Accumulator = typename std::tuple_element_t<15, ContainerOverSubrelations>;
-            auto tmp =
-                new_term.ecc_sel * (((new_term.ecc_r_x - ecc_EITHER_INF * (new_term.ecc_p_is_inf * new_term.ecc_q_x +
-                                                                           new_term.ecc_q_is_inf * new_term.ecc_p_x)) -
-                                     new_term.ecc_result_infinity * ecc_INFINITY_X) -
-                                    ecc_USE_COMPUTED_RESULT * ecc_COMPUTED_R_X);
+            auto tmp = in.get(C::ecc_sel) *
+                       (((in.get(C::ecc_r_x) - ecc_EITHER_INF * (in.get(C::ecc_p_is_inf) * in.get(C::ecc_q_x) +
+                                                                 in.get(C::ecc_q_is_inf) * in.get(C::ecc_p_x))) -
+                         in.get(C::ecc_result_infinity) * ecc_INFINITY_X) -
+                        ecc_USE_COMPUTED_RESULT * ecc_COMPUTED_R_X);
             tmp *= scaling_factor;
             std::get<15>(evals) += typename Accumulator::View(tmp);
         }
         { // OUTPUT_Y_COORD
             using Accumulator = typename std::tuple_element_t<16, ContainerOverSubrelations>;
-            auto tmp =
-                new_term.ecc_sel * (((new_term.ecc_r_y - ecc_EITHER_INF * (new_term.ecc_p_is_inf * new_term.ecc_q_y +
-                                                                           new_term.ecc_q_is_inf * new_term.ecc_p_y)) -
-                                     new_term.ecc_result_infinity * ecc_INFINITY_Y) -
-                                    ecc_USE_COMPUTED_RESULT * ecc_COMPUTED_R_Y);
+            auto tmp = in.get(C::ecc_sel) *
+                       (((in.get(C::ecc_r_y) - ecc_EITHER_INF * (in.get(C::ecc_p_is_inf) * in.get(C::ecc_q_y) +
+                                                                 in.get(C::ecc_q_is_inf) * in.get(C::ecc_p_y))) -
+                         in.get(C::ecc_result_infinity) * ecc_INFINITY_Y) -
+                        ecc_USE_COMPUTED_RESULT * ecc_COMPUTED_R_Y);
             tmp *= scaling_factor;
             std::get<16>(evals) += typename Accumulator::View(tmp);
         }
         { // OUTPUT_INF_FLAG
             using Accumulator = typename std::tuple_element_t<17, ContainerOverSubrelations>;
-            auto tmp = new_term.ecc_sel * (new_term.ecc_r_is_inf - new_term.ecc_result_infinity);
+            auto tmp = in.get(C::ecc_sel) * (in.get(C::ecc_r_is_inf) - in.get(C::ecc_result_infinity));
             tmp *= scaling_factor;
             std::get<17>(evals) += typename Accumulator::View(tmp);
         }

--- a/barretenberg/cpp/src/barretenberg/vm2/generated/relations/ff_gt.hpp
+++ b/barretenberg/cpp/src/barretenberg/vm2/generated/relations/ff_gt.hpp
@@ -5,6 +5,7 @@
 
 #include "barretenberg/relations/relation_parameters.hpp"
 #include "barretenberg/relations/relation_types.hpp"
+#include "barretenberg/vm2/generated/columns.hpp"
 
 namespace bb::avm2 {
 
@@ -17,202 +18,204 @@ template <typename FF_> class ff_gtImpl {
 
     template <typename AllEntities> inline static bool skip(const AllEntities& in)
     {
-        const auto& new_term = in;
-        return (new_term.ff_gt_sel).is_zero();
+        using C = ColumnAndShifts;
+        return (in.get(C::ff_gt_sel)).is_zero();
     }
 
     template <typename ContainerOverSubrelations, typename AllEntities>
     void static accumulate(ContainerOverSubrelations& evals,
-                           const AllEntities& new_term,
+                           const AllEntities& in,
                            [[maybe_unused]] const RelationParameters<FF>&,
                            [[maybe_unused]] const FF& scaling_factor)
     {
+        using C = ColumnAndShifts;
+
         const auto ff_gt_POW_128 = FF(uint256_t{ 0UL, 0UL, 1UL, 0UL });
         const auto ff_gt_P_LO = FF(uint256_t{ 4891460686036598785UL, 2896914383306846353UL, 0UL, 0UL });
         const auto ff_gt_P_HI = FF(uint256_t{ 13281191951274694749UL, 3486998266802970665UL, 0UL, 0UL });
         const auto ff_gt_A_SUB_B_LO =
-            ((new_term.ff_gt_a_lo - new_term.ff_gt_b_lo) - FF(1)) + new_term.ff_gt_borrow * ff_gt_POW_128;
-        const auto ff_gt_A_SUB_B_HI = ((new_term.ff_gt_a_hi - new_term.ff_gt_b_hi) - new_term.ff_gt_borrow);
+            ((in.get(C::ff_gt_a_lo) - in.get(C::ff_gt_b_lo)) - FF(1)) + in.get(C::ff_gt_borrow) * ff_gt_POW_128;
+        const auto ff_gt_A_SUB_B_HI = ((in.get(C::ff_gt_a_hi) - in.get(C::ff_gt_b_hi)) - in.get(C::ff_gt_borrow));
         const auto ff_gt_B_SUB_A_LO =
-            (new_term.ff_gt_b_lo - new_term.ff_gt_a_lo) + new_term.ff_gt_borrow * ff_gt_POW_128;
-        const auto ff_gt_B_SUB_A_HI = ((new_term.ff_gt_b_hi - new_term.ff_gt_a_hi) - new_term.ff_gt_borrow);
-        const auto ff_gt_IS_GT = new_term.ff_gt_sel_gt * new_term.ff_gt_result;
+            (in.get(C::ff_gt_b_lo) - in.get(C::ff_gt_a_lo)) + in.get(C::ff_gt_borrow) * ff_gt_POW_128;
+        const auto ff_gt_B_SUB_A_HI = ((in.get(C::ff_gt_b_hi) - in.get(C::ff_gt_a_hi)) - in.get(C::ff_gt_borrow));
+        const auto ff_gt_IS_GT = in.get(C::ff_gt_sel_gt) * in.get(C::ff_gt_result);
 
         {
             using Accumulator = typename std::tuple_element_t<0, ContainerOverSubrelations>;
-            auto tmp = new_term.ff_gt_sel * (FF(1) - new_term.ff_gt_sel);
+            auto tmp = in.get(C::ff_gt_sel) * (FF(1) - in.get(C::ff_gt_sel));
             tmp *= scaling_factor;
             std::get<0>(evals) += typename Accumulator::View(tmp);
         }
         {
             using Accumulator = typename std::tuple_element_t<1, ContainerOverSubrelations>;
-            auto tmp = new_term.ff_gt_result * (FF(1) - new_term.ff_gt_result);
+            auto tmp = in.get(C::ff_gt_result) * (FF(1) - in.get(C::ff_gt_result));
             tmp *= scaling_factor;
             std::get<1>(evals) += typename Accumulator::View(tmp);
         }
         {
             using Accumulator = typename std::tuple_element_t<2, ContainerOverSubrelations>;
-            auto tmp = new_term.ff_gt_sel_gt * (FF(1) - new_term.ff_gt_sel_gt);
+            auto tmp = in.get(C::ff_gt_sel_gt) * (FF(1) - in.get(C::ff_gt_sel_gt));
             tmp *= scaling_factor;
             std::get<2>(evals) += typename Accumulator::View(tmp);
         }
         {
             using Accumulator = typename std::tuple_element_t<3, ContainerOverSubrelations>;
-            auto tmp = new_term.ff_gt_sel * (FF(128) - new_term.ff_gt_constant_128);
+            auto tmp = in.get(C::ff_gt_sel) * (FF(128) - in.get(C::ff_gt_constant_128));
             tmp *= scaling_factor;
             std::get<3>(evals) += typename Accumulator::View(tmp);
         }
         { // A_DECOMPOSITION
             using Accumulator = typename std::tuple_element_t<4, ContainerOverSubrelations>;
-            auto tmp = new_term.ff_gt_sel_gt *
-                       (new_term.ff_gt_a - (new_term.ff_gt_a_lo + ff_gt_POW_128 * new_term.ff_gt_a_hi));
+            auto tmp = in.get(C::ff_gt_sel_gt) *
+                       (in.get(C::ff_gt_a) - (in.get(C::ff_gt_a_lo) + ff_gt_POW_128 * in.get(C::ff_gt_a_hi)));
             tmp *= scaling_factor;
             std::get<4>(evals) += typename Accumulator::View(tmp);
         }
         {
             using Accumulator = typename std::tuple_element_t<5, ContainerOverSubrelations>;
-            auto tmp = new_term.ff_gt_p_a_borrow * (FF(1) - new_term.ff_gt_p_a_borrow);
+            auto tmp = in.get(C::ff_gt_p_a_borrow) * (FF(1) - in.get(C::ff_gt_p_a_borrow));
             tmp *= scaling_factor;
             std::get<5>(evals) += typename Accumulator::View(tmp);
         }
         { // P_SUB_A_LO
             using Accumulator = typename std::tuple_element_t<6, ContainerOverSubrelations>;
-            auto tmp = new_term.ff_gt_sel_gt *
-                       (new_term.ff_gt_p_sub_a_lo -
-                        (((ff_gt_P_LO - new_term.ff_gt_a_lo) - FF(1)) + new_term.ff_gt_p_a_borrow * ff_gt_POW_128));
+            auto tmp = in.get(C::ff_gt_sel_gt) *
+                       (in.get(C::ff_gt_p_sub_a_lo) -
+                        (((ff_gt_P_LO - in.get(C::ff_gt_a_lo)) - FF(1)) + in.get(C::ff_gt_p_a_borrow) * ff_gt_POW_128));
             tmp *= scaling_factor;
             std::get<6>(evals) += typename Accumulator::View(tmp);
         }
         { // P_SUB_A_HI
             using Accumulator = typename std::tuple_element_t<7, ContainerOverSubrelations>;
-            auto tmp = new_term.ff_gt_sel_gt *
-                       (new_term.ff_gt_p_sub_a_hi - ((ff_gt_P_HI - new_term.ff_gt_a_hi) - new_term.ff_gt_p_a_borrow));
+            auto tmp = in.get(C::ff_gt_sel_gt) * (in.get(C::ff_gt_p_sub_a_hi) -
+                                                  ((ff_gt_P_HI - in.get(C::ff_gt_a_hi)) - in.get(C::ff_gt_p_a_borrow)));
             tmp *= scaling_factor;
             std::get<7>(evals) += typename Accumulator::View(tmp);
         }
         { // B_DECOMPOSITION
             using Accumulator = typename std::tuple_element_t<8, ContainerOverSubrelations>;
-            auto tmp = new_term.ff_gt_sel_gt *
-                       (new_term.ff_gt_b - (new_term.ff_gt_b_lo + ff_gt_POW_128 * new_term.ff_gt_b_hi));
+            auto tmp = in.get(C::ff_gt_sel_gt) *
+                       (in.get(C::ff_gt_b) - (in.get(C::ff_gt_b_lo) + ff_gt_POW_128 * in.get(C::ff_gt_b_hi)));
             tmp *= scaling_factor;
             std::get<8>(evals) += typename Accumulator::View(tmp);
         }
         {
             using Accumulator = typename std::tuple_element_t<9, ContainerOverSubrelations>;
-            auto tmp = new_term.ff_gt_p_b_borrow * (FF(1) - new_term.ff_gt_p_b_borrow);
+            auto tmp = in.get(C::ff_gt_p_b_borrow) * (FF(1) - in.get(C::ff_gt_p_b_borrow));
             tmp *= scaling_factor;
             std::get<9>(evals) += typename Accumulator::View(tmp);
         }
         { // P_SUB_B_LO
             using Accumulator = typename std::tuple_element_t<10, ContainerOverSubrelations>;
-            auto tmp = new_term.ff_gt_sel_gt *
-                       (new_term.ff_gt_p_sub_b_lo -
-                        (((ff_gt_P_LO - new_term.ff_gt_b_lo) - FF(1)) + new_term.ff_gt_p_b_borrow * ff_gt_POW_128));
+            auto tmp = in.get(C::ff_gt_sel_gt) *
+                       (in.get(C::ff_gt_p_sub_b_lo) -
+                        (((ff_gt_P_LO - in.get(C::ff_gt_b_lo)) - FF(1)) + in.get(C::ff_gt_p_b_borrow) * ff_gt_POW_128));
             tmp *= scaling_factor;
             std::get<10>(evals) += typename Accumulator::View(tmp);
         }
         { // P_SUB_B_HI
             using Accumulator = typename std::tuple_element_t<11, ContainerOverSubrelations>;
-            auto tmp = new_term.ff_gt_sel_gt *
-                       (new_term.ff_gt_p_sub_b_hi - ((ff_gt_P_HI - new_term.ff_gt_b_hi) - new_term.ff_gt_p_b_borrow));
+            auto tmp = in.get(C::ff_gt_sel_gt) * (in.get(C::ff_gt_p_sub_b_hi) -
+                                                  ((ff_gt_P_HI - in.get(C::ff_gt_b_hi)) - in.get(C::ff_gt_p_b_borrow)));
             tmp *= scaling_factor;
             std::get<11>(evals) += typename Accumulator::View(tmp);
         }
         { // RES_LO
             using Accumulator = typename std::tuple_element_t<12, ContainerOverSubrelations>;
             auto tmp =
-                new_term.ff_gt_sel_gt *
-                (new_term.ff_gt_res_lo - (ff_gt_A_SUB_B_LO * ff_gt_IS_GT + ff_gt_B_SUB_A_LO * (FF(1) - ff_gt_IS_GT)));
+                in.get(C::ff_gt_sel_gt) *
+                (in.get(C::ff_gt_res_lo) - (ff_gt_A_SUB_B_LO * ff_gt_IS_GT + ff_gt_B_SUB_A_LO * (FF(1) - ff_gt_IS_GT)));
             tmp *= scaling_factor;
             std::get<12>(evals) += typename Accumulator::View(tmp);
         }
         { // RES_HI
             using Accumulator = typename std::tuple_element_t<13, ContainerOverSubrelations>;
             auto tmp =
-                new_term.ff_gt_sel_gt *
-                (new_term.ff_gt_res_hi - (ff_gt_A_SUB_B_HI * ff_gt_IS_GT + ff_gt_B_SUB_A_HI * (FF(1) - ff_gt_IS_GT)));
+                in.get(C::ff_gt_sel_gt) *
+                (in.get(C::ff_gt_res_hi) - (ff_gt_A_SUB_B_HI * ff_gt_IS_GT + ff_gt_B_SUB_A_HI * (FF(1) - ff_gt_IS_GT)));
             tmp *= scaling_factor;
             std::get<13>(evals) += typename Accumulator::View(tmp);
         }
         { // SET_RNG_CTR
             using Accumulator = typename std::tuple_element_t<14, ContainerOverSubrelations>;
-            auto tmp = new_term.ff_gt_sel_gt * (new_term.ff_gt_cmp_rng_ctr - FF(4));
+            auto tmp = in.get(C::ff_gt_sel_gt) * (in.get(C::ff_gt_cmp_rng_ctr) - FF(4));
             tmp *= scaling_factor;
             std::get<14>(evals) += typename Accumulator::View(tmp);
         }
         { // SUB_RNG_CTR
             using Accumulator = typename std::tuple_element_t<15, ContainerOverSubrelations>;
-            auto tmp =
-                new_term.ff_gt_cmp_rng_ctr * ((new_term.ff_gt_cmp_rng_ctr - FF(1)) - new_term.ff_gt_cmp_rng_ctr_shift);
+            auto tmp = in.get(C::ff_gt_cmp_rng_ctr) *
+                       ((in.get(C::ff_gt_cmp_rng_ctr) - FF(1)) - in.get(C::ff_gt_cmp_rng_ctr_shift));
             tmp *= scaling_factor;
             std::get<15>(evals) += typename Accumulator::View(tmp);
         }
         {
             using Accumulator = typename std::tuple_element_t<16, ContainerOverSubrelations>;
-            auto tmp = new_term.ff_gt_sel_shift_rng * (FF(1) - new_term.ff_gt_sel_shift_rng);
+            auto tmp = in.get(C::ff_gt_sel_shift_rng) * (FF(1) - in.get(C::ff_gt_sel_shift_rng));
             tmp *= scaling_factor;
             std::get<16>(evals) += typename Accumulator::View(tmp);
         }
         { // RNG_CTR_NON_ZERO
             using Accumulator = typename std::tuple_element_t<17, ContainerOverSubrelations>;
-            auto tmp = (new_term.ff_gt_cmp_rng_ctr *
-                            ((FF(1) - new_term.ff_gt_sel_shift_rng) * (FF(1) - new_term.ff_gt_cmp_rng_ctr_inv) +
-                             new_term.ff_gt_cmp_rng_ctr_inv) -
-                        new_term.ff_gt_sel_shift_rng);
+            auto tmp = (in.get(C::ff_gt_cmp_rng_ctr) *
+                            ((FF(1) - in.get(C::ff_gt_sel_shift_rng)) * (FF(1) - in.get(C::ff_gt_cmp_rng_ctr_inv)) +
+                             in.get(C::ff_gt_cmp_rng_ctr_inv)) -
+                        in.get(C::ff_gt_sel_shift_rng));
             tmp *= scaling_factor;
             std::get<17>(evals) += typename Accumulator::View(tmp);
         }
         { // SHIFT_0
             using Accumulator = typename std::tuple_element_t<18, ContainerOverSubrelations>;
-            auto tmp = (new_term.ff_gt_a_lo_shift - new_term.ff_gt_p_sub_a_lo) * new_term.ff_gt_sel_shift_rng;
+            auto tmp = (in.get(C::ff_gt_a_lo_shift) - in.get(C::ff_gt_p_sub_a_lo)) * in.get(C::ff_gt_sel_shift_rng);
             tmp *= scaling_factor;
             std::get<18>(evals) += typename Accumulator::View(tmp);
         }
         {
             using Accumulator = typename std::tuple_element_t<19, ContainerOverSubrelations>;
-            auto tmp = (new_term.ff_gt_a_hi_shift - new_term.ff_gt_p_sub_a_hi) * new_term.ff_gt_sel_shift_rng;
+            auto tmp = (in.get(C::ff_gt_a_hi_shift) - in.get(C::ff_gt_p_sub_a_hi)) * in.get(C::ff_gt_sel_shift_rng);
             tmp *= scaling_factor;
             std::get<19>(evals) += typename Accumulator::View(tmp);
         }
         { // SHIFT_1
             using Accumulator = typename std::tuple_element_t<20, ContainerOverSubrelations>;
-            auto tmp = (new_term.ff_gt_p_sub_a_lo_shift - new_term.ff_gt_b_lo) * new_term.ff_gt_sel_shift_rng;
+            auto tmp = (in.get(C::ff_gt_p_sub_a_lo_shift) - in.get(C::ff_gt_b_lo)) * in.get(C::ff_gt_sel_shift_rng);
             tmp *= scaling_factor;
             std::get<20>(evals) += typename Accumulator::View(tmp);
         }
         {
             using Accumulator = typename std::tuple_element_t<21, ContainerOverSubrelations>;
-            auto tmp = (new_term.ff_gt_p_sub_a_hi_shift - new_term.ff_gt_b_hi) * new_term.ff_gt_sel_shift_rng;
+            auto tmp = (in.get(C::ff_gt_p_sub_a_hi_shift) - in.get(C::ff_gt_b_hi)) * in.get(C::ff_gt_sel_shift_rng);
             tmp *= scaling_factor;
             std::get<21>(evals) += typename Accumulator::View(tmp);
         }
         { // SHIFT_2
             using Accumulator = typename std::tuple_element_t<22, ContainerOverSubrelations>;
-            auto tmp = (new_term.ff_gt_b_lo_shift - new_term.ff_gt_p_sub_b_lo) * new_term.ff_gt_sel_shift_rng;
+            auto tmp = (in.get(C::ff_gt_b_lo_shift) - in.get(C::ff_gt_p_sub_b_lo)) * in.get(C::ff_gt_sel_shift_rng);
             tmp *= scaling_factor;
             std::get<22>(evals) += typename Accumulator::View(tmp);
         }
         {
             using Accumulator = typename std::tuple_element_t<23, ContainerOverSubrelations>;
-            auto tmp = (new_term.ff_gt_b_hi_shift - new_term.ff_gt_p_sub_b_hi) * new_term.ff_gt_sel_shift_rng;
+            auto tmp = (in.get(C::ff_gt_b_hi_shift) - in.get(C::ff_gt_p_sub_b_hi)) * in.get(C::ff_gt_sel_shift_rng);
             tmp *= scaling_factor;
             std::get<23>(evals) += typename Accumulator::View(tmp);
         }
         { // SHIFT_3
             using Accumulator = typename std::tuple_element_t<24, ContainerOverSubrelations>;
-            auto tmp = (new_term.ff_gt_p_sub_b_lo_shift - new_term.ff_gt_res_lo) * new_term.ff_gt_sel_shift_rng;
+            auto tmp = (in.get(C::ff_gt_p_sub_b_lo_shift) - in.get(C::ff_gt_res_lo)) * in.get(C::ff_gt_sel_shift_rng);
             tmp *= scaling_factor;
             std::get<24>(evals) += typename Accumulator::View(tmp);
         }
         {
             using Accumulator = typename std::tuple_element_t<25, ContainerOverSubrelations>;
-            auto tmp = (new_term.ff_gt_p_sub_b_hi_shift - new_term.ff_gt_res_hi) * new_term.ff_gt_sel_shift_rng;
+            auto tmp = (in.get(C::ff_gt_p_sub_b_hi_shift) - in.get(C::ff_gt_res_hi)) * in.get(C::ff_gt_sel_shift_rng);
             tmp *= scaling_factor;
             std::get<25>(evals) += typename Accumulator::View(tmp);
         }
         { // SEL_CONSISTENCY
             using Accumulator = typename std::tuple_element_t<26, ContainerOverSubrelations>;
-            auto tmp = ((new_term.ff_gt_sel_shift_rng + new_term.ff_gt_sel_gt_shift) - new_term.ff_gt_sel_shift);
+            auto tmp = ((in.get(C::ff_gt_sel_shift_rng) + in.get(C::ff_gt_sel_gt_shift)) - in.get(C::ff_gt_sel_shift));
             tmp *= scaling_factor;
             std::get<26>(evals) += typename Accumulator::View(tmp);
         }

--- a/barretenberg/cpp/src/barretenberg/vm2/generated/relations/instr_fetching.hpp
+++ b/barretenberg/cpp/src/barretenberg/vm2/generated/relations/instr_fetching.hpp
@@ -5,6 +5,7 @@
 
 #include "barretenberg/relations/relation_parameters.hpp"
 #include "barretenberg/relations/relation_types.hpp"
+#include "barretenberg/vm2/generated/columns.hpp"
 
 namespace bb::avm2 {
 
@@ -17,244 +18,251 @@ template <typename FF_> class instr_fetchingImpl {
 
     template <typename AllEntities> inline static bool skip(const AllEntities& in)
     {
-        const auto& new_term = in;
-        return (new_term.instr_fetching_sel).is_zero();
+        using C = ColumnAndShifts;
+        return (in.get(C::instr_fetching_sel)).is_zero();
     }
 
     template <typename ContainerOverSubrelations, typename AllEntities>
     void static accumulate(ContainerOverSubrelations& evals,
-                           const AllEntities& new_term,
+                           const AllEntities& in,
                            [[maybe_unused]] const RelationParameters<FF>&,
                            [[maybe_unused]] const FF& scaling_factor)
     {
+        using C = ColumnAndShifts;
+
         const auto constants_AVM_PC_SIZE_IN_BITS = FF(32);
-        const auto instr_fetching_PARSING_ERROR_EXCEPT_TAG_ERROR = new_term.instr_fetching_pc_out_of_range +
-                                                                   new_term.instr_fetching_opcode_out_of_range +
-                                                                   new_term.instr_fetching_instr_out_of_range;
+        const auto instr_fetching_PARSING_ERROR_EXCEPT_TAG_ERROR = in.get(C::instr_fetching_pc_out_of_range) +
+                                                                   in.get(C::instr_fetching_opcode_out_of_range) +
+                                                                   in.get(C::instr_fetching_instr_out_of_range);
         const auto instr_fetching_SEL_OP_DC_18 =
-            new_term.instr_fetching_sel_op_dc_2 + new_term.instr_fetching_sel_op_dc_6;
+            in.get(C::instr_fetching_sel_op_dc_2) + in.get(C::instr_fetching_sel_op_dc_6);
 
         {
             using Accumulator = typename std::tuple_element_t<0, ContainerOverSubrelations>;
-            auto tmp = new_term.instr_fetching_sel * (FF(1) - new_term.instr_fetching_sel);
+            auto tmp = in.get(C::instr_fetching_sel) * (FF(1) - in.get(C::instr_fetching_sel));
             tmp *= scaling_factor;
             std::get<0>(evals) += typename Accumulator::View(tmp);
         }
         {
             using Accumulator = typename std::tuple_element_t<1, ContainerOverSubrelations>;
-            auto tmp = new_term.instr_fetching_pc_out_of_range * (FF(1) - new_term.instr_fetching_pc_out_of_range);
+            auto tmp = in.get(C::instr_fetching_pc_out_of_range) * (FF(1) - in.get(C::instr_fetching_pc_out_of_range));
             tmp *= scaling_factor;
             std::get<1>(evals) += typename Accumulator::View(tmp);
         }
         {
             using Accumulator = typename std::tuple_element_t<2, ContainerOverSubrelations>;
             auto tmp =
-                new_term.instr_fetching_instr_out_of_range * (FF(1) - new_term.instr_fetching_instr_out_of_range);
+                in.get(C::instr_fetching_instr_out_of_range) * (FF(1) - in.get(C::instr_fetching_instr_out_of_range));
             tmp *= scaling_factor;
             std::get<2>(evals) += typename Accumulator::View(tmp);
         }
         {
             using Accumulator = typename std::tuple_element_t<3, ContainerOverSubrelations>;
-            auto tmp = (new_term.instr_fetching_parsing_err -
-                        (instr_fetching_PARSING_ERROR_EXCEPT_TAG_ERROR + new_term.instr_fetching_tag_out_of_range));
+            auto tmp = (in.get(C::instr_fetching_parsing_err) -
+                        (instr_fetching_PARSING_ERROR_EXCEPT_TAG_ERROR + in.get(C::instr_fetching_tag_out_of_range)));
             tmp *= scaling_factor;
             std::get<3>(evals) += typename Accumulator::View(tmp);
         }
         {
             using Accumulator = typename std::tuple_element_t<4, ContainerOverSubrelations>;
-            auto tmp = new_term.instr_fetching_parsing_err * (FF(1) - new_term.instr_fetching_parsing_err);
+            auto tmp = in.get(C::instr_fetching_parsing_err) * (FF(1) - in.get(C::instr_fetching_parsing_err));
             tmp *= scaling_factor;
             std::get<4>(evals) += typename Accumulator::View(tmp);
         }
         { // PC_OUT_OF_RANGE_TOGGLE
             using Accumulator = typename std::tuple_element_t<5, ContainerOverSubrelations>;
-            auto tmp = (new_term.instr_fetching_pc_abs_diff -
-                        new_term.instr_fetching_sel *
-                            (((FF(2) * new_term.instr_fetching_pc_out_of_range - FF(1)) *
-                                  (new_term.instr_fetching_pc - new_term.instr_fetching_bytecode_size) -
+            auto tmp = (in.get(C::instr_fetching_pc_abs_diff) -
+                        in.get(C::instr_fetching_sel) *
+                            (((FF(2) * in.get(C::instr_fetching_pc_out_of_range) - FF(1)) *
+                                  (in.get(C::instr_fetching_pc) - in.get(C::instr_fetching_bytecode_size)) -
                               FF(1)) +
-                             new_term.instr_fetching_pc_out_of_range));
+                             in.get(C::instr_fetching_pc_out_of_range)));
             tmp *= scaling_factor;
             std::get<5>(evals) += typename Accumulator::View(tmp);
         }
         {
             using Accumulator = typename std::tuple_element_t<6, ContainerOverSubrelations>;
-            auto tmp =
-                new_term.instr_fetching_sel * (new_term.instr_fetching_pc_size_in_bits - constants_AVM_PC_SIZE_IN_BITS);
+            auto tmp = in.get(C::instr_fetching_sel) *
+                       (in.get(C::instr_fetching_pc_size_in_bits) - constants_AVM_PC_SIZE_IN_BITS);
             tmp *= scaling_factor;
             std::get<6>(evals) += typename Accumulator::View(tmp);
         }
         { // INSTR_OUT_OF_RANGE_TOGGLE
             using Accumulator = typename std::tuple_element_t<7, ContainerOverSubrelations>;
-            auto tmp = (new_term.instr_fetching_instr_abs_diff -
-                        ((FF(2) * new_term.instr_fetching_instr_out_of_range - FF(1)) *
-                             (new_term.instr_fetching_instr_size - new_term.instr_fetching_bytes_to_read) -
-                         new_term.instr_fetching_instr_out_of_range));
+            auto tmp = (in.get(C::instr_fetching_instr_abs_diff) -
+                        ((FF(2) * in.get(C::instr_fetching_instr_out_of_range) - FF(1)) *
+                             (in.get(C::instr_fetching_instr_size) - in.get(C::instr_fetching_bytes_to_read)) -
+                         in.get(C::instr_fetching_instr_out_of_range)));
             tmp *= scaling_factor;
             std::get<7>(evals) += typename Accumulator::View(tmp);
         }
         { // TAG_VALUE
             using Accumulator = typename std::tuple_element_t<8, ContainerOverSubrelations>;
-            auto tmp = (new_term.instr_fetching_tag_value -
-                        ((new_term.instr_fetching_sel_has_tag - new_term.instr_fetching_sel_tag_is_op2) *
-                             new_term.instr_fetching_op3 +
-                         new_term.instr_fetching_sel_tag_is_op2 * new_term.instr_fetching_op2));
+            auto tmp = (in.get(C::instr_fetching_tag_value) -
+                        ((in.get(C::instr_fetching_sel_has_tag) - in.get(C::instr_fetching_sel_tag_is_op2)) *
+                             in.get(C::instr_fetching_op3) +
+                         in.get(C::instr_fetching_sel_tag_is_op2) * in.get(C::instr_fetching_op2)));
             tmp *= scaling_factor;
             std::get<8>(evals) += typename Accumulator::View(tmp);
         }
         {
             using Accumulator = typename std::tuple_element_t<9, ContainerOverSubrelations>;
-            auto tmp = (new_term.instr_fetching_sel_pc_in_range -
-                        new_term.instr_fetching_sel * (FF(1) - new_term.instr_fetching_pc_out_of_range));
+            auto tmp = (in.get(C::instr_fetching_sel_pc_in_range) -
+                        in.get(C::instr_fetching_sel) * (FF(1) - in.get(C::instr_fetching_pc_out_of_range)));
             tmp *= scaling_factor;
             std::get<9>(evals) += typename Accumulator::View(tmp);
         }
         { // INDIRECT_BYTES_DECOMPOSITION
             using Accumulator = typename std::tuple_element_t<10, ContainerOverSubrelations>;
-            auto tmp = (new_term.instr_fetching_indirect -
+            auto tmp = (in.get(C::instr_fetching_indirect) -
                         (FF(1) - instr_fetching_PARSING_ERROR_EXCEPT_TAG_ERROR) *
-                            (new_term.instr_fetching_sel_op_dc_0 *
-                                 (new_term.instr_fetching_bd1 * FF(256) + new_term.instr_fetching_bd2 * FF(1)) +
-                             instr_fetching_SEL_OP_DC_18 * new_term.instr_fetching_bd1 * FF(1)));
+                            (in.get(C::instr_fetching_sel_op_dc_0) *
+                                 (in.get(C::instr_fetching_bd1) * FF(256) + in.get(C::instr_fetching_bd2) * FF(1)) +
+                             instr_fetching_SEL_OP_DC_18 * in.get(C::instr_fetching_bd1) * FF(1)));
             tmp *= scaling_factor;
             std::get<10>(evals) += typename Accumulator::View(tmp);
         }
         { // OP1_BYTES_DECOMPOSITION
             using Accumulator = typename std::tuple_element_t<11, ContainerOverSubrelations>;
-            auto tmp = (new_term.instr_fetching_op1 -
-                        (FF(1) - instr_fetching_PARSING_ERROR_EXCEPT_TAG_ERROR) *
-                            (new_term.instr_fetching_sel_op_dc_0 *
-                                 (new_term.instr_fetching_bd3 * FF(256) + new_term.instr_fetching_bd4 * FF(1)) +
-                             new_term.instr_fetching_sel_op_dc_2 *
-                                 (new_term.instr_fetching_bd2 * FF(256) + new_term.instr_fetching_bd3 * FF(1)) +
-                             new_term.instr_fetching_sel_op_dc_6 * new_term.instr_fetching_bd2 * FF(1) +
-                             new_term.instr_fetching_sel_op_dc_15 *
-                                 (new_term.instr_fetching_bd1 * FF(16777216) + new_term.instr_fetching_bd2 * FF(65536) +
-                                  new_term.instr_fetching_bd3 * FF(256) + new_term.instr_fetching_bd4 * FF(1))));
+            auto tmp =
+                (in.get(C::instr_fetching_op1) -
+                 (FF(1) - instr_fetching_PARSING_ERROR_EXCEPT_TAG_ERROR) *
+                     (in.get(C::instr_fetching_sel_op_dc_0) *
+                          (in.get(C::instr_fetching_bd3) * FF(256) + in.get(C::instr_fetching_bd4) * FF(1)) +
+                      in.get(C::instr_fetching_sel_op_dc_2) *
+                          (in.get(C::instr_fetching_bd2) * FF(256) + in.get(C::instr_fetching_bd3) * FF(1)) +
+                      in.get(C::instr_fetching_sel_op_dc_6) * in.get(C::instr_fetching_bd2) * FF(1) +
+                      in.get(C::instr_fetching_sel_op_dc_15) *
+                          (in.get(C::instr_fetching_bd1) * FF(16777216) + in.get(C::instr_fetching_bd2) * FF(65536) +
+                           in.get(C::instr_fetching_bd3) * FF(256) + in.get(C::instr_fetching_bd4) * FF(1))));
             tmp *= scaling_factor;
             std::get<11>(evals) += typename Accumulator::View(tmp);
         }
         { // OP2_BYTES_DECOMPOSITION
             using Accumulator = typename std::tuple_element_t<12, ContainerOverSubrelations>;
-            auto tmp = (new_term.instr_fetching_op2 -
-                        (FF(1) - instr_fetching_PARSING_ERROR_EXCEPT_TAG_ERROR) *
-                            (new_term.instr_fetching_sel_op_dc_0 *
-                                 (new_term.instr_fetching_bd5 * FF(256) + new_term.instr_fetching_bd6 * FF(1)) +
-                             new_term.instr_fetching_sel_op_dc_3 *
-                                 (new_term.instr_fetching_bd4 * FF(256) + new_term.instr_fetching_bd5 * FF(1)) +
-                             new_term.instr_fetching_sel_op_dc_6 * new_term.instr_fetching_bd3 * FF(1) +
-                             new_term.instr_fetching_sel_op_dc_8 * new_term.instr_fetching_bd4 * FF(1) +
-                             new_term.instr_fetching_sel_op_dc_16 *
-                                 (new_term.instr_fetching_bd4 * FF(16777216) + new_term.instr_fetching_bd5 * FF(65536) +
-                                  new_term.instr_fetching_bd6 * FF(256) + new_term.instr_fetching_bd7 * FF(1))));
+            auto tmp =
+                (in.get(C::instr_fetching_op2) -
+                 (FF(1) - instr_fetching_PARSING_ERROR_EXCEPT_TAG_ERROR) *
+                     (in.get(C::instr_fetching_sel_op_dc_0) *
+                          (in.get(C::instr_fetching_bd5) * FF(256) + in.get(C::instr_fetching_bd6) * FF(1)) +
+                      in.get(C::instr_fetching_sel_op_dc_3) *
+                          (in.get(C::instr_fetching_bd4) * FF(256) + in.get(C::instr_fetching_bd5) * FF(1)) +
+                      in.get(C::instr_fetching_sel_op_dc_6) * in.get(C::instr_fetching_bd3) * FF(1) +
+                      in.get(C::instr_fetching_sel_op_dc_8) * in.get(C::instr_fetching_bd4) * FF(1) +
+                      in.get(C::instr_fetching_sel_op_dc_16) *
+                          (in.get(C::instr_fetching_bd4) * FF(16777216) + in.get(C::instr_fetching_bd5) * FF(65536) +
+                           in.get(C::instr_fetching_bd6) * FF(256) + in.get(C::instr_fetching_bd7) * FF(1))));
             tmp *= scaling_factor;
             std::get<12>(evals) += typename Accumulator::View(tmp);
         }
         { // OP3_BYTES_DECOMPOSITION
             using Accumulator = typename std::tuple_element_t<13, ContainerOverSubrelations>;
             auto tmp =
-                (new_term.instr_fetching_op3 -
+                (in.get(C::instr_fetching_op3) -
                  (FF(1) - instr_fetching_PARSING_ERROR_EXCEPT_TAG_ERROR) *
-                     (new_term.instr_fetching_sel_op_dc_0 *
-                          (new_term.instr_fetching_bd7 * FF(256) + new_term.instr_fetching_bd8 * FF(1)) +
-                      new_term.instr_fetching_sel_op_dc_4 *
-                          (new_term.instr_fetching_bd6 * FF(256) + new_term.instr_fetching_bd7 * FF(1)) +
-                      new_term.instr_fetching_sel_op_dc_9 *
-                          (new_term.instr_fetching_bd5 * FF(uint256_t{ 0UL, 0UL, 0UL, 72057594037927936UL }) +
-                           new_term.instr_fetching_bd6 * FF(uint256_t{ 0UL, 0UL, 0UL, 281474976710656UL }) +
-                           new_term.instr_fetching_bd7 * FF(uint256_t{ 0UL, 0UL, 0UL, 1099511627776UL }) +
-                           new_term.instr_fetching_bd8 * FF(uint256_t{ 0UL, 0UL, 0UL, 4294967296UL }) +
-                           new_term.instr_fetching_bd9 * FF(uint256_t{ 0UL, 0UL, 0UL, 16777216UL }) +
-                           new_term.instr_fetching_bd10 * FF(uint256_t{ 0UL, 0UL, 0UL, 65536UL }) +
-                           new_term.instr_fetching_bd11 * FF(uint256_t{ 0UL, 0UL, 0UL, 256UL }) +
-                           new_term.instr_fetching_bd12 * FF(uint256_t{ 0UL, 0UL, 0UL, 1UL }) +
-                           new_term.instr_fetching_bd13 * FF(uint256_t{ 0UL, 0UL, 72057594037927936UL, 0UL }) +
-                           new_term.instr_fetching_bd14 * FF(uint256_t{ 0UL, 0UL, 281474976710656UL, 0UL }) +
-                           new_term.instr_fetching_bd15 * FF(uint256_t{ 0UL, 0UL, 1099511627776UL, 0UL }) +
-                           new_term.instr_fetching_bd16 * FF(uint256_t{ 0UL, 0UL, 4294967296UL, 0UL }) +
-                           new_term.instr_fetching_bd17 * FF(uint256_t{ 0UL, 0UL, 16777216UL, 0UL }) +
-                           new_term.instr_fetching_bd18 * FF(uint256_t{ 0UL, 0UL, 65536UL, 0UL }) +
-                           new_term.instr_fetching_bd19 * FF(uint256_t{ 0UL, 0UL, 256UL, 0UL }) +
-                           new_term.instr_fetching_bd20 * FF(uint256_t{ 0UL, 0UL, 1UL, 0UL }) +
-                           new_term.instr_fetching_bd21 * FF(uint256_t{ 0UL, 72057594037927936UL, 0UL, 0UL }) +
-                           new_term.instr_fetching_bd22 * FF(uint256_t{ 0UL, 281474976710656UL, 0UL, 0UL }) +
-                           new_term.instr_fetching_bd23 * FF(uint256_t{ 0UL, 1099511627776UL, 0UL, 0UL }) +
-                           new_term.instr_fetching_bd24 * FF(uint256_t{ 0UL, 4294967296UL, 0UL, 0UL }) +
-                           new_term.instr_fetching_bd25 * FF(uint256_t{ 0UL, 16777216UL, 0UL, 0UL }) +
-                           new_term.instr_fetching_bd26 * FF(uint256_t{ 0UL, 65536UL, 0UL, 0UL }) +
-                           new_term.instr_fetching_bd27 * FF(uint256_t{ 0UL, 256UL, 0UL, 0UL }) +
-                           new_term.instr_fetching_bd28 * FF(uint256_t{ 0UL, 1UL, 0UL, 0UL }) +
-                           new_term.instr_fetching_bd29 * FF(72057594037927936UL) +
-                           new_term.instr_fetching_bd30 * FF(281474976710656UL) +
-                           new_term.instr_fetching_bd31 * FF(1099511627776UL) +
-                           new_term.instr_fetching_bd32 * FF(4294967296UL) +
-                           new_term.instr_fetching_bd33 * FF(16777216) + new_term.instr_fetching_bd34 * FF(65536) +
-                           new_term.instr_fetching_bd35 * FF(256) + new_term.instr_fetching_bd36 * FF(1)) +
-                      new_term.instr_fetching_sel_op_dc_10 *
-                          (new_term.instr_fetching_bd5 * FF(uint256_t{ 0UL, 72057594037927936UL, 0UL, 0UL }) +
-                           new_term.instr_fetching_bd6 * FF(uint256_t{ 0UL, 281474976710656UL, 0UL, 0UL }) +
-                           new_term.instr_fetching_bd7 * FF(uint256_t{ 0UL, 1099511627776UL, 0UL, 0UL }) +
-                           new_term.instr_fetching_bd8 * FF(uint256_t{ 0UL, 4294967296UL, 0UL, 0UL }) +
-                           new_term.instr_fetching_bd9 * FF(uint256_t{ 0UL, 16777216UL, 0UL, 0UL }) +
-                           new_term.instr_fetching_bd10 * FF(uint256_t{ 0UL, 65536UL, 0UL, 0UL }) +
-                           new_term.instr_fetching_bd11 * FF(uint256_t{ 0UL, 256UL, 0UL, 0UL }) +
-                           new_term.instr_fetching_bd12 * FF(uint256_t{ 0UL, 1UL, 0UL, 0UL }) +
-                           new_term.instr_fetching_bd13 * FF(72057594037927936UL) +
-                           new_term.instr_fetching_bd14 * FF(281474976710656UL) +
-                           new_term.instr_fetching_bd15 * FF(1099511627776UL) +
-                           new_term.instr_fetching_bd16 * FF(4294967296UL) +
-                           new_term.instr_fetching_bd17 * FF(16777216) + new_term.instr_fetching_bd18 * FF(65536) +
-                           new_term.instr_fetching_bd19 * FF(256) + new_term.instr_fetching_bd20 * FF(1)) +
-                      new_term.instr_fetching_sel_op_dc_11 *
-                          (new_term.instr_fetching_bd5 * FF(72057594037927936UL) +
-                           new_term.instr_fetching_bd6 * FF(281474976710656UL) +
-                           new_term.instr_fetching_bd7 * FF(1099511627776UL) +
-                           new_term.instr_fetching_bd8 * FF(4294967296UL) + new_term.instr_fetching_bd9 * FF(16777216) +
-                           new_term.instr_fetching_bd10 * FF(65536) + new_term.instr_fetching_bd11 * FF(256) +
-                           new_term.instr_fetching_bd12 * FF(1)) +
-                      new_term.instr_fetching_sel_op_dc_12 *
-                          (new_term.instr_fetching_bd5 * FF(16777216) + new_term.instr_fetching_bd6 * FF(65536) +
-                           new_term.instr_fetching_bd7 * FF(256) + new_term.instr_fetching_bd8 * FF(1)) +
-                      new_term.instr_fetching_sel_op_dc_13 *
-                          (new_term.instr_fetching_bd5 * FF(256) + new_term.instr_fetching_bd6 * FF(1)) +
-                      new_term.instr_fetching_sel_op_dc_14 * new_term.instr_fetching_bd4 * FF(1) +
-                      new_term.instr_fetching_sel_op_dc_17 * new_term.instr_fetching_bd6 * FF(1)));
+                     (in.get(C::instr_fetching_sel_op_dc_0) *
+                          (in.get(C::instr_fetching_bd7) * FF(256) + in.get(C::instr_fetching_bd8) * FF(1)) +
+                      in.get(C::instr_fetching_sel_op_dc_4) *
+                          (in.get(C::instr_fetching_bd6) * FF(256) + in.get(C::instr_fetching_bd7) * FF(1)) +
+                      in.get(C::instr_fetching_sel_op_dc_9) *
+                          (in.get(C::instr_fetching_bd5) * FF(uint256_t{ 0UL, 0UL, 0UL, 72057594037927936UL }) +
+                           in.get(C::instr_fetching_bd6) * FF(uint256_t{ 0UL, 0UL, 0UL, 281474976710656UL }) +
+                           in.get(C::instr_fetching_bd7) * FF(uint256_t{ 0UL, 0UL, 0UL, 1099511627776UL }) +
+                           in.get(C::instr_fetching_bd8) * FF(uint256_t{ 0UL, 0UL, 0UL, 4294967296UL }) +
+                           in.get(C::instr_fetching_bd9) * FF(uint256_t{ 0UL, 0UL, 0UL, 16777216UL }) +
+                           in.get(C::instr_fetching_bd10) * FF(uint256_t{ 0UL, 0UL, 0UL, 65536UL }) +
+                           in.get(C::instr_fetching_bd11) * FF(uint256_t{ 0UL, 0UL, 0UL, 256UL }) +
+                           in.get(C::instr_fetching_bd12) * FF(uint256_t{ 0UL, 0UL, 0UL, 1UL }) +
+                           in.get(C::instr_fetching_bd13) * FF(uint256_t{ 0UL, 0UL, 72057594037927936UL, 0UL }) +
+                           in.get(C::instr_fetching_bd14) * FF(uint256_t{ 0UL, 0UL, 281474976710656UL, 0UL }) +
+                           in.get(C::instr_fetching_bd15) * FF(uint256_t{ 0UL, 0UL, 1099511627776UL, 0UL }) +
+                           in.get(C::instr_fetching_bd16) * FF(uint256_t{ 0UL, 0UL, 4294967296UL, 0UL }) +
+                           in.get(C::instr_fetching_bd17) * FF(uint256_t{ 0UL, 0UL, 16777216UL, 0UL }) +
+                           in.get(C::instr_fetching_bd18) * FF(uint256_t{ 0UL, 0UL, 65536UL, 0UL }) +
+                           in.get(C::instr_fetching_bd19) * FF(uint256_t{ 0UL, 0UL, 256UL, 0UL }) +
+                           in.get(C::instr_fetching_bd20) * FF(uint256_t{ 0UL, 0UL, 1UL, 0UL }) +
+                           in.get(C::instr_fetching_bd21) * FF(uint256_t{ 0UL, 72057594037927936UL, 0UL, 0UL }) +
+                           in.get(C::instr_fetching_bd22) * FF(uint256_t{ 0UL, 281474976710656UL, 0UL, 0UL }) +
+                           in.get(C::instr_fetching_bd23) * FF(uint256_t{ 0UL, 1099511627776UL, 0UL, 0UL }) +
+                           in.get(C::instr_fetching_bd24) * FF(uint256_t{ 0UL, 4294967296UL, 0UL, 0UL }) +
+                           in.get(C::instr_fetching_bd25) * FF(uint256_t{ 0UL, 16777216UL, 0UL, 0UL }) +
+                           in.get(C::instr_fetching_bd26) * FF(uint256_t{ 0UL, 65536UL, 0UL, 0UL }) +
+                           in.get(C::instr_fetching_bd27) * FF(uint256_t{ 0UL, 256UL, 0UL, 0UL }) +
+                           in.get(C::instr_fetching_bd28) * FF(uint256_t{ 0UL, 1UL, 0UL, 0UL }) +
+                           in.get(C::instr_fetching_bd29) * FF(72057594037927936UL) +
+                           in.get(C::instr_fetching_bd30) * FF(281474976710656UL) +
+                           in.get(C::instr_fetching_bd31) * FF(1099511627776UL) +
+                           in.get(C::instr_fetching_bd32) * FF(4294967296UL) +
+                           in.get(C::instr_fetching_bd33) * FF(16777216) + in.get(C::instr_fetching_bd34) * FF(65536) +
+                           in.get(C::instr_fetching_bd35) * FF(256) + in.get(C::instr_fetching_bd36) * FF(1)) +
+                      in.get(C::instr_fetching_sel_op_dc_10) *
+                          (in.get(C::instr_fetching_bd5) * FF(uint256_t{ 0UL, 72057594037927936UL, 0UL, 0UL }) +
+                           in.get(C::instr_fetching_bd6) * FF(uint256_t{ 0UL, 281474976710656UL, 0UL, 0UL }) +
+                           in.get(C::instr_fetching_bd7) * FF(uint256_t{ 0UL, 1099511627776UL, 0UL, 0UL }) +
+                           in.get(C::instr_fetching_bd8) * FF(uint256_t{ 0UL, 4294967296UL, 0UL, 0UL }) +
+                           in.get(C::instr_fetching_bd9) * FF(uint256_t{ 0UL, 16777216UL, 0UL, 0UL }) +
+                           in.get(C::instr_fetching_bd10) * FF(uint256_t{ 0UL, 65536UL, 0UL, 0UL }) +
+                           in.get(C::instr_fetching_bd11) * FF(uint256_t{ 0UL, 256UL, 0UL, 0UL }) +
+                           in.get(C::instr_fetching_bd12) * FF(uint256_t{ 0UL, 1UL, 0UL, 0UL }) +
+                           in.get(C::instr_fetching_bd13) * FF(72057594037927936UL) +
+                           in.get(C::instr_fetching_bd14) * FF(281474976710656UL) +
+                           in.get(C::instr_fetching_bd15) * FF(1099511627776UL) +
+                           in.get(C::instr_fetching_bd16) * FF(4294967296UL) +
+                           in.get(C::instr_fetching_bd17) * FF(16777216) + in.get(C::instr_fetching_bd18) * FF(65536) +
+                           in.get(C::instr_fetching_bd19) * FF(256) + in.get(C::instr_fetching_bd20) * FF(1)) +
+                      in.get(C::instr_fetching_sel_op_dc_11) *
+                          (in.get(C::instr_fetching_bd5) * FF(72057594037927936UL) +
+                           in.get(C::instr_fetching_bd6) * FF(281474976710656UL) +
+                           in.get(C::instr_fetching_bd7) * FF(1099511627776UL) +
+                           in.get(C::instr_fetching_bd8) * FF(4294967296UL) +
+                           in.get(C::instr_fetching_bd9) * FF(16777216) + in.get(C::instr_fetching_bd10) * FF(65536) +
+                           in.get(C::instr_fetching_bd11) * FF(256) + in.get(C::instr_fetching_bd12) * FF(1)) +
+                      in.get(C::instr_fetching_sel_op_dc_12) *
+                          (in.get(C::instr_fetching_bd5) * FF(16777216) + in.get(C::instr_fetching_bd6) * FF(65536) +
+                           in.get(C::instr_fetching_bd7) * FF(256) + in.get(C::instr_fetching_bd8) * FF(1)) +
+                      in.get(C::instr_fetching_sel_op_dc_13) *
+                          (in.get(C::instr_fetching_bd5) * FF(256) + in.get(C::instr_fetching_bd6) * FF(1)) +
+                      in.get(C::instr_fetching_sel_op_dc_14) * in.get(C::instr_fetching_bd4) * FF(1) +
+                      in.get(C::instr_fetching_sel_op_dc_17) * in.get(C::instr_fetching_bd6) * FF(1)));
             tmp *= scaling_factor;
             std::get<13>(evals) += typename Accumulator::View(tmp);
         }
         { // OP4_BYTES_DECOMPOSITION
             using Accumulator = typename std::tuple_element_t<14, ContainerOverSubrelations>;
-            auto tmp = (new_term.instr_fetching_op4 -
+            auto tmp = (in.get(C::instr_fetching_op4) -
                         (FF(1) - instr_fetching_PARSING_ERROR_EXCEPT_TAG_ERROR) *
-                            (new_term.instr_fetching_sel_op_dc_0 *
-                                 (new_term.instr_fetching_bd9 * FF(256) + new_term.instr_fetching_bd10 * FF(1)) +
-                             new_term.instr_fetching_sel_op_dc_5 *
-                                 (new_term.instr_fetching_bd8 * FF(256) + new_term.instr_fetching_bd9 * FF(1)) +
-                             new_term.instr_fetching_sel_op_dc_7 * new_term.instr_fetching_bd8 * FF(1)));
+                            (in.get(C::instr_fetching_sel_op_dc_0) *
+                                 (in.get(C::instr_fetching_bd9) * FF(256) + in.get(C::instr_fetching_bd10) * FF(1)) +
+                             in.get(C::instr_fetching_sel_op_dc_5) *
+                                 (in.get(C::instr_fetching_bd8) * FF(256) + in.get(C::instr_fetching_bd9) * FF(1)) +
+                             in.get(C::instr_fetching_sel_op_dc_7) * in.get(C::instr_fetching_bd8) * FF(1)));
             tmp *= scaling_factor;
             std::get<14>(evals) += typename Accumulator::View(tmp);
         }
         { // OP5_BYTES_DECOMPOSITION
             using Accumulator = typename std::tuple_element_t<15, ContainerOverSubrelations>;
-            auto tmp = (new_term.instr_fetching_op5 -
-                        (FF(1) - instr_fetching_PARSING_ERROR_EXCEPT_TAG_ERROR) * new_term.instr_fetching_sel_op_dc_0 *
-                            (new_term.instr_fetching_bd11 * FF(256) + new_term.instr_fetching_bd12 * FF(1)));
+            auto tmp =
+                (in.get(C::instr_fetching_op5) -
+                 (FF(1) - instr_fetching_PARSING_ERROR_EXCEPT_TAG_ERROR) * in.get(C::instr_fetching_sel_op_dc_0) *
+                     (in.get(C::instr_fetching_bd11) * FF(256) + in.get(C::instr_fetching_bd12) * FF(1)));
             tmp *= scaling_factor;
             std::get<15>(evals) += typename Accumulator::View(tmp);
         }
         { // OP6_BYTES_DECOMPOSITION
             using Accumulator = typename std::tuple_element_t<16, ContainerOverSubrelations>;
-            auto tmp = (new_term.instr_fetching_op6 -
-                        (FF(1) - instr_fetching_PARSING_ERROR_EXCEPT_TAG_ERROR) * new_term.instr_fetching_sel_op_dc_1 *
-                            (new_term.instr_fetching_bd13 * FF(256) + new_term.instr_fetching_bd14 * FF(1)));
+            auto tmp =
+                (in.get(C::instr_fetching_op6) -
+                 (FF(1) - instr_fetching_PARSING_ERROR_EXCEPT_TAG_ERROR) * in.get(C::instr_fetching_sel_op_dc_1) *
+                     (in.get(C::instr_fetching_bd13) * FF(256) + in.get(C::instr_fetching_bd14) * FF(1)));
             tmp *= scaling_factor;
             std::get<16>(evals) += typename Accumulator::View(tmp);
         }
         { // OP7_BYTES_DECOMPOSITION
             using Accumulator = typename std::tuple_element_t<17, ContainerOverSubrelations>;
-            auto tmp = (new_term.instr_fetching_op7 -
-                        (FF(1) - instr_fetching_PARSING_ERROR_EXCEPT_TAG_ERROR) * new_term.instr_fetching_sel_op_dc_1 *
-                            (new_term.instr_fetching_bd15 * FF(256) + new_term.instr_fetching_bd16 * FF(1)));
+            auto tmp =
+                (in.get(C::instr_fetching_op7) -
+                 (FF(1) - instr_fetching_PARSING_ERROR_EXCEPT_TAG_ERROR) * in.get(C::instr_fetching_sel_op_dc_1) *
+                     (in.get(C::instr_fetching_bd15) * FF(256) + in.get(C::instr_fetching_bd16) * FF(1)));
             tmp *= scaling_factor;
             std::get<17>(evals) += typename Accumulator::View(tmp);
         }

--- a/barretenberg/cpp/src/barretenberg/vm2/generated/relations/keccakf1600.hpp
+++ b/barretenberg/cpp/src/barretenberg/vm2/generated/relations/keccakf1600.hpp
@@ -5,6 +5,7 @@
 
 #include "barretenberg/relations/relation_parameters.hpp"
 #include "barretenberg/relations/relation_types.hpp"
+#include "barretenberg/vm2/generated/columns.hpp"
 
 namespace bb::avm2 {
 
@@ -16,20 +17,21 @@ template <typename FF_> class keccakf1600Impl {
 
     template <typename ContainerOverSubrelations, typename AllEntities>
     void static accumulate(ContainerOverSubrelations& evals,
-                           const AllEntities& new_term,
+                           const AllEntities& in,
                            [[maybe_unused]] const RelationParameters<FF>&,
                            [[maybe_unused]] const FF& scaling_factor)
     {
+        using C = ColumnAndShifts;
 
         {
             using Accumulator = typename std::tuple_element_t<0, ContainerOverSubrelations>;
-            auto tmp = (new_term.keccakf1600_keccak_0_ - new_term.keccakf1600_keccak_0_);
+            auto tmp = (in.get(C::keccakf1600_keccak_0_) - in.get(C::keccakf1600_keccak_0_));
             tmp *= scaling_factor;
             std::get<0>(evals) += typename Accumulator::View(tmp);
         }
         {
             using Accumulator = typename std::tuple_element_t<1, ContainerOverSubrelations>;
-            auto tmp = (new_term.keccakf1600_keccak_1_ - new_term.keccakf1600_keccak_1_);
+            auto tmp = (in.get(C::keccakf1600_keccak_1_) - in.get(C::keccakf1600_keccak_1_));
             tmp *= scaling_factor;
             std::get<1>(evals) += typename Accumulator::View(tmp);
         }

--- a/barretenberg/cpp/src/barretenberg/vm2/generated/relations/memory.hpp
+++ b/barretenberg/cpp/src/barretenberg/vm2/generated/relations/memory.hpp
@@ -5,6 +5,7 @@
 
 #include "barretenberg/relations/relation_parameters.hpp"
 #include "barretenberg/relations/relation_types.hpp"
+#include "barretenberg/vm2/generated/columns.hpp"
 
 namespace bb::avm2 {
 
@@ -16,26 +17,27 @@ template <typename FF_> class memoryImpl {
 
     template <typename AllEntities> inline static bool skip(const AllEntities& in)
     {
-        const auto& new_term = in;
-        return (new_term.memory_sel).is_zero();
+        using C = ColumnAndShifts;
+        return (in.get(C::memory_sel)).is_zero();
     }
 
     template <typename ContainerOverSubrelations, typename AllEntities>
     void static accumulate(ContainerOverSubrelations& evals,
-                           const AllEntities& new_term,
+                           const AllEntities& in,
                            [[maybe_unused]] const RelationParameters<FF>&,
                            [[maybe_unused]] const FF& scaling_factor)
     {
+        using C = ColumnAndShifts;
 
         {
             using Accumulator = typename std::tuple_element_t<0, ContainerOverSubrelations>;
-            auto tmp = new_term.memory_sel * (new_term.memory_sel - FF(1));
+            auto tmp = in.get(C::memory_sel) * (in.get(C::memory_sel) - FF(1));
             tmp *= scaling_factor;
             std::get<0>(evals) += typename Accumulator::View(tmp);
         }
         {
             using Accumulator = typename std::tuple_element_t<1, ContainerOverSubrelations>;
-            auto tmp = new_term.memory_rw * (FF(1) - new_term.memory_rw);
+            auto tmp = in.get(C::memory_rw) * (FF(1) - in.get(C::memory_rw));
             tmp *= scaling_factor;
             std::get<1>(evals) += typename Accumulator::View(tmp);
         }

--- a/barretenberg/cpp/src/barretenberg/vm2/generated/relations/merkle_check.hpp
+++ b/barretenberg/cpp/src/barretenberg/vm2/generated/relations/merkle_check.hpp
@@ -5,6 +5,7 @@
 
 #include "barretenberg/relations/relation_parameters.hpp"
 #include "barretenberg/relations/relation_types.hpp"
+#include "barretenberg/vm2/generated/columns.hpp"
 
 namespace bb::avm2 {
 
@@ -17,198 +18,203 @@ template <typename FF_> class merkle_checkImpl {
 
     template <typename AllEntities> inline static bool skip(const AllEntities& in)
     {
-        const auto& new_term = in;
-        return (new_term.merkle_check_sel).is_zero();
+        using C = ColumnAndShifts;
+        return (in.get(C::merkle_check_sel)).is_zero();
     }
 
     template <typename ContainerOverSubrelations, typename AllEntities>
     void static accumulate(ContainerOverSubrelations& evals,
-                           const AllEntities& new_term,
+                           const AllEntities& in,
                            [[maybe_unused]] const RelationParameters<FF>&,
                            [[maybe_unused]] const FF& scaling_factor)
     {
-        const auto merkle_check_NOT_END = new_term.merkle_check_sel * (FF(1) - new_term.merkle_check_end);
-        const auto merkle_check_LATCH_CONDITION = new_term.merkle_check_end + new_term.precomputed_first_row;
-        const auto merkle_check_REMAINING_PATH_LEN = (new_term.merkle_check_path_len - FF(1));
-        const auto merkle_check_INDEX_IS_ODD = (FF(1) - new_term.merkle_check_index_is_even);
+        using C = ColumnAndShifts;
+
+        const auto merkle_check_NOT_END = in.get(C::merkle_check_sel) * (FF(1) - in.get(C::merkle_check_end));
+        const auto merkle_check_LATCH_CONDITION = in.get(C::merkle_check_end) + in.get(C::precomputed_first_row);
+        const auto merkle_check_REMAINING_PATH_LEN = (in.get(C::merkle_check_path_len) - FF(1));
+        const auto merkle_check_INDEX_IS_ODD = (FF(1) - in.get(C::merkle_check_index_is_even));
 
         {
             using Accumulator = typename std::tuple_element_t<0, ContainerOverSubrelations>;
-            auto tmp = new_term.merkle_check_sel * (FF(1) - new_term.merkle_check_sel);
+            auto tmp = in.get(C::merkle_check_sel) * (FF(1) - in.get(C::merkle_check_sel));
             tmp *= scaling_factor;
             std::get<0>(evals) += typename Accumulator::View(tmp);
         }
         { // TRACE_CONTINUITY
             using Accumulator = typename std::tuple_element_t<1, ContainerOverSubrelations>;
-            auto tmp = (FF(1) - new_term.precomputed_first_row) * (FF(1) - new_term.merkle_check_sel) *
-                       new_term.merkle_check_sel_shift;
+            auto tmp = (FF(1) - in.get(C::precomputed_first_row)) * (FF(1) - in.get(C::merkle_check_sel)) *
+                       in.get(C::merkle_check_sel_shift);
             tmp *= scaling_factor;
             std::get<1>(evals) += typename Accumulator::View(tmp);
         }
         {
             using Accumulator = typename std::tuple_element_t<2, ContainerOverSubrelations>;
-            auto tmp = new_term.merkle_check_write * (FF(1) - new_term.merkle_check_write);
+            auto tmp = in.get(C::merkle_check_write) * (FF(1) - in.get(C::merkle_check_write));
             tmp *= scaling_factor;
             std::get<2>(evals) += typename Accumulator::View(tmp);
         }
         {
             using Accumulator = typename std::tuple_element_t<3, ContainerOverSubrelations>;
-            auto tmp = new_term.merkle_check_start * (FF(1) - new_term.merkle_check_start);
+            auto tmp = in.get(C::merkle_check_start) * (FF(1) - in.get(C::merkle_check_start));
             tmp *= scaling_factor;
             std::get<3>(evals) += typename Accumulator::View(tmp);
         }
         {
             using Accumulator = typename std::tuple_element_t<4, ContainerOverSubrelations>;
-            auto tmp = new_term.merkle_check_end * (FF(1) - new_term.merkle_check_end);
+            auto tmp = in.get(C::merkle_check_end) * (FF(1) - in.get(C::merkle_check_end));
             tmp *= scaling_factor;
             std::get<4>(evals) += typename Accumulator::View(tmp);
         }
         {
             using Accumulator = typename std::tuple_element_t<5, ContainerOverSubrelations>;
-            auto tmp = new_term.merkle_check_end * new_term.precomputed_first_row;
+            auto tmp = in.get(C::merkle_check_end) * in.get(C::precomputed_first_row);
             tmp *= scaling_factor;
             std::get<5>(evals) += typename Accumulator::View(tmp);
         }
         { // START_AFTER_LATCH
             using Accumulator = typename std::tuple_element_t<6, ContainerOverSubrelations>;
-            auto tmp =
-                new_term.merkle_check_sel_shift * (new_term.merkle_check_start_shift - merkle_check_LATCH_CONDITION);
+            auto tmp = in.get(C::merkle_check_sel_shift) *
+                       (in.get(C::merkle_check_start_shift) - merkle_check_LATCH_CONDITION);
             tmp *= scaling_factor;
             std::get<6>(evals) += typename Accumulator::View(tmp);
         }
         { // SELECTOR_ON_END
             using Accumulator = typename std::tuple_element_t<7, ContainerOverSubrelations>;
-            auto tmp = new_term.merkle_check_end * (FF(1) - new_term.merkle_check_sel);
+            auto tmp = in.get(C::merkle_check_end) * (FF(1) - in.get(C::merkle_check_sel));
             tmp *= scaling_factor;
             std::get<7>(evals) += typename Accumulator::View(tmp);
         }
         { // PROPAGATE_READ_ROOT
             using Accumulator = typename std::tuple_element_t<8, ContainerOverSubrelations>;
-            auto tmp = merkle_check_NOT_END * (new_term.merkle_check_read_root_shift - new_term.merkle_check_read_root);
+            auto tmp =
+                merkle_check_NOT_END * (in.get(C::merkle_check_read_root_shift) - in.get(C::merkle_check_read_root));
             tmp *= scaling_factor;
             std::get<8>(evals) += typename Accumulator::View(tmp);
         }
         { // PROPAGATE_WRITE
             using Accumulator = typename std::tuple_element_t<9, ContainerOverSubrelations>;
-            auto tmp = merkle_check_NOT_END * (new_term.merkle_check_write_shift - new_term.merkle_check_write);
+            auto tmp = merkle_check_NOT_END * (in.get(C::merkle_check_write_shift) - in.get(C::merkle_check_write));
             tmp *= scaling_factor;
             std::get<9>(evals) += typename Accumulator::View(tmp);
         }
         { // PROPAGATE_WRITE_ROOT
             using Accumulator = typename std::tuple_element_t<10, ContainerOverSubrelations>;
             auto tmp =
-                merkle_check_NOT_END * (new_term.merkle_check_write_root_shift - new_term.merkle_check_write_root);
+                merkle_check_NOT_END * (in.get(C::merkle_check_write_root_shift) - in.get(C::merkle_check_write_root));
             tmp *= scaling_factor;
             std::get<10>(evals) += typename Accumulator::View(tmp);
         }
         { // PATH_LEN_DECREMENTS
             using Accumulator = typename std::tuple_element_t<11, ContainerOverSubrelations>;
             auto tmp = merkle_check_NOT_END *
-                       ((new_term.merkle_check_path_len_shift - new_term.merkle_check_path_len) + FF(1));
+                       ((in.get(C::merkle_check_path_len_shift) - in.get(C::merkle_check_path_len)) + FF(1));
             tmp *= scaling_factor;
             std::get<11>(evals) += typename Accumulator::View(tmp);
         }
         { // END_WHEN_PATH_EMPTY
             using Accumulator = typename std::tuple_element_t<12, ContainerOverSubrelations>;
-            auto tmp = new_term.merkle_check_sel *
+            auto tmp = in.get(C::merkle_check_sel) *
                        ((merkle_check_REMAINING_PATH_LEN *
-                             (new_term.merkle_check_end * (FF(1) - new_term.merkle_check_remaining_path_len_inv) +
-                              new_term.merkle_check_remaining_path_len_inv) -
+                             (in.get(C::merkle_check_end) * (FF(1) - in.get(C::merkle_check_remaining_path_len_inv)) +
+                              in.get(C::merkle_check_remaining_path_len_inv)) -
                          FF(1)) +
-                        new_term.merkle_check_end);
+                        in.get(C::merkle_check_end));
             tmp *= scaling_factor;
             std::get<12>(evals) += typename Accumulator::View(tmp);
         }
         {
             using Accumulator = typename std::tuple_element_t<13, ContainerOverSubrelations>;
-            auto tmp = new_term.merkle_check_index_is_even * (FF(1) - new_term.merkle_check_index_is_even);
+            auto tmp = in.get(C::merkle_check_index_is_even) * (FF(1) - in.get(C::merkle_check_index_is_even));
             tmp *= scaling_factor;
             std::get<13>(evals) += typename Accumulator::View(tmp);
         }
         { // NEXT_INDEX_IS_HALVED
             using Accumulator = typename std::tuple_element_t<14, ContainerOverSubrelations>;
-            auto tmp = merkle_check_NOT_END * ((new_term.merkle_check_index_shift * FF(2) + merkle_check_INDEX_IS_ODD) -
-                                               new_term.merkle_check_index);
+            auto tmp =
+                merkle_check_NOT_END * ((in.get(C::merkle_check_index_shift) * FF(2) + merkle_check_INDEX_IS_ODD) -
+                                        in.get(C::merkle_check_index));
             tmp *= scaling_factor;
             std::get<14>(evals) += typename Accumulator::View(tmp);
         }
         { // FINAL_INDEX_IS_0_OR_1
             using Accumulator = typename std::tuple_element_t<15, ContainerOverSubrelations>;
-            auto tmp = new_term.merkle_check_end * new_term.merkle_check_index * (FF(1) - new_term.merkle_check_index);
+            auto tmp =
+                in.get(C::merkle_check_end) * in.get(C::merkle_check_index) * (FF(1) - in.get(C::merkle_check_index));
             tmp *= scaling_factor;
             std::get<15>(evals) += typename Accumulator::View(tmp);
         }
         { // ASSIGN_NODE_LEFT_OR_RIGHT_READ
             using Accumulator = typename std::tuple_element_t<16, ContainerOverSubrelations>;
-            auto tmp = new_term.merkle_check_sel *
-                       ((new_term.merkle_check_index_is_even *
-                             (new_term.merkle_check_read_left_node - new_term.merkle_check_read_right_node) +
-                         new_term.merkle_check_read_right_node) -
-                        new_term.merkle_check_read_node);
+            auto tmp = in.get(C::merkle_check_sel) *
+                       ((in.get(C::merkle_check_index_is_even) *
+                             (in.get(C::merkle_check_read_left_node) - in.get(C::merkle_check_read_right_node)) +
+                         in.get(C::merkle_check_read_right_node)) -
+                        in.get(C::merkle_check_read_node));
             tmp *= scaling_factor;
             std::get<16>(evals) += typename Accumulator::View(tmp);
         }
         { // ASSIGN_SIBLING_LEFT_OR_RIGHT_READ
             using Accumulator = typename std::tuple_element_t<17, ContainerOverSubrelations>;
-            auto tmp = new_term.merkle_check_sel *
-                       ((new_term.merkle_check_index_is_even *
-                             (new_term.merkle_check_read_right_node - new_term.merkle_check_read_left_node) +
-                         new_term.merkle_check_read_left_node) -
-                        new_term.merkle_check_sibling);
+            auto tmp = in.get(C::merkle_check_sel) *
+                       ((in.get(C::merkle_check_index_is_even) *
+                             (in.get(C::merkle_check_read_right_node) - in.get(C::merkle_check_read_left_node)) +
+                         in.get(C::merkle_check_read_left_node)) -
+                        in.get(C::merkle_check_sibling));
             tmp *= scaling_factor;
             std::get<17>(evals) += typename Accumulator::View(tmp);
         }
         { // ASSIGN_NODE_LEFT_OR_RIGHT_WRITE
             using Accumulator = typename std::tuple_element_t<18, ContainerOverSubrelations>;
-            auto tmp = new_term.merkle_check_write *
-                       ((new_term.merkle_check_index_is_even *
-                             (new_term.merkle_check_write_left_node - new_term.merkle_check_write_right_node) +
-                         new_term.merkle_check_write_right_node) -
-                        new_term.merkle_check_write_node);
+            auto tmp = in.get(C::merkle_check_write) *
+                       ((in.get(C::merkle_check_index_is_even) *
+                             (in.get(C::merkle_check_write_left_node) - in.get(C::merkle_check_write_right_node)) +
+                         in.get(C::merkle_check_write_right_node)) -
+                        in.get(C::merkle_check_write_node));
             tmp *= scaling_factor;
             std::get<18>(evals) += typename Accumulator::View(tmp);
         }
         { // ASSIGN_SIBLING_LEFT_OR_RIGHT_WRITE
             using Accumulator = typename std::tuple_element_t<19, ContainerOverSubrelations>;
-            auto tmp = new_term.merkle_check_write *
-                       ((new_term.merkle_check_index_is_even *
-                             (new_term.merkle_check_write_right_node - new_term.merkle_check_write_left_node) +
-                         new_term.merkle_check_write_left_node) -
-                        new_term.merkle_check_sibling);
+            auto tmp = in.get(C::merkle_check_write) *
+                       ((in.get(C::merkle_check_index_is_even) *
+                             (in.get(C::merkle_check_write_right_node) - in.get(C::merkle_check_write_left_node)) +
+                         in.get(C::merkle_check_write_left_node)) -
+                        in.get(C::merkle_check_sibling));
             tmp *= scaling_factor;
             std::get<19>(evals) += typename Accumulator::View(tmp);
         }
         {
             using Accumulator = typename std::tuple_element_t<20, ContainerOverSubrelations>;
-            auto tmp = new_term.merkle_check_sel * (new_term.merkle_check_constant_2 - FF(2));
+            auto tmp = in.get(C::merkle_check_sel) * (in.get(C::merkle_check_constant_2) - FF(2));
             tmp *= scaling_factor;
             std::get<20>(evals) += typename Accumulator::View(tmp);
         }
         { // OUTPUT_HASH_IS_NEXT_ROWS_READ_NODE
             using Accumulator = typename std::tuple_element_t<21, ContainerOverSubrelations>;
-            auto tmp =
-                merkle_check_NOT_END * (new_term.merkle_check_read_node_shift - new_term.merkle_check_read_output_hash);
+            auto tmp = merkle_check_NOT_END *
+                       (in.get(C::merkle_check_read_node_shift) - in.get(C::merkle_check_read_output_hash));
             tmp *= scaling_factor;
             std::get<21>(evals) += typename Accumulator::View(tmp);
         }
         { // OUTPUT_HASH_IS_NEXT_ROWS_WRITE_NODE
             using Accumulator = typename std::tuple_element_t<22, ContainerOverSubrelations>;
             auto tmp = merkle_check_NOT_END *
-                       (new_term.merkle_check_write_node_shift - new_term.merkle_check_write_output_hash);
+                       (in.get(C::merkle_check_write_node_shift) - in.get(C::merkle_check_write_output_hash));
             tmp *= scaling_factor;
             std::get<22>(evals) += typename Accumulator::View(tmp);
         }
         { // READ_OUTPUT_HASH_IS_READ_ROOT
             using Accumulator = typename std::tuple_element_t<23, ContainerOverSubrelations>;
-            auto tmp =
-                new_term.merkle_check_end * (new_term.merkle_check_read_output_hash - new_term.merkle_check_read_root);
+            auto tmp = in.get(C::merkle_check_end) *
+                       (in.get(C::merkle_check_read_output_hash) - in.get(C::merkle_check_read_root));
             tmp *= scaling_factor;
             std::get<23>(evals) += typename Accumulator::View(tmp);
         }
         { // WRITE_OUTPUT_HASH_IS_WRITE_ROOT
             using Accumulator = typename std::tuple_element_t<24, ContainerOverSubrelations>;
-            auto tmp = new_term.merkle_check_end *
-                       (new_term.merkle_check_write_output_hash - new_term.merkle_check_write_root);
+            auto tmp = in.get(C::merkle_check_end) *
+                       (in.get(C::merkle_check_write_output_hash) - in.get(C::merkle_check_write_root));
             tmp *= scaling_factor;
             std::get<24>(evals) += typename Accumulator::View(tmp);
         }

--- a/barretenberg/cpp/src/barretenberg/vm2/generated/relations/nullifier_check.hpp
+++ b/barretenberg/cpp/src/barretenberg/vm2/generated/relations/nullifier_check.hpp
@@ -5,6 +5,7 @@
 
 #include "barretenberg/relations/relation_parameters.hpp"
 #include "barretenberg/relations/relation_types.hpp"
+#include "barretenberg/vm2/generated/columns.hpp"
 
 namespace bb::avm2 {
 
@@ -16,108 +17,110 @@ template <typename FF_> class nullifier_checkImpl {
 
     template <typename AllEntities> inline static bool skip(const AllEntities& in)
     {
-        const auto& new_term = in;
-        return (new_term.nullifier_check_sel).is_zero();
+        using C = ColumnAndShifts;
+        return (in.get(C::nullifier_check_sel)).is_zero();
     }
 
     template <typename ContainerOverSubrelations, typename AllEntities>
     void static accumulate(ContainerOverSubrelations& evals,
-                           const AllEntities& new_term,
+                           const AllEntities& in,
                            [[maybe_unused]] const RelationParameters<FF>&,
                            [[maybe_unused]] const FF& scaling_factor)
     {
+        using C = ColumnAndShifts;
+
         const auto constants_NULLIFIER_TREE_HEIGHT = FF(40);
         const auto nullifier_check_NULLIFIER_LOW_LEAF_NULLIFIER_DIFF =
-            (new_term.nullifier_check_nullifier - new_term.nullifier_check_low_leaf_nullifier);
+            (in.get(C::nullifier_check_nullifier) - in.get(C::nullifier_check_low_leaf_nullifier));
         const auto nullifier_check_NEXT_NULLIFIER_IS_ZERO =
-            (FF(1) - new_term.nullifier_check_next_nullifier_is_nonzero);
+            (FF(1) - in.get(C::nullifier_check_next_nullifier_is_nonzero));
 
         {
             using Accumulator = typename std::tuple_element_t<0, ContainerOverSubrelations>;
-            auto tmp = new_term.nullifier_check_sel * (FF(1) - new_term.nullifier_check_sel);
+            auto tmp = in.get(C::nullifier_check_sel) * (FF(1) - in.get(C::nullifier_check_sel));
             tmp *= scaling_factor;
             std::get<0>(evals) += typename Accumulator::View(tmp);
         }
         {
             using Accumulator = typename std::tuple_element_t<1, ContainerOverSubrelations>;
-            auto tmp = new_term.nullifier_check_exists * (FF(1) - new_term.nullifier_check_exists);
+            auto tmp = in.get(C::nullifier_check_exists) * (FF(1) - in.get(C::nullifier_check_exists));
             tmp *= scaling_factor;
             std::get<1>(evals) += typename Accumulator::View(tmp);
         }
         {
             using Accumulator = typename std::tuple_element_t<2, ContainerOverSubrelations>;
-            auto tmp = new_term.nullifier_check_write * (FF(1) - new_term.nullifier_check_write);
+            auto tmp = in.get(C::nullifier_check_write) * (FF(1) - in.get(C::nullifier_check_write));
             tmp *= scaling_factor;
             std::get<2>(evals) += typename Accumulator::View(tmp);
         }
         { // WRITE_EXISTS_NAND
             using Accumulator = typename std::tuple_element_t<3, ContainerOverSubrelations>;
-            auto tmp = new_term.nullifier_check_write * new_term.nullifier_check_exists;
+            auto tmp = in.get(C::nullifier_check_write) * in.get(C::nullifier_check_exists);
             tmp *= scaling_factor;
             std::get<3>(evals) += typename Accumulator::View(tmp);
         }
         {
             using Accumulator = typename std::tuple_element_t<4, ContainerOverSubrelations>;
-            auto tmp = new_term.nullifier_check_write * (new_term.nullifier_check_tree_size_before_write -
-                                                         new_term.nullifier_check_write_low_leaf_next_index);
+            auto tmp = in.get(C::nullifier_check_write) * (in.get(C::nullifier_check_tree_size_before_write) -
+                                                           in.get(C::nullifier_check_write_low_leaf_next_index));
             tmp *= scaling_factor;
             std::get<4>(evals) += typename Accumulator::View(tmp);
         }
         {
             using Accumulator = typename std::tuple_element_t<5, ContainerOverSubrelations>;
-            auto tmp = new_term.nullifier_check_write *
-                       (new_term.nullifier_check_nullifier - new_term.nullifier_check_write_low_leaf_next_nullifier);
+            auto tmp = in.get(C::nullifier_check_write) * (in.get(C::nullifier_check_nullifier) -
+                                                           in.get(C::nullifier_check_write_low_leaf_next_nullifier));
             tmp *= scaling_factor;
             std::get<5>(evals) += typename Accumulator::View(tmp);
         }
         {
             using Accumulator = typename std::tuple_element_t<6, ContainerOverSubrelations>;
-            auto tmp =
-                new_term.nullifier_check_sel * (new_term.nullifier_check_tree_height - constants_NULLIFIER_TREE_HEIGHT);
+            auto tmp = in.get(C::nullifier_check_sel) *
+                       (in.get(C::nullifier_check_tree_height) - constants_NULLIFIER_TREE_HEIGHT);
             tmp *= scaling_factor;
             std::get<6>(evals) += typename Accumulator::View(tmp);
         }
         { // EXISTS_CHECK
             using Accumulator = typename std::tuple_element_t<7, ContainerOverSubrelations>;
-            auto tmp = new_term.nullifier_check_sel *
+            auto tmp = in.get(C::nullifier_check_sel) *
                        ((nullifier_check_NULLIFIER_LOW_LEAF_NULLIFIER_DIFF *
-                             (new_term.nullifier_check_exists *
-                                  (FF(1) - new_term.nullifier_check_nullifier_low_leaf_nullifier_diff_inv) +
-                              new_term.nullifier_check_nullifier_low_leaf_nullifier_diff_inv) -
+                             (in.get(C::nullifier_check_exists) *
+                                  (FF(1) - in.get(C::nullifier_check_nullifier_low_leaf_nullifier_diff_inv)) +
+                              in.get(C::nullifier_check_nullifier_low_leaf_nullifier_diff_inv)) -
                          FF(1)) +
-                        new_term.nullifier_check_exists);
+                        in.get(C::nullifier_check_exists));
             tmp *= scaling_factor;
             std::get<7>(evals) += typename Accumulator::View(tmp);
         }
         {
             using Accumulator = typename std::tuple_element_t<8, ContainerOverSubrelations>;
-            auto tmp = new_term.nullifier_check_sel * (FF(1) - new_term.nullifier_check_one);
+            auto tmp = in.get(C::nullifier_check_sel) * (FF(1) - in.get(C::nullifier_check_one));
             tmp *= scaling_factor;
             std::get<8>(evals) += typename Accumulator::View(tmp);
         }
         {
             using Accumulator = typename std::tuple_element_t<9, ContainerOverSubrelations>;
-            auto tmp = new_term.nullifier_check_sel *
-                       ((FF(1) - new_term.nullifier_check_exists) - new_term.nullifier_check_leaf_not_exists);
+            auto tmp = in.get(C::nullifier_check_sel) *
+                       ((FF(1) - in.get(C::nullifier_check_exists)) - in.get(C::nullifier_check_leaf_not_exists));
             tmp *= scaling_factor;
             std::get<9>(evals) += typename Accumulator::View(tmp);
         }
         {
             using Accumulator = typename std::tuple_element_t<10, ContainerOverSubrelations>;
-            auto tmp = new_term.nullifier_check_next_nullifier_is_nonzero *
-                       (FF(1) - new_term.nullifier_check_next_nullifier_is_nonzero);
+            auto tmp = in.get(C::nullifier_check_next_nullifier_is_nonzero) *
+                       (FF(1) - in.get(C::nullifier_check_next_nullifier_is_nonzero));
             tmp *= scaling_factor;
             std::get<10>(evals) += typename Accumulator::View(tmp);
         }
         { // NEXT_NULLIFIER_IS_ZERO_CHECK
             using Accumulator = typename std::tuple_element_t<11, ContainerOverSubrelations>;
-            auto tmp =
-                new_term.nullifier_check_leaf_not_exists *
-                ((new_term.nullifier_check_low_leaf_next_nullifier *
-                      (nullifier_check_NEXT_NULLIFIER_IS_ZERO * (FF(1) - new_term.nullifier_check_next_nullifier_inv) +
-                       new_term.nullifier_check_next_nullifier_inv) -
-                  FF(1)) +
-                 nullifier_check_NEXT_NULLIFIER_IS_ZERO);
+            auto tmp = in.get(C::nullifier_check_leaf_not_exists) *
+                       ((in.get(C::nullifier_check_low_leaf_next_nullifier) *
+                             (nullifier_check_NEXT_NULLIFIER_IS_ZERO *
+                                  (FF(1) - in.get(C::nullifier_check_next_nullifier_inv)) +
+                              in.get(C::nullifier_check_next_nullifier_inv)) -
+                         FF(1)) +
+                        nullifier_check_NEXT_NULLIFIER_IS_ZERO);
             tmp *= scaling_factor;
             std::get<11>(evals) += typename Accumulator::View(tmp);
         }

--- a/barretenberg/cpp/src/barretenberg/vm2/generated/relations/poseidon2_hash.hpp
+++ b/barretenberg/cpp/src/barretenberg/vm2/generated/relations/poseidon2_hash.hpp
@@ -5,6 +5,7 @@
 
 #include "barretenberg/relations/relation_parameters.hpp"
 #include "barretenberg/relations/relation_types.hpp"
+#include "barretenberg/vm2/generated/columns.hpp"
 
 namespace bb::avm2 {
 
@@ -17,157 +18,160 @@ template <typename FF_> class poseidon2_hashImpl {
 
     template <typename AllEntities> inline static bool skip(const AllEntities& in)
     {
-        const auto& new_term = in;
-        return (new_term.poseidon2_hash_sel).is_zero();
+        using C = ColumnAndShifts;
+        return (in.get(C::poseidon2_hash_sel)).is_zero();
     }
 
     template <typename ContainerOverSubrelations, typename AllEntities>
     void static accumulate(ContainerOverSubrelations& evals,
-                           const AllEntities& new_term,
+                           const AllEntities& in,
                            [[maybe_unused]] const RelationParameters<FF>&,
                            [[maybe_unused]] const FF& scaling_factor)
     {
+        using C = ColumnAndShifts;
+
         const auto poseidon2_hash_TWOPOW64 = FF(uint256_t{ 0UL, 1UL, 0UL, 0UL });
-        const auto poseidon2_hash_IV = poseidon2_hash_TWOPOW64 * new_term.poseidon2_hash_input_len;
-        const auto poseidon2_hash_LATCH_CONDITION = new_term.poseidon2_hash_end + new_term.precomputed_first_row;
-        const auto poseidon2_hash_PADDED_LEN = new_term.poseidon2_hash_input_len + new_term.poseidon2_hash_padding;
-        const auto poseidon2_hash_NEXT_ROUND_COUNT = (new_term.poseidon2_hash_num_perm_rounds_rem - FF(1));
+        const auto poseidon2_hash_IV = poseidon2_hash_TWOPOW64 * in.get(C::poseidon2_hash_input_len);
+        const auto poseidon2_hash_LATCH_CONDITION = in.get(C::poseidon2_hash_end) + in.get(C::precomputed_first_row);
+        const auto poseidon2_hash_PADDED_LEN = in.get(C::poseidon2_hash_input_len) + in.get(C::poseidon2_hash_padding);
+        const auto poseidon2_hash_NEXT_ROUND_COUNT = (in.get(C::poseidon2_hash_num_perm_rounds_rem) - FF(1));
 
         {
             using Accumulator = typename std::tuple_element_t<0, ContainerOverSubrelations>;
-            auto tmp = new_term.poseidon2_hash_sel * (FF(1) - new_term.poseidon2_hash_sel);
+            auto tmp = in.get(C::poseidon2_hash_sel) * (FF(1) - in.get(C::poseidon2_hash_sel));
             tmp *= scaling_factor;
             std::get<0>(evals) += typename Accumulator::View(tmp);
         }
         {
             using Accumulator = typename std::tuple_element_t<1, ContainerOverSubrelations>;
-            auto tmp = new_term.poseidon2_hash_sel * (FF(1) - poseidon2_hash_LATCH_CONDITION) *
-                       (new_term.poseidon2_hash_output_shift - new_term.poseidon2_hash_output);
+            auto tmp = in.get(C::poseidon2_hash_sel) * (FF(1) - poseidon2_hash_LATCH_CONDITION) *
+                       (in.get(C::poseidon2_hash_output_shift) - in.get(C::poseidon2_hash_output));
             tmp *= scaling_factor;
             std::get<1>(evals) += typename Accumulator::View(tmp);
         }
         {
             using Accumulator = typename std::tuple_element_t<2, ContainerOverSubrelations>;
-            auto tmp = new_term.poseidon2_hash_start * (FF(1) - new_term.poseidon2_hash_start);
+            auto tmp = in.get(C::poseidon2_hash_start) * (FF(1) - in.get(C::poseidon2_hash_start));
             tmp *= scaling_factor;
             std::get<2>(evals) += typename Accumulator::View(tmp);
         }
         {
             using Accumulator = typename std::tuple_element_t<3, ContainerOverSubrelations>;
-            auto tmp = new_term.poseidon2_hash_sel_shift *
-                       (new_term.poseidon2_hash_start_shift - poseidon2_hash_LATCH_CONDITION);
+            auto tmp = in.get(C::poseidon2_hash_sel_shift) *
+                       (in.get(C::poseidon2_hash_start_shift) - poseidon2_hash_LATCH_CONDITION);
             tmp *= scaling_factor;
             std::get<3>(evals) += typename Accumulator::View(tmp);
         }
         {
             using Accumulator = typename std::tuple_element_t<4, ContainerOverSubrelations>;
-            auto tmp = new_term.poseidon2_hash_end * (FF(1) - new_term.poseidon2_hash_end);
+            auto tmp = in.get(C::poseidon2_hash_end) * (FF(1) - in.get(C::poseidon2_hash_end));
             tmp *= scaling_factor;
             std::get<4>(evals) += typename Accumulator::View(tmp);
         }
         {
             using Accumulator = typename std::tuple_element_t<5, ContainerOverSubrelations>;
-            auto tmp = new_term.poseidon2_hash_end * new_term.precomputed_first_row;
+            auto tmp = in.get(C::poseidon2_hash_end) * in.get(C::precomputed_first_row);
             tmp *= scaling_factor;
             std::get<5>(evals) += typename Accumulator::View(tmp);
         }
         {
             using Accumulator = typename std::tuple_element_t<6, ContainerOverSubrelations>;
-            auto tmp = new_term.poseidon2_hash_padding * (new_term.poseidon2_hash_padding - FF(1)) *
-                       (new_term.poseidon2_hash_padding - FF(2));
+            auto tmp = in.get(C::poseidon2_hash_padding) * (in.get(C::poseidon2_hash_padding) - FF(1)) *
+                       (in.get(C::poseidon2_hash_padding) - FF(2));
             tmp *= scaling_factor;
             std::get<6>(evals) += typename Accumulator::View(tmp);
         }
         {
             using Accumulator = typename std::tuple_element_t<7, ContainerOverSubrelations>;
-            auto tmp = new_term.poseidon2_hash_sel * new_term.poseidon2_hash_start *
-                       (new_term.poseidon2_hash_num_perm_rounds_rem * FF(3) - poseidon2_hash_PADDED_LEN);
+            auto tmp = in.get(C::poseidon2_hash_sel) * in.get(C::poseidon2_hash_start) *
+                       (in.get(C::poseidon2_hash_num_perm_rounds_rem) * FF(3) - poseidon2_hash_PADDED_LEN);
             tmp *= scaling_factor;
             std::get<7>(evals) += typename Accumulator::View(tmp);
         }
         {
             using Accumulator = typename std::tuple_element_t<8, ContainerOverSubrelations>;
             auto tmp =
-                new_term.poseidon2_hash_sel * (FF(1) - poseidon2_hash_LATCH_CONDITION) *
-                ((new_term.poseidon2_hash_num_perm_rounds_rem_shift - new_term.poseidon2_hash_num_perm_rounds_rem) +
+                in.get(C::poseidon2_hash_sel) * (FF(1) - poseidon2_hash_LATCH_CONDITION) *
+                ((in.get(C::poseidon2_hash_num_perm_rounds_rem_shift) - in.get(C::poseidon2_hash_num_perm_rounds_rem)) +
                  FF(1));
             tmp *= scaling_factor;
             std::get<8>(evals) += typename Accumulator::View(tmp);
         }
         {
             using Accumulator = typename std::tuple_element_t<9, ContainerOverSubrelations>;
-            auto tmp = new_term.poseidon2_hash_sel *
-                       ((poseidon2_hash_NEXT_ROUND_COUNT *
-                             (new_term.poseidon2_hash_end * (FF(1) - new_term.poseidon2_hash_num_perm_rounds_rem_inv) +
-                              new_term.poseidon2_hash_num_perm_rounds_rem_inv) -
-                         FF(1)) +
-                        new_term.poseidon2_hash_end);
+            auto tmp =
+                in.get(C::poseidon2_hash_sel) *
+                ((poseidon2_hash_NEXT_ROUND_COUNT *
+                      (in.get(C::poseidon2_hash_end) * (FF(1) - in.get(C::poseidon2_hash_num_perm_rounds_rem_inv)) +
+                       in.get(C::poseidon2_hash_num_perm_rounds_rem_inv)) -
+                  FF(1)) +
+                 in.get(C::poseidon2_hash_end));
             tmp *= scaling_factor;
             std::get<9>(evals) += typename Accumulator::View(tmp);
         }
         {
             using Accumulator = typename std::tuple_element_t<10, ContainerOverSubrelations>;
-            auto tmp = new_term.poseidon2_hash_sel * new_term.poseidon2_hash_start *
-                       (new_term.poseidon2_hash_a_0 - new_term.poseidon2_hash_input_0);
+            auto tmp = in.get(C::poseidon2_hash_sel) * in.get(C::poseidon2_hash_start) *
+                       (in.get(C::poseidon2_hash_a_0) - in.get(C::poseidon2_hash_input_0));
             tmp *= scaling_factor;
             std::get<10>(evals) += typename Accumulator::View(tmp);
         }
         {
             using Accumulator = typename std::tuple_element_t<11, ContainerOverSubrelations>;
-            auto tmp = new_term.poseidon2_hash_sel * (FF(1) - poseidon2_hash_LATCH_CONDITION) *
-                       ((new_term.poseidon2_hash_a_0_shift - new_term.poseidon2_hash_b_0) -
-                        new_term.poseidon2_hash_input_0_shift);
+            auto tmp = in.get(C::poseidon2_hash_sel) * (FF(1) - poseidon2_hash_LATCH_CONDITION) *
+                       ((in.get(C::poseidon2_hash_a_0_shift) - in.get(C::poseidon2_hash_b_0)) -
+                        in.get(C::poseidon2_hash_input_0_shift));
             tmp *= scaling_factor;
             std::get<11>(evals) += typename Accumulator::View(tmp);
         }
         {
             using Accumulator = typename std::tuple_element_t<12, ContainerOverSubrelations>;
-            auto tmp = new_term.poseidon2_hash_sel * new_term.poseidon2_hash_start *
-                       (new_term.poseidon2_hash_a_1 - new_term.poseidon2_hash_input_1);
+            auto tmp = in.get(C::poseidon2_hash_sel) * in.get(C::poseidon2_hash_start) *
+                       (in.get(C::poseidon2_hash_a_1) - in.get(C::poseidon2_hash_input_1));
             tmp *= scaling_factor;
             std::get<12>(evals) += typename Accumulator::View(tmp);
         }
         {
             using Accumulator = typename std::tuple_element_t<13, ContainerOverSubrelations>;
-            auto tmp = new_term.poseidon2_hash_sel * (FF(1) - poseidon2_hash_LATCH_CONDITION) *
-                       ((new_term.poseidon2_hash_a_1_shift - new_term.poseidon2_hash_b_1) -
-                        new_term.poseidon2_hash_input_1_shift);
+            auto tmp = in.get(C::poseidon2_hash_sel) * (FF(1) - poseidon2_hash_LATCH_CONDITION) *
+                       ((in.get(C::poseidon2_hash_a_1_shift) - in.get(C::poseidon2_hash_b_1)) -
+                        in.get(C::poseidon2_hash_input_1_shift));
             tmp *= scaling_factor;
             std::get<13>(evals) += typename Accumulator::View(tmp);
         }
         {
             using Accumulator = typename std::tuple_element_t<14, ContainerOverSubrelations>;
-            auto tmp = new_term.poseidon2_hash_sel * new_term.poseidon2_hash_start *
-                       (new_term.poseidon2_hash_a_2 - new_term.poseidon2_hash_input_2);
+            auto tmp = in.get(C::poseidon2_hash_sel) * in.get(C::poseidon2_hash_start) *
+                       (in.get(C::poseidon2_hash_a_2) - in.get(C::poseidon2_hash_input_2));
             tmp *= scaling_factor;
             std::get<14>(evals) += typename Accumulator::View(tmp);
         }
         {
             using Accumulator = typename std::tuple_element_t<15, ContainerOverSubrelations>;
-            auto tmp = new_term.poseidon2_hash_sel * (FF(1) - poseidon2_hash_LATCH_CONDITION) *
-                       ((new_term.poseidon2_hash_a_2_shift - new_term.poseidon2_hash_b_2) -
-                        new_term.poseidon2_hash_input_2_shift);
+            auto tmp = in.get(C::poseidon2_hash_sel) * (FF(1) - poseidon2_hash_LATCH_CONDITION) *
+                       ((in.get(C::poseidon2_hash_a_2_shift) - in.get(C::poseidon2_hash_b_2)) -
+                        in.get(C::poseidon2_hash_input_2_shift));
             tmp *= scaling_factor;
             std::get<15>(evals) += typename Accumulator::View(tmp);
         }
         {
             using Accumulator = typename std::tuple_element_t<16, ContainerOverSubrelations>;
-            auto tmp = new_term.poseidon2_hash_sel * new_term.poseidon2_hash_start *
-                       (new_term.poseidon2_hash_a_3 - poseidon2_hash_IV);
+            auto tmp = in.get(C::poseidon2_hash_sel) * in.get(C::poseidon2_hash_start) *
+                       (in.get(C::poseidon2_hash_a_3) - poseidon2_hash_IV);
             tmp *= scaling_factor;
             std::get<16>(evals) += typename Accumulator::View(tmp);
         }
         {
             using Accumulator = typename std::tuple_element_t<17, ContainerOverSubrelations>;
-            auto tmp = new_term.poseidon2_hash_sel * (FF(1) - poseidon2_hash_LATCH_CONDITION) *
-                       (new_term.poseidon2_hash_a_3_shift - new_term.poseidon2_hash_b_3);
+            auto tmp = in.get(C::poseidon2_hash_sel) * (FF(1) - poseidon2_hash_LATCH_CONDITION) *
+                       (in.get(C::poseidon2_hash_a_3_shift) - in.get(C::poseidon2_hash_b_3));
             tmp *= scaling_factor;
             std::get<17>(evals) += typename Accumulator::View(tmp);
         }
         {
             using Accumulator = typename std::tuple_element_t<18, ContainerOverSubrelations>;
-            auto tmp = new_term.poseidon2_hash_sel * poseidon2_hash_LATCH_CONDITION *
-                       (new_term.poseidon2_hash_output - new_term.poseidon2_hash_b_0);
+            auto tmp = in.get(C::poseidon2_hash_sel) * poseidon2_hash_LATCH_CONDITION *
+                       (in.get(C::poseidon2_hash_output) - in.get(C::poseidon2_hash_b_0));
             tmp *= scaling_factor;
             std::get<18>(evals) += typename Accumulator::View(tmp);
         }

--- a/barretenberg/cpp/src/barretenberg/vm2/generated/relations/poseidon2_perm.hpp
+++ b/barretenberg/cpp/src/barretenberg/vm2/generated/relations/poseidon2_perm.hpp
@@ -5,6 +5,7 @@
 
 #include "barretenberg/relations/relation_parameters.hpp"
 #include "barretenberg/relations/relation_types.hpp"
+#include "barretenberg/vm2/generated/columns.hpp"
 
 namespace bb::avm2 {
 
@@ -25,16 +26,18 @@ template <typename FF_> class poseidon2_permImpl {
 
     template <typename AllEntities> inline static bool skip(const AllEntities& in)
     {
-        const auto& new_term = in;
-        return (new_term.poseidon2_perm_sel).is_zero();
+        using C = ColumnAndShifts;
+        return (in.get(C::poseidon2_perm_sel)).is_zero();
     }
 
     template <typename ContainerOverSubrelations, typename AllEntities>
     void static accumulate(ContainerOverSubrelations& evals,
-                           const AllEntities& new_term,
+                           const AllEntities& in,
                            [[maybe_unused]] const RelationParameters<FF>&,
                            [[maybe_unused]] const FF& scaling_factor)
     {
+        using C = ColumnAndShifts;
+
         const auto poseidon2_params_MU_0 =
             FF(uint256_t{ 13071735289386612455UL, 937867514930142591UL, 338297992309721356UL, 1214967615784395659UL });
         const auto poseidon2_params_MU_1 =
@@ -387,14 +390,14 @@ template <typename FF_> class poseidon2_permImpl {
             uint256_t{ 1233442753680249567UL, 15490006495937952898UL, 7249042245074469654UL, 2138985910652398451UL });
         const auto poseidon2_params_C_63_3 =
             FF(uint256_t{ 4115849303762846724UL, 2230284817967990783UL, 5095423606777193313UL, 1685862792723606183UL });
-        const auto poseidon2_perm_EXT_LAYER_0 = new_term.poseidon2_perm_a_0 + new_term.poseidon2_perm_a_1;
-        const auto poseidon2_perm_EXT_LAYER_1 = new_term.poseidon2_perm_a_2 + new_term.poseidon2_perm_a_3;
-        const auto poseidon2_perm_EXT_LAYER_2 = FF(2) * new_term.poseidon2_perm_a_1 + poseidon2_perm_EXT_LAYER_1;
-        const auto poseidon2_perm_EXT_LAYER_3 = FF(2) * new_term.poseidon2_perm_a_3 + poseidon2_perm_EXT_LAYER_0;
-        const auto poseidon2_perm_ARK_0_0 = new_term.poseidon2_perm_EXT_LAYER_6 + poseidon2_params_C_0_0;
-        const auto poseidon2_perm_ARK_0_1 = new_term.poseidon2_perm_EXT_LAYER_5 + poseidon2_params_C_0_1;
-        const auto poseidon2_perm_ARK_0_2 = new_term.poseidon2_perm_EXT_LAYER_7 + poseidon2_params_C_0_2;
-        const auto poseidon2_perm_ARK_0_3 = new_term.poseidon2_perm_EXT_LAYER_4 + poseidon2_params_C_0_3;
+        const auto poseidon2_perm_EXT_LAYER_0 = in.get(C::poseidon2_perm_a_0) + in.get(C::poseidon2_perm_a_1);
+        const auto poseidon2_perm_EXT_LAYER_1 = in.get(C::poseidon2_perm_a_2) + in.get(C::poseidon2_perm_a_3);
+        const auto poseidon2_perm_EXT_LAYER_2 = FF(2) * in.get(C::poseidon2_perm_a_1) + poseidon2_perm_EXT_LAYER_1;
+        const auto poseidon2_perm_EXT_LAYER_3 = FF(2) * in.get(C::poseidon2_perm_a_3) + poseidon2_perm_EXT_LAYER_0;
+        const auto poseidon2_perm_ARK_0_0 = in.get(C::poseidon2_perm_EXT_LAYER_6) + poseidon2_params_C_0_0;
+        const auto poseidon2_perm_ARK_0_1 = in.get(C::poseidon2_perm_EXT_LAYER_5) + poseidon2_params_C_0_1;
+        const auto poseidon2_perm_ARK_0_2 = in.get(C::poseidon2_perm_EXT_LAYER_7) + poseidon2_params_C_0_2;
+        const auto poseidon2_perm_ARK_0_3 = in.get(C::poseidon2_perm_EXT_LAYER_4) + poseidon2_params_C_0_3;
         const auto poseidon2_perm_A_0_0 = poseidon2_perm_ARK_0_0 * poseidon2_perm_ARK_0_0 * poseidon2_perm_ARK_0_0 *
                                           poseidon2_perm_ARK_0_0 * poseidon2_perm_ARK_0_0;
         const auto poseidon2_perm_A_0_1 = poseidon2_perm_ARK_0_1 * poseidon2_perm_ARK_0_1 * poseidon2_perm_ARK_0_1 *
@@ -407,10 +410,10 @@ template <typename FF_> class poseidon2_permImpl {
         const auto poseidon2_perm_T_0_1 = poseidon2_perm_A_0_2 + poseidon2_perm_A_0_3;
         const auto poseidon2_perm_T_0_2 = FF(2) * poseidon2_perm_A_0_1 + poseidon2_perm_T_0_1;
         const auto poseidon2_perm_T_0_3 = FF(2) * poseidon2_perm_A_0_3 + poseidon2_perm_T_0_0;
-        const auto poseidon2_perm_ARK_1_0 = new_term.poseidon2_perm_T_0_6 + poseidon2_params_C_1_0;
-        const auto poseidon2_perm_ARK_1_1 = new_term.poseidon2_perm_T_0_5 + poseidon2_params_C_1_1;
-        const auto poseidon2_perm_ARK_1_2 = new_term.poseidon2_perm_T_0_7 + poseidon2_params_C_1_2;
-        const auto poseidon2_perm_ARK_1_3 = new_term.poseidon2_perm_T_0_4 + poseidon2_params_C_1_3;
+        const auto poseidon2_perm_ARK_1_0 = in.get(C::poseidon2_perm_T_0_6) + poseidon2_params_C_1_0;
+        const auto poseidon2_perm_ARK_1_1 = in.get(C::poseidon2_perm_T_0_5) + poseidon2_params_C_1_1;
+        const auto poseidon2_perm_ARK_1_2 = in.get(C::poseidon2_perm_T_0_7) + poseidon2_params_C_1_2;
+        const auto poseidon2_perm_ARK_1_3 = in.get(C::poseidon2_perm_T_0_4) + poseidon2_params_C_1_3;
         const auto poseidon2_perm_A_1_0 = poseidon2_perm_ARK_1_0 * poseidon2_perm_ARK_1_0 * poseidon2_perm_ARK_1_0 *
                                           poseidon2_perm_ARK_1_0 * poseidon2_perm_ARK_1_0;
         const auto poseidon2_perm_A_1_1 = poseidon2_perm_ARK_1_1 * poseidon2_perm_ARK_1_1 * poseidon2_perm_ARK_1_1 *
@@ -423,10 +426,10 @@ template <typename FF_> class poseidon2_permImpl {
         const auto poseidon2_perm_T_1_1 = poseidon2_perm_A_1_2 + poseidon2_perm_A_1_3;
         const auto poseidon2_perm_T_1_2 = FF(2) * poseidon2_perm_A_1_1 + poseidon2_perm_T_1_1;
         const auto poseidon2_perm_T_1_3 = FF(2) * poseidon2_perm_A_1_3 + poseidon2_perm_T_1_0;
-        const auto poseidon2_perm_ARK_2_0 = new_term.poseidon2_perm_T_1_6 + poseidon2_params_C_2_0;
-        const auto poseidon2_perm_ARK_2_1 = new_term.poseidon2_perm_T_1_5 + poseidon2_params_C_2_1;
-        const auto poseidon2_perm_ARK_2_2 = new_term.poseidon2_perm_T_1_7 + poseidon2_params_C_2_2;
-        const auto poseidon2_perm_ARK_2_3 = new_term.poseidon2_perm_T_1_4 + poseidon2_params_C_2_3;
+        const auto poseidon2_perm_ARK_2_0 = in.get(C::poseidon2_perm_T_1_6) + poseidon2_params_C_2_0;
+        const auto poseidon2_perm_ARK_2_1 = in.get(C::poseidon2_perm_T_1_5) + poseidon2_params_C_2_1;
+        const auto poseidon2_perm_ARK_2_2 = in.get(C::poseidon2_perm_T_1_7) + poseidon2_params_C_2_2;
+        const auto poseidon2_perm_ARK_2_3 = in.get(C::poseidon2_perm_T_1_4) + poseidon2_params_C_2_3;
         const auto poseidon2_perm_A_2_0 = poseidon2_perm_ARK_2_0 * poseidon2_perm_ARK_2_0 * poseidon2_perm_ARK_2_0 *
                                           poseidon2_perm_ARK_2_0 * poseidon2_perm_ARK_2_0;
         const auto poseidon2_perm_A_2_1 = poseidon2_perm_ARK_2_1 * poseidon2_perm_ARK_2_1 * poseidon2_perm_ARK_2_1 *
@@ -439,10 +442,10 @@ template <typename FF_> class poseidon2_permImpl {
         const auto poseidon2_perm_T_2_1 = poseidon2_perm_A_2_2 + poseidon2_perm_A_2_3;
         const auto poseidon2_perm_T_2_2 = FF(2) * poseidon2_perm_A_2_1 + poseidon2_perm_T_2_1;
         const auto poseidon2_perm_T_2_3 = FF(2) * poseidon2_perm_A_2_3 + poseidon2_perm_T_2_0;
-        const auto poseidon2_perm_ARK_3_0 = new_term.poseidon2_perm_T_2_6 + poseidon2_params_C_3_0;
-        const auto poseidon2_perm_ARK_3_1 = new_term.poseidon2_perm_T_2_5 + poseidon2_params_C_3_1;
-        const auto poseidon2_perm_ARK_3_2 = new_term.poseidon2_perm_T_2_7 + poseidon2_params_C_3_2;
-        const auto poseidon2_perm_ARK_3_3 = new_term.poseidon2_perm_T_2_4 + poseidon2_params_C_3_3;
+        const auto poseidon2_perm_ARK_3_0 = in.get(C::poseidon2_perm_T_2_6) + poseidon2_params_C_3_0;
+        const auto poseidon2_perm_ARK_3_1 = in.get(C::poseidon2_perm_T_2_5) + poseidon2_params_C_3_1;
+        const auto poseidon2_perm_ARK_3_2 = in.get(C::poseidon2_perm_T_2_7) + poseidon2_params_C_3_2;
+        const auto poseidon2_perm_ARK_3_3 = in.get(C::poseidon2_perm_T_2_4) + poseidon2_params_C_3_3;
         const auto poseidon2_perm_A_3_0 = poseidon2_perm_ARK_3_0 * poseidon2_perm_ARK_3_0 * poseidon2_perm_ARK_3_0 *
                                           poseidon2_perm_ARK_3_0 * poseidon2_perm_ARK_3_0;
         const auto poseidon2_perm_A_3_1 = poseidon2_perm_ARK_3_1 * poseidon2_perm_ARK_3_1 * poseidon2_perm_ARK_3_1 *
@@ -455,10 +458,10 @@ template <typename FF_> class poseidon2_permImpl {
         const auto poseidon2_perm_T_3_1 = poseidon2_perm_A_3_2 + poseidon2_perm_A_3_3;
         const auto poseidon2_perm_T_3_2 = FF(2) * poseidon2_perm_A_3_1 + poseidon2_perm_T_3_1;
         const auto poseidon2_perm_T_3_3 = FF(2) * poseidon2_perm_A_3_3 + poseidon2_perm_T_3_0;
-        const auto poseidon2_perm_ARK_4_0 = new_term.poseidon2_perm_T_3_6 + poseidon2_params_C_4_0;
-        const auto poseidon2_perm_ARK_4_1 = new_term.poseidon2_perm_T_3_5 + poseidon2_params_C_4_1;
-        const auto poseidon2_perm_ARK_4_2 = new_term.poseidon2_perm_T_3_7 + poseidon2_params_C_4_2;
-        const auto poseidon2_perm_ARK_4_3 = new_term.poseidon2_perm_T_3_4 + poseidon2_params_C_4_3;
+        const auto poseidon2_perm_ARK_4_0 = in.get(C::poseidon2_perm_T_3_6) + poseidon2_params_C_4_0;
+        const auto poseidon2_perm_ARK_4_1 = in.get(C::poseidon2_perm_T_3_5) + poseidon2_params_C_4_1;
+        const auto poseidon2_perm_ARK_4_2 = in.get(C::poseidon2_perm_T_3_7) + poseidon2_params_C_4_2;
+        const auto poseidon2_perm_ARK_4_3 = in.get(C::poseidon2_perm_T_3_4) + poseidon2_params_C_4_3;
         const auto poseidon2_perm_A_4_0 = poseidon2_perm_ARK_4_0 * poseidon2_perm_ARK_4_0 * poseidon2_perm_ARK_4_0 *
                                           poseidon2_perm_ARK_4_0 * poseidon2_perm_ARK_4_0;
         const auto poseidon2_perm_A_4_1 = poseidon2_perm_ARK_4_1;
@@ -466,10 +469,10 @@ template <typename FF_> class poseidon2_permImpl {
         const auto poseidon2_perm_A_4_3 = poseidon2_perm_ARK_4_3;
         const auto poseidon2_perm_SUM_4 =
             poseidon2_perm_A_4_0 + poseidon2_perm_A_4_1 + poseidon2_perm_A_4_2 + poseidon2_perm_A_4_3;
-        const auto poseidon2_perm_ARK_5_0 = new_term.poseidon2_perm_B_4_0 + poseidon2_params_C_5_0;
-        const auto poseidon2_perm_ARK_5_1 = new_term.poseidon2_perm_B_4_1 + poseidon2_params_C_5_1;
-        const auto poseidon2_perm_ARK_5_2 = new_term.poseidon2_perm_B_4_2 + poseidon2_params_C_5_2;
-        const auto poseidon2_perm_ARK_5_3 = new_term.poseidon2_perm_B_4_3 + poseidon2_params_C_5_3;
+        const auto poseidon2_perm_ARK_5_0 = in.get(C::poseidon2_perm_B_4_0) + poseidon2_params_C_5_0;
+        const auto poseidon2_perm_ARK_5_1 = in.get(C::poseidon2_perm_B_4_1) + poseidon2_params_C_5_1;
+        const auto poseidon2_perm_ARK_5_2 = in.get(C::poseidon2_perm_B_4_2) + poseidon2_params_C_5_2;
+        const auto poseidon2_perm_ARK_5_3 = in.get(C::poseidon2_perm_B_4_3) + poseidon2_params_C_5_3;
         const auto poseidon2_perm_A_5_0 = poseidon2_perm_ARK_5_0 * poseidon2_perm_ARK_5_0 * poseidon2_perm_ARK_5_0 *
                                           poseidon2_perm_ARK_5_0 * poseidon2_perm_ARK_5_0;
         const auto poseidon2_perm_A_5_1 = poseidon2_perm_ARK_5_1;
@@ -477,10 +480,10 @@ template <typename FF_> class poseidon2_permImpl {
         const auto poseidon2_perm_A_5_3 = poseidon2_perm_ARK_5_3;
         const auto poseidon2_perm_SUM_5 =
             poseidon2_perm_A_5_0 + poseidon2_perm_A_5_1 + poseidon2_perm_A_5_2 + poseidon2_perm_A_5_3;
-        const auto poseidon2_perm_ARK_6_0 = new_term.poseidon2_perm_B_5_0 + poseidon2_params_C_6_0;
-        const auto poseidon2_perm_ARK_6_1 = new_term.poseidon2_perm_B_5_1 + poseidon2_params_C_6_1;
-        const auto poseidon2_perm_ARK_6_2 = new_term.poseidon2_perm_B_5_2 + poseidon2_params_C_6_2;
-        const auto poseidon2_perm_ARK_6_3 = new_term.poseidon2_perm_B_5_3 + poseidon2_params_C_6_3;
+        const auto poseidon2_perm_ARK_6_0 = in.get(C::poseidon2_perm_B_5_0) + poseidon2_params_C_6_0;
+        const auto poseidon2_perm_ARK_6_1 = in.get(C::poseidon2_perm_B_5_1) + poseidon2_params_C_6_1;
+        const auto poseidon2_perm_ARK_6_2 = in.get(C::poseidon2_perm_B_5_2) + poseidon2_params_C_6_2;
+        const auto poseidon2_perm_ARK_6_3 = in.get(C::poseidon2_perm_B_5_3) + poseidon2_params_C_6_3;
         const auto poseidon2_perm_A_6_0 = poseidon2_perm_ARK_6_0 * poseidon2_perm_ARK_6_0 * poseidon2_perm_ARK_6_0 *
                                           poseidon2_perm_ARK_6_0 * poseidon2_perm_ARK_6_0;
         const auto poseidon2_perm_A_6_1 = poseidon2_perm_ARK_6_1;
@@ -488,10 +491,10 @@ template <typename FF_> class poseidon2_permImpl {
         const auto poseidon2_perm_A_6_3 = poseidon2_perm_ARK_6_3;
         const auto poseidon2_perm_SUM_6 =
             poseidon2_perm_A_6_0 + poseidon2_perm_A_6_1 + poseidon2_perm_A_6_2 + poseidon2_perm_A_6_3;
-        const auto poseidon2_perm_ARK_7_0 = new_term.poseidon2_perm_B_6_0 + poseidon2_params_C_7_0;
-        const auto poseidon2_perm_ARK_7_1 = new_term.poseidon2_perm_B_6_1 + poseidon2_params_C_7_1;
-        const auto poseidon2_perm_ARK_7_2 = new_term.poseidon2_perm_B_6_2 + poseidon2_params_C_7_2;
-        const auto poseidon2_perm_ARK_7_3 = new_term.poseidon2_perm_B_6_3 + poseidon2_params_C_7_3;
+        const auto poseidon2_perm_ARK_7_0 = in.get(C::poseidon2_perm_B_6_0) + poseidon2_params_C_7_0;
+        const auto poseidon2_perm_ARK_7_1 = in.get(C::poseidon2_perm_B_6_1) + poseidon2_params_C_7_1;
+        const auto poseidon2_perm_ARK_7_2 = in.get(C::poseidon2_perm_B_6_2) + poseidon2_params_C_7_2;
+        const auto poseidon2_perm_ARK_7_3 = in.get(C::poseidon2_perm_B_6_3) + poseidon2_params_C_7_3;
         const auto poseidon2_perm_A_7_0 = poseidon2_perm_ARK_7_0 * poseidon2_perm_ARK_7_0 * poseidon2_perm_ARK_7_0 *
                                           poseidon2_perm_ARK_7_0 * poseidon2_perm_ARK_7_0;
         const auto poseidon2_perm_A_7_1 = poseidon2_perm_ARK_7_1;
@@ -499,10 +502,10 @@ template <typename FF_> class poseidon2_permImpl {
         const auto poseidon2_perm_A_7_3 = poseidon2_perm_ARK_7_3;
         const auto poseidon2_perm_SUM_7 =
             poseidon2_perm_A_7_0 + poseidon2_perm_A_7_1 + poseidon2_perm_A_7_2 + poseidon2_perm_A_7_3;
-        const auto poseidon2_perm_ARK_8_0 = new_term.poseidon2_perm_B_7_0 + poseidon2_params_C_8_0;
-        const auto poseidon2_perm_ARK_8_1 = new_term.poseidon2_perm_B_7_1 + poseidon2_params_C_8_1;
-        const auto poseidon2_perm_ARK_8_2 = new_term.poseidon2_perm_B_7_2 + poseidon2_params_C_8_2;
-        const auto poseidon2_perm_ARK_8_3 = new_term.poseidon2_perm_B_7_3 + poseidon2_params_C_8_3;
+        const auto poseidon2_perm_ARK_8_0 = in.get(C::poseidon2_perm_B_7_0) + poseidon2_params_C_8_0;
+        const auto poseidon2_perm_ARK_8_1 = in.get(C::poseidon2_perm_B_7_1) + poseidon2_params_C_8_1;
+        const auto poseidon2_perm_ARK_8_2 = in.get(C::poseidon2_perm_B_7_2) + poseidon2_params_C_8_2;
+        const auto poseidon2_perm_ARK_8_3 = in.get(C::poseidon2_perm_B_7_3) + poseidon2_params_C_8_3;
         const auto poseidon2_perm_A_8_0 = poseidon2_perm_ARK_8_0 * poseidon2_perm_ARK_8_0 * poseidon2_perm_ARK_8_0 *
                                           poseidon2_perm_ARK_8_0 * poseidon2_perm_ARK_8_0;
         const auto poseidon2_perm_A_8_1 = poseidon2_perm_ARK_8_1;
@@ -510,10 +513,10 @@ template <typename FF_> class poseidon2_permImpl {
         const auto poseidon2_perm_A_8_3 = poseidon2_perm_ARK_8_3;
         const auto poseidon2_perm_SUM_8 =
             poseidon2_perm_A_8_0 + poseidon2_perm_A_8_1 + poseidon2_perm_A_8_2 + poseidon2_perm_A_8_3;
-        const auto poseidon2_perm_ARK_9_0 = new_term.poseidon2_perm_B_8_0 + poseidon2_params_C_9_0;
-        const auto poseidon2_perm_ARK_9_1 = new_term.poseidon2_perm_B_8_1 + poseidon2_params_C_9_1;
-        const auto poseidon2_perm_ARK_9_2 = new_term.poseidon2_perm_B_8_2 + poseidon2_params_C_9_2;
-        const auto poseidon2_perm_ARK_9_3 = new_term.poseidon2_perm_B_8_3 + poseidon2_params_C_9_3;
+        const auto poseidon2_perm_ARK_9_0 = in.get(C::poseidon2_perm_B_8_0) + poseidon2_params_C_9_0;
+        const auto poseidon2_perm_ARK_9_1 = in.get(C::poseidon2_perm_B_8_1) + poseidon2_params_C_9_1;
+        const auto poseidon2_perm_ARK_9_2 = in.get(C::poseidon2_perm_B_8_2) + poseidon2_params_C_9_2;
+        const auto poseidon2_perm_ARK_9_3 = in.get(C::poseidon2_perm_B_8_3) + poseidon2_params_C_9_3;
         const auto poseidon2_perm_A_9_0 = poseidon2_perm_ARK_9_0 * poseidon2_perm_ARK_9_0 * poseidon2_perm_ARK_9_0 *
                                           poseidon2_perm_ARK_9_0 * poseidon2_perm_ARK_9_0;
         const auto poseidon2_perm_A_9_1 = poseidon2_perm_ARK_9_1;
@@ -521,10 +524,10 @@ template <typename FF_> class poseidon2_permImpl {
         const auto poseidon2_perm_A_9_3 = poseidon2_perm_ARK_9_3;
         const auto poseidon2_perm_SUM_9 =
             poseidon2_perm_A_9_0 + poseidon2_perm_A_9_1 + poseidon2_perm_A_9_2 + poseidon2_perm_A_9_3;
-        const auto poseidon2_perm_ARK_10_0 = new_term.poseidon2_perm_B_9_0 + poseidon2_params_C_10_0;
-        const auto poseidon2_perm_ARK_10_1 = new_term.poseidon2_perm_B_9_1 + poseidon2_params_C_10_1;
-        const auto poseidon2_perm_ARK_10_2 = new_term.poseidon2_perm_B_9_2 + poseidon2_params_C_10_2;
-        const auto poseidon2_perm_ARK_10_3 = new_term.poseidon2_perm_B_9_3 + poseidon2_params_C_10_3;
+        const auto poseidon2_perm_ARK_10_0 = in.get(C::poseidon2_perm_B_9_0) + poseidon2_params_C_10_0;
+        const auto poseidon2_perm_ARK_10_1 = in.get(C::poseidon2_perm_B_9_1) + poseidon2_params_C_10_1;
+        const auto poseidon2_perm_ARK_10_2 = in.get(C::poseidon2_perm_B_9_2) + poseidon2_params_C_10_2;
+        const auto poseidon2_perm_ARK_10_3 = in.get(C::poseidon2_perm_B_9_3) + poseidon2_params_C_10_3;
         const auto poseidon2_perm_A_10_0 = poseidon2_perm_ARK_10_0 * poseidon2_perm_ARK_10_0 * poseidon2_perm_ARK_10_0 *
                                            poseidon2_perm_ARK_10_0 * poseidon2_perm_ARK_10_0;
         const auto poseidon2_perm_A_10_1 = poseidon2_perm_ARK_10_1;
@@ -532,10 +535,10 @@ template <typename FF_> class poseidon2_permImpl {
         const auto poseidon2_perm_A_10_3 = poseidon2_perm_ARK_10_3;
         const auto poseidon2_perm_SUM_10 =
             poseidon2_perm_A_10_0 + poseidon2_perm_A_10_1 + poseidon2_perm_A_10_2 + poseidon2_perm_A_10_3;
-        const auto poseidon2_perm_ARK_11_0 = new_term.poseidon2_perm_B_10_0 + poseidon2_params_C_11_0;
-        const auto poseidon2_perm_ARK_11_1 = new_term.poseidon2_perm_B_10_1 + poseidon2_params_C_11_1;
-        const auto poseidon2_perm_ARK_11_2 = new_term.poseidon2_perm_B_10_2 + poseidon2_params_C_11_2;
-        const auto poseidon2_perm_ARK_11_3 = new_term.poseidon2_perm_B_10_3 + poseidon2_params_C_11_3;
+        const auto poseidon2_perm_ARK_11_0 = in.get(C::poseidon2_perm_B_10_0) + poseidon2_params_C_11_0;
+        const auto poseidon2_perm_ARK_11_1 = in.get(C::poseidon2_perm_B_10_1) + poseidon2_params_C_11_1;
+        const auto poseidon2_perm_ARK_11_2 = in.get(C::poseidon2_perm_B_10_2) + poseidon2_params_C_11_2;
+        const auto poseidon2_perm_ARK_11_3 = in.get(C::poseidon2_perm_B_10_3) + poseidon2_params_C_11_3;
         const auto poseidon2_perm_A_11_0 = poseidon2_perm_ARK_11_0 * poseidon2_perm_ARK_11_0 * poseidon2_perm_ARK_11_0 *
                                            poseidon2_perm_ARK_11_0 * poseidon2_perm_ARK_11_0;
         const auto poseidon2_perm_A_11_1 = poseidon2_perm_ARK_11_1;
@@ -543,10 +546,10 @@ template <typename FF_> class poseidon2_permImpl {
         const auto poseidon2_perm_A_11_3 = poseidon2_perm_ARK_11_3;
         const auto poseidon2_perm_SUM_11 =
             poseidon2_perm_A_11_0 + poseidon2_perm_A_11_1 + poseidon2_perm_A_11_2 + poseidon2_perm_A_11_3;
-        const auto poseidon2_perm_ARK_12_0 = new_term.poseidon2_perm_B_11_0 + poseidon2_params_C_12_0;
-        const auto poseidon2_perm_ARK_12_1 = new_term.poseidon2_perm_B_11_1 + poseidon2_params_C_12_1;
-        const auto poseidon2_perm_ARK_12_2 = new_term.poseidon2_perm_B_11_2 + poseidon2_params_C_12_2;
-        const auto poseidon2_perm_ARK_12_3 = new_term.poseidon2_perm_B_11_3 + poseidon2_params_C_12_3;
+        const auto poseidon2_perm_ARK_12_0 = in.get(C::poseidon2_perm_B_11_0) + poseidon2_params_C_12_0;
+        const auto poseidon2_perm_ARK_12_1 = in.get(C::poseidon2_perm_B_11_1) + poseidon2_params_C_12_1;
+        const auto poseidon2_perm_ARK_12_2 = in.get(C::poseidon2_perm_B_11_2) + poseidon2_params_C_12_2;
+        const auto poseidon2_perm_ARK_12_3 = in.get(C::poseidon2_perm_B_11_3) + poseidon2_params_C_12_3;
         const auto poseidon2_perm_A_12_0 = poseidon2_perm_ARK_12_0 * poseidon2_perm_ARK_12_0 * poseidon2_perm_ARK_12_0 *
                                            poseidon2_perm_ARK_12_0 * poseidon2_perm_ARK_12_0;
         const auto poseidon2_perm_A_12_1 = poseidon2_perm_ARK_12_1;
@@ -554,10 +557,10 @@ template <typename FF_> class poseidon2_permImpl {
         const auto poseidon2_perm_A_12_3 = poseidon2_perm_ARK_12_3;
         const auto poseidon2_perm_SUM_12 =
             poseidon2_perm_A_12_0 + poseidon2_perm_A_12_1 + poseidon2_perm_A_12_2 + poseidon2_perm_A_12_3;
-        const auto poseidon2_perm_ARK_13_0 = new_term.poseidon2_perm_B_12_0 + poseidon2_params_C_13_0;
-        const auto poseidon2_perm_ARK_13_1 = new_term.poseidon2_perm_B_12_1 + poseidon2_params_C_13_1;
-        const auto poseidon2_perm_ARK_13_2 = new_term.poseidon2_perm_B_12_2 + poseidon2_params_C_13_2;
-        const auto poseidon2_perm_ARK_13_3 = new_term.poseidon2_perm_B_12_3 + poseidon2_params_C_13_3;
+        const auto poseidon2_perm_ARK_13_0 = in.get(C::poseidon2_perm_B_12_0) + poseidon2_params_C_13_0;
+        const auto poseidon2_perm_ARK_13_1 = in.get(C::poseidon2_perm_B_12_1) + poseidon2_params_C_13_1;
+        const auto poseidon2_perm_ARK_13_2 = in.get(C::poseidon2_perm_B_12_2) + poseidon2_params_C_13_2;
+        const auto poseidon2_perm_ARK_13_3 = in.get(C::poseidon2_perm_B_12_3) + poseidon2_params_C_13_3;
         const auto poseidon2_perm_A_13_0 = poseidon2_perm_ARK_13_0 * poseidon2_perm_ARK_13_0 * poseidon2_perm_ARK_13_0 *
                                            poseidon2_perm_ARK_13_0 * poseidon2_perm_ARK_13_0;
         const auto poseidon2_perm_A_13_1 = poseidon2_perm_ARK_13_1;
@@ -565,10 +568,10 @@ template <typename FF_> class poseidon2_permImpl {
         const auto poseidon2_perm_A_13_3 = poseidon2_perm_ARK_13_3;
         const auto poseidon2_perm_SUM_13 =
             poseidon2_perm_A_13_0 + poseidon2_perm_A_13_1 + poseidon2_perm_A_13_2 + poseidon2_perm_A_13_3;
-        const auto poseidon2_perm_ARK_14_0 = new_term.poseidon2_perm_B_13_0 + poseidon2_params_C_14_0;
-        const auto poseidon2_perm_ARK_14_1 = new_term.poseidon2_perm_B_13_1 + poseidon2_params_C_14_1;
-        const auto poseidon2_perm_ARK_14_2 = new_term.poseidon2_perm_B_13_2 + poseidon2_params_C_14_2;
-        const auto poseidon2_perm_ARK_14_3 = new_term.poseidon2_perm_B_13_3 + poseidon2_params_C_14_3;
+        const auto poseidon2_perm_ARK_14_0 = in.get(C::poseidon2_perm_B_13_0) + poseidon2_params_C_14_0;
+        const auto poseidon2_perm_ARK_14_1 = in.get(C::poseidon2_perm_B_13_1) + poseidon2_params_C_14_1;
+        const auto poseidon2_perm_ARK_14_2 = in.get(C::poseidon2_perm_B_13_2) + poseidon2_params_C_14_2;
+        const auto poseidon2_perm_ARK_14_3 = in.get(C::poseidon2_perm_B_13_3) + poseidon2_params_C_14_3;
         const auto poseidon2_perm_A_14_0 = poseidon2_perm_ARK_14_0 * poseidon2_perm_ARK_14_0 * poseidon2_perm_ARK_14_0 *
                                            poseidon2_perm_ARK_14_0 * poseidon2_perm_ARK_14_0;
         const auto poseidon2_perm_A_14_1 = poseidon2_perm_ARK_14_1;
@@ -576,10 +579,10 @@ template <typename FF_> class poseidon2_permImpl {
         const auto poseidon2_perm_A_14_3 = poseidon2_perm_ARK_14_3;
         const auto poseidon2_perm_SUM_14 =
             poseidon2_perm_A_14_0 + poseidon2_perm_A_14_1 + poseidon2_perm_A_14_2 + poseidon2_perm_A_14_3;
-        const auto poseidon2_perm_ARK_15_0 = new_term.poseidon2_perm_B_14_0 + poseidon2_params_C_15_0;
-        const auto poseidon2_perm_ARK_15_1 = new_term.poseidon2_perm_B_14_1 + poseidon2_params_C_15_1;
-        const auto poseidon2_perm_ARK_15_2 = new_term.poseidon2_perm_B_14_2 + poseidon2_params_C_15_2;
-        const auto poseidon2_perm_ARK_15_3 = new_term.poseidon2_perm_B_14_3 + poseidon2_params_C_15_3;
+        const auto poseidon2_perm_ARK_15_0 = in.get(C::poseidon2_perm_B_14_0) + poseidon2_params_C_15_0;
+        const auto poseidon2_perm_ARK_15_1 = in.get(C::poseidon2_perm_B_14_1) + poseidon2_params_C_15_1;
+        const auto poseidon2_perm_ARK_15_2 = in.get(C::poseidon2_perm_B_14_2) + poseidon2_params_C_15_2;
+        const auto poseidon2_perm_ARK_15_3 = in.get(C::poseidon2_perm_B_14_3) + poseidon2_params_C_15_3;
         const auto poseidon2_perm_A_15_0 = poseidon2_perm_ARK_15_0 * poseidon2_perm_ARK_15_0 * poseidon2_perm_ARK_15_0 *
                                            poseidon2_perm_ARK_15_0 * poseidon2_perm_ARK_15_0;
         const auto poseidon2_perm_A_15_1 = poseidon2_perm_ARK_15_1;
@@ -587,10 +590,10 @@ template <typename FF_> class poseidon2_permImpl {
         const auto poseidon2_perm_A_15_3 = poseidon2_perm_ARK_15_3;
         const auto poseidon2_perm_SUM_15 =
             poseidon2_perm_A_15_0 + poseidon2_perm_A_15_1 + poseidon2_perm_A_15_2 + poseidon2_perm_A_15_3;
-        const auto poseidon2_perm_ARK_16_0 = new_term.poseidon2_perm_B_15_0 + poseidon2_params_C_16_0;
-        const auto poseidon2_perm_ARK_16_1 = new_term.poseidon2_perm_B_15_1 + poseidon2_params_C_16_1;
-        const auto poseidon2_perm_ARK_16_2 = new_term.poseidon2_perm_B_15_2 + poseidon2_params_C_16_2;
-        const auto poseidon2_perm_ARK_16_3 = new_term.poseidon2_perm_B_15_3 + poseidon2_params_C_16_3;
+        const auto poseidon2_perm_ARK_16_0 = in.get(C::poseidon2_perm_B_15_0) + poseidon2_params_C_16_0;
+        const auto poseidon2_perm_ARK_16_1 = in.get(C::poseidon2_perm_B_15_1) + poseidon2_params_C_16_1;
+        const auto poseidon2_perm_ARK_16_2 = in.get(C::poseidon2_perm_B_15_2) + poseidon2_params_C_16_2;
+        const auto poseidon2_perm_ARK_16_3 = in.get(C::poseidon2_perm_B_15_3) + poseidon2_params_C_16_3;
         const auto poseidon2_perm_A_16_0 = poseidon2_perm_ARK_16_0 * poseidon2_perm_ARK_16_0 * poseidon2_perm_ARK_16_0 *
                                            poseidon2_perm_ARK_16_0 * poseidon2_perm_ARK_16_0;
         const auto poseidon2_perm_A_16_1 = poseidon2_perm_ARK_16_1;
@@ -598,10 +601,10 @@ template <typename FF_> class poseidon2_permImpl {
         const auto poseidon2_perm_A_16_3 = poseidon2_perm_ARK_16_3;
         const auto poseidon2_perm_SUM_16 =
             poseidon2_perm_A_16_0 + poseidon2_perm_A_16_1 + poseidon2_perm_A_16_2 + poseidon2_perm_A_16_3;
-        const auto poseidon2_perm_ARK_17_0 = new_term.poseidon2_perm_B_16_0 + poseidon2_params_C_17_0;
-        const auto poseidon2_perm_ARK_17_1 = new_term.poseidon2_perm_B_16_1 + poseidon2_params_C_17_1;
-        const auto poseidon2_perm_ARK_17_2 = new_term.poseidon2_perm_B_16_2 + poseidon2_params_C_17_2;
-        const auto poseidon2_perm_ARK_17_3 = new_term.poseidon2_perm_B_16_3 + poseidon2_params_C_17_3;
+        const auto poseidon2_perm_ARK_17_0 = in.get(C::poseidon2_perm_B_16_0) + poseidon2_params_C_17_0;
+        const auto poseidon2_perm_ARK_17_1 = in.get(C::poseidon2_perm_B_16_1) + poseidon2_params_C_17_1;
+        const auto poseidon2_perm_ARK_17_2 = in.get(C::poseidon2_perm_B_16_2) + poseidon2_params_C_17_2;
+        const auto poseidon2_perm_ARK_17_3 = in.get(C::poseidon2_perm_B_16_3) + poseidon2_params_C_17_3;
         const auto poseidon2_perm_A_17_0 = poseidon2_perm_ARK_17_0 * poseidon2_perm_ARK_17_0 * poseidon2_perm_ARK_17_0 *
                                            poseidon2_perm_ARK_17_0 * poseidon2_perm_ARK_17_0;
         const auto poseidon2_perm_A_17_1 = poseidon2_perm_ARK_17_1;
@@ -609,10 +612,10 @@ template <typename FF_> class poseidon2_permImpl {
         const auto poseidon2_perm_A_17_3 = poseidon2_perm_ARK_17_3;
         const auto poseidon2_perm_SUM_17 =
             poseidon2_perm_A_17_0 + poseidon2_perm_A_17_1 + poseidon2_perm_A_17_2 + poseidon2_perm_A_17_3;
-        const auto poseidon2_perm_ARK_18_0 = new_term.poseidon2_perm_B_17_0 + poseidon2_params_C_18_0;
-        const auto poseidon2_perm_ARK_18_1 = new_term.poseidon2_perm_B_17_1 + poseidon2_params_C_18_1;
-        const auto poseidon2_perm_ARK_18_2 = new_term.poseidon2_perm_B_17_2 + poseidon2_params_C_18_2;
-        const auto poseidon2_perm_ARK_18_3 = new_term.poseidon2_perm_B_17_3 + poseidon2_params_C_18_3;
+        const auto poseidon2_perm_ARK_18_0 = in.get(C::poseidon2_perm_B_17_0) + poseidon2_params_C_18_0;
+        const auto poseidon2_perm_ARK_18_1 = in.get(C::poseidon2_perm_B_17_1) + poseidon2_params_C_18_1;
+        const auto poseidon2_perm_ARK_18_2 = in.get(C::poseidon2_perm_B_17_2) + poseidon2_params_C_18_2;
+        const auto poseidon2_perm_ARK_18_3 = in.get(C::poseidon2_perm_B_17_3) + poseidon2_params_C_18_3;
         const auto poseidon2_perm_A_18_0 = poseidon2_perm_ARK_18_0 * poseidon2_perm_ARK_18_0 * poseidon2_perm_ARK_18_0 *
                                            poseidon2_perm_ARK_18_0 * poseidon2_perm_ARK_18_0;
         const auto poseidon2_perm_A_18_1 = poseidon2_perm_ARK_18_1;
@@ -620,10 +623,10 @@ template <typename FF_> class poseidon2_permImpl {
         const auto poseidon2_perm_A_18_3 = poseidon2_perm_ARK_18_3;
         const auto poseidon2_perm_SUM_18 =
             poseidon2_perm_A_18_0 + poseidon2_perm_A_18_1 + poseidon2_perm_A_18_2 + poseidon2_perm_A_18_3;
-        const auto poseidon2_perm_ARK_19_0 = new_term.poseidon2_perm_B_18_0 + poseidon2_params_C_19_0;
-        const auto poseidon2_perm_ARK_19_1 = new_term.poseidon2_perm_B_18_1 + poseidon2_params_C_19_1;
-        const auto poseidon2_perm_ARK_19_2 = new_term.poseidon2_perm_B_18_2 + poseidon2_params_C_19_2;
-        const auto poseidon2_perm_ARK_19_3 = new_term.poseidon2_perm_B_18_3 + poseidon2_params_C_19_3;
+        const auto poseidon2_perm_ARK_19_0 = in.get(C::poseidon2_perm_B_18_0) + poseidon2_params_C_19_0;
+        const auto poseidon2_perm_ARK_19_1 = in.get(C::poseidon2_perm_B_18_1) + poseidon2_params_C_19_1;
+        const auto poseidon2_perm_ARK_19_2 = in.get(C::poseidon2_perm_B_18_2) + poseidon2_params_C_19_2;
+        const auto poseidon2_perm_ARK_19_3 = in.get(C::poseidon2_perm_B_18_3) + poseidon2_params_C_19_3;
         const auto poseidon2_perm_A_19_0 = poseidon2_perm_ARK_19_0 * poseidon2_perm_ARK_19_0 * poseidon2_perm_ARK_19_0 *
                                            poseidon2_perm_ARK_19_0 * poseidon2_perm_ARK_19_0;
         const auto poseidon2_perm_A_19_1 = poseidon2_perm_ARK_19_1;
@@ -631,10 +634,10 @@ template <typename FF_> class poseidon2_permImpl {
         const auto poseidon2_perm_A_19_3 = poseidon2_perm_ARK_19_3;
         const auto poseidon2_perm_SUM_19 =
             poseidon2_perm_A_19_0 + poseidon2_perm_A_19_1 + poseidon2_perm_A_19_2 + poseidon2_perm_A_19_3;
-        const auto poseidon2_perm_ARK_20_0 = new_term.poseidon2_perm_B_19_0 + poseidon2_params_C_20_0;
-        const auto poseidon2_perm_ARK_20_1 = new_term.poseidon2_perm_B_19_1 + poseidon2_params_C_20_1;
-        const auto poseidon2_perm_ARK_20_2 = new_term.poseidon2_perm_B_19_2 + poseidon2_params_C_20_2;
-        const auto poseidon2_perm_ARK_20_3 = new_term.poseidon2_perm_B_19_3 + poseidon2_params_C_20_3;
+        const auto poseidon2_perm_ARK_20_0 = in.get(C::poseidon2_perm_B_19_0) + poseidon2_params_C_20_0;
+        const auto poseidon2_perm_ARK_20_1 = in.get(C::poseidon2_perm_B_19_1) + poseidon2_params_C_20_1;
+        const auto poseidon2_perm_ARK_20_2 = in.get(C::poseidon2_perm_B_19_2) + poseidon2_params_C_20_2;
+        const auto poseidon2_perm_ARK_20_3 = in.get(C::poseidon2_perm_B_19_3) + poseidon2_params_C_20_3;
         const auto poseidon2_perm_A_20_0 = poseidon2_perm_ARK_20_0 * poseidon2_perm_ARK_20_0 * poseidon2_perm_ARK_20_0 *
                                            poseidon2_perm_ARK_20_0 * poseidon2_perm_ARK_20_0;
         const auto poseidon2_perm_A_20_1 = poseidon2_perm_ARK_20_1;
@@ -642,10 +645,10 @@ template <typename FF_> class poseidon2_permImpl {
         const auto poseidon2_perm_A_20_3 = poseidon2_perm_ARK_20_3;
         const auto poseidon2_perm_SUM_20 =
             poseidon2_perm_A_20_0 + poseidon2_perm_A_20_1 + poseidon2_perm_A_20_2 + poseidon2_perm_A_20_3;
-        const auto poseidon2_perm_ARK_21_0 = new_term.poseidon2_perm_B_20_0 + poseidon2_params_C_21_0;
-        const auto poseidon2_perm_ARK_21_1 = new_term.poseidon2_perm_B_20_1 + poseidon2_params_C_21_1;
-        const auto poseidon2_perm_ARK_21_2 = new_term.poseidon2_perm_B_20_2 + poseidon2_params_C_21_2;
-        const auto poseidon2_perm_ARK_21_3 = new_term.poseidon2_perm_B_20_3 + poseidon2_params_C_21_3;
+        const auto poseidon2_perm_ARK_21_0 = in.get(C::poseidon2_perm_B_20_0) + poseidon2_params_C_21_0;
+        const auto poseidon2_perm_ARK_21_1 = in.get(C::poseidon2_perm_B_20_1) + poseidon2_params_C_21_1;
+        const auto poseidon2_perm_ARK_21_2 = in.get(C::poseidon2_perm_B_20_2) + poseidon2_params_C_21_2;
+        const auto poseidon2_perm_ARK_21_3 = in.get(C::poseidon2_perm_B_20_3) + poseidon2_params_C_21_3;
         const auto poseidon2_perm_A_21_0 = poseidon2_perm_ARK_21_0 * poseidon2_perm_ARK_21_0 * poseidon2_perm_ARK_21_0 *
                                            poseidon2_perm_ARK_21_0 * poseidon2_perm_ARK_21_0;
         const auto poseidon2_perm_A_21_1 = poseidon2_perm_ARK_21_1;
@@ -653,10 +656,10 @@ template <typename FF_> class poseidon2_permImpl {
         const auto poseidon2_perm_A_21_3 = poseidon2_perm_ARK_21_3;
         const auto poseidon2_perm_SUM_21 =
             poseidon2_perm_A_21_0 + poseidon2_perm_A_21_1 + poseidon2_perm_A_21_2 + poseidon2_perm_A_21_3;
-        const auto poseidon2_perm_ARK_22_0 = new_term.poseidon2_perm_B_21_0 + poseidon2_params_C_22_0;
-        const auto poseidon2_perm_ARK_22_1 = new_term.poseidon2_perm_B_21_1 + poseidon2_params_C_22_1;
-        const auto poseidon2_perm_ARK_22_2 = new_term.poseidon2_perm_B_21_2 + poseidon2_params_C_22_2;
-        const auto poseidon2_perm_ARK_22_3 = new_term.poseidon2_perm_B_21_3 + poseidon2_params_C_22_3;
+        const auto poseidon2_perm_ARK_22_0 = in.get(C::poseidon2_perm_B_21_0) + poseidon2_params_C_22_0;
+        const auto poseidon2_perm_ARK_22_1 = in.get(C::poseidon2_perm_B_21_1) + poseidon2_params_C_22_1;
+        const auto poseidon2_perm_ARK_22_2 = in.get(C::poseidon2_perm_B_21_2) + poseidon2_params_C_22_2;
+        const auto poseidon2_perm_ARK_22_3 = in.get(C::poseidon2_perm_B_21_3) + poseidon2_params_C_22_3;
         const auto poseidon2_perm_A_22_0 = poseidon2_perm_ARK_22_0 * poseidon2_perm_ARK_22_0 * poseidon2_perm_ARK_22_0 *
                                            poseidon2_perm_ARK_22_0 * poseidon2_perm_ARK_22_0;
         const auto poseidon2_perm_A_22_1 = poseidon2_perm_ARK_22_1;
@@ -664,10 +667,10 @@ template <typename FF_> class poseidon2_permImpl {
         const auto poseidon2_perm_A_22_3 = poseidon2_perm_ARK_22_3;
         const auto poseidon2_perm_SUM_22 =
             poseidon2_perm_A_22_0 + poseidon2_perm_A_22_1 + poseidon2_perm_A_22_2 + poseidon2_perm_A_22_3;
-        const auto poseidon2_perm_ARK_23_0 = new_term.poseidon2_perm_B_22_0 + poseidon2_params_C_23_0;
-        const auto poseidon2_perm_ARK_23_1 = new_term.poseidon2_perm_B_22_1 + poseidon2_params_C_23_1;
-        const auto poseidon2_perm_ARK_23_2 = new_term.poseidon2_perm_B_22_2 + poseidon2_params_C_23_2;
-        const auto poseidon2_perm_ARK_23_3 = new_term.poseidon2_perm_B_22_3 + poseidon2_params_C_23_3;
+        const auto poseidon2_perm_ARK_23_0 = in.get(C::poseidon2_perm_B_22_0) + poseidon2_params_C_23_0;
+        const auto poseidon2_perm_ARK_23_1 = in.get(C::poseidon2_perm_B_22_1) + poseidon2_params_C_23_1;
+        const auto poseidon2_perm_ARK_23_2 = in.get(C::poseidon2_perm_B_22_2) + poseidon2_params_C_23_2;
+        const auto poseidon2_perm_ARK_23_3 = in.get(C::poseidon2_perm_B_22_3) + poseidon2_params_C_23_3;
         const auto poseidon2_perm_A_23_0 = poseidon2_perm_ARK_23_0 * poseidon2_perm_ARK_23_0 * poseidon2_perm_ARK_23_0 *
                                            poseidon2_perm_ARK_23_0 * poseidon2_perm_ARK_23_0;
         const auto poseidon2_perm_A_23_1 = poseidon2_perm_ARK_23_1;
@@ -675,10 +678,10 @@ template <typename FF_> class poseidon2_permImpl {
         const auto poseidon2_perm_A_23_3 = poseidon2_perm_ARK_23_3;
         const auto poseidon2_perm_SUM_23 =
             poseidon2_perm_A_23_0 + poseidon2_perm_A_23_1 + poseidon2_perm_A_23_2 + poseidon2_perm_A_23_3;
-        const auto poseidon2_perm_ARK_24_0 = new_term.poseidon2_perm_B_23_0 + poseidon2_params_C_24_0;
-        const auto poseidon2_perm_ARK_24_1 = new_term.poseidon2_perm_B_23_1 + poseidon2_params_C_24_1;
-        const auto poseidon2_perm_ARK_24_2 = new_term.poseidon2_perm_B_23_2 + poseidon2_params_C_24_2;
-        const auto poseidon2_perm_ARK_24_3 = new_term.poseidon2_perm_B_23_3 + poseidon2_params_C_24_3;
+        const auto poseidon2_perm_ARK_24_0 = in.get(C::poseidon2_perm_B_23_0) + poseidon2_params_C_24_0;
+        const auto poseidon2_perm_ARK_24_1 = in.get(C::poseidon2_perm_B_23_1) + poseidon2_params_C_24_1;
+        const auto poseidon2_perm_ARK_24_2 = in.get(C::poseidon2_perm_B_23_2) + poseidon2_params_C_24_2;
+        const auto poseidon2_perm_ARK_24_3 = in.get(C::poseidon2_perm_B_23_3) + poseidon2_params_C_24_3;
         const auto poseidon2_perm_A_24_0 = poseidon2_perm_ARK_24_0 * poseidon2_perm_ARK_24_0 * poseidon2_perm_ARK_24_0 *
                                            poseidon2_perm_ARK_24_0 * poseidon2_perm_ARK_24_0;
         const auto poseidon2_perm_A_24_1 = poseidon2_perm_ARK_24_1;
@@ -686,10 +689,10 @@ template <typename FF_> class poseidon2_permImpl {
         const auto poseidon2_perm_A_24_3 = poseidon2_perm_ARK_24_3;
         const auto poseidon2_perm_SUM_24 =
             poseidon2_perm_A_24_0 + poseidon2_perm_A_24_1 + poseidon2_perm_A_24_2 + poseidon2_perm_A_24_3;
-        const auto poseidon2_perm_ARK_25_0 = new_term.poseidon2_perm_B_24_0 + poseidon2_params_C_25_0;
-        const auto poseidon2_perm_ARK_25_1 = new_term.poseidon2_perm_B_24_1 + poseidon2_params_C_25_1;
-        const auto poseidon2_perm_ARK_25_2 = new_term.poseidon2_perm_B_24_2 + poseidon2_params_C_25_2;
-        const auto poseidon2_perm_ARK_25_3 = new_term.poseidon2_perm_B_24_3 + poseidon2_params_C_25_3;
+        const auto poseidon2_perm_ARK_25_0 = in.get(C::poseidon2_perm_B_24_0) + poseidon2_params_C_25_0;
+        const auto poseidon2_perm_ARK_25_1 = in.get(C::poseidon2_perm_B_24_1) + poseidon2_params_C_25_1;
+        const auto poseidon2_perm_ARK_25_2 = in.get(C::poseidon2_perm_B_24_2) + poseidon2_params_C_25_2;
+        const auto poseidon2_perm_ARK_25_3 = in.get(C::poseidon2_perm_B_24_3) + poseidon2_params_C_25_3;
         const auto poseidon2_perm_A_25_0 = poseidon2_perm_ARK_25_0 * poseidon2_perm_ARK_25_0 * poseidon2_perm_ARK_25_0 *
                                            poseidon2_perm_ARK_25_0 * poseidon2_perm_ARK_25_0;
         const auto poseidon2_perm_A_25_1 = poseidon2_perm_ARK_25_1;
@@ -697,10 +700,10 @@ template <typename FF_> class poseidon2_permImpl {
         const auto poseidon2_perm_A_25_3 = poseidon2_perm_ARK_25_3;
         const auto poseidon2_perm_SUM_25 =
             poseidon2_perm_A_25_0 + poseidon2_perm_A_25_1 + poseidon2_perm_A_25_2 + poseidon2_perm_A_25_3;
-        const auto poseidon2_perm_ARK_26_0 = new_term.poseidon2_perm_B_25_0 + poseidon2_params_C_26_0;
-        const auto poseidon2_perm_ARK_26_1 = new_term.poseidon2_perm_B_25_1 + poseidon2_params_C_26_1;
-        const auto poseidon2_perm_ARK_26_2 = new_term.poseidon2_perm_B_25_2 + poseidon2_params_C_26_2;
-        const auto poseidon2_perm_ARK_26_3 = new_term.poseidon2_perm_B_25_3 + poseidon2_params_C_26_3;
+        const auto poseidon2_perm_ARK_26_0 = in.get(C::poseidon2_perm_B_25_0) + poseidon2_params_C_26_0;
+        const auto poseidon2_perm_ARK_26_1 = in.get(C::poseidon2_perm_B_25_1) + poseidon2_params_C_26_1;
+        const auto poseidon2_perm_ARK_26_2 = in.get(C::poseidon2_perm_B_25_2) + poseidon2_params_C_26_2;
+        const auto poseidon2_perm_ARK_26_3 = in.get(C::poseidon2_perm_B_25_3) + poseidon2_params_C_26_3;
         const auto poseidon2_perm_A_26_0 = poseidon2_perm_ARK_26_0 * poseidon2_perm_ARK_26_0 * poseidon2_perm_ARK_26_0 *
                                            poseidon2_perm_ARK_26_0 * poseidon2_perm_ARK_26_0;
         const auto poseidon2_perm_A_26_1 = poseidon2_perm_ARK_26_1;
@@ -708,10 +711,10 @@ template <typename FF_> class poseidon2_permImpl {
         const auto poseidon2_perm_A_26_3 = poseidon2_perm_ARK_26_3;
         const auto poseidon2_perm_SUM_26 =
             poseidon2_perm_A_26_0 + poseidon2_perm_A_26_1 + poseidon2_perm_A_26_2 + poseidon2_perm_A_26_3;
-        const auto poseidon2_perm_ARK_27_0 = new_term.poseidon2_perm_B_26_0 + poseidon2_params_C_27_0;
-        const auto poseidon2_perm_ARK_27_1 = new_term.poseidon2_perm_B_26_1 + poseidon2_params_C_27_1;
-        const auto poseidon2_perm_ARK_27_2 = new_term.poseidon2_perm_B_26_2 + poseidon2_params_C_27_2;
-        const auto poseidon2_perm_ARK_27_3 = new_term.poseidon2_perm_B_26_3 + poseidon2_params_C_27_3;
+        const auto poseidon2_perm_ARK_27_0 = in.get(C::poseidon2_perm_B_26_0) + poseidon2_params_C_27_0;
+        const auto poseidon2_perm_ARK_27_1 = in.get(C::poseidon2_perm_B_26_1) + poseidon2_params_C_27_1;
+        const auto poseidon2_perm_ARK_27_2 = in.get(C::poseidon2_perm_B_26_2) + poseidon2_params_C_27_2;
+        const auto poseidon2_perm_ARK_27_3 = in.get(C::poseidon2_perm_B_26_3) + poseidon2_params_C_27_3;
         const auto poseidon2_perm_A_27_0 = poseidon2_perm_ARK_27_0 * poseidon2_perm_ARK_27_0 * poseidon2_perm_ARK_27_0 *
                                            poseidon2_perm_ARK_27_0 * poseidon2_perm_ARK_27_0;
         const auto poseidon2_perm_A_27_1 = poseidon2_perm_ARK_27_1;
@@ -719,10 +722,10 @@ template <typename FF_> class poseidon2_permImpl {
         const auto poseidon2_perm_A_27_3 = poseidon2_perm_ARK_27_3;
         const auto poseidon2_perm_SUM_27 =
             poseidon2_perm_A_27_0 + poseidon2_perm_A_27_1 + poseidon2_perm_A_27_2 + poseidon2_perm_A_27_3;
-        const auto poseidon2_perm_ARK_28_0 = new_term.poseidon2_perm_B_27_0 + poseidon2_params_C_28_0;
-        const auto poseidon2_perm_ARK_28_1 = new_term.poseidon2_perm_B_27_1 + poseidon2_params_C_28_1;
-        const auto poseidon2_perm_ARK_28_2 = new_term.poseidon2_perm_B_27_2 + poseidon2_params_C_28_2;
-        const auto poseidon2_perm_ARK_28_3 = new_term.poseidon2_perm_B_27_3 + poseidon2_params_C_28_3;
+        const auto poseidon2_perm_ARK_28_0 = in.get(C::poseidon2_perm_B_27_0) + poseidon2_params_C_28_0;
+        const auto poseidon2_perm_ARK_28_1 = in.get(C::poseidon2_perm_B_27_1) + poseidon2_params_C_28_1;
+        const auto poseidon2_perm_ARK_28_2 = in.get(C::poseidon2_perm_B_27_2) + poseidon2_params_C_28_2;
+        const auto poseidon2_perm_ARK_28_3 = in.get(C::poseidon2_perm_B_27_3) + poseidon2_params_C_28_3;
         const auto poseidon2_perm_A_28_0 = poseidon2_perm_ARK_28_0 * poseidon2_perm_ARK_28_0 * poseidon2_perm_ARK_28_0 *
                                            poseidon2_perm_ARK_28_0 * poseidon2_perm_ARK_28_0;
         const auto poseidon2_perm_A_28_1 = poseidon2_perm_ARK_28_1;
@@ -730,10 +733,10 @@ template <typename FF_> class poseidon2_permImpl {
         const auto poseidon2_perm_A_28_3 = poseidon2_perm_ARK_28_3;
         const auto poseidon2_perm_SUM_28 =
             poseidon2_perm_A_28_0 + poseidon2_perm_A_28_1 + poseidon2_perm_A_28_2 + poseidon2_perm_A_28_3;
-        const auto poseidon2_perm_ARK_29_0 = new_term.poseidon2_perm_B_28_0 + poseidon2_params_C_29_0;
-        const auto poseidon2_perm_ARK_29_1 = new_term.poseidon2_perm_B_28_1 + poseidon2_params_C_29_1;
-        const auto poseidon2_perm_ARK_29_2 = new_term.poseidon2_perm_B_28_2 + poseidon2_params_C_29_2;
-        const auto poseidon2_perm_ARK_29_3 = new_term.poseidon2_perm_B_28_3 + poseidon2_params_C_29_3;
+        const auto poseidon2_perm_ARK_29_0 = in.get(C::poseidon2_perm_B_28_0) + poseidon2_params_C_29_0;
+        const auto poseidon2_perm_ARK_29_1 = in.get(C::poseidon2_perm_B_28_1) + poseidon2_params_C_29_1;
+        const auto poseidon2_perm_ARK_29_2 = in.get(C::poseidon2_perm_B_28_2) + poseidon2_params_C_29_2;
+        const auto poseidon2_perm_ARK_29_3 = in.get(C::poseidon2_perm_B_28_3) + poseidon2_params_C_29_3;
         const auto poseidon2_perm_A_29_0 = poseidon2_perm_ARK_29_0 * poseidon2_perm_ARK_29_0 * poseidon2_perm_ARK_29_0 *
                                            poseidon2_perm_ARK_29_0 * poseidon2_perm_ARK_29_0;
         const auto poseidon2_perm_A_29_1 = poseidon2_perm_ARK_29_1;
@@ -741,10 +744,10 @@ template <typename FF_> class poseidon2_permImpl {
         const auto poseidon2_perm_A_29_3 = poseidon2_perm_ARK_29_3;
         const auto poseidon2_perm_SUM_29 =
             poseidon2_perm_A_29_0 + poseidon2_perm_A_29_1 + poseidon2_perm_A_29_2 + poseidon2_perm_A_29_3;
-        const auto poseidon2_perm_ARK_30_0 = new_term.poseidon2_perm_B_29_0 + poseidon2_params_C_30_0;
-        const auto poseidon2_perm_ARK_30_1 = new_term.poseidon2_perm_B_29_1 + poseidon2_params_C_30_1;
-        const auto poseidon2_perm_ARK_30_2 = new_term.poseidon2_perm_B_29_2 + poseidon2_params_C_30_2;
-        const auto poseidon2_perm_ARK_30_3 = new_term.poseidon2_perm_B_29_3 + poseidon2_params_C_30_3;
+        const auto poseidon2_perm_ARK_30_0 = in.get(C::poseidon2_perm_B_29_0) + poseidon2_params_C_30_0;
+        const auto poseidon2_perm_ARK_30_1 = in.get(C::poseidon2_perm_B_29_1) + poseidon2_params_C_30_1;
+        const auto poseidon2_perm_ARK_30_2 = in.get(C::poseidon2_perm_B_29_2) + poseidon2_params_C_30_2;
+        const auto poseidon2_perm_ARK_30_3 = in.get(C::poseidon2_perm_B_29_3) + poseidon2_params_C_30_3;
         const auto poseidon2_perm_A_30_0 = poseidon2_perm_ARK_30_0 * poseidon2_perm_ARK_30_0 * poseidon2_perm_ARK_30_0 *
                                            poseidon2_perm_ARK_30_0 * poseidon2_perm_ARK_30_0;
         const auto poseidon2_perm_A_30_1 = poseidon2_perm_ARK_30_1;
@@ -752,10 +755,10 @@ template <typename FF_> class poseidon2_permImpl {
         const auto poseidon2_perm_A_30_3 = poseidon2_perm_ARK_30_3;
         const auto poseidon2_perm_SUM_30 =
             poseidon2_perm_A_30_0 + poseidon2_perm_A_30_1 + poseidon2_perm_A_30_2 + poseidon2_perm_A_30_3;
-        const auto poseidon2_perm_ARK_31_0 = new_term.poseidon2_perm_B_30_0 + poseidon2_params_C_31_0;
-        const auto poseidon2_perm_ARK_31_1 = new_term.poseidon2_perm_B_30_1 + poseidon2_params_C_31_1;
-        const auto poseidon2_perm_ARK_31_2 = new_term.poseidon2_perm_B_30_2 + poseidon2_params_C_31_2;
-        const auto poseidon2_perm_ARK_31_3 = new_term.poseidon2_perm_B_30_3 + poseidon2_params_C_31_3;
+        const auto poseidon2_perm_ARK_31_0 = in.get(C::poseidon2_perm_B_30_0) + poseidon2_params_C_31_0;
+        const auto poseidon2_perm_ARK_31_1 = in.get(C::poseidon2_perm_B_30_1) + poseidon2_params_C_31_1;
+        const auto poseidon2_perm_ARK_31_2 = in.get(C::poseidon2_perm_B_30_2) + poseidon2_params_C_31_2;
+        const auto poseidon2_perm_ARK_31_3 = in.get(C::poseidon2_perm_B_30_3) + poseidon2_params_C_31_3;
         const auto poseidon2_perm_A_31_0 = poseidon2_perm_ARK_31_0 * poseidon2_perm_ARK_31_0 * poseidon2_perm_ARK_31_0 *
                                            poseidon2_perm_ARK_31_0 * poseidon2_perm_ARK_31_0;
         const auto poseidon2_perm_A_31_1 = poseidon2_perm_ARK_31_1;
@@ -763,10 +766,10 @@ template <typename FF_> class poseidon2_permImpl {
         const auto poseidon2_perm_A_31_3 = poseidon2_perm_ARK_31_3;
         const auto poseidon2_perm_SUM_31 =
             poseidon2_perm_A_31_0 + poseidon2_perm_A_31_1 + poseidon2_perm_A_31_2 + poseidon2_perm_A_31_3;
-        const auto poseidon2_perm_ARK_32_0 = new_term.poseidon2_perm_B_31_0 + poseidon2_params_C_32_0;
-        const auto poseidon2_perm_ARK_32_1 = new_term.poseidon2_perm_B_31_1 + poseidon2_params_C_32_1;
-        const auto poseidon2_perm_ARK_32_2 = new_term.poseidon2_perm_B_31_2 + poseidon2_params_C_32_2;
-        const auto poseidon2_perm_ARK_32_3 = new_term.poseidon2_perm_B_31_3 + poseidon2_params_C_32_3;
+        const auto poseidon2_perm_ARK_32_0 = in.get(C::poseidon2_perm_B_31_0) + poseidon2_params_C_32_0;
+        const auto poseidon2_perm_ARK_32_1 = in.get(C::poseidon2_perm_B_31_1) + poseidon2_params_C_32_1;
+        const auto poseidon2_perm_ARK_32_2 = in.get(C::poseidon2_perm_B_31_2) + poseidon2_params_C_32_2;
+        const auto poseidon2_perm_ARK_32_3 = in.get(C::poseidon2_perm_B_31_3) + poseidon2_params_C_32_3;
         const auto poseidon2_perm_A_32_0 = poseidon2_perm_ARK_32_0 * poseidon2_perm_ARK_32_0 * poseidon2_perm_ARK_32_0 *
                                            poseidon2_perm_ARK_32_0 * poseidon2_perm_ARK_32_0;
         const auto poseidon2_perm_A_32_1 = poseidon2_perm_ARK_32_1;
@@ -774,10 +777,10 @@ template <typename FF_> class poseidon2_permImpl {
         const auto poseidon2_perm_A_32_3 = poseidon2_perm_ARK_32_3;
         const auto poseidon2_perm_SUM_32 =
             poseidon2_perm_A_32_0 + poseidon2_perm_A_32_1 + poseidon2_perm_A_32_2 + poseidon2_perm_A_32_3;
-        const auto poseidon2_perm_ARK_33_0 = new_term.poseidon2_perm_B_32_0 + poseidon2_params_C_33_0;
-        const auto poseidon2_perm_ARK_33_1 = new_term.poseidon2_perm_B_32_1 + poseidon2_params_C_33_1;
-        const auto poseidon2_perm_ARK_33_2 = new_term.poseidon2_perm_B_32_2 + poseidon2_params_C_33_2;
-        const auto poseidon2_perm_ARK_33_3 = new_term.poseidon2_perm_B_32_3 + poseidon2_params_C_33_3;
+        const auto poseidon2_perm_ARK_33_0 = in.get(C::poseidon2_perm_B_32_0) + poseidon2_params_C_33_0;
+        const auto poseidon2_perm_ARK_33_1 = in.get(C::poseidon2_perm_B_32_1) + poseidon2_params_C_33_1;
+        const auto poseidon2_perm_ARK_33_2 = in.get(C::poseidon2_perm_B_32_2) + poseidon2_params_C_33_2;
+        const auto poseidon2_perm_ARK_33_3 = in.get(C::poseidon2_perm_B_32_3) + poseidon2_params_C_33_3;
         const auto poseidon2_perm_A_33_0 = poseidon2_perm_ARK_33_0 * poseidon2_perm_ARK_33_0 * poseidon2_perm_ARK_33_0 *
                                            poseidon2_perm_ARK_33_0 * poseidon2_perm_ARK_33_0;
         const auto poseidon2_perm_A_33_1 = poseidon2_perm_ARK_33_1;
@@ -785,10 +788,10 @@ template <typename FF_> class poseidon2_permImpl {
         const auto poseidon2_perm_A_33_3 = poseidon2_perm_ARK_33_3;
         const auto poseidon2_perm_SUM_33 =
             poseidon2_perm_A_33_0 + poseidon2_perm_A_33_1 + poseidon2_perm_A_33_2 + poseidon2_perm_A_33_3;
-        const auto poseidon2_perm_ARK_34_0 = new_term.poseidon2_perm_B_33_0 + poseidon2_params_C_34_0;
-        const auto poseidon2_perm_ARK_34_1 = new_term.poseidon2_perm_B_33_1 + poseidon2_params_C_34_1;
-        const auto poseidon2_perm_ARK_34_2 = new_term.poseidon2_perm_B_33_2 + poseidon2_params_C_34_2;
-        const auto poseidon2_perm_ARK_34_3 = new_term.poseidon2_perm_B_33_3 + poseidon2_params_C_34_3;
+        const auto poseidon2_perm_ARK_34_0 = in.get(C::poseidon2_perm_B_33_0) + poseidon2_params_C_34_0;
+        const auto poseidon2_perm_ARK_34_1 = in.get(C::poseidon2_perm_B_33_1) + poseidon2_params_C_34_1;
+        const auto poseidon2_perm_ARK_34_2 = in.get(C::poseidon2_perm_B_33_2) + poseidon2_params_C_34_2;
+        const auto poseidon2_perm_ARK_34_3 = in.get(C::poseidon2_perm_B_33_3) + poseidon2_params_C_34_3;
         const auto poseidon2_perm_A_34_0 = poseidon2_perm_ARK_34_0 * poseidon2_perm_ARK_34_0 * poseidon2_perm_ARK_34_0 *
                                            poseidon2_perm_ARK_34_0 * poseidon2_perm_ARK_34_0;
         const auto poseidon2_perm_A_34_1 = poseidon2_perm_ARK_34_1;
@@ -796,10 +799,10 @@ template <typename FF_> class poseidon2_permImpl {
         const auto poseidon2_perm_A_34_3 = poseidon2_perm_ARK_34_3;
         const auto poseidon2_perm_SUM_34 =
             poseidon2_perm_A_34_0 + poseidon2_perm_A_34_1 + poseidon2_perm_A_34_2 + poseidon2_perm_A_34_3;
-        const auto poseidon2_perm_ARK_35_0 = new_term.poseidon2_perm_B_34_0 + poseidon2_params_C_35_0;
-        const auto poseidon2_perm_ARK_35_1 = new_term.poseidon2_perm_B_34_1 + poseidon2_params_C_35_1;
-        const auto poseidon2_perm_ARK_35_2 = new_term.poseidon2_perm_B_34_2 + poseidon2_params_C_35_2;
-        const auto poseidon2_perm_ARK_35_3 = new_term.poseidon2_perm_B_34_3 + poseidon2_params_C_35_3;
+        const auto poseidon2_perm_ARK_35_0 = in.get(C::poseidon2_perm_B_34_0) + poseidon2_params_C_35_0;
+        const auto poseidon2_perm_ARK_35_1 = in.get(C::poseidon2_perm_B_34_1) + poseidon2_params_C_35_1;
+        const auto poseidon2_perm_ARK_35_2 = in.get(C::poseidon2_perm_B_34_2) + poseidon2_params_C_35_2;
+        const auto poseidon2_perm_ARK_35_3 = in.get(C::poseidon2_perm_B_34_3) + poseidon2_params_C_35_3;
         const auto poseidon2_perm_A_35_0 = poseidon2_perm_ARK_35_0 * poseidon2_perm_ARK_35_0 * poseidon2_perm_ARK_35_0 *
                                            poseidon2_perm_ARK_35_0 * poseidon2_perm_ARK_35_0;
         const auto poseidon2_perm_A_35_1 = poseidon2_perm_ARK_35_1;
@@ -807,10 +810,10 @@ template <typename FF_> class poseidon2_permImpl {
         const auto poseidon2_perm_A_35_3 = poseidon2_perm_ARK_35_3;
         const auto poseidon2_perm_SUM_35 =
             poseidon2_perm_A_35_0 + poseidon2_perm_A_35_1 + poseidon2_perm_A_35_2 + poseidon2_perm_A_35_3;
-        const auto poseidon2_perm_ARK_36_0 = new_term.poseidon2_perm_B_35_0 + poseidon2_params_C_36_0;
-        const auto poseidon2_perm_ARK_36_1 = new_term.poseidon2_perm_B_35_1 + poseidon2_params_C_36_1;
-        const auto poseidon2_perm_ARK_36_2 = new_term.poseidon2_perm_B_35_2 + poseidon2_params_C_36_2;
-        const auto poseidon2_perm_ARK_36_3 = new_term.poseidon2_perm_B_35_3 + poseidon2_params_C_36_3;
+        const auto poseidon2_perm_ARK_36_0 = in.get(C::poseidon2_perm_B_35_0) + poseidon2_params_C_36_0;
+        const auto poseidon2_perm_ARK_36_1 = in.get(C::poseidon2_perm_B_35_1) + poseidon2_params_C_36_1;
+        const auto poseidon2_perm_ARK_36_2 = in.get(C::poseidon2_perm_B_35_2) + poseidon2_params_C_36_2;
+        const auto poseidon2_perm_ARK_36_3 = in.get(C::poseidon2_perm_B_35_3) + poseidon2_params_C_36_3;
         const auto poseidon2_perm_A_36_0 = poseidon2_perm_ARK_36_0 * poseidon2_perm_ARK_36_0 * poseidon2_perm_ARK_36_0 *
                                            poseidon2_perm_ARK_36_0 * poseidon2_perm_ARK_36_0;
         const auto poseidon2_perm_A_36_1 = poseidon2_perm_ARK_36_1;
@@ -818,10 +821,10 @@ template <typename FF_> class poseidon2_permImpl {
         const auto poseidon2_perm_A_36_3 = poseidon2_perm_ARK_36_3;
         const auto poseidon2_perm_SUM_36 =
             poseidon2_perm_A_36_0 + poseidon2_perm_A_36_1 + poseidon2_perm_A_36_2 + poseidon2_perm_A_36_3;
-        const auto poseidon2_perm_ARK_37_0 = new_term.poseidon2_perm_B_36_0 + poseidon2_params_C_37_0;
-        const auto poseidon2_perm_ARK_37_1 = new_term.poseidon2_perm_B_36_1 + poseidon2_params_C_37_1;
-        const auto poseidon2_perm_ARK_37_2 = new_term.poseidon2_perm_B_36_2 + poseidon2_params_C_37_2;
-        const auto poseidon2_perm_ARK_37_3 = new_term.poseidon2_perm_B_36_3 + poseidon2_params_C_37_3;
+        const auto poseidon2_perm_ARK_37_0 = in.get(C::poseidon2_perm_B_36_0) + poseidon2_params_C_37_0;
+        const auto poseidon2_perm_ARK_37_1 = in.get(C::poseidon2_perm_B_36_1) + poseidon2_params_C_37_1;
+        const auto poseidon2_perm_ARK_37_2 = in.get(C::poseidon2_perm_B_36_2) + poseidon2_params_C_37_2;
+        const auto poseidon2_perm_ARK_37_3 = in.get(C::poseidon2_perm_B_36_3) + poseidon2_params_C_37_3;
         const auto poseidon2_perm_A_37_0 = poseidon2_perm_ARK_37_0 * poseidon2_perm_ARK_37_0 * poseidon2_perm_ARK_37_0 *
                                            poseidon2_perm_ARK_37_0 * poseidon2_perm_ARK_37_0;
         const auto poseidon2_perm_A_37_1 = poseidon2_perm_ARK_37_1;
@@ -829,10 +832,10 @@ template <typename FF_> class poseidon2_permImpl {
         const auto poseidon2_perm_A_37_3 = poseidon2_perm_ARK_37_3;
         const auto poseidon2_perm_SUM_37 =
             poseidon2_perm_A_37_0 + poseidon2_perm_A_37_1 + poseidon2_perm_A_37_2 + poseidon2_perm_A_37_3;
-        const auto poseidon2_perm_ARK_38_0 = new_term.poseidon2_perm_B_37_0 + poseidon2_params_C_38_0;
-        const auto poseidon2_perm_ARK_38_1 = new_term.poseidon2_perm_B_37_1 + poseidon2_params_C_38_1;
-        const auto poseidon2_perm_ARK_38_2 = new_term.poseidon2_perm_B_37_2 + poseidon2_params_C_38_2;
-        const auto poseidon2_perm_ARK_38_3 = new_term.poseidon2_perm_B_37_3 + poseidon2_params_C_38_3;
+        const auto poseidon2_perm_ARK_38_0 = in.get(C::poseidon2_perm_B_37_0) + poseidon2_params_C_38_0;
+        const auto poseidon2_perm_ARK_38_1 = in.get(C::poseidon2_perm_B_37_1) + poseidon2_params_C_38_1;
+        const auto poseidon2_perm_ARK_38_2 = in.get(C::poseidon2_perm_B_37_2) + poseidon2_params_C_38_2;
+        const auto poseidon2_perm_ARK_38_3 = in.get(C::poseidon2_perm_B_37_3) + poseidon2_params_C_38_3;
         const auto poseidon2_perm_A_38_0 = poseidon2_perm_ARK_38_0 * poseidon2_perm_ARK_38_0 * poseidon2_perm_ARK_38_0 *
                                            poseidon2_perm_ARK_38_0 * poseidon2_perm_ARK_38_0;
         const auto poseidon2_perm_A_38_1 = poseidon2_perm_ARK_38_1;
@@ -840,10 +843,10 @@ template <typename FF_> class poseidon2_permImpl {
         const auto poseidon2_perm_A_38_3 = poseidon2_perm_ARK_38_3;
         const auto poseidon2_perm_SUM_38 =
             poseidon2_perm_A_38_0 + poseidon2_perm_A_38_1 + poseidon2_perm_A_38_2 + poseidon2_perm_A_38_3;
-        const auto poseidon2_perm_ARK_39_0 = new_term.poseidon2_perm_B_38_0 + poseidon2_params_C_39_0;
-        const auto poseidon2_perm_ARK_39_1 = new_term.poseidon2_perm_B_38_1 + poseidon2_params_C_39_1;
-        const auto poseidon2_perm_ARK_39_2 = new_term.poseidon2_perm_B_38_2 + poseidon2_params_C_39_2;
-        const auto poseidon2_perm_ARK_39_3 = new_term.poseidon2_perm_B_38_3 + poseidon2_params_C_39_3;
+        const auto poseidon2_perm_ARK_39_0 = in.get(C::poseidon2_perm_B_38_0) + poseidon2_params_C_39_0;
+        const auto poseidon2_perm_ARK_39_1 = in.get(C::poseidon2_perm_B_38_1) + poseidon2_params_C_39_1;
+        const auto poseidon2_perm_ARK_39_2 = in.get(C::poseidon2_perm_B_38_2) + poseidon2_params_C_39_2;
+        const auto poseidon2_perm_ARK_39_3 = in.get(C::poseidon2_perm_B_38_3) + poseidon2_params_C_39_3;
         const auto poseidon2_perm_A_39_0 = poseidon2_perm_ARK_39_0 * poseidon2_perm_ARK_39_0 * poseidon2_perm_ARK_39_0 *
                                            poseidon2_perm_ARK_39_0 * poseidon2_perm_ARK_39_0;
         const auto poseidon2_perm_A_39_1 = poseidon2_perm_ARK_39_1;
@@ -851,10 +854,10 @@ template <typename FF_> class poseidon2_permImpl {
         const auto poseidon2_perm_A_39_3 = poseidon2_perm_ARK_39_3;
         const auto poseidon2_perm_SUM_39 =
             poseidon2_perm_A_39_0 + poseidon2_perm_A_39_1 + poseidon2_perm_A_39_2 + poseidon2_perm_A_39_3;
-        const auto poseidon2_perm_ARK_40_0 = new_term.poseidon2_perm_B_39_0 + poseidon2_params_C_40_0;
-        const auto poseidon2_perm_ARK_40_1 = new_term.poseidon2_perm_B_39_1 + poseidon2_params_C_40_1;
-        const auto poseidon2_perm_ARK_40_2 = new_term.poseidon2_perm_B_39_2 + poseidon2_params_C_40_2;
-        const auto poseidon2_perm_ARK_40_3 = new_term.poseidon2_perm_B_39_3 + poseidon2_params_C_40_3;
+        const auto poseidon2_perm_ARK_40_0 = in.get(C::poseidon2_perm_B_39_0) + poseidon2_params_C_40_0;
+        const auto poseidon2_perm_ARK_40_1 = in.get(C::poseidon2_perm_B_39_1) + poseidon2_params_C_40_1;
+        const auto poseidon2_perm_ARK_40_2 = in.get(C::poseidon2_perm_B_39_2) + poseidon2_params_C_40_2;
+        const auto poseidon2_perm_ARK_40_3 = in.get(C::poseidon2_perm_B_39_3) + poseidon2_params_C_40_3;
         const auto poseidon2_perm_A_40_0 = poseidon2_perm_ARK_40_0 * poseidon2_perm_ARK_40_0 * poseidon2_perm_ARK_40_0 *
                                            poseidon2_perm_ARK_40_0 * poseidon2_perm_ARK_40_0;
         const auto poseidon2_perm_A_40_1 = poseidon2_perm_ARK_40_1;
@@ -862,10 +865,10 @@ template <typename FF_> class poseidon2_permImpl {
         const auto poseidon2_perm_A_40_3 = poseidon2_perm_ARK_40_3;
         const auto poseidon2_perm_SUM_40 =
             poseidon2_perm_A_40_0 + poseidon2_perm_A_40_1 + poseidon2_perm_A_40_2 + poseidon2_perm_A_40_3;
-        const auto poseidon2_perm_ARK_41_0 = new_term.poseidon2_perm_B_40_0 + poseidon2_params_C_41_0;
-        const auto poseidon2_perm_ARK_41_1 = new_term.poseidon2_perm_B_40_1 + poseidon2_params_C_41_1;
-        const auto poseidon2_perm_ARK_41_2 = new_term.poseidon2_perm_B_40_2 + poseidon2_params_C_41_2;
-        const auto poseidon2_perm_ARK_41_3 = new_term.poseidon2_perm_B_40_3 + poseidon2_params_C_41_3;
+        const auto poseidon2_perm_ARK_41_0 = in.get(C::poseidon2_perm_B_40_0) + poseidon2_params_C_41_0;
+        const auto poseidon2_perm_ARK_41_1 = in.get(C::poseidon2_perm_B_40_1) + poseidon2_params_C_41_1;
+        const auto poseidon2_perm_ARK_41_2 = in.get(C::poseidon2_perm_B_40_2) + poseidon2_params_C_41_2;
+        const auto poseidon2_perm_ARK_41_3 = in.get(C::poseidon2_perm_B_40_3) + poseidon2_params_C_41_3;
         const auto poseidon2_perm_A_41_0 = poseidon2_perm_ARK_41_0 * poseidon2_perm_ARK_41_0 * poseidon2_perm_ARK_41_0 *
                                            poseidon2_perm_ARK_41_0 * poseidon2_perm_ARK_41_0;
         const auto poseidon2_perm_A_41_1 = poseidon2_perm_ARK_41_1;
@@ -873,10 +876,10 @@ template <typename FF_> class poseidon2_permImpl {
         const auto poseidon2_perm_A_41_3 = poseidon2_perm_ARK_41_3;
         const auto poseidon2_perm_SUM_41 =
             poseidon2_perm_A_41_0 + poseidon2_perm_A_41_1 + poseidon2_perm_A_41_2 + poseidon2_perm_A_41_3;
-        const auto poseidon2_perm_ARK_42_0 = new_term.poseidon2_perm_B_41_0 + poseidon2_params_C_42_0;
-        const auto poseidon2_perm_ARK_42_1 = new_term.poseidon2_perm_B_41_1 + poseidon2_params_C_42_1;
-        const auto poseidon2_perm_ARK_42_2 = new_term.poseidon2_perm_B_41_2 + poseidon2_params_C_42_2;
-        const auto poseidon2_perm_ARK_42_3 = new_term.poseidon2_perm_B_41_3 + poseidon2_params_C_42_3;
+        const auto poseidon2_perm_ARK_42_0 = in.get(C::poseidon2_perm_B_41_0) + poseidon2_params_C_42_0;
+        const auto poseidon2_perm_ARK_42_1 = in.get(C::poseidon2_perm_B_41_1) + poseidon2_params_C_42_1;
+        const auto poseidon2_perm_ARK_42_2 = in.get(C::poseidon2_perm_B_41_2) + poseidon2_params_C_42_2;
+        const auto poseidon2_perm_ARK_42_3 = in.get(C::poseidon2_perm_B_41_3) + poseidon2_params_C_42_3;
         const auto poseidon2_perm_A_42_0 = poseidon2_perm_ARK_42_0 * poseidon2_perm_ARK_42_0 * poseidon2_perm_ARK_42_0 *
                                            poseidon2_perm_ARK_42_0 * poseidon2_perm_ARK_42_0;
         const auto poseidon2_perm_A_42_1 = poseidon2_perm_ARK_42_1;
@@ -884,10 +887,10 @@ template <typename FF_> class poseidon2_permImpl {
         const auto poseidon2_perm_A_42_3 = poseidon2_perm_ARK_42_3;
         const auto poseidon2_perm_SUM_42 =
             poseidon2_perm_A_42_0 + poseidon2_perm_A_42_1 + poseidon2_perm_A_42_2 + poseidon2_perm_A_42_3;
-        const auto poseidon2_perm_ARK_43_0 = new_term.poseidon2_perm_B_42_0 + poseidon2_params_C_43_0;
-        const auto poseidon2_perm_ARK_43_1 = new_term.poseidon2_perm_B_42_1 + poseidon2_params_C_43_1;
-        const auto poseidon2_perm_ARK_43_2 = new_term.poseidon2_perm_B_42_2 + poseidon2_params_C_43_2;
-        const auto poseidon2_perm_ARK_43_3 = new_term.poseidon2_perm_B_42_3 + poseidon2_params_C_43_3;
+        const auto poseidon2_perm_ARK_43_0 = in.get(C::poseidon2_perm_B_42_0) + poseidon2_params_C_43_0;
+        const auto poseidon2_perm_ARK_43_1 = in.get(C::poseidon2_perm_B_42_1) + poseidon2_params_C_43_1;
+        const auto poseidon2_perm_ARK_43_2 = in.get(C::poseidon2_perm_B_42_2) + poseidon2_params_C_43_2;
+        const auto poseidon2_perm_ARK_43_3 = in.get(C::poseidon2_perm_B_42_3) + poseidon2_params_C_43_3;
         const auto poseidon2_perm_A_43_0 = poseidon2_perm_ARK_43_0 * poseidon2_perm_ARK_43_0 * poseidon2_perm_ARK_43_0 *
                                            poseidon2_perm_ARK_43_0 * poseidon2_perm_ARK_43_0;
         const auto poseidon2_perm_A_43_1 = poseidon2_perm_ARK_43_1;
@@ -895,10 +898,10 @@ template <typename FF_> class poseidon2_permImpl {
         const auto poseidon2_perm_A_43_3 = poseidon2_perm_ARK_43_3;
         const auto poseidon2_perm_SUM_43 =
             poseidon2_perm_A_43_0 + poseidon2_perm_A_43_1 + poseidon2_perm_A_43_2 + poseidon2_perm_A_43_3;
-        const auto poseidon2_perm_ARK_44_0 = new_term.poseidon2_perm_B_43_0 + poseidon2_params_C_44_0;
-        const auto poseidon2_perm_ARK_44_1 = new_term.poseidon2_perm_B_43_1 + poseidon2_params_C_44_1;
-        const auto poseidon2_perm_ARK_44_2 = new_term.poseidon2_perm_B_43_2 + poseidon2_params_C_44_2;
-        const auto poseidon2_perm_ARK_44_3 = new_term.poseidon2_perm_B_43_3 + poseidon2_params_C_44_3;
+        const auto poseidon2_perm_ARK_44_0 = in.get(C::poseidon2_perm_B_43_0) + poseidon2_params_C_44_0;
+        const auto poseidon2_perm_ARK_44_1 = in.get(C::poseidon2_perm_B_43_1) + poseidon2_params_C_44_1;
+        const auto poseidon2_perm_ARK_44_2 = in.get(C::poseidon2_perm_B_43_2) + poseidon2_params_C_44_2;
+        const auto poseidon2_perm_ARK_44_3 = in.get(C::poseidon2_perm_B_43_3) + poseidon2_params_C_44_3;
         const auto poseidon2_perm_A_44_0 = poseidon2_perm_ARK_44_0 * poseidon2_perm_ARK_44_0 * poseidon2_perm_ARK_44_0 *
                                            poseidon2_perm_ARK_44_0 * poseidon2_perm_ARK_44_0;
         const auto poseidon2_perm_A_44_1 = poseidon2_perm_ARK_44_1;
@@ -906,10 +909,10 @@ template <typename FF_> class poseidon2_permImpl {
         const auto poseidon2_perm_A_44_3 = poseidon2_perm_ARK_44_3;
         const auto poseidon2_perm_SUM_44 =
             poseidon2_perm_A_44_0 + poseidon2_perm_A_44_1 + poseidon2_perm_A_44_2 + poseidon2_perm_A_44_3;
-        const auto poseidon2_perm_ARK_45_0 = new_term.poseidon2_perm_B_44_0 + poseidon2_params_C_45_0;
-        const auto poseidon2_perm_ARK_45_1 = new_term.poseidon2_perm_B_44_1 + poseidon2_params_C_45_1;
-        const auto poseidon2_perm_ARK_45_2 = new_term.poseidon2_perm_B_44_2 + poseidon2_params_C_45_2;
-        const auto poseidon2_perm_ARK_45_3 = new_term.poseidon2_perm_B_44_3 + poseidon2_params_C_45_3;
+        const auto poseidon2_perm_ARK_45_0 = in.get(C::poseidon2_perm_B_44_0) + poseidon2_params_C_45_0;
+        const auto poseidon2_perm_ARK_45_1 = in.get(C::poseidon2_perm_B_44_1) + poseidon2_params_C_45_1;
+        const auto poseidon2_perm_ARK_45_2 = in.get(C::poseidon2_perm_B_44_2) + poseidon2_params_C_45_2;
+        const auto poseidon2_perm_ARK_45_3 = in.get(C::poseidon2_perm_B_44_3) + poseidon2_params_C_45_3;
         const auto poseidon2_perm_A_45_0 = poseidon2_perm_ARK_45_0 * poseidon2_perm_ARK_45_0 * poseidon2_perm_ARK_45_0 *
                                            poseidon2_perm_ARK_45_0 * poseidon2_perm_ARK_45_0;
         const auto poseidon2_perm_A_45_1 = poseidon2_perm_ARK_45_1;
@@ -917,10 +920,10 @@ template <typename FF_> class poseidon2_permImpl {
         const auto poseidon2_perm_A_45_3 = poseidon2_perm_ARK_45_3;
         const auto poseidon2_perm_SUM_45 =
             poseidon2_perm_A_45_0 + poseidon2_perm_A_45_1 + poseidon2_perm_A_45_2 + poseidon2_perm_A_45_3;
-        const auto poseidon2_perm_ARK_46_0 = new_term.poseidon2_perm_B_45_0 + poseidon2_params_C_46_0;
-        const auto poseidon2_perm_ARK_46_1 = new_term.poseidon2_perm_B_45_1 + poseidon2_params_C_46_1;
-        const auto poseidon2_perm_ARK_46_2 = new_term.poseidon2_perm_B_45_2 + poseidon2_params_C_46_2;
-        const auto poseidon2_perm_ARK_46_3 = new_term.poseidon2_perm_B_45_3 + poseidon2_params_C_46_3;
+        const auto poseidon2_perm_ARK_46_0 = in.get(C::poseidon2_perm_B_45_0) + poseidon2_params_C_46_0;
+        const auto poseidon2_perm_ARK_46_1 = in.get(C::poseidon2_perm_B_45_1) + poseidon2_params_C_46_1;
+        const auto poseidon2_perm_ARK_46_2 = in.get(C::poseidon2_perm_B_45_2) + poseidon2_params_C_46_2;
+        const auto poseidon2_perm_ARK_46_3 = in.get(C::poseidon2_perm_B_45_3) + poseidon2_params_C_46_3;
         const auto poseidon2_perm_A_46_0 = poseidon2_perm_ARK_46_0 * poseidon2_perm_ARK_46_0 * poseidon2_perm_ARK_46_0 *
                                            poseidon2_perm_ARK_46_0 * poseidon2_perm_ARK_46_0;
         const auto poseidon2_perm_A_46_1 = poseidon2_perm_ARK_46_1;
@@ -928,10 +931,10 @@ template <typename FF_> class poseidon2_permImpl {
         const auto poseidon2_perm_A_46_3 = poseidon2_perm_ARK_46_3;
         const auto poseidon2_perm_SUM_46 =
             poseidon2_perm_A_46_0 + poseidon2_perm_A_46_1 + poseidon2_perm_A_46_2 + poseidon2_perm_A_46_3;
-        const auto poseidon2_perm_ARK_47_0 = new_term.poseidon2_perm_B_46_0 + poseidon2_params_C_47_0;
-        const auto poseidon2_perm_ARK_47_1 = new_term.poseidon2_perm_B_46_1 + poseidon2_params_C_47_1;
-        const auto poseidon2_perm_ARK_47_2 = new_term.poseidon2_perm_B_46_2 + poseidon2_params_C_47_2;
-        const auto poseidon2_perm_ARK_47_3 = new_term.poseidon2_perm_B_46_3 + poseidon2_params_C_47_3;
+        const auto poseidon2_perm_ARK_47_0 = in.get(C::poseidon2_perm_B_46_0) + poseidon2_params_C_47_0;
+        const auto poseidon2_perm_ARK_47_1 = in.get(C::poseidon2_perm_B_46_1) + poseidon2_params_C_47_1;
+        const auto poseidon2_perm_ARK_47_2 = in.get(C::poseidon2_perm_B_46_2) + poseidon2_params_C_47_2;
+        const auto poseidon2_perm_ARK_47_3 = in.get(C::poseidon2_perm_B_46_3) + poseidon2_params_C_47_3;
         const auto poseidon2_perm_A_47_0 = poseidon2_perm_ARK_47_0 * poseidon2_perm_ARK_47_0 * poseidon2_perm_ARK_47_0 *
                                            poseidon2_perm_ARK_47_0 * poseidon2_perm_ARK_47_0;
         const auto poseidon2_perm_A_47_1 = poseidon2_perm_ARK_47_1;
@@ -939,10 +942,10 @@ template <typename FF_> class poseidon2_permImpl {
         const auto poseidon2_perm_A_47_3 = poseidon2_perm_ARK_47_3;
         const auto poseidon2_perm_SUM_47 =
             poseidon2_perm_A_47_0 + poseidon2_perm_A_47_1 + poseidon2_perm_A_47_2 + poseidon2_perm_A_47_3;
-        const auto poseidon2_perm_ARK_48_0 = new_term.poseidon2_perm_B_47_0 + poseidon2_params_C_48_0;
-        const auto poseidon2_perm_ARK_48_1 = new_term.poseidon2_perm_B_47_1 + poseidon2_params_C_48_1;
-        const auto poseidon2_perm_ARK_48_2 = new_term.poseidon2_perm_B_47_2 + poseidon2_params_C_48_2;
-        const auto poseidon2_perm_ARK_48_3 = new_term.poseidon2_perm_B_47_3 + poseidon2_params_C_48_3;
+        const auto poseidon2_perm_ARK_48_0 = in.get(C::poseidon2_perm_B_47_0) + poseidon2_params_C_48_0;
+        const auto poseidon2_perm_ARK_48_1 = in.get(C::poseidon2_perm_B_47_1) + poseidon2_params_C_48_1;
+        const auto poseidon2_perm_ARK_48_2 = in.get(C::poseidon2_perm_B_47_2) + poseidon2_params_C_48_2;
+        const auto poseidon2_perm_ARK_48_3 = in.get(C::poseidon2_perm_B_47_3) + poseidon2_params_C_48_3;
         const auto poseidon2_perm_A_48_0 = poseidon2_perm_ARK_48_0 * poseidon2_perm_ARK_48_0 * poseidon2_perm_ARK_48_0 *
                                            poseidon2_perm_ARK_48_0 * poseidon2_perm_ARK_48_0;
         const auto poseidon2_perm_A_48_1 = poseidon2_perm_ARK_48_1;
@@ -950,10 +953,10 @@ template <typename FF_> class poseidon2_permImpl {
         const auto poseidon2_perm_A_48_3 = poseidon2_perm_ARK_48_3;
         const auto poseidon2_perm_SUM_48 =
             poseidon2_perm_A_48_0 + poseidon2_perm_A_48_1 + poseidon2_perm_A_48_2 + poseidon2_perm_A_48_3;
-        const auto poseidon2_perm_ARK_49_0 = new_term.poseidon2_perm_B_48_0 + poseidon2_params_C_49_0;
-        const auto poseidon2_perm_ARK_49_1 = new_term.poseidon2_perm_B_48_1 + poseidon2_params_C_49_1;
-        const auto poseidon2_perm_ARK_49_2 = new_term.poseidon2_perm_B_48_2 + poseidon2_params_C_49_2;
-        const auto poseidon2_perm_ARK_49_3 = new_term.poseidon2_perm_B_48_3 + poseidon2_params_C_49_3;
+        const auto poseidon2_perm_ARK_49_0 = in.get(C::poseidon2_perm_B_48_0) + poseidon2_params_C_49_0;
+        const auto poseidon2_perm_ARK_49_1 = in.get(C::poseidon2_perm_B_48_1) + poseidon2_params_C_49_1;
+        const auto poseidon2_perm_ARK_49_2 = in.get(C::poseidon2_perm_B_48_2) + poseidon2_params_C_49_2;
+        const auto poseidon2_perm_ARK_49_3 = in.get(C::poseidon2_perm_B_48_3) + poseidon2_params_C_49_3;
         const auto poseidon2_perm_A_49_0 = poseidon2_perm_ARK_49_0 * poseidon2_perm_ARK_49_0 * poseidon2_perm_ARK_49_0 *
                                            poseidon2_perm_ARK_49_0 * poseidon2_perm_ARK_49_0;
         const auto poseidon2_perm_A_49_1 = poseidon2_perm_ARK_49_1;
@@ -961,10 +964,10 @@ template <typename FF_> class poseidon2_permImpl {
         const auto poseidon2_perm_A_49_3 = poseidon2_perm_ARK_49_3;
         const auto poseidon2_perm_SUM_49 =
             poseidon2_perm_A_49_0 + poseidon2_perm_A_49_1 + poseidon2_perm_A_49_2 + poseidon2_perm_A_49_3;
-        const auto poseidon2_perm_ARK_50_0 = new_term.poseidon2_perm_B_49_0 + poseidon2_params_C_50_0;
-        const auto poseidon2_perm_ARK_50_1 = new_term.poseidon2_perm_B_49_1 + poseidon2_params_C_50_1;
-        const auto poseidon2_perm_ARK_50_2 = new_term.poseidon2_perm_B_49_2 + poseidon2_params_C_50_2;
-        const auto poseidon2_perm_ARK_50_3 = new_term.poseidon2_perm_B_49_3 + poseidon2_params_C_50_3;
+        const auto poseidon2_perm_ARK_50_0 = in.get(C::poseidon2_perm_B_49_0) + poseidon2_params_C_50_0;
+        const auto poseidon2_perm_ARK_50_1 = in.get(C::poseidon2_perm_B_49_1) + poseidon2_params_C_50_1;
+        const auto poseidon2_perm_ARK_50_2 = in.get(C::poseidon2_perm_B_49_2) + poseidon2_params_C_50_2;
+        const auto poseidon2_perm_ARK_50_3 = in.get(C::poseidon2_perm_B_49_3) + poseidon2_params_C_50_3;
         const auto poseidon2_perm_A_50_0 = poseidon2_perm_ARK_50_0 * poseidon2_perm_ARK_50_0 * poseidon2_perm_ARK_50_0 *
                                            poseidon2_perm_ARK_50_0 * poseidon2_perm_ARK_50_0;
         const auto poseidon2_perm_A_50_1 = poseidon2_perm_ARK_50_1;
@@ -972,10 +975,10 @@ template <typename FF_> class poseidon2_permImpl {
         const auto poseidon2_perm_A_50_3 = poseidon2_perm_ARK_50_3;
         const auto poseidon2_perm_SUM_50 =
             poseidon2_perm_A_50_0 + poseidon2_perm_A_50_1 + poseidon2_perm_A_50_2 + poseidon2_perm_A_50_3;
-        const auto poseidon2_perm_ARK_51_0 = new_term.poseidon2_perm_B_50_0 + poseidon2_params_C_51_0;
-        const auto poseidon2_perm_ARK_51_1 = new_term.poseidon2_perm_B_50_1 + poseidon2_params_C_51_1;
-        const auto poseidon2_perm_ARK_51_2 = new_term.poseidon2_perm_B_50_2 + poseidon2_params_C_51_2;
-        const auto poseidon2_perm_ARK_51_3 = new_term.poseidon2_perm_B_50_3 + poseidon2_params_C_51_3;
+        const auto poseidon2_perm_ARK_51_0 = in.get(C::poseidon2_perm_B_50_0) + poseidon2_params_C_51_0;
+        const auto poseidon2_perm_ARK_51_1 = in.get(C::poseidon2_perm_B_50_1) + poseidon2_params_C_51_1;
+        const auto poseidon2_perm_ARK_51_2 = in.get(C::poseidon2_perm_B_50_2) + poseidon2_params_C_51_2;
+        const auto poseidon2_perm_ARK_51_3 = in.get(C::poseidon2_perm_B_50_3) + poseidon2_params_C_51_3;
         const auto poseidon2_perm_A_51_0 = poseidon2_perm_ARK_51_0 * poseidon2_perm_ARK_51_0 * poseidon2_perm_ARK_51_0 *
                                            poseidon2_perm_ARK_51_0 * poseidon2_perm_ARK_51_0;
         const auto poseidon2_perm_A_51_1 = poseidon2_perm_ARK_51_1;
@@ -983,10 +986,10 @@ template <typename FF_> class poseidon2_permImpl {
         const auto poseidon2_perm_A_51_3 = poseidon2_perm_ARK_51_3;
         const auto poseidon2_perm_SUM_51 =
             poseidon2_perm_A_51_0 + poseidon2_perm_A_51_1 + poseidon2_perm_A_51_2 + poseidon2_perm_A_51_3;
-        const auto poseidon2_perm_ARK_52_0 = new_term.poseidon2_perm_B_51_0 + poseidon2_params_C_52_0;
-        const auto poseidon2_perm_ARK_52_1 = new_term.poseidon2_perm_B_51_1 + poseidon2_params_C_52_1;
-        const auto poseidon2_perm_ARK_52_2 = new_term.poseidon2_perm_B_51_2 + poseidon2_params_C_52_2;
-        const auto poseidon2_perm_ARK_52_3 = new_term.poseidon2_perm_B_51_3 + poseidon2_params_C_52_3;
+        const auto poseidon2_perm_ARK_52_0 = in.get(C::poseidon2_perm_B_51_0) + poseidon2_params_C_52_0;
+        const auto poseidon2_perm_ARK_52_1 = in.get(C::poseidon2_perm_B_51_1) + poseidon2_params_C_52_1;
+        const auto poseidon2_perm_ARK_52_2 = in.get(C::poseidon2_perm_B_51_2) + poseidon2_params_C_52_2;
+        const auto poseidon2_perm_ARK_52_3 = in.get(C::poseidon2_perm_B_51_3) + poseidon2_params_C_52_3;
         const auto poseidon2_perm_A_52_0 = poseidon2_perm_ARK_52_0 * poseidon2_perm_ARK_52_0 * poseidon2_perm_ARK_52_0 *
                                            poseidon2_perm_ARK_52_0 * poseidon2_perm_ARK_52_0;
         const auto poseidon2_perm_A_52_1 = poseidon2_perm_ARK_52_1;
@@ -994,10 +997,10 @@ template <typename FF_> class poseidon2_permImpl {
         const auto poseidon2_perm_A_52_3 = poseidon2_perm_ARK_52_3;
         const auto poseidon2_perm_SUM_52 =
             poseidon2_perm_A_52_0 + poseidon2_perm_A_52_1 + poseidon2_perm_A_52_2 + poseidon2_perm_A_52_3;
-        const auto poseidon2_perm_ARK_53_0 = new_term.poseidon2_perm_B_52_0 + poseidon2_params_C_53_0;
-        const auto poseidon2_perm_ARK_53_1 = new_term.poseidon2_perm_B_52_1 + poseidon2_params_C_53_1;
-        const auto poseidon2_perm_ARK_53_2 = new_term.poseidon2_perm_B_52_2 + poseidon2_params_C_53_2;
-        const auto poseidon2_perm_ARK_53_3 = new_term.poseidon2_perm_B_52_3 + poseidon2_params_C_53_3;
+        const auto poseidon2_perm_ARK_53_0 = in.get(C::poseidon2_perm_B_52_0) + poseidon2_params_C_53_0;
+        const auto poseidon2_perm_ARK_53_1 = in.get(C::poseidon2_perm_B_52_1) + poseidon2_params_C_53_1;
+        const auto poseidon2_perm_ARK_53_2 = in.get(C::poseidon2_perm_B_52_2) + poseidon2_params_C_53_2;
+        const auto poseidon2_perm_ARK_53_3 = in.get(C::poseidon2_perm_B_52_3) + poseidon2_params_C_53_3;
         const auto poseidon2_perm_A_53_0 = poseidon2_perm_ARK_53_0 * poseidon2_perm_ARK_53_0 * poseidon2_perm_ARK_53_0 *
                                            poseidon2_perm_ARK_53_0 * poseidon2_perm_ARK_53_0;
         const auto poseidon2_perm_A_53_1 = poseidon2_perm_ARK_53_1;
@@ -1005,10 +1008,10 @@ template <typename FF_> class poseidon2_permImpl {
         const auto poseidon2_perm_A_53_3 = poseidon2_perm_ARK_53_3;
         const auto poseidon2_perm_SUM_53 =
             poseidon2_perm_A_53_0 + poseidon2_perm_A_53_1 + poseidon2_perm_A_53_2 + poseidon2_perm_A_53_3;
-        const auto poseidon2_perm_ARK_54_0 = new_term.poseidon2_perm_B_53_0 + poseidon2_params_C_54_0;
-        const auto poseidon2_perm_ARK_54_1 = new_term.poseidon2_perm_B_53_1 + poseidon2_params_C_54_1;
-        const auto poseidon2_perm_ARK_54_2 = new_term.poseidon2_perm_B_53_2 + poseidon2_params_C_54_2;
-        const auto poseidon2_perm_ARK_54_3 = new_term.poseidon2_perm_B_53_3 + poseidon2_params_C_54_3;
+        const auto poseidon2_perm_ARK_54_0 = in.get(C::poseidon2_perm_B_53_0) + poseidon2_params_C_54_0;
+        const auto poseidon2_perm_ARK_54_1 = in.get(C::poseidon2_perm_B_53_1) + poseidon2_params_C_54_1;
+        const auto poseidon2_perm_ARK_54_2 = in.get(C::poseidon2_perm_B_53_2) + poseidon2_params_C_54_2;
+        const auto poseidon2_perm_ARK_54_3 = in.get(C::poseidon2_perm_B_53_3) + poseidon2_params_C_54_3;
         const auto poseidon2_perm_A_54_0 = poseidon2_perm_ARK_54_0 * poseidon2_perm_ARK_54_0 * poseidon2_perm_ARK_54_0 *
                                            poseidon2_perm_ARK_54_0 * poseidon2_perm_ARK_54_0;
         const auto poseidon2_perm_A_54_1 = poseidon2_perm_ARK_54_1;
@@ -1016,10 +1019,10 @@ template <typename FF_> class poseidon2_permImpl {
         const auto poseidon2_perm_A_54_3 = poseidon2_perm_ARK_54_3;
         const auto poseidon2_perm_SUM_54 =
             poseidon2_perm_A_54_0 + poseidon2_perm_A_54_1 + poseidon2_perm_A_54_2 + poseidon2_perm_A_54_3;
-        const auto poseidon2_perm_ARK_55_0 = new_term.poseidon2_perm_B_54_0 + poseidon2_params_C_55_0;
-        const auto poseidon2_perm_ARK_55_1 = new_term.poseidon2_perm_B_54_1 + poseidon2_params_C_55_1;
-        const auto poseidon2_perm_ARK_55_2 = new_term.poseidon2_perm_B_54_2 + poseidon2_params_C_55_2;
-        const auto poseidon2_perm_ARK_55_3 = new_term.poseidon2_perm_B_54_3 + poseidon2_params_C_55_3;
+        const auto poseidon2_perm_ARK_55_0 = in.get(C::poseidon2_perm_B_54_0) + poseidon2_params_C_55_0;
+        const auto poseidon2_perm_ARK_55_1 = in.get(C::poseidon2_perm_B_54_1) + poseidon2_params_C_55_1;
+        const auto poseidon2_perm_ARK_55_2 = in.get(C::poseidon2_perm_B_54_2) + poseidon2_params_C_55_2;
+        const auto poseidon2_perm_ARK_55_3 = in.get(C::poseidon2_perm_B_54_3) + poseidon2_params_C_55_3;
         const auto poseidon2_perm_A_55_0 = poseidon2_perm_ARK_55_0 * poseidon2_perm_ARK_55_0 * poseidon2_perm_ARK_55_0 *
                                            poseidon2_perm_ARK_55_0 * poseidon2_perm_ARK_55_0;
         const auto poseidon2_perm_A_55_1 = poseidon2_perm_ARK_55_1;
@@ -1027,10 +1030,10 @@ template <typename FF_> class poseidon2_permImpl {
         const auto poseidon2_perm_A_55_3 = poseidon2_perm_ARK_55_3;
         const auto poseidon2_perm_SUM_55 =
             poseidon2_perm_A_55_0 + poseidon2_perm_A_55_1 + poseidon2_perm_A_55_2 + poseidon2_perm_A_55_3;
-        const auto poseidon2_perm_ARK_56_0 = new_term.poseidon2_perm_B_55_0 + poseidon2_params_C_56_0;
-        const auto poseidon2_perm_ARK_56_1 = new_term.poseidon2_perm_B_55_1 + poseidon2_params_C_56_1;
-        const auto poseidon2_perm_ARK_56_2 = new_term.poseidon2_perm_B_55_2 + poseidon2_params_C_56_2;
-        const auto poseidon2_perm_ARK_56_3 = new_term.poseidon2_perm_B_55_3 + poseidon2_params_C_56_3;
+        const auto poseidon2_perm_ARK_56_0 = in.get(C::poseidon2_perm_B_55_0) + poseidon2_params_C_56_0;
+        const auto poseidon2_perm_ARK_56_1 = in.get(C::poseidon2_perm_B_55_1) + poseidon2_params_C_56_1;
+        const auto poseidon2_perm_ARK_56_2 = in.get(C::poseidon2_perm_B_55_2) + poseidon2_params_C_56_2;
+        const auto poseidon2_perm_ARK_56_3 = in.get(C::poseidon2_perm_B_55_3) + poseidon2_params_C_56_3;
         const auto poseidon2_perm_A_56_0 = poseidon2_perm_ARK_56_0 * poseidon2_perm_ARK_56_0 * poseidon2_perm_ARK_56_0 *
                                            poseidon2_perm_ARK_56_0 * poseidon2_perm_ARK_56_0;
         const auto poseidon2_perm_A_56_1 = poseidon2_perm_ARK_56_1;
@@ -1038,10 +1041,10 @@ template <typename FF_> class poseidon2_permImpl {
         const auto poseidon2_perm_A_56_3 = poseidon2_perm_ARK_56_3;
         const auto poseidon2_perm_SUM_56 =
             poseidon2_perm_A_56_0 + poseidon2_perm_A_56_1 + poseidon2_perm_A_56_2 + poseidon2_perm_A_56_3;
-        const auto poseidon2_perm_ARK_57_0 = new_term.poseidon2_perm_B_56_0 + poseidon2_params_C_57_0;
-        const auto poseidon2_perm_ARK_57_1 = new_term.poseidon2_perm_B_56_1 + poseidon2_params_C_57_1;
-        const auto poseidon2_perm_ARK_57_2 = new_term.poseidon2_perm_B_56_2 + poseidon2_params_C_57_2;
-        const auto poseidon2_perm_ARK_57_3 = new_term.poseidon2_perm_B_56_3 + poseidon2_params_C_57_3;
+        const auto poseidon2_perm_ARK_57_0 = in.get(C::poseidon2_perm_B_56_0) + poseidon2_params_C_57_0;
+        const auto poseidon2_perm_ARK_57_1 = in.get(C::poseidon2_perm_B_56_1) + poseidon2_params_C_57_1;
+        const auto poseidon2_perm_ARK_57_2 = in.get(C::poseidon2_perm_B_56_2) + poseidon2_params_C_57_2;
+        const auto poseidon2_perm_ARK_57_3 = in.get(C::poseidon2_perm_B_56_3) + poseidon2_params_C_57_3;
         const auto poseidon2_perm_A_57_0 = poseidon2_perm_ARK_57_0 * poseidon2_perm_ARK_57_0 * poseidon2_perm_ARK_57_0 *
                                            poseidon2_perm_ARK_57_0 * poseidon2_perm_ARK_57_0;
         const auto poseidon2_perm_A_57_1 = poseidon2_perm_ARK_57_1;
@@ -1049,10 +1052,10 @@ template <typename FF_> class poseidon2_permImpl {
         const auto poseidon2_perm_A_57_3 = poseidon2_perm_ARK_57_3;
         const auto poseidon2_perm_SUM_57 =
             poseidon2_perm_A_57_0 + poseidon2_perm_A_57_1 + poseidon2_perm_A_57_2 + poseidon2_perm_A_57_3;
-        const auto poseidon2_perm_ARK_58_0 = new_term.poseidon2_perm_B_57_0 + poseidon2_params_C_58_0;
-        const auto poseidon2_perm_ARK_58_1 = new_term.poseidon2_perm_B_57_1 + poseidon2_params_C_58_1;
-        const auto poseidon2_perm_ARK_58_2 = new_term.poseidon2_perm_B_57_2 + poseidon2_params_C_58_2;
-        const auto poseidon2_perm_ARK_58_3 = new_term.poseidon2_perm_B_57_3 + poseidon2_params_C_58_3;
+        const auto poseidon2_perm_ARK_58_0 = in.get(C::poseidon2_perm_B_57_0) + poseidon2_params_C_58_0;
+        const auto poseidon2_perm_ARK_58_1 = in.get(C::poseidon2_perm_B_57_1) + poseidon2_params_C_58_1;
+        const auto poseidon2_perm_ARK_58_2 = in.get(C::poseidon2_perm_B_57_2) + poseidon2_params_C_58_2;
+        const auto poseidon2_perm_ARK_58_3 = in.get(C::poseidon2_perm_B_57_3) + poseidon2_params_C_58_3;
         const auto poseidon2_perm_A_58_0 = poseidon2_perm_ARK_58_0 * poseidon2_perm_ARK_58_0 * poseidon2_perm_ARK_58_0 *
                                            poseidon2_perm_ARK_58_0 * poseidon2_perm_ARK_58_0;
         const auto poseidon2_perm_A_58_1 = poseidon2_perm_ARK_58_1;
@@ -1060,10 +1063,10 @@ template <typename FF_> class poseidon2_permImpl {
         const auto poseidon2_perm_A_58_3 = poseidon2_perm_ARK_58_3;
         const auto poseidon2_perm_SUM_58 =
             poseidon2_perm_A_58_0 + poseidon2_perm_A_58_1 + poseidon2_perm_A_58_2 + poseidon2_perm_A_58_3;
-        const auto poseidon2_perm_ARK_59_0 = new_term.poseidon2_perm_B_58_0 + poseidon2_params_C_59_0;
-        const auto poseidon2_perm_ARK_59_1 = new_term.poseidon2_perm_B_58_1 + poseidon2_params_C_59_1;
-        const auto poseidon2_perm_ARK_59_2 = new_term.poseidon2_perm_B_58_2 + poseidon2_params_C_59_2;
-        const auto poseidon2_perm_ARK_59_3 = new_term.poseidon2_perm_B_58_3 + poseidon2_params_C_59_3;
+        const auto poseidon2_perm_ARK_59_0 = in.get(C::poseidon2_perm_B_58_0) + poseidon2_params_C_59_0;
+        const auto poseidon2_perm_ARK_59_1 = in.get(C::poseidon2_perm_B_58_1) + poseidon2_params_C_59_1;
+        const auto poseidon2_perm_ARK_59_2 = in.get(C::poseidon2_perm_B_58_2) + poseidon2_params_C_59_2;
+        const auto poseidon2_perm_ARK_59_3 = in.get(C::poseidon2_perm_B_58_3) + poseidon2_params_C_59_3;
         const auto poseidon2_perm_A_59_0 = poseidon2_perm_ARK_59_0 * poseidon2_perm_ARK_59_0 * poseidon2_perm_ARK_59_0 *
                                            poseidon2_perm_ARK_59_0 * poseidon2_perm_ARK_59_0;
         const auto poseidon2_perm_A_59_1 = poseidon2_perm_ARK_59_1;
@@ -1071,10 +1074,10 @@ template <typename FF_> class poseidon2_permImpl {
         const auto poseidon2_perm_A_59_3 = poseidon2_perm_ARK_59_3;
         const auto poseidon2_perm_SUM_59 =
             poseidon2_perm_A_59_0 + poseidon2_perm_A_59_1 + poseidon2_perm_A_59_2 + poseidon2_perm_A_59_3;
-        const auto poseidon2_perm_ARK_60_0 = new_term.poseidon2_perm_B_59_0 + poseidon2_params_C_60_0;
-        const auto poseidon2_perm_ARK_60_1 = new_term.poseidon2_perm_B_59_1 + poseidon2_params_C_60_1;
-        const auto poseidon2_perm_ARK_60_2 = new_term.poseidon2_perm_B_59_2 + poseidon2_params_C_60_2;
-        const auto poseidon2_perm_ARK_60_3 = new_term.poseidon2_perm_B_59_3 + poseidon2_params_C_60_3;
+        const auto poseidon2_perm_ARK_60_0 = in.get(C::poseidon2_perm_B_59_0) + poseidon2_params_C_60_0;
+        const auto poseidon2_perm_ARK_60_1 = in.get(C::poseidon2_perm_B_59_1) + poseidon2_params_C_60_1;
+        const auto poseidon2_perm_ARK_60_2 = in.get(C::poseidon2_perm_B_59_2) + poseidon2_params_C_60_2;
+        const auto poseidon2_perm_ARK_60_3 = in.get(C::poseidon2_perm_B_59_3) + poseidon2_params_C_60_3;
         const auto poseidon2_perm_A_60_0 = poseidon2_perm_ARK_60_0 * poseidon2_perm_ARK_60_0 * poseidon2_perm_ARK_60_0 *
                                            poseidon2_perm_ARK_60_0 * poseidon2_perm_ARK_60_0;
         const auto poseidon2_perm_A_60_1 = poseidon2_perm_ARK_60_1 * poseidon2_perm_ARK_60_1 * poseidon2_perm_ARK_60_1 *
@@ -1087,10 +1090,10 @@ template <typename FF_> class poseidon2_permImpl {
         const auto poseidon2_perm_T_60_1 = poseidon2_perm_A_60_2 + poseidon2_perm_A_60_3;
         const auto poseidon2_perm_T_60_2 = FF(2) * poseidon2_perm_A_60_1 + poseidon2_perm_T_60_1;
         const auto poseidon2_perm_T_60_3 = FF(2) * poseidon2_perm_A_60_3 + poseidon2_perm_T_60_0;
-        const auto poseidon2_perm_ARK_61_0 = new_term.poseidon2_perm_T_60_6 + poseidon2_params_C_61_0;
-        const auto poseidon2_perm_ARK_61_1 = new_term.poseidon2_perm_T_60_5 + poseidon2_params_C_61_1;
-        const auto poseidon2_perm_ARK_61_2 = new_term.poseidon2_perm_T_60_7 + poseidon2_params_C_61_2;
-        const auto poseidon2_perm_ARK_61_3 = new_term.poseidon2_perm_T_60_4 + poseidon2_params_C_61_3;
+        const auto poseidon2_perm_ARK_61_0 = in.get(C::poseidon2_perm_T_60_6) + poseidon2_params_C_61_0;
+        const auto poseidon2_perm_ARK_61_1 = in.get(C::poseidon2_perm_T_60_5) + poseidon2_params_C_61_1;
+        const auto poseidon2_perm_ARK_61_2 = in.get(C::poseidon2_perm_T_60_7) + poseidon2_params_C_61_2;
+        const auto poseidon2_perm_ARK_61_3 = in.get(C::poseidon2_perm_T_60_4) + poseidon2_params_C_61_3;
         const auto poseidon2_perm_A_61_0 = poseidon2_perm_ARK_61_0 * poseidon2_perm_ARK_61_0 * poseidon2_perm_ARK_61_0 *
                                            poseidon2_perm_ARK_61_0 * poseidon2_perm_ARK_61_0;
         const auto poseidon2_perm_A_61_1 = poseidon2_perm_ARK_61_1 * poseidon2_perm_ARK_61_1 * poseidon2_perm_ARK_61_1 *
@@ -1103,10 +1106,10 @@ template <typename FF_> class poseidon2_permImpl {
         const auto poseidon2_perm_T_61_1 = poseidon2_perm_A_61_2 + poseidon2_perm_A_61_3;
         const auto poseidon2_perm_T_61_2 = FF(2) * poseidon2_perm_A_61_1 + poseidon2_perm_T_61_1;
         const auto poseidon2_perm_T_61_3 = FF(2) * poseidon2_perm_A_61_3 + poseidon2_perm_T_61_0;
-        const auto poseidon2_perm_ARK_62_0 = new_term.poseidon2_perm_T_61_6 + poseidon2_params_C_62_0;
-        const auto poseidon2_perm_ARK_62_1 = new_term.poseidon2_perm_T_61_5 + poseidon2_params_C_62_1;
-        const auto poseidon2_perm_ARK_62_2 = new_term.poseidon2_perm_T_61_7 + poseidon2_params_C_62_2;
-        const auto poseidon2_perm_ARK_62_3 = new_term.poseidon2_perm_T_61_4 + poseidon2_params_C_62_3;
+        const auto poseidon2_perm_ARK_62_0 = in.get(C::poseidon2_perm_T_61_6) + poseidon2_params_C_62_0;
+        const auto poseidon2_perm_ARK_62_1 = in.get(C::poseidon2_perm_T_61_5) + poseidon2_params_C_62_1;
+        const auto poseidon2_perm_ARK_62_2 = in.get(C::poseidon2_perm_T_61_7) + poseidon2_params_C_62_2;
+        const auto poseidon2_perm_ARK_62_3 = in.get(C::poseidon2_perm_T_61_4) + poseidon2_params_C_62_3;
         const auto poseidon2_perm_A_62_0 = poseidon2_perm_ARK_62_0 * poseidon2_perm_ARK_62_0 * poseidon2_perm_ARK_62_0 *
                                            poseidon2_perm_ARK_62_0 * poseidon2_perm_ARK_62_0;
         const auto poseidon2_perm_A_62_1 = poseidon2_perm_ARK_62_1 * poseidon2_perm_ARK_62_1 * poseidon2_perm_ARK_62_1 *
@@ -1119,10 +1122,10 @@ template <typename FF_> class poseidon2_permImpl {
         const auto poseidon2_perm_T_62_1 = poseidon2_perm_A_62_2 + poseidon2_perm_A_62_3;
         const auto poseidon2_perm_T_62_2 = FF(2) * poseidon2_perm_A_62_1 + poseidon2_perm_T_62_1;
         const auto poseidon2_perm_T_62_3 = FF(2) * poseidon2_perm_A_62_3 + poseidon2_perm_T_62_0;
-        const auto poseidon2_perm_ARK_63_0 = new_term.poseidon2_perm_T_62_6 + poseidon2_params_C_63_0;
-        const auto poseidon2_perm_ARK_63_1 = new_term.poseidon2_perm_T_62_5 + poseidon2_params_C_63_1;
-        const auto poseidon2_perm_ARK_63_2 = new_term.poseidon2_perm_T_62_7 + poseidon2_params_C_63_2;
-        const auto poseidon2_perm_ARK_63_3 = new_term.poseidon2_perm_T_62_4 + poseidon2_params_C_63_3;
+        const auto poseidon2_perm_ARK_63_0 = in.get(C::poseidon2_perm_T_62_6) + poseidon2_params_C_63_0;
+        const auto poseidon2_perm_ARK_63_1 = in.get(C::poseidon2_perm_T_62_5) + poseidon2_params_C_63_1;
+        const auto poseidon2_perm_ARK_63_2 = in.get(C::poseidon2_perm_T_62_7) + poseidon2_params_C_63_2;
+        const auto poseidon2_perm_ARK_63_3 = in.get(C::poseidon2_perm_T_62_4) + poseidon2_params_C_63_3;
         const auto poseidon2_perm_A_63_0 = poseidon2_perm_ARK_63_0 * poseidon2_perm_ARK_63_0 * poseidon2_perm_ARK_63_0 *
                                            poseidon2_perm_ARK_63_0 * poseidon2_perm_ARK_63_0;
         const auto poseidon2_perm_A_63_1 = poseidon2_perm_ARK_63_1 * poseidon2_perm_ARK_63_1 * poseidon2_perm_ARK_63_1 *
@@ -1138,2079 +1141,2083 @@ template <typename FF_> class poseidon2_permImpl {
 
         {
             using Accumulator = typename std::tuple_element_t<0, ContainerOverSubrelations>;
-            auto tmp = new_term.poseidon2_perm_sel * (FF(1) - new_term.poseidon2_perm_sel);
+            auto tmp = in.get(C::poseidon2_perm_sel) * (FF(1) - in.get(C::poseidon2_perm_sel));
             tmp *= scaling_factor;
             std::get<0>(evals) += typename Accumulator::View(tmp);
         }
         {
             using Accumulator = typename std::tuple_element_t<1, ContainerOverSubrelations>;
             auto tmp =
-                new_term.poseidon2_perm_sel * (new_term.poseidon2_perm_EXT_LAYER_4 -
-                                               (FF(4) * poseidon2_perm_EXT_LAYER_1 + poseidon2_perm_EXT_LAYER_3));
+                in.get(C::poseidon2_perm_sel) * (in.get(C::poseidon2_perm_EXT_LAYER_4) -
+                                                 (FF(4) * poseidon2_perm_EXT_LAYER_1 + poseidon2_perm_EXT_LAYER_3));
             tmp *= scaling_factor;
             std::get<1>(evals) += typename Accumulator::View(tmp);
         }
         {
             using Accumulator = typename std::tuple_element_t<2, ContainerOverSubrelations>;
             auto tmp =
-                new_term.poseidon2_perm_sel * (new_term.poseidon2_perm_EXT_LAYER_5 -
-                                               (FF(4) * poseidon2_perm_EXT_LAYER_0 + poseidon2_perm_EXT_LAYER_2));
+                in.get(C::poseidon2_perm_sel) * (in.get(C::poseidon2_perm_EXT_LAYER_5) -
+                                                 (FF(4) * poseidon2_perm_EXT_LAYER_0 + poseidon2_perm_EXT_LAYER_2));
             tmp *= scaling_factor;
             std::get<2>(evals) += typename Accumulator::View(tmp);
         }
         {
             using Accumulator = typename std::tuple_element_t<3, ContainerOverSubrelations>;
             auto tmp =
-                new_term.poseidon2_perm_sel * (new_term.poseidon2_perm_EXT_LAYER_6 -
-                                               (poseidon2_perm_EXT_LAYER_3 + new_term.poseidon2_perm_EXT_LAYER_5));
+                in.get(C::poseidon2_perm_sel) * (in.get(C::poseidon2_perm_EXT_LAYER_6) -
+                                                 (poseidon2_perm_EXT_LAYER_3 + in.get(C::poseidon2_perm_EXT_LAYER_5)));
             tmp *= scaling_factor;
             std::get<3>(evals) += typename Accumulator::View(tmp);
         }
         {
             using Accumulator = typename std::tuple_element_t<4, ContainerOverSubrelations>;
             auto tmp =
-                new_term.poseidon2_perm_sel * (new_term.poseidon2_perm_EXT_LAYER_7 -
-                                               (poseidon2_perm_EXT_LAYER_2 + new_term.poseidon2_perm_EXT_LAYER_4));
+                in.get(C::poseidon2_perm_sel) * (in.get(C::poseidon2_perm_EXT_LAYER_7) -
+                                                 (poseidon2_perm_EXT_LAYER_2 + in.get(C::poseidon2_perm_EXT_LAYER_4)));
             tmp *= scaling_factor;
             std::get<4>(evals) += typename Accumulator::View(tmp);
         }
         {
             using Accumulator = typename std::tuple_element_t<5, ContainerOverSubrelations>;
-            auto tmp = new_term.poseidon2_perm_sel *
-                       (new_term.poseidon2_perm_T_0_4 - (FF(4) * poseidon2_perm_T_0_1 + poseidon2_perm_T_0_3));
+            auto tmp = in.get(C::poseidon2_perm_sel) *
+                       (in.get(C::poseidon2_perm_T_0_4) - (FF(4) * poseidon2_perm_T_0_1 + poseidon2_perm_T_0_3));
             tmp *= scaling_factor;
             std::get<5>(evals) += typename Accumulator::View(tmp);
         }
         {
             using Accumulator = typename std::tuple_element_t<6, ContainerOverSubrelations>;
-            auto tmp = new_term.poseidon2_perm_sel *
-                       (new_term.poseidon2_perm_T_0_5 - (FF(4) * poseidon2_perm_T_0_0 + poseidon2_perm_T_0_2));
+            auto tmp = in.get(C::poseidon2_perm_sel) *
+                       (in.get(C::poseidon2_perm_T_0_5) - (FF(4) * poseidon2_perm_T_0_0 + poseidon2_perm_T_0_2));
             tmp *= scaling_factor;
             std::get<6>(evals) += typename Accumulator::View(tmp);
         }
         {
             using Accumulator = typename std::tuple_element_t<7, ContainerOverSubrelations>;
-            auto tmp = new_term.poseidon2_perm_sel *
-                       (new_term.poseidon2_perm_T_0_6 - (poseidon2_perm_T_0_3 + new_term.poseidon2_perm_T_0_5));
+            auto tmp = in.get(C::poseidon2_perm_sel) *
+                       (in.get(C::poseidon2_perm_T_0_6) - (poseidon2_perm_T_0_3 + in.get(C::poseidon2_perm_T_0_5)));
             tmp *= scaling_factor;
             std::get<7>(evals) += typename Accumulator::View(tmp);
         }
         {
             using Accumulator = typename std::tuple_element_t<8, ContainerOverSubrelations>;
-            auto tmp = new_term.poseidon2_perm_sel *
-                       (new_term.poseidon2_perm_T_0_7 - (poseidon2_perm_T_0_2 + new_term.poseidon2_perm_T_0_4));
+            auto tmp = in.get(C::poseidon2_perm_sel) *
+                       (in.get(C::poseidon2_perm_T_0_7) - (poseidon2_perm_T_0_2 + in.get(C::poseidon2_perm_T_0_4)));
             tmp *= scaling_factor;
             std::get<8>(evals) += typename Accumulator::View(tmp);
         }
         {
             using Accumulator = typename std::tuple_element_t<9, ContainerOverSubrelations>;
-            auto tmp = new_term.poseidon2_perm_sel *
-                       (new_term.poseidon2_perm_T_1_4 - (FF(4) * poseidon2_perm_T_1_1 + poseidon2_perm_T_1_3));
+            auto tmp = in.get(C::poseidon2_perm_sel) *
+                       (in.get(C::poseidon2_perm_T_1_4) - (FF(4) * poseidon2_perm_T_1_1 + poseidon2_perm_T_1_3));
             tmp *= scaling_factor;
             std::get<9>(evals) += typename Accumulator::View(tmp);
         }
         {
             using Accumulator = typename std::tuple_element_t<10, ContainerOverSubrelations>;
-            auto tmp = new_term.poseidon2_perm_sel *
-                       (new_term.poseidon2_perm_T_1_5 - (FF(4) * poseidon2_perm_T_1_0 + poseidon2_perm_T_1_2));
+            auto tmp = in.get(C::poseidon2_perm_sel) *
+                       (in.get(C::poseidon2_perm_T_1_5) - (FF(4) * poseidon2_perm_T_1_0 + poseidon2_perm_T_1_2));
             tmp *= scaling_factor;
             std::get<10>(evals) += typename Accumulator::View(tmp);
         }
         {
             using Accumulator = typename std::tuple_element_t<11, ContainerOverSubrelations>;
-            auto tmp = new_term.poseidon2_perm_sel *
-                       (new_term.poseidon2_perm_T_1_6 - (poseidon2_perm_T_1_3 + new_term.poseidon2_perm_T_1_5));
+            auto tmp = in.get(C::poseidon2_perm_sel) *
+                       (in.get(C::poseidon2_perm_T_1_6) - (poseidon2_perm_T_1_3 + in.get(C::poseidon2_perm_T_1_5)));
             tmp *= scaling_factor;
             std::get<11>(evals) += typename Accumulator::View(tmp);
         }
         {
             using Accumulator = typename std::tuple_element_t<12, ContainerOverSubrelations>;
-            auto tmp = new_term.poseidon2_perm_sel *
-                       (new_term.poseidon2_perm_T_1_7 - (poseidon2_perm_T_1_2 + new_term.poseidon2_perm_T_1_4));
+            auto tmp = in.get(C::poseidon2_perm_sel) *
+                       (in.get(C::poseidon2_perm_T_1_7) - (poseidon2_perm_T_1_2 + in.get(C::poseidon2_perm_T_1_4)));
             tmp *= scaling_factor;
             std::get<12>(evals) += typename Accumulator::View(tmp);
         }
         {
             using Accumulator = typename std::tuple_element_t<13, ContainerOverSubrelations>;
-            auto tmp = new_term.poseidon2_perm_sel *
-                       (new_term.poseidon2_perm_T_2_4 - (FF(4) * poseidon2_perm_T_2_1 + poseidon2_perm_T_2_3));
+            auto tmp = in.get(C::poseidon2_perm_sel) *
+                       (in.get(C::poseidon2_perm_T_2_4) - (FF(4) * poseidon2_perm_T_2_1 + poseidon2_perm_T_2_3));
             tmp *= scaling_factor;
             std::get<13>(evals) += typename Accumulator::View(tmp);
         }
         {
             using Accumulator = typename std::tuple_element_t<14, ContainerOverSubrelations>;
-            auto tmp = new_term.poseidon2_perm_sel *
-                       (new_term.poseidon2_perm_T_2_5 - (FF(4) * poseidon2_perm_T_2_0 + poseidon2_perm_T_2_2));
+            auto tmp = in.get(C::poseidon2_perm_sel) *
+                       (in.get(C::poseidon2_perm_T_2_5) - (FF(4) * poseidon2_perm_T_2_0 + poseidon2_perm_T_2_2));
             tmp *= scaling_factor;
             std::get<14>(evals) += typename Accumulator::View(tmp);
         }
         {
             using Accumulator = typename std::tuple_element_t<15, ContainerOverSubrelations>;
-            auto tmp = new_term.poseidon2_perm_sel *
-                       (new_term.poseidon2_perm_T_2_6 - (poseidon2_perm_T_2_3 + new_term.poseidon2_perm_T_2_5));
+            auto tmp = in.get(C::poseidon2_perm_sel) *
+                       (in.get(C::poseidon2_perm_T_2_6) - (poseidon2_perm_T_2_3 + in.get(C::poseidon2_perm_T_2_5)));
             tmp *= scaling_factor;
             std::get<15>(evals) += typename Accumulator::View(tmp);
         }
         {
             using Accumulator = typename std::tuple_element_t<16, ContainerOverSubrelations>;
-            auto tmp = new_term.poseidon2_perm_sel *
-                       (new_term.poseidon2_perm_T_2_7 - (poseidon2_perm_T_2_2 + new_term.poseidon2_perm_T_2_4));
+            auto tmp = in.get(C::poseidon2_perm_sel) *
+                       (in.get(C::poseidon2_perm_T_2_7) - (poseidon2_perm_T_2_2 + in.get(C::poseidon2_perm_T_2_4)));
             tmp *= scaling_factor;
             std::get<16>(evals) += typename Accumulator::View(tmp);
         }
         {
             using Accumulator = typename std::tuple_element_t<17, ContainerOverSubrelations>;
-            auto tmp = new_term.poseidon2_perm_sel *
-                       (new_term.poseidon2_perm_T_3_4 - (FF(4) * poseidon2_perm_T_3_1 + poseidon2_perm_T_3_3));
+            auto tmp = in.get(C::poseidon2_perm_sel) *
+                       (in.get(C::poseidon2_perm_T_3_4) - (FF(4) * poseidon2_perm_T_3_1 + poseidon2_perm_T_3_3));
             tmp *= scaling_factor;
             std::get<17>(evals) += typename Accumulator::View(tmp);
         }
         {
             using Accumulator = typename std::tuple_element_t<18, ContainerOverSubrelations>;
-            auto tmp = new_term.poseidon2_perm_sel *
-                       (new_term.poseidon2_perm_T_3_5 - (FF(4) * poseidon2_perm_T_3_0 + poseidon2_perm_T_3_2));
+            auto tmp = in.get(C::poseidon2_perm_sel) *
+                       (in.get(C::poseidon2_perm_T_3_5) - (FF(4) * poseidon2_perm_T_3_0 + poseidon2_perm_T_3_2));
             tmp *= scaling_factor;
             std::get<18>(evals) += typename Accumulator::View(tmp);
         }
         {
             using Accumulator = typename std::tuple_element_t<19, ContainerOverSubrelations>;
-            auto tmp = new_term.poseidon2_perm_sel *
-                       (new_term.poseidon2_perm_T_3_6 - (poseidon2_perm_T_3_3 + new_term.poseidon2_perm_T_3_5));
+            auto tmp = in.get(C::poseidon2_perm_sel) *
+                       (in.get(C::poseidon2_perm_T_3_6) - (poseidon2_perm_T_3_3 + in.get(C::poseidon2_perm_T_3_5)));
             tmp *= scaling_factor;
             std::get<19>(evals) += typename Accumulator::View(tmp);
         }
         {
             using Accumulator = typename std::tuple_element_t<20, ContainerOverSubrelations>;
-            auto tmp = new_term.poseidon2_perm_sel *
-                       (new_term.poseidon2_perm_T_3_7 - (poseidon2_perm_T_3_2 + new_term.poseidon2_perm_T_3_4));
+            auto tmp = in.get(C::poseidon2_perm_sel) *
+                       (in.get(C::poseidon2_perm_T_3_7) - (poseidon2_perm_T_3_2 + in.get(C::poseidon2_perm_T_3_4)));
             tmp *= scaling_factor;
             std::get<20>(evals) += typename Accumulator::View(tmp);
         }
         {
             using Accumulator = typename std::tuple_element_t<21, ContainerOverSubrelations>;
             auto tmp =
-                new_term.poseidon2_perm_sel *
-                (new_term.poseidon2_perm_B_4_0 - (poseidon2_params_MU_0 * poseidon2_perm_A_4_0 + poseidon2_perm_SUM_4));
+                in.get(C::poseidon2_perm_sel) * (in.get(C::poseidon2_perm_B_4_0) -
+                                                 (poseidon2_params_MU_0 * poseidon2_perm_A_4_0 + poseidon2_perm_SUM_4));
             tmp *= scaling_factor;
             std::get<21>(evals) += typename Accumulator::View(tmp);
         }
         {
             using Accumulator = typename std::tuple_element_t<22, ContainerOverSubrelations>;
             auto tmp =
-                new_term.poseidon2_perm_sel *
-                (new_term.poseidon2_perm_B_4_1 - (poseidon2_params_MU_1 * poseidon2_perm_A_4_1 + poseidon2_perm_SUM_4));
+                in.get(C::poseidon2_perm_sel) * (in.get(C::poseidon2_perm_B_4_1) -
+                                                 (poseidon2_params_MU_1 * poseidon2_perm_A_4_1 + poseidon2_perm_SUM_4));
             tmp *= scaling_factor;
             std::get<22>(evals) += typename Accumulator::View(tmp);
         }
         {
             using Accumulator = typename std::tuple_element_t<23, ContainerOverSubrelations>;
             auto tmp =
-                new_term.poseidon2_perm_sel *
-                (new_term.poseidon2_perm_B_4_2 - (poseidon2_params_MU_2 * poseidon2_perm_A_4_2 + poseidon2_perm_SUM_4));
+                in.get(C::poseidon2_perm_sel) * (in.get(C::poseidon2_perm_B_4_2) -
+                                                 (poseidon2_params_MU_2 * poseidon2_perm_A_4_2 + poseidon2_perm_SUM_4));
             tmp *= scaling_factor;
             std::get<23>(evals) += typename Accumulator::View(tmp);
         }
         {
             using Accumulator = typename std::tuple_element_t<24, ContainerOverSubrelations>;
             auto tmp =
-                new_term.poseidon2_perm_sel *
-                (new_term.poseidon2_perm_B_4_3 - (poseidon2_params_MU_3 * poseidon2_perm_A_4_3 + poseidon2_perm_SUM_4));
+                in.get(C::poseidon2_perm_sel) * (in.get(C::poseidon2_perm_B_4_3) -
+                                                 (poseidon2_params_MU_3 * poseidon2_perm_A_4_3 + poseidon2_perm_SUM_4));
             tmp *= scaling_factor;
             std::get<24>(evals) += typename Accumulator::View(tmp);
         }
         {
             using Accumulator = typename std::tuple_element_t<25, ContainerOverSubrelations>;
             auto tmp =
-                new_term.poseidon2_perm_sel *
-                (new_term.poseidon2_perm_B_5_0 - (poseidon2_params_MU_0 * poseidon2_perm_A_5_0 + poseidon2_perm_SUM_5));
+                in.get(C::poseidon2_perm_sel) * (in.get(C::poseidon2_perm_B_5_0) -
+                                                 (poseidon2_params_MU_0 * poseidon2_perm_A_5_0 + poseidon2_perm_SUM_5));
             tmp *= scaling_factor;
             std::get<25>(evals) += typename Accumulator::View(tmp);
         }
         {
             using Accumulator = typename std::tuple_element_t<26, ContainerOverSubrelations>;
             auto tmp =
-                new_term.poseidon2_perm_sel *
-                (new_term.poseidon2_perm_B_5_1 - (poseidon2_params_MU_1 * poseidon2_perm_A_5_1 + poseidon2_perm_SUM_5));
+                in.get(C::poseidon2_perm_sel) * (in.get(C::poseidon2_perm_B_5_1) -
+                                                 (poseidon2_params_MU_1 * poseidon2_perm_A_5_1 + poseidon2_perm_SUM_5));
             tmp *= scaling_factor;
             std::get<26>(evals) += typename Accumulator::View(tmp);
         }
         {
             using Accumulator = typename std::tuple_element_t<27, ContainerOverSubrelations>;
             auto tmp =
-                new_term.poseidon2_perm_sel *
-                (new_term.poseidon2_perm_B_5_2 - (poseidon2_params_MU_2 * poseidon2_perm_A_5_2 + poseidon2_perm_SUM_5));
+                in.get(C::poseidon2_perm_sel) * (in.get(C::poseidon2_perm_B_5_2) -
+                                                 (poseidon2_params_MU_2 * poseidon2_perm_A_5_2 + poseidon2_perm_SUM_5));
             tmp *= scaling_factor;
             std::get<27>(evals) += typename Accumulator::View(tmp);
         }
         {
             using Accumulator = typename std::tuple_element_t<28, ContainerOverSubrelations>;
             auto tmp =
-                new_term.poseidon2_perm_sel *
-                (new_term.poseidon2_perm_B_5_3 - (poseidon2_params_MU_3 * poseidon2_perm_A_5_3 + poseidon2_perm_SUM_5));
+                in.get(C::poseidon2_perm_sel) * (in.get(C::poseidon2_perm_B_5_3) -
+                                                 (poseidon2_params_MU_3 * poseidon2_perm_A_5_3 + poseidon2_perm_SUM_5));
             tmp *= scaling_factor;
             std::get<28>(evals) += typename Accumulator::View(tmp);
         }
         {
             using Accumulator = typename std::tuple_element_t<29, ContainerOverSubrelations>;
             auto tmp =
-                new_term.poseidon2_perm_sel *
-                (new_term.poseidon2_perm_B_6_0 - (poseidon2_params_MU_0 * poseidon2_perm_A_6_0 + poseidon2_perm_SUM_6));
+                in.get(C::poseidon2_perm_sel) * (in.get(C::poseidon2_perm_B_6_0) -
+                                                 (poseidon2_params_MU_0 * poseidon2_perm_A_6_0 + poseidon2_perm_SUM_6));
             tmp *= scaling_factor;
             std::get<29>(evals) += typename Accumulator::View(tmp);
         }
         {
             using Accumulator = typename std::tuple_element_t<30, ContainerOverSubrelations>;
             auto tmp =
-                new_term.poseidon2_perm_sel *
-                (new_term.poseidon2_perm_B_6_1 - (poseidon2_params_MU_1 * poseidon2_perm_A_6_1 + poseidon2_perm_SUM_6));
+                in.get(C::poseidon2_perm_sel) * (in.get(C::poseidon2_perm_B_6_1) -
+                                                 (poseidon2_params_MU_1 * poseidon2_perm_A_6_1 + poseidon2_perm_SUM_6));
             tmp *= scaling_factor;
             std::get<30>(evals) += typename Accumulator::View(tmp);
         }
         {
             using Accumulator = typename std::tuple_element_t<31, ContainerOverSubrelations>;
             auto tmp =
-                new_term.poseidon2_perm_sel *
-                (new_term.poseidon2_perm_B_6_2 - (poseidon2_params_MU_2 * poseidon2_perm_A_6_2 + poseidon2_perm_SUM_6));
+                in.get(C::poseidon2_perm_sel) * (in.get(C::poseidon2_perm_B_6_2) -
+                                                 (poseidon2_params_MU_2 * poseidon2_perm_A_6_2 + poseidon2_perm_SUM_6));
             tmp *= scaling_factor;
             std::get<31>(evals) += typename Accumulator::View(tmp);
         }
         {
             using Accumulator = typename std::tuple_element_t<32, ContainerOverSubrelations>;
             auto tmp =
-                new_term.poseidon2_perm_sel *
-                (new_term.poseidon2_perm_B_6_3 - (poseidon2_params_MU_3 * poseidon2_perm_A_6_3 + poseidon2_perm_SUM_6));
+                in.get(C::poseidon2_perm_sel) * (in.get(C::poseidon2_perm_B_6_3) -
+                                                 (poseidon2_params_MU_3 * poseidon2_perm_A_6_3 + poseidon2_perm_SUM_6));
             tmp *= scaling_factor;
             std::get<32>(evals) += typename Accumulator::View(tmp);
         }
         {
             using Accumulator = typename std::tuple_element_t<33, ContainerOverSubrelations>;
             auto tmp =
-                new_term.poseidon2_perm_sel *
-                (new_term.poseidon2_perm_B_7_0 - (poseidon2_params_MU_0 * poseidon2_perm_A_7_0 + poseidon2_perm_SUM_7));
+                in.get(C::poseidon2_perm_sel) * (in.get(C::poseidon2_perm_B_7_0) -
+                                                 (poseidon2_params_MU_0 * poseidon2_perm_A_7_0 + poseidon2_perm_SUM_7));
             tmp *= scaling_factor;
             std::get<33>(evals) += typename Accumulator::View(tmp);
         }
         {
             using Accumulator = typename std::tuple_element_t<34, ContainerOverSubrelations>;
             auto tmp =
-                new_term.poseidon2_perm_sel *
-                (new_term.poseidon2_perm_B_7_1 - (poseidon2_params_MU_1 * poseidon2_perm_A_7_1 + poseidon2_perm_SUM_7));
+                in.get(C::poseidon2_perm_sel) * (in.get(C::poseidon2_perm_B_7_1) -
+                                                 (poseidon2_params_MU_1 * poseidon2_perm_A_7_1 + poseidon2_perm_SUM_7));
             tmp *= scaling_factor;
             std::get<34>(evals) += typename Accumulator::View(tmp);
         }
         {
             using Accumulator = typename std::tuple_element_t<35, ContainerOverSubrelations>;
             auto tmp =
-                new_term.poseidon2_perm_sel *
-                (new_term.poseidon2_perm_B_7_2 - (poseidon2_params_MU_2 * poseidon2_perm_A_7_2 + poseidon2_perm_SUM_7));
+                in.get(C::poseidon2_perm_sel) * (in.get(C::poseidon2_perm_B_7_2) -
+                                                 (poseidon2_params_MU_2 * poseidon2_perm_A_7_2 + poseidon2_perm_SUM_7));
             tmp *= scaling_factor;
             std::get<35>(evals) += typename Accumulator::View(tmp);
         }
         {
             using Accumulator = typename std::tuple_element_t<36, ContainerOverSubrelations>;
             auto tmp =
-                new_term.poseidon2_perm_sel *
-                (new_term.poseidon2_perm_B_7_3 - (poseidon2_params_MU_3 * poseidon2_perm_A_7_3 + poseidon2_perm_SUM_7));
+                in.get(C::poseidon2_perm_sel) * (in.get(C::poseidon2_perm_B_7_3) -
+                                                 (poseidon2_params_MU_3 * poseidon2_perm_A_7_3 + poseidon2_perm_SUM_7));
             tmp *= scaling_factor;
             std::get<36>(evals) += typename Accumulator::View(tmp);
         }
         {
             using Accumulator = typename std::tuple_element_t<37, ContainerOverSubrelations>;
             auto tmp =
-                new_term.poseidon2_perm_sel *
-                (new_term.poseidon2_perm_B_8_0 - (poseidon2_params_MU_0 * poseidon2_perm_A_8_0 + poseidon2_perm_SUM_8));
+                in.get(C::poseidon2_perm_sel) * (in.get(C::poseidon2_perm_B_8_0) -
+                                                 (poseidon2_params_MU_0 * poseidon2_perm_A_8_0 + poseidon2_perm_SUM_8));
             tmp *= scaling_factor;
             std::get<37>(evals) += typename Accumulator::View(tmp);
         }
         {
             using Accumulator = typename std::tuple_element_t<38, ContainerOverSubrelations>;
             auto tmp =
-                new_term.poseidon2_perm_sel *
-                (new_term.poseidon2_perm_B_8_1 - (poseidon2_params_MU_1 * poseidon2_perm_A_8_1 + poseidon2_perm_SUM_8));
+                in.get(C::poseidon2_perm_sel) * (in.get(C::poseidon2_perm_B_8_1) -
+                                                 (poseidon2_params_MU_1 * poseidon2_perm_A_8_1 + poseidon2_perm_SUM_8));
             tmp *= scaling_factor;
             std::get<38>(evals) += typename Accumulator::View(tmp);
         }
         {
             using Accumulator = typename std::tuple_element_t<39, ContainerOverSubrelations>;
             auto tmp =
-                new_term.poseidon2_perm_sel *
-                (new_term.poseidon2_perm_B_8_2 - (poseidon2_params_MU_2 * poseidon2_perm_A_8_2 + poseidon2_perm_SUM_8));
+                in.get(C::poseidon2_perm_sel) * (in.get(C::poseidon2_perm_B_8_2) -
+                                                 (poseidon2_params_MU_2 * poseidon2_perm_A_8_2 + poseidon2_perm_SUM_8));
             tmp *= scaling_factor;
             std::get<39>(evals) += typename Accumulator::View(tmp);
         }
         {
             using Accumulator = typename std::tuple_element_t<40, ContainerOverSubrelations>;
             auto tmp =
-                new_term.poseidon2_perm_sel *
-                (new_term.poseidon2_perm_B_8_3 - (poseidon2_params_MU_3 * poseidon2_perm_A_8_3 + poseidon2_perm_SUM_8));
+                in.get(C::poseidon2_perm_sel) * (in.get(C::poseidon2_perm_B_8_3) -
+                                                 (poseidon2_params_MU_3 * poseidon2_perm_A_8_3 + poseidon2_perm_SUM_8));
             tmp *= scaling_factor;
             std::get<40>(evals) += typename Accumulator::View(tmp);
         }
         {
             using Accumulator = typename std::tuple_element_t<41, ContainerOverSubrelations>;
             auto tmp =
-                new_term.poseidon2_perm_sel *
-                (new_term.poseidon2_perm_B_9_0 - (poseidon2_params_MU_0 * poseidon2_perm_A_9_0 + poseidon2_perm_SUM_9));
+                in.get(C::poseidon2_perm_sel) * (in.get(C::poseidon2_perm_B_9_0) -
+                                                 (poseidon2_params_MU_0 * poseidon2_perm_A_9_0 + poseidon2_perm_SUM_9));
             tmp *= scaling_factor;
             std::get<41>(evals) += typename Accumulator::View(tmp);
         }
         {
             using Accumulator = typename std::tuple_element_t<42, ContainerOverSubrelations>;
             auto tmp =
-                new_term.poseidon2_perm_sel *
-                (new_term.poseidon2_perm_B_9_1 - (poseidon2_params_MU_1 * poseidon2_perm_A_9_1 + poseidon2_perm_SUM_9));
+                in.get(C::poseidon2_perm_sel) * (in.get(C::poseidon2_perm_B_9_1) -
+                                                 (poseidon2_params_MU_1 * poseidon2_perm_A_9_1 + poseidon2_perm_SUM_9));
             tmp *= scaling_factor;
             std::get<42>(evals) += typename Accumulator::View(tmp);
         }
         {
             using Accumulator = typename std::tuple_element_t<43, ContainerOverSubrelations>;
             auto tmp =
-                new_term.poseidon2_perm_sel *
-                (new_term.poseidon2_perm_B_9_2 - (poseidon2_params_MU_2 * poseidon2_perm_A_9_2 + poseidon2_perm_SUM_9));
+                in.get(C::poseidon2_perm_sel) * (in.get(C::poseidon2_perm_B_9_2) -
+                                                 (poseidon2_params_MU_2 * poseidon2_perm_A_9_2 + poseidon2_perm_SUM_9));
             tmp *= scaling_factor;
             std::get<43>(evals) += typename Accumulator::View(tmp);
         }
         {
             using Accumulator = typename std::tuple_element_t<44, ContainerOverSubrelations>;
             auto tmp =
-                new_term.poseidon2_perm_sel *
-                (new_term.poseidon2_perm_B_9_3 - (poseidon2_params_MU_3 * poseidon2_perm_A_9_3 + poseidon2_perm_SUM_9));
+                in.get(C::poseidon2_perm_sel) * (in.get(C::poseidon2_perm_B_9_3) -
+                                                 (poseidon2_params_MU_3 * poseidon2_perm_A_9_3 + poseidon2_perm_SUM_9));
             tmp *= scaling_factor;
             std::get<44>(evals) += typename Accumulator::View(tmp);
         }
         {
             using Accumulator = typename std::tuple_element_t<45, ContainerOverSubrelations>;
-            auto tmp =
-                new_term.poseidon2_perm_sel * (new_term.poseidon2_perm_B_10_0 -
-                                               (poseidon2_params_MU_0 * poseidon2_perm_A_10_0 + poseidon2_perm_SUM_10));
+            auto tmp = in.get(C::poseidon2_perm_sel) *
+                       (in.get(C::poseidon2_perm_B_10_0) -
+                        (poseidon2_params_MU_0 * poseidon2_perm_A_10_0 + poseidon2_perm_SUM_10));
             tmp *= scaling_factor;
             std::get<45>(evals) += typename Accumulator::View(tmp);
         }
         {
             using Accumulator = typename std::tuple_element_t<46, ContainerOverSubrelations>;
-            auto tmp =
-                new_term.poseidon2_perm_sel * (new_term.poseidon2_perm_B_10_1 -
-                                               (poseidon2_params_MU_1 * poseidon2_perm_A_10_1 + poseidon2_perm_SUM_10));
+            auto tmp = in.get(C::poseidon2_perm_sel) *
+                       (in.get(C::poseidon2_perm_B_10_1) -
+                        (poseidon2_params_MU_1 * poseidon2_perm_A_10_1 + poseidon2_perm_SUM_10));
             tmp *= scaling_factor;
             std::get<46>(evals) += typename Accumulator::View(tmp);
         }
         {
             using Accumulator = typename std::tuple_element_t<47, ContainerOverSubrelations>;
-            auto tmp =
-                new_term.poseidon2_perm_sel * (new_term.poseidon2_perm_B_10_2 -
-                                               (poseidon2_params_MU_2 * poseidon2_perm_A_10_2 + poseidon2_perm_SUM_10));
+            auto tmp = in.get(C::poseidon2_perm_sel) *
+                       (in.get(C::poseidon2_perm_B_10_2) -
+                        (poseidon2_params_MU_2 * poseidon2_perm_A_10_2 + poseidon2_perm_SUM_10));
             tmp *= scaling_factor;
             std::get<47>(evals) += typename Accumulator::View(tmp);
         }
         {
             using Accumulator = typename std::tuple_element_t<48, ContainerOverSubrelations>;
-            auto tmp =
-                new_term.poseidon2_perm_sel * (new_term.poseidon2_perm_B_10_3 -
-                                               (poseidon2_params_MU_3 * poseidon2_perm_A_10_3 + poseidon2_perm_SUM_10));
+            auto tmp = in.get(C::poseidon2_perm_sel) *
+                       (in.get(C::poseidon2_perm_B_10_3) -
+                        (poseidon2_params_MU_3 * poseidon2_perm_A_10_3 + poseidon2_perm_SUM_10));
             tmp *= scaling_factor;
             std::get<48>(evals) += typename Accumulator::View(tmp);
         }
         {
             using Accumulator = typename std::tuple_element_t<49, ContainerOverSubrelations>;
-            auto tmp =
-                new_term.poseidon2_perm_sel * (new_term.poseidon2_perm_B_11_0 -
-                                               (poseidon2_params_MU_0 * poseidon2_perm_A_11_0 + poseidon2_perm_SUM_11));
+            auto tmp = in.get(C::poseidon2_perm_sel) *
+                       (in.get(C::poseidon2_perm_B_11_0) -
+                        (poseidon2_params_MU_0 * poseidon2_perm_A_11_0 + poseidon2_perm_SUM_11));
             tmp *= scaling_factor;
             std::get<49>(evals) += typename Accumulator::View(tmp);
         }
         {
             using Accumulator = typename std::tuple_element_t<50, ContainerOverSubrelations>;
-            auto tmp =
-                new_term.poseidon2_perm_sel * (new_term.poseidon2_perm_B_11_1 -
-                                               (poseidon2_params_MU_1 * poseidon2_perm_A_11_1 + poseidon2_perm_SUM_11));
+            auto tmp = in.get(C::poseidon2_perm_sel) *
+                       (in.get(C::poseidon2_perm_B_11_1) -
+                        (poseidon2_params_MU_1 * poseidon2_perm_A_11_1 + poseidon2_perm_SUM_11));
             tmp *= scaling_factor;
             std::get<50>(evals) += typename Accumulator::View(tmp);
         }
         {
             using Accumulator = typename std::tuple_element_t<51, ContainerOverSubrelations>;
-            auto tmp =
-                new_term.poseidon2_perm_sel * (new_term.poseidon2_perm_B_11_2 -
-                                               (poseidon2_params_MU_2 * poseidon2_perm_A_11_2 + poseidon2_perm_SUM_11));
+            auto tmp = in.get(C::poseidon2_perm_sel) *
+                       (in.get(C::poseidon2_perm_B_11_2) -
+                        (poseidon2_params_MU_2 * poseidon2_perm_A_11_2 + poseidon2_perm_SUM_11));
             tmp *= scaling_factor;
             std::get<51>(evals) += typename Accumulator::View(tmp);
         }
         {
             using Accumulator = typename std::tuple_element_t<52, ContainerOverSubrelations>;
-            auto tmp =
-                new_term.poseidon2_perm_sel * (new_term.poseidon2_perm_B_11_3 -
-                                               (poseidon2_params_MU_3 * poseidon2_perm_A_11_3 + poseidon2_perm_SUM_11));
+            auto tmp = in.get(C::poseidon2_perm_sel) *
+                       (in.get(C::poseidon2_perm_B_11_3) -
+                        (poseidon2_params_MU_3 * poseidon2_perm_A_11_3 + poseidon2_perm_SUM_11));
             tmp *= scaling_factor;
             std::get<52>(evals) += typename Accumulator::View(tmp);
         }
         {
             using Accumulator = typename std::tuple_element_t<53, ContainerOverSubrelations>;
-            auto tmp =
-                new_term.poseidon2_perm_sel * (new_term.poseidon2_perm_B_12_0 -
-                                               (poseidon2_params_MU_0 * poseidon2_perm_A_12_0 + poseidon2_perm_SUM_12));
+            auto tmp = in.get(C::poseidon2_perm_sel) *
+                       (in.get(C::poseidon2_perm_B_12_0) -
+                        (poseidon2_params_MU_0 * poseidon2_perm_A_12_0 + poseidon2_perm_SUM_12));
             tmp *= scaling_factor;
             std::get<53>(evals) += typename Accumulator::View(tmp);
         }
         {
             using Accumulator = typename std::tuple_element_t<54, ContainerOverSubrelations>;
-            auto tmp =
-                new_term.poseidon2_perm_sel * (new_term.poseidon2_perm_B_12_1 -
-                                               (poseidon2_params_MU_1 * poseidon2_perm_A_12_1 + poseidon2_perm_SUM_12));
+            auto tmp = in.get(C::poseidon2_perm_sel) *
+                       (in.get(C::poseidon2_perm_B_12_1) -
+                        (poseidon2_params_MU_1 * poseidon2_perm_A_12_1 + poseidon2_perm_SUM_12));
             tmp *= scaling_factor;
             std::get<54>(evals) += typename Accumulator::View(tmp);
         }
         {
             using Accumulator = typename std::tuple_element_t<55, ContainerOverSubrelations>;
-            auto tmp =
-                new_term.poseidon2_perm_sel * (new_term.poseidon2_perm_B_12_2 -
-                                               (poseidon2_params_MU_2 * poseidon2_perm_A_12_2 + poseidon2_perm_SUM_12));
+            auto tmp = in.get(C::poseidon2_perm_sel) *
+                       (in.get(C::poseidon2_perm_B_12_2) -
+                        (poseidon2_params_MU_2 * poseidon2_perm_A_12_2 + poseidon2_perm_SUM_12));
             tmp *= scaling_factor;
             std::get<55>(evals) += typename Accumulator::View(tmp);
         }
         {
             using Accumulator = typename std::tuple_element_t<56, ContainerOverSubrelations>;
-            auto tmp =
-                new_term.poseidon2_perm_sel * (new_term.poseidon2_perm_B_12_3 -
-                                               (poseidon2_params_MU_3 * poseidon2_perm_A_12_3 + poseidon2_perm_SUM_12));
+            auto tmp = in.get(C::poseidon2_perm_sel) *
+                       (in.get(C::poseidon2_perm_B_12_3) -
+                        (poseidon2_params_MU_3 * poseidon2_perm_A_12_3 + poseidon2_perm_SUM_12));
             tmp *= scaling_factor;
             std::get<56>(evals) += typename Accumulator::View(tmp);
         }
         {
             using Accumulator = typename std::tuple_element_t<57, ContainerOverSubrelations>;
-            auto tmp =
-                new_term.poseidon2_perm_sel * (new_term.poseidon2_perm_B_13_0 -
-                                               (poseidon2_params_MU_0 * poseidon2_perm_A_13_0 + poseidon2_perm_SUM_13));
+            auto tmp = in.get(C::poseidon2_perm_sel) *
+                       (in.get(C::poseidon2_perm_B_13_0) -
+                        (poseidon2_params_MU_0 * poseidon2_perm_A_13_0 + poseidon2_perm_SUM_13));
             tmp *= scaling_factor;
             std::get<57>(evals) += typename Accumulator::View(tmp);
         }
         {
             using Accumulator = typename std::tuple_element_t<58, ContainerOverSubrelations>;
-            auto tmp =
-                new_term.poseidon2_perm_sel * (new_term.poseidon2_perm_B_13_1 -
-                                               (poseidon2_params_MU_1 * poseidon2_perm_A_13_1 + poseidon2_perm_SUM_13));
+            auto tmp = in.get(C::poseidon2_perm_sel) *
+                       (in.get(C::poseidon2_perm_B_13_1) -
+                        (poseidon2_params_MU_1 * poseidon2_perm_A_13_1 + poseidon2_perm_SUM_13));
             tmp *= scaling_factor;
             std::get<58>(evals) += typename Accumulator::View(tmp);
         }
         {
             using Accumulator = typename std::tuple_element_t<59, ContainerOverSubrelations>;
-            auto tmp =
-                new_term.poseidon2_perm_sel * (new_term.poseidon2_perm_B_13_2 -
-                                               (poseidon2_params_MU_2 * poseidon2_perm_A_13_2 + poseidon2_perm_SUM_13));
+            auto tmp = in.get(C::poseidon2_perm_sel) *
+                       (in.get(C::poseidon2_perm_B_13_2) -
+                        (poseidon2_params_MU_2 * poseidon2_perm_A_13_2 + poseidon2_perm_SUM_13));
             tmp *= scaling_factor;
             std::get<59>(evals) += typename Accumulator::View(tmp);
         }
         {
             using Accumulator = typename std::tuple_element_t<60, ContainerOverSubrelations>;
-            auto tmp =
-                new_term.poseidon2_perm_sel * (new_term.poseidon2_perm_B_13_3 -
-                                               (poseidon2_params_MU_3 * poseidon2_perm_A_13_3 + poseidon2_perm_SUM_13));
+            auto tmp = in.get(C::poseidon2_perm_sel) *
+                       (in.get(C::poseidon2_perm_B_13_3) -
+                        (poseidon2_params_MU_3 * poseidon2_perm_A_13_3 + poseidon2_perm_SUM_13));
             tmp *= scaling_factor;
             std::get<60>(evals) += typename Accumulator::View(tmp);
         }
         {
             using Accumulator = typename std::tuple_element_t<61, ContainerOverSubrelations>;
-            auto tmp =
-                new_term.poseidon2_perm_sel * (new_term.poseidon2_perm_B_14_0 -
-                                               (poseidon2_params_MU_0 * poseidon2_perm_A_14_0 + poseidon2_perm_SUM_14));
+            auto tmp = in.get(C::poseidon2_perm_sel) *
+                       (in.get(C::poseidon2_perm_B_14_0) -
+                        (poseidon2_params_MU_0 * poseidon2_perm_A_14_0 + poseidon2_perm_SUM_14));
             tmp *= scaling_factor;
             std::get<61>(evals) += typename Accumulator::View(tmp);
         }
         {
             using Accumulator = typename std::tuple_element_t<62, ContainerOverSubrelations>;
-            auto tmp =
-                new_term.poseidon2_perm_sel * (new_term.poseidon2_perm_B_14_1 -
-                                               (poseidon2_params_MU_1 * poseidon2_perm_A_14_1 + poseidon2_perm_SUM_14));
+            auto tmp = in.get(C::poseidon2_perm_sel) *
+                       (in.get(C::poseidon2_perm_B_14_1) -
+                        (poseidon2_params_MU_1 * poseidon2_perm_A_14_1 + poseidon2_perm_SUM_14));
             tmp *= scaling_factor;
             std::get<62>(evals) += typename Accumulator::View(tmp);
         }
         {
             using Accumulator = typename std::tuple_element_t<63, ContainerOverSubrelations>;
-            auto tmp =
-                new_term.poseidon2_perm_sel * (new_term.poseidon2_perm_B_14_2 -
-                                               (poseidon2_params_MU_2 * poseidon2_perm_A_14_2 + poseidon2_perm_SUM_14));
+            auto tmp = in.get(C::poseidon2_perm_sel) *
+                       (in.get(C::poseidon2_perm_B_14_2) -
+                        (poseidon2_params_MU_2 * poseidon2_perm_A_14_2 + poseidon2_perm_SUM_14));
             tmp *= scaling_factor;
             std::get<63>(evals) += typename Accumulator::View(tmp);
         }
         {
             using Accumulator = typename std::tuple_element_t<64, ContainerOverSubrelations>;
-            auto tmp =
-                new_term.poseidon2_perm_sel * (new_term.poseidon2_perm_B_14_3 -
-                                               (poseidon2_params_MU_3 * poseidon2_perm_A_14_3 + poseidon2_perm_SUM_14));
+            auto tmp = in.get(C::poseidon2_perm_sel) *
+                       (in.get(C::poseidon2_perm_B_14_3) -
+                        (poseidon2_params_MU_3 * poseidon2_perm_A_14_3 + poseidon2_perm_SUM_14));
             tmp *= scaling_factor;
             std::get<64>(evals) += typename Accumulator::View(tmp);
         }
         {
             using Accumulator = typename std::tuple_element_t<65, ContainerOverSubrelations>;
-            auto tmp =
-                new_term.poseidon2_perm_sel * (new_term.poseidon2_perm_B_15_0 -
-                                               (poseidon2_params_MU_0 * poseidon2_perm_A_15_0 + poseidon2_perm_SUM_15));
+            auto tmp = in.get(C::poseidon2_perm_sel) *
+                       (in.get(C::poseidon2_perm_B_15_0) -
+                        (poseidon2_params_MU_0 * poseidon2_perm_A_15_0 + poseidon2_perm_SUM_15));
             tmp *= scaling_factor;
             std::get<65>(evals) += typename Accumulator::View(tmp);
         }
         {
             using Accumulator = typename std::tuple_element_t<66, ContainerOverSubrelations>;
-            auto tmp =
-                new_term.poseidon2_perm_sel * (new_term.poseidon2_perm_B_15_1 -
-                                               (poseidon2_params_MU_1 * poseidon2_perm_A_15_1 + poseidon2_perm_SUM_15));
+            auto tmp = in.get(C::poseidon2_perm_sel) *
+                       (in.get(C::poseidon2_perm_B_15_1) -
+                        (poseidon2_params_MU_1 * poseidon2_perm_A_15_1 + poseidon2_perm_SUM_15));
             tmp *= scaling_factor;
             std::get<66>(evals) += typename Accumulator::View(tmp);
         }
         {
             using Accumulator = typename std::tuple_element_t<67, ContainerOverSubrelations>;
-            auto tmp =
-                new_term.poseidon2_perm_sel * (new_term.poseidon2_perm_B_15_2 -
-                                               (poseidon2_params_MU_2 * poseidon2_perm_A_15_2 + poseidon2_perm_SUM_15));
+            auto tmp = in.get(C::poseidon2_perm_sel) *
+                       (in.get(C::poseidon2_perm_B_15_2) -
+                        (poseidon2_params_MU_2 * poseidon2_perm_A_15_2 + poseidon2_perm_SUM_15));
             tmp *= scaling_factor;
             std::get<67>(evals) += typename Accumulator::View(tmp);
         }
         {
             using Accumulator = typename std::tuple_element_t<68, ContainerOverSubrelations>;
-            auto tmp =
-                new_term.poseidon2_perm_sel * (new_term.poseidon2_perm_B_15_3 -
-                                               (poseidon2_params_MU_3 * poseidon2_perm_A_15_3 + poseidon2_perm_SUM_15));
+            auto tmp = in.get(C::poseidon2_perm_sel) *
+                       (in.get(C::poseidon2_perm_B_15_3) -
+                        (poseidon2_params_MU_3 * poseidon2_perm_A_15_3 + poseidon2_perm_SUM_15));
             tmp *= scaling_factor;
             std::get<68>(evals) += typename Accumulator::View(tmp);
         }
         {
             using Accumulator = typename std::tuple_element_t<69, ContainerOverSubrelations>;
-            auto tmp =
-                new_term.poseidon2_perm_sel * (new_term.poseidon2_perm_B_16_0 -
-                                               (poseidon2_params_MU_0 * poseidon2_perm_A_16_0 + poseidon2_perm_SUM_16));
+            auto tmp = in.get(C::poseidon2_perm_sel) *
+                       (in.get(C::poseidon2_perm_B_16_0) -
+                        (poseidon2_params_MU_0 * poseidon2_perm_A_16_0 + poseidon2_perm_SUM_16));
             tmp *= scaling_factor;
             std::get<69>(evals) += typename Accumulator::View(tmp);
         }
         {
             using Accumulator = typename std::tuple_element_t<70, ContainerOverSubrelations>;
-            auto tmp =
-                new_term.poseidon2_perm_sel * (new_term.poseidon2_perm_B_16_1 -
-                                               (poseidon2_params_MU_1 * poseidon2_perm_A_16_1 + poseidon2_perm_SUM_16));
+            auto tmp = in.get(C::poseidon2_perm_sel) *
+                       (in.get(C::poseidon2_perm_B_16_1) -
+                        (poseidon2_params_MU_1 * poseidon2_perm_A_16_1 + poseidon2_perm_SUM_16));
             tmp *= scaling_factor;
             std::get<70>(evals) += typename Accumulator::View(tmp);
         }
         {
             using Accumulator = typename std::tuple_element_t<71, ContainerOverSubrelations>;
-            auto tmp =
-                new_term.poseidon2_perm_sel * (new_term.poseidon2_perm_B_16_2 -
-                                               (poseidon2_params_MU_2 * poseidon2_perm_A_16_2 + poseidon2_perm_SUM_16));
+            auto tmp = in.get(C::poseidon2_perm_sel) *
+                       (in.get(C::poseidon2_perm_B_16_2) -
+                        (poseidon2_params_MU_2 * poseidon2_perm_A_16_2 + poseidon2_perm_SUM_16));
             tmp *= scaling_factor;
             std::get<71>(evals) += typename Accumulator::View(tmp);
         }
         {
             using Accumulator = typename std::tuple_element_t<72, ContainerOverSubrelations>;
-            auto tmp =
-                new_term.poseidon2_perm_sel * (new_term.poseidon2_perm_B_16_3 -
-                                               (poseidon2_params_MU_3 * poseidon2_perm_A_16_3 + poseidon2_perm_SUM_16));
+            auto tmp = in.get(C::poseidon2_perm_sel) *
+                       (in.get(C::poseidon2_perm_B_16_3) -
+                        (poseidon2_params_MU_3 * poseidon2_perm_A_16_3 + poseidon2_perm_SUM_16));
             tmp *= scaling_factor;
             std::get<72>(evals) += typename Accumulator::View(tmp);
         }
         {
             using Accumulator = typename std::tuple_element_t<73, ContainerOverSubrelations>;
-            auto tmp =
-                new_term.poseidon2_perm_sel * (new_term.poseidon2_perm_B_17_0 -
-                                               (poseidon2_params_MU_0 * poseidon2_perm_A_17_0 + poseidon2_perm_SUM_17));
+            auto tmp = in.get(C::poseidon2_perm_sel) *
+                       (in.get(C::poseidon2_perm_B_17_0) -
+                        (poseidon2_params_MU_0 * poseidon2_perm_A_17_0 + poseidon2_perm_SUM_17));
             tmp *= scaling_factor;
             std::get<73>(evals) += typename Accumulator::View(tmp);
         }
         {
             using Accumulator = typename std::tuple_element_t<74, ContainerOverSubrelations>;
-            auto tmp =
-                new_term.poseidon2_perm_sel * (new_term.poseidon2_perm_B_17_1 -
-                                               (poseidon2_params_MU_1 * poseidon2_perm_A_17_1 + poseidon2_perm_SUM_17));
+            auto tmp = in.get(C::poseidon2_perm_sel) *
+                       (in.get(C::poseidon2_perm_B_17_1) -
+                        (poseidon2_params_MU_1 * poseidon2_perm_A_17_1 + poseidon2_perm_SUM_17));
             tmp *= scaling_factor;
             std::get<74>(evals) += typename Accumulator::View(tmp);
         }
         {
             using Accumulator = typename std::tuple_element_t<75, ContainerOverSubrelations>;
-            auto tmp =
-                new_term.poseidon2_perm_sel * (new_term.poseidon2_perm_B_17_2 -
-                                               (poseidon2_params_MU_2 * poseidon2_perm_A_17_2 + poseidon2_perm_SUM_17));
+            auto tmp = in.get(C::poseidon2_perm_sel) *
+                       (in.get(C::poseidon2_perm_B_17_2) -
+                        (poseidon2_params_MU_2 * poseidon2_perm_A_17_2 + poseidon2_perm_SUM_17));
             tmp *= scaling_factor;
             std::get<75>(evals) += typename Accumulator::View(tmp);
         }
         {
             using Accumulator = typename std::tuple_element_t<76, ContainerOverSubrelations>;
-            auto tmp =
-                new_term.poseidon2_perm_sel * (new_term.poseidon2_perm_B_17_3 -
-                                               (poseidon2_params_MU_3 * poseidon2_perm_A_17_3 + poseidon2_perm_SUM_17));
+            auto tmp = in.get(C::poseidon2_perm_sel) *
+                       (in.get(C::poseidon2_perm_B_17_3) -
+                        (poseidon2_params_MU_3 * poseidon2_perm_A_17_3 + poseidon2_perm_SUM_17));
             tmp *= scaling_factor;
             std::get<76>(evals) += typename Accumulator::View(tmp);
         }
         {
             using Accumulator = typename std::tuple_element_t<77, ContainerOverSubrelations>;
-            auto tmp =
-                new_term.poseidon2_perm_sel * (new_term.poseidon2_perm_B_18_0 -
-                                               (poseidon2_params_MU_0 * poseidon2_perm_A_18_0 + poseidon2_perm_SUM_18));
+            auto tmp = in.get(C::poseidon2_perm_sel) *
+                       (in.get(C::poseidon2_perm_B_18_0) -
+                        (poseidon2_params_MU_0 * poseidon2_perm_A_18_0 + poseidon2_perm_SUM_18));
             tmp *= scaling_factor;
             std::get<77>(evals) += typename Accumulator::View(tmp);
         }
         {
             using Accumulator = typename std::tuple_element_t<78, ContainerOverSubrelations>;
-            auto tmp =
-                new_term.poseidon2_perm_sel * (new_term.poseidon2_perm_B_18_1 -
-                                               (poseidon2_params_MU_1 * poseidon2_perm_A_18_1 + poseidon2_perm_SUM_18));
+            auto tmp = in.get(C::poseidon2_perm_sel) *
+                       (in.get(C::poseidon2_perm_B_18_1) -
+                        (poseidon2_params_MU_1 * poseidon2_perm_A_18_1 + poseidon2_perm_SUM_18));
             tmp *= scaling_factor;
             std::get<78>(evals) += typename Accumulator::View(tmp);
         }
         {
             using Accumulator = typename std::tuple_element_t<79, ContainerOverSubrelations>;
-            auto tmp =
-                new_term.poseidon2_perm_sel * (new_term.poseidon2_perm_B_18_2 -
-                                               (poseidon2_params_MU_2 * poseidon2_perm_A_18_2 + poseidon2_perm_SUM_18));
+            auto tmp = in.get(C::poseidon2_perm_sel) *
+                       (in.get(C::poseidon2_perm_B_18_2) -
+                        (poseidon2_params_MU_2 * poseidon2_perm_A_18_2 + poseidon2_perm_SUM_18));
             tmp *= scaling_factor;
             std::get<79>(evals) += typename Accumulator::View(tmp);
         }
         {
             using Accumulator = typename std::tuple_element_t<80, ContainerOverSubrelations>;
-            auto tmp =
-                new_term.poseidon2_perm_sel * (new_term.poseidon2_perm_B_18_3 -
-                                               (poseidon2_params_MU_3 * poseidon2_perm_A_18_3 + poseidon2_perm_SUM_18));
+            auto tmp = in.get(C::poseidon2_perm_sel) *
+                       (in.get(C::poseidon2_perm_B_18_3) -
+                        (poseidon2_params_MU_3 * poseidon2_perm_A_18_3 + poseidon2_perm_SUM_18));
             tmp *= scaling_factor;
             std::get<80>(evals) += typename Accumulator::View(tmp);
         }
         {
             using Accumulator = typename std::tuple_element_t<81, ContainerOverSubrelations>;
-            auto tmp =
-                new_term.poseidon2_perm_sel * (new_term.poseidon2_perm_B_19_0 -
-                                               (poseidon2_params_MU_0 * poseidon2_perm_A_19_0 + poseidon2_perm_SUM_19));
+            auto tmp = in.get(C::poseidon2_perm_sel) *
+                       (in.get(C::poseidon2_perm_B_19_0) -
+                        (poseidon2_params_MU_0 * poseidon2_perm_A_19_0 + poseidon2_perm_SUM_19));
             tmp *= scaling_factor;
             std::get<81>(evals) += typename Accumulator::View(tmp);
         }
         {
             using Accumulator = typename std::tuple_element_t<82, ContainerOverSubrelations>;
-            auto tmp =
-                new_term.poseidon2_perm_sel * (new_term.poseidon2_perm_B_19_1 -
-                                               (poseidon2_params_MU_1 * poseidon2_perm_A_19_1 + poseidon2_perm_SUM_19));
+            auto tmp = in.get(C::poseidon2_perm_sel) *
+                       (in.get(C::poseidon2_perm_B_19_1) -
+                        (poseidon2_params_MU_1 * poseidon2_perm_A_19_1 + poseidon2_perm_SUM_19));
             tmp *= scaling_factor;
             std::get<82>(evals) += typename Accumulator::View(tmp);
         }
         {
             using Accumulator = typename std::tuple_element_t<83, ContainerOverSubrelations>;
-            auto tmp =
-                new_term.poseidon2_perm_sel * (new_term.poseidon2_perm_B_19_2 -
-                                               (poseidon2_params_MU_2 * poseidon2_perm_A_19_2 + poseidon2_perm_SUM_19));
+            auto tmp = in.get(C::poseidon2_perm_sel) *
+                       (in.get(C::poseidon2_perm_B_19_2) -
+                        (poseidon2_params_MU_2 * poseidon2_perm_A_19_2 + poseidon2_perm_SUM_19));
             tmp *= scaling_factor;
             std::get<83>(evals) += typename Accumulator::View(tmp);
         }
         {
             using Accumulator = typename std::tuple_element_t<84, ContainerOverSubrelations>;
-            auto tmp =
-                new_term.poseidon2_perm_sel * (new_term.poseidon2_perm_B_19_3 -
-                                               (poseidon2_params_MU_3 * poseidon2_perm_A_19_3 + poseidon2_perm_SUM_19));
+            auto tmp = in.get(C::poseidon2_perm_sel) *
+                       (in.get(C::poseidon2_perm_B_19_3) -
+                        (poseidon2_params_MU_3 * poseidon2_perm_A_19_3 + poseidon2_perm_SUM_19));
             tmp *= scaling_factor;
             std::get<84>(evals) += typename Accumulator::View(tmp);
         }
         {
             using Accumulator = typename std::tuple_element_t<85, ContainerOverSubrelations>;
-            auto tmp =
-                new_term.poseidon2_perm_sel * (new_term.poseidon2_perm_B_20_0 -
-                                               (poseidon2_params_MU_0 * poseidon2_perm_A_20_0 + poseidon2_perm_SUM_20));
+            auto tmp = in.get(C::poseidon2_perm_sel) *
+                       (in.get(C::poseidon2_perm_B_20_0) -
+                        (poseidon2_params_MU_0 * poseidon2_perm_A_20_0 + poseidon2_perm_SUM_20));
             tmp *= scaling_factor;
             std::get<85>(evals) += typename Accumulator::View(tmp);
         }
         {
             using Accumulator = typename std::tuple_element_t<86, ContainerOverSubrelations>;
-            auto tmp =
-                new_term.poseidon2_perm_sel * (new_term.poseidon2_perm_B_20_1 -
-                                               (poseidon2_params_MU_1 * poseidon2_perm_A_20_1 + poseidon2_perm_SUM_20));
+            auto tmp = in.get(C::poseidon2_perm_sel) *
+                       (in.get(C::poseidon2_perm_B_20_1) -
+                        (poseidon2_params_MU_1 * poseidon2_perm_A_20_1 + poseidon2_perm_SUM_20));
             tmp *= scaling_factor;
             std::get<86>(evals) += typename Accumulator::View(tmp);
         }
         {
             using Accumulator = typename std::tuple_element_t<87, ContainerOverSubrelations>;
-            auto tmp =
-                new_term.poseidon2_perm_sel * (new_term.poseidon2_perm_B_20_2 -
-                                               (poseidon2_params_MU_2 * poseidon2_perm_A_20_2 + poseidon2_perm_SUM_20));
+            auto tmp = in.get(C::poseidon2_perm_sel) *
+                       (in.get(C::poseidon2_perm_B_20_2) -
+                        (poseidon2_params_MU_2 * poseidon2_perm_A_20_2 + poseidon2_perm_SUM_20));
             tmp *= scaling_factor;
             std::get<87>(evals) += typename Accumulator::View(tmp);
         }
         {
             using Accumulator = typename std::tuple_element_t<88, ContainerOverSubrelations>;
-            auto tmp =
-                new_term.poseidon2_perm_sel * (new_term.poseidon2_perm_B_20_3 -
-                                               (poseidon2_params_MU_3 * poseidon2_perm_A_20_3 + poseidon2_perm_SUM_20));
+            auto tmp = in.get(C::poseidon2_perm_sel) *
+                       (in.get(C::poseidon2_perm_B_20_3) -
+                        (poseidon2_params_MU_3 * poseidon2_perm_A_20_3 + poseidon2_perm_SUM_20));
             tmp *= scaling_factor;
             std::get<88>(evals) += typename Accumulator::View(tmp);
         }
         {
             using Accumulator = typename std::tuple_element_t<89, ContainerOverSubrelations>;
-            auto tmp =
-                new_term.poseidon2_perm_sel * (new_term.poseidon2_perm_B_21_0 -
-                                               (poseidon2_params_MU_0 * poseidon2_perm_A_21_0 + poseidon2_perm_SUM_21));
+            auto tmp = in.get(C::poseidon2_perm_sel) *
+                       (in.get(C::poseidon2_perm_B_21_0) -
+                        (poseidon2_params_MU_0 * poseidon2_perm_A_21_0 + poseidon2_perm_SUM_21));
             tmp *= scaling_factor;
             std::get<89>(evals) += typename Accumulator::View(tmp);
         }
         {
             using Accumulator = typename std::tuple_element_t<90, ContainerOverSubrelations>;
-            auto tmp =
-                new_term.poseidon2_perm_sel * (new_term.poseidon2_perm_B_21_1 -
-                                               (poseidon2_params_MU_1 * poseidon2_perm_A_21_1 + poseidon2_perm_SUM_21));
+            auto tmp = in.get(C::poseidon2_perm_sel) *
+                       (in.get(C::poseidon2_perm_B_21_1) -
+                        (poseidon2_params_MU_1 * poseidon2_perm_A_21_1 + poseidon2_perm_SUM_21));
             tmp *= scaling_factor;
             std::get<90>(evals) += typename Accumulator::View(tmp);
         }
         {
             using Accumulator = typename std::tuple_element_t<91, ContainerOverSubrelations>;
-            auto tmp =
-                new_term.poseidon2_perm_sel * (new_term.poseidon2_perm_B_21_2 -
-                                               (poseidon2_params_MU_2 * poseidon2_perm_A_21_2 + poseidon2_perm_SUM_21));
+            auto tmp = in.get(C::poseidon2_perm_sel) *
+                       (in.get(C::poseidon2_perm_B_21_2) -
+                        (poseidon2_params_MU_2 * poseidon2_perm_A_21_2 + poseidon2_perm_SUM_21));
             tmp *= scaling_factor;
             std::get<91>(evals) += typename Accumulator::View(tmp);
         }
         {
             using Accumulator = typename std::tuple_element_t<92, ContainerOverSubrelations>;
-            auto tmp =
-                new_term.poseidon2_perm_sel * (new_term.poseidon2_perm_B_21_3 -
-                                               (poseidon2_params_MU_3 * poseidon2_perm_A_21_3 + poseidon2_perm_SUM_21));
+            auto tmp = in.get(C::poseidon2_perm_sel) *
+                       (in.get(C::poseidon2_perm_B_21_3) -
+                        (poseidon2_params_MU_3 * poseidon2_perm_A_21_3 + poseidon2_perm_SUM_21));
             tmp *= scaling_factor;
             std::get<92>(evals) += typename Accumulator::View(tmp);
         }
         {
             using Accumulator = typename std::tuple_element_t<93, ContainerOverSubrelations>;
-            auto tmp =
-                new_term.poseidon2_perm_sel * (new_term.poseidon2_perm_B_22_0 -
-                                               (poseidon2_params_MU_0 * poseidon2_perm_A_22_0 + poseidon2_perm_SUM_22));
+            auto tmp = in.get(C::poseidon2_perm_sel) *
+                       (in.get(C::poseidon2_perm_B_22_0) -
+                        (poseidon2_params_MU_0 * poseidon2_perm_A_22_0 + poseidon2_perm_SUM_22));
             tmp *= scaling_factor;
             std::get<93>(evals) += typename Accumulator::View(tmp);
         }
         {
             using Accumulator = typename std::tuple_element_t<94, ContainerOverSubrelations>;
-            auto tmp =
-                new_term.poseidon2_perm_sel * (new_term.poseidon2_perm_B_22_1 -
-                                               (poseidon2_params_MU_1 * poseidon2_perm_A_22_1 + poseidon2_perm_SUM_22));
+            auto tmp = in.get(C::poseidon2_perm_sel) *
+                       (in.get(C::poseidon2_perm_B_22_1) -
+                        (poseidon2_params_MU_1 * poseidon2_perm_A_22_1 + poseidon2_perm_SUM_22));
             tmp *= scaling_factor;
             std::get<94>(evals) += typename Accumulator::View(tmp);
         }
         {
             using Accumulator = typename std::tuple_element_t<95, ContainerOverSubrelations>;
-            auto tmp =
-                new_term.poseidon2_perm_sel * (new_term.poseidon2_perm_B_22_2 -
-                                               (poseidon2_params_MU_2 * poseidon2_perm_A_22_2 + poseidon2_perm_SUM_22));
+            auto tmp = in.get(C::poseidon2_perm_sel) *
+                       (in.get(C::poseidon2_perm_B_22_2) -
+                        (poseidon2_params_MU_2 * poseidon2_perm_A_22_2 + poseidon2_perm_SUM_22));
             tmp *= scaling_factor;
             std::get<95>(evals) += typename Accumulator::View(tmp);
         }
         {
             using Accumulator = typename std::tuple_element_t<96, ContainerOverSubrelations>;
-            auto tmp =
-                new_term.poseidon2_perm_sel * (new_term.poseidon2_perm_B_22_3 -
-                                               (poseidon2_params_MU_3 * poseidon2_perm_A_22_3 + poseidon2_perm_SUM_22));
+            auto tmp = in.get(C::poseidon2_perm_sel) *
+                       (in.get(C::poseidon2_perm_B_22_3) -
+                        (poseidon2_params_MU_3 * poseidon2_perm_A_22_3 + poseidon2_perm_SUM_22));
             tmp *= scaling_factor;
             std::get<96>(evals) += typename Accumulator::View(tmp);
         }
         {
             using Accumulator = typename std::tuple_element_t<97, ContainerOverSubrelations>;
-            auto tmp =
-                new_term.poseidon2_perm_sel * (new_term.poseidon2_perm_B_23_0 -
-                                               (poseidon2_params_MU_0 * poseidon2_perm_A_23_0 + poseidon2_perm_SUM_23));
+            auto tmp = in.get(C::poseidon2_perm_sel) *
+                       (in.get(C::poseidon2_perm_B_23_0) -
+                        (poseidon2_params_MU_0 * poseidon2_perm_A_23_0 + poseidon2_perm_SUM_23));
             tmp *= scaling_factor;
             std::get<97>(evals) += typename Accumulator::View(tmp);
         }
         {
             using Accumulator = typename std::tuple_element_t<98, ContainerOverSubrelations>;
-            auto tmp =
-                new_term.poseidon2_perm_sel * (new_term.poseidon2_perm_B_23_1 -
-                                               (poseidon2_params_MU_1 * poseidon2_perm_A_23_1 + poseidon2_perm_SUM_23));
+            auto tmp = in.get(C::poseidon2_perm_sel) *
+                       (in.get(C::poseidon2_perm_B_23_1) -
+                        (poseidon2_params_MU_1 * poseidon2_perm_A_23_1 + poseidon2_perm_SUM_23));
             tmp *= scaling_factor;
             std::get<98>(evals) += typename Accumulator::View(tmp);
         }
         {
             using Accumulator = typename std::tuple_element_t<99, ContainerOverSubrelations>;
-            auto tmp =
-                new_term.poseidon2_perm_sel * (new_term.poseidon2_perm_B_23_2 -
-                                               (poseidon2_params_MU_2 * poseidon2_perm_A_23_2 + poseidon2_perm_SUM_23));
+            auto tmp = in.get(C::poseidon2_perm_sel) *
+                       (in.get(C::poseidon2_perm_B_23_2) -
+                        (poseidon2_params_MU_2 * poseidon2_perm_A_23_2 + poseidon2_perm_SUM_23));
             tmp *= scaling_factor;
             std::get<99>(evals) += typename Accumulator::View(tmp);
         }
         {
             using Accumulator = typename std::tuple_element_t<100, ContainerOverSubrelations>;
-            auto tmp =
-                new_term.poseidon2_perm_sel * (new_term.poseidon2_perm_B_23_3 -
-                                               (poseidon2_params_MU_3 * poseidon2_perm_A_23_3 + poseidon2_perm_SUM_23));
+            auto tmp = in.get(C::poseidon2_perm_sel) *
+                       (in.get(C::poseidon2_perm_B_23_3) -
+                        (poseidon2_params_MU_3 * poseidon2_perm_A_23_3 + poseidon2_perm_SUM_23));
             tmp *= scaling_factor;
             std::get<100>(evals) += typename Accumulator::View(tmp);
         }
         {
             using Accumulator = typename std::tuple_element_t<101, ContainerOverSubrelations>;
-            auto tmp =
-                new_term.poseidon2_perm_sel * (new_term.poseidon2_perm_B_24_0 -
-                                               (poseidon2_params_MU_0 * poseidon2_perm_A_24_0 + poseidon2_perm_SUM_24));
+            auto tmp = in.get(C::poseidon2_perm_sel) *
+                       (in.get(C::poseidon2_perm_B_24_0) -
+                        (poseidon2_params_MU_0 * poseidon2_perm_A_24_0 + poseidon2_perm_SUM_24));
             tmp *= scaling_factor;
             std::get<101>(evals) += typename Accumulator::View(tmp);
         }
         {
             using Accumulator = typename std::tuple_element_t<102, ContainerOverSubrelations>;
-            auto tmp =
-                new_term.poseidon2_perm_sel * (new_term.poseidon2_perm_B_24_1 -
-                                               (poseidon2_params_MU_1 * poseidon2_perm_A_24_1 + poseidon2_perm_SUM_24));
+            auto tmp = in.get(C::poseidon2_perm_sel) *
+                       (in.get(C::poseidon2_perm_B_24_1) -
+                        (poseidon2_params_MU_1 * poseidon2_perm_A_24_1 + poseidon2_perm_SUM_24));
             tmp *= scaling_factor;
             std::get<102>(evals) += typename Accumulator::View(tmp);
         }
         {
             using Accumulator = typename std::tuple_element_t<103, ContainerOverSubrelations>;
-            auto tmp =
-                new_term.poseidon2_perm_sel * (new_term.poseidon2_perm_B_24_2 -
-                                               (poseidon2_params_MU_2 * poseidon2_perm_A_24_2 + poseidon2_perm_SUM_24));
+            auto tmp = in.get(C::poseidon2_perm_sel) *
+                       (in.get(C::poseidon2_perm_B_24_2) -
+                        (poseidon2_params_MU_2 * poseidon2_perm_A_24_2 + poseidon2_perm_SUM_24));
             tmp *= scaling_factor;
             std::get<103>(evals) += typename Accumulator::View(tmp);
         }
         {
             using Accumulator = typename std::tuple_element_t<104, ContainerOverSubrelations>;
-            auto tmp =
-                new_term.poseidon2_perm_sel * (new_term.poseidon2_perm_B_24_3 -
-                                               (poseidon2_params_MU_3 * poseidon2_perm_A_24_3 + poseidon2_perm_SUM_24));
+            auto tmp = in.get(C::poseidon2_perm_sel) *
+                       (in.get(C::poseidon2_perm_B_24_3) -
+                        (poseidon2_params_MU_3 * poseidon2_perm_A_24_3 + poseidon2_perm_SUM_24));
             tmp *= scaling_factor;
             std::get<104>(evals) += typename Accumulator::View(tmp);
         }
         {
             using Accumulator = typename std::tuple_element_t<105, ContainerOverSubrelations>;
-            auto tmp =
-                new_term.poseidon2_perm_sel * (new_term.poseidon2_perm_B_25_0 -
-                                               (poseidon2_params_MU_0 * poseidon2_perm_A_25_0 + poseidon2_perm_SUM_25));
+            auto tmp = in.get(C::poseidon2_perm_sel) *
+                       (in.get(C::poseidon2_perm_B_25_0) -
+                        (poseidon2_params_MU_0 * poseidon2_perm_A_25_0 + poseidon2_perm_SUM_25));
             tmp *= scaling_factor;
             std::get<105>(evals) += typename Accumulator::View(tmp);
         }
         {
             using Accumulator = typename std::tuple_element_t<106, ContainerOverSubrelations>;
-            auto tmp =
-                new_term.poseidon2_perm_sel * (new_term.poseidon2_perm_B_25_1 -
-                                               (poseidon2_params_MU_1 * poseidon2_perm_A_25_1 + poseidon2_perm_SUM_25));
+            auto tmp = in.get(C::poseidon2_perm_sel) *
+                       (in.get(C::poseidon2_perm_B_25_1) -
+                        (poseidon2_params_MU_1 * poseidon2_perm_A_25_1 + poseidon2_perm_SUM_25));
             tmp *= scaling_factor;
             std::get<106>(evals) += typename Accumulator::View(tmp);
         }
         {
             using Accumulator = typename std::tuple_element_t<107, ContainerOverSubrelations>;
-            auto tmp =
-                new_term.poseidon2_perm_sel * (new_term.poseidon2_perm_B_25_2 -
-                                               (poseidon2_params_MU_2 * poseidon2_perm_A_25_2 + poseidon2_perm_SUM_25));
+            auto tmp = in.get(C::poseidon2_perm_sel) *
+                       (in.get(C::poseidon2_perm_B_25_2) -
+                        (poseidon2_params_MU_2 * poseidon2_perm_A_25_2 + poseidon2_perm_SUM_25));
             tmp *= scaling_factor;
             std::get<107>(evals) += typename Accumulator::View(tmp);
         }
         {
             using Accumulator = typename std::tuple_element_t<108, ContainerOverSubrelations>;
-            auto tmp =
-                new_term.poseidon2_perm_sel * (new_term.poseidon2_perm_B_25_3 -
-                                               (poseidon2_params_MU_3 * poseidon2_perm_A_25_3 + poseidon2_perm_SUM_25));
+            auto tmp = in.get(C::poseidon2_perm_sel) *
+                       (in.get(C::poseidon2_perm_B_25_3) -
+                        (poseidon2_params_MU_3 * poseidon2_perm_A_25_3 + poseidon2_perm_SUM_25));
             tmp *= scaling_factor;
             std::get<108>(evals) += typename Accumulator::View(tmp);
         }
         {
             using Accumulator = typename std::tuple_element_t<109, ContainerOverSubrelations>;
-            auto tmp =
-                new_term.poseidon2_perm_sel * (new_term.poseidon2_perm_B_26_0 -
-                                               (poseidon2_params_MU_0 * poseidon2_perm_A_26_0 + poseidon2_perm_SUM_26));
+            auto tmp = in.get(C::poseidon2_perm_sel) *
+                       (in.get(C::poseidon2_perm_B_26_0) -
+                        (poseidon2_params_MU_0 * poseidon2_perm_A_26_0 + poseidon2_perm_SUM_26));
             tmp *= scaling_factor;
             std::get<109>(evals) += typename Accumulator::View(tmp);
         }
         {
             using Accumulator = typename std::tuple_element_t<110, ContainerOverSubrelations>;
-            auto tmp =
-                new_term.poseidon2_perm_sel * (new_term.poseidon2_perm_B_26_1 -
-                                               (poseidon2_params_MU_1 * poseidon2_perm_A_26_1 + poseidon2_perm_SUM_26));
+            auto tmp = in.get(C::poseidon2_perm_sel) *
+                       (in.get(C::poseidon2_perm_B_26_1) -
+                        (poseidon2_params_MU_1 * poseidon2_perm_A_26_1 + poseidon2_perm_SUM_26));
             tmp *= scaling_factor;
             std::get<110>(evals) += typename Accumulator::View(tmp);
         }
         {
             using Accumulator = typename std::tuple_element_t<111, ContainerOverSubrelations>;
-            auto tmp =
-                new_term.poseidon2_perm_sel * (new_term.poseidon2_perm_B_26_2 -
-                                               (poseidon2_params_MU_2 * poseidon2_perm_A_26_2 + poseidon2_perm_SUM_26));
+            auto tmp = in.get(C::poseidon2_perm_sel) *
+                       (in.get(C::poseidon2_perm_B_26_2) -
+                        (poseidon2_params_MU_2 * poseidon2_perm_A_26_2 + poseidon2_perm_SUM_26));
             tmp *= scaling_factor;
             std::get<111>(evals) += typename Accumulator::View(tmp);
         }
         {
             using Accumulator = typename std::tuple_element_t<112, ContainerOverSubrelations>;
-            auto tmp =
-                new_term.poseidon2_perm_sel * (new_term.poseidon2_perm_B_26_3 -
-                                               (poseidon2_params_MU_3 * poseidon2_perm_A_26_3 + poseidon2_perm_SUM_26));
+            auto tmp = in.get(C::poseidon2_perm_sel) *
+                       (in.get(C::poseidon2_perm_B_26_3) -
+                        (poseidon2_params_MU_3 * poseidon2_perm_A_26_3 + poseidon2_perm_SUM_26));
             tmp *= scaling_factor;
             std::get<112>(evals) += typename Accumulator::View(tmp);
         }
         {
             using Accumulator = typename std::tuple_element_t<113, ContainerOverSubrelations>;
-            auto tmp =
-                new_term.poseidon2_perm_sel * (new_term.poseidon2_perm_B_27_0 -
-                                               (poseidon2_params_MU_0 * poseidon2_perm_A_27_0 + poseidon2_perm_SUM_27));
+            auto tmp = in.get(C::poseidon2_perm_sel) *
+                       (in.get(C::poseidon2_perm_B_27_0) -
+                        (poseidon2_params_MU_0 * poseidon2_perm_A_27_0 + poseidon2_perm_SUM_27));
             tmp *= scaling_factor;
             std::get<113>(evals) += typename Accumulator::View(tmp);
         }
         {
             using Accumulator = typename std::tuple_element_t<114, ContainerOverSubrelations>;
-            auto tmp =
-                new_term.poseidon2_perm_sel * (new_term.poseidon2_perm_B_27_1 -
-                                               (poseidon2_params_MU_1 * poseidon2_perm_A_27_1 + poseidon2_perm_SUM_27));
+            auto tmp = in.get(C::poseidon2_perm_sel) *
+                       (in.get(C::poseidon2_perm_B_27_1) -
+                        (poseidon2_params_MU_1 * poseidon2_perm_A_27_1 + poseidon2_perm_SUM_27));
             tmp *= scaling_factor;
             std::get<114>(evals) += typename Accumulator::View(tmp);
         }
         {
             using Accumulator = typename std::tuple_element_t<115, ContainerOverSubrelations>;
-            auto tmp =
-                new_term.poseidon2_perm_sel * (new_term.poseidon2_perm_B_27_2 -
-                                               (poseidon2_params_MU_2 * poseidon2_perm_A_27_2 + poseidon2_perm_SUM_27));
+            auto tmp = in.get(C::poseidon2_perm_sel) *
+                       (in.get(C::poseidon2_perm_B_27_2) -
+                        (poseidon2_params_MU_2 * poseidon2_perm_A_27_2 + poseidon2_perm_SUM_27));
             tmp *= scaling_factor;
             std::get<115>(evals) += typename Accumulator::View(tmp);
         }
         {
             using Accumulator = typename std::tuple_element_t<116, ContainerOverSubrelations>;
-            auto tmp =
-                new_term.poseidon2_perm_sel * (new_term.poseidon2_perm_B_27_3 -
-                                               (poseidon2_params_MU_3 * poseidon2_perm_A_27_3 + poseidon2_perm_SUM_27));
+            auto tmp = in.get(C::poseidon2_perm_sel) *
+                       (in.get(C::poseidon2_perm_B_27_3) -
+                        (poseidon2_params_MU_3 * poseidon2_perm_A_27_3 + poseidon2_perm_SUM_27));
             tmp *= scaling_factor;
             std::get<116>(evals) += typename Accumulator::View(tmp);
         }
         {
             using Accumulator = typename std::tuple_element_t<117, ContainerOverSubrelations>;
-            auto tmp =
-                new_term.poseidon2_perm_sel * (new_term.poseidon2_perm_B_28_0 -
-                                               (poseidon2_params_MU_0 * poseidon2_perm_A_28_0 + poseidon2_perm_SUM_28));
+            auto tmp = in.get(C::poseidon2_perm_sel) *
+                       (in.get(C::poseidon2_perm_B_28_0) -
+                        (poseidon2_params_MU_0 * poseidon2_perm_A_28_0 + poseidon2_perm_SUM_28));
             tmp *= scaling_factor;
             std::get<117>(evals) += typename Accumulator::View(tmp);
         }
         {
             using Accumulator = typename std::tuple_element_t<118, ContainerOverSubrelations>;
-            auto tmp =
-                new_term.poseidon2_perm_sel * (new_term.poseidon2_perm_B_28_1 -
-                                               (poseidon2_params_MU_1 * poseidon2_perm_A_28_1 + poseidon2_perm_SUM_28));
+            auto tmp = in.get(C::poseidon2_perm_sel) *
+                       (in.get(C::poseidon2_perm_B_28_1) -
+                        (poseidon2_params_MU_1 * poseidon2_perm_A_28_1 + poseidon2_perm_SUM_28));
             tmp *= scaling_factor;
             std::get<118>(evals) += typename Accumulator::View(tmp);
         }
         {
             using Accumulator = typename std::tuple_element_t<119, ContainerOverSubrelations>;
-            auto tmp =
-                new_term.poseidon2_perm_sel * (new_term.poseidon2_perm_B_28_2 -
-                                               (poseidon2_params_MU_2 * poseidon2_perm_A_28_2 + poseidon2_perm_SUM_28));
+            auto tmp = in.get(C::poseidon2_perm_sel) *
+                       (in.get(C::poseidon2_perm_B_28_2) -
+                        (poseidon2_params_MU_2 * poseidon2_perm_A_28_2 + poseidon2_perm_SUM_28));
             tmp *= scaling_factor;
             std::get<119>(evals) += typename Accumulator::View(tmp);
         }
         {
             using Accumulator = typename std::tuple_element_t<120, ContainerOverSubrelations>;
-            auto tmp =
-                new_term.poseidon2_perm_sel * (new_term.poseidon2_perm_B_28_3 -
-                                               (poseidon2_params_MU_3 * poseidon2_perm_A_28_3 + poseidon2_perm_SUM_28));
+            auto tmp = in.get(C::poseidon2_perm_sel) *
+                       (in.get(C::poseidon2_perm_B_28_3) -
+                        (poseidon2_params_MU_3 * poseidon2_perm_A_28_3 + poseidon2_perm_SUM_28));
             tmp *= scaling_factor;
             std::get<120>(evals) += typename Accumulator::View(tmp);
         }
         {
             using Accumulator = typename std::tuple_element_t<121, ContainerOverSubrelations>;
-            auto tmp =
-                new_term.poseidon2_perm_sel * (new_term.poseidon2_perm_B_29_0 -
-                                               (poseidon2_params_MU_0 * poseidon2_perm_A_29_0 + poseidon2_perm_SUM_29));
+            auto tmp = in.get(C::poseidon2_perm_sel) *
+                       (in.get(C::poseidon2_perm_B_29_0) -
+                        (poseidon2_params_MU_0 * poseidon2_perm_A_29_0 + poseidon2_perm_SUM_29));
             tmp *= scaling_factor;
             std::get<121>(evals) += typename Accumulator::View(tmp);
         }
         {
             using Accumulator = typename std::tuple_element_t<122, ContainerOverSubrelations>;
-            auto tmp =
-                new_term.poseidon2_perm_sel * (new_term.poseidon2_perm_B_29_1 -
-                                               (poseidon2_params_MU_1 * poseidon2_perm_A_29_1 + poseidon2_perm_SUM_29));
+            auto tmp = in.get(C::poseidon2_perm_sel) *
+                       (in.get(C::poseidon2_perm_B_29_1) -
+                        (poseidon2_params_MU_1 * poseidon2_perm_A_29_1 + poseidon2_perm_SUM_29));
             tmp *= scaling_factor;
             std::get<122>(evals) += typename Accumulator::View(tmp);
         }
         {
             using Accumulator = typename std::tuple_element_t<123, ContainerOverSubrelations>;
-            auto tmp =
-                new_term.poseidon2_perm_sel * (new_term.poseidon2_perm_B_29_2 -
-                                               (poseidon2_params_MU_2 * poseidon2_perm_A_29_2 + poseidon2_perm_SUM_29));
+            auto tmp = in.get(C::poseidon2_perm_sel) *
+                       (in.get(C::poseidon2_perm_B_29_2) -
+                        (poseidon2_params_MU_2 * poseidon2_perm_A_29_2 + poseidon2_perm_SUM_29));
             tmp *= scaling_factor;
             std::get<123>(evals) += typename Accumulator::View(tmp);
         }
         {
             using Accumulator = typename std::tuple_element_t<124, ContainerOverSubrelations>;
-            auto tmp =
-                new_term.poseidon2_perm_sel * (new_term.poseidon2_perm_B_29_3 -
-                                               (poseidon2_params_MU_3 * poseidon2_perm_A_29_3 + poseidon2_perm_SUM_29));
+            auto tmp = in.get(C::poseidon2_perm_sel) *
+                       (in.get(C::poseidon2_perm_B_29_3) -
+                        (poseidon2_params_MU_3 * poseidon2_perm_A_29_3 + poseidon2_perm_SUM_29));
             tmp *= scaling_factor;
             std::get<124>(evals) += typename Accumulator::View(tmp);
         }
         {
             using Accumulator = typename std::tuple_element_t<125, ContainerOverSubrelations>;
-            auto tmp =
-                new_term.poseidon2_perm_sel * (new_term.poseidon2_perm_B_30_0 -
-                                               (poseidon2_params_MU_0 * poseidon2_perm_A_30_0 + poseidon2_perm_SUM_30));
+            auto tmp = in.get(C::poseidon2_perm_sel) *
+                       (in.get(C::poseidon2_perm_B_30_0) -
+                        (poseidon2_params_MU_0 * poseidon2_perm_A_30_0 + poseidon2_perm_SUM_30));
             tmp *= scaling_factor;
             std::get<125>(evals) += typename Accumulator::View(tmp);
         }
         {
             using Accumulator = typename std::tuple_element_t<126, ContainerOverSubrelations>;
-            auto tmp =
-                new_term.poseidon2_perm_sel * (new_term.poseidon2_perm_B_30_1 -
-                                               (poseidon2_params_MU_1 * poseidon2_perm_A_30_1 + poseidon2_perm_SUM_30));
+            auto tmp = in.get(C::poseidon2_perm_sel) *
+                       (in.get(C::poseidon2_perm_B_30_1) -
+                        (poseidon2_params_MU_1 * poseidon2_perm_A_30_1 + poseidon2_perm_SUM_30));
             tmp *= scaling_factor;
             std::get<126>(evals) += typename Accumulator::View(tmp);
         }
         {
             using Accumulator = typename std::tuple_element_t<127, ContainerOverSubrelations>;
-            auto tmp =
-                new_term.poseidon2_perm_sel * (new_term.poseidon2_perm_B_30_2 -
-                                               (poseidon2_params_MU_2 * poseidon2_perm_A_30_2 + poseidon2_perm_SUM_30));
+            auto tmp = in.get(C::poseidon2_perm_sel) *
+                       (in.get(C::poseidon2_perm_B_30_2) -
+                        (poseidon2_params_MU_2 * poseidon2_perm_A_30_2 + poseidon2_perm_SUM_30));
             tmp *= scaling_factor;
             std::get<127>(evals) += typename Accumulator::View(tmp);
         }
         {
             using Accumulator = typename std::tuple_element_t<128, ContainerOverSubrelations>;
-            auto tmp =
-                new_term.poseidon2_perm_sel * (new_term.poseidon2_perm_B_30_3 -
-                                               (poseidon2_params_MU_3 * poseidon2_perm_A_30_3 + poseidon2_perm_SUM_30));
+            auto tmp = in.get(C::poseidon2_perm_sel) *
+                       (in.get(C::poseidon2_perm_B_30_3) -
+                        (poseidon2_params_MU_3 * poseidon2_perm_A_30_3 + poseidon2_perm_SUM_30));
             tmp *= scaling_factor;
             std::get<128>(evals) += typename Accumulator::View(tmp);
         }
         {
             using Accumulator = typename std::tuple_element_t<129, ContainerOverSubrelations>;
-            auto tmp =
-                new_term.poseidon2_perm_sel * (new_term.poseidon2_perm_B_31_0 -
-                                               (poseidon2_params_MU_0 * poseidon2_perm_A_31_0 + poseidon2_perm_SUM_31));
+            auto tmp = in.get(C::poseidon2_perm_sel) *
+                       (in.get(C::poseidon2_perm_B_31_0) -
+                        (poseidon2_params_MU_0 * poseidon2_perm_A_31_0 + poseidon2_perm_SUM_31));
             tmp *= scaling_factor;
             std::get<129>(evals) += typename Accumulator::View(tmp);
         }
         {
             using Accumulator = typename std::tuple_element_t<130, ContainerOverSubrelations>;
-            auto tmp =
-                new_term.poseidon2_perm_sel * (new_term.poseidon2_perm_B_31_1 -
-                                               (poseidon2_params_MU_1 * poseidon2_perm_A_31_1 + poseidon2_perm_SUM_31));
+            auto tmp = in.get(C::poseidon2_perm_sel) *
+                       (in.get(C::poseidon2_perm_B_31_1) -
+                        (poseidon2_params_MU_1 * poseidon2_perm_A_31_1 + poseidon2_perm_SUM_31));
             tmp *= scaling_factor;
             std::get<130>(evals) += typename Accumulator::View(tmp);
         }
         {
             using Accumulator = typename std::tuple_element_t<131, ContainerOverSubrelations>;
-            auto tmp =
-                new_term.poseidon2_perm_sel * (new_term.poseidon2_perm_B_31_2 -
-                                               (poseidon2_params_MU_2 * poseidon2_perm_A_31_2 + poseidon2_perm_SUM_31));
+            auto tmp = in.get(C::poseidon2_perm_sel) *
+                       (in.get(C::poseidon2_perm_B_31_2) -
+                        (poseidon2_params_MU_2 * poseidon2_perm_A_31_2 + poseidon2_perm_SUM_31));
             tmp *= scaling_factor;
             std::get<131>(evals) += typename Accumulator::View(tmp);
         }
         {
             using Accumulator = typename std::tuple_element_t<132, ContainerOverSubrelations>;
-            auto tmp =
-                new_term.poseidon2_perm_sel * (new_term.poseidon2_perm_B_31_3 -
-                                               (poseidon2_params_MU_3 * poseidon2_perm_A_31_3 + poseidon2_perm_SUM_31));
+            auto tmp = in.get(C::poseidon2_perm_sel) *
+                       (in.get(C::poseidon2_perm_B_31_3) -
+                        (poseidon2_params_MU_3 * poseidon2_perm_A_31_3 + poseidon2_perm_SUM_31));
             tmp *= scaling_factor;
             std::get<132>(evals) += typename Accumulator::View(tmp);
         }
         {
             using Accumulator = typename std::tuple_element_t<133, ContainerOverSubrelations>;
-            auto tmp =
-                new_term.poseidon2_perm_sel * (new_term.poseidon2_perm_B_32_0 -
-                                               (poseidon2_params_MU_0 * poseidon2_perm_A_32_0 + poseidon2_perm_SUM_32));
+            auto tmp = in.get(C::poseidon2_perm_sel) *
+                       (in.get(C::poseidon2_perm_B_32_0) -
+                        (poseidon2_params_MU_0 * poseidon2_perm_A_32_0 + poseidon2_perm_SUM_32));
             tmp *= scaling_factor;
             std::get<133>(evals) += typename Accumulator::View(tmp);
         }
         {
             using Accumulator = typename std::tuple_element_t<134, ContainerOverSubrelations>;
-            auto tmp =
-                new_term.poseidon2_perm_sel * (new_term.poseidon2_perm_B_32_1 -
-                                               (poseidon2_params_MU_1 * poseidon2_perm_A_32_1 + poseidon2_perm_SUM_32));
+            auto tmp = in.get(C::poseidon2_perm_sel) *
+                       (in.get(C::poseidon2_perm_B_32_1) -
+                        (poseidon2_params_MU_1 * poseidon2_perm_A_32_1 + poseidon2_perm_SUM_32));
             tmp *= scaling_factor;
             std::get<134>(evals) += typename Accumulator::View(tmp);
         }
         {
             using Accumulator = typename std::tuple_element_t<135, ContainerOverSubrelations>;
-            auto tmp =
-                new_term.poseidon2_perm_sel * (new_term.poseidon2_perm_B_32_2 -
-                                               (poseidon2_params_MU_2 * poseidon2_perm_A_32_2 + poseidon2_perm_SUM_32));
+            auto tmp = in.get(C::poseidon2_perm_sel) *
+                       (in.get(C::poseidon2_perm_B_32_2) -
+                        (poseidon2_params_MU_2 * poseidon2_perm_A_32_2 + poseidon2_perm_SUM_32));
             tmp *= scaling_factor;
             std::get<135>(evals) += typename Accumulator::View(tmp);
         }
         {
             using Accumulator = typename std::tuple_element_t<136, ContainerOverSubrelations>;
-            auto tmp =
-                new_term.poseidon2_perm_sel * (new_term.poseidon2_perm_B_32_3 -
-                                               (poseidon2_params_MU_3 * poseidon2_perm_A_32_3 + poseidon2_perm_SUM_32));
+            auto tmp = in.get(C::poseidon2_perm_sel) *
+                       (in.get(C::poseidon2_perm_B_32_3) -
+                        (poseidon2_params_MU_3 * poseidon2_perm_A_32_3 + poseidon2_perm_SUM_32));
             tmp *= scaling_factor;
             std::get<136>(evals) += typename Accumulator::View(tmp);
         }
         {
             using Accumulator = typename std::tuple_element_t<137, ContainerOverSubrelations>;
-            auto tmp =
-                new_term.poseidon2_perm_sel * (new_term.poseidon2_perm_B_33_0 -
-                                               (poseidon2_params_MU_0 * poseidon2_perm_A_33_0 + poseidon2_perm_SUM_33));
+            auto tmp = in.get(C::poseidon2_perm_sel) *
+                       (in.get(C::poseidon2_perm_B_33_0) -
+                        (poseidon2_params_MU_0 * poseidon2_perm_A_33_0 + poseidon2_perm_SUM_33));
             tmp *= scaling_factor;
             std::get<137>(evals) += typename Accumulator::View(tmp);
         }
         {
             using Accumulator = typename std::tuple_element_t<138, ContainerOverSubrelations>;
-            auto tmp =
-                new_term.poseidon2_perm_sel * (new_term.poseidon2_perm_B_33_1 -
-                                               (poseidon2_params_MU_1 * poseidon2_perm_A_33_1 + poseidon2_perm_SUM_33));
+            auto tmp = in.get(C::poseidon2_perm_sel) *
+                       (in.get(C::poseidon2_perm_B_33_1) -
+                        (poseidon2_params_MU_1 * poseidon2_perm_A_33_1 + poseidon2_perm_SUM_33));
             tmp *= scaling_factor;
             std::get<138>(evals) += typename Accumulator::View(tmp);
         }
         {
             using Accumulator = typename std::tuple_element_t<139, ContainerOverSubrelations>;
-            auto tmp =
-                new_term.poseidon2_perm_sel * (new_term.poseidon2_perm_B_33_2 -
-                                               (poseidon2_params_MU_2 * poseidon2_perm_A_33_2 + poseidon2_perm_SUM_33));
+            auto tmp = in.get(C::poseidon2_perm_sel) *
+                       (in.get(C::poseidon2_perm_B_33_2) -
+                        (poseidon2_params_MU_2 * poseidon2_perm_A_33_2 + poseidon2_perm_SUM_33));
             tmp *= scaling_factor;
             std::get<139>(evals) += typename Accumulator::View(tmp);
         }
         {
             using Accumulator = typename std::tuple_element_t<140, ContainerOverSubrelations>;
-            auto tmp =
-                new_term.poseidon2_perm_sel * (new_term.poseidon2_perm_B_33_3 -
-                                               (poseidon2_params_MU_3 * poseidon2_perm_A_33_3 + poseidon2_perm_SUM_33));
+            auto tmp = in.get(C::poseidon2_perm_sel) *
+                       (in.get(C::poseidon2_perm_B_33_3) -
+                        (poseidon2_params_MU_3 * poseidon2_perm_A_33_3 + poseidon2_perm_SUM_33));
             tmp *= scaling_factor;
             std::get<140>(evals) += typename Accumulator::View(tmp);
         }
         {
             using Accumulator = typename std::tuple_element_t<141, ContainerOverSubrelations>;
-            auto tmp =
-                new_term.poseidon2_perm_sel * (new_term.poseidon2_perm_B_34_0 -
-                                               (poseidon2_params_MU_0 * poseidon2_perm_A_34_0 + poseidon2_perm_SUM_34));
+            auto tmp = in.get(C::poseidon2_perm_sel) *
+                       (in.get(C::poseidon2_perm_B_34_0) -
+                        (poseidon2_params_MU_0 * poseidon2_perm_A_34_0 + poseidon2_perm_SUM_34));
             tmp *= scaling_factor;
             std::get<141>(evals) += typename Accumulator::View(tmp);
         }
         {
             using Accumulator = typename std::tuple_element_t<142, ContainerOverSubrelations>;
-            auto tmp =
-                new_term.poseidon2_perm_sel * (new_term.poseidon2_perm_B_34_1 -
-                                               (poseidon2_params_MU_1 * poseidon2_perm_A_34_1 + poseidon2_perm_SUM_34));
+            auto tmp = in.get(C::poseidon2_perm_sel) *
+                       (in.get(C::poseidon2_perm_B_34_1) -
+                        (poseidon2_params_MU_1 * poseidon2_perm_A_34_1 + poseidon2_perm_SUM_34));
             tmp *= scaling_factor;
             std::get<142>(evals) += typename Accumulator::View(tmp);
         }
         {
             using Accumulator = typename std::tuple_element_t<143, ContainerOverSubrelations>;
-            auto tmp =
-                new_term.poseidon2_perm_sel * (new_term.poseidon2_perm_B_34_2 -
-                                               (poseidon2_params_MU_2 * poseidon2_perm_A_34_2 + poseidon2_perm_SUM_34));
+            auto tmp = in.get(C::poseidon2_perm_sel) *
+                       (in.get(C::poseidon2_perm_B_34_2) -
+                        (poseidon2_params_MU_2 * poseidon2_perm_A_34_2 + poseidon2_perm_SUM_34));
             tmp *= scaling_factor;
             std::get<143>(evals) += typename Accumulator::View(tmp);
         }
         {
             using Accumulator = typename std::tuple_element_t<144, ContainerOverSubrelations>;
-            auto tmp =
-                new_term.poseidon2_perm_sel * (new_term.poseidon2_perm_B_34_3 -
-                                               (poseidon2_params_MU_3 * poseidon2_perm_A_34_3 + poseidon2_perm_SUM_34));
+            auto tmp = in.get(C::poseidon2_perm_sel) *
+                       (in.get(C::poseidon2_perm_B_34_3) -
+                        (poseidon2_params_MU_3 * poseidon2_perm_A_34_3 + poseidon2_perm_SUM_34));
             tmp *= scaling_factor;
             std::get<144>(evals) += typename Accumulator::View(tmp);
         }
         {
             using Accumulator = typename std::tuple_element_t<145, ContainerOverSubrelations>;
-            auto tmp =
-                new_term.poseidon2_perm_sel * (new_term.poseidon2_perm_B_35_0 -
-                                               (poseidon2_params_MU_0 * poseidon2_perm_A_35_0 + poseidon2_perm_SUM_35));
+            auto tmp = in.get(C::poseidon2_perm_sel) *
+                       (in.get(C::poseidon2_perm_B_35_0) -
+                        (poseidon2_params_MU_0 * poseidon2_perm_A_35_0 + poseidon2_perm_SUM_35));
             tmp *= scaling_factor;
             std::get<145>(evals) += typename Accumulator::View(tmp);
         }
         {
             using Accumulator = typename std::tuple_element_t<146, ContainerOverSubrelations>;
-            auto tmp =
-                new_term.poseidon2_perm_sel * (new_term.poseidon2_perm_B_35_1 -
-                                               (poseidon2_params_MU_1 * poseidon2_perm_A_35_1 + poseidon2_perm_SUM_35));
+            auto tmp = in.get(C::poseidon2_perm_sel) *
+                       (in.get(C::poseidon2_perm_B_35_1) -
+                        (poseidon2_params_MU_1 * poseidon2_perm_A_35_1 + poseidon2_perm_SUM_35));
             tmp *= scaling_factor;
             std::get<146>(evals) += typename Accumulator::View(tmp);
         }
         {
             using Accumulator = typename std::tuple_element_t<147, ContainerOverSubrelations>;
-            auto tmp =
-                new_term.poseidon2_perm_sel * (new_term.poseidon2_perm_B_35_2 -
-                                               (poseidon2_params_MU_2 * poseidon2_perm_A_35_2 + poseidon2_perm_SUM_35));
+            auto tmp = in.get(C::poseidon2_perm_sel) *
+                       (in.get(C::poseidon2_perm_B_35_2) -
+                        (poseidon2_params_MU_2 * poseidon2_perm_A_35_2 + poseidon2_perm_SUM_35));
             tmp *= scaling_factor;
             std::get<147>(evals) += typename Accumulator::View(tmp);
         }
         {
             using Accumulator = typename std::tuple_element_t<148, ContainerOverSubrelations>;
-            auto tmp =
-                new_term.poseidon2_perm_sel * (new_term.poseidon2_perm_B_35_3 -
-                                               (poseidon2_params_MU_3 * poseidon2_perm_A_35_3 + poseidon2_perm_SUM_35));
+            auto tmp = in.get(C::poseidon2_perm_sel) *
+                       (in.get(C::poseidon2_perm_B_35_3) -
+                        (poseidon2_params_MU_3 * poseidon2_perm_A_35_3 + poseidon2_perm_SUM_35));
             tmp *= scaling_factor;
             std::get<148>(evals) += typename Accumulator::View(tmp);
         }
         {
             using Accumulator = typename std::tuple_element_t<149, ContainerOverSubrelations>;
-            auto tmp =
-                new_term.poseidon2_perm_sel * (new_term.poseidon2_perm_B_36_0 -
-                                               (poseidon2_params_MU_0 * poseidon2_perm_A_36_0 + poseidon2_perm_SUM_36));
+            auto tmp = in.get(C::poseidon2_perm_sel) *
+                       (in.get(C::poseidon2_perm_B_36_0) -
+                        (poseidon2_params_MU_0 * poseidon2_perm_A_36_0 + poseidon2_perm_SUM_36));
             tmp *= scaling_factor;
             std::get<149>(evals) += typename Accumulator::View(tmp);
         }
         {
             using Accumulator = typename std::tuple_element_t<150, ContainerOverSubrelations>;
-            auto tmp =
-                new_term.poseidon2_perm_sel * (new_term.poseidon2_perm_B_36_1 -
-                                               (poseidon2_params_MU_1 * poseidon2_perm_A_36_1 + poseidon2_perm_SUM_36));
+            auto tmp = in.get(C::poseidon2_perm_sel) *
+                       (in.get(C::poseidon2_perm_B_36_1) -
+                        (poseidon2_params_MU_1 * poseidon2_perm_A_36_1 + poseidon2_perm_SUM_36));
             tmp *= scaling_factor;
             std::get<150>(evals) += typename Accumulator::View(tmp);
         }
         {
             using Accumulator = typename std::tuple_element_t<151, ContainerOverSubrelations>;
-            auto tmp =
-                new_term.poseidon2_perm_sel * (new_term.poseidon2_perm_B_36_2 -
-                                               (poseidon2_params_MU_2 * poseidon2_perm_A_36_2 + poseidon2_perm_SUM_36));
+            auto tmp = in.get(C::poseidon2_perm_sel) *
+                       (in.get(C::poseidon2_perm_B_36_2) -
+                        (poseidon2_params_MU_2 * poseidon2_perm_A_36_2 + poseidon2_perm_SUM_36));
             tmp *= scaling_factor;
             std::get<151>(evals) += typename Accumulator::View(tmp);
         }
         {
             using Accumulator = typename std::tuple_element_t<152, ContainerOverSubrelations>;
-            auto tmp =
-                new_term.poseidon2_perm_sel * (new_term.poseidon2_perm_B_36_3 -
-                                               (poseidon2_params_MU_3 * poseidon2_perm_A_36_3 + poseidon2_perm_SUM_36));
+            auto tmp = in.get(C::poseidon2_perm_sel) *
+                       (in.get(C::poseidon2_perm_B_36_3) -
+                        (poseidon2_params_MU_3 * poseidon2_perm_A_36_3 + poseidon2_perm_SUM_36));
             tmp *= scaling_factor;
             std::get<152>(evals) += typename Accumulator::View(tmp);
         }
         {
             using Accumulator = typename std::tuple_element_t<153, ContainerOverSubrelations>;
-            auto tmp =
-                new_term.poseidon2_perm_sel * (new_term.poseidon2_perm_B_37_0 -
-                                               (poseidon2_params_MU_0 * poseidon2_perm_A_37_0 + poseidon2_perm_SUM_37));
+            auto tmp = in.get(C::poseidon2_perm_sel) *
+                       (in.get(C::poseidon2_perm_B_37_0) -
+                        (poseidon2_params_MU_0 * poseidon2_perm_A_37_0 + poseidon2_perm_SUM_37));
             tmp *= scaling_factor;
             std::get<153>(evals) += typename Accumulator::View(tmp);
         }
         {
             using Accumulator = typename std::tuple_element_t<154, ContainerOverSubrelations>;
-            auto tmp =
-                new_term.poseidon2_perm_sel * (new_term.poseidon2_perm_B_37_1 -
-                                               (poseidon2_params_MU_1 * poseidon2_perm_A_37_1 + poseidon2_perm_SUM_37));
+            auto tmp = in.get(C::poseidon2_perm_sel) *
+                       (in.get(C::poseidon2_perm_B_37_1) -
+                        (poseidon2_params_MU_1 * poseidon2_perm_A_37_1 + poseidon2_perm_SUM_37));
             tmp *= scaling_factor;
             std::get<154>(evals) += typename Accumulator::View(tmp);
         }
         {
             using Accumulator = typename std::tuple_element_t<155, ContainerOverSubrelations>;
-            auto tmp =
-                new_term.poseidon2_perm_sel * (new_term.poseidon2_perm_B_37_2 -
-                                               (poseidon2_params_MU_2 * poseidon2_perm_A_37_2 + poseidon2_perm_SUM_37));
+            auto tmp = in.get(C::poseidon2_perm_sel) *
+                       (in.get(C::poseidon2_perm_B_37_2) -
+                        (poseidon2_params_MU_2 * poseidon2_perm_A_37_2 + poseidon2_perm_SUM_37));
             tmp *= scaling_factor;
             std::get<155>(evals) += typename Accumulator::View(tmp);
         }
         {
             using Accumulator = typename std::tuple_element_t<156, ContainerOverSubrelations>;
-            auto tmp =
-                new_term.poseidon2_perm_sel * (new_term.poseidon2_perm_B_37_3 -
-                                               (poseidon2_params_MU_3 * poseidon2_perm_A_37_3 + poseidon2_perm_SUM_37));
+            auto tmp = in.get(C::poseidon2_perm_sel) *
+                       (in.get(C::poseidon2_perm_B_37_3) -
+                        (poseidon2_params_MU_3 * poseidon2_perm_A_37_3 + poseidon2_perm_SUM_37));
             tmp *= scaling_factor;
             std::get<156>(evals) += typename Accumulator::View(tmp);
         }
         {
             using Accumulator = typename std::tuple_element_t<157, ContainerOverSubrelations>;
-            auto tmp =
-                new_term.poseidon2_perm_sel * (new_term.poseidon2_perm_B_38_0 -
-                                               (poseidon2_params_MU_0 * poseidon2_perm_A_38_0 + poseidon2_perm_SUM_38));
+            auto tmp = in.get(C::poseidon2_perm_sel) *
+                       (in.get(C::poseidon2_perm_B_38_0) -
+                        (poseidon2_params_MU_0 * poseidon2_perm_A_38_0 + poseidon2_perm_SUM_38));
             tmp *= scaling_factor;
             std::get<157>(evals) += typename Accumulator::View(tmp);
         }
         {
             using Accumulator = typename std::tuple_element_t<158, ContainerOverSubrelations>;
-            auto tmp =
-                new_term.poseidon2_perm_sel * (new_term.poseidon2_perm_B_38_1 -
-                                               (poseidon2_params_MU_1 * poseidon2_perm_A_38_1 + poseidon2_perm_SUM_38));
+            auto tmp = in.get(C::poseidon2_perm_sel) *
+                       (in.get(C::poseidon2_perm_B_38_1) -
+                        (poseidon2_params_MU_1 * poseidon2_perm_A_38_1 + poseidon2_perm_SUM_38));
             tmp *= scaling_factor;
             std::get<158>(evals) += typename Accumulator::View(tmp);
         }
         {
             using Accumulator = typename std::tuple_element_t<159, ContainerOverSubrelations>;
-            auto tmp =
-                new_term.poseidon2_perm_sel * (new_term.poseidon2_perm_B_38_2 -
-                                               (poseidon2_params_MU_2 * poseidon2_perm_A_38_2 + poseidon2_perm_SUM_38));
+            auto tmp = in.get(C::poseidon2_perm_sel) *
+                       (in.get(C::poseidon2_perm_B_38_2) -
+                        (poseidon2_params_MU_2 * poseidon2_perm_A_38_2 + poseidon2_perm_SUM_38));
             tmp *= scaling_factor;
             std::get<159>(evals) += typename Accumulator::View(tmp);
         }
         {
             using Accumulator = typename std::tuple_element_t<160, ContainerOverSubrelations>;
-            auto tmp =
-                new_term.poseidon2_perm_sel * (new_term.poseidon2_perm_B_38_3 -
-                                               (poseidon2_params_MU_3 * poseidon2_perm_A_38_3 + poseidon2_perm_SUM_38));
+            auto tmp = in.get(C::poseidon2_perm_sel) *
+                       (in.get(C::poseidon2_perm_B_38_3) -
+                        (poseidon2_params_MU_3 * poseidon2_perm_A_38_3 + poseidon2_perm_SUM_38));
             tmp *= scaling_factor;
             std::get<160>(evals) += typename Accumulator::View(tmp);
         }
         {
             using Accumulator = typename std::tuple_element_t<161, ContainerOverSubrelations>;
-            auto tmp =
-                new_term.poseidon2_perm_sel * (new_term.poseidon2_perm_B_39_0 -
-                                               (poseidon2_params_MU_0 * poseidon2_perm_A_39_0 + poseidon2_perm_SUM_39));
+            auto tmp = in.get(C::poseidon2_perm_sel) *
+                       (in.get(C::poseidon2_perm_B_39_0) -
+                        (poseidon2_params_MU_0 * poseidon2_perm_A_39_0 + poseidon2_perm_SUM_39));
             tmp *= scaling_factor;
             std::get<161>(evals) += typename Accumulator::View(tmp);
         }
         {
             using Accumulator = typename std::tuple_element_t<162, ContainerOverSubrelations>;
-            auto tmp =
-                new_term.poseidon2_perm_sel * (new_term.poseidon2_perm_B_39_1 -
-                                               (poseidon2_params_MU_1 * poseidon2_perm_A_39_1 + poseidon2_perm_SUM_39));
+            auto tmp = in.get(C::poseidon2_perm_sel) *
+                       (in.get(C::poseidon2_perm_B_39_1) -
+                        (poseidon2_params_MU_1 * poseidon2_perm_A_39_1 + poseidon2_perm_SUM_39));
             tmp *= scaling_factor;
             std::get<162>(evals) += typename Accumulator::View(tmp);
         }
         {
             using Accumulator = typename std::tuple_element_t<163, ContainerOverSubrelations>;
-            auto tmp =
-                new_term.poseidon2_perm_sel * (new_term.poseidon2_perm_B_39_2 -
-                                               (poseidon2_params_MU_2 * poseidon2_perm_A_39_2 + poseidon2_perm_SUM_39));
+            auto tmp = in.get(C::poseidon2_perm_sel) *
+                       (in.get(C::poseidon2_perm_B_39_2) -
+                        (poseidon2_params_MU_2 * poseidon2_perm_A_39_2 + poseidon2_perm_SUM_39));
             tmp *= scaling_factor;
             std::get<163>(evals) += typename Accumulator::View(tmp);
         }
         {
             using Accumulator = typename std::tuple_element_t<164, ContainerOverSubrelations>;
-            auto tmp =
-                new_term.poseidon2_perm_sel * (new_term.poseidon2_perm_B_39_3 -
-                                               (poseidon2_params_MU_3 * poseidon2_perm_A_39_3 + poseidon2_perm_SUM_39));
+            auto tmp = in.get(C::poseidon2_perm_sel) *
+                       (in.get(C::poseidon2_perm_B_39_3) -
+                        (poseidon2_params_MU_3 * poseidon2_perm_A_39_3 + poseidon2_perm_SUM_39));
             tmp *= scaling_factor;
             std::get<164>(evals) += typename Accumulator::View(tmp);
         }
         {
             using Accumulator = typename std::tuple_element_t<165, ContainerOverSubrelations>;
-            auto tmp =
-                new_term.poseidon2_perm_sel * (new_term.poseidon2_perm_B_40_0 -
-                                               (poseidon2_params_MU_0 * poseidon2_perm_A_40_0 + poseidon2_perm_SUM_40));
+            auto tmp = in.get(C::poseidon2_perm_sel) *
+                       (in.get(C::poseidon2_perm_B_40_0) -
+                        (poseidon2_params_MU_0 * poseidon2_perm_A_40_0 + poseidon2_perm_SUM_40));
             tmp *= scaling_factor;
             std::get<165>(evals) += typename Accumulator::View(tmp);
         }
         {
             using Accumulator = typename std::tuple_element_t<166, ContainerOverSubrelations>;
-            auto tmp =
-                new_term.poseidon2_perm_sel * (new_term.poseidon2_perm_B_40_1 -
-                                               (poseidon2_params_MU_1 * poseidon2_perm_A_40_1 + poseidon2_perm_SUM_40));
+            auto tmp = in.get(C::poseidon2_perm_sel) *
+                       (in.get(C::poseidon2_perm_B_40_1) -
+                        (poseidon2_params_MU_1 * poseidon2_perm_A_40_1 + poseidon2_perm_SUM_40));
             tmp *= scaling_factor;
             std::get<166>(evals) += typename Accumulator::View(tmp);
         }
         {
             using Accumulator = typename std::tuple_element_t<167, ContainerOverSubrelations>;
-            auto tmp =
-                new_term.poseidon2_perm_sel * (new_term.poseidon2_perm_B_40_2 -
-                                               (poseidon2_params_MU_2 * poseidon2_perm_A_40_2 + poseidon2_perm_SUM_40));
+            auto tmp = in.get(C::poseidon2_perm_sel) *
+                       (in.get(C::poseidon2_perm_B_40_2) -
+                        (poseidon2_params_MU_2 * poseidon2_perm_A_40_2 + poseidon2_perm_SUM_40));
             tmp *= scaling_factor;
             std::get<167>(evals) += typename Accumulator::View(tmp);
         }
         {
             using Accumulator = typename std::tuple_element_t<168, ContainerOverSubrelations>;
-            auto tmp =
-                new_term.poseidon2_perm_sel * (new_term.poseidon2_perm_B_40_3 -
-                                               (poseidon2_params_MU_3 * poseidon2_perm_A_40_3 + poseidon2_perm_SUM_40));
+            auto tmp = in.get(C::poseidon2_perm_sel) *
+                       (in.get(C::poseidon2_perm_B_40_3) -
+                        (poseidon2_params_MU_3 * poseidon2_perm_A_40_3 + poseidon2_perm_SUM_40));
             tmp *= scaling_factor;
             std::get<168>(evals) += typename Accumulator::View(tmp);
         }
         {
             using Accumulator = typename std::tuple_element_t<169, ContainerOverSubrelations>;
-            auto tmp =
-                new_term.poseidon2_perm_sel * (new_term.poseidon2_perm_B_41_0 -
-                                               (poseidon2_params_MU_0 * poseidon2_perm_A_41_0 + poseidon2_perm_SUM_41));
+            auto tmp = in.get(C::poseidon2_perm_sel) *
+                       (in.get(C::poseidon2_perm_B_41_0) -
+                        (poseidon2_params_MU_0 * poseidon2_perm_A_41_0 + poseidon2_perm_SUM_41));
             tmp *= scaling_factor;
             std::get<169>(evals) += typename Accumulator::View(tmp);
         }
         {
             using Accumulator = typename std::tuple_element_t<170, ContainerOverSubrelations>;
-            auto tmp =
-                new_term.poseidon2_perm_sel * (new_term.poseidon2_perm_B_41_1 -
-                                               (poseidon2_params_MU_1 * poseidon2_perm_A_41_1 + poseidon2_perm_SUM_41));
+            auto tmp = in.get(C::poseidon2_perm_sel) *
+                       (in.get(C::poseidon2_perm_B_41_1) -
+                        (poseidon2_params_MU_1 * poseidon2_perm_A_41_1 + poseidon2_perm_SUM_41));
             tmp *= scaling_factor;
             std::get<170>(evals) += typename Accumulator::View(tmp);
         }
         {
             using Accumulator = typename std::tuple_element_t<171, ContainerOverSubrelations>;
-            auto tmp =
-                new_term.poseidon2_perm_sel * (new_term.poseidon2_perm_B_41_2 -
-                                               (poseidon2_params_MU_2 * poseidon2_perm_A_41_2 + poseidon2_perm_SUM_41));
+            auto tmp = in.get(C::poseidon2_perm_sel) *
+                       (in.get(C::poseidon2_perm_B_41_2) -
+                        (poseidon2_params_MU_2 * poseidon2_perm_A_41_2 + poseidon2_perm_SUM_41));
             tmp *= scaling_factor;
             std::get<171>(evals) += typename Accumulator::View(tmp);
         }
         {
             using Accumulator = typename std::tuple_element_t<172, ContainerOverSubrelations>;
-            auto tmp =
-                new_term.poseidon2_perm_sel * (new_term.poseidon2_perm_B_41_3 -
-                                               (poseidon2_params_MU_3 * poseidon2_perm_A_41_3 + poseidon2_perm_SUM_41));
+            auto tmp = in.get(C::poseidon2_perm_sel) *
+                       (in.get(C::poseidon2_perm_B_41_3) -
+                        (poseidon2_params_MU_3 * poseidon2_perm_A_41_3 + poseidon2_perm_SUM_41));
             tmp *= scaling_factor;
             std::get<172>(evals) += typename Accumulator::View(tmp);
         }
         {
             using Accumulator = typename std::tuple_element_t<173, ContainerOverSubrelations>;
-            auto tmp =
-                new_term.poseidon2_perm_sel * (new_term.poseidon2_perm_B_42_0 -
-                                               (poseidon2_params_MU_0 * poseidon2_perm_A_42_0 + poseidon2_perm_SUM_42));
+            auto tmp = in.get(C::poseidon2_perm_sel) *
+                       (in.get(C::poseidon2_perm_B_42_0) -
+                        (poseidon2_params_MU_0 * poseidon2_perm_A_42_0 + poseidon2_perm_SUM_42));
             tmp *= scaling_factor;
             std::get<173>(evals) += typename Accumulator::View(tmp);
         }
         {
             using Accumulator = typename std::tuple_element_t<174, ContainerOverSubrelations>;
-            auto tmp =
-                new_term.poseidon2_perm_sel * (new_term.poseidon2_perm_B_42_1 -
-                                               (poseidon2_params_MU_1 * poseidon2_perm_A_42_1 + poseidon2_perm_SUM_42));
+            auto tmp = in.get(C::poseidon2_perm_sel) *
+                       (in.get(C::poseidon2_perm_B_42_1) -
+                        (poseidon2_params_MU_1 * poseidon2_perm_A_42_1 + poseidon2_perm_SUM_42));
             tmp *= scaling_factor;
             std::get<174>(evals) += typename Accumulator::View(tmp);
         }
         {
             using Accumulator = typename std::tuple_element_t<175, ContainerOverSubrelations>;
-            auto tmp =
-                new_term.poseidon2_perm_sel * (new_term.poseidon2_perm_B_42_2 -
-                                               (poseidon2_params_MU_2 * poseidon2_perm_A_42_2 + poseidon2_perm_SUM_42));
+            auto tmp = in.get(C::poseidon2_perm_sel) *
+                       (in.get(C::poseidon2_perm_B_42_2) -
+                        (poseidon2_params_MU_2 * poseidon2_perm_A_42_2 + poseidon2_perm_SUM_42));
             tmp *= scaling_factor;
             std::get<175>(evals) += typename Accumulator::View(tmp);
         }
         {
             using Accumulator = typename std::tuple_element_t<176, ContainerOverSubrelations>;
-            auto tmp =
-                new_term.poseidon2_perm_sel * (new_term.poseidon2_perm_B_42_3 -
-                                               (poseidon2_params_MU_3 * poseidon2_perm_A_42_3 + poseidon2_perm_SUM_42));
+            auto tmp = in.get(C::poseidon2_perm_sel) *
+                       (in.get(C::poseidon2_perm_B_42_3) -
+                        (poseidon2_params_MU_3 * poseidon2_perm_A_42_3 + poseidon2_perm_SUM_42));
             tmp *= scaling_factor;
             std::get<176>(evals) += typename Accumulator::View(tmp);
         }
         {
             using Accumulator = typename std::tuple_element_t<177, ContainerOverSubrelations>;
-            auto tmp =
-                new_term.poseidon2_perm_sel * (new_term.poseidon2_perm_B_43_0 -
-                                               (poseidon2_params_MU_0 * poseidon2_perm_A_43_0 + poseidon2_perm_SUM_43));
+            auto tmp = in.get(C::poseidon2_perm_sel) *
+                       (in.get(C::poseidon2_perm_B_43_0) -
+                        (poseidon2_params_MU_0 * poseidon2_perm_A_43_0 + poseidon2_perm_SUM_43));
             tmp *= scaling_factor;
             std::get<177>(evals) += typename Accumulator::View(tmp);
         }
         {
             using Accumulator = typename std::tuple_element_t<178, ContainerOverSubrelations>;
-            auto tmp =
-                new_term.poseidon2_perm_sel * (new_term.poseidon2_perm_B_43_1 -
-                                               (poseidon2_params_MU_1 * poseidon2_perm_A_43_1 + poseidon2_perm_SUM_43));
+            auto tmp = in.get(C::poseidon2_perm_sel) *
+                       (in.get(C::poseidon2_perm_B_43_1) -
+                        (poseidon2_params_MU_1 * poseidon2_perm_A_43_1 + poseidon2_perm_SUM_43));
             tmp *= scaling_factor;
             std::get<178>(evals) += typename Accumulator::View(tmp);
         }
         {
             using Accumulator = typename std::tuple_element_t<179, ContainerOverSubrelations>;
-            auto tmp =
-                new_term.poseidon2_perm_sel * (new_term.poseidon2_perm_B_43_2 -
-                                               (poseidon2_params_MU_2 * poseidon2_perm_A_43_2 + poseidon2_perm_SUM_43));
+            auto tmp = in.get(C::poseidon2_perm_sel) *
+                       (in.get(C::poseidon2_perm_B_43_2) -
+                        (poseidon2_params_MU_2 * poseidon2_perm_A_43_2 + poseidon2_perm_SUM_43));
             tmp *= scaling_factor;
             std::get<179>(evals) += typename Accumulator::View(tmp);
         }
         {
             using Accumulator = typename std::tuple_element_t<180, ContainerOverSubrelations>;
-            auto tmp =
-                new_term.poseidon2_perm_sel * (new_term.poseidon2_perm_B_43_3 -
-                                               (poseidon2_params_MU_3 * poseidon2_perm_A_43_3 + poseidon2_perm_SUM_43));
+            auto tmp = in.get(C::poseidon2_perm_sel) *
+                       (in.get(C::poseidon2_perm_B_43_3) -
+                        (poseidon2_params_MU_3 * poseidon2_perm_A_43_3 + poseidon2_perm_SUM_43));
             tmp *= scaling_factor;
             std::get<180>(evals) += typename Accumulator::View(tmp);
         }
         {
             using Accumulator = typename std::tuple_element_t<181, ContainerOverSubrelations>;
-            auto tmp =
-                new_term.poseidon2_perm_sel * (new_term.poseidon2_perm_B_44_0 -
-                                               (poseidon2_params_MU_0 * poseidon2_perm_A_44_0 + poseidon2_perm_SUM_44));
+            auto tmp = in.get(C::poseidon2_perm_sel) *
+                       (in.get(C::poseidon2_perm_B_44_0) -
+                        (poseidon2_params_MU_0 * poseidon2_perm_A_44_0 + poseidon2_perm_SUM_44));
             tmp *= scaling_factor;
             std::get<181>(evals) += typename Accumulator::View(tmp);
         }
         {
             using Accumulator = typename std::tuple_element_t<182, ContainerOverSubrelations>;
-            auto tmp =
-                new_term.poseidon2_perm_sel * (new_term.poseidon2_perm_B_44_1 -
-                                               (poseidon2_params_MU_1 * poseidon2_perm_A_44_1 + poseidon2_perm_SUM_44));
+            auto tmp = in.get(C::poseidon2_perm_sel) *
+                       (in.get(C::poseidon2_perm_B_44_1) -
+                        (poseidon2_params_MU_1 * poseidon2_perm_A_44_1 + poseidon2_perm_SUM_44));
             tmp *= scaling_factor;
             std::get<182>(evals) += typename Accumulator::View(tmp);
         }
         {
             using Accumulator = typename std::tuple_element_t<183, ContainerOverSubrelations>;
-            auto tmp =
-                new_term.poseidon2_perm_sel * (new_term.poseidon2_perm_B_44_2 -
-                                               (poseidon2_params_MU_2 * poseidon2_perm_A_44_2 + poseidon2_perm_SUM_44));
+            auto tmp = in.get(C::poseidon2_perm_sel) *
+                       (in.get(C::poseidon2_perm_B_44_2) -
+                        (poseidon2_params_MU_2 * poseidon2_perm_A_44_2 + poseidon2_perm_SUM_44));
             tmp *= scaling_factor;
             std::get<183>(evals) += typename Accumulator::View(tmp);
         }
         {
             using Accumulator = typename std::tuple_element_t<184, ContainerOverSubrelations>;
-            auto tmp =
-                new_term.poseidon2_perm_sel * (new_term.poseidon2_perm_B_44_3 -
-                                               (poseidon2_params_MU_3 * poseidon2_perm_A_44_3 + poseidon2_perm_SUM_44));
+            auto tmp = in.get(C::poseidon2_perm_sel) *
+                       (in.get(C::poseidon2_perm_B_44_3) -
+                        (poseidon2_params_MU_3 * poseidon2_perm_A_44_3 + poseidon2_perm_SUM_44));
             tmp *= scaling_factor;
             std::get<184>(evals) += typename Accumulator::View(tmp);
         }
         {
             using Accumulator = typename std::tuple_element_t<185, ContainerOverSubrelations>;
-            auto tmp =
-                new_term.poseidon2_perm_sel * (new_term.poseidon2_perm_B_45_0 -
-                                               (poseidon2_params_MU_0 * poseidon2_perm_A_45_0 + poseidon2_perm_SUM_45));
+            auto tmp = in.get(C::poseidon2_perm_sel) *
+                       (in.get(C::poseidon2_perm_B_45_0) -
+                        (poseidon2_params_MU_0 * poseidon2_perm_A_45_0 + poseidon2_perm_SUM_45));
             tmp *= scaling_factor;
             std::get<185>(evals) += typename Accumulator::View(tmp);
         }
         {
             using Accumulator = typename std::tuple_element_t<186, ContainerOverSubrelations>;
-            auto tmp =
-                new_term.poseidon2_perm_sel * (new_term.poseidon2_perm_B_45_1 -
-                                               (poseidon2_params_MU_1 * poseidon2_perm_A_45_1 + poseidon2_perm_SUM_45));
+            auto tmp = in.get(C::poseidon2_perm_sel) *
+                       (in.get(C::poseidon2_perm_B_45_1) -
+                        (poseidon2_params_MU_1 * poseidon2_perm_A_45_1 + poseidon2_perm_SUM_45));
             tmp *= scaling_factor;
             std::get<186>(evals) += typename Accumulator::View(tmp);
         }
         {
             using Accumulator = typename std::tuple_element_t<187, ContainerOverSubrelations>;
-            auto tmp =
-                new_term.poseidon2_perm_sel * (new_term.poseidon2_perm_B_45_2 -
-                                               (poseidon2_params_MU_2 * poseidon2_perm_A_45_2 + poseidon2_perm_SUM_45));
+            auto tmp = in.get(C::poseidon2_perm_sel) *
+                       (in.get(C::poseidon2_perm_B_45_2) -
+                        (poseidon2_params_MU_2 * poseidon2_perm_A_45_2 + poseidon2_perm_SUM_45));
             tmp *= scaling_factor;
             std::get<187>(evals) += typename Accumulator::View(tmp);
         }
         {
             using Accumulator = typename std::tuple_element_t<188, ContainerOverSubrelations>;
-            auto tmp =
-                new_term.poseidon2_perm_sel * (new_term.poseidon2_perm_B_45_3 -
-                                               (poseidon2_params_MU_3 * poseidon2_perm_A_45_3 + poseidon2_perm_SUM_45));
+            auto tmp = in.get(C::poseidon2_perm_sel) *
+                       (in.get(C::poseidon2_perm_B_45_3) -
+                        (poseidon2_params_MU_3 * poseidon2_perm_A_45_3 + poseidon2_perm_SUM_45));
             tmp *= scaling_factor;
             std::get<188>(evals) += typename Accumulator::View(tmp);
         }
         {
             using Accumulator = typename std::tuple_element_t<189, ContainerOverSubrelations>;
-            auto tmp =
-                new_term.poseidon2_perm_sel * (new_term.poseidon2_perm_B_46_0 -
-                                               (poseidon2_params_MU_0 * poseidon2_perm_A_46_0 + poseidon2_perm_SUM_46));
+            auto tmp = in.get(C::poseidon2_perm_sel) *
+                       (in.get(C::poseidon2_perm_B_46_0) -
+                        (poseidon2_params_MU_0 * poseidon2_perm_A_46_0 + poseidon2_perm_SUM_46));
             tmp *= scaling_factor;
             std::get<189>(evals) += typename Accumulator::View(tmp);
         }
         {
             using Accumulator = typename std::tuple_element_t<190, ContainerOverSubrelations>;
-            auto tmp =
-                new_term.poseidon2_perm_sel * (new_term.poseidon2_perm_B_46_1 -
-                                               (poseidon2_params_MU_1 * poseidon2_perm_A_46_1 + poseidon2_perm_SUM_46));
+            auto tmp = in.get(C::poseidon2_perm_sel) *
+                       (in.get(C::poseidon2_perm_B_46_1) -
+                        (poseidon2_params_MU_1 * poseidon2_perm_A_46_1 + poseidon2_perm_SUM_46));
             tmp *= scaling_factor;
             std::get<190>(evals) += typename Accumulator::View(tmp);
         }
         {
             using Accumulator = typename std::tuple_element_t<191, ContainerOverSubrelations>;
-            auto tmp =
-                new_term.poseidon2_perm_sel * (new_term.poseidon2_perm_B_46_2 -
-                                               (poseidon2_params_MU_2 * poseidon2_perm_A_46_2 + poseidon2_perm_SUM_46));
+            auto tmp = in.get(C::poseidon2_perm_sel) *
+                       (in.get(C::poseidon2_perm_B_46_2) -
+                        (poseidon2_params_MU_2 * poseidon2_perm_A_46_2 + poseidon2_perm_SUM_46));
             tmp *= scaling_factor;
             std::get<191>(evals) += typename Accumulator::View(tmp);
         }
         {
             using Accumulator = typename std::tuple_element_t<192, ContainerOverSubrelations>;
-            auto tmp =
-                new_term.poseidon2_perm_sel * (new_term.poseidon2_perm_B_46_3 -
-                                               (poseidon2_params_MU_3 * poseidon2_perm_A_46_3 + poseidon2_perm_SUM_46));
+            auto tmp = in.get(C::poseidon2_perm_sel) *
+                       (in.get(C::poseidon2_perm_B_46_3) -
+                        (poseidon2_params_MU_3 * poseidon2_perm_A_46_3 + poseidon2_perm_SUM_46));
             tmp *= scaling_factor;
             std::get<192>(evals) += typename Accumulator::View(tmp);
         }
         {
             using Accumulator = typename std::tuple_element_t<193, ContainerOverSubrelations>;
-            auto tmp =
-                new_term.poseidon2_perm_sel * (new_term.poseidon2_perm_B_47_0 -
-                                               (poseidon2_params_MU_0 * poseidon2_perm_A_47_0 + poseidon2_perm_SUM_47));
+            auto tmp = in.get(C::poseidon2_perm_sel) *
+                       (in.get(C::poseidon2_perm_B_47_0) -
+                        (poseidon2_params_MU_0 * poseidon2_perm_A_47_0 + poseidon2_perm_SUM_47));
             tmp *= scaling_factor;
             std::get<193>(evals) += typename Accumulator::View(tmp);
         }
         {
             using Accumulator = typename std::tuple_element_t<194, ContainerOverSubrelations>;
-            auto tmp =
-                new_term.poseidon2_perm_sel * (new_term.poseidon2_perm_B_47_1 -
-                                               (poseidon2_params_MU_1 * poseidon2_perm_A_47_1 + poseidon2_perm_SUM_47));
+            auto tmp = in.get(C::poseidon2_perm_sel) *
+                       (in.get(C::poseidon2_perm_B_47_1) -
+                        (poseidon2_params_MU_1 * poseidon2_perm_A_47_1 + poseidon2_perm_SUM_47));
             tmp *= scaling_factor;
             std::get<194>(evals) += typename Accumulator::View(tmp);
         }
         {
             using Accumulator = typename std::tuple_element_t<195, ContainerOverSubrelations>;
-            auto tmp =
-                new_term.poseidon2_perm_sel * (new_term.poseidon2_perm_B_47_2 -
-                                               (poseidon2_params_MU_2 * poseidon2_perm_A_47_2 + poseidon2_perm_SUM_47));
+            auto tmp = in.get(C::poseidon2_perm_sel) *
+                       (in.get(C::poseidon2_perm_B_47_2) -
+                        (poseidon2_params_MU_2 * poseidon2_perm_A_47_2 + poseidon2_perm_SUM_47));
             tmp *= scaling_factor;
             std::get<195>(evals) += typename Accumulator::View(tmp);
         }
         {
             using Accumulator = typename std::tuple_element_t<196, ContainerOverSubrelations>;
-            auto tmp =
-                new_term.poseidon2_perm_sel * (new_term.poseidon2_perm_B_47_3 -
-                                               (poseidon2_params_MU_3 * poseidon2_perm_A_47_3 + poseidon2_perm_SUM_47));
+            auto tmp = in.get(C::poseidon2_perm_sel) *
+                       (in.get(C::poseidon2_perm_B_47_3) -
+                        (poseidon2_params_MU_3 * poseidon2_perm_A_47_3 + poseidon2_perm_SUM_47));
             tmp *= scaling_factor;
             std::get<196>(evals) += typename Accumulator::View(tmp);
         }
         {
             using Accumulator = typename std::tuple_element_t<197, ContainerOverSubrelations>;
-            auto tmp =
-                new_term.poseidon2_perm_sel * (new_term.poseidon2_perm_B_48_0 -
-                                               (poseidon2_params_MU_0 * poseidon2_perm_A_48_0 + poseidon2_perm_SUM_48));
+            auto tmp = in.get(C::poseidon2_perm_sel) *
+                       (in.get(C::poseidon2_perm_B_48_0) -
+                        (poseidon2_params_MU_0 * poseidon2_perm_A_48_0 + poseidon2_perm_SUM_48));
             tmp *= scaling_factor;
             std::get<197>(evals) += typename Accumulator::View(tmp);
         }
         {
             using Accumulator = typename std::tuple_element_t<198, ContainerOverSubrelations>;
-            auto tmp =
-                new_term.poseidon2_perm_sel * (new_term.poseidon2_perm_B_48_1 -
-                                               (poseidon2_params_MU_1 * poseidon2_perm_A_48_1 + poseidon2_perm_SUM_48));
+            auto tmp = in.get(C::poseidon2_perm_sel) *
+                       (in.get(C::poseidon2_perm_B_48_1) -
+                        (poseidon2_params_MU_1 * poseidon2_perm_A_48_1 + poseidon2_perm_SUM_48));
             tmp *= scaling_factor;
             std::get<198>(evals) += typename Accumulator::View(tmp);
         }
         {
             using Accumulator = typename std::tuple_element_t<199, ContainerOverSubrelations>;
-            auto tmp =
-                new_term.poseidon2_perm_sel * (new_term.poseidon2_perm_B_48_2 -
-                                               (poseidon2_params_MU_2 * poseidon2_perm_A_48_2 + poseidon2_perm_SUM_48));
+            auto tmp = in.get(C::poseidon2_perm_sel) *
+                       (in.get(C::poseidon2_perm_B_48_2) -
+                        (poseidon2_params_MU_2 * poseidon2_perm_A_48_2 + poseidon2_perm_SUM_48));
             tmp *= scaling_factor;
             std::get<199>(evals) += typename Accumulator::View(tmp);
         }
         {
             using Accumulator = typename std::tuple_element_t<200, ContainerOverSubrelations>;
-            auto tmp =
-                new_term.poseidon2_perm_sel * (new_term.poseidon2_perm_B_48_3 -
-                                               (poseidon2_params_MU_3 * poseidon2_perm_A_48_3 + poseidon2_perm_SUM_48));
+            auto tmp = in.get(C::poseidon2_perm_sel) *
+                       (in.get(C::poseidon2_perm_B_48_3) -
+                        (poseidon2_params_MU_3 * poseidon2_perm_A_48_3 + poseidon2_perm_SUM_48));
             tmp *= scaling_factor;
             std::get<200>(evals) += typename Accumulator::View(tmp);
         }
         {
             using Accumulator = typename std::tuple_element_t<201, ContainerOverSubrelations>;
-            auto tmp =
-                new_term.poseidon2_perm_sel * (new_term.poseidon2_perm_B_49_0 -
-                                               (poseidon2_params_MU_0 * poseidon2_perm_A_49_0 + poseidon2_perm_SUM_49));
+            auto tmp = in.get(C::poseidon2_perm_sel) *
+                       (in.get(C::poseidon2_perm_B_49_0) -
+                        (poseidon2_params_MU_0 * poseidon2_perm_A_49_0 + poseidon2_perm_SUM_49));
             tmp *= scaling_factor;
             std::get<201>(evals) += typename Accumulator::View(tmp);
         }
         {
             using Accumulator = typename std::tuple_element_t<202, ContainerOverSubrelations>;
-            auto tmp =
-                new_term.poseidon2_perm_sel * (new_term.poseidon2_perm_B_49_1 -
-                                               (poseidon2_params_MU_1 * poseidon2_perm_A_49_1 + poseidon2_perm_SUM_49));
+            auto tmp = in.get(C::poseidon2_perm_sel) *
+                       (in.get(C::poseidon2_perm_B_49_1) -
+                        (poseidon2_params_MU_1 * poseidon2_perm_A_49_1 + poseidon2_perm_SUM_49));
             tmp *= scaling_factor;
             std::get<202>(evals) += typename Accumulator::View(tmp);
         }
         {
             using Accumulator = typename std::tuple_element_t<203, ContainerOverSubrelations>;
-            auto tmp =
-                new_term.poseidon2_perm_sel * (new_term.poseidon2_perm_B_49_2 -
-                                               (poseidon2_params_MU_2 * poseidon2_perm_A_49_2 + poseidon2_perm_SUM_49));
+            auto tmp = in.get(C::poseidon2_perm_sel) *
+                       (in.get(C::poseidon2_perm_B_49_2) -
+                        (poseidon2_params_MU_2 * poseidon2_perm_A_49_2 + poseidon2_perm_SUM_49));
             tmp *= scaling_factor;
             std::get<203>(evals) += typename Accumulator::View(tmp);
         }
         {
             using Accumulator = typename std::tuple_element_t<204, ContainerOverSubrelations>;
-            auto tmp =
-                new_term.poseidon2_perm_sel * (new_term.poseidon2_perm_B_49_3 -
-                                               (poseidon2_params_MU_3 * poseidon2_perm_A_49_3 + poseidon2_perm_SUM_49));
+            auto tmp = in.get(C::poseidon2_perm_sel) *
+                       (in.get(C::poseidon2_perm_B_49_3) -
+                        (poseidon2_params_MU_3 * poseidon2_perm_A_49_3 + poseidon2_perm_SUM_49));
             tmp *= scaling_factor;
             std::get<204>(evals) += typename Accumulator::View(tmp);
         }
         {
             using Accumulator = typename std::tuple_element_t<205, ContainerOverSubrelations>;
-            auto tmp =
-                new_term.poseidon2_perm_sel * (new_term.poseidon2_perm_B_50_0 -
-                                               (poseidon2_params_MU_0 * poseidon2_perm_A_50_0 + poseidon2_perm_SUM_50));
+            auto tmp = in.get(C::poseidon2_perm_sel) *
+                       (in.get(C::poseidon2_perm_B_50_0) -
+                        (poseidon2_params_MU_0 * poseidon2_perm_A_50_0 + poseidon2_perm_SUM_50));
             tmp *= scaling_factor;
             std::get<205>(evals) += typename Accumulator::View(tmp);
         }
         {
             using Accumulator = typename std::tuple_element_t<206, ContainerOverSubrelations>;
-            auto tmp =
-                new_term.poseidon2_perm_sel * (new_term.poseidon2_perm_B_50_1 -
-                                               (poseidon2_params_MU_1 * poseidon2_perm_A_50_1 + poseidon2_perm_SUM_50));
+            auto tmp = in.get(C::poseidon2_perm_sel) *
+                       (in.get(C::poseidon2_perm_B_50_1) -
+                        (poseidon2_params_MU_1 * poseidon2_perm_A_50_1 + poseidon2_perm_SUM_50));
             tmp *= scaling_factor;
             std::get<206>(evals) += typename Accumulator::View(tmp);
         }
         {
             using Accumulator = typename std::tuple_element_t<207, ContainerOverSubrelations>;
-            auto tmp =
-                new_term.poseidon2_perm_sel * (new_term.poseidon2_perm_B_50_2 -
-                                               (poseidon2_params_MU_2 * poseidon2_perm_A_50_2 + poseidon2_perm_SUM_50));
+            auto tmp = in.get(C::poseidon2_perm_sel) *
+                       (in.get(C::poseidon2_perm_B_50_2) -
+                        (poseidon2_params_MU_2 * poseidon2_perm_A_50_2 + poseidon2_perm_SUM_50));
             tmp *= scaling_factor;
             std::get<207>(evals) += typename Accumulator::View(tmp);
         }
         {
             using Accumulator = typename std::tuple_element_t<208, ContainerOverSubrelations>;
-            auto tmp =
-                new_term.poseidon2_perm_sel * (new_term.poseidon2_perm_B_50_3 -
-                                               (poseidon2_params_MU_3 * poseidon2_perm_A_50_3 + poseidon2_perm_SUM_50));
+            auto tmp = in.get(C::poseidon2_perm_sel) *
+                       (in.get(C::poseidon2_perm_B_50_3) -
+                        (poseidon2_params_MU_3 * poseidon2_perm_A_50_3 + poseidon2_perm_SUM_50));
             tmp *= scaling_factor;
             std::get<208>(evals) += typename Accumulator::View(tmp);
         }
         {
             using Accumulator = typename std::tuple_element_t<209, ContainerOverSubrelations>;
-            auto tmp =
-                new_term.poseidon2_perm_sel * (new_term.poseidon2_perm_B_51_0 -
-                                               (poseidon2_params_MU_0 * poseidon2_perm_A_51_0 + poseidon2_perm_SUM_51));
+            auto tmp = in.get(C::poseidon2_perm_sel) *
+                       (in.get(C::poseidon2_perm_B_51_0) -
+                        (poseidon2_params_MU_0 * poseidon2_perm_A_51_0 + poseidon2_perm_SUM_51));
             tmp *= scaling_factor;
             std::get<209>(evals) += typename Accumulator::View(tmp);
         }
         {
             using Accumulator = typename std::tuple_element_t<210, ContainerOverSubrelations>;
-            auto tmp =
-                new_term.poseidon2_perm_sel * (new_term.poseidon2_perm_B_51_1 -
-                                               (poseidon2_params_MU_1 * poseidon2_perm_A_51_1 + poseidon2_perm_SUM_51));
+            auto tmp = in.get(C::poseidon2_perm_sel) *
+                       (in.get(C::poseidon2_perm_B_51_1) -
+                        (poseidon2_params_MU_1 * poseidon2_perm_A_51_1 + poseidon2_perm_SUM_51));
             tmp *= scaling_factor;
             std::get<210>(evals) += typename Accumulator::View(tmp);
         }
         {
             using Accumulator = typename std::tuple_element_t<211, ContainerOverSubrelations>;
-            auto tmp =
-                new_term.poseidon2_perm_sel * (new_term.poseidon2_perm_B_51_2 -
-                                               (poseidon2_params_MU_2 * poseidon2_perm_A_51_2 + poseidon2_perm_SUM_51));
+            auto tmp = in.get(C::poseidon2_perm_sel) *
+                       (in.get(C::poseidon2_perm_B_51_2) -
+                        (poseidon2_params_MU_2 * poseidon2_perm_A_51_2 + poseidon2_perm_SUM_51));
             tmp *= scaling_factor;
             std::get<211>(evals) += typename Accumulator::View(tmp);
         }
         {
             using Accumulator = typename std::tuple_element_t<212, ContainerOverSubrelations>;
-            auto tmp =
-                new_term.poseidon2_perm_sel * (new_term.poseidon2_perm_B_51_3 -
-                                               (poseidon2_params_MU_3 * poseidon2_perm_A_51_3 + poseidon2_perm_SUM_51));
+            auto tmp = in.get(C::poseidon2_perm_sel) *
+                       (in.get(C::poseidon2_perm_B_51_3) -
+                        (poseidon2_params_MU_3 * poseidon2_perm_A_51_3 + poseidon2_perm_SUM_51));
             tmp *= scaling_factor;
             std::get<212>(evals) += typename Accumulator::View(tmp);
         }
         {
             using Accumulator = typename std::tuple_element_t<213, ContainerOverSubrelations>;
-            auto tmp =
-                new_term.poseidon2_perm_sel * (new_term.poseidon2_perm_B_52_0 -
-                                               (poseidon2_params_MU_0 * poseidon2_perm_A_52_0 + poseidon2_perm_SUM_52));
+            auto tmp = in.get(C::poseidon2_perm_sel) *
+                       (in.get(C::poseidon2_perm_B_52_0) -
+                        (poseidon2_params_MU_0 * poseidon2_perm_A_52_0 + poseidon2_perm_SUM_52));
             tmp *= scaling_factor;
             std::get<213>(evals) += typename Accumulator::View(tmp);
         }
         {
             using Accumulator = typename std::tuple_element_t<214, ContainerOverSubrelations>;
-            auto tmp =
-                new_term.poseidon2_perm_sel * (new_term.poseidon2_perm_B_52_1 -
-                                               (poseidon2_params_MU_1 * poseidon2_perm_A_52_1 + poseidon2_perm_SUM_52));
+            auto tmp = in.get(C::poseidon2_perm_sel) *
+                       (in.get(C::poseidon2_perm_B_52_1) -
+                        (poseidon2_params_MU_1 * poseidon2_perm_A_52_1 + poseidon2_perm_SUM_52));
             tmp *= scaling_factor;
             std::get<214>(evals) += typename Accumulator::View(tmp);
         }
         {
             using Accumulator = typename std::tuple_element_t<215, ContainerOverSubrelations>;
-            auto tmp =
-                new_term.poseidon2_perm_sel * (new_term.poseidon2_perm_B_52_2 -
-                                               (poseidon2_params_MU_2 * poseidon2_perm_A_52_2 + poseidon2_perm_SUM_52));
+            auto tmp = in.get(C::poseidon2_perm_sel) *
+                       (in.get(C::poseidon2_perm_B_52_2) -
+                        (poseidon2_params_MU_2 * poseidon2_perm_A_52_2 + poseidon2_perm_SUM_52));
             tmp *= scaling_factor;
             std::get<215>(evals) += typename Accumulator::View(tmp);
         }
         {
             using Accumulator = typename std::tuple_element_t<216, ContainerOverSubrelations>;
-            auto tmp =
-                new_term.poseidon2_perm_sel * (new_term.poseidon2_perm_B_52_3 -
-                                               (poseidon2_params_MU_3 * poseidon2_perm_A_52_3 + poseidon2_perm_SUM_52));
+            auto tmp = in.get(C::poseidon2_perm_sel) *
+                       (in.get(C::poseidon2_perm_B_52_3) -
+                        (poseidon2_params_MU_3 * poseidon2_perm_A_52_3 + poseidon2_perm_SUM_52));
             tmp *= scaling_factor;
             std::get<216>(evals) += typename Accumulator::View(tmp);
         }
         {
             using Accumulator = typename std::tuple_element_t<217, ContainerOverSubrelations>;
-            auto tmp =
-                new_term.poseidon2_perm_sel * (new_term.poseidon2_perm_B_53_0 -
-                                               (poseidon2_params_MU_0 * poseidon2_perm_A_53_0 + poseidon2_perm_SUM_53));
+            auto tmp = in.get(C::poseidon2_perm_sel) *
+                       (in.get(C::poseidon2_perm_B_53_0) -
+                        (poseidon2_params_MU_0 * poseidon2_perm_A_53_0 + poseidon2_perm_SUM_53));
             tmp *= scaling_factor;
             std::get<217>(evals) += typename Accumulator::View(tmp);
         }
         {
             using Accumulator = typename std::tuple_element_t<218, ContainerOverSubrelations>;
-            auto tmp =
-                new_term.poseidon2_perm_sel * (new_term.poseidon2_perm_B_53_1 -
-                                               (poseidon2_params_MU_1 * poseidon2_perm_A_53_1 + poseidon2_perm_SUM_53));
+            auto tmp = in.get(C::poseidon2_perm_sel) *
+                       (in.get(C::poseidon2_perm_B_53_1) -
+                        (poseidon2_params_MU_1 * poseidon2_perm_A_53_1 + poseidon2_perm_SUM_53));
             tmp *= scaling_factor;
             std::get<218>(evals) += typename Accumulator::View(tmp);
         }
         {
             using Accumulator = typename std::tuple_element_t<219, ContainerOverSubrelations>;
-            auto tmp =
-                new_term.poseidon2_perm_sel * (new_term.poseidon2_perm_B_53_2 -
-                                               (poseidon2_params_MU_2 * poseidon2_perm_A_53_2 + poseidon2_perm_SUM_53));
+            auto tmp = in.get(C::poseidon2_perm_sel) *
+                       (in.get(C::poseidon2_perm_B_53_2) -
+                        (poseidon2_params_MU_2 * poseidon2_perm_A_53_2 + poseidon2_perm_SUM_53));
             tmp *= scaling_factor;
             std::get<219>(evals) += typename Accumulator::View(tmp);
         }
         {
             using Accumulator = typename std::tuple_element_t<220, ContainerOverSubrelations>;
-            auto tmp =
-                new_term.poseidon2_perm_sel * (new_term.poseidon2_perm_B_53_3 -
-                                               (poseidon2_params_MU_3 * poseidon2_perm_A_53_3 + poseidon2_perm_SUM_53));
+            auto tmp = in.get(C::poseidon2_perm_sel) *
+                       (in.get(C::poseidon2_perm_B_53_3) -
+                        (poseidon2_params_MU_3 * poseidon2_perm_A_53_3 + poseidon2_perm_SUM_53));
             tmp *= scaling_factor;
             std::get<220>(evals) += typename Accumulator::View(tmp);
         }
         {
             using Accumulator = typename std::tuple_element_t<221, ContainerOverSubrelations>;
-            auto tmp =
-                new_term.poseidon2_perm_sel * (new_term.poseidon2_perm_B_54_0 -
-                                               (poseidon2_params_MU_0 * poseidon2_perm_A_54_0 + poseidon2_perm_SUM_54));
+            auto tmp = in.get(C::poseidon2_perm_sel) *
+                       (in.get(C::poseidon2_perm_B_54_0) -
+                        (poseidon2_params_MU_0 * poseidon2_perm_A_54_0 + poseidon2_perm_SUM_54));
             tmp *= scaling_factor;
             std::get<221>(evals) += typename Accumulator::View(tmp);
         }
         {
             using Accumulator = typename std::tuple_element_t<222, ContainerOverSubrelations>;
-            auto tmp =
-                new_term.poseidon2_perm_sel * (new_term.poseidon2_perm_B_54_1 -
-                                               (poseidon2_params_MU_1 * poseidon2_perm_A_54_1 + poseidon2_perm_SUM_54));
+            auto tmp = in.get(C::poseidon2_perm_sel) *
+                       (in.get(C::poseidon2_perm_B_54_1) -
+                        (poseidon2_params_MU_1 * poseidon2_perm_A_54_1 + poseidon2_perm_SUM_54));
             tmp *= scaling_factor;
             std::get<222>(evals) += typename Accumulator::View(tmp);
         }
         {
             using Accumulator = typename std::tuple_element_t<223, ContainerOverSubrelations>;
-            auto tmp =
-                new_term.poseidon2_perm_sel * (new_term.poseidon2_perm_B_54_2 -
-                                               (poseidon2_params_MU_2 * poseidon2_perm_A_54_2 + poseidon2_perm_SUM_54));
+            auto tmp = in.get(C::poseidon2_perm_sel) *
+                       (in.get(C::poseidon2_perm_B_54_2) -
+                        (poseidon2_params_MU_2 * poseidon2_perm_A_54_2 + poseidon2_perm_SUM_54));
             tmp *= scaling_factor;
             std::get<223>(evals) += typename Accumulator::View(tmp);
         }
         {
             using Accumulator = typename std::tuple_element_t<224, ContainerOverSubrelations>;
-            auto tmp =
-                new_term.poseidon2_perm_sel * (new_term.poseidon2_perm_B_54_3 -
-                                               (poseidon2_params_MU_3 * poseidon2_perm_A_54_3 + poseidon2_perm_SUM_54));
+            auto tmp = in.get(C::poseidon2_perm_sel) *
+                       (in.get(C::poseidon2_perm_B_54_3) -
+                        (poseidon2_params_MU_3 * poseidon2_perm_A_54_3 + poseidon2_perm_SUM_54));
             tmp *= scaling_factor;
             std::get<224>(evals) += typename Accumulator::View(tmp);
         }
         {
             using Accumulator = typename std::tuple_element_t<225, ContainerOverSubrelations>;
-            auto tmp =
-                new_term.poseidon2_perm_sel * (new_term.poseidon2_perm_B_55_0 -
-                                               (poseidon2_params_MU_0 * poseidon2_perm_A_55_0 + poseidon2_perm_SUM_55));
+            auto tmp = in.get(C::poseidon2_perm_sel) *
+                       (in.get(C::poseidon2_perm_B_55_0) -
+                        (poseidon2_params_MU_0 * poseidon2_perm_A_55_0 + poseidon2_perm_SUM_55));
             tmp *= scaling_factor;
             std::get<225>(evals) += typename Accumulator::View(tmp);
         }
         {
             using Accumulator = typename std::tuple_element_t<226, ContainerOverSubrelations>;
-            auto tmp =
-                new_term.poseidon2_perm_sel * (new_term.poseidon2_perm_B_55_1 -
-                                               (poseidon2_params_MU_1 * poseidon2_perm_A_55_1 + poseidon2_perm_SUM_55));
+            auto tmp = in.get(C::poseidon2_perm_sel) *
+                       (in.get(C::poseidon2_perm_B_55_1) -
+                        (poseidon2_params_MU_1 * poseidon2_perm_A_55_1 + poseidon2_perm_SUM_55));
             tmp *= scaling_factor;
             std::get<226>(evals) += typename Accumulator::View(tmp);
         }
         {
             using Accumulator = typename std::tuple_element_t<227, ContainerOverSubrelations>;
-            auto tmp =
-                new_term.poseidon2_perm_sel * (new_term.poseidon2_perm_B_55_2 -
-                                               (poseidon2_params_MU_2 * poseidon2_perm_A_55_2 + poseidon2_perm_SUM_55));
+            auto tmp = in.get(C::poseidon2_perm_sel) *
+                       (in.get(C::poseidon2_perm_B_55_2) -
+                        (poseidon2_params_MU_2 * poseidon2_perm_A_55_2 + poseidon2_perm_SUM_55));
             tmp *= scaling_factor;
             std::get<227>(evals) += typename Accumulator::View(tmp);
         }
         {
             using Accumulator = typename std::tuple_element_t<228, ContainerOverSubrelations>;
-            auto tmp =
-                new_term.poseidon2_perm_sel * (new_term.poseidon2_perm_B_55_3 -
-                                               (poseidon2_params_MU_3 * poseidon2_perm_A_55_3 + poseidon2_perm_SUM_55));
+            auto tmp = in.get(C::poseidon2_perm_sel) *
+                       (in.get(C::poseidon2_perm_B_55_3) -
+                        (poseidon2_params_MU_3 * poseidon2_perm_A_55_3 + poseidon2_perm_SUM_55));
             tmp *= scaling_factor;
             std::get<228>(evals) += typename Accumulator::View(tmp);
         }
         {
             using Accumulator = typename std::tuple_element_t<229, ContainerOverSubrelations>;
-            auto tmp =
-                new_term.poseidon2_perm_sel * (new_term.poseidon2_perm_B_56_0 -
-                                               (poseidon2_params_MU_0 * poseidon2_perm_A_56_0 + poseidon2_perm_SUM_56));
+            auto tmp = in.get(C::poseidon2_perm_sel) *
+                       (in.get(C::poseidon2_perm_B_56_0) -
+                        (poseidon2_params_MU_0 * poseidon2_perm_A_56_0 + poseidon2_perm_SUM_56));
             tmp *= scaling_factor;
             std::get<229>(evals) += typename Accumulator::View(tmp);
         }
         {
             using Accumulator = typename std::tuple_element_t<230, ContainerOverSubrelations>;
-            auto tmp =
-                new_term.poseidon2_perm_sel * (new_term.poseidon2_perm_B_56_1 -
-                                               (poseidon2_params_MU_1 * poseidon2_perm_A_56_1 + poseidon2_perm_SUM_56));
+            auto tmp = in.get(C::poseidon2_perm_sel) *
+                       (in.get(C::poseidon2_perm_B_56_1) -
+                        (poseidon2_params_MU_1 * poseidon2_perm_A_56_1 + poseidon2_perm_SUM_56));
             tmp *= scaling_factor;
             std::get<230>(evals) += typename Accumulator::View(tmp);
         }
         {
             using Accumulator = typename std::tuple_element_t<231, ContainerOverSubrelations>;
-            auto tmp =
-                new_term.poseidon2_perm_sel * (new_term.poseidon2_perm_B_56_2 -
-                                               (poseidon2_params_MU_2 * poseidon2_perm_A_56_2 + poseidon2_perm_SUM_56));
+            auto tmp = in.get(C::poseidon2_perm_sel) *
+                       (in.get(C::poseidon2_perm_B_56_2) -
+                        (poseidon2_params_MU_2 * poseidon2_perm_A_56_2 + poseidon2_perm_SUM_56));
             tmp *= scaling_factor;
             std::get<231>(evals) += typename Accumulator::View(tmp);
         }
         {
             using Accumulator = typename std::tuple_element_t<232, ContainerOverSubrelations>;
-            auto tmp =
-                new_term.poseidon2_perm_sel * (new_term.poseidon2_perm_B_56_3 -
-                                               (poseidon2_params_MU_3 * poseidon2_perm_A_56_3 + poseidon2_perm_SUM_56));
+            auto tmp = in.get(C::poseidon2_perm_sel) *
+                       (in.get(C::poseidon2_perm_B_56_3) -
+                        (poseidon2_params_MU_3 * poseidon2_perm_A_56_3 + poseidon2_perm_SUM_56));
             tmp *= scaling_factor;
             std::get<232>(evals) += typename Accumulator::View(tmp);
         }
         {
             using Accumulator = typename std::tuple_element_t<233, ContainerOverSubrelations>;
-            auto tmp =
-                new_term.poseidon2_perm_sel * (new_term.poseidon2_perm_B_57_0 -
-                                               (poseidon2_params_MU_0 * poseidon2_perm_A_57_0 + poseidon2_perm_SUM_57));
+            auto tmp = in.get(C::poseidon2_perm_sel) *
+                       (in.get(C::poseidon2_perm_B_57_0) -
+                        (poseidon2_params_MU_0 * poseidon2_perm_A_57_0 + poseidon2_perm_SUM_57));
             tmp *= scaling_factor;
             std::get<233>(evals) += typename Accumulator::View(tmp);
         }
         {
             using Accumulator = typename std::tuple_element_t<234, ContainerOverSubrelations>;
-            auto tmp =
-                new_term.poseidon2_perm_sel * (new_term.poseidon2_perm_B_57_1 -
-                                               (poseidon2_params_MU_1 * poseidon2_perm_A_57_1 + poseidon2_perm_SUM_57));
+            auto tmp = in.get(C::poseidon2_perm_sel) *
+                       (in.get(C::poseidon2_perm_B_57_1) -
+                        (poseidon2_params_MU_1 * poseidon2_perm_A_57_1 + poseidon2_perm_SUM_57));
             tmp *= scaling_factor;
             std::get<234>(evals) += typename Accumulator::View(tmp);
         }
         {
             using Accumulator = typename std::tuple_element_t<235, ContainerOverSubrelations>;
-            auto tmp =
-                new_term.poseidon2_perm_sel * (new_term.poseidon2_perm_B_57_2 -
-                                               (poseidon2_params_MU_2 * poseidon2_perm_A_57_2 + poseidon2_perm_SUM_57));
+            auto tmp = in.get(C::poseidon2_perm_sel) *
+                       (in.get(C::poseidon2_perm_B_57_2) -
+                        (poseidon2_params_MU_2 * poseidon2_perm_A_57_2 + poseidon2_perm_SUM_57));
             tmp *= scaling_factor;
             std::get<235>(evals) += typename Accumulator::View(tmp);
         }
         {
             using Accumulator = typename std::tuple_element_t<236, ContainerOverSubrelations>;
-            auto tmp =
-                new_term.poseidon2_perm_sel * (new_term.poseidon2_perm_B_57_3 -
-                                               (poseidon2_params_MU_3 * poseidon2_perm_A_57_3 + poseidon2_perm_SUM_57));
+            auto tmp = in.get(C::poseidon2_perm_sel) *
+                       (in.get(C::poseidon2_perm_B_57_3) -
+                        (poseidon2_params_MU_3 * poseidon2_perm_A_57_3 + poseidon2_perm_SUM_57));
             tmp *= scaling_factor;
             std::get<236>(evals) += typename Accumulator::View(tmp);
         }
         {
             using Accumulator = typename std::tuple_element_t<237, ContainerOverSubrelations>;
-            auto tmp =
-                new_term.poseidon2_perm_sel * (new_term.poseidon2_perm_B_58_0 -
-                                               (poseidon2_params_MU_0 * poseidon2_perm_A_58_0 + poseidon2_perm_SUM_58));
+            auto tmp = in.get(C::poseidon2_perm_sel) *
+                       (in.get(C::poseidon2_perm_B_58_0) -
+                        (poseidon2_params_MU_0 * poseidon2_perm_A_58_0 + poseidon2_perm_SUM_58));
             tmp *= scaling_factor;
             std::get<237>(evals) += typename Accumulator::View(tmp);
         }
         {
             using Accumulator = typename std::tuple_element_t<238, ContainerOverSubrelations>;
-            auto tmp =
-                new_term.poseidon2_perm_sel * (new_term.poseidon2_perm_B_58_1 -
-                                               (poseidon2_params_MU_1 * poseidon2_perm_A_58_1 + poseidon2_perm_SUM_58));
+            auto tmp = in.get(C::poseidon2_perm_sel) *
+                       (in.get(C::poseidon2_perm_B_58_1) -
+                        (poseidon2_params_MU_1 * poseidon2_perm_A_58_1 + poseidon2_perm_SUM_58));
             tmp *= scaling_factor;
             std::get<238>(evals) += typename Accumulator::View(tmp);
         }
         {
             using Accumulator = typename std::tuple_element_t<239, ContainerOverSubrelations>;
-            auto tmp =
-                new_term.poseidon2_perm_sel * (new_term.poseidon2_perm_B_58_2 -
-                                               (poseidon2_params_MU_2 * poseidon2_perm_A_58_2 + poseidon2_perm_SUM_58));
+            auto tmp = in.get(C::poseidon2_perm_sel) *
+                       (in.get(C::poseidon2_perm_B_58_2) -
+                        (poseidon2_params_MU_2 * poseidon2_perm_A_58_2 + poseidon2_perm_SUM_58));
             tmp *= scaling_factor;
             std::get<239>(evals) += typename Accumulator::View(tmp);
         }
         {
             using Accumulator = typename std::tuple_element_t<240, ContainerOverSubrelations>;
-            auto tmp =
-                new_term.poseidon2_perm_sel * (new_term.poseidon2_perm_B_58_3 -
-                                               (poseidon2_params_MU_3 * poseidon2_perm_A_58_3 + poseidon2_perm_SUM_58));
+            auto tmp = in.get(C::poseidon2_perm_sel) *
+                       (in.get(C::poseidon2_perm_B_58_3) -
+                        (poseidon2_params_MU_3 * poseidon2_perm_A_58_3 + poseidon2_perm_SUM_58));
             tmp *= scaling_factor;
             std::get<240>(evals) += typename Accumulator::View(tmp);
         }
         {
             using Accumulator = typename std::tuple_element_t<241, ContainerOverSubrelations>;
-            auto tmp =
-                new_term.poseidon2_perm_sel * (new_term.poseidon2_perm_B_59_0 -
-                                               (poseidon2_params_MU_0 * poseidon2_perm_A_59_0 + poseidon2_perm_SUM_59));
+            auto tmp = in.get(C::poseidon2_perm_sel) *
+                       (in.get(C::poseidon2_perm_B_59_0) -
+                        (poseidon2_params_MU_0 * poseidon2_perm_A_59_0 + poseidon2_perm_SUM_59));
             tmp *= scaling_factor;
             std::get<241>(evals) += typename Accumulator::View(tmp);
         }
         {
             using Accumulator = typename std::tuple_element_t<242, ContainerOverSubrelations>;
-            auto tmp =
-                new_term.poseidon2_perm_sel * (new_term.poseidon2_perm_B_59_1 -
-                                               (poseidon2_params_MU_1 * poseidon2_perm_A_59_1 + poseidon2_perm_SUM_59));
+            auto tmp = in.get(C::poseidon2_perm_sel) *
+                       (in.get(C::poseidon2_perm_B_59_1) -
+                        (poseidon2_params_MU_1 * poseidon2_perm_A_59_1 + poseidon2_perm_SUM_59));
             tmp *= scaling_factor;
             std::get<242>(evals) += typename Accumulator::View(tmp);
         }
         {
             using Accumulator = typename std::tuple_element_t<243, ContainerOverSubrelations>;
-            auto tmp =
-                new_term.poseidon2_perm_sel * (new_term.poseidon2_perm_B_59_2 -
-                                               (poseidon2_params_MU_2 * poseidon2_perm_A_59_2 + poseidon2_perm_SUM_59));
+            auto tmp = in.get(C::poseidon2_perm_sel) *
+                       (in.get(C::poseidon2_perm_B_59_2) -
+                        (poseidon2_params_MU_2 * poseidon2_perm_A_59_2 + poseidon2_perm_SUM_59));
             tmp *= scaling_factor;
             std::get<243>(evals) += typename Accumulator::View(tmp);
         }
         {
             using Accumulator = typename std::tuple_element_t<244, ContainerOverSubrelations>;
-            auto tmp =
-                new_term.poseidon2_perm_sel * (new_term.poseidon2_perm_B_59_3 -
-                                               (poseidon2_params_MU_3 * poseidon2_perm_A_59_3 + poseidon2_perm_SUM_59));
+            auto tmp = in.get(C::poseidon2_perm_sel) *
+                       (in.get(C::poseidon2_perm_B_59_3) -
+                        (poseidon2_params_MU_3 * poseidon2_perm_A_59_3 + poseidon2_perm_SUM_59));
             tmp *= scaling_factor;
             std::get<244>(evals) += typename Accumulator::View(tmp);
         }
         {
             using Accumulator = typename std::tuple_element_t<245, ContainerOverSubrelations>;
-            auto tmp = new_term.poseidon2_perm_sel *
-                       (new_term.poseidon2_perm_T_60_4 - (FF(4) * poseidon2_perm_T_60_1 + poseidon2_perm_T_60_3));
+            auto tmp = in.get(C::poseidon2_perm_sel) *
+                       (in.get(C::poseidon2_perm_T_60_4) - (FF(4) * poseidon2_perm_T_60_1 + poseidon2_perm_T_60_3));
             tmp *= scaling_factor;
             std::get<245>(evals) += typename Accumulator::View(tmp);
         }
         {
             using Accumulator = typename std::tuple_element_t<246, ContainerOverSubrelations>;
-            auto tmp = new_term.poseidon2_perm_sel *
-                       (new_term.poseidon2_perm_T_60_5 - (FF(4) * poseidon2_perm_T_60_0 + poseidon2_perm_T_60_2));
+            auto tmp = in.get(C::poseidon2_perm_sel) *
+                       (in.get(C::poseidon2_perm_T_60_5) - (FF(4) * poseidon2_perm_T_60_0 + poseidon2_perm_T_60_2));
             tmp *= scaling_factor;
             std::get<246>(evals) += typename Accumulator::View(tmp);
         }
         {
             using Accumulator = typename std::tuple_element_t<247, ContainerOverSubrelations>;
-            auto tmp = new_term.poseidon2_perm_sel *
-                       (new_term.poseidon2_perm_T_60_6 - (poseidon2_perm_T_60_3 + new_term.poseidon2_perm_T_60_5));
+            auto tmp = in.get(C::poseidon2_perm_sel) *
+                       (in.get(C::poseidon2_perm_T_60_6) - (poseidon2_perm_T_60_3 + in.get(C::poseidon2_perm_T_60_5)));
             tmp *= scaling_factor;
             std::get<247>(evals) += typename Accumulator::View(tmp);
         }
         {
             using Accumulator = typename std::tuple_element_t<248, ContainerOverSubrelations>;
-            auto tmp = new_term.poseidon2_perm_sel *
-                       (new_term.poseidon2_perm_T_60_7 - (poseidon2_perm_T_60_2 + new_term.poseidon2_perm_T_60_4));
+            auto tmp = in.get(C::poseidon2_perm_sel) *
+                       (in.get(C::poseidon2_perm_T_60_7) - (poseidon2_perm_T_60_2 + in.get(C::poseidon2_perm_T_60_4)));
             tmp *= scaling_factor;
             std::get<248>(evals) += typename Accumulator::View(tmp);
         }
         {
             using Accumulator = typename std::tuple_element_t<249, ContainerOverSubrelations>;
-            auto tmp = new_term.poseidon2_perm_sel *
-                       (new_term.poseidon2_perm_T_61_4 - (FF(4) * poseidon2_perm_T_61_1 + poseidon2_perm_T_61_3));
+            auto tmp = in.get(C::poseidon2_perm_sel) *
+                       (in.get(C::poseidon2_perm_T_61_4) - (FF(4) * poseidon2_perm_T_61_1 + poseidon2_perm_T_61_3));
             tmp *= scaling_factor;
             std::get<249>(evals) += typename Accumulator::View(tmp);
         }
         {
             using Accumulator = typename std::tuple_element_t<250, ContainerOverSubrelations>;
-            auto tmp = new_term.poseidon2_perm_sel *
-                       (new_term.poseidon2_perm_T_61_5 - (FF(4) * poseidon2_perm_T_61_0 + poseidon2_perm_T_61_2));
+            auto tmp = in.get(C::poseidon2_perm_sel) *
+                       (in.get(C::poseidon2_perm_T_61_5) - (FF(4) * poseidon2_perm_T_61_0 + poseidon2_perm_T_61_2));
             tmp *= scaling_factor;
             std::get<250>(evals) += typename Accumulator::View(tmp);
         }
         {
             using Accumulator = typename std::tuple_element_t<251, ContainerOverSubrelations>;
-            auto tmp = new_term.poseidon2_perm_sel *
-                       (new_term.poseidon2_perm_T_61_6 - (poseidon2_perm_T_61_3 + new_term.poseidon2_perm_T_61_5));
+            auto tmp = in.get(C::poseidon2_perm_sel) *
+                       (in.get(C::poseidon2_perm_T_61_6) - (poseidon2_perm_T_61_3 + in.get(C::poseidon2_perm_T_61_5)));
             tmp *= scaling_factor;
             std::get<251>(evals) += typename Accumulator::View(tmp);
         }
         {
             using Accumulator = typename std::tuple_element_t<252, ContainerOverSubrelations>;
-            auto tmp = new_term.poseidon2_perm_sel *
-                       (new_term.poseidon2_perm_T_61_7 - (poseidon2_perm_T_61_2 + new_term.poseidon2_perm_T_61_4));
+            auto tmp = in.get(C::poseidon2_perm_sel) *
+                       (in.get(C::poseidon2_perm_T_61_7) - (poseidon2_perm_T_61_2 + in.get(C::poseidon2_perm_T_61_4)));
             tmp *= scaling_factor;
             std::get<252>(evals) += typename Accumulator::View(tmp);
         }
         {
             using Accumulator = typename std::tuple_element_t<253, ContainerOverSubrelations>;
-            auto tmp = new_term.poseidon2_perm_sel *
-                       (new_term.poseidon2_perm_T_62_4 - (FF(4) * poseidon2_perm_T_62_1 + poseidon2_perm_T_62_3));
+            auto tmp = in.get(C::poseidon2_perm_sel) *
+                       (in.get(C::poseidon2_perm_T_62_4) - (FF(4) * poseidon2_perm_T_62_1 + poseidon2_perm_T_62_3));
             tmp *= scaling_factor;
             std::get<253>(evals) += typename Accumulator::View(tmp);
         }
         {
             using Accumulator = typename std::tuple_element_t<254, ContainerOverSubrelations>;
-            auto tmp = new_term.poseidon2_perm_sel *
-                       (new_term.poseidon2_perm_T_62_5 - (FF(4) * poseidon2_perm_T_62_0 + poseidon2_perm_T_62_2));
+            auto tmp = in.get(C::poseidon2_perm_sel) *
+                       (in.get(C::poseidon2_perm_T_62_5) - (FF(4) * poseidon2_perm_T_62_0 + poseidon2_perm_T_62_2));
             tmp *= scaling_factor;
             std::get<254>(evals) += typename Accumulator::View(tmp);
         }
         {
             using Accumulator = typename std::tuple_element_t<255, ContainerOverSubrelations>;
-            auto tmp = new_term.poseidon2_perm_sel *
-                       (new_term.poseidon2_perm_T_62_6 - (poseidon2_perm_T_62_3 + new_term.poseidon2_perm_T_62_5));
+            auto tmp = in.get(C::poseidon2_perm_sel) *
+                       (in.get(C::poseidon2_perm_T_62_6) - (poseidon2_perm_T_62_3 + in.get(C::poseidon2_perm_T_62_5)));
             tmp *= scaling_factor;
             std::get<255>(evals) += typename Accumulator::View(tmp);
         }
         {
             using Accumulator = typename std::tuple_element_t<256, ContainerOverSubrelations>;
-            auto tmp = new_term.poseidon2_perm_sel *
-                       (new_term.poseidon2_perm_T_62_7 - (poseidon2_perm_T_62_2 + new_term.poseidon2_perm_T_62_4));
+            auto tmp = in.get(C::poseidon2_perm_sel) *
+                       (in.get(C::poseidon2_perm_T_62_7) - (poseidon2_perm_T_62_2 + in.get(C::poseidon2_perm_T_62_4)));
             tmp *= scaling_factor;
             std::get<256>(evals) += typename Accumulator::View(tmp);
         }
         {
             using Accumulator = typename std::tuple_element_t<257, ContainerOverSubrelations>;
-            auto tmp = new_term.poseidon2_perm_sel *
-                       (new_term.poseidon2_perm_T_63_4 - (FF(4) * poseidon2_perm_T_63_1 + poseidon2_perm_T_63_3));
+            auto tmp = in.get(C::poseidon2_perm_sel) *
+                       (in.get(C::poseidon2_perm_T_63_4) - (FF(4) * poseidon2_perm_T_63_1 + poseidon2_perm_T_63_3));
             tmp *= scaling_factor;
             std::get<257>(evals) += typename Accumulator::View(tmp);
         }
         {
             using Accumulator = typename std::tuple_element_t<258, ContainerOverSubrelations>;
-            auto tmp = new_term.poseidon2_perm_sel *
-                       (new_term.poseidon2_perm_T_63_5 - (FF(4) * poseidon2_perm_T_63_0 + poseidon2_perm_T_63_2));
+            auto tmp = in.get(C::poseidon2_perm_sel) *
+                       (in.get(C::poseidon2_perm_T_63_5) - (FF(4) * poseidon2_perm_T_63_0 + poseidon2_perm_T_63_2));
             tmp *= scaling_factor;
             std::get<258>(evals) += typename Accumulator::View(tmp);
         }
         {
             using Accumulator = typename std::tuple_element_t<259, ContainerOverSubrelations>;
-            auto tmp = new_term.poseidon2_perm_sel *
-                       (new_term.poseidon2_perm_T_63_6 - (poseidon2_perm_T_63_3 + new_term.poseidon2_perm_T_63_5));
+            auto tmp = in.get(C::poseidon2_perm_sel) *
+                       (in.get(C::poseidon2_perm_T_63_6) - (poseidon2_perm_T_63_3 + in.get(C::poseidon2_perm_T_63_5)));
             tmp *= scaling_factor;
             std::get<259>(evals) += typename Accumulator::View(tmp);
         }
         {
             using Accumulator = typename std::tuple_element_t<260, ContainerOverSubrelations>;
-            auto tmp = new_term.poseidon2_perm_sel *
-                       (new_term.poseidon2_perm_T_63_7 - (poseidon2_perm_T_63_2 + new_term.poseidon2_perm_T_63_4));
+            auto tmp = in.get(C::poseidon2_perm_sel) *
+                       (in.get(C::poseidon2_perm_T_63_7) - (poseidon2_perm_T_63_2 + in.get(C::poseidon2_perm_T_63_4)));
             tmp *= scaling_factor;
             std::get<260>(evals) += typename Accumulator::View(tmp);
         }
         {
             using Accumulator = typename std::tuple_element_t<261, ContainerOverSubrelations>;
-            auto tmp = new_term.poseidon2_perm_sel * (new_term.poseidon2_perm_b_0 - new_term.poseidon2_perm_T_63_6);
+            auto tmp =
+                in.get(C::poseidon2_perm_sel) * (in.get(C::poseidon2_perm_b_0) - in.get(C::poseidon2_perm_T_63_6));
             tmp *= scaling_factor;
             std::get<261>(evals) += typename Accumulator::View(tmp);
         }
         {
             using Accumulator = typename std::tuple_element_t<262, ContainerOverSubrelations>;
-            auto tmp = new_term.poseidon2_perm_sel * (new_term.poseidon2_perm_b_1 - new_term.poseidon2_perm_T_63_5);
+            auto tmp =
+                in.get(C::poseidon2_perm_sel) * (in.get(C::poseidon2_perm_b_1) - in.get(C::poseidon2_perm_T_63_5));
             tmp *= scaling_factor;
             std::get<262>(evals) += typename Accumulator::View(tmp);
         }
         {
             using Accumulator = typename std::tuple_element_t<263, ContainerOverSubrelations>;
-            auto tmp = new_term.poseidon2_perm_sel * (new_term.poseidon2_perm_b_2 - new_term.poseidon2_perm_T_63_7);
+            auto tmp =
+                in.get(C::poseidon2_perm_sel) * (in.get(C::poseidon2_perm_b_2) - in.get(C::poseidon2_perm_T_63_7));
             tmp *= scaling_factor;
             std::get<263>(evals) += typename Accumulator::View(tmp);
         }
         {
             using Accumulator = typename std::tuple_element_t<264, ContainerOverSubrelations>;
-            auto tmp = new_term.poseidon2_perm_sel * (new_term.poseidon2_perm_b_3 - new_term.poseidon2_perm_T_63_4);
+            auto tmp =
+                in.get(C::poseidon2_perm_sel) * (in.get(C::poseidon2_perm_b_3) - in.get(C::poseidon2_perm_T_63_4));
             tmp *= scaling_factor;
             std::get<264>(evals) += typename Accumulator::View(tmp);
         }

--- a/barretenberg/cpp/src/barretenberg/vm2/generated/relations/public_data_read.hpp
+++ b/barretenberg/cpp/src/barretenberg/vm2/generated/relations/public_data_read.hpp
@@ -5,6 +5,7 @@
 
 #include "barretenberg/relations/relation_parameters.hpp"
 #include "barretenberg/relations/relation_types.hpp"
+#include "barretenberg/vm2/generated/columns.hpp"
 
 namespace bb::avm2 {
 
@@ -16,79 +17,82 @@ template <typename FF_> class public_data_readImpl {
 
     template <typename AllEntities> inline static bool skip(const AllEntities& in)
     {
-        const auto& new_term = in;
-        return (new_term.public_data_read_sel).is_zero();
+        using C = ColumnAndShifts;
+        return (in.get(C::public_data_read_sel)).is_zero();
     }
 
     template <typename ContainerOverSubrelations, typename AllEntities>
     void static accumulate(ContainerOverSubrelations& evals,
-                           const AllEntities& new_term,
+                           const AllEntities& in,
                            [[maybe_unused]] const RelationParameters<FF>&,
                            [[maybe_unused]] const FF& scaling_factor)
     {
+        using C = ColumnAndShifts;
+
         const auto constants_PUBLIC_DATA_TREE_HEIGHT = FF(40);
-        const auto public_data_read_LEAF_EXISTS = (FF(1) - new_term.public_data_read_leaf_not_exists);
+        const auto public_data_read_LEAF_EXISTS = (FF(1) - in.get(C::public_data_read_leaf_not_exists));
         const auto public_data_read_SLOT_LOW_LEAF_SLOT_DIFF =
-            (new_term.public_data_read_slot - new_term.public_data_read_low_leaf_slot);
-        const auto public_data_read_NEXT_SLOT_IS_ZERO = (FF(1) - new_term.public_data_read_next_slot_is_nonzero);
+            (in.get(C::public_data_read_slot) - in.get(C::public_data_read_low_leaf_slot));
+        const auto public_data_read_NEXT_SLOT_IS_ZERO = (FF(1) - in.get(C::public_data_read_next_slot_is_nonzero));
 
         {
             using Accumulator = typename std::tuple_element_t<0, ContainerOverSubrelations>;
-            auto tmp = new_term.public_data_read_sel * (FF(1) - new_term.public_data_read_sel);
+            auto tmp = in.get(C::public_data_read_sel) * (FF(1) - in.get(C::public_data_read_sel));
             tmp *= scaling_factor;
             std::get<0>(evals) += typename Accumulator::View(tmp);
         }
         {
             using Accumulator = typename std::tuple_element_t<1, ContainerOverSubrelations>;
-            auto tmp = new_term.public_data_read_sel *
-                       (new_term.public_data_read_tree_height - constants_PUBLIC_DATA_TREE_HEIGHT);
+            auto tmp = in.get(C::public_data_read_sel) *
+                       (in.get(C::public_data_read_tree_height) - constants_PUBLIC_DATA_TREE_HEIGHT);
             tmp *= scaling_factor;
             std::get<1>(evals) += typename Accumulator::View(tmp);
         }
         {
             using Accumulator = typename std::tuple_element_t<2, ContainerOverSubrelations>;
-            auto tmp = new_term.public_data_read_leaf_not_exists * (FF(1) - new_term.public_data_read_leaf_not_exists);
+            auto tmp =
+                in.get(C::public_data_read_leaf_not_exists) * (FF(1) - in.get(C::public_data_read_leaf_not_exists));
             tmp *= scaling_factor;
             std::get<2>(evals) += typename Accumulator::View(tmp);
         }
         { // EXISTS_FLAG_CHECK
             using Accumulator = typename std::tuple_element_t<3, ContainerOverSubrelations>;
-            auto tmp =
-                new_term.public_data_read_sel *
-                ((public_data_read_SLOT_LOW_LEAF_SLOT_DIFF *
-                      (public_data_read_LEAF_EXISTS * (FF(1) - new_term.public_data_read_slot_low_leaf_slot_diff_inv) +
-                       new_term.public_data_read_slot_low_leaf_slot_diff_inv) -
-                  FF(1)) +
-                 public_data_read_LEAF_EXISTS);
+            auto tmp = in.get(C::public_data_read_sel) *
+                       ((public_data_read_SLOT_LOW_LEAF_SLOT_DIFF *
+                             (public_data_read_LEAF_EXISTS *
+                                  (FF(1) - in.get(C::public_data_read_slot_low_leaf_slot_diff_inv)) +
+                              in.get(C::public_data_read_slot_low_leaf_slot_diff_inv)) -
+                         FF(1)) +
+                        public_data_read_LEAF_EXISTS);
             tmp *= scaling_factor;
             std::get<3>(evals) += typename Accumulator::View(tmp);
         }
         { // VALUE_IS_CORRECT
             using Accumulator = typename std::tuple_element_t<4, ContainerOverSubrelations>;
-            auto tmp = (new_term.public_data_read_low_leaf_value * public_data_read_LEAF_EXISTS -
-                        new_term.public_data_read_value);
+            auto tmp = (in.get(C::public_data_read_low_leaf_value) * public_data_read_LEAF_EXISTS -
+                        in.get(C::public_data_read_value));
             tmp *= scaling_factor;
             std::get<4>(evals) += typename Accumulator::View(tmp);
         }
         {
             using Accumulator = typename std::tuple_element_t<5, ContainerOverSubrelations>;
-            auto tmp = new_term.public_data_read_sel * (FF(1) - new_term.public_data_read_one);
+            auto tmp = in.get(C::public_data_read_sel) * (FF(1) - in.get(C::public_data_read_one));
             tmp *= scaling_factor;
             std::get<5>(evals) += typename Accumulator::View(tmp);
         }
         {
             using Accumulator = typename std::tuple_element_t<6, ContainerOverSubrelations>;
-            auto tmp = new_term.public_data_read_next_slot_is_nonzero *
-                       (FF(1) - new_term.public_data_read_next_slot_is_nonzero);
+            auto tmp = in.get(C::public_data_read_next_slot_is_nonzero) *
+                       (FF(1) - in.get(C::public_data_read_next_slot_is_nonzero));
             tmp *= scaling_factor;
             std::get<6>(evals) += typename Accumulator::View(tmp);
         }
         { // NEXT_SLOT_IS_ZERO_CHECK
             using Accumulator = typename std::tuple_element_t<7, ContainerOverSubrelations>;
-            auto tmp = new_term.public_data_read_leaf_not_exists *
-                       ((new_term.public_data_read_low_leaf_next_slot *
-                             (public_data_read_NEXT_SLOT_IS_ZERO * (FF(1) - new_term.public_data_read_next_slot_inv) +
-                              new_term.public_data_read_next_slot_inv) -
+            auto tmp = in.get(C::public_data_read_leaf_not_exists) *
+                       ((in.get(C::public_data_read_low_leaf_next_slot) *
+                             (public_data_read_NEXT_SLOT_IS_ZERO * (FF(1) - in.get(C::public_data_read_next_slot_inv)) +
+                              in.get(C::public_data_read_next_slot_inv)) -
                          FF(1)) +
                         public_data_read_NEXT_SLOT_IS_ZERO);
             tmp *= scaling_factor;

--- a/barretenberg/cpp/src/barretenberg/vm2/generated/relations/range_check.hpp
+++ b/barretenberg/cpp/src/barretenberg/vm2/generated/relations/range_check.hpp
@@ -5,6 +5,7 @@
 
 #include "barretenberg/relations/relation_parameters.hpp"
 #include "barretenberg/relations/relation_types.hpp"
+#include "barretenberg/vm2/generated/columns.hpp"
 
 namespace bb::avm2 {
 
@@ -17,181 +18,183 @@ template <typename FF_> class range_checkImpl {
 
     template <typename AllEntities> inline static bool skip(const AllEntities& in)
     {
-        const auto& new_term = in;
-        return (new_term.range_check_sel).is_zero();
+        using C = ColumnAndShifts;
+        return (in.get(C::range_check_sel)).is_zero();
     }
 
     template <typename ContainerOverSubrelations, typename AllEntities>
     void static accumulate(ContainerOverSubrelations& evals,
-                           const AllEntities& new_term,
+                           const AllEntities& in,
                            [[maybe_unused]] const RelationParameters<FF>&,
                            [[maybe_unused]] const FF& scaling_factor)
     {
+        using C = ColumnAndShifts;
+
         const auto range_check_PX_0 = FF(0);
-        const auto range_check_R7_0 = new_term.range_check_u16_r7;
-        const auto range_check_PX_1 = new_term.range_check_u16_r0;
+        const auto range_check_R7_0 = in.get(C::range_check_u16_r7);
+        const auto range_check_PX_1 = in.get(C::range_check_u16_r0);
         const auto range_check_R7_1 = range_check_R7_0 * FF(65536);
-        const auto range_check_PX_2 = range_check_PX_1 + new_term.range_check_u16_r1 * FF(65536);
+        const auto range_check_PX_2 = range_check_PX_1 + in.get(C::range_check_u16_r1) * FF(65536);
         const auto range_check_R7_2 = range_check_R7_1 * FF(65536);
-        const auto range_check_PX_3 = range_check_PX_2 + new_term.range_check_u16_r2 * FF(4294967296UL);
+        const auto range_check_PX_3 = range_check_PX_2 + in.get(C::range_check_u16_r2) * FF(4294967296UL);
         const auto range_check_R7_3 = range_check_R7_2 * FF(65536);
-        const auto range_check_PX_4 = range_check_PX_3 + new_term.range_check_u16_r3 * FF(281474976710656UL);
+        const auto range_check_PX_4 = range_check_PX_3 + in.get(C::range_check_u16_r3) * FF(281474976710656UL);
         const auto range_check_R7_4 = range_check_R7_3 * FF(65536);
         const auto range_check_PX_5 =
-            range_check_PX_4 + new_term.range_check_u16_r4 * FF(uint256_t{ 0UL, 1UL, 0UL, 0UL });
+            range_check_PX_4 + in.get(C::range_check_u16_r4) * FF(uint256_t{ 0UL, 1UL, 0UL, 0UL });
         const auto range_check_R7_5 = range_check_R7_4 * FF(65536);
         const auto range_check_PX_6 =
-            range_check_PX_5 + new_term.range_check_u16_r5 * FF(uint256_t{ 0UL, 65536UL, 0UL, 0UL });
+            range_check_PX_5 + in.get(C::range_check_u16_r5) * FF(uint256_t{ 0UL, 65536UL, 0UL, 0UL });
         const auto range_check_R7_6 = range_check_R7_5 * FF(65536);
         const auto range_check_PX_7 =
-            range_check_PX_6 + new_term.range_check_u16_r6 * FF(uint256_t{ 0UL, 4294967296UL, 0UL, 0UL });
+            range_check_PX_6 + in.get(C::range_check_u16_r6) * FF(uint256_t{ 0UL, 4294967296UL, 0UL, 0UL });
         const auto range_check_R7_7 = range_check_R7_6 * FF(65536);
-        const auto range_check_RESULT = new_term.range_check_is_lte_u16 * (range_check_PX_0 + range_check_R7_0) +
-                                        new_term.range_check_is_lte_u32 * (range_check_PX_1 + range_check_R7_1) +
-                                        new_term.range_check_is_lte_u48 * (range_check_PX_2 + range_check_R7_2) +
-                                        new_term.range_check_is_lte_u64 * (range_check_PX_3 + range_check_R7_3) +
-                                        new_term.range_check_is_lte_u80 * (range_check_PX_4 + range_check_R7_4) +
-                                        new_term.range_check_is_lte_u96 * (range_check_PX_5 + range_check_R7_5) +
-                                        new_term.range_check_is_lte_u112 * (range_check_PX_6 + range_check_R7_6) +
-                                        new_term.range_check_is_lte_u128 * (range_check_PX_7 + range_check_R7_7);
-        const auto range_check_CUM_LTE_128 = new_term.range_check_is_lte_u128;
-        const auto range_check_CUM_LTE_112 = new_term.range_check_is_lte_u112 + range_check_CUM_LTE_128;
-        const auto range_check_CUM_LTE_96 = new_term.range_check_is_lte_u96 + range_check_CUM_LTE_112;
-        const auto range_check_CUM_LTE_80 = new_term.range_check_is_lte_u80 + range_check_CUM_LTE_96;
-        const auto range_check_CUM_LTE_64 = new_term.range_check_is_lte_u64 + range_check_CUM_LTE_80;
-        const auto range_check_CUM_LTE_48 = new_term.range_check_is_lte_u48 + range_check_CUM_LTE_64;
-        const auto range_check_CUM_LTE_32 = new_term.range_check_is_lte_u32 + range_check_CUM_LTE_48;
+        const auto range_check_RESULT = in.get(C::range_check_is_lte_u16) * (range_check_PX_0 + range_check_R7_0) +
+                                        in.get(C::range_check_is_lte_u32) * (range_check_PX_1 + range_check_R7_1) +
+                                        in.get(C::range_check_is_lte_u48) * (range_check_PX_2 + range_check_R7_2) +
+                                        in.get(C::range_check_is_lte_u64) * (range_check_PX_3 + range_check_R7_3) +
+                                        in.get(C::range_check_is_lte_u80) * (range_check_PX_4 + range_check_R7_4) +
+                                        in.get(C::range_check_is_lte_u96) * (range_check_PX_5 + range_check_R7_5) +
+                                        in.get(C::range_check_is_lte_u112) * (range_check_PX_6 + range_check_R7_6) +
+                                        in.get(C::range_check_is_lte_u128) * (range_check_PX_7 + range_check_R7_7);
+        const auto range_check_CUM_LTE_128 = in.get(C::range_check_is_lte_u128);
+        const auto range_check_CUM_LTE_112 = in.get(C::range_check_is_lte_u112) + range_check_CUM_LTE_128;
+        const auto range_check_CUM_LTE_96 = in.get(C::range_check_is_lte_u96) + range_check_CUM_LTE_112;
+        const auto range_check_CUM_LTE_80 = in.get(C::range_check_is_lte_u80) + range_check_CUM_LTE_96;
+        const auto range_check_CUM_LTE_64 = in.get(C::range_check_is_lte_u64) + range_check_CUM_LTE_80;
+        const auto range_check_CUM_LTE_48 = in.get(C::range_check_is_lte_u48) + range_check_CUM_LTE_64;
+        const auto range_check_CUM_LTE_32 = in.get(C::range_check_is_lte_u32) + range_check_CUM_LTE_48;
 
         {
             using Accumulator = typename std::tuple_element_t<0, ContainerOverSubrelations>;
-            auto tmp = new_term.range_check_sel * (FF(1) - new_term.range_check_sel);
+            auto tmp = in.get(C::range_check_sel) * (FF(1) - in.get(C::range_check_sel));
             tmp *= scaling_factor;
             std::get<0>(evals) += typename Accumulator::View(tmp);
         }
         {
             using Accumulator = typename std::tuple_element_t<1, ContainerOverSubrelations>;
-            auto tmp = new_term.range_check_is_lte_u16 * (FF(1) - new_term.range_check_is_lte_u16);
+            auto tmp = in.get(C::range_check_is_lte_u16) * (FF(1) - in.get(C::range_check_is_lte_u16));
             tmp *= scaling_factor;
             std::get<1>(evals) += typename Accumulator::View(tmp);
         }
         {
             using Accumulator = typename std::tuple_element_t<2, ContainerOverSubrelations>;
-            auto tmp = new_term.range_check_is_lte_u32 * (FF(1) - new_term.range_check_is_lte_u32);
+            auto tmp = in.get(C::range_check_is_lte_u32) * (FF(1) - in.get(C::range_check_is_lte_u32));
             tmp *= scaling_factor;
             std::get<2>(evals) += typename Accumulator::View(tmp);
         }
         {
             using Accumulator = typename std::tuple_element_t<3, ContainerOverSubrelations>;
-            auto tmp = new_term.range_check_is_lte_u48 * (FF(1) - new_term.range_check_is_lte_u48);
+            auto tmp = in.get(C::range_check_is_lte_u48) * (FF(1) - in.get(C::range_check_is_lte_u48));
             tmp *= scaling_factor;
             std::get<3>(evals) += typename Accumulator::View(tmp);
         }
         {
             using Accumulator = typename std::tuple_element_t<4, ContainerOverSubrelations>;
-            auto tmp = new_term.range_check_is_lte_u64 * (FF(1) - new_term.range_check_is_lte_u64);
+            auto tmp = in.get(C::range_check_is_lte_u64) * (FF(1) - in.get(C::range_check_is_lte_u64));
             tmp *= scaling_factor;
             std::get<4>(evals) += typename Accumulator::View(tmp);
         }
         {
             using Accumulator = typename std::tuple_element_t<5, ContainerOverSubrelations>;
-            auto tmp = new_term.range_check_is_lte_u80 * (FF(1) - new_term.range_check_is_lte_u80);
+            auto tmp = in.get(C::range_check_is_lte_u80) * (FF(1) - in.get(C::range_check_is_lte_u80));
             tmp *= scaling_factor;
             std::get<5>(evals) += typename Accumulator::View(tmp);
         }
         {
             using Accumulator = typename std::tuple_element_t<6, ContainerOverSubrelations>;
-            auto tmp = new_term.range_check_is_lte_u96 * (FF(1) - new_term.range_check_is_lte_u96);
+            auto tmp = in.get(C::range_check_is_lte_u96) * (FF(1) - in.get(C::range_check_is_lte_u96));
             tmp *= scaling_factor;
             std::get<6>(evals) += typename Accumulator::View(tmp);
         }
         {
             using Accumulator = typename std::tuple_element_t<7, ContainerOverSubrelations>;
-            auto tmp = new_term.range_check_is_lte_u112 * (FF(1) - new_term.range_check_is_lte_u112);
+            auto tmp = in.get(C::range_check_is_lte_u112) * (FF(1) - in.get(C::range_check_is_lte_u112));
             tmp *= scaling_factor;
             std::get<7>(evals) += typename Accumulator::View(tmp);
         }
         {
             using Accumulator = typename std::tuple_element_t<8, ContainerOverSubrelations>;
-            auto tmp = new_term.range_check_is_lte_u128 * (FF(1) - new_term.range_check_is_lte_u128);
+            auto tmp = in.get(C::range_check_is_lte_u128) * (FF(1) - in.get(C::range_check_is_lte_u128));
             tmp *= scaling_factor;
             std::get<8>(evals) += typename Accumulator::View(tmp);
         }
         { // IS_LTE_MUTUALLY_EXCLUSIVE
             using Accumulator = typename std::tuple_element_t<9, ContainerOverSubrelations>;
-            auto tmp =
-                ((new_term.range_check_is_lte_u16 + new_term.range_check_is_lte_u32 + new_term.range_check_is_lte_u48 +
-                  new_term.range_check_is_lte_u64 + new_term.range_check_is_lte_u80 + new_term.range_check_is_lte_u96 +
-                  new_term.range_check_is_lte_u112 + new_term.range_check_is_lte_u128) -
-                 new_term.range_check_sel);
+            auto tmp = ((in.get(C::range_check_is_lte_u16) + in.get(C::range_check_is_lte_u32) +
+                         in.get(C::range_check_is_lte_u48) + in.get(C::range_check_is_lte_u64) +
+                         in.get(C::range_check_is_lte_u80) + in.get(C::range_check_is_lte_u96) +
+                         in.get(C::range_check_is_lte_u112) + in.get(C::range_check_is_lte_u128)) -
+                        in.get(C::range_check_sel));
             tmp *= scaling_factor;
             std::get<9>(evals) += typename Accumulator::View(tmp);
         }
         { // CHECK_RECOMPOSITION
             using Accumulator = typename std::tuple_element_t<10, ContainerOverSubrelations>;
-            auto tmp = new_term.range_check_sel * (range_check_RESULT - new_term.range_check_value);
+            auto tmp = in.get(C::range_check_sel) * (range_check_RESULT - in.get(C::range_check_value));
             tmp *= scaling_factor;
             std::get<10>(evals) += typename Accumulator::View(tmp);
         }
         {
             using Accumulator = typename std::tuple_element_t<11, ContainerOverSubrelations>;
-            auto tmp = (new_term.range_check_dyn_rng_chk_bits -
-                        (((((((new_term.range_check_rng_chk_bits - new_term.range_check_is_lte_u32 * FF(16)) -
-                              new_term.range_check_is_lte_u48 * FF(32)) -
-                             new_term.range_check_is_lte_u64 * FF(48)) -
-                            new_term.range_check_is_lte_u80 * FF(64)) -
-                           new_term.range_check_is_lte_u96 * FF(80)) -
-                          new_term.range_check_is_lte_u112 * FF(96)) -
-                         new_term.range_check_is_lte_u128 * FF(112)));
+            auto tmp = (in.get(C::range_check_dyn_rng_chk_bits) -
+                        (((((((in.get(C::range_check_rng_chk_bits) - in.get(C::range_check_is_lte_u32) * FF(16)) -
+                              in.get(C::range_check_is_lte_u48) * FF(32)) -
+                             in.get(C::range_check_is_lte_u64) * FF(48)) -
+                            in.get(C::range_check_is_lte_u80) * FF(64)) -
+                           in.get(C::range_check_is_lte_u96) * FF(80)) -
+                          in.get(C::range_check_is_lte_u112) * FF(96)) -
+                         in.get(C::range_check_is_lte_u128) * FF(112)));
             tmp *= scaling_factor;
             std::get<11>(evals) += typename Accumulator::View(tmp);
         }
         {
             using Accumulator = typename std::tuple_element_t<12, ContainerOverSubrelations>;
-            auto tmp = new_term.range_check_sel *
-                       (new_term.range_check_dyn_diff -
-                        ((new_term.range_check_dyn_rng_chk_pow_2 - new_term.range_check_u16_r7) - FF(1)));
+            auto tmp = in.get(C::range_check_sel) *
+                       (in.get(C::range_check_dyn_diff) -
+                        ((in.get(C::range_check_dyn_rng_chk_pow_2) - in.get(C::range_check_u16_r7)) - FF(1)));
             tmp *= scaling_factor;
             std::get<12>(evals) += typename Accumulator::View(tmp);
         }
         {
             using Accumulator = typename std::tuple_element_t<13, ContainerOverSubrelations>;
-            auto tmp = (new_term.range_check_sel_r0_16_bit_rng_lookup - range_check_CUM_LTE_32);
+            auto tmp = (in.get(C::range_check_sel_r0_16_bit_rng_lookup) - range_check_CUM_LTE_32);
             tmp *= scaling_factor;
             std::get<13>(evals) += typename Accumulator::View(tmp);
         }
         {
             using Accumulator = typename std::tuple_element_t<14, ContainerOverSubrelations>;
-            auto tmp = (new_term.range_check_sel_r1_16_bit_rng_lookup - range_check_CUM_LTE_48);
+            auto tmp = (in.get(C::range_check_sel_r1_16_bit_rng_lookup) - range_check_CUM_LTE_48);
             tmp *= scaling_factor;
             std::get<14>(evals) += typename Accumulator::View(tmp);
         }
         {
             using Accumulator = typename std::tuple_element_t<15, ContainerOverSubrelations>;
-            auto tmp = (new_term.range_check_sel_r2_16_bit_rng_lookup - range_check_CUM_LTE_64);
+            auto tmp = (in.get(C::range_check_sel_r2_16_bit_rng_lookup) - range_check_CUM_LTE_64);
             tmp *= scaling_factor;
             std::get<15>(evals) += typename Accumulator::View(tmp);
         }
         {
             using Accumulator = typename std::tuple_element_t<16, ContainerOverSubrelations>;
-            auto tmp = (new_term.range_check_sel_r3_16_bit_rng_lookup - range_check_CUM_LTE_80);
+            auto tmp = (in.get(C::range_check_sel_r3_16_bit_rng_lookup) - range_check_CUM_LTE_80);
             tmp *= scaling_factor;
             std::get<16>(evals) += typename Accumulator::View(tmp);
         }
         {
             using Accumulator = typename std::tuple_element_t<17, ContainerOverSubrelations>;
-            auto tmp = (new_term.range_check_sel_r4_16_bit_rng_lookup - range_check_CUM_LTE_96);
+            auto tmp = (in.get(C::range_check_sel_r4_16_bit_rng_lookup) - range_check_CUM_LTE_96);
             tmp *= scaling_factor;
             std::get<17>(evals) += typename Accumulator::View(tmp);
         }
         {
             using Accumulator = typename std::tuple_element_t<18, ContainerOverSubrelations>;
-            auto tmp = (new_term.range_check_sel_r5_16_bit_rng_lookup - range_check_CUM_LTE_112);
+            auto tmp = (in.get(C::range_check_sel_r5_16_bit_rng_lookup) - range_check_CUM_LTE_112);
             tmp *= scaling_factor;
             std::get<18>(evals) += typename Accumulator::View(tmp);
         }
         {
             using Accumulator = typename std::tuple_element_t<19, ContainerOverSubrelations>;
-            auto tmp = (new_term.range_check_sel_r6_16_bit_rng_lookup - range_check_CUM_LTE_128);
+            auto tmp = (in.get(C::range_check_sel_r6_16_bit_rng_lookup) - range_check_CUM_LTE_128);
             tmp *= scaling_factor;
             std::get<19>(evals) += typename Accumulator::View(tmp);
         }

--- a/barretenberg/cpp/src/barretenberg/vm2/generated/relations/scalar_mul.hpp
+++ b/barretenberg/cpp/src/barretenberg/vm2/generated/relations/scalar_mul.hpp
@@ -5,6 +5,7 @@
 
 #include "barretenberg/relations/relation_parameters.hpp"
 #include "barretenberg/relations/relation_types.hpp"
+#include "barretenberg/vm2/generated/columns.hpp"
 
 namespace bb::avm2 {
 
@@ -18,214 +19,222 @@ template <typename FF_> class scalar_mulImpl {
 
     template <typename AllEntities> inline static bool skip(const AllEntities& in)
     {
-        const auto& new_term = in;
-        return (new_term.scalar_mul_sel).is_zero();
+        using C = ColumnAndShifts;
+        return (in.get(C::scalar_mul_sel)).is_zero();
     }
 
     template <typename ContainerOverSubrelations, typename AllEntities>
     void static accumulate(ContainerOverSubrelations& evals,
-                           const AllEntities& new_term,
+                           const AllEntities& in,
                            [[maybe_unused]] const RelationParameters<FF>&,
                            [[maybe_unused]] const FF& scaling_factor)
     {
-        const auto scalar_mul_LATCH_CONDITION = new_term.scalar_mul_end + new_term.precomputed_first_row;
-        const auto scalar_mul_should_pass = new_term.scalar_mul_not_end * (FF(1) - new_term.scalar_mul_bit);
+        using C = ColumnAndShifts;
+
+        const auto scalar_mul_LATCH_CONDITION = in.get(C::scalar_mul_end) + in.get(C::precomputed_first_row);
+        const auto scalar_mul_should_pass = in.get(C::scalar_mul_not_end) * (FF(1) - in.get(C::scalar_mul_bit));
 
         {
             using Accumulator = typename std::tuple_element_t<0, ContainerOverSubrelations>;
-            auto tmp = new_term.scalar_mul_sel * (FF(1) - new_term.scalar_mul_sel);
+            auto tmp = in.get(C::scalar_mul_sel) * (FF(1) - in.get(C::scalar_mul_sel));
             tmp *= scaling_factor;
             std::get<0>(evals) += typename Accumulator::View(tmp);
         }
         {
             using Accumulator = typename std::tuple_element_t<1, ContainerOverSubrelations>;
-            auto tmp = new_term.scalar_mul_point_inf * (FF(1) - new_term.scalar_mul_point_inf);
+            auto tmp = in.get(C::scalar_mul_point_inf) * (FF(1) - in.get(C::scalar_mul_point_inf));
             tmp *= scaling_factor;
             std::get<1>(evals) += typename Accumulator::View(tmp);
         }
         {
             using Accumulator = typename std::tuple_element_t<2, ContainerOverSubrelations>;
-            auto tmp = new_term.scalar_mul_start * (FF(1) - new_term.scalar_mul_start);
+            auto tmp = in.get(C::scalar_mul_start) * (FF(1) - in.get(C::scalar_mul_start));
             tmp *= scaling_factor;
             std::get<2>(evals) += typename Accumulator::View(tmp);
         }
         {
             using Accumulator = typename std::tuple_element_t<3, ContainerOverSubrelations>;
-            auto tmp = new_term.scalar_mul_end * (FF(1) - new_term.scalar_mul_end);
+            auto tmp = in.get(C::scalar_mul_end) * (FF(1) - in.get(C::scalar_mul_end));
             tmp *= scaling_factor;
             std::get<3>(evals) += typename Accumulator::View(tmp);
         }
         {
             using Accumulator = typename std::tuple_element_t<4, ContainerOverSubrelations>;
-            auto tmp = new_term.scalar_mul_end * new_term.precomputed_first_row;
+            auto tmp = in.get(C::scalar_mul_end) * in.get(C::precomputed_first_row);
             tmp *= scaling_factor;
             std::get<4>(evals) += typename Accumulator::View(tmp);
         }
         { // START_AFTER_LATCH
             using Accumulator = typename std::tuple_element_t<5, ContainerOverSubrelations>;
-            auto tmp = new_term.scalar_mul_sel_shift * (new_term.scalar_mul_start_shift - scalar_mul_LATCH_CONDITION);
+            auto tmp =
+                in.get(C::scalar_mul_sel_shift) * (in.get(C::scalar_mul_start_shift) - scalar_mul_LATCH_CONDITION);
             tmp *= scaling_factor;
             std::get<5>(evals) += typename Accumulator::View(tmp);
         }
         { // SELECTOR_ON_START
             using Accumulator = typename std::tuple_element_t<6, ContainerOverSubrelations>;
-            auto tmp = new_term.scalar_mul_start * (FF(1) - new_term.scalar_mul_sel);
+            auto tmp = in.get(C::scalar_mul_start) * (FF(1) - in.get(C::scalar_mul_sel));
             tmp *= scaling_factor;
             std::get<6>(evals) += typename Accumulator::View(tmp);
         }
         { // SELECTOR_CONSISTENCY
             using Accumulator = typename std::tuple_element_t<7, ContainerOverSubrelations>;
-            auto tmp = (new_term.scalar_mul_sel_shift - new_term.scalar_mul_sel) * (FF(1) - scalar_mul_LATCH_CONDITION);
+            auto tmp =
+                (in.get(C::scalar_mul_sel_shift) - in.get(C::scalar_mul_sel)) * (FF(1) - scalar_mul_LATCH_CONDITION);
             tmp *= scaling_factor;
             std::get<7>(evals) += typename Accumulator::View(tmp);
         }
         {
             using Accumulator = typename std::tuple_element_t<8, ContainerOverSubrelations>;
-            auto tmp = new_term.scalar_mul_end * (FF(1) - new_term.scalar_mul_sel);
+            auto tmp = in.get(C::scalar_mul_end) * (FF(1) - in.get(C::scalar_mul_sel));
             tmp *= scaling_factor;
             std::get<8>(evals) += typename Accumulator::View(tmp);
         }
         {
             using Accumulator = typename std::tuple_element_t<9, ContainerOverSubrelations>;
-            auto tmp = (new_term.scalar_mul_not_end - new_term.scalar_mul_sel * (FF(1) - new_term.scalar_mul_end));
+            auto tmp =
+                (in.get(C::scalar_mul_not_end) - in.get(C::scalar_mul_sel) * (FF(1) - in.get(C::scalar_mul_end)));
             tmp *= scaling_factor;
             std::get<9>(evals) += typename Accumulator::View(tmp);
         }
         {
             using Accumulator = typename std::tuple_element_t<10, ContainerOverSubrelations>;
-            auto tmp = ((new_term.scalar_mul_end + new_term.scalar_mul_not_end) - new_term.scalar_mul_sel);
+            auto tmp = ((in.get(C::scalar_mul_end) + in.get(C::scalar_mul_not_end)) - in.get(C::scalar_mul_sel));
             tmp *= scaling_factor;
             std::get<10>(evals) += typename Accumulator::View(tmp);
         }
         { // INPUT_CONSISTENCY_X
             using Accumulator = typename std::tuple_element_t<11, ContainerOverSubrelations>;
-            auto tmp = new_term.scalar_mul_not_end * (new_term.scalar_mul_point_x - new_term.scalar_mul_point_x_shift);
+            auto tmp =
+                in.get(C::scalar_mul_not_end) * (in.get(C::scalar_mul_point_x) - in.get(C::scalar_mul_point_x_shift));
             tmp *= scaling_factor;
             std::get<11>(evals) += typename Accumulator::View(tmp);
         }
         { // INPUT_CONSISTENCY_Y
             using Accumulator = typename std::tuple_element_t<12, ContainerOverSubrelations>;
-            auto tmp = new_term.scalar_mul_not_end * (new_term.scalar_mul_point_y - new_term.scalar_mul_point_y_shift);
+            auto tmp =
+                in.get(C::scalar_mul_not_end) * (in.get(C::scalar_mul_point_y) - in.get(C::scalar_mul_point_y_shift));
             tmp *= scaling_factor;
             std::get<12>(evals) += typename Accumulator::View(tmp);
         }
         { // INPUT_CONSISTENCY_INF
             using Accumulator = typename std::tuple_element_t<13, ContainerOverSubrelations>;
-            auto tmp =
-                new_term.scalar_mul_not_end * (new_term.scalar_mul_point_inf - new_term.scalar_mul_point_inf_shift);
+            auto tmp = in.get(C::scalar_mul_not_end) *
+                       (in.get(C::scalar_mul_point_inf) - in.get(C::scalar_mul_point_inf_shift));
             tmp *= scaling_factor;
             std::get<13>(evals) += typename Accumulator::View(tmp);
         }
         { // INPUT_CONSISTENCY_SCALAR
             using Accumulator = typename std::tuple_element_t<14, ContainerOverSubrelations>;
-            auto tmp = new_term.scalar_mul_not_end * (new_term.scalar_mul_scalar - new_term.scalar_mul_scalar_shift);
+            auto tmp =
+                in.get(C::scalar_mul_not_end) * (in.get(C::scalar_mul_scalar) - in.get(C::scalar_mul_scalar_shift));
             tmp *= scaling_factor;
             std::get<14>(evals) += typename Accumulator::View(tmp);
         }
         {
             using Accumulator = typename std::tuple_element_t<15, ContainerOverSubrelations>;
-            auto tmp = new_term.scalar_mul_start * (new_term.scalar_mul_bit_idx - FF(253));
+            auto tmp = in.get(C::scalar_mul_start) * (in.get(C::scalar_mul_bit_idx) - FF(253));
             tmp *= scaling_factor;
             std::get<15>(evals) += typename Accumulator::View(tmp);
         }
         {
             using Accumulator = typename std::tuple_element_t<16, ContainerOverSubrelations>;
-            auto tmp = new_term.scalar_mul_end * new_term.scalar_mul_bit_idx;
+            auto tmp = in.get(C::scalar_mul_end) * in.get(C::scalar_mul_bit_idx);
             tmp *= scaling_factor;
             std::get<16>(evals) += typename Accumulator::View(tmp);
         }
         {
             using Accumulator = typename std::tuple_element_t<17, ContainerOverSubrelations>;
-            auto tmp = new_term.scalar_mul_not_end *
-                       (new_term.scalar_mul_bit_idx - (new_term.scalar_mul_bit_idx_shift + FF(1)));
+            auto tmp = in.get(C::scalar_mul_not_end) *
+                       (in.get(C::scalar_mul_bit_idx) - (in.get(C::scalar_mul_bit_idx_shift) + FF(1)));
             tmp *= scaling_factor;
             std::get<17>(evals) += typename Accumulator::View(tmp);
         }
         {
             using Accumulator = typename std::tuple_element_t<18, ContainerOverSubrelations>;
-            auto tmp = new_term.scalar_mul_sel * (new_term.scalar_mul_bit_radix - FF(2));
+            auto tmp = in.get(C::scalar_mul_sel) * (in.get(C::scalar_mul_bit_radix) - FF(2));
             tmp *= scaling_factor;
             std::get<18>(evals) += typename Accumulator::View(tmp);
         }
         {
             using Accumulator = typename std::tuple_element_t<19, ContainerOverSubrelations>;
-            auto tmp = new_term.scalar_mul_end * (new_term.scalar_mul_temp_x - new_term.scalar_mul_point_x);
+            auto tmp = in.get(C::scalar_mul_end) * (in.get(C::scalar_mul_temp_x) - in.get(C::scalar_mul_point_x));
             tmp *= scaling_factor;
             std::get<19>(evals) += typename Accumulator::View(tmp);
         }
         {
             using Accumulator = typename std::tuple_element_t<20, ContainerOverSubrelations>;
-            auto tmp = new_term.scalar_mul_end * (new_term.scalar_mul_temp_y - new_term.scalar_mul_point_y);
+            auto tmp = in.get(C::scalar_mul_end) * (in.get(C::scalar_mul_temp_y) - in.get(C::scalar_mul_point_y));
             tmp *= scaling_factor;
             std::get<20>(evals) += typename Accumulator::View(tmp);
         }
         {
             using Accumulator = typename std::tuple_element_t<21, ContainerOverSubrelations>;
-            auto tmp = new_term.scalar_mul_end * (new_term.scalar_mul_temp_inf - new_term.scalar_mul_point_inf);
+            auto tmp = in.get(C::scalar_mul_end) * (in.get(C::scalar_mul_temp_inf) - in.get(C::scalar_mul_point_inf));
             tmp *= scaling_factor;
             std::get<21>(evals) += typename Accumulator::View(tmp);
         }
         {
             using Accumulator = typename std::tuple_element_t<22, ContainerOverSubrelations>;
-            auto tmp = (new_term.scalar_mul_temp_x_shift - new_term.scalar_mul_temp_x_shift);
+            auto tmp = (in.get(C::scalar_mul_temp_x_shift) - in.get(C::scalar_mul_temp_x_shift));
             tmp *= scaling_factor;
             std::get<22>(evals) += typename Accumulator::View(tmp);
         }
         {
             using Accumulator = typename std::tuple_element_t<23, ContainerOverSubrelations>;
-            auto tmp = (new_term.scalar_mul_temp_y_shift - new_term.scalar_mul_temp_y_shift);
+            auto tmp = (in.get(C::scalar_mul_temp_y_shift) - in.get(C::scalar_mul_temp_y_shift));
             tmp *= scaling_factor;
             std::get<23>(evals) += typename Accumulator::View(tmp);
         }
         {
             using Accumulator = typename std::tuple_element_t<24, ContainerOverSubrelations>;
-            auto tmp = (new_term.scalar_mul_temp_inf_shift - new_term.scalar_mul_temp_inf_shift);
+            auto tmp = (in.get(C::scalar_mul_temp_inf_shift) - in.get(C::scalar_mul_temp_inf_shift));
             tmp *= scaling_factor;
             std::get<24>(evals) += typename Accumulator::View(tmp);
         }
         {
             using Accumulator = typename std::tuple_element_t<25, ContainerOverSubrelations>;
-            auto tmp = new_term.scalar_mul_end *
-                       (new_term.scalar_mul_point_x * new_term.scalar_mul_bit - new_term.scalar_mul_res_x);
+            auto tmp = in.get(C::scalar_mul_end) *
+                       (in.get(C::scalar_mul_point_x) * in.get(C::scalar_mul_bit) - in.get(C::scalar_mul_res_x));
             tmp *= scaling_factor;
             std::get<25>(evals) += typename Accumulator::View(tmp);
         }
         {
             using Accumulator = typename std::tuple_element_t<26, ContainerOverSubrelations>;
-            auto tmp = new_term.scalar_mul_end *
-                       (new_term.scalar_mul_point_y * new_term.scalar_mul_bit - new_term.scalar_mul_res_y);
+            auto tmp = in.get(C::scalar_mul_end) *
+                       (in.get(C::scalar_mul_point_y) * in.get(C::scalar_mul_bit) - in.get(C::scalar_mul_res_y));
             tmp *= scaling_factor;
             std::get<26>(evals) += typename Accumulator::View(tmp);
         }
         {
             using Accumulator = typename std::tuple_element_t<27, ContainerOverSubrelations>;
-            auto tmp =
-                new_term.scalar_mul_end * (((new_term.scalar_mul_point_inf - FF(1)) * new_term.scalar_mul_bit + FF(1)) -
-                                           new_term.scalar_mul_res_inf);
+            auto tmp = in.get(C::scalar_mul_end) *
+                       (((in.get(C::scalar_mul_point_inf) - FF(1)) * in.get(C::scalar_mul_bit) + FF(1)) -
+                        in.get(C::scalar_mul_res_inf));
             tmp *= scaling_factor;
             std::get<27>(evals) += typename Accumulator::View(tmp);
         }
         {
             using Accumulator = typename std::tuple_element_t<28, ContainerOverSubrelations>;
-            auto tmp = (new_term.scalar_mul_should_add - new_term.scalar_mul_not_end * new_term.scalar_mul_bit);
+            auto tmp = (in.get(C::scalar_mul_should_add) - in.get(C::scalar_mul_not_end) * in.get(C::scalar_mul_bit));
             tmp *= scaling_factor;
             std::get<28>(evals) += typename Accumulator::View(tmp);
         }
         {
             using Accumulator = typename std::tuple_element_t<29, ContainerOverSubrelations>;
-            auto tmp = scalar_mul_should_pass * (new_term.scalar_mul_res_x - new_term.scalar_mul_res_x_shift);
+            auto tmp = scalar_mul_should_pass * (in.get(C::scalar_mul_res_x) - in.get(C::scalar_mul_res_x_shift));
             tmp *= scaling_factor;
             std::get<29>(evals) += typename Accumulator::View(tmp);
         }
         {
             using Accumulator = typename std::tuple_element_t<30, ContainerOverSubrelations>;
-            auto tmp = scalar_mul_should_pass * (new_term.scalar_mul_res_y - new_term.scalar_mul_res_y_shift);
+            auto tmp = scalar_mul_should_pass * (in.get(C::scalar_mul_res_y) - in.get(C::scalar_mul_res_y_shift));
             tmp *= scaling_factor;
             std::get<30>(evals) += typename Accumulator::View(tmp);
         }
         {
             using Accumulator = typename std::tuple_element_t<31, ContainerOverSubrelations>;
-            auto tmp = scalar_mul_should_pass * (new_term.scalar_mul_res_inf - new_term.scalar_mul_res_inf_shift);
+            auto tmp = scalar_mul_should_pass * (in.get(C::scalar_mul_res_inf) - in.get(C::scalar_mul_res_inf_shift));
             tmp *= scaling_factor;
             std::get<31>(evals) += typename Accumulator::View(tmp);
         }

--- a/barretenberg/cpp/src/barretenberg/vm2/generated/relations/sha256.hpp
+++ b/barretenberg/cpp/src/barretenberg/vm2/generated/relations/sha256.hpp
@@ -5,6 +5,7 @@
 
 #include "barretenberg/relations/relation_parameters.hpp"
 #include "barretenberg/relations/relation_types.hpp"
+#include "barretenberg/vm2/generated/columns.hpp"
 
 namespace bb::avm2 {
 
@@ -19,202 +20,219 @@ template <typename FF_> class sha256Impl {
 
     template <typename AllEntities> inline static bool skip(const AllEntities& in)
     {
-        const auto& new_term = in;
-        return (new_term.sha256_sel).is_zero();
+        using C = ColumnAndShifts;
+        return (in.get(C::sha256_sel)).is_zero();
     }
 
     template <typename ContainerOverSubrelations, typename AllEntities>
     void static accumulate(ContainerOverSubrelations& evals,
-                           const AllEntities& new_term,
+                           const AllEntities& in,
                            [[maybe_unused]] const RelationParameters<FF>&,
                            [[maybe_unused]] const FF& scaling_factor)
     {
-        const auto sha256_LAST = new_term.sha256_sel * new_term.sha256_latch;
+        using C = ColumnAndShifts;
+
+        const auto sha256_LAST = in.get(C::sha256_sel) * in.get(C::sha256_latch);
         const auto sha256_NUM_ROUNDS = FF(64);
-        const auto sha256_COMPUTED_W =
-            new_term.sha256_helper_w0 + new_term.sha256_w_s_0 + new_term.sha256_helper_w9 + new_term.sha256_w_s_1;
-        const auto sha256_TMP_1 = new_term.sha256_h + new_term.sha256_s_1 + new_term.sha256_ch +
-                                  new_term.sha256_round_constant + new_term.sha256_w;
-        const auto sha256_NEXT_A = new_term.sha256_s_0 + new_term.sha256_maj + sha256_TMP_1;
-        const auto sha256_NEXT_E = new_term.sha256_d + sha256_TMP_1;
-        const auto sha256_OUT_A = new_term.sha256_a + new_term.sha256_init_a;
-        const auto sha256_OUT_B = new_term.sha256_b + new_term.sha256_init_b;
-        const auto sha256_OUT_C = new_term.sha256_c + new_term.sha256_init_c;
-        const auto sha256_OUT_D = new_term.sha256_d + new_term.sha256_init_d;
-        const auto sha256_OUT_E = new_term.sha256_e + new_term.sha256_init_e;
-        const auto sha256_OUT_F = new_term.sha256_f + new_term.sha256_init_f;
-        const auto sha256_OUT_G = new_term.sha256_g + new_term.sha256_init_g;
-        const auto sha256_OUT_H = new_term.sha256_h + new_term.sha256_init_h;
+        const auto sha256_COMPUTED_W = in.get(C::sha256_helper_w0) + in.get(C::sha256_w_s_0) +
+                                       in.get(C::sha256_helper_w9) + in.get(C::sha256_w_s_1);
+        const auto sha256_TMP_1 = in.get(C::sha256_h) + in.get(C::sha256_s_1) + in.get(C::sha256_ch) +
+                                  in.get(C::sha256_round_constant) + in.get(C::sha256_w);
+        const auto sha256_NEXT_A = in.get(C::sha256_s_0) + in.get(C::sha256_maj) + sha256_TMP_1;
+        const auto sha256_NEXT_E = in.get(C::sha256_d) + sha256_TMP_1;
+        const auto sha256_OUT_A = in.get(C::sha256_a) + in.get(C::sha256_init_a);
+        const auto sha256_OUT_B = in.get(C::sha256_b) + in.get(C::sha256_init_b);
+        const auto sha256_OUT_C = in.get(C::sha256_c) + in.get(C::sha256_init_c);
+        const auto sha256_OUT_D = in.get(C::sha256_d) + in.get(C::sha256_init_d);
+        const auto sha256_OUT_E = in.get(C::sha256_e) + in.get(C::sha256_init_e);
+        const auto sha256_OUT_F = in.get(C::sha256_f) + in.get(C::sha256_init_f);
+        const auto sha256_OUT_G = in.get(C::sha256_g) + in.get(C::sha256_init_g);
+        const auto sha256_OUT_H = in.get(C::sha256_h) + in.get(C::sha256_init_h);
 
         {
             using Accumulator = typename std::tuple_element_t<0, ContainerOverSubrelations>;
-            auto tmp = new_term.sha256_sel * (FF(1) - new_term.sha256_sel);
+            auto tmp = in.get(C::sha256_sel) * (FF(1) - in.get(C::sha256_sel));
             tmp *= scaling_factor;
             std::get<0>(evals) += typename Accumulator::View(tmp);
         }
         {
             using Accumulator = typename std::tuple_element_t<1, ContainerOverSubrelations>;
-            auto tmp = new_term.sha256_perform_round * (new_term.sha256_xor_sel - FF(2));
+            auto tmp = in.get(C::sha256_perform_round) * (in.get(C::sha256_xor_sel) - FF(2));
             tmp *= scaling_factor;
             std::get<1>(evals) += typename Accumulator::View(tmp);
         }
         {
             using Accumulator = typename std::tuple_element_t<2, ContainerOverSubrelations>;
-            auto tmp = new_term.sha256_and_sel;
+            auto tmp = in.get(C::sha256_and_sel);
             tmp *= scaling_factor;
             std::get<2>(evals) += typename Accumulator::View(tmp);
         }
         {
             using Accumulator = typename std::tuple_element_t<3, ContainerOverSubrelations>;
-            auto tmp = new_term.sha256_start * (FF(1) - new_term.sha256_start);
+            auto tmp = in.get(C::sha256_start) * (FF(1) - in.get(C::sha256_start));
             tmp *= scaling_factor;
             std::get<3>(evals) += typename Accumulator::View(tmp);
         }
         {
             using Accumulator = typename std::tuple_element_t<4, ContainerOverSubrelations>;
-            auto tmp = (new_term.sha256_start_shift -
-                        (new_term.sha256_latch + new_term.precomputed_first_row) * new_term.sha256_sel_shift);
+            auto tmp = (in.get(C::sha256_start_shift) -
+                        (in.get(C::sha256_latch) + in.get(C::precomputed_first_row)) * in.get(C::sha256_sel_shift));
             tmp *= scaling_factor;
             std::get<4>(evals) += typename Accumulator::View(tmp);
         }
         {
             using Accumulator = typename std::tuple_element_t<5, ContainerOverSubrelations>;
-            auto tmp = new_term.sha256_latch * (FF(1) - new_term.sha256_latch);
+            auto tmp = in.get(C::sha256_latch) * (FF(1) - in.get(C::sha256_latch));
             tmp *= scaling_factor;
             std::get<5>(evals) += typename Accumulator::View(tmp);
         }
         {
             using Accumulator = typename std::tuple_element_t<6, ContainerOverSubrelations>;
-            auto tmp = (new_term.sha256_perform_round - new_term.sha256_sel * (FF(1) - new_term.sha256_latch));
+            auto tmp = (in.get(C::sha256_perform_round) - in.get(C::sha256_sel) * (FF(1) - in.get(C::sha256_latch)));
             tmp *= scaling_factor;
             std::get<6>(evals) += typename Accumulator::View(tmp);
         }
         {
             using Accumulator = typename std::tuple_element_t<7, ContainerOverSubrelations>;
-            auto tmp = (new_term.sha256_start * (new_term.sha256_rounds_remaining - sha256_NUM_ROUNDS) +
-                        new_term.sha256_perform_round *
-                            ((new_term.sha256_rounds_remaining - new_term.sha256_rounds_remaining_shift) - FF(1)));
+            auto tmp = (in.get(C::sha256_start) * (in.get(C::sha256_rounds_remaining) - sha256_NUM_ROUNDS) +
+                        in.get(C::sha256_perform_round) *
+                            ((in.get(C::sha256_rounds_remaining) - in.get(C::sha256_rounds_remaining_shift)) - FF(1)));
             tmp *= scaling_factor;
             std::get<7>(evals) += typename Accumulator::View(tmp);
         }
         {
             using Accumulator = typename std::tuple_element_t<8, ContainerOverSubrelations>;
-            auto tmp = new_term.sha256_sel *
-                       (new_term.sha256_round_count - (sha256_NUM_ROUNDS - new_term.sha256_rounds_remaining));
+            auto tmp = in.get(C::sha256_sel) *
+                       (in.get(C::sha256_round_count) - (sha256_NUM_ROUNDS - in.get(C::sha256_rounds_remaining)));
             tmp *= scaling_factor;
             std::get<8>(evals) += typename Accumulator::View(tmp);
         }
         {
             using Accumulator = typename std::tuple_element_t<9, ContainerOverSubrelations>;
-            auto tmp =
-                new_term.sha256_sel * ((new_term.sha256_rounds_remaining *
-                                            (new_term.sha256_latch * (FF(1) - new_term.sha256_rounds_remaining_inv) +
-                                             new_term.sha256_rounds_remaining_inv) -
-                                        FF(1)) +
-                                       new_term.sha256_latch);
+            auto tmp = in.get(C::sha256_sel) *
+                       ((in.get(C::sha256_rounds_remaining) *
+                             (in.get(C::sha256_latch) * (FF(1) - in.get(C::sha256_rounds_remaining_inv)) +
+                              in.get(C::sha256_rounds_remaining_inv)) -
+                         FF(1)) +
+                        in.get(C::sha256_latch));
             tmp *= scaling_factor;
             std::get<9>(evals) += typename Accumulator::View(tmp);
         }
         {
             using Accumulator = typename std::tuple_element_t<10, ContainerOverSubrelations>;
-            auto tmp = new_term.sha256_perform_round * (new_term.sha256_helper_w0_shift - new_term.sha256_helper_w1);
+            auto tmp =
+                in.get(C::sha256_perform_round) * (in.get(C::sha256_helper_w0_shift) - in.get(C::sha256_helper_w1));
             tmp *= scaling_factor;
             std::get<10>(evals) += typename Accumulator::View(tmp);
         }
         {
             using Accumulator = typename std::tuple_element_t<11, ContainerOverSubrelations>;
-            auto tmp = new_term.sha256_perform_round * (new_term.sha256_helper_w1_shift - new_term.sha256_helper_w2);
+            auto tmp =
+                in.get(C::sha256_perform_round) * (in.get(C::sha256_helper_w1_shift) - in.get(C::sha256_helper_w2));
             tmp *= scaling_factor;
             std::get<11>(evals) += typename Accumulator::View(tmp);
         }
         {
             using Accumulator = typename std::tuple_element_t<12, ContainerOverSubrelations>;
-            auto tmp = new_term.sha256_perform_round * (new_term.sha256_helper_w2_shift - new_term.sha256_helper_w3);
+            auto tmp =
+                in.get(C::sha256_perform_round) * (in.get(C::sha256_helper_w2_shift) - in.get(C::sha256_helper_w3));
             tmp *= scaling_factor;
             std::get<12>(evals) += typename Accumulator::View(tmp);
         }
         {
             using Accumulator = typename std::tuple_element_t<13, ContainerOverSubrelations>;
-            auto tmp = new_term.sha256_perform_round * (new_term.sha256_helper_w3_shift - new_term.sha256_helper_w4);
+            auto tmp =
+                in.get(C::sha256_perform_round) * (in.get(C::sha256_helper_w3_shift) - in.get(C::sha256_helper_w4));
             tmp *= scaling_factor;
             std::get<13>(evals) += typename Accumulator::View(tmp);
         }
         {
             using Accumulator = typename std::tuple_element_t<14, ContainerOverSubrelations>;
-            auto tmp = new_term.sha256_perform_round * (new_term.sha256_helper_w4_shift - new_term.sha256_helper_w5);
+            auto tmp =
+                in.get(C::sha256_perform_round) * (in.get(C::sha256_helper_w4_shift) - in.get(C::sha256_helper_w5));
             tmp *= scaling_factor;
             std::get<14>(evals) += typename Accumulator::View(tmp);
         }
         {
             using Accumulator = typename std::tuple_element_t<15, ContainerOverSubrelations>;
-            auto tmp = new_term.sha256_perform_round * (new_term.sha256_helper_w5_shift - new_term.sha256_helper_w6);
+            auto tmp =
+                in.get(C::sha256_perform_round) * (in.get(C::sha256_helper_w5_shift) - in.get(C::sha256_helper_w6));
             tmp *= scaling_factor;
             std::get<15>(evals) += typename Accumulator::View(tmp);
         }
         {
             using Accumulator = typename std::tuple_element_t<16, ContainerOverSubrelations>;
-            auto tmp = new_term.sha256_perform_round * (new_term.sha256_helper_w6_shift - new_term.sha256_helper_w7);
+            auto tmp =
+                in.get(C::sha256_perform_round) * (in.get(C::sha256_helper_w6_shift) - in.get(C::sha256_helper_w7));
             tmp *= scaling_factor;
             std::get<16>(evals) += typename Accumulator::View(tmp);
         }
         {
             using Accumulator = typename std::tuple_element_t<17, ContainerOverSubrelations>;
-            auto tmp = new_term.sha256_perform_round * (new_term.sha256_helper_w7_shift - new_term.sha256_helper_w8);
+            auto tmp =
+                in.get(C::sha256_perform_round) * (in.get(C::sha256_helper_w7_shift) - in.get(C::sha256_helper_w8));
             tmp *= scaling_factor;
             std::get<17>(evals) += typename Accumulator::View(tmp);
         }
         {
             using Accumulator = typename std::tuple_element_t<18, ContainerOverSubrelations>;
-            auto tmp = new_term.sha256_perform_round * (new_term.sha256_helper_w8_shift - new_term.sha256_helper_w9);
+            auto tmp =
+                in.get(C::sha256_perform_round) * (in.get(C::sha256_helper_w8_shift) - in.get(C::sha256_helper_w9));
             tmp *= scaling_factor;
             std::get<18>(evals) += typename Accumulator::View(tmp);
         }
         {
             using Accumulator = typename std::tuple_element_t<19, ContainerOverSubrelations>;
-            auto tmp = new_term.sha256_perform_round * (new_term.sha256_helper_w9_shift - new_term.sha256_helper_w10);
+            auto tmp =
+                in.get(C::sha256_perform_round) * (in.get(C::sha256_helper_w9_shift) - in.get(C::sha256_helper_w10));
             tmp *= scaling_factor;
             std::get<19>(evals) += typename Accumulator::View(tmp);
         }
         {
             using Accumulator = typename std::tuple_element_t<20, ContainerOverSubrelations>;
-            auto tmp = new_term.sha256_perform_round * (new_term.sha256_helper_w10_shift - new_term.sha256_helper_w11);
+            auto tmp =
+                in.get(C::sha256_perform_round) * (in.get(C::sha256_helper_w10_shift) - in.get(C::sha256_helper_w11));
             tmp *= scaling_factor;
             std::get<20>(evals) += typename Accumulator::View(tmp);
         }
         {
             using Accumulator = typename std::tuple_element_t<21, ContainerOverSubrelations>;
-            auto tmp = new_term.sha256_perform_round * (new_term.sha256_helper_w11_shift - new_term.sha256_helper_w12);
+            auto tmp =
+                in.get(C::sha256_perform_round) * (in.get(C::sha256_helper_w11_shift) - in.get(C::sha256_helper_w12));
             tmp *= scaling_factor;
             std::get<21>(evals) += typename Accumulator::View(tmp);
         }
         {
             using Accumulator = typename std::tuple_element_t<22, ContainerOverSubrelations>;
-            auto tmp = new_term.sha256_perform_round * (new_term.sha256_helper_w12_shift - new_term.sha256_helper_w13);
+            auto tmp =
+                in.get(C::sha256_perform_round) * (in.get(C::sha256_helper_w12_shift) - in.get(C::sha256_helper_w13));
             tmp *= scaling_factor;
             std::get<22>(evals) += typename Accumulator::View(tmp);
         }
         {
             using Accumulator = typename std::tuple_element_t<23, ContainerOverSubrelations>;
-            auto tmp = new_term.sha256_perform_round * (new_term.sha256_helper_w13_shift - new_term.sha256_helper_w14);
+            auto tmp =
+                in.get(C::sha256_perform_round) * (in.get(C::sha256_helper_w13_shift) - in.get(C::sha256_helper_w14));
             tmp *= scaling_factor;
             std::get<23>(evals) += typename Accumulator::View(tmp);
         }
         {
             using Accumulator = typename std::tuple_element_t<24, ContainerOverSubrelations>;
-            auto tmp = new_term.sha256_perform_round * (new_term.sha256_helper_w14_shift - new_term.sha256_helper_w15);
+            auto tmp =
+                in.get(C::sha256_perform_round) * (in.get(C::sha256_helper_w14_shift) - in.get(C::sha256_helper_w15));
             tmp *= scaling_factor;
             std::get<24>(evals) += typename Accumulator::View(tmp);
         }
         {
             using Accumulator = typename std::tuple_element_t<25, ContainerOverSubrelations>;
-            auto tmp = new_term.sha256_perform_round * (new_term.sha256_helper_w15_shift - new_term.sha256_w);
+            auto tmp = in.get(C::sha256_perform_round) * (in.get(C::sha256_helper_w15_shift) - in.get(C::sha256_w));
             tmp *= scaling_factor;
             std::get<25>(evals) += typename Accumulator::View(tmp);
         }
         {
             using Accumulator = typename std::tuple_element_t<26, ContainerOverSubrelations>;
-            auto tmp = new_term.sha256_perform_round *
-                       ((new_term.sha256_computed_w_lhs * FF(4294967296UL) + new_term.sha256_computed_w_rhs) -
+            auto tmp = in.get(C::sha256_perform_round) *
+                       ((in.get(C::sha256_computed_w_lhs) * FF(4294967296UL) + in.get(C::sha256_computed_w_rhs)) -
                         sha256_COMPUTED_W);
             tmp *= scaling_factor;
             std::get<26>(evals) += typename Accumulator::View(tmp);
@@ -222,306 +240,325 @@ template <typename FF_> class sha256Impl {
         {
             using Accumulator = typename std::tuple_element_t<27, ContainerOverSubrelations>;
             auto tmp =
-                new_term.sha256_perform_round *
-                (new_term.sha256_w - (new_term.sha256_is_input_round * new_term.sha256_helper_w0 +
-                                      (FF(1) - new_term.sha256_is_input_round) * new_term.sha256_computed_w_rhs));
+                in.get(C::sha256_perform_round) *
+                (in.get(C::sha256_w) - (in.get(C::sha256_is_input_round) * in.get(C::sha256_helper_w0) +
+                                        (FF(1) - in.get(C::sha256_is_input_round)) * in.get(C::sha256_computed_w_rhs)));
             tmp *= scaling_factor;
             std::get<27>(evals) += typename Accumulator::View(tmp);
         }
         {
             using Accumulator = typename std::tuple_element_t<28, ContainerOverSubrelations>;
-            auto tmp = new_term.sha256_perform_round *
-                       (new_term.sha256_helper_w1 - (new_term.sha256_lhs_w_7 * FF(128) + new_term.sha256_rhs_w_7));
+            auto tmp =
+                in.get(C::sha256_perform_round) *
+                (in.get(C::sha256_helper_w1) - (in.get(C::sha256_lhs_w_7) * FF(128) + in.get(C::sha256_rhs_w_7)));
             tmp *= scaling_factor;
             std::get<28>(evals) += typename Accumulator::View(tmp);
         }
         {
             using Accumulator = typename std::tuple_element_t<29, ContainerOverSubrelations>;
-            auto tmp =
-                new_term.sha256_perform_round *
-                (new_term.sha256_w_15_rotr_7 - (new_term.sha256_rhs_w_7 * FF(33554432) + new_term.sha256_lhs_w_7));
+            auto tmp = in.get(C::sha256_perform_round) *
+                       (in.get(C::sha256_w_15_rotr_7) -
+                        (in.get(C::sha256_rhs_w_7) * FF(33554432) + in.get(C::sha256_lhs_w_7)));
             tmp *= scaling_factor;
             std::get<29>(evals) += typename Accumulator::View(tmp);
         }
         {
             using Accumulator = typename std::tuple_element_t<30, ContainerOverSubrelations>;
-            auto tmp = new_term.sha256_perform_round *
-                       (new_term.sha256_helper_w1 - (new_term.sha256_lhs_w_18 * FF(262144) + new_term.sha256_rhs_w_18));
+            auto tmp =
+                in.get(C::sha256_perform_round) *
+                (in.get(C::sha256_helper_w1) - (in.get(C::sha256_lhs_w_18) * FF(262144) + in.get(C::sha256_rhs_w_18)));
             tmp *= scaling_factor;
             std::get<30>(evals) += typename Accumulator::View(tmp);
         }
         {
             using Accumulator = typename std::tuple_element_t<31, ContainerOverSubrelations>;
-            auto tmp =
-                new_term.sha256_perform_round *
-                (new_term.sha256_w_15_rotr_18 - (new_term.sha256_rhs_w_18 * FF(16384) + new_term.sha256_lhs_w_18));
+            auto tmp = in.get(C::sha256_perform_round) *
+                       (in.get(C::sha256_w_15_rotr_18) -
+                        (in.get(C::sha256_rhs_w_18) * FF(16384) + in.get(C::sha256_lhs_w_18)));
             tmp *= scaling_factor;
             std::get<31>(evals) += typename Accumulator::View(tmp);
         }
         {
             using Accumulator = typename std::tuple_element_t<32, ContainerOverSubrelations>;
-            auto tmp = new_term.sha256_perform_round *
-                       (new_term.sha256_helper_w1 - (new_term.sha256_lhs_w_3 * FF(8) + new_term.sha256_rhs_w_3));
+            auto tmp = in.get(C::sha256_perform_round) *
+                       (in.get(C::sha256_helper_w1) - (in.get(C::sha256_lhs_w_3) * FF(8) + in.get(C::sha256_rhs_w_3)));
             tmp *= scaling_factor;
             std::get<32>(evals) += typename Accumulator::View(tmp);
         }
         {
             using Accumulator = typename std::tuple_element_t<33, ContainerOverSubrelations>;
-            auto tmp = new_term.sha256_perform_round * (new_term.sha256_w_15_rshift_3 - new_term.sha256_lhs_w_3);
+            auto tmp = in.get(C::sha256_perform_round) * (in.get(C::sha256_w_15_rshift_3) - in.get(C::sha256_lhs_w_3));
             tmp *= scaling_factor;
             std::get<33>(evals) += typename Accumulator::View(tmp);
         }
         {
             using Accumulator = typename std::tuple_element_t<34, ContainerOverSubrelations>;
             auto tmp =
-                new_term.sha256_perform_round *
-                (new_term.sha256_helper_w14 - (new_term.sha256_lhs_w_17 * FF(131072) + new_term.sha256_rhs_w_17));
+                in.get(C::sha256_perform_round) *
+                (in.get(C::sha256_helper_w14) - (in.get(C::sha256_lhs_w_17) * FF(131072) + in.get(C::sha256_rhs_w_17)));
             tmp *= scaling_factor;
             std::get<34>(evals) += typename Accumulator::View(tmp);
         }
         {
             using Accumulator = typename std::tuple_element_t<35, ContainerOverSubrelations>;
             auto tmp =
-                new_term.sha256_perform_round *
-                (new_term.sha256_w_2_rotr_17 - (new_term.sha256_rhs_w_17 * FF(32768) + new_term.sha256_lhs_w_17));
+                in.get(C::sha256_perform_round) *
+                (in.get(C::sha256_w_2_rotr_17) - (in.get(C::sha256_rhs_w_17) * FF(32768) + in.get(C::sha256_lhs_w_17)));
             tmp *= scaling_factor;
             std::get<35>(evals) += typename Accumulator::View(tmp);
         }
         {
             using Accumulator = typename std::tuple_element_t<36, ContainerOverSubrelations>;
             auto tmp =
-                new_term.sha256_perform_round *
-                (new_term.sha256_helper_w14 - (new_term.sha256_lhs_w_19 * FF(524288) + new_term.sha256_rhs_w_19));
+                in.get(C::sha256_perform_round) *
+                (in.get(C::sha256_helper_w14) - (in.get(C::sha256_lhs_w_19) * FF(524288) + in.get(C::sha256_rhs_w_19)));
             tmp *= scaling_factor;
             std::get<36>(evals) += typename Accumulator::View(tmp);
         }
         {
             using Accumulator = typename std::tuple_element_t<37, ContainerOverSubrelations>;
-            auto tmp = new_term.sha256_perform_round *
-                       (new_term.sha256_w_2_rotr_19 - (new_term.sha256_rhs_w_19 * FF(8192) + new_term.sha256_lhs_w_19));
+            auto tmp =
+                in.get(C::sha256_perform_round) *
+                (in.get(C::sha256_w_2_rotr_19) - (in.get(C::sha256_rhs_w_19) * FF(8192) + in.get(C::sha256_lhs_w_19)));
             tmp *= scaling_factor;
             std::get<37>(evals) += typename Accumulator::View(tmp);
         }
         {
             using Accumulator = typename std::tuple_element_t<38, ContainerOverSubrelations>;
-            auto tmp = new_term.sha256_perform_round *
-                       (new_term.sha256_helper_w14 - (new_term.sha256_lhs_w_10 * FF(1024) + new_term.sha256_rhs_w_10));
+            auto tmp =
+                in.get(C::sha256_perform_round) *
+                (in.get(C::sha256_helper_w14) - (in.get(C::sha256_lhs_w_10) * FF(1024) + in.get(C::sha256_rhs_w_10)));
             tmp *= scaling_factor;
             std::get<38>(evals) += typename Accumulator::View(tmp);
         }
         {
             using Accumulator = typename std::tuple_element_t<39, ContainerOverSubrelations>;
-            auto tmp = new_term.sha256_perform_round * (new_term.sha256_w_2_rshift_10 - new_term.sha256_lhs_w_10);
+            auto tmp = in.get(C::sha256_perform_round) * (in.get(C::sha256_w_2_rshift_10) - in.get(C::sha256_lhs_w_10));
             tmp *= scaling_factor;
             std::get<39>(evals) += typename Accumulator::View(tmp);
         }
         {
             using Accumulator = typename std::tuple_element_t<40, ContainerOverSubrelations>;
-            auto tmp = new_term.sha256_perform_round *
-                       (new_term.sha256_e - (new_term.sha256_lhs_e_6 * FF(64) + new_term.sha256_rhs_e_6));
+            auto tmp = in.get(C::sha256_perform_round) *
+                       (in.get(C::sha256_e) - (in.get(C::sha256_lhs_e_6) * FF(64) + in.get(C::sha256_rhs_e_6)));
             tmp *= scaling_factor;
             std::get<40>(evals) += typename Accumulator::View(tmp);
         }
         {
             using Accumulator = typename std::tuple_element_t<41, ContainerOverSubrelations>;
-            auto tmp = new_term.sha256_perform_round *
-                       (new_term.sha256_e_rotr_6 - (new_term.sha256_rhs_e_6 * FF(67108864) + new_term.sha256_lhs_e_6));
+            auto tmp =
+                in.get(C::sha256_perform_round) *
+                (in.get(C::sha256_e_rotr_6) - (in.get(C::sha256_rhs_e_6) * FF(67108864) + in.get(C::sha256_lhs_e_6)));
             tmp *= scaling_factor;
             std::get<41>(evals) += typename Accumulator::View(tmp);
         }
         {
             using Accumulator = typename std::tuple_element_t<42, ContainerOverSubrelations>;
-            auto tmp = new_term.sha256_perform_round *
-                       (new_term.sha256_e - (new_term.sha256_lhs_e_11 * FF(2048) + new_term.sha256_rhs_e_11));
+            auto tmp = in.get(C::sha256_perform_round) *
+                       (in.get(C::sha256_e) - (in.get(C::sha256_lhs_e_11) * FF(2048) + in.get(C::sha256_rhs_e_11)));
             tmp *= scaling_factor;
             std::get<42>(evals) += typename Accumulator::View(tmp);
         }
         {
             using Accumulator = typename std::tuple_element_t<43, ContainerOverSubrelations>;
             auto tmp =
-                new_term.sha256_perform_round *
-                (new_term.sha256_e_rotr_11 - (new_term.sha256_rhs_e_11 * FF(2097152) + new_term.sha256_lhs_e_11));
+                in.get(C::sha256_perform_round) *
+                (in.get(C::sha256_e_rotr_11) - (in.get(C::sha256_rhs_e_11) * FF(2097152) + in.get(C::sha256_lhs_e_11)));
             tmp *= scaling_factor;
             std::get<43>(evals) += typename Accumulator::View(tmp);
         }
         {
             using Accumulator = typename std::tuple_element_t<44, ContainerOverSubrelations>;
-            auto tmp = new_term.sha256_perform_round *
-                       (new_term.sha256_e - (new_term.sha256_lhs_e_25 * FF(33554432) + new_term.sha256_rhs_e_25));
+            auto tmp = in.get(C::sha256_perform_round) *
+                       (in.get(C::sha256_e) - (in.get(C::sha256_lhs_e_25) * FF(33554432) + in.get(C::sha256_rhs_e_25)));
             tmp *= scaling_factor;
             std::get<44>(evals) += typename Accumulator::View(tmp);
         }
         {
             using Accumulator = typename std::tuple_element_t<45, ContainerOverSubrelations>;
-            auto tmp = new_term.sha256_perform_round *
-                       (new_term.sha256_e_rotr_25 - (new_term.sha256_rhs_e_25 * FF(128) + new_term.sha256_lhs_e_25));
+            auto tmp =
+                in.get(C::sha256_perform_round) *
+                (in.get(C::sha256_e_rotr_25) - (in.get(C::sha256_rhs_e_25) * FF(128) + in.get(C::sha256_lhs_e_25)));
             tmp *= scaling_factor;
             std::get<45>(evals) += typename Accumulator::View(tmp);
         }
         {
             using Accumulator = typename std::tuple_element_t<46, ContainerOverSubrelations>;
-            auto tmp = new_term.sha256_perform_round * ((new_term.sha256_e + new_term.sha256_not_e) - FF(4294967295UL));
+            auto tmp =
+                in.get(C::sha256_perform_round) * ((in.get(C::sha256_e) + in.get(C::sha256_not_e)) - FF(4294967295UL));
             tmp *= scaling_factor;
             std::get<46>(evals) += typename Accumulator::View(tmp);
         }
         {
             using Accumulator = typename std::tuple_element_t<47, ContainerOverSubrelations>;
-            auto tmp = new_term.sha256_perform_round *
-                       (new_term.sha256_a - (new_term.sha256_lhs_a_2 * FF(4) + new_term.sha256_rhs_a_2));
+            auto tmp = in.get(C::sha256_perform_round) *
+                       (in.get(C::sha256_a) - (in.get(C::sha256_lhs_a_2) * FF(4) + in.get(C::sha256_rhs_a_2)));
             tmp *= scaling_factor;
             std::get<47>(evals) += typename Accumulator::View(tmp);
         }
         {
             using Accumulator = typename std::tuple_element_t<48, ContainerOverSubrelations>;
             auto tmp =
-                new_term.sha256_perform_round *
-                (new_term.sha256_a_rotr_2 - (new_term.sha256_rhs_a_2 * FF(1073741824) + new_term.sha256_lhs_a_2));
+                in.get(C::sha256_perform_round) *
+                (in.get(C::sha256_a_rotr_2) - (in.get(C::sha256_rhs_a_2) * FF(1073741824) + in.get(C::sha256_lhs_a_2)));
             tmp *= scaling_factor;
             std::get<48>(evals) += typename Accumulator::View(tmp);
         }
         {
             using Accumulator = typename std::tuple_element_t<49, ContainerOverSubrelations>;
-            auto tmp = new_term.sha256_perform_round *
-                       (new_term.sha256_a - (new_term.sha256_lhs_a_13 * FF(8192) + new_term.sha256_rhs_a_13));
+            auto tmp = in.get(C::sha256_perform_round) *
+                       (in.get(C::sha256_a) - (in.get(C::sha256_lhs_a_13) * FF(8192) + in.get(C::sha256_rhs_a_13)));
             tmp *= scaling_factor;
             std::get<49>(evals) += typename Accumulator::View(tmp);
         }
         {
             using Accumulator = typename std::tuple_element_t<50, ContainerOverSubrelations>;
-            auto tmp = new_term.sha256_perform_round *
-                       (new_term.sha256_a_rotr_13 - (new_term.sha256_rhs_a_13 * FF(524288) + new_term.sha256_lhs_a_13));
+            auto tmp =
+                in.get(C::sha256_perform_round) *
+                (in.get(C::sha256_a_rotr_13) - (in.get(C::sha256_rhs_a_13) * FF(524288) + in.get(C::sha256_lhs_a_13)));
             tmp *= scaling_factor;
             std::get<50>(evals) += typename Accumulator::View(tmp);
         }
         {
             using Accumulator = typename std::tuple_element_t<51, ContainerOverSubrelations>;
-            auto tmp = new_term.sha256_perform_round *
-                       (new_term.sha256_a - (new_term.sha256_lhs_a_22 * FF(4194304) + new_term.sha256_rhs_a_22));
+            auto tmp = in.get(C::sha256_perform_round) *
+                       (in.get(C::sha256_a) - (in.get(C::sha256_lhs_a_22) * FF(4194304) + in.get(C::sha256_rhs_a_22)));
             tmp *= scaling_factor;
             std::get<51>(evals) += typename Accumulator::View(tmp);
         }
         {
             using Accumulator = typename std::tuple_element_t<52, ContainerOverSubrelations>;
-            auto tmp = new_term.sha256_perform_round *
-                       (new_term.sha256_a_rotr_22 - (new_term.sha256_rhs_a_22 * FF(1024) + new_term.sha256_lhs_a_22));
+            auto tmp =
+                in.get(C::sha256_perform_round) *
+                (in.get(C::sha256_a_rotr_22) - (in.get(C::sha256_rhs_a_22) * FF(1024) + in.get(C::sha256_lhs_a_22)));
             tmp *= scaling_factor;
             std::get<52>(evals) += typename Accumulator::View(tmp);
         }
         {
             using Accumulator = typename std::tuple_element_t<53, ContainerOverSubrelations>;
-            auto tmp = new_term.sha256_perform_round *
-                       ((new_term.sha256_next_a_lhs * FF(4294967296UL) + new_term.sha256_next_a_rhs) - sha256_NEXT_A);
+            auto tmp =
+                in.get(C::sha256_perform_round) *
+                ((in.get(C::sha256_next_a_lhs) * FF(4294967296UL) + in.get(C::sha256_next_a_rhs)) - sha256_NEXT_A);
             tmp *= scaling_factor;
             std::get<53>(evals) += typename Accumulator::View(tmp);
         }
         {
             using Accumulator = typename std::tuple_element_t<54, ContainerOverSubrelations>;
-            auto tmp = new_term.sha256_perform_round *
-                       ((new_term.sha256_next_e_lhs * FF(4294967296UL) + new_term.sha256_next_e_rhs) - sha256_NEXT_E);
+            auto tmp =
+                in.get(C::sha256_perform_round) *
+                ((in.get(C::sha256_next_e_lhs) * FF(4294967296UL) + in.get(C::sha256_next_e_rhs)) - sha256_NEXT_E);
             tmp *= scaling_factor;
             std::get<54>(evals) += typename Accumulator::View(tmp);
         }
         {
             using Accumulator = typename std::tuple_element_t<55, ContainerOverSubrelations>;
-            auto tmp = new_term.sha256_perform_round * (new_term.sha256_a_shift - new_term.sha256_next_a_rhs);
+            auto tmp = in.get(C::sha256_perform_round) * (in.get(C::sha256_a_shift) - in.get(C::sha256_next_a_rhs));
             tmp *= scaling_factor;
             std::get<55>(evals) += typename Accumulator::View(tmp);
         }
         {
             using Accumulator = typename std::tuple_element_t<56, ContainerOverSubrelations>;
-            auto tmp = new_term.sha256_perform_round * (new_term.sha256_b_shift - new_term.sha256_a);
+            auto tmp = in.get(C::sha256_perform_round) * (in.get(C::sha256_b_shift) - in.get(C::sha256_a));
             tmp *= scaling_factor;
             std::get<56>(evals) += typename Accumulator::View(tmp);
         }
         {
             using Accumulator = typename std::tuple_element_t<57, ContainerOverSubrelations>;
-            auto tmp = new_term.sha256_perform_round * (new_term.sha256_c_shift - new_term.sha256_b);
+            auto tmp = in.get(C::sha256_perform_round) * (in.get(C::sha256_c_shift) - in.get(C::sha256_b));
             tmp *= scaling_factor;
             std::get<57>(evals) += typename Accumulator::View(tmp);
         }
         {
             using Accumulator = typename std::tuple_element_t<58, ContainerOverSubrelations>;
-            auto tmp = new_term.sha256_perform_round * (new_term.sha256_d_shift - new_term.sha256_c);
+            auto tmp = in.get(C::sha256_perform_round) * (in.get(C::sha256_d_shift) - in.get(C::sha256_c));
             tmp *= scaling_factor;
             std::get<58>(evals) += typename Accumulator::View(tmp);
         }
         {
             using Accumulator = typename std::tuple_element_t<59, ContainerOverSubrelations>;
-            auto tmp = new_term.sha256_perform_round * (new_term.sha256_e_shift - new_term.sha256_next_e_rhs);
+            auto tmp = in.get(C::sha256_perform_round) * (in.get(C::sha256_e_shift) - in.get(C::sha256_next_e_rhs));
             tmp *= scaling_factor;
             std::get<59>(evals) += typename Accumulator::View(tmp);
         }
         {
             using Accumulator = typename std::tuple_element_t<60, ContainerOverSubrelations>;
-            auto tmp = new_term.sha256_perform_round * (new_term.sha256_f_shift - new_term.sha256_e);
+            auto tmp = in.get(C::sha256_perform_round) * (in.get(C::sha256_f_shift) - in.get(C::sha256_e));
             tmp *= scaling_factor;
             std::get<60>(evals) += typename Accumulator::View(tmp);
         }
         {
             using Accumulator = typename std::tuple_element_t<61, ContainerOverSubrelations>;
-            auto tmp = new_term.sha256_perform_round * (new_term.sha256_g_shift - new_term.sha256_f);
+            auto tmp = in.get(C::sha256_perform_round) * (in.get(C::sha256_g_shift) - in.get(C::sha256_f));
             tmp *= scaling_factor;
             std::get<61>(evals) += typename Accumulator::View(tmp);
         }
         {
             using Accumulator = typename std::tuple_element_t<62, ContainerOverSubrelations>;
-            auto tmp = new_term.sha256_perform_round * (new_term.sha256_h_shift - new_term.sha256_g);
+            auto tmp = in.get(C::sha256_perform_round) * (in.get(C::sha256_h_shift) - in.get(C::sha256_g));
             tmp *= scaling_factor;
             std::get<62>(evals) += typename Accumulator::View(tmp);
         }
         {
             using Accumulator = typename std::tuple_element_t<63, ContainerOverSubrelations>;
-            auto tmp = sha256_LAST * (sha256_OUT_A -
-                                      (new_term.sha256_output_a_lhs * FF(4294967296UL) + new_term.sha256_output_a_rhs));
+            auto tmp =
+                sha256_LAST *
+                (sha256_OUT_A - (in.get(C::sha256_output_a_lhs) * FF(4294967296UL) + in.get(C::sha256_output_a_rhs)));
             tmp *= scaling_factor;
             std::get<63>(evals) += typename Accumulator::View(tmp);
         }
         {
             using Accumulator = typename std::tuple_element_t<64, ContainerOverSubrelations>;
-            auto tmp = sha256_LAST * (sha256_OUT_B -
-                                      (new_term.sha256_output_b_lhs * FF(4294967296UL) + new_term.sha256_output_b_rhs));
+            auto tmp =
+                sha256_LAST *
+                (sha256_OUT_B - (in.get(C::sha256_output_b_lhs) * FF(4294967296UL) + in.get(C::sha256_output_b_rhs)));
             tmp *= scaling_factor;
             std::get<64>(evals) += typename Accumulator::View(tmp);
         }
         {
             using Accumulator = typename std::tuple_element_t<65, ContainerOverSubrelations>;
-            auto tmp = sha256_LAST * (sha256_OUT_C -
-                                      (new_term.sha256_output_c_lhs * FF(4294967296UL) + new_term.sha256_output_c_rhs));
+            auto tmp =
+                sha256_LAST *
+                (sha256_OUT_C - (in.get(C::sha256_output_c_lhs) * FF(4294967296UL) + in.get(C::sha256_output_c_rhs)));
             tmp *= scaling_factor;
             std::get<65>(evals) += typename Accumulator::View(tmp);
         }
         {
             using Accumulator = typename std::tuple_element_t<66, ContainerOverSubrelations>;
-            auto tmp = sha256_LAST * (sha256_OUT_D -
-                                      (new_term.sha256_output_d_lhs * FF(4294967296UL) + new_term.sha256_output_d_rhs));
+            auto tmp =
+                sha256_LAST *
+                (sha256_OUT_D - (in.get(C::sha256_output_d_lhs) * FF(4294967296UL) + in.get(C::sha256_output_d_rhs)));
             tmp *= scaling_factor;
             std::get<66>(evals) += typename Accumulator::View(tmp);
         }
         {
             using Accumulator = typename std::tuple_element_t<67, ContainerOverSubrelations>;
-            auto tmp = sha256_LAST * (sha256_OUT_E -
-                                      (new_term.sha256_output_e_lhs * FF(4294967296UL) + new_term.sha256_output_e_rhs));
+            auto tmp =
+                sha256_LAST *
+                (sha256_OUT_E - (in.get(C::sha256_output_e_lhs) * FF(4294967296UL) + in.get(C::sha256_output_e_rhs)));
             tmp *= scaling_factor;
             std::get<67>(evals) += typename Accumulator::View(tmp);
         }
         {
             using Accumulator = typename std::tuple_element_t<68, ContainerOverSubrelations>;
-            auto tmp = sha256_LAST * (sha256_OUT_F -
-                                      (new_term.sha256_output_f_lhs * FF(4294967296UL) + new_term.sha256_output_f_rhs));
+            auto tmp =
+                sha256_LAST *
+                (sha256_OUT_F - (in.get(C::sha256_output_f_lhs) * FF(4294967296UL) + in.get(C::sha256_output_f_rhs)));
             tmp *= scaling_factor;
             std::get<68>(evals) += typename Accumulator::View(tmp);
         }
         {
             using Accumulator = typename std::tuple_element_t<69, ContainerOverSubrelations>;
-            auto tmp = sha256_LAST * (sha256_OUT_G -
-                                      (new_term.sha256_output_g_lhs * FF(4294967296UL) + new_term.sha256_output_g_rhs));
+            auto tmp =
+                sha256_LAST *
+                (sha256_OUT_G - (in.get(C::sha256_output_g_lhs) * FF(4294967296UL) + in.get(C::sha256_output_g_rhs)));
             tmp *= scaling_factor;
             std::get<69>(evals) += typename Accumulator::View(tmp);
         }
         {
             using Accumulator = typename std::tuple_element_t<70, ContainerOverSubrelations>;
-            auto tmp = sha256_LAST * (sha256_OUT_H -
-                                      (new_term.sha256_output_h_lhs * FF(4294967296UL) + new_term.sha256_output_h_rhs));
+            auto tmp =
+                sha256_LAST *
+                (sha256_OUT_H - (in.get(C::sha256_output_h_lhs) * FF(4294967296UL) + in.get(C::sha256_output_h_rhs)));
             tmp *= scaling_factor;
             std::get<70>(evals) += typename Accumulator::View(tmp);
         }

--- a/barretenberg/cpp/src/barretenberg/vm2/generated/relations/to_radix.hpp
+++ b/barretenberg/cpp/src/barretenberg/vm2/generated/relations/to_radix.hpp
@@ -5,6 +5,7 @@
 
 #include "barretenberg/relations/relation_parameters.hpp"
 #include "barretenberg/relations/relation_types.hpp"
+#include "barretenberg/vm2/generated/columns.hpp"
 
 namespace bb::avm2 {
 
@@ -18,283 +19,288 @@ template <typename FF_> class to_radixImpl {
 
     template <typename AllEntities> inline static bool skip(const AllEntities& in)
     {
-        const auto& new_term = in;
-        return (new_term.to_radix_sel).is_zero();
+        using C = ColumnAndShifts;
+        return (in.get(C::to_radix_sel)).is_zero();
     }
 
     template <typename ContainerOverSubrelations, typename AllEntities>
     void static accumulate(ContainerOverSubrelations& evals,
-                           const AllEntities& new_term,
+                           const AllEntities& in,
                            [[maybe_unused]] const RelationParameters<FF>&,
                            [[maybe_unused]] const FF& scaling_factor)
     {
-        const auto to_radix_LATCH_CONDITION = new_term.to_radix_end + new_term.precomputed_first_row;
-        const auto to_radix_REM = (new_term.to_radix_value - new_term.to_radix_acc);
-        const auto to_radix_safety_diff = (new_term.to_radix_limb_index - new_term.to_radix_safe_limbs);
-        const auto to_radix_LIMB_LT_P = ((new_term.to_radix_p_limb - new_term.to_radix_limb) - FF(1));
-        const auto to_radix_LIMB_GT_P = ((new_term.to_radix_limb - new_term.to_radix_p_limb) - FF(1));
-        const auto to_radix_LIMB_EQ_P = (new_term.to_radix_limb - new_term.to_radix_p_limb) * FF(256);
+        using C = ColumnAndShifts;
+
+        const auto to_radix_LATCH_CONDITION = in.get(C::to_radix_end) + in.get(C::precomputed_first_row);
+        const auto to_radix_REM = (in.get(C::to_radix_value) - in.get(C::to_radix_acc));
+        const auto to_radix_safety_diff = (in.get(C::to_radix_limb_index) - in.get(C::to_radix_safe_limbs));
+        const auto to_radix_LIMB_LT_P = ((in.get(C::to_radix_p_limb) - in.get(C::to_radix_limb)) - FF(1));
+        const auto to_radix_LIMB_GT_P = ((in.get(C::to_radix_limb) - in.get(C::to_radix_p_limb)) - FF(1));
+        const auto to_radix_LIMB_EQ_P = (in.get(C::to_radix_limb) - in.get(C::to_radix_p_limb)) * FF(256);
 
         {
             using Accumulator = typename std::tuple_element_t<0, ContainerOverSubrelations>;
-            auto tmp = new_term.to_radix_sel * (FF(1) - new_term.to_radix_sel);
+            auto tmp = in.get(C::to_radix_sel) * (FF(1) - in.get(C::to_radix_sel));
             tmp *= scaling_factor;
             std::get<0>(evals) += typename Accumulator::View(tmp);
         }
         {
             using Accumulator = typename std::tuple_element_t<1, ContainerOverSubrelations>;
-            auto tmp = new_term.to_radix_start * (FF(1) - new_term.to_radix_start);
+            auto tmp = in.get(C::to_radix_start) * (FF(1) - in.get(C::to_radix_start));
             tmp *= scaling_factor;
             std::get<1>(evals) += typename Accumulator::View(tmp);
         }
         {
             using Accumulator = typename std::tuple_element_t<2, ContainerOverSubrelations>;
-            auto tmp = new_term.to_radix_end * (FF(1) - new_term.to_radix_end);
+            auto tmp = in.get(C::to_radix_end) * (FF(1) - in.get(C::to_radix_end));
             tmp *= scaling_factor;
             std::get<2>(evals) += typename Accumulator::View(tmp);
         }
         {
             using Accumulator = typename std::tuple_element_t<3, ContainerOverSubrelations>;
-            auto tmp = new_term.to_radix_end * new_term.precomputed_first_row;
+            auto tmp = in.get(C::to_radix_end) * in.get(C::precomputed_first_row);
             tmp *= scaling_factor;
             std::get<3>(evals) += typename Accumulator::View(tmp);
         }
         { // START_AFTER_LATCH
             using Accumulator = typename std::tuple_element_t<4, ContainerOverSubrelations>;
-            auto tmp = new_term.to_radix_sel_shift * (new_term.to_radix_start_shift - to_radix_LATCH_CONDITION);
+            auto tmp = in.get(C::to_radix_sel_shift) * (in.get(C::to_radix_start_shift) - to_radix_LATCH_CONDITION);
             tmp *= scaling_factor;
             std::get<4>(evals) += typename Accumulator::View(tmp);
         }
         { // SELECTOR_ON_START
             using Accumulator = typename std::tuple_element_t<5, ContainerOverSubrelations>;
-            auto tmp = new_term.to_radix_start * (FF(1) - new_term.to_radix_sel);
+            auto tmp = in.get(C::to_radix_start) * (FF(1) - in.get(C::to_radix_sel));
             tmp *= scaling_factor;
             std::get<5>(evals) += typename Accumulator::View(tmp);
         }
         { // SELECTOR_CONSISTENCY
             using Accumulator = typename std::tuple_element_t<6, ContainerOverSubrelations>;
-            auto tmp = (new_term.to_radix_sel_shift - new_term.to_radix_sel) * (FF(1) - to_radix_LATCH_CONDITION);
+            auto tmp = (in.get(C::to_radix_sel_shift) - in.get(C::to_radix_sel)) * (FF(1) - to_radix_LATCH_CONDITION);
             tmp *= scaling_factor;
             std::get<6>(evals) += typename Accumulator::View(tmp);
         }
         {
             using Accumulator = typename std::tuple_element_t<7, ContainerOverSubrelations>;
-            auto tmp = new_term.to_radix_end * (FF(1) - new_term.to_radix_sel);
+            auto tmp = in.get(C::to_radix_end) * (FF(1) - in.get(C::to_radix_sel));
             tmp *= scaling_factor;
             std::get<7>(evals) += typename Accumulator::View(tmp);
         }
         {
             using Accumulator = typename std::tuple_element_t<8, ContainerOverSubrelations>;
-            auto tmp = (new_term.to_radix_sel * (FF(1) - new_term.to_radix_end) - new_term.to_radix_not_end);
+            auto tmp = (in.get(C::to_radix_sel) * (FF(1) - in.get(C::to_radix_end)) - in.get(C::to_radix_not_end));
             tmp *= scaling_factor;
             std::get<8>(evals) += typename Accumulator::View(tmp);
         }
         {
             using Accumulator = typename std::tuple_element_t<9, ContainerOverSubrelations>;
-            auto tmp = new_term.to_radix_not_padding_limb * (FF(1) - new_term.to_radix_not_padding_limb);
+            auto tmp = in.get(C::to_radix_not_padding_limb) * (FF(1) - in.get(C::to_radix_not_padding_limb));
             tmp *= scaling_factor;
             std::get<9>(evals) += typename Accumulator::View(tmp);
         }
         {
             using Accumulator = typename std::tuple_element_t<10, ContainerOverSubrelations>;
-            auto tmp = new_term.to_radix_start * (new_term.to_radix_exponent - FF(1));
+            auto tmp = in.get(C::to_radix_start) * (in.get(C::to_radix_exponent) - FF(1));
             tmp *= scaling_factor;
             std::get<10>(evals) += typename Accumulator::View(tmp);
         }
         {
             using Accumulator = typename std::tuple_element_t<11, ContainerOverSubrelations>;
-            auto tmp = new_term.to_radix_not_end * new_term.to_radix_not_padding_limb_shift *
-                       (new_term.to_radix_exponent * new_term.to_radix_radix - new_term.to_radix_exponent_shift);
+            auto tmp = in.get(C::to_radix_not_end) * in.get(C::to_radix_not_padding_limb_shift) *
+                       (in.get(C::to_radix_exponent) * in.get(C::to_radix_radix) - in.get(C::to_radix_exponent_shift));
             tmp *= scaling_factor;
             std::get<11>(evals) += typename Accumulator::View(tmp);
         }
         {
             using Accumulator = typename std::tuple_element_t<12, ContainerOverSubrelations>;
-            auto tmp = new_term.to_radix_start * (FF(1) - new_term.to_radix_not_padding_limb);
+            auto tmp = in.get(C::to_radix_start) * (FF(1) - in.get(C::to_radix_not_padding_limb));
             tmp *= scaling_factor;
             std::get<12>(evals) += typename Accumulator::View(tmp);
         }
         {
             using Accumulator = typename std::tuple_element_t<13, ContainerOverSubrelations>;
-            auto tmp = new_term.to_radix_not_end *
-                       (((FF(0) - new_term.to_radix_not_padding_limb) * new_term.to_radix_is_unsafe_limb +
-                         new_term.to_radix_not_padding_limb) -
-                        new_term.to_radix_not_padding_limb_shift);
+            auto tmp = in.get(C::to_radix_not_end) *
+                       (((FF(0) - in.get(C::to_radix_not_padding_limb)) * in.get(C::to_radix_is_unsafe_limb) +
+                         in.get(C::to_radix_not_padding_limb)) -
+                        in.get(C::to_radix_not_padding_limb_shift));
             tmp *= scaling_factor;
             std::get<13>(evals) += typename Accumulator::View(tmp);
         }
         {
             using Accumulator = typename std::tuple_element_t<14, ContainerOverSubrelations>;
-            auto tmp = (FF(1) - new_term.to_radix_not_padding_limb) * new_term.to_radix_exponent;
+            auto tmp = (FF(1) - in.get(C::to_radix_not_padding_limb)) * in.get(C::to_radix_exponent);
             tmp *= scaling_factor;
             std::get<14>(evals) += typename Accumulator::View(tmp);
         }
         {
             using Accumulator = typename std::tuple_element_t<15, ContainerOverSubrelations>;
-            auto tmp = new_term.to_radix_found * (FF(1) - new_term.to_radix_found);
+            auto tmp = in.get(C::to_radix_found) * (FF(1) - in.get(C::to_radix_found));
             tmp *= scaling_factor;
             std::get<15>(evals) += typename Accumulator::View(tmp);
         }
         {
             using Accumulator = typename std::tuple_element_t<16, ContainerOverSubrelations>;
-            auto tmp = new_term.to_radix_start * new_term.to_radix_limb_index;
+            auto tmp = in.get(C::to_radix_start) * in.get(C::to_radix_limb_index);
             tmp *= scaling_factor;
             std::get<16>(evals) += typename Accumulator::View(tmp);
         }
         {
             using Accumulator = typename std::tuple_element_t<17, ContainerOverSubrelations>;
-            auto tmp = new_term.to_radix_not_end *
-                       ((new_term.to_radix_limb_index + FF(1)) - new_term.to_radix_limb_index_shift);
+            auto tmp = in.get(C::to_radix_not_end) *
+                       ((in.get(C::to_radix_limb_index) + FF(1)) - in.get(C::to_radix_limb_index_shift));
             tmp *= scaling_factor;
             std::get<17>(evals) += typename Accumulator::View(tmp);
         }
         {
             using Accumulator = typename std::tuple_element_t<18, ContainerOverSubrelations>;
-            auto tmp = new_term.to_radix_sel * (((new_term.to_radix_radix - FF(1)) - new_term.to_radix_limb) -
-                                                new_term.to_radix_limb_radix_diff);
+            auto tmp = in.get(C::to_radix_sel) * (((in.get(C::to_radix_radix) - FF(1)) - in.get(C::to_radix_limb)) -
+                                                  in.get(C::to_radix_limb_radix_diff));
             tmp *= scaling_factor;
             std::get<18>(evals) += typename Accumulator::View(tmp);
         }
         {
             using Accumulator = typename std::tuple_element_t<19, ContainerOverSubrelations>;
-            auto tmp = new_term.to_radix_start * (new_term.to_radix_acc - new_term.to_radix_limb);
+            auto tmp = in.get(C::to_radix_start) * (in.get(C::to_radix_acc) - in.get(C::to_radix_limb));
             tmp *= scaling_factor;
             std::get<19>(evals) += typename Accumulator::View(tmp);
         }
         {
             using Accumulator = typename std::tuple_element_t<20, ContainerOverSubrelations>;
-            auto tmp = new_term.to_radix_not_end *
-                       ((new_term.to_radix_acc + new_term.to_radix_exponent_shift * new_term.to_radix_limb_shift) -
-                        new_term.to_radix_acc_shift);
+            auto tmp =
+                in.get(C::to_radix_not_end) *
+                ((in.get(C::to_radix_acc) + in.get(C::to_radix_exponent_shift) * in.get(C::to_radix_limb_shift)) -
+                 in.get(C::to_radix_acc_shift));
             tmp *= scaling_factor;
             std::get<20>(evals) += typename Accumulator::View(tmp);
         }
         {
             using Accumulator = typename std::tuple_element_t<21, ContainerOverSubrelations>;
-            auto tmp = new_term.to_radix_sel *
-                       ((to_radix_REM * (new_term.to_radix_found * (FF(1) - new_term.to_radix_rem_inverse) +
-                                         new_term.to_radix_rem_inverse) -
+            auto tmp = in.get(C::to_radix_sel) *
+                       ((to_radix_REM * (in.get(C::to_radix_found) * (FF(1) - in.get(C::to_radix_rem_inverse)) +
+                                         in.get(C::to_radix_rem_inverse)) -
                          FF(1)) +
-                        new_term.to_radix_found);
+                        in.get(C::to_radix_found));
             tmp *= scaling_factor;
             std::get<21>(evals) += typename Accumulator::View(tmp);
         }
         {
             using Accumulator = typename std::tuple_element_t<22, ContainerOverSubrelations>;
-            auto tmp = new_term.to_radix_not_end * new_term.to_radix_found * new_term.to_radix_limb_shift;
+            auto tmp = in.get(C::to_radix_not_end) * in.get(C::to_radix_found) * in.get(C::to_radix_limb_shift);
             tmp *= scaling_factor;
             std::get<22>(evals) += typename Accumulator::View(tmp);
         }
         {
             using Accumulator = typename std::tuple_element_t<23, ContainerOverSubrelations>;
-            auto tmp = (FF(1) - new_term.to_radix_found) * new_term.to_radix_end;
+            auto tmp = (FF(1) - in.get(C::to_radix_found)) * in.get(C::to_radix_end);
             tmp *= scaling_factor;
             std::get<23>(evals) += typename Accumulator::View(tmp);
         }
         {
             using Accumulator = typename std::tuple_element_t<24, ContainerOverSubrelations>;
-            auto tmp = new_term.to_radix_is_unsafe_limb * (FF(1) - new_term.to_radix_is_unsafe_limb);
+            auto tmp = in.get(C::to_radix_is_unsafe_limb) * (FF(1) - in.get(C::to_radix_is_unsafe_limb));
             tmp *= scaling_factor;
             std::get<24>(evals) += typename Accumulator::View(tmp);
         }
         {
             using Accumulator = typename std::tuple_element_t<25, ContainerOverSubrelations>;
-            auto tmp = (FF(1) - new_term.to_radix_not_padding_limb) * new_term.to_radix_limb;
+            auto tmp = (FF(1) - in.get(C::to_radix_not_padding_limb)) * in.get(C::to_radix_limb);
             tmp *= scaling_factor;
             std::get<25>(evals) += typename Accumulator::View(tmp);
         }
         {
             using Accumulator = typename std::tuple_element_t<26, ContainerOverSubrelations>;
-            auto tmp = (FF(1) - new_term.to_radix_not_padding_limb) * new_term.to_radix_p_limb;
+            auto tmp = (FF(1) - in.get(C::to_radix_not_padding_limb)) * in.get(C::to_radix_p_limb);
             tmp *= scaling_factor;
             std::get<26>(evals) += typename Accumulator::View(tmp);
         }
         {
             using Accumulator = typename std::tuple_element_t<27, ContainerOverSubrelations>;
-            auto tmp = new_term.to_radix_sel *
+            auto tmp = in.get(C::to_radix_sel) *
                        ((to_radix_safety_diff *
-                             (new_term.to_radix_is_unsafe_limb * (FF(1) - new_term.to_radix_safety_diff_inverse) +
-                              new_term.to_radix_safety_diff_inverse) -
+                             (in.get(C::to_radix_is_unsafe_limb) * (FF(1) - in.get(C::to_radix_safety_diff_inverse)) +
+                              in.get(C::to_radix_safety_diff_inverse)) -
                          FF(1)) +
-                        new_term.to_radix_is_unsafe_limb);
+                        in.get(C::to_radix_is_unsafe_limb));
             tmp *= scaling_factor;
             std::get<27>(evals) += typename Accumulator::View(tmp);
         }
         {
             using Accumulator = typename std::tuple_element_t<28, ContainerOverSubrelations>;
-            auto tmp = new_term.to_radix_acc_under_p * (FF(1) - new_term.to_radix_acc_under_p);
+            auto tmp = in.get(C::to_radix_acc_under_p) * (FF(1) - in.get(C::to_radix_acc_under_p));
             tmp *= scaling_factor;
             std::get<28>(evals) += typename Accumulator::View(tmp);
         }
         {
             using Accumulator = typename std::tuple_element_t<29, ContainerOverSubrelations>;
-            auto tmp = new_term.to_radix_limb_lt_p * (FF(1) - new_term.to_radix_limb_lt_p);
+            auto tmp = in.get(C::to_radix_limb_lt_p) * (FF(1) - in.get(C::to_radix_limb_lt_p));
             tmp *= scaling_factor;
             std::get<29>(evals) += typename Accumulator::View(tmp);
         }
         {
             using Accumulator = typename std::tuple_element_t<30, ContainerOverSubrelations>;
-            auto tmp = new_term.to_radix_limb_eq_p * (FF(1) - new_term.to_radix_limb_eq_p);
+            auto tmp = in.get(C::to_radix_limb_eq_p) * (FF(1) - in.get(C::to_radix_limb_eq_p));
             tmp *= scaling_factor;
             std::get<30>(evals) += typename Accumulator::View(tmp);
         }
         {
             using Accumulator = typename std::tuple_element_t<31, ContainerOverSubrelations>;
-            auto tmp = new_term.to_radix_limb_eq_p * new_term.to_radix_limb_lt_p;
+            auto tmp = in.get(C::to_radix_limb_eq_p) * in.get(C::to_radix_limb_lt_p);
             tmp *= scaling_factor;
             std::get<31>(evals) += typename Accumulator::View(tmp);
         }
         {
             using Accumulator = typename std::tuple_element_t<32, ContainerOverSubrelations>;
-            auto tmp = new_term.to_radix_limb_lt_p * (to_radix_LIMB_LT_P - new_term.to_radix_limb_p_diff);
+            auto tmp = in.get(C::to_radix_limb_lt_p) * (to_radix_LIMB_LT_P - in.get(C::to_radix_limb_p_diff));
             tmp *= scaling_factor;
             std::get<32>(evals) += typename Accumulator::View(tmp);
         }
         {
             using Accumulator = typename std::tuple_element_t<33, ContainerOverSubrelations>;
-            auto tmp = new_term.to_radix_sel * (FF(1) - new_term.to_radix_limb_lt_p) *
-                       (((to_radix_LIMB_EQ_P - to_radix_LIMB_GT_P) * new_term.to_radix_limb_eq_p + to_radix_LIMB_GT_P) -
-                        new_term.to_radix_limb_p_diff);
+            auto tmp =
+                in.get(C::to_radix_sel) * (FF(1) - in.get(C::to_radix_limb_lt_p)) *
+                (((to_radix_LIMB_EQ_P - to_radix_LIMB_GT_P) * in.get(C::to_radix_limb_eq_p) + to_radix_LIMB_GT_P) -
+                 in.get(C::to_radix_limb_p_diff));
             tmp *= scaling_factor;
             std::get<33>(evals) += typename Accumulator::View(tmp);
         }
         {
             using Accumulator = typename std::tuple_element_t<34, ContainerOverSubrelations>;
-            auto tmp = new_term.to_radix_start * (new_term.to_radix_acc_under_p - new_term.to_radix_limb_lt_p);
+            auto tmp = in.get(C::to_radix_start) * (in.get(C::to_radix_acc_under_p) - in.get(C::to_radix_limb_lt_p));
             tmp *= scaling_factor;
             std::get<34>(evals) += typename Accumulator::View(tmp);
         }
         {
             using Accumulator = typename std::tuple_element_t<35, ContainerOverSubrelations>;
-            auto tmp =
-                new_term.to_radix_not_end * (((new_term.to_radix_acc_under_p - new_term.to_radix_limb_lt_p_shift) *
-                                                  new_term.to_radix_limb_eq_p_shift +
-                                              new_term.to_radix_limb_lt_p_shift) -
-                                             new_term.to_radix_acc_under_p_shift);
+            auto tmp = in.get(C::to_radix_not_end) *
+                       (((in.get(C::to_radix_acc_under_p) - in.get(C::to_radix_limb_lt_p_shift)) *
+                             in.get(C::to_radix_limb_eq_p_shift) +
+                         in.get(C::to_radix_limb_lt_p_shift)) -
+                        in.get(C::to_radix_acc_under_p_shift));
             tmp *= scaling_factor;
             std::get<35>(evals) += typename Accumulator::View(tmp);
         }
         { // OVERFLOW_CHECK
             using Accumulator = typename std::tuple_element_t<36, ContainerOverSubrelations>;
-            auto tmp = new_term.to_radix_is_unsafe_limb * (FF(1) - new_term.to_radix_acc_under_p);
+            auto tmp = in.get(C::to_radix_is_unsafe_limb) * (FF(1) - in.get(C::to_radix_acc_under_p));
             tmp *= scaling_factor;
             std::get<36>(evals) += typename Accumulator::View(tmp);
         }
         { // CONSTANT_CONSISTENCY_RADIX
             using Accumulator = typename std::tuple_element_t<37, ContainerOverSubrelations>;
-            auto tmp = new_term.to_radix_not_end * (new_term.to_radix_radix - new_term.to_radix_radix_shift);
+            auto tmp = in.get(C::to_radix_not_end) * (in.get(C::to_radix_radix) - in.get(C::to_radix_radix_shift));
             tmp *= scaling_factor;
             std::get<37>(evals) += typename Accumulator::View(tmp);
         }
         { // CONSTANT_CONSISTENCY_VALUE
             using Accumulator = typename std::tuple_element_t<38, ContainerOverSubrelations>;
-            auto tmp = new_term.to_radix_not_end * (new_term.to_radix_value - new_term.to_radix_value_shift);
+            auto tmp = in.get(C::to_radix_not_end) * (in.get(C::to_radix_value) - in.get(C::to_radix_value_shift));
             tmp *= scaling_factor;
             std::get<38>(evals) += typename Accumulator::View(tmp);
         }
         { // CONSTANT_CONSISTENCY_SAFE_LIMBS
             using Accumulator = typename std::tuple_element_t<39, ContainerOverSubrelations>;
-            auto tmp = new_term.to_radix_not_end * (new_term.to_radix_safe_limbs - new_term.to_radix_safe_limbs_shift);
+            auto tmp =
+                in.get(C::to_radix_not_end) * (in.get(C::to_radix_safe_limbs) - in.get(C::to_radix_safe_limbs_shift));
             tmp *= scaling_factor;
             std::get<39>(evals) += typename Accumulator::View(tmp);
         }

--- a/barretenberg/cpp/src/barretenberg/vm2/generated/relations/update_check.hpp
+++ b/barretenberg/cpp/src/barretenberg/vm2/generated/relations/update_check.hpp
@@ -5,6 +5,7 @@
 
 #include "barretenberg/relations/relation_parameters.hpp"
 #include "barretenberg/relations/relation_types.hpp"
+#include "barretenberg/vm2/generated/columns.hpp"
 
 namespace bb::avm2 {
 
@@ -17,75 +18,77 @@ template <typename FF_> class update_checkImpl {
 
     template <typename AllEntities> inline static bool skip(const AllEntities& in)
     {
-        const auto& new_term = in;
-        return (new_term.update_check_sel).is_zero();
+        using C = ColumnAndShifts;
+        return (in.get(C::update_check_sel)).is_zero();
     }
 
     template <typename ContainerOverSubrelations, typename AllEntities>
     void static accumulate(ContainerOverSubrelations& evals,
-                           const AllEntities& new_term,
+                           const AllEntities& in,
                            [[maybe_unused]] const RelationParameters<FF>&,
                            [[maybe_unused]] const FF& scaling_factor)
     {
+        using C = ColumnAndShifts;
+
         const auto constants_DEPLOYER_CONTRACT_ADDRESS = FF(2);
         const auto constants_UPDATED_CLASS_IDS_SLOT = FF(1);
         const auto constants_BLOCK_NUMBER_BIT_SIZE = FF(32);
         const auto constants_UPDATES_SHARED_MUTABLE_VALUES_LEN = FF(3);
         const auto constants_UPDATES_SHARED_MUTABLE_METADATA_BIT_SIZE = FF(144);
         const auto constants_GENERATOR_INDEX__PUBLIC_LEAF_INDEX = FF(23);
-        const auto update_check_HASH_IS_ZERO = (FF(1) - new_term.update_check_hash_not_zero);
+        const auto update_check_HASH_IS_ZERO = (FF(1) - in.get(C::update_check_hash_not_zero));
         const auto update_check_TWO_POW_32 = FF(4294967296UL);
         const auto update_check_BLOCKNUMBER_LT_BLOCK_OF_CHANGE =
-            ((new_term.update_check_update_block_of_change - FF(1)) - new_term.update_check_block_number);
+            ((in.get(C::update_check_update_block_of_change) - FF(1)) - in.get(C::update_check_block_number));
         const auto update_check_BLOCKNUMBER_GTE_BLOCK_OF_CHANGE =
-            (new_term.update_check_block_number - new_term.update_check_update_block_of_change);
+            (in.get(C::update_check_block_number) - in.get(C::update_check_update_block_of_change));
 
         {
             using Accumulator = typename std::tuple_element_t<0, ContainerOverSubrelations>;
-            auto tmp = new_term.update_check_sel * (FF(1) - new_term.update_check_sel);
+            auto tmp = in.get(C::update_check_sel) * (FF(1) - in.get(C::update_check_sel));
             tmp *= scaling_factor;
             std::get<0>(evals) += typename Accumulator::View(tmp);
         }
         {
             using Accumulator = typename std::tuple_element_t<1, ContainerOverSubrelations>;
-            auto tmp = new_term.update_check_sel *
-                       (constants_UPDATED_CLASS_IDS_SLOT - new_term.update_check_updated_class_ids_slot);
+            auto tmp = in.get(C::update_check_sel) *
+                       (constants_UPDATED_CLASS_IDS_SLOT - in.get(C::update_check_updated_class_ids_slot));
             tmp *= scaling_factor;
             std::get<1>(evals) += typename Accumulator::View(tmp);
         }
         {
             using Accumulator = typename std::tuple_element_t<2, ContainerOverSubrelations>;
-            auto tmp = new_term.update_check_sel *
-                       ((new_term.update_check_shared_mutable_slot + constants_UPDATES_SHARED_MUTABLE_VALUES_LEN) -
-                        new_term.update_check_shared_mutable_hash_slot);
+            auto tmp = in.get(C::update_check_sel) *
+                       ((in.get(C::update_check_shared_mutable_slot) + constants_UPDATES_SHARED_MUTABLE_VALUES_LEN) -
+                        in.get(C::update_check_shared_mutable_hash_slot));
             tmp *= scaling_factor;
             std::get<2>(evals) += typename Accumulator::View(tmp);
         }
         {
             using Accumulator = typename std::tuple_element_t<3, ContainerOverSubrelations>;
-            auto tmp = new_term.update_check_sel * (constants_GENERATOR_INDEX__PUBLIC_LEAF_INDEX -
-                                                    new_term.update_check_public_leaf_index_domain_separator);
+            auto tmp = in.get(C::update_check_sel) * (constants_GENERATOR_INDEX__PUBLIC_LEAF_INDEX -
+                                                      in.get(C::update_check_public_leaf_index_domain_separator));
             tmp *= scaling_factor;
             std::get<3>(evals) += typename Accumulator::View(tmp);
         }
         {
             using Accumulator = typename std::tuple_element_t<4, ContainerOverSubrelations>;
-            auto tmp = new_term.update_check_sel *
-                       (constants_DEPLOYER_CONTRACT_ADDRESS - new_term.update_check_deployer_protocol_contract_address);
+            auto tmp = in.get(C::update_check_sel) * (constants_DEPLOYER_CONTRACT_ADDRESS -
+                                                      in.get(C::update_check_deployer_protocol_contract_address));
             tmp *= scaling_factor;
             std::get<4>(evals) += typename Accumulator::View(tmp);
         }
         {
             using Accumulator = typename std::tuple_element_t<5, ContainerOverSubrelations>;
-            auto tmp = new_term.update_check_hash_not_zero * (FF(1) - new_term.update_check_hash_not_zero);
+            auto tmp = in.get(C::update_check_hash_not_zero) * (FF(1) - in.get(C::update_check_hash_not_zero));
             tmp *= scaling_factor;
             std::get<5>(evals) += typename Accumulator::View(tmp);
         }
         { // HASH_IS_ZERO_CHECK
             using Accumulator = typename std::tuple_element_t<6, ContainerOverSubrelations>;
-            auto tmp = ((new_term.update_check_update_hash *
-                             (update_check_HASH_IS_ZERO * (FF(1) - new_term.update_check_update_hash_inv) +
-                              new_term.update_check_update_hash_inv) -
+            auto tmp = ((in.get(C::update_check_update_hash) *
+                             (update_check_HASH_IS_ZERO * (FF(1) - in.get(C::update_check_update_hash_inv)) +
+                              in.get(C::update_check_update_hash_inv)) -
                          FF(1)) +
                         update_check_HASH_IS_ZERO);
             tmp *= scaling_factor;
@@ -93,104 +96,106 @@ template <typename FF_> class update_checkImpl {
         }
         { // NEVER_UPDATED_CHECK
             using Accumulator = typename std::tuple_element_t<7, ContainerOverSubrelations>;
-            auto tmp = (FF(1) - new_term.update_check_hash_not_zero) *
-                       (new_term.update_check_current_class_id - new_term.update_check_original_class_id);
+            auto tmp = (FF(1) - in.get(C::update_check_hash_not_zero)) *
+                       (in.get(C::update_check_current_class_id) - in.get(C::update_check_original_class_id));
             tmp *= scaling_factor;
             std::get<7>(evals) += typename Accumulator::View(tmp);
         }
         {
             using Accumulator = typename std::tuple_element_t<8, ContainerOverSubrelations>;
-            auto tmp = new_term.update_check_hash_not_zero *
+            auto tmp = in.get(C::update_check_hash_not_zero) *
                        ((constants_UPDATES_SHARED_MUTABLE_METADATA_BIT_SIZE - constants_BLOCK_NUMBER_BIT_SIZE) -
-                        new_term.update_check_update_hi_metadata_bit_size);
+                        in.get(C::update_check_update_hi_metadata_bit_size));
             tmp *= scaling_factor;
             std::get<8>(evals) += typename Accumulator::View(tmp);
         }
         {
             using Accumulator = typename std::tuple_element_t<9, ContainerOverSubrelations>;
-            auto tmp = new_term.update_check_hash_not_zero *
-                       (constants_BLOCK_NUMBER_BIT_SIZE - new_term.update_check_block_number_bit_size);
+            auto tmp = in.get(C::update_check_hash_not_zero) *
+                       (constants_BLOCK_NUMBER_BIT_SIZE - in.get(C::update_check_block_number_bit_size));
             tmp *= scaling_factor;
             std::get<9>(evals) += typename Accumulator::View(tmp);
         }
         { // UPDATE_METADATA_DECOMPOSITION
             using Accumulator = typename std::tuple_element_t<10, ContainerOverSubrelations>;
-            auto tmp = ((new_term.update_check_update_hi_metadata * update_check_TWO_POW_32 +
-                         new_term.update_check_update_block_of_change) -
-                        new_term.update_check_update_preimage_metadata);
+            auto tmp = ((in.get(C::update_check_update_hi_metadata) * update_check_TWO_POW_32 +
+                         in.get(C::update_check_update_block_of_change)) -
+                        in.get(C::update_check_update_preimage_metadata));
             tmp *= scaling_factor;
             std::get<10>(evals) += typename Accumulator::View(tmp);
         }
         {
             using Accumulator = typename std::tuple_element_t<11, ContainerOverSubrelations>;
-            auto tmp = new_term.update_check_block_number_is_lt_block_of_change *
-                       (FF(1) - new_term.update_check_block_number_is_lt_block_of_change);
+            auto tmp = in.get(C::update_check_block_number_is_lt_block_of_change) *
+                       (FF(1) - in.get(C::update_check_block_number_is_lt_block_of_change));
             tmp *= scaling_factor;
             std::get<11>(evals) += typename Accumulator::View(tmp);
         }
         {
             using Accumulator = typename std::tuple_element_t<12, ContainerOverSubrelations>;
             auto tmp = (((update_check_BLOCKNUMBER_LT_BLOCK_OF_CHANGE - update_check_BLOCKNUMBER_GTE_BLOCK_OF_CHANGE) *
-                             new_term.update_check_block_number_is_lt_block_of_change +
+                             in.get(C::update_check_block_number_is_lt_block_of_change) +
                          update_check_BLOCKNUMBER_GTE_BLOCK_OF_CHANGE) -
-                        new_term.update_check_block_of_change_subtraction);
+                        in.get(C::update_check_block_of_change_subtraction));
             tmp *= scaling_factor;
             std::get<12>(evals) += typename Accumulator::View(tmp);
         }
         {
             using Accumulator = typename std::tuple_element_t<13, ContainerOverSubrelations>;
-            auto tmp = new_term.update_check_update_pre_class_id_is_zero *
-                       (FF(1) - new_term.update_check_update_pre_class_id_is_zero);
+            auto tmp = in.get(C::update_check_update_pre_class_id_is_zero) *
+                       (FF(1) - in.get(C::update_check_update_pre_class_id_is_zero));
             tmp *= scaling_factor;
             std::get<13>(evals) += typename Accumulator::View(tmp);
         }
         { // UPDATE_PRE_CLASS_IS_ZERO
             using Accumulator = typename std::tuple_element_t<14, ContainerOverSubrelations>;
-            auto tmp =
-                new_term.update_check_hash_not_zero * ((new_term.update_check_update_preimage_pre_class_id *
-                                                            (new_term.update_check_update_pre_class_id_is_zero *
-                                                                 (FF(1) - new_term.update_check_update_pre_class_inv) +
-                                                             new_term.update_check_update_pre_class_inv) -
-                                                        FF(1)) +
-                                                       new_term.update_check_update_pre_class_id_is_zero);
+            auto tmp = in.get(C::update_check_hash_not_zero) *
+                       ((in.get(C::update_check_update_preimage_pre_class_id) *
+                             (in.get(C::update_check_update_pre_class_id_is_zero) *
+                                  (FF(1) - in.get(C::update_check_update_pre_class_inv)) +
+                              in.get(C::update_check_update_pre_class_inv)) -
+                         FF(1)) +
+                        in.get(C::update_check_update_pre_class_id_is_zero));
             tmp *= scaling_factor;
             std::get<14>(evals) += typename Accumulator::View(tmp);
         }
         {
             using Accumulator = typename std::tuple_element_t<15, ContainerOverSubrelations>;
-            auto tmp = new_term.update_check_update_post_class_id_is_zero *
-                       (FF(1) - new_term.update_check_update_post_class_id_is_zero);
+            auto tmp = in.get(C::update_check_update_post_class_id_is_zero) *
+                       (FF(1) - in.get(C::update_check_update_post_class_id_is_zero));
             tmp *= scaling_factor;
             std::get<15>(evals) += typename Accumulator::View(tmp);
         }
         { // UPDATE_POST_CLASS_IS_ZERO
             using Accumulator = typename std::tuple_element_t<16, ContainerOverSubrelations>;
-            auto tmp =
-                new_term.update_check_hash_not_zero * ((new_term.update_check_update_preimage_post_class_id *
-                                                            (new_term.update_check_update_post_class_id_is_zero *
-                                                                 (FF(1) - new_term.update_check_update_post_class_inv) +
-                                                             new_term.update_check_update_post_class_inv) -
-                                                        FF(1)) +
-                                                       new_term.update_check_update_post_class_id_is_zero);
+            auto tmp = in.get(C::update_check_hash_not_zero) *
+                       ((in.get(C::update_check_update_preimage_post_class_id) *
+                             (in.get(C::update_check_update_post_class_id_is_zero) *
+                                  (FF(1) - in.get(C::update_check_update_post_class_inv)) +
+                              in.get(C::update_check_update_post_class_inv)) -
+                         FF(1)) +
+                        in.get(C::update_check_update_post_class_id_is_zero));
             tmp *= scaling_factor;
             std::get<16>(evals) += typename Accumulator::View(tmp);
         }
         { // FUTURE_UPDATE_CLASS_ID_ASSIGNMENT
             using Accumulator = typename std::tuple_element_t<17, ContainerOverSubrelations>;
-            auto tmp = new_term.update_check_hash_not_zero * new_term.update_check_block_number_is_lt_block_of_change *
-                       ((new_term.update_check_original_class_id * new_term.update_check_update_pre_class_id_is_zero +
-                         new_term.update_check_update_preimage_pre_class_id) -
-                        new_term.update_check_current_class_id);
+            auto tmp =
+                in.get(C::update_check_hash_not_zero) * in.get(C::update_check_block_number_is_lt_block_of_change) *
+                ((in.get(C::update_check_original_class_id) * in.get(C::update_check_update_pre_class_id_is_zero) +
+                  in.get(C::update_check_update_preimage_pre_class_id)) -
+                 in.get(C::update_check_current_class_id));
             tmp *= scaling_factor;
             std::get<17>(evals) += typename Accumulator::View(tmp);
         }
         { // PAST_UPDATE_CLASS_ID_ASSIGNMENT
             using Accumulator = typename std::tuple_element_t<18, ContainerOverSubrelations>;
-            auto tmp = new_term.update_check_hash_not_zero *
-                       (FF(1) - new_term.update_check_block_number_is_lt_block_of_change) *
-                       ((new_term.update_check_original_class_id * new_term.update_check_update_post_class_id_is_zero +
-                         new_term.update_check_update_preimage_post_class_id) -
-                        new_term.update_check_current_class_id);
+            auto tmp =
+                in.get(C::update_check_hash_not_zero) *
+                (FF(1) - in.get(C::update_check_block_number_is_lt_block_of_change)) *
+                ((in.get(C::update_check_original_class_id) * in.get(C::update_check_update_post_class_id_is_zero) +
+                  in.get(C::update_check_update_preimage_post_class_id)) -
+                 in.get(C::update_check_current_class_id));
             tmp *= scaling_factor;
             std::get<18>(evals) += typename Accumulator::View(tmp);
         }

--- a/barretenberg/cpp/src/barretenberg/vm2/tracegen/bytecode_trace.test.cpp
+++ b/barretenberg/cpp/src/barretenberg/vm2/tracegen/bytecode_trace.test.cpp
@@ -41,13 +41,14 @@ TEST(BytecodeTraceGenTest, BasicShortLength)
             },
         },
         trace);
+    auto rows = trace.as_rows();
 
     // One extra empty row is prepended. Note that precomputed_first_row is not set through process_decomposition()
     // because it pertains to another subtrace.
-    EXPECT_EQ(trace.as_rows().size(), 4 + 1);
+    ASSERT_EQ(rows.size(), 4 + 1);
 
     // We do not inspect row at index 0 as it is completely empty.
-    EXPECT_THAT(trace.as_rows()[1],
+    EXPECT_THAT(rows.at(1),
                 AllOf(ROW_FIELD_EQ(R, bc_decomposition_sel, 1),
                       ROW_FIELD_EQ(R, bc_decomposition_id, 43),
                       ROW_FIELD_EQ(R, bc_decomposition_bytes, 12),
@@ -62,7 +63,7 @@ TEST(BytecodeTraceGenTest, BasicShortLength)
                       ROW_FIELD_EQ(R, bc_decomposition_bytes_to_read, 4),
                       ROW_FIELD_EQ(R, bc_decomposition_last_of_contract, 0)));
 
-    EXPECT_THAT(trace.as_rows()[2],
+    EXPECT_THAT(rows.at(2),
                 AllOf(ROW_FIELD_EQ(R, bc_decomposition_sel, 1),
                       ROW_FIELD_EQ(R, bc_decomposition_id, 43),
                       ROW_FIELD_EQ(R, bc_decomposition_bytes, 31),
@@ -76,7 +77,7 @@ TEST(BytecodeTraceGenTest, BasicShortLength)
                       ROW_FIELD_EQ(R, bc_decomposition_bytes_to_read, 3),
                       ROW_FIELD_EQ(R, bc_decomposition_last_of_contract, 0)));
 
-    EXPECT_THAT(trace.as_rows()[3],
+    EXPECT_THAT(rows.at(3),
                 AllOf(ROW_FIELD_EQ(R, bc_decomposition_sel, 1),
                       ROW_FIELD_EQ(R, bc_decomposition_id, 43),
                       ROW_FIELD_EQ(R, bc_decomposition_bytes, 5),
@@ -89,7 +90,7 @@ TEST(BytecodeTraceGenTest, BasicShortLength)
                       ROW_FIELD_EQ(R, bc_decomposition_bytes_to_read, 2),
                       ROW_FIELD_EQ(R, bc_decomposition_last_of_contract, 0)));
 
-    EXPECT_THAT(trace.as_rows()[4],
+    EXPECT_THAT(rows.at(4),
                 AllOf(ROW_FIELD_EQ(R, bc_decomposition_sel, 1),
                       ROW_FIELD_EQ(R, bc_decomposition_id, 43),
                       ROW_FIELD_EQ(R, bc_decomposition_bytes, 2),
@@ -124,13 +125,14 @@ TEST(BytecodeTraceGenTest, BasicLongerThanWindowSize)
             },
         },
         trace);
+    auto rows = trace.as_rows();
 
     // One extra empty row is prepended. Note that precomputed_first_row is not set through process_decomposition()
     // because it pertains to another subtrace.
-    EXPECT_EQ(trace.as_rows().size(), bytecode_size + 1);
+    ASSERT_EQ(rows.size(), bytecode_size + 1);
 
     // We do not inspect row at index 0 as it is completely empty.
-    EXPECT_THAT(trace.as_rows()[1],
+    EXPECT_THAT(rows.at(1),
                 AllOf(ROW_FIELD_EQ(R, bc_decomposition_sel, 1),
                       ROW_FIELD_EQ(R, bc_decomposition_id, 7),
                       ROW_FIELD_EQ(R, bc_decomposition_bytes, first_byte),
@@ -143,7 +145,7 @@ TEST(BytecodeTraceGenTest, BasicLongerThanWindowSize)
 
     // We are interested to inspect the boundary aroud bytes_remaining == windows size
 
-    EXPECT_THAT(trace.as_rows()[9],
+    EXPECT_THAT(rows.at(9),
                 AllOf(ROW_FIELD_EQ(R, bc_decomposition_sel, 1),
                       ROW_FIELD_EQ(R, bc_decomposition_id, 7),
                       ROW_FIELD_EQ(R, bc_decomposition_bytes, first_byte + 8),
@@ -154,7 +156,7 @@ TEST(BytecodeTraceGenTest, BasicLongerThanWindowSize)
                       ROW_FIELD_EQ(R, bc_decomposition_bytes_to_read, DECOMPOSE_WINDOW_SIZE),
                       ROW_FIELD_EQ(R, bc_decomposition_last_of_contract, 0)));
 
-    EXPECT_THAT(trace.as_rows()[10],
+    EXPECT_THAT(rows.at(10),
                 AllOf(ROW_FIELD_EQ(R, bc_decomposition_sel, 1),
                       ROW_FIELD_EQ(R, bc_decomposition_id, 7),
                       ROW_FIELD_EQ(R, bc_decomposition_bytes, first_byte + 9),
@@ -166,7 +168,7 @@ TEST(BytecodeTraceGenTest, BasicLongerThanWindowSize)
                       ROW_FIELD_EQ(R, bc_decomposition_last_of_contract, 0)));
 
     // Last row
-    EXPECT_THAT(trace.as_rows()[bytecode_size],
+    EXPECT_THAT(rows.at(bytecode_size),
                 AllOf(ROW_FIELD_EQ(R, bc_decomposition_sel, 1),
                       ROW_FIELD_EQ(R, bc_decomposition_id, 7),
                       ROW_FIELD_EQ(R, bc_decomposition_bytes, first_byte + bytecode_size - 1),
@@ -215,11 +217,11 @@ TEST(BytecodeTraceGenTest, MultipleEvents)
             },
         },
         trace);
+    auto rows = trace.as_rows();
 
     // One extra empty row is prepended.
-    EXPECT_EQ(trace.as_rows().size(), 2 * DECOMPOSE_WINDOW_SIZE + 20 + 1);
+    ASSERT_EQ(rows.size(), 2 * DECOMPOSE_WINDOW_SIZE + 20 + 1);
 
-    const auto rows = trace.as_rows();
     size_t row_pos = 1;
     for (uint32_t i = 0; i < 4; i++) {
         for (uint32_t j = 0; j < bc_sizes[i]; j++) {
@@ -258,9 +260,9 @@ TEST(BytecodeTraceGenTest, BasicHashing)
             },
         },
         trace);
+    const auto rows = trace.as_rows();
 
     // One extra empty row is prepended.
-    const auto rows = trace.as_rows();
     EXPECT_THAT(rows.at(1),
                 AllOf(ROW_FIELD_EQ(R, bc_hashing_sel, 1),
                       ROW_FIELD_EQ(R, bc_hashing_start, 1),
@@ -566,7 +568,7 @@ TEST(BytecodeTraceGenTest, InstrFetchingParsingErrors)
 
     // One extra empty row is prepended.
     const auto rows = trace.as_rows();
-    EXPECT_EQ(rows.size(), 3 + 1);
+    ASSERT_EQ(rows.size(), 3 + 1);
 
     EXPECT_THAT(rows.at(1),
                 AllOf(ROW_FIELD_EQ(R, instr_fetching_sel, 1),
@@ -657,7 +659,7 @@ TEST(BytecodeTraceGenTest, InstrFetchingErrorTagOutOfRange)
 
     // One extra empty row is prepended.
     const auto rows = trace.as_rows();
-    EXPECT_EQ(rows.size(), 2 + 1);
+    ASSERT_EQ(rows.size(), 2 + 1);
 
     EXPECT_THAT(rows.at(1),
                 AllOf(ROW_FIELD_EQ(R, instr_fetching_sel, 1),

--- a/barretenberg/cpp/src/barretenberg/vm2/tracegen/test_trace_container.cpp
+++ b/barretenberg/cpp/src/barretenberg/vm2/tracegen/test_trace_container.cpp
@@ -33,9 +33,9 @@ TestTraceContainer TestTraceContainer::from_rows(const std::vector<AvmFullRow>& 
     return container;
 }
 
-AvmFullRowConstRef TestTraceContainer::get_row(uint32_t row) const
+AvmFullRowProxy TestTraceContainer::get_row(uint32_t row) const
 {
-    return get_full_row_ref(*this, row);
+    return { row, *this };
 }
 
 std::vector<AvmFullRowConstRef> TestTraceContainer::as_rows() const
@@ -44,7 +44,7 @@ std::vector<AvmFullRowConstRef> TestTraceContainer::as_rows() const
     std::vector<AvmFullRowConstRef> full_row_trace;
     full_row_trace.reserve(max_rows);
     for (uint32_t i = 0; i < max_rows; ++i) {
-        full_row_trace.push_back(get_row(i));
+        full_row_trace.push_back(get_full_row_ref(*this, i));
     }
     return full_row_trace;
 }

--- a/barretenberg/cpp/src/barretenberg/vm2/tracegen/test_trace_container.hpp
+++ b/barretenberg/cpp/src/barretenberg/vm2/tracegen/test_trace_container.hpp
@@ -1,6 +1,5 @@
 #pragma once
 
-#include <unordered_map>
 #include <vector>
 
 #include "barretenberg/vm2/constraining/full_row.hpp"
@@ -15,14 +14,17 @@ class TestTraceContainer : public TraceContainer {
     static TestTraceContainer from_rows(const std::vector<AvmFullRow>& rows);
 
     TestTraceContainer() = default;
+    virtual ~TestTraceContainer() = default;
     TestTraceContainer(const std::vector<std::vector<std::pair<Column, FF>>>& values);
     // Copy constructor. We allow copying for testing purposes.
     TestTraceContainer(const TestTraceContainer&);
 
+    // Returns a row that can be used for accumulation, etc.
+    // You cannot refer to entities by name (e.g., row.column_name) using this type.
+    AvmFullRowProxy get_row(uint32_t row) const;
     // Returns a trace in dense format with properly filled in shifted columns.
     // The returned rows are lightweight references to the original trace.
     // Therefore the original trace should outlive the returned rows.
-    AvmFullRowConstRef get_row(uint32_t row) const;
     std::vector<AvmFullRowConstRef> as_rows() const;
 };
 

--- a/bb-pilcom/bb-pil-backend/src/expression_evaluation.rs
+++ b/bb-pilcom/bb-pil-backend/src/expression_evaluation.rs
@@ -137,7 +137,7 @@ pub fn recurse_expression<F: FieldElement>(
                 if polyref.next {
                     poly_name = format!("{}_shift", poly_name);
                 }
-                (1, format!("new_term.{}", poly_name), HashSet::new())
+                (1, format!("in.get(C::{})", poly_name), HashSet::new())
             }
         }
         AlgebraicExpression::BinaryOperation(AlgebraicBinaryOperation {

--- a/bb-pilcom/bb-pil-backend/templates/relation.hpp.hbs
+++ b/bb-pilcom/bb-pil-backend/templates/relation.hpp.hbs
@@ -5,6 +5,7 @@
 
 #include "barretenberg/relations/relation_parameters.hpp"
 #include "barretenberg/relations/relation_types.hpp"
+#include "barretenberg/vm2/generated/columns.hpp"
 
 namespace bb::{{snakeCase root_name}} {
 
@@ -19,7 +20,7 @@ template <typename FF_> class {{name}}Impl {
         {{#if skippable_if}}
         template <typename AllEntities> inline static bool skip(const AllEntities& in)
         {
-            const auto& new_term = in;
+            using C = ColumnAndShifts;
             return ({{skippable_if}}).is_zero();
         }
         {{/if}}
@@ -27,10 +28,12 @@ template <typename FF_> class {{name}}Impl {
         template <typename ContainerOverSubrelations, typename AllEntities>
         void static accumulate(
             ContainerOverSubrelations& evals,
-            const AllEntities& new_term,
+            const AllEntities& in,
             [[maybe_unused]] const RelationParameters<FF>&,
             [[maybe_unused]] const FF& scaling_factor
         ){
+            using C = ColumnAndShifts;
+
             {{#each alias_defs as |alias|}}
             const auto {{alias.name}} = {{alias.expr}};
             {{/each}}


### PR DESCRIPTION
This PR changes the code-generated relations to access the entities using `in.get(C::column)` instead of `in.column`.

This unifies the access with what was done for lookups (to speed them up).

WARNING: this is a bit of a deeper change than it may seem.

I'll start with the advantages
* Tests speedup: from 15s to 3s.
* Potential check_circuit speedup: I was expecting a similar speedup but check_circuit stayed the same. I'll look later.
* Unified access through a function lets us pull off tricks like what I do in the polynomials (for lookups) and in AvmFullRowProxy (for tests). That is, we can decide what `get()` does.
* Now we have a uniform interface that accumulate uses in the AVM. The entities should provide a `get()` that returns, say, an FF (or univariate). This opens the doors to actually defining an interface of some kind, and then we could MAYBE have the compiler only have to instantiate the accumulate templates for that one interface (caveats apply). Right now we instantiate the template for ~6 types. This could reduce compilation time.

The potential disadvantage is just one: we are making a function call where before we were directly referring to a structure member. In theory this could be slower, but:
* We still use a lot of templating, and the compiler seems to have access to this information and is maybe able to optimize things.
* Things might (or might not) get a bit worse due to vtable dispatching if we choose to use an interface.

Right now, the change doesn't seem to have affected proving at all, both in our truncated bulk test (still at ~11s) and in the giant trace that I created (still at 3m).