### PR TITLE
chore: comment civc trace size log parsing

### DIFF
--- a/barretenberg/cpp/src/barretenberg/plonk_honk_shared/execution_trace/execution_trace_usage_tracker.hpp
+++ b/barretenberg/cpp/src/barretenberg/plonk_honk_shared/execution_trace/execution_trace_usage_tracker.hpp
@@ -127,11 +127,13 @@ struct ExecutionTraceUsageTracker {
 
     void print()
     {
+        // NOTE: This is used by downstream tools for parsing the required block sizes. Do not change this
+        // without updating (or consulting Grego).
         info("Largest circuit: ", max_gates_size, " gates. Trace details:");
+        info("Minimum required block sizes for structured trace: ");
         size_t idx = 0;
         for (auto max_size : max_sizes.get()) {
-            std::cout << std::left << std::setw(20) << block_labels[idx] << ": " << max_size;
-            std::cout << std::endl;
+            std::cout << std::left << std::setw(20) << block_labels[idx] << ": " << max_size << std::endl;
             idx++;
         }
         info("");


### PR DESCRIPTION
Grego is relying on this format and we've changed it a few times lately, a comment is prudent