### PR TITLE
fix: Finish sequencer flushing only on successful publish

### DIFF
--- a/yarn-project/sequencer-client/src/sequencer/sequencer.ts
+++ b/yarn-project/sequencer-client/src/sequencer/sequencer.ts
@@ -360,11 +360,10 @@ export class Sequencer {
       const proposedBlock = resp.validActions.find(a => a === 'propose');
       if (proposedBlock) {
         this.metrics.incFilledSlot(this.publisher.getSenderAddress().toString());
+        if (finishedFlushing) {
+          this.isFlushing = false;
+        }
       }
-    }
-
-    if (finishedFlushing) {
-      this.isFlushing = false;
     }
 
     this.setState(SequencerState.IDLE, 0n);


### PR DESCRIPTION
This [CI run](http://ci.aztec-labs.com/2322cdddbb351b34) failed due to a timeout. The last successful log we see in that run is `Deposited to Aztec public successfully`. After that happens, we call `advanceL2Block` twice to make sure the msg is available:

https://github.com/AztecProtocol/aztec-packages/blob/5419eceed222f85b3836ad9c809bed95af3aeabd/yarn-project/end-to-end/src/shared/gas_portal_test_harness.ts#L161-L168

Under the hood, this instructs the sequencer to flush txs to ensure blocks get mined in spite of having no txs:

https://github.com/AztecProtocol/aztec-packages/blob/5419eceed222f85b3836ad9c809bed95af3aeabd/yarn-project/end-to-end/src/shared/gas_portal_test_harness.ts#L181-L185

In a [successful run](http://ci.aztec-labs.com/85ea7bc49a32864c), we see two blocks mined with zero txs, meaning the two flushes worked. But in the failed run, we see the first block mined, but the second one fails with `Unable to build/enqueue block Rollup__InvalidArchive`. Now, we have a lot of those in logs (which is another issue we need to address!), but the problem here is that the sequencer considers the flushing to be completed even if the block didn't get published. This means that, in the failed run, the sequencer refuses to build the 2nd block because it does not have enough txs:

```
14:53:19 [14:53:19.350] VERBOSE: sequencer Not enough txs to build block 8 at slot 10 (got 0 txs, need 1) {"chainTipArchive":"0x15666b3071851d4ec79b3d625d0e61fb864bf49210a7df6dd31ea4c2a0e0bd90","blockNumber":8,"slot":10}
```

This PR changes it so we only flag flushed txs as flushed if the block does get published. That said, I'd vote for killing `flushTxs` altogether, in favor of updating sequencer `minTxs` config temporarily. We only use flushTxs for advancing the L2 block for cross-chain messaging tests.