### PR TITLE
feat: txe new contract calling flow

### DIFF
--- a/noir-projects/aztec-nr/aztec/src/test/helpers/cheatcodes.nr
+++ b/noir-projects/aztec-nr/aztec/src/test/helpers/cheatcodes.nr
@@ -3,7 +3,7 @@ use crate::test::helpers::utils::TestAccount;
 use dep::protocol_types::{
     abis::function_selector::FunctionSelector, address::AztecAddress,
     constants::CONTRACT_INSTANCE_LENGTH, contract_instance::ContractInstance,
-    public_keys::PublicKeys, traits::Deserialize,
+    public_keys::PublicKeys, traits::Deserialize, utils::reader::Reader,
 };
 
 pub unconstrained fn reset() {
@@ -87,6 +87,31 @@ pub unconstrained fn assert_private_call_fails(
     )
 }
 
+pub unconstrained fn private_call_new_flow(
+    from: AztecAddress,
+    contract_address: AztecAddress,
+    function_selector: FunctionSelector,
+    args: [Field],
+    args_hash: Field,
+    is_static_call: bool,
+) -> (u32, Field, Field) {
+    let fields = oracle_private_call_new_flow(
+        from,
+        contract_address,
+        function_selector,
+        args,
+        args_hash,
+        is_static_call,
+    );
+
+    let mut reader = Reader::new(fields);
+    let end_side_effect_counter = reader.read_u32();
+    let returns_hash = reader.read();
+    let tx_hash = reader.read();
+
+    (end_side_effect_counter, returns_hash, tx_hash)
+}
+
 #[oracle(reset)]
 unconstrained fn oracle_reset() {}
 
@@ -147,3 +172,13 @@ unconstrained fn oracle_assert_private_call_fails(
     sideEffectsCounter: Field,
     isStaticCall: bool,
 ) {}
+
+#[oracle(privateCallNewFlow)]
+unconstrained fn oracle_private_call_new_flow(
+    _from: AztecAddress,
+    _contract_address: AztecAddress,
+    _function_selector: FunctionSelector,
+    _args: [Field],
+    _args_hash: Field,
+    _is_static_call: bool,
+) -> [Field; 3] {}

--- a/noir-projects/aztec-nr/aztec/src/test/helpers/test_environment.nr
+++ b/noir-projects/aztec-nr/aztec/src/test/helpers/test_environment.nr
@@ -1,18 +1,30 @@
-use dep::protocol_types::{abis::function_selector::FunctionSelector, address::AztecAddress};
+use dep::protocol_types::{
+    abis::function_selector::FunctionSelector,
+    address::AztecAddress,
+    constants::PUBLIC_DISPATCH_SELECTOR,
+    traits::{Deserialize, FromField, Packable, ToField},
+};
 
-use crate::context::{call_interfaces::CallInterface, PrivateContext, PublicContext, UtilityContext};
+use crate::context::{
+    call_interfaces::CallInterface, PrivateCallInterface, PrivateContext, PrivateVoidCallInterface,
+    PublicContext, ReturnsHash, UtilityContext,
+};
 use crate::hash::hash_args;
 use crate::test::helpers::{cheatcodes, utils::Deployer};
 
 use crate::note::note_interface::{NoteHash, NoteType};
 use crate::oracle::{
     execution::{get_block_number, get_contract_address},
+    execution_cache,
     notes::notify_created_note,
 };
-use protocol_types::constants::PUBLIC_DISPATCH_SELECTOR;
-use protocol_types::traits::{FromField, Packable, ToField};
 
 pub struct TestEnvironment {}
+
+pub struct CallResult<T> {
+    return_value: Option<T>,
+    tx_hash: Field,
+}
 
 impl TestEnvironment {
     pub unconstrained fn new() -> Self {
@@ -182,6 +194,53 @@ impl TestEnvironment {
             cheatcodes::get_side_effects_counter() as Field,
             call_interface.get_is_static(),
         );
+    }
+
+    pub unconstrained fn call_private<T, let M: u32>(
+        _self: Self,
+        from: AztecAddress,
+        call_interface: PrivateCallInterface<M, T>,
+    ) -> CallResult<T>
+    where
+        T: Deserialize<M>,
+    {
+        let args = call_interface.get_args();
+        let args_hash = hash_args(args);
+
+        let (_end_side_effect_counter, returns_hash, tx_hash) = cheatcodes::private_call_new_flow(
+            from,
+            call_interface.get_contract_address(),
+            call_interface.get_selector(),
+            args,
+            args_hash,
+            call_interface.get_is_static(),
+        );
+
+        let returns: T = ReturnsHash::new(returns_hash).get_preimage();
+        CallResult { return_value: Option::some(returns), tx_hash }
+    }
+
+    pub unconstrained fn call_private_void<let M: u32>(
+        _self: Self,
+        from: AztecAddress,
+        call_interface: PrivateVoidCallInterface<M>,
+    ) -> CallResult<()> {
+        let args = call_interface.get_args();
+        let args_hash = hash_args(args);
+        execution_cache::store(args, args_hash);
+
+        let (_end_side_effect_counter, returns_hash, tx_hash) = cheatcodes::private_call_new_flow(
+            from,
+            call_interface.get_contract_address(),
+            call_interface.get_selector(),
+            args,
+            args_hash,
+            call_interface.get_is_static(),
+        );
+
+        ReturnsHash::new(returns_hash).assert_empty();
+
+        CallResult { return_value: Option::none(), tx_hash }
     }
 
     /// Manually adds a note to TXE. This needs to be called if you want to work with a note in your test with the note

--- a/noir-projects/aztec-nr/aztec/src/test/helpers/utils.nr
+++ b/noir-projects/aztec-nr/aztec/src/test/helpers/utils.nr
@@ -40,7 +40,7 @@ impl<let N: u32, let M: u32> Deployer<N, M> {
             call_interface.get_args(),
             self.secret,
         );
-        cheatcodes::advance_blocks_by(1);
+
         let inputs = cheatcodes::get_private_context_inputs(get_block_number() - 1);
         let mut private_context = PrivateContext::new(inputs, 0);
         let args = call_interface.get_args();
@@ -52,6 +52,8 @@ impl<let N: u32, let M: u32> Deployer<N, M> {
             args_hash,
             call_interface.get_is_static(),
         );
+
+        cheatcodes::advance_blocks_by(1);
 
         instance
     }
@@ -70,7 +72,6 @@ impl<let N: u32, let M: u32> Deployer<N, M> {
             call_interface.get_args(),
             self.secret,
         );
-        cheatcodes::advance_blocks_by(1);
 
         let mut public_context = PublicContext::new(|| panic(f"Provide args hash manually"));
 
@@ -81,6 +82,8 @@ impl<let N: u32, let M: u32> Deployer<N, M> {
             GasOpts::default(),
         );
         assert(results.len() == 0);
+
+        cheatcodes::advance_blocks_by(1);
 
         instance
     }
@@ -100,7 +103,6 @@ impl<let N: u32, let M: u32> Deployer<N, M> {
             call_interface.get_args(),
             self.secret,
         );
-        cheatcodes::advance_blocks_by(1);
 
         let mut public_context = PublicContext::new(|| panic(f"Provide args hash manually"));
 
@@ -110,6 +112,8 @@ impl<let N: u32, let M: u32> Deployer<N, M> {
             call_interface.get_args(),
             GasOpts::default(),
         );
+
+        cheatcodes::advance_blocks_by(1);
 
         instance
     }

--- a/noir-projects/noir-contracts/contracts/app/auth_contract/src/test/utils.nr
+++ b/noir-projects/noir-contracts/contracts/app/auth_contract/src/test/utils.nr
@@ -14,6 +14,6 @@ pub unconstrained fn setup() -> (&mut TestEnvironment, AztecAddress, AztecAddres
     let auth_contract =
         env.deploy_self("Auth").with_public_void_initializer(initializer_call_interface);
     let auth_contract_address = auth_contract.to_address();
-    env.advance_block_by(1);
+
     (&mut env, auth_contract_address, admin, to_authorize, other)
 }

--- a/noir-projects/noir-contracts/contracts/test/counter_contract/src/main.nr
+++ b/noir-projects/noir-contracts/contracts/test/counter_contract/src/main.nr
@@ -6,9 +6,12 @@ use dep::aztec::macros::aztec;
 pub contract Counter {
     // docs:end:setup
     // docs:start:imports
-    use aztec::macros::{functions::{initializer, private, utility}, storage::storage};
+    use aztec::macros::{functions::{initializer, private, public, utility}, storage::storage};
     use aztec::prelude::{AztecAddress, Map};
-    use aztec::protocol_types::traits::{FromField, ToField};
+    use aztec::protocol_types::{
+        abis::function_selector::FunctionSelector,
+        traits::{FromField, ToField},
+    };
     use easy_private_state::EasyPrivateUint;
     use value_note::{balance_utils, value_note::ValueNote};
     // docs:end:imports
@@ -39,6 +42,9 @@ pub contract Counter {
                 [owner.to_field()],
             );
         }
+
+        Counter::at(context.this_address()).emit_in_public(12345).enqueue(&mut context);
+
         let counters = storage.counters;
         counters.at(owner).add(1, owner, sender);
     }
@@ -87,6 +93,31 @@ pub contract Counter {
     unconstrained fn get_counter(owner: AztecAddress) -> Field {
         let counters = storage.counters;
         balance_utils::get_balance(counters.at(owner).set)
+    }
+
+    #[private]
+    fn increment_self_and_other(
+        other_counter: AztecAddress,
+        owner: AztecAddress,
+        sender: AztecAddress,
+    ) {
+        unsafe {
+            dep::aztec::oracle::debug_log::debug_log_format(
+                "Incrementing counter for other {0}",
+                [owner.to_field()],
+            );
+        }
+
+        let counters = storage.counters;
+        counters.at(owner).add(1, owner, sender);
+
+        Counter::at(context.this_address()).emit_in_public(9876).enqueue(&mut context);
+        Counter::at(other_counter).increment(owner, sender).call(&mut context);
+    }
+
+    #[public]
+    fn emit_in_public(n: Field) {
+        context.push_note_hash(n);
     }
 
     // docs:end:get_counter
@@ -206,5 +237,89 @@ pub contract Counter {
             view_notes(owner_storage_slot, options);
         assert(get_counter(owner) == 6);
         assert(notes.len() == 4);
+    }
+
+    #[test]
+    unconstrained fn new_calling_flow_increment_self_and_other() {
+        let mut env = TestEnvironment::new();
+        let owner = env.create_account(1);
+        let sender = env.create_account(2);
+        let third = env.create_account(3);
+
+        env.impersonate(owner);
+
+        let initial_value: Field = 2;
+        let initializer = Counter::interface().initialize(initial_value as u64, owner);
+        let counter_contract = env.deploy_self("Counter").with_private_initializer(initializer);
+        let contract_address = counter_contract.to_address();
+
+        let initializer2 = Counter::interface().initialize(initial_value as u64, third);
+        let counter_contract2 = env.deploy_self("Counter").with_private_initializer(initializer2);
+        let contract_address2 = counter_contract2.to_address();
+
+        let _ = env.call_private_void(
+            owner,
+            Counter::at(contract_address).increment_self_and_other(contract_address2, owner, sender),
+        );
+
+        env.impersonate(contract_address);
+
+        sync_notes();
+        let mut options = NoteViewerOptions::new();
+        let counter_slot = Counter::storage_layout().counters.slot;
+
+        let owner_storage_slot = derive_storage_slot_in_map(counter_slot, owner);
+        let notes: BoundedVec<ValueNote, MAX_NOTES_PER_PAGE> =
+            view_notes(owner_storage_slot, options);
+
+        let current_value_for_owner = get_counter(owner);
+
+        assert_eq(notes.len(), 2);
+        assert_eq(current_value_for_owner, 3);
+
+        env.impersonate(contract_address2);
+
+        sync_notes();
+        let counter_slot = Counter::storage_layout().counters.slot;
+
+        let owner_storage_slot = derive_storage_slot_in_map(counter_slot, owner);
+        let notes: BoundedVec<ValueNote, MAX_NOTES_PER_PAGE> =
+            view_notes(owner_storage_slot, options);
+
+        let current_value_for_owner = get_counter(owner);
+
+        assert_eq(notes.len(), 1);
+        assert_eq(current_value_for_owner, 1);
+    }
+
+    #[test]
+    unconstrained fn new_calling_flow_increment_with_new_call_flow() {
+        let mut env = TestEnvironment::new();
+        let owner = env.create_account(1);
+        let sender = env.create_account(2);
+        env.impersonate(owner);
+
+        let initial_value: Field = 2;
+        let initializer = Counter::interface().initialize(initial_value as u64, owner);
+        let counter_contract = env.deploy_self("Counter").with_private_initializer(initializer);
+        let contract_address = counter_contract.to_address();
+
+        let _ =
+            env.call_private_void(owner, Counter::at(contract_address).increment(owner, sender));
+
+        env.impersonate(contract_address);
+
+        sync_notes();
+        let mut options = NoteViewerOptions::new();
+        let counter_slot = Counter::storage_layout().counters.slot;
+
+        let owner_storage_slot = derive_storage_slot_in_map(counter_slot, owner);
+        let notes: BoundedVec<ValueNote, MAX_NOTES_PER_PAGE> =
+            view_notes(owner_storage_slot, options);
+
+        let current_value_for_owner = get_counter(owner);
+
+        assert_eq(notes.len(), 2);
+        assert_eq(current_value_for_owner, 3);
     }
 }

--- a/noir-projects/noir-contracts/contracts/test/counter_contract/src/main.nr
+++ b/noir-projects/noir-contracts/contracts/test/counter_contract/src/main.nr
@@ -114,6 +114,7 @@ pub contract Counter {
         // docs:start:txe_test_read_notes
         // Read the stored value in the note
         env.impersonate(contract_address);
+        sync_notes();
         let counter_slot = Counter::storage_layout().counters.slot;
         let owner_storage_slot = derive_storage_slot_in_map(counter_slot, owner);
         let mut options = NoteViewerOptions::new();
@@ -126,8 +127,11 @@ pub contract Counter {
         );
         // docs:end:txe_test_read_notes
         // Increment the counter
+        env.impersonate(owner);
         Counter::at(contract_address).increment(owner, sender).call(&mut env.private());
         // get_counter is an unconstrained function, so we call it directly (we're in the same module)
+        env.impersonate(contract_address);
+        sync_notes();
         let current_value_for_owner = get_counter(owner);
         let expected_current_value = initial_value + 1;
         assert(
@@ -142,23 +146,9 @@ pub contract Counter {
         let initial_value = 5;
         let (env, contract_address, owner, sender) = test::setup(initial_value);
 
-        // Checking from the note cache
-        env.impersonate(contract_address);
-        let counter_slot = Counter::storage_layout().counters.slot;
-        let owner_storage_slot = derive_storage_slot_in_map(counter_slot, owner);
-        let mut options = NoteViewerOptions::new();
-        let notes: BoundedVec<ValueNote, MAX_NOTES_PER_PAGE> =
-            view_notes(owner_storage_slot, options);
-        let initial_note_value = notes.get(0).value;
-        assert(
-            initial_note_value == initial_value,
-            f"Expected {initial_value} but got {initial_note_value}",
-        );
-
         // Checking that the note was discovered from private logs
-        env.advance_block_by(1);
-        sync_notes();
         env.impersonate(contract_address);
+        sync_notes();
         let counter_slot = Counter::storage_layout().counters.slot;
         let owner_storage_slot = derive_storage_slot_in_map(counter_slot, owner);
         let mut options = NoteViewerOptions::new();

--- a/noir-projects/noir-contracts/contracts/test/test_contract/src/test.nr
+++ b/noir-projects/noir-contracts/contracts/test/test_contract/src/test.nr
@@ -104,8 +104,7 @@ unconstrained fn test_storage_slot_allocation() {
 
 global CONTRACT_DEPLOYED_AT: u32 = 3;
 
-// In env.deploy_self("Test").with_private_initializer(initializer); it first deploys the contract, then advances a block, then calls the initializer.
-global CONTRACT_INITIALIZED_AT: u32 = CONTRACT_DEPLOYED_AT + 1;
+global CONTRACT_INITIALIZED_AT: u32 = CONTRACT_DEPLOYED_AT;
 
 pub unconstrained fn setup() -> (&mut TestEnvironment, AztecAddress, AztecAddress) {
     // Setup env, generate keys
@@ -123,8 +122,6 @@ pub unconstrained fn setup() -> (&mut TestEnvironment, AztecAddress, AztecAddres
     let initializer = Test::interface().initialize();
     let test_contract = env.deploy_self("Test").with_private_initializer(initializer);
     let contract_address = test_contract.to_address();
-
-    env.advance_block_by(1);
 
     (&mut env, contract_address, owner)
 }
@@ -171,7 +168,7 @@ unconstrained fn proving_contract_deployment_fails() {
 
 // In this test, we fail to prove contract initialization at the block before it was deployed. This checks for inclusion
 // of the initialization nullifier in state.
-#[test(should_fail_with = "Nullifier membership witness not found at block 3.")]
+#[test(should_fail_with = "Nullifier membership witness not found at block 2.")]
 unconstrained fn proving_contract_initialization_fails() {
     let (env, contract_address) = setup();
 

--- a/yarn-project/end-to-end/src/e2e_deploy_contract/deploy_method.test.ts
+++ b/yarn-project/end-to-end/src/e2e_deploy_contract/deploy_method.test.ts
@@ -93,8 +93,8 @@ describe('e2e_deploy_contract deploy method', () => {
     const opts = { skipClassRegistration: true, skipPublicDeployment: true };
     const contract = await CounterContract.deploy(wallet, 10, wallet.getAddress()).send(opts).deployed();
     logger.debug(`Calling a function to ensure the contract was properly initialized`);
-    await contract.methods.increment(wallet.getAddress(), wallet.getAddress()).send().wait();
-    expect(await contract.methods.get_counter(wallet.getAddress()).simulate()).toEqual(11n);
+    await contract.methods.increment_twice(wallet.getAddress(), wallet.getAddress()).send().wait();
+    expect(await contract.methods.get_counter(wallet.getAddress()).simulate()).toEqual(12n);
   });
 
   it('publicly deploys a contract with no constructor', async () => {

--- a/yarn-project/simulator/src/private/index.ts
+++ b/yarn-project/simulator/src/private/index.ts
@@ -9,6 +9,8 @@ export { ExecutionNoteCache } from './execution_note_cache.js';
 export { extractPrivateCircuitPublicInputs, readCurrentClassId } from './private_execution.js';
 export { witnessMapToFields } from './acvm/deserialize.js';
 export { toACVMWitness } from './acvm/serialize.js';
+export { executePrivateFunction } from './private_execution.js';
+export { PrivateExecutionOracle } from './private_execution_oracle.js';
 export { extractCallStack } from './acvm/acvm.js';
 export { type NoteData, TypedOracle } from './acvm/oracle/typed_oracle.js';
 export { Oracle } from './acvm/oracle/oracle.js';

--- a/yarn-project/simulator/src/public/avm/avm_simulator.test.ts
+++ b/yarn-project/simulator/src/public/avm/avm_simulator.test.ts
@@ -12,7 +12,7 @@ import { Fq, Fr, Point } from '@aztec/foundation/fields';
 import type { Fieldable } from '@aztec/foundation/serialize';
 import { AvmGadgetsTestContract } from '@aztec/noir-test-contracts.js/AvmGadgetsTest';
 import { AvmTestContract } from '@aztec/noir-test-contracts.js/AvmTest';
-import { CounterContract } from '@aztec/noir-test-contracts.js/Counter';
+import { NoteGetterContract } from '@aztec/noir-test-contracts.js/NoteGetter';
 import { type FunctionArtifact, FunctionSelector } from '@aztec/stdlib/abi';
 import { AztecAddress } from '@aztec/stdlib/aztec-address';
 import { SerializableContractInstance, computePublicBytecodeCommitment } from '@aztec/stdlib/contract';
@@ -1263,10 +1263,10 @@ describe('AVM simulator: transpiled Noir contracts', () => {
   it('should be able to execute contracts that only have private functions', async () => {
     const context = initContext({ env: initExecutionEnvironment({ calldata: [] }) });
 
-    // Counter contract is a private only contract (no public functions)
+    // NoteGetter contract is a private only contract (no public functions)
     const counterDispatch = getContractFunctionArtifact(
       'public_dispatch',
-      CounterContract.artifact,
+      NoteGetterContract.artifact,
     ) as FunctionArtifact;
     assert(!!counterDispatch?.bytecode);
     const results = await new AvmSimulator(context).executeBytecode(counterDispatch.bytecode);
@@ -1278,7 +1278,7 @@ describe('AVM simulator: transpiled Noir contracts', () => {
         'public_dispatch',
         results.revertReason!,
         results.output,
-        CounterContract.artifact,
+        NoteGetterContract.artifact,
       ),
     ).toMatch('No public functions');
   });

--- a/yarn-project/txe/src/oracle/txe_oracle.ts
+++ b/yarn-project/txe/src/oracle/txe_oracle.ts
@@ -140,7 +140,7 @@ export class TXE implements TypedOracle {
 
   private simulationProvider = new WASMSimulator();
 
-  private noteCache: ExecutionNoteCache;
+  public noteCache: ExecutionNoteCache;
 
   private authwits: Map<string, AuthWitness> = new Map();
 
@@ -729,6 +729,7 @@ export class TXE implements TypedOracle {
     txEffect.noteHashes = [...uniqueNoteHashesFromPrivate, ...this.uniqueNoteHashesFromPublic];
 
     txEffect.nullifiers = [...this.siloedNullifiersFromPublic, ...this.noteCache.getAllNullifiers()];
+
     if (usedTxRequestHashForNonces) {
       txEffect.nullifiers.unshift(this.getTxRequestHash());
     }

--- a/yarn-project/txe/src/oracle/txe_oracle.ts
+++ b/yarn-project/txe/src/oracle/txe_oracle.ts
@@ -1,8 +1,15 @@
 import { type AztecNode, Body, L2Block, Note } from '@aztec/aztec.js';
 import {
+  DEFAULT_GAS_LIMIT,
+  DEFAULT_TEARDOWN_GAS_LIMIT,
   type L1_TO_L2_MSG_TREE_HEIGHT,
+  MAX_CONTRACT_CLASS_LOGS_PER_TX,
+  MAX_ENQUEUED_CALLS_PER_TX,
+  MAX_L2_GAS_PER_TX_PUBLIC_PORTION,
+  MAX_L2_TO_L1_MSGS_PER_TX,
   MAX_NOTE_HASHES_PER_TX,
   MAX_NULLIFIERS_PER_TX,
+  MAX_PRIVATE_LOGS_PER_TX,
   NULLIFIER_SUBTREE_HEIGHT,
   type NULLIFIER_TREE_HEIGHT,
   NUMBER_OF_L1_L2_MESSAGES_PER_ROLLUP,
@@ -13,7 +20,7 @@ import { padArrayEnd } from '@aztec/foundation/collection';
 import { Aes128, Schnorr, poseidon2Hash } from '@aztec/foundation/crypto';
 import { Fr, Point } from '@aztec/foundation/fields';
 import { type Logger, applyStringFormatting } from '@aztec/foundation/log';
-import { Timer } from '@aztec/foundation/timer';
+import { TestDateProvider, Timer } from '@aztec/foundation/timer';
 import { KeyStore } from '@aztec/key-store';
 import type { AztecAsyncKVStore } from '@aztec/kv-store';
 import type { ProtocolContract } from '@aztec/protocol-contracts';
@@ -34,8 +41,10 @@ import {
   type MessageLoadOracleInputs,
   type NoteData,
   Oracle,
+  PrivateExecutionOracle,
   type TypedOracle,
   WASMSimulator,
+  executePrivateFunction,
   extractCallStack,
   extractPrivateCircuitPublicInputs,
   pickNotes,
@@ -46,6 +55,7 @@ import { createTxForPublicCalls } from '@aztec/simulator/public/fixtures';
 import {
   ExecutionError,
   PublicContractsDB,
+  PublicProcessor,
   type PublicTxResult,
   PublicTxSimulator,
   createSimulationError,
@@ -64,7 +74,7 @@ import { PublicDataWrite } from '@aztec/stdlib/avm';
 import { AztecAddress } from '@aztec/stdlib/aztec-address';
 import type { ContractInstance, ContractInstanceWithAddress } from '@aztec/stdlib/contract';
 import { SimulationError } from '@aztec/stdlib/errors';
-import { Gas, GasFees } from '@aztec/stdlib/gas';
+import { Gas, GasFees, GasSettings } from '@aztec/stdlib/gas';
 import {
   computeNoteHashNonce,
   computePublicDataTreeLeafSlot,
@@ -73,16 +83,23 @@ import {
   siloNullifier,
 } from '@aztec/stdlib/hash';
 import type { MerkleTreeReadOperations, MerkleTreeWriteOperations } from '@aztec/stdlib/interfaces/server';
-import { type KeyValidationRequest, PrivateContextInputs, PublicCallRequest } from '@aztec/stdlib/kernel';
-import { deriveKeys } from '@aztec/stdlib/keys';
 import {
-  ContractClassLog,
-  IndexedTaggingSecret,
-  LogWithTxData,
-  type PrivateLog,
-  type PublicLog,
-} from '@aztec/stdlib/logs';
+  type KeyValidationRequest,
+  PartialPrivateTailPublicInputsForPublic,
+  PartialPrivateTailPublicInputsForRollup,
+  PrivateContextInputs,
+  PrivateKernelTailCircuitPublicInputs,
+  PrivateToPublicAccumulatedData,
+  PrivateToRollupAccumulatedData,
+  PublicCallRequest,
+  RollupValidationRequests,
+  ScopedLogHash,
+} from '@aztec/stdlib/kernel';
+import { deriveKeys } from '@aztec/stdlib/keys';
+import { ContractClassLog, IndexedTaggingSecret, LogWithTxData, PrivateLog, type PublicLog } from '@aztec/stdlib/logs';
+import { ScopedL2ToL1Message } from '@aztec/stdlib/messaging';
 import type { NoteStatus } from '@aztec/stdlib/note';
+import { ClientIvcProof } from '@aztec/stdlib/proofs';
 import type { CircuitWitnessGenerationStats } from '@aztec/stdlib/stats';
 import {
   makeAppendOnlyTreeSnapshot,
@@ -103,9 +120,15 @@ import {
   BlockHeader,
   CallContext,
   GlobalVariables,
+  HashedValues,
+  PrivateExecutionResult,
   PublicCallRequestWithCalldata,
+  Tx,
+  TxConstantData,
+  TxContext,
   TxEffect,
   TxHash,
+  collectNested,
 } from '@aztec/stdlib/tx';
 import { ForkCheckpoint, NativeWorldStateService } from '@aztec/world-state/native';
 
@@ -1267,5 +1290,277 @@ export class TXE implements TypedOracle {
       logIndexInTx,
       txIndexInBlock,
     );
+  }
+
+  async privateCallNewFlow(
+    from: AztecAddress,
+    targetContractAddress: AztecAddress = AztecAddress.zero(),
+    functionSelector: FunctionSelector = FunctionSelector.empty(),
+    args: Fr[],
+    argsHash: Fr = Fr.zero(),
+    isStaticCall: boolean = false,
+  ) {
+    this.logger.verbose(
+      `Executing external function ${await this.getDebugFunctionName(
+        targetContractAddress,
+        functionSelector,
+      )}@${targetContractAddress} isStaticCall=${isStaticCall}`,
+    );
+
+    const artifact = await this.contractDataProvider.getFunctionArtifact(targetContractAddress, functionSelector);
+
+    if (artifact === undefined) {
+      throw new Error('Function Artifact does not exist');
+    }
+
+    const callContext = new CallContext(from, targetContractAddress, functionSelector, isStaticCall);
+
+    const gasLimits = new Gas(DEFAULT_GAS_LIMIT, MAX_L2_GAS_PER_TX_PUBLIC_PORTION);
+
+    const teardownGasLimits = new Gas(DEFAULT_TEARDOWN_GAS_LIMIT, MAX_L2_GAS_PER_TX_PUBLIC_PORTION);
+
+    const gasSettings = new GasSettings(gasLimits, teardownGasLimits, GasFees.empty(), GasFees.empty());
+
+    const txContext = new TxContext(this.CHAIN_ID, this.ROLLUP_VERSION, gasSettings);
+
+    const blockHeader = await this.pxeOracleInterface.getBlockHeader();
+
+    const noteCache = new ExecutionNoteCache(this.getTxRequestHash());
+
+    const context = new PrivateExecutionOracle(
+      argsHash,
+      txContext,
+      callContext,
+      /** Header of a block whose state is used during private execution (not the block the transaction is included in). */
+      blockHeader,
+      /** List of transient auth witnesses to be used during this simulation */
+      [],
+      /** List of transient auth witnesses to be used during this simulation */
+      [],
+      HashedValuesCache.create(),
+      noteCache,
+      this.pxeOracleInterface,
+      this.simulationProvider,
+      0,
+      1,
+    );
+
+    context.storeInExecutionCache(args, argsHash);
+
+    // Note: This is a slight modification of simulator.run without any of the checks. Maybe we should modify simulator.run with a boolean value to skip checks.
+    let result;
+    try {
+      const executionResult = await executePrivateFunction(
+        this.simulationProvider,
+        context,
+        artifact,
+        targetContractAddress,
+        functionSelector,
+      );
+      const { usedTxRequestHashForNonces } = noteCache.finish();
+      const firstNullifierHint = usedTxRequestHashForNonces ? Fr.ZERO : noteCache.getAllNullifiers()[0];
+
+      const publicCallRequests = collectNested([executionResult], r => [
+        ...r.publicInputs.publicCallRequests.map(r => r.inner),
+        r.publicInputs.publicTeardownCallRequest,
+      ]).filter(r => !r.isEmpty());
+      const publicFunctionsCalldata = await Promise.all(
+        publicCallRequests.map(async r => {
+          const calldata = await context.loadFromExecutionCache(r.calldataHash);
+          return new HashedValues(calldata, r.calldataHash);
+        }),
+      );
+
+      result = new PrivateExecutionResult(executionResult, firstNullifierHint, publicFunctionsCalldata);
+    } catch (err) {
+      throw createSimulationError(err instanceof Error ? err : new Error('Unknown error during private execution'));
+    }
+
+    const uniqueNoteHashes: Fr[] = [];
+    const taggedPrivateLogs: PrivateLog[] = [];
+    const nullifiers: Fr[] = result.firstNullifier.equals(Fr.ZERO)
+      ? [this.getTxRequestHash()]
+      : noteCache.getAllNullifiers();
+    const l2ToL1Messages: ScopedL2ToL1Message[] = [];
+    const contractClassLogsHashes: ScopedLogHash[] = [];
+    const publicCallRequests: PublicCallRequest[] = [];
+
+    const nonceGenerator = nullifiers[0];
+
+    let publicTeardownCallRequest;
+
+    let noteHashIndexInTx = 0;
+    const executions = [result.entrypoint];
+    while (executions.length !== 0) {
+      const execution = executions.shift()!;
+      executions.unshift(...execution!.nestedExecutions);
+
+      const { contractAddress } = execution.publicInputs.callContext;
+
+      const noteHashesFromExecution = await Promise.all(
+        execution.publicInputs.noteHashes
+          .filter(noteHash => !noteHash.isEmpty())
+          .map(async noteHash => {
+            const nonce = await computeNoteHashNonce(nonceGenerator, noteHashIndexInTx++);
+            const siloedNoteHash = await siloNoteHash(contractAddress, noteHash.value);
+
+            // We could defer this to the public processor, and pass this in as non-revertible.
+            return computeUniqueNoteHash(nonce, siloedNoteHash);
+          }),
+      );
+
+      const privateLogsFromExecution = await Promise.all(
+        execution.publicInputs.privateLogs
+          .filter(privateLog => !privateLog.isEmpty())
+          .map(async metadata => {
+            metadata.log.fields[0] = await poseidon2Hash([contractAddress, metadata.log.fields[0]]);
+
+            return metadata.log;
+          }),
+      );
+
+      uniqueNoteHashes.push(...noteHashesFromExecution);
+      taggedPrivateLogs.push(...privateLogsFromExecution);
+      l2ToL1Messages.push(
+        ...execution.publicInputs.l2ToL1Msgs
+          .filter(l2ToL1Message => !l2ToL1Message.isEmpty())
+          .map(message => message.scope(contractAddress)),
+      );
+      contractClassLogsHashes.push(
+        ...execution.publicInputs.contractClassLogsHashes
+          .filter(contractClassLogsHash => !contractClassLogsHash.isEmpty())
+          .map(message => message.scope(contractAddress)),
+      );
+      publicCallRequests.push(
+        ...execution.publicInputs.publicCallRequests
+          .filter(publicCallRequest => !publicCallRequest.isEmpty())
+          .map(callRequest => callRequest.inner),
+      );
+
+      if (publicTeardownCallRequest !== undefined && !execution.publicInputs.publicTeardownCallRequest.isEmpty()) {
+        throw new Error('Trying to set multiple teardown requests');
+      }
+
+      publicTeardownCallRequest = execution.publicInputs.publicTeardownCallRequest.isEmpty()
+        ? publicTeardownCallRequest
+        : execution.publicInputs.publicTeardownCallRequest;
+    }
+
+    const globals = makeGlobalVariables();
+    globals.blockNumber = new Fr(this.blockNumber);
+    globals.gasFees = GasFees.empty();
+
+    const contractsDB = new PublicContractsDB(new TXEPublicContractDataSource(this));
+    const simulator = new PublicTxSimulator(this.baseFork, contractsDB, globals, true, true);
+    const processor = new PublicProcessor(globals, this.baseFork, contractsDB, simulator, new TestDateProvider());
+
+    const constantData = new TxConstantData(blockHeader, txContext, Fr.zero(), Fr.zero());
+
+    const hasPublicCalls = result.publicFunctionCalldata.length !== 0;
+    let inputsForRollup;
+    let inputsForPublic;
+
+    // Private only
+    if (result.publicFunctionCalldata.length === 0) {
+      const accumulatedDataForRollup = new PrivateToRollupAccumulatedData(
+        padArrayEnd(uniqueNoteHashes, Fr.ZERO, MAX_NOTE_HASHES_PER_TX),
+        padArrayEnd(nullifiers, Fr.ZERO, MAX_NULLIFIERS_PER_TX),
+        padArrayEnd(l2ToL1Messages, ScopedL2ToL1Message.empty(), MAX_L2_TO_L1_MSGS_PER_TX),
+        padArrayEnd(taggedPrivateLogs, PrivateLog.empty(), MAX_PRIVATE_LOGS_PER_TX),
+        padArrayEnd(contractClassLogsHashes, ScopedLogHash.empty(), MAX_CONTRACT_CLASS_LOGS_PER_TX),
+      );
+
+      inputsForRollup = new PartialPrivateTailPublicInputsForRollup(accumulatedDataForRollup);
+    } else {
+      const accumulatedDataForPublic = new PrivateToPublicAccumulatedData(
+        padArrayEnd(uniqueNoteHashes, Fr.ZERO, MAX_NOTE_HASHES_PER_TX),
+        padArrayEnd(nullifiers, Fr.ZERO, MAX_NULLIFIERS_PER_TX),
+        padArrayEnd(l2ToL1Messages, ScopedL2ToL1Message.empty(), MAX_L2_TO_L1_MSGS_PER_TX),
+        padArrayEnd(taggedPrivateLogs, PrivateLog.empty(), MAX_PRIVATE_LOGS_PER_TX),
+        padArrayEnd(contractClassLogsHashes, ScopedLogHash.empty(), MAX_CONTRACT_CLASS_LOGS_PER_TX),
+        padArrayEnd(publicCallRequests, PublicCallRequest.empty(), MAX_ENQUEUED_CALLS_PER_TX),
+      );
+
+      inputsForPublic = new PartialPrivateTailPublicInputsForPublic(
+        // We are using non-revertible because we set the first nullifier to be used as a nonce generator, otherwise the tx hash is manually calculated.
+        // nonrevertible
+        accumulatedDataForPublic,
+        // revertible
+        PrivateToPublicAccumulatedData.empty(),
+        publicTeardownCallRequest ?? PublicCallRequest.empty(),
+      );
+    }
+
+    const txData = new PrivateKernelTailCircuitPublicInputs(
+      constantData,
+      RollupValidationRequests.empty(),
+      /*gasUsed=*/ new Gas(0, 0),
+      /*feePayer=*/ AztecAddress.zero(),
+      hasPublicCalls ? inputsForPublic : undefined,
+      !hasPublicCalls ? inputsForRollup : undefined,
+    );
+
+    const tx = new Tx(txData, ClientIvcProof.empty(), [], result.publicFunctionCalldata);
+
+    const results = await processor.process([tx]);
+
+    const processedTxs = results[0];
+    const failedTxs = results[1];
+
+    if (failedTxs.length !== 0) {
+      throw new Error('Public execution has failed');
+    }
+
+    const fork = this.baseFork;
+
+    const txEffect = TxEffect.empty();
+
+    txEffect.noteHashes = processedTxs[0]!.txEffect.noteHashes;
+    txEffect.nullifiers = processedTxs[0]!.txEffect.nullifiers;
+    txEffect.privateLogs = taggedPrivateLogs;
+    txEffect.publicLogs = processedTxs[0]!.txEffect.publicLogs;
+    txEffect.publicDataWrites = processedTxs[0]!.txEffect.publicDataWrites;
+
+    txEffect.txHash = new TxHash(new Fr(this.blockNumber));
+
+    const body = new Body([txEffect]);
+
+    const l2Block = new L2Block(
+      makeAppendOnlyTreeSnapshot(this.blockNumber + 1),
+      makeHeader(0, this.blockNumber, this.blockNumber),
+      body,
+    );
+
+    const l1ToL2Messages = Array(NUMBER_OF_L1_L2_MESSAGES_PER_ROLLUP).fill(0).map(Fr.zero);
+    await fork.appendLeaves(MerkleTreeId.L1_TO_L2_MESSAGE_TREE, l1ToL2Messages);
+
+    const stateReference = await fork.getStateReference();
+    const archiveInfo = await fork.getTreeInfo(MerkleTreeId.ARCHIVE);
+
+    const header = new BlockHeader(
+      new AppendOnlyTreeSnapshot(new Fr(archiveInfo.root), Number(archiveInfo.size)),
+      makeContentCommitment(),
+      stateReference,
+      globals,
+      Fr.ZERO,
+      Fr.ZERO,
+    );
+
+    header.globalVariables.blockNumber = new Fr(this.blockNumber);
+
+    l2Block.header = header;
+
+    await fork.updateArchive(l2Block.header);
+
+    await this.stateMachine.handleL2Block(l2Block);
+
+    const txRequestHash = this.getTxRequestHash();
+
+    this.setBlockNumber(this.blockNumber + 1);
+    return {
+      endSideEffectCounter: result.entrypoint.publicInputs.endSideEffectCounter,
+      returnsHash: result.entrypoint.publicInputs.returnsHash,
+      txHash: txRequestHash,
+    };
   }
 }

--- a/yarn-project/txe/src/txe_service/txe_service.ts
+++ b/yarn-project/txe/src/txe_service/txe_service.ts
@@ -827,4 +827,25 @@ export class TXEService {
     const success = (this.typedOracle as TXE).avmOpcodeSuccessCopy();
     return toForeignCallResult([toSingle(new Fr(success))]);
   }
+
+  async privateCallNewFlow(
+    from: ForeignCallSingle,
+    targetContractAddress: ForeignCallSingle,
+    functionSelector: ForeignCallSingle,
+    _argsLength: ForeignCallSingle,
+    args: ForeignCallArray,
+    argsHash: ForeignCallSingle,
+    isStaticCall: ForeignCallSingle,
+  ) {
+    const result = await (this.typedOracle as TXE).privateCallNewFlow(
+      addressFromSingle(from),
+      addressFromSingle(targetContractAddress),
+      FunctionSelector.fromField(fromSingle(functionSelector)),
+      fromArray(args),
+      fromSingle(argsHash),
+      fromSingle(isStaticCall).toBool(),
+    );
+
+    return toForeignCallResult([toArray([result.endSideEffectCounter, result.returnsHash, result.txHash])]);
+  }
 }

--- a/yarn-project/txe/src/txe_service/txe_service.ts
+++ b/yarn-project/txe/src/txe_service/txe_service.ts
@@ -10,7 +10,7 @@ import { PublicDataWrite } from '@aztec/stdlib/avm';
 import { AztecAddress } from '@aztec/stdlib/aztec-address';
 import { computePartialAddress } from '@aztec/stdlib/contract';
 import { SimulationError } from '@aztec/stdlib/errors';
-import { computePublicDataTreeLeafSlot, siloNullifier } from '@aztec/stdlib/hash';
+import { computePublicDataTreeLeafSlot } from '@aztec/stdlib/hash';
 import { LogWithTxData } from '@aztec/stdlib/logs';
 import { MerkleTreeId } from '@aztec/stdlib/trees';
 
@@ -76,9 +76,10 @@ export class TXEService {
 
   async deploy(artifact: ContractArtifact, instance: ContractInstanceWithAddress, secret: ForeignCallSingle) {
     // Emit deployment nullifier
-    (this.typedOracle as TXE).addSiloedNullifiersFromPublic([
-      await siloNullifier(AztecAddress.fromNumber(DEPLOYER_CONTRACT_ADDRESS), instance.address.toField()),
-    ]);
+    await (this.typedOracle as TXE).noteCache.nullifierCreated(
+      AztecAddress.fromNumber(DEPLOYER_CONTRACT_ADDRESS),
+      instance.address.toField(),
+    );
 
     if (!fromSingle(secret).equals(Fr.ZERO)) {
       await this.addAccount(artifact, instance, secret);


### PR DESCRIPTION
This is the first phase of TXe 2.0.

We're adding a new interface for calling private contract functions. This handles external calls, as well as proper public calls.

This leverages the existing `PrivateExecutionContext` as well as the `PublicProcessor` to handle the execution.