### PR TITLE
feat: Add manual rollback command to node admin API

### DIFF
--- a/yarn-project/archiver/src/archiver/archiver_store.ts
+++ b/yarn-project/archiver/src/archiver/archiver_store.ts
@@ -250,4 +250,10 @@ export interface ArchiverDataStore {
 
   /** Closes the underlying data store. */
   close(): Promise<void>;
+
+  /** Deletes all L1 to L2 messages up until (excluding) the target L2 block number. */
+  rollbackL1ToL2MessagesToL2Block(
+    targetBlockNumber: number | bigint,
+    currentBlockNumber: number | bigint,
+  ): Promise<void>;
 }

--- a/yarn-project/archiver/src/archiver/archiver_store_test_suite.ts
+++ b/yarn-project/archiver/src/archiver/archiver_store_test_suite.ts
@@ -309,6 +309,26 @@ export function describeArchiverDataStore(
           await store.getL1ToL2Messages(l2BlockNumber);
         }).rejects.toThrow(`L1 to L2 message gap found in block ${l2BlockNumber}`);
       });
+
+      it('removes messages up to the given block number', async () => {
+        for (let blockNum = 1n; blockNum < 5n; blockNum++) {
+          await store.addL1ToL2Messages({
+            lastProcessedL1BlockNumber: blockNum,
+            retrievedData: generateBlockMessages(blockNum, l1ToL2MessageSubtreeSize),
+          });
+        }
+
+        for (let blockNum = 1n; blockNum < 5n; blockNum++) {
+          expect(await store.getL1ToL2Messages(blockNum)).toHaveLength(l1ToL2MessageSubtreeSize);
+        }
+
+        await store.rollbackL1ToL2MessagesToL2Block(2n, 4n);
+
+        expect(await store.getL1ToL2Messages(1n)).toHaveLength(l1ToL2MessageSubtreeSize);
+        expect(await store.getL1ToL2Messages(2n)).toHaveLength(l1ToL2MessageSubtreeSize);
+        expect(await store.getL1ToL2Messages(3n)).toHaveLength(0);
+        expect(await store.getL1ToL2Messages(4n)).toHaveLength(0);
+      });
     });
 
     describe('contractInstances', () => {

--- a/yarn-project/archiver/src/archiver/kv_archiver_store/kv_archiver_store.ts
+++ b/yarn-project/archiver/src/archiver/kv_archiver_store/kv_archiver_store.ts
@@ -359,4 +359,11 @@ export class KVArchiverDataStore implements ArchiverDataStore, ContractDataSourc
   public estimateSize(): Promise<StoreSize> {
     return this.db.estimateSize();
   }
+
+  public rollbackL1ToL2MessagesToL2Block(
+    targetBlockNumber: number | bigint,
+    currentBlock: number | bigint,
+  ): Promise<void> {
+    return this.#messageStore.rollbackL1ToL2MessagesToL2Block(BigInt(targetBlockNumber), BigInt(currentBlock));
+  }
 }

--- a/yarn-project/aztec-node/src/aztec-node/server.ts
+++ b/yarn-project/aztec-node/src/aztec-node/server.ts
@@ -16,6 +16,7 @@ import { EthAddress } from '@aztec/foundation/eth-address';
 import { Fr } from '@aztec/foundation/fields';
 import { type Logger, createLogger } from '@aztec/foundation/log';
 import { SerialQueue } from '@aztec/foundation/queue';
+import { count } from '@aztec/foundation/string';
 import { DateProvider, Timer } from '@aztec/foundation/timer';
 import { SiblingPath } from '@aztec/foundation/trees';
 import type { AztecKVStore } from '@aztec/kv-store';
@@ -1063,6 +1064,55 @@ export class AztecNodeService implements AztecNode, AztecNodeAdmin, Traceable {
         this.log.error(`Error uploading snapshot: ${err}`);
       });
 
+    return Promise.resolve();
+  }
+
+  public async rollbackTo(targetBlock: number, force?: boolean): Promise<void> {
+    const archiver = this.blockSource as Archiver;
+    if (!('rollbackTo' in archiver)) {
+      throw new Error('Archiver implementation does not support rollbacks.');
+    }
+
+    const finalizedBlock = await archiver.getL2Tips().then(tips => tips.finalized.number);
+    if (targetBlock < finalizedBlock) {
+      if (force) {
+        this.log.warn(`Clearing world state database to allow rolling back behind finalized block ${finalizedBlock}`);
+        await this.worldStateSynchronizer.clear();
+        await this.p2pClient.clear();
+      } else {
+        throw new Error(`Cannot rollback to block ${targetBlock} as it is before finalized ${finalizedBlock}`);
+      }
+    }
+
+    try {
+      this.log.info(`Pausing archiver and world state sync to start rollback`);
+      await archiver.stop();
+      await this.worldStateSynchronizer.stopSync();
+      const currentBlock = await archiver.getBlockNumber();
+      const blocksToUnwind = currentBlock - targetBlock;
+      this.log.info(`Unwinding ${count(blocksToUnwind, 'block')} from L2 block ${currentBlock} to ${targetBlock}`);
+      await archiver.rollbackTo(targetBlock);
+      this.log.info(`Unwinding complete.`);
+    } catch (err) {
+      this.log.error(`Error during rollback`, err);
+      throw err;
+    } finally {
+      this.log.info(`Resuming world state and archiver sync.`);
+      this.worldStateSynchronizer.resumeSync();
+      archiver.resume();
+    }
+  }
+
+  public async pauseSync(): Promise<void> {
+    this.log.info(`Pausing archiver and world state sync`);
+    await (this.blockSource as Archiver).stop();
+    await this.worldStateSynchronizer.stopSync();
+  }
+
+  public resumeSync(): Promise<void> {
+    this.log.info(`Resuming world state and archiver sync.`);
+    this.worldStateSynchronizer.resumeSync();
+    (this.blockSource as Archiver).resume();
     return Promise.resolve();
   }
 

--- a/yarn-project/end-to-end/bootstrap.sh
+++ b/yarn-project/end-to-end/bootstrap.sh
@@ -54,6 +54,7 @@ function test_cmds {
   echo "$prefix simple e2e_double_spend"
   echo "$prefix simple e2e_epochs/epochs_empty_blocks"
   echo "$prefix simple e2e_epochs/epochs_long_proving_time"
+  echo "$prefix simple e2e_epochs/epochs_manual_rollback"
   echo "$prefix simple e2e_epochs/epochs_multi_proof"
   echo "$prefix simple e2e_epochs/epochs_proof_fails"
   echo "$prefix simple e2e_epochs/epochs_sync_after_reorg"

--- a/yarn-project/end-to-end/src/e2e_epochs/epochs_manual_rollback.test.ts
+++ b/yarn-project/end-to-end/src/e2e_epochs/epochs_manual_rollback.test.ts
@@ -1,0 +1,57 @@
+import { type AztecNode, type Logger, retryUntil } from '@aztec/aztec.js';
+import type { RollupContract } from '@aztec/ethereum';
+
+import { jest } from '@jest/globals';
+
+import type { EndToEndContext } from '../fixtures/utils.js';
+import { EpochsTestContext, type EpochsTestOpts } from './epochs_test.js';
+
+jest.setTimeout(1000 * 60 * 10);
+
+describe('e2e_epochs/manual_rollback', () => {
+  let context: EndToEndContext;
+  let logger: Logger;
+  let node: AztecNode;
+  let rollup: RollupContract;
+
+  let test: EpochsTestContext;
+
+  const setup = async (opts: Partial<EpochsTestOpts> = {}) => {
+    test = await EpochsTestContext.setup({ ...opts, txPropagationMaxQueryAttempts: 1 });
+    ({ context, logger, rollup } = test);
+    ({ aztecNode: node } = context);
+  };
+
+  afterEach(async () => {
+    jest.restoreAllMocks();
+    await test.teardown();
+  });
+
+  describe('to unfinalized block', () => {
+    beforeEach(async () => {
+      await setup({ aztecEpochDuration: 100 }); // No L2 reorgs, no finalized blocks
+    });
+
+    it('manually rolls back', async () => {
+      logger.info(`Starting manual rollback test to unfinalized block`);
+      await context.sequencer?.updateSequencerConfig({ minTxsPerBlock: 0 });
+      await test.waitUntilL2BlockNumber(4, 60);
+      await retryUntil(async () => await node.getBlockNumber().then(b => b >= 4), 'sync to 4', 10, 0.1);
+
+      logger.info(`Synced to block 4. Pausing syncing and rolling back the chain.`);
+      await context.aztecNodeAdmin!.pauseSync();
+      await context.sequencer?.updateSequencerConfig({ minTxsPerBlock: 100 }); // Ensure no new blocks are produced
+      await context.cheatCodes.eth.reorg(2);
+      const blockAfterReorg = Number(await rollup.getBlockNumber());
+      expect(blockAfterReorg).toBeLessThan(4);
+      logger.info(`Rolled back to L2 block ${blockAfterReorg}.`);
+
+      logger.info(`Manually rolling back node to ${blockAfterReorg - 1}.`);
+      await context.aztecNodeAdmin!.rollbackTo(blockAfterReorg - 1);
+      expect(await node.getBlockNumber()).toEqual(blockAfterReorg - 1);
+
+      logger.info(`Waiting for node to re-sync to ${blockAfterReorg}.`);
+      await retryUntil(async () => await node.getBlockNumber().then(b => b >= blockAfterReorg), 'resync', 10, 0.1);
+    });
+  });
+});

--- a/yarn-project/end-to-end/src/e2e_epochs/epochs_test.ts
+++ b/yarn-project/end-to-end/src/e2e_epochs/epochs_test.ts
@@ -32,7 +32,12 @@ export const ARCHIVER_POLL_INTERVAL = 50;
 export type EpochsTestOpts = Partial<
   Pick<
     SetupOptions,
-    'startProverNode' | 'aztecProofSubmissionWindow' | 'aztecEpochDuration' | 'proverTestDelayMs' | 'proverNodeConfig'
+    | 'startProverNode'
+    | 'aztecProofSubmissionWindow'
+    | 'aztecEpochDuration'
+    | 'proverTestDelayMs'
+    | 'proverNodeConfig'
+    | 'txPropagationMaxQueryAttempts'
   >
 >;
 
@@ -86,7 +91,7 @@ export class EpochsTestContext {
       proverId: Fr.fromString('1'),
       // This must be enough so that the tx from the prover is delayed properly,
       // but not so much to hang the sequencer and timeout the teardown
-      txPropagationMaxQueryAttempts: 12,
+      txPropagationMaxQueryAttempts: opts.txPropagationMaxQueryAttempts ?? 12,
       worldStateBlockHistory: WORLD_STATE_BLOCK_HISTORY,
       ...opts,
     });

--- a/yarn-project/p2p/src/client/p2p_client.ts
+++ b/yarn-project/p2p/src/client/p2p_client.ts
@@ -190,6 +190,9 @@ export type P2P<T extends P2PClientType = P2PClientType.Full> = P2PApi<T> & {
 
   /** Identifies a p2p client. */
   isP2PClient(): true;
+
+  /** Clears the p2p db. */
+  clear(): Promise<void>;
 };
 
 /**
@@ -234,7 +237,7 @@ export class P2PClient<T extends P2PClientType = P2PClientType.Full>
    */
   constructor(
     _clientType: T,
-    store: AztecAsyncKVStore,
+    private store: AztecAsyncKVStore,
     private l2BlockSource: L2BlockSource & ContractDataSource,
     mempools: MemPools<T>,
     private p2pService: P2PService,
@@ -265,6 +268,10 @@ export class P2PClient<T extends P2PClientType = P2PClientType.Full>
 
     this.txPool = mempools.txPool;
     this.attestationPool = mempools.attestationPool!;
+  }
+
+  public clear(): Promise<void> {
+    return this.store.clear();
   }
 
   public isP2PClient(): true {

--- a/yarn-project/stdlib/src/interfaces/aztec-node-admin.test.ts
+++ b/yarn-project/stdlib/src/interfaces/aztec-node-admin.test.ts
@@ -37,6 +37,18 @@ describe('AztecNodeAdminApiSchema', () => {
   it('startSnapshotUpload', async () => {
     await context.client.startSnapshotUpload('foo');
   });
+
+  it('rollbackTo', async () => {
+    await context.client.rollbackTo(123);
+  });
+
+  it('pauseSync', async () => {
+    await context.client.pauseSync();
+  });
+
+  it('resumeSync', async () => {
+    await context.client.resumeSync();
+  });
 });
 
 class MockAztecNodeAdmin implements AztecNodeAdmin {
@@ -49,6 +61,15 @@ class MockAztecNodeAdmin implements AztecNodeAdmin {
     return Promise.resolve();
   }
   startSnapshotUpload(_location: string): Promise<void> {
+    return Promise.resolve();
+  }
+  rollbackTo(_targetBlockNumber: number): Promise<void> {
+    return Promise.resolve();
+  }
+  pauseSync(): Promise<void> {
+    return Promise.resolve();
+  }
+  resumeSync(): Promise<void> {
     return Promise.resolve();
   }
 }

--- a/yarn-project/stdlib/src/interfaces/aztec-node-admin.ts
+++ b/yarn-project/stdlib/src/interfaces/aztec-node-admin.ts
@@ -28,12 +28,28 @@ export interface AztecNodeAdmin {
    * @param location - The location to upload the snapshot to.
    */
   startSnapshotUpload(location: string): Promise<void>;
+
+  /**
+   * Pauses syncing and rolls back the database to the target L2 block number.
+   * @param targetBlockNumber - The block number to roll back to.
+   * @param force - If true, clears the world state db and p2p dbs if rolling back to behind the finalized block.
+   */
+  rollbackTo(targetBlockNumber: number, force?: boolean): Promise<void>;
+
+  /** Pauses archiver and world state syncing. */
+  pauseSync(): Promise<void>;
+
+  /** Resumes archiver and world state syncing. */
+  resumeSync(): Promise<void>;
 }
 
 export const AztecNodeAdminApiSchema: ApiSchemaFor<AztecNodeAdmin> = {
   setConfig: z.function().args(SequencerConfigSchema.merge(ProverConfigSchema).partial()).returns(z.void()),
   flushTxs: z.function().returns(z.void()),
   startSnapshotUpload: z.function().args(z.string()).returns(z.void()),
+  rollbackTo: z.function().args(z.number()).returns(z.void()),
+  pauseSync: z.function().returns(z.void()),
+  resumeSync: z.function().returns(z.void()),
 };
 
 export function createAztecNodeAdminClient(

--- a/yarn-project/stdlib/src/interfaces/world_state.ts
+++ b/yarn-project/stdlib/src/interfaces/world_state.ts
@@ -76,6 +76,9 @@ export interface WorldStateSynchronizer extends ForkMerkleTreeOperations {
 
   /** Returns an instance of MerkleTreeAdminOperations that will not include uncommitted data. */
   getCommitted(): MerkleTreeReadOperations;
+
+  /** Deletes the db */
+  clear(): Promise<void>;
 }
 
 export const WorldStateSyncStatusSchema = z.object({

--- a/yarn-project/world-state/src/native/native_world_state.test.ts
+++ b/yarn-project/world-state/src/native/native_world_state.test.ts
@@ -223,6 +223,24 @@ describe('NativeWorldState', () => {
         'World state trees are out of sync',
       );
     });
+
+    it('manually clears the database', async () => {
+      const ws = await NativeWorldStateService.new(EthAddress.random(), dataDir, defaultDBMapSize);
+      const initialStatus = await ws.getStatusSummary();
+      expect(initialStatus.unfinalisedBlockNumber).toBe(0n);
+
+      // Populate the db
+      const fork = await ws.fork();
+      ({ block, messages } = await mockBlock(1, 2, fork));
+      await fork.close();
+      const status = await ws.handleL2BlockAndMessages(block, messages);
+      expect(status.summary.unfinalisedBlockNumber).toBe(1n);
+
+      // Clear it
+      await ws.clear();
+      const emptyStatus = await ws.getStatusSummary();
+      expect(emptyStatus.unfinalisedBlockNumber).toBe(0n);
+    });
   });
 
   describe('Forks', () => {

--- a/yarn-project/world-state/src/native/native_world_state.ts
+++ b/yarn-project/world-state/src/native/native_world_state.ts
@@ -2,6 +2,7 @@ import { MAX_NOTE_HASHES_PER_TX, MAX_NULLIFIERS_PER_TX, NUMBER_OF_L1_L2_MESSAGES
 import { fromEntries, padArrayEnd } from '@aztec/foundation/collection';
 import { EthAddress } from '@aztec/foundation/eth-address';
 import { Fr } from '@aztec/foundation/fields';
+import { tryRmDir } from '@aztec/foundation/fs';
 import { type Logger, createLogger } from '@aztec/foundation/log';
 import type { L2Block } from '@aztec/stdlib/block';
 import { DatabaseVersionManager } from '@aztec/stdlib/database-version';
@@ -47,7 +48,7 @@ export class NativeWorldStateService implements MerkleTreeDatabase {
   private cachedStatusSummary: WorldStateStatusSummary | undefined;
 
   protected constructor(
-    protected readonly instance: NativeWorldState,
+    protected instance: NativeWorldState,
     protected readonly worldStateInstrumentation: WorldStateInstrumentation,
     protected readonly log: Logger = createLogger('world-state:database'),
     private readonly cleanup = () => Promise.resolve(),
@@ -128,6 +129,13 @@ export class NativeWorldStateService implements MerkleTreeDatabase {
     const indices = await committed.findLeafIndices(MerkleTreeId.ARCHIVE, [await this.initialHeader.hash()]);
     const initialHeaderIndex = indices[0];
     assert.strictEqual(initialHeaderIndex, 0n, 'Invalid initial archive state');
+  }
+
+  public async clear() {
+    await this.instance.close();
+    this.cachedStatusSummary = undefined;
+    await tryRmDir(this.instance.getDataDir(), this.log);
+    this.instance = this.instance.clone();
   }
 
   public getCommitted(): MerkleTreeReadOperations {

--- a/yarn-project/world-state/src/native/native_world_state_instance.ts
+++ b/yarn-project/world-state/src/native/native_world_state_instance.ts
@@ -50,11 +50,11 @@ export class NativeWorldState implements NativeWorldStateInstance {
 
   /** Creates a new native WorldState instance */
   constructor(
-    dataDir: string,
-    dbMapSizeKb: number,
-    prefilledPublicData: PublicDataTreeLeaf[] = [],
-    private instrumentation: WorldStateInstrumentation,
-    private log: Logger = createLogger('world-state:database'),
+    private readonly dataDir: string,
+    private readonly dbMapSizeKb: number,
+    private readonly prefilledPublicData: PublicDataTreeLeaf[] = [],
+    private readonly instrumentation: WorldStateInstrumentation,
+    private readonly log: Logger = createLogger('world-state:database'),
   ) {
     const threads = Math.min(cpus().length, MAX_WORLD_STATE_THREADS);
     log.info(
@@ -82,6 +82,20 @@ export class NativeWorldState implements NativeWorldStateInstance {
     this.instance = new MsgpackChannel(ws);
     // Manually create the queue for the canonical fork
     this.queues.set(0, new WorldStateOpsQueue());
+  }
+
+  public getDataDir() {
+    return this.dataDir;
+  }
+
+  public clone() {
+    return new NativeWorldState(
+      this.dataDir,
+      this.dbMapSizeKb,
+      this.prefilledPublicData,
+      this.instrumentation,
+      this.log,
+    );
   }
 
   /**

--- a/yarn-project/world-state/src/synchronizer/server_world_state_synchronizer.ts
+++ b/yarn-project/world-state/src/synchronizer/server_world_state_synchronizer.ts
@@ -85,6 +85,10 @@ export class ServerWorldStateSynchronizer
     return this.merkleTreeDb.backupTo(dstPath, compact);
   }
 
+  public clear(): Promise<void> {
+    return this.merkleTreeDb.clear();
+  }
+
   public async start() {
     if (this.currentState === WorldStateRunningState.STOPPED) {
       throw new Error('Synchronizer already stopped');

--- a/yarn-project/world-state/src/world-state-db/merkle_tree_db.ts
+++ b/yarn-project/world-state/src/world-state-db/merkle_tree_db.ts
@@ -76,4 +76,7 @@ export interface MerkleTreeAdminDatabase extends ForkMerkleTreeOperations {
 
   /** Stops the database */
   close(): Promise<void>;
+
+  /** Deletes the db. */
+  clear(): Promise<void>;
 }


### PR DESCRIPTION
Adds a `node_rollbackTo` command to the admin API. This will instruct the archiver to roll back blocks and messages to the specified L2 block number, clears the proven block marker, and resets the L1 sync point to that of the specified L2 block.

In addition, if the target block is behind the last finalized block, we clear p2p and world state dbs and have them sync from scratch from the archiver, since these components dont know how to roll back to before a finalized block.
