### PR TITLE
fix!: Use deterministic stringify for artifact hash (cherrypick)

### DIFF
--- a/yarn-project/stdlib/package.json
+++ b/yarn-project/stdlib/package.json
@@ -75,6 +75,7 @@
     "@aztec/foundation": "workspace:^",
     "@aztec/noir-noirc_abi": "portal:../../noir/packages/noirc_abi",
     "@google-cloud/storage": "^7.15.0",
+    "json-stringify-deterministic": "1.0.12",
     "lodash.chunk": "^4.2.0",
     "lodash.isequal": "^4.5.0",
     "lodash.omit": "^4.5.0",

--- a/yarn-project/stdlib/src/contract/artifact_hash.ts
+++ b/yarn-project/stdlib/src/contract/artifact_hash.ts
@@ -4,6 +4,8 @@ import { createLogger } from '@aztec/foundation/log';
 import { numToUInt8 } from '@aztec/foundation/serialize';
 import { MerkleTree, MerkleTreeCalculator } from '@aztec/foundation/trees';
 
+import deterministicStringify from 'json-stringify-deterministic';
+
 import { type ContractArtifact, type FunctionArtifact, FunctionSelector, FunctionType } from '../abi/index.js';
 
 const VERSION = 1;
@@ -58,7 +60,7 @@ export async function computeArtifactHashPreimage(artifact: ContractArtifact) {
 }
 
 export function computeArtifactMetadataHash(artifact: ContractArtifact) {
-  return sha256Fr(Buffer.from(JSON.stringify({ name: artifact.name, outputs: artifact.outputs }), 'utf-8'));
+  return sha256Fr(Buffer.from(deterministicStringify({ name: artifact.name, outputs: artifact.outputs }), 'utf-8'));
 }
 
 export async function computeArtifactFunctionTreeRoot(artifact: ContractArtifact, fnType: FunctionType) {
@@ -103,7 +105,7 @@ export async function computeFunctionArtifactHash(
 }
 
 export function computeFunctionMetadataHash(fn: FunctionArtifact) {
-  return sha256Fr(Buffer.from(JSON.stringify(fn.returnTypes), 'utf8'));
+  return sha256Fr(Buffer.from(deterministicStringify(fn.returnTypes), 'utf8'));
 }
 
 function getLogger() {

--- a/yarn-project/yarn.lock
+++ b/yarn-project/yarn.lock
@@ -1371,6 +1371,7 @@ __metadata:
     eslint: "npm:^8.35.0"
     jest: "npm:^29.5.0"
     jest-mock-extended: "npm:^4.0.0-beta1"
+    json-stringify-deterministic: "npm:1.0.12"
     lodash.chunk: "npm:^4.2.0"
     lodash.isequal: "npm:^4.5.0"
     lodash.omit: "npm:^4.5.0"
@@ -14809,6 +14810,13 @@ __metadata:
   version: 1.0.1
   resolution: "json-stable-stringify-without-jsonify@npm:1.0.1"
   checksum: 10/12786c2e2f22c27439e6db0532ba321f1d0617c27ad8cb1c352a0e9249a50182fd1ba8b52a18899291604b0c32eafa8afd09e51203f19109a0537f68db2b652d
+  languageName: node
+  linkType: hard
+
+"json-stringify-deterministic@npm:1.0.12":
+  version: 1.0.12
+  resolution: "json-stringify-deterministic@npm:1.0.12"
+  checksum: 10/57b4bffa823e20e1bf12f21a1abb16dd44a7a5d09299a2fdef72f3b125b8009575ea210b6eea384f1c8315216d0cdf8c1ef6802081c000fb4c590aa61527c0ca
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
Cherry picks https://github.com/AztecProtocol/aztec-packages/pull/14289

Breaking change since class IDS might change after this, due to the keys in stringified jsons being sorted.