### PR TITLE
fix: pass CommitmentKey by value.

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -42,6 +42,17 @@
       "initCommands": [
         "command script import ${workspaceFolder}/barretenberg/cpp/scripts/lldb_format.py"
       ],
+    },
+    {
+      "name": "Debug Test",
+      "type": "lldb",
+      "request": "launch",
+      "program": "${workspaceFolder}/barretenberg/cpp/build-debug/bin/vm2_tests",
+      "args": ["--gtest_filter=AvmRecursiveTests.GoblinRecursion"],
+      "cwd": "${workspaceFolder}/barretenberg/cpp/build-debug",
+      "initCommands": [
+        "command script import ${workspaceFolder}/barretenberg/cpp/scripts/lldb_format.py"
+      ],
     }
   ]
 }

--- a/barretenberg/cpp/src/barretenberg/benchmark/basics_bench/basics.bench.cpp
+++ b/barretenberg/cpp/src/barretenberg/benchmark/basics_bench/basics.bench.cpp
@@ -462,7 +462,7 @@ void pippenger(State& state)
             pol.at(i).self_reduce_once();
         }
 
-        auto ck = CommitmentKey<curve::BN254>(num_cycles);
+        CommitmentKey<curve::BN254> ck(num_cycles);
         state.ResumeTiming();
         benchmark::DoNotOptimize(ck.commit(pol));
     }

--- a/barretenberg/cpp/src/barretenberg/benchmark/basics_bench/basics.bench.cpp
+++ b/barretenberg/cpp/src/barretenberg/benchmark/basics_bench/basics.bench.cpp
@@ -462,9 +462,9 @@ void pippenger(State& state)
             pol.at(i).self_reduce_once();
         }
 
-        auto ck = std::make_shared<CommitmentKey<curve::BN254>>(num_cycles);
+        auto ck = CommitmentKey<curve::BN254>(num_cycles);
         state.ResumeTiming();
-        benchmark::DoNotOptimize(ck->commit(pol));
+        benchmark::DoNotOptimize(ck.commit(pol));
     }
 }
 

--- a/barretenberg/cpp/src/barretenberg/benchmark/ipa_bench/ipa.bench.cpp
+++ b/barretenberg/cpp/src/barretenberg/benchmark/ipa_bench/ipa.bench.cpp
@@ -13,7 +13,7 @@ using Polynomial = Polynomial<Fr>;
 constexpr size_t MIN_POLYNOMIAL_DEGREE_LOG2 = 10;
 constexpr size_t MAX_POLYNOMIAL_DEGREE_LOG2 = 16;
 
-std::shared_ptr<CommitmentKey<Curve>> ck;
+CommitmentKey<Curve> ck;
 std::shared_ptr<VerifierCommitmentKey<Curve>> vk;
 std::vector<std::shared_ptr<NativeTranscript>> prover_transcripts(MAX_POLYNOMIAL_DEGREE_LOG2 -
                                                                   MIN_POLYNOMIAL_DEGREE_LOG2 + 1);
@@ -21,7 +21,7 @@ std::vector<OpeningClaim<Curve>> opening_claims(MAX_POLYNOMIAL_DEGREE_LOG2 - MIN
 static void DoSetup(const benchmark::State&)
 {
     srs::init_file_crs_factory(srs::bb_crs_path());
-    ck = std::make_shared<CommitmentKey<Curve>>(1 << MAX_POLYNOMIAL_DEGREE_LOG2);
+    ck = CommitmentKey<Curve>(1 << MAX_POLYNOMIAL_DEGREE_LOG2);
     vk = std::make_shared<VerifierCommitmentKey<Curve>>(1 << MAX_POLYNOMIAL_DEGREE_LOG2,
                                                         srs::get_grumpkin_crs_factory());
 }
@@ -40,7 +40,7 @@ void ipa_open(State& state) noexcept
         auto x = Fr::random_element(&engine);
         auto eval = poly.evaluate(x);
         const OpeningPair<Curve> opening_pair = { x, eval };
-        const OpeningClaim<Curve> opening_claim{ opening_pair, ck->commit(poly) };
+        const OpeningClaim<Curve> opening_claim{ opening_pair, ck.commit(poly) };
         // initialize empty prover transcript
         auto prover_transcript = std::make_shared<NativeTranscript>();
         state.ResumeTiming();

--- a/barretenberg/cpp/src/barretenberg/client_ivc/client_ivc.cpp
+++ b/barretenberg/cpp/src/barretenberg/client_ivc/client_ivc.cpp
@@ -24,7 +24,7 @@ ClientIVC::ClientIVC(TraceSettings trace_settings)
         std::max(trace_settings.dyadic_size(), 1UL << TranslatorFlavor::CONST_TRANSLATOR_LOG_N);
     info("BN254 commitment key size: ", commitment_key_size);
     // TODO(https://github.com/AztecProtocol/barretenberg/issues/1420): pass commitment keys by value
-    bn254_commitment_key = std::make_shared<CommitmentKey<curve::BN254>>(commitment_key_size);
+    bn254_commitment_key = CommitmentKey<curve::BN254>(commitment_key_size);
 }
 
 /**
@@ -193,9 +193,9 @@ void ClientIVC::accumulate(ClientCircuit& circuit,
 
     // If the current circuit overflows past the current size of the commitment key, reinitialize accordingly.
     // TODO(https://github.com/AztecProtocol/barretenberg/issues/1319)
-    if (proving_key->proving_key.circuit_size > bn254_commitment_key->dyadic_size) {
+    if (proving_key->proving_key.circuit_size > bn254_commitment_key.dyadic_size) {
         // TODO(https://github.com/AztecProtocol/barretenberg/issues/1420): pass commitment keys by value
-        bn254_commitment_key = std::make_shared<CommitmentKey<curve::BN254>>(proving_key->proving_key.circuit_size);
+        bn254_commitment_key = CommitmentKey<curve::BN254>(proving_key->proving_key.circuit_size);
         goblin.commitment_key = bn254_commitment_key;
     }
     proving_key->proving_key.commitment_key = bn254_commitment_key;

--- a/barretenberg/cpp/src/barretenberg/client_ivc/client_ivc.hpp
+++ b/barretenberg/cpp/src/barretenberg/client_ivc/client_ivc.hpp
@@ -169,7 +169,7 @@ class ClientIVC {
     // Settings related to the use of fixed block sizes for each gate in the execution trace
     TraceSettings trace_settings;
 
-    std::shared_ptr<typename MegaFlavor::CommitmentKey> bn254_commitment_key;
+    typename MegaFlavor::CommitmentKey bn254_commitment_key;
 
     Goblin goblin;
 

--- a/barretenberg/cpp/src/barretenberg/commitment_schemes/commit.bench.cpp
+++ b/barretenberg/cpp/src/barretenberg/commitment_schemes/commit.bench.cpp
@@ -12,11 +12,11 @@
 
 namespace bb {
 
-template <typename Curve> std::shared_ptr<CommitmentKey<Curve>> create_commitment_key(const size_t num_points)
+template <typename Curve> CommitmentKey<Curve> create_commitment_key(const size_t num_points)
 {
     bb::srs::init_file_crs_factory(bb::srs::bb_crs_path());
     std::string srs_path;
-    return std::make_shared<CommitmentKey<Curve>>(num_points);
+    return CommitmentKey<Curve>(num_points);
 }
 
 // Generate a polynomial with a specified number of nonzero random coefficients
@@ -99,7 +99,7 @@ template <typename Curve> void bench_commit_zero(::benchmark::State& state)
     const size_t num_points = 1 << state.range(0);
     const auto polynomial = Polynomial<typename Curve::ScalarField>(num_points);
     for (auto _ : state) {
-        key->commit(polynomial);
+        key.commit(polynomial);
     }
 }
 
@@ -118,7 +118,7 @@ template <typename Curve> void bench_commit_sparse(::benchmark::State& state)
     }
 
     for (auto _ : state) {
-        key->commit(polynomial);
+        key.commit(polynomial);
     }
 }
 
@@ -137,7 +137,7 @@ template <typename Curve> void bench_commit_sparse_preprocessed(::benchmark::Sta
     }
 
     for (auto _ : state) {
-        key->commit_sparse(polynomial);
+        key.commit_sparse(polynomial);
     }
 }
 
@@ -153,7 +153,7 @@ template <typename Curve> void bench_commit_sparse_random(::benchmark::State& st
     auto polynomial = sparse_random_poly<Fr>(num_points, num_nonzero);
 
     for (auto _ : state) {
-        key->commit(polynomial);
+        key.commit(polynomial);
     }
 }
 
@@ -169,7 +169,7 @@ template <typename Curve> void bench_commit_sparse_random_preprocessed(::benchma
     auto polynomial = sparse_random_poly<Fr>(num_points, num_nonzero);
 
     for (auto _ : state) {
-        key->commit_sparse(polynomial);
+        key.commit_sparse(polynomial);
     }
 }
 
@@ -182,7 +182,7 @@ template <typename Curve> void bench_commit_random(::benchmark::State& state)
     const size_t num_points = 1 << state.range(0);
     Polynomial<Fr> polynomial = Polynomial<Fr>::random(num_points);
     for (auto _ : state) {
-        key->commit(polynomial);
+        key.commit(polynomial);
     }
 }
 
@@ -196,7 +196,7 @@ template <typename Curve> void bench_commit_random_non_power_of_2(::benchmark::S
     const size_t num_points = 1 << state.range(0);
     Polynomial<Fr> polynomial = Polynomial<Fr>::random(num_points - 1);
     for (auto _ : state) {
-        key->commit(polynomial);
+        key.commit(polynomial);
     }
 }
 
@@ -209,7 +209,7 @@ template <typename Curve> void bench_commit_structured_random_poly(::benchmark::
     auto [polynomial, active_range_endpoints] = structured_random_poly<Fr>();
 
     for (auto _ : state) {
-        key->commit(polynomial);
+        key.commit(polynomial);
     }
 }
 
@@ -222,7 +222,7 @@ template <typename Curve> void bench_commit_structured_random_poly_preprocessed(
     auto [polynomial, active_range_endpoints] = structured_random_poly<Fr>();
 
     for (auto _ : state) {
-        key->commit_structured(polynomial, active_range_endpoints);
+        key.commit_structured(polynomial, active_range_endpoints);
     }
 }
 
@@ -235,7 +235,7 @@ template <typename Curve> void bench_commit_mock_z_perm(::benchmark::State& stat
     auto [polynomial, active_range_endpoints] = structured_random_poly<Fr>(/*non_zero_complement=*/true);
 
     for (auto _ : state) {
-        key->commit(polynomial);
+        key.commit(polynomial);
     }
 }
 
@@ -248,7 +248,7 @@ template <typename Curve> void bench_commit_mock_z_perm_preprocessed(::benchmark
     auto [polynomial, active_range_endpoints] = structured_random_poly<Fr>(/*non_zero_complement=*/true);
 
     for (auto _ : state) {
-        key->commit_structured_with_nonzero_complement(polynomial, active_range_endpoints);
+        key.commit_structured_with_nonzero_complement(polynomial, active_range_endpoints);
     }
 }
 

--- a/barretenberg/cpp/src/barretenberg/commitment_schemes/commitment_key.hpp
+++ b/barretenberg/cpp/src/barretenberg/commitment_schemes/commitment_key.hpp
@@ -75,14 +75,22 @@ template <class Curve> class CommitmentKey {
     {}
 
     /**
+     * @brief Checks the commitment key is properly initialized.
+     *
+     * @return bool
+     */
+    bool initialized() const { return pippenger_runtime_state.initialized(); }
+
+    /**
      * @brief Uses the ProverSRS to create a commitment to p(X)
      *
      * @param polynomial a univariate polynomial p(X) = ∑ᵢ aᵢ⋅Xⁱ
      * @return Commitment computed as C = [p(x)] = ∑ᵢ aᵢ⋅Gᵢ
      */
-    Commitment commit(PolynomialSpan<const Fr> polynomial)
+    Commitment commit(PolynomialSpan<const Fr> polynomial) const
     {
         PROFILE_THIS_NAME("commit");
+        ASSERT(initialized());
         // We must have a power-of-2 SRS points *after* subtracting by start_index.
         size_t dyadic_poly_size = numeric::round_up_power_2(polynomial.size());
         BB_ASSERT_LTE(dyadic_poly_size, dyadic_size, "Polynomial size exceeds commitment key size.");

--- a/barretenberg/cpp/src/barretenberg/commitment_schemes/commitment_key.hpp
+++ b/barretenberg/cpp/src/barretenberg/commitment_schemes/commitment_key.hpp
@@ -59,7 +59,7 @@ template <class Curve> class CommitmentKey {
     std::shared_ptr<srs::factories::Crs<Curve>> srs;
     size_t dyadic_size;
 
-    CommitmentKey() = delete;
+    CommitmentKey() = default;
 
     /**
      * @brief Construct a new Kate Commitment Key object from existing SRS

--- a/barretenberg/cpp/src/barretenberg/commitment_schemes/commitment_key.test.hpp
+++ b/barretenberg/cpp/src/barretenberg/commitment_schemes/commitment_key.test.hpp
@@ -20,34 +20,32 @@ namespace bb {
 constexpr size_t COMMITMENT_TEST_NUM_BN254_POINTS = 4096;
 constexpr size_t COMMITMENT_TEST_NUM_GRUMPKIN_POINTS = 1 << CONST_ECCVM_LOG_N;
 
-template <class CK> inline std::shared_ptr<CK> create_commitment_key(const size_t num_points = 0);
+template <class CK> CK create_commitment_key(const size_t num_points = 0);
 
 template <>
-inline std::shared_ptr<CommitmentKey<curve::BN254>> create_commitment_key<CommitmentKey<curve::BN254>>(
-    const size_t num_points)
+inline CommitmentKey<curve::BN254> create_commitment_key<CommitmentKey<curve::BN254>>(const size_t num_points)
 {
     bb::srs::init_file_crs_factory(bb::srs::bb_crs_path());
     if (num_points != 0) {
-        return std::make_shared<CommitmentKey<curve::BN254>>(num_points);
+        return CommitmentKey<curve::BN254>(num_points);
     };
-    return std::make_shared<CommitmentKey<curve::BN254>>(COMMITMENT_TEST_NUM_BN254_POINTS);
+    return CommitmentKey<curve::BN254>(COMMITMENT_TEST_NUM_BN254_POINTS);
 }
 // For IPA
 template <>
-inline std::shared_ptr<CommitmentKey<curve::Grumpkin>> create_commitment_key<CommitmentKey<curve::Grumpkin>>(
-    const size_t num_points)
+inline CommitmentKey<curve::Grumpkin> create_commitment_key<CommitmentKey<curve::Grumpkin>>(const size_t num_points)
 {
     srs::init_file_crs_factory(bb::srs::bb_crs_path());
     if (num_points != 0) {
-        return std::make_shared<CommitmentKey<curve::Grumpkin>>(num_points);
+        return CommitmentKey<curve::Grumpkin>(num_points);
     }
-    return std::make_shared<CommitmentKey<curve::Grumpkin>>(COMMITMENT_TEST_NUM_GRUMPKIN_POINTS);
+    return CommitmentKey<curve::Grumpkin>(COMMITMENT_TEST_NUM_GRUMPKIN_POINTS);
 }
 
-template <typename CK> inline std::shared_ptr<CK> create_commitment_key(size_t num_points)
+template <typename CK> inline CK create_commitment_key(size_t num_points)
 // requires std::default_initializable<CK>
 {
-    return std::make_shared<CK>(num_points);
+    return CK(num_points);
 }
 
 template <class VK> inline std::shared_ptr<VK> create_verifier_commitment_key();
@@ -85,10 +83,10 @@ template <typename Curve> class CommitmentTest : public ::testing::Test {
         : engine{ &numeric::get_randomness() }
     {}
 
-    std::shared_ptr<CK> ck() { return commitment_key; }
+    CK& ck() { return commitment_key; }
     std::shared_ptr<VK> vk() { return verification_key; }
 
-    Commitment commit(const Polynomial& polynomial) { return commitment_key->commit(polynomial); }
+    Commitment commit(const Polynomial& polynomial) { return commitment_key.commit(polynomial); }
 
     Fr random_element() { return Fr::random_element(engine); }
 
@@ -110,7 +108,7 @@ template <typename Curve> class CommitmentTest : public ::testing::Test {
 
     void verify_opening_claim(const OpeningClaim<Curve>& claim,
                               const Polynomial& witness,
-                              const std::shared_ptr<CommitmentKey<Curve>>& ck = nullptr)
+                              CommitmentKey<Curve> ck = CommitmentKey<Curve>())
     {
         auto& commitment = claim.commitment;
         auto& [x, y] = claim.opening_pair;
@@ -118,10 +116,10 @@ template <typename Curve> class CommitmentTest : public ::testing::Test {
         EXPECT_EQ(y, y_expected) << "OpeningClaim: evaluations mismatch";
         Commitment commitment_expected;
 
-        if (!ck) {
+        if (!ck.srs) {
             commitment_expected = commit(witness);
         } else {
-            commitment_expected = ck->commit(witness);
+            commitment_expected = ck.commit(witness);
         }
 
         EXPECT_EQ(commitment, commitment_expected) << "OpeningClaim: commitment mismatch";
@@ -173,7 +171,7 @@ template <typename Curve> class CommitmentTest : public ::testing::Test {
     static void SetUpTestSuite()
     {
         // Avoid reallocating static objects if called in subclasses of FooTest.
-        if (commitment_key == nullptr) {
+        if (commitment_key.srs == nullptr) {
             commitment_key = create_commitment_key<CK>();
         }
         if (verification_key == nullptr) {
@@ -186,12 +184,11 @@ template <typename Curve> class CommitmentTest : public ::testing::Test {
     // Can be omitted if not needed.
     static void TearDownTestSuite() {}
 
-    static typename std::shared_ptr<CK> commitment_key;
+    static CK commitment_key;
     static typename std::shared_ptr<VK> verification_key;
 };
 
-template <typename Curve>
-typename std::shared_ptr<CommitmentKey<Curve>> CommitmentTest<Curve>::commitment_key = nullptr;
+template <typename Curve> CommitmentKey<Curve> CommitmentTest<Curve>::commitment_key;
 template <typename Curve>
 typename std::shared_ptr<VerifierCommitmentKey<Curve>> CommitmentTest<Curve>::verification_key = nullptr;
 

--- a/barretenberg/cpp/src/barretenberg/commitment_schemes/commitment_key.test.hpp
+++ b/barretenberg/cpp/src/barretenberg/commitment_schemes/commitment_key.test.hpp
@@ -171,7 +171,7 @@ template <typename Curve> class CommitmentTest : public ::testing::Test {
     static void SetUpTestSuite()
     {
         // Avoid reallocating static objects if called in subclasses of FooTest.
-        if (commitment_key.srs == nullptr) {
+        if (!commitment_key.initialized()) {
             commitment_key = create_commitment_key<CK>();
         }
         if (verification_key == nullptr) {

--- a/barretenberg/cpp/src/barretenberg/commitment_schemes/gemini/gemini.hpp
+++ b/barretenberg/cpp/src/barretenberg/commitment_schemes/gemini/gemini.hpp
@@ -335,7 +335,7 @@ template <typename Curve> class GeminiProver_ {
     static std::vector<Claim> prove(const Fr circuit_size,
                                     PolynomialBatcher& polynomial_batcher,
                                     std::span<Fr> multilinear_challenge,
-                                    CommitmentKey<Curve>& commitment_key,
+                                    const CommitmentKey<Curve>& commitment_key,
                                     const std::shared_ptr<Transcript>& transcript,
                                     bool has_zk = false);
 

--- a/barretenberg/cpp/src/barretenberg/commitment_schemes/gemini/gemini.hpp
+++ b/barretenberg/cpp/src/barretenberg/commitment_schemes/gemini/gemini.hpp
@@ -335,7 +335,7 @@ template <typename Curve> class GeminiProver_ {
     static std::vector<Claim> prove(const Fr circuit_size,
                                     PolynomialBatcher& polynomial_batcher,
                                     std::span<Fr> multilinear_challenge,
-                                    const std::shared_ptr<CommitmentKey<Curve>>& commitment_key,
+                                    CommitmentKey<Curve>& commitment_key,
                                     const std::shared_ptr<Transcript>& transcript,
                                     bool has_zk = false);
 

--- a/barretenberg/cpp/src/barretenberg/commitment_schemes/gemini/gemini.test.cpp
+++ b/barretenberg/cpp/src/barretenberg/commitment_schemes/gemini/gemini.test.cpp
@@ -18,7 +18,7 @@ template <class Curve> class GeminiTest : public CommitmentTest<Curve> {
     using CK = CommitmentKey<Curve>;
     using VK = VerifierCommitmentKey<Curve>;
 
-    static std::shared_ptr<CK> ck;
+    static CK ck;
     static std::shared_ptr<VK> vk;
 
     static void SetUpTestSuite()
@@ -192,8 +192,8 @@ TYPED_TEST(GeminiTest, SoundnessRegression)
     fold_1.at(2) = -(Fr(1) - u[1]) * fold_1.at(1) * u[1].invert(); // fold₁[2] = -(1 - u₁) ⋅ fold₁[1] / u₁
     fold_1.at(3) = Fr(0);
 
-    prover_transcript->template send_to_verifier("Gemini:FOLD_1", this->ck->commit(fold_1));
-    prover_transcript->template send_to_verifier("Gemini:FOLD_2", this->ck->commit(fold_2));
+    prover_transcript->template send_to_verifier("Gemini:FOLD_1", this->ck.commit(fold_1));
+    prover_transcript->template send_to_verifier("Gemini:FOLD_2", this->ck.commit(fold_2));
 
     // Get Gemini evaluation challenge
     const Fr gemini_r = prover_transcript->template get_challenge<Fr>("Gemini:r");
@@ -229,7 +229,7 @@ TYPED_TEST(GeminiTest, SoundnessRegression)
 
     auto verifier_transcript = NativeTranscript::verifier_init_empty(prover_transcript);
 
-    std::vector<Commitment> unshifted_commitments = { this->ck->commit(fold_0) };
+    std::vector<Commitment> unshifted_commitments = { this->ck.commit(fold_0) };
     std::vector<Fr> unshifted_evals = { claimed_multilinear_eval * rho.pow(0) };
 
     ClaimBatcher claim_batcher{ .unshifted =
@@ -254,5 +254,5 @@ TYPED_TEST(GeminiTest, SoundnessRegression)
     }
 }
 
-template <class Curve> std::shared_ptr<typename GeminiTest<Curve>::CK> GeminiTest<Curve>::ck = nullptr;
+template <class Curve> typename GeminiTest<Curve>::CK GeminiTest<Curve>::ck;
 template <class Curve> std::shared_ptr<typename GeminiTest<Curve>::VK> GeminiTest<Curve>::vk = nullptr;

--- a/barretenberg/cpp/src/barretenberg/commitment_schemes/gemini/gemini_impl.hpp
+++ b/barretenberg/cpp/src/barretenberg/commitment_schemes/gemini/gemini_impl.hpp
@@ -51,7 +51,7 @@ std::vector<typename GeminiProver_<Curve>::Claim> GeminiProver_<Curve>::prove(
     Fr circuit_size,
     PolynomialBatcher& polynomial_batcher,
     std::span<Fr> multilinear_challenge,
-    CommitmentKey<Curve>& commitment_key,
+    const CommitmentKey<Curve>& commitment_key,
     const std::shared_ptr<Transcript>& transcript,
     bool has_zk)
 {

--- a/barretenberg/cpp/src/barretenberg/commitment_schemes/gemini/gemini_impl.hpp
+++ b/barretenberg/cpp/src/barretenberg/commitment_schemes/gemini/gemini_impl.hpp
@@ -51,7 +51,7 @@ std::vector<typename GeminiProver_<Curve>::Claim> GeminiProver_<Curve>::prove(
     Fr circuit_size,
     PolynomialBatcher& polynomial_batcher,
     std::span<Fr> multilinear_challenge,
-    const std::shared_ptr<CommitmentKey<Curve>>& commitment_key,
+    CommitmentKey<Curve>& commitment_key,
     const std::shared_ptr<Transcript>& transcript,
     bool has_zk)
 {
@@ -63,7 +63,7 @@ std::vector<typename GeminiProver_<Curve>::Claim> GeminiProver_<Curve>::prove(
     // To achieve ZK, we mask the batched polynomial by a random polynomial of the same size
     if (has_zk) {
         Polynomial random_polynomial = Polynomial::random(n);
-        transcript->send_to_verifier("Gemini:masking_poly_comm", commitment_key->commit(random_polynomial));
+        transcript->send_to_verifier("Gemini:masking_poly_comm", commitment_key.commit(random_polynomial));
         // In the provers, the size of multilinear_challenge is `virtual_log_n`, but we need to evaluate the
         // hiding polynomial as multilinear in log_n variables
         transcript->send_to_verifier("Gemini:masking_poly_eval",
@@ -86,7 +86,7 @@ std::vector<typename GeminiProver_<Curve>::Claim> GeminiProver_<Curve>::prove(
     for (size_t l = 0; l < virtual_log_n - 1; l++) {
         std::string label = "Gemini:FOLD_" + std::to_string(l + 1);
         if (l < log_n - 1) {
-            transcript->send_to_verifier(label, commitment_key->commit(fold_polynomials[l]));
+            transcript->send_to_verifier(label, commitment_key.commit(fold_polynomials[l]));
         } else {
             transcript->send_to_verifier(label, Commitment::one());
         }

--- a/barretenberg/cpp/src/barretenberg/commitment_schemes/ipa/ipa.fuzzer.cpp
+++ b/barretenberg/cpp/src/barretenberg/commitment_schemes/ipa/ipa.fuzzer.cpp
@@ -25,7 +25,7 @@ std::shared_ptr<VerifierCommitmentKey<Curve>> vk;
 class ProxyCaller {
   public:
     template <typename Transcript>
-    static void compute_opening_proof_internal(CommitmentKey<Curve>& ck,
+    static void compute_opening_proof_internal(const CommitmentKey<Curve>& ck,
                                                const ProverOpeningClaim<Curve>& opening_claim,
                                                const std::shared_ptr<Transcript>& transcript)
     {

--- a/barretenberg/cpp/src/barretenberg/commitment_schemes/ipa/ipa.fuzzer.cpp
+++ b/barretenberg/cpp/src/barretenberg/commitment_schemes/ipa/ipa.fuzzer.cpp
@@ -16,7 +16,7 @@ namespace bb {
 // We actually only use 4, because fuzzing is very slow
 constexpr size_t COMMITMENT_TEST_NUM_POINTS = 32;
 using Curve = curve::Grumpkin;
-std::shared_ptr<CommitmentKey<Curve>> ck;
+CommitmentKey<Curve> ck;
 std::shared_ptr<VerifierCommitmentKey<Curve>> vk;
 /**
  * @brief Class that allows us to call internal IPA methods, because it's friendly
@@ -25,7 +25,7 @@ std::shared_ptr<VerifierCommitmentKey<Curve>> vk;
 class ProxyCaller {
   public:
     template <typename Transcript>
-    static void compute_opening_proof_internal(const std::shared_ptr<CommitmentKey<Curve>>& ck,
+    static void compute_opening_proof_internal(CommitmentKey<Curve>& ck,
                                                const ProverOpeningClaim<Curve>& opening_claim,
                                                const std::shared_ptr<Transcript>& transcript)
     {
@@ -50,7 +50,7 @@ using namespace bb;
 extern "C" void LLVMFuzzerInitialize(int*, char***)
 {
     srs::init_file_crs_factory(srs::bb_crs_path());
-    ck = std::make_shared<CommitmentKey<Curve>>(COMMITMENT_TEST_NUM_POINTS);
+    ck = CommitmentKey<Curve>(COMMITMENT_TEST_NUM_POINTS);
     vk = std::make_shared<VerifierCommitmentKey<curve::Grumpkin>>(COMMITMENT_TEST_NUM_POINTS);
 }
 
@@ -148,7 +148,7 @@ extern "C" int LLVMFuzzerTestOneInput(const unsigned char* data, size_t size)
         x.self_from_montgomery_form();
     }
     auto const opening_pair = OpeningPair<Curve>{ x, poly.evaluate(x) };
-    auto const opening_claim = OpeningClaim<Curve>{ opening_pair, ck->commit(poly) };
+    auto const opening_claim = OpeningClaim<Curve>{ opening_pair, ck.commit(poly) };
     ProxyCaller::compute_opening_proof_internal(ck, { poly, opening_pair }, transcript);
 
     // Reset challenge indices

--- a/barretenberg/cpp/src/barretenberg/commitment_schemes/ipa/ipa.hpp
+++ b/barretenberg/cpp/src/barretenberg/commitment_schemes/ipa/ipa.hpp
@@ -966,7 +966,7 @@ template <typename Curve_> class IPA {
         using Builder = typename Curve::Builder;
         using Curve = stdlib::grumpkin<Builder>;
         auto ipa_transcript = std::make_shared<NativeTranscript>();
-        auto ipa_commitment_key = CommitmentKey<NativeCurve>(1 << CONST_ECCVM_LOG_N);
+        CommitmentKey<NativeCurve> ipa_commitment_key(1 << CONST_ECCVM_LOG_N);
         size_t n = 4;
         auto poly = Polynomial<fq>(n);
         for (size_t i = 0; i < n; i++) {

--- a/barretenberg/cpp/src/barretenberg/commitment_schemes/ipa/ipa.hpp
+++ b/barretenberg/cpp/src/barretenberg/commitment_schemes/ipa/ipa.hpp
@@ -144,7 +144,7 @@ template <typename Curve_> class IPA {
     *7. Send the final \f$\vec{a}_{0} = (a_0)\f$ to the verifier
     */
     template <typename Transcript>
-    static void compute_opening_proof_internal(const std::shared_ptr<CK>& ck,
+    static void compute_opening_proof_internal(const CK& ck,
                                                const ProverOpeningClaim<Curve>& opening_claim,
                                                const std::shared_ptr<Transcript>& transcript)
     {
@@ -178,7 +178,7 @@ template <typename Curve_> class IPA {
         // Set initial vector a to the polynomial monomial coefficients and load vector G
         // Ensure the polynomial copy is fully-formed
         auto a_vec = polynomial.full();
-        std::span<Commitment> srs_elements = ck->srs->get_monomial_points();
+        std::span<Commitment> srs_elements = ck.srs->get_monomial_points();
         std::vector<Commitment> G_vec_local(poly_length);
 
         if (poly_length * 2 > srs_elements.size()) {
@@ -239,13 +239,13 @@ template <typename Curve_> class IPA {
             // Step 6.a (using letters, because doxygen automatically converts the sublist counters to letters :( )
             // L_i = < a_vec_lo, G_vec_hi > + inner_prod_L * aux_generator
             L_i = bb::scalar_multiplication::pippenger_without_endomorphism_basis_points<Curve>(
-                {0, {&a_vec.at(0), /*size*/ round_size}}, {&G_vec_local[round_size], /*size*/ round_size}, ck->pippenger_runtime_state.get());
+                {0, {&a_vec.at(0), /*size*/ round_size}}, {&G_vec_local[round_size], /*size*/ round_size}, ck.pippenger_runtime_state.get());
             L_i += aux_generator * inner_prod_L;
 
             // Step 6.b
             // R_i = < a_vec_hi, G_vec_lo > + inner_prod_R * aux_generator
             R_i = bb::scalar_multiplication::pippenger_without_endomorphism_basis_points<Curve>(
-                {0, {&a_vec.at(round_size), /*size*/ round_size}}, {&G_vec_local[0], /*size*/ round_size}, ck->pippenger_runtime_state.get());
+                {0, {&a_vec.at(round_size), /*size*/ round_size}}, {&G_vec_local[0], /*size*/ round_size}, ck.pippenger_runtime_state.get());
             R_i += aux_generator * inner_prod_R;
 
             // Step 6.c
@@ -557,7 +557,7 @@ template <typename Curve_> class IPA {
      * @remark Detailed documentation can be found in \link IPA::compute_opening_proof_internal
      * compute_opening_proof_internal \endlink.
      */
-    static void compute_opening_proof(const std::shared_ptr<CK>& ck,
+    static void compute_opening_proof(const CK& ck,
                                       const ProverOpeningClaim<Curve>& opening_claim,
                                       const std::shared_ptr<NativeTranscript>& transcript)
     {
@@ -910,7 +910,7 @@ template <typename Curve_> class IPA {
      * @param claim_2
      * @return std::pair<OpeningClaim<Curve>, HonkProof>
      */
-    static std::pair<OpeningClaim<Curve>, HonkProof> accumulate(const std::shared_ptr<CommitmentKey<curve::Grumpkin>>& ck, auto& transcript_1, OpeningClaim<Curve> claim_1, auto& transcript_2, OpeningClaim<Curve> claim_2)
+    static std::pair<OpeningClaim<Curve>, HonkProof> accumulate(const CommitmentKey<curve::Grumpkin>& ck, auto& transcript_1, OpeningClaim<Curve> claim_1, auto& transcript_2, OpeningClaim<Curve> claim_2)
     requires Curve::is_stdlib_type
     {
         using NativeCurve = curve::Grumpkin;
@@ -966,7 +966,7 @@ template <typename Curve_> class IPA {
         using Builder = typename Curve::Builder;
         using Curve = stdlib::grumpkin<Builder>;
         auto ipa_transcript = std::make_shared<NativeTranscript>();
-        auto ipa_commitment_key = std::make_shared<CommitmentKey<NativeCurve>>(1 << CONST_ECCVM_LOG_N);
+        auto ipa_commitment_key = CommitmentKey<NativeCurve>(1 << CONST_ECCVM_LOG_N);
         size_t n = 4;
         auto poly = Polynomial<fq>(n);
         for (size_t i = 0; i < n; i++) {
@@ -974,7 +974,7 @@ template <typename Curve_> class IPA {
         }
         fq x = fq::random_element();
         fq eval = poly.evaluate(x);
-        auto commitment = ipa_commitment_key->commit(poly);
+        auto commitment = ipa_commitment_key.commit(poly);
         const OpeningPair<NativeCurve> opening_pair = { x, eval };
         IPA<NativeCurve>::compute_opening_proof(ipa_commitment_key, { poly, opening_pair }, ipa_transcript);
 

--- a/barretenberg/cpp/src/barretenberg/commitment_schemes/ipa/ipa.test.cpp
+++ b/barretenberg/cpp/src/barretenberg/commitment_schemes/ipa/ipa.test.cpp
@@ -27,7 +27,7 @@ class IPATest : public CommitmentTest<Curve> {
     using ClaimBatcher = ClaimBatcher_<Curve>;
     using ClaimBatch = ClaimBatcher::Batch;
 
-    static std::shared_ptr<CK> ck;
+    static CK ck;
     static std::shared_ptr<VK> vk;
 
     // Default polynomial size
@@ -56,8 +56,8 @@ TEST_F(IPATest, CommitOnManyZeroCoeffPolyWorks)
         p.at(i) = Fr::zero();
     }
     p.at(3) = Fr::one();
-    GroupElement commitment = ck->commit(p);
-    auto srs_elements = ck->srs->get_monomial_points();
+    GroupElement commitment = ck.commit(p);
+    auto srs_elements = ck.srs->get_monomial_points();
     GroupElement expected = srs_elements[0] * p[0];
     // The SRS stored in the commitment key is the result after applying the pippenger point table so the
     // values at odd indices contain the point {srs[i-1].x * beta, srs[i-1].y}, where beta is the endomorphism
@@ -74,7 +74,7 @@ TEST_F(IPATest, OpenZeroPolynomial)
 {
     Polynomial poly(small_n);
     // Commit to a zero polynomial
-    Commitment commitment = ck->commit(poly);
+    Commitment commitment = ck.commit(poly);
     EXPECT_TRUE(commitment.is_point_at_infinity());
 
     auto [x, eval] = this->random_eval(poly);
@@ -101,7 +101,7 @@ TEST_F(IPATest, OpenAtZero)
     auto poly = Polynomial::random(n);
     const Fr x = Fr::zero();
     const Fr eval = poly.evaluate(x);
-    const Commitment commitment = ck->commit(poly);
+    const Commitment commitment = ck.commit(poly);
     const OpeningPair<Curve> opening_pair = { x, eval };
     const OpeningClaim<Curve> opening_claim{ opening_pair, commitment };
 
@@ -124,7 +124,7 @@ TEST_F(IPATest, ChallengesAreZero)
     // generate a random polynomial, degree needs to be a power of two
     auto poly = Polynomial::random(n);
     auto [x, eval] = this->random_eval(poly);
-    auto commitment = ck->commit(poly);
+    auto commitment = ck.commit(poly);
     const OpeningPair<Curve> opening_pair = { x, eval };
     const OpeningClaim<Curve> opening_claim{ opening_pair, commitment };
 
@@ -173,7 +173,7 @@ TEST_F(IPATest, AIsZeroAfterOneRound)
         poly.at(i + (n / 2)) = poly[i];
     }
     auto [x, eval] = this->random_eval(poly);
-    auto commitment = ck->commit(poly);
+    auto commitment = ck.commit(poly);
     const OpeningPair<Curve> opening_pair = { x, eval };
     const OpeningClaim<Curve> opening_claim{ opening_pair, commitment };
 
@@ -208,8 +208,8 @@ TEST_F(IPATest, AIsZeroAfterOneRound)
 TEST_F(IPATest, Commit)
 {
     auto poly = Polynomial::random(n);
-    const GroupElement commitment = ck->commit(poly);
-    auto srs_elements = ck->srs->get_monomial_points();
+    const GroupElement commitment = ck.commit(poly);
+    auto srs_elements = ck.srs->get_monomial_points();
     GroupElement expected = srs_elements[0] * poly[0];
     // The SRS stored in the commitment key is the result after applying the pippenger point table so the
     // values at odd indices contain the point {srs[i-1].x * beta, srs[i-1].y}, where beta is the endomorphism
@@ -225,7 +225,7 @@ TEST_F(IPATest, Open)
     // generate a random polynomial, degree needs to be a power of two
     auto poly = Polynomial::random(n);
     auto [x, eval] = this->random_eval(poly);
-    auto commitment = ck->commit(poly);
+    auto commitment = ck.commit(poly);
     const OpeningPair<Curve> opening_pair = { x, eval };
     const OpeningClaim<Curve> opening_claim{ opening_pair, commitment };
 
@@ -374,5 +374,5 @@ TEST_F(IPATest, ShpleminiIPAShiftsRemoval)
     auto result = PCS::reduce_verify_batch_opening_claim(batch_opening_claim, vk, verifier_transcript);
     EXPECT_EQ(result, true);
 }
-std::shared_ptr<typename IPATest::CK> IPATest::ck = nullptr;
+typename IPATest::CK IPATest::ck;
 std::shared_ptr<typename IPATest::VK> IPATest::vk = nullptr;

--- a/barretenberg/cpp/src/barretenberg/commitment_schemes/kzg/kzg.hpp
+++ b/barretenberg/cpp/src/barretenberg/commitment_schemes/kzg/kzg.hpp
@@ -37,7 +37,7 @@ template <typename Curve_> class KZG {
      * @param prover_transcript Prover transcript
      */
     template <typename Transcript>
-    static void compute_opening_proof(std::shared_ptr<CK> ck,
+    static void compute_opening_proof(CK& ck,
                                       const ProverOpeningClaim<Curve>& opening_claim,
                                       const std::shared_ptr<Transcript>& prover_trancript)
     {
@@ -46,7 +46,7 @@ template <typename Curve_> class KZG {
         quotient.at(0) = quotient[0] - pair.evaluation;
         // Computes the coefficients for the quotient polynomial q(X) = (p(X) - v) / (X - r) through an FFT
         quotient.factor_roots(pair.challenge);
-        auto quotient_commitment = ck->commit(quotient);
+        auto quotient_commitment = ck.commit(quotient);
         // TODO(#479): for now we compute the KZG commitment directly to unify the KZG and IPA interfaces but in the
         // future we might need to adjust this to use the incoming alternative to work queue (i.e. variation of
         // pthreads) or even the work queue itself

--- a/barretenberg/cpp/src/barretenberg/commitment_schemes/kzg/kzg.hpp
+++ b/barretenberg/cpp/src/barretenberg/commitment_schemes/kzg/kzg.hpp
@@ -37,7 +37,7 @@ template <typename Curve_> class KZG {
      * @param prover_transcript Prover transcript
      */
     template <typename Transcript>
-    static void compute_opening_proof(CK& ck,
+    static void compute_opening_proof(const CK& ck,
                                       const ProverOpeningClaim<Curve>& opening_claim,
                                       const std::shared_ptr<Transcript>& prover_trancript)
     {

--- a/barretenberg/cpp/src/barretenberg/commitment_schemes/kzg/kzg.test.cpp
+++ b/barretenberg/cpp/src/barretenberg/commitment_schemes/kzg/kzg.test.cpp
@@ -25,7 +25,7 @@ class KZGTest : public CommitmentTest<Curve> {
 
     using CK = CommitmentKey<Curve>;
     using VK = VerifierCommitmentKey<Curve>;
-    static std::shared_ptr<CK> ck;
+    static CK ck;
     static std::shared_ptr<VK> vk;
 
     static constexpr Commitment g1_identity = Commitment::one();
@@ -41,7 +41,7 @@ TEST_F(KZGTest, single)
 {
 
     auto witness = bb::Polynomial<Fr>::random(n);
-    const Commitment commitment = ck->commit(witness);
+    const Commitment commitment = ck.commit(witness);
 
     const Fr challenge = Fr::random_element();
     const Fr evaluation = witness.evaluate(challenge);
@@ -74,7 +74,7 @@ TEST_F(KZGTest, SingleInLagrangeBasis)
     // compute the monomial coefficients
     bb::Polynomial<Fr> witness_polynomial(std::span<Fr>(eval_points), std::span<Fr>(witness), n);
     // commit to the polynomial in the monomial form
-    g1::element commitment = ck->commit(witness_polynomial);
+    g1::element commitment = ck.commit(witness_polynomial);
 
     const Fr challenge = Fr::random_element();
     // evaluate the original univariate
@@ -331,5 +331,5 @@ TEST_F(KZGTest, ShpleminiKzgShiftsRemoval)
 }
 
 } // namespace bb
-std::shared_ptr<typename bb::KZGTest::CK> bb::KZGTest::ck = nullptr;
+typename bb::KZGTest::CK bb::KZGTest::ck;
 std::shared_ptr<typename bb::KZGTest::VK> bb::KZGTest::vk = nullptr;

--- a/barretenberg/cpp/src/barretenberg/commitment_schemes/shplonk/shplemini.hpp
+++ b/barretenberg/cpp/src/barretenberg/commitment_schemes/shplonk/shplemini.hpp
@@ -35,7 +35,7 @@ template <typename Curve> class ShpleminiProver_ {
     static OpeningClaim prove(const FF circuit_size,
                               PolynomialBatcher& polynomial_batcher,
                               std::span<FF> multilinear_challenge,
-                              CommitmentKey<Curve>& commitment_key,
+                              const CommitmentKey<Curve>& commitment_key,
                               const std::shared_ptr<Transcript>& transcript,
                               const std::array<Polynomial, NUM_SMALL_IPA_EVALUATIONS>& libra_polynomials = {},
                               const std::vector<Polynomial>& sumcheck_round_univariates = {},

--- a/barretenberg/cpp/src/barretenberg/commitment_schemes/shplonk/shplemini.hpp
+++ b/barretenberg/cpp/src/barretenberg/commitment_schemes/shplonk/shplemini.hpp
@@ -35,7 +35,7 @@ template <typename Curve> class ShpleminiProver_ {
     static OpeningClaim prove(const FF circuit_size,
                               PolynomialBatcher& polynomial_batcher,
                               std::span<FF> multilinear_challenge,
-                              const std::shared_ptr<CommitmentKey<Curve>>& commitment_key,
+                              CommitmentKey<Curve>& commitment_key,
                               const std::shared_ptr<Transcript>& transcript,
                               const std::array<Polynomial, NUM_SMALL_IPA_EVALUATIONS>& libra_polynomials = {},
                               const std::vector<Polynomial>& sumcheck_round_univariates = {},

--- a/barretenberg/cpp/src/barretenberg/commitment_schemes/shplonk/shplemini.test.cpp
+++ b/barretenberg/cpp/src/barretenberg/commitment_schemes/shplonk/shplemini.test.cpp
@@ -51,7 +51,7 @@ TYPED_TEST(ShpleminiTest, CorrectnessOfMultivariateClaimBatching)
     using Commitment = typename Curve::AffineElement;
     using CK = typename TypeParam::CommitmentKey;
 
-    std::shared_ptr<CK> ck = create_commitment_key<CK>(this->n);
+    CK ck = create_commitment_key<CK>(this->n);
 
     // Generate mock challenges
     Fr rho = Fr::random_element();
@@ -160,7 +160,7 @@ TYPED_TEST(ShpleminiTest, CorrectnessOfGeminiClaimBatching)
     using Polynomial = typename bb::Polynomial<Fr>;
     using CK = typename TypeParam::CommitmentKey;
 
-    std::shared_ptr<CK> ck = create_commitment_key<CK>(this->n);
+    CK ck = create_commitment_key<CK>(this->n);
 
     // Generate mock challenges
     Fr rho = Fr::random_element();
@@ -194,7 +194,7 @@ TYPED_TEST(ShpleminiTest, CorrectnessOfGeminiClaimBatching)
 
     std::vector<Commitment> prover_commitments;
     for (size_t l = 0; l < this->log_n - 1; ++l) {
-        auto commitment = ck->commit(fold_polynomials[l]);
+        auto commitment = ck.commit(fold_polynomials[l]);
         prover_commitments.emplace_back(commitment);
     }
 
@@ -282,7 +282,7 @@ TYPED_TEST(ShpleminiTest, ShpleminiZKNoSumcheckOpenings)
 
     // SmallSubgroupIPAProver requires at least CURVE::SUBGROUP_SIZE + 3 elements in the ck.
     static constexpr size_t log_subgroup_size = static_cast<size_t>(numeric::get_msb(Curve::SUBGROUP_SIZE));
-    std::shared_ptr<CK> ck = create_commitment_key<CK>(std::max<size_t>(this->n, 1ULL << (log_subgroup_size + 1)));
+    CK ck = create_commitment_key<CK>(std::max<size_t>(this->n, 1ULL << (log_subgroup_size + 1)));
 
     // Generate Libra polynomials, compute masked concatenated Libra polynomial, commit to it
     ZKData zk_sumcheck_data(this->log_n, prover_transcript, ck);
@@ -391,7 +391,7 @@ TYPED_TEST(ShpleminiTest, ShpleminiZKWithSumcheckOpenings)
     using ShpleminiProver = ShpleminiProver_<Curve>;
     using ShpleminiVerifier = ShpleminiVerifier_<Curve>;
 
-    std::shared_ptr<CK> ck = create_commitment_key<CK>(4096);
+    CK ck = create_commitment_key<CK>(4096);
 
     // Generate Sumcheck challenge
     std::vector<Fr> challenge = this->random_evaluation_point(this->log_n);

--- a/barretenberg/cpp/src/barretenberg/commitment_schemes/shplonk/shplonk.hpp
+++ b/barretenberg/cpp/src/barretenberg/commitment_schemes/shplonk/shplonk.hpp
@@ -263,7 +263,7 @@ template <typename Curve> class ShplonkProver_ {
      * @return ProverOpeningClaim<Curve>
      */
     template <typename Transcript>
-    static ProverOpeningClaim<Curve> prove(CommitmentKey<Curve>& commitment_key,
+    static ProverOpeningClaim<Curve> prove(const CommitmentKey<Curve>& commitment_key,
                                            std::span<ProverOpeningClaim<Curve>> opening_claims,
                                            const std::shared_ptr<Transcript>& transcript,
                                            std::span<ProverOpeningClaim<Curve>> libra_opening_claims = {},

--- a/barretenberg/cpp/src/barretenberg/commitment_schemes/shplonk/shplonk.hpp
+++ b/barretenberg/cpp/src/barretenberg/commitment_schemes/shplonk/shplonk.hpp
@@ -263,7 +263,7 @@ template <typename Curve> class ShplonkProver_ {
      * @return ProverOpeningClaim<Curve>
      */
     template <typename Transcript>
-    static ProverOpeningClaim<Curve> prove(const std::shared_ptr<CommitmentKey<Curve>>& commitment_key,
+    static ProverOpeningClaim<Curve> prove(CommitmentKey<Curve>& commitment_key,
                                            std::span<ProverOpeningClaim<Curve>> opening_claims,
                                            const std::shared_ptr<Transcript>& transcript,
                                            std::span<ProverOpeningClaim<Curve>> libra_opening_claims = {},
@@ -281,7 +281,7 @@ template <typename Curve> class ShplonkProver_ {
                                                          gemini_fold_pos_evaluations,
                                                          libra_opening_claims,
                                                          sumcheck_round_claims);
-        auto batched_quotient_commitment = commitment_key->commit(batched_quotient);
+        auto batched_quotient_commitment = commitment_key.commit(batched_quotient);
         transcript->send_to_verifier("Shplonk:Q", batched_quotient_commitment);
         const Fr z = transcript->template get_challenge<Fr>("Shplonk:z");
 

--- a/barretenberg/cpp/src/barretenberg/commitment_schemes/small_subgroup_ipa/small_subgroup_ipa.cpp
+++ b/barretenberg/cpp/src/barretenberg/commitment_schemes/small_subgroup_ipa/small_subgroup_ipa.cpp
@@ -28,7 +28,7 @@ namespace bb {
 // Default constructor to initialize all common members.
 template <typename Flavor>
 SmallSubgroupIPAProver<Flavor>::SmallSubgroupIPAProver(const std::shared_ptr<typename Flavor::Transcript>& transcript,
-                                                       std::shared_ptr<typename Flavor::CommitmentKey>& commitment_key)
+                                                       typename Flavor::CommitmentKey& commitment_key)
     : interpolation_domain{}
     , concatenated_polynomial(MASKED_CONCATENATED_WITNESS_LENGTH)
     , concatenated_lagrange_form(SUBGROUP_SIZE)
@@ -42,8 +42,8 @@ SmallSubgroupIPAProver<Flavor>::SmallSubgroupIPAProver(const std::shared_ptr<typ
 {
     // Reallocate the commitment key if necessary. This is an edge case with SmallSubgroupIPA since it has
     // polynomials that may exceed the circuit size.
-    if (commitment_key->dyadic_size < MASKED_GRAND_SUM_LENGTH) {
-        commitment_key = std::make_shared<typename Flavor::CommitmentKey>(MASKED_GRAND_SUM_LENGTH);
+    if (commitment_key.dyadic_size < MASKED_GRAND_SUM_LENGTH) {
+        commitment_key = typename Flavor::CommitmentKey(MASKED_GRAND_SUM_LENGTH);
     };
     this->commitment_key = commitment_key;
 };
@@ -60,7 +60,7 @@ SmallSubgroupIPAProver<Flavor>::SmallSubgroupIPAProver(ZKSumcheckData<Flavor>& z
                                                        const std::vector<FF>& multivariate_challenge,
                                                        const FF claimed_inner_product,
                                                        const std::shared_ptr<typename Flavor::Transcript>& transcript,
-                                                       std::shared_ptr<typename Flavor::CommitmentKey>& commitment_key)
+                                                       typename Flavor::CommitmentKey& commitment_key)
     : SmallSubgroupIPAProver(transcript, commitment_key)
 {
     this->claimed_inner_product = claimed_inner_product;
@@ -94,7 +94,7 @@ SmallSubgroupIPAProver<Flavor>::SmallSubgroupIPAProver(TranslationData<typename 
                                                        const FF evaluation_challenge_x,
                                                        const FF batching_challenge_v,
                                                        const std::shared_ptr<typename Flavor::Transcript>& transcript,
-                                                       std::shared_ptr<typename Flavor::CommitmentKey>& commitment_key)
+                                                       typename Flavor::CommitmentKey& commitment_key)
     : SmallSubgroupIPAProver(transcript, commitment_key)
 
 {
@@ -155,7 +155,7 @@ template <typename Flavor> void SmallSubgroupIPAProver<Flavor>::prove()
 
     // Send masked commitment [A + Z_H * R] to the verifier, where R is of degree 2
     transcript->template send_to_verifier(label_prefix + "grand_sum_commitment",
-                                          commitment_key->commit(grand_sum_polynomial));
+                                          commitment_key.commit(grand_sum_polynomial));
 
     // Compute C(X)
     compute_grand_sum_identity_polynomial();
@@ -165,7 +165,7 @@ template <typename Flavor> void SmallSubgroupIPAProver<Flavor>::prove()
 
     // Send commitment [Q] to the verifier
     transcript->template send_to_verifier(label_prefix + "quotient_commitment",
-                                          commitment_key->commit(grand_sum_identity_quotient));
+                                          commitment_key.commit(grand_sum_identity_quotient));
 }
 
 /**

--- a/barretenberg/cpp/src/barretenberg/commitment_schemes/small_subgroup_ipa/small_subgroup_ipa.cpp
+++ b/barretenberg/cpp/src/barretenberg/commitment_schemes/small_subgroup_ipa/small_subgroup_ipa.cpp
@@ -28,7 +28,7 @@ namespace bb {
 // Default constructor to initialize all common members.
 template <typename Flavor>
 SmallSubgroupIPAProver<Flavor>::SmallSubgroupIPAProver(const std::shared_ptr<typename Flavor::Transcript>& transcript,
-                                                       typename Flavor::CommitmentKey& commitment_key)
+                                                       typename Flavor::CommitmentKey commitment_key)
     : interpolation_domain{}
     , concatenated_polynomial(MASKED_CONCATENATED_WITNESS_LENGTH)
     , concatenated_lagrange_form(SUBGROUP_SIZE)
@@ -60,7 +60,7 @@ SmallSubgroupIPAProver<Flavor>::SmallSubgroupIPAProver(ZKSumcheckData<Flavor>& z
                                                        const std::vector<FF>& multivariate_challenge,
                                                        const FF claimed_inner_product,
                                                        const std::shared_ptr<typename Flavor::Transcript>& transcript,
-                                                       typename Flavor::CommitmentKey& commitment_key)
+                                                       const typename Flavor::CommitmentKey& commitment_key)
     : SmallSubgroupIPAProver(transcript, commitment_key)
 {
     this->claimed_inner_product = claimed_inner_product;
@@ -94,7 +94,7 @@ SmallSubgroupIPAProver<Flavor>::SmallSubgroupIPAProver(TranslationData<typename 
                                                        const FF evaluation_challenge_x,
                                                        const FF batching_challenge_v,
                                                        const std::shared_ptr<typename Flavor::Transcript>& transcript,
-                                                       typename Flavor::CommitmentKey& commitment_key)
+                                                       const typename Flavor::CommitmentKey& commitment_key)
     : SmallSubgroupIPAProver(transcript, commitment_key)
 
 {

--- a/barretenberg/cpp/src/barretenberg/commitment_schemes/small_subgroup_ipa/small_subgroup_ipa.hpp
+++ b/barretenberg/cpp/src/barretenberg/commitment_schemes/small_subgroup_ipa/small_subgroup_ipa.hpp
@@ -132,21 +132,21 @@ template <typename Flavor> class SmallSubgroupIPAProver {
 
     // Default constructor to initialize all polynomials, transcript, and commitment key.
     SmallSubgroupIPAProver(const std::shared_ptr<typename Flavor::Transcript>& transcript,
-                           typename Flavor::CommitmentKey& commitment_key);
+                           typename Flavor::CommitmentKey commitment_key);
 
     // Construct prover from ZKSumcheckData. Used by all ZK Provers.
     SmallSubgroupIPAProver(ZKSumcheckData<Flavor>& zk_sumcheck_data,
                            const std::vector<FF>& multivariate_challenge,
                            const FF claimed_inner_product,
                            const std::shared_ptr<typename Flavor::Transcript>& transcript,
-                           typename Flavor::CommitmentKey& commitment_key);
+                           const typename Flavor::CommitmentKey& commitment_key);
 
     // Construct prover from TranslationData. Used by ECCVMProver.
     SmallSubgroupIPAProver(TranslationData<typename Flavor::Transcript>& translation_data,
                            const FF evaluation_challenge_x,
                            const FF batching_challenge_v,
                            const std::shared_ptr<typename Flavor::Transcript>& transcript,
-                           typename Flavor::CommitmentKey& commitment_key);
+                           const typename Flavor::CommitmentKey& commitment_key);
 
     void prove();
 

--- a/barretenberg/cpp/src/barretenberg/commitment_schemes/small_subgroup_ipa/small_subgroup_ipa.hpp
+++ b/barretenberg/cpp/src/barretenberg/commitment_schemes/small_subgroup_ipa/small_subgroup_ipa.hpp
@@ -124,7 +124,7 @@ template <typename Flavor> class SmallSubgroupIPAProver {
     std::string label_prefix;
 
     std::shared_ptr<typename Flavor::Transcript> transcript;
-    std::shared_ptr<typename Flavor::CommitmentKey> commitment_key;
+    typename Flavor::CommitmentKey commitment_key;
 
   public:
     // The SmallSubgroupIPA claim
@@ -132,21 +132,21 @@ template <typename Flavor> class SmallSubgroupIPAProver {
 
     // Default constructor to initialize all polynomials, transcript, and commitment key.
     SmallSubgroupIPAProver(const std::shared_ptr<typename Flavor::Transcript>& transcript,
-                           std::shared_ptr<typename Flavor::CommitmentKey>& commitment_key);
+                           typename Flavor::CommitmentKey& commitment_key);
 
     // Construct prover from ZKSumcheckData. Used by all ZK Provers.
     SmallSubgroupIPAProver(ZKSumcheckData<Flavor>& zk_sumcheck_data,
                            const std::vector<FF>& multivariate_challenge,
                            const FF claimed_inner_product,
                            const std::shared_ptr<typename Flavor::Transcript>& transcript,
-                           std::shared_ptr<typename Flavor::CommitmentKey>& commitment_key);
+                           typename Flavor::CommitmentKey& commitment_key);
 
     // Construct prover from TranslationData. Used by ECCVMProver.
     SmallSubgroupIPAProver(TranslationData<typename Flavor::Transcript>& translation_data,
                            const FF evaluation_challenge_x,
                            const FF batching_challenge_v,
                            const std::shared_ptr<typename Flavor::Transcript>& transcript,
-                           std::shared_ptr<typename Flavor::CommitmentKey>& commitment_key);
+                           typename Flavor::CommitmentKey& commitment_key);
 
     void prove();
 

--- a/barretenberg/cpp/src/barretenberg/commitment_schemes/small_subgroup_ipa/small_subgroup_ipa.test.cpp
+++ b/barretenberg/cpp/src/barretenberg/commitment_schemes/small_subgroup_ipa/small_subgroup_ipa.test.cpp
@@ -60,8 +60,7 @@ TYPED_TEST(SmallSubgroupIPATest, ProverComputationsCorrectness)
 
     // SmallSubgroupIPAProver requires at least CURVE::SUBGROUP_SIZE + 3 elements in the ck.
     static constexpr size_t log_subgroup_size = static_cast<size_t>(numeric::get_msb(SUBGROUP_SIZE));
-    std::shared_ptr<CK> ck =
-        create_commitment_key<CK>(std::max<size_t>(this->circuit_size, 1ULL << (log_subgroup_size + 1)));
+    CK ck = create_commitment_key<CK>(std::max<size_t>(this->circuit_size, 1ULL << (log_subgroup_size + 1)));
 
     auto prover_transcript = TypeParam::Transcript::prover_init_empty();
 
@@ -184,8 +183,7 @@ TYPED_TEST(SmallSubgroupIPATest, LibraEvaluationsConsistency)
 
     // SmallSubgroupIPAProver requires at least CURVE::SUBGROUP_SIZE + 3 elements in the ck.
     static constexpr size_t log_subgroup_size = static_cast<size_t>(numeric::get_msb(Curve::SUBGROUP_SIZE));
-    std::shared_ptr<CK> ck =
-        create_commitment_key<CK>(std::max<size_t>(this->circuit_size, 1ULL << (log_subgroup_size + 1)));
+    CK ck = create_commitment_key<CK>(std::max<size_t>(this->circuit_size, 1ULL << (log_subgroup_size + 1)));
 
     ZKData zk_sumcheck_data(this->log_circuit_size, prover_transcript, ck);
 
@@ -222,8 +220,7 @@ TYPED_TEST(SmallSubgroupIPATest, LibraEvaluationsConsistencyFailure)
 
     // SmallSubgroupIPAProver requires at least CURVE::SUBGROUP_SIZE + 3 elements in the ck.
     static constexpr size_t log_subgroup_size = static_cast<size_t>(numeric::get_msb(Curve::SUBGROUP_SIZE));
-    std::shared_ptr<CK> ck =
-        create_commitment_key<CK>(std::max<size_t>(this->circuit_size, 1ULL << (log_subgroup_size + 1)));
+    CK ck = create_commitment_key<CK>(std::max<size_t>(this->circuit_size, 1ULL << (log_subgroup_size + 1)));
 
     ZKData zk_sumcheck_data(this->log_circuit_size, prover_transcript, ck);
 
@@ -273,8 +270,7 @@ TYPED_TEST(SmallSubgroupIPATest, TranslationMaskingTermConsistency)
 
         // SmallSubgroupIPAProver requires at least CURVE::SUBGROUP_SIZE + 3 elements in the ck.
         static constexpr size_t log_subgroup_size = static_cast<size_t>(numeric::get_msb(Curve::SUBGROUP_SIZE));
-        std::shared_ptr<CK> ck =
-            create_commitment_key<CK>(std::max<size_t>(this->circuit_size, 1ULL << (log_subgroup_size + 1)));
+        CK ck = create_commitment_key<CK>(std::max<size_t>(this->circuit_size, 1ULL << (log_subgroup_size + 1)));
 
         // Generate transcript polynomials
         std::vector<Polynomial<FF>> transcript_polynomials;
@@ -326,8 +322,7 @@ TYPED_TEST(SmallSubgroupIPATest, TranslationMaskingTermConsistencyFailure)
 
         // SmallSubgroupIPAProver requires at least CURVE::SUBGROUP_SIZE + 3 elements in the ck.
         static constexpr size_t log_subgroup_size = static_cast<size_t>(numeric::get_msb(Curve::SUBGROUP_SIZE));
-        std::shared_ptr<CK> ck =
-            create_commitment_key<CK>(std::max<size_t>(this->circuit_size, 1ULL << (log_subgroup_size + 1)));
+        CK ck = create_commitment_key<CK>(std::max<size_t>(this->circuit_size, 1ULL << (log_subgroup_size + 1)));
 
         // Generate transcript polynomials
         std::vector<Polynomial<FF>> transcript_polynomials;

--- a/barretenberg/cpp/src/barretenberg/commitment_schemes/sparse_commitment.test.cpp
+++ b/barretenberg/cpp/src/barretenberg/commitment_schemes/sparse_commitment.test.cpp
@@ -20,7 +20,7 @@ template <typename Curve> class CommitmentKeyTest : public ::testing::Test {
     };
 
   public:
-    template <class CK> inline std::shared_ptr<CK> create_commitment_key(size_t num_points);
+    template <class CK> CK create_commitment_key(size_t num_points);
 
     // Construct a random poly with the prescribed block structure; complement is zero/constant if non_zero_complement =
     // false/true (to mimic wire/z_perm)
@@ -74,20 +74,20 @@ template <typename Curve> class CommitmentKeyTest : public ::testing::Test {
 
 template <>
 template <>
-std::shared_ptr<CommitmentKey<curve::BN254>> CommitmentKeyTest<curve::BN254>::create_commitment_key<
-    CommitmentKey<curve::BN254>>(const size_t num_points)
+CommitmentKey<curve::BN254> CommitmentKeyTest<curve::BN254>::create_commitment_key<CommitmentKey<curve::BN254>>(
+    const size_t num_points)
 {
     bb::srs::init_file_crs_factory(bb::srs::bb_crs_path());
-    return std::make_shared<CommitmentKey<curve::BN254>>(num_points);
+    return CommitmentKey<curve::BN254>(num_points);
 }
 
 template <>
 template <>
-std::shared_ptr<CommitmentKey<curve::Grumpkin>> CommitmentKeyTest<curve::Grumpkin>::create_commitment_key<
+CommitmentKey<curve::Grumpkin> CommitmentKeyTest<curve::Grumpkin>::create_commitment_key<
     CommitmentKey<curve::Grumpkin>>(const size_t num_points)
 {
     srs::init_file_crs_factory(bb::srs::bb_crs_path());
-    return std::make_shared<CommitmentKey<curve::Grumpkin>>(num_points);
+    return CommitmentKey<curve::Grumpkin>(num_points);
 }
 
 using Curves = ::testing::Types<curve::BN254, curve::Grumpkin>;
@@ -115,9 +115,9 @@ TYPED_TEST(CommitmentKeyTest, CommitFull)
 
     // Commit to the polynomial and the same polynomial but full
     auto key = TestFixture::template create_commitment_key<CK>(num_points);
-    G1 commit_result = key->commit(poly);
+    G1 commit_result = key.commit(poly);
     auto full_poly = poly.full();
-    G1 full_commit_result = key->commit(full_poly);
+    G1 full_commit_result = key.commit(full_poly);
 
     EXPECT_EQ(commit_result, full_commit_result);
 }
@@ -143,9 +143,9 @@ TYPED_TEST(CommitmentKeyTest, CommitFullMedium)
 
     // Commit to the polynomial and the same polynomial but full
     auto key = TestFixture::template create_commitment_key<CK>(num_points);
-    G1 commit_result = key->commit(poly);
+    G1 commit_result = key.commit(poly);
     auto full_poly = poly.full();
-    G1 full_commit_result = key->commit(full_poly);
+    G1 full_commit_result = key.commit(full_poly);
 
     EXPECT_EQ(commit_result, full_commit_result);
 }
@@ -171,9 +171,9 @@ TYPED_TEST(CommitmentKeyTest, CommitSRSCheck)
 
     // Commit to the polynomial and the same polynomial but full
     auto key = TestFixture::template create_commitment_key<CK>(num_points);
-    G1 commit_result = key->commit(poly);
+    G1 commit_result = key.commit(poly);
     auto full_poly = poly.full();
-    G1 full_commit_result = key->commit(full_poly);
+    G1 full_commit_result = key.commit(full_poly);
 
     EXPECT_EQ(commit_result, full_commit_result);
 }
@@ -199,8 +199,8 @@ TYPED_TEST(CommitmentKeyTest, CommitSparse)
 
     // Commit to the polynomial using both the conventional commit method and the sparse commitment method
     auto key = TestFixture::template create_commitment_key<CK>(num_points);
-    G1 commit_result = key->commit(poly);
-    G1 sparse_commit_result = key->commit_sparse(poly);
+    G1 commit_result = key.commit(poly);
+    G1 sparse_commit_result = key.commit_sparse(poly);
 
     EXPECT_EQ(sparse_commit_result, commit_result);
 }
@@ -228,8 +228,8 @@ TYPED_TEST(CommitmentKeyTest, CommitSparseSmallSize)
 
     // Commit to the polynomial using both the conventional commit method and the sparse commitment method
     auto key = TestFixture::template create_commitment_key<CK>(num_points);
-    G1 commit_result = key->commit(poly);
-    G1 sparse_commit_result = key->commit_sparse(poly);
+    G1 commit_result = key.commit(poly);
+    G1 sparse_commit_result = key.commit_sparse(poly);
 
     EXPECT_EQ(sparse_commit_result, commit_result);
 }
@@ -258,8 +258,8 @@ TYPED_TEST(CommitmentKeyTest, CommitSparseNonZeroStartIndex)
 
     // Commit to the polynomial using both the conventional commit method and the sparse commitment method
     auto key = TestFixture::template create_commitment_key<CK>(num_points);
-    G1 commit_result = key->commit(poly);
-    G1 sparse_commit_result = key->commit_sparse(poly);
+    G1 commit_result = key.commit(poly);
+    G1 sparse_commit_result = key.commit_sparse(poly);
 
     EXPECT_EQ(sparse_commit_result, commit_result);
 }
@@ -289,8 +289,8 @@ TYPED_TEST(CommitmentKeyTest, CommitSparseMediumNonZeroStartIndex)
 
     // Commit to the polynomial using both the conventional commit method and the sparse commitment method
     auto key = TestFixture::template create_commitment_key<CK>(num_points);
-    G1 commit_result = key->commit(poly);
-    G1 sparse_commit_result = key->commit_sparse(poly);
+    G1 commit_result = key.commit(poly);
+    G1 sparse_commit_result = key.commit_sparse(poly);
 
     EXPECT_EQ(sparse_commit_result, commit_result);
 }
@@ -322,9 +322,9 @@ TYPED_TEST(CommitmentKeyTest, CommitStructuredWire)
     auto key = TestFixture::template create_commitment_key<CK>(polynomial.virtual_size());
 
     auto full_poly = polynomial.full();
-    G1 actual_expected_result = key->commit(full_poly);
-    G1 expected_result = key->commit(polynomial);
-    G1 result = key->commit_structured(polynomial, active_range_endpoints);
+    G1 actual_expected_result = key.commit(full_poly);
+    G1 expected_result = key.commit(polynomial);
+    G1 result = key.commit_structured(polynomial, active_range_endpoints);
     EXPECT_EQ(actual_expected_result, expected_result);
     EXPECT_EQ(result, expected_result);
 }
@@ -358,9 +358,9 @@ TYPED_TEST(CommitmentKeyTest, CommitStructuredMaskedWire)
     auto key = TestFixture::template create_commitment_key<CK>(polynomial.virtual_size());
 
     auto full_poly = polynomial.full();
-    G1 actual_expected_result = key->commit(full_poly);
-    G1 expected_result = key->commit(polynomial);
-    G1 result = key->commit_structured(polynomial, active_range_endpoints);
+    G1 actual_expected_result = key.commit(full_poly);
+    G1 expected_result = key.commit(polynomial);
+    G1 result = key.commit_structured(polynomial, active_range_endpoints);
     EXPECT_EQ(actual_expected_result, expected_result);
     EXPECT_EQ(result, expected_result);
 }
@@ -392,8 +392,8 @@ TYPED_TEST(CommitmentKeyTest, CommitStructuredNonzeroComplement)
     // Commit to the polynomial using both the conventional commit method and the sparse commitment method
     auto key = TestFixture::template create_commitment_key<CK>(polynomial.virtual_size());
 
-    G1 expected_result = key->commit(polynomial);
-    G1 result = key->commit_structured_with_nonzero_complement(polynomial, active_range_endpoints);
+    G1 expected_result = key.commit(polynomial);
+    G1 result = key.commit_structured_with_nonzero_complement(polynomial, active_range_endpoints);
 
     EXPECT_EQ(result, expected_result);
 }

--- a/barretenberg/cpp/src/barretenberg/commitment_schemes/utils/mock_witness_generator.hpp
+++ b/barretenberg/cpp/src/barretenberg/commitment_schemes/utils/mock_witness_generator.hpp
@@ -79,7 +79,7 @@ template <typename Curve> struct MockClaimGenerator {
                        const size_t num_to_be_shifted,
                        const size_t num_to_be_right_shifted_by_k,
                        const std::vector<Fr>& mle_opening_point,
-                       CommitmentKey& commitment_key,
+                       const CommitmentKey& commitment_key,
                        size_t num_interleaved = 0,
                        size_t num_to_be_interleaved = 0)
 
@@ -166,7 +166,7 @@ template <typename Curve> struct MockClaimGenerator {
     InterleaveData generate_interleaving_inputs(const std::vector<Fr>& u_challenge,
                                                 const size_t num_interleaved,
                                                 const size_t group_size,
-                                                CommitmentKey& ck)
+                                                const CommitmentKey& ck)
     {
 
         size_t N = 1 << u_challenge.size();
@@ -225,7 +225,7 @@ template <typename Curve> struct MockClaimGenerator {
     void compute_sumcheck_opening_data(const size_t log_n,
                                        const size_t sumcheck_univariate_length,
                                        std::vector<Fr>& challenge,
-                                       CommitmentKey& ck)
+                                       const CommitmentKey& ck)
     {
         // Generate valid sumcheck polynomials of given length
         auto mock_sumcheck_polynomials = ZKSumcheckData<Flavor>(log_n, sumcheck_univariate_length);

--- a/barretenberg/cpp/src/barretenberg/commitment_schemes/utils/mock_witness_generator.hpp
+++ b/barretenberg/cpp/src/barretenberg/commitment_schemes/utils/mock_witness_generator.hpp
@@ -31,7 +31,7 @@ template <typename Curve> struct MockClaimGenerator {
     using ClaimBatch = ClaimBatcher::Batch;
     using InterleavedBatch = ClaimBatcher::InterleavedBatch;
 
-    std::shared_ptr<CommitmentKey> ck;
+    CommitmentKey ck;
 
     struct ClaimData {
         std::vector<Polynomial> polys;
@@ -79,7 +79,7 @@ template <typename Curve> struct MockClaimGenerator {
                        const size_t num_to_be_shifted,
                        const size_t num_to_be_right_shifted_by_k,
                        const std::vector<Fr>& mle_opening_point,
-                       std::shared_ptr<CommitmentKey>& commitment_key,
+                       CommitmentKey& commitment_key,
                        size_t num_interleaved = 0,
                        size_t num_to_be_interleaved = 0)
 
@@ -94,7 +94,7 @@ template <typename Curve> struct MockClaimGenerator {
         // Construct claim data for polynomials that are NOT to be shifted
         for (size_t idx = 0; idx < num_not_to_be_shifted; idx++) {
             Polynomial poly = Polynomial::random(poly_size);
-            unshifted.commitments.push_back(ck->commit(poly));
+            unshifted.commitments.push_back(ck.commit(poly));
             unshifted.evals.push_back(poly.evaluate_mle(mle_opening_point));
             unshifted.polys.push_back(std::move(poly));
         }
@@ -102,7 +102,7 @@ template <typename Curve> struct MockClaimGenerator {
         // Construct claim data for polynomials that are to-be-shifted
         for (size_t idx = 0; idx < num_to_be_shifted; idx++) {
             Polynomial poly = Polynomial::random(poly_size, /*shiftable*/ 1);
-            Commitment commitment = ck->commit(poly);
+            Commitment commitment = ck.commit(poly);
             to_be_shifted.commitments.push_back(commitment);
             to_be_shifted.evals.push_back(poly.shifted().evaluate_mle(mle_opening_point));
             to_be_shifted.polys.push_back(poly.share());
@@ -115,7 +115,7 @@ template <typename Curve> struct MockClaimGenerator {
         // Construct claim data for polynomials that are to-be-right-shifted-by-k
         for (size_t idx = 0; idx < num_to_be_right_shifted_by_k; idx++) {
             Polynomial poly = Polynomial::random(poly_size - k_magnitude, poly_size, 0);
-            Commitment commitment = ck->commit(poly);
+            Commitment commitment = ck.commit(poly);
             to_be_right_shifted_by_k.commitments.push_back(commitment);
             to_be_right_shifted_by_k.evals.push_back(poly.right_shifted(k_magnitude).evaluate_mle(mle_opening_point));
             to_be_right_shifted_by_k.polys.push_back(poly.share());
@@ -166,7 +166,7 @@ template <typename Curve> struct MockClaimGenerator {
     InterleaveData generate_interleaving_inputs(const std::vector<Fr>& u_challenge,
                                                 const size_t num_interleaved,
                                                 const size_t group_size,
-                                                const std::shared_ptr<CommitmentKey>& ck)
+                                                CommitmentKey& ck)
     {
 
         size_t N = 1 << u_challenge.size();
@@ -213,7 +213,7 @@ template <typename Curve> struct MockClaimGenerator {
         for (size_t i = 0; i < num_interleaved; ++i) {
             std::vector<Commitment> group_commitment;
             for (size_t j = 0; j < group_size; j++) {
-                group_commitment.emplace_back(ck->commit(groups[i][j]));
+                group_commitment.emplace_back(ck.commit(groups[i][j]));
             }
             groups_commitments.emplace_back(group_commitment);
         }
@@ -225,7 +225,7 @@ template <typename Curve> struct MockClaimGenerator {
     void compute_sumcheck_opening_data(const size_t log_n,
                                        const size_t sumcheck_univariate_length,
                                        std::vector<Fr>& challenge,
-                                       std::shared_ptr<CommitmentKey>& ck)
+                                       CommitmentKey& ck)
     {
         // Generate valid sumcheck polynomials of given length
         auto mock_sumcheck_polynomials = ZKSumcheckData<Flavor>(log_n, sumcheck_univariate_length);
@@ -235,7 +235,7 @@ template <typename Curve> struct MockClaimGenerator {
 
             round_univariate.at(0) += mock_sumcheck_polynomials.libra_running_sum;
 
-            sumcheck_commitments.push_back(ck->commit(round_univariate));
+            sumcheck_commitments.push_back(ck.commit(round_univariate));
 
             sumcheck_evaluations.push_back({ round_univariate.at(0),
                                              round_univariate.evaluate(Fr(1)),

--- a/barretenberg/cpp/src/barretenberg/commitment_schemes/utils/test_utils.hpp
+++ b/barretenberg/cpp/src/barretenberg/commitment_schemes/utils/test_utils.hpp
@@ -21,7 +21,7 @@ static std::tuple<std::vector<std::vector<bb::Polynomial<typename Curve::ScalarF
 generate_concatenation_inputs(const std::vector<typename Curve::ScalarField>& u_challenge,
                               const size_t num_concatenated,
                               const size_t group_size,
-                              CommitmentKey<Curve>& ck)
+                              const CommitmentKey<Curve>& ck)
 {
     using Fr = typename Curve::ScalarField;
     using Commitment = typename Curve::AffineElement;

--- a/barretenberg/cpp/src/barretenberg/commitment_schemes/utils/test_utils.hpp
+++ b/barretenberg/cpp/src/barretenberg/commitment_schemes/utils/test_utils.hpp
@@ -21,7 +21,7 @@ static std::tuple<std::vector<std::vector<bb::Polynomial<typename Curve::ScalarF
 generate_concatenation_inputs(const std::vector<typename Curve::ScalarField>& u_challenge,
                               const size_t num_concatenated,
                               const size_t group_size,
-                              const std::shared_ptr<CommitmentKey<Curve>>& ck)
+                              CommitmentKey<Curve>& ck)
 {
     using Fr = typename Curve::ScalarField;
     using Commitment = typename Curve::AffineElement;
@@ -71,7 +71,7 @@ generate_concatenation_inputs(const std::vector<typename Curve::ScalarField>& u_
     for (size_t i = 0; i < num_concatenated; ++i) {
         std::vector<Commitment> concatenation_group_commitment;
         for (size_t j = 0; j < group_size; j++) {
-            concatenation_group_commitment.emplace_back(ck->commit(concatenation_groups[i][j]));
+            concatenation_group_commitment.emplace_back(ck.commit(concatenation_groups[i][j]));
         }
         concatenation_groups_commitments.emplace_back(concatenation_group_commitment);
     }

--- a/barretenberg/cpp/src/barretenberg/commitment_schemes_recursion/shplemini.test.cpp
+++ b/barretenberg/cpp/src/barretenberg/commitment_schemes_recursion/shplemini.test.cpp
@@ -55,7 +55,7 @@ TEST(ShpleminiRecursionTest, ProveAndVerifySingle)
         constexpr size_t NUM_SHIFTED = 2;
         constexpr size_t NUM_RIGHT_SHIFTED_BY_K = 1;
 
-        auto commitment_key = std::make_shared<CommitmentKey>(16384);
+        CommitmentKey commitment_key(16384);
 
         std::vector<NativeFr> u_challenge;
         u_challenge.reserve(CONST_PROOF_SIZE_LOG_N);

--- a/barretenberg/cpp/src/barretenberg/dsl/acir_format/acir_format.cpp
+++ b/barretenberg/cpp/src/barretenberg/dsl/acir_format/acir_format.cpp
@@ -351,7 +351,7 @@ void handle_IPA_accumulation(Builder& builder,
     }
     if (nested_ipa_claims.size() == 2) {
         // If we have two claims, accumulate.
-        auto commitment_key = CommitmentKey<curve::Grumpkin>(1 << CONST_ECCVM_LOG_N);
+        CommitmentKey<curve::Grumpkin> commitment_key(1 << CONST_ECCVM_LOG_N);
         using StdlibTranscript = bb::stdlib::recursion::honk::UltraStdlibTranscript;
 
         auto ipa_transcript_1 = std::make_shared<StdlibTranscript>(nested_ipa_proofs[0]);

--- a/barretenberg/cpp/src/barretenberg/dsl/acir_format/acir_format.cpp
+++ b/barretenberg/cpp/src/barretenberg/dsl/acir_format/acir_format.cpp
@@ -351,7 +351,7 @@ void handle_IPA_accumulation(Builder& builder,
     }
     if (nested_ipa_claims.size() == 2) {
         // If we have two claims, accumulate.
-        auto commitment_key = std::make_shared<CommitmentKey<curve::Grumpkin>>(1 << CONST_ECCVM_LOG_N);
+        auto commitment_key = CommitmentKey<curve::Grumpkin>(1 << CONST_ECCVM_LOG_N);
         using StdlibTranscript = bb::stdlib::recursion::honk::UltraStdlibTranscript;
 
         auto ipa_transcript_1 = std::make_shared<StdlibTranscript>(nested_ipa_proofs[0]);

--- a/barretenberg/cpp/src/barretenberg/ecc/scalar_multiplication/runtime_states.hpp
+++ b/barretenberg/cpp/src/barretenberg/ecc/scalar_multiplication/runtime_states.hpp
@@ -161,5 +161,6 @@ template <typename Curve> class PippengerReference {
         : reference(get_singleton(num_initial_points))
     {}
     pippenger_runtime_state<Curve>& get() const { return *reference; }
+    bool initialized() const { return reference != nullptr; }
 };
 } // namespace bb::scalar_multiplication

--- a/barretenberg/cpp/src/barretenberg/ecc/scalar_multiplication/runtime_states.hpp
+++ b/barretenberg/cpp/src/barretenberg/ecc/scalar_multiplication/runtime_states.hpp
@@ -155,6 +155,8 @@ template <typename Curve> class PippengerReference {
     }
 
   public:
+    PippengerReference() = default;
+
     PippengerReference(size_t num_initial_points)
         : reference(get_singleton(num_initial_points))
     {}

--- a/barretenberg/cpp/src/barretenberg/eccvm/eccvm_flavor.hpp
+++ b/barretenberg/cpp/src/barretenberg/eccvm/eccvm_flavor.hpp
@@ -785,7 +785,7 @@ class ECCVMFlavor {
 
             for (auto [polynomial, commitment] :
                  zip_view(proving_key->polynomials.get_precomputed(), this->get_all())) {
-                commitment = proving_key->commitment_key->commit(polynomial);
+                commitment = proving_key->commitment_key.commit(polynomial);
             }
         }
         // TODO(https://github.com/AztecProtocol/barretenberg/issues/1324): Remove `circuit_size` and `log_circuit_size`

--- a/barretenberg/cpp/src/barretenberg/eccvm/eccvm_prover.cpp
+++ b/barretenberg/cpp/src/barretenberg/eccvm/eccvm_prover.cpp
@@ -32,7 +32,7 @@ ECCVMProver::ECCVMProver(CircuitBuilder& builder,
     // Construct the proving key; populates all polynomials except for witness polys
     key = std::make_shared<ProvingKey>(builder);
 
-    key->commitment_key = std::make_shared<CommitmentKey>(key->circuit_size);
+    key->commitment_key = CommitmentKey(key->circuit_size);
 }
 
 /**
@@ -319,6 +319,6 @@ void ECCVMProver::commit_to_witness_polynomial(Polynomial& polynomial,
     // We add NUM_DISABLED_ROWS_IN_SUMCHECK-1 random values to the coefficients of each wire polynomial to not leak
     // information via the commitment and evaluations. -1 is caused by shifts.
     polynomial.mask();
-    transcript->send_to_verifier(label, key->commitment_key->commit_with_type(polynomial, commit_type, active_ranges));
+    transcript->send_to_verifier(label, key->commitment_key.commit_with_type(polynomial, commit_type, active_ranges));
 }
 } // namespace bb

--- a/barretenberg/cpp/src/barretenberg/eccvm/eccvm_translation_data.hpp
+++ b/barretenberg/cpp/src/barretenberg/eccvm/eccvm_translation_data.hpp
@@ -59,14 +59,14 @@ template <typename Transcript> class TranslationData {
      */
     TranslationData(const RefVector<Polynomial>& transcript_polynomials,
                     const std::shared_ptr<Transcript>& transcript,
-                    std::shared_ptr<CommitmentKey>& commitment_key)
+                    CommitmentKey& commitment_key)
         : concatenated_polynomial_lagrange(SUBGROUP_SIZE)
         , masked_concatenated_polynomial(MASKED_CONCATENATED_WITNESS_LENGTH)
     {
         // Reallocate the commitment key if necessary. This is an edge case with SmallSubgroupIPA since it has
         // polynomials that may exceed the circuit size.
-        if (commitment_key->dyadic_size < MASKED_CONCATENATED_WITNESS_LENGTH) {
-            commitment_key = std::make_shared<typename Flavor::CommitmentKey>(MASKED_CONCATENATED_WITNESS_LENGTH);
+        if (commitment_key.dyadic_size < MASKED_CONCATENATED_WITNESS_LENGTH) {
+            commitment_key = typename Flavor::CommitmentKey(MASKED_CONCATENATED_WITNESS_LENGTH);
         }
         // Create interpolation domain required for Lagrange interpolation
         interpolation_domain[0] = FF{ 1 };
@@ -79,7 +79,7 @@ template <typename Transcript> class TranslationData {
 
         // Commit to  M(X) + Z_H(X)*R(X), where R is a random polynomial of WITNESS_MASKING_TERM_LENGTH.
         transcript->template send_to_verifier("Translation:concatenated_masking_term_commitment",
-                                              commitment_key->commit(masked_concatenated_polynomial));
+                                              commitment_key.commit(masked_concatenated_polynomial));
     }
     /**
      * @brief   Let \f$ T = NUM_TRANSLATION_EVALUATIONS \f$ and let \f$ m_0, ..., m_{T-1}\f$ be the vectors of last \f$

--- a/barretenberg/cpp/src/barretenberg/flavor/flavor.hpp
+++ b/barretenberg/cpp/src/barretenberg/flavor/flavor.hpp
@@ -132,7 +132,7 @@ template <typename FF, typename CommitmentKey_> class ProvingKey_ {
     size_t circuit_size;
     PublicComponentKey pairing_inputs_public_input_key;
     bb::EvaluationDomain<FF> evaluation_domain;
-    std::shared_ptr<CommitmentKey_> commitment_key;
+    CommitmentKey_ commitment_key;
     size_t num_public_inputs;
     size_t log_circuit_size;
 
@@ -148,7 +148,7 @@ template <typename FF, typename CommitmentKey_> class ProvingKey_ {
     ProvingKey_() = default;
     ProvingKey_(const size_t dyadic_circuit_size,
                 const size_t num_public_inputs = 0,
-                std::shared_ptr<CommitmentKey_> commitment_key = nullptr)
+                CommitmentKey_ commitment_key = CommitmentKey_())
         : circuit_size(dyadic_circuit_size)
         , evaluation_domain(bb::EvaluationDomain<FF>(dyadic_circuit_size, dyadic_circuit_size))
         , commitment_key(commitment_key)

--- a/barretenberg/cpp/src/barretenberg/goblin/goblin.cpp
+++ b/barretenberg/cpp/src/barretenberg/goblin/goblin.cpp
@@ -5,17 +5,18 @@
 // =====================
 
 #include "goblin.hpp"
+
 #include "barretenberg/eccvm/eccvm_verifier.hpp"
 #include "barretenberg/translator_vm/translator_prover.hpp"
 #include "barretenberg/translator_vm/translator_proving_key.hpp"
 #include "barretenberg/translator_vm/translator_verifier.hpp"
 #include "barretenberg/ultra_honk/merge_verifier.hpp"
+#include <utility>
 
 namespace bb {
 
-Goblin::Goblin(const std::shared_ptr<CommitmentKey<curve::BN254>>& bn254_commitment_key,
-               const std::shared_ptr<Transcript>& transcript)
-    : commitment_key(bn254_commitment_key)
+Goblin::Goblin(CommitmentKey<curve::BN254> bn254_commitment_key, const std::shared_ptr<Transcript>& transcript)
+    : commitment_key(std::move(bn254_commitment_key))
     , transcript(transcript)
 {}
 

--- a/barretenberg/cpp/src/barretenberg/goblin/goblin.hpp
+++ b/barretenberg/cpp/src/barretenberg/goblin/goblin.hpp
@@ -38,7 +38,7 @@ class Goblin {
     using PairingPoints = MergeRecursiveVerifier::PairingPoints;
 
     std::shared_ptr<OpQueue> op_queue = std::make_shared<OpQueue>();
-    std::shared_ptr<CommitmentKey<curve::BN254>> commitment_key;
+    CommitmentKey<curve::BN254> commitment_key;
 
     GoblinProof goblin_proof;
 
@@ -54,7 +54,7 @@ class Goblin {
             std::make_shared<TranslatorVerificationKey>();
     };
 
-    Goblin(const std::shared_ptr<CommitmentKey<curve::BN254>>& bn254_commitment_key = nullptr,
+    Goblin(CommitmentKey<curve::BN254> bn254_commitment_key = CommitmentKey<curve::BN254>(),
            const std::shared_ptr<Transcript>& transcript = std::make_shared<Transcript>());
 
     /**

--- a/barretenberg/cpp/src/barretenberg/protogalaxy/protogalaxy_prover.hpp
+++ b/barretenberg/cpp/src/barretenberg/protogalaxy/protogalaxy_prover.hpp
@@ -37,7 +37,7 @@ template <class DeciderProvingKeys_> class ProtogalaxyProver_ {
     static constexpr size_t NUM_SUBRELATIONS = DeciderProvingKeys_::NUM_SUBRELATIONS;
 
     DeciderProvingKeys_ keys_to_fold;
-    std::shared_ptr<CommitmentKey> commitment_key;
+    CommitmentKey commitment_key;
 
     // the state updated and carried forward beween rounds
     std::shared_ptr<Transcript> transcript = std::make_shared<Transcript>();

--- a/barretenberg/cpp/src/barretenberg/stdlib_circuit_builders/mega_flavor.hpp
+++ b/barretenberg/cpp/src/barretenberg/stdlib_circuit_builders/mega_flavor.hpp
@@ -480,7 +480,7 @@ class MegaFlavor {
         {
             set_metadata(proving_key);
             auto& ck = proving_key.commitment_key;
-            if (!ck.srs || ck.srs->get_monomial_size() < proving_key.circuit_size) {
+            if (!ck.initialized() || ck.srs->get_monomial_size() < proving_key.circuit_size) {
                 ck = CommitmentKey(proving_key.circuit_size);
             }
             for (auto [polynomial, commitment] : zip_view(proving_key.polynomials.get_precomputed(), this->get_all())) {

--- a/barretenberg/cpp/src/barretenberg/stdlib_circuit_builders/mega_flavor.hpp
+++ b/barretenberg/cpp/src/barretenberg/stdlib_circuit_builders/mega_flavor.hpp
@@ -5,6 +5,8 @@
 // =====================
 
 #pragma once
+#include <utility>
+
 #include "barretenberg/commitment_schemes/kzg/kzg.hpp"
 #include "barretenberg/common/ref_vector.hpp"
 #include "barretenberg/flavor/flavor.hpp"
@@ -421,8 +423,8 @@ class MegaFlavor {
         ProvingKey() = default;
         ProvingKey(const size_t circuit_size,
                    const size_t num_public_inputs,
-                   std::shared_ptr<CommitmentKey> commitment_key = nullptr)
-            : Base(circuit_size, num_public_inputs, commitment_key){};
+                   CommitmentKey commitment_key = CommitmentKey())
+            : Base(circuit_size, num_public_inputs, std::move(commitment_key)){};
 
         std::vector<uint32_t> memory_read_records;
         std::vector<uint32_t> memory_write_records;
@@ -478,11 +480,11 @@ class MegaFlavor {
         {
             set_metadata(proving_key);
             auto& ck = proving_key.commitment_key;
-            if (!ck || ck->srs->get_monomial_size() < proving_key.circuit_size) {
-                ck = std::make_shared<CommitmentKey>(proving_key.circuit_size);
+            if (!ck.srs || ck.srs->get_monomial_size() < proving_key.circuit_size) {
+                ck = CommitmentKey(proving_key.circuit_size);
             }
             for (auto [polynomial, commitment] : zip_view(proving_key.polynomials.get_precomputed(), this->get_all())) {
-                commitment = ck->commit(polynomial);
+                commitment = ck.commit(polynomial);
             }
         }
 

--- a/barretenberg/cpp/src/barretenberg/stdlib_circuit_builders/ultra_flavor.hpp
+++ b/barretenberg/cpp/src/barretenberg/stdlib_circuit_builders/ultra_flavor.hpp
@@ -377,7 +377,7 @@ class UltraFlavor {
             this->pub_inputs_offset = proving_key.pub_inputs_offset;
             this->pairing_inputs_public_input_key = proving_key.pairing_inputs_public_input_key;
 
-            if (proving_key.commitment_key.srs == nullptr) {
+            if (!proving_key.commitment_key.initialized()) {
                 // TODO(https://github.com/AztecProtocol/barretenberg/issues/1420): pass commitment keys by value
                 proving_key.commitment_key = CommitmentKey(proving_key.circuit_size);
             }

--- a/barretenberg/cpp/src/barretenberg/stdlib_circuit_builders/ultra_flavor.hpp
+++ b/barretenberg/cpp/src/barretenberg/stdlib_circuit_builders/ultra_flavor.hpp
@@ -340,7 +340,7 @@ class UltraFlavor {
         ProvingKey() = default;
         ProvingKey(const size_t dyadic_circuit_size,
                    const size_t num_public_inputs,
-                   std::shared_ptr<CommitmentKey> commitment_key = nullptr)
+                   CommitmentKey commitment_key = CommitmentKey())
             : Base(dyadic_circuit_size, num_public_inputs, std::move(commitment_key)){};
 
         std::vector<uint32_t> memory_read_records;
@@ -377,12 +377,12 @@ class UltraFlavor {
             this->pub_inputs_offset = proving_key.pub_inputs_offset;
             this->pairing_inputs_public_input_key = proving_key.pairing_inputs_public_input_key;
 
-            if (proving_key.commitment_key == nullptr) {
+            if (proving_key.commitment_key.srs == nullptr) {
                 // TODO(https://github.com/AztecProtocol/barretenberg/issues/1420): pass commitment keys by value
-                proving_key.commitment_key = std::make_shared<CommitmentKey>(proving_key.circuit_size);
+                proving_key.commitment_key = CommitmentKey(proving_key.circuit_size);
             }
             for (auto [polynomial, commitment] : zip_view(proving_key.polynomials.get_precomputed(), this->get_all())) {
-                commitment = proving_key.commitment_key->commit(polynomial);
+                commitment = proving_key.commitment_key.commit(polynomial);
             }
         }
         // TODO(https://github.com/AztecProtocol/barretenberg/issues/964): Clean the boilerplate

--- a/barretenberg/cpp/src/barretenberg/stdlib_circuit_builders/ultra_keccak_flavor.hpp
+++ b/barretenberg/cpp/src/barretenberg/stdlib_circuit_builders/ultra_keccak_flavor.hpp
@@ -59,12 +59,11 @@ class UltraKeccakFlavor : public bb::UltraFlavor {
             this->num_public_inputs = proving_key.num_public_inputs;
             this->pub_inputs_offset = proving_key.pub_inputs_offset;
 
-            if (proving_key.commitment_key == nullptr) {
-                // TODO(https://github.com/AztecProtocol/barretenberg/issues/1420): pass commitment keys by value
-                proving_key.commitment_key = std::make_shared<CommitmentKey>(proving_key.circuit_size);
+            if (proving_key.commitment_key.srs == nullptr) {
+                proving_key.commitment_key = CommitmentKey(proving_key.circuit_size);
             }
             for (auto [polynomial, commitment] : zip_view(proving_key.polynomials.get_precomputed(), this->get_all())) {
-                commitment = proving_key.commitment_key->commit(polynomial);
+                commitment = proving_key.commitment_key.commit(polynomial);
             }
         }
 

--- a/barretenberg/cpp/src/barretenberg/stdlib_circuit_builders/ultra_keccak_flavor.hpp
+++ b/barretenberg/cpp/src/barretenberg/stdlib_circuit_builders/ultra_keccak_flavor.hpp
@@ -59,7 +59,7 @@ class UltraKeccakFlavor : public bb::UltraFlavor {
             this->num_public_inputs = proving_key.num_public_inputs;
             this->pub_inputs_offset = proving_key.pub_inputs_offset;
 
-            if (proving_key.commitment_key.srs == nullptr) {
+            if (!proving_key.commitment_key.initialized()) {
                 proving_key.commitment_key = CommitmentKey(proving_key.circuit_size);
             }
             for (auto [polynomial, commitment] : zip_view(proving_key.polynomials.get_precomputed(), this->get_all())) {

--- a/barretenberg/cpp/src/barretenberg/stdlib_circuit_builders/ultra_rollup_flavor.hpp
+++ b/barretenberg/cpp/src/barretenberg/stdlib_circuit_builders/ultra_rollup_flavor.hpp
@@ -90,11 +90,11 @@ class UltraRollupFlavor : public bb::UltraFlavor {
             this->pub_inputs_offset = proving_key.pub_inputs_offset;
             this->pairing_inputs_public_input_key = proving_key.pairing_inputs_public_input_key;
 
-            if (proving_key.commitment_key == nullptr) {
-                proving_key.commitment_key = std::make_shared<CommitmentKey>(proving_key.circuit_size);
+            if (proving_key.commitment_key.srs == nullptr) {
+                proving_key.commitment_key = CommitmentKey(proving_key.circuit_size);
             }
             for (auto [polynomial, commitment] : zip_view(proving_key.polynomials.get_precomputed(), this->get_all())) {
-                commitment = proving_key.commitment_key->commit(polynomial);
+                commitment = proving_key.commitment_key.commit(polynomial);
             }
         }
 

--- a/barretenberg/cpp/src/barretenberg/stdlib_circuit_builders/ultra_rollup_flavor.hpp
+++ b/barretenberg/cpp/src/barretenberg/stdlib_circuit_builders/ultra_rollup_flavor.hpp
@@ -90,7 +90,7 @@ class UltraRollupFlavor : public bb::UltraFlavor {
             this->pub_inputs_offset = proving_key.pub_inputs_offset;
             this->pairing_inputs_public_input_key = proving_key.pairing_inputs_public_input_key;
 
-            if (proving_key.commitment_key.srs == nullptr) {
+            if (!proving_key.commitment_key.initialized()) {
                 proving_key.commitment_key = CommitmentKey(proving_key.circuit_size);
             }
             for (auto [polynomial, commitment] : zip_view(proving_key.polynomials.get_precomputed(), this->get_all())) {

--- a/barretenberg/cpp/src/barretenberg/sumcheck/sumcheck.hpp
+++ b/barretenberg/cpp/src/barretenberg/sumcheck/sumcheck.hpp
@@ -273,11 +273,11 @@ template <typename Flavor, const size_t virtual_log_n = CONST_PROOF_SIZE_LOG_N> 
                                  ZKData& zk_sumcheck_data)
         requires Flavor::HasZK
     {
-        std::shared_ptr<CommitmentKey> ck = nullptr;
+        CommitmentKey ck;
 
         if constexpr (IsGrumpkinFlavor<Flavor>) {
             // TODO(https://github.com/AztecProtocol/barretenberg/issues/1420): pass commitment keys by value
-            ck = std::make_shared<CommitmentKey>(BATCHED_RELATION_PARTIAL_LENGTH);
+            ck = CommitmentKey(BATCHED_RELATION_PARTIAL_LENGTH);
             // Compute the vector {0, 1, \ldots, BATCHED_RELATION_PARTIAL_LENGTH-1} needed to transform the round
             // univariates from Lagrange to monomial basis
             for (size_t idx = 0; idx < BATCHED_RELATION_PARTIAL_LENGTH; idx++) {
@@ -387,7 +387,7 @@ template <typename Flavor, const size_t virtual_log_n = CONST_PROOF_SIZE_LOG_N> 
                 transcript->send_to_verifier("Sumcheck:univariate_" + std::to_string(idx), zero_univariate);
             } else {
                 transcript->send_to_verifier("Sumcheck:univariate_comm_" + std::to_string(idx),
-                                             ck->commit(Polynomial<FF>(std::span(zero_univariate))));
+                                             ck.commit(Polynomial<FF>(std::span(zero_univariate))));
                 transcript->send_to_verifier("Sumcheck:univariate_" + std::to_string(idx) + "_eval_0", FF(0));
                 transcript->send_to_verifier("Sumcheck:univariate_" + std::to_string(idx) + "_eval_1", FF(0));
             }
@@ -540,7 +540,7 @@ template <typename Flavor, const size_t virtual_log_n = CONST_PROOF_SIZE_LOG_N> 
      */
     void commit_to_round_univariate(const size_t round_idx,
                                     bb::Univariate<FF, BATCHED_RELATION_PARTIAL_LENGTH>& round_univariate,
-                                    const std::shared_ptr<CommitmentKey>& ck)
+                                    CommitmentKey& ck)
 
     {
         const std::string idx = std::to_string(round_idx);
@@ -548,7 +548,7 @@ template <typename Flavor, const size_t virtual_log_n = CONST_PROOF_SIZE_LOG_N> 
         // Transform to monomial form and commit to it
         Polynomial<FF> round_poly_monomial(
             eval_domain, std::span<FF>(round_univariate.evaluations), BATCHED_RELATION_PARTIAL_LENGTH);
-        transcript->send_to_verifier("Sumcheck:univariate_comm_" + idx, ck->commit(round_poly_monomial));
+        transcript->send_to_verifier("Sumcheck:univariate_comm_" + idx, ck.commit(round_poly_monomial));
 
         // Store round univariate in monomial, as it is required by Shplemini
         round_univariates.push_back(std::move(round_poly_monomial));

--- a/barretenberg/cpp/src/barretenberg/sumcheck/sumcheck.hpp
+++ b/barretenberg/cpp/src/barretenberg/sumcheck/sumcheck.hpp
@@ -540,7 +540,7 @@ template <typename Flavor, const size_t virtual_log_n = CONST_PROOF_SIZE_LOG_N> 
      */
     void commit_to_round_univariate(const size_t round_idx,
                                     bb::Univariate<FF, BATCHED_RELATION_PARTIAL_LENGTH>& round_univariate,
-                                    CommitmentKey& ck)
+                                    const CommitmentKey& ck)
 
     {
         const std::string idx = std::to_string(round_idx);

--- a/barretenberg/cpp/src/barretenberg/sumcheck/zk_sumcheck_data.hpp
+++ b/barretenberg/cpp/src/barretenberg/sumcheck/zk_sumcheck_data.hpp
@@ -71,7 +71,7 @@ template <typename Flavor> struct ZKSumcheckData {
         compute_concatenated_libra_polynomial();
 
         // If proving_key is provided, commit to the concatenated and masked libra polynomial
-        if (commitment_key.srs != nullptr) {
+        if (commitment_key.initialized()) {
             auto libra_commitment = commitment_key.commit(libra_concatenated_monomial_form);
             transcript->template send_to_verifier("Libra:concatenation_commitment", libra_commitment);
         }

--- a/barretenberg/cpp/src/barretenberg/sumcheck/zk_sumcheck_data.hpp
+++ b/barretenberg/cpp/src/barretenberg/sumcheck/zk_sumcheck_data.hpp
@@ -58,7 +58,7 @@ template <typename Flavor> struct ZKSumcheckData {
     // Main constructor
     ZKSumcheckData(const size_t multivariate_d,
                    std::shared_ptr<typename Flavor::Transcript> transcript = nullptr,
-                   typename Flavor::CommitmentKey commitment_key = Flavor::CommitmentKey())
+                   typename Flavor::CommitmentKey commitment_key = typename Flavor::CommitmentKey())
         : constant_term(FF::random_element())
         , libra_concatenated_monomial_form(SUBGROUP_SIZE + 2) // includes masking
         , libra_univariates(generate_libra_univariates(multivariate_d, LIBRA_UNIVARIATES_LENGTH))

--- a/barretenberg/cpp/src/barretenberg/sumcheck/zk_sumcheck_data.hpp
+++ b/barretenberg/cpp/src/barretenberg/sumcheck/zk_sumcheck_data.hpp
@@ -58,7 +58,7 @@ template <typename Flavor> struct ZKSumcheckData {
     // Main constructor
     ZKSumcheckData(const size_t multivariate_d,
                    std::shared_ptr<typename Flavor::Transcript> transcript = nullptr,
-                   std::shared_ptr<typename Flavor::CommitmentKey> commitment_key = nullptr)
+                   typename Flavor::CommitmentKey commitment_key = Flavor::CommitmentKey())
         : constant_term(FF::random_element())
         , libra_concatenated_monomial_form(SUBGROUP_SIZE + 2) // includes masking
         , libra_univariates(generate_libra_univariates(multivariate_d, LIBRA_UNIVARIATES_LENGTH))
@@ -71,8 +71,8 @@ template <typename Flavor> struct ZKSumcheckData {
         compute_concatenated_libra_polynomial();
 
         // If proving_key is provided, commit to the concatenated and masked libra polynomial
-        if (commitment_key != nullptr) {
-            auto libra_commitment = commitment_key->commit(libra_concatenated_monomial_form);
+        if (commitment_key.srs != nullptr) {
+            auto libra_commitment = commitment_key.commit(libra_concatenated_monomial_form);
             transcript->template send_to_verifier("Libra:concatenation_commitment", libra_commitment);
         }
         // Compute the total sum of the Libra polynomials

--- a/barretenberg/cpp/src/barretenberg/translator_vm/translator_flavor.hpp
+++ b/barretenberg/cpp/src/barretenberg/translator_vm/translator_flavor.hpp
@@ -708,7 +708,7 @@ class TranslatorFlavor {
         using Base = ProvingKey_<FF, CommitmentKey>;
         using Base::Base;
 
-        ProvingKey(std::shared_ptr<CommitmentKey> commitment_key = nullptr)
+        ProvingKey(CommitmentKey commitment_key = CommitmentKey())
             : Base(1UL << CONST_TRANSLATOR_LOG_N, 0, std::move(commitment_key))
         {}
     };
@@ -745,7 +745,7 @@ class TranslatorFlavor {
 
             for (auto [polynomial, commitment] :
                  zip_view(proving_key->polynomials.get_precomputed(), this->get_all())) {
-                commitment = proving_key->commitment_key->commit(polynomial);
+                commitment = proving_key->commitment_key.commit(polynomial);
             }
         }
         // TODO(https://github.com/AztecProtocol/barretenberg/issues/1324): Remove `circuit_size` and `log_circuit_size`

--- a/barretenberg/cpp/src/barretenberg/translator_vm/translator_prover.cpp
+++ b/barretenberg/cpp/src/barretenberg/translator_vm/translator_prover.cpp
@@ -20,8 +20,8 @@ TranslatorProver::TranslatorProver(const std::shared_ptr<TranslatorProvingKey>& 
     , key(key)
 {
     PROFILE_THIS();
-    if (key->proving_key->commitment_key == nullptr) {
-        key->proving_key->commitment_key = std::make_shared<CommitmentKey>(key->proving_key->circuit_size);
+    if (key->proving_key->commitment_key.srs == nullptr) {
+        key->proving_key->commitment_key = CommitmentKey(key->proving_key->circuit_size);
     }
 }
 
@@ -57,7 +57,7 @@ void TranslatorProver::execute_preamble_round()
  */
 void TranslatorProver::commit_to_witness_polynomial(Polynomial& polynomial, const std::string& label)
 {
-    transcript->send_to_verifier(label, key->proving_key->commitment_key->commit(polynomial));
+    transcript->send_to_verifier(label, key->proving_key->commitment_key.commit(polynomial));
 }
 
 /**
@@ -144,7 +144,7 @@ void TranslatorProver::execute_relation_check_rounds()
     // // Create a temporary commitment key that is only used to initialise the ZKSumcheckData
     // // If proving in WASM, the commitment key that is part of the Translator proving key remains deallocated
     // //  until we enter the PCS round
-    auto ck = std::make_shared<CommitmentKey>(1 << (log_subgroup_size + 1));
+    auto ck = CommitmentKey(1 << (log_subgroup_size + 1));
 
     zk_sumcheck_data = ZKData(key->proving_key->log_circuit_size, transcript, ck);
 
@@ -167,7 +167,9 @@ void TranslatorProver::execute_pcs_rounds()
 
     // Check whether the commitment key has been deallocated and reinitialise it if necessary
     auto& ck = key->proving_key->commitment_key;
-    ck = ck ? ck : std::make_shared<CommitmentKey>(key->proving_key->circuit_size);
+    if (!ck.srs) {
+        ck = CommitmentKey(key->proving_key->circuit_size);
+    }
 
     SmallSubgroupIPA small_subgroup_ipa_prover(
         zk_sumcheck_data, sumcheck_output.challenge, sumcheck_output.claimed_libra_evaluation, transcript, ck);
@@ -212,7 +214,7 @@ HonkProof TranslatorProver::construct_proof()
 
     // #ifndef __wasm__
     // Free the commitment key
-    key->proving_key->commitment_key = nullptr;
+    key->proving_key->commitment_key = CommitmentKey();
     // #endif
 
     // Fiat-Shamir: alpha

--- a/barretenberg/cpp/src/barretenberg/translator_vm/translator_prover.cpp
+++ b/barretenberg/cpp/src/barretenberg/translator_vm/translator_prover.cpp
@@ -20,7 +20,7 @@ TranslatorProver::TranslatorProver(const std::shared_ptr<TranslatorProvingKey>& 
     , key(key)
 {
     PROFILE_THIS();
-    if (key->proving_key->commitment_key.srs == nullptr) {
+    if (!key->proving_key->commitment_key.initialized()) {
         key->proving_key->commitment_key = CommitmentKey(key->proving_key->circuit_size);
     }
 }
@@ -144,7 +144,7 @@ void TranslatorProver::execute_relation_check_rounds()
     // // Create a temporary commitment key that is only used to initialise the ZKSumcheckData
     // // If proving in WASM, the commitment key that is part of the Translator proving key remains deallocated
     // //  until we enter the PCS round
-    auto ck = CommitmentKey(1 << (log_subgroup_size + 1));
+    CommitmentKey ck(1 << (log_subgroup_size + 1));
 
     zk_sumcheck_data = ZKData(key->proving_key->log_circuit_size, transcript, ck);
 
@@ -167,7 +167,7 @@ void TranslatorProver::execute_pcs_rounds()
 
     // Check whether the commitment key has been deallocated and reinitialise it if necessary
     auto& ck = key->proving_key->commitment_key;
-    if (!ck.srs) {
+    if (!ck.initialized()) {
         ck = CommitmentKey(key->proving_key->circuit_size);
     }
 

--- a/barretenberg/cpp/src/barretenberg/translator_vm/translator_proving_key.hpp
+++ b/barretenberg/cpp/src/barretenberg/translator_vm/translator_proving_key.hpp
@@ -41,7 +41,7 @@ class TranslatorProvingKey {
 
     TranslatorProvingKey() = default;
 
-    TranslatorProvingKey(const Circuit& circuit, std::shared_ptr<CommitmentKey> commitment_key = nullptr)
+    TranslatorProvingKey(const Circuit& circuit, CommitmentKey commitment_key = CommitmentKey())
         : batching_challenge_v(circuit.batching_challenge_v)
         , evaluation_input_x(circuit.evaluation_input_x)
     {

--- a/barretenberg/cpp/src/barretenberg/ultra_honk/decider_prover.cpp
+++ b/barretenberg/cpp/src/barretenberg/ultra_honk/decider_prover.cpp
@@ -71,7 +71,7 @@ template <IsUltraOrMegaHonk Flavor> void DeciderProver_<Flavor>::execute_pcs_rou
     using PolynomialBatcher = GeminiProver_<Curve>::PolynomialBatcher;
 
     auto& ck = proving_key->proving_key.commitment_key;
-    if (!ck.srs) {
+    if (!ck.initialized()) {
         ck = CommitmentKey(proving_key->proving_key.circuit_size);
     }
 

--- a/barretenberg/cpp/src/barretenberg/ultra_honk/decider_prover.cpp
+++ b/barretenberg/cpp/src/barretenberg/ultra_honk/decider_prover.cpp
@@ -42,7 +42,7 @@ template <IsUltraOrMegaHonk Flavor> void DeciderProver_<Flavor>::execute_relatio
 
         if constexpr (Flavor::HasZK) {
             const size_t log_subgroup_size = static_cast<size_t>(numeric::get_msb(Curve::SUBGROUP_SIZE));
-            auto commitment_key = CommitmentKey(1 << (log_subgroup_size + 1));
+            CommitmentKey commitment_key(1 << (log_subgroup_size + 1));
             zk_sumcheck_data = ZKData(numeric::get_msb(polynomial_size), transcript, commitment_key);
             sumcheck_output = sumcheck.prove(proving_key->proving_key.polynomials,
                                              proving_key->relation_parameters,

--- a/barretenberg/cpp/src/barretenberg/ultra_honk/decider_prover.cpp
+++ b/barretenberg/cpp/src/barretenberg/ultra_honk/decider_prover.cpp
@@ -42,7 +42,7 @@ template <IsUltraOrMegaHonk Flavor> void DeciderProver_<Flavor>::execute_relatio
 
         if constexpr (Flavor::HasZK) {
             const size_t log_subgroup_size = static_cast<size_t>(numeric::get_msb(Curve::SUBGROUP_SIZE));
-            auto commitment_key = std::make_shared<CommitmentKey>(1 << (log_subgroup_size + 1));
+            auto commitment_key = CommitmentKey(1 << (log_subgroup_size + 1));
             zk_sumcheck_data = ZKData(numeric::get_msb(polynomial_size), transcript, commitment_key);
             sumcheck_output = sumcheck.prove(proving_key->proving_key.polynomials,
                                              proving_key->relation_parameters,
@@ -71,7 +71,9 @@ template <IsUltraOrMegaHonk Flavor> void DeciderProver_<Flavor>::execute_pcs_rou
     using PolynomialBatcher = GeminiProver_<Curve>::PolynomialBatcher;
 
     auto& ck = proving_key->proving_key.commitment_key;
-    ck = ck ? ck : std::make_shared<CommitmentKey>(proving_key->proving_key.circuit_size);
+    if (!ck.srs) {
+        ck = CommitmentKey(proving_key->proving_key.circuit_size);
+    }
 
     PolynomialBatcher polynomial_batcher(proving_key->proving_key.circuit_size);
     polynomial_batcher.set_unshifted(proving_key->proving_key.polynomials.get_unshifted());

--- a/barretenberg/cpp/src/barretenberg/ultra_honk/decider_proving_key.hpp
+++ b/barretenberg/cpp/src/barretenberg/ultra_honk/decider_proving_key.hpp
@@ -62,7 +62,7 @@ template <IsUltraOrMegaHonk Flavor> class DeciderProvingKey_ {
 
     DeciderProvingKey_(Circuit& circuit,
                        TraceSettings trace_settings = {},
-                       std::shared_ptr<CommitmentKey> commitment_key = nullptr)
+                       CommitmentKey commitment_key = CommitmentKey())
         : is_structured(trace_settings.structure.has_value())
     {
         PROFILE_THIS_NAME("DeciderProvingKey(Circuit&)");

--- a/barretenberg/cpp/src/barretenberg/ultra_honk/merge_prover.cpp
+++ b/barretenberg/cpp/src/barretenberg/ultra_honk/merge_prover.cpp
@@ -19,7 +19,8 @@ MergeProver::MergeProver(const std::shared_ptr<ECCOpQueue>& op_queue,
                          const std::shared_ptr<Transcript>& transcript)
     : op_queue(op_queue)
     // TODO(https://github.com/AztecProtocol/barretenberg/issues/1420): pass commitment keys by value
-    , pcs_commitment_key(commitment_key.srs ? commitment_key : CommitmentKey(op_queue->get_ultra_ops_table_num_rows()))
+    , pcs_commitment_key(commitment_key.initialized() ? commitment_key
+                                                      : CommitmentKey(op_queue->get_ultra_ops_table_num_rows()))
     , transcript(transcript){};
 
 /**

--- a/barretenberg/cpp/src/barretenberg/ultra_honk/merge_prover.cpp
+++ b/barretenberg/cpp/src/barretenberg/ultra_honk/merge_prover.cpp
@@ -15,12 +15,11 @@ namespace bb {
  * TODO(https://github.com/AztecProtocol/barretenberg/issues/1267): consider possible efficiency improvements
  */
 MergeProver::MergeProver(const std::shared_ptr<ECCOpQueue>& op_queue,
-                         const std::shared_ptr<CommitmentKey>& commitment_key,
+                         CommitmentKey commitment_key,
                          const std::shared_ptr<Transcript>& transcript)
     : op_queue(op_queue)
     // TODO(https://github.com/AztecProtocol/barretenberg/issues/1420): pass commitment keys by value
-    , pcs_commitment_key(commitment_key ? commitment_key
-                                        : std::make_shared<CommitmentKey>(op_queue->get_ultra_ops_table_num_rows()))
+    , pcs_commitment_key(commitment_key.srs ? commitment_key : CommitmentKey(op_queue->get_ultra_ops_table_num_rows()))
     , transcript(transcript){};
 
 /**
@@ -53,9 +52,9 @@ MergeProver::MergeProof MergeProver::construct_proof()
     // Compute/get commitments [t^{shift}], [T_prev], and [T] and add to transcript
     for (size_t idx = 0; idx < NUM_WIRES; ++idx) {
         // Compute commitments
-        Commitment t_commitment = pcs_commitment_key->commit(t_current[idx]);
-        Commitment T_prev_commitment = pcs_commitment_key->commit(T_prev[idx]);
-        Commitment T_commitment = pcs_commitment_key->commit(T_current[idx]);
+        Commitment t_commitment = pcs_commitment_key.commit(t_current[idx]);
+        Commitment T_prev_commitment = pcs_commitment_key.commit(T_prev[idx]);
+        Commitment T_commitment = pcs_commitment_key.commit(T_current[idx]);
 
         std::string suffix = std::to_string(idx);
         transcript->send_to_verifier("t_CURRENT_" + suffix, t_commitment);

--- a/barretenberg/cpp/src/barretenberg/ultra_honk/merge_prover.hpp
+++ b/barretenberg/cpp/src/barretenberg/ultra_honk/merge_prover.hpp
@@ -34,13 +34,13 @@ class MergeProver {
     using MergeProof = std::vector<FF>;
 
     explicit MergeProver(const std::shared_ptr<ECCOpQueue>& op_queue,
-                         const std::shared_ptr<CommitmentKey>& commitment_key = nullptr,
+                         CommitmentKey commitment_key = CommitmentKey(),
                          const std::shared_ptr<Transcript>& transcript = std::make_shared<Transcript>());
 
     BB_PROFILE MergeProof construct_proof();
 
     std::shared_ptr<ECCOpQueue> op_queue;
-    std::shared_ptr<CommitmentKey> pcs_commitment_key;
+    CommitmentKey pcs_commitment_key;
     std::shared_ptr<Transcript> transcript;
     // Number of columns that jointly constitute the op_queue, should be the same as the number of wires in the
     // MegaCircuitBuilder

--- a/barretenberg/cpp/src/barretenberg/ultra_honk/oink_prover.cpp
+++ b/barretenberg/cpp/src/barretenberg/ultra_honk/oink_prover.cpp
@@ -20,9 +20,8 @@ namespace bb {
  */
 template <IsUltraOrMegaHonk Flavor> HonkProof OinkProver<Flavor>::prove()
 {
-    if (proving_key->proving_key.commitment_key == nullptr) {
-        proving_key->proving_key.commitment_key =
-            std::make_shared<CommitmentKey>(proving_key->proving_key.circuit_size);
+    if (proving_key->proving_key.commitment_key.srs == nullptr) {
+        proving_key->proving_key.commitment_key = CommitmentKey(proving_key->proving_key.circuit_size);
     }
     {
 
@@ -67,7 +66,7 @@ template <IsUltraOrMegaHonk Flavor> HonkProof OinkProver<Flavor>::prove()
 
     // #ifndef __wasm__
     // Free the commitment key
-    proving_key->proving_key.commitment_key = nullptr;
+    proving_key->proving_key.commitment_key = CommitmentKey();
     // #endif
 
     return transcript->proof_data;
@@ -140,7 +139,7 @@ template <IsUltraOrMegaHonk Flavor> void OinkProver<Flavor>::execute_wire_commit
             {
                 PROFILE_THIS_NAME("COMMIT::ecc_op_wires");
                 transcript->send_to_verifier(domain_separator + label,
-                                             proving_key->proving_key.commitment_key->commit(polynomial));
+                                             proving_key->proving_key.commitment_key.commit(polynomial));
             };
         }
 
@@ -277,7 +276,7 @@ void OinkProver<Flavor>::commit_to_witness_polynomial(Polynomial<FF>& polynomial
 
     typename Flavor::Commitment commitment;
 
-    commitment = proving_key->proving_key.commitment_key->commit_with_type(
+    commitment = proving_key->proving_key.commitment_key.commit_with_type(
         polynomial, type, proving_key->proving_key.active_region_data.get_ranges());
     // Send the commitment to the verifier
     transcript->send_to_verifier(domain_separator + label, commitment);

--- a/barretenberg/cpp/src/barretenberg/ultra_honk/oink_prover.cpp
+++ b/barretenberg/cpp/src/barretenberg/ultra_honk/oink_prover.cpp
@@ -20,7 +20,7 @@ namespace bb {
  */
 template <IsUltraOrMegaHonk Flavor> HonkProof OinkProver<Flavor>::prove()
 {
-    if (proving_key->proving_key.commitment_key.srs == nullptr) {
+    if (!proving_key->proving_key.commitment_key.initialized()) {
         proving_key->proving_key.commitment_key = CommitmentKey(proving_key->proving_key.circuit_size);
     }
     {

--- a/barretenberg/cpp/src/barretenberg/ultra_honk/ultra_prover.cpp
+++ b/barretenberg/cpp/src/barretenberg/ultra_honk/ultra_prover.cpp
@@ -11,8 +11,7 @@
 namespace bb {
 
 template <IsUltraOrMegaHonk Flavor>
-UltraProver_<Flavor>::UltraProver_(const std::shared_ptr<DeciderPK>& proving_key,
-                                   const std::shared_ptr<CommitmentKey>& commitment_key)
+UltraProver_<Flavor>::UltraProver_(const std::shared_ptr<DeciderPK>& proving_key, CommitmentKey& commitment_key)
     : proving_key(std::move(proving_key))
     , transcript(std::make_shared<Transcript>())
     , commitment_key(commitment_key)

--- a/barretenberg/cpp/src/barretenberg/ultra_honk/ultra_prover.cpp
+++ b/barretenberg/cpp/src/barretenberg/ultra_honk/ultra_prover.cpp
@@ -11,7 +11,7 @@
 namespace bb {
 
 template <IsUltraOrMegaHonk Flavor>
-UltraProver_<Flavor>::UltraProver_(const std::shared_ptr<DeciderPK>& proving_key, CommitmentKey& commitment_key)
+UltraProver_<Flavor>::UltraProver_(const std::shared_ptr<DeciderPK>& proving_key, const CommitmentKey& commitment_key)
     : proving_key(std::move(proving_key))
     , transcript(std::make_shared<Transcript>())
     , commitment_key(commitment_key)

--- a/barretenberg/cpp/src/barretenberg/ultra_honk/ultra_prover.hpp
+++ b/barretenberg/cpp/src/barretenberg/ultra_honk/ultra_prover.hpp
@@ -43,7 +43,7 @@ template <IsUltraOrMegaHonk Flavor_> class UltraProver_ {
 
     CommitmentKey commitment_key;
 
-    UltraProver_(const std::shared_ptr<DeciderPK>&, CommitmentKey&);
+    UltraProver_(const std::shared_ptr<DeciderPK>&, const CommitmentKey&);
 
     explicit UltraProver_(const std::shared_ptr<DeciderPK>&,
                           const std::shared_ptr<Transcript>& transcript = std::make_shared<Transcript>());

--- a/barretenberg/cpp/src/barretenberg/ultra_honk/ultra_prover.hpp
+++ b/barretenberg/cpp/src/barretenberg/ultra_honk/ultra_prover.hpp
@@ -41,9 +41,9 @@ template <IsUltraOrMegaHonk Flavor_> class UltraProver_ {
 
     SumcheckOutput<Flavor> sumcheck_output;
 
-    std::shared_ptr<CommitmentKey> commitment_key;
+    CommitmentKey commitment_key;
 
-    UltraProver_(const std::shared_ptr<DeciderPK>&, const std::shared_ptr<CommitmentKey>&);
+    UltraProver_(const std::shared_ptr<DeciderPK>&, CommitmentKey&);
 
     explicit UltraProver_(const std::shared_ptr<DeciderPK>&,
                           const std::shared_ptr<Transcript>& transcript = std::make_shared<Transcript>());

--- a/barretenberg/cpp/src/barretenberg/vm2/constraining/flavor.cpp
+++ b/barretenberg/cpp/src/barretenberg/vm2/constraining/flavor.cpp
@@ -100,7 +100,7 @@ AvmFlavor::ProvingKey::ProvingKey(const size_t circuit_size, const size_t num_pu
     , num_public_inputs(num_public_inputs)
     , evaluation_domain(bb::EvaluationDomain<FF>(circuit_size, circuit_size))
     // TODO(https://github.com/AztecProtocol/barretenberg/issues/1420): pass commitment keys by value
-    , commitment_key(std::make_shared<CommitmentKey>(circuit_size + 1)){
+    , commitment_key(circuit_size + 1){
         // The proving key's polynomials are not allocated here because they are later overwritten
         // AvmComposer::compute_witness(). We should probably refactor this flow.
     };

--- a/barretenberg/cpp/src/barretenberg/vm2/constraining/flavor.hpp
+++ b/barretenberg/cpp/src/barretenberg/vm2/constraining/flavor.hpp
@@ -206,7 +206,7 @@ class AvmFlavor {
         size_t log_circuit_size;
         size_t num_public_inputs;
         bb::EvaluationDomain<FF> evaluation_domain;
-        std::shared_ptr<CommitmentKey> commitment_key;
+        CommitmentKey commitment_key;
 
         // Offset off the public inputs from the start of the execution trace
         size_t pub_inputs_offset = 0;
@@ -232,7 +232,7 @@ class AvmFlavor {
         {
             for (auto [polynomial, commitment] :
                  zip_view(proving_key->get_precomputed_polynomials(), this->get_all())) {
-                commitment = proving_key->commitment_key->commit(polynomial);
+                commitment = proving_key->commitment_key.commit(polynomial);
             }
         }
 

--- a/barretenberg/cpp/src/barretenberg/vm2/constraining/prover.cpp
+++ b/barretenberg/cpp/src/barretenberg/vm2/constraining/prover.cpp
@@ -24,10 +24,10 @@ using FF = Flavor::FF;
  *
  * @tparam settings Settings class.
  */
-AvmProver::AvmProver(std::shared_ptr<Flavor::ProvingKey> input_key, PCSCommitmentKey& commitment_key)
+AvmProver::AvmProver(std::shared_ptr<Flavor::ProvingKey> input_key, const PCSCommitmentKey& commitment_key)
     : key(std::move(input_key))
     , prover_polynomials(*key)
-    , commitment_key(std::move(commitment_key))
+    , commitment_key(commitment_key)
 {}
 
 /**

--- a/barretenberg/cpp/src/barretenberg/vm2/constraining/prover.cpp
+++ b/barretenberg/cpp/src/barretenberg/vm2/constraining/prover.cpp
@@ -24,7 +24,7 @@ using FF = Flavor::FF;
  *
  * @tparam settings Settings class.
  */
-AvmProver::AvmProver(std::shared_ptr<Flavor::ProvingKey> input_key, std::shared_ptr<PCSCommitmentKey> commitment_key)
+AvmProver::AvmProver(std::shared_ptr<Flavor::ProvingKey> input_key, PCSCommitmentKey& commitment_key)
     : key(std::move(input_key))
     , prover_polynomials(*key)
     , commitment_key(std::move(commitment_key))
@@ -52,7 +52,7 @@ void AvmProver::execute_wire_commitments_round()
     auto wire_polys = prover_polynomials.get_wires();
     const auto& labels = prover_polynomials.get_wires_labels();
     for (size_t idx = 0; idx < wire_polys.size(); ++idx) {
-        transcript->send_to_verifier(labels[idx], commitment_key->commit(wire_polys[idx]));
+        transcript->send_to_verifier(labels[idx], commitment_key.commit(wire_polys[idx]));
     }
 }
 
@@ -79,7 +79,7 @@ void AvmProver::execute_log_derivative_inverse_commitments_round()
 {
     // Commit to all logderivative inverse polynomials
     for (auto [commitment, key_poly] : zip_view(witness_commitments.get_derived(), key->get_derived())) {
-        commitment = commitment_key->commit(key_poly);
+        commitment = commitment_key.commit(key_poly);
     }
 
     // Send all commitments to the verifier

--- a/barretenberg/cpp/src/barretenberg/vm2/constraining/prover.hpp
+++ b/barretenberg/cpp/src/barretenberg/vm2/constraining/prover.hpp
@@ -21,7 +21,7 @@ class AvmProver {
     using Transcript = Flavor::Transcript;
     using Proof = HonkProof;
 
-    explicit AvmProver(std::shared_ptr<ProvingKey> input_key, PCSCommitmentKey& commitment_key);
+    explicit AvmProver(std::shared_ptr<ProvingKey> input_key, const PCSCommitmentKey& commitment_key);
     AvmProver(AvmProver&& prover) = default;
     virtual ~AvmProver() = default;
 

--- a/barretenberg/cpp/src/barretenberg/vm2/constraining/prover.hpp
+++ b/barretenberg/cpp/src/barretenberg/vm2/constraining/prover.hpp
@@ -21,7 +21,7 @@ class AvmProver {
     using Transcript = Flavor::Transcript;
     using Proof = HonkProof;
 
-    explicit AvmProver(std::shared_ptr<ProvingKey> input_key, std::shared_ptr<PCSCommitmentKey> commitment_key);
+    explicit AvmProver(std::shared_ptr<ProvingKey> input_key, PCSCommitmentKey& commitment_key);
     AvmProver(AvmProver&& prover) = default;
     virtual ~AvmProver() = default;
 
@@ -54,7 +54,7 @@ class AvmProver {
 
     SumcheckOutput<Flavor> sumcheck_output;
 
-    std::shared_ptr<PCSCommitmentKey> commitment_key;
+    PCSCommitmentKey commitment_key;
 
   protected:
     HonkProof proof;

--- a/barretenberg/cpp/src/barretenberg/vm2/constraining/recursion/recursive_verifier.test.cpp
+++ b/barretenberg/cpp/src/barretenberg/vm2/constraining/recursion/recursive_verifier.test.cpp
@@ -128,7 +128,7 @@ TEST_F(AvmRecursiveTests, StandardRecursion)
     // Make a proof of the verification of an AVM proof
     const size_t srs_size = 1 << 24; // Current outer_circuit size is 9.6 millions
     auto ultra_instance = std::make_shared<OuterDeciderProvingKey>(
-        outer_circuit, TraceSettings{}, std::make_shared<bb::CommitmentKey<curve::BN254>>(srs_size));
+        outer_circuit, TraceSettings{}, bb::CommitmentKey<curve::BN254>(srs_size));
 
     // Scoped to free memory of OuterProver.
     auto outer_proof = [&]() {

--- a/barretenberg/cpp/src/barretenberg/vm2/proving_helper.cpp
+++ b/barretenberg/cpp/src/barretenberg/vm2/proving_helper.cpp
@@ -30,7 +30,7 @@ std::shared_ptr<AvmProver::ProvingKey> create_proving_key(AvmProver::ProverPolyn
         key_poly = std::move(prover_poly);
     }
 
-    proving_key->commitment_key = std::make_shared<AvmProver::PCSCommitmentKey>(CIRCUIT_SUBGROUP_SIZE);
+    proving_key->commitment_key = AvmProver::PCSCommitmentKey(CIRCUIT_SUBGROUP_SIZE);
 
     return proving_key;
 }


### PR DESCRIPTION
Once PippengerReference exists in the code we no longer need to pass commitment keys by reference, and can just pass them by value. A default constructor is added to PippengerReference as well so that we can default construct CommitmentKey.

Closes https://github.com/AztecProtocol/barretenberg/issues/1420