### PR TITLE
feat: add experimental utility call interfaces and use them with `env.simulate_utility` txe tests

### DIFF
--- a/noir-projects/aztec-nr/aztec/src/context/call_interfaces.nr
+++ b/noir-projects/aztec-nr/aztec/src/context/call_interfaces.nr
@@ -683,3 +683,105 @@ impl<let N: u32> CallInterface<N> for PublicStaticVoidCallInterface<N> {
         self.is_static
     }
 }
+
+// UtilityCallInterface
+
+pub struct UtilityCallInterface<let N: u32, T> {
+    target_contract: AztecAddress,
+    selector: FunctionSelector,
+    name: str<N>,
+    args_hash: Field,
+    args: [Field],
+    return_type: T,
+    is_static: bool,
+}
+
+impl<let N: u32, T> UtilityCallInterface<N, T> {
+    pub fn new(
+        target_contract: AztecAddress,
+        selector: FunctionSelector,
+        name: str<N>,
+        args: [Field],
+        is_static: bool,
+    ) -> Self {
+        let args_hash = hash_args(args);
+        Self {
+            target_contract,
+            selector,
+            name,
+            args_hash,
+            args,
+            return_type: std::mem::zeroed(),
+            is_static,
+        }
+    }
+}
+
+impl<let N: u32, T> CallInterface<N> for UtilityCallInterface<N, T> {
+    fn get_args(self) -> [Field] {
+        self.args
+    }
+
+    fn get_selector(self) -> FunctionSelector {
+        self.selector
+    }
+
+    fn get_name(self) -> str<N> {
+        self.name
+    }
+
+    fn get_contract_address(self) -> AztecAddress {
+        self.target_contract
+    }
+
+    fn get_is_static(self) -> bool {
+        self.is_static
+    }
+}
+
+// UtilityVoidCallInterface
+
+pub struct UtilityVoidCallInterface<let N: u32> {
+    target_contract: AztecAddress,
+    selector: FunctionSelector,
+    name: str<N>,
+    args_hash: Field,
+    args: [Field],
+    return_type: (),
+    is_static: bool,
+}
+
+impl<let N: u32> UtilityVoidCallInterface<N> {
+    pub fn new(
+        target_contract: AztecAddress,
+        selector: FunctionSelector,
+        name: str<N>,
+        args: [Field],
+        is_static: bool,
+    ) -> Self {
+        let args_hash = hash_args(args);
+        Self { target_contract, selector, name, args_hash, args, return_type: (), is_static }
+    }
+}
+
+impl<let N: u32> CallInterface<N> for UtilityVoidCallInterface<N> {
+    fn get_args(self) -> [Field] {
+        self.args
+    }
+
+    fn get_selector(self) -> FunctionSelector {
+        self.selector
+    }
+
+    fn get_name(self) -> str<N> {
+        self.name
+    }
+
+    fn get_contract_address(self) -> AztecAddress {
+        self.target_contract
+    }
+
+    fn get_is_static(self) -> bool {
+        self.is_static
+    }
+}

--- a/noir-projects/aztec-nr/aztec/src/context/call_interfaces.nr
+++ b/noir-projects/aztec-nr/aztec/src/context/call_interfaces.nr
@@ -693,7 +693,6 @@ pub struct UtilityCallInterface<let N: u32, T> {
     args_hash: Field,
     args: [Field],
     return_type: T,
-    is_static: bool,
 }
 
 impl<let N: u32, T> UtilityCallInterface<N, T> {
@@ -702,40 +701,25 @@ impl<let N: u32, T> UtilityCallInterface<N, T> {
         selector: FunctionSelector,
         name: str<N>,
         args: [Field],
-        is_static: bool,
     ) -> Self {
         let args_hash = hash_args(args);
-        Self {
-            target_contract,
-            selector,
-            name,
-            args_hash,
-            args,
-            return_type: std::mem::zeroed(),
-            is_static,
-        }
+        Self { target_contract, selector, name, args_hash, args, return_type: std::mem::zeroed() }
     }
-}
 
-impl<let N: u32, T> CallInterface<N> for UtilityCallInterface<N, T> {
-    fn get_args(self) -> [Field] {
+    pub fn get_args(self) -> [Field] {
         self.args
     }
 
-    fn get_selector(self) -> FunctionSelector {
+    pub fn get_selector(self) -> FunctionSelector {
         self.selector
     }
 
-    fn get_name(self) -> str<N> {
+    pub fn get_name(self) -> str<N> {
         self.name
     }
 
-    fn get_contract_address(self) -> AztecAddress {
+    pub fn get_contract_address(self) -> AztecAddress {
         self.target_contract
-    }
-
-    fn get_is_static(self) -> bool {
-        self.is_static
     }
 }
 
@@ -748,7 +732,6 @@ pub struct UtilityVoidCallInterface<let N: u32> {
     args_hash: Field,
     args: [Field],
     return_type: (),
-    is_static: bool,
 }
 
 impl<let N: u32> UtilityVoidCallInterface<N> {
@@ -757,31 +740,24 @@ impl<let N: u32> UtilityVoidCallInterface<N> {
         selector: FunctionSelector,
         name: str<N>,
         args: [Field],
-        is_static: bool,
     ) -> Self {
         let args_hash = hash_args(args);
-        Self { target_contract, selector, name, args_hash, args, return_type: (), is_static }
+        Self { target_contract, selector, name, args_hash, args, return_type: () }
     }
-}
 
-impl<let N: u32> CallInterface<N> for UtilityVoidCallInterface<N> {
-    fn get_args(self) -> [Field] {
+    pub fn get_args(self) -> [Field] {
         self.args
     }
 
-    fn get_selector(self) -> FunctionSelector {
+    pub fn get_selector(self) -> FunctionSelector {
         self.selector
     }
 
-    fn get_name(self) -> str<N> {
+    pub fn get_name(self) -> str<N> {
         self.name
     }
 
-    fn get_contract_address(self) -> AztecAddress {
+    pub fn get_contract_address(self) -> AztecAddress {
         self.target_contract
-    }
-
-    fn get_is_static(self) -> bool {
-        self.is_static
     }
 }

--- a/noir-projects/aztec-nr/aztec/src/context/mod.nr
+++ b/noir-projects/aztec-nr/aztec/src/context/mod.nr
@@ -12,7 +12,7 @@ pub mod gas;
 pub use call_interfaces::{
     PrivateCallInterface, PrivateStaticCallInterface, PrivateStaticVoidCallInterface,
     PrivateVoidCallInterface, PublicCallInterface, PublicStaticCallInterface,
-    PublicStaticVoidCallInterface, PublicVoidCallInterface,
+    PublicStaticVoidCallInterface, PublicVoidCallInterface, UtilityCallInterface,
 };
 pub use private_context::PrivateContext;
 pub use public_context::PublicContext;

--- a/noir-projects/aztec-nr/aztec/src/macros/functions/call_interface_stubs.nr
+++ b/noir-projects/aztec-nr/aztec/src/macros/functions/call_interface_stubs.nr
@@ -1,5 +1,5 @@
 use crate::macros::utils::{
-    add_to_field_slice, AsStrQuote, compute_fn_selector, is_fn_private, is_fn_view,
+    add_to_field_slice, AsStrQuote, compute_fn_selector, is_fn_private, is_fn_public, is_fn_view,
 };
 use std::meta::{type_of, unquote};
 
@@ -33,7 +33,7 @@ pub comptime fn stub_fn(f: FunctionDefinition) -> Quoted {
                 create_private_stub(f)
             }
         }
-    } else {
+    } else if is_fn_public(f) {
         if is_static_call {
             if is_void {
                 create_public_static_void_stub(f)
@@ -46,6 +46,12 @@ pub comptime fn stub_fn(f: FunctionDefinition) -> Quoted {
             } else {
                 create_public_stub(f)
             }
+        }
+    } else {
+        if is_void {
+            create_utility_void_stub(f)
+        } else {
+            create_utility_stub(f)
         }
     }
 }
@@ -237,6 +243,47 @@ comptime fn create_public_static_void_stub(f: FunctionDefinition) -> Quoted {
                 selector,
                 $fn_name_str,
                 serialized_args
+            )
+        }
+    }
+}
+
+comptime fn create_utility_stub(f: FunctionDefinition) -> Quoted {
+    let (fn_name, fn_parameters_list, serialized_args_slice_construction, fn_name_str, fn_name_len, fn_selector) =
+        create_stub_base(f);
+    let fn_return_type = f.return_type();
+
+    quote {
+        pub fn $fn_name(self, $fn_parameters_list) -> dep::aztec::context::call_interfaces::UtilityCallInterface<$fn_name_len, $fn_return_type> {
+            $serialized_args_slice_construction
+            let selector = $FROM_FIELD($fn_selector);
+            dep::aztec::context::call_interfaces::UtilityCallInterface::new(
+                self.target_contract,
+                selector,
+                $fn_name_str,
+                $SERIALIZED_ARGS_SLICE_NAME,
+                // Utility functions are static
+                true
+            )
+        }
+    }
+}
+
+comptime fn create_utility_void_stub(f: FunctionDefinition) -> Quoted {
+    let (fn_name, fn_parameters_list, serialized_args_slice_construction, fn_name_str, fn_name_len, fn_selector) =
+        create_stub_base(f);
+
+    quote {
+        pub fn $fn_name(self, $fn_parameters_list) -> dep::aztec::context::call_interfaces::UtilityVoidCallInterface<$fn_name_len> {
+            $serialized_args_slice_construction
+            let selector = $FROM_FIELD($fn_selector);
+            dep::aztec::context::call_interfaces::UtilityVoidCallInterface::new(
+                self.target_contract,
+                selector,
+                $fn_name_str,
+                $SERIALIZED_ARGS_SLICE_NAME,
+                // Utility functions are static
+                true
             )
         }
     }

--- a/noir-projects/aztec-nr/aztec/src/macros/functions/call_interface_stubs.nr
+++ b/noir-projects/aztec-nr/aztec/src/macros/functions/call_interface_stubs.nr
@@ -253,8 +253,11 @@ comptime fn create_utility_stub(f: FunctionDefinition) -> Quoted {
         create_stub_base(f);
     let fn_return_type = f.return_type();
 
+    // This is here because utility function call interfaces can only be used within TXe tests.
+    let modified_fn_name = f"_experimental_{fn_name}".quoted_contents();
+
     quote {
-        pub fn $fn_name(self, $fn_parameters_list) -> dep::aztec::context::call_interfaces::UtilityCallInterface<$fn_name_len, $fn_return_type> {
+        pub fn $modified_fn_name(self, $fn_parameters_list) -> dep::aztec::context::call_interfaces::UtilityCallInterface<$fn_name_len, $fn_return_type> {
             $serialized_args_slice_construction
             let selector = $FROM_FIELD($fn_selector);
             dep::aztec::context::call_interfaces::UtilityCallInterface::new(
@@ -262,8 +265,6 @@ comptime fn create_utility_stub(f: FunctionDefinition) -> Quoted {
                 selector,
                 $fn_name_str,
                 $SERIALIZED_ARGS_SLICE_NAME,
-                // Utility functions are static
-                true
             )
         }
     }
@@ -273,8 +274,11 @@ comptime fn create_utility_void_stub(f: FunctionDefinition) -> Quoted {
     let (fn_name, fn_parameters_list, serialized_args_slice_construction, fn_name_str, fn_name_len, fn_selector) =
         create_stub_base(f);
 
+    // This is here because utility function call interfaces can only be used within TXe tests.
+    let modified_fn_name = f"_experimental_{fn_name}".quoted_contents();
+
     quote {
-        pub fn $fn_name(self, $fn_parameters_list) -> dep::aztec::context::call_interfaces::UtilityVoidCallInterface<$fn_name_len> {
+        pub fn $modified_fn_name(self, $fn_parameters_list) -> dep::aztec::context::call_interfaces::UtilityVoidCallInterface<$fn_name_len> {
             $serialized_args_slice_construction
             let selector = $FROM_FIELD($fn_selector);
             dep::aztec::context::call_interfaces::UtilityVoidCallInterface::new(
@@ -282,8 +286,6 @@ comptime fn create_utility_void_stub(f: FunctionDefinition) -> Quoted {
                 selector,
                 $fn_name_str,
                 $SERIALIZED_ARGS_SLICE_NAME,
-                // Utility functions are static
-                true
             )
         }
     }

--- a/noir-projects/aztec-nr/aztec/src/macros/functions/mod.nr
+++ b/noir-projects/aztec-nr/aztec/src/macros/functions/mod.nr
@@ -59,6 +59,6 @@ pub comptime fn public(f: FunctionDefinition) -> Quoted {
 /// Utility functions are standalone unconstrained functions that cannot be called from another function in a contract.
 /// They are typically used either to obtain some information from the contract (e.g. token balance of a user) or to
 /// modify internal contract-related state of PXE (e.g. processing logs in Aztec.nr during sync).
-pub comptime fn utility(f: FunctionDefinition) {
-    transform_utility(f);
+pub comptime fn utility(f: FunctionDefinition) -> Quoted {
+    transform_utility(f)
 }

--- a/noir-projects/aztec-nr/aztec/src/macros/functions/utils.nr
+++ b/noir-projects/aztec-nr/aztec/src/macros/functions/utils.nr
@@ -272,7 +272,11 @@ pub(crate) comptime fn transform_public(f: FunctionDefinition) -> Quoted {
     fn_abi
 }
 
-pub(crate) comptime fn transform_utility(f: FunctionDefinition) {
+pub(crate) comptime fn transform_utility(f: FunctionDefinition) -> Quoted {
+    let fn_abi = create_fn_abi_export(f);
+    let fn_stub = stub_fn(f);
+    stub_registry::register(f.module(), fn_stub);
+
     // Check if function is marked as unconstrained
     if !f.is_unconstrained() {
         let name = f.name();
@@ -319,6 +323,8 @@ pub(crate) comptime fn transform_utility(f: FunctionDefinition) {
     f.set_body(modified_body);
 
     f.set_return_public(true);
+
+    fn_abi
 }
 
 comptime fn create_internal_check(f: FunctionDefinition) -> Quoted {

--- a/noir-projects/aztec-nr/aztec/src/oracle/mod.nr
+++ b/noir-projects/aztec-nr/aztec/src/oracle/mod.nr
@@ -5,6 +5,7 @@
 pub mod aes128_decrypt;
 pub mod block_header;
 pub mod call_private_function;
+pub mod simulate_utility_function;
 pub mod capsules;
 pub mod enqueue_public_function_call;
 pub mod execution;

--- a/noir-projects/aztec-nr/aztec/src/oracle/simulate_utility_function.nr
+++ b/noir-projects/aztec-nr/aztec/src/oracle/simulate_utility_function.nr
@@ -1,0 +1,25 @@
+use dep::protocol_types::{abis::function_selector::FunctionSelector, address::AztecAddress};
+
+pub unconstrained fn simulate_utility_function(
+    contract_address: AztecAddress,
+    function_selector: FunctionSelector,
+    args_hash: Field,
+    is_static_call: bool,
+) -> Field {
+    let returns_hash = simulate_utility_function_oracle(
+        contract_address,
+        function_selector,
+        args_hash,
+        is_static_call,
+    );
+
+    returns_hash
+}
+
+#[oracle(simulateUtilityFunction)]
+unconstrained fn simulate_utility_function_oracle(
+    _contract_address: AztecAddress,
+    _function_selector: FunctionSelector,
+    _args_hash: Field,
+    _is_static_call: bool,
+) -> Field {}

--- a/noir-projects/aztec-nr/aztec/src/oracle/simulate_utility_function.nr
+++ b/noir-projects/aztec-nr/aztec/src/oracle/simulate_utility_function.nr
@@ -4,14 +4,9 @@ pub unconstrained fn simulate_utility_function(
     contract_address: AztecAddress,
     function_selector: FunctionSelector,
     args_hash: Field,
-    is_static_call: bool,
 ) -> Field {
-    let returns_hash = simulate_utility_function_oracle(
-        contract_address,
-        function_selector,
-        args_hash,
-        is_static_call,
-    );
+    let returns_hash =
+        simulate_utility_function_oracle(contract_address, function_selector, args_hash);
 
     returns_hash
 }
@@ -21,5 +16,4 @@ unconstrained fn simulate_utility_function_oracle(
     _contract_address: AztecAddress,
     _function_selector: FunctionSelector,
     _args_hash: Field,
-    _is_static_call: bool,
 ) -> Field {}

--- a/noir-projects/aztec-nr/aztec/src/test/helpers/test_environment.nr
+++ b/noir-projects/aztec-nr/aztec/src/test/helpers/test_environment.nr
@@ -264,7 +264,6 @@ impl TestEnvironment {
             call_interface.get_contract_address(),
             call_interface.get_selector(),
             args_hash,
-            call_interface.get_is_static(),
         );
 
         let returns: T = ReturnsHash::new(returns_hash).get_preimage();
@@ -283,7 +282,6 @@ impl TestEnvironment {
             call_interface.get_contract_address(),
             call_interface.get_selector(),
             args_hash,
-            call_interface.get_is_static(),
         );
 
         ReturnsHash::new(returns_hash).assert_empty();

--- a/noir-projects/aztec-nr/aztec/src/test/helpers/test_environment.nr
+++ b/noir-projects/aztec-nr/aztec/src/test/helpers/test_environment.nr
@@ -7,7 +7,7 @@ use dep::protocol_types::{
 
 use crate::context::{
     call_interfaces::CallInterface, PrivateCallInterface, PrivateContext, PrivateVoidCallInterface,
-    PublicContext, ReturnsHash, UtilityContext,
+    PublicContext, ReturnsHash, UtilityCallInterface, UtilityContext,
 };
 use crate::hash::hash_args;
 use crate::test::helpers::{cheatcodes, utils::Deployer};
@@ -247,6 +247,46 @@ impl TestEnvironment {
         ReturnsHash::new(returns_hash).assert_empty();
 
         CallResult { return_value: Option::none(), tx_hash }
+    }
+
+    pub unconstrained fn simulate_utility<T, let N: u32, let M: u32>(
+        _self: Self,
+        call_interface: UtilityCallInterface<M, T>,
+    ) -> T
+    where
+        T: Deserialize<N>,
+    {
+        let args = call_interface.get_args();
+        let args_hash = hash_args(args);
+        execution_cache::store(args, args_hash);
+
+        let returns_hash = crate::oracle::simulate_utility_function::simulate_utility_function(
+            call_interface.get_contract_address(),
+            call_interface.get_selector(),
+            args_hash,
+            call_interface.get_is_static(),
+        );
+
+        let returns: T = ReturnsHash::new(returns_hash).get_preimage();
+        returns
+    }
+
+    pub unconstrained fn simulate_void_utility<T, let N: u32, let M: u32>(
+        _self: Self,
+        call_interface: UtilityCallInterface<M, T>,
+    ) {
+        let args = call_interface.get_args();
+        let args_hash = hash_args(args);
+        execution_cache::store(args, args_hash);
+
+        let returns_hash = crate::oracle::simulate_utility_function::simulate_utility_function(
+            call_interface.get_contract_address(),
+            call_interface.get_selector(),
+            args_hash,
+            call_interface.get_is_static(),
+        );
+
+        ReturnsHash::new(returns_hash).assert_empty();
     }
 
     /// Manually adds a note to TXE. This needs to be called if you want to work with a note in your test with the note

--- a/noir-projects/noir-contracts/contracts/test/counter_contract/src/main.nr
+++ b/noir-projects/noir-contracts/contracts/test/counter_contract/src/main.nr
@@ -145,7 +145,7 @@ pub contract Counter {
         // docs:start:txe_test_read_notes
         // Read the stored value in the note
         let initial_counter =
-            env.simulate_utility(Counter::at(contract_address).get_counter(owner));
+            env.simulate_utility(Counter::at(contract_address)._experimental_get_counter(owner));
         assert(
             initial_counter == initial_value,
             f"Expected {initial_value} but got {initial_counter}",
@@ -157,7 +157,7 @@ pub contract Counter {
             env.call_private_void(owner, Counter::at(contract_address).increment(owner, sender));
 
         let incremented_counter =
-            env.simulate_utility(Counter::at(contract_address).get_counter(owner));
+            env.simulate_utility(Counter::at(contract_address)._experimental_get_counter(owner));
         let expected_current_value = initial_value + 1;
         assert(
             expected_current_value == incremented_counter,

--- a/noir-projects/noir-contracts/contracts/test/counter_contract/src/main.nr
+++ b/noir-projects/noir-contracts/contracts/test/counter_contract/src/main.nr
@@ -144,30 +144,24 @@ pub contract Counter {
         let contract_address = counter_contract.to_address();
         // docs:start:txe_test_read_notes
         // Read the stored value in the note
-        env.impersonate(contract_address);
-        sync_notes();
-        let counter_slot = Counter::storage_layout().counters.slot;
-        let owner_storage_slot = derive_storage_slot_in_map(counter_slot, owner);
-        let mut options = NoteViewerOptions::new();
-        let notes: BoundedVec<ValueNote, MAX_NOTES_PER_PAGE> =
-            view_notes(owner_storage_slot, options);
-        let initial_note_value = notes.get(0).value;
+        let initial_counter =
+            env.simulate_utility(Counter::at(contract_address).get_counter(owner));
         assert(
-            initial_note_value == initial_value,
-            f"Expected {initial_value} but got {initial_note_value}",
+            initial_counter == initial_value,
+            f"Expected {initial_value} but got {initial_counter}",
         );
         // docs:end:txe_test_read_notes
+
         // Increment the counter
-        env.impersonate(owner);
-        Counter::at(contract_address).increment(owner, sender).call(&mut env.private());
-        // get_counter is an unconstrained function, so we call it directly (we're in the same module)
-        env.impersonate(contract_address);
-        sync_notes();
-        let current_value_for_owner = get_counter(owner);
+        let _ =
+            env.call_private_void(owner, Counter::at(contract_address).increment(owner, sender));
+
+        let incremented_counter =
+            env.simulate_utility(Counter::at(contract_address).get_counter(owner));
         let expected_current_value = initial_value + 1;
         assert(
-            expected_current_value == current_value_for_owner,
-            f"Expected {expected_current_value} but got {current_value_for_owner}",
+            expected_current_value == incremented_counter,
+            f"Expected {expected_current_value} but got {incremented_counter}",
         );
     }
     // docs:end:txe_test_increment

--- a/noir-projects/noir-protocol-circuits/crates/types/src/traits.nr
+++ b/noir-projects/noir-protocol-circuits/crates/types/src/traits.nr
@@ -217,6 +217,61 @@ impl<let N: u32> Serialize<N> for str<N> {
     }
 }
 
+// T = type of item in BoundedVec
+// M = max length of BoundedVec
+// O = field length of T
+// O * M + 1 = total serialized length of BoundedVec<T, M> (the +1 is for length of the BoundedVec)
+impl<T, let M: u32, let O: u32> Deserialize<O * M + 1> for BoundedVec<T, M>
+where
+    T: Deserialize<O>,
+{
+    fn deserialize(fields: [Field; O * M + 1]) -> Self {
+        let mut new_bounded_vec: BoundedVec<T, M> = BoundedVec::new();
+
+        let len = fields[0] as u32;
+        let mut index = 1;
+
+        for _ in 0..len {
+            let mut nested_fields = [0; O];
+            for j in 0..O {
+                nested_fields[j] = fields[index];
+                index += 1;
+            }
+
+            let item = T::deserialize(nested_fields);
+            new_bounded_vec.push(item);
+        }
+
+        new_bounded_vec
+    }
+}
+
+impl<T, let M: u32, let O: u32> Serialize<O * M + 1> for BoundedVec<T, M>
+where
+    T: Serialize<O>,
+{
+    fn serialize(self) -> [Field; O * M + 1] {
+        let mut fields = [0; O * M + 1];
+
+        let len = self.len();
+        fields[0] = len as Field;
+
+        let mut index: u32 = 1;
+
+        for i in 0..len {
+            let item = self.get_unchecked(i);
+            let serialized_item = item.serialize();
+
+            for j in 0..O {
+                fields[index] = serialized_item[j];
+                index += 1;
+            }
+        }
+
+        fields
+    }
+}
+
 // docs:start:deserialize
 /// Trait for deserializing Noir types from arrays of Fields.
 ///

--- a/yarn-project/simulator/src/private/index.ts
+++ b/yarn-project/simulator/src/private/index.ts
@@ -11,6 +11,7 @@ export { witnessMapToFields } from './acvm/deserialize.js';
 export { toACVMWitness } from './acvm/serialize.js';
 export { executePrivateFunction } from './private_execution.js';
 export { PrivateExecutionOracle } from './private_execution_oracle.js';
+export { UtilityExecutionOracle } from './utility_execution_oracle.js';
 export { extractCallStack } from './acvm/acvm.js';
 export { type NoteData, TypedOracle } from './acvm/oracle/typed_oracle.js';
 export { Oracle } from './acvm/oracle/oracle.js';

--- a/yarn-project/txe/src/oracle/txe_oracle.ts
+++ b/yarn-project/txe/src/oracle/txe_oracle.ts
@@ -837,12 +837,7 @@ export class TXE implements TypedOracle {
     throw new Error('Method not implemented.');
   }
 
-  async simulateUtilityFunction(
-    targetContractAddress: AztecAddress,
-    functionSelector: FunctionSelector,
-    argsHash: Fr,
-    _isStaticCall: boolean,
-  ) {
+  async simulateUtilityFunction(targetContractAddress: AztecAddress, functionSelector: FunctionSelector, argsHash: Fr) {
     const artifact = await this.contractDataProvider.getFunctionArtifact(targetContractAddress, functionSelector);
     if (!artifact) {
       throw new Error(`Cannot call ${functionSelector} as there is artifact found at ${targetContractAddress}.`);

--- a/yarn-project/txe/src/oracle/txe_oracle.ts
+++ b/yarn-project/txe/src/oracle/txe_oracle.ts
@@ -43,6 +43,7 @@ import {
   Oracle,
   PrivateExecutionOracle,
   type TypedOracle,
+  UtilityExecutionOracle,
   WASMSimulator,
   executePrivateFunction,
   extractCallStack,
@@ -66,6 +67,7 @@ import {
   EventSelector,
   type FunctionAbi,
   FunctionSelector,
+  FunctionType,
   type NoteSelector,
   countArgumentsSize,
 } from '@aztec/stdlib/abi';
@@ -79,6 +81,7 @@ import {
   computeNoteHashNonce,
   computePublicDataTreeLeafSlot,
   computeUniqueNoteHash,
+  computeVarArgsHash,
   siloNoteHash,
   siloNullifier,
 } from '@aztec/stdlib/hash';
@@ -832,6 +835,66 @@ export class TXE implements TypedOracle {
 
   notifyCreatedContractClassLog(_log: ContractClassLog, _counter: number): Fr {
     throw new Error('Method not implemented.');
+  }
+
+  async simulateUtilityFunction(
+    targetContractAddress: AztecAddress,
+    functionSelector: FunctionSelector,
+    argsHash: Fr,
+    _isStaticCall: boolean,
+  ) {
+    const artifact = await this.contractDataProvider.getFunctionArtifact(targetContractAddress, functionSelector);
+    if (!artifact) {
+      throw new Error(`Cannot call ${functionSelector} as there is artifact found at ${targetContractAddress}.`);
+    }
+
+    const call = {
+      name: artifact.name,
+      selector: functionSelector,
+      to: targetContractAddress,
+    };
+
+    const entryPointArtifact = await this.pxeOracleInterface.getFunctionArtifact(call.to, call.selector);
+
+    if (entryPointArtifact.functionType !== FunctionType.UTILITY) {
+      throw new Error(`Cannot run ${entryPointArtifact.functionType} function as utility`);
+    }
+
+    const oracle = new UtilityExecutionOracle(call.to, [], [], this.pxeOracleInterface, undefined, undefined);
+
+    try {
+      this.logger.verbose(`Executing utility function ${entryPointArtifact.name}`, {
+        contract: call.to,
+        selector: call.selector,
+      });
+
+      const args = await this.loadFromExecutionCache(argsHash);
+      const initialWitness = toACVMWitness(0, args);
+      const acirExecutionResult = await this.simulationProvider
+        .executeUserCircuit(initialWitness, entryPointArtifact, new Oracle(oracle))
+        .catch((err: Error) => {
+          err.message = resolveAssertionMessageFromError(err, entryPointArtifact);
+          throw new ExecutionError(
+            err.message,
+            {
+              contractAddress: call.to,
+              functionSelector: call.selector,
+            },
+            extractCallStack(err, entryPointArtifact.debug),
+            { cause: err },
+          );
+        });
+
+      const returnWitness = witnessMapToFields(acirExecutionResult.returnWitness);
+      this.logger.verbose(`Utility simulation for ${call.to}.${call.selector} completed`);
+
+      const returnHash = await computeVarArgsHash(returnWitness);
+
+      this.storeInExecutionCache(returnWitness, returnHash);
+      return returnHash;
+    } catch (err) {
+      throw createSimulationError(err instanceof Error ? err : new Error('Unknown error during private execution'));
+    }
   }
 
   async callPrivateFunction(

--- a/yarn-project/txe/src/txe_service/txe_service.ts
+++ b/yarn-project/txe/src/txe_service/txe_service.ts
@@ -1199,13 +1199,11 @@ export class TXEService {
     targetContractAddress: ForeignCallSingle,
     functionSelector: ForeignCallSingle,
     argsHash: ForeignCallSingle,
-    isStaticCall: ForeignCallSingle,
   ) {
     const result = await (this.typedOracle as TXE).simulateUtilityFunction(
       addressFromSingle(targetContractAddress),
       FunctionSelector.fromField(fromSingle(functionSelector)),
       fromSingle(argsHash),
-      fromSingle(isStaticCall).toBool(),
     );
 
     return toForeignCallResult([toSingle(result)]);

--- a/yarn-project/txe/src/txe_service/txe_service.ts
+++ b/yarn-project/txe/src/txe_service/txe_service.ts
@@ -1194,4 +1194,20 @@ export class TXEService {
   enableOracles() {
     this.oraclesEnabled = true;
   }
+
+  async simulateUtilityFunction(
+    targetContractAddress: ForeignCallSingle,
+    functionSelector: ForeignCallSingle,
+    argsHash: ForeignCallSingle,
+    isStaticCall: ForeignCallSingle,
+  ) {
+    const result = await (this.typedOracle as TXE).simulateUtilityFunction(
+      addressFromSingle(targetContractAddress),
+      FunctionSelector.fromField(fromSingle(functionSelector)),
+      fromSingle(argsHash),
+      fromSingle(isStaticCall).toBool(),
+    );
+
+    return toForeignCallResult([toSingle(result)]);
+  }
 }


### PR DESCRIPTION
This does not affect users not calling this via the TXe, as there is no API to call the actual interface on the call interface itself.

This simply allows for the macro to expose the UtilityCallInterface, so we can have parity when writing TXe tests.