### PR TITLE
fix: `Cannot read properties of undefined (reading 'txHash')` in reqresp

### DIFF
--- a/yarn-project/end-to-end/src/e2e_p2p/reqresp.test.ts
+++ b/yarn-project/end-to-end/src/e2e_p2p/reqresp.test.ts
@@ -122,7 +122,7 @@ describe('e2e_p2p_reqresp_tx', () => {
       c.txs.map(tx => {
         const node = nodes[proposerIndexes[i]];
         void node.sendTx(tx).catch(err => t.logger.error(`Error sending tx: ${err}`));
-        return new SentTx(node, tx.getTxHash);
+        return new SentTx(node, () => tx.getTxHash());
       }),
     );
 


### PR DESCRIPTION
Callback was incorrectly bound. This wont fix the flakes in the test, but will prevent it from consistently failing.
