### PR TITLE
chore: Support ci-no-fail-fast label

### DIFF
--- a/.github/workflows/ci3-external.yml
+++ b/.github/workflows/ci3-external.yml
@@ -32,7 +32,7 @@ jobs:
           # The commit to checkout.  We want our actual commit, and not the result of merging the PR to the target.
           ref: ${{ github.event.pull_request.head.sha || github.sha }}
 
-      # NOTE: in ci3.yml we just rely on draft mode not being mergable. 
+      # NOTE: in ci3.yml we just rely on draft mode not being mergable.
       # Here we are a little more careful than just skipping the worklfow, in case of an edge case allowing merge.
       - name: Fail If Draft
         if: github.event.pull_request.draft
@@ -69,6 +69,10 @@ jobs:
       - name: Cache Override
         if: contains(github.event.pull_request.labels.*.name, 'ci-no-cache')
         run: echo "NO_CACHE=1" >> $GITHUB_ENV
+
+      - name: Fail Fast Override
+        if: contains(github.event.pull_request.labels.*.name, 'ci-no-fail-fast')
+        run: echo "NO_FAIL_FAST=1" >> $GITHUB_ENV
 
       - name: Setup
         run: |

--- a/.github/workflows/ci3.yml
+++ b/.github/workflows/ci3.yml
@@ -42,6 +42,10 @@ jobs:
         if: contains(github.event.pull_request.labels.*.name, 'ci-no-cache')
         run: echo "NO_CACHE=1" >> $GITHUB_ENV
 
+      - name: Fail Fast Override
+        if: contains(github.event.pull_request.labels.*.name, 'ci-no-fail-fast')
+        run: echo "NO_FAIL_FAST=1" >> $GITHUB_ENV
+
       - name: Compute Target Branch
         id: target_branch
         run: |

--- a/ci3/bootstrap_ec2
+++ b/ci3/bootstrap_ec2
@@ -234,6 +234,7 @@ function run {
       -e TARGET_BRANCH=${TARGET_BRANCH:-} \
       -e PARENT_LOG_URL=${PARENT_LOG_URL:-} \
       -e NO_CACHE=${NO_CACHE:-} \
+      -e NO_FAIL_FAST=${NO_FAIL_FAST:-} \
       -e CI_REDIS='ci-redis-tiered.lzka0i.ng.0001.use2.cache.amazonaws.com' \
       -e SSH_CONNECTION=' ' \
       -e LOCAL_USER_ID=\$(id -u) \


### PR DESCRIPTION
Similar to ci-no-cache, checks if the `ci-no-fail-fast` label is set, and if so, sets `NO_FAIL_FAST` in the env.
