### PR TITLE
feat!: auto-encoding array as BoundedVec

### DIFF
--- a/yarn-project/builder/src/contract-interface-gen/typescript.ts
+++ b/yarn-project/builder/src/contract-interface-gen/typescript.ts
@@ -8,6 +8,7 @@ import {
   getAllFunctionAbis,
   getDefaultInitializer,
   isAztecAddressStruct,
+  isBoundedVecStruct,
   isEthAddressStruct,
   isFunctionSelectorStruct,
   isWrappedFieldStruct,
@@ -42,6 +43,11 @@ function abiTypeToTypescript(type: ABIParameter['type']): string {
       }
       if (isWrappedFieldStruct(type)) {
         return 'WrappedFieldLike';
+      }
+      if (isBoundedVecStruct(type)) {
+        // To make BoundedVec easier to work with, we expect a simple array on the input and then we encode it
+        // as a BoundedVec in the ArgumentsEncoder.
+        return `${abiTypeToTypescript(type.fields[0].type)}`;
       }
       return `{ ${type.fields.map(f => `${f.name}: ${abiTypeToTypescript(f.type)}`).join(', ')} }`;
     default:

--- a/yarn-project/end-to-end/src/composed/e2e_persistence.test.ts
+++ b/yarn-project/end-to-end/src/composed/e2e_persistence.test.ts
@@ -7,7 +7,6 @@ import {
   type TxHash,
   computeSecretHash,
 } from '@aztec/aztec.js';
-import { MAX_NOTE_HASHES_PER_TX } from '@aztec/constants';
 import type { DeployL1ContractsReturnType } from '@aztec/ethereum';
 import { Fr } from '@aztec/foundation/fields';
 // We use TokenBlacklist because we want to test the persistence of manually added notes and standard token no longer
@@ -349,10 +348,6 @@ describe('Aztec persistence', () => {
   });
 });
 
-function toBoundedVec(arr: Fr[], maxLen: number) {
-  return { len: arr.length, storage: arr.concat(new Array(maxLen - arr.length).fill(new Fr(0))) };
-}
-
 async function addPendingShieldNoteToPXE(
   contract: TokenBlacklistContract,
   recipient: AztecAddress,
@@ -369,7 +364,7 @@ async function addPendingShieldNoteToPXE(
       amount,
       secretHash,
       txHash.hash,
-      toBoundedVec(txEffects!.data.noteHashes, MAX_NOTE_HASHES_PER_TX),
+      txEffects!.data.noteHashes,
       txEffects!.data.nullifiers[0],
       recipient,
     )

--- a/yarn-project/end-to-end/src/e2e_blacklist_token_contract/blacklist_token_contract_test.ts
+++ b/yarn-project/end-to-end/src/e2e_blacklist_token_contract/blacklist_token_contract_test.ts
@@ -10,7 +10,6 @@ import {
   computeSecretHash,
   createLogger,
 } from '@aztec/aztec.js';
-import { MAX_NOTE_HASHES_PER_TX } from '@aztec/constants';
 import type { TokenContract } from '@aztec/noir-contracts.js/Token';
 import { TokenBlacklistContract } from '@aztec/noir-contracts.js/TokenBlacklist';
 import { InvalidAccountContract } from '@aztec/noir-test-contracts.js/InvalidAccount';
@@ -162,10 +161,6 @@ export class BlacklistTokenContractTest {
     await this.snapshotManager.teardown();
   }
 
-  #toBoundedVec(arr: Fr[], maxLen: number) {
-    return { len: arr.length, storage: arr.concat(new Array(maxLen - arr.length).fill(new Fr(0))) };
-  }
-
   async addPendingShieldNoteToPXE(
     contract: TokenBlacklistContract,
     recipient: AztecAddress,
@@ -180,7 +175,7 @@ export class BlacklistTokenContractTest {
         amount,
         secretHash,
         txHash.hash,
-        this.#toBoundedVec(txEffects!.data.noteHashes, MAX_NOTE_HASHES_PER_TX),
+        txEffects!.data.noteHashes,
         txEffects!.data.nullifiers[0],
         recipient,
       )

--- a/yarn-project/end-to-end/src/e2e_offchain_message.test.ts
+++ b/yarn-project/end-to-end/src/e2e_offchain_message.test.ts
@@ -22,36 +22,11 @@ describe('e2e_offchain_message', () => {
 
   beforeAll(async () => {
     ({ teardown, wallets, pxe, aztecNode } = await setup(1));
-    // TODO(benesjan): The following results in one of the txs being dropped. There seems to be an issue in Aztec.js
-    // deployments.
-    // [contract1, contract2] = await Promise.all([
-    //   OffchainMessageContract.deploy(wallets[0]).send({ contractAddressSalt: Fr.random() }).deployed(),
-    //   OffchainMessageContract.deploy(wallets[0]).send({ contractAddressSalt: Fr.random() }).deployed(),
-    // ]);
     contract1 = await OffchainMessageContract.deploy(wallets[0]).send().deployed();
     contract2 = await OffchainMessageContract.deploy(wallets[0]).send().deployed();
   });
 
   afterAll(() => teardown());
-
-  function toBoundedVec<T>(arr: T[], maxLen: number) {
-    const paddingMessagePayload = {
-      message: [Fr.ZERO, Fr.ZERO, Fr.ZERO, Fr.ZERO, Fr.ZERO],
-      recipient: AztecAddress.ZERO,
-      // eslint-disable-next-line camelcase
-      next_contract: AztecAddress.ZERO,
-    };
-
-    return {
-      len: arr.length,
-      storage: arr.concat(new Array(maxLen - arr.length).fill(paddingMessagePayload)),
-    };
-  }
-
-  // TODO: To be nuked soon.
-  function toBoundedVecOfFields(arr: Fr[], maxLen: number) {
-    return { len: arr.length, storage: arr.concat(new Array(maxLen - arr.length).fill(new Fr(0))) };
-  }
 
   it('should emit offchain message', async () => {
     const messages = await Promise.all(
@@ -65,7 +40,7 @@ describe('e2e_offchain_message', () => {
         })),
     );
 
-    const provenTx = await contract1.methods.emit_offchain_message_for_recipient(toBoundedVec(messages, 6)).prove();
+    const provenTx = await contract1.methods.emit_offchain_message_for_recipient(messages).prove();
 
     // The expected order of offchain messages is the reverse because the messages are popped from the end of the input
     // BoundedVec.
@@ -81,7 +56,7 @@ describe('e2e_offchain_message', () => {
   });
 
   it('should not emit any offchain messages', async () => {
-    const provenTx = await contract1.methods.emit_offchain_message_for_recipient(toBoundedVec([], 6)).prove();
+    const provenTx = await contract1.methods.emit_offchain_message_for_recipient([]).prove();
     expect(provenTx.offchainMessages).toEqual([]);
   });
 
@@ -108,12 +83,7 @@ describe('e2e_offchain_message', () => {
     const messageContext = MessageContext.fromTxEffectAndRecipient(txEffect, recipient);
 
     // Process the message
-    await contract1.methods
-      .process_message(
-        toBoundedVecOfFields(offchainMessage.message, PRIVATE_LOG_CIPHERTEXT_LEN),
-        messageContext.toNoirStruct(),
-      )
-      .simulate();
+    await contract1.methods.process_message(offchainMessage.message, messageContext.toNoirStruct()).simulate();
 
     // Get the event from PXE
     const events = await pxe.getPrivateEvents<TestEvent>(
@@ -150,12 +120,7 @@ describe('e2e_offchain_message', () => {
     const messageContext = MessageContext.fromTxEffectAndRecipient(txEffect, recipient);
 
     // Process the message
-    await contract1.methods
-      .process_message(
-        toBoundedVecOfFields(offchainMessage.message, PRIVATE_LOG_CIPHERTEXT_LEN),
-        messageContext.toNoirStruct(),
-      )
-      .simulate();
+    await contract1.methods.process_message(offchainMessage.message, messageContext.toNoirStruct()).simulate();
 
     // Get the note value
     const noteValue = await contract1.methods.get_note_value(owner).simulate();

--- a/yarn-project/stdlib/src/abi/encoder.test.ts
+++ b/yarn-project/stdlib/src/abi/encoder.test.ts
@@ -235,4 +235,262 @@ describe('abi/encoder', () => {
 
     expect(() => encodeArguments(testFunctionAbi, args)).toThrow(/Invalid hex-encoded string/);
   });
+
+  describe('bounded vec of fields', () => {
+    const testFunctionAbi: FunctionAbi = {
+      name: 'test',
+      functionType: FunctionType.PRIVATE,
+      isInternal: false,
+      isInitializer: false,
+      isStatic: false,
+      parameters: [
+        {
+          name: 'vec',
+          type: {
+            kind: 'struct',
+            path: 'std::collections::bounded_vec::BoundedVec',
+            fields: [
+              {
+                name: 'storage',
+                type: {
+                  kind: 'array',
+                  length: 2,
+                  type: { kind: 'field' },
+                },
+              },
+              {
+                name: 'len',
+                type: {
+                  kind: 'integer',
+                  sign: 'unsigned',
+                  width: 32,
+                },
+              },
+            ],
+          },
+          visibility: 'private',
+        },
+      ],
+      returnTypes: [],
+      errorTypes: {},
+    };
+
+    it('encodes empty array as bounded vec', () => {
+      const args = [[]];
+      const result = encodeArguments(testFunctionAbi, args);
+      expect(result).toEqual([Fr.ZERO, Fr.ZERO, new Fr(0n)]); // Two zeros for storage, one for length
+    });
+
+    it('encodes array with one element', () => {
+      const args = [[42n]];
+      const result = encodeArguments(testFunctionAbi, args);
+      expect(result).toEqual([new Fr(42n), Fr.ZERO, new Fr(1n)]); // One value, one padding zero, length 1
+    });
+
+    it('encodes array at max length', () => {
+      const args = [[123n, 456n]];
+      const result = encodeArguments(testFunctionAbi, args);
+      expect(result).toEqual([new Fr(123n), new Fr(456n), new Fr(2n)]); // Two values, length 2
+    });
+
+    it('throws when array length exceeds bounded vec max length', () => {
+      const args = [[1n, 2n, 3n]]; // Array with length 3 when max is 2
+      expect(() => encodeArguments(testFunctionAbi, args)).toThrow(
+        "Error encoding param 'vec': expected an array of maximum length 2 and got 3 instead: [ 1, 2, 3 ]",
+      );
+    });
+  });
+
+  describe('bounded vec of complex structs', () => {
+    const testFunctionAbi: FunctionAbi = {
+      name: 'test',
+      functionType: FunctionType.PRIVATE,
+      isInternal: false,
+      isInitializer: false,
+      isStatic: false,
+      parameters: [
+        {
+          name: 'vec',
+          type: {
+            kind: 'struct',
+            path: 'std::collections::bounded_vec::BoundedVec',
+            fields: [
+              {
+                name: 'storage',
+                type: {
+                  kind: 'array',
+                  length: 2,
+                  type: {
+                    kind: 'struct',
+                    path: 'my_crate::my_struct::MyStruct',
+                    fields: [
+                      {
+                        name: 'a',
+                        type: { kind: 'field' },
+                      },
+                      {
+                        name: 'b',
+                        type: { kind: 'field' },
+                      },
+                    ],
+                  },
+                },
+              },
+              {
+                name: 'len',
+                type: {
+                  kind: 'integer',
+                  sign: 'unsigned',
+                  width: 32,
+                },
+              },
+            ],
+          },
+          visibility: 'private',
+        },
+      ],
+      returnTypes: [],
+      errorTypes: {},
+    };
+
+    it('encodes empty array as bounded ve', () => {
+      const args = [[]];
+      const result = encodeArguments(testFunctionAbi, args);
+      expect(result).toEqual([Fr.ZERO, Fr.ZERO, Fr.ZERO, Fr.ZERO, Fr.ZERO]); // Four zeros for storage (2 structs * 2 fields), one for length
+    });
+
+    it('encodes array with one element', () => {
+      const args = [[{ a: 42n, b: 43n }]];
+      const result = encodeArguments(testFunctionAbi, args);
+      expect(result).toEqual([new Fr(42n), new Fr(43n), Fr.ZERO, Fr.ZERO, new Fr(1n)]); // One struct (2 fields), one padding struct (2 zeros), length 1
+    });
+
+    it('encodes array at max length', () => {
+      const args = [
+        [
+          { a: 123n, b: 124n },
+          { a: 456n, b: 457n },
+        ],
+      ];
+      const result = encodeArguments(testFunctionAbi, args);
+      expect(result).toEqual([new Fr(123n), new Fr(124n), new Fr(456n), new Fr(457n), new Fr(2n)]); // Two structs (4 fields total), length 2
+    });
+
+    it('throws when array length exceeds bounded vec max length', () => {
+      const args = [
+        [
+          { a: 1n, b: 2n },
+          { a: 3n, b: 4n },
+          { a: 5n, b: 6n },
+        ],
+      ]; // Array with length 3 when max is 2
+      expect(() => encodeArguments(testFunctionAbi, args)).toThrow(
+        "Error encoding param 'vec': expected an array of maximum length 2 and got 3 instead: [ {a: 1, b: 2}, {a: 3, b: 4}, {a: 5, b: 6} ]",
+      );
+    });
+  });
+
+  describe('bounded vec of arrays', () => {
+    const testFunctionAbi: FunctionAbi = {
+      name: 'test',
+      functionType: FunctionType.PRIVATE,
+      isInternal: false,
+      isInitializer: false,
+      isStatic: false,
+      parameters: [
+        {
+          name: 'vec',
+          type: {
+            kind: 'struct',
+            path: 'std::collections::bounded_vec::BoundedVec',
+            fields: [
+              {
+                name: 'storage',
+                type: {
+                  kind: 'array',
+                  length: 2,
+                  type: {
+                    kind: 'array',
+                    length: 3,
+                    type: { kind: 'field' },
+                  },
+                },
+              },
+              {
+                name: 'len',
+                type: {
+                  kind: 'integer',
+                  sign: 'unsigned',
+                  width: 32,
+                },
+              },
+            ],
+          },
+          visibility: 'private',
+        },
+      ],
+      returnTypes: [],
+      errorTypes: {},
+    };
+
+    it('encodes empty array as bounded vec', () => {
+      const args = [[]];
+      const result = encodeArguments(testFunctionAbi, args);
+      expect(result).toEqual([
+        Fr.ZERO,
+        Fr.ZERO,
+        Fr.ZERO, // First array (3 fields)
+        Fr.ZERO,
+        Fr.ZERO,
+        Fr.ZERO, // Second array (3 fields)
+        Fr.ZERO, // Length
+      ]);
+    });
+
+    it('encodes array with one element', () => {
+      const args = [[[1n, 2n, 3n]]];
+      const result = encodeArguments(testFunctionAbi, args);
+      expect(result).toEqual([
+        new Fr(1n),
+        new Fr(2n),
+        new Fr(3n), // First array
+        Fr.ZERO,
+        Fr.ZERO,
+        Fr.ZERO, // Padding array
+        new Fr(1n), // Length 1
+      ]);
+    });
+
+    it('encodes array at max length', () => {
+      const args = [
+        [
+          [1n, 2n, 3n],
+          [4n, 5n, 6n],
+        ],
+      ];
+      const result = encodeArguments(testFunctionAbi, args);
+      expect(result).toEqual([
+        new Fr(1n),
+        new Fr(2n),
+        new Fr(3n), // First array
+        new Fr(4n),
+        new Fr(5n),
+        new Fr(6n), // Second array
+        new Fr(2n), // Length 2
+      ]);
+    });
+
+    it('throws when array length exceeds bounded vec max length', () => {
+      const args = [
+        [
+          [1n, 2n, 3n],
+          [4n, 5n, 6n],
+          [7n, 8n, 9n],
+        ],
+      ];
+      expect(() => encodeArguments(testFunctionAbi, args)).toThrow(
+        "Error encoding param 'vec': expected an array of maximum length 2 and got 3 instead: [ [1, 2, 3], [4, 5, 6], [7, 8, 9] ]",
+      );
+    });
+  });
 });

--- a/yarn-project/stdlib/src/abi/utils.ts
+++ b/yarn-project/stdlib/src/abi/utils.ts
@@ -50,6 +50,21 @@ export function isWrappedFieldStruct(abiType: AbiType) {
 }
 
 /**
+ * Returns whether the ABI type is a BoundedVec struct from Noir's std::collections::bounded_vec.
+ * @param abiType - Type to check.
+ * @returns A boolean indicating whether the ABI type is a BoundedVec struct.
+ */
+export function isBoundedVecStruct(abiType: AbiType) {
+  return (
+    abiType.kind === 'struct' &&
+    abiType.path === 'std::collections::bounded_vec::BoundedVec' &&
+    abiType.fields.length === 2 &&
+    abiType.fields[0].name === 'storage' &&
+    abiType.fields[1].name === 'len'
+  );
+}
+
+/**
  * Returns a bigint by parsing a serialized 2's complement signed int.
  * @param b - The signed int as a buffer
  * @returns - a deserialized bigint

--- a/yarn-project/stdlib/src/logs/message_context.ts
+++ b/yarn-project/stdlib/src/logs/message_context.ts
@@ -35,12 +35,7 @@ export class MessageContext {
     /* eslint-disable camelcase */
     return {
       tx_hash: this.txHash.hash,
-      // TODO: This ugly encoding should be unnecessary once the following PR is merged:
-      // https://github.com/AztecProtocol/aztec-packages/pull/14891
-      unique_note_hashes_in_tx: {
-        storage: serializeBoundedVec(this.uniqueNoteHashesInTx, MAX_NOTE_HASHES_PER_TX).slice(0, -1),
-        len: this.uniqueNoteHashesInTx.length,
-      },
+      unique_note_hashes_in_tx: this.uniqueNoteHashesInTx,
       first_nullifier_in_tx: this.firstNullifierInTx,
       recipient: this.recipient,
     };


### PR DESCRIPTION
Fixes #14853

Encoding `BoundedVec` manually was a pain so in this PR I modify `ArgumentsEncoder` such that it accepts array on the input and automatically encodes it as BVec.

Compile time check of the max length of input args will be added in https://github.com/AztecProtocol/aztec-packages/pull/15035