### PR TITLE
fix: use correct public call ordering on new txe flow

### DIFF
--- a/noir-projects/noir-contracts/contracts/app/nft_contract/src/test/utils.nr
+++ b/noir-projects/noir-contracts/contracts/app/nft_contract/src/test/utils.nr
@@ -38,7 +38,7 @@ pub unconstrained fn setup(
     let nft_contract =
         env.deploy_self("NFT").with_public_void_initializer(owner, initializer_call_interface);
     let nft_contract_address = nft_contract.to_address();
-    env.advance_block_by(1);
+
     (&mut env, nft_contract_address, owner, recipient)
 }
 
@@ -67,11 +67,10 @@ pub unconstrained fn setup_mint_and_transfer_to_private(
     let _ = OracleMock::mock("getRandomField").returns(note_randomness);
 
     // We transfer the public NFT to private.
-    NFT::at(nft_contract_address).transfer_to_private(owner, minted_token_id).call(
-        &mut env.private(),
+    let _ = env.call_private_void(
+        owner,
+        NFT::at(nft_contract_address).transfer_to_private(owner, minted_token_id),
     );
-
-    env.advance_block_by(1);
 
     (env, nft_contract_address, owner, recipient, minted_token_id)
 }

--- a/yarn-project/txe/src/oracle/txe_oracle.ts
+++ b/yarn-project/txe/src/oracle/txe_oracle.ts
@@ -1536,7 +1536,8 @@ export class TXE implements TypedOracle {
         padArrayEnd(l2ToL1Messages, ScopedL2ToL1Message.empty(), MAX_L2_TO_L1_MSGS_PER_TX),
         padArrayEnd(taggedPrivateLogs, PrivateLog.empty(), MAX_PRIVATE_LOGS_PER_TX),
         padArrayEnd(contractClassLogsHashes, ScopedLogHash.empty(), MAX_CONTRACT_CLASS_LOGS_PER_TX),
-        padArrayEnd(publicCallRequests, PublicCallRequest.empty(), MAX_ENQUEUED_CALLS_PER_TX),
+        // We need to reverse the public call requests because the public processor expects the first one at the top of the array (the last element)
+        padArrayEnd(publicCallRequests.reverse(), PublicCallRequest.empty(), MAX_ENQUEUED_CALLS_PER_TX),
       );
 
       inputsForPublic = new PartialPrivateTailPublicInputsForPublic(


### PR DESCRIPTION
Found this little bug when trying to replace the NFT tests with the new format. Have made the modification separately with the rest of the porting
