### PR TITLE
chore: renaming living to zombie

### DIFF
--- a/l1-contracts/src/core/libraries/rollup/StakingLib.sol
+++ b/l1-contracts/src/core/libraries/rollup/StakingLib.sol
@@ -18,13 +18,13 @@ import {SafeCast} from "@oz/utils/math/SafeCast.sol";
 
 // None -> Does not exist in our setup
 // Validating -> Participating as validator
-// Living -> Not participating as validator, but have funds in setup,
+// Zombie -> Not participating as validator, but have funds in setup,
 // 			 hit if slashes and going below the minimum
 // Exiting -> In the process of exiting the system
 enum Status {
   NONE,
   VALIDATING,
-  LIVING,
+  ZOMBIE,
   EXITING
 }
 
@@ -327,7 +327,7 @@ library StakingLib {
 
     Status status;
     if (exit.exists) {
-      status = exit.isRecipient ? Status.EXITING : Status.LIVING;
+      status = exit.isRecipient ? Status.EXITING : Status.ZOMBIE;
     } else {
       status = effectiveBalance > 0 ? Status.VALIDATING : Status.NONE;
     }

--- a/l1-contracts/test/base/Base.sol
+++ b/l1-contracts/test/base/Base.sol
@@ -245,8 +245,8 @@ contract TestBase is Test {
 
   function logStatus(Status status) internal {
     string memory statusString;
-    if (status == Status.LIVING) {
-      statusString = "LIVING";
+    if (status == Status.ZOMBIE) {
+      statusString = "ZOMBIE";
     } else if (status == Status.VALIDATING) {
       statusString = "VALIDATING";
     } else if (status == Status.EXITING) {

--- a/l1-contracts/test/governance/scenario/slashing/Slashing.t.sol
+++ b/l1-contracts/test/governance/scenario/slashing/Slashing.t.sol
@@ -132,7 +132,7 @@ contract SlashingTest is TestBase {
       AttesterView memory attesterView = rollup.getAttesterView(attesters[i]);
       assertEq(attesterView.effectiveBalance, 0);
       assertEq(attesterView.exit.amount, stakes[i] - slashAmount1 - slashAmount2, "Invalid stake");
-      assertTrue(attesterView.status == Status.LIVING, "Invalid status");
+      assertTrue(attesterView.status == Status.ZOMBIE, "Invalid status");
     }
   }
 }

--- a/l1-contracts/test/staking/deposit.t.sol
+++ b/l1-contracts/test/staking/deposit.t.sol
@@ -83,7 +83,7 @@ contract DepositTest is StakingBase {
 
     vm.prank(SLASHER);
     staking.slash(ATTESTER, DEPOSIT_AMOUNT - MINIMUM_STAKE + 1);
-    assertEq(uint256(staking.getStatus(ATTESTER)), uint256(Status.LIVING));
+    assertEq(uint256(staking.getStatus(ATTESTER)), uint256(Status.ZOMBIE));
 
     vm.expectRevert(abi.encodeWithSelector(Errors.Staking__AlreadyExiting.selector, ATTESTER));
     staking.deposit({_attester: ATTESTER, _withdrawer: WITHDRAWER, _onCanonical: true});

--- a/l1-contracts/test/staking/initiateWithdraw.t.sol
+++ b/l1-contracts/test/staking/initiateWithdraw.t.sol
@@ -140,7 +140,7 @@ contract InitiateWithdrawTest is StakingBase {
     assertEq(stakingAsset.balanceOf(RECIPIENT), 0);
 
     AttesterView memory attesterView = staking.getAttesterView(ATTESTER);
-    assertTrue(attesterView.status == Status.LIVING);
+    assertTrue(attesterView.status == Status.ZOMBIE);
     assertEq(attesterView.exit.exitableAt, Timestamp.wrap(block.timestamp) + staking.getExitDelay());
     assertEq(attesterView.exit.exists, true);
     assertEq(attesterView.exit.isRecipient, false);

--- a/l1-contracts/test/staking/slash.t.sol
+++ b/l1-contracts/test/staking/slash.t.sol
@@ -102,7 +102,7 @@ contract SlashTest is StakingBase {
       // Prepare the status and state
       AttesterView memory attesterView = staking.getAttesterView(ATTESTER);
       assertTrue(
-        attesterView.status == (isAlive ? Status.VALIDATING : Status.LIVING), "Invalid status"
+        attesterView.status == (isAlive ? Status.VALIDATING : Status.ZOMBIE), "Invalid status"
       );
       assertEq(staking.getActiveAttesterCount(), isAlive ? 1 : 0, "Invalid active attester count");
 
@@ -128,7 +128,7 @@ contract SlashTest is StakingBase {
         // The second round, we are not longer active, but there are money left
         assertEq(attesterView.effectiveBalance, 0, "Invalid effective balance");
         assertEq(attesterView.exit.amount, balance - slashingAmount, "Invalid exit amount");
-        assertTrue(attesterView.status == Status.LIVING, "Invalid status after slash");
+        assertTrue(attesterView.status == Status.ZOMBIE, "Invalid status after slash");
         assertEq(staking.getActiveAttesterCount(), 0, "Invalid active attester count");
       } else {
         // Fully slashed! NUKE IT.
@@ -184,7 +184,7 @@ contract SlashTest is StakingBase {
     attesterView = staking.getAttesterView(ATTESTER);
     assertEq(attesterView.effectiveBalance, 0);
     assertEq(attesterView.exit.amount, balance - slashingAmount);
-    assertTrue(attesterView.status == Status.LIVING);
+    assertTrue(attesterView.status == Status.ZOMBIE);
 
     assertEq(staking.getActiveAttesterCount(), activeAttesterCount - 1);
   }

--- a/l1-contracts/test/validator-selection/ValidatorSelection.t.sol
+++ b/l1-contracts/test/validator-selection/ValidatorSelection.t.sol
@@ -221,12 +221,12 @@ contract ValidatorSelectionTest is ValidatorSelectionTestBase {
     slasher.slash(slashPayload);
 
     // Make sure that the slash was successful,
-    // Meaning that validators are now LIVING and have lost the slash amount
+    // Meaning that validators are now ZOMBIE and have lost the slash amount
     for (uint256 i = 0; i < attesters.length; i++) {
       AttesterView memory attesterView = rollup.getAttesterView(attesters[i]);
       assertEq(attesterView.effectiveBalance, 0);
       assertEq(attesterView.exit.amount, stakes[i] - slashAmount, "Invalid stake");
-      assertTrue(attesterView.status == Status.LIVING, "Invalid status after");
+      assertTrue(attesterView.status == Status.ZOMBIE, "Invalid status after");
     }
   }
 


### PR DESCRIPTION
Fixes #14937 by renaming the `LIVING` status into `ZOMBIE`