### PR TITLE
feat: restart node container if it is already running

### DIFF
--- a/aztec-up/bin/.aztec-run
+++ b/aztec-up/bin/.aztec-run
@@ -130,6 +130,27 @@ if [ -n "$CONTAINER_NAME" ]; then
   arg_container_name="--name $CONTAINER_NAME"
 fi
 
+# Restart container in case it is already running.
+check_conflicts() {
+  running=$(docker ps --filter "name=aztec-start-" \
+                      --format '{{.ID}} {{.Names}} {{.Ports}}')
+  for mapping in ${PORTS_TO_EXPOSE:-}; do
+    host_port=${mapping%%:*}; host_port=${host_port%%/*}
+    hit=$(grep -E "\b0\.0\.0\.0:${host_port}->" <<<"$running" || true)
+    if [[ -n $hit ]]; then
+      cid=$(awk '{print $1}' <<<"$hit")
+      cname=$(awk '{print $2}' <<<"$hit")
+      read -r -p "A container named: \"${cname}\" already exists at port \"${host_port}\". Do you want to close it? [y/N] " ans
+      if [[ $ans =~ ^[Yy]$ ]]; then
+        docker rm -f "$cid"
+      else
+        warn "Aborting."
+        exit 1
+      fi
+    fi
+  done
+}
+
 function run {
   docker run \
     ${arg_container_name:-} \
@@ -148,6 +169,7 @@ function run {
 if [ -t 0 ]; then
   # We're in a terminal. Docker will receive e.g. SIGINT directly.
   arg_interactive=-ti
+  check_conflicts
   run
 else
   # Not connected to a terminal. We need to ensure we can propagate kill signals.


### PR DESCRIPTION
### Description:

This makes it easier to restart a node. If you run the command again, the script will check for any container named **`aztec-start-*`** that's already using the same port(s) and ask if you want to close it before starting a new one.

This saves you from having to manually run `docker ps` and `docker kill ...` every time you restart a node, which feels awkward. Just hit **`y`** when prompted, and the old container will be closed for you.

I thought about adding a flag for this, but it feels unsafe. The container names are random so it's not indubitable it's the container you want to restart without warning with a `--restart` flag. But if aztec is being run in a non-interactive way, maybe there’s a case for it…

### Changes:

Added to `aztec-up/bin/.aztec-run`:
```sh
# Restart container in case it is already running.
check_conflicts() {
  running=$(docker ps --filter "name=aztec-start-" \
                      --format '{{.ID}} {{.Names}} {{.Ports}}')
  for mapping in ${PORTS_TO_EXPOSE:-}; do
    host_port=${mapping%%:*}; host_port=${host_port%%/*}
    hit=$(grep -E "\b0\.0\.0\.0:${host_port}->" <<<"$running" || true)
    if [[ -n $hit ]]; then
      cid=$(awk '{print $1}' <<<"$hit")
      cname=$(awk '{print $2}' <<<"$hit")
      read -r -p "A container named: \"${cname}\" already exists at port \"${host_port}\". Do you want to close it? [y/N] " ans
      if [[ $ans =~ ^[Yy]$ ]]; then
        docker rm -f "$cid"
      else
        warn "Aborting."
        exit 1
      fi
    fi
  done
}
```

``` diff
if [ -t 0 ]; then
  # We're in a terminal. Docker will receive e.g. SIGINT directly.
  arg_interactive=-ti
+  check_conflicts
  run
else

```

### Port Collision Message:

#### After

`A container named: "aztec-start-12345678" already exists at port "40400". Do you want to close it? [y/N] N`

#### Before

`docker: Error response from daemon: driver failed programming external connectivity on endpoint aztec-start-12345678 (fe24b6e861c4d7c0080664c58bd3844521091c997d96b6a519d2ef10aec0e4e2): Bind for 0.0.0.0:40400 failed: port is already allocated.`