### PR TITLE
feat: print memory usage on every bb print

### DIFF
--- a/barretenberg/cpp/src/barretenberg/env/logstr.cpp
+++ b/barretenberg/cpp/src/barretenberg/env/logstr.cpp
@@ -1,9 +1,23 @@
 #include <iostream>
+#ifdef __linux__
+#include <sys/resource.h>
+#endif
 
 extern "C" {
 
 void logstr(char const* str)
 {
-    std::cerr << str << std::endl;
+    std::cerr << str;
+
+#ifdef __linux__
+    struct rusage usage;
+    if (getrusage(RUSAGE_SELF, &usage) == 0) {
+        // ru_maxrss is in kilobytes on Linux
+        // match the format in barretenberg/ts/src/barretenberg_wasm/index.ts
+        std::cerr << " (mem: " << (usage.ru_maxrss / 1024) << " MiB)"; // NOLINT
+    }
+#endif
+
+    std::cerr << std::endl;
 }
 }

--- a/barretenberg/cpp/src/barretenberg/env/logstr.cpp
+++ b/barretenberg/cpp/src/barretenberg/env/logstr.cpp
@@ -14,6 +14,7 @@ void logstr(char const* str)
     if (getrusage(RUSAGE_SELF, &usage) == 0) {
         // ru_maxrss is in kilobytes on Linux
         // match the format in barretenberg/ts/src/barretenberg_wasm/index.ts
+        // TODO(AD): do this on non-linux platforms
         std::cerr << " (mem: " << (usage.ru_maxrss / 1024) << " MiB)"; // NOLINT
     }
 #endif

--- a/barretenberg/cpp/src/barretenberg/env/logstr.cpp
+++ b/barretenberg/cpp/src/barretenberg/env/logstr.cpp
@@ -1,24 +1,75 @@
+// logstr()
+// --------------------
+// Logs a message to stderr and appends the *peak* resident-set size (RSS)
+// of the current process in MiB.
+//
+//  Windows note: link with Psapi.lib
+
+#include <cstddef>
+#include <iomanip>
 #include <iostream>
-#ifdef __linux__
+
+#if defined(__linux__) || defined(__APPLE__) || defined(__FreeBSD__)
 #include <sys/resource.h>
+#elif defined(_WIN32)
+#define NOMINMAX
+#define PSAPI_VERSION 1
+#include <psapi.h>
+#include <windows.h>
 #endif
 
-extern "C" {
-
-void logstr(char const* str)
+namespace {
+//---------------------------------------------------------------------
+// peak_rss_bytes()
+//---------------------------------------------------------------------
+// Returns the *peak* RSS in **bytes** for the current process,
+// or 0 on failure / unsupported platform.
+//---------------------------------------------------------------------
+std::size_t peak_rss_bytes()
 {
-    std::cerr << str;
+#if defined(_WIN32)
+    PROCESS_MEMORY_COUNTERS pmc{};
+    if (GetProcessMemoryInfo(GetCurrentProcess(), &pmc, sizeof(pmc)))
+        return static_cast<std::size_t>(pmc.PeakWorkingSetSize);
 
-#ifdef __linux__
-    struct rusage usage;
-    if (getrusage(RUSAGE_SELF, &usage) == 0) {
-        // ru_maxrss is in kilobytes on Linux
-        // match the format in barretenberg/ts/src/barretenberg_wasm/index.ts
-        // TODO(AD): do this on non-linux platforms
-        std::cerr << " (mem: " << (usage.ru_maxrss / 1024) << " MiB)"; // NOLINT
-    }
+#elif defined(__APPLE__) || defined(__FreeBSD__)
+    struct rusage usage {};
+    if (getrusage(RUSAGE_SELF, &usage) == 0)
+        // ru_maxrss is already bytes on macOS / BSD
+        return static_cast<std::size_t>(usage.ru_maxrss);
+
+#elif defined(__linux__)
+    struct rusage usage {};
+    if (getrusage(RUSAGE_SELF, &usage) == 0)
+        // ru_maxrss is kilobytes on Linux → convert to bytes
+        return static_cast<std::size_t>(usage.ru_maxrss) * 1024ULL;
 #endif
 
-    std::cerr << std::endl;
+    return 0; // fallback on error / unknown OS
 }
+
+} // namespace
+
+//---------------------------------------------------------------------
+// C-linkage wrapper: log_with_mem_usage()
+//---------------------------------------------------------------------
+//   Prints  "<msg> (mem: <value> MiB)"  with two-digit precision.
+//
+//   • Safe to call from C, C++, or dlopen’d plugins.
+//   • Thread-safe w.r.t. internal state; output lines may still
+//     interleave if multiple threads call concurrently (as with any
+//     stderr logging).
+//---------------------------------------------------------------------
+extern "C" void logstr(char const* msg)
+{
+    const std::size_t bytes = peak_rss_bytes();
+    std::cerr << msg;
+
+    if (bytes != 0) {
+        const double mib = static_cast<double>(bytes) / (1024.0 * 1024.0);
+        std::cerr << " (mem: " << std::fixed << std::setprecision(2) << mib << " MiB)";
+    } else {
+        std::cerr << " (mem: N/A)";
+    }
+    std::cerr << '\n';
 }

--- a/yarn-project/bb-prover/package.json
+++ b/yarn-project/bb-prover/package.json
@@ -78,7 +78,6 @@
     "@aztec/world-state": "workspace:^",
     "commander": "^12.1.0",
     "pako": "^2.1.0",
-    "pidusage": "^4.0.1",
     "source-map-support": "^0.5.21",
     "tslib": "^2.4.0"
   },
@@ -91,7 +90,6 @@
     "@jest/globals": "^29.5.0",
     "@types/jest": "^29.5.0",
     "@types/node": "^22.15.17",
-    "@types/pidusage": "^2.0.5",
     "@types/source-map-support": "^0.5.10",
     "jest": "^29.5.0",
     "jest-mock-extended": "^3.0.3",

--- a/yarn-project/bb-prover/src/bb/execute.ts
+++ b/yarn-project/bb-prover/src/bb/execute.ts
@@ -6,7 +6,6 @@ import type { AvmCircuitInputs, AvmCircuitPublicInputs } from '@aztec/stdlib/avm
 import * as proc from 'child_process';
 import { promises as fs } from 'fs';
 import { basename, dirname, join } from 'path';
-import pidusage from 'pidusage';
 
 import type { UltraHonkFlavor } from '../honk.js';
 
@@ -98,23 +97,11 @@ export function executeBB(
 
     bb.stdout.on('data', data => {
       const message = data.toString('utf-8').replace(/\n$/, '');
-      pidusage(bb.pid!, (err, stats) => {
-        if (err) {
-          logger(message);
-        } else {
-          logger(`${message} (mem: ${(stats.memory / 1024 / 1024).toFixed(2)}MiB)`);
-        }
-      });
+      logger(message);
     });
     bb.stderr.on('data', data => {
       const message = data.toString('utf-8').replace(/\n$/, '');
-      pidusage(bb.pid!, (err, stats) => {
-        if (err) {
-          logger(message);
-        } else {
-          logger(`${message} (mem: ${(stats.memory / 1024 / 1024).toFixed(2)}MiB)`);
-        }
-      });
+      logger(message);
     });
     bb.on('close', (exitCode: number, signal?: string) => {
       if (timeoutId) {

--- a/yarn-project/yarn.lock
+++ b/yarn-project/yarn.lock
@@ -329,13 +329,11 @@ __metadata:
     "@jest/globals": "npm:^29.5.0"
     "@types/jest": "npm:^29.5.0"
     "@types/node": "npm:^22.15.17"
-    "@types/pidusage": "npm:^2.0.5"
     "@types/source-map-support": "npm:^0.5.10"
     commander: "npm:^12.1.0"
     jest: "npm:^29.5.0"
     jest-mock-extended: "npm:^3.0.3"
     pako: "npm:^2.1.0"
-    pidusage: "npm:^4.0.1"
     source-map-support: "npm:^0.5.21"
     ts-node: "npm:^10.9.1"
     tslib: "npm:^2.4.0"
@@ -6372,13 +6370,6 @@ __metadata:
   version: 6.0.3
   resolution: "@types/parse5@npm:6.0.3"
   checksum: 10/834d40c9b1a8a99a9574b0b3f6629cf48adcff2eda01a35d701f1de5dcf46ce24223684647890aba9f985d6c801b233f878168683de0ae425940403c383fba8f
-  languageName: node
-  linkType: hard
-
-"@types/pidusage@npm:^2.0.5":
-  version: 2.0.5
-  resolution: "@types/pidusage@npm:2.0.5"
-  checksum: 10/24188bf108b9b5a2ccb16155a492ff1cca7d7bf07aa4e2649cce421e0940dd5b0cd06baa48da9b8bde46343463fc500a7070c0788a0ed3f3f57d3e3bcf4ac64d
   languageName: node
   linkType: hard
 
@@ -18402,15 +18393,6 @@ __metadata:
   version: 4.0.2
   resolution: "picomatch@npm:4.0.2"
   checksum: 10/ce617b8da36797d09c0baacb96ca8a44460452c89362d7cb8f70ca46b4158ba8bc3606912de7c818eb4a939f7f9015cef3c766ec8a0c6bfc725fdc078e39c717
-  languageName: node
-  linkType: hard
-
-"pidusage@npm:^4.0.1":
-  version: 4.0.1
-  resolution: "pidusage@npm:4.0.1"
-  dependencies:
-    safe-buffer: "npm:^5.2.1"
-  checksum: 10/ce791293a32c3c9a89ffe1033d0fd132606278adc68cbfd24c201562edec1b8fdc6df86e89fda1e0f9be7906449cc6173aaade7853c6dec22080258bc694e548
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
This mirrors the useful WASM prints. This prints the max resident memory usage in pages. This is the relevant memory figure as it represents our peak. Example (Note now says mem: ... MiB):
```
Scheme is: client_ivc, num threads: 192 (Memory 16 MB)
BN254 commitment key size: 262144 (Memory 153 MB)
ClientIVC: accumulating EcdsaRAccount:entrypoint (Memory 442 MB)
ClientIVC: accumulating private_kernel_init (Memory 684 MB)
ClientIVC: accumulating SponsoredFPC:sponsor_unconditionally (Memory 968 MB)
ClientIVC: accumulating private_kernel_inner (Memory 1015 MB)
ClientIVC: accumulating Token:transfer (Memory 1134 MB)
ClientIVC: accumulating private_kernel_inner (Memory 1203 MB)
ClientIVC: accumulating private_kernel_reset (Memory 1294 MB)
ClientIVC: accumulating private_kernel_tail (Memory 1403 MB)
Largest circuit: 101131 gates. Trace details: (Memory 1414 MB)
Minimum required block sizes for structured trace:  (Memory 1414 MB)
ecc_op              : 792
busread             : 4185
lookup              : 8266
pub_inputs          : 845
arithmetic          : 43917
delta_range         : 17435
elliptic            : 1314
aux                 : 25394
poseidon2_external  : 6092
poseidon2_internal  : 34715
overflow            : 0
 (Memory 1414 MB)
Constructing a Goblin proof with num ultra ops = 3022 (Memory 1414 MB)
```