### PR TITLE
fix: Fork world-state from the correct block when building a new one

### DIFF
--- a/yarn-project/sequencer-client/src/sequencer/sequencer.ts
+++ b/yarn-project/sequencer-client/src/sequencer/sequencer.ts
@@ -454,8 +454,8 @@ export class Sequencer {
     this.log.debug(`Synced to previous block ${blockNumber - 1}`);
 
     // NB: separating the dbs because both should update the state
-    const publicProcessorDBFork = await this.worldState.fork();
-    const orchestratorDBFork = await this.worldState.fork();
+    const publicProcessorDBFork = await this.worldState.fork(blockNumber - 1);
+    const orchestratorDBFork = await this.worldState.fork(blockNumber - 1);
 
     const previousBlockHeader =
       (await this.l2BlockSource.getBlock(blockNumber - 1))?.header ?? orchestratorDBFork.getInitialHeader();


### PR DESCRIPTION
Fixes issue where a validator would get a reexec state mismatch when attesting immediately after a reorg it has not yet seen, so the latest block from world-state is not the correct one.