### PR TITLE
feat: adapt balance set tests for new txe flow

### DIFF
--- a/noir-projects/noir-contracts/contracts/app/token_contract/src/types.nr
+++ b/noir-projects/noir-contracts/contracts/app/token_contract/src/types.nr
@@ -1,1 +1,1 @@
-pub(crate) mod balance_set;
+pub mod balance_set;

--- a/noir-projects/noir-contracts/contracts/test/aztec_nr_test_contract/Nargo.toml
+++ b/noir-projects/noir-contracts/contracts/test/aztec_nr_test_contract/Nargo.toml
@@ -1,0 +1,9 @@
+[package]
+name = "aztec_nr_test_contract"
+authors = [""]
+compiler_version = ">=0.25.0"
+type = "contract"
+
+[dependencies]
+aztec = { path = "../../../../aztec-nr/aztec" }
+token = { path = "../../app/token_contract" }

--- a/noir-projects/noir-contracts/contracts/test/aztec_nr_test_contract/src/main.nr
+++ b/noir-projects/noir-contracts/contracts/test/aztec_nr_test_contract/src/main.nr
@@ -1,0 +1,73 @@
+use dep::aztec::macros::aztec;
+
+#[aztec]
+pub contract AztecNrTest {
+    use dep::aztec::prelude::{
+        AztecAddress, Map
+    };
+
+    use dep::aztec::{
+        macros::{
+            functions::private,
+            storage::storage,
+        },
+        messages::logs::{
+            note::encode_and_encrypt_note_unconstrained,
+        },
+    };
+
+    use dep::token::types::balance_set::BalanceSet;
+    #[storage]
+    struct Storage<Context> {
+        balances: Map<AztecAddress, BalanceSet<Context>, Context>,
+    }
+
+    #[private]
+    fn balance_set_test_setup(recipient: AztecAddress, small_amount: u128, large_amount: u128, small_amount_first: bool) {
+        let (first, second) = if (small_amount_first) {
+            (small_amount, large_amount)
+        } else {
+            (large_amount, small_amount)
+        };
+
+        storage.balances.at(recipient).add(recipient, first).emit(encode_and_encrypt_note_unconstrained(&mut context, recipient, recipient));
+        storage.balances.at(recipient).add(recipient, second).emit(encode_and_encrypt_note_unconstrained(&mut context, recipient, recipient));
+    }
+
+    #[private]
+    fn balance_set_subtract(recipient: AztecAddress, amount_to_sub: u128) -> u128 {
+        let emission = storage.balances.at(recipient).sub(recipient, amount_to_sub);
+        emission.emission.unwrap().note.value
+    }
+
+    use dep::aztec::test::helpers::test_environment::TestEnvironment;
+
+    global LARGE_AMOUNT: u128 = 50;
+    global SMALL_AMOUNT: u128 = 5;
+
+    #[test]
+    unconstrained fn balance_set_uses_largest_note_first() {
+        let mut env = TestEnvironment::new();
+        let owner = env.create_account(1);
+
+        let contract_address =
+            env.deploy_self("AztecNrTest").without_initializer().to_address();
+
+        let _ = env.call_private_test(owner, AztecNrTest::at(contract_address).balance_set_test_setup(owner, SMALL_AMOUNT, LARGE_AMOUNT, true));
+        let change_note_value = env.call_private_test(owner, AztecNrTest::at(contract_address).balance_set_subtract(owner, SMALL_AMOUNT)).return_value;
+        assert_eq(change_note_value, LARGE_AMOUNT - SMALL_AMOUNT);
+    }
+
+    #[test]
+    unconstrained fn balance_set_uses_largest_note_first_different_order() {
+        let mut env = TestEnvironment::new();
+        let owner = env.create_account(1);
+
+        let contract_address =
+            env.deploy_self("AztecNrTest").without_initializer().to_address();
+
+        let _ = env.call_private_test(owner, AztecNrTest::at(contract_address).balance_set_test_setup(owner, SMALL_AMOUNT, LARGE AMOUNT, false));
+        let change_note_value = env.call_private_test(owner, AztecNrTest::at(contract_address).balance_set_subtract(owner, SMALL_AMOUNT)).return_value;
+        assert_eq(change_note_value, LARGE_AMOUNT - SMALL_AMOUNT);
+    }
+}

--- a/noir-projects/noir-contracts/contracts/test/aztec_nr_test_contract/src/test_note.nr
+++ b/noir-projects/noir-contracts/contracts/test/aztec_nr_test_contract/src/test_note.nr
@@ -1,0 +1,54 @@
+use dep::aztec::{
+    context::PrivateContext,
+    macros::notes::custom_note,
+    note::note_interface::NoteHash,
+    protocol_types::{
+        constants::GENERATOR_INDEX__NOTE_HASH, hash::poseidon2_hash_with_separator,
+        traits::Packable, utils::arrays::array_concat,
+    },
+};
+
+/// A note used only for testing purposes.
+#[custom_note]
+#[derive(Eq)]
+pub struct TestNote {
+    value: Field,
+}
+
+impl NoteHash for TestNote {
+    fn compute_note_hash(self, storage_slot: Field) -> Field {
+        // The note is inserted into the state in the Test contract so we provide a real compute_note_hash
+        // implementation.
+        let inputs = array_concat(self.pack(), [storage_slot]);
+        poseidon2_hash_with_separator(inputs, GENERATOR_INDEX__NOTE_HASH)
+    }
+
+    fn compute_nullifier(
+        _self: Self,
+        _context: &mut PrivateContext,
+        _note_hash_for_nullify: Field,
+    ) -> Field {
+        // This note's nullifier is never used for any meaningful purpose so we don't care about having a real
+        // implementation here.
+        0
+    }
+
+    unconstrained fn compute_nullifier_unconstrained(
+        _self: Self,
+        _note_hash_for_nullify: Field,
+    ) -> Field {
+        // This note's nullifier is never used for any meaningful purpose so we don't care about having a real
+        // implementation here.
+        0
+    }
+}
+
+impl TestNote {
+    pub fn new(value: Field) -> Self {
+        TestNote { value }
+    }
+
+    pub fn get_value(self) -> Field {
+        self.value
+    }
+}

--- a/noir-projects/noir-protocol-circuits/crates/types/src/traits.nr
+++ b/noir-projects/noir-protocol-circuits/crates/types/src/traits.nr
@@ -136,6 +136,7 @@ impl ToField for u128 {
         self as Field
     }
 }
+
 impl<let N: u32> ToField for str<N> {
     #[inline_always]
     fn to_field(self) -> Field {
@@ -275,6 +276,7 @@ where
 // I think this is okay because I don't foresee a unit type being used as input. But leaving this comment as a hint
 // if someone does run into this in the future.
 impl<let N: u32> Deserialize<0> for () {
+    #[inline_always]
     fn deserialize(_fields: [Field; 0]) -> Self {
         ()
     }


### PR DESCRIPTION
Not sure the best way to organize this, but this is an example of the `balance_set` tests being redone though  contract entrypoints only. We may want to have some sort of heuristics / conventions to follow for the best practices when testing isolated components inside contracts though. This uses a pattern of function = setup, then function to do an isolated behavior, with the asserts being checked in the test itself. Note that this easily could be done in a way in which each contract function itself is a test with the assert inside of itself.