### PR TITLE
fix: Handle unseen proven and finalized blocks in p2p client

### DIFF
--- a/yarn-project/p2p/src/client/p2p_client.ts
+++ b/yarn-project/p2p/src/client/p2p_client.ts
@@ -3,6 +3,7 @@ import { createLogger } from '@aztec/foundation/log';
 import type { AztecAsyncKVStore, AztecAsyncMap, AztecAsyncSingleton } from '@aztec/kv-store';
 import type {
   L2Block,
+  L2BlockId,
   L2BlockSource,
   L2BlockStream,
   L2BlockStreamEvent,
@@ -163,6 +164,7 @@ export class P2PClient<T extends P2PClientType = P2PClientType.Full>
         break;
       case 'chain-finalized': {
         // TODO (alexg): I think we can prune the block hashes map here
+        await this.setBlockHash(event.block);
         const from = (await this.getSyncedFinalizedBlockNum()) + 1;
         const limit = event.block.number - from + 1;
         if (limit > 0) {
@@ -171,16 +173,24 @@ export class P2PClient<T extends P2PClientType = P2PClientType.Full>
         break;
       }
       case 'chain-proven': {
+        await this.setBlockHash(event.block);
         await this.synchedProvenBlockNumber.set(event.block.number);
         break;
       }
       case 'chain-pruned':
+        await this.setBlockHash(event.block);
         await this.handlePruneL2Blocks(event.block.number);
         break;
       default: {
         const _: never = event;
         break;
       }
+    }
+  }
+
+  private async setBlockHash(block: L2BlockId): Promise<void> {
+    if (block.hash !== undefined) {
+      await this.synchedBlockHashes.set(block.number, block.hash.toString());
     }
   }
 
@@ -235,7 +245,7 @@ export class P2PClient<T extends P2PClientType = P2PClientType.Full>
       this.syncPromise = new Promise(resolve => {
         this.syncResolve = resolve;
       });
-      this.log.verbose(`Initiating p2p sync from ${syncedLatestBlock}`, {
+      this.log.info(`Initiating p2p sync from ${syncedLatestBlock}`, {
         syncedLatestBlock,
         syncedProvenBlock,
         syncedFinalizedBlock,
@@ -639,9 +649,16 @@ export class P2PClient<T extends P2PClientType = P2PClientType.Full>
     void this.requestMissingTxsFromUnprovenBlocks(blocks.map(b => b.block));
 
     const lastBlock = blocks.at(-1)!.block;
+
     await Promise.all(
-      blocks.map(async block => this.synchedBlockHashes.set(block.block.number, (await block.block.hash()).toString())),
+      blocks.map(async block =>
+        this.setBlockHash({
+          number: block.block.number,
+          hash: await block.block.hash().then(h => h.toString()),
+        }),
+      ),
     );
+
     await this.synchedLatestBlockNumber.set(lastBlock.number);
     await this.synchedLatestSlot.set(lastBlock.header.getSlot());
     this.log.verbose(`Synched to latest block ${lastBlock.number}`);
@@ -677,7 +694,7 @@ export class P2PClient<T extends P2PClientType = P2PClientType.Full>
    * @returns Empty promise.
    */
   private async handleFinalizedL2Blocks(blocks: L2Block[]): Promise<void> {
-    this.log.warn(`handling finalized ${blocks.length} ${blocks.at(-1)?.number}`);
+    this.log.trace(`Handling finalized blocks ${blocks.length} up to ${blocks.at(-1)?.number}`);
     if (!blocks.length) {
       return Promise.resolve();
     }


### PR DESCRIPTION
P2P client would panic if a block it hadnt seen was marked as proven or finalized. Props to @just-mitch for finding this.

Fun fact: this would not have been hit if I had implemented the `REFACTOR: Try replacing these with an L2TipsStore` comment I left in the code.
