### PR TITLE
feat(avm): debug permutation builder

### DIFF
--- a/barretenberg/cpp/src/barretenberg/vm2/common/stringify.hpp
+++ b/barretenberg/cpp/src/barretenberg/vm2/common/stringify.hpp
@@ -8,6 +8,7 @@
 
 #include "barretenberg/numeric/uint128/uint128.hpp"
 #include "barretenberg/vm2/common/field.hpp"
+#include "barretenberg/vm2/generated/columns.hpp"
 
 namespace bb::avm2 {
 
@@ -28,14 +29,29 @@ std::string to_hex(T value)
 template <size_t N> std::string to_string(const std::array<FF, N>& arr)
 {
     std::ostringstream stream;
-    stream << "(";
+    stream << "{";
     for (size_t i = 0; i < N; ++i) {
         stream << field_to_string(arr[i]);
         if (i < N - 1) {
             stream << ", ";
         }
     }
-    stream << ")";
+    stream << "}";
+    return stream.str();
+}
+
+template <size_t N>
+std::string column_values_to_string(const std::array<FF, N>& arr, const std::array<ColumnAndShifts, N>& columns)
+{
+    std::ostringstream stream;
+    stream << "{";
+    for (size_t i = 0; i < N; ++i) {
+        stream << COLUMN_NAMES[static_cast<size_t>(columns[i])] << ": " << field_to_string(arr[i]);
+        if (i < N - 1) {
+            stream << ", ";
+        }
+    }
+    stream << "}";
     return stream.str();
 }
 

--- a/barretenberg/cpp/src/barretenberg/vm2/tracegen/lib/permutation_builder.hpp
+++ b/barretenberg/cpp/src/barretenberg/vm2/tracegen/lib/permutation_builder.hpp
@@ -1,5 +1,11 @@
 #pragma once
 
+#include <string>
+#include <unordered_set>
+
+#include "barretenberg/common/log.hpp"
+#include "barretenberg/vm2/common/map.hpp"
+#include "barretenberg/vm2/common/stringify.hpp"
 #include "barretenberg/vm2/tracegen/lib/interaction_builder.hpp"
 #include "barretenberg/vm2/tracegen/trace_container.hpp"
 
@@ -11,6 +17,75 @@ namespace bb::avm2::tracegen {
 template <typename PermutationSettings> class PermutationBuilder : public InteractionBuilderInterface {
   public:
     void process(TraceContainer& trace) override { SetDummyInverses<PermutationSettings>(trace); }
+};
+
+// Builds a permutation and performs additional checks.
+// Only use in tests and debugging. This is slow and memory intensive.
+template <typename PermutationSettings> class DebugPermutationBuilder : public PermutationBuilder<PermutationSettings> {
+  public:
+    using ArrayTuple = std::array<FF, PermutationSettings::COLUMNS_PER_SET>;
+
+    void process(TraceContainer& trace) override
+    {
+        PermutationBuilder<PermutationSettings>::process(trace);
+
+        // Collect the source and destination tuples.
+        source_tuples.clear();
+        trace.visit_column(PermutationSettings::SRC_SELECTOR, [&](uint32_t row, const FF&) {
+            auto src_values = trace.get_multiple(PermutationSettings::SRC_COLUMNS, row);
+            source_tuples[src_values].insert(row);
+        });
+        destination_tuples.clear();
+        trace.visit_column(PermutationSettings::DST_SELECTOR, [&](uint32_t row, const FF&) {
+            auto dst_values = trace.get_multiple(PermutationSettings::DST_COLUMNS, row);
+            destination_tuples[dst_values].insert(row);
+        });
+
+        auto build_error_message =
+            [&](const ArrayTuple& tuple, const auto& columns, const auto& src_rows, const auto& dst_rows) {
+                std::string error = "Failure to build permutation " + std::string(PermutationSettings::NAME) + ".\n";
+                error += format("Tuple ",
+                                column_values_to_string(tuple, columns),
+                                " has multiplicity ",
+                                src_rows.size(),
+                                " in the source, but ",
+                                dst_rows.size(),
+                                " in the destination.\n");
+                error += format("Source rows: ");
+                for (auto row : src_rows) {
+                    error += format(row, " ");
+                }
+                error += format("\n");
+                error += format("Destination rows: ");
+                for (auto row : dst_rows) {
+                    error += format(row, " ");
+                }
+                return error;
+            };
+
+        // Check that every source tuple is found in the destination with the same multiplicity.
+        for (const auto& [src_tuple, src_rows] : source_tuples) {
+            auto dst_rows = destination_tuples.contains(src_tuple) ? destination_tuples.at(src_tuple)
+                                                                   : std::unordered_set<uint32_t>();
+            if (src_rows.size() != dst_rows.size()) {
+                throw std::runtime_error(
+                    build_error_message(src_tuple, PermutationSettings::SRC_COLUMNS, src_rows, dst_rows));
+            }
+        }
+        // Check that every destination tuple is found in the source with the same multiplicity.
+        for (const auto& [dst_tuple, dst_rows] : destination_tuples) {
+            auto src_rows =
+                source_tuples.contains(dst_tuple) ? source_tuples.at(dst_tuple) : std::unordered_set<uint32_t>();
+            if (src_rows.size() != dst_rows.size()) {
+                throw std::runtime_error(
+                    build_error_message(dst_tuple, PermutationSettings::DST_COLUMNS, src_rows, dst_rows));
+            }
+        }
+    }
+
+  private:
+    unordered_flat_map<ArrayTuple, std::unordered_set<uint32_t>> source_tuples;
+    unordered_flat_map<ArrayTuple, std::unordered_set<uint32_t>> destination_tuples;
 };
 
 } // namespace bb::avm2::tracegen

--- a/bb-pilcom/bb-pil-backend/src/permutation_builder.rs
+++ b/bb-pilcom/bb-pil-backend/src/permutation_builder.rs
@@ -159,13 +159,15 @@ fn create_permutation_settings_data(permutation: &Permutation) -> Json {
     ]
     .to_vec();
 
-    perm_entities.extend(lhs_cols);
-    perm_entities.extend(rhs_cols);
+    perm_entities.extend(lhs_cols.clone());
+    perm_entities.extend(rhs_cols.clone());
 
     json!({
         "perm_name": permutation.name,
         "relation_name": permutation.owning_relation,
         "columns_per_set": columns_per_set,
+        "lhs_cols": lhs_cols,
+        "rhs_cols": rhs_cols,
         "lhs_selector": lhs_selector,
         "rhs_selector": rhs_selector,
         "perm_entities": perm_entities,

--- a/bb-pilcom/bb-pil-backend/templates/permutation.hpp.hbs
+++ b/bb-pilcom/bb-pil-backend/templates/permutation.hpp.hbs
@@ -25,6 +25,16 @@ class {{perm_name}}_settings {
     static constexpr Column SRC_SELECTOR = Column::{{lhs_selector}};
     static constexpr Column DST_SELECTOR = Column::{{rhs_selector}};
     static constexpr Column INVERSES = Column::{{inverses_col}};
+    static constexpr std::array<ColumnAndShifts, COLUMNS_PER_SET> SRC_COLUMNS = {
+        {{#each lhs_cols as |col|}}
+        ColumnAndShifts::{{col}}{{#unless @last}},{{/unless}}
+        {{/each}}
+    };
+    static constexpr std::array<ColumnAndShifts, COLUMNS_PER_SET> DST_COLUMNS = {
+        {{#each rhs_cols as |col|}}
+        ColumnAndShifts::{{col}}{{#unless @last}},{{/unless}}
+        {{/each}}
+    };
 
     template <typename AllEntities> static inline auto inverse_polynomial_is_computed_at_row(const AllEntities& in)
     {


### PR DESCRIPTION
Adds a new `DebugPermutationBuilder` that can be used in tests (and while debugging) to assert that the permutation is ok.

Example failure

```
Failure to build permutation PERM_KECCAKF1600_WRITE_TO_SLICE.
Tuple {keccak_memory_val00: 0x1, keccak_memory_val01: 0x2, keccak_memory_val02: 0x3, keccak_memory_val03: 0x4, keccak_memory_val04: 0x5, keccak_memory_val10: 0x6, keccak_memory_val11: 0x7, keccak_memory_val12: 0x8, keccak_memory_val13: 0x9, keccak_memory_val14: 0xa, keccak_memory_val20: 0xb, keccak_memory_val21: 0xc, keccak_memory_val22: 0xd, keccak_memory_val23: 0xe, keccak_memory_val24: 0xf, keccak_memory_val30: 0x10, keccak_memory_val31: 0x11, keccak_memory_val32: 0x12, keccak_memory_val33: 0x13, keccak_memory_val34: 0x14, keccak_memory_val40: 0x15, keccak_memory_val41: 0x16, keccak_memory_val42: 0x17, keccak_memory_val43: 0x18, keccak_memory_val44: 0x19, keccak_memory_clk: 0x1d, keccak_memory_rw: 0x0, keccak_memory_addr: 0x1, keccak_memory_space_id: 0x1} has multiplicity 0 in the source, but 1 in the destination.
Source rows: 
Destination rows: 1 
```

Fixes #14759.
