### PR TITLE
feat: remove extra pairing point aggregation batch_mul

### DIFF
--- a/barretenberg/cpp/scripts/test_civc_standalone_vks_havent_changed.sh
+++ b/barretenberg/cpp/scripts/test_civc_standalone_vks_havent_changed.sh
@@ -8,7 +8,7 @@ cd ..
 # IF A VK CHANGE IS EXPECTED - we need to redo this:
 # - Generate inputs: $root/yarn-project/end-to-end/bootstrap.sh generate_example_app_ivc_inputs
 # - Upload the compressed results: aws s3 cp bb-civc-inputs-[version].tar.gz s3://aztec-ci-artifacts/protocol/bb-civc-inputs-[version].tar.gz
-pinned_civc_inputs_url="https://aztec-ci-artifacts.s3.us-east-2.amazonaws.com/protocol/bb-civc-inputs-v6.tar.gz"
+pinned_civc_inputs_url="https://aztec-ci-artifacts.s3.us-east-2.amazonaws.com/protocol/bb-civc-inputs-v7.tar.gz"
 
 export inputs_tmp_dir=$(mktemp -d)
 trap 'rm -rf "$inputs_tmp_dir"' EXIT SIGINT

--- a/barretenberg/cpp/src/barretenberg/client_ivc/mock_kernel_pinning.test.cpp
+++ b/barretenberg/cpp/src/barretenberg/client_ivc/mock_kernel_pinning.test.cpp
@@ -36,5 +36,5 @@ TEST_F(MockKernelTest, PinFoldingKernelSizes)
         EXPECT_TRUE(circuit.blocks.has_overflow); // trace overflow mechanism should be triggered
     }
 
-    EXPECT_EQ(ivc.fold_output.accumulator->proving_key.log_circuit_size, 20);
+    EXPECT_EQ(ivc.fold_output.accumulator->proving_key.log_circuit_size, 19);
 }

--- a/barretenberg/cpp/src/barretenberg/goblin/mock_circuits.hpp
+++ b/barretenberg/cpp/src/barretenberg/goblin/mock_circuits.hpp
@@ -83,7 +83,7 @@ class GoblinMockCircuits {
 
         if (large) { // Results in circuit size 2^19
             stdlib::generate_sha256_test_circuit(builder, 9);
-            stdlib::generate_ecdsa_verification_test_circuit(builder, 9);
+            stdlib::generate_ecdsa_verification_test_circuit(builder, 8);
             stdlib::generate_merkle_membership_test_circuit(builder, 12);
         } else { // Results in circuit size 2^17
             stdlib::generate_sha256_test_circuit(builder, 8);
@@ -97,35 +97,6 @@ class GoblinMockCircuits {
         // MegaHonk circuits (where we don't explicitly need to add goblin ops), in IVC merge proving happens prior to
         // folding where the absense of goblin ecc ops will result in zero commitments.
         MockCircuits::construct_goblin_ecc_op_circuit(builder);
-        PairingPoints::add_default_to_public_inputs(builder);
-    }
-
-    /**
-     * @brief Populate a builder with some arbitrary but nontrivial constraints
-     * @details Although the details of the circuit constructed here are arbitrary, the intent is to mock something a
-     * bit more realistic than a circuit comprised entirely of arithmetic gates. E.g. the circuit should respond
-     * realistically to efforts to parallelize circuit construction.
-     *
-     * @param builder
-     * @param large If true, construct a "large" circuit (2^19), else a medium circuit (2^17)
-     */
-    static void construct_mock_function_circuit(MegaBuilder& builder, bool large = false)
-    {
-        PROFILE_THIS();
-
-        // Determine number of times to execute the below operations that constitute the mock circuit logic. Note that
-        // the circuit size does not scale linearly with number of iterations due to e.g. amortization of lookup costs
-        const size_t NUM_ITERATIONS_LARGE = 12; // results in circuit size 2^19 (502238 gates)
-
-        if (large) {
-            stdlib::generate_sha256_test_circuit(builder, NUM_ITERATIONS_LARGE);
-            stdlib::generate_ecdsa_verification_test_circuit(builder, NUM_ITERATIONS_LARGE / 2);
-            stdlib::generate_merkle_membership_test_circuit(builder, NUM_ITERATIONS_LARGE);
-        } else { // Results in circuit size 2^17 when accumulated via ClientIvc
-            stdlib::generate_sha256_test_circuit(builder, 5);
-            stdlib::generate_ecdsa_verification_test_circuit(builder, 1);
-            stdlib::generate_merkle_membership_test_circuit(builder, 10);
-        }
         PairingPoints::add_default_to_public_inputs(builder);
     }
 

--- a/barretenberg/cpp/src/barretenberg/goblin/mock_circuits_pinning.test.cpp
+++ b/barretenberg/cpp/src/barretenberg/goblin/mock_circuits_pinning.test.cpp
@@ -17,34 +17,18 @@ class MegaMockCircuitsPinning : public ::testing::Test {
     static void SetUpTestSuite() { bb::srs::init_file_crs_factory(bb::srs::bb_crs_path()); }
 };
 
-TEST_F(MegaMockCircuitsPinning, FunctionSizes)
-{
-    const auto run_test = [](bool large) {
-        Goblin goblin;
-        MegaCircuitBuilder app_circuit{ goblin.op_queue };
-        GoblinMockCircuits::construct_mock_function_circuit(app_circuit, large);
-        auto proving_key = std::make_shared<DeciderProvingKey>(app_circuit);
-        if (large) {
-            EXPECT_EQ(proving_key->proving_key.log_circuit_size, 19);
-        } else {
-            EXPECT_EQ(proving_key->proving_key.log_circuit_size, 17);
-        };
-    };
-    run_test(true);
-    run_test(false);
-}
-
 TEST_F(MegaMockCircuitsPinning, AppCircuitSizes)
 {
     const auto run_test = [](bool large) {
         Goblin goblin;
         MegaCircuitBuilder app_circuit{ goblin.op_queue };
         GoblinMockCircuits::construct_mock_app_circuit(app_circuit, large);
-        auto proving_key = std::make_shared<DeciderProvingKey>(app_circuit);
+        TraceSettings trace_settings{ AZTEC_TRACE_STRUCTURE };
+        auto proving_key = std::make_shared<DeciderProvingKey>(app_circuit, trace_settings);
         if (large) {
             EXPECT_EQ(proving_key->proving_key.log_circuit_size, 19);
         } else {
-            EXPECT_EQ(proving_key->proving_key.log_circuit_size, 17);
+            EXPECT_EQ(proving_key->proving_key.log_circuit_size, 18);
         };
     };
     run_test(true);

--- a/barretenberg/cpp/src/barretenberg/plonk_honk_shared/execution_trace/mega_execution_trace.hpp
+++ b/barretenberg/cpp/src/barretenberg/plonk_honk_shared/execution_trace/mega_execution_trace.hpp
@@ -222,6 +222,7 @@ class MegaExecutionTraceBlocks : public MegaTraceBlockData<MegaTraceBlock> {
         info("poseidon int  :\t", this->poseidon2_internal.size(), "/", this->poseidon2_internal.get_fixed_size());
         info("overflow      :\t", this->overflow.size(), "/", this->overflow.get_fixed_size());
         info("");
+        info("Total structured size: ", get_structured_size());
     }
 
     // Get cumulative size of all blocks
@@ -234,12 +235,18 @@ class MegaExecutionTraceBlocks : public MegaTraceBlockData<MegaTraceBlock> {
         return total_size;
     }
 
-    size_t get_structured_dyadic_size() const
+    size_t get_structured_size() const
     {
         size_t total_size = 1; // start at 1 because the 0th row is unused for selectors for Honk
         for (const auto& block : this->get()) {
             total_size += block.get_fixed_size();
         }
+        return total_size;
+    }
+
+    size_t get_structured_dyadic_size() const
+    {
+        size_t total_size = get_structured_size();
 
         auto log2_n = static_cast<size_t>(numeric::get_msb(total_size));
         if ((1UL << log2_n) != (total_size)) {

--- a/barretenberg/cpp/src/barretenberg/stdlib/plonk_recursion/pairing_points.hpp
+++ b/barretenberg/cpp/src/barretenberg/stdlib/plonk_recursion/pairing_points.hpp
@@ -71,7 +71,7 @@ template <typename Builder_> struct PairingPoints {
             transcript.template get_challenge<typename Curve::ScalarField>("recursion_separator");
         // If Mega Builder is in use, the EC operations are deferred via Goblin
         if constexpr (std::is_same_v<Builder, MegaCircuitBuilder>) {
-            // TODO(https://github.com/AztecProtocol/barretenberg/issues/1325): Can we improve efficiency here?
+            // TODO(https://github.com/AztecProtocol/barretenberg/issues/1385): Can we improve efficiency here?
             P0 = Group::batch_mul({ P0, other.P0 }, { 1, recursion_separator });
             P1 = Group::batch_mul({ P1, other.P1 }, { 1, recursion_separator });
         } else {

--- a/barretenberg/cpp/src/barretenberg/stdlib/plonk_recursion/pairing_points.hpp
+++ b/barretenberg/cpp/src/barretenberg/stdlib/plonk_recursion/pairing_points.hpp
@@ -72,8 +72,8 @@ template <typename Builder_> struct PairingPoints {
         // If Mega Builder is in use, the EC operations are deferred via Goblin
         if constexpr (std::is_same_v<Builder, MegaCircuitBuilder>) {
             // TODO(https://github.com/AztecProtocol/barretenberg/issues/1325): Can we improve efficiency here?
-            P0 += other.P0 * recursion_separator;
-            P1 += other.P1 * recursion_separator;
+            P0 = Group::batch_mul({ P0, other.P0 }, { 1, recursion_separator });
+            P1 = Group::batch_mul({ P1, other.P1 }, { 1, recursion_separator });
         } else {
             // Save gates using short scalars. We don't apply `bn254_endo_batch_mul` to the vector {1,
             // recursion_separator} directly to avoid edge cases.


### PR DESCRIPTION
Closes https://github.com/AztecProtocol/barretenberg/issues/1325.

We are currently doing pairing point aggregation with a batchmul of size 1 in operator* and then another batchmul of size 2 in operator+. If we just directly do it, we can do it with just 1 batchmul of size 2. This drops the number of transcript rows in the ECCVM, but doesn't affect the actual number of rows because the MSM builder row count dominates it by a significant margin.