### PR TITLE
fix: no validation on eth_simulateV1

### DIFF
--- a/yarn-project/ethereum/src/l1_tx_utils.ts
+++ b/yarn-project/ethereum/src/l1_tx_utils.ts
@@ -733,7 +733,7 @@ export class L1TxUtils {
 
     try {
       const result = await this.publicClient.simulate({
-        validation: true,
+        validation: false,
         blocks: [
           {
             blockOverrides,


### PR DESCRIPTION
don't perform validation on `eth_simulateV1` bc it requires the account to have enough ETH for the simulation (which uses 12m gas). 