### PR TITLE
feat(contracts-periphery): coinbase and splits forwarders

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -17,3 +17,6 @@
 	path = bb-pilcom/powdr
 	url = https://github.com/AztecProtocol/powdr
 	branch = avm-minimal
+[submodule "l1-contracts/lib/splits-contracts-monorepo"]
+	path = l1-contracts/lib/splits-contracts-monorepo
+	url = https://github.com/0xSplits/splits-contracts-monorepo

--- a/l1-contracts/foundry.toml
+++ b/l1-contracts/foundry.toml
@@ -15,6 +15,7 @@ gas_reports = ["Governance","Registry","RewardDistributor","GovernanceProposer",
 
 remappings = [
   "@oz/=lib/openzeppelin-contracts/contracts/",
+  "@splits/=lib/splits-contracts-monorepo/packages/splits-v2/src",
   "@aztec/=src",
   "@test/=test"
 ]

--- a/l1-contracts/src/periphery/forwarders/CoinbaseForwarder.sol
+++ b/l1-contracts/src/periphery/forwarders/CoinbaseForwarder.sol
@@ -1,0 +1,114 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright 2024 Aztec Labs.
+pragma solidity >=0.8.27;
+
+import {Ownable} from "@oz/access/Ownable.sol";
+import {Address} from "@oz/utils/Address.sol";
+import {IForwarder} from "../interfaces/IForwarder.sol";
+
+struct CoinbaseLocation {
+  address contractAddress;
+  bytes4 proposeSignature;
+  uint256 offset;
+}
+
+contract CoinbaseForwarder is Ownable, IForwarder {
+  using Address for address;
+
+  error CoinbaseForwarder__Mismatch(address expected, address actual);
+  error CoinbaseForwarder__NoCoinbaseLocationSet();
+
+  address public immutable COINBASE;
+  CoinbaseLocation public COINBASE_LOCATION;
+
+  constructor(address __owner, address _coinbase) Ownable(__owner) {
+    COINBASE = _coinbase;
+  }
+
+
+  /**
+   * @notice Set the coinbase location for the forwarder
+   *         This is the rollup contract address and the offset of the coinbase location
+   * @param _coinbaseLocation The coinbase location to set
+   */
+  function setCoinbaseLocation(CoinbaseLocation memory _coinbaseLocation) external onlyOwner {
+    COINBASE_LOCATION = _coinbaseLocation;
+  }
+
+  /**
+   * @notice Enforce that the coinbase in the calldata is set to an address expected by the forwarder
+   * @param _coinbaseLocation The coinbase location to enforce
+   */
+  function _enforceCoinbaseLocation(CoinbaseLocation memory _coinbaseLocation, uint256 _callIndex) internal view {
+    uint256 coinbaseOffset = _coinbaseLocation.offset;
+    address recoveredCoinbase;
+
+    assembly {
+      // Get the memory offset of the correct calldata
+      // (to[], data[])
+      // (0x04, 0x24)
+      let calldataArrayOffset := calldataload(0x24)
+
+
+      // Get the start of the calldata array
+      // [0x04, ......... [data.length, data[0].offset, data[1].offset, ...]]
+      //                               ^
+      //                     targetCalldataArrayOffset
+      let targetCalldataArrayOffset := add(0x04, add(calldataArrayOffset, 0x20))
+
+      // Get the offset of the target calldata
+      // In the case the callIndex parameter is 1
+      // [0x04, ......... [data.length, data[0].offset, data[1].offset, ...]]
+      //                                               ^
+      //                                      targetCalldataOffsetPointer
+      let targetCalldataOffsetPointer := add(targetCalldataArrayOffset, mul(0x20, _callIndex))
+
+      // Since the targetCalldataOffsetPointer is relative to the start of the calldata array, we get the true pointer
+      // for calldata by adding it to the calldata location of the start of the array
+      // [0x04, ......... [data.length, data[0].offset, data[1].offset, ..., targetCalldata.length, targetCalldata.......]]
+      // .                                                                   ^
+      //                                                                targetCalldataOffset
+      let targetCalldataOffset := add(targetCalldataArrayOffset , calldataload(targetCalldataOffsetPointer))
+
+      // Get the start of the target calldata
+      // [0x04, ......... [data.length, data[0].offset, data[1].offset, ..., targetCalldata.length, targetCalldata.......]]
+      //                                                                                            ^
+      //                                                                                         calldataStart
+      let calldataStart := add(0x20, targetCalldataOffset) // it contains its length
+
+      // The forwarder provides the expected location of the coinbase value in calldata
+      // [0x04, ......... [data.length, data[0].offset, data[1].offset, ..., targetCalldata.length, [something, something, coinbase, something, ...]...]]
+      //                                                                                                                    ^
+      //                                                                                                           coinbaseOffset
+      recoveredCoinbase := calldataload(add(calldataStart, coinbaseOffset))
+    }
+
+    // If the coinbase in the calldata is incorrect, then the entire call will revert
+    if (recoveredCoinbase != COINBASE) {
+      revert CoinbaseForwarder__Mismatch(COINBASE, recoveredCoinbase);
+    }
+  }
+
+  function forward(address[] calldata _to, bytes[] calldata _data)
+    external
+    override(IForwarder)
+    onlyOwner
+  {
+    // Enforce coinbase is set the coinbase address
+    CoinbaseLocation memory coinbaseLocation = COINBASE_LOCATION;
+    if (coinbaseLocation.contractAddress == address(0)) {
+      revert CoinbaseForwarder__NoCoinbaseLocationSet();
+    }
+
+    require(
+      _to.length == _data.length, IForwarder.ForwarderLengthMismatch(_to.length, _data.length)
+    );
+    for (uint256 i = 0; i < _to.length; i++) {
+      if (coinbaseLocation.contractAddress == _to[i] && coinbaseLocation.proposeSignature == bytes4(_data[i][0:4])) {
+        _enforceCoinbaseLocation(coinbaseLocation, i);
+      }
+
+      _to[i].functionCall(_data[i]);
+    }
+  }
+}

--- a/l1-contracts/src/periphery/forwarders/Forwarder.sol
+++ b/l1-contracts/src/periphery/forwarders/Forwarder.sol
@@ -4,7 +4,7 @@ pragma solidity >=0.8.27;
 
 import {Ownable} from "@oz/access/Ownable.sol";
 import {Address} from "@oz/utils/Address.sol";
-import {IForwarder} from "./interfaces/IForwarder.sol";
+import {IForwarder} from "../interfaces/IForwarder.sol";
 
 contract Forwarder is Ownable, IForwarder {
   using Address for address;

--- a/l1-contracts/test/benchmark/happy.t.sol
+++ b/l1-contracts/test/benchmark/happy.t.sol
@@ -60,7 +60,7 @@ import {MessageHashUtils} from "@oz/utils/cryptography/MessageHashUtils.sol";
 import {
   Timestamp, Slot, Epoch, SlotLib, EpochLib, TimeLib
 } from "@aztec/core/libraries/TimeLib.sol";
-import {Forwarder} from "@aztec/periphery/Forwarder.sol";
+import {Forwarder} from "@aztec/periphery/forwarders/Forwarder.sol";
 import {Header} from "@aztec/core/libraries/rollup/HeaderLib.sol";
 
 // solhint-disable comprehensive-interface

--- a/l1-contracts/test/forwarders/CoinbaseForwarder.t.sol
+++ b/l1-contracts/test/forwarders/CoinbaseForwarder.t.sol
@@ -1,120 +1,204 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright 2024 Aztec Labs.
+pragma solidity >=0.8.27;
 
-import {Test} from "forge-std/Test.sol";
+import {TestBase} from "../base/Base.sol";
 
-import {CoinbaseForwarder, CoinbaseLocation} from "@aztec/periphery/forwarders/CoinbaseForwarder.sol";
+import {
+  CoinbaseForwarder, CoinbaseLocation
+} from "@aztec/periphery/forwarders/CoinbaseForwarder.sol";
+import {IRollupCore} from "@aztec/core/interfaces/IRollup.sol";
+import {OracleInput} from "@aztec/core/libraries/rollup/FeeLib.sol";
+import {ProposeArgs} from "@aztec/core/libraries/rollup/ProposeLib.sol";
+import {Header, ContentCommitment, GasFees} from "@aztec/core/libraries/rollup/HeaderLib.sol";
+import {Slot, Timestamp} from "@aztec/core/libraries/TimeLib.sol";
+import {Signature} from "@aztec/core/libraries/crypto/SignatureLib.sol";
+
+import "forge-std/console.sol";
 
 interface IMockRollup {
-    event Proposed();
-    event Voted();
+  event Proposed();
+  event Voted();
 
-    struct Calldata {
-        address someStuff;
-        address coinbase;
-        bytes data;
-    }
+  struct Calldata {
+    address someStuff;
+    address coinbase;
+    bytes data;
+  }
 
-    struct DifferentCalldataStructure {
-        address someStuff;
-        address otherStuff;
-        address coinbase;
-        bytes data;
-    }
+  struct DifferentCalldataStructure {
+    address someStuff;
+    address otherStuff;
+    address coinbase;
+    bytes data;
+  }
 }
 
 contract MockRollup is IMockRollup {
-    function propose(Calldata memory) external {
-        emit Proposed();
-    }
-    function vote() external {
-        emit Voted();
-    }
+  function propose(Calldata memory) external {
+    emit Proposed();
+  }
+
+  function vote() external {
+    emit Voted();
+  }
 }
 
 contract MockRollupWithDifferentCalldataStructure is IMockRollup {
-    function propose(DifferentCalldataStructure memory) external {
-        emit Proposed();
-    }
-    function vote() external {
-        emit Voted();
-    }
+  function propose(DifferentCalldataStructure memory) external {
+    emit Proposed();
+  }
+
+  function vote() external {
+    emit Voted();
+  }
 }
 
-contract CoinbaseForwarderTest is Test {
-    address public coinbase = address(0xcafe);
-    MockRollup public rollup;
+contract MockRollupWithRealRollupCalldataStructure is IMockRollup {
+  function propose(ProposeArgs calldata, Signature[] memory, bytes calldata) external {
+    emit Proposed();
+  }
 
-    function setUp() public {
-        rollup = new MockRollup();
-    }
+  function vote() external {
+    emit Voted();
+  }
+}
 
-    function test_revertsWhenNoCoinbaseLocationSet() public {
-        // If no coinbase location is set, the forwarder should revert
-        CoinbaseForwarder forwarder = new CoinbaseForwarder(address(this), coinbase);
+contract CoinbaseForwarderTest is TestBase {
+  address public coinbase = address(0xcafe);
+  MockRollup public rollup;
 
-        vm.expectRevert(CoinbaseForwarder.CoinbaseForwarder__NoCoinbaseLocationSet.selector);
-        forwarder.forward(new address[](1), new bytes[](1));
-    }
+  function setUp() public {
+    rollup = new MockRollup();
+  }
 
-    function test_succeedsWhenCoinbaseLocationSet() public {
-        CoinbaseForwarder forwarder = new CoinbaseForwarder(address(this), coinbase);
+  function test_revertsWhenNoCoinbaseLocationSet() public {
+    // If no coinbase location is set, the forwarder should revert
+    CoinbaseForwarder forwarder = new CoinbaseForwarder(address(this), coinbase);
 
-        CoinbaseLocation memory coinbaseLocation = CoinbaseLocation({
-            contractAddress: address(rollup),
-            proposeSignature: MockRollup.propose.selector,
-            offset: 0x44 // correct offset in MockRollup.Calldata.coinbase
-        });
+    vm.expectRevert(CoinbaseForwarder.CoinbaseForwarder__NoCoinbaseLocationSet.selector);
+    forwarder.forward(new address[](1), new bytes[](1));
+  }
 
-        forwarder.setCoinbaseLocation(coinbaseLocation);
+  function test_succeedsWhenCoinbaseLocationSet() public {
+    CoinbaseForwarder forwarder = new CoinbaseForwarder(address(this), coinbase);
 
-        // To
-        address[] memory to = new address[](2);
-        to[0] = address(rollup);
-        to[1] = address(rollup);
+    CoinbaseLocation memory coinbaseLocation = CoinbaseLocation({
+      contractAddress: address(rollup),
+      proposeSignature: MockRollup.propose.selector,
+      offset: 0x44 // correct offset in MockRollup.Calldata.coinbase
+    });
 
-        // Calldata
-        IMockRollup.Calldata memory rollupCalldataOne = IMockRollup.Calldata({
-            someStuff: address(0xbeef),
-            coinbase: coinbase,
-            data: bytes(string("something to put in the calldata"))
-        });
+    forwarder.setCoinbaseLocation(coinbaseLocation);
 
-        bytes[] memory data = new bytes[](2);
-        data[0] = abi.encodeCall(MockRollup.propose, (rollupCalldataOne));
-        data[1] = abi.encodeCall(MockRollup.vote, ());
+    // To
+    address[] memory to = new address[](2);
+    to[0] = address(rollup);
+    to[1] = address(rollup);
 
-        vm.expectEmit(false, false, false, false);
-        emit IMockRollup.Proposed();
-        forwarder.forward(to, data);
+    // Calldata
+    IMockRollup.Calldata memory rollupCalldataOne = IMockRollup.Calldata({
+      someStuff: address(0xbeef),
+      coinbase: coinbase,
+      data: bytes(string("something to put in the calldata"))
+    });
 
-        // Update the forwarder to use the different calldata structure
-        MockRollupWithDifferentCalldataStructure differentRollup = new MockRollupWithDifferentCalldataStructure();
-        CoinbaseLocation memory differentCoinbaseLocation = CoinbaseLocation({
-            contractAddress: address(differentRollup),
-            proposeSignature: MockRollupWithDifferentCalldataStructure.propose.selector,
-            offset: 0x64 // correct offset in MockRollup.Calldata.coinbase
-        });
+    bytes[] memory data = new bytes[](2);
+    data[0] = abi.encodeCall(MockRollup.propose, (rollupCalldataOne));
+    data[1] = abi.encodeCall(MockRollup.vote, ());
 
-        forwarder.setCoinbaseLocation(differentCoinbaseLocation);
+    vm.expectEmit(false, false, false, false);
+    emit IMockRollup.Proposed();
+    forwarder.forward(to, data);
 
-        // Update the calldata
-        IMockRollup.DifferentCalldataStructure memory differentRollupCalldata = IMockRollup.DifferentCalldataStructure({
-            someStuff: address(0xbeef),
-            otherStuff: address(0xdead),
-            coinbase: coinbase,
-            data: bytes(string("something to put in the calldata"))
-        });
+    // Update the forwarder to use the different calldata structure
+    MockRollupWithDifferentCalldataStructure differentRollup =
+      new MockRollupWithDifferentCalldataStructure();
+    CoinbaseLocation memory differentCoinbaseLocation = CoinbaseLocation({
+      contractAddress: address(differentRollup),
+      proposeSignature: MockRollupWithDifferentCalldataStructure.propose.selector,
+      offset: 0x64 // correct offset in MockRollup.Calldata.coinbase
+    });
 
+    forwarder.setCoinbaseLocation(differentCoinbaseLocation);
 
-        address[] memory differentTo = new address[](2);
-        differentTo[0] = address(differentRollup);
-        differentTo[1] = address(differentRollup);
+    // Update the calldata
+    IMockRollup.DifferentCalldataStructure memory differentRollupCalldata = IMockRollup
+      .DifferentCalldataStructure({
+      someStuff: address(0xbeef),
+      otherStuff: address(0xdead),
+      coinbase: coinbase,
+      data: bytes(string("something to put in the calldata"))
+    });
 
-        bytes[] memory differentData = new bytes[](2);
-        differentData[0] = abi.encodeCall(MockRollupWithDifferentCalldataStructure.vote, ());
-        differentData[1] = abi.encodeCall(MockRollupWithDifferentCalldataStructure.propose, (differentRollupCalldata));
+    address[] memory differentTo = new address[](2);
+    differentTo[0] = address(differentRollup);
+    differentTo[1] = address(differentRollup);
 
-        vm.expectEmit(false, false, false, false);
-        emit IMockRollup.Proposed();
-        forwarder.forward(differentTo, differentData);
-    }
+    bytes[] memory differentData = new bytes[](2);
+    differentData[0] = abi.encodeCall(MockRollupWithDifferentCalldataStructure.vote, ());
+    differentData[1] =
+      abi.encodeCall(MockRollupWithDifferentCalldataStructure.propose, (differentRollupCalldata));
+
+    vm.expectEmit(false, false, false, false);
+    emit IMockRollup.Proposed();
+    forwarder.forward(differentTo, differentData);
+  }
+
+  function test_realProposeArgs() public {
+    MockRollupWithRealRollupCalldataStructure realRollup =
+      new MockRollupWithRealRollupCalldataStructure();
+
+    CoinbaseForwarder forwarder = new CoinbaseForwarder(address(this), coinbase);
+
+    CoinbaseLocation memory coinbaseLocation = CoinbaseLocation({
+      contractAddress: address(realRollup),
+      proposeSignature: MockRollupWithRealRollupCalldataStructure.propose.selector,
+      // Note: in its current implementation this puts some very real constraints as to the location of the header
+      offset: 0x244
+    });
+
+    forwarder.setCoinbaseLocation(coinbaseLocation);
+
+    Header memory header = Header({
+      lastArchiveRoot: bytes32(0),
+      contentCommitment: ContentCommitment({
+        numTxs: 0,
+        blobsHash: bytes32(0),
+        inHash: bytes32(0),
+        outHash: bytes32(0)
+      }),
+      slotNumber: Slot.wrap(0),
+      timestamp: Timestamp.wrap(0),
+      coinbase: coinbase,
+      feeRecipient: 0,
+      gasFees: GasFees({feePerDaGas: 0, feePerL2Gas: 0}),
+      totalManaUsed: 0
+    });
+
+    bytes memory sr = bytes(string("something else"));
+    ProposeArgs memory args = ProposeArgs({
+      archive: bytes32(0),
+      stateReference: EMPTY_STATE_REFERENCE,
+      oracleInput: OracleInput({feeAssetPriceModifier: 0}),
+      header: header,
+      txHashes: new bytes32[](0)
+    });
+
+    Signature[] memory sigs = new Signature[](0);
+    bytes memory blobInput = bytes(string("blob input"));
+
+    address[] memory to = new address[](1);
+    to[0] = address(realRollup);
+
+    bytes[] memory data = new bytes[](1);
+    data[0] =
+      abi.encodeCall(MockRollupWithRealRollupCalldataStructure.propose, (args, sigs, blobInput));
+
+    console.logBytes(data[0]);
+
+    vm.expectEmit(false, false, false, false);
+    emit IMockRollup.Proposed();
+    forwarder.forward(to, data);
+  }
 }

--- a/l1-contracts/test/forwarders/CoinbaseForwarder.t.sol
+++ b/l1-contracts/test/forwarders/CoinbaseForwarder.t.sol
@@ -1,0 +1,120 @@
+
+import {Test} from "forge-std/Test.sol";
+
+import {CoinbaseForwarder, CoinbaseLocation} from "@aztec/periphery/forwarders/CoinbaseForwarder.sol";
+
+interface IMockRollup {
+    event Proposed();
+    event Voted();
+
+    struct Calldata {
+        address someStuff;
+        address coinbase;
+        bytes data;
+    }
+
+    struct DifferentCalldataStructure {
+        address someStuff;
+        address otherStuff;
+        address coinbase;
+        bytes data;
+    }
+}
+
+contract MockRollup is IMockRollup {
+    function propose(Calldata memory) external {
+        emit Proposed();
+    }
+    function vote() external {
+        emit Voted();
+    }
+}
+
+contract MockRollupWithDifferentCalldataStructure is IMockRollup {
+    function propose(DifferentCalldataStructure memory) external {
+        emit Proposed();
+    }
+    function vote() external {
+        emit Voted();
+    }
+}
+
+contract CoinbaseForwarderTest is Test {
+    address public coinbase = address(0xcafe);
+    MockRollup public rollup;
+
+    function setUp() public {
+        rollup = new MockRollup();
+    }
+
+    function test_revertsWhenNoCoinbaseLocationSet() public {
+        // If no coinbase location is set, the forwarder should revert
+        CoinbaseForwarder forwarder = new CoinbaseForwarder(address(this), coinbase);
+
+        vm.expectRevert(CoinbaseForwarder.CoinbaseForwarder__NoCoinbaseLocationSet.selector);
+        forwarder.forward(new address[](1), new bytes[](1));
+    }
+
+    function test_succeedsWhenCoinbaseLocationSet() public {
+        CoinbaseForwarder forwarder = new CoinbaseForwarder(address(this), coinbase);
+
+        CoinbaseLocation memory coinbaseLocation = CoinbaseLocation({
+            contractAddress: address(rollup),
+            proposeSignature: MockRollup.propose.selector,
+            offset: 0x44 // correct offset in MockRollup.Calldata.coinbase
+        });
+
+        forwarder.setCoinbaseLocation(coinbaseLocation);
+
+        // To
+        address[] memory to = new address[](2);
+        to[0] = address(rollup);
+        to[1] = address(rollup);
+
+        // Calldata
+        IMockRollup.Calldata memory rollupCalldataOne = IMockRollup.Calldata({
+            someStuff: address(0xbeef),
+            coinbase: coinbase,
+            data: bytes(string("something to put in the calldata"))
+        });
+
+        bytes[] memory data = new bytes[](2);
+        data[0] = abi.encodeCall(MockRollup.propose, (rollupCalldataOne));
+        data[1] = abi.encodeCall(MockRollup.vote, ());
+
+        vm.expectEmit(false, false, false, false);
+        emit IMockRollup.Proposed();
+        forwarder.forward(to, data);
+
+        // Update the forwarder to use the different calldata structure
+        MockRollupWithDifferentCalldataStructure differentRollup = new MockRollupWithDifferentCalldataStructure();
+        CoinbaseLocation memory differentCoinbaseLocation = CoinbaseLocation({
+            contractAddress: address(differentRollup),
+            proposeSignature: MockRollupWithDifferentCalldataStructure.propose.selector,
+            offset: 0x64 // correct offset in MockRollup.Calldata.coinbase
+        });
+
+        forwarder.setCoinbaseLocation(differentCoinbaseLocation);
+
+        // Update the calldata
+        IMockRollup.DifferentCalldataStructure memory differentRollupCalldata = IMockRollup.DifferentCalldataStructure({
+            someStuff: address(0xbeef),
+            otherStuff: address(0xdead),
+            coinbase: coinbase,
+            data: bytes(string("something to put in the calldata"))
+        });
+
+
+        address[] memory differentTo = new address[](2);
+        differentTo[0] = address(differentRollup);
+        differentTo[1] = address(differentRollup);
+
+        bytes[] memory differentData = new bytes[](2);
+        differentData[0] = abi.encodeCall(MockRollupWithDifferentCalldataStructure.vote, ());
+        differentData[1] = abi.encodeCall(MockRollupWithDifferentCalldataStructure.propose, (differentRollupCalldata));
+
+        vm.expectEmit(false, false, false, false);
+        emit IMockRollup.Proposed();
+        forwarder.forward(differentTo, differentData);
+    }
+}

--- a/l1-contracts/test/forwarders/CoinbaseForwarderWithSplits.t.sol
+++ b/l1-contracts/test/forwarders/CoinbaseForwarderWithSplits.t.sol
@@ -1,0 +1,173 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright 2024 Aztec Labs.
+pragma solidity >=0.8.27;
+
+import {PullSplitFactory} from "@splits/splitters/pull/PullSplitFactory.sol";
+import {SplitsWarehouse} from "@splits/SplitsWarehouse.sol";
+import {SplitV2Lib} from "@splits/libraries/SplitV2.sol";
+
+import {
+  CoinbaseForwarder, CoinbaseLocation
+} from "@aztec/periphery/forwarders/CoinbaseForwarder.sol";
+
+import {Registry} from "@aztec/governance/Registry.sol";
+import {TestERC20} from "@aztec/mock/TestERC20.sol";
+import {FeeJuicePortal} from "@aztec/core/messagebridge/FeeJuicePortal.sol";
+import {RewardDistributor} from "@aztec/governance/RewardDistributor.sol";
+import {ProposeArgs, ProposeLib} from "@aztec/core/libraries/rollup/ProposeLib.sol";
+
+import {
+  Timestamp, Slot, Epoch, SlotLib, EpochLib, TimeLib
+} from "@aztec/core/libraries/TimeLib.sol";
+
+import {DecoderBase} from "../base/DecoderBase.sol";
+import {RollupBase, IInstance, IRollup, IRollupCore} from "../base/RollupBase.sol";
+import {TestConstants} from "../harnesses/TestConstants.sol";
+
+import {Rollup} from "@aztec/core/Rollup.sol";
+import {IERC20} from "@oz/token/ERC20/IERC20.sol";
+
+/**
+ * @title CoinbaseForwarderWithSplits
+ * @notice Test a forwarder that splits the coinbase rewards between multiple recipients
+ *
+ * This test inherits from the Rollup test to test the fee split logic end to end.
+ */
+contract CoinbaseForwarderWithSplits is RollupBase {
+  using SlotLib for Slot;
+  using EpochLib for Epoch;
+  using ProposeLib for ProposeArgs;
+  using TimeLib for Timestamp;
+  using TimeLib for Slot;
+  using TimeLib for Epoch;
+
+  PullSplitFactory splitFactory;
+  address split;
+
+  Registry internal registry;
+  TestERC20 internal testERC20;
+  FeeJuicePortal internal feeJuicePortal;
+  RewardDistributor internal rewardDistributor;
+
+  address internal nodeOwner = address(bytes20("nodeOwner"));
+  address internal nodeOperator = address(bytes20("nodeOperator"));
+
+  uint256 internal SLOT_DURATION;
+  uint256 internal EPOCH_DURATION;
+
+  address internal sequencer = address(bytes20("sequencer"));
+
+  constructor() {
+    TimeLib.initialize(
+      block.timestamp, TestConstants.AZTEC_SLOT_DURATION, TestConstants.AZTEC_EPOCH_DURATION
+    );
+    SLOT_DURATION = TestConstants.AZTEC_SLOT_DURATION;
+    EPOCH_DURATION = TestConstants.AZTEC_EPOCH_DURATION;
+
+    SplitsWarehouse warehouse = new SplitsWarehouse("eth", "eth");
+    splitFactory = new PullSplitFactory(address(warehouse));
+  }
+
+  function setUp() public {}
+
+  modifier setUpFor(string memory _name) {
+    {
+      testERC20 = new TestERC20("test", "TEST", address(this));
+
+      DecoderBase.Full memory full = load(_name);
+      uint256 slotNumber = Slot.unwrap(full.block.header.slotNumber);
+      uint256 initialTime =
+        Timestamp.unwrap(full.block.header.timestamp) - slotNumber * SLOT_DURATION;
+      vm.warp(initialTime);
+    }
+
+    registry = new Registry(address(this), IERC20(address(testERC20)));
+    rewardDistributor = RewardDistributor(address(registry.getRewardDistributor()));
+
+    testERC20.mint(address(rewardDistributor), 1e6 ether);
+
+    rollup = IInstance(
+      address(
+        new Rollup(
+          testERC20,
+          rewardDistributor,
+          testERC20,
+          address(this),
+          TestConstants.getGenesisState(),
+          TestConstants.getRollupConfigInput()
+        )
+      )
+    );
+
+    feeJuicePortal = FeeJuicePortal(address(rollup.getFeeAssetPortal()));
+
+    registry.addRollup(IRollup(address(rollup)));
+
+    _;
+  }
+
+  function test_SplitCoinbase() public setUpFor("mixed_block_1") {
+    // Create a split between the node operator and the deployer
+    //
+    // nodeOwner = 80%
+    // nodeOperator = 20%
+    address[] memory recipients = new address[](2);
+    recipients[0] = nodeOwner;
+    recipients[1] = nodeOperator;
+
+    uint256[] memory allocations = new uint256[](2);
+    allocations[0] = 80;
+    allocations[1] = 20;
+
+    uint256 totalAllocation = 100;
+
+    SplitV2Lib.Split memory splitInstance = SplitV2Lib.Split({
+      recipients: recipients,
+      allocations: allocations,
+      totalAllocation: totalAllocation,
+      distributionIncentive: 0
+    });
+
+    split = splitFactory.createSplit(
+      splitInstance,
+      /*owner=*/
+      nodeOwner,
+      /*creator=*/
+      address(this)
+    );
+
+    // Now that we have a split created, we can deploy a Coinbase Forwarder with the split address enforced as the coinbase
+
+    // TODO: update permissions, the nodeOperator is the person calling it, but they should not have the power to update the coinbase locations / set the coinbase
+
+    CoinbaseForwarder forwarder =
+      new CoinbaseForwarder( /*owner=*/ nodeOperator, /*coinbase*/ split);
+
+    // Set the coinbase location for this rollup - note, ideally this will be set by the deployer contract in a factory format
+    CoinbaseLocation memory coinbaseLocation = CoinbaseLocation({
+      contractAddress: address(rollup),
+      offset: 0x240,
+      proposeSignature: IRollupCore.propose.selector
+    });
+
+    // TODO: update to the nodeOwner
+    vm.prank(nodeOperator);
+    forwarder.setCoinbaseLocation(coinbaseLocation);
+
+    // Call rollup.propose with custom forwarder args
+    ProposeWithForwarderArgs memory forwarderArgs = ProposeWithForwarderArgs({
+      enabled: true,
+      overwriteCoinbase: true,
+      forwarder: address(forwarder),
+      sender: address(nodeOperator),
+      setCoinbase: address(split)
+    });
+    _proposeBlockWithCustomForwarder("mixed_block_1", 1, forwarderArgs);
+
+    // Check for fee updates to the split address
+
+    // Prove the epoch, recieve the fees
+
+    // Pull the split rewards
+  }
+}

--- a/l1-contracts/test/forwarders/Forwarder.t.sol
+++ b/l1-contracts/test/forwarders/Forwarder.t.sol
@@ -3,8 +3,8 @@
 pragma solidity >=0.8.27;
 
 import {Test} from "forge-std/Test.sol";
-import {Forwarder} from "../src/periphery/Forwarder.sol";
-import {IForwarder} from "../src/periphery/interfaces/IForwarder.sol";
+import {Forwarder} from "../../src/periphery/forwarders/Forwarder.sol";
+import {IForwarder} from "../../src/periphery/interfaces/IForwarder.sol";
 import {TestERC20} from "@aztec/mock/TestERC20.sol";
 import {Ownable} from "@oz/access/Ownable.sol";
 // solhint-disable comprehensive-interface


### PR DESCRIPTION
## Overview

Implement a forwarder that enforces the coinbase to be a specific address

This forwarder requires the coinbase location to be settable such that it can be updated for different rollup versions

in progress:
- implement a test which deploys a split for between the forwarders
