### PR TITLE
fix: reenable protocol vk caching. fix bad l1-contracts cache

### DIFF
--- a/ci3/cache_content_hash
+++ b/ci3/cache_content_hash
@@ -26,7 +26,7 @@ for arg in "$@"; do
   elif [[ "$arg" == ^* ]]; then
     # Add as pattern literally
     rebuild_patterns+="$arg"$'\n'
-  elif
+  else
     # Ensure the folder exists, and add folder as pattern relative to repo root
     if [[ ! -d "$arg" ]]; then
       echo_stderr "Error: Directory '$arg' does not exist."

--- a/ci3/cache_content_hash
+++ b/ci3/cache_content_hash
@@ -20,15 +20,18 @@ PLATFORM_TAG="${PLATFORM_TAG:-${OSTYPE:-unknown}-$(uname -m)}"
 rebuild_patterns=()
 for arg in "$@"; do
   if [[ -f "$arg" ]]; then
+    # If the file is a rebuild patterns file, read it and add its contents to the patterns.
     rebuild_patterns+=$(cat "$arg")
     rebuild_patterns+=$'\n'
-  else
-    # Ensure the folder exists
+  elif [[ "$arg" == ^* ]]; then
+    # Add as pattern literally
+    rebuild_patterns+="$arg"$'\n'
+  elif
+    # Ensure the folder exists, and add folder as pattern relative to repo root
     if [[ ! -d "$arg" ]]; then
-      echo "Error: Directory '$arg' does not exist."
+      echo_stderr "Error: Directory '$arg' does not exist."
       exit 1
     fi
-    # Add it as a pattern relative to repo root
     arg=$(realpath --relative-to="$(git rev-parse --show-toplevel)" "$arg")
     rebuild_patterns+="$arg"$'\n'
   fi

--- a/ci3/cache_content_hash
+++ b/ci3/cache_content_hash
@@ -23,6 +23,13 @@ for arg in "$@"; do
     rebuild_patterns+=$(cat "$arg")
     rebuild_patterns+=$'\n'
   else
+    # Ensure the folder exists
+    if [[ ! -d "$arg" ]]; then
+      echo "Error: Directory '$arg' does not exist."
+      exit 1
+    fi
+    # Add it as a pattern relative to repo root
+    arg=$(realpath --relative-to="$(git rev-parse --show-toplevel)" "$arg")
     rebuild_patterns+="$arg"$'\n'
   fi
 done
@@ -51,6 +58,8 @@ if [ -n "$diff" ] && [ "$AZTEC_CACHE_COMMIT" == "HEAD" ]; then
   echo "disabled-cache"
   exit 0
 fi
+
+echo "$AWK_PATTERN">&2
 
 # Calculate a content hash for matched files
 # Use git ls-tree and AWK to filter files matching the rebuild patterns and extract their hashes

--- a/ci3/cache_content_hash
+++ b/ci3/cache_content_hash
@@ -59,8 +59,6 @@ if [ -n "$diff" ] && [ "$AZTEC_CACHE_COMMIT" == "HEAD" ]; then
   exit 0
 fi
 
-echo "$AWK_PATTERN">&2
-
 # Calculate a content hash for matched files
 # Use git ls-tree and AWK to filter files matching the rebuild patterns and extract their hashes
 # Sort the hashes and compute the content hash

--- a/noir-projects/noir-protocol-circuits/bootstrap.sh
+++ b/noir-projects/noir-protocol-circuits/bootstrap.sh
@@ -51,7 +51,7 @@ function compile {
   echo_stderr "Hash preimage: $NOIR_HASH-$program_hash"
   hash=$(hash_str "$NOIR_HASH-$program_hash")
 
-  if [ "${USE_CIRCUITS_CACHE:-0}" -eq 0 ] || ! cache_download circuit-$hash.tar.gz 1>&2; then
+  if ! cache_download circuit-$hash.tar.gz 1>&2; then
     SECONDS=0
     rm -f $json_path
     # TODO(#10754): Remove --skip-brillig-constraints-check


### PR DESCRIPTION
It was likely the culprit of a few mysterious prover full failures. It was broken in the ci3.3 merge. It was just not relying on noir-protocol-circuits at all.
Hazard to turn back on noir-protocol-circuits vk caching.