### PR TITLE
refactor: ordering events by commitment index

### DIFF
--- a/noir-projects/aztec-nr/aztec/src/messages/discovery/private_events.nr
+++ b/noir-projects/aztec-nr/aztec/src/messages/discovery/private_events.nr
@@ -23,8 +23,6 @@ pub unconstrained fn process_private_event_msg(
     msg_metadata: u64,
     msg_content: BoundedVec<Field, MAX_MESSAGE_CONTENT_LEN>,
     tx_hash: Field,
-    log_index_in_tx: Field,
-    tx_index_in_block: Field,
 ) {
     // In the case of events, the msg metadata is the event selector.
     let event_type_id = EventSelector::from_field(msg_metadata as Field);
@@ -62,7 +60,5 @@ pub unconstrained fn process_private_event_msg(
         event_commitment,
         tx_hash,
         recipient,
-        log_index_in_tx,
-        tx_index_in_block,
     );
 }

--- a/noir-projects/aztec-nr/aztec/src/messages/discovery/private_logs.nr
+++ b/noir-projects/aztec-nr/aztec/src/messages/discovery/private_logs.nr
@@ -77,8 +77,6 @@ pub(crate) unconstrained fn process_private_log<Env>(
             msg_metadata,
             msg_content,
             pending_tagged_log.tx_hash,
-            pending_tagged_log.log_index_in_tx,
-            pending_tagged_log.tx_index_in_block,
         );
     } else {
         debug_log_format("Unknown msg type id {0}", [msg_type_id as Field]);

--- a/noir-projects/aztec-nr/aztec/src/messages/processing/event_validation_request.nr
+++ b/noir-projects/aztec-nr/aztec/src/messages/processing/event_validation_request.nr
@@ -11,8 +11,6 @@ pub(crate) struct EventValidationRequest {
     pub event_commitment: Field,
     pub tx_hash: Field,
     pub recipient: AztecAddress,
-    pub log_index_in_tx: Field,
-    pub tx_index_in_block: Field,
 }
 
 mod test {
@@ -32,8 +30,6 @@ mod test {
             event_commitment: 5,
             tx_hash: 6,
             recipient: AztecAddress::from_field(7),
-            log_index_in_tx: 8,
-            tx_index_in_block: 9,
         };
 
         // We define the serialization in Noir and the deserialization in TS. If the deserialization changes from the
@@ -50,8 +46,6 @@ mod test {
             5, // event_commitment
             6, // tx_hash
             7, // recipient
-            8, // log_index_in_tx
-            9, // tx_index_in_block
         ];
 
         assert_eq(request.serialize(), expected_serialization);

--- a/noir-projects/aztec-nr/aztec/src/messages/processing/mod.nr
+++ b/noir-projects/aztec-nr/aztec/src/messages/processing/mod.nr
@@ -96,8 +96,6 @@ pub(crate) unconstrained fn enqueue_event_for_validation(
     event_commitment: Field,
     tx_hash: Field,
     recipient: AztecAddress,
-    log_index_in_tx: Field,
-    tx_index_in_block: Field,
 ) {
     // We store requests in a `CapsuleArray`, which PXE will later read from and deserialize into its version of the
     // Noir `EventValidationRequest`
@@ -109,8 +107,6 @@ pub(crate) unconstrained fn enqueue_event_for_validation(
             event_commitment,
             tx_hash,
             recipient,
-            log_index_in_tx,
-            tx_index_in_block,
         },
     )
 }

--- a/noir-projects/aztec-nr/aztec/src/messages/processing/pending_tagged_log.nr
+++ b/noir-projects/aztec-nr/aztec/src/messages/processing/pending_tagged_log.nr
@@ -13,8 +13,6 @@ pub(crate) struct PendingTaggedLog {
     pub unique_note_hashes_in_tx: BoundedVec<Field, MAX_NOTE_HASHES_PER_TX>,
     pub first_nullifier_in_tx: Field,
     pub recipient: AztecAddress,
-    pub log_index_in_tx: Field,
-    pub tx_index_in_block: Field,
 }
 
 mod test {
@@ -28,16 +26,12 @@ mod test {
         let unique_note_hashes = BoundedVec::from_array([4, 5]);
         let first_nullifier = 6;
         let recipient = AztecAddress::from_field(789);
-        let log_index_in_tx = 10;
-        let tx_index_in_block = 11;
         let pending_log = PendingTaggedLog {
             log,
             tx_hash,
             unique_note_hashes_in_tx: unique_note_hashes,
             first_nullifier_in_tx: first_nullifier,
             recipient,
-            log_index_in_tx,
-            tx_index_in_block,
         };
 
         let serialized = pending_log.serialize();
@@ -132,8 +126,6 @@ mod test {
             0x0000000000000000000000000000000000000000000000000000000000000002,
             0x0000000000000000000000000000000000000000000000000000000000000006,
             0x0000000000000000000000000000000000000000000000000000000000000315,
-            0x000000000000000000000000000000000000000000000000000000000000000a,
-            0x000000000000000000000000000000000000000000000000000000000000000b,
         ];
 
         assert_eq(serialized, serialized_pending_tagged_log_from_typescript);

--- a/yarn-project/pxe/src/contract_function_simulator/event_validation_request.test.ts
+++ b/yarn-project/pxe/src/contract_function_simulator/event_validation_request.test.ts
@@ -26,8 +26,6 @@ describe('EventValidationRequest', () => {
       5, // event_commitment
       6, // tx_hash
       7, // recipient
-      8, // log_index_in_tx
-      9, // tx_index_in_block
     ].map(n => new Fr(n));
 
     const request = EventValidationRequest.fromFields(serialized);
@@ -38,7 +36,5 @@ describe('EventValidationRequest', () => {
     expect(request.eventCommitment).toEqual(new Fr(5));
     expect(request.txHash).toEqual(TxHash.fromBigInt(6n));
     expect(request.recipient).toEqual(AztecAddress.fromBigInt(7n));
-    expect(request.logIndexInTx).toEqual(8);
-    expect(request.txIndexInBlock).toEqual(9);
   });
 });

--- a/yarn-project/pxe/src/contract_function_simulator/event_validation_request.ts
+++ b/yarn-project/pxe/src/contract_function_simulator/event_validation_request.ts
@@ -19,8 +19,6 @@ export class EventValidationRequest {
     public eventCommitment: Fr,
     public txHash: TxHash,
     public recipient: AztecAddress,
-    public logIndexInTx: number,
-    public txIndexInBlock: number,
   ) {}
 
   static fromFields(fields: Fr[] | FieldReader): EventValidationRequest {
@@ -36,8 +34,6 @@ export class EventValidationRequest {
     const eventCommitment = reader.readField();
     const txHash = TxHash.fromField(reader.readField());
     const recipient = AztecAddress.fromField(reader.readField());
-    const logIndexInTx = reader.readField().toNumber();
-    const txIndexInBlock = reader.readField().toNumber();
 
     return new EventValidationRequest(
       contractAddress,
@@ -46,8 +42,6 @@ export class EventValidationRequest {
       eventCommitment,
       txHash,
       recipient,
-      logIndexInTx,
-      txIndexInBlock,
     );
   }
 }

--- a/yarn-project/pxe/src/contract_function_simulator/pxe_oracle_interface.ts
+++ b/yarn-project/pxe/src/contract_function_simulator/pxe_oracle_interface.ts
@@ -592,8 +592,6 @@ export class PXEOracleInterface implements ExecutionDataProvider {
           txEffect.data.noteHashes,
           txEffect.data.nullifiers[0],
           recipient,
-          scopedLog.logIndexInTx,
-          txEffect.txIndexInBlock,
         );
 
         return pendingTaggedLog.toFields();
@@ -638,8 +636,6 @@ export class PXEOracleInterface implements ExecutionDataProvider {
         request.serializedEvent,
         request.eventCommitment,
         request.txHash,
-        request.logIndexInTx,
-        request.txIndexInBlock,
         request.recipient,
       ),
     );
@@ -743,8 +739,6 @@ export class PXEOracleInterface implements ExecutionDataProvider {
     content: Fr[],
     eventCommitment: Fr,
     txHash: TxHash,
-    logIndexInTx: number,
-    txIndexInBlock: number,
     recipient: AztecAddress,
   ): Promise<void> {
     // While using 'latest' block number would be fine for private events since they cannot be accessed from Aztec.nr
@@ -771,8 +765,7 @@ export class PXEOracleInterface implements ExecutionDataProvider {
       selector,
       content,
       txHash,
-      logIndexInTx,
-      txIndexInBlock,
+      Number(nullifierIndex.data), // Index of the event commitment in the nullifier tree
       nullifierIndex.l2BlockNumber, // Block in which the event was emitted
     );
   }

--- a/yarn-project/pxe/src/storage/private_event_data_provider/private_event_data_provider.test.ts
+++ b/yarn-project/pxe/src/storage/private_event_data_provider/private_event_data_provider.test.ts
@@ -249,7 +249,7 @@ describe('PrivateEventDataProvider', () => {
         eventSelector,
         msgContent2,
         TxHash.random(),
-        1,
+        1, // eventCommitmentIndex
         200,
       );
 
@@ -259,7 +259,7 @@ describe('PrivateEventDataProvider', () => {
         eventSelector,
         msgContent1,
         TxHash.random(),
-        0,
+        0, // eventCommitmentIndex
         100,
       );
 
@@ -269,7 +269,7 @@ describe('PrivateEventDataProvider', () => {
         eventSelector,
         msgContent3,
         TxHash.random(),
-        2,
+        2, // eventCommitmentIndex
         300,
       );
 

--- a/yarn-project/pxe/src/storage/private_event_data_provider/private_event_data_provider.test.ts
+++ b/yarn-project/pxe/src/storage/private_event_data_provider/private_event_data_provider.test.ts
@@ -19,8 +19,7 @@ describe('PrivateEventDataProvider', () => {
   let blockNumber: number;
   let eventSelector: EventSelector;
   let txHash: TxHash;
-  let logIndexInTx: number;
-  let txIndexInBlock: number;
+  let eventCommitmentIndex: number;
 
   beforeEach(async () => {
     const store = await openTmpStore('private_event_data_provider_test');
@@ -31,8 +30,7 @@ describe('PrivateEventDataProvider', () => {
     blockNumber = 123;
     eventSelector = EventSelector.random();
     txHash = TxHash.random();
-    logIndexInTx = randomInt(10);
-    txIndexInBlock = randomInt(10);
+    eventCommitmentIndex = randomInt(10);
   });
 
   it('stores and retrieves private events', async () => {
@@ -42,8 +40,7 @@ describe('PrivateEventDataProvider', () => {
       eventSelector,
       msgContent,
       txHash,
-      logIndexInTx,
-      txIndexInBlock,
+      eventCommitmentIndex,
       blockNumber,
     );
     const events = await privateEventDataProvider.getPrivateEvents(
@@ -56,15 +53,14 @@ describe('PrivateEventDataProvider', () => {
     expect(events).toEqual([msgContent]);
   });
 
-  it('ignores duplicate events with same txHash and logIndexInTx', async () => {
+  it('ignores duplicate events with same eventCommitmentIndex', async () => {
     await privateEventDataProvider.storePrivateEventLog(
       contractAddress,
       recipient,
       eventSelector,
       msgContent,
       txHash,
-      logIndexInTx,
-      txIndexInBlock,
+      eventCommitmentIndex,
       blockNumber,
     );
     await privateEventDataProvider.storePrivateEventLog(
@@ -73,8 +69,7 @@ describe('PrivateEventDataProvider', () => {
       eventSelector,
       msgContent,
       txHash,
-      logIndexInTx,
-      txIndexInBlock,
+      eventCommitmentIndex,
       blockNumber,
     );
     const events = await privateEventDataProvider.getPrivateEvents(
@@ -87,16 +82,15 @@ describe('PrivateEventDataProvider', () => {
     expect(events).toEqual([msgContent]);
   });
 
-  it('allows multiple events with same content but different txHash', async () => {
-    const otherTxHash = TxHash.random();
+  it('allows multiple events with same content but different eventCommitmentIndex', async () => {
+    const otherEventCommitmentIndex = eventCommitmentIndex + 1;
     await privateEventDataProvider.storePrivateEventLog(
       contractAddress,
       recipient,
       eventSelector,
       msgContent,
       txHash,
-      logIndexInTx,
-      txIndexInBlock,
+      eventCommitmentIndex,
       blockNumber,
     );
     await privateEventDataProvider.storePrivateEventLog(
@@ -104,9 +98,8 @@ describe('PrivateEventDataProvider', () => {
       recipient,
       eventSelector,
       msgContent,
-      otherTxHash,
-      logIndexInTx,
-      txIndexInBlock,
+      txHash,
+      otherEventCommitmentIndex,
       blockNumber,
     );
     const events = await privateEventDataProvider.getPrivateEvents(
@@ -126,8 +119,7 @@ describe('PrivateEventDataProvider', () => {
       eventSelector,
       getRandomMsgContent(),
       TxHash.random(),
-      logIndexInTx,
-      txIndexInBlock,
+      0,
       100,
     );
     await privateEventDataProvider.storePrivateEventLog(
@@ -136,8 +128,7 @@ describe('PrivateEventDataProvider', () => {
       eventSelector,
       msgContent,
       TxHash.random(),
-      logIndexInTx,
-      txIndexInBlock,
+      1,
       200,
     );
     await privateEventDataProvider.storePrivateEventLog(
@@ -146,8 +137,7 @@ describe('PrivateEventDataProvider', () => {
       eventSelector,
       getRandomMsgContent(),
       TxHash.random(),
-      logIndexInTx,
-      txIndexInBlock,
+      2,
       300,
     );
 
@@ -170,8 +160,7 @@ describe('PrivateEventDataProvider', () => {
       eventSelector,
       msgContent,
       txHash,
-      logIndexInTx,
-      txIndexInBlock,
+      eventCommitmentIndex,
       blockNumber,
     );
     await privateEventDataProvider.storePrivateEventLog(
@@ -180,8 +169,7 @@ describe('PrivateEventDataProvider', () => {
       eventSelector,
       msgContent,
       TxHash.random(),
-      logIndexInTx,
-      txIndexInBlock,
+      eventCommitmentIndex + 1,
       blockNumber,
     );
 
@@ -215,8 +203,7 @@ describe('PrivateEventDataProvider', () => {
       eventSelector,
       msgContent,
       txHash,
-      logIndexInTx,
-      txIndexInBlock,
+      eventCommitmentIndex,
       blockNumber,
     );
     expect(await privateEventDataProvider.getSize()).toBe(1);
@@ -227,8 +214,7 @@ describe('PrivateEventDataProvider', () => {
       eventSelector,
       msgContent,
       txHash,
-      logIndexInTx,
-      txIndexInBlock,
+      eventCommitmentIndex,
       blockNumber,
     );
     expect(await privateEventDataProvider.getSize()).toBe(1); // Duplicate event not stored
@@ -239,8 +225,7 @@ describe('PrivateEventDataProvider', () => {
       eventSelector,
       msgContent,
       TxHash.random(),
-      logIndexInTx,
-      txIndexInBlock,
+      eventCommitmentIndex + 1,
       blockNumber,
     );
     expect(await privateEventDataProvider.getSize()).toBe(2);
@@ -257,28 +242,25 @@ describe('PrivateEventDataProvider', () => {
       msgContent3 = getRandomMsgContent();
     });
 
-    it('returns events in order across different blocks', async () => {
+    it('returns events in order by eventCommitmentIndex', async () => {
       await privateEventDataProvider.storePrivateEventLog(
         contractAddress,
         recipient,
         eventSelector,
         msgContent2,
         TxHash.random(),
-        0, // logIndexInTx
-        0, // txIndexInBlock
-        200, // blockNumber
+        1,
+        200,
       );
 
-      // Store events in different blocks
       await privateEventDataProvider.storePrivateEventLog(
         contractAddress,
         recipient,
         eventSelector,
         msgContent1,
         TxHash.random(),
-        0, // logIndexInTx
-        0, // txIndexInBlock
-        100, // blockNumber
+        0,
+        100,
       );
 
       await privateEventDataProvider.storePrivateEventLog(
@@ -287,117 +269,19 @@ describe('PrivateEventDataProvider', () => {
         eventSelector,
         msgContent3,
         TxHash.random(),
-        0, // logIndexInTx
-        0, // txIndexInBlock
-        300, // blockNumber
+        2,
+        300,
       );
 
-      // Get events across all blocks
       const events = await privateEventDataProvider.getPrivateEvents(
         contractAddress,
-        0, // from
-        1000, // numBlocks
+        0,
+        1000,
         [recipient],
         eventSelector,
       );
 
       expect(events).toEqual([msgContent1, msgContent2, msgContent3]);
-    });
-
-    it('returns events in order within same block but different transactions', async () => {
-      const sameBlockNumber = 400;
-
-      await privateEventDataProvider.storePrivateEventLog(
-        contractAddress,
-        recipient,
-        eventSelector,
-        msgContent2,
-        TxHash.random(),
-        0, // logIndexInTx
-        1, // txIndexInBlock
-        sameBlockNumber,
-      );
-
-      await privateEventDataProvider.storePrivateEventLog(
-        contractAddress,
-        recipient,
-        eventSelector,
-        msgContent1,
-        TxHash.random(),
-        0, // logIndexInTx
-        0, // txIndexInBlock
-        sameBlockNumber,
-      );
-
-      await privateEventDataProvider.storePrivateEventLog(
-        contractAddress,
-        recipient,
-        eventSelector,
-        msgContent3,
-        TxHash.random(),
-        0, // logIndexInTx
-        2, // txIndexInBlock
-        sameBlockNumber,
-      );
-
-      // Get events from just that block
-      const sameBlockEvents = await privateEventDataProvider.getPrivateEvents(
-        contractAddress,
-        sameBlockNumber,
-        1, // numBlocks
-        [recipient],
-        eventSelector,
-      );
-
-      expect(sameBlockEvents).toEqual([msgContent1, msgContent2, msgContent3]);
-    });
-
-    it('returns events in order within the same transaction', async () => {
-      const sameTxHash = TxHash.random();
-
-      await privateEventDataProvider.storePrivateEventLog(
-        contractAddress,
-        recipient,
-        eventSelector,
-        msgContent3,
-        sameTxHash,
-        2, // logIndexInTx
-        3, // txIndexInBlock
-        500, // blockNumber
-      );
-
-      await privateEventDataProvider.storePrivateEventLog(
-        contractAddress,
-        recipient,
-        eventSelector,
-        msgContent1,
-        sameTxHash,
-        0, // logIndexInTx
-        3, // txIndexInBlock
-        500, // blockNumber
-      );
-
-      await privateEventDataProvider.storePrivateEventLog(
-        contractAddress,
-        recipient,
-        eventSelector,
-        msgContent2,
-        sameTxHash,
-        1, // logIndexInTx
-        3, // txIndexInBlock
-        500, // blockNumber
-      );
-
-      // Get events from just that block
-      const sameTxEvents = await privateEventDataProvider.getPrivateEvents(
-        contractAddress,
-        500, // from
-        1, // numBlocks
-        [recipient],
-        eventSelector,
-      );
-
-      expect(sameTxEvents).toEqual([msgContent1, msgContent2, msgContent3]);
     });
   });
 });

--- a/yarn-project/stdlib/src/logs/pending_tagged_log.test.ts
+++ b/yarn-project/stdlib/src/logs/pending_tagged_log.test.ts
@@ -12,18 +12,8 @@ describe('PendingTaggedLog', () => {
     const uniqueNoteHashes = [new Fr(4n), new Fr(5n)];
     const firstNullifier = new Fr(6n);
     const recipient = AztecAddress.fromField(new Fr(789n));
-    const logIndexInTx = 10;
-    const txIndexInBlock = 11;
 
-    const pendingLog = new PendingTaggedLog(
-      log,
-      txHash,
-      uniqueNoteHashes,
-      firstNullifier,
-      recipient,
-      logIndexInTx,
-      txIndexInBlock,
-    );
+    const pendingLog = new PendingTaggedLog(log, txHash, uniqueNoteHashes, firstNullifier, recipient);
     const serialized = pendingLog.toFields();
 
     // Test against snapshot
@@ -116,8 +106,6 @@ describe('PendingTaggedLog', () => {
         "0x0000000000000000000000000000000000000000000000000000000000000002",
         "0x0000000000000000000000000000000000000000000000000000000000000006",
         "0x0000000000000000000000000000000000000000000000000000000000000315",
-        "0x000000000000000000000000000000000000000000000000000000000000000a",
-        "0x000000000000000000000000000000000000000000000000000000000000000b",
       ]
     `);
 

--- a/yarn-project/stdlib/src/logs/pending_tagged_log.ts
+++ b/yarn-project/stdlib/src/logs/pending_tagged_log.ts
@@ -15,8 +15,6 @@ export class PendingTaggedLog {
     public uniqueNoteHashesInTx: Fr[],
     public firstNullifierInTx: Fr,
     public recipient: AztecAddress,
-    public logIndexInTx: number,
-    public txIndexInBlock: number,
   ) {}
 
   toFields(): Fr[] {
@@ -26,8 +24,6 @@ export class PendingTaggedLog {
       ...serializeBoundedVec(this.uniqueNoteHashesInTx, MAX_NOTE_HASHES_PER_TX),
       this.firstNullifierInTx,
       this.recipient.toField(),
-      new Fr(this.logIndexInTx),
-      new Fr(this.txIndexInBlock),
     ];
   }
 }


### PR DESCRIPTION
To be able to return private events in the order in which they were emitted we stored `logIndexInTx`, `txIndeInBlock` and `blockNumber` along with the event and then we ordered based on these 3 values. This solution started to be problematic with offchain message delivery as when an event is delivered via the offchain message channel it doesn't have an index "compatible" with the private log index since it's a completely separate information channel.

However with [this PR](https://github.com/AztecProtocol/aztec-packages/pull/14634) we commit to events and we insert the commitment to the nullifier tree. This gives us a global ordering we can use.

In this PR I modify the code such that we order by this event commitment index.