### PR TITLE
fix: Merge queue instances have pr name for uniquness in e.g. reorgs.

### DIFF
--- a/ci.sh
+++ b/ci.sh
@@ -85,6 +85,14 @@ case "$cmd" in
     export JOB_ID="x1-full"
     exec bootstrap_ec2 "./bootstrap.sh ci-full"
     ;;
+  "grind")
+    # Spin up ec2 instance and run the merge-queue flow.
+    run() {
+      JOB_ID=$1 INSTANCE_POSTFIX=$1 ARCH=$2 exec denoise "bootstrap_ec2 './bootstrap.sh $3'"
+    }
+    export -f run
+    seq 1 ${1:-5} | parallel --termseq 'TERM,10000' --line-buffered --halt now,fail=1  'run $USER-x{}-full amd64 ci-full'
+    ;;
   "merge-queue")
     # Spin up ec2 instance and run the merge-queue flow.
     run() {

--- a/ci3/bootstrap_ec2
+++ b/ci3/bootstrap_ec2
@@ -42,10 +42,13 @@ if [[ "$(git fetch origin --negotiate-only --negotiation-tip=$current_commit)" !
   exit 1
 fi
 
-if [ "$REF_NAME" == "master" ]; then
-  # Allow parallelism on master by having the instance name be the commit.
-  instance_name="$current_commit"_$arch
+# Our instance_name acts as a uniqueness key for the instance.
+# Instances are terminated if they exist with the same name.
+if [[ "$REF_NAME" =~ ^gh-readonly-queue/.*(pr-[0-9]+) ]]; then
+  # In merge queue, use the pr number as the instance name.
+  instance_name="${BASH_REMATCH[1]}_$arch"
 else
+  # In local or pr's, use the branch name as the instance name.
   instance_name=$(echo -n "$REF_NAME" | head -c 50 | tr -c 'a-zA-Z0-9-' '_')_$arch
 fi
 


### PR DESCRIPTION
Please read [contributing guidelines](CONTRIBUTING.md) and remove this line.
