### PR TITLE
feat!: AVMs getenv opcode should use "effective fees" rather than feePerGas from globals

### DIFF
--- a/yarn-project/simulator/src/public/avm/avm_execution_environment.ts
+++ b/yarn-project/simulator/src/public/avm/avm_execution_environment.ts
@@ -1,5 +1,6 @@
 import { Fr } from '@aztec/foundation/fields';
 import type { AztecAddress } from '@aztec/stdlib/aztec-address';
+import type { GasFees } from '@aztec/stdlib/gas';
 import type { GlobalVariables } from '@aztec/stdlib/tx';
 
 /**
@@ -15,6 +16,7 @@ export class AvmExecutionEnvironment {
     public readonly globals: GlobalVariables,
     public readonly isStaticCall: boolean,
     public readonly calldata: Fr[],
+    public readonly effectiveGasFees: GasFees,
     public readonly clientInitiatedSimulation: boolean = false,
   ) {}
 
@@ -31,6 +33,7 @@ export class AvmExecutionEnvironment {
       this.globals,
       isStaticCall,
       calldata,
+      this.effectiveGasFees,
       /*clientInitiatedSimulation=*/ this.clientInitiatedSimulation,
     );
   }

--- a/yarn-project/simulator/src/public/avm/avm_simulator.test.ts
+++ b/yarn-project/simulator/src/public/avm/avm_simulator.test.ts
@@ -493,6 +493,7 @@ describe('AVM simulator: transpiled Noir contracts', () => {
     const blockNumber = randomInt(20000);
     const timestamp = BigInt(randomInt(100000)); // timestamp as UInt64
     const gasFees = GasFees.random();
+    const effectiveGasFees = GasFees.random(); // Create separate effective gas fees for testing
 
     beforeAll(async () => {
       address = await AztecAddress.random();
@@ -510,6 +511,7 @@ describe('AVM simulator: transpiled Noir contracts', () => {
         sender,
         transactionFee,
         globals,
+        effectiveGasFees,
       });
     });
 
@@ -525,8 +527,8 @@ describe('AVM simulator: transpiled Noir contracts', () => {
       ['version', () => version.toField(), 'get_version'],
       ['blockNumber', () => new Fr(blockNumber), 'get_block_number'],
       ['timestamp', () => new Fr(timestamp), 'get_timestamp'],
-      ['feePerDaGas', () => new Fr(gasFees.feePerDaGas), 'get_fee_per_da_gas'],
-      ['feePerL2Gas', () => new Fr(gasFees.feePerL2Gas), 'get_fee_per_l2_gas'],
+      ['feePerDaGas', () => new Fr(effectiveGasFees.feePerDaGas), 'get_fee_per_da_gas'],
+      ['feePerL2Gas', () => new Fr(effectiveGasFees.feePerL2Gas), 'get_fee_per_l2_gas'],
     ])('%s getter', async (_name: string, valueGetter: () => Fr, functionName: string) => {
       const value = valueGetter();
       const bytecode = getAvmTestContractBytecode(functionName);

--- a/yarn-project/simulator/src/public/avm/avm_simulator.ts
+++ b/yarn-project/simulator/src/public/avm/avm_simulator.ts
@@ -2,6 +2,7 @@ import { MAX_L2_GAS_PER_TX_PUBLIC_PORTION } from '@aztec/constants';
 import { Fr } from '@aztec/foundation/fields';
 import { type Logger, createLogger } from '@aztec/foundation/log';
 import type { AztecAddress } from '@aztec/stdlib/aztec-address';
+import type { GasFees } from '@aztec/stdlib/gas';
 import type { GlobalVariables } from '@aztec/stdlib/tx';
 
 import { strict as assert } from 'assert';
@@ -79,6 +80,7 @@ export class AvmSimulator implements AvmSimulatorInterface {
     isStaticCall: boolean,
     calldata: Fr[],
     allocatedGas: Gas,
+    effectiveGasFees: GasFees,
     clientInitiatedSimulation: boolean = false,
   ) {
     const avmExecutionEnv = new AvmExecutionEnvironment(
@@ -89,6 +91,7 @@ export class AvmSimulator implements AvmSimulatorInterface {
       globals,
       isStaticCall,
       calldata,
+      effectiveGasFees,
       clientInitiatedSimulation,
     );
 

--- a/yarn-project/simulator/src/public/avm/fixtures/avm_simulation_tester.ts
+++ b/yarn-project/simulator/src/public/avm/fixtures/avm_simulation_tester.ts
@@ -86,6 +86,7 @@ export class AvmSimulationTester extends BaseAvmSimulationTester {
       address,
       sender,
       isStaticCall,
+      effectiveGasFees: DEFAULT_GAS_FEES,
     });
     const persistableState = await this.stateManager.fork();
     const context = initContext({ env: environment, persistableState });

--- a/yarn-project/simulator/src/public/avm/fixtures/initializers.ts
+++ b/yarn-project/simulator/src/public/avm/fixtures/initializers.ts
@@ -71,6 +71,7 @@ export function initExecutionEnvironment(overrides?: Partial<AvmExecutionEnviron
     overrides?.globals ?? GlobalVariables.empty(),
     overrides?.isStaticCall ?? false,
     overrides?.calldata ?? [],
+    overrides?.effectiveGasFees ?? GasFees.empty(),
     overrides?.clientInitiatedSimulation ?? true, // default to true for testing even though internal default is false
   );
 }

--- a/yarn-project/simulator/src/public/avm/opcodes/environment_getters.test.ts
+++ b/yarn-project/simulator/src/public/avm/opcodes/environment_getters.test.ts
@@ -20,6 +20,7 @@ describe('Environment getters', () => {
   const timestamp = BigInt(randomInt(100000)); // timestamp as UInt64
   const isStaticCall = true;
   const gasFees = GasFees.random();
+  const effectiveGasFees = GasFees.random(); // Create separate effective gas fees for testing
   const globals = initGlobalVariables({
     chainId,
     version,
@@ -36,6 +37,7 @@ describe('Environment getters', () => {
       transactionFee,
       globals,
       isStaticCall,
+      effectiveGasFees,
     });
     context = initContext({ env });
   });
@@ -64,8 +66,8 @@ describe('Environment getters', () => {
     [EnvironmentVariable.VERSION, version.toField()],
     [EnvironmentVariable.BLOCKNUMBER, new Fr(blockNumber), TypeTag.UINT32],
     [EnvironmentVariable.TIMESTAMP, new Fr(timestamp), TypeTag.UINT64],
-    [EnvironmentVariable.FEEPERDAGAS, new Fr(gasFees.feePerDaGas), TypeTag.UINT128],
-    [EnvironmentVariable.FEEPERL2GAS, new Fr(gasFees.feePerL2Gas), TypeTag.UINT128],
+    [EnvironmentVariable.FEEPERDAGAS, new Fr(effectiveGasFees.feePerDaGas), TypeTag.UINT128],
+    [EnvironmentVariable.FEEPERL2GAS, new Fr(effectiveGasFees.feePerL2Gas), TypeTag.UINT128],
     [EnvironmentVariable.ISSTATICCALL, new Fr(isStaticCall ? 1 : 0)],
   ])('Environment getter instructions', (envVar: EnvironmentVariable, value: Fr, tag: TypeTag = TypeTag.FIELD) => {
     it(`Should read '${EnvironmentVariable[envVar]}' correctly`, async () => {

--- a/yarn-project/simulator/src/public/avm/opcodes/environment_getters.ts
+++ b/yarn-project/simulator/src/public/avm/opcodes/environment_getters.ts
@@ -37,9 +37,9 @@ function getValue(e: EnvironmentVariable, ctx: AvmContext) {
     case EnvironmentVariable.TIMESTAMP:
       return new Uint64(ctx.environment.globals.timestamp);
     case EnvironmentVariable.FEEPERL2GAS:
-      return new Uint128(ctx.environment.globals.gasFees.feePerL2Gas);
+      return new Uint128(ctx.environment.effectiveGasFees.feePerL2Gas);
     case EnvironmentVariable.FEEPERDAGAS:
-      return new Uint128(ctx.environment.globals.gasFees.feePerDaGas);
+      return new Uint128(ctx.environment.effectiveGasFees.feePerDaGas);
     case EnvironmentVariable.ISSTATICCALL:
       return new Field(ctx.environment.isStaticCall ? 1 : 0);
     case EnvironmentVariable.L2GASLEFT:

--- a/yarn-project/simulator/src/public/public_tx_simulator/public_tx_simulator.ts
+++ b/yarn-project/simulator/src/public/public_tx_simulator/public_tx_simulator.ts
@@ -12,6 +12,7 @@ import {
 } from '@aztec/stdlib/avm';
 import { SimulationError } from '@aztec/stdlib/errors';
 import type { Gas, GasUsed } from '@aztec/stdlib/gas';
+import { GasFees } from '@aztec/stdlib/gas';
 import { ProvingRequestType } from '@aztec/stdlib/proofs';
 import type { MerkleTreeWriteOperations } from '@aztec/stdlib/trees';
 import {
@@ -276,6 +277,7 @@ export class PublicTxSimulator {
       callRequest,
       allocatedGas,
       /*transactionFee=*/ context.getTransactionFee(phase),
+      context.getEffectiveGasFees(),
       fnName,
     );
 
@@ -303,6 +305,8 @@ export class PublicTxSimulator {
    * @param stateManager - The state manager for AvmSimulation
    * @param callRequest - The public function call request, including the calldata.
    * @param allocatedGas - The gas allocated to the enqueued call
+   * @param transactionFee - The transaction fee
+   * @param effectiveGasFees - The effective gas fees
    * @param fnName - The name of the function
    * @returns The result of execution.
    */
@@ -311,6 +315,7 @@ export class PublicTxSimulator {
     { request, calldata }: PublicCallRequestWithCalldata,
     allocatedGas: Gas,
     transactionFee: Fr,
+    effectiveGasFees: GasFees,
     fnName: string,
   ): Promise<AvmFinalizedCallResult> {
     const address = request.contractAddress;
@@ -329,6 +334,7 @@ export class PublicTxSimulator {
       request.isStaticCall,
       calldata,
       allocatedGas,
+      effectiveGasFees,
       this.clientInitiatedSimulation,
     );
     const avmCallResult = await simulator.execute();

--- a/yarn-project/stdlib/src/fees/transaction_fee.test.ts
+++ b/yarn-project/stdlib/src/fees/transaction_fee.test.ts
@@ -5,7 +5,7 @@ import type { Writeable } from '@aztec/foundation/types';
 import { Gas } from '../gas/gas.js';
 import { GasFees } from '../gas/gas_fees.js';
 import { GasSettings } from '../gas/gas_settings.js';
-import { computeTransactionFee } from './transaction_fee.js';
+import { computeEffectiveGasFees, computeTransactionFee } from './transaction_fee.js';
 
 describe('computeTransactionFee', () => {
   let gasFees: GasFees;
@@ -13,7 +13,8 @@ describe('computeTransactionFee', () => {
   let gasUsed: Gas;
 
   const expectFee = (feeStr: string) => {
-    const fee = computeTransactionFee(gasFees, gasSettings, gasUsed);
+    const effectiveGasFees = computeEffectiveGasFees(gasFees, gasSettings);
+    const fee = computeTransactionFee(effectiveGasFees, gasUsed);
     expect(fee).toEqual(new Fr(BigInt(eval(feeStr))));
   };
 

--- a/yarn-project/stdlib/src/fees/transaction_fee.ts
+++ b/yarn-project/stdlib/src/fees/transaction_fee.ts
@@ -24,7 +24,6 @@ export function computeEffectiveGasFees(gasFees: GasFees, gasSettings: GasSettin
   return effectiveFees;
 }
 
-export function computeTransactionFee(gasFees: GasFees, gasSettings: GasSettings, gasUsed: Gas): Fr {
-  const effectiveFees = computeEffectiveGasFees(gasFees, gasSettings);
-  return gasUsed.computeFee(effectiveFees);
+export function computeTransactionFee(effectiveGasFees: GasFees, gasUsed: Gas): Fr {
+  return gasUsed.computeFee(effectiveGasFees);
 }


### PR DESCRIPTION
Please read [contributing guidelines](CONTRIBUTING.md) and remove this line.
