### PR TITLE
fix: Store pending tx count

### DIFF
--- a/yarn-project/aztec-node/src/aztec-node/server.ts
+++ b/yarn-project/aztec-node/src/aztec-node/server.ts
@@ -542,9 +542,8 @@ export class AztecNodeService implements AztecNode, AztecNodeAdmin, Traceable {
     return this.p2pClient!.getPendingTxs();
   }
 
-  public async getPendingTxCount() {
-    const pendingTxs = await this.getPendingTxs();
-    return pendingTxs.length;
+  public getPendingTxCount() {
+    return this.p2pClient!.getPendingTxCount();
   }
 
   /**

--- a/yarn-project/bot/src/runner.ts
+++ b/yarn-project/bot/src/runner.ts
@@ -163,9 +163,9 @@ export class BotRunner implements BotRunnerApi, Traceable {
   @trackSpan('Bot.work')
   async #work() {
     if (this.config.maxPendingTxs > 0) {
-      const pendingTxs = await this.node.getPendingTxs();
-      if (pendingTxs.length >= this.config.maxPendingTxs) {
-        this.log.verbose(`Not sending bot tx since node has ${pendingTxs.length} pending txs`);
+      const pendingTxCount = await this.node.getPendingTxCount();
+      if (pendingTxCount >= this.config.maxPendingTxs) {
+        this.log.verbose(`Not sending bot tx since node has ${pendingTxCount} pending txs`);
         return;
       }
     }

--- a/yarn-project/p2p/src/client/p2p_client.ts
+++ b/yarn-project/p2p/src/client/p2p_client.ts
@@ -373,12 +373,11 @@ export class P2PClient<T extends P2PClientType = P2PClientType.Full>
   }
 
   public getPendingTxs(): Promise<Tx[]> {
-    return Promise.resolve(this.getTxs('pending'));
+    return this.getTxs('pending');
   }
 
-  public async getPendingTxCount(): Promise<number> {
-    const pendingTxs = await this.txPool.getPendingTxHashes();
-    return pendingTxs.length;
+  public getPendingTxCount(): Promise<number> {
+    return this.txPool.getPendingTxCount();
   }
 
   public async *iteratePendingTxs(): AsyncIterableIterator<Tx> {

--- a/yarn-project/p2p/src/mem_pools/tx_pool/aztec_kv_tx_pool.test.ts
+++ b/yarn-project/p2p/src/mem_pools/tx_pool/aztec_kv_tx_pool.test.ts
@@ -16,6 +16,11 @@ describe('KV TX pool', () => {
   let worldState: MockProxy<WorldStateSynchronizer>;
   let db: MockProxy<MerkleTreeReadOperations>;
 
+  const checkPendingTxConsistency = async () => {
+    const pendingTxHashCount = await txPool.getPendingTxHashes().then(h => h.length);
+    expect(await txPool.getPendingTxCount()).toEqual(pendingTxHashCount);
+  };
+
   beforeEach(async () => {
     worldState = worldState = mock<WorldStateSynchronizer>();
     db = mock<MerkleTreeReadOperations>();
@@ -27,6 +32,8 @@ describe('KV TX pool', () => {
     );
     txPool.mockArchiveCache.getArchiveIndices.mockImplementation(() => Promise.resolve([BigInt(1)]));
   });
+
+  afterEach(checkPendingTxConsistency);
 
   describeTxPool(() => txPool);
 
@@ -72,6 +79,7 @@ describe('KV TX pool', () => {
     const tx2 = await mockTx(2, { maxPriorityFeesPerGas: new GasFees(2, 2) });
     const tx3 = await mockTx(3, { maxPriorityFeesPerGas: new GasFees(3, 3) });
     await txPool.addTxs([tx1, tx2, tx3]);
+    await checkPendingTxConsistency();
     await expect(txPool.getPendingTxHashes()).resolves.toEqual([
       await tx3.getTxHash(),
       await tx2.getTxHash(),
@@ -82,6 +90,7 @@ describe('KV TX pool', () => {
     const tx4 = await mockTx(4, { maxPriorityFeesPerGas: new GasFees(4, 4) });
     const tx5 = await mockTx(5, { maxPriorityFeesPerGas: new GasFees(5, 5) });
     await txPool.addTxs([tx4, tx5]);
+    await checkPendingTxConsistency();
     await expect(txPool.getPendingTxHashes()).resolves.toEqual([
       await tx5.getTxHash(),
       await tx4.getTxHash(),
@@ -91,6 +100,7 @@ describe('KV TX pool', () => {
     // if another low priority tx is added after the tx pool size limit is reached, it should be evicted
     const tx6 = await mockTx(6, { maxPriorityFeesPerGas: new GasFees(1, 1) });
     await txPool.addTxs([tx6]);
+    await checkPendingTxConsistency();
     await expect(txPool.getPendingTxHashes()).resolves.toEqual([
       await tx5.getTxHash(),
       await tx4.getTxHash(),
@@ -101,6 +111,7 @@ describe('KV TX pool', () => {
     await txPool.deleteTxs([await tx3.getTxHash()]);
     const tx7 = await mockTx(7, { maxPriorityFeesPerGas: new GasFees(2, 2) });
     await txPool.addTxs([tx7]);
+    await checkPendingTxConsistency();
     await expect(txPool.getPendingTxHashes()).resolves.toEqual([
       await tx5.getTxHash(),
       await tx4.getTxHash(),
@@ -111,6 +122,7 @@ describe('KV TX pool', () => {
     await txPool.markAsMined([await tx4.getTxHash()], 1);
     const tx8 = await mockTx(8, { maxPriorityFeesPerGas: new GasFees(3, 3) });
     await txPool.addTxs([tx8]);
+    await checkPendingTxConsistency();
     await expect(txPool.getPendingTxHashes()).resolves.toEqual([
       await tx5.getTxHash(),
       await tx8.getTxHash(),
@@ -120,6 +132,7 @@ describe('KV TX pool', () => {
     // verify that the tx pool size limit is respected after mining and deletions
     const tx9 = await mockTx(9, { maxPriorityFeesPerGas: new GasFees(1, 1) });
     await txPool.addTxs([tx9]);
+    await checkPendingTxConsistency();
     await expect(txPool.getPendingTxHashes()).resolves.toEqual([
       await tx5.getTxHash(),
       await tx8.getTxHash(),
@@ -211,6 +224,7 @@ describe('KV TX pool', () => {
 
     await txPool.addTxs([tx1, tx2, tx3]);
     await txPool.markAsMined([await tx2.getTxHash()], 1);
+    await checkPendingTxConsistency();
 
     // modify tx1 to have an insufficient fee payer balance after the reorg
     txPool.mockGasTxValidator.validateTxFee.mockImplementation(async (tx: Tx) => {
@@ -219,6 +233,7 @@ describe('KV TX pool', () => {
       } as TxValidationResult);
     });
     await txPool.markMinedAsPending([await tx2.getTxHash()]);
+    await checkPendingTxConsistency();
 
     const pendingTxHashes = await txPool.getPendingTxHashes();
     expect(pendingTxHashes).toEqual(expect.arrayContaining([await tx2.getTxHash(), await tx3.getTxHash()]));

--- a/yarn-project/p2p/src/mem_pools/tx_pool/aztec_kv_tx_pool.ts
+++ b/yarn-project/p2p/src/mem_pools/tx_pool/aztec_kv_tx_pool.ts
@@ -646,7 +646,7 @@ export class AztecKVTxPool implements TxPool {
 
   private async increasePendingTxCount(count: number): Promise<void> {
     const pendingTxCount = (await this.#pendingTxCount.getAsync()) ?? 0;
-    this.#log.warn(
+    this.#log.debug(
       `Increasing pending tx count: current ${pendingTxCount} + count ${count} = ${pendingTxCount + count}`,
     );
     await this.#pendingTxCount.set(pendingTxCount + count);

--- a/yarn-project/p2p/src/mem_pools/tx_pool/memory_tx_pool.ts
+++ b/yarn-project/p2p/src/mem_pools/tx_pool/memory_tx_pool.ts
@@ -86,6 +86,10 @@ export class InMemoryTxPool implements TxPool {
     );
   }
 
+  public getPendingTxCount(): Promise<number> {
+    return Promise.resolve(this.pendingTxs.size);
+  }
+
   public getTxStatus(txHash: TxHash): Promise<'pending' | 'mined' | undefined> {
     const key = txHash.toBigInt();
     if (this.pendingTxs.has(key)) {

--- a/yarn-project/p2p/src/mem_pools/tx_pool/tx_pool.ts
+++ b/yarn-project/p2p/src/mem_pools/tx_pool/tx_pool.ts
@@ -75,6 +75,9 @@ export interface TxPool {
    */
   getPendingTxHashes(): Promise<TxHash[]>;
 
+  /** Returns the number of pending txs in the pool. */
+  getPendingTxCount(): Promise<number>;
+
   /**
    * Gets the hashes of mined transactions currently in the tx pool.
    * @returns An array of mined transaction hashes found in the tx pool.

--- a/yarn-project/p2p/src/mem_pools/tx_pool/tx_pool_test_suite.ts
+++ b/yarn-project/p2p/src/mem_pools/tx_pool/tx_pool_test_suite.ts
@@ -24,6 +24,7 @@ export function describeTxPool(getTxPool: () => TxPool) {
     expect(await poolTx!.getTxHash()).toEqual(await tx1.getTxHash());
     await expect(pool.getTxStatus(await tx1.getTxHash())).resolves.toEqual('pending');
     await expect(pool.getPendingTxHashes()).resolves.toEqual([await tx1.getTxHash()]);
+    await expect(pool.getPendingTxCount()).resolves.toEqual(1);
   });
 
   it('Removes txs from the pool', async () => {
@@ -34,6 +35,7 @@ export function describeTxPool(getTxPool: () => TxPool) {
 
     await expect(pool.getTxByHash(await tx1.getTxHash())).resolves.toBeFalsy();
     await expect(pool.getTxStatus(await tx1.getTxHash())).resolves.toBeUndefined();
+    await expect(pool.getPendingTxCount()).resolves.toEqual(0);
   });
 
   it('Marks txs as mined', async () => {
@@ -47,6 +49,7 @@ export function describeTxPool(getTxPool: () => TxPool) {
     await expect(pool.getTxStatus(await tx1.getTxHash())).resolves.toEqual('mined');
     await expect(pool.getMinedTxHashes()).resolves.toEqual([[await tx1.getTxHash(), 1]]);
     await expect(pool.getPendingTxHashes()).resolves.toEqual([await tx2.getTxHash()]);
+    await expect(pool.getPendingTxCount()).resolves.toEqual(1);
   });
 
   it('Marks txs as pending after being mined', async () => {
@@ -61,6 +64,7 @@ export function describeTxPool(getTxPool: () => TxPool) {
     const pending = await pool.getPendingTxHashes();
     expect(pending).toHaveLength(2);
     expect(pending).toEqual(expect.arrayContaining([await tx1.getTxHash(), await tx2.getTxHash()]));
+    await expect(pool.getPendingTxCount()).resolves.toEqual(2);
   });
 
   it('Only marks txs as pending if they are known', async () => {
@@ -82,6 +86,7 @@ export function describeTxPool(getTxPool: () => TxPool) {
     await pool.markMinedAsPending([await tx1.getTxHash(), someTxHashThatThisPeerDidNotSee]);
     await expect(pool.getMinedTxHashes()).resolves.toEqual([]);
     await expect(pool.getPendingTxHashes()).resolves.toEqual([await tx1.getTxHash()]); // tx2 is not in the pool
+    await expect(pool.getPendingTxCount()).resolves.toEqual(1);
   });
 
   it('Returns all transactions in the pool', async () => {
@@ -94,6 +99,7 @@ export function describeTxPool(getTxPool: () => TxPool) {
     const poolTxs = await pool.getAllTxs();
     expect(poolTxs).toHaveLength(3);
     expect(poolTxs).toEqual(expect.arrayContaining([tx1, tx2, tx3]));
+    await expect(pool.getPendingTxCount()).resolves.toEqual(3);
   });
 
   it('Returns all txHashes in the pool', async () => {
@@ -104,10 +110,10 @@ export function describeTxPool(getTxPool: () => TxPool) {
     await pool.addTxs([tx1, tx2, tx3]);
 
     const poolTxHashes = await pool.getAllTxHashes();
+    const expectedHashes = await Promise.all([tx1, tx2, tx3].map(tx => tx.getTxHash()));
     expect(poolTxHashes).toHaveLength(3);
-    expect(poolTxHashes).toEqual(
-      expect.arrayContaining([await tx1.getTxHash(), await tx2.getTxHash(), await tx3.getTxHash()]),
-    );
+    expect(poolTxHashes).toEqual(expect.arrayContaining(expectedHashes));
+    await expect(pool.getPendingTxCount()).resolves.toEqual(3);
   });
 
   it('Returns txs by their hash', async () => {

--- a/yarn-project/p2p/src/testbench/p2p_client_testbench_worker.ts
+++ b/yarn-project/p2p/src/testbench/p2p_client_testbench_worker.ts
@@ -44,6 +44,7 @@ function mockTxPool(): TxPool {
     getAllTxs: () => Promise.resolve([]),
     getAllTxHashes: () => Promise.resolve([]),
     getPendingTxHashes: () => Promise.resolve([]),
+    getPendingTxCount: () => Promise.resolve(0),
     getMinedTxHashes: () => Promise.resolve([]),
     getTxStatus: () => Promise.resolve(TxStatus.PENDING),
     getTxsByHash: () => Promise.resolve([]),

--- a/yarn-project/stdlib/src/interfaces/p2p.test.ts
+++ b/yarn-project/stdlib/src/interfaces/p2p.test.ts
@@ -36,6 +36,11 @@ describe('P2PApiSchema', () => {
     expect(txs[0]).toBeInstanceOf(Tx);
   });
 
+  it('getPendingTxCount', async () => {
+    const txs = await context.client.getPendingTxCount();
+    expect(txs).toEqual(10);
+  });
+
   it('getEncodedEnr', async () => {
     const enr = await context.client.getEncodedEnr();
     expect(enr).toEqual('enr');
@@ -72,6 +77,10 @@ class MockP2P implements P2PApi {
 
   getPendingTxs(): Promise<Tx[]> {
     return Promise.resolve([Tx.random()]);
+  }
+
+  getPendingTxCount(): Promise<number> {
+    return Promise.resolve(10);
   }
 
   getEncodedEnr(): Promise<string | undefined> {

--- a/yarn-project/stdlib/src/interfaces/p2p.ts
+++ b/yarn-project/stdlib/src/interfaces/p2p.ts
@@ -30,6 +30,9 @@ export interface P2PApiWithoutAttestations {
    */
   getPendingTxs(): Promise<Tx[]>;
 
+  /** Returns the number of pending txs in the p2p tx pool. */
+  getPendingTxCount(): Promise<number>;
+
   /**
    * Returns the ENR for this node, if any.
    */
@@ -65,6 +68,7 @@ export const P2PApiSchema: ApiSchemaFor<P2PApi> = {
     .args(schemas.BigInt, optional(z.string()))
     .returns(z.array(BlockAttestation.schema)),
   getPendingTxs: z.function().returns(z.array(Tx.schema)),
+  getPendingTxCount: z.function().returns(schemas.Integer),
   getEncodedEnr: z.function().returns(z.string().optional()),
   getPeers: z.function().args(optional(z.boolean())).returns(z.array(PeerInfoSchema)),
   addAttestation: z.function().args(BlockAttestation.schema).returns(z.void()),

--- a/yarn-project/txe/src/state_machine/dummy_p2p_client.ts
+++ b/yarn-project/txe/src/state_machine/dummy_p2p_client.ts
@@ -12,6 +12,7 @@ export class DummyP2P implements P2P {
   public clear(): Promise<void> {
     throw new Error('DummyP2P does not implement "clear".');
   }
+
   public getPendingTxs(): Promise<Tx[]> {
     throw new Error('DummyP2P does not implement "getPendingTxs"');
   }


### PR DESCRIPTION
So we can answer how many pending txs are there instead of loading them all and counting them.

Fixes #14258
