### PR TITLE
chore: compute sorted steps in translator only once

### DIFF
--- a/barretenberg/cpp/src/barretenberg/translator_vm/translator_prover.hpp
+++ b/barretenberg/cpp/src/barretenberg/translator_vm/translator_prover.hpp
@@ -27,9 +27,6 @@ class TranslatorProver {
     using PCS = typename Flavor::PCS;
     using Transcript = typename Flavor::Transcript;
     using ZKData = ZKSumcheckData<Flavor>;
-    size_t total_num_gates = 0;          // num_gates (already include zero row offset) (used to compute dyadic size)
-    size_t dyadic_circuit_size = 0;      // final power-of-2 circuit size
-    size_t mini_circuit_dyadic_size = 0; // The size of the small circuit that contains non-range constraint relations
 
     explicit TranslatorProver(const std::shared_ptr<TranslatorProvingKey>& key,
                               const std::shared_ptr<Transcript>& transcript);

--- a/barretenberg/cpp/src/barretenberg/translator_vm/translator_proving_key.cpp
+++ b/barretenberg/cpp/src/barretenberg/translator_vm/translator_proving_key.cpp
@@ -88,7 +88,7 @@ void TranslatorProvingKey::compute_translator_range_constraint_ordered_polynomia
                                              proving_key->polynomials.ordered_range_constraints_3 };
     std::vector<size_t> extra_denominator_uint(dyadic_circuit_size_without_masking);
 
-    auto sorted_elements = get_sorted_steps();
+    const auto sorted_elements = get_sorted_steps();
     auto to_be_interleaved_groups = proving_key->polynomials.get_groups_to_be_interleaved();
 
     // Given the polynomials in group_i, transfer their elements, sorted in non-descending order, into the corresponding
@@ -214,7 +214,7 @@ void TranslatorProvingKey::compute_lagrange_polynomials()
 void TranslatorProvingKey::compute_extra_range_constraint_numerator()
 {
 
-    auto sorted_elements = get_sorted_steps();
+    const auto sorted_elements = get_sorted_steps();
     // TODO(#756): can be parallelized further. This will use at most 5 threads
     auto fill_with_shift = [&](size_t shift) {
         for (size_t i = 0; i < sorted_elements.size(); i++) {

--- a/barretenberg/cpp/src/barretenberg/translator_vm/translator_proving_key.hpp
+++ b/barretenberg/cpp/src/barretenberg/translator_vm/translator_proving_key.hpp
@@ -117,16 +117,19 @@ class TranslatorProvingKey {
      * range (e.g. p_1(x) = {0, 2^14 - 1, 2^14 - 1, 2^14 - 1}), to ensure the relation is still satisfied, we
      * concatenate the set of coefficients to a set of steps that span across the desired range.
      */
-    static const std::array<size_t, Flavor::SORTED_STEPS_COUNT>& get_sorted_steps()
+    static std::array<size_t, Flavor::SORTED_STEPS_COUNT> get_sorted_steps()
     {
         static const std::array<size_t, Flavor::SORTED_STEPS_COUNT> sorted_elements = [] {
             std::array<size_t, Flavor::SORTED_STEPS_COUNT> inner_array{};
 
+            // The value we have to end polynomials with, 2¹⁴ - 1
             const size_t max_value = (1 << Flavor::MICRO_LIMB_BITS) - 1;
-            const size_t min_iterations_per_thread = 1 << 6;
 
+            // min number of iterations for which we'll spin up a unique thread
+            const size_t min_iterations_per_thread = 1 << 6;
             const size_t num_threads =
                 bb::calculate_num_threads_pow2(Flavor::SORTED_STEPS_COUNT, min_iterations_per_thread);
+            // actual iterations per thread
             const size_t iterations_per_thread = Flavor::SORTED_STEPS_COUNT / num_threads;
             const size_t leftovers = Flavor::SORTED_STEPS_COUNT % num_threads;
 
@@ -134,7 +137,6 @@ class TranslatorProvingKey {
                 const size_t start = thread_idx * iterations_per_thread;
                 const size_t end =
                     (thread_idx + 1) * iterations_per_thread + (thread_idx == num_threads - 1 ? leftovers : 0);
-
                 for (size_t idx = start; idx < end; ++idx) {
                     inner_array[idx] = max_value - Flavor::SORT_STEP * idx;
                 }

--- a/barretenberg/cpp/src/barretenberg/translator_vm/translator_proving_key.hpp
+++ b/barretenberg/cpp/src/barretenberg/translator_vm/translator_proving_key.hpp
@@ -117,23 +117,32 @@ class TranslatorProvingKey {
      * range (e.g. p_1(x) = {0, 2^14 - 1, 2^14 - 1, 2^14 - 1}), to ensure the relation is still satisfied, we
      * concatenate the set of coefficients to a set of steps that span across the desired range.
      */
-    static std::array<size_t, Flavor::SORTED_STEPS_COUNT> get_sorted_steps()
+    static const std::array<size_t, Flavor::SORTED_STEPS_COUNT>& get_sorted_steps()
     {
-        std::array<size_t, Flavor::SORTED_STEPS_COUNT> sorted_elements;
-        // The value we have to end polynomials with, 2¹⁴ - 1
-        const size_t max_value = (1 << Flavor::MICRO_LIMB_BITS) - 1;
+        static const std::array<size_t, Flavor::SORTED_STEPS_COUNT> sorted_elements = [] {
+            std::array<size_t, Flavor::SORTED_STEPS_COUNT> inner_array{};
 
-        size_t min_iterations_per_thread = 1 << 6; // min number of iterations for which we'll spin up a unique thread
-        size_t num_threads = bb::calculate_num_threads_pow2(Flavor::SORTED_STEPS_COUNT, min_iterations_per_thread);
-        size_t iterations_per_thread = Flavor::SORTED_STEPS_COUNT / num_threads; // actual iterations per thread
-        size_t leftovers = Flavor::SORTED_STEPS_COUNT % num_threads;
-        parallel_for(num_threads, [&](size_t thread_idx) {
-            size_t start = thread_idx * iterations_per_thread;
-            size_t end = (thread_idx + 1) * iterations_per_thread + (thread_idx == num_threads - 1 ? leftovers : 0);
-            for (size_t idx = start; idx < end; idx++) {
-                sorted_elements[idx] = max_value - Flavor::SORT_STEP * idx;
-            }
-        });
+            const size_t max_value = (1 << Flavor::MICRO_LIMB_BITS) - 1;
+            const size_t min_iterations_per_thread = 1 << 6;
+
+            const size_t num_threads =
+                bb::calculate_num_threads_pow2(Flavor::SORTED_STEPS_COUNT, min_iterations_per_thread);
+            const size_t iterations_per_thread = Flavor::SORTED_STEPS_COUNT / num_threads;
+            const size_t leftovers = Flavor::SORTED_STEPS_COUNT % num_threads;
+
+            parallel_for(num_threads, [&](size_t thread_idx) {
+                const size_t start = thread_idx * iterations_per_thread;
+                const size_t end =
+                    (thread_idx + 1) * iterations_per_thread + (thread_idx == num_threads - 1 ? leftovers : 0);
+
+                for (size_t idx = start; idx < end; ++idx) {
+                    inner_array[idx] = max_value - Flavor::SORT_STEP * idx;
+                }
+            });
+
+            return inner_array;
+        }();
+
         return sorted_elements;
     }
 


### PR DESCRIPTION
`get_sorted_steps` produces an array of constant values that is used in various places in translator, but it makes sense for it to  be computed only once.
