### PR TITLE
fix: tuple mismatch in some tests

### DIFF
--- a/noir-projects/noir-contracts/contracts/test/test_contract/src/test.nr
+++ b/noir-projects/noir-contracts/contracts/test/test_contract/src/test.nr
@@ -132,7 +132,7 @@ pub unconstrained fn setup() -> (&mut TestEnvironment, AztecAddress, AztecAddres
 // In these tests we deploy a contract and can prove whether it has been deployed / initialized at specific blocks.
 #[test]
 unconstrained fn contract_historical_proofs_happy_path() {
-    let (env, contract_address) = setup();
+    let (env, contract_address, _owner) = setup();
 
     let context_at_block_before_deployment = env.private_at(CONTRACT_DEPLOYED_AT - 1);
     let context_at_block_of_deployment = env.private_at(CONTRACT_DEPLOYED_AT);
@@ -159,7 +159,7 @@ unconstrained fn contract_historical_proofs_happy_path() {
 // of the deployment nullifier in state.
 #[test(should_fail_with = "Nullifier membership witness not found at block 2.")]
 unconstrained fn proving_contract_deployment_fails() {
-    let (env, contract_address) = setup();
+    let (env, contract_address, _owner) = setup();
 
     let context = env.private_at(CONTRACT_DEPLOYED_AT - 1);
 
@@ -170,7 +170,7 @@ unconstrained fn proving_contract_deployment_fails() {
 // of the initialization nullifier in state.
 #[test(should_fail_with = "Nullifier membership witness not found at block 2.")]
 unconstrained fn proving_contract_initialization_fails() {
-    let (env, contract_address) = setup();
+    let (env, contract_address, _owner) = setup();
 
     let context = env.private_at(CONTRACT_INITIALIZED_AT - 1);
 
@@ -180,7 +180,7 @@ unconstrained fn proving_contract_initialization_fails() {
 // In this test, we fail to prove contract non-deployment at the block of its deployment.
 #[test(should_fail_with = "Proving nullifier non-inclusion failed")]
 unconstrained fn proving_contract_non_deployment_fails() {
-    let (env, contract_address) = setup();
+    let (env, contract_address, _owner) = setup();
 
     let context = env.private_at(CONTRACT_DEPLOYED_AT);
 
@@ -190,7 +190,7 @@ unconstrained fn proving_contract_non_deployment_fails() {
 // In this test, we fail to prove contract non-initialization at the block of its deployment.
 #[test(should_fail_with = "Proving nullifier non-inclusion failed")]
 unconstrained fn proving_contract_non_initialization_fails() {
-    let (env, contract_address) = setup();
+    let (env, contract_address, _owner) = setup();
 
     let context = env.private_at(CONTRACT_INITIALIZED_AT);
 


### PR DESCRIPTION
If you have code like this:

```noir
fn main() {
    let (x, y) = (1, 2, 3);
}
```

then Noir, unlike Rust, doesn't complain that the left-hand side tuple doesn't have exactly the number of elements that are on the right side.

That's about to change (it's a bug) when this PR merges: https://github.com/noir-lang/noir/pull/8424

Before that, we can fix the existing errors here.

I chose to ignore the extra tuple element because it's currently ignored, but I don't know if the "owner" should be used for something in tests (alternatively maybe "owner" should not be returned if it's not going to be used).