### PR TITLE
fix: denoise works without redis creds

### DIFF
--- a/ci3/denoise
+++ b/ci3/denoise
@@ -82,7 +82,7 @@ done;
 status=${PIPESTATUS[0]}
 
 time="${SECONDS}s"
-[ -n "$publish_pid" ] && kill $publish_pid &>/dev/null || true
+[ -n "${publish_pid:-}" ] && kill $publish_pid &>/dev/null || true
 publish_log
 
 # Handle non-zero exit status


### PR DESCRIPTION
Unblocks externals