### PR TITLE
fix: make `msgpackr` a full dependency of `bb.js`

### DIFF
--- a/barretenberg/ts/package.json
+++ b/barretenberg/ts/package.json
@@ -67,6 +67,7 @@
     "commander": "^12.1.0",
     "debug": "^4.3.4",
     "fflate": "^0.8.0",
+    "msgpackr": "^1.11.2",
     "pako": "^2.1.0",
     "tslib": "^2.4.0"
   },
@@ -88,7 +89,6 @@
     "html-webpack-plugin": "^5.6.3",
     "idb-keyval": "^6.2.1",
     "jest": "^29.5.0",
-    "msgpackr": "^1.11.2",
     "node-polyfill-webpack-plugin": "^4.1.0",
     "prettier": "^2.8.4",
     "terser-webpack-plugin": "^5.3.14",


### PR DESCRIPTION
This PR fixes the issue in bb.js dependencies which is causing failures in https://github.com/noir-lang/noir/pull/8506

This was broken in https://github.com/AztecProtocol/aztec-packages/pull/13590 where the existing msgpack dependency was removed.