### PR TITLE
fix: allow sparse multimaps in the browser

### DIFF
--- a/yarn-project/kv-store/src/indexeddb/multi_map.ts
+++ b/yarn-project/kv-store/src/indexeddb/multi_map.ts
@@ -12,6 +12,7 @@ export class IndexedDBAztecMultiMap<K extends Key, V extends Value>
   implements AztecAsyncMultiMap<K, V>
 {
   override async set(key: K, val: V): Promise<void> {
+    // Inserting repeated values is a no-op
     const exists = !!(await this.db
       .index('hash')
       .get(
@@ -23,9 +24,19 @@ export class IndexedDBAztecMultiMap<K extends Key, V extends Value>
     if (exists) {
       return;
     }
-    const count = await this.db
-      .index('key')
-      .count(IDBKeyRange.bound([this.container, this.normalizeKey(key)], [this.container, this.normalizeKey(key)]));
+    // Get the maximum keyCount for the given key
+    // In order to support sparse multimaps, we cannot rely
+    // on just counting the number of entries for the key, since we would repeat slots
+    // if we delete an entry
+    // set -> container:key:0 (keyCount = 1)
+    // set -> container:key:1 (keyCount = 2)
+    // delete -> container:key:0 (keyCount = 1)
+    // set -> container:key:1 <--- already exists!
+    // Instead, we iterate in reverse order to get the last inserted entry
+    const index = this.db.index('keyCount');
+    const rangeQuery = IDBKeyRange.upperBound([this.container, this.normalizeKey(key), Number.MAX_SAFE_INTEGER]);
+    const maxEntry = (await index.iterate(rangeQuery, 'prevunique').next()).value;
+    const count = maxEntry?.value?.keyCount ?? 0;
     await this.db.put({
       value: val,
       hash: hash(val),
@@ -37,6 +48,7 @@ export class IndexedDBAztecMultiMap<K extends Key, V extends Value>
   }
 
   async *getValuesAsync(key: K): AsyncIterableIterator<V> {
+    // Iterate over the whole range of keyCount for the given key
     const index = this.db.index('keyCount');
     const rangeQuery = IDBKeyRange.bound(
       [this.container, this.normalizeKey(key), 0],
@@ -50,6 +62,8 @@ export class IndexedDBAztecMultiMap<K extends Key, V extends Value>
   }
 
   async deleteValue(key: K, val: V): Promise<void> {
+    // Since we know the value, we can hash it and directly query the "hash" index
+    // to avoid having to iterate over all the values
     const fullKey = await this.db
       .index('hash')
       .getKey(

--- a/yarn-project/kv-store/src/indexeddb/store.ts
+++ b/yarn-project/kv-store/src/indexeddb/store.ts
@@ -73,7 +73,11 @@ export class AztecIndexedDBStore implements AztecAsyncKVStore {
         const objectStore = db.createObjectStore('data', { keyPath: 'slot' });
 
         objectStore.createIndex('key', ['container', 'key'], { unique: false });
+        // Keep count of the maximum number of keys ever inserted in the container
+        // This allows unique slots for repeated keys, which is useful for multi-maps
         objectStore.createIndex('keyCount', ['container', 'key', 'keyCount'], { unique: false });
+        // Keep an index on the pair key-hash for a given container, allowing us to efficiently
+        // delete unique values from multi-maps
         objectStore.createIndex('hash', ['container', 'key', 'hash'], { unique: true });
       },
     });

--- a/yarn-project/kv-store/src/interfaces/multi_map_test_suite.ts
+++ b/yarn-project/kv-store/src/interfaces/multi_map_test_suite.ts
@@ -124,12 +124,17 @@ export function describeAztecMultiMap(
     });
 
     it('should be able to delete individual values for a single key', async () => {
+      await multiMap.set('foo', '1');
+      await multiMap.set('foo', '2');
+      await multiMap.set('foo', '3');
+
+      await multiMap.deleteValue('foo', '2');
+
+      expect(await getValues('foo')).to.deep.equal(['1', '3']);
+
       await multiMap.set('foo', 'bar');
-      await multiMap.set('foo', 'baz');
 
-      await multiMap.deleteValue('foo', 'bar');
-
-      expect(await getValues('foo')).to.deep.equal(['baz']);
+      expect(await getValues('foo')).to.deep.equal(['1', '3', 'bar']);
     });
 
     it('supports range queries', async () => {

--- a/yarn-project/kv-store/src/interfaces/multi_map_test_suite.ts
+++ b/yarn-project/kv-store/src/interfaces/multi_map_test_suite.ts
@@ -128,13 +128,29 @@ export function describeAztecMultiMap(
       await multiMap.set('foo', '2');
       await multiMap.set('foo', '3');
 
+      // Out-of-order delete
       await multiMap.deleteValue('foo', '2');
 
       expect(await getValues('foo')).to.deep.equal(['1', '3']);
 
+      // Insertion after delete
       await multiMap.set('foo', 'bar');
 
       expect(await getValues('foo')).to.deep.equal(['1', '3', 'bar']);
+
+      // Delete the last key
+      await multiMap.deleteValue('foo', 'bar');
+
+      expect(await getValues('foo')).to.deep.equal(['1', '3']);
+
+      // Reinsert the initially deleted key
+      await multiMap.set('foo', '2');
+
+      // LMDB and IndexedDB behave differently here, the former ordering by value and the
+      // latter by insertion. This is fine because there is no expectation for values in a map (or multimap) to
+      // be ordered.
+      const values = (await getValues('foo')).sort((a, b) => a.localeCompare(b));
+      expect(values).to.deep.equal(['1', '2', '3']);
     });
 
     it('supports range queries', async () => {


### PR DESCRIPTION
Fixes: https://github.com/AztecProtocol/aztec-packages/issues/13805

Multimaps were behaving incorrectly in the browser, breaking PXE when retrieving notes under certain conditions.

This was due to us not tracking correctly the keys for multimaps in case entries were erased out of natural iteration order. This PR enables sparse multimaps by generating monotonically increasing slots instead of relying on the current count of elements for slot allocation.
