### PR TITLE
chore: construct thread ranges as list of active ranges

### DIFF
--- a/barretenberg/cpp/src/barretenberg/honk/execution_trace/execution_trace_usage_tracker.test.cpp
+++ b/barretenberg/cpp/src/barretenberg/honk/execution_trace/execution_trace_usage_tracker.test.cpp
@@ -84,7 +84,7 @@ TEST_F(ExecutionTraceUsageTrackerTest, ConstructThreadRangesSplitsLargeRange)
     std::vector<Range> union_ranges = { { 0, 1 }, { 2, 101 } };
 
     std::vector<std::vector<Range>> expected_thread_ranges = { { { 0, 1 }, { 2, 34 } },
-                                                               { { 34, 66 } },
+                                                               { { 34, 67 } },
                                                                { { 67, 101 } } };
 
     const size_t num_threads = 3;

--- a/barretenberg/cpp/src/barretenberg/honk/execution_trace/execution_trace_usage_tracker.test.cpp
+++ b/barretenberg/cpp/src/barretenberg/honk/execution_trace/execution_trace_usage_tracker.test.cpp
@@ -74,3 +74,22 @@ TEST_F(ExecutionTraceUsageTrackerTest, ConstructThreadRangesMoreThreadsThanWork)
 
     EXPECT_EQ(thread_ranges, expected_thread_ranges);
 }
+
+// Test that a large range is properly split across multiple threads
+TEST_F(ExecutionTraceUsageTrackerTest, ConstructThreadRangesSplitsLargeRange)
+{
+    using Range = ExecutionTraceUsageTracker::Range;
+
+    // Single range that is too large to fit in a single thread
+    std::vector<Range> union_ranges = { { 0, 1 }, { 2, 101 } };
+
+    std::vector<std::vector<Range>> expected_thread_ranges = { { { 0, 1 }, { 2, 34 } },
+                                                               { { 34, 66 } },
+                                                               { { 67, 101 } } };
+
+    const size_t num_threads = 3;
+    std::vector<std::vector<Range>> thread_ranges =
+        ExecutionTraceUsageTracker::construct_ranges_for_equal_content_distribution(union_ranges, num_threads);
+
+    EXPECT_EQ(thread_ranges, expected_thread_ranges);
+}

--- a/barretenberg/cpp/src/barretenberg/honk/execution_trace/execution_trace_usage_tracker.test.cpp
+++ b/barretenberg/cpp/src/barretenberg/honk/execution_trace/execution_trace_usage_tracker.test.cpp
@@ -32,10 +32,44 @@ TEST_F(ExecutionTraceUsageTrackerTest, ConstructThreadRanges)
 
     std::vector<Range> union_ranges = { { 2, 8 }, { 13, 34 }, { 36, 42 }, { 50, 57 } };
 
-    std::vector<Range> expected_thread_ranges = { { 2, 17 }, { 17, 27 }, { 27, 39 }, { 39, 57 } };
+    std::vector<std::vector<Range>> expected_thread_ranges = {
+        { { 2, 8 }, { 13, 17 } }, { { 17, 27 } }, { { 27, 34 }, { 36, 39 } }, { { 39, 42 }, { 50, 57 } }
+    };
 
     const size_t num_threads = 4;
-    std::vector<Range> thread_ranges =
+    std::vector<std::vector<Range>> thread_ranges =
+        ExecutionTraceUsageTracker::construct_ranges_for_equal_content_distribution(union_ranges, num_threads);
+
+    EXPECT_EQ(thread_ranges, expected_thread_ranges);
+}
+
+TEST_F(ExecutionTraceUsageTrackerTest, ConstructThreadRangesNotDivisible)
+{
+    using Range = ExecutionTraceUsageTracker::Range;
+
+    std::vector<Range> union_ranges = { { 2, 8 }, { 13, 34 }, { 36, 42 }, { 50, 60 } };
+
+    std::vector<std::vector<Range>> expected_thread_ranges = {
+        { { 2, 8 }, { 13, 17 } }, { { 17, 27 } }, { { 27, 34 }, { 36, 39 } }, { { 39, 42 }, { 50, 60 } }
+    };
+
+    const size_t num_threads = 4;
+    std::vector<std::vector<Range>> thread_ranges =
+        ExecutionTraceUsageTracker::construct_ranges_for_equal_content_distribution(union_ranges, num_threads);
+
+    EXPECT_EQ(thread_ranges, expected_thread_ranges);
+}
+
+TEST_F(ExecutionTraceUsageTrackerTest, ConstructThreadRangesMoreThreadsThanWork)
+{
+    using Range = ExecutionTraceUsageTracker::Range;
+
+    std::vector<Range> union_ranges = { { 2, 3 }, { 13, 14 } };
+
+    std::vector<std::vector<Range>> expected_thread_ranges = { {}, {}, {}, { { 2, 3 }, { 13, 14 } } };
+
+    const size_t num_threads = 4;
+    std::vector<std::vector<Range>> thread_ranges =
         ExecutionTraceUsageTracker::construct_ranges_for_equal_content_distribution(union_ranges, num_threads);
 
     EXPECT_EQ(thread_ranges, expected_thread_ranges);

--- a/barretenberg/cpp/src/barretenberg/protogalaxy/combiner.test.cpp
+++ b/barretenberg/cpp/src/barretenberg/protogalaxy/combiner.test.cpp
@@ -89,10 +89,8 @@ class PGInternalTest : public ProtogalaxyProverInternal<DeciderProvingKeys_<Flav
             // Construct extended univariates containers; one per thread
             ExtendedUnivariatesTypeNoOptimisticSkipping extended_univariates;
 
-            const size_t start = trace_usage_tracker.thread_ranges[thread_idx].first;
-            const size_t end = trace_usage_tracker.thread_ranges[thread_idx].second;
-            for (size_t idx = start; idx < end; idx++) {
-                if (trace_usage_tracker.check_is_active(idx)) {
+            for (const ExecutionTraceUsageTracker::Range& range : trace_usage_tracker.thread_ranges[thread_idx]) {
+                for (size_t idx = range.first; idx < range.second; idx++) {
                     // Instantiate univariates, possibly with skipping toto ignore computation in those indices (they
                     // are still available for skipping relations, but all derived univariate will ignore those
                     // evaluations) No need to initialise extended_univariates to 0, as it's assigned to.


### PR DESCRIPTION
Before this PR, `construct_ranges_for_equal_content_distribution` only gives a start and end index for each thread. For example:

```
    std::vector<Range> union_ranges = { { 2, 8 }, { 13, 34 }, { 36, 42 }, { 50, 57 } };

    std::vector<Range> expected_thread_ranges = { { 2, 17 }, { 17, 27 }, { 27, 39 }, { 39, 57 } };
```

And then in `compute_row_evaluations` and `compute_combiner`, for each thread range, a loops checks whether each index is in the union_ranges. In the above example, it would call `check_is_active` on indices 2-16 even though we should already know that 8-12 is not active.

This PR makes `construct_ranges_for_equal_content_distribution` return a list of ranges for each thread, each guaranteed to be active. In the above example, the expected ranges will be:
```
{ { { 2, 8 }, { 13, 17 } }, { { 17, 27 } }, { { 27, 34 }, { 36, 39 } }, { { 39, 42 }, { 50, 57 } } };
```

Now we can eliminate the `check_is_active` calls because we only iterate on the active ranges.

See https://github.com/AztecProtocol/barretenberg/issues/1195 for previous profiling results.