### PR TITLE
fix: unbound-variable error for BIN in Update bb_prove_bbjs_verify.sh

### DIFF
--- a/barretenberg/acir_tests/flows/bb_prove_bbjs_verify.sh
+++ b/barretenberg/acir_tests/flows/bb_prove_bbjs_verify.sh
@@ -1,7 +1,17 @@
 #!/bin/bash
 
-# prove with bb.js and verify using bb classes
+# Usage:
+#   BIN=/path/to/bb SYS=ultra_honk ./run_ultra_honk_flow.sh
+#
+# This script generates a proof with Barretenberg’s UltraHonk backend and then
+# verifies it using bb.js. The environment variable $BIN must point to the
+# Barretenberg CLI executable (e.g. “bb”). Under set -u, any undefined variable
+# is treated as a fatal error.
+
 set -eu
+
+# Ensure that BIN is defined; otherwise, print a clear error and exit.
+: "${BIN:?Environment variable BIN must be set to the Barretenberg CLI executable (e.g. /usr/local/bin/bb).}"
 
 if [ "${SYS:-}" != "ultra_honk" ]; then
   echo "Error: This flow only supports ultra_honk"


### PR DESCRIPTION
Description:
This pull request addresses a critical issue in the bash proof/verify workflow for UltraHonk: the environment variable BIN is referenced without ever being initialized. Because the script is run under set -u, Bash treats any undefined variable as an immediate failure. In practice, this means that as soon as the script reaches a line like: $BIN prove \
  --scheme ultra_honk \
  -b $artifact_dir/program.json \
  -w $artifact_dir/witness.gz \
  --output_format bytes_and_fields \
  -o $output_dir

it will exit with: ./run_ultra_honk_flow.sh: line XX: BIN: unbound variable
This is a show-stopper: no proof or verification steps ever execute, and developers/users receive no clear indication of how to fix it besides “export BIN yourself,” which is not documented in this repository. We need to ensure that:

The script either enforces that BIN is defined (with a helpful error message),

Or assigns a reasonable default (for instance, “bb” if that binary is always installed via our toolchain),

And documents this requirement in the header of the script.

Summary:
The script previously referenced $BIN (Barretenberg CLI path) without checking or defaulting it. Under set -u, this caused an immediate “unbound variable” error. This change adds:

A guard at the top:: "${BIN:?Environment variable BIN must be set to the Barretenberg CLI executable (e.g. /usr/local/bin/bb).}"

which prints a clear message and exits if BIN is missing.

A comment in the header explaining that users must export BIN before running the script.

With this, anyone running SYS=ultra_honk ./run_ultra_honk_flow.sh without first setting BIN will see a concise error, and the script will never fail silently.
