### PR TITLE
fix!: handle error from sending tx properly

### DIFF
--- a/yarn-project/aztec.js/src/account_manager/account_manager.ts
+++ b/yarn-project/aztec.js/src/account_manager/account_manager.ts
@@ -222,29 +222,30 @@ export class AccountManager {
    */
   public deploy(opts?: DeployAccountOptions): DeployAccountSentTx {
     let deployMethod: DeployMethod;
-    const sentTx = this.getDeployMethod(opts?.deployWallet)
-      .then(method => {
-        deployMethod = method;
-        if (!opts?.deployWallet && opts?.fee) {
-          return this.getSelfPaymentMethod(opts?.fee?.paymentMethod);
-        }
-      })
-      .then(maybeWrappedPaymentMethod => {
-        let fee = opts?.fee;
-        if (maybeWrappedPaymentMethod) {
-          fee = { ...opts?.fee, paymentMethod: maybeWrappedPaymentMethod };
-        }
-        return deployMethod.send({
-          contractAddressSalt: new Fr(this.salt),
-          skipClassRegistration: opts?.skipClassRegistration ?? true,
-          skipPublicDeployment: opts?.skipPublicDeployment ?? true,
-          skipInitialization: opts?.skipInitialization ?? false,
-          universalDeploy: true,
-          fee,
-        });
-      })
-      .then(tx => tx.getTxHash());
-    return new DeployAccountSentTx(this.pxe, sentTx, this.getWallet());
+    const sendTx = () =>
+      this.getDeployMethod(opts?.deployWallet)
+        .then(method => {
+          deployMethod = method;
+          if (!opts?.deployWallet && opts?.fee) {
+            return this.getSelfPaymentMethod(opts?.fee?.paymentMethod);
+          }
+        })
+        .then(maybeWrappedPaymentMethod => {
+          let fee = opts?.fee;
+          if (maybeWrappedPaymentMethod) {
+            fee = { ...opts?.fee, paymentMethod: maybeWrappedPaymentMethod };
+          }
+          return deployMethod.send({
+            contractAddressSalt: new Fr(this.salt),
+            skipClassRegistration: opts?.skipClassRegistration ?? true,
+            skipPublicDeployment: opts?.skipPublicDeployment ?? true,
+            skipInitialization: opts?.skipInitialization ?? false,
+            universalDeploy: true,
+            fee,
+          });
+        })
+        .then(tx => tx.getTxHash());
+    return new DeployAccountSentTx(this.pxe, sendTx, this.getWallet());
   }
 
   /**

--- a/yarn-project/aztec.js/src/account_manager/deploy_account_sent_tx.ts
+++ b/yarn-project/aztec.js/src/account_manager/deploy_account_sent_tx.ts
@@ -17,10 +17,10 @@ export type DeployAccountTxReceipt = FieldsOf<TxReceipt> & {
 export class DeployAccountSentTx extends SentTx {
   constructor(
     pxeOrNode: AztecNode | PXE,
-    txHashPromise: Promise<TxHash>,
+    sendTx: () => Promise<TxHash>,
     private getWalletPromise: Promise<Wallet>,
   ) {
-    super(pxeOrNode, txHashPromise);
+    super(pxeOrNode, sendTx);
   }
 
   /**

--- a/yarn-project/aztec.js/src/contract/base_contract_interaction.ts
+++ b/yarn-project/aztec.js/src/contract/base_contract_interaction.ts
@@ -81,11 +81,11 @@ export abstract class BaseContractInteraction {
    */
   public send(options: SendMethodOptions = {}): SentTx {
     // docs:end:send
-    const promise = (async () => {
+    const sendTx = async () => {
       const txProvingResult = await this.proveInternal(options);
       return this.wallet.sendTx(txProvingResult.toTx());
-    })();
-    return new SentTx(this.wallet, promise);
+    };
+    return new SentTx(this.wallet, sendTx);
   }
 
   // docs:start:estimateGas

--- a/yarn-project/aztec.js/src/contract/deploy_method.ts
+++ b/yarn-project/aztec.js/src/contract/deploy_method.ts
@@ -214,9 +214,9 @@ export class DeployMethod<TContract extends ContractBase = Contract> extends Bas
    * @returns A SentTx object that returns the receipt and the deployed contract instance.
    */
   public override send(options: DeployOptions = {}): DeploySentTx<TContract> {
-    const txHashPromise = super.send(options).getTxHash();
+    const sendTx = () => super.send(options).getTxHash();
     this.log.debug(`Sent deployment tx of ${this.artifact.name} contract`);
-    return new DeploySentTx(this.wallet, txHashPromise, this.postDeployCtor, () => this.getInstance(options));
+    return new DeploySentTx(this.wallet, sendTx, this.postDeployCtor, () => this.getInstance(options));
   }
 
   /**

--- a/yarn-project/aztec.js/src/contract/deploy_proven_tx.ts
+++ b/yarn-project/aztec.js/src/contract/deploy_proven_tx.ts
@@ -25,10 +25,8 @@ export class DeployProvenTx<TContract extends Contract = Contract> extends Prove
    * Sends the transaction to the network via the provided wallet.
    */
   public override send(): DeploySentTx<TContract> {
-    const promise = (() => {
-      return this.wallet.sendTx(this.getPlainDataTx());
-    })();
+    const sendTx = () => this.wallet.sendTx(this.getPlainDataTx());
 
-    return new DeploySentTx(this.wallet, promise, this.postDeployCtor, this.instanceGetter);
+    return new DeploySentTx(this.wallet, sendTx, this.postDeployCtor, this.instanceGetter);
   }
 }

--- a/yarn-project/aztec.js/src/contract/deploy_sent_tx.ts
+++ b/yarn-project/aztec.js/src/contract/deploy_sent_tx.ts
@@ -30,12 +30,12 @@ export class DeploySentTx<TContract extends Contract = Contract> extends SentTx 
 
   constructor(
     wallet: Wallet,
-    txHashPromise: Promise<TxHash>,
+    sendTx: () => Promise<TxHash>,
     private postDeployCtor: (address: AztecAddress, wallet: Wallet) => Promise<TContract>,
     /** A getter for the deployed contract instance */
     public instanceGetter: () => Promise<ContractInstanceWithAddress>,
   ) {
-    super(wallet, txHashPromise);
+    super(wallet, sendTx);
   }
 
   /**

--- a/yarn-project/aztec.js/src/contract/proven_tx.ts
+++ b/yarn-project/aztec.js/src/contract/proven_tx.ts
@@ -27,10 +27,8 @@ export class ProvenTx extends Tx {
    * Sends the transaction to the network via the provided wallet.
    */
   public send(): SentTx {
-    const promise = (() => {
-      return this.wallet.sendTx(this.getPlainDataTx());
-    })();
+    const sendTx = () => this.wallet.sendTx(this.getPlainDataTx());
 
-    return new SentTx(this.wallet, promise);
+    return new SentTx(this.wallet, sendTx);
   }
 }

--- a/yarn-project/aztec.js/src/contract/sent_tx.test.ts
+++ b/yarn-project/aztec.js/src/contract/sent_tx.test.ts
@@ -9,14 +9,13 @@ import { SentTx } from './sent_tx.js';
 describe('SentTx', () => {
   let pxe: MockProxy<PXE>;
   let node: MockProxy<AztecNode>;
-  let txHashPromise: Promise<TxHash>;
-
   let sentTx: SentTx;
+
+  const txHashGetter = () => Promise.resolve(new TxHash(new Fr(1n)));
 
   beforeEach(() => {
     pxe = mock();
     node = mock();
-    txHashPromise = Promise.resolve(new TxHash(new Fr(1n)));
   });
 
   describe('wait with PXE', () => {
@@ -24,7 +23,7 @@ describe('SentTx', () => {
     beforeEach(() => {
       txReceipt = { status: TxStatus.SUCCESS, blockNumber: 20 } as TxReceipt;
       pxe.getTxReceipt.mockResolvedValue(txReceipt);
-      sentTx = new SentTx(pxe, txHashPromise);
+      sentTx = new SentTx(pxe, txHashGetter);
     });
 
     it('throws if tx is dropped', async () => {
@@ -38,12 +37,45 @@ describe('SentTx', () => {
     beforeEach(() => {
       txReceipt = { status: TxStatus.SUCCESS, blockNumber: 20 } as TxReceipt;
       node.getTxReceipt.mockResolvedValue(txReceipt);
-      sentTx = new SentTx(node, txHashPromise);
+      sentTx = new SentTx(node, txHashGetter);
     });
 
     it('throws if tx is dropped', async () => {
       node.getTxReceipt.mockResolvedValue({ ...txReceipt, status: TxStatus.DROPPED } as TxReceipt);
       await expect(sentTx.wait({ timeout: 1, interval: 0.4, ignoreDroppedReceiptsFor: 0 })).rejects.toThrow(/dropped/);
+    });
+  });
+
+  describe('throw in txHashPromise', () => {
+    const alwaysThrows = (): Promise<TxHash> => {
+      return Promise.reject(new Error('test error'));
+    };
+
+    it('can be constructed even if txHashPromise throws', () => {
+      const sentTx = new SentTx(pxe, alwaysThrows);
+      expect(sentTx).toBeDefined();
+    });
+
+    it('throws if getTxHash is called', async () => {
+      const sentTx = new SentTx(pxe, alwaysThrows);
+      await expect(sentTx.getTxHash()).rejects.toThrow('test error');
+    });
+
+    it('throws every time getTxHash is called', async () => {
+      const sentTx = new SentTx(pxe, alwaysThrows);
+      await expect(sentTx.getTxHash()).rejects.toThrow('test error');
+      await expect(sentTx.getTxHash()).rejects.toThrow('test error');
+      await expect(sentTx.getTxHash()).rejects.toThrow('test error');
+    });
+
+    it('throws if getReceipt is called', async () => {
+      const sentTx = new SentTx(pxe, alwaysThrows);
+      await expect(sentTx.getReceipt()).rejects.toThrow('test error');
+    });
+
+    it('throws if wait is called', async () => {
+      const sentTx = new SentTx(pxe, alwaysThrows);
+      await expect(sentTx.wait()).rejects.toThrow('test error');
     });
   });
 });

--- a/yarn-project/cli-wallet/src/cmds/cancel_tx.ts
+++ b/yarn-project/cli-wallet/src/cmds/cancel_tx.ts
@@ -46,7 +46,7 @@ export async function cancelTx(
   });
   const txSimulationResult = await wallet.simulateTx(txRequest, true);
   const txProvingResult = await wallet.proveTx(txRequest, txSimulationResult.privateExecutionResult);
-  const sentTx = new SentTx(wallet, wallet.sendTx(txProvingResult.toTx()));
+  const sentTx = new SentTx(wallet, () => wallet.sendTx(txProvingResult.toTx()));
   try {
     await sentTx.wait({ timeout: DEFAULT_TX_TIMEOUT_S });
 

--- a/yarn-project/end-to-end/src/e2e_p2p/reqresp.test.ts
+++ b/yarn-project/end-to-end/src/e2e_p2p/reqresp.test.ts
@@ -122,7 +122,7 @@ describe('e2e_p2p_reqresp_tx', () => {
       c.txs.map(tx => {
         const node = nodes[proposerIndexes[i]];
         void node.sendTx(tx).catch(err => t.logger.error(`Error sending tx: ${err}`));
-        return new SentTx(node, tx.getTxHash());
+        return new SentTx(node, tx.getTxHash);
       }),
     );
 

--- a/yarn-project/end-to-end/src/e2e_prover/full.test.ts
+++ b/yarn-project/end-to-end/src/e2e_prover/full.test.ts
@@ -310,9 +310,8 @@ describe('full_prover', () => {
 
       // Spam node with invalid txs
       logger.info(`Submitting ${NUM_INVALID_TXS} invalid transactions to simulate a ddos attack`);
-      const invalidTxPromises = [];
       const data = provenTx.data;
-      for (let i = 0; i < NUM_INVALID_TXS; i++) {
+      const invalidTxs = Array.from({ length: NUM_INVALID_TXS }, (_, i) => {
         // Use a random ClientIvcProof and alter the public tx data to generate a unique invalid tx hash
         const invalidProvenTx = new ProvenTx(
           wallet,
@@ -331,10 +330,8 @@ describe('full_prover', () => {
           ),
           [],
         );
-
-        const sentTx = invalidProvenTx.send();
-        invalidTxPromises.push(sentTx.wait({ timeout: 10, interval: 0.1, dontThrowOnRevert: true }));
-      }
+        return invalidProvenTx.send();
+      });
 
       logger.info(`Sending proven tx`);
       const validTx = provenTx.send();
@@ -347,7 +344,10 @@ describe('full_prover', () => {
       logger.info(`Advancing from epoch ${epoch} to next epoch`);
       await cheatCodes.rollup.advanceToNextEpoch();
 
-      const results = await Promise.allSettled([...invalidTxPromises, validTx.wait({ timeout: 300, interval: 10 })]);
+      const results = await Promise.allSettled([
+        ...invalidTxs.map(tx => tx.wait({ timeout: 10, interval: 0.1, dontThrowOnRevert: true })),
+        validTx.wait({ timeout: 300, interval: 10 }),
+      ]);
 
       // Assert that the large influx of invalid txs are rejected and do not ddos the node
       for (let i = 0; i < NUM_INVALID_TXS; i++) {


### PR DESCRIPTION
`SentTx` took a promise in the constructor that resolved to `TxHash`. This promise was often the result of calling `wallet.sendTx`. But it could throw an error when the proof is invalid. We intentionally trigger this error in the last test case in e2e `prover/full.test.ts`. If the error is thrown before it's been awaited via `sentTx.getTxHash`, it will break the test. For example, [this failing test](http://ci.aztec-labs.com/9dc4f218b4acc8ff) was caused by it.

One way to reproduce the error is to sleep for a second before this line:
```
const results = await Promise.allSettled([...invalidTxPromises, validTx.wait({ timeout: 300, interval: 10 })]);
```

The solution is to pass the function into `SentTx` instead. It will execute the function and manage the result or error. When `sentTx.getTxHash` is called, it returns the value or throws an error accordingly.