### PR TITLE
fix: Sleep on slasher client stop

### DIFF
--- a/yarn-project/aztec-node/src/aztec-node/server.ts
+++ b/yarn-project/aztec-node/src/aztec-node/server.ts
@@ -589,7 +589,7 @@ export class AztecNodeService implements AztecNode, AztecNodeAdmin, Traceable {
     await this.txQueue.end();
     await tryStop(this.validatorsSentinel);
     await tryStop(this.epochPruneWatcher);
-    this.slasherClient?.stop();
+    await tryStop(this.slasherClient);
     await tryStop(this.proofVerifier);
     await tryStop(this.sequencer);
     await tryStop(this.p2pClient);

--- a/yarn-project/slasher/src/slasher_client.test.ts
+++ b/yarn-project/slasher/src/slasher_client.test.ts
@@ -113,8 +113,7 @@ describe('SlasherClient', () => {
   });
 
   afterAll(async () => {
-    slasherClient.stop();
-    await sleep(500); // let the calls to uninstall the filters resolve
+    await slasherClient.stop();
     await anvil.stop().catch(logger.error);
   });
 


### PR DESCRIPTION
The slasher client calls `uninstallFilter` under the hood during `stop`, but viem does not catch any errors that happen during that call. This means that tests that shut down anvil before the slasher got to uninstall its filter fail with an unhandled rejection.

Note that this was handled manually on the slasher client unit tests, but caused errors in e2e tests as well (see [this run](http://ci.aztec-labs.com/d77a1d2711b8eae2) for an example). By moving it to the client itself, we should handle all instances of this error.