### PR TITLE
feat!: staking entry queue

### DIFF
--- a/l1-contracts/src/core/Rollup.sol
+++ b/l1-contracts/src/core/Rollup.sol
@@ -252,10 +252,6 @@ contract Rollup is IStaking, IValidatorSelection, IRollup, RollupCore {
     return StakingLib.getStorage().gse;
   }
 
-  function getActiveAttesterCount() external view override(IStaking) returns (uint256) {
-    return StakingLib.getAttesterCountAtTime(Timestamp.wrap(block.timestamp));
-  }
-
   function getManaTarget() external view override(IRollup) returns (uint256) {
     return FeeLib.getStorage().manaTarget;
   }
@@ -744,5 +740,9 @@ contract Rollup is IStaking, IValidatorSelection, IRollup, RollupCore {
    */
   function getCurrentEpoch() public view override(IValidatorSelection) returns (Epoch) {
     return Timestamp.wrap(block.timestamp).epochFromTimestamp();
+  }
+
+  function getNextFlushableEpoch() public view override(IStaking) returns (Epoch) {
+    return StakingLib.getNextFlushableEpoch();
   }
 }

--- a/l1-contracts/src/core/interfaces/IRollup.sol
+++ b/l1-contracts/src/core/interfaces/IRollup.sol
@@ -76,6 +76,8 @@ struct RollupConfigInput {
   uint256 slashingQuorum;
   uint256 slashingRoundSize;
   uint256 manaTarget;
+  uint256 entryQueueFlushSizeMin;
+  uint256 entryQueueFlushSizeQuotient;
   EthValue provingCostPerMana;
   RewardConfig rewardConfig;
 }
@@ -91,6 +93,8 @@ struct RollupConfig {
   IInbox inbox;
   IOutbox outbox;
   uint256 version;
+  uint256 entryQueueFlushSizeMin;
+  uint256 entryQueueFlushSizeQuotient;
 }
 
 struct RollupStore {

--- a/l1-contracts/src/core/interfaces/IStaking.sol
+++ b/l1-contracts/src/core/interfaces/IStaking.sol
@@ -4,28 +4,34 @@ pragma solidity >=0.8.27;
 
 import {Exit, Status, AttesterView} from "@aztec/core/libraries/staking/StakingLib.sol";
 import {Timestamp} from "@aztec/core/libraries/TimeMath.sol";
+import {Epoch} from "@aztec/core/libraries/TimeMath.sol";
 import {AttesterConfig, GSE} from "@aztec/core/staking/GSE.sol";
 import {IERC20} from "@oz/token/ERC20/IERC20.sol";
 
 interface IStakingCore {
   event SlasherUpdated(address indexed oldSlasher, address indexed newSlasher);
+  event ValidatorQueued(address indexed attester, address indexed withdrawer);
   event Deposit(address indexed attester, address indexed withdrawer, uint256 amount);
+  event FailedDeposit(address indexed attester, address indexed withdrawer);
   event WithdrawInitiated(address indexed attester, address indexed recipient, uint256 amount);
   event WithdrawFinalised(address indexed attester, address indexed recipient, uint256 amount);
   event Slashed(address indexed attester, uint256 amount);
 
   function setSlasher(address _slasher) external;
   function deposit(address _attester, address _withdrawer, bool _onCanonical) external;
+  function flushEntryQueue() external;
   function initiateWithdraw(address _attester, address _recipient) external returns (bool);
   function finaliseWithdraw(address _attester) external;
   function slash(address _attester, uint256 _amount) external;
   function vote(uint256 _proposalId) external;
+
+  function getEntryQueueFlushSize() external view returns (uint256);
+  function getActiveAttesterCount() external view returns (uint256);
 }
 
 interface IStaking is IStakingCore {
   function getConfig(address _attester) external view returns (AttesterConfig memory);
   function getExit(address _attester) external view returns (Exit memory);
-  function getActiveAttesterCount() external view returns (uint256);
   function getAttesterAtIndex(uint256 _index) external view returns (address);
   function getSlasher() external view returns (address);
   function getStakingAsset() external view returns (IERC20);
@@ -35,4 +41,5 @@ interface IStaking is IStakingCore {
   function getGSE() external view returns (GSE);
   function getAttesterView(address _attester) external view returns (AttesterView memory);
   function getStatus(address _attester) external view returns (Status);
+  function getNextFlushableEpoch() external view returns (Epoch);
 }

--- a/l1-contracts/src/core/libraries/Errors.sol
+++ b/l1-contracts/src/core/libraries/Errors.sol
@@ -107,7 +107,11 @@ library Errors {
   error ValidatorSelection__InvalidAttestationsLength(uint256 expected, uint256 actual); // 0xe923198c
 
   // Staking
+  error Staking__AlreadyQueued(address _attester);
+  error Staking__QueueEmpty();
+  error Staking__DepositOutOfGas();
   error Staking__AlreadyActive(address attester); // 0x5e206fa4
+  error Staking__QueueAlreadyFlushed(Epoch epoch); // 0x21148c78
   error Staking__AlreadyRegistered(address instance, address attester);
   error Staking__CannotSlashExitedStake(address); // 0x45bf4940
   error Staking__FailedToRemove(address); // 0xa7d7baab

--- a/l1-contracts/src/core/libraries/StakingQueue.sol
+++ b/l1-contracts/src/core/libraries/StakingQueue.sol
@@ -1,0 +1,58 @@
+// SPDX-License-Identifier: Apache-2.0
+pragma solidity >=0.8.27;
+
+import {Errors} from "./Errors.sol";
+
+struct DepositArgs {
+  address attester;
+  address withdrawer;
+  bool onCanonical;
+}
+
+struct StakingQueue {
+  mapping(uint256 index => DepositArgs validator) validators;
+  uint128 first;
+  uint128 last;
+}
+
+library StakingQueueLib {
+  function init(StakingQueue storage self) internal {
+    self.first = 1;
+    self.last = 1;
+  }
+
+  function enqueue(
+    StakingQueue storage self,
+    address _attester,
+    address _withdrawer,
+    bool _onCanonical
+  ) internal returns (uint256) {
+    uint128 queueLocation = self.last;
+
+    self.validators[queueLocation] =
+      DepositArgs({attester: _attester, withdrawer: _withdrawer, onCanonical: _onCanonical});
+    self.last = queueLocation + 1;
+
+    return queueLocation;
+  }
+
+  function dequeue(StakingQueue storage self) internal returns (DepositArgs memory validator) {
+    require(self.last > self.first, Errors.Staking__QueueEmpty());
+
+    validator = self.validators[self.first];
+
+    self.first += 1;
+  }
+
+  function length(StakingQueue storage self) internal view returns (uint256 len) {
+    len = self.last - self.first;
+  }
+
+  function getFirst(StakingQueue storage self) internal view returns (uint256) {
+    return self.first;
+  }
+
+  function getLast(StakingQueue storage self) internal view returns (uint256) {
+    return self.last;
+  }
+}

--- a/l1-contracts/src/core/libraries/rollup/ExtRollupLib2.sol
+++ b/l1-contracts/src/core/libraries/rollup/ExtRollupLib2.sol
@@ -22,6 +22,10 @@ library ExtRollupLib2 {
     StakingLib.deposit(_attester, _withdrawer, _onCanonical);
   }
 
+  function flushEntryQueue(uint256 _maxAddableValidators) external {
+    StakingLib.flushEntryQueue(_maxAddableValidators);
+  }
+
   function initiateWithdraw(address _attester, address _recipient) external returns (bool) {
     return StakingLib.initiateWithdraw(_attester, _recipient);
   }

--- a/l1-contracts/src/core/libraries/staking/StakingLib.sol
+++ b/l1-contracts/src/core/libraries/staking/StakingLib.sol
@@ -8,7 +8,9 @@ import {
   AddressSnapshotLib,
   SnapshottedAddressSet
 } from "@aztec/core/libraries/staking/AddressSnapshotLib.sol";
-import {Timestamp} from "@aztec/core/libraries/TimeLib.sol";
+import {StakingQueueLib, StakingQueue, DepositArgs} from "@aztec/core/libraries/StakingQueue.sol";
+import {Epoch, Timestamp} from "@aztec/core/libraries/TimeLib.sol";
+import {TimeLib} from "@aztec/core/libraries/TimeLib.sol";
 import {GSE, AttesterConfig} from "@aztec/core/staking/GSE.sol";
 import {Governance} from "@aztec/governance/Governance.sol";
 import {DataStructures} from "@aztec/governance/libraries/DataStructures.sol";
@@ -53,6 +55,8 @@ struct StakingStorage {
   GSE gse;
   Timestamp exitDelay;
   mapping(address attester => Exit) exits;
+  StakingQueue entryQueue;
+  Epoch nextFlushableEpoch;
 }
 
 library StakingLib {
@@ -60,6 +64,7 @@ library StakingLib {
   using SafeERC20 for IERC20;
   using AddressSnapshotLib for SnapshottedAddressSet;
   using ProposalLib for DataStructures.Proposal;
+  using StakingQueueLib for StakingQueue;
 
   bytes32 private constant STAKING_SLOT = keccak256("aztec.core.staking.storage");
 
@@ -71,6 +76,7 @@ library StakingLib {
     store.gse = _gse;
     store.exitDelay = _exitDelay;
     store.slasher = _slasher;
+    store.entryQueue.init();
   }
 
   function setSlasher(address _slasher) internal {
@@ -202,8 +208,38 @@ library StakingLib {
     uint256 amount = store.gse.DEPOSIT_AMOUNT();
 
     store.stakingAsset.transferFrom(msg.sender, address(this), amount);
-    store.stakingAsset.approve(address(store.gse), amount);
-    store.gse.deposit(_attester, _withdrawer, _onCanonical);
+    store.entryQueue.enqueue(_attester, _withdrawer, _onCanonical);
+    emit IStakingCore.ValidatorQueued(_attester, _withdrawer);
+  }
+
+  function flushEntryQueue(uint256 _maxAddableValidators) internal {
+    Epoch currentEpoch = TimeLib.epochFromTimestamp(Timestamp.wrap(block.timestamp));
+    StakingStorage storage store = getStorage();
+    require(
+      store.nextFlushableEpoch <= currentEpoch, Errors.Staking__QueueAlreadyFlushed(currentEpoch)
+    );
+    store.nextFlushableEpoch = currentEpoch + Epoch.wrap(1);
+    uint256 amount = store.gse.DEPOSIT_AMOUNT();
+
+    uint256 queueLength = store.entryQueue.length();
+    uint256 numToDequeue = _maxAddableValidators > queueLength ? queueLength : _maxAddableValidators;
+    store.stakingAsset.approve(address(store.gse), amount * numToDequeue);
+    for (uint256 i = 0; i < numToDequeue; i++) {
+      DepositArgs memory args = store.entryQueue.dequeue();
+      (bool success, bytes memory data) = address(store.gse).call(
+        abi.encodeWithSelector(
+          IStakingCore.deposit.selector, args.attester, args.withdrawer, args.onCanonical
+        )
+      );
+      if (success) {
+        emit IStakingCore.Deposit(args.attester, args.withdrawer, amount);
+      } else {
+        require(data.length > 0, Errors.Staking__DepositOutOfGas());
+        store.stakingAsset.transfer(args.withdrawer, amount);
+        emit IStakingCore.FailedDeposit(args.attester, args.withdrawer);
+      }
+    }
+    store.stakingAsset.approve(address(store.gse), 0);
   }
 
   function initiateWithdraw(address _attester, address _recipient) internal returns (bool) {
@@ -246,6 +282,10 @@ library StakingLib {
     }
 
     return true;
+  }
+
+  function getNextFlushableEpoch() internal view returns (Epoch) {
+    return getStorage().nextFlushableEpoch;
   }
 
   function getAttesterCountAtTime(Timestamp _timestamp) internal view returns (uint256) {

--- a/l1-contracts/src/mock/MultiAdder.sol
+++ b/l1-contracts/src/mock/MultiAdder.sol
@@ -33,5 +33,6 @@ contract MultiAdder is IMultiAdder {
     for (uint256 i = 0; i < _args.length; i++) {
       STAKING.deposit(_args[i].attester, _args[i].withdrawer, true);
     }
+    STAKING.flushEntryQueue();
   }
 }

--- a/l1-contracts/test/builder/RollupBuilder.sol
+++ b/l1-contracts/test/builder/RollupBuilder.sol
@@ -181,6 +181,22 @@ contract RollupBuilder is Test {
     return this;
   }
 
+  function setEntryQueueFlushSizeMin(uint256 _entryQueueFlushSizeMin)
+    public
+    returns (RollupBuilder)
+  {
+    config.rollupConfigInput.entryQueueFlushSizeMin = _entryQueueFlushSizeMin;
+    return this;
+  }
+
+  function setEntryQueueFlushSizeQuotient(uint256 _entryQueueFlushSizeQuotient)
+    public
+    returns (RollupBuilder)
+  {
+    config.rollupConfigInput.entryQueueFlushSizeQuotient = _entryQueueFlushSizeQuotient;
+    return this;
+  }
+
   /* -------------------------------------------------------------------------- */
   /*                              Rollup config end                             */
   /* -------------------------------------------------------------------------- */

--- a/l1-contracts/test/delegation/base.t.sol
+++ b/l1-contracts/test/delegation/base.t.sol
@@ -19,9 +19,11 @@ contract GSEBase is TestBase {
   address internal constant WITHDRAWER = address(bytes20("WITHDRAWER"));
   address internal constant RECIPIENT = address(bytes20("RECIPIENT"));
 
+  uint256 internal EPOCH_DURATION_SECONDS;
+
   function setUp() public virtual {
-    RollupBuilder builder =
-      new RollupBuilder(address(this)).setSlashingQuorum(1).setSlashingRoundSize(1);
+    RollupBuilder builder = new RollupBuilder(address(this)).setSlashingQuorum(1)
+      .setSlashingRoundSize(1).setEpochDuration(1).setSlotDuration(1);
     builder.deploy();
 
     registry = builder.getConfig().registry;
@@ -29,6 +31,9 @@ contract GSEBase is TestBase {
     stakingAsset = builder.getConfig().testERC20;
     gse = builder.getConfig().gse;
     governance = builder.getConfig().governance;
+
+    EPOCH_DURATION_SECONDS = builder.getConfig().rollupConfigInput.aztecEpochDuration
+      * builder.getConfig().rollupConfigInput.aztecSlotDuration;
 
     vm.label(address(governance), "governance");
     vm.label(address(governance.governanceProposer()), "governance proposer");
@@ -46,6 +51,7 @@ contract GSEBase is TestBase {
     uint256 balance = stakingAsset.balanceOf(address(governance));
 
     ROLLUP.deposit({_attester: _attester, _withdrawer: _withdrawer, _onCanonical: _onCanonical});
+    ROLLUP.flushEntryQueue();
 
     assertEq(
       stakingAsset.balanceOf(address(governance)), balance + depositAmount, "invalid gov balance"

--- a/l1-contracts/test/delegation/minimal.t.sol
+++ b/l1-contracts/test/delegation/minimal.t.sol
@@ -60,14 +60,14 @@ contract MinimalDelegationTest is GSEBase {
     Timestamps memory ts;
 
     ts.ts1 = block.timestamp;
-    ts.ts2 = ts.ts1 + 10;
-    ts.ts3 = ts.ts2 + 10;
+    ts.ts2 = ts.ts1 + EPOCH_DURATION_SECONDS;
+    ts.ts3 = ts.ts2 + EPOCH_DURATION_SECONDS;
 
-    require(votingTime > ts.ts3, "ts");
-    ts.ts4 = votingTime + 10;
-    ts.ts5 = ts.ts4 + 10;
-    ts.ts6 = ts.ts5 + 10;
-    ts.ts7 = ts.ts6 + 10;
+    require(votingTime > ts.ts3, "voting time not long enough");
+    ts.ts4 = votingTime + EPOCH_DURATION_SECONDS;
+    ts.ts5 = ts.ts4 + EPOCH_DURATION_SECONDS;
+    ts.ts6 = ts.ts5 + EPOCH_DURATION_SECONDS;
+    ts.ts7 = ts.ts6 + EPOCH_DURATION_SECONDS;
 
     // Lets start
     assertEq(gse.getVotingPower(canonical), 0, "votingPowerCanonical");

--- a/l1-contracts/test/governance/scenario/AddRollup.t.sol
+++ b/l1-contracts/test/governance/scenario/AddRollup.t.sol
@@ -27,6 +27,7 @@ import {GSEPayload} from "@aztec/governance/GSEPayload.sol";
 import {FakeRollup} from "../governance/TestPayloads.sol";
 import {RegisterNewRollupVersionPayload} from "./RegisterNewRollupVersionPayload.sol";
 import {IInstance} from "@aztec/core/interfaces/IInstance.sol";
+import {stdStorage, StdStorage} from "forge-std/StdStorage.sol";
 
 contract BadRollup {
   IGSE public immutable gse;
@@ -46,6 +47,7 @@ contract BadRollup {
 
 contract AddRollupTest is TestBase {
   using ProposalLib for DataStructures.Proposal;
+  using stdStorage for StdStorage;
 
   IMintableERC20 internal token;
   Registry internal registry;
@@ -67,7 +69,8 @@ contract AddRollupTest is TestBase {
   function setUp() external {
     // We need to make a timejump that is far enough that we can go at least 2 epochs in the past
     vm.warp(100000);
-    RollupBuilder builder = new RollupBuilder(address(this)).setGovProposerN(7).setGovProposerM(10);
+    RollupBuilder builder = new RollupBuilder(address(this)).setGovProposerN(7).setGovProposerM(10)
+      .setEntryQueueFlushSizeMin(VALIDATOR_COUNT * 2);
     builder.deploy();
 
     rollup = builder.getConfig().rollup;
@@ -141,12 +144,18 @@ contract AddRollupTest is TestBase {
       // is > 1/3, such that it cannot pass.
       uint256 val = 1;
 
-      while (gse.supplyOf(gse.getCanonical()) < gse.totalSupply() / 3) {
+      // We need 1/3 of the total supply to be off canonical
+      // So we add 1/2 of the initial supply to the specific instance
+      // The result is that 1/3 of the new total supply is off canonical
+      uint256 validatorsNeeded = (gse.totalSupply() / 2) / rollup.getDepositAmount() + 1;
+
+      while (val <= validatorsNeeded) {
         token.mint(address(this), rollup.getDepositAmount());
         token.approve(address(rollup), rollup.getDepositAmount());
         rollup.deposit(address(uint160(val)), address(this), false);
         val++;
       }
+      rollup.flushEntryQueue();
 
       // While Errors.GovernanceProposer__GSEPayloadInvalid.selector is the error, we are catching it
       // So the expected error is that the call failed and the address of it.

--- a/l1-contracts/test/harnesses/TestConstants.sol
+++ b/l1-contracts/test/harnesses/TestConstants.sol
@@ -21,6 +21,8 @@ library TestConstants {
   uint256 internal constant AZTEC_SLASHING_QUORUM = 6;
   uint256 internal constant AZTEC_SLASHING_ROUND_SIZE = 10;
   uint256 internal constant AZTEC_MANA_TARGET = 100000000;
+  uint256 internal constant AZTEC_ENTRY_QUEUE_FLUSH_SIZE_MIN = 4;
+  uint256 internal constant AZTEC_ENTRY_QUEUE_FLUSH_SIZE_QUOTIENT = 2;
   EthValue internal constant AZTEC_PROVING_COST_PER_MANA = EthValue.wrap(100);
 
   // Genesis state
@@ -56,6 +58,8 @@ library TestConstants {
       slashingQuorum: AZTEC_SLASHING_QUORUM,
       slashingRoundSize: AZTEC_SLASHING_ROUND_SIZE,
       manaTarget: AZTEC_MANA_TARGET,
+      entryQueueFlushSizeMin: AZTEC_ENTRY_QUEUE_FLUSH_SIZE_MIN,
+      entryQueueFlushSizeQuotient: AZTEC_ENTRY_QUEUE_FLUSH_SIZE_QUOTIENT,
       provingCostPerMana: AZTEC_PROVING_COST_PER_MANA,
       rewardConfig: getRewardConfig()
     });

--- a/l1-contracts/test/staking/base.t.sol
+++ b/l1-contracts/test/staking/base.t.sol
@@ -4,6 +4,7 @@ pragma solidity >=0.8.27;
 import {TestBase} from "@test/base/Base.sol";
 import {Registry} from "@aztec/governance/Registry.sol";
 import {IStaking} from "@aztec/core/interfaces/IStaking.sol";
+import {RollupConfigInput} from "@aztec/core/interfaces/IRollup.sol";
 import {TestERC20} from "@aztec/mock/TestERC20.sol";
 import {RollupBuilder} from "../builder/RollupBuilder.sol";
 
@@ -19,6 +20,8 @@ contract StakingBase is TestBase {
   uint256 internal DEPOSIT_AMOUNT;
   uint256 internal MINIMUM_STAKE;
 
+  uint256 internal EPOCH_DURATION_SECONDS;
+
   address internal SLASHER;
 
   function setUp() public virtual {
@@ -28,12 +31,15 @@ contract StakingBase is TestBase {
 
     registry = builder.getConfig().registry;
 
+    RollupConfigInput memory rollupConfig = builder.getConfig().rollupConfigInput;
+
+    EPOCH_DURATION_SECONDS = rollupConfig.aztecEpochDuration * rollupConfig.aztecSlotDuration;
+
     staking = IStaking(address(builder.getConfig().rollup));
     stakingAsset = builder.getConfig().testERC20;
 
     DEPOSIT_AMOUNT = staking.getDepositAmount();
     MINIMUM_STAKE = staking.getMinimumStake();
-
     SLASHER = staking.getSlasher();
   }
 }

--- a/l1-contracts/test/staking/deposit.t.sol
+++ b/l1-contracts/test/staking/deposit.t.sol
@@ -1,13 +1,21 @@
 // SPDX-License-Identifier: UNLICENSED
+// solhint-disable func-name-mixedcase
+// solhint-disable imports-order
+// solhint-disable comprehensive-interface
+// solhint-disable ordering
+
 pragma solidity >=0.8.27;
 
 import {StakingBase} from "./base.t.sol";
 import {Errors} from "@aztec/core/libraries/Errors.sol";
 import {IERC20Errors} from "@oz/interfaces/draft-IERC6093.sol";
-import {IStakingCore, Status, AttesterView} from "@aztec/core/interfaces/IStaking.sol";
-import {IGSE, IGSECore} from "@aztec/core/staking/GSE.sol";
+import {Status, IStakingCore, AttesterView, IStaking} from "@aztec/core/interfaces/IStaking.sol";
+import {Epoch} from "@aztec/core/libraries/TimeMath.sol";
+import {stdStorage, StdStorage} from "forge-std/Test.sol";
 
 contract DepositTest is StakingBase {
+  using stdStorage for StdStorage;
+
   function test_GivenCallerHasInsufficientAllowance() external {
     // it reverts
 
@@ -50,16 +58,25 @@ contract DepositTest is StakingBase {
     // it reverts
 
     staking.deposit({_attester: ATTESTER, _withdrawer: WITHDRAWER, _onCanonical: true});
+    staking.flushEntryQueue();
 
     stakingAsset.mint(address(this), DEPOSIT_AMOUNT);
     stakingAsset.approve(address(staking), type(uint256).max);
 
-    address magicAddress = address(staking.getGSE().CANONICAL_MAGIC_ADDRESS());
-
-    vm.expectRevert(
-      abi.encodeWithSelector(Errors.Staking__AlreadyRegistered.selector, magicAddress, ATTESTER)
-    );
+    // Now reset the next flushable epoch to 0
+    stdstore.enable_packed_slots().target(address(staking)).sig(
+      IStaking.getNextFlushableEpoch.selector
+    ).depth(0).checked_write(uint256(0));
     staking.deposit({_attester: ATTESTER, _withdrawer: WITHDRAWER, _onCanonical: true});
+
+    // The real error gets caught by the flushEntryQueue call
+    // address magicAddress = address(staking.getGSE().CANONICAL_MAGIC_ADDRESS());
+    // vm.expectRevert(
+    //   abi.encodeWithSelector(Errors.Staking__AlreadyRegistered.selector, magicAddress, ATTESTER)
+    // );
+    vm.expectEmit(true, true, true, true, address(staking));
+    emit IStakingCore.FailedDeposit(ATTESTER, WITHDRAWER);
+    staking.flushEntryQueue();
 
     vm.prank(SLASHER);
     staking.slash(ATTESTER, DEPOSIT_AMOUNT - MINIMUM_STAKE + 1);
@@ -96,23 +113,22 @@ contract DepositTest is StakingBase {
     givenCallerHasSufficientFunds
     givenAttesterIsNotRegistered
   {
-    // it transfer funds from the caller
-    // it adds attester to the set
-    // it updates the operator info
-    // it emits a {Deposit} event
+    // it adds attester to the entry queue
+    // it emits a {ValidatorQueued} event
 
-    assertEq(stakingAsset.balanceOf(address(staking)), 0);
-
-    vm.expectEmit(true, true, true, true, address(staking.getGSE()));
-    emit IGSECore.Deposit(address(staking.getGSE().CANONICAL_MAGIC_ADDRESS()), ATTESTER, WITHDRAWER);
+    vm.expectEmit(true, true, true, true, address(staking));
+    emit IStakingCore.ValidatorQueued(ATTESTER, WITHDRAWER);
 
     staking.deposit({_attester: ATTESTER, _withdrawer: WITHDRAWER, _onCanonical: true});
-
-    assertEq(stakingAsset.balanceOf(address(staking.getGSE().getGovernance())), DEPOSIT_AMOUNT);
+    // the money is in the staking contract
+    assertEq(stakingAsset.balanceOf(address(staking)), DEPOSIT_AMOUNT);
+    // the money is not in the GSE
+    assertEq(stakingAsset.balanceOf(address(staking.getGSE())), 0);
+    // nor in governance
+    assertEq(stakingAsset.balanceOf(address(staking.getGSE().getGovernance())), 0);
 
     AttesterView memory attesterView = staking.getAttesterView(ATTESTER);
-    assertEq(attesterView.effectiveBalance, DEPOSIT_AMOUNT, "effective balance");
-    assertEq(attesterView.config.withdrawer, WITHDRAWER);
-    assertTrue(attesterView.status == Status.VALIDATING);
+    assertEq(attesterView.effectiveBalance, 0, "effective balance");
+    assertTrue(attesterView.status == Status.NONE);
   }
 }

--- a/l1-contracts/test/staking/deposit.tree
+++ b/l1-contracts/test/staking/deposit.tree
@@ -14,7 +14,6 @@ DepositTest
                 ├── given attester is already active
                 │   └── it reverts
                 └── given attester is not active
-                    ├── it transfer funds from the caller
-                    ├── it adds attester to the set
-                    ├── it updates the operator info
-                    └── it emits a {Deposit} event
+                    ├── it transfers funds from the caller
+                    ├── it adds attester to the entry queue
+                    └── it emits a {ValidatorQueued} event

--- a/l1-contracts/test/staking/finaliseWithdraw.t.sol
+++ b/l1-contracts/test/staking/finaliseWithdraw.t.sol
@@ -1,11 +1,10 @@
 // SPDX-License-Identifier: UNLICENSED
+// solhint-disable
 pragma solidity >=0.8.27;
 
-import {StakingBase} from "./base.t.sol";
+import {Timestamp, Status, AttesterView, IStakingCore} from "@aztec/core/interfaces/IStaking.sol";
 import {Errors} from "@aztec/core/libraries/Errors.sol";
-import {
-  Timestamp, Status, AttesterView, Exit, IStakingCore
-} from "@aztec/core/interfaces/IStaking.sol";
+import {StakingBase} from "./base.t.sol";
 
 contract FinaliseWithdrawTest is StakingBase {
   function test_GivenStatusIsNotExiting() external {
@@ -18,6 +17,7 @@ contract FinaliseWithdrawTest is StakingBase {
     stakingAsset.approve(address(staking), DEPOSIT_AMOUNT);
 
     staking.deposit({_attester: ATTESTER, _withdrawer: WITHDRAWER, _onCanonical: true});
+    staking.flushEntryQueue();
 
     vm.expectRevert(abi.encodeWithSelector(Errors.Staking__NotExiting.selector, ATTESTER));
     staking.finaliseWithdraw(ATTESTER);
@@ -36,6 +36,7 @@ contract FinaliseWithdrawTest is StakingBase {
     stakingAsset.approve(address(staking), DEPOSIT_AMOUNT);
 
     staking.deposit({_attester: ATTESTER, _withdrawer: WITHDRAWER, _onCanonical: true});
+    staking.flushEntryQueue();
 
     vm.prank(WITHDRAWER);
     staking.initiateWithdraw(ATTESTER, RECIPIENT);

--- a/l1-contracts/test/staking/flushEntryQueue.t.sol
+++ b/l1-contracts/test/staking/flushEntryQueue.t.sol
@@ -1,0 +1,152 @@
+// SPDX-License-Identifier: UNLICENSED
+// solhint-disable func-name-mixedcase
+// solhint-disable imports-order
+// solhint-disable comprehensive-interface
+// solhint-disable ordering
+
+pragma solidity >=0.8.27;
+
+import {StakingBase} from "./base.t.sol";
+import {Errors} from "@aztec/core/libraries/Errors.sol";
+import {Epoch, Timestamp} from "@aztec/core/libraries/TimeMath.sol";
+import {Status, AttesterView, IStakingCore} from "@aztec/core/interfaces/IStaking.sol";
+import {Math} from "@oz/utils/math/Math.sol";
+import {GSE, IGSECore} from "@aztec/core/staking/GSE.sol";
+
+contract FlushEntryQueueTest is StakingBase {
+  function test_GivenTheQueueHasAlreadyBeenFlushedThisEpoch() external {
+    // it reverts
+
+    // the first one should be okay
+    staking.flushEntryQueue();
+
+    vm.expectRevert(
+      abi.encodeWithSelector(
+        Errors.Staking__QueueAlreadyFlushed.selector,
+        Epoch.wrap(block.timestamp / EPOCH_DURATION_SECONDS)
+      )
+    );
+    staking.flushEntryQueue();
+  }
+
+  function test_GivenTheQueueHasNotBeenFlushedThisEpoch(uint256 _numValidators) external {
+    // it dequeues up to the configured flush size
+    // it calls deposit for each dequeued validator
+    // it emits a {Deposit} event for each successful deposit
+    // it emits a {FailedDeposit} event for each failed deposit
+    // it refunds the withdrawer if the deposit fails
+    GSE gse = staking.getGSE();
+
+    uint256 flushSize = staking.getEntryQueueFlushSize();
+
+    _numValidators = bound(_numValidators, 0, 2 * flushSize);
+
+    for (uint256 i = 1; i <= _numValidators; i++) {
+      bool onCanonical = i % 2 == 0;
+      _help_deposit(address(uint160(i * 2)), address(uint160(i * 2 + 1)), onCanonical);
+    }
+
+    assertEq(staking.getActiveAttesterCount(), 0, "depositors should not be active");
+    assertEq(
+      stakingAsset.balanceOf(address(staking)), _numValidators * DEPOSIT_AMOUNT, "invalid balance"
+    );
+
+    uint256 numDequeued = Math.min(flushSize, _numValidators);
+    uint256 numStillInQueue = _numValidators - numDequeued;
+    uint256 onCanonicalCount = 0;
+    uint256 depositCount = 0;
+    for (uint256 i = 1; i <= numDequeued; i++) {
+      address attester = address(uint160(i * 2));
+      address withdrawer = address(uint160(i * 2 + 1));
+      bool onCanonical = i % 2 == 0;
+      if (i == 1) {
+        // mock that the first depositor fails
+        vm.mockCallRevert(
+          address(gse),
+          abi.encodeWithSelector(IGSECore.deposit.selector, attester, withdrawer, false),
+          bytes(string("something bad happened"))
+        );
+        vm.expectEmit(true, true, true, true);
+        emit IStakingCore.FailedDeposit(attester, withdrawer);
+      } else {
+        if (onCanonical) {
+          onCanonicalCount++;
+        }
+        depositCount++;
+        vm.expectEmit(true, true, true, true);
+        emit IStakingCore.Deposit(attester, withdrawer, DEPOSIT_AMOUNT);
+      }
+    }
+
+    staking.flushEntryQueue();
+
+    assertEq(stakingAsset.allowance(address(staking), address(gse)), 0, "invalid allowance");
+
+    assertEq(staking.getActiveAttesterCount(), depositCount, "invalid active attester count");
+
+    assertEq(
+      stakingAsset.balanceOf(address(staking)),
+      numStillInQueue * DEPOSIT_AMOUNT,
+      "rollup should still have some balance"
+    );
+
+    assertEq(
+      stakingAsset.balanceOf(address(staking.getGSE().getGovernance())),
+      depositCount * DEPOSIT_AMOUNT,
+      "governance should have received the deposits from successful deposits"
+    );
+
+    if (numDequeued > 1) {
+      assertEq(
+        stakingAsset.balanceOf(address(uint160(1 * 2 + 1))),
+        DEPOSIT_AMOUNT,
+        "withdrawer should have received the deposit"
+      );
+    }
+
+    for (uint256 i = 1; i <= numDequeued; i++) {
+      address attester = address(uint160(i * 2));
+      address withdrawer = address(uint160(i * 2 + 1));
+      AttesterView memory attesterView = staking.getAttesterView(attester);
+      if (i == 1) {
+        assertEq(attesterView.effectiveBalance, 0, "invalid effective balance");
+        assertTrue(attesterView.status == Status.NONE, "invalid status");
+      } else {
+        attesterView = staking.getAttesterView(attester);
+        assertEq(attesterView.effectiveBalance, DEPOSIT_AMOUNT, "invalid effective balance");
+        assertEq(attesterView.config.withdrawer, withdrawer, "invalid withdrawer");
+        assertTrue(attesterView.status == Status.VALIDATING, "invalid status");
+      }
+    }
+
+    // Check the canonical set has the proper validators
+    address canonicalMagicAddress = gse.CANONICAL_MAGIC_ADDRESS();
+    address[] memory attestersOnCanonical =
+      gse.getAttestersAtTime(canonicalMagicAddress, Timestamp.wrap(block.timestamp));
+    assertEq(
+      attestersOnCanonical.length, onCanonicalCount, "invalid number of attesters on canonical"
+    );
+    for (uint256 i = 0; i < attestersOnCanonical.length; i++) {
+      assertEq(attestersOnCanonical[i], address(uint160((i + 1) * 4)), "invalid attester");
+    }
+
+    // Check the instance set has the proper validators
+    address[] memory attestersOnInstance =
+      gse.getAttestersAtTime(address(staking), Timestamp.wrap(block.timestamp));
+    assertEq(attestersOnInstance.length, depositCount, "invalid number of attesters on instance");
+    for (uint256 i = 0; i < attestersOnInstance.length - onCanonicalCount; i++) {
+      // + 6 because the first validator is not on the instance
+      assertEq(attestersOnInstance[i], address(uint160(i * 4 + 6)), "invalid attester");
+    }
+  }
+
+  function _help_deposit(address _attester, address _withdrawer, bool _onCanonical) internal {
+    stakingAsset.mint(address(this), DEPOSIT_AMOUNT);
+    stakingAsset.approve(address(staking), DEPOSIT_AMOUNT);
+    uint256 balance = stakingAsset.balanceOf(address(staking));
+
+    staking.deposit({_attester: _attester, _withdrawer: _withdrawer, _onCanonical: _onCanonical});
+
+    assertEq(stakingAsset.balanceOf(address(staking)), balance + DEPOSIT_AMOUNT, "invalid balance");
+  }
+}

--- a/l1-contracts/test/staking/flushEntryQueue.tree
+++ b/l1-contracts/test/staking/flushEntryQueue.tree
@@ -1,0 +1,9 @@
+FlushEntryQueueTest
+├── given the queue has already been flushed this epoch
+│   └── it reverts
+└── given the queue has not been flushed this epoch
+    ├── it dequeues up to the configured flush size
+    ├── it calls deposit for each dequeued validator
+    ├── it emits a {Deposit} event for each successful deposit
+    ├── it emits a {FailedDeposit} event for each failed deposit
+    └── it refunds the withdrawer if the deposit fails

--- a/l1-contracts/test/staking/getters.t.sol
+++ b/l1-contracts/test/staking/getters.t.sol
@@ -10,6 +10,7 @@ contract GettersTest is StakingBase {
     stakingAsset.mint(address(this), DEPOSIT_AMOUNT);
     stakingAsset.approve(address(staking), DEPOSIT_AMOUNT);
     staking.deposit({_attester: ATTESTER, _withdrawer: WITHDRAWER, _onCanonical: true});
+    staking.flushEntryQueue();
   }
 
   function test_getAttesterAtIndex() external view {

--- a/l1-contracts/test/staking/initiateWithdraw.t.sol
+++ b/l1-contracts/test/staking/initiateWithdraw.t.sol
@@ -19,6 +19,7 @@ contract InitiateWithdrawTest is StakingBase {
     stakingAsset.mint(address(this), DEPOSIT_AMOUNT);
     stakingAsset.approve(address(staking), DEPOSIT_AMOUNT);
     staking.deposit({_attester: ATTESTER, _withdrawer: WITHDRAWER, _onCanonical: true});
+    staking.flushEntryQueue();
     _;
   }
 

--- a/l1-contracts/test/staking/slash.t.sol
+++ b/l1-contracts/test/staking/slash.t.sol
@@ -39,6 +39,7 @@ contract SlashTest is StakingBase {
     stakingAsset.approve(address(staking), DEPOSIT_AMOUNT);
 
     staking.deposit({_attester: ATTESTER, _withdrawer: WITHDRAWER, _onCanonical: true});
+    staking.flushEntryQueue();
     _;
   }
 

--- a/l1-contracts/test/staking_asset_handler/addValidator.t.sol
+++ b/l1-contracts/test/staking_asset_handler/addValidator.t.sol
@@ -35,6 +35,7 @@ contract addValidatorToQueueTest is StakingAssetHandlerBase {
     if (_isExiting) {
       vm.prank(unhinged);
       stakingAssetHandler.addValidatorToQueue(_attester, fakeProof);
+      staking.flushEntryQueue();
 
       vm.prank(WITHDRAWER);
       staking.initiateWithdraw(_attester, address(this));
@@ -45,6 +46,7 @@ contract addValidatorToQueueTest is StakingAssetHandlerBase {
 
     vm.prank(unhinged);
     stakingAssetHandler.addValidatorToQueue(_attester, fakeProof);
+    staking.flushEntryQueue();
 
     AttesterView memory attesterView = staking.getAttesterView(_attester);
     assertEq(attesterView.config.withdrawer, WITHDRAWER);
@@ -84,6 +86,7 @@ contract addValidatorToQueueTest is StakingAssetHandlerBase {
     );
     vm.prank(_caller);
     stakingAssetHandler.dripQueue();
+    staking.flushEntryQueue();
   }
 
   function test_WhenSufficientTimePassed(address _caller, address _attester)
@@ -115,6 +118,7 @@ contract addValidatorToQueueTest is StakingAssetHandlerBase {
     emit IStakingAssetHandler.ValidatorAdded(address(staking), _attester, WITHDRAWER);
     vm.prank(_caller);
     stakingAssetHandler.dripQueue();
+    staking.flushEntryQueue();
 
     AttesterView memory attesterView = staking.getAttesterView(_attester);
     assertEq(attesterView.config.withdrawer, WITHDRAWER);
@@ -167,6 +171,7 @@ contract addValidatorToQueueTest is StakingAssetHandlerBase {
     emit IStakingAssetHandler.ValidatorAdded(address(staking), _attester, WITHDRAWER);
     vm.prank(_caller);
     stakingAssetHandler.dripQueue();
+    staking.flushEntryQueue();
 
     AttesterView memory attesterView = staking.getAttesterView(_attester);
     assertEq(attesterView.config.withdrawer, WITHDRAWER);
@@ -188,7 +193,7 @@ contract addValidatorToQueueTest is StakingAssetHandlerBase {
         && _caller != unhinged
     );
 
-    uint256 revertTimestamp = stakingAssetHandler.lastMintTimestamp() + mintInterval;
+    uint256 revertTimestamp = block.timestamp + mintInterval;
     vm.warp(revertTimestamp);
 
     vm.expectEmit(true, true, true, true, address(stakingAssetHandler));
@@ -220,7 +225,7 @@ contract addValidatorToQueueTest is StakingAssetHandlerBase {
       _attester != address(0) && _caller != address(this) && _attester != address(this)
         && _attester != unhinged
     );
-    uint256 revertTimestamp = stakingAssetHandler.lastMintTimestamp() + mintInterval;
+    uint256 revertTimestamp = block.timestamp + mintInterval;
     vm.warp(revertTimestamp);
 
     vm.expectRevert(abi.encodeWithSelector(IStakingAssetHandler.InvalidProof.selector));
@@ -270,7 +275,7 @@ contract addValidatorToQueueTest is StakingAssetHandlerBase {
     );
     vm.assume(_caller != address(this) && _caller != unhinged);
 
-    uint256 revertTimestamp = stakingAssetHandler.lastMintTimestamp() + mintInterval + mintInterval;
+    uint256 revertTimestamp = block.timestamp + mintInterval + mintInterval;
     vm.warp(revertTimestamp);
 
     // Allow more than one deposit per mint
@@ -314,6 +319,8 @@ contract addValidatorToQueueTest is StakingAssetHandlerBase {
     );
     vm.prank(_caller);
     stakingAssetHandler.dripQueue();
+
+    staking.flushEntryQueue();
 
     AttesterView memory attesterView = staking.getAttesterView(_attester);
     assertEq(attesterView.config.withdrawer, WITHDRAWER);

--- a/l1-contracts/test/staking_asset_handler/reenterExitedValidator.t.sol
+++ b/l1-contracts/test/staking_asset_handler/reenterExitedValidator.t.sol
@@ -43,6 +43,7 @@ contract ReenterExitedValidatorTest is StakingAssetHandlerBase {
 
     emit IStakingAssetHandler.AddedToQueue(_attester, 0);
     stakingAssetHandler.dripQueue();
+    staking.flushEntryQueue();
 
     // 2. Exit the validator
     vm.prank(WITHDRAWER);

--- a/l1-contracts/test/staking_asset_handler/setWithdrawer.t.sol
+++ b/l1-contracts/test/staking_asset_handler/setWithdrawer.t.sol
@@ -50,6 +50,7 @@ contract SetWithdrawerTest is StakingAssetHandlerBase {
     vm.expectEmit(true, true, true, true, address(stakingAssetHandler));
     emit IStakingAssetHandler.ValidatorAdded(rollup, attester, _newWithdrawer);
     stakingAssetHandler.addValidatorToQueue(attester, realProof);
+    staking.flushEntryQueue();
     assertEq(staking.getAttesterView(attester).config.withdrawer, _newWithdrawer);
   }
 }

--- a/l1-contracts/test/validator-selection/ValidatorSelection.t.sol
+++ b/l1-contracts/test/validator-selection/ValidatorSelection.t.sol
@@ -146,6 +146,7 @@ contract ValidatorSelectionTest is ValidatorSelectionTestBase {
     testERC20.mint(address(this), rollup.getDepositAmount());
     testERC20.approve(address(rollup), rollup.getDepositAmount());
     rollup.deposit(address(0xdead), address(0xdead), true);
+    rollup.flushEntryQueue();
 
     assertEq(rollup.getCurrentEpoch(), epoch);
     address[] memory committee = rollup.getCurrentEpochCommittee();

--- a/l1-contracts/test/validator-selection/ValidatorSelectionBase.sol
+++ b/l1-contracts/test/validator-selection/ValidatorSelectionBase.sol
@@ -26,6 +26,7 @@ import {RollupBuilder} from "../builder/RollupBuilder.sol";
 import {Slot} from "@aztec/core/libraries/TimeLib.sol";
 
 import {TimeCheater} from "../staking/TimeCheater.sol";
+import {stdStorage, StdStorage} from "forge-std/Test.sol";
 // solhint-disable comprehensive-interface
 
 /**
@@ -35,6 +36,7 @@ import {TimeCheater} from "../staking/TimeCheater.sol";
 contract ValidatorSelectionTestBase is DecoderBase {
   using MessageHashUtils for bytes32;
   using EpochLib for Epoch;
+  using stdStorage for StdStorage;
 
   struct StructToAvoidDeepStacks {
     uint256 needed;
@@ -85,7 +87,8 @@ contract ValidatorSelectionTestBase is DecoderBase {
       initialValidators[i - 1] = createDepositArgs(i);
     }
 
-    RollupBuilder builder = new RollupBuilder(address(this));
+    RollupBuilder builder =
+      new RollupBuilder(address(this)).setEntryQueueFlushSizeMin(_validatorCount);
     builder.deploy();
 
     rollup = builder.getConfig().rollup;

--- a/l1-contracts/test/validator-selection/setupEpoch.t.sol
+++ b/l1-contracts/test/validator-selection/setupEpoch.t.sol
@@ -8,9 +8,12 @@ import {Checkpoints} from "@oz/utils/structs/Checkpoints.sol";
 import {IValidatorSelection} from "@aztec/core/interfaces/IValidatorSelection.sol";
 import {TestConstants} from "../harnesses/TestConstants.sol";
 import {MultiAdder} from "@aztec/mock/MultiAdder.sol";
+import {IStaking} from "@aztec/core/interfaces/IStaking.sol";
+import {stdStorage, StdStorage} from "forge-std/Test.sol";
 
 contract SetupEpochTest is ValidatorSelectionTestBase {
   using Checkpoints for Checkpoints.Trace224;
+  using stdStorage for StdStorage;
 
   modifier whenTheRollupIsInGenesisState() {
     // Enforced with setup(0) modifier
@@ -105,6 +108,12 @@ contract SetupEpochTest is ValidatorSelectionTestBase {
       "Committee should have the same length"
     );
     assertEq(committeeAfterRepeatedSetup, initialCommittee, "Committee should be the same");
+
+    // Overwrite the flushable epoch to 0 to force our ability to add more validators this epoch
+    // Now reset the next flushable epoch to 0
+    stdstore.enable_packed_slots().target(address(rollup)).sig(
+      IStaking.getNextFlushableEpoch.selector
+    ).depth(0).checked_write(uint256(0));
 
     // Add a couple of extra validators during this epoch, the sampled validator set should not change
     addNumberOfValidators(420420, 2);

--- a/yarn-project/cli/src/cmds/infrastructure/sequencers.ts
+++ b/yarn-project/cli/src/cmds/infrastructure/sequencers.ts
@@ -7,7 +7,7 @@ import { createPublicClient, createWalletClient, fallback, getContract, http } f
 import { mnemonicToAccount } from 'viem/accounts';
 
 export async function sequencers(opts: {
-  command: 'list' | 'add' | 'remove' | 'who-next';
+  command: 'list' | 'add' | 'remove' | 'who-next' | 'flush';
   who?: string;
   mnemonic?: string;
   rpcUrl: string;
@@ -82,6 +82,14 @@ export async function sequencers(opts: {
     const hash = await writeableRollup.write.deposit([who, who, true]);
     await publicClient.waitForTransactionReceipt({ hash });
     log(`Added in tx ${hash}`);
+  } else if (command === 'flush') {
+    if (!writeableRollup) {
+      throw new Error(`Missing sequencer address`);
+    }
+    log(`Flushing staking entry queue`);
+    const hash = await writeableRollup.write.flushEntryQueue();
+    await publicClient.waitForTransactionReceipt({ hash });
+    log(`Flushed staking entry queue in tx ${hash}`);
   } else if (command === 'remove') {
     if (!who || !writeableRollup) {
       throw new Error(`Missing sequencer address`);

--- a/yarn-project/end-to-end/src/e2e_p2p/gossip_network_no_cheat.test.ts
+++ b/yarn-project/end-to-end/src/e2e_p2p/gossip_network_no_cheat.test.ts
@@ -146,6 +146,10 @@ describe('e2e_p2p_network', () => {
       debugLogger: t.logger,
     });
 
+    await t.ctx.deployL1ContractsValues.l1Client.waitForTransactionReceipt({
+      hash: await rollup.write.flushEntryQueue(),
+    });
+
     const attestersImmedatelyAfterAdding = await rollup.read.getAttesters();
     expect(attestersImmedatelyAfterAdding.length).toBe(validators.length);
 

--- a/yarn-project/ethereum/src/config.ts
+++ b/yarn-project/ethereum/src/config.ts
@@ -72,6 +72,12 @@ export const DefaultRewardConfig = {
   minimum: 100000,
 };
 
+// Similar to the above, no need for environment variables for this.
+export const DefaultEntryQueueConfig = {
+  flushSizeMin: 48,
+  flushSizeQuotient: 2,
+};
+
 export const l1ContractsConfigMappings: ConfigMappingsType<L1ContractsConfig> = {
   ethereumSlotDuration: {
     env: 'ETHEREUM_SLOT_DURATION',

--- a/yarn-project/ethereum/src/deploy_l1_contracts.ts
+++ b/yarn-project/ethereum/src/deploy_l1_contracts.ts
@@ -68,7 +68,7 @@ import { foundry } from 'viem/chains';
 
 import { isAnvilTestChain } from './chain.js';
 import { createExtendedL1Client } from './client.js';
-import { DefaultRewardConfig, type L1ContractsConfig } from './config.js';
+import { DefaultEntryQueueConfig, DefaultRewardConfig, type L1ContractsConfig } from './config.js';
 import { RegistryContract } from './contracts/registry.js';
 import { RollupContract } from './contracts/rollup.js';
 import type { L1ContractAddresses } from './l1_contract_addresses.js';
@@ -224,6 +224,9 @@ export const l1Artifacts = {
     contractAbi: HonkVerifierAbi,
     contractBytecode: HonkVerifierBytecode as Hex,
   },
+};
+
+const mockVerifiers = {
   mockVerifier: {
     contractAbi: MockVerifierAbi,
     contractBytecode: MockVerifierBytecode as Hex,
@@ -519,7 +522,7 @@ export const deploySharedContracts = async (
 
 const getZkPassportVerifierAddress = async (deployer: L1Deployer, args: DeployL1ContractsArgs): Promise<EthAddress> => {
   if (args.zkPassportArgs?.mockZkPassportVerifier) {
-    return await deployer.deploy(l1Artifacts.mockZkPassportVerifier);
+    return await deployer.deploy(mockVerifiers.mockZkPassportVerifier);
   }
   return ZK_PASSPORT_VERIFIER_ADDRESS;
 };
@@ -610,7 +613,7 @@ export const deployRollup = async (
     epochProofVerifier = await deployer.deploy(l1Artifacts.honkVerifier);
     logger.verbose(`Rollup will use the real verifier at ${epochProofVerifier}`);
   } else {
-    epochProofVerifier = await deployer.deploy(l1Artifacts.mockVerifier);
+    epochProofVerifier = await deployer.deploy(mockVerifiers.mockVerifier);
     logger.verbose(`Rollup will use the mock verifier at ${epochProofVerifier}`);
   }
 
@@ -622,6 +625,8 @@ export const deployRollup = async (
     slashingQuorum: args.slashingQuorum,
     slashingRoundSize: args.slashingRoundSize,
     manaTarget: args.manaTarget,
+    entryQueueFlushSizeMin: DefaultEntryQueueConfig.flushSizeMin,
+    entryQueueFlushSizeQuotient: DefaultEntryQueueConfig.flushSizeQuotient,
     provingCostPerMana: args.provingCostPerMana,
     rewardConfig: DefaultRewardConfig,
   };


### PR DESCRIPTION
# Add Staking Entry Queue

This PR introduces a staking entry queue to manage validator onboarding in a controlled manner. Instead of immediately adding validators when they deposit, they are first placed in a queue and then processed in batches during a flush operation.

Key changes:
- Add `StakingQueue` data structure to manage validator entries
- Implement `flushEntryQueue` to process queued validators up to a configurable limit per epoch
- Add configuration parameters for controlling queue flush size:
  - `entryQueueFlushSizeMin`: Minimum number of validators to process per flush
  - `entryQueueFlushSizeQuotient`: Controls the maximum number of validators to add relative to the current active set
- Move `getActiveAttesterCount` from `Rollup` to `RollupCore` for better accessibility
- Update CLI to support the new `flush` command for staking entry queue
