### PR TITLE
fix: Verify tar.gz file integrity before extraction in bbup scripts

### DIFF
--- a/barretenberg/bbup/bbup
+++ b/barretenberg/bbup/bbup
@@ -122,7 +122,27 @@ install_bb() {
     fi
     local binary_url="${release_url_base}/${release_tag}/barretenberg-${architecture}-${platform}.tar.gz"
 
+    printf "${BLUE}Downloading from ${binary_url}${NC}\n"
     curl -L "$binary_url" -o "$temp_tar"
+
+    # Verify the integrity of the downloaded file before extraction
+    printf "${BLUE}Verifying file integrity...${NC}\n"
+    local checksum_url="${release_url_base}/${release_tag}/barretenberg-${architecture}-${platform}.tar.gz.sha256"
+    local expected_checksum=$(curl -s -L "$checksum_url" || echo "")
+
+    if [ -z "$expected_checksum" ]; then
+        warn "No checksum file available. Skipping verification."
+    else
+        local calculated_checksum=$(shasum -a 256 "$temp_tar" | cut -d ' ' -f 1)
+        if [ "$calculated_checksum" != "$expected_checksum" ]; then
+            printf "${RED}${ERROR} Checksum verification failed! Expected: ${expected_checksum}, Got: ${calculated_checksum}${NC}\n"
+            printf "${RED}${ERROR} The downloaded file may be corrupted or tampered with.${NC}\n"
+            rm -rf "$temp_dir"
+            exit 1
+        fi
+        printf "${GREEN}${SUCCESS} Checksum verification passed${NC}\n"
+    fi
+
     mkdir -p "$BB_PATH"
     tar xzf "$temp_tar" -C "$BB_PATH"
     rm -rf "$temp_dir"

--- a/barretenberg/cpp/installation/bbup
+++ b/barretenberg/cpp/installation/bbup
@@ -65,9 +65,46 @@ main() {
   RELEASE_URL="https://github.com/${BBUP_REPO}/releases/download/${BBUP_TAG}"
   BIN_TARBALL_URL="${RELEASE_URL}/barretenberg-${ARCHITECTURE}-${PLATFORM}.tar.gz"
 
-  # Download the binary's tarball and unpack it into the .bb directory.
-  say "downloading bb to '$BB_HOME'"
-  ensure curl -# -L $BIN_TARBALL_URL | tar -xzC $BB_HOME
+  # Create temporary directory and file
+  TEMP_DIR=$(mktemp -d)
+  TEMP_TAR="${TEMP_DIR}/bb.tar.gz"
+
+  # Download the binary's tarball
+  say "downloading bb from ${BIN_TARBALL_URL}"
+  ensure curl -# -L $BIN_TARBALL_URL -o "$TEMP_TAR"
+
+  # Verify the integrity of the downloaded file before extraction
+  say "verifying file integrity"
+  CHECKSUM_URL="${RELEASE_URL}/barretenberg-${ARCHITECTURE}-${PLATFORM}.tar.gz.sha256"
+  EXPECTED_CHECKSUM=$(curl -s -L "$CHECKSUM_URL" || echo "")
+
+  if [ -z "$EXPECTED_CHECKSUM" ]; then
+    warn "no checksum file available. skipping verification."
+  else
+    if command -v shasum >/dev/null 2>&1; then
+      CALCULATED_CHECKSUM=$(shasum -a 256 "$TEMP_TAR" | cut -d ' ' -f 1)
+    elif command -v sha256sum >/dev/null 2>&1; then
+      CALCULATED_CHECKSUM=$(sha256sum "$TEMP_TAR" | cut -d ' ' -f 1)
+    else
+      warn "neither shasum nor sha256sum commands available. skipping verification."
+      CALCULATED_CHECKSUM=""
+    fi
+
+    if [ -n "$CALCULATED_CHECKSUM" ] && [ "$CALCULATED_CHECKSUM" != "$EXPECTED_CHECKSUM" ]; then
+      err "checksum verification failed! Expected: ${EXPECTED_CHECKSUM}, Got: ${CALCULATED_CHECKSUM}. The downloaded file may be corrupted or tampered with."
+    elif [ -n "$CALCULATED_CHECKSUM" ]; then
+      say "checksum verification passed"
+    fi
+  fi
+
+  # Create the installation directory if it doesn't exist
+  mkdir -p "$BB_HOME"
+
+  # Extract the tarball
+  ensure tar -xzf "$TEMP_TAR" -C "$BB_HOME"
+
+  # Clean up
+  rm -rf "$TEMP_DIR"
 
   say "done"
 }


### PR DESCRIPTION
 Fixes #14335

Add SHA256 checksum verification to prevent security vulnerabilities when downloading and extracting barretenberg binaries in both bbup scripts.