### PR TITLE
chore: dont enable manifest in places where it could lead to fragmentation

### DIFF
--- a/barretenberg/cpp/src/barretenberg/client_ivc/client_ivc.cpp
+++ b/barretenberg/cpp/src/barretenberg/client_ivc/client_ivc.cpp
@@ -343,7 +343,6 @@ HonkProof ClientIVC::construct_and_prove_hiding_circuit()
 {
     // Create a transcript to be shared by final merge prover, ECCVM, Translator, and Hiding Circuit provers.
     goblin.transcript = std::make_shared<Goblin::Transcript>();
-    goblin.transcript->enable_manifest();
     auto decider_pk = construct_hiding_circuit_key();
     // Hiding circuit is proven by a MegaZKProver
     MegaZKProver prover(decider_pk, goblin.transcript);

--- a/barretenberg/cpp/src/barretenberg/stdlib/protogalaxy_verifier/protogalaxy_recursive_verifier.cpp
+++ b/barretenberg/cpp/src/barretenberg/stdlib/protogalaxy_verifier/protogalaxy_recursive_verifier.cpp
@@ -25,7 +25,6 @@ void ProtogalaxyRecursiveVerifier_<DeciderVerificationKeys>::run_oink_verifier_o
     const std::vector<FF>& proof)
 {
     transcript = std::make_shared<Transcript>(proof);
-    transcript->enable_manifest();
     size_t index = 0;
     auto key = keys_to_fold[0];
     auto domain_separator = std::to_string(index);

--- a/barretenberg/cpp/src/barretenberg/stdlib/protogalaxy_verifier/protogalaxy_recursive_verifier.cpp
+++ b/barretenberg/cpp/src/barretenberg/stdlib/protogalaxy_verifier/protogalaxy_recursive_verifier.cpp
@@ -25,6 +25,7 @@ void ProtogalaxyRecursiveVerifier_<DeciderVerificationKeys>::run_oink_verifier_o
     const std::vector<FF>& proof)
 {
     transcript = std::make_shared<Transcript>(proof);
+    transcript->enable_manifest();
     size_t index = 0;
     auto key = keys_to_fold[0];
     auto domain_separator = std::to_string(index);


### PR DESCRIPTION
The transcript manifest mechanism is strictly a debugging tool for ensuring that a prover and verifier interact with the transcript in the same way. Using it in production has been observed in some cases to lead to memory fragmentation since it involves growing small vectors of data at runtime. This PR turns it off in one location where this phenomenon might come into play. 