### PR TITLE
chore: simplify trace poly population methods

### DIFF
--- a/barretenberg/cpp/src/barretenberg/circuit_checker/ultra_circuit_checker.cpp
+++ b/barretenberg/cpp/src/barretenberg/circuit_checker/ultra_circuit_checker.cpp
@@ -253,10 +253,11 @@ void UltraCircuitChecker::populate_values(
     values.w_o = builder.get_variable(block.w_o()[idx]);
     // Note: memory_data contains indices into the block to which RAM/ROM gates were added so we need to check that
     // we are indexing into the correct block before updating the w_4 value.
-    if (block.has_ram_rom && memory_data.read_record_gates.contains(idx)) {
+    const bool is_ram_rom_block = (&block == &builder.blocks.aux);
+    if (is_ram_rom_block && memory_data.read_record_gates.contains(idx)) {
         values.w_4 = compute_memory_record_term(
             values.w_l, values.w_r, values.w_o, memory_data.eta, memory_data.eta_two, memory_data.eta_three);
-    } else if (block.has_ram_rom && memory_data.write_record_gates.contains(idx)) {
+    } else if (is_ram_rom_block && memory_data.write_record_gates.contains(idx)) {
         values.w_4 =
             compute_memory_record_term(
                 values.w_l, values.w_r, values.w_o, memory_data.eta, memory_data.eta_two, memory_data.eta_three) +
@@ -270,14 +271,14 @@ void UltraCircuitChecker::populate_values(
         values.w_l_shift = builder.get_variable(block.w_l()[idx + 1]);
         values.w_r_shift = builder.get_variable(block.w_r()[idx + 1]);
         values.w_o_shift = builder.get_variable(block.w_o()[idx + 1]);
-        if (block.has_ram_rom && memory_data.read_record_gates.contains(idx + 1)) {
+        if (is_ram_rom_block && memory_data.read_record_gates.contains(idx + 1)) {
             values.w_4_shift = compute_memory_record_term(values.w_l_shift,
                                                           values.w_r_shift,
                                                           values.w_o_shift,
                                                           memory_data.eta,
                                                           memory_data.eta_two,
                                                           memory_data.eta_three);
-        } else if (block.has_ram_rom && memory_data.write_record_gates.contains(idx + 1)) {
+        } else if (is_ram_rom_block && memory_data.write_record_gates.contains(idx + 1)) {
             values.w_4_shift = compute_memory_record_term(values.w_l_shift,
                                                           values.w_r_shift,
                                                           values.w_o_shift,

--- a/barretenberg/cpp/src/barretenberg/dsl/acir_format/ivc_recursion_constraint.cpp
+++ b/barretenberg/cpp/src/barretenberg/dsl/acir_format/ivc_recursion_constraint.cpp
@@ -104,7 +104,7 @@ ClientIVC::VerifierInputs create_mock_verification_queue_entry(const ClientIVC::
     blocks.set_fixed_block_sizes(trace_settings);
     blocks.compute_offsets(/*is_structured=*/true);
     size_t dyadic_size = blocks.get_structured_dyadic_size();
-    size_t pub_inputs_offset = blocks.pub_inputs.trace_offset;
+    size_t pub_inputs_offset = blocks.pub_inputs.trace_offset();
     // All circuits have pairing point public inputs; kernels have additional public inputs for two databus commitments
     size_t num_public_inputs = bb::PAIRING_POINTS_SIZE;
     if (is_kernel) {

--- a/barretenberg/cpp/src/barretenberg/honk/composer/composer_lib.hpp
+++ b/barretenberg/cpp/src/barretenberg/honk/composer/composer_lib.hpp
@@ -30,7 +30,7 @@ void construct_lookup_table_polynomials(const RefArray<typename Flavor::Polynomi
     // TODO(https://github.com/AztecProtocol/barretenberg/issues/1033): construct tables and counts at top of trace
     const size_t tables_size = circuit.get_tables_size();
     ASSERT(dyadic_circuit_size > tables_size + additional_offset);
-    size_t offset = circuit.blocks.lookup.trace_offset;
+    size_t offset = circuit.blocks.lookup.trace_offset();
 
     for (const auto& table : circuit.lookup_tables) {
         const fr table_index(table.table_index);
@@ -59,7 +59,7 @@ void construct_lookup_read_counts(typename Flavor::Polynomial& read_counts,
                                   [[maybe_unused]] const size_t dyadic_circuit_size)
 {
     // TODO(https://github.com/AztecProtocol/barretenberg/issues/1033): construct tables and counts at top of trace
-    size_t table_offset = circuit.blocks.lookup.trace_offset;
+    size_t table_offset = circuit.blocks.lookup.trace_offset();
 
     // loop over all tables used in the circuit; each table contains data about the lookups made on it
     for (auto& table : circuit.lookup_tables) {

--- a/barretenberg/cpp/src/barretenberg/honk/composer/composer_lib.test.cpp
+++ b/barretenberg/cpp/src/barretenberg/honk/composer/composer_lib.test.cpp
@@ -52,10 +52,10 @@ TEST_F(ComposerLibTests, LookupReadCounts)
     Polynomial read_counts{ circuit_size };
     Polynomial read_tags{ circuit_size };
 
+    builder.blocks.compute_offsets(/*is_structured=*/false);
     construct_lookup_read_counts<Flavor>(read_counts, read_tags, builder, circuit_size);
 
-    // The table polys are constructed at the bottom of the trace, thus so to are the counts/tags
-    // TODO(https://github.com/AztecProtocol/barretenberg/issues/1033): construct tables and counts at top of trace
+    // The table polys are constructed at the start of the lookup gates block, thus so to are the counts/tags
     size_t offset = builder.blocks.lookup.trace_offset();
 
     // The uint32 XOR lookup table is constructed for 6 bit operands via double for loop that iterates through the left

--- a/barretenberg/cpp/src/barretenberg/honk/composer/composer_lib.test.cpp
+++ b/barretenberg/cpp/src/barretenberg/honk/composer/composer_lib.test.cpp
@@ -56,7 +56,7 @@ TEST_F(ComposerLibTests, LookupReadCounts)
 
     // The table polys are constructed at the bottom of the trace, thus so to are the counts/tags
     // TODO(https://github.com/AztecProtocol/barretenberg/issues/1033): construct tables and counts at top of trace
-    size_t offset = builder.blocks.lookup.trace_offset;
+    size_t offset = builder.blocks.lookup.trace_offset();
 
     // The uint32 XOR lookup table is constructed for 6 bit operands via double for loop that iterates through the left
     // operand externally (0 to 63) then the right operand internally (0 to 63). Computing (1 XOR 5) will thus result in

--- a/barretenberg/cpp/src/barretenberg/honk/execution_trace/execution_trace_block.hpp
+++ b/barretenberg/cpp/src/barretenberg/honk/execution_trace/execution_trace_block.hpp
@@ -69,9 +69,13 @@ template <typename FF, size_t NUM_WIRES_, size_t NUM_SELECTORS_> class Execution
 
     Wires wires; // vectors of indices into a witness variables array
     Selectors selectors;
-    bool has_ram_rom = false;   // does the block contain RAM/ROM gates
-    bool is_pub_inputs = false; // is this the public inputs block
-    uint32_t trace_offset = 0;  // where this block starts in the trace
+    uint32_t trace_offset_ = std::numeric_limits<uint32_t>::max(); // where this block starts in the trace
+
+    uint32_t trace_offset() const
+    {
+        ASSERT(trace_offset_ != std::numeric_limits<uint32_t>::max());
+        return trace_offset_;
+    }
 
     bool operator==(const ExecutionTraceBlock& other) const = default;
 

--- a/barretenberg/cpp/src/barretenberg/honk/execution_trace/execution_trace_usage_tracker.hpp
+++ b/barretenberg/cpp/src/barretenberg/honk/execution_trace/execution_trace_usage_tracker.hpp
@@ -92,7 +92,7 @@ struct ExecutionTraceUsageTracker {
         previous_active_ranges = active_ranges; // store active ranges based on all but the present circuit
         active_ranges.clear();
         for (auto [max_size, fixed_block] : zip_view(max_sizes.get(), fixed_sizes.get())) {
-            size_t start_idx = fixed_block.trace_offset;
+            size_t start_idx = fixed_block.trace_offset();
             size_t end_idx = start_idx + max_size;
             active_ranges.push_back(Range{ start_idx, end_idx });
         }
@@ -105,9 +105,9 @@ struct ExecutionTraceUsageTracker {
         // max_databus_size } but this breaks for certain choices of num_threads. It should also be possible to have the
         // lookup table data be Range{lookup_start, max_tables_size} but that also breaks.
         size_t databus_end =
-            std::max(max_databus_size, static_cast<size_t>(fixed_sizes.busread.trace_offset + max_sizes.busread));
+            std::max(max_databus_size, static_cast<size_t>(fixed_sizes.busread.trace_offset() + max_sizes.busread));
         active_ranges.push_back(Range{ 0, databus_end });
-        size_t lookups_start = fixed_sizes.lookup.trace_offset;
+        size_t lookups_start = fixed_sizes.lookup.trace_offset();
         size_t lookups_end = lookups_start + std::max(max_tables_size, static_cast<size_t>(max_sizes.lookup));
         active_ranges.emplace_back(Range{ lookups_start, lookups_end });
     }

--- a/barretenberg/cpp/src/barretenberg/honk/execution_trace/mega_execution_trace.hpp
+++ b/barretenberg/cpp/src/barretenberg/honk/execution_trace/mega_execution_trace.hpp
@@ -177,11 +177,7 @@ class MegaExecutionTraceBlocks : public MegaTraceBlockData<MegaTraceBlock> {
 
     bool has_overflow = false; // indicates whether the overflow block has non-zero fixed or actual size
 
-    MegaExecutionTraceBlocks()
-    {
-        this->aux.has_ram_rom = true;
-        this->pub_inputs.is_pub_inputs = true;
-    }
+    MegaExecutionTraceBlocks() = default;
 
     void set_fixed_block_sizes(const TraceSettings& settings)
     {
@@ -198,7 +194,7 @@ class MegaExecutionTraceBlocks : public MegaTraceBlockData<MegaTraceBlock> {
     {
         uint32_t offset = 1; // start at 1 because the 0th row is unused for selectors for Honk
         for (auto& block : this->get()) {
-            block.trace_offset = offset;
+            block.trace_offset_ = offset;
             offset += block.get_fixed_size(is_structured);
         }
     }

--- a/barretenberg/cpp/src/barretenberg/honk/execution_trace/ultra_execution_trace.hpp
+++ b/barretenberg/cpp/src/barretenberg/honk/execution_trace/ultra_execution_trace.hpp
@@ -104,11 +104,7 @@ class UltraExecutionTraceBlocks : public UltraTraceBlockData<UltraTraceBlock> {
 
     bool has_overflow = false;
 
-    UltraExecutionTraceBlocks()
-    {
-        this->aux.has_ram_rom = true;
-        this->pub_inputs.is_pub_inputs = true;
-    }
+    UltraExecutionTraceBlocks() = default;
 
     void compute_offsets(bool is_structured)
     {
@@ -118,7 +114,7 @@ class UltraExecutionTraceBlocks : public UltraTraceBlockData<UltraTraceBlock> {
         }
         uint32_t offset = 1; // start at 1 because the 0th row is unused for selectors for Honk
         for (auto& block : this->get()) {
-            block.trace_offset = offset;
+            block.trace_offset_ = offset;
             offset += block.get_fixed_size(is_structured);
         }
     }

--- a/barretenberg/cpp/src/barretenberg/stdlib/primitives/field/field.test.cpp
+++ b/barretenberg/cpp/src/barretenberg/stdlib/primitives/field/field.test.cpp
@@ -1058,25 +1058,25 @@ template <typename Builder> class stdlib_field : public testing::Test {
         }
     }
 
-    static void test_pow_exponent_out_of_range()
-    {
-        Builder builder = Builder();
+    //     static void test_pow_exponent_out_of_range()
+    //     {
+    //         Builder builder = Builder();
 
-        fr base_val(engine.get_random_uint256());
-        uint64_t exponent_val = engine.get_random_uint32();
-        exponent_val += (uint64_t(1) << 32);
+    //         fr base_val(engine.get_random_uint256());
+    //         uint64_t exponent_val = engine.get_random_uint32();
+    //         exponent_val += (uint64_t(1) << 32);
 
-        field_ct base = witness_ct(&builder, base_val);
-        field_ct exponent = witness_ct(&builder, exponent_val);
-#ifndef NDEBUG
-        EXPECT_DEATH(base.pow(exponent), "Assertion failed: \\(exponent_value.get_msb\\(\\) < 32\\)");
-#endif
+    //         field_ct base = witness_ct(&builder, base_val);
+    //         field_ct exponent = witness_ct(&builder, exponent_val);
+    // #ifndef NDEBUG
+    //         EXPECT_DEATH(base.pow(exponent), "Assertion failed: \\(exponent_value.get_msb\\(\\) < 32\\)");
+    // #endif
 
-        exponent = field_ct(exponent_val);
-#ifndef NDEBUG
-        EXPECT_DEATH(base.pow(exponent), "Assertion failed: \\(exponent_value.get_msb\\(\\) < 32\\)");
-#endif
-    };
+    //         exponent = field_ct(exponent_val);
+    // #ifndef NDEBUG
+    //         EXPECT_DEATH(base.pow(exponent), "Assertion failed: \\(exponent_value.get_msb\\(\\) < 32\\)");
+    // #endif
+    //     };
 
     static void test_copy_as_new_witness()
     {
@@ -1542,10 +1542,10 @@ TYPED_TEST(stdlib_field, test_pow)
 {
     TestFixture::test_pow();
 }
-TYPED_TEST(stdlib_field, test_pow_exponent_out_of_range)
-{
-    TestFixture::test_pow_exponent_out_of_range();
-}
+// TYPED_TEST(stdlib_field, test_pow_exponent_out_of_range)
+// {
+//     TestFixture::test_pow_exponent_out_of_range();
+// }
 TYPED_TEST(stdlib_field, test_prefix_increment)
 {
     TestFixture::test_prefix_increment();

--- a/barretenberg/cpp/src/barretenberg/stdlib/primitives/field/field.test.cpp
+++ b/barretenberg/cpp/src/barretenberg/stdlib/primitives/field/field.test.cpp
@@ -1058,25 +1058,25 @@ template <typename Builder> class stdlib_field : public testing::Test {
         }
     }
 
-    //     static void test_pow_exponent_out_of_range()
-    //     {
-    //         Builder builder = Builder();
+    static void test_pow_exponent_out_of_range()
+    {
+        Builder builder = Builder();
 
-    //         fr base_val(engine.get_random_uint256());
-    //         uint64_t exponent_val = engine.get_random_uint32();
-    //         exponent_val += (uint64_t(1) << 32);
+        fr base_val(engine.get_random_uint256());
+        uint64_t exponent_val = engine.get_random_uint32();
+        exponent_val += (uint64_t(1) << 32);
 
-    //         field_ct base = witness_ct(&builder, base_val);
-    //         field_ct exponent = witness_ct(&builder, exponent_val);
-    // #ifndef NDEBUG
-    //         EXPECT_DEATH(base.pow(exponent), "Assertion failed: \\(exponent_value.get_msb\\(\\) < 32\\)");
-    // #endif
+        field_ct base = witness_ct(&builder, base_val);
+        field_ct exponent = witness_ct(&builder, exponent_val);
+#ifndef NDEBUG
+        EXPECT_DEATH(base.pow(exponent), "Assertion failed: \\(exponent_value.get_msb\\(\\) < 32\\)");
+#endif
 
-    //         exponent = field_ct(exponent_val);
-    // #ifndef NDEBUG
-    //         EXPECT_DEATH(base.pow(exponent), "Assertion failed: \\(exponent_value.get_msb\\(\\) < 32\\)");
-    // #endif
-    //     };
+        exponent = field_ct(exponent_val);
+#ifndef NDEBUG
+        EXPECT_DEATH(base.pow(exponent), "Assertion failed: \\(exponent_value.get_msb\\(\\) < 32\\)");
+#endif
+    };
 
     static void test_copy_as_new_witness()
     {
@@ -1542,10 +1542,10 @@ TYPED_TEST(stdlib_field, test_pow)
 {
     TestFixture::test_pow();
 }
-// TYPED_TEST(stdlib_field, test_pow_exponent_out_of_range)
-// {
-//     TestFixture::test_pow_exponent_out_of_range();
-// }
+TYPED_TEST(stdlib_field, test_pow_exponent_out_of_range)
+{
+    TestFixture::test_pow_exponent_out_of_range();
+}
 TYPED_TEST(stdlib_field, test_prefix_increment)
 {
     TestFixture::test_prefix_increment();

--- a/barretenberg/cpp/src/barretenberg/trace_to_polynomials/trace_to_polynomials.cpp
+++ b/barretenberg/cpp/src/barretenberg/trace_to_polynomials/trace_to_polynomials.cpp
@@ -27,18 +27,15 @@ void TraceToPolynomials<Flavor>::populate(Builder& builder,
     // data
     auto trace_data = construct_trace_data(builder, proving_key, is_structured);
 
-    if constexpr (IsUltraOrMegaHonk<Flavor>) {
-        proving_key.pub_inputs_offset = trace_data.pub_inputs_offset;
-    }
-    if constexpr (IsUltraOrMegaHonk<Flavor>) {
+    proving_key.pub_inputs_offset = trace_data.pub_inputs_offset;
 
+    {
         PROFILE_THIS_NAME("add_memory_records_to_proving_key");
 
         add_memory_records_to_proving_key(trace_data, builder, proving_key);
     }
 
     if constexpr (IsMegaFlavor<Flavor>) {
-
         PROFILE_THIS_NAME("add_ecc_op_wires_to_proving_key");
 
         add_ecc_op_wires_to_proving_key(builder, proving_key);
@@ -46,7 +43,6 @@ void TraceToPolynomials<Flavor>::populate(Builder& builder,
 
     // Compute the permutation argument polynomials (sigma/id) and add them to proving key
     {
-
         PROFILE_THIS_NAME("compute_permutation_argument_polynomials");
 
         compute_permutation_argument_polynomials<Flavor>(builder, &proving_key, trace_data.copy_cycles);

--- a/barretenberg/cpp/src/barretenberg/trace_to_polynomials/trace_to_polynomials.hpp
+++ b/barretenberg/cpp/src/barretenberg/trace_to_polynomials/trace_to_polynomials.hpp
@@ -35,34 +35,14 @@ template <class Flavor> class TraceToPolynomials {
 
         TraceData(Builder& builder, ProvingKey& proving_key)
         {
-
             PROFILE_THIS_NAME("TraceData constructor");
 
-            if constexpr (IsUltraOrMegaHonk<Flavor>) {
-                // Initialize and share the wire and selector polynomials
-                for (auto [wire, other_wire] : zip_view(wires, proving_key.polynomials.get_wires())) {
-                    wire = other_wire.share();
-                }
-                for (auto [selector, other_selector] : zip_view(selectors, proving_key.polynomials.get_selectors())) {
-                    selector = other_selector.share();
-                }
-            } else {
-                // Initialize and share the wire and selector polynomials
-                for (size_t idx = 0; idx < NUM_WIRES; ++idx) {
-                    wires[idx] = Polynomial(proving_key.circuit_size);
-                    std::string wire_tag = "w_" + std::to_string(idx + 1) + "_lagrange";
-                    proving_key.polynomial_store.put(wire_tag, wires[idx].share());
-                }
-                {
-
-                    PROFILE_THIS_NAME("selector initialization");
-
-                    for (size_t idx = 0; idx < Builder::ExecutionTrace::NUM_SELECTORS; ++idx) {
-                        selectors[idx] = Polynomial(proving_key.circuit_size);
-                        std::string selector_tag = builder.selector_names[idx] + "_lagrange";
-                        proving_key.polynomial_store.put(selector_tag, selectors[idx].share());
-                    }
-                }
+            // Initialize and share the wire and selector polynomials
+            for (auto [wire, other_wire] : zip_view(wires, proving_key.polynomials.get_wires())) {
+                wire = other_wire.share();
+            }
+            for (auto [selector, other_selector] : zip_view(selectors, proving_key.polynomials.get_selectors())) {
+                selector = other_selector.share();
             }
             {
                 PROFILE_THIS_NAME("copy cycle initialization");

--- a/barretenberg/cpp/src/barretenberg/trace_to_polynomials/trace_to_polynomials.hpp
+++ b/barretenberg/cpp/src/barretenberg/trace_to_polynomials/trace_to_polynomials.hpp
@@ -25,6 +25,7 @@ template <class Flavor> class TraceToPolynomials {
 
     static constexpr size_t NUM_SELECTORS = Builder::ExecutionTrace::NUM_SELECTORS;
 
+    // WORKTODO: get rid of this struct altogether
     struct TraceData {
         std::array<Polynomial, NUM_WIRES> wires;
         std::array<Polynomial, NUM_SELECTORS> selectors;

--- a/barretenberg/cpp/src/barretenberg/trace_to_polynomials/trace_to_polynomials.hpp
+++ b/barretenberg/cpp/src/barretenberg/trace_to_polynomials/trace_to_polynomials.hpp
@@ -30,8 +30,6 @@ template <class Flavor> class TraceToPolynomials {
         std::array<Polynomial, NUM_SELECTORS> selectors;
         // A vector of sets (vectors) of addresses into the wire polynomials whose values are copy constrained
         std::vector<CyclicPermutation> copy_cycles;
-        uint32_t ram_rom_offset = 0;    // offset of the RAM/ROM block in the execution trace
-        uint32_t pub_inputs_offset = 0; // offset of the public inputs block in the execution trace
 
         TraceData(Builder& builder, ProvingKey& proving_key)
         {
@@ -63,7 +61,7 @@ template <class Flavor> class TraceToPolynomials {
      * @param builder
      * @param is_structured whether or not the trace is to be structured with a fixed block size
      */
-    static void populate(Builder& builder, ProvingKey&, bool is_structured = false);
+    static void populate(Builder& builder, ProvingKey&);
 
   private:
     /**
@@ -78,10 +76,7 @@ template <class Flavor> class TraceToPolynomials {
      * @param builder
      * @param proving_key
      */
-    static void add_memory_records_to_proving_key(TraceData& trace_data,
-                                                  Builder& builder,
-                                                  typename Flavor::ProvingKey& proving_key)
-        requires IsUltraOrMegaHonk<Flavor>;
+    static void add_memory_records_to_proving_key(Builder& builder, typename Flavor::ProvingKey& proving_key);
 
     /**
      * @brief Construct wire polynomials, selector polynomials and copy cycles from raw circuit data
@@ -91,9 +86,7 @@ template <class Flavor> class TraceToPolynomials {
      * @param is_structured whether or not the trace is to be structured with a fixed block size
      * @return TraceData
      */
-    static TraceData construct_trace_data(Builder& builder,
-                                          typename Flavor::ProvingKey& proving_key,
-                                          bool is_structured = false);
+    static TraceData construct_trace_data(Builder& builder, typename Flavor::ProvingKey& proving_key);
 
     /**
      * @brief Construct and add the goblin ecc op wires to the proving key

--- a/barretenberg/cpp/src/barretenberg/ultra_honk/decider_proving_key.cpp
+++ b/barretenberg/cpp/src/barretenberg/ultra_honk/decider_proving_key.cpp
@@ -82,11 +82,11 @@ template <IsUltraOrMegaHonk Flavor> void DeciderProvingKey_<Flavor>::allocate_se
         // TODO(https://github.com/AztecProtocol/barretenberg/issues/914): q_arith is currently used
         // in aux block.
         if (&block == &circuit.blocks.arithmetic) {
-            size_t arith_size = circuit.blocks.aux.trace_offset - circuit.blocks.arithmetic.trace_offset +
+            size_t arith_size = circuit.blocks.aux.trace_offset() - circuit.blocks.arithmetic.trace_offset() +
                                 circuit.blocks.aux.get_fixed_size(is_structured);
-            selector = Polynomial(arith_size, proving_key.circuit_size, circuit.blocks.arithmetic.trace_offset);
+            selector = Polynomial(arith_size, proving_key.circuit_size, circuit.blocks.arithmetic.trace_offset());
         } else {
-            selector = Polynomial(block.get_fixed_size(is_structured), proving_key.circuit_size, block.trace_offset);
+            selector = Polynomial(block.get_fixed_size(is_structured), proving_key.circuit_size, block.trace_offset());
         }
     }
 
@@ -101,7 +101,7 @@ void DeciderProvingKey_<Flavor>::allocate_table_lookup_polynomials(const Circuit
 {
     PROFILE_THIS_NAME("allocate_table_lookup_and_lookup_read_polynomials");
 
-    size_t table_offset = circuit.blocks.lookup.trace_offset;
+    size_t table_offset = circuit.blocks.lookup.trace_offset();
     // TODO(https://github.com/AztecProtocol/barretenberg/issues/1193): can potentially improve memory footprint
     const size_t max_tables_size = dyadic_circuit_size - table_offset;
     ASSERT(dyadic_circuit_size > max_tables_size);
@@ -118,8 +118,8 @@ void DeciderProvingKey_<Flavor>::allocate_table_lookup_polynomials(const Circuit
     proving_key.polynomials.lookup_read_tags = Polynomial(max_tables_size, dyadic_circuit_size, table_offset);
 
     const size_t lookup_block_end =
-        static_cast<size_t>(circuit.blocks.lookup.trace_offset + circuit.blocks.lookup.get_fixed_size(is_structured));
-    const auto tables_end = circuit.blocks.lookup.trace_offset + max_tables_size;
+        static_cast<size_t>(circuit.blocks.lookup.trace_offset() + circuit.blocks.lookup.get_fixed_size(is_structured));
+    const auto tables_end = circuit.blocks.lookup.trace_offset() + max_tables_size;
 
     // Allocate the lookup_inverses polynomial
 
@@ -163,7 +163,7 @@ void DeciderProvingKey_<Flavor>::allocate_databus_polynomials(const Circuit& cir
 
     // Allocate log derivative lookup argument inverse polynomials
     const size_t q_busread_end =
-        circuit.blocks.busread.trace_offset + circuit.blocks.busread.get_fixed_size(is_structured);
+        circuit.blocks.busread.trace_offset() + circuit.blocks.busread.get_fixed_size(is_structured);
     proving_key.polynomials.calldata_inverses =
         Polynomial(std::max(circuit.get_calldata().size(), q_busread_end), dyadic_circuit_size);
     proving_key.polynomials.secondary_calldata_inverses =
@@ -256,14 +256,14 @@ void DeciderProvingKey_<Flavor>::move_structured_trace_overflow_to_overflow_bloc
         uint32_t fixed_block_size = block.get_fixed_size();
         if (block_size > fixed_block_size && block != overflow_block) {
             // Disallow overflow in blocks that are not expected to be used by App circuits
-            if (block.is_pub_inputs) {
+            if (&block == &blocks.pub_inputs) {
                 info("WARNING: Number of public inputs (",
                      block_size,
                      ") cannot exceed capacity specified in structured trace: ",
                      fixed_block_size);
                 ASSERT(false);
             }
-            if (block == blocks.ecc_op) {
+            if (&block == &blocks.ecc_op) {
                 info("WARNING: Number of ecc op gates (",
                      block_size,
                      ") cannot exceed capacity specified in structured trace: ",
@@ -277,10 +277,11 @@ void DeciderProvingKey_<Flavor>::move_structured_trace_overflow_to_overflow_bloc
             // The circuit memory read/write records store the indices at which a RAM/ROM read/write has occurred. If
             // the block containing RAM/ROM gates overflows, the indices of the corresponding gates in the memory
             // records need to be updated to reflect their new position in the overflow block
-            if (block.has_ram_rom) {
-                uint32_t overflow_cur_idx = overflow_block.trace_offset + static_cast<uint32_t>(overflow_block.size());
-                overflow_cur_idx -= block.trace_offset; // we'll add block.trace_offset to everything later
-                uint32_t offset = overflow_cur_idx + 1; // +1 accounts for duplication of final gate
+            if (&block == &blocks.aux) {
+                uint32_t overflow_cur_idx =
+                    overflow_block.trace_offset() + static_cast<uint32_t>(overflow_block.size());
+                overflow_cur_idx -= block.trace_offset(); // we'll add block.trace_offset to everything later
+                uint32_t offset = overflow_cur_idx + 1;   // +1 accounts for duplication of final gate
                 for (auto& idx : circuit.memory_read_records) {
                     // last gate in the main block will be duplicated; if necessary, duplicate the memory read idx too
                     if (idx == fixed_block_size - 1) {

--- a/barretenberg/cpp/src/barretenberg/ultra_honk/decider_proving_key.hpp
+++ b/barretenberg/cpp/src/barretenberg/ultra_honk/decider_proving_key.hpp
@@ -93,7 +93,7 @@ template <IsUltraOrMegaHonk Flavor> class DeciderProvingKey_ {
         // Find index of last non-trivial wire value in the trace
         for (auto& block : circuit.blocks.get()) {
             if (block.size() > 0) {
-                final_active_wire_idx = block.trace_offset + block.size() - 1;
+                final_active_wire_idx = block.trace_offset() + block.size() - 1;
             }
         }
 
@@ -133,7 +133,7 @@ template <IsUltraOrMegaHonk Flavor> class DeciderProvingKey_ {
 
         // Construct and add to proving key the wire, selector and copy constraint polynomials
         vinfo("populating trace...");
-        Trace::populate(circuit, proving_key, is_structured);
+        Trace::populate(circuit, proving_key);
 
         {
             PROFILE_THIS_NAME("constructing prover instance after trace populate");


### PR DESCRIPTION
Makes some simplifications to the methods that populate the core trace polynomials from circuit data. (No changes to underlying logic). This is largely fallout from the Plonk removal but also includes some general cleanup.