### PR TITLE
fix: processing events in contracts with no notes

### DIFF
--- a/noir-projects/aztec-nr/aztec/src/macros/functions/utils.nr
+++ b/noir-projects/aztec-nr/aztec/src/macros/functions/utils.nr
@@ -99,7 +99,9 @@ pub(crate) comptime fn transform_private(f: FunctionDefinition) -> Quoted {
     };
 
     // All private functions perform message discovery, since they may need to access notes. This is slightly
-    // inefficient and could be improved by only doing it once we actually attempt to read any.
+    // inefficient and could be improved by only doing it once we actually attempt to read any. Note that the message
+    // discovery call syncs private events as well. We do not sync those here if there are no notes because we don't
+    // have an API that would access events from private functions.
     let message_discovery_call = if NOTES.len() > 0 {
         create_message_discovery_call()
     } else {
@@ -303,13 +305,9 @@ pub(crate) comptime fn transform_utility(f: FunctionDefinition) -> Quoted {
     };
 
     // All utility functions perform message discovery, since they may need to access private notes that would be
-    // found during this process. This is slightly inefficient and could be improved by only doing it once we actually
-    // attempt to read any.
-    let message_discovery_call = if NOTES.len() > 0 {
-        create_message_discovery_call()
-    } else {
-        quote {}
-    };
+    // found during this process or they may be used to sync private events from TypeScript
+    // (`sync_private_state` function gets invoked by PXE::getPrivateEvents function).
+    let message_discovery_call = create_message_discovery_call();
 
     // Inject context creation, storage initialization, and message discovery call at the beginning of the function
     // body.

--- a/noir-projects/noir-contracts/Nargo.toml
+++ b/noir-projects/noir-contracts/Nargo.toml
@@ -38,6 +38,7 @@ members = [
     "contracts/test/benchmarking_contract",
     "contracts/test/child_contract",
     "contracts/test/counter_contract",
+    "contracts/test/event_only_contract",
     "contracts/test/import_test_contract",
     "contracts/test/invalid_account_contract",
     "contracts/test/no_constructor_contract",

--- a/noir-projects/noir-contracts/contracts/test/event_only_contract/Nargo.toml
+++ b/noir-projects/noir-contracts/contracts/test/event_only_contract/Nargo.toml
@@ -1,0 +1,8 @@
+[package]
+name = "event_only_contract"
+authors = [""]
+compiler_version = ">=0.25.0"
+type = "contract"
+
+[dependencies]
+aztec = { path = "../../../../aztec-nr/aztec" }

--- a/noir-projects/noir-contracts/contracts/test/event_only_contract/src/main.nr
+++ b/noir-projects/noir-contracts/contracts/test/event_only_contract/src/main.nr
@@ -1,0 +1,32 @@
+use aztec::macros::aztec;
+
+/// This contract is used to test that the event emission is working correctly even when the contract doesn't work with
+/// notes.
+#[aztec]
+contract EventOnly {
+    use aztec::event::event_interface::EventInterface;
+    use aztec::macros::{
+        events::event,
+        functions::{initializer, private, public, utility},
+        storage::storage,
+    };
+    use aztec::messages::logs::event::encode_and_encrypt_event_unconstrained;
+    use aztec::protocol_types::traits::Serialize;
+    use std::meta::derive;
+
+    #[derive(Serialize)]
+    #[event]
+    struct TestEvent {
+        value: Field,
+    }
+
+    #[private]
+    fn emit_event_for_msg_sender() {
+        let sender = context.msg_sender();
+        TestEvent { value: 42 }.emit(encode_and_encrypt_event_unconstrained(
+            &mut context,
+            sender,
+            sender,
+        ));
+    }
+}

--- a/noir-projects/noir-contracts/contracts/test/event_only_contract/src/main.nr
+++ b/noir-projects/noir-contracts/contracts/test/event_only_contract/src/main.nr
@@ -4,14 +4,12 @@ use aztec::macros::aztec;
 /// notes.
 #[aztec]
 contract EventOnly {
-    use aztec::event::event_interface::EventInterface;
-    use aztec::macros::{
-        events::event,
-        functions::{initializer, private, public, utility},
-        storage::storage,
+    use aztec::{
+        event::event_interface::EventInterface,
+        macros::{events::event, functions::private},
+        messages::logs::event::encode_and_encrypt_event_unconstrained,
+        protocol_types::traits::Serialize,
     };
-    use aztec::messages::logs::event::encode_and_encrypt_event_unconstrained;
-    use aztec::protocol_types::traits::Serialize;
     use std::meta::derive;
 
     #[derive(Serialize)]
@@ -21,9 +19,9 @@ contract EventOnly {
     }
 
     #[private]
-    fn emit_event_for_msg_sender() {
+    fn emit_event_for_msg_sender(value: Field) {
         let sender = context.msg_sender();
-        TestEvent { value: 42 }.emit(encode_and_encrypt_event_unconstrained(
+        TestEvent { value }.emit(encode_and_encrypt_event_unconstrained(
             &mut context,
             sender,
             sender,

--- a/noir-projects/noir-contracts/contracts/test/event_only_contract/src/main.nr
+++ b/noir-projects/noir-contracts/contracts/test/event_only_contract/src/main.nr
@@ -1,7 +1,7 @@
 use aztec::macros::aztec;
 
-/// This contract is used to test that the event emission is working correctly even when the contract doesn't work with
-/// notes.
+/// This contract is used to test that the private event synchronization is working correctly even when the contract
+/// doesn't work with notes.
 #[aztec]
 contract EventOnly {
     use aztec::{

--- a/yarn-project/end-to-end/src/e2e_event_only.test.ts
+++ b/yarn-project/end-to-end/src/e2e_event_only.test.ts
@@ -36,6 +36,6 @@ describe('EventOnly', () => {
     );
 
     expect(events.length).toBe(1);
-    expect(events[0].value).toBe(value);
+    expect(events[0].value).toBe(value.toBigInt());
   });
 });

--- a/yarn-project/end-to-end/src/e2e_event_only.test.ts
+++ b/yarn-project/end-to-end/src/e2e_event_only.test.ts
@@ -7,7 +7,7 @@ import { ensureAccountsPubliclyDeployed, setup } from './fixtures/utils.js';
 
 const TIMEOUT = 120_000;
 
-/// In this test we check that a private event can be obtained for a contract that does not work with notes.
+/// Tests that a private event can be obtained for a contract that does not work with notes.
 describe('EventOnly', () => {
   let eventOnlyContract: EventOnlyContract;
   jest.setTimeout(TIMEOUT);

--- a/yarn-project/end-to-end/src/e2e_event_only.test.ts
+++ b/yarn-project/end-to-end/src/e2e_event_only.test.ts
@@ -1,0 +1,41 @@
+import { type AccountWalletWithSecretKey, Fr } from '@aztec/aztec.js';
+import { EventOnlyContract, type TestEvent } from '@aztec/noir-test-contracts.js/EventOnly';
+
+import { jest } from '@jest/globals';
+
+import { ensureAccountsPubliclyDeployed, setup } from './fixtures/utils.js';
+
+const TIMEOUT = 120_000;
+
+/// In this test we check that a private event can be obtained for a contract that does not work with notes.
+describe('EventOnly', () => {
+  let eventOnlyContract: EventOnlyContract;
+  jest.setTimeout(TIMEOUT);
+
+  let wallets: AccountWalletWithSecretKey[];
+  let teardown: () => Promise<void>;
+
+  beforeAll(async () => {
+    ({ teardown, wallets } = await setup(2));
+    await ensureAccountsPubliclyDeployed(wallets[0], wallets.slice(0, 2));
+    eventOnlyContract = await EventOnlyContract.deploy(wallets[0]).send().deployed();
+  });
+
+  afterAll(() => teardown());
+
+  it('emits and retrieves a private event for a contract with no notes', async () => {
+    const value = Fr.random();
+    const tx = await eventOnlyContract.methods.emit_event_for_msg_sender(value).send().wait();
+
+    const events = await wallets[0].getPrivateEvents<TestEvent>(
+      eventOnlyContract.address,
+      EventOnlyContract.events.TestEvent,
+      tx.blockNumber!,
+      1,
+      [wallets[0].getAddress()],
+    );
+
+    expect(events.length).toBe(1);
+    expect(events[0].value).toBe(value);
+  });
+});


### PR DESCRIPTION
We used to process logs of private events only if the contract also had notes. In this PR this is fixed.

Fixes #14499
