### PR TITLE
feat: testnet archival node

### DIFF
--- a/spartan/aztec-network/templates/full-node.yaml
+++ b/spartan/aztec-network/templates/full-node.yaml
@@ -16,7 +16,10 @@ spec:
   volumeClaimTemplates:
     - metadata:
         name: full-node-data
+        annotations:
+          "helm.sh/resource-policy": {{ .Values.fullNode.storageRetentionPolicy | default "Delete" | quote }}
       spec:
+        storageClassName: {{ .Values.fullNode.storageClass | default "standard" }}
         accessModes: [ "ReadWriteOnce" ]
         resources:
           requests:

--- a/spartan/aztec-network/values/archival-node.yaml
+++ b/spartan/aztec-network/values/archival-node.yaml
@@ -1,0 +1,75 @@
+telemetry:
+  enabled: true
+
+snapshots:
+  uploadLocation: "gs://aztec-testnet/snapshots/"
+  syncUrl: "https://storage.googleapis.com/aztec-testnet/snapshots/"
+  frequency: "0 0 * * *" # daily uploads at midnight
+
+network:
+  public: true
+
+ethereum:
+  chainId: "11155111"
+  l1GasPriceMax: 1000
+  l1FixedPriorityFeePerGas: 3
+
+aztec:
+  realProofs: true
+  numberOfDefaultAccounts: 0
+  testAccounts: false
+  sponsoredFPC: true
+  bootstrapENRs: "enr:-LO4QLbJddVpePYjaiCftOBY-L7O6Mfj_43TAn5Q1Y-5qQ_OWmSFc7bTKWHzw5xmdVIqXUiizum_kIRniXdPnWHHcwEEhWF6dGVjqDAwLTExMTU1MTExLTAwMDAwMDAwLTAtMTgwNmEwMjgtMWE1MzBmM2KCaWSCdjSCaXCEI8nh9YlzZWNwMjU2azGhA-_dX6aFcXP1DLk91negbXL2a0mNYGXH4hrMvb2i92I0g3VkcIKd0A,enr:-LO4QN4WF8kFyV3sQVX0C_y_03Eepxk5Wac70l9QJcIDRYwKS6aRst1YcfbTDdvovXdRfKf-WSXNVWViGLhDA-dUz2MEhWF6dGVjqDAwLTExMTU1MTExLTAwMDAwMDAwLTAtMTgwNmEwMjgtMWE1MzBmM2KCaWSCdjSCaXCEIicTHolzZWNwMjU2azGhAsz7aFFYRnP5xjTux5UW-HyEQcW_EJrZMT1CNm79N4g-g3VkcIKd0A,enr:-LO4QFrGfkRaCk_iFTeUjR5ESwo45Eov9hx_T1-BLdoT-iHzFgCiHMT4V1KBtdFp8D0ajLSe5HcNYrhalmdJXgv6NTUEhWF6dGVjqDAwLTExMTU1MTExLTAwMDAwMDAwLTAtMTgwNmEwMjgtMWE1MzBmM2KCaWSCdjSCaXCEIlICt4lzZWNwMjU2azGhAlC6nKB3iDtRFqWKWqxf_t-P9hc-SZ6VFBJV4y3bTZBQg3VkcIKd0A"
+  contracts:
+    registryAddress: "0x4d2cc1d5fb6be65240e0bfc8154243e69c0fb19e"
+    rollupAddress: "0x8d1cc702453fa889f137dbd5734cdb7ee96b6ba0"
+    slashFactoryAddress: "0x3c9ccf55a8ac3c2eeedf2ee2aa1722188fd676be"
+    feeAssetHandlerContractAddress: "0x80d848dc9f52df56789e2d62ce66f19555ff1019"
+
+fullNode:
+  enabled: true
+  fixedStaticIpName: "alpha-archival-full-node-ip"
+  staticIpUrl: full-node.alpha-archival.aztec.network # TODO: add Route53 record if we want access to this later
+  replicas: 1
+  maxOldSpaceSize: "8192"
+  storageSize: "1Ti"
+  storageClass: "standard"
+  storageRetentionPolicy: "Retain"
+  resources:
+    requests:
+      cpu: "3"
+      memory: "10Gi"
+  p2p:
+    archivedTxLimit: "10000000" # 10 million
+  startupProbe:
+    periodSeconds: 60
+    failureThreshold: 60
+
+blobSink:
+  enabled: false
+
+bootNode:
+  enabled: false
+  externalHost: "http://localhost:8080"
+
+validator:
+  replicas: 0
+
+proverNode:
+  replicas: 0
+  externalHost: "http://localhost:8080"
+
+proverAgent:
+  enabled: false
+
+proverBroker:
+  enabled: false
+
+pxe:
+  enabled: false
+
+faucet:
+  enabled: false
+
+bot:
+  enabled: false

--- a/yarn-project/p2p/src/mem_pools/tx_pool/aztec_kv_tx_pool.ts
+++ b/yarn-project/p2p/src/mem_pools/tx_pool/aztec_kv_tx_pool.ts
@@ -311,6 +311,9 @@ export class AztecKVTxPool implements TxPool {
    * @returns Empty promise.
    */
   public deleteTxs(txHashes: TxHash[], eviction = false): Promise<void> {
+    if (txHashes.length === 0) {
+      return Promise.resolve();
+    }
     const deletedTxs: Tx[] = [];
     const poolDbTx = this.#store.transactionAsync(async () => {
       let pendingTxSize = (await this.#pendingTxSize.getAsync()) ?? 0;
@@ -336,7 +339,7 @@ export class AztecKVTxPool implements TxPool {
 
       await this.#pendingTxSize.set(pendingTxSize);
     });
-
+    this.#log.debug(`Deleted ${txHashes.length} txs from pool`, { txHashes });
     return this.#archivedTxLimit ? poolDbTx.then(() => this.archiveTxs(deletedTxs)) : poolDbTx;
   }
 
@@ -441,31 +444,45 @@ export class AztecKVTxPool implements TxPool {
    * @returns Empty promise.
    */
   private async archiveTxs(txs: Tx[]): Promise<void> {
-    const txHashes = await Promise.all(txs.map(tx => tx.getTxHash()));
-    await this.#archive.transactionAsync(async () => {
-      // calcualte the head and tail indices of the archived txs by insertion order.
-      let headIdx =
-        ((await this.#archivedTxIndices.entriesAsync({ limit: 1, reverse: true }).next()).value?.[0] ?? -1) + 1;
-      let tailIdx = (await this.#archivedTxIndices.entriesAsync({ limit: 1 }).next()).value?.[0] ?? 0;
+    if (txs.length === 0) {
+      return;
+    }
+    try {
+      const txHashes = await Promise.all(txs.map(tx => tx.getTxHash()));
+      await this.#archive.transactionAsync(async () => {
+        // calculate the head and tail indices of the archived txs by insertion order.
+        let headIdx =
+          ((await this.#archivedTxIndices.entriesAsync({ limit: 1, reverse: true }).next()).value?.[0] ?? -1) + 1;
+        let tailIdx = (await this.#archivedTxIndices.entriesAsync({ limit: 1 }).next()).value?.[0] ?? 0;
 
-      for (let i = 0; i < txs.length; i++) {
-        const tx = txs[i];
-        while (headIdx - tailIdx >= this.#archivedTxLimit) {
-          const txHash = await this.#archivedTxIndices.getAsync(tailIdx);
-          if (txHash) {
-            await this.#archivedTxs.delete(txHash);
-            await this.#archivedTxIndices.delete(tailIdx);
+        for (let i = 0; i < txs.length; i++) {
+          const tx = txs[i];
+          while (headIdx - tailIdx >= this.#archivedTxLimit) {
+            const txHash = await this.#archivedTxIndices.getAsync(tailIdx);
+            if (txHash) {
+              await this.#archivedTxs.delete(txHash);
+              await this.#archivedTxIndices.delete(tailIdx);
+            }
+            tailIdx++;
           }
-          tailIdx++;
-        }
 
-        const archivedTx: Tx = new Tx(tx.data, ClientIvcProof.empty(), tx.contractClassLogs, tx.publicFunctionCalldata);
-        const txHash = txHashes[i].toString();
-        await this.#archivedTxs.set(txHash, archivedTx.toBuffer());
-        await this.#archivedTxIndices.set(headIdx, txHash);
-        headIdx++;
-      }
-    });
+          const archivedTx: Tx = new Tx(
+            tx.data,
+            ClientIvcProof.empty(),
+            tx.contractClassLogs,
+            tx.publicFunctionCalldata,
+          );
+          const txHash = txHashes[i].toString();
+          await this.#archivedTxs.set(txHash, archivedTx.toBuffer());
+          await this.#archivedTxIndices.set(headIdx, txHash);
+          headIdx++;
+        }
+        this.#log.debug(`Archived ${txs.length} txs`, { txHashes });
+        this.#log.debug(`Total archived txs: ${headIdx - tailIdx}`);
+      });
+    } catch (error) {
+      this.#log.error(`Error archiving txs`, { error });
+    }
   }
 
   /**


### PR DESCRIPTION
- adds helm values for a full node that archives transactions
- adds some logging around deleting & archiving txs
- skips delete & archive logic if txs array is empty