### PR TITLE
fix: box flake regex

### DIFF
--- a/.test_patterns.yml
+++ b/.test_patterns.yml
@@ -216,7 +216,7 @@ tests:
     owners:
       - *sean
   - regex: "p2p/src/services/reqresp/reqresp.test.ts"
-    x: "✕ should stop after max retry attempts"
+    error_regex: "✕ should stop after max retry attempts"
     owners:
       - *sean
   - regex: "p2p/src/client/p2p_client.integration.test.ts" # http://ci.aztec-labs.com/31c4c9821b1a533c

--- a/.test_patterns.yml
+++ b/.test_patterns.yml
@@ -216,7 +216,7 @@ tests:
     owners:
       - *sean
   - regex: "p2p/src/services/reqresp/reqresp.test.ts"
-    error_regex: "✕ should stop after max retry attempts"
+    x: "✕ should stop after max retry attempts"
     owners:
       - *sean
   - regex: "p2p/src/client/p2p_client.integration.test.ts" # http://ci.aztec-labs.com/31c4c9821b1a533c
@@ -274,7 +274,12 @@ tests:
 
   # boxes
   - regex: "boxes/boxes/vanilla/tests/e2e.spec.ts"
-    error_regex: "Error: Timed out 20000ms waiting for expect(locator).toHaveText(expected)"
+    error_regex: "Error: Timed out \d*ms waiting for expect\(locator\)"
+    owners:
+      - *saleel
+
+  - regex: "tests/browser.spec.ts"
+    error_regex: "Error: locator\.click: Test timeout of"
     owners:
       - *saleel
 

--- a/.test_patterns.yml
+++ b/.test_patterns.yml
@@ -274,12 +274,12 @@ tests:
 
   # boxes
   - regex: "boxes/boxes/vanilla/tests/e2e.spec.ts"
-    error_regex: "Error: Timed out \d*ms waiting for expect\(locator\)"
+    error_regex: "Error: Timed out \\d*ms waiting for expect\\(locator\\)"
     owners:
       - *saleel
 
   - regex: "tests/browser.spec.ts"
-    error_regex: "Error: locator\.click: Test timeout of"
+    error_regex: "Error: locator\\.click: Test timeout of"
     owners:
       - *saleel
 


### PR DESCRIPTION
The regex from https://github.com/AztecProtocol/aztec-packages/pull/14727 hardcoded a timeout duration, so the timeout increase in https://github.com/AztecProtocol/aztec-packages/pull/14827 broke it. I Added a second flake entry for `browser.spec.ts`, which is also timing out.