### PR TITLE
[WIP] chore: add test and benchmarks for muldiv

### DIFF
--- a/noir-projects/noir-contracts/contracts/test/avm_gadgets_test_contract/src/main.nr
+++ b/noir-projects/noir-contracts/contracts/test/avm_gadgets_test_contract/src/main.nr
@@ -90,4 +90,179 @@ contract AvmGadgetsTest {
     fn pedersen_hash_with_index(data: [Field; 10]) -> Field {
         std::hash::pedersen_hash_with_separator(data, /*index=*/ 20)
     }
+
+    use std::ops::arith::WrappingAdd;
+
+    #[contract_library_method]
+    fn muldiv(a: u128, b: u128, c: u128) -> u128 {
+        assert(c != 0, "division by zero");
+
+        // Split a and b into 64-bit halves
+        let a_lo = a & 0xFFFFFFFFFFFFFFFF;
+        let a_hi = a >> 64;
+        let b_lo = b & 0xFFFFFFFFFFFFFFFF;
+        let b_hi = b >> 64;
+
+        // Compute partial products (all fit in u128)
+        let lo_lo = a_lo * b_lo;
+        let lo_hi = a_lo * b_hi;
+        let hi_lo = a_hi * b_lo;
+        let hi_hi = a_hi * b_hi;
+
+        // Now we simulate 256-bit addition:
+        //   lo_lo + ((lo_hi + hi_lo) << 64) + (hi_hi << 128)
+
+        // First: add lo_hi + hi_lo with carry
+        let (mid, carry_mid) = add_with_carry(lo_hi, hi_lo);
+
+        // mid contributes to both low and high 128 bits
+        let mid_lo = mid << 64;
+        let mid_hi = mid >> 64;
+
+        // Now add low 128 bits: lo_lo + mid_lo
+        let (sum_lo, carry_lo) = add_with_carry(lo_lo, mid_lo);
+
+        // Combine high part:
+        let mut sum_hi = hi_hi + mid_hi + carry_mid + carry_lo;
+
+        // Now we have full 256-bit result: (sum_hi, sum_lo)
+        let result = div_256_by_128(sum_hi, sum_lo, c);
+        result
+    }
+
+    // Returns (sum, carry)
+    #[contract_library_method]
+    fn add_with_carry(a: u128, b: u128) -> (u128, u128) {
+        let sum = a.wrapping_add(b);
+        let carry = if sum < a { 1 } else { 0 };
+        (sum, carry)
+    }
+
+    // Performs (hi:lo) / denom, returns floor division result
+    #[contract_library_method]
+    fn div_256_by_128(hi: u128, lo: u128, denom: u128) -> u128 {
+        let mut quotient: u128 = 0;
+        let mut r_hi = hi;
+        let mut r_lo = lo;
+
+        for i in 0..128 {
+            let j = 128 - i - 1;
+            let overflow = (r_lo & (1 << 127)) != 0;
+            r_lo = r_lo << 1;
+            r_hi = (r_hi << 1) | (if overflow { 1 } else { 0 });
+
+            if r_hi >= denom {
+                r_hi = r_hi - denom;
+                quotient = quotient | (1 << j);
+            }
+        }
+
+        quotient
+    }
+
+    #[public]
+    fn muldiv_small_values() {
+        let a: u128 = 10;
+        let b: u128 = 20;
+        let c: u128 = 4;
+        let result = muldiv(a, b, c);
+        assert(result == 50);
+    }
+
+    #[public]
+    fn muldiv_exact_division() {
+        let a: u128 = 1000;
+        let b: u128 = 2000;
+        let c: u128 = 10;
+        let result = muldiv(a, b, c);
+        assert(result == 200_000);
+    }
+
+    #[public]
+    fn muldiv_large_values() {
+        let a: u128 = 0xFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFF;
+        let b: u128 = 2;
+        let c: u128 = 3;
+        let result = muldiv(a, b, c);
+        assert(result == 226854911280625642308916404954512140970);
+    }
+
+    #[public]
+    fn muldiv_rounding_down() {
+        let a: u128 = 5;
+        let b: u128 = 5;
+        let c: u128 = 3;
+        let result = muldiv(a, b, c);
+        assert(result == (5 * 5) / 3); // 25 / 3 = 8
+    }
+
+    #[public]
+    fn muldiv_division_by_one() {
+        let a: u128 = 123456789;
+        let b: u128 = 987654321;
+        let c: u128 = 1;
+        let result = muldiv(a, b, c);
+        assert(result == a * b);
+    }
+
+    #[public]
+    fn muldiv_large_10_times() {
+        for _i in 0..10 {
+            let a: u128 = 0xFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFF;
+            let b: u128 = 2;
+            let c: u128 = 3;
+            let result = muldiv(a, b, c);
+            assert(result == 226854911280625642308916404954512140970);
+        }
+    }
+
+    #[public]
+    fn add_with_carry_no_overflow() {
+        let a: u128 = 100;
+        let b: u128 = 200;
+        let (sum, carry) = add_with_carry(a, b);
+        assert(sum == 300);
+        assert(carry == 0);
+    }
+
+    #[public]
+    fn add_with_carry_with_overflow() {
+        let a: u128 = 0xFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFF;
+        let b: u128 = 1;
+        let (sum, carry) = add_with_carry(a, b);
+        assert(sum == 0);
+        assert(carry == 1);
+    }
+
+    #[public]
+    fn div_256_by_128_exact() {
+        // (hi, lo) = (0, 1000), c = 10 => expect 100
+        let result = div_256_by_128(0, 1000, 10);
+        assert(result == 100);
+    }
+
+    #[public]
+    fn div_256_by_128_exact_10_times() {
+        for _i in 0..10 {
+            let result = div_256_by_128(0, 1000, 10);
+            assert(result == 100);
+        }
+    }
+
+    #[public]
+    fn div_256_by_128_large_hi() {
+        // 2^128 / 2 = 2^127
+        let hi: u128 = 1;
+        let lo: u128 = 0;
+        let c: u128 = 2;
+        let result = div_256_by_128(hi, lo, c);
+        assert(result == (1 as u128 << 127));
+    }
+
+    #[public]
+    fn div_256_by_128_non_exact() {
+        // (hi:lo) = (0, 1000), c = 3 => expect 333
+        let result = div_256_by_128(0, 1000, 3);
+        assert(result == 333);
+    }
 }

--- a/yarn-project/simulator/src/public/public_tx_simulator/apps_tests/bench.test.ts
+++ b/yarn-project/simulator/src/public/public_tx_simulator/apps_tests/bench.test.ts
@@ -201,5 +201,197 @@ describe('Public TX simulator apps tests: benchmarks', () => {
       );
       expect(result.revertCode.isOK()).toBe(true);
     });
+
+    it('muldiv_small_values', async () => {
+      const result = await tester.simulateTxWithLabel(
+        /*txLabel=*/ 'AvmGadgetsTest/muldiv_small_values',
+        /*sender=*/ deployer,
+        /*setupCalls=*/ [],
+        /*appCalls=*/ [
+          {
+            address: avmGadgetsTestContract.address,
+            fnName: 'muldiv_small_values',
+            args: [],
+          },
+        ],
+      );
+      expect(result.revertCode.isOK()).toBe(true);
+    });
+
+    it('muldiv_exact_division', async () => {
+      const result = await tester.simulateTxWithLabel(
+        /*txLabel=*/ 'AvmGadgetsTest/muldiv_exact_division',
+        /*sender=*/ deployer,
+        /*setupCalls=*/ [],
+        /*appCalls=*/ [
+          {
+            address: avmGadgetsTestContract.address,
+            fnName: 'muldiv_exact_division',
+            args: [],
+          },
+        ],
+      );
+      expect(result.revertCode.isOK()).toBe(true);
+    });
+
+    it('muldiv_large_values', async () => {
+      const result = await tester.simulateTxWithLabel(
+        /*txLabel=*/ 'AvmGadgetsTest/muldiv_large_values',
+        /*sender=*/ deployer,
+        /*setupCalls=*/ [],
+        /*appCalls=*/ [
+          {
+            address: avmGadgetsTestContract.address,
+            fnName: 'muldiv_large_values',
+            args: [],
+          },
+        ],
+      );
+      expect(result.revertCode.isOK()).toBe(true);
+    });
+
+    it('muldiv_rounding_down', async () => {
+      const result = await tester.simulateTxWithLabel(
+        /*txLabel=*/ 'AvmGadgetsTest/muldiv_rounding_down',
+        /*sender=*/ deployer,
+        /*setupCalls=*/ [],
+        /*appCalls=*/ [
+          {
+            address: avmGadgetsTestContract.address,
+            fnName: 'muldiv_rounding_down',
+            args: [],
+          },
+        ],
+      );
+      expect(result.revertCode.isOK()).toBe(true);
+    });
+
+    it('muldiv_division_by_one', async () => {
+      const result = await tester.simulateTxWithLabel(
+        /*txLabel=*/ 'AvmGadgetsTest/muldiv_division_by_one',
+        /*sender=*/ deployer,
+        /*setupCalls=*/ [],
+        /*appCalls=*/ [
+          {
+            address: avmGadgetsTestContract.address,
+            fnName: 'muldiv_division_by_one',
+            args: [],
+          },
+        ],
+      );
+      expect(result.revertCode.isOK()).toBe(true);
+    });
+
+    it('muldiv_large_10_times', async () => {
+      const result = await tester.simulateTxWithLabel(
+        /*txLabel=*/ 'AvmGadgetsTest/muldiv_large_10_times',
+        /*sender=*/ deployer,
+        /*setupCalls=*/ [],
+        /*appCalls=*/ [
+          {
+            address: avmGadgetsTestContract.address,
+            fnName: 'muldiv_large_10_times',
+            args: [],
+          },
+        ],
+      );
+      expect(result.revertCode.isOK()).toBe(true);
+    });
+
+    it('add_with_carry_no_overflow', async () => {
+      const result = await tester.simulateTxWithLabel(
+        /*txLabel=*/ 'AvmGadgetsTest/add_with_carry_no_overflow',
+        /*sender=*/ deployer,
+        /*setupCalls=*/ [],
+        /*appCalls=*/ [
+          {
+            address: avmGadgetsTestContract.address,
+            fnName: 'add_with_carry_no_overflow',
+            args: [],
+          },
+        ],
+      );
+      expect(result.revertCode.isOK()).toBe(true);
+    });
+
+    it('add_with_carry_with_overflow', async () => {
+      const result = await tester.simulateTxWithLabel(
+        /*txLabel=*/ 'AvmGadgetsTest/add_with_carry_with_overflow',
+        /*sender=*/ deployer,
+        /*setupCalls=*/ [],
+        /*appCalls=*/ [
+          {
+            address: avmGadgetsTestContract.address,
+            fnName: 'add_with_carry_with_overflow',
+            args: [],
+          },
+        ],
+      );
+      expect(result.revertCode.isOK()).toBe(true);
+    });
+
+    it('div_256_by_128_exact', async () => {
+      const result = await tester.simulateTxWithLabel(
+        /*txLabel=*/ 'AvmGadgetsTest/div_256_by_128_exact',
+        /*sender=*/ deployer,
+        /*setupCalls=*/ [],
+        /*appCalls=*/ [
+          {
+            address: avmGadgetsTestContract.address,
+            fnName: 'div_256_by_128_exact',
+            args: [],
+          },
+        ],
+      );
+      expect(result.revertCode.isOK()).toBe(true);
+    });
+
+    it('div_256_by_128_large_hi', async () => {
+      const result = await tester.simulateTxWithLabel(
+        /*txLabel=*/ 'AvmGadgetsTest/div_256_by_128_large_hi',
+        /*sender=*/ deployer,
+        /*setupCalls=*/ [],
+        /*appCalls=*/ [
+          {
+            address: avmGadgetsTestContract.address,
+            fnName: 'div_256_by_128_large_hi',
+            args: [],
+          },
+        ],
+      );
+      expect(result.revertCode.isOK()).toBe(true);
+    });
+
+    it('div_256_by_128_non_exact', async () => {
+      const result = await tester.simulateTxWithLabel(
+        /*txLabel=*/ 'AvmGadgetsTest/div_256_by_128_non_exact',
+        /*sender=*/ deployer,
+        /*setupCalls=*/ [],
+        /*appCalls=*/ [
+          {
+            address: avmGadgetsTestContract.address,
+            fnName: 'div_256_by_128_non_exact',
+            args: [],
+          },
+        ],
+      );
+      expect(result.revertCode.isOK()).toBe(true);
+    });
+
+    it('div_256_by_128_exact_10_times', async () => {
+      const result = await tester.simulateTxWithLabel(
+        /*txLabel=*/ 'AvmGadgetsTest/div_256_by_128_exact_10_times',
+        /*sender=*/ deployer,
+        /*setupCalls=*/ [],
+        /*appCalls=*/ [
+          {
+            address: avmGadgetsTestContract.address,
+            fnName: 'div_256_by_128_exact_10_times',
+            args: [],
+          },
+        ],
+      );
+      expect(result.revertCode.isOK()).toBe(true);
+    });
   });
 });


### PR DESCRIPTION
When I try to up the loop tests to 100 iterations (like 100 muldivs), it runs out of gas with the following breakdown:

![image](https://github.com/user-attachments/assets/37433447-4444-4128-8aef-6a819e9367d6)


Here are the benchmark results for these new public test functions:

## TX Label: AvmGadgetsTest contract tests/AvmGadgetsTest/muldiv_small_values/20
- Total duration: `56.901 ms`
- Total mana used: `70,017`
- Mana per second: `1,230,500`
- Total instructions executed: `3,408`
- Tx hash computation: `21.066 ms`
- Private insertions:
    - Non-revertible: `2.971 ms`
    - Revertible: `0.72 ms`
- Enqueued public calls:
    - **Fn: AvmGadgetsTest.muldiv_small_values**
        - Duration: `17.988 ms`
        - Mana used: `70,017`
        - Mana per second: `3,892,506`
        - Instructions executed: `3,408`

---------------------------------------------------------------------

## TX Label: AvmGadgetsTest contract tests/AvmGadgetsTest/muldiv_exact_division/21
- Total duration: `53.692 ms`
- Total mana used: `70,794`
- Mana per second: `1,318,513`
- Total instructions executed: `3,444`
- Tx hash computation: `20.984 ms`
- Private insertions:
    - Non-revertible: `2.945 ms`
    - Revertible: `0.698 ms`
- Enqueued public calls:
    - **Fn: AvmGadgetsTest.muldiv_exact_division**
        - Duration: `16.384 ms`
        - Mana used: `70,794`
        - Mana per second: `4,320,922`
        - Instructions executed: `3,444`

---------------------------------------------------------------------

## TX Label: AvmGadgetsTest contract tests/AvmGadgetsTest/muldiv_large_values/22
- Total duration: `55.095 ms`
- Total mana used: `86,124`
- Mana per second: `1,563,202`
- Total instructions executed: `4,142`
- Tx hash computation: `20.892 ms`
- Private insertions:
    - Non-revertible: `2.921 ms`
    - Revertible: `0.573 ms`
- Enqueued public calls:
    - **Fn: AvmGadgetsTest.muldiv_large_values**
        - Duration: `17.625 ms`
        - Mana used: `86,124`
        - Mana per second: `4,886,469`
        - Instructions executed: `4,142`

---------------------------------------------------------------------

## TX Label: AvmGadgetsTest contract tests/AvmGadgetsTest/muldiv_rounding_down/23
- Total duration: `55.97 ms`
- Total mana used: `69,561`
- Mana per second: `1,242,831`
- Total instructions executed: `3,392`
- Tx hash computation: `20.899 ms`
- Private insertions:
    - Non-revertible: `2.868 ms`
    - Revertible: `3.487 ms`
- Enqueued public calls:
    - **Fn: AvmGadgetsTest.muldiv_rounding_down**
        - Duration: `16.034 ms`
        - Mana used: `69,561`
        - Mana per second: `4,338,359`
        - Instructions executed: `3,392`

---------------------------------------------------------------------

## TX Label: AvmGadgetsTest contract tests/AvmGadgetsTest/muldiv_division_by_one/24
- Total duration: `55.042 ms`
- Total mana used: `77,796`
- Mana per second: `1,413,394`
- Total instructions executed: `3,769`
- Tx hash computation: `20.985 ms`
- Private insertions:
    - Non-revertible: `2.44 ms`
    - Revertible: `0.69 ms`
- Enqueued public calls:
    - **Fn: AvmGadgetsTest.muldiv_division_by_one**
        - Duration: `18.218 ms`
        - Mana used: `77,796`
        - Mana per second: `4,270,396`
        - Instructions executed: `3,769`

---------------------------------------------------------------------

## TX Label: AvmGadgetsTest contract tests/AvmGadgetsTest/muldiv_large_10_times/25
- Total duration: `157.648 ms`
- Total mana used: `817,245`
- Mana per second: `5,183,997`
- Total instructions executed: `37,754`
- Tx hash computation: `20.972 ms`
- Private insertions:
    - Non-revertible: `2.605 ms`
    - Revertible: `0.585 ms`
- Enqueued public calls:
    - **Fn: AvmGadgetsTest.muldiv_large_10_times**
        - Duration: `119.654 ms`
        - Mana used: `817,245`
        - Mana per second: `6,830,050`
        - Instructions executed: `37,754`

---------------------------------------------------------------------

## TX Label: AvmGadgetsTest contract tests/AvmGadgetsTest/add_with_carry_no_overflow/26
- Total duration: `43.352 ms`
- Total mana used: `5,709`
- Mana per second: `131,691`
- Total instructions executed: `475`
- Tx hash computation: `20.933 ms`
- Private insertions:
    - Non-revertible: `2.288 ms`
    - Revertible: `0.603 ms`
- Enqueued public calls:
    - **Fn: AvmGadgetsTest.add_with_carry_no_overflow**
        - Duration: `5.998 ms`
        - Mana used: `5,709`
        - Mana per second: `951,748`
        - Instructions executed: `475`

---------------------------------------------------------------------

## TX Label: AvmGadgetsTest contract tests/AvmGadgetsTest/add_with_carry_with_overflow/27
- Total duration: `43.343 ms`
- Total mana used: `5,727`
- Mana per second: `132,131`
- Total instructions executed: `477`
- Tx hash computation: `20.961 ms`
- Private insertions:
    - Non-revertible: `2.613 ms`
    - Revertible: `0.659 ms`
- Enqueued public calls:
    - **Fn: AvmGadgetsTest.add_with_carry_with_overflow**
        - Duration: `6.248 ms`
        - Mana used: `5,727`
        - Mana per second: `916,591`
        - Instructions executed: `477`

---------------------------------------------------------------------

## TX Label: AvmGadgetsTest contract tests/AvmGadgetsTest/div_256_by_128_exact/28
- Total duration: `57.33 ms`
- Total mana used: `68,625`
- Mana per second: `1,197,014`
- Total instructions executed: `3,324`
- Tx hash computation: `21.358 ms`
- Private insertions:
    - Non-revertible: `5.317 ms`
    - Revertible: `0.608 ms`
- Enqueued public calls:
    - **Fn: AvmGadgetsTest.div_256_by_128_exact**
        - Duration: `14.299 ms`
        - Mana used: `68,625`
        - Mana per second: `4,799,127`
        - Instructions executed: `3,324`

---------------------------------------------------------------------

## TX Label: AvmGadgetsTest contract tests/AvmGadgetsTest/div_256_by_128_large_hi/29
- Total duration: `53.979 ms`
- Total mana used: `68,181`
- Mana per second: `1,263,097`
- Total instructions executed: `3,308`
- Tx hash computation: `21.045 ms`
- Private insertions:
    - Non-revertible: `2.778 ms`
    - Revertible: `0.645 ms`
- Enqueued public calls:
    - **Fn: AvmGadgetsTest.div_256_by_128_large_hi**
        - Duration: `14.945 ms`
        - Mana used: `68,181`
        - Mana per second: `4,561,976`
        - Instructions executed: `3,308`

---------------------------------------------------------------------

## TX Label: AvmGadgetsTest contract tests/AvmGadgetsTest/div_256_by_128_non_exact/30
- Total duration: `52.082 ms`
- Total mana used: `69,291`
- Mana per second: `1,330,415`
- Total instructions executed: `3,361`
- Tx hash computation: `21.005 ms`
- Private insertions:
    - Non-revertible: `2.334 ms`
    - Revertible: `0.655 ms`
- Enqueued public calls:
    - **Fn: AvmGadgetsTest.div_256_by_128_non_exact**
        - Duration: `15.293 ms`
        - Mana used: `69,291`
        - Mana per second: `4,530,825`
        - Instructions executed: `3,361`

---------------------------------------------------------------------

## TX Label: AvmGadgetsTest contract tests/AvmGadgetsTest/div_256_by_128_exact_10_times/31
- Total duration: `131.837 ms`
- Total mana used: `639,903`
- Mana per second: `4,853,731`
- Total instructions executed: `29,350`
- Tx hash computation: `20.952 ms`
- Private insertions:
    - Non-revertible: `2.697 ms`
    - Revertible: `0.591 ms`
- Enqueued public calls:
    - **Fn: AvmGadgetsTest.div_256_by_128_exact_10_times**
        - Duration: `94.677 ms`
        - Mana used: `639,903`
        - Mana per second: `6,758,830`
        - Instructions executed: `29,350`

---------------------------------------------------------------------

