### PR TITLE
chore: Disable flood publish by default

### DIFF
--- a/yarn-project/p2p/src/config.ts
+++ b/yarn-project/p2p/src/config.ts
@@ -308,7 +308,7 @@ export const p2pConfigMappings: ConfigMappingsType<P2PConfig> = {
   gossipsubFloodPublish: {
     env: 'P2P_GOSSIPSUB_FLOOD_PUBLISH',
     description: 'Whether to flood publish messages. - For testing purposes only',
-    ...booleanConfigHelper(true),
+    ...booleanConfigHelper(false),
   },
   gossipsubMcacheLength: {
     env: 'P2P_GOSSIPSUB_MCACHE_LENGTH',


### PR DESCRIPTION
This PR disables flood publishing in gossipsub by default. We shouldn't need this and it will potentially be detrimental as we implement enhanced request/response functionality.
