### PR TITLE
fix: Rollup invalid archive error

### DIFF
--- a/yarn-project/archiver/src/archiver/archiver.ts
+++ b/yarn-project/archiver/src/archiver/archiver.ts
@@ -907,20 +907,20 @@ export class Archiver extends (EventEmitter as new () => ArchiverEmitter) implem
     return l1BlockNumber;
   }
 
-  public getL1Timestamp(): bigint {
+  public getL1Timestamp(): Promise<bigint> {
     const l1Timestamp = this.l1Timestamp;
     if (!l1Timestamp) {
       throw new Error('L1 timestamp not yet available. Complete an initial sync first.');
     }
-    return l1Timestamp;
+    return Promise.resolve(l1Timestamp);
   }
 
-  public getL2SlotNumber(): Promise<bigint> {
-    return Promise.resolve(getSlotAtTimestamp(this.getL1Timestamp(), this.l1constants));
+  public async getL2SlotNumber(): Promise<bigint> {
+    return getSlotAtTimestamp(await this.getL1Timestamp(), this.l1constants);
   }
 
-  public getL2EpochNumber(): Promise<bigint> {
-    return Promise.resolve(getEpochNumberAtTimestamp(this.getL1Timestamp(), this.l1constants));
+  public async getL2EpochNumber(): Promise<bigint> {
+    return getEpochNumberAtTimestamp(await this.getL1Timestamp(), this.l1constants);
   }
 
   public async getBlocksForEpoch(epochNumber: bigint): Promise<L2Block[]> {

--- a/yarn-project/archiver/src/test/mock_l2_block_source.ts
+++ b/yarn-project/archiver/src/test/mock_l2_block_source.ts
@@ -221,6 +221,10 @@ export class MockL2BlockSource implements L2BlockSource, ContractDataSource {
     throw new Error('Method not implemented.');
   }
 
+  getL1Timestamp(): Promise<bigint> {
+    throw new Error('Method not implemented.');
+  }
+
   /**
    * Starts the block source. In this mock implementation, this is a noop.
    * @returns A promise that signals the initialization of the l2 block source on completion.

--- a/yarn-project/ethereum/src/eth_cheat_codes.ts
+++ b/yarn-project/ethereum/src/eth_cheat_codes.ts
@@ -30,7 +30,7 @@ export class EthCheatCodes {
 
   async rpcCall(method: string, params: any[]) {
     const paramsString = jsonStringify(params);
-    this.logger.info(`Calling ${method} with params: ${paramsString} on ${this.rpcUrls.join(', ')}`);
+    this.logger.debug(`Calling ${method} with params: ${paramsString} on ${this.rpcUrls.join(', ')}`);
     return (await this.publicClient.transport.request({
       method,
       params,

--- a/yarn-project/sequencer-client/src/publisher/sequencer-publisher.ts
+++ b/yarn-project/sequencer-client/src/publisher/sequencer-publisher.ts
@@ -263,12 +263,12 @@ export class SequencerPublisher {
    * @param tipArchive - The archive to check
    * @returns The slot and block number if it is possible to propose, undefined otherwise
    */
-  public canProposeAtNextEthBlock(tipArchive: Buffer) {
+  public canProposeAtNextEthBlock(tipArchive: Buffer, msgSender: EthAddress) {
     // TODO: #14291 - should loop through multiple keys to check if any of them can propose
     const ignoredErrors = ['SlotAlreadyInChain', 'InvalidProposer', 'InvalidArchive'];
 
     return this.rollupContract
-      .canProposeAtNextEthBlock(tipArchive, this.getForwarderAddress().toString(), this.ethereumSlotDuration)
+      .canProposeAtNextEthBlock(tipArchive, msgSender.toString(), this.ethereumSlotDuration)
       .catch(err => {
         if (err instanceof FormattedViemError && ignoredErrors.find(e => err.message.includes(e))) {
           this.log.debug(err.message);

--- a/yarn-project/sequencer-client/src/publisher/sequencer-publisher.ts
+++ b/yarn-project/sequencer-client/src/publisher/sequencer-publisher.ts
@@ -271,7 +271,9 @@ export class SequencerPublisher {
       .canProposeAtNextEthBlock(tipArchive, msgSender.toString(), this.ethereumSlotDuration)
       .catch(err => {
         if (err instanceof FormattedViemError && ignoredErrors.find(e => err.message.includes(e))) {
-          this.log.debug(err.message);
+          this.log.warn(`Failed canProposeAtTime check with ${ignoredErrors.find(e => err.message.includes(e))}`, {
+            error: err.message,
+          });
         } else {
           this.log.error(err.name, err);
         }

--- a/yarn-project/sequencer-client/src/sequencer/sequencer.ts
+++ b/yarn-project/sequencer-client/src/sequencer/sequencer.ts
@@ -256,33 +256,63 @@ export class Sequencer {
    */
   protected async doRealWork() {
     this.setState(SequencerState.SYNCHRONIZING, 0n);
-    // Update state when the previous block has been synced
-    const chainTip = await this.getChainTip();
+
+    // Check all components are synced to latest as seen by the archiver
+    const syncedTo = await this.getChainTip();
+
     // Do not go forward with new block if the previous one has not been mined and processed
-    if (!chainTip) {
+    if (!syncedTo) {
       return;
     }
 
     this.setState(SequencerState.PROPOSER_CHECK, 0n);
 
-    const newBlockNumber = chainTip.blockNumber + 1;
+    const chainTipArchive = syncedTo.archive;
+    const newBlockNumber = syncedTo.blockNumber + 1;
 
-    // If we cannot find a tip archive, assume genesis.
-    const chainTipArchive = chainTip.archive;
-
-    const { slot } = this.publisher.epochCache.getEpochAndSlotInNextSlot();
+    const { slot, ts } = this.publisher.epochCache.getEpochAndSlotInNextL1Slot();
     this.metrics.observeSlotChange(slot, this.publisher.getSenderAddress().toString());
 
+    // Check that the archiver and dependencies have synced to the previous L1 slot at least
+    // TODO(#14766): Archiver reports L1 timestamp based on L1 blocks seen, which means that a missed L1 block will
+    // cause the archiver L1 timestamp to fall behind, and cause this sequencer to start processing one L1 slot later.
+    const l1SlotDuration = BigInt(this.l1Constants.ethereumSlotDuration);
+    const syncLogData = { syncedToL1Ts: syncedTo.l1Timestamp, nextSlotTs: ts, l1SlotDuration };
+    if (syncedTo.l1Timestamp + l1SlotDuration < ts) {
+      this.log.verbose(
+        `Cannot propose block ${newBlockNumber} at next L2 slot ${slot} due to pending sync from L1`,
+        syncLogData,
+      );
+      return;
+    } else {
+      this.log.debug(`Successfully synced to previous L1 block`, syncLogData);
+    }
+
+    // Check that we are a proposer for the next slot
     const proposerInNextSlot = await this.publisher.epochCache.getProposerAttesterAddressInNextSlot();
     const validatorAddresses = this.validatorClient!.getValidatorAddresses();
 
     // If get proposer in next slot is undefined, then there is no proposer set, and it is in free for all (sandbox) so we continue
     // If we calculate a proposer in the next slot, and it is not us, then stop
     if (proposerInNextSlot !== undefined && !validatorAddresses.some(addr => addr.equals(proposerInNextSlot))) {
-      this.log.debug(`Cannot propose block ${newBlockNumber}`, {
+      this.log.debug(`Cannot propose block ${newBlockNumber} since we are not a proposer`, {
         us: validatorAddresses,
         proposer: proposerInNextSlot,
       });
+      return;
+    }
+
+    // Double check we are good for proposing at the next block before we start operations.
+    // We should never fail this check assuming the logic above is good.
+    const proposerAddress = proposerInNextSlot === undefined ? EthAddress.ZERO : this.publisher.getForwarderAddress();
+    const slotAndBlock = await this.publisher.canProposeAtNextEthBlock(chainTipArchive.toBuffer(), proposerAddress);
+    if (slotAndBlock === undefined) {
+      this.log.warn(`Cannot propose block ${newBlockNumber} at slot ${slot} due to failed rollup contract check`);
+      return;
+    } else if (slotAndBlock[0] !== slot || slotAndBlock[1] !== BigInt(newBlockNumber)) {
+      this.log.warn(
+        `Cannot propose block due to mismatch with rollup contract. Expected ${newBlockNumber} at slot ${slot} but got ${slotAndBlock[1]} at slot ${slotAndBlock[0]}.`,
+      );
       return;
     }
 
@@ -300,6 +330,7 @@ export class Sequencer {
       newGlobalVariables.timestamp.toBigInt(),
       VoteType.GOVERNANCE,
     );
+
     const enqueueSlashingVotePromise = this.publisher.enqueueCastVote(
       slot,
       newGlobalVariables.timestamp.toBigInt(),
@@ -307,7 +338,8 @@ export class Sequencer {
     );
 
     this.setState(SequencerState.INITIALIZING_PROPOSAL, slot);
-    this.log.debug(`Preparing proposal for block ${newBlockNumber} at slot ${slot}`, {
+    this.log.verbose(`Preparing proposal for block ${newBlockNumber} at slot ${slot}`, {
+      globalVariables: newGlobalVariables.toInspect(),
       chainTipArchive,
       blockNumber: newBlockNumber,
       slot,
@@ -324,7 +356,6 @@ export class Sequencer {
 
     let finishedFlushing = false;
     const pendingTxCount = await this.p2pClient.getPendingTxCount();
-    this.log.debug(`Pending tx count: ${pendingTxCount}`);
     if (pendingTxCount >= this.minTxsPerBlock || this.isFlushing) {
       // We don't fetch exactly maxTxsPerBlock txs here because we may not need all of them if we hit a limit before,
       // and also we may need to fetch more if we don't have enough valid txs.
@@ -623,7 +654,7 @@ export class Sequencer {
    * We don't check against the previous block submitted since it may have been reorg'd out.
    * @returns Boolean indicating if our dependencies are synced to the latest block.
    */
-  protected async getChainTip(): Promise<{ blockNumber: number; archive: Fr } | undefined> {
+  protected async getChainTip(): Promise<{ blockNumber: number; archive: Fr; l1Timestamp: bigint } | undefined> {
     const syncedBlocks = await Promise.all([
       this.worldState.status().then(({ syncSummary }) => ({
         number: syncSummary.latestBlockNumber,
@@ -632,9 +663,10 @@ export class Sequencer {
       this.l2BlockSource.getL2Tips().then(t => t.latest),
       this.p2pClient.getStatus().then(p2p => p2p.syncedToL2Block),
       this.l1ToL2MessageSource.getL2Tips().then(t => t.latest),
+      this.l2BlockSource.getL1Timestamp(),
     ] as const);
 
-    const [worldState, l2BlockSource, p2p, l1ToL2MessageSource] = syncedBlocks;
+    const [worldState, l2BlockSource, p2p, l1ToL2MessageSource, l1Timestamp] = syncedBlocks;
 
     // The archiver reports 'undefined' hash for the genesis block
     // because it doesn't have access to world state to compute it (facepalm)
@@ -663,10 +695,10 @@ export class Sequencer {
         return undefined;
       }
 
-      return { blockNumber: block.number, archive: block.archive.root };
+      return { blockNumber: block.number, archive: block.archive.root, l1Timestamp };
     } else {
       const archive = new Fr((await this.worldState.getCommitted().getTreeInfo(MerkleTreeId.ARCHIVE)).root);
-      return { blockNumber: INITIAL_L2_BLOCK_NUM - 1, archive };
+      return { blockNumber: INITIAL_L2_BLOCK_NUM - 1, archive, l1Timestamp };
     }
   }
 

--- a/yarn-project/slasher/src/slasher_client.ts
+++ b/yarn-project/slasher/src/slasher_client.ts
@@ -162,7 +162,7 @@ export class SlasherClient {
     }
 
     const selectedPayload = this.monitoredPayloads[0];
-    this.log.info('selectedPayload', selectedPayload);
+    this.log.info(`Selected slash payload at ${selectedPayload.payloadAddress}`, selectedPayload);
 
     return Promise.resolve(selectedPayload.payloadAddress);
   }

--- a/yarn-project/stdlib/src/block/l2_block_source.ts
+++ b/yarn-project/stdlib/src/block/l2_block_source.ts
@@ -119,6 +119,9 @@ export interface L2BlockSource {
    */
   getL1Constants(): Promise<L1RollupConstants>;
 
+  /** Latest synced L1 timestamp. */
+  getL1Timestamp(): Promise<bigint>;
+
   /** Force a sync. */
   syncImmediate(): Promise<void>;
 }

--- a/yarn-project/stdlib/src/interfaces/archiver.test.ts
+++ b/yarn-project/stdlib/src/interfaces/archiver.test.ts
@@ -240,6 +240,11 @@ describe('ArchiverApiSchema', () => {
   it('syncImmediate', async () => {
     await context.client.syncImmediate();
   });
+
+  it('getL1Timestamp', async () => {
+    const result = await context.client.getL1Timestamp();
+    expect(result).toBe(1n);
+  });
 });
 
 class MockArchiver implements ArchiverApi {
@@ -389,5 +394,8 @@ class MockArchiver implements ArchiverApi {
   }
   getL1Constants(): Promise<L1RollupConstants> {
     return Promise.resolve(EmptyL1RollupConstants);
+  }
+  getL1Timestamp(): Promise<bigint> {
+    return Promise.resolve(1n);
   }
 }

--- a/yarn-project/stdlib/src/interfaces/archiver.ts
+++ b/yarn-project/stdlib/src/interfaces/archiver.ts
@@ -73,5 +73,6 @@ export const ArchiverApiSchema: ApiSchemaFor<ArchiverApi> = {
   getL1ToL2MessageIndex: z.function().args(schemas.Fr).returns(schemas.BigInt.optional()),
   getDebugFunctionName: z.function().args(schemas.AztecAddress, schemas.FunctionSelector).returns(optional(z.string())),
   getL1Constants: z.function().args().returns(L1RollupConstantsSchema),
+  getL1Timestamp: z.function().args().returns(schemas.BigInt),
   syncImmediate: z.function().args().returns(z.void()),
 };

--- a/yarn-project/txe/src/state_machine/archiver.ts
+++ b/yarn-project/txe/src/state_machine/archiver.ts
@@ -129,4 +129,8 @@ export class TXEArchiver extends ArchiverStoreHelper {
   public getRegistryAddress(): Promise<EthAddress> {
     throw new Error('TXE Archiver does not implement "getRegistryAddress"');
   }
+
+  public getL1Timestamp(): Promise<bigint> {
+    throw new Error('TXE Archiver does not implement "getL1Timestamp"');
+  }
 }


### PR DESCRIPTION
Fixes multiple `Rollup__InvalidArchive` errors that were popping up on tests since https://github.com/AztecProtocol/aztec-packages/pull/13700.

Example from [this run](http://ci.aztec-labs.com/c82b760acf321da6):
```
09:42:54 [09:42:54.569] VERBOSE: sequencer Unable to build/enqueue block Rollup__InvalidArchive(0x2fdc940e38cff0a9fd112204b3ad9b7e75c3efaf9495dd7aeaecbcc8d2bba20f, 0x18674a63a7dd5a173cff9633512b7e5bd6b5536ea0b7c96929dcc68473c31e45)
```

The cause for this was the removal of the `canProposeAtNextEthBlock` check [here](https://github.com/AztecProtocol/aztec-packages/pull/13700/files#diff-1c2150b6e6b122e3a184b1132b8d6946e4e27fefe53381035810638fabcebe9cL384). This call to the rollup contract was removed since we were now manually checking the proposer using the epoch cache (which is a good thing!), but we lost the check for the latest archive root.

This meant that, if the sequencer started building _before_ the archiver was caught up to the previous block, it would build off an older chain tip, and only get rejected during block publishing. Note that in an actual setting, it should actually fail to collect attestations, since the proposal should be deemed invalid by validators due to a wrong parent, but most of our e2e tests don't have a committee.

This PR makes the sequencer check that the archiver has synched to the previous L1 block before proceeding. Note that L1 missed slots would cause issues here, but we can address that when we get to #[14766](https://github.com/AztecProtocol/aztec-packages/issues/14766). In addition, this PR restores the early call to `canProposeAtNextEthBlock` to be on the safe side before we start building.