### PR TITLE
fix: do not cast numeric to bool

### DIFF
--- a/noir-projects/aztec-nr/aztec/src/messages/encryption/aes128.nr
+++ b/noir-projects/aztec-nr/aztec/src/messages/encryption/aes128.nr
@@ -278,7 +278,7 @@ impl LogEncryption for AES128 {
         let ciphertext_without_eph_pk_x = bytes_from_fields(ciphertext_without_eph_pk_x_fields);
 
         // First byte of the ciphertext represents the ephemeral public key sign
-        let eph_pk_sign_bool = ciphertext_without_eph_pk_x.get(0) as bool;
+        let eph_pk_sign_bool = ciphertext_without_eph_pk_x.get(0) != 0;
         // With the sign and the x-coordinate of the ephemeral public key, we can reconstruct the point
         let eph_pk = point_from_x_coord_and_sign(eph_pk_x, eph_pk_sign_bool);
 

--- a/noir-projects/aztec-nr/aztec/src/note/retrieved_note.nr
+++ b/noir-projects/aztec-nr/aztec/src/note/retrieved_note.nr
@@ -41,7 +41,7 @@ where
 {
     let contract_address = AztecAddress::from_field(packed_retrieved_note[0]);
     let nonce = packed_retrieved_note[1];
-    let nonzero_note_hash_counter = packed_retrieved_note[2] != 0;
+    let nonzero_note_hash_counter = (packed_retrieved_note[2] as u1) != 0;
 
     let packed_note = subarray(packed_retrieved_note, RETRIEVED_NOTE_OVERHEAD);
     let note = NOTE::unpack(packed_note);

--- a/noir-projects/aztec-nr/aztec/src/note/retrieved_note.nr
+++ b/noir-projects/aztec-nr/aztec/src/note/retrieved_note.nr
@@ -41,7 +41,7 @@ where
 {
     let contract_address = AztecAddress::from_field(packed_retrieved_note[0]);
     let nonce = packed_retrieved_note[1];
-    let nonzero_note_hash_counter = packed_retrieved_note[2] as bool;
+    let nonzero_note_hash_counter = packed_retrieved_note[2] != 0;
 
     let packed_note = subarray(packed_retrieved_note, RETRIEVED_NOTE_OVERHEAD);
     let note = NOTE::unpack(packed_note);

--- a/noir-projects/aztec-nr/aztec/src/oracle/keys.nr
+++ b/noir-projects/aztec-nr/aztec/src/oracle/keys.nr
@@ -13,16 +13,10 @@ pub unconstrained fn get_public_keys_and_partial_address(
     let result = get_public_keys_and_partial_address_oracle(address);
 
     let keys = PublicKeys {
-        npk_m: NpkM { inner: Point { x: result[0], y: result[1], is_infinite: result[2] as bool } },
-        ivpk_m: IvpkM {
-            inner: Point { x: result[3], y: result[4], is_infinite: result[5] as bool },
-        },
-        ovpk_m: OvpkM {
-            inner: Point { x: result[6], y: result[7], is_infinite: result[8] as bool },
-        },
-        tpk_m: TpkM {
-            inner: Point { x: result[9], y: result[10], is_infinite: result[11] as bool },
-        },
+        npk_m: NpkM { inner: Point { x: result[0], y: result[1], is_infinite: result[2] != 0 } },
+        ivpk_m: IvpkM { inner: Point { x: result[3], y: result[4], is_infinite: result[5] != 0 } },
+        ovpk_m: OvpkM { inner: Point { x: result[6], y: result[7], is_infinite: result[8] != 0 } },
+        tpk_m: TpkM { inner: Point { x: result[9], y: result[10], is_infinite: result[11] != 0 } },
     };
 
     let partial_address = PartialAddress::from_field(result[12]);

--- a/noir-projects/noir-contracts/contracts/app/token_blacklist_contract/src/types/roles.nr
+++ b/noir-projects/noir-contracts/contracts/app/token_blacklist_contract/src/types/roles.nr
@@ -63,11 +63,7 @@ impl Serialize<3> for UserFlags {
 // after having received the serialized value as a return-value
 impl Deserialize<3> for UserFlags {
     fn deserialize(fields: [Field; 3]) -> Self {
-        Self {
-            is_admin: fields[0] as bool,
-            is_minter: fields[1] as bool,
-            is_blacklisted: fields[2] as bool,
-        }
+        Self { is_admin: fields[0] != 0, is_minter: fields[1] != 0, is_blacklisted: fields[2] != 0 }
     }
 }
 

--- a/noir-projects/noir-protocol-circuits/crates/types/src/abis/avm_circuit_public_inputs.nr
+++ b/noir-projects/noir-protocol-circuits/crates/types/src/abis/avm_circuit_public_inputs.nr
@@ -244,7 +244,7 @@ impl Deserialize<AVM_CIRCUIT_PUBLIC_INPUTS_LENGTH> for AvmCircuitPublicInputs {
             ),
             accumulated_data: reader.read_struct(AvmAccumulatedData::deserialize),
             transaction_fee: reader.read(),
-            reverted: reader.read() as bool,
+            reverted: reader.read() != 0,
         };
         reader.finish();
         item

--- a/noir-projects/noir-protocol-circuits/crates/types/src/abis/avm_circuit_public_inputs.nr
+++ b/noir-projects/noir-protocol-circuits/crates/types/src/abis/avm_circuit_public_inputs.nr
@@ -244,7 +244,7 @@ impl Deserialize<AVM_CIRCUIT_PUBLIC_INPUTS_LENGTH> for AvmCircuitPublicInputs {
             ),
             accumulated_data: reader.read_struct(AvmAccumulatedData::deserialize),
             transaction_fee: reader.read(),
-            reverted: reader.read() != 0,
+            reverted: reader.read_bool(),
         };
         reader.finish();
         item

--- a/noir-projects/noir-protocol-circuits/crates/types/src/abis/call_context.nr
+++ b/noir-projects/noir-protocol-circuits/crates/types/src/abis/call_context.nr
@@ -44,7 +44,7 @@ impl Deserialize<CALL_CONTEXT_LENGTH> for CallContext {
             msg_sender: AztecAddress::from_field(reader.read()),
             contract_address: AztecAddress::from_field(reader.read()),
             function_selector: FunctionSelector::from_field(reader.read()),
-            is_static_call: reader.read() != 0,
+            is_static_call: reader.read_bool(),
         }
     }
 }

--- a/noir-projects/noir-protocol-circuits/crates/types/src/abis/call_context.nr
+++ b/noir-projects/noir-protocol-circuits/crates/types/src/abis/call_context.nr
@@ -44,7 +44,7 @@ impl Deserialize<CALL_CONTEXT_LENGTH> for CallContext {
             msg_sender: AztecAddress::from_field(reader.read()),
             contract_address: AztecAddress::from_field(reader.read()),
             function_selector: FunctionSelector::from_field(reader.read()),
-            is_static_call: reader.read() as bool,
+            is_static_call: reader.read() != 0,
         }
     }
 }

--- a/noir-projects/noir-protocol-circuits/crates/types/src/abis/function_data.nr
+++ b/noir-projects/noir-protocol-circuits/crates/types/src/abis/function_data.nr
@@ -28,7 +28,7 @@ impl Deserialize<FUNCTION_DATA_LENGTH> for FunctionData {
     fn deserialize(serialized: [Field; FUNCTION_DATA_LENGTH]) -> Self {
         Self {
             selector: FunctionSelector::from_field(serialized[0]),
-            is_private: serialized[1] as bool,
+            is_private: serialized[1] != 0,
         }
     }
 }

--- a/noir-projects/noir-protocol-circuits/crates/types/src/abis/max_block_number.nr
+++ b/noir-projects/noir-protocol-circuits/crates/types/src/abis/max_block_number.nr
@@ -25,7 +25,7 @@ impl Serialize<MAX_BLOCK_NUMBER_LENGTH> for MaxBlockNumber {
 impl Deserialize<MAX_BLOCK_NUMBER_LENGTH> for MaxBlockNumber {
     fn deserialize(serialized: [Field; MAX_BLOCK_NUMBER_LENGTH]) -> MaxBlockNumber {
         MaxBlockNumber {
-            _opt: if serialized[0] as bool {
+            _opt: if serialized[0] != 0 {
                 Option::some(serialized[1] as u32)
             } else {
                 Option::none()

--- a/noir-projects/noir-protocol-circuits/crates/types/src/abis/public_call_request.nr
+++ b/noir-projects/noir-protocol-circuits/crates/types/src/abis/public_call_request.nr
@@ -56,7 +56,7 @@ impl Deserialize<PUBLIC_CALL_REQUEST_LENGTH> for PublicCallRequest {
         let request = PublicCallRequest {
             msg_sender: AztecAddress::from_field(reader.read()),
             contract_address: AztecAddress::from_field(reader.read()),
-            is_static_call: reader.read() as bool,
+            is_static_call: reader.read() != 0,
             calldata_hash: reader.read(),
         };
         reader.finish();
@@ -119,7 +119,7 @@ impl Deserialize<NUM_PUBLIC_CALL_REQUEST_ARRAYS> for PublicCallRequestArrayLengt
         let item = PublicCallRequestArrayLengths {
             setup_calls: reader.read_u32(),
             app_logic_calls: reader.read_u32(),
-            teardown_call: reader.read() as bool,
+            teardown_call: reader.read() != 0,
         };
 
         reader.finish();

--- a/noir-projects/noir-protocol-circuits/crates/types/src/abis/public_call_request.nr
+++ b/noir-projects/noir-protocol-circuits/crates/types/src/abis/public_call_request.nr
@@ -56,7 +56,7 @@ impl Deserialize<PUBLIC_CALL_REQUEST_LENGTH> for PublicCallRequest {
         let request = PublicCallRequest {
             msg_sender: AztecAddress::from_field(reader.read()),
             contract_address: AztecAddress::from_field(reader.read()),
-            is_static_call: reader.read() != 0,
+            is_static_call: reader.read_bool(),
             calldata_hash: reader.read(),
         };
         reader.finish();
@@ -119,7 +119,7 @@ impl Deserialize<NUM_PUBLIC_CALL_REQUEST_ARRAYS> for PublicCallRequestArrayLengt
         let item = PublicCallRequestArrayLengths {
             setup_calls: reader.read_u32(),
             app_logic_calls: reader.read_u32(),
-            teardown_call: reader.read() != 0,
+            teardown_call: reader.read_bool(),
         };
 
         reader.finish();

--- a/noir-projects/noir-protocol-circuits/crates/types/src/abis/sponge_blob.nr
+++ b/noir-projects/noir-protocol-circuits/crates/types/src/abis/sponge_blob.nr
@@ -91,7 +91,7 @@ impl Deserialize<SPONGE_BLOB_LENGTH> for SpongeBlob {
                 cache: [fields[0], fields[1], fields[2]],
                 state: [fields[3], fields[4], fields[5], fields[6]],
                 cache_size: fields[7] as u32,
-                squeeze_mode: fields[8] as bool,
+                squeeze_mode: fields[8] != 0,
             },
             fields: fields[9] as u32,
             expected_fields: fields[10] as u32,

--- a/noir-projects/noir-protocol-circuits/crates/types/src/abis/validation_requests/key_validation_request.nr
+++ b/noir-projects/noir-protocol-circuits/crates/types/src/abis/validation_requests/key_validation_request.nr
@@ -27,7 +27,7 @@ impl Serialize<KEY_VALIDATION_REQUEST_LENGTH> for KeyValidationRequest {
 impl Deserialize<KEY_VALIDATION_REQUEST_LENGTH> for KeyValidationRequest {
     fn deserialize(fields: [Field; KEY_VALIDATION_REQUEST_LENGTH]) -> Self {
         Self {
-            pk_m: Point { x: fields[0], y: fields[1], is_infinite: fields[2] as bool },
+            pk_m: Point { x: fields[0], y: fields[1], is_infinite: fields[2] != 0 },
             sk_app: fields[3],
         }
     }

--- a/noir-projects/noir-protocol-circuits/crates/types/src/meta/mod.nr
+++ b/noir-projects/noir-protocol-circuits/crates/types/src/meta/mod.nr
@@ -111,6 +111,10 @@ pub comptime fn generate_deserialize_from_fields(
         result = quote { $unpack_method([ $packed_fields ]) };
 
         consumed_counter = packed_len;
+    } else if typ.is_bool() {
+        // The field is a primitive so we just reference it in the field array
+        result = quote { $field_array_name[$num_already_consumed] != 0 };
+        consumed_counter = 1;
     } else if typ.is_field() | typ.as_integer().is_some() | typ.is_bool() {
         // The field is a primitive so we just reference it in the field array
         result = quote { $field_array_name[$num_already_consumed] as $typ };

--- a/noir-projects/noir-protocol-circuits/crates/types/src/meta/mod.nr
+++ b/noir-projects/noir-protocol-circuits/crates/types/src/meta/mod.nr
@@ -115,7 +115,7 @@ pub comptime fn generate_deserialize_from_fields(
         // The field is a primitive so we just reference it in the field array
         result = quote { $field_array_name[$num_already_consumed] != 0 };
         consumed_counter = 1;
-    } else if typ.is_field() | typ.as_integer().is_some() | typ.is_bool() {
+    } else if typ.is_field() | typ.as_integer().is_some() {
         // The field is a primitive so we just reference it in the field array
         result = quote { $field_array_name[$num_already_consumed] as $typ };
         consumed_counter = 1;

--- a/noir-projects/noir-protocol-circuits/crates/types/src/point.nr
+++ b/noir-projects/noir-protocol-circuits/crates/types/src/point.nr
@@ -25,7 +25,7 @@ impl Empty for Point {
 
 impl Deserialize<POINT_LENGTH> for Point {
     fn deserialize(serialized: [Field; POINT_LENGTH]) -> Point {
-        Point { x: serialized[0], y: serialized[1], is_infinite: serialized[2] as bool }
+        Point { x: serialized[0], y: serialized[1], is_infinite: serialized[2] != 0 }
     }
 }
 // TODO(#11356): use compact representation here.

--- a/noir-projects/noir-protocol-circuits/crates/types/src/public_keys.nr
+++ b/noir-projects/noir-protocol-circuits/crates/types/src/public_keys.nr
@@ -165,28 +165,28 @@ impl Deserialize<PUBLIC_KEYS_LENGTH> for PublicKeys {
                 inner: Point {
                     x: serialized[0],
                     y: serialized[1],
-                    is_infinite: serialized[2] as bool,
+                    is_infinite: serialized[2] != 0,
                 },
             },
             ivpk_m: IvpkM {
                 inner: Point {
                     x: serialized[3],
                     y: serialized[4],
-                    is_infinite: serialized[5] as bool,
+                    is_infinite: serialized[5] != 0,
                 },
             },
             ovpk_m: OvpkM {
                 inner: Point {
                     x: serialized[6],
                     y: serialized[7],
-                    is_infinite: serialized[8] as bool,
+                    is_infinite: serialized[8] != 0,
                 },
             },
             tpk_m: TpkM {
                 inner: Point {
                     x: serialized[9],
                     y: serialized[10],
-                    is_infinite: serialized[11] as bool,
+                    is_infinite: serialized[11] != 0,
                 },
             },
         }

--- a/noir-projects/noir-protocol-circuits/crates/types/src/shared_mutable/shared_mutable_values.nr
+++ b/noir-projects/noir-protocol-circuits/crates/types/src/shared_mutable/shared_mutable_values.nr
@@ -55,13 +55,13 @@ pub fn unpack_delay_change<let INITIAL_DELAY: u32>(
     let sdc_block_of_change = tmp as u32;
 
     tmp = (tmp - sdc_block_of_change as Field) / TWO_POW_32;
-    let sdc_post_is_some = tmp != 0;
+    let sdc_post_is_some = (tmp as u1) != 0;
 
     tmp = (tmp - sdc_post_is_some as Field) / TWO_POW_8;
     let sdc_post_inner = tmp as u32;
 
     tmp = (tmp - sdc_post_inner as Field) / TWO_POW_32;
-    let sdc_pre_is_some = tmp != 0;
+    let sdc_pre_is_some = (tmp as u1) != 0;
 
     tmp = (tmp - sdc_pre_is_some as Field) / TWO_POW_8;
     let sdc_pre_inner = tmp as u32;

--- a/noir-projects/noir-protocol-circuits/crates/types/src/shared_mutable/shared_mutable_values.nr
+++ b/noir-projects/noir-protocol-circuits/crates/types/src/shared_mutable/shared_mutable_values.nr
@@ -55,13 +55,13 @@ pub fn unpack_delay_change<let INITIAL_DELAY: u32>(
     let sdc_block_of_change = tmp as u32;
 
     tmp = (tmp - sdc_block_of_change as Field) / TWO_POW_32;
-    let sdc_post_is_some = tmp as bool;
+    let sdc_post_is_some = tmp != 0;
 
     tmp = (tmp - sdc_post_is_some as Field) / TWO_POW_8;
     let sdc_post_inner = tmp as u32;
 
     tmp = (tmp - sdc_post_inner as Field) / TWO_POW_32;
-    let sdc_pre_is_some = tmp as bool;
+    let sdc_pre_is_some = tmp != 0;
 
     tmp = (tmp - sdc_pre_is_some as Field) / TWO_POW_8;
     let sdc_pre_inner = tmp as u32;

--- a/noir-projects/noir-protocol-circuits/crates/types/src/traits.nr
+++ b/noir-projects/noir-protocol-circuits/crates/types/src/traits.nr
@@ -158,7 +158,7 @@ impl FromField for Field {
 impl FromField for bool {
     #[inline_always]
     fn from_field(value: Field) -> Self {
-        value as bool
+        value != 0
     }
 }
 impl FromField for u1 {

--- a/noir-projects/noir-protocol-circuits/crates/types/src/type_packing.nr
+++ b/noir-projects/noir-protocol-circuits/crates/types/src/type_packing.nr
@@ -18,7 +18,7 @@ impl Packable<BOOL_PACKED_LEN> for bool {
     }
 
     fn unpack(fields: [Field; BOOL_PACKED_LEN]) -> bool {
-        fields[0] as bool
+        fields[0] != 0
     }
 }
 

--- a/noir-projects/noir-protocol-circuits/crates/types/src/type_packing.nr
+++ b/noir-projects/noir-protocol-circuits/crates/types/src/type_packing.nr
@@ -18,7 +18,7 @@ impl Packable<BOOL_PACKED_LEN> for bool {
     }
 
     fn unpack(fields: [Field; BOOL_PACKED_LEN]) -> bool {
-        fields[0] != 0
+        (fields[0] as u1) != 0
     }
 }
 

--- a/noir-projects/noir-protocol-circuits/crates/types/src/type_serialization.nr
+++ b/noir-projects/noir-protocol-circuits/crates/types/src/type_serialization.nr
@@ -20,7 +20,7 @@ impl Serialize<BOOL_SERIALIZED_LEN> for bool {
 
 impl Deserialize<BOOL_SERIALIZED_LEN> for bool {
     fn deserialize(fields: [Field; BOOL_SERIALIZED_LEN]) -> bool {
-        fields[0] as bool
+        fields[0] != 0
     }
 }
 

--- a/noir-projects/noir-protocol-circuits/crates/types/src/utils/reader.nr
+++ b/noir-projects/noir-protocol-circuits/crates/types/src/utils/reader.nr
@@ -19,7 +19,7 @@ impl<let N: u32> Reader<N> {
     }
 
     pub fn read_bool(&mut self) -> bool {
-        self.read() as bool
+        self.read() != 0
     }
 
     pub fn read_array<let K: u32>(&mut self) -> [Field; K] {


### PR DESCRIPTION
For https://github.com/noir-lang/noir/pull/8703

In Noir, casting a number to bool is the same as casting that number to `u1` first, then checking if that `u1` is 0 or 1. That might be a bit unexpected, and actually in Rust you can't cast numbers to bool, so it's going to be disallowed soon.

This PR changes `as bool` to `!= 0` in most cases, though in some unpacking cases it seems the desired behavior was actually `(value as u1) != 0`, so there are a couple of those (without these a couple of tests fail).