### PR TITLE
fix: Receipt transaction hash mismatch

### DIFF
--- a/.test_patterns.yml
+++ b/.test_patterns.yml
@@ -153,10 +153,9 @@ tests:
     owners:
       - *lasse
   - regex: "src/e2e_epochs/epochs_l1_reorgs"
-    error_regex: "updates L1 to L2 messages changed due to an L1 reorg|sending signal TERM to command|Receipt transaction hash mismatch"
+    error_regex: "updates L1 to L2 messages changed due to an L1 reorg|sending signal TERM to command"
     owners:
       - *spyros
-      - *alex
   - regex: "src/e2e_epochs/epochs_empty_blocks"
     error_regex: "✕ successfully proves multiple epochs"
     owners:

--- a/.test_patterns.yml
+++ b/.test_patterns.yml
@@ -153,9 +153,10 @@ tests:
     owners:
       - *lasse
   - regex: "src/e2e_epochs/epochs_l1_reorgs"
-    error_regex: "updates L1 to L2 messages changed due to an L1 reorg|sending signal TERM to command"
+    error_regex: "updates L1 to L2 messages changed due to an L1 reorg|sending signal TERM to command|Receipt transaction hash mismatch"
     owners:
       - *spyros
+      - *alex
   - regex: "src/e2e_epochs/epochs_empty_blocks"
     error_regex: "✕ successfully proves multiple epochs"
     owners:

--- a/.test_patterns.yml
+++ b/.test_patterns.yml
@@ -152,10 +152,6 @@ tests:
     error_regex: "✕ Repay"
     owners:
       - *lasse
-  - regex: "src/e2e_epochs/epochs_l1_reorgs"
-    error_regex: "updates L1 to L2 messages changed due to an L1 reorg|sending signal TERM to command"
-    owners:
-      - *spyros
   - regex: "src/e2e_epochs/epochs_empty_blocks"
     error_regex: "✕ successfully proves multiple epochs"
     owners:

--- a/yarn-project/aztec-node/src/aztec-node/server.ts
+++ b/yarn-project/aztec-node/src/aztec-node/server.ts
@@ -121,8 +121,6 @@ export class AztecNodeService implements AztecNode, AztecNodeAdmin, Traceable {
   // Serial queue to ensure that we only send one tx at a time
   private txQueue: SerialQueue = new SerialQueue();
 
-  private provenBlockNumberInterval: NodeJS.Timeout;
-
   public readonly tracer: Tracer;
 
   constructor(
@@ -151,10 +149,6 @@ export class AztecNodeService implements AztecNode, AztecNodeAdmin, Traceable {
 
     this.log.info(`Aztec Node version: ${this.packageVersion}`);
     this.log.info(`Aztec Node started on chain 0x${l1ChainId.toString(16)}`, config.l1Contracts);
-
-    this.provenBlockNumberInterval = setInterval(() => {
-      void this.getProvenBlockNumber().then(b => this.log.info(`proven block number: ${b}`));
-    }, 100);
   }
 
   public async getWorldStateSyncStatus(): Promise<WorldStateSyncStatus> {
@@ -617,7 +611,6 @@ export class AztecNodeService implements AztecNode, AztecNodeAdmin, Traceable {
    * Method to stop the aztec node.
    */
   public async stop() {
-    clearInterval(this.provenBlockNumberInterval);
     this.log.info(`Stopping Aztec Node`);
     await this.txQueue.end();
     await tryStop(this.validatorsSentinel);

--- a/yarn-project/aztec-node/src/aztec-node/server.ts
+++ b/yarn-project/aztec-node/src/aztec-node/server.ts
@@ -121,6 +121,8 @@ export class AztecNodeService implements AztecNode, AztecNodeAdmin, Traceable {
   // Serial queue to ensure that we only send one tx at a time
   private txQueue: SerialQueue = new SerialQueue();
 
+  private provenBlockNumberInterval: NodeJS.Timeout;
+
   public readonly tracer: Tracer;
 
   constructor(
@@ -149,6 +151,10 @@ export class AztecNodeService implements AztecNode, AztecNodeAdmin, Traceable {
 
     this.log.info(`Aztec Node version: ${this.packageVersion}`);
     this.log.info(`Aztec Node started on chain 0x${l1ChainId.toString(16)}`, config.l1Contracts);
+
+    this.provenBlockNumberInterval = setInterval(() => {
+      void this.getProvenBlockNumber().then(b => this.log.info(`proven block number: ${b}`));
+    }, 100);
   }
 
   public async getWorldStateSyncStatus(): Promise<WorldStateSyncStatus> {
@@ -611,6 +617,7 @@ export class AztecNodeService implements AztecNode, AztecNodeAdmin, Traceable {
    * Method to stop the aztec node.
    */
   public async stop() {
+    clearInterval(this.provenBlockNumberInterval);
     this.log.info(`Stopping Aztec Node`);
     await this.txQueue.end();
     await tryStop(this.validatorsSentinel);

--- a/yarn-project/end-to-end/src/e2e_epochs/epochs_l1_reorgs.test.ts
+++ b/yarn-project/end-to-end/src/e2e_epochs/epochs_l1_reorgs.test.ts
@@ -72,7 +72,7 @@ describe('e2e_epochs/epochs_l1_reorgs', () => {
   it('prunes L2 blocks if a proof is removed due to an L1 reorg', async () => {
     // Wait until we have proven something and the nodes have caught up
     logger.warn(`Waiting for initial proof to land`);
-    const provenBlockEvent = await executeTimeout(async signal => {
+    const provenBlockEvent = await executeTimeout(signal => {
       return new Promise<{ l2ProvenBlockNumber: number; l1BlockNumber: number }>((res, rej) => {
         const handleMsg = (...[ev]: ChainMonitorEventMap['l2-block-proven']) => {
           res(ev);

--- a/yarn-project/end-to-end/src/e2e_epochs/epochs_l1_reorgs.test.ts
+++ b/yarn-project/end-to-end/src/e2e_epochs/epochs_l1_reorgs.test.ts
@@ -107,7 +107,7 @@ describe('e2e_epochs/epochs_l1_reorgs', () => {
     await newNode.stop();
   });
 
-  it.only('does not prune if a second proof lands within the submission window after the first one is reorged out', async () => {
+  it('does not prune if a second proof lands within the submission window after the first one is reorged out', async () => {
     // Wait until we have proven something and the nodes have caught up
     logger.warn(`Waiting for initial proof to land`);
     const provenBlock = await test.waitUntilProvenL2BlockNumber(1);

--- a/yarn-project/end-to-end/src/e2e_epochs/epochs_l1_reorgs.test.ts
+++ b/yarn-project/end-to-end/src/e2e_epochs/epochs_l1_reorgs.test.ts
@@ -36,7 +36,7 @@ describe('e2e_epochs/epochs_l1_reorgs', () => {
 
   let test: EpochsTestContext;
 
-  let l1ClientForMesssages: ExtendedViemWalletClient;
+  let l1ClientForMessages: ExtendedViemWalletClient;
 
   beforeEach(async () => {
     test = await EpochsTestContext.setup({
@@ -50,14 +50,14 @@ describe('e2e_epochs/epochs_l1_reorgs', () => {
     proverNode = context.proverNode!;
 
     const account = privateKeyToAccount(generatePrivateKey());
-    l1ClientForMesssages = createExtendedL1Client(
+    l1ClientForMessages = createExtendedL1Client(
       [...test.l1Client.chain.rpcUrls.default.http],
       account,
       test.l1Client.chain,
     );
 
     const fundingTx = await test.l1Client.sendTransaction({
-      to: l1ClientForMesssages.account.address,
+      to: l1ClientForMessages.account.address,
       value: BigInt(1e16),
     });
 
@@ -255,7 +255,7 @@ describe('e2e_epochs/epochs_l1_reorgs', () => {
       sendL1ToL2Message(
         { recipient: await AztecAddress.random(), content: Fr.random(), secretHash: Fr.random() },
         {
-          l1Client: l1ClientForMesssages,
+          l1Client: l1ClientForMessages,
           l1ContractAddresses: context.deployL1ContractsValues.l1ContractAddresses,
         },
       );

--- a/yarn-project/end-to-end/src/e2e_epochs/epochs_l1_reorgs.test.ts
+++ b/yarn-project/end-to-end/src/e2e_epochs/epochs_l1_reorgs.test.ts
@@ -57,12 +57,17 @@ describe('e2e_epochs/epochs_l1_reorgs', () => {
       test.l1Client.chain,
     );
 
-    const fundingTx = await test.l1Client.sendTransaction({
-      to: l1ClientForMessages.account.address,
-      value: BigInt(1e16),
-    });
+    while (true) {
+      const fundingTx = await test.l1Client.sendTransaction({
+        to: l1ClientForMessages.account.address,
+        value: BigInt(1e18),
+      });
 
-    await test.l1Client.waitForTransactionReceipt({ hash: fundingTx });
+      const receipt = await test.l1Client.waitForTransactionReceipt({ hash: fundingTx });
+      if (receipt.transactionHash === fundingTx && receipt.status === 'success') {
+        break;
+      }
+    }
   });
 
   afterEach(async () => {

--- a/yarn-project/end-to-end/src/e2e_epochs/epochs_l1_reorgs.test.ts
+++ b/yarn-project/end-to-end/src/e2e_epochs/epochs_l1_reorgs.test.ts
@@ -65,7 +65,6 @@ describe('e2e_epochs/epochs_l1_reorgs', () => {
   });
 
   afterEach(async () => {
-    await context.cheatCodes.eth.setIntervalMining(0);
     await test.teardown();
   });
 

--- a/yarn-project/end-to-end/src/e2e_epochs/epochs_l1_reorgs.test.ts
+++ b/yarn-project/end-to-end/src/e2e_epochs/epochs_l1_reorgs.test.ts
@@ -107,37 +107,33 @@ describe('e2e_epochs/epochs_l1_reorgs', () => {
     await newNode.stop();
   });
 
-  it,
-    only(
-      'does not prune if a second proof lands within the submission window after the first one is reorged out',
-      async () => {
-        // Wait until we have proven something and the nodes have caught up
-        logger.warn(`Waiting for initial proof to land`);
-        const provenBlock = await test.waitUntilProvenL2BlockNumber(1);
-        await retryUntil(() => node.getProvenBlockNumber().then(p => p >= provenBlock), 'node sync', 10, 0.1);
+  it.only('does not prune if a second proof lands within the submission window after the first one is reorged out', async () => {
+    // Wait until we have proven something and the nodes have caught up
+    logger.warn(`Waiting for initial proof to land`);
+    const provenBlock = await test.waitUntilProvenL2BlockNumber(1);
+    await retryUntil(() => node.getProvenBlockNumber().then(p => p >= provenBlock), 'node sync', 10, 0.1);
 
-        // Remove the proof from L1 but do not change the block number
-        await context.cheatCodes.eth.reorgWithReplacement(1);
-        await expect(monitor.run(true).then(m => m.l2ProvenBlockNumber)).resolves.toEqual(0);
+    // Remove the proof from L1 but do not change the block number
+    await context.cheatCodes.eth.reorgWithReplacement(1);
+    await expect(monitor.run(true).then(m => m.l2ProvenBlockNumber)).resolves.toEqual(0);
 
-        // Create another prover node so it submits a proof
-        await test.createProverNode();
+    // Create another prover node so it submits a proof
+    await test.createProverNode();
 
-        // Wait until the end of the proof submission window for the first epoch
-        await test.waitUntilEndOfProofSubmissionWindow(0);
+    // Wait until the end of the proof submission window for the first epoch
+    await test.waitUntilEndOfProofSubmissionWindow(0);
 
-        // And expect that the other node has submitted a proof
-        await expect(monitor.run(true).then(m => m.l2ProvenBlockNumber)).resolves.toBeGreaterThanOrEqual(1);
+    // And expect that the other node has submitted a proof
+    await expect(monitor.run(true).then(m => m.l2ProvenBlockNumber)).resolves.toBeGreaterThanOrEqual(1);
 
-        // Check that the node has followed along
-        logger.warn(`Testing old node`);
-        const currentBlock = monitor.l2BlockNumber;
-        expect(await node.getProvenBlockNumber()).toBeGreaterThanOrEqual(1);
-        expect(await node.getBlockNumber()).toBeWithin(currentBlock - 1, currentBlock + 1);
+    // Check that the node has followed along
+    logger.warn(`Testing old node`);
+    const currentBlock = monitor.l2BlockNumber;
+    expect(await node.getProvenBlockNumber()).toBeGreaterThanOrEqual(1);
+    expect(await node.getBlockNumber()).toBeWithin(currentBlock - 1, currentBlock + 1);
 
-        logger.warn(`Test succeeded`);
-      },
-    );
+    logger.warn(`Test succeeded`);
+  });
 
   it('restores L2 blocks if a proof is added due to an L1 reorg', async () => {
     // Next proof shall not land

--- a/yarn-project/end-to-end/src/e2e_epochs/epochs_l1_reorgs.test.ts
+++ b/yarn-project/end-to-end/src/e2e_epochs/epochs_l1_reorgs.test.ts
@@ -12,7 +12,7 @@ import type { ProverNode } from '@aztec/prover-node';
 
 import { jest } from '@jest/globals';
 import 'jest-extended';
-import { createWalletClient, formatEther, keccak256, parseTransaction } from 'viem';
+import { keccak256, parseTransaction } from 'viem';
 import { generatePrivateKey, privateKeyToAccount } from 'viem/accounts';
 
 import { sendL1ToL2Message } from '../fixtures/l1_to_l2_messaging.js';

--- a/yarn-project/end-to-end/src/e2e_epochs/epochs_test.ts
+++ b/yarn-project/end-to-end/src/e2e_epochs/epochs_test.ts
@@ -9,7 +9,7 @@ import {
   retryUntil,
   sleep,
 } from '@aztec/aztec.js';
-import type { ViemClient } from '@aztec/ethereum';
+import type { ExtendedViemWalletClient } from '@aztec/ethereum';
 import { RollupContract } from '@aztec/ethereum/contracts';
 import { ChainMonitor, DelayedTxUtils, type Delayer, waitUntilL1Timestamp } from '@aztec/ethereum/test';
 import { randomBytes } from '@aztec/foundation/crypto';
@@ -64,7 +64,7 @@ export type EpochsTestOpts = Partial<
  */
 export class EpochsTestContext {
   public context!: EndToEndContext;
-  public l1Client!: ViemClient;
+  public l1Client!: ExtendedViemWalletClient;
   public rollup!: RollupContract;
   public constants!: L1RollupConstants;
   public logger!: Logger;

--- a/yarn-project/end-to-end/src/fixtures/l1_to_l2_messaging.ts
+++ b/yarn-project/end-to-end/src/fixtures/l1_to_l2_messaging.ts
@@ -37,7 +37,7 @@ export async function sendL1ToL2Message(
   // We check that the message was correctly injected by checking the emitted event
   const txReceipt = await ctx.l1Client.waitForTransactionReceipt({ hash: txHash });
 
-  logger.info(`L1 to L2 message receipt retried for tx ${txReceipt.transactionHash}`);
+  logger.info(`L1 to L2 message receipt retrived for tx ${txReceipt.transactionHash}`);
 
   if (txReceipt.transactionHash !== txHash) {
     throw new Error(`Receipt transaction hash mismatch: ${txReceipt.transactionHash} !== ${txHash}`);

--- a/yarn-project/end-to-end/src/fixtures/l1_to_l2_messaging.ts
+++ b/yarn-project/end-to-end/src/fixtures/l1_to_l2_messaging.ts
@@ -42,7 +42,7 @@ export async function sendL1ToL2Message(
     throw new Error(`L1 to L2 message failed to be sent in tx ${txHash}. Status: ${txReceipt.status}`);
   }
 
-  logger.info(`L1 to L2 message receipt retrieved for tx ${txReceipt.transactionHash}`);
+  logger.info(`L1 to L2 message receipt retrieved for tx ${txReceipt.transactionHash}`, txReceipt);
 
   if (txReceipt.transactionHash !== txHash) {
     throw new Error(`Receipt transaction hash mismatch: ${txReceipt.transactionHash} !== ${txHash}`);

--- a/yarn-project/end-to-end/src/fixtures/l1_to_l2_messaging.ts
+++ b/yarn-project/end-to-end/src/fixtures/l1_to_l2_messaging.ts
@@ -38,6 +38,10 @@ export async function sendL1ToL2Message(
   // We check that the message was correctly injected by checking the emitted event
   const txReceipt = await ctx.l1Client.waitForTransactionReceipt({ hash: txHash });
 
+  if (txReceipt.status !== 'success') {
+    throw new Error(`L1 to L2 message failed to be sent in tx ${txHash}. Status: ${txReceipt.status}`);
+  }
+
   logger.info(`L1 to L2 message receipt retrieved for tx ${txReceipt.transactionHash}`);
 
   if (txReceipt.transactionHash !== txHash) {

--- a/yarn-project/end-to-end/src/fixtures/l1_to_l2_messaging.ts
+++ b/yarn-project/end-to-end/src/fixtures/l1_to_l2_messaging.ts
@@ -37,7 +37,7 @@ export async function sendL1ToL2Message(
   // We check that the message was correctly injected by checking the emitted event
   const txReceipt = await ctx.l1Client.waitForTransactionReceipt({ hash: txHash });
 
-  logger.info(`L1 to L2 message receipt retrived for tx ${txReceipt.transactionHash}`);
+  logger.info(`L1 to L2 message receipt retrieved for tx ${txReceipt.transactionHash}`);
 
   if (txReceipt.transactionHash !== txHash) {
     throw new Error(`Receipt transaction hash mismatch: ${txReceipt.transactionHash} !== ${txHash}`);

--- a/yarn-project/end-to-end/src/fixtures/l1_to_l2_messaging.ts
+++ b/yarn-project/end-to-end/src/fixtures/l1_to_l2_messaging.ts
@@ -27,11 +27,12 @@ export async function sendL1ToL2Message(
   const version = await new RollupContract(ctx.l1Client, ctx.l1ContractAddresses.rollupAddress.toString()).getVersion();
 
   // We inject the message to Inbox
-  const txHash = await inbox.write.sendL2Message([
-    { actor: recipient.toString(), version: BigInt(version) },
-    content.toString(),
-    secretHash.toString(),
-  ]);
+  const txHash = await inbox.write.sendL2Message(
+    [{ actor: recipient.toString(), version: BigInt(version) }, content.toString(), secretHash.toString()],
+    {
+      gas: 1_000_000n,
+    },
+  );
   logger.info(`L1 to L2 message sent in tx ${txHash}`);
 
   // We check that the message was correctly injected by checking the emitted event

--- a/yarn-project/end-to-end/src/fixtures/utils.ts
+++ b/yarn-project/end-to-end/src/fixtures/utils.ts
@@ -84,10 +84,9 @@ import fs from 'fs/promises';
 import getPort from 'get-port';
 import { tmpdir } from 'os';
 import * as path from 'path';
-import { type Chain, type HDAccount, type Hex, type PrivateKeyAccount, createNonceManager, getContract } from 'viem';
+import { type Chain, type HDAccount, type Hex, type PrivateKeyAccount, getContract } from 'viem';
 import { mnemonicToAccount, privateKeyToAccount } from 'viem/accounts';
 import { foundry } from 'viem/chains';
-import { jsonRpc } from 'viem/nonce';
 
 import { MNEMONIC, TEST_PEER_CHECK_INTERVAL_MS } from './fixtures.js';
 import { getACVMConfig } from './get_acvm_config.js';
@@ -419,16 +418,11 @@ export async function setup(
     let publisherHdAccount = undefined;
 
     if (config.publisherPrivateKey && config.publisherPrivateKey != NULL_KEY) {
-      publisherHdAccount = privateKeyToAccount(config.publisherPrivateKey, {
-        nonceManager: createNonceManager({ source: jsonRpc() }),
-      });
+      publisherHdAccount = privateKeyToAccount(config.publisherPrivateKey);
     } else if (!MNEMONIC) {
       throw new Error(`Mnemonic not provided and no publisher private key`);
     } else {
-      publisherHdAccount = mnemonicToAccount(MNEMONIC, {
-        addressIndex: 0,
-        nonceManager: createNonceManager({ source: jsonRpc() }),
-      });
+      publisherHdAccount = mnemonicToAccount(MNEMONIC, { addressIndex: 0 });
       const publisherPrivKeyRaw = publisherHdAccount.getHdKey().privateKey;
       publisherPrivKey = publisherPrivKeyRaw === null ? null : Buffer.from(publisherPrivKeyRaw);
       config.publisherPrivateKey = `0x${publisherPrivKey!.toString('hex')}`;

--- a/yarn-project/end-to-end/src/fixtures/utils.ts
+++ b/yarn-project/end-to-end/src/fixtures/utils.ts
@@ -84,9 +84,10 @@ import fs from 'fs/promises';
 import getPort from 'get-port';
 import { tmpdir } from 'os';
 import * as path from 'path';
-import { type Chain, type HDAccount, type Hex, type PrivateKeyAccount, getContract } from 'viem';
+import { type Chain, type HDAccount, type Hex, type PrivateKeyAccount, createNonceManager, getContract } from 'viem';
 import { mnemonicToAccount, privateKeyToAccount } from 'viem/accounts';
 import { foundry } from 'viem/chains';
+import { jsonRpc } from 'viem/nonce';
 
 import { MNEMONIC, TEST_PEER_CHECK_INTERVAL_MS } from './fixtures.js';
 import { getACVMConfig } from './get_acvm_config.js';
@@ -418,11 +419,16 @@ export async function setup(
     let publisherHdAccount = undefined;
 
     if (config.publisherPrivateKey && config.publisherPrivateKey != NULL_KEY) {
-      publisherHdAccount = privateKeyToAccount(config.publisherPrivateKey);
+      publisherHdAccount = privateKeyToAccount(config.publisherPrivateKey, {
+        nonceManager: createNonceManager({ source: jsonRpc() }),
+      });
     } else if (!MNEMONIC) {
       throw new Error(`Mnemonic not provided and no publisher private key`);
     } else {
-      publisherHdAccount = mnemonicToAccount(MNEMONIC, { addressIndex: 0 });
+      publisherHdAccount = mnemonicToAccount(MNEMONIC, {
+        addressIndex: 0,
+        nonceManager: createNonceManager({ source: jsonRpc() }),
+      });
       const publisherPrivKeyRaw = publisherHdAccount.getHdKey().privateKey;
       publisherPrivKey = publisherPrivKeyRaw === null ? null : Buffer.from(publisherPrivKeyRaw);
       config.publisherPrivateKey = `0x${publisherPrivKey!.toString('hex')}`;

--- a/yarn-project/end-to-end/src/fixtures/utils.ts
+++ b/yarn-project/end-to-end/src/fixtures/utils.ts
@@ -560,7 +560,7 @@ export async function setup(
     config.p2pIp = opts.p2pIp ?? config.p2pIp ?? '127.0.0.1';
     const aztecNode = await AztecNodeService.createAndSync(
       config, // REFACTOR: createAndSync mutates this config
-      { dateProvider, blobSinkClient, telemetry, p2pClientDeps },
+      { dateProvider, blobSinkClient, telemetry, p2pClientDeps, logger: createLogger('node:MAIN-aztec-node') },
       { prefilledPublicData },
     );
     const sequencer = aztecNode.getSequencer();

--- a/yarn-project/ethereum/src/eth_cheat_codes.ts
+++ b/yarn-project/ethereum/src/eth_cheat_codes.ts
@@ -362,7 +362,7 @@ export class EthCheatCodes {
    * Triggers a reorg of the given depth, removing those blocks from the chain.
    * @param depth - The depth of the reorg
    */
-  public async reorg(depth: number): Promise<void> {
+  public reorg(depth: number): Promise<void> {
     return this.execWithPausedAnvil(() => {
       return this.rpcCall('anvil_rollback', [depth]);
     });
@@ -372,7 +372,7 @@ export class EthCheatCodes {
    * Causes Anvil to reorg until the given block number is the new tip
    * @param blockNumber - The block number that's going to be the new tip
    */
-  public async reorgTo(blockNumber: number): Promise<void> {
+  public reorgTo(blockNumber: number): Promise<void> {
     if (blockNumber <= 0) {
       throw new Error(`Can't reorg to block before genesis: ${blockNumber}`);
     }

--- a/yarn-project/ethereum/src/eth_cheat_codes.ts
+++ b/yarn-project/ethereum/src/eth_cheat_codes.ts
@@ -364,7 +364,20 @@ export class EthCheatCodes {
    */
   public async reorg(depth: number): Promise<void> {
     try {
+      const wasAutoMining = await this.isAutoMining();
+
+      // disable mining
+      if (wasAutoMining) {
+        await this.setAutomine(false);
+      }
+
+      // reorg
       await this.rpcCall('anvil_rollback', [depth]);
+
+      // restore automine if necessary
+      if (wasAutoMining) {
+        await this.setAutomine(true);
+      }
     } catch (err) {
       throw new Error(`Error rolling back: ${err}`);
     }

--- a/yarn-project/ethereum/src/eth_cheat_codes.ts
+++ b/yarn-project/ethereum/src/eth_cheat_codes.ts
@@ -349,6 +349,16 @@ export class EthCheatCodes {
   }
 
   /**
+   * Get the trace for a given transaction hash
+   * @param txHash - The transaction hash
+   * @returns The trace
+   */
+  public async debugTraceTransaction(txHash: Hex): Promise<any> {
+    const res = await this.rpcCall('debug_traceTransaction', [txHash]);
+    return res;
+  }
+
+  /**
    * Triggers a reorg of the given depth, removing those blocks from the chain.
    * @param depth - The depth of the reorg
    */

--- a/yarn-project/ethereum/src/test/chain_monitor.ts
+++ b/yarn-project/ethereum/src/test/chain_monitor.ts
@@ -6,8 +6,15 @@ import { EventEmitter } from 'events';
 
 import type { ViemClient } from '../types.js';
 
+export type ChainMonitorEventMap = {
+  'l1-block': [{ l1BlockNumber: number; timestamp: bigint }];
+  'l2-block': [{ l2BlockNumber: number; l1BlockNumber: number; timestamp: bigint }];
+  'l2-block-proven': [{ l2ProvenBlockNumber: number; l1BlockNumber: number; timestamp: bigint }];
+  'l2-messages': [{ totalL2Messages: number; l1BlockNumber: number }];
+};
+
 /** Utility class that polls the chain on quick intervals and logs new L1 blocks, L2 blocks, and L2 proofs. */
-export class ChainMonitor extends EventEmitter {
+export class ChainMonitor extends EventEmitter<ChainMonitorEventMap> {
   private readonly l1Client: ViemClient;
   private inbox: InboxContract | undefined;
   private handle: NodeJS.Timeout | undefined;

--- a/yarn-project/prover-client/src/proving_broker/proving_broker.ts
+++ b/yarn-project/prover-client/src/proving_broker/proving_broker.ts
@@ -2,16 +2,17 @@ import { createLogger } from '@aztec/foundation/log';
 import { type PromiseWithResolvers, RunningPromise, promiseWithResolvers } from '@aztec/foundation/promise';
 import { PriorityMemoryQueue } from '@aztec/foundation/queue';
 import { Timer } from '@aztec/foundation/timer';
-import type {
-  GetProvingJobResponse,
-  ProofUri,
-  ProvingJob,
-  ProvingJobConsumer,
-  ProvingJobFilter,
-  ProvingJobId,
-  ProvingJobProducer,
-  ProvingJobSettledResult,
-  ProvingJobStatus,
+import {
+  type GetProvingJobResponse,
+  type ProofUri,
+  type ProvingJob,
+  type ProvingJobConsumer,
+  type ProvingJobFilter,
+  type ProvingJobId,
+  type ProvingJobProducer,
+  type ProvingJobSettledResult,
+  type ProvingJobStatus,
+  tryStop,
 } from '@aztec/stdlib/interfaces/server';
 import { ProvingRequestType } from '@aztec/stdlib/proofs';
 import {
@@ -184,7 +185,7 @@ export class ProvingBroker implements ProvingJobProducer, ProvingJobConsumer, Tr
       this.logger.warn('ProvingBroker not started');
       return Promise.resolve();
     }
-    await this.cleanupPromise.stop();
+    await tryStop(this.cleanupPromise);
   }
 
   public enqueueProvingJob(job: ProvingJob): Promise<ProvingJobStatus> {


### PR DESCRIPTION
viem would get confused if two txs with the same nonce landed in the mempool at the same time. This could happen is a tx to send an L1 to L2 message and a tx to publish a block were at the same time in the mempool.

I first tried using a nonce manager but due to this test causing reorgs on purpose the nonce got out of synch. I think the solution of just using a separate account is better 

follow-up: https://github.com/AztecProtocol/aztec-packages/issues/14954