### PR TITLE
fix: correctly decoding string return value

### DIFF
--- a/yarn-project/stdlib/src/abi/decoder.test.ts
+++ b/yarn-project/stdlib/src/abi/decoder.test.ts
@@ -263,9 +263,7 @@ describe('decoder', () => {
       1n,
       2n,
       false,
-      // TODO(#14600): correctly decode the string as string instead of 3 bigints
-      // 'xyz',
-      [120n, 121n, 122n],
+      'xyz',
       AztecAddress.fromBigInt(1n),
       // eslint-disable-next-line camelcase
       { x: 1n, y: 2n, is_infinite: false },

--- a/yarn-project/stdlib/src/abi/decoder.ts
+++ b/yarn-project/stdlib/src/abi/decoder.ts
@@ -7,7 +7,7 @@ import { isAztecAddressStruct, parseSignedInt } from './utils.js';
 /**
  * The type of our decoded ABI.
  */
-export type AbiDecoded = bigint | boolean | AztecAddress | AbiDecoded[] | { [key: string]: AbiDecoded };
+export type AbiDecoded = bigint | boolean | string | AztecAddress | AbiDecoded[] | { [key: string]: AbiDecoded };
 
 /**
  * Decodes values using a provided ABI.
@@ -58,11 +58,12 @@ class AbiDecoder {
         return struct;
       }
       case 'string': {
-        const array = [];
+        let str = '';
         for (let i = 0; i < abiType.length; i += 1) {
-          array.push(this.getNextField().toBigInt());
+          const charCode = Number(this.getNextField().toBigInt());
+          str += String.fromCharCode(charCode);
         }
-        return array;
+        return str;
       }
       case 'tuple': {
         const array = [];


### PR DESCRIPTION
This pull request addresses an issue where the ABI decoder incorrectly returns string values as numeric byte arrays (e.g., [120n, 121n, 122n]) instead of the expected string ("xyz"). The fix modifies the `AbiDecoder` class to properly parse and convert byte-array-based string representations into their corresponding string literals.

Fixes #14600