### PR TITLE
chore: Try deflake l1-reorg test

### DIFF
--- a/yarn-project/end-to-end/src/e2e_p2p/reqresp.test.ts
+++ b/yarn-project/end-to-end/src/e2e_p2p/reqresp.test.ts
@@ -1,5 +1,5 @@
 import type { AztecNodeService } from '@aztec/aztec-node';
-import { SentTx, sleep } from '@aztec/aztec.js';
+import { SentTx, Tx, createLogger, sleep } from '@aztec/aztec.js';
 import { RollupContract } from '@aztec/ethereum';
 import { timesAsync } from '@aztec/foundation/collection';
 
@@ -50,6 +50,8 @@ describe('e2e_p2p_reqresp_tx', () => {
     }
   });
 
+  const getNodePort = (nodeIndex: number) => BOOT_NODE_UDP_PORT + 1 + nodeIndex;
+
   it('should produce an attestation by requesting tx data over the p2p network', async () => {
     /**
      * Birds eye overview of the test
@@ -96,16 +98,21 @@ describe('e2e_p2p_reqresp_tx', () => {
     t.ctx.dateProvider.setTime(Number(timestamp) * 1000);
 
     const { proposerIndexes, nodesToTurnOffTxGossip } = await getProposerIndexes();
-    t.logger.info(`Turning off tx gossip for nodes: ${nodesToTurnOffTxGossip}`);
-    t.logger.info(`Sending txs to proposer nodes: ${proposerIndexes}`);
+    t.logger.info(`Turning off tx gossip for nodes: ${nodesToTurnOffTxGossip.map(getNodePort)}`);
+    t.logger.info(`Sending txs to proposer nodes: ${proposerIndexes.map(getNodePort)}`);
 
     // Replace the p2p node implementation of some of the nodes with a spy such that it does not store transactions that are gossiped to it
     // Original implementation of `handleGossipedTx` will store received transactions in the tx pool.
     // We chose the first 2 nodes that will be the proposers for the next few slots
     for (const nodeIndex of nodesToTurnOffTxGossip) {
-      jest
-        .spyOn((nodes[nodeIndex] as any).p2pClient.p2pService, 'handleGossipedTx')
-        .mockImplementation(() => Promise.resolve());
+      const logger = createLogger(`p2p:${getNodePort(nodeIndex)}`);
+      jest.spyOn((nodes[nodeIndex] as any).p2pClient.p2pService, 'handleGossipedTx').mockImplementation((async (
+        payloadData: Buffer,
+      ) => {
+        const txHash = await Tx.fromBuffer(payloadData).getTxHash();
+        logger.info(`Skipping storage of gossiped transaction ${txHash.toString()}`);
+        return Promise.resolve();
+      }) as any);
     }
 
     // We send the tx to the proposer nodes directly, ignoring the pxe and node in each context

--- a/yarn-project/end-to-end/src/fixtures/l1_to_l2_messaging.ts
+++ b/yarn-project/end-to-end/src/fixtures/l1_to_l2_messaging.ts
@@ -1,9 +1,9 @@
 import { type ExtendedViemWalletClient, type L1ContractAddresses, RollupContract } from '@aztec/ethereum';
 import { Fr } from '@aztec/foundation/fields';
+import { tryJsonStringify } from '@aztec/foundation/json-rpc';
 import { InboxAbi } from '@aztec/l1-artifacts';
 import type { AztecAddress } from '@aztec/stdlib/aztec-address';
 
-import { expect } from '@jest/globals';
 import { decodeEventLog, getContract } from 'viem';
 
 export async function sendL1ToL2Message(
@@ -34,7 +34,11 @@ export async function sendL1ToL2Message(
   const txReceipt = await ctx.l1Client.waitForTransactionReceipt({ hash: txHash });
 
   // Exactly 1 event should be emitted in the transaction
-  expect(txReceipt.logs.length).toBe(1);
+  if (txReceipt.logs.length !== 1) {
+    throw new Error(
+      `Wrong number of logs found in transaction (got ${txReceipt.logs.length} expected 1)\n${tryJsonStringify(txReceipt.logs)}`,
+    );
+  }
 
   // We decode the event and get leaf out of it
   const messageSentLog = txReceipt.logs[0];

--- a/yarn-project/ethereum/src/eth_cheat_codes.ts
+++ b/yarn-project/ethereum/src/eth_cheat_codes.ts
@@ -353,4 +353,8 @@ export class EthCheatCodes {
     }
     this.logger.warn(`Reorged L1 chain with depth ${depth} and ${newBlocks.length} new blocks`, { depth, newBlocks });
   }
+
+  public traceTransaction(txHash: Hex): Promise<any> {
+    return this.rpcCall('trace_transaction', [txHash]);
+  }
 }

--- a/yarn-project/p2p/src/services/libp2p/libp2p_service.ts
+++ b/yarn-project/p2p/src/services/libp2p/libp2p_service.ts
@@ -616,7 +616,10 @@ export class LibP2PService<T extends P2PClientType = P2PClientType.Full> extends
     }
     const txHash = await tx.getTxHash();
     const txHashString = txHash.toString();
-    this.logger.verbose(`Received tx ${txHashString} from external peer ${source.toString()}.`);
+    this.logger.verbose(`Received tx ${txHashString} from external peer ${source.toString()} via gossip`, {
+      source: source.toString(),
+      txHash: txHashString,
+    });
     await this.mempools.txPool.addTxs([tx]);
   }
 
@@ -647,12 +650,13 @@ export class LibP2PService<T extends P2PClientType = P2PClientType.Full> extends
       return;
     }
     this.logger.debug(
-      `Received attestation for block ${attestation.blockNumber.toNumber()} slot ${attestation.slotNumber.toNumber()} from external peer.`,
+      `Received attestation for block ${attestation.blockNumber.toNumber()} slot ${attestation.slotNumber.toNumber()} from external peer ${source.toString()}`,
       {
         p2pMessageIdentifier: await attestation.p2pMessageIdentifier(),
         slot: attestation.slotNumber.toNumber(),
         archive: attestation.archive.toString(),
         block: attestation.blockNumber.toNumber(),
+        source: source.toString(),
       },
     );
     await this.mempools.attestationPool!.addAttestations([attestation]);
@@ -678,6 +682,7 @@ export class LibP2PService<T extends P2PClientType = P2PClientType.Full> extends
     if (!result || !block) {
       return;
     }
+
     await this.processValidBlockProposal(block, source);
   }
 
@@ -693,12 +698,13 @@ export class LibP2PService<T extends P2PClientType = P2PClientType.Full> extends
     const previousSlot = slot - 1n;
     const epoch = slot / 32n;
     this.logger.verbose(
-      `Received block ${block.blockNumber.toNumber()} for slot ${slot}, epoch ${epoch} from external peer.`,
+      `Received block ${block.blockNumber.toNumber()} for slot ${slot} epoch ${epoch} from external peer ${sender.toString()}.`,
       {
         p2pMessageIdentifier: await block.p2pMessageIdentifier(),
         slot: block.slotNumber.toNumber(),
         archive: block.archive.toString(),
         block: block.blockNumber.toNumber(),
+        source: sender.toString(),
       },
     );
     const attestationsForPreviousSlot = await this.mempools.attestationPool?.getAttestationsForSlot(previousSlot);

--- a/yarn-project/validator-client/src/errors/validator.error.ts
+++ b/yarn-project/validator-client/src/errors/validator.error.ts
@@ -14,7 +14,7 @@ export class InvalidValidatorPrivateKeyError extends ValidatorError {
 
 export class AttestationTimeoutError extends ValidatorError {
   constructor(numberOfRequiredAttestations: number, slot: bigint) {
-    super(`Timeout waiting for ${numberOfRequiredAttestations} attestations for slot, ${slot}`);
+    super(`Timeout waiting for ${numberOfRequiredAttestations} attestations for slot ${slot}`);
   }
 }
 

--- a/yarn-project/validator-client/src/validator.ts
+++ b/yarn-project/validator-client/src/validator.ts
@@ -163,12 +163,10 @@ export class ValidatorClient extends WithTracer implements Validator {
     const inCommittee = await this.epochCache.filterInCommittee(myAddresses);
     if (inCommittee.length > 0) {
       this.log.info(
-        `Started validator with addresses in current validator committee:
-         ${inCommittee.map(a => a.toString()).join(', ')}`,
+        `Started validator with addresses in current validator committee: ${inCommittee.map(a => a.toString()).join(', ')}`,
       );
     } else {
-      this.log.info(`Started validator with addresses:
-        ${myAddresses.map(a => a.toString()).join(', ')}`);
+      this.log.info(`Started validator with addresses: ${myAddresses.map(a => a.toString()).join(', ')}`);
     }
     this.epochCacheUpdateLoop.start();
     return Promise.resolve();


### PR DESCRIPTION
Try deflaking l1-reorg test `sees new blocks added in an L1 reorg` (see failing run [here](http://ci.aztec-labs.com/41f6438e922af7f5)), where the tx that inserted the block after the reorg reverted. 

Adding a trace call revealed that it was reverting with an invalid slot error, probably because we were replaying it in the wrong L1 block. This PR changes when we pin the L1 block number, which should ensure the tx lands in the correct L2 slot. It also includes a bunch of unrelated logging changes to help in other flakes.