### PR TITLE
chore: Fix another flake in validator sentinel e2e

### DIFF
--- a/.test_patterns.yml
+++ b/.test_patterns.yml
@@ -122,10 +122,6 @@ tests:
     error_regex: "Expected: >= 2"
     owners:
       - *palla
-  - regex: "e2e_p2p/validators_sentinel"
-    error_regex: "replacement transaction underpriced"
-    owners:
-      - *palla
   - regex: "src/e2e_fees/private_payments"
     owners:
       - *phil

--- a/yarn-project/end-to-end/src/e2e_p2p/p2p_network.ts
+++ b/yarn-project/end-to-end/src/e2e_p2p/p2p_network.ts
@@ -85,7 +85,7 @@ export class P2PNetworkTest {
     this.logger = createLogger(`e2e:e2e_p2p:${testName}`);
 
     // Set up the base account and node private keys for the initial network deployment
-    this.baseAccountPrivateKey = `0x${getPrivateKeyFromIndex(0)!.toString('hex')}`;
+    this.baseAccountPrivateKey = `0x${getPrivateKeyFromIndex(1)!.toString('hex')}`;
     this.baseAccount = privateKeyToAccount(this.baseAccountPrivateKey);
     this.proposerPrivateKeys = generatePrivateKeys(PROPOSER_PRIVATE_KEYS_START_INDEX, numberOfNodes);
     this.attesterPrivateKeys = generatePrivateKeys(ATTESTER_PRIVATE_KEYS_START_INDEX, numberOfNodes);

--- a/yarn-project/end-to-end/src/fixtures/setup_p2p_test.ts
+++ b/yarn-project/end-to-end/src/fixtures/setup_p2p_test.ts
@@ -15,9 +15,9 @@ import { TEST_PEER_CHECK_INTERVAL_MS } from './fixtures.js';
 import { getPrivateKeyFromIndex } from './utils.js';
 import { getEndToEndTestTelemetryClient } from './with_telemetry_utils.js';
 
-// Setup snapshots will create a node with index 0, so all of our loops here
-// need to start from 1 to avoid running validators with the same key
-export const PROPOSER_PRIVATE_KEYS_START_INDEX = 1;
+// Setup snapshots will create a node with index 0, and run extra bootstrap with
+// index 1, so all of our loops here need to start from 2 to avoid running validators with the same key
+export const PROPOSER_PRIVATE_KEYS_START_INDEX = 2;
 export const ATTESTER_PRIVATE_KEYS_START_INDEX = 1001;
 
 export interface NodeContext {


### PR DESCRIPTION
Sample failed run [here](http://ci.aztec-labs.com/1908d2e1e79be275):

```
09:51:15  FAIL  src/e2e_p2p/validators_sentinel.test.ts
09:51:15   ● e2e_p2p_validators_sentinel › with an offline validator › collects stats on offline validator
09:51:15
09:51:15     ContractFunctionExecutionError: Transaction creation failed.
09:51:15
09:51:15     URL: http://127.0.0.1:8545
09:51:15     Request body: {"method":"eth_sendRawTransaction","params":["0x02f90333827a69198455d4a8008465589b3d830cc89994322813fd9a801c5507c9de605d63cea4f2ce6c4480b902c42335d47e00000000000000000000000000000000000000000000000000000000000000200000000000000000000000000000000000000000000000000000000000000005000000000000000000000000a1153393636750230f4db253300e59ca8bd3a9c0000000000000000000000000ad6855add35f78bc594102e0ac781527cdeb9c52000000000000000000000000a1153393636750230f4db253300e59ca8bd3a9c00000000000000000000000000000000000000000000000056bc75e2d63100000000000000000000000000000c223b10ef31d74b74ac4931da23c76dfd154e43f0000000000000000000000006c7810a6a724f0a3c5882e7149b90d23e8bf6e63000000000000000000000000c223b10ef31d74b74ac4931da23c76dfd154e43f0000000000000000000000000000000000000000000000056bc75e2d631000000000000000000000000000004af126598417209bfa57bab856963c42c2fee5db000000000000000000000000c6edfc31693e921df3c826b102a999db5cc1ca960000000000000000000000004af126598417209bfa57bab856963c42c2fee5db0000000000000000000000000000000000000000000000056bc75e2d63100000000000000000000000000000037bbe29c2766243a070a4b3cbf38917670973080000000000000000000000007d2cd31b604b34e289e02538d468948ec515b10c000000000000000000000000037bbe29c2766243a070a4b3cbf38917670973080000000000000000000000000000000000000000000000056bc75e2d6310000000000000000000000000000061b13c781397bdb68284f02961e16602b9ce8923000000000000000000000000b50043ea007490e0a0250aff54831d8443d1393f00000000000000000000000061b13c781397bdb68284f02961e16602b9ce89230000000000000000000000000000000000000000000000056bc75e2d63100000c001a008e84c0ff4a6160f63addfeb56108f608cd3912e605684616a151be96b5916f5a0100fcf130916031fcfe3aaef969ca8beac5781bbc1b37a29c4b33f36871f8570"]}
09:51:15
09:51:15     Request Arguments:
09:51:15       from:  0xf39Fd6e51aad88F6F4ce6aB8827279cffFb92266
09:51:15       to:    0x322813fd9a801c5507c9de605d63cea4f2ce6c44
09:51:15       data:  0x2335d47e00000000000000000000000000000000000000000000000000000000000000200000000000000000000000000000000000000000000000000000000000000005000000000000000000000000a1153393636750230f4db253300e59ca8bd3a9c0000000000000000000000000ad6855add35f78bc594102e0ac781527cdeb9c52000000000000000000000000a1153393636750230f4db253300e59ca8bd3a9c00000000000000000000000000000000000000000000000056bc75e2d63100000000000000000000000000000c223b10ef31d74b74ac4931da23c76dfd154e43f0000000000000000000000006c7810a6a724f0a3c5882e7149b90d23e8bf6e63000000000000000000000000c223b10ef31d74b74ac4931da23c76dfd154e43f0000000000000000000000000000000000000000000000056bc75e2d631000000000000000000000000000004af126598417209bfa57bab856963c42c2fee5db000000000000000000000000c6edfc31693e921df3c826b102a999db5cc1ca960000000000000000000000004af126598417209bfa57bab856963c42c2fee5db0000000000000000000000000000000000000000000000056bc75e2d63100000000000000000000000000000037bbe29c2766243a070a4b3cbf38917670973080000000000000000000000007d2cd31b604b34e289e02538d468948ec515b10c000000000000000000000000037bbe29c2766243a070a4b3cbf38917670973080000000000000000000000000000000000000000000000056bc75e2d6310000000000000000000000000000061b13c781397bdb68284f02961e16602b9ce8923000000000000000000000000b50043ea007490e0a0250aff54831d8443d1393f00000000000000000000000061b13c781397bdb68284f02961e16602b9ce89230000000000000000000000000000000000000000000000056bc75e2d63100000
09:51:15
09:51:15     Contract Call:
09:51:15       address:   0x322813fd9a801c5507c9de605d63cea4f2ce6c44
09:51:15       function:  addValidators((address attester, address proposer, address withdrawer, uint256 amount)[])
09:51:15       args:                   ([{"attester":"0xa1153393636750230f4dB253300E59Ca8bD3a9c0","proposer":"0xad6855aDD35F78bc594102E0aC781527cDEb9c52","withdrawer":"0xa1153393636750230f4dB253300E59Ca8bD3a9c0","amount":"100000000000000000000"},{"attester":"0xC223B10ef31d74B74ac4931da23c76dfD154e43F","proposer":"0x6C7810A6A724f0A3c5882e7149b90D23E8bF6e63","withdrawer":"0xC223B10ef31d74B74ac4931da23c76dfD154e43F","amount":"100000000000000000000"},{"attester":"0x4aF126598417209bFa57bab856963c42C2fee5Db","proposer":"0xC6edFc31693E921DF3C826B102a999DB5cC1cA96","withdrawer":"0x4aF126598417209bFa57bab856963c42C2fee5Db","amount":"100000000000000000000"},{"attester":"0x037BBe29C2766243A070a4b3cbf3891767097308","proposer":"0x7D2Cd31b604B34e289E02538D468948eC515b10C","withdrawer":"0x037BBe29C2766243A070a4b3cbf3891767097308","amount":"100000000000000000000"},{"attester":"0x61B13C781397Bdb68284F02961e16602B9ce8923","proposer":"0xB50043ea007490e0a0250afF54831D8443D1393f","withdrawer":"0x61B13C781397Bdb68284F02961e16602B9ce8923","amount":"100000000000000000000"}])
09:51:15       sender:    0xf39Fd6e51aad88F6F4ce6aB8827279cffFb92266
09:51:15
09:51:15     Docs: https://viem.sh/docs/contract/writeContract
09:51:15     Details: replacement transaction underpriced
09:51:15     Version: viem@2.23.7
09:51:15
09:51:15       234 |
09:51:15       235 |         await deployL1ContractsValues.l1Client.waitForTransactionReceipt({
09:51:15     > 236 |           hash: await multiAdder.write.addValidators([this.validators]),
09:51:15           |                 ^
09:51:15       237 |         });
09:51:15       238 |
09:51:15       239 |         const slotsInEpoch = await rollup.read.getEpochDuration();
09:51:15
09:51:15       at getContractError (../../node_modules/viem/utils/errors/getContractError.ts:78:10)
09:51:15       at writeContract (../../node_modules/viem/actions/wallet/writeContract.ts:208:11)
09:51:15       at e2e_p2p/p2p_network.ts:236:17
09:51:15       at MockSnapshotManager.snapshot (fixtures/snapshot_manager.ts:132:26)
09:51:15       at P2PNetworkTest.applyBaseSnapshots (e2e_p2p/p2p_network.ts:195:5)
09:51:15       at Object.<anonymous> (e2e_p2p/validators_sentinel.test.ts:43:5)
09:51:15
09:51:15     Cause:
09:51:15     TransactionExecutionError: Transaction creation failed.
```