### PR TITLE
fix: fix test_pattern regex for boxes

### DIFF
--- a/.test_patterns.yml
+++ b/.test_patterns.yml
@@ -277,14 +277,9 @@ tests:
 
   # boxes
   - regex: "boxes/boxes/vanilla/tests/e2e.spec.ts"
-    error_regex: "Error: Timed out \\d*ms waiting for expect\\(locator\\)"
+    error_regex: "Error: Timed out [0-9]+ms waiting for expect\\(locator\\)"
     owners:
       - *saleel
-  - regex: "vanilla-all-browsers box boxes"
-    error_regex: "Expected pattern: /Candidate 4: 1 votes/"
-    owners:
-      - *nico
-      - *grego
 
   - regex: "tests/browser.spec.ts"
     error_regex: "Error: locator\\.click: Test timeout of"


### PR DESCRIPTION
- `d*` is not working with grep unless you add `-P` flag (we are using `-E` [here](https://github.com/AztecProtocol/aztec-packages/blob/saleel/fix-box-regex/ci3/get_test_owner#L17) . Replaced with `[0-9]*`
- The one removed is redundant. It was probably added because the original one didn't trigger due to the above issue.