### PR TITLE
fix!: fix hiding circuit VK consistency in overflow case

### DIFF
--- a/barretenberg/cpp/src/barretenberg/client_ivc/client_ivc.test.cpp
+++ b/barretenberg/cpp/src/barretenberg/client_ivc/client_ivc.test.cpp
@@ -294,7 +294,7 @@ TEST_F(ClientIVCTests, StructuredPrecomputedVKs)
 };
 
 /**
- * @brief Perform accumulation with a structured trace and precomputed verification keys
+ * @brief Ensure that the CIVC VK is independent of the number of circuits accumulated
  *
  */
 TEST_F(ClientIVCTests, VKIndependenceTest)
@@ -331,6 +331,56 @@ TEST_F(ClientIVCTests, VKIndependenceTest)
 
     // Check the equality of the Translator components of the ClientIVC VKeys.
     EXPECT_EQ(*civc_vk_2.translator.get(), *civc_vk_20.translator.get());
+};
+
+/**
+ * @brief Ensure that the CIVC VK is independent of whether any of the circuits being accumulated overflows the
+ * structured trace
+ * @details If one of the circuits being accumulated overflows the structured trace, the dyadic size of the accumulator
+ * may increase. In this case we want to ensure that the CIVC VK (and in particular the hiding circuit VK) is identical
+ * to the non-overflow case. This requires, for example, that the padding_indicator_array logic used in somecheck is
+ * functioning properly.
+ */
+TEST_F(ClientIVCTests, VKIndependenceWithOverflow)
+{
+    // Run IVC for two sets of circuits: a nomical case where all circuits fit within the structured trace and an
+    // "overflow" case where all (but importantly at least one) circuit overflows the structured trace.
+    const size_t NUM_CIRCUITS = 4;
+    const size_t log2_num_gates_nominal = 5;   // number of gates in baseline mockeded circuits
+    const size_t log2_num_gates_overflow = 18; // number of gates in the "overflow"" mocked circuit
+
+    TraceStructure trace_structure = SMALL_TEST_STRUCTURE;
+
+    // Check that we will indeed overflow the trace structure
+    EXPECT_TRUE(1 << log2_num_gates_overflow > trace_structure.size()); // 1 << 18 > 1 << 16
+
+    auto generate_vk = [&](size_t num_circuits, size_t log2_num_gates) {
+        ClientIVC ivc{ { trace_structure } };
+        ClientIVCMockCircuitProducer circuit_producer;
+        for (size_t j = 0; j < num_circuits; ++j) {
+            auto circuit = circuit_producer.create_next_circuit(ivc, log2_num_gates);
+            ivc.accumulate(circuit);
+        }
+        ivc.prove();
+        auto ivc_vk = ivc.get_vk();
+
+        // PCS verification keys will not match so set to null before comparing
+        ivc_vk.eccvm->pcs_verification_key = nullptr;
+
+        return ivc_vk;
+    };
+
+    auto civc_vk_nominal = generate_vk(NUM_CIRCUITS, log2_num_gates_nominal);
+    auto civc_vk_overflow = generate_vk(NUM_CIRCUITS, log2_num_gates_overflow);
+
+    // Check the equality of the Mega components of the ClientIVC VKeys.
+    EXPECT_EQ(*civc_vk_nominal.mega.get(), *civc_vk_overflow.mega.get());
+
+    // Check the equality of the ECCVM components of the ClientIVC VKeys.
+    EXPECT_EQ(*civc_vk_nominal.eccvm.get(), *civc_vk_overflow.eccvm.get());
+
+    // Check the equality of the Translator components of the ClientIVC VKeys.
+    EXPECT_EQ(*civc_vk_nominal.translator.get(), *civc_vk_overflow.translator.get());
 };
 
 /**

--- a/barretenberg/cpp/src/barretenberg/client_ivc/client_ivc.test.cpp
+++ b/barretenberg/cpp/src/barretenberg/client_ivc/client_ivc.test.cpp
@@ -346,7 +346,7 @@ TEST_F(ClientIVCTests, VKIndependenceWithOverflow)
     // Run IVC for two sets of circuits: a nomical case where all circuits fit within the structured trace and an
     // "overflow" case where all (but importantly at least one) circuit overflows the structured trace.
     const size_t NUM_CIRCUITS = 4;
-    const size_t log2_num_gates_nominal = 5;   // number of gates in baseline mockeded circuits
+    const size_t log2_num_gates_nominal = 5;   // number of gates in baseline mocked circuits
     const size_t log2_num_gates_overflow = 18; // number of gates in the "overflow"" mocked circuit
 
     TraceStructure trace_structure = SMALL_TEST_STRUCTURE;

--- a/barretenberg/cpp/src/barretenberg/client_ivc/client_ivc.test.cpp
+++ b/barretenberg/cpp/src/barretenberg/client_ivc/client_ivc.test.cpp
@@ -347,7 +347,7 @@ TEST_F(ClientIVCTests, VKIndependenceWithOverflow)
     // "overflow" case where all (but importantly at least one) circuit overflows the structured trace.
     const size_t NUM_CIRCUITS = 4;
     const size_t log2_num_gates_nominal = 5;   // number of gates in baseline mocked circuits
-    const size_t log2_num_gates_overflow = 18; // number of gates in the "overflow"" mocked circuit
+    const size_t log2_num_gates_overflow = 18; // number of gates in the "overflow" mocked circuit
 
     TraceStructure trace_structure = SMALL_TEST_STRUCTURE;
 

--- a/barretenberg/cpp/src/barretenberg/stdlib/protogalaxy_verifier/protogalaxy_recursive_verifier.cpp
+++ b/barretenberg/cpp/src/barretenberg/stdlib/protogalaxy_verifier/protogalaxy_recursive_verifier.cpp
@@ -178,9 +178,9 @@ std::shared_ptr<typename DeciderVerificationKeys::DeciderVK> ProtogalaxyRecursiv
     accumulator->gate_challenges = update_gate_challenges(perturbator_challenge, accumulator->gate_challenges, deltas);
 
     // Set the accumulator circuit size data based on the max of the keys being accumulated
-    const size_t accumulator_log_circuit_size = keys_to_fold.get_max_log_circuit_size();
+    auto [accumulator_circuit_size, accumulator_log_circuit_size] = keys_to_fold.get_max_circuit_size_and_log_size();
     accumulator->verification_key->log_circuit_size = accumulator_log_circuit_size;
-    accumulator->verification_key->circuit_size = 1 << accumulator_log_circuit_size;
+    accumulator->verification_key->circuit_size = accumulator_circuit_size;
 
     // Fold the relation parameters
     for (auto [combination, to_combine] : zip_view(accumulator->alphas, keys_to_fold.get_alphas())) {

--- a/barretenberg/cpp/src/barretenberg/stdlib/protogalaxy_verifier/recursive_decider_verification_keys.hpp
+++ b/barretenberg/cpp/src/barretenberg/stdlib/protogalaxy_verifier/recursive_decider_verification_keys.hpp
@@ -53,9 +53,11 @@ template <IsRecursiveFlavor Flavor_, size_t NUM_> struct RecursiveDeciderVerific
     {
         // Find the key with the largest circuit size and reaturn its circuit size and log circuit size
         auto* max_key = _data[0].get();
-        size_t max_circuit_size = static_cast<size_t>(max_key->verification_key->circuit_size.get_value());
+        size_t max_circuit_size =
+            static_cast<size_t>(static_cast<uint32_t>(max_key->verification_key->circuit_size.get_value()));
         for (const auto& key : _data) {
-            if (static_cast<size_t>(key->verification_key->circuit_size.get_value()) > max_circuit_size) {
+            if (static_cast<size_t>(static_cast<uint32_t>(key->verification_key->circuit_size.get_value())) >
+                max_circuit_size) {
                 max_key = key.get();
             }
         }

--- a/barretenberg/cpp/src/barretenberg/stdlib/protogalaxy_verifier/recursive_decider_verification_keys.hpp
+++ b/barretenberg/cpp/src/barretenberg/stdlib/protogalaxy_verifier/recursive_decider_verification_keys.hpp
@@ -16,6 +16,7 @@ template <IsRecursiveFlavor Flavor_, size_t NUM_> struct RecursiveDeciderVerific
     using VerificationKey = typename Flavor::VerificationKey;
     using DeciderVK = RecursiveDeciderVerificationKey_<Flavor>;
     using ArrayType = std::array<std::shared_ptr<DeciderVK>, NUM_>;
+    using FF = typename Flavor::FF;
 
   public:
     static constexpr size_t NUM = NUM_;
@@ -43,20 +44,22 @@ template <IsRecursiveFlavor Flavor_, size_t NUM_> struct RecursiveDeciderVerific
     }
 
     /**
-     * @brief Get the max log circuit size from the set of decider verification keys
+     * @brief Get the max circuit size (and corresponding log circuit size) from the set of decider verification keys
      *
-     * @return size_t
+     * @return {max circuit size, max log circuit size}
+     * @todo TODO(https://github.com/AztecProtocol/barretenberg/issues/1283): Suspicious get_value().
      */
-    size_t get_max_log_circuit_size() const
+    std::pair<FF, FF> get_max_circuit_size_and_log_size() const
     {
-        size_t max_log_circuit_size{ 0 };
-        for (auto key : _data) {
-            // TODO(https://github.com/AztecProtocol/barretenberg/issues/1283): Suspicious get_value.
-            max_log_circuit_size = std::max(
-                max_log_circuit_size,
-                static_cast<size_t>(static_cast<uint32_t>(key->verification_key->log_circuit_size.get_value())));
+        // Find the key with the largest circuit size and reaturn its circuit size and log circuit size
+        auto* max_key = _data[0].get();
+        size_t max_circuit_size = static_cast<size_t>(max_key->verification_key->circuit_size.get_value());
+        for (const auto& key : _data) {
+            if (static_cast<size_t>(key->verification_key->circuit_size.get_value()) > max_circuit_size) {
+                max_key = key.get();
+            }
         }
-        return max_log_circuit_size;
+        return { max_key->verification_key->circuit_size, max_key->verification_key->log_circuit_size };
     }
 
     /**


### PR DESCRIPTION
Prior to this update, the PG recursive verifier was not treating the circuit size and log circuit size as witnesses. This led to the `padding_indicator_array` used in the decider recursive verifier in the hiding circuit being populated with constant values. This is turn led to different constraints in the case where the accumulator had a circuit size larger than the nominal one determined by the structured trace (which occurs when the overflow mechanism is active for example).

This PR makes those values witnesses and adds an additional CIVC VK consistency test for the case where one or more of the circuits overflows and results in an accumulator with larger dyadic size than the nominal structured trace dyadic size.