### PR TITLE
fix: correct str<N> deserialization using into conversion

### DIFF
--- a/noir-projects/noir-protocol-circuits/crates/types/src/traits.nr
+++ b/noir-projects/noir-protocol-circuits/crates/types/src/traits.nr
@@ -326,7 +326,8 @@ pub trait Deserialize<let N: u32> {
 impl<let N: u32> Deserialize<N> for str<N> {
     #[inline_always]
     fn deserialize(fields: [Field; N]) -> Self {
-        str::<N>::from(fields.map(|value| value as u8))
+        let bytes: [u8; N] = fields.map(|value| value as u8);
+        bytes.into()
     }
 }
 


### PR DESCRIPTION
Replaced invalid `str::<N>::from(...)` usage with `bytes.into()` to correctly deserialize [Field; N] into str<N>.

This fixes a compilation error due to unsupported generic function calls and direct type constructors in Noir.

Tested on aztec-packages v0.87.2 and verified deserialization works as expected.
