### PR TITLE
chore: creating a node rpc should have retries by default

### DIFF
--- a/yarn-project/stdlib/src/interfaces/aztec-node.ts
+++ b/yarn-project/stdlib/src/interfaces/aztec-node.ts
@@ -7,7 +7,7 @@ import {
 } from '@aztec/constants';
 import { type L1ContractAddresses, L1ContractAddressesSchema } from '@aztec/ethereum/l1-contract-addresses';
 import type { Fr } from '@aztec/foundation/fields';
-import { createSafeJsonRpcClient, defaultFetch } from '@aztec/foundation/json-rpc/client';
+import { createSafeJsonRpcClient, makeFetch } from '@aztec/foundation/json-rpc/client';
 import { SiblingPath } from '@aztec/foundation/trees';
 
 import { z } from 'zod';
@@ -551,7 +551,7 @@ export const AztecNodeApiSchema: ApiSchemaFor<AztecNode> = {
 export function createAztecNodeClient(
   url: string,
   versions: Partial<ComponentsVersions> = {},
-  fetch = defaultFetch,
+  fetch = makeFetch([1, 2, 3], false),
 ): AztecNode {
   return createSafeJsonRpcClient<AztecNode>(url, AztecNodeApiSchema, {
     namespaceMethods: 'node',


### PR DESCRIPTION
Externals are seeing lots of issues with 502's which break the useability of anything that requires a node via rpc (which is nearly everything). The actual backoff is arbitrarily set, but this is a placeholder series that hopefully informs our builders that a retry is possible. Furthermore I foresee this simple retry solving and unblocking a large proportion of the current issues faced.