### PR TITLE
fix: impl of Serialize and Deserialize for BoundedVec

### DIFF
--- a/noir-projects/noir-protocol-circuits/crates/private-kernel-lib/src/components/private_call_data_validator.nr
+++ b/noir-projects/noir-protocol-circuits/crates/private-kernel-lib/src/components/private_call_data_validator.nr
@@ -159,6 +159,10 @@ impl PrivateCallDataValidator {
             public_inputs.call_context,
             "call_context does not match call request",
         );
+        // If you get this error, you've most likely made a mistake in serialization of the contract function
+        // arguments. Thoroughly check that the implementations of Serialize and Deserialize of all the function
+        // arguments follow Noir's intrinsic serialization rules (i.e. the order in the serialized array has to
+        // match the order of the struct fields in the struct body).
         assert_eq(
             request.args_hash,
             public_inputs.args_hash,

--- a/noir-projects/noir-protocol-circuits/crates/types/src/traits.nr
+++ b/noir-projects/noir-protocol-circuits/crates/types/src/traits.nr
@@ -253,14 +253,14 @@ where
     fn deserialize(fields: [Field; O * M + 1]) -> Self {
         let mut new_bounded_vec: BoundedVec<T, M> = BoundedVec::new();
 
-        let len = fields[0] as u32;
-        let mut index = 1;
+        // Length is stored in the last field as we need to match intrinsic Noir serialization and the `len` struct
+        // field is after `storage` struct field (see `bounded_vec.nr` in noir-stdlib)
+        let len = fields[O * M] as u32;
 
-        for _ in 0..len {
+        for i in 0..len {
             let mut nested_fields = [0; O];
             for j in 0..O {
-                nested_fields[j] = fields[index];
-                index += 1;
+                nested_fields[j] = fields[i * O + j];
             }
 
             let item = T::deserialize(nested_fields);
@@ -278,7 +278,6 @@ where
     #[inline_always]
     fn serialize(self) -> [Field; O * M + 1] {
         let mut fields = [0; O * M + 1];
-        fields[0] = self.len() as Field;
 
         let storage = self.storage();
 
@@ -286,9 +285,13 @@ where
             let serialized_item = storage[i].serialize();
 
             for j in 0..O {
-                fields[i * O + j + 1] = serialized_item[j];
+                fields[i * O + j] = serialized_item[j];
             }
         }
+
+        // Length is stored in the last field as we need to match intrinsic Noir serialization and the `len` struct
+        // field is after `storage` struct field (see `bounded_vec.nr` in noir-stdlib)
+        fields[O * M] = self.len() as Field;
 
         fields
     }


### PR DESCRIPTION
Implementation of Serialize and Deserialize for BoundedVec didn't match Noir's intrinsic serialization and it caused args hash mismatch in kernel. The issue was that the lenght was serialized as a first field while it should have been the last (because that's the order of the struct fields in BoundedVec).

Thanks @sirasistant for helping me spot this 🙏 
