### PR TITLE
chore: avoid casting signed integers to Field directly

### DIFF
--- a/noir-projects/noir-protocol-circuits/crates/types/src/type_packing.nr
+++ b/noir-projects/noir-protocol-circuits/crates/types/src/type_packing.nr
@@ -84,41 +84,41 @@ impl Packable<FIELD_PACKED_LEN> for Field {
 
 impl Packable<I8_PACKED_LEN> for i8 {
     fn pack(self) -> [Field; I8_PACKED_LEN] {
-        [self as Field]
+        [self as u8 as Field]
     }
 
     fn unpack(fields: [Field; I8_PACKED_LEN]) -> Self {
-        fields[0] as i8
+        fields[0] as u8 as i8
     }
 }
 
 impl Packable<I16_PACKED_LEN> for i16 {
     fn pack(self) -> [Field; I16_PACKED_LEN] {
-        [self as Field]
+        [self as u16 as Field]
     }
 
     fn unpack(fields: [Field; I16_PACKED_LEN]) -> Self {
-        fields[0] as i16
+        fields[0] as u16 as i16
     }
 }
 
 impl Packable<I32_PACKED_LEN> for i32 {
     fn pack(self) -> [Field; I32_PACKED_LEN] {
-        [self as Field]
+        [self as u32 as Field]
     }
 
     fn unpack(fields: [Field; I32_PACKED_LEN]) -> Self {
-        fields[0] as i32
+        fields[0] as u32 as i32
     }
 }
 
 impl Packable<I64_PACKED_LEN> for i64 {
     fn pack(self) -> [Field; I64_PACKED_LEN] {
-        [self as Field]
+        [self as u64 as Field]
     }
 
     fn unpack(fields: [Field; I64_PACKED_LEN]) -> Self {
-        fields[0] as i64
+        fields[0] as u64 as i64
     }
 }
 

--- a/noir-projects/noir-protocol-circuits/crates/types/src/type_serialization.nr
+++ b/noir-projects/noir-protocol-circuits/crates/types/src/type_serialization.nr
@@ -98,49 +98,49 @@ impl Deserialize<FIELD_SERIALIZED_LEN> for Field {
 
 impl Serialize<I8_SERIALIZED_LEN> for i8 {
     fn serialize(self) -> [Field; I8_SERIALIZED_LEN] {
-        [self as Field]
+        [self as u8 as Field]
     }
 }
 
 impl Deserialize<I8_SERIALIZED_LEN> for i8 {
     fn deserialize(fields: [Field; I8_SERIALIZED_LEN]) -> Self {
-        fields[0] as i8
+        fields[0] as u8 as i8
     }
 }
 
 impl Serialize<I16_SERIALIZED_LEN> for i16 {
     fn serialize(self) -> [Field; I16_SERIALIZED_LEN] {
-        [self as Field]
+        [self as u16 as Field]
     }
 }
 
 impl Deserialize<I16_SERIALIZED_LEN> for i16 {
     fn deserialize(fields: [Field; I16_SERIALIZED_LEN]) -> Self {
-        fields[0] as i16
+        fields[0] as u16 as i16
     }
 }
 
 impl Serialize<I32_SERIALIZED_LEN> for i32 {
     fn serialize(self) -> [Field; I32_SERIALIZED_LEN] {
-        [self as Field]
+        [self as u32 as Field]
     }
 }
 
 impl Deserialize<I32_SERIALIZED_LEN> for i32 {
     fn deserialize(fields: [Field; I32_SERIALIZED_LEN]) -> Self {
-        fields[0] as i32
+        fields[0] as u32 as i32
     }
 }
 
 impl Serialize<I64_SERIALIZED_LEN> for i64 {
     fn serialize(self) -> [Field; I64_SERIALIZED_LEN] {
-        [self as Field]
+        [self as u64 as Field]
     }
 }
 
 impl Deserialize<I64_SERIALIZED_LEN> for i64 {
     fn deserialize(fields: [Field; I64_SERIALIZED_LEN]) -> Self {
-        fields[0] as i64
+        fields[0] as u64 as i64
     }
 }
 


### PR DESCRIPTION
Do not cast between signed types and Field in Noir, to prep for https://github.com/noir-lang/noir/pull/8818 that will remove such cast.
