### PR TITLE
chore(ci): avoid locally-poisoned cache

### DIFF
--- a/ci3/cache_upload
+++ b/ci3/cache_upload
@@ -17,7 +17,7 @@ name="$1"
 # Now $@ = our binary path args
 shift 1
 
-if [[ -z "${S3_FORCE_UPLOAD:-}" && "${CI:0}" -eq 0 ]]; then
+if [[ -z "${S3_FORCE_UPLOAD:-}" && "${CI:-0}" -eq 0 ]]; then
   echo_stderr "Skipping upload because CI=0 and S3_FORCE_UPLOAD not set."
   exit 0
 fi

--- a/ci3/cache_upload
+++ b/ci3/cache_upload
@@ -17,12 +17,17 @@ name="$1"
 # Now $@ = our binary path args
 shift 1
 
+if [[ -z "${S3_FORCE_UPLOAD:-}" && "${CI:0}" -eq 1 ]]; then
+  echo_stderr "Skipping upload because CI=0 and S3_FORCE_UPLOAD not set."
+  exit 0
+fi
+
 if [[ -z "${AWS_ACCESS_KEY_ID:-}" || -z "${AWS_SECRET_ACCESS_KEY:-}" ]] && ! aws configure get aws_access_key_id &>/dev/null; then
   echo_stderr "Skipping upload, no AWS credentials found."
   exit 0
 fi
 
-if [ -z ${S3_FORCE_UPLOAD:-} ] && \
+if [ -z "${S3_FORCE_UPLOAD:-}" ] && \
   aws ${S3_BUILD_CACHE_AWS_PARAMS:-} s3 ls "s3://aztec-ci-artifacts/build-cache/$name" &>/dev/null; then
     echo_stderr "Skipping upload, already exists: $name"
     exit 0

--- a/ci3/cache_upload
+++ b/ci3/cache_upload
@@ -17,7 +17,7 @@ name="$1"
 # Now $@ = our binary path args
 shift 1
 
-if [[ -z "${S3_FORCE_UPLOAD:-}" && "${CI:0}" -eq 1 ]]; then
+if [[ -z "${S3_FORCE_UPLOAD:-}" && "${CI:0}" -eq 0 ]]; then
   echo_stderr "Skipping upload because CI=0 and S3_FORCE_UPLOAD not set."
   exit 0
 fi


### PR DESCRIPTION
This has bit us a few times lately. If you want it, you can do S3_FORCE_UPLOAD but it should be after a `./bootstrap.sh clean ; ./bootstrap.sh`