### PR TITLE
chore: await validating before withdrawing

### DIFF
--- a/yarn-project/end-to-end/src/e2e_multi_validator_node.test.ts
+++ b/yarn-project/end-to-end/src/e2e_multi_validator_node.test.ts
@@ -100,6 +100,15 @@ describe('e2e_multi_validator_node', () => {
     // We jump to the next epoch such that the committee can be setup.
     const timeToJump = (await rollup.getEpochDuration()) * 2n;
     await progressTimeBySlot(timeToJump);
+    await retryUntil(
+      async () => {
+        const view = await rollup.getAttesterView(validatorAddresses[0]);
+        return view.effectiveBalance > 0;
+      },
+      'attester is attesting',
+      config.ethereumSlotDuration * 3,
+      1,
+    );
   });
 
   afterEach(async () => {
@@ -137,16 +146,6 @@ describe('e2e_multi_validator_node', () => {
     expect(signers).toEqual(expect.arrayContaining(validatorAddresses));
   });
   it('should attest ONLY with the correct validator keys', async () => {
-    await retryUntil(
-      async () => {
-        const view = await rollup.getAttesterView(validatorAddresses[0]);
-        return view.effectiveBalance > 0;
-      },
-      'attester is attesting',
-      config.ethereumSlotDuration * 3,
-      1,
-    );
-
     const rollupContract1 = getContract({
       address: deployL1ContractsValues.l1ContractAddresses.rollupAddress.toString(),
       abi: RollupAbi,

--- a/yarn-project/end-to-end/src/e2e_multi_validator_node.test.ts
+++ b/yarn-project/end-to-end/src/e2e_multi_validator_node.test.ts
@@ -7,6 +7,7 @@ import {
   Fr,
   type Logger,
   type Wallet,
+  retryUntil,
   waitForProven,
 } from '@aztec/aztec.js';
 import {
@@ -136,6 +137,16 @@ describe('e2e_multi_validator_node', () => {
     expect(signers).toEqual(expect.arrayContaining(validatorAddresses));
   });
   it('should attest ONLY with the correct validator keys', async () => {
+    await retryUntil(
+      async () => {
+        const view = await rollup.getAttesterView(validatorAddresses[0]);
+        return view.effectiveBalance > 0;
+      },
+      'attester is attesting',
+      config.ethereumSlotDuration * 3,
+      1,
+    );
+
     const rollupContract1 = getContract({
       address: deployL1ContractsValues.l1ContractAddresses.rollupAddress.toString(),
       abi: RollupAbi,


### PR DESCRIPTION
Ran `./yarn-project/end-to-end/scripts/deflaker.sh yarn-project/end-to-end/scripts/test_simple.sh end-to-end/src/e2e_multi_validator_node.test.ts` before and after changes. Before: failed on run 48. After: passes 100 runs.