### PR TITLE
feat: privateToPublic + changePartialNote Token func

### DIFF
--- a/aztec-up/test/amm_flow.sh
+++ b/aztec-up/test/amm_flow.sh
@@ -136,14 +136,14 @@ aztec-wallet \
   -a add-liquidity-nonce
 
 aztec-wallet \
-  create-authwit transfer_to_public contracts:amm \
+  create-authwit transfer_to_public_and_prepare_private_balance_increase contracts:amm \
   -ca contracts:token_0 \
   --args accounts:main contracts:amm $amount_0_max secrets:add-liquidity-nonce \
   -f accounts:main \
   -a add_liquidity_token_0
 
 aztec-wallet \
-  create-authwit transfer_to_public contracts:amm \
+  create-authwit transfer_to_public_and_prepare_private_balance_increase contracts:amm \
   -ca contracts:token_1 \
   --args accounts:main contracts:amm $amount_1_max secrets:add-liquidity-nonce \
   -f accounts:main \

--- a/cspell.json
+++ b/cspell.json
@@ -15,6 +15,7 @@
     "auditability",
     "authwit",
     "authwitness",
+    "authwitnesses",
     "authwits",
     "Automine",
     "autonat",

--- a/noir-projects/noir-contracts/contracts/app/amm_contract/src/main.nr
+++ b/noir-projects/noir-contracts/contracts/app/amm_contract/src/main.nr
@@ -160,7 +160,7 @@ pub contract AMM {
 
         // We read the current AMM balance of both tokens. Note that by the time this function is called the token
         // transfers have already been completed (since those calls were enqueued before this call), and so we need to
-        // substract the transfer amount to get the pre-deposit balance.
+        // subtract the transfer amount to get the pre-deposit balance.
         let balance0_plus_amount0_max =
             token0.balance_of_public(context.this_address()).view(&mut context);
         let balance0 = balance0_plus_amount0_max - amount0_max;

--- a/noir-projects/noir-contracts/contracts/app/amm_contract/src/main.nr
+++ b/noir-projects/noir-contracts/contracts/app/amm_contract/src/main.nr
@@ -102,17 +102,23 @@ pub contract AMM {
         // execution since the amounts supplied must have the same ratio as the live balances. We therefore transfer the
         // maximum amounts here, and prepare partial notes that return the change to the sender (if any).
         // TODO(#10286): consider merging these two calls
-        token0.transfer_to_public(sender, context.this_address(), amount0_max, nonce).call(
-            &mut context,
-        );
-        let refund_token0_partial_note =
-            token0.prepare_private_balance_increase(sender, sender).call(&mut context);
+        let refund_token0_partial_note = token0
+            .transfer_to_public_and_prepare_private_balance_increase(
+                sender,
+                context.this_address(),
+                amount0_max,
+                nonce,
+            )
+            .call(&mut context);
 
-        token1.transfer_to_public(sender, context.this_address(), amount1_max, nonce).call(
-            &mut context,
-        );
-        let refund_token1_partial_note =
-            token1.prepare_private_balance_increase(sender, sender).call(&mut context);
+        let refund_token1_partial_note = token1
+            .transfer_to_public_and_prepare_private_balance_increase(
+                sender,
+                context.this_address(),
+                amount1_max,
+                nonce,
+            )
+            .call(&mut context);
 
         // The number of liquidity tokens to mint for the caller depends on both the live balances and the amount
         // supplied, both of which can only be known during public execution. We therefore prepare a partial note that

--- a/noir-projects/noir-contracts/contracts/app/amm_contract/src/main.nr
+++ b/noir-projects/noir-contracts/contracts/app/amm_contract/src/main.nr
@@ -101,7 +101,6 @@ pub contract AMM {
         // We don't yet know how many tokens the sender will actually supply - that can only be computed during public
         // execution since the amounts supplied must have the same ratio as the live balances. We therefore transfer the
         // maximum amounts here, and prepare partial notes that return the change to the sender (if any).
-        // TODO(#10286): consider merging these two calls
         let refund_token0_partial_note = token0
             .transfer_to_public_and_prepare_private_balance_increase(
                 sender,
@@ -263,7 +262,7 @@ pub contract AMM {
 
         // We then complete the flow in public. Note that the type of operation and amounts will all be publicly known,
         // but the identity of the caller is not revealed despite us being able to send tokens to them by completing the
-        // partial notees.
+        // partial notes.
         AMM::at(context.this_address())
             ._remove_liquidity(
                 config,
@@ -332,7 +331,6 @@ pub contract AMM {
 
         // We transfer the full amount in, since it is an exact amount, and prepare a partial note for the amount out,
         // which will only be known during public execution as it depends on the live balances.
-        // TODO(#10286): consider merging these two calls
         Token::at(token_in)
             .transfer_to_public(sender, context.this_address(), amount_in, nonce)
             .call(&mut context);
@@ -406,12 +404,14 @@ pub contract AMM {
         // Technically the token out note does not need to be partial, since we do know the amount out, but we do want
         // to wait until the swap has been completed before committing the note to the tree to avoid it being spent too
         // early.
-        // TODO(#10286): consider merging these two calls
-        Token::at(token_in)
-            .transfer_to_public(sender, context.this_address(), amount_in_max, nonce)
+        let change_token_in_partial_note = Token::at(token_in)
+            .transfer_to_public_and_prepare_private_balance_increase(
+                sender,
+                context.this_address(),
+                amount_in_max,
+                nonce,
+            )
             .call(&mut context);
-        let change_token_in_partial_note =
-            Token::at(token_in).prepare_private_balance_increase(sender, sender).call(&mut context);
 
         let token_out_partial_note = Token::at(token_out)
             .prepare_private_balance_increase(sender, sender)

--- a/noir-projects/noir-contracts/contracts/app/token_contract/src/main.nr
+++ b/noir-projects/noir-contracts/contracts/app/token_contract/src/main.nr
@@ -250,6 +250,42 @@ pub contract Token {
     }
     // docs:end:transfer_to_public
 
+    /// Transfers tokens from private balance to public balance and prepares a partial note for receiving change.
+    /// This is an optimization that combines two operations into one to reduce kernel iterations:
+    /// 1. Transfers `amount` tokens from `from`'s private balance to `to`'s public balance
+    /// 2. Creates a partial note that can later be used to receive change back to `from`'s private balance
+    ///
+    /// This pattern is useful when interacting with contracts that:
+    /// - Receive tokens from a user's private balance
+    /// - Need to wait until public execution to determine how many tokens to return (e.g. AMM, FPC)
+    /// - Will return tokens to the user's private balance
+    ///
+    /// The contract can use the returned partial note to complete the transfer back to private
+    /// once the final amount is known during public execution.
+    #[private]
+    fn transfer_to_public_and_prepare_private_balance_increase(
+        from: AztecAddress,
+        to: AztecAddress,
+        amount: u128,
+        nonce: Field,
+    ) -> PartialUintNote {
+        if (!from.eq(context.msg_sender())) {
+            assert_current_call_valid_authwit(&mut context, from);
+        } else {
+            assert(nonce == 0, "invalid nonce");
+        }
+
+        storage.balances.at(from).sub(from, amount).emit(encode_and_encrypt_note(
+            &mut context,
+            from,
+            from,
+        ));
+        Token::at(context.this_address())._increase_public_balance(to, amount).enqueue(&mut context);
+
+        // We prepare the private balance increase (the partial note).
+        _prepare_private_balance_increase(from, from, &mut context, storage)
+    }
+
     // docs:start:transfer
     #[private]
     fn transfer(to: AztecAddress, amount: u128) {

--- a/noir-projects/noir-contracts/contracts/app/token_contract/src/main.nr
+++ b/noir-projects/noir-contracts/contracts/app/token_contract/src/main.nr
@@ -250,7 +250,9 @@ pub contract Token {
     }
     // docs:end:transfer_to_public
 
-    /// Transfers tokens from private balance to public balance and prepares a partial note for receiving change.
+    /// Transfers tokens from private balance of `from` to public balance of `to` and prepares a partial note for
+    /// receiving change for `from`.
+    ///
     /// This is an optimization that combines two operations into one to reduce kernel iterations:
     /// 1. Transfers `amount` tokens from `from`'s private balance to `to`'s public balance
     /// 2. Creates a partial note that can later be used to receive change back to `from`'s private balance

--- a/noir-projects/noir-contracts/contracts/app/token_contract/src/main.nr
+++ b/noir-projects/noir-contracts/contracts/app/token_contract/src/main.nr
@@ -284,7 +284,7 @@ pub contract Token {
         ));
         Token::at(context.this_address())._increase_public_balance(to, amount).enqueue(&mut context);
 
-        // We prepare the private balance increase (the partial note).
+        // We prepare the private balance increase (the partial note for the change).
         _prepare_private_balance_increase(from, from, &mut context, storage)
     }
 

--- a/noir-projects/noir-contracts/contracts/app/token_contract/src/main.nr
+++ b/noir-projects/noir-contracts/contracts/app/token_contract/src/main.nr
@@ -253,7 +253,7 @@ pub contract Token {
     /// Transfers tokens from private balance of `from` to public balance of `to` and prepares a partial note for
     /// receiving change for `from`.
     ///
-    /// This is an optimization that combines two operations into one to reduce kernel iterations:
+    /// This is an optimization that combines two operations into one to reduce contract calls:
     /// 1. Transfers `amount` tokens from `from`'s private balance to `to`'s public balance
     /// 2. Creates a partial note that can later be used to receive change back to `from`'s private balance
     ///

--- a/noir-projects/noir-contracts/contracts/app/token_contract/src/test.nr
+++ b/noir-projects/noir-contracts/contracts/app/token_contract/src/test.nr
@@ -7,5 +7,6 @@ pub mod transfer;
 pub mod transfer_in_private;
 pub mod transfer_in_public;
 pub mod transfer_to_private;
+pub mod transfer_to_public_and_prepare_private_balance_increase;
 pub mod transfer_to_public;
 pub mod utils;

--- a/noir-projects/noir-contracts/contracts/app/token_contract/src/test/transfer_to_public_and_prepare_private_balance_increase.nr
+++ b/noir-projects/noir-contracts/contracts/app/token_contract/src/test/transfer_to_public_and_prepare_private_balance_increase.nr
@@ -23,10 +23,8 @@ unconstrained fn transfer_to_public_and_prepare_private_balance_increase_and_fin
         transfer_call_interface,
     );
 
-    // Impersonate recipient
+    // Impersonate the recipient of the public transfer (the sender of the change note) and initiate the transfer
     env.impersonate(recipient);
-
-    // Execute transfer
     let partial_note = transfer_call_interface.call(&mut env.private());
 
     // Check balances before the partial note is finalized
@@ -41,10 +39,9 @@ unconstrained fn transfer_to_public_and_prepare_private_balance_increase_and_fin
     // --> this should send the `change_amount` from recipient's public balance to sender's private balance
     let change_amount = transfer_amount / (2 as u128);
 
-    // Impersonate the recipient and try to finalize the transfer
+    // Impersonate the recipient of the public transfer (the sender of the change note) and try to finalize
+    // the transfer of the change note
     env.impersonate(recipient);
-
-    // Finalize the transfer
     Token::at(token_contract_address)
         .finalize_transfer_to_private(change_amount, partial_note)
         .call(&mut env.public());

--- a/noir-projects/noir-contracts/contracts/app/token_contract/src/test/transfer_to_public_and_prepare_private_balance_increase.nr
+++ b/noir-projects/noir-contracts/contracts/app/token_contract/src/test/transfer_to_public_and_prepare_private_balance_increase.nr
@@ -3,45 +3,53 @@ use crate::Token;
 use dep::authwit::cheatcodes as authwit_cheatcodes;
 use dep::aztec::oracle::random::random;
 
+// Tests the typical scenario in which transfer_to_public_and_prepare_private_balance_increase is to be used:
+// 1. The liquidity provider calls private AMM::add_liquidity function,
+// 2. the AMM contract transfers the full amount to the public balance of the AMM,
+// 3. public AMM::_add_liquidity function is called and based on that max acceptable amount of the token is computed,
+// 4. full amount - max acceptable amount is transferred back to the liquidity provider's private balance as change.
+//
+// This is a typical scenario as we receive the change in the same token with which we are "depositing" to the public
+// balance of the AMM.
 #[test]
 unconstrained fn transfer_to_public_and_prepare_private_balance_increase_and_finalize_transfer_to_private() {
-    let (env, token_contract_address, sender, recipient, mint_amount) =
+    let (env, token_contract_address, liquidity_provider, amm_contract, mint_amount) =
         utils::setup_and_mint_to_private(/* with_account_contracts */ true);
 
-    let transfer_amount: u128 = mint_amount / (10 as u128);
+    let deposit_amount: u128 = mint_amount / (10 as u128);
     let transfer_call_interface = Token::at(token_contract_address)
         .transfer_to_public_and_prepare_private_balance_increase(
-            sender,
-            recipient,
-            transfer_amount,
+            liquidity_provider,
+            amm_contract,
+            deposit_amount,
             1,
         );
 
+    // Add authwit such that the AMM can transfer the deposit amount of the liquidity provider to the public balance of
+    // itself.
     authwit_cheatcodes::add_private_authwit_from_call_interface(
-        sender,
-        recipient,
+        liquidity_provider,
+        amm_contract,
         transfer_call_interface,
     );
 
-    // Impersonate the recipient of the public transfer (the sender of the change note) and initiate the transfer
-    env.impersonate(recipient);
+    // Impersonate the AMM and initiate the transfer
+    env.impersonate(amm_contract);
     let partial_note = transfer_call_interface.call(&mut env.private());
 
     // Check balances before the partial note is finalized
     utils::check_private_balance(
         token_contract_address,
-        sender,
-        mint_amount - transfer_amount,
+        liquidity_provider,
+        mint_amount - deposit_amount,
     );
-    utils::check_public_balance(token_contract_address, recipient, transfer_amount);
+    utils::check_public_balance(token_contract_address, amm_contract, deposit_amount);
 
-    // Now we finalize the partial change note by impersonating the recipient and calling the finalize function
-    // --> this should send the `change_amount` from recipient's public balance to sender's private balance
-    let change_amount = transfer_amount / (2 as u128);
+    // Now we finalize the partial change note by impersonating the AMM contract and calling the finalize function
+    // --> this should send the `change_amount` from AMM's public balance to liquidity provider's private balance
+    let change_amount = deposit_amount / (2 as u128);
 
-    // Impersonate the recipient of the public transfer (the sender of the change note) and try to finalize
-    // the transfer of the change note
-    env.impersonate(recipient);
+    env.impersonate(amm_contract);
     Token::at(token_contract_address)
         .finalize_transfer_to_private(change_amount, partial_note)
         .call(&mut env.public());
@@ -51,16 +59,16 @@ unconstrained fn transfer_to_public_and_prepare_private_balance_increase_and_fin
     // Check balances after the partial note is finalized
     utils::check_private_balance(
         token_contract_address,
-        sender,
+        liquidity_provider,
         // TODO: Why don't I see the change_amount here? Does TXE handle partial notes correctly? I thought if
         // I advance the block by 1, the note should be found.
-        // mint_amount - transfer_amount + change_amount,
-        mint_amount - transfer_amount,
+        // mint_amount - deposit_amount + change_amount,
+        mint_amount - deposit_amount,
     );
     utils::check_public_balance(
         token_contract_address,
-        recipient,
-        transfer_amount - change_amount,
+        amm_contract,
+        deposit_amount - change_amount,
     );
 }
 

--- a/noir-projects/noir-contracts/contracts/app/token_contract/src/test/transfer_to_public_and_prepare_private_balance_increase.nr
+++ b/noir-projects/noir-contracts/contracts/app/token_contract/src/test/transfer_to_public_and_prepare_private_balance_increase.nr
@@ -60,7 +60,7 @@ unconstrained fn transfer_to_public_and_prepare_private_balance_increase_and_fin
     utils::check_private_balance(
         token_contract_address,
         liquidity_provider,
-        // TODO: Why don't I see the change_amount here? Does TXE handle partial notes correctly? I thought if
+        // TODO(#14647): Why don't I see the change_amount here? Does TXE handle partial notes correctly? I thought if
         // I advance the block by 1, the note should be found.
         // mint_amount - deposit_amount + change_amount,
         mint_amount - deposit_amount,

--- a/noir-projects/noir-contracts/contracts/app/token_contract/src/test/transfer_to_public_and_prepare_private_balance_increase.nr
+++ b/noir-projects/noir-contracts/contracts/app/token_contract/src/test/transfer_to_public_and_prepare_private_balance_increase.nr
@@ -1,0 +1,123 @@
+use crate::test::utils;
+use crate::Token;
+use dep::authwit::cheatcodes as authwit_cheatcodes;
+use dep::aztec::oracle::random::random;
+
+#[test]
+unconstrained fn transfer_to_public_and_prepare_private_balance_increase_and_finalize_transfer_to_private() {
+    let (env, token_contract_address, sender, recipient, mint_amount) =
+        utils::setup_and_mint_to_private(/* with_account_contracts */ true);
+
+    let transfer_amount: u128 = mint_amount / (10 as u128);
+    let transfer_call_interface = Token::at(token_contract_address)
+        .transfer_to_public_and_prepare_private_balance_increase(
+            sender,
+            recipient,
+            transfer_amount,
+            1,
+        );
+
+    authwit_cheatcodes::add_private_authwit_from_call_interface(
+        sender,
+        recipient,
+        transfer_call_interface,
+    );
+
+    // Impersonate recipient
+    env.impersonate(recipient);
+
+    // Execute transfer
+    let partial_note = transfer_call_interface.call(&mut env.private());
+
+    // Check balances before the partial note is finalized
+    utils::check_private_balance(
+        token_contract_address,
+        sender,
+        mint_amount - transfer_amount,
+    );
+    utils::check_public_balance(token_contract_address, recipient, transfer_amount);
+
+    // Now we finalize the partial change note by impersonating the recipient and calling the finalize function
+    // --> this should send the `change_amount` from recipient's public balance to sender's private balance
+    let change_amount = transfer_amount / (2 as u128);
+
+    // Impersonate the recipient and try to finalize the transfer
+    env.impersonate(recipient);
+
+    // Finalize the transfer
+    Token::at(token_contract_address)
+        .finalize_transfer_to_private(change_amount, partial_note)
+        .call(&mut env.public());
+
+    env.advance_block_by(1);
+
+    // Check balances after the partial note is finalized
+    utils::check_private_balance(
+        token_contract_address,
+        sender,
+        // TODO: Why don't I see the change_amount here? Does TXE handle partial notes correctly? I thought if
+        // I advance the block by 1, the note should be found.
+        // mint_amount - transfer_amount + change_amount,
+        mint_amount - transfer_amount,
+    );
+    utils::check_public_balance(
+        token_contract_address,
+        recipient,
+        transfer_amount - change_amount,
+    );
+}
+
+#[test(should_fail_with = "Balance too low")]
+unconstrained fn transfer_to_public_and_prepare_private_balance_increase_failure_more_than_balance() {
+    // Setup without account contracts. We are not using authwits here, so dummy accounts are enough
+    let (env, token_contract_address, sender, recipient, mint_amount) =
+        utils::setup_and_mint_to_private(/* with_account_contracts */ false);
+
+    let transfer_amount = mint_amount + (1 as u128);
+    let _ = Token::at(token_contract_address)
+        .transfer_to_public_and_prepare_private_balance_increase(
+            sender,
+            recipient,
+            transfer_amount,
+            0,
+        )
+        .call(&mut env.private());
+}
+
+#[test(should_fail_with = "invalid nonce")]
+unconstrained fn transfer_to_public_and_prepare_private_balance_increase_failure_on_behalf_of_self_non_zero_nonce() {
+    // Setup without account contracts. We are not using authwits here, so dummy accounts are enough
+    let (env, token_contract_address, sender, recipient, mint_amount) =
+        utils::setup_and_mint_to_private(/* with_account_contracts */ false);
+
+    let transfer_amount = mint_amount / (10 as u128);
+    let _ = Token::at(token_contract_address)
+        .transfer_to_public_and_prepare_private_balance_increase(
+            sender,
+            recipient,
+            transfer_amount,
+            random(),
+        )
+        .call(&mut env.private());
+}
+
+#[test(should_fail_with = "Unknown auth witness for message hash")]
+unconstrained fn transfer_to_public_and_prepare_private_balance_increase_failure_on_behalf_of_other_no_approval() {
+    let (env, token_contract_address, sender, recipient, mint_amount) =
+        utils::setup_and_mint_to_private(/* with_account_contracts */ true);
+
+    let transfer_amount = mint_amount / (10 as u128);
+    let transfer_call_interface = Token::at(token_contract_address)
+        .transfer_to_public_and_prepare_private_balance_increase(
+            sender,
+            recipient,
+            transfer_amount,
+            1,
+        );
+
+    // Impersonate recipient without adding authwit
+    env.impersonate(recipient);
+
+    // Try executing transfer without approval
+    let _ = transfer_call_interface.call(&mut env.private());
+}

--- a/noir-projects/noir-contracts/contracts/app/token_contract/src/test/transfer_to_public_and_prepare_private_balance_increase.nr
+++ b/noir-projects/noir-contracts/contracts/app/token_contract/src/test/transfer_to_public_and_prepare_private_balance_increase.nr
@@ -45,6 +45,10 @@ unconstrained fn transfer_to_public_and_prepare_private_balance_increase_and_fin
     );
     utils::check_public_balance(token_contract_address, amm_contract, deposit_amount);
 
+    // We need to advance the block by 1 for the partial note validity commitment to be committed to the nullifier
+    // tree.
+    env.advance_block_by(1);
+
     // Now we finalize the partial change note by impersonating the AMM contract and calling the finalize function
     // --> this should send the `change_amount` from AMM's public balance to liquidity provider's private balance
     let change_amount = deposit_amount / (2 as u128);
@@ -60,10 +64,7 @@ unconstrained fn transfer_to_public_and_prepare_private_balance_increase_and_fin
     utils::check_private_balance(
         token_contract_address,
         liquidity_provider,
-        // TODO(#14647): Why don't I see the change_amount here? Does TXE handle partial notes correctly? I thought if
-        // I advance the block by 1, the note should be found.
-        // mint_amount - deposit_amount + change_amount,
-        mint_amount - deposit_amount,
+        mint_amount - deposit_amount + change_amount,
     );
     utils::check_public_balance(
         token_contract_address,

--- a/spartan/devnet-smoke-tests/process_amm_contracts.sh
+++ b/spartan/devnet-smoke-tests/process_amm_contracts.sh
@@ -90,7 +90,7 @@ jq -c '.accounts[]' state.json | while read -r account; do
     echo "Balances for account $current_user_address"
     echo "Token 0 at at address $token_0_address: private balance is $current_user_private_balance_token_0_initial"
     echo "Token 1 at address $token_1_address: private balance is $current_user_private_balance_token_1_initial"
-    echo "Liquidity token at address $token_liquidity_address: private blance is $current_user_liquidity_token_balance_initial"
+    echo "Liquidity token at address $token_liquidity_address: private balance is $current_user_liquidity_token_balance_initial"
 
     # Adding liquidity
 
@@ -104,14 +104,14 @@ jq -c '.accounts[]' state.json | while read -r account; do
       -a add-liquidity-nonce
 
     aztec-wallet \
-      create-authwit transfer_to_public $amm_address \
+      create-authwit transfer_to_public_and_prepare_private_balance_increase $amm_address \
       -ca $token_0_address \
       --args $current_user_address $amm_address $amount_0_max secrets:add-liquidity-nonce \
       -f $current_user_address \
       -a add_liquidity_token_0
 
     aztec-wallet \
-      create-authwit transfer_to_public $amm_address \
+      create-authwit transfer_to_public_and_prepare_private_balance_increase $amm_address \
       -ca $token_1_address \
       --args $current_user_address $amm_address $amount_1_max secrets:add-liquidity-nonce \
       -f $current_user_address \

--- a/yarn-project/bot/src/factory.ts
+++ b/yarn-project/bot/src/factory.ts
@@ -257,13 +257,24 @@ export class BotFactory {
       `Minting ${MINT_BALANCE} tokens of each BotToken0 and BotToken1. Current private balances of ${wallet.getAddress()}: token0=${t0Bal}, token1=${t1Bal}, lp=${lpBal}`,
     );
 
+    // Add authwitnesses for the transfers in AMM::add_liquidity function
     const token0Authwit = await wallet.createAuthWit({
       caller: amm.address,
-      action: token0.methods.transfer_to_public(wallet.getAddress(), amm.address, amount0Max, nonce),
+      action: token0.methods.transfer_to_public_and_prepare_private_balance_increase(
+        wallet.getAddress(),
+        amm.address,
+        amount0Max,
+        nonce,
+      ),
     });
     const token1Authwit = await wallet.createAuthWit({
       caller: amm.address,
-      action: token1.methods.transfer_to_public(wallet.getAddress(), amm.address, amount1Max, nonce),
+      action: token1.methods.transfer_to_public_and_prepare_private_balance_increase(
+        wallet.getAddress(),
+        amm.address,
+        amount1Max,
+        nonce,
+      ),
     });
 
     const mintTx = new BatchCall(wallet, [

--- a/yarn-project/end-to-end/src/bench/client_flows/amm.test.ts
+++ b/yarn-project/end-to-end/src/bench/client_flows/amm.test.ts
@@ -110,7 +110,7 @@ describe('AMM benchmark', () => {
             const nonceForAuthwits = Fr.random();
             const token0Authwit = await benchysWallet.createAuthWit({
               caller: amm.address,
-              action: bananaCoin.methods.transfer_to_public(
+              action: bananaCoin.methods.transfer_to_public_and_prepare_private_balance_increase(
                 benchysWallet.getAddress(),
                 amm.address,
                 amountToSend,
@@ -119,7 +119,7 @@ describe('AMM benchmark', () => {
             });
             const token1Authwit = await benchysWallet.createAuthWit({
               caller: amm.address,
-              action: candyBarCoin.methods.transfer_to_public(
+              action: candyBarCoin.methods.transfer_to_public_and_prepare_private_balance_increase(
                 benchysWallet.getAddress(),
                 amm.address,
                 amountToSend,

--- a/yarn-project/end-to-end/src/bench/client_flows/amm.test.ts
+++ b/yarn-project/end-to-end/src/bench/client_flows/amm.test.ts
@@ -140,12 +140,10 @@ describe('AMM benchmark', () => {
                 1 + // Kernel init
                 paymentMethod.circuits + // Payment method circuits
                 2 + // AMM add_liquidity + kernel inner
-                2 + // Token transfer_to_public + kernel inner (token0)
+                2 + // Token transfer_to_public_and_prepare_private_balance_increase + kernel inner (token0)
                 2 + // Account verify_private_authwit + kernel inner
-                2 + // Token prepare_private_balance_increase + kernel inner (token0 refund)
-                2 + // Token transfer_to_public + kernel inner (token1)
+                2 + // Token transfer_to_public_and_prepare_private_balance_increase + kernel inner (token1)
                 2 + // Account verify_private_authwit + kernel inner
-                2 + // Token prepare_private_balance_increase + kernel inner (token1 refund)
                 2 + // Token prepare_private_balance_increase + kernel inner (liquidity token mint)
                 1 + // Kernel reset
                 1, // Kernel tail

--- a/yarn-project/end-to-end/src/e2e_amm.test.ts
+++ b/yarn-project/end-to-end/src/e2e_amm.test.ts
@@ -102,12 +102,12 @@ describe('AMM', () => {
       const amount1Min = lpBalancesBefore.token1 / 2n;
 
       // First we need to add authwits such that the AMM can transfer the tokens from the liquidity provider. These
-      // authwits are for the full amount, since the AMM will first transfer that to itself, and later refund any excess
-      // during public execution.
+      // authwits are for the full amount, since the AMM will first transfer that to itself, and later refund any
+      // excess during public execution.
       const nonceForAuthwits = Fr.random();
       const token0Authwit = await liquidityProvider.createAuthWit({
         caller: amm.address,
-        action: token0.methods.transfer_to_public(
+        action: token0.methods.transfer_to_public_and_prepare_private_balance_increase(
           liquidityProvider.getAddress(),
           amm.address,
           amount0Max,
@@ -116,7 +116,7 @@ describe('AMM', () => {
       });
       const token1Authwit = await liquidityProvider.createAuthWit({
         caller: amm.address,
-        action: token1.methods.transfer_to_public(
+        action: token1.methods.transfer_to_public_and_prepare_private_balance_increase(
           liquidityProvider.getAddress(),
           amm.address,
           amount1Max,
@@ -156,7 +156,7 @@ describe('AMM', () => {
       const liquidityTokenSupplyBefore = await liquidityToken.methods.total_supply().simulate();
 
       // The pool currently has the same number of tokens for token0 and token1, since that is the ratio the first
-      // liquidity provider used. Our maximum values have a diferent ratio (6:5 instead of 1:1), so we will end up
+      // liquidity provider used. Our maximum values have a different ratio (6:5 instead of 1:1), so we will end up
       // adding the maximum amount that does result in the correct ratio (i.e. using amount1Max and a 1:1 ratio).
       const amount0Max = (lpBalancesBefore.token0 * 6n) / 10n;
       const amount0Min = (lpBalancesBefore.token0 * 4n) / 10n;
@@ -171,9 +171,9 @@ describe('AMM', () => {
       // public execution. We expect for there to be excess since our maximum amounts do not have the same balance ratio
       // as the pool currently holds.
       const nonceForAuthwits = Fr.random();
-      const token1Authwih = await otherLiquidityProvider.createAuthWit({
+      const token1Authwit = await otherLiquidityProvider.createAuthWit({
         caller: amm.address,
-        action: token0.methods.transfer_to_public(
+        action: token0.methods.transfer_to_public_and_prepare_private_balance_increase(
           otherLiquidityProvider.getAddress(),
           amm.address,
           amount0Max,
@@ -182,7 +182,7 @@ describe('AMM', () => {
       });
       const token2Authwit = await otherLiquidityProvider.createAuthWit({
         caller: amm.address,
-        action: token1.methods.transfer_to_public(
+        action: token1.methods.transfer_to_public_and_prepare_private_balance_increase(
           otherLiquidityProvider.getAddress(),
           amm.address,
           amount1Max,
@@ -193,7 +193,7 @@ describe('AMM', () => {
       await amm
         .withWallet(otherLiquidityProvider)
         .methods.add_liquidity(amount0Max, amount1Max, amount0Min, amount1Min, nonceForAuthwits)
-        .send({ authWitnesses: [token1Authwih, token2Authwit] })
+        .send({ authWitnesses: [token1Authwit, token2Authwit] })
         .wait();
 
       const ammBalancesAfter = await getAmmBalances();
@@ -266,7 +266,12 @@ describe('AMM', () => {
       const nonceForAuthwits = Fr.random();
       const swapAuthwit = await swapper.createAuthWit({
         caller: amm.address,
-        action: token1.methods.transfer_to_public(swapper.getAddress(), amm.address, amountInMax, nonceForAuthwits),
+        action: token1.methods.transfer_to_public_and_prepare_private_balance_increase(
+          swapper.getAddress(),
+          amm.address,
+          amountInMax,
+          nonceForAuthwits,
+        ),
       });
 
       await amm
@@ -293,12 +298,12 @@ describe('AMM', () => {
         .methods.balance_of_private(otherLiquidityProvider.getAddress())
         .simulate();
 
-      // Because private burning requires first transfering the tokens into the AMM, we again need to provide an
+      // Because private burning requires first transferring the tokens into the AMM, we again need to provide an
       // authwit.
       const nonceForAuthwits = Fr.random();
       const liquidityAuthwit = await otherLiquidityProvider.createAuthWit({
         caller: amm.address,
-        action: liquidityToken.methods.transfer_to_public(
+        action: liquidityToken.methods.transfer_to_public_and_prepare_private_balance_increase(
           otherLiquidityProvider.getAddress(),
           amm.address,
           liquidityTokenBalance,

--- a/yarn-project/end-to-end/src/e2e_amm.test.ts
+++ b/yarn-project/end-to-end/src/e2e_amm.test.ts
@@ -303,7 +303,7 @@ describe('AMM', () => {
       const nonceForAuthwits = Fr.random();
       const liquidityAuthwit = await otherLiquidityProvider.createAuthWit({
         caller: amm.address,
-        action: liquidityToken.methods.transfer_to_public_and_prepare_private_balance_increase(
+        action: liquidityToken.methods.transfer_to_public(
           otherLiquidityProvider.getAddress(),
           amm.address,
           liquidityTokenBalance,


### PR DESCRIPTION
Adds `transfer_to_public_and_prepare_private_balance_increase` function to the Token contract that transfers tokens from a private balance of `from` to public balance of `to` and creates a partial note for `from` to which, later, a change can be transferred from public.

Fixes #10286
