### PR TITLE
fix: fix overflow mechanism and add robustness testing

### DIFF
--- a/barretenberg/cpp/src/barretenberg/client_ivc/client_ivc.test.cpp
+++ b/barretenberg/cpp/src/barretenberg/client_ivc/client_ivc.test.cpp
@@ -541,7 +541,7 @@ TEST_F(ClientIVCTests, StructuredTraceOverflow)
 };
 
 /**
- * @brief Test the structure trace overflow mechanism in a variety of different scenarios
+ * @brief Test the structured trace overflow mechanism in a variety of different scenarios
  *
  */
 TEST_F(ClientIVCTests, DynamicTraceOverflow)

--- a/barretenberg/cpp/src/barretenberg/client_ivc/client_ivc.test.cpp
+++ b/barretenberg/cpp/src/barretenberg/client_ivc/client_ivc.test.cpp
@@ -541,61 +541,46 @@ TEST_F(ClientIVCTests, StructuredTraceOverflow)
 };
 
 /**
- * @brief Test dynamic structured trace overflow block mechanism
- * @details Tests the case where the required overflow capacity is not known until runtime. Accumulates two circuits,
- * the second of which overflows the trace but not enough to change the dyadic circuit size and thus there is no need
- * for a virtual size increase of the first key.
+ * @brief Test the structure trace overflow mechanism in a variety of different scenarios
  *
  */
-TEST_F(ClientIVCTests, DynamicOverflow)
+TEST_F(ClientIVCTests, DynamicTraceOverflow)
 {
-    // Define trace settings with zero overflow capacity
-    ClientIVC ivc{ { SMALL_TEST_STRUCTURE_FOR_OVERFLOWS, /*overflow_capacity=*/0 } };
+    struct TestCase {
+        std::string name;
+        std::vector<size_t> log2_num_arith_gates;
+    };
 
-    ClientIVCMockCircuitProducer circuit_producer;
+    // Define some test cases that overflow the structured trace in different ways at different points in the
+    // accumulation. We distinguish between a simple overflow that exceeds one or more structured trace capacities but
+    // does not bump the dyadic circuit size and an overflow that does increase the dyadic circuit size.
+    std::vector<TestCase> test_cases = {
+        { "Case 1", { 18, 14 } },         /* first circuit overflows with dyadic size increase */
+        { "Case 2", { 14, 16 } },         /* simple overlow (no dyadic size increase)*/
+        { "Case 3", { 14, 18 } },         /* overflow with dyadic size increase*/
+        { "Case 4", { 14, 18, 14, 16 } }, /* dyadic size overflow then simple overflow */
+        { "Case 5", { 14, 16, 14, 18 } }, /* simple overflow then dyadic size overflow */
+    };
 
-    const size_t NUM_CIRCUITS = 2;
+    for (const auto& test : test_cases) {
+        SCOPED_TRACE(test.name); // improves test output readability
 
-    // define parameters for two circuits; the first fits within the structured trace, the second overflows
-    const std::vector<size_t> log2_num_arith_gates = { 14, 16 };
-    // Accumulate
-    for (size_t idx = 0; idx < NUM_CIRCUITS; ++idx) {
-        auto circuit = circuit_producer.create_next_circuit(ivc, log2_num_arith_gates[idx]);
-        ivc.accumulate(circuit);
+        uint32_t overflow_capacity = 0;
+        ClientIVC ivc{ { SMALL_TEST_STRUCTURE_FOR_OVERFLOWS, overflow_capacity } };
+        ClientIVCMockCircuitProducer circuit_producer;
+
+        const size_t NUM_CIRCUITS = test.log2_num_arith_gates.size();
+
+        // Accumulate
+        for (size_t idx = 0; idx < NUM_CIRCUITS; ++idx) {
+            auto circuit = circuit_producer.create_next_circuit(ivc, test.log2_num_arith_gates[idx]);
+            ivc.accumulate(circuit);
+        }
+
+        EXPECT_EQ(check_accumulator_target_sum_manual(ivc.fold_output.accumulator), true);
+        EXPECT_TRUE(ivc.prove_and_verify());
     }
-
-    EXPECT_EQ(check_accumulator_target_sum_manual(ivc.fold_output.accumulator), true);
-    EXPECT_TRUE(ivc.prove_and_verify());
-};
-
-/**
- * @brief Test dynamic trace overflow where the dyadic circuit size also increases
- * @details Accumulates two circuits, the second of which overflows the trace structure and leads to an increased dyadic
- * circuit size. This requires the virtual size of the polynomials in the first key to be increased accordingly which
- * should be handled automatically in PG/ClientIvc.
- *
- */
-TEST_F(ClientIVCTests, DynamicOverflowCircuitSizeChange)
-{
-    uint32_t overflow_capacity = 0;
-    // uint32_t overflow_capacity = 1 << 1;
-    ClientIVC ivc{ { SMALL_TEST_STRUCTURE_FOR_OVERFLOWS, overflow_capacity } };
-
-    ClientIVCMockCircuitProducer circuit_producer;
-
-    const size_t NUM_CIRCUITS = 2;
-
-    // define parameters for two circuits; the first fits within the structured trace, the second overflows
-    const std::vector<size_t> log2_num_arith_gates = { 14, 18 };
-    // Accumulate
-    for (size_t idx = 0; idx < NUM_CIRCUITS; ++idx) {
-        auto circuit = circuit_producer.create_next_circuit(ivc, log2_num_arith_gates[idx]);
-        ivc.accumulate(circuit);
-    }
-
-    EXPECT_EQ(check_accumulator_target_sum_manual(ivc.fold_output.accumulator), true);
-    EXPECT_TRUE(ivc.prove_and_verify());
-};
+}
 
 /**
  * @brief Test methods for serializing and deserializing a proof to/from a file in msgpack format

--- a/barretenberg/cpp/src/barretenberg/dsl/acir_format/acir_integration.test.cpp
+++ b/barretenberg/cpp/src/barretenberg/dsl/acir_format/acir_integration.test.cpp
@@ -499,8 +499,9 @@ TEST_F(AcirIntegrationTest, DISABLED_ClientIVCMsgpackInputs)
     //      export  AZTEC_CACHE_COMMIT=origin/master~3
     //      export DOWNLOAD_ONLY=1
     //      yarn-project/end-to-end/bootstrap.sh generate_example_app_ivc_inputs
-    std::string input_path = "../../../yarn-project/end-to-end/example-app-ivc-inputs-out/"
-                             "ecdsar1+transfer_0_recursions+sponsored_fpc/ivc-inputs.msgpack";
+    std::string input_path = "../../../GregoFailure/ivc-inputs.msgpack";
+    // std::string input_path = "../../../yarn-project/end-to-end/example-app-ivc-inputs-out/"
+    //                          "ecdsar1+transfer_0_recursions+sponsored_fpc/ivc-inputs.msgpack";
 
     PrivateExecutionSteps steps;
     steps.parse(PrivateExecutionStepRaw::load_and_decompress(input_path));
@@ -517,8 +518,9 @@ TEST_F(AcirIntegrationTest, DISABLED_ClientIVCMsgpackInputs)
  */
 TEST_F(AcirIntegrationTest, DISABLED_DummyWitnessVkConsistency)
 {
-    std::string input_path = "../../../yarn-project/end-to-end/example-app-ivc-inputs-out/"
-                             "ecdsar1+transfer_0_recursions+sponsored_fpc/ivc-inputs.msgpack";
+    std::string input_path = "../../../GregoFailure/ivc-inputs.msgpack";
+    // std::string input_path = "../../../yarn-project/end-to-end/example-app-ivc-inputs-out/"
+    //                          "ecdsar1+transfer_0_recursions+sponsored_fpc/ivc-inputs.msgpack";
 
     PrivateExecutionSteps steps;
     steps.parse(PrivateExecutionStepRaw::load_and_decompress(input_path));
@@ -559,6 +561,7 @@ TEST_F(AcirIntegrationTest, DISABLED_DummyWitnessVkConsistency)
         }
 
         EXPECT_EQ(recomputed_vk_hash, computed_vk_hash);
+        EXPECT_EQ(computed_vk_hash, precomputed_vk->hash());
     }
 }
 #endif

--- a/barretenberg/cpp/src/barretenberg/dsl/acir_format/acir_integration.test.cpp
+++ b/barretenberg/cpp/src/barretenberg/dsl/acir_format/acir_integration.test.cpp
@@ -498,10 +498,9 @@ TEST_F(AcirIntegrationTest, DISABLED_ClientIVCMsgpackInputs)
     // NOTE: to populate the test inputs at this location, run the following commands:
     //      export  AZTEC_CACHE_COMMIT=origin/master~3
     //      export DOWNLOAD_ONLY=1
-    //      yarn-project/end-to-end/bootstrap.sh generate_example_app_ivc_inputs
-    std::string input_path = "../../../GregoFailure/ivc-inputs.msgpack";
-    // std::string input_path = "../../../yarn-project/end-to-end/example-app-ivc-inputs-out/"
-    //                          "ecdsar1+transfer_0_recursions+sponsored_fpc/ivc-inputs.msgpack";
+    //      yarn-project/end-to-end/bootstrap.sh build_bench
+    std::string input_path = "../../../yarn-project/end-to-end/example-app-ivc-inputs-out/"
+                             "ecdsar1+transfer_0_recursions+sponsored_fpc/ivc-inputs.msgpack";
 
     PrivateExecutionSteps steps;
     steps.parse(PrivateExecutionStepRaw::load_and_decompress(input_path));
@@ -518,9 +517,8 @@ TEST_F(AcirIntegrationTest, DISABLED_ClientIVCMsgpackInputs)
  */
 TEST_F(AcirIntegrationTest, DISABLED_DummyWitnessVkConsistency)
 {
-    std::string input_path = "../../../GregoFailure/ivc-inputs.msgpack";
-    // std::string input_path = "../../../yarn-project/end-to-end/example-app-ivc-inputs-out/"
-    //                          "ecdsar1+transfer_0_recursions+sponsored_fpc/ivc-inputs.msgpack";
+    std::string input_path = "../../../yarn-project/end-to-end/example-app-ivc-inputs-out/"
+                             "ecdsar1+transfer_0_recursions+sponsored_fpc/ivc-inputs.msgpack";
 
     PrivateExecutionSteps steps;
     steps.parse(PrivateExecutionStepRaw::load_and_decompress(input_path));
@@ -560,7 +558,9 @@ TEST_F(AcirIntegrationTest, DISABLED_DummyWitnessVkConsistency)
             computed_vk_hash = proving_key_inspector::compute_vk_hash<MegaFlavor>(circuit);
         }
 
+        // Check that the hashes computed from the dummy witness VK and the genuine witness VK are equal
         EXPECT_EQ(recomputed_vk_hash, computed_vk_hash);
+        // Check that the VK hashes match the hash of the precomputed VK contained in the msgpack inputs
         EXPECT_EQ(computed_vk_hash, precomputed_vk->hash());
     }
 }

--- a/barretenberg/cpp/src/barretenberg/protogalaxy/protogalaxy_prover.hpp
+++ b/barretenberg/cpp/src/barretenberg/protogalaxy/protogalaxy_prover.hpp
@@ -31,6 +31,9 @@ template <class DeciderProvingKeys_> class ProtogalaxyProver_ {
     using DeciderProvingKeys = DeciderProvingKeys_;
     using PGInternal = ProtogalaxyProverInternal<DeciderProvingKeys>;
 
+    // TODO(https://github.com/AztecProtocol/barretenberg/issues/1239): clean out broken support for multi-folding
+    static_assert(DeciderProvingKeys::NUM == 2, "Protogalaxy currently only supports folding one instance at a time.");
+
     static constexpr size_t NUM_SUBRELATIONS = DeciderProvingKeys_::NUM_SUBRELATIONS;
 
     DeciderProvingKeys_ keys_to_fold;

--- a/barretenberg/cpp/src/barretenberg/protogalaxy/protogalaxy_prover.hpp
+++ b/barretenberg/cpp/src/barretenberg/protogalaxy/protogalaxy_prover.hpp
@@ -100,11 +100,11 @@ template <class DeciderProvingKeys_> class ProtogalaxyProver_ {
      * multiplication of matrices whose columns are polynomials, as well as taking similar linear combinations of the
      * relation parameters.
      */
-    FoldingResult<Flavor> update_target_sum_and_fold(const DeciderProvingKeys_& keys,
-                                                     const CombinerQuotient& combiner_quotient,
-                                                     const UnivariateRelationSeparator& alphas,
-                                                     const UnivariateRelationParameters& univariate_relation_parameters,
-                                                     const FF& perturbator_evaluation);
+    void update_target_sum_and_fold(const DeciderProvingKeys_& keys,
+                                    const CombinerQuotient& combiner_quotient,
+                                    const UnivariateRelationSeparator& alphas,
+                                    const UnivariateRelationParameters& univariate_relation_parameters,
+                                    const FF& perturbator_evaluation);
 
     /**
      * @brief Execute the folding prover.

--- a/barretenberg/cpp/src/barretenberg/protogalaxy/protogalaxy_prover_impl.hpp
+++ b/barretenberg/cpp/src/barretenberg/protogalaxy/protogalaxy_prover_impl.hpp
@@ -142,6 +142,7 @@ void ProtogalaxyProver_<DeciderProvingKeys>::update_target_sum_and_fold(
     // the accumulator polynomials will not be sufficient to contain the contribution from the incoming polynomials. The
     // solution is to simply reverse the order or the terms in the linear combination by swapping the polynomials and
     // the lagrange coefficients between the accumulator and the incoming key.
+    // TODO(https://github.com/AztecProtocol/barretenberg/issues/1417): make this swapping logic more robust.
     if (incoming->overflow_size > accumulator->overflow_size) {
         std::swap(accumulator->proving_key.polynomials, incoming->proving_key.polynomials);   // swap the polys
         std::swap(accumulator->proving_key.circuit_size, incoming->proving_key.circuit_size); // swap circuit size

--- a/barretenberg/cpp/src/barretenberg/protogalaxy/protogalaxy_prover_impl.hpp
+++ b/barretenberg/cpp/src/barretenberg/protogalaxy/protogalaxy_prover_impl.hpp
@@ -113,7 +113,7 @@ ProtogalaxyProver_<DeciderProvingKeys>::combiner_quotient_round(const std::vecto
  * @brief Given the challenge \gamma, compute Z(\gamma) and {L_0(\gamma),L_1(\gamma)}
  */
 template <class DeciderProvingKeys>
-FoldingResult<typename DeciderProvingKeys::Flavor> ProtogalaxyProver_<DeciderProvingKeys>::update_target_sum_and_fold(
+void ProtogalaxyProver_<DeciderProvingKeys>::update_target_sum_and_fold(
     const DeciderProvingKeys& keys,
     const CombinerQuotient& combiner_quotient,
     const UnivariateRelationSeparator& alphas,
@@ -171,8 +171,6 @@ FoldingResult<typename DeciderProvingKeys::Flavor> ProtogalaxyProver_<DeciderPro
          zip_view(univariate_relation_parameters.get_to_fold(), accumulator->relation_parameters.get_to_fold())) {
         value = univariate.evaluate(combiner_challenge);
     }
-
-    return FoldingResult<Flavor>{ .accumulator = accumulator, .proof = std::move(transcript->proof_data) };
 }
 
 template <class DeciderProvingKeys>
@@ -208,10 +206,9 @@ FoldingResult<typename DeciderProvingKeys::Flavor> ProtogalaxyProver_<DeciderPro
         combiner_quotient_round(accumulator->gate_challenges, deltas, keys_to_fold);
     vinfo("combiner quotient round");
 
-    const FoldingResult<Flavor> result = update_target_sum_and_fold(
-        keys_to_fold, combiner_quotient, alphas, relation_parameters, perturbator_evaluation);
+    update_target_sum_and_fold(keys_to_fold, combiner_quotient, alphas, relation_parameters, perturbator_evaluation);
     vinfo("folded");
 
-    return result;
+    return FoldingResult<Flavor>{ .accumulator = keys_to_fold[0], .proof = std::move(transcript->proof_data) };
 }
 } // namespace bb

--- a/barretenberg/cpp/src/barretenberg/protogalaxy/protogalaxy_prover_impl.hpp
+++ b/barretenberg/cpp/src/barretenberg/protogalaxy/protogalaxy_prover_impl.hpp
@@ -122,56 +122,57 @@ FoldingResult<typename DeciderProvingKeys::Flavor> ProtogalaxyProver_<DeciderPro
 {
     PROFILE_THIS_NAME("ProtogalaxyProver_::update_target_sum_and_fold");
 
-    const FF combiner_challenge = transcript->template get_challenge<FF>("combiner_quotient_challenge");
+    std::shared_ptr<DeciderProvingKey> accumulator = keys[0];
+    std::shared_ptr<DeciderProvingKey> incoming = keys[1];
+    accumulator->is_accumulator = true;
 
-    FoldingResult<Flavor> result{ .accumulator = keys[0], .proof = std::move(transcript->proof_data) };
-    result.accumulator->is_accumulator = true;
+    // At this point the virtual sizes of the polynomials should already agree
+    BB_ASSERT_EQ(accumulator->proving_key.polynomials.w_l.virtual_size(),
+                 incoming->proving_key.polynomials.w_l.virtual_size());
+
+    const FF combiner_challenge = transcript->template get_challenge<FF>("combiner_quotient_challenge");
 
     // Compute the next target sum (for its own use; verifier must compute its own values)
     auto [vanishing_polynomial_at_challenge, lagranges] =
         PGInternal::compute_vanishing_polynomial_and_lagranges(combiner_challenge);
-    result.accumulator->target_sum = perturbator_evaluation * lagranges[0] +
-                                     vanishing_polynomial_at_challenge * combiner_quotient.evaluate(combiner_challenge);
+    accumulator->target_sum = perturbator_evaluation * lagranges[0] +
+                              vanishing_polynomial_at_challenge * combiner_quotient.evaluate(combiner_challenge);
 
     // Check whether the incoming key has a larger trace overflow than the accumulator. If so, the memory structure of
     // the accumulator polynomials will not be sufficient to contain the contribution from the incoming polynomials. The
     // solution is to simply reverse the order or the terms in the linear combination by swapping the polynomials and
     // the lagrange coefficients between the accumulator and the incoming key.
-    if (keys[1]->overflow_size > result.accumulator->overflow_size) {
-        ASSERT(DeciderProvingKeys::NUM == 2); // this mechanism is not supported for the folding of multiple keys
-        // DEBUG: At this point the virtual sizes of the polynomials should already agree
-        BB_ASSERT_EQ(result.accumulator->proving_key.polynomials.w_l.virtual_size(),
-                     keys[1]->proving_key.polynomials.w_l.virtual_size());
-        std::swap(result.accumulator->proving_key.polynomials, keys[1]->proving_key.polynomials); // swap the polys
+    if (incoming->overflow_size > accumulator->overflow_size) {
+        std::swap(accumulator->proving_key.polynomials, incoming->proving_key.polynomials);   // swap the polys
+        std::swap(accumulator->proving_key.circuit_size, incoming->proving_key.circuit_size); // swap circuit size
+        std::swap(accumulator->proving_key.log_circuit_size, incoming->proving_key.log_circuit_size);
         std::swap(lagranges[0], lagranges[1]); // swap the lagrange coefficients so the sum is unchanged
-        std::swap(result.accumulator->proving_key.circuit_size, keys[1]->proving_key.circuit_size); // swap circuit size
-        std::swap(result.accumulator->proving_key.log_circuit_size, keys[1]->proving_key.log_circuit_size);
+        std::swap(accumulator->overflow_size, incoming->overflow_size);             // swap overflow size
+        std::swap(accumulator->dyadic_circuit_size, incoming->dyadic_circuit_size); // swap dyadic size
     }
 
     // Fold the proving key polynomials
-    for (auto& poly : result.accumulator->proving_key.polynomials.get_unshifted()) {
+    for (auto& poly : accumulator->proving_key.polynomials.get_unshifted()) {
         poly *= lagranges[0];
     }
-    for (size_t key_idx = 1; key_idx < DeciderProvingKeys::NUM; key_idx++) {
-        for (auto [acc_poly, key_poly] : zip_view(result.accumulator->proving_key.polynomials.get_unshifted(),
-                                                  keys[key_idx]->proving_key.polynomials.get_unshifted())) {
-            acc_poly.add_scaled(key_poly, lagranges[key_idx]);
-        }
+    for (auto [acc_poly, key_poly] : zip_view(accumulator->proving_key.polynomials.get_unshifted(),
+                                              incoming->proving_key.polynomials.get_unshifted())) {
+        acc_poly.add_scaled(key_poly, lagranges[1]);
     }
 
     // Evaluate the combined batching  α_i univariate at challenge to obtain next α_i and send it to the
     // verifier, where i ∈ {0,...,NUM_SUBRELATIONS - 1}
-    for (auto [folded_alpha, key_alpha] : zip_view(result.accumulator->alphas, alphas)) {
+    for (auto [folded_alpha, key_alpha] : zip_view(accumulator->alphas, alphas)) {
         folded_alpha = key_alpha.evaluate(combiner_challenge);
     }
 
     // Evaluate each relation parameter univariate at challenge to obtain the folded relation parameters.
-    for (auto [univariate, value] : zip_view(univariate_relation_parameters.get_to_fold(),
-                                             result.accumulator->relation_parameters.get_to_fold())) {
+    for (auto [univariate, value] :
+         zip_view(univariate_relation_parameters.get_to_fold(), accumulator->relation_parameters.get_to_fold())) {
         value = univariate.evaluate(combiner_challenge);
     }
 
-    return result;
+    return FoldingResult<Flavor>{ .accumulator = accumulator, .proof = std::move(transcript->proof_data) };
 }
 
 template <class DeciderProvingKeys>

--- a/barretenberg/cpp/src/barretenberg/protogalaxy/protogalaxy_prover_internal.hpp
+++ b/barretenberg/cpp/src/barretenberg/protogalaxy/protogalaxy_prover_internal.hpp
@@ -262,6 +262,8 @@ template <class DeciderProvingKeys_> class ProtogalaxyProverInternal {
             accumulator->proving_key.polynomials, accumulator->alphas, accumulator->relation_parameters);
         const auto betas = accumulator->gate_challenges;
         BB_ASSERT_EQ(betas.size(), deltas.size());
+        // WORKTODO: it seems brittle to define log size and size seprately from polynomial virtual size. Can we connect
+        // these so they cant go out of sync?
         const size_t log_circuit_size = accumulator->proving_key.log_circuit_size;
 
         // Compute the perturbator using only the first log_circuit_size-many betas/deltas

--- a/barretenberg/cpp/src/barretenberg/protogalaxy/protogalaxy_prover_internal.hpp
+++ b/barretenberg/cpp/src/barretenberg/protogalaxy/protogalaxy_prover_internal.hpp
@@ -262,8 +262,6 @@ template <class DeciderProvingKeys_> class ProtogalaxyProverInternal {
             accumulator->proving_key.polynomials, accumulator->alphas, accumulator->relation_parameters);
         const auto betas = accumulator->gate_challenges;
         BB_ASSERT_EQ(betas.size(), deltas.size());
-        // WORKTODO: it seems brittle to define log size and size seprately from polynomial virtual size. Can we connect
-        // these so they cant go out of sync?
         const size_t log_circuit_size = accumulator->proving_key.log_circuit_size;
 
         // Compute the perturbator using only the first log_circuit_size-many betas/deltas


### PR DESCRIPTION
Fix the overflow mechanism in cases where we have two different overflow instances in the same flow, one of which results in a dyadic circuit size increase and one of which does not.