### PR TITLE
chore: Store tx effects individually

### DIFF
--- a/yarn-project/archiver/src/archiver/kv_archiver_store/block_store.ts
+++ b/yarn-project/archiver/src/archiver/kv_archiver_store/block_store.ts
@@ -2,11 +2,20 @@ import { INITIAL_L2_BLOCK_NUM } from '@aztec/constants';
 import { Fr } from '@aztec/foundation/fields';
 import { toArray } from '@aztec/foundation/iterable';
 import { createLogger } from '@aztec/foundation/log';
+import { BufferReader } from '@aztec/foundation/serialize';
 import type { AztecAsyncKVStore, AztecAsyncMap, AztecAsyncSingleton, Range } from '@aztec/kv-store';
 import type { AztecAddress } from '@aztec/stdlib/aztec-address';
 import { Body, CommitteeAttestation, L2Block, L2BlockHash } from '@aztec/stdlib/block';
 import { AppendOnlyTreeSnapshot } from '@aztec/stdlib/trees';
-import { BlockHeader, type IndexedTxEffect, TxHash, TxReceipt } from '@aztec/stdlib/tx';
+import {
+  BlockHeader,
+  type IndexedTxEffect,
+  TxEffect,
+  TxHash,
+  TxReceipt,
+  deserializeIndexedTxEffect,
+  serializeIndexedTxEffect,
+} from '@aztec/stdlib/tx';
 
 import { BlockNumberNotSequentialError, InitialBlockNumberNotSequentialError } from '../errors.js';
 import type { L1PublishedData, PublishedL2Block } from '../structs/published.js';
@@ -30,17 +39,17 @@ export class BlockStore {
   /** Map block number to block data */
   #blocks: AztecAsyncMap<number, BlockStorage>;
 
-  /** Map block hash to block body */
-  #blockBodies: AztecAsyncMap<string, Buffer>;
+  /** Map block hash to list of tx hashes */
+  #blockTxs: AztecAsyncMap<string, Buffer>;
+
+  /** Tx hash to serialized IndexedTxEffect */
+  #txEffects: AztecAsyncMap<string, Buffer>;
 
   /** Stores L1 block number in which the last processed L2 block was included */
   #lastSynchedL1Block: AztecAsyncSingleton<bigint>;
 
   /** Stores l2 block number of the last proven block */
   #lastProvenL2Block: AztecAsyncSingleton<number>;
-
-  /** Index mapping transaction hash (as a string) to its location in a block */
-  #txIndex: AztecAsyncMap<string, BlockIndexValue>;
 
   /** Index mapping a contract's address (as a string) to its location in a block */
   #contractIndex: AztecAsyncMap<string, BlockIndexValue>;
@@ -49,8 +58,8 @@ export class BlockStore {
 
   constructor(private db: AztecAsyncKVStore) {
     this.#blocks = db.openMap('archiver_blocks');
-    this.#blockBodies = db.openMap('archiver_block_bodies');
-    this.#txIndex = db.openMap('archiver_tx_index');
+    this.#blockTxs = db.openMap('archiver_block_txs');
+    this.#txEffects = db.openMap('archiver_tx_effects');
     this.#contractIndex = db.openMap('archiver_contract_index');
     this.#lastSynchedL1Block = db.openSingleton('archiver_last_synched_l1_block');
     this.#lastProvenL2Block = db.openSingleton('archiver_last_proven_l2_block');
@@ -97,11 +106,19 @@ export class BlockStore {
         });
 
         for (let i = 0; i < block.block.body.txEffects.length; i++) {
-          const txEffect = block.block.body.txEffects[i];
-          await this.#txIndex.set(txEffect.txHash.toString(), [block.block.number, i]);
+          const txEffect: IndexedTxEffect = {
+            data: block.block.body.txEffects[i],
+            l2BlockNumber: block.block.number,
+            l2BlockHash: blockHash.toString(),
+            txIndexInBlock: i,
+          };
+          await this.#txEffects.set(txEffect.data.txHash.toString(), serializeIndexedTxEffect(txEffect));
         }
 
-        await this.#blockBodies.set(blockHash.toString(), block.block.body.toBuffer());
+        await this.#blockTxs.set(
+          blockHash.toString(),
+          Buffer.concat(block.block.body.txEffects.map(tx => tx.txHash.toBuffer())),
+        );
       }
 
       await this.#lastSynchedL1Block.set(blocks[blocks.length - 1].l1.blockNumber);
@@ -137,9 +154,9 @@ export class BlockStore {
           continue;
         }
         await this.#blocks.delete(block.block.number);
-        await Promise.all(block.block.body.txEffects.map(tx => this.#txIndex.delete(tx.txHash.toString())));
+        await Promise.all(block.block.body.txEffects.map(tx => this.#txEffects.delete(tx.txHash.toString())));
         const blockHash = (await block.block.hash()).toString();
-        await this.#blockBodies.delete(blockHash);
+        await this.#blockTxs.delete(blockHash);
         this.#log.debug(`Unwound block ${blockNumber} ${blockHash}`);
       }
 
@@ -211,13 +228,26 @@ export class BlockStore {
     const archive = AppendOnlyTreeSnapshot.fromBuffer(blockStorage.archive);
     const blockHash = blockStorage.blockHash;
     const blockHashString = blockHash.toString();
-    const blockBodyBuffer = await this.#blockBodies.getAsync(blockHashString);
-    if (blockBodyBuffer === undefined) {
+    const blockTxsBuffer = await this.#blockTxs.getAsync(blockHashString);
+    if (blockTxsBuffer === undefined) {
       this.#log.warn(`Could not find body for block ${header.globalVariables.blockNumber} ${blockHash}`);
       return undefined;
     }
-    const body = Body.fromBuffer(blockBodyBuffer);
+
+    const txEffects: TxEffect[] = [];
+    const reader = BufferReader.asReader(blockTxsBuffer);
+    while (!reader.isEmpty()) {
+      const txHash = reader.readObject(TxHash);
+      const txEffect = await this.#txEffects.getAsync(txHash.toString());
+      if (txEffect === undefined) {
+        this.#log.warn(`Could not find tx effect for tx ${txHash} in block ${blockNumber}`);
+        return undefined;
+      }
+      txEffects.push(deserializeIndexedTxEffect(txEffect).data);
+    }
+    const body = new Body(txEffects);
     const block = new L2Block(archive, header, body, Fr.fromBuffer(blockHash));
+
     if (block.number !== blockNumber) {
       throw new Error(
         `Block number mismatch when retrieving block from archive (expected ${blockNumber} but got ${
@@ -235,22 +265,11 @@ export class BlockStore {
    * @returns The requested tx effect with block info (or undefined if not found).
    */
   async getTxEffect(txHash: TxHash): Promise<IndexedTxEffect | undefined> {
-    const [blockNumber, txIndex] = (await this.getTxLocation(txHash)) ?? [];
-    if (typeof blockNumber !== 'number' || typeof txIndex !== 'number') {
+    const buffer = await this.#txEffects.getAsync(txHash.toString());
+    if (!buffer) {
       return undefined;
     }
-
-    const block = await this.getBlock(blockNumber);
-    if (!block) {
-      return undefined;
-    }
-
-    return {
-      data: block.block.body.txEffects[txIndex],
-      l2BlockNumber: block.block.number,
-      l2BlockHash: (await block.block.hash()).toString(),
-      txIndexInBlock: txIndex,
-    };
+    return deserializeIndexedTxEffect(buffer);
   }
 
   /**
@@ -259,25 +278,18 @@ export class BlockStore {
    * @returns The requested tx receipt (or undefined if not found).
    */
   async getSettledTxReceipt(txHash: TxHash): Promise<TxReceipt | undefined> {
-    const [blockNumber, txIndex] = (await this.getTxLocation(txHash)) ?? [];
-    if (typeof blockNumber !== 'number' || typeof txIndex !== 'number') {
+    const txEffect = await this.getTxEffect(txHash);
+    if (!txEffect) {
       return undefined;
     }
-
-    const block = await this.getBlock(blockNumber);
-    if (!block) {
-      return undefined;
-    }
-
-    const tx = block.block.body.txEffects[txIndex];
 
     return new TxReceipt(
       txHash,
-      TxReceipt.statusFromRevertCode(tx.revertCode),
+      TxReceipt.statusFromRevertCode(txEffect.data.revertCode),
       '',
-      tx.transactionFee.toBigInt(),
-      L2BlockHash.fromField(await block.block.hash()),
-      block.block.number,
+      txEffect.data.transactionFee.toBigInt(),
+      L2BlockHash.fromString(txEffect.l2BlockHash),
+      txEffect.l2BlockNumber,
     );
   }
 
@@ -286,8 +298,13 @@ export class BlockStore {
    * @param txHash - The txHash of the tx.
    * @returns The block number and index of the tx.
    */
-  getTxLocation(txHash: TxHash): Promise<[blockNumber: number, txIndex: number] | undefined> {
-    return this.#txIndex.getAsync(txHash.toString());
+  public async getTxLocation(txHash: TxHash): Promise<[blockNumber: number, txIndex: number] | undefined> {
+    const txEffect = await this.#txEffects.getAsync(txHash.toString());
+    if (!txEffect) {
+      return undefined;
+    }
+    const { l2BlockNumber, txIndexInBlock } = deserializeIndexedTxEffect(txEffect);
+    return [l2BlockNumber, txIndexInBlock];
   }
 
   /**

--- a/yarn-project/archiver/src/test/mock_l2_block_source.ts
+++ b/yarn-project/archiver/src/test/mock_l2_block_source.ts
@@ -150,7 +150,7 @@ export class MockL2BlockSource implements L2BlockSource, ContractDataSource {
     return {
       data: txEffect,
       l2BlockNumber: block.number,
-      l2BlockHash: (await block.hash()).toString(),
+      l2BlockHash: L2BlockHash.fromField(await block.hash()),
       txIndexInBlock: block.body.txEffects.indexOf(txEffect),
     };
   }

--- a/yarn-project/aztec-node/src/aztec-node/server.ts
+++ b/yarn-project/aztec-node/src/aztec-node/server.ts
@@ -47,7 +47,14 @@ import {
 import { PublicProcessorFactory } from '@aztec/simulator/server';
 import { EpochPruneWatcher, SlasherClient, type Watcher } from '@aztec/slasher';
 import { AztecAddress } from '@aztec/stdlib/aztec-address';
-import type { InBlock, L2Block, L2BlockNumber, L2BlockSource, PublishedL2Block } from '@aztec/stdlib/block';
+import {
+  type InBlock,
+  type L2Block,
+  L2BlockHash,
+  type L2BlockNumber,
+  type L2BlockSource,
+  type PublishedL2Block,
+} from '@aztec/stdlib/block';
 import type {
   ContractClassPublic,
   ContractDataSource,
@@ -724,13 +731,13 @@ export class AztecNodeService implements AztecNode, AztecNodeAdmin, Traceable {
         return undefined;
       }
       const blockHashIndex = uniqueBlockNumbers.indexOf(blockNumber);
-      const blockHash = blockHashes[blockHashIndex]?.toString();
+      const blockHash = blockHashes[blockHashIndex];
       if (!blockHash) {
         return undefined;
       }
       return {
         l2BlockNumber: Number(blockNumber),
-        l2BlockHash: blockHash,
+        l2BlockHash: L2BlockHash.fromField(blockHash),
         data: index,
       };
     });

--- a/yarn-project/pxe/src/contract_function_simulator/pxe_oracle_interface.ts
+++ b/yarn-project/pxe/src/contract_function_simulator/pxe_oracle_interface.ts
@@ -703,7 +703,7 @@ export class PXEOracleInterface implements ExecutionDataProvider {
       siloedNullifier,
       txHash,
       uniqueNoteHashTreeIndexInBlock?.l2BlockNumber,
-      uniqueNoteHashTreeIndexInBlock?.l2BlockHash,
+      uniqueNoteHashTreeIndexInBlock?.l2BlockHash.toString(),
       uniqueNoteHashTreeIndexInBlock?.data,
       recipient,
     );

--- a/yarn-project/pxe/src/storage/note_data_provider/note_data_provider.test.ts
+++ b/yarn-project/pxe/src/storage/note_data_provider/note_data_provider.test.ts
@@ -2,6 +2,7 @@ import { timesParallel } from '@aztec/foundation/collection';
 import { Fr } from '@aztec/foundation/fields';
 import { openTmpStore } from '@aztec/kv-store/lmdb-v2';
 import { AztecAddress } from '@aztec/stdlib/aztec-address';
+import { L2BlockHash } from '@aztec/stdlib/block';
 import { NoteStatus, type NotesFilter } from '@aztec/stdlib/note';
 import { randomTxHash } from '@aztec/stdlib/testing';
 
@@ -96,7 +97,7 @@ describe('NoteDataProvider', () => {
       const nullifiers = notesToNullify.map(note => ({
         data: note.siloedNullifier,
         l2BlockNumber: note.l2BlockNumber,
-        l2BlockHash: note.l2BlockHash,
+        l2BlockHash: L2BlockHash.fromString(note.l2BlockHash),
       }));
       await expect(noteDataProvider.removeNullifiedNotes(nullifiers, recipient)).resolves.toEqual(notesToNullify);
     }
@@ -112,7 +113,7 @@ describe('NoteDataProvider', () => {
     const nullifiers = notesToNullify.map(note => ({
       data: note.siloedNullifier,
       l2BlockNumber: note.l2BlockNumber,
-      l2BlockHash: note.l2BlockHash,
+      l2BlockHash: L2BlockHash.fromString(note.l2BlockHash),
     }));
     await expect(noteDataProvider.removeNullifiedNotes(nullifiers, notesToNullify[0].recipient)).resolves.toEqual(
       notesToNullify,
@@ -132,7 +133,7 @@ describe('NoteDataProvider', () => {
     const nullifiers = notesToNullify.map(note => ({
       data: note.siloedNullifier,
       l2BlockNumber: 99,
-      l2BlockHash: Fr.random().toString(),
+      l2BlockHash: L2BlockHash.random(),
     }));
     await expect(noteDataProvider.removeNullifiedNotes(nullifiers, notesToNullify[0].recipient)).resolves.toEqual(
       notesToNullify,
@@ -151,7 +152,7 @@ describe('NoteDataProvider', () => {
     const nullifiers = notesToNullify.map(note => ({
       data: note.siloedNullifier,
       l2BlockNumber: note.l2BlockNumber,
-      l2BlockHash: note.l2BlockHash,
+      l2BlockHash: L2BlockHash.fromString(note.l2BlockHash),
     }));
     await expect(noteDataProvider.removeNullifiedNotes(nullifiers, notesToNullify[0].recipient)).resolves.toEqual(
       notesToNullify,
@@ -209,7 +210,7 @@ describe('NoteDataProvider', () => {
         [
           {
             data: notes[0].siloedNullifier,
-            l2BlockHash: notes[0].l2BlockHash,
+            l2BlockHash: L2BlockHash.fromString(notes[0].l2BlockHash),
             l2BlockNumber: notes[0].l2BlockNumber,
           },
         ],

--- a/yarn-project/stdlib/src/block/block_hash.ts
+++ b/yarn-project/stdlib/src/block/block_hash.ts
@@ -1,5 +1,6 @@
 import { Buffer32 } from '@aztec/foundation/buffer';
 import { Fr } from '@aztec/foundation/fields';
+import { BufferReader } from '@aztec/foundation/serialize';
 
 import { schemas } from '../schemas/schemas.js';
 
@@ -14,6 +15,19 @@ export class L2BlockHash extends Buffer32 {
 
   static override random() {
     return new L2BlockHash(Fr.random().toBuffer());
+  }
+
+  static override fromNumber(num: number): L2BlockHash {
+    return new L2BlockHash(super.fromNumber(num).toBuffer());
+  }
+
+  static override fromBuffer(buffer: Buffer | BufferReader) {
+    const reader = BufferReader.asReader(buffer);
+    return new L2BlockHash(reader.readBytes(L2BlockHash.SIZE));
+  }
+
+  static override fromString(str: string): Buffer32 {
+    return new L2BlockHash(super.fromString(str).toBuffer());
   }
 
   static get schema() {

--- a/yarn-project/stdlib/src/block/in_block.ts
+++ b/yarn-project/stdlib/src/block/in_block.ts
@@ -1,14 +1,13 @@
-import { Fr } from '@aztec/foundation/fields';
-
 import { type ZodTypeAny, z } from 'zod';
 
 import { schemas } from '../schemas/index.js';
+import { L2BlockHash } from './block_hash.js';
 import type { L2Block } from './l2_block.js';
 
 // Note: If you expand this type with indexInBlock, then delete `IndexedTxEffect` and use this type instead.
 export type InBlock<T> = {
   l2BlockNumber: number;
-  l2BlockHash: string;
+  l2BlockHash: L2BlockHash;
   data: T;
 };
 
@@ -16,7 +15,7 @@ export function randomInBlock<T>(data: T): InBlock<T> {
   return {
     data,
     l2BlockNumber: Math.floor(Math.random() * 1000),
-    l2BlockHash: Fr.random().toString(),
+    l2BlockHash: L2BlockHash.random(),
   };
 }
 
@@ -24,7 +23,7 @@ export async function wrapInBlock<T>(data: T, block: L2Block): Promise<InBlock<T
   return {
     data,
     l2BlockNumber: block.number,
-    l2BlockHash: (await block.hash()).toString(),
+    l2BlockHash: L2BlockHash.fromField(await block.hash()),
   };
 }
 
@@ -32,6 +31,6 @@ export function inBlockSchemaFor<T extends ZodTypeAny>(schema: T) {
   return z.object({
     data: schema,
     l2BlockNumber: schemas.Integer,
-    l2BlockHash: z.string(),
+    l2BlockHash: L2BlockHash.schema,
   });
 }

--- a/yarn-project/stdlib/src/interfaces/archiver.test.ts
+++ b/yarn-project/stdlib/src/interfaces/archiver.test.ts
@@ -8,7 +8,7 @@ import omit from 'lodash.omit';
 import type { ContractArtifact } from '../abi/abi.js';
 import { FunctionSelector } from '../abi/function_selector.js';
 import { AztecAddress } from '../aztec-address/index.js';
-import { CommitteeAttestation } from '../block/index.js';
+import { CommitteeAttestation, L2BlockHash } from '../block/index.js';
 import { L2Block } from '../block/l2_block.js';
 import type { L2Tips } from '../block/l2_block_source.js';
 import type { PublishedL2Block } from '../block/published_l2_block.js';
@@ -285,7 +285,12 @@ class MockArchiver implements ArchiverApi {
   }
   async getTxEffect(_txHash: TxHash): Promise<IndexedTxEffect | undefined> {
     expect(_txHash).toBeInstanceOf(TxHash);
-    return { l2BlockNumber: 1, l2BlockHash: '0x12', data: await TxEffect.random(), txIndexInBlock: randomInt(10) };
+    return {
+      l2BlockNumber: 1,
+      l2BlockHash: L2BlockHash.fromNumber(0x12),
+      data: await TxEffect.random(),
+      txIndexInBlock: randomInt(10),
+    };
   }
   getSettledTxReceipt(txHash: TxHash): Promise<TxReceipt | undefined> {
     expect(txHash).toBeInstanceOf(TxHash);

--- a/yarn-project/stdlib/src/interfaces/aztec-node.test.ts
+++ b/yarn-project/stdlib/src/interfaces/aztec-node.test.ts
@@ -20,7 +20,7 @@ import times from 'lodash.times';
 import type { ContractArtifact } from '../abi/abi.js';
 import { AztecAddress } from '../aztec-address/index.js';
 import type { InBlock } from '../block/in_block.js';
-import { CommitteeAttestation, type L2BlockNumber } from '../block/index.js';
+import { CommitteeAttestation, L2BlockHash, type L2BlockNumber } from '../block/index.js';
 import { L2Block } from '../block/l2_block.js';
 import type { L2Tips } from '../block/l2_block_source.js';
 import type { PublishedL2Block } from '../block/published_l2_block.js';
@@ -96,7 +96,7 @@ describe('AztecNodeApiSchema', () => {
 
   it('findLeavesIndexes', async () => {
     const response = await context.client.findLeavesIndexes(1, MerkleTreeId.ARCHIVE, [Fr.random(), Fr.random()]);
-    expect(response).toEqual([{ data: 1n, l2BlockNumber: 1, l2BlockHash: '0x01' }, undefined]);
+    expect(response).toEqual([{ data: 1n, l2BlockNumber: 1, l2BlockHash: L2BlockHash.fromNumber(1) }, undefined]);
 
     await expect(
       context.client.findLeavesIndexes(1, MerkleTreeId.ARCHIVE, times(MAX_RPC_LEN + 1, Fr.random)),
@@ -448,7 +448,7 @@ class MockAztecNode implements AztecNode {
     expect(leafValues).toHaveLength(2);
     expect(leafValues[0]).toBeInstanceOf(Fr);
     expect(leafValues[1]).toBeInstanceOf(Fr);
-    return Promise.resolve([{ data: 1n, l2BlockNumber: 1, l2BlockHash: '0x01' }, undefined]);
+    return Promise.resolve([{ data: 1n, l2BlockNumber: 1, l2BlockHash: L2BlockHash.fromNumber(1) }, undefined]);
   }
   getNullifierSiblingPath(
     blockNumber: number | 'latest',
@@ -623,7 +623,12 @@ class MockAztecNode implements AztecNode {
   }
   async getTxEffect(txHash: TxHash): Promise<IndexedTxEffect | undefined> {
     expect(txHash).toBeInstanceOf(TxHash);
-    return { l2BlockNumber: 1, l2BlockHash: '0x12', data: await TxEffect.random(), txIndexInBlock: randomInt(10) };
+    return {
+      l2BlockNumber: 1,
+      l2BlockHash: L2BlockHash.fromNumber(0x12),
+      data: await TxEffect.random(),
+      txIndexInBlock: randomInt(10),
+    };
   }
   getPendingTxs(): Promise<Tx[]> {
     return Promise.resolve([Tx.random()]);

--- a/yarn-project/stdlib/src/interfaces/pxe.test.ts
+++ b/yarn-project/stdlib/src/interfaces/pxe.test.ts
@@ -15,6 +15,7 @@ import type { ContractArtifact } from '../abi/abi.js';
 import { EventSelector } from '../abi/event_selector.js';
 import { AuthWitness } from '../auth_witness/auth_witness.js';
 import { AztecAddress } from '../aztec-address/index.js';
+import { L2BlockHash } from '../block/block_hash.js';
 import { L2Block } from '../block/l2_block.js';
 import {
   CompleteAddress,
@@ -191,7 +192,7 @@ describe('PXESchema', () => {
   it('getTxEffect', async () => {
     const { l2BlockHash, l2BlockNumber, data } = (await context.client.getTxEffect(TxHash.random()))!;
     expect(data).toBeInstanceOf(TxEffect);
-    expect(l2BlockHash).toMatch(/0x[a-fA-F0-9]{64}/);
+    expect(l2BlockHash).toBeInstanceOf(L2BlockHash);
     expect(l2BlockNumber).toBe(1);
   });
 
@@ -417,7 +418,7 @@ class MockPXE implements PXE {
     expect(txHash).toBeInstanceOf(TxHash);
     return {
       data: await TxEffect.random(),
-      l2BlockHash: Fr.random().toString(),
+      l2BlockHash: L2BlockHash.random(),
       l2BlockNumber: 1,
       txIndexInBlock: randomInt(10),
     };

--- a/yarn-project/stdlib/src/tx/indexed_tx_effect.test.ts
+++ b/yarn-project/stdlib/src/tx/indexed_tx_effect.test.ts
@@ -1,0 +1,15 @@
+import { deserializeIndexedTxEffect, randomIndexedTxEffect, serializeIndexedTxEffect } from './indexed_tx_effect.js';
+
+describe('IndexedTxEffect', () => {
+  it('serializes and deserializes correctly', async () => {
+    const effect = await randomIndexedTxEffect();
+
+    const serialized = serializeIndexedTxEffect(effect);
+    const deserialized = deserializeIndexedTxEffect(serialized);
+
+    expect(deserialized.l2BlockHash).toEqual(effect.l2BlockHash);
+    expect(deserialized.l2BlockNumber).toEqual(effect.l2BlockNumber);
+    expect(deserialized.txIndexInBlock).toEqual(effect.txIndexInBlock);
+    expect(deserialized.data).toEqual(effect.data);
+  });
+});

--- a/yarn-project/stdlib/src/tx/indexed_tx_effect.ts
+++ b/yarn-project/stdlib/src/tx/indexed_tx_effect.ts
@@ -1,7 +1,7 @@
-import { Buffer32 } from '@aztec/foundation/buffer';
 import { schemas } from '@aztec/foundation/schemas';
 import { BufferReader, serializeToBuffer } from '@aztec/foundation/serialize';
 
+import { L2BlockHash } from '../block/block_hash.js';
 import { type InBlock, inBlockSchemaFor, randomInBlock } from '../block/in_block.js';
 import { TxEffect } from './tx_effect.js';
 
@@ -19,18 +19,13 @@ export async function randomIndexedTxEffect(): Promise<IndexedTxEffect> {
 }
 
 export function serializeIndexedTxEffect(effect: IndexedTxEffect): Buffer {
-  return serializeToBuffer(
-    Buffer32.fromString(effect.l2BlockHash),
-    effect.l2BlockNumber,
-    effect.txIndexInBlock,
-    effect.data,
-  );
+  return serializeToBuffer(effect.l2BlockHash, effect.l2BlockNumber, effect.txIndexInBlock, effect.data);
 }
 
 export function deserializeIndexedTxEffect(buffer: Buffer): IndexedTxEffect {
   const reader = BufferReader.asReader(buffer);
 
-  const l2BlockHash = reader.readObject(Buffer32).toString();
+  const l2BlockHash = reader.readObject(L2BlockHash);
   const l2BlockNumber = reader.readNumber();
   const txIndexInBlock = reader.readNumber();
   const data = reader.readObject(TxEffect);

--- a/yarn-project/stdlib/src/tx/indexed_tx_effect.ts
+++ b/yarn-project/stdlib/src/tx/indexed_tx_effect.ts
@@ -1,4 +1,6 @@
+import { Buffer32 } from '@aztec/foundation/buffer';
 import { schemas } from '@aztec/foundation/schemas';
+import { BufferReader, serializeToBuffer } from '@aztec/foundation/serialize';
 
 import { type InBlock, inBlockSchemaFor, randomInBlock } from '../block/in_block.js';
 import { TxEffect } from './tx_effect.js';
@@ -13,5 +15,30 @@ export async function randomIndexedTxEffect(): Promise<IndexedTxEffect> {
   return {
     ...randomInBlock(await TxEffect.random()),
     txIndexInBlock: Math.floor(Math.random() * 1000),
+  };
+}
+
+export function serializeIndexedTxEffect(effect: IndexedTxEffect): Buffer {
+  return serializeToBuffer(
+    Buffer32.fromString(effect.l2BlockHash),
+    effect.l2BlockNumber,
+    effect.txIndexInBlock,
+    effect.data,
+  );
+}
+
+export function deserializeIndexedTxEffect(buffer: Buffer): IndexedTxEffect {
+  const reader = BufferReader.asReader(buffer);
+
+  const l2BlockHash = reader.readObject(Buffer32).toString();
+  const l2BlockNumber = reader.readNumber();
+  const txIndexInBlock = reader.readNumber();
+  const data = reader.readObject(TxEffect);
+
+  return {
+    l2BlockHash,
+    l2BlockNumber,
+    txIndexInBlock,
+    data,
   };
 }


### PR DESCRIPTION
We were storing tx effects in the archiver as part of the block body. This means that every time we had to get a tx receipt or effect, we had to deserialize the entire block to get just one tx.

This changes the structure of the archiver db so we store each tx effect on its own, and the block just stores the list of block hashes it contains.

Fixes #14299