### PR TITLE
chore: bigfield negation operator audit and bug fix

### DIFF
--- a/barretenberg/cpp/src/barretenberg/stdlib/primitives/bigfield/bigfield.hpp
+++ b/barretenberg/cpp/src/barretenberg/stdlib/primitives/bigfield/bigfield.hpp
@@ -929,6 +929,9 @@ template <typename Builder, typename T> class bigfield {
                                                                const std::vector<uint1024_t>& remainders_max = {
                                                                    DEFAULT_MAXIMUM_REMAINDER });
 
+    static std::pair<uint512_t, std::array<uint256_t, NUM_LIMBS>> get_multiple_of_modulus_for_subtracting(
+        const bigfield& to_subtract);
+
     /**
      * @brief Evaluate a multiply add identity with several added elements and several remainders
      *

--- a/barretenberg/cpp/src/barretenberg/stdlib/primitives/bigfield/bigfield.hpp
+++ b/barretenberg/cpp/src/barretenberg/stdlib/primitives/bigfield/bigfield.hpp
@@ -566,6 +566,12 @@ template <typename Builder, typename T> class bigfield {
     bigfield div_without_denominator_check(const bigfield& denominator);
     static bigfield div_check_denominator_nonzero(const std::vector<bigfield>& numerators, const bigfield& denominator);
 
+    /**
+     * @brief Conditionally negate the bigfield element.
+     *
+     * @param predicate The condition to check.
+     * @return bigfield If predicate is true, return `-this`, otherwise return `this`.
+     */
     bigfield conditional_negate(const bool_t<Builder>& predicate) const;
     bigfield conditional_select(const bigfield& other, const bool_t<Builder>& predicate) const;
     static bigfield conditional_assign(const bool_t<Builder>& predicate, const bigfield& lhs, const bigfield& rhs)

--- a/barretenberg/cpp/src/barretenberg/stdlib/primitives/bigfield/bigfield_impl.hpp
+++ b/barretenberg/cpp/src/barretenberg/stdlib/primitives/bigfield/bigfield_impl.hpp
@@ -10,7 +10,11 @@
 #include "barretenberg/common/zip_view.hpp"
 #include "barretenberg/numeric/uint256/uint256.hpp"
 #include "barretenberg/numeric/uintx/uintx.hpp"
+#include <array>
+#include <cstddef>
+#include <cstdint>
 #include <tuple>
+#include <utility>
 
 #include "../circuit_builders/circuit_builders.hpp"
 #include "bigfield.hpp"
@@ -1500,73 +1504,46 @@ bigfield<Builder, T> bigfield<Builder, T>::conditional_negate(const bool_t<Build
     }
     reduction_check();
 
-    uint256_t limb_0_maximum_value = binary_basis_limbs[0].maximum_value;
-    uint64_t limb_0_borrow_shift = std::max(limb_0_maximum_value.get_msb() + 1, NUM_LIMB_BITS);
-    uint256_t limb_1_maximum_value =
-        binary_basis_limbs[1].maximum_value + (uint256_t(1) << (limb_0_borrow_shift - NUM_LIMB_BITS));
-    uint64_t limb_1_borrow_shift = std::max(limb_1_maximum_value.get_msb() + 1, NUM_LIMB_BITS);
-    uint256_t limb_2_maximum_value =
-        binary_basis_limbs[2].maximum_value + (uint256_t(1) << (limb_1_borrow_shift - NUM_LIMB_BITS));
-    uint64_t limb_2_borrow_shift = std::max(limb_2_maximum_value.get_msb() + 1, NUM_LIMB_BITS);
+    // We must adjust the maximum value of the limbs of `this` to account for the multiplication by 2.
+    // And we must compute the constant to add based on this updated maximum value.
+    //
+    // This is because we are computing:
+    // (1 - predicate) * value + predicate * (0 - value)
+    // = value - predicate * 2 * value
+    //
+    bigfield<Builder, T> updated_this = *this;
+    updated_this.binary_basis_limbs[0].maximum_value *= 2;
+    updated_this.binary_basis_limbs[1].maximum_value *= 2;
+    updated_this.binary_basis_limbs[2].maximum_value *= 2;
+    updated_this.binary_basis_limbs[3].maximum_value *= 2;
 
-    uint256_t limb_3_maximum_value =
-        binary_basis_limbs[3].maximum_value + (uint256_t(1) << (limb_2_borrow_shift - NUM_LIMB_BITS));
-
-    // uint256_t comparison_maximum = uint256_t(modulus_u512.slice(NUM_LIMB_BITS * 3, NUM_LIMB_BITS * 4));
-    // uint256_t additive_term = comparison_maximum;
-    // TODO(https://github.com/AztecProtocol/aztec-packages/issues/14656): This is terribly inefficient. We should
-    // change it.
-    uint512_t constant_to_add = modulus_u512;
-    while (constant_to_add.slice(NUM_LIMB_BITS * 3, NUM_LIMB_BITS * 4).lo <= limb_3_maximum_value) {
-        constant_to_add += modulus_u512;
-    }
-
-    uint256_t t0(uint256_t(1) << limb_0_borrow_shift);
-    uint256_t t1((uint256_t(1) << limb_1_borrow_shift) - (uint256_t(1) << (limb_0_borrow_shift - NUM_LIMB_BITS)));
-    uint256_t t2((uint256_t(1) << limb_2_borrow_shift) - (uint256_t(1) << (limb_1_borrow_shift - NUM_LIMB_BITS)));
-    uint256_t t3(uint256_t(1) << (limb_2_borrow_shift - NUM_LIMB_BITS));
-
-    uint256_t to_add_0_u256 = uint256_t(constant_to_add.slice(0, NUM_LIMB_BITS));
-    uint256_t to_add_1_u256 = uint256_t(constant_to_add.slice(NUM_LIMB_BITS, NUM_LIMB_BITS * 2));
-    uint256_t to_add_2_u256 = uint256_t(constant_to_add.slice(NUM_LIMB_BITS * 2, NUM_LIMB_BITS * 3));
-    uint256_t to_add_3_u256 = uint256_t(constant_to_add.slice(NUM_LIMB_BITS * 3, NUM_LIMB_BITS * 4));
-
-    bb::fr to_add_0(t0 + to_add_0_u256);
-    bb::fr to_add_1(t1 + to_add_1_u256);
-    bb::fr to_add_2(t2 + to_add_2_u256);
-    bb::fr to_add_3(to_add_3_u256 - t3);
+    uint512_t constant_to_add = 0;
+    std::array<uint256_t, bigfield<Builder, T>::NUM_LIMBS> to_add_limbs{ 0, 0, 0, 0 };
+    std::tie(constant_to_add, to_add_limbs) =
+        bigfield<Builder, T>::get_multiple_of_modulus_for_subtracting(updated_this);
 
     // we either return current value if predicate is false, or (limb_i - value) if predicate is true
     // (1 - predicate) * value + predicate * (limb_i - value)
     // = predicate * (limb_i - 2 * value) + value
     bb::fr two(2);
 
-    field_t limb_0 = static_cast<field_t<Builder>>(predicate).madd(-(binary_basis_limbs[0].element * two) + to_add_0,
-                                                                   binary_basis_limbs[0].element);
-    field_t limb_1 = static_cast<field_t<Builder>>(predicate).madd(-(binary_basis_limbs[1].element * two) + to_add_1,
-                                                                   binary_basis_limbs[1].element);
-    field_t limb_2 = static_cast<field_t<Builder>>(predicate).madd(-(binary_basis_limbs[2].element * two) + to_add_2,
-                                                                   binary_basis_limbs[2].element);
-    field_t limb_3 = static_cast<field_t<Builder>>(predicate).madd(-(binary_basis_limbs[3].element * two) + to_add_3,
-                                                                   binary_basis_limbs[3].element);
+    field_t limb_0 = static_cast<field_t<Builder>>(predicate).madd(
+        -(binary_basis_limbs[0].element * two) + bb::fr(to_add_limbs[0]), binary_basis_limbs[0].element);
+    field_t limb_1 = static_cast<field_t<Builder>>(predicate).madd(
+        -(binary_basis_limbs[1].element * two) + bb::fr(to_add_limbs[1]), binary_basis_limbs[1].element);
+    field_t limb_2 = static_cast<field_t<Builder>>(predicate).madd(
+        -(binary_basis_limbs[2].element * two) + bb::fr(to_add_limbs[2]), binary_basis_limbs[2].element);
+    field_t limb_3 = static_cast<field_t<Builder>>(predicate).madd(
+        -(binary_basis_limbs[3].element * two) + bb::fr(to_add_limbs[3]), binary_basis_limbs[3].element);
 
-    uint256_t maximum_negated_limb_0 = to_add_0_u256 + t0;
-    uint256_t maximum_negated_limb_1 = to_add_1_u256 + t1;
-    uint256_t maximum_negated_limb_2 = to_add_2_u256 + t2;
-    uint256_t maximum_negated_limb_3 = to_add_3_u256;
-
-    uint256_t max_limb_0 = binary_basis_limbs[0].maximum_value > maximum_negated_limb_0
-                               ? binary_basis_limbs[0].maximum_value
-                               : maximum_negated_limb_0;
-    uint256_t max_limb_1 = binary_basis_limbs[1].maximum_value > maximum_negated_limb_1
-                               ? binary_basis_limbs[1].maximum_value
-                               : maximum_negated_limb_1;
-    uint256_t max_limb_2 = binary_basis_limbs[2].maximum_value > maximum_negated_limb_2
-                               ? binary_basis_limbs[2].maximum_value
-                               : maximum_negated_limb_2;
-    uint256_t max_limb_3 = binary_basis_limbs[3].maximum_value > maximum_negated_limb_3
-                               ? binary_basis_limbs[3].maximum_value
-                               : maximum_negated_limb_3;
+    uint256_t max_limb_0 =
+        binary_basis_limbs[0].maximum_value > to_add_limbs[0] ? binary_basis_limbs[0].maximum_value : to_add_limbs[0];
+    uint256_t max_limb_1 =
+        binary_basis_limbs[1].maximum_value > to_add_limbs[1] ? binary_basis_limbs[1].maximum_value : to_add_limbs[1];
+    uint256_t max_limb_2 =
+        binary_basis_limbs[2].maximum_value > to_add_limbs[2] ? binary_basis_limbs[2].maximum_value : to_add_limbs[2];
+    uint256_t max_limb_3 =
+        binary_basis_limbs[3].maximum_value > to_add_limbs[3] ? binary_basis_limbs[3].maximum_value : to_add_limbs[3];
 
     bigfield result(ctx);
     result.binary_basis_limbs[0] = Limb(limb_0, max_limb_0);

--- a/barretenberg/cpp/src/barretenberg/stdlib/primitives/bigfield/bigfield_impl.hpp
+++ b/barretenberg/cpp/src/barretenberg/stdlib/primitives/bigfield/bigfield_impl.hpp
@@ -1527,14 +1527,14 @@ bigfield<Builder, T> bigfield<Builder, T>::conditional_negate(const bool_t<Build
     // = predicate * (limb_i - 2 * value) + value
     bb::fr two(2);
 
-    field_t limb_0 = static_cast<field_t<Builder>>(predicate).madd(
-        -(binary_basis_limbs[0].element * two) + bb::fr(to_add_limbs[0]), binary_basis_limbs[0].element);
-    field_t limb_1 = static_cast<field_t<Builder>>(predicate).madd(
-        -(binary_basis_limbs[1].element * two) + bb::fr(to_add_limbs[1]), binary_basis_limbs[1].element);
-    field_t limb_2 = static_cast<field_t<Builder>>(predicate).madd(
-        -(binary_basis_limbs[2].element * two) + bb::fr(to_add_limbs[2]), binary_basis_limbs[2].element);
-    field_t limb_3 = static_cast<field_t<Builder>>(predicate).madd(
-        -(binary_basis_limbs[3].element * two) + bb::fr(to_add_limbs[3]), binary_basis_limbs[3].element);
+    field_t limb_0 = field_t<Builder>::conditional_assign(
+        predicate, bb::fr(to_add_limbs[0]) - (binary_basis_limbs[0].element * two), binary_basis_limbs[0].element);
+    field_t limb_1 = field_t<Builder>::conditional_assign(
+        predicate, bb::fr(to_add_limbs[1]) - (binary_basis_limbs[1].element * two), binary_basis_limbs[1].element);
+    field_t limb_2 = field_t<Builder>::conditional_assign(
+        predicate, bb::fr(to_add_limbs[2]) - (binary_basis_limbs[2].element * two), binary_basis_limbs[2].element);
+    field_t limb_3 = field_t<Builder>::conditional_assign(
+        predicate, bb::fr(to_add_limbs[3]) - (binary_basis_limbs[3].element * two), binary_basis_limbs[3].element);
 
     uint256_t max_limb_0 =
         binary_basis_limbs[0].maximum_value > to_add_limbs[0] ? binary_basis_limbs[0].maximum_value : to_add_limbs[0];

--- a/barretenberg/cpp/src/barretenberg/stdlib/primitives/bigfield/bigfield_impl.hpp
+++ b/barretenberg/cpp/src/barretenberg/stdlib/primitives/bigfield/bigfield_impl.hpp
@@ -521,23 +521,6 @@ bigfield<Builder, T> bigfield<Builder, T>::operator-(const bigfield& other) cons
         return operator+(bigfield(ctx, uint256_t(neg_right.lo)));
     }
 
-    /**
-     * Plookup bigfield subtractoin
-     *
-     * We have a special addition gate we can toggle, that will compute: (w_1 + w_4 - w_4_omega + q_arith = 0)
-     * This is in addition to the regular addition gate
-     *
-     * We can arrange our wires in memory like this:
-     *
-     *   |  1  |  2  |  3  |  4  |
-     *   |-----|-----|-----|-----|
-     *   | b.p | a.0 | b.0 | c.p | (b.p + c.p - a.p = 0) AND (a.0 - b.0 - c.0 = 0)
-     *   | a.p | a.1 | b.1 | c.0 | (a.1 - b.1 - c.1 = 0)
-     *   | a.2 | b.2 | c.2 | c.1 | (a.2 - b.2 - c.2 = 0)
-     *   | a.3 | b.3 | c.3 | --- | (a.3 - b.3 - c.3 = 0)
-     *
-     **/
-
     bigfield result(ctx);
 
     uint512_t constant_to_add = 0;

--- a/barretenberg/cpp/src/barretenberg/stdlib/primitives/bigfield/bigfield_impl.hpp
+++ b/barretenberg/cpp/src/barretenberg/stdlib/primitives/bigfield/bigfield_impl.hpp
@@ -1522,19 +1522,20 @@ bigfield<Builder, T> bigfield<Builder, T>::conditional_negate(const bool_t<Build
     std::tie(constant_to_add, to_add_limbs) =
         bigfield<Builder, T>::get_multiple_of_modulus_for_subtracting(updated_this);
 
-    // we either return current value if predicate is false, or (limb_i - value) if predicate is true
-    // (1 - predicate) * value + predicate * (limb_i - value)
-    // = predicate * (limb_i - 2 * value) + value
+    // predicate = 0 ==> limb_i
+    // predicate = 1 ==> X_i - 2 * limb_i
+    // ==> (1 - predicate) * limb_i + predicate * (X_i - limb_i)
+    //
     bb::fr two(2);
 
     field_t limb_0 = field_t<Builder>::conditional_assign(
-        predicate, -(binary_basis_limbs[0].element * two) + bb::fr(to_add_limbs[0]), binary_basis_limbs[0].element);
+        predicate, -(binary_basis_limbs[0].element) + bb::fr(to_add_limbs[0]), binary_basis_limbs[0].element);
     field_t limb_1 = field_t<Builder>::conditional_assign(
-        predicate, -(binary_basis_limbs[1].element * two) + bb::fr(to_add_limbs[1]), binary_basis_limbs[1].element);
+        predicate, -(binary_basis_limbs[1].element) + bb::fr(to_add_limbs[1]), binary_basis_limbs[1].element);
     field_t limb_2 = field_t<Builder>::conditional_assign(
-        predicate, -(binary_basis_limbs[2].element * two) + bb::fr(to_add_limbs[2]), binary_basis_limbs[2].element);
+        predicate, -(binary_basis_limbs[2].element) + bb::fr(to_add_limbs[2]), binary_basis_limbs[2].element);
     field_t limb_3 = field_t<Builder>::conditional_assign(
-        predicate, -(binary_basis_limbs[3].element * two) + bb::fr(to_add_limbs[3]), binary_basis_limbs[3].element);
+        predicate, -(binary_basis_limbs[3].element) + bb::fr(to_add_limbs[3]), binary_basis_limbs[3].element);
 
     uint256_t max_limb_0 =
         binary_basis_limbs[0].maximum_value > to_add_limbs[0] ? binary_basis_limbs[0].maximum_value : to_add_limbs[0];
@@ -1554,7 +1555,7 @@ bigfield<Builder, T> bigfield<Builder, T>::conditional_negate(const bool_t<Build
     uint512_t constant_to_add_mod_p = constant_to_add % prime_basis.modulus;
     field_t prime_basis_to_add(ctx, bb::fr(constant_to_add_mod_p.lo));
     result.prime_basis_limb =
-        static_cast<field_t<Builder>>(predicate).madd(-(prime_basis_limb * two) + prime_basis_to_add, prime_basis_limb);
+        field_t<Builder>::conditional_assign(predicate, -(prime_basis_limb) + prime_basis_to_add, prime_basis_limb);
 
     result.set_origin_tag(OriginTag(get_origin_tag(), predicate.tag));
 

--- a/barretenberg/cpp/src/barretenberg/stdlib/primitives/bigfield/bigfield_impl.hpp
+++ b/barretenberg/cpp/src/barretenberg/stdlib/primitives/bigfield/bigfield_impl.hpp
@@ -540,89 +540,25 @@ bigfield<Builder, T> bigfield<Builder, T>::operator-(const bigfield& other) cons
 
     bigfield result(ctx);
 
-    /**
-     * Step 1: For each limb compute the MAXIMUM value we will have to borrow from the next significant limb
-     *
-     * i.e. if we assume that `*this = 0` and `other = other.maximum_value`, how many bits do we need to borrow from
-     * the next significant limb to ensure each limb value is positive?
-     *
-     * N.B. for this segment `maximum_value` really refers to maximum NEGATIVE value of the result
-     **/
-    uint256_t limb_0_maximum_value = other.binary_basis_limbs[0].maximum_value;
-
-    // Compute maximum shift factor for limb_0
-    uint64_t limb_0_borrow_shift = std::max(limb_0_maximum_value.get_msb() + 1, NUM_LIMB_BITS);
-
-    // Compute the maximum negative value of limb_1, including the bits limb_0 may need to borrow
-    uint256_t limb_1_maximum_value =
-        other.binary_basis_limbs[1].maximum_value + (uint256_t(1) << (limb_0_borrow_shift - NUM_LIMB_BITS));
-
-    // repeat the above for the remaining limbs
-    uint64_t limb_1_borrow_shift = std::max(limb_1_maximum_value.get_msb() + 1, NUM_LIMB_BITS);
-    uint256_t limb_2_maximum_value =
-        other.binary_basis_limbs[2].maximum_value + (uint256_t(1) << (limb_1_borrow_shift - NUM_LIMB_BITS));
-    uint64_t limb_2_borrow_shift = std::max(limb_2_maximum_value.get_msb() + 1, NUM_LIMB_BITS);
-
-    uint256_t limb_3_maximum_value =
-        other.binary_basis_limbs[3].maximum_value + (uint256_t(1) << (limb_2_borrow_shift - NUM_LIMB_BITS));
-
-    /**
-     * Step 2: Compute the constant value `X = m * p` we must add to the result to ensure EVERY limb is >= 0
-     *
-     * We need to find a value `X` where `X.limb[3] > limb_3_maximum_value`.
-     * As long as the above holds, we can borrow bits from X.limb[3] to ensure less significant limbs are positive
-     *
-     * Start by setting constant_to_add = p
-     **/
-    uint512_t constant_to_add = modulus_u512;
-    // add a large enough multiple of p to not get negative result in subtraction
-    while (constant_to_add.slice(NUM_LIMB_BITS * 3, NUM_LIMB_BITS * 4).lo <= limb_3_maximum_value) {
-        constant_to_add += modulus_u512;
-    }
-
-    /**
-     * Step 3: Compute offset terms t0, t1, t2, t3 that we add to our result to ensure each limb is positive
-     *
-     * t3 represents the value we are BORROWING from constant_to_add.limb[3]
-     * t2, t1, t0 are the terms we will ADD to constant_to_add.limb[2], constant_to_add.limb[1],
-     *constant_to_add.limb[0]
-     *
-     * i.e. The net value we add to `constant_to_add` is 0. We must ensure that:
-     * t3 = t0 + (t1 << NUM_LIMB_BITS) + (t2 << NUM_LIMB_BITS * 2)
-     *
-     * e.g. the value we borrow to produce t0 is subtracted from t1,
-     *      the value we borrow from t1 is subtracted from t2
-     *      the value we borrow from t2 is equal to t3
-     **/
-    uint256_t t0(uint256_t(1) << limb_0_borrow_shift);
-    uint256_t t1((uint256_t(1) << limb_1_borrow_shift) - (uint256_t(1) << (limb_0_borrow_shift - NUM_LIMB_BITS)));
-    uint256_t t2((uint256_t(1) << limb_2_borrow_shift) - (uint256_t(1) << (limb_1_borrow_shift - NUM_LIMB_BITS)));
-    uint256_t t3(uint256_t(1) << (limb_2_borrow_shift - NUM_LIMB_BITS));
-
-    /**
-     * Compute the limbs of `constant_to_add`, including our offset terms t0, t1, t2, t3 that ensure each result
-     *limb is positive
-     **/
-    uint256_t to_add_0 = uint256_t(constant_to_add.slice(0, NUM_LIMB_BITS)) + t0;
-    uint256_t to_add_1 = uint256_t(constant_to_add.slice(NUM_LIMB_BITS, NUM_LIMB_BITS * 2)) + t1;
-    uint256_t to_add_2 = uint256_t(constant_to_add.slice(NUM_LIMB_BITS * 2, NUM_LIMB_BITS * 3)) + t2;
-    uint256_t to_add_3 = uint256_t(constant_to_add.slice(NUM_LIMB_BITS * 3, NUM_LIMB_BITS * 4)) - t3;
+    uint512_t constant_to_add = 0;
+    std::array<uint256_t, bigfield<Builder, T>::NUM_LIMBS> to_add_limbs{ 0, 0, 0, 0 };
+    std::tie(constant_to_add, to_add_limbs) = bigfield<Builder, T>::get_multiple_of_modulus_for_subtracting(other);
 
     /**
      * Update the maximum possible value of the result. We assume here that (*this.value) = 0
      **/
-    result.binary_basis_limbs[0].maximum_value = binary_basis_limbs[0].maximum_value + to_add_0;
-    result.binary_basis_limbs[1].maximum_value = binary_basis_limbs[1].maximum_value + to_add_1;
-    result.binary_basis_limbs[2].maximum_value = binary_basis_limbs[2].maximum_value + to_add_2;
-    result.binary_basis_limbs[3].maximum_value = binary_basis_limbs[3].maximum_value + to_add_3;
+    result.binary_basis_limbs[0].maximum_value = binary_basis_limbs[0].maximum_value + to_add_limbs[0];
+    result.binary_basis_limbs[1].maximum_value = binary_basis_limbs[1].maximum_value + to_add_limbs[1];
+    result.binary_basis_limbs[2].maximum_value = binary_basis_limbs[2].maximum_value + to_add_limbs[2];
+    result.binary_basis_limbs[3].maximum_value = binary_basis_limbs[3].maximum_value + to_add_limbs[3];
 
     /**
      * Compute the binary basis limbs of our result
      **/
-    result.binary_basis_limbs[0].element = binary_basis_limbs[0].element + bb::fr(to_add_0);
-    result.binary_basis_limbs[1].element = binary_basis_limbs[1].element + bb::fr(to_add_1);
-    result.binary_basis_limbs[2].element = binary_basis_limbs[2].element + bb::fr(to_add_2);
-    result.binary_basis_limbs[3].element = binary_basis_limbs[3].element + bb::fr(to_add_3);
+    result.binary_basis_limbs[0].element = binary_basis_limbs[0].element + bb::fr(to_add_limbs[0]);
+    result.binary_basis_limbs[1].element = binary_basis_limbs[1].element + bb::fr(to_add_limbs[1]);
+    result.binary_basis_limbs[2].element = binary_basis_limbs[2].element + bb::fr(to_add_limbs[2]);
+    result.binary_basis_limbs[3].element = binary_basis_limbs[3].element + bb::fr(to_add_limbs[3]);
 
     if (prime_basis_limb.multiplicative_constant == 1 && other.prime_basis_limb.multiplicative_constant == 1 &&
         !is_constant() && !other.is_constant()) {

--- a/barretenberg/cpp/src/barretenberg/stdlib/primitives/bigfield/bigfield_impl.hpp
+++ b/barretenberg/cpp/src/barretenberg/stdlib/primitives/bigfield/bigfield_impl.hpp
@@ -1526,8 +1526,6 @@ bigfield<Builder, T> bigfield<Builder, T>::conditional_negate(const bool_t<Build
     // predicate = 1 ==> X_i - 2 * limb_i
     // ==> (1 - predicate) * limb_i + predicate * (X_i - limb_i)
     //
-    bb::fr two(2);
-
     field_t limb_0 = field_t<Builder>::conditional_assign(
         predicate, -(binary_basis_limbs[0].element) + bb::fr(to_add_limbs[0]), binary_basis_limbs[0].element);
     field_t limb_1 = field_t<Builder>::conditional_assign(

--- a/barretenberg/cpp/src/barretenberg/stdlib/primitives/bigfield/bigfield_impl.hpp
+++ b/barretenberg/cpp/src/barretenberg/stdlib/primitives/bigfield/bigfield_impl.hpp
@@ -1528,13 +1528,13 @@ bigfield<Builder, T> bigfield<Builder, T>::conditional_negate(const bool_t<Build
     bb::fr two(2);
 
     field_t limb_0 = field_t<Builder>::conditional_assign(
-        predicate, bb::fr(to_add_limbs[0]) - (binary_basis_limbs[0].element * two), binary_basis_limbs[0].element);
+        predicate, -(binary_basis_limbs[0].element * two) + bb::fr(to_add_limbs[0]), binary_basis_limbs[0].element);
     field_t limb_1 = field_t<Builder>::conditional_assign(
-        predicate, bb::fr(to_add_limbs[1]) - (binary_basis_limbs[1].element * two), binary_basis_limbs[1].element);
+        predicate, -(binary_basis_limbs[1].element * two) + bb::fr(to_add_limbs[1]), binary_basis_limbs[1].element);
     field_t limb_2 = field_t<Builder>::conditional_assign(
-        predicate, bb::fr(to_add_limbs[2]) - (binary_basis_limbs[2].element * two), binary_basis_limbs[2].element);
+        predicate, -(binary_basis_limbs[2].element * two) + bb::fr(to_add_limbs[2]), binary_basis_limbs[2].element);
     field_t limb_3 = field_t<Builder>::conditional_assign(
-        predicate, bb::fr(to_add_limbs[3]) - (binary_basis_limbs[3].element * two), binary_basis_limbs[3].element);
+        predicate, -(binary_basis_limbs[3].element * two) + bb::fr(to_add_limbs[3]), binary_basis_limbs[3].element);
 
     uint256_t max_limb_0 =
         binary_basis_limbs[0].maximum_value > to_add_limbs[0] ? binary_basis_limbs[0].maximum_value : to_add_limbs[0];


### PR DESCRIPTION
Audit of the `operator-` and `conditional_negate` function in bigfield.

- We were duplicating code in computing the constant $X := (m \cdot p)$ to be added while subtracting, so created a new function.
- In `conditional_negate` we were computing the above constant for $(0 - v)$ when we are actually computing:
$$(1 - \textsf{b}) \cdot (v) +  \textsf{b} \cdot (0 - 2v)$$
where $\textsf{b}$ is the predicate. 
- We were setting the max value of limb 3 to be $X[3] + t_3$ where $t_3$ is the value that limb 2 borrowed from limb 3. 
- Use `field_t::conditional_assign` instead of `madd` function for readability.