### PR TITLE
chore: codeowner and changetest

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -32,3 +32,6 @@
 
 # Notify fairies of changes to playground bundler config
 /playground/vite.config.ts @Thunkar
+
+# Notify turtles of painful changes to L1-contracts
+/l1-contracts/test/scream-and-shout.t.sol @LHerskind @Maddiaa0 @just-mitch

--- a/l1-contracts/test/scream-and-shout.t.sol
+++ b/l1-contracts/test/scream-and-shout.t.sol
@@ -1,0 +1,49 @@
+// SPDX-License-Identifier: UNLICENSED
+pragma solidity >=0.8.27;
+
+import {Test} from "forge-std/Test.sol";
+import {Rollup} from "@aztec/core/Rollup.sol";
+import {Registry} from "@aztec/governance/Registry.sol";
+import {Governance} from "@aztec/governance/Governance.sol";
+
+/**
+ * @notice  This test is used to ensure that changes to L1 contracts don't go unnoticed.
+ *          While still allowing the addition of more tests etc without having to update it.
+ *          The test is fairly simple, check if the creation code has changed for the important
+ *          contracts. If it has, the test will fail, so it needs to be updated.
+ *          Updating this file should then notify the turtles, as they are the code owners of this file.
+ */
+contract ScreamAndShoutTest is Test {
+  function test_RollupCreationCode() public pure {
+    bytes memory creationCode = type(Rollup).creationCode;
+    bytes32 codeHash = keccak256(creationCode);
+
+    assertEq(
+      codeHash,
+      0xc5594d87bc16a899c69da562e03152d6ce1250ceb174eca00ff76617e5fbffc2,
+      "You have changed the rollup!"
+    );
+  }
+
+  function test_GovernanceCreationCode() public pure {
+    bytes memory creationCode = type(Governance).creationCode;
+    bytes32 codeHash = keccak256(creationCode);
+
+    assertEq(
+      codeHash,
+      0x349b3b4efae2d8139f18b0458a23fc1f08d41714cf6bef73ebfa95e4e0e0554e,
+      "You have changed the governance!"
+    );
+  }
+
+  function test_RegistryCreationCode() public pure {
+    bytes memory creationCode = type(Registry).creationCode;
+    bytes32 codeHash = keccak256(creationCode);
+
+    assertEq(
+      codeHash,
+      0x45bb8de1be4c8238209f5882f7a5e1089fb7aad5ae97162f789ba15cd56aacff,
+      "You have changed the registry!"
+    );
+  }
+}


### PR DESCRIPTION
Adds a new test that do some minimal checks to catch if the contract code have been changed, and add the turtles as codeowners for the test. 

That way, we should be able to somewhat avoid not noticing if there are changes made to the contracts. It only check a few of the contracts; `rollup`, `governance` and `registry` as those are the big ones and should deal with most changes. 

I only do codeowners on this one file instead of the dir as we don't to be notified around extra tests or things that would not really cause a problem if used for nodes.