### PR TITLE
chore: Separate out ROM/RAM logic from `ultra_circuit_builder`

### DIFF
--- a/barretenberg/cpp/src/barretenberg/boomerang_value_detection/graph.cpp
+++ b/barretenberg/cpp/src/barretenberg/boomerang_value_detection/graph.cpp
@@ -427,7 +427,7 @@ inline std::vector<uint32_t> StaticAnalyzer_<FF>::get_auxiliary_gate_connected_c
  */
 template <typename FF>
 inline std::vector<uint32_t> StaticAnalyzer_<FF>::get_rom_table_connected_component(
-    bb::UltraCircuitBuilder& ultra_builder, const UltraCircuitBuilder::RomTranscript& rom_array)
+    bb::UltraCircuitBuilder& ultra_builder, const bb::RomTranscript& rom_array)
 {
     size_t block_index = find_block_index(ultra_builder, ultra_builder.blocks.aux);
     ASSERT(block_index == 5);
@@ -488,7 +488,7 @@ inline std::vector<uint32_t> StaticAnalyzer_<FF>::get_rom_table_connected_compon
  */
 template <typename FF>
 inline std::vector<uint32_t> StaticAnalyzer_<FF>::get_ram_table_connected_component(
-    bb::UltraCircuitBuilder& ultra_builder, const UltraCircuitBuilder::RamTranscript& ram_array)
+    bb::UltraCircuitBuilder& ultra_builder, const bb::RamTranscript& ram_array)
 {
     size_t block_index = find_block_index(ultra_builder, ultra_builder.blocks.aux);
     ASSERT(block_index == 5);
@@ -619,7 +619,7 @@ StaticAnalyzer_<FF>::StaticAnalyzer_(bb::UltraCircuitBuilder& ultra_circuit_cons
         }
     }
 
-    const auto& rom_arrays = ultra_circuit_constructor.rom_arrays;
+    const auto& rom_arrays = ultra_circuit_constructor.rom_ram_logic.rom_arrays;
     if (!rom_arrays.empty()) {
         for (const auto& rom_array : rom_arrays) {
             std::vector<uint32_t> variable_indices =
@@ -630,7 +630,7 @@ StaticAnalyzer_<FF>::StaticAnalyzer_(bb::UltraCircuitBuilder& ultra_circuit_cons
         }
     }
 
-    const auto& ram_arrays = ultra_circuit_constructor.ram_arrays;
+    const auto& ram_arrays = ultra_circuit_constructor.rom_ram_logic.ram_arrays;
     if (!ram_arrays.empty()) {
         for (const auto& ram_array : ram_arrays) {
             std::vector<uint32_t> variable_indices =

--- a/barretenberg/cpp/src/barretenberg/boomerang_value_detection/graph.hpp
+++ b/barretenberg/cpp/src/barretenberg/boomerang_value_detection/graph.hpp
@@ -114,9 +114,9 @@ template <typename FF> class StaticAnalyzer_ {
                                                                  size_t block_idx,
                                                                  UltraBlock& blk);
     std::vector<uint32_t> get_rom_table_connected_component(bb::UltraCircuitBuilder& ultra_circuit_builder,
-                                                            const bb::UltraCircuitBuilder::RomTranscript& rom_array);
+                                                            const bb::RomTranscript& rom_array);
     std::vector<uint32_t> get_ram_table_connected_component(bb::UltraCircuitBuilder& ultra_builder,
-                                                            const bb::UltraCircuitBuilder::RamTranscript& ram_array);
+                                                            const bb::RamTranscript& ram_array);
 
     void add_new_edge(const uint32_t& first_variable_index, const uint32_t& second_variable_index);
     std::vector<uint32_t> get_variable_adjacency_list(const uint32_t& variable_index)

--- a/barretenberg/cpp/src/barretenberg/circuit_checker/ultra_circuit_checker.cpp
+++ b/barretenberg/cpp/src/barretenberg/circuit_checker/ultra_circuit_checker.cpp
@@ -432,8 +432,8 @@ template <typename Builder> bool UltraCircuitChecker::relaxed_check_delta_range_
  */
 template <typename Builder> bool UltraCircuitChecker::relaxed_check_aux_relation(Builder& builder)
 {
-    for (size_t i = 0; i < builder.rom_arrays.size(); i++) {
-        auto rom_array = builder.rom_arrays[i];
+    for (size_t i = 0; i < builder.rom_ram_logic.rom_arrays.size(); i++) {
+        auto rom_array = builder.rom_ram_logic.rom_arrays[i];
 
         // check set and read ROM records
         for (auto& rr : rom_array.records) {
@@ -455,8 +455,8 @@ template <typename Builder> bool UltraCircuitChecker::relaxed_check_aux_relation
         }
     }
 
-    for (size_t i = 0; i < builder.ram_arrays.size(); i++) {
-        auto ram_array = builder.ram_arrays[i];
+    for (size_t i = 0; i < builder.rom_ram_logic.ram_arrays.size(); i++) {
+        auto ram_array = builder.rom_ram_logic.ram_arrays[i];
 
         std::vector<uint32_t> tmp_state(ram_array.state.size());
 
@@ -469,13 +469,13 @@ template <typename Builder> bool UltraCircuitChecker::relaxed_check_aux_relation
             uint32_t table_witness = tmp_state[index];
 
             switch (access_type) {
-            case Builder::RamRecord::AccessType::READ:
+            case bb::RamRecord::AccessType::READ:
                 if (builder.get_variable(value_witness) != builder.get_variable(table_witness)) {
                     info("Failed RAM read in table = ", i, " at idx = ", index);
                     return false;
                 }
                 break;
-            case Builder::RamRecord::AccessType::WRITE:
+            case bb::RamRecord::AccessType::WRITE:
                 tmp_state[index] = value_witness;
                 break;
             default:

--- a/barretenberg/cpp/src/barretenberg/stdlib_circuit_builders/rom_ram_logic.cpp
+++ b/barretenberg/cpp/src/barretenberg/stdlib_circuit_builders/rom_ram_logic.cpp
@@ -1,0 +1,566 @@
+#include "rom_ram_logic.hpp"
+#include "ultra_circuit_builder.hpp"
+#include <execution>
+
+namespace bb {
+
+template <typename ExecutionTrace> size_t RomRamLogic_<ExecutionTrace>::create_ROM_array(const size_t array_size)
+{
+    RomTranscript new_transcript;
+    for (size_t i = 0; i < array_size; ++i) {
+        new_transcript.state.emplace_back(
+            std::array<uint32_t, 2>{ UNINITIALIZED_MEMORY_RECORD, UNINITIALIZED_MEMORY_RECORD });
+    }
+    rom_arrays.emplace_back(new_transcript);
+    return rom_arrays.size() - 1;
+}
+/**
+ * Initialize a ROM cell to equal `value_witness`
+ * `index_value` is a RAW VALUE that describes the cell index. It is NOT a witness
+ * When intializing ROM arrays, it is important that the index of the cell is known when compiling the circuit.
+ * This ensures that, for a given circuit, we know with 100% certainty that EVERY rom cell is initialized
+ **/
+template <typename ExecutionTrace>
+void RomRamLogic_<ExecutionTrace>::set_ROM_element(CircuitBuilder* builder,
+                                                   const size_t rom_id,
+                                                   const size_t index_value,
+                                                   const uint32_t value_witness)
+{
+    ASSERT(rom_arrays.size() > rom_id);
+    RomTranscript& rom_array = rom_arrays[rom_id];
+    const uint32_t index_witness =
+        (index_value == 0) ? builder->zero_idx : builder->put_constant_variable((uint64_t)index_value);
+    ASSERT(rom_array.state.size() > index_value);
+    ASSERT(rom_array.state[index_value][0] == UNINITIALIZED_MEMORY_RECORD);
+
+    RomRecord new_record{
+        .index_witness = index_witness,
+        .value_column1_witness = value_witness,
+        .value_column2_witness = builder->zero_idx,
+        .index = static_cast<uint32_t>(index_value),
+        .record_witness = 0,
+        .gate_index = 0,
+    };
+    rom_array.state[index_value][0] = value_witness;
+    rom_array.state[index_value][1] = builder->zero_idx;
+    create_ROM_gate(builder, new_record);
+    rom_array.records.emplace_back(new_record);
+}
+
+template <typename ExecutionTrace>
+void RomRamLogic_<ExecutionTrace>::set_ROM_element_pair(CircuitBuilder* builder,
+                                                        const size_t rom_id,
+                                                        const size_t index_value,
+                                                        const std::array<uint32_t, 2>& value_witnesses)
+{
+    ASSERT(rom_arrays.size() > rom_id);
+    RomTranscript& rom_array = rom_arrays[rom_id];
+    const uint32_t index_witness =
+        (index_value == 0) ? builder->zero_idx : builder->put_constant_variable((uint64_t)index_value);
+    ASSERT(rom_array.state.size() > index_value);
+    ASSERT(rom_array.state[index_value][0] == UNINITIALIZED_MEMORY_RECORD);
+    RomRecord new_record{
+        .index_witness = index_witness,
+        .value_column1_witness = value_witnesses[0],
+        .value_column2_witness = value_witnesses[1],
+        .index = static_cast<uint32_t>(index_value),
+        .record_witness = 0,
+        .gate_index = 0,
+    };
+    rom_array.state[index_value][0] = value_witnesses[0];
+    rom_array.state[index_value][1] = value_witnesses[1];
+    create_ROM_gate(builder, new_record);
+    rom_array.records.emplace_back(new_record);
+}
+
+template <typename ExecutionTrace>
+uint32_t RomRamLogic_<ExecutionTrace>::read_ROM_array(CircuitBuilder* builder,
+                                                      const size_t rom_id,
+                                                      const uint32_t index_witness)
+{
+    ASSERT(rom_arrays.size() > rom_id);
+    RomTranscript& rom_array = rom_arrays[rom_id];
+    const uint32_t index = static_cast<uint32_t>(uint256_t(builder->get_variable(index_witness)));
+    ASSERT(rom_array.state.size() > index);
+    ASSERT(rom_array.state[index][0] != UNINITIALIZED_MEMORY_RECORD);
+    const auto value = builder->get_variable(rom_array.state[index][0]);
+    const uint32_t value_witness = builder->add_variable(value);
+    RomRecord new_record{
+        .index_witness = index_witness,
+        .value_column1_witness = value_witness,
+        .value_column2_witness = builder->zero_idx,
+        .index = index,
+        .record_witness = 0,
+        .gate_index = 0,
+    };
+    create_ROM_gate(builder, new_record);
+    rom_array.records.emplace_back(new_record);
+
+    // create_read_gate
+    return value_witness;
+}
+
+template <typename ExecutionTrace>
+std::array<uint32_t, 2> RomRamLogic_<ExecutionTrace>::read_ROM_array_pair(CircuitBuilder* builder,
+                                                                          const size_t rom_id,
+                                                                          const uint32_t index_witness)
+{
+    std::array<uint32_t, 2> value_witnesses;
+
+    const uint32_t index = static_cast<uint32_t>(uint256_t(builder->get_variable(index_witness)));
+    ASSERT(rom_arrays.size() > rom_id);
+    RomTranscript& rom_array = rom_arrays[rom_id];
+    ASSERT(rom_array.state.size() > index);
+    ASSERT(rom_array.state[index][0] != UNINITIALIZED_MEMORY_RECORD);
+    ASSERT(rom_array.state[index][1] != UNINITIALIZED_MEMORY_RECORD);
+    const auto value1 = builder->get_variable(rom_array.state[index][0]);
+    const auto value2 = builder->get_variable(rom_array.state[index][1]);
+    value_witnesses[0] = builder->add_variable(value1);
+    value_witnesses[1] = builder->add_variable(value2);
+    RomRecord new_record{
+        .index_witness = index_witness,
+        .value_column1_witness = value_witnesses[0],
+        .value_column2_witness = value_witnesses[1],
+        .index = index,
+        .record_witness = 0,
+        .gate_index = 0,
+    };
+    create_ROM_gate(builder, new_record);
+    rom_array.records.emplace_back(new_record);
+
+    // create_read_gate
+    return value_witnesses;
+}
+
+template <typename ExecutionTrace>
+void RomRamLogic_<ExecutionTrace>::create_ROM_gate(CircuitBuilder* builder, RomRecord& record)
+{
+    // Record wire value can't yet be computed
+    record.record_witness = builder->add_variable(0);
+    builder->apply_aux_selectors(CircuitBuilder::AUX_SELECTORS::ROM_READ);
+    builder->blocks.aux.populate_wires(
+        record.index_witness, record.value_column1_witness, record.value_column2_witness, record.record_witness);
+    // Note: record the index into the aux block that contains the RAM/ROM gates
+    record.gate_index = builder->blocks.aux.size() - 1;
+    builder->check_selector_length_consistency();
+    ++builder->num_gates;
+}
+
+template <typename ExecutionTrace>
+void RomRamLogic_<ExecutionTrace>::create_sorted_ROM_gate(CircuitBuilder* builder, RomRecord& record)
+{
+    record.record_witness = builder->add_variable(0);
+    // record_witness is intentionally used only in a single gate
+    builder->update_used_witnesses(record.record_witness);
+    builder->apply_aux_selectors(CircuitBuilder::AUX_SELECTORS::ROM_CONSISTENCY_CHECK);
+    builder->blocks.aux.populate_wires(
+        record.index_witness, record.value_column1_witness, record.value_column2_witness, record.record_witness);
+    // Note: record the index into the aux block that contains the RAM/ROM gates
+    record.gate_index = builder->blocks.aux.size() - 1;
+    builder->check_selector_length_consistency();
+    ++builder->num_gates;
+}
+
+template <typename ExecutionTrace>
+void RomRamLogic_<ExecutionTrace>::process_ROM_array(CircuitBuilder* builder, const size_t rom_id)
+{
+    auto& rom_array = rom_arrays[rom_id];
+    const auto read_tag = builder->get_new_tag();        // current_tag + 1;
+    const auto sorted_list_tag = builder->get_new_tag(); // current_tag + 2;
+    builder->create_tag(read_tag, sorted_list_tag);
+    builder->create_tag(sorted_list_tag, read_tag);
+
+    // Make sure that every cell has been initialized
+    for (size_t i = 0; i < rom_array.state.size(); ++i) {
+        if (rom_array.state[i][0] == UNINITIALIZED_MEMORY_RECORD) {
+            set_ROM_element_pair(builder, rom_id, static_cast<uint32_t>(i), { builder->zero_idx, builder->zero_idx });
+        }
+    }
+
+#ifdef NO_PAR_ALGOS
+    std::sort(rom_array.records.begin(), rom_array.records.end());
+#else
+    std::sort(std::execution::par_unseq, rom_array.records.begin(), rom_array.records.end());
+#endif
+
+    for (const RomRecord& record : rom_array.records) {
+        const auto index = record.index;
+        const auto value1 = builder->get_variable(record.value_column1_witness);
+        const auto value2 = builder->get_variable(record.value_column2_witness);
+        const auto index_witness = builder->add_variable(FF((uint64_t)index));
+        // the same thing as with the record witness
+        builder->update_used_witnesses(index_witness);
+        const auto value1_witness = builder->add_variable(value1);
+        const auto value2_witness = builder->add_variable(value2);
+        RomRecord sorted_record{
+            .index_witness = index_witness,
+            .value_column1_witness = value1_witness,
+            .value_column2_witness = value2_witness,
+            .index = index,
+            .record_witness = 0,
+            .gate_index = 0,
+        };
+        create_sorted_ROM_gate(builder, sorted_record);
+
+        builder->assign_tag(record.record_witness, read_tag);
+        builder->assign_tag(sorted_record.record_witness, sorted_list_tag);
+
+        // For ROM/RAM gates, the 'record' wire value (wire column 4) is a linear combination of the first 3 wire
+        // values. However...the record value uses the random challenge 'eta', generated after the first 3 wires are
+        // committed to. i.e. we can't compute the record witness here because we don't know what `eta` is! Take the
+        // gate indices of the two rom gates (original read gate + sorted gate) and store in `memory_records`. Once
+        // we
+        // generate the `eta` challenge, we'll use `memory_records` to figure out which gates need a record wire
+        // value
+        // to be computed.
+        // record (w4) = w3 * eta^3 + w2 * eta^2 + w1 * eta + read_write_flag (0 for reads, 1 for writes)
+        // Separate containers used to store gate indices of reads and writes. Need to differentiate because of
+        // `read_write_flag` (N.B. all ROM accesses are considered reads. Writes are for RAM operations)
+        builder->memory_read_records.push_back(static_cast<uint32_t>(sorted_record.gate_index));
+        builder->memory_read_records.push_back(static_cast<uint32_t>(record.gate_index));
+    }
+    // One of the checks we run on the sorted list, is to validate the difference between
+    // the index field across two gates is either 0 or 1.
+    // If we add a dummy gate at the end of the sorted list, where we force the first wire to
+    // equal `m + 1`, where `m` is the maximum allowed index in the sorted list,
+    // we have validated that all ROM reads are correctly constrained
+    FF max_index_value((uint64_t)rom_array.state.size());
+    uint32_t max_index = builder->add_variable(max_index_value);
+    // TODO(https://github.com/AztecProtocol/barretenberg/issues/879): This was formerly a single arithmetic gate. A
+    // dummy gate has been added to allow the previous gate to access the required wire data via shifts, allowing the
+    // arithmetic gate to occur out of sequence.
+    builder->create_dummy_gate(builder->blocks.aux, max_index, builder->zero_idx, builder->zero_idx, builder->zero_idx);
+    builder->create_big_add_gate(
+        {
+            max_index,
+            builder->zero_idx,
+            builder->zero_idx,
+            builder->zero_idx,
+            1,
+            0,
+            0,
+            0,
+            -max_index_value,
+        },
+        false);
+    // N.B. If the above check holds, we know the sorted list begins with an index value of 0,
+    // because the first cell is explicitly initialized using zero_idx as the index field.
+}
+
+template <typename ExecutionTrace> void RomRamLogic_<ExecutionTrace>::process_ROM_arrays(CircuitBuilder* builder)
+{
+    for (size_t i = 0; i < rom_arrays.size(); ++i) {
+        process_ROM_array(builder, i);
+    }
+}
+
+template <typename ExecutionTrace> size_t RomRamLogic_<ExecutionTrace>::create_RAM_array(const size_t array_size)
+{
+    RamTranscript new_transcript;
+    for (size_t i = 0; i < array_size; ++i) {
+        new_transcript.state.emplace_back(UNINITIALIZED_MEMORY_RECORD);
+    }
+    ram_arrays.emplace_back(new_transcript);
+    return ram_arrays.size() - 1;
+}
+
+template <typename ExecutionTrace>
+void RomRamLogic_<ExecutionTrace>::init_RAM_element(CircuitBuilder* builder,
+                                                    const size_t ram_id,
+                                                    const size_t index_value,
+                                                    const uint32_t value_witness)
+{
+    ASSERT(ram_arrays.size() > ram_id);
+    RamTranscript& ram_array = ram_arrays[ram_id];
+    const uint32_t index_witness =
+        (index_value == 0) ? builder->zero_idx : builder->put_constant_variable((uint64_t)index_value);
+    ASSERT(ram_array.state.size() > index_value);
+    ASSERT(ram_array.state[index_value] == UNINITIALIZED_MEMORY_RECORD);
+    RamRecord new_record{ .index_witness = index_witness,
+                          .timestamp_witness = builder->put_constant_variable((uint64_t)ram_array.access_count),
+                          .value_witness = value_witness,
+                          .index = static_cast<uint32_t>(index_value), // TODO: size_t?
+                          .timestamp = static_cast<uint32_t>(ram_array.access_count),
+                          .access_type = RamRecord::AccessType::WRITE,
+                          .record_witness = 0,
+                          .gate_index = 0 };
+    ram_array.state[index_value] = value_witness;
+    ram_array.access_count++;
+    create_RAM_gate(builder, new_record);
+    ram_array.records.emplace_back(new_record);
+}
+
+template <typename ExecutionTrace>
+uint32_t RomRamLogic_<ExecutionTrace>::read_RAM_array(CircuitBuilder* builder,
+                                                      const size_t ram_id,
+                                                      const uint32_t index_witness)
+{
+    ASSERT(ram_arrays.size() > ram_id);
+    RamTranscript& ram_array = ram_arrays[ram_id];
+    const uint32_t index = static_cast<uint32_t>(uint256_t(builder->get_variable(index_witness)));
+    ASSERT(ram_array.state.size() > index);
+    ASSERT(ram_array.state[index] != UNINITIALIZED_MEMORY_RECORD);
+    const auto value = builder->get_variable(ram_array.state[index]);
+    const uint32_t value_witness = builder->add_variable(value);
+
+    RamRecord new_record{ .index_witness = index_witness,
+                          .timestamp_witness = builder->put_constant_variable((uint64_t)ram_array.access_count),
+                          .value_witness = value_witness,
+                          .index = index,
+                          .timestamp = static_cast<uint32_t>(ram_array.access_count),
+                          .access_type = RamRecord::AccessType::READ,
+                          .record_witness = 0,
+                          .gate_index = 0 };
+    create_RAM_gate(builder, new_record);
+    ram_array.records.emplace_back(new_record);
+
+    // increment ram array's access count
+    ram_array.access_count++;
+
+    // return witness index of the value in the array
+    return value_witness;
+}
+
+template <typename ExecutionTrace>
+void RomRamLogic_<ExecutionTrace>::write_RAM_array(CircuitBuilder* builder,
+                                                   const size_t ram_id,
+                                                   const uint32_t index_witness,
+                                                   const uint32_t value_witness)
+{
+    ASSERT(ram_arrays.size() > ram_id);
+    RamTranscript& ram_array = ram_arrays[ram_id];
+    const uint32_t index = static_cast<uint32_t>(uint256_t(builder->get_variable(index_witness)));
+    ASSERT(ram_array.state.size() > index);
+    ASSERT(ram_array.state[index] != UNINITIALIZED_MEMORY_RECORD);
+
+    RamRecord new_record{ .index_witness = index_witness,
+                          .timestamp_witness = builder->put_constant_variable((uint64_t)ram_array.access_count),
+                          .value_witness = value_witness,
+                          .index = index,
+                          .timestamp = static_cast<uint32_t>(ram_array.access_count),
+                          .access_type = RamRecord::AccessType::WRITE,
+                          .record_witness = 0,
+                          .gate_index = 0 };
+    create_RAM_gate(builder, new_record);
+    ram_array.records.emplace_back(new_record);
+
+    // increment ram array's access count
+    ram_array.access_count++;
+
+    // update Composer's current state of RAM array
+    ram_array.state[index] = value_witness;
+}
+
+template <typename ExecutionTrace>
+void RomRamLogic_<ExecutionTrace>::create_RAM_gate(CircuitBuilder* builder, RamRecord& record)
+{
+    // Record wire value can't yet be computed (uses randomnes generated during proof construction).
+    // However it needs a distinct witness index,
+    // we will be applying copy constraints + set membership constraints.
+    // Later on during proof construction we will compute the record wire value + assign it
+    record.record_witness = builder->add_variable(0);
+    builder->apply_aux_selectors(record.access_type == RamRecord::AccessType::READ
+                                     ? CircuitBuilder::AUX_SELECTORS::RAM_READ
+                                     : CircuitBuilder::AUX_SELECTORS::RAM_WRITE);
+    builder->blocks.aux.populate_wires(
+        record.index_witness, record.timestamp_witness, record.value_witness, record.record_witness);
+
+    // Note: record the index into the block that contains the RAM/ROM gates
+    record.gate_index = builder->blocks.aux.size() - 1;
+    ++builder->num_gates;
+}
+
+template <typename ExecutionTrace>
+void RomRamLogic_<ExecutionTrace>::create_sorted_RAM_gate(CircuitBuilder* builder, RamRecord& record)
+{
+    record.record_witness = builder->add_variable(0);
+    builder->apply_aux_selectors(CircuitBuilder::AUX_SELECTORS::RAM_CONSISTENCY_CHECK);
+    builder->blocks.aux.populate_wires(
+        record.index_witness, record.timestamp_witness, record.value_witness, record.record_witness);
+    // Note: record the index into the aux block that contains the RAM/ROM gates
+    record.gate_index = builder->blocks.aux.size() - 1;
+    builder->check_selector_length_consistency();
+    ++builder->num_gates;
+}
+
+template <typename ExecutionTrace>
+void RomRamLogic_<ExecutionTrace>::create_final_sorted_RAM_gate(CircuitBuilder* builder,
+                                                                RamRecord& record,
+                                                                const size_t ram_array_size)
+{
+    record.record_witness = builder->add_variable(0);
+    // Note: record the index into the block that contains the RAM/ROM gates
+    record.gate_index = builder->blocks.aux.size(); // no -1 since we havent added the gate yet
+
+    // TODO(https://github.com/AztecProtocol/barretenberg/issues/879): This method used to add a single arithmetic gate
+    // with two purposes: (1) to provide wire values to the previous RAM gate via shifts, and (2) to perform a
+    // consistency check on the value in wire 1. These two purposes have been split into a dummy gate and a simplified
+    // arithmetic gate, respectively. This allows both purposes to be served even after arithmetic gates are sorted out
+    // of sequence with the RAM gates.
+
+    // Create a final gate with all selectors zero; wire values are accessed by the previous RAM gate via
+    // shifted wires
+    builder->create_dummy_gate(builder->blocks.aux,
+                               record.index_witness,
+                               record.timestamp_witness,
+                               record.value_witness,
+                               record.record_witness);
+
+    // Create an add gate ensuring the final index is consistent with the size of the RAM array
+    builder->create_big_add_gate({
+        record.index_witness,
+        builder->zero_idx,
+        builder->zero_idx,
+        builder->zero_idx,
+        1,
+        0,
+        0,
+        0,
+        -FF(static_cast<uint64_t>(ram_array_size) - 1),
+    });
+}
+
+template <typename ExecutionTrace>
+void RomRamLogic_<ExecutionTrace>::process_RAM_array(CircuitBuilder* builder, const size_t ram_id)
+{
+    RamTranscript& ram_array = ram_arrays[ram_id];
+    const auto access_tag = builder->get_new_tag();      // current_tag + 1;
+    const auto sorted_list_tag = builder->get_new_tag(); // current_tag + 2;
+    builder->create_tag(access_tag, sorted_list_tag);
+    builder->create_tag(sorted_list_tag, access_tag);
+
+    // Make sure that every cell has been initialized
+    // TODO: throw some kind of error here? Circuit should initialize all RAM elements to prevent errors.
+    // e.g. if a RAM record is uninitialized but the index of that record is a function of public/private inputs,
+    // different public iputs will produce different circuit constraints.
+    for (size_t i = 0; i < ram_array.state.size(); ++i) {
+        if (ram_array.state[i] == UNINITIALIZED_MEMORY_RECORD) {
+            init_RAM_element(builder, ram_id, static_cast<uint32_t>(i), builder->zero_idx);
+        }
+    }
+
+#ifdef NO_PAR_ALGOS
+    std::sort(ram_array.records.begin(), ram_array.records.end());
+#else
+    std::sort(std::execution::par_unseq, ram_array.records.begin(), ram_array.records.end());
+#endif
+
+    std::vector<RamRecord> sorted_ram_records;
+
+    // Iterate over all but final RAM record.
+    for (size_t i = 0; i < ram_array.records.size(); ++i) {
+        const RamRecord& record = ram_array.records[i];
+
+        const auto index = record.index;
+        const auto value = builder->get_variable(record.value_witness);
+        const auto index_witness = builder->add_variable(FF((uint64_t)index));
+        const auto timestamp_witess = builder->add_variable(record.timestamp);
+        const auto value_witness = builder->add_variable(value);
+        RamRecord sorted_record{
+            .index_witness = index_witness,
+            .timestamp_witness = timestamp_witess,
+            .value_witness = value_witness,
+            .index = index,
+            .timestamp = record.timestamp,
+            .access_type = record.access_type,
+            .record_witness = 0,
+            .gate_index = 0,
+        };
+
+        // create a list of sorted ram records
+        sorted_ram_records.emplace_back(sorted_record);
+
+        // We don't apply the RAM consistency check gate to the final record,
+        // as this gate expects a RAM record to be present at the next gate
+        if (i < ram_array.records.size() - 1) {
+            create_sorted_RAM_gate(builder, sorted_record);
+        } else {
+            // For the final record in the sorted list, we do not apply the full consistency check gate.
+            // Only need to check the index value = RAM array size - 1.
+            create_final_sorted_RAM_gate(builder, sorted_record, ram_array.state.size());
+        }
+
+        // Assign record/sorted records to tags that we will perform set equivalence checks on
+        builder->assign_tag(record.record_witness, access_tag);
+        builder->assign_tag(sorted_record.record_witness, sorted_list_tag);
+
+        // For ROM/RAM gates, the 'record' wire value (wire column 4) is a linear combination of the first 3 wire
+        // values. However...the record value uses the random challenge 'eta', generated after the first 3 wires are
+        // committed to. i.e. we can't compute the record witness here because we don't know what `eta` is! Take the
+        // gate indices of the two rom gates (original read gate + sorted gate) and store in `memory_records`. Once
+        // we
+        // generate the `eta` challenge, we'll use `memory_records` to figure out which gates need a record wire
+        // value
+        // to be computed.
+
+        switch (record.access_type) {
+        case RamRecord::AccessType::READ: {
+            builder->memory_read_records.push_back(static_cast<uint32_t>(sorted_record.gate_index));
+            builder->memory_read_records.push_back(static_cast<uint32_t>(record.gate_index));
+            break;
+        }
+        case RamRecord::AccessType::WRITE: {
+            builder->memory_write_records.push_back(static_cast<uint32_t>(sorted_record.gate_index));
+            builder->memory_write_records.push_back(static_cast<uint32_t>(record.gate_index));
+            break;
+        }
+        default: {
+            ASSERT(false); // shouldn't get here!
+        }
+        }
+    }
+
+    // Step 2: Create gates that validate correctness of RAM timestamps
+
+    std::vector<uint32_t> timestamp_deltas;
+    for (size_t i = 0; i < sorted_ram_records.size() - 1; ++i) {
+        // create_RAM_timestamp_gate(sorted_records[i], sorted_records[i + 1])
+        const auto& current = sorted_ram_records[i];
+        const auto& next = sorted_ram_records[i + 1];
+
+        const bool share_index = current.index == next.index;
+
+        FF timestamp_delta = 0;
+        if (share_index) {
+            ASSERT(next.timestamp > current.timestamp);
+            timestamp_delta = FF(next.timestamp - current.timestamp);
+        }
+
+        uint32_t timestamp_delta_witness = builder->add_variable(timestamp_delta);
+
+        builder->apply_aux_selectors(CircuitBuilder::AUX_SELECTORS::RAM_TIMESTAMP_CHECK);
+        builder->blocks.aux.populate_wires(
+            current.index_witness, current.timestamp_witness, timestamp_delta_witness, builder->zero_idx);
+
+        ++builder->num_gates;
+
+        // store timestamp offsets for later. Need to apply range checks to them, but calling
+        // `create_new_range_constraint` can add gates. Would ruin the structure of our sorted timestamp list.
+        timestamp_deltas.push_back(timestamp_delta_witness);
+    }
+
+    // add the index/timestamp values of the last sorted record in an empty add gate.
+    // (the previous gate will access the wires on this gate and requires them to be those of the last record)
+    const auto& last = sorted_ram_records[ram_array.records.size() - 1];
+    builder->create_dummy_gate(
+        builder->blocks.aux, last.index_witness, last.timestamp_witness, builder->zero_idx, builder->zero_idx);
+
+    // Step 3: validate difference in timestamps is monotonically increasing. i.e. is <= maximum timestamp
+    const size_t max_timestamp = ram_array.access_count - 1;
+    for (auto& w : timestamp_deltas) {
+        builder->create_new_range_constraint(w, max_timestamp);
+    }
+}
+
+template <typename ExecutionTrace> void RomRamLogic_<ExecutionTrace>::process_RAM_arrays(CircuitBuilder* builder)
+{
+    for (size_t i = 0; i < ram_arrays.size(); ++i) {
+        process_RAM_array(builder, i);
+    }
+}
+
+// Template instantiations
+template class RomRamLogic_<UltraExecutionTraceBlocks>;
+template class RomRamLogic_<MegaExecutionTraceBlocks>;
+
+} // namespace bb

--- a/barretenberg/cpp/src/barretenberg/stdlib_circuit_builders/rom_ram_logic.hpp
+++ b/barretenberg/cpp/src/barretenberg/stdlib_circuit_builders/rom_ram_logic.hpp
@@ -1,0 +1,284 @@
+#pragma once
+
+#include "barretenberg/common/assert.hpp"
+#include <array>
+#include <cstdint>
+#include <vector>
+
+namespace bb {
+// Forward declaration
+template <typename ExecutionTrace_> class UltraCircuitBuilder_;
+
+// Constants
+static constexpr uint32_t UNINITIALIZED_MEMORY_RECORD = UINT32_MAX;
+
+/**
+ * @brief A ROM memory record that can be ordered
+ */
+struct RomRecord {
+    uint32_t index_witness = 0;
+    uint32_t value_column1_witness = 0;
+    uint32_t value_column2_witness = 0;
+    uint32_t index = 0;
+    uint32_t record_witness = 0;
+    size_t gate_index = 0;
+    bool operator<(const RomRecord& other) const { return index < other.index; }
+    bool operator==(const RomRecord& other) const noexcept
+    {
+        return index_witness == other.index_witness && value_column1_witness == other.value_column1_witness &&
+               value_column2_witness == other.value_column2_witness && index == other.index &&
+               record_witness == other.record_witness && gate_index == other.gate_index;
+    }
+};
+
+/**
+ * @brief A RAM memory record that can be ordered.
+ */
+struct RamRecord {
+    enum AccessType {
+        READ,
+        WRITE,
+    };
+    uint32_t index_witness = 0;
+    uint32_t timestamp_witness = 0;
+    uint32_t value_witness = 0;
+    uint32_t index = 0;
+    uint32_t timestamp = 0;
+    AccessType access_type = AccessType::READ;
+    uint32_t record_witness = 0;
+    size_t gate_index = 0;
+    bool operator<(const RamRecord& other) const
+    {
+        bool index_test = (index) < (other.index);
+        return index_test || (index == other.index && timestamp < other.timestamp);
+    }
+    bool operator==(const RamRecord& other) const noexcept
+    {
+        return index_witness == other.index_witness && timestamp_witness == other.timestamp_witness &&
+               value_witness == other.value_witness && index == other.index && timestamp == other.timestamp &&
+               access_type == other.access_type && record_witness == other.record_witness &&
+               gate_index == other.gate_index;
+    }
+};
+
+/**
+ * @brief Each rom array is an instance of memory transcript. It saves values and indexes for a particular memory
+ * array
+ */
+struct RomTranscript {
+    // Contains the value of each index of the array
+    std::vector<std::array<uint32_t, 2>> state;
+    // A vector of records, each of which contains:
+    // + The constant witness with the index
+    // + The value in the memory slot
+    // + The actual index value
+    std::vector<RomRecord> records;
+    // Used to check that the state hasn't changed in tests
+    bool operator==(const RomTranscript& other) const noexcept
+    {
+        return (state == other.state && records == other.records);
+    }
+};
+
+/**
+ * @brief Each ram array is an instance of memory transcript. It saves values and indexes for a particular memory
+ * array
+ */
+struct RamTranscript {
+    // Contains the value of each index of the array
+    std::vector<uint32_t> state;
+    // A vector of records, each of which contains:
+    // + The constant witness with the index
+    // + The value in the memory slot
+    // + The actual index value
+    std::vector<RamRecord> records;
+    // used for RAM records, to compute the timestamp when performing a read/write
+    size_t access_count = 0;
+    // Used to check that the state hasn't changed in tests
+    bool operator==(const RamTranscript& other) const noexcept
+    {
+        return (state == other.state && records == other.records && access_count == other.access_count);
+    }
+};
+
+/**
+ * @brief ROM/RAM logic handler for UltraCircuitBuilder
+ */
+template <typename ExecutionTrace> class RomRamLogic_ {
+  public:
+    using FF = typename ExecutionTrace::FF;
+    using CircuitBuilder = UltraCircuitBuilder_<ExecutionTrace>;
+
+    // Storage
+    /**
+     * @brief Each entry in ram_arrays represents an independent RAM table.
+     * RamTranscript tracks the current table state,
+     * as well as the 'records' produced by each read and write operation.
+     * Used in `compute_proving_key` to generate consistency check gates required to validate the RAM read/write
+     * history
+     */
+    std::vector<RamTranscript> ram_arrays;
+    /**
+     * @brief Each entry in ram_arrays represents an independent ROM table.
+     * RomTranscript tracks the current table state,
+     * as well as the 'records' produced by each read operation.
+     * Used in `compute_proving_key` to generate consistency check gates required to validate the ROM read history
+     */
+    std::vector<RomTranscript> rom_arrays;
+
+    RomRamLogic_() = default;
+
+    // ROM operations
+    /**
+     * @brief Create a new read-only memory region
+     *
+     * @details Creates a transcript object, where the inside memory state array is filled with "uninitialized memory"
+     * and empty memory record array. Puts this object into the vector of ROM arrays.
+     *
+     * @param array_size The size of region in elements
+     * @return size_t The index of the element
+     */
+    size_t create_ROM_array(const size_t array_size);
+
+    /**
+     * @brief Initialize a rom cell to equal `value_witness`
+     *
+     * @param builder
+     * @param rom_id The index of the ROM array, which cell we are initializing
+     * @param index_value The index of the cell within the array (an actual index, not a witness index)
+     * @param value_witness The index of the witness with the value that should be in the
+     */
+    void set_ROM_element(CircuitBuilder* builder,
+                         const size_t rom_id,
+                         const size_t index_value,
+                         const uint32_t value_witness);
+    /**
+     * @brief Initialize a ROM array element with a pair of witness values
+     *
+     * @param builder
+     * @param rom_id  ROM array id
+     * @param index_value Index in the array
+     * @param value_witnesses The witnesses to put in the slot
+     */
+    void set_ROM_element_pair(CircuitBuilder* builder,
+                              const size_t rom_id,
+                              const size_t index_value,
+                              const std::array<uint32_t, 2>& value_witnesses);
+    /**
+     * @brief Read a single element from ROM
+     *
+     * @param builder
+     * @param rom_id The index of the array to read from
+     * @param index_witness The witness with the index inside the array
+     * @return uint32_t Cell value witness index
+     */
+    uint32_t read_ROM_array(CircuitBuilder* builder, const size_t rom_id, const uint32_t index_witness);
+    /**
+     * @brief  Read a pair of elements from ROM
+     *
+     * @param rom_id The id of the ROM array
+     * @param index_witness The witness containing the index in the array
+     * @return std::array<uint32_t, 2> A pair of indexes of witness variables of cell values
+     */
+    std::array<uint32_t, 2> read_ROM_array_pair(CircuitBuilder* builder,
+                                                const size_t rom_id,
+                                                const uint32_t index_witness);
+    /**
+     * @brief
+     * Gate that'reads' from a ROM table, i.e., the table index is a witness not precomputed
+     *
+     * @param builder
+     * @param record Stores details of this read operation. Mutated by this fn!
+     */
+    void create_ROM_gate(CircuitBuilder* builder, RomRecord& record);
+    /**
+     * @brief Gate that performs consistency checks to validate that a claimed ROM read value is correct
+     *
+     * @details sorted ROM gates are generated sequentially, each ROM record is sorted by index
+     *
+     * @param builder
+     * @param record Stores details of this read operation. Mutated by this fn!
+     */
+    void create_sorted_ROM_gate(CircuitBuilder* builder, RomRecord& record);
+    /**
+     * @brief Compute additional gates required to validate ROM reads. Called when generating the proving key
+     *
+     * @param builder
+     * @param rom_id The id of the ROM table
+     * @param gate_offset_from_public_inputs Required to track the gate position of where we're adding extra gates
+     */
+    void process_ROM_array(CircuitBuilder* builder, const size_t rom_id);
+    /**
+     * @brief Process all of the ROM arrays.
+     */
+    void process_ROM_arrays(CircuitBuilder* builder);
+
+    // RAM operations
+    /**
+     * @brief Create a new updatable memory region
+     *
+     * @details Creates a transcript object, where the inside memory state array is filled with "uninitialized memory"
+     * and empty memory record array. Puts this object into the vector of ROM arrays.
+     *
+     * @param array_size The size of region in elements
+     * @return size_t The index of the element
+     */
+    size_t create_RAM_array(const size_t array_size);
+    /**
+     * @brief Initialize a RAM cell to equal `value_witness`
+     *
+     * @param builder
+     * @param ram_id The index of the RAM array, which cell we are initializing
+     * @param index_value The index of the cell within the array (an actual index, not a witness index)
+     * @param value_witness The index of the witness with the value that should be in the
+     */
+    void init_RAM_element(CircuitBuilder* builder,
+                          const size_t ram_id,
+                          const size_t index_value,
+                          const uint32_t value_witness);
+    uint32_t read_RAM_array(CircuitBuilder* builder, const size_t ram_id, const uint32_t index_witness);
+    void write_RAM_array(CircuitBuilder* builder,
+                         const size_t ram_id,
+                         const uint32_t index_witness,
+                         const uint32_t value_witness);
+    /**
+     * @brief Gate that performs a read/write operation into a RAM table, i.e. table index is a witness not precomputed
+     *
+     * @param builder
+     * @param record Stores details of this read operation. Mutated by this fn!
+     */
+    void create_RAM_gate(CircuitBuilder* builder, RamRecord& record);
+    /**
+     * @brief Gate that performs consistency checks to validate that a claimed RAM read/write value is
+     * correct
+     *
+     * @details sorted RAM gates are generated sequentially, each RAM record is sorted first by index then by timestamp
+     *
+     * @param builder
+     * @param record Stores details of this read operation. Mutated by this fn!
+     */
+    void create_sorted_RAM_gate(CircuitBuilder* builder, RamRecord& record);
+    /**
+     * @brief Performs consistency checks to validate that a claimed RAM read/write value is correct.
+     * Used for the final gate in a list of sorted RAM records
+     *
+     * @param builder
+     * @param record Stores details of this read operation. Mutated by this fn!
+     */
+    void create_final_sorted_RAM_gate(CircuitBuilder* builder, RamRecord& record, const size_t ram_array_size);
+    /**
+     * @brief Compute additional gates required to validate RAM read/writes. Called when generating the proving key
+     *
+     * @param ram_id The id of the RAM table
+     * @param gate_offset_from_public_inputs Required to track the gate position of where we're adding extra gates
+     */
+    void process_RAM_array(CircuitBuilder* builder, const size_t ram_id);
+    void process_RAM_arrays(CircuitBuilder* builder);
+
+    bool operator==(const RomRamLogic_& other) const noexcept
+    {
+        return ram_arrays == other.ram_arrays && rom_arrays == other.rom_arrays;
+    }
+};
+
+} // namespace bb

--- a/barretenberg/cpp/src/barretenberg/stdlib_circuit_builders/ultra_circuit_builder.cpp
+++ b/barretenberg/cpp/src/barretenberg/stdlib_circuit_builders/ultra_circuit_builder.cpp
@@ -13,6 +13,7 @@
  */
 #include "ultra_circuit_builder.hpp"
 #include "barretenberg/crypto/poseidon2/poseidon2_params.hpp"
+#include "rom_ram_logic.hpp"
 
 #include "barretenberg/crypto/sha256/sha256.hpp"
 #include "barretenberg/serialize/msgpack_impl.hpp"
@@ -56,8 +57,8 @@ void UltraCircuitBuilder_<ExecutionTrace>::finalize_circuit(const bool ensure_no
         }
         process_non_native_field_multiplications();
 #ifndef ULTRA_FUZZ
-        process_ROM_arrays();
-        process_RAM_arrays();
+        this->rom_ram_logic.process_ROM_arrays(this);
+        this->rom_ram_logic.process_RAM_arrays(this);
         process_range_lists();
 #endif
         populate_public_inputs_block();
@@ -1759,7 +1760,6 @@ std::array<uint32_t, 2> UltraCircuitBuilder_<ExecutionTrace>::evaluate_non_nativ
                           0 },
                         true);
     create_dummy_gate(blocks.arithmetic, this->zero_idx, this->zero_idx, this->zero_idx, lo_0_idx);
-
     //
     // a = (a3 || a2 || a1 || a0) = (a3 * 2^b + a2) * 2^b + (a1 * 2^b + a0)
     // b = (b3 || b2 || b1 || b0) = (b3 * 2^b + b2) * 2^b + (b1 * 2^b + b0)
@@ -2214,146 +2214,20 @@ std::array<uint32_t, 5> UltraCircuitBuilder_<ExecutionTrace>::evaluate_non_nativ
     };
 }
 
-/**
- * @brief
- * Gate that'reads' from a ROM table.
- * i.e. table index is a witness not precomputed
- *
- * @param record Stores details of this read operation. Mutated by this fn!
- */
-template <typename ExecutionTrace> void UltraCircuitBuilder_<ExecutionTrace>::create_ROM_gate(RomRecord& record)
-{
-    // Record wire value can't yet be computed
-    record.record_witness = this->add_variable(0);
-    apply_aux_selectors(AUX_SELECTORS::ROM_READ);
-    blocks.aux.populate_wires(
-        record.index_witness, record.value_column1_witness, record.value_column2_witness, record.record_witness);
-
-    // Note: record the index into the block that contains the RAM/ROM gates
-    record.gate_index = this->blocks.aux.size() - 1;
-    ++this->num_gates;
-}
-
-/**
- * @brief Gate that performs consistency checks to validate that a claimed ROM read value is correct
- *
- * @details sorted ROM gates are generated sequentially, each ROM record is sorted by index
- *
- * @param record Stores details of this read operation. Mutated by this fn!
- */
-template <typename ExecutionTrace> void UltraCircuitBuilder_<ExecutionTrace>::create_sorted_ROM_gate(RomRecord& record)
-{
-    record.record_witness = this->add_variable(0);
-    // record_witness is intentionally used only in a single gate
-    update_used_witnesses(record.record_witness);
-    apply_aux_selectors(AUX_SELECTORS::ROM_CONSISTENCY_CHECK);
-    blocks.aux.populate_wires(
-        record.index_witness, record.value_column1_witness, record.value_column2_witness, record.record_witness);
-
-    // Note: record the index into the block that contains the RAM/ROM gates
-    record.gate_index = this->blocks.aux.size() - 1;
-    ++this->num_gates;
-}
-
-/**
- * @brief Create a new read-only memory region
- *
- * @details Creates a transcript object, where the inside memory state array is filled with "uninitialized memory" and
- * empty memory record array. Puts this object into the vector of ROM arrays.
- *
- * @param array_size The size of region in elements
- * @return size_t The index of the element
- */
+// /**
+//  * @brief Create a new read-only memory region
+//  *
+//  * @details Creates a transcript object, where the inside memory state array is filled with "uninitialized memory"
+//  and
+//  * empty memory record array. Puts this object into the vector of ROM arrays.
+//  *
+//  * @param array_size The size of region in elements
+//  * @return size_t The index of the element
+//  */
 template <typename ExecutionTrace>
 size_t UltraCircuitBuilder_<ExecutionTrace>::create_ROM_array(const size_t array_size)
 {
-    RomTranscript new_transcript;
-    for (size_t i = 0; i < array_size; ++i) {
-        new_transcript.state.emplace_back(
-            std::array<uint32_t, 2>{ UNINITIALIZED_MEMORY_RECORD, UNINITIALIZED_MEMORY_RECORD });
-    }
-    rom_arrays.emplace_back(new_transcript);
-    return rom_arrays.size() - 1;
-}
-
-/**
- * @brief Gate that performs a read/write operation into a RAM table.
- * i.e. table index is a witness not precomputed
- *
- * @param record Stores details of this read operation. Mutated by this fn!
- */
-template <typename ExecutionTrace> void UltraCircuitBuilder_<ExecutionTrace>::create_RAM_gate(RamRecord& record)
-{
-    // Record wire value can't yet be computed (uses randomnes generated during proof construction).
-    // However it needs a distinct witness index,
-    // we will be applying copy constraints + set membership constraints.
-    // Later on during proof construction we will compute the record wire value + assign it
-    record.record_witness = this->add_variable(0);
-    apply_aux_selectors(record.access_type == RamRecord::AccessType::READ ? AUX_SELECTORS::RAM_READ
-                                                                          : AUX_SELECTORS::RAM_WRITE);
-    blocks.aux.populate_wires(
-        record.index_witness, record.timestamp_witness, record.value_witness, record.record_witness);
-
-    // Note: record the index into the block that contains the RAM/ROM gates
-    record.gate_index = this->blocks.aux.size() - 1;
-    ++this->num_gates;
-}
-
-/**
- * @brief Gate that performs consistency checks to validate that a claimed RAM read/write value is
- * correct
- *
- * @details sorted RAM gates are generated sequentially, each RAM record is sorted first by index then by timestamp
- *
- * @param record Stores details of this read operation. Mutated by this fn!
- */
-template <typename ExecutionTrace> void UltraCircuitBuilder_<ExecutionTrace>::create_sorted_RAM_gate(RamRecord& record)
-{
-    record.record_witness = this->add_variable(0);
-    apply_aux_selectors(AUX_SELECTORS::RAM_CONSISTENCY_CHECK);
-    blocks.aux.populate_wires(
-        record.index_witness, record.timestamp_witness, record.value_witness, record.record_witness);
-
-    // Note: record the index into the block that contains the RAM/ROM gates
-    record.gate_index = this->blocks.aux.size() - 1;
-    ++this->num_gates;
-}
-
-/**
- * @brief Performs consistency checks to validate that a claimed RAM read/write value is correct.
- * Used for the final gate in a list of sorted RAM records
- *
- * @param record Stores details of this read operation. Mutated by this fn!
- */
-template <typename ExecutionTrace>
-void UltraCircuitBuilder_<ExecutionTrace>::create_final_sorted_RAM_gate(RamRecord& record, const size_t ram_array_size)
-{
-    record.record_witness = this->add_variable(0);
-    // Note: record the index into the block that contains the RAM/ROM gates
-    record.gate_index = this->blocks.aux.size(); // no -1 since we havent added the gate yet
-
-    // TODO(https://github.com/AztecProtocol/barretenberg/issues/879): This method used to add a single arithmetic gate
-    // with two purposes: (1) to provide wire values to the previous RAM gate via shifts, and (2) to perform a
-    // consistency check on the value in wire 1. These two purposes have been split into a dummy gate and a simplified
-    // arithmetic gate, respectively. This allows both purposes to be served even after arithmetic gates are sorted out
-    // of sequence with the RAM gates.
-
-    // Create a final gate with all selectors zero; wire values are accessed by the previous RAM gate via shifted wires
-    create_dummy_gate(
-        blocks.aux, record.index_witness, record.timestamp_witness, record.value_witness, record.record_witness);
-
-    // Create an add gate ensuring the final index is consistent with the size of the RAM array
-    create_big_add_gate({
-        record.index_witness,
-        this->zero_idx,
-        this->zero_idx,
-        this->zero_idx,
-        1,
-        0,
-        0,
-        0,
-        -FF((uint64_t)ram_array_size - 1),
-    });
+    return this->rom_ram_logic.create_ROM_array(array_size);
 }
 
 /**
@@ -2369,12 +2243,7 @@ void UltraCircuitBuilder_<ExecutionTrace>::create_final_sorted_RAM_gate(RamRecor
 template <typename ExecutionTrace>
 size_t UltraCircuitBuilder_<ExecutionTrace>::create_RAM_array(const size_t array_size)
 {
-    RamTranscript new_transcript;
-    for (size_t i = 0; i < array_size; ++i) {
-        new_transcript.state.emplace_back(UNINITIALIZED_MEMORY_RECORD);
-    }
-    ram_arrays.emplace_back(new_transcript);
-    return ram_arrays.size() - 1;
+    return this->rom_ram_logic.create_RAM_array(array_size);
 }
 
 /**
@@ -2389,52 +2258,13 @@ void UltraCircuitBuilder_<ExecutionTrace>::init_RAM_element(const size_t ram_id,
                                                             const size_t index_value,
                                                             const uint32_t value_witness)
 {
-    ASSERT(ram_arrays.size() > ram_id);
-    RamTranscript& ram_array = ram_arrays[ram_id];
-    const uint32_t index_witness = (index_value == 0) ? this->zero_idx : put_constant_variable((uint64_t)index_value);
-    ASSERT(ram_array.state.size() > index_value);
-    ASSERT(ram_array.state[index_value] == UNINITIALIZED_MEMORY_RECORD);
-    RamRecord new_record{ .index_witness = index_witness,
-                          .timestamp_witness = put_constant_variable((uint64_t)ram_array.access_count),
-                          .value_witness = value_witness,
-                          .index = static_cast<uint32_t>(index_value), // TODO: size_t?
-                          .timestamp = static_cast<uint32_t>(ram_array.access_count),
-                          .access_type = RamRecord::AccessType::WRITE,
-                          .record_witness = 0,
-                          .gate_index = 0 };
-    ram_array.state[index_value] = value_witness;
-    ram_array.access_count++;
-    create_RAM_gate(new_record);
-    ram_array.records.emplace_back(new_record);
+    this->rom_ram_logic.init_RAM_element(this, ram_id, index_value, value_witness);
 }
 
 template <typename ExecutionTrace>
 uint32_t UltraCircuitBuilder_<ExecutionTrace>::read_RAM_array(const size_t ram_id, const uint32_t index_witness)
 {
-    ASSERT(ram_arrays.size() > ram_id);
-    RamTranscript& ram_array = ram_arrays[ram_id];
-    const uint32_t index = static_cast<uint32_t>(uint256_t(this->get_variable(index_witness)));
-    ASSERT(ram_array.state.size() > index);
-    ASSERT(ram_array.state[index] != UNINITIALIZED_MEMORY_RECORD);
-    const auto value = this->get_variable(ram_array.state[index]);
-    const uint32_t value_witness = this->add_variable(value);
-
-    RamRecord new_record{ .index_witness = index_witness,
-                          .timestamp_witness = put_constant_variable((uint64_t)ram_array.access_count),
-                          .value_witness = value_witness,
-                          .index = index,
-                          .timestamp = static_cast<uint32_t>(ram_array.access_count),
-                          .access_type = RamRecord::AccessType::READ,
-                          .record_witness = 0,
-                          .gate_index = 0 };
-    create_RAM_gate(new_record);
-    ram_array.records.emplace_back(new_record);
-
-    // increment ram array's access count
-    ram_array.access_count++;
-
-    // return witness index of the value in the array
-    return value_witness;
+    return this->rom_ram_logic.read_RAM_array(this, ram_id, index_witness);
 }
 
 template <typename ExecutionTrace>
@@ -2442,28 +2272,7 @@ void UltraCircuitBuilder_<ExecutionTrace>::write_RAM_array(const size_t ram_id,
                                                            const uint32_t index_witness,
                                                            const uint32_t value_witness)
 {
-    ASSERT(ram_arrays.size() > ram_id);
-    RamTranscript& ram_array = ram_arrays[ram_id];
-    const uint32_t index = static_cast<uint32_t>(uint256_t(this->get_variable(index_witness)));
-    ASSERT(ram_array.state.size() > index);
-    ASSERT(ram_array.state[index] != UNINITIALIZED_MEMORY_RECORD);
-
-    RamRecord new_record{ .index_witness = index_witness,
-                          .timestamp_witness = put_constant_variable((uint64_t)ram_array.access_count),
-                          .value_witness = value_witness,
-                          .index = index,
-                          .timestamp = static_cast<uint32_t>(ram_array.access_count),
-                          .access_type = RamRecord::AccessType::WRITE,
-                          .record_witness = 0,
-                          .gate_index = 0 };
-    create_RAM_gate(new_record);
-    ram_array.records.emplace_back(new_record);
-
-    // increment ram array's access count
-    ram_array.access_count++;
-
-    // update Composer's current state of RAM array
-    ram_array.state[index] = value_witness;
+    this->rom_ram_logic.write_RAM_array(this, ram_id, index_witness, value_witness);
 }
 
 /**
@@ -2485,35 +2294,7 @@ void UltraCircuitBuilder_<ExecutionTrace>::set_ROM_element(const size_t rom_id,
                                                            const size_t index_value,
                                                            const uint32_t value_witness)
 {
-    ASSERT(rom_arrays.size() > rom_id);
-    RomTranscript& rom_array = rom_arrays[rom_id];
-    const uint32_t index_witness = (index_value == 0) ? this->zero_idx : put_constant_variable((uint64_t)index_value);
-    ASSERT(rom_array.state.size() > index_value);
-    ASSERT(rom_array.state[index_value][0] == UNINITIALIZED_MEMORY_RECORD);
-    /**
-     * The structure MemoryRecord contains the following members in this order:
-     *   uint32_t index_witness;
-     *   uint32_t timestamp_witness;
-     *   uint32_t value_witness;
-     *   uint32_t index;
-     *   uint32_t timestamp;
-     *   uint32_t record_witness;
-     *   size_t gate_index;
-     * The second initialization value here is the witness, because in ROM it doesn't matter. We will decouple this
-     * logic later.
-     */
-    RomRecord new_record{
-        .index_witness = index_witness,
-        .value_column1_witness = value_witness,
-        .value_column2_witness = this->zero_idx,
-        .index = static_cast<uint32_t>(index_value),
-        .record_witness = 0,
-        .gate_index = 0,
-    };
-    rom_array.state[index_value][0] = value_witness;
-    rom_array.state[index_value][1] = this->zero_idx;
-    create_ROM_gate(new_record);
-    rom_array.records.emplace_back(new_record);
+    this->rom_ram_logic.set_ROM_element(this, rom_id, index_value, value_witness);
 }
 
 /**
@@ -2528,23 +2309,7 @@ void UltraCircuitBuilder_<ExecutionTrace>::set_ROM_element_pair(const size_t rom
                                                                 const size_t index_value,
                                                                 const std::array<uint32_t, 2>& value_witnesses)
 {
-    ASSERT(rom_arrays.size() > rom_id);
-    RomTranscript& rom_array = rom_arrays[rom_id];
-    const uint32_t index_witness = (index_value == 0) ? this->zero_idx : put_constant_variable((uint64_t)index_value);
-    ASSERT(rom_array.state.size() > index_value);
-    ASSERT(rom_array.state[index_value][0] == UNINITIALIZED_MEMORY_RECORD);
-    RomRecord new_record{
-        .index_witness = index_witness,
-        .value_column1_witness = value_witnesses[0],
-        .value_column2_witness = value_witnesses[1],
-        .index = static_cast<uint32_t>(index_value),
-        .record_witness = 0,
-        .gate_index = 0,
-    };
-    rom_array.state[index_value][0] = value_witnesses[0];
-    rom_array.state[index_value][1] = value_witnesses[1];
-    create_ROM_gate(new_record);
-    rom_array.records.emplace_back(new_record);
+    this->rom_ram_logic.set_ROM_element_pair(this, rom_id, index_value, value_witnesses);
 }
 
 /**
@@ -2557,26 +2322,7 @@ void UltraCircuitBuilder_<ExecutionTrace>::set_ROM_element_pair(const size_t rom
 template <typename ExecutionTrace>
 uint32_t UltraCircuitBuilder_<ExecutionTrace>::read_ROM_array(const size_t rom_id, const uint32_t index_witness)
 {
-    ASSERT(rom_arrays.size() > rom_id);
-    RomTranscript& rom_array = rom_arrays[rom_id];
-    const uint32_t index = static_cast<uint32_t>(uint256_t(this->get_variable(index_witness)));
-    ASSERT(rom_array.state.size() > index);
-    ASSERT(rom_array.state[index][0] != UNINITIALIZED_MEMORY_RECORD);
-    const auto value = this->get_variable(rom_array.state[index][0]);
-    const uint32_t value_witness = this->add_variable(value);
-    RomRecord new_record{
-        .index_witness = index_witness,
-        .value_column1_witness = value_witness,
-        .value_column2_witness = this->zero_idx,
-        .index = index,
-        .record_witness = 0,
-        .gate_index = 0,
-    };
-    create_ROM_gate(new_record);
-    rom_array.records.emplace_back(new_record);
-
-    // create_read_gate
-    return value_witness;
+    return this->rom_ram_logic.read_ROM_array(this, rom_id, index_witness);
 }
 
 /**
@@ -2586,277 +2332,11 @@ uint32_t UltraCircuitBuilder_<ExecutionTrace>::read_ROM_array(const size_t rom_i
  * @param index_witness The witness containing the index in the array
  * @return std::array<uint32_t, 2> A pair of indexes of witness variables of cell values
  */
-
 template <typename ExecutionTrace>
 std::array<uint32_t, 2> UltraCircuitBuilder_<ExecutionTrace>::read_ROM_array_pair(const size_t rom_id,
                                                                                   const uint32_t index_witness)
 {
-    std::array<uint32_t, 2> value_witnesses;
-
-    const uint32_t index = static_cast<uint32_t>(uint256_t(this->get_variable(index_witness)));
-    ASSERT(rom_arrays.size() > rom_id);
-    RomTranscript& rom_array = rom_arrays[rom_id];
-    ASSERT(rom_array.state.size() > index);
-    ASSERT(rom_array.state[index][0] != UNINITIALIZED_MEMORY_RECORD);
-    ASSERT(rom_array.state[index][1] != UNINITIALIZED_MEMORY_RECORD);
-    const auto value1 = this->get_variable(rom_array.state[index][0]);
-    const auto value2 = this->get_variable(rom_array.state[index][1]);
-    value_witnesses[0] = this->add_variable(value1);
-    value_witnesses[1] = this->add_variable(value2);
-    RomRecord new_record{
-        .index_witness = index_witness,
-        .value_column1_witness = value_witnesses[0],
-        .value_column2_witness = value_witnesses[1],
-        .index = index,
-        .record_witness = 0,
-        .gate_index = 0,
-    };
-    create_ROM_gate(new_record);
-    rom_array.records.emplace_back(new_record);
-
-    // create_read_gate
-    return value_witnesses;
-}
-
-/**
- * @brief Compute additional gates required to validate ROM reads. Called when generating the proving key
- *
- * @param rom_id The id of the ROM table
- * @param gate_offset_from_public_inputs Required to track the gate position of where we're adding extra gates
- */
-template <typename ExecutionTrace> void UltraCircuitBuilder_<ExecutionTrace>::process_ROM_array(const size_t rom_id)
-{
-
-    auto& rom_array = rom_arrays[rom_id];
-    const auto read_tag = get_new_tag();        // current_tag + 1;
-    const auto sorted_list_tag = get_new_tag(); // current_tag + 2;
-    create_tag(read_tag, sorted_list_tag);
-    create_tag(sorted_list_tag, read_tag);
-
-    // Make sure that every cell has been initialized
-    for (size_t i = 0; i < rom_array.state.size(); ++i) {
-        if (rom_array.state[i][0] == UNINITIALIZED_MEMORY_RECORD) {
-            set_ROM_element_pair(rom_id, static_cast<uint32_t>(i), { this->zero_idx, this->zero_idx });
-        }
-    }
-
-#ifdef NO_PAR_ALGOS
-    std::sort(rom_array.records.begin(), rom_array.records.end());
-#else
-    std::sort(std::execution::par_unseq, rom_array.records.begin(), rom_array.records.end());
-#endif
-
-    for (const RomRecord& record : rom_array.records) {
-        const auto index = record.index;
-        const auto value1 = this->get_variable(record.value_column1_witness);
-        const auto value2 = this->get_variable(record.value_column2_witness);
-        const auto index_witness = this->add_variable(FF((uint64_t)index));
-        // the same thing as with the record witness
-        update_used_witnesses(index_witness);
-        const auto value1_witness = this->add_variable(value1);
-        const auto value2_witness = this->add_variable(value2);
-        RomRecord sorted_record{
-            .index_witness = index_witness,
-            .value_column1_witness = value1_witness,
-            .value_column2_witness = value2_witness,
-            .index = index,
-            .record_witness = 0,
-            .gate_index = 0,
-        };
-        create_sorted_ROM_gate(sorted_record);
-
-        assign_tag(record.record_witness, read_tag);
-        assign_tag(sorted_record.record_witness, sorted_list_tag);
-
-        // For ROM/RAM gates, the 'record' wire value (wire column 4) is a linear combination of the first 3 wire
-        // values. However...the record value uses the random challenge 'eta', generated after the first 3 wires are
-        // committed to. i.e. we can't compute the record witness here because we don't know what `eta` is! Take the
-        // gate indices of the two rom gates (original read gate + sorted gate) and store in `memory_records`. Once
-        // we
-        // generate the `eta` challenge, we'll use `memory_records` to figure out which gates need a record wire
-        // value
-        // to be computed.
-        // record (w4) = w3 * eta^3 + w2 * eta^2 + w1 * eta + read_write_flag (0 for reads, 1 for writes)
-        // Separate containers used to store gate indices of reads and writes. Need to differentiate because of
-        // `read_write_flag` (N.B. all ROM accesses are considered reads. Writes are for RAM operations)
-        memory_read_records.push_back(static_cast<uint32_t>(sorted_record.gate_index));
-        memory_read_records.push_back(static_cast<uint32_t>(record.gate_index));
-    }
-    // One of the checks we run on the sorted list, is to validate the difference between
-    // the index field across two gates is either 0 or 1.
-    // If we add a dummy gate at the end of the sorted list, where we force the first wire to
-    // equal `m + 1`, where `m` is the maximum allowed index in the sorted list,
-    // we have validated that all ROM reads are correctly constrained
-    FF max_index_value((uint64_t)rom_array.state.size());
-    uint32_t max_index = this->add_variable(max_index_value);
-    // TODO(https://github.com/AztecProtocol/barretenberg/issues/879): This was formerly a single arithmetic gate. A
-    // dummy gate has been added to allow the previous gate to access the required wire data via shifts, allowing the
-    // arithmetic gate to occur out of sequence.
-    create_dummy_gate(blocks.aux, max_index, this->zero_idx, this->zero_idx, this->zero_idx);
-    create_big_add_gate(
-        {
-            max_index,
-            this->zero_idx,
-            this->zero_idx,
-            this->zero_idx,
-            1,
-            0,
-            0,
-            0,
-            -max_index_value,
-        },
-        false);
-    // N.B. If the above check holds, we know the sorted list begins with an index value of 0,
-    // because the first cell is explicitly initialized using zero_idx as the index field.
-}
-
-/**
- * @brief Compute additional gates required to validate RAM read/writes. Called when generating the proving key
- *
- * @param ram_id The id of the RAM table
- * @param gate_offset_from_public_inputs Required to track the gate position of where we're adding extra gates
- */
-template <typename ExecutionTrace> void UltraCircuitBuilder_<ExecutionTrace>::process_RAM_array(const size_t ram_id)
-{
-    RamTranscript& ram_array = ram_arrays[ram_id];
-    const auto access_tag = get_new_tag();      // current_tag + 1;
-    const auto sorted_list_tag = get_new_tag(); // current_tag + 2;
-    create_tag(access_tag, sorted_list_tag);
-    create_tag(sorted_list_tag, access_tag);
-
-    // Make sure that every cell has been initialized
-    // TODO: throw some kind of error here? Circuit should initialize all RAM elements to prevent errors.
-    // e.g. if a RAM record is uninitialized but the index of that record is a function of public/private inputs,
-    // different public iputs will produce different circuit constraints.
-    for (size_t i = 0; i < ram_array.state.size(); ++i) {
-        if (ram_array.state[i] == UNINITIALIZED_MEMORY_RECORD) {
-            init_RAM_element(ram_id, static_cast<uint32_t>(i), this->zero_idx);
-        }
-    }
-
-#ifdef NO_PAR_ALGOS
-    std::sort(ram_array.records.begin(), ram_array.records.end());
-#else
-    std::sort(std::execution::par_unseq, ram_array.records.begin(), ram_array.records.end());
-#endif
-
-    std::vector<RamRecord> sorted_ram_records;
-
-    // Iterate over all but final RAM record.
-    for (size_t i = 0; i < ram_array.records.size(); ++i) {
-        const RamRecord& record = ram_array.records[i];
-
-        const auto index = record.index;
-        const auto value = this->get_variable(record.value_witness);
-        const auto index_witness = this->add_variable(FF((uint64_t)index));
-        const auto timestamp_witess = this->add_variable(record.timestamp);
-        const auto value_witness = this->add_variable(value);
-        RamRecord sorted_record{
-            .index_witness = index_witness,
-            .timestamp_witness = timestamp_witess,
-            .value_witness = value_witness,
-            .index = index,
-            .timestamp = record.timestamp,
-            .access_type = record.access_type,
-            .record_witness = 0,
-            .gate_index = 0,
-        };
-
-        // create a list of sorted ram records
-        sorted_ram_records.emplace_back(sorted_record);
-
-        // We don't apply the RAM consistency check gate to the final record,
-        // as this gate expects a RAM record to be present at the next gate
-        if (i < ram_array.records.size() - 1) {
-            create_sorted_RAM_gate(sorted_record);
-        } else {
-            // For the final record in the sorted list, we do not apply the full consistency check gate.
-            // Only need to check the index value = RAM array size - 1.
-            create_final_sorted_RAM_gate(sorted_record, ram_array.state.size());
-        }
-
-        // Assign record/sorted records to tags that we will perform set equivalence checks on
-        assign_tag(record.record_witness, access_tag);
-        assign_tag(sorted_record.record_witness, sorted_list_tag);
-
-        // For ROM/RAM gates, the 'record' wire value (wire column 4) is a linear combination of the first 3 wire
-        // values. However...the record value uses the random challenge 'eta', generated after the first 3 wires are
-        // committed to. i.e. we can't compute the record witness here because we don't know what `eta` is! Take the
-        // gate indices of the two rom gates (original read gate + sorted gate) and store in `memory_records`. Once
-        // we
-        // generate the `eta` challenge, we'll use `memory_records` to figure out which gates need a record wire
-        // value
-        // to be computed.
-
-        switch (record.access_type) {
-        case RamRecord::AccessType::READ: {
-            memory_read_records.push_back(static_cast<uint32_t>(sorted_record.gate_index));
-            memory_read_records.push_back(static_cast<uint32_t>(record.gate_index));
-            break;
-        }
-        case RamRecord::AccessType::WRITE: {
-            memory_write_records.push_back(static_cast<uint32_t>(sorted_record.gate_index));
-            memory_write_records.push_back(static_cast<uint32_t>(record.gate_index));
-            break;
-        }
-        default: {
-            ASSERT(false); // shouldn't get here!
-        }
-        }
-    }
-
-    // Step 2: Create gates that validate correctness of RAM timestamps
-
-    std::vector<uint32_t> timestamp_deltas;
-    for (size_t i = 0; i < sorted_ram_records.size() - 1; ++i) {
-        // create_RAM_timestamp_gate(sorted_records[i], sorted_records[i + 1])
-        const auto& current = sorted_ram_records[i];
-        const auto& next = sorted_ram_records[i + 1];
-
-        const bool share_index = current.index == next.index;
-
-        FF timestamp_delta = 0;
-        if (share_index) {
-            ASSERT(next.timestamp > current.timestamp);
-            timestamp_delta = FF(next.timestamp - current.timestamp);
-        }
-
-        uint32_t timestamp_delta_witness = this->add_variable(timestamp_delta);
-
-        apply_aux_selectors(AUX_SELECTORS::RAM_TIMESTAMP_CHECK);
-        blocks.aux.populate_wires(
-            current.index_witness, current.timestamp_witness, timestamp_delta_witness, this->zero_idx);
-
-        ++this->num_gates;
-
-        // store timestamp offsets for later. Need to apply range checks to them, but calling
-        // `create_new_range_constraint` can add gates. Would ruin the structure of our sorted timestamp list.
-        timestamp_deltas.push_back(timestamp_delta_witness);
-    }
-
-    // add the index/timestamp values of the last sorted record in an empty add gate.
-    // (the previous gate will access the wires on this gate and requires them to be those of the last record)
-    const auto& last = sorted_ram_records[ram_array.records.size() - 1];
-    create_dummy_gate(blocks.aux, last.index_witness, last.timestamp_witness, this->zero_idx, this->zero_idx);
-
-    // Step 3: validate difference in timestamps is monotonically increasing. i.e. is <= maximum timestamp
-    const size_t max_timestamp = ram_array.access_count - 1;
-    for (auto& w : timestamp_deltas) {
-        create_new_range_constraint(w, max_timestamp);
-    }
-}
-
-template <typename ExecutionTrace> void UltraCircuitBuilder_<ExecutionTrace>::process_ROM_arrays()
-{
-    for (size_t i = 0; i < rom_arrays.size(); ++i) {
-        process_ROM_array(i);
-    }
-}
-template <typename ExecutionTrace> void UltraCircuitBuilder_<ExecutionTrace>::process_RAM_arrays()
-{
-    for (size_t i = 0; i < ram_arrays.size(); ++i) {
-        process_RAM_array(i);
-    }
+    return this->rom_ram_logic.read_ROM_array_pair(this, rom_id, index_witness);
 }
 
 /**
@@ -2966,7 +2446,7 @@ template <typename ExecutionTrace> msgpack::sbuffer UltraCircuitBuilder_<Executi
     using base = CircuitBuilderBase<FF>;
     CircuitSchemaInternal<FF> cir;
 
-    uint64_t modulus[4] = {
+    std::array<uint64_t, 4> modulus = {
         FF::Params::modulus_0, FF::Params::modulus_1, FF::Params::modulus_2, FF::Params::modulus_3
     };
     std::stringstream buf;
@@ -3049,7 +2529,7 @@ template <typename ExecutionTrace> msgpack::sbuffer UltraCircuitBuilder_<Executi
         cir.range_tags[list.second.range_tag] = list.first;
     }
 
-    for (auto& rom_table : this->rom_arrays) {
+    for (auto& rom_table : this->rom_ram_logic.rom_arrays) {
         std::sort(rom_table.records.begin(), rom_table.records.end());
 
         std::vector<std::vector<uint32_t>> table;
@@ -3065,7 +2545,7 @@ template <typename ExecutionTrace> msgpack::sbuffer UltraCircuitBuilder_<Executi
         cir.rom_states.push_back(rom_table.state);
     }
 
-    for (auto& ram_table : this->ram_arrays) {
+    for (auto& ram_table : this->rom_ram_logic.ram_arrays) {
         std::sort(ram_table.records.begin(), ram_table.records.end());
 
         std::vector<std::vector<uint32_t>> table;

--- a/barretenberg/cpp/src/barretenberg/stdlib_circuit_builders/ultra_circuit_builder.cpp
+++ b/barretenberg/cpp/src/barretenberg/stdlib_circuit_builders/ultra_circuit_builder.cpp
@@ -2214,16 +2214,16 @@ std::array<uint32_t, 5> UltraCircuitBuilder_<ExecutionTrace>::evaluate_non_nativ
     };
 }
 
-// /**
-//  * @brief Create a new read-only memory region
-//  *
-//  * @details Creates a transcript object, where the inside memory state array is filled with "uninitialized memory"
-//  and
-//  * empty memory record array. Puts this object into the vector of ROM arrays.
-//  *
-//  * @param array_size The size of region in elements
-//  * @return size_t The index of the element
-//  */
+/**
+ * @brief Create a new read-only memory region
+ *
+ * @details Creates a transcript object, where the inside memory state array is filled with "uninitialized memory"
+ and
+ * empty memory record array. Puts this object into the vector of ROM arrays.
+ *
+ * @param array_size The size of region in elements
+ * @return size_t The index of the element
+ */
 template <typename ExecutionTrace>
 size_t UltraCircuitBuilder_<ExecutionTrace>::create_ROM_array(const size_t array_size)
 {

--- a/barretenberg/cpp/src/barretenberg/stdlib_circuit_builders/ultra_circuit_builder.hpp
+++ b/barretenberg/cpp/src/barretenberg/stdlib_circuit_builders/ultra_circuit_builder.hpp
@@ -14,6 +14,7 @@
 
 // TODO(md): note that this has now been added
 #include "circuit_builder_base.hpp"
+#include "rom_ram_logic.hpp"
 #include <optional>
 #include <unordered_set>
 
@@ -35,8 +36,9 @@ template <typename ExecutionTrace_>
 class UltraCircuitBuilder_ : public CircuitBuilderBase<typename ExecutionTrace_::FF> {
   public:
     using ExecutionTrace = ExecutionTrace_;
-
     using FF = typename ExecutionTrace::FF;
+    using RomRamLogic = RomRamLogic_<ExecutionTrace>;
+
     static constexpr size_t NUM_WIRES = ExecutionTrace::NUM_WIRES;
     // Keeping NUM_WIRES, at least temporarily, for backward compatibility
     static constexpr size_t program_width = ExecutionTrace::NUM_WIRES;
@@ -84,107 +86,6 @@ class UltraCircuitBuilder_ : public CircuitBuilderBase<typename ExecutionTrace_:
         {
             return target_range == other.target_range && range_tag == other.range_tag && tau_tag == other.tau_tag &&
                    variable_indices == other.variable_indices;
-        }
-    };
-
-    /**
-     * @brief A ROM memory record that can be ordered
-     *
-     *
-     */
-    struct RomRecord {
-        uint32_t index_witness = 0;
-        uint32_t value_column1_witness = 0;
-        uint32_t value_column2_witness = 0;
-        uint32_t index = 0;
-        uint32_t record_witness = 0;
-        size_t gate_index = 0;
-        bool operator<(const RomRecord& other) const { return index < other.index; }
-        bool operator==(const RomRecord& other) const noexcept
-        {
-            return index_witness == other.index_witness && value_column1_witness == other.value_column1_witness &&
-                   value_column2_witness == other.value_column2_witness && index == other.index &&
-                   record_witness == other.record_witness && gate_index == other.gate_index;
-        }
-    };
-
-    /**
-     * @brief A RAM memory record that can be ordered
-     *
-     *
-     */
-    struct RamRecord {
-        enum AccessType {
-            READ,
-            WRITE,
-        };
-        uint32_t index_witness = 0;
-        uint32_t timestamp_witness = 0;
-        uint32_t value_witness = 0;
-        uint32_t index = 0;
-        uint32_t timestamp = 0;
-        AccessType access_type = AccessType::READ; // read or write?
-        uint32_t record_witness = 0;
-        size_t gate_index = 0;
-        bool operator<(const RamRecord& other) const
-        {
-            bool index_test = (index) < (other.index);
-            return index_test || (index == other.index && timestamp < other.timestamp);
-        }
-        bool operator==(const RamRecord& other) const noexcept
-        {
-            return index_witness == other.index_witness && timestamp_witness == other.timestamp_witness &&
-                   value_witness == other.value_witness && index == other.index && timestamp == other.timestamp &&
-                   access_type == other.access_type && record_witness == other.record_witness &&
-                   gate_index == other.gate_index;
-        }
-    };
-
-    /**
-     * @brief Each ram array is an instance of memory transcript. It saves values and indexes for a particular memory
-     * array
-     *
-     *
-     */
-    struct RamTranscript {
-        // Contains the value of each index of the array
-        std::vector<uint32_t> state;
-
-        // A vector of records, each of which contains:
-        // + The constant witness with the index
-        // + The value in the memory slot
-        // + The actual index value
-        std::vector<RamRecord> records;
-
-        // used for RAM records, to compute the timestamp when performing a read/write
-        size_t access_count = 0;
-        // Used to check that the state hasn't changed in tests
-        bool operator==(const RamTranscript& other) const noexcept
-        {
-            return (state == other.state && records == other.records && access_count == other.access_count);
-        }
-    };
-
-    /**
-     * @brief Each rom array is an instance of memory transcript. It saves values and indexes for a particular memory
-     * array
-     *
-     *
-     */
-    struct RomTranscript {
-        // Contains the value of each index of the array
-        std::vector<std::array<uint32_t, 2>> state;
-
-        // A vector of records, each of which contains:
-        // + The constant witness with the index
-        // + The value in the memory slot
-        // + The actual index value
-        std::vector<RomRecord> records;
-
-        // Used to check that the state hasn't changed in tests
-        bool operator==(const RomTranscript& other) const noexcept
-        {
-            return (state == other.state && records == other.records);
         }
     };
 
@@ -301,29 +202,16 @@ class UltraCircuitBuilder_ : public CircuitBuilderBase<typename ExecutionTrace_:
     // The set of lookup tables used by the circuit, plus the gate data for the lookups from each table
     std::vector<plookup::BasicTable> lookup_tables;
 
-    std::map<uint64_t, RangeList> range_lists; // DOCTODO: explain this.
+    // Rom/Ram logic
+    RomRamLogic rom_ram_logic = RomRamLogic();
 
-    /**
-     * @brief Each entry in ram_arrays represents an independent RAM table.
-     * RamTranscript tracks the current table state,
-     * as well as the 'records' produced by each read and write operation.
-     * Used in `compute_proving_key` to generate consistency check gates required to validate the RAM read/write
-     * history
-     */
-    std::vector<RamTranscript> ram_arrays;
-
-    /**
-     * @brief Each entry in ram_arrays represents an independent ROM table.
-     * RomTranscript tracks the current table state,
-     * as well as the 'records' produced by each read operation.
-     * Used in `compute_proving_key` to generate consistency check gates required to validate the ROM read history
-     */
-    std::vector<RomTranscript> rom_arrays;
-
-    // Stores gate index of ROM and RAM reads (required by proving key)
+    // Stores gate index of ROM/RAM reads (required by proving key)
     std::vector<uint32_t> memory_read_records;
     // Stores gate index of RAM writes (required by proving key)
     std::vector<uint32_t> memory_write_records;
+    std::map<uint64_t, RangeList> range_lists; // DOCTODO: explain this.
+                                               // Stores gate index of ROM and RAM reads (required by proving key)
+
     // Witnesses that can be in one gate, but that's intentional (used in boomerang catcher)
     std::vector<uint32_t> used_witnesses;
     std::vector<cached_partial_non_native_field_multiplication> cached_partial_non_native_field_multiplications;
@@ -385,11 +273,10 @@ class UltraCircuitBuilder_ : public CircuitBuilderBase<typename ExecutionTrace_:
         , blocks(other.blocks)
         , constant_variable_indices(other.constant_variable_indices)
         , lookup_tables(other.lookup_tables)
-        , range_lists(other.range_lists)
-        , ram_arrays(other.ram_arrays)
-        , rom_arrays(other.rom_arrays)
+        , rom_ram_logic(other.rom_ram_logic)
         , memory_read_records(other.memory_read_records)
         , memory_write_records(other.memory_write_records)
+        , range_lists(other.range_lists)
         , cached_partial_non_native_field_multiplications(other.cached_partial_non_native_field_multiplications)
         , circuit_finalized(other.circuit_finalized)
         , ipa_proof(other.ipa_proof){};
@@ -402,8 +289,7 @@ class UltraCircuitBuilder_ : public CircuitBuilderBase<typename ExecutionTrace_:
 
         lookup_tables = other.lookup_tables;
         range_lists = other.range_lists;
-        ram_arrays = other.ram_arrays;
-        rom_arrays = other.rom_arrays;
+        rom_ram_logic = other.rom_ram_logic;
         memory_read_records = other.memory_read_records;
         memory_write_records = other.memory_write_records;
         cached_partial_non_native_field_multiplications = other.cached_partial_non_native_field_multiplications;
@@ -413,8 +299,22 @@ class UltraCircuitBuilder_ : public CircuitBuilderBase<typename ExecutionTrace_:
     };
     ~UltraCircuitBuilder_() override = default;
 
-    bool operator==(const UltraCircuitBuilder_& other) const = default;
+    bool operator==(const UltraCircuitBuilder_& other) const
+    {
+        // // Compare the underlying rom_ram_logic instead of the reference members
+        // if (!(rom_ram_logic == other.rom_ram_logic))
+        //     return false;
 
+        // // Compare all other non-reference members
+        return blocks == other.blocks && constant_variable_indices == other.constant_variable_indices &&
+               lookup_tables == other.lookup_tables && memory_read_records == other.memory_read_records &&
+               memory_write_records == other.memory_write_records && range_lists == other.range_lists &&
+               cached_partial_non_native_field_multiplications ==
+                   other.cached_partial_non_native_field_multiplications &&
+               used_witnesses == other.used_witnesses && rom_ram_logic == other.rom_ram_logic &&
+               // Compare the base class
+               CircuitBuilderBase<FF>::operator==(other);
+    }
     /**
      * @brief Debug helper method for ensuring all selectors have the same size
      * @details Each gate construction method manually appends values to the selectors. Failing to update one of the
@@ -433,6 +333,7 @@ class UltraCircuitBuilder_ : public CircuitBuilderBase<typename ExecutionTrace_:
                 ASSERT(block.selectors[idx].size() == nominal_size);
             }
         }
+
 #endif // NDEBUG
     }
 
@@ -522,14 +423,15 @@ class UltraCircuitBuilder_ : public CircuitBuilderBase<typename ExecutionTrace_:
         size_t& count, size_t& rangecount, size_t& romcount, size_t& ramcount, size_t& nnfcount) const
     {
         count = this->num_gates;
+
         // each ROM gate adds +1 extra gate due to the rom reads being copied to a sorted list set
-        for (size_t i = 0; i < rom_arrays.size(); ++i) {
-            for (size_t j = 0; j < rom_arrays[i].state.size(); ++j) {
-                if (rom_arrays[i].state[j][0] == UNINITIALIZED_MEMORY_RECORD) {
+        for (size_t i = 0; i < rom_ram_logic.rom_arrays.size(); ++i) {
+            for (size_t j = 0; j < rom_ram_logic.rom_arrays[i].state.size(); ++j) {
+                if (rom_ram_logic.rom_arrays[i].state[j][0] == UNINITIALIZED_MEMORY_RECORD) {
                     romcount += 2;
                 }
             }
-            romcount += (rom_arrays[i].records.size());
+            romcount += (rom_ram_logic.rom_arrays[i].records.size());
             romcount += 1; // we add an addition gate after procesing a rom array
         }
 
@@ -538,20 +440,21 @@ class UltraCircuitBuilder_ : public CircuitBuilderBase<typename ExecutionTrace_:
         std::vector<size_t> ram_timestamps;
         std::vector<size_t> ram_range_sizes;
         std::vector<size_t> ram_range_exists;
-        for (size_t i = 0; i < ram_arrays.size(); ++i) {
-            for (size_t j = 0; j < ram_arrays[i].state.size(); ++j) {
-                if (ram_arrays[i].state[j] == UNINITIALIZED_MEMORY_RECORD) {
+        for (size_t i = 0; i < rom_ram_logic.ram_arrays.size(); ++i) {
+            for (size_t j = 0; j < rom_ram_logic.ram_arrays[i].state.size(); ++j) {
+                if (rom_ram_logic.ram_arrays[i].state[j] == UNINITIALIZED_MEMORY_RECORD) {
                     ramcount += NUMBER_OF_GATES_PER_RAM_ACCESS;
                 }
             }
-            ramcount += (ram_arrays[i].records.size() * NUMBER_OF_GATES_PER_RAM_ACCESS);
+            ramcount += (rom_ram_logic.ram_arrays[i].records.size() * NUMBER_OF_GATES_PER_RAM_ACCESS);
             ramcount += NUMBER_OF_ARITHMETIC_GATES_PER_RAM_ARRAY; // we add an addition gate after procesing a ram array
 
             // there will be 'max_timestamp' number of range checks, need to calculate.
-            const auto max_timestamp = ram_arrays[i].access_count - 1;
+            const auto max_timestamp = rom_ram_logic.ram_arrays[i].access_count - 1;
 
             // if a range check of length `max_timestamp` already exists, we are double counting.
             // We record `ram_timestamps` to detect and correct for this error when we process range lists.
+
             ram_timestamps.push_back(max_timestamp);
             size_t padding = (NUM_WIRES - (max_timestamp % NUM_WIRES)) % NUM_WIRES;
             if (max_timestamp == NUM_WIRES) {
@@ -783,6 +686,10 @@ class UltraCircuitBuilder_ : public CircuitBuilderBase<typename ExecutionTrace_:
         if (this->real_variable_tags[this->real_variable_index[variable_index]] == tag) {
             return;
         }
+
+        if (!(this->real_variable_tags[this->real_variable_index[variable_index]] == DUMMY_TAG)) {
+            return;
+        }
         ASSERT(this->real_variable_tags[this->real_variable_index[variable_index]] == DUMMY_TAG);
         this->real_variable_tags[this->real_variable_index[variable_index]] = tag;
     }
@@ -837,30 +744,23 @@ class UltraCircuitBuilder_ : public CircuitBuilderBase<typename ExecutionTrace_:
      * Memory
      **/
 
-    // size_t create_RAM_array(const size_t array_size);
     size_t create_ROM_array(const size_t array_size);
-
     void set_ROM_element(const size_t rom_id, const size_t index_value, const uint32_t value_witness);
     void set_ROM_element_pair(const size_t rom_id,
                               const size_t index_value,
                               const std::array<uint32_t, 2>& value_witnesses);
+
     uint32_t read_ROM_array(const size_t rom_id, const uint32_t index_witness);
     std::array<uint32_t, 2> read_ROM_array_pair(const size_t rom_id, const uint32_t index_witness);
-    void create_ROM_gate(RomRecord& record);
-    void create_sorted_ROM_gate(RomRecord& record);
-    void process_ROM_array(const size_t rom_id);
-    void process_ROM_arrays();
-
-    void create_RAM_gate(RamRecord& record);
-    void create_sorted_RAM_gate(RamRecord& record);
-    void create_final_sorted_RAM_gate(RamRecord& record, const size_t ram_array_size);
 
     size_t create_RAM_array(const size_t array_size);
     void init_RAM_element(const size_t ram_id, const size_t index_value, const uint32_t value_witness);
+
     uint32_t read_RAM_array(const size_t ram_id, const uint32_t index_witness);
     void write_RAM_array(const size_t ram_id, const uint32_t index_witness, const uint32_t value_witness);
-    void process_RAM_array(const size_t ram_id);
-    void process_RAM_arrays();
+    // note that the process_ROM_array and process_RAM_array methods are controlled by RomRamLogic.
+    // void process_RAM_array(const size_t ram_id);
+    // void process_RAM_arrays();
 
     void create_poseidon2_external_gate(const poseidon2_external_gate_<FF>& in);
     void create_poseidon2_internal_gate(const poseidon2_internal_gate_<FF>& in);

--- a/barretenberg/cpp/src/barretenberg/stdlib_circuit_builders/ultra_circuit_builder.hpp
+++ b/barretenberg/cpp/src/barretenberg/stdlib_circuit_builders/ultra_circuit_builder.hpp
@@ -210,7 +210,6 @@ class UltraCircuitBuilder_ : public CircuitBuilderBase<typename ExecutionTrace_:
     // Stores gate index of RAM writes (required by proving key)
     std::vector<uint32_t> memory_write_records;
     std::map<uint64_t, RangeList> range_lists; // DOCTODO: explain this.
-                                               // Stores gate index of ROM and RAM reads (required by proving key)
 
     // Witnesses that can be in one gate, but that's intentional (used in boomerang catcher)
     std::vector<uint32_t> used_witnesses;
@@ -301,11 +300,7 @@ class UltraCircuitBuilder_ : public CircuitBuilderBase<typename ExecutionTrace_:
 
     bool operator==(const UltraCircuitBuilder_& other) const
     {
-        // // Compare the underlying rom_ram_logic instead of the reference members
-        // if (!(rom_ram_logic == other.rom_ram_logic))
-        //     return false;
 
-        // // Compare all other non-reference members
         return blocks == other.blocks && constant_variable_indices == other.constant_variable_indices &&
                lookup_tables == other.lookup_tables && memory_read_records == other.memory_read_records &&
                memory_write_records == other.memory_write_records && range_lists == other.range_lists &&
@@ -687,9 +682,6 @@ class UltraCircuitBuilder_ : public CircuitBuilderBase<typename ExecutionTrace_:
             return;
         }
 
-        if (!(this->real_variable_tags[this->real_variable_index[variable_index]] == DUMMY_TAG)) {
-            return;
-        }
         ASSERT(this->real_variable_tags[this->real_variable_index[variable_index]] == DUMMY_TAG);
         this->real_variable_tags[this->real_variable_index[variable_index]] = tag;
     }
@@ -758,9 +750,8 @@ class UltraCircuitBuilder_ : public CircuitBuilderBase<typename ExecutionTrace_:
 
     uint32_t read_RAM_array(const size_t ram_id, const uint32_t index_witness);
     void write_RAM_array(const size_t ram_id, const uint32_t index_witness, const uint32_t value_witness);
-    // note that the process_ROM_array and process_RAM_array methods are controlled by RomRamLogic.
-    // void process_RAM_array(const size_t ram_id);
-    // void process_RAM_arrays();
+    // note that the `process_ROM_array` and `process_RAM_array` methods are controlled by `RomRamLogic` and hence are
+    // not present here.
 
     void create_poseidon2_external_gate(const poseidon2_external_gate_<FF>& in);
     void create_poseidon2_internal_gate(const poseidon2_internal_gate_<FF>& in);


### PR DESCRIPTION
This PR splits off the ROM/RAM logic from `ultra_circuit_builder` to its own file, with the hope that this part of the logic will be easier to audit.