### PR TITLE
fix(cli): remove extra .split

### DIFF
--- a/yarn-project/cli/src/cmds/infrastructure/index.ts
+++ b/yarn-project/cli/src/cmds/infrastructure/index.ts
@@ -51,7 +51,7 @@ export function injectCommands(program: Command, log: LogFn, debugLogger: Logger
         who,
         mnemonic: options.mnemonic,
         rpcUrl: options.rpcUrl,
-        l1RpcUrls: options.l1RpcUrls.split(','),
+        l1RpcUrls: options.l1RpcUrls,
         chainId: options.l1ChainId,
         blockNumber: options.blockNumber,
         log,


### PR DESCRIPTION
It is already parsed in the sequencers command
fixes: https://github.com/AztecProtocol/aztec-packages/issues/14167