### PR TITLE
fix(ci): ./bootstrap.sh test

### DIFF
--- a/ci3/source_redis
+++ b/ci3/source_redis
@@ -39,10 +39,11 @@ if [ "$CI_REDIS_AVAILABLE" -eq 0 ]; then
   echo_stderr "${yellow}Redis unavailable. Disabling test cache.${reset}"
   export USE_TEST_CACHE=0
 else
-  export USE_TEST_CACHE=${USE_TEST_CACHE:-1}
+  # Default to not using test cache.
+  export USE_TEST_CACHE=${USE_TEST_CACHE:-0}
 fi
 
-# Will set log expiry to 2i weeks in CI, and 8 hours for local runs.
+# Will set log expiry to 2 weeks in CI, and 8 hours for local runs.
 if [ "${CI:-0}" -eq 1 ]; then
   CI_REDIS_EXPIRE=$((60 * 60 * 24 * 14))
 else

--- a/ci3/source_redis
+++ b/ci3/source_redis
@@ -38,9 +38,11 @@ fi
 if [ "$CI_REDIS_AVAILABLE" -eq 0 ]; then
   echo_stderr "${yellow}Redis unavailable. Disabling test cache.${reset}"
   export USE_TEST_CACHE=0
+else
+  export USE_TEST_CACHE=${USE_TEST_CACHE:-1}
 fi
 
-# Will set log expiry to 2 weeks in CI, and 8 hours for local runs.
+# Will set log expiry to 2i weeks in CI, and 8 hours for local runs.
 if [ "${CI:-0}" -eq 1 ]; then
   CI_REDIS_EXPIRE=$((60 * 60 * 24 * 14))
 else


### PR DESCRIPTION
A recent change had meant this env var was not set in normal dev work