### PR TITLE
refactor(bb): iterative `apply_to_tuple_*`

### DIFF
--- a/barretenberg/cpp/src/barretenberg/protogalaxy/protogalaxy_prover_internal.hpp
+++ b/barretenberg/cpp/src/barretenberg/protogalaxy/protogalaxy_prover_internal.hpp
@@ -456,7 +456,7 @@ template <class DeciderProvingKeys_> class ProtogalaxyProverInternal {
         };
 
         TupleOfTuplesOfUnivariatesNoOptimisticSkipping result;
-        RelationUtils::template apply_to_tuple_of_tuples<0, 0>(result, deoptimise);
+        RelationUtils::template apply_to_tuple_of_tuples(result, deoptimise);
         return result;
     }
 
@@ -468,13 +468,17 @@ template <class DeciderProvingKeys_> class ProtogalaxyProverInternal {
             std::get<0>(std::get<0>(univariate_accumulators)).template extend_to<DeciderPKs::BATCHED_EXTENDED_LENGTH>();
         size_t idx = 0;
         const auto scale_and_sum = [&]<size_t outer_idx, size_t inner_idx>(auto& element) {
+            if constexpr (outer_idx == 0 && inner_idx == 0) {
+                return;
+            }
+
             auto extended = element.template extend_to<DeciderPKs::BATCHED_EXTENDED_LENGTH>();
             extended *= alpha[idx];
             result += extended;
             idx++;
         };
 
-        RelationUtils::template apply_to_tuple_of_tuples<0, 1>(univariate_accumulators, scale_and_sum);
+        RelationUtils::template apply_to_tuple_of_tuples(univariate_accumulators, scale_and_sum);
         RelationUtils::zero_univariates(univariate_accumulators);
 
         return result;

--- a/barretenberg/cpp/src/barretenberg/relations/utils.hpp
+++ b/barretenberg/cpp/src/barretenberg/relations/utils.hpp
@@ -5,11 +5,14 @@
 // =====================
 
 #pragma once
+
+#include <tuple>
+#include <utility>
+
+#include "barretenberg/common/constexpr_utils.hpp"
 #include "barretenberg/flavor/flavor.hpp"
 #include "barretenberg/polynomials/gate_separator.hpp"
 #include "barretenberg/relations/relation_parameters.hpp"
-#include <tuple>
-#include <utility>
 
 namespace bb {
 
@@ -31,29 +34,20 @@ template <typename Flavor> class RelationUtils {
      * @brief General purpose method for applying an operation to a tuple of tuples of Univariates
      *
      * @tparam Operation Any operation valid on Univariates
-     * @tparam outer_idx Index into the outer tuple
-     * @tparam inner_idx Index into the inner tuple
      * @param tuple A Tuple of tuples of Univariates
      * @param operation Operation to apply to Univariates
      */
-    template <size_t outer_idx = 0, size_t inner_idx = 0, class Operation>
-    static void apply_to_tuple_of_tuples(auto& tuple, Operation&& operation)
+    template <class Operation> static void apply_to_tuple_of_tuples(auto& tuple, Operation&& operation)
     {
-        auto& inner_tuple = std::get<outer_idx>(tuple);
-        auto& univariate = std::get<inner_idx>(inner_tuple);
-
-        // Apply the specified operation to each Univariate
-        operation.template operator()<outer_idx, inner_idx>(univariate);
-
-        const size_t inner_size = std::tuple_size_v<std::decay_t<decltype(std::get<outer_idx>(tuple))>>;
-        const size_t outer_size = std::tuple_size_v<std::decay_t<decltype(tuple)>>;
-
-        // Recurse over inner and outer tuples
-        if constexpr (inner_idx + 1 < inner_size) {
-            apply_to_tuple_of_tuples<outer_idx, inner_idx + 1, Operation>(tuple, std::forward<Operation>(operation));
-        } else if constexpr (outer_idx + 1 < outer_size) {
-            apply_to_tuple_of_tuples<outer_idx + 1, 0, Operation>(tuple, std::forward<Operation>(operation));
-        }
+        constexpr size_t outer_tuple_size = std::tuple_size_v<std::decay_t<decltype(tuple)>>;
+        constexpr_for<0, outer_tuple_size, 1>([&]<size_t outer_idx>() {
+            auto& inner_tuple = std::get<outer_idx>(tuple);
+            constexpr size_t inner_tuple_size = std::tuple_size_v<std::decay_t<decltype(inner_tuple)>>;
+            constexpr_for<0, inner_tuple_size, 1>([&]<size_t inner_idx>() {
+                std::forward<Operation>(operation).template operator()<outer_idx, inner_idx>(
+                    std::get<inner_idx>(inner_tuple));
+            });
+        });
     }
 
     /**
@@ -278,16 +272,17 @@ template <typename Flavor> class RelationUtils {
      * @tparam Operation Any operation valid on elements of the inner arrays (FFs)
      * @param tuple Tuple of arrays (of FFs)
      */
-    template <size_t idx = 0, typename Operation, typename... Ts>
+    template <typename Operation, typename... Ts>
     static void apply_to_tuple_of_arrays(Operation&& operation, std::tuple<Ts...>& tuple)
     {
-        auto& element = std::get<idx>(tuple);
-
-        std::invoke(std::forward<Operation>(operation), element);
-
-        if constexpr (idx + 1 < sizeof...(Ts)) {
-            apply_to_tuple_of_arrays<idx + 1, Operation>(operation, tuple);
-        }
+        std::apply(
+            [&operation](auto&... elements_ref) {
+                // The comma operator ensures sequential application of the operation to each element.
+                // (void) cast is used to discard the result of std::invoke if it's not void,
+                // to prevent issues with overloaded comma operators.
+                ((void)std::invoke(std::forward<Operation>(operation), elements_ref), ...);
+            },
+            tuple);
     }
 
     /**
@@ -298,24 +293,35 @@ template <typename Flavor> class RelationUtils {
      * of array are values of subrelations and we want to accumulate some of these values separately (the linearly
      * dependent contribution when we compute the evaluation of full rel_U(G)H at particular row.)
      */
-    template <size_t outer_idx = 0, size_t inner_idx = 0, typename Operation, typename... Ts>
+    template <typename Operation, typename... Ts>
     static void apply_to_tuple_of_arrays_elements(Operation&& operation, const std::tuple<Ts...>& tuple)
     {
-        using Relation = typename std::tuple_element_t<outer_idx, Relations>;
-        const auto subrelation_length = Relation::SUBRELATION_PARTIAL_LENGTHS.size();
-        auto& element = std::get<outer_idx>(tuple);
+        // Iterate over each array in the outer tuple.
+        // OuterIdx is the compile-time index of the current array in the tuple.
+        constexpr_for<0, sizeof...(Ts), 1>([&]<size_t OuterIdx>() {
+            // Determine the specific Relation type corresponding to the OuterIdx-th array.
+            // This is used to find the number of elements in the current array.
+            using Relation = typename std::tuple_element_t<OuterIdx, Relations>;
 
-        // Invoke the operation with outer_idx (array index) and inner_idx (element index) as template arguments
-        operation.template operator()<outer_idx, inner_idx>(element[inner_idx]);
+            // Determine the number of elements in the current array.
+            // This relies on Relation::SUBRELATION_PARTIAL_LENGTHS.size() being a constexpr value,
+            // which indicates how many subrelations (and thus, evaluations) are in this relation's array.
+            constexpr size_t num_elements_in_current_array = Relation::SUBRELATION_PARTIAL_LENGTHS.size();
 
-        if constexpr (inner_idx + 1 < subrelation_length) {
-            // Recursively call for the next element within the same array
-            apply_to_tuple_of_arrays_elements<outer_idx, inner_idx + 1, Operation>(std::forward<Operation>(operation),
-                                                                                   tuple);
-        } else if constexpr (outer_idx + 1 < sizeof...(Ts)) {
-            // Move to the next array in the tuple
-            apply_to_tuple_of_arrays_elements<outer_idx + 1, 0, Operation>(std::forward<Operation>(operation), tuple);
-        }
+            // Get a const reference to the current array from the tuple.
+            const auto& current_array = std::get<OuterIdx>(tuple);
+
+            // Iterate over each element within the current_array.
+            // InnerIdx is the compile-time index of the element within this specific array.
+            constexpr_for<0, num_elements_in_current_array, 1>([&]<size_t InnerIdx>() {
+                // Invoke the operation.
+                // The operation is called with OuterIdx (array index in the tuple) and
+                // InnerIdx (element index in the current array) as template arguments.
+                // The current element (e.g., an FF value) is passed as an argument.
+                std::forward<Operation>(operation).template operator()<OuterIdx, InnerIdx>(current_array[InnerIdx]);
+            });
+        });
     }
 };
+
 } // namespace bb


### PR DESCRIPTION
This function was blowing up the max template recursion limit. We temporarily bumped it but I think the iterative version is even more readable as well.
