### PR TITLE
chore: Remove `HasPlookup` from `bigfield` and `biggroup` classes

### DIFF
--- a/avm-transpiler/Cargo.lock
+++ b/avm-transpiler/Cargo.lock
@@ -4,7 +4,7 @@ version = 4
 
 [[package]]
 name = "acir"
-version = "1.0.0-beta.6"
+version = "1.0.0-beta.4"
 dependencies = [
  "acir_field",
  "base64 0.21.7",
@@ -13,7 +13,6 @@ dependencies = [
  "color-eyre",
  "flate2",
  "noir_protobuf",
- "num_enum",
  "prost",
  "prost-build",
  "protoc-prebuilt",
@@ -27,7 +26,7 @@ dependencies = [
 
 [[package]]
 name = "acir_field"
-version = "1.0.0-beta.6"
+version = "1.0.0-beta.4"
 dependencies = [
  "ark-bn254",
  "ark-ff",
@@ -40,7 +39,7 @@ dependencies = [
 
 [[package]]
 name = "acvm"
-version = "1.0.0-beta.6"
+version = "1.0.0-beta.4"
 dependencies = [
  "acir",
  "acvm_blackbox_solver",
@@ -54,7 +53,7 @@ dependencies = [
 
 [[package]]
 name = "acvm_blackbox_solver"
-version = "1.0.0-beta.6"
+version = "1.0.0-beta.4"
 dependencies = [
  "acir",
  "blake2",
@@ -454,7 +453,7 @@ dependencies = [
 
 [[package]]
 name = "bn254_blackbox_solver"
-version = "1.0.0-beta.6"
+version = "1.0.0-beta.4"
 dependencies = [
  "acir",
  "acvm_blackbox_solver",
@@ -478,7 +477,7 @@ dependencies = [
 
 [[package]]
 name = "brillig"
-version = "1.0.0-beta.6"
+version = "1.0.0-beta.4"
 dependencies = [
  "acir_field",
  "serde",
@@ -486,7 +485,7 @@ dependencies = [
 
 [[package]]
 name = "brillig_vm"
-version = "1.0.0-beta.6"
+version = "1.0.0-beta.4"
 dependencies = [
  "acir",
  "acvm_blackbox_solver",
@@ -926,7 +925,7 @@ dependencies = [
 
 [[package]]
 name = "fm"
-version = "1.0.0-beta.6"
+version = "1.0.0-beta.4"
 dependencies = [
  "codespan-reporting",
  "iter-extended",
@@ -1266,7 +1265,7 @@ checksum = "f8478577c03552c21db0e2724ffb8986a5ce7af88107e6be5d2ee6e158c12800"
 
 [[package]]
 name = "iter-extended"
-version = "1.0.0-beta.6"
+version = "1.0.0-beta.4"
 
 [[package]]
 name = "itertools"
@@ -1374,7 +1373,7 @@ checksum = "defc4c55412d89136f966bbb339008b474350e5e6e78d2714439c386b3137a03"
 
 [[package]]
 name = "noir_protobuf"
-version = "1.0.0-beta.6"
+version = "1.0.0-beta.4"
 dependencies = [
  "color-eyre",
  "prost",
@@ -1382,7 +1381,7 @@ dependencies = [
 
 [[package]]
 name = "noirc_abi"
-version = "1.0.0-beta.6"
+version = "1.0.0-beta.4"
 dependencies = [
  "acvm",
  "iter-extended",
@@ -1397,11 +1396,11 @@ dependencies = [
 
 [[package]]
 name = "noirc_arena"
-version = "1.0.0-beta.6"
+version = "1.0.0-beta.4"
 
 [[package]]
 name = "noirc_errors"
-version = "1.0.0-beta.6"
+version = "1.0.0-beta.4"
 dependencies = [
  "acvm",
  "base64 0.21.7",
@@ -1418,7 +1417,7 @@ dependencies = [
 
 [[package]]
 name = "noirc_evaluator"
-version = "1.0.0-beta.6"
+version = "1.0.0-beta.4"
 dependencies = [
  "acvm",
  "bn254_blackbox_solver",
@@ -1429,7 +1428,6 @@ dependencies = [
  "iter-extended",
  "noirc_errors",
  "noirc_frontend",
- "noirc_printable_type",
  "num-bigint",
  "num-integer",
  "num-traits",
@@ -1446,7 +1444,7 @@ dependencies = [
 
 [[package]]
 name = "noirc_frontend"
-version = "1.0.0-beta.6"
+version = "1.0.0-beta.4"
 dependencies = [
  "acvm",
  "bn254_blackbox_solver",
@@ -1475,12 +1473,10 @@ dependencies = [
 
 [[package]]
 name = "noirc_printable_type"
-version = "1.0.0-beta.6"
+version = "1.0.0-beta.4"
 dependencies = [
  "acvm",
- "iter-extended",
  "serde",
- "serde_json",
 ]
 
 [[package]]
@@ -1515,27 +1511,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "071dfc062690e90b734c0b2273ce72ad0ffa95f0c74596bc250dcfd960262841"
 dependencies = [
  "autocfg",
-]
-
-[[package]]
-name = "num_enum"
-version = "0.7.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4e613fc340b2220f734a8595782c551f1250e969d87d3be1ae0579e8d4065179"
-dependencies = [
- "num_enum_derive",
-]
-
-[[package]]
-name = "num_enum_derive"
-version = "0.7.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "af1844ef2428cc3e1cb900be36181049ef3d3193c63e43026cfe202983b27a56"
-dependencies = [
- "proc-macro-crate",
- "proc-macro2",
- "quote",
- "syn 2.0.87",
 ]
 
 [[package]]
@@ -1657,15 +1632,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "353e1ca18966c16d9deb1c69278edbc5f194139612772bd9537af60ac231e1e6"
 dependencies = [
  "elliptic-curve",
-]
-
-[[package]]
-name = "proc-macro-crate"
-version = "3.3.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "edce586971a4dfaa28950c6f18ed55e0406c1ab88bbce2c6f6293a7aaba73d35"
-dependencies = [
- "toml_edit 0.22.24",
 ]
 
 [[package]]
@@ -2311,7 +2277,7 @@ dependencies = [
  "serde",
  "serde_spanned",
  "toml_datetime",
- "toml_edit 0.19.15",
+ "toml_edit",
 ]
 
 [[package]]
@@ -2333,18 +2299,7 @@ dependencies = [
  "serde",
  "serde_spanned",
  "toml_datetime",
- "winnow 0.5.40",
-]
-
-[[package]]
-name = "toml_edit"
-version = "0.22.24"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "17b4795ff5edd201c7cd6dca065ae59972ce77d1b80fa0a84d94950ece7d1474"
-dependencies = [
- "indexmap 2.8.0",
- "toml_datetime",
- "winnow 0.7.10",
+ "winnow",
 ]
 
 [[package]]
@@ -2669,15 +2624,6 @@ name = "winnow"
 version = "0.5.40"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f593a95398737aeed53e489c785df13f3618e41dbcd6718c6addbf1395aa6876"
-dependencies = [
- "memchr",
-]
-
-[[package]]
-name = "winnow"
-version = "0.7.10"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c06928c8748d81b05c9be96aad92e1b6ff01833332f281e8cfca3be4b35fc9ec"
 dependencies = [
  "memchr",
 ]

--- a/avm-transpiler/Cargo.lock
+++ b/avm-transpiler/Cargo.lock
@@ -4,7 +4,7 @@ version = 4
 
 [[package]]
 name = "acir"
-version = "1.0.0-beta.4"
+version = "1.0.0-beta.6"
 dependencies = [
  "acir_field",
  "base64 0.21.7",
@@ -13,6 +13,7 @@ dependencies = [
  "color-eyre",
  "flate2",
  "noir_protobuf",
+ "num_enum",
  "prost",
  "prost-build",
  "protoc-prebuilt",
@@ -26,7 +27,7 @@ dependencies = [
 
 [[package]]
 name = "acir_field"
-version = "1.0.0-beta.4"
+version = "1.0.0-beta.6"
 dependencies = [
  "ark-bn254",
  "ark-ff",
@@ -39,7 +40,7 @@ dependencies = [
 
 [[package]]
 name = "acvm"
-version = "1.0.0-beta.4"
+version = "1.0.0-beta.6"
 dependencies = [
  "acir",
  "acvm_blackbox_solver",
@@ -53,7 +54,7 @@ dependencies = [
 
 [[package]]
 name = "acvm_blackbox_solver"
-version = "1.0.0-beta.4"
+version = "1.0.0-beta.6"
 dependencies = [
  "acir",
  "blake2",
@@ -453,7 +454,7 @@ dependencies = [
 
 [[package]]
 name = "bn254_blackbox_solver"
-version = "1.0.0-beta.4"
+version = "1.0.0-beta.6"
 dependencies = [
  "acir",
  "acvm_blackbox_solver",
@@ -477,7 +478,7 @@ dependencies = [
 
 [[package]]
 name = "brillig"
-version = "1.0.0-beta.4"
+version = "1.0.0-beta.6"
 dependencies = [
  "acir_field",
  "serde",
@@ -485,7 +486,7 @@ dependencies = [
 
 [[package]]
 name = "brillig_vm"
-version = "1.0.0-beta.4"
+version = "1.0.0-beta.6"
 dependencies = [
  "acir",
  "acvm_blackbox_solver",
@@ -925,7 +926,7 @@ dependencies = [
 
 [[package]]
 name = "fm"
-version = "1.0.0-beta.4"
+version = "1.0.0-beta.6"
 dependencies = [
  "codespan-reporting",
  "iter-extended",
@@ -1265,7 +1266,7 @@ checksum = "f8478577c03552c21db0e2724ffb8986a5ce7af88107e6be5d2ee6e158c12800"
 
 [[package]]
 name = "iter-extended"
-version = "1.0.0-beta.4"
+version = "1.0.0-beta.6"
 
 [[package]]
 name = "itertools"
@@ -1373,7 +1374,7 @@ checksum = "defc4c55412d89136f966bbb339008b474350e5e6e78d2714439c386b3137a03"
 
 [[package]]
 name = "noir_protobuf"
-version = "1.0.0-beta.4"
+version = "1.0.0-beta.6"
 dependencies = [
  "color-eyre",
  "prost",
@@ -1381,7 +1382,7 @@ dependencies = [
 
 [[package]]
 name = "noirc_abi"
-version = "1.0.0-beta.4"
+version = "1.0.0-beta.6"
 dependencies = [
  "acvm",
  "iter-extended",
@@ -1396,11 +1397,11 @@ dependencies = [
 
 [[package]]
 name = "noirc_arena"
-version = "1.0.0-beta.4"
+version = "1.0.0-beta.6"
 
 [[package]]
 name = "noirc_errors"
-version = "1.0.0-beta.4"
+version = "1.0.0-beta.6"
 dependencies = [
  "acvm",
  "base64 0.21.7",
@@ -1417,7 +1418,7 @@ dependencies = [
 
 [[package]]
 name = "noirc_evaluator"
-version = "1.0.0-beta.4"
+version = "1.0.0-beta.6"
 dependencies = [
  "acvm",
  "bn254_blackbox_solver",
@@ -1428,6 +1429,7 @@ dependencies = [
  "iter-extended",
  "noirc_errors",
  "noirc_frontend",
+ "noirc_printable_type",
  "num-bigint",
  "num-integer",
  "num-traits",
@@ -1444,7 +1446,7 @@ dependencies = [
 
 [[package]]
 name = "noirc_frontend"
-version = "1.0.0-beta.4"
+version = "1.0.0-beta.6"
 dependencies = [
  "acvm",
  "bn254_blackbox_solver",
@@ -1473,10 +1475,12 @@ dependencies = [
 
 [[package]]
 name = "noirc_printable_type"
-version = "1.0.0-beta.4"
+version = "1.0.0-beta.6"
 dependencies = [
  "acvm",
+ "iter-extended",
  "serde",
+ "serde_json",
 ]
 
 [[package]]
@@ -1511,6 +1515,27 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "071dfc062690e90b734c0b2273ce72ad0ffa95f0c74596bc250dcfd960262841"
 dependencies = [
  "autocfg",
+]
+
+[[package]]
+name = "num_enum"
+version = "0.7.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4e613fc340b2220f734a8595782c551f1250e969d87d3be1ae0579e8d4065179"
+dependencies = [
+ "num_enum_derive",
+]
+
+[[package]]
+name = "num_enum_derive"
+version = "0.7.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "af1844ef2428cc3e1cb900be36181049ef3d3193c63e43026cfe202983b27a56"
+dependencies = [
+ "proc-macro-crate",
+ "proc-macro2",
+ "quote",
+ "syn 2.0.87",
 ]
 
 [[package]]
@@ -1632,6 +1657,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "353e1ca18966c16d9deb1c69278edbc5f194139612772bd9537af60ac231e1e6"
 dependencies = [
  "elliptic-curve",
+]
+
+[[package]]
+name = "proc-macro-crate"
+version = "3.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "edce586971a4dfaa28950c6f18ed55e0406c1ab88bbce2c6f6293a7aaba73d35"
+dependencies = [
+ "toml_edit 0.22.24",
 ]
 
 [[package]]
@@ -2277,7 +2311,7 @@ dependencies = [
  "serde",
  "serde_spanned",
  "toml_datetime",
- "toml_edit",
+ "toml_edit 0.19.15",
 ]
 
 [[package]]
@@ -2299,7 +2333,18 @@ dependencies = [
  "serde",
  "serde_spanned",
  "toml_datetime",
- "winnow",
+ "winnow 0.5.40",
+]
+
+[[package]]
+name = "toml_edit"
+version = "0.22.24"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "17b4795ff5edd201c7cd6dca065ae59972ce77d1b80fa0a84d94950ece7d1474"
+dependencies = [
+ "indexmap 2.8.0",
+ "toml_datetime",
+ "winnow 0.7.10",
 ]
 
 [[package]]
@@ -2624,6 +2669,15 @@ name = "winnow"
 version = "0.5.40"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f593a95398737aeed53e489c785df13f3618e41dbcd6718c6addbf1395aa6876"
+dependencies = [
+ "memchr",
+]
+
+[[package]]
+name = "winnow"
+version = "0.7.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c06928c8748d81b05c9be96aad92e1b6ff01833332f281e8cfca3be4b35fc9ec"
 dependencies = [
  "memchr",
 ]

--- a/barretenberg/cpp/src/barretenberg/stdlib/encryption/ecdsa/ecdsa_impl.hpp
+++ b/barretenberg/cpp/src/barretenberg/stdlib/encryption/ecdsa/ecdsa_impl.hpp
@@ -99,7 +99,7 @@ bool_t<Builder> ecdsa_verify_signature(const stdlib::byte_array<Builder>& messag
     // TODO(Cody): Having Plookup should not determine which curve is used.
     // Use special plookup secp256k1 ECDSA mul if available (this relies on k1 endomorphism, and cannot be used for
     // other curves)
-    if constexpr (HasPlookup<Builder> && Curve::type == bb::CurveType::SECP256K1) {
+    if constexpr (Curve::type == bb::CurveType::SECP256K1) {
         result = G1::secp256k1_ecdsa_mul(public_key, u1, u2);
     } else {
         result = G1::batch_mul({ G1::one(ctx), public_key }, { u1, u2 });

--- a/barretenberg/cpp/src/barretenberg/stdlib/encryption/ecdsa/ecdsa_impl.hpp
+++ b/barretenberg/cpp/src/barretenberg/stdlib/encryption/ecdsa/ecdsa_impl.hpp
@@ -174,7 +174,7 @@ bool_t<Builder> ecdsa_verify_signature_prehashed_message_noassert(const stdlib::
     G1 result;
     // Use special plookup secp256k1 ECDSA mul if available (this relies on k1 endomorphism, and cannot be used for
     // other curves)
-    if constexpr (HasPlookup<Builder> && Curve::type == bb::CurveType::SECP256K1) {
+    if constexpr (Curve::type == bb::CurveType::SECP256K1) {
         result = G1::secp256k1_ecdsa_mul(public_key, u1, u2);
     } else {
         result = G1::batch_mul({ G1::one(ctx), public_key }, { u1, u2 });

--- a/barretenberg/cpp/src/barretenberg/stdlib/primitives/bigfield/bigfield.hpp
+++ b/barretenberg/cpp/src/barretenberg/stdlib/primitives/bigfield/bigfield.hpp
@@ -527,11 +527,27 @@ template <typename Builder, typename T> class bigfield {
     static constexpr uint512_t get_maximum_unreduced_value()
     {
         // This = `T * n = 2^272 * |BN(Fr)|` So this equals n*2^t
-
         uint1024_t maximum_product = uint1024_t(binary_basis.modulus) * uint1024_t(prime_basis.modulus);
-        // TODO: compute square root (the following is a lower bound, so good for the CRT use)
-        // We use -1 to stay safer, because it provides additional space to avoid the overflow, but get_msb() by itself
-        // should be enough
+
+        // In multiplying two bigfield elements a and b, we must check that:
+        //
+        // a * b = q * p + r
+        //
+        // where p is the quotient, r is the remainder, and p is the size of the non-native field.
+        // The CRT requires that we check that each side of the equation is less than:
+        // (a) the size of the native field n, and
+        // (b) the max product M = 2^t * n.
+        // Thus, the max value of an unreduced value of a bigfield element is √M. In this case, we use
+        // an even stricter bound. Let n = 2^m + l (where 1 < l < 2^m). Thus, we have:
+        //
+        //     M = 2^t * n = 2^t * (2^m + l) = 2^(t + m) + (2^t * l)
+        // =>  M > 2^(t + m)
+        // => √M > 2^((t + m) / 2)
+        //
+        // Thus the maximum unreduced value of a bigfield element is: 2^((t + m) / 2).
+        //
+        // Note: We use a further safer bound of 2^((t + m) / 2 - 1). We use -1 to stay safer,
+        // because it provides additional space to avoid the overflow, but get_msb() by itself should be enough.
         uint64_t maximum_product_bits = maximum_product.get_msb() - 1;
         return (uint512_t(1) << (maximum_product_bits >> 1));
     }

--- a/barretenberg/cpp/src/barretenberg/stdlib/primitives/bigfield/bigfield.hpp
+++ b/barretenberg/cpp/src/barretenberg/stdlib/primitives/bigfield/bigfield.hpp
@@ -534,19 +534,20 @@ template <typename Builder, typename T> class bigfield {
         // a * b = q * p + r
         //
         // where p is the quotient, r is the remainder, and p is the size of the non-native field.
-        // The CRT requires that we check that each side of the equation is less than:
-        // (a) the size of the native field n, and
-        // (b) the max product M = 2^t * n.
-        // Thus, the max value of an unreduced value of a bigfield element is √M. In this case, we use
+        // The CRT requires that we check that the equation:
+        // (a) holds modulo the size of the native field n,
+        // (b) holds modulo the size of the bigger ring 2^t,
+        // (c) both sides of the equation are less than the max product M = 2^t * n.
+        // Thus, the max value of an unreduced bigfield element is √M. In this case, we use
         // an even stricter bound. Let n = 2^m + l (where 1 < l < 2^m). Thus, we have:
         //
         //     M = 2^t * n = 2^t * (2^m + l) = 2^(t + m) + (2^t * l)
         // =>  M > 2^(t + m)
         // => √M > 2^((t + m) / 2)
         //
-        // Thus the maximum unreduced value of a bigfield element is: 2^((t + m) / 2).
+        // We set the maximum unreduced value of a bigfield element to be: 2^((t + m) / 2) < √M.
         //
-        // Note: We use a further safer bound of 2^((t + m) / 2 - 1). We use -1 to stay safer,
+        // Note: We use a further safer bound of 2^((t + m - 1) / 2). We use -1 to stay safer,
         // because it provides additional space to avoid the overflow, but get_msb() by itself should be enough.
         uint64_t maximum_product_bits = maximum_product.get_msb() - 1;
         return (uint512_t(1) << (maximum_product_bits >> 1));
@@ -557,7 +558,6 @@ template <typename Builder, typename T> class bigfield {
     {
         uint1024_t maximum_product = uint1024_t(binary_basis.modulus) * uint1024_t(prime_basis.modulus);
         uint64_t maximum_product_bits = maximum_product.get_msb() - 1;
-        // TODO(suyash): is this related anyway to prohibited limb size?
         const size_t arbitrary_secure_margin = 20;
         return (uint512_t(1) << ((maximum_product_bits >> 1) + arbitrary_secure_margin)) - uint512_t(1);
     }

--- a/barretenberg/cpp/src/barretenberg/stdlib/primitives/bigfield/bigfield.hpp
+++ b/barretenberg/cpp/src/barretenberg/stdlib/primitives/bigfield/bigfield.hpp
@@ -159,23 +159,20 @@ template <typename Builder, typename T> class bigfield {
                                       .add_two(result.binary_basis_limbs[2].element * shift_2,
                                                result.binary_basis_limbs[1].element * shift_1);
         result.prime_basis_limb += (result.binary_basis_limbs[0].element);
-        const size_t num_last_limb_bits = (can_overflow) ? NUM_LIMB_BITS : static_cast<size_t>(NUM_LAST_LIMB_BITS);
-        if constexpr (HasPlookup<Builder>) {
-            ctx->range_constrain_two_limbs(result.binary_basis_limbs[0].element.get_normalized_witness_index(),
-                                           result.binary_basis_limbs[1].element.get_normalized_witness_index(),
-                                           static_cast<size_t>(NUM_LIMB_BITS),
-                                           static_cast<size_t>(NUM_LIMB_BITS));
-            ctx->range_constrain_two_limbs(result.binary_basis_limbs[2].element.get_normalized_witness_index(),
-                                           result.binary_basis_limbs[3].element.get_normalized_witness_index(),
-                                           static_cast<size_t>(NUM_LIMB_BITS),
-                                           static_cast<size_t>(num_last_limb_bits));
 
-        } else {
-            a.create_range_constraint(NUM_LIMB_BITS);
-            b.create_range_constraint(NUM_LIMB_BITS);
-            c.create_range_constraint(NUM_LIMB_BITS);
-            d.create_range_constraint(num_last_limb_bits);
-        }
+        // Range contrain the first two limbs each to NUM_LIMB_BITS
+        ctx->range_constrain_two_limbs(result.binary_basis_limbs[0].element.get_normalized_witness_index(),
+                                       result.binary_basis_limbs[1].element.get_normalized_witness_index(),
+                                       static_cast<size_t>(NUM_LIMB_BITS),
+                                       static_cast<size_t>(NUM_LIMB_BITS));
+
+        // Range constrain the last two limbs to NUM_LIMB_BITS and NUM_LAST_LIMB_BITS
+        const size_t num_last_limb_bits = (can_overflow) ? NUM_LIMB_BITS : NUM_LAST_LIMB_BITS;
+        ctx->range_constrain_two_limbs(result.binary_basis_limbs[2].element.get_normalized_witness_index(),
+                                       result.binary_basis_limbs[3].element.get_normalized_witness_index(),
+                                       static_cast<size_t>(NUM_LIMB_BITS),
+                                       static_cast<size_t>(num_last_limb_bits));
+
         return result;
     };
     /**

--- a/barretenberg/cpp/src/barretenberg/stdlib/primitives/bigfield/bigfield.hpp
+++ b/barretenberg/cpp/src/barretenberg/stdlib/primitives/bigfield/bigfield.hpp
@@ -541,6 +541,7 @@ template <typename Builder, typename T> class bigfield {
     {
         uint1024_t maximum_product = uint1024_t(binary_basis.modulus) * uint1024_t(prime_basis.modulus);
         uint64_t maximum_product_bits = maximum_product.get_msb() - 1;
+        // TODO(suyash): is this related anyway to prohibited limb size?
         const size_t arbitrary_secure_margin = 20;
         return (uint512_t(1) << ((maximum_product_bits >> 1) + arbitrary_secure_margin)) - uint512_t(1);
     }

--- a/barretenberg/cpp/src/barretenberg/stdlib/primitives/bigfield/bigfield_impl.hpp
+++ b/barretenberg/cpp/src/barretenberg/stdlib/primitives/bigfield/bigfield_impl.hpp
@@ -61,37 +61,12 @@ bigfield<Builder, T>::bigfield(const field_t<Builder>& low_bits_in,
     field_t<Builder> limb_2(context);
     field_t<Builder> limb_3(context);
     if (!low_bits_in.is_constant()) {
-        std::vector<uint32_t> low_accumulator;
-        if constexpr (HasPlookup<Builder>) {
-            // MERGE NOTE: this was the if constexpr block introduced in ecebe7643
-            const auto limb_witnesses =
-                context->decompose_non_native_field_double_width_limb(low_bits_in.get_normalized_witness_index());
-            limb_0.witness_index = limb_witnesses[0];
-            limb_1.witness_index = limb_witnesses[1];
-            field_t<Builder>::evaluate_linear_identity(low_bits_in, -limb_0, -limb_1 * shift_1, field_t<Builder>(0));
-
-            // // Enforce that low_bits_in indeed only contains 2*NUM_LIMB_BITS bits
-            // low_accumulator = context->decompose_into_default_range(low_bits_in.witness_index,
-            //                                                         static_cast<size_t>(NUM_LIMB_BITS * 2));
-            // // If this doesn't hold we're using a default plookup range size that doesn't work well with the limb
-            // size
-            // // here
-            // ASSERT(low_accumulator.size() % 2 == 0);
-            // size_t mid_index = low_accumulator.size() / 2 - 1;
-            // limb_0.witness_index = low_accumulator[mid_index]; // Q:safer to just slice this from low_bits_in?
-            // limb_1 = (low_bits_in - limb_0) * shift_right_1;
-        } else {
-            size_t mid_index;
-            low_accumulator = context->decompose_into_base4_accumulators(low_bits_in.get_normalized_witness_index(),
-                                                                         static_cast<size_t>(NUM_LIMB_BITS * 2),
-                                                                         "bigfield: low_bits_in too large.");
-            mid_index = static_cast<size_t>((NUM_LIMB_BITS / 2) - 1);
-            // Range constraint returns an array of partial sums, midpoint will happen to hold the big limb
-            // value
-            limb_1.witness_index = low_accumulator[mid_index];
-            // We can get the first half bits of low_bits_in from the variables we already created
-            limb_0 = (low_bits_in - (limb_1 * shift_1));
-        }
+        // Decompose the low bits into 2 limbs and range constrain them.
+        const auto limb_witnesses =
+            context->decompose_non_native_field_double_width_limb(low_bits_in.get_normalized_witness_index());
+        limb_0.witness_index = limb_witnesses[0];
+        limb_1.witness_index = limb_witnesses[1];
+        field_t<Builder>::evaluate_linear_identity(low_bits_in, -limb_0, -limb_1 * shift_1, field_t<Builder>(0));
     } else {
         uint256_t slice_0 = uint256_t(low_bits_in.additive_constant).slice(0, NUM_LIMB_BITS);
         uint256_t slice_1 = uint256_t(low_bits_in.additive_constant).slice(NUM_LIMB_BITS, 2 * NUM_LIMB_BITS);
@@ -112,23 +87,12 @@ bigfield<Builder, T>::bigfield(const field_t<Builder>& low_bits_in,
     // We create the high limb values similar to the low limb ones above
     const uint64_t num_high_limb_bits = NUM_LIMB_BITS + num_last_limb_bits;
     if (!high_bits_in.is_constant()) {
-
-        std::vector<uint32_t> high_accumulator;
-        if constexpr (HasPlookup<Builder>) {
-            const auto limb_witnesses = context->decompose_non_native_field_double_width_limb(
-                high_bits_in.get_normalized_witness_index(), (size_t)num_high_limb_bits);
-            limb_2.witness_index = limb_witnesses[0];
-            limb_3.witness_index = limb_witnesses[1];
-            field_t<Builder>::evaluate_linear_identity(high_bits_in, -limb_2, -limb_3 * shift_1, field_t<Builder>(0));
-
-        } else {
-            high_accumulator = context->decompose_into_base4_accumulators(high_bits_in.get_normalized_witness_index(),
-                                                                          static_cast<size_t>(num_high_limb_bits),
-                                                                          "bigfield: high_bits_in too large.");
-
-            limb_3.witness_index = high_accumulator[static_cast<size_t>(((num_last_limb_bits + 1) / 2) - 1)];
-            limb_2 = (high_bits_in - (limb_3 * shift_1));
-        }
+        // Decompose the high bits into 2 limbs and range constrain them.
+        const auto limb_witnesses = context->decompose_non_native_field_double_width_limb(
+            high_bits_in.get_normalized_witness_index(), (size_t)num_high_limb_bits);
+        limb_2.witness_index = limb_witnesses[0];
+        limb_3.witness_index = limb_witnesses[1];
+        field_t<Builder>::evaluate_linear_identity(high_bits_in, -limb_2, -limb_3 * shift_1, field_t<Builder>(0));
     } else {
         uint256_t slice_2 = uint256_t(high_bits_in.additive_constant).slice(0, NUM_LIMB_BITS);
         uint256_t slice_3 = uint256_t(high_bits_in.additive_constant).slice(NUM_LIMB_BITS, num_high_limb_bits);
@@ -197,72 +161,63 @@ bigfield<Builder, T> bigfield<Builder, T>::create_from_u512_as_witness(Builder* 
     limbs[2] = value.slice(NUM_LIMB_BITS * 2, NUM_LIMB_BITS * 3).lo;
     limbs[3] = value.slice(NUM_LIMB_BITS * 3, NUM_LIMB_BITS * 4).lo;
 
-    if constexpr (HasPlookup<Builder>) {
-        field_t<Builder> limb_0(ctx);
-        field_t<Builder> limb_1(ctx);
-        field_t<Builder> limb_2(ctx);
-        field_t<Builder> limb_3(ctx);
-        field_t<Builder> prime_limb(ctx);
-        limb_0.witness_index = ctx->add_variable(bb::fr(limbs[0]));
-        limb_1.witness_index = ctx->add_variable(bb::fr(limbs[1]));
-        limb_2.witness_index = ctx->add_variable(bb::fr(limbs[2]));
-        limb_3.witness_index = ctx->add_variable(bb::fr(limbs[3]));
-        prime_limb.witness_index = ctx->add_variable(limb_0.get_value() + limb_1.get_value() * shift_1 +
-                                                     limb_2.get_value() * shift_2 + limb_3.get_value() * shift_3);
-        // evaluate prime basis limb with addition gate that taps into the 4th wire in the next gate
-        ctx->create_big_add_gate({ limb_1.get_normalized_witness_index(),
-                                   limb_2.get_normalized_witness_index(),
-                                   limb_3.get_normalized_witness_index(),
-                                   prime_limb.get_normalized_witness_index(),
-                                   shift_1,
-                                   shift_2,
-                                   shift_3,
-                                   -1,
-                                   0 },
-                                 true);
-        // TODO(https://github.com/AztecProtocol/barretenberg/issues/879): dummy necessary for preceeding big add
-        // gate
-        ctx->create_dummy_gate(
-            ctx->blocks.arithmetic, ctx->zero_idx, ctx->zero_idx, ctx->zero_idx, limb_0.get_normalized_witness_index());
+    field_t<Builder> limb_0(ctx);
+    field_t<Builder> limb_1(ctx);
+    field_t<Builder> limb_2(ctx);
+    field_t<Builder> limb_3(ctx);
+    field_t<Builder> prime_limb(ctx);
+    limb_0.witness_index = ctx->add_variable(bb::fr(limbs[0]));
+    limb_1.witness_index = ctx->add_variable(bb::fr(limbs[1]));
+    limb_2.witness_index = ctx->add_variable(bb::fr(limbs[2]));
+    limb_3.witness_index = ctx->add_variable(bb::fr(limbs[3]));
+    prime_limb.witness_index = ctx->add_variable(limb_0.get_value() + limb_1.get_value() * shift_1 +
+                                                 limb_2.get_value() * shift_2 + limb_3.get_value() * shift_3);
+    // evaluate prime basis limb with addition gate that taps into the 4th wire in the next gate
+    ctx->create_big_add_gate({ limb_1.get_normalized_witness_index(),
+                               limb_2.get_normalized_witness_index(),
+                               limb_3.get_normalized_witness_index(),
+                               prime_limb.get_normalized_witness_index(),
+                               shift_1,
+                               shift_2,
+                               shift_3,
+                               -1,
+                               0 },
+                             true);
+    // TODO(https://github.com/AztecProtocol/barretenberg/issues/879): dummy necessary for preceeding big add
+    // gate
+    ctx->create_dummy_gate(
+        ctx->blocks.arithmetic, ctx->zero_idx, ctx->zero_idx, ctx->zero_idx, limb_0.get_normalized_witness_index());
 
-        uint64_t num_last_limb_bits = (can_overflow) ? NUM_LIMB_BITS : NUM_LAST_LIMB_BITS;
+    uint64_t num_last_limb_bits = (can_overflow) ? NUM_LIMB_BITS : NUM_LAST_LIMB_BITS;
 
-        bigfield result(ctx);
-        result.binary_basis_limbs[0] = Limb(limb_0, DEFAULT_MAXIMUM_LIMB);
-        result.binary_basis_limbs[1] = Limb(limb_1, DEFAULT_MAXIMUM_LIMB);
-        result.binary_basis_limbs[2] = Limb(limb_2, DEFAULT_MAXIMUM_LIMB);
-        result.binary_basis_limbs[3] =
-            Limb(limb_3, can_overflow ? DEFAULT_MAXIMUM_LIMB : DEFAULT_MAXIMUM_MOST_SIGNIFICANT_LIMB);
+    bigfield result(ctx);
+    result.binary_basis_limbs[0] = Limb(limb_0, DEFAULT_MAXIMUM_LIMB);
+    result.binary_basis_limbs[1] = Limb(limb_1, DEFAULT_MAXIMUM_LIMB);
+    result.binary_basis_limbs[2] = Limb(limb_2, DEFAULT_MAXIMUM_LIMB);
+    result.binary_basis_limbs[3] =
+        Limb(limb_3, can_overflow ? DEFAULT_MAXIMUM_LIMB : DEFAULT_MAXIMUM_MOST_SIGNIFICANT_LIMB);
 
-        // if maximum_bitlength is set, this supercedes can_overflow
-        if (maximum_bitlength > 0) {
-            ASSERT(maximum_bitlength > 3 * NUM_LIMB_BITS);
-            num_last_limb_bits = maximum_bitlength - (3 * NUM_LIMB_BITS);
-            uint256_t max_limb_value = (uint256_t(1) << num_last_limb_bits) - 1;
-            result.binary_basis_limbs[3].maximum_value = max_limb_value;
-        }
-        result.prime_basis_limb = prime_limb;
-        ctx->range_constrain_two_limbs(limb_0.get_normalized_witness_index(),
-                                       limb_1.get_normalized_witness_index(),
-                                       (size_t)NUM_LIMB_BITS,
-                                       (size_t)NUM_LIMB_BITS);
-        ctx->range_constrain_two_limbs(limb_2.get_normalized_witness_index(),
-                                       limb_3.get_normalized_witness_index(),
-                                       (size_t)NUM_LIMB_BITS,
-                                       (size_t)num_last_limb_bits);
-
-        // Mark the element as coming out of nowhere
-        result.set_free_witness_tag();
-        return result;
-    } else {
-        auto result = bigfield(witness_t(ctx, fr(limbs[0] + limbs[1] * shift_1)),
-                               witness_t(ctx, fr(limbs[2] + limbs[3] * shift_1)),
-                               can_overflow,
-                               maximum_bitlength);
-        // Mark the element as coming out of nowhere
-        result.set_free_witness_tag();
-        return result;
+    // if maximum_bitlength is set, this supercedes can_overflow
+    if (maximum_bitlength > 0) {
+        ASSERT(maximum_bitlength > 3 * NUM_LIMB_BITS);
+        num_last_limb_bits = maximum_bitlength - (3 * NUM_LIMB_BITS);
+        uint256_t max_limb_value = (uint256_t(1) << num_last_limb_bits) - 1;
+        result.binary_basis_limbs[3].maximum_value = max_limb_value;
     }
+    result.prime_basis_limb = prime_limb;
+    ctx->range_constrain_two_limbs(limb_0.get_normalized_witness_index(),
+                                   limb_1.get_normalized_witness_index(),
+                                   (size_t)NUM_LIMB_BITS,
+                                   (size_t)NUM_LIMB_BITS);
+    ctx->range_constrain_two_limbs(limb_2.get_normalized_witness_index(),
+                                   limb_3.get_normalized_witness_index(),
+                                   (size_t)NUM_LIMB_BITS,
+                                   (size_t)num_last_limb_bits);
+
+    // Mark the element as coming out of nowhere
+    result.set_free_witness_tag();
+
+    return result;
 }
 
 template <typename Builder, typename T> bigfield<Builder, T>::bigfield(const byte_array<Builder>& bytes)

--- a/barretenberg/cpp/src/barretenberg/stdlib/primitives/bigfield/bigfield_impl.hpp
+++ b/barretenberg/cpp/src/barretenberg/stdlib/primitives/bigfield/bigfield_impl.hpp
@@ -2071,25 +2071,10 @@ template <typename Builder, typename T> void bigfield<Builder, T>::assert_less_t
     r1 = r1.normalize();
     r2 = r2.normalize();
     r3 = r3.normalize();
-    if constexpr (HasPlookup<Builder>) {
-        context->decompose_into_default_range(r0.get_normalized_witness_index(), static_cast<size_t>(NUM_LIMB_BITS));
-        context->decompose_into_default_range(r1.get_normalized_witness_index(), static_cast<size_t>(NUM_LIMB_BITS));
-        context->decompose_into_default_range(r2.get_normalized_witness_index(), static_cast<size_t>(NUM_LIMB_BITS));
-        context->decompose_into_default_range(r3.get_normalized_witness_index(), static_cast<size_t>(NUM_LIMB_BITS));
-    } else {
-        context->decompose_into_base4_accumulators(r0.get_normalized_witness_index(),
-                                                   static_cast<size_t>(NUM_LIMB_BITS),
-                                                   "bigfield: assert_less_than range constraint 1.");
-        context->decompose_into_base4_accumulators(r1.get_normalized_witness_index(),
-                                                   static_cast<size_t>(NUM_LIMB_BITS),
-                                                   "bigfield: assert_less_than range constraint 2.");
-        context->decompose_into_base4_accumulators(r2.get_normalized_witness_index(),
-                                                   static_cast<size_t>(NUM_LIMB_BITS),
-                                                   "bigfield: assert_less_than range constraint 3.");
-        context->decompose_into_base4_accumulators(r3.get_normalized_witness_index(),
-                                                   static_cast<size_t>(NUM_LIMB_BITS),
-                                                   "bigfield: assert_less_than range constraint 4.");
-    }
+    context->decompose_into_default_range(r0.get_normalized_witness_index(), static_cast<size_t>(NUM_LIMB_BITS));
+    context->decompose_into_default_range(r1.get_normalized_witness_index(), static_cast<size_t>(NUM_LIMB_BITS));
+    context->decompose_into_default_range(r2.get_normalized_witness_index(), static_cast<size_t>(NUM_LIMB_BITS));
+    context->decompose_into_default_range(r3.get_normalized_witness_index(), static_cast<size_t>(NUM_LIMB_BITS));
 }
 
 // check elements are equal mod p by proving their integer difference is a multiple of p.

--- a/barretenberg/cpp/src/barretenberg/stdlib/primitives/bigfield/bigfield_impl.hpp
+++ b/barretenberg/cpp/src/barretenberg/stdlib/primitives/bigfield/bigfield_impl.hpp
@@ -2219,14 +2219,8 @@ template <typename Builder, typename T> void bigfield<Builder, T>::self_reduce()
     ASSERT(maximum_quotient_bits <= NUM_LIMB_BITS);
     uint32_t quotient_limb_index = context->add_variable(bb::fr(quotient_value.lo));
     field_t<Builder> quotient_limb = field_t<Builder>::from_witness_index(context, quotient_limb_index);
-    if constexpr (HasPlookup<Builder>) {
-        context->decompose_into_default_range(quotient_limb.get_normalized_witness_index(),
-                                              static_cast<size_t>(maximum_quotient_bits));
-    } else {
-        context->decompose_into_base4_accumulators(quotient_limb.get_normalized_witness_index(),
-                                                   static_cast<size_t>(maximum_quotient_bits),
-                                                   "bigfield: quotient_limb too large.");
-    }
+    context->decompose_into_default_range(quotient_limb.get_normalized_witness_index(),
+                                          static_cast<size_t>(maximum_quotient_bits));
 
     ASSERT((uint1024_t(1) << maximum_quotient_bits) * uint1024_t(modulus_u512) + DEFAULT_MAXIMUM_REMAINDER <
            get_maximum_crt_product());

--- a/barretenberg/cpp/src/barretenberg/stdlib/primitives/bigfield/bigfield_impl.hpp
+++ b/barretenberg/cpp/src/barretenberg/stdlib/primitives/bigfield/bigfield_impl.hpp
@@ -2867,17 +2867,6 @@ void bigfield<Builder, T>::unsafe_evaluate_multiple_multiply_add(const std::vect
         ctx->decompose_into_default_range(hi.get_normalized_witness_index(), carry_hi_msb);
         ctx->decompose_into_default_range(lo.get_normalized_witness_index(), carry_lo_msb);
     }
-    /*  NOTE TO AUDITOR: An extraneous block
-           if constexpr (HasPlookup<Builder>) {
-               carry_lo = carry_lo.normalize();
-               carry_hi = carry_hi.normalize();
-               ctx->decompose_into_default_range(carry_lo.witness_index, static_cast<size_t>(carry_lo_msb));
-               ctx->decompose_into_default_range(carry_hi.witness_index, static_cast<size_t>(carry_hi_msb));
-           }
-        was removed from the `else` block below. See  the conversation at
-           https://github.com/AztecProtocol/aztec2-internal/pull/1023
-        We should make sure that no constraint like this is needed but missing (e.g., an equivalent constraint
-        was just imposed?). */
 }
 
 template <typename Builder, typename T>

--- a/barretenberg/cpp/src/barretenberg/stdlib/primitives/bigfield/bigfield_impl.hpp
+++ b/barretenberg/cpp/src/barretenberg/stdlib/primitives/bigfield/bigfield_impl.hpp
@@ -2640,7 +2640,7 @@ void bigfield<Builder, T>::unsafe_evaluate_multiple_multiply_add(const std::vect
         ++max_hi_bits;
     }
 
-    // The plookup custom bigfield gate requires inputs are witnesses.
+    // The custom bigfield multiplication gate requires inputs are witnesses.
     // If we're using constant values, instantiate them as circuit variables
     //
     // Explanation:

--- a/barretenberg/cpp/src/barretenberg/stdlib/primitives/bigfield/bigfield_impl.hpp
+++ b/barretenberg/cpp/src/barretenberg/stdlib/primitives/bigfield/bigfield_impl.hpp
@@ -2460,7 +2460,7 @@ void bigfield<Builder, T>::unsafe_evaluate_multiply_add(const bigfield& input_le
         modulus,
     };
 
-    // N.B. this method also evaluates the prime field component of the non-native field mul
+    // N.B. this method DOES NOT evaluate the prime field component of the non-native field mul
     const auto [lo_idx, hi_idx] = ctx->evaluate_non_native_field_multiplication(witnesses);
 
     bb::fr neg_prime = -bb::fr(uint256_t(target_basis.modulus));

--- a/barretenberg/cpp/src/barretenberg/stdlib/primitives/bigfield/bigfield_impl.hpp
+++ b/barretenberg/cpp/src/barretenberg/stdlib/primitives/bigfield/bigfield_impl.hpp
@@ -415,7 +415,6 @@ bigfield<Builder, T> bigfield<Builder, T>::operator+(const bigfield& other) cons
     // gate 3: z.limb_2 = x.limb_2 + y.limb_2
     // gate 4: z.limb_3 = x.limb_3 + y.limb_3
     //
-    // TODO(suyash): does prime_basis_limb need a "normalize" check?
     bool both_witness = !is_constant() && !other.is_constant();
     bool both_prime_limb_multiplicative_constant_one =
         (prime_basis_limb.multiplicative_constant == 1 && other.prime_basis_limb.multiplicative_constant == 1);

--- a/barretenberg/cpp/src/barretenberg/stdlib/primitives/bigfield/bigfield_impl.hpp
+++ b/barretenberg/cpp/src/barretenberg/stdlib/primitives/bigfield/bigfield_impl.hpp
@@ -419,7 +419,6 @@ bigfield<Builder, T> bigfield<Builder, T>::operator+(const bigfield& other) cons
     bool both_prime_limb_multiplicative_constant_one =
         (prime_basis_limb.multiplicative_constant == 1 && other.prime_basis_limb.multiplicative_constant == 1);
     if (both_prime_limb_multiplicative_constant_one && both_witness) {
-        // TODO(suyash): add is_constant check for bigfield instead of checking each limb
         bool limbconst = binary_basis_limbs[0].element.is_constant();
         limbconst = limbconst || binary_basis_limbs[1].element.is_constant();
         limbconst = limbconst || binary_basis_limbs[2].element.is_constant();

--- a/barretenberg/cpp/src/barretenberg/stdlib/primitives/bigfield/bigfield_impl.hpp
+++ b/barretenberg/cpp/src/barretenberg/stdlib/primitives/bigfield/bigfield_impl.hpp
@@ -1756,7 +1756,8 @@ bigfield<Builder, T> bigfield<Builder, T>::conditional_negate(const bool_t<Build
 
     // uint256_t comparison_maximum = uint256_t(modulus_u512.slice(NUM_LIMB_BITS * 3, NUM_LIMB_BITS * 4));
     // uint256_t additive_term = comparison_maximum;
-    // TODO: This is terribly inefficient. We should change it.
+    // TODO(https://github.com/AztecProtocol/aztec-packages/issues/14656): This is terribly inefficient. We should
+    // change it.
     uint512_t constant_to_add = modulus_u512;
     while (constant_to_add.slice(NUM_LIMB_BITS * 3, NUM_LIMB_BITS * 4).lo <= limb_3_maximum_value) {
         constant_to_add += modulus_u512;
@@ -1846,7 +1847,7 @@ bigfield<Builder, T> bigfield<Builder, T>::conditional_select(const bigfield& ot
     }
     Builder* ctx = context ? context : (other.context ? other.context : predicate.context);
 
-    // TODO: use field_t::conditional_assign method
+    // TODO(https://github.com/AztecProtocol/aztec-packages/issues/14657): use field_t::conditional_assign method
     field_t binary_limb_0 = static_cast<field_t<Builder>>(predicate).madd(
         other.binary_basis_limbs[0].element - binary_basis_limbs[0].element, binary_basis_limbs[0].element);
     field_t binary_limb_1 = static_cast<field_t<Builder>>(predicate).madd(
@@ -1953,7 +1954,8 @@ template <typename Builder, typename T> void bigfield<Builder, T>::reduction_che
 {
 
     if (is_constant()) { // this seems not a reduction check, but actually computing the reduction
-                         // TODO THIS IS UGLY WHY CAN'T WE JUST DO (*THIS) = REDUCED?
+                         // TODO(https://github.com/AztecProtocol/aztec-packages/issues/14658) THIS IS UGLY WHY CAN'T WE
+                         // JUST DO (*THIS) = REDUCED?
         uint256_t reduced_value = (get_value() % modulus_u512).lo;
         bigfield reduced(context, uint256_t(reduced_value));
         // Save tags
@@ -2185,7 +2187,8 @@ template <typename Builder, typename T> void bigfield<Builder, T>::self_reduce()
         return;
     }
     OriginTag new_tag = get_origin_tag();
-    // TODO: handle situation where some limbs are constant and others are not constant
+    // TODO(https://github.com/AztecProtocol/aztec-packages/issues/14660): handle situation where some limbs are
+    // constant and others are not constant
     const auto [quotient_value, remainder_value] = get_value().divmod(target_basis.modulus);
 
     bigfield quotient(context);
@@ -2263,7 +2266,8 @@ void bigfield<Builder, T>::unsafe_evaluate_multiply_add(const bigfield& input_le
     bigfield to_mul = input_to_mul;
     bigfield quotient = input_quotient;
 
-    // TODO(suyash): what if left and to_mul both do not have a context?
+    // TODO(https://github.com/AztecProtocol/aztec-packages/issues/14661): what if left and to_mul both do not have a
+    // context?
     Builder* ctx = left.context ? left.context : to_mul.context;
 
     uint512_t max_b0 = (left.binary_basis_limbs[1].maximum_value * to_mul.binary_basis_limbs[0].maximum_value);

--- a/barretenberg/cpp/src/barretenberg/stdlib/primitives/bigfield/bigfield_impl.hpp
+++ b/barretenberg/cpp/src/barretenberg/stdlib/primitives/bigfield/bigfield_impl.hpp
@@ -691,68 +691,65 @@ bigfield<Builder, T> bigfield<Builder, T>::operator-(const bigfield& other) cons
     result.binary_basis_limbs[2].element = binary_basis_limbs[2].element + bb::fr(to_add_2);
     result.binary_basis_limbs[3].element = binary_basis_limbs[3].element + bb::fr(to_add_3);
 
-    if constexpr (HasPlookup<Builder>) {
-        if (prime_basis_limb.multiplicative_constant == 1 && other.prime_basis_limb.multiplicative_constant == 1 &&
-            !is_constant() && !other.is_constant()) {
-            bool limbconst = result.binary_basis_limbs[0].element.is_constant();
-            limbconst = limbconst || result.binary_basis_limbs[1].element.is_constant();
-            limbconst = limbconst || result.binary_basis_limbs[2].element.is_constant();
-            limbconst = limbconst || result.binary_basis_limbs[3].element.is_constant();
-            limbconst = limbconst || prime_basis_limb.is_constant();
-            limbconst = limbconst || other.binary_basis_limbs[0].element.is_constant();
-            limbconst = limbconst || other.binary_basis_limbs[1].element.is_constant();
-            limbconst = limbconst || other.binary_basis_limbs[2].element.is_constant();
-            limbconst = limbconst || other.binary_basis_limbs[3].element.is_constant();
-            limbconst = limbconst || other.prime_basis_limb.is_constant();
-            limbconst =
-                limbconst ||
-                (prime_basis_limb.witness_index ==
-                 other.prime_basis_limb.witness_index); // We are checking if this is and identical element, so we
-                                                        // need to compare the actual indices, not normalized ones
-            if (!limbconst) {
-                std::pair<uint32_t, bb::fr> x0{ result.binary_basis_limbs[0].element.witness_index,
-                                                binary_basis_limbs[0].element.multiplicative_constant };
-                std::pair<uint32_t, bb::fr> x1{ result.binary_basis_limbs[1].element.witness_index,
-                                                binary_basis_limbs[1].element.multiplicative_constant };
-                std::pair<uint32_t, bb::fr> x2{ result.binary_basis_limbs[2].element.witness_index,
-                                                binary_basis_limbs[2].element.multiplicative_constant };
-                std::pair<uint32_t, bb::fr> x3{ result.binary_basis_limbs[3].element.witness_index,
-                                                binary_basis_limbs[3].element.multiplicative_constant };
-                std::pair<uint32_t, bb::fr> y0{ other.binary_basis_limbs[0].element.witness_index,
-                                                other.binary_basis_limbs[0].element.multiplicative_constant };
-                std::pair<uint32_t, bb::fr> y1{ other.binary_basis_limbs[1].element.witness_index,
-                                                other.binary_basis_limbs[1].element.multiplicative_constant };
-                std::pair<uint32_t, bb::fr> y2{ other.binary_basis_limbs[2].element.witness_index,
-                                                other.binary_basis_limbs[2].element.multiplicative_constant };
-                std::pair<uint32_t, bb::fr> y3{ other.binary_basis_limbs[3].element.witness_index,
-                                                other.binary_basis_limbs[3].element.multiplicative_constant };
-                bb::fr c0(result.binary_basis_limbs[0].element.additive_constant -
-                          other.binary_basis_limbs[0].element.additive_constant);
-                bb::fr c1(result.binary_basis_limbs[1].element.additive_constant -
-                          other.binary_basis_limbs[1].element.additive_constant);
-                bb::fr c2(result.binary_basis_limbs[2].element.additive_constant -
-                          other.binary_basis_limbs[2].element.additive_constant);
-                bb::fr c3(result.binary_basis_limbs[3].element.additive_constant -
-                          other.binary_basis_limbs[3].element.additive_constant);
+    if (prime_basis_limb.multiplicative_constant == 1 && other.prime_basis_limb.multiplicative_constant == 1 &&
+        !is_constant() && !other.is_constant()) {
+        bool limbconst = result.binary_basis_limbs[0].element.is_constant();
+        limbconst = limbconst || result.binary_basis_limbs[1].element.is_constant();
+        limbconst = limbconst || result.binary_basis_limbs[2].element.is_constant();
+        limbconst = limbconst || result.binary_basis_limbs[3].element.is_constant();
+        limbconst = limbconst || prime_basis_limb.is_constant();
+        limbconst = limbconst || other.binary_basis_limbs[0].element.is_constant();
+        limbconst = limbconst || other.binary_basis_limbs[1].element.is_constant();
+        limbconst = limbconst || other.binary_basis_limbs[2].element.is_constant();
+        limbconst = limbconst || other.binary_basis_limbs[3].element.is_constant();
+        limbconst = limbconst || other.prime_basis_limb.is_constant();
+        limbconst = limbconst ||
+                    (prime_basis_limb.witness_index ==
+                     other.prime_basis_limb.witness_index); // We are checking if this is and identical element, so we
+                                                            // need to compare the actual indices, not normalized ones
+        if (!limbconst) {
+            std::pair<uint32_t, bb::fr> x0{ result.binary_basis_limbs[0].element.witness_index,
+                                            binary_basis_limbs[0].element.multiplicative_constant };
+            std::pair<uint32_t, bb::fr> x1{ result.binary_basis_limbs[1].element.witness_index,
+                                            binary_basis_limbs[1].element.multiplicative_constant };
+            std::pair<uint32_t, bb::fr> x2{ result.binary_basis_limbs[2].element.witness_index,
+                                            binary_basis_limbs[2].element.multiplicative_constant };
+            std::pair<uint32_t, bb::fr> x3{ result.binary_basis_limbs[3].element.witness_index,
+                                            binary_basis_limbs[3].element.multiplicative_constant };
+            std::pair<uint32_t, bb::fr> y0{ other.binary_basis_limbs[0].element.witness_index,
+                                            other.binary_basis_limbs[0].element.multiplicative_constant };
+            std::pair<uint32_t, bb::fr> y1{ other.binary_basis_limbs[1].element.witness_index,
+                                            other.binary_basis_limbs[1].element.multiplicative_constant };
+            std::pair<uint32_t, bb::fr> y2{ other.binary_basis_limbs[2].element.witness_index,
+                                            other.binary_basis_limbs[2].element.multiplicative_constant };
+            std::pair<uint32_t, bb::fr> y3{ other.binary_basis_limbs[3].element.witness_index,
+                                            other.binary_basis_limbs[3].element.multiplicative_constant };
+            bb::fr c0(result.binary_basis_limbs[0].element.additive_constant -
+                      other.binary_basis_limbs[0].element.additive_constant);
+            bb::fr c1(result.binary_basis_limbs[1].element.additive_constant -
+                      other.binary_basis_limbs[1].element.additive_constant);
+            bb::fr c2(result.binary_basis_limbs[2].element.additive_constant -
+                      other.binary_basis_limbs[2].element.additive_constant);
+            bb::fr c3(result.binary_basis_limbs[3].element.additive_constant -
+                      other.binary_basis_limbs[3].element.additive_constant);
 
-                uint32_t xp(prime_basis_limb.witness_index);
-                uint32_t yp(other.prime_basis_limb.witness_index);
-                bb::fr cp(prime_basis_limb.additive_constant - other.prime_basis_limb.additive_constant);
-                uint512_t constant_to_add_mod_p = (constant_to_add) % prime_basis.modulus;
-                cp += bb::fr(constant_to_add_mod_p.lo);
+            uint32_t xp(prime_basis_limb.witness_index);
+            uint32_t yp(other.prime_basis_limb.witness_index);
+            bb::fr cp(prime_basis_limb.additive_constant - other.prime_basis_limb.additive_constant);
+            uint512_t constant_to_add_mod_p = (constant_to_add) % prime_basis.modulus;
+            cp += bb::fr(constant_to_add_mod_p.lo);
 
-                const auto output_witnesses = ctx->evaluate_non_native_field_subtraction(
-                    { x0, y0, c0 }, { x1, y1, c1 }, { x2, y2, c2 }, { x3, y3, c3 }, { xp, yp, cp });
+            const auto output_witnesses = ctx->evaluate_non_native_field_subtraction(
+                { x0, y0, c0 }, { x1, y1, c1 }, { x2, y2, c2 }, { x3, y3, c3 }, { xp, yp, cp });
 
-                result.binary_basis_limbs[0].element = field_t<Builder>::from_witness_index(ctx, output_witnesses[0]);
-                result.binary_basis_limbs[1].element = field_t<Builder>::from_witness_index(ctx, output_witnesses[1]);
-                result.binary_basis_limbs[2].element = field_t<Builder>::from_witness_index(ctx, output_witnesses[2]);
-                result.binary_basis_limbs[3].element = field_t<Builder>::from_witness_index(ctx, output_witnesses[3]);
-                result.prime_basis_limb = field_t<Builder>::from_witness_index(ctx, output_witnesses[4]);
+            result.binary_basis_limbs[0].element = field_t<Builder>::from_witness_index(ctx, output_witnesses[0]);
+            result.binary_basis_limbs[1].element = field_t<Builder>::from_witness_index(ctx, output_witnesses[1]);
+            result.binary_basis_limbs[2].element = field_t<Builder>::from_witness_index(ctx, output_witnesses[2]);
+            result.binary_basis_limbs[3].element = field_t<Builder>::from_witness_index(ctx, output_witnesses[3]);
+            result.prime_basis_limb = field_t<Builder>::from_witness_index(ctx, output_witnesses[4]);
 
-                result.set_origin_tag(OriginTag(get_origin_tag(), other.get_origin_tag()));
-                return result;
-            }
+            result.set_origin_tag(OriginTag(get_origin_tag(), other.get_origin_tag()));
+            return result;
         }
     }
 

--- a/barretenberg/cpp/src/barretenberg/stdlib/primitives/bigfield/bigfield_impl.hpp
+++ b/barretenberg/cpp/src/barretenberg/stdlib/primitives/bigfield/bigfield_impl.hpp
@@ -366,6 +366,20 @@ bigfield<Builder, T> bigfield<Builder, T>::add_to_lower_limb(const field_t<Build
     return result;
 }
 
+/**
+ * @brief Adds two bigfield elements. Inputs are reduced to the modulus if necessary. Requires 4 gates if both elements
+ * are witnesses.
+ *
+ * @details Naive addition of two bigfield elements would require 5 gates: 4 gates to add the binary basis limbs and 1
+ * gate to add the prime basis limbs. However, if both elements are witnesses, we can use an optimised addition trick
+ * that uses 4 gates instead of 5. In this case, we add the prime basis limbs and one of the binary basis limbs in a
+ * single gate.
+ *
+ * @tparam Builder
+ * @tparam T
+ * @param other
+ * @return bigfield<Builder, T>
+ */
 template <typename Builder, typename T>
 bigfield<Builder, T> bigfield<Builder, T>::operator+(const bigfield& other) const
 {
@@ -389,66 +403,83 @@ bigfield<Builder, T> bigfield<Builder, T>::operator+(const bigfield& other) cons
     result.binary_basis_limbs[3].maximum_value =
         binary_basis_limbs[3].maximum_value + other.binary_basis_limbs[3].maximum_value;
 
-    if constexpr (HasPlookup<Builder>) {
-        if (prime_basis_limb.multiplicative_constant == 1 && other.prime_basis_limb.multiplicative_constant == 1 &&
-            !is_constant() && !other.is_constant()) {
-            bool limbconst = binary_basis_limbs[0].element.is_constant();
-            limbconst = limbconst || binary_basis_limbs[1].element.is_constant();
-            limbconst = limbconst || binary_basis_limbs[2].element.is_constant();
-            limbconst = limbconst || binary_basis_limbs[3].element.is_constant();
-            limbconst = limbconst || prime_basis_limb.is_constant();
-            limbconst = limbconst || other.binary_basis_limbs[0].element.is_constant();
-            limbconst = limbconst || other.binary_basis_limbs[1].element.is_constant();
-            limbconst = limbconst || other.binary_basis_limbs[2].element.is_constant();
-            limbconst = limbconst || other.binary_basis_limbs[3].element.is_constant();
-            limbconst = limbconst || other.prime_basis_limb.is_constant();
-            limbconst =
-                limbconst || (prime_basis_limb.get_witness_index() ==
-                              other.prime_basis_limb
-                                  .get_witness_index()); // We are comparing if the bigfield elements are exactly the
-                                                         // same object, so we compare the unnormalized witness indices
-            if (!limbconst) {
-                std::pair<uint32_t, bb::fr> x0{ binary_basis_limbs[0].element.witness_index,
-                                                binary_basis_limbs[0].element.multiplicative_constant };
-                std::pair<uint32_t, bb::fr> x1{ binary_basis_limbs[1].element.witness_index,
-                                                binary_basis_limbs[1].element.multiplicative_constant };
-                std::pair<uint32_t, bb::fr> x2{ binary_basis_limbs[2].element.witness_index,
-                                                binary_basis_limbs[2].element.multiplicative_constant };
-                std::pair<uint32_t, bb::fr> x3{ binary_basis_limbs[3].element.witness_index,
-                                                binary_basis_limbs[3].element.multiplicative_constant };
-                std::pair<uint32_t, bb::fr> y0{ other.binary_basis_limbs[0].element.witness_index,
-                                                other.binary_basis_limbs[0].element.multiplicative_constant };
-                std::pair<uint32_t, bb::fr> y1{ other.binary_basis_limbs[1].element.witness_index,
-                                                other.binary_basis_limbs[1].element.multiplicative_constant };
-                std::pair<uint32_t, bb::fr> y2{ other.binary_basis_limbs[2].element.witness_index,
-                                                other.binary_basis_limbs[2].element.multiplicative_constant };
-                std::pair<uint32_t, bb::fr> y3{ other.binary_basis_limbs[3].element.witness_index,
-                                                other.binary_basis_limbs[3].element.multiplicative_constant };
-                bb::fr c0(binary_basis_limbs[0].element.additive_constant +
-                          other.binary_basis_limbs[0].element.additive_constant);
-                bb::fr c1(binary_basis_limbs[1].element.additive_constant +
-                          other.binary_basis_limbs[1].element.additive_constant);
-                bb::fr c2(binary_basis_limbs[2].element.additive_constant +
-                          other.binary_basis_limbs[2].element.additive_constant);
-                bb::fr c3(binary_basis_limbs[3].element.additive_constant +
-                          other.binary_basis_limbs[3].element.additive_constant);
+    // If both the elements are witnesses, we use an optimised addition trick that uses 4 gates instead of 5.
+    //
+    // Naively, we would need 5 gates to add two bigfield elements: 4 gates to add the binary basis limbs and
+    // 1 gate to add the prime basis limbs.
+    //
+    // In the optimised version, we fit 15 witnesses into 4 gates (4 + 4 + 4 + 3 = 15), and we add the prime basis limbs
+    // and one of the binary basis limbs in the first gate.
+    // gate 1: z.limb_0 = x.limb_0 + y.limb_0  &&  z.prime_limb = x.prime_limb + y.prime_limb
+    // gate 2: z.limb_1 = x.limb_1 + y.limb_1
+    // gate 3: z.limb_2 = x.limb_2 + y.limb_2
+    // gate 4: z.limb_3 = x.limb_3 + y.limb_3
+    //
+    // TODO(suyash): does prime_basis_limb need a "normalize" check?
+    bool both_witness = !is_constant() && !other.is_constant();
+    bool both_prime_limb_multiplicative_constant_one =
+        (prime_basis_limb.multiplicative_constant == 1 && other.prime_basis_limb.multiplicative_constant == 1);
+    if (both_prime_limb_multiplicative_constant_one && both_witness) {
+        // TODO(suyash): add is_constant check for bigfield instead of checking each limb
+        bool limbconst = binary_basis_limbs[0].element.is_constant();
+        limbconst = limbconst || binary_basis_limbs[1].element.is_constant();
+        limbconst = limbconst || binary_basis_limbs[2].element.is_constant();
+        limbconst = limbconst || binary_basis_limbs[3].element.is_constant();
+        limbconst = limbconst || prime_basis_limb.is_constant();
+        limbconst = limbconst || other.binary_basis_limbs[0].element.is_constant();
+        limbconst = limbconst || other.binary_basis_limbs[1].element.is_constant();
+        limbconst = limbconst || other.binary_basis_limbs[2].element.is_constant();
+        limbconst = limbconst || other.binary_basis_limbs[3].element.is_constant();
+        limbconst = limbconst || other.prime_basis_limb.is_constant();
+        limbconst =
+            limbconst ||
+            (prime_basis_limb.get_witness_index() ==
+             other.prime_basis_limb.get_witness_index()); // We are comparing if the bigfield elements are exactly the
+                                                          // same object, so we compare the unnormalized witness indices
+        if (!limbconst) {
+            std::pair<uint32_t, bb::fr> x0{ binary_basis_limbs[0].element.witness_index,
+                                            binary_basis_limbs[0].element.multiplicative_constant };
+            std::pair<uint32_t, bb::fr> x1{ binary_basis_limbs[1].element.witness_index,
+                                            binary_basis_limbs[1].element.multiplicative_constant };
+            std::pair<uint32_t, bb::fr> x2{ binary_basis_limbs[2].element.witness_index,
+                                            binary_basis_limbs[2].element.multiplicative_constant };
+            std::pair<uint32_t, bb::fr> x3{ binary_basis_limbs[3].element.witness_index,
+                                            binary_basis_limbs[3].element.multiplicative_constant };
+            std::pair<uint32_t, bb::fr> y0{ other.binary_basis_limbs[0].element.witness_index,
+                                            other.binary_basis_limbs[0].element.multiplicative_constant };
+            std::pair<uint32_t, bb::fr> y1{ other.binary_basis_limbs[1].element.witness_index,
+                                            other.binary_basis_limbs[1].element.multiplicative_constant };
+            std::pair<uint32_t, bb::fr> y2{ other.binary_basis_limbs[2].element.witness_index,
+                                            other.binary_basis_limbs[2].element.multiplicative_constant };
+            std::pair<uint32_t, bb::fr> y3{ other.binary_basis_limbs[3].element.witness_index,
+                                            other.binary_basis_limbs[3].element.multiplicative_constant };
+            bb::fr c0(binary_basis_limbs[0].element.additive_constant +
+                      other.binary_basis_limbs[0].element.additive_constant);
+            bb::fr c1(binary_basis_limbs[1].element.additive_constant +
+                      other.binary_basis_limbs[1].element.additive_constant);
+            bb::fr c2(binary_basis_limbs[2].element.additive_constant +
+                      other.binary_basis_limbs[2].element.additive_constant);
+            bb::fr c3(binary_basis_limbs[3].element.additive_constant +
+                      other.binary_basis_limbs[3].element.additive_constant);
 
-                uint32_t xp(prime_basis_limb.witness_index);
-                uint32_t yp(other.prime_basis_limb.witness_index);
-                bb::fr cp(prime_basis_limb.additive_constant + other.prime_basis_limb.additive_constant);
-                const auto output_witnesses = ctx->evaluate_non_native_field_addition(
-                    { x0, y0, c0 }, { x1, y1, c1 }, { x2, y2, c2 }, { x3, y3, c3 }, { xp, yp, cp });
-                result.binary_basis_limbs[0].element = field_t<Builder>::from_witness_index(ctx, output_witnesses[0]);
-                result.binary_basis_limbs[1].element = field_t<Builder>::from_witness_index(ctx, output_witnesses[1]);
-                result.binary_basis_limbs[2].element = field_t<Builder>::from_witness_index(ctx, output_witnesses[2]);
-                result.binary_basis_limbs[3].element = field_t<Builder>::from_witness_index(ctx, output_witnesses[3]);
-                result.prime_basis_limb = field_t<Builder>::from_witness_index(ctx, output_witnesses[4]);
-                result.set_origin_tag(OriginTag(get_origin_tag(), other.get_origin_tag()));
-                return result;
-            }
+            uint32_t xp(prime_basis_limb.witness_index);
+            uint32_t yp(other.prime_basis_limb.witness_index);
+            bb::fr cp(prime_basis_limb.additive_constant + other.prime_basis_limb.additive_constant);
+            const auto output_witnesses = ctx->evaluate_non_native_field_addition(
+                { x0, y0, c0 }, { x1, y1, c1 }, { x2, y2, c2 }, { x3, y3, c3 }, { xp, yp, cp });
+            result.binary_basis_limbs[0].element = field_t<Builder>::from_witness_index(ctx, output_witnesses[0]);
+            result.binary_basis_limbs[1].element = field_t<Builder>::from_witness_index(ctx, output_witnesses[1]);
+            result.binary_basis_limbs[2].element = field_t<Builder>::from_witness_index(ctx, output_witnesses[2]);
+            result.binary_basis_limbs[3].element = field_t<Builder>::from_witness_index(ctx, output_witnesses[3]);
+            result.prime_basis_limb = field_t<Builder>::from_witness_index(ctx, output_witnesses[4]);
+            result.set_origin_tag(OriginTag(get_origin_tag(), other.get_origin_tag()));
+            return result;
         }
     }
 
+    // If one of the elements is a constant or its prime limb does not have a multiplicative constant of 1, we
+    // use the standard addition method. This will not use additional gates because field addition with one constant
+    // does not require any additional gates.
     result.binary_basis_limbs[0].element = binary_basis_limbs[0].element + other.binary_basis_limbs[0].element;
     result.binary_basis_limbs[1].element = binary_basis_limbs[1].element + other.binary_basis_limbs[1].element;
     result.binary_basis_limbs[2].element = binary_basis_limbs[2].element + other.binary_basis_limbs[2].element;

--- a/barretenberg/cpp/src/barretenberg/stdlib/primitives/bigfield/bigfield_impl.hpp
+++ b/barretenberg/cpp/src/barretenberg/stdlib/primitives/bigfield/bigfield_impl.hpp
@@ -2640,407 +2640,244 @@ void bigfield<Builder, T>::unsafe_evaluate_multiple_multiply_add(const std::vect
         ++max_hi_bits;
     }
 
-    if constexpr (HasPlookup<Builder>) {
-        // The plookup custom bigfield gate requires inputs are witnesses.
-        // If we're using constant values, instantiate them as circuit variables
+    // The plookup custom bigfield gate requires inputs are witnesses.
+    // If we're using constant values, instantiate them as circuit variables
+    //
+    // Explanation:
+    // The bigfield multiplication gate expects witnesses and disallows circuit constants
+    // because allowing circuit constants would lead to complex circuit logic to support
+    // different combinations of constant and witness inputs. Particularly, bigfield multiplication
+    // gate enforces constraints of the form: a * b - q * p + r = 0, where:
+    //
+    // input left  a = (a3 || a2 || a1 || a0)
+    // input right b = (b3 || b2 || b1 || b0)
+    // quotient    q = (q3 || q2 || q1 || q0)
+    // remainder   r = (r3 || r2 || r1 || r0)
+    //
+    // | a1 | b1 | r0 | lo_0 | <-- product gate 1: check lo_0
+    // | a0 | b0 | a3 | b3   |
+    // | a2 | b2 | r3 | hi_0 |
+    // | a1 | b1 | r2 | hi_1 |
+    //
+    // Example constaint: lo_0 = (a1 * b0 + a0 * b1) * 2^b   + (a0 * b0)   - r0
+    //                 ==>  w4 = (w1 * w'2 + w'1 * w2) * 2^b + (w'1 * w'2) - w3
+    //
+    // If a, b both are witnesses, this special gate performs 3 field multiplications per gate.
+    // If b was a constant, then we would need to no field multiplications, but instead update the
+    // the limbs of a with multiplicative and additive constants. This just makes the circuit logic
+    // more complex, so we disallow constants. If there are constants, we convert them to fixed witnesses (at the
+    // expense of 1 extra gate per constant).
+    //
+    const auto convert_constant_to_fixed_witness = [ctx](const bigfield& input) {
+        bigfield output(input);
+        output.prime_basis_limb =
+            field_t<Builder>::from_witness_index(ctx, ctx->put_constant_variable(input.prime_basis_limb.get_value()));
+        output.binary_basis_limbs[0].element = field_t<Builder>::from_witness_index(
+            ctx, ctx->put_constant_variable(input.binary_basis_limbs[0].element.get_value()));
+        output.binary_basis_limbs[1].element = field_t<Builder>::from_witness_index(
+            ctx, ctx->put_constant_variable(input.binary_basis_limbs[1].element.get_value()));
+        output.binary_basis_limbs[2].element = field_t<Builder>::from_witness_index(
+            ctx, ctx->put_constant_variable(input.binary_basis_limbs[2].element.get_value()));
+        output.binary_basis_limbs[3].element = field_t<Builder>::from_witness_index(
+            ctx, ctx->put_constant_variable(input.binary_basis_limbs[3].element.get_value()));
+        output.context = ctx;
+        return output;
+    };
 
-        const auto convert_constant_to_fixed_witness = [ctx](const bigfield& input) {
-            bigfield output(input);
-            output.prime_basis_limb = field_t<Builder>::from_witness_index(
-                ctx, ctx->put_constant_variable(input.prime_basis_limb.get_value()));
-            output.binary_basis_limbs[0].element = field_t<Builder>::from_witness_index(
-                ctx, ctx->put_constant_variable(input.binary_basis_limbs[0].element.get_value()));
-            output.binary_basis_limbs[1].element = field_t<Builder>::from_witness_index(
-                ctx, ctx->put_constant_variable(input.binary_basis_limbs[1].element.get_value()));
-            output.binary_basis_limbs[2].element = field_t<Builder>::from_witness_index(
-                ctx, ctx->put_constant_variable(input.binary_basis_limbs[2].element.get_value()));
-            output.binary_basis_limbs[3].element = field_t<Builder>::from_witness_index(
-                ctx, ctx->put_constant_variable(input.binary_basis_limbs[3].element.get_value()));
-            output.context = ctx;
-            return output;
-        };
+    // evalaute a nnf mul and add into existing lohi output for our extra product terms
+    // we need to add the result of (left_b * right_b) into lo_1_idx and hi_1_idx
+    // our custom gate evaluates: ((a * b) + (q * neg_modulus) - r) / 2^{136} = lo + hi * 2^{136}
+    // where q is a 'quotient' bigfield and neg_modulus is defined by selector polynomial values
+    // The custom gate costs 7 constraints, which is cheaper than computing `a * b` using multiplication +
+    // addition gates But....we want to obtain `left_a * right_b + lo_1 + hi_1 * 2^{136} = lo + hi * 2^{136}` If
+    // we set `neg_modulus = [2^{136}, 0, 0, 0]` and `q = [lo_1, 0, hi_1, 0]`, then we will add `lo_1` into
+    // `lo`, and `lo_1/2^{136} + hi_1` into `hi`. we can then subtract off `lo_1/2^{136}` from `hi`, by setting
+    // `r = [0, 0, lo_1, 0]` This saves us 2 addition gates as we don't have to add together the outputs of two
+    // calls to `evaluate_non_native_field_multiplication`
+    std::vector<field_t<Builder>> limb_0_accumulator;
+    std::vector<field_t<Builder>> limb_2_accumulator;
+    std::vector<field_t<Builder>> prime_limb_accumulator;
 
-        // evalaute a nnf mul and add into existing lohi output for our extra product terms
-        // we need to add the result of (left_b * right_b) into lo_1_idx and hi_1_idx
-        // our custom gate evaluates: ((a * b) + (q * neg_modulus) - r) / 2^{136} = lo + hi * 2^{136}
-        // where q is a 'quotient' bigfield and neg_modulus is defined by selector polynomial values
-        // The custom gate costs 7 constraints, which is cheaper than computing `a * b` using multiplication +
-        // addition gates But....we want to obtain `left_a * right_b + lo_1 + hi_1 * 2^{136} = lo + hi * 2^{136}` If
-        // we set `neg_modulus = [2^{136}, 0, 0, 0]` and `q = [lo_1, 0, hi_1, 0]`, then we will add `lo_1` into
-        // `lo`, and `lo_1/2^{136} + hi_1` into `hi`. we can then subtract off `lo_1/2^{136}` from `hi`, by setting
-        // `r = [0, 0, lo_1, 0]` This saves us 2 addition gates as we don't have to add together the outputs of two
-        // calls to `evaluate_non_native_field_multiplication`
-        std::vector<field_t<Builder>> limb_0_accumulator;
-        std::vector<field_t<Builder>> limb_2_accumulator;
-        std::vector<field_t<Builder>> prime_limb_accumulator;
-
-        for (size_t i = 0; i < num_multiplications; ++i) {
-            if (i == 0 && left[0].is_constant()) {
-                left[0] = convert_constant_to_fixed_witness(left[0]);
-            }
-            if (i == 0 && right[0].is_constant()) {
-                right[0] = convert_constant_to_fixed_witness(right[0]);
-            }
-            if (i > 0 && left[i].is_constant()) {
-                left[i] = convert_constant_to_fixed_witness(left[i]);
-            }
-            if (i > 0 && right[i].is_constant()) {
-                right[i] = convert_constant_to_fixed_witness(right[i]);
-            }
-
-            if (i > 0) {
-                bb::non_native_field_witnesses<bb::fr> mul_witnesses = {
-                    {
-                        left[i].binary_basis_limbs[0].element.get_normalized_witness_index(),
-                        left[i].binary_basis_limbs[1].element.get_normalized_witness_index(),
-                        left[i].binary_basis_limbs[2].element.get_normalized_witness_index(),
-                        left[i].binary_basis_limbs[3].element.get_normalized_witness_index(),
-                    },
-                    {
-                        right[i].binary_basis_limbs[0].element.get_normalized_witness_index(),
-                        right[i].binary_basis_limbs[1].element.get_normalized_witness_index(),
-                        right[i].binary_basis_limbs[2].element.get_normalized_witness_index(),
-                        right[i].binary_basis_limbs[3].element.get_normalized_witness_index(),
-                    },
-                    {
-                        ctx->zero_idx,
-                        ctx->zero_idx,
-                        ctx->zero_idx,
-                        ctx->zero_idx,
-                    },
-                    {
-                        ctx->zero_idx,
-                        ctx->zero_idx,
-                        ctx->zero_idx,
-                        ctx->zero_idx,
-                    },
-                    { 0, 0, 0, 0 },
-                    modulus,
-                };
-
-                const auto [lo_2_idx, hi_2_idx] = ctx->queue_partial_non_native_field_multiplication(mul_witnesses);
-
-                field_t<Builder> lo_2 = field_t<Builder>::from_witness_index(ctx, lo_2_idx);
-                field_t<Builder> hi_2 = field_t<Builder>::from_witness_index(ctx, hi_2_idx);
-
-                limb_0_accumulator.emplace_back(-lo_2);
-                limb_2_accumulator.emplace_back(-hi_2);
-                prime_limb_accumulator.emplace_back(-(left[i].prime_basis_limb * right[i].prime_basis_limb));
-            }
+    for (size_t i = 0; i < num_multiplications; ++i) {
+        if (i == 0 && left[0].is_constant()) {
+            left[0] = convert_constant_to_fixed_witness(left[0]);
         }
-        if (quotient.is_constant()) {
-            quotient = convert_constant_to_fixed_witness(quotient);
+        if (i == 0 && right[0].is_constant()) {
+            right[0] = convert_constant_to_fixed_witness(right[0]);
+        }
+        if (i > 0 && left[i].is_constant()) {
+            left[i] = convert_constant_to_fixed_witness(left[i]);
+        }
+        if (i > 0 && right[i].is_constant()) {
+            right[i] = convert_constant_to_fixed_witness(right[i]);
         }
 
-        bool no_remainders = remainders.size() == 0;
-        if (!no_remainders) {
-            limb_0_accumulator.emplace_back(remainders[0].binary_basis_limbs[0].element);
-            limb_2_accumulator.emplace_back(remainders[0].binary_basis_limbs[2].element);
-            prime_limb_accumulator.emplace_back(remainders[0].prime_basis_limb);
-        }
-        for (size_t i = 1; i < remainders.size(); ++i) {
-            limb_0_accumulator.emplace_back(remainders[i].binary_basis_limbs[0].element);
-            limb_0_accumulator.emplace_back(remainders[i].binary_basis_limbs[1].element * shift_1);
-            limb_2_accumulator.emplace_back(remainders[i].binary_basis_limbs[2].element);
-            limb_2_accumulator.emplace_back(remainders[i].binary_basis_limbs[3].element * shift_1);
-            prime_limb_accumulator.emplace_back(remainders[i].prime_basis_limb);
-        }
-        for (const auto& add : to_add) {
-            limb_0_accumulator.emplace_back(-add.binary_basis_limbs[0].element);
-            limb_0_accumulator.emplace_back(-add.binary_basis_limbs[1].element * shift_1);
-            limb_2_accumulator.emplace_back(-add.binary_basis_limbs[2].element);
-            limb_2_accumulator.emplace_back(-add.binary_basis_limbs[3].element * shift_1);
-            prime_limb_accumulator.emplace_back(-add.prime_basis_limb);
-        }
+        if (i > 0) {
+            bb::non_native_field_witnesses<bb::fr> mul_witnesses = {
+                {
+                    left[i].binary_basis_limbs[0].element.get_normalized_witness_index(),
+                    left[i].binary_basis_limbs[1].element.get_normalized_witness_index(),
+                    left[i].binary_basis_limbs[2].element.get_normalized_witness_index(),
+                    left[i].binary_basis_limbs[3].element.get_normalized_witness_index(),
+                },
+                {
+                    right[i].binary_basis_limbs[0].element.get_normalized_witness_index(),
+                    right[i].binary_basis_limbs[1].element.get_normalized_witness_index(),
+                    right[i].binary_basis_limbs[2].element.get_normalized_witness_index(),
+                    right[i].binary_basis_limbs[3].element.get_normalized_witness_index(),
+                },
+                {
+                    ctx->zero_idx,
+                    ctx->zero_idx,
+                    ctx->zero_idx,
+                    ctx->zero_idx,
+                },
+                {
+                    ctx->zero_idx,
+                    ctx->zero_idx,
+                    ctx->zero_idx,
+                    ctx->zero_idx,
+                },
+                { 0, 0, 0, 0 },
+                modulus,
+            };
 
-        field_t<Builder> accumulated_lo = field_t<Builder>::accumulate(limb_0_accumulator);
-        field_t<Builder> accumulated_hi = field_t<Builder>::accumulate(limb_2_accumulator);
-        if (accumulated_lo.is_constant()) {
-            accumulated_lo =
-                field_t<Builder>::from_witness_index(ctx, ctx->put_constant_variable(accumulated_lo.get_value()));
-        }
-        if (accumulated_hi.is_constant()) {
-            accumulated_hi =
-                field_t<Builder>::from_witness_index(ctx, ctx->put_constant_variable(accumulated_hi.get_value()));
-        }
-        field_t<Builder> remainder1 = no_remainders ? field_t<Builder>::from_witness_index(ctx, ctx->zero_idx)
-                                                    : remainders[0].binary_basis_limbs[1].element;
-        if (remainder1.is_constant()) {
-            remainder1 = field_t<Builder>::from_witness_index(ctx, ctx->put_constant_variable(remainder1.get_value()));
-        }
-        field_t<Builder> remainder3 = no_remainders ? field_t<Builder>::from_witness_index(ctx, ctx->zero_idx)
-                                                    : remainders[0].binary_basis_limbs[3].element;
-        if (remainder3.is_constant()) {
-            remainder3 = field_t<Builder>::from_witness_index(ctx, ctx->put_constant_variable(remainder3.get_value()));
-        }
-        field_t<Builder> remainder_limbs[4]{
-            accumulated_lo,
-            remainder1,
-            accumulated_hi,
-            remainder3,
-        };
-        field_t<Builder> remainder_prime_limb = field_t<Builder>::accumulate(prime_limb_accumulator);
+            const auto [lo_2_idx, hi_2_idx] = ctx->queue_partial_non_native_field_multiplication(mul_witnesses);
 
-        bb::non_native_field_witnesses<bb::fr> witnesses{
-            {
-                left[0].binary_basis_limbs[0].element.get_normalized_witness_index(),
-                left[0].binary_basis_limbs[1].element.get_normalized_witness_index(),
-                left[0].binary_basis_limbs[2].element.get_normalized_witness_index(),
-                left[0].binary_basis_limbs[3].element.get_normalized_witness_index(),
-            },
-            {
-                right[0].binary_basis_limbs[0].element.get_normalized_witness_index(),
-                right[0].binary_basis_limbs[1].element.get_normalized_witness_index(),
-                right[0].binary_basis_limbs[2].element.get_normalized_witness_index(),
-                right[0].binary_basis_limbs[3].element.get_normalized_witness_index(),
-            },
-            {
-                quotient.binary_basis_limbs[0].element.get_normalized_witness_index(),
-                quotient.binary_basis_limbs[1].element.get_normalized_witness_index(),
-                quotient.binary_basis_limbs[2].element.get_normalized_witness_index(),
-                quotient.binary_basis_limbs[3].element.get_normalized_witness_index(),
-            },
-            {
-                remainder_limbs[0].get_normalized_witness_index(),
-                remainder_limbs[1].get_normalized_witness_index(),
-                remainder_limbs[2].get_normalized_witness_index(),
-                remainder_limbs[3].get_normalized_witness_index(),
-            },
-            { neg_modulus_limbs[0], neg_modulus_limbs[1], neg_modulus_limbs[2], neg_modulus_limbs[3] },
-            modulus,
-        };
-
-        const auto [lo_1_idx, hi_1_idx] = ctx->evaluate_non_native_field_multiplication(witnesses);
-
-        bb::fr neg_prime = -bb::fr(uint256_t(target_basis.modulus));
-
-        field_t<Builder>::evaluate_polynomial_identity(left[0].prime_basis_limb,
-                                                       right[0].prime_basis_limb,
-                                                       quotient.prime_basis_limb * neg_prime,
-                                                       -remainder_prime_limb);
-
-        field_t lo = field_t<Builder>::from_witness_index(ctx, lo_1_idx) + borrow_lo;
-        field_t hi = field_t<Builder>::from_witness_index(ctx, hi_1_idx);
-
-        uint64_t carry_lo_msb = max_lo_bits - (2 * NUM_LIMB_BITS);
-        uint64_t carry_hi_msb = max_hi_bits - (2 * NUM_LIMB_BITS);
-
-        if (max_lo_bits < (2 * NUM_LIMB_BITS)) {
-            carry_lo_msb = 0;
-        }
-        if (max_hi_bits < (2 * NUM_LIMB_BITS)) {
-            carry_hi_msb = 0;
-        }
-
-        // if both the hi and lo output limbs have less than 70 bits, we can use our custom
-        // limb accumulation gate (accumulates 2 field elements, each composed of 5 14-bit limbs, in 3 gates)
-        if (carry_lo_msb <= 70 && carry_hi_msb <= 70) {
-            ctx->range_constrain_two_limbs(hi.get_normalized_witness_index(),
-                                           lo.get_normalized_witness_index(),
-                                           (size_t)carry_hi_msb,
-                                           (size_t)carry_lo_msb);
-        } else {
-            ctx->decompose_into_default_range(hi.get_normalized_witness_index(), carry_hi_msb);
-            ctx->decompose_into_default_range(lo.get_normalized_witness_index(), carry_lo_msb);
-        }
-        /*  NOTE TO AUDITOR: An extraneous block
-               if constexpr (HasPlookup<Builder>) {
-                   carry_lo = carry_lo.normalize();
-                   carry_hi = carry_hi.normalize();
-                   ctx->decompose_into_default_range(carry_lo.witness_index, static_cast<size_t>(carry_lo_msb));
-                   ctx->decompose_into_default_range(carry_hi.witness_index, static_cast<size_t>(carry_hi_msb));
-               }
-            was removed from the `else` block below. See  the conversation at
-               https://github.com/AztecProtocol/aztec2-internal/pull/1023
-            We should make sure that no constraint like this is needed but missing (e.g., an equivalent constraint
-            was just imposed?). */
-    } else {
-        field_t b0 = left[0].binary_basis_limbs[1].element.madd(
-            right[0].binary_basis_limbs[0].element, quotient.binary_basis_limbs[1].element * neg_modulus_limbs[0]);
-        field_t b1 = left[0].binary_basis_limbs[0].element.madd(
-            right[0].binary_basis_limbs[1].element, quotient.binary_basis_limbs[0].element * neg_modulus_limbs[1]);
-        field_t c0 = left[0].binary_basis_limbs[1].element.madd(
-            right[0].binary_basis_limbs[1].element, quotient.binary_basis_limbs[1].element * neg_modulus_limbs[1]);
-        field_t c1 = left[0].binary_basis_limbs[2].element.madd(
-            right[0].binary_basis_limbs[0].element, quotient.binary_basis_limbs[2].element * neg_modulus_limbs[0]);
-        field_t c2 = left[0].binary_basis_limbs[0].element.madd(
-            right[0].binary_basis_limbs[2].element, quotient.binary_basis_limbs[0].element * neg_modulus_limbs[2]);
-        field_t d0 = left[0].binary_basis_limbs[3].element.madd(
-            right[0].binary_basis_limbs[0].element, quotient.binary_basis_limbs[3].element * neg_modulus_limbs[0]);
-        field_t d1 = left[0].binary_basis_limbs[2].element.madd(
-            right[0].binary_basis_limbs[1].element, quotient.binary_basis_limbs[2].element * neg_modulus_limbs[1]);
-        field_t d2 = left[0].binary_basis_limbs[1].element.madd(
-            right[0].binary_basis_limbs[2].element, quotient.binary_basis_limbs[1].element * neg_modulus_limbs[2]);
-        field_t d3 = left[0].binary_basis_limbs[0].element.madd(
-            right[0].binary_basis_limbs[3].element, quotient.binary_basis_limbs[0].element * neg_modulus_limbs[3]);
-
-        /**
-         * Compute "limb accumulators"
-         * `limb_0_accumulator` contains contributions in the range 0 - 2^{3t}
-         * `limb_2_accumulator` contains contributiosn in the range 2^{2t} - 2^{5t} (t = MAX_NUM_LIMB_BITS)
-         * Actual range will vary a few bits because of lazy reduction techniques
-         *
-         * We store these values in an "accumulator" vector in order to efficiently add them into a sum.
-         * i.e. limb_0 =- field_t::accumulate(limb_0_accumulator)
-         * This costs us fewer gates than addition operations because we can add 2 values into a sum in a single
-         * custom gate.
-         **/
-
-        std::vector<field_t<Builder>> limb_0_accumulator;
-        std::vector<field_t<Builder>> limb_2_accumulator;
-        std::vector<field_t<Builder>> prime_limb_accumulator;
-
-        // Add remaining products into the limb accumulators.
-        // We negate the product values because the accumulator values itself will be negated
-        // TODO: why do we do this double negation exactly? seems a bit pointless. I think it stems from the fact
-        // that the accumulators originaly tracked the remainder term (which is negated)
-
-        for (size_t i = 1; i < num_multiplications; ++i) {
-            field_t lo_2 = left[i].binary_basis_limbs[0].element * right[i].binary_basis_limbs[0].element;
-            lo_2 = left[i].binary_basis_limbs[1].element.madd(right[i].binary_basis_limbs[0].element * shift_1, lo_2);
-            lo_2 = left[i].binary_basis_limbs[0].element.madd(right[i].binary_basis_limbs[1].element * shift_1, lo_2);
-            field_t hi_2 = left[i].binary_basis_limbs[1].element * right[i].binary_basis_limbs[1].element;
-            hi_2 = left[i].binary_basis_limbs[2].element.madd(right[i].binary_basis_limbs[0].element, hi_2);
-            hi_2 = left[i].binary_basis_limbs[0].element.madd(right[i].binary_basis_limbs[2].element, hi_2);
-            hi_2 = left[i].binary_basis_limbs[3].element.madd(right[i].binary_basis_limbs[0].element * shift_1, hi_2);
-            hi_2 = left[i].binary_basis_limbs[2].element.madd(right[i].binary_basis_limbs[1].element * shift_1, hi_2);
-            hi_2 = left[i].binary_basis_limbs[1].element.madd(right[i].binary_basis_limbs[2].element * shift_1, hi_2);
-            hi_2 = left[i].binary_basis_limbs[0].element.madd(right[i].binary_basis_limbs[3].element * shift_1, hi_2);
+            field_t<Builder> lo_2 = field_t<Builder>::from_witness_index(ctx, lo_2_idx);
+            field_t<Builder> hi_2 = field_t<Builder>::from_witness_index(ctx, hi_2_idx);
 
             limb_0_accumulator.emplace_back(-lo_2);
             limb_2_accumulator.emplace_back(-hi_2);
             prime_limb_accumulator.emplace_back(-(left[i].prime_basis_limb * right[i].prime_basis_limb));
         }
-        // add cached products into the limb accumulators.
-        // We negate the cache values because the accumulator values itself will be negated
-        // TODO: why do we do this double negation exactly? seems a bit pointless. I think it stems from the fact
-        // that the accumulators originaly tracked the remainder term (which is negated)
-
-        // Update the accumulators with the remainder terms. First check we actually have remainder terms!
-        //(not present when we're checking a product is 0 mod p). See `assert_is_in_field`
-
-        bool no_remainders = remainders.size() == 0;
-        if (!no_remainders) {
-            limb_0_accumulator.emplace_back(remainders[0].binary_basis_limbs[0].element);
-            limb_2_accumulator.emplace_back(remainders[0].binary_basis_limbs[2].element);
-            prime_limb_accumulator.emplace_back(remainders[0].prime_basis_limb);
-        }
-        for (size_t i = 1; i < remainders.size(); ++i) {
-            limb_0_accumulator.emplace_back(remainders[i].binary_basis_limbs[0].element);
-            limb_0_accumulator.emplace_back(remainders[i].binary_basis_limbs[1].element * shift_1);
-            limb_2_accumulator.emplace_back(remainders[i].binary_basis_limbs[2].element);
-            limb_2_accumulator.emplace_back(remainders[i].binary_basis_limbs[3].element * shift_1);
-            prime_limb_accumulator.emplace_back(remainders[i].prime_basis_limb);
-        }
-        for (const auto& add : to_add) {
-            limb_0_accumulator.emplace_back(-add.binary_basis_limbs[0].element);
-            limb_0_accumulator.emplace_back(-add.binary_basis_limbs[1].element * shift_1);
-            limb_2_accumulator.emplace_back(-add.binary_basis_limbs[2].element);
-            limb_2_accumulator.emplace_back(-add.binary_basis_limbs[3].element * shift_1);
-            prime_limb_accumulator.emplace_back(-add.prime_basis_limb);
-        }
-
-        field_t<Builder> accumulated_lo = field_t<Builder>::accumulate(limb_0_accumulator);
-        field_t<Builder> accumulated_hi = field_t<Builder>::accumulate(limb_2_accumulator);
-        if (accumulated_lo.is_constant()) {
-            accumulated_lo =
-                field_t<Builder>::from_witness_index(ctx, ctx->put_constant_variable(accumulated_lo.get_value()));
-        }
-        if (accumulated_hi.is_constant()) {
-            accumulated_hi =
-                field_t<Builder>::from_witness_index(ctx, ctx->put_constant_variable(accumulated_hi.get_value()));
-        }
-        field_t<Builder> remainder1 = no_remainders ? field_t<Builder>::from_witness_index(ctx, ctx->zero_idx)
-                                                    : remainders[0].binary_basis_limbs[1].element;
-        if (remainder1.is_constant()) {
-            remainder1 = field_t<Builder>::from_witness_index(ctx, ctx->put_constant_variable(remainder1.get_value()));
-        }
-        field_t<Builder> remainder3 = no_remainders ? field_t<Builder>::from_witness_index(ctx, ctx->zero_idx)
-                                                    : remainders[0].binary_basis_limbs[3].element;
-        if (remainder3.is_constant()) {
-            remainder3 = field_t<Builder>::from_witness_index(ctx, ctx->put_constant_variable(remainder3.get_value()));
-        }
-        field_t<Builder> remainder_limbs[4]{
-            accumulated_lo,
-            remainder1,
-            accumulated_hi,
-            remainder3,
-        };
-        field_t<Builder> remainder_prime_limb = field_t<Builder>::accumulate(prime_limb_accumulator);
-
-        // We wish to show that left*right - quotient*remainder = 0 mod 2^t, we do this by collecting the limb
-        // products into two separate variables - carry_lo and carry_hi, which are still small enough not to wrap
-        // mod r Their first t/2 bits will equal, respectively, the first and second t/2 bits of the expresssion
-        // Thus it will suffice to check that each of them begins with t/2 zeroes. We do this by in fact assigning
-        // to these variables those expressions divided by 2^{t/2}. Since we have bounds on their ranage that are
-        // smaller than r, We can range check the divisions by the original range bounds divided by 2^{t/2}
-
-        field_t r0 = left[0].binary_basis_limbs[0].element.madd(
-            right[0].binary_basis_limbs[0].element, quotient.binary_basis_limbs[0].element * neg_modulus_limbs[0]);
-        field_t r1 = b0.add_two(b1, -remainder_limbs[1]);
-        const field_t r2 = c0.add_two(c1, c2);
-        const field_t r3 = d0 + d1.add_two(d2, d3);
-
-        field_t carry_lo_0 = r0 * shift_right_2;
-        field_t carry_lo_1 = r1 * (shift_1 * shift_right_2);
-        field_t carry_lo_2 = -(remainder_limbs[0] * shift_right_2);
-        field_t carry_lo = carry_lo_0.add_two(carry_lo_1, carry_lo_2);
-
-        field_t t1 = carry_lo.add_two(-remainder_limbs[2], -(remainder_limbs[3] * shift_1));
-        carry_lo += borrow_lo;
-        field_t carry_hi_0 = r2 * shift_right_2;
-        field_t carry_hi_1 = r3 * (shift_1 * shift_right_2);
-        field_t carry_hi_2 = t1 * shift_right_2;
-        field_t carry_hi = carry_hi_0.add_two(carry_hi_1, carry_hi_2);
-
-        bb::fr neg_prime = -bb::fr(uint256_t(target_basis.modulus));
-
-        field_t<Builder> linear_terms(ctx, bb::fr(0));
-
-        linear_terms += -remainder_prime_limb;
-
-        // This is where we show our identity is zero mod r (to use CRT we show it's zero mod r and mod 2^t)
-        field_t<Builder>::evaluate_polynomial_identity(
-            left[0].prime_basis_limb, right[0].prime_basis_limb, quotient.prime_basis_limb * neg_prime, linear_terms);
-
-        const uint64_t carry_lo_msb = max_lo_bits - (2 * NUM_LIMB_BITS);
-        const uint64_t carry_hi_msb = max_hi_bits - (2 * NUM_LIMB_BITS);
-
-        const bb::fr carry_lo_shift(uint256_t(uint256_t(1) << carry_lo_msb));
-
-        if constexpr (HasPlookup<Builder>) {
-            carry_lo = carry_lo.normalize();
-            carry_hi = carry_hi.normalize();
-            ctx->decompose_into_default_range(carry_lo.get_normalized_witness_index(),
-                                              static_cast<size_t>(carry_lo_msb));
-            ctx->decompose_into_default_range(carry_hi.get_normalized_witness_index(),
-                                              static_cast<size_t>(carry_hi_msb));
-
-        } else {
-            if ((carry_hi_msb + carry_lo_msb) < field_t<Builder>::modulus.get_msb()) {
-                field_t carry_combined = carry_lo + (carry_hi * carry_lo_shift);
-                carry_combined = carry_combined.normalize();
-                const auto accumulators = ctx->decompose_into_base4_accumulators(
-                    carry_combined.get_normalized_witness_index(),
-                    static_cast<size_t>(carry_lo_msb + carry_hi_msb),
-                    "bigfield: carry_combined too large in unsafe_evaluate_multiple_multiply_add.");
-                field_t<Builder> accumulator_midpoint = field_t<Builder>::from_witness_index(
-                    ctx, accumulators[static_cast<size_t>((carry_hi_msb / 2) - 1)]);
-                carry_hi.assert_equal(accumulator_midpoint, "bigfield multiply range check failed");
-            } else {
-                carry_lo = carry_lo.normalize();
-                carry_hi = carry_hi.normalize();
-                ctx->decompose_into_base4_accumulators(
-                    carry_lo.get_normalized_witness_index(),
-                    static_cast<size_t>(carry_lo_msb),
-                    "bigfield: carry_lo too large in unsafe_evaluate_multiple_multiply_add.");
-                ctx->decompose_into_base4_accumulators(
-                    carry_hi.get_normalized_witness_index(),
-                    static_cast<size_t>(carry_hi_msb),
-                    "bigfield: carry_hi too large in unsafe_evaluate_multiple_multiply_add.");
-            }
-        }
     }
+    if (quotient.is_constant()) {
+        quotient = convert_constant_to_fixed_witness(quotient);
+    }
+
+    bool no_remainders = remainders.size() == 0;
+    if (!no_remainders) {
+        limb_0_accumulator.emplace_back(remainders[0].binary_basis_limbs[0].element);
+        limb_2_accumulator.emplace_back(remainders[0].binary_basis_limbs[2].element);
+        prime_limb_accumulator.emplace_back(remainders[0].prime_basis_limb);
+    }
+    for (size_t i = 1; i < remainders.size(); ++i) {
+        limb_0_accumulator.emplace_back(remainders[i].binary_basis_limbs[0].element);
+        limb_0_accumulator.emplace_back(remainders[i].binary_basis_limbs[1].element * shift_1);
+        limb_2_accumulator.emplace_back(remainders[i].binary_basis_limbs[2].element);
+        limb_2_accumulator.emplace_back(remainders[i].binary_basis_limbs[3].element * shift_1);
+        prime_limb_accumulator.emplace_back(remainders[i].prime_basis_limb);
+    }
+    for (const auto& add : to_add) {
+        limb_0_accumulator.emplace_back(-add.binary_basis_limbs[0].element);
+        limb_0_accumulator.emplace_back(-add.binary_basis_limbs[1].element * shift_1);
+        limb_2_accumulator.emplace_back(-add.binary_basis_limbs[2].element);
+        limb_2_accumulator.emplace_back(-add.binary_basis_limbs[3].element * shift_1);
+        prime_limb_accumulator.emplace_back(-add.prime_basis_limb);
+    }
+
+    field_t<Builder> accumulated_lo = field_t<Builder>::accumulate(limb_0_accumulator);
+    field_t<Builder> accumulated_hi = field_t<Builder>::accumulate(limb_2_accumulator);
+    if (accumulated_lo.is_constant()) {
+        accumulated_lo =
+            field_t<Builder>::from_witness_index(ctx, ctx->put_constant_variable(accumulated_lo.get_value()));
+    }
+    if (accumulated_hi.is_constant()) {
+        accumulated_hi =
+            field_t<Builder>::from_witness_index(ctx, ctx->put_constant_variable(accumulated_hi.get_value()));
+    }
+    field_t<Builder> remainder1 = no_remainders ? field_t<Builder>::from_witness_index(ctx, ctx->zero_idx)
+                                                : remainders[0].binary_basis_limbs[1].element;
+    if (remainder1.is_constant()) {
+        remainder1 = field_t<Builder>::from_witness_index(ctx, ctx->put_constant_variable(remainder1.get_value()));
+    }
+    field_t<Builder> remainder3 = no_remainders ? field_t<Builder>::from_witness_index(ctx, ctx->zero_idx)
+                                                : remainders[0].binary_basis_limbs[3].element;
+    if (remainder3.is_constant()) {
+        remainder3 = field_t<Builder>::from_witness_index(ctx, ctx->put_constant_variable(remainder3.get_value()));
+    }
+    field_t<Builder> remainder_limbs[4]{
+        accumulated_lo,
+        remainder1,
+        accumulated_hi,
+        remainder3,
+    };
+    field_t<Builder> remainder_prime_limb = field_t<Builder>::accumulate(prime_limb_accumulator);
+
+    bb::non_native_field_witnesses<bb::fr> witnesses{
+        {
+            left[0].binary_basis_limbs[0].element.get_normalized_witness_index(),
+            left[0].binary_basis_limbs[1].element.get_normalized_witness_index(),
+            left[0].binary_basis_limbs[2].element.get_normalized_witness_index(),
+            left[0].binary_basis_limbs[3].element.get_normalized_witness_index(),
+        },
+        {
+            right[0].binary_basis_limbs[0].element.get_normalized_witness_index(),
+            right[0].binary_basis_limbs[1].element.get_normalized_witness_index(),
+            right[0].binary_basis_limbs[2].element.get_normalized_witness_index(),
+            right[0].binary_basis_limbs[3].element.get_normalized_witness_index(),
+        },
+        {
+            quotient.binary_basis_limbs[0].element.get_normalized_witness_index(),
+            quotient.binary_basis_limbs[1].element.get_normalized_witness_index(),
+            quotient.binary_basis_limbs[2].element.get_normalized_witness_index(),
+            quotient.binary_basis_limbs[3].element.get_normalized_witness_index(),
+        },
+        {
+            remainder_limbs[0].get_normalized_witness_index(),
+            remainder_limbs[1].get_normalized_witness_index(),
+            remainder_limbs[2].get_normalized_witness_index(),
+            remainder_limbs[3].get_normalized_witness_index(),
+        },
+        { neg_modulus_limbs[0], neg_modulus_limbs[1], neg_modulus_limbs[2], neg_modulus_limbs[3] },
+        modulus,
+    };
+
+    const auto [lo_1_idx, hi_1_idx] = ctx->evaluate_non_native_field_multiplication(witnesses);
+
+    bb::fr neg_prime = -bb::fr(uint256_t(target_basis.modulus));
+
+    field_t<Builder>::evaluate_polynomial_identity(left[0].prime_basis_limb,
+                                                   right[0].prime_basis_limb,
+                                                   quotient.prime_basis_limb * neg_prime,
+                                                   -remainder_prime_limb);
+
+    field_t lo = field_t<Builder>::from_witness_index(ctx, lo_1_idx) + borrow_lo;
+    field_t hi = field_t<Builder>::from_witness_index(ctx, hi_1_idx);
+
+    uint64_t carry_lo_msb = max_lo_bits - (2 * NUM_LIMB_BITS);
+    uint64_t carry_hi_msb = max_hi_bits - (2 * NUM_LIMB_BITS);
+
+    if (max_lo_bits < (2 * NUM_LIMB_BITS)) {
+        carry_lo_msb = 0;
+    }
+    if (max_hi_bits < (2 * NUM_LIMB_BITS)) {
+        carry_hi_msb = 0;
+    }
+
+    // if both the hi and lo output limbs have less than 70 bits, we can use our custom
+    // limb accumulation gate (accumulates 2 field elements, each composed of 5 14-bit limbs, in 3 gates)
+    if (carry_lo_msb <= 70 && carry_hi_msb <= 70) {
+        ctx->range_constrain_two_limbs(hi.get_normalized_witness_index(),
+                                       lo.get_normalized_witness_index(),
+                                       (size_t)carry_hi_msb,
+                                       (size_t)carry_lo_msb);
+    } else {
+        ctx->decompose_into_default_range(hi.get_normalized_witness_index(), carry_hi_msb);
+        ctx->decompose_into_default_range(lo.get_normalized_witness_index(), carry_lo_msb);
+    }
+    /*  NOTE TO AUDITOR: An extraneous block
+           if constexpr (HasPlookup<Builder>) {
+               carry_lo = carry_lo.normalize();
+               carry_hi = carry_hi.normalize();
+               ctx->decompose_into_default_range(carry_lo.witness_index, static_cast<size_t>(carry_lo_msb));
+               ctx->decompose_into_default_range(carry_hi.witness_index, static_cast<size_t>(carry_hi_msb));
+           }
+        was removed from the `else` block below. See  the conversation at
+           https://github.com/AztecProtocol/aztec2-internal/pull/1023
+        We should make sure that no constraint like this is needed but missing (e.g., an equivalent constraint
+        was just imposed?). */
 }
 
 template <typename Builder, typename T>

--- a/barretenberg/cpp/src/barretenberg/stdlib/primitives/biggroup/biggroup.hpp
+++ b/barretenberg/cpp/src/barretenberg/stdlib/primitives/biggroup/biggroup.hpp
@@ -522,11 +522,11 @@ template <class Builder, class Fq, class Fr, class NativeGroup> class element {
         std::array<uint256_t, 8> limb_max;
     };
 
-    using twin_lookup_table = typename lookup_table_plookup<2>::type;
+    using twin_lookup_table = lookup_table_plookup<2>;
 
-    using triple_lookup_table = typename lookup_table_plookup<3>::type;
+    using triple_lookup_table = lookup_table_plookup<3>;
 
-    using quad_lookup_table = typename lookup_table_plookup<4>::type;
+    using quad_lookup_table = lookup_table_plookup<4>;
 
     /**
      * Creates a pair of 4-bit lookup tables, the former corresponding to 4 input points,
@@ -1001,7 +1001,7 @@ template <class Builder, class Fq, class Fr, class NativeGroup> class element {
         bool has_singleton;
     };
 
-    using batch_lookup_table = typename batch_lookup_table_plookup::type;
+    using batch_lookup_table = batch_lookup_table_plookup;
 };
 
 template <typename C, typename Fq, typename Fr, typename G>

--- a/barretenberg/cpp/src/barretenberg/stdlib/primitives/biggroup/biggroup.hpp
+++ b/barretenberg/cpp/src/barretenberg/stdlib/primitives/biggroup/biggroup.hpp
@@ -386,11 +386,11 @@ template <class Builder, class Fq, class Fr, class NativeGroup> class element {
   private:
     bool_ct _is_infinity;
 
-    template <size_t num_elements, typename = typename std::enable_if<HasPlookup<Builder>>>
+    template <size_t num_elements>
     static std::array<twin_rom_table<Builder>, 5> create_group_element_rom_tables(
         const std::array<element, num_elements>& elements, std::array<uint256_t, 8>& limb_max);
 
-    template <size_t num_elements, typename = typename std::enable_if<HasPlookup<Builder>>>
+    template <size_t num_elements>
     static element read_group_element_rom_tables(const std::array<twin_rom_table<Builder>, 5>& tables,
                                                  const field_t<Builder>& index,
                                                  const std::array<uint256_t, 8>& limb_max);
@@ -398,7 +398,7 @@ template <class Builder, class Fq, class Fr, class NativeGroup> class element {
     static std::pair<element, element> compute_offset_generators(const size_t num_rounds);
     static typename NativeGroup::affine_element compute_table_offset_generator();
 
-    template <typename = typename std::enable_if<HasPlookup<Builder>>> struct four_bit_table_plookup {
+    struct four_bit_table_plookup {
         four_bit_table_plookup(){};
         four_bit_table_plookup(const element& input);
 
@@ -412,7 +412,7 @@ template <class Builder, class Fq, class Fr, class NativeGroup> class element {
         std::array<uint256_t, 8> limb_max; // tracks the maximum limb size represented in each element_table entry
     };
 
-    template <typename = typename std::enable_if<HasPlookup<Builder>>> struct eight_bit_fixed_base_table {
+    struct eight_bit_fixed_base_table {
         enum CurveType { BN254, SECP256K1, SECP256R1 };
         eight_bit_fixed_base_table(const CurveType input_curve_type, bool use_endo)
             : curve_type(input_curve_type)
@@ -429,12 +429,11 @@ template <class Builder, class Fq, class Fr, class NativeGroup> class element {
         bool use_endomorphism;
     };
 
-    template <typename = typename std::enable_if<HasPlookup<Builder>>>
-    static std::pair<four_bit_table_plookup<>, four_bit_table_plookup<>> create_endo_pair_four_bit_table_plookup(
+    static std::pair<four_bit_table_plookup, four_bit_table_plookup> create_endo_pair_four_bit_table_plookup(
         const element& input)
     {
-        four_bit_table_plookup<> P1;
-        four_bit_table_plookup<> endoP1;
+        four_bit_table_plookup P1;
+        four_bit_table_plookup endoP1;
         element d2 = input.dbl();
 
         P1.element_table[8] = input;
@@ -455,8 +454,7 @@ template <class Builder, class Fq, class Fr, class NativeGroup> class element {
         }
         P1.coordinates = create_group_element_rom_tables<16>(P1.element_table, P1.limb_max);
         endoP1.coordinates = create_group_element_rom_tables<16>(endoP1.element_table, endoP1.limb_max);
-        auto result = std::make_pair<four_bit_table_plookup<>, four_bit_table_plookup<>>(
-            (four_bit_table_plookup<>)P1, (four_bit_table_plookup<>)endoP1);
+        auto result = std::make_pair(four_bit_table_plookup(P1), four_bit_table_plookup(endoP1));
         return result;
     }
 
@@ -508,7 +506,7 @@ template <class Builder, class Fq, class Fr, class NativeGroup> class element {
      *
      * Uses ROM tables to efficiently access lookup table
      **/
-    template <size_t length, typename = typename std::enable_if<HasPlookup<Builder>>> struct lookup_table_plookup {
+    template <size_t length> struct lookup_table_plookup {
         static constexpr size_t table_size = (1ULL << (length));
         lookup_table_plookup() {}
         lookup_table_plookup(const std::array<element, length>& inputs);
@@ -524,14 +522,11 @@ template <class Builder, class Fq, class Fr, class NativeGroup> class element {
         std::array<uint256_t, 8> limb_max;
     };
 
-    using twin_lookup_table =
-        typename std::conditional<HasPlookup<Builder>, lookup_table_plookup<2, void>, lookup_table_base<2>>::type;
+    using twin_lookup_table = typename lookup_table_plookup<2>::type;
 
-    using triple_lookup_table =
-        typename std::conditional<HasPlookup<Builder>, lookup_table_plookup<3, void>, lookup_table_base<3>>::type;
+    using triple_lookup_table = typename lookup_table_plookup<3>::type;
 
-    using quad_lookup_table =
-        typename std::conditional<HasPlookup<Builder>, lookup_table_plookup<4, void>, lookup_table_base<4>>::type;
+    using quad_lookup_table = typename lookup_table_plookup<4>::type;
 
     /**
      * Creates a pair of 4-bit lookup tables, the former corresponding to 4 input points,
@@ -544,23 +539,14 @@ template <class Builder, class Fq, class Fr, class NativeGroup> class element {
         quad_lookup_table endo_table;
         uint256_t beta_val = bb::field<typename Fq::TParams>::cube_root_of_unity();
         Fq beta(bb::fr(beta_val.slice(0, 136)), bb::fr(beta_val.slice(136, 256)), false);
-        if constexpr (HasPlookup<Builder>) {
-            for (size_t i = 0; i < 8; ++i) {
-                endo_table.element_table[i + 8].x = base_table[7 - i].x * beta;
-                endo_table.element_table[i + 8].y = base_table[7 - i].y;
+        for (size_t i = 0; i < 8; ++i) {
+            endo_table.element_table[i + 8].x = base_table[7 - i].x * beta;
+            endo_table.element_table[i + 8].y = base_table[7 - i].y;
 
-                endo_table.element_table[7 - i] = (-endo_table.element_table[i + 8]);
-            }
-
-            endo_table.coordinates = create_group_element_rom_tables<16>(endo_table.element_table, endo_table.limb_max);
-        } else {
-            std::array<element, 4> endo_inputs(inputs);
-            for (auto& input : endo_inputs) {
-                input.x *= beta;
-                input.y = -input.y;
-            }
-            endo_table = quad_lookup_table(endo_inputs);
+            endo_table.element_table[7 - i] = (-endo_table.element_table[i + 8]);
         }
+
+        endo_table.coordinates = create_group_element_rom_tables<16>(endo_table.element_table, endo_table.limb_max);
         return std::make_pair<quad_lookup_table, quad_lookup_table>((quad_lookup_table)base_table,
                                                                     (quad_lookup_table)endo_table);
     }
@@ -569,24 +555,22 @@ template <class Builder, class Fq, class Fr, class NativeGroup> class element {
      * Creates a pair of 5-bit lookup tables, the former corresponding to 5 input points,
      * the latter corresponding to the endomorphism equivalent of the 5 input points (e.g. x -> \beta * x, y -> -y)
      **/
-    template <typename X = typename std::enable_if<HasPlookup<Builder>>>
-    static std::pair<lookup_table_plookup<5, X>, lookup_table_plookup<5, X>> create_endo_pair_five_lookup_table(
+    static std::pair<lookup_table_plookup<5>, lookup_table_plookup<5>> create_endo_pair_five_lookup_table(
         const std::array<element, 5>& inputs)
     {
         lookup_table_plookup<5> base_table(inputs);
         lookup_table_plookup<5> endo_table;
         uint256_t beta_val = bb::field<typename Fq::TParams>::cube_root_of_unity();
         Fq beta(bb::fr(beta_val.slice(0, 136)), bb::fr(beta_val.slice(136, 256)), false);
-        if constexpr (HasPlookup<Builder>) {
-            for (size_t i = 0; i < 16; ++i) {
-                endo_table.element_table[i + 16].x = base_table[15 - i].x * beta;
-                endo_table.element_table[i + 16].y = base_table[15 - i].y;
+        for (size_t i = 0; i < 16; ++i) {
+            endo_table.element_table[i + 16].x = base_table[15 - i].x * beta;
+            endo_table.element_table[i + 16].y = base_table[15 - i].y;
 
-                endo_table.element_table[15 - i] = (-endo_table.element_table[i + 16]);
-            }
-
-            endo_table.coordinates = create_group_element_rom_tables<32>(endo_table.element_table, endo_table.limb_max);
+            endo_table.element_table[15 - i] = (-endo_table.element_table[i + 16]);
         }
+
+        endo_table.coordinates = create_group_element_rom_tables<32>(endo_table.element_table, endo_table.limb_max);
+
         return std::make_pair<lookup_table_plookup<5>, lookup_table_plookup<5>>((lookup_table_plookup<5>)base_table,
                                                                                 (lookup_table_plookup<5>)endo_table);
     }
@@ -596,7 +580,7 @@ template <class Builder, class Fq, class Fr, class NativeGroup> class element {
      *
      * Ultra version
      **/
-    template <typename X = typename std::enable_if<HasPlookup<Builder>>> struct batch_lookup_table_plookup {
+    struct batch_lookup_table_plookup {
         batch_lookup_table_plookup(const std::vector<element>& points)
         {
             num_points = points.size();
@@ -1017,8 +1001,7 @@ template <class Builder, class Fq, class Fr, class NativeGroup> class element {
         bool has_singleton;
     };
 
-    using batch_lookup_table =
-        typename std::conditional<HasPlookup<Builder>, batch_lookup_table_plookup<>, batch_lookup_table_base>::type;
+    using batch_lookup_table = typename batch_lookup_table_plookup::type;
 };
 
 template <typename C, typename Fq, typename Fr, typename G>

--- a/barretenberg/cpp/src/barretenberg/stdlib/primitives/biggroup/biggroup.test.cpp
+++ b/barretenberg/cpp/src/barretenberg/stdlib/primitives/biggroup/biggroup.test.cpp
@@ -7,8 +7,6 @@
 #include "barretenberg/numeric/random/engine.hpp"
 #include "barretenberg/stdlib/primitives/circuit_builders/circuit_builders.hpp"
 #include "barretenberg/stdlib/primitives/curves/bn254.hpp"
-#include "barretenberg/stdlib/primitives/curves/secp256k1.hpp"
-#include "barretenberg/stdlib/primitives/curves/secp256r1.hpp"
 #include "barretenberg/transcript/origin_tag.hpp"
 #include <vector>
 
@@ -1640,77 +1638,6 @@ template <typename TestType> class stdlib_biggroup : public testing::Test {
 
         EXPECT_CIRCUIT_CORRECTNESS(builder);
     };
-
-    static void test_wnaf_secp256k1()
-    {
-        Builder builder = Builder();
-        size_t num_repetitions = 1;
-        for (size_t i = 0; i < num_repetitions; ++i) {
-            fr scalar_a(fr::random_element());
-            if ((uint256_t(scalar_a).get_bit(0) & 1) == 1) {
-                scalar_a -= fr(1); // skew bit is 1
-            }
-            scalar_ct x_a = scalar_ct::from_witness(&builder, scalar_a);
-            element_ct::template compute_secp256k1_endo_wnaf<4, 0, 3>(x_a);
-            element_ct::template compute_secp256k1_endo_wnaf<4, 1, 2>(x_a);
-            element_ct::template compute_secp256k1_endo_wnaf<4, 2, 1>(x_a);
-            element_ct::template compute_secp256k1_endo_wnaf<4, 3, 0>(x_a);
-        }
-
-        EXPECT_CIRCUIT_CORRECTNESS(builder);
-    }
-
-    static void test_wnaf_8bit_secp256k1()
-    {
-        Builder builder = Builder();
-        size_t num_repetitions = 1;
-        for (size_t i = 0; i < num_repetitions; ++i) {
-            fr scalar_a(fr::random_element());
-            if ((uint256_t(scalar_a).get_bit(0) & 1) == 1) {
-                scalar_a -= fr(1); // skew bit is 1
-            }
-            scalar_ct x_a = scalar_ct::from_witness(&builder, scalar_a);
-            element_ct::template compute_secp256k1_endo_wnaf<8, 0, 3>(x_a);
-            element_ct::template compute_secp256k1_endo_wnaf<8, 1, 2>(x_a);
-            element_ct::template compute_secp256k1_endo_wnaf<8, 2, 1>(x_a);
-            element_ct::template compute_secp256k1_endo_wnaf<8, 3, 0>(x_a);
-        }
-
-        EXPECT_CIRCUIT_CORRECTNESS(builder);
-    }
-
-    static void test_ecdsa_mul_secp256k1()
-    {
-        Builder builder = Builder();
-        size_t num_repetitions = 1;
-        for (size_t i = 0; i < num_repetitions; ++i) {
-            fr scalar_a(fr::random_element());
-            fr scalar_b(fr::random_element());
-            fr scalar_c(fr::random_element());
-            if ((uint256_t(scalar_a).get_bit(0) & 1) == 1) {
-                scalar_a -= fr(1); // skew bit is 1
-            }
-            element_ct P_a = element_ct::from_witness(&builder, g1::one * scalar_c);
-            scalar_ct u1 = scalar_ct::from_witness(&builder, scalar_a);
-            scalar_ct u2 = scalar_ct::from_witness(&builder, scalar_b);
-
-            fr alo;
-            fr ahi;
-            fr blo;
-            fr bhi;
-
-            fr::split_into_endomorphism_scalars(scalar_a.from_montgomery_form(), alo, ahi);
-            fr::split_into_endomorphism_scalars(scalar_b.from_montgomery_form(), blo, bhi);
-
-            auto output = element_ct::secp256k1_ecdsa_mul(P_a, u1, u2);
-
-            auto expected = affine_element(g1::one * (scalar_c * scalar_b) + g1::one * scalar_a);
-            EXPECT_EQ(output.x.get_value().lo, uint256_t(expected.x));
-            EXPECT_EQ(output.y.get_value().lo, uint256_t(expected.y));
-        }
-
-        EXPECT_CIRCUIT_CORRECTNESS(builder);
-    }
 };
 
 enum UseBigfield { No, Yes };
@@ -1966,32 +1893,6 @@ HEAVY_TYPED_TEST(stdlib_biggroup, mixed_mul_bn254_endo)
         } else {
             TestFixture::test_mixed_mul_bn254_endo();
         };
-    } else {
-        GTEST_SKIP();
-    }
-}
-
-/* The following tests are specific to SECP256k1 */
-HEAVY_TYPED_TEST(stdlib_biggroup, wnaf_secp256k1)
-{
-    if constexpr (TypeParam::Curve::type == CurveType::SECP256K1) {
-        TestFixture::test_wnaf_secp256k1();
-    } else {
-        GTEST_SKIP();
-    }
-}
-HEAVY_TYPED_TEST(stdlib_biggroup, wnaf_8bit_secp256k1)
-{
-    if constexpr (TypeParam::Curve::type == CurveType::SECP256K1) {
-        TestFixture::test_wnaf_8bit_secp256k1();
-    } else {
-        GTEST_SKIP();
-    }
-}
-HEAVY_TYPED_TEST(stdlib_biggroup, ecdsa_mul_secp256k1)
-{
-    if constexpr (TypeParam::Curve::type == CurveType::SECP256K1) {
-        TestFixture::test_ecdsa_mul_secp256k1();
     } else {
         GTEST_SKIP();
     }

--- a/barretenberg/cpp/src/barretenberg/stdlib/primitives/biggroup/biggroup.test.cpp
+++ b/barretenberg/cpp/src/barretenberg/stdlib/primitives/biggroup/biggroup.test.cpp
@@ -1800,37 +1800,28 @@ HEAVY_TYPED_TEST(stdlib_biggroup, compute_naf)
 /* These tests only work for Ultra Circuit Constructor */
 HEAVY_TYPED_TEST(stdlib_biggroup, wnaf_batch_mul)
 {
-    if constexpr (HasPlookup<typename TypeParam::Curve::Builder>) {
-        if constexpr (TypeParam::Curve::type == CurveType::BN254 && HasGoblinBuilder<TypeParam>) {
-            GTEST_SKIP();
-        } else {
-            TestFixture::test_compute_wnaf();
-        };
-    } else {
+    if constexpr (TypeParam::Curve::type == CurveType::BN254 && HasGoblinBuilder<TypeParam>) {
         GTEST_SKIP();
-    }
+    } else {
+        TestFixture::test_compute_wnaf();
+    };
 }
 
 /* These tests only work for Ultra Circuit Constructor */
 HEAVY_TYPED_TEST(stdlib_biggroup, wnaf_batch_mul_edge_cases)
 {
-    if constexpr (HasPlookup<typename TypeParam::Curve::Builder>) {
-        if constexpr (TypeParam::Curve::type == CurveType::BN254 && HasGoblinBuilder<TypeParam>) {
-            GTEST_SKIP();
-        } else {
-            TestFixture::test_compute_wnaf();
-        };
-    } else {
+    if constexpr (TypeParam::Curve::type == CurveType::BN254 && HasGoblinBuilder<TypeParam>) {
         GTEST_SKIP();
-    }
+    } else {
+        TestFixture::test_compute_wnaf();
+    };
 }
 
 /* the following test was only developed as a test of Ultra Circuit Constructor. It fails for Standard in the
    case where Fr is a bigfield. */
 HEAVY_TYPED_TEST(stdlib_biggroup, compute_wnaf)
 {
-    if constexpr ((!HasPlookup<typename TypeParam::Curve::Builder> && TypeParam::use_bigfield) ||
-                  (TypeParam::Curve::type == CurveType::BN254 && HasGoblinBuilder<TypeParam>)) {
+    if constexpr (TypeParam::Curve::type == CurveType::BN254 && HasGoblinBuilder<TypeParam>) {
         GTEST_SKIP();
     } else {
         TestFixture::test_compute_wnaf();

--- a/barretenberg/cpp/src/barretenberg/stdlib/primitives/biggroup/biggroup.test.cpp
+++ b/barretenberg/cpp/src/barretenberg/stdlib/primitives/biggroup/biggroup.test.cpp
@@ -1990,8 +1990,7 @@ HEAVY_TYPED_TEST(stdlib_biggroup, wnaf_8bit_secp256k1)
 }
 HEAVY_TYPED_TEST(stdlib_biggroup, ecdsa_mul_secp256k1)
 {
-    // TODO(suyash): temporary hasplookup, remove once we get ecdsa tests working.
-    if constexpr (HasPlookup<typename TypeParam::Curve::Builder> && TypeParam::Curve::type == CurveType::SECP256K1) {
+    if constexpr (TypeParam::Curve::type == CurveType::SECP256K1) {
         TestFixture::test_ecdsa_mul_secp256k1();
     } else {
         GTEST_SKIP();

--- a/barretenberg/cpp/src/barretenberg/stdlib/primitives/biggroup/biggroup.test.cpp
+++ b/barretenberg/cpp/src/barretenberg/stdlib/primitives/biggroup/biggroup.test.cpp
@@ -1990,7 +1990,8 @@ HEAVY_TYPED_TEST(stdlib_biggroup, wnaf_8bit_secp256k1)
 }
 HEAVY_TYPED_TEST(stdlib_biggroup, ecdsa_mul_secp256k1)
 {
-    if constexpr (TypeParam::Curve::type == CurveType::SECP256K1) {
+    // TODO(suyash): temporary hasplookup, remove once we get ecdsa tests working.
+    if constexpr (HasPlookup<typename TypeParam::Curve::Builder> && TypeParam::Curve::type == CurveType::SECP256K1) {
         TestFixture::test_ecdsa_mul_secp256k1();
     } else {
         GTEST_SKIP();

--- a/barretenberg/cpp/src/barretenberg/stdlib/primitives/biggroup/biggroup_batch_mul.hpp
+++ b/barretenberg/cpp/src/barretenberg/stdlib/primitives/biggroup/biggroup_batch_mul.hpp
@@ -13,9 +13,7 @@ namespace bb::stdlib::element_default {
 /**
  * @brief Multiscalar multiplication that utilizes 4-bit wNAF lookup tables.
  * @details This is more efficient than points-as-linear-combinations lookup tables, if the number of points is 3 or
- * fewer. Only works for Plookup (otherwise falls back on batch_mul)!
- * @todo : TODO(https://github.com/AztecProtocol/barretenberg/issues/1001) when we nuke standard and turbo plonk we
- * should remove the fallback batch mul method!
+ * fewer.
  */
 template <typename C, class Fq, class Fr, class G>
 template <size_t max_num_bits>
@@ -24,9 +22,6 @@ element<C, Fq, Fr, G> element<C, Fq, Fr, G>::wnaf_batch_mul(const std::vector<el
 {
     constexpr size_t WNAF_SIZE = 4;
     ASSERT(_points.size() == _scalars.size());
-    if constexpr (!HasPlookup<C>) {
-        return batch_mul(_points, _scalars, max_num_bits);
-    }
 
     const auto [points, scalars] = handle_points_at_infinity(_points, _scalars);
 

--- a/barretenberg/cpp/src/barretenberg/stdlib/primitives/biggroup/biggroup_batch_mul.hpp
+++ b/barretenberg/cpp/src/barretenberg/stdlib/primitives/biggroup/biggroup_batch_mul.hpp
@@ -25,9 +25,9 @@ element<C, Fq, Fr, G> element<C, Fq, Fr, G>::wnaf_batch_mul(const std::vector<el
 
     const auto [points, scalars] = handle_points_at_infinity(_points, _scalars);
 
-    std::vector<four_bit_table_plookup<>> point_tables;
+    std::vector<four_bit_table_plookup> point_tables;
     for (const auto& point : points) {
-        point_tables.emplace_back(four_bit_table_plookup<>(point));
+        point_tables.emplace_back(four_bit_table_plookup(point));
     }
 
     std::vector<std::vector<field_t<C>>> wnaf_entries;

--- a/barretenberg/cpp/src/barretenberg/stdlib/primitives/biggroup/biggroup_bn254.hpp
+++ b/barretenberg/cpp/src/barretenberg/stdlib/primitives/biggroup/biggroup_bn254.hpp
@@ -82,9 +82,9 @@ element<C, Fq, Fr, G> element<C, Fq, Fr, G>::bn254_endo_batch_mul_with_generator
     const std::vector<field_t<C>> generator_wnaf = compute_wnaf<128, 8>(generator_k1);
     const std::vector<field_t<C>> generator_endo_wnaf = compute_wnaf<128, 8>(generator_k2);
     const auto generator_table =
-        element::eight_bit_fixed_base_table<>(element::eight_bit_fixed_base_table<>::CurveType::BN254, false);
+        element::eight_bit_fixed_base_table(element::eight_bit_fixed_base_table::CurveType::BN254, false);
     const auto generator_endo_table =
-        element::eight_bit_fixed_base_table<>(element::eight_bit_fixed_base_table<>::CurveType::BN254, true);
+        element::eight_bit_fixed_base_table(element::eight_bit_fixed_base_table::CurveType::BN254, true);
 
     for (size_t i = 0; i < small_points.size(); ++i) {
         small_naf_entries.emplace_back(compute_naf(small_scalars[i], max_num_small_bits));

--- a/barretenberg/cpp/src/barretenberg/stdlib/primitives/biggroup/biggroup_bn254.hpp
+++ b/barretenberg/cpp/src/barretenberg/stdlib/primitives/biggroup/biggroup_bn254.hpp
@@ -47,170 +47,157 @@ element<C, Fq, Fr, G> element<C, Fq, Fr, G>::bn254_endo_batch_mul_with_generator
             break;
         }
     }
-    if constexpr (!HasPlookup<C>) {
-        // MERGENOTE: these four lines don't have an equivalent in d-b-p
-        std::vector<element> modified_big_points = big_points;
-        std::vector<Fr> modified_big_scalars = big_scalars;
-        modified_big_points.emplace_back(element::one(ctx));
-        modified_big_scalars.emplace_back(generator_scalar);
-        return bn254_endo_batch_mul(
-            modified_big_points, modified_big_scalars, small_points, small_scalars, max_num_small_bits);
-    } else {
-        constexpr size_t NUM_BIG_POINTS = 4;
-        // TODO: handle situation where big points size is not 4 :/
 
-        auto big_table_pair =
-            create_endo_pair_quad_lookup_table({ big_points[0], big_points[1], big_points[2], big_points[3] });
-        auto& big_table = big_table_pair.first;
-        auto& endo_table = big_table_pair.second;
-        batch_lookup_table small_table(small_points);
-        std::vector<std::vector<bool_ct>> big_naf_entries;
-        std::vector<std::vector<bool_ct>> endo_naf_entries;
-        std::vector<std::vector<bool_ct>> small_naf_entries;
+    constexpr size_t NUM_BIG_POINTS = 4;
+    // TODO: handle situation where big points size is not 4 :/
 
-        const auto split_into_endomorphism_scalars = [ctx](const Fr& scalar) {
-            bb::fr k = scalar.get_value();
-            bb::fr k1(0);
-            bb::fr k2(0);
-            bb::fr::split_into_endomorphism_scalars(k.from_montgomery_form(), k1, k2);
-            Fr scalar_k1 = Fr::from_witness(ctx, k1.to_montgomery_form());
-            Fr scalar_k2 = Fr::from_witness(ctx, k2.to_montgomery_form());
-            bb::fr beta = bb::fr::cube_root_of_unity();
-            scalar.assert_equal(scalar_k1 - scalar_k2 * beta);
-            return std::make_pair<Fr, Fr>((Fr)scalar_k1, (Fr)scalar_k2);
-        };
+    auto big_table_pair =
+        create_endo_pair_quad_lookup_table({ big_points[0], big_points[1], big_points[2], big_points[3] });
+    auto& big_table = big_table_pair.first;
+    auto& endo_table = big_table_pair.second;
+    batch_lookup_table small_table(small_points);
+    std::vector<std::vector<bool_ct>> big_naf_entries;
+    std::vector<std::vector<bool_ct>> endo_naf_entries;
+    std::vector<std::vector<bool_ct>> small_naf_entries;
 
-        for (size_t i = 0; i < NUM_BIG_POINTS; ++i) {
-            const auto [scalar_k1, scalar_k2] = split_into_endomorphism_scalars(big_scalars[i]);
-            big_naf_entries.emplace_back(compute_naf(scalar_k1, max_num_small_bits));
-            endo_naf_entries.emplace_back(compute_naf(scalar_k2, max_num_small_bits));
-        }
+    const auto split_into_endomorphism_scalars = [ctx](const Fr& scalar) {
+        bb::fr k = scalar.get_value();
+        bb::fr k1(0);
+        bb::fr k2(0);
+        bb::fr::split_into_endomorphism_scalars(k.from_montgomery_form(), k1, k2);
+        Fr scalar_k1 = Fr::from_witness(ctx, k1.to_montgomery_form());
+        Fr scalar_k2 = Fr::from_witness(ctx, k2.to_montgomery_form());
+        bb::fr beta = bb::fr::cube_root_of_unity();
+        scalar.assert_equal(scalar_k1 - scalar_k2 * beta);
+        return std::make_pair<Fr, Fr>((Fr)scalar_k1, (Fr)scalar_k2);
+    };
 
-        const auto [generator_k1, generator_k2] = split_into_endomorphism_scalars(generator_scalar);
-        const std::vector<field_t<C>> generator_wnaf = compute_wnaf<128, 8>(generator_k1);
-        const std::vector<field_t<C>> generator_endo_wnaf = compute_wnaf<128, 8>(generator_k2);
-        const auto generator_table =
-            element::eight_bit_fixed_base_table<>(element::eight_bit_fixed_base_table<>::CurveType::BN254, false);
-        const auto generator_endo_table =
-            element::eight_bit_fixed_base_table<>(element::eight_bit_fixed_base_table<>::CurveType::BN254, true);
-
-        for (size_t i = 0; i < small_points.size(); ++i) {
-            small_naf_entries.emplace_back(compute_naf(small_scalars[i], max_num_small_bits));
-        }
-
-        const size_t num_rounds = max_num_small_bits;
-
-        const auto offset_generators = compute_offset_generators(num_rounds);
-
-        auto init_point = element::chain_add(offset_generators.first, small_table.get_chain_initial_entry());
-        init_point = element::chain_add(endo_table[0], init_point);
-        init_point = element::chain_add(big_table[0], init_point);
-
-        element accumulator = element::chain_add_end(init_point);
-
-        const auto get_point_to_add = [&](size_t naf_index) {
-            std::vector<bool_ct> small_nafs;
-            std::vector<bool_ct> big_nafs;
-            std::vector<bool_ct> endo_nafs;
-            for (size_t i = 0; i < small_points.size(); ++i) {
-                small_nafs.emplace_back(small_naf_entries[i][naf_index]);
-            }
-            for (size_t i = 0; i < NUM_BIG_POINTS; ++i) {
-                big_nafs.emplace_back(big_naf_entries[i][naf_index]);
-                endo_nafs.emplace_back(endo_naf_entries[i][naf_index]);
-            }
-
-            auto to_add = small_table.get_chain_add_accumulator(small_nafs);
-            to_add = element::chain_add(big_table.get({ big_nafs[0], big_nafs[1], big_nafs[2], big_nafs[3] }), to_add);
-            to_add =
-                element::chain_add(endo_table.get({ endo_nafs[0], endo_nafs[1], endo_nafs[2], endo_nafs[3] }), to_add);
-            return to_add;
-        };
-
-        // Perform multiple rounds of the montgomery ladder algoritm per "iteration" of our main loop.
-        // This is in order to reduce the number of field reductions required when calling `multiple_montgomery_ladder`
-        constexpr size_t num_rounds_per_iteration = 4;
-
-        // we require that we perform max of one generator per iteration
-        static_assert(num_rounds_per_iteration < 8);
-
-        size_t num_iterations = num_rounds / num_rounds_per_iteration;
-        num_iterations += ((num_iterations * num_rounds_per_iteration) == num_rounds) ? 0 : 1;
-        const size_t num_rounds_per_final_iteration =
-            (num_rounds - 1) - ((num_iterations - 1) * num_rounds_per_iteration);
-
-        size_t generator_idx = 0;
-        for (size_t i = 0; i < num_iterations; ++i) {
-
-            const size_t inner_num_rounds =
-                (i != num_iterations - 1) ? num_rounds_per_iteration : num_rounds_per_final_iteration;
-            std::vector<element::chain_add_accumulator> to_add;
-
-            for (size_t j = 0; j < inner_num_rounds; ++j) {
-                to_add.emplace_back(get_point_to_add(i * num_rounds_per_iteration + j + 1));
-            }
-
-            bool add_generator_this_round = false;
-            size_t add_idx = 0;
-            for (size_t j = 0; j < inner_num_rounds; ++j) {
-                add_generator_this_round = ((i * num_rounds_per_iteration + j) % 8) == 6;
-                if (add_generator_this_round) {
-                    add_idx = j;
-                    break;
-                }
-            }
-            if (add_generator_this_round) {
-                to_add[add_idx] = element::chain_add(generator_table[generator_wnaf[generator_idx]], to_add[add_idx]);
-                to_add[add_idx] =
-                    element::chain_add(generator_endo_table[generator_endo_wnaf[generator_idx]], to_add[add_idx]);
-                generator_idx++;
-            }
-            accumulator = accumulator.multiple_montgomery_ladder(to_add);
-        }
-
-        for (size_t i = 0; i < small_points.size(); ++i) {
-            element skew = accumulator - small_points[i];
-            Fq out_x = accumulator.x.conditional_select(skew.x, small_naf_entries[i][num_rounds]);
-            Fq out_y = accumulator.y.conditional_select(skew.y, small_naf_entries[i][num_rounds]);
-            accumulator = element(out_x, out_y);
-        }
-
-        uint256_t beta_val = bb::field<typename Fq::TParams>::cube_root_of_unity();
-        Fq beta(bb::fr(beta_val.slice(0, 136)), bb::fr(beta_val.slice(136, 256)), false);
-
-        for (size_t i = 0; i < NUM_BIG_POINTS; ++i) {
-            element skew_point = big_points[i];
-            skew_point.x *= beta;
-            element skew = accumulator + skew_point;
-            Fq out_x = accumulator.x.conditional_select(skew.x, endo_naf_entries[i][num_rounds]);
-            Fq out_y = accumulator.y.conditional_select(skew.y, endo_naf_entries[i][num_rounds]);
-            accumulator = element(out_x, out_y);
-        }
-        {
-            element skew = accumulator - generator_table[128];
-            Fq out_x = accumulator.x.conditional_select(skew.x, bool_ct(generator_wnaf[generator_wnaf.size() - 1]));
-            Fq out_y = accumulator.y.conditional_select(skew.y, bool_ct(generator_wnaf[generator_wnaf.size() - 1]));
-            accumulator = element(out_x, out_y);
-        }
-        {
-            element skew = accumulator - generator_endo_table[128];
-            Fq out_x =
-                accumulator.x.conditional_select(skew.x, bool_ct(generator_endo_wnaf[generator_wnaf.size() - 1]));
-            Fq out_y =
-                accumulator.y.conditional_select(skew.y, bool_ct(generator_endo_wnaf[generator_wnaf.size() - 1]));
-            accumulator = element(out_x, out_y);
-        }
-
-        for (size_t i = 0; i < NUM_BIG_POINTS; ++i) {
-            element skew = accumulator - big_points[i];
-            Fq out_x = accumulator.x.conditional_select(skew.x, big_naf_entries[i][num_rounds]);
-            Fq out_y = accumulator.y.conditional_select(skew.y, big_naf_entries[i][num_rounds]);
-            accumulator = element(out_x, out_y);
-        }
-        accumulator = accumulator - offset_generators.second;
-
-        return accumulator;
+    for (size_t i = 0; i < NUM_BIG_POINTS; ++i) {
+        const auto [scalar_k1, scalar_k2] = split_into_endomorphism_scalars(big_scalars[i]);
+        big_naf_entries.emplace_back(compute_naf(scalar_k1, max_num_small_bits));
+        endo_naf_entries.emplace_back(compute_naf(scalar_k2, max_num_small_bits));
     }
+
+    const auto [generator_k1, generator_k2] = split_into_endomorphism_scalars(generator_scalar);
+    const std::vector<field_t<C>> generator_wnaf = compute_wnaf<128, 8>(generator_k1);
+    const std::vector<field_t<C>> generator_endo_wnaf = compute_wnaf<128, 8>(generator_k2);
+    const auto generator_table =
+        element::eight_bit_fixed_base_table<>(element::eight_bit_fixed_base_table<>::CurveType::BN254, false);
+    const auto generator_endo_table =
+        element::eight_bit_fixed_base_table<>(element::eight_bit_fixed_base_table<>::CurveType::BN254, true);
+
+    for (size_t i = 0; i < small_points.size(); ++i) {
+        small_naf_entries.emplace_back(compute_naf(small_scalars[i], max_num_small_bits));
+    }
+
+    const size_t num_rounds = max_num_small_bits;
+
+    const auto offset_generators = compute_offset_generators(num_rounds);
+
+    auto init_point = element::chain_add(offset_generators.first, small_table.get_chain_initial_entry());
+    init_point = element::chain_add(endo_table[0], init_point);
+    init_point = element::chain_add(big_table[0], init_point);
+
+    element accumulator = element::chain_add_end(init_point);
+
+    const auto get_point_to_add = [&](size_t naf_index) {
+        std::vector<bool_ct> small_nafs;
+        std::vector<bool_ct> big_nafs;
+        std::vector<bool_ct> endo_nafs;
+        for (size_t i = 0; i < small_points.size(); ++i) {
+            small_nafs.emplace_back(small_naf_entries[i][naf_index]);
+        }
+        for (size_t i = 0; i < NUM_BIG_POINTS; ++i) {
+            big_nafs.emplace_back(big_naf_entries[i][naf_index]);
+            endo_nafs.emplace_back(endo_naf_entries[i][naf_index]);
+        }
+
+        auto to_add = small_table.get_chain_add_accumulator(small_nafs);
+        to_add = element::chain_add(big_table.get({ big_nafs[0], big_nafs[1], big_nafs[2], big_nafs[3] }), to_add);
+        to_add = element::chain_add(endo_table.get({ endo_nafs[0], endo_nafs[1], endo_nafs[2], endo_nafs[3] }), to_add);
+        return to_add;
+    };
+
+    // Perform multiple rounds of the montgomery ladder algoritm per "iteration" of our main loop.
+    // This is in order to reduce the number of field reductions required when calling `multiple_montgomery_ladder`
+    constexpr size_t num_rounds_per_iteration = 4;
+
+    // we require that we perform max of one generator per iteration
+    static_assert(num_rounds_per_iteration < 8);
+
+    size_t num_iterations = num_rounds / num_rounds_per_iteration;
+    num_iterations += ((num_iterations * num_rounds_per_iteration) == num_rounds) ? 0 : 1;
+    const size_t num_rounds_per_final_iteration = (num_rounds - 1) - ((num_iterations - 1) * num_rounds_per_iteration);
+
+    size_t generator_idx = 0;
+    for (size_t i = 0; i < num_iterations; ++i) {
+
+        const size_t inner_num_rounds =
+            (i != num_iterations - 1) ? num_rounds_per_iteration : num_rounds_per_final_iteration;
+        std::vector<element::chain_add_accumulator> to_add;
+
+        for (size_t j = 0; j < inner_num_rounds; ++j) {
+            to_add.emplace_back(get_point_to_add(i * num_rounds_per_iteration + j + 1));
+        }
+
+        bool add_generator_this_round = false;
+        size_t add_idx = 0;
+        for (size_t j = 0; j < inner_num_rounds; ++j) {
+            add_generator_this_round = ((i * num_rounds_per_iteration + j) % 8) == 6;
+            if (add_generator_this_round) {
+                add_idx = j;
+                break;
+            }
+        }
+        if (add_generator_this_round) {
+            to_add[add_idx] = element::chain_add(generator_table[generator_wnaf[generator_idx]], to_add[add_idx]);
+            to_add[add_idx] =
+                element::chain_add(generator_endo_table[generator_endo_wnaf[generator_idx]], to_add[add_idx]);
+            generator_idx++;
+        }
+        accumulator = accumulator.multiple_montgomery_ladder(to_add);
+    }
+
+    for (size_t i = 0; i < small_points.size(); ++i) {
+        element skew = accumulator - small_points[i];
+        Fq out_x = accumulator.x.conditional_select(skew.x, small_naf_entries[i][num_rounds]);
+        Fq out_y = accumulator.y.conditional_select(skew.y, small_naf_entries[i][num_rounds]);
+        accumulator = element(out_x, out_y);
+    }
+
+    uint256_t beta_val = bb::field<typename Fq::TParams>::cube_root_of_unity();
+    Fq beta(bb::fr(beta_val.slice(0, 136)), bb::fr(beta_val.slice(136, 256)), false);
+
+    for (size_t i = 0; i < NUM_BIG_POINTS; ++i) {
+        element skew_point = big_points[i];
+        skew_point.x *= beta;
+        element skew = accumulator + skew_point;
+        Fq out_x = accumulator.x.conditional_select(skew.x, endo_naf_entries[i][num_rounds]);
+        Fq out_y = accumulator.y.conditional_select(skew.y, endo_naf_entries[i][num_rounds]);
+        accumulator = element(out_x, out_y);
+    }
+    {
+        element skew = accumulator - generator_table[128];
+        Fq out_x = accumulator.x.conditional_select(skew.x, bool_ct(generator_wnaf[generator_wnaf.size() - 1]));
+        Fq out_y = accumulator.y.conditional_select(skew.y, bool_ct(generator_wnaf[generator_wnaf.size() - 1]));
+        accumulator = element(out_x, out_y);
+    }
+    {
+        element skew = accumulator - generator_endo_table[128];
+        Fq out_x = accumulator.x.conditional_select(skew.x, bool_ct(generator_endo_wnaf[generator_wnaf.size() - 1]));
+        Fq out_y = accumulator.y.conditional_select(skew.y, bool_ct(generator_endo_wnaf[generator_wnaf.size() - 1]));
+        accumulator = element(out_x, out_y);
+    }
+
+    for (size_t i = 0; i < NUM_BIG_POINTS; ++i) {
+        element skew = accumulator - big_points[i];
+        Fq out_x = accumulator.x.conditional_select(skew.x, big_naf_entries[i][num_rounds]);
+        Fq out_y = accumulator.y.conditional_select(skew.y, big_naf_entries[i][num_rounds]);
+        accumulator = element(out_x, out_y);
+    }
+    accumulator = accumulator - offset_generators.second;
+
+    return accumulator;
 }
 
 /**

--- a/barretenberg/cpp/src/barretenberg/stdlib/primitives/biggroup/biggroup_nafs.hpp
+++ b/barretenberg/cpp/src/barretenberg/stdlib/primitives/biggroup/biggroup_nafs.hpp
@@ -383,21 +383,14 @@ std::vector<field_t<C>> element<C, Fq, Fr, G>::compute_wnaf(const Fr& scalar)
             offset_entry = (1ULL << (WNAF_SIZE - 1)) - 1 - (wnaf_values[i] & 0xffffff);
         }
         field_t<C> entry(witness_t<C>(ctx, offset_entry));
-        if constexpr (HasPlookup<C>) {
-            ctx->create_new_range_constraint(entry.witness_index, 1ULL << (WNAF_SIZE), "biggroup_nafs");
-        } else {
-            ctx->create_range_constraint(entry.witness_index, WNAF_SIZE, "biggroup_nafs");
-        }
+        ctx->create_new_range_constraint(entry.witness_index, 1ULL << (WNAF_SIZE), "biggroup_nafs");
+
         wnaf_entries.emplace_back(entry);
     }
 
     // add skew
     wnaf_entries.emplace_back(witness_t<C>(ctx, skew));
-    if constexpr (HasPlookup<C>) {
-        ctx->create_new_range_constraint(wnaf_entries[wnaf_entries.size() - 1].witness_index, 1, "biggroup_nafs");
-    } else {
-        ctx->create_range_constraint(wnaf_entries[wnaf_entries.size() - 1].witness_index, 1, "biggroup_nafs");
-    }
+    ctx->create_new_range_constraint(wnaf_entries[wnaf_entries.size() - 1].witness_index, 1, "biggroup_nafs");
 
     // TODO(https://github.com/AztecProtocol/barretenberg/issues/664)
     // VALIDATE SUM DOES NOT OVERFLOW P
@@ -521,25 +514,17 @@ std::vector<bool_t<C>> element<C, Fq, Fr, G>::compute_naf(const Fr& scalar, cons
             bit.context = ctx;
             bit.witness_index = witness_t<C>(ctx, true).witness_index; // flip sign
             bit.witness_bool = true;
-            if constexpr (HasPlookup<C>) {
-                ctx->create_new_range_constraint(
-                    bit.witness_index, 1, "biggroup_nafs: compute_naf extracted too many bits in non-next_entry case");
-            } else {
-                ctx->create_range_constraint(
-                    bit.witness_index, 1, "biggroup_nafs: compute_naf extracted too many bits in non-next_entry case");
-            }
+            ctx->create_new_range_constraint(
+                bit.witness_index, 1, "biggroup_nafs: compute_naf extracted too many bits in non-next_entry case");
+
             naf_entries[num_rounds - i - 1] = bit;
         } else {
             bool_ct bit(ctx, false);
             bit.witness_index = witness_t<C>(ctx, false).witness_index; // don't flip sign
             bit.witness_bool = false;
-            if constexpr (HasPlookup<C>) {
-                ctx->create_new_range_constraint(
-                    bit.witness_index, 1, "biggroup_nafs: compute_naf extracted too many bits in next_entry case");
-            } else {
-                ctx->create_range_constraint(
-                    bit.witness_index, 1, "biggroup_nafs: compute_naf extracted too many bits in next_entry case");
-            }
+            ctx->create_new_range_constraint(
+                bit.witness_index, 1, "biggroup_nafs: compute_naf extracted too many bits in next_entry case");
+
             naf_entries[num_rounds - i - 1] = bit;
         }
         // We need to manually propagate the origin tag

--- a/barretenberg/cpp/src/barretenberg/stdlib/primitives/biggroup/biggroup_nafs.hpp
+++ b/barretenberg/cpp/src/barretenberg/stdlib/primitives/biggroup/biggroup_nafs.hpp
@@ -249,15 +249,9 @@ typename element<C, Fq, Fr, G>::secp256k1_wnaf_pair element<C, Fq, Fr, G>::compu
         // Compute and constrain skews
         field_t<C> negative_skew = witness_t<C>(ctx, is_negative ? 0 : skew);
         field_t<C> positive_skew = witness_t<C>(ctx, is_negative ? skew : 0);
-        if constexpr (HasPlookup<C>) {
-            ctx->create_new_range_constraint(negative_skew.witness_index, 1, "biggroup_nafs");
-            ctx->create_new_range_constraint(positive_skew.witness_index, 1, "biggroup_nafs");
-            ctx->create_new_range_constraint((negative_skew + positive_skew).witness_index, 1, "biggroup_nafs");
-        } else {
-            ctx->create_range_constraint(negative_skew.witness_index, 1, "biggroup_nafs");
-            ctx->create_range_constraint(positive_skew.witness_index, 1, "biggroup_nafs");
-            ctx->create_range_constraint((negative_skew + positive_skew).witness_index, 1, "biggroup_nafs");
-        }
+        ctx->create_new_range_constraint(negative_skew.witness_index, 1, "biggroup_nafs");
+        ctx->create_new_range_constraint(positive_skew.witness_index, 1, "biggroup_nafs");
+        ctx->create_new_range_constraint((negative_skew + positive_skew).witness_index, 1, "biggroup_nafs");
 
         const auto reconstruct_bigfield_from_wnaf = [ctx](const std::vector<field_t<C>>& wnaf,
                                                           const field_t<C>& positive_skew,

--- a/barretenberg/cpp/src/barretenberg/stdlib/primitives/biggroup/biggroup_secp256k1.hpp
+++ b/barretenberg/cpp/src/barretenberg/stdlib/primitives/biggroup/biggroup_secp256k1.hpp
@@ -18,10 +18,6 @@ template <typename C, class Fq, class Fr, class G>
 template <typename, typename>
 element<C, Fq, Fr, G> element<C, Fq, Fr, G>::secp256k1_ecdsa_mul(const element& pubkey, const Fr& u1, const Fr& u2)
 {
-    if constexpr (!HasPlookup<C>) {
-        C* ctx = pubkey.get_context();
-        return batch_mul({ element::one(ctx), pubkey }, { u1, u2 });
-    }
     /**
      * Compute `out = u1.[1] + u2.[pubkey]
      *

--- a/barretenberg/cpp/src/barretenberg/stdlib/primitives/biggroup/biggroup_secp256k1.hpp
+++ b/barretenberg/cpp/src/barretenberg/stdlib/primitives/biggroup/biggroup_secp256k1.hpp
@@ -53,9 +53,9 @@ element<C, Fq, Fr, G> element<C, Fq, Fr, G>::secp256k1_ecdsa_mul(const element& 
     auto P1 = element::one(pubkey.get_context());
     auto P2 = pubkey;
     const auto P1_table =
-        element::eight_bit_fixed_base_table<>(element::eight_bit_fixed_base_table<>::CurveType::SECP256K1, false);
+        element::eight_bit_fixed_base_table(element::eight_bit_fixed_base_table::CurveType::SECP256K1, false);
     const auto endoP1_table =
-        element::eight_bit_fixed_base_table<>(element::eight_bit_fixed_base_table<>::CurveType::SECP256K1, true);
+        element::eight_bit_fixed_base_table(element::eight_bit_fixed_base_table::CurveType::SECP256K1, true);
     const auto [P2_table, endoP2_table] = create_endo_pair_four_bit_table_plookup(P2);
 
     // Initialize our accumulator

--- a/barretenberg/cpp/src/barretenberg/stdlib/primitives/biggroup/biggroup_secp256k1.test.cpp
+++ b/barretenberg/cpp/src/barretenberg/stdlib/primitives/biggroup/biggroup_secp256k1.test.cpp
@@ -1,0 +1,135 @@
+#include "../bigfield/bigfield.hpp"
+#include "../biggroup/biggroup.hpp"
+#include "../bool/bool.hpp"
+#include "../field/field.hpp"
+#include "barretenberg/circuit_checker/circuit_checker.hpp"
+#include "barretenberg/common/test.hpp"
+#include "barretenberg/numeric/random/engine.hpp"
+#include "barretenberg/stdlib/primitives/circuit_builders/circuit_builders.hpp"
+#include "barretenberg/stdlib/primitives/circuit_builders/circuit_builders_fwd.hpp"
+#include "barretenberg/stdlib/primitives/curves/bn254.hpp"
+#include "barretenberg/stdlib/primitives/curves/secp256k1.hpp"
+#include "barretenberg/stdlib/primitives/curves/secp256r1.hpp"
+#include "barretenberg/transcript/origin_tag.hpp"
+#include <vector>
+
+using namespace bb;
+
+namespace {
+auto& engine = numeric::get_debug_randomness();
+}
+
+template <typename Curve> class stdlibBiggroupSecp256k1 : public testing::Test {
+  public:
+    // We always use bigfield for secp256k1 as the scalar field is large.
+    using element_ct = typename Curve::g1_bigfr_ct;
+    using scalar_ct = typename Curve::bigfr_ct;
+
+    using fq = typename Curve::fq;
+    using fr = typename Curve::fr;
+    using g1 = typename Curve::g1;
+    using affine_element = typename g1::affine_element;
+    using element = typename g1::element;
+
+    using Builder = typename Curve::Builder;
+    using witness_ct = stdlib::witness_t<Builder>;
+    using bool_ct = stdlib::bool_t<Builder>;
+
+    static constexpr auto EXPECT_CIRCUIT_CORRECTNESS = [](Builder& builder, bool expected_result = true) {
+        info("num gates = ", builder.get_estimated_num_finalized_gates());
+        EXPECT_EQ(CircuitChecker::check(builder), expected_result);
+    };
+
+    // Add the necessary utility methods used in tests
+    static void test_wnaf_secp256k1()
+    {
+        Builder builder = Builder();
+        size_t num_repetitions = 1;
+        for (size_t i = 0; i < num_repetitions; ++i) {
+            fr scalar_a(fr::random_element());
+            if ((uint256_t(scalar_a).get_bit(0) & 1) == 1) {
+                scalar_a -= fr(1); // skew bit is 1
+            }
+            scalar_ct x_a = scalar_ct::from_witness(&builder, scalar_a);
+            element_ct::template compute_secp256k1_endo_wnaf<4, 0, 3>(x_a);
+            element_ct::template compute_secp256k1_endo_wnaf<4, 1, 2>(x_a);
+            element_ct::template compute_secp256k1_endo_wnaf<4, 2, 1>(x_a);
+            element_ct::template compute_secp256k1_endo_wnaf<4, 3, 0>(x_a);
+        }
+
+        EXPECT_CIRCUIT_CORRECTNESS(builder);
+    }
+
+    static void test_wnaf_8bit_secp256k1()
+    {
+        Builder builder = Builder();
+        size_t num_repetitions = 1;
+        for (size_t i = 0; i < num_repetitions; ++i) {
+            fr scalar_a(fr::random_element());
+            if ((uint256_t(scalar_a).get_bit(0) & 1) == 1) {
+                scalar_a -= fr(1); // skew bit is 1
+            }
+            scalar_ct x_a = scalar_ct::from_witness(&builder, scalar_a);
+            element_ct::template compute_secp256k1_endo_wnaf<8, 0, 3>(x_a);
+            element_ct::template compute_secp256k1_endo_wnaf<8, 1, 2>(x_a);
+            element_ct::template compute_secp256k1_endo_wnaf<8, 2, 1>(x_a);
+            element_ct::template compute_secp256k1_endo_wnaf<8, 3, 0>(x_a);
+        }
+
+        EXPECT_CIRCUIT_CORRECTNESS(builder);
+    }
+
+    static void test_ecdsa_mul_secp256k1()
+    {
+        Builder builder = Builder();
+        size_t num_repetitions = 1;
+        for (size_t i = 0; i < num_repetitions; ++i) {
+            fr scalar_a(fr::random_element());
+            fr scalar_b(fr::random_element());
+            fr scalar_c(fr::random_element());
+            if ((uint256_t(scalar_a).get_bit(0) & 1) == 1) {
+                scalar_a -= fr(1); // skew bit is 1
+            }
+            element_ct P_a = element_ct::from_witness(&builder, g1::one * scalar_c);
+            scalar_ct u1 = scalar_ct::from_witness(&builder, scalar_a);
+            scalar_ct u2 = scalar_ct::from_witness(&builder, scalar_b);
+
+            fr alo;
+            fr ahi;
+            fr blo;
+            fr bhi;
+
+            fr::split_into_endomorphism_scalars(scalar_a.from_montgomery_form(), alo, ahi);
+            fr::split_into_endomorphism_scalars(scalar_b.from_montgomery_form(), blo, bhi);
+
+            auto output = element_ct::secp256k1_ecdsa_mul(P_a, u1, u2);
+
+            auto expected = affine_element(g1::one * (scalar_c * scalar_b) + g1::one * scalar_a);
+            EXPECT_EQ(output.x.get_value().lo, uint256_t(expected.x));
+            EXPECT_EQ(output.y.get_value().lo, uint256_t(expected.y));
+        }
+
+        EXPECT_CIRCUIT_CORRECTNESS(builder);
+    }
+};
+
+// Then define the test types
+using Secp256k1TestTypes =
+    testing::Types<stdlib::secp256k1<bb::UltraCircuitBuilder>, stdlib::secp256k1<bb::MegaCircuitBuilder>>;
+
+// Now register the test suite with the types
+TYPED_TEST_SUITE(stdlibBiggroupSecp256k1, Secp256k1TestTypes);
+
+// Define the individual tests
+TYPED_TEST(stdlibBiggroupSecp256k1, WnafSecp256k1)
+{
+    TestFixture::test_wnaf_secp256k1();
+}
+TYPED_TEST(stdlibBiggroupSecp256k1, Wnaf8bitSecp256k1)
+{
+    TestFixture::test_wnaf_8bit_secp256k1();
+}
+TYPED_TEST(stdlibBiggroupSecp256k1, EcdsaMulSecp256k1)
+{
+    TestFixture::test_ecdsa_mul_secp256k1();
+}

--- a/barretenberg/cpp/src/barretenberg/stdlib/primitives/biggroup/biggroup_tables.hpp
+++ b/barretenberg/cpp/src/barretenberg/stdlib/primitives/biggroup/biggroup_tables.hpp
@@ -29,7 +29,7 @@ using plookup::MultiTableId;
  * @return std::array<twin_rom_table<C>, 5>
  */
 template <typename C, class Fq, class Fr, class G>
-template <size_t num_elements, typename>
+template <size_t num_elements>
 std::array<twin_rom_table<C>, 5> element<C, Fq, Fr, G>::create_group_element_rom_tables(
     const std::array<element, num_elements>& rom_data, std::array<uint256_t, 8>& limb_max)
 {
@@ -70,7 +70,7 @@ std::array<twin_rom_table<C>, 5> element<C, Fq, Fr, G>::create_group_element_rom
 }
 
 template <typename C, class Fq, class Fr, class G>
-template <size_t, typename>
+template <size_t>
 element<C, Fq, Fr, G> element<C, Fq, Fr, G>::read_group_element_rom_tables(
     const std::array<twin_rom_table<C>, 5>& tables, const field_t<C>& index, const std::array<uint256_t, 8>& limb_max)
 {
@@ -97,8 +97,7 @@ element<C, Fq, Fr, G> element<C, Fq, Fr, G>::read_group_element_rom_tables(
 }
 
 template <typename C, class Fq, class Fr, class G>
-template <typename X>
-element<C, Fq, Fr, G>::four_bit_table_plookup<X>::four_bit_table_plookup(const element& input)
+element<C, Fq, Fr, G>::four_bit_table_plookup::four_bit_table_plookup(const element& input)
 {
     element d2 = input.dbl();
 
@@ -114,15 +113,13 @@ element<C, Fq, Fr, G>::four_bit_table_plookup<X>::four_bit_table_plookup(const e
 }
 
 template <typename C, class Fq, class Fr, class G>
-template <typename X>
-element<C, Fq, Fr, G> element<C, Fq, Fr, G>::four_bit_table_plookup<X>::operator[](const field_t<C>& index) const
+element<C, Fq, Fr, G> element<C, Fq, Fr, G>::four_bit_table_plookup::operator[](const field_t<C>& index) const
 {
     return read_group_element_rom_tables<16>(coordinates, index, limb_max);
 }
 
 template <class C, class Fq, class Fr, class G>
-template <typename X>
-element<C, Fq, Fr, G> element<C, Fq, Fr, G>::eight_bit_fixed_base_table<X>::operator[](const field_t<C>& index) const
+element<C, Fq, Fr, G> element<C, Fq, Fr, G>::eight_bit_fixed_base_table::operator[](const field_t<C>& index) const
 {
     const auto get_plookup_tags = [this]() {
         switch (curve_type) {
@@ -177,8 +174,7 @@ element<C, Fq, Fr, G> element<C, Fq, Fr, G>::eight_bit_fixed_base_table<X>::oper
 }
 
 template <typename C, class Fq, class Fr, class G>
-template <typename X>
-element<C, Fq, Fr, G> element<C, Fq, Fr, G>::eight_bit_fixed_base_table<X>::operator[](const size_t index) const
+element<C, Fq, Fr, G> element<C, Fq, Fr, G>::eight_bit_fixed_base_table::operator[](const size_t index) const
 {
     return operator[](field_t<C>(index));
 }
@@ -187,8 +183,8 @@ element<C, Fq, Fr, G> element<C, Fq, Fr, G>::eight_bit_fixed_base_table<X>::oper
  * lookup_table_plookup
  **/
 template <typename C, class Fq, class Fr, class G>
-template <size_t length, typename X>
-element<C, Fq, Fr, G>::lookup_table_plookup<length, X>::lookup_table_plookup(const std::array<element, length>& inputs)
+template <size_t length>
+element<C, Fq, Fr, G>::lookup_table_plookup<length>::lookup_table_plookup(const std::array<element, length>& inputs)
 {
     if constexpr (length == 2) {
         auto [A0, A1] = inputs[1].checked_unconditional_add_sub(inputs[0]);
@@ -417,8 +413,8 @@ element<C, Fq, Fr, G>::lookup_table_plookup<length, X>::lookup_table_plookup(con
 }
 
 template <typename C, class Fq, class Fr, class G>
-template <size_t length, typename X>
-element<C, Fq, Fr, G> element<C, Fq, Fr, G>::lookup_table_plookup<length, X>::get(
+template <size_t length>
+element<C, Fq, Fr, G> element<C, Fq, Fr, G>::lookup_table_plookup<length>::get(
     const std::array<bool_ct, length>& bits) const
 {
     std::vector<field_t<C>> accumulators;


### PR DESCRIPTION
Please read [contributing guidelines](CONTRIBUTING.md) and remove this line.

Since `StandardCircuitBuilder` has been removed, we want to get rid of the boolean `HasPlookup`. In this PR, we get rid of `HasPlookup` conditional branches in the `bigfield` and `biggroup` class. Summary of the PR:
- Removes `HasPlookup` keyword from the bigfield` and `biggroup` classes
- Separate test suite for the `biggroup` tests for the `secp256k1` curve since we have custom functions for `secp256k1`. These tests were not being triggered in the current setup (not even with `UltraCircuitBuilder`.