### PR TITLE
chore: reasonable logging defaults for sandbox and txe tests

### DIFF
--- a/aztec-up/bin/aztec
+++ b/aztec-up/bin/aztec
@@ -70,6 +70,7 @@ case ${1:-} in
 
     # TODO: Need to force ipv4 here with 127.0.0.1 for some reason. TXE's not on ipv6?
     exec $(dirname $0)/.aztec-run "" bash -c "
+      export LOG_LEVEL=${LOG_LEVEL:-"info"}
       node --no-warnings /usr/src/yarn-project/aztec/dest/bin/index.js start --txe --port 8081 &
       while ! nc -z 127.0.0.1 8081 &>/dev/null; do sleep 0.2; done
       export NARGO_FOREIGN_CALL_TIMEOUT=300000
@@ -99,7 +100,7 @@ case ${1:-} in
       export WS_BLOCK_CHECK_INTERVAL_MS=500
       export ARCHIVER_VIEM_POLLING_INTERVAL_MS=500
       export TEST_ACCOUNTS=${TEST_ACCOUNTS:-true}
-      export LOG_LEVEL=${LOG_LEVEL:-info}
+      export LOG_LEVEL=${LOG_LEVEL:-info;silent:sequencer;verbose:debug_log}
       export DEPLOY_AZTEC_CONTRACTS_SALT=${DEPLOY_AZTEC_CONTRACTS_SALT:-$RANDOM}
 
 


### PR DESCRIPTION
leaving info default but muting sequencer as those logs are quite spammy, and letting debug logs surface.