### PR TITLE
chore: import blockchain node engine

### DIFF
--- a/spartan/terraform/blockchain-node-engine/main.tf
+++ b/spartan/terraform/blockchain-node-engine/main.tf
@@ -1,0 +1,36 @@
+terraform {
+  backend "gcs" {
+    bucket = "aztec-terraform"
+    prefix = "terraform/state/blockchain-node-engine"
+  }
+  required_providers {
+    google = {
+      source  = "hashicorp/google"
+      version = "~> 5.0"
+    }
+  }
+}
+
+provider "google" {
+  project = var.project
+  region  = var.region
+}
+
+import {
+  id = "projects/${var.project}/locations/${var.import_blockchain_node_region}/blockchainNodes/${var.import_blockchain_node_id}"
+  to = google_blockchain_node_engine_blockchain_nodes.default
+}
+
+resource "google_blockchain_node_engine_blockchain_nodes" "default" {
+  location           = var.import_blockchain_node_region
+  blockchain_node_id = var.import_blockchain_node_id
+  blockchain_type    = "ETHEREUM"
+  ethereum_details {
+    api_enable_admin = false
+    api_enable_debug = false
+    consensus_client = "LIGHTHOUSE"
+    execution_client = "GETH"
+    network          = "TESTNET_SEPOLIA"
+    node_type        = "FULL"
+  }
+}

--- a/spartan/terraform/blockchain-node-engine/outputs.tf
+++ b/spartan/terraform/blockchain-node-engine/outputs.tf
@@ -1,0 +1,9 @@
+output "sepolia_node_rpc_api_url" {
+  description = "A URL to access the JSON-RPC API of an L1 node"
+  value       = google_blockchain_node_engine_blockchain_nodes.default.connection_info.0.endpoint_info.0.json_rpc_api_endpoint
+}
+
+output "sepolia_node_beacon_api_url" {
+  description = "A URL to access the consensus API of an L1 node"
+  value       = google_blockchain_node_engine_blockchain_nodes.default.ethereum_details.0.additional_endpoints.0.beacon_api_endpoint
+}

--- a/spartan/terraform/blockchain-node-engine/variables.tf
+++ b/spartan/terraform/blockchain-node-engine/variables.tf
@@ -1,0 +1,15 @@
+variable "project" {
+  default = "testnet-440309"
+}
+
+variable "region" {
+  default = "us-west1"
+}
+
+variable "import_blockchain_node_region" {
+  default = "us-central1"
+}
+
+variable "import_blockchain_node_id" {
+  default = "eth-sepolia-node-3"
+}


### PR DESCRIPTION
This PR imports the blockchain node engine into TF state so that its outputs may be used in other parts of the stack