### PR TITLE
fix: Error enriching after noir changes

### DIFF
--- a/yarn-project/end-to-end/src/e2e_avm_simulator.test.ts
+++ b/yarn-project/end-to-end/src/e2e_avm_simulator.test.ts
@@ -33,11 +33,11 @@ describe('e2e_avm_simulator', () => {
     describe('Assertions & error enriching', () => {
       /**
        * Expect an error like:
-       * Assertion failed: This assertion should fail! 'quote { $self }'
+       * Assertion failed: This assertion should fail! 'not_true == true'
        * ...
+       * at not_true == true (../../../../../../../home/aztec-dev/aztec-packages/noir-projects/noir-contracts/contracts/test/avm_test_contract/src/main.nr:223:16)
+       * at inner_helper_with_failed_assertion() (../../../../../../../home/aztec-dev/aztec-packages/noir-projects/noir-contracts/contracts/test/avm_test_contract/src/main.nr:228:9)
        * at quote { $self } (../std/meta/expr.nr:269:9)
-       * at inner_helper_with_failed_assertion() (../../../../../../../../../home/aztec-dev/aztec-packages/noir-projects/noir-contracts/contracts/test/avm_test_contract/src/main.nr:228:9)
-       * at not_true == true (../../../../../../../../../home/aztec-dev/aztec-packages/noir-projects/noir-contracts/contracts/test/avm_test_contract/src/main.nr:223:16)
        * at function.name();
        * let call = quote { $name($args) (/home/aztec-dev/aztec-packages/noir-projects/aztec-nr/aztec/src/macros/dispatch.nr:59:20)
        * at AvmTest.0xc3515746

--- a/yarn-project/end-to-end/src/e2e_avm_simulator.test.ts
+++ b/yarn-project/end-to-end/src/e2e_avm_simulator.test.ts
@@ -30,11 +30,25 @@ describe('e2e_avm_simulator', () => {
       secondAvmContract = await AvmTestContract.deploy(wallet).send().deployed();
     });
 
-    describe('Assertions', () => {
+    describe('Assertions & error enriching', () => {
+      /**
+       * Expect an error like:
+       * Assertion failed: This assertion should fail! 'quote { $self }'
+       * ...
+       * at quote { $self } (../std/meta/expr.nr:269:9)
+       * at inner_helper_with_failed_assertion() (../../../../../../../../../home/aztec-dev/aztec-packages/noir-projects/noir-contracts/contracts/test/avm_test_contract/src/main.nr:228:9)
+       * at not_true == true (../../../../../../../../../home/aztec-dev/aztec-packages/noir-projects/noir-contracts/contracts/test/avm_test_contract/src/main.nr:223:16)
+       * at function.name();
+       * let call = quote { $name($args) (/home/aztec-dev/aztec-packages/noir-projects/aztec-nr/aztec/src/macros/dispatch.nr:59:20)
+       * at AvmTest.0xc3515746
+       */
       describe('Not nested', () => {
-        it('PXE processes user code assertions and recovers message', async () => {
+        it('PXE processes user code assertions and recovers message (properly enriched)', async () => {
           await expect(avmContract.methods.assertion_failure().simulate()).rejects.toThrow(
-            'Assertion failed: This assertion should fail!',
+            expect.objectContaining({
+              message: expect.stringMatching(/Assertion failed: This assertion should fail! 'not_true == true'/),
+              stack: expect.stringMatching(/at inner_helper_with_failed_assertion[\s\S]*at AvmTest\..*/),
+            }),
           );
         });
         it('PXE processes user code assertions and recovers message (complex)', async () => {

--- a/yarn-project/end-to-end/src/e2e_token_contract/transfer_in_private.test.ts
+++ b/yarn-project/end-to-end/src/e2e_token_contract/transfer_in_private.test.ts
@@ -62,7 +62,12 @@ describe('e2e_token_contract transfer private', () => {
       expect(amount).toBeGreaterThan(0n);
       await expect(
         asset.methods.transfer_in_private(accounts[0].address, accounts[1].address, amount, 1).simulate(),
-      ).rejects.toThrow('Assertion failed: invalid nonce');
+      ).rejects.toThrow(
+        expect.objectContaining({
+          message: expect.stringMatching(/Assertion failed: invalid nonce 'nonce == 0'/),
+          stack: expect.stringMatching(/at nonce == 0[\s\S]*at Token\.transfer_in_private.*/),
+        }),
+      );
     });
 
     it('transfer more than balance on behalf of other', async () => {

--- a/yarn-project/pxe/src/pxe_service/error_enriching.ts
+++ b/yarn-project/pxe/src/pxe_service/error_enriching.ts
@@ -22,10 +22,10 @@ export async function enrichSimulationError(
   const mentionedFunctions: Map<string, Set<FunctionSelector>> = new Map();
 
   err.getCallStack().forEach(({ contractAddress, functionSelector }) => {
+    if (!mentionedFunctions.has(contractAddress.toString())) {
+      mentionedFunctions.set(contractAddress.toString(), new Set());
+    }
     if (functionSelector) {
-      if (!mentionedFunctions.has(contractAddress.toString())) {
-        mentionedFunctions.set(contractAddress.toString(), new Set());
-      }
       mentionedFunctions.get(contractAddress.toString())!.add(functionSelector);
     }
   });

--- a/yarn-project/pxe/src/pxe_service/error_enriching.ts
+++ b/yarn-project/pxe/src/pxe_service/error_enriching.ts
@@ -16,35 +16,45 @@ export async function enrichSimulationError(
   contractDataProvider: ContractDataProvider,
   logger: Logger,
 ) {
-  // Maps contract addresses to the set of function names that were in error.
+  // Maps contract addresses to the set of function selectors that were in error.
   // Map and Set do reference equality for their keys instead of value equality, so we store the string
   // representation to get e.g. different contract address objects with the same address value to match.
-  const mentionedFunctions: Map<string, Set<string>> = new Map();
+  const mentionedFunctions: Map<string, Set<FunctionSelector>> = new Map();
 
-  err.getCallStack().forEach(({ contractAddress, functionName }) => {
-    if (!mentionedFunctions.has(contractAddress.toString())) {
-      mentionedFunctions.set(contractAddress.toString(), new Set());
+  err.getCallStack().forEach(({ contractAddress, functionSelector }) => {
+    if (functionSelector) {
+      if (!mentionedFunctions.has(contractAddress.toString())) {
+        mentionedFunctions.set(contractAddress.toString(), new Set());
+      }
+      mentionedFunctions.get(contractAddress.toString())!.add(functionSelector);
     }
-    mentionedFunctions.get(contractAddress.toString())!.add(functionName?.toString() ?? '');
   });
 
   await Promise.all(
-    [...mentionedFunctions.entries()].map(async ([contractAddress, fnNames]) => {
+    [...mentionedFunctions.entries()].map(async ([contractAddress, fnSelectors]) => {
       const parsedContractAddress = AztecAddress.fromString(contractAddress);
       const contract = await contractDataProvider.getContract(parsedContractAddress);
       if (contract) {
         err.enrichWithContractName(parsedContractAddress, contract.name);
-        for (const fnName of fnNames) {
-          const functionArtifact = contract.functions.find(f => fnName === f.name);
-          if (functionArtifact) {
+        // Map from function selector to function name. It uses a stringified key for the same reason as mentionedFunctions.
+        const selectorToNameMap: Map<string, string> = new Map();
+        await Promise.all(
+          contract.functions.map(async fn => {
+            const selector = await FunctionSelector.fromNameAndParameters(fn);
+            selectorToNameMap.set(selector.toString(), fn.name);
+          }),
+        );
+
+        for (const fnSelector of fnSelectors) {
+          if (selectorToNameMap.has(fnSelector.toString())) {
             err.enrichWithFunctionName(
               parsedContractAddress,
-              await FunctionSelector.fromNameAndParameters(functionArtifact),
-              functionArtifact.name,
+              fnSelector,
+              selectorToNameMap.get(fnSelector.toString())!,
             );
           } else {
             logger.warn(
-              `Could not find function artifact in contract ${contract.name} for function '${fnName}' when enriching error callstack`,
+              `Could not find function artifact in contract ${contract.name} for function '${fnSelector}' when enriching error callstack`,
             );
           }
         }

--- a/yarn-project/pxe/src/pxe_service/error_enriching.ts
+++ b/yarn-project/pxe/src/pxe_service/error_enriching.ts
@@ -85,7 +85,7 @@ export async function enrichPublicSimulationError(
       try {
         // Public functions are simulated as a single Brillig entry point.
         // Thus, we can safely assume here that the Brillig function id is `0`.
-        const parsedCallStack = resolveOpcodeLocations(noirCallStack, debugInfo, 0);
+        const parsedCallStack = resolveOpcodeLocations(noirCallStack, debugInfo.debugSymbols, debugInfo.files, 0);
         err.setNoirCallStack(parsedCallStack);
       } catch (err) {
         logger.warn(

--- a/yarn-project/simulator/src/common/errors.ts
+++ b/yarn-project/simulator/src/common/errors.ts
@@ -97,13 +97,13 @@ export function resolveOpcodeLocations(
 
   // Adds the acir call stack if the last location is a brillig opcode
   if (locations.length > 0) {
-    const runtimeLocations = opcodeLocations[opcodeLocations.length - 1].split('.');
-    if (runtimeLocations.length === 2) {
-      const acirCallstackId = debug.acir_locations[runtimeLocations[0]];
+    const decomposedOpcodeLocation = opcodeLocations[opcodeLocations.length - 1].split('.');
+    if (decomposedOpcodeLocation.length === 2) {
+      const acirCallstackId = debug.acir_locations[decomposedOpcodeLocation[0]];
       if (acirCallstackId !== undefined) {
         const callStack = debug.location_tree.locations[acirCallstackId];
         const acirCallstack = getCallStackFromLocationNode(callStack, debug.location_tree.locations, files);
-        locations = locations.concat(acirCallstack);
+        locations = acirCallstack.concat(locations);
       }
     }
   }

--- a/yarn-project/simulator/src/private/acvm/acvm.ts
+++ b/yarn-project/simulator/src/private/acvm/acvm.ts
@@ -103,7 +103,7 @@ export function extractCallStack(
   }
 
   try {
-    return resolveOpcodeLocations(callStack, debug, brilligFunctionId);
+    return resolveOpcodeLocations(callStack, debug.debugSymbols, debug.files, brilligFunctionId);
   } catch (err) {
     return callStack;
   }

--- a/yarn-project/simulator/src/private/providers/simulation_provider.ts
+++ b/yarn-project/simulator/src/private/providers/simulation_provider.ts
@@ -46,25 +46,23 @@ export type DecodedError = ExecutionError & { decodedAssertionPayload?: any; noi
 // Payload parsing taken from noir/noir-repo/tooling/noir_js/src/witness_generation.ts.
 // TODO: import this in isolation without having to import noir_js in its entirety.
 export function enrichNoirError(artifact: NoirCompiledCircuit, originalError: ExecutionError): DecodedError {
-  const payload = originalError.rawAssertionPayload;
-  if (!payload) {
-    return originalError;
-  }
   const enrichedError = originalError as DecodedError;
 
-  try {
-    // Decode the payload
-    const decodedPayload = abiDecodeError(artifact.abi, payload);
+  if (originalError.rawAssertionPayload) {
+    try {
+      // Decode the payload
+      const decodedPayload = abiDecodeError(artifact.abi, originalError.rawAssertionPayload);
 
-    if (typeof decodedPayload === 'string') {
-      // If it's a string, just add it to the error message
-      enrichedError.message = `Circuit execution failed: ${decodedPayload}`;
-    } else {
-      // If not, attach the payload to the original error
-      enrichedError.decodedAssertionPayload = decodedPayload;
+      if (typeof decodedPayload === 'string') {
+        // If it's a string, just add it to the error message
+        enrichedError.message = `Circuit execution failed: ${decodedPayload}`;
+      } else {
+        // If not, attach the payload to the original error
+        enrichedError.decodedAssertionPayload = decodedPayload;
+      }
+    } catch (_errorDecoding) {
+      // Ignore errors decoding the payload
     }
-  } catch (_errorDecoding) {
-    // Ignore errors decoding the payload
   }
 
   try {

--- a/yarn-project/stdlib/src/abi/abi.ts
+++ b/yarn-project/stdlib/src/abi/abi.ts
@@ -209,12 +209,19 @@ export interface FunctionDebugMetadata {
 
 export const FunctionDebugMetadataSchema = z.object({
   debugSymbols: z.object({
-    locations: z.record(
-      z.array(z.object({ span: z.object({ start: z.number(), end: z.number() }), file: z.number() })),
-    ),
-    brillig_locations: z.record(
-      z.record(z.array(z.object({ span: z.object({ start: z.number(), end: z.number() }), file: z.number() }))),
-    ),
+    location_tree: z.object({
+      locations: z.array(
+        z.object({
+          parent: z.number().nullable(),
+          value: z.object({
+            span: z.object({ start: z.number(), end: z.number() }),
+            file: z.number(),
+          }),
+        }),
+      ),
+    }),
+    acir_locations: z.record(z.number()),
+    brillig_locations: z.record(z.record(z.number())),
   }),
   files: z.record(z.object({ source: z.string(), path: z.string() })),
 }) satisfies z.ZodType<FunctionDebugMetadata>;
@@ -246,10 +253,10 @@ export const FunctionArtifactSchema = FunctionAbiSchema.and(
 ) satisfies ZodFor<FunctionArtifact>;
 
 /** A file ID. It's assigned during compilation. */
-export type FileId = number;
+type FileId = number;
 
 /** A pointer to a specific section of the source code. */
-export interface SourceCodeLocation {
+interface SourceCodeLocation {
   /** The section of the source code. */
   span: {
     /** The byte where the section starts. */
@@ -269,12 +276,22 @@ export type OpcodeLocation = string;
 
 export type BrilligFunctionId = number;
 
-export type OpcodeToLocationsMap = Record<OpcodeLocation, SourceCodeLocation[]>;
+export type OpcodeToLocationsMap = Record<OpcodeLocation, number>;
+
+export type LocationNodeDebugInfo = {
+  parent: number | null;
+  value: SourceCodeLocation;
+};
+
+export type LocationTree = {
+  locations: LocationNodeDebugInfo[];
+};
 
 /** The debug information for a given function. */
 export interface DebugInfo {
   /** A map of the opcode location to the source code location. */
-  locations: OpcodeToLocationsMap;
+  location_tree: LocationTree;
+  acir_locations: OpcodeToLocationsMap;
   /** For each Brillig function, we have a map of the opcode location to the source code location. */
   brillig_locations: Record<BrilligFunctionId, OpcodeToLocationsMap>;
 }


### PR DESCRIPTION
Updates our error enrichment code after the changes in noir to use a locations tree. Partially based on https://github.com/AztecProtocol/aztec-packages/pull/14016