### PR TITLE
chore: Fix flake in validator sentinel

### DIFF
--- a/yarn-project/end-to-end/src/e2e_p2p/validators_sentinel.test.ts
+++ b/yarn-project/end-to-end/src/e2e_p2p/validators_sentinel.test.ts
@@ -156,6 +156,14 @@ describe('e2e_p2p_validators_sentinel', () => {
       await retryUntil(() => t.monitor.l2BlockNumber > l2BlockNumber + 3, 'more blocks mined', timeout);
       await sleep(1000);
 
+      t.logger.info(`Waiting for sentinel to collect history`);
+      await retryUntil(
+        () => newNode.getValidatorsStats().then(s => Object.keys(s.stats).length > 1),
+        'sentinel stats',
+        SHORTENED_BLOCK_TIME_CONFIG.aztecSlotDuration * 2,
+        1,
+      );
+
       const stats = await newNode.getValidatorsStats();
       t.logger.info(`Collected validator stats from new node at block ${t.monitor.l2BlockNumber}`, { stats });
       const newNodeValidator = t.validators.at(-1)!.attester.toLowerCase();


### PR DESCRIPTION
Fixes flake

```
17:54:55  FAIL  src/e2e_p2p/validators_sentinel.test.ts
17:54:55   e2e_p2p_validators_sentinel
17:54:55     with an offline validator
17:54:55       ✓ collects stats on offline validator (7 ms)
17:54:55       ✓ collects stats on a block builder (3 ms)
17:54:55       ✓ collects stats on an attestor (6 ms)
17:54:55       ✕ starts a sentinel on a fresh node (48514 ms)
17:54:55 
17:54:55   ● e2e_p2p_validators_sentinel › with an offline validator › starts a sentinel on a fresh node
17:54:55 
17:54:55     expect(received).toBeGreaterThan(expected)
17:54:55 
17:54:55     Expected: > 1
17:54:55     Received:   1
17:54:55 
17:54:55       162 |       expect(stats.stats[newNodeValidator]).toBeDefined();
17:54:55       163 |       expect(stats.stats[newNodeValidator].history.length).toBeGreaterThanOrEqual(1);
17:54:55     > 164 |       expect(Object.keys(stats.stats).length).toBeGreaterThan(1);
17:54:55           |                                               ^
17:54:55       165 |     });
17:54:55       166 |   });
17:54:55       167 | });
17:54:55 
17:54:55       at Object.toBeGreaterThan (e2e_p2p/validators_sentinel.test.ts:164:47)
```