### PR TITLE
feat: txe add new public call flow

### DIFF
--- a/.test_patterns.yml
+++ b/.test_patterns.yml
@@ -143,6 +143,10 @@ tests:
     error_regex: "updates L1 to L2 messages changed due to an L1 reorg"
     owners:
       - *lasse
+  - regex: "src/e2e_epochs/epochs_empty_blocks"
+    error_regex: "✕ successfully proves multiple epochs"
+    owners:
+      - *lasse
   - regex: "src/e2e_cross_chain_messaging/token_bridge_private"
     error_regex: "✕ Claim secret is enough to consume the message"
     owners:

--- a/noir-projects/aztec-nr/aztec/src/test/helpers/cheatcodes.nr
+++ b/noir-projects/aztec-nr/aztec/src/test/helpers/cheatcodes.nr
@@ -1,9 +1,13 @@
 use crate::context::inputs::PrivateContextInputs;
 use crate::test::helpers::utils::TestAccount;
 use dep::protocol_types::{
-    abis::function_selector::FunctionSelector, address::AztecAddress,
-    constants::CONTRACT_INSTANCE_LENGTH, contract_instance::ContractInstance,
-    public_keys::PublicKeys, traits::Deserialize, utils::reader::Reader,
+    abis::function_selector::FunctionSelector,
+    address::AztecAddress,
+    constants::CONTRACT_INSTANCE_LENGTH,
+    contract_instance::ContractInstance,
+    public_keys::PublicKeys,
+    traits::{Deserialize, ToField},
+    utils::reader::Reader,
 };
 
 pub unconstrained fn reset() {
@@ -116,6 +120,24 @@ pub unconstrained fn private_call_new_flow(
     (end_side_effect_counter, returns_hash, tx_hash)
 }
 
+pub unconstrained fn public_call_new_flow(
+    from: AztecAddress,
+    contract_address: AztecAddress,
+    function_selector: FunctionSelector,
+    args: [Field],
+    is_static_call: bool,
+) -> (Field, Field) {
+    let calldata = args.push_front(function_selector.to_field());
+
+    let fields = oracle_public_call_new_flow(from, contract_address, calldata, is_static_call);
+
+    let mut reader = Reader::new(fields);
+    let returns_hash = reader.read();
+    let tx_hash = reader.read();
+
+    (returns_hash, tx_hash)
+}
+
 pub unconstrained fn disable_oracles() {
     oracle_disable_oracles();
 }
@@ -203,3 +225,11 @@ unconstrained fn oracle_disable_oracles() {}
 
 #[oracle(disableOracles)]
 unconstrained fn oracle_enable_oracles() {}
+
+#[oracle(publicCallNewFlow)]
+unconstrained fn oracle_public_call_new_flow(
+    from: AztecAddress,
+    contract_address: AztecAddress,
+    calldata: [Field],
+    is_static_call: bool,
+) -> [Field; 2] {}

--- a/noir-projects/aztec-nr/aztec/src/test/helpers/test_environment.nr
+++ b/noir-projects/aztec-nr/aztec/src/test/helpers/test_environment.nr
@@ -7,7 +7,8 @@ use dep::protocol_types::{
 
 use crate::context::{
     call_interfaces::CallInterface, PrivateCallInterface, PrivateContext, PrivateVoidCallInterface,
-    PublicContext, ReturnsHash, UtilityCallInterface, UtilityContext,
+    PublicCallInterface, PublicContext, PublicVoidCallInterface, ReturnsHash, UtilityCallInterface,
+    UtilityContext,
 };
 use crate::hash::hash_args;
 use crate::test::helpers::{cheatcodes, utils::Deployer};
@@ -18,6 +19,7 @@ use crate::oracle::{
     execution_cache,
     notes::notify_created_note,
 };
+use super::cheatcodes::public_call_new_flow;
 
 pub struct TestEnvironment {}
 
@@ -285,6 +287,45 @@ impl TestEnvironment {
         );
 
         ReturnsHash::new(returns_hash).assert_empty();
+    }
+
+    pub unconstrained fn call_public<T, let N: u32, let M: u32>(
+        _self: Self,
+        from: AztecAddress,
+        call_interface: PublicCallInterface<M, T>,
+    ) -> CallResult<T>
+    where
+        T: Deserialize<N>,
+    {
+        let (returns_hash, tx_hash) = public_call_new_flow(
+            from,
+            call_interface.get_contract_address(),
+            call_interface.get_selector(),
+            call_interface.get_args(),
+            false,
+        );
+
+        // This shouldn't be using ReturnsHash, but I don't think CalldataHash is right either in this context
+        let returns: T = ReturnsHash::new(returns_hash).get_preimage();
+        CallResult { return_value: returns, tx_hash }
+    }
+
+    pub unconstrained fn call_public_void<T, let M: u32>(
+        _self: Self,
+        from: AztecAddress,
+        call_interface: PublicVoidCallInterface<M>,
+    ) -> CallResult<()> {
+        let (returns_hash, tx_hash) = public_call_new_flow(
+            from,
+            call_interface.get_contract_address(),
+            call_interface.get_selector(),
+            call_interface.get_args(),
+            false,
+        );
+
+        ReturnsHash::new(returns_hash).assert_empty();
+
+        CallResult { return_value: (), tx_hash }
     }
 
     /// Manually adds a note to TXE. This needs to be called if you want to work with a note in your test with the note

--- a/noir-projects/noir-contracts/contracts/test/txe_test_contract/src/main.nr
+++ b/noir-projects/noir-contracts/contracts/test/txe_test_contract/src/main.nr
@@ -109,4 +109,9 @@ pub contract TXETest {
     fn emit_in_public(n: Field) {
         context.push_note_hash(n);
     }
+
+    #[public]
+    fn return_public(n: Field) -> Field {
+        n
+    }
 }

--- a/noir-projects/noir-contracts/contracts/test/txe_test_contract/src/test.nr
+++ b/noir-projects/noir-contracts/contracts/test/txe_test_contract/src/test.nr
@@ -105,3 +105,21 @@ unconstrained fn new_calling_flow_increment_with_new_call_flow() {
     assert_eq(notes.len(), 2);
     assert_eq(current_value_for_owner, 3);
 }
+
+#[test]
+unconstrained fn new_public_calling_flow() {
+    let mut env = TestEnvironment::new();
+    let owner = env.create_account(1);
+
+    let initial_value: Field = 2;
+    let initializer = TXETest::interface().initialize(initial_value as u64, owner);
+    let contract_address =
+        env.deploy_self("TXETest").with_private_initializer(owner, initializer).to_address();
+
+    let expected_value = 69420;
+
+    let call_result =
+        env.call_public(owner, TXETest::at(contract_address).return_public(expected_value));
+
+    assert_eq(call_result.return_value, expected_value);
+}

--- a/yarn-project/txe/src/oracle/txe_oracle.ts
+++ b/yarn-project/txe/src/oracle/txe_oracle.ts
@@ -78,6 +78,7 @@ import type { ContractInstance, ContractInstanceWithAddress } from '@aztec/stdli
 import { SimulationError } from '@aztec/stdlib/errors';
 import { Gas, GasFees, GasSettings } from '@aztec/stdlib/gas';
 import {
+  computeCalldataHash,
   computeNoteHashNonce,
   computePublicDataTreeLeafSlot,
   computeUniqueNoteHash,
@@ -1623,6 +1624,153 @@ export class TXE implements TypedOracle {
     return {
       endSideEffectCounter: result.entrypoint.publicInputs.endSideEffectCounter,
       returnsHash: result.entrypoint.publicInputs.returnsHash,
+      txHash: txRequestHash,
+    };
+  }
+
+  async publicCallNewFlow(
+    from: AztecAddress,
+    targetContractAddress: AztecAddress,
+    calldata: Fr[],
+    isStaticCall: boolean,
+  ) {
+    this.logger.verbose(
+      `Executing public function ${await this.getDebugFunctionName(
+        targetContractAddress,
+        FunctionSelector.fromField(calldata[0]),
+      )}@${targetContractAddress} isStaticCall=${isStaticCall}`,
+    );
+
+    const gasLimits = new Gas(DEFAULT_GAS_LIMIT, MAX_L2_GAS_PER_TX_PUBLIC_PORTION);
+
+    const teardownGasLimits = new Gas(DEFAULT_TEARDOWN_GAS_LIMIT, MAX_L2_GAS_PER_TX_PUBLIC_PORTION);
+
+    const gasSettings = new GasSettings(gasLimits, teardownGasLimits, GasFees.empty(), GasFees.empty());
+
+    const txContext = new TxContext(this.CHAIN_ID, this.ROLLUP_VERSION, gasSettings);
+
+    const blockHeader = await this.pxeOracleInterface.getBlockHeader();
+
+    const uniqueNoteHashes: Fr[] = [];
+    const taggedPrivateLogs: PrivateLog[] = [];
+    const nullifiers: Fr[] = [this.getTxRequestHash()];
+    const l2ToL1Messages: ScopedL2ToL1Message[] = [];
+    const contractClassLogsHashes: ScopedLogHash[] = [];
+
+    const calldataHash = await computeCalldataHash(calldata);
+
+    const calldataHashedValues = new HashedValues(calldata, calldataHash);
+
+    const publicCallRequest = new PublicCallRequest(from, targetContractAddress, isStaticCall, calldataHash);
+    const publicCallRequests: PublicCallRequest[] = [publicCallRequest];
+
+    const globals = makeGlobalVariables();
+    globals.blockNumber = new Fr(this.blockNumber);
+    globals.gasFees = GasFees.empty();
+
+    const contractsDB = new PublicContractsDB(new TXEPublicContractDataSource(this));
+    const simulator = new PublicTxSimulator(this.baseFork, contractsDB, globals, true, true);
+    const processor = new PublicProcessor(globals, this.baseFork, contractsDB, simulator, new TestDateProvider());
+
+    const constantData = new TxConstantData(blockHeader, txContext, Fr.zero(), Fr.zero());
+
+    const accumulatedDataForPublic = new PrivateToPublicAccumulatedData(
+      padArrayEnd(uniqueNoteHashes, Fr.ZERO, MAX_NOTE_HASHES_PER_TX),
+      padArrayEnd(nullifiers, Fr.ZERO, MAX_NULLIFIERS_PER_TX),
+      padArrayEnd(l2ToL1Messages, ScopedL2ToL1Message.empty(), MAX_L2_TO_L1_MSGS_PER_TX),
+      padArrayEnd(taggedPrivateLogs, PrivateLog.empty(), MAX_PRIVATE_LOGS_PER_TX),
+      padArrayEnd(contractClassLogsHashes, ScopedLogHash.empty(), MAX_CONTRACT_CLASS_LOGS_PER_TX),
+      padArrayEnd(publicCallRequests, PublicCallRequest.empty(), MAX_ENQUEUED_CALLS_PER_TX),
+    );
+
+    const inputsForPublic = new PartialPrivateTailPublicInputsForPublic(
+      // nonrevertible
+      PrivateToPublicAccumulatedData.empty(),
+      // revertible
+      // We are using revertible (app phase) because only the app-phase returns are exposed.
+      accumulatedDataForPublic,
+      PublicCallRequest.empty(),
+    );
+
+    const txData = new PrivateKernelTailCircuitPublicInputs(
+      constantData,
+      RollupValidationRequests.empty(),
+      /*gasUsed=*/ new Gas(0, 0),
+      /*feePayer=*/ AztecAddress.zero(),
+      inputsForPublic,
+      undefined,
+    );
+
+    const tx = new Tx(txData, ClientIvcProof.empty(), [], [calldataHashedValues]);
+
+    const results = await processor.process([tx]);
+
+    const processedTxs = results[0];
+    const failedTxs = results[1];
+
+    if (failedTxs.length !== 0 || !processedTxs[0].revertCode.isOK()) {
+      throw new Error('Public execution has failed');
+    }
+
+    const returnValues = results[3][0].values;
+    let returnValuesHash;
+
+    if (returnValues !== undefined) {
+      // This is a bit of a hack to not deal with returning a slice in nr which is what normally happens.
+      // Investigate whether it is faster to do this or return from the oracle directly.
+      returnValuesHash = await computeVarArgsHash(returnValues);
+      this.storeInExecutionCache(returnValues, returnValuesHash);
+    }
+
+    const fork = this.baseFork;
+
+    const txEffect = TxEffect.empty();
+
+    txEffect.noteHashes = processedTxs[0]!.txEffect.noteHashes;
+    txEffect.nullifiers = processedTxs[0]!.txEffect.nullifiers;
+    txEffect.privateLogs = taggedPrivateLogs;
+    txEffect.publicLogs = processedTxs[0]!.txEffect.publicLogs;
+    txEffect.publicDataWrites = processedTxs[0]!.txEffect.publicDataWrites;
+
+    txEffect.txHash = new TxHash(new Fr(this.blockNumber));
+
+    const body = new Body([txEffect]);
+
+    const l2Block = new L2Block(
+      makeAppendOnlyTreeSnapshot(this.blockNumber + 1),
+      makeHeader(0, this.blockNumber, this.blockNumber),
+      body,
+    );
+
+    const l1ToL2Messages = Array(NUMBER_OF_L1_L2_MESSAGES_PER_ROLLUP).fill(0).map(Fr.zero);
+    await fork.appendLeaves(MerkleTreeId.L1_TO_L2_MESSAGE_TREE, l1ToL2Messages);
+
+    const stateReference = await fork.getStateReference();
+    const archiveInfo = await fork.getTreeInfo(MerkleTreeId.ARCHIVE);
+
+    const header = new BlockHeader(
+      new AppendOnlyTreeSnapshot(new Fr(archiveInfo.root), Number(archiveInfo.size)),
+      makeContentCommitment(),
+      stateReference,
+      globals,
+      Fr.ZERO,
+      Fr.ZERO,
+    );
+
+    header.globalVariables.blockNumber = new Fr(this.blockNumber);
+
+    l2Block.header = header;
+
+    await fork.updateArchive(l2Block.header);
+
+    await this.stateMachine.handleL2Block(l2Block);
+
+    const txRequestHash = this.getTxRequestHash();
+
+    this.setBlockNumber(this.blockNumber + 1);
+
+    return {
+      returnsHash: returnValuesHash ?? Fr.ZERO,
       txHash: txRequestHash,
     };
   }

--- a/yarn-project/txe/src/txe_service/txe_service.ts
+++ b/yarn-project/txe/src/txe_service/txe_service.ts
@@ -1227,4 +1227,21 @@ export class TXEService {
 
     return toForeignCallResult([toSingle(result)]);
   }
+
+  async publicCallNewFlow(
+    from: ForeignCallSingle,
+    address: ForeignCallSingle,
+    _length: ForeignCallSingle,
+    calldata: ForeignCallArray,
+    isStaticCall: ForeignCallSingle,
+  ) {
+    const result = await (this.typedOracle as TXE).publicCallNewFlow(
+      addressFromSingle(from),
+      addressFromSingle(address),
+      fromArray(calldata),
+      fromSingle(isStaticCall).toBool(),
+    );
+
+    return toForeignCallResult([toArray([result.returnsHash, result.txHash])]);
+  }
 }


### PR DESCRIPTION
This enables the new public flow. Please note there is a lot of code reuse between `privateCallNewFlow` and `publicCallNewFlow`. This will be cleaned up in a downstack PR.