### PR TITLE
fix: Fork world-state from the correct block when building a new one

### DIFF
--- a/yarn-project/sequencer-client/src/sequencer/block_builder.ts
+++ b/yarn-project/sequencer-client/src/sequencer/block_builder.ts
@@ -120,7 +120,8 @@ export class FullNodeBlockBuilder implements IFullNodeBlockBuilder {
   }
 
   public async makeBlockBuilderDeps(globalVariables: GlobalVariables, opts: BuildBlockOptions) {
-    const publicProcessorDBFork = await this.worldState.fork();
+    const blockNumber = globalVariables.blockNumber.toNumber();
+    const publicProcessorDBFork = await this.worldState.fork(blockNumber - 1);
     const contractsDB = new PublicContractsDB(this.contractDataSource);
     const guardedFork = new GuardedMerkleTreeOperations(publicProcessorDBFork);
 


### PR DESCRIPTION
Fixes issue where a validator would get a reexec state mismatch when attesting immediately after a reorg it has not yet seen, so the latest block from world-state is not the correc tone.

Cherry-pick of #14748 from master to next
