### PR TITLE
chore: updated sepolia account funding actions

### DIFF
--- a/.github/workflows/fund-sepolia-accounts.yml
+++ b/.github/workflows/fund-sepolia-accounts.yml
@@ -1,0 +1,80 @@
+name: Fund Sepolia Accounts
+
+on:
+  workflow_call:
+    inputs:
+      values_file:
+        description: The values file to use, e.g. 1-validators.yaml
+        required: true
+        type: string
+      sepolia_accounts_mnemonic_secret_name:
+        description: The name of the secret which holds the sepolia accounts mnemonic. Will create a new one if it doesn't exist.
+        required: true
+        type: string
+        default: sepolia-accounts-mnemonic
+
+jobs:
+  fund-sepolia-accounts:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+        with:
+          ref: ${{ github.ref }}
+
+      - name: Authenticate to Google Cloud
+        uses: google-github-actions/auth@v2
+        with:
+          credentials_json: ${{ secrets.GCP_SA_KEY }}
+
+      - name: Set up Cloud SDK
+        uses: google-github-actions/setup-gcloud@v2
+
+      - name: Install cast
+        run: |
+          if ! command -v cast &>/dev/null; then
+            echo "Installing cast..."
+            curl -L https://foundry.paradigm.xyz | bash
+            $HOME/.foundry/bin/foundryup
+          fi
+
+      - name: Get mnemonic
+        id: get-mnemonic
+        run: |
+          if gcloud secrets describe ${{ inputs.sepolia_accounts_mnemonic_secret_name }} >/dev/null 2>&1; then
+            echo "::add-mask::$(gcloud secrets versions access latest --secret=${{ inputs.sepolia_accounts_mnemonic_secret_name }})"
+            echo "mnemonic=$(gcloud secrets versions access latest --secret=${{ inputs.sepolia_accounts_mnemonic_secret_name }})" >> "$GITHUB_OUTPUT"
+            echo "new_mnemonic=false" >> "$GITHUB_OUTPUT"
+          else
+            echo "new_mnemonic=true" >> "$GITHUB_OUTPUT"
+          fi
+
+      - name: Fund accounts
+        id: fund-accounts
+        run: |
+          # Check if we need a new mnemonic
+          if [[ "${{ steps.get-mnemonic.outputs.new_mnemonic }}" == "true" ]]; then
+            echo "Generating new mnemonic"
+          else
+            MNEMONIC="${{ steps.get-mnemonic.outputs.mnemonic }}"
+            echo "Using mnemonic from GCP"
+          fi
+
+          REPO=$(git rev-parse --show-toplevel)
+          MNEMONIC_FILE=$(mktemp)
+          export FUNDING_PRIVATE_KEY=${{ secrets.SEPOLIA_FUNDING_PRIVATE_KEY }}
+          export ETHEREUM_HOST="https://json-rpc.${{ secrets.GCP_SEPOLIA_URL }}?key=${{ secrets.GCP_SEPOLIA_API_KEY }}"
+
+          echo "Funding accounts..."
+          $REPO/spartan/scripts/fund_sepolia_accounts.sh ${{ inputs.values_file }} "$MNEMONIC_FILE"
+          mnemonic=$(cat "$MNEMONIC_FILE")
+          rm "$MNEMONIC_FILE"
+          echo "::add-mask::$mnemonic"
+          echo "mnemonic=$mnemonic" >> "$GITHUB_OUTPUT"
+
+      - name: Save mnemonic to GCP
+        if: ${{ steps.get-mnemonic.outputs.new_mnemonic == 'true' }}
+        run: |
+          echo "Saving mnemonic to GCP"
+          echo "::add-mask::${{ steps.get-mnemonic.outputs.mnemonic }}"
+          gcloud secrets versions add latest --secret=${{ inputs.sepolia_accounts_mnemonic_secret_name }} --data-file="$MNEMONIC_FILE"

--- a/.github/workflows/network-deploy.yml
+++ b/.github/workflows/network-deploy.yml
@@ -59,6 +59,11 @@ on:
         required: false
         type: string
         default: "false"
+      sepolia_accounts_mnemonic_secret_name:
+        description: The name of the secret which holds the sepolia accounts mnemonic
+        required: false
+        type: string
+        default: sepolia-accounts-mnemonic
     secrets:
       GCP_SA_KEY:
         required: true
@@ -105,6 +110,11 @@ on:
         required: false
         type: string
         default: "false"
+      sepolia_accounts_mnemonic_secret_name:
+        description: The name of the secret which holds the sepolia accounts mnemonic
+        required: false
+        type: string
+        default: sepolia-accounts-mnemonic
 
 jobs:
   network_deployment:
@@ -182,6 +192,13 @@ jobs:
 
           $REPO/spartan/scripts/generate_devnet_config.sh ${{ env.VALUES_FILE }}
 
+      - name: Fund sepolia accounts
+        uses: ./.github/workflows/fund-sepolia-accounts.yml
+        if: ${{ inputs.sepolia_deployment == 'true' }}
+        with:
+          values_file: ${{ env.VALUES_FILE }}
+          sepolia_accounts_mnemonic_secret_name: ${{ inputs.sepolia_accounts_mnemonic_secret_name }}
+
       - name: Generate sepolia accounts
         id: generate-sepolia-accounts
         if: ${{ inputs.sepolia_deployment == 'true' }}
@@ -216,7 +233,7 @@ jobs:
         continue-on-error: true
         run: |
           if ${{ inputs.sepolia_deployment == 'true' }}; then
-            export L1_DEPLOYMENT_MNEMONIC="${{ steps.generate-sepolia-accounts.outputs.mnemonic }}"
+            L1_DEPLOYMENT_MNEMONIC=$(gcloud secrets versions access latest --secret=${{ inputs.sepolia_accounts_mnemonic_secret_name }})
             terraform destroy -auto-approve \
               -var="RELEASE_NAME=${{ env.NAMESPACE }}" \
               -var="VALUES_FILE=${{ env.VALUES_FILE }}" \
@@ -247,7 +264,7 @@ jobs:
         working-directory: ./spartan/terraform/deploy-release
         run: |
           if ${{ inputs.sepolia_deployment == 'true' }}; then
-            export L1_DEPLOYMENT_MNEMONIC="${{ steps.generate-sepolia-accounts.outputs.mnemonic }}"
+            L1_DEPLOYMENT_MNEMONIC=$(gcloud secrets versions access latest --secret=${{ inputs.sepolia_accounts_mnemonic_secret_name }})
             terraform plan \
               -var="RELEASE_NAME=${{ env.NAMESPACE }}" \
               -var="VALUES_FILE=${{ env.VALUES_FILE }}" \

--- a/spartan/scripts/prepare_sepolia_accounts.sh
+++ b/spartan/scripts/prepare_sepolia_accounts.sh
@@ -90,13 +90,18 @@ max_index=$((max_index > bot_max_index ? max_index : bot_max_index))
 # Total number of accounts needed
 total_accounts=$((num_validators + num_provers + num_bots))
 
-# Create a new mnemonic
-echo "Creating mnemonic..."
-cast wallet new-mnemonic --json >"$tmp_filename"
-MNEMONIC=$(jq -r '.mnemonic' "$tmp_filename")
+# Check if mnemonic is provided
+if [ -z "$MNEMONIC" ]; then
+  # Create a new mnemonic
+  echo "Creating mnemonic..."
+  cast wallet new-mnemonic --json >"$tmp_filename"
+  MNEMONIC=$(jq -r '.mnemonic' "$tmp_filename")
 
-echo "MNEMONIC:"
-echo "::add-mask::$MNEMONIC"
+  echo "MNEMONIC:"
+  echo "::add-mask::$MNEMONIC"
+else
+  echo "Using provided mnemonic"
+fi
 
 # Cast has a limit of 255 accounts per mnemonic command
 # We'll need to derive accounts in batches


### PR DESCRIPTION
- new action specifically to fund accounts on sepolia, derived from a mnemonic + values file with mnemonic indices
  - can be used with an existing mnemonic, or will generate a new one if GCP secret doesn't exist
- network-deploy now uses that action so can also be used with an existing mnemonic or will create a new one with chosen name 

Fixes #14113 