### PR TITLE
docs: comment on partial note reuse

### DIFF
--- a/noir-projects/noir-contracts/contracts/app/nft_contract/src/main.nr
+++ b/noir-projects/noir-contracts/contracts/app/nft_contract/src/main.nr
@@ -237,9 +237,15 @@ pub contract NFT {
         context.storage_write(validity_commitment, true);
     }
     // docs:end:store_payload_in_transient_storage_unsafe
+
     /// Finalizes a transfer of NFT with `token_id` from public balance of `msg_sender` to a private balance of `to`.
     /// The transfer must be prepared by calling `prepare_private_balance_increase` from `msg_sender` account and the
     /// resulting `partial_note` must be passed as an argument to this function.
+    ///
+    /// Note that this contract does not protect against a `partial_note` being used multiple times and it is up to
+    /// the developer to ensure that it doesn't happen. If the same `partial_note` is used multiple times, the NFT
+    /// with `token_id` would most likely get lost (the partial note log processing functionality would fail to find
+    /// the pending partial note when trying to complete it).
     // docs:start:finalize_transfer_to_private
     #[public]
     fn finalize_transfer_to_private(token_id: Field, partial_note: PartialNFTNote) {
@@ -296,7 +302,9 @@ pub contract NFT {
         // We verify that the partial note we're completing is valid (i.e. completer is correct, it uses the correct
         // state variable's storage slot, and it is internally consistent). We *could* clear the storage since each
         // partial note should only be used once, but since the AVM offers no gas refunds for doing so this would just
-        // make the transaction be more expensive.
+        // make the transaction be more expensive. We don't worry about the validity commitment being checked against multiple
+        // times because it is up to the developer to ensure that the same partial note is not used multiple times (see
+        // comment of `finalize_transfer_to_private`).
         assert(
             context.storage_read(partial_note.compute_validity_commitment(from_and_completer)),
             "Invalid partial note or completer",

--- a/noir-projects/noir-contracts/contracts/app/nft_contract/src/main.nr
+++ b/noir-projects/noir-contracts/contracts/app/nft_contract/src/main.nr
@@ -243,9 +243,9 @@ pub contract NFT {
     /// resulting `partial_note` must be passed as an argument to this function.
     ///
     /// Note that this contract does not protect against a `partial_note` being used multiple times and it is up to
-    /// the caller of this function to ensure that it doesn't happen. If the same `partial_note` is used multiple times, the NFT
-    /// with `token_id` would most likely get lost (the partial note log processing functionality would fail to find
-    /// the pending partial note when trying to complete it).
+    /// the caller of this function to ensure that it doesn't happen. If the same `partial_note` is used multiple
+    /// times, the NFT with `token_id` would most likely get lost (the partial note log processing functionality
+    /// would fail to find the pending partial note when trying to complete it).
     // docs:start:finalize_transfer_to_private
     #[public]
     fn finalize_transfer_to_private(token_id: Field, partial_note: PartialNFTNote) {
@@ -303,8 +303,8 @@ pub contract NFT {
         // state variable's storage slot, and it is internally consistent). We *could* clear the storage since each
         // partial note should only be used once, but since the AVM offers no gas refunds for doing so this would just
         // make the transaction be more expensive. We don't worry about the validity commitment being checked against
-        // multiple times because it is up to the caller to ensure that a partial note is used only once (see
-        // function docs of `finalize_transfer_to_private`).
+        // multiple times because it is up to the caller to ensure that a partial note is used only once (see function
+        // docs of `finalize_transfer_to_private`).
         assert(
             context.storage_read(partial_note.compute_validity_commitment(from_and_completer)),
             "Invalid partial note or completer",

--- a/noir-projects/noir-contracts/contracts/app/nft_contract/src/main.nr
+++ b/noir-projects/noir-contracts/contracts/app/nft_contract/src/main.nr
@@ -243,7 +243,7 @@ pub contract NFT {
     /// resulting `partial_note` must be passed as an argument to this function.
     ///
     /// Note that this contract does not protect against a `partial_note` being used multiple times and it is up to
-    /// the developer to ensure that it doesn't happen. If the same `partial_note` is used multiple times, the NFT
+    /// the caller of this function to ensure that it doesn't happen. If the same `partial_note` is used multiple times, the NFT
     /// with `token_id` would most likely get lost (the partial note log processing functionality would fail to find
     /// the pending partial note when trying to complete it).
     // docs:start:finalize_transfer_to_private

--- a/noir-projects/noir-contracts/contracts/app/nft_contract/src/main.nr
+++ b/noir-projects/noir-contracts/contracts/app/nft_contract/src/main.nr
@@ -303,7 +303,7 @@ pub contract NFT {
         // state variable's storage slot, and it is internally consistent). We *could* clear the storage since each
         // partial note should only be used once, but since the AVM offers no gas refunds for doing so this would just
         // make the transaction be more expensive. We don't worry about the validity commitment being checked against
-        // multiple times because it is up to the developer to ensure that a partial note is used only once (see
+        // multiple times because it is up to the caller to ensure that a partial note is used only once (see
         // function docs of `finalize_transfer_to_private`).
         assert(
             context.storage_read(partial_note.compute_validity_commitment(from_and_completer)),

--- a/noir-projects/noir-contracts/contracts/app/nft_contract/src/main.nr
+++ b/noir-projects/noir-contracts/contracts/app/nft_contract/src/main.nr
@@ -302,9 +302,9 @@ pub contract NFT {
         // We verify that the partial note we're completing is valid (i.e. completer is correct, it uses the correct
         // state variable's storage slot, and it is internally consistent). We *could* clear the storage since each
         // partial note should only be used once, but since the AVM offers no gas refunds for doing so this would just
-        // make the transaction be more expensive. We don't worry about the validity commitment being checked against multiple
-        // times because it is up to the developer to ensure that the same partial note is not used multiple times (see
-        // comment of `finalize_transfer_to_private`).
+        // make the transaction be more expensive. We don't worry about the validity commitment being checked against
+        // multiple times because it is up to the developer to ensure that a partial note is used only once (see
+        // function docs of `finalize_transfer_to_private`).
         assert(
             context.storage_read(partial_note.compute_validity_commitment(from_and_completer)),
             "Invalid partial note or completer",

--- a/noir-projects/noir-contracts/contracts/app/token_contract/src/main.nr
+++ b/noir-projects/noir-contracts/contracts/app/token_contract/src/main.nr
@@ -468,6 +468,11 @@ pub contract Token {
     /// Finalizes a transfer of token `amount` from public balance of `msg_sender` to a private balance of `to`.
     /// The transfer must be prepared by calling `prepare_private_balance_increase` from `msg_sender` account and
     /// the resulting `partial_note` must be passed as an argument to this function.
+    ///
+    /// Note that this contract does not protect against a `partial_note` being used multiple times and it is up to
+    /// the caller of this function to ensure that it doesn't happen. If the same `partial_note` is used multiple
+    /// times, the token `amount` would most likely get lost (the partial note log processing functionality would fail
+    /// to find the pending partial note when trying to complete it).
     #[public]
     fn finalize_transfer_to_private(amount: u128, partial_note: PartialUintNote) {
         // Completer is the entity that can complete the partial note. In this case, it's the same as the account

--- a/noir-projects/noir-contracts/contracts/app/token_contract/src/main.nr
+++ b/noir-projects/noir-contracts/contracts/app/token_contract/src/main.nr
@@ -526,8 +526,10 @@ pub contract Token {
 
         // We verify that the partial note we're completing is valid (i.e. completer is correct, it uses the correct
         // state variable's storage slot, and it is internally consistent). We *could* clear the storage since each
-        // partial note should only be used once, but since the AVM offers no gas refunds for doing so this would
-        // just make the transaction be more expensive.
+        // partial note should only be used once, but since the AVM offers no gas refunds for doing so this would just
+        // make the transaction be more expensive. We don't worry about the validity commitment being checked against
+        // multiple times because it is up to the caller to ensure that a partial note is used only once (see function
+        // docs of `finalize_transfer_to_private`).
         assert(
             context.storage_read(partial_note.compute_validity_commitment(from_and_completer)),
             "Invalid partial note or completer",


### PR DESCRIPTION
Added a comment to clarify why a partial note should not be reused.

Will copy the comment to the fungible token once I get approval.
