### PR TITLE
feat: detecting event selector collisions

### DIFF
--- a/noir-projects/aztec-nr/aztec/src/macros/events.nr
+++ b/noir-projects/aztec-nr/aztec/src/macros/events.nr
@@ -1,12 +1,12 @@
 use super::utils::{compute_event_selector, get_trait_impl_method};
 use poseidon::poseidon2::Poseidon2Hasher;
 use protocol_types::meta::derive_serialize;
-use std::{collections::umap::UHashMap, hash::{BuildHasherDefault, Hash, Hasher}};
+use std::{collections::umap::UHashMap, hash::BuildHasherDefault, panic};
 
-/// A map from event selector to a boolean indicating whether the event selector has already been seen during
+/// A map from event selector to event name indicating whether the event selector has already been seen during
 /// the contract compilation - prevents event selector collisions.
-pub comptime mut global EVENT_SELECTORS: UHashMap<Field, bool, BuildHasherDefault<Poseidon2Hasher>>
-     = UHashMap::default();
+pub comptime mut global EVENT_SELECTORS: UHashMap<Field, Quoted, BuildHasherDefault<Poseidon2Hasher>> =
+    UHashMap::default();
 
 comptime fn generate_event_interface_and_get_selector(s: TypeDefinition) -> (Quoted, Field) {
     let name = s.name();
@@ -54,14 +54,19 @@ comptime fn derive_serialize_if_not_implemented(s: TypeDefinition) -> Quoted {
     }
 }
 
-comptime fn register_event_selector(event_selector: Field) {
-    assert(!EVENT_SELECTORS.contains_key(event_selector), "Event selector collision detected");
-    EVENT_SELECTORS.insert(event_selector, true);
+comptime fn register_event_selector(event_selector: Field, event_name: Quoted) {
+    if EVENT_SELECTORS.contains_key(event_selector) {
+        let existing_event = EVENT_SELECTORS.get(event_selector).unwrap();
+        panic(
+            f"Event selector collision detected between events '{event_name}' and '{existing_event}'",
+        );
+    }
+    EVENT_SELECTORS.insert(event_selector, event_name);
 }
 
 pub comptime fn event(s: TypeDefinition) -> Quoted {
     let (event_interface_impl, event_selector) = generate_event_interface_and_get_selector(s);
-    register_event_selector(event_selector);
+    register_event_selector(event_selector, s.name());
 
     let serialize_impl = derive_serialize_if_not_implemented(s);
 

--- a/noir-projects/aztec-nr/aztec/src/macros/events.nr
+++ b/noir-projects/aztec-nr/aztec/src/macros/events.nr
@@ -1,10 +1,17 @@
 use super::utils::{compute_event_selector, get_trait_impl_method};
+use poseidon::poseidon2::Poseidon2Hasher;
 use protocol_types::meta::derive_serialize;
+use std::{collections::umap::UHashMap, hash::{BuildHasherDefault, Hash, Hasher}};
 
-comptime fn generate_event_interface(s: TypeDefinition) -> Quoted {
+/// A map from event selector to a boolean indicating whether the event selector has already been seen during
+/// the contract compilation - prevents event selector collisions.
+pub comptime mut global EVENT_SELECTORS: UHashMap<Field, bool, BuildHasherDefault<Poseidon2Hasher>>
+     = UHashMap::default();
+
+comptime fn generate_event_interface_and_get_selector(s: TypeDefinition) -> (Quoted, Field) {
     let name = s.name();
 
-    let event_type_id = compute_event_selector(s);
+    let event_selector = compute_event_selector(s);
 
     let from_field = get_trait_impl_method(
         quote { crate::protocol_types::abis::event_selector::EventSelector }.as_type(),
@@ -12,13 +19,16 @@ comptime fn generate_event_interface(s: TypeDefinition) -> Quoted {
         quote { from_field },
     );
 
-    quote {
+    (
+        quote {
         impl aztec::event::event_interface::EventInterface for $name {
             fn get_event_type_id() -> aztec::protocol_types::abis::event_selector::EventSelector {
-                $from_field($event_type_id)
+                $from_field($event_selector)
             }
         }
-    }
+    },
+        event_selector,
+    )
 }
 
 /// Generates a quote that implements `Serialize` for a given struct `s`.
@@ -44,8 +54,15 @@ comptime fn derive_serialize_if_not_implemented(s: TypeDefinition) -> Quoted {
     }
 }
 
+comptime fn register_event_selector(event_selector: Field) {
+    assert(!EVENT_SELECTORS.contains_key(event_selector), "Event selector collision detected");
+    EVENT_SELECTORS.insert(event_selector, true);
+}
+
 pub comptime fn event(s: TypeDefinition) -> Quoted {
-    let event_interface_impl = generate_event_interface(s);
+    let (event_interface_impl, event_selector) = generate_event_interface_and_get_selector(s);
+    register_event_selector(event_selector);
+
     let serialize_impl = derive_serialize_if_not_implemented(s);
 
     s.add_attribute("abi(events)");

--- a/noir-projects/noir-contracts-comp-failures/contracts/event_selector_collision/Nargo.toml
+++ b/noir-projects/noir-contracts-comp-failures/contracts/event_selector_collision/Nargo.toml
@@ -1,0 +1,8 @@
+[package]
+name = "event_selector_collision"
+authors = [""]
+compiler_version = ">=0.25.0"
+type = "contract"
+
+[dependencies]
+aztec = { path = "../../../aztec-nr/aztec" }

--- a/noir-projects/noir-contracts-comp-failures/contracts/event_selector_collision/expected_error
+++ b/noir-projects/noir-contracts-comp-failures/contracts/event_selector_collision/expected_error
@@ -1,1 +1,1 @@
-Event selector collision detected
+Event selector collision detected between events

--- a/noir-projects/noir-contracts-comp-failures/contracts/event_selector_collision/expected_error
+++ b/noir-projects/noir-contracts-comp-failures/contracts/event_selector_collision/expected_error
@@ -1,0 +1,1 @@
+Event selector collision detected

--- a/noir-projects/noir-contracts-comp-failures/contracts/event_selector_collision/src/main.nr
+++ b/noir-projects/noir-contracts-comp-failures/contracts/event_selector_collision/src/main.nr
@@ -1,0 +1,79 @@
+use aztec::macros::aztec;
+
+#[aztec]
+pub contract EventSelectorCollision {
+    use aztec::{
+        macros::events::event,
+        protocol_types::{
+            abis::event_selector::EventSelector, hash::poseidon2_hash_bytes, traits::ToField,
+        },
+    };
+
+    // TODO: replace this with nice event signatures once Zorzal shares his script
+    #[event]
+    struct fn_selector_collision {
+    }
+
+    #[event]
+    struct fn_selector_collision_1442740381 {
+    }
+}
+
+mod tests {
+    use aztec::protocol_types::{
+        abis::event_selector::EventSelector,
+        hash::{poseidon2_hash_bytes, poseidon2_hash_slice},
+        traits::ToField,
+    };
+
+    fn compute_selector_from_bytes<let N: u32>(bytes: [u8; N]) -> Field {
+        poseidon2_hash_bytes(bytes) as u32 as Field
+    }
+
+    #[test]
+    unconstrained fn find_colliding_event_selectors() {
+        let event_signature = "fn_selector_collision()";
+        let event_selector = EventSelector::from_signature(event_signature).to_field();
+
+        let event_signature_2 = "fn_selector_collision_1442740381()";
+        let event_selector_2 = EventSelector::from_signature(event_signature_2).to_field();
+
+        std::println(event_selector);
+        std::println(event_selector_2);
+
+        // assert_eq(
+        //     compute_selector_from_bytes(event_signature.as_bytes()),
+        //     event_selector,
+        //     "Event selector implementation changed",
+        // );
+
+        // // Now we will keep on modifying the event signature until we find a collision.
+        // let mut i = 0;
+        // let mut found = false;
+        // let mut test_signature = "TestEvent_".as_bytes().as_slice().map(|x| x as Field);
+        // while !found & (i < 1000000) {
+        //     let mut test_signature_copy = test_signature;
+        //     for j in 32..127 {
+        //         test_signature_copy = test_signature_copy.push_back(j as Field);
+
+        //         let test_selector = poseidon2_hash_slice(test_signature_copy) as u32 as Field;
+        //         // let test_selector = EventSelector::from_signature(test_signature);
+
+        //         std::println(test_selector);
+
+        //         if test_selector.eq(event_selector) {
+        //             found = true;
+        //             std::println(
+        //                 f"Found collision! Original: {event_signature} New: {test_signature}",
+        //             );
+        //         }
+        //     }
+        //     i += 1;
+        //     test_signature = test_signature_copy;
+        // }
+
+        // if !found {
+        //     std::println("No collision found after 1M attempts");
+        // }
+    }
+}

--- a/noir-projects/noir-contracts-comp-failures/contracts/event_selector_collision/src/main.nr
+++ b/noir-projects/noir-contracts-comp-failures/contracts/event_selector_collision/src/main.nr
@@ -4,10 +4,9 @@ use aztec::macros::aztec;
 pub contract EventSelectorCollision {
     use aztec::macros::events::event;
 
-    // TODO: replace this with nice event signatures once Zorzal shares his script
     #[event]
-    struct fn_selector_collision {}
+    struct EventCollision {}
 
     #[event]
-    struct fn_selector_collision_1442740381 {}
+    struct EventCollision8370082250 {}
 }

--- a/noir-projects/noir-contracts-comp-failures/contracts/event_selector_collision/src/main.nr
+++ b/noir-projects/noir-contracts-comp-failures/contracts/event_selector_collision/src/main.nr
@@ -2,78 +2,12 @@ use aztec::macros::aztec;
 
 #[aztec]
 pub contract EventSelectorCollision {
-    use aztec::{
-        macros::events::event,
-        protocol_types::{
-            abis::event_selector::EventSelector, hash::poseidon2_hash_bytes, traits::ToField,
-        },
-    };
+    use aztec::macros::events::event;
 
     // TODO: replace this with nice event signatures once Zorzal shares his script
     #[event]
-    struct fn_selector_collision {
-    }
+    struct fn_selector_collision {}
 
     #[event]
-    struct fn_selector_collision_1442740381 {
-    }
-}
-
-mod tests {
-    use aztec::protocol_types::{
-        abis::event_selector::EventSelector,
-        hash::{poseidon2_hash_bytes, poseidon2_hash_slice},
-        traits::ToField,
-    };
-
-    fn compute_selector_from_bytes<let N: u32>(bytes: [u8; N]) -> Field {
-        poseidon2_hash_bytes(bytes) as u32 as Field
-    }
-
-    #[test]
-    unconstrained fn find_colliding_event_selectors() {
-        let event_signature = "fn_selector_collision()";
-        let event_selector = EventSelector::from_signature(event_signature).to_field();
-
-        let event_signature_2 = "fn_selector_collision_1442740381()";
-        let event_selector_2 = EventSelector::from_signature(event_signature_2).to_field();
-
-        std::println(event_selector);
-        std::println(event_selector_2);
-
-        // assert_eq(
-        //     compute_selector_from_bytes(event_signature.as_bytes()),
-        //     event_selector,
-        //     "Event selector implementation changed",
-        // );
-
-        // // Now we will keep on modifying the event signature until we find a collision.
-        // let mut i = 0;
-        // let mut found = false;
-        // let mut test_signature = "TestEvent_".as_bytes().as_slice().map(|x| x as Field);
-        // while !found & (i < 1000000) {
-        //     let mut test_signature_copy = test_signature;
-        //     for j in 32..127 {
-        //         test_signature_copy = test_signature_copy.push_back(j as Field);
-
-        //         let test_selector = poseidon2_hash_slice(test_signature_copy) as u32 as Field;
-        //         // let test_selector = EventSelector::from_signature(test_signature);
-
-        //         std::println(test_selector);
-
-        //         if test_selector.eq(event_selector) {
-        //             found = true;
-        //             std::println(
-        //                 f"Found collision! Original: {event_signature} New: {test_signature}",
-        //             );
-        //         }
-        //     }
-        //     i += 1;
-        //     test_signature = test_signature_copy;
-        // }
-
-        // if !found {
-        //     std::println("No collision found after 1M attempts");
-        // }
-    }
+    struct fn_selector_collision_1442740381 {}
 }


### PR DESCRIPTION
Fixes #2707

Adds a compile time check asserting that there are no colliding event selectors in a contract.
