### PR TITLE
fix: await rollup registration

### DIFF
--- a/yarn-project/ethereum/src/deploy_l1_contracts.test.ts
+++ b/yarn-project/ethereum/src/deploy_l1_contracts.test.ts
@@ -76,17 +76,19 @@ describe('deploy_l1_contracts', () => {
   it('deploys initializing validators', async () => {
     const deployed = await deploy({ initialValidators });
     const rollup = getRollup(deployed);
-    for (const validator of initialValidators) {
-      await retryUntil(
-        async () => {
-          const view = await rollup.getAttesterView(validator.attester);
-          return view.status > 0;
-        },
-        'attester is attesting',
-        DefaultL1ContractsConfig.ethereumSlotDuration * 3,
-        1,
-      );
-    }
+    await Promise.all(
+      initialValidators.map(async validator => {
+        await retryUntil(
+          async () => {
+            const view = await rollup.getAttesterView(validator.attester);
+            return view.status > 0;
+          },
+          `attester ${validator.attester} is attesting`,
+          DefaultL1ContractsConfig.ethereumSlotDuration * 3,
+          1,
+        );
+      }),
+    );
   });
 
   it('deploys with salt on different addresses', async () => {

--- a/yarn-project/ethereum/src/deploy_l1_contracts.ts
+++ b/yarn-project/ethereum/src/deploy_l1_contracts.ts
@@ -635,7 +635,8 @@ export const deployRollup = async (
       });
       logger.verbose(`Adding rollup ${rollupContract.address} to GSE ${addresses.gseAddress} in tx ${addRollupTxHash}`);
 
-      txHashes.push(addRollupTxHash);
+      // wait for this tx to land in case we have to register initialValidators
+      await extendedClient.waitForTransactionReceipt({ hash: addRollupTxHash });
     } else {
       logger.verbose(`Rollup ${rollupContract.address} is already registered in GSE ${addresses.gseAddress}`);
     }


### PR DESCRIPTION
Registering `initialValidators` is contingent on the rollup having been registered with the registry, but the tx doing that was not being awaited so it was a race condition if things would be done in the correct order.