### PR TITLE
fix: bug in `TxProvingResult` schema (#14498)

### DIFF
--- a/yarn-project/stdlib/src/tx/proven_tx.ts
+++ b/yarn-project/stdlib/src/tx/proven_tx.ts
@@ -6,7 +6,7 @@ import { z } from 'zod';
 import { PrivateKernelTailCircuitPublicInputs } from '../kernel/private_kernel_tail_circuit_public_inputs.js';
 import { ClientIvcProof } from '../proofs/client_ivc_proof.js';
 import { PrivateExecutionResult, collectSortedContractClassLogs } from './private_execution_result.js';
-import { type ProvingTimings, SimulationTimingsSchema } from './profiling.js';
+import { type ProvingTimings, ProvingTimingsSchema } from './profiling.js';
 import { Tx } from './tx.js';
 
 export class TxProvingResult {
@@ -35,7 +35,7 @@ export class TxProvingResult {
         privateExecutionResult: PrivateExecutionResult.schema,
         publicInputs: PrivateKernelTailCircuitPublicInputs.schema,
         clientIvcProof: ClientIvcProof.schema,
-        timings: optional(SimulationTimingsSchema),
+        timings: optional(ProvingTimingsSchema),
       })
       .transform(TxProvingResult.from);
   }


### PR DESCRIPTION
This PR proposes a fix for the bug/typo in the `TxProvingResult` schema, causing zod errors when parsing responses from `PXE.proveTx(...)`.


