### PR TITLE
fix: avoid unnecesary async chunks

### DIFF
--- a/barretenberg/ts/webpack.config.js
+++ b/barretenberg/ts/webpack.config.js
@@ -54,6 +54,7 @@ export default {
     library: {
       type: 'module',
     },
+    asyncChunks: false,
   },
   optimization: {
     minimizer: [
@@ -68,10 +69,6 @@ export default {
         },
       }),
     ],
-    splitChunks: {
-      chunks: 'async',
-    },
-    runtimeChunk: false
   },
   experiments: {
     outputModule: true,


### PR DESCRIPTION
We manually handle all async chunks on bb.js (default wasm and workers), so this PR disables automatic async chunking that provided no size benefits and caused vite to complain about non-analyzable imports downstream
