### PR TITLE
fix: incorrectly computing l2 to l1 msg subtree root

### DIFF
--- a/yarn-project/aztec-node/src/aztec-node/server.ts
+++ b/yarn-project/aztec-node/src/aztec-node/server.ts
@@ -754,7 +754,10 @@ export class AztecNodeService implements AztecNode, AztecNodeAdmin, Traceable {
       return [BigInt(indexOfMsgInSubtree), subtreePathOfL2ToL1Message];
     }
 
-    const l2toL1SubtreeRoots = l2toL1Subtrees.map(t => Fr.fromBuffer(t.getRoot(true)));
+    // For a tx with no messages, we have to set an out hash of 0 to match the circuit/contract behavior
+    const l2toL1SubtreeRoots = l2toL1Subtrees.map(t =>
+      t.getNumLeaves(true) == 0n ? Fr.ZERO : Fr.fromBuffer(t.getRoot(true)),
+    );
     const maxTreeHeight = Math.ceil(Math.log2(l2toL1SubtreeRoots.length));
     // The root of this tree is the out_hash calculated in Noir => we truncate to match Noir's SHA
     const outHashTree = new UnbalancedTree(new SHA256Trunc(), 'temp_outhash_sibling_path', maxTreeHeight, Fr);


### PR DESCRIPTION
Fixes #14174

@MirandaWood managed to figure out that we did not correctly compute the message subtree root for a tx with no messages.

In a followup PR I will merge the e2e_outbox and l2_to_l1 e2e tests as having them separated is purely a tech debt. I will also consider cleaning up `AztecNodeService.getL2ToL1MessageMembershipWitness`.