### PR TITLE
refactor: separate unpack RetrievedNote function from `notes.nr`

### DIFF
--- a/noir-projects/aztec-nr/aztec/src/note/retrieved_note.nr
+++ b/noir-projects/aztec-nr/aztec/src/note/retrieved_note.nr
@@ -1,4 +1,4 @@
-use crate::note::note_metadata::NoteMetadata;
+use crate::{note::note_metadata::NoteMetadata, utils::array};
 use protocol_types::{
     address::AztecAddress,
     traits::{FromField, Packable, Serialize, ToField},
@@ -31,30 +31,24 @@ where
     }
 }
 
-impl<NOTE, let N: u32> Packable<N + RETRIEVED_NOTE_OVERHEAD> for RetrievedNote<NOTE>
+// This function is not part of the Packable trait implementation because in the case of the retrieved note, the pack
+// functionality resides in TS (oracle.ts and txe_service.ts).
+pub fn unpack_retrieved_note<NOTE, let N: u32>(
+    packed_retrieved_note: [Field; N + RETRIEVED_NOTE_OVERHEAD],
+) -> RetrievedNote<NOTE>
 where
     NOTE: Packable<N>,
 {
-    fn pack(self) -> [Field; N + RETRIEVED_NOTE_OVERHEAD] {
-        let packed_note = self.note.pack();
-        arrays::array_concat(
-            arrays::array_concat(packed_note, [self.contract_address.to_field()]),
-            self.metadata.serialize(),
-        )
-    }
+    let contract_address = AztecAddress::from_field(packed_retrieved_note[0]);
+    let nonce = packed_retrieved_note[1];
+    let nonzero_note_hash_counter = packed_retrieved_note[2] as bool;
 
-    fn unpack(packed_retrieved_note: [Field; N + RETRIEVED_NOTE_OVERHEAD]) -> Self {
-        let contract_address = AztecAddress::from_field(packed_retrieved_note[N]);
-        let nonce = packed_retrieved_note[N + 1];
-        let nonzero_note_hash_counter = packed_retrieved_note[N + 2] as bool;
+    let packed_note = array::subarray(packed_retrieved_note, RETRIEVED_NOTE_OVERHEAD);
+    let note = NOTE::unpack(packed_note);
 
-        let packed_note = arrays::subarray(packed_retrieved_note, RETRIEVED_NOTE_OVERHEAD);
-        let note = NOTE::unpack(packed_note);
-
-        RetrievedNote {
-            note,
-            contract_address,
-            metadata: NoteMetadata::from_raw_data(nonzero_note_hash_counter, nonce),
-        }
+    RetrievedNote {
+        note,
+        contract_address,
+        metadata: NoteMetadata::from_raw_data(nonzero_note_hash_counter, nonce),
     }
 }

--- a/noir-projects/aztec-nr/aztec/src/note/retrieved_note.nr
+++ b/noir-projects/aztec-nr/aztec/src/note/retrieved_note.nr
@@ -1,8 +1,8 @@
-use crate::{note::note_metadata::NoteMetadata, utils::array};
+use crate::{note::note_metadata::NoteMetadata, utils::array::subarray::subarray};
 use protocol_types::{
     address::AztecAddress,
     traits::{FromField, Packable, Serialize, ToField},
-    utils::arrays,
+    utils::arrays::array_concat,
 };
 
 // Number of fields a RetrievedNote adds to the packed or serialized representation of a note
@@ -24,8 +24,8 @@ where
     NOTE: Serialize<N>,
 {
     fn serialize(self) -> [Field; N + RETRIEVED_NOTE_OVERHEAD] {
-        arrays::array_concat(
-            arrays::array_concat(self.note.serialize(), [self.contract_address.to_field()]),
+        array_concat(
+            array_concat(self.note.serialize(), [self.contract_address.to_field()]),
             self.metadata.serialize(),
         )
     }
@@ -43,7 +43,7 @@ where
     let nonce = packed_retrieved_note[1];
     let nonzero_note_hash_counter = packed_retrieved_note[2] as bool;
 
-    let packed_note = array::subarray(packed_retrieved_note, RETRIEVED_NOTE_OVERHEAD);
+    let packed_note = subarray(packed_retrieved_note, RETRIEVED_NOTE_OVERHEAD);
     let note = NOTE::unpack(packed_note);
 
     RetrievedNote {

--- a/noir-projects/aztec-nr/aztec/src/note/retrieved_note.nr
+++ b/noir-projects/aztec-nr/aztec/src/note/retrieved_note.nr
@@ -1,8 +1,8 @@
 use crate::note::note_metadata::NoteMetadata;
 use protocol_types::{
     address::AztecAddress,
-    traits::{Serialize, ToField},
-    utils::arrays::array_concat,
+    traits::{FromField, Packable, Serialize, ToField},
+    utils::arrays,
 };
 
 // Number of fields a RetrievedNote adds to the packed or serialized representation of a note
@@ -24,9 +24,37 @@ where
     NOTE: Serialize<N>,
 {
     fn serialize(self) -> [Field; N + RETRIEVED_NOTE_OVERHEAD] {
-        array_concat(
-            array_concat(self.note.serialize(), [self.contract_address.to_field()]),
+        arrays::array_concat(
+            arrays::array_concat(self.note.serialize(), [self.contract_address.to_field()]),
             self.metadata.serialize(),
         )
+    }
+}
+
+impl<NOTE, let N: u32> Packable<N + RETRIEVED_NOTE_OVERHEAD> for RetrievedNote<NOTE>
+where
+    NOTE: Packable<N>,
+{
+    fn pack(self) -> [Field; N + RETRIEVED_NOTE_OVERHEAD] {
+        let packed_note = self.note.pack();
+        arrays::array_concat(
+            arrays::array_concat(packed_note, [self.contract_address.to_field()]),
+            self.metadata.serialize(),
+        )
+    }
+
+    fn unpack(packed_retrieved_note: [Field; N + RETRIEVED_NOTE_OVERHEAD]) -> Self {
+        let contract_address = AztecAddress::from_field(packed_retrieved_note[N]);
+        let nonce = packed_retrieved_note[N + 1];
+        let nonzero_note_hash_counter = packed_retrieved_note[N + 2] as bool;
+
+        let packed_note = arrays::subarray(packed_retrieved_note, RETRIEVED_NOTE_OVERHEAD);
+        let note = NOTE::unpack(packed_note);
+
+        RetrievedNote {
+            note,
+            contract_address,
+            metadata: NoteMetadata::from_raw_data(nonzero_note_hash_counter, nonce),
+        }
     }
 }

--- a/noir-projects/aztec-nr/aztec/src/oracle/notes.nr
+++ b/noir-projects/aztec-nr/aztec/src/oracle/notes.nr
@@ -1,16 +1,10 @@
-use crate::{
-    note::{
-        note_interface::NoteType,
-        note_metadata::NoteMetadata,
-        retrieved_note::{RETRIEVED_NOTE_OVERHEAD, RetrievedNote},
-    },
-    utils::array,
+use crate::note::{
+    note_interface::NoteType,
+    retrieved_note::{RETRIEVED_NOTE_OVERHEAD, RetrievedNote},
 };
 
 use dep::protocol_types::{
-    address::AztecAddress,
-    indexed_tagging_secret::IndexedTaggingSecret,
-    traits::{FromField, Packable},
+    address::AztecAddress, indexed_tagging_secret::IndexedTaggingSecret, traits::Packable,
 };
 
 /// Notifies the simulator that a note has been created, so that it can be returned in future read requests in the same
@@ -152,21 +146,7 @@ where
 
     let mut notes = BoundedVec::<_, MAX_NOTES>::new();
     for i in 0..packed_retrieved_notes.len() {
-        let packed_retrieved_note = packed_retrieved_notes.get(i);
-
-        let contract_address = AztecAddress::from_field(packed_retrieved_note[0]);
-        let nonce = packed_retrieved_note[1];
-        let nonzero_note_hash_counter = packed_retrieved_note[2] as bool;
-
-        let packed_note = array::subarray(packed_retrieved_note, RETRIEVED_NOTE_OVERHEAD);
-        let note = Note::unpack(packed_note);
-
-        let retrieved_note = RetrievedNote {
-            note,
-            contract_address,
-            metadata: NoteMetadata::from_raw_data(nonzero_note_hash_counter, nonce),
-        };
-
+        let retrieved_note = RetrievedNote::unpack(packed_retrieved_notes.get(i));
         notes.push(retrieved_note);
     }
 

--- a/noir-projects/aztec-nr/aztec/src/oracle/notes.nr
+++ b/noir-projects/aztec-nr/aztec/src/oracle/notes.nr
@@ -1,6 +1,6 @@
 use crate::note::{
     note_interface::NoteType,
-    retrieved_note::{RETRIEVED_NOTE_OVERHEAD, RetrievedNote},
+    retrieved_note::{RETRIEVED_NOTE_OVERHEAD, RetrievedNote, unpack_retrieved_note},
 };
 
 use dep::protocol_types::{
@@ -146,7 +146,7 @@ where
 
     let mut notes = BoundedVec::<_, MAX_NOTES>::new();
     for i in 0..packed_retrieved_notes.len() {
-        let retrieved_note = RetrievedNote::unpack(packed_retrieved_notes.get(i));
+        let retrieved_note = unpack_retrieved_note(packed_retrieved_notes.get(i));
         notes.push(retrieved_note);
     }
 

--- a/yarn-project/simulator/src/private/acvm/oracle/oracle.ts
+++ b/yarn-project/simulator/src/private/acvm/oracle/oracle.ts
@@ -202,12 +202,14 @@ export class Oracle {
     }
 
     // The expected return type is a BoundedVec<[Field; packedRetrievedNoteLength], maxNotes> where each
-    // array is structured as [contract_address, nonce, nonzero_note_hash_counter, ...packed_note]
+    // array is structured as [contract_address, nonce, nonzero_note_hash_counter, ...packed_note].
 
     const returnDataAsArrayOfArrays = noteDatas.map(({ contractAddress, nonce, index, note }) => {
       // If index is undefined, the note is transient which implies that the nonzero_note_hash_counter has to be true
       const noteIsTransient = index === undefined;
       const nonzeroNoteHashCounter = noteIsTransient ? true : false;
+      // If you change the array on the next line you have to change the `unpack_retrieved_note` function in
+      // `aztec/src/note/retrieved_note.nr`
       return [contractAddress, nonce, nonzeroNoteHashCounter, ...note.items];
     });
 

--- a/yarn-project/txe/src/txe_service/txe_service.ts
+++ b/yarn-project/txe/src/txe_service/txe_service.ts
@@ -363,12 +363,14 @@ export class TXEService {
     }
 
     // The expected return type is a BoundedVec<[Field; packedRetrievedNoteLength], maxNotes> where each
-    // array is structured as [contract_address, nonce, nonzero_note_hash_counter, ...packed_note]
+    // array is structured as [contract_address, nonce, nonzero_note_hash_counter, ...packed_note].
 
     const returnDataAsArrayOfArrays = noteDatas.map(({ contractAddress, nonce, index, note }) => {
       // If index is undefined, the note is transient which implies that the nonzero_note_hash_counter has to be true
       const noteIsTransient = index === undefined;
       const nonzeroNoteHashCounter = noteIsTransient ? true : false;
+      // If you change the array on the next line you have to change the `unpack_retrieved_note` function in
+      // `aztec/src/note/retrieved_note.nr`
       return [contractAddress, nonce, nonzeroNoteHashCounter, ...note.items];
     });
 


### PR DESCRIPTION
In this PR I improve readability of `notes.nr` by moving the unpacking functionality of RetrievedNote to `retrieved_note.nr`. It's a small change but didn't do it in a PR down the stack as it would worsen diff readability.