### PR TITLE
fix: prevent race condition when requesting txs

### DIFF
--- a/yarn-project/p2p/src/client/interface.ts
+++ b/yarn-project/p2p/src/client/interface.ts
@@ -140,6 +140,18 @@ export type P2P<T extends P2PClientType = P2PClientType.Full> = P2PApi<T> & {
   getPendingTxCount(): Promise<number>;
 
   /**
+   * Marks transactions as non-evictible in the pool.
+   * @param txHashes - Hashes of the transactions to mark as non-evictible.
+   */
+  markTxsAsNonEvictable(txHashes: TxHash[]): Promise<void>;
+
+  /**
+   * Marks transactions as evictible in the pool.
+   * @param txHashes - Hashes of the transactions to mark as evictible.
+   */
+  markTxsAsEvictable(txHashes: TxHash[]): Promise<void>;
+
+  /**
    * Starts the p2p client.
    * @returns A promise signalling the completion of the block sync.
    */

--- a/yarn-project/p2p/src/mem_pools/tx_pool/aztec_kv_tx_pool.ts
+++ b/yarn-project/p2p/src/mem_pools/tx_pool/aztec_kv_tx_pool.ts
@@ -322,6 +322,7 @@ export class AztecKVTxPool implements TxPool {
       let pendingTxSize = (await this.#pendingTxSize.getAsync()) ?? 0;
       for (const hash of txHashes) {
         const key = hash.toString();
+        this.#nonEvictableTxs.delete(key);
         const tx = await this.getTxByHash(hash);
 
         if (tx) {

--- a/yarn-project/p2p/src/mem_pools/tx_pool/memory_tx_pool.ts
+++ b/yarn-project/p2p/src/mem_pools/tx_pool/memory_tx_pool.ts
@@ -186,4 +186,12 @@ export class InMemoryTxPool implements TxPool {
   setMaxTxPoolSize(_maxSizeBytes: number | undefined): Promise<void> {
     return Promise.resolve();
   }
+
+  markTxsAsNonEvictable(_txHashes: TxHash[]): Promise<void> {
+    return Promise.resolve();
+  }
+
+  markTxsAsEvictable(_txHashes: TxHash[]): Promise<void> {
+    return Promise.resolve();
+  }
 }

--- a/yarn-project/p2p/src/mem_pools/tx_pool/tx_pool.ts
+++ b/yarn-project/p2p/src/mem_pools/tx_pool/tx_pool.ts
@@ -94,6 +94,18 @@ export interface TxPool {
    */
   setMaxTxPoolSize(maxSizeBytes: number | undefined): Promise<void>;
 
+  /**
+   * Marks transactions as non-evictible in the pool.
+   * @param txHashes - Hashes of the transactions to mark as non-evictible.
+   */
+  markTxsAsNonEvictable(txHashes: TxHash[]): Promise<void>;
+
+  /**
+   * Marks transactions as evictible in the pool.
+   * @param txHashes - Hashes of the transactions to mark as evictible.
+   */
+  markTxsAsEvictable(txHashes: TxHash[]): Promise<void>;
+
   /** Returns whether the pool is empty. */
   isEmpty(): Promise<boolean>;
 }

--- a/yarn-project/validator-client/src/validator.ts
+++ b/yarn-project/validator-client/src/validator.ts
@@ -332,6 +332,7 @@ export class ValidatorClient extends WithTracer implements Validator {
       this.log.verbose(`Received block proposal with no transactions, skipping transaction availability check`);
       return [];
     }
+    this.p2pClient.markTxsAsNonEvictable(proposal.payload.txHashes);
     // Is this a new style proposal?
     if (proposal.txs && proposal.txs.length > 0 && proposal.txs.length === proposal.payload.txHashes.length) {
       // Yes, any txs that we already have we should use
@@ -378,6 +379,7 @@ export class ValidatorClient extends WithTracer implements Validator {
         );
 
         await this.p2pClient.validate(txsToUse as Tx[]);
+        this.p2pClient.markTxsAsEvictable(hashesFromPayload);
         return txsToUse as Tx[];
       }
     }
@@ -387,7 +389,6 @@ export class ValidatorClient extends WithTracer implements Validator {
     // Old style proposal, we will perform a request by hash from pool
     // This will request from network any txs that are missing
     const txHashes: TxHash[] = proposal.payload.txHashes;
-    this.p2pClient.markTxsAsNonEvictable(txHashes);
 
     // This part is just for logging that we are requesting from the network
     const availability = await this.p2pClient.hasTxsInPool(txHashes);


### PR DESCRIPTION
fixes https://github.com/AztecProtocol/aztec-packages/issues/13883

The validator client, when asked to attest to a proposal, first checks that all txs are available on the tx pool and then loads them as needed. However, between these two calls, the p2p mempool (if full) may have chosen to evict some of these txs, meaning the validator will not have the txs it needs. This race condition may also happen during any process that loops requesting txs (e.g. prover coordination).

This PR adds a way to instruct the p2p mempool to not evict txs that are going to be needed soon and calls it right before any process that starts collecting txs (re-execution or proving). After the request is done, the txs are marked as evictable again.
