### PR TITLE
fix: `fish` path installation

### DIFF
--- a/barretenberg/bbup/install
+++ b/barretenberg/bbup/install
@@ -37,7 +37,7 @@ chmod 755 "$INSTALL_PATH"
 
 # Add to shell config files if not already present
 PATH_ENTRY="export PATH=\"\${HOME}/.bb:\${PATH}\""
-FISH_PATH_ENTRY="set -gx PATH \${HOME}/.bb \$PATH"
+FISH_PATH_ENTRY="fish_add_path $HOME/.bb || true"
 
 add_to_config() {
     local config_file="$1"


### PR DESCRIPTION
Fixes an issue with installation with `fish` (tested on the `next` branch as well).

```
~/.config/fish/config.fish (line 20): Variables cannot be bracketed. In fish, please use {$HOME}.
set -gx PATH ${HOME}/.bb $PATH
              ^
from sourcing file ~/.config/fish/config.fish
        called during startup
source: Error while reading file '/Users/rumcajs/.config/fish/config.fish'
```

I used the canonical (since March 2021) https://fishshell.com/docs/current/cmds/fish_add_path.html. I removed the brackets; they are not needed.

Related (not merged) https://github.com/AztecProtocol/aztec-packages/pull/10559