### PR TITLE
fix: release nightly artifacts

### DIFF
--- a/bootstrap.sh
+++ b/bootstrap.sh
@@ -402,6 +402,7 @@ case "$cmd" in
     export CI_NIGHTLY=1
     build
     test
+    release
     docs/bootstrap.sh release-docs
     ;;
   "ci-release")


### PR DESCRIPTION
The `release` step was missing from the `ci-nightly` command. This PR adds it back in.
