### PR TITLE
chore: add UltraRollupFlavor to ultra honk tests

### DIFF
--- a/barretenberg/cpp/src/barretenberg/polynomials/shared_shifted_virtual_zeroes_array.hpp
+++ b/barretenberg/cpp/src/barretenberg/polynomials/shared_shifted_virtual_zeroes_array.hpp
@@ -92,10 +92,8 @@ template <typename T> struct SharedShiftedVirtualZeroesArray {
 
     T& operator[](size_t index)
     {
-        if (index < start_ || index >= end_) {
-            vinfo("index = ", index, ", start_ = ", start_, ", end_ = ", end_);
-            ASSERT(false);
-        }
+        BB_ASSERT_GTE(index, start_);
+        BB_ASSERT_LT(index, end_);
         return data()[index - start_];
     }
     // get() is more useful, but for completeness with the non-const operator[]

--- a/barretenberg/cpp/src/barretenberg/ultra_honk/ultra_honk.test.cpp
+++ b/barretenberg/cpp/src/barretenberg/ultra_honk/ultra_honk.test.cpp
@@ -1,15 +1,18 @@
 #include "barretenberg/common/serialize.hpp"
 #include "barretenberg/ecc/curves/bn254/fr.hpp"
+#include "barretenberg/flavor/flavor.hpp"
 #include "barretenberg/numeric/uint256/uint256.hpp"
 #include "barretenberg/plonk_honk_shared/library/grand_product_delta.hpp"
 #include "barretenberg/plonk_honk_shared/types/aggregation_object_type.hpp"
 #include "barretenberg/relations/permutation_relation.hpp"
 #include "barretenberg/relations/relation_parameters.hpp"
 #include "barretenberg/stdlib/plonk_recursion/pairing_points.hpp"
+#include "barretenberg/stdlib/primitives/curves/grumpkin.hpp"
 #include "barretenberg/stdlib_circuit_builders/mock_circuits.hpp"
 #include "barretenberg/stdlib_circuit_builders/plookup_tables/fixed_base/fixed_base.hpp"
 #include "barretenberg/stdlib_circuit_builders/plookup_tables/types.hpp"
 #include "barretenberg/stdlib_circuit_builders/ultra_circuit_builder.hpp"
+#include "barretenberg/stdlib_circuit_builders/ultra_rollup_flavor.hpp"
 #include "barretenberg/sumcheck/sumcheck_round.hpp"
 #include "barretenberg/ultra_honk/ultra_prover.hpp"
 #include "barretenberg/ultra_honk/ultra_verifier.hpp"
@@ -36,19 +39,42 @@ template <typename Flavor> class UltraHonkTests : public ::testing::Test {
         return res;
     }
 
+    void set_default_pairing_points_and_ipa_claim_and_proof(UltraCircuitBuilder& builder)
+    {
+        AggregationState::add_default_to_public_inputs(builder);
+        if constexpr (HasIPAAccumulator<Flavor>) {
+            auto [stdlib_opening_claim, ipa_proof] =
+                IPA<stdlib::grumpkin<UltraCircuitBuilder>>::create_fake_ipa_claim_and_proof(builder);
+            stdlib_opening_claim.set_public();
+            builder.ipa_proof = ipa_proof;
+        }
+    }
+
     void prove_and_verify(auto& circuit_builder, bool expected_result)
     {
         auto proving_key = std::make_shared<DeciderProvingKey>(circuit_builder);
         Prover prover(proving_key);
-        auto verification_key = std::make_shared<VerificationKey>(proving_key->proving_key);
-        Verifier verifier(verification_key);
         auto proof = prover.construct_proof();
-        bool verified = verifier.verify_proof(proof);
-        EXPECT_EQ(verified, expected_result);
+        auto verification_key = std::make_shared<VerificationKey>(proving_key->proving_key);
+        if constexpr (HasIPAAccumulator<Flavor>) {
+            auto ipa_verification_key =
+                std::make_shared<VerifierCommitmentKey<curve::Grumpkin>>(1 << CONST_ECCVM_LOG_N);
+            Verifier verifier(verification_key, ipa_verification_key);
+            bool verified = verifier.verify_proof(proof, proving_key->proving_key.ipa_proof);
+            EXPECT_EQ(verified, expected_result);
+        } else {
+            Verifier verifier(verification_key);
+            bool verified = verifier.verify_proof(proof);
+            EXPECT_EQ(verified, expected_result);
+        }
     };
 
   protected:
-    static void SetUpTestSuite() { bb::srs::init_crs_factory(bb::srs::get_ignition_crs_path()); }
+    static void SetUpTestSuite()
+    {
+        bb::srs::init_crs_factory(bb::srs::get_ignition_crs_path());
+        bb::srs::init_grumpkin_crs_factory(bb::srs::get_grumpkin_crs_path());
+    }
 };
 
 #ifdef STARKNET_GARAGA_FLAVORS
@@ -56,10 +82,12 @@ using FlavorTypes = testing::Types<UltraFlavor,
                                    UltraZKFlavor,
                                    UltraKeccakFlavor,
                                    UltraKeccakZKFlavor,
+                                   UltraRollupFlavor,
                                    UltraStarknetFlavor,
                                    UltraStarknetZKFlavor>;
 #else
-using FlavorTypes = testing::Types<UltraFlavor, UltraZKFlavor, UltraKeccakFlavor, UltraKeccakZKFlavor>;
+using FlavorTypes =
+    testing::Types<UltraFlavor, UltraZKFlavor, UltraKeccakFlavor, UltraKeccakZKFlavor, UltraRollupFlavor>;
 #endif
 
 TYPED_TEST_SUITE(UltraHonkTests, FlavorTypes);
@@ -78,12 +106,16 @@ TYPED_TEST(UltraHonkTests, UltraProofSizeCheck)
     using Flavor = TypeParam;
 
     auto builder = typename Flavor::CircuitBuilder{};
-    stdlib::recursion::PairingPoints<typename Flavor::CircuitBuilder>::add_default_to_public_inputs(builder);
+    TestFixture::set_default_pairing_points_and_ipa_claim_and_proof(builder);
     // Construct a UH proof and ensure its size matches expectation; if not, the constant may need to be updated
     auto proving_key = std::make_shared<DeciderProvingKey_<Flavor>>(builder);
     UltraProver_<Flavor> prover(proving_key);
     HonkProof ultra_proof = prover.construct_proof();
-    EXPECT_EQ(ultra_proof.size(), Flavor::PROOF_LENGTH_WITHOUT_PUB_INPUTS + PAIRING_POINTS_SIZE);
+    size_t expected_proof_length = Flavor::PROOF_LENGTH_WITHOUT_PUB_INPUTS + PAIRING_POINTS_SIZE;
+    if (HasIPAAccumulator<Flavor>) {
+        expected_proof_length += IPA_CLAIM_SIZE;
+    }
+    EXPECT_EQ(ultra_proof.size(), expected_proof_length);
 }
 
 /**
@@ -96,7 +128,7 @@ TYPED_TEST(UltraHonkTests, UltraProofSizeCheck)
 TYPED_TEST(UltraHonkTests, ANonZeroPolynomialIsAGoodPolynomial)
 {
     auto circuit_builder = UltraCircuitBuilder();
-    AggregationState::add_default_to_public_inputs(circuit_builder);
+    TestFixture::set_default_pairing_points_and_ipa_claim_and_proof(circuit_builder);
 
     auto proving_key = std::make_shared<typename TestFixture::DeciderProvingKey>(circuit_builder);
     typename TestFixture::Prover prover(proving_key);
@@ -135,8 +167,8 @@ TYPED_TEST(UltraHonkTests, PublicInputs)
 
     // Add some arbitrary arithmetic gates that utilize public inputs
     MockCircuits::add_arithmetic_gates_with_public_inputs(builder, num_gates);
+    TestFixture::set_default_pairing_points_and_ipa_claim_and_proof(builder);
 
-    AggregationState::add_default_to_public_inputs(builder);
     TestFixture::prove_and_verify(builder, /*expected_result=*/true);
 }
 
@@ -163,8 +195,8 @@ TYPED_TEST(UltraHonkTests, XorConstraint)
     EXPECT_EQ(xor_result, xor_result_expected);
     circuit_builder.create_gates_from_plookup_accumulators(
         plookup::MultiTableId::UINT32_XOR, lookup_accumulators, left_witness_index, right_witness_index);
+    TestFixture::set_default_pairing_points_and_ipa_claim_and_proof(circuit_builder);
 
-    AggregationState::add_default_to_public_inputs(circuit_builder);
     TestFixture::prove_and_verify(circuit_builder, /*expected_result=*/true);
 }
 
@@ -224,7 +256,8 @@ TYPED_TEST(UltraHonkTests, CreateGatesFromPlookupAccumulators)
             expected_scalar >>= table_bits;
         }
     }
-    AggregationState::add_default_to_public_inputs(circuit_builder);
+    TestFixture::set_default_pairing_points_and_ipa_claim_and_proof(circuit_builder);
+
     TestFixture::prove_and_verify(circuit_builder, /*expected_result=*/true);
 }
 
@@ -237,21 +270,29 @@ TYPED_TEST(UltraHonkTests, LookupFailure)
     using DeciderProvingKey = typename TestFixture::DeciderProvingKey;
     using VerificationKey = typename TestFixture::VerificationKey;
     // Construct a circuit with lookup and arithmetic gates
-    auto construct_circuit_with_lookups = []() {
+    auto construct_circuit_with_lookups = [this]() {
         UltraCircuitBuilder builder;
 
         MockCircuits::add_lookup_gates(builder);
         MockCircuits::add_arithmetic_gates(builder);
-        AggregationState::add_default_to_public_inputs(builder);
+        TestFixture::set_default_pairing_points_and_ipa_claim_and_proof(builder);
+
         return builder;
     };
 
     auto prove_and_verify = [](auto& proving_key) {
         typename TestFixture::Prover prover(proving_key);
-        auto verification_key = std::make_shared<VerificationKey>(proving_key->proving_key);
-        typename TestFixture::Verifier verifier(verification_key);
         auto proof = prover.construct_proof();
-        return verifier.verify_proof(proof);
+        auto verification_key = std::make_shared<VerificationKey>(proving_key->proving_key);
+        if constexpr (HasIPAAccumulator<TypeParam>) {
+            auto ipa_verification_key =
+                std::make_shared<VerifierCommitmentKey<curve::Grumpkin>>(1 << CONST_ECCVM_LOG_N);
+            typename TestFixture::Verifier verifier(verification_key, ipa_verification_key);
+            return verifier.verify_proof(proof, proving_key->proving_key.ipa_proof);
+        } else {
+            typename TestFixture::Verifier verifier(verification_key);
+            return verifier.verify_proof(proof);
+        }
     };
 
     // Ensure the unaltered test circuit is valid
@@ -276,6 +317,7 @@ TYPED_TEST(UltraHonkTests, LookupFailure)
         // question will be zero. So if read counts is incremented at some arbitrary index but read tags is not, the
         // inverse will be 0 and the erroneous read_counts value will get multiplied by 0 in the relation. This is
         // expected behavior.
+        polynomials.lookup_inverses = polynomials.lookup_inverses.full();
         polynomials.lookup_read_counts = polynomials.lookup_read_counts.full();
         polynomials.lookup_read_counts.at(25) = 1;
         polynomials.lookup_read_tags = polynomials.lookup_read_tags.full();
@@ -312,6 +354,7 @@ TYPED_TEST(UltraHonkTests, LookupFailure)
         auto& polynomials = proving_key->proving_key.polynomials;
 
         // Turn the lookup selector on for an arbitrary row where it is not already active
+        polynomials.lookup_inverses = polynomials.lookup_inverses.full();
         polynomials.q_lookup = polynomials.q_lookup.full();
         EXPECT_TRUE(polynomials.q_lookup[25] != 1);
         polynomials.q_lookup.at(25) = 1;
@@ -338,7 +381,8 @@ TYPED_TEST(UltraHonkTests, TestNoLookupProof)
                 { left_idx, right_idx, result_idx, add_idx, fr(1), fr(1), fr(1), fr(-1), fr(0) });
         }
     }
-    AggregationState::add_default_to_public_inputs(circuit_builder);
+    TestFixture::set_default_pairing_points_and_ipa_claim_and_proof(circuit_builder);
+
     TestFixture::prove_and_verify(circuit_builder, /*expected_result=*/true);
 }
 
@@ -372,7 +416,8 @@ TYPED_TEST(UltraHonkTests, TestEllipticGate)
     y3 = circuit_builder.add_variable(p3.y);
     circuit_builder.create_ecc_add_gate({ x1, y1, x2, y2, x3, y3, -1 });
 
-    AggregationState::add_default_to_public_inputs(circuit_builder);
+    TestFixture::set_default_pairing_points_and_ipa_claim_and_proof(circuit_builder);
+
     TestFixture::prove_and_verify(circuit_builder, /*expected_result=*/true);
 }
 
@@ -399,8 +444,8 @@ TYPED_TEST(UltraHonkTests, NonTrivialTagPermutation)
     circuit_builder.assign_tag(b_idx, 1);
     circuit_builder.assign_tag(c_idx, 2);
     circuit_builder.assign_tag(d_idx, 2);
+    TestFixture::set_default_pairing_points_and_ipa_claim_and_proof(circuit_builder);
 
-    AggregationState::add_default_to_public_inputs(circuit_builder);
     TestFixture::prove_and_verify(circuit_builder, /*expected_result=*/true);
 }
 
@@ -437,8 +482,8 @@ TYPED_TEST(UltraHonkTests, NonTrivialTagPermutationAndCycles)
         { c_idx, g_idx, circuit_builder.zero_idx, fr::one(), -fr::one(), fr::zero(), fr::zero() });
     circuit_builder.create_add_gate(
         { e_idx, f_idx, circuit_builder.zero_idx, fr::one(), -fr::one(), fr::zero(), fr::zero() });
+    TestFixture::set_default_pairing_points_and_ipa_claim_and_proof(circuit_builder);
 
-    AggregationState::add_default_to_public_inputs(circuit_builder);
     TestFixture::prove_and_verify(circuit_builder, /*expected_result=*/true);
 }
 
@@ -464,8 +509,8 @@ TYPED_TEST(UltraHonkTests, BadTagPermutation)
         circuit_builder.assign_tag(b_idx, 1);
         circuit_builder.assign_tag(c_idx, 2);
         circuit_builder.assign_tag(d_idx, 2);
+        TestFixture::set_default_pairing_points_and_ipa_claim_and_proof(circuit_builder);
 
-        AggregationState::add_default_to_public_inputs(circuit_builder);
         TestFixture::prove_and_verify(circuit_builder, /*expected_result=*/false);
     }
     // Same as above but without tag creation to check reason of failure is really tag mismatch
@@ -481,8 +526,8 @@ TYPED_TEST(UltraHonkTests, BadTagPermutation)
 
         circuit_builder.create_add_gate({ a_idx, b_idx, circuit_builder.zero_idx, 1, 1, 0, 0 });
         circuit_builder.create_add_gate({ c_idx, d_idx, circuit_builder.zero_idx, 1, 1, 0, -1 });
+        TestFixture::set_default_pairing_points_and_ipa_claim_and_proof(circuit_builder);
 
-        AggregationState::add_default_to_public_inputs(circuit_builder);
         TestFixture::prove_and_verify(circuit_builder, /*expected_result=*/true);
     }
 }
@@ -501,7 +546,8 @@ TYPED_TEST(UltraHonkTests, SortWidget)
     auto d_idx = circuit_builder.add_variable(d);
     circuit_builder.create_sort_constraint({ a_idx, b_idx, c_idx, d_idx });
 
-    AggregationState::add_default_to_public_inputs(circuit_builder);
+    TestFixture::set_default_pairing_points_and_ipa_claim_and_proof(circuit_builder);
+
     TestFixture::prove_and_verify(circuit_builder, /*expected_result=*/true);
 }
 
@@ -529,7 +575,8 @@ TYPED_TEST(UltraHonkTests, SortWithEdgesGate)
         circuit_builder.create_sort_constraint_with_edges(
             { a_idx, b_idx, c_idx, d_idx, e_idx, f_idx, g_idx, h_idx }, a, h);
 
-        AggregationState::add_default_to_public_inputs(circuit_builder);
+        TestFixture::set_default_pairing_points_and_ipa_claim_and_proof(circuit_builder);
+
         TestFixture::prove_and_verify(circuit_builder, /*expected_result=*/true);
     }
 
@@ -546,7 +593,8 @@ TYPED_TEST(UltraHonkTests, SortWithEdgesGate)
         circuit_builder.create_sort_constraint_with_edges(
             { a_idx, b_idx, c_idx, d_idx, e_idx, f_idx, g_idx, h_idx }, a, g);
 
-        AggregationState::add_default_to_public_inputs(circuit_builder);
+        TestFixture::set_default_pairing_points_and_ipa_claim_and_proof(circuit_builder);
+
         TestFixture::prove_and_verify(circuit_builder, /*expected_result=*/false);
     }
     {
@@ -562,7 +610,8 @@ TYPED_TEST(UltraHonkTests, SortWithEdgesGate)
         circuit_builder.create_sort_constraint_with_edges(
             { a_idx, b_idx, c_idx, d_idx, e_idx, f_idx, g_idx, h_idx }, b, h);
 
-        AggregationState::add_default_to_public_inputs(circuit_builder);
+        TestFixture::set_default_pairing_points_and_ipa_claim_and_proof(circuit_builder);
+
         TestFixture::prove_and_verify(circuit_builder, /*expected_result=*/false);
     }
     {
@@ -578,7 +627,8 @@ TYPED_TEST(UltraHonkTests, SortWithEdgesGate)
         circuit_builder.create_sort_constraint_with_edges(
             { a_idx, b2_idx, c_idx, d_idx, e_idx, f_idx, g_idx, h_idx }, b, h);
 
-        AggregationState::add_default_to_public_inputs(circuit_builder);
+        TestFixture::set_default_pairing_points_and_ipa_claim_and_proof(circuit_builder);
+
         TestFixture::prove_and_verify(circuit_builder, /*expected_result=*/false);
     }
     {
@@ -588,7 +638,8 @@ TYPED_TEST(UltraHonkTests, SortWithEdgesGate)
                                                           26, 29, 29, 32, 32, 33, 35, 38, 39, 39, 42, 42, 43, 45 });
         circuit_builder.create_sort_constraint_with_edges(idx, 1, 45);
 
-        AggregationState::add_default_to_public_inputs(circuit_builder);
+        TestFixture::set_default_pairing_points_and_ipa_claim_and_proof(circuit_builder);
+
         TestFixture::prove_and_verify(circuit_builder, /*expected_result=*/true);
     }
     {
@@ -598,7 +649,8 @@ TYPED_TEST(UltraHonkTests, SortWithEdgesGate)
                                                           26, 29, 29, 32, 32, 33, 35, 38, 39, 39, 42, 42, 43, 45 });
         circuit_builder.create_sort_constraint_with_edges(idx, 1, 29);
 
-        AggregationState::add_default_to_public_inputs(circuit_builder);
+        TestFixture::set_default_pairing_points_and_ipa_claim_and_proof(circuit_builder);
+
         TestFixture::prove_and_verify(circuit_builder, /*expected_result=*/false);
     }
 }
@@ -614,7 +666,8 @@ TYPED_TEST(UltraHonkTests, RangeConstraint)
         // auto ind = {a_idx,b_idx,c_idx,d_idx,e_idx,f_idx,g_idx,h_idx};
         circuit_builder.create_sort_constraint(indices);
 
-        AggregationState::add_default_to_public_inputs(circuit_builder);
+        TestFixture::set_default_pairing_points_and_ipa_claim_and_proof(circuit_builder);
+
         TestFixture::prove_and_verify(circuit_builder, /*expected_result=*/true);
     }
     {
@@ -626,7 +679,8 @@ TYPED_TEST(UltraHonkTests, RangeConstraint)
         // auto ind = {a_idx,b_idx,c_idx,d_idx,e_idx,f_idx,g_idx,h_idx};
         circuit_builder.create_dummy_constraints(indices);
 
-        AggregationState::add_default_to_public_inputs(circuit_builder);
+        TestFixture::set_default_pairing_points_and_ipa_claim_and_proof(circuit_builder);
+
         TestFixture::prove_and_verify(circuit_builder, /*expected_result=*/true);
     }
     {
@@ -637,7 +691,8 @@ TYPED_TEST(UltraHonkTests, RangeConstraint)
         }
         circuit_builder.create_sort_constraint(indices);
 
-        AggregationState::add_default_to_public_inputs(circuit_builder);
+        TestFixture::set_default_pairing_points_and_ipa_claim_and_proof(circuit_builder);
+
         TestFixture::prove_and_verify(circuit_builder, /*expected_result=*/false);
     }
     {
@@ -649,7 +704,8 @@ TYPED_TEST(UltraHonkTests, RangeConstraint)
         }
         circuit_builder.create_dummy_constraints(indices);
 
-        AggregationState::add_default_to_public_inputs(circuit_builder);
+        TestFixture::set_default_pairing_points_and_ipa_claim_and_proof(circuit_builder);
+
         TestFixture::prove_and_verify(circuit_builder, /*expected_result=*/true);
     }
     {
@@ -661,7 +717,8 @@ TYPED_TEST(UltraHonkTests, RangeConstraint)
         }
         circuit_builder.create_dummy_constraints(indices);
 
-        AggregationState::add_default_to_public_inputs(circuit_builder);
+        TestFixture::set_default_pairing_points_and_ipa_claim_and_proof(circuit_builder);
+
         TestFixture::prove_and_verify(circuit_builder, /*expected_result=*/false);
     }
     {
@@ -673,7 +730,8 @@ TYPED_TEST(UltraHonkTests, RangeConstraint)
         }
         circuit_builder.create_dummy_constraints(indices);
 
-        AggregationState::add_default_to_public_inputs(circuit_builder);
+        TestFixture::set_default_pairing_points_and_ipa_claim_and_proof(circuit_builder);
+
         TestFixture::prove_and_verify(circuit_builder, /*expected_result=*/false);
     }
 }
@@ -693,7 +751,8 @@ TYPED_TEST(UltraHonkTests, RangeWithGates)
     circuit_builder.create_add_gate(
         { idx[6], idx[7], circuit_builder.zero_idx, fr::one(), fr::one(), fr::zero(), -15 });
 
-    AggregationState::add_default_to_public_inputs(circuit_builder);
+    TestFixture::set_default_pairing_points_and_ipa_claim_and_proof(circuit_builder);
+
     TestFixture::prove_and_verify(circuit_builder, /*expected_result=*/true);
 }
 
@@ -712,7 +771,8 @@ TYPED_TEST(UltraHonkTests, RangeWithGatesWhereRangeIsNotAPowerOfTwo)
     circuit_builder.create_add_gate(
         { idx[6], idx[7], circuit_builder.zero_idx, fr::one(), fr::one(), fr::zero(), -15 });
 
-    AggregationState::add_default_to_public_inputs(circuit_builder);
+    TestFixture::set_default_pairing_points_and_ipa_claim_and_proof(circuit_builder);
+
     TestFixture::prove_and_verify(circuit_builder, /*expected_result=*/true);
 }
 
@@ -727,7 +787,8 @@ TYPED_TEST(UltraHonkTests, SortWidgetComplex)
             ind.emplace_back(circuit_builder.add_variable(val));
         circuit_builder.create_sort_constraint(ind);
 
-        AggregationState::add_default_to_public_inputs(circuit_builder);
+        TestFixture::set_default_pairing_points_and_ipa_claim_and_proof(circuit_builder);
+
         TestFixture::prove_and_verify(circuit_builder, /*expected_result=*/true);
     }
     {
@@ -739,7 +800,8 @@ TYPED_TEST(UltraHonkTests, SortWidgetComplex)
             ind.emplace_back(circuit_builder.add_variable(val));
         circuit_builder.create_sort_constraint(ind);
 
-        AggregationState::add_default_to_public_inputs(circuit_builder);
+        TestFixture::set_default_pairing_points_and_ipa_claim_and_proof(circuit_builder);
+
         TestFixture::prove_and_verify(circuit_builder, /*expected_result=*/false);
     }
 }
@@ -758,7 +820,8 @@ TYPED_TEST(UltraHonkTests, SortWidgetNeg)
     auto d_idx = circuit_builder.add_variable(d);
     circuit_builder.create_sort_constraint({ a_idx, b_idx, c_idx, d_idx });
 
-    AggregationState::add_default_to_public_inputs(circuit_builder);
+    TestFixture::set_default_pairing_points_and_ipa_claim_and_proof(circuit_builder);
+
     TestFixture::prove_and_verify(circuit_builder, /*expected_result=*/false);
 }
 
@@ -772,7 +835,8 @@ TYPED_TEST(UltraHonkTests, ComposedRangeConstraint)
     circuit_builder.create_add_gate({ a_idx, circuit_builder.zero_idx, circuit_builder.zero_idx, 1, 0, 0, -fr(e) });
     circuit_builder.decompose_into_default_range(a_idx, 134);
 
-    AggregationState::add_default_to_public_inputs(circuit_builder);
+    TestFixture::set_default_pairing_points_and_ipa_claim_and_proof(circuit_builder);
+
     TestFixture::prove_and_verify(circuit_builder, /*expected_result=*/true);
 }
 
@@ -827,7 +891,8 @@ TYPED_TEST(UltraHonkTests, NonNativeFieldMultiplication)
     const auto [lo_1_idx, hi_1_idx] = circuit_builder.evaluate_non_native_field_multiplication(inputs);
     circuit_builder.range_constrain_two_limbs(lo_1_idx, hi_1_idx, 70, 70);
 
-    AggregationState::add_default_to_public_inputs(circuit_builder);
+    TestFixture::set_default_pairing_points_and_ipa_claim_and_proof(circuit_builder);
+
     TestFixture::prove_and_verify(circuit_builder, /*expected_result=*/true);
 }
 
@@ -868,8 +933,8 @@ TYPED_TEST(UltraHonkTests, Rom)
         -1,
         0,
     });
+    TestFixture::set_default_pairing_points_and_ipa_claim_and_proof(circuit_builder);
 
-    AggregationState::add_default_to_public_inputs(circuit_builder);
     TestFixture::prove_and_verify(circuit_builder, /*expected_result=*/true);
 }
 
@@ -933,7 +998,8 @@ TYPED_TEST(UltraHonkTests, Ram)
         },
         false);
 
-    AggregationState::add_default_to_public_inputs(circuit_builder);
+    TestFixture::set_default_pairing_points_and_ipa_claim_and_proof(circuit_builder);
+
     TestFixture::prove_and_verify(circuit_builder, /*expected_result=*/true);
 }
 
@@ -969,7 +1035,8 @@ TYPED_TEST(UltraHonkTests, RangeChecksOnDuplicates)
         },
         false);
 
-    AggregationState::add_default_to_public_inputs(circuit_builder);
+    TestFixture::set_default_pairing_points_and_ipa_claim_and_proof(circuit_builder);
+
     TestFixture::prove_and_verify(circuit_builder, /*expected_result=*/true);
 }
 
@@ -993,6 +1060,7 @@ TYPED_TEST(UltraHonkTests, RangeConstraintSmallVariable)
     circuit_builder.create_range_constraint(c_idx, 8, "bad range");
     circuit_builder.assert_equal(a_idx, c_idx);
 
-    AggregationState::add_default_to_public_inputs(circuit_builder);
+    TestFixture::set_default_pairing_points_and_ipa_claim_and_proof(circuit_builder);
+
     TestFixture::prove_and_verify(circuit_builder, /*expected_result=*/true);
 }


### PR DESCRIPTION
We were missing UltraRollupFlavor in these tests, so I added them to be complete.