### PR TITLE
feat: Validate block proposal in hash

### DIFF
--- a/aztec-up/bin/aztec
+++ b/aztec-up/bin/aztec
@@ -109,6 +109,7 @@ case ${1:-} in
       PORTS_TO_EXPOSE="${PORTS_TO_EXPOSE:-} $anvil_port_assignment"
 
       exec $(dirname $0)/.aztec-run aztec-sandbox bash -c "
+        anvil --version
         anvil --host 0.0.0.0 --silent &
         node --no-warnings /usr/src/yarn-project/aztec/dest/bin/index.js \"\$@\"
       " bash "$@"

--- a/yarn-project/aztec-node/src/aztec-node/server.ts
+++ b/yarn-project/aztec-node/src/aztec-node/server.ts
@@ -282,7 +282,6 @@ export class AztecNodeService implements AztecNode, AztecNodeAdmin, Traceable {
         l1ChainId: config.l1ChainId,
         txPublicSetupAllowList: config.txPublicSetupAllowList,
       },
-      archiver,
       worldStateSynchronizer,
       archiver,
       dateProvider,
@@ -305,6 +304,7 @@ export class AztecNodeService implements AztecNode, AztecNodeAdmin, Traceable {
       const txCollector = new TxCollector(p2pClient);
       epochPruneWatcher = new EpochPruneWatcher(
         archiver,
+        archiver,
         epochCache,
         txCollector,
         blockBuilder,
@@ -321,6 +321,7 @@ export class AztecNodeService implements AztecNode, AztecNodeAdmin, Traceable {
       epochCache,
       blockBuilder,
       blockSource: archiver,
+      l1ToL2MessageSource: archiver,
     });
 
     if (validatorClient) {

--- a/yarn-project/end-to-end/src/e2e_p2p/reex.test.ts
+++ b/yarn-project/end-to-end/src/e2e_p2p/reex.test.ts
@@ -1,5 +1,5 @@
 import type { AztecNodeService } from '@aztec/aztec-node';
-import { type SentTx, Tx, sleep } from '@aztec/aztec.js';
+import { Fr, type SentTx, Tx, sleep } from '@aztec/aztec.js';
 import { times } from '@aztec/foundation/collection';
 import type { BlockBuilder } from '@aztec/sequencer-client';
 import type { PublicTxResult, PublicTxSimulator } from '@aztec/simulator/server';
@@ -193,7 +193,7 @@ describe('e2e_p2p_reex', () => {
     };
 
     it.each([
-      ['ReExStateMismatchError', new ReExStateMismatchError().message, interceptBroadcastProposal],
+      ['ReExStateMismatchError', new ReExStateMismatchError(Fr.ZERO, Fr.ZERO).message, interceptBroadcastProposal],
       ['ReExTimeoutError', new ReExTimeoutError().message, interceptTxProcessorWithTimeout],
       ['ReExFailedTxsError', new ReExFailedTxsError(1).message, interceptTxProcessorWithFailure],
     ])(

--- a/yarn-project/foundation/src/trees/merkle_tree_calculator.ts
+++ b/yarn-project/foundation/src/trees/merkle_tree_calculator.ts
@@ -17,7 +17,7 @@ export class MerkleTreeCalculator {
 
   static async create(
     height: number,
-    zeroLeaf = Buffer.alloc(32),
+    zeroLeaf: Buffer = Buffer.alloc(32),
     hasher = async (left: Buffer, right: Buffer) =>
       (await pedersenHash([left, right])).toBuffer() as Buffer<ArrayBuffer>,
   ) {

--- a/yarn-project/prover-client/src/orchestrator/block-building-helpers.ts
+++ b/yarn-project/prover-client/src/orchestrator/block-building-helpers.ts
@@ -351,16 +351,7 @@ export const buildHeaderAndBodyFromTxs = runInSpan(
               ),
             );
 
-    l1ToL2Messages = padArrayEnd(l1ToL2Messages, Fr.ZERO, NUMBER_OF_L1_L2_MESSAGES_PER_ROLLUP);
-    const hasher = (left: Buffer, right: Buffer) =>
-      Promise.resolve(sha256Trunc(Buffer.concat([left, right])) as Buffer<ArrayBuffer>);
-    const parityHeight = Math.ceil(Math.log2(NUMBER_OF_L1_L2_MESSAGES_PER_ROLLUP));
-    const parityCalculator = await MerkleTreeCalculator.create(
-      parityHeight,
-      Fr.ZERO.toBuffer() as Buffer<ArrayBuffer>,
-      hasher,
-    );
-    const parityShaRoot = new Fr(await parityCalculator.computeTreeRoot(l1ToL2Messages.map(msg => msg.toBuffer())));
+    const parityShaRoot = await computeInHashFromL1ToL2Messages(l1ToL2Messages);
     const blobsHash = getBlobsHashFromBlobs(await Blob.getBlobsPerBlock(body.toBlobFields()));
 
     const contentCommitment = new ContentCommitment(blobsHash, parityShaRoot, outHash);
@@ -373,6 +364,16 @@ export const buildHeaderAndBodyFromTxs = runInSpan(
     return { header, body };
   },
 );
+
+/** Computes the inHash for a block's ContentCommitment given its l1 to l2 messages. */
+export async function computeInHashFromL1ToL2Messages(unpaddedL1ToL2Messages: Fr[]): Promise<Fr> {
+  const l1ToL2Messages = padArrayEnd(unpaddedL1ToL2Messages, Fr.ZERO, NUMBER_OF_L1_L2_MESSAGES_PER_ROLLUP);
+  const hasher = (left: Buffer, right: Buffer) =>
+    Promise.resolve(sha256Trunc(Buffer.concat([left, right])) as Buffer<ArrayBuffer>);
+  const parityHeight = Math.ceil(Math.log2(NUMBER_OF_L1_L2_MESSAGES_PER_ROLLUP));
+  const parityCalculator = await MerkleTreeCalculator.create(parityHeight, Fr.ZERO.toBuffer(), hasher);
+  return new Fr(await parityCalculator.computeTreeRoot(l1ToL2Messages.map(msg => msg.toBuffer())));
+}
 
 export function getBlobsHashFromBlobs(inputs: Blob[]): Fr {
   return sha256ToField(inputs.map(b => b.getEthVersionedBlobHash()));

--- a/yarn-project/sequencer-client/src/sequencer/block_builder.test.ts
+++ b/yarn-project/sequencer-client/src/sequencer/block_builder.test.ts
@@ -1,4 +1,3 @@
-import { NUMBER_OF_L1_L2_MESSAGES_PER_ROLLUP } from '@aztec/constants';
 import { DefaultL1ContractsConfig } from '@aztec/ethereum';
 import { timesParallel } from '@aztec/foundation/collection';
 import { EthAddress } from '@aztec/foundation/eth-address';
@@ -16,8 +15,7 @@ import {
   type WorldStateSynchronizer,
   type WorldStateSynchronizerStatus,
 } from '@aztec/stdlib/interfaces/server';
-import type { L1ToL2MessageSource } from '@aztec/stdlib/messaging';
-import { mockTxForRollup } from '@aztec/stdlib/testing';
+import { makeStateReference, mockTxForRollup } from '@aztec/stdlib/testing';
 import { MerkleTreeId, type MerkleTreeWriteOperations } from '@aztec/stdlib/trees';
 import {
   BlockHeader,
@@ -44,7 +42,6 @@ describe('BlockBuilder', () => {
   let lastBlockNumber: number;
   let newBlockNumber: number;
   let globalVariables: GlobalVariables;
-  let l1ToL2MessageSource: MockProxy<L1ToL2MessageSource>;
   let worldState: MockProxy<WorldStateSynchronizer>;
   let fork: MockProxy<MerkleTreeWriteOperations>;
   let contractDataSource: MockProxy<ContractDataSource>;
@@ -105,18 +102,15 @@ describe('BlockBuilder', () => {
       l1ChainId: chainId,
       rollupVersion: version,
     };
-    l1ToL2MessageSource = mock<L1ToL2MessageSource>({
-      getL1ToL2Messages: () => Promise.resolve(Array(NUMBER_OF_L1_L2_MESSAGES_PER_ROLLUP).fill(Fr.ZERO)),
-      getBlockNumber: mockFn().mockResolvedValue(lastBlockNumber),
-      getL2Tips: mockFn().mockResolvedValue({ latest: { number: lastBlockNumber, hash } }),
-    });
 
     fork = mock<MerkleTreeWriteOperations>({
       getInitialHeader: () => initialBlockHeader,
       getTreeInfo: (treeId: MerkleTreeId) =>
         Promise.resolve({ treeId, root: Fr.random().toBuffer(), size: 99n, depth: 5 }),
       findLeafIndices: (_treeId: MerkleTreeId, _values: any[]) => Promise.resolve([undefined]),
+      getStateReference: () => Promise.resolve(makeStateReference()),
     });
+
     worldState = mock<WorldStateSynchronizer>({
       fork: () => Promise.resolve(fork),
       syncImmediate: () => Promise.resolve(lastBlockNumber),
@@ -132,6 +126,7 @@ describe('BlockBuilder', () => {
         },
       } satisfies WorldStateSynchronizerStatus),
     });
+
     contractDataSource = mock<ContractDataSource>();
     const dateProvider = new TestDateProvider();
     publicProcessor = mock<PublicProcessor>();
@@ -155,14 +150,14 @@ describe('BlockBuilder', () => {
       // Assuming all txs are processed successfully and none failed for this mock
       return [processedTxs, [], allTxs, []] as any;
     });
-    blockBuilder = new TestBlockBuilder(l1Constants, l1ToL2MessageSource, worldState, contractDataSource, dateProvider);
+    blockBuilder = new TestBlockBuilder(l1Constants, worldState, contractDataSource, dateProvider);
   });
 
   it('builds a block out of a single tx', async () => {
     const tx = await makeTx();
     const iterator = mockTxIterator([tx]);
 
-    const blockResult = await blockBuilder.buildBlock(iterator, globalVariables, {});
+    const blockResult = await blockBuilder.buildBlock(iterator, [], globalVariables, {});
     expect(publicProcessor.process).toHaveBeenCalledTimes(1);
     expect(publicProcessor.process).toHaveBeenCalledWith(iterator, {}, validator);
     logger.info('Built Block', blockResult.block);
@@ -180,7 +175,7 @@ describe('BlockBuilder', () => {
   it('builds a block with the correct options', async () => {
     const txs = await timesParallel(5, i => makeTx(i * 0x10000));
     const deadline = new Date(Date.now() + 1000);
-    await blockBuilder.buildBlock(txs, globalVariables, {
+    await blockBuilder.buildBlock(txs, [], globalVariables, {
       maxTransactions: 4,
       deadline,
     });
@@ -197,7 +192,7 @@ describe('BlockBuilder', () => {
 
   it('builds a block for validation ignoring limits', async () => {
     const txs = await timesParallel(5, i => makeTx(i * 0x10000));
-    await blockBuilder.buildBlock(txs, globalVariables, {});
+    await blockBuilder.buildBlock(txs, [], globalVariables, {});
 
     expect(publicProcessor.process).toHaveBeenCalledWith(txs, {}, validator);
   });
@@ -233,7 +228,7 @@ describe('BlockBuilder', () => {
       return [processedTxs, failedTxs, usedTxs, []] as any;
     });
 
-    const blockResult = await blockBuilder.buildBlock(txs, globalVariables, {});
+    const blockResult = await blockBuilder.buildBlock(txs, [], globalVariables, {});
     expect(blockResult.failedTxs).toEqual([{ tx: invalidTx, error: new Error() }]);
     expect(blockResult.usedTxs).toEqual(validTxs);
   });

--- a/yarn-project/sequencer-client/src/sequencer/sequencer.test.ts
+++ b/yarn-project/sequencer-client/src/sequencer/sequencer.test.ts
@@ -325,7 +325,12 @@ describe('sequencer', () => {
     publisher.validateBlockHeader.mockResolvedValue();
 
     await sequencer.doRealWork();
-    expect(blockBuilder.buildBlock).toHaveBeenCalledWith(expect.anything(), globalVariables, expect.anything());
+    expect(blockBuilder.buildBlock).toHaveBeenCalledWith(
+      expect.anything(),
+      expect.anything(),
+      globalVariables,
+      expect.anything(),
+    );
     expectPublisherProposeL2Block([txHash]);
   });
 
@@ -351,7 +356,12 @@ describe('sequencer', () => {
 
     await sequencer.doRealWork();
 
-    expect(blockBuilder.buildBlock).toHaveBeenCalledWith(expect.anything(), globalVariables, expect.anything());
+    expect(blockBuilder.buildBlock).toHaveBeenCalledWith(
+      expect.anything(),
+      expect.anything(),
+      globalVariables,
+      expect.anything(),
+    );
 
     expectPublisherProposeL2Block(await Promise.all(neededTxs.map(tx => tx.getTxHash())));
   });
@@ -380,7 +390,12 @@ describe('sequencer', () => {
 
     await sequencer.doRealWork();
 
-    expect(blockBuilder.buildBlock).toHaveBeenCalledWith(expect.anything(), globalVariables, expect.anything());
+    expect(blockBuilder.buildBlock).toHaveBeenCalledWith(
+      expect.anything(),
+      expect.anything(),
+      globalVariables,
+      expect.anything(),
+    );
     expectPublisherProposeL2Block([]);
   });
 
@@ -410,7 +425,12 @@ describe('sequencer', () => {
 
     await sequencer.doRealWork();
     expect(blockBuilder.buildBlock).toHaveBeenCalledTimes(1);
-    expect(blockBuilder.buildBlock).toHaveBeenCalledWith(expect.anything(), globalVariables, expect.anything());
+    expect(blockBuilder.buildBlock).toHaveBeenCalledWith(
+      expect.anything(),
+      expect.anything(),
+      globalVariables,
+      expect.anything(),
+    );
 
     expectPublisherProposeL2Block(postFlushTxHashes);
   });

--- a/yarn-project/sequencer-client/src/sequencer/sequencer.ts
+++ b/yarn-project/sequencer-client/src/sequencer/sequencer.ts
@@ -558,6 +558,7 @@ export class Sequencer extends (EventEmitter as new () => TypedEventEmitter<Sequ
 
     const blockNumber = newGlobalVariables.blockNumber;
     const slot = proposalHeader.slotNumber.toBigInt();
+    const l1ToL2Messages = await this.l1ToL2MessageSource.getL1ToL2Messages(blockNumber);
 
     // this.metrics.recordNewBlock(blockNumber, validTxs.length);
     const workTimer = new Timer();
@@ -565,7 +566,12 @@ export class Sequencer extends (EventEmitter as new () => TypedEventEmitter<Sequ
 
     try {
       const blockBuilderOptions = this.getDefaultBlockBuilderOptions(Number(slot));
-      const buildBlockRes = await this.blockBuilder.buildBlock(pendingTxs, newGlobalVariables, blockBuilderOptions);
+      const buildBlockRes = await this.blockBuilder.buildBlock(
+        pendingTxs,
+        l1ToL2Messages,
+        newGlobalVariables,
+        blockBuilderOptions,
+      );
       const { publicGas, block, publicProcessorDuration, numTxs, numMsgs, blockBuildingTimer, usedTxs, failedTxs } =
         buildBlockRes;
       const blockBuildDuration = workTimer.ms();

--- a/yarn-project/slasher/src/epoch_prune_watcher.ts
+++ b/yarn-project/slasher/src/epoch_prune_watcher.ts
@@ -8,6 +8,7 @@ import {
   L2BlockSourceEvents,
 } from '@aztec/stdlib/block';
 import type { IFullNodeBlockBuilder, ITxCollector, MerkleTreeWriteOperations } from '@aztec/stdlib/interfaces/server';
+import type { L1ToL2MessageSource } from '@aztec/stdlib/messaging';
 import {
   ReExFailedTxsError,
   ReExStateMismatchError,
@@ -35,6 +36,7 @@ export class EpochPruneWatcher extends (EventEmitter as new () => WatcherEmitter
 
   constructor(
     private l2BlockSource: L2BlockSourceEventEmitter,
+    private l1ToL2MessageSource: L1ToL2MessageSource,
     private epochCache: EpochCache,
     private txCollector: ITxCollector,
     private blockBuilder: IFullNodeBlockBuilder,
@@ -125,8 +127,10 @@ export class EpochPruneWatcher extends (EventEmitter as new () => WatcherEmitter
     if (missing && missing.length > 0) {
       throw new TransactionsNotAvailableError(missing);
     }
+    const l1ToL2Messages = await this.l1ToL2MessageSource.getL1ToL2Messages(blockFromL1.number);
     const { block, failedTxs, numTxs } = await this.blockBuilder.buildBlock(
       txs,
+      l1ToL2Messages,
       blockFromL1.header.globalVariables,
       {},
       fork,
@@ -139,7 +143,7 @@ export class EpochPruneWatcher extends (EventEmitter as new () => WatcherEmitter
       throw new ReExFailedTxsError(failedTxs.length);
     }
     if (!block.archive.root.equals(blockFromL1.archive.root)) {
-      throw new ReExStateMismatchError();
+      throw new ReExStateMismatchError(blockFromL1.archive.root, block.archive.root);
     }
   }
 

--- a/yarn-project/stdlib/src/interfaces/block-builder.ts
+++ b/yarn-project/stdlib/src/interfaces/block-builder.ts
@@ -69,6 +69,7 @@ export interface IFullNodeBlockBuilder {
 
   buildBlock(
     txs: Iterable<Tx> | AsyncIterable<Tx>,
+    l1ToL2Messages: Fr[],
     globalVariables: GlobalVariables,
     options: PublicProcessorLimits,
     fork?: MerkleTreeWriteOperations,

--- a/yarn-project/stdlib/src/tests/factories.ts
+++ b/yarn-project/stdlib/src/tests/factories.ts
@@ -906,18 +906,20 @@ export function makeHeader(
   seed = 0,
   blockNumber: number | undefined = undefined,
   slotNumber: number | undefined = undefined,
+  overrides: Partial<FieldsOf<BlockHeader>> = {},
 ): BlockHeader {
-  return new BlockHeader(
-    makeAppendOnlyTreeSnapshot(seed + 0x100),
-    makeContentCommitment(seed + 0x200),
-    makeStateReference(seed + 0x600),
-    makeGlobalVariables((seed += 0x700), {
+  return BlockHeader.from({
+    lastArchive: makeAppendOnlyTreeSnapshot(seed + 0x100),
+    contentCommitment: makeContentCommitment(seed + 0x200),
+    state: makeStateReference(seed + 0x600),
+    globalVariables: makeGlobalVariables((seed += 0x700), {
       ...(blockNumber ? { blockNumber } : {}),
       ...(slotNumber ? { slotNumber: new Fr(slotNumber) } : {}),
     }),
-    fr(seed + 0x800),
-    fr(seed + 0x900),
-  );
+    totalFees: fr(seed + 0x800),
+    totalManaUsed: fr(seed + 0x900),
+    ...overrides,
+  });
 }
 
 /**

--- a/yarn-project/stdlib/src/validators/errors.ts
+++ b/yarn-project/stdlib/src/validators/errors.ts
@@ -1,4 +1,5 @@
-import type { TxHash } from '@aztec/stdlib/tx';
+import type { Fr } from '@aztec/foundation/fields';
+import type { StateReference, TxHash } from '@aztec/stdlib/tx';
 
 export class ValidatorError extends Error {
   constructor(message: string) {
@@ -35,7 +36,12 @@ export class FailedToReExecuteTransactionsError extends ValidatorError {
 }
 
 export class ReExStateMismatchError extends ValidatorError {
-  constructor() {
+  constructor(
+    public readonly expectedArchiveRoot: Fr,
+    public readonly actualArchiveRoot: Fr,
+    public readonly expectedStateReference?: StateReference,
+    public readonly actualStateReference?: StateReference,
+  ) {
     super('Re-execution state mismatch');
   }
 }

--- a/yarn-project/validator-client/package.json
+++ b/yarn-project/validator-client/package.json
@@ -69,6 +69,7 @@
     "@aztec/ethereum": "workspace:^",
     "@aztec/foundation": "workspace:^",
     "@aztec/p2p": "workspace:^",
+    "@aztec/prover-client": "workspace:^",
     "@aztec/slasher": "workspace:^",
     "@aztec/stdlib": "workspace:^",
     "@aztec/telemetry-client": "workspace:^",

--- a/yarn-project/validator-client/src/factory.ts
+++ b/yarn-project/validator-client/src/factory.ts
@@ -5,6 +5,7 @@ import type { P2P } from '@aztec/p2p';
 import type { SlasherConfig } from '@aztec/slasher/config';
 import type { L2BlockSource } from '@aztec/stdlib/block';
 import type { IFullNodeBlockBuilder } from '@aztec/stdlib/interfaces/server';
+import type { L1ToL2MessageSource } from '@aztec/stdlib/messaging';
 import type { TelemetryClient } from '@aztec/telemetry-client';
 
 import { generatePrivateKey } from 'viem/accounts';
@@ -19,6 +20,7 @@ export function createValidatorClient(
     blockBuilder: IFullNodeBlockBuilder;
     p2pClient: P2P;
     blockSource: L2BlockSource;
+    l1ToL2MessageSource: L1ToL2MessageSource;
     telemetry: TelemetryClient;
     dateProvider: DateProvider;
     epochCache: EpochCache;
@@ -37,6 +39,7 @@ export function createValidatorClient(
     deps.epochCache,
     deps.p2pClient,
     deps.blockSource,
+    deps.l1ToL2MessageSource,
     deps.dateProvider,
     deps.telemetry,
   );

--- a/yarn-project/validator-client/src/validator.test.ts
+++ b/yarn-project/validator-client/src/validator.test.ts
@@ -6,14 +6,16 @@ import { EthAddress } from '@aztec/foundation/eth-address';
 import { Fr } from '@aztec/foundation/fields';
 import { TestDateProvider, Timer } from '@aztec/foundation/timer';
 import type { P2P, PeerId } from '@aztec/p2p';
+import { computeInHashFromL1ToL2Messages } from '@aztec/prover-client/helpers';
 import { Offense, type SlasherConfig, WANT_TO_SLASH_EVENT } from '@aztec/slasher';
 import type { L2Block, L2BlockSource } from '@aztec/stdlib/block';
 import { Gas } from '@aztec/stdlib/gas';
-import type { IFullNodeBlockBuilder } from '@aztec/stdlib/interfaces/server';
+import type { BuildBlockResult, IFullNodeBlockBuilder } from '@aztec/stdlib/interfaces/server';
+import type { L1ToL2MessageSource } from '@aztec/stdlib/messaging';
 import type { BlockProposal } from '@aztec/stdlib/p2p';
 import { makeBlockAttestation, makeBlockProposal, makeHeader, mockTx } from '@aztec/stdlib/testing';
 import { AppendOnlyTreeSnapshot } from '@aztec/stdlib/trees';
-import { Tx, TxHash } from '@aztec/stdlib/tx';
+import { ContentCommitment, Tx, TxHash } from '@aztec/stdlib/tx';
 import { AttestationTimeoutError, InvalidValidatorPrivateKeyError } from '@aztec/stdlib/validators';
 
 import { describe, expect, it, jest } from '@jest/globals';
@@ -29,6 +31,7 @@ describe('ValidatorClient', () => {
   let validatorClient: ValidatorClient;
   let p2pClient: MockProxy<P2P>;
   let blockSource: MockProxy<L2BlockSource>;
+  let l1ToL2MessageSource: MockProxy<L1ToL2MessageSource>;
   let epochCache: MockProxy<EpochCache>;
   let blockBuilder: MockProxy<IFullNodeBlockBuilder>;
   let validatorAccounts: PrivateKeyAccount[];
@@ -46,6 +49,8 @@ describe('ValidatorClient', () => {
     });
     epochCache = mock<EpochCache>();
     blockSource = mock<L2BlockSource>();
+    l1ToL2MessageSource = mock<L1ToL2MessageSource>();
+    l1ToL2MessageSource.getL1ToL2Messages.mockResolvedValue([]);
     dateProvider = new TestDateProvider();
 
     const validatorPrivateKeys = [generatePrivateKey(), generatePrivateKey()];
@@ -61,29 +66,31 @@ describe('ValidatorClient', () => {
       slashInvalidBlockPenalty: 1n,
       slashInvalidBlockMaxPenalty: 100n,
     };
-    validatorClient = ValidatorClient.new(config, blockBuilder, epochCache, p2pClient, blockSource, dateProvider);
-  });
-
-  it('Should collect attestations from its own validators', async () => {
-    epochCache.filterInCommittee.mockResolvedValueOnce(
-      validatorAccounts.map(account => EthAddress.fromString(account.address)),
+    validatorClient = ValidatorClient.new(
+      config,
+      blockBuilder,
+      epochCache,
+      p2pClient,
+      blockSource,
+      l1ToL2MessageSource,
+      dateProvider,
     );
-    const addAttestationsSpy = jest.spyOn(p2pClient, 'addAttestations');
-    const proposal = makeBlockProposal();
-    // collectAttestations still throws as we don't have a real p2pClient
-    await expect(validatorClient.collectAttestations(proposal, 3, new Date(dateProvider.now() + 100))).rejects.toThrow(
-      AttestationTimeoutError,
-    );
-    expect(addAttestationsSpy).toHaveBeenCalled();
-    expect(addAttestationsSpy.mock.calls[0][0]).toHaveLength(2);
   });
 
   describe('constructor', () => {
     it('should throw error if an invalid private key is provided', () => {
       config.validatorPrivateKeys = new SecretValue(['0x1234567890123456789']);
-      expect(() => ValidatorClient.new(config, blockBuilder, epochCache, p2pClient, blockSource, dateProvider)).toThrow(
-        InvalidValidatorPrivateKeyError,
-      );
+      expect(() =>
+        ValidatorClient.new(
+          config,
+          blockBuilder,
+          epochCache,
+          p2pClient,
+          blockSource,
+          l1ToL2MessageSource,
+          dateProvider,
+        ),
+      ).toThrow(InvalidValidatorPrivateKeyError);
     });
   });
 
@@ -153,16 +160,38 @@ describe('ValidatorClient', () => {
 
       expect(attestations).toHaveLength(numberOfRequiredAttestations);
     });
+
+    it('should collect attestations from its own validators', async () => {
+      epochCache.filterInCommittee.mockResolvedValueOnce(
+        validatorAccounts.map(account => EthAddress.fromString(account.address)),
+      );
+      const addAttestationsSpy = jest.spyOn(p2pClient, 'addAttestations');
+      const proposal = makeBlockProposal();
+      // collectAttestations still throws as we don't have a real p2pClient
+      await expect(
+        validatorClient.collectAttestations(proposal, 3, new Date(dateProvider.now() + 100)),
+      ).rejects.toThrow(AttestationTimeoutError);
+      expect(addAttestationsSpy).toHaveBeenCalled();
+      expect(addAttestationsSpy.mock.calls[0][0]).toHaveLength(2);
+    });
   });
 
   describe('attestToProposal', () => {
     let proposal: BlockProposal;
     let sender: PeerId;
+    let blockBuildResult: BuildBlockResult;
 
     const makeTxFromHash = (txHash: TxHash) => ({ getTxHash: () => Promise.resolve(txHash) }) as Tx;
 
-    beforeEach(() => {
-      proposal = makeBlockProposal();
+    const enableReexecution = () => {
+      (validatorClient as any).config.validatorReexecute = true;
+      blockBuilder.buildBlock.mockImplementation(() => Promise.resolve(blockBuildResult));
+    };
+
+    beforeEach(async () => {
+      const emptyInHash = await computeInHashFromL1ToL2Messages([]);
+      const contentCommitment = new ContentCommitment(Fr.random(), emptyInHash, Fr.random());
+      proposal = makeBlockProposal({ header: makeHeader(1, 100, 100, { contentCommitment }) });
       sender = { toString: () => 'proposal-sender-peer-id' } as PeerId;
 
       p2pClient.getTxStatus.mockResolvedValue('pending');
@@ -182,6 +211,21 @@ describe('ValidatorClient', () => {
       blockSource.getBlock.mockResolvedValue({
         archive: new AppendOnlyTreeSnapshot(proposal.payload.header.lastArchiveRoot, proposal.blockNumber),
       } as L2Block);
+
+      blockBuildResult = {
+        publicProcessorDuration: 0,
+        numTxs: proposal.payload.txHashes.length,
+        blockBuildingTimer: new Timer(),
+        failedTxs: [],
+        publicGas: Gas.empty(),
+        numMsgs: 0,
+        usedTxs: [],
+        block: {
+          header: makeHeader(),
+          body: { txEffects: times(proposal.payload.txHashes.length, () => ({})) },
+          archive: new AppendOnlyTreeSnapshot(proposal.archive, proposal.blockNumber),
+        } as L2Block,
+      };
     });
 
     it('should attest to proposal', async () => {
@@ -192,23 +236,7 @@ describe('ValidatorClient', () => {
     });
 
     it('should re-execute and attest to proposal', async () => {
-      (validatorClient as any).config.validatorReexecute = true;
-      blockBuilder.buildBlock.mockImplementation(() =>
-        Promise.resolve({
-          publicProcessorDuration: 0,
-          numTxs: proposal.payload.txHashes.length,
-          blockBuildingTimer: new Timer(),
-          failedTxs: [],
-          publicGas: Gas.empty(),
-          numMsgs: 0,
-          usedTxs: [],
-          block: {
-            body: { txEffects: times(proposal.payload.txHashes.length, () => ({})) },
-            archive: new AppendOnlyTreeSnapshot(proposal.archive, proposal.blockNumber),
-          } as L2Block,
-        }),
-      );
-
+      enableReexecution();
       const attestations = await validatorClient.attestToProposal(proposal, sender);
       expect(attestations?.length).toBeGreaterThan(0);
     });
@@ -216,22 +244,8 @@ describe('ValidatorClient', () => {
     it('should not attest to proposal if roots do not match, and should emit WANT_TO_SLASH_EVENT', async () => {
       // Block builder returns a block with a different root
       const emitSpy = jest.spyOn(validatorClient, 'emit');
-      (validatorClient as any).config.validatorReexecute = true;
-      blockBuilder.buildBlock.mockImplementation(() =>
-        Promise.resolve({
-          publicProcessorDuration: 0,
-          numTxs: proposal.payload.txHashes.length,
-          blockBuildingTimer: new Timer(),
-          failedTxs: [],
-          publicGas: Gas.empty(),
-          numMsgs: 0,
-          usedTxs: [],
-          block: {
-            body: { txEffects: times(proposal.payload.txHashes.length, () => ({})) },
-            archive: new AppendOnlyTreeSnapshot(Fr.random(), proposal.blockNumber),
-          } as L2Block,
-        }),
-      );
+      enableReexecution();
+      blockBuildResult.block.archive.root = Fr.random();
 
       // We should not attest to the proposal
       const attestations = await validatorClient.attestToProposal(proposal, sender);
@@ -265,26 +279,13 @@ describe('ValidatorClient', () => {
         }),
       ).resolves.toBe(false);
     });
+
     it('should not emit WANT_TO_SLASH_EVENT if slashing is disabled', async () => {
       validatorClient.configureSlashing({ slashInvalidBlockEnabled: false });
 
       const emitSpy = jest.spyOn(validatorClient, 'emit');
-      (validatorClient as any).config.validatorReexecute = true;
-      blockBuilder.buildBlock.mockImplementation(() =>
-        Promise.resolve({
-          publicProcessorDuration: 0,
-          numTxs: proposal.payload.txHashes.length,
-          blockBuildingTimer: new Timer(),
-          failedTxs: [],
-          publicGas: Gas.empty(),
-          numMsgs: 0,
-          usedTxs: [],
-          block: {
-            body: { txEffects: times(proposal.payload.txHashes.length, () => ({})) },
-            archive: new AppendOnlyTreeSnapshot(Fr.random(), proposal.blockNumber),
-          } as L2Block,
-        }),
-      );
+      enableReexecution();
+      blockBuildResult.block.archive.root = Fr.random();
 
       const attestations = await validatorClient.attestToProposal(proposal, sender);
       expect(attestations).toBeUndefined();
@@ -321,7 +322,7 @@ describe('ValidatorClient', () => {
     });
 
     it('should not return an attestation if re-execution fails', async () => {
-      (validatorClient as any).config.validatorReexecute = true;
+      enableReexecution();
       blockBuilder.buildBlock.mockImplementation(() => {
         throw new Error('Failed to build block');
       });
@@ -367,6 +368,14 @@ describe('ValidatorClient', () => {
         currentSlot: proposal.slotNumber.toBigInt() + 20n,
         nextSlot: proposal.slotNumber.toBigInt() + 21n,
       });
+
+      const attestation = await validatorClient.attestToProposal(proposal, sender);
+      expect(attestation).toBeUndefined();
+    });
+
+    it('should not return an attestation if messages do not match', async () => {
+      enableReexecution();
+      l1ToL2MessageSource.getL1ToL2Messages.mockResolvedValue([Fr.random()]);
 
       const attestation = await validatorClient.attestToProposal(proposal, sender);
       expect(attestation).toBeUndefined();

--- a/yarn-project/validator-client/src/validator.ts
+++ b/yarn-project/validator-client/src/validator.ts
@@ -10,6 +10,7 @@ import { DateProvider } from '@aztec/foundation/timer';
 import type { P2P, PeerId } from '@aztec/p2p';
 import { TxCollector } from '@aztec/p2p';
 import { BlockProposalValidator } from '@aztec/p2p/msg_validators';
+import { computeInHashFromL1ToL2Messages } from '@aztec/prover-client/helpers';
 import {
   Offense,
   type SlasherConfig,
@@ -21,6 +22,7 @@ import {
 import type { L2BlockSource } from '@aztec/stdlib/block';
 import { getTimestampForSlot } from '@aztec/stdlib/epoch-helpers';
 import type { IFullNodeBlockBuilder, ITxCollector, SequencerConfig } from '@aztec/stdlib/interfaces/server';
+import type { L1ToL2MessageSource } from '@aztec/stdlib/messaging';
 import type { BlockAttestation, BlockProposal, BlockProposalOptions } from '@aztec/stdlib/p2p';
 import { GlobalVariables, type ProposedBlockHeader, type StateReference, type Tx } from '@aztec/stdlib/tx';
 import {
@@ -90,6 +92,7 @@ export class ValidatorClient extends (EventEmitter as new () => WatcherEmitter) 
     private epochCache: EpochCache,
     private p2pClient: P2P,
     private blockSource: L2BlockSource,
+    private l1ToL2MessageSource: L1ToL2MessageSource,
     private config: ValidatorClientConfig &
       Pick<SequencerConfig, 'txPublicSetupAllowList'> &
       Pick<SlasherConfig, 'slashInvalidBlockEnabled' | 'slashInvalidBlockPenalty' | 'slashInvalidBlockMaxPenalty'>,
@@ -148,6 +151,7 @@ export class ValidatorClient extends (EventEmitter as new () => WatcherEmitter) 
     epochCache: EpochCache,
     p2pClient: P2P,
     blockSource: L2BlockSource,
+    l1ToL2MessageSource: L1ToL2MessageSource,
     dateProvider: DateProvider = new DateProvider(),
     telemetry: TelemetryClient = getTelemetryClient(),
   ) {
@@ -164,6 +168,7 @@ export class ValidatorClient extends (EventEmitter as new () => WatcherEmitter) 
       epochCache,
       p2pClient,
       blockSource,
+      l1ToL2MessageSource,
       config,
       dateProvider,
       telemetry,
@@ -219,20 +224,23 @@ export class ValidatorClient extends (EventEmitter as new () => WatcherEmitter) 
   async attestToProposal(proposal: BlockProposal, proposalSender: PeerId): Promise<BlockAttestation[] | undefined> {
     const slotNumber = proposal.slotNumber.toNumber();
     const blockNumber = proposal.blockNumber;
+    const proposer = proposal.getSender();
+
     const proposalInfo = {
       slotNumber,
       blockNumber,
+      proposer: proposer.toString(),
       archive: proposal.payload.archive.toString(),
       txCount: proposal.payload.txHashes.length,
       txHashes: proposal.payload.txHashes.map(txHash => txHash.toString()),
     };
-    this.log.verbose(`Received request to attest for slot ${slotNumber}`);
+    this.log.info(`Received request to attest for slot ${slotNumber}`, proposalInfo);
 
     // Check that the proposal is from the current proposer, or the next proposer.
     // Q: Should this be moved to the block proposal validator, so we disregard proposals from anyone?
     const invalidProposal = await this.blockProposalValidator.validate(proposal);
     if (invalidProposal) {
-      this.log.verbose(`Proposal is not valid, skipping attestation`);
+      this.log.warn(`Proposal is not valid, skipping attestation`);
       this.metrics.incFailedAttestations(1, 'invalid_proposal');
       return undefined;
     }
@@ -245,12 +253,12 @@ export class ValidatorClient extends (EventEmitter as new () => WatcherEmitter) 
     if (blockNumber > INITIAL_L2_BLOCK_NUM) {
       const parentBlock = await this.blockSource.getBlock(blockNumber - 1);
       if (parentBlock === undefined) {
-        this.log.verbose(`Parent block for ${blockNumber} not found, skipping attestation`);
+        this.log.warn(`Parent block for ${blockNumber} not found, skipping attestation`);
         this.metrics.incFailedAttestations(1, 'parent_block_not_found');
         return undefined;
       }
       if (!proposal.payload.header.lastArchiveRoot.equals(parentBlock.archive.root)) {
-        this.log.verbose(`Parent block archive root for proposal does not match, skipping attestation`, {
+        this.log.warn(`Parent block archive root for proposal does not match, skipping attestation`, {
           proposalLastArchiveRoot: proposal.payload.header.lastArchiveRoot.toString(),
           parentBlockArchiveRoot: parentBlock.archive.root.toString(),
           ...proposalInfo,
@@ -272,12 +280,25 @@ export class ValidatorClient extends (EventEmitter as new () => WatcherEmitter) 
 
     // Check that all of the transactions in the proposal are available in the tx pool before attesting
     if (missing && missing.length > 0) {
-      this.log.error(
-        `Missing ${missing.length}/${proposal.payload.txHashes.length} txs to attest to proposal`,
-        undefined,
-        { proposalInfo, missing },
-      );
+      this.log.warn(`Missing ${missing.length}/${proposal.payload.txHashes.length} txs to attest to proposal`, {
+        ...proposalInfo,
+        missing,
+      });
       this.metrics.incFailedAttestations(1, 'TransactionsNotAvailableError');
+      return undefined;
+    }
+
+    // Check that I have the same set of l1ToL2Messages as the proposal
+    const l1ToL2Messages = await this.l1ToL2MessageSource.getL1ToL2Messages(blockNumber);
+    const computedInHash = await computeInHashFromL1ToL2Messages(l1ToL2Messages);
+    const proposalInHash = proposal.payload.header.contentCommitment.inHash;
+    if (!computedInHash.equals(proposalInHash)) {
+      this.log.warn(`L1 to L2 messages in hash mismatch, skipping attestation`, {
+        proposalInHash: proposalInHash.toString(),
+        computedInHash: computedInHash.toString(),
+        ...proposalInfo,
+      });
+      this.metrics.incFailedAttestations(1, 'in_hash_mismatch');
       return undefined;
     }
 
@@ -286,17 +307,15 @@ export class ValidatorClient extends (EventEmitter as new () => WatcherEmitter) 
       this.log.verbose(`Processing attestation for slot ${slotNumber}`, proposalInfo);
       if (this.config.validatorReexecute) {
         this.log.verbose(`Re-executing transactions in the proposal before attesting`);
-        await this.reExecuteTransactions(proposal, txs).catch(error => {
-          if (error instanceof ReExStateMismatchError) {
-            this.log.warn(`Re-execution state mismatch, slashing invalid block`, proposalInfo);
-            this.slashInvalidBlock(proposal);
-          }
-          throw error;
-        });
+        await this.reExecuteTransactions(proposal, txs, l1ToL2Messages);
       }
     } catch (error: any) {
       this.metrics.incFailedAttestations(1, error instanceof Error ? error.name : 'unknown');
-      this.log.error(`Failed to attest to proposal`, error, proposalInfo);
+      this.log.error(`Error reexecuting txs while processing block proposal`, error, proposalInfo);
+      if (error instanceof ReExStateMismatchError && this.config.slashInvalidBlockEnabled) {
+        this.log.warn(`Slashing proposer for invalid block proposal`, proposalInfo);
+        this.slashInvalidBlock(proposal);
+      }
       return undefined;
     }
 
@@ -321,7 +340,7 @@ export class ValidatorClient extends (EventEmitter as new () => WatcherEmitter) 
    * Re-execute the transactions in the proposal and check that the state updates match the header state
    * @param proposal - The proposal to re-execute
    */
-  async reExecuteTransactions(proposal: BlockProposal, txs: Tx[]) {
+  async reExecuteTransactions(proposal: BlockProposal, txs: Tx[], l1ToL2Messages: Fr[]): Promise<void> {
     const { header, txHashes } = proposal.payload;
 
     // If we do not have all of the transactions, then we should fail
@@ -342,7 +361,7 @@ export class ValidatorClient extends (EventEmitter as new () => WatcherEmitter) 
       version: new Fr(config.rollupVersion),
     });
 
-    const { block, failedTxs } = await this.blockBuilder.buildBlock(txs, globalVariables, {
+    const { block, failedTxs } = await this.blockBuilder.buildBlock(txs, l1ToL2Messages, globalVariables, {
       deadline: this.getReexecutionDeadline(proposal, config),
     });
     stopTimer();
@@ -363,15 +382,16 @@ export class ValidatorClient extends (EventEmitter as new () => WatcherEmitter) 
     // This function will throw an error if state updates do not match
     if (!block.archive.root.equals(proposal.archive)) {
       this.metrics.recordFailedReexecution(proposal);
-      throw new ReExStateMismatchError();
+      throw new ReExStateMismatchError(
+        proposal.archive,
+        block.archive.root,
+        proposal.payload.stateReference,
+        block.header.state,
+      );
     }
   }
 
   private slashInvalidBlock(proposal: BlockProposal) {
-    if (!this.config.slashInvalidBlockEnabled) {
-      return;
-    }
-
     const proposer = proposal.getSender();
 
     // Trim the set if it's too big.

--- a/yarn-project/validator-client/tsconfig.json
+++ b/yarn-project/validator-client/tsconfig.json
@@ -22,6 +22,9 @@
       "path": "../p2p"
     },
     {
+      "path": "../prover-client"
+    },
+    {
       "path": "../slasher"
     },
     {

--- a/yarn-project/yarn.lock
+++ b/yarn-project/yarn.lock
@@ -1508,6 +1508,7 @@ __metadata:
     "@aztec/ethereum": "workspace:^"
     "@aztec/foundation": "workspace:^"
     "@aztec/p2p": "workspace:^"
+    "@aztec/prover-client": "workspace:^"
     "@aztec/slasher": "workspace:^"
     "@aztec/stdlib": "workspace:^"
     "@aztec/telemetry-client": "workspace:^"


### PR DESCRIPTION
When validators attested to a block proposal, we assumed that they had the correct set of L1 to L2 messages, downloaded from L1. But if their archivers had not properly synced them, then the attestation would fail with a reexecution error, caused by a mismatch in the archiver root.

This PR adds an early check for the content commitment `inHash` (should we review this name?) in the proposal, which is a merkle root of the L1-to-L2 messages present in the block. If the `inHash` in the proposal does not match a value manually computed from the validator's L1-to-L2 messages for that block, we fail early rather than reexecute everything.

This change required removing the `L1ToL2MessageSource` out of the block builder. Now, the block builder receives the l1 to l2 messages, same as it received the txs, from its caller. Also, this PR adds extra info to the `ReExStateMismatchError`, so we can compare individual tree roots to spot the issue in reexecution.

