### PR TITLE
chore: Don't publish txs with block proposals

### DIFF
--- a/spartan/terraform/gke-cluster/snapshots.tf
+++ b/spartan/terraform/gke-cluster/snapshots.tf
@@ -53,7 +53,7 @@ resource "google_storage_bucket_object" "alpha_testnet_json" {
     version = "0.87.9"
     config = {
       maxTxsPerBlock            = 8
-      publishTxsWithProposals   = true
+      publishTxsWithProposals   = false
       governanceProposerPayload = "0x0000000000000000000000000000000000000000"
     }
   })


### PR DESCRIPTION
This PR simply updates the testnet config to not publish transactions with proposals