### PR TITLE
refactor: use open zeppelin library

### DIFF
--- a/l1-contracts/src/governance/Governance.sol
+++ b/l1-contracts/src/governance/Governance.sol
@@ -9,7 +9,7 @@ import {ConfigurationLib} from "@aztec/governance/libraries/ConfigurationLib.sol
 import {DataStructures} from "@aztec/governance/libraries/DataStructures.sol";
 import {Errors} from "@aztec/governance/libraries/Errors.sol";
 import {ProposalLib, VoteTabulationReturn} from "@aztec/governance/libraries/ProposalLib.sol";
-import {UserLib} from "@aztec/governance/libraries/UserLib.sol";
+import {User, UserLib} from "@aztec/governance/libraries/UserLib.sol";
 import {IERC20} from "@oz/token/ERC20/IERC20.sol";
 import {SafeERC20} from "@oz/token/ERC20/utils/SafeERC20.sol";
 
@@ -25,7 +25,7 @@ import {SafeERC20} from "@oz/token/ERC20/utils/SafeERC20.sol";
 contract Governance is IGovernance {
   using SafeERC20 for IERC20;
   using ProposalLib for DataStructures.Proposal;
-  using UserLib for DataStructures.User;
+  using UserLib for User;
   using ConfigurationLib for DataStructures.Configuration;
 
   IERC20 public immutable ASSET;
@@ -34,11 +34,11 @@ contract Governance is IGovernance {
 
   mapping(uint256 proposalId => DataStructures.Proposal) internal proposals;
   mapping(uint256 proposalId => mapping(address user => DataStructures.Ballot)) public ballots;
-  mapping(address => DataStructures.User) internal users;
+  mapping(address => User) internal users;
   mapping(uint256 withdrawalId => DataStructures.Withdrawal) internal withdrawals;
 
   DataStructures.Configuration internal configuration;
-  DataStructures.User internal total;
+  User internal total;
   uint256 public proposalCount;
   uint256 public withdrawalCount;
 

--- a/l1-contracts/src/governance/libraries/DataStructures.sol
+++ b/l1-contracts/src/governance/libraries/DataStructures.sol
@@ -53,16 +53,6 @@ library DataStructures {
     Ballot summedBallot;
   }
 
-  struct CheckPoint {
-    Timestamp time;
-    uint256 power;
-  }
-
-  struct User {
-    uint256 numCheckPoints;
-    mapping(uint256 checkpointIndex => CheckPoint) checkpoints;
-  }
-
   struct Withdrawal {
     uint256 amount;
     Timestamp unlocksAt;

--- a/l1-contracts/src/governance/libraries/UserLib.sol
+++ b/l1-contracts/src/governance/libraries/UserLib.sol
@@ -3,95 +3,51 @@
 pragma solidity >=0.8.27;
 
 import {Timestamp} from "@aztec/core/libraries/TimeLib.sol";
-import {DataStructures} from "@aztec/governance/libraries/DataStructures.sol";
 import {Errors} from "@aztec/governance/libraries/Errors.sol";
 
+import {SafeCast} from "@oz/utils/math/SafeCast.sol";
+import {Checkpoints} from "@oz/utils/structs/Checkpoints.sol";
+
+struct User {
+  Checkpoints.Trace224 checkpoints;
+}
+
+/**
+ * @title UserLib
+ * @notice Library for managing user power
+ * Using timestamp to uint32 to fit neatly with the Trace224 struct. We see this as sane
+ * because the governance can upgrade itself and will hopefully have figured out something better
+ * by then.
+ */
 library UserLib {
-  function add(DataStructures.User storage _self, uint256 _amount) internal {
+  using Checkpoints for Checkpoints.Trace224;
+  using SafeCast for uint256;
+
+  function add(User storage _self, uint256 _amount) internal {
     if (_amount == 0) {
       return;
     }
-    if (_self.numCheckPoints == 0) {
-      _self.checkpoints[0] =
-        DataStructures.CheckPoint({time: Timestamp.wrap(block.timestamp), power: _amount});
-      _self.numCheckPoints += 1;
-    } else {
-      DataStructures.CheckPoint storage last = _self.checkpoints[_self.numCheckPoints - 1];
-      if (last.time == Timestamp.wrap(block.timestamp)) {
-        last.power += _amount;
-      } else {
-        _self.checkpoints[_self.numCheckPoints] = DataStructures.CheckPoint({
-          time: Timestamp.wrap(block.timestamp),
-          power: last.power + _amount
-        });
-        _self.numCheckPoints += 1;
-      }
-    }
+    uint224 current = _self.checkpoints.latest();
+    _self.checkpoints.push(block.timestamp.toUint32(), current + _amount.toUint224());
   }
 
-  function sub(DataStructures.User storage _self, uint256 _amount) internal {
+  function sub(User storage _self, uint256 _amount) internal {
     if (_amount == 0) {
       return;
     }
-    require(_self.numCheckPoints > 0, Errors.Governance__NoCheckpointsFound());
-    DataStructures.CheckPoint storage last = _self.checkpoints[_self.numCheckPoints - 1];
-    require(
-      last.power >= _amount, Errors.Governance__InsufficientPower(msg.sender, last.power, _amount)
-    );
-    if (last.time == Timestamp.wrap(block.timestamp)) {
-      last.power -= _amount;
-    } else {
-      _self.checkpoints[_self.numCheckPoints] = DataStructures.CheckPoint({
-        time: Timestamp.wrap(block.timestamp),
-        power: last.power - _amount
-      });
-      _self.numCheckPoints += 1;
-    }
+    uint224 current = _self.checkpoints.latest();
+    uint224 amount = _amount.toUint224();
+    require(current >= amount, Errors.Governance__InsufficientPower(msg.sender, current, amount));
+    _self.checkpoints.push(block.timestamp.toUint32(), current - amount);
   }
 
-  function powerNow(DataStructures.User storage _self) internal view returns (uint256) {
-    uint256 numCheckPoints = _self.numCheckPoints;
-    if (numCheckPoints == 0) {
-      return 0;
-    }
-    return _self.checkpoints[numCheckPoints - 1].power;
+  function powerNow(User storage _self) internal view returns (uint256) {
+    return _self.checkpoints.latest();
   }
 
-  function powerAt(DataStructures.User storage _self, Timestamp _time)
-    internal
-    view
-    returns (uint256)
-  {
-    // If not in the past, the values are not stable.
-    // We disallow using it to avoid potential misuse.
+  function powerAt(User storage _self, Timestamp _time) internal view returns (uint256) {
+    // If not in the past, the values are not stable. We disallow using it to avoid potential misuse.
     require(_time < Timestamp.wrap(block.timestamp), Errors.Governance__UserLib__NotInPast());
-
-    uint256 numCheckPoints = _self.numCheckPoints;
-    if (numCheckPoints == 0) {
-      return 0;
-    }
-
-    if (_self.checkpoints[numCheckPoints - 1].time <= _time) {
-      return _self.checkpoints[numCheckPoints - 1].power;
-    }
-
-    if (_self.checkpoints[0].time > _time) {
-      return 0;
-    }
-
-    uint256 lower = 0;
-    uint256 upper = numCheckPoints - 1;
-    while (upper > lower) {
-      uint256 center = upper - (upper - lower) / 2; // ceil, avoiding overflow
-      DataStructures.CheckPoint memory cp = _self.checkpoints[center];
-      if (cp.time == _time) {
-        return cp.power;
-      } else if (cp.time < _time) {
-        lower = center;
-      } else {
-        upper = center - 1;
-      }
-    }
-    return _self.checkpoints[lower].power;
+    return _self.checkpoints.upperLookup(Timestamp.unwrap(_time).toUint32());
   }
 }

--- a/l1-contracts/test/governance/governance/deposit.t.sol
+++ b/l1-contracts/test/governance/governance/deposit.t.sol
@@ -57,7 +57,7 @@ contract DepositTest is GovernanceBase {
     for (uint256 i = 0; i < DEPOSIT_COUNT; i++) {
       address onBehalfOf = i % 2 == 0 ? _onBehalfOfs[i] : address(0xdeadbeef);
       uint256 amount = bound(_deposits[i], 1, type(uint128).max);
-      uint256 timeJump = bound(_timejumps[i], 1, type(uint32).max);
+      uint256 timeJump = bound(_timejumps[i], 1, type(uint16).max);
 
       token.mint(address(this), amount);
       token.approve(address(governance), amount);

--- a/l1-contracts/test/governance/governance/finaliseWithdraw.t.sol
+++ b/l1-contracts/test/governance/governance/finaliseWithdraw.t.sol
@@ -30,7 +30,7 @@ contract FinaliseWithdrawTest is GovernanceBase {
     uint256[WITHDRAWAL_COUNT] memory _withdrawals,
     uint256[WITHDRAWAL_COUNT] memory _timejumps
   ) {
-    deposit = _depositAmount;
+    deposit = bound(_depositAmount, 1, type(uint224).max);
     uint256 sum = deposit;
 
     token.mint(address(this), deposit);

--- a/l1-contracts/test/governance/governance/initiateWithdraw.t.sol
+++ b/l1-contracts/test/governance/governance/initiateWithdraw.t.sol
@@ -20,8 +20,12 @@ contract InitiateWithdrawTest is GovernanceBase {
 
   function test_GivenNoCheckpoints(uint256 _amount) external whenCallerHaveInsufficientDeposits {
     // it revert
-    uint256 amount = bound(_amount, 1, type(uint256).max);
-    vm.expectRevert(abi.encodeWithSelector(Errors.Governance__NoCheckpointsFound.selector));
+    uint256 amount = bound(_amount, 1, type(uint224).max);
+    vm.expectRevert(
+      abi.encodeWithSelector(
+        Errors.Governance__InsufficientPower.selector, address(this), 0, amount
+      )
+    );
     governance.initiateWithdraw(address(this), amount);
   }
 
@@ -31,7 +35,7 @@ contract InitiateWithdrawTest is GovernanceBase {
   {
     // it revert
     uint256 depositAmount = bound(_depositAmount, 1, type(uint128).max);
-    uint256 withdrawalAmount = bound(_withdrawalAmount, depositAmount + 1, type(uint256).max);
+    uint256 withdrawalAmount = bound(_withdrawalAmount, depositAmount + 1, type(uint224).max);
 
     token.mint(address(this), depositAmount);
     token.approve(address(governance), depositAmount);
@@ -59,7 +63,7 @@ contract InitiateWithdrawTest is GovernanceBase {
     // it creates a pending withdrawal with time of unlock
     // it emits {WithdrawalInitiated} event
 
-    uint256 deposit = _depositAmount;
+    uint256 deposit = bound(_depositAmount, 1, type(uint224).max);
     uint256 sum = deposit;
     uint256 withdrawalId = 0;
 
@@ -73,7 +77,7 @@ contract InitiateWithdrawTest is GovernanceBase {
     for (uint256 i = 0; i < WITHDRAWAL_COUNT; i++) {
       address recipient = i % 2 == 0 ? _recipient[i] : address(0xdeadbeef);
       uint256 amount = bound(_withdrawals[i], 0, sum);
-      uint256 timeJump = bound(_timejumps[i], 1, type(uint32).max);
+      uint256 timeJump = bound(_timejumps[i], 1, type(uint16).max);
 
       if (amount == 0) {
         continue;

--- a/l1-contracts/test/governance/governance/userlib/add.t.sol
+++ b/l1-contracts/test/governance/governance/userlib/add.t.sol
@@ -2,42 +2,47 @@
 pragma solidity >=0.8.27;
 
 import {UserLibBase} from "./base.t.sol";
-import {DataStructures} from "@aztec/governance/libraries/DataStructures.sol";
-import {UserLib} from "@aztec/governance/libraries/UserLib.sol";
-import {Timestamp} from "@aztec/core/libraries/TimeLib.sol";
+import {User, UserLib} from "@aztec/governance/libraries/UserLib.sol";
+import {Timestamp, TimeLib} from "@aztec/core/libraries/TimeLib.sol";
+import {Checkpoints} from "@oz/utils/structs/Checkpoints.sol";
+import {SafeCast} from "@oz/utils/math/SafeCast.sol";
 
 contract AddTest is UserLibBase {
-  using UserLib for DataStructures.User;
+  using UserLib for User;
+  using Checkpoints for Checkpoints.Trace224;
+  using TimeLib for Timestamp;
+  using SafeCast for uint256;
 
   function test_WhenAmountEq0() external {
     // it return instantly with no changes
 
-    assertEq(user.numCheckPoints, 0);
+    assertEq(user.checkpoints.length(), 0);
 
     vm.record();
     user.add(0);
     (bytes32[] memory reads, bytes32[] memory writes) = vm.accesses(address(this));
 
-    assertEq(user.numCheckPoints, 0);
+    assertEq(user.checkpoints.length(), 0);
     assertEq(reads.length, 0);
     assertEq(writes.length, 0);
   }
 
-  function test_GivenUserHaveNoCheckpoints(uint256 _amount, uint256 _time)
+  function test_GivenUserHaveNoCheckpoints(uint256 _amount, uint32 _time)
     external
     whenAmountGt0(_amount)
   {
     // it adds checkpoint with amount
     // it increases num checkpoints
 
-    assertEq(user.numCheckPoints, 0);
+    assertEq(user.checkpoints.length(), 0);
 
     vm.warp(_time);
     user.add(amount);
 
-    assertEq(user.numCheckPoints, 1);
-    assertEq(user.checkpoints[0].time, Timestamp.wrap(_time));
-    assertEq(user.checkpoints[0].power, amount);
+    assertEq(user.checkpoints.length(), 1);
+    Checkpoints.Checkpoint224 memory last = user.checkpoints.at(0);
+    assertEq(last._key, _time);
+    assertEq(last._value, amount.toUint224());
   }
 
   function test_WhenLastCheckpointIsNow(
@@ -48,17 +53,17 @@ contract AddTest is UserLibBase {
   ) external whenAmountGt0(_amount) givenUserHaveCheckpoints(_insert, _timeBetween, _amounts) {
     // it increases power by amount
 
-    assertEq(user.numCheckPoints, insertions, "num checkpoints");
+    assertEq(user.checkpoints.length(), insertions, "num checkpoints");
     // Cache in memory
-    DataStructures.CheckPoint memory last = user.checkpoints[user.numCheckPoints - 1];
+    Checkpoints.Checkpoint224 memory last = user.checkpoints.at(uint32(insertions - 1));
 
     user.add(amount);
 
-    assertEq(user.numCheckPoints, insertions, "num checkpoints");
-    DataStructures.CheckPoint memory last2 = user.checkpoints[user.numCheckPoints - 1];
+    assertEq(user.checkpoints.length(), insertions, "num checkpoints");
+    Checkpoints.Checkpoint224 memory last2 = user.checkpoints.at(uint32(insertions - 1));
 
-    assertEq(last2.time, last.time, "time");
-    assertEq(last2.power, last.power + amount, "power");
+    assertEq(last2._key, last._key, "key");
+    assertEq(last2._value, last._value + amount.toUint224(), "power");
   }
 
   function test_WhenLastCheckpointInPast(
@@ -71,19 +76,19 @@ contract AddTest is UserLibBase {
     // it adds a checkpoint with power eq to last.power + amount
     // it increases num checkpoints
 
-    uint256 time = bound(_time, 1, type(uint32).max);
+    uint256 time = bound(_time, 1, type(uint16).max);
 
-    assertEq(user.numCheckPoints, insertions);
+    assertEq(user.checkpoints.length(), insertions);
     // Cache in memory
-    DataStructures.CheckPoint memory last = user.checkpoints[user.numCheckPoints - 1];
+    Checkpoints.Checkpoint224 memory last = user.checkpoints.at(uint32(insertions - 1));
 
     vm.warp(block.timestamp + time);
     user.add(amount);
 
-    assertEq(user.numCheckPoints, insertions + 1);
-    DataStructures.CheckPoint memory last2 = user.checkpoints[user.numCheckPoints - 1];
+    assertEq(user.checkpoints.length(), insertions + 1);
+    Checkpoints.Checkpoint224 memory last2 = user.checkpoints.at(uint32(insertions));
 
-    assertEq(last2.time, last.time + Timestamp.wrap(time));
-    assertEq(last2.power, last.power + amount);
+    assertEq(last2._key, last._key + time.toUint32());
+    assertEq(last2._value, last._value + amount);
   }
 }

--- a/l1-contracts/test/governance/governance/userlib/base.t.sol
+++ b/l1-contracts/test/governance/governance/userlib/base.t.sol
@@ -2,16 +2,14 @@
 pragma solidity >=0.8.27;
 
 import {TestBase} from "@test/base/Base.sol";
-import {DataStructures} from "@aztec/governance/libraries/DataStructures.sol";
-import {UserLib} from "@aztec/governance/libraries/UserLib.sol";
-import {Timestamp} from "@aztec/core/libraries/TimeLib.sol";
+import {User, UserLib} from "@aztec/governance/libraries/UserLib.sol";
 
 contract UserLibBase is TestBase {
-  using UserLib for DataStructures.User;
+  using UserLib for User;
 
   uint256 internal constant CHECKPOINT_COUNT = 8;
 
-  DataStructures.User internal user;
+  User internal user;
 
   uint256 internal amount;
   uint256 internal sumBefore;

--- a/l1-contracts/test/governance/governance/userlib/powerNow.t.sol
+++ b/l1-contracts/test/governance/governance/userlib/powerNow.t.sol
@@ -2,13 +2,14 @@
 pragma solidity >=0.8.27;
 
 import {UserLibBase} from "./base.t.sol";
-import {DataStructures} from "@aztec/governance/libraries/DataStructures.sol";
-import {UserLib} from "@aztec/governance/libraries/UserLib.sol";
+import {User, UserLib} from "@aztec/governance/libraries/UserLib.sol";
 import {Timestamp} from "@aztec/core/libraries/TimeLib.sol";
 import {Errors} from "@aztec/governance/libraries/Errors.sol";
+import {Checkpoints} from "@oz/utils/structs/Checkpoints.sol";
 
 contract PowerNowTest is UserLibBase {
-  using UserLib for DataStructures.User;
+  using UserLib for User;
+  using Checkpoints for Checkpoints.Trace224;
 
   Timestamp internal time;
 
@@ -28,6 +29,6 @@ contract PowerNowTest is UserLibBase {
 
     vm.warp(block.timestamp + _timeJump);
 
-    assertEq(user.powerNow(), user.checkpoints[user.numCheckPoints - 1].power);
+    assertEq(user.powerNow(), user.checkpoints.latest());
   }
 }

--- a/l1-contracts/test/governance/governance/userlib/sub.t.sol
+++ b/l1-contracts/test/governance/governance/userlib/sub.t.sol
@@ -2,31 +2,36 @@
 pragma solidity >=0.8.27;
 
 import {UserLibBase} from "./base.t.sol";
-import {DataStructures} from "@aztec/governance/libraries/DataStructures.sol";
-import {UserLib} from "@aztec/governance/libraries/UserLib.sol";
+import {User, UserLib} from "@aztec/governance/libraries/UserLib.sol";
 import {Timestamp} from "@aztec/core/libraries/TimeLib.sol";
 import {Errors} from "@aztec/governance/libraries/Errors.sol";
+import {Checkpoints} from "@oz/utils/structs/Checkpoints.sol";
+import {SafeCast} from "@oz/utils/math/SafeCast.sol";
 
 contract SubTest is UserLibBase {
-  using UserLib for DataStructures.User;
+  using UserLib for User;
+  using Checkpoints for Checkpoints.Trace224;
+  using SafeCast for uint256;
 
   function test_WhenAmountEq0() external {
     // it return instantly with no changes
 
-    assertEq(user.numCheckPoints, 0);
+    assertEq(user.checkpoints.length(), 0);
 
     vm.record();
     user.sub(0);
     (bytes32[] memory reads, bytes32[] memory writes) = vm.accesses(address(this));
 
-    assertEq(user.numCheckPoints, 0);
+    assertEq(user.checkpoints.length(), 0);
     assertEq(reads.length, 0);
     assertEq(writes.length, 0);
   }
 
   function test_GivenUserHaveNoCheckpoints(uint256 _amount) external whenAmountGt0(_amount) {
     // it revert
-    vm.expectRevert(abi.encodeWithSelector(Errors.Governance__NoCheckpointsFound.selector));
+    vm.expectRevert(
+      abi.encodeWithSelector(Errors.Governance__InsufficientPower.selector, msg.sender, 0, amount)
+    );
     vm.prank(msg.sender);
     this.callSub(amount);
   }
@@ -39,7 +44,7 @@ contract SubTest is UserLibBase {
   ) external whenAmountGt0(_amount) givenUserHaveCheckpoints(_insert, _timeBetween, _amounts) {
     // it reverts
 
-    amount = bound(amount, sumBefore + 1, type(uint256).max);
+    amount = bound(amount, sumBefore + 1, type(uint224).max);
 
     vm.expectRevert(
       abi.encodeWithSelector(
@@ -69,17 +74,17 @@ contract SubTest is UserLibBase {
   {
     // it decreases power by amount
 
-    assertEq(user.numCheckPoints, insertions, "num checkpoints");
+    assertEq(user.checkpoints.length(), insertions, "num checkpoints");
     // Cache in memory
-    DataStructures.CheckPoint memory last = user.checkpoints[user.numCheckPoints - 1];
+    Checkpoints.Checkpoint224 memory last = user.checkpoints.at(uint32(insertions - 1));
 
     user.sub(amount);
 
-    assertEq(user.numCheckPoints, insertions, "num checkpoints");
-    DataStructures.CheckPoint memory last2 = user.checkpoints[user.numCheckPoints - 1];
+    assertEq(user.checkpoints.length(), insertions, "num checkpoints");
+    Checkpoints.Checkpoint224 memory last2 = user.checkpoints.at(uint32(insertions - 1));
 
-    assertEq(last2.time, last.time, "time");
-    assertEq(last2.power, last.power - amount, "power");
+    assertEq(last2._key, last._key, "time");
+    assertEq(last2._value, last._value - amount.toUint224(), "power");
   }
 
   function test_WhenLastCheckpointInPast(
@@ -97,20 +102,20 @@ contract SubTest is UserLibBase {
     // it adds a checkpoint with power equal to last.power - amount
     // it increases num checkpoints
 
-    uint256 time = bound(_time, 1, type(uint32).max);
+    uint256 time = bound(_time, 1, type(uint16).max);
 
-    assertEq(user.numCheckPoints, insertions);
+    assertEq(user.checkpoints.length(), insertions);
     // Cache in memory
-    DataStructures.CheckPoint memory last = user.checkpoints[user.numCheckPoints - 1];
+    Checkpoints.Checkpoint224 memory last = user.checkpoints.at(uint32(insertions - 1));
 
     vm.warp(block.timestamp + time);
     user.sub(amount);
 
-    assertEq(user.numCheckPoints, insertions + 1);
-    DataStructures.CheckPoint memory last2 = user.checkpoints[user.numCheckPoints - 1];
+    assertEq(user.checkpoints.length(), insertions + 1);
+    Checkpoints.Checkpoint224 memory last2 = user.checkpoints.at(uint32(insertions));
 
-    assertEq(last2.time, last.time + Timestamp.wrap(time));
-    assertEq(last2.power, last.power - amount);
+    assertEq(last2._key, last._key + time.toUint32());
+    assertEq(last2._value, last._value - amount.toUint224());
   }
 
   // @dev helper for testing, to avoid:


### PR DESCRIPTION
Fixes #13873.

Replaces most of the custom things in the `UserLib` with the open zeppelin checkpoint library. Still let the `UserLib` exist because the `add` and `sub` makes logic makes it simpler to use, and more plug and play (also expect to be able to reuse it later).

⚠️ Uses `uint32` for timestamps ⚠️ 