### PR TITLE
chore: Add boxes flake

### DIFF
--- a/.test_patterns.yml
+++ b/.test_patterns.yml
@@ -276,6 +276,11 @@ tests:
     owners:
       - *saleel
 
+  - regex: "run_compose_test react-[a-z]* box boxes"
+    error_regex: "toBeVisible" # http://ci.aztec-labs.com/b7b10b95167d5ed6
+    owners:
+      - *saleel
+
   - regex: "tests/browser.spec.ts"
     error_regex: "Error: locator\\.click: Test timeout of"
     owners:


### PR DESCRIPTION
```
13:08:09   ✘  1 [webkit] › browser.spec.ts:3:1 › test (16.8s)
13:08:09 box-1       |
13:08:09 box-1       |   1) [webkit] › browser.spec.ts:3:1 › test ─────────────────────────────────────────────────────────
13:08:09 box-1       |
13:08:09 box-1       |     Error: expect(locator).toBeVisible()
13:08:09 box-1       |
13:08:09 box-1       |     Locator: getByText('Number set to: 1')
13:08:09 box-1       |     Expected: visible
13:08:09 box-1       |     Received: <element(s) not found>
13:08:09 box-1       |     Call log:
13:08:09 box-1       |       - expect.toBeVisible with timeout 90000ms
13:08:09 box-1       |       - waiting for getByText('Number set to: 1')
13:08:09 box-1       |
13:08:09 box-1       |
13:08:09 box-1       |       18 |   await page.getByRole('button', { name: 'Write' }).click();
13:08:09 box-1       |       19 |   await expect(page.getByText('Setting number...')).toBeVisible();
13:08:09 box-1       |     > 20 |   await expect(page.getByText('Number set to: 1')).toBeVisible();
13:08:09 box-1       |          |                                                    ^
13:08:09 box-1       |       21 |
13:08:09 box-1       |       22 |   // Read number
13:08:09 box-1       |       23 |   await page.getByRole('button', { name: 'Read' }).click();
13:08:09 box-1       |         at /root/aztec-packages/boxes/boxes/react/tests/browser.spec.ts:20:52
13:08:09 box-1       |
13:08:09 box-1       |   Slow test file: [webkit] › browser.spec.ts (16.8s)
13:08:09 box-1       |   Consider splitting slow test files to speed up parallel execution
13:08:09 box-1       |   1 failed
13:08:09 box-1       |     [webkit] › browser.spec.ts:3:1 › test ──────────────────────────────────────────────────────────
```
