### PR TITLE
chore: fix update issue + add test to catch some of the offenses

### DIFF
--- a/l1-contracts/src/core/Rollup.sol
+++ b/l1-contracts/src/core/Rollup.sol
@@ -117,24 +117,7 @@ contract Rollup is IStaking, IValidatorSelection, IRollup, RollupCore {
     override(IValidatorSelection)
     returns (address[] memory)
   {
-    return ValidatorSelectionLib.getCommitteeAt(StakingLib.getStorage(), getCurrentEpoch());
-  }
-
-  /**
-   * @notice  Get the validator set for a given epoch
-   *
-   * @dev     Consider removing this to replace with a `size` and individual getter.
-   *
-   * @param _epoch The epoch number to get the validator set for
-   *
-   * @return The validator set for the given epoch
-   */
-  function getEpochCommittee(Epoch _epoch)
-    external
-    override(IValidatorSelection)
-    returns (address[] memory)
-  {
-    return ValidatorSelectionLib.getCommitteeAt(StakingLib.getStorage(), _epoch);
+    return getEpochCommittee(getCurrentEpoch());
   }
 
   /**
@@ -149,7 +132,7 @@ contract Rollup is IStaking, IValidatorSelection, IRollup, RollupCore {
     override(IValidatorSelection)
     returns (address[] memory)
   {
-    return ValidatorSelectionLib.getCommitteeAt(StakingLib.getStorage(), getEpochAt(_ts));
+    return getEpochCommittee(getEpochAt(_ts));
   }
 
   /**
@@ -599,6 +582,23 @@ contract Rollup is IStaking, IValidatorSelection, IRollup, RollupCore {
 
   function getBurnAddress() external pure override(IRollup) returns (address) {
     return EpochProofLib.BURN_ADDRESS;
+  }
+
+  /**
+   * @notice  Get the validator set for a given epoch
+   *
+   * @dev     Consider removing this to replace with a `size` and individual getter.
+   *
+   * @param _epoch The epoch number to get the validator set for
+   *
+   * @return The validator set for the given epoch
+   */
+  function getEpochCommittee(Epoch _epoch)
+    public
+    override(IValidatorSelection)
+    returns (address[] memory)
+  {
+    return ValidatorSelectionLib.getCommitteeAt(StakingLib.getStorage(), _epoch);
   }
 
   /**

--- a/l1-contracts/src/core/libraries/validator-selection/ValidatorSelectionLib.sol
+++ b/l1-contracts/src/core/libraries/validator-selection/ValidatorSelectionLib.sol
@@ -217,13 +217,11 @@ library ValidatorSelectionLib {
     ValidatorSelectionStorage storage store = getStorage();
     EpochData storage epoch = store.epochs[_epochNumber];
 
-    // If no committee has been stored, then we need to setup the epoch
-    uint256 committeeSize = epoch.committee.length;
-    if (committeeSize == 0) {
-      // This will set epoch.committee and the next sample seed in the store, meaning epoch.commitee on the line below will be set (storage reference)
-      setupEpoch(_stakingStore, _epochNumber);
+    // If the committe is already set, just return that, otherwise need to sample
+    if (epoch.committee.length > 0) {
+      return epoch.committee;
     }
-    return epoch.committee;
+    return sampleValidators(_stakingStore, _epochNumber, getSampleSeed(_epochNumber));
   }
 
   /**

--- a/l1-contracts/test/RollupGetters.t.sol
+++ b/l1-contracts/test/RollupGetters.t.sol
@@ -1,0 +1,148 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright 2024 Aztec Labs.
+pragma solidity >=0.8.27;
+
+import {DecoderBase} from "./base/DecoderBase.sol";
+
+import {DataStructures} from "@aztec/core/libraries/DataStructures.sol";
+import {Constants} from "@aztec/core/libraries/ConstantsGen.sol";
+import {Signature} from "@aztec/core/libraries/crypto/SignatureLib.sol";
+import {Math} from "@oz/utils/math/Math.sol";
+
+import {Registry} from "@aztec/governance/Registry.sol";
+import {Inbox} from "@aztec/core/messagebridge/Inbox.sol";
+import {Outbox} from "@aztec/core/messagebridge/Outbox.sol";
+import {Errors} from "@aztec/core/libraries/Errors.sol";
+import {Rollup} from "@aztec/core/Rollup.sol";
+import {TestConstants} from "./harnesses/TestConstants.sol";
+
+import {
+  IRollup,
+  IRollupCore,
+  BlockLog,
+  SubmitEpochRootProofArgs,
+  EthValue,
+  FeeAssetValue,
+  FeeAssetPerEthE9,
+  PublicInputArgs
+} from "@aztec/core/interfaces/IRollup.sol";
+import {FeeJuicePortal} from "@aztec/core/messagebridge/FeeJuicePortal.sol";
+import {NaiveMerkle} from "./merkle/Naive.sol";
+import {MerkleTestUtil} from "./merkle/TestUtil.sol";
+import {TestERC20} from "@aztec/mock/TestERC20.sol";
+import {TestConstants} from "./harnesses/TestConstants.sol";
+import {RewardDistributor} from "@aztec/governance/RewardDistributor.sol";
+import {IERC20Errors} from "@oz/interfaces/draft-IERC6093.sol";
+import {ProposeArgs, OracleInput, ProposeLib} from "@aztec/core/libraries/rollup/ProposeLib.sol";
+import {IERC20} from "@oz/token/ERC20/IERC20.sol";
+import {
+  Timestamp, Slot, Epoch, SlotLib, EpochLib, TimeLib
+} from "@aztec/core/libraries/TimeLib.sol";
+
+import {ValidatorSelectionTestBase} from "./validator-selection/ValidatorSelectionBase.sol";
+
+/**
+ * Testing the things that should be getters are not updating state!
+ * Look at the `rollup.sol` with \)\s*(?:external|public)(?!\s*(?:\r?\n\s*)*(?:view|pure)\b)
+ * to find the functions that should be getters. Things that are in there should be getters only.
+ *
+ * We have to look a bit into the `RollupCore.sol` to make sure that we are not missing anything.
+ */
+contract RollupShouldBeGetters is ValidatorSelectionTestBase {
+  function test_getEpochCommittee(uint16 _epochToGet, bool _setup) external setup(4) {
+    uint256 expectedSize = _epochToGet == 0 ? 0 : 4;
+    Epoch e = Epoch.wrap(_epochToGet);
+    Timestamp t = timeCheater.epochToTimestamp(e);
+
+    vm.warp(Timestamp.unwrap(t));
+
+    if (_setup) {
+      rollup.setupEpoch();
+    }
+
+    vm.record();
+
+    address[] memory committee = rollup.getEpochCommittee(e);
+    address[] memory committee2 = rollup.getCommitteeAt(t);
+    address[] memory committee3 = rollup.getCurrentEpochCommittee();
+    assertEq(committee.length, expectedSize, "invalid getEpochCommittee");
+    assertEq(committee2.length, expectedSize, "invalid getCommitteeAt");
+    assertEq(committee3.length, expectedSize, "invalid getCurrentEpochCommittee");
+
+    (, bytes32[] memory writes) = vm.accesses(address(rollup));
+    assertEq(writes.length, 0, "No writes should be done");
+  }
+
+  function test_getEpochCommitteeBig(uint16 _epochToGet, bool _setup) external setup(49) {
+    uint256 expectedSize = _epochToGet == 0 ? 0 : 48;
+    Epoch e = Epoch.wrap(_epochToGet);
+    Timestamp t = timeCheater.epochToTimestamp(e);
+
+    vm.warp(Timestamp.unwrap(t));
+
+    if (_setup) {
+      rollup.setupEpoch();
+    }
+
+    vm.record();
+
+    address[] memory committee = rollup.getEpochCommittee(e);
+    address[] memory committee2 = rollup.getCommitteeAt(t);
+    address[] memory committee3 = rollup.getCurrentEpochCommittee();
+    assertEq(committee.length, expectedSize, "invalid getEpochCommittee");
+    assertEq(committee2.length, expectedSize, "invalid getCommitteeAt");
+    assertEq(committee3.length, expectedSize, "invalid getCurrentEpochCommittee");
+
+    (, bytes32[] memory writes) = vm.accesses(address(rollup));
+    assertEq(writes.length, 0, "No writes should be done");
+  }
+
+  function test_getProposerAt(uint16 _slot, bool _setup) external setup(4) {
+    Slot s = Slot.wrap(_slot);
+    Timestamp t = timeCheater.slotToTimestamp(s);
+
+    vm.warp(Timestamp.unwrap(t));
+
+    if (_setup) {
+      rollup.setupEpoch();
+    }
+
+    vm.record();
+
+    address proposer = rollup.getProposerAt(t);
+    address proposer2 = rollup.getCurrentProposer();
+
+    assertEq(proposer, proposer2, "proposer should be the same");
+
+    (, bytes32[] memory writes) = vm.accesses(address(rollup));
+    assertEq(writes.length, 0, "No writes should be done");
+  }
+
+  function test_validateHeader() external setup(4) {
+    // Todo this one is a bit annoying here really. We need a lot of header information.
+  }
+
+  function test_canProposeAtTime(uint16 _timestamp, bool _setup) external setup(1) {
+    timeCheater.cheat__progressEpoch();
+
+    Timestamp t = Timestamp.wrap(block.timestamp + _timestamp);
+
+    vm.warp(Timestamp.unwrap(t));
+
+    if (_setup) {
+      rollup.setupEpoch();
+    }
+
+    address proposer = rollup.getCurrentProposer();
+
+    BlockLog memory log = rollup.getBlock(rollup.getPendingBlockNumber());
+
+    vm.record();
+
+    vm.prank(proposer);
+    rollup.canProposeAtTime(t, log.archive);
+
+    (, bytes32[] memory writes) = vm.accesses(address(rollup));
+    assertEq(writes.length, 0, "No writes should be done");
+  }
+}

--- a/l1-contracts/test/scream-and-shout.t.sol
+++ b/l1-contracts/test/scream-and-shout.t.sol
@@ -20,7 +20,7 @@ contract ScreamAndShoutTest is Test {
 
     assertEq(
       codeHash,
-      0xe1a99243725cba6a14a269d2dd1f883d96bbadca557f77c5fd3330d9fcf4e464,
+      0xa9964a56e118c2ea0ebaf5a30abdb298bd7c8e7613b0d6d7fd7780d1ed2500d0,
       "You have changed the rollup!"
     );
   }
@@ -42,7 +42,7 @@ contract ScreamAndShoutTest is Test {
 
     assertEq(
       codeHash,
-      0x24ba98129795af21f9b87264f1bb6892a5d3391473021d107f0155d65fbfc63c,
+      0x359af758fa9000e3c32af9f90c006ff42fffad6147fe61ce7c74f4284cb599c8,
       "You have changed the registry!"
     );
   }

--- a/l1-contracts/test/staking/TimeCheater.sol
+++ b/l1-contracts/test/staking/TimeCheater.sol
@@ -2,7 +2,7 @@
 // Copyright 2025 Aztec Labs.
 pragma solidity >=0.8.27;
 
-import {TimeStorage, TimeLib, Epoch} from "@aztec/core/libraries/TimeLib.sol";
+import {TimeStorage, Timestamp, TimeLib, Epoch, Slot} from "@aztec/core/libraries/TimeLib.sol";
 import {Vm} from "forge-std/Vm.sol";
 
 contract TimeCheater {
@@ -54,6 +54,18 @@ contract TimeCheater {
         )
       )
     );
+
+    TimeLib.initialize(
+      _timeStorage.genesisTime, _timeStorage.slotDuration, _timeStorage.epochDuration
+    );
+  }
+
+  function epochToTimestamp(Epoch _epoch) public view returns (Timestamp) {
+    return TimeLib.toTimestamp(_epoch);
+  }
+
+  function slotToTimestamp(Slot _slot) public view returns (Timestamp) {
+    return TimeLib.toTimestamp(_slot);
   }
 
   function cheat__setEpochNow(uint256 _epoch) public {

--- a/l1-contracts/test/validator-selection/ValidatorSelection.t.sol
+++ b/l1-contracts/test/validator-selection/ValidatorSelection.t.sol
@@ -352,17 +352,4 @@ contract ValidatorSelectionTest is ValidatorSelectionTestBase {
       );
     }
   }
-
-  function createSignature(address _signer, bytes32 _digest)
-    internal
-    view
-    returns (Signature memory)
-  {
-    uint256 privateKey = attesterPrivateKeys[_signer];
-
-    bytes32 digest = _digest.toEthSignedMessageHash();
-    (uint8 v, bytes32 r, bytes32 s) = vm.sign(privateKey, digest);
-
-    return Signature({isEmpty: false, v: v, r: r, s: s});
-  }
 }

--- a/l1-contracts/test/validator-selection/ValidatorSelectionBase.sol
+++ b/l1-contracts/test/validator-selection/ValidatorSelectionBase.sol
@@ -125,4 +125,17 @@ contract ValidatorSelectionTestBase is DecoderBase {
       amount: TestConstants.AZTEC_MINIMUM_STAKE
     });
   }
+
+  function createSignature(address _signer, bytes32 _digest)
+    internal
+    view
+    returns (Signature memory)
+  {
+    uint256 privateKey = attesterPrivateKeys[_signer];
+
+    bytes32 digest = _digest.toEthSignedMessageHash();
+    (uint8 v, bytes32 r, bytes32 s) = vm.sign(privateKey, digest);
+
+    return Signature({isEmpty: false, v: v, r: r, s: s});
+  }
 }


### PR DESCRIPTION
Fixes an issue that @spalladino found, as some optimisation works relying on tstore went a bit too far on writes. The diff on the getter is minimal, but we also add a bunch of tests here such that we should have a better change to catch it in the future.

Longer term, we would like to ideally get back to a `view` but, right now, it is what it is.