### PR TITLE
feat: parse config object

### DIFF
--- a/spartan/terraform/gke-cluster/snapshots.tf
+++ b/spartan/terraform/gke-cluster/snapshots.tf
@@ -47,9 +47,12 @@ resource "google_storage_bucket_object" "alpha_testnet_json" {
   bucket = google_storage_managed_folder.aztec_testnet_auto_update_folder.bucket
   name   = "${google_storage_managed_folder.aztec_testnet_auto_update_folder.name}alpha-testnet.json"
   content_type = "application/json"
+  cache_control = "no-store"
   # see yarn-project/foundation/src/update-checker/update-checker.ts for latest schema
   content = jsonencode({
-    config = {}
+    version = ""
+    config = {
+      governanceProposerPayload = "0x0000000000000000000000000000000000000000"
+    }
   })
 }
-

--- a/yarn-project/aztec/src/cli/cmds/start_node.ts
+++ b/yarn-project/aztec/src/cli/cmds/start_node.ts
@@ -193,7 +193,7 @@ export async function startNode(
       getPublicClient(nodeConfig!),
       nodeConfig.l1Contracts.registryAddress,
       signalHandlers,
-      config => node.setConfig(config),
+      async config => node.setConfig((await AztecNodeAdminApiSchema.setConfig.parameters().parseAsync([config]))[0]),
     );
   }
 

--- a/yarn-project/aztec/src/cli/util.ts
+++ b/yarn-project/aztec/src/cli/util.ts
@@ -288,7 +288,11 @@ export async function setupUpdateMonitor(
   checker.on('updateNodeConfig', async config => {
     if ((autoUpdateMode === 'config' || autoUpdateMode === 'config-and-version') && updateNodeConfig) {
       logger.warn(`Config change detected. Updating node`, config);
-      await updateNodeConfig(config);
+      try {
+        await updateNodeConfig(config);
+      } catch (err) {
+        logger.warn('Failed to update config', { err });
+      }
     }
     // don't notify on these config changes
   });


### PR DESCRIPTION
Parse config object before passing it to the node in order to create the proper structure (and convert strings to class instances)