### PR TITLE
feat: brittle benchmark for UH RV in Ultra gate count

### DIFF
--- a/barretenberg/cpp/src/barretenberg/stdlib/honk_verifier/ultra_recursive_verifier.test.cpp
+++ b/barretenberg/cpp/src/barretenberg/stdlib/honk_verifier/ultra_recursive_verifier.test.cpp
@@ -208,7 +208,6 @@ template <typename RecursiveFlavor> class RecursiveVerifierTest : public testing
             output.ipa_claim.set_public();
             outer_circuit.ipa_proof = convert_stdlib_proof_to_native(output.ipa_proof);
         }
-        info("Recursive Verifier: num gates = ", outer_circuit.get_estimated_num_finalized_gates());
 
         // Check for a failure flag in the recursive verifier circuit
         EXPECT_EQ(outer_circuit.failed(), false) << outer_circuit.err();
@@ -241,6 +240,12 @@ template <typename RecursiveFlavor> class RecursiveVerifierTest : public testing
         // Check 3: Construct and verify a proof of the recursive verifier circuit
         {
             auto proving_key = std::make_shared<OuterDeciderProvingKey>(outer_circuit);
+            info("Recursive Verifier: num gates = ", outer_circuit.get_num_finalized_gates());
+            if constexpr (std::same_as<Flavor, UltraRecursiveFlavor_<UltraCircuitBuilder>>) {
+                BB_ASSERT_EQ(outer_circuit.get_num_finalized_gates(),
+                             731001,
+                             "UltraHonk Recursive verifier built in Ultra changed in gate count.");
+            }
             OuterProver prover(proving_key);
             auto verification_key = std::make_shared<typename OuterFlavor::VerificationKey>(proving_key->proving_key);
             auto proof = prover.construct_proof();

--- a/barretenberg/cpp/src/barretenberg/stdlib/honk_verifier/ultra_recursive_verifier.test.cpp
+++ b/barretenberg/cpp/src/barretenberg/stdlib/honk_verifier/ultra_recursive_verifier.test.cpp
@@ -255,8 +255,8 @@ template <typename RecursiveFlavor> class RecursiveVerifierTest : public testing
             }
         }
         // Check the size of the recursive verifier
-        if constexpr (std::same_as<Flavor, UltraRecursiveFlavor_<UltraCircuitBuilder>>) {
-            uint32_t NUM_GATES_EXPECTED = 730689;
+        if constexpr (std::same_as<Flavor, MegaZKRecursiveFlavor_<UltraCircuitBuilder>>) {
+            uint32_t NUM_GATES_EXPECTED = 937885;
             BB_ASSERT_EQ(static_cast<uint32_t>(outer_circuit.get_num_finalized_gates()),
                          NUM_GATES_EXPECTED,
                          "UltraHonk Recursive verifier built in Ultra changed in gate count! Update this value if you "

--- a/barretenberg/cpp/src/barretenberg/stdlib/honk_verifier/ultra_recursive_verifier.test.cpp
+++ b/barretenberg/cpp/src/barretenberg/stdlib/honk_verifier/ultra_recursive_verifier.test.cpp
@@ -241,11 +241,6 @@ template <typename RecursiveFlavor> class RecursiveVerifierTest : public testing
         {
             auto proving_key = std::make_shared<OuterDeciderProvingKey>(outer_circuit);
             info("Recursive Verifier: num gates = ", outer_circuit.get_num_finalized_gates());
-            if constexpr (std::same_as<Flavor, UltraRecursiveFlavor_<UltraCircuitBuilder>>) {
-                BB_ASSERT_EQ(outer_circuit.get_num_finalized_gates(),
-                             730689,
-                             "UltraHonk Recursive verifier built in Ultra changed in gate count.");
-            }
             OuterProver prover(proving_key);
             auto verification_key = std::make_shared<typename OuterFlavor::VerificationKey>(proving_key->proving_key);
             auto proof = prover.construct_proof();
@@ -258,6 +253,14 @@ template <typename RecursiveFlavor> class RecursiveVerifierTest : public testing
                 OuterVerifier verifier(verification_key);
                 ASSERT(verifier.verify_proof(proof));
             }
+        }
+        // Check the size of the recursive verifier
+        if constexpr (std::same_as<Flavor, UltraRecursiveFlavor_<UltraCircuitBuilder>>) {
+            uint32_t NUM_GATES_EXPECTED = 730689;
+            BB_ASSERT_EQ(static_cast<uint32_t>(outer_circuit.get_num_finalized_gates()),
+                         NUM_GATES_EXPECTED,
+                         "UltraHonk Recursive verifier built in Ultra changed in gate count! Update this value if you "
+                         "are sure this is expected.");
         }
     }
 

--- a/barretenberg/cpp/src/barretenberg/stdlib/honk_verifier/ultra_recursive_verifier.test.cpp
+++ b/barretenberg/cpp/src/barretenberg/stdlib/honk_verifier/ultra_recursive_verifier.test.cpp
@@ -243,7 +243,7 @@ template <typename RecursiveFlavor> class RecursiveVerifierTest : public testing
             info("Recursive Verifier: num gates = ", outer_circuit.get_num_finalized_gates());
             if constexpr (std::same_as<Flavor, UltraRecursiveFlavor_<UltraCircuitBuilder>>) {
                 BB_ASSERT_EQ(outer_circuit.get_num_finalized_gates(),
-                             731001,
+                             730689,
                              "UltraHonk Recursive verifier built in Ultra changed in gate count.");
             }
             OuterProver prover(proving_key);

--- a/barretenberg/cpp/src/barretenberg/stdlib/honk_verifier/ultra_recursive_verifier.test.cpp
+++ b/barretenberg/cpp/src/barretenberg/stdlib/honk_verifier/ultra_recursive_verifier.test.cpp
@@ -259,7 +259,7 @@ template <typename RecursiveFlavor> class RecursiveVerifierTest : public testing
             uint32_t NUM_GATES_EXPECTED = 937885;
             BB_ASSERT_EQ(static_cast<uint32_t>(outer_circuit.get_num_finalized_gates()),
                          NUM_GATES_EXPECTED,
-                         "UltraHonk Recursive verifier built in Ultra changed in gate count! Update this value if you "
+                         "MegaZKHonk Recursive verifier changed in Ultra gate count! Update this value if you "
                          "are sure this is expected.");
         }
     }

--- a/barretenberg/cpp/src/barretenberg/stdlib/honk_verifier/ultra_recursive_verifier.test.cpp
+++ b/barretenberg/cpp/src/barretenberg/stdlib/honk_verifier/ultra_recursive_verifier.test.cpp
@@ -255,7 +255,7 @@ template <typename RecursiveFlavor> class RecursiveVerifierTest : public testing
             }
         }
         // Check the size of the recursive verifier
-        if constexpr (std::same_as<Flavor, MegaZKRecursiveFlavor_<UltraCircuitBuilder>>) {
+        if constexpr (std::same_as<RecursiveFlavor, MegaZKRecursiveFlavor_<UltraCircuitBuilder>>) {
             uint32_t NUM_GATES_EXPECTED = 937885;
             BB_ASSERT_EQ(static_cast<uint32_t>(outer_circuit.get_num_finalized_gates()),
                          NUM_GATES_EXPECTED,


### PR DESCRIPTION
Augments UltraRecursiveVerifier test by adding a gate count pinning check, so we can keep track of the Ultra gate count of a MegaZKRecursiveVerifier.

Helps in closing https://github.com/AztecProtocol/barretenberg/issues/1380 because I needed a measurement of the impact of an optimization.