### PR TITLE
chore(ci): shell-new takes command

### DIFF
--- a/ci.sh
+++ b/ci.sh
@@ -137,7 +137,8 @@ case "$cmd" in
   "shell-new")
     # Spin up ec2 instance, clone, and drop into shell.
     # False triggers the shell on fail.
-    exec bootstrap_ec2 "false"
+    cmd="${1:-false}"
+    exec bootstrap_ec2 "$cmd"
     ;;
   "shell-container")
     # Drop into a shell in the current running build instance container.


### PR DESCRIPTION
Helps with automated testing. Note as long as there's a bad exit code, this drops into interactive mode
