### PR TITLE
refactor: syncNotes --> syncPrivateState

### DIFF
--- a/boxes/boxes/react/src/pages/contract.tsx
+++ b/boxes/boxes/react/src/pages/contract.tsx
@@ -2,7 +2,7 @@ import { useState } from 'react';
 import { Contract, FunctionType } from '@aztec/aztec.js';
 import { useNumber } from '../hooks/useNumber';
 
-const IGNORE_FUNCTIONS = ['constructor', 'sync_notes'];
+const IGNORE_FUNCTIONS = ['constructor', 'sync_private_state'];
 
 export function ContractComponent({ contract }: { contract: Contract }) {
   const [showInput, setShowInput] = useState(true);

--- a/boxes/boxes/vite/src/pages/contract.tsx
+++ b/boxes/boxes/vite/src/pages/contract.tsx
@@ -2,7 +2,7 @@ import { useState } from "react";
 import { Contract, FunctionType } from "@aztec/aztec.js";
 import { useNumber } from "../hooks/useNumber";
 
-const IGNORE_FUNCTIONS = ["constructor", "sync_notes"];
+const IGNORE_FUNCTIONS = ["constructor", "sync_private_state"];
 
 export function ContractComponent({ contract }: { contract: Contract }) {
   const [showInput, setShowInput] = useState(true);

--- a/noir-projects/aztec-nr/aztec/src/macros/aztec.nr
+++ b/noir-projects/aztec-nr/aztec/src/macros/aztec.nr
@@ -10,7 +10,7 @@ use crate::{
 };
 
 /// Marks a contract as an Aztec contract, generating the interfaces for its functions and notes, as well as injecting
-/// the `sync_notes` utility function PXE requires in order to discover notes.
+/// the `sync_private_state` utility function PXE requires in order to discover notes.
 /// Note: This is a module annotation, so the returned quote gets injected inside the module (contract) itself.
 pub comptime fn aztec(m: Module) -> Quoted {
     let interface = generate_contract_interface(m);
@@ -23,14 +23,14 @@ pub comptime fn aztec(m: Module) -> Quoted {
         generate_contract_library_method_compute_note_hash_and_nullifier();
     let note_exports = generate_note_exports();
     let public_dispatch = generate_public_dispatch(m);
-    let sync_notes = generate_sync_notes();
+    let sync_private_state = generate_sync_private_state();
 
     quote {
         $note_exports
         $interface
         $contract_library_method_compute_note_hash_and_nullifier
         $public_dispatch
-        $sync_notes
+        $sync_private_state
     }
 }
 
@@ -264,7 +264,7 @@ comptime fn generate_note_exports() -> Quoted {
         .join(quote {})
 }
 
-comptime fn generate_sync_notes() -> Quoted {
+comptime fn generate_sync_private_state() -> Quoted {
     // We obtain the `utility` function on the next line instead of directly doing
     // `#[aztec::macros::functions::utility]` in the returned quote because the latter would result in the function
     // attribute having the full path in the ABI. This is undesirable because we use the information in the ABI only
@@ -275,7 +275,7 @@ comptime fn generate_sync_notes() -> Quoted {
     // need to do anything extra.
     quote {
         #[$utility]
-        unconstrained fn sync_notes() {
+        unconstrained fn sync_private_state() {
         }
     }
 }

--- a/noir-projects/aztec-nr/aztec/src/messages/discovery/pending_tagged_log.nr
+++ b/noir-projects/aztec-nr/aztec/src/messages/discovery/pending_tagged_log.nr
@@ -5,12 +5,12 @@ use protocol_types::{
     traits::{Deserialize, Serialize},
 };
 
-// Base slot for the pending tagged log array to which the syncNotes oracle inserts found private logs.
+// Base slot for the pending tagged log array to which the syncPrivateState oracle inserts found private logs.
 pub(crate) global PENDING_TAGGED_LOG_ARRAY_BASE_SLOT: Field = sha256_to_field(
     "AZTEC_NR::PENDING_TAGGED_PENDING_TAGGED_LOG_ARRAY_BASE_SLOT".as_bytes(),
 );
 
-/// Represents a log as it is stored in the pending tagged log array to which the syncNotes oracle inserts found private log.
+/// Represents a log as it is stored in the pending tagged log array to which the syncPrivateState oracle inserts found private log.
 #[derive(Deserialize, Serialize)]
 pub(crate) struct PendingTaggedLog {
     pub log: BoundedVec<Field, PRIVATE_LOG_SIZE_IN_FIELDS>,

--- a/noir-projects/aztec-nr/aztec/src/messages/discovery/private_logs.nr
+++ b/noir-projects/aztec-nr/aztec/src/messages/discovery/private_logs.nr
@@ -13,7 +13,7 @@ use crate::{
             PARTIAL_NOTE_PRIVATE_MSG_TYPE_ID, PRIVATE_EVENT_MSG_TYPE_ID, PRIVATE_NOTE_MSG_TYPE_ID,
         },
     },
-    oracle::{logs::store_private_event_log, message_discovery::sync_notes},
+    oracle::{logs::store_private_event_log, message_discovery::sync_private_state},
     utils::array,
 };
 
@@ -31,10 +31,10 @@ pub unconstrained fn fetch_and_process_private_tagged_logs<Env>(
     contract_address: AztecAddress,
     compute_note_hash_and_nullifier: ComputeNoteHashAndNullifier<Env>,
 ) {
-    // We will eventually perform log discovery via tagging here, but for now we simply call the `syncNotes` oracle.
+    // We will eventually perform log discovery via tagging here, but for now we simply call the `syncPrivateState` oracle.
     // This makes PXE synchronize tags, download logs and store the pending tagged logs in capsule array which are then
     // retrieved and processed here.
-    sync_notes(PENDING_TAGGED_LOG_ARRAY_BASE_SLOT);
+    sync_private_state(PENDING_TAGGED_LOG_ARRAY_BASE_SLOT);
 
     // Get the logs from the capsule array and process them one by one
     let logs =

--- a/noir-projects/aztec-nr/aztec/src/oracle/message_discovery.nr
+++ b/noir-projects/aztec-nr/aztec/src/oracle/message_discovery.nr
@@ -6,12 +6,12 @@ use dep::protocol_types::{
 
 /// Finds new private logs that may have been sent to all registered accounts in PXE in the current contract and makes
 /// them available for later processing in Noir by storing them in a capsule array.
-pub unconstrained fn sync_notes(pending_tagged_log_array_base_slot: Field) {
-    sync_notes_oracle(pending_tagged_log_array_base_slot);
+pub unconstrained fn sync_private_state(pending_tagged_log_array_base_slot: Field) {
+    sync_private_state_oracle(pending_tagged_log_array_base_slot);
 }
 
-#[oracle(syncNotes)]
-unconstrained fn sync_notes_oracle(pending_tagged_log_array_base_slot: Field) {}
+#[oracle(syncPrivateState)]
+unconstrained fn sync_private_state_oracle(pending_tagged_log_array_base_slot: Field) {}
 
 /// Informs PXE of a note's existence so that it can later be retrieved by the `getNotes` oracle. The note will be
 /// scoped to `contract_address`, meaning other contracts will not be able to access it unless authorized.

--- a/noir-projects/noir-contracts/contracts/test/counter_contract/src/main.nr
+++ b/noir-projects/noir-contracts/contracts/test/counter_contract/src/main.nr
@@ -174,7 +174,7 @@ pub contract Counter {
 
         // Checking that the note was discovered from private logs
         env.impersonate(contract_address);
-        sync_notes();
+        sync_private_state();
         let counter_slot = Counter::storage_layout().counters.slot;
         let owner_storage_slot = derive_storage_slot_in_map(counter_slot, owner);
         let mut options = NoteViewerOptions::new();
@@ -196,7 +196,7 @@ pub contract Counter {
 
         // Checking that the note was discovered from private logs
         env.advance_block_by(1);
-        sync_notes();
+        sync_private_state();
         let notes: BoundedVec<ValueNote, MAX_NOTES_PER_PAGE> =
             view_notes(owner_storage_slot, options);
         assert(get_counter(owner) == 7);
@@ -212,7 +212,7 @@ pub contract Counter {
 
         // Checking that the note was discovered from private logs
         env.advance_block_by(1);
-        sync_notes();
+        sync_private_state();
         let notes: BoundedVec<ValueNote, MAX_NOTES_PER_PAGE> =
             view_notes(owner_storage_slot, options);
         assert(notes.len() == 4);
@@ -227,7 +227,7 @@ pub contract Counter {
 
         // Checking that the note was discovered from private logs
         env.advance_block_by(1);
-        sync_notes();
+        sync_private_state();
         let notes: BoundedVec<ValueNote, MAX_NOTES_PER_PAGE> =
             view_notes(owner_storage_slot, options);
         assert(get_counter(owner) == 6);

--- a/noir-projects/noir-contracts/contracts/test/txe_test_contract/src/test.nr
+++ b/noir-projects/noir-contracts/contracts/test/txe_test_contract/src/test.nr
@@ -51,7 +51,7 @@ unconstrained fn new_calling_flow_increment_self_and_other() {
 
     env.impersonate(contract_address);
 
-    TXETest::sync_notes();
+    TXETest::sync_private_state();
     let mut options = NoteViewerOptions::new();
     let counter_slot = TXETest::storage_layout().counters.slot;
 
@@ -65,7 +65,7 @@ unconstrained fn new_calling_flow_increment_self_and_other() {
 
     env.impersonate(contract_address2);
 
-    TXETest::sync_notes();
+    TXETest::sync_private_state();
     let counter_slot = TXETest::storage_layout().counters.slot;
 
     let owner_storage_slot = derive_storage_slot_in_map(counter_slot, owner);
@@ -93,7 +93,7 @@ unconstrained fn new_calling_flow_increment_with_new_call_flow() {
 
     env.impersonate(contract_address);
 
-    TXETest::sync_notes();
+    TXETest::sync_private_state();
     let mut options = NoteViewerOptions::new();
     let counter_slot = TXETest::storage_layout().counters.slot;
 

--- a/playground/src/components/contract/Contract.tsx
+++ b/playground/src/components/contract/Contract.tsx
@@ -155,7 +155,7 @@ const deployedContractCss = css({
   },
 });
 
-const FORBIDDEN_FUNCTIONS = ['process_log', 'sync_notes', 'public_dispatch'];
+const FORBIDDEN_FUNCTIONS = ['process_log', 'sync_private_state', 'public_dispatch'];
 
 export function ContractComponent() {
   const [currentContract, setCurrentContract] = useState<Contract | null>(null);

--- a/playground/src/constants.ts
+++ b/playground/src/constants.ts
@@ -7,7 +7,7 @@ export const PREDEFINED_CONTRACTS = {
   CUSTOM_UPLOAD: 'custom_upload',
 };
 
-export const FORBIDDEN_FUNCTIONS = ['process_log', 'sync_notes', 'public_dispatch'];
+export const FORBIDDEN_FUNCTIONS = ['process_log', 'sync_private_state', 'public_dispatch'];
 
 export const TX_TIMEOUT = 180;
 

--- a/yarn-project/end-to-end/src/e2e_blacklist_token_contract/minting.test.ts
+++ b/yarn-project/end-to-end/src/e2e_blacklist_token_contract/minting.test.ts
@@ -94,7 +94,7 @@ describe('e2e_blacklist_token_contract mint', () => {
 
         tokenSim.mintPrivate(wallets[0].getAddress(), amount);
         // Trigger a note sync
-        await asset.methods.sync_notes().simulate();
+        await asset.methods.sync_private_state().simulate();
         // 1 note should have been created containing `amount` of tokens
         const visibleNotes = await pxe.getNotes({ txHash: receiptClaim.txHash });
         expect(visibleNotes.length).toBe(1);

--- a/yarn-project/end-to-end/src/e2e_cheat_codes.test.ts
+++ b/yarn-project/end-to-end/src/e2e_cheat_codes.test.ts
@@ -182,7 +182,7 @@ describe('e2e_cheat_codes', () => {
       const mintAmount = 100n;
 
       await mintTokensToPrivate(token, wallet, admin, mintAmount);
-      await token.methods.sync_notes().simulate();
+      await token.methods.sync_private_state().simulate();
 
       const balancesAdminSlot = await cc.aztec.computeSlotInMap(TokenContract.storage.balances.slot, admin);
 

--- a/yarn-project/end-to-end/src/e2e_crowdfunding_and_claim.test.ts
+++ b/yarn-project/end-to-end/src/e2e_crowdfunding_and_claim.test.ts
@@ -161,7 +161,7 @@ describe('e2e_crowdfunding_and_claim', () => {
         .wait();
 
       // Get the notes emitted by the Crowdfunding contract and check that only 1 was emitted (the UintNote)
-      await crowdfundingContract.withWallet(donorWallets[0]).methods.sync_notes().simulate();
+      await crowdfundingContract.withWallet(donorWallets[0]).methods.sync_private_state().simulate();
       const notes = await pxe.getNotes({ txHash: donateTxReceipt.txHash });
       const filteredNotes = notes.filter(x => x.contractAddress.equals(crowdfundingContract.address));
       expect(filteredNotes!.length).toEqual(1);
@@ -225,7 +225,7 @@ describe('e2e_crowdfunding_and_claim', () => {
       .wait();
 
     // Get the notes emitted by the Crowdfunding contract and check that only 1 was emitted (the UintNote)
-    await crowdfundingContract.withWallet(unrelatedWallet).methods.sync_notes().simulate();
+    await crowdfundingContract.withWallet(unrelatedWallet).methods.sync_private_state().simulate();
     const notes = await pxe.getNotes({ txHash: donateTxReceipt.txHash });
     const filtered = notes.filter(x => x.contractAddress.equals(crowdfundingContract.address));
     expect(filtered!.length).toEqual(1);
@@ -272,7 +272,7 @@ describe('e2e_crowdfunding_and_claim', () => {
         .call_create_note(arbitraryValue, owner, sender, arbitraryStorageSlot)
         .send()
         .wait();
-      await testContract.methods.sync_notes().simulate();
+      await testContract.methods.sync_private_state().simulate();
       const notes = await pxe.getNotes({ txHash: receipt.txHash });
       expect(notes.length).toEqual(1);
       note = processUniqueNote(notes[0]);

--- a/yarn-project/end-to-end/src/e2e_pending_note_hashes_contract.test.ts
+++ b/yarn-project/end-to-end/src/e2e_pending_note_hashes_contract.test.ts
@@ -293,7 +293,7 @@ describe('e2e_pending_note_hashes_contract', () => {
     // Then emit another note log with the same counter as the one above, but with value 5
     const txReceipt = await deployedContract.methods.test_emit_bad_note_log(owner, sender).send().wait();
 
-    await deployedContract.methods.sync_notes().simulate();
+    await deployedContract.methods.sync_private_state().simulate();
 
     const notes = await pxe.getNotes({ txHash: txReceipt.txHash });
 

--- a/yarn-project/end-to-end/src/guides/dapp_testing.test.ts
+++ b/yarn-project/end-to-end/src/guides/dapp_testing.test.ts
@@ -80,7 +80,7 @@ describe('guides/dapp/testing', () => {
 
       it('checks private storage', async () => {
         // docs:start:private-storage
-        await token.methods.sync_notes().simulate();
+        await token.methods.sync_private_state().simulate();
         const notes = await pxe.getNotes({
           recipient: owner.getAddress(),
           contractAddress: token.address,

--- a/yarn-project/pxe/src/pxe_service/pxe_service.ts
+++ b/yarn-project/pxe/src/pxe_service/pxe_service.ts
@@ -1011,8 +1011,8 @@ export class PXEService implements PXE {
 
     this.log.verbose(`Getting private events for ${contractAddress.toString()} from ${from} to ${from + numBlocks}`);
 
-    // TODO(#13113): This is a temporary hack to ensure that the notes are synced before getting the events.
-    await this.simulateUtility('sync_notes', [], contractAddress);
+    // We need to manually trigger private state sync to have a guarantee that all the events are available.
+    await this.simulateUtility('sync_private_state', [], contractAddress);
 
     const events = await this.privateEventDataProvider.getPrivateEvents(
       contractAddress,

--- a/yarn-project/simulator/src/private/acvm/oracle/oracle.ts
+++ b/yarn-project/simulator/src/private/acvm/oracle/oracle.ts
@@ -379,8 +379,8 @@ export class Oracle {
     return [];
   }
 
-  async syncNotes([pendingTaggedLogArrayBaseSlot]: ACVMField[]): Promise<ACVMField[]> {
-    await this.typedOracle.syncNotes(Fr.fromString(pendingTaggedLogArrayBaseSlot));
+  async syncPrivateState([pendingTaggedLogArrayBaseSlot]: ACVMField[]): Promise<ACVMField[]> {
+    await this.typedOracle.syncPrivateState(Fr.fromString(pendingTaggedLogArrayBaseSlot));
     return [];
   }
 

--- a/yarn-project/simulator/src/private/acvm/oracle/typed_oracle.ts
+++ b/yarn-project/simulator/src/private/acvm/oracle/typed_oracle.ts
@@ -214,8 +214,8 @@ export abstract class TypedOracle {
     return Promise.reject(new OracleMethodNotAvailableError('incrementAppTaggingSecretIndexAsSender'));
   }
 
-  syncNotes(_pendingTaggedLogArrayBaseSlot: Fr): Promise<void> {
-    return Promise.reject(new OracleMethodNotAvailableError('syncNotes'));
+  syncPrivateState(_pendingTaggedLogArrayBaseSlot: Fr): Promise<void> {
+    return Promise.reject(new OracleMethodNotAvailableError('syncPrivateState'));
   }
 
   deliverNote(

--- a/yarn-project/simulator/src/private/private_execution_oracle.ts
+++ b/yarn-project/simulator/src/private/private_execution_oracle.ts
@@ -500,7 +500,7 @@ export class PrivateExecutionOracle extends UtilityExecutionOracle {
     await this.executionDataProvider.incrementAppTaggingSecretIndexAsSender(this.contractAddress, sender, recipient);
   }
 
-  public override async syncNotes(pendingTaggedLogArrayBaseSlot: Fr) {
+  public override async syncPrivateState(pendingTaggedLogArrayBaseSlot: Fr) {
     await this.executionDataProvider.syncTaggedLogs(this.contractAddress, pendingTaggedLogArrayBaseSlot, this.scopes);
 
     await this.executionDataProvider.removeNullifiedNotes(this.contractAddress);

--- a/yarn-project/simulator/src/private/providers/circuit_recording/circuit_recorder.ts
+++ b/yarn-project/simulator/src/private/providers/circuit_recording/circuit_recorder.ts
@@ -51,7 +51,7 @@ import { Oracle } from '../../acvm/oracle/oracle.js';
  *       ]
  *     },
  *     {
- *       "name": "syncNotes",
+ *       "name": "syncPrivateState",
  *       "inputs": []
  *     }
  *   ]

--- a/yarn-project/simulator/src/private/utility_execution_oracle.ts
+++ b/yarn-project/simulator/src/private/utility_execution_oracle.ts
@@ -274,7 +274,7 @@ export class UtilityExecutionOracle extends TypedOracle {
     return await this.executionDataProvider.getIndexedTaggingSecretAsSender(this.contractAddress, sender, recipient);
   }
 
-  public override async syncNotes(pendingTaggedLogArrayBaseSlot: Fr) {
+  public override async syncPrivateState(pendingTaggedLogArrayBaseSlot: Fr) {
     await this.executionDataProvider.syncTaggedLogs(this.contractAddress, pendingTaggedLogArrayBaseSlot, this.scopes);
 
     await this.executionDataProvider.removeNullifiedNotes(this.contractAddress);

--- a/yarn-project/stdlib/src/logs/pending_tagged_log.ts
+++ b/yarn-project/stdlib/src/logs/pending_tagged_log.ts
@@ -5,7 +5,7 @@ import type { AztecAddress } from '../aztec-address/index.js';
 import type { TxHash } from '../tx/tx_hash.js';
 
 /**
- * Represents a pending tagged log as it is stored in the pending tagged log array to which the syncNotes oracle
+ * Represents a pending tagged log as it is stored in the pending tagged log array to which the syncPrivateState oracle
  * inserts found private logs. A TS version of `pending_tagged_log.nr`.
  */
 export class PendingTaggedLog {

--- a/yarn-project/txe/src/oracle/txe_oracle.ts
+++ b/yarn-project/txe/src/oracle/txe_oracle.ts
@@ -1161,7 +1161,7 @@ export class TXE implements TypedOracle {
     return await this.pxeOracleInterface.getIndexedTaggingSecretAsSender(this.contractAddress, sender, recipient);
   }
 
-  async syncNotes(pendingTaggedLogArrayBaseSlot: Fr) {
+  async syncPrivateState(pendingTaggedLogArrayBaseSlot: Fr) {
     await this.pxeOracleInterface.syncTaggedLogs(this.contractAddress, pendingTaggedLogArrayBaseSlot);
 
     await this.pxeOracleInterface.removeNullifiedNotes(this.contractAddress);

--- a/yarn-project/txe/src/txe_service/txe_service.ts
+++ b/yarn-project/txe/src/txe_service/txe_service.ts
@@ -689,14 +689,14 @@ export class TXEService {
     return toForeignCallResult(secret.toFields().map(toSingle));
   }
 
-  async syncNotes(pendingTaggedLogArrayBaseSlot: ForeignCallSingle) {
+  async syncPrivateState(pendingTaggedLogArrayBaseSlot: ForeignCallSingle) {
     if (!this.oraclesEnabled) {
       throw new Error(
         'Oracle access from the root of a TXe test are not enabled. Please use env._ to interact with the oracles.',
       );
     }
 
-    await this.typedOracle.syncNotes(fromSingle(pendingTaggedLogArrayBaseSlot));
+    await this.typedOracle.syncPrivateState(fromSingle(pendingTaggedLogArrayBaseSlot));
     return toForeignCallResult([]);
   }
 


### PR DESCRIPTION
The oracle no longer syncs just notes but now it syncs events as well. Hence it made sense to rename it.

Fixes #13113

