### PR TITLE
chore(stakingAssetHandler): include queue position in added to queue event

### DIFF
--- a/l1-contracts/src/mock/StakingAssetHandler.sol
+++ b/l1-contracts/src/mock/StakingAssetHandler.sol
@@ -32,7 +32,7 @@ import {QueueLib, Queue} from "./staking_asset_handler/Queue.sol";
 
 interface IStakingAssetHandler {
   event ToppedUp(uint256 _amount);
-  event AddedToQueue(address indexed _attester);
+  event AddedToQueue(address indexed _attester, uint256 _position);
   event ValidatorAdded(address indexed _rollup, address indexed _attester, address _withdrawer);
   event IntervalUpdated(uint256 _interval);
   event DepositsPerMintUpdated(uint256 _depositsPerMint);
@@ -69,6 +69,8 @@ interface IStakingAssetHandler {
 
   // View
   function getQueueLength() external view returns (uint256);
+  function getFrontOfQueue() external view returns (uint256);
+  function getEndOfQueue() external view returns (uint256);
   function getRollup() external view returns (address);
 }
 
@@ -264,6 +266,14 @@ contract StakingAssetHandler is IStakingAssetHandler, Ownable {
     return entryQueue.length();
   }
 
+  function getFrontOfQueue() external view override(IStakingAssetHandler) returns (uint256) {
+    return entryQueue.getFirst();
+  }
+
+  function getEndOfQueue() external view override(IStakingAssetHandler) returns (uint256) {
+    return entryQueue.getLast();
+  }
+
   /**
    * Validate an attester's zk passport proof
    *
@@ -300,8 +310,8 @@ contract StakingAssetHandler is IStakingAssetHandler, Ownable {
    */
   function _addToQueue(address _attester) internal {
     // Add validator into the entry queue
-    entryQueue.enqueue(_attester);
-    emit AddedToQueue(_attester);
+    uint256 queueLocation = entryQueue.enqueue(_attester);
+    emit AddedToQueue(_attester, queueLocation);
   }
 
   /**

--- a/l1-contracts/src/mock/staking_asset_handler/Queue.sol
+++ b/l1-contracts/src/mock/staking_asset_handler/Queue.sol
@@ -17,12 +17,16 @@ library QueueLib {
     self.last = 1;
   }
 
-  function enqueue(Queue storage self, address _attester) internal {
+  function enqueue(Queue storage self, address _attester) internal returns (uint256) {
     require(!self.inQueue[_attester], AlreadySeen(_attester));
 
-    self.attester[self.last] = _attester;
+    uint256 queueLocation = self.last;
+
+    self.attester[queueLocation] = _attester;
     self.inQueue[_attester] = true;
     self.last += 1;
+
+    return queueLocation;
   }
 
   function dequeue(Queue storage self) internal returns (address attester) {
@@ -41,5 +45,13 @@ library QueueLib {
 
   function isInQueue(Queue storage self, address _attester) internal view returns (bool) {
     return self.inQueue[_attester];
+  }
+
+  function getFirst(Queue storage self) internal view returns (uint256) {
+    return self.first;
+  }
+
+  function getLast(Queue storage self) internal view returns (uint256) {
+    return self.last;
   }
 }

--- a/l1-contracts/test/staking_asset_handler/addValidator.t.sol
+++ b/l1-contracts/test/staking_asset_handler/addValidator.t.sol
@@ -73,7 +73,7 @@ contract addValidatorToQueueTest is StakingAssetHandlerBase {
     uint256 revertTimestamp = stakingAssetHandler.lastMintTimestamp() + mintInterval;
 
     vm.expectEmit(true, true, true, true, address(stakingAssetHandler));
-    emit IStakingAssetHandler.AddedToQueue(_attester);
+    emit IStakingAssetHandler.AddedToQueue(_attester, 1);
     vm.prank(_caller);
     stakingAssetHandler.addValidatorToQueue(_attester, realProof);
 
@@ -100,12 +100,12 @@ contract addValidatorToQueueTest is StakingAssetHandlerBase {
     // it deposits into the rollup
     // it emits a {ValidatorAdded} event
 
-    vm.assume(_attester != address(0));
+    vm.assume(_attester != address(0) && _attester != unhinged);
     uint256 revertTimestamp = stakingAssetHandler.lastMintTimestamp() + mintInterval;
     vm.warp(revertTimestamp);
 
     vm.expectEmit(true, true, true, true, address(stakingAssetHandler));
-    emit IStakingAssetHandler.AddedToQueue(_attester);
+    emit IStakingAssetHandler.AddedToQueue(_attester, 1);
     vm.prank(_caller);
     stakingAssetHandler.addValidatorToQueue(_attester, realProof);
 
@@ -149,12 +149,15 @@ contract addValidatorToQueueTest is StakingAssetHandlerBase {
     // it deposits into the rollup
     // it emits a {ValidatorAdded} event
 
-    vm.assume(_attester != address(0) && _caller != address(this) && _attester != address(this));
+    vm.assume(
+      _attester != address(0) && _caller != address(this) && _attester != address(this)
+        && _caller != unhinged
+    );
     uint256 revertTimestamp = stakingAssetHandler.lastMintTimestamp() + mintInterval;
     vm.warp(revertTimestamp);
 
     vm.expectEmit(true, true, true, true, address(stakingAssetHandler));
-    emit IStakingAssetHandler.AddedToQueue(_attester);
+    emit IStakingAssetHandler.AddedToQueue(_attester, 1);
     vm.prank(_caller);
     stakingAssetHandler.addValidatorToQueue(_attester, proof);
 
@@ -180,14 +183,16 @@ contract addValidatorToQueueTest is StakingAssetHandlerBase {
     givenPassportProofIsValid
   {
     // it reverts
-
-    vm.assume(_attester != address(0) && _caller != address(this) && _attester != address(this));
+    vm.assume(
+      _attester != address(0) && _caller != address(this) && _attester != address(this)
+        && _caller != unhinged
+    );
 
     uint256 revertTimestamp = stakingAssetHandler.lastMintTimestamp() + mintInterval;
     vm.warp(revertTimestamp);
 
     vm.expectEmit(true, true, true, true, address(stakingAssetHandler));
-    emit IStakingAssetHandler.AddedToQueue(_attester);
+    emit IStakingAssetHandler.AddedToQueue(_attester, 1);
     vm.prank(_caller);
     stakingAssetHandler.addValidatorToQueue(_attester, proof);
 
@@ -198,7 +203,7 @@ contract addValidatorToQueueTest is StakingAssetHandlerBase {
       )
     );
     // Call from somebody else
-    vm.prank(_attester);
+    vm.prank(_caller);
     stakingAssetHandler.addValidatorToQueue(_attester, proof);
   }
 
@@ -211,7 +216,10 @@ contract addValidatorToQueueTest is StakingAssetHandlerBase {
     // it reverts
     proof.devMode = true;
 
-    vm.assume(_attester != address(0) && _caller != address(this) && _attester != address(this));
+    vm.assume(
+      _attester != address(0) && _caller != address(this) && _attester != address(this)
+        && _attester != unhinged
+    );
     uint256 revertTimestamp = stakingAssetHandler.lastMintTimestamp() + mintInterval;
     vm.warp(revertTimestamp);
 
@@ -229,7 +237,7 @@ contract addValidatorToQueueTest is StakingAssetHandlerBase {
     // it reverts
 
     vm.assume(_daysInFuture > 8);
-    vm.assume(_caller != address(this));
+    vm.assume(_caller != address(this) && _caller != unhinged);
 
     address attester = address(uint160(42));
 
@@ -260,6 +268,7 @@ contract addValidatorToQueueTest is StakingAssetHandlerBase {
       _attester != _secondAttester && _attester != _thirdAttester
         && _secondAttester != _thirdAttester
     );
+    vm.assume(_caller != address(this) && _caller != unhinged);
 
     uint256 revertTimestamp = stakingAssetHandler.lastMintTimestamp() + mintInterval + mintInterval;
     vm.warp(revertTimestamp);
@@ -269,7 +278,7 @@ contract addValidatorToQueueTest is StakingAssetHandlerBase {
     stakingAssetHandler.setDepositsPerMint(_depositsPerMint);
 
     vm.expectEmit(true, true, true, true, address(stakingAssetHandler));
-    emit IStakingAssetHandler.AddedToQueue(_attester);
+    emit IStakingAssetHandler.AddedToQueue(_attester, 1);
     vm.prank(_caller);
     stakingAssetHandler.addValidatorToQueue(_attester, realProof);
 
@@ -278,14 +287,14 @@ contract addValidatorToQueueTest is StakingAssetHandlerBase {
 
     // later we will mock that this deposit call fails, with a swapped attester
     vm.expectEmit(true, true, true, true, address(stakingAssetHandler));
-    emit IStakingAssetHandler.AddedToQueue(_secondAttester);
+    emit IStakingAssetHandler.AddedToQueue(_secondAttester, 2);
     vm.prank(_caller);
     stakingAssetHandler.addValidatorToQueue(_secondAttester, realProof);
 
     mockZKPassportVerifier.incrementUniqueIdentifier();
 
     vm.expectEmit(true, true, true, true, address(stakingAssetHandler));
-    emit IStakingAssetHandler.AddedToQueue(_thirdAttester);
+    emit IStakingAssetHandler.AddedToQueue(_thirdAttester, 3);
     vm.prank(_caller);
     stakingAssetHandler.addValidatorToQueue(_thirdAttester, realProof);
 

--- a/l1-contracts/test/staking_asset_handler/reenterExitedValidator.t.sol
+++ b/l1-contracts/test/staking_asset_handler/reenterExitedValidator.t.sol
@@ -41,7 +41,7 @@ contract ReenterExitedValidatorTest is StakingAssetHandlerBase {
     vm.prank(_caller);
     stakingAssetHandler.addValidatorToQueue(_attester, realProof);
 
-    emit IStakingAssetHandler.AddedToQueue(_attester);
+    emit IStakingAssetHandler.AddedToQueue(_attester, 0);
     stakingAssetHandler.dripQueue();
 
     // 2. Exit the validator
@@ -53,7 +53,7 @@ contract ReenterExitedValidatorTest is StakingAssetHandlerBase {
 
     // 3. Reenter the validator
     vm.prank(_caller);
-    emit IStakingAssetHandler.AddedToQueue(_attester);
+    emit IStakingAssetHandler.AddedToQueue(_attester, 1);
     stakingAssetHandler.reenterExitedValidator(_attester);
 
     vm.prank(_caller);

--- a/l1-contracts/test/staking_asset_handler/setDepositsPerMint.t.sol
+++ b/l1-contracts/test/staking_asset_handler/setDepositsPerMint.t.sol
@@ -69,7 +69,7 @@ contract SetDepositsPerMintTest is StakingAssetHandlerBase {
 
     for (uint256 i = 0; i < _depositsPerMint; i++) {
       vm.expectEmit(true, true, true, true, address(stakingAssetHandler));
-      emit IStakingAssetHandler.AddedToQueue(validators[i]);
+      emit IStakingAssetHandler.AddedToQueue(validators[i], 1 + i);
       vm.prank(caller);
       stakingAssetHandler.addValidatorToQueue(validators[i], realProof);
 
@@ -92,7 +92,7 @@ contract SetDepositsPerMintTest is StakingAssetHandlerBase {
 
     // Added to the queue successfully
     vm.expectEmit(true, true, true, true, address(stakingAssetHandler));
-    emit IStakingAssetHandler.AddedToQueue(address(0xbeefdeef));
+    emit IStakingAssetHandler.AddedToQueue(address(0xbeefdeef), _depositsPerMint + 1);
     vm.prank(caller);
     stakingAssetHandler.addValidatorToQueue(address(0xbeefdeef), realProof);
 

--- a/l1-contracts/test/staking_asset_handler/setMintInterval.t.sol
+++ b/l1-contracts/test/staking_asset_handler/setMintInterval.t.sol
@@ -63,7 +63,7 @@ contract SetMintIntervalTest is StakingAssetHandlerBase {
     address rollup = stakingAssetHandler.getRollup();
 
     vm.expectEmit(true, true, true, true, address(stakingAssetHandler));
-    emit IStakingAssetHandler.AddedToQueue(address(1));
+    emit IStakingAssetHandler.AddedToQueue(address(1), 1);
     vm.prank(address(0xbeefdeef));
     stakingAssetHandler.addValidatorToQueue(address(1), realProof);
 


### PR DESCRIPTION
Includes the queue position in the addedToQueue event, this in conjunction with getters to know the start and end
index of the queue are enough to know where a validator is in the queue at a given time.
