### PR TITLE
fix: don't create ./out when verifying

### DIFF
--- a/barretenberg/cpp/src/barretenberg/bb/cli.cpp
+++ b/barretenberg/cpp/src/barretenberg/bb/cli.cpp
@@ -596,7 +596,7 @@ int parse_and_run_cli_command(int argc, char* argv[])
     // Immediately after parsing, we can init the global CRS factory. Note this does not yet read or download any
     // points; that is done on-demand.
     srs::init_net_crs_factory(flags.crs_path);
-    if (prove->parsed() || verify->parsed() || write_vk->parsed()) {
+    if (prove->parsed() || write_vk->parsed()) {
         // If writing to an output folder, make sure it exists.
         std::filesystem::create_directories(output_path);
     }


### PR DESCRIPTION
this doesn't seem to be needed and breaks nodes running on read-only filesystems
