### PR TITLE
feat: enable provers to run in node chart

### DIFF
--- a/spartan/aztec-node/templates/secret.yaml
+++ b/spartan/aztec-node/templates/secret.yaml
@@ -1,7 +1,8 @@
+{{- if or (has "--sequencer" .Values.node.startCmd) (has "--prover-node" .Values.node.startCmd) }}
 apiVersion: v1
 kind: Secret
 metadata:
-  name: {{ include "chart.name" . }}-l1-publisher
+  name: {{ include "chart.fullname" . }}-l1-publisher
   labels:
     {{- include "chart.labels" . | nindent 4 }}
 data:
@@ -11,3 +12,4 @@ data:
   {{- else }}
   privateKeys: {{ join "\n" .Values.node.l1Publisher.privateKeys | b64enc }}
   {{- end }}
+{{- end }}

--- a/spartan/aztec-node/templates/statefulset.yaml
+++ b/spartan/aztec-node/templates/statefulset.yaml
@@ -1,11 +1,11 @@
 apiVersion: apps/v1
 kind: StatefulSet
 metadata:
-  name: {{ include "chart.name" . }}-node
+  name: {{ include "chart.fullname" . }}
   labels:
     {{- include "chart.labels" . | nindent 4 }}
 spec:
-  serviceName: {{ include "chart.name" . }}-node
+  serviceName: {{ include "chart.fullname" . }}
   replicas: {{ .Values.node.replicas }}
   podManagementPolicy: {{ .Values.podManagementPolicy }}
   updateStrategy:
@@ -23,6 +23,7 @@ spec:
       serviceAccountName: {{ include "chart.serviceAccountName" . }}
       dnsPolicy: ClusterFirstWithHostNet
       hostNetwork: {{ .Values.hostNetwork }}
+      {{- if or .Values.service.p2p.nodePortEnabled .Values.hostNetwork }}
       affinity:
         podAntiAffinity:
           requiredDuringSchedulingIgnoredDuringExecution:
@@ -34,6 +35,7 @@ spec:
                       - node
               topologyKey: kubernetes.io/hostname
               namespaceSelector: {}
+      {{- end }}
       initContainers:
       {{- if .Values.initContainers }}
         {{- tpl (toYaml .Values.initContainers | nindent 8) $ }}
@@ -77,7 +79,7 @@ spec:
               mountPath: /env
       {{- end }}
       containers:
-        - name: node
+        - name: aztec
           image: "{{ .Values.image.repository }}:{{ .Values.image.tag | default .Chart.AppVersion }}"
           imagePullPolicy: {{ .Values.image.pullPolicy }}
           command:
@@ -119,6 +121,11 @@ spec:
               {{- end }}
 
               start_cmd+=({{ join " " .Values.node.startCmd }})
+
+              {{- if .Values.node.preStartScript }}
+              {{ .Values.node.preStartScript | nindent 14 }}
+
+              {{- end }}
               "${start_cmd[@]}"
           startupProbe:
             httpGet:
@@ -197,7 +204,7 @@ spec:
               value: {{ .Values.node.remoteUrl.archiver | quote }}
             {{- end }}
             {{- if .Values.node.remoteUrl.proverBroker }}
-            - name: PROVER_BROKER_URL
+            - name: PROVER_BROKER_HOST
               value: {{ .Values.node.remoteUrl.proverBroker | quote }}
             {{- end }}
             {{- if .Values.node.remoteUrl.blobSink }}
@@ -251,19 +258,25 @@ spec:
           ports:
             - containerPort: {{ .Values.service.httpPort }}
               name: http-rpc
+            {{- if .Values.service.admin.enabled }}
             - containerPort: {{ .Values.service.admin.port }}
               name: admin
+            {{- end }}
+            {{- if .Values.service.p2p.enabled }}
             - containerPort: {{ .Values.service.p2p.port }}
               name: p2p-tcp
             - containerPort: {{ .Values.service.p2p.port }}
               protocol: UDP
               name: p2p-udp
+            {{- end }}
           resources:
             {{- toYaml .Values.node.resources | nindent 12 }}
       volumes:
+        {{- if or (has "--sequencer" .Values.node.startCmd) (has "--prover-node" .Values.node.startCmd) }}
         - name: l1-publisher
           secret:
-            secretName: {{ include "chart.name" . }}-l1-publisher
+            secretName: {{ include "chart.fullname" . }}-l1-publisher
+        {{- end }}
         {{- if or .Values.service.p2p.nodePortEnabled .Values.hostNetwork }}
         - name: init-nodeport
           emptyDir: {}

--- a/spartan/aztec-node/templates/svc.headless.yaml
+++ b/spartan/aztec-node/templates/svc.headless.yaml
@@ -1,3 +1,4 @@
+{{- if .Values.service.headless.enabled }}
 apiVersion: v1
 kind: Service
 metadata:
@@ -7,6 +8,7 @@ metadata:
 spec:
   clusterIP: None
   ports:
+    {{- if .Values.service.p2p.enabled }}
     - port: {{ .Values.service.p2p.port }}
       targetPort: p2p-tcp
       protocol: TCP
@@ -15,13 +17,17 @@ spec:
       targetPort: p2p-udp
       protocol: UDP
       name: p2p-udp
+    {{- end }}
     - port: {{ .Values.service.httpPort }}
       targetPort: http-rpc
       protocol: TCP
       name: http-rpc
+    {{- if .Values.service.admin.enabled }}
     - port: {{ .Values.service.admin.port }}
       targetPort: admin
       protocol: TCP
       name: admin
+    {{- end }}
   selector:
     {{- include "chart.selectorLabels" . | nindent 4 }}
+{{- end }}

--- a/spartan/aztec-node/templates/svc.nodeport.yaml
+++ b/spartan/aztec-node/templates/svc.nodeport.yaml
@@ -1,4 +1,4 @@
-{{- if and .Values.service.p2p.nodePortEnabled (not .Values.hostNetwork) -}}
+{{- if and .Values.service.p2p.enabled .Values.service.p2p.nodePortEnabled (not .Values.hostNetwork) -}}
 {{- range $i, $e := until (.Values.node.replicas | int) }}
 ---
 apiVersion: v1

--- a/spartan/aztec-node/templates/svc.yaml
+++ b/spartan/aztec-node/templates/svc.yaml
@@ -1,7 +1,7 @@
 apiVersion: v1
 kind: Service
 metadata:
-  name: {{ include "chart.fullname" . }}-node-svc
+  name: {{ include "chart.fullname" . }}
   labels:
     {{- include "chart.labels" . | nindent 4 }}
   {{- with .Values.service.ingress.annotations }}
@@ -11,6 +11,7 @@ metadata:
 spec:
   type: ClusterIP
   ports:
+    {{- if .Values.service.p2p.enabled }}
     - port: {{ .Values.service.p2p.port }}
       targetPort: p2p-tcp
       protocol: TCP
@@ -19,13 +20,16 @@ spec:
       targetPort: p2p-udp
       protocol: UDP
       name: p2p-udp
+    {{- end }}
     - port: {{ .Values.service.httpPort }}
       targetPort: http-rpc
       protocol: TCP
       name: http-rpc
+    {{- if .Values.service.admin.enabled }}
     - port: {{ .Values.service.admin.port }}
       targetPort: admin
       protocol: TCP
       name: admin
+    {{- end }}
   selector:
     {{- include "chart.selectorLabels" . | nindent 4 }}

--- a/spartan/aztec-node/values.yaml
+++ b/spartan/aztec-node/values.yaml
@@ -54,6 +54,8 @@ node:
   ## Example: "X-API-KEY"
   l1ConsensusHostApiKeyHeaders: []
 
+  preStartScript: ""
+
   startCmd:
     - --node
     - --archiver
@@ -137,6 +139,9 @@ service:
     # kubernetes.io/ingress.global-static-ip-name: my-static-ip
     hosts: []
     # - node.example.com
+
+  headless:
+    enabled: true
 
   p2p:
     enabled: true

--- a/yarn-project/prover-client/src/proving_broker/proving_agent.ts
+++ b/yarn-project/prover-client/src/proving_broker/proving_agent.ts
@@ -5,6 +5,7 @@ import { truncate } from '@aztec/foundation/string';
 import { ProvingError } from '@aztec/stdlib/errors';
 import type {
   GetProvingJobResponse,
+  ProverAgentStatus,
   ProvingJobConsumer,
   ProvingJobId,
   ProvingJobInputs,
@@ -69,6 +70,19 @@ export class ProvingAgent implements Traceable {
   public async stop(): Promise<void> {
     this.currentJobController?.abort();
     await this.runningPromise.stop();
+  }
+
+  public getStatus(): ProverAgentStatus {
+    if (this.currentJobController) {
+      return {
+        status: 'proving',
+        jobId: this.currentJobController.getJobId(),
+        proofType: this.currentJobController.getProofType(),
+        startedAtISO: new Date(this.currentJobController.getStartedAt()).toISOString(),
+      };
+    }
+
+    return this.runningPromise.isRunning() ? { status: 'running' } : { status: 'stopped' };
   }
 
   @trackSpan('ProvingAgent.safeWork')

--- a/yarn-project/stdlib/src/interfaces/prover-agent.ts
+++ b/yarn-project/stdlib/src/interfaces/prover-agent.ts
@@ -2,19 +2,18 @@ import { z } from 'zod';
 
 import type { ApiSchemaFor } from '../schemas/index.js';
 
+export const ProverAgentStatusSchema = z.discriminatedUnion('status', [
+  z.object({ status: z.literal('stopped') }),
+  z.object({ status: z.literal('running') }),
+  z.object({ status: z.literal('proving'), jobId: z.string(), proofType: z.number(), startedAtISO: z.string() }),
+]);
+
+export type ProverAgentStatus = z.infer<typeof ProverAgentStatusSchema>;
+
 export interface ProverAgentApi {
-  setMaxConcurrency(maxConcurrency: number): Promise<void>;
-
-  isRunning(): Promise<boolean>;
-
-  getCurrentJobs(): Promise<{ id: string; type: string }[]>;
+  getStatus(): Promise<unknown>;
 }
 
 export const ProverAgentApiSchema: ApiSchemaFor<ProverAgentApi> = {
-  setMaxConcurrency: z.function().args(z.number().min(1).int()).returns(z.void()),
-  isRunning: z.function().args().returns(z.boolean()),
-  getCurrentJobs: z
-    .function()
-    .args()
-    .returns(z.array(z.object({ id: z.string(), type: z.string() }))),
+  getStatus: z.function().args().returns(ProverAgentStatusSchema),
 };


### PR DESCRIPTION
This PR refactors the node chart so that it can be run as a prover node/broker/agent
