### PR TITLE
fix: Handle missed l1-to-l2 messages in archiver

### DIFF
--- a/yarn-project/archiver/src/archiver/archiver.ts
+++ b/yarn-project/archiver/src/archiver/archiver.ts
@@ -433,7 +433,7 @@ export class Archiver extends (EventEmitter as new () => ArchiverEmitter) implem
   private async handleL1ToL2Messages(
     messagesSyncPoint: L1BlockId,
     currentL1BlockNumber: bigint,
-    currentL1BlockHash: Buffer32,
+    _currentL1BlockHash: Buffer32,
   ) {
     this.log.trace(`Handling L1 to L2 messages from ${messagesSyncPoint.l1BlockNumber} to ${currentL1BlockNumber}.`);
     if (currentL1BlockNumber <= messagesSyncPoint.l1BlockNumber) {
@@ -459,10 +459,6 @@ export class Archiver extends (EventEmitter as new () => ArchiverEmitter) implem
       this.log.debug(
         `No L1 to L2 messages to query between L1 blocks ${messagesSyncPoint.l1BlockNumber} and ${currentL1BlockNumber}.`,
       );
-      await this.store.setMessageSynchedL1Block({
-        l1BlockHash: currentL1BlockHash,
-        l1BlockNumber: currentL1BlockNumber,
-      });
       return;
     }
 

--- a/yarn-project/end-to-end/src/e2e_epochs/epochs_l1_reorgs.test.ts
+++ b/yarn-project/end-to-end/src/e2e_epochs/epochs_l1_reorgs.test.ts
@@ -3,7 +3,7 @@ import type { AztecNodeService } from '@aztec/aztec-node';
 import { AztecAddress, type AztecNode, Fr, type Logger, retryUntil } from '@aztec/aztec.js';
 import { Blob } from '@aztec/blob-lib';
 import { createBlobSinkClient } from '@aztec/blob-sink/client';
-import { createExtendedL1Client } from '@aztec/ethereum';
+import type { ExtendedViemWalletClient } from '@aztec/ethereum';
 import type { ChainMonitor, ChainMonitorEventMap, Delayer } from '@aztec/ethereum/test';
 import { timesAsync } from '@aztec/foundation/collection';
 import { AbortError } from '@aztec/foundation/error';
@@ -14,7 +14,6 @@ import type { ProverNode } from '@aztec/prover-node';
 import { jest } from '@jest/globals';
 import 'jest-extended';
 import { keccak256, parseTransaction } from 'viem';
-import { generatePrivateKey, privateKeyToAccount } from 'viem/accounts';
 
 import { sendL1ToL2Message } from '../fixtures/l1_to_l2_messaging.js';
 import type { EndToEndContext } from '../fixtures/utils.js';
@@ -53,269 +52,287 @@ describe('e2e_epochs/epochs_l1_reorgs', () => {
     await test.teardown();
   });
 
-  it('prunes L2 blocks if a proof is removed due to an L1 reorg', async () => {
-    // Wait until we have proven something and the nodes have caught up
-    const epochDurationSeconds = test.constants.epochDuration * test.constants.slotDuration;
-    logger.warn(`Waiting for initial proof to land`);
-    const provenBlockEvent = await executeTimeout(
-      signal => {
-        return new Promise<{ l2ProvenBlockNumber: number; l1BlockNumber: number }>((res, rej) => {
-          const handleMsg = (...[ev]: ChainMonitorEventMap['l2-block-proven']) => {
-            if (ev.l2ProvenBlockNumber !== 0) {
-              res(ev);
-              monitor.off('l2-block-proven', handleMsg);
-            }
-          };
-
-          signal.onabort = () => {
-            monitor.off('l2-block-proven', handleMsg);
-            rej(new AbortError());
-          };
-          monitor.on('l2-block-proven', handleMsg);
-        });
-      },
-      epochDurationSeconds * 4 * 1000,
-    );
-
-    // Stop the prover node so it doesn't re-submit the proof after we've removed it
-    logger.warn(`Proof for block ${provenBlockEvent.l2ProvenBlockNumber} mined, stopping prover node`);
-    await proverNode.stop();
-
-    // And remove the proof from L1
-    await context.cheatCodes.eth.reorgTo(provenBlockEvent.l1BlockNumber - 1);
-    expect((await monitor.run(true)).l2ProvenBlockNumber).toEqual(0);
-
-    // Wait until the end of the proof submission window for the first epoch
-    await test.waitUntilEndOfProofSubmissionWindow(0);
-
-    // Ensure that a new node sees the reorg
-    logger.warn(`Syncing new node to test reorg`);
-    const newNode = await executeTimeout(() => test.createNonValidatorNode(), 10_000, `new node sync`);
-    expect(await newNode.getProvenBlockNumber()).toEqual(0);
-
-    // Latest block number seen by the node may be the current one, or one less if it was *just* mined.
-    // This is because the call to createNonValidatorNode will block until the initial sync is completed,
-    // but the initial sync is done to the latest L1 block _at the time the initial sync starts_. So a new
-    // node may have appeared while the initial sync runs, that's why we account for a small span of blocks.
-    const currentBlock = (await monitor.run(true)).l2BlockNumber;
-    expect(await newNode.getBlockNumber()).toBeWithin(currentBlock - 1, currentBlock + 1);
-
-    // And check that the old node has processed the reorg as well
-    logger.warn(`Testing old node after reorg`);
-    expect(await node.getProvenBlockNumber()).toEqual(0);
-    expect(await node.getBlockNumber()).toBeWithin(currentBlock - 1, currentBlock + 1);
-
-    logger.warn(`Test succeeded`);
-    await newNode.stop();
-  });
-
-  it('does not prune if a second proof lands within the submission window after the first one is reorged out', async () => {
-    // Wait until we have proven something and the nodes have caught up
-    logger.warn(`Waiting for initial proof to land`);
-    const provenBlock = await test.waitUntilProvenL2BlockNumber(1);
-    await retryUntil(() => node.getProvenBlockNumber().then(p => p >= provenBlock), 'node sync', 10, 0.1);
-
-    // Remove the proof from L1 but do not change the block number
-    await context.cheatCodes.eth.reorgWithReplacement(1);
-    await expect(monitor.run(true).then(m => m.l2ProvenBlockNumber)).resolves.toEqual(0);
-
-    // Create another prover node so it submits a proof
-    await test.createProverNode();
-
-    // Wait until the end of the proof submission window for the first epoch
-    await test.waitUntilEndOfProofSubmissionWindow(0);
-
-    // And expect that the other node has submitted a proof
-    await expect(monitor.run(true).then(m => m.l2ProvenBlockNumber)).resolves.toBeGreaterThanOrEqual(1);
-
-    // Check that the node has followed along
-    logger.warn(`Testing old node`);
-    const currentBlock = monitor.l2BlockNumber;
-    expect(await node.getProvenBlockNumber()).toBeGreaterThanOrEqual(1);
-    expect(await node.getBlockNumber()).toBeWithin(currentBlock - 1, currentBlock + 1);
-
-    logger.warn(`Test succeeded`);
-  });
-
-  it('restores L2 blocks if a proof is added due to an L1 reorg', async () => {
-    // Next proof shall not land
-    proverDelayer.cancelNextTx();
-
-    // Expect pending chain to advance, so there's something to be pruned
-    await retryUntil(() => node.getBlockNumber().then(b => b > 1), 'node sync', 60, 0.1);
-
-    // Wait until the end of the proof submission window for the first epoch
-    await test.waitUntilEndOfProofSubmissionWindow(0);
-    await monitor.run(true);
-    logger.warn(`End of epoch 0 submission window (L1 block ${await monitor.run(true).then(m => m.l1BlockNumber)}).`);
-
-    // Grab the prover's tx to submit it later as part of a reorg and stop the prover
-    const [proofTx] = proverDelayer.getCancelledTxs();
-    expect(proofTx).toBeDefined();
-    await proverNode.stop();
-
-    // Wait for the node to prune
-    const syncTimeout = L2_SLOT_DURATION_IN_S * 2;
-    await retryUntil(() => node.getBlockNumber().then(b => b <= 1), 'node sync', syncTimeout, 0.1);
-    expect(monitor.l2ProvenBlockNumber).toEqual(0);
-    expect(await node.getProvenBlockNumber()).toEqual(0);
-
-    // But not all is lost, for a reorg gets the proof back on chain!
-    logger.warn(`Reorging proof back (L1 block ${await monitor.run(true).then(m => m.l1BlockNumber)}).`);
-    await context.cheatCodes.eth.reorgWithReplacement(4, [[proofTx]]);
-    const proofTxReceipt = await test.l1Client.getTransactionReceipt({ hash: keccak256(proofTx) });
-    expect(proofTxReceipt.status).toEqual('success');
-
-    // Monitor should update to see the proof
-    const { l2BlockNumber, l2ProvenBlockNumber } = await monitor.run(true);
-    expect(l2BlockNumber).toBeGreaterThan(1);
-    expect(l2ProvenBlockNumber).toBeGreaterThan(0);
-
-    // And so the node undoes its reorg
-    await retryUntil(() => node.getBlockNumber().then(b => b >= l2BlockNumber), 'node sync', syncTimeout, 0.1);
-    await retryUntil(() => node.getProvenBlockNumber().then(b => b >= l2ProvenBlockNumber), 'proof sync', 1, 0.1);
-
-    logger.warn(`Test succeeded`);
-  });
-
-  it('prunes L2 blocks from pending chain removed from L1 due to an L1 reorg', async () => {
-    // Wait until L2_BLOCK_NUMBER is mined and node synced, and stop the sequencer
-    const L2_BLOCK_NUMBER = 3;
-    await test.waitUntilL2BlockNumber(L2_BLOCK_NUMBER, L2_SLOT_DURATION_IN_S * (L2_BLOCK_NUMBER + 4));
-    expect(monitor.l2BlockNumber).toEqual(L2_BLOCK_NUMBER);
-    const l1BlockNumber = monitor.l1BlockNumber;
-    await retryUntil(() => node.getBlockNumber().then(b => b === L2_BLOCK_NUMBER), 'node sync', 10, 0.1);
-
-    logger.warn(`Reached block ${L2_BLOCK_NUMBER}. Stopping block production.`);
-    await context.aztecNodeAdmin!.setConfig({ minTxsPerBlock: 100 });
-
-    // Remove the L2 block from L1
-    const l1BlocksToReorg = monitor.l1BlockNumber - l1BlockNumber + 1;
-    await context.cheatCodes.eth.reorgWithReplacement(l1BlocksToReorg);
-    expect(await monitor.run(true).then(monitor => monitor.l2BlockNumber)).toEqual(L2_BLOCK_NUMBER - 1);
-    logger.warn(`Removed block ${L2_BLOCK_NUMBER} via L1 reorg`);
-
-    // And expect the node to prune the block
-    await retryUntil(() => node.getBlockNumber().then(b => b === L2_BLOCK_NUMBER - 1), 'node sync', 30, 0.1);
-  });
-
-  it('sees new blocks added in an L1 reorg', async () => {
-    // Wait until the block *before* L2_BLOCK_NUMBER is mined and node synced
-    const L2_BLOCK_NUMBER = 3;
-    await test.waitUntilL2BlockNumber(L2_BLOCK_NUMBER - 1, L2_SLOT_DURATION_IN_S * (L2_BLOCK_NUMBER + 4));
-    expect(monitor.l2BlockNumber).toEqual(L2_BLOCK_NUMBER - 1);
-    await retryUntil(() => node.getBlockNumber().then(b => b === L2_BLOCK_NUMBER - 1), 'node sync', 5, 0.1);
-
-    // Cancel the next tx to be mined and pause the sequencer
-    sequencerDelayer.cancelNextTx();
-    await retryUntil(() => sequencerDelayer.getCancelledTxs().length, 'next block tx', L2_SLOT_DURATION_IN_S * 2, 0.1);
-    const [l2BlockTx] = sequencerDelayer.getCancelledTxs();
-    await context.aztecNodeAdmin!.setConfig({ minTxsPerBlock: 100 });
-
-    // Save the L1 block number when the L2 block would have been mined
-    const l1BlockNumber = monitor.l1BlockNumber;
-
-    // Wait until a few more L1 blocks go by
-    await retryUntil(() => monitor.l1BlockNumber > l1BlockNumber + 1, 'l1 block number', L1_BLOCK_TIME_IN_S * 4, 0.1);
-    await retryUntil(() => archiver.getL1BlockNumber() > l1BlockNumber + 1, 'archiver sync', 10, 0.1);
-    expect(await node.getBlockNumber()).toEqual(L2_BLOCK_NUMBER - 1);
-
-    // Manually update the archiver's L1 syncpoint to ensure we look back when needed
-    // Otherwise this test just passes because we do not update the L1 syncpoint in the archiver since there are no new blocks
-    await archiver.dataStore.setBlockSynchedL1BlockNumber(BigInt(archiver.getL1BlockNumber()));
-
-    // Now trigger the reorg. Note that we cannot use reorgWithReplacement here for the reorg, due to an anvil bug with
-    // blob txs (now fixed, we can just update its version), so we reorg, then replay the tx, and then mine.
-    const reorgDepth = monitor.l1BlockNumber - l1BlockNumber;
-    expect(reorgDepth).toBeGreaterThan(0);
-    logger.warn(`Triggering ${reorgDepth}-block L1 reorg to include L2 block`);
-    await context.cheatCodes.eth.reorg(reorgDepth);
-    expect(await context.cheatCodes.eth.blockNumber()).toEqual(l1BlockNumber);
-    logger.warn(`Sending L2 block tx to L1`);
-    const txHash = await test.l1Client.sendRawTransaction({ serializedTransaction: l2BlockTx });
-    await context.cheatCodes.eth.mine(reorgDepth);
-
-    // Check that the tx was reorged in and succeeded. We log the trace to debug any issues with the tx.
-    const txReceipt = await test.l1Client.getTransactionReceipt({ hash: txHash });
-    logger.warn(`L2 block tx receipt`, { receipt: txReceipt });
-    logger.warn(`L2 block tx trace`, { trace: await context.cheatCodes.eth.traceTransaction(txHash) });
-    expect(txReceipt.status).toEqual('success');
-    expect(txReceipt.blobGasUsed).toBeGreaterThan(0n);
-    expect(await monitor.run(true).then(m => m.l2BlockNumber)).toEqual(L2_BLOCK_NUMBER);
-
-    // We also need to send the blob to the sink, so the node can get it
-    logger.warn(`Sending blobs to blob sink`);
-    const blobs = await getBlobs(l2BlockTx);
-    const blobSinkClient = createBlobSinkClient(context.config);
-    await blobSinkClient.sendBlobsToBlobSink(txReceipt.blockHash, blobs);
-
-    // And wait for the node to see the new block
-    await retryUntil(() => node.getBlockNumber().then(b => b === L2_BLOCK_NUMBER), 'node sync', 5, 0.1);
-  });
-
-  it('updates L1 to L2 messages changed due to an L1 reorg', async () => {
-    const account = privateKeyToAccount(generatePrivateKey());
-    const l1ClientForMessages = createExtendedL1Client(
-      [...test.l1Client.chain.rpcUrls.default.http],
-      account,
-      test.l1Client.chain,
-    );
-
-    while (true) {
-      const fundingTx = await test.l1Client.sendTransaction({
-        to: l1ClientForMessages.account.address,
-        value: BigInt(1e18),
-      });
-
-      const receipt = await test.l1Client.waitForTransactionReceipt({ hash: fundingTx });
-      if (receipt.transactionHash === fundingTx && receipt.status === 'success') {
-        break;
+  describe('blocks', () => {
+    const getBlobs = (serializedTx: `0x${string}`) => {
+      const parsedTx = parseTransaction(serializedTx);
+      if (parsedTx.sidecars === false) {
+        throw new Error('No sidecars found in tx');
       }
-    }
+      return Promise.all(parsedTx.sidecars!.map(sidecar => Blob.fromEncodedBlobBuffer(hexToBuffer(sidecar.blob))));
+    };
+
+    it('prunes L2 blocks if a proof is removed due to an L1 reorg', async () => {
+      // Wait until we have proven something and the nodes have caught up
+      const epochDurationSeconds = test.constants.epochDuration * test.constants.slotDuration;
+      logger.warn(`Waiting for initial proof to land`);
+      const provenBlockEvent = await executeTimeout(
+        signal => {
+          return new Promise<{ l2ProvenBlockNumber: number; l1BlockNumber: number }>((res, rej) => {
+            const handleMsg = (...[ev]: ChainMonitorEventMap['l2-block-proven']) => {
+              if (ev.l2ProvenBlockNumber !== 0) {
+                res(ev);
+                monitor.off('l2-block-proven', handleMsg);
+              }
+            };
+
+            signal.onabort = () => {
+              monitor.off('l2-block-proven', handleMsg);
+              rej(new AbortError());
+            };
+            monitor.on('l2-block-proven', handleMsg);
+          });
+        },
+        epochDurationSeconds * 4 * 1000,
+      );
+
+      // Stop the prover node so it doesn't re-submit the proof after we've removed it
+      logger.warn(`Proof for block ${provenBlockEvent.l2ProvenBlockNumber} mined, stopping prover node`);
+      await proverNode.stop();
+
+      // And remove the proof from L1
+      await context.cheatCodes.eth.reorgTo(provenBlockEvent.l1BlockNumber - 1);
+      expect((await monitor.run(true)).l2ProvenBlockNumber).toEqual(0);
+
+      // Wait until the end of the proof submission window for the first epoch
+      await test.waitUntilEndOfProofSubmissionWindow(0);
+
+      // Ensure that a new node sees the reorg
+      logger.warn(`Syncing new node to test reorg`);
+      const newNode = await executeTimeout(() => test.createNonValidatorNode(), 10_000, `new node sync`);
+      expect(await newNode.getProvenBlockNumber()).toEqual(0);
+
+      // Latest block number seen by the node may be the current one, or one less if it was *just* mined.
+      // This is because the call to createNonValidatorNode will block until the initial sync is completed,
+      // but the initial sync is done to the latest L1 block _at the time the initial sync starts_. So a new
+      // node may have appeared while the initial sync runs, that's why we account for a small span of blocks.
+      const currentBlock = (await monitor.run(true)).l2BlockNumber;
+      expect(await newNode.getBlockNumber()).toBeWithin(currentBlock - 1, currentBlock + 1);
+
+      // And check that the old node has processed the reorg as well
+      logger.warn(`Testing old node after reorg`);
+      expect(await node.getProvenBlockNumber()).toEqual(0);
+      expect(await node.getBlockNumber()).toBeWithin(currentBlock - 1, currentBlock + 1);
+
+      logger.warn(`Test succeeded`);
+      await newNode.stop();
+    });
+
+    it('does not prune if a second proof lands within the submission window after the first one is reorged out', async () => {
+      // Wait until we have proven something and the nodes have caught up
+      logger.warn(`Waiting for initial proof to land`);
+      const provenBlock = await test.waitUntilProvenL2BlockNumber(1);
+      await retryUntil(() => node.getProvenBlockNumber().then(p => p >= provenBlock), 'node sync', 10, 0.1);
+
+      // Remove the proof from L1 but do not change the block number
+      await context.cheatCodes.eth.reorgWithReplacement(1);
+      await expect(monitor.run(true).then(m => m.l2ProvenBlockNumber)).resolves.toEqual(0);
+
+      // Create another prover node so it submits a proof
+      await test.createProverNode();
+
+      // Wait until the end of the proof submission window for the first epoch
+      await test.waitUntilEndOfProofSubmissionWindow(0);
+
+      // And expect that the other node has submitted a proof
+      await expect(monitor.run(true).then(m => m.l2ProvenBlockNumber)).resolves.toBeGreaterThanOrEqual(1);
+
+      // Check that the node has followed along
+      logger.warn(`Testing old node`);
+      const currentBlock = monitor.l2BlockNumber;
+      expect(await node.getProvenBlockNumber()).toBeGreaterThanOrEqual(1);
+      expect(await node.getBlockNumber()).toBeWithin(currentBlock - 1, currentBlock + 1);
+
+      logger.warn(`Test succeeded`);
+    });
+
+    it('restores L2 blocks if a proof is added due to an L1 reorg', async () => {
+      // Next proof shall not land
+      proverDelayer.cancelNextTx();
+
+      // Expect pending chain to advance, so there's something to be pruned
+      await retryUntil(() => node.getBlockNumber().then(b => b > 1), 'node sync', 60, 0.1);
+
+      // Wait until the end of the proof submission window for the first epoch
+      await test.waitUntilEndOfProofSubmissionWindow(0);
+      await monitor.run(true);
+      logger.warn(`End of epoch 0 submission window (L1 block ${await monitor.run(true).then(m => m.l1BlockNumber)}).`);
+
+      // Grab the prover's tx to submit it later as part of a reorg and stop the prover
+      const [proofTx] = proverDelayer.getCancelledTxs();
+      expect(proofTx).toBeDefined();
+      await proverNode.stop();
+
+      // Wait for the node to prune
+      const syncTimeout = L2_SLOT_DURATION_IN_S * 2;
+      await retryUntil(() => node.getBlockNumber().then(b => b <= 1), 'node sync', syncTimeout, 0.1);
+      expect(monitor.l2ProvenBlockNumber).toEqual(0);
+      expect(await node.getProvenBlockNumber()).toEqual(0);
+
+      // But not all is lost, for a reorg gets the proof back on chain!
+      logger.warn(`Reorging proof back (L1 block ${await monitor.run(true).then(m => m.l1BlockNumber)}).`);
+      await context.cheatCodes.eth.reorgWithReplacement(4, [[proofTx]]);
+      const proofTxReceipt = await test.l1Client.getTransactionReceipt({ hash: keccak256(proofTx) });
+      expect(proofTxReceipt.status).toEqual('success');
+
+      // Monitor should update to see the proof
+      const { l2BlockNumber, l2ProvenBlockNumber } = await monitor.run(true);
+      expect(l2BlockNumber).toBeGreaterThan(1);
+      expect(l2ProvenBlockNumber).toBeGreaterThan(0);
+
+      // And so the node undoes its reorg
+      await retryUntil(() => node.getBlockNumber().then(b => b >= l2BlockNumber), 'node sync', syncTimeout, 0.1);
+      await retryUntil(() => node.getProvenBlockNumber().then(b => b >= l2ProvenBlockNumber), 'proof sync', 1, 0.1);
+
+      logger.warn(`Test succeeded`);
+    });
+
+    it('prunes L2 blocks from pending chain removed from L1 due to an L1 reorg', async () => {
+      // Wait until L2_BLOCK_NUMBER is mined and node synced, and stop the sequencer
+      const L2_BLOCK_NUMBER = 3;
+      await test.waitUntilL2BlockNumber(L2_BLOCK_NUMBER, L2_SLOT_DURATION_IN_S * (L2_BLOCK_NUMBER + 4));
+      expect(monitor.l2BlockNumber).toEqual(L2_BLOCK_NUMBER);
+      const l1BlockNumber = monitor.l1BlockNumber;
+      await retryUntil(() => node.getBlockNumber().then(b => b === L2_BLOCK_NUMBER), 'node sync', 10, 0.1);
+
+      logger.warn(`Reached block ${L2_BLOCK_NUMBER}. Stopping block production.`);
+      await context.aztecNodeAdmin!.setConfig({ minTxsPerBlock: 100 });
+
+      // Remove the L2 block from L1
+      const l1BlocksToReorg = monitor.l1BlockNumber - l1BlockNumber + 1;
+      await context.cheatCodes.eth.reorgWithReplacement(l1BlocksToReorg);
+      expect(await monitor.run(true).then(monitor => monitor.l2BlockNumber)).toEqual(L2_BLOCK_NUMBER - 1);
+      logger.warn(`Removed block ${L2_BLOCK_NUMBER} via L1 reorg`);
+
+      // And expect the node to prune the block
+      await retryUntil(() => node.getBlockNumber().then(b => b === L2_BLOCK_NUMBER - 1), 'node sync', 30, 0.1);
+    });
+
+    it('sees new blocks added in an L1 reorg', async () => {
+      // Wait until the block *before* L2_BLOCK_NUMBER is mined and node synced
+      const L2_BLOCK_NUMBER = 3;
+      await test.waitUntilL2BlockNumber(L2_BLOCK_NUMBER - 1, L2_SLOT_DURATION_IN_S * (L2_BLOCK_NUMBER + 4));
+      expect(monitor.l2BlockNumber).toEqual(L2_BLOCK_NUMBER - 1);
+      await retryUntil(() => node.getBlockNumber().then(b => b === L2_BLOCK_NUMBER - 1), 'node sync', 5, 0.1);
+
+      // Cancel the next tx to be mined and pause the sequencer
+      sequencerDelayer.cancelNextTx();
+      await retryUntil(() => sequencerDelayer.getCancelledTxs().length, 'next block', L2_SLOT_DURATION_IN_S * 2, 0.1);
+      const [l2BlockTx] = sequencerDelayer.getCancelledTxs();
+      await context.aztecNodeAdmin!.setConfig({ minTxsPerBlock: 100 });
+
+      // Save the L1 block number when the L2 block would have been mined
+      const l1BlockNumber = monitor.l1BlockNumber;
+
+      // Wait until a few more L1 blocks go by
+      await retryUntil(() => monitor.l1BlockNumber > l1BlockNumber + 1, 'l1 block number', L1_BLOCK_TIME_IN_S * 4, 0.1);
+      await retryUntil(() => archiver.getL1BlockNumber() > l1BlockNumber + 1, 'archiver sync', 10, 0.1);
+      expect(await node.getBlockNumber()).toEqual(L2_BLOCK_NUMBER - 1);
+
+      // Manually update the archiver's L1 syncpoint to ensure we look back when needed
+      // Otherwise this test just passes because we do not update the L1 syncpoint in the archiver since there are no new blocks
+      await archiver.dataStore.setBlockSynchedL1BlockNumber(BigInt(archiver.getL1BlockNumber()));
+
+      // Now trigger the reorg. Note that we cannot use reorgWithReplacement here for the reorg, due to an anvil bug with
+      // blob txs (now fixed, we can just update its version), so we reorg, then replay the tx, and then mine.
+      const reorgDepth = monitor.l1BlockNumber - l1BlockNumber;
+      expect(reorgDepth).toBeGreaterThan(0);
+      logger.warn(`Triggering ${reorgDepth}-block L1 reorg to include L2 block`);
+      await context.cheatCodes.eth.reorg(reorgDepth);
+      expect(await context.cheatCodes.eth.blockNumber()).toEqual(l1BlockNumber);
+      logger.warn(`Sending L2 block tx to L1`);
+      const txHash = await test.l1Client.sendRawTransaction({ serializedTransaction: l2BlockTx });
+      await context.cheatCodes.eth.mine(reorgDepth);
+
+      // Check that the tx was reorged in and succeeded. We log the trace to debug any issues with the tx.
+      const txReceipt = await test.l1Client.getTransactionReceipt({ hash: txHash });
+      logger.warn(`L2 block tx receipt`, { receipt: txReceipt });
+      logger.warn(`L2 block tx trace`, { trace: await context.cheatCodes.eth.traceTransaction(txHash) });
+      expect(txReceipt.status).toEqual('success');
+      expect(txReceipt.blobGasUsed).toBeGreaterThan(0n);
+      expect(await monitor.run(true).then(m => m.l2BlockNumber)).toEqual(L2_BLOCK_NUMBER);
+
+      // We also need to send the blob to the sink, so the node can get it
+      logger.warn(`Sending blobs to blob sink`);
+      const blobs = await getBlobs(l2BlockTx);
+      const blobSinkClient = createBlobSinkClient(context.config);
+      await blobSinkClient.sendBlobsToBlobSink(txReceipt.blockHash, blobs);
+
+      // And wait for the node to see the new block
+      await retryUntil(() => node.getBlockNumber().then(b => b === L2_BLOCK_NUMBER), 'node sync', 5, 0.1);
+    });
+  });
+
+  describe('messages', () => {
+    let l1Client: ExtendedViemWalletClient;
+    let l1ClientDelayer: Delayer;
+
+    beforeEach(async () => {
+      ({ client: l1Client, delayer: l1ClientDelayer } = await test.createL1Client());
+    });
 
     const sendMessage = async () =>
       sendL1ToL2Message(
         { recipient: await AztecAddress.random(), content: Fr.random(), secretHash: Fr.random() },
-        {
-          l1Client: l1ClientForMessages,
-          l1ContractAddresses: context.deployL1ContractsValues.l1ContractAddresses,
-        },
+        { l1ContractAddresses: context.deployL1ContractsValues.l1ContractAddresses, l1Client },
       );
 
-    // Send 3 messages and wait for archiver sync
-    logger.warn(`Sending 3 cross chain messages`);
-    const msgs = await timesAsync(3, async (i: number) => {
-      logger.warn(`Sending message ${i + 1}`);
-      return await sendMessage();
+    it('updates L1 to L2 messages changed due to an L1 reorg', async () => {
+      // Send 3 messages and wait for archiver sync
+      logger.warn(`Sending 3 cross chain messages`);
+      const msgs = await timesAsync(3, async (i: number) => {
+        logger.warn(`Sending message ${i + 1}`);
+        return await sendMessage();
+      });
+      logger.warn(`Sent messages on L1 blocks ${msgs.map(m => m.txReceipt.blockNumber)}`);
+
+      await retryUntil(
+        () => node.isL1ToL2MessageSynced(msgs.at(-1)!.msgHash),
+        'message sync',
+        msgs.length * L1_BLOCK_TIME_IN_S * 2,
+        1,
+      );
+
+      // Reorg the last message out
+      logger.warn(`Triggering reorg to remove last message`);
+      const l1BlockNumber = await monitor.run(true).then(m => m.l1BlockNumber);
+      const l1BlocksToReorg = l1BlockNumber - Number(msgs.at(-1)!.txReceipt.blockNumber) + 1;
+      await context.cheatCodes.eth.reorg(l1BlocksToReorg);
+      const newMsg = await sendMessage();
+      logger.warn(`Sent new message on L1 block ${newMsg.txReceipt.blockNumber}`);
+
+      // New msg gets synced, and old one is out
+      await retryUntil(() => node.isL1ToL2MessageSynced(newMsg.msgHash), 'new message sync', L1_BLOCK_TIME_IN_S * 6, 1);
+      expect(await node.isL1ToL2MessageSynced(msgs[0].msgHash)).toBe(true);
+      expect(await node.isL1ToL2MessageSynced(msgs.at(-1)!.msgHash)).toBe(false);
     });
-    logger.warn(`Sent messages on L1 blocks ${msgs.map(m => m.txReceipt.blockNumber)}`);
 
-    await retryUntil(
-      () => node.isL1ToL2MessageSynced(msgs.at(-1)!.msgHash),
-      'message sync',
-      msgs.length * L1_BLOCK_TIME_IN_S * 2,
-      1,
-    );
+    it('handles missed message inserted by an L1 reorg', async () => {
+      // Send a message and wait for node to sync it
+      logger.warn(`Sending first cross chain message`);
+      const firstMsg = await sendMessage();
+      logger.warn(`Sent first message on L1 block ${firstMsg.txReceipt.blockNumber}`);
+      await retryUntil(() => node.isL1ToL2MessageSynced(firstMsg.msgHash), '1st msg sync', L1_BLOCK_TIME_IN_S * 3, 1);
+      logger.warn(`Synced first message`);
 
-    // Reorg the last message out
-    logger.warn(`Triggering reorg to remove last message`);
-    const l1BlockNumber = await monitor.run(true).then(m => m.l1BlockNumber);
-    const l1BlocksToReorg = l1BlockNumber - Number(msgs.at(-1)!.txReceipt.blockNumber) + 1;
-    await context.cheatCodes.eth.reorg(l1BlocksToReorg);
-    const newMsg = await sendMessage();
-    logger.warn(`Sent new message on L1 block ${newMsg.txReceipt.blockNumber}`);
+      // Next message shall not land
+      l1ClientDelayer.cancelNextTx();
+      const secondMsgPromise = sendMessage();
+      await retryUntil(() => l1ClientDelayer.getCancelledTxs().length, 'next msg tx', L1_BLOCK_TIME_IN_S, 0.1);
 
-    // New msg gets synced, and old one is out
-    await retryUntil(() => node.isL1ToL2MessageSynced(newMsg.msgHash), 'new message sync', L1_BLOCK_TIME_IN_S * 6, 1);
-    expect(await node.isL1ToL2MessageSynced(msgs[0].msgHash)).toBe(true);
-    expect(await node.isL1ToL2MessageSynced(msgs.at(-1)!.msgHash)).toBe(false);
+      // Wait until the archiver moves the syncpoint forward
+      const l1BlockNumber = await monitor.run(true).then(m => m.l1BlockNumber);
+      await retryUntil(() => archiver.getL1BlockNumber() > l1BlockNumber, 'archiver sync', L1_BLOCK_TIME_IN_S * 2, 0.1);
+
+      // Now trigger the reorg, where we insert the second message
+      logger.warn(`Triggering reorg to insert second message`);
+      const reorgDepth = (await monitor.run(true).then(m => m.l1BlockNumber)) - l1BlockNumber;
+      await context.cheatCodes.eth.reorgWithReplacement(reorgDepth, [[l1ClientDelayer.getCancelledTxs()[0]]]);
+      const secondMsg = await secondMsgPromise;
+
+      // Archiver should see the new message and should be able to accept a third one on top, without any rolling hash issues
+      logger.warn(`Reorged-in second message on L1 block ${secondMsg.txReceipt.blockNumber}. Sending third message.`);
+      const thirdMsg = await sendMessage();
+      await retryUntil(() => node.isL1ToL2MessageSynced(thirdMsg.msgHash), '3rd msg sync', L1_BLOCK_TIME_IN_S * 3, 1);
+    });
   });
 });
-
-function getBlobs(serializedTx: `0x${string}`) {
-  const parsedTx = parseTransaction(serializedTx);
-  if (parsedTx.sidecars === false) {
-    throw new Error('No sidecars found in tx');
-  }
-  return Promise.all(parsedTx.sidecars!.map(sidecar => Blob.fromEncodedBlobBuffer(hexToBuffer(sidecar.blob))));
-}


### PR DESCRIPTION
Fixes how the archiver handles a missed L1-to-L2 message caused by an L1 reorg. The archiver was updating the L1 syncpoint (ie last L1 block checked) when there was no changes in the Inbox state, which means that if a new message landed _before_ the syncpoint due to an L1 reorg, the archiver would not see it. 

This PR changes it so the syncpoint is only updated when messages are actually retrieved. A downside for this change is that `inbox.getState` gets called on L1 on every archiver loop, instead of once per L1 block, but we can revisit when (if) we optimize the archiver's usage of L1 RPC.