### PR TITLE
chore: advance block when deploying contract txe

### DIFF
--- a/noir-projects/aztec-nr/aztec/src/test/helpers/utils.nr
+++ b/noir-projects/aztec-nr/aztec/src/test/helpers/utils.nr
@@ -40,7 +40,7 @@ impl<let N: u32, let M: u32> Deployer<N, M> {
             call_interface.get_args(),
             self.secret,
         );
-        cheatcodes::advance_blocks_by(1);
+
         let inputs = cheatcodes::get_private_context_inputs(get_block_number() - 1);
         let mut private_context = PrivateContext::new(inputs, 0);
         let args = call_interface.get_args();
@@ -52,6 +52,8 @@ impl<let N: u32, let M: u32> Deployer<N, M> {
             args_hash,
             call_interface.get_is_static(),
         );
+
+        cheatcodes::advance_blocks_by(1);
 
         instance
     }
@@ -70,7 +72,6 @@ impl<let N: u32, let M: u32> Deployer<N, M> {
             call_interface.get_args(),
             self.secret,
         );
-        cheatcodes::advance_blocks_by(1);
 
         let mut public_context = PublicContext::new(|| panic(f"Provide args hash manually"));
 
@@ -81,6 +82,8 @@ impl<let N: u32, let M: u32> Deployer<N, M> {
             GasOpts::default(),
         );
         assert(results.len() == 0);
+
+        cheatcodes::advance_blocks_by(1);
 
         instance
     }
@@ -100,7 +103,6 @@ impl<let N: u32, let M: u32> Deployer<N, M> {
             call_interface.get_args(),
             self.secret,
         );
-        cheatcodes::advance_blocks_by(1);
 
         let mut public_context = PublicContext::new(|| panic(f"Provide args hash manually"));
 
@@ -110,6 +112,8 @@ impl<let N: u32, let M: u32> Deployer<N, M> {
             call_interface.get_args(),
             GasOpts::default(),
         );
+
+        cheatcodes::advance_blocks_by(1);
 
         instance
     }

--- a/noir-projects/noir-contracts/contracts/test/counter_contract/src/main.nr
+++ b/noir-projects/noir-contracts/contracts/test/counter_contract/src/main.nr
@@ -114,6 +114,7 @@ pub contract Counter {
         // docs:start:txe_test_read_notes
         // Read the stored value in the note
         env.impersonate(contract_address);
+        sync_notes();
         let counter_slot = Counter::storage_layout().counters.slot;
         let owner_storage_slot = derive_storage_slot_in_map(counter_slot, owner);
         let mut options = NoteViewerOptions::new();
@@ -126,8 +127,11 @@ pub contract Counter {
         );
         // docs:end:txe_test_read_notes
         // Increment the counter
+        env.impersonate(owner);
         Counter::at(contract_address).increment(owner, sender).call(&mut env.private());
         // get_counter is an unconstrained function, so we call it directly (we're in the same module)
+        env.impersonate(contract_address);
+        sync_notes();
         let current_value_for_owner = get_counter(owner);
         let expected_current_value = initial_value + 1;
         assert(
@@ -142,23 +146,9 @@ pub contract Counter {
         let initial_value = 5;
         let (env, contract_address, owner, sender) = test::setup(initial_value);
 
-        // Checking from the note cache
-        env.impersonate(contract_address);
-        let counter_slot = Counter::storage_layout().counters.slot;
-        let owner_storage_slot = derive_storage_slot_in_map(counter_slot, owner);
-        let mut options = NoteViewerOptions::new();
-        let notes: BoundedVec<ValueNote, MAX_NOTES_PER_PAGE> =
-            view_notes(owner_storage_slot, options);
-        let initial_note_value = notes.get(0).value;
-        assert(
-            initial_note_value == initial_value,
-            f"Expected {initial_value} but got {initial_note_value}",
-        );
-
         // Checking that the note was discovered from private logs
-        env.advance_block_by(1);
-        sync_notes();
         env.impersonate(contract_address);
+        sync_notes();
         let counter_slot = Counter::storage_layout().counters.slot;
         let owner_storage_slot = derive_storage_slot_in_map(counter_slot, owner);
         let mut options = NoteViewerOptions::new();

--- a/noir-projects/noir-contracts/contracts/test/test_contract/src/test.nr
+++ b/noir-projects/noir-contracts/contracts/test/test_contract/src/test.nr
@@ -104,8 +104,7 @@ unconstrained fn test_storage_slot_allocation() {
 
 global CONTRACT_DEPLOYED_AT: u32 = 3;
 
-// In env.deploy_self("Test").with_private_initializer(initializer); it first deploys the contract, then advances a block, then calls the initializer.
-global CONTRACT_INITIALIZED_AT: u32 = CONTRACT_DEPLOYED_AT + 1;
+global CONTRACT_INITIALIZED_AT: u32 = CONTRACT_DEPLOYED_AT;
 
 pub unconstrained fn setup() -> (&mut TestEnvironment, AztecAddress, AztecAddress) {
     // Setup env, generate keys
@@ -123,8 +122,6 @@ pub unconstrained fn setup() -> (&mut TestEnvironment, AztecAddress, AztecAddres
     let initializer = Test::interface().initialize();
     let test_contract = env.deploy_self("Test").with_private_initializer(initializer);
     let contract_address = test_contract.to_address();
-
-    env.advance_block_by(1);
 
     (&mut env, contract_address, owner)
 }
@@ -171,7 +168,7 @@ unconstrained fn proving_contract_deployment_fails() {
 
 // In this test, we fail to prove contract initialization at the block before it was deployed. This checks for inclusion
 // of the initialization nullifier in state.
-#[test(should_fail_with = "Nullifier membership witness not found at block 3.")]
+#[test(should_fail_with = "Nullifier membership witness not found at block 2.")]
 unconstrained fn proving_contract_initialization_fails() {
     let (env, contract_address) = setup();
 

--- a/yarn-project/txe/src/oracle/txe_oracle.ts
+++ b/yarn-project/txe/src/oracle/txe_oracle.ts
@@ -140,7 +140,7 @@ export class TXE implements TypedOracle {
 
   private simulationProvider = new WASMSimulator();
 
-  private noteCache: ExecutionNoteCache;
+  public noteCache: ExecutionNoteCache;
 
   private authwits: Map<string, AuthWitness> = new Map();
 
@@ -729,6 +729,7 @@ export class TXE implements TypedOracle {
     txEffect.noteHashes = [...uniqueNoteHashesFromPrivate, ...this.uniqueNoteHashesFromPublic];
 
     txEffect.nullifiers = [...this.siloedNullifiersFromPublic, ...this.noteCache.getAllNullifiers()];
+
     if (usedTxRequestHashForNonces) {
       txEffect.nullifiers.unshift(this.getTxRequestHash());
     }

--- a/yarn-project/txe/src/txe_service/txe_service.ts
+++ b/yarn-project/txe/src/txe_service/txe_service.ts
@@ -10,7 +10,7 @@ import { PublicDataWrite } from '@aztec/stdlib/avm';
 import { AztecAddress } from '@aztec/stdlib/aztec-address';
 import { computePartialAddress } from '@aztec/stdlib/contract';
 import { SimulationError } from '@aztec/stdlib/errors';
-import { computePublicDataTreeLeafSlot, siloNullifier } from '@aztec/stdlib/hash';
+import { computePublicDataTreeLeafSlot } from '@aztec/stdlib/hash';
 import { LogWithTxData } from '@aztec/stdlib/logs';
 import { MerkleTreeId } from '@aztec/stdlib/trees';
 
@@ -76,9 +76,10 @@ export class TXEService {
 
   async deploy(artifact: ContractArtifact, instance: ContractInstanceWithAddress, secret: ForeignCallSingle) {
     // Emit deployment nullifier
-    (this.typedOracle as TXE).addSiloedNullifiersFromPublic([
-      await siloNullifier(AztecAddress.fromNumber(DEPLOYER_CONTRACT_ADDRESS), instance.address.toField()),
-    ]);
+    await (this.typedOracle as TXE).noteCache.nullifierCreated(
+      AztecAddress.fromNumber(DEPLOYER_CONTRACT_ADDRESS),
+      instance.address.toField(),
+    );
 
     if (!fromSingle(secret).equals(Fr.ZERO)) {
       await this.addAccount(artifact, instance, secret);


### PR DESCRIPTION
Right now we mine an extra block when we do not need to and not after any initializers have been emitted, forcing us to `env.advance_block_by()` after any time we deploy to actually discover those side effects via note discovery.

Note that this removes the ability to check the note cache directly after deployment but I think that is such a niche case and we can always re-add an endpoint that doesn't advance block after deployment if necessary