### PR TITLE
chore: Fix l1-reorg e2e flakes

### DIFF
--- a/yarn-project/archiver/src/archiver/archiver.ts
+++ b/yarn-project/archiver/src/archiver/archiver.ts
@@ -642,6 +642,8 @@ export class Archiver extends EventEmitter implements ArchiveSource, Traceable {
           blockNumber: block.block.number,
           txCount: block.block.body.txEffects.length,
           globalVariables: block.block.header.globalVariables.toInspect(),
+          archiveRoot: block.block.archive.root.toString(),
+          archiveNextLeafIndex: block.block.archive.nextAvailableLeafIndex,
         });
       }
       lastRetrievedBlock = publishedBlocks.at(-1) ?? lastRetrievedBlock;

--- a/yarn-project/end-to-end/src/e2e_epochs/epochs_l1_reorgs.test.ts
+++ b/yarn-project/end-to-end/src/e2e_epochs/epochs_l1_reorgs.test.ts
@@ -141,13 +141,13 @@ describe('e2e_epochs/epochs_l1_reorgs', () => {
     expect(proofTxReceipt.status).toEqual('success');
 
     // Monitor should update to see the proof
-    await monitor.run(true);
-    expect(monitor.l2BlockNumber).toBeGreaterThan(1);
-    expect(monitor.l2ProvenBlockNumber).toBeGreaterThan(0);
+    const { l2BlockNumber, l2ProvenBlockNumber } = await monitor.run(true);
+    expect(l2BlockNumber).toBeGreaterThan(1);
+    expect(l2ProvenBlockNumber).toBeGreaterThan(0);
 
     // And so the node undoes its reorg
-    await retryUntil(() => node.getBlockNumber().then(b => b === monitor.l2BlockNumber), 'node sync', syncTimeout, 0.1);
-    await expect(node.getProvenBlockNumber()).resolves.toEqual(monitor.l2ProvenBlockNumber);
+    await retryUntil(() => node.getBlockNumber().then(b => b >= l2BlockNumber), 'node sync', syncTimeout, 0.1);
+    await retryUntil(() => node.getProvenBlockNumber().then(b => b >= l2ProvenBlockNumber), 'proof sync', 1, 0.1);
 
     logger.warn(`Test succeeded`);
   });

--- a/yarn-project/end-to-end/src/e2e_epochs/epochs_l1_reorgs.test.ts
+++ b/yarn-project/end-to-end/src/e2e_epochs/epochs_l1_reorgs.test.ts
@@ -57,8 +57,7 @@ describe('e2e_epochs/epochs_l1_reorgs', () => {
 
     // And remove the proof from L1
     await context.cheatCodes.eth.reorg(2);
-    await monitor.run();
-    expect(monitor.l2ProvenBlockNumber).toEqual(0);
+    expect((await monitor.run(true)).l2ProvenBlockNumber).toEqual(0);
 
     // Wait until the end of the proof submission window for the first epoch
     await test.waitUntilEndOfProofSubmissionWindow(0);
@@ -72,7 +71,7 @@ describe('e2e_epochs/epochs_l1_reorgs', () => {
     // This is because the call to createNonValidatorNode will block until the initial sync is completed,
     // but the initial sync is done to the latest L1 block _at the time the initial sync starts_. So a new
     // node may have appeared while the initial sync runs, that's why we account for a small span of blocks.
-    const currentBlock = monitor.l2BlockNumber;
+    const currentBlock = (await monitor.run(true)).l2BlockNumber;
     expect(await newNode.getBlockNumber()).toBeWithin(currentBlock - 1, currentBlock + 1);
 
     // And check that the old node has processed the reorg as well


### PR DESCRIPTION
Attempted fixes for:

```
13:15:46  FAIL  src/e2e_epochs/epochs_l1_reorgs.test.ts (322.03 s)
13:15:46   e2e_epochs/epochs_l1_reorgs
13:15:46     ✓ prunes L2 blocks if a proof is removed due to an L1 reorg (77417 ms)
13:15:46     ✓ does not prune if a second proof lands within the submission window after the first one is reorged out (68186 ms)
13:15:46     ✕ restores L2 blocks if a proof is added due to an L1 reorg (72522 ms)
13:15:46     ✓ prunes L2 blocks from pending chain removed from L1 due to an L1 reorg (48771 ms)
13:15:46     ✓ sees new blocks added in an L1 reorg (48871 ms)
13:15:46     ○ skipped updates cross-chain messages changed due to an L1 reorg
13:15:46 
13:15:46   ● e2e_epochs/epochs_l1_reorgs › restores L2 blocks if a proof is added due to an L1 reorg
13:15:46 
13:15:46     expect(received).resolves.toEqual(expected) // deep equality
13:15:46 
13:15:46     Expected: 2
13:15:46     Received: 0
13:15:46 
13:15:46       149 |     // And so the node undoes its reorg
13:15:46       150 |     await retryUntil(() => node.getBlockNumber().then(b => b === monitor.l2BlockNumber), 'node sync', syncTimeout, 0.1);
13:15:46     > 151 |     await expect(node.getProvenBlockNumber()).resolves.toEqual(monitor.l2ProvenBlockNumber);
13:15:46           |                                                        ^
13:15:46       152 |
13:15:46       153 |     logger.warn(`Test succeeded`);
13:15:46       154 |   });
13:15:46 
13:15:46       at Object.toEqual (../../node_modules/expect/build/index.js:174:22)
13:15:46       at Object.toEqual (e2e_epochs/epochs_l1_reorgs.test.ts:151:56)
```

(link to run [here](http://ci.aztec-labs.com/46d88c7dd30334d2))

```
10:34:18  FAIL  src/e2e_epochs/epochs_l1_reorgs.test.ts
10:34:18   e2e_epochs/epochs_l1_reorgs
10:34:18     ✕ prunes L2 blocks if a proof is removed due to an L1 reorg (45473 ms)
10:34:18     ✓ does not prune if a second proof lands within the submission window after the first one is reorged out (68275 ms)
10:34:18     ✓ restores L2 blocks if a proof is added due to an L1 reorg (73214 ms)
10:34:18     ✓ prunes L2 blocks from pending chain removed from L1 due to an L1 reorg (48365 ms)
10:34:18     ✓ sees new blocks added in an L1 reorg (48927 ms)
10:34:18     ○ skipped updates cross-chain messages changed due to an L1 reorg
10:34:18 
10:34:18   ● e2e_epochs/epochs_l1_reorgs › prunes L2 blocks if a proof is removed due to an L1 reorg
10:34:18 
10:34:18     expect(received).toEqual(expected) // deep equality
10:34:18 
10:34:18     Expected: 0
10:34:18     Received: 2
10:34:18 
10:34:18       59 |     await context.cheatCodes.eth.reorg(2);
10:34:18       60 |     await monitor.run();
10:34:18     > 61 |     expect(monitor.l2ProvenBlockNumber).toEqual(0);
10:34:18          |                                         ^
10:34:18       62 |
10:34:18       63 |     // Wait until the end of the proof submission window for the first epoch
10:34:18       64 |     await test.waitUntilEndOfProofSubmissionWindow(0);
10:34:18 
10:34:18       at Object.toEqual (e2e_epochs/epochs_l1_reorgs.test.ts:61:41)
```

(link to run [here](http://ci.aztec-labs.com/acafe11a371dc863))
