### PR TITLE
fix: check the contract address

### DIFF
--- a/yarn-project/archiver/src/archiver/archiver_store_test_suite.ts
+++ b/yarn-project/archiver/src/archiver/archiver_store_test_suite.ts
@@ -433,6 +433,52 @@ export function describeArchiverDataStore(
         expect(fetchedInstance?.originalContractClassId).toEqual(classId);
         expect(fetchedInstance?.currentContractClassId).toEqual(nextClassId);
       });
+
+      it('ignores updates for the wrong contract', async () => {
+        const otherClassId = Fr.random();
+        const randomInstance = await SerializableContractInstance.random({
+          currentContractClassId: otherClassId,
+          originalContractClassId: otherClassId,
+        });
+        const otherContractInstance = {
+          ...randomInstance,
+          address: await AztecAddress.random(),
+        };
+        await store.addContractInstances([otherContractInstance], 1);
+
+        const fetchedInstance = await store.getContractInstance(otherContractInstance.address, blockOfChange + 1);
+        expect(fetchedInstance?.originalContractClassId).toEqual(otherClassId);
+        expect(fetchedInstance?.currentContractClassId).toEqual(otherClassId);
+      });
+
+      it('bounds its search to the right contract if more than than one update exists', async () => {
+        const otherClassId = Fr.random();
+        const otherNextClassId = Fr.random();
+        const randomInstance = await SerializableContractInstance.random({
+          currentContractClassId: otherClassId,
+          originalContractClassId: otherNextClassId,
+        });
+        const otherContractInstance = {
+          ...randomInstance,
+          address: await AztecAddress.random(),
+        };
+        await store.addContractInstances([otherContractInstance], 1);
+        await store.addContractInstanceUpdates(
+          [
+            {
+              prevContractClassId: otherClassId,
+              newContractClassId: otherNextClassId,
+              blockOfChange,
+              address: otherContractInstance.address,
+            },
+          ],
+          blockOfChange - 1,
+        );
+
+        const fetchedInstance = await store.getContractInstance(contractInstance.address, blockOfChange + 1);
+        expect(fetchedInstance?.originalContractClassId).toEqual(classId);
+        expect(fetchedInstance?.currentContractClassId).toEqual(nextClassId);
+      });
     });
 
     describe('contractClasses', () => {

--- a/yarn-project/archiver/src/archiver/kv_archiver_store/contract_instance_store.ts
+++ b/yarn-project/archiver/src/archiver/kv_archiver_store/contract_instance_store.ts
@@ -71,6 +71,7 @@ export class ContractInstanceStore {
     const queryResult = await this.#contractInstanceUpdates
       .valuesAsync({
         reverse: true,
+        start: this.getUpdateKey(address, 0), // Make sure we only look at updates for this contract
         end: this.getUpdateKey(address, blockNumber + 1), // No update can match this key since it doesn't have a log index. We want the highest key <= blockNumber
         limit: 1,
       })


### PR DESCRIPTION
Bounds the search for contract class updates to only look at updates for the current contract address.