### PR TITLE
fix: e2e boxes CI flake

### DIFF
--- a/boxes/boxes/vanilla/playwright.config.ts
+++ b/boxes/boxes/vanilla/playwright.config.ts
@@ -15,7 +15,7 @@ export default defineConfig({
     baseURL: 'http://127.0.0.1:3000',
   },
   expect: {
-    timeout: 20_000,
+    timeout: 30_000,
   },
   timeout: 400_000,
   projects: [

--- a/boxes/boxes/vanilla/tests/e2e.spec.ts
+++ b/boxes/boxes/vanilla/tests/e2e.spec.ts
@@ -1,7 +1,7 @@
 import { test, expect } from '@playwright/test';
 
 // Time take to generate a proof.
-const proofTimeout = 150_000;
+const proofTimeout = 200_000;
 
 test.beforeAll(async () => {
   // Make sure the node is running


### PR DESCRIPTION
Bringing #14755 into `next`, which has fixed the flakyness on `master`.