### PR TITLE
refactor: partial notes optimization with nullifier

### DIFF
--- a/cspell.json
+++ b/cspell.json
@@ -39,6 +39,7 @@
     "buildx",
     "bytecodes",
     "calldatacopy",
+    "callsites",
     "callstack",
     "callstacks",
     "camelcase",

--- a/docs/docs/developers/tutorials/codealong/contract_tutorials/nft_contract.md
+++ b/docs/docs/developers/tutorials/codealong/contract_tutorials/nft_contract.md
@@ -122,7 +122,6 @@ These functions are useful for getting contract information in another contract 
 
 Internal functions are functions that can only be called by the contract itself. These can be used when the contract needs to call one of it's public functions from one of it's private functions.
 
-- [`_store_payload_in_transient_storage_unsafe`](#_store_payload_in_transient_storage_unsafe) - a public function that is called when preparing a private balance increase. This function handles the needed public state updates.
 - [`finalize_transfer_to_private_unsafe`](#_finalize_transfer_to_private_unsafe) - finalizes a transfer from public to private state
 
 ### Utility functions
@@ -261,8 +260,6 @@ This function calls `_prepare_private_balance_increase` which is marked as `#[co
 
 :::
 
-It also calls [`_store_payload_in_transient_storage_unsafe`](#_store_payload_in_transient_storage_unsafe) to store the partial note in "transient storage" (more below)
-
 #include_code prepare_private_balance_increase /noir-projects/noir-contracts/contracts/app/nft_contract/src/main.nr rust
 
 #### `cancel_authwit`
@@ -286,14 +283,6 @@ Transfers and NFT from private storage to public storage. The private call enque
 ### Internal function implementations
 
 Internal functions are functions that can only be called by this contract. The following 3 functions are public functions that are called from the [private execution context](#execution-contexts). Marking these as `internal` ensures that only the desired private functions in this contract are able to call them. Private functions defer execution to public functions because private functions cannot update public state directly.
-
-#### `_store_payload_in_transient_storage_unsafe`
-
-It is labeled unsafe because the public function does not check the value of the storage slot before writing, but it is safe because of the private execution preceding this call.
-
-This is transient storage since the storage is not permanent, but is scoped to the current transaction only, after which it will be reset. The partial note is stored the "hiding point slot" value (computed in `_prepare_private_balance_increase()`) in public storage. However subsequent enqueued call to `_finalize_transfer_to_private_unsafe()` will read the partial note in this slot, complete it and emit it. Since the note is completed, there is no use of storing the hiding point slot anymore so we will reset to empty. This saves a write to public storage too.
-
-#include_code store_payload_in_transient_storage_unsafe /noir-projects/noir-contracts/contracts/app/nft_contract/src/main.nr rust
 
 #### `_finalize_transfer_to_private_unsafe`
 

--- a/noir-projects/aztec-nr/uint-note/src/uint_note.nr
+++ b/noir-projects/aztec-nr/uint-note/src/uint_note.nr
@@ -117,7 +117,7 @@ impl UintNote {
     ///
     /// As part of the partial note creation process, a log will be sent to `recipient` from `sender` so that they can
     /// discover the note. `recipient` will typically be the same as `owner`.
-    pub fn setup_partial_note(
+    pub fn partial(
         owner: AztecAddress,
         storage_slot: Field,
         context: &mut PrivateContext,

--- a/noir-projects/aztec-nr/uint-note/src/uint_note.nr
+++ b/noir-projects/aztec-nr/uint-note/src/uint_note.nr
@@ -204,24 +204,33 @@ pub struct PartialUintNote {
 }
 
 impl PartialUintNote {
-    /// Computes a partial note validity commitment. This commitment is stored in public storage when creating the
-    /// partial note in private and then is used to check that completer and note are valid upon partial note
-    /// completion in public (completer is the entity that can complete the partial note).
-    pub fn compute_validity_commitment(self, completer: AztecAddress) -> Field {
-        poseidon2_hash_with_separator(
-            [self.commitment, completer.to_field()],
-            GENERATOR_INDEX__PARTIAL_NOTE_VALIDITY_COMMITMENT,
-        )
+    /// Computes and records a validity commitment for this partial note in the nullifier tree. The commitment
+    /// cryptographically binds the note's private data with the designated completer address. When the note is later
+    /// completed in public execution, this commitment allows verification that both the partial note (e.g. that the
+    /// storage slot corresponds to the correct owner, and that we're using the correct state variable) and completer
+    /// are legitimate. This function should be invoked during private note creation, before the note is completed.
+    pub fn insert_validity_commitment(self, context: &mut PrivateContext, completer: AztecAddress) {
+        // The validity commitment can be safely pushed to the nullifier tree since it uses its own separator,
+        // making collisions with actual note nullifiers practically impossible.
+        context.push_nullifier(self.compute_validity_commitment(completer));
     }
 
     /// Completes the partial note, creating a new note that can be used like any other UintNote.
-    pub fn complete(self, value: u128, context: &mut PublicContext) {
+    pub fn complete(self, context: &mut PublicContext, completer: AztecAddress, value: u128) {
         // A note with a value of zero is valid, but we cannot currently complete a partial note with such a value
         // because this will result in the completion log having its last field set to 0. Public logs currently do not
         // track their length, and so trailing zeros are simply trimmed. This results in the completion log missing its
         // last field (the value), and note discovery failing.
         // TODO(#11636): remove this
         assert(value != 0, "Cannot complete a PartialUintNote with a value of 0");
+
+        // We verify that the partial note we're completing is valid (i.e. completer is correct, it uses the correct
+        // state variable's storage slot, and it is internally consistent).
+        let validity_commitment = self.compute_validity_commitment(completer);
+        assert(
+            context.nullifier_exists(validity_commitment, context.this_address()),
+            "Invalid partial note or completer",
+        );
 
         // We need to do two things:
         //  - emit a public log containing the public fields (the value). The contract will later find it by searching
@@ -231,6 +240,13 @@ impl PartialUintNote {
         //  inserted in public as the public values are provided and the note hash computed.
         context.emit_public_log(self.compute_note_completion_log(value));
         context.push_note_hash(self.compute_complete_note_hash(value));
+    }
+
+    fn compute_validity_commitment(self, completer: AztecAddress) -> Field {
+        poseidon2_hash_with_separator(
+            [self.commitment, completer.to_field()],
+            GENERATOR_INDEX__PARTIAL_NOTE_VALIDITY_COMMITMENT,
+        )
     }
 
     fn compute_note_completion_log(self, value: u128) -> [Field; 2] {

--- a/noir-projects/aztec-nr/uint-note/src/uint_note.nr
+++ b/noir-projects/aztec-nr/uint-note/src/uint_note.nr
@@ -108,21 +108,22 @@ impl UintNote {
     /// completed in public. This is a powerful technique for scenarios in which the value cannot be known in private
     /// (e.g. because it depends on some public state, such as a DEX).
     ///
-    /// The returned `PartialUintNote` value must be sent to public execution via a secure channel, since it is not
-    /// possible to verify the integrity of its contents due to it hiding information. The recommended ways to do this
-    /// are to retrieve it from public storage, or to receive it in an internal public function call.
+    /// This function inserts a partial note validity commitment into the nullifier tree to be later on able to verify
+    /// that the partial note and completer are legitimate. See function docs of `compute_validity_commitment` for more
+    /// details.
     ///
     /// Each partial note should only be used once, since otherwise multiple notes would be linked together and known to
     /// belong to the same owner.
     ///
     /// As part of the partial note creation process, a log will be sent to `recipient` from `sender` so that they can
     /// discover the note. `recipient` will typically be the same as `owner`.
-    pub fn partial(
+    pub fn setup_partial_note(
         owner: AztecAddress,
         storage_slot: Field,
         context: &mut PrivateContext,
         recipient: AztecAddress,
         sender: AztecAddress,
+        completer: AztecAddress,
     ) -> PartialUintNote {
         // Safety: We use the randomness to preserve the privacy of the note recipient by preventing brute-forcing,
         // so a malicious sender could use non-random values to make the note less private. But they already know
@@ -153,7 +154,15 @@ impl UintNote {
         let length = encrypted_log.len();
         context.emit_private_log(encrypted_log, length);
 
-        PartialUintNote { commitment }
+        let partial_note = PartialUintNote { commitment };
+
+        // Now we compute the validity commitment and push it to the nullifier tree. It can be safely pushed to
+        // the nullifier tree since it uses its own separator, making collisions with actual note nullifiers
+        // practically impossible.
+        let validity_commitment = partial_note.compute_validity_commitment(completer);
+        context.push_nullifier(validity_commitment);
+
+        partial_note
     }
 }
 
@@ -204,17 +213,6 @@ pub struct PartialUintNote {
 }
 
 impl PartialUintNote {
-    /// Computes and records a validity commitment for this partial note in the nullifier tree. The commitment
-    /// cryptographically binds the note's private data with the designated completer address. When the note is later
-    /// completed in public execution, this commitment allows verification that both the partial note (e.g. that the
-    /// storage slot corresponds to the correct owner, and that we're using the correct state variable) and completer
-    /// are legitimate. This function should be invoked during private note creation, before the note is completed.
-    pub fn insert_validity_commitment(self, context: &mut PrivateContext, completer: AztecAddress) {
-        // The validity commitment can be safely pushed to the nullifier tree since it uses its own separator,
-        // making collisions with actual note nullifiers practically impossible.
-        context.push_nullifier(self.compute_validity_commitment(completer));
-    }
-
     /// Completes the partial note, creating a new note that can be used like any other UintNote.
     pub fn complete(self, context: &mut PublicContext, completer: AztecAddress, value: u128) {
         // A note with a value of zero is valid, but we cannot currently complete a partial note with such a value
@@ -242,7 +240,12 @@ impl PartialUintNote {
         context.push_note_hash(self.compute_complete_note_hash(value));
     }
 
-    fn compute_validity_commitment(self, completer: AztecAddress) -> Field {
+    /// Computes a validity commitment for this partial note. The commitment cryptographically binds the note's private
+    /// data with the designated completer address. When the note is later completed in public execution, we can load
+    /// this commitment from the nullifier tree and verify that both the partial note (e.g. that the storage slot
+    /// corresponds to the correct owner, and that we're using the correct state variable) and completer are
+    /// legitimate.
+    pub fn compute_validity_commitment(self, completer: AztecAddress) -> Field {
         poseidon2_hash_with_separator(
             [self.commitment, completer.to_field()],
             GENERATOR_INDEX__PARTIAL_NOTE_VALIDITY_COMMITMENT,

--- a/noir-projects/noir-contracts/contracts/app/nft_contract/src/main.nr
+++ b/noir-projects/noir-contracts/contracts/app/nft_contract/src/main.nr
@@ -199,19 +199,15 @@ pub contract NFT {
     ) -> PartialNFTNote {
         let sender_and_completer = context.msg_sender();
 
-        // We create a partial note with unpopulated/zero token id for 'to'
-        let partial_note = NFTNote::partial(
+        // We setup a partial note with unpopulated/zero token id for 'to'.
+        let partial_note = NFTNote::setup_partial_note(
             to,
             storage.private_nfts.at(to).storage_slot,
             context,
             to,
             sender_and_completer,
+            sender_and_completer,
         );
-
-        // We insert the partial note validity commitment into the nullifier tree to be later on able to verify that
-        // the partial note and completer are legitimate. See function docs of `insert_validity_commitment` for more
-        // details.
-        partial_note.insert_validity_commitment(context, sender_and_completer);
 
         partial_note
     }

--- a/noir-projects/noir-contracts/contracts/app/nft_contract/src/main.nr
+++ b/noir-projects/noir-contracts/contracts/app/nft_contract/src/main.nr
@@ -213,30 +213,18 @@ pub contract NFT {
         // state variable and not a different one) once this information is hidden in the partial note commitment.
         // We also want to verify that only the caller of this function can complete the partial note.
         //
-        // We achieve the above by storing a flag in public storage under a slot index equal to its
-        // `validity_commitment`. This commitment contains all the necessary information to verify the completer and
-        // to validate the partial note.
+        // We achieve this by storing a `validity_commitment` in the nullifier tree. This commitment contains all
+        // the necessary information to verify the completer and the partial note. Later, if we successfully
+        // read this commitment from the nullifier tree, we know that the partial note is valid.
         let validity_commitment = partial_note.compute_validity_commitment(sender_and_completer);
 
-        NFT::at(context.this_address())._set_nft_partial_note_validity(validity_commitment).enqueue(
-            context,
-        );
+        // The validity commitment can be safely pushed to the nullifier tree since it uses its own separator,
+        // making collisions with actual note nullifiers practically impossible.
+        context.push_nullifier(validity_commitment);
 
         partial_note
     }
     // docs:end:prepare_private_balance_increase
-
-    // docs:start:store_payload_in_transient_storage_unsafe
-    #[public]
-    #[internal]
-    fn _set_nft_partial_note_validity(validity_commitment: Field) {
-        // We store the partial note validity flag in a slot equal to its validity commitment. This is safe because
-        // the commitment is computed using a generator different from the one used to compute storage slots, so there
-        // can be no collisions. We could consider storing all pending partial notes in e.g. some array, but ultimately
-        // this is pointless: all we need to verify is that the note is valid.
-        context.storage_write(validity_commitment, true);
-    }
-    // docs:end:store_payload_in_transient_storage_unsafe
 
     /// Finalizes a transfer of NFT with `token_id` from public balance of `msg_sender` to a private balance of `to`.
     /// The transfer must be prepared by calling `prepare_private_balance_increase` from `msg_sender` account and the
@@ -305,8 +293,9 @@ pub contract NFT {
         // make the transaction be more expensive. We don't worry about the validity commitment being checked against
         // multiple times because it is up to the caller to ensure that a partial note is used only once (see function
         // docs of `finalize_transfer_to_private`).
+        let validity_commitment = partial_note.compute_validity_commitment(from_and_completer);
         assert(
-            context.storage_read(partial_note.compute_validity_commitment(from_and_completer)),
+            context.nullifier_exists(validity_commitment, context.this_address()),
             "Invalid partial note or completer",
         );
         partial_note.complete(token_id, context);

--- a/noir-projects/noir-contracts/contracts/app/nft_contract/src/main.nr
+++ b/noir-projects/noir-contracts/contracts/app/nft_contract/src/main.nr
@@ -208,19 +208,10 @@ pub contract NFT {
             sender_and_completer,
         );
 
-        // We can't simply return the partial note because we won't be able to later on verify that it was created
-        // correctly (e.g. that the storage slot corresponds to the owner, and that we're using the `private_nfts`
-        // state variable and not a different one) once this information is hidden in the partial note commitment.
-        // We also want to verify that only the caller of this function can complete the partial note.
-        //
-        // We achieve this by storing a `validity_commitment` in the nullifier tree. This commitment contains all
-        // the necessary information to verify the completer and the partial note. Later, if we successfully
-        // read this commitment from the nullifier tree, we know that the partial note is valid.
-        let validity_commitment = partial_note.compute_validity_commitment(sender_and_completer);
-
-        // The validity commitment can be safely pushed to the nullifier tree since it uses its own separator,
-        // making collisions with actual note nullifiers practically impossible.
-        context.push_nullifier(validity_commitment);
+        // We insert the partial note validity commitment into the nullifier tree to be later on able to verify that
+        // the partial note and completer are legitimate. See function docs of `insert_validity_commitment` for more
+        // details.
+        partial_note.insert_validity_commitment(context, sender_and_completer);
 
         partial_note
     }
@@ -287,18 +278,8 @@ pub contract NFT {
         // Set the public NFT owner to zero
         public_owners_storage.write(AztecAddress::zero());
 
-        // We verify that the partial note we're completing is valid (i.e. completer is correct, it uses the correct
-        // state variable's storage slot, and it is internally consistent). We *could* clear the storage since each
-        // partial note should only be used once, but since the AVM offers no gas refunds for doing so this would just
-        // make the transaction be more expensive. We don't worry about the validity commitment being checked against
-        // multiple times because it is up to the caller to ensure that a partial note is used only once (see function
-        // docs of `finalize_transfer_to_private`).
-        let validity_commitment = partial_note.compute_validity_commitment(from_and_completer);
-        assert(
-            context.nullifier_exists(validity_commitment, context.this_address()),
-            "Invalid partial note or completer",
-        );
-        partial_note.complete(token_id, context);
+        // We finalize the transfer by completing the partial note.
+        partial_note.complete(context, from_and_completer, token_id);
     }
 
     /**

--- a/noir-projects/noir-contracts/contracts/app/nft_contract/src/main.nr
+++ b/noir-projects/noir-contracts/contracts/app/nft_contract/src/main.nr
@@ -200,7 +200,7 @@ pub contract NFT {
         let sender_and_completer = context.msg_sender();
 
         // We setup a partial note with unpopulated/zero token id for 'to'.
-        let partial_note = NFTNote::setup_partial_note(
+        let partial_note = NFTNote::partial(
             to,
             storage.private_nfts.at(to).storage_slot,
             context,

--- a/noir-projects/noir-contracts/contracts/app/nft_contract/src/types/nft_note.nr
+++ b/noir-projects/noir-contracts/contracts/app/nft_contract/src/types/nft_note.nr
@@ -118,7 +118,7 @@ impl NFTNote {
     ///
     /// As part of the partial note creation process, a log will be sent to `recipient` from `sender` so that they can
     /// discover the note. `recipient` will typically be the same as `owner`.
-    pub fn setup_partial_note(
+    pub fn partial(
         owner: AztecAddress,
         storage_slot: Field,
         context: &mut PrivateContext,

--- a/noir-projects/noir-contracts/contracts/app/nft_contract/src/types/nft_note.nr
+++ b/noir-projects/noir-contracts/contracts/app/nft_contract/src/types/nft_note.nr
@@ -205,24 +205,33 @@ pub struct PartialNFTNote {
 }
 
 impl PartialNFTNote {
-    /// Computes a partial note validity commitment. This commitment is stored in public storage when creating the
-    /// partial note in private and then is used to check that completer and note are valid upon partial note completion
-    /// in public (completer is the entity that can complete the partial note).
-    pub fn compute_validity_commitment(self, completer: AztecAddress) -> Field {
-        poseidon2_hash_with_separator(
-            [self.commitment, completer.to_field()],
-            GENERATOR_INDEX__PARTIAL_NOTE_VALIDITY_COMMITMENT,
-        )
+    /// Computes and records a validity commitment for this partial note in the nullifier tree. The commitment
+    /// cryptographically binds the note's private data with the designated completer address. When the note is later
+    /// completed in public execution, this commitment allows verification that both the partial note (e.g. that the
+    /// storage slot corresponds to the correct owner, and that we're using the correct state variable) and completer
+    /// are legitimate. This function should be invoked during private note creation, before the note is completed.
+    pub fn insert_validity_commitment(self, context: &mut PrivateContext, completer: AztecAddress) {
+        // The validity commitment can be safely pushed to the nullifier tree since it uses its own separator,
+        // making collisions with actual note nullifiers practically impossible.
+        context.push_nullifier(self.compute_validity_commitment(completer));
     }
 
     /// Completes the partial note, creating a new note that can be used like any other NFTNote.
-    pub fn complete(self, token_id: Field, context: &mut PublicContext) {
+    pub fn complete(self, context: &mut PublicContext, completer: AztecAddress, token_id: Field) {
         // A note with a value of zero is valid, but we cannot currently complete a partial note with such a value
         // because this will result in the completion log having its last field set to 0. Public logs currently do not
         // track their length, and so trailing zeros are simply trimmed. This results in the completion log missing its
         // last field (the value), and note discovery failing.
         // TODO(#11636): remove this
         assert(token_id != 0, "Cannot complete a PartialNFTNote with a value of 0");
+
+        // We verify that the partial note we're completing is valid (i.e. completer is correct, it uses the correct
+        // state variable's storage slot, and it is internally consistent).
+        let validity_commitment = self.compute_validity_commitment(completer);
+        assert(
+            context.nullifier_exists(validity_commitment, context.this_address()),
+            "Invalid partial note or completer",
+        );
 
         // We need to do two things:
         //  - emit a public log containing the public fields (the token id). The contract will later find it by
@@ -232,6 +241,13 @@ impl PartialNFTNote {
         //  inserted in public as the public values are provided and the note hash computed.
         context.emit_public_log(self.compute_note_completion_log(token_id));
         context.push_note_hash(self.compute_complete_note_hash(token_id));
+    }
+
+    fn compute_validity_commitment(self, completer: AztecAddress) -> Field {
+        poseidon2_hash_with_separator(
+            [self.commitment, completer.to_field()],
+            GENERATOR_INDEX__PARTIAL_NOTE_VALIDITY_COMMITMENT,
+        )
     }
 
     fn compute_note_completion_log(self, token_id: Field) -> [Field; 2] {

--- a/noir-projects/noir-contracts/contracts/app/nft_contract/src/types/nft_note.nr
+++ b/noir-projects/noir-contracts/contracts/app/nft_contract/src/types/nft_note.nr
@@ -109,21 +109,22 @@ impl NFTNote {
     /// later completed in public. This is a powerful technique for scenarios in which the token id cannot be known in
     /// private (e.g. because it depends on some public state, such as a DEX).
     ///
-    /// The returned `PartialNFTNote` value must be sent to public execution via a secure channel, since it is not
-    /// possible to verify the integrity of its contents due to it hiding information. The recommended ways to do this
-    /// are to retrieve it from public storage, or to receive it in an internal public function call.
+    /// This function inserts a partial note validity commitment into the nullifier tree to be later on able to verify
+    /// that the partial note and completer are legitimate. See function docs of `compute_validity_commitment` for more
+    /// details.
     ///
     /// Each partial note should only be used once, since otherwise multiple notes would be linked together and known to
     /// belong to the same owner.
     ///
     /// As part of the partial note creation process, a log will be sent to `recipient` from `sender` so that they can
     /// discover the note. `recipient` will typically be the same as `owner`.
-    pub fn partial(
+    pub fn setup_partial_note(
         owner: AztecAddress,
         storage_slot: Field,
         context: &mut PrivateContext,
         recipient: AztecAddress,
         sender: AztecAddress,
+        completer: AztecAddress,
     ) -> PartialNFTNote {
         // Safety: We use the randomness to preserve the privacy of the note recipient by preventing brute-forcing,
         // so a malicious sender could use non-random values to make the note less private. But they already know
@@ -154,7 +155,15 @@ impl NFTNote {
         let length = encrypted_log.len();
         context.emit_private_log(encrypted_log, length);
 
-        PartialNFTNote { commitment }
+        let partial_note = PartialNFTNote { commitment };
+
+        // Now we compute the validity commitment and push it to the nullifier tree. It can be safely pushed to
+        // the nullifier tree since it uses its own separator, making collisions with actual note nullifiers
+        // practically impossible.
+        let validity_commitment = partial_note.compute_validity_commitment(completer);
+        context.push_nullifier(validity_commitment);
+
+        partial_note
     }
 }
 
@@ -205,17 +214,6 @@ pub struct PartialNFTNote {
 }
 
 impl PartialNFTNote {
-    /// Computes and records a validity commitment for this partial note in the nullifier tree. The commitment
-    /// cryptographically binds the note's private data with the designated completer address. When the note is later
-    /// completed in public execution, this commitment allows verification that both the partial note (e.g. that the
-    /// storage slot corresponds to the correct owner, and that we're using the correct state variable) and completer
-    /// are legitimate. This function should be invoked during private note creation, before the note is completed.
-    pub fn insert_validity_commitment(self, context: &mut PrivateContext, completer: AztecAddress) {
-        // The validity commitment can be safely pushed to the nullifier tree since it uses its own separator,
-        // making collisions with actual note nullifiers practically impossible.
-        context.push_nullifier(self.compute_validity_commitment(completer));
-    }
-
     /// Completes the partial note, creating a new note that can be used like any other NFTNote.
     pub fn complete(self, context: &mut PublicContext, completer: AztecAddress, token_id: Field) {
         // A note with a value of zero is valid, but we cannot currently complete a partial note with such a value
@@ -243,7 +241,12 @@ impl PartialNFTNote {
         context.push_note_hash(self.compute_complete_note_hash(token_id));
     }
 
-    fn compute_validity_commitment(self, completer: AztecAddress) -> Field {
+    /// Computes a validity commitment for this partial note. The commitment cryptographically binds the note's private
+    /// data with the designated completer address. When the note is later completed in public execution, we can load
+    /// this commitment from the nullifier tree and verify that both the partial note (e.g. that the storage slot
+    /// corresponds to the correct owner, and that we're using the correct state variable) and completer are
+    /// legitimate.
+    pub fn compute_validity_commitment(self, completer: AztecAddress) -> Field {
         poseidon2_hash_with_separator(
             [self.commitment, completer.to_field()],
             GENERATOR_INDEX__PARTIAL_NOTE_VALIDITY_COMMITMENT,

--- a/noir-projects/noir-contracts/contracts/app/simple_token_contract/src/main.nr
+++ b/noir-projects/noir-contracts/contracts/app/simple_token_contract/src/main.nr
@@ -223,15 +223,14 @@ pub contract SimpleToken {
         context: &mut PrivateContext,
         storage: Storage<&mut PrivateContext>,
     ) -> PartialUintNote {
-        let partial_note = UintNote::partial(
+        let partial_note = UintNote::setup_partial_note(
             to,
             storage.balances.at(to).set.storage_slot,
             context,
             to,
             from,
+            from,
         );
-
-        partial_note.insert_validity_commitment(context, from);
 
         partial_note
     }

--- a/noir-projects/noir-contracts/contracts/app/simple_token_contract/src/main.nr
+++ b/noir-projects/noir-contracts/contracts/app/simple_token_contract/src/main.nr
@@ -231,8 +231,7 @@ pub contract SimpleToken {
             from,
         );
 
-        let validity_commitment = partial_note.compute_validity_commitment(context.msg_sender());
-        context.push_nullifier(validity_commitment);
+        partial_note.insert_validity_commitment(context, from);
 
         partial_note
     }
@@ -276,12 +275,7 @@ pub contract SimpleToken {
         let from_balance = storage.public_balances.at(from_and_completer).read().sub(amount);
         storage.public_balances.at(from_and_completer).write(from_balance);
 
-        let validity_commitment = partial_note.compute_validity_commitment(from_and_completer);
-        assert(
-            context.nullifier_exists(validity_commitment, context.this_address()),
-            "Invalid partial note or completer",
-        );
-        partial_note.complete(amount, context);
+        partial_note.complete(context, from_and_completer, amount);
     }
 
     #[private]
@@ -331,12 +325,7 @@ pub contract SimpleToken {
         let supply = storage.total_supply.read().add(amount);
         storage.total_supply.write(supply);
 
-        let validity_commitment = partial_note.compute_validity_commitment(completer);
-        assert(
-            context.nullifier_exists(validity_commitment, context.this_address()),
-            "Invalid partial note or completer",
-        );
-        partial_note.complete(amount, context);
+        partial_note.complete(context, completer, amount);
     }
 
     #[public]

--- a/noir-projects/noir-contracts/contracts/app/simple_token_contract/src/main.nr
+++ b/noir-projects/noir-contracts/contracts/app/simple_token_contract/src/main.nr
@@ -232,10 +232,7 @@ pub contract SimpleToken {
         );
 
         let validity_commitment = partial_note.compute_validity_commitment(context.msg_sender());
-
-        SimpleToken::at(context.this_address())
-            ._set_uint_partial_note_validity(validity_commitment)
-            .enqueue(context);
+        context.push_nullifier(validity_commitment);
 
         partial_note
     }
@@ -279,8 +276,9 @@ pub contract SimpleToken {
         let from_balance = storage.public_balances.at(from_and_completer).read().sub(amount);
         storage.public_balances.at(from_and_completer).write(from_balance);
 
+        let validity_commitment = partial_note.compute_validity_commitment(from_and_completer);
         assert(
-            context.storage_read(partial_note.compute_validity_commitment(from_and_completer)),
+            context.nullifier_exists(validity_commitment, context.this_address()),
             "Invalid partial note or completer",
         );
         partial_note.complete(amount, context);
@@ -333,17 +331,12 @@ pub contract SimpleToken {
         let supply = storage.total_supply.read().add(amount);
         storage.total_supply.write(supply);
 
+        let validity_commitment = partial_note.compute_validity_commitment(completer);
         assert(
-            context.storage_read(partial_note.compute_validity_commitment(completer)),
+            context.nullifier_exists(validity_commitment, context.this_address()),
             "Invalid partial note or completer",
         );
         partial_note.complete(amount, context);
-    }
-
-    #[public]
-    #[internal]
-    fn _set_uint_partial_note_validity(validity_commitment: Field) {
-        context.storage_write(validity_commitment, true);
     }
 
     #[public]

--- a/noir-projects/noir-contracts/contracts/app/simple_token_contract/src/main.nr
+++ b/noir-projects/noir-contracts/contracts/app/simple_token_contract/src/main.nr
@@ -223,7 +223,7 @@ pub contract SimpleToken {
         context: &mut PrivateContext,
         storage: Storage<&mut PrivateContext>,
     ) -> PartialUintNote {
-        let partial_note = UintNote::setup_partial_note(
+        let partial_note = UintNote::partial(
             to,
             storage.balances.at(to).set.storage_slot,
             context,

--- a/noir-projects/noir-contracts/contracts/app/token_contract/src/main.nr
+++ b/noir-projects/noir-contracts/contracts/app/token_contract/src/main.nr
@@ -452,14 +452,14 @@ pub contract Token {
         // a different one) once this information is hidden in the partial note commitment. We also want to verify that
         // only the caller of this function can complete the partial note.
         //
-        // We achieve the above by storing a flag in public storage under a slot index equal to its
-        // `validity_commitment`. This commitment contains all the necessary information to verify the completer and
-        // to validate the partial note.
+        // We achieve this by storing a `validity_commitment` in the nullifier tree. This commitment contains all
+        // the necessary information to verify the completer and the partial note. Later, if we successfully
+        // read this commitment from the nullifier tree, we know that the partial note is valid.
         let validity_commitment = partial_note.compute_validity_commitment(context.msg_sender());
 
-        Token::at(context.this_address())
-            ._set_uint_partial_note_validity(validity_commitment)
-            .enqueue(context);
+        // The validity commitment can be safely pushed to the nullifier tree since it uses its own separator,
+        // making collisions with actual note nullifiers practically impossible.
+        context.push_nullifier(validity_commitment);
 
         partial_note
     }
@@ -530,8 +530,9 @@ pub contract Token {
         // make the transaction be more expensive. We don't worry about the validity commitment being checked against
         // multiple times because it is up to the caller to ensure that a partial note is used only once (see function
         // docs of `finalize_transfer_to_private`).
+        let validity_commitment = partial_note.compute_validity_commitment(from_and_completer);
         assert(
-            context.storage_read(partial_note.compute_validity_commitment(from_and_completer)),
+            context.nullifier_exists(validity_commitment, context.this_address()),
             "Invalid partial note or completer",
         );
         partial_note.complete(amount, context);
@@ -625,21 +626,12 @@ pub contract Token {
         // slot, and it is internally consistent). We *could* clear the storage since each partial note should only be
         // used once, but since the AVM offers no gas refunds for doing so this would just make the transaction be more
         // expensive.
+        let validity_commitment = partial_note.compute_validity_commitment(completer);
         assert(
-            context.storage_read(partial_note.compute_validity_commitment(completer)),
+            context.nullifier_exists(validity_commitment, context.this_address()),
             "Invalid partial note or completer",
         );
         partial_note.complete(amount, context);
-    }
-
-    #[public]
-    #[internal]
-    fn _set_uint_partial_note_validity(validity_commitment: Field) {
-        // We store the partial note validity flag in a slot equal to its validity commitment. This is safe because
-        // the commitment is computed using a generator different from the one used to compute storage slots, so there
-        // can be no collisions. We could consider storing all pending partial notes in e.g. some array, but ultimately
-        // this is pointless: all we need to verify is that the note is valid.
-        context.storage_write(validity_commitment, true);
     }
 
     /// Internal ///

--- a/noir-projects/noir-contracts/contracts/app/token_contract/src/main.nr
+++ b/noir-projects/noir-contracts/contracts/app/token_contract/src/main.nr
@@ -441,18 +441,14 @@ pub contract Token {
         context: &mut PrivateContext,
         storage: Storage<&mut PrivateContext>,
     ) -> PartialUintNote {
-        let partial_note = UintNote::partial(
+        let partial_note = UintNote::setup_partial_note(
             to,
             storage.balances.at(to).set.storage_slot,
             context,
             to,
             from,
+            context.msg_sender(),
         );
-
-        // We insert the partial note validity commitment into the nullifier tree to be later on able to verify that
-        // the partial note and completer are legitimate. See function docs of `insert_validity_commitment` for more
-        // details.
-        partial_note.insert_validity_commitment(context, context.msg_sender());
 
         partial_note
     }

--- a/noir-projects/noir-contracts/contracts/app/token_contract/src/main.nr
+++ b/noir-projects/noir-contracts/contracts/app/token_contract/src/main.nr
@@ -428,7 +428,9 @@ pub contract Token {
     // docs:end:prepare_private_balance_increase
 
     /// This function exists separately from `prepare_private_balance_increase` solely as an optimization as it allows
-    /// us to have it inlined in the `transfer_to_private` function which results in one fewer kernel iteration.
+    /// us to have it inlined in the `transfer_to_private` function which results in one fewer kernel iteration. Note
+    /// that in this case we don't pass `completer` as an argument to this function because in all the callsites we
+    /// want to use the message sender as the completer anyway.
     ///
     /// TODO(#9180): Consider adding macro support for functions callable both as an entrypoint and as an internal
     /// function.
@@ -447,19 +449,10 @@ pub contract Token {
             from,
         );
 
-        // We can't simply return the partial note because we won't be able to later on verify that it was created
-        // correctly (e.g. that the storage slot corresponds to the owner, and that we're using the balance set and not
-        // a different one) once this information is hidden in the partial note commitment. We also want to verify that
-        // only the caller of this function can complete the partial note.
-        //
-        // We achieve this by storing a `validity_commitment` in the nullifier tree. This commitment contains all
-        // the necessary information to verify the completer and the partial note. Later, if we successfully
-        // read this commitment from the nullifier tree, we know that the partial note is valid.
-        let validity_commitment = partial_note.compute_validity_commitment(context.msg_sender());
-
-        // The validity commitment can be safely pushed to the nullifier tree since it uses its own separator,
-        // making collisions with actual note nullifiers practically impossible.
-        context.push_nullifier(validity_commitment);
+        // We insert the partial note validity commitment into the nullifier tree to be later on able to verify that
+        // the partial note and completer are legitimate. See function docs of `insert_validity_commitment` for more
+        // details.
+        partial_note.insert_validity_commitment(context, context.msg_sender());
 
         partial_note
     }
@@ -524,18 +517,8 @@ pub contract Token {
         let from_balance = storage.public_balances.at(from_and_completer).read().sub(amount);
         storage.public_balances.at(from_and_completer).write(from_balance);
 
-        // We verify that the partial note we're completing is valid (i.e. completer is correct, it uses the correct
-        // state variable's storage slot, and it is internally consistent). We *could* clear the storage since each
-        // partial note should only be used once, but since the AVM offers no gas refunds for doing so this would just
-        // make the transaction be more expensive. We don't worry about the validity commitment being checked against
-        // multiple times because it is up to the caller to ensure that a partial note is used only once (see function
-        // docs of `finalize_transfer_to_private`).
-        let validity_commitment = partial_note.compute_validity_commitment(from_and_completer);
-        assert(
-            context.nullifier_exists(validity_commitment, context.this_address()),
-            "Invalid partial note or completer",
-        );
-        partial_note.complete(amount, context);
+        // We finalize the transfer by completing the partial note.
+        partial_note.complete(context, from_and_completer, amount);
     }
 
     // docs:start:mint_to_private
@@ -622,16 +605,8 @@ pub contract Token {
         let supply = storage.total_supply.read().add(amount);
         storage.total_supply.write(supply);
 
-        // We verify that the partial note we're completing is valid (i.e. it uses the correct state variable's storage
-        // slot, and it is internally consistent). We *could* clear the storage since each partial note should only be
-        // used once, but since the AVM offers no gas refunds for doing so this would just make the transaction be more
-        // expensive.
-        let validity_commitment = partial_note.compute_validity_commitment(completer);
-        assert(
-            context.nullifier_exists(validity_commitment, context.this_address()),
-            "Invalid partial note or completer",
-        );
-        partial_note.complete(amount, context);
+        // We finalize the transfer by completing the partial note.
+        partial_note.complete(context, completer, amount);
     }
 
     /// Internal ///

--- a/noir-projects/noir-contracts/contracts/app/token_contract/src/main.nr
+++ b/noir-projects/noir-contracts/contracts/app/token_contract/src/main.nr
@@ -441,7 +441,7 @@ pub contract Token {
         context: &mut PrivateContext,
         storage: Storage<&mut PrivateContext>,
     ) -> PartialUintNote {
-        let partial_note = UintNote::setup_partial_note(
+        let partial_note = UintNote::partial(
             to,
             storage.balances.at(to).set.storage_slot,
             context,

--- a/yarn-project/end-to-end/src/bench/client_flows/transfers.test.ts
+++ b/yarn-project/end-to-end/src/bench/client_flows/transfers.test.ts
@@ -150,10 +150,10 @@ describe('Transfer benchmark', () => {
                * We should have created the following nullifiers:
                * - One per created note
                * - One for the transaction
-               * - One for the fee note if we're using private fpc
+               * - One for the fee note and one for the partial note validity commitment if we're using private fpc
                */
               expect(txEffects!.data.nullifiers.length).toBe(
-                notesToCreate + 1 + (benchmarkingPaymentMethod === 'private_fpc' ? 1 : 0),
+                notesToCreate + 1 + (benchmarkingPaymentMethod === 'private_fpc' ? 2 : 0),
               );
               /** We should have created 4 new notes,
                *  - One for the recipient

--- a/yarn-project/simulator/src/public/avm/fixtures/base_avm_simulation_tester.ts
+++ b/yarn-project/simulator/src/public/avm/fixtures/base_avm_simulation_tester.ts
@@ -100,4 +100,9 @@ export abstract class BaseAvmSimulationTester {
     );
     await this.merkleTrees.sequentialInsert(MerkleTreeId.NULLIFIER_TREE, [contractAddressNullifier.toBuffer()]);
   }
+
+  async insertNullifier(contractThatEmitted: AztecAddress, nullifier: Fr) {
+    const siloedNullifier = await siloNullifier(contractThatEmitted, nullifier);
+    await this.merkleTrees.sequentialInsert(MerkleTreeId.NULLIFIER_TREE, [siloedNullifier.toBuffer()]);
+  }
 }

--- a/yarn-project/simulator/src/public/public_tx_simulator/apps_tests/amm_test.ts
+++ b/yarn-project/simulator/src/public/public_tx_simulator/apps_tests/amm_test.ts
@@ -139,18 +139,6 @@ async function addLiquidity(
   const liquidityPartialNote = {
     commitment: new Fr(99),
   };
-  const refundToken0PartialNoteValidityCommitment = await computePartialNoteValidityCommitment(
-    refundToken0PartialNote,
-    amm.address,
-  );
-  const refundToken1PartialNoteValidityCommitment = await computePartialNoteValidityCommitment(
-    refundToken1PartialNote,
-    amm.address,
-  );
-  const liquidityPartialNoteValidityCommitment = await computePartialNoteValidityCommitment(
-    liquidityPartialNote,
-    amm.address,
-  );
   return await tester.simulateTxWithLabel(
     /*txLabel=*/ 'AMM/add_liquidity',
     /*sender=*/ sender,
@@ -163,33 +151,12 @@ async function addLiquidity(
         args: [/*to=*/ amm.address, /*amount=*/ amount0Max],
         address: token0.address,
       },
-      // token0.prepare_private_balance_increase enqueues a call to _set_uint_partial_note_validity
-      {
-        sender: token0.address, // INTERNAL FUNCTION! Sender must be 'this'.
-        fnName: '_set_uint_partial_note_validity',
-        args: [refundToken0PartialNoteValidityCommitment],
-        address: token0.address,
-      },
       // token1.transfer_to_public enqueues a call to _increase_public_balance
       {
         sender: token1.address, // INTERNAL FUNCTION! Sender must be 'this'.
         fnName: '_increase_public_balance',
         args: [/*to=*/ amm.address, /*amount=*/ amount1Max],
         address: token1.address,
-      },
-      // token1.prepare_private_balance_increase enqueues a call to _set_uint_partial_note_validity
-      {
-        sender: token1.address, // INTERNAL FUNCTION! Sender must be 'this'.
-        fnName: '_set_uint_partial_note_validity',
-        args: [refundToken1PartialNoteValidityCommitment],
-        address: token1.address,
-      },
-      // liquidityToken.prepare_private_balance_increase enqueues a call to _set_uint_partial_note_validity
-      {
-        sender: liquidityToken.address, // INTERNAL FUNCTION! Sender must be 'this'.
-        fnName: '_set_uint_partial_note_validity',
-        args: [liquidityPartialNoteValidityCommitment],
-        address: liquidityToken.address,
       },
       // amm.add_liquidity enqueues a call to _add_liquidity
       {
@@ -229,10 +196,6 @@ async function swapExactTokensForTokens(
   const tokenOutPartialNote = {
     commitment: new Fr(66),
   };
-  const tokenOutPartialNoteValidityCommitment = await computePartialNoteValidityCommitment(
-    tokenOutPartialNote,
-    amm.address,
-  );
 
   return await tester.simulateTxWithLabel(
     /*txLabel=*/ 'AMM/swap_exact_tokens_for_tokens',
@@ -246,14 +209,6 @@ async function swapExactTokensForTokens(
         args: [/*to=*/ amm.address, /*amount=*/ amountIn],
         address: tokenIn.address,
       },
-      // tokenOut.prepare_private_balance_increase enqueues a call to _set_uint_partial_note_validity
-      {
-        sender: tokenOut.address, // INTERNAL FUNCTION! Sender must be 'this'.
-        fnName: '_set_uint_partial_note_validity',
-        args: [tokenOutPartialNoteValidityCommitment],
-        address: tokenOut.address,
-      },
-
       {
         sender: amm.address, // INTERNAL FUNCTION! Sender must be 'this'.
         fnName: '_swap_exact_tokens_for_tokens',
@@ -282,14 +237,6 @@ async function removeLiquidity(
   const token1PartialNote = {
     commitment: new Fr(222),
   };
-  const token0PartialNoteValidityCommitment = await computePartialNoteValidityCommitment(
-    token0PartialNote,
-    amm.address,
-  );
-  const token1PartialNoteValidityCommitment = await computePartialNoteValidityCommitment(
-    token1PartialNote,
-    amm.address,
-  );
   return await tester.simulateTxWithLabel(
     /*txLabel=*/ 'AMM/remove_liquidity',
     /*sender=*/ sender,
@@ -301,20 +248,6 @@ async function removeLiquidity(
         fnName: '_increase_public_balance',
         args: [/*to=*/ amm.address, /*amount=*/ liquidity],
         address: liquidityToken.address,
-      },
-      // token0.prepare_private_balance_increase enqueues a call to _set_uint_partial_note_validity
-      {
-        sender: token0.address, // INTERNAL FUNCTION! Sender must be 'this'.
-        fnName: '_set_uint_partial_note_validity',
-        args: [token0PartialNoteValidityCommitment],
-        address: token0.address,
-      },
-      // token1.prepare_private_balance_increase enqueues a call to _set_uint_partial_note_validity
-      {
-        sender: token1.address, // INTERNAL FUNCTION! Sender must be 'this'.
-        fnName: '_set_uint_partial_note_validity',
-        args: [token1PartialNoteValidityCommitment],
-        address: token1.address,
       },
       // amm.remove_liquidity enqueues a call to _remove_liquidity
       {
@@ -336,12 +269,5 @@ async function removeLiquidity(
         address: amm.address,
       },
     ],
-  );
-}
-
-async function computePartialNoteValidityCommitment(partialNote: { commitment: Fr }, completer: AztecAddress) {
-  return await poseidon2HashWithSeparator(
-    [partialNote.commitment, completer],
-    GeneratorIndex.PARTIAL_NOTE_VALIDITY_COMMITMENT,
   );
 }


### PR DESCRIPTION
Fixes #14365

Instead of storing partial note validity commitment in public storage we store it in the nullifier tree. This yields the following savings:
1. One less public function call since we can insert the nullifier directly from private (as opposed to us enqueueing a public call to write the info to pub storage),
2. only 1 fields sent to DA instead of 2 since nullifier tree write does not need an index (unlike pub tree write).

## What tests did I decide to write
- I decided to not write any new single tx tests because that is already tested in the token contract in the `transfer_to_private.nr::transfer_to_private_internal_orchestration` test case.
- I decided to not write any new multi tx tests because that is already tested in the token contract in the `transfer_to_private.nr::transfer_to_private_external_orchestration` test case.

Seems to be that it's all sufficiently covered already and hence no new test was needed.