### PR TITLE
chore: benchmark IPA MSM

### DIFF
--- a/barretenberg/cpp/src/barretenberg/commitment_schemes/commit.bench.cpp
+++ b/barretenberg/cpp/src/barretenberg/commitment_schemes/commit.bench.cpp
@@ -5,6 +5,7 @@
 // =====================
 
 #include "barretenberg/commitment_schemes/commitment_key.hpp"
+#include "barretenberg/commitment_schemes/verification_key.hpp"
 #include "barretenberg/ecc//batched_affine_addition/batched_affine_addition.hpp"
 #include "barretenberg/polynomials/polynomial.hpp"
 #include "barretenberg/srs/factories/mem_bn254_crs_factory.hpp"
@@ -251,6 +252,45 @@ template <typename Curve> void bench_commit_mock_z_perm_preprocessed(::benchmark
         key.commit_structured_with_nonzero_complement(polynomial, active_range_endpoints);
     }
 }
+
+constexpr size_t MIN_LOG_NUM_GRUMPKIN_POINTS = 12;
+constexpr size_t MAX_LOG_NUM_GRUMPKIN_POINTS = 16;
+constexpr size_t MAX_NUM_GRUMPKIN_POINTS = 1 << MAX_LOG_NUM_GRUMPKIN_POINTS;
+
+/**
+ * @brief Benchmark pippenger_without_endomorphism_basis_points function, which is used notably in the IPA verifier.
+ *
+ * @tparam Curve
+ * @param state
+ */
+template <typename Curve> void bench_pippenger_without_endomorphism_basis_points(::benchmark::State& state)
+{
+    using Fr = typename Curve::ScalarField;
+    using Commitment = typename Curve::AffineElement;
+
+    bb::srs::init_file_crs_factory(bb::srs::bb_crs_path());
+    auto pcs_verification_key = std::make_shared<VerifierCommitmentKey<Curve>>(MAX_NUM_GRUMPKIN_POINTS + 1);
+
+    for (auto _ : state) {
+        state.PauseTiming();
+        const size_t num_points = 1 << state.range(0);
+        Polynomial<Fr> s_poly = Polynomial<Fr>::random(num_points);
+
+        state.ResumeTiming();
+        std::span<const Commitment> srs_elements = pcs_verification_key->get_monomial_points();
+        std::vector<Commitment> G_vec_local(num_points);
+        parallel_for_heuristic(
+            num_points, [&](size_t i) { G_vec_local[i] = srs_elements[i * 2]; }, thread_heuristics::FF_COPY_COST * 2);
+
+        // IPA MSM
+        bb::scalar_multiplication::pippenger_without_endomorphism_basis_points<Curve>(
+            s_poly, { &G_vec_local[0], /*size*/ num_points }, pcs_verification_key->pippenger_runtime_state.get());
+    }
+}
+
+BENCHMARK(bench_pippenger_without_endomorphism_basis_points<curve::Grumpkin>)
+    ->DenseRange(MIN_LOG_NUM_GRUMPKIN_POINTS, MAX_LOG_NUM_GRUMPKIN_POINTS)
+    ->Unit(benchmark::kMillisecond);
 
 BENCHMARK(bench_commit_zero<curve::BN254>)
     ->DenseRange(MIN_LOG_NUM_POINTS, MAX_LOG_NUM_POINTS)


### PR DESCRIPTION
Adds a benchmark for the IPA MSM that makes up a large portion of IVC verification time.

The benchmark reports 273ms for 1 thread, and 30ms for 16 threads.