### PR TITLE
chore: Ignore whitelisted unhandled rejections in jest teardowns

### DIFF
--- a/yarn-project/accounts/package.json
+++ b/yarn-project/accounts/package.json
@@ -72,7 +72,8 @@
     "testTimeout": 120000,
     "setupFiles": [
       "../../foundation/src/jest/setup.mjs"
-    ]
+    ],
+    "testEnvironment": "../../foundation/src/jest/env.mjs"
   },
   "dependencies": {
     "@aztec/aztec.js": "workspace:^",

--- a/yarn-project/archiver/package.json
+++ b/yarn-project/archiver/package.json
@@ -59,7 +59,8 @@
     "testTimeout": 120000,
     "setupFiles": [
       "../../foundation/src/jest/setup.mjs"
-    ]
+    ],
+    "testEnvironment": "../../foundation/src/jest/env.mjs"
   },
   "dependencies": {
     "@aztec/blob-lib": "workspace:^",

--- a/yarn-project/aztec-faucet/package.json
+++ b/yarn-project/aztec-faucet/package.json
@@ -56,7 +56,8 @@
     "testTimeout": 120000,
     "setupFiles": [
       "../../foundation/src/jest/setup.mjs"
-    ]
+    ],
+    "testEnvironment": "../../foundation/src/jest/env.mjs"
   },
   "dependencies": {
     "@aztec/ethereum": "workspace:^",

--- a/yarn-project/aztec-node/package.json
+++ b/yarn-project/aztec-node/package.json
@@ -58,7 +58,8 @@
     "testTimeout": 120000,
     "setupFiles": [
       "../../foundation/src/jest/setup.mjs"
-    ]
+    ],
+    "testEnvironment": "../../foundation/src/jest/env.mjs"
   },
   "dependencies": {
     "@aztec/archiver": "workspace:^",

--- a/yarn-project/aztec.js/package.json
+++ b/yarn-project/aztec.js/package.json
@@ -75,7 +75,8 @@
     "testTimeout": 120000,
     "setupFiles": [
       "../../foundation/src/jest/setup.mjs"
-    ]
+    ],
+    "testEnvironment": "../../foundation/src/jest/env.mjs"
   },
   "dependencies": {
     "@aztec/constants": "workspace:^",

--- a/yarn-project/aztec/package.json
+++ b/yarn-project/aztec/package.json
@@ -109,7 +109,8 @@
     "testTimeout": 120000,
     "setupFiles": [
       "../../foundation/src/jest/setup.mjs"
-    ]
+    ],
+    "testEnvironment": "../../foundation/src/jest/env.mjs"
   },
   "engines": {
     "node": ">=20.10"

--- a/yarn-project/bb-prover/package.json
+++ b/yarn-project/bb-prover/package.json
@@ -63,7 +63,8 @@
     "testTimeout": 120000,
     "setupFiles": [
       "../../foundation/src/jest/setup.mjs"
-    ]
+    ],
+    "testEnvironment": "../../foundation/src/jest/env.mjs"
   },
   "dependencies": {
     "@aztec/bb.js": "portal:../../barretenberg/ts",

--- a/yarn-project/blob-lib/package.json
+++ b/yarn-project/blob-lib/package.json
@@ -76,7 +76,8 @@
     "testTimeout": 120000,
     "setupFiles": [
       "../../foundation/src/jest/setup.mjs"
-    ]
+    ],
+    "testEnvironment": "../../foundation/src/jest/env.mjs"
   },
   "engines": {
     "node": ">=20.10"

--- a/yarn-project/blob-sink/package.json
+++ b/yarn-project/blob-sink/package.json
@@ -51,7 +51,8 @@
     "testTimeout": 120000,
     "setupFiles": [
       "../../foundation/src/jest/setup.mjs"
-    ]
+    ],
+    "testEnvironment": "../../foundation/src/jest/env.mjs"
   },
   "dependencies": {
     "@aztec/blob-lib": "workspace:^",

--- a/yarn-project/bot/package.json
+++ b/yarn-project/bot/package.json
@@ -47,7 +47,8 @@
     "testTimeout": 120000,
     "setupFiles": [
       "../../foundation/src/jest/setup.mjs"
-    ]
+    ],
+    "testEnvironment": "../../foundation/src/jest/env.mjs"
   },
   "dependencies": {
     "@aztec/accounts": "workspace:^",

--- a/yarn-project/builder/package.json
+++ b/yarn-project/builder/package.json
@@ -62,7 +62,8 @@
     "testTimeout": 120000,
     "setupFiles": [
       "../../foundation/src/jest/setup.mjs"
-    ]
+    ],
+    "testEnvironment": "../../foundation/src/jest/env.mjs"
   },
   "dependencies": {
     "@aztec/foundation": "workspace:^",

--- a/yarn-project/cli-wallet/package.json
+++ b/yarn-project/cli-wallet/package.json
@@ -60,7 +60,8 @@
     "testTimeout": 120000,
     "setupFiles": [
       "../../foundation/src/jest/setup.mjs"
-    ]
+    ],
+    "testEnvironment": "../../foundation/src/jest/env.mjs"
   },
   "dependencies": {
     "@aztec/accounts": "workspace:^",

--- a/yarn-project/cli/package.json
+++ b/yarn-project/cli/package.json
@@ -62,7 +62,8 @@
     "testTimeout": 120000,
     "setupFiles": [
       "../../foundation/src/jest/setup.mjs"
-    ]
+    ],
+    "testEnvironment": "../../foundation/src/jest/env.mjs"
   },
   "dependencies": {
     "@aztec/archiver": "workspace:^",

--- a/yarn-project/constants/package.json
+++ b/yarn-project/constants/package.json
@@ -69,6 +69,7 @@
     "testTimeout": 120000,
     "setupFiles": [
       "../../foundation/src/jest/setup.mjs"
-    ]
+    ],
+    "testEnvironment": "../../foundation/src/jest/env.mjs"
   }
 }

--- a/yarn-project/end-to-end/package.json
+++ b/yarn-project/end-to-end/package.json
@@ -155,6 +155,7 @@
     "testTimeout": 120000,
     "setupFiles": [
       "../../foundation/src/jest/setup.mjs"
-    ]
+    ],
+    "testEnvironment": "../../foundation/src/jest/env.mjs"
   }
 }

--- a/yarn-project/entrypoints/package.json
+++ b/yarn-project/entrypoints/package.json
@@ -61,7 +61,8 @@
     "testTimeout": 120000,
     "setupFiles": [
       "../../foundation/src/jest/setup.mjs"
-    ]
+    ],
+    "testEnvironment": "../../foundation/src/jest/env.mjs"
   },
   "dependencies": {
     "@aztec/constants": "workspace:^",

--- a/yarn-project/epoch-cache/package.json
+++ b/yarn-project/epoch-cache/package.json
@@ -83,7 +83,8 @@
     "testTimeout": 120000,
     "setupFiles": [
       "../../foundation/src/jest/setup.mjs"
-    ]
+    ],
+    "testEnvironment": "../../foundation/src/jest/env.mjs"
   },
   "engines": {
     "node": ">=20.10"

--- a/yarn-project/ethereum/package.json
+++ b/yarn-project/ethereum/package.json
@@ -90,7 +90,8 @@
     "testTimeout": 120000,
     "setupFiles": [
       "../../foundation/src/jest/setup.mjs"
-    ]
+    ],
+    "testEnvironment": "../../foundation/src/jest/env.mjs"
   },
   "engines": {
     "node": ">=20.10"

--- a/yarn-project/ethereum/src/test/start_anvil.test.ts
+++ b/yarn-project/ethereum/src/test/start_anvil.test.ts
@@ -1,13 +1,29 @@
-import { createLogger } from '@aztec/foundation/log';
+import { type Logger, createLogger } from '@aztec/foundation/log';
+import { sleep } from '@aztec/foundation/sleep';
 
-import { createPublicClient, http } from 'viem';
+import type { Anvil } from '@viem/anvil';
+import { createPublicClient, http, parseAbiItem } from 'viem';
 
 import { startAnvil } from './start_anvil.js';
 
 describe('start_anvil', () => {
-  it('starts anvil on a free port', async () => {
-    const { anvil, rpcUrl } = await startAnvil();
+  let logger: Logger;
+  let anvil: Anvil;
+  let rpcUrl: string;
+  let sleepAfterTeardown: number;
 
+  beforeEach(async () => {
+    sleepAfterTeardown = 0;
+    logger = createLogger('ethereum:test:anvil');
+    ({ anvil, rpcUrl } = await startAnvil());
+  });
+
+  afterEach(async () => {
+    await anvil.stop().catch(err => logger.error(err));
+    await sleep(sleepAfterTeardown);
+  });
+
+  it('starts anvil on a free port', async () => {
     const port = parseInt(new URL(rpcUrl).port);
     expect(port).toBeLessThan(65536);
     expect(port).toBeGreaterThan(1024);
@@ -23,5 +39,19 @@ describe('start_anvil', () => {
 
     await anvil.stop().catch(err => createLogger('cleanup').error(err));
     expect(anvil.status).toEqual('idle');
+  });
+
+  it('ignores errors uninstalling filters during teardown', async () => {
+    const publicClient = createPublicClient({ transport: http(rpcUrl) });
+    const abiItem = parseAbiItem('event Transfer(address indexed from, address indexed to, uint256 value)');
+
+    const stopWatching = publicClient.watchEvent({ event: abiItem, onLogs: () => {} });
+    await sleep(100);
+
+    sleepAfterTeardown = 3000;
+    setTimeout(() => {
+      logger.info('Stopping watch event');
+      stopWatching();
+    }, 500);
   });
 });

--- a/yarn-project/foundation/eslint.config.js
+++ b/yarn-project/foundation/eslint.config.js
@@ -17,7 +17,7 @@ export default [
     '**/scripts/**',
     'eslint.config.js',
     'eslint.config.*.js',
-    'src/jest/setup.mjs',
+    'src/jest/*.mjs',
   ]),
   ...tseslint.config({
     extends: [

--- a/yarn-project/foundation/package.json
+++ b/yarn-project/foundation/package.json
@@ -97,7 +97,8 @@
     ],
     "setupFiles": [
       "../../foundation/src/jest/setup.mjs"
-    ]
+    ],
+    "testEnvironment": "../../foundation/src/jest/env.mjs"
   },
   "dependencies": {
     "@aztec/bb.js": "portal:../../barretenberg/ts",

--- a/yarn-project/foundation/src/jest/env.mjs
+++ b/yarn-project/foundation/src/jest/env.mjs
@@ -1,0 +1,52 @@
+import { TestEnvironment } from 'jest-environment-node';
+
+// What errors should be ignored in after hooks
+const IgnoredErrors = ['HttpRequestError', 'CodeError'];
+
+/** Custom Jest environment that ignores any whitelisted unhandled rejections that occur during `after` hooks */
+export default class CustomEnvironment extends TestEnvironment {
+  constructor(config, context) {
+    super(config, context);
+  }
+
+  async handleTestEvent(event, state) {
+    if (event.name === 'setup') {
+      // Jest 29 reports both unhandledRejection and uncaughtException events as plain `error`, without any means to differentiate them
+      // (see https://github.com/jestjs/jest/issues/9210). Jest 30 fixes it as part of a larger change (see
+      // https://github.com/jestjs/jest/pull/14315/files#diff-9bdc1fdb60c8631b1e346eff6e4899c4e64ae3a44f4f12d0d7ac70c2aabd1d93R12-R29),
+      // but we cannot update to 30 as it is still in beta at the time of writing this code. So we remove jest's unhandledRejection listener,
+      // replace it with our own, and delegate to the original listener only if the error is not in the ignored list.
+      const parentProcess = event.parentProcess;
+      const [jestListener] = parentProcess.listeners('unhandledRejection');
+      parentProcess.removeAllListeners('unhandledRejection');
+      const patchedListener = (err, _promise) => {
+        if (state.isInAfterHook && IgnoredErrors.some(error => err && err.name && err.name.includes(error))) {
+          // Ignore the error only if it was an unhandled async rejection (not sync exception), it's on the IgnoredErrors list, and we're in an after hook.
+          console.error('Ignoring unhandled rejection in after hook:', err);
+        } else if (state.isInAfterHook) {
+          // Log non-ignored unhandled rejection in an after hook, and pass the error to the original jest listener to fail the test.
+          console.error(`Unhandled rejection in after hook:`, err);
+          jestListener && jestListener(err);
+        } else {
+          // Otherwise, just delegate to the original jest listener, to emit the `error` event under the hood.
+          jestListener && jestListener(err);
+        }
+      };
+      parentProcess.on('unhandledRejection', patchedListener);
+      state.patchedListener = patchedListener;
+    } else if (event.name === 'teardown') {
+      // Remove the patched handler we added in setup.
+      const parentProcess = state.parentProcess;
+      parentProcess.removeListener('unhandledRejection', state.patchedListener);
+    } else if (event.name === 'hook_start' && event.hook.type.startsWith('after')) {
+      // Track that we have entered an after hook.
+      state.isInAfterHook = true;
+    } else if (
+      (event.name === 'hook_success' || event.name === 'hook_failure') &&
+      event.hook.type.startsWith('after')
+    ) {
+      // Reset the flag that we are in an after hook when we exit it.
+      state.isInAfterHook = false;
+    }
+  }
+}

--- a/yarn-project/ivc-integration/package.json
+++ b/yarn-project/ivc-integration/package.json
@@ -55,7 +55,8 @@
     "testTimeout": 120000,
     "setupFiles": [
       "../../foundation/src/jest/setup.mjs"
-    ]
+    ],
+    "testEnvironment": "../../foundation/src/jest/env.mjs"
   },
   "dependencies": {
     "@aztec/bb.js": "../../ts",

--- a/yarn-project/key-store/package.json
+++ b/yarn-project/key-store/package.json
@@ -50,7 +50,8 @@
     "testTimeout": 120000,
     "setupFiles": [
       "../../foundation/src/jest/setup.mjs"
-    ]
+    ],
+    "testEnvironment": "../../foundation/src/jest/env.mjs"
   },
   "dependencies": {
     "@aztec/constants": "workspace:^",

--- a/yarn-project/kv-store/package.json
+++ b/yarn-project/kv-store/package.json
@@ -93,6 +93,7 @@
     "testTimeout": 120000,
     "setupFiles": [
       "../../foundation/src/jest/setup.mjs"
-    ]
+    ],
+    "testEnvironment": "../../foundation/src/jest/env.mjs"
   }
 }

--- a/yarn-project/merkle-tree/package.json
+++ b/yarn-project/merkle-tree/package.json
@@ -51,7 +51,8 @@
     "testTimeout": 120000,
     "setupFiles": [
       "../../foundation/src/jest/setup.mjs"
-    ]
+    ],
+    "testEnvironment": "../../foundation/src/jest/env.mjs"
   },
   "dependencies": {
     "@aztec/foundation": "workspace:^",

--- a/yarn-project/native/package.json
+++ b/yarn-project/native/package.json
@@ -71,6 +71,7 @@
     "testTimeout": 120000,
     "setupFiles": [
       "../../foundation/src/jest/setup.mjs"
-    ]
+    ],
+    "testEnvironment": "../../foundation/src/jest/env.mjs"
   }
 }

--- a/yarn-project/node-lib/package.json
+++ b/yarn-project/node-lib/package.json
@@ -47,7 +47,8 @@
     "testTimeout": 120000,
     "setupFiles": [
       "../../foundation/src/jest/setup.mjs"
-    ]
+    ],
+    "testEnvironment": "../../foundation/src/jest/env.mjs"
   },
   "dependencies": {
     "@aztec/archiver": "workspace:^",

--- a/yarn-project/noir-bb-bench/package.json
+++ b/yarn-project/noir-bb-bench/package.json
@@ -87,6 +87,7 @@
     "rootDir": "./src",
     "setupFiles": [
       "../../foundation/src/jest/setup.mjs"
-    ]
+    ],
+    "testEnvironment": "../../foundation/src/jest/env.mjs"
   }
 }

--- a/yarn-project/noir-contracts.js/package.json
+++ b/yarn-project/noir-contracts.js/package.json
@@ -50,7 +50,8 @@
     "testTimeout": 120000,
     "setupFiles": [
       "../../foundation/src/jest/setup.mjs"
-    ]
+    ],
+    "testEnvironment": "../../foundation/src/jest/env.mjs"
   },
   "dependencies": {
     "@aztec/aztec.js": "workspace:^",

--- a/yarn-project/noir-protocol-circuits-types/package.json
+++ b/yarn-project/noir-protocol-circuits-types/package.json
@@ -56,7 +56,8 @@
     "testTimeout": 120000,
     "setupFiles": [
       "../../foundation/src/jest/setup.mjs"
-    ]
+    ],
+    "testEnvironment": "../../foundation/src/jest/env.mjs"
   },
   "dependencies": {
     "@aztec/blob-lib": "workspace:^",

--- a/yarn-project/noir-test-contracts.js/package.json
+++ b/yarn-project/noir-test-contracts.js/package.json
@@ -52,7 +52,8 @@
     "testTimeout": 120000,
     "setupFiles": [
       "../../foundation/src/jest/setup.mjs"
-    ]
+    ],
+    "testEnvironment": "../../foundation/src/jest/env.mjs"
   },
   "dependencies": {
     "@aztec/aztec.js": "workspace:^",

--- a/yarn-project/p2p-bootstrap/package.json
+++ b/yarn-project/p2p-bootstrap/package.json
@@ -78,7 +78,8 @@
     "testTimeout": 120000,
     "setupFiles": [
       "../../foundation/src/jest/setup.mjs"
-    ]
+    ],
+    "testEnvironment": "../../foundation/src/jest/env.mjs"
   },
   "engines": {
     "node": ">=20.10"

--- a/yarn-project/p2p/package.json
+++ b/yarn-project/p2p/package.json
@@ -60,7 +60,8 @@
     "testTimeout": 120000,
     "setupFiles": [
       "../../foundation/src/jest/setup.mjs"
-    ]
+    ],
+    "testEnvironment": "../../foundation/src/jest/env.mjs"
   },
   "dependencies": {
     "@aztec/constants": "workspace:^",

--- a/yarn-project/package.common.json
+++ b/yarn-project/package.common.json
@@ -41,6 +41,7 @@
     "testTimeout": 120000,
     "testRegex": "./src/.*\\.test\\.(js|mjs|ts)$",
     "rootDir": "./src",
-    "setupFiles": ["../../foundation/src/jest/setup.mjs"]
+    "setupFiles": ["../../foundation/src/jest/setup.mjs"],
+    "testEnvironment": "../../foundation/src/jest/env.mjs"
   }
 }

--- a/yarn-project/protocol-contracts/package.json
+++ b/yarn-project/protocol-contracts/package.json
@@ -66,7 +66,8 @@
     "testTimeout": 120000,
     "setupFiles": [
       "../../foundation/src/jest/setup.mjs"
-    ]
+    ],
+    "testEnvironment": "../../foundation/src/jest/env.mjs"
   },
   "dependencies": {
     "@aztec/constants": "workspace:^",

--- a/yarn-project/prover-client/package.json
+++ b/yarn-project/prover-client/package.json
@@ -61,7 +61,8 @@
     "testTimeout": 120000,
     "setupFiles": [
       "../../foundation/src/jest/setup.mjs"
-    ]
+    ],
+    "testEnvironment": "../../foundation/src/jest/env.mjs"
   },
   "dependencies": {
     "@aztec/bb-prover": "workspace:^",

--- a/yarn-project/prover-node/package.json
+++ b/yarn-project/prover-node/package.json
@@ -49,7 +49,8 @@
     "testTimeout": 120000,
     "setupFiles": [
       "../../foundation/src/jest/setup.mjs"
-    ]
+    ],
+    "testEnvironment": "../../foundation/src/jest/env.mjs"
   },
   "dependencies": {
     "@aztec/archiver": "workspace:^",

--- a/yarn-project/pxe/package.json
+++ b/yarn-project/pxe/package.json
@@ -55,7 +55,8 @@
     "testTimeout": 120000,
     "setupFiles": [
       "../../foundation/src/jest/setup.mjs"
-    ]
+    ],
+    "testEnvironment": "../../foundation/src/jest/env.mjs"
   },
   "dependencies": {
     "@aztec/bb-prover": "workspace:^",

--- a/yarn-project/sequencer-client/package.json
+++ b/yarn-project/sequencer-client/package.json
@@ -111,6 +111,7 @@
     "testTimeout": 120000,
     "setupFiles": [
       "../../foundation/src/jest/setup.mjs"
-    ]
+    ],
+    "testEnvironment": "../../foundation/src/jest/env.mjs"
   }
 }

--- a/yarn-project/simulator/package.json
+++ b/yarn-project/simulator/package.json
@@ -55,7 +55,8 @@
     "testTimeout": 120000,
     "setupFiles": [
       "../../foundation/src/jest/setup.mjs"
-    ]
+    ],
+    "testEnvironment": "../../foundation/src/jest/env.mjs"
   },
   "dependencies": {
     "@aztec/constants": "workspace:^",

--- a/yarn-project/slasher/package.json
+++ b/yarn-project/slasher/package.json
@@ -47,7 +47,8 @@
     "testTimeout": 120000,
     "setupFiles": [
       "../../foundation/src/jest/setup.mjs"
-    ]
+    ],
+    "testEnvironment": "../../foundation/src/jest/env.mjs"
   },
   "dependencies": {
     "@aztec/epoch-cache": "workspace:^",

--- a/yarn-project/stdlib/package.json
+++ b/yarn-project/stdlib/package.json
@@ -145,6 +145,7 @@
     "testTimeout": 120000,
     "setupFiles": [
       "../../foundation/src/jest/setup.mjs"
-    ]
+    ],
+    "testEnvironment": "../../foundation/src/jest/env.mjs"
   }
 }

--- a/yarn-project/telemetry-client/package.json
+++ b/yarn-project/telemetry-client/package.json
@@ -83,6 +83,7 @@
     "testTimeout": 120000,
     "setupFiles": [
       "../../foundation/src/jest/setup.mjs"
-    ]
+    ],
+    "testEnvironment": "../../foundation/src/jest/env.mjs"
   }
 }

--- a/yarn-project/txe/package.json
+++ b/yarn-project/txe/package.json
@@ -54,7 +54,8 @@
     "testTimeout": 120000,
     "setupFiles": [
       "../../foundation/src/jest/setup.mjs"
-    ]
+    ],
+    "testEnvironment": "../../foundation/src/jest/env.mjs"
   },
   "dependencies": {
     "@aztec/accounts": "workspace:^",

--- a/yarn-project/validator-client/package.json
+++ b/yarn-project/validator-client/package.json
@@ -57,7 +57,8 @@
     "testTimeout": 120000,
     "setupFiles": [
       "../../foundation/src/jest/setup.mjs"
-    ]
+    ],
+    "testEnvironment": "../../foundation/src/jest/env.mjs"
   },
   "dependencies": {
     "@aztec/constants": "workspace:^",

--- a/yarn-project/world-state/package.json
+++ b/yarn-project/world-state/package.json
@@ -57,7 +57,8 @@
     "testTimeout": 120000,
     "setupFiles": [
       "../../foundation/src/jest/setup.mjs"
-    ]
+    ],
+    "testEnvironment": "../../foundation/src/jest/env.mjs"
   },
   "dependencies": {
     "@aztec/constants": "workspace:^",


### PR DESCRIPTION
We have several tests failing due to unhandled rejections during teardown (see https://github.com/AztecProtocol/aztec-packages/pull/14903 for an example, or the infamous `CodeError` from libp2p). To avoid having the whole test fail due to known cleanup errors, this PR introduces a custom jest environment that catches unhandled rejections during `afterEach`/`afterAll` hooks, and if they match a whitelist, ignores them.

This whitelist has `CodeError` (from libp2p) and `HttpRequestError` (from viem) for now, but we can add more known unhandled rejections from 3rd party libraries.

Note that just installing a `process.on('unhandledRejection')` does not work, since `jest` overrides them (see [here](https://github.com/jestjs/jest/blob/v29.7.0/packages/jest-circus/src/globalErrorHandlers.ts)). And if we try to manually set these handlers after setup and inside the test, it does not work either because the handlers need to be set on the parent process (see [this comment](https://github.com/jestjs/jest/blob/4e56991693da7cd4c3730dc3579a1dd1403ee630/packages/jest-circus/src/eventHandler.ts#L239-L244) from Dan Abramov). So the only way around this is defining a custom jest circus env.