### PR TITLE
fix: bad quoting in noir bootstrap

### DIFF
--- a/noir/bootstrap.sh
+++ b/noir/bootstrap.sh
@@ -64,7 +64,7 @@ function noir_content_hash {
   fi
 }
 
-if [ ! -v NOIR_HASH ] && [ $cmd != "clean" ]; then
+if [ ! -v NOIR_HASH ] && [ "$cmd" != "clean" ]; then
   noir_sync
   export NOIR_HASH=$(noir_content_hash)
 fi


### PR DESCRIPTION
It was breaking direct calls to noir/bootstrap.sh and release action
