### PR TITLE
fix: Add configurable maxBatchSize limit for JSON-RPC batch requests

### DIFF
--- a/yarn-project/pxe/src/pxe_http/pxe_http_server.ts
+++ b/yarn-project/pxe/src/pxe_http/pxe_http_server.ts
@@ -7,18 +7,19 @@ import http from 'http';
  * Wraps an instance of Private eXecution Environment (PXE) implementation to a JSON RPC HTTP interface.
  * @returns A new instance of the HTTP server.
  */
-export function createPXERpcServer(pxeService: PXE) {
-  return createSafeJsonRpcServer(pxeService, PXESchema);
+export function createPXERpcServer(pxeService: PXE, maxBatchSize?: number) {
+  return createSafeJsonRpcServer(pxeService, PXESchema, { maxBatchSize });
 }
 
 /**
  * Creates an http server that forwards calls to the PXE and starts it on the given port.
  * @param pxeService - PXE that answers queries to the created HTTP server.
  * @param port - Port to listen in.
+ * @param maxBatchSize - Maximum allowed batch size for JSON RPC batch requests.
  * @returns A running http server.
  */
-export function startPXEHttpServer(pxeService: PXE, port: string | number): http.Server {
-  const rpcServer = createNamespacedSafeJsonRpcServer({ pxe: [pxeService, PXESchema] });
+export function startPXEHttpServer(pxeService: PXE, port: string | number, maxBatchSize?: number): http.Server {
+  const rpcServer = createNamespacedSafeJsonRpcServer({ pxe: [pxeService, PXESchema] }, { maxBatchSize });
 
   const app = rpcServer.getApp();
   // eslint-disable-next-line @typescript-eslint/no-misused-promises


### PR DESCRIPTION
I introduced a new `maxBatchSize` option (defaulting to 100) into our JSON-RPC server. In `SafeJsonRpcServer` and its factory functions, any incoming batch larger than this limit is now rejected upfront with JSON-RPC error –32600 (honoring `http200OnError`). This prevents resource exhaustion from unbounded batch requests.

I then exposed the same option in our PXE HTTP wrappers (`createPXERpcServer` and `startPXEHttpServer`), so PXE deployments can opt into the batch limit with a single parameter. These additions close out the issue around oversized batch handling.

Fixes: #14300 
