### PR TITLE
fix: use correct bounds when sampling

### DIFF
--- a/l1-contracts/src/core/libraries/crypto/SampleLib.sol
+++ b/l1-contracts/src/core/libraries/crypto/SampleLib.sol
@@ -44,7 +44,7 @@ library SampleLib {
     uint256 upperLimit = _indexCount - 1;
 
     for (uint256 index = 0; index < _committeeSize; index++) {
-      uint256 sampledIndex = computeSampleIndex(index, upperLimit, _seed);
+      uint256 sampledIndex = computeSampleIndex(index, upperLimit + 1, _seed);
 
       // Get index, or its swapped override
       sampledIndices[index] = getValue(sampledIndex);

--- a/l1-contracts/test/validator-selection/Sampling.t.sol
+++ b/l1-contracts/test/validator-selection/Sampling.t.sol
@@ -53,14 +53,19 @@ contract SamplingTest is Test {
   }
 
   function testSimpleSample() public {
-    bool saw1 = false;
+    uint256 saw0 = 0;
+    uint256 saw1 = 0;
+
     for (uint256 i = 0; i < 1000; i++) {
       uint256[] memory committee = sampler.computeCommittee(1, 2, i);
       assertEq(committee.length, 1, "committee length is 1");
-      if (committee[0] == 1) {
-        saw1 = true;
+      if (committee[0] == 0) {
+        saw0++;
+      } else {
+        saw1++;
       }
     }
-    assertEq(saw1, true, "should have seen 1");
+    assertGt(saw0, 400, "should have seen more 0s");
+    assertGt(saw1, 400, "should have seen more 1s");
   }
 }

--- a/l1-contracts/test/validator-selection/Sampling.t.sol
+++ b/l1-contracts/test/validator-selection/Sampling.t.sol
@@ -2,9 +2,11 @@
 // Copyright 2024 Aztec Labs.
 pragma solidity >=0.8.27;
 
+import {SampleLib} from "@aztec/core/libraries/crypto/SampleLib.sol";
 import {Test} from "forge-std/Test.sol";
 
-import {SampleLib} from "@aztec/core/libraries/crypto/SampleLib.sol";
+// solhint-disable comprehensive-interface
+// solhint-disable func-name-mixedcase
 
 // Adding a contract to get some gas-numbers out.
 contract Sampler {
@@ -17,7 +19,7 @@ contract Sampler {
 }
 
 contract SamplingTest is Test {
-  Sampler sampler = new Sampler();
+  Sampler public sampler = new Sampler();
 
   function testSampleFuzz(uint8 _committeeSize, uint8 _validatorSetSize, uint256 _seed) public {
     vm.assume(_committeeSize <= _validatorSetSize);
@@ -48,5 +50,17 @@ contract SamplingTest is Test {
     assertEq(committee1, committee2);
     assertEq(committee1, committee3);
     assertEq(committee2, committee3);
+  }
+
+  function testSimpleSample() public {
+    bool saw1 = false;
+    for (uint256 i = 0; i < 1000; i++) {
+      uint256[] memory committee = sampler.computeCommittee(1, 2, i);
+      assertEq(committee.length, 1, "committee length is 1");
+      if (committee[0] == 1) {
+        saw1 = true;
+      }
+    }
+    assertEq(saw1, true, "should have seen 1");
   }
 }


### PR DESCRIPTION
Without this, we would never select the last item in the index, unless it was first swapped in.