### PR TITLE
fix!: cycle group fix (results in protocol circuit changes)

### DIFF
--- a/barretenberg/cpp/src/barretenberg/stdlib/primitives/group/cycle_group.cpp
+++ b/barretenberg/cpp/src/barretenberg/stdlib/primitives/group/cycle_group.cpp
@@ -1287,7 +1287,7 @@ cycle_group<Builder>::straus_lookup_table::straus_lookup_table(Builder* context,
     // if the input point is constant, it is cheaper to fix the point as a witness and then derive the table, than it is
     // to derive the table and fix its witnesses to be constant! (due to group additions = 1 gate, and fixing x/y coords
     // to be constant = 2 gates)
-    if (modded_base_point.is_constant() && !base_point.is_point_at_infinity().get_value()) {
+    if (base_point.is_constant() && !base_point.is_point_at_infinity().get_value()) {
         modded_base_point = cycle_group::from_constant_witness(_context, modded_base_point.get_value());
         point_table[0] = cycle_group::from_constant_witness(_context, offset_generator.get_value());
         for (size_t i = 1; i < table_size; ++i) {


### PR DESCRIPTION
Explanation of the fix:
In the constructor for `straus_lookup_table` there is conditional logic intended to gracefully handle the point at infinity. The conditional previously included the check: `modded_base_point.is_constant()` where the point was computed as:
```
    cycle_group fallback_point(Group::affine_one);
    field_t modded_x = field_t::conditional_assign(base_point.is_point_at_infinity(), fallback_point.x, base_point.x);
    field_t modded_y = field_t::conditional_assign(base_point.is_point_at_infinity(), fallback_point.y, base_point.y);
    cycle_group modded_base_point(modded_x, modded_y, false);
```
The intent was for this to result in modded_base_point.is_constant() if and only if base_point.is_constant(). However there is an edge case where `conditional_assign(lhs, rhs)` will return `lhs` if `lhs == rhs`. Since `fallback_point` is _always_ constant by definition, this meant that `modded_base_point.is_constant()` was true any time `fallback_point == base_point`. This happened frequently in the dummy witness case since `Group::affine_one` is used in multi_scalar_mul constraints in place of unknown point values. 

Note: This change results in changes in both the non-dummy witness case and the dummy witness case.

Fixes https://github.com/AztecProtocol/barretenberg/issues/1374