### PR TITLE
fix: remove unused generics

### DIFF
--- a/noir-projects/aztec-nr/aztec/src/macros/utils.nr
+++ b/noir-projects/aztec-nr/aztec/src/macros/utils.nr
@@ -164,7 +164,7 @@ pub(crate) trait AsStrQuote {
     fn as_str_quote(self) -> (Self, u32);
 }
 
-impl<let N: u32, Env> AsStrQuote for Quoted {
+impl AsStrQuote for Quoted {
     // Used to convert an arbitrary quoted type into a quoted string, removing whitespace between tokens
     comptime fn as_str_quote(self) -> (Quoted, u32) {
         let tokens = self.tokens();

--- a/noir-projects/aztec-nr/aztec/src/state_vars/public_immutable.nr
+++ b/noir-projects/aztec-nr/aztec/src/state_vars/public_immutable.nr
@@ -42,10 +42,7 @@ pub struct PublicImmutable<T, Context> {
 
 /// `WithHash<T>` stores both the packed value (using N fields) and its hash (1 field), requiring N = M + 1 total
 /// fields.
-impl<T, Context, let M: u32, let N: u32> Storage<N> for PublicImmutable<T, Context>
-where
-    WithHash<T, M>: Packable<N>,
-{
+impl<T, Context, let N: u32> Storage<N> for PublicImmutable<T, Context> {
     fn get_storage_slot(self) -> Field {
         self.storage_slot
     }

--- a/noir-projects/noir-protocol-circuits/crates/types/src/shared_mutable/shared_mutable_values.nr
+++ b/noir-projects/noir-protocol-circuits/crates/types/src/shared_mutable/shared_mutable_values.nr
@@ -119,9 +119,9 @@ where
     }
 }
 
-impl<T, let INITIAL_DELAY: u32, let N: u32> Hash for SharedMutableValues<T, INITIAL_DELAY>
+impl<T, let INITIAL_DELAY: u32> Hash for SharedMutableValues<T, INITIAL_DELAY>
 where
-    T: Packable<N>,
+    T: Packable<_>,
 {
     fn hash(self) -> Field {
         poseidon2_hash(self.pack())


### PR DESCRIPTION
Luckily it works because we can do `where T: Packable<_>`, though that's not valid in Rust so it should probably eventually error in Noir.

I don't think there's a way to fix this unless the `N` in `Packable` becomes an associated constant, and maybe it should be because there's probably only one way to pack/unpack a value from a Field array.