### PR TITLE
fix: tolerate duplicate proposals

### DIFF
--- a/yarn-project/slasher/src/slasher_client.ts
+++ b/yarn-project/slasher/src/slasher_client.ts
@@ -14,6 +14,7 @@ import { SlashFactoryAbi } from '@aztec/l1-artifacts';
 import {
   type GetContractEventsReturnType,
   type GetContractReturnType,
+  type Hex,
   encodeFunctionData,
   getAddress,
   getContract,
@@ -142,6 +143,7 @@ export class SlasherClient {
   }
 
   public clearMonitoredPayloads() {
+    this.log.warn('Clearing monitored payloads', this.monitoredPayloads);
     this.monitoredPayloads = [];
   }
 
@@ -209,7 +211,6 @@ export class SlasherClient {
    * @param args - the arguments from the watcher, including the validators, amounts, and offenses
    */
   private wantToSlash(args: WantToSlashArgs[]) {
-    // TODO(#14489): need to sort the payloads by attester address
     const sortedArgs = [...args].sort((a, b) => a.validator.toString().localeCompare(b.validator.toString()));
     this.log.info('Wants to slash', sortedArgs);
     this.l1TxUtils
@@ -224,6 +225,42 @@ export class SlasherClient {
             sortedArgs.map(a => BigInt(a.offense)),
           ],
         }),
+      })
+      .then(tx => {
+        if (tx.receipt.status !== 'success') {
+          this.log.error('Slash payload creation failed', tx);
+          // TODO
+          // this.l1TxUtils.tryGetErrorFromRevertedTx()
+          throw new Error('Slash payload creation failed');
+        }
+        return this.getAddressAndIsDeployed(
+          sortedArgs.map(a => a.validator),
+          sortedArgs.map(a => a.amount),
+        );
+      })
+      .then(({ address, salt, isDeployed }) => {
+        if (!isDeployed) {
+          this.log.info('Slash payload not deployed', { address, salt });
+          throw new Error('Slash payload not deployed');
+        }
+        const payload = this.slashPayloadToMonitoredPayload({
+          payloadAddress: address.toString(),
+          validators: sortedArgs.map(a => a.validator.toString()),
+          amounts: sortedArgs.map(a => a.amount),
+          offences: sortedArgs.map(a => BigInt(a.offense)),
+        });
+        if (!payload) {
+          this.log.error('Invalid payload', { address, salt });
+          throw new Error('Invalid payload');
+        }
+        return this.addMonitoredPayload(payload);
+      })
+      .then(added => {
+        if (!added) {
+          this.log.warn('Failed to add monitored payload that we created');
+        } else {
+          this.log.info('Added monitored payload that we created');
+        }
       })
       // note, we don't need to monitor the logs here,
       // it is handled by watchSlashFactoryEvents
@@ -268,20 +305,28 @@ export class SlasherClient {
       if (!event.args) {
         continue;
       }
-      const args = event.args;
-      if (!args.payloadAddress || !args.validators || !args.amounts || !args.offences) {
+      const payload = this.slashPayloadToMonitoredPayload(event.args);
+      if (!payload) {
         continue;
       }
-
-      yield {
-        payloadAddress: EthAddress.fromString(args.payloadAddress),
-        validators: args.validators.map(EthAddress.fromString),
-        amounts: args.amounts,
-        offenses: args.offences.map(offense => bigIntToOffence(offense)),
-        observedAtSeconds: this.dateProvider.now() / 1000,
-        totalAmount: args.amounts.reduce((acc, amount) => acc + amount, BigInt(0)),
-      };
+      yield payload;
     }
+  }
+
+  private slashPayloadToMonitoredPayload(
+    payload: GetContractEventsReturnType<typeof SlashFactoryAbi, 'SlashPayloadCreated'>[number]['args'],
+  ): MonitoredSlashPayload | undefined {
+    if (!payload.payloadAddress || !payload.validators || !payload.amounts || !payload.offences) {
+      return undefined;
+    }
+    return {
+      payloadAddress: EthAddress.fromString(payload.payloadAddress),
+      validators: payload.validators.map(EthAddress.fromString),
+      amounts: payload.amounts,
+      offenses: payload.offences.map(offense => bigIntToOffence(offense)),
+      observedAtSeconds: this.dateProvider.now() / 1000,
+      totalAmount: payload.amounts.reduce((acc, amount) => acc + amount, BigInt(0)),
+    };
   }
 
   /**
@@ -289,12 +334,19 @@ export class SlasherClient {
    *
    * @param payload
    */
-  private async addMonitoredPayload(payload: MonitoredSlashPayload) {
+  private async addMonitoredPayload(payload: MonitoredSlashPayload): Promise<boolean> {
+    const duplicate = this.monitoredPayloads.find(p => p.payloadAddress.equals(payload.payloadAddress));
+    if (duplicate) {
+      this.log.verbose('Duplicate payload. Not adding to monitored payloads', payload);
+      return false;
+    }
     if (await this.doIAgreeWithPayload(payload)) {
       this.log.info('Adding monitored payload', payload);
       this.monitoredPayloads.push(payload);
+      return true;
     } else {
-      this.log.info('Disagreeing with payload', payload);
+      this.log.info('Disagree with payload. Not adding to monitored payloads', payload);
+      return false;
     }
   }
 
@@ -400,5 +452,16 @@ export class SlasherClient {
       return;
     }
     this.monitoredPayloads.splice(index, 1);
+  }
+
+  private async getAddressAndIsDeployed(
+    validators: EthAddress[],
+    amounts: bigint[],
+  ): Promise<{ address: EthAddress; salt: Hex; isDeployed: boolean }> {
+    const [address, salt, isDeployed] = await this.slashFactoryContract.read.getAddressAndIsDeployed([
+      validators.map(v => v.toString()),
+      amounts,
+    ]);
+    return { address: EthAddress.fromString(address), salt, isDeployed };
   }
 }


### PR DESCRIPTION
We used to only look at payloads that come in through events. 

This was a problem because if the payload was already deployed, we don't emit an event.

So we need to grab the expected address, and insert it ourselves.

At the same time then, we need to make sure we aren't adding the same payload to the queue multiple times. 

Fix #14694 