### PR TITLE
chore(docs): Make alpha-testnet storage doc match v0.86

### DIFF
--- a/docs/versioned_docs/version-alpha-testnet/developers/reference/smart_contract_reference/storage/index.md
+++ b/docs/versioned_docs/version-alpha-testnet/developers/reference/smart_contract_reference/storage/index.md
@@ -26,28 +26,13 @@ On this and the following pages in this section, you’ll learn:
 
 Aztec contracts have three different modes of execution: private, public, and utility. How storage is accessed depends on the execution mode: for example, `PublicImmutable` can be read in all execution modes but only initialized in public, while `PrivateMutable` is entirely unavailable in public.
 
-Aztec.nr prevents developers from calling functions unavailable in the current execution mode via the `context` variable that is injected into all contract functions. Its type indicates the current execution mode:
+Aztec.nr prevents developers from calling functions unavailable in the current execution mode via the `Context` variable that is injected into all contract functions. Its type indicates the current execution mode:
 
 - `&mut PrivateContext` for private execution
 - `&mut PublicContext` for public execution
 - `UtilityContext` for utility execution
 
-All state variables are generic over this `Context` type, and expose different methods in each execution mode. In the example above, `PublicImmutable`'s `initialize` function is only available with a public execution context, and so the following code results in a compilation error:
-
-```rust
-#[storage]
-struct Storage {
-  variable: PublicImmutable<Field>,
-}
-
-#[private]
-fn some_private_function() {
-  storage.variable.initialize(0);
-  // ^ ERROR: Expected type PublicImmutable<_, &mut PublicContext>, found type PublicImmutable<Field, &mut PrivateContext>
-}
-```
-
-The `Context` generic type parameter is not visible in the code above as it is automatically injected by the `#[storage]` macro, in order to reduce boilerplate. Similarly, all state variables in that struct (e.g. `PublicImmutable`) similarly have that same type parameter automatically passed to them.
+All state variables are generic over this `Context` type, and expose different methods in each execution mode.
 
 ## Map
 


### PR DESCRIPTION
applies some feedback to the alpha-testnet docs that is in v0.86.0