### PR TITLE
fix: Use first machine IP in rootless Docker

### DIFF
--- a/aztec-up/bin/.aztec-run
+++ b/aztec-up/bin/.aztec-run
@@ -52,8 +52,8 @@ fi
 # Set up host.docker.internal alias on Linux, just like it is on mac.
 if [[ -z "${SKIP_NET:-}" && "$uname" == "Linux" ]]; then
   if [ -n "${ROOTLESS:-}" ]; then
-    # We're in rootless docker. Probe for the host ip and use that.
-    ip=$(hostname -I | head | tr -d ' ')
+    # We're in rootless docker. Probe for the first host ip and use that.
+    ip=$(hostname -I | head -n 1 | cut -d ' ' -f 1)
     warn "WARNING: Running within rootless docker. Using $ip as host ip. Ensure listening services are listening on this interface."
     arg_host_binds="--add-host host.docker.internal:$ip"
   else


### PR DESCRIPTION
Resolves https://github.com/AztecProtocol/aztec-packages/issues/14654

Change IP address used for `--add-host` in rootless Docker to the first address from `hostname -I` instead of concatenating all addresses together.

### Testing
I have manually tested this bash line by simulating single & multi IP outputs from `hostname -I` (i.e. `echo "127.0.0.1 ..." | ...`)  to ensure the original authors expected setup continue to work, as well as accommodating other possible outputs.

I am unsure if there are automated tests which cover this path, but would be happy to update and/or add to them if desired.