### PR TITLE
feat: Added world state query to retrieve sibling paths by leaf value

### DIFF
--- a/barretenberg/cpp/src/barretenberg/crypto/merkle_tree/append_only_tree/content_addressed_append_only_tree.hpp
+++ b/barretenberg/cpp/src/barretenberg/crypto/merkle_tree/append_only_tree/content_addressed_append_only_tree.hpp
@@ -52,6 +52,7 @@ template <typename Store, typename HashingPolicy> class ContentAddressedAppendOn
     using MetaDataCallback = std::function<void(TypedResponse<TreeMetaResponse>&)>;
     using HashPathCallback = std::function<void(TypedResponse<GetSiblingPathResponse>&)>;
     using FindLeafCallback = std::function<void(TypedResponse<FindLeafIndexResponse>&)>;
+    using FindSiblingPathCallback = std::function<void(TypedResponse<FindLeafPathResponse>&)>;
     using GetLeafCallback = std::function<void(TypedResponse<GetLeafResponse>&)>;
     using CommitCallback = std::function<void(TypedResponse<CommitResponse>&)>;
     using RollbackCallback = EmptyResponseCallback;
@@ -183,6 +184,21 @@ template <typename Store, typename HashingPolicy> class ContentAddressedAppendOn
                            const block_number_t& blockNumber,
                            bool includeUncommitted,
                            const FindLeafCallback& on_completion) const;
+
+    /**
+     * @brief Returns the sibling paths for the provided leaves in the tree
+     */
+    void find_leaf_sibling_paths(const std::vector<typename Store::LeafType>& leaves,
+                                 bool includeUncommitted,
+                                 const FindSiblingPathCallback& on_completion) const;
+
+    /**
+     * @brief Returns the sibling paths for the provided leaves in the tree
+     */
+    void find_leaf_sibling_paths(const std::vector<typename Store::LeafType>& leaves,
+                                 const block_number_t& block_number,
+                                 bool includeUncommitted,
+                                 const FindSiblingPathCallback& on_completion) const;
 
     /**
      * @brief Returns the index of the provided leaf in the tree only if it exists after the index value provided
@@ -803,6 +819,83 @@ void ContentAddressedAppendOnlyTree<Store, HashingPolicy>::find_leaf_indices_fro
                     std::optional<index_t> leaf_index =
                         store_->find_leaf_index_from(leaf, start_index, requestContext, *tx);
                     response.inner.leaf_indices.emplace_back(leaf_index);
+                }
+            },
+            on_completion);
+    };
+    workers_->enqueue(job);
+}
+
+template <typename Store, typename HashingPolicy>
+void ContentAddressedAppendOnlyTree<Store, HashingPolicy>::find_leaf_sibling_paths(
+    const std::vector<typename Store::LeafType>& leaves,
+    bool includeUncommitted,
+    const FindSiblingPathCallback& on_completion) const
+{
+    auto job = [=, this]() -> void {
+        execute_and_report<FindLeafPathResponse>(
+            [=, this](TypedResponse<FindLeafPathResponse>& response) {
+                response.inner.leaf_paths.reserve(leaves.size());
+                ReadTransactionPtr tx = store_->create_read_transaction();
+
+                RequestContext requestContext;
+                requestContext.includeUncommitted = includeUncommitted;
+                requestContext.root = store_->get_current_root(*tx, includeUncommitted);
+
+                for (const auto& leaf : leaves) {
+                    std::optional<index_t> leaf_index = store_->find_leaf_index_from(leaf, 0, requestContext, *tx);
+                    if (!leaf_index.has_value()) {
+                        response.inner.leaf_paths.emplace_back(std::nullopt);
+                        continue;
+                    }
+                    OptionalSiblingPath optional_path =
+                        get_subtree_sibling_path_internal(leaf_index.value(), 0, requestContext, *tx);
+                    fr_sibling_path leaf_path = optional_sibling_path_to_full_sibling_path(optional_path);
+                    response.inner.leaf_paths.emplace_back(leaf_path);
+                }
+            },
+            on_completion);
+    };
+    workers_->enqueue(job);
+}
+
+template <typename Store, typename HashingPolicy>
+void ContentAddressedAppendOnlyTree<Store, HashingPolicy>::find_leaf_sibling_paths(
+    const std::vector<typename Store::LeafType>& leaves,
+    const block_number_t& blockNumber,
+    bool includeUncommitted,
+    const FindSiblingPathCallback& on_completion) const
+{
+    auto job = [=, this]() -> void {
+        execute_and_report<FindLeafPathResponse>(
+            [=, this](TypedResponse<FindLeafPathResponse>& response) {
+                response.inner.leaf_paths.reserve(leaves.size());
+                if (blockNumber == 0) {
+                    throw std::runtime_error("Unable to find leaf index for block number 0");
+                }
+                ReadTransactionPtr tx = store_->create_read_transaction();
+                BlockPayload blockData;
+                if (!store_->get_block_data(blockNumber, blockData, *tx)) {
+                    throw std::runtime_error(
+                        format("Unable to find sibling path for block ", blockNumber, ", failed to get block data."));
+                }
+
+                RequestContext requestContext;
+                requestContext.blockNumber = blockNumber;
+                requestContext.includeUncommitted = includeUncommitted;
+                requestContext.maxIndex = blockData.size;
+                requestContext.root = blockData.root;
+
+                for (const auto& leaf : leaves) {
+                    std::optional<index_t> leaf_index = store_->find_leaf_index_from(leaf, 0, requestContext, *tx);
+                    if (!leaf_index.has_value()) {
+                        response.inner.leaf_paths.emplace_back(std::nullopt);
+                        continue;
+                    }
+                    OptionalSiblingPath optional_path =
+                        get_subtree_sibling_path_internal(leaf_index.value(), 0, requestContext, *tx);
+                    fr_sibling_path leaf_path = optional_sibling_path_to_full_sibling_path(optional_path);
+                    response.inner.leaf_paths.emplace_back(leaf_path);
                 }
             },
             on_completion);

--- a/barretenberg/cpp/src/barretenberg/crypto/merkle_tree/append_only_tree/content_addressed_append_only_tree.test.cpp
+++ b/barretenberg/cpp/src/barretenberg/crypto/merkle_tree/append_only_tree/content_addressed_append_only_tree.test.cpp
@@ -728,7 +728,7 @@ TEST_F(PersistedContentAddressedAppendOnlyTreeTest, can_add_multiple_values)
     TreeType tree(std::move(store), pool);
     MemoryTree<Poseidon2HashPolicy> memdb(depth);
 
-    for (size_t i = 0; i < 2; ++i) {
+    for (size_t i = 0; i < NUM_VALUES; ++i) {
         fr mock_root = memdb.update_element(i, VALUES[i]);
         add_value(tree, VALUES[i]);
         check_root(tree, mock_root);

--- a/barretenberg/cpp/src/barretenberg/crypto/merkle_tree/append_only_tree/content_addressed_append_only_tree.test.cpp
+++ b/barretenberg/cpp/src/barretenberg/crypto/merkle_tree/append_only_tree/content_addressed_append_only_tree.test.cpp
@@ -122,6 +122,24 @@ void check_sibling_path(TreeType& tree,
     signal.wait_for_level();
 }
 
+void check_sibling_path_by_value(TreeType& tree,
+                                 fr value,
+                                 fr_sibling_path expected_sibling_path,
+                                 bool includeUncommitted = true,
+                                 bool expected_result = true)
+{
+    Signal signal;
+    auto completion = [&](const TypedResponse<FindLeafPathResponse>& response) -> void {
+        EXPECT_EQ(response.success, expected_result);
+        if (expected_result) {
+            EXPECT_EQ(response.inner.leaf_paths[0], expected_sibling_path);
+        }
+        signal.signal_level();
+    };
+    tree.find_leaf_sibling_paths({ value }, includeUncommitted, completion);
+    signal.wait_for_level();
+}
+
 void check_historic_sibling_path(TreeType& tree,
                                  index_t index,
                                  fr_sibling_path expected_sibling_path,
@@ -137,6 +155,24 @@ void check_historic_sibling_path(TreeType& tree,
         signal.signal_level();
     };
     tree.get_sibling_path(index, blockNumber, completion, false);
+    signal.wait_for_level();
+}
+
+void check_historic_sibling_path_by_value(TreeType& tree,
+                                          fr value,
+                                          fr_sibling_path expected_sibling_path,
+                                          block_number_t blockNumber,
+                                          bool expected_success = true)
+{
+    Signal signal;
+    auto completion = [&](const TypedResponse<FindLeafPathResponse>& response) -> void {
+        EXPECT_EQ(response.success, expected_success);
+        if (response.success) {
+            EXPECT_EQ(response.inner.leaf_paths[0], expected_sibling_path);
+        }
+        signal.signal_level();
+    };
+    tree.find_leaf_sibling_paths({ value }, blockNumber, false, completion);
     signal.wait_for_level();
 }
 
@@ -375,6 +411,7 @@ TEST_F(PersistedContentAddressedAppendOnlyTreeTest, can_add_value_and_get_siblin
     check_size(tree, 1);
     check_root(tree, memdb.root());
     check_sibling_path(tree, 0, memdb.get_sibling_path(0));
+    check_sibling_path_by_value(tree, VALUES[0], memdb.get_sibling_path(0));
 }
 
 TEST_F(PersistedContentAddressedAppendOnlyTreeTest, reports_an_error_if_tree_is_overfilled)
@@ -691,13 +728,16 @@ TEST_F(PersistedContentAddressedAppendOnlyTreeTest, can_add_multiple_values)
     TreeType tree(std::move(store), pool);
     MemoryTree<Poseidon2HashPolicy> memdb(depth);
 
-    for (size_t i = 0; i < NUM_VALUES; ++i) {
+    for (size_t i = 0; i < 2; ++i) {
         fr mock_root = memdb.update_element(i, VALUES[i]);
         add_value(tree, VALUES[i]);
         check_root(tree, mock_root);
 
         check_sibling_path(tree, 0, memdb.get_sibling_path(0));
         check_sibling_path(tree, i, memdb.get_sibling_path(i));
+
+        check_sibling_path_by_value(tree, VALUES[0], memdb.get_sibling_path(0));
+        check_sibling_path_by_value(tree, VALUES[i], memdb.get_sibling_path(i));
     }
 }
 
@@ -722,6 +762,8 @@ TEST_F(PersistedContentAddressedAppendOnlyTreeTest, can_add_multiple_values_in_a
     check_root(tree, memdb.root());
     check_sibling_path(tree, 0, memdb.get_sibling_path(0));
     check_sibling_path(tree, 4 - 1, memdb.get_sibling_path(4 - 1));
+    check_sibling_path_by_value(tree, VALUES[0], memdb.get_sibling_path(0));
+    check_sibling_path_by_value(tree, VALUES[4 - 1], memdb.get_sibling_path(4 - 1));
 }
 
 TEST_F(PersistedContentAddressedAppendOnlyTreeTest, can_pad_with_zero_leaves)
@@ -875,8 +917,10 @@ TEST_F(PersistedContentAddressedAppendOnlyTreeTest, can_retrieve_historic_siblin
 
         for (uint32_t i = 0; i < historicPathsZeroIndex.size(); i++) {
             check_historic_sibling_path(tree, 0, historicPathsZeroIndex[i], i + 1);
+            check_historic_sibling_path_by_value(tree, VALUES[0], historicPathsZeroIndex[i], i + 1);
             index_t maxSizeAtBlock = ((i + 1) * batch_size) - 1;
             check_historic_sibling_path(tree, maxSizeAtBlock, historicPathsMaxIndex[i], i + 1);
+            check_historic_sibling_path_by_value(tree, VALUES[maxSizeAtBlock], historicPathsMaxIndex[i], i + 1);
         }
     };
 

--- a/barretenberg/cpp/src/barretenberg/crypto/merkle_tree/response.hpp
+++ b/barretenberg/cpp/src/barretenberg/crypto/merkle_tree/response.hpp
@@ -124,6 +124,17 @@ struct FindLeafIndexResponse {
     FindLeafIndexResponse& operator=(FindLeafIndexResponse&& other) noexcept = default;
 };
 
+struct FindLeafPathResponse {
+    std::vector<std::optional<fr_sibling_path>> leaf_paths;
+
+    FindLeafPathResponse() = default;
+    ~FindLeafPathResponse() = default;
+    FindLeafPathResponse(const FindLeafPathResponse& other) = default;
+    FindLeafPathResponse(FindLeafPathResponse&& other) noexcept = default;
+    FindLeafPathResponse& operator=(const FindLeafPathResponse& other) = default;
+    FindLeafPathResponse& operator=(FindLeafPathResponse&& other) noexcept = default;
+};
+
 struct GetLeafResponse {
     std::optional<bb::fr> leaf;
 

--- a/barretenberg/cpp/src/barretenberg/nodejs_module/world_state/world_state.cpp
+++ b/barretenberg/cpp/src/barretenberg/nodejs_module/world_state/world_state.cpp
@@ -191,6 +191,10 @@ WorldStateWrapper::WorldStateWrapper(const Napi::CallbackInfo& info)
         [this](msgpack::object& obj, msgpack::sbuffer& buffer) { return find_leaf_indices(obj, buffer); });
 
     _dispatcher.register_target(
+        WorldStateMessageType::FIND_SIBLING_PATHS,
+        [this](msgpack::object& obj, msgpack::sbuffer& buffer) { return find_sibling_paths(obj, buffer); });
+
+    _dispatcher.register_target(
         WorldStateMessageType::FIND_LOW_LEAF,
         [this](msgpack::object& obj, msgpack::sbuffer& buffer) { return find_low_leaf(obj, buffer); });
 
@@ -494,6 +498,47 @@ bool WorldStateWrapper::find_leaf_indices(msgpack::object& obj, msgpack::sbuffer
     MsgHeader header(request.header.messageId);
     messaging::TypedMessage<FindLeafIndicesResponse> resp_msg(
         WorldStateMessageType::FIND_LEAF_INDICES, header, response);
+    msgpack::pack(buffer, resp_msg);
+
+    return true;
+}
+
+bool WorldStateWrapper::find_sibling_paths(msgpack::object& obj, msgpack::sbuffer& buffer) const
+{
+    TypedMessage<TreeIdAndRevisionRequest> request;
+    obj.convert(request);
+
+    FindLeafPathsResponse response;
+
+    switch (request.value.treeId) {
+    case MerkleTreeId::NOTE_HASH_TREE:
+    case MerkleTreeId::L1_TO_L2_MESSAGE_TREE:
+    case MerkleTreeId::ARCHIVE: {
+        TypedMessage<FindLeafPathsRequest<bb::fr>> r1;
+        obj.convert(r1);
+        _ws->find_sibling_paths<bb::fr>(request.value.revision, request.value.treeId, r1.value.leaves, response.paths);
+        break;
+    }
+
+    case MerkleTreeId::PUBLIC_DATA_TREE: {
+        TypedMessage<FindLeafPathsRequest<crypto::merkle_tree::PublicDataLeafValue>> r2;
+        obj.convert(r2);
+        _ws->find_sibling_paths<PublicDataLeafValue>(
+            request.value.revision, request.value.treeId, r2.value.leaves, response.paths);
+        break;
+    }
+    case MerkleTreeId::NULLIFIER_TREE: {
+        TypedMessage<FindLeafPathsRequest<crypto::merkle_tree::NullifierLeafValue>> r3;
+        obj.convert(r3);
+        _ws->find_sibling_paths<NullifierLeafValue>(
+            request.value.revision, request.value.treeId, r3.value.leaves, response.paths);
+        break;
+    }
+    }
+
+    MsgHeader header(request.header.messageId);
+    messaging::TypedMessage<FindLeafPathsResponse> resp_msg(
+        WorldStateMessageType::FIND_SIBLING_PATHS, header, response);
     msgpack::pack(buffer, resp_msg);
 
     return true;

--- a/barretenberg/cpp/src/barretenberg/nodejs_module/world_state/world_state.hpp
+++ b/barretenberg/cpp/src/barretenberg/nodejs_module/world_state/world_state.hpp
@@ -42,6 +42,7 @@ class WorldStateWrapper : public Napi::ObjectWrap<WorldStateWrapper> {
 
     bool find_leaf_indices(msgpack::object& obj, msgpack::sbuffer& buffer) const;
     bool find_low_leaf(msgpack::object& obj, msgpack::sbuffer& buffer) const;
+    bool find_sibling_paths(msgpack::object& obj, msgpack::sbuffer& buffer) const;
 
     bool append_leaves(msgpack::object& obj, msgpack::sbuffer& buffer);
     bool batch_insert(msgpack::object& obj, msgpack::sbuffer& buffer);

--- a/barretenberg/cpp/src/barretenberg/nodejs_module/world_state/world_state_message.hpp
+++ b/barretenberg/cpp/src/barretenberg/nodejs_module/world_state/world_state_message.hpp
@@ -1,4 +1,5 @@
 #pragma once
+#include "barretenberg/crypto/merkle_tree/hash_path.hpp"
 #include "barretenberg/crypto/merkle_tree/indexed_tree/indexed_leaf.hpp"
 #include "barretenberg/crypto/merkle_tree/types.hpp"
 #include "barretenberg/ecc/curves/bn254/fr.hpp"
@@ -27,6 +28,7 @@ enum WorldStateMessageType {
 
     FIND_LEAF_INDICES,
     FIND_LOW_LEAF,
+    FIND_SIBLING_PATHS,
 
     APPEND_LEAVES,
     BATCH_INSERT,
@@ -167,6 +169,18 @@ template <typename T> struct FindLeafIndicesRequest {
 struct FindLeafIndicesResponse {
     std::vector<std::optional<index_t>> indices;
     MSGPACK_FIELDS(indices);
+};
+
+template <typename T> struct FindLeafPathsRequest {
+    MerkleTreeId treeId;
+    WorldStateRevision revision;
+    std::vector<T> leaves;
+    MSGPACK_FIELDS(treeId, revision, leaves);
+};
+
+struct FindLeafPathsResponse {
+    std::vector<std::optional<fr_sibling_path>> paths;
+    MSGPACK_FIELDS(paths);
 };
 
 struct FindLowLeafRequest {

--- a/barretenberg/cpp/src/barretenberg/world_state/world_state.hpp
+++ b/barretenberg/cpp/src/barretenberg/world_state/world_state.hpp
@@ -193,6 +193,20 @@ class WorldState {
                            index_t start_index = 0) const;
 
     /**
+     * @brief Finds the sibling paths of leaves in a tree
+     *
+     * @param revision The revision to query
+     * @param tree_id The ID of the tree
+     * @param leaves The leaves to find paths for
+     * @param paths The paths to be retrieved
+     */
+    template <typename T>
+    void find_sibling_paths(const WorldStateRevision& revision,
+                            MerkleTreeId tree_id,
+                            const std::vector<T>& leaves,
+                            std::vector<std::optional<fr_sibling_path>>& paths) const;
+
+    /**
      * @brief Appends a set of leaves to an existing Merkle Tree.
      *
      * @tparam T The type of the leaves.
@@ -551,6 +565,51 @@ void WorldState::find_leaf_indices(const WorldStateRevision& rev,
     }
 
     indices = std::move(local.inner.leaf_indices);
+}
+
+template <typename T>
+void WorldState::find_sibling_paths(const WorldStateRevision& rev,
+                                    MerkleTreeId id,
+                                    const std::vector<T>& leaves,
+                                    std::vector<std::optional<fr_sibling_path>>& paths) const
+{
+    using namespace crypto::merkle_tree;
+
+    Fork::SharedPtr fork = retrieve_fork(rev.forkId);
+    TypedResponse<FindLeafPathResponse> local;
+
+    Signal signal;
+    auto callback = [&](TypedResponse<FindLeafPathResponse>& response) {
+        local = std::move(response);
+        signal.signal_level(0);
+    };
+    if constexpr (std::is_same_v<bb::fr, T>) {
+        const auto& wrapper = std::get<TreeWithStore<FrTree>>(fork->_trees.at(id));
+        if (rev.blockNumber) {
+            wrapper.tree->find_leaf_sibling_paths(leaves, rev.blockNumber, rev.includeUncommitted, callback);
+        } else {
+            wrapper.tree->find_leaf_sibling_paths(leaves, rev.includeUncommitted, callback);
+        }
+
+    } else {
+        using Store = ContentAddressedCachedTreeStore<T>;
+        using Tree = ContentAddressedIndexedTree<Store, HashPolicy>;
+
+        auto& wrapper = std::get<TreeWithStore<Tree>>(fork->_trees.at(id));
+        if (rev.blockNumber) {
+            wrapper.tree->find_leaf_sibling_paths(leaves, rev.blockNumber, rev.includeUncommitted, callback);
+        } else {
+            wrapper.tree->find_leaf_sibling_paths(leaves, rev.includeUncommitted, callback);
+        }
+    }
+
+    signal.wait_for_level(0);
+
+    if (!local.success || local.inner.leaf_paths.size() != leaves.size()) {
+        throw std::runtime_error(local.message);
+    }
+
+    paths = std::move(local.inner.leaf_paths);
 }
 
 template <typename T> void WorldState::append_leaves(MerkleTreeId id, const std::vector<T>& leaves, Fork::Id fork_id)

--- a/yarn-project/simulator/src/public/hinting_db_sources.ts
+++ b/yarn-project/simulator/src/public/hinting_db_sources.ts
@@ -459,6 +459,13 @@ export class HintingMerkleWriteOperations implements MerkleTreeWriteOperations {
     return await this.db.findLeafIndices(treeId, values);
   }
 
+  public async findSiblingPaths<ID extends MerkleTreeId, N extends number>(
+    treeId: ID,
+    values: MerkleTreeLeafType<ID>[],
+  ): Promise<(SiblingPath<N> | undefined)[]> {
+    return await this.db.findSiblingPaths(treeId, values);
+  }
+
   public async findLeafIndicesAfter<ID extends MerkleTreeId>(
     treeId: ID,
     values: MerkleTreeLeafType<ID>[],

--- a/yarn-project/stdlib/src/interfaces/merkle_tree_operations.ts
+++ b/yarn-project/stdlib/src/interfaces/merkle_tree_operations.ts
@@ -179,6 +179,16 @@ export interface MerkleTreeReadOperations {
   ): Promise<(bigint | undefined)[]>;
 
   /**
+   * Returns the sibling paths for the given leaf values
+   * @param treeId - The tree for which the index should be returned.
+   * @param values - The values to search for in the tree.
+   */
+  findSiblingPaths<ID extends MerkleTreeId, N extends number>(
+    treeId: ID,
+    values: MerkleTreeLeafType<ID>[],
+  ): Promise<(SiblingPath<N> | undefined)[]>;
+
+  /**
    * Returns the first index containing a leaf value after `startIndex`.
    * @param treeId - The tree for which the index should be returned.
    * @param value - The value to search for in the tree.

--- a/yarn-project/world-state/src/native/merkle_trees_facade.ts
+++ b/yarn-project/world-state/src/native/merkle_trees_facade.ts
@@ -46,6 +46,24 @@ export class MerkleTreesFacade implements MerkleTreeReadOperations {
     return this.findLeafIndicesAfter(treeId, values, 0n);
   }
 
+  async findSiblingPaths<N extends number>(
+    treeId: MerkleTreeId,
+    values: MerkleTreeLeafType<MerkleTreeId>[],
+  ): Promise<(SiblingPath<N> | undefined)[]> {
+    const response = await this.instance.call(WorldStateMessageType.FIND_SIBLING_PATHS, {
+      leaves: values.map(leaf => serializeLeaf(hydrateLeaf(treeId, leaf))),
+      revision: this.revision,
+      treeId,
+    });
+
+    return response.paths.map(path => {
+      if (!path) {
+        return undefined;
+      }
+      return new SiblingPath(path.length, path) as any;
+    });
+  }
+
   async findLeafIndicesAfter(
     treeId: MerkleTreeId,
     leaves: MerkleTreeLeafType<MerkleTreeId>[],

--- a/yarn-project/world-state/src/native/message.ts
+++ b/yarn-project/world-state/src/native/message.ts
@@ -16,6 +16,7 @@ export enum WorldStateMessageType {
 
   FIND_LEAF_INDICES,
   FIND_LOW_LEAF,
+  FIND_SIBLING_PATHS,
 
   APPEND_LEAVES,
   BATCH_INSERT,
@@ -350,6 +351,11 @@ interface FindLeafIndicesResponse {
   indices: bigint[];
 }
 
+interface FindSiblingPathsRequest extends WithTreeId, WithLeafValues, WithWorldStateRevision {}
+interface FindSiblingPathsResponse {
+  paths: Buffer[][];
+}
+
 interface FindLowLeafRequest extends WithTreeId, WithWorldStateRevision {
   key: Fr;
 }
@@ -446,6 +452,7 @@ export type WorldStateRequest = {
 
   [WorldStateMessageType.FIND_LEAF_INDICES]: FindLeafIndicesRequest;
   [WorldStateMessageType.FIND_LOW_LEAF]: FindLowLeafRequest;
+  [WorldStateMessageType.FIND_SIBLING_PATHS]: FindSiblingPathsRequest;
 
   [WorldStateMessageType.APPEND_LEAVES]: AppendLeavesRequest;
   [WorldStateMessageType.BATCH_INSERT]: BatchInsertRequest;
@@ -488,6 +495,7 @@ export type WorldStateResponse = {
 
   [WorldStateMessageType.FIND_LEAF_INDICES]: FindLeafIndicesResponse;
   [WorldStateMessageType.FIND_LOW_LEAF]: FindLowLeafResponse;
+  [WorldStateMessageType.FIND_SIBLING_PATHS]: FindSiblingPathsResponse;
 
   [WorldStateMessageType.APPEND_LEAVES]: void;
   [WorldStateMessageType.BATCH_INSERT]: BatchInsertResponse;


### PR DESCRIPTION
This PR introduces a new query to the native world state allowing for sibling paths to be retrieved by value.
