### PR TITLE
chore(ci): ensure build_asan_fast doesn't have bloated cache

### DIFF
--- a/barretenberg/cpp/bootstrap.sh
+++ b/barretenberg/cpp/bootstrap.sh
@@ -62,7 +62,8 @@ function build_asan_fast {
   if ! cache_download barretenberg-asan-fast-$hash.zst; then
     # Pass the keys from asan_tests to the build_preset function.
     build_preset asan-fast --target "${!asan_tests[@]}"
-    cache_upload barretenberg-asan-fast-$hash.zst build-asan-fast/bin
+    # We upload only the binaries specified in --target in build-asan-fast/bin
+    echo cache_upload barretenberg-asan-fast-$hash.zst $(printf "build-asan-fast/bin/%s " "${!asan_tests[@]}")
   fi
 }
 


### PR DESCRIPTION
This might bloat if someone had built targets in asan fast bin dir