### PR TITLE
feat: auto-deriving `Serialize` for events

### DIFF
--- a/noir-projects/aztec-nr/aztec/src/macros/events.nr
+++ b/noir-projects/aztec-nr/aztec/src/macros/events.nr
@@ -1,4 +1,5 @@
 use super::utils::{compute_event_selector, get_trait_impl_method};
+use protocol_types::meta::derive_serialize;
 
 comptime fn generate_event_interface(s: TypeDefinition) -> Quoted {
     let name = s.name();
@@ -20,10 +21,37 @@ comptime fn generate_event_interface(s: TypeDefinition) -> Quoted {
     }
 }
 
+/// Generates a quote that implements `Serialize` for a given struct `s`.
+/// If the struct already implements `Serialize`, we return an empty quote.
+// TODO(#11571): Drop this function and use the `derive_packable_if_not_implemented_and_get_len` function instead.
+comptime fn derive_serialize_if_not_implemented(s: TypeDefinition) -> Quoted {
+    // We try to get the serialized length of the struct. If it does not implement `Serialize`, we get Option::none()
+    let serialized_len_typ = std::meta::typ::fresh_type_variable();
+    // We don't care about the result of the implements check. We just want to get the serialized length.
+    let _ = s.as_type().implements(
+        quote { crate::protocol_types::traits::Serialize<$serialized_len_typ> }.as_trait_constraint(),
+    );
+    let maybe_serialized_length = serialized_len_typ.as_constant();
+
+    if maybe_serialized_length.is_some() {
+        // We got some serialized length meaning that the struct implements `Serialize`. For this reason we return
+        // an empty quote for the implementation.
+        quote {}
+    } else {
+        // We didn't manage to get the serialized length which means the struct doesn't implement `Serialize`
+        // so we derive it.
+        derive_serialize(s)
+    }
+}
+
 pub comptime fn event(s: TypeDefinition) -> Quoted {
-    let event_interface = generate_event_interface(s);
+    let event_interface_impl = generate_event_interface(s);
+    let serialize_impl = derive_serialize_if_not_implemented(s);
+
     s.add_attribute("abi(events)");
+
     quote {
-        $event_interface
+        $event_interface_impl
+        $serialize_impl
     }
 }

--- a/noir-projects/noir-contracts/contracts/app/crowdfunding_contract/src/main.nr
+++ b/noir-projects/noir-contracts/contracts/app/crowdfunding_contract/src/main.nr
@@ -17,17 +17,14 @@ pub contract Crowdfunding {
         },
         messages::logs::note::encode_and_encrypt_note,
         prelude::{AztecAddress, PrivateSet, PublicImmutable},
-        protocol_types::traits::Serialize,
         utils::comparison::Comparator,
     };
     use dep::uint_note::uint_note::UintNote;
     use router::utils::privately_check_timestamp;
-    use std::meta::derive;
     use token::Token;
     // docs:end:all-deps
 
     // docs:start:withdrawal-processed-event
-    #[derive(Serialize)]
     #[event]
     struct WithdrawalProcessed {
         who: AztecAddress,

--- a/noir-projects/noir-contracts/contracts/app/nft_contract/src/main.nr
+++ b/noir-projects/noir-contracts/contracts/app/nft_contract/src/main.nr
@@ -2,18 +2,18 @@
 mod types;
 mod test;
 
-use dep::aztec::macros::aztec;
+use aztec::macros::aztec;
 
 // Minimal NFT implementation with `AuthWit` support that allows minting in public-only and transfers in both public
 // and private.
 #[aztec]
 pub contract NFT {
     use crate::types::nft_note::{NFTNote, PartialNFTNote};
-    use dep::authwit::auth::{
+    use authwit::auth::{
         assert_current_call_valid_authwit, assert_current_call_valid_authwit_public,
         compute_authwit_nullifier,
     };
-    use dep::aztec::{
+    use aztec::{
         macros::{
             events::event,
             functions::{initializer, internal, private, public, utility, view},
@@ -25,10 +25,10 @@ pub contract NFT {
             AztecAddress, Map, NoteGetterOptions, NoteViewerOptions, PrivateContext, PrivateSet,
             PublicContext, PublicImmutable, PublicMutable,
         },
+        protocol_types::traits::ToField,
         utils::comparison::Comparator,
     };
-    use dep::compressed_string::FieldCompressedString;
-    use aztec::protocol_types::traits::ToField;
+    use compressed_string::FieldCompressedString;
 
     // docs:end:imports
 

--- a/noir-projects/noir-contracts/contracts/app/nft_contract/src/main.nr
+++ b/noir-projects/noir-contracts/contracts/app/nft_contract/src/main.nr
@@ -25,18 +25,15 @@ pub contract NFT {
             AztecAddress, Map, NoteGetterOptions, NoteViewerOptions, PrivateContext, PrivateSet,
             PublicContext, PublicImmutable, PublicMutable,
         },
-        protocol_types::traits::Serialize,
         utils::comparison::Comparator,
     };
     use dep::compressed_string::FieldCompressedString;
     use aztec::protocol_types::traits::ToField;
-    use std::meta::derive;
 
     // docs:end:imports
 
     // TODO(#8467): Rename this to Transfer - calling this NFTTransfer to avoid export conflict with the Transfer event
     // in the Token contract.
-    #[derive(Serialize)]
     #[event]
     struct NFTTransfer {
         from: AztecAddress,

--- a/noir-projects/noir-contracts/contracts/app/orderbook_contract/src/main.nr
+++ b/noir-projects/noir-contracts/contracts/app/orderbook_contract/src/main.nr
@@ -41,20 +41,18 @@ pub contract Orderbook {
         },
         oracle::notes::check_nullifier_exists,
         prelude::{AztecAddress, Map, PublicImmutable},
-        protocol_types::traits::{FromField, Serialize, ToField},
+        protocol_types::traits::{FromField, ToField},
     };
 
     use token::Token;
     use uint_note::uint_note::PartialUintNote;
 
     // The event contains only the `order_id` as the order itself can be retrieved via the `get_order` function.
-    #[derive(Serialize)]
     #[event]
     struct OrderCreated {
         order_id: Field,
     }
 
-    #[derive(Serialize)]
     #[event]
     struct OrderFulfilled {
         order_id: Field,

--- a/noir-projects/noir-contracts/contracts/app/simple_token_contract/src/main.nr
+++ b/noir-projects/noir-contracts/contracts/app/simple_token_contract/src/main.nr
@@ -8,7 +8,7 @@ use dep::aztec::macros::aztec;
 
 #[aztec]
 pub contract SimpleToken {
-    use std::{meta::derive, ops::{Add, Sub}};
+    use std::ops::{Add, Sub};
 
     use dep::compressed_string::FieldCompressedString;
 
@@ -22,7 +22,6 @@ pub contract SimpleToken {
         },
         messages::logs::note::{encode_and_encrypt_note, encode_and_encrypt_note_unconstrained},
         prelude::{AztecAddress, Map, PublicContext, PublicImmutable, PublicMutable},
-        protocol_types::traits::Serialize,
     };
 
     use dep::uint_note::uint_note::{PartialUintNote, UintNote};
@@ -37,7 +36,6 @@ pub contract SimpleToken {
     global INITIAL_TRANSFER_CALL_MAX_NOTES: u32 = 2;
     global RECURSIVE_TRANSFER_CALL_MAX_NOTES: u32 = 8;
 
-    #[derive(Serialize)]
     #[event]
     struct Transfer {
         from: AztecAddress,

--- a/noir-projects/noir-contracts/contracts/app/token_contract/src/main.nr
+++ b/noir-projects/noir-contracts/contracts/app/token_contract/src/main.nr
@@ -14,7 +14,7 @@ use dep::aztec::macros::aztec;
 #[aztec]
 pub contract Token {
     // Libs
-    use std::{meta::derive, ops::{Add, Sub}};
+    use std::ops::{Add, Sub};
 
     use dep::compressed_string::FieldCompressedString;
 
@@ -28,7 +28,6 @@ pub contract Token {
         },
         messages::logs::note::{encode_and_encrypt_note, encode_and_encrypt_note_unconstrained},
         prelude::{AztecAddress, Map, PublicContext, PublicImmutable, PublicMutable},
-        protocol_types::traits::Serialize,
     };
 
     use dep::uint_note::uint_note::{PartialUintNote, UintNote};
@@ -54,7 +53,6 @@ pub contract Token {
     // an overall small circuit regardless.
     global RECURSIVE_TRANSFER_CALL_MAX_NOTES: u32 = 8;
 
-    #[derive(Serialize)]
     #[event]
     struct Transfer {
         from: AztecAddress,

--- a/noir-projects/noir-contracts/contracts/protocol/contract_instance_deployer_contract/src/main.nr
+++ b/noir-projects/noir-contracts/contracts/protocol/contract_instance_deployer_contract/src/main.nr
@@ -17,9 +17,7 @@ pub contract ContractInstanceDeployer {
         utils::arrays::array_concat,
     };
     use dep::contract_class_registerer::ContractClassRegisterer;
-    use std::meta::derive;
 
-    #[derive(Serialize)]
     #[event]
     struct ContractInstanceDeployed {
         DEPLOYER_CONTRACT_INSTANCE_DEPLOYED_MAGIC_VALUE: Field,
@@ -83,7 +81,6 @@ pub contract ContractInstanceDeployer {
         }
     }
 
-    #[derive(Serialize)]
     #[event]
     struct ContractInstanceUpdated {
         DEPLOYER_CONTRACT_INSTANCE_UPDATED_MAGIC_VALUE: Field,

--- a/noir-projects/noir-contracts/contracts/protocol/contract_instance_deployer_contract/src/main.nr
+++ b/noir-projects/noir-contracts/contracts/protocol/contract_instance_deployer_contract/src/main.nr
@@ -1,22 +1,24 @@
-use dep::aztec::macros::aztec;
+use aztec::macros::aztec;
 
 #[aztec]
 pub contract ContractInstanceDeployer {
-    use dep::aztec::macros::{events::event, functions::{private, public, view}, storage::storage};
-    use dep::aztec::prelude::{Map, SharedMutable};
-    use dep::aztec::protocol_types::{
-        address::{AztecAddress, PartialAddress},
-        constants::{
-            DEFAULT_UPDATE_DELAY, DEPLOYER_CONTRACT_INSTANCE_DEPLOYED_MAGIC_VALUE,
-            DEPLOYER_CONTRACT_INSTANCE_UPDATED_MAGIC_VALUE, MINIMUM_UPDATE_DELAY,
-            REGISTERER_CONTRACT_ADDRESS,
+    use aztec::{
+        macros::{events::event, functions::{private, public, view}, storage::storage},
+        prelude::{Map, SharedMutable},
+        protocol_types::{
+            address::{AztecAddress, PartialAddress},
+            constants::{
+                DEFAULT_UPDATE_DELAY, DEPLOYER_CONTRACT_INSTANCE_DEPLOYED_MAGIC_VALUE,
+                DEPLOYER_CONTRACT_INSTANCE_UPDATED_MAGIC_VALUE, MINIMUM_UPDATE_DELAY,
+                REGISTERER_CONTRACT_ADDRESS,
+            },
+            contract_class_id::ContractClassId,
+            public_keys::PublicKeys,
+            traits::{Serialize, ToField},
+            utils::arrays::array_concat,
         },
-        contract_class_id::ContractClassId,
-        public_keys::PublicKeys,
-        traits::{Serialize, ToField},
-        utils::arrays::array_concat,
     };
-    use dep::contract_class_registerer::ContractClassRegisterer;
+    use contract_class_registerer::ContractClassRegisterer;
 
     #[event]
     struct ContractInstanceDeployed {
@@ -135,7 +137,7 @@ pub contract ContractInstanceDeployer {
         };
 
         let payload = event.serialize_non_standard();
-        dep::aztec::oracle::debug_log::debug_log_format("ContractInstanceDeployed: {}", payload);
+        aztec::oracle::debug_log::debug_log_format("ContractInstanceDeployed: {}", payload);
 
         let padded_log = array_concat(payload, [0; 3]);
         // Only the payload needs to be emitted. Since the siloed tag of this event log is publicly known, it's

--- a/noir-projects/noir-contracts/contracts/test/event_only_contract/src/main.nr
+++ b/noir-projects/noir-contracts/contracts/test/event_only_contract/src/main.nr
@@ -5,13 +5,10 @@ use aztec::macros::aztec;
 #[aztec]
 contract EventOnly {
     use aztec::{
-        event::event_interface::{emit_event_in_private_log, EventInterface, PrivateLogContent},
+        event::event_interface::{emit_event_in_private_log, PrivateLogContent},
         macros::{events::event, functions::private},
-        protocol_types::traits::Serialize,
     };
-    use std::meta::derive;
 
-    #[derive(Serialize)]
     #[event]
     struct TestEvent {
         value: Field,

--- a/noir-projects/noir-contracts/contracts/test/test_contract/src/main.nr
+++ b/noir-projects/noir-contracts/contracts/test/test_contract/src/main.nr
@@ -60,7 +60,6 @@ pub contract Test {
     use address_note::address_note::AddressNote;
     use value_note::value_note::ValueNote;
 
-    #[derive(Serialize)]
     #[event]
     struct ExampleEvent {
         value0: Field,

--- a/noir-projects/noir-contracts/contracts/test/test_log_contract/src/main.nr
+++ b/noir-projects/noir-contracts/contracts/test/test_log_contract/src/main.nr
@@ -1,25 +1,23 @@
-use dep::aztec::macros::aztec;
+use aztec::macros::aztec;
 
 #[aztec]
 pub contract TestLog {
-    use dep::aztec::macros::{events::event, functions::{private, public}, storage::storage};
-    use dep::aztec::prelude::PrivateSet;
-    use dep::aztec::protocol_types::{address::AztecAddress, traits::Serialize};
-    use dep::value_note::value_note::ValueNote;
-    use aztec::event::event_interface::{
-        emit_event_in_private_log, emit_event_in_public_log, PrivateLogContent,
+    use aztec::{
+        event::event_interface::{
+            emit_event_in_private_log, emit_event_in_public_log, PrivateLogContent,
+        },
+        macros::{events::event, functions::{private, public}, storage::storage},
+        prelude::PrivateSet,
+        protocol_types::{address::AztecAddress, traits::FromField},
     };
-    use aztec::protocol_types::traits::FromField;
-    use std::meta::derive;
+    use value_note::value_note::ValueNote;
 
-    #[derive(Serialize)]
     #[event]
     struct ExampleEvent0 {
         value0: Field,
         value1: Field,
     }
 
-    #[derive(Serialize)]
     #[event]
     struct ExampleEvent1 {
         value2: AztecAddress,

--- a/noir-projects/noir-protocol-circuits/crates/types/src/meta/mod.nr
+++ b/noir-projects/noir-protocol-circuits/crates/types/src/meta/mod.nr
@@ -423,7 +423,7 @@ comptime fn collapse_to_one_token(q: Quoted) -> Quoted {
     single_token
 }
 
-pub(crate) comptime fn derive_serialize(s: TypeDefinition) -> Quoted {
+pub comptime fn derive_serialize(s: TypeDefinition) -> Quoted {
     let typ = s.as_type();
     let (fields, aux_vars) = generate_serialize_to_fields(quote { self }, typ, false);
     let aux_vars_for_serialization = if aux_vars.len() > 0 {
@@ -435,8 +435,10 @@ pub(crate) comptime fn derive_serialize(s: TypeDefinition) -> Quoted {
 
     let field_serializations = fields.join(quote {,});
     let serialized_len = fields.len();
+    let serialize_trait: TraitConstraint =
+        quote { Serialize<$serialized_len> }.as_trait_constraint();
     quote {
-        impl Serialize<$serialized_len> for $typ {
+        impl $serialize_trait for $typ {
             #[inline_always]
             fn serialize(self) -> [Field; $serialized_len] {
                 $aux_vars_for_serialization


### PR DESCRIPTION
For the `EventInterface::compute_event_hash` function which I am about to implement while tackling https://github.com/AztecProtocol/aztec-packages/issues/14367 I need all the events to have an implementation of `Serialize` trait. In this PR I auto-derive it if not implemented manually.
