### PR TITLE
fix: use globalThis instead of self in PXE

### DIFF
--- a/yarn-project/kv-store/src/indexeddb/store.ts
+++ b/yarn-project/kv-store/src/indexeddb/store.ts
@@ -66,7 +66,7 @@ export class AztecIndexedDBStore implements AztecAsyncKVStore {
    * @returns The store
    */
   static async open(log: Logger, name?: string, ephemeral: boolean = false): Promise<AztecIndexedDBStore> {
-    name = name && !ephemeral ? name : self.crypto.getRandomValues(new Uint8Array(16)).join('');
+    name = name && !ephemeral ? name : globalThis.crypto.getRandomValues(new Uint8Array(16)).join('');
     log.debug(`Opening IndexedDB ${ephemeral ? 'temp ' : ''}database with name ${name}`);
     const rootDB = await openDB<AztecIDBSchema>(name, 1, {
       upgrade(db) {


### PR DESCRIPTION
A simple fix to make `@pxe/client` work in node.js. Not tested. Please run CI. Similar to https://github.com/AztecProtocol/aztec-packages/pull/10747