### PR TITLE
fix: deploy verifier CLI PK parsing

### DIFF
--- a/yarn-project/cli/src/cmds/l1/deploy_l1_verifier.ts
+++ b/yarn-project/cli/src/cmds/l1/deploy_l1_verifier.ts
@@ -5,6 +5,7 @@ import { HonkVerifierAbi, HonkVerifierBytecode } from '@aztec/l1-artifacts';
 
 import { InvalidOptionArgumentError } from 'commander';
 import { type Hex, getContract } from 'viem';
+import { mnemonicToAccount, privateKeyToAccount } from 'viem/accounts';
 
 export async function deployUltraHonkVerifier(
   rollupAddress: Hex | undefined,
@@ -12,13 +13,17 @@ export async function deployUltraHonkVerifier(
   l1ChainId: string,
   privateKey: string | undefined,
   mnemonic: string,
+  mnemonicIndex: number,
   pxeRpcUrl: string,
   log: LogFn,
   debugLogger: Logger,
 ) {
+  const account = !privateKey
+    ? mnemonicToAccount(mnemonic!, { addressIndex: mnemonicIndex })
+    : privateKeyToAccount(`${privateKey.startsWith('0x') ? '' : '0x'}${privateKey}` as `0x${string}`);
   const extendedClient = createExtendedL1Client(
     ethRpcUrls,
-    privateKey ?? mnemonic,
+    account,
     createEthereumChain(ethRpcUrls, l1ChainId).chainInfo,
   );
 

--- a/yarn-project/cli/src/cmds/l1/index.ts
+++ b/yarn-project/cli/src/cmds/l1/index.ts
@@ -436,6 +436,7 @@ export function injectCommands(program: Command, log: LogFn, debugLogger: Logger
       'The mnemonic to use in deployment',
       'test test test test test test test test test test test junk',
     )
+    .option('-i, --mnemonic-index <number>', 'The index of the mnemonic to use in deployment', arg => parseInt(arg), 0)
     .requiredOption('--verifier <verifier>', 'Either mock or real', 'real')
     .action(async options => {
       const { deployMockVerifier, deployUltraHonkVerifier } = await import('./deploy_l1_verifier.js');
@@ -457,6 +458,7 @@ export function injectCommands(program: Command, log: LogFn, debugLogger: Logger
           options.l1ChainId,
           options.l1PrivateKey,
           options.mnemonic,
+          options.mnemonicIndex,
           options.rpcUrl,
           log,
           debugLogger,


### PR DESCRIPTION
Fix parsing private keys that don't necessarily start with `0x` 
Also add `--mnemonic-index` option like other CLI commands with `--mnemonic` input
Fixes #14503 