### PR TITLE
chore: make space

### DIFF
--- a/l1-contracts/src/core/Rollup.sol
+++ b/l1-contracts/src/core/Rollup.sol
@@ -31,7 +31,6 @@ import {StakingLib} from "@aztec/core/libraries/staking/StakingLib.sol";
 import {GSE} from "@aztec/core/staking/GSE.sol";
 import {ProposeLib, ValidateHeaderArgs} from "./libraries/rollup/ProposeLib.sol";
 import {RewardLib, ActivityScore} from "./libraries/rollup/RewardLib.sol";
-import {ValidatorSelectionLib} from "./libraries/validator-selection/ValidatorSelectionLib.sol";
 import {
   RollupCore,
   GenesisState,
@@ -45,6 +44,7 @@ import {
   Errors,
   CommitteeAttestation,
   ExtRollupLib,
+  ExtRollupLib2,
   EthValue,
   STFLib,
   RollupStore,
@@ -110,7 +110,7 @@ contract Rollup is IStaking, IValidatorSelection, IRollup, RollupCore {
     bytes32 _blobsHash,
     BlockHeaderValidationFlags memory _flags
   ) external override(IRollup) {
-    ProposeLib.validateHeader(
+    ExtRollupLib.validateHeader(
       ValidateHeaderArgs({
         header: _header,
         attestations: _attestations,
@@ -163,7 +163,7 @@ contract Rollup is IStaking, IValidatorSelection, IRollup, RollupCore {
     override(IValidatorSelection)
     returns (bytes32, uint256)
   {
-    return ValidatorSelectionLib.getCommitteeCommitmentAt(getEpochAt(_ts));
+    return ExtRollupLib2.getCommitteeCommitmentAt(getEpochAt(_ts));
   }
 
   /**
@@ -204,7 +204,7 @@ contract Rollup is IStaking, IValidatorSelection, IRollup, RollupCore {
     bytes32 tipArchive = rollupStore.blocks[pendingBlockNumber].archive;
     require(tipArchive == _archive, Errors.Rollup__InvalidArchive(tipArchive, _archive));
 
-    address proposer = ValidatorSelectionLib.getProposerAt(slot);
+    address proposer = ExtRollupLib2.getProposerAt(slot);
     require(
       proposer == msg.sender, Errors.ValidatorSelection__InvalidProposer(proposer, msg.sender)
     );
@@ -213,7 +213,7 @@ contract Rollup is IStaking, IValidatorSelection, IRollup, RollupCore {
   }
 
   function getTargetCommitteeSize() external view override(IValidatorSelection) returns (uint256) {
-    return ValidatorSelectionLib.getStorage().targetCommitteeSize;
+    return ExtRollupLib2.getTargetCommitteeSize();
   }
 
   function getGenesisTime() external view override(IValidatorSelection) returns (Timestamp) {
@@ -429,7 +429,7 @@ contract Rollup is IStaking, IValidatorSelection, IRollup, RollupCore {
     override(IValidatorSelection)
     returns (uint256)
   {
-    return ValidatorSelectionLib.getSampleSeed(getEpochAt(_ts));
+    return ExtRollupLib2.getSampleSeedAt(getEpochAt(_ts));
   }
 
   /**
@@ -438,7 +438,7 @@ contract Rollup is IStaking, IValidatorSelection, IRollup, RollupCore {
    * @return The sample seed for the current epoch
    */
   function getCurrentSampleSeed() external view override(IValidatorSelection) returns (uint256) {
-    return ValidatorSelectionLib.getSampleSeed(getCurrentEpoch());
+    return ExtRollupLib2.getSampleSeedAt(getCurrentEpoch());
   }
 
   /**
@@ -631,7 +631,7 @@ contract Rollup is IStaking, IValidatorSelection, IRollup, RollupCore {
     override(IValidatorSelection)
     returns (address[] memory)
   {
-    return ValidatorSelectionLib.getCommitteeAt(_epoch);
+    return ExtRollupLib2.getCommitteeAt(_epoch);
   }
 
   /**
@@ -656,7 +656,7 @@ contract Rollup is IStaking, IValidatorSelection, IRollup, RollupCore {
    * @return The address of the proposer
    */
   function getProposerAt(Timestamp _ts) public override(IValidatorSelection) returns (address) {
-    return ValidatorSelectionLib.getProposerAt(_ts.slotFromTimestamp());
+    return ExtRollupLib2.getProposerAt(_ts.slotFromTimestamp());
   }
 
   /**

--- a/l1-contracts/src/core/RollupCore.sol
+++ b/l1-contracts/src/core/RollupCore.sol
@@ -19,8 +19,9 @@ import {Constants} from "@aztec/core/libraries/ConstantsGen.sol";
 import {CommitteeAttestation} from "@aztec/core/libraries/crypto/SignatureLib.sol";
 import {Errors} from "@aztec/core/libraries/Errors.sol";
 import {ExtRollupLib} from "@aztec/core/libraries/rollup/ExtRollupLib.sol";
+import {ExtRollupLib2} from "@aztec/core/libraries/rollup/ExtRollupLib2.sol";
 import {EthValue, FeeLib} from "@aztec/core/libraries/rollup/FeeLib.sol";
-import {ProposeArgs, ProposeLib} from "@aztec/core/libraries/rollup/ProposeLib.sol";
+import {ProposeArgs} from "@aztec/core/libraries/rollup/ProposeLib.sol";
 import {STFLib, GenesisState} from "@aztec/core/libraries/rollup/STFLib.sol";
 import {StakingLib} from "@aztec/core/libraries/staking/StakingLib.sol";
 import {Timestamp, Slot, Epoch, TimeLib} from "@aztec/core/libraries/TimeLib.sol";
@@ -48,8 +49,6 @@ contract RollupCore is
   IValidatorSelectionCore,
   IRollupCore
 {
-  using ProposeLib for ProposeArgs;
-
   using TimeLib for Timestamp;
   using TimeLib for Slot;
   using TimeLib for Epoch;
@@ -80,7 +79,7 @@ contract RollupCore is
     Timestamp exitDelay = Timestamp.wrap(60 * 60 * 24);
     Slasher slasher = new Slasher(_config.slashingQuorum, _config.slashingRoundSize);
     StakingLib.initialize(_stakingAsset, _gse, exitDelay, address(slasher));
-    ExtRollupLib.initializeValidatorSelection(_config.targetCommitteeSize);
+    ExtRollupLib2.initializeValidatorSelection(_config.targetCommitteeSize);
     RewardLib.initialize(_config.rewardConfig);
 
     L1_BLOCK_AT_GENESIS = block.number;
@@ -115,10 +114,6 @@ contract RollupCore is
     FeeLib.initialize(_config.manaTarget, _config.provingCostPerMana);
   }
 
-  /* -------------------------------------------------------------------------- */
-  /*                          CHEAT CODES START HERE                            */
-  /* -------------------------------------------------------------------------- */
-
   function updateManaTarget(uint256 _manaTarget) external override(IRollupCore) onlyOwner {
     uint256 currentManaTarget = FeeLib.getStorage().manaTarget;
     require(
@@ -129,17 +124,13 @@ contract RollupCore is
     emit IRollupCore.ManaTargetUpdated(_manaTarget);
   }
 
-  /* -------------------------------------------------------------------------- */
-  /*                          CHEAT CODES END HERE                              */
-  /* -------------------------------------------------------------------------- */
-
   function setRewardsClaimable(bool _isRewardsClaimable) external override(IRollupCore) onlyOwner {
     isRewardsClaimable = _isRewardsClaimable;
     emit RewardsClaimableUpdated(_isRewardsClaimable);
   }
 
   function setSlasher(address _slasher) external override(IStakingCore) onlyOwner {
-    ExtRollupLib.setSlasher(_slasher);
+    ExtRollupLib2.setSlasher(_slasher);
   }
 
   function setProvingCostPerMana(EthValue _provingCostPerMana)
@@ -169,14 +160,14 @@ contract RollupCore is
   }
 
   function vote(uint256 _proposalId) external override(IStakingCore) {
-    ExtRollupLib.vote(_proposalId);
+    ExtRollupLib2.vote(_proposalId);
   }
 
   function deposit(address _attester, address _withdrawer, bool _onCanonical)
     external
     override(IStakingCore)
   {
-    ExtRollupLib.deposit(_attester, _withdrawer, _onCanonical);
+    ExtRollupLib2.deposit(_attester, _withdrawer, _onCanonical);
   }
 
   function initiateWithdraw(address _attester, address _recipient)
@@ -184,7 +175,7 @@ contract RollupCore is
     override(IStakingCore)
     returns (bool)
   {
-    return ExtRollupLib.initiateWithdraw(_attester, _recipient);
+    return ExtRollupLib2.initiateWithdraw(_attester, _recipient);
   }
 
   function finaliseWithdraw(address _attester) external override(IStakingCore) {
@@ -216,11 +207,11 @@ contract RollupCore is
   }
 
   function setupEpoch() public override(IValidatorSelectionCore) {
-    ExtRollupLib.setupEpoch();
+    ExtRollupLib2.setupEpoch();
   }
 
   function setupSeedSnapshotForNextEpoch() public override(IValidatorSelectionCore) {
-    ExtRollupLib.setupSeedSnapshotForNextEpoch();
+    ExtRollupLib2.setupSeedSnapshotForNextEpoch();
   }
 
   /**

--- a/l1-contracts/src/core/libraries/rollup/ExtRollupLib.sol
+++ b/l1-contracts/src/core/libraries/rollup/ExtRollupLib.sol
@@ -4,12 +4,10 @@
 pragma solidity >=0.8.27;
 
 import {SubmitEpochRootProofArgs, PublicInputArgs} from "@aztec/core/interfaces/IRollup.sol";
-import {Epoch, Timestamp, TimeLib} from "@aztec/core/libraries/TimeLib.sol";
-import {StakingLib} from "./../staking/StakingLib.sol";
-import {ValidatorSelectionLib} from "./../validator-selection/ValidatorSelectionLib.sol";
+import {Timestamp, TimeLib} from "@aztec/core/libraries/TimeLib.sol";
 import {BlobLib} from "./BlobLib.sol";
 import {EpochProofLib} from "./EpochProofLib.sol";
-import {ProposeLib, ProposeArgs, CommitteeAttestation} from "./ProposeLib.sol";
+import {ProposeLib, ProposeArgs, CommitteeAttestation, ValidateHeaderArgs} from "./ProposeLib.sol";
 
 // We are using this library such that we can more easily "link" just a larger external library
 // instead of a few smaller ones.
@@ -20,6 +18,10 @@ library ExtRollupLib {
     EpochProofLib.submitEpochRootProof(_args);
   }
 
+  function validateHeader(ValidateHeaderArgs calldata _args) external {
+    ProposeLib.validateHeader(_args);
+  }
+
   function propose(
     ProposeArgs calldata _args,
     CommitteeAttestation[] memory _attestations,
@@ -27,36 +29,6 @@ library ExtRollupLib {
     bool _checkBlob
   ) external {
     ProposeLib.propose(_args, _attestations, _blobInput, _checkBlob);
-  }
-
-  function initializeValidatorSelection(uint256 _targetCommitteeSize) external {
-    ValidatorSelectionLib.initialize(_targetCommitteeSize);
-  }
-
-  function setupEpoch() external {
-    Epoch currentEpoch = Timestamp.wrap(block.timestamp).epochFromTimestamp();
-    ValidatorSelectionLib.setupEpoch(currentEpoch);
-  }
-
-  function setupSeedSnapshotForNextEpoch() external {
-    Epoch currentEpoch = Timestamp.wrap(block.timestamp).epochFromTimestamp();
-    ValidatorSelectionLib.setSampleSeedForNextEpoch(currentEpoch);
-  }
-
-  function setSlasher(address _slasher) external {
-    StakingLib.setSlasher(_slasher);
-  }
-
-  function vote(uint256 _proposalId) external {
-    StakingLib.vote(_proposalId);
-  }
-
-  function deposit(address _attester, address _withdrawer, bool _onCanonical) external {
-    StakingLib.deposit(_attester, _withdrawer, _onCanonical);
-  }
-
-  function initiateWithdraw(address _attester, address _recipient) external returns (bool) {
-    return StakingLib.initiateWithdraw(_attester, _recipient);
   }
 
   function getEpochProofPublicInputs(

--- a/l1-contracts/src/core/libraries/rollup/ExtRollupLib2.sol
+++ b/l1-contracts/src/core/libraries/rollup/ExtRollupLib2.sol
@@ -1,0 +1,62 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright 2024 Aztec Labs.
+// solhint-disable imports-order
+pragma solidity >=0.8.27;
+
+import {Epoch, Slot, Timestamp, TimeLib} from "@aztec/core/libraries/TimeLib.sol";
+import {StakingLib} from "./../staking/StakingLib.sol";
+import {ValidatorSelectionLib} from "./../validator-selection/ValidatorSelectionLib.sol";
+
+library ExtRollupLib2 {
+  using TimeLib for Timestamp;
+
+  function setSlasher(address _slasher) external {
+    StakingLib.setSlasher(_slasher);
+  }
+
+  function vote(uint256 _proposalId) external {
+    StakingLib.vote(_proposalId);
+  }
+
+  function deposit(address _attester, address _withdrawer, bool _onCanonical) external {
+    StakingLib.deposit(_attester, _withdrawer, _onCanonical);
+  }
+
+  function initiateWithdraw(address _attester, address _recipient) external returns (bool) {
+    return StakingLib.initiateWithdraw(_attester, _recipient);
+  }
+
+  function initializeValidatorSelection(uint256 _targetCommitteeSize) external {
+    ValidatorSelectionLib.initialize(_targetCommitteeSize);
+  }
+
+  function setupEpoch() external {
+    Epoch currentEpoch = Timestamp.wrap(block.timestamp).epochFromTimestamp();
+    ValidatorSelectionLib.setupEpoch(currentEpoch);
+  }
+
+  function setupSeedSnapshotForNextEpoch() external {
+    Epoch currentEpoch = Timestamp.wrap(block.timestamp).epochFromTimestamp();
+    ValidatorSelectionLib.setSampleSeedForNextEpoch(currentEpoch);
+  }
+
+  function getCommitteeAt(Epoch _epoch) external returns (address[] memory) {
+    return ValidatorSelectionLib.getCommitteeAt(_epoch);
+  }
+
+  function getProposerAt(Slot _slot) external returns (address) {
+    return ValidatorSelectionLib.getProposerAt(_slot);
+  }
+
+  function getCommitteeCommitmentAt(Epoch _epoch) external returns (bytes32, uint256) {
+    return ValidatorSelectionLib.getCommitteeCommitmentAt(_epoch);
+  }
+
+  function getSampleSeedAt(Epoch _epoch) external view returns (uint256) {
+    return ValidatorSelectionLib.getSampleSeed(_epoch);
+  }
+
+  function getTargetCommitteeSize() external view returns (uint256) {
+    return ValidatorSelectionLib.getStorage().targetCommitteeSize;
+  }
+}

--- a/yarn-project/ethereum/src/deploy_l1_contracts.ts
+++ b/yarn-project/ethereum/src/deploy_l1_contracts.ts
@@ -4,6 +4,8 @@ import { type Logger, createLogger } from '@aztec/foundation/log';
 import {
   CoinIssuerAbi,
   CoinIssuerBytecode,
+  ExtRollupLib2Abi,
+  ExtRollupLib2Bytecode,
   ExtRollupLibAbi,
   ExtRollupLibBytecode,
   FeeAssetHandlerAbi,
@@ -158,6 +160,10 @@ export const l1Artifacts = {
         ExtRollupLib: {
           contractAbi: ExtRollupLibAbi,
           contractBytecode: ExtRollupLibBytecode as Hex,
+        },
+        ExtRollupLib2: {
+          contractAbi: ExtRollupLib2Abi,
+          contractBytecode: ExtRollupLib2Bytecode as Hex,
         },
       },
     },

--- a/yarn-project/l1-artifacts/scripts/generate-artifacts.sh
+++ b/yarn-project/l1-artifacts/scripts/generate-artifacts.sh
@@ -14,6 +14,7 @@ contracts=(
   "CoinIssuer"
   "EmpireBase"
   "ExtRollupLib"
+  "ExtRollupLib2"
   "FeeJuicePortal"
   "Forwarder"
   "Governance"


### PR DESCRIPTION
Splitting the `ExtRollupLib` into two and moving more calls into it such that we have bit more wiggle room. Will increase gas costs, but we can go back to tighter fit when things are colder.