### PR TITLE
fix: remove default prover-agent limits

### DIFF
--- a/spartan/aztec-network/resources/gcloud.yaml
+++ b/spartan/aztec-network/resources/gcloud.yaml
@@ -35,9 +35,6 @@ proverAgent:
     requests:
       memory: "64Gi"
       cpu: "16"
-    limits:
-      memory: "96Gi"
-      cpu: "16"
 
 proverBroker:
   resources:


### PR DESCRIPTION
Remove default limits as they were interfering with greater resource requests in rc-1.yaml.