### PR TITLE
feat!: stricter vote call

### DIFF
--- a/l1-contracts/src/core/libraries/Errors.sol
+++ b/l1-contracts/src/core/libraries/Errors.sol
@@ -128,7 +128,8 @@ library Errors {
   error Staking__InsufficientPower(uint256, uint256);
   error Staking__AlreadyExiting(address);
   error Staking__FatalError(string);
-  error Staking__NotOurProposal(uint256);
+  error Staking__NotOurProposal(uint256, address, address);
+  error Staking__IncorrectGovProposer(uint256);
   error Staking__GovernanceAlreadySet();
 
   // GSE

--- a/l1-contracts/src/core/libraries/staking/StakingLib.sol
+++ b/l1-contracts/src/core/libraries/staking/StakingLib.sol
@@ -85,17 +85,24 @@ library StakingLib {
     StakingStorage storage store = getStorage();
     Governance gov = store.gse.getGovernance();
 
-    // We need to check if we made the proposal. We are assuming an honest gov, because if dishonest
-    // this vote don't matter anyway.
-    // We must be the current canonical instance. Because we only want to vote on our own proposals.
+    // We will vote if:
+    // 1. We are the canonical instance as seen be my the governance proposer
+    // 2. We are the actor that was canonical when the proposal was made in the governance proposer
+    // 3. The proposer in the governance is the governance proposer.
+    // This means that if we only vote if canonical and on our own proposals (assuming that the governance
+    // proposer don't lie to us).
+
     GovernanceProposer govProposer = GovernanceProposer(gov.governanceProposer());
     require(address(this) == govProposer.getInstance(), Errors.Staking__NotCanonical(address(this)));
+    address proposalProposer = govProposer.getProposalProposer(_proposalId);
     require(
-      address(this) == govProposer.getProposalProposer(_proposalId),
-      Errors.Staking__NotOurProposal(_proposalId)
+      address(this) == proposalProposer,
+      Errors.Staking__NotOurProposal(_proposalId, address(this), proposalProposer)
     );
     DataStructures.Proposal memory proposal = gov.getProposal(_proposalId);
-    require(proposal.proposer == address(govProposer), Errors.Staking__NotOurProposal(_proposalId));
+    require(
+      proposal.proposer == address(govProposer), Errors.Staking__IncorrectGovProposer(_proposalId)
+    );
 
     Timestamp ts = proposal.pendingThroughMemory();
 

--- a/l1-contracts/src/core/libraries/staking/StakingLib.sol
+++ b/l1-contracts/src/core/libraries/staking/StakingLib.sol
@@ -88,13 +88,14 @@ library StakingLib {
     // We need to check if we made the proposal. We are assuming an honest gov, because if dishonest
     // this vote don't matter anyway.
     // We must be the current canonical instance. Because we only want to vote on our own proposals.
-    address govProposer = gov.governanceProposer();
+    GovernanceProposer govProposer = GovernanceProposer(gov.governanceProposer());
+    require(address(this) == govProposer.getInstance(), Errors.Staking__NotCanonical(address(this)));
     require(
-      address(this) == GovernanceProposer(govProposer).getInstance(),
-      Errors.Staking__NotCanonical(address(this))
+      address(this) == govProposer.getProposalProposer(_proposalId),
+      Errors.Staking__NotOurProposal(_proposalId)
     );
     DataStructures.Proposal memory proposal = gov.getProposal(_proposalId);
-    require(proposal.proposer == govProposer, Errors.Staking__NotOurProposal(_proposalId));
+    require(proposal.proposer == address(govProposer), Errors.Staking__NotOurProposal(_proposalId));
 
     Timestamp ts = proposal.pendingThroughMemory();
 

--- a/l1-contracts/src/core/slashing/SlashingProposer.sol
+++ b/l1-contracts/src/core/slashing/SlashingProposer.sol
@@ -3,14 +3,14 @@
 pragma solidity >=0.8.27;
 
 import {ISlasher} from "@aztec/core/interfaces/ISlasher.sol";
-import {IGovernanceProposer} from "@aztec/governance/interfaces/IGovernanceProposer.sol";
 import {IPayload} from "@aztec/governance/interfaces/IPayload.sol";
 import {EmpireBase} from "@aztec/governance/proposer/EmpireBase.sol";
+import {IEmpire} from "@aztec/governance/interfaces/IEmpire.sol";
 
 /**
  * @notice  A SlashingProposer implementation following the empire model
  */
-contract SlashingProposer is IGovernanceProposer, EmpireBase {
+contract SlashingProposer is IEmpire, EmpireBase {
   address public immutable INSTANCE;
   ISlasher public immutable SLASHER;
 
@@ -21,11 +21,11 @@ contract SlashingProposer is IGovernanceProposer, EmpireBase {
     SLASHER = _slasher;
   }
 
-  function getExecutor() public view override(EmpireBase, IGovernanceProposer) returns (address) {
+  function getExecutor() public view override(EmpireBase, IEmpire) returns (address) {
     return address(SLASHER);
   }
 
-  function getInstance() public view override(EmpireBase, IGovernanceProposer) returns (address) {
+  function getInstance() public view override(EmpireBase, IEmpire) returns (address) {
     return INSTANCE;
   }
 

--- a/l1-contracts/src/core/slashing/SlashingProposer.sol
+++ b/l1-contracts/src/core/slashing/SlashingProposer.sol
@@ -3,9 +3,9 @@
 pragma solidity >=0.8.27;
 
 import {ISlasher} from "@aztec/core/interfaces/ISlasher.sol";
+import {IEmpire} from "@aztec/governance/interfaces/IEmpire.sol";
 import {IPayload} from "@aztec/governance/interfaces/IPayload.sol";
 import {EmpireBase} from "@aztec/governance/proposer/EmpireBase.sol";
-import {IEmpire} from "@aztec/governance/interfaces/IEmpire.sol";
 
 /**
  * @notice  A SlashingProposer implementation following the empire model

--- a/l1-contracts/src/governance/Governance.sol
+++ b/l1-contracts/src/governance/Governance.sol
@@ -158,7 +158,7 @@ contract Governance is IGovernance {
     ASSET.safeTransfer(withdrawal.recipient, withdrawal.amount);
   }
 
-  function propose(IPayload _proposal) external override(IGovernance) returns (bool) {
+  function propose(IPayload _proposal) external override(IGovernance) returns (uint256) {
     require(
       msg.sender == governanceProposer,
       Errors.Governance__CallerNotGovernanceProposer(msg.sender, governanceProposer)
@@ -178,12 +178,12 @@ contract Governance is IGovernance {
    *
    * @param _proposal The proposal to propose
    * @param _to The address to send the lock to
-   * @return True if the proposal was proposed
+   * @return The id of the proposal
    */
   function proposeWithLock(IPayload _proposal, address _to)
     external
     override(IGovernance)
-    returns (bool)
+    returns (uint256)
   {
     uint256 availablePower = users[msg.sender].powerNow();
     uint256 amount = configuration.proposeConfig.lockAmount;
@@ -396,7 +396,7 @@ contract Governance is IGovernance {
     return withdrawalId;
   }
 
-  function _propose(IPayload _proposal, address _proposer) internal returns (bool) {
+  function _propose(IPayload _proposal, address _proposer) internal returns (uint256) {
     uint256 proposalId = proposalCount++;
 
     proposals[proposalId] = DataStructures.Proposal({
@@ -410,6 +410,6 @@ contract Governance is IGovernance {
 
     emit Proposed(proposalId, address(_proposal));
 
-    return true;
+    return proposalId;
   }
 }

--- a/l1-contracts/src/governance/interfaces/IEmpire.sol
+++ b/l1-contracts/src/governance/interfaces/IEmpire.sol
@@ -1,0 +1,26 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright 2024 Aztec Labs.
+// solhint-disable imports-order
+pragma solidity >=0.8.27;
+
+import {Slot} from "@aztec/core/libraries/TimeLib.sol";
+import {IPayload} from "@aztec/governance/interfaces/IPayload.sol";
+import {Signature} from "@aztec/core/libraries/crypto/SignatureLib.sol";
+
+interface IEmpire {
+  event VoteCast(IPayload indexed proposal, uint256 indexed round, address indexed voter);
+  event ProposalExecutable(IPayload indexed proposal, uint256 indexed round);
+  event ProposalExecuted(IPayload indexed proposal, uint256 indexed round);
+
+  function vote(IPayload _proposal) external returns (bool);
+  function voteWithSig(IPayload _proposal, Signature memory _sig) external returns (bool);
+
+  function executeProposal(uint256 _roundNumber) external returns (bool);
+  function yeaCount(address _instance, uint256 _round, IPayload _proposal)
+    external
+    view
+    returns (uint256);
+  function computeRound(Slot _slot) external view returns (uint256);
+  function getInstance() external view returns (address);
+  function getExecutor() external view returns (address);
+}

--- a/l1-contracts/src/governance/interfaces/IGovernance.sol
+++ b/l1-contracts/src/governance/interfaces/IGovernance.sol
@@ -28,8 +28,8 @@ interface IGovernance {
   function deposit(address _onBehalfOf, uint256 _amount) external;
   function initiateWithdraw(address _to, uint256 _amount) external returns (uint256);
   function finaliseWithdraw(uint256 _withdrawalId) external;
-  function propose(IPayload _proposal) external returns (bool);
-  function proposeWithLock(IPayload _proposal, address _to) external returns (bool);
+  function propose(IPayload _proposal) external returns (uint256);
+  function proposeWithLock(IPayload _proposal, address _to) external returns (uint256);
   function vote(uint256 _proposalId, uint256 _amount, bool _support) external returns (bool);
   function execute(uint256 _proposalId) external returns (bool);
   function dropProposal(uint256 _proposalId) external returns (bool);

--- a/l1-contracts/src/governance/interfaces/IGovernanceProposer.sol
+++ b/l1-contracts/src/governance/interfaces/IGovernanceProposer.sol
@@ -3,24 +3,8 @@
 // solhint-disable imports-order
 pragma solidity >=0.8.27;
 
-import {Slot} from "@aztec/core/libraries/TimeLib.sol";
-import {IPayload} from "@aztec/governance/interfaces/IPayload.sol";
-import {Signature} from "@aztec/core/libraries/crypto/SignatureLib.sol";
+import {IEmpire} from "./IEmpire.sol";
 
-interface IGovernanceProposer {
-  event VoteCast(IPayload indexed proposal, uint256 indexed round, address indexed voter);
-  event ProposalExecutable(IPayload indexed proposal, uint256 indexed round);
-  event ProposalExecuted(IPayload indexed proposal, uint256 indexed round);
-
-  function vote(IPayload _proposal) external returns (bool);
-  function voteWithSig(IPayload _proposal, Signature memory _sig) external returns (bool);
-
-  function executeProposal(uint256 _roundNumber) external returns (bool);
-  function yeaCount(address _instance, uint256 _round, IPayload _proposal)
-    external
-    view
-    returns (uint256);
-  function computeRound(Slot _slot) external view returns (uint256);
-  function getInstance() external view returns (address);
-  function getExecutor() external view returns (address);
+interface IGovernanceProposer is IEmpire {
+  function getProposalProposer(uint256 _proposalId) external view returns (address);
 }

--- a/l1-contracts/src/governance/proposer/EmpireBase.sol
+++ b/l1-contracts/src/governance/proposer/EmpireBase.sol
@@ -4,7 +4,7 @@
 pragma solidity >=0.8.27;
 
 import {SignatureLib, Signature} from "@aztec/core/libraries/crypto/SignatureLib.sol";
-import {IGovernanceProposer} from "@aztec/governance/interfaces/IGovernanceProposer.sol";
+import {IEmpire} from "@aztec/governance/interfaces/IEmpire.sol";
 import {IValidatorSelection} from "@aztec/core/interfaces/IValidatorSelection.sol";
 import {Slot, SlotLib} from "@aztec/core/libraries/TimeLib.sol";
 import {Errors} from "@aztec/governance/libraries/Errors.sol";
@@ -18,7 +18,7 @@ import {EIP712} from "@oz/utils/cryptography/EIP712.sol";
  *          This also means that the implementation here will need to be "updated" if
  *          the interfaces of the sequencer selection changes, for example going optimistic.
  */
-abstract contract EmpireBase is EIP712, IGovernanceProposer {
+abstract contract EmpireBase is EIP712, IEmpire {
   using SlotLib for Slot;
   using SignatureLib for Signature;
 
@@ -60,7 +60,7 @@ abstract contract EmpireBase is EIP712, IGovernanceProposer {
    *
    * @return True if executed successfully, false otherwise
    */
-  function vote(IPayload _proposal) external override(IGovernanceProposer) returns (bool) {
+  function vote(IPayload _proposal) external override(IEmpire) returns (bool) {
     return _internalVote(_proposal, Signature({v: 0, r: bytes32(0), s: bytes32(0)}));
   }
 
@@ -76,7 +76,7 @@ abstract contract EmpireBase is EIP712, IGovernanceProposer {
    */
   function voteWithSig(IPayload _proposal, Signature memory _sig)
     external
-    override(IGovernanceProposer)
+    override(IEmpire)
     returns (bool)
   {
     return _internalVote(_proposal, _sig);
@@ -89,11 +89,7 @@ abstract contract EmpireBase is EIP712, IGovernanceProposer {
    *
    * @return True if executed successfully, false otherwise
    */
-  function executeProposal(uint256 _roundNumber)
-    external
-    override(IGovernanceProposer)
-    returns (bool)
-  {
+  function executeProposal(uint256 _roundNumber) external override(IEmpire) returns (bool) {
     // Need to ensure that the round is not active.
     address instance = getInstance();
     require(instance.code.length > 0, Errors.GovernanceProposer__InstanceHaveNoCode(instance));
@@ -136,7 +132,7 @@ abstract contract EmpireBase is EIP712, IGovernanceProposer {
   function yeaCount(address _instance, uint256 _round, IPayload _proposal)
     external
     view
-    override(IGovernanceProposer)
+    override(IEmpire)
     returns (uint256)
   {
     return rounds[_instance][_round].yeaCount[_proposal];
@@ -160,13 +156,13 @@ abstract contract EmpireBase is EIP712, IGovernanceProposer {
    *
    * @return The round number
    */
-  function computeRound(Slot _slot) public view override(IGovernanceProposer) returns (uint256) {
+  function computeRound(Slot _slot) public view override(IEmpire) returns (uint256) {
     return _slot.unwrap() / M;
   }
 
   // Virtual functions
-  function getInstance() public view virtual override(IGovernanceProposer) returns (address);
-  function getExecutor() public view virtual override(IGovernanceProposer) returns (address);
+  function getInstance() public view virtual override(IEmpire) returns (address);
+  function getExecutor() public view virtual override(IEmpire) returns (address);
   function _execute(IPayload _proposal) internal virtual returns (bool);
 
   function _internalVote(IPayload _proposal, Signature memory _sig) internal returns (bool) {

--- a/l1-contracts/src/governance/proposer/GovernanceProposer.sol
+++ b/l1-contracts/src/governance/proposer/GovernanceProposer.sol
@@ -9,6 +9,7 @@ import {IGovernanceProposer} from "@aztec/governance/interfaces/IGovernancePropo
 import {IPayload} from "@aztec/governance/interfaces/IPayload.sol";
 import {IRegistry} from "@aztec/governance/interfaces/IRegistry.sol";
 import {EmpireBase} from "./EmpireBase.sol";
+import {IEmpire} from "@aztec/governance/interfaces/IEmpire.sol";
 
 /**
  * @notice  A GovernanceProposer implementation following the empire model
@@ -21,21 +22,36 @@ contract GovernanceProposer is IGovernanceProposer, EmpireBase {
   IRegistry public immutable REGISTRY;
   IGSE public immutable GSE;
 
+  mapping(uint256 proposalId => address proposer) internal proposalProposer;
+
+  event Lasser(uint256 proposalId, address proposer);
+
   constructor(IRegistry _registry, IGSE _gse, uint256 _n, uint256 _m) EmpireBase(_n, _m) {
     REGISTRY = _registry;
     GSE = _gse;
   }
 
-  function getExecutor() public view override(EmpireBase, IGovernanceProposer) returns (address) {
+  function getProposalProposer(uint256 _proposalId)
+    external
+    view
+    override(IGovernanceProposer)
+    returns (address)
+  {
+    return proposalProposer[_proposalId];
+  }
+
+  function getExecutor() public view override(EmpireBase, IEmpire) returns (address) {
     return REGISTRY.getGovernance();
   }
 
-  function getInstance() public view override(EmpireBase, IGovernanceProposer) returns (address) {
+  function getInstance() public view override(EmpireBase, IEmpire) returns (address) {
     return address(REGISTRY.getCanonicalRollup());
   }
 
   function _execute(IPayload _proposal) internal override(EmpireBase) returns (bool) {
     GSEPayload extendedPayload = new GSEPayload(_proposal, GSE);
-    return IGovernance(getExecutor()).propose(IPayload(address(extendedPayload)));
+    uint256 proposalId = IGovernance(getExecutor()).propose(IPayload(address(extendedPayload)));
+    proposalProposer[proposalId] = getInstance();
+    return true;
   }
 }

--- a/l1-contracts/src/governance/proposer/GovernanceProposer.sol
+++ b/l1-contracts/src/governance/proposer/GovernanceProposer.sol
@@ -24,8 +24,6 @@ contract GovernanceProposer is IGovernanceProposer, EmpireBase {
 
   mapping(uint256 proposalId => address proposer) internal proposalProposer;
 
-  event Lasser(uint256 proposalId, address proposer);
-
   constructor(IRegistry _registry, IGSE _gse, uint256 _n, uint256 _m) EmpireBase(_n, _m) {
     REGISTRY = _registry;
     GSE = _gse;

--- a/l1-contracts/src/governance/proposer/GovernanceProposer.sol
+++ b/l1-contracts/src/governance/proposer/GovernanceProposer.sol
@@ -4,12 +4,12 @@ pragma solidity >=0.8.27;
 
 import {IGSE} from "@aztec/core/staking/GSE.sol";
 import {GSEPayload} from "@aztec/governance/GSEPayload.sol";
+import {IEmpire} from "@aztec/governance/interfaces/IEmpire.sol";
 import {IGovernance} from "@aztec/governance/interfaces/IGovernance.sol";
 import {IGovernanceProposer} from "@aztec/governance/interfaces/IGovernanceProposer.sol";
 import {IPayload} from "@aztec/governance/interfaces/IPayload.sol";
 import {IRegistry} from "@aztec/governance/interfaces/IRegistry.sol";
 import {EmpireBase} from "./EmpireBase.sol";
-import {IEmpire} from "@aztec/governance/interfaces/IEmpire.sol";
 
 /**
  * @notice  A GovernanceProposer implementation following the empire model

--- a/l1-contracts/test/delegation/base.t.sol
+++ b/l1-contracts/test/delegation/base.t.sol
@@ -29,6 +29,13 @@ contract GSEBase is TestBase {
     stakingAsset = builder.getConfig().testERC20;
     gse = builder.getConfig().gse;
     governance = builder.getConfig().governance;
+
+    vm.label(address(governance), "governance");
+    vm.label(address(governance.governanceProposer()), "governance proposer");
+    vm.label(address(gse), "gse");
+    vm.label(address(stakingAsset), "staking asset");
+    vm.label(address(ROLLUP), "rollup");
+    vm.label(address(registry), "registry");
   }
 
   function help__deposit(address _attester, address _withdrawer, bool _onCanonical) internal {

--- a/l1-contracts/test/delegation/minimal.t.sol
+++ b/l1-contracts/test/delegation/minimal.t.sol
@@ -15,6 +15,16 @@ import {GovernanceProposer} from "@aztec/governance/proposer/GovernanceProposer.
 import {Fakerollup} from "../governance/governance-proposer/mocks/Fakerollup.sol";
 import {IRollup} from "@aztec/core/interfaces/IRollup.sol";
 
+struct Timestamps {
+  uint256 ts1;
+  uint256 ts2;
+  uint256 ts3;
+  uint256 ts4;
+  uint256 ts5;
+  uint256 ts6;
+  uint256 ts7;
+}
+
 // Collection of minimal test suite to get some idea
 // Not to be seen as full tests
 contract MinimalDelegationTest is GSEBase {
@@ -31,7 +41,7 @@ contract MinimalDelegationTest is GSEBase {
     vm.label(canonical, "canonical");
   }
 
-  function test_votingPower(bool _overwriteDelay, bool _claim) public {
+  function test_votingPower(bool _overwriteDelay, bool _claim, bool _updateRegistry) public {
     // Setup
 
     address proposer = governance.governanceProposer();
@@ -39,44 +49,46 @@ contract MinimalDelegationTest is GSEBase {
     uint256 proposalId = governance.propose(IPayload(address(ROLLUP))); // Useless payload, just to get it in there.
 
     // Fake it till you make it
-    stdstore.target(address(governance.governanceProposer())).sig("getProposalProposer(uint256)")
-      .with_key(proposalId).checked_write(proposer);
-
-    assertEq(
-      GovernanceProposer(governance.governanceProposer()).getProposalProposer(proposalId), proposer
+    stdstore.target(proposer).sig("getProposalProposer(uint256)").with_key(proposalId).checked_write(
+      address(ROLLUP)
     );
+    assertEq(GovernanceProposer(proposer).getProposalProposer(proposalId), address(ROLLUP));
 
     uint256 votingTime =
       Timestamp.unwrap(ProposalLib.pendingThroughMemory(governance.getProposal(0)));
 
-    uint256 ts1 = block.timestamp;
-    uint256 ts2 = ts1 + 10;
-    uint256 ts3 = ts2 + 10;
+    Timestamps memory ts;
 
-    require(votingTime > ts3, "ts");
-    uint256 ts4 = votingTime + 10;
-    uint256 ts5 = ts4 + 10;
-    uint256 ts6 = ts5 + 10;
-    uint256 ts7 = ts6 + 10;
+    ts.ts1 = block.timestamp;
+    ts.ts2 = ts.ts1 + 10;
+    ts.ts3 = ts.ts2 + 10;
+
+    require(votingTime > ts.ts3, "ts");
+    ts.ts4 = votingTime + 10;
+    ts.ts5 = ts.ts4 + 10;
+    ts.ts6 = ts.ts5 + 10;
+    ts.ts7 = ts.ts6 + 10;
 
     // Lets start
     assertEq(gse.getVotingPower(canonical), 0, "votingPowerCanonical");
 
     help__deposit(ATTESTER1, WITHDRAWER, true);
 
-    vm.warp(ts2);
+    vm.warp(ts.ts2);
 
     help__deposit(ATTESTER2, WITHDRAWER, false);
 
-    vm.warp(ts3);
+    vm.warp(ts.ts3);
 
     help__deposit(WITHDRAWER, WITHDRAWER, true);
 
-    vm.warp(ts4);
+    vm.warp(ts.ts4);
 
-    _checkInstanceCanonical(address(ROLLUP), 0, depositAmount, Timestamp.wrap(ts1));
-    _checkInstanceCanonical(address(ROLLUP), depositAmount, depositAmount, Timestamp.wrap(ts2));
-    _checkInstanceCanonical(address(ROLLUP), depositAmount, depositAmount * 2, Timestamp.wrap(ts3));
+    _checkInstanceCanonical(address(ROLLUP), 0, depositAmount, Timestamp.wrap(ts.ts1));
+    _checkInstanceCanonical(address(ROLLUP), depositAmount, depositAmount, Timestamp.wrap(ts.ts2));
+    _checkInstanceCanonical(
+      address(ROLLUP), depositAmount, depositAmount * 2, Timestamp.wrap(ts.ts3)
+    );
 
     assertEq(gse.getVotingPower(ATTESTER1), 0, "voting power user");
     assertEq(gse.getVotingPower(ATTESTER2), 0, "voting power user");
@@ -85,9 +97,10 @@ contract MinimalDelegationTest is GSEBase {
     vm.prank(WITHDRAWER);
     gse.delegate(canonical, ATTESTER1, WITHDRAWER);
 
-    vm.warp(ts5);
+    vm.warp(ts.ts5);
 
     Fakerollup dead = new Fakerollup();
+    vm.label(address(dead), "fake rollup");
 
     // From the view of the GSE we make a new version canonical.
     // Beware that the registry don't have the same, and that we are abusing this
@@ -96,13 +109,16 @@ contract MinimalDelegationTest is GSEBase {
     vm.prank(gse.owner());
     gse.addRollup(address(dead));
 
-    // When we pass along this, we
-    //  vm.prank(registry.owner());
-    //    registry.addRollup(IRollup(address(dead)));
+    if (_updateRegistry) {
+      // If we update the registry. The governance proposer will be belonging to someone else!
+      // We should not be failing because we are not longer canonical :sob:
+      vm.prank(registry.owner());
+      registry.addRollup(IRollup(address(dead)));
+    }
 
-    vm.warp(ts6);
+    vm.warp(ts.ts6);
 
-    assertEq(governance.totalPowerAt(Timestamp.wrap(ts6)), depositAmount * 3);
+    assertEq(governance.totalPowerAt(Timestamp.wrap(ts.ts6)), depositAmount * 3);
 
     if (_overwriteDelay) {
       stdstore.target(address(ROLLUP)).sig("getExitDelay()").checked_write(5);
@@ -111,28 +127,30 @@ contract MinimalDelegationTest is GSEBase {
     vm.prank(WITHDRAWER);
     ROLLUP.initiateWithdraw(ATTESTER2, WITHDRAWER);
 
-    assertEq(governance.totalPowerAt(Timestamp.wrap(ts6)), depositAmount * 2);
+    assertEq(governance.totalPowerAt(Timestamp.wrap(ts.ts6)), depositAmount * 2);
 
-    vm.warp(ts7);
+    vm.warp(ts.ts7);
 
     // Check power at different points in time.
-    _checkInstanceCanonical(address(ROLLUP), 0, depositAmount, Timestamp.wrap(ts1));
-    _checkInstanceNonCanonical(address(dead), 0, Timestamp.wrap(ts1));
+    _checkInstanceCanonical(address(ROLLUP), 0, depositAmount, Timestamp.wrap(ts.ts1));
+    _checkInstanceNonCanonical(address(dead), 0, Timestamp.wrap(ts.ts1));
 
-    _checkInstanceCanonical(address(ROLLUP), depositAmount, depositAmount, Timestamp.wrap(ts2));
-    _checkInstanceNonCanonical(address(dead), 0, Timestamp.wrap(ts2));
+    _checkInstanceCanonical(address(ROLLUP), depositAmount, depositAmount, Timestamp.wrap(ts.ts2));
+    _checkInstanceNonCanonical(address(dead), 0, Timestamp.wrap(ts.ts2));
 
-    _checkInstanceCanonical(address(ROLLUP), depositAmount, depositAmount * 2, Timestamp.wrap(ts3));
-    _checkInstanceNonCanonical(address(dead), 0, Timestamp.wrap(ts3));
+    _checkInstanceCanonical(
+      address(ROLLUP), depositAmount, depositAmount * 2, Timestamp.wrap(ts.ts3)
+    );
+    _checkInstanceNonCanonical(address(dead), 0, Timestamp.wrap(ts.ts3));
 
-    _checkInstanceCanonical(address(ROLLUP), depositAmount, depositAmount, Timestamp.wrap(ts4));
-    _checkInstanceNonCanonical(address(dead), 0, Timestamp.wrap(ts4));
+    _checkInstanceCanonical(address(ROLLUP), depositAmount, depositAmount, Timestamp.wrap(ts.ts4));
+    _checkInstanceNonCanonical(address(dead), 0, Timestamp.wrap(ts.ts4));
 
-    _checkInstanceNonCanonical(address(ROLLUP), depositAmount, Timestamp.wrap(ts5));
-    _checkInstanceCanonical(address(dead), 0, depositAmount, Timestamp.wrap(ts5));
+    _checkInstanceNonCanonical(address(ROLLUP), depositAmount, Timestamp.wrap(ts.ts5));
+    _checkInstanceCanonical(address(dead), 0, depositAmount, Timestamp.wrap(ts.ts5));
 
-    _checkInstanceNonCanonical(address(ROLLUP), 0, Timestamp.wrap(ts6));
-    _checkInstanceCanonical(address(dead), 0, depositAmount, Timestamp.wrap(ts6));
+    _checkInstanceNonCanonical(address(ROLLUP), 0, Timestamp.wrap(ts.ts6));
+    _checkInstanceCanonical(address(dead), 0, depositAmount, Timestamp.wrap(ts.ts6));
 
     assertEq(gse.getVotingPower(WITHDRAWER), depositAmount, "voting power user");
 
@@ -145,14 +163,27 @@ contract MinimalDelegationTest is GSEBase {
     uint256 powerToVoteSelf = gse.getVotingPowerAt(address(ROLLUP), Timestamp.wrap(votingTime));
     assertEq(powerToVoteSelf, depositAmount, "powerToVoteSelf");
 
-    // We go to the rollup and have it vote. We can do this because the registry and governanceProposer still
-    // belive that the rollup is canonical so it can use the governance proposer. Thereby, the rollup is voting
-    // on a proposal that it have made itself.
-    vm.expectEmit(true, true, true, true, address(governance));
-    emit IGovernance.VoteCast(0, address(gse), true, depositAmount);
-    vm.expectEmit(true, true, true, true, address(governance));
-    emit IGovernance.VoteCast(0, address(gse), true, depositAmount * 2);
-    ROLLUP.vote(0);
+    // We go to the rollup and have it vote.
+    // If we did not update the registry, it and the governanceProposer still belive that the rollup is canonical
+    // so it can use the governance proposer.
+    // But if updated, we should instead break and explode!
+
+    if (_updateRegistry) {
+      vm.expectRevert(
+        abi.encodeWithSelector(Errors.Staking__NotCanonical.selector, address(ROLLUP))
+      );
+    } else {
+      vm.expectEmit(true, true, true, true, address(governance));
+      emit IGovernance.VoteCast(proposalId, address(gse), true, depositAmount);
+      vm.expectEmit(true, true, true, true, address(governance));
+      emit IGovernance.VoteCast(proposalId, address(gse), true, depositAmount * 2);
+    }
+    ROLLUP.vote(proposalId);
+
+    // Exit early as things revert and so will a lot below!
+    if (_updateRegistry) {
+      return;
+    }
 
     assertEq(gse.getPowerUsed(WITHDRAWER, 0), 0, "power used");
     assertEq(gse.getPowerUsed(address(ROLLUP), 0), depositAmount, "power used");
@@ -165,7 +196,7 @@ contract MinimalDelegationTest is GSEBase {
         Errors.Staking__InsufficientPower.selector, depositAmount, depositAmount * 2
       )
     );
-    gse.vote(0, powerToVoteSelf, true);
+    gse.vote(proposalId, powerToVoteSelf, true);
 
     // Now make the same checks but with the canonical
     powerToVoteSelf = gse.getVotingPowerAt(canonical, Timestamp.wrap(votingTime));
@@ -176,19 +207,21 @@ contract MinimalDelegationTest is GSEBase {
         Errors.Staking__InsufficientPower.selector, depositAmount * 2, depositAmount * 4
       )
     );
-    gse.voteWithCanonical(0, powerToVoteSelf, true);
+    gse.voteWithCanonical(proposalId, powerToVoteSelf, true);
 
-    // Finalise the exit. We are doing it down here because the timetravel messes with voting
-    Timestamp govUnlocks = governance.getWithdrawal(0).unlocksAt;
-    Timestamp exitAt = ROLLUP.getExit(ATTESTER2).exitableAt;
+    {
+      // Finalise the exit. We are doing it down here because the timetravel messes with voting
+      Timestamp govUnlocks = governance.getWithdrawal(0).unlocksAt;
+      Timestamp exitAt = ROLLUP.getExit(ATTESTER2).exitableAt;
 
-    if (_overwriteDelay) {
-      assertTrue(govUnlocks > exitAt, "govUnlocks > exitAt");
-    } else {
-      assertTrue(govUnlocks < exitAt, "govUnlocks < exitAt");
+      if (_overwriteDelay) {
+        assertTrue(govUnlocks > exitAt, "govUnlocks > exitAt");
+      } else {
+        assertTrue(govUnlocks < exitAt, "govUnlocks < exitAt");
+      }
+
+      vm.warp(Timestamp.unwrap(govUnlocks > exitAt ? govUnlocks : exitAt));
     }
-
-    vm.warp(Timestamp.unwrap(govUnlocks > exitAt ? govUnlocks : exitAt));
 
     if (_claim) {
       governance.finaliseWithdraw(0);
@@ -198,11 +231,8 @@ contract MinimalDelegationTest is GSEBase {
     assertEq(governance.totalPowerAt(Timestamp.wrap(block.timestamp)), depositAmount * 2);
     assertEq(stakingAsset.balanceOf(WITHDRAWER), depositAmount);
 
-    uint256 yeas = governance.getProposal(0).summedBallot.yea;
-    uint256 neas = governance.getProposal(0).summedBallot.nea;
-
-    assertEq(yeas, depositAmount * 3, "yeas");
-    assertEq(neas, 0, "neas");
+    assertEq(governance.getProposal(proposalId).summedBallot.yea, depositAmount * 3, "yeas");
+    assertEq(governance.getProposal(proposalId).summedBallot.nea, 0, "neas");
   }
 
   function _checkPowerUsed(address _delegatee, uint256 _used, uint256 _power, uint256 _votingTime)

--- a/l1-contracts/test/governance/governance-proposer/Base.t.sol
+++ b/l1-contracts/test/governance/governance-proposer/Base.t.sol
@@ -9,19 +9,24 @@ import {GovernanceProposer} from "@aztec/governance/proposer/GovernanceProposer.
 import {IPayload} from "@aztec/governance/interfaces/IPayload.sol";
 import {TestERC20} from "@aztec/mock/TestERC20.sol";
 import {IGSE} from "@aztec/core/staking/GSE.sol";
+import {IGovernance} from "@aztec/governance/interfaces/IGovernance.sol";
 
 contract FakeGovernance {
   address immutable GOVERNANCE_PROPOSER;
 
   mapping(IPayload => bool) public proposals;
+  mapping(uint256 => address) public proposalProposer;
+  uint256 public proposalCount;
 
   constructor(address _governanceProposer) {
     GOVERNANCE_PROPOSER = _governanceProposer;
   }
 
-  function propose(IPayload _proposal) external returns (bool) {
+  function propose(IPayload _proposal) external returns (uint256) {
+    uint256 id = proposalCount++;
     proposals[_proposal] = true;
-    return true;
+    proposalProposer[id] = GOVERNANCE_PROPOSER;
+    return id;
   }
 }
 

--- a/l1-contracts/test/governance/governance-proposer/executeProposal.t.sol
+++ b/l1-contracts/test/governance/governance-proposer/executeProposal.t.sol
@@ -2,13 +2,12 @@
 pragma solidity >=0.8.27;
 
 import {IPayload} from "@aztec/governance/interfaces/IPayload.sol";
-import {IGovernanceProposer} from "@aztec/governance/interfaces/IGovernanceProposer.sol";
+import {IEmpire} from "@aztec/governance/interfaces/IEmpire.sol";
 import {GovernanceProposerBase} from "./Base.t.sol";
 import {Errors} from "@aztec/governance/libraries/Errors.sol";
 import {Slot, SlotLib, Timestamp} from "@aztec/core/libraries/TimeLib.sol";
 
 import {FaultyGovernance} from "./mocks/FaultyGovernance.sol";
-import {FalsyGovernance} from "./mocks/FalsyGovernance.sol";
 import {Fakerollup} from "./mocks/Fakerollup.sol";
 import {IRollup} from "@aztec/core/interfaces/IRollup.sol";
 
@@ -256,25 +255,6 @@ contract ExecuteProposalTest is GovernanceProposerBase {
     governanceProposer.executeProposal(1);
   }
 
-  function test_GivenGovernanceCallReturnFalse(uint256 _yeas)
-    external
-    givenCanonicalInstanceHoldCode
-    whenRoundInPast
-    whenRoundInRecentPast
-    givenRoundNotExecutedBefore
-    givenLeaderIsNotAddress0
-    givenSufficientYea(_yeas)
-  {
-    // it revert
-    FalsyGovernance falsy = new FalsyGovernance();
-    vm.etch(address(governance), address(falsy).code);
-
-    vm.expectRevert(
-      abi.encodeWithSelector(Errors.GovernanceProposer__FailedToPropose.selector, proposal)
-    );
-    governanceProposer.executeProposal(1);
-  }
-
   function test_GivenGovernanceCallFails(uint256 _yeas)
     external
     givenCanonicalInstanceHoldCode
@@ -305,10 +285,11 @@ contract ExecuteProposalTest is GovernanceProposerBase {
     // it emits {ProposalExecuted} event
     // it return true
     vm.expectEmit(true, true, true, true, address(governanceProposer));
-    emit IGovernanceProposer.ProposalExecuted(proposal, 1);
+    emit IEmpire.ProposalExecuted(proposal, 1);
     assertTrue(governanceProposer.executeProposal(1));
     (, IPayload leader, bool executed) = governanceProposer.rounds(address(validatorSelection), 1);
     assertTrue(executed);
     assertEq(address(leader), address(proposal));
+    assertEq(governanceProposer.getProposalProposer(0), address(validatorSelection));
   }
 }

--- a/l1-contracts/test/governance/governance-proposer/executeProposal.tree
+++ b/l1-contracts/test/governance/governance-proposer/executeProposal.tree
@@ -19,8 +19,6 @@ ExecuteProposalTest
                     └── given sufficient yea
                         ├── given new canonical instance
                         │   └── it revert
-                        ├── given governance call return false
-                        │   └── it revert
                         ├── given governance call fails
                         │   └── it revert
                         └── given governance call succeeds

--- a/l1-contracts/test/governance/governance-proposer/mocks/FalsyGovernance.sol
+++ b/l1-contracts/test/governance/governance-proposer/mocks/FalsyGovernance.sol
@@ -1,8 +1,0 @@
-// SPDX-License-Identifier: UNLICENSED
-pragma solidity >=0.8.27;
-
-contract FalsyGovernance {
-  function propose(address) external pure returns (bool) {
-    return false;
-  }
-}

--- a/l1-contracts/test/governance/governance-proposer/vote.t.sol
+++ b/l1-contracts/test/governance/governance-proposer/vote.t.sol
@@ -2,7 +2,7 @@
 pragma solidity >=0.8.27;
 
 import {IPayload} from "@aztec/governance/interfaces/IPayload.sol";
-import {IGovernanceProposer} from "@aztec/governance/interfaces/IGovernanceProposer.sol";
+import {IEmpire} from "@aztec/governance/interfaces/IEmpire.sol";
 import {GovernanceProposerBase} from "./Base.t.sol";
 import {Errors} from "@aztec/governance/libraries/Errors.sol";
 import {Slot, SlotLib, Timestamp} from "@aztec/core/libraries/TimeLib.sol";
@@ -161,7 +161,7 @@ contract VoteTest is GovernanceProposerBase {
 
     vm.prank(proposer);
     vm.expectEmit(true, true, true, true, address(governanceProposer));
-    emit IGovernanceProposer.VoteCast(proposal, freshRound, proposer);
+    emit IEmpire.VoteCast(proposal, freshRound, proposer);
     assertTrue(governanceProposer.vote(proposal));
 
     // Check the new instance
@@ -232,7 +232,7 @@ contract VoteTest is GovernanceProposerBase {
 
     vm.prank(proposer);
     vm.expectEmit(true, true, true, true, address(governanceProposer));
-    emit IGovernanceProposer.VoteCast(proposal, round, proposer);
+    emit IEmpire.VoteCast(proposal, round, proposer);
     assertTrue(governanceProposer.vote(proposal));
 
     (Slot lastVote, IPayload leader, bool executed) =
@@ -267,7 +267,7 @@ contract VoteTest is GovernanceProposerBase {
 
     vm.prank(proposer);
     vm.expectEmit(true, true, true, true, address(governanceProposer));
-    emit IGovernanceProposer.VoteCast(IPayload(address(validatorSelection)), round, proposer);
+    emit IEmpire.VoteCast(IPayload(address(validatorSelection)), round, proposer);
     assertTrue(governanceProposer.vote(IPayload(address(validatorSelection))));
 
     (Slot lastVote, IPayload leader, bool executed) =
@@ -311,7 +311,7 @@ contract VoteTest is GovernanceProposerBase {
     for (uint256 i = 0; i < leaderYeaBefore + 1; i++) {
       vm.prank(proposer);
       vm.expectEmit(true, true, true, true, address(governanceProposer));
-      emit IGovernanceProposer.VoteCast(IPayload(address(validatorSelection)), round, proposer);
+      emit IEmpire.VoteCast(IPayload(address(validatorSelection)), round, proposer);
       assertTrue(governanceProposer.vote(IPayload(address(validatorSelection))));
 
       vm.warp(

--- a/l1-contracts/test/governance/governance-proposer/voteWithsig.t.sol
+++ b/l1-contracts/test/governance/governance-proposer/voteWithsig.t.sol
@@ -2,7 +2,7 @@
 pragma solidity >=0.8.27;
 
 import {IPayload} from "@aztec/governance/interfaces/IPayload.sol";
-import {IGovernanceProposer} from "@aztec/governance/interfaces/IGovernanceProposer.sol";
+import {IEmpire} from "@aztec/governance/interfaces/IEmpire.sol";
 import {GovernanceProposerBase} from "./Base.t.sol";
 import {Errors} from "@aztec/governance/libraries/Errors.sol";
 import {Slot, SlotLib, Timestamp} from "@aztec/core/libraries/TimeLib.sol";
@@ -164,7 +164,7 @@ contract VoteWithSigTest is GovernanceProposerBase {
 
     vm.prank(proposer);
     vm.expectEmit(true, true, true, true, address(governanceProposer));
-    emit IGovernanceProposer.VoteCast(proposal, freshRound, proposer);
+    emit IEmpire.VoteCast(proposal, freshRound, proposer);
     assertTrue(governanceProposer.vote(proposal));
 
     // Check the new instance
@@ -235,7 +235,7 @@ contract VoteWithSigTest is GovernanceProposerBase {
 
     vm.prank(proposer);
     vm.expectEmit(true, true, true, true, address(governanceProposer));
-    emit IGovernanceProposer.VoteCast(proposal, round, proposer);
+    emit IEmpire.VoteCast(proposal, round, proposer);
     assertTrue(governanceProposer.vote(proposal));
 
     (Slot lastVote, IPayload leader, bool executed) =
@@ -270,7 +270,7 @@ contract VoteWithSigTest is GovernanceProposerBase {
 
     vm.prank(proposer);
     vm.expectEmit(true, true, true, true, address(governanceProposer));
-    emit IGovernanceProposer.VoteCast(IPayload(address(validatorSelection)), round, proposer);
+    emit IEmpire.VoteCast(IPayload(address(validatorSelection)), round, proposer);
     assertTrue(governanceProposer.vote(IPayload(address(validatorSelection))));
 
     (Slot lastVote, IPayload leader, bool executed) =
@@ -314,7 +314,7 @@ contract VoteWithSigTest is GovernanceProposerBase {
     for (uint256 i = 0; i < leaderYeaBefore + 1; i++) {
       vm.prank(proposer);
       vm.expectEmit(true, true, true, true, address(governanceProposer));
-      emit IGovernanceProposer.VoteCast(IPayload(address(validatorSelection)), round, proposer);
+      emit IEmpire.VoteCast(IPayload(address(validatorSelection)), round, proposer);
       assertTrue(governanceProposer.vote(IPayload(address(validatorSelection))));
 
       vm.warp(

--- a/l1-contracts/test/governance/governance/base.t.sol
+++ b/l1-contracts/test/governance/governance/base.t.sol
@@ -50,7 +50,7 @@ contract GovernanceBase is TestBase {
     {
       CallAssetPayload payload = new CallAssetPayload(token, address(governance));
       vm.prank(address(governanceProposer));
-      assertTrue(governance.propose(payload));
+      governance.propose(payload);
 
       proposalIds["call_asset"] = governance.proposalCount() - 1;
       proposals["call_asset"] = governance.getProposal(proposalIds["call_asset"]);
@@ -59,7 +59,7 @@ contract GovernanceBase is TestBase {
     {
       UpgradePayload payload = new UpgradePayload(registry);
       vm.prank(address(governanceProposer));
-      assertTrue(governance.propose(payload));
+      governance.propose(payload);
 
       proposalIds["upgrade"] = governance.proposalCount() - 1;
       proposals["upgrade"] = governance.getProposal(proposalIds["upgrade"]);
@@ -68,7 +68,7 @@ contract GovernanceBase is TestBase {
     {
       CallRevertingPayload payload = new CallRevertingPayload();
       vm.prank(address(governanceProposer));
-      assertTrue(governance.propose(payload));
+      governance.propose(payload);
 
       proposalIds["revert"] = governance.proposalCount() - 1;
       proposals["revert"] = governance.getProposal(proposalIds["revert"]);
@@ -77,7 +77,7 @@ contract GovernanceBase is TestBase {
     {
       EmptyPayload payload = new EmptyPayload();
       vm.prank(address(governanceProposer));
-      assertTrue(governance.propose(payload));
+      governance.propose(payload);
 
       proposalIds["empty"] = governance.proposalCount() - 1;
       proposals["empty"] = governance.getProposal(proposalIds["empty"]);

--- a/l1-contracts/test/governance/governance/propose.t.sol
+++ b/l1-contracts/test/governance/governance/propose.t.sol
@@ -34,7 +34,7 @@ contract ProposeTest is GovernanceBase {
     emit IGovernance.Proposed(proposalId, _proposal);
 
     vm.prank(address(governanceProposer));
-    assertTrue(governance.propose(IPayload(_proposal)));
+    governance.propose(IPayload(_proposal));
 
     DataStructures.Proposal memory proposal = governance.getProposal(proposalId);
     assertEq(proposal.config.executionDelay, config.executionDelay);

--- a/l1-contracts/test/governance/governance/proposeWithLock.t.sol
+++ b/l1-contracts/test/governance/governance/proposeWithLock.t.sol
@@ -39,7 +39,7 @@ contract ProposeWithLockTest is GovernanceBase {
     vm.expectEmit(true, true, true, true, address(governance));
     emit IGovernance.Proposed(proposalId, _proposal);
 
-    assertTrue(governance.proposeWithLock(IPayload(_proposal), address(this)));
+    governance.proposeWithLock(IPayload(_proposal), address(this));
 
     DataStructures.Proposal memory proposal = governance.getProposal(proposalId);
     assertEq(proposal.config.executionDelay, config.executionDelay);

--- a/l1-contracts/test/governance/governance/scenarios/lockAndPass.t.sol
+++ b/l1-contracts/test/governance/governance/scenarios/lockAndPass.t.sol
@@ -35,7 +35,7 @@ contract LockAndPassTest is GovernanceBase {
     proposalId = governance.proposalCount();
     vm.expectEmit(true, true, true, true, address(governance));
     emit IGovernance.Proposed(proposalId, address(payload));
-    assertTrue(governance.proposeWithLock(IPayload(address(payload)), address(this)));
+    governance.proposeWithLock(IPayload(address(payload)), address(this));
 
     proposal = governance.getProposal(proposalId);
     assertEq(address(proposal.payload), address(payload));


### PR DESCRIPTION
Fixes #14777. 

Makes the `vote` function on the rollup more strict. Now it forces that it must also be the `Rollup` itself that made the proposal. This was added by extending the `GovernanceProposer` such that it keeps track of the `proposalId => proposer` on itself. And the governance was updated such that it is not returning the `proposalId` instead of `success` for the `propose` function.