### PR TITLE
feat: adapt token txe tests to use the new model

### DIFF
--- a/noir-projects/aztec-nr/aztec/src/test/helpers/test_environment.nr
+++ b/noir-projects/aztec-nr/aztec/src/test/helpers/test_environment.nr
@@ -375,6 +375,17 @@ impl TestEnvironment {
         CallResult { return_value: (), tx_hash }
     }
 
+    pub unconstrained fn read_storage<T, let N: u32>(
+        self: Self,
+        address: AztecAddress,
+        storage_slot: Field,
+    ) -> T
+    where
+        T: Packable<N>,
+    {
+        crate::oracle::storage::storage_read(address, storage_slot, self.block_number())
+    }
+
     /// Manually adds a note to TXE. This needs to be called if you want to work with a note in your test with the note
     /// not having an encrypted log emitted.
     pub unconstrained fn add_note<Note, let N: u32>(

--- a/noir-projects/noir-contracts/contracts/app/token_contract/src/test/access_control.nr
+++ b/noir-projects/noir-contracts/contracts/app/token_contract/src/test/access_control.nr
@@ -9,26 +9,42 @@ unconstrained fn access_control() {
         utils::setup(/* with_account_contracts */ false);
 
     // Set a new admin
-    Token::at(token_contract_address).set_admin(recipient).call(&mut env.public());
+    let _ = env.call_public_void(owner, Token::at(token_contract_address).set_admin(recipient));
     // Check it worked
-    let admin = Token::at(token_contract_address).get_admin().view(&mut env.public());
+    let admin =
+        env.call_public_test(owner, Token::at(token_contract_address).get_admin()).return_value;
+
     assert(admin == recipient.to_field());
-    // Impersonate new admin
-    env.impersonate(recipient);
+
     // Check new admin is not a minter
-    let is_minter_call_interface = Token::at(token_contract_address).is_minter(recipient);
-    let is_minter = is_minter_call_interface.view(&mut env.public());
+    let is_minter = env
+        .call_public_test(recipient, Token::at(token_contract_address).is_minter(recipient))
+        .return_value;
     assert(is_minter == false);
+
     // Set admin as minter
-    Token::at(token_contract_address).set_minter(recipient, true).call(&mut env.public());
+    let _ = env.call_public_void(
+        recipient,
+        Token::at(token_contract_address).set_minter(recipient, true),
+    );
+
     // Check it worked
-    let is_minter = is_minter_call_interface.view(&mut env.public());
+    let is_minter = env
+        .call_public_test(recipient, Token::at(token_contract_address).is_minter(recipient))
+        .return_value;
     assert(is_minter == true);
+
     // Revoke minter as admin
-    Token::at(token_contract_address).set_minter(recipient, false).call(&mut env.public());
+    let _ = env
+        .call_public_void(recipient, Token::at(token_contract_address).set_minter(recipient, false))
+        .return_value;
+
     // Check it worked
-    let is_minter = is_minter_call_interface.view(&mut env.public());
+    let is_minter = env
+        .call_public_test(recipient, Token::at(token_contract_address).is_minter(recipient))
+        .return_value;
     assert(is_minter == false);
+
     // Impersonate original admin
     env.impersonate(owner);
     // docs:start:assert_public_fail

--- a/noir-projects/noir-contracts/contracts/app/token_contract/src/test/burn_private.nr
+++ b/noir-projects/noir-contracts/contracts/app/token_contract/src/test/burn_private.nr
@@ -10,8 +10,16 @@ unconstrained fn burn_private_on_behalf_of_self() {
     let burn_amount = mint_amount / (10 as u128);
 
     // Burn less than balance
-    Token::at(token_contract_address).burn_private(owner, burn_amount, 0).call(&mut env.private());
-    utils::check_private_balance(token_contract_address, owner, mint_amount - burn_amount);
+    let _ = env.call_private_void(
+        owner,
+        Token::at(token_contract_address).burn_private(owner, burn_amount, 0),
+    );
+    utils::check_private_balance(
+        env,
+        token_contract_address,
+        owner,
+        mint_amount - burn_amount,
+    );
 }
 
 #[test]
@@ -28,11 +36,15 @@ unconstrained fn burn_private_on_behalf_of_other() {
         recipient,
         burn_call_interface,
     );
-    // Impersonate recipient to perform the call
-    env.impersonate(recipient);
+
     // Burn tokens
-    burn_call_interface.call(&mut env.private());
-    utils::check_private_balance(token_contract_address, owner, mint_amount - burn_amount);
+    let _ = env.call_private_void(recipient, burn_call_interface);
+    utils::check_private_balance(
+        env,
+        token_contract_address,
+        owner,
+        mint_amount - burn_amount,
+    );
 }
 
 #[test(should_fail_with = "Balance too low")]
@@ -42,7 +54,10 @@ unconstrained fn burn_private_failure_more_than_balance() {
 
     // Burn more than balance
     let burn_amount = mint_amount * (10 as u128);
-    Token::at(token_contract_address).burn_private(owner, burn_amount, 0).call(&mut env.private());
+    let _ = env.call_private_void(
+        owner,
+        Token::at(token_contract_address).burn_private(owner, burn_amount, 0),
+    );
 }
 
 #[test(should_fail_with = "invalid nonce")]
@@ -52,8 +67,9 @@ unconstrained fn burn_private_failure_on_behalf_of_self_non_zero_nonce() {
 
     // Burn more than balance
     let burn_amount = mint_amount / (10 as u128);
-    Token::at(token_contract_address).burn_private(owner, burn_amount, random()).call(
-        &mut env.private(),
+    let _ = env.call_private_void(
+        owner,
+        Token::at(token_contract_address).burn_private(owner, burn_amount, random()),
     );
 }
 
@@ -72,9 +88,8 @@ unconstrained fn burn_private_failure_on_behalf_of_other_more_than_balance() {
         recipient,
         burn_call_interface,
     );
-    // Impersonate recipient to perform the call
-    env.impersonate(recipient);
-    burn_call_interface.call(&mut env.private());
+
+    let _ = env.call_private_void(recipient, burn_call_interface);
 }
 
 #[test(should_fail_with = "Unknown auth witness for message hash")]
@@ -85,10 +100,10 @@ unconstrained fn burn_private_failure_on_behalf_of_other_without_approval() {
     // Burn more than balance
     let burn_amount = mint_amount / (10 as u128);
     // Burn on behalf of other
-    let burn_call_interface = Token::at(token_contract_address).burn_private(owner, burn_amount, 3);
-    // Impersonate recipient to perform the call
-    env.impersonate(recipient);
-    burn_call_interface.call(&mut env.private());
+    let _ = env.call_private_void(
+        recipient,
+        Token::at(token_contract_address).burn_private(owner, burn_amount, 3),
+    );
 }
 
 #[test(should_fail_with = "Unknown auth witness for message hash")]
@@ -101,7 +116,6 @@ unconstrained fn burn_private_failure_on_behalf_of_other_wrong_designated_caller
     // Burn on behalf of other
     let burn_call_interface = Token::at(token_contract_address).burn_private(owner, burn_amount, 3);
     authwit_cheatcodes::add_private_authwit_from_call_interface(owner, owner, burn_call_interface);
-    // Impersonate recipient to perform the call
-    env.impersonate(recipient);
-    burn_call_interface.call(&mut env.private());
+
+    let _ = env.call_private_void(recipient, burn_call_interface);
 }

--- a/noir-projects/noir-contracts/contracts/app/token_contract/src/test/burn_public.nr
+++ b/noir-projects/noir-contracts/contracts/app/token_contract/src/test/burn_public.nr
@@ -5,13 +5,21 @@ use dep::aztec::oracle::random::random;
 
 #[test]
 unconstrained fn burn_public_success() {
-    let (env, token_contract_address, owner, recipient, mint_amount) =
+    let (env, token_contract_address, owner, _, mint_amount) =
         utils::setup_and_mint_to_public(/* with_account_contracts */ false);
     let burn_amount = mint_amount / (10 as u128);
 
     // Burn less than balance
-    Token::at(token_contract_address).burn_public(owner, burn_amount, 0).call(&mut env.public());
-    utils::check_public_balance(token_contract_address, owner, mint_amount - burn_amount);
+    let _ = env.call_public_void(
+        owner,
+        Token::at(token_contract_address).burn_public(owner, burn_amount, 0),
+    );
+    utils::check_public_balance(
+        env,
+        token_contract_address,
+        owner,
+        mint_amount - burn_amount,
+    );
 }
 
 #[test]
@@ -28,11 +36,15 @@ unconstrained fn burn_public_on_behalf_of_other() {
         recipient,
         burn_call_interface,
     );
-    // Impersonate recipient to perform the call
-    env.impersonate(recipient);
+
     // Burn tokens
-    burn_call_interface.call(&mut env.public());
-    utils::check_public_balance(token_contract_address, owner, mint_amount - burn_amount);
+    let _ = env.call_public_void(recipient, burn_call_interface);
+    utils::check_public_balance(
+        env,
+        token_contract_address,
+        owner,
+        mint_amount - burn_amount,
+    );
 }
 
 #[test(should_fail_with = "Assertion failed: attempt to subtract with overflow")]
@@ -43,7 +55,10 @@ unconstrained fn burn_public_failure_more_than_balance() {
     // Burn more than balance
     let burn_amount = mint_amount * (10 as u128);
     // Try to burn
-    Token::at(token_contract_address).burn_public(owner, burn_amount, 0).call(&mut env.public());
+    let _ = env.call_public_void(
+        owner,
+        Token::at(token_contract_address).burn_public(owner, burn_amount, 0),
+    );
 }
 
 #[test(should_fail_with = "invalid nonce")]
@@ -54,8 +69,9 @@ unconstrained fn burn_public_failure_on_behalf_of_self_non_zero_nonce() {
     // Burn on behalf of self with non-zero nonce
     let burn_amount = mint_amount / (10 as u128);
     // Try to burn
-    Token::at(token_contract_address).burn_public(owner, burn_amount, random()).call(
-        &mut env.public(),
+    let _ = env.call_public_void(
+        owner,
+        Token::at(token_contract_address).burn_public(owner, burn_amount, random()),
     );
 }
 
@@ -68,9 +84,8 @@ unconstrained fn burn_public_failure_on_behalf_of_other_without_approval() {
     let burn_amount = mint_amount / (10 as u128);
     let burn_call_interface =
         Token::at(token_contract_address).burn_public(owner, burn_amount, random());
-    // Impersonate recipient to perform the call
-    env.impersonate(recipient);
-    burn_call_interface.call(&mut env.public());
+
+    let _ = env.call_public_void(recipient, burn_call_interface);
 }
 
 #[test(should_fail_with = "unauthorized")]
@@ -83,7 +98,6 @@ unconstrained fn burn_public_failure_on_behalf_of_other_wrong_caller() {
     let burn_call_interface =
         Token::at(token_contract_address).burn_public(owner, burn_amount, random());
     authwit_cheatcodes::add_public_authwit_from_call_interface(owner, owner, burn_call_interface);
-    // Impersonate recipient to perform the call
-    env.impersonate(recipient);
-    burn_call_interface.call(&mut env.public());
+
+    let _ = env.call_public_void(recipient, burn_call_interface);
 }

--- a/noir-projects/noir-contracts/contracts/app/token_contract/src/test/mint_to_public.nr
+++ b/noir-projects/noir-contracts/contracts/app/token_contract/src/test/mint_to_public.nr
@@ -6,12 +6,13 @@ unconstrained fn mint_to_public_success() {
     let (env, token_contract_address, owner, _) = utils::setup(/* with_account_contracts */ false);
 
     let mint_amount = 10_000 as u128;
-    Token::at(token_contract_address).mint_to_public(owner, mint_amount).call(&mut env.public());
+    let _ = env.call_public_void(
+        owner,
+        Token::at(token_contract_address).mint_to_public(owner, mint_amount),
+    );
 
-    utils::check_public_balance(token_contract_address, owner, mint_amount);
-
-    let total_supply = Token::at(token_contract_address).total_supply().view(&mut env.public());
-    assert(total_supply == mint_amount);
+    utils::check_public_balance(env, token_contract_address, owner, mint_amount);
+    utils::check_total_supply(env, token_contract_address, mint_amount);
 }
 
 #[test]
@@ -27,7 +28,7 @@ unconstrained fn mint_to_public_failures() {
         Token::at(token_contract_address).mint_to_public(owner, mint_amount);
     env.assert_public_call_fails(mint_to_public_call_interface);
 
-    utils::check_public_balance(token_contract_address, owner, 0 as u128);
+    utils::check_public_balance(env, token_contract_address, owner, 0 as u128);
 
     env.impersonate(owner);
 
@@ -37,19 +38,22 @@ unconstrained fn mint_to_public_failures() {
     let amount_until_overflow = 1000 as u128;
     let mint_amount = (2.pow_32(128) - amount_until_overflow as Field) as u128;
 
-    Token::at(token_contract_address).mint_to_public(recipient, mint_amount).call(&mut env.public());
+    let _ = env.call_public_void(
+        owner,
+        Token::at(token_contract_address).mint_to_public(recipient, mint_amount),
+    );
 
     let mint_to_public_call_interface =
         Token::at(token_contract_address).mint_to_public(owner, amount_until_overflow);
     env.assert_public_call_fails(mint_to_public_call_interface);
 
-    utils::check_public_balance(token_contract_address, owner, 0 as u128);
-    utils::check_total_supply(token_contract_address, mint_amount);
+    utils::check_public_balance(env, token_contract_address, owner, 0 as u128);
+    utils::check_total_supply(env, token_contract_address, mint_amount);
 
     // Overflow total supply
     let mint_to_public_call_interface =
         Token::at(token_contract_address).mint_to_public(owner, mint_amount);
     env.assert_public_call_fails(mint_to_public_call_interface);
 
-    utils::check_public_balance(token_contract_address, owner, 0 as u128);
+    utils::check_public_balance(env, token_contract_address, owner, 0 as u128);
 }

--- a/noir-projects/noir-contracts/contracts/app/token_contract/src/test/reading_constants.nr
+++ b/noir-projects/noir-contracts/contracts/app/token_contract/src/test/reading_constants.nr
@@ -1,27 +1,30 @@
 use crate::test::utils;
 use crate::Token;
-use dep::aztec::test::helpers::cheatcodes;
 
 // It is not possible to deserialize strings in Noir ATM, so name and symbol cannot be checked yet.
 
 #[test]
 unconstrained fn check_decimals_private() {
     // Setup without account contracts. We are not using authwits here, so dummy accounts are enough
-    let (env, token_contract_address, _, _) = utils::setup(/* with_account_contracts */ false);
+    let (env, token_contract_address, owner, _) = utils::setup(/* with_account_contracts */ false);
 
     // Check decimals
-    let result = Token::at(token_contract_address).private_get_decimals().view(&mut env.private());
+    let result = env
+        .call_private_test(owner, Token::at(token_contract_address).private_get_decimals())
+        .return_value;
 
-    assert(result == 18);
+    assert(result == 18 as u8);
 }
 
 #[test]
 unconstrained fn check_decimals_public() {
     // Setup without account contracts. We are not using authwits here, so dummy accounts are enough
-    let (env, token_contract_address, _, _) = utils::setup(/* with_account_contracts */ false);
+    let (env, token_contract_address, owner, _) = utils::setup(/* with_account_contracts */ false);
 
     // Check decimals
-    let result = Token::at(token_contract_address).public_get_decimals().view(&mut env.public());
+    let result = env
+        .call_public_test(owner, Token::at(token_contract_address).public_get_decimals())
+        .return_value;
 
-    assert(result == 18);
+    assert(result == 18 as u8);
 }

--- a/noir-projects/noir-contracts/contracts/app/token_contract/src/test/transfer.nr
+++ b/noir-projects/noir-contracts/contracts/app/token_contract/src/test/transfer.nr
@@ -11,11 +11,20 @@ unconstrained fn transfer_private() {
     // docs:start:txe_test_transfer_private
     // Transfer tokens
     let transfer_amount = 1000 as u128;
-    Token::at(token_contract_address).transfer(recipient, transfer_amount).call(&mut env.private());
+    let _ = env.call_private_void(
+        owner,
+        Token::at(token_contract_address).transfer(recipient, transfer_amount),
+    );
+
     // docs:end:txe_test_transfer_private
     // Check balances
-    utils::check_private_balance(token_contract_address, owner, mint_amount - transfer_amount);
-    utils::check_private_balance(token_contract_address, recipient, transfer_amount);
+    utils::check_private_balance(
+        env,
+        token_contract_address,
+        owner,
+        mint_amount - transfer_amount,
+    );
+    utils::check_private_balance(env, token_contract_address, recipient, transfer_amount);
 }
 
 #[test]
@@ -25,10 +34,13 @@ unconstrained fn transfer_private_to_self() {
         utils::setup_and_mint_to_private(/* with_account_contracts */ false);
     // Transfer tokens
     let transfer_amount = 1000 as u128;
-    Token::at(token_contract_address).transfer(owner, transfer_amount).call(&mut env.private());
+    let _ = env.call_private_void(
+        owner,
+        Token::at(token_contract_address).transfer(owner, transfer_amount),
+    );
 
     // Check balances
-    utils::check_private_balance(token_contract_address, owner, mint_amount);
+    utils::check_private_balance(env, token_contract_address, owner, mint_amount);
 }
 
 #[test]
@@ -39,13 +51,20 @@ unconstrained fn transfer_private_to_non_deployed_account() {
     let not_deployed = cheatcodes::create_account(999);
     // Transfer tokens
     let transfer_amount = 1000 as u128;
-    Token::at(token_contract_address).transfer(not_deployed.address, transfer_amount).call(
-        &mut env.private(),
+    let _ = env.call_private_void(
+        owner,
+        Token::at(token_contract_address).transfer(not_deployed.address, transfer_amount),
     );
 
     // Check balances
-    utils::check_private_balance(token_contract_address, owner, mint_amount - transfer_amount);
     utils::check_private_balance(
+        env,
+        token_contract_address,
+        owner,
+        mint_amount - transfer_amount,
+    );
+    utils::check_private_balance(
+        env,
         token_contract_address,
         not_deployed.address,
         transfer_amount,
@@ -55,9 +74,12 @@ unconstrained fn transfer_private_to_non_deployed_account() {
 #[test(should_fail_with = "Balance too low")]
 unconstrained fn transfer_private_failure_more_than_balance() {
     // Setup without account contracts. We are not using authwits here, so dummy accounts are enough
-    let (env, token_contract_address, _, recipient, mint_amount) =
+    let (env, token_contract_address, owner, recipient, mint_amount) =
         utils::setup_and_mint_to_private(/* with_account_contracts */ false);
     // Transfer tokens
     let transfer_amount = mint_amount + (1 as u128);
-    Token::at(token_contract_address).transfer(recipient, transfer_amount).call(&mut env.private());
+    let _ = env.call_private_void(
+        owner,
+        Token::at(token_contract_address).transfer(recipient, transfer_amount),
+    );
 }

--- a/noir-projects/noir-contracts/contracts/app/token_contract/src/test/transfer_in_private.nr
+++ b/noir-projects/noir-contracts/contracts/app/token_contract/src/test/transfer_in_private.nr
@@ -17,14 +17,17 @@ unconstrained fn transfer_private_on_behalf_of_other() {
         recipient,
         transfer_private_from_call_interface,
     );
-    // Impersonate recipient to perform the call
-    env.impersonate(recipient);
     // Transfer tokens
-    transfer_private_from_call_interface.call(&mut env.private());
+    env.call_private_void(recipient, transfer_private_from_call_interface);
     // docs:end:private_authwit
     // Check balances
-    utils::check_private_balance(token_contract_address, owner, mint_amount - transfer_amount);
-    utils::check_private_balance(token_contract_address, recipient, transfer_amount);
+    utils::check_private_balance(
+        env,
+        token_contract_address,
+        owner,
+        mint_amount - transfer_amount,
+    );
+    utils::check_private_balance(env, token_contract_address, recipient, transfer_amount);
 }
 
 // docs:start:fail_with_message
@@ -43,7 +46,7 @@ unconstrained fn transfer_private_failure_on_behalf_of_self_non_zero_nonce() {
         transfer_private_from_call_interface,
     );
     // Transfer tokens
-    transfer_private_from_call_interface.call(&mut env.private());
+    let _ = env.call_private_void(owner, transfer_private_from_call_interface);
 }
 // docs:end:fail_with_message
 
@@ -61,10 +64,8 @@ unconstrained fn transfer_private_failure_on_behalf_of_more_than_balance() {
         recipient,
         transfer_private_from_call_interface,
     );
-    // Impersonate recipient to perform the call
-    env.impersonate(recipient);
     // Transfer tokens
-    transfer_private_from_call_interface.call(&mut env.private());
+    let _ = env.call_private_void(recipient, transfer_private_from_call_interface);
 }
 
 #[test(should_fail_with = "Unknown auth witness for message hash")]
@@ -76,10 +77,8 @@ unconstrained fn transfer_private_failure_on_behalf_of_other_without_approval() 
     let transfer_amount = 1000 as u128;
     let transfer_private_from_call_interface =
         Token::at(token_contract_address).transfer_in_private(owner, recipient, transfer_amount, 1);
-    // Impersonate recipient to perform the call
-    env.impersonate(recipient);
     // Transfer tokens
-    transfer_private_from_call_interface.call(&mut env.private());
+    env.call_private_void(recipient, transfer_private_from_call_interface);
 }
 
 #[test(should_fail_with = "Unknown auth witness for message hash")]
@@ -96,8 +95,6 @@ unconstrained fn transfer_private_failure_on_behalf_of_other_wrong_caller() {
         owner,
         transfer_private_from_call_interface,
     );
-    // Impersonate recipient to perform the call
-    env.impersonate(recipient);
     // Transfer tokens
-    transfer_private_from_call_interface.call(&mut env.private());
+    env.call_private_void(recipient, transfer_private_from_call_interface);
 }

--- a/noir-projects/noir-contracts/contracts/app/token_contract/src/test/transfer_in_public.nr
+++ b/noir-projects/noir-contracts/contracts/app/token_contract/src/test/transfer_in_public.nr
@@ -10,13 +10,19 @@ unconstrained fn public_transfer() {
         utils::setup_and_mint_to_public(/* with_account_contracts */ false);
     // Transfer tokens
     let transfer_amount = mint_amount / (10 as u128);
-    Token::at(token_contract_address).transfer_in_public(owner, recipient, transfer_amount, 0).call(
-        &mut env.public(),
+    let _ = env.call_public_void(
+        owner,
+        Token::at(token_contract_address).transfer_in_public(owner, recipient, transfer_amount, 0),
     );
 
     // Check balances
-    utils::check_public_balance(token_contract_address, owner, mint_amount - transfer_amount);
-    utils::check_public_balance(token_contract_address, recipient, transfer_amount);
+    utils::check_public_balance(
+        env,
+        token_contract_address,
+        owner,
+        mint_amount - transfer_amount,
+    );
+    utils::check_public_balance(env, token_contract_address, recipient, transfer_amount);
 }
 
 #[test]
@@ -27,12 +33,14 @@ unconstrained fn public_transfer_to_self() {
     // Transfer tokens
     let transfer_amount = mint_amount / (10 as u128);
     // docs:start:call_public
-    Token::at(token_contract_address).transfer_in_public(owner, owner, transfer_amount, 0).call(
-        &mut env.public(),
+    let _ = env.call_public_void(
+        owner,
+        Token::at(token_contract_address).transfer_in_public(owner, owner, transfer_amount, 0),
     );
+
     // docs:end:call_public
     // Check balances
-    utils::check_public_balance(token_contract_address, owner, mint_amount);
+    utils::check_public_balance(env, token_contract_address, owner, mint_amount);
 }
 
 #[test]
@@ -48,13 +56,17 @@ unconstrained fn public_transfer_on_behalf_of_other() {
         recipient,
         public_transfer_in_private_call_interface,
     );
-    // Impersonate recipient to perform the call
-    env.impersonate(recipient);
     // Transfer tokens
-    public_transfer_in_private_call_interface.call(&mut env.public());
+    let _ = env.call_public_void(recipient, public_transfer_in_private_call_interface);
+
     // Check balances
-    utils::check_public_balance(token_contract_address, owner, mint_amount - transfer_amount);
-    utils::check_public_balance(token_contract_address, recipient, transfer_amount);
+    utils::check_public_balance(
+        env,
+        token_contract_address,
+        owner,
+        mint_amount - transfer_amount,
+    );
+    utils::check_public_balance(env, token_contract_address, recipient, transfer_amount);
 }
 
 #[test(should_fail_with = "Assertion failed: attempt to subtract with overflow")]
@@ -67,7 +79,7 @@ unconstrained fn public_transfer_failure_more_than_balance() {
     let public_transfer_call_interface =
         Token::at(token_contract_address).transfer_in_public(owner, recipient, transfer_amount, 0);
     // Try to transfer tokens
-    public_transfer_call_interface.call(&mut env.public());
+    let _ = env.call_public_void(owner, public_transfer_call_interface);
 }
 
 #[test(should_fail_with = "invalid nonce")]
@@ -89,7 +101,7 @@ unconstrained fn public_transfer_failure_on_behalf_of_self_non_zero_nonce() {
         public_transfer_call_interface,
     );
     // Try to transfer tokens
-    public_transfer_call_interface.call(&mut env.public());
+    let _ = env.call_public_void(owner, public_transfer_call_interface);
 }
 
 #[test(should_fail_with = "unauthorized")]
@@ -100,10 +112,8 @@ unconstrained fn public_transfer_failure_on_behalf_of_other_without_approval() {
     let transfer_amount = mint_amount / (10 as u128);
     let public_transfer_in_private_call_interface =
         Token::at(token_contract_address).transfer_in_public(owner, recipient, transfer_amount, 1);
-    // Impersonate recipient to perform the call
-    env.impersonate(recipient);
     // Try to transfer tokens
-    public_transfer_in_private_call_interface.call(&mut env.public());
+    let _ = env.call_public_void(recipient, public_transfer_in_private_call_interface);
 }
 
 #[test(should_fail_with = "Assertion failed: attempt to subtract with overflow")]
@@ -121,10 +131,8 @@ unconstrained fn public_transfer_failure_on_behalf_of_other_more_than_balance() 
         public_transfer_in_private_call_interface,
     );
     // docs:end:public_authwit
-    // Impersonate recipient to perform the call
-    env.impersonate(recipient);
     // Try to transfer tokens
-    public_transfer_in_private_call_interface.call(&mut env.public());
+    let _ = env.call_public_void(recipient, public_transfer_in_private_call_interface);
 }
 
 #[test(should_fail_with = "unauthorized")]
@@ -140,8 +148,6 @@ unconstrained fn public_transfer_failure_on_behalf_of_other_wrong_caller() {
         owner,
         public_transfer_in_private_call_interface,
     );
-    // Impersonate recipient to perform the call
-    env.impersonate(recipient);
     // Try to transfer tokens
-    public_transfer_in_private_call_interface.call(&mut env.public());
+    let _ = env.call_public_void(recipient, public_transfer_in_private_call_interface);
 }

--- a/noir-projects/noir-contracts/contracts/app/token_contract/src/test/transfer_to_private.nr
+++ b/noir-projects/noir-contracts/contracts/app/token_contract/src/test/transfer_to_private.nr
@@ -11,11 +11,13 @@ unconstrained fn transfer_to_private_internal_orchestration() {
     // The transfer to private is done in `utils::setup_and_mint_to_private` and for this reason
     // in this test we just call it and check the outcome.
     // Setup without account contracts. We are not using authwits here, so dummy accounts are enough
-    let (_, token_contract_address, user, _, amount) =
+    let (env, token_contract_address, user, _, amount) =
         utils::setup_and_mint_to_private(/* with_account_contracts */ false);
 
     // User's private balance should be equal to the amount
-    utils::check_private_balance(token_contract_address, user, amount);
+    let balance = env.simulate_utility(Token::at(token_contract_address)
+        ._experimental_balance_of_private(user));
+    assert_eq(balance, amount);
 }
 
 /// External orchestration means that the calls to prepare and finalize are not done by the Token contract. This flow
@@ -27,33 +29,38 @@ unconstrained fn transfer_to_private_external_orchestration() {
         utils::setup_and_mint_to_public(/* with_account_contracts */ false);
 
     // We prepare the transfer
-    let partial_uint_note = Token::at(token_contract_address)
-        .prepare_private_balance_increase(recipient, owner)
-        .call(&mut env.private());
+    let partial_uint_note = env
+        .call_private(
+            owner,
+            Token::at(token_contract_address).prepare_private_balance_increase(recipient, owner),
+        )
+        .return_value;
 
     // Finalize the transfer of the tokens (message sender owns the tokens in public)
-    Token::at(token_contract_address).finalize_transfer_to_private(amount, partial_uint_note).call(
-        &mut env.public(),
+    let _ = env.call_public_void(
+        owner,
+        Token::at(token_contract_address).finalize_transfer_to_private(amount, partial_uint_note),
     );
 
-    env.advance_block_by(1);
-
     // Recipient's private balance should be equal to the amount
-    utils::check_private_balance(token_contract_address, recipient, amount);
+    let balance = env.simulate_utility(Token::at(token_contract_address)
+        ._experimental_balance_of_private(recipient));
+    assert_eq(balance, amount);
 }
 
 #[test(should_fail_with = "Invalid partial note or completer")]
 unconstrained fn transfer_to_private_transfer_not_prepared() {
     // Setup without account contracts. We are not using authwits here, so dummy accounts are enough
-    let (env, token_contract_address, _, _, amount) =
+    let (env, token_contract_address, owner, _, amount) =
         utils::setup_and_mint_to_public(/* with_account_contracts */ false);
 
     // Transfer was not prepared so we can use random value for the partial note
     let partial_uint_note = PartialUintNote { commitment: random() };
 
     // Try finalizing the transfer without preparing it
-    Token::at(token_contract_address).finalize_transfer_to_private(amount, partial_uint_note).call(
-        &mut env.public(),
+    let _ = env.call_public_void(
+        owner,
+        Token::at(token_contract_address).finalize_transfer_to_private(amount, partial_uint_note),
     );
 }
 
@@ -66,14 +73,17 @@ unconstrained fn transfer_to_private_failure_not_an_owner() {
     // (For this specific test we could set a random value for the commitment and not do the call to `prepare...`
     // as the token balance check is before we use the value but that would made the test less robust against changes
     // in the contract.)
-    let partial_uint_note = Token::at(token_contract_address)
-        .prepare_private_balance_increase(not_owner, owner)
-        .call(&mut env.private());
+    let partial_uint_note = env
+        .call_private(
+            owner,
+            Token::at(token_contract_address).prepare_private_balance_increase(not_owner, owner),
+        )
+        .return_value;
 
     // Try transferring someone else's token balance
-    env.impersonate(not_owner);
-    Token::at(token_contract_address).finalize_transfer_to_private(amount, partial_uint_note).call(
-        &mut env.public(),
+    let _ = env.call_public_void(
+        not_owner,
+        Token::at(token_contract_address).finalize_transfer_to_private(amount, partial_uint_note),
     );
 }
 
@@ -90,14 +100,19 @@ unconstrained fn incorrect_completer_cannot_complete_partial_note() {
     let arbitrary_sender = env.create_account(4);
 
     // We prepare the partial note as a completer
-    env.impersonate(completer);
-    let partial_uint_note = Token::at(token_contract_address)
-        .prepare_private_balance_increase(recipient, arbitrary_sender)
-        .call(&mut env.private());
+    let partial_uint_note = env
+        .call_private(
+            completer,
+            Token::at(token_contract_address).prepare_private_balance_increase(
+                recipient,
+                arbitrary_sender,
+            ),
+        )
+        .return_value;
 
     // We impersonate the incorrect completer and try to finalize the transfer
-    env.impersonate(incorrect_completer);
-    Token::at(token_contract_address).finalize_transfer_to_private(amount, partial_uint_note).call(
-        &mut env.public(),
+    let _ = env.call_public_void(
+        incorrect_completer,
+        Token::at(token_contract_address).finalize_transfer_to_private(amount, partial_uint_note),
     );
 }

--- a/noir-projects/noir-contracts/contracts/app/token_contract/src/test/transfer_to_public.nr
+++ b/noir-projects/noir-contracts/contracts/app/token_contract/src/test/transfer_to_public.nr
@@ -10,15 +10,26 @@ unconstrained fn transfer_to_public_on_behalf_of_self() {
         utils::setup_and_mint_to_private(/* with_account_contracts */ false);
 
     let transfer_to_public_amount = mint_amount / (10 as u128);
-    Token::at(token_contract_address)
-        .transfer_to_public(owner, owner, transfer_to_public_amount, 0)
-        .call(&mut env.private());
-    utils::check_private_balance(
+    let _ = env.call_private_void(
+        owner,
+        Token::at(token_contract_address).transfer_to_public(
+            owner,
+            owner,
+            transfer_to_public_amount,
+            0,
+        ),
+    );
+
+    let amount = env.simulate_utility(Token::at(token_contract_address)
+        ._experimental_balance_of_private(owner));
+    assert_eq(amount, mint_amount - transfer_to_public_amount);
+
+    utils::check_public_balance(
+        env,
         token_contract_address,
         owner,
-        mint_amount - transfer_to_public_amount,
+        transfer_to_public_amount,
     );
-    utils::check_public_balance(token_contract_address, owner, transfer_to_public_amount);
 }
 
 #[test]
@@ -38,16 +49,20 @@ unconstrained fn transfer_to_public_on_behalf_of_other() {
         recipient,
         transfer_to_public_call_interface,
     );
-    // Impersonate recipient
-    env.impersonate(recipient);
+
     // transfer_to_public tokens
-    transfer_to_public_call_interface.call(&mut env.private());
-    utils::check_private_balance(
+    let _ = env.call_private_void(recipient, transfer_to_public_call_interface);
+
+    let amount = env.simulate_utility(Token::at(token_contract_address)
+        ._experimental_balance_of_private(owner));
+    assert_eq(amount, mint_amount - transfer_to_public_amount);
+
+    utils::check_public_balance(
+        env,
         token_contract_address,
-        owner,
-        mint_amount - transfer_to_public_amount,
+        recipient,
+        transfer_to_public_amount,
     );
-    utils::check_public_balance(token_contract_address, recipient, transfer_to_public_amount);
 }
 
 #[test(should_fail_with = "Balance too low")]
@@ -57,9 +72,16 @@ unconstrained fn transfer_to_public_failure_more_than_balance() {
         utils::setup_and_mint_to_private(/* with_account_contracts */ false);
 
     let transfer_to_public_amount = mint_amount + (1 as u128);
-    Token::at(token_contract_address)
-        .transfer_to_public(owner, owner, transfer_to_public_amount, 0)
-        .call(&mut env.private());
+
+    let _ = env.call_private_void(
+        owner,
+        Token::at(token_contract_address).transfer_to_public(
+            owner,
+            owner,
+            transfer_to_public_amount,
+            0,
+        ),
+    );
 }
 
 #[test(should_fail_with = "invalid nonce")]
@@ -69,9 +91,16 @@ unconstrained fn transfer_to_public_failure_on_behalf_of_self_non_zero_nonce() {
         utils::setup_and_mint_to_private(/* with_account_contracts */ false);
 
     let transfer_to_public_amount = mint_amount + (1 as u128);
-    Token::at(token_contract_address)
-        .transfer_to_public(owner, owner, transfer_to_public_amount, random())
-        .call(&mut env.private());
+
+    let _ = env.call_private_void(
+        owner,
+        Token::at(token_contract_address).transfer_to_public(
+            owner,
+            owner,
+            transfer_to_public_amount,
+            random(),
+        ),
+    );
 }
 
 #[test(should_fail_with = "Balance too low")]
@@ -91,10 +120,9 @@ unconstrained fn transfer_to_public_failure_on_behalf_of_other_more_than_balance
         recipient,
         transfer_to_public_call_interface,
     );
-    // Impersonate recipient
-    env.impersonate(recipient);
+
     // transfer_to_public tokens
-    transfer_to_public_call_interface.call(&mut env.private());
+    let _ = env.call_private_void(recipient, transfer_to_public_call_interface);
 }
 
 #[test(should_fail_with = "Unknown auth witness for message hash")]
@@ -114,10 +142,9 @@ unconstrained fn transfer_to_public_failure_on_behalf_of_other_invalid_designate
         owner,
         transfer_to_public_call_interface,
     );
-    // Impersonate recipient
-    env.impersonate(recipient);
+
     // transfer_to_public tokens
-    transfer_to_public_call_interface.call(&mut env.private());
+    let _ = env.call_private_void(recipient, transfer_to_public_call_interface);
 }
 
 #[test(should_fail_with = "Unknown auth witness for message hash")]
@@ -132,8 +159,7 @@ unconstrained fn transfer_to_public_failure_on_behalf_of_other_no_approval() {
         transfer_to_public_amount,
         0,
     );
-    // Impersonate recipient
-    env.impersonate(recipient);
+
     // transfer_to_public tokens
-    transfer_to_public_call_interface.call(&mut env.private());
+    let _ = env.call_private_void(recipient, transfer_to_public_call_interface);
 }

--- a/noir-projects/noir-contracts/contracts/app/token_contract/src/test/utils.nr
+++ b/noir-projects/noir-contracts/contracts/app/token_contract/src/test/utils.nr
@@ -1,10 +1,8 @@
 use crate::Token;
 use dep::uint_note::uint_note::UintNote;
 use aztec::{
-    oracle::{execution::{get_block_number, get_contract_address}, storage::storage_read},
-    prelude::AztecAddress,
-    protocol_types::storage::map::derive_storage_slot_in_map,
-    test::helpers::{cheatcodes, test_environment::TestEnvironment},
+    prelude::AztecAddress, protocol_types::storage::map::derive_storage_slot_in_map,
+    test::helpers::test_environment::TestEnvironment,
 };
 
 pub unconstrained fn setup(
@@ -22,9 +20,6 @@ pub unconstrained fn setup(
         (owner, recipient)
     };
 
-    // Start the test in the account contract address
-    env.impersonate(owner);
-
     // Deploy token contract
     let initializer_call_interface = Token::interface().constructor(
         owner,
@@ -35,7 +30,7 @@ pub unconstrained fn setup(
     let token_contract =
         env.deploy_self("Token").with_public_void_initializer(owner, initializer_call_interface);
     let token_contract_address = token_contract.to_address();
-    env.advance_block_by(1);
+
     (&mut env, token_contract_address, owner, recipient)
 }
 
@@ -46,7 +41,10 @@ pub unconstrained fn setup_and_mint_to_public(
     let (env, token_contract_address, owner, recipient) = setup(with_account_contracts);
     let mint_amount = 10000 as u128;
     // Mint some tokens
-    Token::at(token_contract_address).mint_to_public(owner, mint_amount).call(&mut env.public());
+    let _ = env.call_public_void(
+        owner,
+        Token::at(token_contract_address).mint_to_public(owner, mint_amount),
+    );
 
     (env, token_contract_address, owner, recipient, mint_amount)
 }
@@ -59,7 +57,7 @@ pub unconstrained fn setup_and_mint_amount_to_private(
     let (env, token_contract_address, owner, recipient) = setup(with_account_contracts);
 
     // Mint some tokens
-    mint_to_private(env, token_contract_address, owner, mint_amount);
+    mint_to_private(env, token_contract_address, owner, owner, mint_amount);
 
     (env, token_contract_address, owner, recipient, mint_amount)
 }
@@ -74,88 +72,71 @@ pub unconstrained fn setup_and_mint_to_private(
 pub unconstrained fn mint_to_private(
     env: &mut TestEnvironment,
     token_contract_address: AztecAddress,
+    minter: AztecAddress,
     recipient: AztecAddress,
     amount: u128,
 ) {
     let from = recipient; // we are setting from to recipient because we need to compute the tag
-    Token::at(token_contract_address).mint_to_private(from, recipient, amount).call(
-        &mut env.private(),
-    );
 
-    env.advance_block_by(1);
+    let _ = env.call_private_void(
+        minter,
+        Token::at(token_contract_address).mint_to_private(from, recipient, amount),
+    );
 }
 
 // docs:start:txe_test_read_public
 pub unconstrained fn check_public_balance(
+    env: &mut TestEnvironment,
     token_contract_address: AztecAddress,
     address: AztecAddress,
     address_amount: u128,
 ) {
-    let current_contract_address = get_contract_address();
-    cheatcodes::set_contract_address(token_contract_address);
-    let block_number = get_block_number();
-
-    let balances_slot = Token::storage_layout().public_balances.slot;
-    let address_slot = derive_storage_slot_in_map(balances_slot, address);
-    let amount: u128 = storage_read(token_contract_address, address_slot, block_number);
+    let amount = get_public_balance(env, token_contract_address, address);
     assert(amount == address_amount, "Public balance is not correct");
-    cheatcodes::set_contract_address(current_contract_address);
 }
 // docs:end:txe_test_read_public
 
 pub unconstrained fn get_public_balance(
+    env: &mut TestEnvironment,
     token_contract_address: AztecAddress,
     address: AztecAddress,
 ) -> u128 {
-    let current_contract_address = get_contract_address();
-    cheatcodes::set_contract_address(token_contract_address);
-    let block_number = get_block_number();
-
     let balances_slot = Token::storage_layout().public_balances.slot;
     let address_slot = derive_storage_slot_in_map(balances_slot, address);
-    let amount: u128 = storage_read(token_contract_address, address_slot, block_number);
-    cheatcodes::set_contract_address(current_contract_address);
+    let amount: u128 = env.read_storage(token_contract_address, address_slot);
     amount
 }
 
 pub unconstrained fn check_total_supply(
+    env: &mut TestEnvironment,
     token_contract_address: AztecAddress,
     expected_total_supply: u128,
 ) {
-    let current_contract_address = get_contract_address();
-    cheatcodes::set_contract_address(token_contract_address);
-    let block_number = get_block_number();
-
     let total_supply_slot = Token::storage_layout().total_supply.slot;
-    let total_supply: u128 = storage_read(token_contract_address, total_supply_slot, block_number);
+    let total_supply: u128 = env.read_storage(token_contract_address, total_supply_slot);
     assert(total_supply == expected_total_supply, "Total supply is not correct");
-    cheatcodes::set_contract_address(current_contract_address);
 }
 
 // docs:start:txe_test_call_utility
 pub unconstrained fn check_private_balance(
+    env: &mut TestEnvironment,
     token_contract_address: AztecAddress,
     address: AztecAddress,
     address_amount: u128,
 ) {
-    let current_contract_address = get_contract_address();
-    cheatcodes::set_contract_address(token_contract_address);
-    // Direct call to a utility function
-    let balance_of_private = Token::balance_of_private(address);
-    assert(balance_of_private == address_amount, "Private balance is not correct");
-    cheatcodes::set_contract_address(current_contract_address);
+    let balance = get_private_balance(env, token_contract_address, address);
+    assert(balance == address_amount, "Private balance is not correct");
 }
 // docs:end:txe_test_call_utility
 
 pub unconstrained fn get_private_balance(
+    env: &mut TestEnvironment,
     token_contract_address: AztecAddress,
     address: AztecAddress,
 ) -> u128 {
-    let current_contract_address = get_contract_address();
-    cheatcodes::set_contract_address(token_contract_address);
-    let amt = Token::balance_of_private(address);
-    cheatcodes::set_contract_address(current_contract_address);
-    amt
+    let balance = env.simulate_utility(Token::at(token_contract_address)
+        ._experimental_balance_of_private(address));
+    balance
 }
 
 // This is used if we need to add a token note manually, in the case where the note is not emitted in logs.

--- a/noir-projects/noir-contracts/contracts/app/token_contract/src/types/balance_set.nr
+++ b/noir-projects/noir-contracts/contracts/app/token_contract/src/types/balance_set.nr
@@ -165,6 +165,7 @@ mod test {
         // We check the recipient balance is correct both as a sanity check and as a way to make sure we've discovered
         // the notes.
         utils::check_private_balance(
+            env,
             token_contract_address,
             recipient,
             small_mint_amount + large_mint_amount,
@@ -208,6 +209,7 @@ mod test {
         // We check the recipient balance is correct both as a sanity check and as a way to make sure we've discovered
         // the notes.
         utils::check_private_balance(
+            env,
             token_contract_address,
             recipient,
             small_mint_amount + large_mint_amount,

--- a/noir-projects/noir-contracts/contracts/test/parent_contract/src/main.nr
+++ b/noir-projects/noir-contracts/contracts/test/parent_contract/src/main.nr
@@ -271,39 +271,48 @@ pub contract Parent {
         let mut env = TestEnvironment::new();
         let owner = env.create_account(1);
         // Deploy parent contract
-        let parent_contract = env.deploy_self("Parent").without_initializer();
-        let parent_contract_address = parent_contract.to_address();
+        let parent_contract_address = env.deploy_self("Parent").without_initializer().to_address();
         // Deploy child contract
-        let child_contract = env.deploy("./@child_contract", "Child").without_initializer();
-        let child_contract_address = child_contract.to_address();
-        cheatcodes::advance_blocks_by(1);
+        let child_contract_address =
+            env.deploy("./@child_contract", "Child").without_initializer().to_address();
+
         // Set value in child through parent
         let value_to_set = 7;
-        let result = Parent::at(parent_contract_address)
-            .private_call(
-                child_contract_address,
-                comptime { FunctionSelector::from_signature("private_set_value(Field,(Field))") },
-                [value_to_set, owner.to_field()],
+        let result = env
+            .call_private(
+                owner,
+                Parent::at(parent_contract_address).private_call(
+                    child_contract_address,
+                    comptime {
+                        FunctionSelector::from_signature("private_set_value(Field,(Field))")
+                    },
+                    [value_to_set, owner.to_field()],
+                ),
             )
-            .call(&mut env.private());
+            .return_value;
         assert(result == value_to_set);
-        // Read the stored value in the note. We have to change the contract address to the child contract in order to read its notes
-        env.impersonate(child_contract_address);
-        let counter_slot = Child::storage_layout().a_map_with_private_values.slot;
-        let owner_slot = derive_storage_slot_in_map(counter_slot, owner);
-        let mut options = NoteViewerOptions::new();
-        let notes: BoundedVec<ValueNote, MAX_NOTES_PER_PAGE> = view_notes(owner_slot, options);
-        let note_value = notes.get(0).value;
-        assert(note_value == value_to_set);
-        assert(note_value == result);
-        // Get value from child through parent
-        let read_result = Parent::at(parent_contract_address)
-            .private_call(
-                child_contract_address,
-                comptime { FunctionSelector::from_signature("private_get_value(Field,(Field))") },
-                [7, owner.to_field()],
+
+        let note_value = env
+            .call_private(
+                owner,
+                Child::at(child_contract_address).private_get_value(value_to_set, owner),
             )
-            .call(&mut env.private());
-        assert(note_value == read_result);
+            .return_value;
+        assert(note_value == value_to_set);
+
+        // Get value from child through parent
+        let read_result = env
+            .call_private(
+                owner,
+                Parent::at(parent_contract_address).private_call(
+                    child_contract_address,
+                    comptime {
+                        FunctionSelector::from_signature("private_get_value(Field,(Field))")
+                    },
+                    [7, owner.to_field()],
+                ),
+            )
+            .return_value;
+        assert(read_result == value_to_set);
     }
 }

--- a/yarn-project/txe/src/oracle/txe_oracle.ts
+++ b/yarn-project/txe/src/oracle/txe_oracle.ts
@@ -1393,7 +1393,7 @@ export class TXE implements TypedOracle {
       /** Header of a block whose state is used during private execution (not the block the transaction is included in). */
       blockHeader,
       /** List of transient auth witnesses to be used during this simulation */
-      [],
+      [...this.authwits].map(([_, authwit]) => authwit),
       /** List of transient auth witnesses to be used during this simulation */
       [],
       HashedValuesCache.create(),
@@ -1582,8 +1582,13 @@ export class TXE implements TypedOracle {
     const processedTxs = results[0];
     const failedTxs = results[1];
 
-    if (failedTxs.length !== 0) {
-      throw new Error('Public execution has failed');
+    if (failedTxs.length !== 0 || !processedTxs[0].revertCode.isOK()) {
+      if (processedTxs[0]?.revertReason && processedTxs[0]?.revertReason instanceof SimulationError) {
+        await enrichPublicSimulationError(processedTxs[0]?.revertReason, this.getContractDataProvider(), this.logger);
+        throw new Error(processedTxs[0]?.revertReason.message);
+      }
+
+      throw new Error(`Public function call reverted: ${processedTxs[0]?.revertReason}`);
     }
 
     if (isStaticCall) {
@@ -1736,7 +1741,12 @@ export class TXE implements TypedOracle {
     const failedTxs = results[1];
 
     if (failedTxs.length !== 0 || !processedTxs[0].revertCode.isOK()) {
-      throw new Error('Public execution has failed');
+      if (processedTxs[0]?.revertReason && processedTxs[0]?.revertReason instanceof SimulationError) {
+        await enrichPublicSimulationError(processedTxs[0]?.revertReason, this.getContractDataProvider(), this.logger);
+        throw new Error(processedTxs[0]?.revertReason.message);
+      }
+
+      throw new Error(`Public function call reverted: ${processedTxs[0]?.revertReason}`);
     }
 
     const returnValues = results[3][0].values;


### PR DESCRIPTION
Everything here should use the new flow. 

Note this is still not polished / finalized as you will notice some inconsistencies / jank within some call interfaces but should be quite indicative of how tests will look like with the new txe call api. There is also some weirdness to debug with completing partial notes but I will do all of the above when I am back from ooo.

We eliminate all cases of `env.impersonate` and `call_interface.call(&mut env)` except for when we use `env.assert_x_call_fails`. I will handle this case in a downstream PR. 

Rudimentary benchmarks as below:

Setup: Mainframe @ ~0000 UTC, avg of 3 attempts, rounded up to the nearest second, one terminal with txe running (restarted and cleared output every run), other running the txe tests specifying each suite defined by the column 'key'. Note that these are super non-scientific but generally shows we're in a similar ballpark of performance (we are not sacrificing too much by making the execution model match).

| test suite  | before | after |
| ---------- | ------ | ----- |
| access_control  | 11s  | 12s |
| transfer_to_private  | 21s  | 21s |
| transfer_to_public  | 31s | 30s |


