### PR TITLE
fix: deploying the same contract class twice at the same time

### DIFF
--- a/yarn-project/end-to-end/src/e2e_deploy_contract/deploy_method.test.ts
+++ b/yarn-project/end-to-end/src/e2e_deploy_contract/deploy_method.test.ts
@@ -113,6 +113,16 @@ describe('e2e_deploy_contract deploy method', () => {
     await expect(NoConstructorContract.deploy(wallet).prove(opts)).rejects.toThrow(/no function calls needed/i);
   });
 
+  it('succeeds in deploying the same contract class twice at the same time', async () => {
+    logger.debug(`Deploying contract with no constructor`);
+    const [contract1, contract2] = await Promise.all([
+      NoConstructorContract.deploy(wallet).send().deployed(),
+      NoConstructorContract.deploy(wallet).send().deployed(),
+    ]);
+    expect(contract1.address).toBeDefined();
+    expect(contract2.address).toBeDefined();
+  });
+
   it('publicly deploys and calls a public contract in the same batched call', async () => {
     const owner = wallet.getAddress();
     // Create a contract instance and make the PXE aware of it


### PR DESCRIPTION
Currently investigating this. The newly introduced test fails with:
![image](https://github.com/user-attachments/assets/cdcc1e4a-e647-4633-8998-c46ec87a2dd5)

There is some issue with `Aztec.js` when deploying the same contract class multiple times at the same time. Most likely some kind of nullifier collision as one of the txs gets dropped.

**Update**: The issue was with the same contract class getting registered twice.