### PR TITLE
feat: optimize getting contract address

### DIFF
--- a/noir-projects/aztec-nr/aztec/src/macros/functions/initialization_utils.nr
+++ b/noir-projects/aztec-nr/aztec/src/macros/functions/initialization_utils.nr
@@ -24,8 +24,9 @@ pub fn mark_as_initialized_private(context: &mut PrivateContext) {
 }
 
 pub fn assert_is_initialized_public(context: &mut PublicContext) {
-    let init_nullifier = compute_unsiloed_contract_initialization_nullifier(context.this_address());
-    assert(context.nullifier_exists(init_nullifier, context.this_address()), "Not initialized");
+    let this_address = context.this_address();
+    let init_nullifier = compute_unsiloed_contract_initialization_nullifier(this_address);
+    assert(context.nullifier_exists(init_nullifier, this_address), "Not initialized");
 }
 
 pub fn assert_is_initialized_private(context: &mut PrivateContext) {

--- a/noir-projects/noir-contracts/contracts/app/amm_contract/src/main.nr
+++ b/noir-projects/noir-contracts/contracts/app/amm_contract/src/main.nr
@@ -98,6 +98,7 @@ pub contract AMM {
         let liquidity_token = Token::at(config.liquidity_token);
 
         let sender = context.msg_sender();
+        let this_address = context.this_address();
 
         // We don't yet know how many tokens the sender will actually supply - that can only be computed during public
         // execution since the amounts supplied must have the same ratio as the live balances. We therefore transfer the
@@ -105,7 +106,7 @@ pub contract AMM {
         let refund_token0_partial_note = token0
             .transfer_to_public_and_prepare_private_balance_increase(
                 sender,
-                context.this_address(),
+                this_address,
                 amount0_max,
                 authwit_nonce,
             )
@@ -114,7 +115,7 @@ pub contract AMM {
         let refund_token1_partial_note = token1
             .transfer_to_public_and_prepare_private_balance_increase(
                 sender,
-                context.this_address(),
+                this_address,
                 amount1_max,
                 authwit_nonce,
             )
@@ -129,7 +130,7 @@ pub contract AMM {
         // We then complete the flow in public. Note that the type of operation and amounts will all be publicly known,
         // but the identity of the caller is not revealed despite us being able to send tokens to them by completing the
         // partial notes.
-        AMM::at(context.this_address())
+        AMM::at(this_address)
             ._add_liquidity(
                 config,
                 refund_token0_partial_note,
@@ -158,16 +159,17 @@ pub contract AMM {
         let token0 = Token::at(config.token0);
         let token1 = Token::at(config.token1);
         let liquidity_token = Token::at(config.liquidity_token);
+        let this_address = context.this_address();
 
         // We read the current AMM balance of both tokens. Note that by the time this function is called the token
         // transfers have already been completed (since those calls were enqueued before this call), and so we need to
         // subtract the transfer amount to get the pre-deposit balance.
         let balance0_plus_amount0_max =
-            token0.balance_of_public(context.this_address()).view(&mut context);
+            token0.balance_of_public(this_address).view(&mut context);
         let balance0 = balance0_plus_amount0_max - amount0_max;
 
         let balance1_plus_amount1_max =
-            token1.balance_of_public(context.this_address()).view(&mut context);
+            token1.balance_of_public(this_address).view(&mut context);
         let balance1 = balance1_plus_amount1_max - amount1_max;
 
         // With the current balances known, we can calculate the token amounts to the pool, respecting the user's
@@ -251,13 +253,14 @@ pub contract AMM {
         let token1 = Token::at(config.token1);
 
         let sender = context.msg_sender();
+        let this_address = context.this_address();
 
         // Liquidity tokens are burned when liquidity is removed in order to reduce the total supply. However, we lack
         // a function to privately burn, so we instead transfer the tokens into the AMM's public balance, and then have
         // the AMM publicly burn its own tokens.
         // TODO(#10287): consider adding a private burn
         liquidity_token
-            .transfer_to_public(sender, context.this_address(), liquidity, authwit_nonce)
+            .transfer_to_public(sender, this_address, liquidity, authwit_nonce)
             .call(&mut context);
 
         // We don't yet know how many tokens the sender will get - that can only be computed during public execution
@@ -270,7 +273,7 @@ pub contract AMM {
         // We then complete the flow in public. Note that the type of operation and amounts will all be publicly known,
         // but the identity of the caller is not revealed despite us being able to send tokens to them by completing the
         // partial notes.
-        AMM::at(context.this_address())
+        AMM::at(this_address)
             ._remove_liquidity(
                 config,
                 liquidity,
@@ -295,11 +298,13 @@ pub contract AMM {
         let token0 = Token::at(config.token0);
         let token1 = Token::at(config.token1);
         let liquidity_token = Token::at(config.liquidity_token);
+        let this_address = context.this_address();
+
 
         // We need the current balance of both tokens as well as the liquidity token total supply in order to compute
         // the amounts to send the user.
-        let balance0 = token0.balance_of_public(context.this_address()).view(&mut context);
-        let balance1 = token1.balance_of_public(context.this_address()).view(&mut context);
+        let balance0 = token0.balance_of_public(this_address).view(&mut context);
+        let balance1 = token1.balance_of_public(this_address).view(&mut context);
         let total_supply = liquidity_token.total_supply().view(&mut context);
 
         // We calculate the amounts of token0 and token1 the user is entitled to based on the amount of liquidity they
@@ -310,7 +315,7 @@ pub contract AMM {
 
         // We can now burn the liquidity tokens that had been privately transferred into the AMM, as well as complete
         // both partial notes.
-        liquidity_token.burn_public(context.this_address(), liquidity, 0).call(&mut context);
+        liquidity_token.burn_public(this_address, liquidity, 0).call(&mut context);
         token0.finalize_transfer_to_private(amount0, token0_partial_note).call(&mut context);
         token1.finalize_transfer_to_private(amount1, token1_partial_note).call(&mut context);
     }
@@ -336,17 +341,18 @@ pub contract AMM {
         assert(token_in != token_out, "SAME_TOKEN_SWAP");
 
         let sender = context.msg_sender();
+        let this_address = context.this_address();
 
         // We transfer the full amount in, since it is an exact amount, and prepare a partial note for the amount out,
         // which will only be known during public execution as it depends on the live balances.
         Token::at(token_in)
-            .transfer_to_public(sender, context.this_address(), amount_in, authwit_nonce)
+            .transfer_to_public(sender, this_address, amount_in, authwit_nonce)
             .call(&mut context);
         let token_out_partial_note = Token::at(token_out)
             .prepare_private_balance_increase(sender, sender)
             .call(&mut context);
 
-        AMM::at(context.this_address())
+        AMM::at(this_address)
             ._swap_exact_tokens_for_tokens(
                 token_in,
                 token_out,
@@ -369,12 +375,13 @@ pub contract AMM {
         // In order to compute the amount to swap we need the live token balances. Note that at this state the token in
         // transfer has already been completed as that function call was enqueued before this one. We therefore need to
         // subtract the amount in to get the pre-swap balances.
+        let this_address = context.this_address();
         let balance_in_plus_amount_in =
-            Token::at(token_in).balance_of_public(context.this_address()).view(&mut context);
+            Token::at(token_in).balance_of_public(this_address).view(&mut context);
         let balance_in = balance_in_plus_amount_in - amount_in;
 
         let balance_out =
-            Token::at(token_out).balance_of_public(context.this_address()).view(&mut context);
+            Token::at(token_out).balance_of_public(this_address).view(&mut context);
 
         // We can now compute the number of tokens to transfer and complete the partial note.
         let amount_out = get_amount_out(amount_in, balance_in, balance_out);
@@ -406,6 +413,7 @@ pub contract AMM {
         assert(token_in != token_out, "SAME_TOKEN_SWAP");
 
         let sender = context.msg_sender();
+        let this_address = context.this_address();
 
         // We don't know how many tokens we'll receive from the user, since the swap amount will only be known during
         // public execution as it depends on the live balances. We therefore transfer the full maximum amount and
@@ -416,7 +424,7 @@ pub contract AMM {
         let change_token_in_partial_note = Token::at(token_in)
             .transfer_to_public_and_prepare_private_balance_increase(
                 sender,
-                context.this_address(),
+                this_address,
                 amount_in_max,
                 authwit_nonce,
             )
@@ -426,7 +434,7 @@ pub contract AMM {
             .prepare_private_balance_increase(sender, sender)
             .call(&mut context);
 
-        AMM::at(context.this_address())
+        AMM::at(this_address)
             ._swap_tokens_for_exact_tokens(
                 token_in,
                 token_out,
@@ -451,12 +459,13 @@ pub contract AMM {
         // In order to compute the amount to swap we need the live token balances. Note that at this state the token in
         // transfer has already been completed as that function call was enqueued before this one. We therefore need to
         // subtract the amount in to get the pre-swap balances.
+        let this_address = context.this_address();
         let balance_in_plus_amount_in_max =
-            Token::at(token_in).balance_of_public(context.this_address()).view(&mut context);
+            Token::at(token_in).balance_of_public(this_address).view(&mut context);
         let balance_in = balance_in_plus_amount_in_max - amount_in_max;
 
         let balance_out =
-            Token::at(token_out).balance_of_public(context.this_address()).view(&mut context);
+            Token::at(token_out).balance_of_public(this_address).view(&mut context);
 
         // We can now compute the number of tokens we need to receive and complete the partial note with the change.
         let amount_in = get_amount_in(amount_out, balance_in, balance_out);

--- a/noir-projects/noir-contracts/contracts/app/amm_contract/src/main.nr
+++ b/noir-projects/noir-contracts/contracts/app/amm_contract/src/main.nr
@@ -164,12 +164,10 @@ pub contract AMM {
         // We read the current AMM balance of both tokens. Note that by the time this function is called the token
         // transfers have already been completed (since those calls were enqueued before this call), and so we need to
         // subtract the transfer amount to get the pre-deposit balance.
-        let balance0_plus_amount0_max =
-            token0.balance_of_public(this_address).view(&mut context);
+        let balance0_plus_amount0_max = token0.balance_of_public(this_address).view(&mut context);
         let balance0 = balance0_plus_amount0_max - amount0_max;
 
-        let balance1_plus_amount1_max =
-            token1.balance_of_public(this_address).view(&mut context);
+        let balance1_plus_amount1_max = token1.balance_of_public(this_address).view(&mut context);
         let balance1 = balance1_plus_amount1_max - amount1_max;
 
         // With the current balances known, we can calculate the token amounts to the pool, respecting the user's
@@ -259,9 +257,9 @@ pub contract AMM {
         // a function to privately burn, so we instead transfer the tokens into the AMM's public balance, and then have
         // the AMM publicly burn its own tokens.
         // TODO(#10287): consider adding a private burn
-        liquidity_token
-            .transfer_to_public(sender, this_address, liquidity, authwit_nonce)
-            .call(&mut context);
+        liquidity_token.transfer_to_public(sender, this_address, liquidity, authwit_nonce).call(
+            &mut context,
+        );
 
         // We don't yet know how many tokens the sender will get - that can only be computed during public execution
         // since the it depends on the live balances. We therefore simply prepare partial notes to the sender.
@@ -299,7 +297,6 @@ pub contract AMM {
         let token1 = Token::at(config.token1);
         let liquidity_token = Token::at(config.liquidity_token);
         let this_address = context.this_address();
-
 
         // We need the current balance of both tokens as well as the liquidity token total supply in order to compute
         // the amounts to send the user.
@@ -345,9 +342,9 @@ pub contract AMM {
 
         // We transfer the full amount in, since it is an exact amount, and prepare a partial note for the amount out,
         // which will only be known during public execution as it depends on the live balances.
-        Token::at(token_in)
-            .transfer_to_public(sender, this_address, amount_in, authwit_nonce)
-            .call(&mut context);
+        Token::at(token_in).transfer_to_public(sender, this_address, amount_in, authwit_nonce).call(
+            &mut context,
+        );
         let token_out_partial_note = Token::at(token_out)
             .prepare_private_balance_increase(sender, sender)
             .call(&mut context);
@@ -380,8 +377,7 @@ pub contract AMM {
             Token::at(token_in).balance_of_public(this_address).view(&mut context);
         let balance_in = balance_in_plus_amount_in - amount_in;
 
-        let balance_out =
-            Token::at(token_out).balance_of_public(this_address).view(&mut context);
+        let balance_out = Token::at(token_out).balance_of_public(this_address).view(&mut context);
 
         // We can now compute the number of tokens to transfer and complete the partial note.
         let amount_out = get_amount_out(amount_in, balance_in, balance_out);
@@ -464,8 +460,7 @@ pub contract AMM {
             Token::at(token_in).balance_of_public(this_address).view(&mut context);
         let balance_in = balance_in_plus_amount_in_max - amount_in_max;
 
-        let balance_out =
-            Token::at(token_out).balance_of_public(this_address).view(&mut context);
+        let balance_out = Token::at(token_out).balance_of_public(this_address).view(&mut context);
 
         // We can now compute the number of tokens we need to receive and complete the partial note with the change.
         let amount_in = get_amount_in(amount_out, balance_in, balance_out);

--- a/noir-projects/noir-contracts/contracts/app/lending_contract/src/main.nr
+++ b/noir-projects/noir-contracts/contracts/app/lending_contract/src/main.nr
@@ -111,13 +111,14 @@ pub contract Lending {
         on_behalf_of: Field,
         collateral_asset: AztecAddress,
     ) {
+        let this_address = context.this_address();
         let on_behalf_of =
             compute_identifier(secret, on_behalf_of, context.msg_sender().to_field());
         let _res = Token::at(collateral_asset)
-            .transfer_to_public(from, context.this_address(), amount, authwit_nonce)
+            .transfer_to_public(from, this_address, amount, authwit_nonce)
             .call(&mut context);
         // docs:start:enqueue_public
-        Lending::at(context.this_address())
+        Lending::at(this_address)
             ._deposit(AztecAddress::from_field(on_behalf_of), amount, collateral_asset)
             .enqueue(&mut context);
         // docs:end:enqueue_public
@@ -131,11 +132,12 @@ pub contract Lending {
         collateral_asset: AztecAddress,
     ) {
         // docs:start:public_to_public_call
+        let this_address = context.this_address();
         let _ = Token::at(collateral_asset)
-            .transfer_in_public(context.msg_sender(), context.this_address(), amount, authwit_nonce)
+            .transfer_in_public(context.msg_sender(), this_address, amount, authwit_nonce)
             .call(&mut context);
         // docs:end:public_to_public_call
-        let _ = Lending::at(context.this_address())
+        let _ = Lending::at(this_address)
             ._deposit(AztecAddress::from_field(on_behalf_of), amount, collateral_asset)
             .call(&mut context);
     }

--- a/noir-projects/noir-contracts/contracts/fees/fpc_contract/src/main.nr
+++ b/noir-projects/noir-contracts/contracts/fees/fpc_contract/src/main.nr
@@ -196,8 +196,9 @@ pub contract FPC {
         let token = Token::at(config.accepted_asset);
 
         // We send the full balance to `to`.
-        let balance = token.balance_of_public(context.this_address()).view(&mut context);
-        token.transfer_in_public(context.this_address(), to, balance, 0).call(&mut context);
+        let this_address = context.this_address();
+        let balance = token.balance_of_public(this_address).view(&mut context);
+        token.transfer_in_public(this_address, to, balance, 0).call(&mut context);
     }
 
     /// Note: Not marked as view as we need it to be callable as an entrypoint since in some places we need to obtain


### PR DESCRIPTION
Oracle calls are all considered impure as we we can't enforce that it will return a consistent value on repeated calls. This means that we're doing unnecessary oracle calls here where we can just cache the result.