### PR TITLE
feat: public function selectors collision comptime check

### DIFF
--- a/noir-projects/aztec-nr/aztec/src/macros/dispatch.nr
+++ b/noir-projects/aztec-nr/aztec/src/macros/dispatch.nr
@@ -10,9 +10,8 @@ pub comptime fn generate_public_dispatch(m: Module) -> Quoted {
 
     let unit = get_type::<()>();
 
-    let mut seen_selectors: UHashMap<Field, bool, BuildHasherDefault<Poseidon2Hasher>> =
-        UHashMap::default();
-    let mut seen_selectors_ref = &mut seen_selectors;
+    let seen_selectors =
+        &mut UHashMap::<Field, bool, BuildHasherDefault<Poseidon2Hasher>>::default();
 
     let ifs = functions.map(|function: FunctionDefinition| {
         let parameters = function.parameters();
@@ -24,10 +23,10 @@ pub comptime fn generate_public_dispatch(m: Module) -> Quoted {
         // it's possible to have collisions. With the following assert, we ensure it doesn't happen within
         // the same contract.
         assert(
-            !seen_selectors_ref.contains_key(selector),
+            !seen_selectors.contains_key(selector),
             "Public function selector collision detected",
         );
-        seen_selectors_ref.insert(selector, true);
+        seen_selectors.insert(selector, true);
 
         let mut parameters_size = 0;
         for param in parameters {

--- a/noir-projects/aztec-nr/aztec/src/macros/dispatch.nr
+++ b/noir-projects/aztec-nr/aztec/src/macros/dispatch.nr
@@ -1,5 +1,6 @@
 use super::utils::compute_fn_selector;
-use std::panic;
+use poseidon::poseidon2::Poseidon2Hasher;
+use std::{collections::umap::UHashMap, hash::BuildHasherDefault, panic};
 
 /// Returns an `fn public_dispatch(...)` function for the given module that's assumed to be an Aztec contract.
 pub comptime fn generate_public_dispatch(m: Module) -> Quoted {
@@ -9,11 +10,24 @@ pub comptime fn generate_public_dispatch(m: Module) -> Quoted {
 
     let unit = get_type::<()>();
 
+    let mut seen_selectors: UHashMap<Field, bool, BuildHasherDefault<Poseidon2Hasher>> =
+        UHashMap::default();
+    let mut seen_selectors_ref = &mut seen_selectors;
+
     let ifs = functions.map(|function: FunctionDefinition| {
         let parameters = function.parameters();
         let return_type = function.return_type();
 
         let selector: Field = compute_fn_selector(function);
+
+        // Since function selectors are computed as the first 4 bytes of the hash of the function signature,
+        // it's possible to have collisions. With the following assert, we ensure it doesn't happen within
+        // the same contract.
+        assert(
+            !seen_selectors_ref.contains_key(selector),
+            "Public function selector collision detected",
+        );
+        seen_selectors_ref.insert(selector, true);
 
         let mut parameters_size = 0;
         for param in parameters {

--- a/noir-projects/aztec-nr/aztec/src/macros/dispatch.nr
+++ b/noir-projects/aztec-nr/aztec/src/macros/dispatch.nr
@@ -11,22 +11,25 @@ pub comptime fn generate_public_dispatch(m: Module) -> Quoted {
     let unit = get_type::<()>();
 
     let seen_selectors =
-        &mut UHashMap::<Field, bool, BuildHasherDefault<Poseidon2Hasher>>::default();
+        &mut UHashMap::<Field, Quoted, BuildHasherDefault<Poseidon2Hasher>>::default();
 
     let ifs = functions.map(|function: FunctionDefinition| {
         let parameters = function.parameters();
         let return_type = function.return_type();
 
         let selector: Field = compute_fn_selector(function);
+        let fn_name = function.name();
 
         // Since function selectors are computed as the first 4 bytes of the hash of the function signature,
-        // it's possible to have collisions. With the following assert, we ensure it doesn't happen within
+        // it's possible to have collisions. With the following check, we ensure it doesn't happen within
         // the same contract.
-        assert(
-            !seen_selectors.contains_key(selector),
-            "Public function selector collision detected",
-        );
-        seen_selectors.insert(selector, true);
+        if seen_selectors.contains_key(selector) {
+            let existing_fn = seen_selectors.get(selector).unwrap();
+            panic(
+                f"Public function selector collision detected between functions '{fn_name}' and '{existing_fn}'",
+            );
+        }
+        seen_selectors.insert(selector, fn_name);
 
         let mut parameters_size = 0;
         for param in parameters {

--- a/noir-projects/noir-contracts-comp-failures/contracts/public_function_selector_collision/Nargo.toml
+++ b/noir-projects/noir-contracts-comp-failures/contracts/public_function_selector_collision/Nargo.toml
@@ -1,0 +1,8 @@
+[package]
+name = "public_function_selector_collision"
+authors = [""]
+compiler_version = ">=0.25.0"
+type = "contract"
+
+[dependencies]
+aztec = { path = "../../../aztec-nr/aztec" }

--- a/noir-projects/noir-contracts-comp-failures/contracts/public_function_selector_collision/expected_error
+++ b/noir-projects/noir-contracts-comp-failures/contracts/public_function_selector_collision/expected_error
@@ -1,0 +1,1 @@
+Public function selector collision detected

--- a/noir-projects/noir-contracts-comp-failures/contracts/public_function_selector_collision/expected_error
+++ b/noir-projects/noir-contracts-comp-failures/contracts/public_function_selector_collision/expected_error
@@ -1,1 +1,1 @@
-Public function selector collision detected
+Public function selector collision detected between functions

--- a/noir-projects/noir-contracts-comp-failures/contracts/public_function_selector_collision/src/main.nr
+++ b/noir-projects/noir-contracts-comp-failures/contracts/public_function_selector_collision/src/main.nr
@@ -1,5 +1,6 @@
 use aztec::macros::aztec;
 
+/// This contract is used to test that the compile-time public function selector collision detection works.
 #[aztec]
 pub contract PublicFunctionSelectorCollision {
     use aztec::macros::functions::public;

--- a/noir-projects/noir-contracts-comp-failures/contracts/public_function_selector_collision/src/main.nr
+++ b/noir-projects/noir-contracts-comp-failures/contracts/public_function_selector_collision/src/main.nr
@@ -1,0 +1,12 @@
+use aztec::macros::aztec;
+
+#[aztec]
+pub contract PublicFunctionSelectorCollision {
+    use aztec::macros::functions::public;
+
+    #[public]
+    fn fn_selector_collision() {}
+
+    #[public]
+    fn fn_selector_collision_1442740381() {}
+}


### PR DESCRIPTION
Fixes #14588

Adds a compile time check asserting that there are no colliding public function selectors in a contract.
