### PR TITLE
feat!: swap copyOffset and dataOffset operands

### DIFF
--- a/avm-transpiler/src/transpile.rs
+++ b/avm-transpiler/src/transpile.rs
@@ -252,16 +252,16 @@ pub fn brillig_to_avm(brillig_bytecode: &[BrilligOpcode<FieldElement>]) -> (Vec<
                     opcode: AvmOpcode::CALLDATACOPY,
                     indirect: Some(
                         AddressingModeBuilder::default()
-                            .direct_operand(offset_address)
                             .direct_operand(size_address)
+                            .direct_operand(offset_address)
                             .direct_operand(destination_address)
                             .build(),
                     ),
                     operands: vec![
+                        AvmOperand::U16 { value: size_address.to_usize() as u16 }, // sizeOffset
                         AvmOperand::U16 {
                             value: offset_address.to_usize() as u16, // cdOffset (calldata offset)
                         },
-                        AvmOperand::U16 { value: size_address.to_usize() as u16 }, // sizeOffset
                         AvmOperand::U16 {
                             value: destination_address.to_usize() as u16, // dstOffset
                         },
@@ -631,16 +631,16 @@ fn handle_external_call(
                 .direct_operand(l2_gas_offset)
                 .direct_operand(da_gas_offset)
                 .direct_operand(address_offset)
-                .indirect_operand(args_offset_ptr)
                 .direct_operand(args_size_offset)
+                .indirect_operand(args_offset_ptr)
                 .build(),
         ),
         operands: vec![
             AvmOperand::U16 { value: l2_gas_offset.to_usize() as u16 },
             AvmOperand::U16 { value: da_gas_offset.to_usize() as u16 },
             AvmOperand::U16 { value: address_offset.to_usize() as u16 },
-            AvmOperand::U16 { value: args_offset_ptr.to_usize() as u16 },
             AvmOperand::U16 { value: args_size_offset.to_usize() as u16 },
+            AvmOperand::U16 { value: args_offset_ptr.to_usize() as u16 },
         ],
         ..Default::default()
     });
@@ -1402,14 +1402,14 @@ fn handle_calldata_copy(
         opcode: AvmOpcode::CALLDATACOPY,
         indirect: Some(
             AddressingModeBuilder::default()
-                .direct_operand(&cd_offset)
                 .direct_operand(&copy_size_offset)
+                .direct_operand(&cd_offset)
                 .indirect_operand(&dest_offset)
                 .build(),
         ),
         operands: vec![
-            AvmOperand::U16 { value: cd_offset.to_usize() as u16 },
             AvmOperand::U16 { value: copy_size_offset.to_usize() as u16 },
+            AvmOperand::U16 { value: cd_offset.to_usize() as u16 },
             AvmOperand::U16 { value: dest_offset.to_usize() as u16 },
         ],
         ..Default::default()
@@ -1471,14 +1471,14 @@ fn handle_returndata_copy(
             opcode: AvmOpcode::RETURNDATACOPY,
             indirect: Some(
                 AddressingModeBuilder::default()
-                    .direct_operand(&cd_offset)
                     .direct_operand(&copy_size_offset)
+                    .direct_operand(&cd_offset)
                     .indirect_operand(&dest_offset)
                     .build(),
             ),
             operands: vec![
-                AvmOperand::U16 { value: cd_offset.to_usize() as u16 },
                 AvmOperand::U16 { value: copy_size_offset.to_usize() as u16 },
+                AvmOperand::U16 { value: cd_offset.to_usize() as u16 },
                 AvmOperand::U16 { value: dest_offset.to_usize() as u16 },
             ],
             ..Default::default()

--- a/yarn-project/simulator/src/public/avm/avm_gas.test.ts
+++ b/yarn-project/simulator/src/public/avm/avm_gas.test.ts
@@ -11,9 +11,9 @@ describe.skip('AVM simulator: dynamic gas costs per instruction', () => {
     // BASE_GAS(10) * 1 + MEMORY_WRITE(100) = 110
     [new SetInstruction(/*indirect=*/ 0, /*dstOffset=*/ 0, /*inTag=*/ TypeTag.UINT32, /*value=*/ 1), [110]],
     // BASE_GAS(10) * 1 + MEMORY_WRITE(100) = 110
-    [new CalldataCopy(/*indirect=*/ 0, /*cdOffset=*/ TypeTag.UINT8, /*copySize=*/ 1, /*dstOffset=*/ 0), [110]],
+    [new CalldataCopy(/*indirect=*/ 0, /*copySize=*/ 1, /*cdOffset=*/ TypeTag.UINT8, /*dstOffset=*/ 0), [110]],
     // BASE_GAS(10) * 5 + MEMORY_WRITE(100) * 5 = 550
-    [new CalldataCopy(/*indirect=*/ 0, /*cdOffset=*/ TypeTag.UINT8, /*copySize=*/ 5, /*dstOffset=*/ 0), [510]],
+    [new CalldataCopy(/*indirect=*/ 0, /*copySize=*/ 5, /*cdOffset=*/ TypeTag.UINT8, /*dstOffset=*/ 0), [510]],
     // BASE_GAS(10) * 1 + MEMORY_READ(10) * 2 + MEMORY_WRITE(100) = 130
     [new Add(/*indirect=*/ 0, /*aOffset=*/ 1, /*bOffset=*/ 2, /*dstOffset=*/ 3), [130]],
     // BASE_GAS(10) * 4 + MEMORY_READ(10) * 2 + MEMORY_WRITE(100) = 160

--- a/yarn-project/simulator/src/public/avm/avm_simulator.test.ts
+++ b/yarn-project/simulator/src/public/avm/avm_simulator.test.ts
@@ -100,7 +100,7 @@ describe('AVM simulator: injected bytecode', () => {
     bytecode = encodeToBytecode([
       new Set(/*indirect*/ 0, /*dstOffset*/ 0, TypeTag.UINT32, /*value*/ 0).as(Opcode.SET_8, Set.wireFormat8),
       new Set(/*indirect*/ 0, /*dstOffset*/ 1, TypeTag.UINT32, /*value*/ 2).as(Opcode.SET_8, Set.wireFormat8),
-      new CalldataCopy(/*indirect=*/ 0, /*cdOffset=*/ 0, /*copySize=*/ 1, /*dstOffset=*/ 0),
+      new CalldataCopy(/*indirect=*/ 0, /*copySize=*/ 1, /*cdOffset=*/ 0, /*dstOffset=*/ 0),
       new Add(/*indirect=*/ 0, /*aOffset=*/ 0, /*bOffset=*/ 1, /*dstOffset=*/ 2).as(Opcode.ADD_8, Add.wireFormat8),
       new Set(/*indirect*/ 0, /*dstOffset*/ 0, TypeTag.UINT32, /*value*/ 1).as(Opcode.SET_8, Set.wireFormat8),
       new Return(/*indirect=*/ 0, /*copySizeOffset=*/ 0, /*returnOffset=*/ 2),

--- a/yarn-project/simulator/src/public/avm/opcodes/external_calls.test.ts
+++ b/yarn-project/simulator/src/public/avm/opcodes/external_calls.test.ts
@@ -49,16 +49,16 @@ describe('External Calls', () => {
         ...Buffer.from('1234', 'hex'), // l2GasOffset
         ...Buffer.from('5678', 'hex'), // daGasOffset
         ...Buffer.from('a234', 'hex'), // addrOffset
-        ...Buffer.from('b234', 'hex'), // argsOffset
         ...Buffer.from('c234', 'hex'), // argsSizeOffset
+        ...Buffer.from('b234', 'hex'), // argsOffset
       ]);
       const inst = new Call(
         /*indirect=*/ 0x1234,
         /*l2GasOffset=*/ 0x1234,
         /*daGasOffset=*/ 0x5678,
         /*addrOffset=*/ 0xa234,
-        /*argsOffset=*/ 0xb234,
         /*argsSizeOffset=*/ 0xc234,
+        /*argsOffset=*/ 0xb234,
       );
 
       expect(Call.fromBuffer(buf)).toEqual(inst);
@@ -87,7 +87,7 @@ describe('External Calls', () => {
       context.machineState.memory.set(argsSizeOffset, new Uint32(argsSize));
       context.machineState.memory.setSlice(3, args);
 
-      const instruction = new Call(/*indirect=*/ 0, l2GasOffset, daGasOffset, addrOffset, argsOffset, argsSizeOffset);
+      const instruction = new Call(/*indirect=*/ 0, l2GasOffset, daGasOffset, addrOffset, argsSizeOffset, argsOffset);
       await instruction.execute(context);
 
       // Use SuccessCopy to get success
@@ -124,7 +124,7 @@ describe('External Calls', () => {
         new Set(/*indirect=*/ 0, /*dstOffset=*/ 0, TypeTag.UINT32, 0).as(Opcode.SET_8, Set.wireFormat8),
         new Set(/*indirect=*/ 0, /*dstOffset=*/ 1, TypeTag.UINT32, argsSize).as(Opcode.SET_8, Set.wireFormat8),
         new Set(/*indirect=*/ 0, /*dstOffset=*/ 2, TypeTag.UINT32, 2).as(Opcode.SET_8, Set.wireFormat8),
-        new CalldataCopy(/*indirect=*/ 0, /*csOffsetAddress=*/ 0, /*copySizeOffset=*/ 1, /*dstOffset=*/ 3),
+        new CalldataCopy(/*indirect=*/ 0, /*copySizeOffset=*/ 1, /*csOffsetAddress=*/ 0, /*dstOffset=*/ 3),
         new Return(/*indirect=*/ 0, /*sizeOffset=*/ 2, /*retOffset=*/ 3),
       ]);
       const contractClass = await makeContractClassPublic(0, otherContextInstructionsBytecode);
@@ -142,7 +142,7 @@ describe('External Calls', () => {
       context.machineState.memory.set(argsSizeOffset, new Uint32(argsSize));
       context.machineState.memory.setSlice(3, args);
 
-      const instruction = new Call(/*indirect=*/ 0, l2GasOffset, daGasOffset, addrOffset, argsOffset, argsSizeOffset);
+      const instruction = new Call(/*indirect=*/ 0, l2GasOffset, daGasOffset, addrOffset, argsSizeOffset, argsOffset);
       await instruction.execute(context);
 
       // Use SuccessCopy to get success
@@ -200,8 +200,8 @@ describe('External Calls', () => {
         l2GasOffset,
         daGasOffset,
         addrOffset,
-        /*argsOffset=*/ 0,
         argsSizeOffset,
+        /*argsOffset=*/ 0,
       );
       await instruction.execute(context);
 
@@ -229,16 +229,16 @@ describe('External Calls', () => {
         ...Buffer.from('1234', 'hex'), // l2GasOffset
         ...Buffer.from('5678', 'hex'), // daGasOffset
         ...Buffer.from('a234', 'hex'), // addrOffset
-        ...Buffer.from('b234', 'hex'), // argsOffset
         ...Buffer.from('c234', 'hex'), // argsSizeOffset
+        ...Buffer.from('b234', 'hex'), // argsOffset
       ]);
       const inst = new StaticCall(
         /*indirect=*/ 0x1234,
         /*l2GasOffset=*/ 0x1234,
         /*daGasOffset=*/ 0x5678,
         /*addrOffset=*/ 0xa234,
-        /*argsOffset=*/ 0xb234,
         /*argsSizeOffset=*/ 0xc234,
+        /*argsOffset=*/ 0xb234,
       );
 
       expect(StaticCall.fromBuffer(buf)).toEqual(inst);
@@ -281,8 +281,8 @@ describe('External Calls', () => {
         l2GasOffset,
         daGasOffset,
         addrOffset,
-        argsOffset,
         argsSizeOffset,
+        argsOffset,
       );
       await instruction.execute(context);
       // Ideally we'd mock the nested call.

--- a/yarn-project/simulator/src/public/avm/opcodes/external_calls.ts
+++ b/yarn-project/simulator/src/public/avm/opcodes/external_calls.ts
@@ -22,17 +22,17 @@ abstract class ExternalCall extends Instruction {
     private l2GasOffset: number,
     private daGasOffset: number,
     private addrOffset: number,
-    private argsOffset: number,
     private argsSizeOffset: number,
+    private argsOffset: number,
   ) {
     super();
   }
 
   public async execute(context: AvmContext) {
     const memory = context.machineState.memory;
-    const operands = [this.l2GasOffset, this.daGasOffset, this.addrOffset, this.argsOffset, this.argsSizeOffset];
+    const operands = [this.l2GasOffset, this.daGasOffset, this.addrOffset, this.argsSizeOffset, this.argsOffset];
     const addressing = Addressing.fromWire(this.indirect, operands.length);
-    const [l2GasOffset, daGasOffset, addrOffset, argsOffset, argsSizeOffset] = addressing.resolve(operands, memory);
+    const [l2GasOffset, daGasOffset, addrOffset, argsSizeOffset, argsOffset] = addressing.resolve(operands, memory);
     // TODO: Should be U32
     memory.checkTags(TypeTag.FIELD, l2GasOffset);
     memory.checkTags(TypeTag.FIELD, daGasOffset);

--- a/yarn-project/simulator/src/public/avm/opcodes/memory.test.ts
+++ b/yarn-project/simulator/src/public/avm/opcodes/memory.test.ts
@@ -369,15 +369,15 @@ describe('Memory instructions', () => {
     it('Should (de)serialize correctly', () => {
       const buf = Buffer.from([
         CalldataCopy.opcode, // opcode
-        0x01, // indirect
-        ...Buffer.from('1234', 'hex'), // cdOffsetAddress
+        0x10, // indirect
         ...Buffer.from('2345', 'hex'), // copysizeOffset
+        ...Buffer.from('1234', 'hex'), // cdOffsetAddress
         ...Buffer.from('3456', 'hex'), // dstOffset
       ]);
       const inst = new CalldataCopy(
-        /*indirect=*/ 0x01,
-        /*cdOffsetAddress=*/ 0x1234,
+        /*indirect=*/ 0x10,
         /*copysizeOffset=*/ 0x2345,
+        /*cdOffsetAddress=*/ 0x1234,
         /*dstOffset=*/ 0x3456,
       );
 
@@ -392,7 +392,7 @@ describe('Memory instructions', () => {
       context.machineState.memory.set(1, new Uint32(0)); // size
       context.machineState.memory.set(3, new Uint16(12)); // not overwritten
 
-      await new CalldataCopy(/*indirect=*/ 0, /*cdOffset=*/ 0, /*copySize=*/ 1, /*dstOffset=*/ 0).execute(context);
+      await new CalldataCopy(/*indirect=*/ 0, /*copySize=*/ 1, /*cdOffset=*/ 0, /*dstOffset=*/ 0).execute(context);
 
       const actual = context.machineState.memory.get(3);
       expect(actual).toEqual(new Uint16(12));
@@ -404,7 +404,7 @@ describe('Memory instructions', () => {
       context.machineState.memory.set(0, new Uint32(0)); // cdoffset
       context.machineState.memory.set(1, new Uint32(3)); // size
 
-      await new CalldataCopy(/*indirect=*/ 0, /*cdOffset=*/ 0, /*copySize=*/ 1, /*dstOffset=*/ 0).execute(context);
+      await new CalldataCopy(/*indirect=*/ 0, /*copySize=*/ 1, /*cdOffset=*/ 0, /*dstOffset=*/ 0).execute(context);
 
       const actual = context.machineState.memory.getSlice(/*offset=*/ 0, /*size=*/ 3);
       expect(actual).toEqual([new Field(1), new Field(2), new Field(3)]);
@@ -416,7 +416,7 @@ describe('Memory instructions', () => {
       context.machineState.memory.set(0, new Uint32(1)); // cdoffset
       context.machineState.memory.set(1, new Uint32(2)); // size
 
-      await new CalldataCopy(/*indirect=*/ 0, /*cdOffset=*/ 0, /*copySize=*/ 1, /*dstOffset=*/ 0).execute(context);
+      await new CalldataCopy(/*indirect=*/ 0, /*copySize=*/ 1, /*cdOffset=*/ 0, /*dstOffset=*/ 0).execute(context);
 
       const actual = context.machineState.memory.getSlice(/*offset=*/ 0, /*size=*/ 2);
       expect(actual).toEqual([new Field(2), new Field(3)]);
@@ -431,8 +431,8 @@ describe('Memory instructions', () => {
       await expect(
         new CalldataCopy(
           /*indirect=*/ 0,
-          /*cdStartOffset=*/ 0,
           /*copySizeOffset=*/ 1,
+          /*cdStartOffset=*/ 0,
           /*dstOffset=*/ TaggedMemory.MAX_MEMORY_SIZE - 2,
         ).execute(context),
       ).rejects.toThrow(MemorySliceOutOfRangeError);
@@ -444,7 +444,7 @@ describe('Memory instructions', () => {
       context.machineState.memory.set(0, new Uint32(2)); // cdStart = 2
       context.machineState.memory.set(1, new Uint32(3)); // copySize = 3
 
-      await new CalldataCopy(/*indirect=*/ 0, /*cdStartOffset=*/ 0, /*copySizeOffset=*/ 1, /*dstOffset=*/ 0).execute(
+      await new CalldataCopy(/*indirect=*/ 0, /*copySizeOffset=*/ 1, /*cdStartOffset=*/ 0, /*dstOffset=*/ 0).execute(
         context,
       );
 
@@ -481,15 +481,15 @@ describe('Memory instructions', () => {
     it('Should (de)serialize correctly', () => {
       const buf = Buffer.from([
         ReturndataCopy.opcode, // opcode
-        0x01, // indirect
-        ...Buffer.from('1234', 'hex'), // rdOffsetAddress
+        0x10, // indirect
         ...Buffer.from('2345', 'hex'), // copysizeOffset
+        ...Buffer.from('1234', 'hex'), // rdOffsetAddress
         ...Buffer.from('3456', 'hex'), // dstOffset
       ]);
       const inst = new ReturndataCopy(
-        /*indirect=*/ 0x01,
-        /*cdOffsetAddress=*/ 0x1234,
+        /*indirect=*/ 0x10,
         /*copysizeOffset=*/ 0x2345,
+        /*cdOffsetAddress=*/ 0x1234,
         /*dstOffset=*/ 0x3456,
       );
 
@@ -504,7 +504,7 @@ describe('Memory instructions', () => {
       context.machineState.memory.set(1, new Uint32(0)); // size
       context.machineState.memory.set(3, new Uint16(12)); // not overwritten
 
-      await new ReturndataCopy(/*indirect=*/ 0, /*rdOffset=*/ 0, /*copySize=*/ 1, /*dstOffset=*/ 0).execute(context);
+      await new ReturndataCopy(/*indirect=*/ 0, /*copySize=*/ 1, /*rdOffset=*/ 0, /*dstOffset=*/ 0).execute(context);
 
       const actual = context.machineState.memory.get(3);
       expect(actual).toEqual(new Uint16(12));
@@ -516,7 +516,7 @@ describe('Memory instructions', () => {
       context.machineState.memory.set(0, new Uint32(0)); // rdoffset
       context.machineState.memory.set(1, new Uint32(3)); // size
 
-      await new ReturndataCopy(/*indirect=*/ 0, /*rdOffset=*/ 0, /*copySize=*/ 1, /*dstOffset=*/ 0).execute(context);
+      await new ReturndataCopy(/*indirect=*/ 0, /*copySize=*/ 1, /*rdOffset=*/ 0, /*dstOffset=*/ 0).execute(context);
 
       const actual = context.machineState.memory.getSlice(/*offset=*/ 0, /*size=*/ 3);
       expect(actual).toEqual([new Field(1), new Field(2), new Field(3)]);
@@ -528,7 +528,7 @@ describe('Memory instructions', () => {
       context.machineState.memory.set(0, new Uint32(1)); // rdoffset
       context.machineState.memory.set(1, new Uint32(2)); // size
 
-      await new ReturndataCopy(/*indirect=*/ 0, /*rdOffset=*/ 0, /*copySize=*/ 1, /*dstOffset=*/ 0).execute(context);
+      await new ReturndataCopy(/*indirect=*/ 0, /*copySize=*/ 1, /*rdOffset=*/ 0, /*dstOffset=*/ 0).execute(context);
 
       const actual = context.machineState.memory.getSlice(/*offset=*/ 0, /*size=*/ 2);
       expect(actual).toEqual([new Field(2), new Field(3)]);
@@ -543,8 +543,8 @@ describe('Memory instructions', () => {
       await expect(
         new ReturndataCopy(
           /*indirect=*/ 0,
-          /*rdStartOffset=*/ 0,
           /*copySizeOffset=*/ 1,
+          /*rdStartOffset=*/ 0,
           /*dstOffset=*/ TaggedMemory.MAX_MEMORY_SIZE - 1,
         ).execute(context),
       ).rejects.toThrow(MemorySliceOutOfRangeError);
@@ -556,7 +556,7 @@ describe('Memory instructions', () => {
       context.machineState.memory.set(0, new Uint32(2)); // rdStart = 2
       context.machineState.memory.set(1, new Uint32(3)); // copySize = 3
 
-      await new ReturndataCopy(/*indirect=*/ 0, /*rdStartOffset=*/ 0, /*copySizeOffset=*/ 1, /*dstOffset=*/ 0).execute(
+      await new ReturndataCopy(/*indirect=*/ 0, /*copySizeOffset=*/ 1, /*rdStartOffset=*/ 0, /*dstOffset=*/ 0).execute(
         context,
       );
 

--- a/yarn-project/simulator/src/public/avm/opcodes/memory.ts
+++ b/yarn-project/simulator/src/public/avm/opcodes/memory.ts
@@ -162,8 +162,8 @@ export class CalldataCopy extends Instruction {
 
   constructor(
     private indirect: number,
-    private cdStartOffset: number,
     private copySizeOffset: number,
+    private cdStartOffset: number,
     private dstOffset: number,
   ) {
     super();
@@ -171,9 +171,9 @@ export class CalldataCopy extends Instruction {
 
   public async execute(context: AvmContext): Promise<void> {
     const memory = context.machineState.memory;
-    const operands = [this.cdStartOffset, this.copySizeOffset, this.dstOffset];
+    const operands = [this.copySizeOffset, this.cdStartOffset, this.dstOffset];
     const addressing = Addressing.fromWire(this.indirect, operands.length);
-    const [cdStartOffset, copySizeOffset, dstOffset] = addressing.resolve(operands, memory);
+    const [copySizeOffset, cdStartOffset, dstOffset] = addressing.resolve(operands, memory);
 
     memory.checkTags(TypeTag.UINT32, cdStartOffset, copySizeOffset);
     const cdStart = memory.get(cdStartOffset).toNumber();
@@ -224,8 +224,8 @@ export class ReturndataCopy extends Instruction {
 
   constructor(
     private indirect: number,
-    private rdStartOffset: number,
     private copySizeOffset: number,
+    private rdStartOffset: number,
     private dstOffset: number,
   ) {
     super();
@@ -233,9 +233,9 @@ export class ReturndataCopy extends Instruction {
 
   public async execute(context: AvmContext): Promise<void> {
     const memory = context.machineState.memory;
-    const operands = [this.rdStartOffset, this.copySizeOffset, this.dstOffset];
+    const operands = [this.copySizeOffset, this.rdStartOffset, this.dstOffset];
     const addressing = Addressing.fromWire(this.indirect, operands.length);
-    const [rdStartOffset, copySizeOffset, dstOffset] = addressing.resolve(operands, memory);
+    const [copySizeOffset, rdStartOffset, dstOffset] = addressing.resolve(operands, memory);
 
     memory.checkTags(TypeTag.UINT32, rdStartOffset, copySizeOffset);
     const rdStart = memory.get(rdStartOffset).toNumber();

--- a/yarn-project/simulator/src/public/avm/serialization/bytecode_serialization.test.ts
+++ b/yarn-project/simulator/src/public/avm/serialization/bytecode_serialization.test.ts
@@ -84,16 +84,16 @@ describe('Bytecode Serialization', () => {
         /*l2GasOffset=*/ 0x1234,
         /*daGasOffset=*/ 0x5678,
         /*addrOffset=*/ 0xa234,
-        /*argsOffset=*/ 0xb234,
         /*argsSize=*/ 0xc234,
+        /*argsOffset=*/ 0xb234,
       ),
       new StaticCall(
         /*indirect=*/ 0x01,
         /*l2GasOffset=*/ 0x1234,
         /*daGasOffset=*/ 0x5678,
         /*addrOffset=*/ 0xa234,
-        /*argsOffset=*/ 0xb234,
         /*argsSize=*/ 0xc234,
+        /*argsOffset=*/ 0xb234,
       ),
     ];
     const bytecode = Buffer.concat(instructions.map(i => i.toBuffer()));
@@ -116,16 +116,16 @@ describe('Bytecode Serialization', () => {
         /*l2GasOffset=*/ 0x1234,
         /*daGasOffset=*/ 0x5678,
         /*addrOffset=*/ 0xa234,
-        /*argsOffset=*/ 0xb234,
         /*argsSize=*/ 0xc234,
+        /*argsOffset=*/ 0xb234,
       ),
       new StaticCall(
         /*indirect=*/ 0x01,
         /*l2GasOffset=*/ 0x1234,
         /*daGasOffset=*/ 0x5678,
         /*addrOffset=*/ 0xa234,
-        /*argsOffset=*/ 0xb234,
         /*argsSize=*/ 0xc234,
+        /*argsOffset=*/ 0xb234,
       ),
     ];
 


### PR DESCRIPTION
Similar to the changes to return / revert. 

The copySizeOffset and dataOffset operands are swapped for cdCopy, rdCopy and Call to match retrun/revert