### PR TITLE
chore: address misc coverage

### DIFF
--- a/l1-contracts/test/governance/registry/addRollup.t.sol
+++ b/l1-contracts/test/governance/registry/addRollup.t.sol
@@ -46,6 +46,9 @@ contract UpgradeTest is RegistryBase {
     IRollup newRollup = IRollup(address(new FakeRollup()));
     uint256 version = newRollup.getVersion();
 
+    vm.expectRevert(abi.encodeWithSelector(Errors.Registry__RollupNotRegistered.selector, version));
+    registry.getRollup(version);
+
     vm.expectEmit(true, true, false, false, address(registry));
     emit IRegistry.InstanceAdded(address(newRollup), version);
     registry.addRollup(newRollup);
@@ -53,5 +56,6 @@ contract UpgradeTest is RegistryBase {
     assertEq(registry.numberOfVersions(), 1);
 
     assertEq(address(registry.getRollup(version)), address(newRollup));
+    assertEq(registry.getVersion(0), version);
   }
 }

--- a/l1-contracts/test/governance/reward-distributor/claimBlockRewards.t.sol
+++ b/l1-contracts/test/governance/reward-distributor/claimBlockRewards.t.sol
@@ -30,7 +30,7 @@ contract ClaimBlockRewardsTest is RewardDistributorBase {
     vm.record();
     vm.prank(caller);
     assertEq(rewardDistributor.claimBlockRewards(caller, _blocks), 0);
-    (, bytes32[] memory writes) = vm.accesses(address(this));
+    (, bytes32[] memory writes) = vm.accesses(address(token));
     assertEq(writes.length, 0);
   }
 

--- a/l1-contracts/test/governance/reward-distributor/claimBlockRewards.t.sol
+++ b/l1-contracts/test/governance/reward-distributor/claimBlockRewards.t.sol
@@ -1,0 +1,61 @@
+// SPDX-License-Identifier: UNLICENSED
+pragma solidity >=0.8.27;
+
+import {RewardDistributorBase} from "./Base.t.sol";
+
+import {Errors} from "@aztec/governance/libraries/Errors.sol";
+
+contract ClaimBlockRewardsTest is RewardDistributorBase {
+  address internal caller;
+
+  function test_WhenCallerIsNotCanonical(address _caller) external {
+    // it reverts
+    address canonical = rewardDistributor.canonicalRollup();
+    vm.assume(_caller != canonical);
+
+    vm.expectRevert(
+      abi.encodeWithSelector(Errors.RewardDistributor__InvalidCaller.selector, _caller, canonical)
+    );
+    vm.prank(_caller);
+    rewardDistributor.claimBlockRewards(_caller, 1);
+  }
+
+  modifier whenCallerIsCanonical() {
+    caller = address(registry.getCanonicalRollup());
+    _;
+  }
+
+  function test_GivenBalanceIs0(uint8 _blocks) external whenCallerIsCanonical {
+    // it return 0
+    vm.record();
+    vm.prank(caller);
+    assertEq(rewardDistributor.claimBlockRewards(caller, _blocks), 0);
+    (, bytes32[] memory writes) = vm.accesses(address(this));
+    assertEq(writes.length, 0);
+  }
+
+  function test_GivenBalanceGt0(uint256 _balance, uint8 _blocks) external whenCallerIsCanonical {
+    // it transfer min(balance, BLOCK_REWARD * blocks)
+    // it return min(balance, BLOCK_REWARD * blocks)
+
+    uint256 blocks = bound(_blocks, 1, type(uint8).max);
+    uint256 balance = bound(_balance, 1, type(uint256).max);
+    token.mint(address(rewardDistributor), balance);
+
+    uint256 reward = balance > rewardDistributor.BLOCK_REWARD() * blocks
+      ? rewardDistributor.BLOCK_REWARD() * blocks
+      : balance;
+
+    uint256 callerBalance = token.balanceOf(caller);
+    vm.prank(caller);
+    vm.record();
+    uint256 claimed = rewardDistributor.claimBlockRewards(caller, blocks);
+    (, bytes32[] memory writes) = vm.accesses(address(token));
+
+    assertEq(claimed, reward);
+    assertEq(token.balanceOf(caller), callerBalance + reward);
+    assertEq(token.balanceOf(address(rewardDistributor)), balance - reward);
+
+    assertEq(writes.length, 2, "writes");
+  }
+}

--- a/l1-contracts/test/governance/reward-distributor/claimBlockRewards.tree
+++ b/l1-contracts/test/governance/reward-distributor/claimBlockRewards.tree
@@ -1,0 +1,9 @@
+ClaimBlockRewardsTest
+├── when caller is not canonical
+│   └── it reverts
+└── when caller is canonical
+    ├── given balance is 0
+    │   └── it return 0
+    └── given balance gt 0
+        ├── it transfer min(balance, BLOCK_REWARD * blocks)
+        └── it return min(balance, BLOCK_REWARD * blocks)


### PR DESCRIPTION
Adds a few tests to have explicit covered as part of the governance on its own, no need to run the core tests to have that covered. 

Few missing partly because of some oddities with modifiers. 


![mood GIF](https://media4.giphy.com/media/sRGUfdb6sNwn1lXRp9/giphy.gif)

![image](https://github.com/user-attachments/assets/169b94eb-f2b9-43b3-8336-1b1d3d54abdb)
