### PR TITLE
test: fixing flakey `gas_estimation.test.ts`

### DIFF
--- a/.test_patterns.yml
+++ b/.test_patterns.yml
@@ -167,10 +167,6 @@ tests:
     error_regex: "Anvil failed to stop in time"
     owners:
       - *palla
-  - regex: "src/e2e_fees/gas_estimation.test.ts"
-    error_regex: "✕ estimates gas with public payment method"
-    owners:
-      - *jan
 
   # yarn-project tests
   - regex: "p2p/src/services/discv5/discv5_service.test.ts"

--- a/yarn-project/end-to-end/src/e2e_fees/gas_estimation.test.ts
+++ b/yarn-project/end-to-end/src/e2e_fees/gas_estimation.test.ts
@@ -5,8 +5,6 @@ import {
   FeeJuicePaymentMethod,
   type FeePaymentMethod,
   PublicFeePaymentMethod,
-  retryUntil,
-  sleep,
 } from '@aztec/aztec.js';
 import type { Logger } from '@aztec/foundation/log';
 import type { FPCContract } from '@aztec/noir-contracts.js/FPC';
@@ -36,7 +34,6 @@ describe('e2e_fees gas_estimation', () => {
   });
 
   beforeEach(async () => {
-    await sleep(5000);
     // Load the gas fees at the start of each test, use those exactly as the max fees per gas
     const gasFees = await aliceWallet.getCurrentBaseFees();
     gasSettings = GasSettings.from({
@@ -91,34 +88,40 @@ describe('e2e_fees gas_estimation', () => {
     expect(estimatedGas.teardownGasLimits.l2Gas).toEqual(0);
     expect(estimatedGas.teardownGasLimits.daGas).toEqual(0);
 
-    const estimatedFee = estimatedGas.gasLimits.computeFee(gasSettings.maxFeesPerGas).toBigInt();
+    // Check that estimated fee and fee of the tx with estimate are the same. We need to use the gas fees (gas price)
+    // from the block in which the tx with estimate landed.
+    const gasFeesForBlockInWhichTxWithEstimateLanded = block!.header.globalVariables.gasFees;
+    const estimatedFee = estimatedGas.gasLimits.computeFee(gasFeesForBlockInWhichTxWithEstimateLanded).toBigInt();
     expect(estimatedFee).toEqual(withEstimate.transactionFee!);
-
-    await retryUntil(async () => (await t.pxe.getBlockNumber()) >= withEstimate.blockNumber!);
   });
 
   it('estimates gas with public payment method', async () => {
-    const teardownFixedFee = gasSettings.teardownGasLimits.computeFee(gasSettings.maxFeesPerGas).toBigInt();
     const paymentMethod = new PublicFeePaymentMethod(bananaFPC.address, aliceWallet);
+    const [withEstimate, withoutEstimate] = await sendTransfers(paymentMethod);
+
+    const teardownFixedFee = gasSettings.teardownGasLimits.computeFee(gasSettings.maxFeesPerGas).toBigInt();
     const estimatedGas = await makeTransferRequest().estimateGas({
       fee: { gasSettings, paymentMethod, estimatedGasPadding: 0 },
     });
     logGasEstimate(estimatedGas);
 
-    const [withEstimate, withoutEstimate] = await sendTransfers(paymentMethod);
-
-    // Actual teardown gas used is less than the limits.
+    // Checks that estimated teardown gas limits are less than the default ones.
     expect(estimatedGas.teardownGasLimits.l2Gas).toBeLessThan(gasSettings.teardownGasLimits.l2Gas);
     expect(estimatedGas.teardownGasLimits.daGas).toBeLessThan(gasSettings.teardownGasLimits.daGas);
 
-    // Estimation should yield that teardown has reduced cost, but is not zero
+    // Estimation should reduce tx fee because all of teardown gas limit gets consumed!
     expect(withEstimate.transactionFee!).toBeLessThan(withoutEstimate.transactionFee!);
     expect(withEstimate.transactionFee!).toBeGreaterThan(withoutEstimate.transactionFee! - teardownFixedFee);
 
     // Check that estimated gas for teardown are not zero since we're doing work there
     expect(estimatedGas.teardownGasLimits.l2Gas).toBeGreaterThan(0);
 
-    const estimatedFee = estimatedGas.gasLimits.computeFee(gasSettings.maxFeesPerGas).toBigInt();
+    // Check that estimated fee and fee of the tx with estimate are the same. We need to use the gas fees (gas price)
+    // from the block in which the tx with estimate landed.
+    const block = await t.pxe.getBlock(withEstimate.blockNumber!);
+    const gasFeesForBlockInWhichTxWithEstimateLanded = block!.header.globalVariables.gasFees;
+
+    const estimatedFee = estimatedGas.gasLimits.computeFee(gasFeesForBlockInWhichTxWithEstimateLanded).toBigInt();
     expect(estimatedFee).toEqual(withEstimate.transactionFee!);
   });
 
@@ -144,7 +147,12 @@ describe('e2e_fees gas_estimation', () => {
     expect(estimatedGas.teardownGasLimits.l2Gas).toEqual(0);
     expect(estimatedGas.teardownGasLimits.daGas).toEqual(0);
 
-    const estimatedFee = estimatedGas.gasLimits.computeFee(gasSettings.maxFeesPerGas).toBigInt();
+    // Check that estimated fee and fee of the tx with estimate are the same. We need to use the gas fees (gas price)
+    // from the block in which the tx with estimate landed.
+    const block = await t.pxe.getBlock(withEstimate.blockNumber!);
+    const gasFeesForBlockInWhichTxWithEstimateLanded = block!.header.globalVariables.gasFees;
+
+    const estimatedFee = estimatedGas.gasLimits.computeFee(gasFeesForBlockInWhichTxWithEstimateLanded).toBigInt();
     expect(estimatedFee).toEqual(withEstimate.transactionFee!);
   });
 });


### PR DESCRIPTION
This test was sometimes flakey - an estimated tx fee was different from the one included in a tx. This happened because we used a stale gas price to compute the estimated tx fee. I confirmed this by checking the gas price in the block in which the tx landed with the gas price used for estimation. It was incorrect to assume that the gas price would stay constant.

I run the 10 times and confirmed the flake went away (before I got it to fail like every 3rd time).

While only 1 test case was flakey I decided to do the change in the other 2 as well to ensure this does not bite us in the future again.