### PR TITLE
chore: better handling of ultra ops in translator circuit builder

### DIFF
--- a/barretenberg/cpp/src/barretenberg/relations/translator_vm/translator_extra_relations.hpp
+++ b/barretenberg/cpp/src/barretenberg/relations/translator_vm/translator_extra_relations.hpp
@@ -14,7 +14,7 @@ template <typename FF_> class TranslatorOpcodeConstraintRelationImpl {
     using FF = FF_;
 
     // 1 + polynomial degree of this relation
-    static constexpr size_t RELATION_LENGTH = 5; // degree(op(op - 1)(op - 2)(op - 3)(op - 4)(op - 8)) = 4
+    static constexpr size_t RELATION_LENGTH = 5; // degree(op(op - 3)(op - 4)(op - 8)) = 4
     static constexpr std::array<size_t, 1> SUBRELATION_PARTIAL_LENGTHS{
         5 // opcode constraint relation
     };

--- a/barretenberg/cpp/src/barretenberg/relations/translator_vm/translator_extra_relations.hpp
+++ b/barretenberg/cpp/src/barretenberg/relations/translator_vm/translator_extra_relations.hpp
@@ -14,9 +14,9 @@ template <typename FF_> class TranslatorOpcodeConstraintRelationImpl {
     using FF = FF_;
 
     // 1 + polynomial degree of this relation
-    static constexpr size_t RELATION_LENGTH = 7; // degree(op(op - 1)(op - 2)(op - 3)(op - 4)(op - 8)) = 6
+    static constexpr size_t RELATION_LENGTH = 5; // degree(op(op - 1)(op - 2)(op - 3)(op - 4)(op - 8)) = 4
     static constexpr std::array<size_t, 1> SUBRELATION_PARTIAL_LENGTHS{
-        7 // opcode constraint relation
+        5 // opcode constraint relation
     };
 
     /**

--- a/barretenberg/cpp/src/barretenberg/relations/translator_vm/translator_extra_relations_impl.hpp
+++ b/barretenberg/cpp/src/barretenberg/relations/translator_vm/translator_extra_relations_impl.hpp
@@ -10,7 +10,7 @@
 namespace bb {
 
 /**
- * @brief Expression for enforcing the value of the Opcode to be {0,1,2,3,4,8}
+ * @brief Expression for enforcing the value of the Opcode to be {0,3,4,8} (nop, eq and reset, mul or add)
  * @details This relation enforces the opcode to be one of described values. Since we don't care about even
  * values in the opcode wire and usually just set them to zero, we don't use a lagrange polynomial to specify
  * the relation to be enforced just at odd indices, which brings the degree down by 1.

--- a/barretenberg/cpp/src/barretenberg/relations/translator_vm/translator_extra_relations_impl.hpp
+++ b/barretenberg/cpp/src/barretenberg/relations/translator_vm/translator_extra_relations_impl.hpp
@@ -32,16 +32,12 @@ void TranslatorOpcodeConstraintRelationImpl<FF>::accumulate(ContainerOverSubrela
     using View = typename Accumulator::View;
 
     auto op = View(in.op);
-    static const FF minus_one = FF(-1);
-    static const FF minus_two = FF(-2);
     static const FF minus_three = FF(-3);
     static const FF minus_four = FF(-4);
     static const FF minus_eight = FF(-8);
 
-    // Contribution (1) (op(op-1)(op-2)(op-3)(op-4)(op-8))
-    auto tmp_1 = op * (op + minus_one);
-    tmp_1 *= (op + minus_two);
-    tmp_1 *= (op + minus_three);
+    // Contribution (1) op(op-3)(op-4)(op-8))
+    auto tmp_1 = op * (op + minus_three);
     tmp_1 *= (op + minus_four);
     tmp_1 *= (op + minus_eight);
     tmp_1 *= scaling_factor;

--- a/barretenberg/cpp/src/barretenberg/relations/translator_vm/translator_relation_consistency.test.cpp
+++ b/barretenberg/cpp/src/barretenberg/relations/translator_vm/translator_relation_consistency.test.cpp
@@ -739,7 +739,7 @@ TEST_F(TranslatorRelationConsistency, OpcodeConstraintRelation)
         const auto parameters = RelationParameters<FF>::get_random();
 
         // (Contribution 1)
-        auto contribution_1 = op * (op - FF(1)) * (op - FF(2)) * (op - FF(3)) * (op - FF(4)) * (op - FF(8));
+        auto contribution_1 = op * (op - FF(3)) * (op - FF(4)) * (op - FF(8));
         expected_values[0] = contribution_1;
 
         validate_relation_execution<Relation>(expected_values, input_elements, parameters);

--- a/barretenberg/cpp/src/barretenberg/stdlib/translator_vm_verifier/translator_extra_relations.cpp
+++ b/barretenberg/cpp/src/barretenberg/stdlib/translator_vm_verifier/translator_extra_relations.cpp
@@ -11,8 +11,10 @@
 namespace bb {
 template class TranslatorOpcodeConstraintRelationImpl<stdlib::field_t<UltraCircuitBuilder>>;
 template class TranslatorAccumulatorTransferRelationImpl<stdlib::field_t<UltraCircuitBuilder>>;
+template class TranslatorZeroConstraintsRelationImpl<stdlib::field_t<UltraCircuitBuilder>>;
 template class TranslatorOpcodeConstraintRelationImpl<stdlib::field_t<MegaCircuitBuilder>>;
 template class TranslatorAccumulatorTransferRelationImpl<stdlib::field_t<MegaCircuitBuilder>>;
+template class TranslatorZeroConstraintsRelationImpl<stdlib::field_t<MegaCircuitBuilder>>;
 DEFINE_SUMCHECK_VERIFIER_RELATION_CLASS(TranslatorOpcodeConstraintRelationImpl,
                                         TranslatorRecursiveFlavor_<UltraCircuitBuilder>);
 DEFINE_SUMCHECK_VERIFIER_RELATION_CLASS(TranslatorOpcodeConstraintRelationImpl,
@@ -20,6 +22,10 @@ DEFINE_SUMCHECK_VERIFIER_RELATION_CLASS(TranslatorOpcodeConstraintRelationImpl,
 DEFINE_SUMCHECK_VERIFIER_RELATION_CLASS(TranslatorAccumulatorTransferRelationImpl,
                                         TranslatorRecursiveFlavor_<UltraCircuitBuilder>);
 DEFINE_SUMCHECK_VERIFIER_RELATION_CLASS(TranslatorAccumulatorTransferRelationImpl,
+                                        TranslatorRecursiveFlavor_<MegaCircuitBuilder>);
+DEFINE_SUMCHECK_VERIFIER_RELATION_CLASS(TranslatorZeroConstraintsRelationImpl,
+                                        TranslatorRecursiveFlavor_<UltraCircuitBuilder>);
+DEFINE_SUMCHECK_VERIFIER_RELATION_CLASS(TranslatorZeroConstraintsRelationImpl,
                                         TranslatorRecursiveFlavor_<MegaCircuitBuilder>);
 
 } // namespace bb

--- a/barretenberg/cpp/src/barretenberg/translator_vm/relation_correctness.test.cpp
+++ b/barretenberg/cpp/src/barretenberg/translator_vm/relation_correctness.test.cpp
@@ -152,8 +152,8 @@ TEST_F(TranslatorRelationCorrectnessTests, TranslatorExtraRelationsCorrectness)
         prover_polynomials.lagrange_odd_in_minicircuit.at(i) = 1;
         prover_polynomials.lagrange_even_in_minicircuit.at(i + 1) = 1;
     }
-    constexpr size_t NUMBER_OF_POSSIBLE_OPCODES = 6;
-    constexpr std::array<uint64_t, NUMBER_OF_POSSIBLE_OPCODES> possible_opcode_values = { 0, 1, 2, 3, 4, 8 };
+    constexpr size_t NUMBER_OF_POSSIBLE_OPCODES = 4;
+    constexpr std::array<uint64_t, NUMBER_OF_POSSIBLE_OPCODES> possible_opcode_values = { 0, 3, 4, 8 };
 
     // Assign random opcode values
     for (size_t i = 1; i < mini_circuit_size - 1; i += 2) {

--- a/barretenberg/cpp/src/barretenberg/translator_vm/translator_circuit_builder.cpp
+++ b/barretenberg/cpp/src/barretenberg/translator_vm/translator_circuit_builder.cpp
@@ -27,26 +27,14 @@ namespace bb {
  *
  * @tparam Fq
  * @tparam Fr
- * @param op_code Opcode value
- * @param p_x_lo Low 136 bits of P.x
- * @param p_x_hi High 118 bits of P.x
- * @param p_y_lo Low 136 bits of P.y
- * @param p_y_hi High 118 bits of P.y
- * @param z1 z1 scalar
- * @param z2 z2 scalar
+ * @param ultra_op The ultra op used to produce the wire data
  * @param previous_accumulator The value of the previous accumulator (we assume standard decomposition into limbs)
  * @param batching_challenge_v The value of the challenge for batching polynomial evaluations
  * @param evaluation_input_x The value at which we evaluate the polynomials
  * @return TranslatorCircuitBuilder::AccumulationInput
  */
 TranslatorCircuitBuilder::AccumulationInput TranslatorCircuitBuilder::generate_witness_values(
-    const Fr& op_code,
-    const Fr& p_x_lo,
-    const Fr& p_x_hi,
-    const Fr& p_y_lo,
-    const Fr& p_y_hi,
-    const Fr& z1,
-    const Fr& z2,
+    const UltraOp& ultra_op,
     const Fq& previous_accumulator,
     const Fq& batching_challenge_v,
     const Fq& evaluation_input_x)
@@ -159,13 +147,14 @@ TranslatorCircuitBuilder::AccumulationInput TranslatorCircuitBuilder::generate_w
 
     // To calculate the quotient, we need to evaluate the expression in integers. So we need uint512_t versions of all
     // elements involved
+    size_t op_code = ultra_op.op_code.value();
     auto uint_previous_accumulator = uint512_t(previous_accumulator);
     auto uint_x = uint512_t(evaluation_input_x);
     auto uint_op = uint512_t(op_code);
-    auto uint_p_x = uint512_t(uint256_t(p_x_lo) + (uint256_t(p_x_hi) << (NUM_LIMB_BITS << 1)));
-    auto uint_p_y = uint512_t(uint256_t(p_y_lo) + (uint256_t(p_y_hi) << (NUM_LIMB_BITS << 1)));
-    auto uint_z1 = uint512_t(z1);
-    auto uint_z2 = uint512_t(z2);
+    auto uint_p_x = uint512_t(uint256_t(ultra_op.x_lo) + (uint256_t(ultra_op.x_hi) << (NUM_LIMB_BITS << 1)));
+    auto uint_p_y = uint512_t(uint256_t(ultra_op.y_lo) + (uint256_t(ultra_op.y_hi) << (NUM_LIMB_BITS << 1)));
+    auto uint_z1 = uint512_t(ultra_op.z_1);
+    auto uint_z2 = uint512_t(ultra_op.z_2);
     auto uint_v = uint512_t(batching_challenge_v);
     auto uint_v_squared = uint512_t(v_squared);
     auto uint_v_cubed = uint512_t(v_cubed);
@@ -173,22 +162,22 @@ TranslatorCircuitBuilder::AccumulationInput TranslatorCircuitBuilder::generate_w
 
     // Construct Fq for op, P.x, P.y, z_1, z_2 for use in witness computation
     Fq base_op = Fq(uint256_t(op_code));
-    Fq base_p_x = Fq(uint256_t(p_x_lo) + (uint256_t(p_x_hi) << (NUM_LIMB_BITS << 1)));
-    Fq base_p_y = Fq(uint256_t(p_y_lo) + (uint256_t(p_y_hi) << (NUM_LIMB_BITS << 1)));
-    Fq base_z_1 = Fq(uint256_t(z1));
-    Fq base_z_2 = Fq(uint256_t(z2));
+    Fq base_p_x = Fq(uint256_t(ultra_op.x_lo) + (uint256_t(ultra_op.x_hi) << (NUM_LIMB_BITS << 1)));
+    Fq base_p_y = Fq(uint256_t(ultra_op.y_lo) + (uint256_t(ultra_op.y_hi) << (NUM_LIMB_BITS << 1)));
+    Fq base_z_1 = Fq(uint256_t(ultra_op.z_1));
+    Fq base_z_2 = Fq(uint256_t(ultra_op.z_2));
 
     // Construct bigfield representations of P.x and P.y
-    auto [p_x_0, p_x_1] = split_wide_limb_into_2_limbs(p_x_lo);
-    auto [p_x_2, p_x_3] = split_wide_limb_into_2_limbs(p_x_hi);
+    auto [p_x_0, p_x_1] = split_wide_limb_into_2_limbs(ultra_op.x_lo);
+    auto [p_x_2, p_x_3] = split_wide_limb_into_2_limbs(ultra_op.x_hi);
     std::array<Fr, NUM_BINARY_LIMBS> p_x_limbs = { p_x_0, p_x_1, p_x_2, p_x_3 };
-    auto [p_y_0, p_y_1] = split_wide_limb_into_2_limbs(p_y_lo);
-    auto [p_y_2, p_y_3] = split_wide_limb_into_2_limbs(p_y_hi);
+    auto [p_y_0, p_y_1] = split_wide_limb_into_2_limbs(ultra_op.y_lo);
+    auto [p_y_2, p_y_3] = split_wide_limb_into_2_limbs(ultra_op.y_hi);
     std::array<Fr, NUM_BINARY_LIMBS> p_y_limbs = { p_y_0, p_y_1, p_y_2, p_y_3 };
 
-    // Construct bigfield representations of z1 and z2 only using 2 limbs each
-    auto z_1_limbs = split_wide_limb_into_2_limbs(z1);
-    auto z_2_limbs = split_wide_limb_into_2_limbs(z2);
+    // Construct bigfield representations of ultra_op.z_1 and ultra_op.z_2 only using 2 limbs each
+    auto z_1_limbs = split_wide_limb_into_2_limbs(ultra_op.z_1);
+    auto z_2_limbs = split_wide_limb_into_2_limbs(ultra_op.z_2);
 
     // The formula is `accumulator = accumulator⋅x + (op + v⋅p.x + v²⋅p.y + v³⋅z₁ + v⁴z₂)`. We need to compute the
     // remainder (new accumulator value)
@@ -311,19 +300,13 @@ TranslatorCircuitBuilder::AccumulationInput TranslatorCircuitBuilder::generate_w
 
     // Start filling the witness container
     AccumulationInput input{
-        .op_code = op_code,
-        .P_x_lo = p_x_lo,
-        .P_x_hi = p_x_hi,
+        .ultra_op = ultra_op,
         .P_x_limbs = p_x_limbs,
         .P_x_microlimbs = P_x_microlimbs,
-        .P_y_lo = p_y_lo,
-        .P_y_hi = p_y_hi,
         .P_y_limbs = p_y_limbs,
         .P_y_microlimbs = P_y_microlimbs,
-        .z_1 = z1,
         .z_1_limbs = z_1_limbs,
         .z_1_microlimbs = z_1_microlimbs,
-        .z_2 = z2,
         .z_2_limbs = z_2_limbs,
         .z_2_microlimbs = z_2_microlimbs,
         .previous_accumulator = previous_accumulator_limbs,
@@ -334,44 +317,43 @@ TranslatorCircuitBuilder::AccumulationInput TranslatorCircuitBuilder::generate_w
         .relation_wide_limbs = { low_wide_relation_limb_divided, high_wide_relation_limb_divided },
         .relation_wide_microlimbs = { split_relation_limb_into_micro_limbs(low_wide_relation_limb_divided),
                                       split_relation_limb_into_micro_limbs(high_wide_relation_limb_divided) },
-        .x_limbs = x_witnesses,
-        .v_limbs = v_witnesses,
-        .v_squared_limbs = v_squared_witnesses,
-        .v_cubed_limbs = v_cubed_witnesses,
-        .v_quarted_limbs = v_quarted_witnesses,
 
     };
 
     return input;
 }
 
+void TranslatorCircuitBuilder::assert_well_formed_ultra_op(const UltraOp& ultra_op)
+{
+    // Opcode should be {0,3,4,8}
+    size_t op_code = ultra_op.op_code.value();
+    ASSERT(op_code == 0 || op_code == 3 || op_code == 4 || op_code == 8);
+
+    // Check and insert x_lo and y_hi into wire 1
+    ASSERT(uint256_t(ultra_op.x_lo) <= MAX_LOW_WIDE_LIMB_SIZE);
+    ASSERT(uint256_t(ultra_op.y_hi) <= MAX_HIGH_WIDE_LIMB_SIZE);
+
+    // Check and insert x_hi and z_1 into wire 2
+    ASSERT(uint256_t(ultra_op.x_hi) <= MAX_HIGH_WIDE_LIMB_SIZE);
+    ASSERT(uint256_t(ultra_op.z_1) <= MAX_LOW_WIDE_LIMB_SIZE);
+
+    // Check and insert y_lo and z_2 into wire 3
+    ASSERT(uint256_t(ultra_op.y_lo) <= MAX_LOW_WIDE_LIMB_SIZE);
+    ASSERT(uint256_t(ultra_op.z_2) <= MAX_LOW_WIDE_LIMB_SIZE);
+}
+
 void TranslatorCircuitBuilder::assert_well_formed_accumulation_input(const AccumulationInput& acc_step)
 {
     // The first wires OpQueue/Transcript wires
-    // Opcode should be {0,1,2,3,4,8}
-    ASSERT(acc_step.op_code == 0 || acc_step.op_code == 1 || acc_step.op_code == 2 || acc_step.op_code == 3 ||
-           acc_step.op_code == 4 || acc_step.op_code == 8);
-
-    // Check and insert P_x_lo and P_y_hi into wire 1
-    ASSERT(uint256_t(acc_step.P_x_lo) <= MAX_LOW_WIDE_LIMB_SIZE);
-    ASSERT(uint256_t(acc_step.P_y_hi) <= MAX_HIGH_WIDE_LIMB_SIZE);
-
-    // Check and insert P_x_hi and z_1 into wire 2
-    ASSERT(uint256_t(acc_step.P_x_hi) <= MAX_HIGH_WIDE_LIMB_SIZE);
-    ASSERT(uint256_t(acc_step.z_1) <= MAX_LOW_WIDE_LIMB_SIZE);
-
-    // Check and insert P_y_lo and z_2 into wire 3
-    ASSERT(uint256_t(acc_step.P_y_lo) <= MAX_LOW_WIDE_LIMB_SIZE);
-    ASSERT(uint256_t(acc_step.z_2) <= MAX_LOW_WIDE_LIMB_SIZE);
+    assert_well_formed_ultra_op(acc_step.ultra_op);
 
     // Check decomposition of values from the Queue into limbs used in bigfield evaluations
-    ASSERT(acc_step.P_x_lo == (acc_step.P_x_limbs[0] + acc_step.P_x_limbs[1] * SHIFT_1));
-    ASSERT(acc_step.P_x_hi == (acc_step.P_x_limbs[2] + acc_step.P_x_limbs[3] * SHIFT_1));
-    ASSERT(acc_step.P_y_lo == (acc_step.P_y_limbs[0] + acc_step.P_y_limbs[1] * SHIFT_1));
-    ASSERT(acc_step.P_y_hi == (acc_step.P_y_limbs[2] + acc_step.P_y_limbs[3] * SHIFT_1));
-    ASSERT(acc_step.z_1 == (acc_step.z_1_limbs[0] + acc_step.z_1_limbs[1] * SHIFT_1));
-    ASSERT(acc_step.z_2 == (acc_step.z_2_limbs[0] + acc_step.z_2_limbs[1] * SHIFT_1));
-
+    ASSERT(acc_step.ultra_op.x_lo == (acc_step.P_x_limbs[0] + acc_step.P_x_limbs[1] * SHIFT_1));
+    ASSERT(acc_step.ultra_op.x_hi == (acc_step.P_x_limbs[2] + acc_step.P_x_limbs[3] * SHIFT_1));
+    ASSERT(acc_step.ultra_op.y_lo == (acc_step.P_y_limbs[0] + acc_step.P_y_limbs[1] * SHIFT_1));
+    ASSERT(acc_step.ultra_op.y_hi == (acc_step.P_y_limbs[2] + acc_step.P_y_limbs[3] * SHIFT_1));
+    ASSERT(acc_step.ultra_op.z_1 == (acc_step.z_1_limbs[0] + acc_step.z_1_limbs[1] * SHIFT_1));
+    ASSERT(acc_step.ultra_op.z_2 == (acc_step.z_2_limbs[0] + acc_step.z_2_limbs[1] * SHIFT_1));
     /**
      * @brief Check correctness of limbs values
      *
@@ -416,6 +398,21 @@ void TranslatorCircuitBuilder::assert_well_formed_accumulation_input(const Accum
     ASSERT(uint256_t(acc_step.relation_wide_limbs[0]) < MAX_RELATION_WIDE_LIMB_SIZE);
     ASSERT(uint256_t(acc_step.relation_wide_limbs[1]) < MAX_RELATION_WIDE_LIMB_SIZE);
 }
+
+void TranslatorCircuitBuilder::populate_wires_from_ultra_op(const UltraOp& ultra_op)
+{
+    auto& op_wire = std::get<WireIds::OP>(wires);
+    op_wire.push_back(add_variable(ultra_op.op_code.value()));
+    // Similarly to the ColumnPolynomials in the merge protocol, the op_wire is 0 at every second index
+    op_wire.push_back(zero_idx);
+
+    insert_pair_into_wire(WireIds::X_LOW_Y_HI, ultra_op.x_lo, ultra_op.y_hi);
+
+    insert_pair_into_wire(WireIds::X_HIGH_Z_1, ultra_op.x_hi, ultra_op.z_1);
+
+    insert_pair_into_wire(WireIds::Y_LOW_Z_2, ultra_op.y_lo, ultra_op.z_2);
+}
+
 /**
  * @brief Create a single accumulation gate
  *
@@ -425,26 +422,7 @@ void TranslatorCircuitBuilder::create_accumulation_gate(const AccumulationInput&
 {
     assert_well_formed_accumulation_input(acc_step);
 
-    auto& op_wire = std::get<WireIds::OP>(wires);
-    op_wire.push_back(add_variable(acc_step.op_code));
-    // Every second op value in the transcript (indices 3, 5, etc) are not defined so let's just put zero there
-    op_wire.push_back(zero_idx);
-
-    /**
-     * @brief Insert two values into the same wire sequentially
-     *
-     */
-    auto insert_pair_into_wire = [this](WireIds wire_index, Fr first, Fr second) {
-        auto& current_wire = wires[wire_index];
-        current_wire.push_back(add_variable(first));
-        current_wire.push_back(add_variable(second));
-    };
-
-    insert_pair_into_wire(WireIds::X_LOW_Y_HI, acc_step.P_x_lo, acc_step.P_y_hi);
-
-    insert_pair_into_wire(WireIds::X_HIGH_Z_1, acc_step.P_x_hi, acc_step.z_1);
-
-    insert_pair_into_wire(WireIds::Y_LOW_Z_2, acc_step.P_y_lo, acc_step.z_2);
+    populate_wires_from_ultra_op(acc_step.ultra_op);
 
     // Insert limbs used in bigfield evaluations
     insert_pair_into_wire(P_X_LOW_LIMBS, acc_step.P_x_limbs[0], acc_step.P_x_limbs[1]);
@@ -569,16 +547,8 @@ void TranslatorCircuitBuilder::feed_ecc_op_queue_into_circuit(const std::shared_
             accumulator_trace.pop_back();
         }
         // Compute witness values
-        AccumulationInput one_accumulation_step = generate_witness_values(ultra_op.op_code.value(),
-                                                                          ultra_op.x_lo,
-                                                                          ultra_op.x_hi,
-                                                                          ultra_op.y_lo,
-                                                                          ultra_op.y_hi,
-                                                                          ultra_op.z_1,
-                                                                          ultra_op.z_2,
-                                                                          previous_accumulator,
-                                                                          batching_challenge_v,
-                                                                          evaluation_input_x);
+        AccumulationInput one_accumulation_step =
+            generate_witness_values(ultra_op, previous_accumulator, batching_challenge_v, evaluation_input_x);
 
         // And put them into the wires
         create_accumulation_gate(one_accumulation_step);

--- a/barretenberg/cpp/src/barretenberg/translator_vm/translator_circuit_builder.hpp
+++ b/barretenberg/cpp/src/barretenberg/translator_vm/translator_circuit_builder.hpp
@@ -277,6 +277,7 @@ class TranslatorCircuitBuilder : public CircuitBuilderBase<bb::fr> {
         Fr(NEGATIVE_PRIME_MODULUS.slice(NUM_LIMB_BITS * 3, NUM_LIMB_BITS * 4).lo),
         -Fr(Fq::modulus)
     };
+
     /**
      * @brief The accumulation input structure contains all the necessary values to initalize an accumulation gate as
      * well as additional values for checking its correctness
@@ -287,20 +288,14 @@ class TranslatorCircuitBuilder : public CircuitBuilderBase<bb::fr> {
      */
     struct AccumulationInput {
         // Members necessary for the gate creation
-        Fr op_code; // Operator
-        Fr P_x_lo;
-        Fr P_x_hi;
+        UltraOp ultra_op;
         std::array<Fr, NUM_BINARY_LIMBS> P_x_limbs;
         std::array<std::array<Fr, NUM_MICRO_LIMBS>, NUM_BINARY_LIMBS> P_x_microlimbs;
-        Fr P_y_lo;
-        Fr P_y_hi;
         std::array<Fr, NUM_BINARY_LIMBS> P_y_limbs;
         std::array<std::array<Fr, NUM_MICRO_LIMBS>, NUM_BINARY_LIMBS> P_y_microlimbs;
 
-        Fr z_1;
         std::array<Fr, NUM_Z_LIMBS> z_1_limbs;
         std::array<std::array<Fr, NUM_MICRO_LIMBS>, NUM_Z_LIMBS> z_1_microlimbs;
-        Fr z_2;
         std::array<Fr, NUM_Z_LIMBS> z_2_limbs;
         std::array<std::array<Fr, NUM_MICRO_LIMBS>, NUM_Z_LIMBS> z_2_microlimbs;
 
@@ -311,13 +306,6 @@ class TranslatorCircuitBuilder : public CircuitBuilderBase<bb::fr> {
         std::array<std::array<Fr, NUM_MICRO_LIMBS>, NUM_BINARY_LIMBS> quotient_microlimbs;
         std::array<Fr, NUM_RELATION_WIDE_LIMBS> relation_wide_limbs;
         std::array<std::array<Fr, NUM_MICRO_LIMBS>, 2> relation_wide_microlimbs;
-
-        // Additional
-        std::array<Fr, NUM_BINARY_LIMBS> x_limbs;
-        std::array<Fr, NUM_BINARY_LIMBS> v_limbs;
-        std::array<Fr, NUM_BINARY_LIMBS> v_squared_limbs = { 0 };
-        std::array<Fr, NUM_BINARY_LIMBS> v_cubed_limbs = { 0 };
-        std::array<Fr, NUM_BINARY_LIMBS> v_quarted_limbs = { 0 };
     };
 
     static constexpr std::string_view NAME_STRING = "TranslatorCircuitBuilder";
@@ -397,6 +385,8 @@ class TranslatorCircuitBuilder : public CircuitBuilderBase<bb::fr> {
         });
     }
 
+    static void assert_well_formed_ultra_op(const UltraOp& ultra_op);
+
     /**
      * @brief Ensures the accumulation input is well-formed and can be used to create a gate.
      * @details There are two main types of checks: that members of the AccumulationInput are within the appropriate
@@ -417,6 +407,15 @@ class TranslatorCircuitBuilder : public CircuitBuilderBase<bb::fr> {
      */
     void create_accumulation_gate(const AccumulationInput& acc_step);
 
+    void populate_wires_from_ultra_op(const UltraOp& ultra_op);
+
+    void insert_pair_into_wire(WireIds wire_index, Fr first, Fr second)
+    {
+        auto& current_wire = wires[wire_index];
+        current_wire.push_back(add_variable(first));
+        current_wire.push_back(add_variable(second));
+    }
+
     /**
      * @brief Generate all the gates required to prove the correctness of batched evalution of polynomials representing
      * commitments to ECCOpQueue
@@ -425,13 +424,7 @@ class TranslatorCircuitBuilder : public CircuitBuilderBase<bb::fr> {
      */
     void feed_ecc_op_queue_into_circuit(const std::shared_ptr<ECCOpQueue> ecc_op_queue);
 
-    static AccumulationInput generate_witness_values(const Fr& op_code,
-                                                     const Fr& p_x_lo,
-                                                     const Fr& p_x_hi,
-                                                     const Fr& p_y_lo,
-                                                     const Fr& p_y_hi,
-                                                     const Fr& z1,
-                                                     const Fr& z2,
+    static AccumulationInput generate_witness_values(const UltraOp& ultra_op,
                                                      const Fq& previous_accumulator,
                                                      const Fq& batching_challenge_v,
                                                      const Fq& evaluation_input_x);


### PR DESCRIPTION
This PR attempts to improve clarity in the circuit builder and reduce the size of existing methods by separating the logic that checks  ultra ops and the logic that  populates corresponding wire data using the ultra op from other  builder logic. This will additionally help code shareability in upcoming modifications. I also fixed the `TranslatorOpcodeConstraintRelation` as it was accepting some opcodes that are not supported