### PR TITLE
feat: completing partial notes in private

### DIFF
--- a/noir-projects/aztec-nr/aztec/src/messages/discovery/partial_notes.nr
+++ b/noir-projects/aztec-nr/aztec/src/messages/discovery/partial_notes.nr
@@ -5,7 +5,7 @@ use crate::{
         encoding::MAX_MESSAGE_CONTENT_LEN,
         processing::enqueue_note_for_validation,
     },
-    oracle::message_processing::get_log_by_tag_from_contract,
+    oracle::message_processing::get_log_by_tag,
     utils::array,
 };
 
@@ -89,7 +89,7 @@ pub unconstrained fn fetch_and_process_public_partial_note_completion_logs<Env>(
     );
 
     pending_partial_notes.for_each(|i, pending_partial_note: DeliveredPendingPartialNote| {
-        let maybe_log = get_log_by_tag_from_contract::<MAX_PARTIAL_NOTE_COMPLETION_LOG_LEN>(
+        let maybe_log = get_log_by_tag::<MAX_PARTIAL_NOTE_COMPLETION_LOG_LEN>(
             pending_partial_note.note_completion_log_tag,
             contract_address,
         );

--- a/noir-projects/aztec-nr/aztec/src/messages/discovery/partial_notes.nr
+++ b/noir-projects/aztec-nr/aztec/src/messages/discovery/partial_notes.nr
@@ -11,7 +11,7 @@ use crate::{
 
 use protocol_types::{
     address::AztecAddress,
-    constants::PUBLIC_LOG_PLAINTEXT_LEN,
+    constants::{PRIVATE_LOG_CIPHERTEXT_LEN, PUBLIC_LOG_PLAINTEXT_LEN},
     debug_log::debug_log_format,
     hash::sha256_to_field,
     traits::{Deserialize, Serialize},
@@ -29,11 +29,11 @@ pub global DELIVERED_PENDING_PARTIAL_NOTE_ARRAY_LENGTH_CAPSULES_SLOT: Field = sh
     "AZTEC_NR::DELIVERED_PENDING_PARTIAL_NOTE_ARRAY_LENGTH_CAPSULES_SLOT".as_bytes(),
 );
 
-/// A partial note completion log's maximum length matches that of a public log plaintext. While these logs can be
-/// transmitted through either the public or private log stream, we standardize their length to the shorter public
-/// format. This ensures consistent behavior regardless of the delivery mechanism, with public logs being the limiting
-/// factor due to their smaller size.
-global MAX_PARTIAL_NOTE_COMPLETION_LOG_LEN: u32 = PUBLIC_LOG_PLAINTEXT_LEN;
+/// A partial note completion log's maximum length is the minimum of the public log plaintext length and private log
+/// ciphertext length. While these logs can be transmitted through either the public or private log stream, we standardize
+/// their length to whichever format is shorter. This ensures consistent behavior regardless of the delivery mechanism.
+global MAX_PARTIAL_NOTE_COMPLETION_LOG_LEN: u32 =
+    std::cmp::min(PUBLIC_LOG_PLAINTEXT_LEN, PRIVATE_LOG_CIPHERTEXT_LEN);
 
 /// A partial note that was delivered but is still pending completion. Contains the information necessary to find the
 /// log that will complete it and lead to a note being discovered and delivered.

--- a/noir-projects/aztec-nr/aztec/src/messages/discovery/partial_notes.nr
+++ b/noir-projects/aztec-nr/aztec/src/messages/discovery/partial_notes.nr
@@ -5,12 +5,13 @@ use crate::{
         encoding::MAX_MESSAGE_CONTENT_LEN,
         processing::enqueue_note_for_validation,
     },
-    oracle::message_processing::get_public_log_by_tag,
+    oracle::message_processing::get_log_by_tag_from_contract,
     utils::array,
 };
 
-use dep::protocol_types::{
+use protocol_types::{
     address::AztecAddress,
+    constants::PUBLIC_LOG_PLAINTEXT_LEN,
     debug_log::debug_log_format,
     hash::sha256_to_field,
     traits::{Deserialize, Serialize},
@@ -27,6 +28,12 @@ pub global MAX_PARTIAL_NOTE_PRIVATE_PACKED_LEN: u32 =
 pub global DELIVERED_PENDING_PARTIAL_NOTE_ARRAY_LENGTH_CAPSULES_SLOT: Field = sha256_to_field(
     "AZTEC_NR::DELIVERED_PENDING_PARTIAL_NOTE_ARRAY_LENGTH_CAPSULES_SLOT".as_bytes(),
 );
+
+/// A partial note completion log's maximum length matches that of a public log plaintext. While these logs can be
+/// transmitted through either the public or private log stream, we standardize their length to the shorter public
+/// format. This ensures consistent behavior regardless of the delivery mechanism, with public logs being the limiting
+/// factor due to their smaller size.
+global MAX_PARTIAL_NOTE_COMPLETION_LOG_LEN: u32 = PUBLIC_LOG_PLAINTEXT_LEN;
 
 /// A partial note that was delivered but is still pending completion. Contains the information necessary to find the
 /// log that will complete it and lead to a note being discovered and delivered.
@@ -82,7 +89,7 @@ pub unconstrained fn fetch_and_process_public_partial_note_completion_logs<Env>(
     );
 
     pending_partial_notes.for_each(|i, pending_partial_note: DeliveredPendingPartialNote| {
-        let maybe_log = get_public_log_by_tag(
+        let maybe_log = get_log_by_tag_from_contract::<MAX_PARTIAL_NOTE_COMPLETION_LOG_LEN>(
             pending_partial_note.note_completion_log_tag,
             contract_address,
         );
@@ -107,7 +114,7 @@ pub unconstrained fn fetch_and_process_public_partial_note_completion_logs<Env>(
             // the complete packed content.
             let complete_packed_note = array::append(
                 pending_partial_note.packed_private_note_content,
-                log.log_plaintext,
+                log.log_payload,
             );
 
             let discovered_notes = attempt_note_nonce_discovery(

--- a/noir-projects/aztec-nr/aztec/src/oracle/message_processing.nr
+++ b/noir-projects/aztec-nr/aztec/src/oracle/message_processing.nr
@@ -1,6 +1,6 @@
-use dep::protocol_types::{
-    address::AztecAddress,
-    constants::{MAX_NOTE_HASHES_PER_TX, PUBLIC_LOG_PLAINTEXT_LEN},
+use protocol_types::{
+    hash::compute_siloed_private_log_field, address::AztecAddress,
+    constants::{PRIVATE_LOG_CIPHERTEXT_LEN, MAX_NOTE_HASHES_PER_TX, PUBLIC_LOG_PLAINTEXT_LEN},
 };
 
 /// Finds new private logs that may have been sent to all registered accounts in PXE in the current contract and makes
@@ -12,11 +12,11 @@ pub unconstrained fn fetch_tagged_logs(pending_tagged_log_array_base_slot: Field
 #[oracle(fetchTaggedLogs)]
 unconstrained fn fetch_tagged_logs_oracle(pending_tagged_log_array_base_slot: Field) {}
 
-/// The plaintext of a public log (i.e. the content minus the tag), plus contextual information about the transaction
-// in which the log was emitted. This is the data required in order to discover notes that are being delivered in a
-// log.
-pub struct PublicLogWithTxData {
-    pub log_plaintext: BoundedVec<Field, PUBLIC_LOG_PLAINTEXT_LEN>,
+/// The payload of a log (i.e. the content minus the tag, called plaintext for public logs and ciphertext for private),
+/// plus contextual information about the transaction in which the log was emitted. This is the data required in order
+/// to discover notes that are being delivered in a log.
+pub struct LogWithTxData<let N: u32> {
+    pub log_payload: BoundedVec<Field, N>,
     pub tx_hash: Field,
     /// The array of new note hashes created by `tx_hash`
     pub unique_note_hashes_in_tx: BoundedVec<Field, MAX_NOTE_HASHES_PER_TX>,
@@ -24,22 +24,105 @@ pub struct PublicLogWithTxData {
     pub first_nullifier_in_tx: Field,
 }
 
-/// Fetches a public log emitted by `contract_address` that has the corresponding `tag`. The tag is the first field in the log's content.
-/// Returns `Option::none` if no such log exists. Throws if more than one log with that tag exists.
+/// The plaintext of a public log (i.e. the content minus the tag), plus contextual information about the transaction
+// in which the log was emitted. This is the data required in order to discover notes that are being delivered in a
+// log.
+impl<let N: u32> LogWithTxData<N> {
+    /// Returns a copy of the original log with payload max length equal to TO_LEN.
+    ///
+    /// # Arguments
+    /// * `log` - The log to convert
+    /// * `FROM_LEN` - The max length of the log payload
+    /// * `TO_LEN` - The max length of the log payload
+    ///
+    /// # Panics
+    /// If the log's content exceeds TO_LEN
+    pub fn update_max_len<let TO_LEN: u32>(self) -> LogWithTxData<TO_LEN> {
+        // We need to check that the actual log content is not longer than the max length.
+        assert(self.log_payload.len() <= TO_LEN, "Source log payload too long");
+
+        // We copy the log content to the BoundedVec of the correct max length.
+        let mut log_payload = BoundedVec::new();
+        log_payload.extend_from_bounded_vec(self.log_payload);
+
+        LogWithTxData {
+            log_payload,
+            tx_hash: self.tx_hash,
+            unique_note_hashes_in_tx: self.unique_note_hashes_in_tx,
+            first_nullifier_in_tx: self.first_nullifier_in_tx,
+        }
+    }
+}
+
+/// Fetches a public log emitted by `contract_address` that has the corresponding `tag`. Returns `Option::none` if no
+/// such log exists. Throws if more than one log with that tag exists.
 // TODO(#11627): handle multiple logs with the same tag.
-// TODO(#10273): improve contract siloing of logs, don't introduce an extra field.
 pub unconstrained fn get_public_log_by_tag(
     tag: Field,
     contract_address: AztecAddress,
-) -> Option<PublicLogWithTxData> {
+) -> Option<LogWithTxData<PUBLIC_LOG_PLAINTEXT_LEN>> {
     get_public_log_by_tag_oracle(tag, contract_address)
 }
 
-#[oracle(getPublicLogByTag)]
-unconstrained fn get_public_log_by_tag_oracle(
+/// Fetches a private log from the node that has the corresponding `tag`. Returns `Option::none` if no such log exists.
+/// Throws if more than one log with that tag exists.
+// TODO(#11627): handle multiple logs with the same tag.
+pub unconstrained fn get_private_log_by_tag(
     tag: Field,
     contract_address: AztecAddress,
-) -> Option<PublicLogWithTxData> {}
+) -> Option<LogWithTxData<PRIVATE_LOG_CIPHERTEXT_LEN>> {
+    // Note that unlike in the public case, the tag is siloed with the contract address.
+    let siloed_tag = compute_siloed_private_log_field(contract_address, tag);
+
+    get_private_log_by_tag_oracle(siloed_tag)
+}
+
+/// Attempts to retrieve a log by its tag from both public and private sources.
+///
+/// First checks public logs, falling back to private logs if no public log is found.
+/// The returned log content is coerced to have max length equal to MAX_LOG_PAYLOAD_LEN.
+///
+/// # Arguments
+/// * `tag` - The tag to search for in both public and private logs
+/// * `contract_address` - The contract address to search logs from
+///
+/// # Returns
+/// A log with payload max length equal to MAX_LOG_PAYLOAD_LEN
+///
+/// # Panics
+/// If the found log's content exceeds MAX_LOG_PAYLOAD_LEN
+pub unconstrained fn get_log_by_tag_from_contract<let MAX_LOG_PAYLOAD_LEN: u32>(
+    tag: Field,
+    contract_address: AztecAddress,
+) -> Option<LogWithTxData<MAX_LOG_PAYLOAD_LEN>> {
+    // This function works with both private and public logs and for this reason it's necessary that
+    // MAX_LOG_PAYLOAD_LEN is less than or equal to the smaller of the two log sizes. We check this against both log
+    // sizes instead of just the smaller one to make this resistant to future log size changes.
+    std::static_assert(
+        MAX_LOG_PAYLOAD_LEN <= PUBLIC_LOG_PLAINTEXT_LEN,
+        "MAX_LOG_PAYLOAD_LEN must be less than PUBLIC_LOG_PLAINTEXT_LEN",
+    );
+    std::static_assert(
+        MAX_LOG_PAYLOAD_LEN <= PRIVATE_LOG_CIPHERTEXT_LEN,
+        "MAX_LOG_PAYLOAD_LEN must be less than PRIVATE_LOG_CIPHERTEXT_LEN",
+    );
+
+    let maybe_public_log = get_public_log_by_tag(tag, contract_address);
+    if maybe_public_log.is_some() {
+        let public_log = maybe_public_log.unwrap_unchecked();
+        Option::some(public_log.update_max_len())
+    } else {
+        // We didn't manage to obtain the log from the public log stream, so we try the private one.
+        let maybe_private_log = get_private_log_by_tag(tag, contract_address);
+        if maybe_private_log.is_some() {
+            let private_log = maybe_private_log.unwrap_unchecked();
+            Option::some(private_log.update_max_len())
+        } else {
+            Option::none()
+        }
+    }
+}
+
 
 pub(crate) unconstrained fn validate_enqueued_notes(
     contract_address: AztecAddress,
@@ -47,6 +130,17 @@ pub(crate) unconstrained fn validate_enqueued_notes(
 ) {
     validate_enqueued_notes_oracle(contract_address, base_slot);
 }
+
+#[oracle(getPublicLogByTag)]
+unconstrained fn get_public_log_by_tag_oracle(
+    tag: Field,
+    contract_address: AztecAddress,
+) -> Option<LogWithTxData<PUBLIC_LOG_PLAINTEXT_LEN>> {}
+
+#[oracle(getPrivateLogByTag)]
+unconstrained fn get_private_log_by_tag_oracle(
+    siloed_tag: Field,
+) -> Option<LogWithTxData<PRIVATE_LOG_CIPHERTEXT_LEN>> {}
 
 #[oracle(validateEnqueuedNotes)]
 unconstrained fn validate_enqueued_notes_oracle(contract_address: AztecAddress, base_slot: Field) {}

--- a/noir-projects/aztec-nr/aztec/src/oracle/message_processing.nr
+++ b/noir-projects/aztec-nr/aztec/src/oracle/message_processing.nr
@@ -92,7 +92,7 @@ pub unconstrained fn get_private_log_by_tag(
 ///
 /// # Panics
 /// If the found log's content exceeds MAX_LOG_PAYLOAD_LEN
-pub unconstrained fn get_log_by_tag_from_contract<let MAX_LOG_PAYLOAD_LEN: u32>(
+pub unconstrained fn get_log_by_tag<let MAX_LOG_PAYLOAD_LEN: u32>(
     tag: Field,
     contract_address: AztecAddress,
 ) -> Option<LogWithTxData<MAX_LOG_PAYLOAD_LEN>> {

--- a/noir-projects/aztec-nr/aztec/src/oracle/message_processing.nr
+++ b/noir-projects/aztec-nr/aztec/src/oracle/message_processing.nr
@@ -65,6 +65,12 @@ pub unconstrained fn get_public_log_by_tag(
     get_public_log_by_tag_oracle(tag, contract_address)
 }
 
+#[oracle(getPublicLogByTag)]
+unconstrained fn get_public_log_by_tag_oracle(
+    tag: Field,
+    contract_address: AztecAddress,
+) -> Option<LogWithTxData<PUBLIC_LOG_PLAINTEXT_LEN>> {}
+
 /// Fetches a private log from the node that has the corresponding `tag`. Returns `Option::none` if no such log exists.
 /// Throws if more than one log with that tag exists.
 // TODO(#11627): handle multiple logs with the same tag.
@@ -77,6 +83,11 @@ pub unconstrained fn get_private_log_by_tag(
 
     get_private_log_by_tag_oracle(siloed_tag)
 }
+
+#[oracle(getPrivateLogByTag)]
+unconstrained fn get_private_log_by_tag_oracle(
+    siloed_tag: Field,
+) -> Option<LogWithTxData<PRIVATE_LOG_CIPHERTEXT_LEN>> {}
 
 /// Attempts to retrieve a log by its tag from both public and private sources.
 ///
@@ -130,17 +141,6 @@ pub(crate) unconstrained fn validate_enqueued_notes(
 ) {
     validate_enqueued_notes_oracle(contract_address, base_slot);
 }
-
-#[oracle(getPublicLogByTag)]
-unconstrained fn get_public_log_by_tag_oracle(
-    tag: Field,
-    contract_address: AztecAddress,
-) -> Option<LogWithTxData<PUBLIC_LOG_PLAINTEXT_LEN>> {}
-
-#[oracle(getPrivateLogByTag)]
-unconstrained fn get_private_log_by_tag_oracle(
-    siloed_tag: Field,
-) -> Option<LogWithTxData<PRIVATE_LOG_CIPHERTEXT_LEN>> {}
 
 #[oracle(validateEnqueuedNotes)]
 unconstrained fn validate_enqueued_notes_oracle(contract_address: AztecAddress, base_slot: Field) {}

--- a/noir-projects/aztec-nr/aztec/src/oracle/message_processing.nr
+++ b/noir-projects/aztec-nr/aztec/src/oracle/message_processing.nr
@@ -1,6 +1,7 @@
 use protocol_types::{
-    hash::compute_siloed_private_log_field, address::AztecAddress,
-    constants::{PRIVATE_LOG_CIPHERTEXT_LEN, MAX_NOTE_HASHES_PER_TX, PUBLIC_LOG_PLAINTEXT_LEN},
+    address::AztecAddress,
+    constants::{MAX_NOTE_HASHES_PER_TX, PRIVATE_LOG_CIPHERTEXT_LEN, PUBLIC_LOG_PLAINTEXT_LEN},
+    hash::compute_siloed_private_log_field,
 };
 
 /// Finds new private logs that may have been sent to all registered accounts in PXE in the current contract and makes
@@ -122,7 +123,6 @@ pub unconstrained fn get_log_by_tag_from_contract<let MAX_LOG_PAYLOAD_LEN: u32>(
         }
     }
 }
-
 
 pub(crate) unconstrained fn validate_enqueued_notes(
     contract_address: AztecAddress,

--- a/noir-projects/aztec-nr/uint-note/src/uint_note.nr
+++ b/noir-projects/aztec-nr/uint-note/src/uint_note.nr
@@ -1,5 +1,6 @@
 use dep::aztec::{
     context::{PrivateContext, PublicContext},
+    history::nullifier_inclusion::ProveNullifierInclusion,
     keys::getters::{get_nsk_app, get_public_keys},
     macros::notes::custom_note,
     messages::logs::note,
@@ -9,9 +10,9 @@ use dep::aztec::{
         address::AztecAddress,
         constants::{
             GENERATOR_INDEX__NOTE_HASH, GENERATOR_INDEX__NOTE_NULLIFIER,
-            GENERATOR_INDEX__PARTIAL_NOTE_VALIDITY_COMMITMENT,
+            GENERATOR_INDEX__PARTIAL_NOTE_VALIDITY_COMMITMENT, PRIVATE_LOG_SIZE_IN_FIELDS,
         },
-        hash::poseidon2_hash_with_separator,
+        hash::{compute_siloed_nullifier, poseidon2_hash_with_separator},
         traits::{Deserialize, FromField, Hash, Packable, Serialize, ToField},
         utils::arrays::array_concat,
     },
@@ -212,6 +213,8 @@ pub struct PartialUintNote {
     commitment: Field,
 }
 
+global NOTE_COMPLETION_LOG_LENGTH: u32 = 2;
+
 impl PartialUintNote {
     /// Completes the partial note, creating a new note that can be used like any other UintNote.
     pub fn complete(self, context: &mut PublicContext, completer: AztecAddress, value: u128) {
@@ -240,6 +243,38 @@ impl PartialUintNote {
         context.push_note_hash(self.compute_complete_note_hash(value));
     }
 
+    /// Completes the partial note, creating a new note that can be used like any other UintNote. Same as `complete`
+    /// function but works from private context.
+    pub fn complete_from_private(
+        self,
+        context: &mut PrivateContext,
+        completer: AztecAddress,
+        value: u128,
+    ) {
+        // We verify that the partial note we're completing is valid (i.e. completer is correct, it uses the correct
+        // state variable's storage slot, and it is internally consistent).
+        let validity_commitment = self.compute_validity_commitment(completer);
+        // `prove_nullifier_inclusion` function expects the nullifier to be siloed (hashed with the address of
+        // the contract that emitted the nullifier) as it checks the value directly against the nullifier tree and all
+        // the nullifiers in the tree are siloed by the protocol.
+        let siloed_validity_commitment =
+            compute_siloed_nullifier(context.this_address(), validity_commitment);
+        context.get_block_header().prove_nullifier_inclusion(siloed_validity_commitment);
+
+        // We need to do two things:
+        //  - emit an unencrypted log containing the public fields (the value) via the private log channel. The
+        //  contract will later find it by searching for the expected tag (which is simply the partial note
+        //  commitment).
+        //  - insert the completion note hash (i.e. the hash of the note) into the note hash tree. This is typically
+        //  only done in private to hide the preimage of the hash that is inserted, but completed partial notes are
+        //  inserted in public as the public values are provided and the note hash computed.
+        context.emit_private_log(
+            self.compute_note_completion_log_padded_for_private_log(value),
+            NOTE_COMPLETION_LOG_LENGTH,
+        );
+        context.push_note_hash(self.compute_complete_note_hash(value));
+    }
+
     /// Computes a validity commitment for this partial note. The commitment cryptographically binds the note's private
     /// data with the designated completer address. When the note is later completed in public execution, we can load
     /// this commitment from the nullifier tree and verify that both the partial note (e.g. that the storage slot
@@ -252,10 +287,19 @@ impl PartialUintNote {
         )
     }
 
-    fn compute_note_completion_log(self, value: u128) -> [Field; 2] {
+    fn compute_note_completion_log(self, value: u128) -> [Field; NOTE_COMPLETION_LOG_LENGTH] {
         // The first field of this log must be the tag that the recipient of the partial note private field logs
         // expects, which is equal to the partial note commitment.
         [self.commitment, value.to_field()]
+    }
+
+    fn compute_note_completion_log_padded_for_private_log(
+        self,
+        value: u128,
+    ) -> [Field; PRIVATE_LOG_SIZE_IN_FIELDS] {
+        let note_completion_log = self.compute_note_completion_log(value);
+        let padding = [0; PRIVATE_LOG_SIZE_IN_FIELDS - NOTE_COMPLETION_LOG_LENGTH];
+        array_concat(note_completion_log, padding)
     }
 
     fn compute_complete_note_hash(self, value: u128) -> Field {

--- a/noir-projects/noir-contracts/contracts/app/orderbook_contract/src/main.nr
+++ b/noir-projects/noir-contracts/contracts/app/orderbook_contract/src/main.nr
@@ -129,11 +129,17 @@ pub contract Orderbook {
         // Determine which tokens are being exchanged based on bid_token_is_zero flag
         let (bid_token, ask_token) = config.get_tokens(order.bid_token_is_zero);
 
-        // TODO(#14362): Once we allow partial note completion in private we can skip the transfer to public here and
-        // just finalize the maker's partial note straight away here.
-        // Transfer the ask_amount from taker to the contract
+        // The `order_id` is a serialized form of the maker's partial note.
+        let maker_partial_note = PartialUintNote::from_field(order_id);
+
+        // Transfer the ask_amount from taker directly to the maker's partial note.
         Token::at(ask_token)
-            .transfer_to_public(taker, context.this_address(), order.ask_amount, nonce)
+            .finalize_transfer_to_private_from_private(
+                taker,
+                maker_partial_note,
+                order.ask_amount,
+                nonce,
+            )
             .call(&mut context);
 
         // Prepare partial note for taker to receive bid_token
@@ -149,14 +155,7 @@ pub contract Orderbook {
 
         // Enqueue the fulfillment to finalize both partial notes
         Orderbook::at(context.this_address())
-            ._fulfill_order(
-                order_id,
-                taker_partial_note,
-                bid_token,
-                ask_token,
-                order.bid_amount,
-                order.ask_amount,
-            )
+            ._fulfill_order(order_id, taker_partial_note, bid_token, order.bid_amount)
             .enqueue(&mut context);
     }
 
@@ -166,23 +165,16 @@ pub contract Orderbook {
         order_id: Field,
         taker_partial_note: PartialUintNote,
         bid_token: AztecAddress,
-        ask_token: AztecAddress,
         bid_amount: u128,
-        ask_amount: u128,
     ) {
-        // The `order_id` is a serialized form of the maker's partial note.
-        let maker_partial_note = PartialUintNote::from_field(order_id);
-
-        // Finalize transfer of ask_amount of ask_token to maker
-        Token::at(ask_token).finalize_transfer_to_private(ask_amount, maker_partial_note).call(
-            &mut context,
-        );
-
         // Finalize transfer of bid_amount of bid_token to taker
         Token::at(bid_token).finalize_transfer_to_private(bid_amount, taker_partial_note).call(
             &mut context,
         );
 
+        // TODO: This would make sense to emit in `fulfill_order` as then we would not have to pass it to this function
+        // and we would do less args hashing. But as far as I know emitting of unencrypted events in private is not
+        // supported.
         emit_event_in_public_log(OrderFulfilled { order_id }, &mut context);
     }
 

--- a/noir-projects/noir-contracts/contracts/app/orderbook_contract/src/main.nr
+++ b/noir-projects/noir-contracts/contracts/app/orderbook_contract/src/main.nr
@@ -172,9 +172,6 @@ pub contract Orderbook {
             &mut context,
         );
 
-        // TODO: This would make sense to emit in `fulfill_order` as then we would not have to pass it to this function
-        // and we would do less args hashing. But as far as I know emitting of unencrypted events in private is not
-        // supported.
         emit_event_in_public_log(OrderFulfilled { order_id }, &mut context);
     }
 

--- a/noir-projects/noir-contracts/contracts/app/token_contract/src/main.nr
+++ b/noir-projects/noir-contracts/contracts/app/token_contract/src/main.nr
@@ -512,6 +512,37 @@ pub contract Token {
     }
     // docs:end:finalize_transfer_to_private
 
+    /// Finalizes a transfer of token `amount` from private balance of `from` to a private balance of `to`.
+    /// The transfer must be prepared by calling `prepare_private_balance_increase` from `from` account and
+    /// the resulting `partial_note` must be passed as an argument to this function.
+    ///
+    /// Note that this contract does not protect against a `partial_note` being used multiple times and it is up to
+    /// the caller of this function to ensure that it doesn't happen. If the same `partial_note` is used multiple
+    /// times, the token `amount` would most likely get lost (the partial note log processing functionality would fail
+    /// to find the pending partial note when trying to complete it).
+    #[private]
+    fn finalize_transfer_to_private_from_private(
+        from: AztecAddress,
+        partial_note: PartialUintNote,
+        amount: u128,
+        nonce: Field,
+    ) {
+        if (!from.eq(context.msg_sender())) {
+            assert_current_call_valid_authwit(&mut context, from);
+        } else {
+            assert(nonce == 0, "invalid nonce");
+        }
+
+        // First we subtract the `amount` from the private balance of `from`
+        storage.balances.at(from).sub(from, amount).emit(encode_and_encrypt_note(
+            &mut context,
+            from,
+            from,
+        ));
+
+        partial_note.complete_from_private(&mut context, context.msg_sender(), amount);
+    }
+
     // docs:start:finalize_transfer_to_private_unsafe
     /// This is a wrapper around `_finalize_transfer_to_private` placed here so that a call
     /// to `_finalize_transfer_to_private` can be enqueued. Called unsafe as it does not check `from_and_completer`

--- a/noir-projects/noir-contracts/contracts/app/token_contract/src/test/transfer_to_private.nr
+++ b/noir-projects/noir-contracts/contracts/app/token_contract/src/test/transfer_to_private.nr
@@ -42,6 +42,36 @@ unconstrained fn transfer_to_private_external_orchestration() {
     utils::check_private_balance(token_contract_address, recipient, amount);
 }
 
+// TODO(#10289): Enable this test once TXE handles partial notes properly. Currently it fails on the recipient amount
+// check.
+// /// External orchestration means that the calls to prepare and finalize are not done by the Token contract. This flow
+// /// will typically be used by a DEX.
+// #[test]
+// unconstrained fn transfer_to_private_from_private_external_orchestration() {
+//     // Setup without account contracts. We are not using authwits here, so dummy accounts are enough
+//     let (env, token_contract_address, owner, recipient, amount) =
+//         utils::setup_and_mint_to_private(/* with_account_contracts */ false);
+
+//     // We prepare the transfer
+//     let partial_uint_note = Token::at(token_contract_address)
+//         .prepare_private_balance_increase(recipient, owner)
+//         .call(&mut env.private());
+
+//     // Finalize the transfer of the tokens (message sender owns the tokens in public)
+//     Token::at(token_contract_address).finalize_transfer_to_private_from_private(
+//         owner,
+//         partial_uint_note,
+//         amount,
+//         0,
+//     ).call(&mut env.private());
+
+//     env.advance_block_by(1);
+
+//     // Recipient's private balance should be equal to the amount
+//     utils::check_private_balance(token_contract_address, recipient, amount);
+//     utils::check_private_balance(token_contract_address, owner, 0);
+// }
+
 #[test(should_fail_with = "Invalid partial note or completer")]
 unconstrained fn transfer_to_private_transfer_not_prepared() {
     // Setup without account contracts. We are not using authwits here, so dummy accounts are enough

--- a/yarn-project/end-to-end/src/e2e_orderbook.test.ts
+++ b/yarn-project/end-to-end/src/e2e_orderbook.test.ts
@@ -99,10 +99,15 @@ describe('Orderbook', () => {
     it('fulfills an order', async () => {
       const nonceForAuthwits = Fr.random();
 
-      // Create authwit for taker to allow orderbook to transfer askAmount of token1 to itself
+      // Create authwit for taker to allow orderbook to transfer askAmount of token1 from taker to maker's partial note
       const takerAuthwit = await taker.createAuthWit({
         caller: orderbook.address,
-        action: token1.methods.transfer_to_public(taker.getAddress(), orderbook.address, askAmount, nonceForAuthwits),
+        action: token1.methods.finalize_transfer_to_private_from_private(
+          taker.getAddress(),
+          { commitment: orderId }, // makerPartialNote
+          askAmount,
+          nonceForAuthwits,
+        ),
       });
 
       // Fulfill order

--- a/yarn-project/pxe/src/contract_function_simulator/execution_data_provider.ts
+++ b/yarn-project/pxe/src/contract_function_simulator/execution_data_provider.ts
@@ -10,7 +10,7 @@ import type { AztecAddress } from '@aztec/stdlib/aztec-address';
 import type { L2Block } from '@aztec/stdlib/block';
 import type { CompleteAddress, ContractInstance } from '@aztec/stdlib/contract';
 import type { KeyValidationRequest } from '@aztec/stdlib/kernel';
-import { IndexedTaggingSecret, PublicLogWithTxData } from '@aztec/stdlib/logs';
+import { IndexedTaggingSecret, PrivateLogWithTxData, PublicLogWithTxData } from '@aztec/stdlib/logs';
 import type { NoteStatus } from '@aztec/stdlib/note';
 import { type MerkleTreeId, type NullifierMembershipWitness, PublicDataWitness } from '@aztec/stdlib/trees';
 import type { BlockHeader, NodeStats, TxHash } from '@aztec/stdlib/tx';
@@ -296,6 +296,15 @@ export interface ExecutionDataProvider {
    * @throws If more than one log with that tag exists.
    */
   getPublicLogByTag(tag: Fr, contractAddress: AztecAddress): Promise<PublicLogWithTxData | null>;
+
+  /**
+   * Searches for a private log with the corresponding `siloedTag` and returns it along with contextual transaction
+   * information.
+   *
+   * @param siloedTag - The siloed log tag to search for.
+   * @returns The private log with transaction data if found, null otherwise.
+   */
+  getPrivateLogByTag(siloedTag: Fr): Promise<PrivateLogWithTxData | null>;
 
   /**
    * Removes all of a contract's notes that have been nullified from the note database.

--- a/yarn-project/pxe/src/contract_function_simulator/oracle/oracle.ts
+++ b/yarn-project/pxe/src/contract_function_simulator/oracle/oracle.ts
@@ -12,7 +12,12 @@ import {
 } from '@aztec/simulator/client';
 import { EventSelector, FunctionSelector, NoteSelector } from '@aztec/stdlib/abi';
 import { AztecAddress } from '@aztec/stdlib/aztec-address';
-import { ContractClassLog, ContractClassLogFields, PublicLogWithTxData } from '@aztec/stdlib/logs';
+import {
+  ContractClassLog,
+  ContractClassLogFields,
+  PrivateLogWithTxData,
+  PublicLogWithTxData,
+} from '@aztec/stdlib/logs';
 import { MerkleTreeId } from '@aztec/stdlib/trees';
 import { TxHash } from '@aztec/stdlib/tx';
 
@@ -419,6 +424,16 @@ export class Oracle {
 
     if (log == null) {
       return [toACVMField(0), ...PublicLogWithTxData.noirSerializationOfEmpty().map(toACVMFieldSingleOrArray)];
+    } else {
+      return [toACVMField(1), ...log.toNoirSerialization().map(toACVMFieldSingleOrArray)];
+    }
+  }
+
+  async getPrivateLogByTag([siloedTag]: ACVMField[]): Promise<(ACVMField | ACVMField[])[]> {
+    const log = await this.typedOracle.getPrivateLogByTag(Fr.fromString(siloedTag));
+
+    if (log == null) {
+      return [toACVMField(0), ...PrivateLogWithTxData.noirSerializationOfEmpty().map(toACVMFieldSingleOrArray)];
     } else {
       return [toACVMField(1), ...log.toNoirSerialization().map(toACVMFieldSingleOrArray)];
     }

--- a/yarn-project/pxe/src/contract_function_simulator/oracle/typed_oracle.ts
+++ b/yarn-project/pxe/src/contract_function_simulator/oracle/typed_oracle.ts
@@ -4,7 +4,12 @@ import type { EventSelector, FunctionSelector, NoteSelector } from '@aztec/stdli
 import type { AztecAddress } from '@aztec/stdlib/aztec-address';
 import type { CompleteAddress, ContractInstance } from '@aztec/stdlib/contract';
 import type { KeyValidationRequest } from '@aztec/stdlib/kernel';
-import type { ContractClassLog, IndexedTaggingSecret, PublicLogWithTxData } from '@aztec/stdlib/logs';
+import type {
+  ContractClassLog,
+  IndexedTaggingSecret,
+  PrivateLogWithTxData,
+  PublicLogWithTxData,
+} from '@aztec/stdlib/logs';
 import type { Note, NoteStatus } from '@aztec/stdlib/note';
 import { type MerkleTreeId, type NullifierMembershipWitness, PublicDataWitness } from '@aztec/stdlib/trees';
 import type { BlockHeader, TxHash } from '@aztec/stdlib/tx';
@@ -224,6 +229,10 @@ export abstract class TypedOracle {
 
   getPublicLogByTag(_tag: Fr, _contractAddress: AztecAddress): Promise<PublicLogWithTxData | null> {
     throw new OracleMethodNotAvailableError('getPublicLogByTag');
+  }
+
+  getPrivateLogByTag(_siloedTag: Fr): Promise<PrivateLogWithTxData | null> {
+    throw new OracleMethodNotAvailableError('getPrivateLogByTag');
   }
 
   storeCapsule(_contractAddress: AztecAddress, _key: Fr, _capsule: Fr[]): Promise<void> {

--- a/yarn-project/pxe/src/contract_function_simulator/oracle/utility_execution_oracle.ts
+++ b/yarn-project/pxe/src/contract_function_simulator/oracle/utility_execution_oracle.ts
@@ -7,7 +7,7 @@ import { AztecAddress } from '@aztec/stdlib/aztec-address';
 import type { CompleteAddress, ContractInstance } from '@aztec/stdlib/contract';
 import { siloNullifier } from '@aztec/stdlib/hash';
 import type { KeyValidationRequest } from '@aztec/stdlib/kernel';
-import { IndexedTaggingSecret, PublicLogWithTxData } from '@aztec/stdlib/logs';
+import { IndexedTaggingSecret, PrivateLogWithTxData, PublicLogWithTxData } from '@aztec/stdlib/logs';
 import type { NoteStatus } from '@aztec/stdlib/note';
 import { type MerkleTreeId, type NullifierMembershipWitness, PublicDataWitness } from '@aztec/stdlib/trees';
 import type { BlockHeader, Capsule, TxHash } from '@aztec/stdlib/tx';
@@ -291,6 +291,10 @@ export class UtilityExecutionOracle extends TypedOracle {
 
   public override getPublicLogByTag(tag: Fr, contractAddress: AztecAddress): Promise<PublicLogWithTxData | null> {
     return this.executionDataProvider.getPublicLogByTag(tag, contractAddress);
+  }
+
+  public override getPrivateLogByTag(siloedTag: Fr): Promise<PrivateLogWithTxData | null> {
+    return this.executionDataProvider.getPrivateLogByTag(siloedTag);
   }
 
   public override storeCapsule(contractAddress: AztecAddress, slot: Fr, capsule: Fr[]): Promise<void> {

--- a/yarn-project/stdlib/src/logs/log_with_tx_data.ts
+++ b/yarn-project/stdlib/src/logs/log_with_tx_data.ts
@@ -1,29 +1,47 @@
-import { MAX_NOTE_HASHES_PER_TX, PUBLIC_LOG_PLAINTEXT_LEN } from '@aztec/constants';
+import { MAX_NOTE_HASHES_PER_TX, PRIVATE_LOG_CIPHERTEXT_LEN, PUBLIC_LOG_PLAINTEXT_LEN } from '@aztec/constants';
 import { Fr } from '@aztec/foundation/fields';
 import { TxHash } from '@aztec/stdlib/tx';
 
-// TypeScript representation of the Noir aztec::oracle::message_processing::PublicLogWithTxData struct. This is used as a
-// response for PXE's custom getPublicLogByTag oracle.
-export class PublicLogWithTxData {
+// TypeScript representation of the Noir aztec::oracle::message_processing::LogWithTxData<N> struct. This is used as a
+// response for PXE's custom getPublicLogByTag and getPrivateLogByTag oracles.
+class LogWithTxData<N extends number> {
   constructor(
-    // The emitted fields of a log.
-    public logPlaintext: Fr[],
+    public logPayload: Fr[],
     public txHash: TxHash,
     public uniqueNoteHashesInTx: Fr[],
     public firstNullifierInTx: Fr,
+    private maxLogContentLength: N,
   ) {}
 
   toNoirSerialization(): (Fr | Fr[])[] {
     return [
-      ...toBoundedVecSerialization(this.logPlaintext, PUBLIC_LOG_PLAINTEXT_LEN),
+      ...toBoundedVecSerialization(this.logPayload, this.maxLogContentLength),
       this.txHash.hash,
       ...toBoundedVecSerialization(this.uniqueNoteHashesInTx, MAX_NOTE_HASHES_PER_TX),
       this.firstNullifierInTx,
     ];
   }
+}
+
+// This is used as a response for PXE's custom getPublicLogByTag oracle.
+export class PublicLogWithTxData extends LogWithTxData<typeof PUBLIC_LOG_PLAINTEXT_LEN> {
+  constructor(logContent: Fr[], txHash: TxHash, uniqueNoteHashesInTx: Fr[], firstNullifierInTx: Fr) {
+    super(logContent, txHash, uniqueNoteHashesInTx, firstNullifierInTx, PUBLIC_LOG_PLAINTEXT_LEN);
+  }
 
   static noirSerializationOfEmpty(): (Fr | Fr[])[] {
     return new PublicLogWithTxData([], TxHash.zero(), [], new Fr(0)).toNoirSerialization();
+  }
+}
+
+// This is used as a response for PXE's custom getPrivateLogByTag oracle.
+export class PrivateLogWithTxData extends LogWithTxData<typeof PRIVATE_LOG_CIPHERTEXT_LEN> {
+  constructor(logContent: Fr[], txHash: TxHash, uniqueNoteHashesInTx: Fr[], firstNullifierInTx: Fr) {
+    super(logContent, txHash, uniqueNoteHashesInTx, firstNullifierInTx, PRIVATE_LOG_CIPHERTEXT_LEN);
+  }
+
+  static noirSerializationOfEmpty(): (Fr | Fr[])[] {
+    return new PrivateLogWithTxData([], TxHash.zero(), [], new Fr(0)).toNoirSerialization();
   }
 }
 

--- a/yarn-project/txe/src/oracle/txe_oracle.ts
+++ b/yarn-project/txe/src/oracle/txe_oracle.ts
@@ -102,6 +102,7 @@ import {
   ContractClassLog,
   IndexedTaggingSecret,
   PrivateLog,
+  PrivateLogWithTxData,
   type PublicLog,
   PublicLogWithTxData,
 } from '@aztec/stdlib/logs';
@@ -1183,6 +1184,10 @@ export class TXE implements TypedOracle {
 
   async getPublicLogByTag(tag: Fr, contractAddress: AztecAddress): Promise<PublicLogWithTxData | null> {
     return await this.pxeOracleInterface.getPublicLogByTag(tag, contractAddress);
+  }
+
+  async getPrivateLogByTag(siloedTag: Fr): Promise<PrivateLogWithTxData | null> {
+    return await this.pxeOracleInterface.getPrivateLogByTag(siloedTag);
   }
 
   // AVM oracles

--- a/yarn-project/txe/src/txe_service/txe_service.ts
+++ b/yarn-project/txe/src/txe_service/txe_service.ts
@@ -11,7 +11,7 @@ import { AztecAddress } from '@aztec/stdlib/aztec-address';
 import { computePartialAddress } from '@aztec/stdlib/contract';
 import { SimulationError } from '@aztec/stdlib/errors';
 import { computePublicDataTreeLeafSlot } from '@aztec/stdlib/hash';
-import { PublicLogWithTxData } from '@aztec/stdlib/logs';
+import { PrivateLogWithTxData, PublicLogWithTxData } from '@aztec/stdlib/logs';
 import { MerkleTreeId } from '@aztec/stdlib/trees';
 
 import { TXE } from '../oracle/txe_oracle.js';
@@ -734,6 +734,24 @@ export class TXEService {
       return toForeignCallResult([
         toSingle(Fr.ZERO),
         ...PublicLogWithTxData.noirSerializationOfEmpty().map(toSingleOrArray),
+      ]);
+    } else {
+      return toForeignCallResult([toSingle(Fr.ONE), ...log.toNoirSerialization().map(toSingleOrArray)]);
+    }
+  }
+
+  async getPrivateLogByTag(siloedTag: ForeignCallSingle) {
+    if (!this.oraclesEnabled) {
+      throw new Error(
+        'Oracle access from the root of a TXe test are not enabled. Please use env._ to interact with the oracles.',
+      );
+    }
+
+    const log = await this.typedOracle.getPrivateLogByTag(fromSingle(siloedTag));
+    if (log == null) {
+      return toForeignCallResult([
+        toSingle(Fr.ZERO),
+        ...PrivateLogWithTxData.noirSerializationOfEmpty().map(toSingleOrArray),
       ]);
     } else {
       return toForeignCallResult([toSingle(Fr.ONE), ...log.toNoirSerialization().map(toSingleOrArray)]);


### PR DESCRIPTION
Fixes #14362

Implements partial note completion in private. This PR is quite big but I decided to just keep it like that because:
1. we currently don't have a way to unit test oracles,
2. testing partial notes flows in TXE test [doesn't really work.](https://github.com/AztecProtocol/aztec-packages/issues/10289).

This prevented me from implementing the oracles, the partial note completion and Orderbook changes in 3 PRs as I needed them in one to verify it works.

## ~Update~
~Mr. Nico said this is too ugly (😭) and that I should do https://github.com/AztecProtocol/aztec-packages/issues/10273 first~

The above is addressed now.