### PR TITLE
feat!: minimum committee size

### DIFF
--- a/l1-contracts/src/core/libraries/Errors.sol
+++ b/l1-contracts/src/core/libraries/Errors.sol
@@ -105,6 +105,7 @@ library Errors {
   error ValidatorSelection__InsufficientAttestations(uint256 minimumNeeded, uint256 provided); // 0xaf47297f
   error ValidatorSelection__InvalidCommitteeCommitment(bytes32 reconstructed, bytes32 expected); // 0xca8d5954
   error ValidatorSelection__InvalidAttestationsLength(uint256 expected, uint256 actual); // 0xe923198c
+  error ValidatorSelection__InsufficientCommitteeSize(uint256 actual, uint256 expected);
 
   // Staking
   error Staking__AlreadyQueued(address _attester);

--- a/l1-contracts/src/core/libraries/crypto/SampleLib.sol
+++ b/l1-contracts/src/core/libraries/crypto/SampleLib.sol
@@ -39,6 +39,10 @@ library SampleLib {
       Errors.SampleLib__SampleLargerThanIndex(_committeeSize, _indexCount)
     );
 
+    if (_committeeSize == 0) {
+      return new uint256[](0);
+    }
+
     uint256[] memory sampledIndices = new uint256[](_committeeSize);
 
     uint256 upperLimit = _indexCount - 1;

--- a/l1-contracts/test/MultiProof.t.sol
+++ b/l1-contracts/test/MultiProof.t.sol
@@ -4,8 +4,6 @@ pragma solidity >=0.8.27;
 
 import {DecoderBase} from "./base/DecoderBase.sol";
 
-import {Constants} from "@aztec/core/libraries/ConstantsGen.sol";
-
 import {Registry} from "@aztec/governance/Registry.sol";
 import {FeeJuicePortal} from "@aztec/core/messagebridge/FeeJuicePortal.sol";
 import {TestERC20} from "@aztec/mock/TestERC20.sol";
@@ -17,12 +15,10 @@ import {
   Timestamp, Slot, Epoch, SlotLib, EpochLib, TimeLib
 } from "@aztec/core/libraries/TimeLib.sol";
 
-import {Rollup} from "@aztec/core/Rollup.sol";
 import {Strings} from "@oz/utils/Strings.sol";
 import {Errors} from "@aztec/core/libraries/Errors.sol";
-import {IERC20} from "@oz/token/ERC20/IERC20.sol";
 
-import {RollupBase, IInstance, IRollup} from "./base/RollupBase.sol";
+import {RollupBase, IInstance} from "./base/RollupBase.sol";
 import {RollupBuilder} from "./builder/RollupBuilder.sol";
 import {Ownable} from "@oz/access/Ownable.sol";
 import {ActivityScore} from "@aztec/core/libraries/rollup/RewardLib.sol";
@@ -72,7 +68,7 @@ contract MultiProofTest is RollupBase {
       vm.warp(initialTime);
     }
 
-    RollupBuilder builder = new RollupBuilder(address(this));
+    RollupBuilder builder = new RollupBuilder(address(this)).setTargetCommitteeSize(0);
     builder.deploy();
 
     rollup = IInstance(address(builder.getConfig().rollup));

--- a/l1-contracts/test/Rollup.t.sol
+++ b/l1-contracts/test/Rollup.t.sol
@@ -12,7 +12,6 @@ import {Registry} from "@aztec/governance/Registry.sol";
 import {Inbox} from "@aztec/core/messagebridge/Inbox.sol";
 import {Outbox} from "@aztec/core/messagebridge/Outbox.sol";
 import {Errors} from "@aztec/core/libraries/Errors.sol";
-import {Rollup} from "@aztec/core/Rollup.sol";
 import {ProposedHeader} from "@aztec/core/libraries/rollup/ProposedHeaderLib.sol";
 
 import {
@@ -83,7 +82,7 @@ contract RollupTest is RollupBase {
       vm.warp(initialTime);
     }
 
-    RollupBuilder builder = new RollupBuilder(address(this));
+    RollupBuilder builder = new RollupBuilder(address(this)).setTargetCommitteeSize(0);
     builder.deploy();
 
     testERC20 = builder.getConfig().testERC20;

--- a/l1-contracts/test/RollupGetters.t.sol
+++ b/l1-contracts/test/RollupGetters.t.sol
@@ -1,45 +1,14 @@
 // SPDX-License-Identifier: Apache-2.0
 // Copyright 2024 Aztec Labs.
+// solhint-disable imports-order
+// solhint-disable comprehensive-interface
+// solhint-disable func-name-mixedcase
 pragma solidity >=0.8.27;
 
-import {DecoderBase} from "./base/DecoderBase.sol";
-
-import {DataStructures} from "@aztec/core/libraries/DataStructures.sol";
-import {Constants} from "@aztec/core/libraries/ConstantsGen.sol";
-import {Signature} from "@aztec/core/libraries/crypto/SignatureLib.sol";
-import {Math} from "@oz/utils/math/Math.sol";
-
-import {Registry} from "@aztec/governance/Registry.sol";
-import {Inbox} from "@aztec/core/messagebridge/Inbox.sol";
-import {Outbox} from "@aztec/core/messagebridge/Outbox.sol";
-import {Errors} from "@aztec/core/libraries/Errors.sol";
-import {Rollup} from "@aztec/core/Rollup.sol";
+import {IRollupCore, BlockLog} from "@aztec/core/interfaces/IRollup.sol";
 import {TestConstants} from "./harnesses/TestConstants.sol";
-
-import {
-  IRollup,
-  IRollupCore,
-  BlockLog,
-  SubmitEpochRootProofArgs,
-  EthValue,
-  FeeAssetValue,
-  FeeAssetPerEthE9,
-  PublicInputArgs
-} from "@aztec/core/interfaces/IRollup.sol";
-import {FeeJuicePortal} from "@aztec/core/messagebridge/FeeJuicePortal.sol";
-import {NaiveMerkle} from "./merkle/Naive.sol";
-import {MerkleTestUtil} from "./merkle/TestUtil.sol";
-import {TestERC20} from "@aztec/mock/TestERC20.sol";
-import {TestConstants} from "./harnesses/TestConstants.sol";
-import {RewardDistributor} from "@aztec/governance/RewardDistributor.sol";
-import {IERC20Errors} from "@oz/interfaces/draft-IERC6093.sol";
-import {ProposeArgs, OracleInput, ProposeLib} from "@aztec/core/libraries/rollup/ProposeLib.sol";
-import {IERC20} from "@oz/token/ERC20/IERC20.sol";
-import {
-  Timestamp, Slot, Epoch, SlotLib, EpochLib, TimeLib
-} from "@aztec/core/libraries/TimeLib.sol";
+import {Timestamp, Slot, Epoch} from "@aztec/core/libraries/TimeLib.sol";
 import {RewardConfig, Bps} from "@aztec/core/libraries/rollup/RewardLib.sol";
-
 import {ValidatorSelectionTestBase} from "./validator-selection/ValidatorSelectionBase.sol";
 
 /**
@@ -50,8 +19,9 @@ import {ValidatorSelectionTestBase} from "./validator-selection/ValidatorSelecti
  * We have to look a bit into the `RollupCore.sol` to make sure that we are not missing anything.
  */
 contract RollupShouldBeGetters is ValidatorSelectionTestBase {
-  function test_getEpochCommittee(uint16 _epochToGet, bool _setup) external setup(4) {
-    uint256 expectedSize = _epochToGet < 2 ? 0 : 4;
+  function test_getEpochCommittee(uint16 _epochToGet, bool _setup) external setup(4, 4) {
+    vm.assume(_epochToGet >= 2);
+    uint256 expectedSize = 4;
     Epoch e = Epoch.wrap(_epochToGet);
     Timestamp t = timeCheater.epochToTimestamp(e);
 
@@ -78,8 +48,9 @@ contract RollupShouldBeGetters is ValidatorSelectionTestBase {
     assertEq(writes.length, 0, "No writes should be done");
   }
 
-  function test_getEpochCommitteeBig(uint16 _epochToGet, bool _setup) external setup(49) {
-    uint256 expectedSize = _epochToGet < 2 ? 0 : 48;
+  function test_getBigEpochCommittee(uint16 _epochToGet, bool _setup) external setup(49, 48) {
+    vm.assume(_epochToGet >= 2);
+    uint256 expectedSize = 48;
     Epoch e = Epoch.wrap(_epochToGet);
     Timestamp t = timeCheater.epochToTimestamp(e);
 
@@ -106,8 +77,9 @@ contract RollupShouldBeGetters is ValidatorSelectionTestBase {
     assertEq(writes.length, 0, "No writes should be done");
   }
 
-  function test_getProposerAt(uint16 _slot, bool _setup) external setup(4) {
-    Slot s = Slot.wrap(_slot);
+  function test_getProposerAt(uint16 _slot, bool _setup) external setup(4, 4) {
+    timeCheater.cheat__jumpForwardEpochs(2);
+    Slot s = Slot.wrap(timeCheater.currentSlot()) + Slot.wrap(_slot);
     Timestamp t = timeCheater.slotToTimestamp(s);
 
     vm.warp(Timestamp.unwrap(t));
@@ -127,12 +99,12 @@ contract RollupShouldBeGetters is ValidatorSelectionTestBase {
     assertEq(writes.length, 0, "No writes should be done");
   }
 
-  function test_validateHeader() external setup(4) {
+  function test_validateHeader() external setup(4, 4) {
     // Todo this one is a bit annoying here really. We need a lot of header information.
   }
 
-  function test_canProposeAtTime(uint16 _timestamp, bool _setup) external setup(1) {
-    timeCheater.cheat__progressEpoch();
+  function test_canProposeAtTime(uint16 _timestamp, bool _setup) external setup(1, 1) {
+    timeCheater.cheat__jumpForwardEpochs(2);
 
     Timestamp t = Timestamp.wrap(block.timestamp + _timestamp);
 
@@ -155,7 +127,7 @@ contract RollupShouldBeGetters is ValidatorSelectionTestBase {
     assertEq(writes.length, 0, "No writes should be done");
   }
 
-  function test_getRewardConfig() external setup(1) {
+  function test_getRewardConfig() external setup(1, 1) {
     RewardConfig memory defaultConfig = TestConstants.getRewardConfig();
 
     RewardConfig memory config = rollup.getRewardConfig();

--- a/l1-contracts/test/builder/RollupBuilder.sol
+++ b/l1-contracts/test/builder/RollupBuilder.sol
@@ -1,5 +1,6 @@
 // SPDX-License-Identifier: Apache-2.0
 // Copyright 2024 Aztec Labs.
+// solhint-disable comprehensive-interface
 pragma solidity >=0.8.27;
 
 import {Rollup, GenesisState, RollupConfigInput} from "@aztec/core/Rollup.sol";
@@ -13,6 +14,7 @@ import {Governance} from "@aztec/governance/Governance.sol";
 import {GovernanceProposer} from "@aztec/governance/proposer/GovernanceProposer.sol";
 import {MockVerifier} from "@aztec/mock/MockVerifier.sol";
 import {Test} from "forge-std/Test.sol";
+import {MultiAdder, CheatDepositArgs} from "@aztec/mock/MultiAdder.sol";
 
 // Stack the layers to avoid the stack too deep 🧌
 struct ConfigFlags {
@@ -40,6 +42,7 @@ struct Config {
   RollupConfigInput rollupConfigInput;
   ConfigValues values;
   ConfigFlags flags;
+  CheatDepositArgs[] validators;
 }
 
 /**
@@ -197,6 +200,13 @@ contract RollupBuilder is Test {
     return this;
   }
 
+  function setValidators(CheatDepositArgs[] memory _validators) public returns (RollupBuilder) {
+    for (uint256 i = 0; i < _validators.length; i++) {
+      config.validators.push(_validators[i]);
+    }
+    return this;
+  }
+
   /* -------------------------------------------------------------------------- */
   /*                              Rollup config end                             */
   /* -------------------------------------------------------------------------- */
@@ -259,6 +269,14 @@ contract RollupBuilder is Test {
 
       vm.prank(config.gse.owner());
       config.gse.addRollup(address(config.rollup));
+    }
+
+    if (config.validators.length > 0) {
+      MultiAdder multiAdder = new MultiAdder(address(config.rollup), address(this));
+      config.testERC20.mint(
+        address(multiAdder), config.gse.DEPOSIT_AMOUNT() * config.validators.length
+      );
+      multiAdder.addValidators(config.validators);
     }
 
     if (config.flags.updateOwnerships) {

--- a/l1-contracts/test/fees/FeeRollup.t.sol
+++ b/l1-contracts/test/fees/FeeRollup.t.sol
@@ -109,7 +109,9 @@ contract FeeRollupTest is FeeModelTestPoints, DecoderBase {
 
     RollupBuilder builder = new RollupBuilder(address(this)).setProvingCostPerMana(provingCost)
       .setManaTarget(MANA_TARGET).setSlotDuration(SLOT_DURATION).setEpochDuration(EPOCH_DURATION)
-      .setProofSubmissionWindow(EPOCH_DURATION * 2 - 1).setMintFeeAmount(1e30);
+      .setProofSubmissionWindow(EPOCH_DURATION * 2 - 1).setMintFeeAmount(1e30).setTargetCommitteeSize(
+      0
+    );
     builder.deploy();
 
     rollup = builder.getConfig().rollup;

--- a/l1-contracts/test/governance/scenario/AddRollup.t.sol
+++ b/l1-contracts/test/governance/scenario/AddRollup.t.sol
@@ -70,7 +70,7 @@ contract AddRollupTest is TestBase {
     // We need to make a timejump that is far enough that we can go at least 2 epochs in the past
     vm.warp(100000);
     RollupBuilder builder = new RollupBuilder(address(this)).setGovProposerN(7).setGovProposerM(10)
-      .setEntryQueueFlushSizeMin(VALIDATOR_COUNT * 2);
+      .setEntryQueueFlushSizeMin(VALIDATOR_COUNT * 2).setTargetCommitteeSize(0);
     builder.deploy();
 
     rollup = builder.getConfig().rollup;

--- a/l1-contracts/test/governance/scenario/UpgradeGovernanceProposerTest.t.sol
+++ b/l1-contracts/test/governance/scenario/UpgradeGovernanceProposerTest.t.sol
@@ -23,6 +23,7 @@ import {MultiAdder, CheatDepositArgs} from "@aztec/mock/MultiAdder.sol";
 import {RollupBuilder} from "../../builder/RollupBuilder.sol";
 import {IGSE} from "@aztec/core/staking/GSE.sol";
 import {GSEPayload} from "@aztec/governance/GSEPayload.sol";
+import {TimeCheater} from "../../staking/TimeCheater.sol";
 
 /**
  * @title UpgradeGovernanceProposerTest
@@ -38,6 +39,7 @@ contract UpgradeGovernanceProposerTest is TestBase {
   GovernanceProposer internal governanceProposer;
   Rollup internal rollup;
   IGSE internal gse;
+  TimeCheater internal timeCheater;
 
   DataStructures.Proposal internal proposal;
 
@@ -51,17 +53,6 @@ contract UpgradeGovernanceProposerTest is TestBase {
 
   function setUp() external {
     // We do a timejump to ensure that we don't underflow with time when looking up sample
-    vm.warp(100000);
-    RollupBuilder builder = new RollupBuilder(address(this)).setGovProposerN(7).setGovProposerM(10);
-    builder.deploy();
-
-    rollup = builder.getConfig().rollup;
-    registry = builder.getConfig().registry;
-    token = builder.getConfig().testERC20;
-    governance = builder.getConfig().governance;
-    governanceProposer = GovernanceProposer(governance.governanceProposer());
-    gse = IGSE(address(rollup.getGSE()));
-
     CheatDepositArgs[] memory initialValidators = new CheatDepositArgs[](VALIDATOR_COUNT);
     for (uint256 i = 1; i <= VALIDATOR_COUNT; i++) {
       uint256 privateKey = uint256(keccak256(abi.encode("validator", i)));
@@ -71,17 +62,31 @@ contract UpgradeGovernanceProposerTest is TestBase {
       initialValidators[i - 1] = CheatDepositArgs({attester: validator, withdrawer: validator});
     }
 
-    MultiAdder multiAdder = new MultiAdder(address(rollup), address(this));
-    token.mint(address(multiAdder), rollup.getDepositAmount() * VALIDATOR_COUNT);
-    multiAdder.addValidators(initialValidators);
+    RollupBuilder builder = new RollupBuilder(address(this)).setGovProposerN(7).setGovProposerM(10)
+      .setValidators(initialValidators).setTargetCommitteeSize(4).setEpochDuration(1);
+    builder.deploy();
+
+    rollup = builder.getConfig().rollup;
+    registry = builder.getConfig().registry;
+    token = builder.getConfig().testERC20;
+    governance = builder.getConfig().governance;
+    governanceProposer = GovernanceProposer(governance.governanceProposer());
+    gse = IGSE(address(rollup.getGSE()));
 
     registry.updateGovernance(address(governance));
     registry.transferOwnership(address(governance));
+
+    timeCheater = new TimeCheater(
+      address(rollup),
+      block.timestamp,
+      builder.getConfig().rollupConfigInput.aztecSlotDuration,
+      builder.getConfig().rollupConfigInput.aztecEpochDuration
+    );
   }
 
   function test_UpgradeIntoNewVersion() external {
+    timeCheater.cheat__jumpForwardEpochs(2);
     payload = IPayload(address(new NewGovernanceProposerPayload(registry, gse)));
-    vm.warp(Timestamp.unwrap(rollup.getTimestampForSlot(Slot.wrap(1))));
 
     for (uint256 i = 0; i < 10; i++) {
       address proposer = rollup.getCurrentProposer();

--- a/l1-contracts/test/governance/scenario/slashing/Slashing.t.sol
+++ b/l1-contracts/test/governance/scenario/slashing/Slashing.t.sol
@@ -79,7 +79,8 @@ contract SlashingTest is TestBase {
       initialValidators[i - 1] = CheatDepositArgs({attester: attester, withdrawer: address(this)});
     }
 
-    RollupBuilder builder = new RollupBuilder(address(this));
+    RollupBuilder builder =
+      new RollupBuilder(address(this)).setValidators(initialValidators).setTargetCommitteeSize(4);
     builder.deploy();
 
     rollup = builder.getConfig().rollup;
@@ -95,10 +96,6 @@ contract SlashingTest is TestBase {
       TestConstants.AZTEC_SLOT_DURATION,
       TestConstants.AZTEC_EPOCH_DURATION
     );
-
-    MultiAdder multiAdder = new MultiAdder(address(rollup), address(this));
-    testERC20.mint(address(multiAdder), rollup.getDepositAmount() * validatorCount);
-    multiAdder.addValidators(initialValidators);
 
     // We jumpt forward 2 epochs because there are nothing interesting happening in the first epochs
     // as our sampling is delayed zzz.

--- a/l1-contracts/test/ignition.t.sol
+++ b/l1-contracts/test/ignition.t.sol
@@ -4,8 +4,6 @@ pragma solidity >=0.8.27;
 
 import {DecoderBase} from "./base/DecoderBase.sol";
 
-import {Constants} from "@aztec/core/libraries/ConstantsGen.sol";
-
 import {Registry} from "@aztec/governance/Registry.sol";
 import {FeeJuicePortal} from "@aztec/core/messagebridge/FeeJuicePortal.sol";
 import {TestERC20} from "@aztec/mock/TestERC20.sol";
@@ -17,12 +15,9 @@ import {
   Timestamp, Slot, Epoch, SlotLib, EpochLib, TimeLib
 } from "@aztec/core/libraries/TimeLib.sol";
 
-import {Rollup} from "@aztec/core/Rollup.sol";
-import {Strings} from "@oz/utils/Strings.sol";
 import {Errors} from "@aztec/core/libraries/Errors.sol";
 
 import {RollupBase, IInstance} from "./base/RollupBase.sol";
-import {IRollup, RollupConfigInput} from "@aztec/core/interfaces/IRollup.sol";
 import {RollupBuilder} from "./builder/RollupBuilder.sol";
 import {TimeCheater} from "./staking/TimeCheater.sol";
 // solhint-disable comprehensive-interface
@@ -71,7 +66,8 @@ contract IgnitionTest is RollupBase {
       vm.warp(initialTime);
     }
 
-    RollupBuilder builder = new RollupBuilder(address(this)).setManaTarget(0);
+    RollupBuilder builder =
+      new RollupBuilder(address(this)).setManaTarget(0).setTargetCommitteeSize(0);
     builder.deploy();
 
     rollup = IInstance(address(builder.getConfig().rollup));

--- a/l1-contracts/test/validator-selection/ValidatorSelection.t.sol
+++ b/l1-contracts/test/validator-selection/ValidatorSelection.t.sol
@@ -61,7 +61,7 @@ contract ValidatorSelectionTest is ValidatorSelectionTestBase {
     invalidCommitteeCommitment: false
   });
 
-  function testInitialCommitteeMatch() public setup(4) progressEpochs(2) {
+  function testInitialCommitteeMatch() public setup(4, 4) progressEpochs(2) {
     address[] memory attesters = rollup.getAttesters();
     address[] memory committee = rollup.getCurrentEpochCommittee();
     assertEq(rollup.getCurrentEpoch(), 2);
@@ -84,7 +84,7 @@ contract ValidatorSelectionTest is ValidatorSelectionTestBase {
     assertTrue(_seenCommittee[proposer]);
   }
 
-  function testProposerForNonSetupEpoch(uint8 _epochsToJump) public setup(4) progressEpochs(2) {
+  function testProposerForNonSetupEpoch(uint8 _epochsToJump) public setup(4, 4) progressEpochs(2) {
     Epoch pre = rollup.getCurrentEpoch();
     vm.warp(
       block.timestamp
@@ -104,7 +104,7 @@ contract ValidatorSelectionTest is ValidatorSelectionTestBase {
     assertEq(expectedProposer, actualProposer, "Invalid proposer");
   }
 
-  function testCommitteeForNonSetupEpoch(uint8 _epochsToJump) public setup(4) progressEpochs(2) {
+  function testCommitteeForNonSetupEpoch(uint8 _epochsToJump) public setup(4, 4) progressEpochs(2) {
     Epoch pre = rollup.getCurrentEpoch();
     vm.warp(
       block.timestamp
@@ -127,7 +127,7 @@ contract ValidatorSelectionTest is ValidatorSelectionTestBase {
     assertEq(preCommittee, postCommittee, "Committee elements have changed");
   }
 
-  function testStableCommittee(uint8 _timeToJump) public setup(4) progressEpochs(2) {
+  function testStableCommittee(uint8 _timeToJump) public setup(4, 4) progressEpochs(2) {
     Epoch epoch = rollup.getCurrentEpoch();
 
     uint256 preSize = rollup.getActiveAttesterCount();
@@ -165,7 +165,7 @@ contract ValidatorSelectionTest is ValidatorSelectionTestBase {
   /// forge-config: default.isolate = true
   function testValidatorSetLargerThanCommittee(bool _insufficientSigs)
     public
-    setup(100)
+    setup(100, 48)
     progressEpochs(2)
   {
     assertGt(rollup.getAttesters().length, rollup.getTargetCommitteeSize(), "Not enough validators");
@@ -190,12 +190,12 @@ contract ValidatorSelectionTest is ValidatorSelectionTestBase {
     );
   }
 
-  function testHappyPath() public setup(4) progressEpochs(2) {
+  function testHappyPath() public setup(4, 4) progressEpochs(2) {
     _testBlock("mixed_block_1", false, 3, NO_FLAGS);
     _testBlock("mixed_block_2", false, 3, NO_FLAGS);
   }
 
-  function testNukeFromOrbit() public setup(4) progressEpochs(2) {
+  function testNukeFromOrbit() public setup(4, 4) progressEpochs(2) {
     // We propose some blocks, and have a bunch of validators attest to them.
     // Then we slash EVERYONE that was in the committees because the epoch never
     // got finalised.
@@ -232,7 +232,7 @@ contract ValidatorSelectionTest is ValidatorSelectionTestBase {
     }
   }
 
-  function testRelayedForProposer() public setup(4) progressEpochs(2) {
+  function testRelayedForProposer() public setup(4, 4) progressEpochs(2) {
     // Having someone that is not the proposer submit it, but with all signatures (so there is signature from proposer)
     _testBlock(
       "mixed_block_1",
@@ -247,7 +247,7 @@ contract ValidatorSelectionTest is ValidatorSelectionTestBase {
     );
   }
 
-  function testProposerNotProvided() public setup(4) progressEpochs(2) {
+  function testProposerNotProvided() public setup(4, 4) progressEpochs(2) {
     _testBlock(
       "mixed_block_1",
       true,
@@ -261,7 +261,7 @@ contract ValidatorSelectionTest is ValidatorSelectionTestBase {
     );
   }
 
-  function testInvalidCommitteeCommitment() public setup(4) progressEpochs(2) {
+  function testInvalidCommitteeCommitment() public setup(4, 4) progressEpochs(2) {
     _testBlock(
       "mixed_block_1",
       true,
@@ -275,7 +275,7 @@ contract ValidatorSelectionTest is ValidatorSelectionTestBase {
     );
   }
 
-  function testInsufficientSigsMove() public setup(4) progressEpochs(2) {
+  function testInsufficientSigsMove() public setup(4, 4) progressEpochs(2) {
     GSE gse = rollup.getGSE();
     address caller = gse.owner();
     vm.prank(caller);

--- a/l1-contracts/test/validator-selection/ValidatorSelectionBase.sol
+++ b/l1-contracts/test/validator-selection/ValidatorSelectionBase.sol
@@ -64,7 +64,7 @@ contract ValidatorSelectionTestBase is DecoderBase {
   /**
    * @notice Setup contracts needed for the tests with the a given number of validators
    */
-  modifier setup(uint256 _validatorCount) {
+  modifier setup(uint256 _validatorCount, uint256 _targetCommitteeSize) {
     string memory _name = "mixed_block_1";
     {
       DecoderBase.Full memory full = load(_name);
@@ -87,8 +87,9 @@ contract ValidatorSelectionTestBase is DecoderBase {
       initialValidators[i - 1] = createDepositArgs(i);
     }
 
-    RollupBuilder builder =
-      new RollupBuilder(address(this)).setEntryQueueFlushSizeMin(_validatorCount);
+    RollupBuilder builder = new RollupBuilder(address(this)).setEntryQueueFlushSizeMin(
+      _validatorCount
+    ).setValidators(initialValidators).setTargetCommitteeSize(_targetCommitteeSize);
     builder.deploy();
 
     rollup = builder.getConfig().rollup;
@@ -96,12 +97,6 @@ contract ValidatorSelectionTestBase is DecoderBase {
     testERC20 = builder.getConfig().testERC20;
     slasher = Slasher(rollup.getSlasher());
     slashFactory = new SlashFactory(IValidatorSelection(address(rollup)));
-
-    if (initialValidators.length > 0) {
-      MultiAdder multiAdder = new MultiAdder(address(rollup), address(this));
-      testERC20.mint(address(multiAdder), rollup.getDepositAmount() * initialValidators.length);
-      multiAdder.addValidators(initialValidators);
-    }
 
     inbox = Inbox(address(rollup.getInbox()));
     outbox = Outbox(address(rollup.getOutbox()));

--- a/l1-contracts/test/validator-selection/setupEpoch.t.sol
+++ b/l1-contracts/test/validator-selection/setupEpoch.t.sol
@@ -2,29 +2,31 @@
 // Copyright 2025 Aztec Labs.
 pragma solidity >=0.8.27;
 
-import {ValidatorSelectionTestBase, CheatDepositArgs} from "./ValidatorSelectionBase.sol";
-import {Epoch, Timestamp} from "@aztec/core/libraries/TimeLib.sol";
-import {Checkpoints} from "@oz/utils/structs/Checkpoints.sol";
 import {IValidatorSelection} from "@aztec/core/interfaces/IValidatorSelection.sol";
-import {TestConstants} from "../harnesses/TestConstants.sol";
+import {Timestamp} from "@aztec/core/libraries/TimeLib.sol";
 import {MultiAdder} from "@aztec/mock/MultiAdder.sol";
 import {IStaking} from "@aztec/core/interfaces/IStaking.sol";
 import {stdStorage, StdStorage} from "forge-std/Test.sol";
+import {Checkpoints} from "@oz/utils/structs/Checkpoints.sol";
+import {TestConstants} from "./../harnesses/TestConstants.sol";
+import {ValidatorSelectionTestBase, CheatDepositArgs} from "./ValidatorSelectionBase.sol";
+import {Errors} from "@aztec/core/libraries/Errors.sol";
 
 contract SetupEpochTest is ValidatorSelectionTestBase {
   using Checkpoints for Checkpoints.Trace224;
   using stdStorage for StdStorage;
 
-  modifier whenTheRollupIsInGenesisState() {
-    // Enforced with setup(0) modifier
-    _;
-  }
+  function test_WhenTheRollupDoesNotHaveTheTargetCommitteeSize() external setup(0, 48) {
+    // it should not allow setting up any epoch
+    // it should have the always seed set to max
 
-  function test_GivenTheRollupIsInGenesisState() external setup(0) whenTheRollupIsInGenesisState {
-    // it should set the sample seed to max
-    // it should set the sample seed for the next 2 epochs
-    // it should not change the current epoch
-
+    vm.expectRevert(
+      abi.encodeWithSelector(
+        Errors.ValidatorSelection__InsufficientCommitteeSize.selector,
+        0,
+        rollup.getTargetCommitteeSize()
+      )
+    );
     rollup.setupEpoch();
 
     // Read the sample seed for epoch 0 through the rollup contract
@@ -42,24 +44,34 @@ contract SetupEpochTest is ValidatorSelectionTestBase {
     Timestamp epoch2Timestamp = Timestamp.wrap(
       block.timestamp + 2 * TestConstants.AZTEC_EPOCH_DURATION * TestConstants.AZTEC_SLOT_DURATION
     );
-    uint256 epoch2Seed = IValidatorSelection(address(rollup)).getSampleSeedAt(epoch2Timestamp);
-    assertTrue(epoch2Seed != 0, "Epoch 2 seed should be set");
-    assertTrue(epoch2Seed != type(uint224).max, "Epoch 2 seed should be different from max");
+    assertTrue(
+      IValidatorSelection(address(rollup)).getSampleSeedAt(epoch2Timestamp) == type(uint224).max,
+      "Epoch 2 seed should be max"
+    );
 
     // Advance into epoch 2
     vm.warp(Timestamp.unwrap(epoch2Timestamp));
 
     // Read the sample seed for epoch 2 now that we are in epoch 2, it should not change
-    uint256 epoch2SampleSeedInPast = IValidatorSelection(address(rollup)).getCurrentSampleSeed();
     assertEq(
-      epoch2SampleSeedInPast, epoch2Seed, "Epoch 2 seed should remain the same when re-reading"
+      IValidatorSelection(address(rollup)).getCurrentSampleSeed(),
+      type(uint224).max,
+      "Epoch 2 seed should remain the same when re-reading"
     );
 
     // Call setupEpoch again, from the current epoch it should not change the sample seed
+    vm.expectRevert(
+      abi.encodeWithSelector(
+        Errors.ValidatorSelection__InsufficientCommitteeSize.selector,
+        0,
+        rollup.getTargetCommitteeSize()
+      )
+    );
     rollup.setupEpoch();
+
     assertEq(
       IValidatorSelection(address(rollup)).getCurrentSampleSeed(),
-      epoch2Seed,
+      type(uint224).max,
       "Epoch 2 seed should not change when calling setupEpoch"
     );
 
@@ -67,20 +79,31 @@ contract SetupEpochTest is ValidatorSelectionTestBase {
     Timestamp epoch4Timestamp = Timestamp.wrap(
       block.timestamp + 2 * TestConstants.AZTEC_EPOCH_DURATION * TestConstants.AZTEC_SLOT_DURATION
     );
-    uint256 epoch4Seed = IValidatorSelection(address(rollup)).getSampleSeedAt(epoch4Timestamp);
-    assertTrue(epoch4Seed != epoch2Seed, "Epoch 4 seed should not be the same as epoch 2 seed");
+    assertTrue(
+      IValidatorSelection(address(rollup)).getSampleSeedAt(epoch4Timestamp) == type(uint224).max,
+      "Epoch 4 seed should be max"
+    );
   }
 
-  modifier whenTheRollupIsNotInGenesisState() {
-    // Enforced with setup(4) modifier
+  modifier whenTheRollupHasTheTargetCommitteeSize() {
     _;
   }
 
-  function test_GivenTheSeedHasBeenSampled() external setup(4) whenTheRollupIsNotInGenesisState {
+  function test_WhenTheSampleSeedHasBeenSet()
+    external
+    setup(4, 4)
+    whenTheRollupHasTheTargetCommitteeSize
+  {
     // it should not change the sample seed
     // it should be calculate the same committee when looking into the past
     // it should not change the commitee even when validators are added or removed
     // it should not change the next seed
+
+    Timestamp epoch2Timestamp = Timestamp.wrap(
+      block.timestamp + 2 * TestConstants.AZTEC_EPOCH_DURATION * TestConstants.AZTEC_SLOT_DURATION
+    );
+
+    vm.warp(Timestamp.unwrap(epoch2Timestamp));
 
     rollup.setupEpoch();
 
@@ -139,9 +162,15 @@ contract SetupEpochTest is ValidatorSelectionTestBase {
 
   function test_WhenItHasBeenALongTimeSinceTheLastSampleSeedWasSet()
     external
-    setup(50)
-    whenItHasBeenALongTimeSinceTheLastSampleSeedWasSet
+    setup(50, 48)
+    whenTheRollupHasTheTargetCommitteeSize
   {
+    Timestamp epoch2Timestamp = Timestamp.wrap(
+      block.timestamp + 2 * TestConstants.AZTEC_EPOCH_DURATION * TestConstants.AZTEC_SLOT_DURATION
+    );
+
+    vm.warp(Timestamp.unwrap(epoch2Timestamp));
+
     // it should use the most recent sample seed
     rollup.setupEpoch();
 

--- a/l1-contracts/test/validator-selection/setupEpoch.tree
+++ b/l1-contracts/test/validator-selection/setupEpoch.tree
@@ -1,15 +1,13 @@
 SetupEpochTest
-├── when the rollup is in genesis state
-│   └── Given the rollup is in genesis state
-│       ├── it should set the sample seed to max
-│       ├── it should set the sample seed for the next epoch
-│       └── it should not change the current epoch
-├── when the rollup is not in genesis state
-│   └── Given the seed has been sampled
-│       ├── it should not change the sample seed
-│       ├── it should be calculate the same committee when looking into the past
-│       ├── it should not change the commitee even when validators are added or removed
-│       └── it should not change the next seed
-└── when it has been a long time since the last sample seed was set
-    └──  it should use the most recent sample seed
+├── when the rollup does not have the target committee size
+│   ├── it should not allow setting up any epoch
+│   └── it should have the always seed set to max
+└── when the rollup has the target committee size
+    ├── when the sample seed has been set
+    │   ├── it should not change the sample seed
+    │   ├── it should be calculate the same committee when looking into the past
+    │   ├── it should not change the commitee even when validators are added or removed
+    │   └── it should not change the next seed
+    └── when it has been a long time since the last sample seed was set
+        └── it should use the most recent sample seed
 

--- a/l1-contracts/test/validator-selection/setupSampleSeed.t.sol
+++ b/l1-contracts/test/validator-selection/setupSampleSeed.t.sol
@@ -9,7 +9,7 @@ import {IValidatorSelection} from "@aztec/core/interfaces/IValidatorSelection.so
 import {TestConstants} from "../harnesses/TestConstants.sol";
 
 contract SetupSampleSeedTest is ValidatorSelectionTestBase {
-  function test_setupSampleSeed(uint16 _epochToTest) public setup(4) {
+  function test_setupSampleSeed(uint16 _epochToTest) public setup(4, 4) {
     // Check that the epoch is not set
     _epochToTest = uint16(bound(_epochToTest, 2, type(uint16).max));
 

--- a/yarn-project/aztec-node/src/aztec-node/server.ts
+++ b/yarn-project/aztec-node/src/aztec-node/server.ts
@@ -285,8 +285,12 @@ export class AztecNodeService implements AztecNode, AztecNodeAdmin, Traceable {
     const watchers: Watcher[] = [];
 
     const validatorsSentinel = await createSentinel(epochCache, archiver, p2pClient, config);
-    if (validatorsSentinel && config.slashInactivityEnabled) {
-      watchers.push(validatorsSentinel);
+    if (validatorsSentinel) {
+      // we can run a sentinel without trying to slash.
+      await validatorsSentinel.start();
+      if (config.slashInactivityEnabled) {
+        watchers.push(validatorsSentinel);
+      }
     }
 
     let epochPruneWatcher: EpochPruneWatcher | undefined;

--- a/yarn-project/aztec-node/src/sentinel/sentinel.ts
+++ b/yarn-project/aztec-node/src/sentinel/sentinel.ts
@@ -129,6 +129,10 @@ export class Sentinel extends (EventEmitter as new () => WatcherEmitter) impleme
     const fromSlot = provenSlots[0];
     const toSlot = provenSlots[provenSlots.length - 1];
     const { committee } = await this.epochCache.getCommittee(fromSlot);
+    if (!committee) {
+      this.logger.trace(`No committee found for slot ${fromSlot}`);
+      return {};
+    }
     const stats = await this.computeStats({ fromSlot, toSlot });
     this.logger.debug(`Stats for epoch ${epoch}`, stats);
 
@@ -273,8 +277,8 @@ export class Sentinel extends (EventEmitter as new () => WatcherEmitter) impleme
    */
   protected async processSlot(slot: bigint) {
     const { epoch, seed, committee } = await this.epochCache.getCommittee(slot);
-    if (committee.length === 0) {
-      this.logger.warn(`No committee found for slot ${slot} at epoch ${epoch}`);
+    if (!committee || committee.length === 0) {
+      this.logger.trace(`No committee found for slot ${slot} at epoch ${epoch}`);
       this.lastProcessedSlot = slot;
       return;
     }

--- a/yarn-project/aztec.js/src/test/rollup_cheat_codes.ts
+++ b/yarn-project/aztec.js/src/test/rollup_cheat_codes.ts
@@ -74,7 +74,7 @@ export class RollupCheatCodes {
     this.logger.info(`Pending block num: ${pendingNum}`);
     this.logger.info(`Proven block num: ${provenNum}`);
     this.logger.info(`Validators: ${validators.map(v => v.toString()).join(', ')}`);
-    this.logger.info(`Committee: ${committee.map(v => v.toString()).join(', ')}`);
+    this.logger.info(`Committee: ${committee?.map(v => v.toString()).join(', ')}`);
     this.logger.info(`Archive: ${archive}`);
     this.logger.info(`Epoch num: ${epochNum}`);
     this.logger.info(`Slot: ${slot}`);

--- a/yarn-project/aztec/src/sandbox/sandbox.ts
+++ b/yarn-project/aztec/src/sandbox/sandbox.ts
@@ -77,6 +77,7 @@ export async function deployContractsToL1(
       genesisArchiveRoot: opts.genesisArchiveRoot ?? new Fr(GENESIS_ARCHIVE_ROOT),
       salt: opts.salt,
       feeJuicePortalInitialBalance: opts.feeJuicePortalInitialBalance,
+      aztecTargetCommitteeSize: 0, // no committee in sandbox
       realVerifier: false,
     },
   );

--- a/yarn-project/cli/src/cmds/l1/update_l1_validators.ts
+++ b/yarn-project/cli/src/cmds/l1/update_l1_validators.ts
@@ -236,7 +236,7 @@ export async function debugRollup({ rpcUrls, chainId, rollupAddress, log }: Roll
   const validators = await rollup.getAttesters();
   log(`Validators: ${validators.map(v => v.toString()).join(', ')}`);
   const committee = await rollup.getCurrentEpochCommittee();
-  log(`Committee: ${committee.map(v => v.toString()).join(', ')}`);
+  log(`Committee: ${committee?.map(v => v.toString()).join(', ')}`);
   const archive = await rollup.archive();
   log(`Archive: ${archive}`);
   const epochNum = await rollup.getEpochNumber();

--- a/yarn-project/end-to-end/src/composed/integration_l1_publisher.test.ts
+++ b/yarn-project/end-to-end/src/composed/integration_l1_publisher.test.ts
@@ -119,7 +119,9 @@ describe('L1Publisher integration', () => {
 
   beforeEach(async () => {
     deployerAccount = privateKeyToAccount(deployerPK);
-    ({ l1ContractAddresses, l1Client } = await setupL1Contracts(config.l1RpcUrls, deployerAccount, logger));
+    ({ l1ContractAddresses, l1Client } = await setupL1Contracts(config.l1RpcUrls, deployerAccount, logger, {
+      aztecTargetCommitteeSize: 0,
+    }));
 
     ethCheatCodes = new EthCheatCodesWithState(config.l1RpcUrls);
 

--- a/yarn-project/end-to-end/src/e2e_epochs/epochs_monitor_block_building.test.ts
+++ b/yarn-project/end-to-end/src/e2e_epochs/epochs_monitor_block_building.test.ts
@@ -1,6 +1,5 @@
 import type { AztecNodeService } from '@aztec/aztec-node';
 import { EthAddress, type Logger } from '@aztec/aztec.js';
-import type { CheatCodes } from '@aztec/aztec.js/testing';
 import type { Operator } from '@aztec/ethereum';
 import { asyncMap } from '@aztec/foundation/async-map';
 import { times, timesAsync } from '@aztec/foundation/collection';
@@ -26,7 +25,6 @@ const TX_COUNT = 3;
 describe('e2e_epochs/epochs_monitor_block_building', () => {
   let context: EndToEndContext;
   let logger: Logger;
-  let cheatCodes: CheatCodes;
 
   let test: EpochsTestContext;
   let validators: (Operator & { privateKey: `0x${string}` })[];
@@ -51,7 +49,6 @@ describe('e2e_epochs/epochs_monitor_block_building', () => {
     });
 
     ({ context, logger } = test);
-    ({ cheatCodes } = context);
 
     // Halt block building in initial aztec node, which was not set up as a validator.
     logger.warn(`Stopping sequencer in initial aztec node.`);
@@ -80,17 +77,6 @@ describe('e2e_epochs/epochs_monitor_block_building', () => {
     const sentTxs = await Promise.all(txs.map(tx => tx.send()));
     logger.warn(`Sent ${sentTxs.length} transactions`, {
       txs: await Promise.all(sentTxs.map(tx => tx.getTxHash())),
-    });
-
-    // Warp forward to epoch 2
-    const ts = await cheatCodes.rollup.advanceToEpoch(2n, {
-      updateDateProvider: context.dateProvider,
-      resetBlockInterval: true,
-    });
-    logger.warn(`Warped to epoch 2`, {
-      epochTs: ts,
-      dateProvider: context.dateProvider!.nowInSeconds(),
-      chainTs: await cheatCodes.eth.timestamp(),
     });
 
     // Listen to all failure related events of the sequencers.

--- a/yarn-project/end-to-end/src/e2e_epochs/epochs_test.ts
+++ b/yarn-project/end-to-end/src/e2e_epochs/epochs_test.ts
@@ -115,6 +115,7 @@ export class EpochsTestContext {
       aztecSlotDuration,
       ethereumSlotDuration,
       aztecProofSubmissionWindow,
+      aztecTargetCommitteeSize: opts.initialValidators?.length ?? 0,
       minTxsPerBlock: 0,
       realProofs: false,
       startProverNode: true,

--- a/yarn-project/end-to-end/src/e2e_multi_validator_node.test.ts
+++ b/yarn-project/end-to-end/src/e2e_multi_validator_node.test.ts
@@ -10,14 +10,13 @@ import {
   retryUntil,
   waitForProven,
 } from '@aztec/aztec.js';
+import type { CheatCodes } from '@aztec/aztec.js/testing';
 import {
   type DeployL1ContractsReturnType,
-  type ExtendedViemWalletClient,
   RollupContract,
   createExtendedL1Client,
   getL1ContractsConfigEnvVars,
 } from '@aztec/ethereum';
-import { EthCheatCodesWithState } from '@aztec/ethereum/test';
 import { RollupAbi } from '@aztec/l1-artifacts/RollupAbi';
 import { StatefulTestContractArtifact } from '@aztec/noir-test-contracts.js/StatefulTest';
 import { BlockAttestation, ConsensusPayload } from '@aztec/stdlib/p2p';
@@ -28,6 +27,7 @@ import { privateKeyToAccount } from 'viem/accounts';
 import { getPrivateKeyFromIndex, setup } from './fixtures/utils.js';
 
 const VALIDATOR_COUNT = 5;
+const COMMITTEE_SIZE = VALIDATOR_COUNT - 2;
 
 describe('e2e_multi_validator_node', () => {
   let initialValidatorPrivateKeys: `0x${string}`[];
@@ -38,19 +38,9 @@ describe('e2e_multi_validator_node', () => {
   let config: AztecNodeConfig;
   let logger: Logger;
   let deployL1ContractsValues: DeployL1ContractsReturnType;
-  let l1Client: ExtendedViemWalletClient;
   let rollup: RollupContract;
-  let ethCheatCodes: EthCheatCodesWithState;
+  let cheatCodes: CheatCodes;
   const artifact = StatefulTestContractArtifact;
-
-  const progressTimeBySlot = async (slotsToJump = 1n) => {
-    const currentTime = (await l1Client.getBlock()).timestamp;
-    const currentSlot = await rollup.getSlotNumber();
-    const timestamp = await rollup.getTimestampForSlot(currentSlot + slotsToJump);
-    if (timestamp > currentTime) {
-      await ethCheatCodes.warp(Number(timestamp));
-    }
-  };
 
   beforeEach(async () => {
     initialValidatorPrivateKeys = Array.from(
@@ -79,8 +69,10 @@ describe('e2e_multi_validator_node', () => {
       aztecNode,
       config,
       deployL1ContractsValues,
+      cheatCodes,
     } = await setup(1, {
       initialValidators,
+      aztecTargetCommitteeSize: COMMITTEE_SIZE,
       publisherPrivateKey,
       minTxsPerBlock: 1,
       archiverPollingIntervalMS: 200,
@@ -90,16 +82,12 @@ describe('e2e_multi_validator_node', () => {
       startProverNode: true,
     }));
 
-    ethCheatCodes = new EthCheatCodesWithState(config.l1RpcUrls);
-    l1Client = deployL1ContractsValues.l1Client;
     rollup = new RollupContract(
       deployL1ContractsValues.l1Client,
       deployL1ContractsValues.l1ContractAddresses.rollupAddress.toString(),
     );
 
     // We jump to the next epoch such that the committee can be setup.
-    const timeToJump = (await rollup.getEpochDuration()) * 2n;
-    await progressTimeBySlot(timeToJump);
     await retryUntil(
       async () => {
         const view = await rollup.getAttesterView(validatorAddresses[0]);
@@ -139,11 +127,11 @@ describe('e2e_multi_validator_node', () => {
       .filter(a => !a.signature.isEmpty())
       .map(a => new BlockAttestation(block.block.number, payload, a.signature));
 
-    expect(attestations.length).toBeGreaterThanOrEqual(4); // Math.floor((5 * 2) / 3) + 1
+    expect(attestations.length).toBeGreaterThanOrEqual((COMMITTEE_SIZE * 2) / 3 + 1);
 
     const signers = attestations.map(att => att.getSender().toString());
 
-    expect(signers).toEqual(expect.arrayContaining(validatorAddresses));
+    expect(signers.every(s => validatorAddresses.includes(s))).toBe(true);
   });
   it('should attest ONLY with the correct validator keys', async () => {
     const rollupContract1 = getContract({
@@ -166,12 +154,12 @@ describe('e2e_multi_validator_node', () => {
       validatorAddresses[VALIDATOR_COUNT - 2],
     ]);
 
-    const timeToJump = (await rollup.getEpochDuration()) * 2n;
-    await progressTimeBySlot(timeToJump);
+    await cheatCodes.rollup.advanceToNextEpoch();
+    await cheatCodes.rollup.advanceToNextEpoch();
 
-    // check that the committee is the correct size now
+    // check that the committee is undefined
     const committee = await rollup.getCurrentEpochCommittee();
-    expect(committee.length).toBe(VALIDATOR_COUNT - 2);
+    expect(committee?.length).toBe(COMMITTEE_SIZE);
 
     // new aztec transaction
     const ownerAddress = owner.getCompleteAddress().address;
@@ -197,10 +185,10 @@ describe('e2e_multi_validator_node', () => {
       .filter(a => !a.signature.isEmpty())
       .map(a => new BlockAttestation(block.block.number, payload, a.signature));
 
-    expect(attestations.length).toBeGreaterThanOrEqual(3); // Math.floor((3 * 2) / 3) + 1
+    expect(attestations.length).toBeGreaterThanOrEqual((COMMITTEE_SIZE * 2) / 3 + 1);
 
     const signers = attestations.map(att => att.getSender().toString());
 
-    expect(signers).toEqual(expect.arrayContaining(validatorAddresses.slice(0, VALIDATOR_COUNT - 2)));
+    expect(signers).toEqual(expect.arrayContaining(validatorAddresses.slice(0, COMMITTEE_SIZE)));
   });
 });

--- a/yarn-project/end-to-end/src/e2e_p2p/data_withholding_slash.test.ts
+++ b/yarn-project/end-to-end/src/e2e_p2p/data_withholding_slash.test.ts
@@ -63,7 +63,6 @@ describe('e2e_p2p_data_withholding_slash', () => {
       },
     });
 
-    await t.setupAccount();
     await t.applyBaseSnapshots();
     await t.setup();
   });
@@ -92,7 +91,6 @@ describe('e2e_p2p_data_withholding_slash', () => {
       const newTime = await t.ctx.cheatCodes.rollup.advanceToEpoch(4n);
       t.ctx.dateProvider.setTime(Number(newTime * 1000n));
       // Send tx
-      await t.sendDummyTx();
       await debugRollup();
     }
 

--- a/yarn-project/end-to-end/src/e2e_p2p/gossip_network.test.ts
+++ b/yarn-project/end-to-end/src/e2e_p2p/gossip_network.test.ts
@@ -52,10 +52,8 @@ describe('e2e_p2p_network', () => {
       },
     });
 
-    await t.setupAccount();
     await t.applyBaseSnapshots();
     await t.setup();
-    await t.removeInitialNode();
   });
 
   afterEach(async () => {
@@ -100,7 +98,12 @@ describe('e2e_p2p_network', () => {
     );
 
     // wait a bit for peers to discover each other
-    await sleep(4000);
+    await sleep(8000);
+
+    // We need to `createNodes` before we setup account, because
+    // those nodes actually form the committee, and so we cannot build
+    // blocks without them (since targetCommitteeSize is set to the number of nodes)
+    await t.setupAccount();
 
     t.logger.info('Submitting transactions');
     for (const node of nodes) {

--- a/yarn-project/end-to-end/src/e2e_p2p/gossip_network_no_cheat.test.ts
+++ b/yarn-project/end-to-end/src/e2e_p2p/gossip_network_no_cheat.test.ts
@@ -59,10 +59,8 @@ describe('e2e_p2p_network', () => {
       mockZkPassportVerifier: true,
     });
 
-    await t.setupAccount();
     await t.addBootstrapNode();
     await t.setup();
-    await t.removeInitialNode();
   });
 
   afterEach(async () => {
@@ -200,7 +198,12 @@ describe('e2e_p2p_network', () => {
     );
 
     // wait a bit for peers to discover each other
-    await sleep(4000);
+    await sleep(8000);
+
+    // We need to `createNodes` before we setup account, because
+    // those nodes actually form the committee, and so we cannot build
+    // blocks without them (since targetCommitteeSize is set to the number of nodes)
+    await t.setupAccount();
 
     t.logger.info('Submitting transactions');
     for (const node of nodes) {

--- a/yarn-project/end-to-end/src/e2e_p2p/p2p_network.ts
+++ b/yarn-project/end-to-end/src/e2e_p2p/p2p_network.ts
@@ -102,6 +102,7 @@ export class P2PNetworkTest {
         aztecSlotDuration: initialValidatorConfig.aztecSlotDuration ?? l1ContractsConfig.aztecSlotDuration,
         aztecProofSubmissionWindow:
           initialValidatorConfig.aztecProofSubmissionWindow ?? l1ContractsConfig.aztecProofSubmissionWindow,
+        aztecTargetCommitteeSize: numberOfNodes,
         salt: 420,
         metricsPort: metricsPort,
         numberOfInitialFundedAccounts: 2,
@@ -114,6 +115,7 @@ export class P2PNetworkTest {
         aztecSlotDuration: initialValidatorConfig.aztecSlotDuration ?? l1ContractsConfig.aztecSlotDuration,
         aztecProofSubmissionWindow:
           initialValidatorConfig.aztecProofSubmissionWindow ?? l1ContractsConfig.aztecProofSubmissionWindow,
+        aztecTargetCommitteeSize: numberOfNodes,
         initialValidators: [],
         zkPassportArgs: {
           mockZkPassportVerifier,

--- a/yarn-project/end-to-end/src/e2e_p2p/rediscovery.test.ts
+++ b/yarn-project/end-to-end/src/e2e_p2p/rediscovery.test.ts
@@ -33,12 +33,8 @@ describe('e2e_p2p_rediscovery', () => {
         listenAddress: '127.0.0.1',
       },
     });
-    await t.setupAccount();
     await t.applyBaseSnapshots();
     await t.setup();
-
-    // We remove the initial node such that it will no longer attempt to build blocks / be in the sequencing set
-    await t.removeInitialNode();
   });
 
   afterEach(async () => {
@@ -65,7 +61,12 @@ describe('e2e_p2p_rediscovery', () => {
     );
 
     // wait a bit for peers to discover each other
-    await sleep(3000);
+    await sleep(8000);
+
+    // We need to `createNodes` before we setup account, because
+    // those nodes actually form the committee, and so we cannot build
+    // blocks without them (since targetCommitteeSize is set to the number of nodes)
+    await t.setupAccount();
 
     // stop bootstrap node
     await t.bootstrapNode?.stop();

--- a/yarn-project/end-to-end/src/e2e_p2p/reex.test.ts
+++ b/yarn-project/end-to-end/src/e2e_p2p/reex.test.ts
@@ -44,12 +44,6 @@ describe('e2e_p2p_reex', () => {
       },
     });
 
-    t.logger.info('Setup account');
-    await t.setupAccount();
-
-    t.logger.info('Deploy spam contract');
-    await t.deploySpamContract();
-
     t.logger.info('Apply base snapshots');
     await t.applyBaseSnapshots();
 
@@ -68,7 +62,7 @@ describe('e2e_p2p_reex', () => {
       {
         ...t.ctx.aztecNodeConfig,
         validatorReexecute: true,
-        minTxsPerBlock: NUM_TXS_PER_NODE + 1,
+        minTxsPerBlock: 1,
         maxTxsPerBlock: NUM_TXS_PER_NODE,
       },
       t.ctx.dateProvider,
@@ -83,7 +77,13 @@ describe('e2e_p2p_reex', () => {
 
     // Wait a bit for peers to discover each other
     t.logger.info('Waiting for peer discovery');
-    await sleep(4000);
+    await sleep(8000);
+
+    t.logger.info('Setup account');
+    await t.setupAccount();
+
+    t.logger.info('Deploy spam contract');
+    await t.deploySpamContract();
 
     // Submit the txs to the mempool. We submit a single set of txs, and then inject different behaviors
     // into the validator nodes to cause them to fail in different ways.

--- a/yarn-project/end-to-end/src/e2e_p2p/reqresp.test.ts
+++ b/yarn-project/end-to-end/src/e2e_p2p/reqresp.test.ts
@@ -37,7 +37,6 @@ describe('e2e_p2p_reqresp_tx', () => {
         aztecEpochDuration: 64, // stable committee
       },
     });
-    await t.setupAccount();
     await t.applyBaseSnapshots();
     await t.setup();
   });
@@ -70,14 +69,6 @@ describe('e2e_p2p_reqresp_tx', () => {
       throw new Error('Bootstrap node ENR is not available');
     }
 
-    t.logger.info('Preparing transactions to send');
-    const contexts = await timesAsync(2, () =>
-      createPXEServiceAndPrepareTransactions(t.logger, t.ctx.aztecNode, NUM_TXS_PER_NODE, t.fundedAccount),
-    );
-
-    t.logger.info('Removing initial node');
-    await t.removeInitialNode();
-
     t.logger.info('Creating nodes');
     nodes = await createNodes(
       t.ctx.aztecNodeConfig,
@@ -92,6 +83,16 @@ describe('e2e_p2p_reqresp_tx', () => {
 
     t.logger.info('Sleeping to allow nodes to connect');
     await sleep(4000);
+
+    await t.setupAccount();
+
+    t.logger.info('Preparing transactions to send');
+    const contexts = await timesAsync(2, () =>
+      createPXEServiceAndPrepareTransactions(t.logger, t.ctx.aztecNode, NUM_TXS_PER_NODE, t.fundedAccount),
+    );
+
+    t.logger.info('Removing initial node');
+    await t.removeInitialNode();
 
     t.logger.info('Starting fresh slot');
     const [timestamp] = await t.ctx.cheatCodes.rollup.advanceToNextSlot();

--- a/yarn-project/end-to-end/src/e2e_p2p/reqresp_no_handshake.test.ts
+++ b/yarn-project/end-to-end/src/e2e_p2p/reqresp_no_handshake.test.ts
@@ -42,7 +42,6 @@ describe('e2e_p2p_reqresp_tx_no_handshake', () => {
         aztecEpochDuration: 64, // stable committee
       },
     });
-    await t.setupAccount();
     await t.applyBaseSnapshots();
     await t.setup();
   });
@@ -71,18 +70,6 @@ describe('e2e_p2p_reqresp_tx_no_handshake', () => {
      *       from the other pxes.
      */
 
-    if (!t.bootstrapNodeEnr) {
-      throw new Error('Bootstrap node ENR is not available');
-    }
-
-    t.logger.info('Preparing transactions to send');
-    const contexts = await timesAsync(2, () =>
-      createPXEServiceAndPrepareTransactions(t.logger, t.ctx.aztecNode, NUM_TXS_PER_NODE, t.fundedAccount),
-    );
-
-    t.logger.info('Removing initial node');
-    await t.removeInitialNode();
-
     t.logger.info('Creating nodes');
     nodes = await createNodes(
       { ...t.ctx.aztecNodeConfig, p2pDisableStatusHandshake: true }, // DIFFERENCE FROM reqresp.test.ts
@@ -95,8 +82,22 @@ describe('e2e_p2p_reqresp_tx_no_handshake', () => {
       shouldCollectMetrics(),
     );
 
+    if (!t.bootstrapNodeEnr) {
+      throw new Error('Bootstrap node ENR is not available');
+    }
+
     t.logger.info('Sleeping to allow nodes to connect');
     await sleep(4000);
+
+    await t.setupAccount();
+
+    t.logger.info('Preparing transactions to send');
+    const contexts = await timesAsync(2, () =>
+      createPXEServiceAndPrepareTransactions(t.logger, t.ctx.aztecNode, NUM_TXS_PER_NODE, t.fundedAccount),
+    );
+
+    t.logger.info('Removing initial node');
+    await t.removeInitialNode();
 
     t.logger.info('Starting fresh slot');
     const [timestamp] = await t.ctx.cheatCodes.rollup.advanceToNextSlot();

--- a/yarn-project/end-to-end/src/e2e_p2p/shared.ts
+++ b/yarn-project/end-to-end/src/e2e_p2p/shared.ts
@@ -127,20 +127,30 @@ export async function awaitProposalExecution(
   );
 }
 
-export async function awaitCommitteeExists({ rollup, logger }: { rollup: RollupContract; logger: Logger }) {
+export async function awaitCommitteeExists({
+  rollup,
+  logger,
+}: {
+  rollup: RollupContract;
+  logger: Logger;
+}): Promise<readonly `0x${string}`[]> {
   logger.info(`Waiting for committee to be set`);
-  let committee: readonly `0x${string}`[] = [];
+  let committee: readonly `0x${string}`[] | undefined;
   await retryUntil(
     async () => {
       committee = await rollup.getCurrentEpochCommittee();
-      return committee.length > 0;
+      return committee && committee.length > 0;
     },
     'non-empty committee',
     60,
   );
-  return committee;
+  return committee!;
 }
 
+/**
+ * Await the committee to be slashed out of the validator set.
+ * Currently assumes that the committee is the same size as the validator set.
+ */
 export async function awaitCommitteeKicked({
   offense,
   rollup,
@@ -204,7 +214,7 @@ export async function awaitCommitteeKicked({
   // but they should be reduced to the "living" status
   await cheatCodes.debugRollup();
   const committeePostSlashing = await rollup.getCurrentEpochCommittee();
-  expect(committeePostSlashing.length).toBe(attestersPre.length);
+  expect(committeePostSlashing?.length).toBe(attestersPre.length);
 
   const attestersPostSlashing = await rollup.getAttesters();
   expect(attestersPostSlashing.length).toBe(0);
@@ -220,7 +230,9 @@ export async function awaitCommitteeKicked({
   await cheatCodes.debugRollup();
 
   const committeeNextEpoch = await rollup.getCurrentEpochCommittee();
-  expect(committeeNextEpoch.length).toBe(0);
+  // The committee should be undefined, since the validator set is empty
+  // and the tests currently using this helper always set a target committee size.
+  expect(committeeNextEpoch).toBeUndefined();
 
   const attestersNextEpoch = await rollup.getAttesters();
   expect(attestersNextEpoch.length).toBe(0);

--- a/yarn-project/end-to-end/src/e2e_p2p/valid_epoch_pruned.test.ts
+++ b/yarn-project/end-to-end/src/e2e_p2p/valid_epoch_pruned.test.ts
@@ -51,7 +51,6 @@ describe('e2e_p2p_valid_epoch_pruned', () => {
       },
     });
 
-    await t.setupAccount();
     await t.applyBaseSnapshots();
     await t.setup();
     await t.removeInitialNode();
@@ -86,8 +85,6 @@ describe('e2e_p2p_valid_epoch_pruned', () => {
 
     // Jump forward to an epoch in the future such that the validator set is not empty
     await t.ctx.cheatCodes.rollup.advanceToEpoch(4n);
-    // Send tx
-    await t.sendDummyTx();
 
     // create our network of nodes and submit txs into each of them
     // the number of txs per node and the number of txs per rollup

--- a/yarn-project/end-to-end/src/e2e_p2p/validators_sentinel.test.ts
+++ b/yarn-project/end-to-end/src/e2e_p2p/validators_sentinel.test.ts
@@ -56,7 +56,6 @@ describe('e2e_p2p_validators_sentinel', () => {
       },
     });
 
-    await t.setupAccount();
     await t.applyBaseSnapshots();
     await t.setup();
 

--- a/yarn-project/end-to-end/src/e2e_simple.test.ts
+++ b/yarn-project/end-to-end/src/e2e_simple.test.ts
@@ -39,6 +39,7 @@ describe('e2e_simple', () => {
         aztecEpochDuration: 4,
         aztecProofSubmissionWindow: 8,
         aztecSlotDuration: 12,
+        aztecTargetCommitteeSize: 0,
         ethereumSlotDuration: 4,
         startProverNode: true,
       }));

--- a/yarn-project/end-to-end/src/fixtures/snapshot_manager.ts
+++ b/yarn-project/end-to-end/src/fixtures/snapshot_manager.ts
@@ -307,7 +307,11 @@ async function setupFromFresh(
   aztecNodeConfig.realProofs = !!opts.realProofs;
   // Only enforce the time table if requested
   aztecNodeConfig.enforceTimeTable = !!opts.enforceTimeTable;
+  // Only set the target committee size if it is explicitly set
+  aztecNodeConfig.aztecTargetCommitteeSize = opts.aztecTargetCommitteeSize ?? 0;
   aztecNodeConfig.listenAddress = '127.0.0.1';
+
+  deployL1ContractsArgs.aztecTargetCommitteeSize ??= aztecNodeConfig.aztecTargetCommitteeSize;
 
   // Create a temp directory for all ephemeral state and cleanup afterwards
   const directoryToCleanup = path.join(tmpdir(), randomBytes(8).toString('hex'));

--- a/yarn-project/end-to-end/src/fixtures/utils.ts
+++ b/yarn-project/end-to-end/src/fixtures/utils.ts
@@ -363,6 +363,8 @@ export async function setup(
 ): Promise<EndToEndContext> {
   let anvil: Anvil | undefined;
   try {
+    opts.aztecTargetCommitteeSize ??= 0;
+
     const config = { ...getConfigEnvVars(), ...opts };
     // use initialValidators for the node config
     config.validatorPrivateKeys = opts.initialValidators?.map(v => v.privateKey);
@@ -589,6 +591,17 @@ export async function setup(
     logger.verbose('Creating a pxe...');
     const { pxe, teardown: pxeTeardown } = await setupPXEService(aztecNode!, pxeOpts, logger);
 
+    const cheatCodes = await CheatCodes.create(config.l1RpcUrls, pxe!);
+
+    if (
+      (opts.aztecTargetCommitteeSize && opts.aztecTargetCommitteeSize > 0) ||
+      (opts.initialValidators && opts.initialValidators.length > 0)
+    ) {
+      // We need to advance to epoch 2 such that the committee is set up.
+      logger.info(`Advancing to epoch 2`);
+      await cheatCodes.rollup.advanceToEpoch(2n, { updateDateProvider: dateProvider });
+    }
+
     const accountManagers = await deployFundedSchnorrAccounts(pxe, initialFundedAccounts.slice(0, numberOfAccounts));
     const wallets = await Promise.all(accountManagers.map(account => account.getWallet()));
     if (initialFundedAccounts.length < numberOfAccounts) {
@@ -597,8 +610,6 @@ export async function setup(
         `Unable to deploy ${numberOfAccounts} accounts. Only ${initialFundedAccounts.length} accounts were funded.`,
       );
     }
-
-    const cheatCodes = await CheatCodes.create(config.l1RpcUrls, pxe!);
 
     const teardown = async () => {
       try {

--- a/yarn-project/epoch-cache/src/epoch_cache.ts
+++ b/yarn-project/epoch-cache/src/epoch_cache.ts
@@ -1,4 +1,4 @@
-import { RollupContract, createEthereumChain } from '@aztec/ethereum';
+import { NoCommitteeError, RollupContract, createEthereumChain } from '@aztec/ethereum';
 import { EthAddress } from '@aztec/foundation/eth-address';
 import { type Logger, createLogger } from '@aztec/foundation/log';
 import { DateProvider } from '@aztec/foundation/timer';
@@ -24,7 +24,7 @@ type EpochAndSlot = {
 };
 
 export type EpochCommitteeInfo = {
-  committee: EthAddress[];
+  committee: EthAddress[] | undefined;
   seed: bigint;
   epoch: bigint;
 };
@@ -59,14 +59,14 @@ export class EpochCache implements EpochCacheInterface {
   constructor(
     private rollup: RollupContract,
     initialEpoch: bigint = 0n,
-    initialValidators: EthAddress[] = [],
+    initialValidators: EthAddress[] | undefined = undefined,
     initialSampleSeed: bigint = 0n,
     private readonly l1constants: L1RollupConstants = EmptyL1RollupConstants,
     private readonly dateProvider: DateProvider = new DateProvider(),
     private readonly config = { cacheSize: 12 },
   ) {
     this.cache.set(initialEpoch, { epoch: initialEpoch, committee: initialValidators, seed: initialSampleSeed });
-    this.log.debug(`Initialized EpochCache with ${initialValidators.length} validators`, {
+    this.log.debug(`Initialized EpochCache with ${initialValidators?.length ?? 'no'} validators`, {
       l1constants,
       initialValidators,
       initialSampleSeed,
@@ -109,7 +109,7 @@ export class EpochCache implements EpochCacheInterface {
     return new EpochCache(
       rollup,
       epochNumber,
-      initialValidators.map(v => EthAddress.fromString(v)),
+      initialValidators?.map(v => EthAddress.fromString(v)),
       sampleSeed,
       l1RollupConstants,
       deps.dateProvider,
@@ -168,8 +168,8 @@ export class EpochCache implements EpochCacheInterface {
     }
 
     const epochData = await this.computeCommittee({ epoch, ts });
-    // If the committee size is 0, then do not cache
-    if (epochData.committee.length == 0) {
+    // If the committee size is 0 or undefined, then do not cache
+    if (!epochData.committee || epochData.committee.length === 0) {
       return epochData;
     }
     this.cache.set(epoch, epochData);
@@ -195,7 +195,7 @@ export class EpochCache implements EpochCacheInterface {
   private async computeCommittee(when: { epoch: bigint; ts: bigint }): Promise<EpochCommitteeInfo> {
     const { ts, epoch } = when;
     const [committeeHex, seed] = await Promise.all([this.rollup.getCommitteeAt(ts), this.rollup.getSampleSeedAt(ts)]);
-    const committee = committeeHex.map((v: `0x${string}`) => EthAddress.fromString(v));
+    const committee = committeeHex?.map((v: `0x${string}`) => EthAddress.fromString(v));
     return { committee, seed, epoch };
   }
 
@@ -244,15 +244,31 @@ export class EpochCache implements EpochCacheInterface {
     };
   }
 
+  /**
+   * Get the proposer attester address in the next slot
+   * @returns The proposer attester address. If the committee does not exist, we throw a NoCommitteeError.
+   * If the committee is empty (i.e. target committee size is 0, and anyone can propose), we return undefined.
+   */
   getProposerAttesterAddressInNextSlot(): Promise<EthAddress | undefined> {
     const epochAndSlot = this.getEpochAndSlotInNextL1Slot();
 
     return this.getProposerAttesterAddressAt(epochAndSlot);
   }
 
+  /**
+   * Get the proposer attester address at a given epoch and slot
+   * @param when - The epoch and slot to get the proposer attester address at
+   * @returns The proposer attester address. If the committee does not exist, we throw a NoCommitteeError.
+   * If the committee is empty (i.e. target committee size is 0, and anyone can propose), we return undefined.
+   */
   private async getProposerAttesterAddressAt(when: EpochAndSlot) {
     const { epoch, slot } = when;
-    const { seed, committee } = await this.getCommittee(slot);
+    const { committee, seed } = await this.getCommittee(slot);
+    if (!committee) {
+      throw new NoCommitteeError();
+    } else if (committee.length === 0) {
+      return undefined;
+    }
 
     const proposerIndex = this.computeProposerIndex(slot, epoch, seed, BigInt(committee.length));
     return committee[Number(proposerIndex)];
@@ -263,11 +279,17 @@ export class EpochCache implements EpochCacheInterface {
    */
   async isInCommittee(validator: EthAddress): Promise<boolean> {
     const { committee } = await this.getCommittee();
+    if (!committee) {
+      return false;
+    }
     return committee.some(v => v.equals(validator));
   }
 
   async filterInCommittee(validators: EthAddress[]): Promise<EthAddress[]> {
     const { committee } = await this.getCommittee();
+    if (!committee) {
+      return [];
+    }
     const committeeSet = new Set(committee.map(v => v.toString()));
     return validators.filter(v => committeeSet.has(v.toString()));
   }

--- a/yarn-project/ethereum/src/contracts/errors.ts
+++ b/yarn-project/ethereum/src/contracts/errors.ts
@@ -4,3 +4,10 @@ export class BlockTagTooOldError extends Error {
     this.name = 'BlockTagTooOldError';
   }
 }
+
+export class NoCommitteeError extends Error {
+  constructor() {
+    super('The committee does not exist on L1');
+    this.name = 'NoCommitteeError';
+  }
+}

--- a/yarn-project/ethereum/src/contracts/forwarder.test.ts
+++ b/yarn-project/ethereum/src/contracts/forwarder.test.ts
@@ -51,6 +51,7 @@ describe('Forwarder', () => {
       protocolContractTreeRoot,
       genesisArchiveRoot: Fr.random(),
       realVerifier: false,
+      aztecTargetCommitteeSize: 0,
     });
 
     govProposerAddress = deployed.l1ContractAddresses.governanceProposerAddress;

--- a/yarn-project/ethereum/src/contracts/rollup.ts
+++ b/yarn-project/ethereum/src/contracts/rollup.ts
@@ -239,13 +239,20 @@ export class RollupContract {
     return this.rollup.read.getFeeAssetPerEth();
   }
 
-  async getCommitteeAt(timestamp: bigint) {
-    const { result } = await this.client.simulateContract({
-      address: this.address,
-      abi: RollupAbi,
-      functionName: 'getCommitteeAt',
-      args: [timestamp],
-    });
+  async getCommitteeAt(timestamp: bigint): Promise<readonly `0x${string}`[] | undefined> {
+    const { result } = await this.client
+      .simulateContract({
+        address: this.address,
+        abi: RollupAbi,
+        functionName: 'getCommitteeAt',
+        args: [timestamp],
+      })
+      .catch(e => {
+        if (e instanceof Error && e.message.includes('ValidatorSelection__InsufficientCommitteeSize')) {
+          return { result: undefined };
+        }
+        throw e;
+      });
 
     return result;
   }
@@ -262,13 +269,20 @@ export class RollupContract {
     return this.rollup.read.getCurrentEpoch();
   }
 
-  async getCurrentEpochCommittee() {
-    const { result } = await this.client.simulateContract({
-      address: this.address,
-      abi: RollupAbi,
-      functionName: 'getCurrentEpochCommittee',
-      args: [],
-    });
+  async getCurrentEpochCommittee(): Promise<readonly `0x${string}`[] | undefined> {
+    const { result } = await this.client
+      .simulateContract({
+        address: this.address,
+        abi: RollupAbi,
+        functionName: 'getCurrentEpochCommittee',
+        args: [],
+      })
+      .catch(e => {
+        if (e instanceof Error && e.message.includes('ValidatorSelection__InsufficientCommitteeSize')) {
+          return { result: undefined };
+        }
+        throw e;
+      });
 
     return result;
   }
@@ -290,17 +304,6 @@ export class RollupContract {
       abi: RollupAbi,
       functionName: 'getProposerAt',
       args: [timestamp],
-    });
-
-    return result;
-  }
-
-  async getEpochCommittee(epoch: bigint) {
-    const { result } = await this.client.simulateContract({
-      address: this.address,
-      abi: RollupAbi,
-      functionName: 'getEpochCommittee',
-      args: [epoch],
     });
 
     return result;

--- a/yarn-project/p2p/package.json
+++ b/yarn-project/p2p/package.json
@@ -66,6 +66,7 @@
   "dependencies": {
     "@aztec/constants": "workspace:^",
     "@aztec/epoch-cache": "workspace:^",
+    "@aztec/ethereum": "workspace:^",
     "@aztec/foundation": "workspace:^",
     "@aztec/kv-store": "workspace:^",
     "@aztec/noir-contracts.js": "workspace:^",

--- a/yarn-project/p2p/src/msg_validators/attestation_validator/attestation_validator.ts
+++ b/yarn-project/p2p/src/msg_validators/attestation_validator/attestation_validator.ts
@@ -1,4 +1,5 @@
 import type { EpochCacheInterface } from '@aztec/epoch-cache';
+import { NoCommitteeError } from '@aztec/ethereum';
 import { type BlockAttestation, type P2PValidator, PeerErrorSeverity } from '@aztec/stdlib/p2p';
 
 export class AttestationValidator implements P2PValidator<BlockAttestation> {
@@ -9,18 +10,25 @@ export class AttestationValidator implements P2PValidator<BlockAttestation> {
   }
 
   async validate(message: BlockAttestation): Promise<PeerErrorSeverity | undefined> {
-    const { currentSlot, nextSlot } = await this.epochCache.getProposerAttesterAddressInCurrentOrNextSlot();
+    try {
+      const { currentSlot, nextSlot } = await this.epochCache.getProposerAttesterAddressInCurrentOrNextSlot();
 
-    const slotNumberBigInt = message.payload.header.slotNumber.toBigInt();
-    if (slotNumberBigInt !== currentSlot && slotNumberBigInt !== nextSlot) {
-      return PeerErrorSeverity.HighToleranceError;
+      const slotNumberBigInt = message.payload.header.slotNumber.toBigInt();
+      if (slotNumberBigInt !== currentSlot && slotNumberBigInt !== nextSlot) {
+        return PeerErrorSeverity.HighToleranceError;
+      }
+
+      const attester = message.getSender();
+      if (!(await this.epochCache.isInCommittee(attester))) {
+        return PeerErrorSeverity.HighToleranceError;
+      }
+      return undefined;
+    } catch (e) {
+      // People shouldn't be sending us attestations if the committee doesn't exist
+      if (e instanceof NoCommitteeError) {
+        return PeerErrorSeverity.LowToleranceError;
+      }
+      throw e;
     }
-
-    const attester = message.getSender();
-    if (!(await this.epochCache.isInCommittee(attester))) {
-      return PeerErrorSeverity.HighToleranceError;
-    }
-
-    return undefined;
   }
 }

--- a/yarn-project/p2p/src/msg_validators/block_proposal_validator/block_proposal_validator.ts
+++ b/yarn-project/p2p/src/msg_validators/block_proposal_validator/block_proposal_validator.ts
@@ -1,4 +1,5 @@
 import type { EpochCacheInterface } from '@aztec/epoch-cache';
+import { NoCommitteeError } from '@aztec/ethereum';
 import { type Logger, createLogger } from '@aztec/foundation/log';
 import { type BlockProposal, type P2PValidator, PeerErrorSeverity } from '@aztec/stdlib/p2p';
 
@@ -12,32 +13,40 @@ export class BlockProposalValidator implements P2PValidator<BlockProposal> {
   }
 
   async validate(block: BlockProposal): Promise<PeerErrorSeverity | undefined> {
-    const { currentProposer, nextProposer, currentSlot, nextSlot } =
-      await this.epochCache.getProposerAttesterAddressInCurrentOrNextSlot();
+    try {
+      const { currentProposer, nextProposer, currentSlot, nextSlot } =
+        await this.epochCache.getProposerAttesterAddressInCurrentOrNextSlot();
 
-    // Check that the attestation is for the current or next slot
-    const slotNumberBigInt = block.payload.header.slotNumber.toBigInt();
-    if (slotNumberBigInt !== currentSlot && slotNumberBigInt !== nextSlot) {
-      this.logger.debug(
-        `Penalizing peer for invalid slot number ${slotNumberBigInt}, current slot: ${currentSlot}, next slot: ${nextSlot}`,
-      );
-      return PeerErrorSeverity.HighToleranceError;
+      // Check that the attestation is for the current or next slot
+      const slotNumberBigInt = block.payload.header.slotNumber.toBigInt();
+      if (slotNumberBigInt !== currentSlot && slotNumberBigInt !== nextSlot) {
+        this.logger.debug(
+          `Penalizing peer for invalid slot number ${slotNumberBigInt}, current slot: ${currentSlot}, next slot: ${nextSlot}`,
+        );
+        return PeerErrorSeverity.HighToleranceError;
+      }
+
+      // Check that the block proposal is from the current or next proposer
+      const proposer = block.getSender();
+      if (
+        currentProposer !== undefined &&
+        !proposer.equals(currentProposer) &&
+        nextProposer !== undefined &&
+        !proposer.equals(nextProposer)
+      ) {
+        this.logger.debug(
+          `Penalizing peer for invalid proposer ${proposer.toString()}, current proposer: ${currentProposer.toString()}, next proposer: ${nextProposer.toString()}`,
+        );
+        return PeerErrorSeverity.HighToleranceError;
+      }
+
+      return undefined;
+    } catch (e) {
+      // People shouldn't be sending us block proposals if the committee doesn't exist
+      if (e instanceof NoCommitteeError) {
+        return PeerErrorSeverity.LowToleranceError;
+      }
+      throw e;
     }
-
-    // Check that the block proposal is from the current or next proposer
-    const proposer = block.getSender();
-    if (
-      currentProposer !== undefined &&
-      !proposer.equals(currentProposer) &&
-      nextProposer !== undefined &&
-      !proposer.equals(nextProposer)
-    ) {
-      this.logger.debug(
-        `Penalizing peer for invalid proposer ${proposer.toString()}, current proposer: ${currentProposer.toString()}, next proposer: ${nextProposer.toString()}`,
-      );
-      return PeerErrorSeverity.HighToleranceError;
-    }
-
-    return undefined;
   }
 }

--- a/yarn-project/p2p/tsconfig.json
+++ b/yarn-project/p2p/tsconfig.json
@@ -13,6 +13,9 @@
       "path": "../epoch-cache"
     },
     {
+      "path": "../ethereum"
+    },
+    {
       "path": "../foundation"
     },
     {

--- a/yarn-project/slasher/src/epoch_prune_watcher.ts
+++ b/yarn-project/slasher/src/epoch_prune_watcher.ts
@@ -155,6 +155,10 @@ export class EpochPruneWatcher extends (EventEmitter as new () => WatcherEmitter
 
   private async getValidatorsForEpoch(epochNumber: bigint): Promise<EthAddress[]> {
     const { committee } = await this.epochCache.getCommitteeForEpoch(epochNumber);
+    if (!committee) {
+      this.log.trace(`No committee found for epoch ${epochNumber}`);
+      return [];
+    }
     return committee;
   }
 

--- a/yarn-project/slasher/src/slasher_client.test.ts
+++ b/yarn-project/slasher/src/slasher_client.test.ts
@@ -140,7 +140,7 @@ describe('SlasherClient', () => {
         await rollup.setupEpoch(l1TxUtils);
         const c = await rollup.getCurrentEpochCommittee();
         logger.debug('committee', c);
-        return c.length === 1 && c[0].toLowerCase() === privateKey.address.toLowerCase();
+        return c && c.length === 1 && c[0].toLowerCase() === privateKey.address.toLowerCase();
       },
       'non-empty committee',
       20,
@@ -150,6 +150,10 @@ describe('SlasherClient', () => {
     const slashAmount = depositAmount - 1n;
     expect(slashAmount).toBeLessThan(depositAmount);
     const committee = await rollup.getCurrentEpochCommittee();
+    if (!committee) {
+      throw new Error('No committee found');
+    }
+
     const amounts = Array.from({ length: committee.length }, () => slashAmount);
     const offenses = Array.from({ length: committee.length }, () => Offense.UNKNOWN);
 

--- a/yarn-project/validator-client/src/validator.ts
+++ b/yarn-project/validator-client/src/validator.ts
@@ -117,6 +117,10 @@ export class ValidatorClient extends (EventEmitter as new () => WatcherEmitter) 
   private async handleEpochCommitteeUpdate() {
     try {
       const { committee, epoch } = await this.epochCache.getCommittee('now');
+      if (!committee) {
+        this.log.trace(`No committee found for slot`);
+        return;
+      }
       if (epoch !== this.lastEpoch) {
         const me = this.myAddresses;
         const committeeSet = new Set(committee.map(v => v.toString()));

--- a/yarn-project/yarn.lock
+++ b/yarn-project/yarn.lock
@@ -1077,6 +1077,7 @@ __metadata:
     "@aztec/archiver": "workspace:^"
     "@aztec/constants": "workspace:^"
     "@aztec/epoch-cache": "workspace:^"
+    "@aztec/ethereum": "workspace:^"
     "@aztec/foundation": "workspace:^"
     "@aztec/kv-store": "workspace:^"
     "@aztec/noir-contracts.js": "workspace:^"


### PR DESCRIPTION
Now the rollup insists that it has at least the targetCommitteeSize in validators, else it is impossible to propose blocks because a committee will not form because it will not sample the validator set.

The important caveat is that if the rollup is deployed with a target committee size of 0, in which case the committee is guaranteed to be empty, and the `ValidatorSelectionLib` `verify` function will always pass.

Indeed, operations which query L1 for the current committee, such as `getCommitteeAt` and `getCurrentEpochCommittee` will revert with `ValidatorSelection__InsufficientCommitteeSize`. 

Because of this, typescript needed to change. In `rollup.ts`, we explicitly catch that error and return `undefined`. In the EpochCache, when we explicitly ask for the next proposer, we return `undefined` if the committee is empty, and throw a `NoCommitteeError` if the committee does not exist on L1.

TS tests now generally specify target committee size of 0. The exception is the e2e tests. It is now important that no transactions are awaited before the validator nodes are up, because the initial node cannot submit blocks. 

