### PR TITLE
fix: disable validation

### DIFF
--- a/yarn-project/ethereum/src/l1_tx_utils.ts
+++ b/yarn-project/ethereum/src/l1_tx_utils.ts
@@ -480,7 +480,7 @@ export class ReadOnlyL1TxUtils {
   ) {
     try {
       const result = await this.client.simulateBlocks({
-        validation: true,
+        validation: false,
         blocks: [
           {
             blockOverrides,


### PR DESCRIPTION
Disable tx validation as it fails if the tx simulation does not contain a nonce