### PR TITLE
chore: prepare scream (invalid hashes on purpose)

### DIFF
--- a/l1-contracts/bootstrap.sh
+++ b/l1-contracts/bootstrap.sh
@@ -52,10 +52,25 @@ function build {
   fi
 }
 
+function test_scream {
+  echo_header "l1-contracts screaming test"
+
+  if ! git merge-base --is-ancestor origin/next HEAD; then
+    echo "Not child of next, running screaming test"
+    build
+    forge test --no-match-contract UniswapPortalTest --match-contract ScreamAndShoutTest
+  else
+    echo "Child of next, skipping screaming test"
+  fi
+}
+
 function test_cmds {
   echo "$hash cd l1-contracts && solhint --config ./.solhint.json \"src/**/*.sol\""
   echo "$hash cd l1-contracts && forge fmt --check"
-  echo "$hash cd l1-contracts && forge test --no-match-contract UniswapPortalTest"
+  echo "$hash cd l1-contracts && forge test"
+  if ! git merge-base --is-ancestor origin/next HEAD; then
+    echo "$hash cd l1-contracts && forge test --no-match-contract UniswapPortalTest --match-contract ScreamAndShoutTest"
+  fi
 }
 
 function test {
@@ -437,7 +452,7 @@ case "$cmd" in
     shift
     gas_benchmark "$@"
     ;;
-  test|test_cmds|bench|bench_cmds|inspect|release)
+  test|test_scream|test_cmds|bench|bench_cmds|inspect|release)
     $cmd
     ;;
   "hash")

--- a/l1-contracts/foundry.toml
+++ b/l1-contracts/foundry.toml
@@ -31,6 +31,8 @@ fs_permissions = [
   {access = "read", path = "./test/fixtures/fee_data_points.json"},
 ]
 
+no_match_contract="(ScreamAndShoutTest|UniswapPortalTest)"
+
 [fmt]
 line_length = 100
 tab_width = 2

--- a/l1-contracts/test/shouting.t.sol
+++ b/l1-contracts/test/shouting.t.sol
@@ -1,0 +1,47 @@
+// SPDX-License-Identifier: UNLICENSED
+pragma solidity >=0.8.27;
+
+import {Test} from "forge-std/Test.sol";
+import {Rollup} from "@aztec/core/Rollup.sol";
+import {Registry} from "@aztec/governance/Registry.sol";
+import {Governance} from "@aztec/governance/Governance.sol";
+import {HonkVerifier} from "../generated/HonkVerifier.sol";
+
+/**
+ * @notice  This test is used to ensure that changes to L1 contracts don't go unnoticed.
+ *          While still allowing the addition of more tests etc without having to update it.
+ *          The test is fairly simple, check if the creation code has changed for the important
+ *          contracts. If it has, the test will fail, so it needs to be updated.
+ *          This should not be needed for master, so if you have a diff, it probably have to go to NEXT.
+ */
+contract ScreamAndShoutTest is Test {
+  string internal constant ERR_STRING = "This belongs in NEXT!";
+
+  function test_GovernanceCreationCode() public pure {
+    bytes memory creationCode = type(Governance).creationCode;
+    bytes32 codeHash = keccak256(creationCode);
+
+    assertEq(codeHash, 0x00, ERR_STRING);
+  }
+
+  function test_HonkVerifierCreationCode() public pure {
+    bytes memory creationCode = type(HonkVerifier).creationCode;
+    bytes32 codeHash = keccak256(creationCode);
+
+    assertEq(codeHash, 0x00, ERR_STRING);
+  }
+
+  function test_RegistryCreationCode() public pure {
+    bytes memory creationCode = type(Registry).creationCode;
+    bytes32 codeHash = keccak256(creationCode);
+
+    assertEq(codeHash, 0x00, ERR_STRING);
+  }
+
+  function test_RollupCreationCode() public pure {
+    bytes memory creationCode = type(Rollup).creationCode;
+    bytes32 codeHash = keccak256(creationCode);
+
+    assertEq(codeHash, 0x00, ERR_STRING);
+  }
+}


### PR DESCRIPTION
Creating a check that should scream at us if we are breaking things. Should only run this test when next is not an ancestor of the current branch. 

Need some changes to go into next, before it makes sense to run, since next is currently an ancestor of master making making us pass as if we are on next.