### PR TITLE
chore(ci): defensive change for bad test_cmds/bench_cmds

### DIFF
--- a/aztec-up/bootstrap.sh
+++ b/aztec-up/bootstrap.sh
@@ -32,7 +32,7 @@ function test_cmds {
 
 function test {
   echo_header "aztec-up test"
-  test_cmds | filter_test_cmds | parallelise
+  (test_cmds || exit 1) | filter_test_cmds | parallelise
 }
 
 function release {

--- a/barretenberg/acir_tests/bootstrap.sh
+++ b/barretenberg/acir_tests/bootstrap.sh
@@ -120,7 +120,7 @@ function build {
 
 function test {
   echo_header "acir_tests testing"
-  test_cmds | filter_test_cmds | parallelise
+  (test_cmds || exit 1) | filter_test_cmds | parallelise
 }
 
 # Prints to stdout, one per line, the command to execute each individual test.
@@ -197,7 +197,7 @@ function bench_cmds {
 # TODO(https://github.com/AztecProtocol/barretenberg/issues/1254): More complete testing, including failure tests
 function bench {
   rm -rf bench-out && mkdir -p bench-out
-  bench_cmds | STRICT_SCHEDULING=1 parallelise
+  (bench_cmds || exit 1) | STRICT_SCHEDULING=1 parallelise
 }
 
 case "$cmd" in

--- a/barretenberg/bbup/bootstrap.sh
+++ b/barretenberg/bbup/bootstrap.sh
@@ -19,7 +19,7 @@ function test_cmds {
 # This is not called in ci. It is just for a developer to run the tests.
 function test {
   echo_header "bbup test"
-  test_cmds | filter_test_cmds | parallelise
+  (test_cmds || exit 1) | filter_test_cmds | parallelise
 }
 
 case "$cmd" in

--- a/barretenberg/cpp/bootstrap.sh
+++ b/barretenberg/cpp/bootstrap.sh
@@ -220,7 +220,7 @@ function test_cmds {
 # This is not called in ci. It is just for a developer to run the tests.
 function test {
   echo_header "bb test"
-  test_cmds | filter_test_cmds | parallelise
+  (test_cmds || exit 1) | filter_test_cmds | parallelise
 }
 
 function build_bench {
@@ -255,7 +255,7 @@ function bench_cmds {
 function bench {
   echo_header "bb bench"
   rm -rf bench-out && mkdir -p bench-out
-  bench_cmds | STRICT_SCHEDULING=1 parallelise
+  (bench_cmds || exit 1) | STRICT_SCHEDULING=1 parallelise
 }
 
 # Upload assets to release.
@@ -304,7 +304,7 @@ case "$cmd" in
 
     # Recreation of logic from bench.
     ../../yarn-project/end-to-end/bootstrap.sh build_bench
-    ../../yarn-project/end-to-end/bootstrap.sh bench_cmds | grep barretenberg/cpp/scripts/ci_benchmark_ivc_flows.sh | STRICT_SCHEDULING=1 parallelise
+    ../../yarn-project/end-to-end/bootstrap.sh (bench_cmds || exit 1) | grep barretenberg/cpp/scripts/ci_benchmark_ivc_flows.sh | STRICT_SCHEDULING=1 parallelise
     ;;
   "hash")
     echo $hash

--- a/barretenberg/cpp/bootstrap.sh
+++ b/barretenberg/cpp/bootstrap.sh
@@ -304,7 +304,7 @@ case "$cmd" in
 
     # Recreation of logic from bench.
     ../../yarn-project/end-to-end/bootstrap.sh build_bench
-    ../../yarn-project/end-to-end/bootstrap.sh (bench_cmds || exit 1) | grep barretenberg/cpp/scripts/ci_benchmark_ivc_flows.sh | STRICT_SCHEDULING=1 parallelise
+    (../../yarn-project/end-to-end/bootstrap.sh bench_cmds || exit 1) | grep barretenberg/cpp/scripts/ci_benchmark_ivc_flows.sh | STRICT_SCHEDULING=1 parallelise
     ;;
   "hash")
     echo $hash

--- a/barretenberg/ts/bootstrap.sh
+++ b/barretenberg/ts/bootstrap.sh
@@ -43,7 +43,7 @@ function test_cmds {
 
 function test {
   echo_header "bb.js test"
-  test_cmds | filter_test_cmds | parallelise
+  (test_cmds || exit 1) | filter_test_cmds | parallelise
 }
 
 function release {

--- a/bootstrap.sh
+++ b/bootstrap.sh
@@ -275,7 +275,7 @@ function bench {
   fi
   echo_header "bench all"
   find . -type d -iname bench-out | xargs rm -rf
-  bench_cmds | STRICT_SCHEDULING=1 parallelise
+  (bench_cmds || exit 1) | STRICT_SCHEDULING=1 parallelise
   rm -rf bench-out
   mkdir -p bench-out
   bench_merge

--- a/boxes/bootstrap.sh
+++ b/boxes/bootstrap.sh
@@ -28,7 +28,7 @@ function build {
 
 function test {
   echo_header "boxes test"
-  test_cmds | filter_test_cmds | parallelise
+  (test_cmds || exit 1) | filter_test_cmds | parallelise
 }
 
 function test_cmds {

--- a/ci.sh
+++ b/ci.sh
@@ -270,7 +270,7 @@ case "$cmd" in
       echo "Not connected to CI redis."
       exit 1
     fi
-    ./bootstrap.sh test_cmds | \
+    (./bootstrap.sh test_cmds || exit 1) | \
        grep -Ev -f <(yq e '.tests[] | select(.skip == true) | .regex' $root/.test_patterns.yml) | \
        USE_TEST_CACHE=1 filter_cached_test_cmd
     ;;

--- a/docs/bootstrap.sh
+++ b/docs/bootstrap.sh
@@ -52,7 +52,7 @@ function test_cmds {
 
 function test {
   echo_header "docs test"
-  test_cmds | parallelise
+  (test_cmds || exit 1) | parallelise
 }
 
 case "$cmd" in

--- a/l1-contracts/bootstrap.sh
+++ b/l1-contracts/bootstrap.sh
@@ -63,7 +63,7 @@ function test_cmds {
 
 function test {
   echo_header "l1-contracts test"
-  test_cmds | filter_test_cmds | parallelise
+  (test_cmds || exit 1) | filter_test_cmds | parallelise
 }
 
 function inspect {

--- a/noir-projects/aztec-nr/bootstrap.sh
+++ b/noir-projects/aztec-nr/bootstrap.sh
@@ -33,7 +33,7 @@ function test {
   while ! nc -z 127.0.0.1 45730 &>/dev/null; do sleep 1; done
 
   export NARGO_FOREIGN_CALL_TIMEOUT=300000
-  test_cmds | filter_test_cmds | parallelise
+  (test_cmds || exit 1) | filter_test_cmds | parallelise
 
   # Run the macro compilation failure tests
   ./macro_compilation_failure_tests/assert_macro_compilation_failure.sh

--- a/noir-projects/bootstrap.sh
+++ b/noir-projects/bootstrap.sh
@@ -35,7 +35,7 @@ function test_cmds {
 
 function test {
   echo_header "noir-projects test"
-  test_cmds | filter_test_cmds | parallelise
+  (test_cmds || exit 1) | filter_test_cmds | parallelise
 }
 
 function format {

--- a/noir-projects/noir-contracts/bootstrap.sh
+++ b/noir-projects/noir-contracts/bootstrap.sh
@@ -213,7 +213,7 @@ function test {
   done
 
   export NARGO_FOREIGN_CALL_TIMEOUT=300000
-  test_cmds | filter_test_cmds | parallelise
+  (test_cmds || exit 1) | filter_test_cmds | parallelise
 }
 
 function format {

--- a/noir-projects/noir-protocol-circuits/bootstrap.sh
+++ b/noir-projects/noir-protocol-circuits/bootstrap.sh
@@ -176,7 +176,7 @@ function test_cmds {
 }
 
 function test {
-  test_cmds | filter_test_cmds | parallelise
+  (test_cmds || exit 1) | filter_test_cmds | parallelise
 }
 
 function format {
@@ -201,7 +201,7 @@ function bench_cmds {
 function bench {
   rm -rf bench-out && mkdir -p bench-out
 
-  bench_cmds | STRICT_SCHEDULING=1 parallelise
+  (bench_cmds || exit 1) | STRICT_SCHEDULING=1 parallelise
 }
 
 case "$cmd" in

--- a/noir/bootstrap.sh
+++ b/noir/bootstrap.sh
@@ -153,7 +153,7 @@ function build {
 
 function test {
   echo_header "noir test"
-  test_cmds | filter_test_cmds | parallelise
+  (test_cmds || exit 1) | filter_test_cmds | parallelise
 }
 
 # Prints the commands to run tests, one line per test, prefixed with the appropriate content hash.

--- a/playground/bootstrap.sh
+++ b/playground/bootstrap.sh
@@ -17,7 +17,7 @@ function build {
 
 function test {
   echo_header "playground test"
-  test_cmds | filter_test_cmds | parallelise
+  (test_cmds || exit 1) | filter_test_cmds | parallelise
 }
 
 function test_cmds {

--- a/spartan/bootstrap.sh
+++ b/spartan/bootstrap.sh
@@ -76,7 +76,7 @@ function test_cmds {
 
 function test {
   echo_header "spartan test"
-  test_cmds | filter_test_cmds | parallelise
+  (test_cmds || exit 1) | filter_test_cmds | parallelise
 }
 
 case "$cmd" in

--- a/yarn-project/bootstrap.sh
+++ b/yarn-project/bootstrap.sh
@@ -148,7 +148,7 @@ function test_cmds {
 
 function test {
   echo_header "yarn-project test"
-  test_cmds | filter_test_cmds | parallelise
+  (test_cmds || exit 1) | filter_test_cmds | parallelise
 }
 
 function bench_cmds {

--- a/yarn-project/end-to-end/bootstrap.sh
+++ b/yarn-project/end-to-end/bootstrap.sh
@@ -54,7 +54,7 @@ function test_cmds {
 
 function test {
   echo_header "e2e tests"
-  test_cmds | filter_test_cmds | parallelise
+  (test_cmds || exit 1) | filter_test_cmds | parallelise
 }
 
 function bench_cmds {
@@ -92,7 +92,7 @@ function build_bench {
 function bench {
   rm -rf bench-out
   mkdir -p bench-out
-  bench_cmds | STRICT_SCHEDULING=1 parallelise
+  (bench_cmds || exit 1) | STRICT_SCHEDULING=1 parallelise
 }
 
 case "$cmd" in


### PR DESCRIPTION
Prior to this, a bad exit code in test_cmds or bench_cmds would still run what *did* output to completion, causing confusing behaviour once it does fail, disconnected from the error source