### PR TITLE
refactor(bb): use shared cache for pippenger_runtime_state

### DIFF
--- a/barretenberg/cpp/src/barretenberg/client_ivc/client_ivc.cpp
+++ b/barretenberg/cpp/src/barretenberg/client_ivc/client_ivc.cpp
@@ -23,6 +23,7 @@ ClientIVC::ClientIVC(TraceSettings trace_settings)
     size_t commitment_key_size =
         std::max(trace_settings.dyadic_size(), 1UL << TranslatorFlavor::CONST_TRANSLATOR_LOG_N);
     info("BN254 commitment key size: ", commitment_key_size);
+    // TODO(https://github.com/AztecProtocol/barretenberg/issues/1420): pass commitment keys by value
     bn254_commitment_key = std::make_shared<CommitmentKey<curve::BN254>>(commitment_key_size);
 }
 
@@ -195,6 +196,7 @@ void ClientIVC::accumulate(ClientCircuit& circuit,
     // If the current circuit overflows past the current size of the commitment key, reinitialize accordingly.
     // TODO(https://github.com/AztecProtocol/barretenberg/issues/1319)
     if (proving_key->proving_key.circuit_size > bn254_commitment_key->dyadic_size) {
+        // TODO(https://github.com/AztecProtocol/barretenberg/issues/1420): pass commitment keys by value
         bn254_commitment_key = std::make_shared<CommitmentKey<curve::BN254>>(proving_key->proving_key.circuit_size);
         goblin.commitment_key = bn254_commitment_key;
     }

--- a/barretenberg/cpp/src/barretenberg/commitment_schemes/commitment_key.hpp
+++ b/barretenberg/cpp/src/barretenberg/commitment_schemes/commitment_key.hpp
@@ -13,7 +13,6 @@
  * simplify the codebase.
  */
 
-#include "barretenberg/common/debug_log.hpp"
 #include "barretenberg/common/op_count.hpp"
 #include "barretenberg/ecc/batched_affine_addition/batched_affine_addition.hpp"
 #include "barretenberg/ecc/scalar_multiplication/scalar_multiplication.hpp"
@@ -56,8 +55,7 @@ template <class Curve> class CommitmentKey {
     }
 
   public:
-    scalar_multiplication::pippenger_runtime_state<Curve> pippenger_runtime_state;
-    std::shared_ptr<srs::factories::CrsFactory<Curve>> crs_factory;
+    scalar_multiplication::PippengerReference<Curve> pippenger_runtime_state;
     std::shared_ptr<srs::factories::Crs<Curve>> srs;
     size_t dyadic_size;
 
@@ -72,8 +70,7 @@ template <class Curve> class CommitmentKey {
      */
     CommitmentKey(const size_t num_points)
         : pippenger_runtime_state(get_num_needed_srs_points(num_points))
-        , crs_factory(srs::get_crs_factory<Curve>())
-        , srs(crs_factory->get_crs(get_num_needed_srs_points(num_points)))
+        , srs(srs::get_crs_factory<Curve>()->get_crs(get_num_needed_srs_points(num_points)))
         , dyadic_size(get_num_needed_srs_points(num_points))
     {}
 
@@ -115,10 +112,8 @@ template <class Curve> class CommitmentKey {
         // with our polynomial span.
 
         std::span<G1> point_table = srs->get_monomial_points().subspan(actual_start_index * 2);
-        DEBUG_LOG_ALL(polynomial.span);
         Commitment point = scalar_multiplication::pippenger_unsafe_optimized_for_non_dyadic_polys<Curve>(
-            { relative_start_index, polynomial.span }, point_table, pippenger_runtime_state);
-        DEBUG_LOG(point);
+            { relative_start_index, polynomial.span }, point_table, pippenger_runtime_state.get());
         return point;
     };
 
@@ -189,7 +184,7 @@ template <class Curve> class CommitmentKey {
         }
 
         // Call the version of pippenger which assumes all points are distinct
-        return scalar_multiplication::pippenger_unsafe<Curve>({ 0, scalars }, points, pippenger_runtime_state);
+        return scalar_multiplication::pippenger_unsafe<Curve>({ 0, scalars }, points, pippenger_runtime_state.get());
     }
 
     /**
@@ -252,7 +247,7 @@ template <class Curve> class CommitmentKey {
         }
 
         // Call pippenger
-        return scalar_multiplication::pippenger_unsafe<Curve>({ 0, scalars }, points, pippenger_runtime_state);
+        return scalar_multiplication::pippenger_unsafe<Curve>({ 0, scalars }, points, pippenger_runtime_state.get());
     }
 
     /**

--- a/barretenberg/cpp/src/barretenberg/commitment_schemes/ipa/ipa.hpp
+++ b/barretenberg/cpp/src/barretenberg/commitment_schemes/ipa/ipa.hpp
@@ -239,13 +239,13 @@ template <typename Curve_> class IPA {
             // Step 6.a (using letters, because doxygen automatically converts the sublist counters to letters :( )
             // L_i = < a_vec_lo, G_vec_hi > + inner_prod_L * aux_generator
             L_i = bb::scalar_multiplication::pippenger_without_endomorphism_basis_points<Curve>(
-                {0, {&a_vec.at(0), /*size*/ round_size}}, {&G_vec_local[round_size], /*size*/ round_size}, ck->pippenger_runtime_state);
+                {0, {&a_vec.at(0), /*size*/ round_size}}, {&G_vec_local[round_size], /*size*/ round_size}, ck->pippenger_runtime_state.get());
             L_i += aux_generator * inner_prod_L;
 
             // Step 6.b
             // R_i = < a_vec_hi, G_vec_lo > + inner_prod_R * aux_generator
             R_i = bb::scalar_multiplication::pippenger_without_endomorphism_basis_points<Curve>(
-                {0, {&a_vec.at(round_size), /*size*/ round_size}}, {&G_vec_local[0], /*size*/ round_size}, ck->pippenger_runtime_state);
+                {0, {&a_vec.at(round_size), /*size*/ round_size}}, {&G_vec_local[0], /*size*/ round_size}, ck->pippenger_runtime_state.get());
             R_i += aux_generator * inner_prod_R;
 
             // Step 6.c
@@ -388,7 +388,7 @@ template <typename Curve_> class IPA {
         // Step 5.
         // Compute C₀ = C' + ∑_{j ∈ [k]} u_j^{-1}L_j + ∑_{j ∈ [k]} u_jR_j
         GroupElement LR_sums = bb::scalar_multiplication::pippenger_without_endomorphism_basis_points<Curve>(
-            {0, {&msm_scalars[0], /*size*/ pippenger_size}}, {&msm_elements[0], /*size*/ pippenger_size}, vk->pippenger_runtime_state);
+            {0, {&msm_scalars[0], /*size*/ pippenger_size}}, {&msm_elements[0], /*size*/ pippenger_size}, vk->pippenger_runtime_state.get());
         GroupElement C_zero = C_prime + LR_sums;
 
         //  Step 6.
@@ -424,7 +424,7 @@ template <typename Curve_> class IPA {
         // Step 8.
         // Compute G₀
         Commitment G_zero = bb::scalar_multiplication::pippenger_without_endomorphism_basis_points<Curve>(
-           s_poly, {&G_vec_local[0], /*size*/ poly_length}, vk->pippenger_runtime_state);
+           s_poly, {&G_vec_local[0], /*size*/ poly_length}, vk->pippenger_runtime_state.get());
         Commitment G_zero_sent = transcript->template receive_from_prover<Commitment>("IPA:G_0");
         BB_ASSERT_EQ(G_zero, G_zero_sent, "G_0 should be equal to G_0 sent in transcript.");
 

--- a/barretenberg/cpp/src/barretenberg/commitment_schemes/verification_key.hpp
+++ b/barretenberg/cpp/src/barretenberg/commitment_schemes/verification_key.hpp
@@ -98,7 +98,7 @@ template <> class VerifierCommitmentKey<curve::Grumpkin> {
 
     std::span<const Commitment> get_monomial_points() { return srs->get_monomial_points(); }
 
-    bb::scalar_multiplication::pippenger_runtime_state<Curve> pippenger_runtime_state;
+    bb::scalar_multiplication::PippengerReference<Curve> pippenger_runtime_state;
 
   private:
     std::shared_ptr<bb::srs::factories::Crs<Curve>> srs;

--- a/barretenberg/cpp/src/barretenberg/ecc/scalar_multiplication/runtime_states.hpp
+++ b/barretenberg/cpp/src/barretenberg/ecc/scalar_multiplication/runtime_states.hpp
@@ -9,6 +9,7 @@
 #include "barretenberg/ecc/curves/bn254/bn254.hpp"
 #include "barretenberg/ecc/curves/grumpkin/grumpkin.hpp"
 #include "barretenberg/ecc/groups/wnaf.hpp"
+#include <memory>
 
 namespace bb::scalar_multiplication {
 // simple helper functions to retrieve pointers to pre-allocated memory for the scalar multiplication algorithm.
@@ -120,4 +121,43 @@ template <typename Curve> struct pippenger_runtime_state {
     affine_product_runtime_state<Curve> get_affine_product_runtime_state(size_t num_threads, size_t thread_index);
 };
 
+// PippengerReference is a singleton manager for pippenger_runtime_state instances.
+// It provides thread-unsafe caching and automatic reallocation when larger sizes are needed.
+// It ensures at most one singleton exists, but can be deallocated when no PippengerReference instances are live.
+template <typename Curve> class PippengerReference {
+  private:
+    inline static std::weak_ptr<pippenger_runtime_state<Curve>> pippenger_runtime_singleton; // NOLINT
+    std::shared_ptr<pippenger_runtime_state<Curve>> reference;
+
+    // WARNING: Not thread safe! This should be OK as pippenger itself will error out if called from multiple threads
+    static std::shared_ptr<pippenger_runtime_state<Curve>> get_singleton(size_t num_initial_points)
+    {
+        const size_t num_points = num_initial_points * 2;
+        std::shared_ptr<pippenger_runtime_state<Curve>> singleton = pippenger_runtime_singleton.lock();
+        // Were no PippengerReference instances live?
+        if (singleton == nullptr) {
+            singleton = std::make_shared<pippenger_runtime_state<Curve>>(num_initial_points);
+            pippenger_runtime_singleton = singleton;
+        }
+        // Do we need to grow the singleton?
+        if (num_points > singleton->num_points) {
+            // Deallocate existing. We hijack the move constructor to do this.
+            // This is important for peak memory.
+            {
+                BB_UNUSED pippenger_runtime_state<Curve> _unused = std::move(*singleton);
+            }
+            // Create a new one with the correct size.
+            pippenger_runtime_state<Curve> reallocated_state(num_initial_points);
+            // Move the reallocated state into our empty object.
+            *singleton = std::move(reallocated_state);
+        }
+        return singleton;
+    }
+
+  public:
+    PippengerReference(size_t num_initial_points)
+        : reference(get_singleton(num_initial_points))
+    {}
+    pippenger_runtime_state<Curve>& get() const { return *reference; }
+};
 } // namespace bb::scalar_multiplication

--- a/barretenberg/cpp/src/barretenberg/stdlib_circuit_builders/ultra_flavor.hpp
+++ b/barretenberg/cpp/src/barretenberg/stdlib_circuit_builders/ultra_flavor.hpp
@@ -378,6 +378,7 @@ class UltraFlavor {
             this->pairing_inputs_public_input_key = proving_key.pairing_inputs_public_input_key;
 
             if (proving_key.commitment_key == nullptr) {
+                // TODO(https://github.com/AztecProtocol/barretenberg/issues/1420): pass commitment keys by value
                 proving_key.commitment_key = std::make_shared<CommitmentKey>(proving_key.circuit_size);
             }
             for (auto [polynomial, commitment] : zip_view(proving_key.polynomials.get_precomputed(), this->get_all())) {

--- a/barretenberg/cpp/src/barretenberg/stdlib_circuit_builders/ultra_keccak_flavor.hpp
+++ b/barretenberg/cpp/src/barretenberg/stdlib_circuit_builders/ultra_keccak_flavor.hpp
@@ -60,6 +60,7 @@ class UltraKeccakFlavor : public bb::UltraFlavor {
             this->pub_inputs_offset = proving_key.pub_inputs_offset;
 
             if (proving_key.commitment_key == nullptr) {
+                // TODO(https://github.com/AztecProtocol/barretenberg/issues/1420): pass commitment keys by value
                 proving_key.commitment_key = std::make_shared<CommitmentKey>(proving_key.circuit_size);
             }
             for (auto [polynomial, commitment] : zip_view(proving_key.polynomials.get_precomputed(), this->get_all())) {

--- a/barretenberg/cpp/src/barretenberg/sumcheck/sumcheck.hpp
+++ b/barretenberg/cpp/src/barretenberg/sumcheck/sumcheck.hpp
@@ -276,6 +276,7 @@ template <typename Flavor, const size_t virtual_log_n = CONST_PROOF_SIZE_LOG_N> 
         std::shared_ptr<CommitmentKey> ck = nullptr;
 
         if constexpr (IsGrumpkinFlavor<Flavor>) {
+            // TODO(https://github.com/AztecProtocol/barretenberg/issues/1420): pass commitment keys by value
             ck = std::make_shared<CommitmentKey>(BATCHED_RELATION_PARTIAL_LENGTH);
             // Compute the vector {0, 1, \ldots, BATCHED_RELATION_PARTIAL_LENGTH-1} needed to transform the round
             // univariates from Lagrange to monomial basis

--- a/barretenberg/cpp/src/barretenberg/ultra_honk/merge_prover.cpp
+++ b/barretenberg/cpp/src/barretenberg/ultra_honk/merge_prover.cpp
@@ -18,6 +18,7 @@ MergeProver::MergeProver(const std::shared_ptr<ECCOpQueue>& op_queue,
                          const std::shared_ptr<CommitmentKey>& commitment_key,
                          const std::shared_ptr<Transcript>& transcript)
     : op_queue(op_queue)
+    // TODO(https://github.com/AztecProtocol/barretenberg/issues/1420): pass commitment keys by value
     , pcs_commitment_key(commitment_key ? commitment_key
                                         : std::make_shared<CommitmentKey>(op_queue->get_ultra_ops_table_num_rows()))
     , transcript(transcript){};

--- a/barretenberg/cpp/src/barretenberg/vm2/constraining/flavor.cpp
+++ b/barretenberg/cpp/src/barretenberg/vm2/constraining/flavor.cpp
@@ -100,6 +100,7 @@ AvmFlavor::ProvingKey::ProvingKey(const size_t circuit_size, const size_t num_pu
     , log_circuit_size(numeric::get_msb(circuit_size))
     , num_public_inputs(num_public_inputs)
     , evaluation_domain(bb::EvaluationDomain<FF>(circuit_size, circuit_size))
+    // TODO(https://github.com/AztecProtocol/barretenberg/issues/1420): pass commitment keys by value
     , commitment_key(std::make_shared<CommitmentKey>(circuit_size + 1)){
         // The proving key's polynomials are not allocated here because they are later overwritten
         // AvmComposer::compute_witness(). We should probably refactor this flow.


### PR DESCRIPTION
We have been doing complicated things when resizing commitment keys. This PR means they have trivial lifetime analysis: we always keep at most one pippenger_runtime_state (per curve). 

Followup: https://github.com/AztecProtocol/barretenberg/issues/1420 with commitment keys so simplified, just pass them by value. 