### PR TITLE
fix: auto-update bucket

### DIFF
--- a/spartan/terraform/gke-cluster/cluster/main.tf
+++ b/spartan/terraform/gke-cluster/cluster/main.tf
@@ -202,7 +202,7 @@ resource "google_container_node_pool" "aztec_nodes-8core" {
   # Enable autoscaling
   autoscaling {
     min_node_count = 0
-    max_node_count = 50
+    max_node_count = 1
   }
 
   # Node configuration

--- a/spartan/terraform/gke-cluster/cluster/main.tf
+++ b/spartan/terraform/gke-cluster/cluster/main.tf
@@ -193,42 +193,6 @@ resource "google_container_node_pool" "spot_nodes_32core" {
   }
 }
 
-# 8 Core nodes
-resource "google_container_node_pool" "aztec_nodes-8core" {
-  name     = "${var.cluster_name}-8core"
-  location = var.zone
-  cluster  = var.cluster_name
-  version  = var.node_version
-  # Enable autoscaling
-  autoscaling {
-    min_node_count = 0
-    max_node_count = 1
-  }
-
-  # Node configuration
-  node_config {
-    machine_type = "t2d-standard-8"
-
-    service_account = var.service_account
-    oauth_scopes = [
-      "https://www.googleapis.com/auth/cloud-platform"
-    ]
-
-    labels = {
-      env       = "production"
-      local-ssd = "false"
-      node-type = "network"
-    }
-    tags = ["aztec-gke-node", "aztec"]
-  }
-
-  # Management configuration
-  management {
-    auto_repair  = true
-    auto_upgrade = false
-  }
-}
-
 # Create 8 core spot instance node pool with autoscaling
 resource "google_container_node_pool" "spot_nodes_8core" {
   name     = "${var.cluster_name}-8core-spot"

--- a/spartan/terraform/gke-cluster/iam.tf
+++ b/spartan/terraform/gke-cluster/iam.tf
@@ -39,3 +39,13 @@ resource "google_project_iam_member" "helm_sa_roles" {
   role    = each.key
   member  = "serviceAccount:${google_service_account.helm_sa.email}"
 }
+
+data "google_iam_policy" "all_users_storage_read" {
+  binding {
+    role = "roles/storage.objectViewer"
+    members = [
+      "allUsers",
+    ]
+  }
+}
+

--- a/spartan/terraform/gke-cluster/snapshots.tf
+++ b/spartan/terraform/gke-cluster/snapshots.tf
@@ -30,3 +30,26 @@ resource "google_storage_bucket" "snapshots-bucket" {
       }
     }
 }
+
+resource "google_storage_managed_folder" "aztec_testnet_auto_update_folder" {
+  bucket        = google_storage_bucket.snapshots-bucket.name
+  name          = "auto-update/"
+  force_destroy = true
+}
+
+resource "google_storage_managed_folder_iam_policy" "aztec_testnet_auto_update_folder_policy" {
+  bucket         = google_storage_managed_folder.aztec_testnet_auto_update_folder.bucket
+  managed_folder = google_storage_managed_folder.aztec_testnet_auto_update_folder.name
+  policy_data    = data.google_iam_policy.all_users_storage_read.policy_data
+}
+
+resource "google_storage_bucket_object" "alpha_testnet_json" {
+  bucket = google_storage_managed_folder.aztec_testnet_auto_update_folder.bucket
+  name   = "${google_storage_managed_folder.aztec_testnet_auto_update_folder.name}alpha-testnet.json"
+  content_type = "application/json"
+  # see yarn-project/foundation/src/update-checker/update-checker.ts for latest schema
+  content = jsonencode({
+    config = {}
+  })
+}
+

--- a/yarn-project/aztec/src/cli/chain_l2_config.ts
+++ b/yarn-project/aztec/src/cli/chain_l2_config.ts
@@ -65,8 +65,8 @@ export const alphaTestnetL2ChainConfig: L2ChainConfig = {
   seqMaxTxsPerBlock: 20,
   realProofs: true,
   snapshotsUrl: 'https://storage.googleapis.com/aztec-testnet/snapshots/',
-  autoUpdate: 'enabled',
-  autoUpdateUrl: 'https://storage.googleapis.com/aztec-testnet/auto-update/',
+  autoUpdate: 'config-and-version',
+  autoUpdateUrl: 'https://storage.googleapis.com/aztec-testnet/auto-update/alpha-testnet.json',
 };
 
 export async function getBootnodes(networkName: NetworkNames) {

--- a/yarn-project/aztec/src/cli/cmds/start_node.ts
+++ b/yarn-project/aztec/src/cli/cmds/start_node.ts
@@ -189,7 +189,7 @@ export async function startNode(
     await setupUpdateMonitor(
       nodeConfig.autoUpdate,
       new URL(nodeConfig.autoUpdateUrl),
-      followsCanonicalRollup ? 'canonical' : nodeConfig.rollupVersion,
+      followsCanonicalRollup,
       getPublicClient(nodeConfig!),
       nodeConfig.l1Contracts.registryAddress,
       signalHandlers,

--- a/yarn-project/aztec/src/cli/cmds/start_prover_node.ts
+++ b/yarn-project/aztec/src/cli/cmds/start_prover_node.ts
@@ -125,7 +125,7 @@ export async function startProverNode(
     await setupUpdateMonitor(
       proverConfig.autoUpdate,
       new URL(proverConfig.autoUpdateUrl),
-      followsCanonicalRollup ? 'canonical' : proverConfig.rollupVersion,
+      followsCanonicalRollup,
       getPublicClient(proverConfig),
       proverConfig.l1Contracts.registryAddress,
       signalHandlers,

--- a/yarn-project/node-lib/src/config/index.ts
+++ b/yarn-project/node-lib/src/config/index.ts
@@ -11,7 +11,7 @@ export type SharedNodeConfig = {
   snapshotsUrl?: string;
 
   /** Auto update mode: disabled - to completely ignore remote signals to update the node. enabled - to respect the signals (potentially shutting this node down). log - check for updates but log a warning instead of applying them*/
-  autoUpdate?: 'disabled' | 'enabled' | 'notify';
+  autoUpdate?: 'disabled' | 'notify' | 'config' | 'config-and-version';
   /** The base URL against which to check for updates */
   autoUpdateUrl?: string;
 };

--- a/yarn-project/stdlib/src/interfaces/aztec-node.ts
+++ b/yarn-project/stdlib/src/interfaces/aztec-node.ts
@@ -552,7 +552,7 @@ export function createAztecNodeClient(
   url: string,
   versions: Partial<ComponentsVersions> = {},
   fetch = makeFetch([1, 2, 3], false),
-  batchWindowMS = 25,
+  batchWindowMS = 0,
 ): AztecNode {
   return createSafeJsonRpcClient<AztecNode>(url, AztecNodeApiSchema, {
     namespaceMethods: 'node',

--- a/yarn-project/stdlib/src/update-checker/update-checker.test.ts
+++ b/yarn-project/stdlib/src/update-checker/update-checker.test.ts
@@ -1,5 +1,4 @@
 import { randomBigInt } from '@aztec/foundation/crypto';
-import { EthAddress } from '@aztec/foundation/eth-address';
 
 import { jest } from '@jest/globals';
 

--- a/yarn-project/stdlib/src/update-checker/update-checker.test.ts
+++ b/yarn-project/stdlib/src/update-checker/update-checker.test.ts
@@ -1,3 +1,4 @@
+import { randomBigInt } from '@aztec/foundation/crypto';
 import { EthAddress } from '@aztec/foundation/eth-address';
 
 import { jest } from '@jest/globals';
@@ -7,8 +8,8 @@ import { type EventMap, UpdateChecker } from './update-checker.js';
 describe('UpdateChecker', () => {
   let checker: UpdateChecker;
   let fetch: jest.Mock<typeof globalThis.fetch>;
-  let getRollupAddress: jest.Mock<(version: number | 'canonical') => Promise<EthAddress>>;
-  let rollupAddressAtStart: EthAddress;
+  let getCanonicalRollupVersion: jest.Mock<() => Promise<bigint>>;
+  let rollupVersionAtStart: bigint;
   let nodeVersionAtStart: string;
   let eventHandlers: {
     [K in keyof EventMap]: jest.Mock<(...args: EventMap[K]) => void>;
@@ -16,24 +17,23 @@ describe('UpdateChecker', () => {
 
   beforeEach(() => {
     nodeVersionAtStart = '0.1.0';
-    rollupAddressAtStart = EthAddress.random();
+    rollupVersionAtStart = randomBigInt(1000n);
     fetch = jest.fn(() => Promise.resolve(new Response(JSON.stringify({ version: nodeVersionAtStart }))));
-    getRollupAddress = jest.fn(() => Promise.resolve(rollupAddressAtStart));
+    getCanonicalRollupVersion = jest.fn(() => Promise.resolve(rollupVersionAtStart));
 
     checker = new UpdateChecker(
       new URL('http://localhost'),
       nodeVersionAtStart,
-      'canonical',
-      rollupAddressAtStart,
+      rollupVersionAtStart,
       fetch,
-      getRollupAddress,
+      getCanonicalRollupVersion,
       100,
     );
 
     eventHandlers = {
-      updateConfig: jest.fn(),
-      newVersion: jest.fn(),
-      newRollup: jest.fn(),
+      updateNodeConfig: jest.fn(),
+      newNodeVersion: jest.fn(),
+      newRollupVersion: jest.fn(),
     };
 
     for (const [event, fn] of Object.entries(eventHandlers)) {
@@ -52,7 +52,7 @@ describe('UpdateChecker', () => {
     [
       'fetching rollup address fails',
       () => {
-        getRollupAddress.mockRejectedValue(new Error('test error'));
+        getCanonicalRollupVersion.mockRejectedValue(new Error('test error'));
       },
     ],
     [
@@ -91,19 +91,19 @@ describe('UpdateChecker', () => {
 
   it.each<[keyof EventMap, () => void]>([
     [
-      'newRollup',
+      'newRollupVersion',
       () => {
-        getRollupAddress.mockResolvedValueOnce(EthAddress.random());
+        getCanonicalRollupVersion.mockResolvedValueOnce(randomBigInt(1000n));
       },
     ],
     [
-      'newVersion',
+      'newNodeVersion',
       () => {
         fetch.mockResolvedValueOnce(new Response(JSON.stringify({ version: '0.1.0-foo' })));
       },
     ],
     [
-      'updateConfig',
+      'updateNodeConfig',
       () => {
         fetch.mockResolvedValueOnce(new Response(JSON.stringify({ config: { maxTxsPerBlock: 16 } })));
       },
@@ -127,10 +127,10 @@ describe('UpdateChecker', () => {
     );
 
     await checker.trigger();
-    expect(eventHandlers.updateConfig).toHaveBeenCalledTimes(1);
+    expect(eventHandlers.updateNodeConfig).toHaveBeenCalledTimes(1);
 
     await checker.trigger();
-    expect(eventHandlers.updateConfig).toHaveBeenCalledTimes(1);
+    expect(eventHandlers.updateNodeConfig).toHaveBeenCalledTimes(1);
 
     fetch.mockResolvedValue(
       new Response(
@@ -144,11 +144,11 @@ describe('UpdateChecker', () => {
     );
 
     await checker.trigger();
-    expect(eventHandlers.updateConfig).toHaveBeenCalledTimes(2);
+    expect(eventHandlers.updateNodeConfig).toHaveBeenCalledTimes(2);
   });
 
   it('reaches out to the expected config URL', async () => {
     await checker.trigger();
-    expect(fetch).toHaveBeenCalledWith(new URL(`http://localhost/aztec-${rollupAddressAtStart}/index.json`));
+    expect(fetch).toHaveBeenCalledWith(new URL(`http://localhost`));
   });
 });

--- a/yarn-project/stdlib/src/update-checker/update-checker.ts
+++ b/yarn-project/stdlib/src/update-checker/update-checker.ts
@@ -16,14 +16,13 @@ const updateConfigSchema = z.object({
 });
 
 export type EventMap = {
-  newVersion: [{ currentVersion: string; latestVersion: string }];
-  updateConfig: [object];
-  newRollup: [{ currentRollup: EthAddress; latestRollup: EthAddress }];
+  newRollupVersion: [{ currentVersion: bigint; latestVersion: bigint }];
+  newNodeVersion: [{ currentVersion: string; latestVersion: string }];
+  updateNodeConfig: [object];
 };
 
 type Config = {
   baseURL: URL;
-  rollupVersion?: number | 'canonical';
   nodeVersion?: string;
   checkIntervalMs?: number;
   registryContractAddress: EthAddress;
@@ -36,12 +35,11 @@ export class UpdateChecker extends EventEmitter<EventMap> {
   private lastPatchedConfig: object = {};
 
   constructor(
-    private configBasePath: URL,
+    private updatesUrl: URL,
     private nodeVersion: string | undefined,
-    private rollupVersion: number | 'canonical',
-    private rollupAddressAtStart: EthAddress,
+    private rollupVersion: bigint,
     private fetch: typeof globalThis.fetch,
-    private getRollupAddress: (version: number | 'canonical') => Promise<EthAddress>,
+    private getLatestRollupVersion: () => Promise<bigint>,
     private checkIntervalMs = 60_000, // every minute
     private log = createLogger('foundation:update-check'),
   ) {
@@ -51,15 +49,14 @@ export class UpdateChecker extends EventEmitter<EventMap> {
 
   public static async new(config: Config): Promise<UpdateChecker> {
     const registryContract = new RegistryContract(config.publicClient, config.registryContractAddress);
-    const rollupAddress = await registryContract.getRollupAddress(config.rollupVersion ?? 'canonical');
+    const getLatestRollupVersion = () => registryContract.getRollupVersions().then(versions => versions.at(-1)!);
 
     return new UpdateChecker(
       config.baseURL,
       config.nodeVersion ?? getPackageVersion(),
-      config.rollupVersion ?? 'canonical',
-      rollupAddress,
+      await getLatestRollupVersion(),
       config.fetch ?? fetch,
-      version => registryContract.getRollupAddress(version),
+      getLatestRollupVersion,
       config.checkIntervalMs,
     );
   }
@@ -70,6 +67,10 @@ export class UpdateChecker extends EventEmitter<EventMap> {
       return;
     }
 
+    this.log.info('Starting update checker', {
+      nodeVersion: this.nodeVersion,
+      rollupVersion: this.rollupVersion,
+    });
     this.runningPromise.start();
   }
 
@@ -91,9 +92,13 @@ export class UpdateChecker extends EventEmitter<EventMap> {
 
   private async checkRollupVersion(): Promise<void> {
     try {
-      const canonicalRollup = await this.getRollupAddress(this.rollupVersion);
-      if (!canonicalRollup.equals(this.rollupAddressAtStart)) {
-        this.emit('newRollup', { currentRollup: this.rollupAddressAtStart, latestRollup: canonicalRollup });
+      const canonicalRollupVersion = await this.getLatestRollupVersion();
+      if (canonicalRollupVersion !== this.rollupVersion) {
+        this.log.debug('New canonical rollup version', {
+          currentVersion: this.rollupVersion,
+          latestVersion: canonicalRollupVersion,
+        });
+        this.emit('newRollupVersion', { currentVersion: this.rollupVersion, latestVersion: canonicalRollupVersion });
       }
     } catch (err) {
       this.log.warn(`Failed to check if there is a new rollup`, err);
@@ -102,26 +107,27 @@ export class UpdateChecker extends EventEmitter<EventMap> {
 
   private async checkConfig(): Promise<void> {
     try {
-      const response = await this.fetch(
-        new URL('aztec-' + this.rollupAddressAtStart.toString() + '/index.json', this.configBasePath),
-      );
+      const response = await this.fetch(this.updatesUrl);
       const body = await response.json();
       if (!response.ok) {
         this.log.warn(`Unexpected HTTP response checking for updates`, {
           status: response.status,
           body: await response.text(),
+          url: this.updatesUrl,
         });
       }
 
       const { version, config } = updateConfigSchema.parse(body);
 
       if (this.nodeVersion !== undefined && version !== undefined && version !== this.nodeVersion) {
-        this.emit('newVersion', { currentVersion: this.nodeVersion, latestVersion: version });
+        this.log.debug('New node version', { currentVersion: this.nodeVersion, latestVersion: version });
+        this.emit('newNodeVersion', { currentVersion: this.nodeVersion, latestVersion: version });
       }
 
       if (config && Object.keys(config).length > 0 && !isDeepStrictEqual(config, this.lastPatchedConfig)) {
+        this.log.debug('New node config', { config });
         this.lastPatchedConfig = config;
-        this.emit('updateConfig', config);
+        this.emit('updateNodeConfig', config);
       }
     } catch (err) {
       this.log.warn(`Failed to check if there is an update`, err);

--- a/yarn-project/stdlib/src/update-checker/update-checker.ts
+++ b/yarn-project/stdlib/src/update-checker/update-checker.ts
@@ -119,7 +119,7 @@ export class UpdateChecker extends EventEmitter<EventMap> {
 
       const { version, config } = updateConfigSchema.parse(body);
 
-      if (this.nodeVersion !== undefined && version !== undefined && version !== this.nodeVersion) {
+      if (this.nodeVersion && version && version !== this.nodeVersion) {
         this.log.debug('New node version', { currentVersion: this.nodeVersion, latestVersion: version });
         this.emit('newNodeVersion', { currentVersion: this.nodeVersion, latestVersion: version });
       }


### PR DESCRIPTION
This PR adds terraform config for the auto-update bucket as well as updating logging in the update checker and adding a new node: config-only -- where the update checker only applies config updates.

This PR also includes lowering the default batching window interval to 0ms in order to not add too much lag to PXE operations.