### PR TITLE
feat: make rewards locked until gov say yay

### DIFF
--- a/l1-contracts/src/core/RollupCore.sol
+++ b/l1-contracts/src/core/RollupCore.sol
@@ -64,6 +64,9 @@ contract RollupCore is
   // @note  Always true, exists to override to false for testing only
   bool public checkBlob = true;
 
+  // @note  This is only a temporary and should be too deeply ingrained into the rollup library
+  bool public isRewardsClaimable = false;
+
   constructor(
     IERC20 _feeAsset,
     IRewardDistributor _rewardDistributor,
@@ -140,6 +143,11 @@ contract RollupCore is
   /*                          CHEAT CODES END HERE                              */
   /* -------------------------------------------------------------------------- */
 
+  function setRewardsClaimable(bool _isRewardsClaimable) external override(IRollupCore) onlyOwner {
+    isRewardsClaimable = _isRewardsClaimable;
+    emit RewardsClaimableUpdated(_isRewardsClaimable);
+  }
+
   function setSlasher(address _slasher) external override(IStakingCore) onlyOwner {
     StakingLib.setSlasher(_slasher);
   }
@@ -157,6 +165,7 @@ contract RollupCore is
     override(IRollupCore)
     returns (uint256)
   {
+    require(isRewardsClaimable, Errors.Rollup__RewardsNotClaimable());
     return RewardLib.claimSequencerRewards(_recipient);
   }
 
@@ -165,6 +174,7 @@ contract RollupCore is
     override(IRollupCore)
     returns (uint256)
   {
+    require(isRewardsClaimable, Errors.Rollup__RewardsNotClaimable());
     return RewardLib.claimProverRewards(_recipient, _epochs);
   }
 

--- a/l1-contracts/src/core/interfaces/IRollup.sol
+++ b/l1-contracts/src/core/interfaces/IRollup.sol
@@ -122,7 +122,9 @@ interface IRollupCore {
   );
   event L2ProofVerified(uint256 indexed blockNumber, address indexed proverId);
   event PrunedPending(uint256 provenBlockNumber, uint256 pendingBlockNumber);
+  event RewardsClaimableUpdated(bool isRewardsClaimable);
 
+  function setRewardsClaimable(bool _isRewardsClaimable) external;
   function claimSequencerRewards(address _recipient) external returns (uint256);
   function claimProverRewards(address _recipient, Epoch[] memory _epochs)
     external

--- a/l1-contracts/src/core/libraries/Errors.sol
+++ b/l1-contracts/src/core/libraries/Errors.sol
@@ -79,6 +79,7 @@ library Errors {
   error Rollup__PastDeadline(Slot deadline, Slot currentSlot);
   error Rollup__ProverHaveAlreadySubmitted(address prover, Epoch epoch);
   error Rollup__ManaLimitExceeded();
+  error Rollup__RewardsNotClaimable();
 
   // HeaderLib
   error HeaderLib__InvalidHeaderSize(uint256 expected, uint256 actual); // 0xf3ccb247

--- a/l1-contracts/test/MultiProof.t.sol
+++ b/l1-contracts/test/MultiProof.t.sol
@@ -140,6 +140,17 @@ contract MultiProofTest is RollupBase {
     assertEq(rollup.getProvenBlockNumber(), 2, "Block not proven");
 
     {
+      // Ensure that we cannot claim rewards when not toggled yet
+      vm.expectRevert(abi.encodeWithSelector(Errors.Rollup__RewardsNotClaimable.selector));
+      rollup.claimSequencerRewards(sequencer);
+
+      vm.expectRevert(abi.encodeWithSelector(Errors.Rollup__RewardsNotClaimable.selector));
+      rollup.claimProverRewards(alice, new Epoch[](1));
+
+      rollup.setRewardsClaimable(true);
+    }
+
+    {
       uint256 sequencerRewards = rollup.getSequencerRewards(sequencer);
       assertGt(sequencerRewards, 0, "Sequencer rewards is zero");
       vm.prank(sequencer);


### PR DESCRIPTION
Fixes #14491. Lock rewards until the gov says yes. Done directly in the rollupcore since I don't want to pollute libraries with this. And all the functions that use it are accessible directly from the core anyway.