### PR TITLE
chore: enable zk-related relation correctness tests in Translator and better handling of const sizes

### DIFF
--- a/barretenberg/cpp/src/barretenberg/flavor/flavor.hpp
+++ b/barretenberg/cpp/src/barretenberg/flavor/flavor.hpp
@@ -145,7 +145,7 @@ template <typename FF, typename CommitmentKey_> class ProvingKey_ {
 
     ProvingKey_() = default;
     ProvingKey_(const size_t dyadic_circuit_size,
-                const size_t num_public_inputs,
+                const size_t num_public_inputs = 0,
                 std::shared_ptr<CommitmentKey_> commitment_key = nullptr)
         : circuit_size(dyadic_circuit_size)
         , evaluation_domain(bb::EvaluationDomain<FF>(dyadic_circuit_size, dyadic_circuit_size))

--- a/barretenberg/cpp/src/barretenberg/flavor/flavor.hpp
+++ b/barretenberg/cpp/src/barretenberg/flavor/flavor.hpp
@@ -147,13 +147,12 @@ template <typename FF, typename CommitmentKey_> class ProvingKey_ {
     ProvingKey_(const size_t dyadic_circuit_size,
                 const size_t num_public_inputs,
                 std::shared_ptr<CommitmentKey_> commitment_key = nullptr)
-    {
-        this->commitment_key = commitment_key;
-        this->evaluation_domain = bb::EvaluationDomain<FF>(dyadic_circuit_size, dyadic_circuit_size);
-        this->circuit_size = dyadic_circuit_size;
-        this->log_circuit_size = numeric::get_msb(dyadic_circuit_size);
-        this->num_public_inputs = num_public_inputs;
-    };
+        : circuit_size(dyadic_circuit_size)
+        , evaluation_domain(bb::EvaluationDomain<FF>(dyadic_circuit_size, dyadic_circuit_size))
+        , commitment_key(commitment_key)
+        , num_public_inputs(num_public_inputs)
+
+              {};
 };
 
 /**

--- a/barretenberg/cpp/src/barretenberg/flavor/flavor.hpp
+++ b/barretenberg/cpp/src/barretenberg/flavor/flavor.hpp
@@ -151,8 +151,7 @@ template <typename FF, typename CommitmentKey_> class ProvingKey_ {
         , evaluation_domain(bb::EvaluationDomain<FF>(dyadic_circuit_size, dyadic_circuit_size))
         , commitment_key(commitment_key)
         , num_public_inputs(num_public_inputs)
-
-              {};
+        , log_circuit_size(numeric::get_msb(dyadic_circuit_size)){};
 };
 
 /**

--- a/barretenberg/cpp/src/barretenberg/translator_vm/relation_correctness.test.cpp
+++ b/barretenberg/cpp/src/barretenberg/translator_vm/relation_correctness.test.cpp
@@ -23,13 +23,12 @@ TEST_F(TranslatorRelationCorrectnessTests, Permutation)
     using FF = typename Flavor::FF;
     using ProverPolynomials = typename Flavor::ProverPolynomials;
     auto& engine = numeric::get_debug_randomness();
-    const size_t mini_circuit_size = 2048;
 
     // Fill needed relation parameters
     RelationParameters<FF> params{ .beta = FF::random_element(), .gamma = FF::random_element() };
 
     // Create storage for polynomials
-    TranslatorProvingKey key{ mini_circuit_size };
+    TranslatorProvingKey key{};
     ProverPolynomials& prover_polynomials = key.proving_key->polynomials;
 
     // Fill in lagrange polynomials used in the permutation relation
@@ -71,11 +70,10 @@ TEST_F(TranslatorRelationCorrectnessTests, DeltaRangeConstraint)
     using FF = typename Flavor::FF;
     using ProverPolynomials = typename Flavor::ProverPolynomials;
     auto& engine = numeric::get_debug_randomness();
-    const size_t mini_circuit_size = 2048;
     const auto sort_step = Flavor::SORT_STEP;
     const auto max_value = (1 << Flavor::MICRO_LIMB_BITS) - 1;
 
-    TranslatorProvingKey key{ mini_circuit_size };
+    TranslatorProvingKey key;
     ProverPolynomials& prover_polynomials = key.proving_key->polynomials;
 
     // Construct lagrange polynomials that are needed for Translator's DeltaRangeConstraint Relation
@@ -137,8 +135,6 @@ TEST_F(TranslatorRelationCorrectnessTests, TranslatorExtraRelationsCorrectness)
 
     auto& engine = numeric::get_debug_randomness();
 
-    const size_t mini_circuit_size = 2048;
-
     // We only use accumulated_result from relation parameters in this relation
     RelationParameters<FF> params;
     params.accumulated_result = {
@@ -146,7 +142,8 @@ TEST_F(TranslatorRelationCorrectnessTests, TranslatorExtraRelationsCorrectness)
     };
 
     // Create storage for polynomials
-    ProverPolynomials prover_polynomials(mini_circuit_size);
+    ProverPolynomials prover_polynomials;
+    constexpr size_t mini_circuit_size = Flavor::MINI_CIRCUIT_SIZE;
     // Fill in lagrange even polynomial
     for (size_t i = 2; i < mini_circuit_size - 1; i += 2) {
         prover_polynomials.lagrange_even_in_minicircuit.at(i) = 1;
@@ -207,13 +204,13 @@ TEST_F(TranslatorRelationCorrectnessTests, Decomposition)
     using ProverPolynomials = typename Flavor::ProverPolynomials;
     auto& engine = numeric::get_debug_randomness();
 
-    constexpr size_t mini_circuit_size = 2048;
+    constexpr size_t mini_circuit_size = Flavor::MINI_CIRCUIT_SIZE;
 
     // Decomposition relation doesn't use any relation parameters
     RelationParameters<FF> params;
 
     // Create storage for polynomials
-    ProverPolynomials prover_polynomials(mini_circuit_size);
+    ProverPolynomials prover_polynomials;
 
     // Fill in lagrange odd polynomial (the only non-witness one we are using)
     for (size_t i = 1; i < mini_circuit_size - 1; i += 2) {
@@ -551,7 +548,8 @@ TEST_F(TranslatorRelationCorrectnessTests, NonNative)
     using GroupElement = typename Flavor::GroupElement;
 
     constexpr size_t NUM_LIMB_BITS = Flavor::NUM_LIMB_BITS;
-    constexpr auto mini_circuit_size = 2048;
+    constexpr auto mini_circuit_size = TranslatorFlavor::MINI_CIRCUIT_SIZE;
+    ;
 
     auto& engine = numeric::get_debug_randomness();
 
@@ -601,7 +599,7 @@ TEST_F(TranslatorRelationCorrectnessTests, NonNative)
                                   uint_input_x };
 
     // Create storage for polynomials
-    ProverPolynomials prover_polynomials = TranslatorFlavor::ProverPolynomials(mini_circuit_size);
+    ProverPolynomials prover_polynomials = TranslatorFlavor::ProverPolynomials();
 
     // Copy values of wires used in the non-native field relation from the circuit builder
     for (size_t i = 1; i < circuit_builder.get_estimated_num_finalized_gates(); i++) {
@@ -655,7 +653,7 @@ TEST_F(TranslatorRelationCorrectnessTests, ZeroKnowledgePermutation)
     auto& engine = numeric::get_debug_randomness();
     const size_t full_masking_offset = NUM_DISABLED_ROWS_IN_SUMCHECK * Flavor::INTERLEAVING_GROUP_SIZE;
 
-    TranslatorProvingKey key{ Flavor::MINI_CIRCUIT_SIZE };
+    TranslatorProvingKey key;
     ProverPolynomials& prover_polynomials = key.proving_key->polynomials;
     const size_t real_circuit_size = full_circuit_size - full_masking_offset;
 
@@ -723,11 +721,10 @@ TEST_F(TranslatorRelationCorrectnessTests, ZeroKnowledgeDeltaRange)
     using FF = typename Flavor::FF;
     using ProverPolynomials = typename Flavor::ProverPolynomials;
     auto& engine = numeric::get_debug_randomness();
-    const size_t mini_circuit_size = 2048;
     const auto sort_step = Flavor::SORT_STEP;
     const auto max_value = (1 << Flavor::MICRO_LIMB_BITS) - 1;
 
-    TranslatorProvingKey key{ mini_circuit_size };
+    TranslatorProvingKey key;
     ProverPolynomials& prover_polynomials = key.proving_key->polynomials;
 
     const size_t full_masking_offset = NUM_DISABLED_ROWS_IN_SUMCHECK * Flavor::INTERLEAVING_GROUP_SIZE;

--- a/barretenberg/cpp/src/barretenberg/translator_vm/relation_correctness.test.cpp
+++ b/barretenberg/cpp/src/barretenberg/translator_vm/relation_correctness.test.cpp
@@ -651,14 +651,13 @@ TEST_F(TranslatorRelationCorrectnessTests, ZeroKnowledgePermutation)
     using FF = typename Flavor::FF;
     using ProverPolynomials = typename Flavor::ProverPolynomials;
 
-    const size_t mini_circuit_size = 2048;
-    const size_t full_circuit_size = mini_circuit_size * Flavor::INTERLEAVING_GROUP_SIZE;
+    const size_t full_circuit_size = Flavor::MINI_CIRCUIT_SIZE * Flavor::INTERLEAVING_GROUP_SIZE;
     auto& engine = numeric::get_debug_randomness();
-    const size_t full_NUM_DISABLED_ROWS_IN_SUMCHECK = NUM_DISABLED_ROWS_IN_SUMCHECK * Flavor::INTERLEAVING_GROUP_SIZE;
+    const size_t full_masking_offset = NUM_DISABLED_ROWS_IN_SUMCHECK * Flavor::INTERLEAVING_GROUP_SIZE;
 
-    TranslatorProvingKey key{ mini_circuit_size };
+    TranslatorProvingKey key{ Flavor::MINI_CIRCUIT_SIZE };
     ProverPolynomials& prover_polynomials = key.proving_key->polynomials;
-    const size_t real_circuit_size = full_circuit_size - full_NUM_DISABLED_ROWS_IN_SUMCHECK;
+    const size_t real_circuit_size = full_circuit_size - full_masking_offset;
 
     // Fill required relation parameters
     RelationParameters<FF> params{ .beta = FF::random_element(), .gamma = FF::random_element() };
@@ -731,8 +730,8 @@ TEST_F(TranslatorRelationCorrectnessTests, ZeroKnowledgeDeltaRange)
     TranslatorProvingKey key{ mini_circuit_size };
     ProverPolynomials& prover_polynomials = key.proving_key->polynomials;
 
-    const size_t full_NUM_DISABLED_ROWS_IN_SUMCHECK = NUM_DISABLED_ROWS_IN_SUMCHECK * Flavor::INTERLEAVING_GROUP_SIZE;
-    const size_t real_circuit_size = key.dyadic_circuit_size - full_NUM_DISABLED_ROWS_IN_SUMCHECK;
+    const size_t full_masking_offset = NUM_DISABLED_ROWS_IN_SUMCHECK * Flavor::INTERLEAVING_GROUP_SIZE;
+    const size_t real_circuit_size = key.dyadic_circuit_size - full_masking_offset;
 
     // Construct lagrange polynomials that are needed for Translator's DeltaRangeConstraint Relation
     prover_polynomials.lagrange_first.at(0) = 0;

--- a/barretenberg/cpp/src/barretenberg/translator_vm/relation_correctness.test.cpp
+++ b/barretenberg/cpp/src/barretenberg/translator_vm/relation_correctness.test.cpp
@@ -645,149 +645,146 @@ TEST_F(TranslatorRelationCorrectnessTests, NonNative)
         prover_polynomials, params, "TranslatorNonNativeFieldRelation");
 }
 
-// TEST_F(TranslatorRelationCorrectnessTests, ZeroKnowledgePermutation)
-// {
-//     using Flavor = TranslatorFlavor;
-//     using FF = typename Flavor::FF;
-//     using ProverPolynomials = typename Flavor::ProverPolynomials;
+TEST_F(TranslatorRelationCorrectnessTests, ZeroKnowledgePermutation)
+{
+    using Flavor = TranslatorFlavor;
+    using FF = typename Flavor::FF;
+    using ProverPolynomials = typename Flavor::ProverPolynomials;
 
-//     const size_t mini_circuit_size = 2048;
-//     auto& engine = numeric::get_debug_randomness();
-//     const size_t full_NUM_DISABLED_ROWS_IN_SUMCHECK = NUM_DISABLED_ROWS_IN_SUMCHECK *
-//     Flavor::INTERLEAVING_GROUP_SIZE;
+    const size_t mini_circuit_size = 2048;
+    const size_t full_circuit_size = mini_circuit_size * Flavor::INTERLEAVING_GROUP_SIZE;
+    auto& engine = numeric::get_debug_randomness();
+    const size_t full_NUM_DISABLED_ROWS_IN_SUMCHECK = NUM_DISABLED_ROWS_IN_SUMCHECK * Flavor::INTERLEAVING_GROUP_SIZE;
 
-//     TranslatorProvingKey key{ mini_circuit_size };
-//     ProverPolynomials& prover_polynomials = key.proving_key->polynomials;
-//     const size_t real_circuit_size = full_circuit_size - full_NUM_DISABLED_ROWS_IN_SUMCHECK;
+    TranslatorProvingKey key{ mini_circuit_size };
+    ProverPolynomials& prover_polynomials = key.proving_key->polynomials;
+    const size_t real_circuit_size = full_circuit_size - full_NUM_DISABLED_ROWS_IN_SUMCHECK;
 
-//     // Fill required relation parameters
-//     RelationParameters<FF> params{ .beta = FF::random_element(), .gamma = FF::random_element() };
+    // Fill required relation parameters
+    RelationParameters<FF> params{ .beta = FF::random_element(), .gamma = FF::random_element() };
 
-//     // Populate the group polynomials with appropriate values and also enough random values to mask their commitment
-//     and
-//     // evaluation
-//     auto fill_polynomial_with_random_14_bit_values = [&](auto& polynomial) {
-//         for (size_t i = polynomial.start_index(); i < polynomial.end_index() - NUM_DISABLED_ROWS_IN_SUMCHECK; i++) {
-//             polynomial.at(i) = engine.get_random_uint16() & ((1 << Flavor::MICRO_LIMB_BITS) - 1);
-//         }
-//         for (size_t i = polynomial.end_index() - NUM_DISABLED_ROWS_IN_SUMCHECK; i < polynomial.end_index(); i++) {
-//             polynomial.at(i) = FF::random_element();
-//         }
-//     };
+    // Populate the group polynomials with appropriate values and also enough random values to mask their commitment
+    // and evaluation
+    auto fill_polynomial_with_random_14_bit_values = [&](auto& polynomial) {
+        for (size_t i = polynomial.start_index(); i < polynomial.end_index() - NUM_DISABLED_ROWS_IN_SUMCHECK; i++) {
+            polynomial.at(i) = engine.get_random_uint16() & ((1 << Flavor::MICRO_LIMB_BITS) - 1);
+        }
+        for (size_t i = polynomial.end_index() - NUM_DISABLED_ROWS_IN_SUMCHECK; i < polynomial.end_index(); i++) {
+            polynomial.at(i) = FF::random_element();
+        }
+    };
 
-//     for (const auto& group : prover_polynomials.get_groups_to_be_interleaved()) {
-//         for (auto& poly : group) {
-//             fill_polynomial_with_random_14_bit_values(poly);
-//         }
-//     }
+    for (const auto& group : prover_polynomials.get_groups_to_be_interleaved()) {
+        for (auto& poly : group) {
+            fill_polynomial_with_random_14_bit_values(poly);
+        }
+    }
 
-//     // Fill in lagrange polynomials used in the permutation relation
-//     prover_polynomials.lagrange_first.at(0) = 1;
-//     prover_polynomials.lagrange_real_last.at(real_circuit_size - 1) = 1;
-//     prover_polynomials.lagrange_last.at(full_circuit_size - 1) = 1;
-//     for (size_t i = real_circuit_size; i < full_circuit_size; i++) {
-//         prover_polynomials.lagrange_masking.at(i) = 1;
-//     }
+    // Fill in lagrange polynomials used in the permutation relation
+    prover_polynomials.lagrange_first.at(0) = 1;
+    prover_polynomials.lagrange_real_last.at(real_circuit_size - 1) = 1;
+    prover_polynomials.lagrange_last.at(full_circuit_size - 1) = 1;
+    for (size_t i = real_circuit_size; i < full_circuit_size; i++) {
+        prover_polynomials.lagrange_masking.at(i) = 1;
+    }
 
-//     key.compute_interleaved_polynomials();
-//     key.compute_extra_range_constraint_numerator();
-//     key.compute_translator_range_constraint_ordered_polynomials(true);
+    key.compute_interleaved_polynomials();
+    key.compute_extra_range_constraint_numerator();
+    key.compute_translator_range_constraint_ordered_polynomials(true);
 
-//     // Populate the first 4 ordered polynomials with the random values from the interleaved polynomials
-//     for (size_t i = 0; i < 4; i++) {
-//         auto& ordered = prover_polynomials.get_ordered_range_constraints()[i];
-//         auto& interleaved = prover_polynomials.get_interleaved()[i];
-//         for (size_t j = real_circuit_size; j < full_circuit_size; j++) {
-//             ordered.at(j) = interleaved.at(j);
-//         }
-//     }
+    // Populate the first 4 ordered polynomials with the random values from the interleaved polynomials
+    for (size_t i = 0; i < 4; i++) {
+        auto& ordered = prover_polynomials.get_ordered_range_constraints()[i];
+        auto& interleaved = prover_polynomials.get_interleaved()[i];
+        for (size_t j = real_circuit_size; j < full_circuit_size; j++) {
+            ordered.at(j) = interleaved.at(j);
+        }
+    }
 
-//     // Populate the last ordered range constraint and the extra polynomial in the numerator with random values
-//     for (size_t i = real_circuit_size; i < full_circuit_size; i++) {
-//         FF random_value = FF::random_element();
-//         prover_polynomials.ordered_extra_range_constraints_numerator.at(i) = random_value;
-//         prover_polynomials.ordered_range_constraints_4.at(i) = random_value;
-//     }
+    // Populate the last ordered range constraint and the extra polynomial in the numerator with random values
+    for (size_t i = real_circuit_size; i < full_circuit_size; i++) {
+        FF random_value = FF::random_element();
+        prover_polynomials.ordered_extra_range_constraints_numerator.at(i) = random_value;
+        prover_polynomials.ordered_range_constraints_4.at(i) = random_value;
+    }
 
-//     // Compute the grand product polynomial
-//     compute_grand_product<Flavor, bb::TranslatorPermutationRelation<FF>>(prover_polynomials, params);
+    // Compute the grand product polynomial
+    compute_grand_product<Flavor, bb::TranslatorPermutationRelation<FF>>(prover_polynomials, params);
 
-//     // Check that permutation relation is satisfied across each row of the prover polynomials
-//     RelationChecker<Flavor>::check<TranslatorPermutationRelation<FF>>(
-//         prover_polynomials, params, "TranslatorPermutationRelation");
-//     RelationChecker<Flavor>::check<TranslatorDeltaRangeConstraintRelation<FF>>(
-//         prover_polynomials, params, "TranslatorPermutationRelation");
-// }
+    // Check that permutation relation is satisfied across each row of the prover polynomials
+    RelationChecker<Flavor>::check<TranslatorPermutationRelation<FF>>(
+        prover_polynomials, params, "TranslatorPermutationRelation");
+    RelationChecker<Flavor>::check<TranslatorDeltaRangeConstraintRelation<FF>>(
+        prover_polynomials, params, "TranslatorPermutationRelation");
+}
 
-// TEST_F(TranslatorRelationCorrectnessTests, ZeroKnowledgeDeltaRange)
-// {
-//     using Flavor = TranslatorFlavor;
-//     using FF = typename Flavor::FF;
-//     using ProverPolynomials = typename Flavor::ProverPolynomials;
-//     auto& engine = numeric::get_debug_randomness();
-//     const size_t mini_circuit_size = 2048;
-//     const auto sort_step = Flavor::SORT_STEP;
-//     const auto max_value = (1 << Flavor::MICRO_LIMB_BITS) - 1;
+TEST_F(TranslatorRelationCorrectnessTests, ZeroKnowledgeDeltaRange)
+{
+    using Flavor = TranslatorFlavor;
+    using FF = typename Flavor::FF;
+    using ProverPolynomials = typename Flavor::ProverPolynomials;
+    auto& engine = numeric::get_debug_randomness();
+    const size_t mini_circuit_size = 2048;
+    const auto sort_step = Flavor::SORT_STEP;
+    const auto max_value = (1 << Flavor::MICRO_LIMB_BITS) - 1;
 
-//     TranslatorProvingKey key{ mini_circuit_size };
-//     ProverPolynomials& prover_polynomials = key.proving_key->polynomials;
+    TranslatorProvingKey key{ mini_circuit_size };
+    ProverPolynomials& prover_polynomials = key.proving_key->polynomials;
 
-//     const size_t full_NUM_DISABLED_ROWS_IN_SUMCHECK = NUM_DISABLED_ROWS_IN_SUMCHECK *
-//     Flavor::INTERLEAVING_GROUP_SIZE; const size_t real_circuit_size = key.dyadic_circuit_size -
-//     full_NUM_DISABLED_ROWS_IN_SUMCHECK;
+    const size_t full_NUM_DISABLED_ROWS_IN_SUMCHECK = NUM_DISABLED_ROWS_IN_SUMCHECK * Flavor::INTERLEAVING_GROUP_SIZE;
+    const size_t real_circuit_size = key.dyadic_circuit_size - full_NUM_DISABLED_ROWS_IN_SUMCHECK;
 
-//     // Construct lagrange polynomials that are needed for Translator's DeltaRangeConstraint Relation
-//     prover_polynomials.lagrange_first.at(0) = 0;
-//     prover_polynomials.lagrange_real_last.at(real_circuit_size - 1) = 1;
+    // Construct lagrange polynomials that are needed for Translator's DeltaRangeConstraint Relation
+    prover_polynomials.lagrange_first.at(0) = 0;
+    prover_polynomials.lagrange_real_last.at(real_circuit_size - 1) = 1;
 
-//     for (size_t i = real_circuit_size; i < key.dyadic_circuit_size; i++) {
-//         prover_polynomials.lagrange_masking.at(i) = 1;
-//     }
+    for (size_t i = real_circuit_size; i < key.dyadic_circuit_size; i++) {
+        prover_polynomials.lagrange_masking.at(i) = 1;
+    }
 
-//     // Create a vector and fill with necessary steps for the DeltaRangeConstraint relation
-//     auto sorted_elements_count = (max_value / sort_step) + 1;
-//     std::vector<uint64_t> vector_for_sorting;
-//     vector_for_sorting.reserve(prover_polynomials.ordered_range_constraints_0.size());
-//     for (size_t i = 0; i < sorted_elements_count - 1; i++) {
-//         vector_for_sorting.emplace_back(i * sort_step);
-//     }
-//     vector_for_sorting[sorted_elements_count - 1] = max_value;
+    // Create a vector and fill with necessary steps for the DeltaRangeConstraint relation
+    auto sorted_elements_count = (max_value / sort_step) + 1;
+    std::vector<uint64_t> vector_for_sorting;
+    vector_for_sorting.reserve(prover_polynomials.ordered_range_constraints_0.size());
+    for (size_t i = 0; i < sorted_elements_count - 1; i++) {
+        vector_for_sorting.emplace_back(i * sort_step);
+    }
+    vector_for_sorting[sorted_elements_count - 1] = max_value;
 
-//     // Add random values in the appropriate range to fill the leftover space
-//     for (size_t i = sorted_elements_count; i < real_circuit_size; i++) {
-//         vector_for_sorting.emplace_back(engine.get_random_uint16() & ((1 << Flavor::MICRO_LIMB_BITS) - 1));
-//     }
+    // Add random values in the appropriate range to fill the leftover space
+    for (size_t i = sorted_elements_count; i < real_circuit_size; i++) {
+        vector_for_sorting.emplace_back(engine.get_random_uint16() & ((1 << Flavor::MICRO_LIMB_BITS) - 1));
+    }
 
-//     // Get ordered polynomials
-//     auto polynomial_pointers = std::vector{ &prover_polynomials.ordered_range_constraints_0,
-//                                             &prover_polynomials.ordered_range_constraints_1,
-//                                             &prover_polynomials.ordered_range_constraints_2,
-//                                             &prover_polynomials.ordered_range_constraints_3,
-//                                             &prover_polynomials.ordered_range_constraints_4 };
+    // Get ordered polynomials
+    auto polynomial_pointers = std::vector{ &prover_polynomials.ordered_range_constraints_0,
+                                            &prover_polynomials.ordered_range_constraints_1,
+                                            &prover_polynomials.ordered_range_constraints_2,
+                                            &prover_polynomials.ordered_range_constraints_3,
+                                            &prover_polynomials.ordered_range_constraints_4 };
 
-//     // Sort the vector
-//     std::sort(vector_for_sorting.begin(), vector_for_sorting.end());
+    std::sort(vector_for_sorting.begin(), vector_for_sorting.end());
 
-//     // Add masking values
-//     for (size_t i = real_circuit_size; i < key.dyadic_circuit_size; i++) {
-//         vector_for_sorting.emplace_back(FF::random_element());
-//     }
+    // Add masking values
+    for (size_t i = real_circuit_size; i < key.dyadic_circuit_size; i++) {
+        vector_for_sorting.emplace_back(FF::random_element());
+    }
 
-//     // Copy values, transforming them into Finite Field elements
-//     std::transform(vector_for_sorting.cbegin(),
-//                    vector_for_sorting.cend(),
-//                    prover_polynomials.ordered_range_constraints_0.coeffs().begin(),
-//                    [](uint64_t in) { return FF(in); });
+    // Copy values, transforming them into Finite Field elements
+    std::transform(vector_for_sorting.cbegin(),
+                   vector_for_sorting.cend(),
+                   prover_polynomials.ordered_range_constraints_0.coeffs().begin(),
+                   [](uint64_t in) { return FF(in); });
 
-//     // Copy the same polynomial into the 4 other ordered polynomials (they are not the same in an actual proof, but
-//     // we only need to check the correctness of the relation and it acts independently on each polynomial)
-//     for (size_t i = 0; i < 4; ++i) {
-//         std::copy(prover_polynomials.ordered_range_constraints_0.coeffs().begin(),
-//                   prover_polynomials.ordered_range_constraints_0.coeffs().end(),
-//                   polynomial_pointers[i + 1]->coeffs().begin());
-//     }
+    // Copy the same polynomial into the 4 other ordered polynomials (they are not the same in an actual proof, but
+    // we only need to check the correctness of the relation and it acts independently on each polynomial)
+    for (size_t i = 0; i < 4; ++i) {
+        std::copy(prover_polynomials.ordered_range_constraints_0.coeffs().begin(),
+                  prover_polynomials.ordered_range_constraints_0.coeffs().end(),
+                  polynomial_pointers[i + 1]->coeffs().begin());
+    }
 
-//     // Check that DeltaRangeConstraint relation is satisfied across each row of the prover polynomials
-//     RelationChecker<Flavor>::check<TranslatorDeltaRangeConstraintRelation<FF>>(
-//         prover_polynomials, RelationParameters<FF>(), "TranslatorDeltaRangeConstraintRelation");
-// }
+    // Check that DeltaRangeConstraint relation is satisfied across each row of the prover polynomials
+    RelationChecker<Flavor>::check<TranslatorDeltaRangeConstraintRelation<FF>>(
+        prover_polynomials, RelationParameters<FF>(), "TranslatorDeltaRangeConstraintRelation");
+}

--- a/barretenberg/cpp/src/barretenberg/translator_vm/relation_correctness.test.cpp
+++ b/barretenberg/cpp/src/barretenberg/translator_vm/relation_correctness.test.cpp
@@ -28,7 +28,8 @@ TEST_F(TranslatorRelationCorrectnessTests, Permutation)
     RelationParameters<FF> params{ .beta = FF::random_element(), .gamma = FF::random_element() };
 
     // Create storage for polynomials
-    TranslatorProvingKey key{};
+    TranslatorProvingKey key;
+    key.proving_key = std::make_shared<typename Flavor::ProvingKey>();
     ProverPolynomials& prover_polynomials = key.proving_key->polynomials;
 
     // Fill in lagrange polynomials used in the permutation relation
@@ -74,6 +75,7 @@ TEST_F(TranslatorRelationCorrectnessTests, DeltaRangeConstraint)
     const auto max_value = (1 << Flavor::MICRO_LIMB_BITS) - 1;
 
     TranslatorProvingKey key;
+    key.proving_key = std::make_shared<typename Flavor::ProvingKey>();
     ProverPolynomials& prover_polynomials = key.proving_key->polynomials;
 
     // Construct lagrange polynomials that are needed for Translator's DeltaRangeConstraint Relation
@@ -653,7 +655,8 @@ TEST_F(TranslatorRelationCorrectnessTests, ZeroKnowledgePermutation)
     auto& engine = numeric::get_debug_randomness();
     const size_t full_masking_offset = NUM_DISABLED_ROWS_IN_SUMCHECK * Flavor::INTERLEAVING_GROUP_SIZE;
 
-    TranslatorProvingKey key;
+    TranslatorProvingKey key{};
+    key.proving_key = std::make_shared<typename Flavor::ProvingKey>();
     ProverPolynomials& prover_polynomials = key.proving_key->polynomials;
     const size_t real_circuit_size = full_circuit_size - full_masking_offset;
 
@@ -725,6 +728,7 @@ TEST_F(TranslatorRelationCorrectnessTests, ZeroKnowledgeDeltaRange)
     const auto max_value = (1 << Flavor::MICRO_LIMB_BITS) - 1;
 
     TranslatorProvingKey key;
+    key.proving_key = std::make_shared<typename Flavor::ProvingKey>();
     ProverPolynomials& prover_polynomials = key.proving_key->polynomials;
 
     const size_t full_masking_offset = NUM_DISABLED_ROWS_IN_SUMCHECK * Flavor::INTERLEAVING_GROUP_SIZE;

--- a/barretenberg/cpp/src/barretenberg/translator_vm/relation_correctness.test.cpp
+++ b/barretenberg/cpp/src/barretenberg/translator_vm/relation_correctness.test.cpp
@@ -551,7 +551,6 @@ TEST_F(TranslatorRelationCorrectnessTests, NonNative)
 
     constexpr size_t NUM_LIMB_BITS = Flavor::NUM_LIMB_BITS;
     constexpr auto mini_circuit_size = TranslatorFlavor::MINI_CIRCUIT_SIZE;
-    ;
 
     auto& engine = numeric::get_debug_randomness();
 

--- a/barretenberg/cpp/src/barretenberg/translator_vm/translator_flavor.hpp
+++ b/barretenberg/cpp/src/barretenberg/translator_vm/translator_flavor.hpp
@@ -61,7 +61,8 @@ class TranslatorFlavor {
     // involved in the interleaving subprotocol)
     static constexpr size_t LOG_MINI_CIRCUIT_SIZE = 14;
 
-    static constexpr size_t CONST_TRANSLATOR_LOG_N = 18;
+    // LOG_MINI_CIRCUIT_SIZE + log2(INTERLEAVING_GROUP_SIZE)
+    static constexpr size_t CONST_TRANSLATOR_LOG_N = LOG_MINI_CIRCUIT_SIZE + numeric::get_msb(INTERLEAVING_GROUP_SIZE);
 
     static constexpr size_t MINI_CIRCUIT_SIZE = 1UL << LOG_MINI_CIRCUIT_SIZE;
 
@@ -614,7 +615,7 @@ class TranslatorFlavor {
         ProverPolynomials()
         {
 
-            size_t circuit_size = MINI_CIRCUIT_SIZE * INTERLEAVING_GROUP_SIZE;
+            const size_t circuit_size = 1 << CONST_TRANSLATOR_LOG_N;
             for (auto& ordered_range_constraint : get_ordered_range_constraints()) {
                 ordered_range_constraint = Polynomial{ /*size*/ circuit_size - 1,
                                                        /*largest possible index*/ circuit_size,

--- a/barretenberg/cpp/src/barretenberg/translator_vm/translator_flavor.hpp
+++ b/barretenberg/cpp/src/barretenberg/translator_vm/translator_flavor.hpp
@@ -57,11 +57,11 @@ class TranslatorFlavor {
     // How many mini_circuit_size polynomials are interleaved in one interleaved_*
     static constexpr size_t INTERLEAVING_GROUP_SIZE = 16;
 
-    // The fixed size of Translator circuit which also corresponds to the size of most polynomials (except the ones
-    // involved in the interleaving subprotocol)
+    // The fixed  log size of Translator circuit determining the size most polynomials (except the ones
+    // involved in the interleaving subprotocol). It should be determined by the size of the EccOpQueue.
     static constexpr size_t LOG_MINI_CIRCUIT_SIZE = 14;
 
-    // Determines the size of the polynomials initialised on the full domain
+    // Log of size of interleaved_* and ordered_* polynomials
     static constexpr size_t CONST_TRANSLATOR_LOG_N = LOG_MINI_CIRCUIT_SIZE + numeric::get_msb(INTERLEAVING_GROUP_SIZE);
 
     static constexpr size_t MINI_CIRCUIT_SIZE = 1UL << LOG_MINI_CIRCUIT_SIZE;

--- a/barretenberg/cpp/src/barretenberg/translator_vm/translator_flavor.hpp
+++ b/barretenberg/cpp/src/barretenberg/translator_vm/translator_flavor.hpp
@@ -61,8 +61,8 @@ class TranslatorFlavor {
     // involved in the interleaving subprotocol)
     static constexpr size_t LOG_MINI_CIRCUIT_SIZE = 14;
 
-    // LOG_MINI_CIRCUIT_SIZE + log2(INTERLEAVING_GROUP_SIZE)
-    static constexpr size_t CONST_TRANSLATOR_LOG_N = LOG_MINI_CIRCUIT_SIZE + numeric::get_msb(INTERLEAVING_GROUP_SIZE);
+    // Determines the size of the polynomials initialised on the full domain
+    static constexpr size_t CONST_TRANSLATOR_LOG_N = 18;
 
     static constexpr size_t MINI_CIRCUIT_SIZE = 1UL << LOG_MINI_CIRCUIT_SIZE;
 

--- a/barretenberg/cpp/src/barretenberg/translator_vm/translator_flavor.hpp
+++ b/barretenberg/cpp/src/barretenberg/translator_vm/translator_flavor.hpp
@@ -52,18 +52,18 @@ class TranslatorFlavor {
     // Important: these constants cannot be arbitrarily changed - please consult with a member of the Crypto team if
     // they become too small.
 
-    // The log of the full Translator circuit size. It determines MINI_CIRCUIT_SIZE and, in the current design,
-    // is the only Translator-related constant that can be modified.
-    static constexpr size_t CONST_TRANSLATOR_LOG_N = 18;
-
     // None of this parameters can be changed
 
     // How many mini_circuit_size polynomials are interleaved in one interleaved_*
     static constexpr size_t INTERLEAVING_GROUP_SIZE = 16;
-    // The size of the circuit which is filled with non-zero values for most polynomials. Most relations (everything
-    // except for Permutation and DeltaRangeConstraint) can be evaluated just on the first chunk
-    // It is also the only parameter that can be changed without updating relations or structures in the flavor
-    static constexpr size_t MINI_CIRCUIT_SIZE = (1UL << CONST_TRANSLATOR_LOG_N) / INTERLEAVING_GROUP_SIZE;
+
+    // The fixed size of Translator circuit which also corresponds to the size of most polynomials (except the ones
+    // involved in the interleaving subprotocol)
+    static constexpr size_t LOG_MINI_CIRCUIT_SIZE = 14;
+
+    static constexpr size_t CONST_TRANSLATOR_LOG_N = 18;
+
+    static constexpr size_t MINI_CIRCUIT_SIZE = 1UL << LOG_MINI_CIRCUIT_SIZE;
 
     // The number of interleaved_* wires
     static constexpr size_t NUM_INTERLEAVED_WIRES = 4;
@@ -607,63 +607,12 @@ class TranslatorFlavor {
      */
     class ProverPolynomials : public AllEntities<Polynomial> {
       public:
-        // Define all operations as default, except copy construction/assignment
-        ProverPolynomials() = default;
-
         /**
          * @brief ProverPolynomials constructor
-         * @details Attempts to initialize polynomials efficiently by using the actual size of the mini circuit rather
-         * than the fixed dydaic size.
-         *
-         * @param actual_mini_circuit_size Actual number of rows in the Translator circuit.
+         * @details Initialises wire polynomials efficiently to be only minicircuit size..
          */
-        // TODO(https://github.com/AztecProtocol/barretenberg/issues/1318)
-        ProverPolynomials([[maybe_unused]] size_t actual_mini_circuit_size)
+        ProverPolynomials()
         {
-            // const size_t mini_circuit_size = MINI_CIRCUIT_SIZE;
-            // const size_t circuit_size = 1UL << CONST_TRANSLATOR_LOG_N;
-
-            // for (auto& ordered_range_constraint : get_ordered_range_constraints()) {
-            //     ordered_range_constraint = Polynomial{ /*size*/ circuit_size - 1,
-            //                                            /*virtual_size*/ circuit_size,
-            //                                            1 };
-            // }
-
-            // z_perm = Polynomial{ /*size*/ circuit_size - 1,
-            //                      /*virtual_size*/ circuit_size,
-            //                      /*start_index*/ 1 };
-
-            // // Initialize to be shifted wires based on actual size of the mini circuit
-            // for (auto& poly : get_wires_to_be_shifted()) {
-            //     poly = Polynomial{ /*size*/ actual_mini_circuit_size - 1,
-            //                        /*virtual_size*/ circuit_size,
-            //                        /*start_index*/ 1 };
-            // }
-
-            // // Initialize interleaved polys based on actual mini circuit size times number of polys to be interleaved
-            // const size_t actual_circuit_size = actual_mini_circuit_size * INTERLEAVING_GROUP_SIZE;
-            // for (auto& poly : get_interleaved()) {
-            //     poly = Polynomial{ actual_circuit_size, circuit_size };
-            // }
-
-            // // Initialize some one-off polys with special structure
-            // lagrange_first = Polynomial{ /*size*/ 1, /*virtual_size*/ circuit_size };
-            // lagrange_result_row = Polynomial{ /*size*/ 3, /*virtual_size*/ circuit_size };
-            // lagrange_even_in_minicircuit = Polynomial{ /*size*/ mini_circuit_size, /*virtual_size*/ circuit_size };
-            // lagrange_odd_in_minicircuit = Polynomial{ /*size*/ mini_circuit_size, /*virtual_size*/ circuit_size };
-
-            // // WORKTODO: why does limiting this to actual_mini_circuit_size not work?
-            // op = Polynomial{ circuit_size }; // Polynomial{ actual_mini_circuit_size, circuit_size };
-
-            // // Catch-all for the rest of the polynomials
-            // // WORKTODO: determine what exactly falls in here and be more specific (just the remaining precomputed?)
-            // for (auto& poly : get_unshifted()) {
-            //     if (poly.is_empty()) { // Only set those polys which were not already set above
-            //         poly = Polynomial{ circuit_size };
-            //     }
-            // }
-            // // Set all shifted polynomials based on their unshifted counterpart
-            // set_shifted();
 
             size_t circuit_size = MINI_CIRCUIT_SIZE * INTERLEAVING_GROUP_SIZE;
             for (auto& ordered_range_constraint : get_ordered_range_constraints()) {
@@ -738,23 +687,12 @@ class TranslatorFlavor {
     class ProvingKey : public ProvingKey_<FF, CommitmentKey> {
       public:
         ProverPolynomials polynomials; // storage for all polynomials evaluated by the prover
-
         // Expose constructors on the base class
         using Base = ProvingKey_<FF, CommitmentKey>;
         using Base::Base;
 
-        ProvingKey() = default;
-        // WORKTODO: this is a constructor used only in tests. We should get rid of it or make it a test-only method.
-        ProvingKey(const size_t dyadic_circuit_size, const size_t actual_mini_circuit_size)
-            : Base(dyadic_circuit_size, 0)
-            , polynomials(actual_mini_circuit_size)
-        {}
-
-        ProvingKey(const size_t dyadic_circuit_size,
-                   std::shared_ptr<CommitmentKey> commitment_key,
-                   const size_t actual_mini_circuit_size)
-            : Base(dyadic_circuit_size, 0, std::move(commitment_key))
-            , polynomials(actual_mini_circuit_size)
+        ProvingKey(std::shared_ptr<CommitmentKey> commitment_key = nullptr)
+            : Base(1UL << CONST_TRANSLATOR_LOG_N, 0, std::move(commitment_key))
         {}
     };
 
@@ -781,12 +719,9 @@ class TranslatorFlavor {
             }
         }
 
-        VerificationKey(const size_t circuit_size, const size_t num_public_inputs)
-            : VerificationKey_(circuit_size, num_public_inputs)
-        {}
         VerificationKey(const std::shared_ptr<ProvingKey>& proving_key)
         {
-            this->circuit_size = 1UL << TranslatorFlavor::CONST_TRANSLATOR_LOG_N;
+            this->circuit_size = 1UL << CONST_TRANSLATOR_LOG_N;
             this->log_circuit_size = CONST_TRANSLATOR_LOG_N;
             this->num_public_inputs = proving_key->num_public_inputs;
             this->pub_inputs_offset = proving_key->pub_inputs_offset;

--- a/barretenberg/cpp/src/barretenberg/translator_vm/translator_flavor.hpp
+++ b/barretenberg/cpp/src/barretenberg/translator_vm/translator_flavor.hpp
@@ -692,7 +692,6 @@ class TranslatorFlavor {
         using Base = ProvingKey_<FF, CommitmentKey>;
         using Base::Base;
 
-        ProvingKey() = default;
         ProvingKey(std::shared_ptr<CommitmentKey> commitment_key = nullptr)
             : Base(1UL << CONST_TRANSLATOR_LOG_N, 0, std::move(commitment_key))
         {}

--- a/barretenberg/cpp/src/barretenberg/translator_vm/translator_flavor.hpp
+++ b/barretenberg/cpp/src/barretenberg/translator_vm/translator_flavor.hpp
@@ -692,6 +692,7 @@ class TranslatorFlavor {
         using Base = ProvingKey_<FF, CommitmentKey>;
         using Base::Base;
 
+        ProvingKey() = default;
         ProvingKey(std::shared_ptr<CommitmentKey> commitment_key = nullptr)
             : Base(1UL << CONST_TRANSLATOR_LOG_N, 0, std::move(commitment_key))
         {}

--- a/barretenberg/cpp/src/barretenberg/translator_vm/translator_flavor.hpp
+++ b/barretenberg/cpp/src/barretenberg/translator_vm/translator_flavor.hpp
@@ -62,7 +62,7 @@ class TranslatorFlavor {
     static constexpr size_t LOG_MINI_CIRCUIT_SIZE = 14;
 
     // Determines the size of the polynomials initialised on the full domain
-    static constexpr size_t CONST_TRANSLATOR_LOG_N = 18;
+    static constexpr size_t CONST_TRANSLATOR_LOG_N = LOG_MINI_CIRCUIT_SIZE + numeric::get_msb(INTERLEAVING_GROUP_SIZE);
 
     static constexpr size_t MINI_CIRCUIT_SIZE = 1UL << LOG_MINI_CIRCUIT_SIZE;
 
@@ -639,7 +639,7 @@ class TranslatorFlavor {
                 }
             }
 
-            // // Initialize some one-off polys with special structure
+            // Initialize some one-off polys with special structure
             lagrange_first = Polynomial{ /*size*/ 1, /*virtual_size*/ circuit_size };
             lagrange_result_row = Polynomial{ /*size*/ 3, /*virtual_size*/ circuit_size };
             lagrange_even_in_minicircuit = Polynomial{ /*size*/ MINI_CIRCUIT_SIZE, /*virtual_size*/ circuit_size };

--- a/barretenberg/cpp/src/barretenberg/translator_vm/translator_proving_key.cpp
+++ b/barretenberg/cpp/src/barretenberg/translator_vm/translator_proving_key.cpp
@@ -86,11 +86,10 @@ void TranslatorProvingKey::compute_translator_range_constraint_ordered_polynomia
     constexpr size_t sort_step = Flavor::SORT_STEP;
     constexpr size_t num_interleaved_wires = Flavor::NUM_INTERLEAVED_WIRES;
 
-    const size_t full_circuit_size = mini_circuit_dyadic_size * Flavor::INTERLEAVING_GROUP_SIZE;
     const size_t mini_NUM_DISABLED_ROWS_IN_SUMCHECK = masking ? NUM_DISABLED_ROWS_IN_SUMCHECK : 0;
     const size_t full_NUM_DISABLED_ROWS_IN_SUMCHECK =
         masking ? mini_NUM_DISABLED_ROWS_IN_SUMCHECK * Flavor::INTERLEAVING_GROUP_SIZE : 0;
-    const size_t real_circuit_size = full_circuit_size - full_NUM_DISABLED_ROWS_IN_SUMCHECK;
+    const size_t real_circuit_size = dyadic_circuit_size - full_NUM_DISABLED_ROWS_IN_SUMCHECK;
 
     // The value we have to end polynomials with, 2¹⁴ - 1
     constexpr uint32_t max_value = (1 << Flavor::MICRO_LIMB_BITS) - 1;

--- a/barretenberg/cpp/src/barretenberg/translator_vm/translator_proving_key.hpp
+++ b/barretenberg/cpp/src/barretenberg/translator_vm/translator_proving_key.hpp
@@ -21,8 +21,11 @@ class TranslatorProvingKey {
     using ProverPolynomials = typename Flavor::ProverPolynomials;
     using CommitmentKey = typename Flavor::CommitmentKey;
 
-    size_t mini_circuit_dyadic_size;
-    size_t dyadic_circuit_size;
+    size_t mini_circuit_dyadic_size = Flavor::MINI_CIRCUIT_SIZE;
+    // The actual circuit size is several times bigger than the trace in the circuit, because we use interleaving
+    // to bring the degree of relations down, while extending the length.
+
+    size_t dyadic_circuit_size = mini_circuit_dyadic_size * Flavor::INTERLEAVING_GROUP_SIZE;
     std::shared_ptr<ProvingKey> proving_key;
 
     BF batching_challenge_v = { 0 };
@@ -40,11 +43,6 @@ class TranslatorProvingKey {
         if (circuit.num_gates > Flavor::MINI_CIRCUIT_SIZE) {
             throw_or_abort("The Translator circuit size has exceeded the fixed upper bound");
         }
-        mini_circuit_dyadic_size = Flavor::MINI_CIRCUIT_SIZE;
-
-        // The actual circuit size is several times bigger than the trace in the circuit, because we use interleaving
-        // to bring the degree of relations down, while extending the length.
-        dyadic_circuit_size = mini_circuit_dyadic_size * Flavor::INTERLEAVING_GROUP_SIZE;
 
         proving_key = std::make_shared<ProvingKey>(std::move(commitment_key));
 

--- a/barretenberg/cpp/src/barretenberg/translator_vm/translator_proving_key.hpp
+++ b/barretenberg/cpp/src/barretenberg/translator_vm/translator_proving_key.hpp
@@ -21,11 +21,11 @@ class TranslatorProvingKey {
     using ProverPolynomials = typename Flavor::ProverPolynomials;
     using CommitmentKey = typename Flavor::CommitmentKey;
 
-    size_t mini_circuit_dyadic_size = Flavor::MINI_CIRCUIT_SIZE;
+    static constexpr size_t mini_circuit_dyadic_size = Flavor::MINI_CIRCUIT_SIZE;
     // The actual circuit size is several times bigger than the trace in the circuit, because we use interleaving
     // to bring the degree of relations down, while extending the length.
 
-    size_t dyadic_circuit_size = mini_circuit_dyadic_size * Flavor::INTERLEAVING_GROUP_SIZE;
+    static constexpr size_t dyadic_circuit_size = mini_circuit_dyadic_size * Flavor::INTERLEAVING_GROUP_SIZE;
     std::shared_ptr<ProvingKey> proving_key;
 
     BF batching_challenge_v = { 0 };

--- a/barretenberg/cpp/src/barretenberg/translator_vm/translator_proving_key.hpp
+++ b/barretenberg/cpp/src/barretenberg/translator_vm/translator_proving_key.hpp
@@ -30,25 +30,23 @@ class TranslatorProvingKey {
 
     TranslatorProvingKey() = default;
 
-    TranslatorProvingKey(size_t actual_mini_circuit_size)
-    {
-        compute_mini_circuit_dyadic_size(actual_mini_circuit_size);
-        compute_dyadic_circuit_size();
-        proving_key = std::make_shared<ProvingKey>(dyadic_circuit_size, actual_mini_circuit_size);
-    }
-
     TranslatorProvingKey(const Circuit& circuit, std::shared_ptr<CommitmentKey> commitment_key = nullptr)
         : batching_challenge_v(circuit.batching_challenge_v)
         , evaluation_input_x(circuit.evaluation_input_x)
     {
         PROFILE_THIS_NAME("TranslatorProvingKey(TranslatorCircuit&)");
+        // Check that the Translator Circuit does not exceed the fixed upper bound, the current value amounts to
+        // a number of EccOps sufficient for 10 rounds of folding (so 20 circuits)
+        if (circuit.num_gates > Flavor::MINI_CIRCUIT_SIZE) {
+            throw_or_abort("The Translator circuit size has exceeded the fixed upper bound");
+        }
+        mini_circuit_dyadic_size = Flavor::MINI_CIRCUIT_SIZE;
 
-        // WORKTODO: the methods below just set the constant values MINI_CIRCUIT_SIZE and 2^{CONST_TRANSLATOR_LOG_N}
-        compute_mini_circuit_dyadic_size(circuit.num_gates);
-        compute_dyadic_circuit_size();
+        // The actual circuit size is several times bigger than the trace in the circuit, because we use interleaving
+        // to bring the degree of relations down, while extending the length.
+        dyadic_circuit_size = mini_circuit_dyadic_size * Flavor::INTERLEAVING_GROUP_SIZE;
 
-        proving_key = std::make_shared<ProvingKey>(
-            dyadic_circuit_size, std::move(commitment_key), /*actual_mini_ circuit_size=*/circuit.num_gates);
+        proving_key = std::make_shared<ProvingKey>(std::move(commitment_key));
 
         // Populate the wire polynomials from the wire vectors in the circuit
         for (auto [wire_poly_, wire_] : zip_view(proving_key->polynomials.get_wires(), circuit.wires)) {
@@ -87,24 +85,6 @@ class TranslatorProvingKey {
         // bridge the range from 0 to 3 (3 is the maximum allowed range defined by the range constraint).
         compute_translator_range_constraint_ordered_polynomials();
     };
-
-    inline void compute_dyadic_circuit_size()
-    {
-
-        // The actual circuit size is several times bigger than the trace in the circuit, because we use interleaving
-        // to bring the degree of relations down, while extending the length.
-        dyadic_circuit_size = mini_circuit_dyadic_size * Flavor::INTERLEAVING_GROUP_SIZE;
-    }
-
-    inline void compute_mini_circuit_dyadic_size(size_t num_gates)
-    {
-        // Check that the Translator Circuit does not exceed the fixed upper bound, the current value 8192 corresponds
-        // to 10 rounds of folding (i.e. 20 circuits)
-        if (num_gates > Flavor::MINI_CIRCUIT_SIZE) {
-            throw_or_abort("The Translator circuit size has exceeded the fixed upper bound");
-        }
-        mini_circuit_dyadic_size = Flavor::MINI_CIRCUIT_SIZE;
-    }
 
     void compute_lagrange_polynomials();
 


### PR DESCRIPTION
We merged a micro-optimisation of initialising Translator ProverPolynomials strictly on their actual mini circuit size. This gets in the way of being able to hide such polynomials and, in fact, the ability to  run ZK correctly (hence having the relation correctness tests with zk commented out). As this optimisation is not necessary to ensure Translator is within the WASM memory limits, we roll back to having the polynomials initialised on the appropriate fixed sizes. I also attempted to cleanup up our initialisation of mini and dyadic circuit size with constants within Translator.