### PR TITLE
fix: Yarn lock

### DIFF
--- a/yarn-project/yarn.lock
+++ b/yarn-project/yarn.lock
@@ -972,7 +972,7 @@ __metadata:
   resolution: "@aztec/noir-noir_codegen@portal:../noir/packages/noir_codegen::locator=%40aztec%2Faztec3-packages%40workspace%3A."
   dependencies:
     "@aztec/noir-types": "npm:1.0.0-beta.6"
-    glob: "npm:^11.0.1"
+    glob: "npm:^11.0.2"
     ts-command-line-args: "npm:^2.5.1"
   bin:
     noir-codegen: lib/main.js
@@ -981,13 +981,13 @@ __metadata:
 
 "@aztec/noir-noir_js@file:../noir/packages/noir_js::locator=%40aztec%2Faztec3-packages%40workspace%3A.":
   version: 1.0.0-beta.6
-  resolution: "@aztec/noir-noir_js@file:../noir/packages/noir_js#../noir/packages/noir_js::hash=354553&locator=%40aztec%2Faztec3-packages%40workspace%3A."
+  resolution: "@aztec/noir-noir_js@file:../noir/packages/noir_js#../noir/packages/noir_js::hash=6efb87&locator=%40aztec%2Faztec3-packages%40workspace%3A."
   dependencies:
     "@aztec/noir-acvm_js": "npm:1.0.0-beta.6"
     "@aztec/noir-noirc_abi": "npm:1.0.0-beta.6"
     "@aztec/noir-types": "npm:1.0.0-beta.6"
     pako: "npm:^2.1.0"
-  checksum: 10/7ed4c3721b60d1a88775e9f0892103164ab6de1828dca033225a48f4f1fde2e39a1b33aad66320fb9182b8aa3df146a416214443dfc657039266f1030cbc7af6
+  checksum: 10/11f477af9793d63309e2e107ce774e266257910f56511935d16cd11cf6263ecf6d95097bd7f15b7a5f83fb85a0fea3352e11172e0191fc7ce221d90e80b903f0
   languageName: node
   linkType: hard
 
@@ -13016,7 +13016,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"glob@npm:^11.0.1":
+"glob@npm:^11.0.2":
   version: 11.0.2
   resolution: "glob@npm:11.0.2"
   dependencies:


### PR DESCRIPTION
Bootstrapping yarn-project is failing with:

```
➤ YN0086: │ Some peer dependencies are incorrectly met by dependencies; run yarn explain peer-requirements for details.
➤ YN0000: │ 
➤ YN0000: │ @@ -971,24 +971,23 @@
➤ YN0000: │    version: 0.0.0-use.local
➤ YN0000: │    resolution: "@aztec/noir-noir_codegen@portal:../noir/packages/noir_codegen::locator=%40aztec%2Faztec3-packages%40workspace%3A."
➤ YN0000: │    dependencies:
➤ YN0000: │      "@aztec/noir-types": "npm:1.0.0-beta.6"
➤ YN0028: │ -    glob: "npm:^11.0.1"
➤ YN0028: │ +    glob: "npm:^11.0.2"
➤ YN0000: │      ts-command-line-args: "npm:^2.5.1"
➤ YN0000: │    bin:
➤ YN0000: │      noir-codegen: lib/main.js
➤ YN0000: │    languageName: node
➤ YN0000: │    linkType: soft
➤ YN0000: │  
➤ YN0000: │  "@aztec/noir-noir_js@file:../noir/packages/noir_js::locator=%40aztec%2Faztec3-packages%40workspace%3A.":
➤ YN0000: │    version: 1.0.0-beta.6
➤ YN0028: │ -  resolution: "@aztec/noir-noir_js@file:../noir/packages/noir_js#../noir/packages/noir_js::hash=354553&locator=%40aztec%2Faztec3-packages%40workspace%3A."
➤ YN0028: │ +  resolution: "@aztec/noir-noir_js@file:../noir/packages/noir_js#../noir/packages/noir_js::hash=6efb87&locator=%40aztec%2Faztec3-packages%40workspace%3A."
➤ YN0000: │    dependencies:
➤ YN0000: │      "@aztec/noir-acvm_js": "npm:1.0.0-beta.6"
➤ YN0000: │      "@aztec/noir-noirc_abi": "npm:1.0.0-beta.6"
➤ YN0000: │      "@aztec/noir-types": "npm:1.0.0-beta.6"
➤ YN0000: │      pako: "npm:^2.1.0"
➤ YN0028: │ -  checksum: 10/7ed4c3721b60d1a88775e9f0892103164ab6de1828dca033225a48f4f1fde2e39a1b33aad66320fb9182b8aa3df146a416214443dfc657039266f1030cbc7af6
➤ YN0000: │    languageName: node
➤ YN0000: │    linkType: hard
➤ YN0000: │  
➤ YN0000: │  "@aztec/noir-noirc_abi@portal:../noir/packages/noirc_abi::locator=%40aztec%2Faztec3-packages%40workspace%3A.":
➤ YN0000: │ @@ -13015,9 +13014,9 @@
➤ YN0000: │    checksum: 10/9e8186abc22dc824b5dd86cefd8e6b5621a72d1be7f68bacc0fd681e8c162ec5546660a6ec0553d6a74757a585e655956c7f8f1a6d24570e8d865c307323d178
➤ YN0000: │    languageName: node
➤ YN0000: │    linkType: hard
➤ YN0000: │  
➤ YN0028: │ -"glob@npm:^11.0.1":
➤ YN0028: │ +"glob@npm:^11.0.2":
➤ YN0000: │    version: 11.0.2
➤ YN0000: │    resolution: "glob@npm:11.0.2"
➤ YN0000: │    dependencies:
➤ YN0000: │      foreground-child: "npm:^3.1.0"
➤ YN0000: │ 
➤ YN0028: │ The lockfile would have been modified by this install, which is explicitly forbidden.
```