### PR TITLE
fix: make TXE fast again

### DIFF
--- a/yarn-project/foundation/src/fields/bls12_point.test.ts
+++ b/yarn-project/foundation/src/fields/bls12_point.test.ts
@@ -223,9 +223,9 @@ describe('BLS12Point', () => {
       expect(p).toEqual(p2);
     });
 
-    it('serializes from and to JSON', async () => {
+    it('serializes from and to JSON', () => {
       const p = BLS12Point.random();
-      const p2 = await jsonParseWithSchema(jsonStringify(p), BLS12Point.schema);
+      const p2 = jsonParseWithSchema(jsonStringify(p), BLS12Point.schema);
       expect(p).toEqual(p2);
       expect(p2).toBeInstanceOf(BLS12Point);
     });

--- a/yarn-project/foundation/src/fields/point.test.ts
+++ b/yarn-project/foundation/src/fields/point.test.ts
@@ -93,7 +93,7 @@ describe('Point', () => {
 
   it('serializes from and to JSON', async () => {
     const p = await Point.random();
-    const p2 = await jsonParseWithSchema(jsonStringify(p), Point.schema);
+    const p2 = jsonParseWithSchema(jsonStringify(p), Point.schema);
     expect(p).toEqual(p2);
     expect(p2).toBeInstanceOf(Point);
   });

--- a/yarn-project/foundation/src/json-rpc/convert.ts
+++ b/yarn-project/foundation/src/json-rpc/convert.ts
@@ -8,16 +8,7 @@ import type { ZodFor } from '../schemas/types.js';
  * @param schema - Zod schema.
  * @returns Result of parsing json with schema.
  */
-export function jsonParseWithSchema<T>(json: string, schema: ZodFor<T>): Promise<T> {
-  return schema.parseAsync(JSON.parse(json));
-}
-/**
- * Parses a json string and then feeds it to a zod schema.
- * @param json - JSON string.
- * @param schema - Zod schema.
- * @returns Result of parsing json with schema.
- */
-export function jsonParseWithSchemaSync<T>(json: string, schema: ZodFor<T>): T {
+export function jsonParseWithSchema<T>(json: string, schema: ZodFor<T>): T {
   return schema.parse(JSON.parse(json));
 }
 

--- a/yarn-project/foundation/src/json-rpc/index.ts
+++ b/yarn-project/foundation/src/json-rpc/index.ts
@@ -1,2 +1,2 @@
-export { jsonStringify, jsonParseWithSchema, jsonParseWithSchemaSync, tryJsonStringify } from './convert.js';
+export { jsonStringify, jsonParseWithSchema, tryJsonStringify } from './convert.js';
 export { BadRequestError } from './errors.js';

--- a/yarn-project/prover-client/src/bin/get-proof-inputs.ts
+++ b/yarn-project/prover-client/src/bin/get-proof-inputs.ts
@@ -36,7 +36,7 @@ async function main() {
   logger.info(`Found inputs for ${ProvingRequestType[input.type]}`);
   writeProofInputs(input, outDir);
 
-  console.log((await jsonParseWithSchema(jsonStringify(input), ProvingJobInputs)).inputs);
+  console.log(jsonParseWithSchema(jsonStringify(input), ProvingJobInputs).inputs);
 }
 
 // This mimics the behavior of bb-prover/src/bb/execute.ts

--- a/yarn-project/prover-client/src/proving_broker/proof_store/inline_proof_store.ts
+++ b/yarn-project/prover-client/src/proving_broker/proof_store/inline_proof_store.ts
@@ -52,7 +52,7 @@ export class InlineProofStore implements ProofStore {
     return (PREFIX + SEPARATOR + encoded) as ProofUri;
   }
 
-  private decode<T>(uri: ProofUri, schema: ZodFor<T>): Promise<T> {
+  private decode<T>(uri: ProofUri, schema: ZodFor<T>): T {
     const [prefix, data] = uri.split(SEPARATOR);
     if (prefix !== PREFIX) {
       throw new Error('Invalid proof input URI: ' + prefix);

--- a/yarn-project/prover-client/src/proving_broker/proving_broker_database/persisted.ts
+++ b/yarn-project/prover-client/src/proving_broker/proving_broker_database/persisted.ts
@@ -46,9 +46,9 @@ class SingleEpochDatabase {
 
   async *allProvingJobs(): AsyncIterableIterator<[ProvingJob, ProvingJobSettledResult | undefined]> {
     for await (const jobStr of this.jobs.valuesAsync()) {
-      const job = await jsonParseWithSchema(jobStr, ProvingJob);
+      const job = jsonParseWithSchema(jobStr, ProvingJob);
       const resultStr = await this.jobResults.getAsync(job.id);
-      const result = resultStr ? await jsonParseWithSchema(resultStr, ProvingJobSettledResult) : undefined;
+      const result = resultStr ? jsonParseWithSchema(resultStr, ProvingJobSettledResult) : undefined;
       yield [job, result];
     }
   }

--- a/yarn-project/prover-node/src/actions/download-epoch-proving-job.ts
+++ b/yarn-project/prover-node/src/actions/download-epoch-proving-job.ts
@@ -1,4 +1,4 @@
-import { jsonParseWithSchemaSync } from '@aztec/foundation/json-rpc';
+import { jsonParseWithSchema } from '@aztec/foundation/json-rpc';
 import type { Logger } from '@aztec/foundation/log';
 import { urlJoin } from '@aztec/foundation/string';
 import { snapshotSync } from '@aztec/node-lib/actions';
@@ -26,7 +26,7 @@ export async function downloadEpochProvingJob(
   const fileStore = await createReadOnlyFileStore(location);
   const metadataUrl = urlJoin(location, 'metadata.json');
   const metadataRaw = await fileStore.read(metadataUrl);
-  const metadata = jsonParseWithSchemaSync(metadataRaw.toString(), UploadSnapshotMetadataSchema);
+  const metadata = jsonParseWithSchema(metadataRaw.toString(), UploadSnapshotMetadataSchema);
 
   const dataUrls = makeSnapshotPaths(location);
   log.info(`Downloading state snapshot from ${location} to local data directory`, { metadata, dataUrls });

--- a/yarn-project/prover-node/src/bin/run-failed-epoch.ts
+++ b/yarn-project/prover-node/src/bin/run-failed-epoch.ts
@@ -1,7 +1,7 @@
 /* eslint-disable no-console */
 import type { L1ContractAddresses } from '@aztec/ethereum';
 import { Fr } from '@aztec/foundation/fields';
-import { jsonParseWithSchemaSync, jsonStringify } from '@aztec/foundation/json-rpc';
+import { jsonParseWithSchema, jsonStringify } from '@aztec/foundation/json-rpc';
 import { createLogger } from '@aztec/foundation/log';
 import { downloadEpochProvingJob, getProverNodeConfigFromEnv, rerunEpochProvingJob } from '@aztec/prover-node';
 import { type UploadSnapshotMetadata, UploadSnapshotMetadataSchema } from '@aztec/stdlib/snapshots';
@@ -33,7 +33,7 @@ async function rerunFailedEpoch(provingJobUrl: string, baseLocalDir: string) {
   const metadataPath = join(localDir, 'metadata.json');
   if (existsSync(metadataPath)) {
     logger.info(`Using downloaded data`);
-    metadata = jsonParseWithSchemaSync(await readFile(metadataPath, 'utf-8'), UploadSnapshotMetadataSchema);
+    metadata = jsonParseWithSchema(await readFile(metadataPath, 'utf-8'), UploadSnapshotMetadataSchema);
   } else {
     logger.info(`Downloading epoch proving job data and state from ${provingJobUrl} to ${localDir}`);
     metadata = await downloadEpochProvingJob(provingJobUrl!, logger, {

--- a/yarn-project/simulator/src/public/public_tx_simulator/apps_tests/avm_minimal.test.ts
+++ b/yarn-project/simulator/src/public/public_tx_simulator/apps_tests/avm_minimal.test.ts
@@ -16,7 +16,7 @@ describe('Public TX simulator apps tests: AvmMinimalTestContract', () => {
     writeTestData(path, Buffer.from(json), /*raw=*/ true);
 
     const expectedJson = readTestData(path);
-    const expectedAvmInputs = await jsonParseWithSchema(expectedJson.toString(), AvmCircuitInputs.schema);
+    const expectedAvmInputs = jsonParseWithSchema(expectedJson.toString(), AvmCircuitInputs.schema);
     expect(expectedAvmInputs).toStrictEqual(inputs);
   });
 

--- a/yarn-project/stdlib/src/abi/contract_artifact.test.ts
+++ b/yarn-project/stdlib/src/abi/contract_artifact.test.ts
@@ -2,10 +2,10 @@ import { getBenchmarkContractArtifact } from '../tests/fixtures.js';
 import { contractArtifactFromBuffer, contractArtifactToBuffer } from './contract_artifact.js';
 
 describe('contract_artifact', () => {
-  it('serializes and deserializes an instance', async () => {
+  it('serializes and deserializes an instance', () => {
     const artifact = getBenchmarkContractArtifact();
     const serialized = contractArtifactToBuffer(artifact);
-    const deserialized = await contractArtifactFromBuffer(serialized);
+    const deserialized = contractArtifactFromBuffer(serialized);
     expect(deserialized).toEqual(artifact);
   });
 });

--- a/yarn-project/stdlib/src/abi/contract_artifact.ts
+++ b/yarn-project/stdlib/src/abi/contract_artifact.ts
@@ -40,7 +40,7 @@ export function contractArtifactToBuffer(artifact: ContractArtifact): Buffer {
  * @param buffer - Buffer to deserialize.
  * @returns Deserialized artifact.
  */
-export function contractArtifactFromBuffer(buffer: Buffer): Promise<ContractArtifact> {
+export function contractArtifactFromBuffer(buffer: Buffer): ContractArtifact {
   return jsonParseWithSchema(buffer.toString('utf-8'), ContractArtifactSchema);
 }
 

--- a/yarn-project/stdlib/src/abi/encoder.test.ts
+++ b/yarn-project/stdlib/src/abi/encoder.test.ts
@@ -7,7 +7,7 @@ import { type FunctionAbi, FunctionType } from './abi.js';
 import { encodeArguments } from './encoder.js';
 
 describe('abi/encoder', () => {
-  it('serializes fields as fields', async () => {
+  it('serializes fields as fields', () => {
     const abi: FunctionAbi = {
       name: 'constructor',
       functionType: FunctionType.PRIVATE,
@@ -30,7 +30,7 @@ describe('abi/encoder', () => {
     const field = Fr.random();
     expect(encodeArguments(abi, [field])).toEqual([field]);
 
-    const serializedField = await jsonParseWithSchema(jsonStringify(field), schemas.Fr);
+    const serializedField = jsonParseWithSchema(jsonStringify(field), schemas.Fr);
     expect(encodeArguments(abi, [serializedField])).toEqual([field]);
   });
 
@@ -122,7 +122,7 @@ describe('abi/encoder', () => {
     const completeAddressLike = { address, publicKey: await Point.random(), partialAddress: Fr.random() };
     expect(encodeArguments(abi, [completeAddressLike])).toEqual([address.toField()]);
 
-    const serializedAddress = await jsonParseWithSchema(jsonStringify(address), schemas.AztecAddress);
+    const serializedAddress = jsonParseWithSchema(jsonStringify(address), schemas.AztecAddress);
     expect(encodeArguments(abi, [serializedAddress])).toEqual([address.toField()]);
   });
 

--- a/yarn-project/stdlib/src/avm/avm.test.ts
+++ b/yarn-project/stdlib/src/avm/avm.test.ts
@@ -10,7 +10,7 @@ describe('Avm circuit inputs', () => {
   it(`serializes to JSON and deserializes it back`, async () => {
     const avmCircuitInputs = await makeAvmCircuitInputs(randomInt(2000));
     const json = jsonStringify(avmCircuitInputs);
-    const res = await jsonParseWithSchema(json, AvmCircuitInputs.schema);
+    const res = jsonParseWithSchema(json, AvmCircuitInputs.schema);
     // Note: ideally we don't want to use toStrictEqual here (see other test),
     // but I couldn't find an equivalent equality check.
     expect(res).toStrictEqual(avmCircuitInputs);

--- a/yarn-project/stdlib/src/database-version/version_manager.ts
+++ b/yarn-project/stdlib/src/database-version/version_manager.ts
@@ -1,5 +1,5 @@
 import { EthAddress } from '@aztec/foundation/eth-address';
-import { jsonParseWithSchemaSync, jsonStringify } from '@aztec/foundation/json-rpc';
+import { jsonParseWithSchema, jsonStringify } from '@aztec/foundation/json-rpc';
 import { type Logger, createLogger } from '@aztec/foundation/log';
 
 import fs from 'fs/promises';
@@ -24,7 +24,7 @@ export class DatabaseVersion {
 
   public static fromBuffer(buf: Buffer): DatabaseVersion {
     try {
-      return jsonParseWithSchemaSync(buf.toString('utf-8'), DatabaseVersion.schema);
+      return jsonParseWithSchema(buf.toString('utf-8'), DatabaseVersion.schema);
     } catch (err) {
       throw new Error(`Failed to deserialize version information: ${err}`, { cause: err });
     }

--- a/yarn-project/stdlib/src/note/note.test.ts
+++ b/yarn-project/stdlib/src/note/note.test.ts
@@ -16,7 +16,7 @@ describe('note', () => {
     expect(Note.fromBuffer(note.toBuffer())).toEqual(note);
   });
 
-  it('converts to and from json', async () => {
-    expect(await jsonParseWithSchema(jsonStringify(note), Note.schema)).toEqual(note);
+  it('converts to and from json', () => {
+    expect(jsonParseWithSchema(jsonStringify(note), Note.schema)).toEqual(note);
   });
 });

--- a/yarn-project/stdlib/src/snapshots/download.ts
+++ b/yarn-project/stdlib/src/snapshots/download.ts
@@ -1,5 +1,5 @@
 import { fromEntries, getEntries, maxBy } from '@aztec/foundation/collection';
-import { jsonParseWithSchemaSync } from '@aztec/foundation/json-rpc';
+import { jsonParseWithSchema } from '@aztec/foundation/json-rpc';
 import type { ReadOnlyFileStore } from '@aztec/stdlib/file-store';
 
 import {
@@ -20,7 +20,7 @@ export async function getSnapshotIndex(
   try {
     if (await store.exists(snapshotIndexPath)) {
       const snapshotIndexData = await store.read(snapshotIndexPath);
-      return jsonParseWithSchemaSync(snapshotIndexData.toString(), SnapshotsIndexSchema);
+      return jsonParseWithSchema(snapshotIndexData.toString(), SnapshotsIndexSchema);
     } else {
       return undefined;
     }

--- a/yarn-project/stdlib/src/tx/private_execution_result.test.ts
+++ b/yarn-project/stdlib/src/tx/private_execution_result.test.ts
@@ -40,7 +40,7 @@ describe('execution_result', () => {
   describe('serialization', () => {
     it('serializes and deserializes correctly', async () => {
       const instance = await PrivateExecutionResult.random();
-      expect(await jsonParseWithSchema(jsonStringify(instance), PrivateExecutionResult.schema)).toEqual(instance);
+      expect(jsonParseWithSchema(jsonStringify(instance), PrivateExecutionResult.schema)).toEqual(instance);
     });
   });
 

--- a/yarn-project/stdlib/src/tx/tx_execution_request.test.ts
+++ b/yarn-project/stdlib/src/tx/tx_execution_request.test.ts
@@ -6,7 +6,7 @@ describe('TxExecutionRequest', () => {
   it('serializes to json and deserializes it back', async () => {
     const request = await TxExecutionRequest.random();
     const json = jsonStringify(request);
-    expect(await jsonParseWithSchema(json, TxExecutionRequest.schema)).toEqual(request);
+    expect(jsonParseWithSchema(json, TxExecutionRequest.schema)).toEqual(request);
   });
 
   it('serializes to buffer and deserializes it back', async () => {

--- a/yarn-project/txe/src/index.ts
+++ b/yarn-project/txe/src/index.ts
@@ -1,7 +1,6 @@
 import { SchnorrAccountContractArtifact } from '@aztec/accounts/schnorr';
 import {
   AztecAddress,
-  type ContractArtifact,
   type ContractInstanceWithAddress,
   Fr,
   type NoirCompiledContract,
@@ -75,8 +74,8 @@ class TXEDispatcher {
 
   private fastHashFile(path: string) {
     return new Promise(resolve => {
-      var fd = createReadStream(path);
-      var hash = createHash('sha1');
+      const fd = createReadStream(path);
+      const hash = createHash('sha1');
       hash.setEncoding('hex');
 
       fd.on('end', function () {

--- a/yarn-project/txe/src/index.ts
+++ b/yarn-project/txe/src/index.ts
@@ -4,6 +4,7 @@ import {
   type ContractArtifact,
   type ContractInstanceWithAddress,
   Fr,
+  type NoirCompiledContract,
   PublicKeys,
   deriveKeys,
   getContractInstanceFromDeployParams,
@@ -13,8 +14,11 @@ import { createSafeJsonRpcServer } from '@aztec/foundation/json-rpc/server';
 import type { Logger } from '@aztec/foundation/log';
 import { type ProtocolContract, protocolContractNames } from '@aztec/protocol-contracts';
 import { BundledProtocolContractsProvider } from '@aztec/protocol-contracts/providers/bundle';
+import { computeArtifactHash } from '@aztec/stdlib/contract';
 import type { ApiSchemaFor, ZodFor } from '@aztec/stdlib/schemas';
 
+import { createHash } from 'crypto';
+import { createReadStream } from 'fs';
 import { readFile, readdir } from 'fs/promises';
 import { join } from 'path';
 import { z } from 'zod';
@@ -32,10 +36,14 @@ import {
   toForeignCallResult,
   toSingle,
 } from './util/encoding.js';
+import type { ContractArtifactWithHash } from './util/txe_contract_data_provider.js';
 
 const TXESessions = new Map<number, TXEService>();
 
-const TXEArtifactsCache = new Map<string, { artifact: ContractArtifact; instance: ContractInstanceWithAddress }>();
+const TXEArtifactsCache = new Map<
+  string,
+  { artifact: ContractArtifactWithHash; instance: ContractInstanceWithAddress }
+>();
 
 type MethodNames<T> = {
   [K in keyof T]: T[K] extends (...args: any[]) => any ? K : never;
@@ -65,6 +73,21 @@ class TXEDispatcher {
 
   constructor(private logger: Logger) {}
 
+  private fastHashFile(path: string) {
+    return new Promise(resolve => {
+      var fd = createReadStream(path);
+      var hash = createHash('sha1');
+      hash.setEncoding('hex');
+
+      fd.on('end', function () {
+        hash.end();
+        resolve(hash.read());
+      });
+
+      fd.pipe(hash);
+    });
+  }
+
   async #processDeployInputs({ inputs, root_path: rootPath, package_name: packageName }: TXEForeignCallInput) {
     const [pathStr, contractName, initializer] = inputs.slice(0, 3).map(input =>
       fromArray(input as ForeignCallArray)
@@ -77,40 +100,48 @@ class TXEDispatcher {
     const publicKeys = secret.equals(Fr.ZERO) ? PublicKeys.default() : (await deriveKeys(secret)).publicKeys;
     const publicKeysHash = await publicKeys.hash();
 
+    let artifactPath = '';
+    // We're deploying the contract under test
+    // env.deploy_self("contractName")
+    if (!pathStr) {
+      artifactPath = join(rootPath, './target', `${packageName}-${contractName}.json`);
+    } else {
+      // We're deploying a contract that belongs in a workspace
+      // env.deploy("../path/to/workspace/root@packageName", "contractName")
+      if (pathStr.includes('@')) {
+        const [workspace, pkg] = pathStr.split('@');
+        const targetPath = join(rootPath, workspace, './target');
+        this.logger.debug(`Looking for compiled artifact in workspace ${targetPath}`);
+        artifactPath = join(targetPath, `${pkg}-${contractName}.json`);
+      } else {
+        // We're deploying a standalone contract
+        // env.deploy("../path/to/contract/root", "contractName")
+        const targetPath = join(rootPath, pathStr, './target');
+        this.logger.debug(`Looking for compiled artifact in ${targetPath}`);
+        [artifactPath] = (await readdir(targetPath)).filter(file => file.endsWith(`-${contractName}.json`));
+      }
+    }
+
+    const fileHash = await this.fastHashFile(artifactPath);
+
     const cacheKey = `${pathStr}-${contractName}-${initializer}-${decodedArgs
       .map(arg => arg.toString())
-      .join('-')}-${publicKeysHash.toString()}`;
+      .join('-')}-${publicKeysHash}-${fileHash}`;
 
-    let artifact;
     let instance;
+    let artifact: ContractArtifactWithHash;
 
     if (TXEArtifactsCache.has(cacheKey)) {
       this.logger.debug(`Using cached artifact for ${cacheKey}`);
       ({ artifact, instance } = TXEArtifactsCache.get(cacheKey)!);
     } else {
-      let artifactPath = '';
-      // We're deploying the contract under test
-      // env.deploy_self("contractName")
-      if (!pathStr) {
-        artifactPath = join(rootPath, './target', `${packageName}-${contractName}.json`);
-      } else {
-        // We're deploying a contract that belongs in a workspace
-        // env.deploy("../path/to/workspace/root@packageName", "contractName")
-        if (pathStr.includes('@')) {
-          const [workspace, pkg] = pathStr.split('@');
-          const targetPath = join(rootPath, workspace, './target');
-          this.logger.debug(`Looking for compiled artifact in workspace ${targetPath}`);
-          artifactPath = join(targetPath, `${pkg}-${contractName}.json`);
-        } else {
-          // We're deploying a standalone contract
-          // env.deploy("../path/to/contract/root", "contractName")
-          const targetPath = join(rootPath, pathStr, './target');
-          this.logger.debug(`Looking for compiled artifact in ${targetPath}`);
-          [artifactPath] = (await readdir(targetPath)).filter(file => file.endsWith(`-${contractName}.json`));
-        }
-      }
       this.logger.debug(`Loading compiled artifact ${artifactPath}`);
-      artifact = loadContractArtifact(JSON.parse(await readFile(artifactPath, 'utf-8')));
+      const artifactJSON = JSON.parse(await readFile(artifactPath, 'utf-8')) as NoirCompiledContract;
+      const artifactWithoutHash = loadContractArtifact(artifactJSON);
+      artifact = {
+        ...artifactWithoutHash,
+        artifactHash: await computeArtifactHash(artifactWithoutHash),
+      };
       this.logger.debug(
         `Deploy ${
           artifact.name
@@ -135,7 +166,7 @@ class TXEDispatcher {
 
     const cacheKey = `SchnorrAccountContract-${secret}`;
 
-    let artifact;
+    let artifact: ContractArtifactWithHash;
     let instance;
 
     if (TXEArtifactsCache.has(cacheKey)) {
@@ -144,7 +175,10 @@ class TXEDispatcher {
     } else {
       const keys = await deriveKeys(secret);
       const args = [keys.publicKeys.masterIncomingViewingPublicKey.x, keys.publicKeys.masterIncomingViewingPublicKey.y];
-      artifact = SchnorrAccountContractArtifact;
+      artifact = {
+        ...SchnorrAccountContractArtifact,
+        artifactHash: await computeArtifactHash(SchnorrAccountContractArtifact),
+      };
       instance = await getContractInstanceFromDeployParams(artifact, {
         constructorArgs: args,
         skipArgsDecoding: true,

--- a/yarn-project/txe/src/index.ts
+++ b/yarn-project/txe/src/index.ts
@@ -39,6 +39,10 @@ import type { ContractArtifactWithHash } from './util/txe_contract_data_provider
 
 const TXESessions = new Map<number, TXEService>();
 
+/*
+ * TXE typically has to load the same contract artifacts over and over again for multiple tests,
+ * so we cache them here to avoid both loading them from disk repeatedly and computing their artifact hashes
+ */
 const TXEArtifactsCache = new Map<
   string,
   { artifact: ContractArtifactWithHash; instance: ContractInstanceWithAddress }
@@ -139,6 +143,8 @@ class TXEDispatcher {
       const artifactWithoutHash = loadContractArtifact(artifactJSON);
       artifact = {
         ...artifactWithoutHash,
+        // Artifact hash is *very* expensive to compute, so we do it here once
+        // and the TXE contract data provider can cache it
         artifactHash: await computeArtifactHash(artifactWithoutHash),
       };
       this.logger.debug(
@@ -176,6 +182,8 @@ class TXEDispatcher {
       const args = [keys.publicKeys.masterIncomingViewingPublicKey.x, keys.publicKeys.masterIncomingViewingPublicKey.y];
       artifact = {
         ...SchnorrAccountContractArtifact,
+        // Artifact hash is *very* expensive to compute, so we do it here once
+        // and the TXE contract data provider can cache it
         artifactHash: await computeArtifactHash(SchnorrAccountContractArtifact),
       };
       instance = await getContractInstanceFromDeployParams(artifact, {

--- a/yarn-project/txe/src/oracle/txe_oracle.ts
+++ b/yarn-project/txe/src/oracle/txe_oracle.ts
@@ -140,6 +140,7 @@ import { ForkCheckpoint, NativeWorldStateService } from '@aztec/world-state/nati
 
 import { TXEStateMachine } from '../state_machine/index.js';
 import { TXEAccountDataProvider } from '../util/txe_account_data_provider.js';
+import { TXEContractDataProvider } from '../util/txe_contract_data_provider.js';
 import { TXEPublicContractDataSource } from '../util/txe_public_contract_data_source.js';
 
 export class TXE implements TypedOracle {
@@ -176,7 +177,7 @@ export class TXE implements TypedOracle {
   private constructor(
     private logger: Logger,
     private keyStore: KeyStore,
-    private contractDataProvider: ContractDataProvider,
+    private contractDataProvider: TXEContractDataProvider,
     private noteDataProvider: NoteDataProvider,
     private capsuleDataProvider: CapsuleDataProvider,
     private syncDataProvider: SyncDataProvider,
@@ -221,7 +222,7 @@ export class TXE implements TypedOracle {
 
     const addressDataProvider = new AddressDataProvider(store);
     const privateEventDataProvider = new PrivateEventDataProvider(store);
-    const contractDataProvider = new ContractDataProvider(store);
+    const contractDataProvider = new TXEContractDataProvider(store);
     const noteDataProvider = await NoteDataProvider.create(store);
     const taggingDataProvider = new TaggingDataProvider(store);
     const capsuleDataProvider = new CapsuleDataProvider(store);

--- a/yarn-project/txe/src/oracle/txe_oracle.ts
+++ b/yarn-project/txe/src/oracle/txe_oracle.ts
@@ -25,7 +25,6 @@ import type { ProtocolContract } from '@aztec/protocol-contracts';
 import {
   AddressDataProvider,
   CapsuleDataProvider,
-  ContractDataProvider,
   NoteDataProvider,
   PXEOracleInterface,
   PrivateEventDataProvider,

--- a/yarn-project/txe/src/util/txe_contract_data_provider.ts
+++ b/yarn-project/txe/src/util/txe_contract_data_provider.ts
@@ -1,0 +1,30 @@
+import { type ContractArtifact, Fr } from '@aztec/aztec.js';
+import { ContractDataProvider } from '@aztec/pxe/server';
+
+export type ContractArtifactWithHash = ContractArtifact & { artifactHash: Fr };
+
+export class TXEContractDataProvider extends ContractDataProvider {
+  #artifactHashes: Map<string, Buffer> = new Map();
+
+  public override async addContractArtifact(
+    id: Fr,
+    artifact: ContractArtifact | ContractArtifactWithHash,
+  ): Promise<void> {
+    if ('artifactHash' in artifact) {
+      this.#artifactHashes.set(id.toString(), artifact.artifactHash.toBuffer());
+    }
+    await super.addContractArtifact(id, artifact);
+  }
+
+  public override async getContractArtifact(
+    contractClassId: Fr,
+  ): Promise<ContractArtifact | ContractArtifactWithHash | undefined> {
+    const artifact = await super.getContractArtifact(contractClassId);
+    if (artifact && this.#artifactHashes.has(contractClassId.toString())) {
+      (artifact as ContractArtifactWithHash).artifactHash = Fr.fromBuffer(
+        this.#artifactHashes.get(contractClassId.toString())!,
+      );
+    }
+    return artifact;
+  }
+}

--- a/yarn-project/txe/src/util/txe_contract_data_provider.ts
+++ b/yarn-project/txe/src/util/txe_contract_data_provider.ts
@@ -3,6 +3,11 @@ import { ContractDataProvider } from '@aztec/pxe/server';
 
 export type ContractArtifactWithHash = ContractArtifact & { artifactHash: Fr };
 
+/*
+ * A contract data provider that stores contract artifacts with their hashes. Since
+ * TXE typically deploys the same contract again and again for multiple tests, caching
+ * the *very* expensive artifact hash computation improves testing speed significantly.
+ */
 export class TXEContractDataProvider extends ContractDataProvider {
   #artifactHashes: Map<string, Buffer> = new Map();
 

--- a/yarn-project/txe/src/util/txe_public_contract_data_source.ts
+++ b/yarn-project/txe/src/util/txe_public_contract_data_source.ts
@@ -13,6 +13,7 @@ import {
 import type { TXE } from '../oracle/txe_oracle.js';
 
 export class TXEPublicContractDataSource implements ContractDataSource {
+  #privateFunctionsRoot: Map<string, Buffer> = new Map();
   constructor(private txeOracle: TXE) {}
 
   getBlockNumber(): Promise<number> {
@@ -29,12 +30,18 @@ export class TXEPublicContractDataSource implements ContractDataSource {
       return;
     }
 
-    const privateFunctions = await Promise.all(
-      artifact.functions
-        .filter(fn => fn.functionType === FunctionType.PRIVATE)
-        .map(fn => getContractClassPrivateFunctionFromArtifact(fn)),
-    );
-    const privateFunctionsRoot = await computePrivateFunctionsRoot(privateFunctions);
+    let privateFunctionsRoot;
+    if (!this.#privateFunctionsRoot.has(id.toString())) {
+      const privateFunctions = await Promise.all(
+        artifact.functions
+          .filter(fn => fn.functionType === FunctionType.PRIVATE)
+          .map(fn => getContractClassPrivateFunctionFromArtifact(fn)),
+      );
+      privateFunctionsRoot = await computePrivateFunctionsRoot(privateFunctions);
+      this.#privateFunctionsRoot.set(id.toString(), privateFunctionsRoot.toBuffer());
+    } else {
+      privateFunctionsRoot = Fr.fromBuffer(this.#privateFunctionsRoot.get(id.toString())!);
+    }
 
     return {
       id,


### PR DESCRIPTION
Somehow a huge regression on TXE speed wasn't caught. Culprits:

- `zod.parseAsync`: Fortunately not needed anymore, should provide a healthy bump in speed
- Excessive hashing: `artifactHash` can be safely cached on TXE. Also the new `TXENode` and its contract provider where redoing a log of private function tree hashing


This also fixes  https://github.com/AztecProtocol/aztec-packages/issues/15132#event-18210743512
