### PR TITLE
chore: use aztec structure in place of ivc bench structure everywhere

### DIFF
--- a/barretenberg/cpp/src/barretenberg/api/api_client_ivc.cpp
+++ b/barretenberg/cpp/src/barretenberg/api/api_client_ivc.cpp
@@ -326,7 +326,7 @@ void write_arbitrary_valid_client_ivc_proof_and_vk_to_file(const std::filesystem
     init_bn254_crs(1 << CONST_PG_LOG_N);
     init_grumpkin_crs(1 << CONST_ECCVM_LOG_N);
 
-    ClientIVC ivc{ { CLIENT_IVC_BENCH_STRUCTURE } };
+    ClientIVC ivc{ { AZTEC_TRACE_STRUCTURE } };
 
     // Construct and accumulate a series of mocked private function execution circuits
     PrivateFunctionExecutionMockCircuitProducer circuit_producer;

--- a/barretenberg/cpp/src/barretenberg/benchmark/client_ivc_bench/client_ivc.bench.cpp
+++ b/barretenberg/cpp/src/barretenberg/benchmark/client_ivc_bench/client_ivc.bench.cpp
@@ -33,7 +33,7 @@ class ClientIVCBench : public benchmark::Fixture {
  */
 BENCHMARK_DEFINE_F(ClientIVCBench, Full)(benchmark::State& state)
 {
-    ClientIVC ivc{ { CLIENT_IVC_BENCH_STRUCTURE } };
+    ClientIVC ivc{ { AZTEC_TRACE_STRUCTURE } };
 
     auto total_num_circuits = 2 * static_cast<size_t>(state.range(0)); // 2x accounts for kernel circuits
     auto mocked_vkeys = mock_verification_keys(total_num_circuits);

--- a/barretenberg/cpp/src/barretenberg/benchmark/mega_memory_bench/mega_memory.bench.cpp
+++ b/barretenberg/cpp/src/barretenberg/benchmark/mega_memory_bench/mega_memory.bench.cpp
@@ -318,7 +318,7 @@ void fill_trace(State& state, TraceSettings settings)
 
 void fill_trace_client_ivc_bench(State& state)
 {
-    fill_trace(state, { CLIENT_IVC_BENCH_STRUCTURE });
+    fill_trace(state, { AZTEC_TRACE_STRUCTURE });
 }
 
 void fill_trace_e2e_full_test(State& state)

--- a/barretenberg/cpp/src/barretenberg/client_ivc/client_ivc.test.cpp
+++ b/barretenberg/cpp/src/barretenberg/client_ivc/client_ivc.test.cpp
@@ -395,7 +395,7 @@ TEST(ClientIVCBenchValidation, Full6)
     bb::srs::init_crs_factory(bb::srs::get_ignition_crs_path());
     bb::srs::init_grumpkin_crs_factory(bb::srs::get_grumpkin_crs_path());
 
-    ClientIVC ivc{ { CLIENT_IVC_BENCH_STRUCTURE } };
+    ClientIVC ivc{ { AZTEC_TRACE_STRUCTURE } };
     size_t total_num_circuits{ 12 };
     PrivateFunctionExecutionMockCircuitProducer circuit_producer;
     auto precomputed_vkeys = circuit_producer.precompute_verification_keys(total_num_circuits, ivc.trace_settings);
@@ -414,7 +414,7 @@ TEST(ClientIVCBenchValidation, Full6MockedVKs)
         bb::srs::init_crs_factory(bb::srs::get_ignition_crs_path());
         bb::srs::init_grumpkin_crs_factory(bb::srs::get_grumpkin_crs_path());
 
-        ClientIVC ivc{ { CLIENT_IVC_BENCH_STRUCTURE } };
+        ClientIVC ivc{ { AZTEC_TRACE_STRUCTURE } };
         size_t total_num_circuits{ 12 };
         PrivateFunctionExecutionMockCircuitProducer circuit_producer;
         auto mocked_vkeys = mock_verification_keys(total_num_circuits);
@@ -430,7 +430,7 @@ TEST(ClientIVCKernelCapacity, MaxCapacityPassing)
     bb::srs::init_crs_factory(bb::srs::get_ignition_crs_path());
     bb::srs::init_grumpkin_crs_factory(bb::srs::get_grumpkin_crs_path());
 
-    ClientIVC ivc{ { CLIENT_IVC_BENCH_STRUCTURE } };
+    ClientIVC ivc{ { AZTEC_TRACE_STRUCTURE } };
     const size_t total_num_circuits{ 2 * MAX_NUM_KERNELS };
     PrivateFunctionExecutionMockCircuitProducer circuit_producer;
     auto precomputed_vkeys = circuit_producer.precompute_verification_keys(total_num_circuits, ivc.trace_settings);
@@ -445,7 +445,7 @@ TEST(ClientIVCKernelCapacity, MaxCapacityFailing)
     bb::srs::init_crs_factory(bb::srs::get_ignition_crs_path());
     bb::srs::init_grumpkin_crs_factory(bb::srs::get_grumpkin_crs_path());
 
-    ClientIVC ivc{ { CLIENT_IVC_BENCH_STRUCTURE } };
+    ClientIVC ivc{ { AZTEC_TRACE_STRUCTURE } };
     const size_t total_num_circuits{ 2 * (MAX_NUM_KERNELS + 1) };
     PrivateFunctionExecutionMockCircuitProducer circuit_producer;
     auto precomputed_vkeys = circuit_producer.precompute_verification_keys(total_num_circuits, ivc.trace_settings);

--- a/barretenberg/cpp/src/barretenberg/client_ivc/client_ivc_integration.test.cpp
+++ b/barretenberg/cpp/src/barretenberg/client_ivc/client_ivc_integration.test.cpp
@@ -36,7 +36,7 @@ class ClientIVCIntegrationTests : public ::testing::Test {
  */
 TEST_F(ClientIVCIntegrationTests, BenchmarkCaseSimple)
 {
-    ClientIVC ivc{ { CLIENT_IVC_BENCH_STRUCTURE } };
+    ClientIVC ivc{ { AZTEC_TRACE_STRUCTURE } };
 
     MockCircuitProducer circuit_producer;
 
@@ -59,7 +59,7 @@ TEST_F(ClientIVCIntegrationTests, BenchmarkCaseSimple)
  */
 TEST_F(ClientIVCIntegrationTests, ConsecutiveKernels)
 {
-    ClientIVC ivc{ { CLIENT_IVC_BENCH_STRUCTURE } };
+    ClientIVC ivc{ { AZTEC_TRACE_STRUCTURE } };
 
     MockCircuitProducer circuit_producer;
 
@@ -86,7 +86,7 @@ TEST_F(ClientIVCIntegrationTests, ConsecutiveKernels)
  */
 TEST_F(ClientIVCIntegrationTests, BenchmarkCasePrecomputedVKs)
 {
-    ClientIVC ivc{ { CLIENT_IVC_BENCH_STRUCTURE } };
+    ClientIVC ivc{ { AZTEC_TRACE_STRUCTURE } };
 
     size_t NUM_CIRCUITS = 6;
 
@@ -119,7 +119,7 @@ TEST_F(ClientIVCIntegrationTests, BenchmarkCasePrecomputedVKs)
  */
 TEST_F(ClientIVCIntegrationTests, DatabusFailure)
 {
-    ClientIVC ivc{ { CLIENT_IVC_BENCH_STRUCTURE } };
+    ClientIVC ivc{ { AZTEC_TRACE_STRUCTURE } };
 
     MockCircuitProducer circuit_producer;
 

--- a/barretenberg/cpp/src/barretenberg/client_ivc/mock_kernel_pinning.test.cpp
+++ b/barretenberg/cpp/src/barretenberg/client_ivc/mock_kernel_pinning.test.cpp
@@ -23,7 +23,7 @@ class MockKernelTest : public ::testing::Test {
 
 TEST_F(MockKernelTest, PinFoldingKernelSizes)
 {
-    ClientIVC ivc{ { CLIENT_IVC_BENCH_STRUCTURE } };
+    ClientIVC ivc{ { AZTEC_TRACE_STRUCTURE } };
 
     MockCircuitProducer circuit_producer;
 
@@ -33,8 +33,8 @@ TEST_F(MockKernelTest, PinFoldingKernelSizes)
         Builder circuit = circuit_producer.create_next_circuit(ivc);
 
         ivc.accumulate(circuit);
-        EXPECT_FALSE(circuit.blocks.has_overflow); // trace oveflow mechanism should not be triggered
+        EXPECT_TRUE(circuit.blocks.has_overflow); // trace oveflow mechanism should not be triggered
     }
 
-    EXPECT_EQ(ivc.fold_output.accumulator->proving_key.log_circuit_size, 19);
+    EXPECT_EQ(ivc.fold_output.accumulator->proving_key.log_circuit_size, 20);
 }

--- a/barretenberg/cpp/src/barretenberg/client_ivc/mock_kernel_pinning.test.cpp
+++ b/barretenberg/cpp/src/barretenberg/client_ivc/mock_kernel_pinning.test.cpp
@@ -33,7 +33,7 @@ TEST_F(MockKernelTest, PinFoldingKernelSizes)
         Builder circuit = circuit_producer.create_next_circuit(ivc);
 
         ivc.accumulate(circuit);
-        EXPECT_TRUE(circuit.blocks.has_overflow); // trace oveflow mechanism should not be triggered
+        EXPECT_TRUE(circuit.blocks.has_overflow); // trace overflow mechanism should be triggered
     }
 
     EXPECT_EQ(ivc.fold_output.accumulator->proving_key.log_circuit_size, 20);

--- a/barretenberg/cpp/src/barretenberg/goblin/mock_circuits_pinning.test.cpp
+++ b/barretenberg/cpp/src/barretenberg/goblin/mock_circuits_pinning.test.cpp
@@ -69,7 +69,7 @@ TEST_F(MegaMockCircuitsPinning, ClientIVCBenchStructuredCircuitSize)
     Goblin goblin;
     MegaCircuitBuilder app_circuit{ goblin.op_queue };
     GoblinMockCircuits::PairingPoints::add_default_to_public_inputs(app_circuit);
-    TraceSettings trace_settings{ CLIENT_IVC_BENCH_STRUCTURE };
+    TraceSettings trace_settings{ AZTEC_TRACE_STRUCTURE };
     auto proving_key = std::make_shared<DeciderProvingKey>(app_circuit, trace_settings);
     EXPECT_EQ(proving_key->proving_key.log_circuit_size, 19);
 }

--- a/barretenberg/cpp/src/barretenberg/goblin/mock_circuits_pinning.test.cpp
+++ b/barretenberg/cpp/src/barretenberg/goblin/mock_circuits_pinning.test.cpp
@@ -64,17 +64,7 @@ TEST_F(MegaMockCircuitsPinning, SmallTestStructuredCircuitSize)
     EXPECT_EQ(proving_key->proving_key.log_circuit_size, 18);
 }
 
-TEST_F(MegaMockCircuitsPinning, ClientIVCBenchStructuredCircuitSize)
-{
-    Goblin goblin;
-    MegaCircuitBuilder app_circuit{ goblin.op_queue };
-    GoblinMockCircuits::PairingPoints::add_default_to_public_inputs(app_circuit);
-    TraceSettings trace_settings{ AZTEC_TRACE_STRUCTURE };
-    auto proving_key = std::make_shared<DeciderProvingKey>(app_circuit, trace_settings);
-    EXPECT_EQ(proving_key->proving_key.log_circuit_size, 19);
-}
-
-TEST_F(MegaMockCircuitsPinning, E2EStructuredCircuitSize)
+TEST_F(MegaMockCircuitsPinning, AztecStructuredCircuitSize)
 {
     Goblin goblin;
     MegaCircuitBuilder app_circuit{ goblin.op_queue };

--- a/barretenberg/cpp/src/barretenberg/plonk_honk_shared/execution_trace/mega_execution_trace.hpp
+++ b/barretenberg/cpp/src/barretenberg/plonk_honk_shared/execution_trace/mega_execution_trace.hpp
@@ -288,22 +288,6 @@ static constexpr TraceStructure SMALL_TEST_STRUCTURE{ .ecc_op = 1 << 14,
                                                       .overflow = 0 };
 
 /**
- * @brief A minimal structuring specifically tailored to the medium complexity transaction of the Client IVC
- * benchmark.
- */
-static constexpr TraceStructure CLIENT_IVC_BENCH_STRUCTURE{ .ecc_op = 1 << 10,
-                                                            .busread = 1 << 7,
-                                                            .lookup = 72000,
-                                                            .pub_inputs = 1 << 7,
-                                                            .arithmetic = 170000,
-                                                            .delta_range = 90000,
-                                                            .elliptic = 9000,
-                                                            .aux = 136000,
-                                                            .poseidon2_external = 5000,
-                                                            .poseidon2_internal = 25000,
-                                                            .overflow = 0 };
-
-/**
  * @brief An example structuring of size 2^18.
  */
 static constexpr TraceStructure EXAMPLE_18{ .ecc_op = 1 << 10,

--- a/barretenberg/cpp/src/barretenberg/stdlib/client_ivc_verifier/client_ivc_recursive_verifier.test.cpp
+++ b/barretenberg/cpp/src/barretenberg/stdlib/client_ivc_verifier/client_ivc_recursive_verifier.test.cpp
@@ -19,7 +19,7 @@ class ClientIVCRecursionTests : public testing::Test {
     using IVCVerificationKey = ClientIVC::VerificationKey;
     using PairingAccumulator = PairingPoints<Builder>;
 
-    static constexpr TraceSettings trace_settings{ CLIENT_IVC_BENCH_STRUCTURE };
+    static constexpr TraceSettings trace_settings{ AZTEC_TRACE_STRUCTURE };
 
     static void SetUpTestSuite()
     {


### PR DESCRIPTION
Replace the old `CLIENT_IVC_BENCH_STRUCTURE` with `AZTEC_TRACE_STRUCTURE`. There's no longer benefit in maintaining a separate benchmarking trace structure now that we're settling into a single genuine structure for Aztec. 

Note: this will negatively effect the nominal Full6 bench but results in performance that is more realistic.