### PR TITLE
chore: deprecate master version in aztec-up

### DIFF
--- a/aztec-up/README.md
+++ b/aztec-up/README.md
@@ -19,10 +19,10 @@ the user's `PATH` variable in their shell startup script so they can be found.
 After installed, you can use `aztec-up` to upgrade or install specific versions.
 
 ```
-VERSION=master aztec-up
+VERSION=nightly aztec-up
 ```
 
-This will install the container built from the master branch.
+This will install the nightly build.
 
 ```
 VERSION=1.2.3 aztec-up

--- a/aztec-up/bin/aztec-up
+++ b/aztec-up/bin/aztec-up
@@ -31,6 +31,11 @@ while [[ $# -gt 0 ]]; do
   esac
 done
 
+if [ "$VERSION" = "master" ]; then
+  echo "Error: The 'master' version is deprecated. Please use 'nightly' instead."
+  exit 1
+fi
+
 if [ -n "$VERSION" ] && [ "$VERSION" != "latest" ]; then
   install_url="$INSTALL_URI/$VERSION/aztec-install"
 else


### PR DESCRIPTION
We don't publish master images anymore and this results in users installing a stale 2 months old version when they install with `VERSION=master aztec-up`. In this PR I prevent this by throwing an error when they attempt to use the master version.

Fixes #13275
