### PR TITLE
feat: Partial epoch proofs

### DIFF
--- a/yarn-project/end-to-end/src/e2e_epochs/epochs_partial_proof.test.ts
+++ b/yarn-project/end-to-end/src/e2e_epochs/epochs_partial_proof.test.ts
@@ -1,0 +1,36 @@
+import { type Logger, retryUntil } from '@aztec/aztec.js';
+import type { ChainMonitor } from '@aztec/ethereum/test';
+
+// eslint-disable-next-line no-restricted-imports
+import { jest } from '@jest/globals';
+
+import { EpochsTestContext } from './epochs_test.js';
+
+jest.setTimeout(1000 * 60 * 10);
+
+describe('e2e_epochs/epochs_partial_proof', () => {
+  let logger: Logger;
+  let monitor: ChainMonitor;
+
+  let test: EpochsTestContext;
+
+  beforeEach(async () => {
+    test = await EpochsTestContext.setup({ aztecEpochDuration: 1000 });
+    ({ monitor, logger } = test);
+  });
+
+  afterEach(async () => {
+    jest.restoreAllMocks();
+    await test.teardown();
+  });
+
+  it('submits partial proofs when instructed manually', async () => {
+    await test.waitUntilL2BlockNumber(4, 60);
+    logger.info(`Kicking off partial proof`);
+
+    await test.context.proverNode!.startProof(0);
+    await retryUntil(() => monitor.l2ProvenBlockNumber > 0, 'proof', 120, 1);
+
+    logger.info(`Test succeeded with proven block number ${monitor.l2ProvenBlockNumber}`);
+  });
+});

--- a/yarn-project/prover-node/src/actions/rerun-epoch-proving-job.ts
+++ b/yarn-project/prover-node/src/actions/rerun-epoch-proving-job.ts
@@ -51,6 +51,7 @@ export async function rerunEpochProvingJob(
     l2BlockSourceForReorgDetection,
     metrics,
     deadline,
+    { skipEpochCheck: true },
   );
 
   log.info(`Rerunning epoch proving job for epoch ${jobData.epochNumber}`);


### PR DESCRIPTION
Support partial epoch proofs by manually triggering a `startProof` on the prover node RPC API. This required disabling the epoch check in those jobs, otherwise the job would kill itself when a new block was added to the epoch.

Alternatively, we could keep the check and add a numeric block range to the epoch job, as @alexghr suggested.
