### PR TITLE
test: let there be gse tests

### DIFF
--- a/l1-contracts/src/core/libraries/Errors.sol
+++ b/l1-contracts/src/core/libraries/Errors.sol
@@ -139,9 +139,6 @@ library Errors {
   error Staking__IncorrectGovProposer(uint256);
   error Staking__GovernanceAlreadySet();
 
-  // GSE
-  error GSE__EmptyVoter();
-
   // Fee Juice Portal
   error FeeJuicePortal__AlreadyInitialized(); // 0xc7a172fe
   error FeeJuicePortal__InvalidInitialization(); // 0xfd9b3208

--- a/l1-contracts/src/core/libraries/rollup/StakingLib.sol
+++ b/l1-contracts/src/core/libraries/rollup/StakingLib.sol
@@ -113,7 +113,7 @@ library StakingLib {
 
     // If we are the canonical at the time of the proposal we also cast those votes.
     if (store.gse.getCanonicalAt(ts) == address(this)) {
-      address magic = store.gse.CANONICAL_MAGIC_ADDRESS();
+      address magic = store.gse.getCanonicalMagicAddress();
       vp = store.gse.getVotingPowerAt(magic, ts);
       store.gse.voteWithCanonical(_proposalId, vp, true);
     }

--- a/l1-contracts/src/governance/GSE.sol
+++ b/l1-contracts/src/governance/GSE.sol
@@ -65,7 +65,6 @@ interface IGSE is IGSECore {
   function balanceOf(address _instance, address _attester) external view returns (uint256);
   function effectiveBalanceOf(address _instance, address _attester) external view returns (uint256);
   function supplyOf(address _instance) external view returns (uint256);
-  function effectiveSupplyOfAt(address _instance, Timestamp _ts) external view returns (uint256);
   function totalSupply() external view returns (uint256);
   function getConfig(address _instance, address _attester)
     external
@@ -90,6 +89,7 @@ interface IGSE is IGSECore {
     view
     returns (address);
   function getPowerUsed(address _delegatee, uint256 _proposalId) external view returns (uint256);
+  function getCanonicalMagicAddress() external view returns (address);
 }
 
 contract GSECore is IGSECore, Ownable {
@@ -397,7 +397,6 @@ contract GSECore is IGSECore, Ownable {
    * @param _support    - True to support the proposal, false otherwise
    */
   function _vote(address _voter, uint256 _proposalId, uint256 _amount, bool _support) internal {
-    require(_voter != address(0), Errors.GSE__EmptyVoter());
     Timestamp ts = _pendingThrough(_proposalId);
     delegation.usePower(_voter, _proposalId, ts, _amount);
     getGovernance().vote(_proposalId, _amount, _support);
@@ -470,19 +469,6 @@ contract GSE is IGSE, GSECore {
       balance += delegation.getBalanceOf(CANONICAL_MAGIC_ADDRESS, _attester);
     }
     return balance;
-  }
-
-  function effectiveSupplyOfAt(address _instance, Timestamp _ts)
-    external
-    view
-    override(IGSE)
-    returns (uint256)
-  {
-    uint256 supply = delegation.getSupplyOf(_instance);
-    if (getCanonicalAt(_ts) == _instance) {
-      supply += delegation.getSupplyOf(CANONICAL_MAGIC_ADDRESS);
-    }
-    return supply;
   }
 
   function supplyOf(address _instance) external view override(IGSE) returns (uint256) {
@@ -566,6 +552,10 @@ contract GSE is IGSE, GSECore {
     return delegation.getPowerUsed(_delegatee, _proposalId);
   }
 
+  function getCanonicalMagicAddress() external pure override(IGSE) returns (address) {
+    return CANONICAL_MAGIC_ADDRESS;
+  }
+
   function getVotingPowerAt(address _delegatee, Timestamp _timestamp)
     public
     view
@@ -632,11 +622,11 @@ contract GSE is IGSE, GSECore {
   function _getInstanceStoreWithAttester(address _instance, address _attester)
     internal
     view
-    returns (InstanceStaking storage store, bool attesterExists, address instanceAddress)
+    returns (InstanceStaking storage, bool, address)
   {
-    store = instances[_instance];
-    attesterExists = store.attesters.contains(_attester);
-    instanceAddress = _instance;
+    InstanceStaking storage store = instances[_instance];
+    bool attesterExists = store.attesters.contains(_attester);
+    address instanceAddress = _instance;
 
     if (
       !attesterExists && getCanonical() == _instance

--- a/l1-contracts/src/governance/GSE.sol
+++ b/l1-contracts/src/governance/GSE.sol
@@ -53,10 +53,6 @@ interface IGSE is IGSECore {
     external
     view
     returns (uint256);
-  function getEffectiveVotingPowerAt(address _attester, Timestamp _timestamp)
-    external
-    view
-    returns (uint256);
 
   function getWithdrawer(address _instance, address _attester)
     external
@@ -486,22 +482,6 @@ contract GSE is IGSE, GSECore {
     returns (address)
   {
     return delegation.getDelegatee(_instance, _attester);
-  }
-
-  /**
-   * @notice  The effective power includes the power delegated to the canonical
-   */
-  function getEffectiveVotingPowerAt(address _delegatee, Timestamp _timestamp)
-    external
-    view
-    override(IGSE)
-    returns (uint256)
-  {
-    uint256 power = delegation.getVotingPowerAt(_delegatee, _timestamp);
-    if (getCanonicalAt(_timestamp) == _delegatee) {
-      power += delegation.getVotingPowerAt(CANONICAL_MAGIC_ADDRESS, _timestamp);
-    }
-    return power;
   }
 
   function getVotingPower(address _delegatee) external view override(IGSE) returns (uint256) {

--- a/l1-contracts/src/governance/GSEPayload.sol
+++ b/l1-contracts/src/governance/GSEPayload.sol
@@ -4,7 +4,6 @@ pragma solidity >=0.8.27;
 
 import {IGSE} from "@aztec/governance/GSE.sol";
 import {Errors} from "@aztec/governance/libraries/Errors.sol";
-import {Timestamp} from "@aztec/shared/libraries/TimeMath.sol";
 import {IPayload} from "./interfaces/IPayload.sol";
 import {IProposerPayload} from "./interfaces/IProposerPayload.sol";
 
@@ -55,8 +54,11 @@ contract GSEPayload is IProposerPayload {
    */
   function amIValid() external view override(IProposerPayload) returns (bool) {
     uint256 totalSupply = GSE.totalSupply();
-    uint256 supplyOf = GSE.effectiveSupplyOfAt(GSE.getCanonical(), Timestamp.wrap(block.timestamp));
-    require(supplyOf > totalSupply * 2 / 3, Errors.GovernanceProposer__GSEPayloadInvalid());
+    address canonical = GSE.getCanonical();
+    address magicCanonical = GSE.getCanonicalMagicAddress();
+    uint256 supplyOfInstance = GSE.supplyOf(canonical) + GSE.supplyOf(magicCanonical);
+
+    require(supplyOfInstance > totalSupply * 2 / 3, Errors.GovernanceProposer__GSEPayloadInvalid());
     return true;
   }
 }

--- a/l1-contracts/src/governance/libraries/Errors.sol
+++ b/l1-contracts/src/governance/libraries/Errors.sol
@@ -79,7 +79,6 @@ library Errors {
   error GSE__FailedToRemove(address);
   error GSE__InstanceDoesNotExist(address);
   error GSE__NotWithdrawer(address, address);
-  error GSE__EmptyVoter();
   error GSE__OutOfBounds(uint256, uint256);
   error GSE__FatalError(string);
 

--- a/l1-contracts/test/builder/GseBuilder.sol
+++ b/l1-contracts/test/builder/GseBuilder.sol
@@ -1,0 +1,116 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright 2024 Aztec Labs.
+// solhint-disable comprehensive-interface
+pragma solidity >=0.8.27;
+
+import {GSE} from "@aztec/governance/GSE.sol";
+import {TestBase} from "@test/base/Base.sol";
+
+import {TestERC20} from "@aztec/mock/TestERC20.sol";
+import {Governance} from "@aztec/governance/Governance.sol";
+import {Registry} from "@aztec/governance/Registry.sol";
+import {RewardDistributor} from "@aztec/governance/RewardDistributor.sol";
+import {GovernanceProposer} from "@aztec/governance/proposer/GovernanceProposer.sol";
+
+struct Flags {
+  bool openFloodgates;
+}
+
+struct Values {
+  uint256 govProposerN;
+  uint256 govProposerM;
+}
+
+struct Config {
+  address owner;
+  TestERC20 testERC20;
+  GSE gse;
+  Governance governance;
+  Registry registry;
+  RewardDistributor rewardDistributor;
+  Values values;
+  Flags flags;
+}
+
+contract GSEBuilder is TestBase {
+  Config internal config;
+
+  constructor() {
+    config.values.govProposerN = 1;
+    config.values.govProposerM = 1;
+    config.flags.openFloodgates = true;
+  }
+
+  function setOpenFloodgates(bool _openFloodgates) public returns (GSEBuilder) {
+    config.flags.openFloodgates = _openFloodgates;
+    return this;
+  }
+
+  function setGovProposerN(uint256 _govProposerN) public returns (GSEBuilder) {
+    config.values.govProposerN = _govProposerN;
+    return this;
+  }
+
+  function setGovProposerM(uint256 _govProposerM) public returns (GSEBuilder) {
+    config.values.govProposerM = _govProposerM;
+    return this;
+  }
+
+  function deploy() public returns (GSEBuilder) {
+    if (address(config.testERC20) == address(0)) {
+      config.testERC20 = new TestERC20("test", "TEST", address(this));
+      vm.label(address(config.testERC20), "TestERC20");
+    }
+
+    if (address(config.gse) == address(0)) {
+      config.gse = new GSE(address(this), config.testERC20);
+      vm.label(address(config.gse), "GSE");
+    }
+
+    if (address(config.registry) == address(0)) {
+      config.registry = new Registry(address(this), config.testERC20);
+      config.rewardDistributor = RewardDistributor(address(config.registry.getRewardDistributor()));
+      config.testERC20.mint(
+        address(config.rewardDistributor), 1e6 * config.rewardDistributor.BLOCK_REWARD()
+      );
+      vm.label(address(config.registry), "Registry");
+      vm.label(address(config.rewardDistributor), "RewardDistributor");
+    }
+
+    GovernanceProposer proposer = new GovernanceProposer(
+      config.registry, config.gse, config.values.govProposerN, config.values.govProposerM
+    );
+    config.governance = new Governance(config.testERC20, address(proposer), address(config.gse));
+    vm.label(address(config.governance), "Governance");
+    vm.label(address(proposer), "GovernanceProposer");
+
+    vm.prank(config.gse.owner());
+    config.gse.setGovernance(config.governance);
+
+    if (config.flags.openFloodgates) {
+      vm.prank(address(config.governance));
+      config.governance.openFloodgates();
+
+      assertEq(config.governance.isAllDepositsAllowed(), true);
+    }
+
+    vm.startPrank(config.registry.owner());
+    config.registry.updateGovernance(address(config.governance));
+    config.registry.transferOwnership(address(config.governance));
+    vm.stopPrank();
+
+    vm.startPrank(config.gse.owner());
+    config.gse.transferOwnership(address(config.governance));
+    vm.stopPrank();
+
+    vm.startPrank(config.testERC20.owner());
+    config.testERC20.transferOwnership(address(config.governance));
+    vm.stopPrank();
+
+    return this;
+  }
+
+  function getConfig() public view returns (Config memory) {
+    return config;
+  }
+}

--- a/l1-contracts/test/delegation/minimal.t.sol
+++ b/l1-contracts/test/delegation/minimal.t.sol
@@ -36,7 +36,7 @@ contract MinimalDelegationTest is GSEBase {
 
   function setUp() public override {
     super.setUp();
-    canonical = gse.CANONICAL_MAGIC_ADDRESS();
+    canonical = gse.getCanonicalMagicAddress();
     depositAmount = ROLLUP.getDepositAmount();
 
     vm.label(canonical, "canonical");

--- a/l1-contracts/test/delegation/minimal.t.sol
+++ b/l1-contracts/test/delegation/minimal.t.sol
@@ -259,11 +259,7 @@ contract MinimalDelegationTest is GSEBase {
   ) internal view {
     assertEq(gse.getVotingPowerAt(canonical, _ts), _canonical, "voting power canonical");
     assertEq(gse.getVotingPowerAt(_instance, _ts), _specific, "voting power specific");
-    assertEq(
-      gse.getEffectiveVotingPowerAt(_instance, _ts),
-      _specific + _canonical,
-      "effective voting power"
-    );
+    assertEq(_instance, gse.getCanonicalAt(_ts), "instance != canonical");
   }
 
   function _checkInstanceNonCanonical(address _instance, uint256 _specific, Timestamp _ts)
@@ -271,6 +267,6 @@ contract MinimalDelegationTest is GSEBase {
     view
   {
     assertEq(gse.getVotingPowerAt(_instance, _ts), _specific, "voting power specific");
-    assertEq(gse.getEffectiveVotingPowerAt(_instance, _ts), _specific, "effective voting power");
+    assertNotEq(_instance, gse.getCanonicalAt(_ts), "instance == canonical");
   }
 }

--- a/l1-contracts/test/governance/gse/gse/addRollup.t.sol
+++ b/l1-contracts/test/governance/gse/gse/addRollup.t.sol
@@ -1,0 +1,101 @@
+// SPDX-License-Identifier: UNLICENSED
+pragma solidity >=0.8.27;
+
+import {WithGSE} from "./base.sol";
+import {Ownable} from "@oz/access/Ownable.sol";
+import {Errors} from "@aztec/governance/libraries/Errors.sol";
+import {Timestamp} from "@aztec/shared/libraries/TimeMath.sol";
+
+contract AddRollupTest is WithGSE {
+  address internal caller;
+
+  function test_WhenCallerNeqOwner(address _caller) external {
+    // it reverts
+
+    vm.assume(_caller != gse.owner());
+
+    vm.prank(_caller);
+    vm.expectRevert(abi.encodeWithSelector(Ownable.OwnableUnauthorizedAccount.selector, _caller));
+    gse.addRollup(address(0));
+  }
+
+  modifier whenCallerEqOwner() {
+    caller = gse.owner();
+    _;
+  }
+
+  function test_GivenRollupEq0() external whenCallerEqOwner {
+    // it reverts
+    vm.prank(caller);
+    vm.expectRevert(abi.encodeWithSelector(Errors.GSE__InvalidRollupAddress.selector, address(0)));
+    gse.addRollup(address(0));
+  }
+
+  modifier givenRollupNeq0(address _rollup) {
+    vm.assume(_rollup != address(0));
+    vm.assume(!gse.isRollupRegistered(_rollup));
+    _;
+  }
+
+  function test_GivenRollupAlreadyRegistered(address _rollup)
+    external
+    whenCallerEqOwner
+    givenRollupNeq0(_rollup)
+  {
+    // it reverts
+
+    // We add it once
+    vm.prank(caller);
+    gse.addRollup(_rollup);
+
+    // We try to add it again
+    vm.prank(caller);
+    vm.expectRevert(abi.encodeWithSelector(Errors.GSE__RollupAlreadyRegistered.selector, _rollup));
+    gse.addRollup(_rollup);
+  }
+
+  function test_GivenRollupNotRegistered(
+    address _rollup,
+    address _rollup2,
+    uint256 _ts1,
+    uint256 _ts2
+  ) external whenCallerEqOwner givenRollupNeq0(_rollup) givenRollupNeq0(_rollup2) {
+    // it adds rollup to instances
+    // it sets rollup exists to true
+    // it pushes rollup to canonical with timestamp
+
+    vm.assume(_rollup != _rollup2);
+
+    vm.label(_rollup, "Rollup1");
+    vm.label(_rollup2, "Rollup2");
+
+    uint256 ts1 = bound(_ts1, 1000, 2000);
+    uint256 ts2 = bound(_ts2, ts1 + 1, ts1 + 2000);
+
+    assertEq(gse.isRollupRegistered(_rollup), false);
+    assertEq(gse.isRollupRegistered(_rollup2), false);
+
+    vm.warp(ts1);
+
+    vm.prank(caller);
+    gse.addRollup(_rollup);
+
+    assertEq(gse.isRollupRegistered(_rollup), true);
+    assertEq(gse.getCanonical(), _rollup);
+
+    vm.warp(ts2);
+
+    vm.prank(caller);
+    gse.addRollup(_rollup2);
+
+    assertEq(gse.isRollupRegistered(_rollup2), true);
+    assertEq(gse.getCanonical(), _rollup2);
+
+    emit log_named_address("canonical", address(gse.getCanonical()));
+    emit log_named_address("canonicalAt", address(gse.getCanonicalAt(Timestamp.wrap(ts1))));
+    emit log_named_address("canonicalAt2", address(gse.getCanonicalAt(Timestamp.wrap(ts2))));
+
+    assertEq(gse.getCanonicalAt(Timestamp.wrap(ts1)), _rollup);
+    assertEq(gse.getCanonicalAt(Timestamp.wrap(ts2)), _rollup2);
+  }
+}

--- a/l1-contracts/test/governance/gse/gse/addRollup.tree
+++ b/l1-contracts/test/governance/gse/gse/addRollup.tree
@@ -1,0 +1,13 @@
+AddRollupTest
+├── when caller neq owner
+│   └── it reverts
+└── when caller eq owner
+    ├── given rollup eq 0
+    │   └── it reverts
+    └── given rollup neq 0
+        ├── given rollup already registered
+        │   └── it reverts
+        └── given rollup not registered
+            ├── it adds rollup to instances
+            ├── it sets rollup exists to true
+            └── it pushes rollup to canonical with timestamp

--- a/l1-contracts/test/governance/gse/gse/base.sol
+++ b/l1-contracts/test/governance/gse/gse/base.sol
@@ -1,0 +1,40 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright 2024 Aztec Labs.
+pragma solidity >=0.8.27;
+
+import {GSE} from "@aztec/governance/GSE.sol";
+import {TestBase} from "@test/base/Base.sol";
+import {GSEBuilder} from "@test/builder/GseBuilder.sol";
+import {TestERC20} from "@aztec/mock/TestERC20.sol";
+import {Governance} from "@aztec/governance/Governance.sol";
+
+contract WithGSE is TestBase {
+  GSE internal gse;
+  TestERC20 internal stakingAsset;
+  Governance internal governance;
+
+  function setUp() public virtual {
+    GSEBuilder builder = new GSEBuilder().deploy();
+    gse = builder.getConfig().gse;
+    vm.label(address(gse), "GSE");
+    stakingAsset = TestERC20(address(gse.STAKING_ASSET()));
+    governance = Governance(address(gse.getGovernance()));
+  }
+
+  function cheat_deposit(
+    address _instance,
+    address _attester,
+    address _withdrawer,
+    bool _onCanonical
+  ) public {
+    uint256 depositAmount = gse.DEPOSIT_AMOUNT();
+
+    vm.prank(stakingAsset.owner());
+    stakingAsset.mint(address(_instance), depositAmount);
+
+    vm.startPrank(_instance);
+    stakingAsset.approve(address(gse), depositAmount);
+    gse.deposit(_attester, _withdrawer, _onCanonical);
+    vm.stopPrank();
+  }
+}

--- a/l1-contracts/test/governance/gse/gse/delegate.t.sol
+++ b/l1-contracts/test/governance/gse/gse/delegate.t.sol
@@ -1,0 +1,101 @@
+// SPDX-License-Identifier: UNLICENSED
+pragma solidity >=0.8.27;
+
+import {WithGSE} from "./base.sol";
+import {Errors} from "@aztec/governance/libraries/Errors.sol";
+import {TestERC20} from "@aztec/mock/TestERC20.sol";
+
+contract DelegateTest is WithGSE {
+  function test_GivenInstanceIsNotRegistered(
+    address _instance,
+    address _attester,
+    address _delegatee
+  ) external {
+    // it reverts
+
+    vm.assume(gse.isRollupRegistered(_instance) == false);
+
+    vm.expectRevert(abi.encodeWithSelector(Errors.GSE__InstanceDoesNotExist.selector, _instance));
+    gse.delegate(_instance, _attester, _delegatee);
+  }
+
+  modifier givenInstanceIsRegistered(address _instance) {
+    vm.assume(_instance != address(0) && _instance != gse.getCanonicalMagicAddress());
+
+    vm.prank(gse.owner());
+    gse.addRollup(_instance);
+
+    _;
+  }
+
+  function test_GivenCallerIsNotWithdrawer(
+    address _instance,
+    address _attester,
+    address _delegatee,
+    address _withdrawer
+  ) external givenInstanceIsRegistered(_instance) {
+    // it reverts
+
+    vm.assume(_withdrawer != _attester);
+    vm.assume(_attester != address(0));
+    vm.assume(_delegatee != address(0));
+
+    TestERC20 testERC20 = TestERC20(address(gse.STAKING_ASSET()));
+    uint256 depositAmount = gse.DEPOSIT_AMOUNT();
+    vm.prank(gse.owner());
+    testERC20.mint(address(_instance), depositAmount);
+
+    vm.prank(_instance);
+    testERC20.approve(address(gse), depositAmount);
+
+    vm.prank(_instance);
+    gse.deposit(_attester, _withdrawer, false);
+
+    vm.prank(_attester);
+    vm.expectRevert(
+      abi.encodeWithSelector(Errors.GSE__NotWithdrawer.selector, _withdrawer, _attester)
+    );
+    gse.delegate(_instance, _attester, _delegatee);
+
+    address magic = gse.getCanonicalMagicAddress();
+
+    vm.prank(_attester);
+    vm.expectRevert(
+      abi.encodeWithSelector(Errors.GSE__NotWithdrawer.selector, address(0), _attester)
+    );
+    gse.delegate(magic, _attester, _delegatee);
+  }
+
+  function test_GivenCallerIsWithdrawer(
+    address _instance,
+    address _attester,
+    address _delegatee,
+    address _withdrawer,
+    bool _isCanonical
+  ) external givenInstanceIsRegistered(_instance) {
+    // it delegates voting power
+
+    vm.assume(_withdrawer != _attester);
+    vm.assume(_attester != address(0));
+    vm.assume(_delegatee != address(0));
+
+    TestERC20 testERC20 = TestERC20(address(gse.STAKING_ASSET()));
+    uint256 depositAmount = gse.DEPOSIT_AMOUNT();
+    vm.prank(gse.owner());
+    testERC20.mint(address(_instance), depositAmount);
+
+    vm.prank(_instance);
+    testERC20.approve(address(gse), depositAmount);
+
+    vm.prank(_instance);
+    gse.deposit(_attester, _withdrawer, _isCanonical);
+
+    address addr = _isCanonical ? gse.getCanonicalMagicAddress() : _instance;
+
+    vm.prank(_withdrawer);
+    gse.delegate(addr, _attester, _delegatee);
+
+    // Lookup the delegatee
+    assertEq(gse.getDelegatee(addr, _attester), _delegatee);
+  }
+}

--- a/l1-contracts/test/governance/gse/gse/delegate.tree
+++ b/l1-contracts/test/governance/gse/gse/delegate.tree
@@ -1,0 +1,8 @@
+DelegateTest
+├── given instance is not registered
+│   └── it reverts
+└── given instance is registered
+    ├── given caller is not withdrawer
+    │   └── it reverts
+    └── given caller is withdrawer
+        └── it delegates voting power

--- a/l1-contracts/test/governance/gse/gse/deposit.t.sol
+++ b/l1-contracts/test/governance/gse/gse/deposit.t.sol
@@ -1,0 +1,328 @@
+// SPDX-License-Identifier: UNLICENSED
+pragma solidity >=0.8.27;
+
+import {WithGSE} from "./base.sol";
+import {Errors} from "@aztec/governance/libraries/Errors.sol";
+import {IGSECore} from "@aztec/governance/GSE.sol";
+
+contract DepositTest is WithGSE {
+  address internal caller;
+  bool internal onCanonical = false;
+
+  function test_WhenCallerIsNotRegisteredRollup(address _instance) external {
+    // it reverts
+
+    vm.assume(gse.isRollupRegistered(_instance) == false);
+
+    vm.prank(_instance);
+    vm.expectRevert(abi.encodeWithSelector(Errors.GSE__NotRollup.selector, _instance));
+    gse.deposit(address(0), address(0), onCanonical);
+  }
+
+  modifier whenCallerIsRegisteredRollup(address _instance) {
+    vm.assume(_instance != address(0) && _instance != gse.CANONICAL_MAGIC_ADDRESS());
+
+    vm.prank(gse.owner());
+    gse.addRollup(_instance);
+
+    _;
+  }
+
+  modifier givenOnCanonicalEqTrue() {
+    onCanonical = true;
+    _;
+  }
+
+  function test_GivenCallerIsNotCanonical(address _instance1, address _instance2)
+    external
+    whenCallerIsRegisteredRollup(_instance1)
+    whenCallerIsRegisteredRollup(_instance2)
+    givenOnCanonicalEqTrue
+  {
+    // it reverts
+
+    vm.prank(_instance1);
+    vm.expectRevert(abi.encodeWithSelector(Errors.GSE__NotCanonical.selector, _instance1));
+    gse.deposit(address(0), address(0), onCanonical);
+  }
+
+  modifier givenCallerIsCanonical() {
+    _;
+  }
+
+  function test_GivenAttesterAlreadyRegisteredOnSpecificInstance(
+    address _instance,
+    address _attester,
+    address _withdrawer
+  ) external whenCallerIsRegisteredRollup(_instance) givenOnCanonicalEqTrue givenCallerIsCanonical {
+    // it reverts
+
+    uint256 depositAmount = gse.DEPOSIT_AMOUNT();
+
+    vm.prank(stakingAsset.owner());
+    stakingAsset.mint(address(_instance), depositAmount);
+
+    vm.startPrank(_instance);
+    stakingAsset.approve(address(gse), depositAmount);
+    gse.deposit(_attester, _withdrawer, false);
+    vm.stopPrank();
+
+    vm.prank(_instance);
+    vm.expectRevert(
+      abi.encodeWithSelector(Errors.GSE__AlreadyRegistered.selector, _instance, _attester)
+    );
+    gse.deposit(_attester, _withdrawer, onCanonical);
+  }
+
+  function test_GivenAttesterAlreadyRegisteredOnCanonical(
+    address _instance,
+    address _attester,
+    address _withdrawer
+  ) external whenCallerIsRegisteredRollup(_instance) givenOnCanonicalEqTrue givenCallerIsCanonical {
+    // it reverts
+
+    uint256 depositAmount = gse.DEPOSIT_AMOUNT();
+
+    vm.prank(stakingAsset.owner());
+    stakingAsset.mint(address(_instance), depositAmount);
+
+    vm.startPrank(_instance);
+    stakingAsset.approve(address(gse), depositAmount);
+    gse.deposit(_attester, _withdrawer, true);
+    vm.stopPrank();
+
+    address magic = gse.CANONICAL_MAGIC_ADDRESS();
+
+    vm.prank(_instance);
+    vm.expectRevert(
+      abi.encodeWithSelector(Errors.GSE__AlreadyRegistered.selector, magic, _attester)
+    );
+    gse.deposit(_attester, _withdrawer, onCanonical);
+  }
+
+  function test_GivenAttesterNotRegisteredAnywhere(
+    address _instance,
+    address _attester,
+    address _withdrawer
+  ) external whenCallerIsRegisteredRollup(_instance) givenOnCanonicalEqTrue givenCallerIsCanonical {
+    // it adds attester to canonical instance
+    // it sets attester config with withdrawer
+    // it delegates attester to canonical if not delegated
+    // it increases delegation balance
+    // it transfers staking asset from rollup to GSE
+    // it approves staking asset to governance
+    // it deposits staking asset to governance
+    // it emits Deposit event
+
+    uint256 depositAmount = gse.DEPOSIT_AMOUNT();
+
+    vm.prank(stakingAsset.owner());
+    stakingAsset.mint(address(_instance), depositAmount);
+
+    vm.prank(_instance);
+    stakingAsset.approve(address(gse), depositAmount);
+
+    assertEq(gse.isRegistered(_instance, _attester), false);
+    assertEq(gse.isRegistered(gse.CANONICAL_MAGIC_ADDRESS(), _attester), false);
+
+    address instance = onCanonical ? gse.CANONICAL_MAGIC_ADDRESS() : _instance;
+
+    vm.expectEmit(true, true, true, true);
+    emit IGSECore.Deposit(instance, _attester, _withdrawer);
+    vm.prank(_instance);
+    gse.deposit(_attester, _withdrawer, onCanonical);
+
+    assertEq(stakingAsset.balanceOf(address(gse.getGovernance())), depositAmount);
+    assertEq(stakingAsset.balanceOf(address(gse)), 0);
+
+    assertEq(gse.isRegistered(instance, _attester), true);
+    assertEq(gse.isRegistered(_instance, _attester), false);
+    assertEq(gse.getDelegatee(instance, _attester), gse.CANONICAL_MAGIC_ADDRESS());
+    assertEq(gse.getDelegatee(_instance, _attester), address(0));
+    assertEq(gse.getConfig(instance, _attester).withdrawer, _withdrawer);
+    assertEq(gse.balanceOf(instance, _attester), depositAmount);
+    assertEq(gse.balanceOf(_instance, _attester), 0);
+    assertEq(gse.effectiveBalanceOf(instance, _attester), depositAmount);
+    assertEq(gse.effectiveBalanceOf(_instance, _attester), depositAmount);
+    assertEq(gse.supplyOf(instance), depositAmount);
+    assertEq(gse.supplyOf(_instance), 0);
+    assertEq(gse.totalSupply(), depositAmount);
+  }
+
+  modifier givenOnCanonicalEqFalse() {
+    onCanonical = false;
+    _;
+  }
+
+  function test_GivenAttesterAlreadyRegisteredOnSpecificInstance2(
+    address _instance,
+    address _attester,
+    address _withdrawer
+  ) external whenCallerIsRegisteredRollup(_instance) givenOnCanonicalEqFalse {
+    // it reverts
+
+    // @todo note that this test is exactly the same as test_GivenAttesterAlreadyRegisteredOnSpecificInstance
+    // the only diff is `onCanonical = false` here. We could consider slamming them together, but to be
+    // explicit we are not doing that.
+
+    uint256 depositAmount = gse.DEPOSIT_AMOUNT();
+
+    vm.prank(stakingAsset.owner());
+    stakingAsset.mint(address(_instance), depositAmount);
+
+    vm.startPrank(_instance);
+    stakingAsset.approve(address(gse), depositAmount);
+    gse.deposit(_attester, _withdrawer, false);
+    vm.stopPrank();
+
+    vm.prank(_instance);
+    vm.expectRevert(
+      abi.encodeWithSelector(Errors.GSE__AlreadyRegistered.selector, _instance, _attester)
+    );
+    gse.deposit(_attester, _withdrawer, onCanonical);
+  }
+
+  function test_GivenCallerIsCanonicalAndAttesterRegisteredOnCanonical(
+    address _instance,
+    address _attester,
+    address _withdrawer
+  ) external whenCallerIsRegisteredRollup(_instance) givenOnCanonicalEqFalse {
+    // it reverts
+
+    // Again, this one is essentially same as givenAttesterAlreadyREgisteredOnCanonical but with false.
+
+    uint256 depositAmount = gse.DEPOSIT_AMOUNT();
+
+    vm.prank(stakingAsset.owner());
+    stakingAsset.mint(address(_instance), depositAmount);
+
+    vm.startPrank(_instance);
+    stakingAsset.approve(address(gse), depositAmount);
+    gse.deposit(_attester, _withdrawer, true);
+    vm.stopPrank();
+
+    address magic = gse.CANONICAL_MAGIC_ADDRESS();
+
+    vm.prank(_instance);
+    vm.expectRevert(
+      abi.encodeWithSelector(Errors.GSE__AlreadyRegistered.selector, magic, _attester)
+    );
+    gse.deposit(_attester, _withdrawer, onCanonical);
+  }
+
+  modifier givenAttesterNotRegisteredOnSpecificInstance() {
+    _;
+  }
+
+  function test_GivenCallerIsCanonicalAndAttesterNotRegisteredOnCanonical(
+    address _instance,
+    address _attester,
+    address _withdrawer
+  )
+    external
+    whenCallerIsRegisteredRollup(_instance)
+    givenOnCanonicalEqFalse
+    givenAttesterNotRegisteredOnSpecificInstance
+  {
+    // it adds attester to specific instance
+    // it sets attester config with withdrawer
+    // it delegates attester to instance if not delegated
+    // it increases delegation balance
+    // it transfers staking asset from rollup to GSE
+    // it approves staking asset to governance
+    // it deposits staking asset to governance
+    // it emits Deposit event
+
+    uint256 depositAmount = gse.DEPOSIT_AMOUNT();
+
+    vm.prank(stakingAsset.owner());
+    stakingAsset.mint(address(_instance), depositAmount);
+
+    vm.prank(_instance);
+    stakingAsset.approve(address(gse), depositAmount);
+
+    address magic = gse.CANONICAL_MAGIC_ADDRESS();
+
+    assertEq(gse.isRegistered(_instance, _attester), false);
+    assertEq(gse.isRegistered(magic, _attester), false);
+
+    vm.expectEmit(true, true, true, true);
+    emit IGSECore.Deposit(_instance, _attester, _withdrawer);
+    vm.prank(_instance);
+    gse.deposit(_attester, _withdrawer, onCanonical);
+
+    assertEq(stakingAsset.balanceOf(address(gse.getGovernance())), depositAmount);
+    assertEq(stakingAsset.balanceOf(address(gse)), 0);
+
+    assertEq(gse.isRegistered(_instance, _attester), true);
+    assertEq(gse.isRegistered(magic, _attester), false);
+    assertEq(gse.getDelegatee(_instance, _attester), _instance);
+    assertEq(gse.getDelegatee(magic, _attester), address(0));
+    assertEq(gse.getConfig(_instance, _attester).withdrawer, _withdrawer);
+    assertEq(gse.balanceOf(_instance, _attester), depositAmount);
+    assertEq(gse.balanceOf(magic, _attester), 0);
+    assertEq(gse.effectiveBalanceOf(_instance, _attester), depositAmount);
+    assertEq(gse.effectiveBalanceOf(magic, _attester), 0); // special case
+    assertEq(gse.supplyOf(_instance), depositAmount);
+    assertEq(gse.supplyOf(magic), 0);
+    assertEq(gse.totalSupply(), depositAmount);
+  }
+
+  function test_GivenCallerIsNotCanonical2(
+    address _instance,
+    address _instance2,
+    address _attester,
+    address _withdrawer
+  )
+    external
+    whenCallerIsRegisteredRollup(_instance)
+    whenCallerIsRegisteredRollup(_instance2)
+    givenOnCanonicalEqFalse
+    givenAttesterNotRegisteredOnSpecificInstance
+  {
+    // it adds attester to specific instance
+    // it sets attester config with withdrawer
+    // it delegates attester to instance if not delegated
+    // it increases delegation balance
+    // it transfers staking asset from rollup to GSE
+    // it approves staking asset to governance
+    // it deposits staking asset to governance
+    // it emits Deposit event
+
+    // @todo exactly the same as above, with only diff being not canonical
+
+    uint256 depositAmount = gse.DEPOSIT_AMOUNT();
+
+    vm.prank(stakingAsset.owner());
+    stakingAsset.mint(address(_instance), depositAmount);
+
+    vm.prank(_instance);
+    stakingAsset.approve(address(gse), depositAmount);
+
+    address magic = gse.CANONICAL_MAGIC_ADDRESS();
+
+    assertEq(gse.isRegistered(_instance, _attester), false);
+    assertEq(gse.isRegistered(magic, _attester), false);
+
+    vm.expectEmit(true, true, true, true);
+    emit IGSECore.Deposit(_instance, _attester, _withdrawer);
+    vm.prank(_instance);
+    gse.deposit(_attester, _withdrawer, onCanonical);
+
+    assertEq(stakingAsset.balanceOf(address(gse.getGovernance())), depositAmount);
+    assertEq(stakingAsset.balanceOf(address(gse)), 0);
+
+    assertEq(gse.isRegistered(_instance, _attester), true);
+    assertEq(gse.isRegistered(magic, _attester), false);
+    assertEq(gse.getDelegatee(_instance, _attester), _instance);
+    assertEq(gse.getDelegatee(magic, _attester), address(0));
+    assertEq(gse.getConfig(_instance, _attester).withdrawer, _withdrawer);
+    assertEq(gse.balanceOf(_instance, _attester), depositAmount);
+    assertEq(gse.balanceOf(magic, _attester), 0);
+    assertEq(gse.effectiveBalanceOf(_instance, _attester), depositAmount);
+    assertEq(gse.effectiveBalanceOf(magic, _attester), 0); // special case
+    assertEq(gse.supplyOf(_instance), depositAmount);
+    assertEq(gse.supplyOf(magic), 0);
+    assertEq(gse.totalSupply(), depositAmount);
+  }
+}

--- a/l1-contracts/test/governance/gse/gse/deposit.tree
+++ b/l1-contracts/test/governance/gse/gse/deposit.tree
@@ -1,0 +1,45 @@
+DepositTest
+├── when caller is not registered rollup
+│   └── it reverts
+└── when caller is registered rollup
+    ├── given onCanonical eq true
+    │   ├── given caller is not canonical
+    │   │   └── it reverts
+    │   └── given caller is canonical
+    │       ├── given attester already registered on specific instance
+    │       │   └── it reverts
+    │       ├── given attester already registered on canonical
+    │       │   └── it reverts
+    │       └── given attester not registered anywhere
+    │           ├── it adds attester to canonical instance
+    │           ├── it sets attester config with withdrawer
+    │           ├── it delegates attester to canonical if not delegated
+    │           ├── it increases delegation balance
+    │           ├── it transfers staking asset from rollup to GSE
+    │           ├── it approves staking asset to governance
+    │           ├── it deposits staking asset to governance
+    │           └── it emits Deposit event
+    └── given onCanonical eq false
+        ├── given attester already registered on specific instance 2
+        │   └── it reverts
+        ├── given caller is canonical and attester registered on canonical
+        │   └── it reverts
+        └── given attester not registered on specific instance
+            ├── given caller is canonical and attester not registered on canonical
+            │   ├── it adds attester to specific instance
+            │   ├── it sets attester config with withdrawer
+            │   ├── it delegates attester to instance if not delegated
+            │   ├── it increases delegation balance
+            │   ├── it transfers staking asset from rollup to GSE
+            │   ├── it approves staking asset to governance
+            │   ├── it deposits staking asset to governance
+            │   └── it emits Deposit event
+            └── given caller is not canonical 2
+                ├── it adds attester to specific instance
+                ├── it sets attester config with withdrawer
+                ├── it delegates attester to instance if not delegated
+                ├── it increases delegation balance
+                ├── it transfers staking asset from rollup to GSE
+                ├── it approves staking asset to governance
+                ├── it deposits staking asset to governance
+                └── it emits Deposit event

--- a/l1-contracts/test/governance/gse/gse/finaliseHelper.t.sol
+++ b/l1-contracts/test/governance/gse/gse/finaliseHelper.t.sol
@@ -1,0 +1,61 @@
+// SPDX-License-Identifier: UNLICENSED
+pragma solidity >=0.8.27;
+
+import {WithGSE} from "./base.sol";
+import {Withdrawal} from "@aztec/governance/interfaces/IGovernance.sol";
+import {Timestamp} from "@aztec/shared/libraries/TimeMath.sol";
+
+contract FinaliseHelperTest is WithGSE {
+  uint256 internal withdrawalId;
+
+  address internal ATTESTER = address(0xcafe);
+  address internal INSTANCE = address(0xbeef);
+  address internal WITHDRAWER = address(0xdead);
+
+  function setUp() public override {
+    super.setUp();
+
+    vm.prank(gse.owner());
+    gse.addRollup(INSTANCE);
+
+    cheat_deposit(INSTANCE, ATTESTER, WITHDRAWER, false);
+
+    vm.prank(INSTANCE);
+    (,, withdrawalId) = gse.withdraw(ATTESTER, 100);
+  }
+
+  function test_GivenWithdrawalNotClaimed() external {
+    // it finalises withdrawal in governance
+
+    Withdrawal memory withdrawal = governance.getWithdrawal(withdrawalId);
+
+    vm.warp(Timestamp.unwrap(withdrawal.unlocksAt));
+
+    assertEq(stakingAsset.balanceOf(INSTANCE), 0);
+
+    gse.finaliseHelper(withdrawalId);
+
+    assertEq(stakingAsset.balanceOf(INSTANCE), 100);
+    withdrawal = governance.getWithdrawal(withdrawalId);
+    assertEq(withdrawal.claimed, true);
+  }
+
+  function test_GivenWithdrawalAlreadyClaimed() external {
+    // it does nothing
+
+    Withdrawal memory withdrawal = governance.getWithdrawal(withdrawalId);
+    vm.warp(Timestamp.unwrap(withdrawal.unlocksAt));
+    assertEq(stakingAsset.balanceOf(INSTANCE), 0);
+
+    gse.finaliseHelper(withdrawalId);
+
+    assertEq(stakingAsset.balanceOf(INSTANCE), 100);
+    withdrawal = governance.getWithdrawal(withdrawalId);
+    assertEq(withdrawal.claimed, true);
+
+    vm.record();
+    gse.finaliseHelper(withdrawalId);
+    (, bytes32[] memory writes) = vm.accesses(address(gse));
+    assertEq(writes.length, 0);
+  }
+}

--- a/l1-contracts/test/governance/gse/gse/finaliseHelper.tree
+++ b/l1-contracts/test/governance/gse/gse/finaliseHelper.tree
@@ -1,0 +1,5 @@
+FinaliseHelperTest
+├── given withdrawal not claimed
+│   └── it finalises withdrawal in governance
+└── given withdrawal already claimed
+    └── it does nothing

--- a/l1-contracts/test/governance/gse/gse/setGovernance.t.sol
+++ b/l1-contracts/test/governance/gse/gse/setGovernance.t.sol
@@ -1,0 +1,53 @@
+// SPDX-License-Identifier: UNLICENSED
+pragma solidity >=0.8.27;
+
+import {WithGSE} from "./base.sol";
+import {IERC20} from "@oz/token/ERC20/IERC20.sol";
+import {Ownable} from "@oz/access/Ownable.sol";
+import {GSE} from "@aztec/governance/GSE.sol";
+import {Governance} from "@aztec/governance/Governance.sol";
+import {Errors} from "@aztec/governance/libraries/Errors.sol";
+
+contract SetGovernanceTest is WithGSE {
+  address internal caller;
+
+  function setUp() public override(WithGSE) {
+    gse = new GSE(address(this), IERC20(address(0)));
+  }
+
+  function test_WhenCallerNeqOwner(address _caller) external {
+    // it reverts
+
+    vm.assume(_caller != gse.owner());
+
+    vm.prank(_caller);
+    vm.expectRevert(abi.encodeWithSelector(Ownable.OwnableUnauthorizedAccount.selector, _caller));
+    gse.setGovernance(Governance(address(0)));
+  }
+
+  modifier whenCallerEqOwner() {
+    caller = gse.owner();
+    _;
+  }
+
+  function test_GivenGovernanceNeq0() external whenCallerEqOwner {
+    // it reverts
+
+    gse.setGovernance(Governance(address(1)));
+
+    vm.prank(caller);
+    vm.expectRevert(abi.encodeWithSelector(Errors.GSE__GovernanceAlreadySet.selector));
+    gse.setGovernance(Governance(address(2)));
+  }
+
+  function test_GivenGovernanceEq0(address _governance) external whenCallerEqOwner {
+    // it updates the governance
+
+    vm.assume(_governance != address(0));
+
+    vm.prank(caller);
+    gse.setGovernance(Governance(_governance));
+
+    assertEq(address(gse.getGovernance()), _governance);
+  }
+}

--- a/l1-contracts/test/governance/gse/gse/setGovernance.tree
+++ b/l1-contracts/test/governance/gse/gse/setGovernance.tree
@@ -2,7 +2,7 @@ SetGovernanceTest
 ├── when caller neq owner
 │   └── it reverts
 └── when caller eq owner
-    ├── given governance eq 0
+    ├── given governance neq 0
     │   └── it reverts
-    └── given governance neq 0
+    └── given governance eq 0
         └── it updates the governance

--- a/l1-contracts/test/governance/gse/gse/setGovernance.tree
+++ b/l1-contracts/test/governance/gse/gse/setGovernance.tree
@@ -1,0 +1,8 @@
+SetGovernanceTest
+├── when caller neq owner
+│   └── it reverts
+└── when caller eq owner
+    ├── given governance eq 0
+    │   └── it reverts
+    └── given governance neq 0
+        └── it updates the governance

--- a/l1-contracts/test/governance/gse/gse/static.t.sol
+++ b/l1-contracts/test/governance/gse/gse/static.t.sol
@@ -1,0 +1,111 @@
+// SPDX-License-Identifier: UNLICENSED
+pragma solidity >=0.8.27;
+
+import {WithGSE} from "./base.sol";
+import {IPayload, Proposal} from "@aztec/governance/interfaces/IGovernance.sol";
+import {ProposalLib} from "@aztec/governance/libraries/ProposalLib.sol";
+import {Timestamp} from "@aztec/shared/libraries/TimeMath.sol";
+import {Errors} from "@aztec/governance/libraries/Errors.sol";
+
+contract StaticTest is WithGSE {
+  function test_getWithdrawer(address[2] memory _instances, address _attester, address _withdrawer)
+    external
+  {
+    vm.assume(_instances[0] != _instances[1]);
+    vm.assume(_instances[0] != address(0) && _instances[0] != gse.getCanonicalMagicAddress());
+    vm.assume(_instances[1] != address(0) && _instances[1] != gse.getCanonicalMagicAddress());
+    vm.assume(_attester != _withdrawer);
+
+    vm.prank(gse.owner());
+    gse.addRollup(_instances[0]);
+    vm.prank(gse.owner());
+    gse.addRollup(_instances[1]);
+
+    // Add an attester to instance[0] specifically
+    {
+      cheat_deposit(_instances[0], _attester, _withdrawer, false);
+
+      (address actualWithdrawer, bool exists, address instance) =
+        gse.getWithdrawer(_instances[0], _attester);
+
+      assertEq(actualWithdrawer, _withdrawer, "invalid withdrawer");
+      assertTrue(exists, "withdrawer should exist");
+      assertEq(instance, _instances[0], "invalid instance");
+    }
+
+    // Add an attester to instance[1], but canonically
+    {
+      cheat_deposit(_instances[1], _attester, _withdrawer, true);
+
+      (address actualWithdrawer, bool exists, address instance) =
+        gse.getWithdrawer(_instances[1], _attester);
+
+      assertEq(actualWithdrawer, _withdrawer, "invalid withdrawer");
+      assertTrue(exists, "withdrawer should exist");
+      assertEq(instance, gse.getCanonicalMagicAddress(), "invalid instance");
+    }
+
+    // Withdrawer is not an attester, so should not be able to get a withdrawer
+    {
+      (address actualWithdrawer, bool exists, address instance) =
+        gse.getWithdrawer(_instances[1], _withdrawer);
+
+      assertEq(actualWithdrawer, address(0), "invalid withdrawer");
+      assertFalse(exists, "withdrawer should not exist");
+      assertEq(instance, address(0), "invalid instance");
+    }
+  }
+
+  function test_getVotingPower(address _instance, address _attester) external {
+    vm.assume(_instance != address(0) && _instance != gse.getCanonicalMagicAddress());
+
+    vm.prank(gse.owner());
+    gse.addRollup(_instance);
+
+    cheat_deposit(_instance, _attester, _attester, false);
+
+    assertEq(gse.getVotingPower(_attester), 0, "invalid voting power");
+    assertEq(gse.getVotingPower(_instance), gse.DEPOSIT_AMOUNT(), "invalid voting power");
+  }
+
+  function test_getAttesterFromIndexAtTime(address _instance, address[4] memory _attesters)
+    external
+  {
+    vm.assume(_instance != address(0) && _instance != gse.getCanonicalMagicAddress());
+    for (uint256 i = 0; i < _attesters.length; i++) {
+      for (uint256 j = i + 1; j < _attesters.length; j++) {
+        vm.assume(_attesters[i] != _attesters[j]);
+      }
+    }
+
+    vm.prank(gse.owner());
+    gse.addRollup(_instance);
+
+    Timestamp ts = Timestamp.wrap(block.timestamp);
+    Timestamp ts2 = ts + Timestamp.wrap(1 days);
+
+    cheat_deposit(_instance, _attesters[0], _attesters[0], false);
+    cheat_deposit(_instance, _attesters[1], _attesters[1], true);
+    vm.warp(Timestamp.unwrap(ts2));
+    cheat_deposit(_instance, _attesters[2], _attesters[2], false);
+    cheat_deposit(_instance, _attesters[3], _attesters[3], true);
+
+    assertEq(gse.getAttesterFromIndexAtTime(_instance, 0, ts), _attesters[0], "invalid attester");
+
+    // As _instance is canonical, it will also get attesters[1]
+    assertEq(gse.getAttesterFromIndexAtTime(_instance, 1, ts), _attesters[1], "invalid attester");
+
+    address[] memory attesters = gse.getAttestersAtTime(_instance, ts);
+    assertEq(attesters.length, 2, "invalid attesters");
+    assertEq(attesters[0], _attesters[0], "invalid attester");
+    assertEq(attesters[1], _attesters[1], "invalid attester");
+
+    // Note the indexes of this can look strange as it first the specific then the canonical
+    attesters = gse.getAttestersAtTime(_instance, ts2);
+    assertEq(attesters.length, 4, "invalid attesters");
+    assertEq(attesters[0], _attesters[0], "invalid attester");
+    assertEq(attesters[1], _attesters[2], "invalid attester");
+    assertEq(attesters[2], _attesters[1], "invalid attester");
+    assertEq(attesters[3], _attesters[3], "invalid attester");
+  }
+}

--- a/l1-contracts/test/governance/gse/gse/vote.t.sol
+++ b/l1-contracts/test/governance/gse/gse/vote.t.sol
@@ -1,0 +1,92 @@
+// SPDX-License-Identifier: UNLICENSED
+pragma solidity >=0.8.27;
+
+import {WithGSE} from "./base.sol";
+import {IPayload, Proposal} from "@aztec/governance/interfaces/IGovernance.sol";
+import {ProposalLib} from "@aztec/governance/libraries/ProposalLib.sol";
+import {Timestamp} from "@aztec/shared/libraries/TimeMath.sol";
+import {Errors} from "@aztec/governance/libraries/Errors.sol";
+
+contract VoteTest is WithGSE {
+  using ProposalLib for Proposal;
+
+  function setUp() public override {
+    super.setUp();
+
+    vm.prank(governance.governanceProposer());
+    governance.propose(IPayload(address(0xbeef)));
+  }
+
+  function test_GivenAmountGreaterThanAvailablePower(
+    address _instance,
+    address _attester,
+    address _delegatee,
+    bool _delegate,
+    uint256 _amount
+  ) external {
+    // it reverts
+
+    (address voter, uint256 availablePower) = _prepare(_instance, _attester, _delegatee, _delegate);
+    uint256 amount = bound(_amount, availablePower + 1, type(uint256).max);
+
+    vm.prank(voter);
+    vm.expectRevert(
+      abi.encodeWithSelector(
+        Errors.Delegation__InsufficientPower.selector, voter, availablePower, amount
+      )
+    );
+    gse.vote(0, amount, true);
+  }
+
+  function test_GivenAmountLessOrEqualToAvailablePower(
+    address _instance,
+    address _attester,
+    address _delegatee,
+    bool _delegate,
+    uint256 _amount,
+    bool _support
+  ) external {
+    // it uses delegation power for proposal
+    // it votes in governance
+
+    Proposal memory proposal = governance.getProposal(0);
+    assertEq(proposal.summedBallot.yea, 0);
+    assertEq(proposal.summedBallot.nea, 0);
+
+    (address voter, uint256 availablePower) = _prepare(_instance, _attester, _delegatee, _delegate);
+    uint256 amount = bound(_amount, 0, availablePower);
+
+    vm.prank(voter);
+    gse.vote(0, amount, _support);
+
+    proposal = governance.getProposal(0);
+    assertEq(proposal.summedBallot.yea, _support ? amount : 0);
+    assertEq(proposal.summedBallot.nea, _support ? 0 : amount);
+  }
+
+  function _prepare(address _instance, address _attester, address _delegatee, bool _delegate)
+    internal
+    returns (address, uint256)
+  {
+    vm.assume(_instance != address(0) && _instance != gse.getCanonicalMagicAddress());
+
+    vm.prank(gse.owner());
+    gse.addRollup(_instance);
+
+    cheat_deposit(_instance, _attester, _attester, false);
+
+    if (_delegate) {
+      vm.prank(_attester);
+      gse.delegate(_instance, _attester, _delegatee);
+    }
+
+    Proposal memory proposal = governance.getProposal(0);
+    vm.warp(Timestamp.unwrap(proposal.pendingThroughMemory()) + 1);
+
+    address voter = _delegate ? _delegatee : _attester;
+
+    uint256 availablePower = gse.getVotingPowerAt(voter, proposal.pendingThroughMemory());
+
+    return (voter, availablePower);
+  }
+}

--- a/l1-contracts/test/governance/gse/gse/vote.t.sol
+++ b/l1-contracts/test/governance/gse/gse/vote.t.sol
@@ -55,6 +55,7 @@ contract VoteTest is WithGSE {
 
     (address voter, uint256 availablePower) = _prepare(_instance, _attester, _delegatee, _delegate);
     uint256 amount = bound(_amount, 0, availablePower);
+    assertEq(gse.getPowerUsed(voter, 0), 0);
 
     vm.prank(voter);
     gse.vote(0, amount, _support);
@@ -62,6 +63,8 @@ contract VoteTest is WithGSE {
     proposal = governance.getProposal(0);
     assertEq(proposal.summedBallot.yea, _support ? amount : 0);
     assertEq(proposal.summedBallot.nea, _support ? 0 : amount);
+
+    assertEq(gse.getPowerUsed(voter, 0), amount);
   }
 
   function _prepare(address _instance, address _attester, address _delegatee, bool _delegate)

--- a/l1-contracts/test/governance/gse/gse/vote.tree
+++ b/l1-contracts/test/governance/gse/gse/vote.tree
@@ -1,0 +1,7 @@
+VoteTest
+├── given amount greater than available power
+│   └── it reverts
+└── given amount less or equal to available power
+    ├── it uses delegation power for proposal
+    ├── it votes in governance
+    └── it returns true

--- a/l1-contracts/test/governance/gse/gse/voteWithCanonical.t.sol
+++ b/l1-contracts/test/governance/gse/gse/voteWithCanonical.t.sol
@@ -1,0 +1,96 @@
+// SPDX-License-Identifier: UNLICENSED
+pragma solidity >=0.8.27;
+
+import {WithGSE} from "./base.sol";
+import {IPayload, Proposal} from "@aztec/governance/interfaces/IGovernance.sol";
+import {ProposalLib} from "@aztec/governance/libraries/ProposalLib.sol";
+import {Timestamp} from "@aztec/shared/libraries/TimeMath.sol";
+import {Errors} from "@aztec/governance/libraries/Errors.sol";
+
+contract VoteWithCanonicalTest is WithGSE {
+  using ProposalLib for Proposal;
+
+  address internal MAGIC_ADDRESS;
+
+  function setUp() public override {
+    super.setUp();
+
+    vm.prank(governance.governanceProposer());
+    governance.propose(IPayload(address(0xbeef)));
+
+    MAGIC_ADDRESS = gse.getCanonicalMagicAddress();
+  }
+
+  function test_GivenCallerIsNotCanonicalAtProposalTime(address _instance) external {
+    // it reverts
+
+    vm.assume(_instance != address(0));
+
+    vm.prank(_instance);
+    vm.expectRevert(abi.encodeWithSelector(Errors.GSE__NotCanonical.selector, _instance));
+    gse.voteWithCanonical(0, 0, true);
+  }
+
+  modifier givenCallerIsCanonicalAtProposalTime(address _instance) {
+    vm.assume(_instance != address(0) && _instance != MAGIC_ADDRESS);
+
+    vm.prank(gse.owner());
+    gse.addRollup(_instance);
+
+    _;
+  }
+
+  function test_GivenAmountGreaterThanAvailableCanonicalPower(
+    address _instance,
+    address _attester,
+    uint256 _amount
+  ) external givenCallerIsCanonicalAtProposalTime(_instance) {
+    // it reverts
+
+    uint256 availablePower = _prepare(_instance, _attester);
+    uint256 amount = bound(_amount, availablePower + 1, type(uint256).max);
+
+    vm.prank(_instance);
+    vm.expectRevert(
+      abi.encodeWithSelector(
+        Errors.Delegation__InsufficientPower.selector, MAGIC_ADDRESS, availablePower, amount
+      )
+    );
+    gse.voteWithCanonical(0, amount, true);
+  }
+
+  function test_GivenAmountLessOrEqualToAvailableCanonicalPower(
+    address _instance,
+    address _attester,
+    bool _support,
+    uint256 _amount
+  ) external givenCallerIsCanonicalAtProposalTime(_instance) {
+    // it uses delegation power for canonical
+    // it votes in governance
+
+    Proposal memory proposal = governance.getProposal(0);
+    assertEq(proposal.summedBallot.yea, 0);
+    assertEq(proposal.summedBallot.nea, 0);
+
+    uint256 availablePower = _prepare(_instance, _attester);
+    uint256 amount = bound(_amount, 0, availablePower);
+
+    vm.prank(_instance);
+    gse.voteWithCanonical(0, amount, _support);
+
+    proposal = governance.getProposal(0);
+    assertEq(proposal.summedBallot.yea, _support ? amount : 0);
+    assertEq(proposal.summedBallot.nea, _support ? 0 : amount);
+  }
+
+  function _prepare(address _instance, address _attester) internal returns (uint256) {
+    cheat_deposit(_instance, _attester, _attester, true);
+
+    Proposal memory proposal = governance.getProposal(0);
+    vm.warp(Timestamp.unwrap(proposal.pendingThroughMemory()) + 1);
+
+    uint256 availablePower = gse.getVotingPowerAt(MAGIC_ADDRESS, proposal.pendingThroughMemory());
+
+    return availablePower;
+  }
+}

--- a/l1-contracts/test/governance/gse/gse/voteWithCanonical.tree
+++ b/l1-contracts/test/governance/gse/gse/voteWithCanonical.tree
@@ -1,0 +1,10 @@
+VoteWithCanonicalTest
+├── given caller is not canonical at proposal time
+│   └── it reverts
+└── given caller is canonical at proposal time
+    ├── given amount greater than available canonical power
+    │   └── it reverts
+    └── given amount less or equal to available canonical power
+        ├── it uses delegation power for canonical
+        ├── it votes in governance
+        └── it returns true

--- a/l1-contracts/test/governance/gse/gse/withdraw.t.sol
+++ b/l1-contracts/test/governance/gse/gse/withdraw.t.sol
@@ -1,0 +1,356 @@
+// SPDX-License-Identifier: UNLICENSED
+pragma solidity >=0.8.27;
+
+import {WithGSE} from "./base.sol";
+import {Errors} from "@aztec/governance/libraries/Errors.sol";
+import {Withdrawal} from "@aztec/governance/interfaces/IGovernance.sol";
+
+contract WithdrawTest is WithGSE {
+  address internal caller;
+  bool internal onCanonical = false;
+
+  address internal WITHDRAWER = address(0x1234);
+  address internal MAGIC_ADDRESS;
+  uint256 internal amount;
+
+  function setUp() public override {
+    super.setUp();
+    MAGIC_ADDRESS = gse.CANONICAL_MAGIC_ADDRESS();
+  }
+
+  function test_WhenCallerIsNotRegisteredRollup(address _instance) external {
+    // it reverts
+
+    vm.assume(!gse.isRollupRegistered(_instance));
+
+    vm.prank(_instance);
+    vm.expectRevert(abi.encodeWithSelector(Errors.GSE__NotRollup.selector, _instance));
+    gse.withdraw(address(0), 0);
+  }
+
+  modifier whenCallerIsRegisteredRollup(address _instance) {
+    vm.assume(_instance != address(0) && _instance != MAGIC_ADDRESS);
+
+    vm.prank(gse.owner());
+    gse.addRollup(_instance);
+
+    _;
+  }
+
+  modifier givenAttesterNotFoundInCallerInstance(address _instance, address _attester) {
+    vm.assume(_attester != address(0));
+    vm.assume(!gse.isRegistered(_instance, _attester));
+
+    _;
+  }
+
+  function test_GivenCallerIsNotCanonical(address _instance, address _instance2, address _attester)
+    external
+    whenCallerIsRegisteredRollup(_instance)
+    givenAttesterNotFoundInCallerInstance(_instance, _attester)
+  {
+    // it reverts
+    vm.assume(_instance != _instance2 && _instance2 != address(0) && _instance2 != MAGIC_ADDRESS);
+
+    cheat_deposit(_instance, _attester, WITHDRAWER, true);
+
+    vm.prank(gse.owner());
+    gse.addRollup(_instance2);
+
+    assertEq(gse.isRegistered(_instance, _attester), false);
+    assertEq(gse.isRegistered(_instance2, _attester), false);
+    assertEq(gse.isRegistered(MAGIC_ADDRESS, _attester), true);
+
+    // While it was added when we were canonical, it moved away, so we cannot get it now.
+
+    vm.prank(_instance);
+    vm.expectRevert(abi.encodeWithSelector(Errors.GSE__NothingToExit.selector, _attester));
+    gse.withdraw(_attester, 0);
+  }
+
+  modifier givenCallerIsCanonical() {
+    _;
+  }
+
+  function test_GivenAttesterNotFoundInCanonical(address _instance, address _attester)
+    external
+    whenCallerIsRegisteredRollup(_instance)
+    givenAttesterNotFoundInCallerInstance(_instance, _attester)
+    givenCallerIsCanonical
+  {
+    // it reverts
+
+    assertEq(gse.isRegistered(_instance, _attester), false);
+    assertEq(gse.isRegistered(MAGIC_ADDRESS, _attester), false);
+
+    vm.prank(_instance);
+    vm.expectRevert(abi.encodeWithSelector(Errors.GSE__NothingToExit.selector, _attester));
+    gse.withdraw(_attester, 0);
+  }
+
+  modifier givenAttesterFoundInCanonical(address _instance, address _attester) {
+    vm.assume(_attester != address(0));
+
+    if (!gse.isRegistered(_instance, _attester)) {
+      cheat_deposit(_instance, _attester, WITHDRAWER, true);
+    }
+
+    _;
+  }
+
+  function test_GivenBalanceLessThanAmount(address _instance, address _attester, uint256 _amount)
+    external
+    whenCallerIsRegisteredRollup(_instance)
+    givenAttesterNotFoundInCallerInstance(_instance, _attester)
+    givenCallerIsCanonical
+    givenAttesterFoundInCanonical(_instance, _attester)
+  {
+    // it reverts
+
+    uint256 balance = gse.balanceOf(MAGIC_ADDRESS, _attester);
+    amount = bound(_amount, balance + 1, type(uint256).max);
+
+    vm.prank(_instance);
+    vm.expectRevert(abi.encodeWithSelector(Errors.GSE__InsufficientStake.selector, balance, amount));
+    gse.withdraw(_attester, amount);
+  }
+
+  modifier givenBalanceGreaterOrEqualToAmount(address _attester, uint256 _amount) {
+    uint256 balance = gse.balanceOf(MAGIC_ADDRESS, _attester);
+    amount = bound(_amount, 0, balance);
+    _;
+  }
+
+  function test_GivenBalanceMinusAmountLessThanMinimumStake(
+    address _instance,
+    address _attester,
+    uint256 _amount
+  )
+    external
+    whenCallerIsRegisteredRollup(_instance)
+    givenAttesterNotFoundInCallerInstance(_instance, _attester)
+    givenCallerIsCanonical
+    givenAttesterFoundInCanonical(_instance, _attester)
+    givenBalanceGreaterOrEqualToAmount(_attester, _amount)
+  {
+    // it removes attester from canonical instance
+    // it deletes attester config
+    // it delegates attester to address zero
+    // it withdraws full balance
+    // it decreases delegation balance by full amount
+    // it initiates withdrawal in governance
+    // it returns full balance, true, withdrawal id
+    uint256 balance = gse.balanceOf(MAGIC_ADDRESS, _attester);
+    {
+      assertEq(gse.isRegistered(MAGIC_ADDRESS, _attester), true);
+      assertEq(gse.getDelegatee(MAGIC_ADDRESS, _attester), MAGIC_ADDRESS);
+      assertEq(gse.getConfig(MAGIC_ADDRESS, _attester).withdrawer, WITHDRAWER);
+
+      amount = bound(_amount, balance - gse.MINIMUM_STAKE() + 1, balance);
+    }
+
+    // He will be removed entirely
+    {
+      vm.prank(_instance);
+      (uint256 amountWithdrawn, bool isRemoved, uint256 withdrawalId) =
+        gse.withdraw(_attester, amount);
+      assertEq(amountWithdrawn, balance);
+      assertEq(isRemoved, true);
+      assertEq(withdrawalId, 0);
+    }
+    {
+      Withdrawal memory withdrawal = governance.getWithdrawal(0);
+      assertEq(withdrawal.amount, balance);
+      assertEq(withdrawal.recipient, _instance);
+      assertEq(withdrawal.claimed, false);
+    }
+    {
+      assertEq(gse.isRegistered(MAGIC_ADDRESS, _attester), false);
+      assertEq(gse.getDelegatee(MAGIC_ADDRESS, _attester), address(0));
+      assertEq(gse.getConfig(MAGIC_ADDRESS, _attester).withdrawer, address(0));
+      assertEq(gse.balanceOf(MAGIC_ADDRESS, _attester), 0);
+    }
+  }
+
+  function test_GivenBalanceMinusAmountGreaterOrEqualToMinimumStake(
+    address _instance,
+    address _attester,
+    uint256 _amount
+  )
+    external
+    whenCallerIsRegisteredRollup(_instance)
+    givenAttesterNotFoundInCallerInstance(_instance, _attester)
+    givenCallerIsCanonical
+    givenAttesterFoundInCanonical(_instance, _attester)
+    givenBalanceGreaterOrEqualToAmount(_attester, _amount)
+  {
+    // it withdraws specified amount
+    // it decreases delegation balance by specified amount
+    // it initiates withdrawal in governance
+    // it returns specified amount, false, withdrawal id
+
+    uint256 balance = gse.balanceOf(MAGIC_ADDRESS, _attester);
+    {
+      assertEq(gse.isRegistered(MAGIC_ADDRESS, _attester), true);
+      assertEq(gse.getDelegatee(MAGIC_ADDRESS, _attester), MAGIC_ADDRESS);
+      assertEq(gse.getConfig(MAGIC_ADDRESS, _attester).withdrawer, WITHDRAWER);
+
+      amount = bound(_amount, 0, balance - gse.MINIMUM_STAKE());
+    }
+
+    // He will not be removed
+    {
+      vm.prank(_instance);
+      (uint256 amountWithdrawn, bool isRemoved, uint256 withdrawalId) =
+        gse.withdraw(_attester, amount);
+      assertEq(amountWithdrawn, amount);
+      assertEq(isRemoved, false);
+      assertEq(withdrawalId, 0);
+    }
+    {
+      Withdrawal memory withdrawal = governance.getWithdrawal(0);
+      assertEq(withdrawal.amount, amount);
+      assertEq(withdrawal.recipient, _instance);
+      assertEq(withdrawal.claimed, false);
+    }
+    {
+      assertEq(gse.isRegistered(MAGIC_ADDRESS, _attester), true);
+      assertEq(gse.getDelegatee(MAGIC_ADDRESS, _attester), MAGIC_ADDRESS);
+      assertEq(gse.getConfig(MAGIC_ADDRESS, _attester).withdrawer, WITHDRAWER);
+      assertEq(gse.balanceOf(MAGIC_ADDRESS, _attester), balance - amount);
+    }
+  }
+
+  modifier givenAttesterFoundInCallerInstance(address _instance, address _attester) {
+    vm.assume(_attester != address(0));
+
+    if (!gse.isRegistered(_instance, _attester)) {
+      cheat_deposit(_instance, _attester, WITHDRAWER, false);
+    }
+
+    _;
+  }
+
+  function test_GivenBalanceLessThanAmount2(address _instance, address _attester, uint256 _amount)
+    external
+    whenCallerIsRegisteredRollup(_instance)
+    givenAttesterFoundInCallerInstance(_instance, _attester)
+  {
+    // it reverts
+
+    uint256 balance = gse.balanceOf(_instance, _attester);
+    amount = bound(_amount, balance + 1, type(uint256).max);
+
+    vm.prank(_instance);
+    vm.expectRevert(abi.encodeWithSelector(Errors.GSE__InsufficientStake.selector, balance, amount));
+    gse.withdraw(_attester, amount);
+  }
+
+  modifier givenBalanceGreaterOrEqualToAmount2(
+    address _instance,
+    address _attester,
+    uint256 _amount
+  ) {
+    uint256 balance = gse.balanceOf(_instance, _attester);
+    amount = bound(_amount, 0, balance);
+
+    _;
+  }
+
+  function test_GivenBalanceMinusAmountLessThanMinimumStake2(
+    address _instance,
+    address _attester,
+    uint256 _amount
+  )
+    external
+    whenCallerIsRegisteredRollup(_instance)
+    givenAttesterFoundInCallerInstance(_instance, _attester)
+    givenBalanceGreaterOrEqualToAmount2(_instance, _attester, _amount)
+  {
+    // it removes attester from caller instance
+    // it deletes attester config
+    // it delegates attester to address zero
+    // it withdraws full balance
+    // it decreases delegation balance by full amount
+    // it initiates withdrawal in governance
+    // it returns full balance, true, withdrawal id
+
+    uint256 balance = gse.balanceOf(_instance, _attester);
+    {
+      assertEq(gse.isRegistered(_instance, _attester), true);
+      assertEq(gse.getDelegatee(_instance, _attester), _instance);
+      assertEq(gse.getConfig(_instance, _attester).withdrawer, WITHDRAWER);
+
+      amount = bound(_amount, balance - gse.MINIMUM_STAKE() + 1, balance);
+    }
+
+    // He will be removed entirely
+    {
+      vm.prank(_instance);
+      (uint256 amountWithdrawn, bool isRemoved, uint256 withdrawalId) =
+        gse.withdraw(_attester, amount);
+      assertEq(amountWithdrawn, balance);
+      assertEq(isRemoved, true);
+      assertEq(withdrawalId, 0);
+    }
+    {
+      Withdrawal memory withdrawal = governance.getWithdrawal(0);
+      assertEq(withdrawal.amount, balance);
+      assertEq(withdrawal.recipient, _instance);
+      assertEq(withdrawal.claimed, false);
+    }
+    {
+      assertEq(gse.isRegistered(_instance, _attester), false);
+      assertEq(gse.getDelegatee(_instance, _attester), address(0));
+      assertEq(gse.getConfig(_instance, _attester).withdrawer, address(0));
+      assertEq(gse.balanceOf(_instance, _attester), 0);
+    }
+  }
+
+  function test_GivenBalanceMinusAmountGreaterOrEqualToMinimumStake2(
+    address _instance,
+    address _attester,
+    uint256 _amount
+  )
+    external
+    whenCallerIsRegisteredRollup(_instance)
+    givenAttesterFoundInCallerInstance(_instance, _attester)
+    givenBalanceGreaterOrEqualToAmount2(_instance, _attester, _amount)
+  {
+    // it withdraws specified amount
+    // it decreases delegation balance by specified amount
+    // it initiates withdrawal in governance
+    // it returns specified amount, false, withdrawal id
+
+    uint256 balance = gse.balanceOf(_instance, _attester);
+    {
+      assertEq(gse.isRegistered(_instance, _attester), true);
+      assertEq(gse.getDelegatee(_instance, _attester), _instance);
+      assertEq(gse.getConfig(_instance, _attester).withdrawer, WITHDRAWER);
+
+      amount = bound(_amount, 0, balance - gse.MINIMUM_STAKE());
+    }
+
+    // He will not be removed
+    {
+      vm.prank(_instance);
+      (uint256 amountWithdrawn, bool isRemoved, uint256 withdrawalId) =
+        gse.withdraw(_attester, amount);
+      assertEq(amountWithdrawn, amount);
+      assertEq(isRemoved, false);
+      assertEq(withdrawalId, 0);
+    }
+    {
+      Withdrawal memory withdrawal = governance.getWithdrawal(0);
+      assertEq(withdrawal.amount, amount);
+      assertEq(withdrawal.recipient, _instance);
+      assertEq(withdrawal.claimed, false);
+    }
+    {
+      assertEq(gse.isRegistered(_instance, _attester), true);
+      assertEq(gse.getDelegatee(_instance, _attester), _instance);
+      assertEq(gse.getConfig(_instance, _attester).withdrawer, WITHDRAWER);
+      assertEq(gse.balanceOf(_instance, _attester), balance - amount);
+    }
+  }
+}

--- a/l1-contracts/test/governance/gse/gse/withdraw.tree
+++ b/l1-contracts/test/governance/gse/gse/withdraw.tree
@@ -1,0 +1,44 @@
+WithdrawTest
+├── when caller is not registered rollup
+│   └── it reverts
+└── when caller is registered rollup
+    ├── given attester not found in caller instance
+    │   ├── given caller is not canonical
+    │   │   └── it reverts
+    │   └── given caller is canonical
+    │       ├── given attester not found in canonical
+    │       │   └── it reverts
+    │       └── given attester found in canonical
+    │           ├── given balance less than amount
+    │           │   └── it reverts
+    │           └── given balance greater or equal to amount
+    │               ├── given balance minus amount less than minimum stake
+    │               │   ├── it removes attester from canonical instance
+    │               │   ├── it deletes attester config
+    │               │   ├── it delegates attester to address zero
+    │               │   ├── it withdraws full balance
+    │               │   ├── it decreases delegation balance by full amount
+    │               │   ├── it initiates withdrawal in governance
+    │               │   └── it returns full balance, true, withdrawal id
+    │               └── given balance minus amount greater or equal to minimum stake
+    │                   ├── it withdraws specified amount
+    │                   ├── it decreases delegation balance by specified amount
+    │                   ├── it initiates withdrawal in governance
+    │                   └── it returns specified amount, false, withdrawal id
+    └── given attester found in caller instance
+        ├── given balance less than amount 2
+        │   └── it reverts
+        └── given balance greater or equal to amount 2
+            ├── given balance minus amount less than minimum stake 2
+            │   ├── it removes attester from caller instance
+            │   ├── it deletes attester config
+            │   ├── it delegates attester to address zero
+            │   ├── it withdraws full balance
+            │   ├── it decreases delegation balance by full amount
+            │   ├── it initiates withdrawal in governance
+            │   └── it returns full balance, true, withdrawal id
+            └── given balance minus amount greater or equal to minimum stake 2
+                ├── it withdraws specified amount
+                ├── it decreases delegation balance by specified amount
+                ├── it initiates withdrawal in governance
+                └── it returns specified amount, false, withdrawal id

--- a/l1-contracts/test/staking/deposit.t.sol
+++ b/l1-contracts/test/staking/deposit.t.sol
@@ -73,7 +73,7 @@ contract DepositTest is StakingBase {
     staking.deposit({_attester: ATTESTER, _withdrawer: WITHDRAWER, _onCanonical: true});
 
     // The real error gets caught by the flushEntryQueue call
-    // address magicAddress = address(staking.getGSE().CANONICAL_MAGIC_ADDRESS());
+    // address magicAddress = address(staking.getGSE().getCanonicalMagicAddress());
     // vm.expectRevert(
     //   abi.encodeWithSelector(Errors.Staking__AlreadyRegistered.selector, magicAddress, ATTESTER)
     // );

--- a/l1-contracts/test/staking/flushEntryQueue.t.sol
+++ b/l1-contracts/test/staking/flushEntryQueue.t.sol
@@ -120,7 +120,7 @@ contract FlushEntryQueueTest is StakingBase {
     }
 
     // Check the canonical set has the proper validators
-    address canonicalMagicAddress = gse.CANONICAL_MAGIC_ADDRESS();
+    address canonicalMagicAddress = gse.getCanonicalMagicAddress();
     address[] memory attestersOnCanonical =
       gse.getAttestersAtTime(canonicalMagicAddress, Timestamp.wrap(block.timestamp));
     assertEq(


### PR DESCRIPTION
Fixes #15079 

Adds a whole bunch of tests for the GSE, and deletes some of the `effective` functions as they are likely more confusing than useful. For now keeping the effective balance because it is useful internally in the GSE  