### PR TITLE
chore: fancier coverage command

### DIFF
--- a/build-images/src/Dockerfile
+++ b/build-images/src/Dockerfile
@@ -214,6 +214,7 @@ RUN apt update && \
         htop \
         iproute2 \
         iputils-ping \
+        lcov \
         less \
         libfuse2 \
         lldb \

--- a/l1-contracts/.gitignore
+++ b/l1-contracts/.gitignore
@@ -33,3 +33,5 @@ gas_benchmark.new.*
 gas_benchmark.diff
 
 /bench-out
+
+/coverage

--- a/l1-contracts/bootstrap.sh
+++ b/l1-contracts/bootstrap.sh
@@ -417,6 +417,7 @@ function coverage {
     if [ "$fancy" = "fancy" ]; then
       mkdir -p coverage
       genhtml lcov.info --branch-coverage --output-dir coverage
+      python3 -m http.server --directory "coverage"
     fi
   else
     forge coverage --no-match-coverage "(test|script|mock|generated)"

--- a/l1-contracts/bootstrap.sh
+++ b/l1-contracts/bootstrap.sh
@@ -408,6 +408,21 @@ function release_git_push {
   echo "Release complete ($tag_name) on branch $branch_name."
 }
 
+function coverage {
+  echo_header "l1-contracts coverage"
+  local report_type=${1:-}
+  local fancy=${2:-}
+  if [ "$report_type" = "lcov" ]; then
+    forge coverage --no-match-coverage "(test|script|mock|generated)" --report lcov
+    if [ "$fancy" = "fancy" ]; then
+      mkdir -p coverage
+      genhtml lcov.info --branch-coverage --output-dir coverage
+    fi
+  else
+    forge coverage --no-match-coverage "(test|script|mock|generated)"
+  fi
+}
+
 function release {
   echo_header "l1-contracts release"
   local branch=$(dist_tag)
@@ -436,6 +451,10 @@ case "$cmd" in
   "gas_benchmark")
     shift
     gas_benchmark "$@"
+    ;;
+  "coverage")
+    shift
+    coverage "$@"
     ;;
   test|test_cmds|bench|bench_cmds|inspect|release)
     $cmd


### PR DESCRIPTION
Added a coverage command to the bootstrap to make it simpler to not include the tests in the report, and to generate a html report separately if having genhtml.