### PR TITLE
feat: offchain msg oracle and tx effect

### DIFF
--- a/noir-projects/aztec-nr/aztec/src/oracle/mod.nr
+++ b/noir-projects/aztec-nr/aztec/src/oracle/mod.nr
@@ -20,6 +20,7 @@ pub mod key_validation_request;
 pub mod logs;
 pub mod message_processing;
 pub mod notes;
+pub mod offchain_message;
 pub mod random;
 pub mod shared_secret;
 pub mod storage;

--- a/noir-projects/aztec-nr/aztec/src/oracle/offchain_message.nr
+++ b/noir-projects/aztec-nr/aztec/src/oracle/offchain_message.nr
@@ -11,6 +11,17 @@ use protocol_types::{address::AztecAddress, traits::Serialize};
 /// the payment is considered successful by the recipient once he receives the notes and events off-chain. Hence
 /// having the guaranteed delivery via DA is not necessary.
 ///
+/// # When not to use
+/// This function should not be used when an on-chain guarantee of successful delivery is required. This is the case
+/// when a smart contract (rather than a person) needs to make decisions based on the message. For example, consider
+/// a contract that escrows a privately-stored NFT (i.e. an NFT represented by a note) and releases it to a buyer only
+/// after receiving a payment in a specific token. Without on-chain delivery, the buyer could potentially obtain the
+/// NFT without sending the payment token message (the note hash preimage) to the seller, rugging the seller.
+///
+/// To clarify the above, while the malicious buyer's payment token would still be deducted from their balance, they
+/// would obtain the NFT while the seller would be unable to spend the payment token, keeping the payment token note
+/// in limbo.
+///
 /// # Arguments
 ///
 /// * `message` - The message to emit.

--- a/noir-projects/aztec-nr/aztec/src/oracle/offchain_message.nr
+++ b/noir-projects/aztec-nr/aztec/src/oracle/offchain_message.nr
@@ -1,0 +1,41 @@
+use protocol_types::{address::AztecAddress, traits::Serialize};
+
+/// Emits message that will be delivered off-chain rather than through the data availability layer.
+///
+/// Sends data through an alternative app-specific channel without incurring data availability (DA) costs. After
+/// receiving the message, the recipient is expected to call the `process_message` function implemented on the
+/// contract that originally emitted the message.
+///
+/// # Example use case
+/// A typical use case would be a payment app where the notes and events do not need to be delivered via DA because
+/// the payment is considered successful by the recipient once he receives the notes and events off-chain. Hence
+/// having the guaranteed delivery via DA is not necessary.
+///
+/// # Arguments
+///
+/// * `message` - The message to emit.
+/// * `recipient` - The address of the recipient.
+pub fn emit_offchain_message<T, let N: u32>(message: T, recipient: AztecAddress)
+where
+    T: Serialize<N>,
+{
+    // Safety: This oracle call returns nothing: we only call it for its side effects. It is therefore always safe
+    // to call.
+    unsafe { emit_offchain_message_oracle_wrapper(message, recipient) };
+}
+
+unconstrained fn emit_offchain_message_oracle_wrapper<T, let N: u32>(
+    message: T,
+    recipient: AztecAddress,
+)
+where
+    T: Serialize<N>,
+{
+    emit_offchain_message_oracle(message.serialize(), recipient);
+}
+
+#[oracle(emitOffchainMessage)]
+unconstrained fn emit_offchain_message_oracle<let N: u32>(
+    message: [Field; N],
+    recipient: AztecAddress,
+) {}

--- a/noir-projects/noir-contracts/Nargo.toml
+++ b/noir-projects/noir-contracts/Nargo.toml
@@ -44,6 +44,7 @@ members = [
     "contracts/test/invalid_account_contract",
     "contracts/test/no_constructor_contract",
     "contracts/test/note_getter_contract",
+    "contracts/test/offchain_message_contract",
     "contracts/test/parent_contract",
     "contracts/test/pending_note_hashes_contract",
     "contracts/test/public_immutable_contract",

--- a/noir-projects/noir-contracts/contracts/test/offchain_message_contract/Nargo.toml
+++ b/noir-projects/noir-contracts/contracts/test/offchain_message_contract/Nargo.toml
@@ -1,0 +1,8 @@
+[package]
+name = "offchain_message_contract"
+authors = [""]
+compiler_version = ">=0.25.0"
+type = "contract"
+
+[dependencies]
+aztec = { path = "../../../../aztec-nr/aztec" }

--- a/noir-projects/noir-contracts/contracts/test/offchain_message_contract/src/main.nr
+++ b/noir-projects/noir-contracts/contracts/test/offchain_message_contract/src/main.nr
@@ -16,7 +16,7 @@ contract OffchainMessage {
     }
 
     #[private]
-    fn emit_offchain_message_for_recipient(messages: BoundedVec<MessagePayload, 5>) {
+    fn emit_offchain_message_for_recipient(messages: BoundedVec<MessagePayload, 6>) {
         let mut messages = messages;
         let messagePayload = messages.pop();
         emit_offchain_message(messagePayload.message, messagePayload.recipient);

--- a/noir-projects/noir-contracts/contracts/test/offchain_message_contract/src/main.nr
+++ b/noir-projects/noir-contracts/contracts/test/offchain_message_contract/src/main.nr
@@ -5,20 +5,25 @@ use aztec::macros::aztec;
 contract OffchainMessage {
     use aztec::{
         macros::functions::private, oracle::offchain_message::emit_offchain_message,
-        prelude::AztecAddress,
+        prelude::AztecAddress, protocol_types::traits::Serialize,
     };
 
-    #[private]
-    fn emit_offchain_message_for_recipient(
-        message: [Field; 5],
-        recipient: AztecAddress,
-        num_recursions: u8,
-    ) {
-        emit_offchain_message(message, recipient);
+    #[derive(Serialize)]
+    pub struct MessagePayload {
+        pub message: [Field; 5],
+        pub recipient: AztecAddress,
+        pub next_contract: AztecAddress,
+    }
 
-        if num_recursions > 0 {
-            OffchainMessage::at(context.this_address())
-                .emit_offchain_message_for_recipient(message, recipient, num_recursions - 1)
+    #[private]
+    fn emit_offchain_message_for_recipient(messages: BoundedVec<MessagePayload, 5>) {
+        let mut messages = messages;
+        let messagePayload = messages.pop();
+        emit_offchain_message(messagePayload.message, messagePayload.recipient);
+
+        if messages.len() > 0 {
+            OffchainMessage::at(messagePayload.next_contract)
+                .emit_offchain_message_for_recipient(messages)
                 .call(&mut context);
         }
     }

--- a/noir-projects/noir-contracts/contracts/test/offchain_message_contract/src/main.nr
+++ b/noir-projects/noir-contracts/contracts/test/offchain_message_contract/src/main.nr
@@ -4,8 +4,10 @@ use aztec::macros::aztec;
 #[aztec]
 contract OffchainMessage {
     use aztec::{
-        macros::functions::private, oracle::offchain_message::emit_offchain_message,
-        prelude::AztecAddress, protocol_types::traits::Serialize,
+        macros::functions::{private, utility},
+        oracle::offchain_message::emit_offchain_message,
+        prelude::AztecAddress,
+        protocol_types::traits::Serialize,
     };
 
     #[derive(Serialize)]
@@ -28,5 +30,10 @@ contract OffchainMessage {
                     .call(&mut context);
             }
         }
+    }
+
+    #[utility]
+    unconstrained fn emitting_offchain_message_from_utility_reverts() {
+        emit_offchain_message([0; 5], AztecAddress::zero());
     }
 }

--- a/noir-projects/noir-contracts/contracts/test/offchain_message_contract/src/main.nr
+++ b/noir-projects/noir-contracts/contracts/test/offchain_message_contract/src/main.nr
@@ -17,14 +17,16 @@ contract OffchainMessage {
 
     #[private]
     fn emit_offchain_message_for_recipient(messages: BoundedVec<MessagePayload, 6>) {
-        let mut messages = messages;
-        let messagePayload = messages.pop();
-        emit_offchain_message(messagePayload.message, messagePayload.recipient);
-
         if messages.len() > 0 {
-            OffchainMessage::at(messagePayload.next_contract)
-                .emit_offchain_message_for_recipient(messages)
-                .call(&mut context);
+            let mut messages = messages;
+            let messagePayload = messages.pop();
+            emit_offchain_message(messagePayload.message, messagePayload.recipient);
+
+            if messages.len() > 0 {
+                OffchainMessage::at(messagePayload.next_contract)
+                    .emit_offchain_message_for_recipient(messages)
+                    .call(&mut context);
+            }
         }
     }
 }

--- a/noir-projects/noir-contracts/contracts/test/offchain_message_contract/src/main.nr
+++ b/noir-projects/noir-contracts/contracts/test/offchain_message_contract/src/main.nr
@@ -1,0 +1,15 @@
+use aztec::macros::aztec;
+
+/// This contract is used to test that emitting offchain messages works correctly.
+#[aztec]
+contract OffchainMessage {
+    use aztec::{
+        macros::functions::private, oracle::offchain_message::emit_offchain_message,
+        prelude::AztecAddress,
+    };
+
+    #[private]
+    fn emit_offchain_message_for_recipient(message: [Field; 5], recipient: AztecAddress) {
+        emit_offchain_message(message, recipient);
+    }
+}

--- a/noir-projects/noir-contracts/contracts/test/offchain_message_contract/src/main.nr
+++ b/noir-projects/noir-contracts/contracts/test/offchain_message_contract/src/main.nr
@@ -9,7 +9,17 @@ contract OffchainMessage {
     };
 
     #[private]
-    fn emit_offchain_message_for_recipient(message: [Field; 5], recipient: AztecAddress) {
+    fn emit_offchain_message_for_recipient(
+        message: [Field; 5],
+        recipient: AztecAddress,
+        num_recursions: u8,
+    ) {
         emit_offchain_message(message, recipient);
+
+        if num_recursions > 0 {
+            OffchainMessage::at(context.this_address())
+                .emit_offchain_message_for_recipient(message, recipient, num_recursions - 1)
+                .call(&mut context);
+        }
     }
 }

--- a/yarn-project/aztec.js/src/contract/base_contract_interaction.ts
+++ b/yarn-project/aztec.js/src/contract/base_contract_interaction.ts
@@ -61,8 +61,12 @@ export abstract class BaseContractInteraction {
   public async prove(options: SendMethodOptions = {}): Promise<ProvenTx> {
     // docs:end:prove
     const txProvingResult = await this.proveInternal(options);
-    const offchainMessages = txProvingResult.getOffchainMessages();
-    return new ProvenTx(this.wallet, txProvingResult.toTx(), offchainMessages, txProvingResult.stats);
+    return new ProvenTx(
+        this.wallet, 
+        txProvingResult.toTx(), 
+        txProvingResult.getOffchainMessages(), 
+        txProvingResult.stats
+    );
   }
 
   // docs:start:send

--- a/yarn-project/aztec.js/src/contract/base_contract_interaction.ts
+++ b/yarn-project/aztec.js/src/contract/base_contract_interaction.ts
@@ -62,10 +62,10 @@ export abstract class BaseContractInteraction {
     // docs:end:prove
     const txProvingResult = await this.proveInternal(options);
     return new ProvenTx(
-        this.wallet, 
-        txProvingResult.toTx(), 
-        txProvingResult.getOffchainMessages(), 
-        txProvingResult.stats
+      this.wallet,
+      txProvingResult.toTx(),
+      txProvingResult.getOffchainMessages(),
+      txProvingResult.stats,
     );
   }
 

--- a/yarn-project/aztec.js/src/contract/base_contract_interaction.ts
+++ b/yarn-project/aztec.js/src/contract/base_contract_interaction.ts
@@ -61,7 +61,8 @@ export abstract class BaseContractInteraction {
   public async prove(options: SendMethodOptions = {}): Promise<ProvenTx> {
     // docs:end:prove
     const txProvingResult = await this.proveInternal(options);
-    return new ProvenTx(this.wallet, txProvingResult.toTx(), txProvingResult.stats);
+    const offchainMessages = txProvingResult.getOffchainMessages();
+    return new ProvenTx(this.wallet, txProvingResult.toTx(), offchainMessages, txProvingResult.stats);
   }
 
   // docs:start:send

--- a/yarn-project/aztec.js/src/contract/deploy_method.ts
+++ b/yarn-project/aztec.js/src/contract/deploy_method.ts
@@ -247,7 +247,7 @@ export class DeployMethod<TContract extends ContractBase = Contract> extends Bas
     const txProvingResult = await this.proveInternal(options);
     return new DeployProvenTx(
       this.wallet,
-      txProvingResult.toTx(),
+      txProvingResult,
       this.postDeployCtor,
       () => this.getInstance(options),
       txProvingResult.stats,

--- a/yarn-project/aztec.js/src/contract/deploy_proven_tx.ts
+++ b/yarn-project/aztec.js/src/contract/deploy_proven_tx.ts
@@ -1,6 +1,6 @@
 import type { AztecAddress } from '@aztec/stdlib/aztec-address';
 import type { ContractInstanceWithAddress } from '@aztec/stdlib/contract';
-import type { ProvingStats, Tx } from '@aztec/stdlib/tx';
+import type { ProvingStats, TxProvingResult } from '@aztec/stdlib/tx';
 
 import type { Wallet } from '../wallet/wallet.js';
 import type { Contract } from './contract.js';
@@ -13,12 +13,12 @@ import { ProvenTx } from './proven_tx.js';
 export class DeployProvenTx<TContract extends Contract = Contract> extends ProvenTx {
   constructor(
     wallet: Wallet,
-    tx: Tx,
+    txProvingResult: TxProvingResult,
     private postDeployCtor: (address: AztecAddress, wallet: Wallet) => Promise<TContract>,
     private instanceGetter: () => Promise<ContractInstanceWithAddress>,
     stats?: ProvingStats,
   ) {
-    super(wallet, tx, stats);
+    super(wallet, txProvingResult.toTx(), txProvingResult.getOffchainMessages(), stats);
   }
 
   /**

--- a/yarn-project/aztec.js/src/contract/proven_tx.ts
+++ b/yarn-project/aztec.js/src/contract/proven_tx.ts
@@ -1,4 +1,4 @@
-import { type ProvingStats, Tx } from '@aztec/stdlib/tx';
+import { type OffchainMessage, type ProvingStats, Tx } from '@aztec/stdlib/tx';
 
 import type { Wallet } from '../wallet/wallet.js';
 import { SentTx } from './sent_tx.js';
@@ -10,6 +10,8 @@ export class ProvenTx extends Tx {
   constructor(
     protected wallet: Wallet,
     tx: Tx,
+    /** The offchain messages emitted during the execution of the transaction. */
+    public offchainMessages: OffchainMessage[],
     // eslint-disable-next-line jsdoc/require-jsdoc
     public stats?: ProvingStats,
   ) {

--- a/yarn-project/end-to-end/src/e2e_offchain_message.test.ts
+++ b/yarn-project/end-to-end/src/e2e_offchain_message.test.ts
@@ -76,4 +76,10 @@ describe('e2e_offchain_message', () => {
     const provenTx = await contract1.methods.emit_offchain_message_for_recipient(toBoundedVec([], 6)).prove();
     expect(provenTx.offchainMessages).toEqual([]);
   });
+
+  it('should revert when emitting offchain message from utility function', async () => {
+    await expect(contract1.methods.emitting_offchain_message_from_utility_reverts().simulate()).rejects.toThrow(
+      'Cannot emit offchain message from a utility function',
+    );
+  });
 });

--- a/yarn-project/end-to-end/src/e2e_offchain_message.test.ts
+++ b/yarn-project/end-to-end/src/e2e_offchain_message.test.ts
@@ -3,7 +3,7 @@ import { OffchainMessageContract } from '@aztec/noir-test-contracts.js/OffchainM
 
 import { jest } from '@jest/globals';
 
-import { ensureAccountsPubliclyDeployed, setup } from './fixtures/utils.js';
+import { setup } from './fixtures/utils.js';
 
 const TIMEOUT = 120_000;
 
@@ -17,8 +17,7 @@ describe('e2e_offchain_message', () => {
   let teardown: () => Promise<void>;
 
   beforeAll(async () => {
-    ({ teardown, wallets } = await setup(2));
-    await ensureAccountsPubliclyDeployed(wallets[0], wallets.slice(0, 2));
+    ({ teardown, wallets } = await setup(1));
     // TODO(benesjan): The following results in one of the txs being dropped. There seems to be an issue in Aztec.js
     // deployments.
     // [contract1, contract2] = await Promise.all([

--- a/yarn-project/end-to-end/src/e2e_offchain_message.test.ts
+++ b/yarn-project/end-to-end/src/e2e_offchain_message.test.ts
@@ -1,0 +1,42 @@
+import { type AccountWalletWithSecretKey, AztecAddress, Fr } from '@aztec/aztec.js';
+import { OffchainMessageContract } from '@aztec/noir-test-contracts.js/OffchainMessage';
+
+import { jest } from '@jest/globals';
+
+import { ensureAccountsPubliclyDeployed, setup } from './fixtures/utils.js';
+
+const TIMEOUT = 120_000;
+
+describe('e2e_offchain_message', () => {
+  let contract: OffchainMessageContract;
+  jest.setTimeout(TIMEOUT);
+
+  let wallets: AccountWalletWithSecretKey[];
+  let teardown: () => Promise<void>;
+
+  beforeAll(async () => {
+    ({ teardown, wallets } = await setup(2));
+    await ensureAccountsPubliclyDeployed(wallets[0], wallets.slice(0, 2));
+    contract = await OffchainMessageContract.deploy(wallets[0]).send().deployed();
+  });
+
+  afterAll(() => teardown());
+
+  it('should emit offchain message', async () => {
+    const message = [Fr.random(), Fr.random(), Fr.random(), Fr.random(), Fr.random()];
+    const recipient = await AztecAddress.random();
+
+    const numRecursions = 3;
+
+    const provenTx = await contract.methods
+      .emit_offchain_message_for_recipient(message, recipient, numRecursions)
+      .prove();
+
+    const offchainMessages = provenTx.offchainMessages;
+    expect(offchainMessages.length).toBe(4);
+    for (let i = 0; i < offchainMessages.length; i++) {
+      expect(offchainMessages[i].recipient).toEqual(recipient);
+      expect(offchainMessages[i].message).toEqual(message);
+    }
+  });
+});

--- a/yarn-project/end-to-end/src/e2e_offchain_message.test.ts
+++ b/yarn-project/end-to-end/src/e2e_offchain_message.test.ts
@@ -71,4 +71,9 @@ describe('e2e_offchain_message', () => {
 
     expect(provenTx.offchainMessages).toEqual(expectedOffchainMessages);
   });
+
+  it('should not emit any offchain messages', async () => {
+    const provenTx = await contract1.methods.emit_offchain_message_for_recipient(toBoundedVec([], 6)).prove();
+    expect(provenTx.offchainMessages).toEqual([]);
+  });
 });

--- a/yarn-project/end-to-end/src/e2e_prover/full.test.ts
+++ b/yarn-project/end-to-end/src/e2e_prover/full.test.ts
@@ -329,6 +329,7 @@ describe('full_prover', () => {
             provenTx.contractClassLogFields,
             provenTx.publicFunctionCalldata,
           ),
+          [],
         );
 
         const sentTx = invalidProvenTx.send();

--- a/yarn-project/end-to-end/src/spartan/1tps.test.ts
+++ b/yarn-project/end-to-end/src/spartan/1tps.test.ts
@@ -129,7 +129,7 @@ describe('token transfer test', () => {
         }
       }
 
-      const clonedTx = new ProvenTx(wallet, clonedTxData);
+      const clonedTx = new ProvenTx(wallet, clonedTxData, []);
       txs.push(clonedTx);
     }
     await Promise.all(

--- a/yarn-project/pxe/src/contract_function_simulator/contract_function_simulator.ts
+++ b/yarn-project/pxe/src/contract_function_simulator/contract_function_simulator.ts
@@ -82,7 +82,7 @@ export class ContractFunctionSimulator {
     const txRequestHash = await request.toTxRequest().hash();
     const noteCache = new ExecutionNoteCache(txRequestHash);
 
-    const context = new PrivateExecutionOracle(
+    const privateExecutionOracle = new PrivateExecutionOracle(
       request.firstCallArgsHash,
       request.txContext,
       callContext,
@@ -104,7 +104,7 @@ export class ContractFunctionSimulator {
     try {
       const executionResult = await executePrivateFunction(
         this.simulator,
-        context,
+        privateExecutionOracle,
         entryPointArtifact,
         contractAddress,
         request.functionSelector,
@@ -119,7 +119,7 @@ export class ContractFunctionSimulator {
       ]).filter(r => !r.isEmpty());
       const publicFunctionsCalldata = await Promise.all(
         publicCallRequests.map(async r => {
-          const calldata = await context.loadFromExecutionCache(r.calldataHash);
+          const calldata = await privateExecutionOracle.loadFromExecutionCache(r.calldataHash);
           return new HashedValues(calldata, r.calldataHash);
         }),
       );

--- a/yarn-project/pxe/src/contract_function_simulator/oracle/oracle.ts
+++ b/yarn-project/pxe/src/contract_function_simulator/oracle/oracle.ts
@@ -515,4 +515,12 @@ export class Oracle {
     );
     return secret.toFields().map(toACVMField);
   }
+
+  async emitOffchainMessage(message: ACVMField[], [recipient]: ACVMField[]) {
+    await this.typedOracle.emitOffchainMessage(
+      message.map(Fr.fromString),
+      AztecAddress.fromField(Fr.fromString(recipient)),
+    );
+    return [];
+  }
 }

--- a/yarn-project/pxe/src/contract_function_simulator/oracle/private_execution.ts
+++ b/yarn-project/pxe/src/contract_function_simulator/oracle/private_execution.ts
@@ -81,6 +81,7 @@ export async function executePrivateFunction(
   const noteHashLeafIndexMap = privateExecutionOracle.getNoteHashLeafIndexMap();
   const newNotes = privateExecutionOracle.getNewNotes();
   const noteHashNullifierCounterMap = privateExecutionOracle.getNoteHashNullifierCounterMap();
+  const offchainMessages = privateExecutionOracle.getOffchainMessages();
   const nestedExecutions = privateExecutionOracle.getNestedExecutions();
 
   let timerSubtractionList = nestedExecutions;
@@ -103,6 +104,7 @@ export async function executePrivateFunction(
     newNotes,
     noteHashNullifierCounterMap,
     rawReturnValues,
+    offchainMessages,
     nestedExecutions,
     contractClassLogs,
     {

--- a/yarn-project/pxe/src/contract_function_simulator/oracle/private_execution_oracle.ts
+++ b/yarn-project/pxe/src/contract_function_simulator/oracle/private_execution_oracle.ts
@@ -40,8 +40,9 @@ import { UtilityExecutionOracle } from './utility_execution_oracle.js';
 export class PrivateExecutionOracle extends UtilityExecutionOracle {
   /**
    * New notes created during this execution.
-   * It's possible that a note in this list has been nullified (in the same or other executions) and doesn't exist in the ExecutionNoteCache and the final proof data.
-   * But we still include those notes in the execution result because their commitments are still in the public inputs of this execution.
+   * It's possible that a note in this list has been nullified (in the same or other executions) and doesn't exist in
+   * the ExecutionNoteCache and the final proof data. But we still include those notes in the execution result because
+   * their commitments are still in the public inputs of this execution.
    * This information is only for references (currently used for tests), and is not used for any sort of constrains.
    * Users can also use this to get a clearer idea of what's happened during a simulation.
    */
@@ -58,6 +59,7 @@ export class PrivateExecutionOracle extends UtilityExecutionOracle {
   private noteHashLeafIndexMap: Map<bigint, bigint> = new Map();
   private noteHashNullifierCounterMap: Map<number, number> = new Map();
   private contractClassLogs: CountedContractClassLog[] = [];
+  private offchainMessages: { message: Fr[]; recipient: AztecAddress }[] = [];
   private nestedExecutions: PrivateCallExecutionResult[] = [];
 
   constructor(
@@ -136,6 +138,13 @@ export class PrivateExecutionOracle extends UtilityExecutionOracle {
    */
   public getContractClassLogs() {
     return this.contractClassLogs;
+  }
+
+  /**
+   * Return the offchain messages emitted during this execution.
+   */
+  public getOffchainMessages() {
+    return this.offchainMessages;
   }
 
   /**
@@ -514,5 +523,10 @@ export class PrivateExecutionOracle extends UtilityExecutionOracle {
     await this.executionDataProvider.syncTaggedLogs(this.contractAddress, pendingTaggedLogArrayBaseSlot, this.scopes);
 
     await this.executionDataProvider.removeNullifiedNotes(this.contractAddress);
+  }
+
+  public override emitOffchainMessage(message: Fr[], recipient: AztecAddress): Promise<void> {
+    this.offchainMessages.push({ message, recipient });
+    return Promise.resolve();
   }
 }

--- a/yarn-project/pxe/src/contract_function_simulator/oracle/typed_oracle.ts
+++ b/yarn-project/pxe/src/contract_function_simulator/oracle/typed_oracle.ts
@@ -262,4 +262,8 @@ export abstract class TypedOracle {
   getSharedSecret(_address: AztecAddress, _ephPk: Point): Promise<Point> {
     return Promise.reject(new OracleMethodNotAvailableError('getSharedSecret'));
   }
+
+  emitOffchainMessage(_message: Fr[], _recipient: AztecAddress): Promise<void> {
+    return Promise.reject(new OracleMethodNotAvailableError('emitOffchainMessage'));
+  }
 }

--- a/yarn-project/pxe/src/contract_function_simulator/oracle/utility_execution_oracle.ts
+++ b/yarn-project/pxe/src/contract_function_simulator/oracle/utility_execution_oracle.ts
@@ -354,4 +354,8 @@ export class UtilityExecutionOracle extends TypedOracle {
   public override getSharedSecret(address: AztecAddress, ephPk: Point): Promise<Point> {
     return this.executionDataProvider.getSharedSecret(address, ephPk);
   }
+
+  public override emitOffchainMessage(_message: Fr[], _recipient: AztecAddress): Promise<void> {
+    return Promise.reject(new Error('Cannot emit offchain message from a utility function'));
+  }
 }

--- a/yarn-project/pxe/src/private_kernel/private_kernel_execution_prover.test.ts
+++ b/yarn-project/pxe/src/private_kernel/private_kernel_execution_prover.test.ts
@@ -65,6 +65,7 @@ describe('Private Kernel Sequencer', () => {
       newNoteIndices.map(idx => notesAndSlots[idx]),
       new Map(),
       [],
+      [],
       (dependencies[fnName] || []).map(name => createCallExecutionResult(name)),
       [],
     );

--- a/yarn-project/stdlib/src/tests/mocks.ts
+++ b/yarn-project/stdlib/src/tests/mocks.ts
@@ -181,6 +181,7 @@ const emptyPrivateCallExecutionResult = () =>
     [],
     [],
     [],
+    [],
   );
 
 const emptyPrivateExecutionResult = () => new PrivateExecutionResult(emptyPrivateCallExecutionResult(), Fr.zero(), []);

--- a/yarn-project/stdlib/src/tx/index.ts
+++ b/yarn-project/stdlib/src/tx/index.ts
@@ -29,4 +29,5 @@ export * from './capsule.js';
 export * from './global_variable_builder.js';
 export * from './hashed_values.js';
 export * from './indexed_tx_effect.js';
+export * from './offchain_message.js';
 export * from './profiling.js';

--- a/yarn-project/stdlib/src/tx/offchain_message.ts
+++ b/yarn-project/stdlib/src/tx/offchain_message.ts
@@ -1,0 +1,16 @@
+import { Fr } from '@aztec/foundation/fields';
+
+import type { AztecAddress } from '../aztec-address/index.js';
+
+/**
+ * Represents an offchain message emitted via the `emit_offchain_message` oracle (see the oracle documentation for
+ * more details).
+ */
+export type OffchainMessage = {
+  /** The message content */
+  message: Fr[];
+  /** The message recipient */
+  recipient: AztecAddress;
+  /** The contract that emitted the message */
+  contractAddress: AztecAddress;
+};

--- a/yarn-project/stdlib/src/tx/private_execution_result.test.ts
+++ b/yarn-project/stdlib/src/tx/private_execution_result.test.ts
@@ -22,6 +22,7 @@ function emptyCallExecutionResult(): PrivateCallExecutionResult {
     [],
     [],
     [],
+    [],
   );
 }
 

--- a/yarn-project/stdlib/src/tx/proven_tx.ts
+++ b/yarn-project/stdlib/src/tx/proven_tx.ts
@@ -5,7 +5,12 @@ import { z } from 'zod';
 
 import { PrivateKernelTailCircuitPublicInputs } from '../kernel/private_kernel_tail_circuit_public_inputs.js';
 import { ClientIvcProof } from '../proofs/client_ivc_proof.js';
-import { PrivateExecutionResult, collectSortedContractClassLogs } from './private_execution_result.js';
+import type { OffchainMessage } from './offchain_message.js';
+import {
+  PrivateExecutionResult,
+  collectOffchainMessages,
+  collectSortedContractClassLogs,
+} from './private_execution_result.js';
 import { type ProvingStats, ProvingTimingsSchema } from './profiling.js';
 import { Tx } from './tx.js';
 
@@ -27,6 +32,10 @@ export class TxProvingResult {
       this.privateExecutionResult.publicFunctionCalldata,
     );
     return tx;
+  }
+
+  getOffchainMessages(): OffchainMessage[] {
+    return collectOffchainMessages(this.privateExecutionResult);
   }
 
   static get schema() {

--- a/yarn-project/stdlib/src/tx/tx.ts
+++ b/yarn-project/stdlib/src/tx/tx.ts
@@ -163,7 +163,7 @@ export class Tx extends Gossipable {
 
   /**
    * Gets either revertible or non revertible contract class logs emitted by this tx.
-   * @param revertible - true for revertible only logs, false for non reverible only logs.
+   * @param revertible - true for revertible only logs, false for non revertible only logs.
    * @returns The requested logs.
    */
   getSplitContractClassLogs(revertible: boolean): ContractClassLog[] {

--- a/yarn-project/stdlib/src/tx/tx_hash.ts
+++ b/yarn-project/stdlib/src/tx/tx_hash.ts
@@ -5,6 +5,7 @@ import { schemas } from '../schemas/index.js';
 
 /**
  * A class representing hash of Aztec transaction.
+ * @dev Computed by hashing the public inputs of the private kernel tail circuit (see Tx::getTxHash function).
  */
 export class TxHash {
   constructor(

--- a/yarn-project/txe/src/oracle/txe_oracle.ts
+++ b/yarn-project/txe/src/oracle/txe_oracle.ts
@@ -1328,6 +1328,11 @@ export class TXE implements TypedOracle {
     return this.pxeOracleInterface.getSharedSecret(address, ephPk);
   }
 
+  emitOffchainMessage(_message: Fr[], _recipient: AztecAddress) {
+    // Offchain messages are discarded in the TXE tests.
+    return Promise.resolve();
+  }
+
   async privateCallNewFlow(
     from: AztecAddress,
     targetContractAddress: AztecAddress = AztecAddress.zero(),

--- a/yarn-project/txe/src/txe_service/txe_service.ts
+++ b/yarn-project/txe/src/txe_service/txe_service.ts
@@ -874,14 +874,15 @@ export class TXEService {
     return toForeignCallResult(secret.toFields().map(toSingle));
   }
 
-  async emitOffchainMessage(_message: ForeignCallArray, _recipient: ForeignCallSingle) {
+  emitOffchainMessage(_message: ForeignCallArray, _recipient: ForeignCallSingle) {
     if (!this.oraclesEnabled) {
       throw new Error(
         'Oracle access from the root of a TXe test are not enabled. Please use env._ to interact with the oracles.',
       );
     }
 
-    // Offchain messages are discarded in the TXE tests.
+    // Offchain messages are currently discarded in the TXE tests.
+    // TODO: Expose this to the tests.
 
     return toForeignCallResult([]);
   }

--- a/yarn-project/txe/src/txe_service/txe_service.ts
+++ b/yarn-project/txe/src/txe_service/txe_service.ts
@@ -874,6 +874,18 @@ export class TXEService {
     return toForeignCallResult(secret.toFields().map(toSingle));
   }
 
+  async emitOffchainMessage(_message: ForeignCallArray, _recipient: ForeignCallSingle) {
+    if (!this.oraclesEnabled) {
+      throw new Error(
+        'Oracle access from the root of a TXe test are not enabled. Please use env._ to interact with the oracles.',
+      );
+    }
+
+    // Offchain messages are discarded in the TXE tests.
+
+    return toForeignCallResult([]);
+  }
+
   // AVM opcodes
 
   avmOpcodeEmitUnencryptedLog(_message: ForeignCallArray) {


### PR DESCRIPTION
Fixes #14747

Second of a sequence of PRs implementing [out-of-band event delivery](https://github.com/AztecProtocol/aztec-packages/issues/14698) (first one was https://github.com/AztecProtocol/aztec-packages/pull/14634).

In this PR I implemented the following flow:
1. Message gets emitted from contract via the `emit_offchain_message` oracle,
2.  then in TS the messages are stored inside the `PrivateExecutionOracle`,
3. once the execution finishes we collect the messages from the oracle and pass them to the constructor of `PrivateCallExecutionResult`,
4. then once the tx is proven a `TxProvingResult` is constructed and `TxProvingResult` has a new getter that collects all the offchain messages,
5. this getter is called once the tx is proven and the messages are then stored inside `ProvenTx`.

**Note 1:** It didn't make sense to have the offchain messages be stored on the Tx object as that is the thing that is transmitted to the p2p network via aztec node.
**Note 2:** I have not yet figured out the `Aztec.js` API (i.e. how to expose this from the `send(...)` method). That will be done in the following PR. For now the `ProvenTx` was the logical last step to do in this one (the messages "travelled" there "naturally").