### PR TITLE
chore: remove separate governance storage on registry

### DIFF
--- a/l1-contracts/src/governance/Registry.sol
+++ b/l1-contracts/src/governance/Registry.sol
@@ -11,7 +11,6 @@ import {RewardDistributor, IRewardDistributor} from "./RewardDistributor.sol";
 struct RegistryStorage {
   mapping(uint256 version => IHaveVersion rollup) versionToRollup;
   uint256[] versions;
-  address governance;
   IRewardDistributor rewardDistributor;
 }
 
@@ -39,11 +38,6 @@ contract Registry is IRegistry, Ownable {
     $.versions.push(version);
 
     emit InstanceAdded(address(_rollup), version);
-  }
-
-  function updateGovernance(address _governance) external override(IRegistry) onlyOwner {
-    $.governance = _governance;
-    emit GovernanceUpdated(_governance);
   }
 
   function updateRewardDistributor(address _rewardDistributor)
@@ -83,7 +77,7 @@ contract Registry is IRegistry, Ownable {
    * @return The governance address
    */
   function getGovernance() external view override(IRegistry) returns (address) {
-    return $.governance;
+    return this.owner();
   }
 
   function getRewardDistributor() external view override(IRegistry) returns (IRewardDistributor) {

--- a/l1-contracts/src/governance/Registry.sol
+++ b/l1-contracts/src/governance/Registry.sol
@@ -77,7 +77,7 @@ contract Registry is IRegistry, Ownable {
    * @return The governance address
    */
   function getGovernance() external view override(IRegistry) returns (address) {
-    return this.owner();
+    return owner();
   }
 
   function getRewardDistributor() external view override(IRegistry) returns (IRewardDistributor) {

--- a/l1-contracts/src/governance/interfaces/IRegistry.sol
+++ b/l1-contracts/src/governance/interfaces/IRegistry.sol
@@ -9,11 +9,9 @@ interface IHaveVersion {
 
 interface IRegistry {
   event InstanceAdded(address indexed instance, uint256 indexed version);
-  event GovernanceUpdated(address indexed governance);
   event RewardDistributorUpdated(address indexed rewardDistributor);
 
   function addRollup(IHaveVersion _rollup) external;
-  function updateGovernance(address _governance) external;
   function updateRewardDistributor(address _rewardDistributor) external;
 
   // docs:start:registry_get_canonical_rollup

--- a/l1-contracts/test/builder/GseBuilder.sol
+++ b/l1-contracts/test/builder/GseBuilder.sol
@@ -101,7 +101,6 @@ contract GSEBuilder is TestBase {
     }
 
     vm.startPrank(config.registry.owner());
-    config.registry.updateGovernance(address(config.governance));
     config.registry.transferOwnership(address(config.governance));
     vm.stopPrank();
 

--- a/l1-contracts/test/governance/governance-proposer/Base.t.sol
+++ b/l1-contracts/test/governance/governance-proposer/Base.t.sol
@@ -43,7 +43,6 @@ contract GovernanceProposerBase is Test {
     governanceProposer = new GovernanceProposer(registry, IGSE(address(0x03)), 667, 1000);
     governance = new FakeGovernance(address(governanceProposer));
 
-    registry.updateGovernance(address(governance));
     registry.transferOwnership(address(governance));
 
     RollupBuilder builder = new RollupBuilder(address(this));

--- a/l1-contracts/test/governance/scenario/AddRollup.t.sol
+++ b/l1-contracts/test/governance/scenario/AddRollup.t.sol
@@ -96,7 +96,6 @@ contract AddRollupTest is TestBase {
     token.mint(address(multiAdder), rollup.getDepositAmount() * VALIDATOR_COUNT);
     multiAdder.addValidators(initialValidators);
 
-    registry.updateGovernance(address(governance));
     registry.transferOwnership(address(governance));
   }
 

--- a/l1-contracts/test/governance/scenario/UpgradeGovernanceProposerTest.t.sol
+++ b/l1-contracts/test/governance/scenario/UpgradeGovernanceProposerTest.t.sol
@@ -73,7 +73,6 @@ contract UpgradeGovernanceProposerTest is TestBase {
     governanceProposer = GovernanceProposer(governance.governanceProposer());
     gse = IGSE(address(rollup.getGSE()));
 
-    registry.updateGovernance(address(governance));
     registry.transferOwnership(address(governance));
 
     timeCheater = new TimeCheater(

--- a/yarn-project/end-to-end/src/composed/e2e_token_bridge_tutorial_test.test.ts
+++ b/yarn-project/end-to-end/src/composed/e2e_token_bridge_tutorial_test.test.ts
@@ -220,5 +220,5 @@ describe('e2e_cross_chain_messaging token_bridge_tutorial_test', () => {
     logger.info(`New L1 balance of ${ownerEthAddress} is ${newL1Balance}`);
     // docs:end:l1-withdraw
     expect(newL1Balance).toBe(withdrawAmount);
-  }, 60000);
+  }, 90000);
 });

--- a/yarn-project/end-to-end/src/e2e_epochs/epochs_proof_fails.test.ts
+++ b/yarn-project/end-to-end/src/e2e_epochs/epochs_proof_fails.test.ts
@@ -32,7 +32,7 @@ describe('e2e_epochs/epochs_proof_fails', () => {
   let test: EpochsTestContext;
 
   beforeEach(async () => {
-    test = await EpochsTestContext.setup();
+    test = await EpochsTestContext.setup({ aztecEpochDuration: 5 });
     ({ proverDelayer, sequencerDelayer, context, l1Client, rollup, constants, logger, monitor } = test);
     ({ L1_BLOCK_TIME_IN_S, L2_SLOT_DURATION_IN_S } = test);
   });
@@ -68,7 +68,7 @@ describe('e2e_epochs/epochs_proof_fails', () => {
     // Next sequencer to publish a block should trigger a rollback to block 1
     await waitUntilL1Timestamp(l1Client, epoch2Start + BigInt(L1_BLOCK_TIME_IN_S));
     expect(await rollup.getBlockNumber()).toEqual(1n);
-    expect(await rollup.getSlotNumber()).toEqual(8n);
+    expect(await rollup.getSlotNumber()).toEqual(BigInt(2 * test.epochDuration));
 
     // The prover tx should have been rejected, and mined strictly before the one that triggered the rollback
     const lastProverTxHash = proverDelayer.getSentTxHashes().at(-1);

--- a/yarn-project/end-to-end/src/e2e_epochs/epochs_proof_fails.test.ts
+++ b/yarn-project/end-to-end/src/e2e_epochs/epochs_proof_fails.test.ts
@@ -32,6 +32,8 @@ describe('e2e_epochs/epochs_proof_fails', () => {
   let test: EpochsTestContext;
 
   beforeEach(async () => {
+    // Bumping the epoch duration to 5 because otherwise it takes a full epoch before the actual test starts,
+    // which means the prover node is attempting to prove before we setup the mocks.
     test = await EpochsTestContext.setup({ aztecEpochDuration: 5 });
     ({ proverDelayer, sequencerDelayer, context, l1Client, rollup, constants, logger, monitor } = test);
     ({ L1_BLOCK_TIME_IN_S, L2_SLOT_DURATION_IN_S } = test);

--- a/yarn-project/end-to-end/src/e2e_p2p/add_rollup.test.ts
+++ b/yarn-project/end-to-end/src/e2e_p2p/add_rollup.test.ts
@@ -139,26 +139,6 @@ describe('e2e_p2p_add_rollup', () => {
     );
     await t.ctx.cheatCodes.eth.warp(Number(nextRoundTimestamp));
 
-    // Hand over the registry to the governance
-    await l1TxUtils.sendAndMonitorTransaction({
-      to: registry.address,
-      data: encodeFunctionData({
-        abi: RegistryAbi,
-        functionName: 'transferOwnership',
-        args: [governance.address],
-      }),
-    });
-
-    // Hand over the GSE to the governance
-    await l1TxUtils.sendAndMonitorTransaction({
-      to: getAddress(t.ctx.deployL1ContractsValues.l1ContractAddresses.gseAddress!.toString()),
-      data: encodeFunctionData({
-        abi: RegistryAbi,
-        functionName: 'transferOwnership',
-        args: [governance.address],
-      }),
-    });
-
     // Now that we have passed on the registry, we can deploy the new rollup.
     const initialTestAccounts = await getInitialTestAccounts();
     const { genesisArchiveRoot, fundingNeeded, prefilledPublicData } = await getGenesisValues(

--- a/yarn-project/ethereum/src/contracts/registry.test.ts
+++ b/yarn-project/ethereum/src/contracts/registry.test.ts
@@ -1,8 +1,11 @@
+import { EthAddress } from '@aztec/foundation/eth-address';
 import { Fr } from '@aztec/foundation/fields';
 import { type Logger, createLogger } from '@aztec/foundation/log';
+import { RegistryAbi } from '@aztec/l1-artifacts/RegistryAbi';
 
 import type { Anvil } from '@viem/anvil';
 import omit from 'lodash.omit';
+import { createPublicClient, getContract, http } from 'viem';
 import { type PrivateKeyAccount, privateKeyToAccount } from 'viem/accounts';
 import { foundry } from 'viem/chains';
 
@@ -11,6 +14,7 @@ import { DefaultL1ContractsConfig } from '../config.js';
 import { L1Deployer, deployL1Contracts, deployRollup } from '../deploy_l1_contracts.js';
 import type { L1ContractAddresses } from '../l1_contract_addresses.js';
 import { defaultL1TxUtilsConfig } from '../l1_tx_utils.js';
+import { EthCheatCodes } from '../test/eth_cheat_codes.js';
 import { startAnvil } from '../test/start_anvil.js';
 import type { ExtendedViemWalletClient } from '../types.js';
 import { RegistryContract } from './registry.js';
@@ -30,6 +34,7 @@ describe('Registry', () => {
   let registry: RegistryContract;
   let deployedAddresses: L1ContractAddresses;
   let deployedVersion: number;
+  let ethCheatCodes: EthCheatCodes;
 
   beforeAll(async () => {
     logger = createLogger('ethereum:test:registry');
@@ -62,6 +67,9 @@ describe('Registry', () => {
 
     const rollup = new RollupContract(l1Client, deployedAddresses.rollupAddress);
     deployedVersion = Number(await rollup.getVersion());
+
+    ethCheatCodes = new EthCheatCodes([rpcUrl]);
+    await ethCheatCodes.setBalance(deployedAddresses.governanceAddress, 1000000000000000000000000000000000000000n);
   });
 
   afterAll(async () => {
@@ -113,6 +121,9 @@ describe('Registry', () => {
 
     const deployer = new L1Deployer(l1Client, newVersionSalt, undefined, logger, defaultL1TxUtilsConfig);
 
+    // We need to steal ownership of the registry to add a rollup without going through governance
+    await setRegistryOwnership(EthAddress.fromString(deployer.client.account.address));
+
     const { rollup: newRollup } = await deployRollup(
       l1Client,
       deployer,
@@ -127,6 +138,9 @@ describe('Registry', () => {
       deployedAddresses,
       logger,
     );
+
+    // We need to return ownership of the registry to the governance address to collect the addresses
+    await setRegistryOwnership(deployedAddresses.governanceAddress);
 
     const newAddresses = await newRollup.getRollupAddresses();
 
@@ -149,4 +163,22 @@ describe('Registry', () => {
       RegistryContract.collectAddresses(l1Client, deployedAddresses.registryAddress, deployedVersion),
     ).resolves.toEqual(deployedAddresses);
   });
+
+  async function setRegistryOwnership(address: EthAddress) {
+    const owner = await registry.getOwner();
+    await ethCheatCodes.startImpersonating(owner);
+    await l1Client.waitForTransactionReceipt({
+      hash: await getContract({
+        address: deployedAddresses.registryAddress.toString(),
+        abi: RegistryAbi,
+        client: createPublicClient({
+          chain: foundry,
+          transport: http(),
+        }),
+      }).write.transferOwnership([address.toString()], {
+        account: owner.toString(),
+      }),
+    });
+    await ethCheatCodes.stopImpersonating(owner);
+  }
 });

--- a/yarn-project/ethereum/src/contracts/registry.test.ts
+++ b/yarn-project/ethereum/src/contracts/registry.test.ts
@@ -69,7 +69,7 @@ describe('Registry', () => {
     deployedVersion = Number(await rollup.getVersion());
 
     ethCheatCodes = new EthCheatCodes([rpcUrl]);
-    await ethCheatCodes.setBalance(deployedAddresses.governanceAddress, 1000000000000000000000000000000000000000n);
+    await ethCheatCodes.setBalance(deployedAddresses.governanceAddress, 10n ** 18n);
   });
 
   afterAll(async () => {

--- a/yarn-project/ethereum/src/contracts/registry.ts
+++ b/yarn-project/ethereum/src/contracts/registry.ts
@@ -27,6 +27,10 @@ export class RegistryContract {
     this.registry = getContract({ address, abi: RegistryAbi, client });
   }
 
+  public async getOwner(): Promise<EthAddress> {
+    return EthAddress.fromString(await this.registry.read.owner());
+  }
+
   /**
    * Returns the address of the rollup for a given version.
    * @param version - The version of the rollup. 'canonical' can be used to get the canonical address (i.e. the latest version).

--- a/yarn-project/ethereum/src/deploy_l1_contracts.ts
+++ b/yarn-project/ethereum/src/deploy_l1_contracts.ts
@@ -406,7 +406,7 @@ export const deploySharedContracts = async (
     to: registryAddress.toString(),
     data: encodeFunctionData({
       abi: l1Artifacts.registry.contractAbi,
-      functionName: 'updateGovernance',
+      functionName: 'transferOwnership',
       args: [governanceAddress.toString()],
     }),
   });

--- a/yarn-project/sequencer-client/src/sequencer/sequencer.ts
+++ b/yarn-project/sequencer-client/src/sequencer/sequencer.ts
@@ -234,7 +234,7 @@ export class Sequencer extends (EventEmitter as new () => TypedEventEmitter<Sequ
    * Stops the sequencer from processing txs and moves to STOPPED state.
    */
   public async stop(): Promise<void> {
-    this.log.debug(`Stopping sequencer`);
+    this.log.info(`Stopping sequencer`);
     this.metrics.stop();
     await this.validatorClient?.stop();
     await this.runningPromise?.stop();


### PR DESCRIPTION
Remove the separate `governance` reference from the storage of the registry contract, as the owner should just be governance.

Now when we deploy contracts, we deploy all shared contracts, then deploy the rollup and add it to the registry, then transfer ownership of the registry to governance.