### PR TITLE
chore: "deallocate" ck before reinitializing

### DIFF
--- a/barretenberg/cpp/src/barretenberg/client_ivc/client_ivc.hpp
+++ b/barretenberg/cpp/src/barretenberg/client_ivc/client_ivc.hpp
@@ -167,6 +167,7 @@ class ClientIVC {
     // Settings related to the use of fixed block sizes for each gate in the execution trace
     TraceSettings trace_settings;
 
+    // TODO(https://github.com/AztecProtocol/barretenberg/issues/1414): remove use of shared_ptr for commitment key
     std::shared_ptr<typename MegaFlavor::CommitmentKey> bn254_commitment_key;
 
     Goblin goblin;

--- a/barretenberg/cpp/src/barretenberg/goblin/goblin.cpp
+++ b/barretenberg/cpp/src/barretenberg/goblin/goblin.cpp
@@ -20,10 +20,10 @@ Goblin::Goblin(const std::shared_ptr<CommitmentKey<curve::BN254>>& bn254_commitm
     , transcript(transcript)
 {}
 
-Goblin::MergeProof Goblin::prove_merge()
+Goblin::MergeProof Goblin::prove_merge(const std::shared_ptr<CommitmentKey<curve::BN254>>& bn254_commitment_key)
 {
     PROFILE_THIS_NAME("Goblin::merge");
-    MergeProver merge_prover{ op_queue, commitment_key };
+    MergeProver merge_prover{ op_queue, bn254_commitment_key };
     merge_proof = merge_prover.construct_proof();
     return merge_proof;
 }

--- a/barretenberg/cpp/src/barretenberg/goblin/goblin.hpp
+++ b/barretenberg/cpp/src/barretenberg/goblin/goblin.hpp
@@ -60,7 +60,7 @@ class Goblin {
      *
      * @param circuit_builder
      */
-    MergeProof prove_merge();
+    MergeProof prove_merge(const std::shared_ptr<CommitmentKey<curve::BN254>>& bn254_commitment_key = nullptr);
 
     /**
      * @brief Construct the final merge proof, where the prover shares a transcript with ECCVM and Translator.


### PR DESCRIPTION
Previously, in cases where we needed to reallocate a commitment key in CIVC (e.g. overflow) we would temporarily store both the old and the new keys, leading to a spike in memory that seems to have been responsible for the overall peak in these cases. This change attempts to deallocate the old key before constructing the new one.

Note: calling `reset()` on a shared pointer does not in general release the underlying memory since the ref count may be nonzero. A general [issue](https://github.com/AztecProtocol/barretenberg/issues/1414) for removing uses of shared_ptr when something else is more appropriate.