### PR TITLE
chore: introduce message processing

### DIFF
--- a/noir-projects/aztec-nr/aztec/src/messages/discovery/mod.nr
+++ b/noir-projects/aztec-nr/aztec/src/messages/discovery/mod.nr
@@ -67,7 +67,7 @@ pub unconstrained fn discover_new_messages<Env>(
     debug_log("Performing message discovery");
 
     // First we process all private logs, which can contain different kinds of messages e.g. private notes, partial
-    // partial notes, private events, etc.
+    // notes, private events, etc.
     let mut logs = get_private_logs(contract_address);
     logs.for_each(|i, log: PendingTaggedLog| {
         process_private_log(contract_address, compute_note_hash_and_nullifier, log);

--- a/noir-projects/aztec-nr/aztec/src/messages/discovery/mod.nr
+++ b/noir-projects/aztec-nr/aztec/src/messages/discovery/mod.nr
@@ -2,11 +2,13 @@ use protocol_types::{address::AztecAddress, debug_log::debug_log};
 
 pub mod nonce_discovery;
 pub mod partial_notes;
-pub mod pending_tagged_log;
 pub mod private_logs;
 pub mod private_notes;
 
-use private_notes::MAX_NOTE_PACKED_LEN;
+use crate::messages::{
+    discovery::{private_logs::process_private_log, private_notes::MAX_NOTE_PACKED_LEN},
+    processing::{get_private_logs, pending_tagged_log::PendingTaggedLog},
+};
 
 pub struct NoteHashAndNullifier {
     /// The result of NoteHash::compute_note_hash
@@ -64,11 +66,16 @@ pub unconstrained fn discover_new_messages<Env>(
 ) {
     debug_log("Performing message discovery");
 
-    private_logs::fetch_and_process_private_tagged_logs(
-        contract_address,
-        compute_note_hash_and_nullifier,
-    );
+    // First we process all private logs, which can contain different kinds of messages e.g. private notes, partial
+    // partial notes, private events, etc.
+    let mut logs = get_private_logs(contract_address);
+    logs.for_each(|i, log: PendingTaggedLog| {
+        process_private_log(contract_address, compute_note_hash_and_nullifier, log);
+        logs.remove(i);
+    });
 
+    // Then we process all pending partial notes, regardless of whether they were found in the current or previous
+    // executions.
     partial_notes::fetch_and_process_public_partial_note_completion_logs(
         contract_address,
         compute_note_hash_and_nullifier,

--- a/noir-projects/aztec-nr/aztec/src/messages/discovery/private_logs.nr
+++ b/noir-projects/aztec-nr/aztec/src/messages/discovery/private_logs.nr
@@ -1,10 +1,7 @@
 use crate::{
-    capsules::CapsuleArray,
     messages::{
         discovery::{
-            ComputeNoteHashAndNullifier,
-            partial_notes::process_partial_note_private_msg,
-            pending_tagged_log::{PENDING_TAGGED_LOG_ARRAY_BASE_SLOT, PendingTaggedLog},
+            ComputeNoteHashAndNullifier, partial_notes::process_partial_note_private_msg,
             private_notes::process_private_note_msg,
         },
         encoding::decode_message,
@@ -12,8 +9,9 @@ use crate::{
         msg_type::{
             PARTIAL_NOTE_PRIVATE_MSG_TYPE_ID, PRIVATE_EVENT_MSG_TYPE_ID, PRIVATE_NOTE_MSG_TYPE_ID,
         },
+        processing::pending_tagged_log::PendingTaggedLog,
     },
-    oracle::{logs::store_private_event_log, message_discovery::fetch_tagged_logs},
+    oracle::logs::store_private_event_log,
     utils::array,
 };
 
@@ -24,28 +22,8 @@ use protocol_types::{
     traits::FromField,
 };
 
-/// Searches for private logs that signal new private notes that are then delivered to PXE, or new partial notes that
-/// are stored in the PXE capsules so that `fetch_and_process_public_partial_note_completion_logs` can later search for
-/// public logs that will complete them.
-pub unconstrained fn fetch_and_process_private_tagged_logs<Env>(
-    contract_address: AztecAddress,
-    compute_note_hash_and_nullifier: ComputeNoteHashAndNullifier<Env>,
-) {
-    // We will eventually perform log discovery via tagging here, but for now we simply call the `fetchTaggedLogs` oracle.
-    // This makes PXE synchronize tags, download logs and store the pending tagged logs in capsule array which are then
-    // retrieved and processed here.
-    fetch_tagged_logs(PENDING_TAGGED_LOG_ARRAY_BASE_SLOT);
-
-    // Get the logs from the capsule array and process them one by one
-    let logs =
-        CapsuleArray::<PendingTaggedLog>::at(contract_address, PENDING_TAGGED_LOG_ARRAY_BASE_SLOT);
-    logs.for_each(|i, log: PendingTaggedLog| {
-        process_log(contract_address, compute_note_hash_and_nullifier, log);
-        logs.remove(i);
-    });
-}
-
-/// Processes a log's ciphertext by decrypting it and then searching the plaintext for private notes or partial notes.
+/// Processes a private log's ciphertext by decrypting it and then searching the plaintext for private notes or partial
+/// notes.
 ///
 /// Private notes result in nonce discovery being performed prior to delivery, which requires knowledge of the
 /// transaction hash in which the notes would've been created (typically the same transaction in which the log was
@@ -54,7 +32,7 @@ pub unconstrained fn fetch_and_process_private_tagged_logs<Env>(
 ///
 /// Partial notes result in a pending partial note entry being stored in a PXE capsule, which will later be retrieved to
 /// search for the note's completion public log.
-unconstrained fn process_log<Env>(
+pub(crate) unconstrained fn process_private_log<Env>(
     contract_address: AztecAddress,
     compute_note_hash_and_nullifier: ComputeNoteHashAndNullifier<Env>,
     pending_tagged_log: PendingTaggedLog,

--- a/noir-projects/aztec-nr/aztec/src/messages/mod.nr
+++ b/noir-projects/aztec-nr/aztec/src/messages/mod.nr
@@ -3,3 +3,4 @@ pub mod discovery;
 pub mod logs;
 pub mod msg_type;
 pub mod encoding;
+pub mod processing;

--- a/noir-projects/aztec-nr/aztec/src/messages/processing/mod.nr
+++ b/noir-projects/aztec-nr/aztec/src/messages/processing/mod.nr
@@ -1,0 +1,22 @@
+pub(crate) mod pending_tagged_log;
+
+use crate::{capsules::CapsuleArray, oracle};
+use crate::messages::processing::pending_tagged_log::PendingTaggedLog;
+use protocol_types::{address::AztecAddress, hash::sha256_to_field};
+
+// Base slot for the pending tagged log array to which the fetch_tagged_logs oracle inserts found private logs.
+global PENDING_TAGGED_LOG_ARRAY_BASE_SLOT: Field =
+    sha256_to_field("AZTEC_NR::PENDING_TAGGED_LOG_ARRAY_BASE_SLOT".as_bytes());
+
+/// Returns a `CapsuleArray` with all private logs that were found and need to be processed.
+pub(crate) unconstrained fn get_private_logs(
+    contract_address: AztecAddress,
+) -> CapsuleArray<PendingTaggedLog> {
+    // We will eventually perform log discovery via tagging here, but for now we simply call the `fetchTaggedLogs`
+    // oracle. This makes PXE synchronize tags, download logs and store the pending tagged logs in capsule array which
+    // are then retrieved and processed here.
+    oracle::message_discovery::fetch_tagged_logs(PENDING_TAGGED_LOG_ARRAY_BASE_SLOT);
+
+    // Get the logs from the capsule array and process them one by one
+    CapsuleArray::<PendingTaggedLog>::at(contract_address, PENDING_TAGGED_LOG_ARRAY_BASE_SLOT)
+}

--- a/noir-projects/aztec-nr/aztec/src/messages/processing/pending_tagged_log.nr
+++ b/noir-projects/aztec-nr/aztec/src/messages/processing/pending_tagged_log.nr
@@ -1,16 +1,11 @@
 use protocol_types::{
     address::AztecAddress,
     constants::{MAX_NOTE_HASHES_PER_TX, PRIVATE_LOG_SIZE_IN_FIELDS},
-    hash::sha256_to_field,
     traits::{Deserialize, Serialize},
 };
 
-// Base slot for the pending tagged log array to which the fetchTaggedLogs oracle inserts found private logs.
-pub(crate) global PENDING_TAGGED_LOG_ARRAY_BASE_SLOT: Field = sha256_to_field(
-    "AZTEC_NR::PENDING_TAGGED_PENDING_TAGGED_LOG_ARRAY_BASE_SLOT".as_bytes(),
-);
-
-/// Represents a log as it is stored in the pending tagged log array to which the fetchTaggedLogs oracle inserts found private log.
+/// A private log that was tagged for `recipient` and has not yet been processed, plus information related to the
+/// transaction in which it was emitted.
 #[derive(Deserialize, Serialize)]
 pub(crate) struct PendingTaggedLog {
     pub log: BoundedVec<Field, PRIVATE_LOG_SIZE_IN_FIELDS>,
@@ -23,7 +18,7 @@ pub(crate) struct PendingTaggedLog {
 }
 
 mod test {
-    use crate::messages::discovery::pending_tagged_log::PendingTaggedLog;
+    use super::PendingTaggedLog;
     use protocol_types::{address::AztecAddress, traits::{FromField, Serialize}};
 
     #[test]

--- a/yarn-project/stdlib/src/logs/pending_tagged_log.test.ts
+++ b/yarn-project/stdlib/src/logs/pending_tagged_log.test.ts
@@ -124,7 +124,7 @@ describe('PendingTaggedLog', () => {
     // Run with AZTEC_GENERATE_TEST_DATA=1 to update noir test data
     const fieldArrayStr = `[${serialized.map(f => f.toString()).join(',')}]`;
     updateInlineTestData(
-      'noir-projects/aztec-nr/aztec/src/messages/discovery/pending_tagged_log.nr',
+      'noir-projects/aztec-nr/aztec/src/messages/processing/pending_tagged_log.nr',
       'serialized_pending_tagged_log_from_typescript',
       fieldArrayStr,
     );


### PR DESCRIPTION
This creates a new `message::processing` module in aztec-nr, for us to place components related to the message processing pipeline, e.g. fetching of logs, processing of notes, etc. We need such a concept in order to properly handle batched network requests, backups, etc.

This just lays the groundwork by moving some things around, hiding the complexity of log discovery into a `get_private_logs` function. This will be later be expanded upon by also including a capsule array for notes to be added to pxe, etc.