### PR TITLE
test: fix flakey test

### DIFF
--- a/yarn-project/archiver/src/archiver/archiver.ts
+++ b/yarn-project/archiver/src/archiver/archiver.ts
@@ -1155,6 +1155,7 @@ export class Archiver extends (EventEmitter as new () => ArchiverEmitter) implem
 
     // TODO(#13569): Compute proper finalized block number based on L1 finalized block.
     // We just force it 2 epochs worth of proven data for now.
+    // NOTE: update end-to-end/src/e2e_epochs/epochs_empty_blocks.test.ts as that uses finalised blocks in computations
     const finalizedBlockNumber = Math.max(provenBlockNumber - this.l1constants.epochDuration * 2, 0);
 
     const [latestBlockHeader, provenBlockHeader, finalizedBlockHeader] = await Promise.all([

--- a/yarn-project/end-to-end/src/e2e_epochs/epochs_empty_blocks.test.ts
+++ b/yarn-project/end-to-end/src/e2e_epochs/epochs_empty_blocks.test.ts
@@ -68,12 +68,15 @@ describe('e2e_epochs/epochs_empty_blocks', () => {
       epochNumber++;
 
       // Verify the state syncs
-      await test.waitForNodeToSync(provenBlockNumber, 'finalised');
+      await test.waitForNodeToSync(provenBlockNumber, 'proven');
       await test.verifyHistoricBlock(provenBlockNumber, true);
-      const expectedOldestHistoricBlock = provenBlockNumber - WORLD_STATE_BLOCK_HISTORY + 1;
+
+      // right now finalisation means a block is two L2 epochs deep. If this rule changes then we need this test needs to be updated
+      const finalizedBlockNumber = Math.max(provenBlockNumber - context.config.aztecEpochDuration * 2, 0);
+      const expectedOldestHistoricBlock = Math.max(finalizedBlockNumber - WORLD_STATE_BLOCK_HISTORY + 1, 1);
       const expectedBlockRemoved = expectedOldestHistoricBlock - 1;
       await test.waitForNodeToSync(expectedOldestHistoricBlock, 'historic');
-      await test.verifyHistoricBlock(Math.max(expectedOldestHistoricBlock, 1), true);
+      await test.verifyHistoricBlock(expectedOldestHistoricBlock, true);
       if (expectedBlockRemoved > 0) {
         await test.verifyHistoricBlock(expectedBlockRemoved, false);
       }


### PR DESCRIPTION
This PR attempts to fix the flakey `epochs_empty_blocks` test. There were a couple of problems with this test resulting from #13428:
- the test assumes it will run for N consecutive epochs
- but the test also waits for certain blocks to become proven/finalised/historical
- in #13428 the meaning of 'finalised' was changed. This caused the test to _skip_ entire epochs (e.g. entire epochs would be proven in the background while it waited for historical blocks)
- this PR replicates the 'finalised' logic from the archiver so that the epoch counter updates correctly