### PR TITLE
fix: l2 to l1 messages from private should be properly ordered by phase alongside publicly created ones

### DIFF
--- a/yarn-project/simulator/src/public/public_tx_simulator/public_tx_context.ts
+++ b/yarn-project/simulator/src/public/public_tx_simulator/public_tx_context.ts
@@ -21,7 +21,6 @@ import {
   type PrivateToPublicAccumulatedData,
   PublicCallRequest,
   countAccumulatedItems,
-  mergeAccumulatedData,
 } from '@aztec/stdlib/kernel';
 import { PublicLog } from '@aztec/stdlib/logs';
 import { ScopedL2ToL1Message } from '@aztec/stdlib/messaging';
@@ -40,7 +39,7 @@ import { inspect } from 'util';
 
 import type { PublicContractsDBInterface } from '../db_interfaces.js';
 import type { PublicTreesDB } from '../public_db_sources.js';
-import { SideEffectArrayLengths, SideEffectTrace } from '../side_effect_trace.js';
+import { SideEffectTrace } from '../side_effect_trace.js';
 import { PublicPersistableStateManager } from '../state_manager/state_manager.js';
 import { getCallRequestsWithCalldataByPhase } from '../utils.js';
 
@@ -89,16 +88,7 @@ export class PublicTxContext {
   ) {
     const nonRevertibleAccumulatedDataFromPrivate = tx.data.forPublic!.nonRevertibleAccumulatedData;
 
-    const previousAccumulatedDataArrayLengths = new SideEffectArrayLengths(
-      /*publicDataWrites*/ 0,
-      /*protocolPublicDataWrites*/ 0,
-      /*noteHashes*/ 0,
-      /*nullifiers=*/ 0,
-      countAccumulatedItems(nonRevertibleAccumulatedDataFromPrivate.l2ToL1Msgs),
-      /*publicLogs*/ 0,
-    );
-
-    const trace = new SideEffectTrace(/*startSideEffectCounter=*/ 0, previousAccumulatedDataArrayLengths);
+    const trace = new SideEffectTrace();
 
     const firstNullifier = nonRevertibleAccumulatedDataFromPrivate.nullifiers[0];
 
@@ -315,15 +305,6 @@ export class PublicTxContext {
       publicLogs: avmPublicLogs,
     } = this.trace.getSideEffects();
 
-    // We concatenate messages.
-    const msgsFromPrivate = this.revertCode.isOK()
-      ? mergeAccumulatedData(
-          this.nonRevertibleAccumulatedDataFromPrivate.l2ToL1Msgs,
-          this.revertibleAccumulatedDataFromPrivate.l2ToL1Msgs,
-        )
-      : this.nonRevertibleAccumulatedDataFromPrivate.l2ToL1Msgs;
-    const finalL2ToL1Msgs = mergeAccumulatedData(msgsFromPrivate, avmL2ToL1Msgs);
-
     // Private generates PrivateLogs, and public execution generates PublicLogs.
     // Since these are two different categories, they should not be merged.
     const finalPublicLogs = avmPublicLogs;
@@ -354,7 +335,7 @@ export class PublicTxContext {
         Fr.zero(),
         MAX_NULLIFIERS_PER_TX,
       ),
-      /*l2ToL1Msgs=*/ padArrayEnd(finalL2ToL1Msgs, ScopedL2ToL1Message.empty(), MAX_L2_TO_L1_MSGS_PER_TX),
+      /*l2ToL1Msgs=*/ padArrayEnd(avmL2ToL1Msgs, ScopedL2ToL1Message.empty(), MAX_L2_TO_L1_MSGS_PER_TX),
       /*publicLogs=*/ padArrayEnd(finalPublicLogs, PublicLog.empty(), MAX_PUBLIC_LOGS_PER_TX),
       /*publicDataWrites=*/ padArrayEnd(
         finalPublicDataWrites,

--- a/yarn-project/simulator/src/public/public_tx_simulator/public_tx_simulator.test.ts
+++ b/yarn-project/simulator/src/public/public_tx_simulator/public_tx_simulator.test.ts
@@ -5,6 +5,7 @@ import {
   REGISTERER_CONTRACT_ADDRESS,
   REGISTERER_CONTRACT_CLASS_REGISTERED_MAGIC_VALUE,
 } from '@aztec/constants';
+import { EthAddress } from '@aztec/foundation/eth-address';
 import { Fr } from '@aztec/foundation/fields';
 import type { AztecKVStore } from '@aztec/kv-store';
 import { openTmpStore } from '@aztec/kv-store/lmdb';
@@ -21,6 +22,7 @@ import { computePublicDataTreeLeafSlot } from '@aztec/stdlib/hash';
 import type { MerkleTreeWriteOperations } from '@aztec/stdlib/interfaces/server';
 import { ScopedLogHash, countAccumulatedItems } from '@aztec/stdlib/kernel';
 import { ContractClassLog } from '@aztec/stdlib/logs';
+import { L2ToL1Message, ScopedL2ToL1Message } from '@aztec/stdlib/messaging';
 import { fr, makeContractClassPublic, mockTx } from '@aztec/stdlib/testing';
 import { AppendOnlyTreeSnapshot, MerkleTreeId, PublicDataTreeLeaf } from '@aztec/stdlib/trees';
 import {
@@ -103,8 +105,23 @@ describe('public_tx_simulator', () => {
 
     tx.data.forPublic!.nonRevertibleAccumulatedData.nullifiers[0] = new Fr(0x7777);
     tx.data.forPublic!.nonRevertibleAccumulatedData.nullifiers[1] = new Fr(0x8888);
+    tx.data.forPublic!.nonRevertibleAccumulatedData.noteHashes[0] = new Fr(0x9999);
+    tx.data.forPublic!.nonRevertibleAccumulatedData.noteHashes[1] = new Fr(0xaaaa);
+    tx.data.forPublic!.nonRevertibleAccumulatedData.l2ToL1Msgs[0] = new ScopedL2ToL1Message(
+      new L2ToL1Message(EthAddress.fromNumber(0x5555), new Fr(0xbbbb), 0),
+      AztecAddress.fromField(new Fr(0x6666)),
+    );
+    tx.data.forPublic!.nonRevertibleAccumulatedData.l2ToL1Msgs[1] = new ScopedL2ToL1Message(
+      new L2ToL1Message(EthAddress.fromNumber(0x6666), new Fr(0xcccc), 0),
+      AztecAddress.fromField(new Fr(0x7777)),
+    );
 
     tx.data.forPublic!.revertibleAccumulatedData.nullifiers[0] = new Fr(0x9999);
+    tx.data.forPublic!.revertibleAccumulatedData.noteHashes[0] = new Fr(0xbbbb);
+    tx.data.forPublic!.revertibleAccumulatedData.l2ToL1Msgs[0] = new ScopedL2ToL1Message(
+      new L2ToL1Message(EthAddress.fromNumber(0x7777), new Fr(0xdddd), 0),
+      AztecAddress.fromField(new Fr(0x8888)),
+    );
 
     tx.data.gasUsed = privateGasUsed;
     if (hasPublicTeardownCall) {
@@ -548,6 +565,140 @@ describe('public_tx_simulator', () => {
     expect(simulateInternal).toHaveBeenCalledTimes(1);
   });
 
+  it('non-reverting transactions keep all side effects', async function () {
+    const tx = await mockTxWithPublicCalls({
+      numberOfSetupCalls: 1,
+      numberOfAppLogicCalls: 2,
+      hasPublicTeardownCall: true,
+    });
+
+    const siloedNullifiers = [new Fr(0x10000), new Fr(0x20000), new Fr(0x30000), new Fr(0x40000), new Fr(0x50000)];
+    const noteHashes = [new Fr(0x60000), new Fr(0x70000), new Fr(0x80000), new Fr(0x90000), new Fr(0xa0000)];
+    const l2ToL1Addresses = [new Fr(0xa0000), new Fr(0xb0000), new Fr(0xc0000), new Fr(0xf0000), new Fr(0x10000)].map(
+      a => new AztecAddress(a),
+    );
+    const l2ToL1Recipients = [new Fr(0xb0000), new Fr(0xc0000), new Fr(0xd0000), new Fr(0xe0000), new Fr(0xf0000)];
+    const l2ToL1Contents = [new Fr(0x100000), new Fr(0x110000), new Fr(0x120000), new Fr(0x130000), new Fr(0x140000)];
+    const l2ToL1Messages = l2ToL1Recipients.map((recipient, i) =>
+      new L2ToL1Message(EthAddress.fromField(recipient), l2ToL1Contents[i], 0).scope(l2ToL1Addresses[i]),
+    );
+
+    mockPublicExecutor([
+      // SETUP
+      async (stateManager: PublicPersistableStateManager) => {
+        await stateManager.writeSiloedNullifier(siloedNullifiers[0]);
+        await stateManager.writeUniqueNoteHash(noteHashes[0]);
+        stateManager.writeL2ToL1Message(l2ToL1Addresses[0], l2ToL1Recipients[0], l2ToL1Contents[0]);
+      },
+      // APP LOGIC
+      async (stateManager: PublicPersistableStateManager) => {
+        await stateManager.writeSiloedNullifier(siloedNullifiers[1]);
+        await stateManager.writeSiloedNullifier(siloedNullifiers[2]);
+        await stateManager.writeUniqueNoteHash(noteHashes[1]);
+        await stateManager.writeUniqueNoteHash(noteHashes[2]);
+        stateManager.writeL2ToL1Message(l2ToL1Addresses[1], l2ToL1Recipients[1], l2ToL1Contents[1]);
+        stateManager.writeL2ToL1Message(l2ToL1Addresses[2], l2ToL1Recipients[2], l2ToL1Contents[2]);
+      },
+      async (stateManager: PublicPersistableStateManager) => {
+        await stateManager.writeSiloedNullifier(siloedNullifiers[3]);
+        await stateManager.writeUniqueNoteHash(noteHashes[3]);
+        stateManager.writeL2ToL1Message(l2ToL1Addresses[3], l2ToL1Recipients[3], l2ToL1Contents[3]);
+      },
+      // TEARDOWN
+      async (stateManager: PublicPersistableStateManager) => {
+        await stateManager.writeSiloedNullifier(siloedNullifiers[4]);
+        await stateManager.writeUniqueNoteHash(noteHashes[4]);
+        stateManager.writeL2ToL1Message(l2ToL1Addresses[4], l2ToL1Recipients[4], l2ToL1Contents[4]);
+      },
+    ]);
+
+    const txResult = await simulator.simulate(tx);
+
+    expect(txResult.processedPhases).toHaveLength(3);
+    expect(txResult.processedPhases).toEqual([
+      expect.objectContaining({ phase: TxExecutionPhase.SETUP, revertReason: undefined }),
+      expect.objectContaining({ phase: TxExecutionPhase.APP_LOGIC, revertReason: undefined }),
+      expect.objectContaining({ phase: TxExecutionPhase.TEARDOWN, revertReason: undefined }),
+    ]);
+
+    expect(txResult.revertCode).toEqual(RevertCode.OK);
+    expect(txResult.revertReason).toBeUndefined();
+
+    const expectedSetupGas = enqueuedCallGasUsed;
+    const expectedAppLogicGas = enqueuedCallGasUsed.mul(2);
+    const expectedTeardownGasUsed = enqueuedCallGasUsed;
+    const expectedTotalGas = privateGasUsed.add(expectedSetupGas).add(expectedAppLogicGas).add(expectedTeardownGasUsed);
+    const expectedBilledGas = privateGasUsed.add(expectedSetupGas).add(expectedAppLogicGas).add(teardownGasLimits);
+    expect(txResult.gasUsed).toEqual({
+      totalGas: expectedTotalGas,
+      billedGas: expectedBilledGas,
+      teardownGas: expectedTeardownGasUsed,
+      publicGas: expectedTotalGas.sub(privateGasUsed),
+    });
+
+    const availableGasForSetup = gasLimits.sub(teardownGasLimits).sub(privateGasUsed);
+    const availableGasForFirstAppLogic = availableGasForSetup.sub(enqueuedCallGasUsed);
+    const availableGasForSecondAppLogic = availableGasForFirstAppLogic.sub(enqueuedCallGasUsed);
+    expectAvailableGasForCalls([
+      availableGasForSetup,
+      availableGasForFirstAppLogic,
+      availableGasForSecondAppLogic,
+      teardownGasLimits,
+    ]);
+
+    const output = txResult.avmProvingRequest!.inputs.publicInputs;
+
+    const expectedGasUsedForFee = expectedTotalGas.sub(expectedTeardownGasUsed).add(teardownGasLimits);
+    const expectedTxFee = expectedGasUsedForFee.computeFee(gasFees);
+    expect(output.endGasUsed).toEqual(expectedGasUsedForFee);
+    expect(output.transactionFee).toEqual(expectedTxFee);
+
+    // We keep all side effects
+    expect(countAccumulatedItems(output.accumulatedData.nullifiers)).toBe(8);
+    expect(countAccumulatedItems(output.accumulatedData.noteHashes)).toBe(8);
+    expect(countAccumulatedItems(output.accumulatedData.l2ToL1Msgs)).toBe(8);
+
+    // Verify that the actual side effects are as expected and in the right order.
+    const includedSiloedNullifiers = [
+      ...tx.data.forPublic!.nonRevertibleAccumulatedData.nullifiers.filter(n => !n.isZero()),
+      siloedNullifiers[0],
+      ...tx.data.forPublic!.revertibleAccumulatedData.nullifiers.filter(n => !n.isZero()),
+      ...siloedNullifiers.slice(1, 4),
+      // teardown
+      siloedNullifiers[4],
+    ];
+    expect(output.accumulatedData.nullifiers.filter(n => !n.isZero())).toEqual(includedSiloedNullifiers);
+
+    const includedNoteHashes = [
+      ...tx.data.forPublic!.nonRevertibleAccumulatedData.noteHashes.filter(n => !n.isZero()),
+      noteHashes[0],
+      // Cannot use actual revertible note hashes because the AVM will silo them and make them unique.
+      // So we'd have to do so here to actually compare. For now, we just check that the correct number
+      // of nonzero revertible notes end up in the output.
+      //...tx.data.forPublic!.revertibleAccumulatedData.noteHashes.filter(n => !n.isZero()),
+      ...Array.from(
+        { length: tx.data.forPublic!.revertibleAccumulatedData.noteHashes.filter(n => !n.isZero()).length },
+        () => expect.anything(),
+      ),
+      ...noteHashes.slice(1, 4),
+      // Teardown
+      noteHashes[4],
+    ];
+    expect(output.accumulatedData.noteHashes.filter(n => !n.isZero())).toEqual(includedNoteHashes);
+
+    const includedL2ToL1Messages = [
+      ...tx.data.forPublic!.nonRevertibleAccumulatedData.l2ToL1Msgs.filter(m => !m.isEmpty()),
+      l2ToL1Messages[0],
+      ...tx.data.forPublic!.revertibleAccumulatedData.l2ToL1Msgs.filter(m => !m.isEmpty()),
+      ...l2ToL1Messages.slice(1, 4),
+      // Teardown
+      l2ToL1Messages[4],
+    ];
+    expect(output.accumulatedData.l2ToL1Msgs.filter(m => !m.isEmpty())).toEqual(includedL2ToL1Messages);
+
+    await checkNullifierRoot(txResult);
+  });
+
   it('includes a transaction that reverts in app logic only', async function () {
     const tx = await mockTxWithPublicCalls({
       numberOfSetupCalls: 1,
@@ -558,23 +709,43 @@ describe('public_tx_simulator', () => {
     const appLogicFailure = new SimulationError('Simulation Failed in app logic', []);
 
     const siloedNullifiers = [new Fr(0x10000), new Fr(0x20000), new Fr(0x30000), new Fr(0x40000), new Fr(0x50000)];
+    const noteHashes = [new Fr(0x60000), new Fr(0x70000), new Fr(0x80000), new Fr(0x90000), new Fr(0xa0000)];
+    const l2ToL1Addresses = [new Fr(0xa0000), new Fr(0xb0000), new Fr(0xc0000), new Fr(0xf0000), new Fr(0x10000)].map(
+      a => new AztecAddress(a),
+    );
+    const l2ToL1Recipients = [new Fr(0xb0000), new Fr(0xc0000), new Fr(0xd0000), new Fr(0xe0000), new Fr(0xf0000)];
+    const l2ToL1Contents = [new Fr(0x100000), new Fr(0x110000), new Fr(0x120000), new Fr(0x130000), new Fr(0x140000)];
+    const l2ToL1Messages = l2ToL1Recipients.map((recipient, i) =>
+      new L2ToL1Message(EthAddress.fromField(recipient), l2ToL1Contents[i], 0).scope(l2ToL1Addresses[i]),
+    );
+
     mockPublicExecutor([
       // SETUP
       async (stateManager: PublicPersistableStateManager) => {
         await stateManager.writeSiloedNullifier(siloedNullifiers[0]);
+        await stateManager.writeUniqueNoteHash(noteHashes[0]);
+        stateManager.writeL2ToL1Message(l2ToL1Addresses[0], l2ToL1Recipients[0], l2ToL1Contents[0]);
       },
       // APP LOGIC
       async (stateManager: PublicPersistableStateManager) => {
         await stateManager.writeSiloedNullifier(siloedNullifiers[1]);
         await stateManager.writeSiloedNullifier(siloedNullifiers[2]);
+        await stateManager.writeUniqueNoteHash(noteHashes[1]);
+        await stateManager.writeUniqueNoteHash(noteHashes[2]);
+        stateManager.writeL2ToL1Message(l2ToL1Addresses[1], l2ToL1Recipients[1], l2ToL1Contents[1]);
+        stateManager.writeL2ToL1Message(l2ToL1Addresses[2], l2ToL1Recipients[2], l2ToL1Contents[2]);
       },
       async (stateManager: PublicPersistableStateManager) => {
         await stateManager.writeSiloedNullifier(siloedNullifiers[3]);
+        await stateManager.writeUniqueNoteHash(noteHashes[3]);
+        stateManager.writeL2ToL1Message(l2ToL1Addresses[3], l2ToL1Recipients[3], l2ToL1Contents[3]);
         return Promise.resolve(appLogicFailure);
       },
       // TEARDOWN
       async (stateManager: PublicPersistableStateManager) => {
         await stateManager.writeSiloedNullifier(siloedNullifiers[4]);
+        await stateManager.writeUniqueNoteHash(noteHashes[4]);
+        stateManager.writeL2ToL1Message(l2ToL1Addresses[4], l2ToL1Recipients[4], l2ToL1Contents[4]);
       },
     ]);
 
@@ -619,8 +790,12 @@ describe('public_tx_simulator', () => {
     expect(output.endGasUsed).toEqual(expectedGasUsedForFee);
     expect(output.transactionFee).toEqual(expectedTxFee);
 
-    // we keep the non-revertible data.
+    // We keep only the non-revertible data and setup
     expect(countAccumulatedItems(output.accumulatedData.nullifiers)).toBe(4);
+    expect(countAccumulatedItems(output.accumulatedData.noteHashes)).toBe(4);
+    expect(countAccumulatedItems(output.accumulatedData.l2ToL1Msgs)).toBe(4);
+
+    // Verify that the actual side effects are as expected and in the right order.
     const includedSiloedNullifiers = [
       ...tx.data.forPublic!.nonRevertibleAccumulatedData.nullifiers.filter(n => !n.isZero()),
       siloedNullifiers[0],
@@ -631,6 +806,23 @@ describe('public_tx_simulator', () => {
       siloedNullifiers[4],
     ];
     expect(output.accumulatedData.nullifiers.filter(n => !n.isZero())).toEqual(includedSiloedNullifiers);
+
+    const includedNoteHashes = [
+      ...tx.data.forPublic!.nonRevertibleAccumulatedData.noteHashes.filter(n => !n.isZero()),
+      noteHashes[0],
+      // Teardown
+      noteHashes[4],
+    ];
+    expect(output.accumulatedData.noteHashes.filter(n => !n.isZero())).toEqual(includedNoteHashes);
+
+    const includedL2ToL1Messages = [
+      ...tx.data.forPublic!.nonRevertibleAccumulatedData.l2ToL1Msgs.filter(m => !m.isEmpty()),
+      l2ToL1Messages[0],
+      // Teardown
+      l2ToL1Messages[4],
+    ];
+    expect(output.accumulatedData.l2ToL1Msgs.filter(m => !m.isEmpty())).toEqual(includedL2ToL1Messages);
+
     await checkNullifierRoot(txResult);
   });
 
@@ -644,22 +836,42 @@ describe('public_tx_simulator', () => {
     const teardownFailure = new SimulationError('Simulation Failed in teardown', []);
 
     const siloedNullifiers = [new Fr(10000), new Fr(20000), new Fr(30000), new Fr(40000), new Fr(50000)];
+    const noteHashes = [new Fr(0x60000), new Fr(0x70000), new Fr(0x80000), new Fr(0x90000), new Fr(0xa0000)];
+    const l2ToL1Addresses = [new Fr(0xa0000), new Fr(0xb0000), new Fr(0xc0000), new Fr(0xf0000), new Fr(0x10000)].map(
+      a => new AztecAddress(a),
+    );
+    const l2ToL1Recipients = [new Fr(0xb0000), new Fr(0xc0000), new Fr(0xd0000), new Fr(0xe0000), new Fr(0xf0000)];
+    const l2ToL1Contents = [new Fr(0x100000), new Fr(0x110000), new Fr(0x120000), new Fr(0x130000), new Fr(0x140000)];
+    const l2ToL1Messages = l2ToL1Recipients.map((recipient, i) =>
+      new L2ToL1Message(EthAddress.fromField(recipient), l2ToL1Contents[i], 0).scope(l2ToL1Addresses[i]),
+    );
+
     mockPublicExecutor([
       // SETUP
       async (stateManager: PublicPersistableStateManager) => {
         await stateManager.writeSiloedNullifier(siloedNullifiers[0]);
+        await stateManager.writeUniqueNoteHash(noteHashes[0]);
+        stateManager.writeL2ToL1Message(l2ToL1Addresses[0], l2ToL1Recipients[0], l2ToL1Contents[0]);
       },
       // APP LOGIC
       async (stateManager: PublicPersistableStateManager) => {
         await stateManager.writeSiloedNullifier(siloedNullifiers[1]);
         await stateManager.writeSiloedNullifier(siloedNullifiers[2]);
+        await stateManager.writeUniqueNoteHash(noteHashes[1]);
+        await stateManager.writeUniqueNoteHash(noteHashes[2]);
+        stateManager.writeL2ToL1Message(l2ToL1Addresses[1], l2ToL1Recipients[1], l2ToL1Contents[1]);
+        stateManager.writeL2ToL1Message(l2ToL1Addresses[2], l2ToL1Recipients[2], l2ToL1Contents[2]);
       },
       async (stateManager: PublicPersistableStateManager) => {
         await stateManager.writeSiloedNullifier(siloedNullifiers[3]);
+        await stateManager.writeUniqueNoteHash(noteHashes[3]);
+        stateManager.writeL2ToL1Message(l2ToL1Addresses[3], l2ToL1Recipients[3], l2ToL1Contents[3]);
       },
       // TEARDOWN
       async (stateManager: PublicPersistableStateManager) => {
         await stateManager.writeSiloedNullifier(siloedNullifiers[4]);
+        await stateManager.writeUniqueNoteHash(noteHashes[4]);
+        stateManager.writeL2ToL1Message(l2ToL1Addresses[4], l2ToL1Recipients[4], l2ToL1Contents[4]);
         return Promise.resolve(teardownFailure);
       },
     ]);
@@ -704,8 +916,12 @@ describe('public_tx_simulator', () => {
     expect(output.endGasUsed).toEqual(expectedGasUsedForFee);
     expect(output.transactionFee).toEqual(expectedTxFee);
 
-    // We keep the non-revertible data.
+    // We keep only the non-revertible data and setup
     expect(countAccumulatedItems(output.accumulatedData.nullifiers)).toBe(3);
+    expect(countAccumulatedItems(output.accumulatedData.noteHashes)).toBe(3);
+    expect(countAccumulatedItems(output.accumulatedData.l2ToL1Msgs)).toBe(3);
+
+    // Verify that the actual side effects are as expected and in the right order.
     const includedSiloedNullifiers = [
       ...tx.data.forPublic!.nonRevertibleAccumulatedData.nullifiers.filter(n => !n.isZero()),
       siloedNullifiers[0],
@@ -714,6 +930,18 @@ describe('public_tx_simulator', () => {
       //..siloedNullifiers[1...4]
     ];
     expect(output.accumulatedData.nullifiers.filter(n => !n.isZero())).toEqual(includedSiloedNullifiers);
+
+    const includedNoteHashes = [
+      ...tx.data.forPublic!.nonRevertibleAccumulatedData.noteHashes.filter(n => !n.isZero()),
+      noteHashes[0],
+    ];
+    expect(output.accumulatedData.noteHashes.filter(n => !n.isZero())).toEqual(includedNoteHashes);
+
+    const includedL2ToL1Messages = [
+      ...tx.data.forPublic!.nonRevertibleAccumulatedData.l2ToL1Msgs.filter(m => !m.isEmpty()),
+      l2ToL1Messages[0],
+    ];
+    expect(output.accumulatedData.l2ToL1Msgs.filter(m => !m.isEmpty())).toEqual(includedL2ToL1Messages);
     await checkNullifierRoot(txResult);
   });
 
@@ -727,23 +955,37 @@ describe('public_tx_simulator', () => {
     const appLogicFailure = new SimulationError('Simulation Failed in app logic', []);
     const teardownFailure = new SimulationError('Simulation Failed in teardown', []);
     const siloedNullifiers = [new Fr(10000), new Fr(20000), new Fr(30000), new Fr(40000), new Fr(50000)];
+    const noteHashes = [new Fr(60000), new Fr(70000), new Fr(80000), new Fr(90000), new Fr(100000)];
+    const l2ToL1Recipients = [new Fr(110000), new Fr(120000), new Fr(130000), new Fr(140000), new Fr(150000)];
+    const l2ToL1Contents = [new Fr(160000), new Fr(170000), new Fr(180000), new Fr(190000), new Fr(200000)];
+
     mockPublicExecutor([
       // SETUP
       async (stateManager: PublicPersistableStateManager) => {
         await stateManager.writeSiloedNullifier(siloedNullifiers[0]);
+        await stateManager.writeUniqueNoteHash(noteHashes[0]);
+        stateManager.writeL2ToL1Message(await AztecAddress.random(), l2ToL1Recipients[0], l2ToL1Contents[0]);
       },
       // APP LOGIC
       async (stateManager: PublicPersistableStateManager) => {
         await stateManager.writeSiloedNullifier(siloedNullifiers[1]);
         await stateManager.writeSiloedNullifier(siloedNullifiers[2]);
+        await stateManager.writeUniqueNoteHash(noteHashes[1]);
+        await stateManager.writeUniqueNoteHash(noteHashes[2]);
+        stateManager.writeL2ToL1Message(await AztecAddress.random(), l2ToL1Recipients[1], l2ToL1Contents[1]);
+        stateManager.writeL2ToL1Message(await AztecAddress.random(), l2ToL1Recipients[2], l2ToL1Contents[2]);
       },
       async (stateManager: PublicPersistableStateManager) => {
         await stateManager.writeSiloedNullifier(siloedNullifiers[3]);
+        await stateManager.writeUniqueNoteHash(noteHashes[3]);
+        stateManager.writeL2ToL1Message(await AztecAddress.random(), l2ToL1Recipients[3], l2ToL1Contents[3]);
         return Promise.resolve(appLogicFailure);
       },
       // TEARDOWN
       async (stateManager: PublicPersistableStateManager) => {
         await stateManager.writeSiloedNullifier(siloedNullifiers[4]);
+        await stateManager.writeUniqueNoteHash(noteHashes[4]);
+        stateManager.writeL2ToL1Message(await AztecAddress.random(), l2ToL1Recipients[4], l2ToL1Contents[4]);
         return Promise.resolve(teardownFailure);
       },
     ]);
@@ -790,8 +1032,11 @@ describe('public_tx_simulator', () => {
     expect(output.endGasUsed).toEqual(expectedGasUsedForFee);
     expect(output.transactionFee).toEqual(expectedTxFee);
 
-    // we keep the non-revertible data
+    // We keep only the non-revertible data and setup
     expect(countAccumulatedItems(output.accumulatedData.nullifiers)).toBe(3);
+    expect(countAccumulatedItems(output.accumulatedData.noteHashes)).toBe(3);
+    expect(countAccumulatedItems(output.accumulatedData.l2ToL1Msgs)).toBe(3);
+
     const includedSiloedNullifiers = [
       ...tx.data.forPublic!.nonRevertibleAccumulatedData.nullifiers.filter(n => !n.isZero()),
       siloedNullifiers[0],

--- a/yarn-project/simulator/src/public/public_tx_simulator/public_tx_simulator.ts
+++ b/yarn-project/simulator/src/public/public_tx_simulator/public_tx_simulator.ts
@@ -359,6 +359,12 @@ export class PublicTxSimulator {
         await stateManager.writeUniqueNoteHash(noteHash);
       }
     }
+    for (const l2ToL1Message of context.nonRevertibleAccumulatedDataFromPrivate.l2ToL1Msgs) {
+      if (!l2ToL1Message.isEmpty()) {
+        stateManager.writeScopedL2ToL1Message(l2ToL1Message);
+      }
+    }
+
     // add new contracts to the contracts db so that their functions may be found and called
     // TODO(#6464): Should we allow emitting contracts in the private setup phase?
     // FIXME(fcarreiro): this should conceptually use the hinted contracts db.
@@ -398,6 +404,11 @@ export class PublicTxSimulator {
       if (!noteHash.isEmpty()) {
         // Revertible note hashes from private are not hashed with nonce, since private can't know their final position, only we can.
         await stateManager.writeSiloedNoteHash(noteHash);
+      }
+    }
+    for (const l2ToL1Message of context.revertibleAccumulatedDataFromPrivate.l2ToL1Msgs) {
+      if (!l2ToL1Message.isEmpty()) {
+        stateManager.writeScopedL2ToL1Message(l2ToL1Message);
       }
     }
     // add new contracts to the contracts db so that their functions may be found and called

--- a/yarn-project/simulator/src/public/side_effect_trace.test.ts
+++ b/yarn-project/simulator/src/public/side_effect_trace.test.ts
@@ -73,7 +73,7 @@ describe('Public Side Effect Trace', () => {
     trace.traceNewL2ToL1Message(address, recipient, content);
     expect(trace.getCounter()).toBe(startCounterPlus1);
 
-    const expected = [new L2ToL1Message(EthAddress.fromField(recipient), content, startCounter).scope(address)];
+    const expected = [new L2ToL1Message(EthAddress.fromField(recipient), content, 0).scope(address)];
     expect(trace.getSideEffects().l2ToL1Msgs).toEqual(expected);
   });
 

--- a/yarn-project/simulator/src/public/side_effect_trace.ts
+++ b/yarn-project/simulator/src/public/side_effect_trace.ts
@@ -199,9 +199,7 @@ export class SideEffectTrace implements PublicSideEffectTraceInterface {
     }
 
     const recipientAddress = EthAddress.fromField(recipient);
-    this.l2ToL1Messages.push(
-      new L2ToL1Message(recipientAddress, content, this.sideEffectCounter).scope(contractAddress),
-    );
+    this.l2ToL1Messages.push(new L2ToL1Message(recipientAddress, content, 0).scope(contractAddress));
     this.log.trace(`Tracing new l2 to l1 message (counter=${this.sideEffectCounter})`);
     this.incrementSideEffectCounter();
   }

--- a/yarn-project/simulator/src/public/state_manager/state_manager.ts
+++ b/yarn-project/simulator/src/public/state_manager/state_manager.ts
@@ -15,6 +15,7 @@ import { AztecAddress } from '@aztec/stdlib/aztec-address';
 import type { ContractClassPublicWithCommitment, ContractInstanceWithAddress } from '@aztec/stdlib/contract';
 import { SerializableContractInstance } from '@aztec/stdlib/contract';
 import { computeNoteHashNonce, computeUniqueNoteHash, siloNoteHash, siloNullifier } from '@aztec/stdlib/hash';
+import { ScopedL2ToL1Message } from '@aztec/stdlib/messaging';
 import { SharedMutableValues, SharedMutableValuesWithHash } from '@aztec/stdlib/shared-mutable';
 import { MerkleTreeId } from '@aztec/stdlib/trees';
 import type { TreeSnapshots } from '@aztec/stdlib/tx';
@@ -299,6 +300,18 @@ export class PublicPersistableStateManager {
   public writeL2ToL1Message(contractAddress: AztecAddress, recipient: Fr, content: Fr) {
     this.log.trace(`L2ToL1Messages(${contractAddress}) += (recipient: ${recipient}, content: ${content}).`);
     this.trace.traceNewL2ToL1Message(contractAddress, recipient, content);
+  }
+
+  /**
+   * Write a scoped L2 to L1 message.
+   * @param l2ToL1Message - The L2 to L1 message to write.
+   */
+  public writeScopedL2ToL1Message(l2ToL1Message: ScopedL2ToL1Message) {
+    this.writeL2ToL1Message(
+      l2ToL1Message.contractAddress,
+      l2ToL1Message.message.recipient.toField(),
+      l2ToL1Message.message.content,
+    );
   }
 
   /**


### PR DESCRIPTION
Also, better tests of side effects for the public tx simulator, especially including tests of notes & messages being thrown away/kept properly based on whether a phase reverted.