### PR TITLE
fix: record tx hash compution in us

### DIFF
--- a/yarn-project/simulator/src/public/executor_metrics.ts
+++ b/yarn-project/simulator/src/public/executor_metrics.ts
@@ -55,7 +55,7 @@ export class ExecutorMetrics implements ExecutorMetricsInterface {
 
     this.txHashing = meter.createHistogram(Metrics.PUBLIC_EXECUTOR_TX_HASHING, {
       description: 'Tx hashing time',
-      unit: 'ms',
+      unit: 'us',
       valueType: ValueType.INT,
     });
 
@@ -112,8 +112,8 @@ export class ExecutorMetrics implements ExecutorMetricsInterface {
     });
   }
 
-  recordTxHashComputation(durationMs: number) {
-    this.txHashing.record(Math.ceil(durationMs));
+  recordTxHashComputation(durationUs: number) {
+    this.txHashing.record(Math.ceil(durationUs));
   }
 
   recordPrivateEffectsInsertion(durationUs: number, type: 'revertible' | 'non-revertible') {

--- a/yarn-project/simulator/src/public/executor_metrics_interface.ts
+++ b/yarn-project/simulator/src/public/executor_metrics_interface.ts
@@ -10,6 +10,6 @@ export interface ExecutorMetricsInterface {
     manaUsed: number,
     totalInstructionsExecuted: number,
   ): void;
-  recordTxHashComputation(durationMs: number): void;
+  recordTxHashComputation(durationUs: number): void;
   recordPrivateEffectsInsertion(durationUs: number, type: 'revertible' | 'non-revertible'): void;
 }

--- a/yarn-project/simulator/src/public/public_tx_simulator/measured_public_tx_simulator.ts
+++ b/yarn-project/simulator/src/public/public_tx_simulator/measured_public_tx_simulator.ts
@@ -42,7 +42,7 @@ export class MeasuredPublicTxSimulator extends PublicTxSimulator {
   protected override async computeTxHash(tx: Tx) {
     const timer = new Timer();
     const txHash = await super.computeTxHash(tx);
-    this.metrics.recordTxHashComputation(timer.ms());
+    this.metrics.recordTxHashComputation(timer.us());
     return txHash;
   }
 

--- a/yarn-project/simulator/src/public/test_executor_metrics.ts
+++ b/yarn-project/simulator/src/public/test_executor_metrics.ts
@@ -124,11 +124,11 @@ export class TestExecutorMetrics implements ExecutorMetricsInterface {
     });
   }
 
-  recordTxHashComputation(durationMs: number) {
+  recordTxHashComputation(durationUs: number) {
     assert(this.currentTxLabel, 'Cannot record tx hash computation time when no tx is live');
     const txMetrics = this.txMetrics.get(this.currentTxLabel)!;
     assert(txMetrics.txHashMs === undefined, 'Cannot RE-record tx hash computation time');
-    txMetrics.txHashMs = durationMs;
+    txMetrics.txHashMs = durationUs / 1000;
   }
 
   recordPrivateEffectsInsertion(durationUs: number, type: 'revertible' | 'non-revertible') {


### PR DESCRIPTION
Calculating the tx hash is a sub-millisecond operation. Record it as microseconds in Prometheus.

Fix #14420 
