### PR TITLE
refactor: more blobs pls

### DIFF
--- a/l1-contracts/src/core/libraries/rollup/BlobLib.sol
+++ b/l1-contracts/src/core/libraries/rollup/BlobLib.sol
@@ -11,7 +11,6 @@ library BlobLib {
   address public constant VM_ADDRESS = address(uint160(uint256(keccak256("hevm cheat code"))));
   uint256 internal constant VERSIONED_HASH_VERSION_KZG =
     0x0100000000000000000000000000000000000000000000000000000000000000; // 0x01 << 248 to be used in blobHashCheck
-  uint256 internal constant MAX_BLOBS_PER_BLOCK = 6; // Increasing to 9 with Pectra
 
   /**
    * @notice  Get the blob base fee
@@ -54,7 +53,9 @@ library BlobLib {
 
   /**
    * @notice  Validate an L2 block's blobs and return the blobHashes, the hashed blobHashes, and blob commitments.
-   * @notice  We assume that this propose transaction contains only Aztec blobs
+   *
+   *          We assume that the Aztec related blobs will be first in the propose transaction, additional blobs can be at the end.
+   *
    * Input bytes:
    * input[0] - num blobs in block
    * input[1:] - blob commitments (48 bytes * num blobs in block)
@@ -99,11 +100,6 @@ library BlobLib {
         blobHash = blobHashCheck;
       }
       blobHashes[i] = blobHash;
-    }
-    // Ensure no non-Aztec blobs have been emitted in this tx:
-    for (uint256 i = numBlobs; i < MAX_BLOBS_PER_BLOCK; i++) {
-      blobHash = getBlobHash(i);
-      require(blobHash == 0, Errors.Rollup__InvalidBlobHash(blobHash, 0));
     }
     // Hash the EVM blob hashes for the block header
     // TODO(#13430): The below blobsHashesCommitment known as blobsHash elsewhere in the code. The name blobsHashesCommitment is confusingly similar to blobCommitmentsHash

--- a/l1-contracts/test/base/RollupBase.sol
+++ b/l1-contracts/test/base/RollupBase.sol
@@ -107,7 +107,8 @@ contract RollupBase is DecoderBase {
   }
 
   function _proposeBlock(string memory _name, uint256 _slotNumber, uint256 _manaUsed) public {
-    _proposeBlock(_name, _slotNumber, _manaUsed, "");
+    bytes32[] memory extraBlobHashes = new bytes32[](0);
+    _proposeBlock(_name, _slotNumber, _manaUsed, extraBlobHashes, "");
   }
 
   function _proposeBlockFail(
@@ -116,13 +117,24 @@ contract RollupBase is DecoderBase {
     uint256 _manaUsed,
     bytes memory _revertMsg
   ) public {
-    _proposeBlock(_name, _slotNumber, _manaUsed, _revertMsg);
+    bytes32[] memory extraBlobHashes = new bytes32[](0);
+    _proposeBlock(_name, _slotNumber, _manaUsed, extraBlobHashes, _revertMsg);
+  }
+
+  function _proposeBlockWithExtraBlobs(
+    string memory _name,
+    uint256 _slotNumber,
+    uint256 _manaUsed,
+    bytes32[] memory _extraBlobHashes
+  ) public {
+    _proposeBlock(_name, _slotNumber, _manaUsed, _extraBlobHashes, "");
   }
 
   function _proposeBlock(
     string memory _name,
     uint256 _slotNumber,
     uint256 _manaUsed,
+    bytes32[] memory _extraBlobHashes,
     bytes memory _revertMsg
   ) private {
     DecoderBase.Full memory full = load(_name);
@@ -151,10 +163,24 @@ contract RollupBase is DecoderBase {
     full.block.header.contentCommitment.inHash = rollup.getInbox().getRoot(full.block.blockNumber);
 
     {
-      bytes32[] memory blobHashes = this.getBlobHashes(blobCommitments);
+      bytes32[] memory blobHashes;
+      if (_extraBlobHashes.length == 0) {
+        blobHashes = this.getBlobHashes(blobCommitments);
+      } else {
+        bytes32[] memory originalBlobHashes = this.getBlobHashes(blobCommitments);
+        blobHashes = new bytes32[](originalBlobHashes.length + _extraBlobHashes.length);
+        for (uint256 i = 0; i < originalBlobHashes.length; i++) {
+          blobHashes[i] = originalBlobHashes[i];
+        }
+        for (uint256 i = 0; i < _extraBlobHashes.length; i++) {
+          blobHashes[originalBlobHashes.length + i] = _extraBlobHashes[i];
+        }
+      }
+
       // https://github.com/foundry-rs/foundry/issues/10074
       // don't add blob hashes if forge gas report is true
       if (!vm.envOr("FORGE_GAS_REPORT", false)) {
+        emit log("Setting blob hashes");
         vm.blobhashes(blobHashes);
       } else {
         // skip blob check if forge gas report is true


### PR DESCRIPTION
Fixes #15031. Simply removes the limit and test that it is not exploding. The archiver should stay fully functional if additional blobs are included as its applies a filter using the hashes emitted as part of `L2BlockProposed`.