### PR TITLE
chore: remove serialize from the event iface

### DIFF
--- a/noir-projects/aztec-nr/aztec/src/event/event_interface.nr
+++ b/noir-projects/aztec-nr/aztec/src/event/event_interface.nr
@@ -1,8 +1,9 @@
 use dep::protocol_types::abis::event_selector::EventSelector;
-use dep::protocol_types::traits::Serialize;
 
-// TODO(#11571): Make events implement Packable instead of Serialize.
-pub trait EventInterface<let N: u32>: Serialize<N> {
+pub trait EventInterface {
     fn get_event_type_id() -> EventSelector;
-    fn emit<Env>(self, emit: fn[Env](Self) -> ());
+
+    fn emit<Env>(self, _emit: fn[Env](Self) -> ()) {
+        _emit(self);
+    }
 }

--- a/noir-projects/aztec-nr/aztec/src/macros/events.nr
+++ b/noir-projects/aztec-nr/aztec/src/macros/events.nr
@@ -1,11 +1,7 @@
 use super::utils::{compute_event_selector, get_trait_impl_method};
-use protocol_types::meta::generate_serialize_to_fields;
 
 comptime fn generate_event_interface(s: TypeDefinition) -> Quoted {
     let name = s.name();
-    let typ = s.as_type();
-    let (serialization_fields, _) = generate_serialize_to_fields(quote { self }, typ, false);
-    let content_len = serialization_fields.len();
 
     let event_type_id = compute_event_selector(s);
 
@@ -16,13 +12,9 @@ comptime fn generate_event_interface(s: TypeDefinition) -> Quoted {
     );
 
     quote {
-        impl aztec::event::event_interface::EventInterface<$content_len> for $name {
+        impl aztec::event::event_interface::EventInterface for $name {
             fn get_event_type_id() -> aztec::protocol_types::abis::event_selector::EventSelector {
                 $from_field($event_type_id)
-            }
-
-            fn emit<Env>(self, _emit: fn[Env](Self) -> ()) {
-                _emit(self);
             }
         }
     }

--- a/noir-projects/aztec-nr/aztec/src/messages/logs/event.nr
+++ b/noir-projects/aztec-nr/aztec/src/messages/logs/event.nr
@@ -17,7 +17,7 @@ fn compute_log<Event, let N: u32>(
     sender: AztecAddress,
 ) -> [Field; PRIVATE_LOG_SIZE_IN_FIELDS]
 where
-    Event: EventInterface<N>,
+    Event: EventInterface + Serialize<N>,
 {
     // TODO(#11571): with decryption happening in Noir we can now use the Packable trait instead.
     let plaintext = encode_message(
@@ -39,7 +39,7 @@ fn compute_log_unconstrained<Event, let N: u32>(
     sender: AztecAddress,
 ) -> [Field; PRIVATE_LOG_SIZE_IN_FIELDS]
 where
-    Event: EventInterface<N>,
+    Event: EventInterface + Serialize<N>,
 {
     compute_log(event, recipient, sender)
 }
@@ -52,7 +52,7 @@ pub fn encode_and_encrypt_event<Event, let N: u32>(
     sender: AztecAddress,
 ) -> fn[(AztecAddress, AztecAddress, &mut PrivateContext)](Event) -> ()
 where
-    Event: EventInterface<N>,
+    Event: EventInterface + Serialize<N>,
 {
     |e: Event| {
         let encrypted_log = compute_log(e, recipient, sender);
@@ -74,7 +74,7 @@ pub fn encode_and_encrypt_event_unconstrained<Event, let N: u32>(
     sender: AztecAddress,
 ) -> fn[(AztecAddress, AztecAddress, &mut PrivateContext)](Event) -> ()
 where
-    Event: EventInterface<N>,
+    Event: EventInterface + Serialize<N>,
 {
     |e: Event| {
         // Safety: this function does not constrain the encryption of the log, as explained on its description.

--- a/noir-projects/aztec-nr/aztec/src/unencrypted_logs/unencrypted_event_emission.nr
+++ b/noir-projects/aztec-nr/aztec/src/unencrypted_logs/unencrypted_event_emission.nr
@@ -1,9 +1,9 @@
 use crate::{context::PublicContext, event::event_interface::EventInterface};
-use protocol_types::traits::ToField;
+use protocol_types::traits::{Serialize, ToField};
 
 fn emit<Event, let N: u32>(context: &mut PublicContext, event: Event)
 where
-    Event: EventInterface<N>,
+    Event: EventInterface + Serialize<N>,
 {
     let selector = Event::get_event_type_id();
 
@@ -24,7 +24,7 @@ pub fn encode_event<Event, let N: u32>(
     context: &mut PublicContext,
 ) -> fn[(&mut PublicContext,)](Event) -> ()
 where
-    Event: EventInterface<N>,
+    Event: EventInterface + Serialize<N>,
 {
     |e: Event| { emit(context, e); }
 }


### PR DESCRIPTION
Part of misc event improvements and https://github.com/AztecProtocol/aztec-packages/issues/14404. We were coupling the ser trait with the event iface, introducing unnecessary coupling. This just undoes that and simplifies the trait by having a default impl for `emit`.