### PR TITLE
fix: revert if coinbase is zero

### DIFF
--- a/l1-contracts/src/core/libraries/Errors.sol
+++ b/l1-contracts/src/core/libraries/Errors.sol
@@ -82,6 +82,7 @@ library Errors {
   error Rollup__ManaLimitExceeded();
   error Rollup__RewardsNotClaimable();
   error Rollup__InvalidFirstEpochProof();
+  error Rollup__InvalidCoinbase();
 
   // ProposedHeaderLib
   error HeaderLib__InvalidHeaderSize(uint256 expected, uint256 actual); // 0xf3ccb247

--- a/l1-contracts/src/core/libraries/rollup/ProposeLib.sol
+++ b/l1-contracts/src/core/libraries/rollup/ProposeLib.sol
@@ -177,6 +177,7 @@ library ProposeLib {
 
   // @note: not view as sampling validators uses tstore
   function validateHeader(ValidateHeaderArgs memory _args) internal {
+    require(_args.header.coinbase != address(0), Errors.Rollup__InvalidCoinbase());
     require(_args.header.totalManaUsed <= FeeLib.getManaLimit(), Errors.Rollup__ManaLimitExceeded());
 
     RollupStore storage rollupStore = STFLib.getStorage();

--- a/l1-contracts/test/Rollup.t.sol
+++ b/l1-contracts/test/Rollup.t.sol
@@ -749,6 +749,31 @@ contract RollupTest is RollupBase {
     rollup.propose(args, attestations, new bytes(144));
   }
 
+  function testRevertInvalidCoinbase() public setUpFor("empty_block_1") {
+    DecoderBase.Data memory data = load("empty_block_1").block;
+    ProposedHeader memory header = data.header;
+    bytes32 archive = data.archive;
+    bytes32[] memory txHashes = new bytes32[](0);
+
+    Timestamp realTs = header.timestamp;
+
+    vm.warp(max(block.timestamp, Timestamp.unwrap(realTs)));
+
+    // Tweak the coinbase.
+    header.coinbase = address(0);
+
+    skipBlobCheck(address(rollup));
+    vm.expectRevert(abi.encodeWithSelector(Errors.Rollup__InvalidCoinbase.selector));
+    ProposeArgs memory args = ProposeArgs({
+      header: header,
+      archive: archive,
+      stateReference: EMPTY_STATE_REFERENCE,
+      oracleInput: OracleInput(0),
+      txHashes: txHashes
+    });
+    rollup.propose(args, attestations, new bytes(144));
+  }
+
   function testSubmitProofNonExistentBlock() public setUpFor("empty_block_1") {
     _proposeBlock("empty_block_1", 1);
     DecoderBase.Data memory data = load("empty_block_1").block;

--- a/l1-contracts/test/benchmark/happy.t.sol
+++ b/l1-contracts/test/benchmark/happy.t.sol
@@ -218,13 +218,13 @@ contract BenchmarkRollupTest is FeeModelTestPoints, DecoderBase {
     uint256 manaSpent = point.block_header.mana_spent;
 
     address proposer = rollup.getCurrentProposer();
-    address coinbase = proposer != address(0) ? proposer : address(bytes20("MONEY MAKER"));
+    address c = proposer != address(0) ? proposer : coinbase;
 
     // Updating the header with important information!
     header.lastArchiveRoot = archiveRoot;
     header.slotNumber = slotNumber;
     header.timestamp = ts;
-    header.coinbase = coinbase;
+    header.coinbase = c;
     header.feeRecipient = bytes32(0);
     header.gasFees.feePerL2Gas = manaBaseFee;
     header.totalManaUsed = manaSpent;

--- a/l1-contracts/test/benchmark/happy.t.sol
+++ b/l1-contracts/test/benchmark/happy.t.sol
@@ -218,12 +218,13 @@ contract BenchmarkRollupTest is FeeModelTestPoints, DecoderBase {
     uint256 manaSpent = point.block_header.mana_spent;
 
     address proposer = rollup.getCurrentProposer();
+    address coinbase = proposer != address(0) ? proposer : address(bytes20("MONEY MAKER"));
 
     // Updating the header with important information!
     header.lastArchiveRoot = archiveRoot;
     header.slotNumber = slotNumber;
     header.timestamp = ts;
-    header.coinbase = proposer;
+    header.coinbase = coinbase;
     header.feeRecipient = bytes32(0);
     header.gasFees.feePerL2Gas = manaBaseFee;
     header.totalManaUsed = manaSpent;

--- a/yarn-project/sequencer-client/src/sequencer/sequencer.ts
+++ b/yarn-project/sequencer-client/src/sequencer/sequencer.ts
@@ -720,6 +720,10 @@ export class Sequencer {
   }
 
   get coinbase(): EthAddress {
+    if (this._coinbase.isZero()) {
+      this.log.debug(`Coinbase is zero, using publisher sender address`, this.publisher.getSenderAddress());
+      return this.publisher.getSenderAddress();
+    }
     return this._coinbase;
   }
 

--- a/yarn-project/sequencer-client/src/sequencer/sequencer.ts
+++ b/yarn-project/sequencer-client/src/sequencer/sequencer.ts
@@ -326,7 +326,7 @@ export class Sequencer {
 
     const newGlobalVariables = await this.globalsBuilder.buildGlobalVariables(
       new Fr(newBlockNumber),
-      this._coinbase,
+      this.coinbase,
       this._feeRecipient,
       slot,
     );


### PR DESCRIPTION
Fixes #6539.

Alters the sequencer such that it will default the `coinbase` to be either the config provided value, or the sender address of the publisher.