### PR TITLE
fix(bb.js): don't set maximum wasm memory >1GB on ios web, limit SRS

### DIFF
--- a/barretenberg/ts/src/barretenberg_wasm/barretenberg_wasm_main/index.ts
+++ b/barretenberg/ts/src/barretenberg_wasm/barretenberg_wasm_main/index.ts
@@ -65,6 +65,7 @@ export class BarretenbergWasmMain extends BarretenbergWasmBase {
 
   private getDefaultMaximum(): number {
     // iOS browser is very aggressive with memory. Check if running in browser and on iOS
+    // We at any rate expect the mobile iOS browser to kill us >=1GB, so we don't set a maximum higher than that.
     if (typeof window !== 'undefined' && /iPhone/.test(navigator.userAgent)) {
       return 2 ** 14;
     }

--- a/barretenberg/ts/src/barretenberg_wasm/barretenberg_wasm_main/index.ts
+++ b/barretenberg/ts/src/barretenberg_wasm/barretenberg_wasm_main/index.ts
@@ -31,7 +31,7 @@ export class BarretenbergWasmMain extends BarretenbergWasmBase {
     threads = Math.min(getNumCpu(), BarretenbergWasmMain.MAX_THREADS),
     logger: (msg: string) => void = createDebugLogger('bb_wasm'),
     initial = 32,
-    maximum = 2 ** 16,
+    maximum = this.getDefaultMaximum(),
   ) {
     this.logger = logger;
 
@@ -61,6 +61,14 @@ export class BarretenbergWasmMain extends BarretenbergWasmBase {
       this.remoteWasms = await Promise.all(this.workers.map(getRemoteBarretenbergWasm<BarretenbergWasmThreadWorker>));
       await Promise.all(this.remoteWasms.map(w => w.initThread(module, this.memory)));
     }
+  }
+
+  private getDefaultMaximum(): number {
+    // iOS browser is very aggressive with memory. Check if running in browser and on iOS
+    if (typeof window !== 'undefined' && /iPhone/.test(navigator.userAgent)) {
+      return 2 ** 14;
+    }
+    return 2 ** 16;
   }
 
   /**

--- a/barretenberg/ts/src/barretenberg_wasm/barretenberg_wasm_main/index.ts
+++ b/barretenberg/ts/src/barretenberg_wasm/barretenberg_wasm_main/index.ts
@@ -31,7 +31,7 @@ export class BarretenbergWasmMain extends BarretenbergWasmBase {
     threads = Math.min(getNumCpu(), BarretenbergWasmMain.MAX_THREADS),
     logger: (msg: string) => void = createDebugLogger('bb_wasm'),
     initial = 32,
-    maximum = this.getDefaultMaximum(),
+    maximum = this.getDefaultMaximumMemoryPages(),
   ) {
     this.logger = logger;
 
@@ -63,10 +63,10 @@ export class BarretenbergWasmMain extends BarretenbergWasmBase {
     }
   }
 
-  private getDefaultMaximum(): number {
+  private getDefaultMaximumMemoryPages(): number {
     // iOS browser is very aggressive with memory. Check if running in browser and on iOS
     // We at any rate expect the mobile iOS browser to kill us >=1GB, so we don't set a maximum higher than that.
-    if (typeof window !== 'undefined' && /iPhone/.test(navigator.userAgent)) {
+    if (typeof window !== 'undefined' && /iPad|iPhone/.test(navigator.userAgent)) {
       return 2 ** 14;
     }
     return 2 ** 16;


### PR DESCRIPTION
This is the most we expect to be able to use anyway. Without this, we frequently got rangeerror: out of memory

<img width="747" alt="Screenshot 2025-06-12 at 12 18 38 PM" src="https://github.com/user-attachments/assets/27e65af2-07f1-4802-a738-0ec1548c0aeb" />

Fixes https://github.com/AztecProtocol/aztec-packages/issues/10208
Also limits the SRS size, saving crucial memory