### PR TITLE
fix: close prover broker in e2e tests

### DIFF
--- a/yarn-project/prover-client/src/prover-client/prover-client.ts
+++ b/yarn-project/prover-client/src/prover-client/prover-client.ts
@@ -3,15 +3,16 @@ import { times } from '@aztec/foundation/collection';
 import { Fr } from '@aztec/foundation/fields';
 import { createLogger } from '@aztec/foundation/log';
 import { NativeACVMSimulator } from '@aztec/simulator/server';
-import type {
-  ActualProverConfig,
-  EpochProver,
-  EpochProverManager,
-  ForkMerkleTreeOperations,
-  ProvingJobBroker,
-  ProvingJobConsumer,
-  ProvingJobProducer,
-  ServerCircuitProver,
+import {
+  type ActualProverConfig,
+  type EpochProver,
+  type EpochProverManager,
+  type ForkMerkleTreeOperations,
+  type ProvingJobBroker,
+  type ProvingJobConsumer,
+  type ProvingJobProducer,
+  type ServerCircuitProver,
+  tryStop,
 } from '@aztec/stdlib/interfaces/server';
 import { type TelemetryClient, getTelemetryClient } from '@aztec/telemetry-client';
 
@@ -87,6 +88,7 @@ export class ProverClient implements EpochProverManager {
     }
     this.running = false;
     await this.stopAgents();
+    await tryStop(this.orchestratorClient);
   }
 
   /**

--- a/yarn-project/stdlib/src/interfaces/service.ts
+++ b/yarn-project/stdlib/src/interfaces/service.ts
@@ -16,7 +16,7 @@ export interface Service {
 }
 
 /** Tries to call stop on a given object and awaits it. Logs any errors and does not rethrow. */
-export async function tryStop(service?: Partial<Pick<Service, 'stop'>>, logger?: Logger): Promise<void> {
+export async function tryStop(service?: any, logger?: Logger): Promise<void> {
   try {
     return typeof service === 'object' && service && 'stop' in service && typeof service.stop === 'function'
       ? await service.stop()


### PR DESCRIPTION
e2e tests that started a prover agent were not beingclosed correctly because the broker would stay open.