### PR TITLE
chore: Reenable sentinel e2e test

### DIFF
--- a/.test_patterns.yml
+++ b/.test_patterns.yml
@@ -114,8 +114,6 @@ tests:
     owners:
       - *palla
   - regex: "e2e_p2p/validators_sentinel"
-    # Too noisey, skipping.
-    skip: true
     error_regex: "Expected: >= 2"
     owners:
       - *palla

--- a/yarn-project/end-to-end/src/e2e_p2p/validators_sentinel.test.ts
+++ b/yarn-project/end-to-end/src/e2e_p2p/validators_sentinel.test.ts
@@ -75,6 +75,17 @@ describe('e2e_p2p_validators_sentinel', () => {
       t.logger.info(`Waiting until L2 block ${currentBlock + blockCount}`, { currentBlock, blockCount, timeout });
       await retryUntil(() => t.monitor.l2BlockNumber >= currentBlock + blockCount, 'blocks mined', timeout);
 
+      t.logger.info(`Waiting until sentinel processed at least ${blockCount - 1} slots`);
+      await retryUntil(
+        async () => {
+          const { initialSlot, lastProcessedSlot } = await nodes[0].getValidatorsStats();
+          return initialSlot && lastProcessedSlot && lastProcessedSlot - initialSlot >= blockCount - 1;
+        },
+        'sentinel processed blocks',
+        SHORTENED_BLOCK_TIME_CONFIG.aztecSlotDuration * 4,
+        1,
+      );
+
       stats = await nodes[0].getValidatorsStats();
       t.logger.info(`Collected validator stats at block ${t.monitor.l2BlockNumber}`, { stats });
     });


### PR DESCRIPTION
CI was failing as nodes sometimes started a bit late, causing the sentinel to miss the first slot and return a history shorter than expected.

This PR waits until sentinel has collected the expected data.
