### PR TITLE
chore(avm): proper testing lookups

### DIFF
--- a/barretenberg/cpp/src/barretenberg/vm2/tracegen/lib/interaction_def.hpp
+++ b/barretenberg/cpp/src/barretenberg/vm2/tracegen/lib/interaction_def.hpp
@@ -11,6 +11,7 @@
 #include "barretenberg/vm2/tracegen/lib/lookup_into_indexed_by_clk.hpp"
 #include "barretenberg/vm2/tracegen/lib/lookup_into_p_decomposition.hpp"
 #include "barretenberg/vm2/tracegen/lib/permutation_builder.hpp"
+#include "barretenberg/vm2/tracegen/lib/test_interaction_builder.hpp"
 
 namespace bb::avm2::tracegen {
 
@@ -52,18 +53,33 @@ class InteractionDefinition {
     template <typename InteractionSettings, InteractionType type> static Factory get_interaction_factory()
     {
         if constexpr (type == InteractionType::LookupGeneric) {
-            return [](bool) { return std::make_unique<LookupIntoDynamicTableGeneric<InteractionSettings>>(); };
+            return [](bool) {
+                // This class always checks.
+                return std::make_unique<LookupIntoDynamicTableGeneric<InteractionSettings>>();
+            };
         } else if constexpr (type == InteractionType::LookupIntoBitwise) {
-            return [](bool) { return std::make_unique<LookupIntoBitwise<InteractionSettings>>(); };
+            return [](bool strict) {
+                return strict ? std::make_unique<AddChecksToBuilder<LookupIntoBitwise<InteractionSettings>>>()
+                              : std::make_unique<LookupIntoBitwise<InteractionSettings>>();
+            };
         } else if constexpr (type == InteractionType::LookupIntoIndexedByClk) {
-            return [](bool) { return std::make_unique<LookupIntoIndexedByClk<InteractionSettings>>(); };
+            return [](bool strict) {
+                return strict ? std::make_unique<AddChecksToBuilder<LookupIntoIndexedByClk<InteractionSettings>>>()
+                              : std::make_unique<LookupIntoIndexedByClk<InteractionSettings>>();
+            };
         } else if constexpr (type == InteractionType::LookupIntoPDecomposition) {
-            return [](bool) { return std::make_unique<LookupIntoPDecomposition<InteractionSettings>>(); };
+            return [](bool strict) {
+                return strict ? std::make_unique<AddChecksToBuilder<LookupIntoPDecomposition<InteractionSettings>>>()
+                              : std::make_unique<LookupIntoPDecomposition<InteractionSettings>>();
+            };
         } else if constexpr (type == InteractionType::LookupSequential) {
-            return [](bool) { return std::make_unique<LookupIntoDynamicTableSequential<InteractionSettings>>(); };
+            return [](bool) {
+                // This class always checks.
+                return std::make_unique<LookupIntoDynamicTableSequential<InteractionSettings>>();
+            };
         } else if constexpr (type == InteractionType::Permutation) {
             return [](bool strict) {
-                return strict ? std::make_unique<DebugPermutationBuilder<InteractionSettings>>()
+                return strict ? std::make_unique<CheckingPermutationBuilder<InteractionSettings>>()
                               : std::make_unique<PermutationBuilder<InteractionSettings>>();
             };
         } else {

--- a/barretenberg/cpp/src/barretenberg/vm2/tracegen/lib/lookup_builder.hpp
+++ b/barretenberg/cpp/src/barretenberg/vm2/tracegen/lib/lookup_builder.hpp
@@ -16,9 +16,10 @@
 
 namespace bb::avm2::tracegen {
 
-template <typename LookupSettings_> class BaseLookupTraceBuilder : public InteractionBuilderInterface {
+// A lookup builder that uses a function `find_in_dst` to find the destination row for a given source tuple.
+template <typename LookupSettings_> class IndexedLookupTraceBuilder : public InteractionBuilderInterface {
   public:
-    ~BaseLookupTraceBuilder() override = default;
+    ~IndexedLookupTraceBuilder() override = default;
 
     void process(TraceContainer& trace) override
     {
@@ -55,9 +56,8 @@ template <typename LookupSettings_> class BaseLookupTraceBuilder : public Intera
 // It calculates the counts by trying to find the tuple in the destination columns.
 // It creates an index of the destination columns on init, and uses it to find the tuple efficiently.
 // This class should work for any lookup that is not precomputed.
-// However, consider using a more specialized and faster class.
 template <typename LookupSettings_>
-class LookupIntoDynamicTableGeneric : public BaseLookupTraceBuilder<LookupSettings_> {
+class LookupIntoDynamicTableGeneric : public IndexedLookupTraceBuilder<LookupSettings_> {
   public:
     virtual ~LookupIntoDynamicTableGeneric() = default;
 

--- a/barretenberg/cpp/src/barretenberg/vm2/tracegen/lib/lookup_into_bitwise.hpp
+++ b/barretenberg/cpp/src/barretenberg/vm2/tracegen/lib/lookup_into_bitwise.hpp
@@ -6,8 +6,8 @@
 
 namespace bb::avm2::tracegen {
 
-template <typename LookupSettings> class LookupIntoBitwise : public BaseLookupTraceBuilder<LookupSettings> {
-  private:
+template <typename LookupSettings> class LookupIntoBitwise : public IndexedLookupTraceBuilder<LookupSettings> {
+  protected:
     // This is an efficient implementation of indexing into the precomputed table.
     uint32_t find_in_dst(const std::array<FF, LookupSettings::LOOKUP_TUPLE_SIZE>& tup) const override
     {

--- a/barretenberg/cpp/src/barretenberg/vm2/tracegen/lib/lookup_into_indexed_by_clk.hpp
+++ b/barretenberg/cpp/src/barretenberg/vm2/tracegen/lib/lookup_into_indexed_by_clk.hpp
@@ -14,8 +14,8 @@ namespace bb::avm2::tracegen {
  * An example with a size 2 tuple (p denotes precomputed):
  * start {tag, ctr} in p.sel_integral_tag {p.clk, p.integral_tag_length};
  */
-template <typename LookupSettings> class LookupIntoIndexedByClk : public BaseLookupTraceBuilder<LookupSettings> {
-  private:
+template <typename LookupSettings> class LookupIntoIndexedByClk : public IndexedLookupTraceBuilder<LookupSettings> {
+  protected:
     // This is an efficient implementation of indexing into the precomputed table.
     uint32_t find_in_dst(const std::array<FF, LookupSettings::LOOKUP_TUPLE_SIZE>& tup) const override
     {

--- a/barretenberg/cpp/src/barretenberg/vm2/tracegen/lib/lookup_into_p_decomposition.hpp
+++ b/barretenberg/cpp/src/barretenberg/vm2/tracegen/lib/lookup_into_p_decomposition.hpp
@@ -8,8 +8,8 @@
 
 namespace bb::avm2::tracegen {
 
-template <typename LookupSettings> class LookupIntoPDecomposition : public BaseLookupTraceBuilder<LookupSettings> {
-  private:
+template <typename LookupSettings> class LookupIntoPDecomposition : public IndexedLookupTraceBuilder<LookupSettings> {
+  protected:
     uint32_t find_in_dst(const std::array<FF, LookupSettings::LOOKUP_TUPLE_SIZE>& tup) const override
     {
         const auto& [radix, limb_index, _] = tup;

--- a/barretenberg/cpp/src/barretenberg/vm2/tracegen/lib/permutation_builder.hpp
+++ b/barretenberg/cpp/src/barretenberg/vm2/tracegen/lib/permutation_builder.hpp
@@ -1,11 +1,5 @@
 #pragma once
 
-#include <string>
-#include <unordered_set>
-
-#include "barretenberg/common/log.hpp"
-#include "barretenberg/vm2/common/map.hpp"
-#include "barretenberg/vm2/common/stringify.hpp"
 #include "barretenberg/vm2/tracegen/lib/interaction_builder.hpp"
 #include "barretenberg/vm2/tracegen/trace_container.hpp"
 
@@ -17,75 +11,6 @@ namespace bb::avm2::tracegen {
 template <typename PermutationSettings> class PermutationBuilder : public InteractionBuilderInterface {
   public:
     void process(TraceContainer& trace) override { SetDummyInverses<PermutationSettings>(trace); }
-};
-
-// Builds a permutation and performs additional checks.
-// Only use in tests and debugging. This is slow and memory intensive.
-template <typename PermutationSettings> class DebugPermutationBuilder : public PermutationBuilder<PermutationSettings> {
-  public:
-    using ArrayTuple = std::array<FF, PermutationSettings::COLUMNS_PER_SET>;
-
-    void process(TraceContainer& trace) override
-    {
-        PermutationBuilder<PermutationSettings>::process(trace);
-
-        // Collect the source and destination tuples.
-        source_tuples.clear();
-        trace.visit_column(PermutationSettings::SRC_SELECTOR, [&](uint32_t row, const FF&) {
-            auto src_values = trace.get_multiple(PermutationSettings::SRC_COLUMNS, row);
-            source_tuples[src_values].insert(row);
-        });
-        destination_tuples.clear();
-        trace.visit_column(PermutationSettings::DST_SELECTOR, [&](uint32_t row, const FF&) {
-            auto dst_values = trace.get_multiple(PermutationSettings::DST_COLUMNS, row);
-            destination_tuples[dst_values].insert(row);
-        });
-
-        auto build_error_message =
-            [&](const ArrayTuple& tuple, const auto& columns, const auto& src_rows, const auto& dst_rows) {
-                std::string error = "Failure to build permutation " + std::string(PermutationSettings::NAME) + ".\n";
-                error += format("Tuple ",
-                                column_values_to_string(tuple, columns),
-                                " has multiplicity ",
-                                src_rows.size(),
-                                " in the source, but ",
-                                dst_rows.size(),
-                                " in the destination.\n");
-                error += format("Source rows: ");
-                for (auto row : src_rows) {
-                    error += format(row, " ");
-                }
-                error += format("\n");
-                error += format("Destination rows: ");
-                for (auto row : dst_rows) {
-                    error += format(row, " ");
-                }
-                return error;
-            };
-
-        // Check that every source tuple is found in the destination with the same multiplicity.
-        for (const auto& [src_tuple, src_rows] : source_tuples) {
-            auto dst_rows = destination_tuples.contains(src_tuple) ? destination_tuples.at(src_tuple)
-                                                                   : std::unordered_set<uint32_t>();
-            if (src_rows.size() != dst_rows.size()) {
-                throw std::runtime_error(
-                    build_error_message(src_tuple, PermutationSettings::SRC_COLUMNS, src_rows, dst_rows));
-            }
-        }
-        // Check that every destination tuple is found in the source with the same multiplicity.
-        for (const auto& [dst_tuple, dst_rows] : destination_tuples) {
-            auto src_rows =
-                source_tuples.contains(dst_tuple) ? source_tuples.at(dst_tuple) : std::unordered_set<uint32_t>();
-            if (src_rows.size() != dst_rows.size()) {
-                throw std::runtime_error(
-                    build_error_message(dst_tuple, PermutationSettings::DST_COLUMNS, src_rows, dst_rows));
-            }
-        }
-    }
-
-  private:
-    unordered_flat_map<ArrayTuple, std::unordered_set<uint32_t>> source_tuples;
-    unordered_flat_map<ArrayTuple, std::unordered_set<uint32_t>> destination_tuples;
 };
 
 } // namespace bb::avm2::tracegen

--- a/barretenberg/cpp/src/barretenberg/vm2/tracegen/lib/test_interaction_builder.hpp
+++ b/barretenberg/cpp/src/barretenberg/vm2/tracegen/lib/test_interaction_builder.hpp
@@ -1,0 +1,119 @@
+#pragma once
+
+#include <string>
+#include <unordered_set>
+
+#include "barretenberg/common/log.hpp"
+#include "barretenberg/vm2/common/map.hpp"
+#include "barretenberg/vm2/common/stringify.hpp"
+#include "barretenberg/vm2/tracegen/lib/interaction_builder.hpp"
+#include "barretenberg/vm2/tracegen/lib/lookup_builder.hpp"
+#include "barretenberg/vm2/tracegen/lib/permutation_builder.hpp"
+#include "barretenberg/vm2/tracegen/trace_container.hpp"
+
+namespace bb::avm2::tracegen {
+
+// Adds checks to a lookup builder. The BaseBuilder needs to be an IndexedLookupTraceBuilder.
+template <typename BaseBuilder> class AddChecksToBuilder : public BaseBuilder {
+    static_assert(std::is_base_of<IndexedLookupTraceBuilder<typename BaseBuilder::LookupSettings>, BaseBuilder>::value,
+                  "BaseBuilder must be an IndexedLookupTraceBuilder");
+
+  public:
+    ~AddChecksToBuilder() override = default;
+
+    void init(TraceContainer& trace) override
+    {
+        BaseBuilder::init(trace);
+        this->trace = &trace;
+    }
+
+    uint32_t find_in_dst(
+        const std::array<FF, BaseBuilder::LookupSettings::LOOKUP_TUPLE_SIZE>& src_values) const override
+    {
+        uint32_t dst_row = BaseBuilder::find_in_dst(src_values);
+
+        auto dst_values = trace->get_multiple(BaseBuilder::LookupSettings::DST_COLUMNS, dst_row);
+        if (src_values != dst_values) {
+            throw std::runtime_error("Failed computing counts for " + std::string(BaseBuilder::LookupSettings::NAME) +
+                                     ". Could not find tuple in destination. " + "SRC tuple: " +
+                                     column_values_to_string(src_values, BaseBuilder::LookupSettings::SRC_COLUMNS));
+        }
+
+        return dst_row;
+    }
+
+  private:
+    TraceContainer* trace = nullptr;
+};
+
+// Builds a permutation and performs additional checks.
+// Only use in tests and debugging. This is slow and memory intensive.
+template <typename PermutationSettings>
+class CheckingPermutationBuilder : public PermutationBuilder<PermutationSettings> {
+  public:
+    using ArrayTuple = std::array<FF, PermutationSettings::COLUMNS_PER_SET>;
+
+    void process(TraceContainer& trace) override
+    {
+        PermutationBuilder<PermutationSettings>::process(trace);
+
+        // Collect the source and destination tuples.
+        source_tuples.clear();
+        trace.visit_column(PermutationSettings::SRC_SELECTOR, [&](uint32_t row, const FF&) {
+            auto src_values = trace.get_multiple(PermutationSettings::SRC_COLUMNS, row);
+            source_tuples[src_values].insert(row);
+        });
+        destination_tuples.clear();
+        trace.visit_column(PermutationSettings::DST_SELECTOR, [&](uint32_t row, const FF&) {
+            auto dst_values = trace.get_multiple(PermutationSettings::DST_COLUMNS, row);
+            destination_tuples[dst_values].insert(row);
+        });
+
+        auto build_error_message =
+            [&](const ArrayTuple& tuple, const auto& columns, const auto& src_rows, const auto& dst_rows) {
+                std::string error = "Failure to build permutation " + std::string(PermutationSettings::NAME) + ".\n";
+                error += format("Tuple ",
+                                column_values_to_string(tuple, columns),
+                                " has multiplicity ",
+                                src_rows.size(),
+                                " in the source, but ",
+                                dst_rows.size(),
+                                " in the destination.\n");
+                error += format("Source rows: ");
+                for (auto row : src_rows) {
+                    error += format(row, " ");
+                }
+                error += format("\n");
+                error += format("Destination rows: ");
+                for (auto row : dst_rows) {
+                    error += format(row, " ");
+                }
+                return error;
+            };
+
+        // Check that every source tuple is found in the destination with the same multiplicity.
+        for (const auto& [src_tuple, src_rows] : source_tuples) {
+            auto dst_rows = destination_tuples.contains(src_tuple) ? destination_tuples.at(src_tuple)
+                                                                   : std::unordered_set<uint32_t>();
+            if (src_rows.size() != dst_rows.size()) {
+                throw std::runtime_error(
+                    build_error_message(src_tuple, PermutationSettings::SRC_COLUMNS, src_rows, dst_rows));
+            }
+        }
+        // Check that every destination tuple is found in the source with the same multiplicity.
+        for (const auto& [dst_tuple, dst_rows] : destination_tuples) {
+            auto src_rows =
+                source_tuples.contains(dst_tuple) ? source_tuples.at(dst_tuple) : std::unordered_set<uint32_t>();
+            if (src_rows.size() != dst_rows.size()) {
+                throw std::runtime_error(
+                    build_error_message(dst_tuple, PermutationSettings::DST_COLUMNS, src_rows, dst_rows));
+            }
+        }
+    }
+
+  private:
+    unordered_flat_map<ArrayTuple, std::unordered_set<uint32_t>> source_tuples;
+    unordered_flat_map<ArrayTuple, std::unordered_set<uint32_t>> destination_tuples;
+};
+
+} // namespace bb::avm2::tracegen


### PR DESCRIPTION
Lookups will now always throw on tests.

Truly closes the remaining parts of #13140.