### PR TITLE
chore: Monitor sequencer is behaving properly

### DIFF
--- a/.test_patterns.yml
+++ b/.test_patterns.yml
@@ -185,6 +185,10 @@ tests:
     error_regex: "✕ should attest ONLY with the correct validator keys"
     owners:
       - *spyros
+  - regex: "src/e2e_epochs/epochs_monitor_block_building.test.ts"
+    error_regex: "Failed events from sequencers"
+    owners:
+      - *palla
 
   # yarn-project tests
   - regex: "p2p/src/services/discv5/discv5_service.test.ts"

--- a/yarn-project/aztec-node/src/sentinel/sentinel.test.ts
+++ b/yarn-project/aztec-node/src/sentinel/sentinel.test.ts
@@ -80,7 +80,7 @@ describe('sentinel', () => {
       proofSubmissionWindow: 16,
     };
 
-    epochCache.getEpochAndSlotNow.mockReturnValue({ epoch, slot, ts });
+    epochCache.getEpochAndSlotNow.mockReturnValue({ epoch, slot, ts, now: ts });
     epochCache.getL1Constants.mockReturnValue(l1Constants);
 
     sentinel = new TestSentinel(epochCache, archiver, p2p, store, config, blockStream);
@@ -249,7 +249,7 @@ describe('sentinel', () => {
         return header;
       });
 
-      epochCache.getEpochAndSlotNow.mockReturnValue({ epoch: epochNumber, slot, ts });
+      epochCache.getEpochAndSlotNow.mockReturnValue({ epoch: epochNumber, slot, ts, now: ts });
       archiver.getBlock.calledWith(blockNumber).mockResolvedValue(mockBlock.block);
       archiver.getL1Constants.mockResolvedValue(l1Constants);
 

--- a/yarn-project/aztec.js/src/test/rollup_cheat_codes.ts
+++ b/yarn-project/aztec.js/src/test/rollup_cheat_codes.ts
@@ -3,6 +3,7 @@ import { EthCheatCodes } from '@aztec/ethereum/eth-cheatcodes';
 import type { L1ContractAddresses } from '@aztec/ethereum/l1-contract-addresses';
 import { EthAddress } from '@aztec/foundation/eth-address';
 import { createLogger } from '@aztec/foundation/log';
+import type { TestDateProvider } from '@aztec/foundation/timer';
 import { RollupAbi } from '@aztec/l1-artifacts/RollupAbi';
 
 import { type GetContractReturnType, type Hex, createPublicClient, fallback, getContract, http, keccak256 } from 'viem';
@@ -94,15 +95,24 @@ export class RollupCheatCodes {
   /**
    * Advances time to the beginning of the given epoch
    * @param epoch - The epoch to advance to
+   * @param opts - Options
    */
-  public async advanceToEpoch(epoch: bigint) {
+  public async advanceToEpoch(
+    epoch: bigint,
+    opts: {
+      /** Whether to reset the L1 block interval so the next block is mined L1-block-time after thie call */
+      resetBlockInterval?: boolean;
+      /** Optional test date provider to update with the epoch timestamp */
+      updateDateProvider?: TestDateProvider;
+    } = {},
+  ) {
     const { epochDuration: slotsInEpoch } = await this.getConfig();
     const timestamp = await this.rollup.read.getTimestampForSlot([epoch * slotsInEpoch]);
     try {
-      await this.ethCheatCodes.warp(Number(timestamp));
+      await this.ethCheatCodes.warp(Number(timestamp), opts);
       this.logger.warn(`Warped to epoch ${epoch}`);
-    } catch {
-      this.logger.debug('Warp failed, time already satisfied');
+    } catch (err) {
+      this.logger.warn(`Warp to epoch ${epoch} failed: ${err}`);
     }
     return timestamp;
   }
@@ -114,7 +124,7 @@ export class RollupCheatCodes {
     const slotsUntilNextEpoch = epochDuration - (slot % epochDuration) + 1n;
     const timeToNextEpoch = slotsUntilNextEpoch * slotDuration;
     const l1Timestamp = BigInt((await this.client.getBlock()).timestamp);
-    await this.ethCheatCodes.warp(Number(l1Timestamp + timeToNextEpoch), true);
+    await this.ethCheatCodes.warp(Number(l1Timestamp + timeToNextEpoch), { silent: true });
     this.logger.warn(`Advanced to next epoch`);
   }
 
@@ -135,7 +145,7 @@ export class RollupCheatCodes {
     const l1Timestamp = (await this.client.getBlock()).timestamp;
     const slotDuration = await this.rollup.read.getSlotDuration();
     const timeToWarp = BigInt(howMany) * slotDuration;
-    await this.ethCheatCodes.warp(l1Timestamp + timeToWarp, true);
+    await this.ethCheatCodes.warp(l1Timestamp + timeToWarp, { silent: true });
     const [slot, epoch] = await Promise.all([this.getSlot(), this.getEpoch()]);
     this.logger.warn(`Advanced ${howMany} slots up to slot ${slot} in epoch ${epoch}`);
   }

--- a/yarn-project/end-to-end/src/e2e_epochs/epochs_monitor_block_building.test.ts
+++ b/yarn-project/end-to-end/src/e2e_epochs/epochs_monitor_block_building.test.ts
@@ -1,0 +1,136 @@
+import type { AztecNodeService } from '@aztec/aztec-node';
+import { EthAddress, type Logger } from '@aztec/aztec.js';
+import type { CheatCodes } from '@aztec/aztec.js/testing';
+import type { Operator } from '@aztec/ethereum';
+import { asyncMap } from '@aztec/foundation/async-map';
+import { times, timesAsync } from '@aztec/foundation/collection';
+import { bufferToHex } from '@aztec/foundation/string';
+import { executeTimeout } from '@aztec/foundation/timer';
+import type { SpamContract } from '@aztec/noir-test-contracts.js/Spam';
+import type { SequencerEvents } from '@aztec/sequencer-client';
+
+import { jest } from '@jest/globals';
+import { privateKeyToAccount } from 'viem/accounts';
+
+import { type EndToEndContext, getPrivateKeyFromIndex } from '../fixtures/utils.js';
+import { EpochsTestContext } from './epochs_test.js';
+
+jest.setTimeout(1000 * 60 * 10);
+
+const NODE_COUNT = 3;
+const TX_COUNT = 3;
+
+describe('e2e_epochs/epochs_monitor_block_building', () => {
+  let context: EndToEndContext;
+  let logger: Logger;
+  let cheatCodes: CheatCodes;
+
+  let test: EpochsTestContext;
+  let validators: (Operator & { privateKey: `0x${string}` })[];
+  let nodes: AztecNodeService[];
+  let contract: SpamContract;
+
+  beforeEach(async () => {
+    validators = times(NODE_COUNT, i => {
+      const privateKey = bufferToHex(getPrivateKeyFromIndex(i + 3)!);
+      const attester = EthAddress.fromString(privateKeyToAccount(privateKey).address);
+      return { attester, withdrawer: attester, privateKey };
+    });
+
+    // Setup context with the given set of validators, no reorgs, mocked gossip sub network, and no anvil test watcher.
+    test = await EpochsTestContext.setup({
+      numberOfAccounts: 1,
+      initialValidators: validators,
+      aztecProofSubmissionWindow: 1024,
+      mockGossipSubNetwork: true,
+      disableAnvilTestWatcher: true,
+      startProverNode: false,
+    });
+
+    ({ context, logger } = test);
+    ({ cheatCodes } = context);
+
+    // Halt block building in initial aztec node, which was not set up as a validator.
+    logger.warn(`Stopping sequencer in initial aztec node.`);
+    await context.sequencer!.stop();
+
+    // Start the validator nodes
+    logger.warn(`Initial setup complete. Starting ${NODE_COUNT} validator nodes.`);
+    nodes = await asyncMap(validators, ({ privateKey }) =>
+      test.createValidatorNode([privateKey], { dontStartSequencer: true, minTxsPerBlock: 1, maxTxsPerBlock: 1 }),
+    );
+    logger.warn(`Started ${NODE_COUNT} validator nodes.`, { validators: validators.map(v => v.attester.toString()) });
+
+    // Register spam contract for sending txs.
+    contract = await test.registerSpamContract(context.wallet);
+    logger.warn(`Test setup completed.`, { validators: validators.map(v => v.attester.toString()) });
+  });
+
+  afterEach(async () => {
+    jest.restoreAllMocks();
+    await test.teardown();
+  });
+
+  it('builds blocks without errors', async () => {
+    // Create and submit a bunch of txs
+    const txs = await timesAsync(TX_COUNT, i => contract.methods.spam(i, 1n, false).prove());
+    const sentTxs = await Promise.all(txs.map(tx => tx.send()));
+    logger.warn(`Sent ${sentTxs.length} transactions`, {
+      txs: await Promise.all(sentTxs.map(tx => tx.getTxHash())),
+    });
+
+    // Warp forward to epoch 2
+    const ts = await cheatCodes.rollup.advanceToEpoch(2n);
+    context.dateProvider?.setTime(Number(ts) * 1000);
+
+    // Listen to all failure related events of the sequencers.
+    const failEvents: (keyof SequencerEvents)[] = [
+      'block-build-failed',
+      'block-publish-failed',
+      'proposer-rollup-check-failed',
+      'tx-count-check-failed',
+    ];
+    const sequencers = nodes.map(node => node.getSequencer()!);
+    const events: TrackedSequencerEvent[] = [];
+    sequencers.forEach((sequencer, i) => {
+      failEvents.forEach(eventName => {
+        sequencer.getSequencer().on(eventName, (args: Parameters<SequencerEvents[typeof eventName]>[0]) => {
+          const sequencerIndex = i + 2;
+          events.push({
+            ...args,
+            type: eventName,
+            sequencerIndex,
+            validator: validators[i].attester,
+          } as TrackedSequencerEvent);
+          logger.error(
+            `Failed event ${eventName} from sequencer ${sequencerIndex} (${validators[i].attester})`,
+            events.at(-1)!,
+          );
+        });
+      });
+    });
+
+    // Start the sequencers!
+    await Promise.all(sequencers.map(sequencer => sequencer.start()));
+    logger.warn(`Started all sequencers`);
+
+    // Wait until all txs are mined
+    const timeout = test.L2_SLOT_DURATION_IN_S * (TX_COUNT * 2 + 1) * 1000;
+    await executeTimeout(() => Promise.all(sentTxs.map(tx => tx.wait())), timeout);
+    logger.warn(`All txs have been mined`);
+
+    // And expect no failures from sequencers
+    // expect(events).toEqual([]);
+    if (events.length > 0) {
+      logger.error(`Failed events from sequencers`, events);
+    }
+  });
+});
+
+type TrackedSequencerEvent = {
+  [K in keyof SequencerEvents]: Parameters<SequencerEvents[K]>[0] & {
+    type: K;
+    sequencerIndex: number;
+    validator: EthAddress;
+  };
+}[keyof SequencerEvents];

--- a/yarn-project/end-to-end/src/e2e_epochs/epochs_test.ts
+++ b/yarn-project/end-to-end/src/e2e_epochs/epochs_test.ts
@@ -1,10 +1,21 @@
-import { AztecNodeService } from '@aztec/aztec-node';
-import { Fr, type Logger, MerkleTreeId, getTimestampRangeForEpoch, retryUntil, sleep } from '@aztec/aztec.js';
+import { type AztecNodeConfig, AztecNodeService } from '@aztec/aztec-node';
+import {
+  Fr,
+  type Logger,
+  MerkleTreeId,
+  type Wallet,
+  getContractInstanceFromDeployParams,
+  getTimestampRangeForEpoch,
+  retryUntil,
+  sleep,
+} from '@aztec/aztec.js';
 import type { ViemClient } from '@aztec/ethereum';
 import { RollupContract } from '@aztec/ethereum/contracts';
 import { ChainMonitor, DelayedTxUtils, type Delayer, waitUntilL1Timestamp } from '@aztec/ethereum/test';
 import { randomBytes } from '@aztec/foundation/crypto';
 import { withLogNameSuffix } from '@aztec/foundation/log';
+import { SpamContract } from '@aztec/noir-test-contracts.js/Spam';
+import { getMockPubSubP2PServiceFactory } from '@aztec/p2p/test-helpers';
 import { ProverNode, ProverNodePublisher } from '@aztec/prover-node';
 import type { TestProverNode } from '@aztec/prover-node/test';
 import type { SequencerPublisher } from '@aztec/sequencer-client';
@@ -40,8 +51,11 @@ export type EpochsTestOpts = Partial<
     | 'proverNodeConfig'
     | 'ethereumSlotDuration'
     | 'aztecSlotDuration'
+    | 'initialValidators'
+    | 'mockGossipSubNetwork'
+    | 'disableAnvilTestWatcher'
   >
->;
+> & { numberOfAccounts?: number };
 
 /**
  * Tests building of epochs using fast block times and short epochs.
@@ -90,7 +104,8 @@ export class EpochsTestContext {
 
     // Set up system without any account nor protocol contracts
     // and with faster block times and shorter epochs.
-    const context = await setup(0, {
+    const context = await setup(opts.numberOfAccounts ?? 0, {
+      automineL1Setup: true,
       checkIntervalMs: 50,
       archiverPollingIntervalMS: ARCHIVER_POLL_INTERVAL,
       worldStateBlockCheckIntervalMS: WORLD_STATE_BLOCK_CHECK_INTERVAL,
@@ -129,11 +144,14 @@ export class EpochsTestContext {
     this.proverDelayer = context.proverNode
       ? (((context.proverNode as TestProverNode).publisher as ProverNodePublisher).l1TxUtils as DelayedTxUtils).delayer!
       : undefined!;
-    this.sequencerDelayer = (
-      ((context.sequencer as TestSequencerClient).sequencer.publisher as SequencerPublisher).l1TxUtils as DelayedTxUtils
-    ).delayer!;
+    this.sequencerDelayer = context.sequencer
+      ? (
+          ((context.sequencer as TestSequencerClient).sequencer.publisher as SequencerPublisher)
+            .l1TxUtils as DelayedTxUtils
+        ).delayer!
+      : undefined!;
 
-    if ((context.proverNode && !this.proverDelayer) || !this.sequencerDelayer) {
+    if ((context.proverNode && !this.proverDelayer) || (context.sequencer && !this.sequencerDelayer)) {
       throw new Error(`Could not find prover or sequencer delayer`);
     }
 
@@ -176,15 +194,45 @@ export class EpochsTestContext {
     return proverNode;
   }
 
-  public async createNonValidatorNode() {
+  public createNonValidatorNode(opts: Partial<AztecNodeConfig> = {}) {
     this.logger.warn('Creating and syncing a node without a validator...');
+    return this.createNode({ ...opts, disableValidator: true });
+  }
+
+  public createValidatorNode(
+    privateKeys: `0x${string}`[],
+    opts: Partial<AztecNodeConfig> & { dontStartSequencer?: boolean } = {},
+  ) {
+    this.logger.warn('Creating and syncing a validator node...');
+    return this.createNode({ ...opts, disableValidator: false, validatorPrivateKeys: privateKeys });
+  }
+
+  private async createNode(opts: Partial<AztecNodeConfig> & { dontStartSequencer?: boolean } = {}) {
     const suffix = (this.nodes.length + 1).toString();
+    const { mockGossipSubNetwork } = this.context;
+    const resolvedConfig = { ...this.context.config, ...opts };
+    const p2pEnabled = resolvedConfig.p2pEnabled || mockGossipSubNetwork !== undefined;
+    const p2pIp = resolvedConfig.p2pIp ?? (p2pEnabled ? '127.0.0.1' : undefined);
     const node = await withLogNameSuffix(suffix, () =>
-      AztecNodeService.createAndSync({
-        ...this.context.config,
-        disableValidator: true,
-        dataDirectory: join(this.context.config.dataDirectory!, randomBytes(8).toString('hex')),
-      }),
+      AztecNodeService.createAndSync(
+        {
+          ...resolvedConfig,
+          dataDirectory: join(this.context.config.dataDirectory!, randomBytes(8).toString('hex')),
+          validatorPrivateKeys: opts.validatorPrivateKeys,
+          p2pEnabled,
+          p2pIp,
+        },
+        {
+          dateProvider: this.context.dateProvider,
+          p2pClientDeps: {
+            p2pServiceFactory: mockGossipSubNetwork ? getMockPubSubP2PServiceFactory(mockGossipSubNetwork) : undefined,
+          },
+        },
+        {
+          prefilledPublicData: this.context.prefilledPublicData,
+          ...opts,
+        },
+      ),
     );
     this.nodes.push(node);
     return node;
@@ -251,6 +299,19 @@ export class EpochsTestContext {
         synched = syncState.oldestHistoricBlockNumber >= blockNumber;
       }
     }
+  }
+
+  /** Registers the SpamContract on the given wallet. */
+  public async registerSpamContract(wallet: Wallet, salt = Fr.ZERO) {
+    const instance = await getContractInstanceFromDeployParams(SpamContract.artifact, {
+      constructorArgs: [],
+      constructorArtifact: undefined,
+      salt,
+      publicKeys: undefined,
+      deployer: undefined,
+    });
+    await wallet.registerContract({ artifact: SpamContract.artifact, instance });
+    return SpamContract.at(instance.address, wallet);
   }
 
   /** Verifies whether the given block number is found on the aztec node. */

--- a/yarn-project/end-to-end/src/fixtures/utils.ts
+++ b/yarn-project/end-to-end/src/fixtures/utils.ts
@@ -556,10 +556,10 @@ export async function setup(
       p2pClientDeps = { p2pServiceFactory: getMockPubSubP2PServiceFactory(mockGossipSubNetwork) };
     }
 
-    const p2pEnabled = opts.mockGossipSubNetwork || config.p2pEnabled;
-    const p2pIp = opts.p2pIp ?? '127.0.0.1';
+    config.p2pEnabled = opts.mockGossipSubNetwork || config.p2pEnabled;
+    config.p2pIp = opts.p2pIp ?? config.p2pIp ?? '127.0.0.1';
     const aztecNode = await AztecNodeService.createAndSync(
-      { ...config, p2pEnabled, p2pIp },
+      config, // REFACTOR: createAndSync mutates this config
       { dateProvider, blobSinkClient, telemetry, p2pClientDeps },
       { prefilledPublicData },
     );

--- a/yarn-project/epoch-cache/src/epoch_cache.ts
+++ b/yarn-project/epoch-cache/src/epoch_cache.ts
@@ -120,11 +120,12 @@ export class EpochCache implements EpochCacheInterface {
     return this.l1constants;
   }
 
-  public getEpochAndSlotNow(): EpochAndSlot {
-    return this.getEpochAndSlotAtTimestamp(this.nowInSeconds());
+  public getEpochAndSlotNow(): EpochAndSlot & { now: bigint } {
+    const now = this.nowInSeconds();
+    return { ...this.getEpochAndSlotAtTimestamp(now), now };
   }
 
-  private nowInSeconds(): bigint {
+  public nowInSeconds(): bigint {
     return BigInt(Math.floor(this.dateProvider.now() / 1000));
   }
 
@@ -134,9 +135,10 @@ export class EpochCache implements EpochCacheInterface {
     return { epoch, ts, slot };
   }
 
-  public getEpochAndSlotInNextL1Slot(): EpochAndSlot {
-    const nextSlotTs = this.nowInSeconds() + BigInt(this.l1constants.ethereumSlotDuration);
-    return this.getEpochAndSlotAtTimestamp(nextSlotTs);
+  public getEpochAndSlotInNextL1Slot(): EpochAndSlot & { now: bigint } {
+    const now = this.nowInSeconds();
+    const nextSlotTs = now + BigInt(this.l1constants.ethereumSlotDuration);
+    return { ...this.getEpochAndSlotAtTimestamp(nextSlotTs), now };
   }
 
   private getEpochAndSlotAtTimestamp(ts: bigint): EpochAndSlot {

--- a/yarn-project/ethereum/src/contracts/rollup.ts
+++ b/yarn-project/ethereum/src/contracts/rollup.ts
@@ -410,11 +410,12 @@ export class RollupContract {
     archive: Buffer,
     account: `0x${string}` | Account,
     slotDuration: bigint | number,
-  ): Promise<[bigint, bigint]> {
+  ): Promise<{ slot: bigint; blockNumber: bigint; timeOfNextL1Slot: bigint }> {
     if (typeof slotDuration === 'number') {
       slotDuration = BigInt(slotDuration);
     }
-    const timeOfNextL1Slot = (await this.client.getBlock()).timestamp + slotDuration;
+    const latestBlock = await this.client.getBlock();
+    const timeOfNextL1Slot = latestBlock.timestamp + slotDuration;
 
     try {
       const {
@@ -427,7 +428,7 @@ export class RollupContract {
         account,
       });
 
-      return [slot, blockNumber];
+      return { slot, blockNumber, timeOfNextL1Slot };
     } catch (err: unknown) {
       throw formatViemError(err);
     }

--- a/yarn-project/ethereum/src/eth_cheat_codes.ts
+++ b/yarn-project/ethereum/src/eth_cheat_codes.ts
@@ -3,6 +3,7 @@ import { keccak256 } from '@aztec/foundation/crypto';
 import type { EthAddress } from '@aztec/foundation/eth-address';
 import { jsonStringify } from '@aztec/foundation/json-rpc';
 import { createLogger } from '@aztec/foundation/log';
+import type { TestDateProvider } from '@aztec/foundation/timer';
 
 import { type Hex, createPublicClient, fallback, http } from 'viem';
 
@@ -121,7 +122,7 @@ export class EthCheatCodes {
   }
 
   /**
-   * Set the interval between blocks (block time)
+   * Set the interval between successive blocks (block time). This does NOT enable interval mining.
    * @param interval - The interval to use between blocks
    */
   public async setBlockInterval(interval: number): Promise<void> {
@@ -147,7 +148,19 @@ export class EthCheatCodes {
   }
 
   /**
-   * Set the interval between blocks (block time)
+   * Get interval mining if set.
+   * @param seconds - The interval to use between blocks
+   */
+  public getIntervalMining(): Promise<number | null> {
+    try {
+      return this.rpcCall('anvil_getIntervalMining', []);
+    } catch (err) {
+      throw new Error(`Error getting interval mining: ${err}`);
+    }
+  }
+
+  /**
+   * Enable interval mining at the given interval (block time)
    * @param seconds - The interval to use between blocks
    */
   public async setIntervalMining(seconds: number): Promise<void> {
@@ -199,17 +212,39 @@ export class EthCheatCodes {
   }
 
   /**
-   * Set the next block timestamp and mines the block
+   * Set the next block timestamp and mines the block.
+   * Optionally resets interval mining so the next block is mined in `blockInterval` seconds from now.
+   * Optionally updates a provided date provider to follow L1 time.
    * @param timestamp - The timestamp to set the next block to
    */
-  public async warp(timestamp: number | bigint, silent = false): Promise<void> {
+  public async warp(
+    timestamp: number | bigint,
+    opts: { silent?: boolean; resetBlockInterval?: boolean; updateDateProvider?: TestDateProvider } = {},
+  ): Promise<void> {
+    let blockInterval: number | null = null;
     try {
+      // Load current block interval and disable it
+      if (opts.resetBlockInterval) {
+        blockInterval = await this.getIntervalMining();
+        if (blockInterval !== null) {
+          await this.setIntervalMining(0);
+        }
+      }
+      // Set the timestamp of the next block to be mined
       await this.rpcCall('evm_setNextBlockTimestamp', [Number(timestamp)]);
+      // And mine a block so the timestamp goes into effect now
+      await this.doMine();
+      // Update the date provider if provided so it follows L1 time
+      opts.updateDateProvider?.setTime(Number(timestamp) * 1000);
     } catch (err) {
       throw new Error(`Error warping: ${err}`);
+    } finally {
+      // Restore interval mining so the next block is mined in `blockInterval` seconds from this one
+      if (opts.resetBlockInterval && blockInterval !== null && blockInterval > 0) {
+        await this.setIntervalMining(blockInterval);
+      }
     }
-    await this.doMine();
-    if (!silent) {
+    if (!opts.silent) {
       this.logger.warn(`Warped L1 timestamp to ${timestamp}`);
     }
   }

--- a/yarn-project/foundation/src/timer/date.ts
+++ b/yarn-project/foundation/src/timer/date.ts
@@ -5,15 +5,21 @@ export class DateProvider {
   public now(): number {
     return Date.now();
   }
+
+  public nowInSeconds(): number {
+    return Math.floor(this.now() / 1000);
+  }
 }
 
 /** Returns current datetime and allows to override it. */
-export class TestDateProvider implements DateProvider {
+export class TestDateProvider extends DateProvider {
   private offset = 0;
 
-  constructor(private readonly logger = createLogger('foundation:test-date-provider')) {}
+  constructor(private readonly logger = createLogger('foundation:test-date-provider')) {
+    super();
+  }
 
-  public now(): number {
+  public override now(): number {
     return Date.now() + this.offset;
   }
 

--- a/yarn-project/ivc-integration/src/rollup_ivc_integration.test.ts
+++ b/yarn-project/ivc-integration/src/rollup_ivc_integration.test.ts
@@ -33,7 +33,7 @@ import type { KernelPublicInputs } from './types/index.js';
 
 /* eslint-disable camelcase */
 
-jest.setTimeout(120_000);
+jest.setTimeout(240_000);
 
 const logger = createLogger('ivc-integration:test:rollup-native');
 

--- a/yarn-project/p2p/src/services/dummy_service.ts
+++ b/yarn-project/p2p/src/services/dummy_service.ts
@@ -1,12 +1,22 @@
 import type { PeerInfo } from '@aztec/stdlib/interfaces/server';
-import type { Gossipable } from '@aztec/stdlib/p2p';
+import type { Gossipable, PeerErrorSeverity } from '@aztec/stdlib/p2p';
 import { Tx, TxHash } from '@aztec/stdlib/tx';
 
 import type { ENR } from '@chainsafe/enr';
 import type { PeerId } from '@libp2p/interface';
 import EventEmitter from 'events';
 
-import type { ReqRespSubProtocol, SubProtocolMap } from './reqresp/interface.js';
+import type { PeerManagerInterface } from './peer-manager/interface.js';
+import type {
+  ReqRespInterface,
+  ReqRespResponse,
+  ReqRespSubProtocol,
+  ReqRespSubProtocolHandlers,
+  ReqRespSubProtocolValidators,
+  SubProtocolMap,
+} from './reqresp/interface.js';
+import type { GoodByeReason } from './reqresp/protocols/goodbye.js';
+import { ReqRespStatus } from './reqresp/status.js';
 import {
   type P2PBlockReceivedCallback,
   type P2PService,
@@ -142,5 +152,77 @@ export class DummyPeerDiscoveryService extends EventEmitter implements PeerDisco
 
   public getEnr(): undefined {
     return undefined;
+  }
+}
+
+export class DummyPeerManager implements PeerManagerInterface {
+  constructor(
+    public peerId: PeerId,
+    private peersProvider?: { getPeers: () => PeerId[] },
+  ) {}
+
+  public getPeers(_includePending?: boolean): PeerInfo[] {
+    if (!this.peersProvider) {
+      return [];
+    }
+    return this.peersProvider
+      .getPeers()
+      .filter(peer => !peer.equals(this.peerId))
+      .map(id => ({
+        id: id.toString(),
+        status: 'connected',
+        score: 0,
+      }));
+  }
+
+  public initializePeers(): Promise<void> {
+    return Promise.resolve();
+  }
+  public getPeerScore(_peerId: string): number {
+    return 0;
+  }
+  public stop(): Promise<void> {
+    return Promise.resolve();
+  }
+  public heartbeat(): void {}
+  public addTrustedPeer(_peerId: PeerId): void {}
+  public addPrivatePeer(_peerId: PeerId): void {}
+  public goodbyeReceived(_peerId: PeerId, _reason: GoodByeReason): void {}
+  public penalizePeer(_peerId: PeerId, _penalty: PeerErrorSeverity): void {}
+}
+
+export class DummyReqResp implements ReqRespInterface {
+  start(
+    _subProtocolHandlers: ReqRespSubProtocolHandlers,
+    _subProtocolValidators: ReqRespSubProtocolValidators,
+  ): Promise<void> {
+    return Promise.resolve();
+  }
+  stop(): Promise<void> {
+    return Promise.resolve();
+  }
+  sendRequest<SubProtocol extends ReqRespSubProtocol>(
+    _subProtocol: SubProtocol,
+    _request: InstanceType<SubProtocolMap[SubProtocol]['request']>,
+  ): Promise<InstanceType<SubProtocolMap[SubProtocol]['response']> | undefined> {
+    return Promise.resolve(undefined);
+  }
+  sendBatchRequest<SubProtocol extends ReqRespSubProtocol>(
+    _subProtocol: SubProtocol,
+    requests: InstanceType<SubProtocolMap[SubProtocol]['request']>[],
+    _pinnedPeer: PeerId | undefined,
+    _timeoutMs?: number,
+    _maxPeers?: number,
+    _maxRetryAttempts?: number,
+  ): Promise<(InstanceType<SubProtocolMap[SubProtocol]['response']> | undefined)[]> {
+    return Promise.resolve(requests.map(() => undefined));
+  }
+  public sendRequestToPeer(
+    _peerId: PeerId,
+    _subProtocol: ReqRespSubProtocol,
+    _payload: Buffer,
+    _dialTimeout?: number,
+  ): Promise<ReqRespResponse> {
+    return Promise.resolve({ status: ReqRespStatus.SUCCESS, data: Buffer.from([]) });
   }
 }

--- a/yarn-project/p2p/src/services/index.ts
+++ b/yarn-project/p2p/src/services/index.ts
@@ -1,3 +1,4 @@
 export * from './service.js';
 export * from './libp2p/libp2p_service.js';
 export * from './tx_collector.js';
+export * from './dummy_service.js';

--- a/yarn-project/p2p/src/services/libp2p/libp2p_service.ts
+++ b/yarn-project/p2p/src/services/libp2p/libp2p_service.ts
@@ -1,5 +1,5 @@
 import type { EpochCacheInterface } from '@aztec/epoch-cache';
-import { createLibp2pComponentLogger, createLogger } from '@aztec/foundation/log';
+import { type Logger, createLibp2pComponentLogger, createLogger } from '@aztec/foundation/log';
 import { SerialQueue } from '@aztec/foundation/queue';
 import { RunningPromise } from '@aztec/foundation/running-promise';
 import { Timer } from '@aztec/foundation/timer';
@@ -57,11 +57,18 @@ import { GossipSubEvent } from '../../types/index.js';
 import { type PubSubLibp2p, convertToMultiaddr } from '../../util.js';
 import { getVersions } from '../../versioning.js';
 import { AztecDatastore } from '../data_store.js';
+import { DiscV5Service } from '../discv5/discV5_service.js';
 import { SnappyTransform, fastMsgIdFn, getMsgIdFn, msgIdToStrFn } from '../encoding.js';
 import { gossipScoreThresholds } from '../gossipsub/scoring.js';
+import type { PeerManagerInterface } from '../peer-manager/interface.js';
 import { PeerManager } from '../peer-manager/peer_manager.js';
 import { PeerScoring } from '../peer-manager/peer_scoring.js';
-import { DEFAULT_SUB_PROTOCOL_VALIDATORS, ReqRespSubProtocol, type SubProtocolMap } from '../reqresp/interface.js';
+import {
+  DEFAULT_SUB_PROTOCOL_VALIDATORS,
+  type ReqRespInterface,
+  ReqRespSubProtocol,
+  type SubProtocolMap,
+} from '../reqresp/interface.js';
 import { reqGoodbyeHandler } from '../reqresp/protocols/goodbye.js';
 import {
   pingHandler,
@@ -86,7 +93,6 @@ type ValidationOutcome = { allPassed: true } | { allPassed: false; failure: Vali
  */
 export class LibP2PService<T extends P2PClientType = P2PClientType.Full> extends WithTracer implements P2PService {
   private jobQueue: SerialQueue = new SerialQueue();
-  private peerManager: PeerManager;
   private discoveryRunningPromise?: RunningPromise;
   private msgIdSeenValidators: Record<TopicType, MessageSeenValidator> = {} as Record<TopicType, MessageSeenValidator>;
 
@@ -96,12 +102,6 @@ export class LibP2PService<T extends P2PClientType = P2PClientType.Full> extends
 
   private protocolVersion = '';
   private topicStrings: Record<TopicType, string> = {} as Record<TopicType, string>;
-
-  // Request and response sub service
-  public reqresp: ReqResp;
-
-  // Trusted peers ids
-  private trustedPeersIds: PeerId[] = [];
 
   private feesCache: { blockNumber: number; gasFees: GasFees } | undefined;
 
@@ -121,6 +121,8 @@ export class LibP2PService<T extends P2PClientType = P2PClientType.Full> extends
     private config: P2PConfig,
     protected node: PubSubLibp2p,
     private peerDiscoveryService: PeerDiscoveryService,
+    private reqresp: ReqRespInterface,
+    private peerManager: PeerManagerInterface,
     protected mempools: MemPools<T>,
     private archiver: L2BlockSource & ContractDataSource,
     epochCache: EpochCacheInterface,
@@ -148,27 +150,6 @@ export class LibP2PService<T extends P2PClientType = P2PClientType.Full> extends
       this.protocolVersion,
     );
 
-    const peerScoring = new PeerScoring(config);
-    this.reqresp = new ReqResp(config, node, peerScoring);
-
-    this.peerManager = new PeerManager(
-      node,
-      peerDiscoveryService,
-      config,
-      telemetry,
-      createLogger(`${logger.module}:peer_manager`),
-      peerScoring,
-      this.reqresp,
-      this.worldStateSynchronizer,
-      this.protocolVersion,
-    );
-
-    // Update gossipsub score params
-    this.node.services.pubsub.score.params.appSpecificScore = (peerId: string) => {
-      return this.peerManager.getPeerScore(peerId);
-    };
-    this.node.services.pubsub.score.params.appSpecificWeight = 10;
-
     this.attestationValidator = new AttestationValidator(epochCache);
     this.blockProposalValidator = new BlockProposalValidator(epochCache);
 
@@ -192,23 +173,44 @@ export class LibP2PService<T extends P2PClientType = P2PClientType.Full> extends
   public static async new<T extends P2PClientType>(
     clientType: T,
     config: P2PConfig,
-    peerDiscoveryService: PeerDiscoveryService,
     peerId: PeerId,
-    mempools: MemPools<T>,
-    l2BlockSource: L2BlockSource & ContractDataSource,
-    epochCache: EpochCacheInterface,
-    proofVerifier: ClientProtocolCircuitVerifier,
-    worldStateSynchronizer: WorldStateSynchronizer,
-    store: AztecAsyncKVStore,
-    telemetry: TelemetryClient,
-    logger = createLogger('p2p:libp2p_service'),
+    deps: {
+      mempools: MemPools<T>;
+      l2BlockSource: L2BlockSource & ContractDataSource;
+      epochCache: EpochCacheInterface;
+      proofVerifier: ClientProtocolCircuitVerifier;
+      worldStateSynchronizer: WorldStateSynchronizer;
+      peerStore: AztecAsyncKVStore;
+      telemetry: TelemetryClient;
+      logger: Logger;
+      packageVersion: string;
+    },
   ) {
+    const {
+      worldStateSynchronizer,
+      epochCache,
+      l2BlockSource,
+      mempools,
+      proofVerifier,
+      peerStore,
+      telemetry,
+      logger,
+      packageVersion,
+    } = deps;
     const { p2pPort, maxPeerCount, listenAddress } = config;
     const bindAddrTcp = convertToMultiaddr(listenAddress, p2pPort, 'tcp');
 
-    const datastore = new AztecDatastore(store);
+    const datastore = new AztecDatastore(peerStore);
 
     const otelMetricsAdapter = new OtelMetricsAdapter(telemetry);
+
+    const peerDiscoveryService = new DiscV5Service(
+      peerId,
+      config,
+      packageVersion,
+      telemetry,
+      createLogger(`${logger.module}:discv5_service`),
+    );
 
     const bootstrapNodes = peerDiscoveryService.bootstrapNodeEnrs.map(enr => enr.encodeTxt());
 
@@ -314,11 +316,32 @@ export class LibP2PService<T extends P2PClientType = P2PClientType.Full> extends
       logger: createLibp2pComponentLogger(logger.module),
     });
 
+    const peerScoring = new PeerScoring(config);
+    const reqresp = new ReqResp(config, node, peerScoring);
+
+    const peerManager = new PeerManager(
+      node,
+      peerDiscoveryService,
+      config,
+      telemetry,
+      createLogger(`${logger.module}:peer_manager`),
+      peerScoring,
+      reqresp,
+      worldStateSynchronizer,
+      protocolVersion,
+    );
+
+    // Update gossipsub score params
+    node.services.pubsub.score.params.appSpecificWeight = 10;
+    node.services.pubsub.score.params.appSpecificScore = (peerId: string) => peerManager.getPeerScore(peerId);
+
     return new LibP2PService(
       clientType,
       config,
       node,
       peerDiscoveryService,
+      reqresp,
+      peerManager,
       mempools,
       l2BlockSource,
       epochCache,

--- a/yarn-project/p2p/src/services/peer-manager/interface.ts
+++ b/yarn-project/p2p/src/services/peer-manager/interface.ts
@@ -1,0 +1,20 @@
+import type { PeerInfo } from '@aztec/stdlib/interfaces/server';
+import type { PeerErrorSeverity } from '@aztec/stdlib/p2p';
+
+import type { PeerId } from '@libp2p/interface';
+
+import type { GoodByeReason } from '../reqresp/protocols/goodbye.js';
+
+export interface PeerManagerInterface {
+  getPeers(_includePending?: boolean): PeerInfo[];
+
+  initializePeers(): Promise<void>;
+  heartbeat(): void;
+  addTrustedPeer(peerId: PeerId): void;
+  addPrivatePeer(peerId: PeerId): void;
+  goodbyeReceived(peerId: PeerId, reason: GoodByeReason): void;
+  penalizePeer(peerId: PeerId, penalty: PeerErrorSeverity): void;
+
+  getPeerScore(peerId: string): number;
+  stop(): Promise<void>;
+}

--- a/yarn-project/p2p/src/services/peer-manager/peer_manager.test.ts
+++ b/yarn-project/p2p/src/services/peer-manager/peer_manager.test.ts
@@ -10,13 +10,12 @@ import { Attributes, getTelemetryClient } from '@aztec/telemetry-client';
 
 import { type ENR, SignableENR } from '@chainsafe/enr';
 import { jest } from '@jest/globals';
-import type { PeerId } from '@libp2p/interface';
+import type { Libp2p, PeerId } from '@libp2p/interface';
 import { createSecp256k1PeerId } from '@libp2p/peer-id-factory';
 import { multiaddr } from '@multiformats/multiaddr';
 
 import { getP2PDefaultConfig } from '../../config.js';
 import { PeerEvent } from '../../types/index.js';
-import type { PubSubLibp2p } from '../../util.js';
 import { ReqRespSubProtocol } from '../reqresp/interface.js';
 import { GoodByeReason } from '../reqresp/protocols/index.js';
 import { PeerManager } from './peer_manager.js';
@@ -873,7 +872,7 @@ describe('PeerManager', () => {
 
   function createMockPeerManager(
     name: string,
-    node: PubSubLibp2p,
+    node: Libp2p,
     maxPeerCount: number,
     trustedPeers?: SignableENR[],
     privatePeers?: SignableENR[],

--- a/yarn-project/p2p/src/services/peer-manager/peer_manager.ts
+++ b/yarn-project/p2p/src/services/peer-manager/peer_manager.ts
@@ -7,17 +7,18 @@ import { type TelemetryClient, trackSpan } from '@aztec/telemetry-client';
 import { ENR } from '@chainsafe/enr';
 import type { Connection, PeerId } from '@libp2p/interface';
 import type { Multiaddr } from '@multiformats/multiaddr';
+import type { Libp2p } from 'libp2p';
 import { inspect } from 'util';
 
 import type { P2PConfig } from '../../config.js';
 import { PeerEvent } from '../../types/index.js';
-import type { PubSubLibp2p } from '../../util.js';
 import { ReqRespSubProtocol } from '../reqresp/interface.js';
 import { GoodByeReason, prettyGoodbyeReason } from '../reqresp/protocols/goodbye.js';
 import { StatusMessage } from '../reqresp/protocols/status.js';
 import type { ReqResp } from '../reqresp/reqresp.js';
 import { ReqRespStatus } from '../reqresp/status.js';
 import type { PeerDiscoveryService } from '../service.js';
+import type { PeerManagerInterface } from './interface.js';
 import { PeerManagerMetrics } from './metrics.js';
 import { PeerScoreState, type PeerScoring } from './peer_scoring.js';
 
@@ -40,7 +41,7 @@ type TimedOutPeer = {
   timeoutUntilMs: number;
 };
 
-export class PeerManager {
+export class PeerManager implements PeerManagerInterface {
   private cachedPeers: Map<string, CachedPeer> = new Map();
   private heartbeatCounter: number = 0;
   private displayPeerCountsPeerHeartbeat: number = 0;
@@ -58,7 +59,7 @@ export class PeerManager {
   };
 
   constructor(
-    private libP2PNode: PubSubLibp2p,
+    private libP2PNode: Libp2p,
     private peerDiscoveryService: PeerDiscoveryService,
     private config: P2PConfig,
     telemetryClient: TelemetryClient,

--- a/yarn-project/p2p/src/services/reqresp/interface.ts
+++ b/yarn-project/p2p/src/services/reqresp/interface.ts
@@ -184,3 +184,29 @@ export const subProtocolMap: SubProtocolMap = {
     response: L2Block,
   },
 };
+
+export interface ReqRespInterface {
+  start(
+    subProtocolHandlers: ReqRespSubProtocolHandlers,
+    subProtocolValidators: ReqRespSubProtocolValidators,
+  ): Promise<void>;
+  stop(): Promise<void>;
+  sendRequest<SubProtocol extends ReqRespSubProtocol>(
+    subProtocol: SubProtocol,
+    request: InstanceType<SubProtocolMap[SubProtocol]['request']>,
+  ): Promise<InstanceType<SubProtocolMap[SubProtocol]['response']> | undefined>;
+  sendBatchRequest<SubProtocol extends ReqRespSubProtocol>(
+    subProtocol: SubProtocol,
+    requests: InstanceType<SubProtocolMap[SubProtocol]['request']>[],
+    pinnedPeer: PeerId | undefined,
+    timeoutMs?: number,
+    maxPeers?: number,
+    maxRetryAttempts?: number,
+  ): Promise<(InstanceType<SubProtocolMap[SubProtocol]['response']> | undefined)[]>;
+  sendRequestToPeer(
+    peerId: PeerId,
+    subProtocol: ReqRespSubProtocol,
+    payload: Buffer,
+    dialTimeout?: number,
+  ): Promise<ReqRespResponse>;
+}

--- a/yarn-project/p2p/src/services/reqresp/protocols/goodbye.ts
+++ b/yarn-project/p2p/src/services/reqresp/protocols/goodbye.ts
@@ -2,7 +2,7 @@ import { createLogger } from '@aztec/foundation/log';
 
 import type { PeerId } from '@libp2p/interface';
 
-import type { PeerManager } from '../../peer-manager/peer_manager.js';
+import type { PeerManagerInterface } from '../../peer-manager/interface.js';
 import { ReqRespSubProtocol, type ReqRespSubProtocolHandler } from '../interface.js';
 import type { ReqResp } from '../reqresp.js';
 
@@ -89,7 +89,7 @@ export class GoodbyeProtocolHandler {
  * @param peerManager - The peer manager.
  * @returns A resolved promise with the goodbye response.
  */
-export function reqGoodbyeHandler(peerManager: PeerManager): ReqRespSubProtocolHandler {
+export function reqGoodbyeHandler(peerManager: PeerManagerInterface): ReqRespSubProtocolHandler {
   return (peerId: PeerId, _msg: Buffer) => {
     const reason = decodeGoodbyeReason(_msg);
 

--- a/yarn-project/p2p/src/services/reqresp/reqresp.ts
+++ b/yarn-project/p2p/src/services/reqresp/reqresp.ts
@@ -25,6 +25,7 @@ import { ConnectionSampler } from './connection-sampler/connection_sampler.js';
 import {
   DEFAULT_SUB_PROTOCOL_HANDLERS,
   DEFAULT_SUB_PROTOCOL_VALIDATORS,
+  type ReqRespInterface,
   type ReqRespResponse,
   ReqRespSubProtocol,
   type ReqRespSubProtocolHandlers,
@@ -55,7 +56,7 @@ import { ReqRespStatus, ReqRespStatusError, parseStatusChunk, prettyPrintReqResp
  *
  * see: https://github.com/ethereum/consensus-specs/blob/dev/specs/phase0/p2p-interface.md#the-reqresp-domain
  */
-export class ReqResp {
+export class ReqResp implements ReqRespInterface {
   protected readonly logger: Logger;
 
   private overallRequestTimeoutMs: number;

--- a/yarn-project/p2p/src/test-helpers/index.ts
+++ b/yarn-project/p2p/src/test-helpers/index.ts
@@ -3,3 +3,4 @@ export * from './get-ports.js';
 export * from './make-enrs.js';
 export * from './make-test-p2p-clients.js';
 export * from './reqresp-nodes.js';
+export * from './mock-pubsub.js';

--- a/yarn-project/p2p/src/test-helpers/make-test-p2p-clients.ts
+++ b/yarn-project/p2p/src/test-helpers/make-test-p2p-clients.ts
@@ -15,6 +15,7 @@ import type { TxPool } from '../mem_pools/tx_pool/index.js';
 import { generatePeerIdPrivateKeys } from '../test-helpers/generate-peer-id-private-keys.js';
 import { getPorts } from './get-ports.js';
 import { makeEnrs } from './make-enrs.js';
+import { type MockGossipSubNetwork, getMockPubSubP2PServiceFactory } from './mock-pubsub.js';
 import { AlwaysFalseCircuitVerifier, AlwaysTrueCircuitVerifier } from './reqresp-nodes.js';
 
 export interface MakeTestP2PClientOptions {
@@ -26,6 +27,7 @@ export interface MakeTestP2PClientOptions {
   p2pBaseConfig: P2PConfig;
   p2pConfigOverrides?: Partial<P2PConfig>;
   logger?: Logger;
+  mockGossipSubNetwork?: MockGossipSubNetwork;
 }
 
 /**
@@ -68,6 +70,7 @@ export async function makeTestP2PClient(
     mockTxPool,
     mockEpochCache,
     mockWorldState,
+    mockGossipSubNetwork,
     logger = createLogger('p2p-test-client'),
   }: MakeTestP2PClientOptions,
 ) {
@@ -91,12 +94,7 @@ export async function makeTestP2PClient(
 
   const proofVerifier = alwaysTrueVerifier ? new AlwaysTrueCircuitVerifier() : new AlwaysFalseCircuitVerifier();
   const kvStore = await openTmpStore('test');
-  const deps = {
-    txPool: mockTxPool as unknown as TxPool,
-    attestationPool: mockAttestationPool as unknown as AttestationPool,
-    store: kvStore,
-    logger,
-  };
+
   const client = await createP2PClient(
     P2PClientType.Full,
     config,
@@ -106,7 +104,13 @@ export async function makeTestP2PClient(
     mockEpochCache,
     'test-p2p-client',
     undefined,
-    deps,
+    {
+      txPool: mockTxPool as unknown as TxPool,
+      attestationPool: mockAttestationPool as unknown as AttestationPool,
+      store: kvStore,
+      logger,
+      p2pServiceFactory: mockGossipSubNetwork && getMockPubSubP2PServiceFactory(mockGossipSubNetwork),
+    },
   );
 
   return client;

--- a/yarn-project/p2p/src/test-helpers/mock-pubsub.ts
+++ b/yarn-project/p2p/src/test-helpers/mock-pubsub.ts
@@ -1,0 +1,187 @@
+import type { EpochCacheInterface } from '@aztec/epoch-cache';
+import { type Logger, createLogger } from '@aztec/foundation/log';
+import type { AztecAsyncKVStore } from '@aztec/kv-store';
+import type { L2BlockSource } from '@aztec/stdlib/block';
+import type { ContractDataSource } from '@aztec/stdlib/contract';
+import type { ClientProtocolCircuitVerifier, WorldStateSynchronizer } from '@aztec/stdlib/interfaces/server';
+import { P2PClientType } from '@aztec/stdlib/p2p';
+import type { TelemetryClient } from '@aztec/telemetry-client';
+
+import type { GossipsubEvents, GossipsubMessage } from '@chainsafe/libp2p-gossipsub';
+import type { MsgIdStr, PeerIdStr, PublishOpts, TopicStr } from '@chainsafe/libp2p-gossipsub/types';
+import {
+  type Libp2pStatus,
+  type PeerId,
+  type PublishResult,
+  type TopicValidatorResult,
+  TypedEventEmitter,
+} from '@libp2p/interface';
+
+import type { P2PConfig } from '../config.js';
+import type { MemPools } from '../mem_pools/interface.js';
+import { DummyPeerDiscoveryService, DummyPeerManager, DummyReqResp, LibP2PService } from '../services/index.js';
+import type { ReqRespInterface } from '../services/reqresp/interface.js';
+import { GossipSubEvent } from '../types/index.js';
+import type { PubSubLibp2p } from '../util.js';
+
+type GossipSubService = PubSubLibp2p['services']['pubsub'];
+
+/**
+ * Given a mock gossip sub network, returns a factory function that creates an instance LibP2PService connected to it.
+ * Designed to be used in tests in P2PClientDeps.p2pServiceFactory.
+ */
+export function getMockPubSubP2PServiceFactory<T extends P2PClientType>(
+  network: MockGossipSubNetwork,
+): (...args: Parameters<(typeof LibP2PService<T>)['new']>) => Promise<LibP2PService<T>> {
+  return (
+    clientType: P2PClientType,
+    config: P2PConfig,
+    peerId: PeerId,
+    deps: {
+      packageVersion: string;
+      mempools: MemPools<T>;
+      l2BlockSource: L2BlockSource & ContractDataSource;
+      epochCache: EpochCacheInterface;
+      proofVerifier: ClientProtocolCircuitVerifier;
+      worldStateSynchronizer: WorldStateSynchronizer;
+      peerStore: AztecAsyncKVStore;
+      telemetry: TelemetryClient;
+      logger: Logger;
+    },
+  ) => {
+    deps.logger.verbose('Creating mock PubSub service');
+    const libp2p = new MockPubSub(peerId, network);
+    const peerManager = new DummyPeerManager(peerId, network);
+    const reqresp: ReqRespInterface = new DummyReqResp();
+    const peerDiscoveryService = new DummyPeerDiscoveryService();
+    const service = new LibP2PService<T>(
+      clientType as T,
+      config,
+      libp2p,
+      peerDiscoveryService,
+      reqresp,
+      peerManager,
+      deps.mempools,
+      deps.l2BlockSource,
+      deps.epochCache,
+      deps.proofVerifier,
+      deps.worldStateSynchronizer,
+      deps.telemetry,
+      deps.logger,
+    );
+
+    return Promise.resolve(service);
+  };
+}
+
+/**
+ * Implementation of PubSub services that relies on a mock gossip sub network.
+ * This is used in tests to simulate a gossip sub network without needing a real P2P network.
+ * All messages are sent to the mock network which then distributes them to subscribed peers.
+ */
+export class MockPubSub implements PubSubLibp2p {
+  public status: Libp2pStatus = 'stopped';
+
+  private gossipSub: GossipSubService;
+
+  constructor(
+    public peerId: PeerId,
+    network: MockGossipSubNetwork,
+  ) {
+    this.gossipSub = new MockGossipSubService(peerId, network);
+  }
+
+  get services() {
+    return {
+      pubsub: this.gossipSub,
+    };
+  }
+
+  start(): void | Promise<void> {
+    this.status = 'started';
+    return Promise.resolve();
+  }
+  stop(): void | Promise<void> {
+    this.status = 'stopped';
+    return Promise.resolve();
+  }
+}
+
+class MockGossipSubService extends TypedEventEmitter<GossipsubEvents> implements GossipSubService {
+  private logger = createLogger('p2p:test:mock-gossipsub');
+  public subscribedTopics: Set<TopicStr> = new Set();
+
+  constructor(
+    public peerId: PeerId,
+    private network: MockGossipSubNetwork,
+  ) {
+    super();
+    network.registerPeer(this);
+  }
+
+  score = {
+    score: (_peerId: PeerIdStr) => 0,
+  };
+
+  publish(topic: TopicStr, data: Uint8Array, _opts?: PublishOpts): Promise<PublishResult> {
+    this.logger.debug(`Publishing message on topic ${topic}`, { topic, sender: this.peerId.toString() });
+    this.network.publishToPeers(topic, data, this.peerId);
+    return Promise.resolve({ recipients: this.network.getPeers().filter(peer => !this.peerId.equals(peer)) });
+  }
+
+  receive(msg: GossipsubMessage) {
+    if (msg.propagationSource.equals(this.peerId)) {
+      return; // Ignore messages from self
+    }
+    this.logger.debug(`Received message on topic ${msg.msg.topic}`, { ...msg });
+    this.safeDispatchEvent<GossipsubMessage>(GossipSubEvent.MESSAGE, { detail: msg });
+  }
+
+  subscribe(topic: TopicStr): void {
+    this.logger.debug(`Subscribed to topic ${topic}`, { topic });
+    this.subscribedTopics.add(topic);
+  }
+
+  reportMessageValidationResult(msgId: MsgIdStr, propagationSource: PeerIdStr, acceptance: TopicValidatorResult): void {
+    this.logger.debug(
+      `Reported message validation result ${acceptance} for msgId ${msgId} from source ${propagationSource}`,
+      { msgId, propagationSource, acceptance },
+    );
+  }
+}
+
+/**
+ * Mock gossip sub network used for testing.
+ * All instances of MockGossipSubService connected to the same network will instantly receive the same messages.
+ */
+export class MockGossipSubNetwork {
+  private peers: MockGossipSubService[] = [];
+  private nextMsgId = 0;
+
+  private logger = createLogger('p2p:test:mock-gossipsub-network');
+
+  public getPeers(): PeerId[] {
+    return this.peers.map(peer => peer.peerId);
+  }
+
+  public registerPeer(peer: MockGossipSubService): void {
+    this.peers.push(peer);
+  }
+
+  public publishToPeers(topic: TopicStr, data: Uint8Array, sender: PeerId): void {
+    const msgId = (this.nextMsgId++).toString();
+    this.logger.debug(`Network is distributing message on topic ${topic}`, {
+      topic,
+      size: data.length,
+      sender: sender.toString(),
+      msgId,
+    });
+
+    const gossipSubMsg: GossipsubMessage = { msgId, msg: { type: 'unsigned', topic, data }, propagationSource: sender };
+    for (const peer of this.peers) {
+      if (peer.subscribedTopics.has(topic)) {
+        peer.receive(gossipSubMsg);
+      }
+    }
+  }
+}

--- a/yarn-project/p2p/src/testbench/p2p_client_testbench_worker.ts
+++ b/yarn-project/p2p/src/testbench/p2p_client_testbench_worker.ts
@@ -26,6 +26,8 @@ import type { AttestationPool } from '../mem_pools/attestation_pool/attestation_
 import type { MemPools } from '../mem_pools/interface.js';
 import type { TxPool } from '../mem_pools/tx_pool/index.js';
 import { LibP2PService } from '../services/libp2p/libp2p_service.js';
+import type { PeerManager } from '../services/peer-manager/peer_manager.js';
+import type { ReqResp } from '../services/reqresp/reqresp.js';
 import type { PeerDiscoveryService } from '../services/service.js';
 import { AlwaysTrueCircuitVerifier } from '../test-helpers/reqresp-nodes.js';
 import type { PubSubLibp2p } from '../util.js';
@@ -108,6 +110,8 @@ class TestLibP2PService<T extends P2PClientType = P2PClientType.Full> extends Li
     config: P2PConfig,
     node: PubSubLibp2p,
     peerDiscoveryService: PeerDiscoveryService,
+    reqresp: ReqResp,
+    peerManager: PeerManager,
     mempools: MemPools<T>,
     archiver: L2BlockSource & ContractDataSource,
     epochCache: EpochCacheInterface,
@@ -122,6 +126,8 @@ class TestLibP2PService<T extends P2PClientType = P2PClientType.Full> extends Li
       config,
       node,
       peerDiscoveryService,
+      reqresp,
+      peerManager,
       mempools,
       archiver,
       epochCache,
@@ -201,8 +207,6 @@ process.on('message', async msg => {
         deps,
       );
 
-      const _client = client as any;
-
       // Create test service with validation disabled
       const testService = new TestLibP2PService(
         P2PClientType.Full,
@@ -210,6 +214,8 @@ process.on('message', async msg => {
         (client as any).p2pService.node,
         (client as any).p2pService.peerDiscoveryService,
         (client as any).p2pService.mempools,
+        (client as any).p2pService.reqresp,
+        (client as any).p2pService.peerManager,
         (client as any).p2pService.archiver,
         epochCache,
         proofVerifier,

--- a/yarn-project/p2p/src/util.ts
+++ b/yarn-project/p2p/src/util.ts
@@ -4,6 +4,7 @@ import type { DataStoreConfig } from '@aztec/kv-store/config';
 
 import type { GossipSub } from '@chainsafe/libp2p-gossipsub';
 import { generateKeyPair, marshalPrivateKey, unmarshalPrivateKey } from '@libp2p/crypto/keys';
+import type { Identify } from '@libp2p/identify';
 import type { PeerId, PrivateKey } from '@libp2p/interface';
 import type { ConnectionManager } from '@libp2p/interface-internal';
 import { createFromPrivKey } from '@libp2p/peer-id-factory';
@@ -16,14 +17,22 @@ import type { P2PConfig } from './config.js';
 
 const PEER_ID_DATA_DIR_FILE = 'p2p-private-key';
 
-export interface PubSubLibp2p extends Libp2p {
+export interface PubSubLibp2p extends Pick<Libp2p, 'status' | 'start' | 'stop' | 'peerId'> {
   services: {
-    pubsub: GossipSub;
-    components: {
-      connectionManager: ConnectionManager;
-    };
+    pubsub: Pick<
+      GossipSub,
+      'addEventListener' | 'removeEventListener' | 'publish' | 'subscribe' | 'reportMessageValidationResult'
+    > & { score: Pick<GossipSub['score'], 'score'> };
   };
 }
+
+export type FullLibp2p = Libp2p<{
+  identify: Identify;
+  pubsub: GossipSub;
+  components: {
+    connectionManager: ConnectionManager;
+  };
+}>;
 
 /**
  * Converts an address string to a multiaddr string.

--- a/yarn-project/sequencer-client/src/client/sequencer-client.ts
+++ b/yarn-project/sequencer-client/src/client/sequencer-client.ts
@@ -31,10 +31,13 @@ import { Sequencer, type SequencerConfig } from '../sequencer/index.js';
  * Encapsulates the full sequencer and publisher.
  */
 export class SequencerClient {
-  constructor(protected sequencer: Sequencer) {}
+  constructor(
+    protected sequencer: Sequencer,
+    protected validatorClient?: ValidatorClient,
+  ) {}
 
   /**
-   * Initializes and starts a new instance.
+   * Initializes a new instance.
    * @param config - Configuration for the sequencer, publisher, and L1 tx sender.
    * @param p2pClient - P2P client that provides the txs to be sequenced.
    * @param validatorClient - Validator client performs attestation duties when rotating proposers.
@@ -169,9 +172,7 @@ export class SequencerClient {
       { ...config, maxL1TxInclusionTimeIntoSlot, maxL2BlockGas: sequencerManaLimit },
       telemetryClient,
     );
-    await validatorClient?.start();
-    sequencer.start();
-    return new SequencerClient(sequencer);
+    return new SequencerClient(sequencer, validatorClient);
   }
 
   /**
@@ -180,6 +181,12 @@ export class SequencerClient {
    */
   public updateSequencerConfig(config: SequencerConfig) {
     return this.sequencer.updateConfig(config);
+  }
+
+  /** Starts the sequencer. */
+  public async start() {
+    await this.validatorClient?.start();
+    this.sequencer.start();
   }
 
   /**
@@ -197,8 +204,8 @@ export class SequencerClient {
   /**
    * Restarts the sequencer after being stopped.
    */
-  public restart() {
-    this.sequencer.restart();
+  public resume() {
+    this.sequencer.resume();
   }
 
   public getSequencer(): Sequencer {

--- a/yarn-project/sequencer-client/src/index.ts
+++ b/yarn-project/sequencer-client/src/index.ts
@@ -1,7 +1,12 @@
 export * from './client/index.js';
 export * from './config.js';
 export * from './publisher/index.js';
-export { FullNodeBlockBuilder as BlockBuilder, Sequencer, SequencerState } from './sequencer/index.js';
+export {
+  FullNodeBlockBuilder as BlockBuilder,
+  Sequencer,
+  SequencerState,
+  type SequencerEvents,
+} from './sequencer/index.js';
 export * from './tx_validator/tx_validator_factory.js';
 
 // Used by the node to simulate public parts of transactions. Should these be moved to a shared library?

--- a/yarn-project/sequencer-client/src/publisher/sequencer-publisher.test.ts
+++ b/yarn-project/sequencer-client/src/publisher/sequencer-publisher.test.ts
@@ -113,7 +113,7 @@ describe('SequencerPublisher', () => {
     governanceProposerContract = mock<GovernanceProposerContract>();
 
     const epochCache = mock<EpochCache>();
-    epochCache.getEpochAndSlotNow.mockReturnValue({ epoch: 1n, slot: 2n, ts: 3n });
+    epochCache.getEpochAndSlotNow.mockReturnValue({ epoch: 1n, slot: 2n, ts: 3n, now: 3n });
     epochCache.getCommittee.mockResolvedValue({ committee: [], seed: 1n, epoch: 1n });
 
     publisher = new SequencerPublisher(config, {

--- a/yarn-project/sequencer-client/src/publisher/sequencer-publisher.ts
+++ b/yarn-project/sequencer-client/src/publisher/sequencer-publisher.ts
@@ -58,7 +58,8 @@ export enum VoteType {
 
 type GetSlashPayloadCallBack = (slotNumber: bigint) => Promise<EthAddress | undefined>;
 
-type Action = 'propose' | 'governance-vote' | 'slashing-vote';
+export type Action = 'propose' | 'governance-vote' | 'slashing-vote';
+
 interface RequestWithExpiry {
   action: Action;
   request: L1TxRequest;
@@ -182,7 +183,7 @@ export class SequencerPublisher {
       return undefined;
     }
     const currentL2Slot = this.getCurrentL2Slot();
-    this.log.debug(`Current L2 slot: ${currentL2Slot}`);
+    this.log.debug(`Sending requests on L2 slot ${currentL2Slot}`);
     const validRequests = requestsToProcess.filter(request => request.lastValidL2Slot >= currentL2Slot);
     const validActions = validRequests.map(x => x.action);
     const expiredActions = requestsToProcess

--- a/yarn-project/sequencer-client/src/sequencer/sequencer.test.ts
+++ b/yarn-project/sequencer-client/src/sequencer/sequencer.test.ts
@@ -161,7 +161,7 @@ describe('sequencer', () => {
     l1Constants = { l1GenesisTime, slotDuration, ethereumSlotDuration };
 
     const epochCache = mockDeep<EpochCache>();
-    epochCache.getEpochAndSlotInNextL1Slot.mockImplementation(() => ({ epoch: 1n, slot: 1n, ts: 1000n }));
+    epochCache.getEpochAndSlotInNextL1Slot.mockImplementation(() => ({ epoch: 1n, slot: 1n, ts: 1000n, now: 1000n }));
 
     publisher = mockDeep<SequencerPublisher>();
     publisher.epochCache = epochCache;
@@ -171,7 +171,11 @@ describe('sequencer', () => {
     publisher.validateBlockForSubmission.mockResolvedValue(1n);
     publisher.enqueueProposeL2Block.mockResolvedValue(true);
     publisher.enqueueCastVote.mockResolvedValue(true);
-    publisher.canProposeAtNextEthBlock.mockResolvedValue([BigInt(newSlotNumber), BigInt(newBlockNumber)]);
+    publisher.canProposeAtNextEthBlock.mockResolvedValue({
+      slot: BigInt(newSlotNumber),
+      blockNumber: BigInt(newBlockNumber),
+      timeOfNextL1Slot: 1000n,
+    });
 
     globalVariableBuilder = mock<GlobalVariableBuilder>();
     globalVariableBuilder.buildGlobalVariables.mockResolvedValue(globalVariables);
@@ -308,10 +312,11 @@ describe('sequencer', () => {
     expect(blockBuilder.buildBlock).not.toHaveBeenCalled();
 
     // Now we can propose, but lets assume that the content is still "bad" (missing sigs etc)
-    publisher.canProposeAtNextEthBlock.mockResolvedValue([
-      block.header.globalVariables.slotNumber.toBigInt(),
-      BigInt(block.header.globalVariables.blockNumber),
-    ]);
+    publisher.canProposeAtNextEthBlock.mockResolvedValue({
+      slot: block.header.globalVariables.slotNumber.toBigInt(),
+      blockNumber: BigInt(block.header.globalVariables.blockNumber),
+      timeOfNextL1Slot: 1000n,
+    });
 
     await sequencer.doRealWork();
     expect(blockBuilder.buildBlock).not.toHaveBeenCalled();


### PR DESCRIPTION
Adds an e2e test to monitor that there are no unexpected recoverable errors during block building.

The test `monitor_block_build` works by spinning up N validator nodes, connected via a mock gossipsub network, and having them produce blocks until all sent txs have been mined. This required:

- Adding a new `MockGossipSub` service, that can be fed into `Libp2pService` instead of an actual `Libp2p` node. This service connects to a singleton that just dispatches messages on the spot. This allows us to remove any p2p errors from this test, and see how nodes behave in a perfect p2p network. This mock implementation is tested in the p2p-integration suite. An alternative to this would have been replacing the `Libp2pService` in `P2PClient`, but we currently have a lot of business logic (mostly validations) in the `Libp2pService` which are good to exercise in tests.
- Turning the sequencer into an `EventEmitter` so we could check when an error would happen. An alternative would have been hijacking the logger and listening for specific error message strings, but having typed events is more robust.
- Adding an option to enable anvil `automine` during L1 contracts deployment in e2e test setup. This was not needed for the test, but I was getting really annoyed at waiting for it.
- Adding an option to disable the anvil test watcher in e2e test setup, because I don't like clocks changing underfoot, and they could cause unexpected sync issues in sequencers.

This test uncovered two issues, now fixed:
- We were doing time warp in anvil wrong.
- We were trying to build more than one block for the same slot.