### PR TITLE
chore: Use the native call to find sibling path

### DIFF
--- a/barretenberg/cpp/src/barretenberg/crypto/merkle_tree/append_only_tree/content_addressed_append_only_tree.hpp
+++ b/barretenberg/cpp/src/barretenberg/crypto/merkle_tree/append_only_tree/content_addressed_append_only_tree.hpp
@@ -852,8 +852,10 @@ void ContentAddressedAppendOnlyTree<Store, HashingPolicy>::find_leaf_sibling_pat
                     }
                     OptionalSiblingPath optional_path =
                         get_subtree_sibling_path_internal(leaf_index.value(), 0, requestContext, *tx);
-                    fr_sibling_path leaf_path = optional_sibling_path_to_full_sibling_path(optional_path);
-                    response.inner.leaf_paths.emplace_back(leaf_path);
+                    SiblingPathAndIndex sibling_path_and_index;
+                    sibling_path_and_index.path = optional_sibling_path_to_full_sibling_path(optional_path);
+                    sibling_path_and_index.index = leaf_index.value();
+                    response.inner.leaf_paths.emplace_back(sibling_path_and_index);
                 }
             },
             on_completion);
@@ -896,8 +898,10 @@ void ContentAddressedAppendOnlyTree<Store, HashingPolicy>::find_leaf_sibling_pat
                     }
                     OptionalSiblingPath optional_path =
                         get_subtree_sibling_path_internal(leaf_index.value(), 0, requestContext, *tx);
-                    fr_sibling_path leaf_path = optional_sibling_path_to_full_sibling_path(optional_path);
-                    response.inner.leaf_paths.emplace_back(leaf_path);
+                    SiblingPathAndIndex sibling_path_and_index;
+                    sibling_path_and_index.path = optional_sibling_path_to_full_sibling_path(optional_path);
+                    sibling_path_and_index.index = leaf_index.value();
+                    response.inner.leaf_paths.emplace_back(sibling_path_and_index);
                 }
             },
             on_completion);

--- a/barretenberg/cpp/src/barretenberg/crypto/merkle_tree/append_only_tree/content_addressed_append_only_tree.test.cpp
+++ b/barretenberg/cpp/src/barretenberg/crypto/merkle_tree/append_only_tree/content_addressed_append_only_tree.test.cpp
@@ -125,6 +125,7 @@ void check_sibling_path(TreeType& tree,
 void check_sibling_path_by_value(TreeType& tree,
                                  fr value,
                                  fr_sibling_path expected_sibling_path,
+                                 index_t expected_index,
                                  bool includeUncommitted = true,
                                  bool expected_result = true)
 {
@@ -132,7 +133,9 @@ void check_sibling_path_by_value(TreeType& tree,
     auto completion = [&](const TypedResponse<FindLeafPathResponse>& response) -> void {
         EXPECT_EQ(response.success, expected_result);
         if (expected_result) {
-            EXPECT_EQ(response.inner.leaf_paths[0], expected_sibling_path);
+            EXPECT_TRUE(response.inner.leaf_paths[0].has_value());
+            EXPECT_EQ(response.inner.leaf_paths[0].value().sibling_path, expected_sibling_path);
+            EXPECT_EQ(response.inner.leaf_paths[0].value().index, expected_index);
         }
         signal.signal_level();
     };
@@ -161,14 +164,17 @@ void check_historic_sibling_path(TreeType& tree,
 void check_historic_sibling_path_by_value(TreeType& tree,
                                           fr value,
                                           fr_sibling_path expected_sibling_path,
+                                          index_t expected_index,
                                           block_number_t blockNumber,
                                           bool expected_success = true)
 {
     Signal signal;
     auto completion = [&](const TypedResponse<FindLeafPathResponse>& response) -> void {
         EXPECT_EQ(response.success, expected_success);
-        if (response.success) {
-            EXPECT_EQ(response.inner.leaf_paths[0], expected_sibling_path);
+        if (expected_success) {
+            EXPECT_TRUE(response.inner.leaf_paths[0].has_value());
+            EXPECT_EQ(response.inner.leaf_paths[0].value().sibling_path, expected_sibling_path);
+            EXPECT_EQ(response.inner.leaf_paths[0].value().index, expected_index);
         }
         signal.signal_level();
     };
@@ -411,7 +417,7 @@ TEST_F(PersistedContentAddressedAppendOnlyTreeTest, can_add_value_and_get_siblin
     check_size(tree, 1);
     check_root(tree, memdb.root());
     check_sibling_path(tree, 0, memdb.get_sibling_path(0));
-    check_sibling_path_by_value(tree, VALUES[0], memdb.get_sibling_path(0));
+    check_sibling_path_by_value(tree, VALUES[0], memdb.get_sibling_path(0), 0);
 }
 
 TEST_F(PersistedContentAddressedAppendOnlyTreeTest, reports_an_error_if_tree_is_overfilled)
@@ -736,8 +742,8 @@ TEST_F(PersistedContentAddressedAppendOnlyTreeTest, can_add_multiple_values)
         check_sibling_path(tree, 0, memdb.get_sibling_path(0));
         check_sibling_path(tree, i, memdb.get_sibling_path(i));
 
-        check_sibling_path_by_value(tree, VALUES[0], memdb.get_sibling_path(0));
-        check_sibling_path_by_value(tree, VALUES[i], memdb.get_sibling_path(i));
+        check_sibling_path_by_value(tree, VALUES[0], memdb.get_sibling_path(0), 0);
+        check_sibling_path_by_value(tree, VALUES[i], memdb.get_sibling_path(i), i);
     }
 }
 
@@ -762,8 +768,8 @@ TEST_F(PersistedContentAddressedAppendOnlyTreeTest, can_add_multiple_values_in_a
     check_root(tree, memdb.root());
     check_sibling_path(tree, 0, memdb.get_sibling_path(0));
     check_sibling_path(tree, 4 - 1, memdb.get_sibling_path(4 - 1));
-    check_sibling_path_by_value(tree, VALUES[0], memdb.get_sibling_path(0));
-    check_sibling_path_by_value(tree, VALUES[4 - 1], memdb.get_sibling_path(4 - 1));
+    check_sibling_path_by_value(tree, VALUES[0], memdb.get_sibling_path(0), 0);
+    check_sibling_path_by_value(tree, VALUES[4 - 1], memdb.get_sibling_path(4 - 1), 4 - 1);
 }
 
 TEST_F(PersistedContentAddressedAppendOnlyTreeTest, can_pad_with_zero_leaves)
@@ -917,10 +923,11 @@ TEST_F(PersistedContentAddressedAppendOnlyTreeTest, can_retrieve_historic_siblin
 
         for (uint32_t i = 0; i < historicPathsZeroIndex.size(); i++) {
             check_historic_sibling_path(tree, 0, historicPathsZeroIndex[i], i + 1);
-            check_historic_sibling_path_by_value(tree, VALUES[0], historicPathsZeroIndex[i], i + 1);
+            check_historic_sibling_path_by_value(tree, VALUES[0], historicPathsZeroIndex[i], 0, i + 1);
             index_t maxSizeAtBlock = ((i + 1) * batch_size) - 1;
             check_historic_sibling_path(tree, maxSizeAtBlock, historicPathsMaxIndex[i], i + 1);
-            check_historic_sibling_path_by_value(tree, VALUES[maxSizeAtBlock], historicPathsMaxIndex[i], i + 1);
+            check_historic_sibling_path_by_value(
+                tree, VALUES[maxSizeAtBlock], historicPathsMaxIndex[i], maxSizeAtBlock, i + 1);
         }
     };
 

--- a/barretenberg/cpp/src/barretenberg/crypto/merkle_tree/append_only_tree/content_addressed_append_only_tree.test.cpp
+++ b/barretenberg/cpp/src/barretenberg/crypto/merkle_tree/append_only_tree/content_addressed_append_only_tree.test.cpp
@@ -134,7 +134,7 @@ void check_sibling_path_by_value(TreeType& tree,
         EXPECT_EQ(response.success, expected_result);
         if (expected_result) {
             EXPECT_TRUE(response.inner.leaf_paths[0].has_value());
-            EXPECT_EQ(response.inner.leaf_paths[0].value().sibling_path, expected_sibling_path);
+            EXPECT_EQ(response.inner.leaf_paths[0].value().path, expected_sibling_path);
             EXPECT_EQ(response.inner.leaf_paths[0].value().index, expected_index);
         }
         signal.signal_level();
@@ -173,7 +173,7 @@ void check_historic_sibling_path_by_value(TreeType& tree,
         EXPECT_EQ(response.success, expected_success);
         if (expected_success) {
             EXPECT_TRUE(response.inner.leaf_paths[0].has_value());
-            EXPECT_EQ(response.inner.leaf_paths[0].value().sibling_path, expected_sibling_path);
+            EXPECT_EQ(response.inner.leaf_paths[0].value().path, expected_sibling_path);
             EXPECT_EQ(response.inner.leaf_paths[0].value().index, expected_index);
         }
         signal.signal_level();

--- a/barretenberg/cpp/src/barretenberg/crypto/merkle_tree/response.hpp
+++ b/barretenberg/cpp/src/barretenberg/crypto/merkle_tree/response.hpp
@@ -124,8 +124,26 @@ struct FindLeafIndexResponse {
     FindLeafIndexResponse& operator=(FindLeafIndexResponse&& other) noexcept = default;
 };
 
+struct SiblingPathAndIndex {
+    index_t index;
+    fr_sibling_path path;
+
+    MSGPACK_FIELDS(index, path);
+
+    SiblingPathAndIndex() = default;
+    ~SiblingPathAndIndex() = default;
+    SiblingPathAndIndex(index_t index, fr_sibling_path path)
+        : index(index)
+        , path(path)
+    {}
+    SiblingPathAndIndex(const SiblingPathAndIndex& other) = default;
+    SiblingPathAndIndex(SiblingPathAndIndex&& other) noexcept = default;
+    SiblingPathAndIndex& operator=(const SiblingPathAndIndex& other) = default;
+    SiblingPathAndIndex& operator=(SiblingPathAndIndex&& other) noexcept = default;
+};
+
 struct FindLeafPathResponse {
-    std::vector<std::optional<fr_sibling_path>> leaf_paths;
+    std::vector<std::optional<SiblingPathAndIndex>> leaf_paths;
 
     FindLeafPathResponse() = default;
     ~FindLeafPathResponse() = default;

--- a/barretenberg/cpp/src/barretenberg/nodejs_module/world_state/world_state_message.hpp
+++ b/barretenberg/cpp/src/barretenberg/nodejs_module/world_state/world_state_message.hpp
@@ -1,6 +1,7 @@
 #pragma once
 #include "barretenberg/crypto/merkle_tree/hash_path.hpp"
 #include "barretenberg/crypto/merkle_tree/indexed_tree/indexed_leaf.hpp"
+#include "barretenberg/crypto/merkle_tree/response.hpp"
 #include "barretenberg/crypto/merkle_tree/types.hpp"
 #include "barretenberg/ecc/curves/bn254/fr.hpp"
 #include "barretenberg/messaging/header.hpp"
@@ -181,7 +182,7 @@ template <typename T> struct FindLeafPathsRequest {
 };
 
 struct FindLeafPathsResponse {
-    std::vector<std::optional<fr_sibling_path>> paths;
+    std::vector<std::optional<SiblingPathAndIndex>> paths;
     MSGPACK_FIELDS(paths);
 };
 

--- a/barretenberg/cpp/src/barretenberg/world_state/world_state.hpp
+++ b/barretenberg/cpp/src/barretenberg/world_state/world_state.hpp
@@ -204,7 +204,7 @@ class WorldState {
     void find_sibling_paths(const WorldStateRevision& revision,
                             MerkleTreeId tree_id,
                             const std::vector<T>& leaves,
-                            std::vector<std::optional<fr_sibling_path>>& paths) const;
+                            std::vector<std::optional<SiblingPathAndIndex>>& paths) const;
 
     /**
      * @brief Appends a set of leaves to an existing Merkle Tree.
@@ -575,7 +575,7 @@ template <typename T>
 void WorldState::find_sibling_paths(const WorldStateRevision& rev,
                                     MerkleTreeId id,
                                     const std::vector<T>& leaves,
-                                    std::vector<std::optional<fr_sibling_path>>& paths) const
+                                    std::vector<std::optional<SiblingPathAndIndex>>& paths) const
 {
     using namespace crypto::merkle_tree;
 

--- a/yarn-project/aztec-node/src/aztec-node/server.ts
+++ b/yarn-project/aztec-node/src/aztec-node/server.ts
@@ -747,11 +747,13 @@ export class AztecNodeService implements AztecNode, AztecNodeAdmin, Traceable {
     archive: Fr,
   ): Promise<MembershipWitness<typeof ARCHIVE_HEIGHT> | undefined> {
     const committedDb = await this.#getWorldState(blockNumber);
-    const [index] = await committedDb.findLeafIndices(MerkleTreeId.ARCHIVE, [archive]);
-    if (index === undefined) {
-      return undefined;
-    }
-    return MembershipWitness.fromSiblingPath(index, await committedDb.getSiblingPath(MerkleTreeId.ARCHIVE, index));
+    const [pathAndIndex] = await committedDb.findSiblingPaths<MerkleTreeId.ARCHIVE, typeof ARCHIVE_HEIGHT>(
+      MerkleTreeId.ARCHIVE,
+      [archive],
+    );
+    return pathAndIndex === undefined
+      ? undefined
+      : MembershipWitness.fromSiblingPath(pathAndIndex.index, pathAndIndex.path);
   }
 
   public async getNoteHashMembershipWitness(
@@ -759,14 +761,13 @@ export class AztecNodeService implements AztecNode, AztecNodeAdmin, Traceable {
     noteHash: Fr,
   ): Promise<MembershipWitness<typeof NOTE_HASH_TREE_HEIGHT> | undefined> {
     const committedDb = await this.#getWorldState(blockNumber);
-    const [index] = await committedDb.findLeafIndices(MerkleTreeId.NOTE_HASH_TREE, [noteHash]);
-    if (index === undefined) {
-      return undefined;
-    }
-    return MembershipWitness.fromSiblingPath(
-      index,
-      await committedDb.getSiblingPath(MerkleTreeId.NOTE_HASH_TREE, index),
-    );
+    const [pathAndIndex] = await committedDb.findSiblingPaths<
+      MerkleTreeId.NOTE_HASH_TREE,
+      typeof NOTE_HASH_TREE_HEIGHT
+    >(MerkleTreeId.NOTE_HASH_TREE, [noteHash]);
+    return pathAndIndex === undefined
+      ? undefined
+      : MembershipWitness.fromSiblingPath(pathAndIndex.index, pathAndIndex.path);
   }
 
   /**

--- a/yarn-project/simulator/src/public/hinting_db_sources.ts
+++ b/yarn-project/simulator/src/public/hinting_db_sources.ts
@@ -470,7 +470,7 @@ export class HintingMerkleWriteOperations implements MerkleTreeWriteOperations {
   public async findSiblingPaths<ID extends MerkleTreeId, N extends number>(
     treeId: ID,
     values: MerkleTreeLeafType<ID>[],
-  ): Promise<(SiblingPath<N> | undefined)[]> {
+  ): Promise<({ path: SiblingPath<N>; index: bigint } | undefined)[]> {
     return await this.db.findSiblingPaths(treeId, values);
   }
 

--- a/yarn-project/simulator/src/public/public_processor/guarded_merkle_tree.ts
+++ b/yarn-project/simulator/src/public/public_processor/guarded_merkle_tree.ts
@@ -142,7 +142,7 @@ export class GuardedMerkleTreeOperations implements MerkleTreeWriteOperations {
   findSiblingPaths<ID extends MerkleTreeId, N extends number>(
     treeId: ID,
     values: MerkleTreeLeafType<ID>[],
-  ): Promise<(SiblingPath<N> | undefined)[]> {
+  ): Promise<({ path: SiblingPath<N>; index: bigint } | undefined)[]> {
     return this.guardAndPush(() => this.target.findSiblingPaths(treeId, values));
   }
 }

--- a/yarn-project/stdlib/src/interfaces/merkle_tree_operations.ts
+++ b/yarn-project/stdlib/src/interfaces/merkle_tree_operations.ts
@@ -186,7 +186,7 @@ export interface MerkleTreeReadOperations {
   findSiblingPaths<ID extends MerkleTreeId, N extends number>(
     treeId: ID,
     values: MerkleTreeLeafType<ID>[],
-  ): Promise<(SiblingPath<N> | undefined)[]>;
+  ): Promise<({ path: SiblingPath<N>; index: bigint } | undefined)[]>;
 
   /**
    * Returns the first index containing a leaf value after `startIndex`.

--- a/yarn-project/world-state/src/native/merkle_trees_facade.ts
+++ b/yarn-project/world-state/src/native/merkle_trees_facade.ts
@@ -1,5 +1,5 @@
 import { Fr } from '@aztec/foundation/fields';
-import { serializeToBuffer } from '@aztec/foundation/serialize';
+import { assertLength, serializeToBuffer } from '@aztec/foundation/serialize';
 import { type IndexedTreeLeafPreimage, SiblingPath } from '@aztec/foundation/trees';
 import type {
   BatchInsertionResult,
@@ -49,7 +49,7 @@ export class MerkleTreesFacade implements MerkleTreeReadOperations {
   async findSiblingPaths<N extends number>(
     treeId: MerkleTreeId,
     values: MerkleTreeLeafType<MerkleTreeId>[],
-  ): Promise<(SiblingPath<N> | undefined)[]> {
+  ): Promise<({ path: SiblingPath<N>; index: bigint } | undefined)[]> {
     const response = await this.instance.call(WorldStateMessageType.FIND_SIBLING_PATHS, {
       leaves: values.map(leaf => serializeLeaf(hydrateLeaf(treeId, leaf))),
       revision: this.revision,
@@ -60,7 +60,7 @@ export class MerkleTreesFacade implements MerkleTreeReadOperations {
       if (!path) {
         return undefined;
       }
-      return new SiblingPath(path.length, path) as any;
+      return { path: new SiblingPath<N>(path.path.length as N, path.path), index: BigInt(path.index) };
     });
   }
 

--- a/yarn-project/world-state/src/native/merkle_trees_facade.ts
+++ b/yarn-project/world-state/src/native/merkle_trees_facade.ts
@@ -1,5 +1,5 @@
 import { Fr } from '@aztec/foundation/fields';
-import { assertLength, serializeToBuffer } from '@aztec/foundation/serialize';
+import { serializeToBuffer } from '@aztec/foundation/serialize';
 import { type IndexedTreeLeafPreimage, SiblingPath } from '@aztec/foundation/trees';
 import type {
   BatchInsertionResult,

--- a/yarn-project/world-state/src/native/message.ts
+++ b/yarn-project/world-state/src/native/message.ts
@@ -354,8 +354,13 @@ interface FindLeafIndicesResponse {
 }
 
 interface FindSiblingPathsRequest extends WithTreeId, WithLeafValues, WithWorldStateRevision {}
+
+interface SiblingPathAndIndex {
+  index: bigint;
+  path: Buffer[];
+}
 interface FindSiblingPathsResponse {
-  paths: Buffer[][];
+  paths: (SiblingPathAndIndex | undefined)[];
 }
 
 interface FindLowLeafRequest extends WithTreeId, WithWorldStateRevision {

--- a/yarn-project/world-state/src/native/native_world_state.test.ts
+++ b/yarn-project/world-state/src/native/native_world_state.test.ts
@@ -938,10 +938,12 @@ describe('NativeWorldState', () => {
           undefined,
           await readOps.getSiblingPath(treeId, indices[5]!),
         ];
+        const expectedIndices = [indices[0], undefined, indices[2], indices[3], undefined, indices[5]];
         const paths = await readOps.findSiblingPaths(treeId, leavesToRequest);
         expect(paths.length).toBe(expectedPaths.length);
         for (let i = 0; i < paths.length; i++) {
-          expect(paths[i]).toEqual(expectedPaths[i]);
+          expect(paths[i]?.path).toEqual(expectedPaths[i]);
+          expect(paths[i]?.index).toEqual(expectedIndices[i]);
         }
       };
       await testQuery(noteHashes, MerkleTreeId.NOTE_HASH_TREE, Fr.random);


### PR DESCRIPTION
This PR contains a minor performance improbment in using the native `findSiblingPaths` function.
