### PR TITLE
fix: comptime friendly Serialize imp of BoundedVec

### DIFF
--- a/noir-projects/noir-protocol-circuits/crates/types/src/traits.nr
+++ b/noir-projects/noir-protocol-circuits/crates/types/src/traits.nr
@@ -278,19 +278,16 @@ where
     #[inline_always]
     fn serialize(self) -> [Field; O * M + 1] {
         let mut fields = [0; O * M + 1];
+        fields[0] = self.len() as Field;
 
-        let len = self.len();
-        fields[0] = len as Field;
+        let storage = self.storage();
 
-        let mut index: u32 = 1;
-
-        for i in 0..len {
-            let item = self.get_unchecked(i);
-            let serialized_item = item.serialize();
+        for i in 0..M {
+            // Calling here serialize on zeroed-out items doesn't seem right, but I don't know what to do :(.
+            let serialized_item = storage[i].serialize();
 
             for j in 0..O {
-                fields[index] = serialized_item[j];
-                index += 1;
+                fields[i * O + j + 1] = serialized_item[j];
             }
         }
 

--- a/noir-projects/noir-protocol-circuits/crates/types/src/traits.nr
+++ b/noir-projects/noir-protocol-circuits/crates/types/src/traits.nr
@@ -283,7 +283,6 @@ where
         let storage = self.storage();
 
         for i in 0..M {
-            // Calling here serialize on zeroed-out items doesn't seem right, but I don't know what to do :(.
             let serialized_item = storage[i].serialize();
 
             for j in 0..O {
@@ -342,4 +341,32 @@ pub trait Packable<let N: u32> {
 
     /// Unpacks a compact array of `Field` elements into the original value.
     fn unpack(fields: [Field; N]) -> Self;
+}
+
+#[test]
+unconstrained fn bounded_vec_serialization() {
+    // Test empty BoundedVec
+    let empty_vec: BoundedVec<Field, 3> = BoundedVec::from_array([]);
+    let serialized = empty_vec.serialize();
+    let deserialized = BoundedVec::<Field, 3>::deserialize(serialized);
+    assert_eq(empty_vec, deserialized);
+    assert_eq(deserialized.len(), 0);
+
+    // Test partially filled BoundedVec
+    let partial_vec: BoundedVec<[u32; 2], 3> = BoundedVec::from_array([[1, 2]]);
+    let serialized = partial_vec.serialize();
+    let deserialized = BoundedVec::<[u32; 2], 3>::deserialize(serialized);
+    assert_eq(partial_vec, deserialized);
+    assert_eq(deserialized.len(), 1);
+    assert_eq(deserialized.get(0), [1, 2]);
+
+    // Test full BoundedVec
+    let full_vec: BoundedVec<[u32; 2], 3> = BoundedVec::from_array([[1, 2], [3, 4], [5, 6]]);
+    let serialized = full_vec.serialize();
+    let deserialized = BoundedVec::<[u32; 2], 3>::deserialize(serialized);
+    assert_eq(full_vec, deserialized);
+    assert_eq(deserialized.len(), 3);
+    assert_eq(deserialized.get(0), [1, 2]);
+    assert_eq(deserialized.get(1), [3, 4]);
+    assert_eq(deserialized.get(2), [5, 6]);
 }


### PR DESCRIPTION
Our implementation of `Serialize` for `BoundedVec` was not comptime friendly:
<img width="1731" alt="image" src="https://github.com/user-attachments/assets/4cf22749-2e35-4514-bfd4-b504b5d677fe" />

We need this to work if we want to pass BVec as arg to a contract function (there Serialize is used for the args hasher stuff).

This implemenation doesn't feel right as it calls serialize on a zeroed-out items. But I don't know what to do. Submitting this PR to get some feedback.