### PR TITLE
chore: nuke validator add cheatcode

### DIFF
--- a/l1-contracts/src/core/RollupCore.sol
+++ b/l1-contracts/src/core/RollupCore.sol
@@ -6,7 +6,6 @@ import {IFeeJuicePortal} from "@aztec/core/interfaces/IFeeJuicePortal.sol";
 import {
   IRollupCore,
   ITestRollup,
-  CheatDepositArgs,
   RollupStore,
   SubmitEpochRootProofArgs,
   RollupConfigInput
@@ -113,14 +112,6 @@ contract RollupCore is
   /* -------------------------------------------------------------------------- */
   /*                          CHEAT CODES START HERE                            */
   /* -------------------------------------------------------------------------- */
-
-  function cheat__InitialiseValidatorSet(CheatDepositArgs[] memory _args)
-    external
-    override(ITestRollup)
-    onlyOwner
-  {
-    CheatLib.cheat__InitialiseValidatorSet(_args);
-  }
 
   function setEpochVerifier(address _verifier) external override(ITestRollup) onlyOwner {
     CheatLib.setEpochVerifier(_verifier);

--- a/l1-contracts/src/core/interfaces/IRollup.sol
+++ b/l1-contracts/src/core/interfaces/IRollup.sol
@@ -110,20 +110,12 @@ struct RollupStore {
   RollupConfig config;
 }
 
-struct CheatDepositArgs {
-  address attester;
-  address proposer;
-  address withdrawer;
-  uint256 amount;
-}
-
 interface ITestRollup {
   event ManaTargetUpdated(uint256 indexed manaTarget);
 
   function setEpochVerifier(address _verifier) external;
   function setVkTreeRoot(bytes32 _vkTreeRoot) external;
   function setProtocolContractTreeRoot(bytes32 _protocolContractTreeRoot) external;
-  function cheat__InitialiseValidatorSet(CheatDepositArgs[] memory _args) external;
   function updateManaTarget(uint256 _manaTarget) external;
 }
 

--- a/l1-contracts/src/core/libraries/rollup/CheatLib.sol
+++ b/l1-contracts/src/core/libraries/rollup/CheatLib.sol
@@ -2,10 +2,8 @@
 // Copyright 2024 Aztec Labs.
 pragma solidity >=0.8.27;
 
-import {CheatDepositArgs} from "@aztec/core/interfaces/IRollup.sol";
 import {IVerifier} from "@aztec/core/interfaces/IVerifier.sol";
 import {STFLib} from "@aztec/core/libraries/rollup/STFLib.sol";
-import {StakingLib} from "@aztec/core/libraries/staking/StakingLib.sol";
 
 /**
  * @title   CheatLib
@@ -14,12 +12,6 @@ import {StakingLib} from "@aztec/core/libraries/staking/StakingLib.sol";
  *          Should be nuked from orbit.
  */
 library CheatLib {
-  function cheat__InitialiseValidatorSet(CheatDepositArgs[] memory _args) internal {
-    for (uint256 i = 0; i < _args.length; i++) {
-      StakingLib.deposit(_args[i].attester, _args[i].proposer, _args[i].withdrawer, _args[i].amount);
-    }
-  }
-
   function setEpochVerifier(address _verifier) internal {
     STFLib.getStorage().config.epochProofVerifier = IVerifier(_verifier);
   }

--- a/l1-contracts/src/mock/MultiAdder.sol
+++ b/l1-contracts/src/mock/MultiAdder.sol
@@ -1,0 +1,37 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright 2024 Aztec Labs.
+pragma solidity >=0.8.27;
+
+import {IStaking} from "@aztec/core/interfaces/IStaking.sol";
+import {IERC20} from "@oz/token/ERC20/IERC20.sol";
+
+struct CheatDepositArgs {
+  address attester;
+  address proposer;
+  address withdrawer;
+  uint256 amount;
+}
+
+interface IMultiAdder {
+  function addValidators(CheatDepositArgs[] memory _args) external;
+}
+
+contract MultiAdder is IMultiAdder {
+  address public immutable OWNER;
+  IStaking public immutable STAKING;
+
+  constructor(address _staking, address _owner) {
+    OWNER = _owner;
+    STAKING = IStaking(_staking);
+
+    IERC20 stakingAsset = STAKING.getStakingAsset();
+    stakingAsset.approve(address(STAKING), type(uint256).max);
+  }
+
+  function addValidators(CheatDepositArgs[] memory _args) external override(IMultiAdder) {
+    require(msg.sender == OWNER, "Not owner");
+    for (uint256 i = 0; i < _args.length; i++) {
+      STAKING.deposit(_args[i].attester, _args[i].proposer, _args[i].withdrawer, _args[i].amount);
+    }
+  }
+}

--- a/l1-contracts/test/benchmark/happy.t.sol
+++ b/l1-contracts/test/benchmark/happy.t.sol
@@ -49,7 +49,6 @@ import {
   L1FeeData,
   ManaBaseFeeComponents
 } from "@aztec/core/libraries/rollup/FeeLib.sol";
-import {CheatDepositArgs} from "@aztec/core/interfaces/IRollup.sol";
 import {
   FeeModelTestPoints,
   TestPoint,
@@ -61,6 +60,7 @@ import {
   Timestamp, Slot, Epoch, SlotLib, EpochLib, TimeLib
 } from "@aztec/core/libraries/TimeLib.sol";
 import {Forwarder} from "@aztec/periphery/Forwarder.sol";
+import {MultiAdder, CheatDepositArgs} from "@aztec/mock/MultiAdder.sol";
 
 // solhint-disable comprehensive-interface
 
@@ -186,9 +186,9 @@ contract BenchmarkRollupTest is FeeModelTestPoints, DecoderBase {
       });
     }
 
-    asset.mint(address(this), TestConstants.AZTEC_MINIMUM_STAKE * _validatorCount);
-    asset.approve(address(rollup), TestConstants.AZTEC_MINIMUM_STAKE * _validatorCount);
-    rollup.cheat__InitialiseValidatorSet(initialValidators);
+    MultiAdder multiAdder = new MultiAdder(address(rollup), address(this));
+    asset.mint(address(multiAdder), TestConstants.AZTEC_MINIMUM_STAKE * _validatorCount);
+    multiAdder.addValidators(initialValidators);
     asset.mint(address(rollup.getFeeAssetPortal()), 1e30);
 
     asset.transferOwnership(address(fakeCanonical));

--- a/l1-contracts/test/governance/scenario/UpgradeGovernanceProposerTest.t.sol
+++ b/l1-contracts/test/governance/scenario/UpgradeGovernanceProposerTest.t.sol
@@ -17,8 +17,9 @@ import {ProposalLib} from "@aztec/governance/libraries/ProposalLib.sol";
 import {Errors} from "@aztec/governance/libraries/Errors.sol";
 import {NewGovernanceProposerPayload} from "./NewGovernanceProposerPayload.sol";
 import {RewardDistributor} from "@aztec/governance/RewardDistributor.sol";
-import {IRollup, CheatDepositArgs} from "@aztec/core/interfaces/IRollup.sol";
+import {IRollup} from "@aztec/core/interfaces/IRollup.sol";
 import {TestConstants} from "../../harnesses/TestConstants.sol";
+import {MultiAdder, CheatDepositArgs} from "@aztec/mock/MultiAdder.sol";
 
 /**
  * @title UpgradeGovernanceProposerTest
@@ -77,9 +78,9 @@ contract UpgradeGovernanceProposerTest is TestBase {
       TestConstants.getRollupConfigInput()
     );
 
-    token.mint(address(this), TestConstants.AZTEC_MINIMUM_STAKE * VALIDATOR_COUNT);
-    token.approve(address(rollup), TestConstants.AZTEC_MINIMUM_STAKE * VALIDATOR_COUNT);
-    rollup.cheat__InitialiseValidatorSet(initialValidators);
+    MultiAdder multiAdder = new MultiAdder(address(rollup), address(this));
+    token.mint(address(multiAdder), TestConstants.AZTEC_MINIMUM_STAKE * VALIDATOR_COUNT);
+    multiAdder.addValidators(initialValidators);
 
     registry.addRollup(IRollup(address(rollup)));
     registry.updateGovernance(address(governance));

--- a/l1-contracts/test/governance/scenario/slashing/Slashing.t.sol
+++ b/l1-contracts/test/governance/scenario/slashing/Slashing.t.sol
@@ -9,7 +9,6 @@ import {Rollup} from "@aztec/core/Rollup.sol";
 import {TestERC20} from "@aztec/mock/TestERC20.sol";
 import {MockFeeJuicePortal} from "@aztec/mock/MockFeeJuicePortal.sol";
 import {TestConstants} from "../../../harnesses/TestConstants.sol";
-import {CheatDepositArgs} from "@aztec/core/interfaces/IRollup.sol";
 
 import {RewardDistributor} from "@aztec/governance/RewardDistributor.sol";
 
@@ -18,11 +17,11 @@ import {Slasher, IPayload} from "@aztec/core/slashing/Slasher.sol";
 import {IValidatorSelection} from "@aztec/core/interfaces/IValidatorSelection.sol";
 import {Status, ValidatorInfo} from "@aztec/core/interfaces/IStaking.sol";
 
-import {CheatDepositArgs} from "@aztec/core/interfaces/IRollup.sol";
 import {SlashingProposer} from "@aztec/core/slashing/SlashingProposer.sol";
 
 import {Timestamp, Slot, Epoch} from "@aztec/core/libraries/TimeLib.sol";
 import {TimeCheater} from "../../../staking/TimeCheater.sol";
+import {MultiAdder, CheatDepositArgs} from "@aztec/mock/MultiAdder.sol";
 
 contract SlashingScenario is TestBase {
   TestERC20 internal testERC20;
@@ -74,9 +73,9 @@ contract SlashingScenario is TestBase {
       TestConstants.AZTEC_EPOCH_DURATION
     );
 
-    testERC20.mint(address(this), TestConstants.AZTEC_MINIMUM_STAKE * validatorCount);
-    testERC20.approve(address(rollup), TestConstants.AZTEC_MINIMUM_STAKE * validatorCount);
-    rollup.cheat__InitialiseValidatorSet(initialValidators);
+    MultiAdder multiAdder = new MultiAdder(address(rollup), address(this));
+    testERC20.mint(address(multiAdder), TestConstants.AZTEC_MINIMUM_STAKE * validatorCount);
+    multiAdder.addValidators(initialValidators);
 
     // Cast a bunch of votes
     timeCheater.cheat__jumpForwardEpochs(1);

--- a/l1-contracts/test/scream-and-shout.t.sol
+++ b/l1-contracts/test/scream-and-shout.t.sol
@@ -20,7 +20,7 @@ contract ScreamAndShoutTest is Test {
 
     assertEq(
       codeHash,
-      0xf5661dc2c5fc8908f0046f7f5a4bad9f2bdd569e730ecc36db30d3bb4e6fb57b,
+      0x5a8abb15e6c3a418fe7fe779136265c6abf412dc8ff8c98daa2dee03d5eb01fa,
       "You have changed the rollup!"
     );
   }
@@ -42,7 +42,7 @@ contract ScreamAndShoutTest is Test {
 
     assertEq(
       codeHash,
-      0x6d6f5c217adc349976fc5992f0e001f83b8674c9f2206384422f8328306bb550,
+      0x27568eebc785fca4b250268f171694358fc50603a7b323aaebffac080e6b3426,
       "You have changed the registry!"
     );
   }

--- a/l1-contracts/test/validator-selection/ValidatorSelectionBase.sol
+++ b/l1-contracts/test/validator-selection/ValidatorSelectionBase.sol
@@ -14,13 +14,13 @@ import {MerkleTestUtil} from "../merkle/TestUtil.sol";
 import {TestERC20} from "@aztec/mock/TestERC20.sol";
 import {MessageHashUtils} from "@oz/utils/cryptography/MessageHashUtils.sol";
 import {TestConstants} from "../harnesses/TestConstants.sol";
-import {CheatDepositArgs} from "@aztec/core/interfaces/IRollup.sol";
 
 import {Epoch, EpochLib, Timestamp} from "@aztec/core/libraries/TimeLib.sol";
 import {RewardDistributor} from "@aztec/governance/RewardDistributor.sol";
 import {SlashFactory} from "@aztec/periphery/SlashFactory.sol";
 import {Slasher} from "@aztec/core/slashing/Slasher.sol";
 import {IValidatorSelection} from "@aztec/core/interfaces/IValidatorSelection.sol";
+import {MultiAdder, CheatDepositArgs} from "@aztec/mock/MultiAdder.sol";
 
 import {TimeCheater} from "../staking/TimeCheater.sol";
 // solhint-disable comprehensive-interface
@@ -95,11 +95,10 @@ contract ValidatorSelectionTestBase is DecoderBase {
     slasher = Slasher(rollup.getSlasher());
     slashFactory = new SlashFactory(IValidatorSelection(address(rollup)));
 
-    testERC20.mint(address(this), TestConstants.AZTEC_MINIMUM_STAKE * _validatorCount);
-    testERC20.approve(address(rollup), TestConstants.AZTEC_MINIMUM_STAKE * _validatorCount);
-
     if (_validatorCount > 0) {
-      rollup.cheat__InitialiseValidatorSet(initialValidators);
+      MultiAdder multiAdder = new MultiAdder(address(rollup), address(this));
+      testERC20.mint(address(multiAdder), TestConstants.AZTEC_MINIMUM_STAKE * _validatorCount);
+      multiAdder.addValidators(initialValidators);
     }
 
     inbox = Inbox(address(rollup.getInbox()));

--- a/l1-contracts/test/validator-selection/setupEpoch.t.sol
+++ b/l1-contracts/test/validator-selection/setupEpoch.t.sol
@@ -7,6 +7,7 @@ import {Epoch, Timestamp} from "@aztec/core/libraries/TimeLib.sol";
 import {Checkpoints} from "@oz/utils/structs/Checkpoints.sol";
 import {IValidatorSelection} from "@aztec/core/interfaces/IValidatorSelection.sol";
 import {TestConstants} from "../harnesses/TestConstants.sol";
+import {MultiAdder} from "@aztec/mock/MultiAdder.sol";
 
 contract SetupEpochTest is ValidatorSelectionTestBase {
   using Checkpoints for Checkpoints.Trace224;
@@ -198,8 +199,8 @@ contract SetupEpochTest is ValidatorSelectionTestBase {
       validators[i] = createDepositArgs(i + _saltStart);
     }
 
-    testERC20.mint(address(this), TestConstants.AZTEC_MINIMUM_STAKE * validators.length);
-    testERC20.approve(address(rollup), TestConstants.AZTEC_MINIMUM_STAKE * validators.length);
-    rollup.cheat__InitialiseValidatorSet(validators);
+    MultiAdder multiAdder = new MultiAdder(address(rollup), address(this));
+    testERC20.mint(address(multiAdder), TestConstants.AZTEC_MINIMUM_STAKE * validators.length);
+    multiAdder.addValidators(validators);
   }
 }

--- a/yarn-project/ethereum/src/deploy_l1_contracts.ts
+++ b/yarn-project/ethereum/src/deploy_l1_contracts.ts
@@ -18,6 +18,8 @@ import {
   GovernanceProposerBytecode,
   InboxAbi,
   InboxBytecode,
+  MultiAdderAbi,
+  MultiAdderBytecode,
   OutboxAbi,
   OutboxBytecode,
   RegisterNewRollupVersionPayloadAbi,
@@ -192,6 +194,10 @@ export const l1Artifacts = {
   stakingAssetHandler: {
     contractAbi: StakingAssetHandlerAbi,
     contractBytecode: StakingAssetHandlerBytecode as Hex,
+  },
+  multiAdder: {
+    contractAbi: MultiAdderAbi,
+    contractBytecode: MultiAdderBytecode as Hex,
   },
 };
 
@@ -664,6 +670,18 @@ export const cheat_initializeValidatorSet = async (
     }
 
     if (validators.length > 0) {
+      const multiAdder = await deployer.deploy(l1Artifacts.multiAdder, [
+        rollupAddress,
+        deployer.client.account.address,
+      ]);
+
+      const validatorsTuples = validators.map(v => ({
+        attester: v,
+        proposer: getExpectedAddress(ForwarderAbi, ForwarderBytecode, [v], v).address,
+        withdrawer: v,
+        amount: minimumStake,
+      }));
+
       // Mint tokens, approve them, use cheat code to initialise validator set without setting up the epoch.
       const stakeNeeded = minimumStake * BigInt(validators.length);
       await Promise.all(
@@ -673,30 +691,16 @@ export const cheat_initializeValidatorSet = async (
             data: encodeFunctionData({
               abi: l1Artifacts.stakingAsset.contractAbi,
               functionName: 'mint',
-              args: [extendedClient.account.address, stakeNeeded],
-            }),
-          }),
-          await deployer.sendTransaction({
-            to: stakingAssetAddress,
-            data: encodeFunctionData({
-              abi: l1Artifacts.stakingAsset.contractAbi,
-              functionName: 'approve',
-              args: [rollupAddress, stakeNeeded],
+              args: [multiAdder.toString(), stakeNeeded],
             }),
           }),
         ].map(tx => extendedClient.waitForTransactionReceipt({ hash: tx.txHash })),
       );
 
-      const validatorsTuples = validators.map(v => ({
-        attester: v,
-        proposer: getExpectedAddress(ForwarderAbi, ForwarderBytecode, [v], v).address,
-        withdrawer: v,
-        amount: minimumStake,
-      }));
       const initiateValidatorSetTxHash = await deployer.client.writeContract({
-        address: rollupAddress,
-        abi: l1Artifacts.rollup.contractAbi,
-        functionName: 'cheat__InitialiseValidatorSet',
+        address: multiAdder.toString(),
+        abi: l1Artifacts.multiAdder.contractAbi,
+        functionName: 'addValidators',
         args: [validatorsTuples],
       });
       await extendedClient.waitForTransactionReceipt({ hash: initiateValidatorSetTxHash });

--- a/yarn-project/l1-artifacts/scripts/generate-artifacts.sh
+++ b/yarn-project/l1-artifacts/scripts/generate-artifacts.sh
@@ -38,6 +38,7 @@ contracts=(
   "TokenPortal"
   "UniswapPortal"
   "ValidatorSelectionLib"
+  "MultiAdder"
 )
 
 # Combine error ABIs once, removing duplicates by {type, name}.


### PR DESCRIPTION
Fixes #12050.

Adds a tiny `MultiAdder` that can be used to add a bunch of validators at once. I could be done similarly with a multicall and a proxy, but this seemed the simplest for my case.