### PR TITLE
refactor: parallel tx validation

### DIFF
--- a/yarn-project/bb-prover/src/bb/execute.ts
+++ b/yarn-project/bb-prover/src/bb/execute.ts
@@ -72,6 +72,7 @@ export function executeBB(
   logger: LogFn,
   timeout?: number,
   resultParser = (code: number) => code === 0,
+  signal?: AbortSignal,
 ): Promise<BBExecResult> {
   return new Promise<BBExecResult>(resolve => {
     // spawn the bb process
@@ -80,6 +81,7 @@ export function executeBB(
     logger(`Executing BB with: ${pathToBB} ${command} ${args.join(' ')}`);
     const bb = proc.spawn(pathToBB, [command, ...args], {
       env,
+      signal,
     });
 
     let timeoutId: NodeJS.Timeout | undefined;
@@ -495,6 +497,7 @@ export async function verifyClientIvcProof(
   proofPath: string,
   keyPath: string,
   log: LogFn,
+  signal?: AbortSignal,
 ): Promise<BBFailure | BBSuccess> {
   const binaryPresent = await fs
     .access(pathToBB, fs.constants.R_OK)
@@ -508,7 +511,7 @@ export async function verifyClientIvcProof(
     const args = ['--scheme', 'client_ivc', '-p', proofPath, '-k', keyPath, '-v'];
     const timer = new Timer();
     const command = 'verify';
-    const result = await executeBB(pathToBB, command, args, log);
+    const result = await executeBB(pathToBB, command, args, log, undefined, undefined, signal);
     const duration = timer.ms();
     if (result.status == BB_RESULT.SUCCESS) {
       return { status: BB_RESULT.SUCCESS, durationMs: duration };

--- a/yarn-project/p2p/src/msg_validators/tx_validator/factory.test.ts
+++ b/yarn-project/p2p/src/msg_validators/tx_validator/factory.test.ts
@@ -1,11 +1,18 @@
 import { Fr } from '@aztec/foundation/fields';
+import { promiseWithResolvers } from '@aztec/foundation/promise';
+import { sleep } from '@aztec/foundation/sleep';
 import type { ContractDataSource } from '@aztec/stdlib/contract';
 import { GasFees } from '@aztec/stdlib/gas';
 import type { ClientProtocolCircuitVerifier, WorldStateSynchronizer } from '@aztec/stdlib/interfaces/server';
+import { PeerErrorSeverity } from '@aztec/stdlib/p2p';
+import { mockTx } from '@aztec/stdlib/testing';
+import type { Tx } from '@aztec/stdlib/tx';
 
+import { jest } from '@jest/globals';
+import { AbortError } from '@libp2p/interface';
 import { type MockProxy, mock } from 'jest-mock-extended';
 
-import { createTxMessageValidators } from './factory.js';
+import { type MessageValidator, type TxValidateFn, createTxMessageValidators, validateInParallel } from './factory.js';
 
 describe('GasTxValidator', () => {
   // Mocks
@@ -39,5 +46,93 @@ describe('GasTxValidator', () => {
       'blockHeaderValidator',
     ]);
     expect(Object.keys(validators[1])).toEqual(['proofValidator']);
+  });
+});
+
+describe('validateInParallel', () => {
+  let mockValidatorFns: Record<'foo' | 'bar' | 'baz', jest.Mock<TxValidateFn>>;
+  let validators: Record<'foo' | 'bar' | 'baz', MessageValidator>;
+  let tx: Tx;
+
+  beforeEach(async () => {
+    mockValidatorFns = {
+      foo: jest.fn<TxValidateFn>(),
+      bar: jest.fn<TxValidateFn>(),
+      baz: jest.fn<TxValidateFn>(),
+    };
+
+    validators = {
+      foo: {
+        validator: { validateTx: mockValidatorFns.foo },
+        severity: PeerErrorSeverity.LowToleranceError,
+      },
+      bar: {
+        validator: { validateTx: mockValidatorFns.bar },
+        severity: PeerErrorSeverity.MidToleranceError,
+      },
+      baz: {
+        validator: { validateTx: mockValidatorFns.baz },
+        severity: PeerErrorSeverity.HighToleranceError,
+      },
+    };
+
+    tx = await mockTx();
+  });
+
+  it('returns ok when all validators pass', async () => {
+    Object.values(mockValidatorFns).forEach(fn => fn.mockResolvedValue({ result: 'valid' }));
+    await expect(validateInParallel(tx, validators)).resolves.toEqual({ allPassed: true });
+  });
+
+  it('returns not ok when a validator fails', async () => {
+    mockValidatorFns.foo.mockResolvedValue({ result: 'valid' });
+    mockValidatorFns.bar.mockResolvedValue({ result: 'valid' });
+    mockValidatorFns.baz.mockResolvedValue({ result: 'invalid', reason: ['Error'] });
+
+    await expect(validateInParallel(tx, validators)).resolves.toEqual({
+      allPassed: false,
+      failure: {
+        name: 'baz',
+        isValid: { result: 'invalid', reason: ['Error'] },
+        severity: PeerErrorSeverity.HighToleranceError,
+      },
+    });
+  });
+
+  it('returns the first failure when some validators fail', async () => {
+    mockValidatorFns.foo.mockResolvedValue({ result: 'invalid', reason: ['Foo error'] });
+    mockValidatorFns.bar.mockResolvedValue({ result: 'valid' });
+    mockValidatorFns.baz.mockResolvedValue({ result: 'invalid', reason: ['Baz error'] });
+
+    await expect(validateInParallel(tx, validators)).resolves.toEqual({
+      allPassed: false,
+      failure: {
+        name: 'foo',
+        isValid: { result: 'invalid', reason: ['Foo error'] },
+        severity: PeerErrorSeverity.LowToleranceError,
+      },
+    });
+  });
+
+  it('cancels validators when any failure is encountered', async () => {
+    const bazPromise = promiseWithResolvers<any>();
+    mockValidatorFns.foo.mockResolvedValue({ result: 'invalid', reason: ['Foo error'] });
+    mockValidatorFns.bar.mockResolvedValue({ result: 'valid' });
+    mockValidatorFns.baz.mockReturnValue(bazPromise.promise);
+
+    const allPromise = validateInParallel(tx, validators);
+
+    await sleep(10);
+    expect(mockValidatorFns.baz.mock.calls[0][1]?.aborted).toEqual(true);
+    bazPromise.reject(new AbortError());
+
+    await expect(allPromise).resolves.toEqual({
+      allPassed: false,
+      failure: {
+        name: 'foo',
+        isValid: { result: 'invalid', reason: ['Foo error'] },
+        severity: PeerErrorSeverity.LowToleranceError,
+      },
+    });
   });
 });

--- a/yarn-project/p2p/src/msg_validators/tx_validator/tx_proof_validator.ts
+++ b/yarn-project/p2p/src/msg_validators/tx_validator/tx_proof_validator.ts
@@ -7,8 +7,8 @@ export class TxProofValidator implements TxValidator<Tx> {
 
   constructor(private verifier: ClientProtocolCircuitVerifier) {}
 
-  async validateTx(tx: Tx): Promise<TxValidationResult> {
-    if (!(await this.verifier.verifyProof(tx))) {
+  async validateTx(tx: Tx, signal?: AbortSignal): Promise<TxValidationResult> {
+    if (!(await this.verifier.verifyProof(tx, signal))) {
       this.#log.verbose(`Rejecting tx ${await Tx.getHash(tx)} for invalid proof`);
       return { result: 'invalid', reason: [TX_ERROR_INVALID_PROOF] };
     }

--- a/yarn-project/p2p/src/services/libp2p/libp2p_service.ts
+++ b/yarn-project/p2p/src/services/libp2p/libp2p_service.ts
@@ -1,5 +1,4 @@
 import type { EpochCacheInterface } from '@aztec/epoch-cache';
-import { AbortError } from '@aztec/foundation/error';
 import { createLibp2pComponentLogger, createLogger } from '@aztec/foundation/log';
 import { SerialQueue } from '@aztec/foundation/queue';
 import { RunningPromise } from '@aztec/foundation/running-promise';
@@ -892,10 +891,7 @@ export class LibP2PService<T extends P2PClientType = P2PClientType.Full> extends
    * @param messageValidators - The message validators to run.
    * @returns The validation outcome.
    */
-  private async runValidations(
-    tx: Tx,
-    messageValidators: Record<string, MessageValidator>,
-  ): Promise<ValidationOutcome> {
+  private runValidations(tx: Tx, messageValidators: Record<string, MessageValidator>): Promise<ValidationOutcome> {
     return validateInParallel(tx, messageValidators, this.logger);
   }
 

--- a/yarn-project/stdlib/src/interfaces/server_circuit_prover.ts
+++ b/yarn-project/stdlib/src/interfaces/server_circuit_prover.ts
@@ -162,7 +162,8 @@ export interface ClientProtocolCircuitVerifier {
   /**
    * Verifies the private protocol circuit's proof.
    * @param tx - The tx to verify the proof of
+   * @param signal - Optional abort signal
    * @returns True if the proof is valid, false otherwise
    */
-  verifyProof(tx: Tx): Promise<boolean>;
+  verifyProof(tx: Tx, signal?: AbortSignal): Promise<boolean>;
 }


### PR DESCRIPTION
This PR adds abort semantics to tx validation such that running validations are cancelled the moment the first failure comes in