### PR TITLE
chore: Fix flake in archiver kv store

### DIFF
--- a/yarn-project/archiver/src/archiver/kv_archiver_store/message_store.ts
+++ b/yarn-project/archiver/src/archiver/kv_archiver_store/message_store.ts
@@ -236,7 +236,7 @@ export class MessageStore {
   }
 
   private indexToKey(index: bigint): number {
-    return Number(index); // Using zero as a key in the map breaks the kvstore.
+    return Number(index);
   }
 
   private leafToIndexKey(leaf: Fr): string {

--- a/yarn-project/archiver/src/test/mock_structs.ts
+++ b/yarn-project/archiver/src/test/mock_structs.ts
@@ -9,7 +9,7 @@ export function makeInboxMessage(
   previousRollingHash = Buffer16.ZERO,
   overrides: Partial<InboxMessage> = {},
 ): InboxMessage {
-  const { l2BlockNumber = randomBigInt(100n) } = overrides;
+  const { l2BlockNumber = randomBigInt(100n) + 1n } = overrides;
   const { l1BlockNumber = l2BlockNumber } = overrides;
   const { l1BlockHash = Buffer32.random() } = overrides;
   const { leaf = Fr.random() } = overrides;


### PR DESCRIPTION
Would fail 1 time out of 100 when the random l2 block number yielded zero (which is below the initial block number).

Sample failed run [here](http://ci.aztec-labs.com/6a0572441fb4f58e):

```
06:50:11   ● KVArchiverDataStore › ArchiverStore › getSynchPoint › returns the latest syncpoint if latest message is behind
06:50:11 
06:50:11     RangeError: The value of "value" is out of range. It must be >= 0n and < 2n ** 64n. Received -16n
06:50:11 
06:50:11       55 |  */ export function bigintToUInt64BE(n, bufferSize = 8) {
06:50:11       56 |     const buf = Buffer.alloc(bufferSize);
06:50:11     > 57 |     buf.writeBigUInt64BE(n, bufferSize - 8);
06:50:11          |         ^
06:50:11       58 |     return buf;
06:50:11       59 | }
06:50:11       60 | /**
06:50:11 
06:50:11       at bigintToUInt64BE (../../foundation/dest/serialize/free_funcs.js:57:9)
06:50:11       at bigintToUInt64BE (archiver/structs/inbox_message.ts:22:5)
06:50:11       at serializeInboxMessage (archiver/kv_archiver_store/message_store.ts:149:72)
06:50:11       at ../../kv-store/dest/lmdb-v2/store.js:111:29
06:50:11       at ../../foundation/dest/queue/serial_queue.js:56:33
06:50:11       at FifoMemoryQueue.process (../../foundation/dest/queue/base_memory_queue.js:110:17)
```