### PR TITLE
feat: updating TXE with timestamp tracking

### DIFF
--- a/noir-projects/aztec-nr/authwit/src/cheatcodes.nr
+++ b/noir-projects/aztec-nr/authwit/src/cheatcodes.nr
@@ -1,7 +1,7 @@
 use dep::aztec::{
     context::{call_interfaces::CallInterface, public_context::PublicContext},
     hash::hash_args,
-    oracle::execution::{get_block_number, get_contract_address},
+    oracle::execution::{get_block_number, get_contract_address, get_timestamp},
     protocol_types::{address::AztecAddress, traits::ToField},
     test::helpers::cheatcodes,
 };
@@ -17,7 +17,7 @@ where
     C: CallInterface<M>,
 {
     let target = call_interface.get_contract_address();
-    let inputs = cheatcodes::get_private_context_inputs(get_block_number());
+    let inputs = cheatcodes::get_private_context_inputs(get_block_number(), get_timestamp());
     let chain_id = inputs.tx_context.chain_id;
     let version = inputs.tx_context.version;
     let args_hash = hash_args(call_interface.get_args());
@@ -39,7 +39,7 @@ where
     let current_contract = get_contract_address();
     cheatcodes::set_contract_address(on_behalf_of);
     let target = call_interface.get_contract_address();
-    let inputs = cheatcodes::get_private_context_inputs(get_block_number());
+    let inputs = cheatcodes::get_private_context_inputs(get_block_number(), get_timestamp());
     let chain_id = inputs.tx_context.chain_id;
     let version = inputs.tx_context.version;
     let args_hash = hash_args(call_interface.get_args());

--- a/noir-projects/aztec-nr/authwit/src/cheatcodes.nr
+++ b/noir-projects/aztec-nr/authwit/src/cheatcodes.nr
@@ -1,7 +1,7 @@
 use dep::aztec::{
     context::{call_interfaces::CallInterface, public_context::PublicContext},
     hash::hash_args,
-    oracle::execution::{get_block_number, get_contract_address, get_timestamp},
+    oracle::execution::get_contract_address,
     protocol_types::{address::AztecAddress, traits::ToField},
     test::helpers::cheatcodes,
 };
@@ -17,7 +17,7 @@ where
     C: CallInterface<M>,
 {
     let target = call_interface.get_contract_address();
-    let inputs = cheatcodes::get_private_context_inputs(get_block_number(), get_timestamp());
+    let inputs = cheatcodes::get_private_context_inputs();
     let chain_id = inputs.tx_context.chain_id;
     let version = inputs.tx_context.version;
     let args_hash = hash_args(call_interface.get_args());
@@ -39,7 +39,7 @@ where
     let current_contract = get_contract_address();
     cheatcodes::set_contract_address(on_behalf_of);
     let target = call_interface.get_contract_address();
-    let inputs = cheatcodes::get_private_context_inputs(get_block_number(), get_timestamp());
+    let inputs = cheatcodes::get_private_context_inputs();
     let chain_id = inputs.tx_context.chain_id;
     let version = inputs.tx_context.version;
     let args_hash = hash_args(call_interface.get_args());

--- a/noir-projects/aztec-nr/aztec/src/context/utility_context.nr
+++ b/noir-projects/aztec-nr/aztec/src/context/utility_context.nr
@@ -1,11 +1,12 @@
 use crate::oracle::{
-    execution::{get_block_number, get_chain_id, get_contract_address, get_version},
+    execution::{get_block_number, get_chain_id, get_contract_address, get_timestamp, get_version},
     storage::storage_read,
 };
 use dep::protocol_types::{address::AztecAddress, traits::Packable};
 
 pub struct UtilityContext {
     block_number: u32,
+    timestamp: u64,
     contract_address: AztecAddress,
     version: Field,
     chain_id: Field,
@@ -18,23 +19,26 @@ impl UtilityContext {
         // incorrectly attempts to create a UtilityContext in an environment in which these oracles are not
         // available.
         let block_number = get_block_number();
+        let timestamp = get_timestamp();
         let contract_address = get_contract_address();
-        let chain_id = get_chain_id();
         let version = get_version();
-        Self { block_number, contract_address, version, chain_id }
+        let chain_id = get_chain_id();
+        Self { block_number, timestamp, contract_address, version, chain_id }
     }
 
     pub unconstrained fn at(contract_address: AztecAddress) -> Self {
         let block_number = get_block_number();
+        let timestamp = get_timestamp();
         let chain_id = get_chain_id();
         let version = get_version();
-        Self { block_number, contract_address, version, chain_id }
+        Self { block_number, timestamp, contract_address, version, chain_id }
     }
 
     pub unconstrained fn at_historical(contract_address: AztecAddress, block_number: u32) -> Self {
+        let timestamp = get_timestamp();
         let chain_id = get_chain_id();
         let version = get_version();
-        Self { block_number, contract_address, version, chain_id }
+        Self { block_number, timestamp, contract_address, version, chain_id }
     }
 
     pub fn block_number(self) -> u32 {

--- a/noir-projects/aztec-nr/aztec/src/context/utility_context.nr
+++ b/noir-projects/aztec-nr/aztec/src/context/utility_context.nr
@@ -45,6 +45,10 @@ impl UtilityContext {
         self.block_number
     }
 
+    pub fn timestamp(self) -> u64 {
+        self.timestamp
+    }
+
     pub fn this_address(self) -> AztecAddress {
         self.contract_address
     }

--- a/noir-projects/aztec-nr/aztec/src/oracle/execution.nr
+++ b/noir-projects/aztec-nr/aztec/src/oracle/execution.nr
@@ -6,6 +6,9 @@ unconstrained fn get_contract_address_oracle() -> AztecAddress {}
 #[oracle(getBlockNumber)]
 unconstrained fn get_block_number_oracle() -> u32 {}
 
+#[oracle(getTimestamp)]
+unconstrained fn get_timestamp_oracle() -> u64 {}
+
 #[oracle(getChainId)]
 unconstrained fn get_chain_id_oracle() -> Field {}
 
@@ -18,6 +21,10 @@ pub unconstrained fn get_contract_address() -> AztecAddress {
 
 pub unconstrained fn get_block_number() -> u32 {
     get_block_number_oracle()
+}
+
+pub unconstrained fn get_timestamp() -> u64 {
+    get_timestamp_oracle()
 }
 
 pub unconstrained fn get_chain_id() -> Field {

--- a/noir-projects/aztec-nr/aztec/src/test/helpers/cheatcodes.nr
+++ b/noir-projects/aztec-nr/aztec/src/test/helpers/cheatcodes.nr
@@ -1,6 +1,10 @@
-use crate::context::inputs::PrivateContextInputs;
-use crate::test::helpers::utils::TestAccount;
-use dep::protocol_types::{
+use crate::{
+    context::inputs::PrivateContextInputs,
+    oracle::execution::{get_block_number, get_timestamp},
+    test::{helpers::utils::TestAccount, txe_constants::AZTEC_SLOT_DURATION},
+};
+
+use protocol_types::{
     abis::function_selector::FunctionSelector,
     address::AztecAddress,
     constants::CONTRACT_INSTANCE_LENGTH,
@@ -34,11 +38,50 @@ pub unconstrained fn advance_timestamp_by(duration: u64) {
     oracle_advance_timestamp_by(duration);
 }
 
-pub unconstrained fn get_private_context_inputs(
+pub unconstrained fn get_private_context_inputs() -> PrivateContextInputs {
+    oracle_get_private_context_inputs(Option::none(), Option::none())
+}
+
+pub unconstrained fn get_private_context_inputs_at_block(
     historical_block_number: u32,
+) -> PrivateContextInputs {
+    let current_block = get_block_number();
+
+    assert(
+        historical_block_number <= current_block,
+        "Cannot request private context inputs for block number greater than current block",
+    );
+
+    // If equal to current block, clamp to current block - 1
+    let block_number = if historical_block_number == current_block {
+        // TODO: Auto-modifying the block number here seems wrong. Would just throw instead.
+        current_block - 1
+    } else {
+        historical_block_number
+    };
+
+    oracle_get_private_context_inputs(Option::some(block_number), Option::none())
+}
+
+pub unconstrained fn get_private_context_inputs_at_timestamp(
     historical_timestamp: u64,
 ) -> PrivateContextInputs {
-    oracle_get_private_context_inputs(historical_block_number, historical_timestamp)
+    let current_timestamp = get_timestamp();
+
+    assert(
+        historical_timestamp <= current_timestamp,
+        "Cannot request private context inputs for timestamp greater than current timestamp",
+    );
+
+    // If equal to current timestamp, clamp to current timestamp - AZTEC_SLOT_DURATION
+    let timestamp = if historical_timestamp == current_timestamp {
+        // TODO: Auto-modifying the timestamp here seems wrong. Would just throw instead.
+        current_timestamp - AZTEC_SLOT_DURATION
+    } else {
+        historical_timestamp
+    };
+
+    oracle_get_private_context_inputs(Option::none(), Option::some(timestamp))
 }
 
 pub unconstrained fn deploy<let N: u32, let M: u32, let P: u32>(
@@ -171,8 +214,8 @@ unconstrained fn oracle_advance_timestamp_by(duration: u64) {}
 
 #[oracle(getPrivateContextInputs)]
 unconstrained fn oracle_get_private_context_inputs(
-    historical_block_number: u32,
-    historical_timestamp: u64,
+    historical_block_number: Option<u32>,
+    historical_timestamp: Option<u64>,
 ) -> PrivateContextInputs {}
 
 #[oracle(deploy)]

--- a/noir-projects/aztec-nr/aztec/src/test/helpers/cheatcodes.nr
+++ b/noir-projects/aztec-nr/aztec/src/test/helpers/cheatcodes.nr
@@ -30,6 +30,10 @@ pub unconstrained fn advance_blocks_by(blocks: u32) {
     oracle_advance_blocks_by(blocks);
 }
 
+pub unconstrained fn advance_timestamp_by(duration: u64) {
+    oracle_advance_timestamp_by(duration);
+}
+
 pub unconstrained fn get_private_context_inputs(
     historical_block_number: u32,
 ) -> PrivateContextInputs {
@@ -160,6 +164,9 @@ unconstrained fn oracle_get_side_effects_counter() -> u32 {}
 
 #[oracle(advanceBlocksBy)]
 unconstrained fn oracle_advance_blocks_by(blocks: u32) {}
+
+#[oracle(advanceTimestampBy)]
+unconstrained fn oracle_advance_timestamp_by(duration: u64) {}
 
 #[oracle(getPrivateContextInputs)]
 unconstrained fn oracle_get_private_context_inputs(

--- a/noir-projects/aztec-nr/aztec/src/test/helpers/cheatcodes.nr
+++ b/noir-projects/aztec-nr/aztec/src/test/helpers/cheatcodes.nr
@@ -36,8 +36,9 @@ pub unconstrained fn advance_timestamp_by(duration: u64) {
 
 pub unconstrained fn get_private_context_inputs(
     historical_block_number: u32,
+    historical_timestamp: u64,
 ) -> PrivateContextInputs {
-    oracle_get_private_context_inputs(historical_block_number)
+    oracle_get_private_context_inputs(historical_block_number, historical_timestamp)
 }
 
 pub unconstrained fn deploy<let N: u32, let M: u32, let P: u32>(
@@ -171,6 +172,7 @@ unconstrained fn oracle_advance_timestamp_by(duration: u64) {}
 #[oracle(getPrivateContextInputs)]
 unconstrained fn oracle_get_private_context_inputs(
     historical_block_number: u32,
+    historical_timestamp: u64,
 ) -> PrivateContextInputs {}
 
 #[oracle(deploy)]

--- a/noir-projects/aztec-nr/aztec/src/test/helpers/test_environment.nr
+++ b/noir-projects/aztec-nr/aztec/src/test/helpers/test_environment.nr
@@ -76,6 +76,12 @@ impl TestEnvironment {
         self.pending_block_number() - 1
     }
 
+    pub unconstrained fn committed_timestamp(self: Self) -> u64 {
+        // Aztec slot duration is copied from TestConstants.sol.
+        let AZTEC_SLOT_DURATION: u64 = 36;
+        self.pending_timestamp() - AZTEC_SLOT_DURATION
+    }
+
     /// With TXe tests, every test is run in a mock "contract". This facilitates the ability to write to and read from storage,
     /// emit and retrieve nullifiers (because they are hashed with a contract address), and formulate notes in a canonical way.
     /// The contract_address also represents the "msg_sender" when we call a contract with a private or public context; and when
@@ -156,7 +162,27 @@ impl TestEnvironment {
             self.advance_block_to(historical_block_number + 1);
         }
 
-        let mut inputs = cheatcodes::get_private_context_inputs(historical_block_number);
+        let mut inputs = cheatcodes::get_private_context_inputs(
+            historical_block_number,
+            self.committed_timestamp(),
+        );
+
+        PrivateContext::new(inputs, 0)
+    }
+
+    /// Instantiates a private context at a specific historical timestamp.
+    pub unconstrained fn private_at_timestamp(
+        &mut self,
+        historical_timestamp: u64,
+    ) -> PrivateContext {
+        if historical_timestamp > get_timestamp() {
+            self.advance_timestamp_to(historical_timestamp);
+        }
+
+        let mut inputs = cheatcodes::get_private_context_inputs(
+            self.committed_block_number(),
+            historical_timestamp,
+        );
 
         PrivateContext::new(inputs, 0)
     }

--- a/noir-projects/aztec-nr/aztec/src/test/helpers/test_environment.nr
+++ b/noir-projects/aztec-nr/aztec/src/test/helpers/test_environment.nr
@@ -162,10 +162,7 @@ impl TestEnvironment {
             self.advance_block_to(historical_block_number + 1);
         }
 
-        let mut inputs = cheatcodes::get_private_context_inputs(
-            historical_block_number,
-            self.committed_timestamp(),
-        );
+        let mut inputs = cheatcodes::get_private_context_inputs_at_block(historical_block_number);
 
         PrivateContext::new(inputs, 0)
     }
@@ -179,10 +176,7 @@ impl TestEnvironment {
             self.advance_timestamp_to(historical_timestamp);
         }
 
-        let mut inputs = cheatcodes::get_private_context_inputs(
-            self.committed_block_number(),
-            historical_timestamp,
-        );
+        let mut inputs = cheatcodes::get_private_context_inputs_at_timestamp(historical_timestamp);
 
         PrivateContext::new(inputs, 0)
     }

--- a/noir-projects/aztec-nr/aztec/src/test/helpers/test_environment.nr
+++ b/noir-projects/aztec-nr/aztec/src/test/helpers/test_environment.nr
@@ -1,42 +1,36 @@
-use dep::protocol_types::{
+use protocol_types::{
     abis::function_selector::FunctionSelector,
     address::AztecAddress,
     constants::PUBLIC_DISPATCH_SELECTOR,
     traits::{Deserialize, FromField, Packable, ToField},
 };
 
-use crate::context::{
-    call_interfaces::{
-        CallInterface, TXEPrivateCallInterface, TXEPublicCallInterface, TXEUtilityCallInterface,
+use crate::{
+    context::{
+        call_interfaces::{
+            CallInterface, TXEPrivateCallInterface, TXEPublicCallInterface, TXEUtilityCallInterface,
+        },
+        PrivateCallInterface,
+        PrivateContext,
+        PrivateVoidCallInterface,
+        PublicCallInterface,
+        PublicContext,
+        PublicVoidCallInterface,
+        ReturnsHash,
+        UtilityCallInterface,
+        UtilityContext,
     },
-    PrivateCallInterface,
-    PrivateContext,
-    PrivateVoidCallInterface,
-    PublicCallInterface,
-    PublicContext,
-    PublicVoidCallInterface,
-    ReturnsHash,
-    UtilityCallInterface,
-    UtilityContext,
+    hash::hash_args,
+    note::note_interface::{NoteHash, NoteType},
+    oracle::{
+        execution::{get_block_number, get_contract_address, get_timestamp},
+        execution_cache,
+        notes::notify_created_note,
+    },
+    test::{helpers::{cheatcodes, utils::Deployer}, txe_constants::AZTEC_SLOT_DURATION},
 };
-use crate::hash::hash_args;
-use crate::test::helpers::{cheatcodes, utils::Deployer};
 
-use crate::note::note_interface::{NoteHash, NoteType};
-use crate::oracle::{
-    execution::{get_block_number, get_contract_address, get_timestamp},
-    execution_cache,
-    notes::notify_created_note,
-};
 use super::cheatcodes::public_call_new_flow;
-
-// TODO(benesjan): Having these hardcoded values below is not ideal as they are not hardcoded anywhere else in the
-// codebase other than in TestConstants.sol (they are loaded from config set at runtime). We could set them via oracles
-// from tests though but would do that in a followup PR if the reviewer agrees. Will create an issue for this once
-// I get feedback.
-
-// Aztec slot duration is copied from TestConstants.sol.
-global AZTEC_SLOT_DURATION: u64 = 36;
 
 pub struct TestEnvironment {}
 

--- a/noir-projects/aztec-nr/aztec/src/test/helpers/test_environment.nr
+++ b/noir-projects/aztec-nr/aztec/src/test/helpers/test_environment.nr
@@ -106,6 +106,17 @@ impl TestEnvironment {
         self.advance_block_by(difference);
     }
 
+    /// Advances the internal TXe timestamp to the specified timestamp.
+    pub unconstrained fn advance_timestamp_to(&mut self, timestamp: u64) {
+        let pending_timestamp = self.pending_timestamp();
+        assert(
+            pending_timestamp <= timestamp,
+            "Cannot go back in time. Timestamp cannot be less than current timestamp.",
+        );
+        let difference: u64 = timestamp - pending_timestamp;
+        self.advance_timestamp_by(difference);
+    }
+
     /// Advances the internal TXe state by the amount of blocks specified. The TXe produces a valid block for every
     /// block advanced, and we are able to fetch historical data from warped over blocks.
     pub unconstrained fn advance_block_by(_self: &mut Self, blocks: u32) {

--- a/noir-projects/aztec-nr/aztec/src/test/helpers/test_environment.nr
+++ b/noir-projects/aztec-nr/aztec/src/test/helpers/test_environment.nr
@@ -52,6 +52,9 @@ impl TestEnvironment {
     /// Returns the block number of the block currently being built. Since sequencer is executing the public part
     /// of transactions when building blocks, this block number is also returned by public_context.block_number().
     pub unconstrained fn pending_block_number(_self: Self) -> u32 {
+        // TODO: This oracle when used in PXE returns the latest synched block number by the node and not the pending
+        // block number! But TXE handles this in some messed up custom way so this might actually be kinda correct.
+        // Terrible.
         get_block_number()
     }
 

--- a/noir-projects/aztec-nr/aztec/src/test/helpers/test_environment.nr
+++ b/noir-projects/aztec-nr/aztec/src/test/helpers/test_environment.nr
@@ -24,7 +24,7 @@ use crate::test::helpers::{cheatcodes, utils::Deployer};
 
 use crate::note::note_interface::{NoteHash, NoteType};
 use crate::oracle::{
-    execution::{get_block_number, get_contract_address},
+    execution::{get_block_number, get_contract_address, get_timestamp},
     execution_cache,
     notes::notify_created_note,
 };
@@ -56,6 +56,13 @@ impl TestEnvironment {
         // block number! But TXE handles this in some messed up custom way so this might actually be kinda correct.
         // Terrible.
         get_block_number()
+    }
+
+    /// Returns the timestamp of the block currently being built. Since sequencer is executing the public part
+    /// of transactions when building blocks, this timestamp is also returned by public_context.timestamp().
+    pub unconstrained fn get_pending_timestamp(_self: Self) -> u64 {
+        // TODO: This has the same behavior as pending_block_number() so it's also messed up.
+        get_timestamp()
     }
 
     /// This does what the above does but should be considered deprecated as the naming is subpar.

--- a/noir-projects/aztec-nr/aztec/src/test/helpers/test_environment.nr
+++ b/noir-projects/aztec-nr/aztec/src/test/helpers/test_environment.nr
@@ -60,7 +60,7 @@ impl TestEnvironment {
 
     /// Returns the timestamp of the block currently being built. Since sequencer is executing the public part
     /// of transactions when building blocks, this timestamp is also returned by public_context.timestamp().
-    pub unconstrained fn get_pending_timestamp(_self: Self) -> u64 {
+    pub unconstrained fn pending_timestamp(_self: Self) -> u64 {
         // TODO: This has the same behavior as pending_block_number() so it's also messed up.
         get_timestamp()
     }

--- a/noir-projects/aztec-nr/aztec/src/test/helpers/test_environment.nr
+++ b/noir-projects/aztec-nr/aztec/src/test/helpers/test_environment.nr
@@ -30,6 +30,14 @@ use crate::oracle::{
 };
 use super::cheatcodes::public_call_new_flow;
 
+// TODO(benesjan): Having these hardcoded values below is not ideal as they are not hardcoded anywhere else in the
+// codebase other than in TestConstants.sol (they are loaded from config set at runtime). We could set them via oracles
+// from tests though but would do that in a followup PR if the reviewer agrees. Will create an issue for this once
+// I get feedback.
+
+// Aztec slot duration is copied from TestConstants.sol.
+global AZTEC_SLOT_DURATION: u64 = 36;
+
 pub struct TestEnvironment {}
 
 pub struct CallResult<T> {
@@ -77,8 +85,6 @@ impl TestEnvironment {
     }
 
     pub unconstrained fn committed_timestamp(self: Self) -> u64 {
-        // Aztec slot duration is copied from TestConstants.sol.
-        let AZTEC_SLOT_DURATION: u64 = 36;
         self.pending_timestamp() - AZTEC_SLOT_DURATION
     }
 

--- a/noir-projects/aztec-nr/aztec/src/test/helpers/test_environment.nr
+++ b/noir-projects/aztec-nr/aztec/src/test/helpers/test_environment.nr
@@ -112,6 +112,11 @@ impl TestEnvironment {
         cheatcodes::advance_blocks_by(blocks);
     }
 
+    /// Advances the internal TXe timestamp by the specified duration in seconds.
+    pub unconstrained fn advance_timestamp_by(_self: &mut Self, duration: u64) {
+        cheatcodes::advance_timestamp_by(duration);
+    }
+
     /// Instantiates a public context. The block number returned from public_context.block_number() will be the
     /// block number of the block currently being built (same as the one returned by self.pending_block_number()).
     pub unconstrained fn public(_self: Self) -> PublicContext {

--- a/noir-projects/aztec-nr/aztec/src/test/helpers/utils.nr
+++ b/noir-projects/aztec-nr/aztec/src/test/helpers/utils.nr
@@ -17,6 +17,7 @@ use crate::test::helpers::cheatcodes;
 use crate::context::gas::GasOpts;
 use crate::hash::hash_args;
 use crate::oracle::execution::get_block_number;
+use crate::oracle::execution::get_timestamp;
 use crate::oracle::execution_cache;
 
 pub struct Deployer<let N: u32, let M: u32> {
@@ -42,7 +43,12 @@ impl<let N: u32, let M: u32> Deployer<N, M> {
             self.secret,
         );
 
-        let inputs = cheatcodes::get_private_context_inputs(get_block_number() - 1);
+        // Aztec slot duration is copied from TestConstants.sol.
+        let AZTEC_SLOT_DURATION = 36;
+        let inputs = cheatcodes::get_private_context_inputs(
+            get_block_number() - 1,
+            get_timestamp() - AZTEC_SLOT_DURATION,
+        );
         let mut private_context = PrivateContext::new(inputs, 0);
         let args = call_interface.get_args();
         let args_hash = if args.len() > 0 { hash_args(args) } else { 0 };

--- a/noir-projects/aztec-nr/aztec/src/test/helpers/utils.nr
+++ b/noir-projects/aztec-nr/aztec/src/test/helpers/utils.nr
@@ -1,8 +1,8 @@
 use crate::{
     context::{call_interfaces::CallInterface, gas::GasOpts, PrivateContext, PublicContext},
     hash::hash_args,
-    oracle::{execution::{get_block_number, get_timestamp}, execution_cache},
-    test::{helpers::cheatcodes, txe_constants::AZTEC_SLOT_DURATION},
+    oracle::execution_cache,
+    test::helpers::cheatcodes,
 };
 use protocol_types::{
     address::AztecAddress,
@@ -39,10 +39,7 @@ impl<let N: u32, let M: u32> Deployer<N, M> {
             self.secret,
         );
 
-        let inputs = cheatcodes::get_private_context_inputs(
-            get_block_number() - 1,
-            get_timestamp() - AZTEC_SLOT_DURATION,
-        );
+        let inputs = cheatcodes::get_private_context_inputs();
         let mut private_context = PrivateContext::new(inputs, 0);
         let args = call_interface.get_args();
         let args_hash = if args.len() > 0 { hash_args(args) } else { 0 };

--- a/noir-projects/aztec-nr/aztec/src/test/helpers/utils.nr
+++ b/noir-projects/aztec-nr/aztec/src/test/helpers/utils.nr
@@ -20,6 +20,14 @@ use crate::oracle::execution::get_block_number;
 use crate::oracle::execution::get_timestamp;
 use crate::oracle::execution_cache;
 
+// TODO(benesjan): Having these hardcoded values below is not ideal as they are not hardcoded anywhere else in the
+// codebase other than in TestConstants.sol (they are loaded from config set at runtime). We could set them via oracles
+// from tests though but would do that in a followup PR if the reviewer agrees. Will create an issue for this once
+// I get feedback.
+
+// Aztec slot duration is copied from TestConstants.sol.
+global AZTEC_SLOT_DURATION: u64 = 36;
+
 pub struct Deployer<let N: u32, let M: u32> {
     pub path: str<N>,
     pub name: str<M>,
@@ -43,8 +51,6 @@ impl<let N: u32, let M: u32> Deployer<N, M> {
             self.secret,
         );
 
-        // Aztec slot duration is copied from TestConstants.sol.
-        let AZTEC_SLOT_DURATION = 36;
         let inputs = cheatcodes::get_private_context_inputs(
             get_block_number() - 1,
             get_timestamp() - AZTEC_SLOT_DURATION,

--- a/noir-projects/aztec-nr/aztec/src/test/helpers/utils.nr
+++ b/noir-projects/aztec-nr/aztec/src/test/helpers/utils.nr
@@ -1,4 +1,10 @@
-use dep::protocol_types::{
+use crate::{
+    context::{call_interfaces::CallInterface, gas::GasOpts, PrivateContext, PublicContext},
+    hash::hash_args,
+    oracle::{execution::{get_block_number, get_timestamp}, execution_cache},
+    test::{helpers::cheatcodes, txe_constants::AZTEC_SLOT_DURATION},
+};
+use protocol_types::{
     address::AztecAddress,
     contract_instance::ContractInstance,
     public_keys::PublicKeys,
@@ -7,26 +13,8 @@ use dep::protocol_types::{
 use std::meta::derive;
 
 // The following 2 lines have been added here because derivation of Serialize and Deserialize does not handle imports
-use dep::protocol_types::public_keys::{IvpkM, NpkM, OvpkM, TpkM};
+use protocol_types::public_keys::{IvpkM, NpkM, OvpkM, TpkM};
 use std::embedded_curve_ops::EmbeddedCurvePoint;
-
-use crate::context::call_interfaces::CallInterface;
-use crate::context::{PrivateContext, PublicContext};
-use crate::test::helpers::cheatcodes;
-
-use crate::context::gas::GasOpts;
-use crate::hash::hash_args;
-use crate::oracle::execution::get_block_number;
-use crate::oracle::execution::get_timestamp;
-use crate::oracle::execution_cache;
-
-// TODO(benesjan): Having these hardcoded values below is not ideal as they are not hardcoded anywhere else in the
-// codebase other than in TestConstants.sol (they are loaded from config set at runtime). We could set them via oracles
-// from tests though but would do that in a followup PR if the reviewer agrees. Will create an issue for this once
-// I get feedback.
-
-// Aztec slot duration is copied from TestConstants.sol.
-global AZTEC_SLOT_DURATION: u64 = 36;
 
 pub struct Deployer<let N: u32, let M: u32> {
     pub path: str<N>,

--- a/noir-projects/aztec-nr/aztec/src/test/mod.nr
+++ b/noir-projects/aztec-nr/aztec/src/test/mod.nr
@@ -1,2 +1,3 @@
 pub mod helpers;
 pub(crate) mod mocks;
+pub mod txe_constants;

--- a/noir-projects/aztec-nr/aztec/src/test/txe_constants.nr
+++ b/noir-projects/aztec-nr/aztec/src/test/txe_constants.nr
@@ -1,0 +1,11 @@
+// Noir version of `txe_constants.ts`. These values need to stay in sync with the values in `txe_constants.ts`.
+
+// Having these hardcoded values below is not ideal as they are not hardcoded anywhere else in the codebase other than
+// in TestConstants.sol (they are loaded from config set at runtime). But loading these from oracles at this point
+// seems like an overkill.
+
+// Aztec slot duration is copied from TestConstants.sol.
+pub global AZTEC_SLOT_DURATION: u64 = 36;
+// Put here Thu Jan 01 2026 00:00:00 GMT+0000. If this file survives until mainnet launch, we would want to use the
+// actual genesis time here.
+pub global GENESIS_TIMESTAMP: u64 = 1767225600;

--- a/yarn-project/aztec-node/src/aztec-node/server.ts
+++ b/yarn-project/aztec-node/src/aztec-node/server.ts
@@ -482,7 +482,7 @@ export class AztecNodeService implements AztecNode, AztecNodeAdmin, Traceable {
   }
 
   /**
-   * Method to fetch the current block number.
+   * Method to fetch the latest block number synchronized by the node.
    * @returns The block number.
    */
   public async getBlockNumber(): Promise<number> {

--- a/yarn-project/pxe/src/contract_function_simulator/execution_data_provider.ts
+++ b/yarn-project/pxe/src/contract_function_simulator/execution_data_provider.ts
@@ -9,6 +9,7 @@ import { IndexedTaggingSecret, PrivateLogWithTxData, PublicLogWithTxData } from 
 import type { NoteStatus } from '@aztec/stdlib/note';
 import { type MerkleTreeId, type NullifierMembershipWitness, PublicDataWitness } from '@aztec/stdlib/trees';
 import type { BlockHeader, NodeStats } from '@aztec/stdlib/tx';
+import type { UInt64 } from '@aztec/stdlib/types';
 
 import type { MessageLoadOracleInputs } from './oracle/message_load_oracle_inputs.js';
 import type { NoteData } from './oracle/typed_oracle.js';
@@ -145,10 +146,9 @@ export interface ExecutionDataProvider {
   ): Promise<MessageLoadOracleInputs<typeof L1_TO_L2_MSG_TREE_HEIGHT>>;
 
   /**
-   * Retrieve the databases view of the Block Header object.
-   * This structure is fed into the circuits simulator and is used to prove against certain historical roots.
-   *
-   * @returns A Promise that resolves to a Header object.
+   * Retrieve the latest block header synchronized by the PXE.
+   * @dev This structure is fed into the circuits simulator and is used to prove against certain historical roots.
+   * @returns The BlockHeader object.
    */
   getBlockHeader(): Promise<BlockHeader>;
 
@@ -209,10 +209,16 @@ export interface ExecutionDataProvider {
   getBlock(blockNumber: number): Promise<L2Block | undefined>;
 
   /**
-   * Fetches the current block number.
+   * Fetches the latest block number synchronized by the node.
    * @returns The block number.
    */
   getBlockNumber(): Promise<number>;
+
+  /**
+   * Fetches the timestamp of the latest block synchronized by the node.
+   * @returns The timestamp.
+   */
+  getTimestamp(): Promise<UInt64>;
 
   /**
    * Fetches the current chain id.

--- a/yarn-project/pxe/src/contract_function_simulator/oracle/oracle.ts
+++ b/yarn-project/pxe/src/contract_function_simulator/oracle/oracle.ts
@@ -62,6 +62,10 @@ export class Oracle {
     return [toACVMField(await this.typedOracle.getBlockNumber())];
   }
 
+  async getTimestamp(): Promise<ACVMField[]> {
+    return [toACVMField(await this.typedOracle.getTimestamp())];
+  }
+
   async getContractAddress(): Promise<ACVMField[]> {
     return [toACVMField(await this.typedOracle.getContractAddress())];
   }

--- a/yarn-project/pxe/src/contract_function_simulator/oracle/typed_oracle.ts
+++ b/yarn-project/pxe/src/contract_function_simulator/oracle/typed_oracle.ts
@@ -64,6 +64,10 @@ export abstract class TypedOracle {
     return Promise.reject(new OracleMethodNotAvailableError('getBlockNumber'));
   }
 
+  getTimestamp(): Promise<number> {
+    return Promise.reject(new OracleMethodNotAvailableError('getTimestamp'));
+  }
+
   getContractAddress(): Promise<AztecAddress> {
     return Promise.reject(new OracleMethodNotAvailableError('getContractAddress'));
   }

--- a/yarn-project/pxe/src/contract_function_simulator/oracle/typed_oracle.ts
+++ b/yarn-project/pxe/src/contract_function_simulator/oracle/typed_oracle.ts
@@ -13,6 +13,7 @@ import type {
 import type { Note, NoteStatus } from '@aztec/stdlib/note';
 import { type MerkleTreeId, type NullifierMembershipWitness, PublicDataWitness } from '@aztec/stdlib/trees';
 import type { BlockHeader } from '@aztec/stdlib/tx';
+import type { UInt64 } from '@aztec/stdlib/types';
 
 import type { MessageLoadOracleInputs } from './message_load_oracle_inputs.js';
 
@@ -64,7 +65,7 @@ export abstract class TypedOracle {
     return Promise.reject(new OracleMethodNotAvailableError('getBlockNumber'));
   }
 
-  getTimestamp(): Promise<number> {
+  getTimestamp(): Promise<UInt64> {
     return Promise.reject(new OracleMethodNotAvailableError('getTimestamp'));
   }
 

--- a/yarn-project/pxe/src/contract_function_simulator/oracle/utility_execution.test.ts
+++ b/yarn-project/pxe/src/contract_function_simulator/oracle/utility_execution.test.ts
@@ -21,9 +21,9 @@ describe('Utility Execution test suite', () => {
   beforeEach(() => {
     executionDataProvider = mock<ExecutionDataProvider>();
 
-    executionDataProvider.getBlockNumber.mockResolvedValue(42);
     executionDataProvider.getChainId.mockResolvedValue(1);
     executionDataProvider.getVersion.mockResolvedValue(1);
+    executionDataProvider.getTimestamp.mockResolvedValue(0n);
 
     acirSimulator = new ContractFunctionSimulator(executionDataProvider, simulator);
   });

--- a/yarn-project/pxe/src/contract_function_simulator/oracle/utility_execution_oracle.ts
+++ b/yarn-project/pxe/src/contract_function_simulator/oracle/utility_execution_oracle.ts
@@ -10,6 +10,7 @@ import { IndexedTaggingSecret, PrivateLogWithTxData, PublicLogWithTxData } from 
 import type { NoteStatus } from '@aztec/stdlib/note';
 import { type MerkleTreeId, type NullifierMembershipWitness, PublicDataWitness } from '@aztec/stdlib/trees';
 import type { BlockHeader, Capsule } from '@aztec/stdlib/tx';
+import type { UInt64 } from '@aztec/stdlib/types';
 
 import type { ExecutionDataProvider } from '../execution_data_provider.js';
 import { pickNotes } from '../pick_notes.js';
@@ -33,6 +34,10 @@ export class UtilityExecutionOracle extends TypedOracle {
 
   public override getBlockNumber(): Promise<number> {
     return this.executionDataProvider.getBlockNumber();
+  }
+
+  public override getTimestamp(): Promise<UInt64> {
+    return this.executionDataProvider.getTimestamp();
   }
 
   public override getContractAddress(): Promise<AztecAddress> {

--- a/yarn-project/pxe/src/contract_function_simulator/pxe_oracle_interface.ts
+++ b/yarn-project/pxe/src/contract_function_simulator/pxe_oracle_interface.ts
@@ -30,6 +30,7 @@ import { Note, type NoteStatus } from '@aztec/stdlib/note';
 import { MerkleTreeId, type NullifierMembershipWitness, PublicDataWitness } from '@aztec/stdlib/trees';
 import type { BlockHeader } from '@aztec/stdlib/tx';
 import { TxHash } from '@aztec/stdlib/tx';
+import type { UInt64 } from '@aztec/stdlib/types';
 
 import type { ExecutionDataProvider, ExecutionStats } from '../contract_function_simulator/execution_data_provider.js';
 import { MessageLoadOracleInputs } from '../contract_function_simulator/oracle/message_load_oracle_inputs.js';
@@ -219,21 +220,34 @@ export class PXEOracleInterface implements ExecutionDataProvider {
   }
 
   /**
-   * Retrieve the databases view of the Block Header object.
-   * This structure is fed into the circuits simulator and is used to prove against certain historical roots.
-   *
-   * @returns A Promise that resolves to a BlockHeader object.
+   * Retrieve the latest block header synchronized by the PXE.
+   * @dev This structure is fed into the circuits simulator and is used to prove against certain historical roots.
+   * @returns The BlockHeader object.
+   * TODO: I think this naming is bad as it's not the latest block header synched by the node, but the latest block
+   * header synchronized by the PXE. Would rename this to something like getSynchronizedBlockHeader().
    */
   getBlockHeader(): Promise<BlockHeader> {
     return this.syncDataProvider.getBlockHeader();
   }
 
   /**
-   * Fetches the current block number.
+   * Fetches the latest block number synchronized by the node.
    * @returns The block number.
    */
   public async getBlockNumber(): Promise<number> {
     return await this.aztecNode.getBlockNumber();
+  }
+
+  /**
+   * Fetches the timestamp of the latest block synchronized by the node.
+   * @returns The timestamp.
+   */
+  public async getTimestamp(): Promise<UInt64> {
+    const latestBlockHeader = await this.aztecNode.getBlockHeader();
+    if (!latestBlockHeader) {
+      throw new Error('Latest block header not found when getting timestamp');
+    }
+    return latestBlockHeader.globalVariables.timestamp;
   }
 
   /**

--- a/yarn-project/pxe/src/pxe_service/pxe_service.ts
+++ b/yarn-project/pxe/src/pxe_service/pxe_service.ts
@@ -1009,7 +1009,7 @@ export class PXEService implements PXE {
   public async getNodeInfo(): Promise<NodeInfo> {
     // This assumes we're connected to a single node, so we cache the info to avoid repeated calls.
     // Load balancers and a myriad other configurations can break this assumption, so review this!
-    // Temporary mesure to avoid hammering full nodes with requests on testnet.
+    // Temporary measure to avoid hammering full nodes with requests on testnet.
     if (!this.#nodeInfo) {
       const [nodeVersion, rollupVersion, chainId, enr, contractAddresses, protocolContractAddresses] =
         await Promise.all([

--- a/yarn-project/stdlib/src/interfaces/aztec-node.ts
+++ b/yarn-project/stdlib/src/interfaces/aztec-node.ts
@@ -220,7 +220,7 @@ export interface AztecNode
   getBlock(number: L2BlockNumber): Promise<L2Block | undefined>;
 
   /**
-   * Fetches the current block number.
+   * Method to fetch the latest block number synchronized by the node.
    * @returns The block number.
    */
   getBlockNumber(): Promise<number>;

--- a/yarn-project/txe/src/oracle/txe_oracle.ts
+++ b/yarn-project/txe/src/oracle/txe_oracle.ts
@@ -341,34 +341,15 @@ export class TXE implements TypedOracle {
   }
 
   async getPrivateContextInputs(
-    blockNumber: number,
-    timestamp: UInt64,
+    blockNumber: number | null,
+    timestamp: UInt64 | null,
     sideEffectsCounter = this.sideEffectCounter,
     isStaticCall = false,
   ) {
-    if (blockNumber > this.blockNumber) {
-      throw new Error(
-        `Tried to request private context inputs for ${blockNumber}, which is greater than our current block number of ${this.blockNumber}`,
-      );
-    } else if (blockNumber === this.blockNumber) {
-      this.logger.debug(
-        `Tried to request private context inputs for ${blockNumber}, equal to current block of ${this.blockNumber}. Clamping to current block - 1.`,
-      );
-      // TODO: Auto-modifying the block number here seems wrong. Would just throw instead.
-      blockNumber = this.blockNumber - 1;
-    }
-
-    if (timestamp > this.timestamp) {
-      throw new Error(
-        `Tried to request private context inputs for timestamp ${timestamp}, which is greater than our current timestamp of ${this.timestamp}`,
-      );
-    } else if (timestamp === this.timestamp) {
-      this.logger.debug(
-        `Tried to request private context inputs for timestamp ${timestamp}, equal to current timestamp of ${this.timestamp}. Clamping to current timestamp - AZTEC_SLOT_DURATION.`,
-      );
-      // TODO: Auto-modifying the timestamp here seems wrong. Would just throw instead.
-      timestamp = this.timestamp - AZTEC_SLOT_DURATION;
-    }
+    // If blockNumber or timestamp is null, use the values corresponding to the latest historical block (number of
+    // the block being built - 1)
+    blockNumber = blockNumber ?? this.blockNumber - 1;
+    timestamp = timestamp ?? this.timestamp - AZTEC_SLOT_DURATION;
 
     const snap = this.nativeWorldStateService.getSnapshot(blockNumber);
     const previousBlockState = this.nativeWorldStateService.getSnapshot(blockNumber - 1);

--- a/yarn-project/txe/src/oracle/txe_oracle.ts
+++ b/yarn-project/txe/src/oracle/txe_oracle.ts
@@ -147,7 +147,7 @@ import { TXEPublicContractDataSource } from '../util/txe_public_contract_data_so
 
 export class TXE implements TypedOracle {
   private blockNumber = 1;
-  private timestamp = 1;
+  private timestamp = 1n;
   private sideEffectCounter = 0;
   private msgSender: AztecAddress;
   private functionSelector = FunctionSelector.fromField(new Fr(0));

--- a/yarn-project/txe/src/oracle/txe_oracle.ts
+++ b/yarn-project/txe/src/oracle/txe_oracle.ts
@@ -306,6 +306,11 @@ export class TXE implements TypedOracle {
 
   setBlockNumber(blockNumber: number) {
     this.blockNumber = blockNumber;
+    const AZTEC_SLOT_DURATION = 36n; // Copied over from `TestConstants.sol`
+    // Currently we assume genesis time to be 0 which points to the beginning of unix timestamp so year 1970.
+    // TODO: After mainnet we might want to define a mainnet genesis time here.
+    // We also assume that in each slot a block was proposed. This is not a problem for TXE.
+    this.timestamp = BigInt(blockNumber) * AZTEC_SLOT_DURATION;
   }
 
   getContractDataProvider() {

--- a/yarn-project/txe/src/oracle/txe_oracle.ts
+++ b/yarn-project/txe/src/oracle/txe_oracle.ts
@@ -168,6 +168,8 @@ export class TXE implements TypedOracle {
 
   private ROLLUP_VERSION = 1;
   private CHAIN_ID = 1;
+  // This slot duration is copied from TestConstants.sol.
+  private AZTEC_SLOT_DURATION = 36n;
 
   private node: AztecNode;
 
@@ -306,11 +308,10 @@ export class TXE implements TypedOracle {
 
   setBlockNumber(blockNumber: number) {
     this.blockNumber = blockNumber;
-    const AZTEC_SLOT_DURATION = 36n; // Copied over from `TestConstants.sol`
-    // Currently we assume genesis time to be 0 which points to the beginning of unix timestamp so year 1970.
-    // TODO: After mainnet we might want to define a mainnet genesis time here.
-    // We also assume that in each slot a block was proposed. This is not a problem for TXE.
-    this.timestamp = BigInt(blockNumber) * AZTEC_SLOT_DURATION;
+  }
+
+  advanceTimestampBy(duration: bigint) {
+    this.timestamp = this.timestamp + duration;
   }
 
   getContractDataProvider() {
@@ -1637,6 +1638,7 @@ export class TXE implements TypedOracle {
     const txRequestHash = this.getTxRequestHash();
 
     this.setBlockNumber(this.blockNumber + 1);
+    this.advanceTimestampBy(this.timestamp + this.AZTEC_SLOT_DURATION);
     return {
       endSideEffectCounter: result.entrypoint.publicInputs.endSideEffectCounter,
       returnsHash: result.entrypoint.publicInputs.returnsHash,
@@ -1800,6 +1802,7 @@ export class TXE implements TypedOracle {
     const txRequestHash = this.getTxRequestHash();
 
     this.setBlockNumber(this.blockNumber + 1);
+    this.advanceTimestampBy(this.AZTEC_SLOT_DURATION);
 
     return {
       returnsHash: returnValuesHash ?? Fr.ZERO,

--- a/yarn-project/txe/src/oracle/txe_oracle.ts
+++ b/yarn-project/txe/src/oracle/txe_oracle.ts
@@ -148,7 +148,7 @@ import { TXEPublicContractDataSource } from '../util/txe_public_contract_data_so
 
 export class TXE implements TypedOracle {
   private blockNumber = 1;
-  private timestamp = 1n;
+  private timestamp = 0n;
   private sideEffectCounter = 0;
   private msgSender: AztecAddress;
   private functionSelector = FunctionSelector.fromField(new Fr(0));

--- a/yarn-project/txe/src/oracle/txe_oracle.ts
+++ b/yarn-project/txe/src/oracle/txe_oracle.ts
@@ -586,30 +586,8 @@ export class TXE implements TypedOracle {
     return new NullifierMembershipWitness(BigInt(index), preimageData as NullifierLeafPreimage, siblingPath);
   }
 
-  async getBlockHeader(blockNumber: number): Promise<BlockHeader | undefined> {
-    if (blockNumber === 1) {
-      // TODO: Figure out why native merkle trees cannot get snapshot of 0, as it defaults to latest
-      throw new Error('Cannot get the block header of block number 1');
-    }
-
-    const snap = this.nativeWorldStateService.getSnapshot(blockNumber);
-    const stateReference = await snap.getStateReference();
-
-    const previousState = this.nativeWorldStateService.getSnapshot(blockNumber - 1);
-    const archiveInfo = await previousState.getTreeInfo(MerkleTreeId.ARCHIVE);
-
-    const header = new BlockHeader(
-      new AppendOnlyTreeSnapshot(new Fr(archiveInfo.root), Number(archiveInfo.size)),
-      makeContentCommitment(),
-      stateReference,
-      makeGlobalVariables(),
-      Fr.ZERO,
-      Fr.ZERO,
-    );
-
-    header.globalVariables.blockNumber = blockNumber;
-
-    return header;
+  getBlockHeader(blockNumber: number): Promise<BlockHeader | undefined> {
+    return this.stateMachine.archiver.getBlockHeader(blockNumber);
   }
 
   getCompleteAddress(account: AztecAddress) {

--- a/yarn-project/txe/src/oracle/txe_oracle.ts
+++ b/yarn-project/txe/src/oracle/txe_oracle.ts
@@ -143,18 +143,9 @@ import type { UInt64 } from '@aztec/stdlib/types';
 import { ForkCheckpoint, NativeWorldStateService } from '@aztec/world-state/native';
 
 import { TXEStateMachine } from '../state_machine/index.js';
+import { AZTEC_SLOT_DURATION, GENESIS_TIMESTAMP } from '../txe_constants.js';
 import { TXEAccountDataProvider } from '../util/txe_account_data_provider.js';
 import { TXEPublicContractDataSource } from '../util/txe_public_contract_data_source.js';
-
-// TODO(benesjan): Having these hardcoded values below is not ideal as they are not hardcoded anywhere else in the
-// codebase other than in TestConstants.sol (they are loaded from config set at runtime). We could set them via oracles
-// from tests though but would do that in a followup PR if the reviewer agrees. Will create an issue for this once
-// I get feedback.
-
-// Aztec slot duration is copied from TestConstants.sol.
-const AZTEC_SLOT_DURATION = 36n;
-// Put here Thu Jan 01 2026 00:00:00 GMT+0000. In the future we would want to use the actual genesis time here.
-const GENESIS_TIMESTAMP = 1767225600n;
 
 export class TXE implements TypedOracle {
   private blockNumber = 1;

--- a/yarn-project/txe/src/oracle/txe_oracle.ts
+++ b/yarn-project/txe/src/oracle/txe_oracle.ts
@@ -147,6 +147,7 @@ import { TXEPublicContractDataSource } from '../util/txe_public_contract_data_so
 
 export class TXE implements TypedOracle {
   private blockNumber = 1;
+  private timestamp = 1;
   private sideEffectCounter = 0;
   private msgSender: AztecAddress;
   private functionSelector = FunctionSelector.fromField(new Fr(0));
@@ -430,6 +431,10 @@ export class TXE implements TypedOracle {
 
   getBlockNumber() {
     return Promise.resolve(this.blockNumber);
+  }
+
+  getTimestamp() {
+    return Promise.resolve(this.timestamp);
   }
 
   getContractAddress() {

--- a/yarn-project/txe/src/txe_constants.ts
+++ b/yarn-project/txe/src/txe_constants.ts
@@ -1,0 +1,11 @@
+// TypeScript version of `txe_constants.nr`. These values need to stay in sync with the values in `txe_constants.nr`.
+
+// Having these hardcoded values below is not ideal as they are not hardcoded anywhere else in the codebase other than
+// in TestConstants.sol (they are loaded from config set at runtime). But loading these from oracles at this point
+// seems like an overkill.
+
+// Aztec slot duration is copied from TestConstants.sol.
+export const AZTEC_SLOT_DURATION = 36n;
+// Put here Thu Jan 01 2026 00:00:00 GMT+0000. If this file survives until mainnet launch, we would want to use the
+// actual genesis time here.
+export const GENESIS_TIMESTAMP = 1767225600n;

--- a/yarn-project/txe/src/txe_service/txe_service.ts
+++ b/yarn-project/txe/src/txe_service/txe_service.ts
@@ -72,10 +72,12 @@ export class TXEService {
     return toForeignCallResult([]);
   }
 
-  advanceTimestampBy(duration: ForeignCallSingle) {
+  async advanceTimestampBy(duration: ForeignCallSingle) {
     const durationBigInt = fromSingle(duration).toBigInt();
     this.logger.debug(`time traveling ${durationBigInt} seconds`);
     (this.typedOracle as TXE).advanceTimestampBy(durationBigInt);
+    // We commit state as currently it is the expectations that these "advanceBy" calls do that.
+    await (this.typedOracle as TXE).commitState();
     return toForeignCallResult([]);
   }
 

--- a/yarn-project/txe/src/txe_service/txe_service.ts
+++ b/yarn-project/txe/src/txe_service/txe_service.ts
@@ -247,6 +247,17 @@ export class TXEService {
     return toForeignCallResult([toSingle(new Fr(blockNumber))]);
   }
 
+  async getTimestamp() {
+    if (!this.oraclesEnabled) {
+      throw new Error(
+        'Oracle access from the root of a TXe test are not enabled. Please use env._ to interact with the oracles.',
+      );
+    }
+
+    const timestamp = await this.typedOracle.getTimestamp();
+    return toForeignCallResult([toSingle(new Fr(timestamp))]);
+  }
+
   // Since the argument is a slice, noir automatically adds a length field to oracle call.
   storeInExecutionCache(_length: ForeignCallSingle, values: ForeignCallArray, hash: ForeignCallSingle) {
     if (!this.oraclesEnabled) {

--- a/yarn-project/txe/src/txe_service/txe_service.ts
+++ b/yarn-project/txe/src/txe_service/txe_service.ts
@@ -52,11 +52,16 @@ export class TXEService {
 
   // Cheatcodes
 
-  async getPrivateContextInputs(blockNumber: ForeignCallSingle, timestamp: ForeignCallSingle) {
-    const inputs = await (this.typedOracle as TXE).getPrivateContextInputs(
-      fromSingle(blockNumber).toNumber(),
-      fromSingle(timestamp).toBigInt(),
-    );
+  async getPrivateContextInputs(
+    blockNumberIsSome: ForeignCallSingle,
+    blockNumberValue: ForeignCallSingle,
+    timestampIsSome: ForeignCallSingle,
+    timestampValue: ForeignCallSingle,
+  ) {
+    const blockNumber = fromSingle(blockNumberIsSome).toBool() ? fromSingle(blockNumberValue).toNumber() : null;
+    const timestamp = fromSingle(timestampIsSome).toBool() ? fromSingle(timestampValue).toBigInt() : null;
+
+    const inputs = await (this.typedOracle as TXE).getPrivateContextInputs(blockNumber, timestamp);
     return toForeignCallResult(inputs.toFields().map(toSingle));
   }
 

--- a/yarn-project/txe/src/txe_service/txe_service.ts
+++ b/yarn-project/txe/src/txe_service/txe_service.ts
@@ -69,6 +69,13 @@ export class TXEService {
     return toForeignCallResult([]);
   }
 
+  advanceTimestampBy(duration: ForeignCallSingle) {
+    const durationBigInt = fromSingle(duration).toBigInt();
+    this.logger.debug(`time traveling ${durationBigInt} seconds`);
+    (this.typedOracle as TXE).advanceTimestampBy(durationBigInt);
+    return toForeignCallResult([]);
+  }
+
   setContractAddress(address: ForeignCallSingle) {
     const typedAddress = addressFromSingle(address);
     (this.typedOracle as TXE).setContractAddress(typedAddress);

--- a/yarn-project/txe/src/txe_service/txe_service.ts
+++ b/yarn-project/txe/src/txe_service/txe_service.ts
@@ -72,12 +72,10 @@ export class TXEService {
     return toForeignCallResult([]);
   }
 
-  async advanceTimestampBy(duration: ForeignCallSingle) {
+  advanceTimestampBy(duration: ForeignCallSingle) {
     const durationBigInt = fromSingle(duration).toBigInt();
     this.logger.debug(`time traveling ${durationBigInt} seconds`);
     (this.typedOracle as TXE).advanceTimestampBy(durationBigInt);
-    // We commit state as currently it is the expectations that these "advanceBy" calls do that.
-    await (this.typedOracle as TXE).commitState();
     return toForeignCallResult([]);
   }
 

--- a/yarn-project/txe/src/txe_service/txe_service.ts
+++ b/yarn-project/txe/src/txe_service/txe_service.ts
@@ -52,8 +52,11 @@ export class TXEService {
 
   // Cheatcodes
 
-  async getPrivateContextInputs(blockNumber: ForeignCallSingle) {
-    const inputs = await (this.typedOracle as TXE).getPrivateContextInputs(fromSingle(blockNumber).toNumber());
+  async getPrivateContextInputs(blockNumber: ForeignCallSingle, timestamp: ForeignCallSingle) {
+    const inputs = await (this.typedOracle as TXE).getPrivateContextInputs(
+      fromSingle(blockNumber).toNumber(),
+      fromSingle(timestamp).toBigInt(),
+    );
     return toForeignCallResult(inputs.toFields().map(toSingle));
   }
 


### PR DESCRIPTION
With `SharedMutable` getting changed to work with timestamp instead of block numbers in a followup PR I need to have a way to get a somewhat real timestamp in TXE tests. In this PR I do a random hodgepodge of changes to make this possible.