### PR TITLE
chore: only one fork when block building

### DIFF
--- a/yarn-project/end-to-end/src/composed/integration_l1_publisher.test.ts
+++ b/yarn-project/end-to-end/src/composed/integration_l1_publisher.test.ts
@@ -25,7 +25,7 @@ import { ForwarderAbi, OutboxAbi, RollupAbi } from '@aztec/l1-artifacts';
 import { SHA256Trunc, StandardTree } from '@aztec/merkle-tree';
 import { getVKTreeRoot } from '@aztec/noir-protocol-circuits-types/vk-tree';
 import { protocolContractTreeRoot } from '@aztec/protocol-contracts';
-import { LightweightBlockBuilder } from '@aztec/prover-client/block-builder';
+import { buildBlockWithCleanDB } from '@aztec/prover-client/block-builder';
 import { SequencerPublisher } from '@aztec/sequencer-client';
 import type { L2Tips } from '@aztec/stdlib/block';
 import { GasFees, GasSettings } from '@aztec/stdlib/gas';
@@ -322,10 +322,7 @@ describe('L1Publisher integration', () => {
   const buildBlock = async (globalVariables: GlobalVariables, txs: ProcessedTx[], l1ToL2Messages: Fr[]) => {
     await worldStateSynchronizer.syncImmediate();
     const tempFork = await worldStateSynchronizer.fork();
-    const tempBuilder = new LightweightBlockBuilder(tempFork);
-    await tempBuilder.startNewBlock(globalVariables, l1ToL2Messages);
-    await tempBuilder.addTxs(txs);
-    const block = await tempBuilder.setBlockCompleted();
+    const block = await buildBlockWithCleanDB(txs, globalVariables, l1ToL2Messages, tempFork);
     await tempFork.close();
     return block;
   };

--- a/yarn-project/prover-client/src/block_builder/light.ts
+++ b/yarn-project/prover-client/src/block_builder/light.ts
@@ -10,20 +10,28 @@ import { type GlobalVariables, type ProcessedTx, toNumBlobFields } from '@aztec/
 import { type TelemetryClient, getTelemetryClient } from '@aztec/telemetry-client';
 
 import {
-  buildBaseRollupHints,
   buildHeaderAndBodyFromTxs,
   getTreeSnapshot,
+  insertSideEffectsAndBuildBaseRollupHints,
 } from '../orchestrator/block-building-helpers.js';
 
 /**
  * Builds a block and its header from a set of processed tx without running any circuits.
+ *
+ * NOTE: the onus is ON THE CALLER to update the db that is passed in with the notes hashes, nullifiers, etc
+ * PRIOR to calling `buildBlock`.
+ *
+ * Why? Because if you are, e.g. building a block in practice from TxObjects, you are using the
+ * PublicProcessor which will do this for you as it processes transactions.
+ *
+ * If you haven't already inserted the side effects, e.g. because you are in a testing context, you can use the helper
+ * function `buildBlockWithCleanDB`, which calls `insertSideEffectsAndBuildBaseRollupHints` for you.
  */
 export class LightweightBlockBuilder implements BlockBuilder {
-  private spongeBlobState?: SpongeBlob;
   private globalVariables?: GlobalVariables;
   private l1ToL2Messages?: Fr[];
 
-  private txs: ProcessedTx[] = [];
+  private txs: ProcessedTx[] | undefined;
 
   private readonly logger = createLogger('prover-client:block_builder');
 
@@ -36,20 +44,21 @@ export class LightweightBlockBuilder implements BlockBuilder {
     this.logger.debug('Starting new block', { globalVariables: globalVariables.toInspect(), l1ToL2Messages });
     this.globalVariables = globalVariables;
     this.l1ToL2Messages = padArrayEnd(l1ToL2Messages, Fr.ZERO, NUMBER_OF_L1_L2_MESSAGES_PER_ROLLUP);
-    this.txs = [];
-    this.spongeBlobState = undefined;
+    this.txs = undefined;
 
     // Update L1 to L2 tree
     await this.db.appendLeaves(MerkleTreeId.L1_TO_L2_MESSAGE_TREE, this.l1ToL2Messages!);
   }
 
-  async addTxs(txs: ProcessedTx[]): Promise<void> {
-    this.spongeBlobState = SpongeBlob.init(toNumBlobFields(txs));
-    for (const tx of txs) {
-      this.logger.debug('Adding new tx to block', { txHash: tx.hash.toString() });
-      this.txs.push(tx);
-      await buildBaseRollupHints(tx, this.globalVariables!, this.db, this.spongeBlobState!);
+  addTxs(txs: ProcessedTx[]): Promise<void> {
+    // Most times, `addTxs` is only called once per block.
+    // So avoid copies.
+    if (this.txs === undefined) {
+      this.txs = txs;
+    } else {
+      this.txs.push(...txs);
     }
+    return Promise.resolve();
   }
 
   setBlockCompleted(): Promise<L2Block> {
@@ -58,7 +67,7 @@ export class LightweightBlockBuilder implements BlockBuilder {
 
   private async buildBlock(): Promise<L2Block> {
     const { header, body } = await buildHeaderAndBodyFromTxs(
-      this.txs,
+      this.txs ?? [],
       this.globalVariables!,
       this.l1ToL2Messages!,
       this.db,
@@ -87,16 +96,20 @@ export class LightweightBlockBuilderFactory {
 }
 
 /**
- * Creates a block builder under the hood with the given txs and messages and creates a block.
- * @param db - A db fork to use for block building.
+ * Inserts the processed transactions into the DB, then creates a block.
+ * @param db - A db fork to use for block building which WILL BE MODIFIED.
  */
-export async function buildBlock(
+export async function buildBlockWithCleanDB(
   txs: ProcessedTx[],
   globalVariables: GlobalVariables,
   l1ToL2Messages: Fr[],
   db: MerkleTreeWriteOperations,
   telemetry: TelemetryClient = getTelemetryClient(),
 ) {
+  const spongeBlobState = SpongeBlob.init(toNumBlobFields(txs));
+  for (const tx of txs) {
+    await insertSideEffectsAndBuildBaseRollupHints(tx, globalVariables, db, spongeBlobState);
+  }
   const builder = new LightweightBlockBuilder(db, telemetry);
   await builder.startNewBlock(globalVariables, l1ToL2Messages);
   await builder.addTxs(txs);

--- a/yarn-project/prover-client/src/mocks/test_context.ts
+++ b/yarn-project/prover-client/src/mocks/test_context.ts
@@ -23,7 +23,7 @@ import { promises as fs } from 'fs';
 // TODO(#12613) This means of sharing test code is not ideal.
 // eslint-disable-next-line import/no-relative-packages
 import { TestCircuitProver } from '../../../bb-prover/src/test/test_circuit_prover.js';
-import { buildBlock } from '../block_builder/light.js';
+import { buildBlockWithCleanDB } from '../block_builder/light.js';
 import { ProvingOrchestrator } from '../orchestrator/index.js';
 import { BrokerCircuitProverFacade } from '../proving_broker/broker_prover_facade.js';
 import { TestBroker } from '../test/mock_prover.js';
@@ -193,7 +193,7 @@ export class TestContext {
     );
     await this.setTreeRoots(txs);
 
-    const block = await buildBlock(txs, globalVariables, msgs, db);
+    const block = await buildBlockWithCleanDB(txs, globalVariables, msgs, db);
     this.headers.set(blockNum, block.header);
     await this.worldState.handleL2BlockAndMessages(block, msgs);
     return { block, txs, msgs };

--- a/yarn-project/prover-client/src/orchestrator/block-building-helpers.ts
+++ b/yarn-project/prover-client/src/orchestrator/block-building-helpers.ts
@@ -64,7 +64,7 @@ type BaseTreeNames = 'NoteHashTree' | 'ContractTree' | 'NullifierTree' | 'Public
 export type TreeNames = BaseTreeNames | 'L1ToL2MessageTree' | 'Archive';
 
 // Builds the hints for base rollup. Updating the contract, nullifier, and data trees in the process.
-export const buildBaseRollupHints = runInSpan(
+export const insertSideEffectsAndBuildBaseRollupHints = runInSpan(
   'BlockBuilderHelpers',
   'buildBaseRollupHints',
   async (

--- a/yarn-project/prover-client/src/orchestrator/orchestrator.ts
+++ b/yarn-project/prover-client/src/orchestrator/orchestrator.ts
@@ -47,12 +47,12 @@ import {
 import { inspect } from 'util';
 
 import {
-  buildBaseRollupHints,
   buildHeaderAndBodyFromTxs,
   getLastSiblingPath,
   getRootTreeSiblingPath,
   getSubtreeSiblingPath,
   getTreeSnapshot,
+  insertSideEffectsAndBuildBaseRollupHints,
   validatePartialState,
   validateTx,
 } from './block-building-helpers.js';
@@ -489,7 +489,7 @@ export class ProvingOrchestrator implements EpochProver {
     // We build the base rollup inputs using a mock proof and verification key.
     // These will be overwritten later once we have proven the tube circuit and any public kernels
     const [ms, hints] = await elapsed(
-      buildBaseRollupHints(tx, provingState.globalVariables, db, provingState.spongeBlobState),
+      insertSideEffectsAndBuildBaseRollupHints(tx, provingState.globalVariables, db, provingState.spongeBlobState),
     );
 
     this.metrics.recordBaseRollupInputs(ms);

--- a/yarn-project/prover-client/src/test/bb_prover_full_rollup.test.ts
+++ b/yarn-project/prover-client/src/test/bb_prover_full_rollup.test.ts
@@ -12,7 +12,7 @@ import { mockTx } from '@aztec/stdlib/testing';
 import type { BlockHeader } from '@aztec/stdlib/tx';
 import { getTelemetryClient } from '@aztec/telemetry-client';
 
-import { buildBlock } from '../block_builder/light.js';
+import { buildBlockWithCleanDB } from '../block_builder/light.js';
 import { makeGlobals } from '../mocks/fixtures.js';
 import { TestContext } from '../mocks/test_context.js';
 
@@ -74,7 +74,7 @@ describe('prover/bb_prover/full-rollup', () => {
         await context.orchestrator.setBlockCompleted(blockNum);
 
         log.info(`Updating world state with new block`);
-        const block = await buildBlock(processed, globals, l1ToL2Messages, await context.worldState.fork());
+        const block = await buildBlockWithCleanDB(processed, globals, l1ToL2Messages, await context.worldState.fork());
         previousBlockHeader = block.header;
         await context.worldState.handleL2BlockAndMessages(block, l1ToL2Messages);
       }


### PR DESCRIPTION
Now sequencers and validators only use a single world state fork while building blocks, and take advantage of the fact that the public processor will do tree insertions.

Note: this does not modify provers, who still do double insertions for now.

Fix #11000 