### PR TITLE
chore(stakingAssetHandler): allow verified people to reenter themselves

### DIFF
--- a/l1-contracts/src/mock/staking_asset_handler/Queue.sol
+++ b/l1-contracts/src/mock/staking_asset_handler/Queue.sol
@@ -3,7 +3,7 @@ pragma solidity >=0.8.27;
 
 struct Queue {
   mapping(uint256 index => address addr) attester;
-  mapping(address attester => bool) seen;
+  mapping(address attester => bool) inQueue;
   uint256 first;
   uint256 last;
 }
@@ -18,10 +18,10 @@ library QueueLib {
   }
 
   function enqueue(Queue storage self, address _attester) internal {
-    require(!self.seen[_attester], AlreadySeen(_attester));
+    require(!self.inQueue[_attester], AlreadySeen(_attester));
 
     self.attester[self.last] = _attester;
-    self.seen[_attester] = true;
+    self.inQueue[_attester] = true;
     self.last += 1;
   }
 
@@ -30,12 +30,16 @@ library QueueLib {
 
     attester = self.attester[self.first];
 
-    delete self.seen[attester];
+    delete self.inQueue[attester];
 
     self.first += 1;
   }
 
   function length(Queue storage self) internal view returns (uint256 len) {
     len = self.last - self.first;
+  }
+
+  function isInQueue(Queue storage self, address _attester) internal view returns (bool) {
+    return self.inQueue[_attester];
   }
 }

--- a/l1-contracts/test/staking_asset_handler/addValidator.t.sol
+++ b/l1-contracts/test/staking_asset_handler/addValidator.t.sol
@@ -149,7 +149,7 @@ contract addValidatorToQueueTest is StakingAssetHandlerBase {
     // it deposits into the rollup
     // it emits a {ValidatorAdded} event
 
-    vm.assume(_attester != address(0));
+    vm.assume(_attester != address(0) && _caller != address(this) && _attester != address(this));
     uint256 revertTimestamp = stakingAssetHandler.lastMintTimestamp() + mintInterval;
     vm.warp(revertTimestamp);
 
@@ -180,7 +180,9 @@ contract addValidatorToQueueTest is StakingAssetHandlerBase {
     givenPassportProofIsValid
   {
     // it reverts
-    vm.assume(_attester != address(0));
+
+    vm.assume(_attester != address(0) && _caller != address(this) && _attester != address(this));
+
     uint256 revertTimestamp = stakingAssetHandler.lastMintTimestamp() + mintInterval;
     vm.warp(revertTimestamp);
 
@@ -209,7 +211,7 @@ contract addValidatorToQueueTest is StakingAssetHandlerBase {
     // it reverts
     proof.devMode = true;
 
-    vm.assume(_attester != address(0));
+    vm.assume(_attester != address(0) && _caller != address(this) && _attester != address(this));
     uint256 revertTimestamp = stakingAssetHandler.lastMintTimestamp() + mintInterval;
     vm.warp(revertTimestamp);
 
@@ -227,6 +229,7 @@ contract addValidatorToQueueTest is StakingAssetHandlerBase {
     // it reverts
 
     vm.assume(_daysInFuture > 8);
+    vm.assume(_caller != address(this));
 
     address attester = address(uint160(42));
 

--- a/l1-contracts/test/staking_asset_handler/reenterExitedValidator.t.sol
+++ b/l1-contracts/test/staking_asset_handler/reenterExitedValidator.t.sol
@@ -1,0 +1,77 @@
+// SPDX-License-Identifier: Apache-2.0
+pragma solidity >=0.8.27;
+
+import {StakingAssetHandlerBase} from "./base.t.sol";
+import {StakingAssetHandler, IStakingAssetHandler} from "@aztec/mock/StakingAssetHandler.sol";
+import {IStakingCore} from "@aztec/core/interfaces/IStaking.sol";
+
+// solhint-disable comprehensive-interface
+// solhint-disable func-name-mixedcase
+// solhint-disable ordering
+
+contract ReenterExitedValidatorTest is StakingAssetHandlerBase {
+  function test_WhenAttesterHasNOTProvidedAValidDeposit(address _attester, address _proposer)
+    external
+  {
+    // it reverts
+
+    vm.assume(_attester != address(0) && _proposer != address(0));
+
+    vm.expectRevert(
+      abi.encodeWithSelector(IStakingAssetHandler.AttesterDoesNotExist.selector, _attester)
+    );
+    stakingAssetHandler.reenterExitedValidator(_attester, _proposer);
+  }
+
+  // TODO: SHOULD NOT BE ABLE TO SKIP THE QUEUE USING THIS FEATURE THE VALIDATOR MUST HAVE BEEN EXITED AT SOME POINT.
+
+  function test_WhenAttesterHasProvidedAValidDeposit(
+    address _caller,
+    address _attester,
+    address _proposer
+  ) external {
+    // it succeeds
+    // it emits a {ValidatorAdded} event
+
+    // 1. Perform a valid deposit
+    // 2. Exit the validator
+    // 3. Reenter the validator
+
+    vm.assume(_attester != address(0) && _proposer != address(0) && _caller != address(this));
+
+    // 1. Perform a valid deposit
+    vm.prank(_caller);
+    stakingAssetHandler.addValidator(_attester, _proposer, realProof);
+
+    emit IStakingAssetHandler.ValidatorAdded(address(staking), _attester, _proposer, WITHDRAWER);
+    stakingAssetHandler.dripQueue();
+
+    // 2. Exit the validator
+    vm.prank(WITHDRAWER);
+    assertTrue(IStakingCore(staking).initiateWithdraw(_attester, WITHDRAWER));
+
+    // Jump forward the withdrawal window - very far in future incase values change
+    vm.warp(block.timestamp + 4 weeks);
+
+    // 3. Reenter the validator
+    vm.prank(_caller);
+    emit IStakingAssetHandler.ValidatorAdded(address(staking), _attester, _proposer, WITHDRAWER);
+    stakingAssetHandler.reenterExitedValidator(_attester, _proposer);
+  }
+
+  function test_WhenInEntryQueue(address _caller, address _attester, address _proposer) external {
+    // it reverts
+
+    // Do not allow deposits from validators that are currently in the entry queue
+    vm.assume(_attester != address(0) && _proposer != address(0) && _caller != address(this));
+
+    // 1. Perform adding to queue
+    vm.prank(_caller);
+    stakingAssetHandler.addValidator(_attester, _proposer, realProof);
+
+    // 2. Reenter the validator should revert
+    vm.prank(_caller);
+    vm.expectRevert(abi.encodeWithSelector(IStakingAssetHandler.InDepositQueue.selector));
+    stakingAssetHandler.reenterExitedValidator(_attester, _proposer);
+  }
+}

--- a/l1-contracts/test/staking_asset_handler/reenterExitedValidator.tree
+++ b/l1-contracts/test/staking_asset_handler/reenterExitedValidator.tree
@@ -1,0 +1,8 @@
+ReenterExitedValidatorTest
+├── when attester has NOT provided a valid deposit
+│   └── it reverts
+├── when attester has provided a valid deposit
+│   └── it succeeds
+│   └── it emits a {ValidatorAdded} event
+└── when in Entry Queue
+    └── it reverts

--- a/l1-contracts/test/staking_asset_handler/reenterExitedValidator.tree
+++ b/l1-contracts/test/staking_asset_handler/reenterExitedValidator.tree
@@ -3,6 +3,6 @@ ReenterExitedValidatorTest
 │   └── it reverts
 ├── when attester has provided a valid deposit
 │   └── it succeeds
-│   └── it emits a {ValidatorAdded} event
+│   └── it emits a {AddedToQueue} event
 └── when in Entry Queue
     └── it reverts


### PR DESCRIPTION
Allows verified individuals to re-enter their validator. 
Will probably be added to the addvalidator flow but it would have caused way more test changes, so leaving on it's own for now
