### PR TITLE
chore: stop voting for override after executed

### DIFF
--- a/yarn-project/slasher/src/slasher_client.ts
+++ b/yarn-project/slasher/src/slasher_client.ts
@@ -215,7 +215,7 @@ export class SlasherClient {
    *
    * Removes the first matching payload from the list of monitored payloads.
    *
-   * Bound to the slashing proposer contract's listenToProposalExecuted method in the constructor.
+   * Bound to the slashing proposer contract's listenToProposalExecuted method in `.start()`.
    *
    * @param {round: bigint; proposal: `0x${string}`} param0
    */
@@ -290,6 +290,7 @@ export class SlasherClient {
         if (!added) {
           this.log.warn('Failed to add monitored payload that we created');
         } else {
+          this.sortMonitoredPayloads();
           this.log.info('Added monitored payload that we created');
         }
       })

--- a/yarn-project/slasher/src/slasher_client.ts
+++ b/yarn-project/slasher/src/slasher_client.ts
@@ -66,6 +66,7 @@ type MonitoredSlashPayload = {
 export class SlasherClient {
   private monitoredPayloads: MonitoredSlashPayload[] = [];
   private unwatchCallbacks: (() => void)[] = [];
+  private overridePayloadActive = false;
 
   static async new(
     config: SlasherConfig,
@@ -100,7 +101,9 @@ export class SlasherClient {
     private watchers: Watcher[],
     private dateProvider: DateProvider,
     private log = createLogger('slasher'),
-  ) {}
+  ) {
+    this.overridePayloadActive = config.slashOverridePayload !== undefined && !config.slashOverridePayload.isZero();
+  }
 
   //////////////////// Public methods ////////////////////
 
@@ -164,6 +167,7 @@ export class SlasherClient {
       slashProposerRoundPollingIntervalSeconds:
         config.slashProposerRoundPollingIntervalSeconds ?? this.config.slashProposerRoundPollingIntervalSeconds,
     };
+    this.overridePayloadActive = config.slashOverridePayload !== undefined && !config.slashOverridePayload.isZero();
     this.config = newConfig;
   }
 
@@ -174,7 +178,7 @@ export class SlasherClient {
    * @returns the payload to slash or undefined if there is no payload to slash
    */
   public getSlashPayload(_slotNumber: bigint): Promise<EthAddress | undefined> {
-    if (this.config.slashOverridePayload && !this.config.slashOverridePayload.isZero()) {
+    if (this.overridePayloadActive && this.config.slashOverridePayload && !this.config.slashOverridePayload.isZero()) {
       this.log.info(`Overriding slash payload to: ${this.config.slashOverridePayload.toString()}`);
       return Promise.resolve(this.config.slashOverridePayload);
     }
@@ -202,6 +206,32 @@ export class SlasherClient {
    */
   public getMonitoredPayloads(): MonitoredSlashPayload[] {
     return this.monitoredPayloads;
+  }
+
+  //////////////////// Protected methods ////////////////////
+
+  /**
+   * Handler for when a proposal is executed.
+   *
+   * Removes the first matching payload from the list of monitored payloads.
+   *
+   * Bound to the slashing proposer contract's listenToProposalExecuted method in the constructor.
+   *
+   * @param {round: bigint; proposal: `0x${string}`} param0
+   */
+  protected proposalExecuted({ round, proposal }: { round: bigint; proposal: `0x${string}` }) {
+    this.log.info('Proposal executed', { round, proposal });
+    const payload = EthAddress.fromString(proposal);
+    // Stop signaling for the override payload if it was executed
+    if (this.overridePayloadActive && this.config.slashOverridePayload?.equals(payload)) {
+      this.overridePayloadActive = false;
+    }
+
+    const index = this.monitoredPayloads.findIndex(p => p.payloadAddress.equals(payload));
+    if (index === -1) {
+      return;
+    }
+    this.monitoredPayloads.splice(index, 1);
   }
 
   //////////////////// Private methods ////////////////////
@@ -435,24 +465,6 @@ export class SlasherClient {
           throw err;
         }
       });
-  }
-
-  /**
-   * Handler for when a proposal is executed.
-   *
-   * Removes the first matching payload from the list of monitored payloads.
-   *
-   * Bound to the slashing proposer contract's listenToProposalExecuted method in the constructor.
-   *
-   * @param {round: bigint; proposal: `0x${string}`} param0
-   */
-  private proposalExecuted({ round, proposal }: { round: bigint; proposal: `0x${string}` }) {
-    this.log.info('Proposal executed', { round, proposal });
-    const index = this.monitoredPayloads.findIndex(p => p.payloadAddress.equals(EthAddress.fromString(proposal)));
-    if (index === -1) {
-      return;
-    }
-    this.monitoredPayloads.splice(index, 1);
   }
 
   private async getAddressAndIsDeployed(


### PR DESCRIPTION
This PR fixes an issue where the SlasherClient would continue to signal an override payload even after it had been executed. Now, when a proposal is executed, the client checks if it matches the override payload and disables the override if it does.

Changes include:
- Added an `overridePayloadActive` flag to track whether the override payload should be used
- Modified `proposalExecuted()` to disable the override when the override payload is executed
- Made `proposalExecuted()` protected instead of private to allow testing
- Added tests to verify the override payload behavior
- Created a `TestSlasherClient` class to expose protected methods for testing

Fix #14488 