### PR TITLE
chore: Only validate txs taken from proposals

### DIFF
--- a/yarn-project/p2p/src/client/interface.ts
+++ b/yarn-project/p2p/src/client/interface.ts
@@ -78,7 +78,7 @@ export type P2P<T extends P2PClientType = P2PClientType.Full> = P2PApiFull<T> & 
    * Adds transactions to the pool. Does not send to peers or validate the tx.
    * @param txs - The transactions.
    **/
-  addTxs(txs: Tx[]): Promise<void>;
+  addTxsToPool(txs: Tx[]): Promise<void>;
 
   /**
    * Deletes 'txs' from the pool, given hashes.

--- a/yarn-project/p2p/src/client/p2p_client.ts
+++ b/yarn-project/p2p/src/client/p2p_client.ts
@@ -442,7 +442,7 @@ export class P2PClient<T extends P2PClientType = P2PClientType.Full>
   /**
    * Returns transactions in the transaction pool by hash.
    * @param txHashes - Hashes of the transactions to look for.
-   * @returns The txs found, not necessarily on the same order as the hashes.
+   * @returns The txs found, in the same order as the requested hashes. If a tx is not found, it will be undefined.
    */
   getTxsByHashFromPool(txHashes: TxHash[]): Promise<(Tx | undefined)[]> {
     return this.txPool.getTxsByHash(txHashes);
@@ -525,7 +525,7 @@ export class P2PClient<T extends P2PClientType = P2PClientType.Full>
    * @returns Empty promise.
    **/
   public async sendTx(tx: Tx): Promise<void> {
-    await this.addTxs([tx]);
+    await this.addTxsToPool([tx]);
     await this.p2pService.propagate(tx);
   }
 
@@ -533,7 +533,7 @@ export class P2PClient<T extends P2PClientType = P2PClientType.Full>
    * Adds transactions to the pool. Does not send to peers or validate the txs.
    * @param txs - The transactions.
    **/
-  public async addTxs(txs: Tx[]): Promise<void> {
+  public async addTxsToPool(txs: Tx[]): Promise<void> {
     this.#assertIsReady();
     await this.txPool.addTxs(txs);
   }

--- a/yarn-project/p2p/src/services/tx_collector.test.ts
+++ b/yarn-project/p2p/src/services/tx_collector.test.ts
@@ -1,0 +1,219 @@
+import { Signature } from '@aztec/foundation/eth-signature';
+import { Fr } from '@aztec/foundation/fields';
+import { type P2P, TxCollector } from '@aztec/p2p';
+import { BlockProposal, ConsensusPayload } from '@aztec/stdlib/p2p';
+import { mockTx } from '@aztec/stdlib/testing';
+import { ProposedBlockHeader, StateReference, type Tx, type TxHash } from '@aztec/stdlib/tx';
+
+import { type MockProxy, mock } from 'jest-mock-extended';
+
+type TxResults = { retrievedTxs: Tx[]; missingTxs: TxHash[] };
+
+describe('tx collector', () => {
+  // Dependencies
+  let p2p: MockProxy<P2P>;
+
+  // There is a tx pool in the p2p layer and one in each node.
+  const txPool: Map<string, Tx> = new Map();
+  // This is a list of txs that are on the p2p network but not in the pool.
+  const additionalP2PTxs: Tx[] = [];
+
+  const generateTransactions = async (numTxs: number) => {
+    return await Promise.all(Array.from({ length: numTxs }, () => mockTx()));
+  };
+
+  const buildProposal = (txs: Tx[], txHashes: TxHash[]) => {
+    const payload = new ConsensusPayload(ProposedBlockHeader.empty(), Fr.random(), StateReference.empty(), txHashes);
+    return new BlockProposal(new Fr(1), payload, Signature.empty(), txs);
+  };
+
+  const setupTxPools = async (txsInPool: number, txsOnP2P: number, txs: Tx[]) => {
+    const txHashes = await Promise.all(txs.map(tx => tx.getTxHash()));
+    let offset = 0;
+    txs.slice(0, txsInPool).forEach((tx, index) => txPool.set(txHashes[index].toString(), tx));
+    offset += txsInPool;
+    additionalP2PTxs.push(...txs.slice(offset, offset + txsOnP2P));
+  };
+
+  const checkTxs = async (received: Tx[], expected: Tx[]) => {
+    expect(received.length).toBe(expected.length);
+    const receivedHashes = await Promise.all(received.map(tx => tx.getTxHash()));
+    const expectedHashes = await Promise.all(expected.map(tx => tx.getTxHash()));
+    expect(receivedHashes.map(txHash => txHash.toString())).toEqual(expectedHashes.map(txHash => txHash.toString()));
+  };
+
+  const checkHashes = (received: TxHash[] | undefined, expected: TxHash[] | undefined) => {
+    if (received === undefined || expected === undefined) {
+      expect(received).toBe(expected);
+      return;
+    }
+    expect(received.length).toBe(expected.length);
+    expect(received.map(txHash => txHash.toString()).sort()).toEqual(expected.map(txHash => txHash.toString()).sort());
+  };
+
+  const checkResults = async (received: TxResults, expected: TxResults) => {
+    await checkTxs(received.retrievedTxs, expected.retrievedTxs);
+    checkHashes(received.missingTxs, expected.missingTxs);
+  };
+
+  const shuffleTxs = (original: Tx[]) => {
+    return original
+      .map(value => ({ value, sort: Math.random() }))
+      .sort((a, b) => a.sort - b.sort)
+      .map(({ value }) => value);
+  };
+
+  beforeEach(() => {
+    txPool.clear();
+    additionalP2PTxs.length = 0;
+
+    p2p = mock<P2P>();
+    p2p.getTxsByHash.mockImplementation(async txHashes => {
+      const p2pTxs = await Promise.all(additionalP2PTxs.map(tx => tx.getTxHash().then(hash => ({ hash, tx }))));
+      const requiredP2PTxs = p2pTxs.filter(p2pTx => txHashes.some(txHash => p2pTx.hash.equals(txHash)));
+      requiredP2PTxs.forEach(tx => txPool.set(tx.hash.toString(), tx.tx));
+      const txs = txHashes.map(txHash => txPool.get(txHash.toString()));
+      return Promise.resolve(txs);
+    });
+    p2p.hasTxsInPool.mockImplementation(txHashes => {
+      return Promise.resolve(txHashes.map(txHash => txPool.has(txHash.toString())));
+    });
+    p2p.getTxsByHashFromPool.mockImplementation(txHashes => {
+      const txs = txHashes.map(txHash => txPool.get(txHash.toString()));
+      return Promise.resolve(txs);
+    });
+    p2p.addTxsToPool.mockImplementation(async txs => {
+      const hashes = await Promise.all(txs.map(tx => tx.getTxHash()));
+      txs.forEach((tx, index) => txPool.set(hashes[index].toString(), tx));
+      return Promise.resolve();
+    });
+  });
+
+  it('can be created', () => {
+    const collector = new TxCollector(p2p);
+    expect(collector).toBeDefined();
+  });
+
+  it('can gather transactions from the network', async () => {
+    const collector = new TxCollector(p2p);
+    const original = await generateTransactions(10);
+    await setupTxPools(0, 10, original);
+
+    // Random shuffle the txs so we test that the collection handles gaps in where txs are found
+    const txs = shuffleTxs(original);
+    const hashes = await Promise.all(txs.map(tx => tx.getTxHash()));
+    const proposal = buildProposal([], hashes);
+    const results = await collector.collectForBlockProposal(proposal, undefined);
+    const expected: TxResults = {
+      retrievedTxs: txs,
+      missingTxs: [],
+    };
+    await checkResults({ retrievedTxs: results.txs, missingTxs: results.missing ?? [] }, expected);
+    expect(txPool.size).toEqual(10);
+  });
+
+  it('reports txs missing from the network', async () => {
+    const collector = new TxCollector(p2p);
+    const original = await generateTransactions(10);
+    const originalHashes = await Promise.all(original.map(tx => tx.getTxHash()));
+    await setupTxPools(0, 5, original);
+
+    const txs = original;
+    const hashes = await Promise.all(txs.map(tx => tx.getTxHash()));
+
+    const proposal = buildProposal([], hashes);
+    const results = await collector.collectForBlockProposal(proposal, undefined);
+    const expected: TxResults = {
+      retrievedTxs: txs.slice(0, 5),
+      missingTxs: originalHashes.slice(5),
+    };
+    await checkResults({ retrievedTxs: results.txs, missingTxs: results.missing ?? [] }, expected);
+    expect(txPool.size).toEqual(5);
+  });
+
+  it('takes txs from the pool as well as the network', async () => {
+    const collector = new TxCollector(p2p);
+    const original = await generateTransactions(10);
+    const originalHashes = await Promise.all(original.map(tx => tx.getTxHash()));
+    await setupTxPools(2, 4, original);
+
+    const txs = original;
+    const hashes = await Promise.all(txs.map(tx => tx.getTxHash()));
+    const proposal = buildProposal([], hashes);
+    const results = await collector.collectForBlockProposal(proposal, undefined);
+    const expected: TxResults = {
+      retrievedTxs: txs.slice(0, 6),
+      missingTxs: originalHashes.slice(6),
+    };
+    await checkResults({ retrievedTxs: results.txs, missingTxs: results.missing ?? [] }, expected);
+    expect(txPool.size).toEqual(6);
+  });
+
+  it('takes txs from the pool, the network, and the proposal', async () => {
+    const collector = new TxCollector(p2p);
+    const original = await generateTransactions(10);
+    await setupTxPools(2, 4, original);
+
+    // Random shuffle the txs so we test that the collection handles gaps in where txs are found
+    const txs = shuffleTxs([...original]);
+    const hashes = await Promise.all(txs.map(tx => tx.getTxHash()));
+    const proposal = buildProposal(original.slice(6), hashes);
+    const results = await collector.collectForBlockProposal(proposal, undefined);
+    const expected: TxResults = {
+      retrievedTxs: txs,
+      missingTxs: [],
+    };
+    await checkResults({ retrievedTxs: results.txs, missingTxs: results.missing ?? [] }, expected);
+    // all txs should be in the pool
+    expect(txPool.size).toEqual(10);
+  });
+
+  it('adds txs from all sources to the pool', async () => {
+    const collector = new TxCollector(p2p);
+    const original = await generateTransactions(10);
+    await setupTxPools(0, 4, original);
+    const originalHashes = await Promise.all(original.map(tx => tx.getTxHash()));
+
+    // Random shuffle the txs so we test that the collection handles gaps in where txs are found
+    const txs = original;
+    const hashes = await Promise.all(txs.map(tx => tx.getTxHash()));
+    const proposal = buildProposal(txs.slice(4, 8), hashes);
+    const results = await collector.collectForBlockProposal(proposal, undefined);
+    const expected: TxResults = {
+      retrievedTxs: txs.slice(0, 8),
+      missingTxs: originalHashes.slice(8),
+    };
+    await checkResults({ retrievedTxs: results.txs, missingTxs: results.missing ?? [] }, expected);
+    // all retrieved txs should be in the pool
+    expect(txPool.size).toEqual(8);
+  });
+
+  it("does not add txs from the proposal if their hash isn't in the payload", async () => {
+    const collector = new TxCollector(p2p);
+    const original = await generateTransactions(10);
+    const additional = await generateTransactions(2);
+    await setupTxPools(0, 4, original);
+    const originalHashes = await Promise.all(original.map(tx => tx.getTxHash()));
+
+    // Random shuffle the txs so we test that the collection handles gaps in where txs are found
+    const txs = original;
+    const hashes = await Promise.all(txs.map(tx => tx.getTxHash()));
+
+    // Add additional txs and these should not be added to the pool and not in the results
+    const proposal = buildProposal(txs.slice(4, 8).concat(additional), hashes);
+    const results = await collector.collectForBlockProposal(proposal, undefined);
+    const expected: TxResults = {
+      retrievedTxs: txs.slice(0, 8),
+      missingTxs: originalHashes.slice(8),
+    };
+    await checkResults({ retrievedTxs: results.txs, missingTxs: results.missing ?? [] }, expected);
+    // all txs should be in the pool
+    expect(txPool.size).toEqual(8);
+
+    // additional txs should not be in the pool
+    const additionalHashes = await Promise.all(additional.map(tx => tx.getTxHash()));
+    for (const hash of additionalHashes) {
+      expect(txPool.has(hash.toString())).toBeFalsy();
+    }
+  });
+});

--- a/yarn-project/p2p/src/services/tx_collector.ts
+++ b/yarn-project/p2p/src/services/tx_collector.ts
@@ -3,96 +3,99 @@ import { type Logger, createLogger } from '@aztec/foundation/log';
 import type { BlockProposal } from '@aztec/stdlib/p2p';
 import type { Tx, TxHash } from '@aztec/stdlib/tx';
 
+import type { PeerId } from '@libp2p/interface';
+
 import type { P2PClient } from '../client/p2p_client.js';
 
 export class TxCollector {
   constructor(
     private p2pClient: Pick<
       P2PClient,
-      'getTxsByHashFromPool' | 'hasTxsInPool' | 'getTxsByHash' | 'validate' | 'requestTxsByHash'
+      'getTxsByHashFromPool' | 'hasTxsInPool' | 'getTxsByHash' | 'validate' | 'requestTxsByHash' | 'addTxsToPool'
     >,
     private log: Logger = createLogger('p2p:tx-collector'),
   ) {}
 
+  // Checks the proposal for transactions we don't already have, validates them and adds them to our pool
+  private async collectFromProposal(proposal: BlockProposal): Promise<void> {
+    // Does this proposal have any transactions?
+    if (!proposal.txs || proposal.txs.length === 0) {
+      return;
+    }
+
+    const proposalHashes = new Set<string>((proposal.payload.txHashes ?? []).map(txHash => txHash.toString()));
+
+    // Get the transactions from the proposal and their hashes
+    // also, we are only interested in txs that are part of the proposal
+    const txsFromProposal = compactArray(
+      await Promise.all(
+        proposal.txs.map(tx =>
+          tx === undefined
+            ? Promise.resolve(undefined)
+            : tx.getTxHash().then(hash => ({
+                txHash: hash,
+                tx,
+              })),
+        ),
+      ),
+    ).filter(tx => proposalHashes.has(tx.txHash.toString()));
+
+    // Of the transactions from the proposal, retrieve those that we have in the pool already
+    const txsToValidate = [];
+    const txsWeAlreadyHave = await this.p2pClient.getTxsByHashFromPool(txsFromProposal.map(tx => tx.txHash));
+
+    // Txs we already have will have holes where we did not find them
+    // Where that is the case we need to validate the tx in the proposal
+    for (let i = 0; i < txsWeAlreadyHave.length; i++) {
+      if (txsWeAlreadyHave[i] === undefined) {
+        txsToValidate.push(txsFromProposal[i].tx);
+      }
+    }
+
+    // Now validate all the transactions from the proposal that we don't have
+    // This will throw if any of the transactions are invalid, this is probably correct, if someone sends us a proposal with invalid
+    // transactions we probably shouldn't spend any more effort on it
+    try {
+      await this.p2pClient.validate(txsToValidate);
+    } catch (err) {
+      this.log.error(`Received proposal with invalid transactions, skipping`);
+      throw err;
+    }
+
+    // Now store these transactions in our pool, provided these are the txs in proposal.payload.txHashes they will be pinned already
+    await this.p2pClient.addTxsToPool(txsToValidate);
+
+    this.log.info(
+      `Received proposal with ${proposal.txs.length} transactions, ${txsToValidate.length} of which were new`,
+    );
+  }
+
   async collectForBlockProposal(
     proposal: BlockProposal,
-    peerWhoSentTheProposal: any,
+    peerWhoSentTheProposal: PeerId | undefined,
   ): Promise<{ txs: Tx[]; missing?: TxHash[] }> {
     if (proposal.payload.txHashes.length === 0) {
       this.log.verbose(`Received block proposal with no transactions, skipping transaction availability check`);
       return { txs: [] };
     }
-    // Is this a new style proposal?
-    if (proposal.txs && proposal.txs.length > 0 && proposal.txs.length === proposal.payload.txHashes.length) {
-      // Yes, any txs that we already have we should use
-      this.log.info(`Using new style proposal with ${proposal.txs.length} transactions`);
 
-      // Request from the pool based on the signed hashes in the payload
-      const hashesFromPayload = proposal.payload.txHashes;
-      const txsToUse = await this.p2pClient.getTxsByHashFromPool(hashesFromPayload);
+    // Take txs from the proposal if there are any
+    await this.collectFromProposal(proposal);
 
-      const missingTxs = txsToUse.filter(tx => tx === undefined).length;
-      if (missingTxs > 0) {
-        this.log.verbose(
-          `Missing ${missingTxs}/${hashesFromPayload.length} transactions in the tx pool, will attempt to take from the proposal`,
-        );
-      }
-
-      let usedFromProposal = 0;
-
-      // Fill any holes with txs in the proposal, provided their hash matches the hash in the payload
-      for (let i = 0; i < txsToUse.length; i++) {
-        if (txsToUse[i] === undefined) {
-          // We don't have the transaction, take from the proposal, provided the hash is the same
-          const hashOfTxInProposal = await proposal.txs[i].getTxHash();
-          if (hashOfTxInProposal.equals(hashesFromPayload[i])) {
-            // Hash is equal, we can use the tx from the proposal
-            txsToUse[i] = proposal.txs[i];
-            usedFromProposal++;
-          } else {
-            this.log.warn(
-              `Unable to take tx: ${hashOfTxInProposal.toString()} from the proposal, it does not match payload hash: ${hashesFromPayload[
-                i
-              ].toString()}`,
-            );
-          }
-        }
-      }
-
-      // See if we still have any holes, if there are then we were not successful and will try the old method
-      if (txsToUse.some(tx => tx === undefined)) {
-        this.log.warn(`Failed to use transactions from proposal. Falling back to old proposal logic`);
-      } else {
-        this.log.info(
-          `Successfully used ${usedFromProposal}/${hashesFromPayload.length} transactions from the proposal`,
-        );
-
-        await this.p2pClient.validate(txsToUse as Tx[]);
-        return { txs: txsToUse as Tx[] };
-      }
-    }
-
-    this.log.info(`Using old style proposal with ${proposal.payload.txHashes.length} transactions`);
-
-    // Old style proposal, we will perform a request by hash from pool
-    // This will request from network any txs that are missing
+    // Now get the txs we need, either from the pool or the p2p network
     const txHashes: TxHash[] = proposal.payload.txHashes;
 
-    // This part is just for logging that we are requesting from the network
-    const availability = await this.p2pClient.hasTxsInPool(txHashes);
-    const notAvailable = availability.filter(availability => availability === false);
-    if (notAvailable.length) {
-      this.log.verbose(
-        `Missing ${notAvailable.length} transactions in the tx pool, will need to request from the network`,
-      );
-    }
-
     // This will request from the network any txs that are missing
-    const retrievedTxs = await this.p2pClient.getTxsByHash(txHashes, peerWhoSentTheProposal);
-    const missingTxs = compactArray(retrievedTxs.map((tx, index) => (tx === undefined ? txHashes[index] : undefined)));
+    // NOTE: this could still return missing txs so we need to (1) be careful to handle undefined and (2) keep the txs in the correct order for re-execution
+    const maybeRetrievedTxs = await this.p2pClient.getTxsByHash(txHashes, peerWhoSentTheProposal);
 
-    await this.p2pClient.validate(retrievedTxs as Tx[]);
+    // Get the txs that we didn't get from the network, if any. This will be empty if we got them al
+    const missingTxs = compactArray(
+      maybeRetrievedTxs.map((tx, index) => (tx === undefined ? txHashes[index] : undefined)),
+    );
 
-    return { txs: retrievedTxs as Tx[], missing: missingTxs };
+    // if we found all txs, this is a noop. If we didn't find all txs then tell the validator to skip attestations because missingTxs.length > 0
+    const retrievedTxs = compactArray(maybeRetrievedTxs);
+    return { txs: retrievedTxs, missing: missingTxs };
   }
 }

--- a/yarn-project/prover-node/src/prover-coordination/combined-prover-coordination.test.ts
+++ b/yarn-project/prover-node/src/prover-coordination/combined-prover-coordination.test.ts
@@ -50,16 +50,16 @@ describe('combined prover coordination', () => {
       const hashes = await Promise.all(additionalP2PTxs.map(tx => tx.getTxHash()));
       additionalP2PTxs.forEach((tx, index) => txPool.set(hashes[index].toString(), tx));
       const txs = txHashes.map(txHash => txPool.get(txHash.toString()));
-      return Promise.resolve(txs.filter(tx => tx !== undefined) as Tx[]);
+      return Promise.resolve(txs);
     });
     p2p.hasTxsInPool.mockImplementation(txHashes => {
       return Promise.resolve(txHashes.map(txHash => txPool.has(txHash.toString())));
     });
     p2p.getTxsByHashFromPool.mockImplementation(txHashes => {
       const txs = txHashes.map(txHash => txPool.get(txHash.toString()));
-      return Promise.resolve(txs.filter(tx => tx !== undefined) as Tx[]);
+      return Promise.resolve(txs);
     });
-    p2p.addTxs.mockImplementation(async txs => {
+    p2p.addTxsToPool.mockImplementation(async txs => {
       const hashes = await Promise.all(txs.map(tx => tx.getTxHash()));
       txs.forEach((tx, index) => txPool.set(hashes[index].toString(), tx));
       return Promise.resolve();

--- a/yarn-project/prover-node/src/prover-coordination/combined-prover-coordination.ts
+++ b/yarn-project/prover-node/src/prover-coordination/combined-prover-coordination.ts
@@ -34,7 +34,7 @@ class P2PCoordinationPool implements CoordinationPool {
     return this.p2p.getTxsByHashFromPool(txHashes);
   }
   addTxs(txs: Tx[]): Promise<void> {
-    return this.p2p.addTxs(txs);
+    return this.p2p.addTxsToPool(txs);
   }
 }
 

--- a/yarn-project/txe/src/state_machine/dummy_p2p_client.ts
+++ b/yarn-project/txe/src/state_machine/dummy_p2p_client.ts
@@ -145,7 +145,7 @@ export class DummyP2P implements P2P {
     throw new Error('DummyP2P does not implement "hasTxsInPool"');
   }
 
-  public addTxs(_txs: Tx[]): Promise<void> {
+  public addTxsToPool(_txs: Tx[]): Promise<void> {
     throw new Error('DummyP2P does not implement "addTxs"');
   }
 


### PR DESCRIPTION
When retrieving transactions in the tx collector, we should only validate txs that are taken from the proposal.

The rest either come from the node's mempool or request/response, both of which will already be validated.

There won't be enough time to validate all the txs in a block at the poit of executing it.
