### PR TITLE
chore: bigfield audit + documentation: part 1

### DIFF
--- a/barretenberg/cpp/src/barretenberg/stdlib/primitives/bigfield/README.md
+++ b/barretenberg/cpp/src/barretenberg/stdlib/primitives/bigfield/README.md
@@ -747,7 +747,7 @@ b \cdot c = q \cdot \const{p} + a,
 $$
 
 where quotient $q$ is computed by dividing the product $(b \cdot c)$ by the modulus $p$.
-One important difference between checking this multiplication and the previously discussed modular multiplication is that the remainder $a$ in this case is an input and it may not necessarily be range-constrained to $[0, p)$ as we allow overflows. This could lead to underflows in the subtraction operation if $b \cdot c < a$. To handle this, we need to ensure that the subtraction does not lead to underflows. To do this, we introduce a constant term $\const{u \cdot p}$ such that:
+One important difference between checking this multiplication and the previously discussed modular multiplication is that the remainder $a$ in this case is an input and it may not necessarily be range-constrained to $[0, 2^s)$ as we allow overflows. This could lead to underflows in the subtraction operation if $b \cdot c < a$. To handle this, we need to ensure that the subtraction does not lead to underflows. To do this, we introduce a constant term $\const{u \cdot p}$ such that:
 
 $$
 \begin{aligned}

--- a/barretenberg/cpp/src/barretenberg/stdlib/primitives/bigfield/README.md
+++ b/barretenberg/cpp/src/barretenberg/stdlib/primitives/bigfield/README.md
@@ -1,0 +1,771 @@
+$\newcommand{\radd}{{\ \textcolor{lightgreen}{+} \ }}$
+$\newcommand{\rsub}{{\ \textcolor{lightgreen}{-} \ }}$
+$\newcommand{\rmul}{{\ \textcolor{lightgreen}{*} \ }}$
+$\newcommand{\padd}{{\ \textcolor{red}{+} \ }}$
+$\newcommand{\pmul}{{\ \textcolor{red}{*} \ }}$
+$\newcommand{\const}[1]{\textcolor{gray}{#1}}$
+$\renewcommand{\prime}[1]{#1_{\textsf{prime}}}$
+
+# Bigfield in Barretenberg
+
+> $\textcolor{orange}{\textsf{Warning}}$: This document is intended to provide an overview of the bigfield multiplication and addition operations in barretenberg. It is not a complete specification and does not cover all edge cases or optimizations. The source code should be consulted for a complete understanding of the implementation.
+
+### Notation
+
+A table that summarizes the notation used in this document:
+| Symbol | Description |
+|---------------|-----------------------------------------------------------------------------------------------|
+| $n$ | Modulus of the native field |
+| $p$ | Modulus of the non-native field (bigfield) |
+| $L$ | Bit size of each limb (fixed as 68 bits) |
+| $T$ | Bit size of the integer representation of bigfield elements defined as: $T := 4L$ |
+| $2^T$ | Modulus for integer representation of bigfield elements |
+| $M$ | The CRT product $M := 2^T \cdot n$ |
+| $\rmul, \radd, \rsub$ | Native field multiplication, addition, and subtraction respectively |
+| $\pmul$ | Non-native (bigfield) multiplication |
+
+### Overview of Bigfield Multiplication with CRT
+
+Given $a, b$ bigfield elements, we want to compute $r := a \ \pmul \ b$, that is $r = a \cdot b \textsf{ mod }p$. This is done by computing the quotient $q$ and remainder $r$ such that
+
+$$
+a \cdot b = q \cdot p + r. \tag{1}
+$$
+
+We can compute $q$ and $r$ natively (using integer arithmetic) as follows:
+
+$$
+\begin{aligned}
+q &= \left\lfloor \frac{a \cdot b}{p} \right\rfloor, \\
+r &= a \cdot b \ \textsf{ mod } \ p.
+\end{aligned}
+$$
+
+Using the Chinese Remainder Theorem (CRT), we know that if equation $(1)$ holds modulo $2^T$ and modulo $n$, then it must also hold modulo $M = 2^T \cdot n$. Further, if it holds modulo $M$ and both sides of the equation are less than $M$, then it must also hold over integers. This means that the quotient $q$ and the remainder $r$ were computed correctly, and hence we can conclude that $a \cdot b = r \textsf{ mod } p$. In other words, $r$ is the correct multiplication result of $a$ and $b$ in the bigfield $\mathbb{F}_p$. Mathematically, this can be expressed as follows:
+
+$$
+\begin{aligned}
+(a \cdot b - q \cdot p - r) \ \textsf{ mod } \ 2^T &\equiv 0, \\
+(a \cdot b - q \cdot p - r) \ \textsf{ mod } \ n &\equiv 0.
+\end{aligned}
+\quad \overset{{\tiny \textsf{CRT}}}{\implies} \quad
+\begin{aligned}
+(a \cdot b - q \cdot p - r) &\equiv 0 \ \textsf{ mod } \ M
+\quad \overset{\substack{a \cdot b \ < \ M, \\[3pt] q \cdot p + r \ < \ M}}{\implies} \quad
+a \cdot b \equiv r \ \textsf{ mod } \ p.
+\end{aligned}
+$$
+
+To summarize, if we can compute the quotient $q$ and the remainder $r$ as per equation $(1)$, and we enforce the following conditions:
+
+$$
+\begin{aligned}
+a \cdot b - q \cdot p - r &= 0 \ \textsf{mod} \ 2^T, \tag{C1}
+\end{aligned}
+$$
+
+$$
+\begin{aligned}
+a \cdot b - q \cdot p - r &= 0 \ \textsf{mod} \ n, \tag{C2}
+\end{aligned}
+$$
+
+$$
+\begin{aligned}
+(q \cdot p + r) &< M \quad \text{and} \quad a \cdot b < M. \tag{C3}
+\end{aligned}
+$$
+
+then we can conclude that $a \ \pmul \ b = r$.
+
+### Representation of Bigfield Elements
+
+Bigfield elements are represented as 4 limbs of size $L$ bits each, where $L = 68$ bits. The limbs are denoted as $a_0, a_1, a_2, a_3$, and the bigfield element $a$ is represented as:
+
+$$
+a \equiv (
+\underbrace{ \qquad a_3 \qquad }_{\color{orange}{L \textsf{ or } |p| - 3L}} \|
+\underbrace{ \qquad a_2 \qquad }_{\color{orange}{L}} \|
+\underbrace{ \qquad a_1 \qquad }_{\color{orange}{L}} \|
+\underbrace{ \qquad a_0 \qquad }_{\color{orange}{L}}
+).
+$$
+
+The orange values indicate the default maximum bit sizes of the limbs. The most-significant limb $a_3$ can be either have $L$ bits or $|p| - 3L$ bits, depending on whether overflow is allowed or not. The other limbs $a_2, a_1, a_0$ always start with $L$ bits each.
+
+We allow overflow in these limbs to enable efficient multiplication and addition operations. To ensure that the bigfield elements are within the permissible limits, we track the maximum values of the limbs. Let $\textcolor{orange}{A_0}, \textcolor{orange}{A_1}, \textcolor{orange}{A_2}, \textcolor{orange}{A_3}$ be the maximum values of the limbs $a_0, a_1, a_2, a_3$ respectively:
+
+$$
+a \equiv (\underbrace{\qquad a_3 \qquad}_{\textcolor{orange}{< \ A_3}} \ \| \ \underbrace{\qquad a_2 \qquad}_{\textcolor{orange}{< \ A_2}} \ \| \ \underbrace{\qquad a_1 \qquad}_{\textcolor{orange}{< \ A_1}} \ \| \ \underbrace{\qquad a_0 \qquad}_{\textcolor{orange}{< \ A_0}}).
+$$
+
+where each $a_i$ is a limb of size $L$ bits and $a_i < \textcolor{orange}{A_i}$. The maximum value of $a$ is given by:
+
+$$
+\textcolor{orange}{A} = \textcolor{orange}{A_0} + \const{2^L} \cdot \textcolor{orange}{A_1} + \const{2^{2L}} \cdot \textcolor{orange}{A_2} + \const{2^{3L}} \cdot \textcolor{orange}{A_3}
+\quad \implies \quad a < \textcolor{orange}{A}.
+$$
+
+As mentioned before, the default maximum values of the limbs $a_0, a_1, a_2$ is $(2^{L} - 1)$ as the default bit-sizes of these limbs are all $L$ bits. For the most-significant limb $a_3$, the default maximum value is either $(2^{L} - 1)$ or $(2^{|p| - 3L} - 1)$ depending on whether overflow is allowed or not.
+
+In addition to the integer-limb representation of bigfield elements, we also define the prime-limb representation of bigfield elements. The prime-limb is basically the value of the bigfield element modulo the native field modulus $n$. The prime-limb representation of a bigfield element $a$ is given by:
+
+$$
+a_{\textsf{prime}} = (a_0 \ \radd \ \const{2^L} \rmul a_1 \ \radd \ \const{2^{2L}} \rmul a_2 \ \radd \ \const{2^{3L}} \rmul a_3) \textsf{ mod } n.
+$$
+
+Hereafter, we represent a bigfield element $a$ as a tuple of its integer-limb representation and its prime-limb representation:
+
+$$
+a = (a_0, \ a_1, \ a_2, \ a_3, \ a_{\textsf{prime}}).
+$$
+
+### Details on Bigfield Addition
+
+Given two bigfield elements $a, b \in [0, 2^T)$
+
+$$
+\begin{aligned}
+a =&\ (a_0, \ a_1, \ a_2, \ a_3, \ a_{\textsf{prime}}) \\
+b =&\ (b_0, \ b_1, \ b_2, \ b_3, \ b_{\textsf{prime}})
+\end{aligned}
+$$
+
+we wish to compute sum $z = a \padd b := (a + b) \ \textsf{mod} \ p$ in the circuit with native field $\mathbb{F}_n$. To do so, we can simply compute field additions of the respective limbs.
+
+$$
+c \equiv (c_0, \ c_1, \ c_2, \ c_3, \ c_{\textsf{prime}}) := ((a_0 \radd b_0), \ (a_1 \radd b_1), \ (a_2 \radd b_2), \ (a_3 \radd b_3), \ (a_{\textsf{prime}} \radd b_{\textsf{prime}})).
+$$
+
+If $a$ and $b$ both are circuit witnesses, then the above addition can be performed using 5 addition gates in the circuit. However, we can optimize this further by defining a custom bigfield addition that uses 4 gates. The custom bigfield addition gate performs two limb additions in one gate and rest of the three limb additions in the other three gates.
+
+$$
+\begin{aligned}
+\textsf{gate 1:} \quad c_0 &= a_0 \radd b_0 \ \textsf{ and } \ c_{\textsf{prime}} = a_{\textsf{prime}} \radd b_{\textsf{prime}} \\
+\textsf{gate 2:} \quad c_1 &= a_1 \radd b_1, \\
+\textsf{gate 3:} \quad c_2 &= a_2 \radd b_2, \\
+\textsf{gate 4:} \quad c_3 &= a_3 \radd b_3.
+\end{aligned}
+$$
+
+It is worth noting that we cannot do better than 4 gates because we have a total of 15 witnesses (5 each for $x, y$ and $z$) that can fit in $\lceil 15/4 \rceil = 4$ gates (4 wires per gate).
+
+#### Tracking Maximum Values due to Addition
+
+When we add two bigfield elements $a$ and $b$, we need to track the maximum values of the limbs of the result. Suppose $a$ and $b$ are two bigfield elements represented as:
+
+$$
+\begin{aligned}
+a &\equiv (\underbrace{\qquad a_3 \qquad}_{\textcolor{orange}{< \ A_3}} \ \| \ \underbrace{\qquad a_2 \qquad}_{\textcolor{orange}{< \ A_2}} \ \| \ \underbrace{\qquad a_1 \qquad}_{\textcolor{orange}{< \ A_1}} \ \| \ \underbrace{\qquad a_0 \qquad}_{\textcolor{orange}{< \ A_0}}), \\
+b &\equiv (\underbrace{\qquad b_3 \qquad}_{\textcolor{orange}{< \ B_3}} \ \| \ \underbrace{\qquad b_2 \qquad}_{\textcolor{orange}{< \ B_2}} \ \| \ \underbrace{\qquad b_1 \qquad}_{\textcolor{orange}{< \ B_1}} \ \| \ \underbrace{\qquad b_0 \qquad}_{\textcolor{orange}{< \ B_0}}).
+\end{aligned}
+$$
+
+When we add $a$ and $b$, the maximum value of the sum $c = a + b$ is given by:
+
+$$
+\textcolor{orange}{C} = \textcolor{orange}{\underbrace{(A_0 + B_0)}_{C_0}} + 2^L \cdot \textcolor{orange}{\underbrace{(A_1 + B_1)}_{C_1}} + 2^{2L} \cdot \textcolor{orange}{\underbrace{(A_2 + B_2)}_{C_2}} + 2^{3L} \cdot \textcolor{orange}{\underbrace{(A_3 + B_3)}_{C_3}}.
+$$
+
+Adding two bigfield elements with default maximum values of the limbs, each limb would overflow by 1 bit. As a result, the resulting bigfield element $c$ would have the following maximum values of the limbs:
+
+$$
+\begin{aligned}
+\textcolor{orange}{C_i} &= (2^L - 1) + (2^L - 1) = 2^{L+1} - 2 \ \implies \ \textsf{overflow by 1 bit} \\
+\end{aligned}
+$$
+
+for $i = 0, 1, 2, 3$. The maximum value of the most-significant limb $\textcolor{orange}{C_3}$ would depend on whether overflow is allowed or not.
+The overflow bit is carried over to the next limb, so the maximum value of the resulting bigfield element $c$ would be affected by the overflow of the most significant limb. Thus, the resulting bigfield element $c$ would also overflow by 1 bit.
+
+### Details on Bigfield Multiplication
+
+Given two bigfield elements $a, b \in [0, 2^T)$ (as described in the previous section), we wish to compute product $r = a \pmul b := (a \cdot b) \ \textsf{mod} \ p$ in the circuit with native field $\mathbb{F}_n$. To do so, we find integers $q$ and $r$ such that
+
+$$a \cdot b = q \cdot p + r$$
+
+where $q$ is the quotient and $r$ is the remainder when we divide $(a \cdot b)$ by $p$. We define
+
+$$X := a \cdot b - q \cdot p - r.$$
+
+As per the conditions $(\text{C1}), (\text{C2})$ and $(\text{C3})$, we know that
+
+$$
+\boxed{
+\begin{aligned}
+X &= 0 \ \ \textsf{mod} \ \ 2^T \\
+X &= 0 \ \ \textsf{mod} \ \ n \\
+\end{aligned}
+\quad \textsf{and} \quad
+\begin{aligned}
+a \cdot b &< M \\
+q \cdot p + r &< M
+\end{aligned}
+}
+\ \implies \
+X = 0 \ \ \textsf{mod} \ \ p.
+$$
+
+Effectively, this means $a \pmul b = r$. Recall that $\pmul$ is used to denote multiplication in the non-native field $\mathbb{F}_p$. We describe the checks: [modulo 2^T](#checking-x--0-textsf-mod--2t), [modulo n](#checking-x--0-textsf-mod--n), and [CRT modulus](#checking-crt-modulus).
+
+#### Checking $X = 0 \textsf{ mod } 2^T$
+
+We proceed to compute $X$ as follows:
+
+$$
+\begin{aligned}
+X &= a \cdot b - q \cdot \const{p} - r \\
+&= \underbrace{a \cdot b}_{\textsf{term 1}} + \underbrace{q \cdot (\const{-p})}_{\textsf{term 2}} - r
+\end{aligned}
+$$
+
+To compute the first term, we look at the integer multiplication of $a$ and $b$ (using schoolbook multiplication):
+
+$$
+\begin{aligned}
+a \cdot b =&\ (a_0 \rmul b_0) \ \radd \ \\
+&\ (a_0 \rmul b_1 \ \radd \ a_1 \rmul b_0) \rmul \const{2^{L}} \ \radd \ \\
+&\ (a_0 \rmul b_2 \ \radd \ a_2 \rmul b_0 \ \radd \ a_1 \rmul b_1) \rmul \const{2^{2L}} \ \radd \ \\
+&\ (a_0 \rmul b_3 \ \radd \ a_3 \rmul b_0 \ \radd \ a_1 \rmul b_2 \ \radd \ a_2 \rmul b_1) \rmul \const{2^{3L}} \ \radd \ \\
+&\ (a_1 \rmul b_3 \ \radd \ a_3 \rmul b_1 \ \radd \ a_2 \rmul b_2) \rmul \const{2^{4L}} \ \radd \ \\
+&\ (a_2 \rmul b_3 \ \radd \ a_3 \rmul b_2) \rmul \const{2^{5L}} \ \radd \ \\
+&\ (a_3 \rmul b_3) \rmul \const{2^{6L}}.
+\end{aligned}
+$$
+
+Since we want to compute $X \ \textsf{mod} \ 2^T$ and $T = 4L$, the last three terms would be $0 \ \textsf{mod} \ 2^{T}$. Hence, we have
+
+$$
+\begin{aligned}
+(a \cdot b) \ \textsf{mod} \ 2^T =&\ (a_0 \rmul b_0) \ \radd \ \\
+&\ (a_0 \rmul b_1 \ \radd \ a_1 \rmul b_0) \rmul \const{2^{L}} \ \radd \ \\
+&\ (a_0 \rmul b_2 \ \radd \ a_2 \rmul b_0 \ \radd \ a_1 \rmul b_1) \rmul \const{2^{2L}} \ \radd \ \\
+&\ (a_0 \rmul b_3 \ \radd \ a_3 \rmul b_0 \ \radd \ a_1 \rmul b_2 \ \radd \ a_2 \rmul b_1) \rmul \const{2^{3L}}.
+\tag{\textsf{term 1}}
+\end{aligned}
+$$
+
+Next, we want to compute $(q \cdot (\const{-p})) \ \textsf{mod} \ 2^T$ given the limb representation of $q \equiv (q_3 \ \| \ q_2 \ \| \ q_1 \ \| \ q_0)$ and circuit constant $(\const{-p}) \ \textsf{mod} \ 2^T := \const{(2^T - p)} \equiv (\ \const{p_3'} \ \| \ \const{p_2'} \ \| \ \const{p_1'} \ \| \ \const{p_0'} \ )$. Thus, we get
+
+$$
+\begin{aligned}
+(q \cdot \const{(-p)}) \ \textsf{mod} \ 2^T = (q \cdot \const{(2^T - p)}) \ \textsf{mod} \ 2^T =&\ (q_0 \rmul \const{p_0'}) \ \radd \ \\
+&\ (q_0 \rmul \const{p_1'} \ \radd \ q_1 \rmul \const{p_0'}) \rmul \const{2^{L}} \ \radd \ \\
+&\ (q_0 \rmul \const{p_2'} \ \radd \ q_2 \rmul \const{p_0'} \ \radd \ q_1 \rmul \const{p_1'}) \rmul \const{2^{2L}} \ \radd \ \\
+&\ (q_0 \rmul \const{p_3'} \ \radd \ q_3 \rmul \const{p_0'} \ \radd \ q_1 \rmul \const{p_2'} \ \radd \ q_2 \rmul \const{p_1'}) \rmul \const{2^{3L}}.
+\tag{\textsf{term 2}}
+\end{aligned}
+$$
+
+With the limb representation of the remainder $r \equiv (r_3 \ \| \ r_2 \ \| \ r_1 \ \| \ r_0)$, we finally get
+
+$$
+\begin{aligned}
+X \ \textsf{mod} \ 2^T :=&\ \left((a \cdot b) + (q \cdot \const{(-p)}) - r\right) \ \textsf{mod} \ 2^T \\[5pt]
+=&\ \underbrace{(a \cdot b) \ \textsf{mod} \ 2^T}_{\textsf{term 1}} + \underbrace{(q \cdot \const{(-p)}) \ \textsf{mod} \ 2^T}_{\textsf{term 2}} - (r \ \textsf{mod} \ 2^T).
+\end{aligned}
+$$
+
+So far, we have figured out how to compute the first two terms of $X \ \textsf{mod} \ 2^T$. We now need to subtract remainder $r \equiv (r_3 \ \| \ r_2 \ \| \ r_1 \ \| \ r_0) \in [0, 2^T)$ from the sum of the first two terms. We need to be a bit careful here because the subtraction of $r$ from the sum of the first two terms can cause a borrow in the limbs. We will handle this borrow later, but for now, we proceed with subtracting $r$ from the sum of the first two terms as follows:
+
+$$
+\begin{aligned}
+X \ \textsf{mod} \ 2^T =&\ \overset{X_{\textsf{low}}}{\boxed{\begin{aligned}
+&(a_0 \rmul b_0 \ \radd \ q_0 \rmul \const{p_0'} \ \rsub \ r_0) \ \radd \\
+&(a_0 \rmul b_1 \ \radd \ a_1 \rmul b_0 \ \radd \ q_0 \rmul \const{p_1'} \ \radd \ q_1 \rmul \const{p_0'} \ \rsub \ r_1) \rmul \const{2^{L}}
+\end{aligned}}} \ \radd \ \\
+&\ \const{2^{2L}} \cdot \underset{X_{\textsf{high}}}{\boxed{\begin{aligned}
+&(a_0 \rmul b_2 \ \radd \ a_2 \rmul b_0 \ \radd \ a_1 \rmul b_1 \ \radd \ q_0 \rmul \const{p_2'} \ \radd \ q_2 \rmul \const{p_0'} \ \radd \ q_1 \rmul \const{p_1'} \ \rsub \ r_2) \ \radd \\
+&(a_0 \rmul b_3 \ \radd \ a_3 \rmul b_0 \ \radd \ a_1 \rmul b_2 \ \radd \ a_2 \rmul b_1 \ \radd \ q_0 \rmul \const{p_3'} \ \radd \ q_3 \rmul \const{p_0'} \ \radd \ q_1 \rmul \const{p_2'} \ \radd \ q_2 \rmul \const{p_1'} \ \rsub \ r_3) \rmul \const{2^{L}}
+\end{aligned}}}.
+\end{aligned}
+$$
+
+As $X \ \textsf{mod} \ 2^T$ is a $4L$-bit integer (i.e., 272 bits), we cannot represent it as a single native field element. Instead, we split it into two parts: $X_{\textsf{low}}$ and $X_{\textsf{high}}$, each of size $2L$ bits (as shown above). The first part $X_{\textsf{low}}$ contains the lower 136 bits of the result, while the second part $X_{\textsf{high}}$ contains the higher 136 bits. We write the expression of the two parts as follows:
+
+$$
+\begin{aligned}
+X_{\textsf{low}} :=&\ (a_0 \rmul b_0 \ \radd \ q_0 \rmul \const{p_0'} \ \rsub \ r_0) \ \radd \ \\ \tag{X}
+&\ (a_0 \rmul b_1 \ \radd \ a_1 \rmul b_0 \ \radd \ q_0 \rmul \const{p_1'} \ \radd \ q_1 \rmul \const{p_0'} \ \rsub \ r_1) \rmul \const{2^{L}}, \\[5pt]
+\textcolor{skyblue}{C_{\textsf{low}}} :=&\ \left\lfloor\frac{X_{\textsf{low}}}{\const{2^{2L}}} \right\rfloor, \qquad {\small \color{grey}{\textsf{// carry due to the low limb}}} \\[5pt]
+X_{\textsf{high}} :=&\ \textcolor{skyblue}{C_{\textsf{low}}} + (a_0 \rmul b_2 \ \radd \ a_2 \rmul b_0 \ \radd \ a_1 \rmul b_1 \ \radd \ q_0 \rmul \const{p_2'} \ \radd \ q_2 \rmul \const{p_0'} \ \radd \ q_1 \rmul \const{p_1'} \ \rsub \ r_2) \ \radd \\
+&\ (a_0 \rmul b_3 \ \radd \ a_3 \rmul b_0 \ \radd \ a_1 \rmul b_2 \ \radd \ a_2 \rmul b_1 \ \radd \ q_0 \rmul \const{p_3'} \ \radd \ q_3 \rmul \const{p_0'} \ \radd \ q_1 \rmul \const{p_2'} \ \radd \ q_2 \rmul \const{p_1'} \ \rsub \ r_3) \rmul \const{2^{L}}, \\[5pt]
+\textcolor{skyblue}{C_{\textsf{high}}} :=&\ \left\lfloor\frac{X_{\textsf{high}}}{\const{2^{2L}}}\right\rfloor. \qquad {\small \color{grey}{\textsf{// carry due to the high limb}}}
+\end{aligned}
+$$
+
+Note that we have defined two circuit witnesses $\textcolor{skyblue}{C_{\textsf{low}}}$ and $\textcolor{skyblue}{C_{\textsf{high}}}$ that represent the carries due to the low and high limbs respectively. Considering these carries are necessary as the limbs $X_{\textsf{low}}$ and $X_{\textsf{high}}$ can overflow.
+Recall that we wanted to show that $X \equiv 0 \ \textsf{mod} \ 2^T$ which implies
+
+$$
+X_{\textsf{low}} \equiv 0 \ \textsf{mod} \ 2^{T/2} \quad \textsf{and} \quad X_{\textsf{high}} \equiv 0 \ \textsf{mod} \ 2^{T/2}.
+$$
+
+This means that the carries $\textcolor{skyblue}{C_{\textsf{low}}}$ and $\textcolor{skyblue}{C_{\textsf{high}}}$ must be small positive integers. We can enforce this by range-constrainting them to be less $\textcolor{skyblue}{b_{\textsf{low}}}$ and $\textcolor{skyblue}{b_{\textsf{high}}}$ bits respectively. To determine these bit sizes of the carries, we need to analyze the maximum values of the limbs involved in the computation of $X_{\textsf{low}}$ and $X_{\textsf{high}}$. Before we do that, we take a quick detour to describe the gate constraints for multiplication.
+
+> .
+>
+> #### Gate constraints for multiplication:
+>
+> As per the analysis, $X_{\textsf{low}}$ requires 3 witness-witness multiplications and $X_{\textsf{high}}$ requires 7 witness-witness multiplications. A simple Plonk gate can perform 1 witness-witness multiplication. Using this naive gate would require a total of at least 10 gates (ignoring any extra additions which will cost additional gates). We define two custom gates that can each perform 4 and 3 witness-witness multiplications respectively, so we would need just 3 such gates for multiplications. We rearrange the above equations to use these custom gates as follows:
+>
+> $$
+> \begin{aligned}
+> X_{\textsf{low}} = C_{\textsf{low}} \rmul \const{2^{2L}}
+> =&\ \color{brown}{\boxed{
+> (a_0 \rmul b_0 \ \rsub \ r_0) \ \radd \ (a_0 \rmul b_1 \ \radd \ a_1 \rmul b_0) \rmul \const{2^L}
+> }}
+> \longleftarrow \ell_0 \\
+> &\ \ \radd \ \color{violet}{\boxed{
+> q_0 \rmul \const{(p_0' + 2^L \cdot p_1')} \ \radd \ q_1 \rmul \const{(2^L \cdot p_0')} \ \rsub \ r_1 \rmul \const{2^{L}}
+> }}
+> \\[10pt]
+> X_{\textsf{high}} = C_{\textsf{high}} \rmul \const{2^{2L}}
+> =&\ C_{\textsf{low}} \ \radd \
+> \color{brown}{\boxed{
+> (a_0 \rmul b_2 \ \radd \ a_2 \rmul b_0 - r_2) \ \radd \ (a_0 \rmul b_3 \ \radd \ a_3 \rmul b_0 \ \rsub \ r_3) \rmul \const{2^L}
+> }}
+> \longleftarrow h_0
+> \\
+> &\ \ \radd \
+> \color{brown}{\boxed{
+> (a_1 \rmul b_1) \ \radd \ (a_1 \rmul b_2 \ \radd \ a_2 \rmul b_1) \rmul \const{2^L}
+> }}
+> \\
+> &\ \ \radd \
+> \color{violet}{\boxed{
+> q_3 \rmul \const{(2^L \cdot p_0')} \ \radd \ q_2 \rmul \const{(p_0' + 2^L \cdot p_1')}
+> }}
+> \\
+> &\ \ \radd \
+> \color{violet}{\boxed{
+> (q_0 \rmul \const{(p_2' + 2^L \cdot p_3')} \ \radd \ q_1 \rmul \const{(p_1' + 2^L \cdot p_2')})
+> }}
+> \end{aligned}
+> $$
+>
+> The $\color{brown}{\textsf{maroon}}$ boxes represent computation that uses the custom bigfield multiplication gate while the $\color{violet}{\textsf{violet}}$ boxes represent computation with typical width-4 addition gates. The $\const{\textsf{grey}}$ terms are circuit constants (that are set as selector values). We enlist the gate constraints as follows.
+>
+> | Gate type     | Constraint                                                                                                                                                                                                 |
+> | ------------- | ---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+> | bigfield mult | $\ell_0 = \color{brown}{(a_0 \rmul b_0 \ \rsub \ r_0) \ \radd \ (a_0 \rmul b_1 \ \radd \ a_1 \rmul b_0) \rmul \const{2^L}}$                                                                                |
+> | add           | $C_{\textsf{low}} \rmul \const{2^{2L}} = \color{brown}{\ell_0} + \color{violet}{q_0 \rmul \const{(p_0' + 2^L \cdot p_1')} \ \radd \ q_1 \rmul \const{(2^L \cdot p_0')} \ \rsub \ r_1 \rmul \const{2^{L}}}$ |
+> | bigfield mult | $h_0 = \color{brown}{(a_0 \rmul b_2 \ \radd \ a_2 \rmul b_0 - r_2) \ \radd \ (a_0 \rmul b_3 \ \radd \ a_3 \rmul b_0 \ \rsub \ r_3) \rmul \const{2^L}}$                                                     |
+> | bigfield mult | $h_1 = \color{brown}{h_0 + (a_1 \rmul b_1) \ \radd \ (a_1 \rmul b_2 \ \radd \ a_2 \rmul b_1) \rmul \const{2^L}}$                                                                                           |
+> | add           | $h_2 = h_1 \ \radd \ C_{\textsf{low}} \ \radd \  \color{violet}{q_3 \rmul \const{(2^L \cdot p_0')} \ \radd \ q_2 \rmul \const{(p_0' + 2^L \cdot p_1')}}$                                                   |
+> | add           | $C_{\textsf{high}} \rmul \const{2^{2L}} = h_2 \ \radd \  \color{violet}{q_0 \rmul \const{(p_2' + 2^L \cdot p_3')} \ \radd \ q_1 \rmul \const{(p_1' + 2^L \cdot p_2')}}$                                    |
+>
+> The output of this custom multiplication function is the two carry outputs $C_{\textsf{low}}$ and $C_{\textsf{high}}$.
+> Note that we need to range-constrain these carries $C_{\textsf{low}}$ and $C_{\textsf{high}}$ to appropriate number of bits (max allowed bits - $2L$). These range constraints (if any) need to be applied outside the custom multiplication function.
+>
+> .
+
+#### Tracking Maximum Values due to Multiplication
+
+Suppose $a$ and $b$ are two bigfield elements represented, along with the maximum values of their limbs, as:
+
+$$
+\begin{aligned}
+a &\equiv (\underbrace{\qquad a_3 \qquad}_{\textcolor{orange}{< \ A_3}} \ \| \ \underbrace{\qquad a_2 \qquad}_{\textcolor{orange}{< \ A_2}} \ \| \ \underbrace{\qquad a_1 \qquad}_{\textcolor{orange}{< \ A_1}} \ \| \ \underbrace{\qquad a_0 \qquad}_{\textcolor{orange}{< \ A_0}}), \\
+b &\equiv (\underbrace{\qquad b_3 \qquad}_{\textcolor{orange}{< \ B_3}} \ \| \ \underbrace{\qquad b_2 \qquad}_{\textcolor{orange}{< \ B_2}} \ \| \ \underbrace{\qquad b_1 \qquad}_{\textcolor{orange}{< \ B_1}} \ \| \ \underbrace{\qquad b_0 \qquad}_{\textcolor{orange}{< \ B_0}}).
+\end{aligned}
+$$
+
+When we multiply $a$ and $b$, we represent the output $d = a \cdot b$ as two field elements: $d = (d_{\textsf{hi}} \ \| \ d_{\textsf{lo}})$. We track the maximum values of the low and high parts separately in $\textcolor{orange}{D_{\textsf{lo}}}$ and $\textcolor{orange}{D_{\textsf{hi}}}$ respectively. Thus, we have
+
+$$
+\begin{aligned}
+\textcolor{orange}{D_{\text{lo}}} = &\ \textcolor{orange}{\underbrace{(A_0 \cdot B_0)}_{D_0}} + \textcolor{orange}{\underbrace{(A_0 \cdot B_1 + A_1 \cdot B_0)}_{D_1}} \cdot \const{2^L},
+\\ \tag{D}
+\textcolor{orange}{D_{\text{hi}}} = &\ \textcolor{orange}{\underbrace{(A_0 \cdot B_2 + A_2 \cdot B_0 + A_1 \cdot B_1)}_{D_2}} + \textcolor{orange}{\underbrace{(A_0 \cdot B_3 + A_3 \cdot B_0 + A_1 \cdot B_2 + A_2 \cdot B_1)}_{D_3}} \cdot \const{2^L}.
+\end{aligned}
+$$
+
+> **Upper Bound on Limb Sizes**:
+>
+> We need to ensure that the maximum value of the limbs of the result of multiplication, $\textcolor{orange}{D_{\textsf{lo}}}$ and $\textcolor{orange}{D_{\textsf{hi}}}$, do not exceed the native field modulus $n$.
+> The question is: how large can the limbs of the bigfield multiplicands be such that the maximum values of the limbs of the product do not exceed $n$?
+> If we allow the limbs to grow to a maximum of $Q$ bits, then the maximum values of the product would be given by:
+>
+> $$
+> \begin{aligned}
+> \textcolor{orange}{D_{\textsf{lo}}} &= (2^{Q} - 1)^2 + 2 \cdot (2^{Q} - 1)^2 \cdot 2^L \ < \ 2^{2Q + L + 1}, \\
+> \textcolor{orange}{D_{\textsf{hi}}} &= 3 \cdot (2^{Q} - 1)^2 + 4 \cdot (2^{Q} - 1)^2 \cdot 2^L \ < \ 2^{2Q + L + 2}.
+> \end{aligned}
+> $$
+>
+> Clearly, maximum value of $\textcolor{orange}{D_{\textsf{hi}}}$ determines the overall maximum of the two outputs of multiplication:
+>
+> $$
+> \textsf{max}(\textcolor{orange}{D_{\textsf{lo}}}, \textcolor{orange}{D_{\textsf{hi}}}) < 2^{2Q + L + 2}.
+> $$
+>
+> This is the maximum value of the resulting limbs of a single product $d = a \cdot b$. Suppose we have $2^k$ such products, then the maximum value of the limbs of the sum of these products would be:
+>
+> $$
+> \begin{aligned}
+> \sum_{i=1}^{2^k} \textcolor{orange}{D_{\textsf{hi}, i}} & \ < \ 2^{k + 2Q + L + 2}.
+> \end{aligned}
+> $$
+>
+> We require that this value must not exceed the native field modulus $n$. Hence, we need to ensure that:
+>
+> $$
+> \begin{aligned}
+> 2^{k + 2Q + L + 2} &< n \quad \implies \quad \boxed{Q < \frac{\text{log}_2(n) - L - k - 2}{2}}.
+> \end{aligned}
+> $$
+>
+> This means that the maximum limb size that must be allowed is $Q = \left\lfloor\frac{253.5 - 68 - 10 - 2}{2}\right\rfloor = 86$.
+>
+> .
+
+#### Range Constraints on Carry Outputs
+
+We need to determine the range constraints on the carry outputs $\textcolor{skyblue}{C_{\textsf{low}}}$ and $\textcolor{skyblue}{C_{\textsf{high}}}$ based on the maximum values of the resulting limbs $X_{\textsf{low}}$ and $X_{\textsf{high}}$. Recall:
+
+$$
+\begin{aligned}
+X \ \textsf{mod} \ 2^T =&\ \underbrace{(a \cdot b) \ \textsf{mod} \ 2^T}_{\textsf{term 1}} + \underbrace{(q \cdot \const{(-p)}) \ \textsf{mod} \ 2^T}_{\textsf{term 2}} - (r \ \textsf{mod} \ 2^T).
+\end{aligned}
+$$
+
+Let the maximum values of the first term be $\textcolor{orange}{D_{\textsf{lo}}}$ and $\textcolor{orange}{D_{\textsf{hi}}}$ as defined above. Let the maximum values of the second term be $\textcolor{orange}{E_{\textsf{lo}}}$ and $\textcolor{orange}{E_{\textsf{hi}}}$. We know how to compute these as described in the previous section. Let the maximum values of the limbs of the remainder term be $\textcolor{orange}{R_{\textsf{lo}}}$ and $\textcolor{orange}{R_{\textsf{hi}}}$.
+The third term is to be subtracted from the sum of the first two terms, so we need to ensure that the overall result is non-negative (i.e., never underflows).
+
+$$
+\begin{aligned}
+\left((a \cdot b) \ \textsf{mod} \ 2^T + (q \cdot \const{(-p)}) \ \textsf{mod} \ 2^T\right)
+&\equiv \ell_{\textsf{low}} + \const{2^L} \cdot \ell_{\textsf{high}}, \\
+(r \ \textsf{mod} \ 2^T)
+&\equiv r_{\textsf{low}} + \const{2^L} \cdot r_{\textsf{high}}.
+\end{aligned}
+$$
+
+First, we argue that underflow in the higher limb is not possible. This is because the remainder $r$ is restricted to be in the range $[0, 2^{|p|})$ while $\ell_{\textsf{high}} \in [0, 2^T)$. For the lower limb, we we must protect against underflow in an extreme case where $h_{\textsf{lo}} = 0$. In that case, we must borrow $\textcolor{orange}{R_{\textsf{low}}}$ from the higher limb to ensure that the result is non-negative. We can write the result $X$ in terms of borrowed value as follows:
+
+$$
+\begin{aligned}
+X_{\textsf{low}} &= 0 + \textcolor{orange}{R_{\textsf{lo}}} - r_{\textsf{low}},\\
+X_{\textsf{high}} &= h_{\textsf{high}} - \left\lfloor\frac{\textcolor{orange}{R_{\textsf{lo}}}}{\const{2^{2L}}}\right\rfloor - r_{\textsf{high}}.
+\end{aligned}
+$$
+
+This works because we know $r_{\textsf{low}} < \textcolor{orange}{R_{\textsf{lo}}}$ which ensures that $X_{\textsf{low}}$ is non-negative. Naturally, we need to adjust the higher limb by removing the borrowed value from it.
+
+Finally, the maximum values of the limbs of the result $X$ are given by:
+
+$$
+\begin{aligned}
+X_{\textsf{low}} &< \textcolor{orange}{D_{\textsf{lo}}} + \textcolor{orange}{E_{\textsf{lo}}} + \textcolor{orange}{R_{\textsf{lo}}}, \\
+X_{\textsf{high}} &< \textcolor{orange}{D_{\textsf{hi}}} + \textcolor{orange}{E_{\textsf{hi}}}.
+\end{aligned}
+$$
+
+and thus the carry outputs (in terms of bits) are bounded by:
+
+$$
+\begin{aligned}
+\textcolor{skyblue}{C_{\textsf{low}}} &< \left\lfloor\frac{\textcolor{orange}{D_{\textsf{lo}}} + \textcolor{orange}{E_{\textsf{lo}}} + \textcolor{orange}{R_{\textsf{lo}}}}{\const{2^{2L}}}\right\rfloor, \\
+\textcolor{skyblue}{C_{\textsf{high}}} &< \left\lfloor\frac{\textcolor{orange}{D_{\textsf{hi}}} + \textcolor{orange}{E_{\textsf{hi}}}}{\const{2^{2L}}}\right\rfloor.
+\end{aligned}
+$$
+
+Note that we do not include the term $(\textcolor{orange}{R_{\textsf{lo}}} / \const{2^{2L}})$ in the carry output bound of $\textcolor{skyblue}{C_{\textsf{high}}}$ as it is unlikely to contribute to the underflow of $X_{\textsf{high}}$.
+
+#### Checking $X = 0 \textsf{ mod } n$
+
+Checking $X$ modulo the native field modulus $n$ is straightforward because we track prime limb representations of the bigfield elements. Thus we can express $X$ as follows:
+
+$$
+\begin{aligned}
+X &= \left((a \cdot b) + (q \cdot \const{(-p)}) - r\right) \textsf{ mod } n \\
+&= (a \textsf{ mod } n) \cdot (b \textsf{ mod } n) + (q \textsf{ mod } n) \cdot (\const{(-p)} \textsf{ mod } n) - (r \textsf{ mod } n) \\
+&= a_{\textsf{prime}} \rmul b_{\textsf{prime}} + q_{\textsf{prime}} \rmul \const{(n - p)} - r_{\textsf{prime}},
+\end{aligned}
+$$
+
+To check that $X \equiv 0 \textsf{ mod } n$, we can use the following constraint:
+
+$$
+\begin{aligned}
+a_{\textsf{prime}} \rmul b_{\textsf{prime}} + q_{\textsf{prime}} \rmul \const{(n - p)} - r_{\textsf{prime}} = 0.
+\end{aligned}
+$$
+
+This can be enforced in the circuit by adding a simple multiplication gate.
+
+#### Checking CRT Modulus
+
+We need to ensure both sides of the original multiplication are less than the CRT modulus $M$:
+
+$$
+\begin{aligned}
+a \cdot b &< M, \\
+q \cdot \const{p} + r &< M.
+\end{aligned}
+$$
+
+To check the first condition, we compute the maximum value of the product $(a \cdot b)$ as $\textcolor{orange}{D_{\textsf{lo}}}$ and $\textcolor{orange}{D_{\textsf{hi}}}$ (see equation $(D)$).
+
+$$
+\begin{aligned}
+\textsf{max}(a \cdot b) = \textcolor{orange}{D_{\textsf{lo}}} + \const{2^{2L}} \cdot \textcolor{orange}{D_{\textsf{hi}}} < M. \tag{\textsf{check 1}}
+\end{aligned}
+$$
+
+The second condition can be used to find the maximum permissible quotient as follows:
+
+$$
+\begin{aligned}
+q \cdot \const{p} + r &< M \quad \implies \quad q  < \frac{M - r}{\const{p}} \quad \implies \quad q_{\textsf{max}} = \left\lfloor \frac{M - \textcolor{orange}{R}}{\const{p}} \right\rfloor.
+\end{aligned}
+$$
+
+where $\textcolor{orange}{R}$ is the maximum value of the remainder $r$. Now, let maximum value of the quotient $q$ that we compute natively be $\textcolor{orange}{Q_{\textsf{max}}}$, which must obey the following range constraint:
+
+$$
+0 \leq \textcolor{orange}{Q_{\textsf{max}}} \leq q_{\textsf{max}} \quad \textsf{where} \quad \textcolor{orange}{Q_{\textsf{max}}} := \left\lfloor \frac{\textsf{max}(a \cdot b)}{\const{p}} \right\rfloor
+= \left\lfloor \frac{\textcolor{orange}{D_{\textsf{lo}}} + \const{2^{2L}} \cdot \textcolor{orange}{D_{\textsf{hi}}}}{\const{p}} \right\rfloor.
+\tag{check 2}
+$$
+
+If both $\textsf{check 1}$ and $\textsf{check 2}$ are satisfied, then we can conclude that the multiplication is valid under the CRT modulus $M$. If either of these checks fail, then we must reduce one of the inputs ($a$ or $b$ depending on which one has a higher maximum value) to ensure that the multiplication is valid under the CRT modulus. If after reducing one of the inputs, the checks still fail, then we reduce the second input as well. Once both inputs are reduced, both checks must pass.
+
+### Handling Multiple Multiplications and Additions
+
+We want to compute the sum of multiple bigfield products and additions while ensuring that the result is still valid under the CRT modulus $M$. In this case, we want to avoid modular reductions of the inputs as much as possible.
+
+Suppose we have $(m + 1)$ bigfield products $a_j \cdot b_j$ for $j = 0, \ldots, m$, and we also want to add $k$ bigfield elements $c_i$ for $i = 1, \ldots, k$. We want to compute the sum:
+
+$$
+\begin{aligned}
+\left(a_0 \cdot b_0 + \sum_{j=1}^{m} a_j \cdot b_j + \sum_{i=1}^{k} c_i\right) \textsf{ mod } p.
+\end{aligned}
+$$
+
+Following the same approach as simple multiplication, we compute the quotient $q$ and the remainder $r$ natively as follows:
+
+$$
+\begin{aligned}
+q &= \left\lfloor \frac{a_0 \cdot b_0 + \sum_{j=1}^{m} a_j \cdot b_j + \sum_{i=1}^{k} c_i}{\const{p}} \right\rfloor, \\
+r &= \left(a_0 \cdot b_0 + \sum_{j=1}^{m} a_j \cdot b_j + \sum_{i=1}^{k} c_i\right) \textsf{ mod } p.
+\end{aligned}
+$$
+
+We then want to ensure that the following condition holds (in circuit):
+
+$$
+\begin{aligned}
+\left(a_0 \cdot b_0 + \sum_{j=1}^{m} a_j \cdot b_j + \sum_{i=1}^{k} c_i\right) = q \cdot \const{p} + r, \\
+\implies a_0 \cdot b_0 = q \cdot \const{p} + \underbrace{\left( r - \sum_{j=1}^{m} a_j \cdot b_j - \sum_{i=1}^{k} c_i \right)}_{=: \ r'}.
+\end{aligned}
+$$
+
+This form is similar to the one we used for simple multiplication, except for two things:
+
+1. We need to define the net remainder $r'$ that accumulates the contributions from all the products (except $a_0 \cdot b_0$) and additions. This will cost additional constraints in the circuit (using efficient field accumulation).
+2. We need to ensure that the maximum values of the limbs of the products and sums do not exceed the CRT modulus $M$.
+
+For the second condition, we need to adjust the maximum values of the limbs to account for the additional products and sums. As a result, the carry outputs will also need to be adjusted accordingly:
+
+$$
+\begin{aligned}
+\textcolor{skyblue}{C_{\textsf{low}}} &< \left\lfloor\frac{
+  \left(\textcolor{orange}{D_{\textsf{lo}}} + \sum_{j=1}^{m} \textcolor{orange}{D_{j, \textsf{lo}}}\right) +
+  \left(\sum_{i=1}^{k} \textcolor{orange}{C_{i, \textsf{lo}}}\right) +
+  \textcolor{orange}{E_{\textsf{lo}}} +
+  \textcolor{orange}{R_{\textsf{lo}}}
+  }{\const{2^{2L}}}
+  \right\rfloor, \\
+\textcolor{skyblue}{C_{\textsf{high}}} &< \left\lfloor\frac{
+  \left(\textcolor{orange}{D_{\textsf{hi}}} + \sum_{j=1}^{m} \textcolor{orange}{D_{j, \textsf{hi}}}\right) +
+  \left(\sum_{i=1}^{k} \textcolor{orange}{C_{i, \textsf{hi}}}\right) +
+  \textcolor{orange}{E_{\textsf{hi}}}
+  }{\const{2^{2L}}}
+  \right\rfloor.
+\end{aligned}
+$$
+
+where $\textcolor{orange}{D_{i, \textsf{lo}}}$ and $\textcolor{orange}{D_{i, \textsf{hi}}}$ are the maximum values of the limbs of the products $a_j \cdot b_j$ for $j = 1, \ldots, m$, and $\textcolor{orange}{C_{i, \textsf{lo}}}$ and $\textcolor{orange}{C_{i, \textsf{hi}}}$ are the maximum values of the limbs of the summands $c_i$ for $i = 1, \ldots, k$. We also need to update the maximum value of the quotient $q$ to account for the additional products and sums:
+
+$$
+\begin{aligned}
+\textcolor{orange}{Q_{\textsf{max}}} =
+\left\lfloor
+\frac{
+  \left(\textcolor{orange}{D_{\textsf{lo}}} + \sum_{j=1}^{m} \textcolor{orange}{D_{j, \textsf{lo}}}\right) +
+  \const{2^{2L}} \left(\textcolor{orange}{D_{\textsf{hi}}} + \sum_{j=1}^{m} \textcolor{orange}{D_{j, \textsf{hi}}}\right) +
+\sum_{i=1}^{k} \left( \textcolor{orange}{C_{i, \textsf{lo}}} + \const{2^{2L}} \cdot \textcolor{orange}{C_{i, \textsf{hi}}} \right)
+}{\const{p}}
+\right\rfloor.
+\end{aligned}
+$$
+
+This ensures that the sum of the products and additions does not exceed the CRT modulus $M$.
+
+### Details on Bigfield Subtraction
+
+Let $a, b \in [0, 2^T)$ be two bigfield elements and we want to compute modular subtraction $a - b \textsf{ mod } p$. Let $c$ be the result of the subtraction. We can compute $c$:
+
+$$
+c = (a - b) \textsf{ mod } p
+$$
+
+If $a > b$, then we would not need to worry about underflows and we can compute $c$ directly. If $a < b$, then we need to ensure that the subtraction does not lead to underflows. To do this, we introduce a constant term $\const{s \cdot p}$ such that:
+
+$$
+\begin{aligned}
+a + \const{s \cdot p} - b \geq 0,
+\end{aligned}
+$$
+
+where $s$ is the smallest integer such that the above condition holds. This ensures that we do not have any underflows when we subtract $b$ from $(a + \const{s \cdot p})$. Note that the result of the modular subtraction remains $c$ because we are adding a multiple of the modulus $\const{p}$ to $a$ before subtracting $b$.
+
+> .
+>
+> **Computing the multiple $s$:**
+>
+> To compute the multiple $s$, we first look at the subtraction formula:
+>
+> $$
+> \begin{aligned}
+> \begin{array}{c|c|c|c}
+> a_3 & a_2 & a_1 & a_0 \\[5pt]
+> b_3 & b_2 & b_1 & b_0 \\[5pt]
+> \hline \\[-4pt]
+> & & a_1 - \beta_0 & \textcolor{olive}{a_0 + \beta_0 \cdot 2^L - b_0} \\[5pt]
+> \hline \\[-4pt]
+>  & a_2 - \beta_1 & \textcolor{olive}{(a_1 - \beta_0) + \beta_1 \cdot 2^L - b_1} & \\[5pt]
+> \hline \\[-4pt]
+> a_3 - \beta_2 & \textcolor{olive}{(a_2 - \beta_1) + \beta_2 \cdot 2^L - b_2} & & \\[5pt]
+> \hline \\[-4pt]
+> \textcolor{olive}{(a_3 - \beta_2) + \beta_3 \cdot 2^L - b_3} & & & \\[5pt]
+> \end{array}
+> \end{aligned}
+> $$
+>
+> where limb $i$ borrows $\beta_i$ bits from the next limb. To compute $s$, we must consider the maximum value of the borrow-chain $\beta_i$, which happens in the extreme case when $a_i = 0$ for all $i$.
+> In other words, if we add maximum possible borrow bits to each limb, we can never underflow the subtraction operation. Thus, we compute the borrows as follows:
+>
+> $$
+> \begin{aligned}
+> \textcolor{olive}{\overset{0}{\cancel{a_0}} + \beta_0 \cdot 2^L - b_0} > 0
+> \quad \implies \quad
+> \textcolor{olive}{\beta_0} &= \left\lceil\frac{\textcolor{orange}{B_0}}{\const{2^L}}\right\rceil, \\
+> \textcolor{olive}{(\overset{0}{\cancel{a_1}} - \beta_0) + \beta_1 \cdot 2^L - b_1} > 0
+> \quad \implies \quad
+> \textcolor{olive}{\beta_1} &= \left\lceil\frac{\textcolor{orange}{B_1} + \textcolor{olive}{\beta_0}}{\const{2^L}}\right\rceil, \\
+> \textcolor{olive}{(\overset{0}{\cancel{a_2}} - \beta_1) + \beta_2 \cdot 2^L - b_2} > 0
+> \quad \implies \quad
+> \textcolor{olive}{\beta_2} &= \left\lceil\frac{\textcolor{orange}{B_2} + \textcolor{olive}{\beta_1}}{\const{2^L}}\right\rceil, \\
+> \textcolor{olive}{(\overset{0}{\cancel{a_3}} - \beta_2) + \beta_3 \cdot 2^L - b_3} > 0
+> \quad \implies \quad
+> \textcolor{olive}{\beta_3} &= \left\lceil\frac{\textcolor{orange}{B_3} + \textcolor{olive}{\beta_2}}{\const{2^L}}\right\rceil,
+> \end{aligned}
+> $$
+>
+> where $\textcolor{orange}{B_i}$ are the maximum values of the limbs of $b$.
+> Now we can compute the constant $S = \const{s \cdot p}$ such that the most-significant limb of $S$ is atleast $(\lceil\textsf{log}_2(\textcolor{olive}{\beta_3})\rceil + \const{L})$ bits long.
+> This would ensure that we can always subtract $b$ from $(a + S)$ without underflows.
+>
+> .
+
+Once we have computed the constant term $\const{s \cdot p}$, we must also ensure that none of the limb subtraction leads to limb-underflow. To do this, we modify the constant term $\const{s \cdot p}$ such that:
+
+$$
+\begin{aligned}
+\begin{array}{c|c|c|c|c}
+& \text{Limb 3} & \text{Limb 2} & \text{Limb 1} & \text{Limb 0} \\[2pt] \hline \\[-4pt]
+S = \const{s \cdot p} & \const{S_3} & \const{S_2} & \const{S_1} & \const{S_0} \\[2pt] \hline \\[-4pt]
+S' = \const{s \cdot p} & (\const{S_3} - \textcolor{olive}{\beta_3}) &
+(\const{S_2} + \textcolor{olive}{\beta_3 \cdot 2^{L}} - \textcolor{olive}{\beta_2}) &
+(\const{S_1} + \textcolor{olive}{\beta_2 \cdot 2^{L}} - \textcolor{olive}{\beta_1}) &
+(\const{S_0} + \textcolor{olive}{\beta_1 \cdot 2^{L}} - \textcolor{olive}{\beta_0}) & \\[2pt] \hline
+\end{array}
+\end{aligned}
+$$
+
+Now we proceed to compute the subtraction of two bigfield elements $a' = (a + \const{S'})$ and $b$ using a custom bigfield subtraction function. The custom subtraction function works similar to the addition function described earlier, but instead of adding the limbs, we subtract them. It also uses 4 gates to compute the result of the subtraction.
+
+#### Tracking Maximum Values due to Subtraction
+
+Since we compute subtraction by adding the constant term $S' = \const{s \cdot p}$ to $a$, we need to track the maximum values of the limbs of the result. The maximum values of the limbs of the result $c = a + \const{s \cdot p} - b$ are given by:
+
+$$
+\begin{aligned}
+\textcolor{orange}{C} = &\ \underbrace{(\textcolor{orange}{A_0} + \const{S'_0})}_{\textcolor{orange}{C_0}} + \underbrace{(\textcolor{orange}{A_1} + \const{S'_1})}_{\textcolor{orange}{C_1}} \cdot \const{2^L} + \underbrace{(\textcolor{orange}{A_2} + \const{S'_2})}_{\textcolor{orange}{C_2}} \cdot \const{2^{2L}} + \underbrace{(\textcolor{orange}{A_3} + \const{S'_3})}_{\textcolor{orange}{C_3}} \cdot \const{2^{3L}},
+\end{aligned}
+$$
+
+where $\textcolor{orange}{A_i}$ are the maximum values of the limbs of $a$.
+
+### Details on Bigfield Division
+
+Let $a, b \in [0, 2^T)$ be two bigfield elements and we want compute modular division $\frac{a}{b} \textsf{ mod } p$. Let $c$ be the result of the division. We can compute $c$ as follows:
+
+$$
+c = \left( \frac{a}{b} \right) \textsf{ mod } p = a \cdot b^{-1} \textsf{ mod } p. \tag{D1}
+$$
+
+Computing inverses in a circuit is too expensive, instead we compute $c = (a \cdot b^{-1} \textsf{ mod } p)$ natively (outside the circuit) and then enforce the following condition in the circuit:
+
+$$
+b \cdot c = a \textsf{ mod } p.
+$$
+
+and checking this in the circuit is cheaper (equivalent to checking multiplication). To check the correctness of the multiplication of $b$ and $c$, as per the previous sections, we need to check the expression:
+
+$$
+\begin{aligned}
+b \cdot c = q \cdot \const{p} + a,
+\end{aligned}
+$$
+
+where quotient $q$ is computed by dividing the product $(b \cdot c)$ by the modulus $p$.
+One important difference between checking this multiplication and the previously discussed modular multiplication is that the remainder $a$ in this case is an input and it may not necessarily be range-constrained to $[0, p)$ as we allow overflows. This could lead to underflows in the subtraction operation if $b \cdot c < a$. To handle this, we need to ensure that the subtraction does not lead to underflows. To do this, we introduce a constant term $\const{u \cdot p}$ such that:
+
+$$
+\begin{aligned}
+b \cdot c + \const{u \cdot p} - a \geq 0,
+\end{aligned}
+$$
+
+where $u$ is the smallest integer such that the above condition holds. This ensures that we do not have any underflows when we subtract $a$ from $(b \cdot c + \const{u \cdot p})$. We compute the modified quotient $q$ as follows:
+
+$$
+\begin{aligned}
+q' &= \frac{b \cdot c + \const{u \cdot p} - a}{\const{p}}.
+\end{aligned}
+$$
+
+Note that $q' \equiv q \textsf{ mod } p$. We can now rewrite the division condition as follows:
+
+$$
+\begin{aligned}
+b \cdot c + \const{u \cdot p} &= q' \cdot \const{p} + a.
+\end{aligned}
+$$
+
+From hereon, we can use the same approach as described in the previous sections to check the correctness of the multiplication operation.
+Only additional constraint we need to add is that the denominator $b$ must not be zero.
+
+> **Computing the multiple $u$:**
+>
+> To compute the multiple $u$, we want to ensure that the subtraction does not lead to underflows. We can compute $u$ as follows:
+>
+> $$
+> \begin{aligned}
+> b \cdot c + \const{u \cdot p} - a &\geq 0 \\
+> \quad \implies \quad
+> \const{u \cdot p} &\geq a - b \cdot c \\
+> \quad \implies \quad
+> \const{u} &= \left\lceil\frac{\textsf{max}(a)}{p}\right\rceil.
+> \end{aligned}
+> $$
+>
+> The value $\textsf{max}(a)$ indicates the maximum possible value of a bigfield that obeys the CRT modulus (as $a$ is the input to the division operation).
+> Thus, $\textsf{max}(a) < \sqrt{2^T \cdot n}$.
+> Using this value of $u$ ensures that we do not have any underflows when we subtract $a$ from $(b \cdot c + \const{u \cdot p})$.
+>
+> .

--- a/barretenberg/cpp/src/barretenberg/stdlib/primitives/bigfield/README.md
+++ b/barretenberg/cpp/src/barretenberg/stdlib/primitives/bigfield/README.md
@@ -120,6 +120,30 @@ $$
 a = (a_0, \ a_1, \ a_2, \ a_3, \ a_{\textsf{prime}}).
 $$
 
+### Bigfield Reduction
+
+Given a bigfield element $a \in [0, 2^T)$ we would like to reduce it to $r \in [0, p)$ such that
+
+$$
+
+a \equiv r \ \textsf{mod} \ p.
+
+
+$$
+
+This is known as full reduction. We need to check the following conditions in the circuit:
+
+1. Compute quotient $q$ and remainder $r$ such that $a = q \cdot \const{p} + r$ natively:
+   - $q := \left\lfloor \frac{a}{\const{p}} \right\rfloor$,
+   - $r := a \ \textsf{mod} \ p$,
+2. Check if $q \cdot \const{p} + r - a = 0$ in the circuit,
+3. Enforce range constraint on quotient $q < 2^L$ (must fit in one limb)
+4. Enforce range constraint on remainder $r < \const{p}$
+
+The last step of checking $r < \const{p}$ is very expensive in circuits. Instead, we perform a relaxed condition on $r < 2^s$ where $s := |\const{p}|$. This is enough for operations where you care more about not overflowing rather than getting an exact value mod $p$. Checking $r < 2^s$ is much cheaper in circuits because it simply implies clearing higher bits.
+
+This relaxed check is knowns as _lazy reduction_. It suffices because in addition chains, if we keep reducing intermediate values to lie within a safe range above $p$ (like $2^s$), then the final result can be reduced mod $p$ at the end.
+
 ### Details on Bigfield Addition
 
 Given two bigfield elements $a, b \in [0, 2^T)$

--- a/barretenberg/cpp/src/barretenberg/stdlib/primitives/bigfield/bigfield.hpp
+++ b/barretenberg/cpp/src/barretenberg/stdlib/primitives/bigfield/bigfield.hpp
@@ -401,11 +401,6 @@ template <typename Builder, typename T> class bigfield {
     bigfield operator-(const bigfield& other) const;
     bigfield operator*(const bigfield& other) const;
 
-    /**
-     * FOR TESTING PURPOSES ONLY DO NOT USE THIS IN PRODUCTION CODE FOR THE LOVE OF GOD!
-     **/
-    bigfield bad_mul(const bigfield& other) const;
-
     bigfield operator/(const bigfield& other) const;
     bigfield operator-() const { return bigfield(get_context(), uint256_t(0)) - *this; }
 

--- a/barretenberg/cpp/src/barretenberg/stdlib/primitives/bigfield/bigfield.hpp
+++ b/barretenberg/cpp/src/barretenberg/stdlib/primitives/bigfield/bigfield.hpp
@@ -755,7 +755,7 @@ template <typename Builder, typename T> class bigfield {
     }
 
     // If we encounter this maximum value of a bigfield we stop execution
-    static constexpr uint512_t get_prohibited_maximum_value()
+    static constexpr uint512_t get_prohibited_value()
     {
         uint1024_t maximum_product = get_maximum_crt_product();
         uint64_t maximum_product_bits = maximum_product.get_msb() - 1;
@@ -884,7 +884,7 @@ template <typename Builder, typename T> class bigfield {
     static constexpr uint256_t get_maximum_unreduced_limb_value() { return uint256_t(1) << MAX_UNREDUCED_LIMB_BITS; }
 
     // If we encounter this maximum value of a limb we stop execution
-    static constexpr uint256_t get_prohibited_maximum_limb_value() { return uint256_t(1) << PROHIBITED_LIMB_BITS; }
+    static constexpr uint256_t get_prohibited_limb_value() { return uint256_t(1) << PROHIBITED_LIMB_BITS; }
 
     static_assert(PROHIBITED_LIMB_BITS < MAXIMUM_LIMB_SIZE_THAT_WOULDNT_OVERFLOW);
 

--- a/barretenberg/cpp/src/barretenberg/stdlib/primitives/bigfield/bigfield.hpp
+++ b/barretenberg/cpp/src/barretenberg/stdlib/primitives/bigfield/bigfield.hpp
@@ -202,7 +202,21 @@ template <typename Builder, typename T> class bigfield {
         return result;
     };
 
+    /**
+     * @brief Constructs a bigfield element from a 256-bit byte array.
+     *
+     * This constructor interprets the input byte array as a 256-bit little-endian integer,
+     * and decomposes it into 4 limbs as follows:
+     *
+     * - Limb 0: 68 bits — bytes b24 to b31 and the high 4 bits of b23
+     * - Limb 1: 68 bits — bytes b14 to b22, and the low 4 bits of b23
+     * - Limb 2: 68 bits — bytes b7 to b14 and the high 4 bits of b6
+     * - Limb 3: 52 bits — bytes b0 to b5 and the low 4 bits of b6
+     *
+     * @param bytes The 32-byte input representing the 256-bit integer (little-endian).
+     */
     bigfield(const byte_array<Builder>& bytes);
+
     bigfield(const bigfield& other);
     bigfield(bigfield&& other);
 

--- a/barretenberg/cpp/src/barretenberg/stdlib/primitives/bigfield/bigfield.hpp
+++ b/barretenberg/cpp/src/barretenberg/stdlib/primitives/bigfield/bigfield.hpp
@@ -462,6 +462,12 @@ template <typename Builder, typename T> class bigfield {
      * We also check that b != 0.
      */
     bigfield operator/(const bigfield& other) const;
+
+    /**
+     * @brief Negation operator, works by subtracting `this` from zero.
+     *
+     * @return bigfield
+     */
     bigfield operator-() const { return bigfield(get_context(), uint256_t(0)) - *this; }
 
     bigfield operator+=(const bigfield& other)

--- a/barretenberg/cpp/src/barretenberg/stdlib/primitives/bigfield/bigfield.hpp
+++ b/barretenberg/cpp/src/barretenberg/stdlib/primitives/bigfield/bigfield.hpp
@@ -692,6 +692,7 @@ template <typename Builder, typename T> class bigfield {
     // as we would reduce the limbs before they reach this size.
     static constexpr uint64_t PROHIBITED_LIMB_BITS = MAX_UNREDUCED_LIMB_BITS + 5;
 
+    // If we encounter this maximum value of a bigfield we need to reduce it.
     static constexpr uint256_t get_maximum_unreduced_limb_value() { return uint256_t(1) << MAX_UNREDUCED_LIMB_BITS; }
 
     // If we encounter this maximum value of a limb we stop execution

--- a/barretenberg/cpp/src/barretenberg/stdlib/primitives/bigfield/bigfield.hpp
+++ b/barretenberg/cpp/src/barretenberg/stdlib/primitives/bigfield/bigfield.hpp
@@ -575,6 +575,15 @@ template <typename Builder, typename T> class bigfield {
         return (uint512_t(1) << ((maximum_product_bits >> 1) + arbitrary_secure_margin)) - uint512_t(1);
     }
 
+    /**
+     * @brief Compute the maximum product of two bigfield elements in CRT: M = 2^t * n.
+     *
+     * @details When we multiply two bigfield elements a and b, we need to check that: a * b = q * p + r,
+     * where q is the quotient, r is the remainder, and p is the size of the non-native field. With the CRT, we should
+     * have both sizes less than the maximum product M = 2^t * n.
+     *
+     * @return uint1024_t Maximum product of two bigfield elements in CRT form
+     */
     static constexpr uint1024_t get_maximum_crt_product()
     {
         uint1024_t maximum_product = uint1024_t(binary_basis.modulus) * uint1024_t(prime_basis.modulus);

--- a/barretenberg/cpp/src/barretenberg/stdlib/primitives/bigfield/bigfield.hpp
+++ b/barretenberg/cpp/src/barretenberg/stdlib/primitives/bigfield/bigfield.hpp
@@ -410,9 +410,24 @@ template <typename Builder, typename T> class bigfield {
      * @param add_a
      * @param add_b
      * @return The sum of three terms
+     *
+     * @details Uses five gates (one for each limb) to add three bigfield elements.
      */
     bigfield add_two(const bigfield& add_a, const bigfield& add_b) const;
 
+    /**
+     * @brief Subtraction operator.
+     *
+     * @param other
+     * @return bigfield
+     *
+     * @details Uses lazy reduction techniques (similar to operator+) to save on field reductions. Instead of computing
+     * `*this - other`, we compute a constant `X = s * p` and compute: `*this + X - other` to ensure we do not
+     * underflow. Note that NOT enough to ensure that the integer value of `*this + X - other` does not underflow. We
+     * must ALSO ensure that each LIMB of the result does not underflow. Based on this condition, we compute the minimum
+     * value of `s` such that, for each limb `i`, the following result is positive:
+     * `*this.limb[i] + X.limb[i] - other.limb[i] ≥ 0`.
+     */
     bigfield operator-(const bigfield& other) const;
     bigfield operator*(const bigfield& other) const;
 

--- a/barretenberg/cpp/src/barretenberg/stdlib/primitives/bigfield/bigfield.hpp
+++ b/barretenberg/cpp/src/barretenberg/stdlib/primitives/bigfield/bigfield.hpp
@@ -958,6 +958,20 @@ template <typename Builder, typename T> class bigfield {
                                                       const bigfield& input_quotient,
                                                       const std::vector<bigfield>& input_remainders);
 
+    /**
+     * @brief Evaluate a square with several additions.
+     *
+     * @param left Left multiplicand
+     * @param to_add Vector of elements to add
+     * @param quotient Quotient term
+     * @param remainder Remainder term
+     *
+     * @details This function evaluates the relationship:
+     * (a * a) + (to_add[0] + .. + to_add[-1]) - q * p - r = 0 mod 2^t (binary basis modulus)
+     * (a * a) + (to_add[0] + .. + to_add[-1]) - q * p - r = 0 mod n (circuit modulus)
+     *
+     * @warning THIS FUNCTION IS UNSAFE TO USE IN CIRCUITS AS IT DOES NOT PROTECT AGAINST CRT OVERFLOWS.
+     */
     static void unsafe_evaluate_square_add(const bigfield& left,
                                            const std::vector<bigfield>& to_add,
                                            const bigfield& quotient,

--- a/barretenberg/cpp/src/barretenberg/stdlib/primitives/bigfield/bigfield.hpp
+++ b/barretenberg/cpp/src/barretenberg/stdlib/primitives/bigfield/bigfield.hpp
@@ -593,6 +593,10 @@ template <typename Builder, typename T> class bigfield {
     /**
      * @brief Compute the maximum number of bits for quotient range proof to protect against CRT underflow
      *
+     * @details When multiplying a and b, we need to check that: a * b = q * p + r, and each side of the equation
+     * is less than the maximum product M = 2^t * n. The quotient q is a size of the non-native field, and we need to
+     * ensure it fits within the available bits. q * p + r < M  ==>  q < (M - r_max) / p
+     *
      * @param remainders_max Maximum sizes of resulting remainders
      * @return Desired length of range proof
      */

--- a/barretenberg/cpp/src/barretenberg/stdlib/primitives/bigfield/bigfield.hpp
+++ b/barretenberg/cpp/src/barretenberg/stdlib/primitives/bigfield/bigfield.hpp
@@ -479,6 +479,13 @@ template <typename Builder, typename T> class bigfield {
         return *this;
     }
 
+    /**
+     * @brief Square operator, computes a * a = c mod p.
+     *
+     * @return bigfield
+     *
+     * @details Costs the same as operator* as it just sets a = b.
+     */
     bigfield sqr() const;
     bigfield sqradd(const std::vector<bigfield>& to_add) const;
     bigfield pow(const size_t exponent) const;

--- a/barretenberg/cpp/src/barretenberg/stdlib/primitives/bigfield/bigfield.hpp
+++ b/barretenberg/cpp/src/barretenberg/stdlib/primitives/bigfield/bigfield.hpp
@@ -668,21 +668,7 @@ template <typename Builder, typename T> class bigfield {
         ASSERT(add_term + maximum_default_bigint < get_maximum_crt_product());
         return ((product_sum + add_term) >= get_maximum_crt_product());
     }
-    // static bool mul_quotient_crt_check(const uint1024_t& q, const std::vector<uint1024_t>& remainders)
-    // {
-    //     uint1024_t product = (q * modulus_u512);
-    //     for (const auto& add : remainders) {
-    //         product += add;
-    //     }
-    //     std::cout << "product = " << product << std::endl;
-    //     std::cout << "crt product = " << get_maximum_crt_product() << std::endl;
 
-    //     if (product >= get_maximum_crt_product()) {
-    //         count++;
-    //         std::cout << "count = " << count << std::endl;
-    //     }
-    //     return (product >= get_maximum_crt_product());
-    // }
     // a (currently generous) upper bound on the log of number of fr additions in any of the class operations
     static constexpr uint64_t MAX_ADDITION_LOG = 10;
     // the rationale of the expression is we should not overflow Fr when applying any bigfield operation (e.g. *) and

--- a/barretenberg/cpp/src/barretenberg/stdlib/primitives/bigfield/bigfield.hpp
+++ b/barretenberg/cpp/src/barretenberg/stdlib/primitives/bigfield/bigfield.hpp
@@ -933,6 +933,25 @@ template <typename Builder, typename T> class bigfield {
                                              const bigfield& quotient,
                                              const std::vector<bigfield>& remainders);
 
+    /**
+     * @brief Evaluate a relation involving multiple multiplications and additions.
+     *
+     * @param input_left Vector of left multiplication operands.
+     * @param input_right Vector of right multiplication operands.
+     * @param to_add Vector of elements to add to the product.
+     * @param input_quotient Quotient term.
+     * @param input_remainders Vector of remainders.
+     *
+     * @details This function evaluates the relationship:
+     * (a[0] * b[0] + ... + (a[-1] * b[-1])) + (to_add[0] + .. + to_add[-1]) - q * p - (r[0] + .. + r[-1]) = 0 mod 2^t
+     * (a[0] * b[0] + ... + (a[-1] * b[-1])) + (to_add[0] + .. + to_add[-1]) - q * p - (r[0] + .. + r[-1]) = 0 mod n
+     *
+     * @note This method supports multiple "remainders" because, when evaluating division of the form:
+     * (n[0] * n[1] + ... + n[-1]) / d, the numerator (which becomes the remainder term) can be a sum of multiple
+     * elements. See `msub_div` for more details on how this is used.
+     *
+     * @warning THIS FUNCTION IS UNSAFE TO USE IN CIRCUITS AS IT DOES NOT PROTECT AGAINST CRT OVERFLOWS.
+     */
     static void unsafe_evaluate_multiple_multiply_add(const std::vector<bigfield>& input_left,
                                                       const std::vector<bigfield>& input_right,
                                                       const std::vector<bigfield>& to_add,

--- a/barretenberg/cpp/src/barretenberg/stdlib/primitives/bigfield/bigfield.hpp
+++ b/barretenberg/cpp/src/barretenberg/stdlib/primitives/bigfield/bigfield.hpp
@@ -393,6 +393,13 @@ template <typename Builder, typename T> class bigfield {
 
     void self_reduce() const;
 
+    /**
+     * @brief Check if the bigfield is constant, i.e. its prime limb is constant.
+     *
+     * @return true if the bigfield is constant, false otherwise.
+     *
+     * TODO(https://github.com/AztecProtocol/aztec-packages/issues/14662): should we check if all limbs are constants?
+     */
     bool is_constant() const { return prime_basis_limb.witness_index == IS_CONSTANT; }
 
     /**

--- a/barretenberg/cpp/src/barretenberg/stdlib/primitives/bigfield/bigfield.hpp
+++ b/barretenberg/cpp/src/barretenberg/stdlib/primitives/bigfield/bigfield.hpp
@@ -318,7 +318,24 @@ template <typename Builder, typename T> class bigfield {
     uint512_t get_value() const;
     uint512_t get_maximum_value() const;
 
+    /**
+     * @brief Add a field element to the lower limb. CAUTION (the element has to be constrained before using this
+     * function)
+     *
+     * @details Sometimes we need to add a small constrained value to a bigfield element (for example, a boolean value),
+     * but we don't want to construct a full bigfield element for that as it would take too many gates. If the maximum
+     * value of the field element being added is small enough, we can simply add it to the lowest limb and increase its
+     * maximum value. That will create 2 additional constraints instead of 5/3 needed to add 2 bigfield elements and
+     * several needed to construct a bigfield element.
+     *
+     * @tparam Builder Builder
+     * @tparam T Field Parameters
+     * @param other Field element that will be added to the lower
+     * @param other_maximum_value The maximum value of other
+     * @return bigfield<Builder, T> Result
+     */
     bigfield add_to_lower_limb(const field_t<Builder>& other, uint256_t other_maximum_value) const;
+
     bigfield operator+(const bigfield& other) const;
     bigfield add_two(const bigfield& add_a, const bigfield& add_b) const;
     bigfield operator-(const bigfield& other) const;

--- a/barretenberg/cpp/src/barretenberg/stdlib/primitives/bigfield/bigfield.hpp
+++ b/barretenberg/cpp/src/barretenberg/stdlib/primitives/bigfield/bigfield.hpp
@@ -34,6 +34,12 @@ template <typename Builder, typename T> class bigfield {
         size_t num_bits;
     };
 
+    /**
+     * @brief Represents a single limb of a bigfield element, with its value and maximum value.
+
+     * @details The default maximum value of a new limb is set to 2^L - 1.
+     *
+     */
     struct Limb {
         Limb() {}
         Limb(const field_t<Builder>& input, const uint256_t& max = DEFAULT_MAXIMUM_LIMB)

--- a/barretenberg/cpp/src/barretenberg/stdlib/primitives/bigfield/bigfield.hpp
+++ b/barretenberg/cpp/src/barretenberg/stdlib/primitives/bigfield/bigfield.hpp
@@ -352,7 +352,18 @@ template <typename Builder, typename T> class bigfield {
      */
     bigfield operator+(const bigfield& other) const;
 
+    /**
+     * @brief Create constraints for summing three
+     * bigfield elements efficiently
+     *
+     * @tparam Builder
+     * @tparam T
+     * @param add_a
+     * @param add_b
+     * @return The sum of three terms
+     */
     bigfield add_two(const bigfield& add_a, const bigfield& add_b) const;
+
     bigfield operator-(const bigfield& other) const;
     bigfield operator*(const bigfield& other) const;
 

--- a/barretenberg/cpp/src/barretenberg/stdlib/primitives/bigfield/bigfield.hpp
+++ b/barretenberg/cpp/src/barretenberg/stdlib/primitives/bigfield/bigfield.hpp
@@ -908,6 +908,25 @@ template <typename Builder, typename T> class bigfield {
                                                                const std::vector<uint1024_t>& remainders_max = {
                                                                    DEFAULT_MAXIMUM_REMAINDER });
 
+    /**
+     * @brief Evaluate a multiply add identity with several added elements and several remainders
+     *
+     * @param left Left multiplicand
+     * @param right Right multiplicand
+     * @param to_add Vector of elements to add
+     * @param quotient Quotient term
+     * @param remainders Vector of remainders
+     *
+     * @details This function evaluates the relationship:
+     * a * b + (to_add[0] + .. + to_add[-1]) - q * p - (r[0] + .. + r[-1]) = 0 mod 2^t (binary basis modulus)
+     * a * b + (to_add[0] + .. + to_add[-1]) - q * p - (r[0] + .. + r[-1]) = 0 mod n (circuit modulus)
+     *
+     * @note This method supports multiple "remainders" because, when evaluating division of the form:
+     * (n[0] * n[1] + ... + n[-1]) / d, the numerator (which becomes the remainder term) can be a sum of multiple
+     * elements.
+     *
+     * @warning THIS FUNCTION IS UNSAFE TO USE IN CIRCUITS AS IT DOES NOT PROTECT AGAINST CRT OVERFLOWS.
+     */
     static void unsafe_evaluate_multiply_add(const bigfield& left,
                                              const bigfield& right_mul,
                                              const std::vector<bigfield>& to_add,

--- a/barretenberg/cpp/src/barretenberg/stdlib/primitives/bigfield/bigfield.hpp
+++ b/barretenberg/cpp/src/barretenberg/stdlib/primitives/bigfield/bigfield.hpp
@@ -612,7 +612,7 @@ template <typename Builder, typename T> class bigfield {
     }
 
     /**
-     * Check that the maximum value of a bigfield product with added values overflows ctf modulus.
+     * Check that the maximum value of a bigfield product with added values overflows crt modulus.
      *
      * @param a_max multiplicand maximum value
      * @param b_max multiplier maximum value
@@ -625,7 +625,7 @@ template <typename Builder, typename T> class bigfield {
                                                   const std::vector<bigfield>& to_add)
     {
         uint1024_t product = a_max * b_max;
-        uint1024_t add_term;
+        uint1024_t add_term = 0;
         for (const auto& add : to_add) {
             add_term += add.get_maximum_value();
         }
@@ -653,8 +653,8 @@ template <typename Builder, typename T> class bigfield {
         std::vector<uint1024_t> products;
         ASSERT(as_max.size() == bs_max.size());
         // Computing individual products
-        uint1024_t product_sum;
-        uint1024_t add_term;
+        uint1024_t product_sum = 0;
+        uint1024_t add_term = 0;
         for (size_t i = 0; i < as_max.size(); i++) {
             product_sum += uint1024_t(as_max[i]) * uint1024_t(bs_max[i]);
         }

--- a/barretenberg/cpp/src/barretenberg/stdlib/primitives/bigfield/bigfield.hpp
+++ b/barretenberg/cpp/src/barretenberg/stdlib/primitives/bigfield/bigfield.hpp
@@ -487,8 +487,38 @@ template <typename Builder, typename T> class bigfield {
      * @details Costs the same as operator* as it just sets a = b.
      */
     bigfield sqr() const;
+
+    /**
+     * @brief Square and add operator, computes a * a + ...to_add = c mod p.
+     *
+     * @param to_add The bigfield element to add to the square.
+     * @return bigfield
+     *
+     * @details We can chain multiple additions to a square/multiply with a single quotient/remainder. Chaining the
+     * additions here is cheaper than calling operator+ because we can combine some gates in `evaluate_multiply_add`
+     */
     bigfield sqradd(const std::vector<bigfield>& to_add) const;
+
+    /**
+     * @brief Raise the bigfield element to the power of (out-of-circuit) exponent.
+     *
+     * @param exponent The exponent to raise the bigfield element to.
+     * @return this ** (exponent)
+     *
+     * @details Uses the square-and-multiply algorithm to compute a^exponent mod p.
+     *
+     * @todo TODO(https://github.com/AztecProtocol/barretenberg/issues/1014) Improve the efficiency of this function.
+     */
     bigfield pow(const size_t exponent) const;
+
+    /**
+     * @brief Compute a * b + ...to_add = c mod p
+     *
+     * @param to_mul Bigfield element to multiply by
+     * @param to_add Vector of elements to add
+     *
+     * @return New bigfield element c
+     **/
     bigfield madd(const bigfield& to_mul, const std::vector<bigfield>& to_add) const;
 
     static void perform_reductions_for_mult_madd(std::vector<bigfield>& mul_left,

--- a/barretenberg/cpp/src/barretenberg/stdlib/primitives/bigfield/bigfield.hpp
+++ b/barretenberg/cpp/src/barretenberg/stdlib/primitives/bigfield/bigfield.hpp
@@ -999,6 +999,12 @@ template <typename Builder, typename T> class bigfield {
      */
     void reduction_check() const;
 
+    /**
+     * @brief Perform a sanity check on a value that is about to interact with another value.
+     *
+     * @details ASSERTs that the value of all limbs is less than or equal to the prohibited maximum value. Checks that
+     *the maximum value of the whole element is also less than a prohibited maximum value.
+     */
     void sanity_check() const;
 
 }; // namespace stdlib

--- a/barretenberg/cpp/src/barretenberg/stdlib/primitives/bigfield/bigfield.hpp
+++ b/barretenberg/cpp/src/barretenberg/stdlib/primitives/bigfield/bigfield.hpp
@@ -783,6 +783,27 @@ template <typename Builder, typename T> class bigfield {
                                  const bigfield& right,
                                  const bigfield& quotient,
                                  const bigfield& remainder);
+
+    /**
+     * @brief Check if the bigfield element needs to be reduced.
+     *
+     * @details This function checks if the bigfield element is within the valid range and reduces it if necessary.
+     * When multiplying bigfield elements a and b, we need to ensure that each side of the equation:
+     *      a * b = q * p + r
+     * (a) holds modulo the size of the native field n,
+     * (b) holds modulo the size of the bigger ring 2^t.
+     * (c) is less than the maximum value: M = 2^t * n.
+     * This implies a, b must always be less than √M, and their limbs must be less than the maximum limb value.
+     *
+     * Given a bigfield element c, this function applies these checks:
+     *  (i) c < √M (see note below).
+     * (ii) each limb (binary basis) of c is less than the maximum limb value.
+     *
+     * These checks prevent our field arithmetic from overflowing the native modulus boundary, whilst ensuring we can
+     * still use the chinese remainder theorem to validate field multiplications with a reduced number of range checks.
+     *
+     * Note: We actually apply a stricter bound, see @ref get_maximum_unreduced_value for an explanation.
+     */
     void reduction_check() const;
 
     void sanity_check() const;

--- a/barretenberg/cpp/src/barretenberg/stdlib/primitives/bigfield/bigfield.hpp
+++ b/barretenberg/cpp/src/barretenberg/stdlib/primitives/bigfield/bigfield.hpp
@@ -220,6 +220,19 @@ template <typename Builder, typename T> class bigfield {
     bigfield(const bigfield& other);
     bigfield(bigfield&& other);
 
+    /**
+     * @brief Creates a bigfield element from a uint512_t.
+     * Bigfield element is constructed as a witness and not a circuit constant
+     *
+     * @param ctx
+     * @param value
+     * @param can_overflow Can the input value have more than log2(modulus) bits?
+     * @param maximum_bitlength Provide the explicit maximum bitlength if known. Otherwise bigfield max value will be
+     * either log2(modulus) bits iff can_overflow = false, or (4 * NUM_LIMB_BITS) iff can_overflow = true
+     * @return bigfield<Builder, T>
+     *
+     * @details This method is 1 gate more efficient than constructing from 2 field_ct elements.
+     */
     static bigfield create_from_u512_as_witness(Builder* ctx,
                                                 const uint512_t& value,
                                                 const bool can_overflow = false,

--- a/barretenberg/cpp/src/barretenberg/stdlib/primitives/bigfield/bigfield.hpp
+++ b/barretenberg/cpp/src/barretenberg/stdlib/primitives/bigfield/bigfield.hpp
@@ -877,6 +877,14 @@ template <typename Builder, typename T> class bigfield {
     static_assert(PROHIBITED_LIMB_BITS < MAXIMUM_LIMB_SIZE_THAT_WOULDNT_OVERFLOW);
 
   private:
+    /**
+     * @brief Compute the quotient and remainder values for dividing (a * b + (to_add[0] + ... + to_add[-1])) with p
+     *
+     * @param a Left multiplicand
+     * @param b Right multiplier
+     * @param to_add Vector of elements to add
+     * @return std::pair<uint512_t, uint512_t> Quotient and remainder values
+     */
     static std::pair<uint512_t, uint512_t> compute_quotient_remainder_values(const bigfield& a,
                                                                              const bigfield& b,
                                                                              const std::vector<bigfield>& to_add);

--- a/barretenberg/cpp/src/barretenberg/stdlib/primitives/bigfield/bigfield.hpp
+++ b/barretenberg/cpp/src/barretenberg/stdlib/primitives/bigfield/bigfield.hpp
@@ -209,6 +209,7 @@ template <typename Builder, typename T> class bigfield {
 
         return result;
     };
+
     /**
      * @brief Construct a bigfield element from binary limbs and a prime basis limb that are already reduced
      *
@@ -251,7 +252,10 @@ template <typename Builder, typename T> class bigfield {
      */
     bigfield(const byte_array<Builder>& bytes);
 
+    // Copy constructor
     bigfield(const bigfield& other);
+
+    // Move constructor
     bigfield(bigfield&& other);
 
     /**
@@ -329,6 +333,15 @@ template <typename Builder, typename T> class bigfield {
         bb::fr(negative_prime_modulus.slice(NUM_LIMB_BITS * 3, NUM_LIMB_BITS * 4).lo),
     };
 
+    /**
+     * @brief Convert the bigfield element to a byte array. Concatenates byte arrays of the high (2L bits) and low (2L
+     * bits) parts of the bigfield element.
+     *
+     * @details Assumes that 2L is divisible by 8, i.e. (NUM_LIMB_BITS * 2) % 8 == 0. Also we check that the bigfield
+     * element is in the target field.
+     *
+     * @return byte_array<Builder>
+     */
     byte_array<Builder> to_byte_array() const
     {
         byte_array<Builder> result(get_context());
@@ -349,7 +362,10 @@ template <typename Builder, typename T> class bigfield {
         return result;
     }
 
+    // Gets the integer (uint512_t) value of the bigfield element by combining the binary basis limbs.
     uint512_t get_value() const;
+
+    // Gets the maximum value of the bigfield element by combining the maximum values of the binary basis limbs.
     uint512_t get_maximum_value() const;
 
     /**
@@ -387,8 +403,7 @@ template <typename Builder, typename T> class bigfield {
     bigfield operator+(const bigfield& other) const;
 
     /**
-     * @brief Create constraints for summing three
-     * bigfield elements efficiently
+     * @brief Create constraints for summing three bigfield elements efficiently
      *
      * @tparam Builder
      * @tparam T

--- a/barretenberg/cpp/src/barretenberg/stdlib/primitives/bigfield/bigfield.hpp
+++ b/barretenberg/cpp/src/barretenberg/stdlib/primitives/bigfield/bigfield.hpp
@@ -683,13 +683,14 @@ template <typename Builder, typename T> class bigfield {
     static constexpr uint64_t MAXIMUM_LIMB_SIZE_THAT_WOULDNT_OVERFLOW =
         (bb::fr::modulus.get_msb() - MAX_ADDITION_LOG - NUM_LIMB_BITS) / 2;
 
-    // If the logarithm of the maximum value of a limb is more than this, we need to reduce
-    static constexpr uint64_t MAX_UNREDUCED_LIMB_BITS =
-        NUM_LIMB_BITS + 10; // We allowa an element to be added to itself 10 times. There is no actual usecase
+    // If the logarithm of the maximum value of a limb is more than this, we need to reduce.
+    // We allow an element to be added to itself 10 times, so we allow the limb to grow by 10 bits.
+    // Number 10 is arbitrary, there's no actual usecase for adding 1024 elements together.
+    static constexpr uint64_t MAX_UNREDUCED_LIMB_BITS = NUM_LIMB_BITS + 10;
 
-    static constexpr uint64_t PROHIBITED_LIMB_BITS =
-        MAX_UNREDUCED_LIMB_BITS +
-        5; // Shouldn't be reachable through addition, reduction should happen earlier. If we detect this, we stop
+    // If we reach this size of a limb, we stop execution (as safety measure). This should never reach during addition
+    // as we would reduce the limbs before they reach this size.
+    static constexpr uint64_t PROHIBITED_LIMB_BITS = MAX_UNREDUCED_LIMB_BITS + 5;
 
     static constexpr uint256_t get_maximum_unreduced_limb_value() { return uint256_t(1) << MAX_UNREDUCED_LIMB_BITS; }
 

--- a/barretenberg/cpp/src/barretenberg/stdlib/primitives/bigfield/bigfield.hpp
+++ b/barretenberg/cpp/src/barretenberg/stdlib/primitives/bigfield/bigfield.hpp
@@ -497,6 +497,7 @@ template <typename Builder, typename T> class bigfield {
      * @return bigfield
      *
      * @details Costs the same as operator* as it just sets a = b.
+     * TODO(https://github.com/AztecProtocol/aztec-packages/issues/15089): can optimise this further.
      */
     bigfield sqr() const;
 

--- a/barretenberg/cpp/src/barretenberg/stdlib/primitives/bigfield/bigfield.hpp
+++ b/barretenberg/cpp/src/barretenberg/stdlib/primitives/bigfield/bigfield.hpp
@@ -336,7 +336,22 @@ template <typename Builder, typename T> class bigfield {
      */
     bigfield add_to_lower_limb(const field_t<Builder>& other, uint256_t other_maximum_value) const;
 
+    /**
+     * @brief Adds two bigfield elements. Inputs are reduced to the modulus if necessary. Requires 4 gates if both
+     * elements are witnesses.
+     *
+     * @details Naive addition of two bigfield elements would require 5 gates: 4 gates to add the binary basis limbs and
+     * 1 gate to add the prime basis limbs. However, if both elements are witnesses, we can use an optimised addition
+     * trick that uses 4 gates instead of 5. In this case, we add the prime basis limbs and one of the binary basis
+     * limbs in a single gate.
+     *
+     * @tparam Builder
+     * @tparam T
+     * @param other
+     * @return bigfield<Builder, T>
+     */
     bigfield operator+(const bigfield& other) const;
+
     bigfield add_two(const bigfield& add_a, const bigfield& add_b) const;
     bigfield operator-(const bigfield& other) const;
     bigfield operator*(const bigfield& other) const;

--- a/barretenberg/cpp/src/barretenberg/stdlib/primitives/bigfield/bigfield.hpp
+++ b/barretenberg/cpp/src/barretenberg/stdlib/primitives/bigfield/bigfield.hpp
@@ -977,11 +977,6 @@ template <typename Builder, typename T> class bigfield {
                                            const bigfield& quotient,
                                            const bigfield& remainder);
 
-    static void evaluate_product(const bigfield& left,
-                                 const bigfield& right,
-                                 const bigfield& quotient,
-                                 const bigfield& remainder);
-
     /**
      * @brief Check if the bigfield element needs to be reduced.
      *

--- a/barretenberg/cpp/src/barretenberg/stdlib/primitives/bigfield/bigfield.hpp
+++ b/barretenberg/cpp/src/barretenberg/stdlib/primitives/bigfield/bigfield.hpp
@@ -327,10 +327,10 @@ template <typename Builder, typename T> class bigfield {
     static constexpr bb::fr negative_prime_modulus_mod_binary_basis = -bb::fr(uint256_t(modulus_u512));
     static constexpr uint512_t negative_prime_modulus = binary_basis.modulus - target_basis.modulus;
     static constexpr uint256_t neg_modulus_limbs_u256[NUM_LIMBS]{
-        uint256_t(negative_prime_modulus.slice(0, NUM_LIMB_BITS).lo),
-        uint256_t(negative_prime_modulus.slice(NUM_LIMB_BITS, NUM_LIMB_BITS * 2).lo),
-        uint256_t(negative_prime_modulus.slice(NUM_LIMB_BITS * 2, NUM_LIMB_BITS * 3).lo),
-        uint256_t(negative_prime_modulus.slice(NUM_LIMB_BITS * 3, NUM_LIMB_BITS * 4).lo),
+        negative_prime_modulus.slice(0, NUM_LIMB_BITS).lo,
+        negative_prime_modulus.slice(NUM_LIMB_BITS, NUM_LIMB_BITS * 2).lo,
+        negative_prime_modulus.slice(NUM_LIMB_BITS * 2, NUM_LIMB_BITS * 3).lo,
+        negative_prime_modulus.slice(NUM_LIMB_BITS * 3, NUM_LIMB_BITS * 4).lo,
     };
     static constexpr bb::fr neg_modulus_limbs[NUM_LIMBS]{
         bb::fr(negative_prime_modulus.slice(0, NUM_LIMB_BITS).lo),

--- a/barretenberg/cpp/src/barretenberg/stdlib/primitives/bigfield/bigfield.hpp
+++ b/barretenberg/cpp/src/barretenberg/stdlib/primitives/bigfield/bigfield.hpp
@@ -728,7 +728,7 @@ template <typename Builder, typename T> class bigfield {
     static constexpr uint512_t get_maximum_unreduced_value()
     {
         // This = `T * n = 2^272 * |BN(Fr)|` So this equals n*2^t
-        uint1024_t maximum_product = uint1024_t(binary_basis.modulus) * uint1024_t(prime_basis.modulus);
+        uint1024_t maximum_product = get_maximum_crt_product();
 
         // In multiplying two bigfield elements a and b, we must check that:
         //
@@ -757,7 +757,7 @@ template <typename Builder, typename T> class bigfield {
     // If we encounter this maximum value of a bigfield we stop execution
     static constexpr uint512_t get_prohibited_maximum_value()
     {
-        uint1024_t maximum_product = uint1024_t(binary_basis.modulus) * uint1024_t(prime_basis.modulus);
+        uint1024_t maximum_product = get_maximum_crt_product();
         uint64_t maximum_product_bits = maximum_product.get_msb() - 1;
         const size_t arbitrary_secure_margin = 20;
         return (uint512_t(1) << ((maximum_product_bits >> 1) + arbitrary_secure_margin)) - uint512_t(1);

--- a/barretenberg/cpp/src/barretenberg/stdlib/primitives/bigfield/bigfield.hpp
+++ b/barretenberg/cpp/src/barretenberg/stdlib/primitives/bigfield/bigfield.hpp
@@ -429,6 +429,20 @@ template <typename Builder, typename T> class bigfield {
      * `*this.limb[i] + X.limb[i] - other.limb[i] ≥ 0`.
      */
     bigfield operator-(const bigfield& other) const;
+
+    /**
+     * @brief Evaluate a non-native field multiplication: (a * b = c mod p) where p == target_basis.modulus
+     *
+     * @param other
+     * @return bigfield
+     *
+     * @details We compute quotient term `q` and remainder `c` and evaluate that:
+     * a * b - q * p - c = 0 mod modulus_u512 (binary basis modulus, currently 2**272)
+     * a * b - q * p - c = 0 mod circuit modulus
+     * We also check that:
+     * a * b < M  and  q * p - c < M, where M = (2^t * n) is CRT modulus.
+     *
+     */
     bigfield operator*(const bigfield& other) const;
 
     bigfield operator/(const bigfield& other) const;

--- a/barretenberg/cpp/src/barretenberg/stdlib/primitives/bigfield/bigfield.hpp
+++ b/barretenberg/cpp/src/barretenberg/stdlib/primitives/bigfield/bigfield.hpp
@@ -445,6 +445,16 @@ template <typename Builder, typename T> class bigfield {
      */
     bigfield operator*(const bigfield& other) const;
 
+    /**
+     * Division operator: a / b. Creates constraints for division in the circuit and checks b != 0.
+     * If you need a variant without the zero check, use `div_without_denominator_check`.
+     *
+     * @param other The denominator.
+     * @return The result of the division c = (a / b) mod p.
+     *
+     * @details To evaluate (a / b = c mod p), we instead evaluate (c * b = a mod p), where p is the target modulus.
+     * We also check that b != 0.
+     */
     bigfield operator/(const bigfield& other) const;
     bigfield operator-() const { return bigfield(get_context(), uint256_t(0)) - *this; }
 

--- a/barretenberg/cpp/src/barretenberg/stdlib/primitives/bigfield/bigfield.hpp
+++ b/barretenberg/cpp/src/barretenberg/stdlib/primitives/bigfield/bigfield.hpp
@@ -315,7 +315,7 @@ template <typename Builder, typename T> class bigfield {
     static constexpr size_t MAXIMUM_SUMMAND_COUNT = 1 << MAXIMUM_SUMMAND_COUNT_LOG;
 
     static constexpr uint256_t prime_basis_maximum_limb =
-        uint256_t(modulus_u512.slice(NUM_LIMB_BITS * (NUM_LIMBS - 1), NUM_LIMB_BITS* NUM_LIMBS));
+        modulus_u512.slice(NUM_LIMB_BITS * (NUM_LIMBS - 1), NUM_LIMB_BITS* NUM_LIMBS).lo;
     static constexpr Basis prime_basis{ uint512_t(bb::fr::modulus), bb::fr::modulus.get_msb() + 1 };
     static constexpr Basis binary_basis{ uint512_t(1) << LOG2_BINARY_MODULUS, LOG2_BINARY_MODULUS };
     static constexpr Basis target_basis{ modulus_u512, static_cast<size_t>(modulus_u512.get_msb() + 1) };

--- a/barretenberg/cpp/src/barretenberg/stdlib/primitives/bigfield/bigfield.hpp
+++ b/barretenberg/cpp/src/barretenberg/stdlib/primitives/bigfield/bigfield.hpp
@@ -59,17 +59,51 @@ template <typename Builder, typename T> class bigfield {
         field_t<Builder> element;
         uint256_t maximum_value;
     };
+
+    // Number of limbs used to represent a bigfield element in the binary basis
     static constexpr size_t NUM_LIMBS = 4;
 
     Builder* context;
+
+    /**
+     * @brief Represents a bigfield element in the binary basis. A bigfield element is represented as a combination of 4
+     * binary basis limbs: a = a[0] + a[1] * 2^L + a[2] * 2^2L + a[3] * 2^3L.
+     */
     mutable std::array<Limb, NUM_LIMBS> binary_basis_limbs;
+
+    /**
+     * @brief Represents a bigfield element in the prime basis: (a mod n) where n is the native modulus.
+     */
     mutable field_t<Builder> prime_basis_limb;
 
+    /**
+     * @brief Constructs a new bigfield object from two field elements representing the low and high bits.
+     *
+     * @param low_bits The field element representing the low 2L bits of the bigfield.
+     * @param high_bits The field element representing the high 2L bits of the bigfield.
+     * @param can_overflow Whether the bigfield can overflow the modulus.
+     * @param maximum_bitlength The maximum bitlength of the bigfield. If 0, it defaults to |p| (target modulus
+     * bitlength).
+     */
     bigfield(const field_t<Builder>& low_bits,
              const field_t<Builder>& high_bits,
              const bool can_overflow = false,
              const size_t maximum_bitlength = 0);
+
+    /**
+     * @brief Constructs a zero bigfield object: all limbs are set to zero.
+     *
+     * @details This constructor is used to create a bigfield element without any context. It is useful for creating
+     * bigfield elements that will be later assigned to a context.
+     */
     bigfield(Builder* parent_context = nullptr);
+
+    /**
+     * @brief Constructs a new bigfield object from a uint256_t value.
+     *
+     * @param parent_context The circuit context in which the bigfield element will be created.
+     * @param value The uint256_t value to be converted to a bigfield element.
+     */
     bigfield(Builder* parent_context, const uint256_t& value);
 
     explicit bigfield(const uint256_t& value)

--- a/barretenberg/cpp/src/barretenberg/stdlib/primitives/bigfield/bigfield_impl.hpp
+++ b/barretenberg/cpp/src/barretenberg/stdlib/primitives/bigfield/bigfield_impl.hpp
@@ -498,29 +498,6 @@ bigfield<Builder, T> bigfield<Builder, T>::add_two(const bigfield& add_a, const 
     return result;
 }
 
-// to make sure we don't go to negative values, add p before subtracting other
-/**
- * Subtraction operator.
- *
- * Like operator+, we use lazy reduction techniques to save on field reductions.
- *
- * Instead of computing `*this - other`, we compute offset X and compute:
- * `*this + X - other`
- * This ensures we do not underflow!
- *
- * Offset `X` will be a multiple of our bigfield modulus `p`
- *
- * i.e `X = m * p`
- *
- * It is NOT enough to ensure that the integer value of `*this + X - other` does not underflow.
- * We must ALSO ensure that each LIMB of the result does not underflow
- *
- * We must compute the MINIMUM value of `m` that ensures that none of the bigfield limbs will underflow!
- *
- * i.e. We must compute the MINIMUM value of `m` such that, for each limb `i`, the following result is positive:
- *
- * *this.limb[i] + X.limb[i] - other.limb[i]
- **/
 template <typename Builder, typename T>
 bigfield<Builder, T> bigfield<Builder, T>::operator-(const bigfield& other) const
 {

--- a/barretenberg/cpp/src/barretenberg/stdlib/primitives/bigfield/bigfield_impl.hpp
+++ b/barretenberg/cpp/src/barretenberg/stdlib/primitives/bigfield/bigfield_impl.hpp
@@ -2300,28 +2300,7 @@ void bigfield<Builder, T>::unsafe_evaluate_multiply_add(const bigfield& input_le
         ctx->decompose_into_default_range(lo.get_normalized_witness_index(), carry_lo_msb);
     }
 }
-/**
- * Evaluate a quadratic relation involving multiple multiplications
- *
- * i.e. evalaute:
- *
- * (left_0 * right_0) + ... + (left_n-1 * right_n-1) + ...to_add - (input_quotient * q + ...input_remainders) = 0
- *
- * This method supports multiple "remainders" because, when evaluating divisions, some of these remainders are terms
- * We're subtracting from our product (see msub_div for more details)
- *
- * The above quadratic relation can be evaluated using only a single quotient/remainder term.
- *
- * Params:
- *
- * `input_left`: left multiplication operands
- * `input_right` : right multiplication operands
- * `to_add` : vector of elements to add to the product
- * `input_quotient` : quotient
- * `input_remainders` : vector of remainders
- *
- * THIS METHOD IS UNSAFE TO USE IN CIRCUITS DIRECTLY AS IT LACKS OVERFLOW CHECKS.
- **/
+
 template <typename Builder, typename T>
 void bigfield<Builder, T>::unsafe_evaluate_multiple_multiply_add(const std::vector<bigfield>& input_left,
                                                                  const std::vector<bigfield>& input_right,

--- a/barretenberg/cpp/src/barretenberg/stdlib/primitives/bigfield/bigfield_impl.hpp
+++ b/barretenberg/cpp/src/barretenberg/stdlib/primitives/bigfield/bigfield_impl.hpp
@@ -2055,18 +2055,6 @@ template <typename Builder, typename T> void bigfield<Builder, T>::self_reduce()
     set_origin_tag(new_tag);
 } // namespace stdlib
 
-/**
- * Evaluate a multiply add identity with several added elements and several remainders
- *
- * i.e:
- *
- * input_left*input_to_mul + (to_add[0]..to_add[-1]) - input_quotient*modulus -
- * (input_remainders[0]+..+input_remainders[-1]) = 0 (mod CRT)
- *
- * See detailed explanation at https://hackmd.io/LoEG5nRHQe-PvstVaD51Yw?view
- *
- * THIS FUNCTION IS UNSAFE TO USE IN CIRCUITS AS IT DOES NOT PROTECT AGAINST CRT OVERFLOWS.
- * */
 template <typename Builder, typename T>
 void bigfield<Builder, T>::unsafe_evaluate_multiply_add(const bigfield& input_left,
                                                         const bigfield& input_to_mul,

--- a/barretenberg/cpp/src/barretenberg/stdlib/primitives/bigfield/bigfield_impl.hpp
+++ b/barretenberg/cpp/src/barretenberg/stdlib/primitives/bigfield/bigfield_impl.hpp
@@ -701,14 +701,6 @@ bigfield<Builder, T> bigfield<Builder, T>::operator-(const bigfield& other) cons
     return result;
 }
 
-/**
- * Evaluate a non-native field multiplication: (a * b = c mod p) where p == target_basis.modulus
- *
- * We compute quotient term `q` and remainder `c` and evaluate that:
- *
- * a * b - q * p - c = 0 mod modulus_u512 (binary basis modulus, currently 2**272)
- * a * b - q * p - c = 0 mod circuit modulus
- **/
 template <typename Builder, typename T>
 bigfield<Builder, T> bigfield<Builder, T>::operator*(const bigfield& other) const
 {

--- a/barretenberg/cpp/src/barretenberg/stdlib/primitives/bigfield/bigfield_impl.hpp
+++ b/barretenberg/cpp/src/barretenberg/stdlib/primitives/bigfield/bigfield_impl.hpp
@@ -308,22 +308,6 @@ template <typename Builder, typename T> uint512_t bigfield<Builder, T>::get_maxi
     return t0 + t1 + t2 + t3;
 }
 
-/**
- * @brief Add a field element to the lower limb. CAUTION (the element has to be constrained before using this
- * function)
- *
- * @details Sometimes we need to add a small constrained value to a bigfield element (for example, a boolean value),
- * but we don't want to construct a full bigfield element for that as it would take too many gates. If the maximum
- * value of the field element being added is small enough, we can simply add it to the lowest limb and increase its
- * maximum value. That will create 2 additional constraints instead of 5/3 needed to add 2 bigfield elements and
- * several needed to construct a bigfield element.
- *
- * @tparam Builder Builder
- * @tparam T Field Parameters
- * @param other Field element that will be added to the lower
- * @param other_maximum_value The maximum value of other
- * @return bigfield<Builder, T> Result
- */
 template <typename Builder, typename T>
 bigfield<Builder, T> bigfield<Builder, T>::add_to_lower_limb(const field_t<Builder>& other,
                                                              uint256_t other_maximum_value) const

--- a/barretenberg/cpp/src/barretenberg/stdlib/primitives/bigfield/bigfield_impl.hpp
+++ b/barretenberg/cpp/src/barretenberg/stdlib/primitives/bigfield/bigfield_impl.hpp
@@ -895,11 +895,7 @@ bigfield<Builder, T> bigfield<Builder, T>::div_check_denominator_nonzero(const s
 {
     return internal_div(numerators, denominator, true);
 }
-/**
- * Compute a * a = c mod p
- *
- * Slightly cheaper than operator* for Standard
- **/
+
 template <typename Builder, typename T> bigfield<Builder, T> bigfield<Builder, T>::sqr() const
 {
     reduction_check();

--- a/barretenberg/cpp/src/barretenberg/stdlib/primitives/bigfield/bigfield_impl.hpp
+++ b/barretenberg/cpp/src/barretenberg/stdlib/primitives/bigfield/bigfield_impl.hpp
@@ -1806,11 +1806,11 @@ template <typename Builder, typename T> void bigfield<Builder, T>::reduction_che
         return;
     }
 
-    uint256_t maximum_limb_value = get_maximum_unreduced_limb_value();
-    bool limb_overflow_test_0 = binary_basis_limbs[0].maximum_value > maximum_limb_value;
-    bool limb_overflow_test_1 = binary_basis_limbs[1].maximum_value > maximum_limb_value;
-    bool limb_overflow_test_2 = binary_basis_limbs[2].maximum_value > maximum_limb_value;
-    bool limb_overflow_test_3 = binary_basis_limbs[3].maximum_value > maximum_limb_value;
+    uint256_t maximum_unreduced_limb_value = get_maximum_unreduced_limb_value();
+    bool limb_overflow_test_0 = binary_basis_limbs[0].maximum_value > maximum_unreduced_limb_value;
+    bool limb_overflow_test_1 = binary_basis_limbs[1].maximum_value > maximum_unreduced_limb_value;
+    bool limb_overflow_test_2 = binary_basis_limbs[2].maximum_value > maximum_unreduced_limb_value;
+    bool limb_overflow_test_3 = binary_basis_limbs[3].maximum_value > maximum_unreduced_limb_value;
     if (get_maximum_value() > get_maximum_unreduced_value() || limb_overflow_test_0 || limb_overflow_test_1 ||
         limb_overflow_test_2 || limb_overflow_test_3) {
         self_reduce();
@@ -1820,12 +1820,14 @@ template <typename Builder, typename T> void bigfield<Builder, T>::reduction_che
 template <typename Builder, typename T> void bigfield<Builder, T>::sanity_check() const
 {
 
-    uint256_t maximum_limb_value = get_prohibited_maximum_limb_value();
-    bool limb_overflow_test_0 = binary_basis_limbs[0].maximum_value > maximum_limb_value;
-    bool limb_overflow_test_1 = binary_basis_limbs[1].maximum_value > maximum_limb_value;
-    bool limb_overflow_test_2 = binary_basis_limbs[2].maximum_value > maximum_limb_value;
-    bool limb_overflow_test_3 = binary_basis_limbs[3].maximum_value > maximum_limb_value;
-    ASSERT(!(get_maximum_value() > get_prohibited_maximum_value() || limb_overflow_test_0 || limb_overflow_test_1 ||
+    uint256_t prohibited_limb_value = get_prohibited_limb_value();
+    bool limb_overflow_test_0 = binary_basis_limbs[0].maximum_value > prohibited_limb_value;
+    bool limb_overflow_test_1 = binary_basis_limbs[1].maximum_value > prohibited_limb_value;
+    bool limb_overflow_test_2 = binary_basis_limbs[2].maximum_value > prohibited_limb_value;
+    bool limb_overflow_test_3 = binary_basis_limbs[3].maximum_value > prohibited_limb_value;
+    // max_val < sqrt(2^T * n)
+    // Note this is a static assertion, so it is not checked at runtime
+    ASSERT(!(get_maximum_value() > get_prohibited_value() || limb_overflow_test_0 || limb_overflow_test_1 ||
              limb_overflow_test_2 || limb_overflow_test_3));
 }
 

--- a/barretenberg/cpp/src/barretenberg/stdlib/primitives/bigfield/bigfield_impl.hpp
+++ b/barretenberg/cpp/src/barretenberg/stdlib/primitives/bigfield/bigfield_impl.hpp
@@ -1868,18 +1868,6 @@ template <typename Builder, typename T> bool_t<Builder> bigfield<Builder, T>::op
     return is_equal;
 }
 
-/**
- * REDUCTION CHECK
- *
- * When performing bigfield operations, we need to ensure the maximum value is less than:
- *      sqrt(2^{272} * native_modulus)
- *
- * We also need to ensure each binary basis limb is less than the maximum limb value
- *
- * This prevents our field arithmetic from overflowing the native modulus boundary, whilst ensuring we can
- * still use the chinese remainder theorem to validate field multiplications with a reduced number of range checks
- *
- **/
 template <typename Builder, typename T> void bigfield<Builder, T>::reduction_check() const
 {
 

--- a/barretenberg/cpp/src/barretenberg/stdlib/primitives/bigfield/bigfield_impl.hpp
+++ b/barretenberg/cpp/src/barretenberg/stdlib/primitives/bigfield/bigfield_impl.hpp
@@ -926,14 +926,6 @@ template <typename Builder, typename T> bigfield<Builder, T> bigfield<Builder, T
     return remainder;
 }
 
-/**
- * Compute a * a + ...to_add = b mod p
- *
- * We can chain multiple additions to a square/multiply with a single quotient/remainder.
- *
- * Chaining the additions here is cheaper than calling operator+ because we can combine some gates in
- *`evaluate_multiply_add`
- **/
 template <typename Builder, typename T>
 bigfield<Builder, T> bigfield<Builder, T>::sqradd(const std::vector<bigfield>& to_add) const
 {
@@ -1006,15 +998,6 @@ bigfield<Builder, T> bigfield<Builder, T>::sqradd(const std::vector<bigfield>& t
     return remainder;
 }
 
-/**
- * @brief Raise a bigfield to a power of an exponent. Note that the exponent must not exceed 32 bits and is
- * implicitly range constrained.
- *
- * @returns this ** (exponent)
- *
- * @todo TODO(https://github.com/AztecProtocol/barretenberg/issues/1014) Improve the efficiency of this function.
- */
-
 template <typename Builder, typename T> bigfield<Builder, T> bigfield<Builder, T>::pow(const size_t exponent) const
 {
     // Just return one immediately
@@ -1046,14 +1029,6 @@ template <typename Builder, typename T> bigfield<Builder, T> bigfield<Builder, T
     return accumulator;
 }
 
-/**
- * Compute a * b + ...to_add = c mod p
- *
- * @param to_mul Bigfield element to multiply by
- * @param to_add Vector of elements to add
- *
- * @return New bigfield elment c
- **/
 template <typename Builder, typename T>
 bigfield<Builder, T> bigfield<Builder, T>::madd(const bigfield& to_mul, const std::vector<bigfield>& to_add) const
 {

--- a/barretenberg/cpp/src/barretenberg/stdlib/primitives/bigfield/bigfield_impl.hpp
+++ b/barretenberg/cpp/src/barretenberg/stdlib/primitives/bigfield/bigfield_impl.hpp
@@ -134,19 +134,6 @@ bigfield<Builder, T>::bigfield(bigfield&& other)
     , prime_basis_limb(other.prime_basis_limb)
 {}
 
-/**
- * @brief Creates a bigfield element from a uint512_t.
- * Bigfield element is constructed as a witness and not a circuit constant
- *
- * @param ctx
- * @param value
- * @param can_overflow Can the input value have more than log2(modulus) bits?
- * @param maximum_bitlength Provide the explicit maximum bitlength if known. Otherwise bigfield max value will be
- * either log2(modulus) bits iff can_overflow = false, or (4 * NUM_LIMB_BITS) iff can_overflow = true
- * @return bigfield<Builder, T>
- *
- * @details This method is 1 gate more efficient than constructing from 2 field_ct elements.
- */
 template <typename Builder, typename T>
 bigfield<Builder, T> bigfield<Builder, T>::create_from_u512_as_witness(Builder* ctx,
                                                                        const uint512_t& value,

--- a/barretenberg/cpp/src/barretenberg/stdlib/primitives/bigfield/bigfield_impl.hpp
+++ b/barretenberg/cpp/src/barretenberg/stdlib/primitives/bigfield/bigfield_impl.hpp
@@ -1817,13 +1817,6 @@ template <typename Builder, typename T> void bigfield<Builder, T>::reduction_che
     }
 }
 
-/**
- * SANITY CHECK on a value that is about to interact with another value
- *
- * @details ASSERTs that the value of all limbs is less than or equal to the prohibited maximum value. Checks that the
- *maximum value of the whole element is also less than a prohibited maximum value
- *
- **/
 template <typename Builder, typename T> void bigfield<Builder, T>::sanity_check() const
 {
 

--- a/barretenberg/cpp/src/barretenberg/stdlib/primitives/bigfield/bigfield_impl.hpp
+++ b/barretenberg/cpp/src/barretenberg/stdlib/primitives/bigfield/bigfield_impl.hpp
@@ -745,12 +745,6 @@ bigfield<Builder, T> bigfield<Builder, T>::operator*(const bigfield& other) cons
     return remainder;
 }
 
-/**
- * Division operator. Create constraints for b!=0 by default. If you need a variant
- *without the zero check,  use div_without_denominator_check.
- *
- * To evaluate (a / b = c mod p), we instead evaluate (c * b = a mod p).
- **/
 template <typename Builder, typename T>
 bigfield<Builder, T> bigfield<Builder, T>::operator/(const bigfield& other) const
 {

--- a/barretenberg/cpp/src/barretenberg/stdlib/primitives/bigfield/bigfield_impl.hpp
+++ b/barretenberg/cpp/src/barretenberg/stdlib/primitives/bigfield/bigfield_impl.hpp
@@ -348,20 +348,6 @@ bigfield<Builder, T> bigfield<Builder, T>::add_to_lower_limb(const field_t<Build
     return result;
 }
 
-/**
- * @brief Adds two bigfield elements. Inputs are reduced to the modulus if necessary. Requires 4 gates if both elements
- * are witnesses.
- *
- * @details Naive addition of two bigfield elements would require 5 gates: 4 gates to add the binary basis limbs and 1
- * gate to add the prime basis limbs. However, if both elements are witnesses, we can use an optimised addition trick
- * that uses 4 gates instead of 5. In this case, we add the prime basis limbs and one of the binary basis limbs in a
- * single gate.
- *
- * @tparam Builder
- * @tparam T
- * @param other
- * @return bigfield<Builder, T>
- */
 template <typename Builder, typename T>
 bigfield<Builder, T> bigfield<Builder, T>::operator+(const bigfield& other) const
 {

--- a/barretenberg/cpp/src/barretenberg/stdlib/primitives/bigfield/bigfield_impl.hpp
+++ b/barretenberg/cpp/src/barretenberg/stdlib/primitives/bigfield/bigfield_impl.hpp
@@ -223,7 +223,7 @@ template <typename Builder, typename T> bigfield<Builder, T>::bigfield(const byt
         const uint256_t hi_nibble_shift = uint256_t(1) << 4;
         const field_t<Builder> sum = lo_nibble + (hi_nibble * hi_nibble_shift);
         sum.assert_equal(split_byte);
-        return std::make_pair<field_t<Builder>, field_t<Builder>>(lo_nibble, hi_nibble);
+        return std::make_pair(lo_nibble, hi_nibble);
     };
 
     const auto reconstruct_two_limbs = [&split_byte_into_nibbles](Builder* ctx,
@@ -236,7 +236,7 @@ template <typename Builder, typename T> bigfield<Builder, T>::bigfield(const byt
         const uint256_t lo_nibble_shift = uint256_t(1) << 64;
         field_t<Builder> hi_limb = hi_nibble + hi_bytes * hi_bytes_shift;
         field_t<Builder> lo_limb = lo_bytes + lo_nibble * lo_nibble_shift;
-        return std::make_pair<field_t<Builder>, field_t<Builder>>(lo_limb, hi_limb);
+        return std::make_pair(lo_limb, hi_limb);
     };
     Builder* ctx = bytes.get_context();
 

--- a/barretenberg/cpp/src/barretenberg/stdlib/primitives/bigfield/bigfield_impl.hpp
+++ b/barretenberg/cpp/src/barretenberg/stdlib/primitives/bigfield/bigfield_impl.hpp
@@ -456,16 +456,6 @@ bigfield<Builder, T> bigfield<Builder, T>::operator+(const bigfield& other) cons
     return result;
 }
 
-/**
- * @brief Create constraints for summing three
- * bigfield elements efficiently
- *
- * @tparam Builder
- * @tparam T
- * @param add_a
- * @param add_b
- * @return The sum of three terms
- */
 template <typename Builder, typename T>
 bigfield<Builder, T> bigfield<Builder, T>::add_two(const bigfield& add_a, const bigfield& add_b) const
 {

--- a/barretenberg/cpp/src/barretenberg/stdlib_circuit_builders/ultra_circuit_builder.cpp
+++ b/barretenberg/cpp/src/barretenberg/stdlib_circuit_builders/ultra_circuit_builder.cpp
@@ -1749,18 +1749,58 @@ std::array<uint32_t, 2> UltraCircuitBuilder_<ExecutionTrace>::evaluate_non_nativ
                         true);
     create_dummy_gate(blocks.arithmetic, this->zero_idx, this->zero_idx, this->zero_idx, lo_0_idx);
 
+    //
+    // a = (a3 || a2 || a1 || a0) = (a3 * 2^b + a2) * 2^b + (a1 * 2^b + a0)
+    // b = (b3 || b2 || b1 || b0) = (b3 * 2^b + b2) * 2^b + (b1 * 2^b + b0)
+    //
+    // Check if lo_0 was computed correctly.
+    // The gate structure for the auxiliary gates is as follows:
+    //
+    // | a1 | b1 | r0 | lo_0 | <-- product gate 1: check lo_0
+    // | a0 | b0 | a3 | b3   |
+    // | a2 | b2 | r3 | hi_0 |
+    // | a1 | b1 | r2 | hi_1 |
+    //
+    // Constaint: lo_0 = (a1 * b0 + a0 * b1) * 2^b  +  (a0 * b0) - r0
+    //              w4 = (w1 * w'2 + w'1 * w2) * 2^b + (w'1 * w'2) - w3
+    //
     blocks.aux.populate_wires(input.a[1], input.b[1], input.r[0], lo_0_idx);
     apply_aux_selectors(AUX_SELECTORS::NON_NATIVE_FIELD_1);
     ++this->num_gates;
 
+    //
+    // Check if hi_0 was computed correctly.
+    //
+    // | a1 | b1 | r0 | lo_0 |
+    // | a0 | b0 | a3 | b3   | <-- product gate 2: check hi_0
+    // | a2 | b2 | r3 | hi_0 |
+    // | a1 | b1 | r2 | hi_1 |
+    //
+    // Constaint: hi_0 = (a0 * b3 + a3 * b0 - r3) * 2^b + (a0 * b2 + a2 * b0) - r2
+    //             w'4 = (w1 * w4 + w2 * w3 - w'3) * 2^b + (w1 * w'2 + w'1 * w2) - w'3
+    //
     blocks.aux.populate_wires(input.a[0], input.b[0], input.a[3], input.b[3]);
     apply_aux_selectors(AUX_SELECTORS::NON_NATIVE_FIELD_2);
     ++this->num_gates;
 
+    //
+    // Check if hi_1 was computed correctly.
+    //
+    // | a1 | b1 | r0 | lo_0 |
+    // | a0 | b0 | a3 | b3   |
+    // | a2 | b2 | r3 | hi_0 | <-- product gate 3: check hi_1
+    // | a1 | b1 | r2 | hi_1 |
+    //
+    // Constaint: hi_1 = hi_0 + (a2 * b1 + a1 * b2) * 2^b + (a1 * b1)
+    //             w'4 = w4 + (w1 * w'2 + w'1 * w2) * 2^b + (w'1 * w'2)
+    //
     blocks.aux.populate_wires(input.a[2], input.b[2], input.r[3], hi_0_idx);
     apply_aux_selectors(AUX_SELECTORS::NON_NATIVE_FIELD_3);
     ++this->num_gates;
 
+    //
+    // Does nothing, but is used by the previous gate to read the hi_1 limb.
+    //
     blocks.aux.populate_wires(input.a[1], input.b[1], input.r[2], hi_1_idx);
     apply_aux_selectors(AUX_SELECTORS::NONE);
     ++this->num_gates;


### PR DESCRIPTION
- Adds a README file to bigfield class that explains the four main operations: `+, -, *, /`
- Adds documentation to some functions that was missing
- Move doxygen documentation from function implementation to declaration
- Minor changes to some function names

Note to reviewer: commit-wise review might be faster as each commit is self-contained and "small"