### PR TITLE
fix: Increase gas limit for propose and vote bundle

### DIFF
--- a/yarn-project/foundation/src/bigint/index.ts
+++ b/yarn-project/foundation/src/bigint/index.ts
@@ -13,3 +13,8 @@ export function maxBigint(...values: bigint[]): bigint {
   }
   return values.reduce((max, value) => (value > max ? value : max), values[0]);
 }
+
+/** Sums an array of bigints */
+export function sumBigint(values: bigint[]): bigint {
+  return values.reduce((sum, value) => sum + value, 0n);
+}

--- a/yarn-project/sequencer-client/src/publisher/sequencer-publisher.test.ts
+++ b/yarn-project/sequencer-client/src/publisher/sequencer-publisher.test.ts
@@ -57,6 +57,7 @@ describe('SequencerPublisher', () => {
   let publisher: SequencerPublisher;
 
   const GAS_GUESS = 300_000n;
+  const VOTE_GAS_GUESS = 200_000n;
 
   beforeEach(async () => {
     jest.clearAllMocks();
@@ -256,8 +257,11 @@ describe('SequencerPublisher', () => {
         },
       ],
       l1TxUtils,
-      // val + (val * 20n) / 100n
-      { gasLimit: 1_000_000n + GAS_GUESS + ((1_000_000n + GAS_GUESS) * 20n) / 100n },
+      // vote + val + (val * 20n) / 100n
+      {
+        gasLimit: VOTE_GAS_GUESS + 1_000_000n + GAS_GUESS + ((1_000_000n + GAS_GUESS) * 20n) / 100n,
+        txTimeoutAt: undefined,
+      },
       { blobs: expectedBlobs.map(b => b.data), kzg },
       mockRollupAddress,
       expect.anything(), // the logger

--- a/yarn-project/sequencer-client/src/publisher/sequencer-publisher.test.ts
+++ b/yarn-project/sequencer-client/src/publisher/sequencer-publisher.test.ts
@@ -57,7 +57,6 @@ describe('SequencerPublisher', () => {
   let publisher: SequencerPublisher;
 
   const GAS_GUESS = 300_000n;
-  const VOTE_GAS_GUESS = 200_000n;
 
   beforeEach(async () => {
     jest.clearAllMocks();
@@ -259,7 +258,7 @@ describe('SequencerPublisher', () => {
       l1TxUtils,
       // vote + val + (val * 20n) / 100n
       {
-        gasLimit: VOTE_GAS_GUESS + 1_000_000n + GAS_GUESS + ((1_000_000n + GAS_GUESS) * 20n) / 100n,
+        gasLimit: SequencerPublisher.VOTE_GAS_GUESS + 1_000_000n + GAS_GUESS + ((1_000_000n + GAS_GUESS) * 20n) / 100n,
         txTimeoutAt: undefined,
       },
       { blobs: expectedBlobs.map(b => b.data), kzg },

--- a/yarn-project/sequencer-client/src/publisher/sequencer-publisher.ts
+++ b/yarn-project/sequencer-client/src/publisher/sequencer-publisher.ts
@@ -100,7 +100,9 @@ export class SequencerPublisher {
   // Total used for full block from int_l1_pub e2e test: 1m (of which 86k is 1x blob)
   // Total used for emptier block from above test: 429k (of which 84k is 1x blob)
   public static PROPOSE_GAS_GUESS: bigint = 12_000_000n;
-  public static VOTE_GAS_GUESS: bigint = 200_000n;
+
+  // Gas report for VotingWithSigTest shows a max gas of 100k, so better err on the safe side
+  public static VOTE_GAS_GUESS: bigint = 500_000n;
 
   public l1TxUtils: L1TxUtilsWithBlobs;
   public rollupContract: RollupContract;


### PR DESCRIPTION
When sending a multicall tx that included a block proposal and a vote, the sequencer publisher is using only the gas limit from the proposal, without taking into consideration the vote.

I suspect this could have been causing many of the failures in the `add_rollup` e2e test, which [timed out](http://ci.aztec-labs.com/6679f77def076f97) after a loop of failed L1 transactions with errors like:

```
11:37:50 [11:37:50.270] VERBOSE: node:4501 Sent L1 transaction 0xa3acf2252fc737e19b5f754b1c4564462de6cbbfc22c1b423558eeee86c17158 {"gasLimit":430488,"maxFeePerGas":"1.207210676","maxPriorityFeePerGas":"1.2","maxFeePerBlobGas":"0.000000001"}
11:37:53 [11:37:53.080] WARN: foundation:test-date-provider Time set to 2025-06-18T11:51:24.000Z {"offset":810920,"timeMs":1750247484000}
11:37:53 [11:37:53.086] INFO: aztecjs:utils:chain_monitor L1 block 46 mined at 11:51:24 {"l1Timestamp":1750247484,"l1BlockNumber":46,"l2SlotNumber":80,"l2BlockNumber":4,"l2ProvenBlockNumber":0,"totalL2Messages":1}
11:37:53 [11:37:53.300] ERROR: node:4501 L1 transaction 0xa3acf2252fc737e19b5f754b1c4564462de6cbbfc22c1b423558eeee86c17158 reverted: {
11:37:53   type: 'eip4844',
11:37:53   status: 'reverted',
11:37:53   cumulativeGasUsed: 424236n,
11:37:53   logs: [],
11:37:53   logsBloom: '0x00000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000',
11:37:53   transactionHash: '0xa3acf2252fc737e19b5f754b1c4564462de6cbbfc22c1b423558eeee86c17158',
11:37:53   transactionIndex: 0,
11:37:53   blockHash: '0x8ea36f346ffa893d41ab81473c11bb45992cfe93807b25f9a4f17af830afaad2',
11:37:53   blockNumber: 46n,
11:37:53   gasUsed: 424236n,
11:37:53   effectiveGasPrice: 1203938893n,
11:37:53   blobGasUsed: 131072n,
11:37:53   blobGasPrice: 1n,
11:37:53   from: '0x3c44cdddb6a900fa2b585dd299e03d12fa4293bc',
11:37:53   to: '0xca11bde05977b3631167028862be2a173976ca11',
11:37:53   contractAddress: null
11:37:53 }
```

Note that the `gasUsed` in the receipt is 424236, the `gasLimit` of the tx is 430488, and that `430488*63/64=423761`, which is very close to `424236`, which may hint to an out of gas (see [EIP150](https://github.com/ethereum/EIPs/blob/master/EIPS/eip-150.md) for rationale on the 63/64). 

Also, if this is indeed an out of gas, this means that if a single call fails due to OOG, the entire tx reverts. So an incorrect estimation of the gas for block building means that the vote will also fail. Not sure if this is can be an issue.

To fix the OOG, this PR adds a gas guess for voting of 500k gas, and adds it to the gas estimate for the proposal. This guess is based on running a gas-report on the `VotingWithSigTest`, which yielded the values below (setting a guess of 200k didn't work).

```
"vote(address)": {
  "calls": 293,
  "min": 34629,
  "mean": 43768,
  "median": 40762,
  "max": 110037
},
```

I'm clueless as to why this works locally and not on CI though.