### PR TITLE
chore: extract proper error messages from multicall3

### DIFF
--- a/yarn-project/aztec.js/src/test/rollup_cheat_codes.ts
+++ b/yarn-project/aztec.js/src/test/rollup_cheat_codes.ts
@@ -200,6 +200,18 @@ export class RollupCheatCodes {
     await this.ethCheatCodes.stopImpersonating(owner);
   }
 
+  /**
+   * Sets up the epoch.
+   */
+  public async setupEpoch() {
+    // Doesn't need to be done as owner, but the functionality is here...
+    await this.asOwner(async (account, rollup) => {
+      const hash = await rollup.write.setupEpoch({ account });
+      await this.client.waitForTransactionReceipt({ hash });
+      this.logger.warn(`Setup epoch`);
+    });
+  }
+
   /** Directly calls the L1 gas fee oracle. */
   public async updateL1GasFeeOracle() {
     await this.asOwner(async (account, rollup) => {

--- a/yarn-project/end-to-end/src/e2e_p2p/p2p_network.ts
+++ b/yarn-project/end-to-end/src/e2e_p2p/p2p_network.ts
@@ -254,7 +254,7 @@ export class P2PNetworkTest {
           ]),
         });
 
-        const timestamp = await cheatCodes.rollup.advanceToEpoch(2n);
+        const timestamp = await cheatCodes.rollup.advanceToEpoch(2n, { updateDateProvider: dateProvider });
 
         // Send and await a tx to make sure we mine a block for the warp to correctly progress.
         await this._sendDummyTx(deployL1ContractsValues.l1Client);

--- a/yarn-project/end-to-end/src/e2e_simple.test.ts
+++ b/yarn-project/end-to-end/src/e2e_simple.test.ts
@@ -39,7 +39,6 @@ describe('e2e_simple', () => {
         aztecEpochDuration: 4,
         aztecSlotDuration: 12,
         aztecTargetCommitteeSize: 0,
-        ethereumSlotDuration: 4,
         startProverNode: true,
       }));
     });

--- a/yarn-project/end-to-end/src/fixtures/utils.ts
+++ b/yarn-project/end-to-end/src/fixtures/utils.ts
@@ -604,6 +604,8 @@ export async function setup(
       // We need to advance to epoch 2 such that the committee is set up.
       logger.info(`Advancing to epoch 2`);
       await cheatCodes.rollup.advanceToEpoch(2n, { updateDateProvider: dateProvider });
+      await cheatCodes.rollup.setupEpoch();
+      await cheatCodes.rollup.debugRollup();
     }
 
     const accountManagers = await deployFundedSchnorrAccounts(pxe, initialFundedAccounts.slice(0, numberOfAccounts));

--- a/yarn-project/ethereum/src/contracts/multicall.test.ts
+++ b/yarn-project/ethereum/src/contracts/multicall.test.ts
@@ -1,0 +1,117 @@
+import { EthAddress } from '@aztec/foundation/eth-address';
+import { Fr } from '@aztec/foundation/fields';
+import { type Logger, createLogger } from '@aztec/foundation/log';
+import { GovernanceProposerAbi } from '@aztec/l1-artifacts/GovernanceProposerAbi';
+import { TestERC20Abi } from '@aztec/l1-artifacts/TestERC20Abi';
+import { TestERC20Bytecode } from '@aztec/l1-artifacts/TestERC20Bytecode';
+
+import type { Anvil } from '@viem/anvil';
+import { type GetContractReturnType, type PrivateKeyAccount, encodeFunctionData, getContract } from 'viem';
+import { privateKeyToAccount } from 'viem/accounts';
+import { foundry } from 'viem/chains';
+
+import { createExtendedL1Client } from '../client.js';
+import { DefaultL1ContractsConfig } from '../config.js';
+import { type DeployL1ContractsReturnType, deployL1Contract, deployL1Contracts } from '../deploy_l1_contracts.js';
+import { L1TxUtils } from '../l1_tx_utils.js';
+import { startAnvil } from '../test/start_anvil.js';
+import type { ExtendedViemWalletClient } from '../types.js';
+import { FormattedViemError } from '../utils.js';
+import { MULTI_CALL_3_ADDRESS, Multicall3, deployMulticall3 } from './multicall.js';
+
+describe('Multicall3', () => {
+  let anvil: Anvil;
+  let rpcUrl: string;
+  let privateKey: PrivateKeyAccount;
+  let logger: Logger;
+  let walletClient: ExtendedViemWalletClient;
+  let deployed: DeployL1ContractsReturnType;
+  let tokenContract: GetContractReturnType<typeof TestERC20Abi, ExtendedViemWalletClient>;
+  let tokenAddress: `0x${string}`;
+  let l1TxUtils: L1TxUtils;
+
+  beforeAll(async () => {
+    logger = createLogger('ethereum:test:multicall');
+    // this is the 6th address that gets funded by the junk mnemonic
+    privateKey = privateKeyToAccount('0x8b3a350cf5c34c9194ca85829a2df0ec3153be0318b5e2d3348e872092edffba');
+    const vkTreeRoot = Fr.random();
+    const protocolContractTreeRoot = Fr.random();
+
+    ({ anvil, rpcUrl } = await startAnvil());
+
+    walletClient = createExtendedL1Client([rpcUrl], privateKey, foundry);
+
+    deployed = await deployL1Contracts([rpcUrl], privateKey, foundry, logger, {
+      ...DefaultL1ContractsConfig,
+      salt: undefined,
+      vkTreeRoot,
+      protocolContractTreeRoot,
+      genesisArchiveRoot: Fr.random(),
+      realVerifier: false,
+    });
+
+    const { address: erc20Address, txHash: erc20TxHash } = await deployL1Contract(
+      walletClient,
+      TestERC20Abi,
+      TestERC20Bytecode,
+      ['test', 'TST', privateKey.address],
+      '0x42',
+      undefined,
+      logger,
+    );
+    expect(erc20TxHash).toBeDefined();
+    await walletClient.waitForTransactionReceipt({ hash: erc20TxHash! });
+    tokenAddress = erc20Address.toString();
+    tokenContract = getContract({
+      address: erc20Address.toString(),
+      abi: TestERC20Abi,
+      client: walletClient,
+    });
+
+    l1TxUtils = new L1TxUtils(walletClient, logger);
+
+    const addMinterHash = await tokenContract.write.addMinter([MULTI_CALL_3_ADDRESS], { account: privateKey });
+    await walletClient.waitForTransactionReceipt({ hash: addMinterHash });
+  });
+
+  afterAll(async () => {
+    await anvil.stop().catch(err => createLogger('cleanup').error(err));
+  });
+
+  it('should be able to call multiple functions in a single transaction', async () => {
+    await deployMulticall3(walletClient, logger);
+    const result = await Multicall3.forward(
+      [
+        {
+          to: tokenAddress,
+          data: encodeFunctionData({
+            abi: TestERC20Abi,
+            functionName: 'mint',
+            args: [privateKey.address, 100n],
+          }),
+          abi: TestERC20Abi,
+        },
+
+        // This one fails
+        {
+          to: deployed.l1ContractAddresses.governanceProposerAddress.toString(),
+          data: encodeFunctionData({
+            abi: GovernanceProposerAbi,
+            functionName: 'vote',
+            args: [EthAddress.random().toString()],
+          }),
+          abi: GovernanceProposerAbi,
+        },
+      ],
+      l1TxUtils,
+      undefined,
+      undefined,
+      deployed.l1ContractAddresses.rollupAddress.toString(),
+      logger,
+    );
+    expect(result).toBeDefined();
+    expect(result).toBeInstanceOf(FormattedViemError);
+    const formattedError = result as FormattedViemError;
+    expect(formattedError.message).toContain('ValidatorSelection__InsufficientCommitteeSize');
+  });
+});

--- a/yarn-project/ethereum/src/contracts/multicall.ts
+++ b/yarn-project/ethereum/src/contracts/multicall.ts
@@ -5,6 +5,7 @@ import { type EncodeFunctionDataParameters, type Hex, encodeFunctionData, multic
 
 import type { L1BlobInputs, L1GasConfig, L1TxRequest, L1TxUtils } from '../l1_tx_utils.js';
 import type { ExtendedViemWalletClient } from '../types.js';
+import { FormattedViemError, formatViemError } from '../utils.js';
 import { RollupContract } from './rollup.js';
 
 export const MULTI_CALL_3_ADDRESS = '0xcA11bde05977b3631167028862bE2a173976CA11' as const;
@@ -32,61 +33,87 @@ export class Multicall3 {
 
     const encodedForwarderData = encodeFunctionData(forwarderFunctionData);
 
-    const { receipt, gasPrice } = await l1TxUtils.sendAndMonitorTransaction(
-      {
-        to: MULTI_CALL_3_ADDRESS,
-        data: encodedForwarderData,
-      },
-      gasConfig,
-      blobConfig,
-    );
+    try {
+      const { receipt, gasPrice } = await l1TxUtils.sendAndMonitorTransaction(
+        {
+          to: MULTI_CALL_3_ADDRESS,
+          data: encodedForwarderData,
+        },
+        gasConfig,
+        blobConfig,
+      );
 
-    if (receipt.status === 'success') {
-      const stats = await l1TxUtils.getTransactionStats(receipt.transactionHash);
-      return { receipt, gasPrice, stats };
-    } else {
-      logger.error('Forwarder transaction failed', undefined, { receipt });
-
-      const args = {
-        ...forwarderFunctionData,
-        address: MULTI_CALL_3_ADDRESS,
-      };
-
-      let errorMsg: string | undefined;
-
-      if (blobConfig) {
-        const maxFeePerBlobGas = blobConfig.maxFeePerBlobGas ?? gasPrice.maxFeePerBlobGas;
-        if (maxFeePerBlobGas === undefined) {
-          errorMsg = 'maxFeePerBlobGas is required to get the error message';
-        } else {
-          logger.debug('Trying to get error from reverted tx with blob config');
-          errorMsg = await l1TxUtils.tryGetErrorFromRevertedTx(
-            encodedForwarderData,
-            args,
-            {
-              blobs: blobConfig.blobs,
-              kzg: blobConfig.kzg,
-              maxFeePerBlobGas,
-            },
-            [
-              {
-                address: rollupAddress,
-                stateDiff: [
-                  {
-                    slot: toPaddedHex(RollupContract.checkBlobStorageSlot, true),
-                    value: toPaddedHex(0n, true),
-                  },
-                ],
-              },
-            ],
-          );
-        }
+      if (receipt.status === 'success') {
+        const stats = await l1TxUtils.getTransactionStats(receipt.transactionHash);
+        return { receipt, gasPrice, stats };
       } else {
-        logger.debug('Trying to get error from reverted tx without blob config');
-        errorMsg = await l1TxUtils.tryGetErrorFromRevertedTx(encodedForwarderData, args, undefined, []);
-      }
+        logger.error('Forwarder transaction failed', undefined, { receipt });
 
-      return { receipt, gasPrice, errorMsg };
+        const args = {
+          ...forwarderFunctionData,
+          address: MULTI_CALL_3_ADDRESS,
+        };
+
+        let errorMsg: string | undefined;
+
+        if (blobConfig) {
+          const maxFeePerBlobGas = blobConfig.maxFeePerBlobGas ?? gasPrice.maxFeePerBlobGas;
+          if (maxFeePerBlobGas === undefined) {
+            errorMsg = 'maxFeePerBlobGas is required to get the error message';
+          } else {
+            logger.debug('Trying to get error from reverted tx with blob config');
+            errorMsg = await l1TxUtils.tryGetErrorFromRevertedTx(
+              encodedForwarderData,
+              args,
+              {
+                blobs: blobConfig.blobs,
+                kzg: blobConfig.kzg,
+                maxFeePerBlobGas,
+              },
+              [
+                {
+                  address: rollupAddress,
+                  stateDiff: [
+                    {
+                      slot: toPaddedHex(RollupContract.checkBlobStorageSlot, true),
+                      value: toPaddedHex(0n, true),
+                    },
+                  ],
+                },
+              ],
+            );
+          }
+        } else {
+          logger.debug('Trying to get error from reverted tx without blob config');
+          errorMsg = await l1TxUtils.tryGetErrorFromRevertedTx(encodedForwarderData, args, undefined, []);
+        }
+
+        return { receipt, gasPrice, errorMsg };
+      }
+    } catch (err) {
+      for (const request of requests) {
+        logger.debug('Simulating request', { request });
+        const result = await l1TxUtils
+          .simulate(request, undefined, [
+            {
+              address: rollupAddress,
+              stateDiff: [
+                { slot: toPaddedHex(RollupContract.checkBlobStorageSlot, true), value: toPaddedHex(0n, true) },
+              ],
+            },
+          ])
+          .catch(err => formatViemError(err, request.abi));
+        if (result instanceof FormattedViemError) {
+          logger.error('Found error in simulation', result, {
+            to: request.to ?? 'null',
+            data: request.data,
+          });
+
+          return result;
+        }
+      }
+      logger.warn('Failed to get error from reverted tx', { err });
+      throw err;
     }
   }
 }

--- a/yarn-project/sequencer-client/src/publisher/sequencer-publisher.test.ts
+++ b/yarn-project/sequencer-client/src/publisher/sequencer-publisher.test.ts
@@ -3,6 +3,7 @@ import { HttpBlobSinkClient } from '@aztec/blob-sink/client';
 import { inboundTransform } from '@aztec/blob-sink/encoding';
 import type { EpochCache } from '@aztec/epoch-cache';
 import {
+  FormattedViemError,
   type GasPrice,
   type GovernanceProposerContract,
   type L1ContractsConfig,
@@ -303,7 +304,12 @@ describe('SequencerPublisher', () => {
     expect(enqueued).toEqual(true);
     const result = await publisher.sendRequests();
 
-    expect(result?.result?.errorMsg).toEqual('Test error');
+    expect(result).not.toBeInstanceOf(FormattedViemError);
+    if (result instanceof FormattedViemError) {
+      fail('Not Expected result to be a FormattedViemError');
+    } else {
+      expect((result as any).result.errorMsg).toEqual('Test error');
+    }
   });
 
   it('does not send requests if interrupted', async () => {


### PR DESCRIPTION
Try to get better error messages when multicall3 calls fail by simulating the individual calls.

Also try to fix some flake in tests by explicitly setting up the epoch after we fast forward.