### PR TITLE
chore: add `from` in txe deploy

### DIFF
--- a/noir-projects/aztec-nr/aztec/src/test/helpers/cheatcodes.nr
+++ b/noir-projects/aztec-nr/aztec/src/test/helpers/cheatcodes.nr
@@ -14,6 +14,10 @@ pub unconstrained fn get_side_effects_counter() -> u32 {
     oracle_get_side_effects_counter()
 }
 
+pub unconstrained fn get_contract_address() -> AztecAddress {
+    oracle_get_contract_address()
+}
+
 pub unconstrained fn set_contract_address(address: AztecAddress) {
     oracle_set_contract_address(address);
 }
@@ -125,6 +129,9 @@ unconstrained fn oracle_reset() {}
 
 #[oracle(setContractAddress)]
 unconstrained fn oracle_set_contract_address(address: AztecAddress) {}
+
+#[oracle(getContractAddress)]
+unconstrained fn oracle_get_contract_address() -> AztecAddress {}
 
 #[oracle(getSideEffectsCounter)]
 unconstrained fn oracle_get_side_effects_counter() -> u32 {}

--- a/noir-projects/aztec-nr/aztec/src/test/helpers/utils.nr
+++ b/noir-projects/aztec-nr/aztec/src/test/helpers/utils.nr
@@ -28,6 +28,7 @@ pub struct Deployer<let N: u32, let M: u32> {
 impl<let N: u32, let M: u32> Deployer<N, M> {
     pub unconstrained fn with_private_initializer<C, let P: u32>(
         self,
+        from: AztecAddress,
         call_interface: C,
     ) -> ContractInstance
     where
@@ -46,12 +47,18 @@ impl<let N: u32, let M: u32> Deployer<N, M> {
         let args = call_interface.get_args();
         let args_hash = if args.len() > 0 { hash_args(args) } else { 0 };
         execution_cache::store(args, args_hash);
+
+        let previous_contract_address = cheatcodes::get_contract_address();
+        cheatcodes::set_contract_address(from);
+
         let _ = private_context.call_private_function_with_args_hash(
             instance.to_address(),
             call_interface.get_selector(),
             args_hash,
             call_interface.get_is_static(),
         );
+
+        cheatcodes::set_contract_address(previous_contract_address);
 
         cheatcodes::advance_blocks_by(1);
 
@@ -60,6 +67,7 @@ impl<let N: u32, let M: u32> Deployer<N, M> {
 
     pub unconstrained fn with_public_void_initializer<let P: u32, C>(
         self,
+        from: AztecAddress,
         call_interface: C,
     ) -> ContractInstance
     where
@@ -75,6 +83,9 @@ impl<let N: u32, let M: u32> Deployer<N, M> {
 
         let mut public_context = PublicContext::new(|| panic(f"Provide args hash manually"));
 
+        let previous_contract_address = cheatcodes::get_contract_address();
+        cheatcodes::set_contract_address(from);
+
         let results = public_context.call_public_function(
             instance.to_address(),
             call_interface.get_selector(),
@@ -83,6 +94,8 @@ impl<let N: u32, let M: u32> Deployer<N, M> {
         );
         assert(results.len() == 0);
 
+        cheatcodes::set_contract_address(previous_contract_address);
+
         cheatcodes::advance_blocks_by(1);
 
         instance
@@ -90,6 +103,7 @@ impl<let N: u32, let M: u32> Deployer<N, M> {
 
     pub unconstrained fn with_public_initializer<let P: u32, T, C>(
         self,
+        from: AztecAddress,
         call_interface: C,
     ) -> ContractInstance
     where
@@ -106,12 +120,16 @@ impl<let N: u32, let M: u32> Deployer<N, M> {
 
         let mut public_context = PublicContext::new(|| panic(f"Provide args hash manually"));
 
+        let previous_contract_address = cheatcodes::get_contract_address();
+        cheatcodes::set_contract_address(from);
+
         let _ = public_context.call_public_function(
             instance.to_address(),
             call_interface.get_selector(),
             call_interface.get_args(),
             GasOpts::default(),
         );
+        cheatcodes::set_contract_address(previous_contract_address);
 
         cheatcodes::advance_blocks_by(1);
 

--- a/noir-projects/noir-contracts/contracts/app/auth_contract/src/test/utils.nr
+++ b/noir-projects/noir-contracts/contracts/app/auth_contract/src/test/utils.nr
@@ -12,7 +12,7 @@ pub unconstrained fn setup() -> (&mut TestEnvironment, AztecAddress, AztecAddres
     let initializer_call_interface = Auth::interface().constructor(admin);
 
     let auth_contract =
-        env.deploy_self("Auth").with_public_void_initializer(initializer_call_interface);
+        env.deploy_self("Auth").with_public_void_initializer(admin, initializer_call_interface);
     let auth_contract_address = auth_contract.to_address();
 
     (&mut env, auth_contract_address, admin, to_authorize, other)

--- a/noir-projects/noir-contracts/contracts/app/easy_private_voting_contract/src/test/utils.nr
+++ b/noir-projects/noir-contracts/contracts/app/easy_private_voting_contract/src/test/utils.nr
@@ -9,6 +9,7 @@ pub unconstrained fn setup() -> (&mut TestEnvironment, AztecAddress, AztecAddres
 
     let initializer_call_interface = EasyPrivateVoting::interface().constructor(admin);
     let voting_contract = env.deploy_self("EasyPrivateVoting").with_public_void_initializer(
+        admin,
         initializer_call_interface,
     );
 

--- a/noir-projects/noir-contracts/contracts/app/nft_contract/src/test/utils.nr
+++ b/noir-projects/noir-contracts/contracts/app/nft_contract/src/test/utils.nr
@@ -36,7 +36,7 @@ pub unconstrained fn setup(
         "TN00000000000000000000000000000",
     );
     let nft_contract =
-        env.deploy_self("NFT").with_public_void_initializer(initializer_call_interface);
+        env.deploy_self("NFT").with_public_void_initializer(owner, initializer_call_interface);
     let nft_contract_address = nft_contract.to_address();
     env.advance_block_by(1);
     (&mut env, nft_contract_address, owner, recipient)

--- a/noir-projects/noir-contracts/contracts/app/token_contract/src/test/utils.nr
+++ b/noir-projects/noir-contracts/contracts/app/token_contract/src/test/utils.nr
@@ -33,7 +33,7 @@ pub unconstrained fn setup(
         18,
     );
     let token_contract =
-        env.deploy_self("Token").with_public_void_initializer(initializer_call_interface);
+        env.deploy_self("Token").with_public_void_initializer(owner, initializer_call_interface);
     let token_contract_address = token_contract.to_address();
     env.advance_block_by(1);
     (&mut env, token_contract_address, owner, recipient)

--- a/noir-projects/noir-contracts/contracts/test/counter_contract/src/main.nr
+++ b/noir-projects/noir-contracts/contracts/test/counter_contract/src/main.nr
@@ -137,11 +137,12 @@ pub contract Counter {
         let owner = env.create_account(1);
         let sender = env.create_account(2);
         let initial_value: Field = 5;
-        env.impersonate(owner);
+
         // Deploy contract and initialize
         let initializer = Counter::interface().initialize(initial_value as u64, owner);
-        let counter_contract = env.deploy_self("Counter").with_private_initializer(initializer);
-        let contract_address = counter_contract.to_address();
+        let contract_address =
+            env.deploy_self("Counter").with_private_initializer(owner, initializer).to_address();
+
         // docs:start:txe_test_read_notes
         // Read the stored value in the note
         let initial_counter =

--- a/noir-projects/noir-contracts/contracts/test/counter_contract/src/test.nr
+++ b/noir-projects/noir-contracts/contracts/test/counter_contract/src/test.nr
@@ -8,11 +8,10 @@ pub unconstrained fn setup(
     let mut env = TestEnvironment::new();
     let owner = env.create_account(1);
     let sender = env.create_account(2);
-    env.impersonate(owner);
 
     // Deploy contract and initialize
     let initializer = Counter::interface().initialize(initial_value as u64, owner);
-    let counter_contract = env.deploy_self("Counter").with_private_initializer(initializer);
+    let counter_contract = env.deploy_self("Counter").with_private_initializer(owner, initializer);
     let contract_address = counter_contract.to_address();
     (&mut env, contract_address, owner, sender)
 }

--- a/noir-projects/noir-contracts/contracts/test/test_contract/src/test.nr
+++ b/noir-projects/noir-contracts/contracts/test/test_contract/src/test.nr
@@ -120,7 +120,7 @@ pub unconstrained fn setup() -> (&mut TestEnvironment, AztecAddress, AztecAddres
 
     // Deploy contract and initialize
     let initializer = Test::interface().initialize();
-    let test_contract = env.deploy_self("Test").with_private_initializer(initializer);
+    let test_contract = env.deploy_self("Test").with_private_initializer(owner, initializer);
     let contract_address = test_contract.to_address();
 
     (&mut env, contract_address, owner)

--- a/noir-projects/noir-contracts/contracts/test/txe_test_contract/src/test.nr
+++ b/noir-projects/noir-contracts/contracts/test/txe_test_contract/src/test.nr
@@ -22,7 +22,7 @@ pub unconstrained fn setup(
 
     // Deploy contract and initialize
     let initializer = TXETest::interface().initialize(initial_value as u64, owner);
-    let counter_contract = env.deploy_self("TXETest").with_private_initializer(initializer);
+    let counter_contract = env.deploy_self("TXETest").with_private_initializer(owner, initializer);
     let contract_address = counter_contract.to_address();
     (&mut env, contract_address, owner, sender)
 }
@@ -34,15 +34,14 @@ unconstrained fn new_calling_flow_increment_self_and_other() {
     let sender = env.create_account(2);
     let third = env.create_account(3);
 
-    env.impersonate(owner);
-
     let initial_value: Field = 2;
     let initializer = TXETest::interface().initialize(initial_value as u64, owner);
-    let counter_contract = env.deploy_self("TXETest").with_private_initializer(initializer);
+    let counter_contract = env.deploy_self("TXETest").with_private_initializer(owner, initializer);
     let contract_address = counter_contract.to_address();
 
     let initializer2 = TXETest::interface().initialize(initial_value as u64, third);
-    let counter_contract2 = env.deploy_self("TXETest").with_private_initializer(initializer2);
+    let counter_contract2 =
+        env.deploy_self("TXETest").with_private_initializer(owner, initializer2);
     let contract_address2 = counter_contract2.to_address();
 
     let _ = env.call_private_void(
@@ -87,7 +86,7 @@ unconstrained fn new_calling_flow_increment_with_new_call_flow() {
 
     let initial_value: Field = 2;
     let initializer = TXETest::interface().initialize(initial_value as u64, owner);
-    let counter_contract = env.deploy_self("TXETest").with_private_initializer(initializer);
+    let counter_contract = env.deploy_self("TXETest").with_private_initializer(owner, initializer);
     let contract_address = counter_contract.to_address();
 
     let _ = env.call_private_void(owner, TXETest::at(contract_address).increment(owner, sender));


### PR DESCRIPTION
Another step in nuking the infamous `env.impersonate`. 

See `counter_contract::test_increment` for the updated TXe test.

I will remove the instances of `cheatcodes::set_contract_address(previous_contract_address);` after we figure out exactly how we'll completely remove this concept of a txe `contractAddress`