### PR TITLE
feat: Add RPC methods to fetch membership witnesses by value

### DIFF
--- a/yarn-project/aztec-node/src/aztec-node/server.ts
+++ b/yarn-project/aztec-node/src/aztec-node/server.ts
@@ -2,7 +2,7 @@ import { Archiver, createArchiver } from '@aztec/archiver';
 import { BBCircuitVerifier, QueuedIVCVerifier, TestCircuitVerifier } from '@aztec/bb-prover';
 import { type BlobSinkClientInterface, createBlobSinkClient } from '@aztec/blob-sink/client';
 import {
-  type ARCHIVE_HEIGHT,
+  ARCHIVE_HEIGHT,
   INITIAL_L2_BLOCK_NUM,
   type L1_TO_L2_MSG_TREE_HEIGHT,
   type NOTE_HASH_TREE_HEIGHT,
@@ -27,7 +27,7 @@ import { type Logger, createLogger } from '@aztec/foundation/log';
 import { SerialQueue } from '@aztec/foundation/queue';
 import { count } from '@aztec/foundation/string';
 import { DateProvider, Timer } from '@aztec/foundation/timer';
-import { SiblingPath } from '@aztec/foundation/trees';
+import { MembershipWitness, SiblingPath } from '@aztec/foundation/trees';
 import { trySnapshotSync, uploadSnapshot } from '@aztec/node-lib/actions';
 import { type P2P, TxCollector, createP2PClient, getDefaultAllowedSetupFunctions } from '@aztec/p2p';
 import { ProtocolContractAddress } from '@aztec/protocol-contracts';
@@ -737,6 +737,33 @@ export class AztecNodeService implements AztecNode, AztecNodeAdmin, Traceable {
   ): Promise<SiblingPath<typeof NOTE_HASH_TREE_HEIGHT>> {
     const committedDb = await this.#getWorldState(blockNumber);
     return committedDb.getSiblingPath(MerkleTreeId.NOTE_HASH_TREE, leafIndex);
+  }
+
+  public async getArchiveMembershipWitness(
+    blockNumber: L2BlockNumber,
+    archive: Fr,
+  ): Promise<MembershipWitness<typeof ARCHIVE_HEIGHT> | undefined> {
+    const committedDb = await this.#getWorldState(blockNumber);
+    const [index] = await committedDb.findLeafIndices(MerkleTreeId.ARCHIVE, [archive]);
+    if (index === undefined) {
+      return undefined;
+    }
+    return MembershipWitness.fromSiblingPath(index, await committedDb.getSiblingPath(MerkleTreeId.ARCHIVE, index));
+  }
+
+  public async getNoteHashMembershipWitness(
+    blockNumber: L2BlockNumber,
+    noteHash: Fr,
+  ): Promise<MembershipWitness<typeof NOTE_HASH_TREE_HEIGHT> | undefined> {
+    const committedDb = await this.#getWorldState(blockNumber);
+    const [index] = await committedDb.findLeafIndices(MerkleTreeId.NOTE_HASH_TREE, [noteHash]);
+    if (index === undefined) {
+      return undefined;
+    }
+    return MembershipWitness.fromSiblingPath(
+      index,
+      await committedDb.getSiblingPath(MerkleTreeId.NOTE_HASH_TREE, index),
+    );
   }
 
   /**

--- a/yarn-project/foundation/src/trees/membership_witness.ts
+++ b/yarn-project/foundation/src/trees/membership_witness.ts
@@ -1,6 +1,7 @@
 import { assertMemberLength } from '../array/array.js';
 import { toBigIntBE, toBufferBE } from '../bigint-buffer/index.js';
 import { Fr } from '../fields/fields.js';
+import { schemas } from '../schemas/schemas.js';
 import { BufferReader, type Tuple, serializeToBuffer } from '../serialize/index.js';
 import type { SiblingPath } from './sibling_path.js';
 
@@ -27,6 +28,18 @@ export class MembershipWitness<N extends number> {
 
   toBuffer() {
     return serializeToBuffer(toBufferBE(this.leafIndex, 32), ...this.siblingPath);
+  }
+
+  toJSON() {
+    return this.toBuffer();
+  }
+
+  toFields(): Fr[] {
+    return [new Fr(this.leafIndex), ...this.siblingPath];
+  }
+
+  static schemaFor<N extends number>(size: N) {
+    return schemas.Buffer.transform(b => MembershipWitness.fromBuffer(b, size));
   }
 
   /**

--- a/yarn-project/pxe/src/contract_function_simulator/execution_data_provider.ts
+++ b/yarn-project/pxe/src/contract_function_simulator/execution_data_provider.ts
@@ -124,13 +124,6 @@ export interface ExecutionDataProvider {
   getNullifierIndex(nullifier: Fr): Promise<bigint | undefined>;
 
   /**
-   * Gets the index of a nullifier in the nullifier tree.
-   * @param nullifier - The nullifier.
-   * @returns - The index of the nullifier. Undefined if it does not exist in the tree.
-   */
-  getNullifierIndex(nullifier: Fr): Promise<bigint | undefined>;
-
-  /**
    * Returns a nullifier membership witness for the given nullifier or undefined if not found.
    * REFACTOR: Same as getL1ToL2MembershipWitness, can be combined with aztec-node method that does almost the same thing.
    * @param nullifier - Nullifier we're looking for.

--- a/yarn-project/pxe/src/contract_function_simulator/pxe_oracle_interface.ts
+++ b/yarn-project/pxe/src/contract_function_simulator/pxe_oracle_interface.ts
@@ -166,26 +166,23 @@ export class PXEOracleInterface implements ExecutionDataProvider {
   }
 
   public async getMembershipWitness(blockNumber: number, treeId: MerkleTreeId, leafValue: Fr): Promise<Fr[]> {
-    const leafIndex = await this.#findLeafIndex(blockNumber, treeId, leafValue);
-    if (!leafIndex) {
-      throw new Error(`Leaf value: ${leafValue} not found in ${MerkleTreeId[treeId]}`);
+    const witness = await this.#tryGetMembershipWitness(blockNumber, treeId, leafValue);
+    if (!witness) {
+      throw new Error(`Leaf value ${leafValue} not found in tree ${MerkleTreeId[treeId]} at block ${blockNumber}`);
     }
-
-    const siblingPath = await this.#getSiblingPath(blockNumber, treeId, leafIndex);
-
-    return [new Fr(leafIndex), ...siblingPath];
+    return witness;
   }
 
-  async #getSiblingPath(blockNumber: number, treeId: MerkleTreeId, leafIndex: bigint): Promise<Fr[]> {
+  async #tryGetMembershipWitness(blockNumber: number, treeId: MerkleTreeId, value: Fr): Promise<Fr[] | undefined> {
     switch (treeId) {
       case MerkleTreeId.NULLIFIER_TREE:
-        return (await this.aztecNode.getNullifierSiblingPath(blockNumber, leafIndex)).toFields();
+        return (await this.aztecNode.getNullifierMembershipWitness(blockNumber, value))?.withoutPreimage().toFields();
       case MerkleTreeId.NOTE_HASH_TREE:
-        return (await this.aztecNode.getNoteHashSiblingPath(blockNumber, leafIndex)).toFields();
+        return (await this.aztecNode.getNoteHashMembershipWitness(blockNumber, value))?.toFields();
       case MerkleTreeId.PUBLIC_DATA_TREE:
-        return (await this.aztecNode.getPublicDataSiblingPath(blockNumber, leafIndex)).toFields();
+        return (await this.aztecNode.getPublicDataWitness(blockNumber, value))?.withoutPreimage().toFields();
       case MerkleTreeId.ARCHIVE:
-        return (await this.aztecNode.getArchiveSiblingPath(blockNumber, leafIndex)).toFields();
+        return (await this.aztecNode.getArchiveMembershipWitness(blockNumber, value))?.toFields();
       default:
         throw new Error('Not implemented');
     }

--- a/yarn-project/stdlib/src/trees/nullifier_membership_witness.ts
+++ b/yarn-project/stdlib/src/trees/nullifier_membership_witness.ts
@@ -1,6 +1,6 @@
 import { NULLIFIER_TREE_HEIGHT } from '@aztec/constants';
 import { Fr } from '@aztec/foundation/fields';
-import { SiblingPath } from '@aztec/foundation/trees';
+import { MembershipWitness, SiblingPath } from '@aztec/foundation/trees';
 
 import { z } from 'zod';
 
@@ -47,6 +47,10 @@ export class NullifierMembershipWitness {
       NullifierLeafPreimage.random(),
       SiblingPath.random(NULLIFIER_TREE_HEIGHT),
     );
+  }
+
+  public withoutPreimage(): MembershipWitness<typeof NULLIFIER_TREE_HEIGHT> {
+    return new MembershipWitness(NULLIFIER_TREE_HEIGHT, this.index, this.siblingPath.toTuple());
   }
 
   /**

--- a/yarn-project/stdlib/src/trees/public_data_witness.ts
+++ b/yarn-project/stdlib/src/trees/public_data_witness.ts
@@ -3,7 +3,7 @@ import { toBigIntBE } from '@aztec/foundation/bigint-buffer';
 import { Fr } from '@aztec/foundation/fields';
 import { BufferReader, serializeToBuffer } from '@aztec/foundation/serialize';
 import { bufferToHex, hexToBuffer } from '@aztec/foundation/string';
-import { SiblingPath } from '@aztec/foundation/trees';
+import { MembershipWitness, SiblingPath } from '@aztec/foundation/trees';
 
 import { z } from 'zod';
 
@@ -90,6 +90,10 @@ export class PublicDataWitness {
       PublicDataTreeLeafPreimage.random(),
       SiblingPath.random(PUBLIC_DATA_TREE_HEIGHT),
     );
+  }
+
+  public withoutPreimage(): MembershipWitness<typeof PUBLIC_DATA_TREE_HEIGHT> {
+    return new MembershipWitness(PUBLIC_DATA_TREE_HEIGHT, this.index, this.siblingPath.toTuple());
   }
 
   /**


### PR DESCRIPTION
Prevents PXE from doing two roundtrips: one for fetching indices, one for fetching sibling paths.

Note that this does not use the world state native query introduced in https://github.com/AztecProtocol/aztec-packages/pull/14578 since that query returns the sibling path without the index, and we need both. For now, we add the RPC methods to save one roundtrip from PXE to node, but still have two roundtrips from node ts to node native. I've created https://github.com/AztecProtocol/aztec-packages/issues/14991 to track that improvement.

Fixes #14302
