### PR TITLE
fix: Recover from block gaps in archiver

### DIFF
--- a/yarn-project/archiver/src/archiver/archiver.test.ts
+++ b/yarn-project/archiver/src/archiver/archiver.test.ts
@@ -5,7 +5,9 @@ import { DefaultL1ContractsConfig, RollupContract, type ViemPublicClient } from 
 import { EthAddress } from '@aztec/foundation/eth-address';
 import { Fr } from '@aztec/foundation/fields';
 import { type Logger, createLogger } from '@aztec/foundation/log';
+import { retryUntil } from '@aztec/foundation/retry';
 import { sleep } from '@aztec/foundation/sleep';
+import { bufferToHex, withoutHexPrefix } from '@aztec/foundation/string';
 import { openTmpStore } from '@aztec/kv-store/lmdb-v2';
 import { ForwarderAbi, type InboxAbi, RollupAbi } from '@aztec/l1-artifacts';
 import { L2Block } from '@aztec/stdlib/block';
@@ -554,6 +556,86 @@ describe('Archiver', () => {
     // Once epoch is flagged as complete, block number must be 1
     expect(await archiver.getBlockNumber()).toEqual(1);
     expect(await archiver.isEpochComplete(0n)).toBe(true);
+  });
+
+  // Regression for https://github.com/AztecProtocol/aztec-packages/issues/13604
+  it('handles a block gap due to a spurious L2 prune', async () => {
+    expect(await archiver.getBlockNumber()).toEqual(0);
+
+    const rollupTxs = await Promise.all(blocks.map(makeRollupTx));
+    const blobHashes = await Promise.all(blocks.map(makeVersionedBlobHashes));
+    const blobsFromBlocks = await Promise.all(blocks.map(b => makeBlobsFromBlock(b)));
+
+    // Return the corresponding archive roots for the current blocks
+    let currentBlocks = blocks.slice(0, 2);
+    mockRollup.read.archiveAt.mockImplementation((args: readonly [bigint]) => {
+      const block = currentBlocks[Number(args[0] - 1n)];
+      return Promise.resolve(block ? block.archive.root.toString() : Fr.ZERO.toString());
+    });
+
+    // And the corresponding rollup txs
+    publicClient.getTransaction.mockImplementation((args: { hash?: `0x${string}` }) => {
+      const index = parseInt(withoutHexPrefix(args.hash!));
+      if (index > blocks.length) {
+        throw new Error(`Transaction not found: ${args.hash}`);
+      }
+      return Promise.resolve(rollupTxs[index - 1]);
+    });
+
+    // And blobs
+    blobSinkClient.getBlobSidecar.mockImplementation((_blockId: string, requestedBlobHashes?: Buffer[]) => {
+      const blobs = [];
+      for (const requestedBlobHash of requestedBlobHashes!) {
+        for (let i = 0; i < blobHashes.flat().length; i++) {
+          const blobHash = blobHashes.flat()[i];
+          if (blobHash === bufferToHex(requestedBlobHash)) {
+            blobs.push(blobsFromBlocks.flat()[i]);
+          }
+        }
+      }
+      return Promise.resolve(blobs);
+    });
+
+    // Start at L1 block 90, we'll advance this every time we want the archiver to do something
+    publicClient.getBlockNumber.mockResolvedValue(90n);
+
+    // Status first returns the two blocks, only so that it then "forgets" the initial block to add it back later
+    mockRollup.read.status.mockResolvedValue([0n, GENESIS_ROOT, 2n, blocks[1].archive.root.toString(), GENESIS_ROOT]);
+
+    // No messages for this test
+    mockInbox.read.totalMessagesInserted.mockResolvedValue(0n);
+
+    makeL2BlockProposedEvent(70n, 1n, blocks[0].archive.root.toString(), blobHashes[0]);
+    makeL2BlockProposedEvent(80n, 2n, blocks[1].archive.root.toString(), blobHashes[1]);
+
+    // Wait until the archiver gets to the target block
+    await archiver.start(false);
+    await retryUntil(async () => (await archiver.getBlockNumber()) === 2, 'sync', 10, 0.1);
+
+    // And now the rollup contract suddenly forgets about the last block, so the archiver rolls back
+    // This is the spurious prune that the archiver needs to recover from on the next iteration
+    // We presume this happens because of L1 reorgs or more likely faulty L1 RPC providers
+    const ZERO = Fr.ZERO.toString();
+    publicClient.getBlockNumber.mockResolvedValue(95n);
+    mockRollup.read.status.mockResolvedValue([0n, GENESIS_ROOT, 1n, blocks[0].archive.root.toString(), ZERO]);
+    currentBlocks = blocks.slice(0, 1);
+    await retryUntil(async () => (await archiver.getBlockNumber()) === 1, 'prune', 10, 0.1);
+
+    // But it was just a fluke, and the rollup keeps advancing. We even get block 3, which triggers
+    // the archiver's "Rolling back L1 sync point..." handler when trying to insert it with block 2 missing.
+    currentBlocks = blocks.slice(0, 3);
+    publicClient.getBlockNumber.mockResolvedValue(105n);
+    makeL2BlockProposedEvent(100n, 3n, blocks[2].archive.root.toString(), blobHashes[2]);
+    mockRollup.read.status.mockResolvedValue([
+      0n,
+      GENESIS_ROOT,
+      3n,
+      blocks[2].archive.root.toString(),
+      blocks[0].archive.root.toString(),
+    ]);
+
+    // Then the archiver must reprocess the old block to get to the new one
+    await retryUntil(async () => (await archiver.getBlockNumber()) === 3, 'resync', 10, 0.1);
   });
 
   // TODO(palla/reorg): Add a unit test for the archiver handleEpochPrune

--- a/yarn-project/archiver/src/archiver/archiver.ts
+++ b/yarn-project/archiver/src/archiver/archiver.ts
@@ -736,11 +736,11 @@ export class Archiver extends EventEmitter implements ArchiveSource, Traceable {
     if (number < 0) {
       number = await this.store.getSynchedL2BlockNumber();
     }
-    if (number == 0) {
+    if (number === 0) {
       return undefined;
     }
-    const blocks = await this.store.getBlocks(number, 1);
-    return blocks.length === 0 ? undefined : blocks[0].block;
+    const publishedBlock = await this.store.getBlock(number);
+    return publishedBlock?.block;
   }
 
   public async getBlockHeader(number: number | 'latest'): Promise<BlockHeader | undefined> {
@@ -1125,7 +1125,9 @@ class ArchiverStoreHelper
 
     return opResults.every(Boolean);
   }
-
+  getBlock(number: number): Promise<PublishedL2Block | undefined> {
+    return this.store.getBlock(number);
+  }
   getBlocks(from: number, limit: number): Promise<PublishedL2Block[]> {
     return this.store.getBlocks(from, limit);
   }

--- a/yarn-project/archiver/src/archiver/archiver.ts
+++ b/yarn-project/archiver/src/archiver/archiver.ts
@@ -57,7 +57,7 @@ import { type GetContractReturnType, createPublicClient, fallback, getContract, 
 import type { ArchiverDataStore, ArchiverL1SynchPoint } from './archiver_store.js';
 import type { ArchiverConfig } from './config.js';
 import { retrieveBlocksFromRollup, retrieveL1ToL2Messages } from './data_retrieval.js';
-import { NoBlobBodiesFoundError } from './errors.js';
+import { InitialBlockNumberNotSequentialError, NoBlobBodiesFoundError } from './errors.js';
 import { ArchiverInstrumentation } from './instrumentation.js';
 import type { DataRetrieval } from './structs/data_retrieval.js';
 import type { PublishedL2Block } from './structs/published.js';
@@ -552,11 +552,30 @@ export class Archiver extends EventEmitter implements ArchiveSource, Traceable {
         });
       }
 
-      const [processDuration] = await elapsed(() => this.store.addBlocks(retrievedBlocks));
-      this.instrumentation.processNewBlocks(
-        processDuration / retrievedBlocks.length,
-        retrievedBlocks.map(b => b.block),
-      );
+      try {
+        const [processDuration] = await elapsed(() => this.store.addBlocks(retrievedBlocks));
+        this.instrumentation.processNewBlocks(
+          processDuration / retrievedBlocks.length,
+          retrievedBlocks.map(b => b.block),
+        );
+      } catch (err) {
+        if (err instanceof InitialBlockNumberNotSequentialError) {
+          const { previousBlockNumber, newBlockNumber } = err;
+          const previousBlock = previousBlockNumber ? await this.store.getBlock(previousBlockNumber) : undefined;
+          const updatedL1SyncPoint = previousBlock?.l1.blockNumber ?? this.l1constants.l1StartBlock;
+          await this.store.setBlockSynchedL1BlockNumber(updatedL1SyncPoint);
+          this.log.warn(
+            `Attempting to insert block ${newBlockNumber} with previous block ${previousBlockNumber}. Rolling back L1 sync point to ${updatedL1SyncPoint} to try and fetch the missing blocks.`,
+            {
+              previousBlockNumber,
+              previousBlockHash: await previousBlock?.block.hash(),
+              newBlockNumber,
+              updatedL1SyncPoint,
+            },
+          );
+        }
+        throw err;
+      }
 
       for (const block of retrievedBlocks) {
         this.log.info(`Downloaded L2 block ${block.block.number}`, {
@@ -1070,6 +1089,12 @@ class ArchiverStoreHelper
   }
 
   async addBlocks(blocks: PublishedL2Block[]): Promise<boolean> {
+    // TODO(palla/reorg): Run all these ops in a single write transaction
+
+    // Add the blocks to the store. Store will throw if the blocks are not in order, there are gaps,
+    // or if the previous block is not in the store.
+    await this.store.addBlocks(blocks);
+
     const opResults = await Promise.all([
       this.store.addLogs(blocks.map(block => block.block)),
       // Unroll all logs emitted during the retrieved blocks and extract any contract classes and instances from them
@@ -1087,7 +1112,6 @@ class ArchiverStoreHelper
           ])
         ).every(Boolean);
       }),
-      this.store.addBlocks(blocks),
     ]);
 
     return opResults.every(Boolean);
@@ -1096,7 +1120,10 @@ class ArchiverStoreHelper
   async unwindBlocks(from: number, blocksToUnwind: number): Promise<boolean> {
     const last = await this.getSynchedL2BlockNumber();
     if (from != last) {
-      throw new Error(`Can only remove from the tip`);
+      throw new Error(`Cannot unwind blocks from block ${from} when the last block is ${last}`);
+    }
+    if (blocksToUnwind <= 0) {
+      throw new Error(`Cannot unwind ${blocksToUnwind} blocks`);
     }
 
     // from - blocksToUnwind = the new head, so + 1 for what we need to remove

--- a/yarn-project/archiver/src/archiver/archiver.ts
+++ b/yarn-project/archiver/src/archiver/archiver.ts
@@ -182,6 +182,8 @@ export class Archiver extends EventEmitter implements ArchiveSource, Traceable {
       throw new Error('Archiver is already running');
     }
 
+    await this.blobSinkClient.testSources();
+
     if (blockUntilSynced) {
       await this.syncSafe(blockUntilSynced);
     }

--- a/yarn-project/archiver/src/archiver/archiver_store.ts
+++ b/yarn-project/archiver/src/archiver/archiver_store.ts
@@ -51,6 +51,12 @@ export interface ArchiverDataStore {
   unwindBlocks(from: number, blocksToUnwind: number): Promise<boolean>;
 
   /**
+   * Returns the block for the given number, or undefined if not exists.
+   * @param number - The block number to return.
+   */
+  getBlock(number: number): Promise<PublishedL2Block | undefined>;
+
+  /**
    * Gets up to `limit` amount of L2 blocks starting from `from`.
    * @param from - Number of the first block to return (inclusive).
    * @param limit - The number of blocks to return.

--- a/yarn-project/archiver/src/archiver/archiver_store.ts
+++ b/yarn-project/archiver/src/archiver/archiver_store.ts
@@ -37,9 +37,11 @@ export interface ArchiverDataStore {
   /**
    * Append new blocks to the store's list.
    * @param blocks - The L2 blocks to be added to the store and the last processed L1 block.
+   * @param opts - Options for the operation.
+   * @param opts.force - If true, the blocks will be added even if they have gaps.
    * @returns True if the operation is successful.
    */
-  addBlocks(blocks: PublishedL2Block[]): Promise<boolean>;
+  addBlocks(blocks: PublishedL2Block[], opts?: { force?: boolean }): Promise<boolean>;
 
   /**
    * Unwinds blocks from the database

--- a/yarn-project/archiver/src/archiver/archiver_store_test_suite.ts
+++ b/yarn-project/archiver/src/archiver/archiver_store_test_suite.ts
@@ -28,6 +28,7 @@ import '@aztec/stdlib/testing/jest';
 import { TxEffect, TxHash } from '@aztec/stdlib/tx';
 
 import type { ArchiverDataStore, ArchiverL1SynchPoint } from './archiver_store.js';
+import { BlockNumberNotSequentialError, InitialBlockNumberNotSequentialError } from './errors.js';
 import type { PublishedL2Block } from './structs/published.js';
 
 /**
@@ -84,6 +85,18 @@ export function describeArchiverDataStore(
       it('allows duplicate blocks', async () => {
         await store.addBlocks(blocks);
         await expect(store.addBlocks(blocks)).resolves.toBe(true);
+      });
+
+      it('throws an error if the previous block does not exist in the store', async () => {
+        const block = makePublished(await L2Block.random(2), 2);
+        await expect(store.addBlocks([block])).rejects.toThrow(InitialBlockNumberNotSequentialError);
+        await expect(store.getBlocks(1, 10)).resolves.toEqual([]);
+      });
+
+      it('throws an error if there is a gap in the blocks being added', async () => {
+        const blocks = [makePublished(await L2Block.random(1), 1), makePublished(await L2Block.random(3), 3)];
+        await expect(store.addBlocks(blocks)).rejects.toThrow(BlockNumberNotSequentialError);
+        await expect(store.getBlocks(1, 10)).resolves.toEqual([]);
       });
     });
 

--- a/yarn-project/archiver/src/archiver/archiver_store_test_suite.ts
+++ b/yarn-project/archiver/src/archiver/archiver_store_test_suite.ts
@@ -136,6 +136,19 @@ export function describeArchiverDataStore(
       it('throws an error if `from` it is out of range', async () => {
         await expect(store.getBlocks(INITIAL_L2_BLOCK_NUM - 100, 1)).rejects.toThrow('Invalid start: -99');
       });
+
+      it('throws an error if unexpected initial block number is found', async () => {
+        await store.addBlocks([makePublished(await L2Block.random(21), 31)]);
+        await expect(store.getBlocks(20, 1)).rejects.toThrow(`mismatch`);
+      });
+
+      it('throws an error if a gap is found', async () => {
+        await store.addBlocks([
+          makePublished(await L2Block.random(20), 30),
+          makePublished(await L2Block.random(22), 32),
+        ]);
+        await expect(store.getBlocks(20, 2)).rejects.toThrow(`mismatch`);
+      });
     });
 
     describe('getSyncedL2BlockNumber', () => {

--- a/yarn-project/archiver/src/archiver/errors.ts
+++ b/yarn-project/archiver/src/archiver/errors.ts
@@ -3,3 +3,21 @@ export class NoBlobBodiesFoundError extends Error {
     super(`No blob bodies found for block ${l2BlockNum}`);
   }
 }
+
+export class InitialBlockNumberNotSequentialError extends Error {
+  constructor(public readonly newBlockNumber: number, public readonly previousBlockNumber: number | undefined) {
+    super(
+      `Cannot insert new block ${newBlockNumber} given previous block number in store is ${
+        previousBlockNumber ?? 'undefined'
+      }`,
+    );
+  }
+}
+
+export class BlockNumberNotSequentialError extends Error {
+  constructor(newBlockNumber: number, previous: number | undefined) {
+    super(
+      `Cannot insert new block ${newBlockNumber} given previous block number in batch is ${previous ?? 'undefined'}`,
+    );
+  }
+}

--- a/yarn-project/archiver/src/archiver/kv_archiver_store/block_store.ts
+++ b/yarn-project/archiver/src/archiver/kv_archiver_store/block_store.ts
@@ -64,7 +64,7 @@ export class BlockStore {
    * @param blocks - The L2 blocks to be added to the store.
    * @returns True if the operation is successful.
    */
-  async addBlocks(blocks: PublishedL2Block[]): Promise<boolean> {
+  async addBlocks(blocks: PublishedL2Block[], opts: { force?: boolean } = {}): Promise<boolean> {
     if (blocks.length === 0) {
       return true;
     }
@@ -78,14 +78,14 @@ export class BlockStore {
       const hasPreviousBlock =
         firstBlockNumber === INITIAL_L2_BLOCK_NUM ||
         (previousBlockNumber !== undefined && previousBlockNumber === firstBlockNumber - 1);
-      if (!hasPreviousBlock) {
+      if (!opts.force && !hasPreviousBlock) {
         throw new InitialBlockNumberNotSequentialError(firstBlockNumber, previousBlockNumber);
       }
 
       // Iterate over blocks array and insert them, checking that the block numbers are sequential.
       let previousBlock: PublishedL2Block | undefined = undefined;
       for (const block of blocks) {
-        if (previousBlock && previousBlock.block.number + 1 !== block.block.number) {
+        if (!opts.force && previousBlock && previousBlock.block.number + 1 !== block.block.number) {
           throw new BlockNumberNotSequentialError(block.block.number, previousBlock.block.number);
         }
         previousBlock = block;

--- a/yarn-project/archiver/src/archiver/kv_archiver_store/kv_archiver_store.ts
+++ b/yarn-project/archiver/src/archiver/kv_archiver_store/kv_archiver_store.ts
@@ -184,6 +184,10 @@ export class KVArchiverDataStore implements ArchiverDataStore, ContractDataSourc
     return this.#blockStore.unwindBlocks(from, blocksToUnwind);
   }
 
+  getBlock(number: number): Promise<PublishedL2Block | undefined> {
+    return this.#blockStore.getBlock(number);
+  }
+
   /**
    * Gets up to `limit` amount of L2 blocks starting from `from`.
    *

--- a/yarn-project/archiver/src/archiver/kv_archiver_store/kv_archiver_store.ts
+++ b/yarn-project/archiver/src/archiver/kv_archiver_store/kv_archiver_store.ts
@@ -169,8 +169,8 @@ export class KVArchiverDataStore implements ArchiverDataStore, ContractDataSourc
    * @param blocks - The L2 blocks to be added to the store and the last processed L1 block.
    * @returns True if the operation is successful.
    */
-  addBlocks(blocks: PublishedL2Block[]): Promise<boolean> {
-    return this.#blockStore.addBlocks(blocks);
+  addBlocks(blocks: PublishedL2Block[], opts: { force?: boolean } = {}): Promise<boolean> {
+    return this.#blockStore.addBlocks(blocks, opts);
   }
 
   /**

--- a/yarn-project/blob-sink/src/archive/interface.ts
+++ b/yarn-project/blob-sink/src/archive/interface.ts
@@ -4,5 +4,6 @@ import type { BlobJson } from '@aztec/blob-lib';
 export interface BlobArchiveClient {
   getBlobData(id: string): Promise<Buffer | undefined>;
   getBlobsFromBlock(blockId: string): Promise<BlobJson[] | undefined>;
+  getLatestBlock(): Promise<{ hash: string; number: number; slot: number }>;
   getBaseUrl(): string;
 }

--- a/yarn-project/blob-sink/src/client/interface.ts
+++ b/yarn-project/blob-sink/src/client/interface.ts
@@ -3,4 +3,5 @@ import type { Blob } from '@aztec/blob-lib';
 export interface BlobSinkClientInterface {
   sendBlobsToBlobSink(blockId: string, blobs: Blob[]): Promise<boolean>;
   getBlobSidecar(blockId: string, blobHashes: Buffer[], indices?: number[]): Promise<Blob[]>;
+  testSources(): Promise<void>;
 }

--- a/yarn-project/blob-sink/src/client/local.ts
+++ b/yarn-project/blob-sink/src/client/local.ts
@@ -11,6 +11,10 @@ export class LocalBlobSinkClient implements BlobSinkClientInterface {
     this.blobStore = blobStore;
   }
 
+  public testSources(): Promise<void> {
+    return Promise.resolve();
+  }
+
   public async sendBlobsToBlobSink(blockId: string, blobs: Blob[]): Promise<boolean> {
     await this.blobStore.addBlobSidecars(
       blockId,


### PR DESCRIPTION
Merges 3 commits into alpha-testnet:

- [`Test blob sources on archiver startup`](https://github.com/AztecProtocol/aztec-packages/commit/6d19a11c152c06400159ef3b8f230518f04ab220) is a cherry-pick from a commit in #13542 in master.
- [`Throw on gaps in blocks in archiver`](https://github.com/AztecProtocol/aztec-packages/commit/92cf557fc226d5197ea35f36ae3c258febcd396a) causes the archiver to throw on `getBlocks` calls where there are gaps, instead of just returning the next available block. This was masking the world-state syncing errors: a missing block in the archiver would result on the _next_ block being returned, so world state syncing would skip a block and fail. This commit also changes the aztec-node to use `getBlock(number)` from the archiver, instead of `getBlocks(number, limit:1)`.
- [`Recover from block gaps due to spurious L2 reorgs`](https://github.com/AztecProtocol/aztec-packages/commit/185c0299acf546e30357b2a21a319117bc073bc7) makes the archiver check if the previous block exists when adding new ones. If not, it rolls back the L1 syncpoint to the last known block. This should help recover from spurious L2 reorgs where the archiver prunes blocks when it shouldn't have (more info in #13604). Note that [this piece of code](https://github.com/AztecProtocol/aztec-packages/pull/13428/files#diff-ea8c8bb366fc42b03ebd6cf063c8e6aa21328b8887942089086fa958f96a3f85R631-R673) from #13428 should also help, but we have not yet moved L1 reorg code to alpha-testnet, and this change is less intrusive.

Except for the first one, these commits are not yet in master.

Fixes #13604 