### PR TITLE
fix: aztec with no args complains on mac

### DIFF
--- a/aztec-up/bin/aztec
+++ b/aztec-up/bin/aztec
@@ -5,7 +5,11 @@ NETWORK=${NETWORK:-}
 VERSION=${VERSION:-${NETWORK:-"latest"}}
 
 # Take copy of command-line arguments, so we can mutate to parse.
-args=("$@")
+if [ $# -eq 0 ]; then
+  args=("--help")
+else
+  args=("$@")
+fi
 while [ "$#" -gt 0 ]; do
   case $1 in
     -p | --port)


### PR DESCRIPTION
bash 3.2.57 on mac considers a=() undefined

```
copypaste@copypastes-MacBook-Pro aztec-test % aztec
/Users/copypaste/.aztec/bin/aztec: line 43: args[@]: unbound variable
```
