### PR TITLE
docs(glossary.md): Update noir installation link

### DIFF
--- a/docs/docs/glossary.md
+++ b/docs/docs/glossary.md
@@ -51,7 +51,7 @@ Read more and review the source code [here](https://aztec.nr).
 
 With `nargo`, you can start new projects, compile, execute, and test your Noir programs.
 
-You can find more information in the nargo installation docs [here](https://noir-lang.org/docs/getting_started/installation/) and the nargo command reference [here](https://noir-lang.org/docs/reference/nargo_commands).
+You can find more information in the nargo installation docs [here](https://noir-lang.org/docs/getting_started/noir_installation/) and the nargo command reference [here](https://noir-lang.org/docs/reference/nargo_commands).
 
 ### Noir
 


### PR DESCRIPTION
This pull request updates the documentation links for the Aztec.js and nargo sections:
- The noir installation and command reference links have been corrected to ensure they direct users to the latest and most relevant documentation.

These changes improve the accuracy and usability of the documentation for developers.

**Before:**
![before](https://github.com/user-attachments/assets/8072a1bb-cd48-4bcb-94b4-7e59be4ba015)

**After:**
![after](https://github.com/user-attachments/assets/7af13ff1-91bd-43c9-a4dd-71d8af750ad4)