### PR TITLE
chore: update p2p loggers

### DIFF
--- a/yarn-project/p2p/src/msg_validators/tx_validator/gas_validator.ts
+++ b/yarn-project/p2p/src/msg_validators/tx_validator/gas_validator.ts
@@ -17,7 +17,7 @@ import {
 } from '@aztec/stdlib/tx';
 
 export class GasTxValidator implements TxValidator<Tx> {
-  #log = createLogger('sequencer:tx_validator:tx_gas');
+  #log = createLogger('p2p:tx_validator:tx_gas');
   #publicDataSource: PublicStateSource;
   #feeJuiceAddress: AztecAddress;
   #gasFees: GasFees;

--- a/yarn-project/p2p/src/msg_validators/tx_validator/phases_validator.ts
+++ b/yarn-project/p2p/src/msg_validators/tx_validator/phases_validator.ts
@@ -13,7 +13,7 @@ import {
 } from '@aztec/stdlib/tx';
 
 export class PhasesTxValidator implements TxValidator<Tx> {
-  #log = createLogger('sequencer:tx_validator:tx_phases');
+  #log = createLogger('p2p:tx_validator:tx_phases');
   private contractsDB: PublicContractsDB;
 
   constructor(contracts: ContractDataSource, private setupAllowList: AllowedElement[], private blockNumber: number) {


### PR DESCRIPTION
update p2p validator loggers to reference `p2p` instead of `sequencer`