### PR TITLE
chore: package vk hash with vk

### DIFF
--- a/barretenberg/acir_tests/bootstrap.sh
+++ b/barretenberg/acir_tests/bootstrap.sh
@@ -49,22 +49,23 @@ function run_proof_generation {
   dump_fail "$prove_cmd"
 
   local vk_fields=$(cat "$outdir/vk_fields.json")
+  local vk_hash_fields=$(cat "$outdir/vk_hash_fields.json")
   local public_inputs_fields=$(cat "$outdir/public_inputs_fields.json")
   local proof_fields=$(cat "$outdir/proof_fields.json")
 
-  generate_toml "$program" "$vk_fields" "$proof_fields" "$public_inputs_fields"
+  generate_toml "$program" "$vk_fields" "$vk_hash_fields" "$proof_fields" "$public_inputs_fields"
 }
 
 function generate_toml {
   local program=$1
   local vk_fields=$2
-  local proof_fields=$3
-  local num_inner_public_inputs=$4
+  local vk_hash_fields=$3
+  local proof_fields=$4
+  local num_inner_public_inputs=$5
   local output_file="../$program/Prover.toml"
-  local key_hash="0x0000000000000000000000000000000000000000000000000000000000000000"
 
   jq -nr \
-      --arg key_hash "$key_hash" \
+      --arg key_hash "$vk_hash_fields" \
       --argjson vk_f "$vk_fields" \
       --argjson public_inputs_f "$public_inputs_fields" \
       --argjson proof_f "$proof_fields" \

--- a/barretenberg/cpp/src/barretenberg/api/api_client_ivc.cpp
+++ b/barretenberg/cpp/src/barretenberg/api/api_client_ivc.cpp
@@ -61,9 +61,7 @@ void write_standalone_vk(const std::string& output_data_type,
     acir_format::AcirProgram program{ get_constraint_system(bytecode_path), /*witness=*/{} };
     std::shared_ptr<ClientIVC::DeciderProvingKey> proving_key = get_acir_program_decider_proving_key(program);
     auto verification_key = std::make_shared<ClientIVC::MegaVerificationKey>(proving_key->proving_key);
-    PubInputsProofAndKey<ClientIVC::MegaVerificationKey> to_write{ PublicInputsVector{},
-                                                                   HonkProof{},
-                                                                   verification_key };
+    PubInputsProofAndKey<ClientIVC::MegaVerificationKey> to_write{ .key = verification_key };
 
     write(to_write, output_data_type, "vk", output_path);
 }

--- a/barretenberg/cpp/src/barretenberg/api/api_ultra_honk.cpp
+++ b/barretenberg/cpp/src/barretenberg/api/api_ultra_honk.cpp
@@ -60,9 +60,8 @@ PubInputsProofAndKey<typename Flavor::VerificationKey> _compute_vk(const std::fi
                                                                    const std::filesystem::path& witness_path)
 {
     auto proving_key = _compute_proving_key<Flavor>(bytecode_path.string(), witness_path.string());
-    return { PublicInputsVector{},
-             HonkProof{},
-             std::make_shared<typename Flavor::VerificationKey>(proving_key->proving_key) };
+    auto vk = std::make_shared<typename Flavor::VerificationKey>(proving_key->proving_key);
+    return { PublicInputsVector{}, HonkProof{}, vk, vk->hash() };
 }
 
 template <typename Flavor>
@@ -102,7 +101,7 @@ PubInputsProofAndKey<typename Flavor::VerificationKey> _prove(const bool compute
         HonkProof(concat_pi_and_proof.begin() + static_cast<std::ptrdiff_t>(num_inner_public_inputs),
                   concat_pi_and_proof.end())
     };
-    return { public_inputs_and_proof.public_inputs, public_inputs_and_proof.proof, vk };
+    return { public_inputs_and_proof.public_inputs, public_inputs_and_proof.proof, vk, vk->hash() };
 }
 
 template <typename Flavor>

--- a/barretenberg/cpp/src/barretenberg/api/write_prover_output.hpp
+++ b/barretenberg/cpp/src/barretenberg/api/write_prover_output.hpp
@@ -14,6 +14,7 @@ template <typename VK> struct PubInputsProofAndKey {
     PublicInputsVector public_inputs;
     HonkProof proof;
     std::shared_ptr<VK> key;
+    fr vk_hash;
 };
 
 template <typename ProverOutput>
@@ -22,7 +23,7 @@ void write(const ProverOutput& prover_output,
            const std::string& output_content,
            const std::filesystem::path& output_dir)
 {
-    enum class ObjectToWrite : size_t { PUBLIC_INPUTS, PROOF, VK };
+    enum class ObjectToWrite : size_t { PUBLIC_INPUTS, PROOF, VK, VK_HASH };
     const bool output_to_stdout = output_dir == "-";
 
     const auto to_json = [](const std::vector<bb::fr>& data) {
@@ -31,6 +32,7 @@ void write(const ProverOutput& prover_output,
         }
         return format("[", join(transform::map(data, [](auto fr) { return format("\"", fr, "\""); })), "]");
     };
+    const auto to_json_fr = [](const bb::fr& fr) { return format("\"", fr, "\""); };
 
     const auto write_bytes = [&](const ObjectToWrite& obj) {
         switch (obj) {
@@ -65,6 +67,16 @@ void write(const ProverOutput& prover_output,
             } else {
                 write_file(output_dir / "vk", buf);
                 info("VK saved to ", output_dir / "vk");
+            }
+            break;
+        }
+        case ObjectToWrite::VK_HASH: {
+            const auto buf = to_buffer(prover_output.vk_hash);
+            if (output_to_stdout) {
+                write_bytes_to_stdout(buf);
+            } else {
+                write_file(output_dir / "vk_hash", buf);
+                info("VK Hash saved to ", output_dir / "vk_hash");
             }
             break;
         }
@@ -104,6 +116,16 @@ void write(const ProverOutput& prover_output,
             }
             break;
         }
+        case ObjectToWrite::VK_HASH: {
+            const std::string vk_hash_json = to_json_fr(prover_output.vk_hash);
+            if (output_to_stdout) {
+                std::cout << vk_hash_json;
+            } else {
+                write_file(output_dir / "vk_hash_fields.json", { vk_hash_json.begin(), vk_hash_json.end() });
+                info("VK Hash fields saved to ", output_dir / "vk_hash_fields.json");
+            }
+            break;
+        }
         }
     };
 
@@ -125,11 +147,15 @@ void write(const ProverOutput& prover_output,
     } else if (output_content == "vk") {
         if (output_format == "bytes") {
             write_bytes(ObjectToWrite::VK);
+            write_bytes(ObjectToWrite::VK_HASH);
         } else if (output_format == "fields") {
             write_fields(ObjectToWrite::VK);
+            write_fields(ObjectToWrite::VK_HASH);
         } else if (output_format == "bytes_and_fields") {
             write_bytes(ObjectToWrite::VK);
+            write_bytes(ObjectToWrite::VK_HASH);
             write_fields(ObjectToWrite::VK);
+            write_fields(ObjectToWrite::VK_HASH);
         } else {
             throw_or_abort("Invalid output_format for output_content vk");
         }
@@ -138,17 +164,21 @@ void write(const ProverOutput& prover_output,
             write_bytes(ObjectToWrite::PUBLIC_INPUTS);
             write_bytes(ObjectToWrite::PROOF);
             write_bytes(ObjectToWrite::VK);
+            write_bytes(ObjectToWrite::VK_HASH);
         } else if (output_format == "fields") {
             write_fields(ObjectToWrite::PUBLIC_INPUTS);
             write_fields(ObjectToWrite::PROOF);
             write_fields(ObjectToWrite::VK);
+            write_fields(ObjectToWrite::VK_HASH);
         } else if (output_format == "bytes_and_fields") {
             write_bytes(ObjectToWrite::PUBLIC_INPUTS);
             write_fields(ObjectToWrite::PUBLIC_INPUTS);
             write_bytes(ObjectToWrite::PROOF);
             write_fields(ObjectToWrite::PROOF);
             write_bytes(ObjectToWrite::VK);
+            write_bytes(ObjectToWrite::VK_HASH);
             write_fields(ObjectToWrite::VK);
+            write_fields(ObjectToWrite::VK_HASH);
         } else {
             throw_or_abort("Invalid output_format for output_content proof_and_vk");
         }

--- a/barretenberg/cpp/src/barretenberg/benchmark/client_ivc_bench/client_ivc.bench.cpp
+++ b/barretenberg/cpp/src/barretenberg/benchmark/client_ivc_bench/client_ivc.bench.cpp
@@ -59,11 +59,11 @@ BENCHMARK_DEFINE_F(ClientIVCBench, Full)(benchmark::State& state)
     ClientIVC ivc{ { AZTEC_TRACE_STRUCTURE } };
 
     auto total_num_circuits = 2 * static_cast<size_t>(state.range(0)); // 2x accounts for kernel circuits
-    auto mocked_vkeys = mock_verification_keys(total_num_circuits);
+    auto mocked_vks = mock_vks(total_num_circuits);
 
     for (auto _ : state) {
         BB_REPORT_OP_COUNT_IN_BENCH(state);
-        perform_ivc_accumulation_rounds(total_num_circuits, ivc, mocked_vkeys, /* mock_vk */ true);
+        perform_ivc_accumulation_rounds(total_num_circuits, ivc, mocked_vks, /* mock_vk */ true);
         ivc.prove();
     }
 }
@@ -76,12 +76,12 @@ BENCHMARK_DEFINE_F(ClientIVCBench, Ambient_17_in_20)(benchmark::State& state)
     ClientIVC ivc{ { AZTEC_TRACE_STRUCTURE } };
 
     auto total_num_circuits = 2 * static_cast<size_t>(state.range(0)); // 2x accounts for kernel circuits
-    auto mocked_vkeys = mock_verification_keys(total_num_circuits);
+    auto mocked_vks = mock_vks(total_num_circuits);
 
     for (auto _ : state) {
         BB_REPORT_OP_COUNT_IN_BENCH(state);
         perform_ivc_accumulation_rounds(
-            total_num_circuits, ivc, mocked_vkeys, /* mock_vk */ true, /* large_first_app */ false);
+            total_num_circuits, ivc, mocked_vks, /* mock_vk */ true, /* large_first_app */ false);
         ivc.prove();
     }
 }

--- a/barretenberg/cpp/src/barretenberg/boomerang_value_detection/graph_description_ultra_recursive_verifier.test.cpp
+++ b/barretenberg/cpp/src/barretenberg/boomerang_value_detection/graph_description_ultra_recursive_verifier.test.cpp
@@ -108,9 +108,11 @@ template <typename RecursiveFlavor> class BoomerangRecursiveVerifierTest : publi
 
         // Create a recursive verification circuit for the proof of the inner circuit
         OuterBuilder outer_circuit;
-        RecursiveVerifier verifier{ &outer_circuit, verification_key };
-        verifier.key->verification_key->num_public_inputs.fix_witness();
-        verifier.key->verification_key->pub_inputs_offset.fix_witness();
+        auto stdlib_vk_and_hash =
+            std::make_shared<typename RecursiveFlavor::VKAndHash>(outer_circuit, verification_key);
+        RecursiveVerifier verifier{ &outer_circuit, stdlib_vk_and_hash };
+        verifier.key->vk_and_hash->vk->num_public_inputs.fix_witness();
+        verifier.key->vk_and_hash->vk->pub_inputs_offset.fix_witness();
 
         VerifierOutput output = verifier.verify_proof(inner_proof);
         PairingObject pairing_points = output.points_accumulator;

--- a/barretenberg/cpp/src/barretenberg/client_ivc/client_ivc.cpp
+++ b/barretenberg/cpp/src/barretenberg/client_ivc/client_ivc.cpp
@@ -39,7 +39,7 @@ ClientIVC::ClientIVC(TraceSettings trace_settings)
  * @param circuit
  */
 void ClientIVC::instantiate_stdlib_verification_queue(
-    ClientCircuit& circuit, const std::vector<std::shared_ptr<RecursiveVerificationKey>>& input_keys)
+    ClientCircuit& circuit, const std::vector<std::shared_ptr<RecursiveVKAndHash>>& input_keys)
 {
     bool vkeys_provided = !input_keys.empty();
     if (vkeys_provided) {
@@ -51,16 +51,21 @@ void ClientIVC::instantiate_stdlib_verification_queue(
 
     size_t key_idx = 0;
     while (!verification_queue.empty()) {
-        auto& [proof, vkey, type] = verification_queue.front();
+        auto& [proof, vk, type] = verification_queue.front();
 
         // Construct stdlib proof directly from the internal native queue data
         StdlibProof stdlib_proof(circuit, proof);
 
         // Use the provided stdlib vkey if present, otherwise construct one from the internal native queue
-        auto stdlib_vkey =
-            vkeys_provided ? input_keys[key_idx++] : std::make_shared<RecursiveVerificationKey>(&circuit, vkey);
+        // Why?? ^
+        std::shared_ptr<RecursiveVKAndHash> stdlib_vk_and_hash;
+        if (vkeys_provided) {
+            stdlib_vk_and_hash = input_keys[key_idx++];
+        } else {
+            stdlib_vk_and_hash = std::make_shared<RecursiveVKAndHash>(circuit, vk);
+        }
 
-        stdlib_verification_queue.push_back({ stdlib_proof, stdlib_vkey, type });
+        stdlib_verification_queue.push_back({ stdlib_proof, stdlib_vk_and_hash, type });
 
         verification_queue.pop_front(); // the native data is not needed beyond this point
     }
@@ -92,10 +97,9 @@ ClientIVC::PairingPoints ClientIVC::perform_recursive_verification_and_databus_c
         auto stdlib_verifier_accum = std::make_shared<RecursiveDeciderVerificationKey>(&circuit, verifier_accumulator);
 
         // Perform folding recursive verification to update the verifier accumulator
-        FoldingRecursiveVerifier verifier{ &circuit,
-                                           stdlib_verifier_accum,
-                                           { verifier_inputs.honk_verification_key },
-                                           accumulation_recursive_transcript };
+        FoldingRecursiveVerifier verifier{
+            &circuit, stdlib_verifier_accum, { verifier_inputs.honk_vk_and_hash }, accumulation_recursive_transcript
+        };
         auto verifier_accum = verifier.verify_folding_proof(verifier_inputs.proof);
 
         // Extract native verifier accumulator from the stdlib accum for use on the next round
@@ -108,7 +112,7 @@ ClientIVC::PairingPoints ClientIVC::perform_recursive_verification_and_databus_c
     case QUEUE_TYPE::OINK: {
         // Construct an incomplete stdlib verifier accumulator from the corresponding stdlib verification key
         auto verifier_accum =
-            std::make_shared<RecursiveDeciderVerificationKey>(&circuit, verifier_inputs.honk_verification_key);
+            std::make_shared<RecursiveDeciderVerificationKey>(&circuit, verifier_inputs.honk_vk_and_hash);
 
         // Perform oink recursive verification to complete the initial verifier accumulator
         OinkRecursiveVerifier oink{ &circuit, verifier_accum, accumulation_recursive_transcript };
@@ -132,7 +136,7 @@ ClientIVC::PairingPoints ClientIVC::perform_recursive_verification_and_databus_c
 
     // Extract and aggregate the pairing points carried in the public inputs of the proof just recursively verified
     PairingPoints nested_pairing_points = PublicPairingPoints::reconstruct(
-        decider_vk->public_inputs, decider_vk->verification_key->pairing_inputs_public_input_key);
+        decider_vk->public_inputs, decider_vk->vk_and_hash->vk->pairing_inputs_public_input_key);
 
     pairing_points.aggregate(nested_pairing_points);
     // Set the return data commitment to be propagated on the public inputs of the present kernel and perform
@@ -143,7 +147,7 @@ ClientIVC::PairingPoints ClientIVC::perform_recursive_verification_and_databus_c
         decider_vk->witness_commitments.calldata,
         decider_vk->witness_commitments.secondary_calldata,
         decider_vk->public_inputs,
-        decider_vk->verification_key->databus_propagation_data);
+        decider_vk->vk_and_hash->vk->databus_propagation_data);
 
     return pairing_points;
 }
@@ -232,6 +236,7 @@ void ClientIVC::accumulate(ClientCircuit& circuit,
         PROFILE_THIS_NAME("ClientIVC::accumulate create MegaVerificationKey");
         honk_vk = precomputed_vk ? precomputed_vk : std::make_shared<MegaVerificationKey>(proving_key->proving_key);
     }
+    // mock_vk is used in benchmarks to avoid any VK construction.
     if (mock_vk) {
         honk_vk->set_metadata(proving_key->proving_key);
         vinfo("set honk vk metadata");
@@ -335,14 +340,15 @@ std::shared_ptr<ClientIVC::DeciderZKProvingKey> ClientIVC::construct_hiding_circ
     auto stdlib_verifier_accumulator =
         std::make_shared<RecursiveDeciderVerificationKey>(&builder, verifier_accumulator);
 
-    auto stdlib_decider_vk =
-        std::make_shared<RecursiveVerificationKey>(&builder, verification_queue[0].honk_verification_key);
+    auto stdlib_vk_and_hash = std::make_shared<RecursiveVKAndHash>(
+        std::make_shared<RecursiveVerificationKey>(&builder, verification_queue[0].honk_vk),
+        ClientIVC::RecursiveFlavor::FF::from_witness(&builder, verification_queue[0].honk_vk->hash()));
 
     StdlibProof stdlib_proof(builder, fold_proof);
 
     // Perform recursive folding verification of the last folding proof
     FoldingRecursiveVerifier folding_verifier{
-        &builder, stdlib_verifier_accumulator, { stdlib_decider_vk }, pg_merge_transcript
+        &builder, stdlib_verifier_accumulator, { stdlib_vk_and_hash }, pg_merge_transcript
     };
     auto recursive_verifier_accumulator = folding_verifier.verify_folding_proof(stdlib_proof);
     verification_queue.clear();
@@ -354,7 +360,7 @@ std::shared_ptr<ClientIVC::DeciderZKProvingKey> ClientIVC::construct_hiding_circ
     // Extract and aggregate the pairing points from the pub inputs of the final accumulated circuit
     PairingPoints nested_pairing_points = PublicPairingPoints::reconstruct(
         recursive_verifier_accumulator->public_inputs,
-        recursive_verifier_accumulator->verification_key->pairing_inputs_public_input_key);
+        recursive_verifier_accumulator->vk_and_hash->vk->pairing_inputs_public_input_key);
     points_accumulator.aggregate(nested_pairing_points);
 
     // Perform recursive decider verification

--- a/barretenberg/cpp/src/barretenberg/client_ivc/client_ivc.hpp
+++ b/barretenberg/cpp/src/barretenberg/client_ivc/client_ivc.hpp
@@ -63,6 +63,7 @@ class ClientIVC {
         bb::stdlib::recursion::honk::RecursiveDeciderVerificationKeys_<RecursiveFlavor, 2>;
     using RecursiveDeciderVerificationKey = RecursiveDeciderVerificationKeys::DeciderVK;
     using RecursiveVerificationKey = RecursiveFlavor::VerificationKey;
+    using RecursiveVKAndHash = RecursiveFlavor::VKAndHash;
     using FoldingRecursiveVerifier =
         bb::stdlib::recursion::honk::ProtogalaxyRecursiveVerifier_<RecursiveDeciderVerificationKeys>;
     using OinkRecursiveVerifier = stdlib::recursion::honk::OinkRecursiveVerifier_<RecursiveFlavor>;
@@ -129,7 +130,7 @@ class ClientIVC {
     // An entry in the native verification queue
     struct VerifierInputs {
         std::vector<FF> proof; // oink or PG
-        std::shared_ptr<MegaVerificationKey> honk_verification_key;
+        std::shared_ptr<MegaVerificationKey> honk_vk;
         QUEUE_TYPE type;
     };
     using VerificationQueue = std::deque<VerifierInputs>;
@@ -137,7 +138,7 @@ class ClientIVC {
     // An entry in the stdlib verification queue
     struct StdlibVerifierInputs {
         StdlibProof proof; // oink or PG
-        std::shared_ptr<RecursiveVerificationKey> honk_verification_key;
+        std::shared_ptr<RecursiveVKAndHash> honk_vk_and_hash;
         QUEUE_TYPE type;
     };
     using StdlibVerificationQueue = std::deque<StdlibVerifierInputs>;
@@ -180,8 +181,8 @@ class ClientIVC {
 
     ClientIVC(TraceSettings trace_settings = {});
 
-    void instantiate_stdlib_verification_queue(
-        ClientCircuit& circuit, const std::vector<std::shared_ptr<RecursiveVerificationKey>>& input_keys = {});
+    void instantiate_stdlib_verification_queue(ClientCircuit& circuit,
+                                               const std::vector<std::shared_ptr<RecursiveVKAndHash>>& input_keys = {});
 
     [[nodiscard("Pairing points should be accumulated")]] PairingPoints
     perform_recursive_verification_and_databus_consistency_checks(

--- a/barretenberg/cpp/src/barretenberg/client_ivc/client_ivc.test.cpp
+++ b/barretenberg/cpp/src/barretenberg/client_ivc/client_ivc.test.cpp
@@ -244,7 +244,7 @@ TEST_F(ClientIVCTests, PrecomputedVerificationKeys)
 
     ClientIVCMockCircuitProducer circuit_producer;
 
-    auto precomputed_vks = circuit_producer.precompute_verification_keys(NUM_CIRCUITS, TraceSettings{});
+    auto precomputed_vks = circuit_producer.precompute_vks(NUM_CIRCUITS, TraceSettings{});
 
     // Construct and accumulate set of circuits using the precomputed vkeys
     for (size_t idx = 0; idx < NUM_CIRCUITS; ++idx) {
@@ -268,8 +268,7 @@ TEST_F(ClientIVCTests, StructuredPrecomputedVKs)
 
     ClientIVCMockCircuitProducer circuit_producer;
 
-    auto precomputed_vks =
-        circuit_producer.precompute_verification_keys(NUM_CIRCUITS, ivc.trace_settings, log2_num_gates);
+    auto precomputed_vks = circuit_producer.precompute_vks(NUM_CIRCUITS, ivc.trace_settings, log2_num_gates);
 
     // Construct and accumulate set of circuits using the precomputed vkeys
     for (size_t idx = 0; idx < NUM_CIRCUITS; ++idx) {
@@ -439,8 +438,8 @@ HEAVY_TEST(ClientIVCBenchValidation, Full6)
     ClientIVC ivc{ { AZTEC_TRACE_STRUCTURE } };
     size_t total_num_circuits{ 12 };
     PrivateFunctionExecutionMockCircuitProducer circuit_producer;
-    auto precomputed_vkeys = circuit_producer.precompute_verification_keys(total_num_circuits, ivc.trace_settings);
-    perform_ivc_accumulation_rounds(total_num_circuits, ivc, precomputed_vkeys);
+    auto precomputed_vks = circuit_producer.precompute_vks(total_num_circuits, ivc.trace_settings);
+    perform_ivc_accumulation_rounds(total_num_circuits, ivc, precomputed_vks);
     auto proof = ivc.prove();
     bool verified = verify_ivc(proof, ivc);
     EXPECT_TRUE(verified);
@@ -457,8 +456,8 @@ HEAVY_TEST(ClientIVCBenchValidation, Full6MockedVKs)
         ClientIVC ivc{ { AZTEC_TRACE_STRUCTURE } };
         size_t total_num_circuits{ 12 };
         PrivateFunctionExecutionMockCircuitProducer circuit_producer;
-        auto mocked_vkeys = mock_verification_keys(total_num_circuits);
-        perform_ivc_accumulation_rounds(total_num_circuits, ivc, mocked_vkeys, /* mock_vk */ true);
+        auto mocked_vks = mock_vks(total_num_circuits);
+        perform_ivc_accumulation_rounds(total_num_circuits, ivc, mocked_vks, /* mock_vk */ true);
         auto proof = ivc.prove();
         verify_ivc(proof, ivc);
     };
@@ -472,8 +471,8 @@ HEAVY_TEST(ClientIVCKernelCapacity, MaxCapacityPassing)
     ClientIVC ivc{ { AZTEC_TRACE_STRUCTURE } };
     const size_t total_num_circuits{ 2 * MAX_NUM_KERNELS };
     PrivateFunctionExecutionMockCircuitProducer circuit_producer;
-    auto precomputed_vkeys = circuit_producer.precompute_verification_keys(total_num_circuits, ivc.trace_settings);
-    perform_ivc_accumulation_rounds(total_num_circuits, ivc, precomputed_vkeys);
+    auto precomputed_vks = circuit_producer.precompute_vks(total_num_circuits, ivc.trace_settings);
+    perform_ivc_accumulation_rounds(total_num_circuits, ivc, precomputed_vks);
     auto proof = ivc.prove();
     bool verified = verify_ivc(proof, ivc);
     EXPECT_TRUE(verified);
@@ -486,8 +485,8 @@ HEAVY_TEST(ClientIVCKernelCapacity, MaxCapacityFailing)
     ClientIVC ivc{ { AZTEC_TRACE_STRUCTURE } };
     const size_t total_num_circuits{ 2 * (MAX_NUM_KERNELS + 1) };
     PrivateFunctionExecutionMockCircuitProducer circuit_producer;
-    auto precomputed_vkeys = circuit_producer.precompute_verification_keys(total_num_circuits, ivc.trace_settings);
-    perform_ivc_accumulation_rounds(total_num_circuits, ivc, precomputed_vkeys);
+    auto precomputed_vks = circuit_producer.precompute_vks(total_num_circuits, ivc.trace_settings);
+    perform_ivc_accumulation_rounds(total_num_circuits, ivc, precomputed_vks);
     EXPECT_ANY_THROW(ivc.prove());
 }
 

--- a/barretenberg/cpp/src/barretenberg/client_ivc/client_ivc_integration.test.cpp
+++ b/barretenberg/cpp/src/barretenberg/client_ivc/client_ivc_integration.test.cpp
@@ -90,7 +90,7 @@ TEST_F(ClientIVCIntegrationTests, BenchmarkCasePrecomputedVKs)
     std::vector<std::shared_ptr<VerificationKey>> precomputed_vks;
     {
         MockCircuitProducer circuit_producer;
-        precomputed_vks = circuit_producer.precompute_verification_keys(NUM_CIRCUITS, ivc.trace_settings);
+        precomputed_vks = circuit_producer.precompute_vks(NUM_CIRCUITS, ivc.trace_settings);
     }
 
     MockCircuitProducer circuit_producer;

--- a/barretenberg/cpp/src/barretenberg/client_ivc/mock_circuit_producer.hpp
+++ b/barretenberg/cpp/src/barretenberg/client_ivc/mock_circuit_producer.hpp
@@ -148,20 +148,20 @@ class PrivateFunctionExecutionMockCircuitProducer {
      * @param trace_structure Trace structuring must be known in advance because it effects the VKs
      * @return set of num_circuits-many verification keys
      */
-    auto precompute_verification_keys(const size_t num_circuits, TraceSettings trace_settings)
+    auto precompute_vks(const size_t num_circuits, TraceSettings trace_settings)
     {
         ClientIVC ivc{ trace_settings }; // temporary IVC instance needed to produce the complete kernel circuits
 
-        std::vector<std::shared_ptr<VerificationKey>> vkeys;
+        std::vector<std::shared_ptr<VerificationKey>> vks;
 
         for (size_t idx = 0; idx < num_circuits; ++idx) {
             ClientCircuit circuit = create_next_circuit(ivc); // create the next circuit
             ivc.accumulate(circuit);                          // accumulate the circuit
-            vkeys.emplace_back(ivc.honk_vk);                  // save the VK for the circuit
+            vks.emplace_back(ivc.honk_vk);                    // save the VK for the circuit
         }
         circuit_counter = 0; // reset the internal circuit counter back to 0
 
-        return vkeys;
+        return vks;
     }
 };
 
@@ -207,22 +207,20 @@ class ClientIVCMockCircuitProducer {
         return circuit;
     }
 
-    auto precompute_verification_keys(const size_t num_circuits,
-                                      TraceSettings trace_settings,
-                                      size_t log2_num_gates = 16)
+    auto precompute_vks(const size_t num_circuits, TraceSettings trace_settings, size_t log2_num_gates = 16)
     {
         ClientIVC ivc{ trace_settings }; // temporary IVC instance needed to produce the complete kernel circuits
 
-        std::vector<std::shared_ptr<MegaFlavor::VerificationKey>> vkeys;
+        std::vector<std::shared_ptr<MegaFlavor::VerificationKey>> vks;
 
         for (size_t idx = 0; idx < num_circuits; ++idx) {
             ClientCircuit circuit = create_next_circuit(ivc, log2_num_gates); // create the next circuit
             ivc.accumulate(circuit);                                          // accumulate the circuit
-            vkeys.emplace_back(ivc.honk_vk);                                  // save the VK for the circuit
+            vks.emplace_back(ivc.honk_vk);                                    // save the VK for the circuit
         }
         is_kernel = false;
 
-        return vkeys;
+        return vks;
     }
 };
 

--- a/barretenberg/cpp/src/barretenberg/client_ivc/private_execution_steps.cpp
+++ b/barretenberg/cpp/src/barretenberg/client_ivc/private_execution_steps.cpp
@@ -113,7 +113,8 @@ std::shared_ptr<ClientIVC> PrivateExecutionSteps::accumulate()
 
     for (auto& vk : precomputed_vks) {
         if (vk == nullptr) {
-            info("DEPRECATED: No VK was provided for at least one client IVC step and it will be computed. This is "
+            info("DEPRECATED: No VK was provided for at least one client IVC step and it will be computed. This "
+                 "is "
                  "slower and insecure.");
             break;
         }

--- a/barretenberg/cpp/src/barretenberg/client_ivc/private_execution_steps.cpp
+++ b/barretenberg/cpp/src/barretenberg/client_ivc/private_execution_steps.cpp
@@ -113,8 +113,7 @@ std::shared_ptr<ClientIVC> PrivateExecutionSteps::accumulate()
 
     for (auto& vk : precomputed_vks) {
         if (vk == nullptr) {
-            info("DEPRECATED: No VK was provided for at least one client IVC step and it will be computed. This "
-                 "is "
+            info("DEPRECATED: No VK was provided for at least one client IVC step and it will be computed. This is "
                  "slower and insecure.");
             break;
         }

--- a/barretenberg/cpp/src/barretenberg/client_ivc/test_bench_shared.hpp
+++ b/barretenberg/cpp/src/barretenberg/client_ivc/test_bench_shared.hpp
@@ -56,7 +56,7 @@ void perform_ivc_accumulation_rounds(size_t NUM_CIRCUITS,
     }
 }
 
-std::vector<std::shared_ptr<typename MegaFlavor::VerificationKey>> mock_verification_keys(const size_t num_circuits)
+std::vector<std::shared_ptr<typename MegaFlavor::VerificationKey>> mock_vks(const size_t num_circuits)
 {
 
     std::vector<std::shared_ptr<typename MegaFlavor::VerificationKey>> vkeys;

--- a/barretenberg/cpp/src/barretenberg/dsl/acir_format/honk_recursion_constraint.cpp
+++ b/barretenberg/cpp/src/barretenberg/dsl/acir_format/honk_recursion_constraint.cpp
@@ -234,6 +234,7 @@ HonkRecursionConstraintOutput<typename Flavor::CircuitBuilder> create_honk_recur
 {
     using Builder = typename Flavor::CircuitBuilder;
     using RecursiveVerificationKey = Flavor::VerificationKey;
+    using RecursiveVKAndHash = Flavor::VKAndHash;
     using RecursiveVerifier = bb::stdlib::recursion::honk::UltraRecursiveVerifier_<Flavor>;
 
     ASSERT(input.proof_type == HONK || input.proof_type == HONK_ZK || HasIPAAccumulator<Flavor>);
@@ -248,6 +249,9 @@ HonkRecursionConstraintOutput<typename Flavor::CircuitBuilder> create_honk_recur
         auto field = field_ct<Builder>::from_witness_index(&builder, idx);
         key_fields.emplace_back(field);
     }
+
+    // Create circuit type for vkey hash.
+    auto vk_hash = field_ct<Builder>::from_witness_index(&builder, input.key_hash);
 
     stdlib::Proof<Builder> proof_fields;
 
@@ -279,7 +283,8 @@ HonkRecursionConstraintOutput<typename Flavor::CircuitBuilder> create_honk_recur
 
     // Recursively verify the proof
     auto vkey = std::make_shared<RecursiveVerificationKey>(builder, key_fields);
-    RecursiveVerifier verifier(&builder, vkey);
+    auto vk_and_hash = std::make_shared<RecursiveVKAndHash>(vkey, vk_hash);
+    RecursiveVerifier verifier(&builder, vk_and_hash);
     UltraRecursiveVerifierOutput<Builder> verifier_output = verifier.verify_proof(proof_fields);
     // TODO(https://github.com/AztecProtocol/barretenberg/issues/996): investigate whether assert_equal on public inputs
     // is important, like what the plonk recursion constraint does.

--- a/barretenberg/cpp/src/barretenberg/dsl/acir_format/honk_recursion_constraint.test.cpp
+++ b/barretenberg/cpp/src/barretenberg/dsl/acir_format/honk_recursion_constraint.test.cpp
@@ -172,6 +172,7 @@ template <typename RecursiveFlavor> class AcirHonkRecursionConstraint : public :
             auto inner_proof = prover.construct_proof();
 
             std::vector<bb::fr> key_witnesses = verification_key->to_field_elements();
+            fr key_hash_witness = verification_key->hash();
             std::vector<fr> proof_witnesses = inner_proof;
             size_t num_public_inputs_to_extract = inner_circuit.get_public_inputs().size() - bb::PAIRING_POINTS_SIZE;
             acir_format::PROOF_TYPE proof_type = acir_format::HONK;
@@ -182,14 +183,15 @@ template <typename RecursiveFlavor> class AcirHonkRecursionConstraint : public :
                 proof_type = HONK_ZK;
             }
 
-            auto [key_indices, proof_indices, inner_public_inputs] = ProofSurgeon::populate_recursion_witness_data(
-                witness, proof_witnesses, key_witnesses, num_public_inputs_to_extract);
+            auto [key_indices, key_hash_index, proof_indices, inner_public_inputs] =
+                ProofSurgeon::populate_recursion_witness_data(
+                    witness, proof_witnesses, key_witnesses, key_hash_witness, num_public_inputs_to_extract);
 
             RecursionConstraint honk_recursion_constraint{
                 .key = key_indices,
                 .proof = proof_indices,
                 .public_inputs = inner_public_inputs,
-                .key_hash = 0, // not used
+                .key_hash = key_hash_index,
                 .proof_type = proof_type,
             };
             honk_recursion_constraints.push_back(honk_recursion_constraint);

--- a/barretenberg/cpp/src/barretenberg/dsl/acir_format/ivc_recursion_constraint.cpp
+++ b/barretenberg/cpp/src/barretenberg/dsl/acir_format/ivc_recursion_constraint.cpp
@@ -21,118 +21,6 @@ namespace acir_format {
 using namespace bb;
 
 /**
- * @brief Create an IVC object with mocked state corresponding to a set of IVC recursion constraints
- * @details Construction of a kernel circuit requires two inputs: kernel prgram acir constraints and an IVC instance
- * containing state needed to complete the kernel logic, e.g. proofs for input to recursive verifiers. To construct
- * verification keys for kernel circuits without running a full IVC, we mock the IVC state corresponding to a provided
- * set of IVC recurson constraints. For example, if the constraints contain a single PG recursive verification, we
- * initialize an IVC with mocked data for the verifier accumulator, the folding proof, the circuit verification key,
- * and a merge proof.
- * @note There are only three valid combinations of IVC recursion constraints for a kernel program. See below for
- * details.
- *
- * @param constraints IVC recursion constraints from a kernel circuit
- * @param trace_settings
- * @return ClientIVC
- */
-std::shared_ptr<ClientIVC> create_mock_ivc_from_constraints(const std::vector<RecursionConstraint>& constraints,
-                                                            const TraceSettings& trace_settings)
-{
-    auto ivc = std::make_shared<ClientIVC>(trace_settings);
-
-    uint32_t oink_type = static_cast<uint32_t>(PROOF_TYPE::OINK);
-    uint32_t pg_type = static_cast<uint32_t>(PROOF_TYPE::PG);
-
-    // There are only three valid combinations of IVC recursion constraints for Aztec kernel circuits:
-
-    // Case: INIT kernel; single Oink recursive verification of an app
-    if (constraints.size() == 1 && constraints[0].proof_type == oink_type) {
-        mock_ivc_accumulation(ivc, ClientIVC::QUEUE_TYPE::OINK, /*is_kernel=*/false);
-        return ivc;
-    }
-
-    // Case: RESET or TAIL kernel; single PG recursive verification of a kernel
-    if (constraints.size() == 1 && constraints[0].proof_type == pg_type) {
-        ivc->verifier_accumulator = create_mock_decider_vk();
-        mock_ivc_accumulation(ivc, ClientIVC::QUEUE_TYPE::PG, /*is_kernel=*/true);
-        return ivc;
-    }
-
-    // Case: INNER kernel; two PG recursive verifications, kernel and app in that order
-    if (constraints.size() == 2) {
-        ASSERT(constraints[0].proof_type == pg_type && constraints[1].proof_type == pg_type);
-        ivc->verifier_accumulator = create_mock_decider_vk();
-        mock_ivc_accumulation(ivc, ClientIVC::QUEUE_TYPE::PG, /*is_kernel=*/true);
-        mock_ivc_accumulation(ivc, ClientIVC::QUEUE_TYPE::PG, /*is_kernel=*/false);
-        return ivc;
-    }
-
-    ASSERT(false && "WARNING: Invalid set of IVC recursion constraints!");
-    return ivc;
-}
-
-/**
- * @brief Populate an IVC instance with data that mimics the state after a single IVC accumulation (Oink or PG)
- * @details Mock state consists of a mock verification queue entry of type OINK (proof, VK) and a mocked merge proof
- *
- * @param ivc
- * @param num_public_inputs_app num pub inputs in accumulated app, excluding fixed components, e.g. pairing points
- */
-void mock_ivc_accumulation(const std::shared_ptr<ClientIVC>& ivc, ClientIVC::QUEUE_TYPE type, const bool is_kernel)
-{
-    ClientIVC::VerifierInputs entry =
-        acir_format::create_mock_verification_queue_entry(type, ivc->trace_settings, is_kernel);
-    ivc->verification_queue.emplace_back(entry);
-    ivc->goblin.merge_verification_queue.emplace_back(acir_format::create_dummy_merge_proof());
-    ivc->initialized = true;
-}
-
-/**
- * @brief Create a mock verification queue entry with proof and VK that have the correct structure but are not
- * necessarily valid
- *
- */
-ClientIVC::VerifierInputs create_mock_verification_queue_entry(const ClientIVC::QUEUE_TYPE verification_type,
-                                                               const TraceSettings& trace_settings,
-                                                               const bool is_kernel)
-{
-    using FF = ClientIVC::FF;
-    using MegaVerificationKey = ClientIVC::MegaVerificationKey;
-
-    // Use the trace settings to determine the correct dyadic size and the public inputs offset
-    MegaExecutionTraceBlocks blocks;
-    blocks.set_fixed_block_sizes(trace_settings);
-    blocks.compute_offsets(/*is_structured=*/true);
-    size_t dyadic_size = blocks.get_structured_dyadic_size();
-    size_t pub_inputs_offset = blocks.pub_inputs.trace_offset();
-    // All circuits have pairing point public inputs; kernels have additional public inputs for two databus commitments
-    size_t num_public_inputs = bb::PAIRING_POINTS_SIZE;
-    if (is_kernel) {
-        num_public_inputs += bb::PROPAGATED_DATABUS_COMMITMENTS_SIZE;
-    }
-
-    // Construct a mock Oink or PG proof
-    std::vector<FF> proof;
-    if (verification_type == ClientIVC::QUEUE_TYPE::OINK) {
-        proof = create_mock_oink_proof(num_public_inputs);
-    } else { // ClientIVC::QUEUE_TYPE::PG)
-        proof = create_mock_pg_proof(num_public_inputs);
-    }
-
-    // Construct a mock MegaHonk verification key
-    std::shared_ptr<MegaVerificationKey> verification_key =
-        create_mock_honk_vk(dyadic_size, num_public_inputs, pub_inputs_offset);
-
-    // If the verification queue entry corresponds to a kernel circuit, set the databus data to indicate the presence of
-    // propagated return data commitments on the public inputs
-    if (is_kernel) {
-        verification_key->databus_propagation_data = bb::DatabusPropagationData::kernel_default();
-    }
-
-    return ClientIVC::VerifierInputs{ proof, verification_key, verification_type };
-}
-
-/**
  * @brief Create a mock oink proof that has the correct structure but is not in general valid
  *
  */
@@ -239,7 +127,9 @@ std::shared_ptr<ClientIVC::DeciderVerificationKey> create_mock_decider_vk()
 
     // Set relevant VK metadata and commitments
     auto decider_verification_key = std::make_shared<ClientIVC::DeciderVerificationKey>();
-    decider_verification_key->verification_key = create_mock_honk_vk(0, 0, 0); // metadata does not need to be accurate
+    std::shared_ptr<ClientIVC::MegaVerificationKey> vk =
+        create_mock_honk_vk(0, 0, 0); // metadata does not need to be accurate
+    decider_verification_key->vk = vk;
     decider_verification_key->is_accumulator = true;
     decider_verification_key->gate_challenges = std::vector<FF>(static_cast<size_t>(CONST_PG_LOG_N), 0);
 
@@ -248,6 +138,118 @@ std::shared_ptr<ClientIVC::DeciderVerificationKey> create_mock_decider_vk()
     }
 
     return decider_verification_key;
+}
+
+/**
+ * @brief Create an IVC object with mocked state corresponding to a set of IVC recursion constraints
+ * @details Construction of a kernel circuit requires two inputs: kernel prgram acir constraints and an IVC instance
+ * containing state needed to complete the kernel logic, e.g. proofs for input to recursive verifiers. To construct
+ * verification keys for kernel circuits without running a full IVC, we mock the IVC state corresponding to a provided
+ * set of IVC recurson constraints. For example, if the constraints contain a single PG recursive verification, we
+ * initialize an IVC with mocked data for the verifier accumulator, the folding proof, the circuit verification key,
+ * and a merge proof.
+ * @note There are only three valid combinations of IVC recursion constraints for a kernel program. See below for
+ * details.
+ *
+ * @param constraints IVC recursion constraints from a kernel circuit
+ * @param trace_settings
+ * @return ClientIVC
+ */
+std::shared_ptr<ClientIVC> create_mock_ivc_from_constraints(const std::vector<RecursionConstraint>& constraints,
+                                                            const TraceSettings& trace_settings)
+{
+    auto ivc = std::make_shared<ClientIVC>(trace_settings);
+
+    uint32_t oink_type = static_cast<uint32_t>(PROOF_TYPE::OINK);
+    uint32_t pg_type = static_cast<uint32_t>(PROOF_TYPE::PG);
+
+    // There are only three valid combinations of IVC recursion constraints for Aztec kernel circuits:
+
+    // Case: INIT kernel; single Oink recursive verification of an app
+    if (constraints.size() == 1 && constraints[0].proof_type == oink_type) {
+        mock_ivc_accumulation(ivc, ClientIVC::QUEUE_TYPE::OINK, /*is_kernel=*/false);
+        return ivc;
+    }
+
+    // Case: RESET or TAIL kernel; single PG recursive verification of a kernel
+    if (constraints.size() == 1 && constraints[0].proof_type == pg_type) {
+        ivc->verifier_accumulator = create_mock_decider_vk();
+        mock_ivc_accumulation(ivc, ClientIVC::QUEUE_TYPE::PG, /*is_kernel=*/true);
+        return ivc;
+    }
+
+    // Case: INNER kernel; two PG recursive verifications, kernel and app in that order
+    if (constraints.size() == 2) {
+        ASSERT(constraints[0].proof_type == pg_type && constraints[1].proof_type == pg_type);
+        ivc->verifier_accumulator = create_mock_decider_vk();
+        mock_ivc_accumulation(ivc, ClientIVC::QUEUE_TYPE::PG, /*is_kernel=*/true);
+        mock_ivc_accumulation(ivc, ClientIVC::QUEUE_TYPE::PG, /*is_kernel=*/false);
+        return ivc;
+    }
+
+    ASSERT(false && "WARNING: Invalid set of IVC recursion constraints!");
+    return ivc;
+}
+
+/**
+ * @brief Create a mock verification queue entry with proof and VK that have the correct structure but are not
+ * necessarily valid
+ *
+ */
+ClientIVC::VerifierInputs create_mock_verification_queue_entry(const ClientIVC::QUEUE_TYPE verification_type,
+                                                               const TraceSettings& trace_settings,
+                                                               const bool is_kernel)
+{
+    using FF = ClientIVC::FF;
+    using MegaVerificationKey = ClientIVC::MegaVerificationKey;
+
+    // Use the trace settings to determine the correct dyadic size and the public inputs offset
+    MegaExecutionTraceBlocks blocks;
+    blocks.set_fixed_block_sizes(trace_settings);
+    blocks.compute_offsets(/*is_structured=*/true);
+    size_t dyadic_size = blocks.get_structured_dyadic_size();
+    size_t pub_inputs_offset = blocks.pub_inputs.trace_offset();
+    // All circuits have pairing point public inputs; kernels have additional public inputs for two databus commitments
+    size_t num_public_inputs = bb::PAIRING_POINTS_SIZE;
+    if (is_kernel) {
+        num_public_inputs += bb::PROPAGATED_DATABUS_COMMITMENTS_SIZE;
+    }
+
+    // Construct a mock Oink or PG proof
+    std::vector<FF> proof;
+    if (verification_type == ClientIVC::QUEUE_TYPE::OINK) {
+        proof = create_mock_oink_proof(num_public_inputs);
+    } else { // ClientIVC::QUEUE_TYPE::PG)
+        proof = create_mock_pg_proof(num_public_inputs);
+    }
+
+    // Construct a mock MegaHonk verification key
+    std::shared_ptr<MegaVerificationKey> verification_key =
+        create_mock_honk_vk(dyadic_size, num_public_inputs, pub_inputs_offset);
+
+    // If the verification queue entry corresponds to a kernel circuit, set the databus data to indicate the presence of
+    // propagated return data commitments on the public inputs
+    if (is_kernel) {
+        verification_key->databus_propagation_data = bb::DatabusPropagationData::kernel_default();
+    }
+
+    return ClientIVC::VerifierInputs{ proof, verification_key, verification_type };
+}
+
+/**
+ * @brief Populate an IVC instance with data that mimics the state after a single IVC accumulation (Oink or PG)
+ * @details Mock state consists of a mock verification queue entry of type OINK (proof, VK) and a mocked merge proof
+ *
+ * @param ivc
+ * @param num_public_inputs_app num pub inputs in accumulated app, excluding fixed components, e.g. pairing points
+ */
+void mock_ivc_accumulation(const std::shared_ptr<ClientIVC>& ivc, ClientIVC::QUEUE_TYPE type, const bool is_kernel)
+{
+    ClientIVC::VerifierInputs entry =
+        acir_format::create_mock_verification_queue_entry(type, ivc->trace_settings, is_kernel);
+    ivc->verification_queue.emplace_back(entry);
+    ivc->goblin.merge_verification_queue.emplace_back(acir_format::create_dummy_merge_proof());
+    ivc->initialized = true;
 }
 
 /**

--- a/barretenberg/cpp/src/barretenberg/dsl/acir_format/ivc_recursion_constraint.hpp
+++ b/barretenberg/cpp/src/barretenberg/dsl/acir_format/ivc_recursion_constraint.hpp
@@ -19,20 +19,6 @@ std::shared_ptr<ClientIVC> create_mock_ivc_from_constraints(const std::vector<Re
 
 void mock_ivc_accumulation(const std::shared_ptr<ClientIVC>& ivc, ClientIVC::QUEUE_TYPE type, const bool is_kernel);
 
-std::vector<ClientIVC::FF> create_mock_oink_proof(const size_t num_public_inputs);
-
-std::vector<ClientIVC::FF> create_mock_pg_proof(const size_t num_public_inputs);
-
-std::shared_ptr<ClientIVC::MegaVerificationKey> create_mock_honk_vk(const size_t dyadic_size,
-                                                                    const size_t num_public_inputs,
-                                                                    const size_t pub_inputs_offset);
-
-std::shared_ptr<ClientIVC::DeciderVerificationKey> create_mock_decider_vk();
-
-ClientIVC::VerifierInputs create_mock_verification_queue_entry(const ClientIVC::QUEUE_TYPE type,
-                                                               const TraceSettings& trace_settings,
-                                                               const bool is_kernel);
-
 Goblin::MergeProof create_dummy_merge_proof();
 
 void populate_dummy_vk_in_constraint(MegaCircuitBuilder& builder,

--- a/barretenberg/cpp/src/barretenberg/dsl/acir_format/ivc_recursion_constraint.test.cpp
+++ b/barretenberg/cpp/src/barretenberg/dsl/acir_format/ivc_recursion_constraint.test.cpp
@@ -98,7 +98,8 @@ class IvcRecursionConstraintTest : public ::testing::Test {
                 EXPECT_FALSE(verifier.verify_proof(inner_proof));
             }
             // Instantiate the recursive verifier using the native verification key
-            stdlib::recursion::honk::UltraRecursiveVerifier_<RecursiveFlavor> verifier(&circuit, honk_vk);
+            auto stdlib_vk_and_hash = std::make_shared<RecursiveFlavor::VKAndHash>(circuit, honk_vk);
+            stdlib::recursion::honk::UltraRecursiveVerifier_<RecursiveFlavor> verifier(&circuit, stdlib_vk_and_hash);
 
             VerifierOutput output = verifier.verify_proof(inner_proof);
             output.points_accumulator.set_public(); // useless for now but just checking if it breaks anything
@@ -118,12 +119,14 @@ class IvcRecursionConstraintTest : public ::testing::Test {
     static RecursionConstraint create_recursion_constraint(const VerifierInputs& input, SlabVector<FF>& witness)
     {
         // Assemble simple vectors of witnesses for vkey and proof
-        std::vector<FF> key_witnesses = input.honk_verification_key->to_field_elements();
+        std::vector<FF> key_witnesses = input.honk_vk->to_field_elements();
+        FF key_hash_witness = input.honk_vk->hash();
         std::vector<FF> proof_witnesses = input.proof; // proof contains the public inputs at this stage
 
         // Construct witness indices for each component in the constraint; populate the witness array
-        auto [key_indices, proof_indices, public_inputs_indices] = ProofSurgeon::populate_recursion_witness_data(
-            witness, proof_witnesses, key_witnesses, /*num_public_inputs_to_extract=*/0);
+        auto [key_indices, key_hash_index, proof_indices, public_inputs_indices] =
+            ProofSurgeon::populate_recursion_witness_data(
+                witness, proof_witnesses, key_witnesses, key_hash_witness, /*num_public_inputs_to_extract=*/0);
 
         // The proof type can be either Oink or PG
         PROOF_TYPE proof_type = input.type == QUEUE_TYPE::OINK ? OINK : PG;
@@ -132,7 +135,7 @@ class IvcRecursionConstraintTest : public ::testing::Test {
             .key = key_indices,
             .proof = {}, // the proof witness indices are not needed in an ivc recursion constraint
             .public_inputs = public_inputs_indices,
-            .key_hash = 0, // not used
+            .key_hash = key_hash_index,
             .proof_type = proof_type,
         };
     }
@@ -186,8 +189,6 @@ class IvcRecursionConstraintTest : public ::testing::Test {
         // Manually construct the VK for the kernel circuit
         auto proving_key = std::make_shared<ClientIVC::DeciderProvingKey>(kernel, trace_settings);
         auto verification_key = std::make_shared<ClientIVC::MegaVerificationKey>(proving_key->proving_key);
-        MegaProver prover(proving_key, verification_key);
-
         return verification_key;
     }
 
@@ -285,7 +286,7 @@ TEST_F(IvcRecursionConstraintTest, GenerateInitKernelVKFromConstraints)
         Builder kernel = acir_format::create_circuit<Builder>(program, metadata);
 
         ivc->accumulate(kernel);
-        expected_kernel_vk = ivc->verification_queue.back().honk_verification_key;
+        expected_kernel_vk = ivc->verification_queue.back().honk_vk;
     }
 
     // Now, construct the kernel VK by mocking the post app accumulation state of the IVC
@@ -335,7 +336,7 @@ TEST_F(IvcRecursionConstraintTest, GenerateResetKernelVKFromConstraints)
             ivc->accumulate(kernel);
         }
 
-        expected_kernel_vk = ivc->verification_queue.back().honk_verification_key;
+        expected_kernel_vk = ivc->verification_queue.back().honk_vk;
     }
 
     // Now, construct the kernel VK by mocking the IVC state prior to kernel construction
@@ -392,7 +393,7 @@ TEST_F(IvcRecursionConstraintTest, GenerateInnerKernelVKFromConstraints)
             ivc->accumulate(kernel);
         }
 
-        expected_kernel_vk = ivc->verification_queue.back().honk_verification_key;
+        expected_kernel_vk = ivc->verification_queue.back().honk_vk;
     }
 
     // Now, construct the kernel VK by mocking the IVC state prior to kernel construction

--- a/barretenberg/cpp/src/barretenberg/dsl/acir_format/proof_surgeon.hpp
+++ b/barretenberg/cpp/src/barretenberg/dsl/acir_format/proof_surgeon.hpp
@@ -42,7 +42,7 @@ class ProofSurgeon {
                                                             bool ipa_accumulation)
     {
         // Convert verification key to fields
-        std::vector<FF> vkey_fields = verification_key->to_field_elements();
+        std::vector<FF> vk_fields = verification_key->to_field_elements();
 
         // Get public inputs by cutting them out of the proof
         size_t num_public_inputs_to_extract =
@@ -58,7 +58,7 @@ class ProofSurgeon {
         // Construct json-style output for each component
         std::string proof_json = to_json(proof);
         std::string pub_inputs_json = to_json(public_inputs);
-        std::string vk_json = to_json(vkey_fields);
+        std::string vk_json = to_json(vk_fields);
 
         // Format with labels for noir recursion input
         std::string toml_content = "key_hash = " + format("\"", FF(0), "\"") + "\n"; // not used by honk
@@ -139,6 +139,7 @@ class ProofSurgeon {
 
     struct RecursionWitnessData {
         std::vector<uint32_t> key_indices;
+        uint32_t key_hash_index;
         std::vector<uint32_t> proof_indices;
         std::vector<uint32_t> public_inputs_indices;
     };
@@ -159,6 +160,7 @@ class ProofSurgeon {
     static RecursionWitnessData populate_recursion_witness_data(bb::SlabVector<bb::fr>& witness,
                                                                 std::vector<bb::fr>& proof_witnesses,
                                                                 const std::vector<bb::fr>& key_witnesses,
+                                                                const bb::fr& key_hash_witness,
                                                                 const size_t num_public_inputs_to_extract)
     {
         // Extract all public inputs except for those corresponding to the aggregation object
@@ -180,10 +182,11 @@ class ProofSurgeon {
 
         // Append key, proof, and public inputs while storing the associated witness indices
         std::vector<uint32_t> key_indices = add_to_witness_and_track_indices(witness, key_witnesses);
+        uint32_t key_hash_index = add_to_witness_and_track_indices(witness, { key_hash_witness })[0];
         std::vector<uint32_t> proof_indices = add_to_witness_and_track_indices(witness, proof_witnesses);
         std::vector<uint32_t> public_input_indices = add_to_witness_and_track_indices(witness, public_input_witnesses);
 
-        return { key_indices, proof_indices, public_input_indices };
+        return { key_indices, key_hash_index, proof_indices, public_input_indices };
     }
 };
 

--- a/barretenberg/cpp/src/barretenberg/flavor/flavor.hpp
+++ b/barretenberg/cpp/src/barretenberg/flavor/flavor.hpp
@@ -216,9 +216,10 @@ template <typename PrecomputedCommitments> class NativeVerificationKey_ : public
  * @tparam FF
  * @tparam PrecomputedCommitments
  */
-template <typename Builder, typename PrecomputedCommitments>
+template <typename Builder_, typename PrecomputedCommitments>
 class StdlibVerificationKey_ : public PrecomputedCommitments {
   public:
+    using Builder = Builder_;
     using FF = stdlib::field_t<Builder>;
     using Commitment = typename PrecomputedCommitments::DataType;
     using Transcript = BaseTranscript<stdlib::recursion::honk::StdlibTranscriptParams<Builder>>;
@@ -293,16 +294,40 @@ class StdlibVerificationKey_ : public PrecomputedCommitments {
      */
     virtual void add_to_transcript(const std::string& domain_separator, Transcript& transcript)
     {
-        transcript.add_to_hash_buffer(domain_separator + "vkey_circuit_size", this->circuit_size);
-        transcript.add_to_hash_buffer(domain_separator + "vkey_num_public_inputs", this->num_public_inputs);
-        transcript.add_to_hash_buffer(domain_separator + "vkey_pub_inputs_offset", this->pub_inputs_offset);
+        transcript.add_to_hash_buffer(domain_separator + "vk_circuit_size", this->circuit_size);
+        transcript.add_to_hash_buffer(domain_separator + "vk_num_public_inputs", this->num_public_inputs);
+        transcript.add_to_hash_buffer(domain_separator + "vk_pub_inputs_offset", this->pub_inputs_offset);
         FF pairing_points_start_idx(this->pairing_inputs_public_input_key.start_idx);
         pairing_points_start_idx.convert_constant_to_fixed_witness(this->circuit_size.context);
-        transcript.add_to_hash_buffer(domain_separator + "vkey_pairing_points_start_idx", pairing_points_start_idx);
+        transcript.add_to_hash_buffer(domain_separator + "vk_pairing_points_start_idx", pairing_points_start_idx);
         for (const Commitment& commitment : this->get_all()) {
-            transcript.add_to_hash_buffer(domain_separator + "vkey_commitment", commitment);
+            transcript.add_to_hash_buffer(domain_separator + "vk_commitment", commitment);
         }
     }
+};
+
+template <typename FF, typename VerificationKey> class VKAndHash_ {
+  public:
+    using Builder = VerificationKey::Builder;
+    using NativeVerificationKey = VerificationKey::NativeVerificationKey;
+
+    VKAndHash_() = default;
+    VKAndHash_(const std::shared_ptr<VerificationKey>& vk)
+        : vk(vk)
+        , hash(vk->hash())
+    {}
+
+    VKAndHash_(const std::shared_ptr<VerificationKey>& vk, const FF& hash)
+        : vk(vk)
+        , hash(hash)
+    {}
+
+    VKAndHash_(Builder& builder, const std::shared_ptr<NativeVerificationKey>& native_vk)
+        : vk(std::make_shared<VerificationKey>(&builder, native_vk))
+        , hash(FF::from_witness(&builder, native_vk->hash()))
+    {}
+    std::shared_ptr<VerificationKey> vk;
+    FF hash;
 };
 
 // Because of how Gemini is written, it is important to put the polynomials out in this order.

--- a/barretenberg/cpp/src/barretenberg/flavor/mega_flavor.hpp
+++ b/barretenberg/cpp/src/barretenberg/flavor/mega_flavor.hpp
@@ -457,7 +457,6 @@ class MegaFlavor {
         // Data pertaining to transfer of databus return data via public inputs of the proof being recursively verified
         DatabusPropagationData databus_propagation_data;
 
-        bool operator==(const VerificationKey&) const = default;
         VerificationKey() = default;
         VerificationKey(const size_t circuit_size, const size_t num_public_inputs)
             : NativeVerificationKey_(circuit_size, num_public_inputs)
@@ -535,21 +534,20 @@ class MegaFlavor {
          */
         void add_to_transcript(const std::string& domain_separator, Transcript& transcript)
         {
-            transcript.add_to_hash_buffer(domain_separator + "vkey_circuit_size", this->circuit_size);
-            transcript.add_to_hash_buffer(domain_separator + "vkey_num_public_inputs", this->num_public_inputs);
-            transcript.add_to_hash_buffer(domain_separator + "vkey_pub_inputs_offset", this->pub_inputs_offset);
-            transcript.add_to_hash_buffer(domain_separator + "vkey_pairing_points_start_idx",
+            transcript.add_to_hash_buffer(domain_separator + "vk_circuit_size", this->circuit_size);
+            transcript.add_to_hash_buffer(domain_separator + "vk_num_public_inputs", this->num_public_inputs);
+            transcript.add_to_hash_buffer(domain_separator + "vk_pub_inputs_offset", this->pub_inputs_offset);
+            transcript.add_to_hash_buffer(domain_separator + "vk_pairing_points_start_idx",
                                           this->pairing_inputs_public_input_key.start_idx);
             transcript.add_to_hash_buffer(
-                domain_separator + "vkey_app_return_data_commitment_start_idx",
+                domain_separator + "vk_app_return_data_commitment_start_idx",
                 this->databus_propagation_data.app_return_data_commitment_pub_input_key.start_idx);
             transcript.add_to_hash_buffer(
-                domain_separator + "vkey_kernel_return_data_commitment_start_idx",
+                domain_separator + "vk_kernel_return_data_commitment_start_idx",
                 this->databus_propagation_data.kernel_return_data_commitment_pub_input_key.start_idx);
-            transcript.add_to_hash_buffer(domain_separator + "vkey_is_kernel",
-                                          this->databus_propagation_data.is_kernel);
+            transcript.add_to_hash_buffer(domain_separator + "vk_is_kernel", this->databus_propagation_data.is_kernel);
             for (const Commitment& commitment : this->get_all()) {
-                transcript.add_to_hash_buffer(domain_separator + "vkey_commitment", commitment);
+                transcript.add_to_hash_buffer(domain_separator + "vk_commitment", commitment);
             }
         }
 

--- a/barretenberg/cpp/src/barretenberg/flavor/native_verification_key.test.cpp
+++ b/barretenberg/cpp/src/barretenberg/flavor/native_verification_key.test.cpp
@@ -56,9 +56,9 @@ TYPED_TEST(NativeVerificationKeyTests, VKHashingConsistency)
     std::vector<fr> vk_field_elements = vk.to_field_elements();
     NativeTranscript transcript;
     for (const auto& field_element : vk_field_elements) {
-        transcript.add_to_hash_buffer("vkey_element", field_element);
+        transcript.add_to_hash_buffer("vk_element", field_element);
     }
-    fr vkey_hash_1 = transcript.get_challenge<fr>("vkey_hash");
+    fr vkey_hash_1 = transcript.get_challenge<fr>("vk_hash");
     // Second method of hashing: using hash().
     fr vkey_hash_2 = vk.hash();
     EXPECT_EQ(vkey_hash_1, vkey_hash_2);
@@ -68,7 +68,7 @@ TYPED_TEST(NativeVerificationKeyTests, VKHashingConsistency)
         // Third method of hashing: using add_to_transcript.
         typename Flavor::Transcript transcript_2;
         vk.add_to_transcript("", transcript_2);
-        fr vkey_hash_3 = transcript_2.template get_challenge<fr>("vkey_hash");
+        fr vkey_hash_3 = transcript_2.template get_challenge<fr>("vk_hash");
         EXPECT_EQ(vkey_hash_2, vkey_hash_3);
     }
 }

--- a/barretenberg/cpp/src/barretenberg/flavor/stdlib_verification_key.test.cpp
+++ b/barretenberg/cpp/src/barretenberg/flavor/stdlib_verification_key.test.cpp
@@ -68,15 +68,15 @@ TYPED_TEST(StdlibVerificationKeyTests, VKHashingConsistency)
     std::vector<FF> vk_field_elements = vk.to_field_elements();
     StdlibTranscript transcript;
     for (const auto& field_element : vk_field_elements) {
-        transcript.add_to_hash_buffer("vkey_element", field_element);
+        transcript.add_to_hash_buffer("vk_element", field_element);
     }
-    FF vkey_hash_1 = transcript.template get_challenge<FF>("vkey_hash");
+    FF vkey_hash_1 = transcript.template get_challenge<FF>("vk_hash");
     // Second method of hashing: using hash().
     FF vkey_hash_2 = vk.hash(outer_builder);
     EXPECT_EQ(vkey_hash_1.get_value(), vkey_hash_2.get_value());
     // Third method of hashing: using add_to_transcript.
     StdlibTranscript transcript_2;
     vk.add_to_transcript("", transcript_2);
-    FF vkey_hash_3 = transcript_2.template get_challenge<FF>("vkey_hash");
+    FF vkey_hash_3 = transcript_2.template get_challenge<FF>("vk_hash");
     EXPECT_EQ(vkey_hash_2.get_value(), vkey_hash_3.get_value());
 }

--- a/barretenberg/cpp/src/barretenberg/flavor/ultra_flavor.hpp
+++ b/barretenberg/cpp/src/barretenberg/flavor/ultra_flavor.hpp
@@ -425,13 +425,13 @@ class UltraFlavor {
         template <typename Transcript>
         void add_to_transcript(const std::string& domain_separator, Transcript& transcript)
         {
-            transcript.add_to_hash_buffer(domain_separator + "vkey_circuit_size", this->circuit_size);
-            transcript.add_to_hash_buffer(domain_separator + "vkey_num_public_inputs", this->num_public_inputs);
-            transcript.add_to_hash_buffer(domain_separator + "vkey_pub_inputs_offset", this->pub_inputs_offset);
-            transcript.add_to_hash_buffer(domain_separator + "vkey_pairing_points_start_idx",
+            transcript.add_to_hash_buffer(domain_separator + "vk_circuit_size", this->circuit_size);
+            transcript.add_to_hash_buffer(domain_separator + "vk_num_public_inputs", this->num_public_inputs);
+            transcript.add_to_hash_buffer(domain_separator + "vk_pub_inputs_offset", this->pub_inputs_offset);
+            transcript.add_to_hash_buffer(domain_separator + "vk_pairing_points_start_idx",
                                           this->pairing_inputs_public_input_key.start_idx);
             for (const Commitment& commitment : this->get_all()) {
-                transcript.add_to_hash_buffer(domain_separator + "vkey_commitment", commitment);
+                transcript.add_to_hash_buffer(domain_separator + "vk_commitment", commitment);
             }
         }
 

--- a/barretenberg/cpp/src/barretenberg/flavor/ultra_keccak_flavor.hpp
+++ b/barretenberg/cpp/src/barretenberg/flavor/ultra_keccak_flavor.hpp
@@ -110,14 +110,14 @@ class UltraKeccakFlavor : public bb::UltraFlavor {
          */
         void add_to_transcript(const std::string& domain_separator, Transcript& transcript)
         {
-            transcript.add_to_hash_buffer(domain_separator + "vkey_circuit_size", this->circuit_size);
-            transcript.add_to_hash_buffer(domain_separator + "vkey_num_public_inputs", this->num_public_inputs);
-            transcript.add_to_hash_buffer(domain_separator + "vkey_pub_inputs_offset", this->pub_inputs_offset);
+            transcript.add_to_hash_buffer(domain_separator + "vk_circuit_size", this->circuit_size);
+            transcript.add_to_hash_buffer(domain_separator + "vk_num_public_inputs", this->num_public_inputs);
+            transcript.add_to_hash_buffer(domain_separator + "vk_pub_inputs_offset", this->pub_inputs_offset);
             // TODO(https://github.com/AztecProtocol/barretenberg/issues/1427): The rest is commented out because the
             // solidity contract hasn't been modified yet to fiat shamir the full vk hash. This will be fixed in a
             // followup PR.
             // for (const Commitment& commitment : this->get_all()) {
-            //     transcript->add_to_hash_buffer(domain_separator + "vkey_commitment", commitment);
+            //     transcript->add_to_hash_buffer(domain_separator + "vk_commitment", commitment);
             // }
         }
 

--- a/barretenberg/cpp/src/barretenberg/flavor/ultra_recursive_flavor.hpp
+++ b/barretenberg/cpp/src/barretenberg/flavor/ultra_recursive_flavor.hpp
@@ -117,6 +117,8 @@ template <typename BuilderType> class UltraRecursiveFlavor_ {
      */
     class VerificationKey : public StdlibVerificationKey_<BuilderType, UltraFlavor::PrecomputedEntities<Commitment>> {
       public:
+        using NativeVerificationKey = NativeFlavor::VerificationKey;
+
         /**
          * @brief Construct a new Verification Key with stdlib types from a provided native verification key
          *
@@ -176,12 +178,12 @@ template <typename BuilderType> class UltraRecursiveFlavor_ {
         static VerificationKey from_witness_indices(CircuitBuilder& builder,
                                                     const std::span<const uint32_t>& witness_indices)
         {
-            std::vector<FF> vkey_fields;
-            vkey_fields.reserve(witness_indices.size());
+            std::vector<FF> vk_fields;
+            vk_fields.reserve(witness_indices.size());
             for (const auto& idx : witness_indices) {
-                vkey_fields.emplace_back(FF::from_witness_index(&builder, idx));
+                vk_fields.emplace_back(FF::from_witness_index(&builder, idx));
             }
-            return VerificationKey(builder, vkey_fields);
+            return VerificationKey(builder, vk_fields);
         }
     };
 
@@ -201,6 +203,8 @@ template <typename BuilderType> class UltraRecursiveFlavor_ {
 
     // Reuse the VerifierCommitments from Ultra
     using VerifierCommitments = UltraFlavor::VerifierCommitments_<Commitment, VerificationKey>;
+
+    using VKAndHash = VKAndHash_<FF, VerificationKey>;
 };
 
 } // namespace bb

--- a/barretenberg/cpp/src/barretenberg/flavor/ultra_rollup_flavor.hpp
+++ b/barretenberg/cpp/src/barretenberg/flavor/ultra_rollup_flavor.hpp
@@ -91,15 +91,15 @@ class UltraRollupFlavor : public bb::UltraFlavor {
          */
         void add_to_transcript(const std::string& domain_separator, Transcript& transcript)
         {
-            transcript.add_to_hash_buffer(domain_separator + "vkey_circuit_size", this->circuit_size);
-            transcript.add_to_hash_buffer(domain_separator + "vkey_num_public_inputs", this->num_public_inputs);
-            transcript.add_to_hash_buffer(domain_separator + "vkey_pub_inputs_offset", this->pub_inputs_offset);
-            transcript.add_to_hash_buffer(domain_separator + "vkey_pairing_points_start_idx",
+            transcript.add_to_hash_buffer(domain_separator + "vk_circuit_size", this->circuit_size);
+            transcript.add_to_hash_buffer(domain_separator + "vk_num_public_inputs", this->num_public_inputs);
+            transcript.add_to_hash_buffer(domain_separator + "vk_pub_inputs_offset", this->pub_inputs_offset);
+            transcript.add_to_hash_buffer(domain_separator + "vk_pairing_points_start_idx",
                                           this->pairing_inputs_public_input_key.start_idx);
-            transcript.add_to_hash_buffer(domain_separator + "vkey_ipa_claim_start_idx",
+            transcript.add_to_hash_buffer(domain_separator + "vk_ipa_claim_start_idx",
                                           ipa_claim_public_input_key.start_idx);
             for (const Commitment& commitment : this->get_all()) {
-                transcript.add_to_hash_buffer(domain_separator + "vkey_commitment", commitment);
+                transcript.add_to_hash_buffer(domain_separator + "vk_commitment", commitment);
             }
         }
 

--- a/barretenberg/cpp/src/barretenberg/flavor/ultra_rollup_recursive_flavor.hpp
+++ b/barretenberg/cpp/src/barretenberg/flavor/ultra_rollup_recursive_flavor.hpp
@@ -57,8 +57,11 @@ template <typename BuilderType> class UltraRollupRecursiveFlavor_ : public Ultra
      * that, and split out separate PrecomputedPolynomials/Commitments data for clarity but also for portability of our
      * circuits.
      */
-    class VerificationKey : public StdlibVerificationKey_<BuilderType, UltraFlavor::PrecomputedEntities<Commitment>> {
+    class VerificationKey
+        : public StdlibVerificationKey_<BuilderType, UltraRollupFlavor::PrecomputedEntities<Commitment>> {
       public:
+        using NativeVerificationKey = NativeFlavor::VerificationKey;
+
         PublicComponentKey ipa_claim_public_input_key; // needs to be a circuit constant
 
         /**
@@ -165,19 +168,19 @@ template <typename BuilderType> class UltraRollupRecursiveFlavor_ : public Ultra
          */
         void add_to_transcript(const std::string& domain_separator, Transcript& transcript) override
         {
-            transcript.add_to_hash_buffer(domain_separator + "vkey_circuit_size", this->circuit_size);
-            transcript.add_to_hash_buffer(domain_separator + "vkey_num_public_inputs", this->num_public_inputs);
-            transcript.add_to_hash_buffer(domain_separator + "vkey_pub_inputs_offset", this->pub_inputs_offset);
+            transcript.add_to_hash_buffer(domain_separator + "vk_circuit_size", this->circuit_size);
+            transcript.add_to_hash_buffer(domain_separator + "vk_num_public_inputs", this->num_public_inputs);
+            transcript.add_to_hash_buffer(domain_separator + "vk_pub_inputs_offset", this->pub_inputs_offset);
             FF pairing_points_start_idx(this->pairing_inputs_public_input_key.start_idx);
             CircuitBuilder* builder = this->circuit_size.context;
             pairing_points_start_idx.convert_constant_to_fixed_witness(
                 builder); // We can't use poseidon2 with constants.
-            transcript.add_to_hash_buffer(domain_separator + "vkey_pairing_points_start_idx", pairing_points_start_idx);
+            transcript.add_to_hash_buffer(domain_separator + "vk_pairing_points_start_idx", pairing_points_start_idx);
             FF ipa_claim_start_idx(this->ipa_claim_public_input_key.start_idx);
             ipa_claim_start_idx.convert_constant_to_fixed_witness(builder); // We can't use poseidon2 with constants.
-            transcript.add_to_hash_buffer(domain_separator + "vkey_ipa_claim_start_idx", ipa_claim_start_idx);
+            transcript.add_to_hash_buffer(domain_separator + "vk_ipa_claim_start_idx", ipa_claim_start_idx);
             for (const Commitment& commitment : this->get_all()) {
-                transcript.add_to_hash_buffer(domain_separator + "vkey_commitment", commitment);
+                transcript.add_to_hash_buffer(domain_separator + "vk_commitment", commitment);
             }
         }
 
@@ -191,17 +194,18 @@ template <typename BuilderType> class UltraRollupRecursiveFlavor_ : public Ultra
         static VerificationKey from_witness_indices(CircuitBuilder& builder,
                                                     const std::span<const uint32_t> witness_indices)
         {
-            std::vector<FF> vkey_fields;
-            vkey_fields.reserve(witness_indices.size());
+            std::vector<FF> vk_fields;
+            vk_fields.reserve(witness_indices.size());
             for (const auto& idx : witness_indices) {
-                vkey_fields.emplace_back(FF::from_witness_index(&builder, idx));
+                vk_fields.emplace_back(FF::from_witness_index(&builder, idx));
             }
-            return VerificationKey(builder, vkey_fields);
+            return VerificationKey(builder, vk_fields);
         }
     };
 
     // Reuse the VerifierCommitments from Ultra
     using VerifierCommitments = UltraFlavor::VerifierCommitments_<Commitment, VerificationKey>;
+    using VKAndHash = VKAndHash_<FF, VerificationKey>;
 };
 
 } // namespace bb

--- a/barretenberg/cpp/src/barretenberg/goblin/mock_circuits.hpp
+++ b/barretenberg/cpp/src/barretenberg/goblin/mock_circuits.hpp
@@ -56,7 +56,7 @@ class GoblinMockCircuits {
     using DeciderVerificationKey = bb::DeciderVerificationKey_<Flavor>;
     using RecursiveDeciderVerificationKey =
         ::bb::stdlib::recursion::honk::RecursiveDeciderVerificationKey_<RecursiveFlavor>;
-    using RecursiveVerificationKey = RecursiveDeciderVerificationKey::VerificationKey;
+    using RecursiveVKAndHash = RecursiveDeciderVerificationKey::VKAndHash;
     using RecursiveVerifierAccumulator = std::shared_ptr<RecursiveDeciderVerificationKey>;
     using VerificationKey = Flavor::VerificationKey;
 

--- a/barretenberg/cpp/src/barretenberg/protogalaxy/protogalaxy_prover_impl.hpp
+++ b/barretenberg/cpp/src/barretenberg/protogalaxy/protogalaxy_prover_impl.hpp
@@ -21,8 +21,7 @@ void ProtogalaxyProver_<Flavor, NUM_KEYS>::run_oink_prover_on_one_incomplete_key
 {
 
     PROFILE_THIS_NAME("ProtogalaxyProver::run_oink_prover_on_one_incomplete_key");
-    OinkProver<typename DeciderProvingKeys::Flavor> oink_prover(
-        key, vk->verification_key, transcript, domain_separator + '_');
+    OinkProver<typename DeciderProvingKeys::Flavor> oink_prover(key, vk->vk, transcript, domain_separator + '_');
     oink_prover.prove();
 }
 

--- a/barretenberg/cpp/src/barretenberg/protogalaxy/protogalaxy_verifier.cpp
+++ b/barretenberg/cpp/src/barretenberg/protogalaxy/protogalaxy_verifier.cpp
@@ -110,13 +110,13 @@ std::shared_ptr<typename DeciderVerificationKeys::DeciderVK> ProtogalaxyVerifier
     const FF combiner_quotient_evaluation = combiner_quotient.evaluate(combiner_challenge);
 
     auto next_accumulator = std::make_shared<DeciderVK>();
-    next_accumulator->verification_key = std::make_shared<VerificationKey>(*accumulator->verification_key);
+    next_accumulator->vk = std::make_shared<VerificationKey>(*accumulator->vk);
     next_accumulator->is_accumulator = true;
 
     // Set the accumulator circuit size data based on the max of the keys being accumulated
     const size_t accumulator_log_circuit_size = keys_to_fold.get_max_log_circuit_size();
-    next_accumulator->verification_key->log_circuit_size = accumulator_log_circuit_size;
-    next_accumulator->verification_key->circuit_size = 1 << accumulator_log_circuit_size;
+    next_accumulator->vk->log_circuit_size = accumulator_log_circuit_size;
+    next_accumulator->vk->circuit_size = 1 << accumulator_log_circuit_size;
 
     // Compute next folding parameters
     const auto [vanishing_polynomial_at_challenge, lagranges] =
@@ -128,7 +128,7 @@ std::shared_ptr<typename DeciderVerificationKeys::DeciderVK> ProtogalaxyVerifier
 
     // // Fold the commitments
     for (auto [combination, to_combine] :
-         zip_view(next_accumulator->verification_key->get_all(), keys_to_fold.get_precomputed_commitments())) {
+         zip_view(next_accumulator->vk->get_all(), keys_to_fold.get_precomputed_commitments())) {
         combination = batch_mul_native(to_combine, lagranges);
     }
     for (auto [combination, to_combine] :

--- a/barretenberg/cpp/src/barretenberg/stdlib/client_ivc_verifier/client_ivc_recursive_verifier.cpp
+++ b/barretenberg/cpp/src/barretenberg/stdlib/client_ivc_verifier/client_ivc_recursive_verifier.cpp
@@ -15,10 +15,10 @@ ClientIVCRecursiveVerifier::Output ClientIVCRecursiveVerifier::verify(const Clie
 {
     std::shared_ptr<Transcript> civc_rec_verifier_transcript(std::make_shared<Transcript>());
     // Construct stdlib Mega verification key
-    auto stdlib_mega_vk = std::make_shared<RecursiveVerificationKey>(builder.get(), ivc_verification_key.mega);
+    auto stdlib_mega_vk_and_hash = std::make_shared<RecursiveVKAndHash>(*builder, ivc_verification_key.mega);
 
     // Perform recursive decider verification
-    MegaVerifier verifier{ builder.get(), stdlib_mega_vk, civc_rec_verifier_transcript };
+    MegaVerifier verifier{ builder.get(), stdlib_mega_vk_and_hash, civc_rec_verifier_transcript };
     MegaVerifier::Output mega_output = verifier.verify_proof(proof.mega_proof);
 
     // Perform Goblin recursive verification

--- a/barretenberg/cpp/src/barretenberg/stdlib/client_ivc_verifier/client_ivc_recursive_verifier.hpp
+++ b/barretenberg/cpp/src/barretenberg/stdlib/client_ivc_verifier/client_ivc_recursive_verifier.hpp
@@ -16,6 +16,7 @@ class ClientIVCRecursiveVerifier {
     using RecursiveDeciderVerificationKeys = RecursiveDeciderVerificationKeys_<RecursiveFlavor, 2>;
     using RecursiveDeciderVerificationKey = RecursiveDeciderVerificationKeys::DeciderVK;
     using RecursiveVerificationKey = RecursiveDeciderVerificationKeys::VerificationKey;
+    using RecursiveVKAndHash = RecursiveDeciderVerificationKeys::VKAndHash;
     using FoldingVerifier = ProtogalaxyRecursiveVerifier_<RecursiveDeciderVerificationKeys>;
     using MegaVerifier = UltraRecursiveVerifier_<RecursiveFlavor>;
     using GoblinVerifier = GoblinRecursiveVerifier;
@@ -26,7 +27,6 @@ class ClientIVCRecursiveVerifier {
 
   public:
     using Proof = ClientIVC::Proof;
-    using FoldVerifierInput = FoldingVerifier::VerifierInput;
     using GoblinVerificationKey = Goblin::VerificationKey;
     using Output = GoblinRecursiveVerifierOutput;
 

--- a/barretenberg/cpp/src/barretenberg/stdlib/client_ivc_verifier/client_ivc_recursive_verifier.test.cpp
+++ b/barretenberg/cpp/src/barretenberg/stdlib/client_ivc_verifier/client_ivc_recursive_verifier.test.cpp
@@ -10,7 +10,6 @@ class ClientIVCRecursionTests : public testing::Test {
   public:
     using Builder = UltraCircuitBuilder;
     using ClientIVCVerifier = ClientIVCRecursiveVerifier;
-    using FoldVerifierInput = ClientIVCVerifier::FoldVerifierInput;
     using Proof = ClientIVC::Proof;
     using RollupFlavor = UltraRollupRecursiveFlavor_<Builder>;
     using NativeFlavor = RollupFlavor::NativeFlavor;
@@ -127,9 +126,9 @@ TEST_F(ClientIVCRecursionTests, ClientTubeBase)
     // Construct a base rollup circuit that recursively verifies the tube proof and forwards the IPA proof.
     Builder base_builder;
     auto tube_vk = std::make_shared<NativeFlavor::VerificationKey>(proving_key->proving_key);
-    auto base_vk = std::make_shared<RollupFlavor::VerificationKey>(&base_builder, tube_vk);
+    auto stdlib_tube_vk_and_hash = std::make_shared<RollupFlavor::VKAndHash>(base_builder, tube_vk);
     stdlib::Proof<Builder> base_tube_proof(base_builder, native_tube_proof);
-    UltraRecursiveVerifier base_verifier{ &base_builder, base_vk };
+    UltraRecursiveVerifier base_verifier{ &base_builder, stdlib_tube_vk_and_hash };
     UltraRecursiveVerifierOutput<Builder> output = base_verifier.verify_proof(base_tube_proof);
     info("Tube UH Recursive Verifier: num prefinalized gates = ", base_builder.num_gates);
     output.points_accumulator.set_public();

--- a/barretenberg/cpp/src/barretenberg/stdlib/eccvm_verifier/eccvm_recursive_flavor.hpp
+++ b/barretenberg/cpp/src/barretenberg/stdlib/eccvm_verifier/eccvm_recursive_flavor.hpp
@@ -136,6 +136,8 @@ template <typename BuilderType> class ECCVMRecursiveFlavor_ {
     // Reuse the transcript from ECCVM
     using Transcript = bb::BaseTranscript<bb::stdlib::recursion::honk::StdlibTranscriptParams<CircuitBuilder>>;
 
+    using VKAndHash = VKAndHash_<VerificationKey, FF>;
+
 }; // NOLINTEND(cppcoreguidelines-avoid-const-or-ref-data-members)
 
 } // namespace bb

--- a/barretenberg/cpp/src/barretenberg/stdlib/honk_verifier/decider_recursive_verifier.cpp
+++ b/barretenberg/cpp/src/barretenberg/stdlib/honk_verifier/decider_recursive_verifier.cpp
@@ -30,12 +30,12 @@ DeciderRecursiveVerifier_<Flavor>::PairingPoints DeciderRecursiveVerifier_<Flavo
     StdlibProof stdlib_proof(*builder, proof);
     transcript->load_proof(stdlib_proof);
 
-    VerifierCommitments commitments{ accumulator->verification_key, accumulator->witness_commitments };
+    VerifierCommitments commitments{ accumulator->vk_and_hash->vk, accumulator->witness_commitments };
 
     const auto padding_indicator_array =
-        compute_padding_indicator_array<Curve, CONST_PROOF_SIZE_LOG_N>(accumulator->verification_key->log_circuit_size);
+        compute_padding_indicator_array<Curve, CONST_PROOF_SIZE_LOG_N>(accumulator->vk_and_hash->vk->log_circuit_size);
 
-    constrain_log_circuit_size(padding_indicator_array, accumulator->verification_key->circuit_size);
+    constrain_log_circuit_size(padding_indicator_array, accumulator->vk_and_hash->vk->circuit_size);
 
     Sumcheck sumcheck(transcript, accumulator->target_sum);
 

--- a/barretenberg/cpp/src/barretenberg/stdlib/honk_verifier/oink_recursive_verifier.cpp
+++ b/barretenberg/cpp/src/barretenberg/stdlib/honk_verifier/oink_recursive_verifier.cpp
@@ -19,10 +19,10 @@ namespace bb::stdlib::recursion::honk {
 
 template <typename Flavor>
 OinkRecursiveVerifier_<Flavor>::OinkRecursiveVerifier_(Builder* builder,
-                                                       const std::shared_ptr<RecursiveDeciderVK>& verification_key,
+                                                       const std::shared_ptr<RecursiveDeciderVK>& decider_vk,
                                                        const std::shared_ptr<Transcript>& transcript,
                                                        std::string domain_separator)
-    : verification_key(verification_key)
+    : decider_vk(decider_vk)
     , builder(builder)
     , transcript(transcript)
     , domain_separator(std::move(domain_separator))
@@ -30,9 +30,9 @@ OinkRecursiveVerifier_<Flavor>::OinkRecursiveVerifier_(Builder* builder,
 
 template <typename Flavor>
 OinkRecursiveVerifier_<Flavor>::OinkRecursiveVerifier_(Builder* builder,
-                                                       const std::shared_ptr<RecursiveDeciderVK>& verification_key,
+                                                       const std::shared_ptr<RecursiveDeciderVK>& decider_vk,
                                                        std::string domain_separator)
-    : verification_key(verification_key)
+    : decider_vk(decider_vk)
     , builder(builder)
     , domain_separator(std::move(domain_separator))
 {}
@@ -50,12 +50,13 @@ template <typename Flavor> void OinkRecursiveVerifier_<Flavor>::verify()
     WitnessCommitments commitments;
     CommitmentLabels labels;
 
-    verification_key->verification_key->add_to_transcript(domain_separator, *transcript);
-    auto [vkey_hash] = transcript->template get_challenges<FF>(domain_separator + "vkey_hash");
-    vinfo("vkey hash in Oink recursive verifier: ", vkey_hash);
+    decider_vk->vk_and_hash->vk->add_to_transcript(domain_separator, *transcript);
+    auto [vkey_hash] = transcript->template get_challenges<FF>(domain_separator + "vk_hash");
+    vinfo("vk hash in Oink recursive verifier: ", vkey_hash);
+    vinfo("expected vk hash: ", decider_vk->vk_and_hash->hash);
 
     size_t num_public_inputs =
-        static_cast<size_t>(static_cast<uint32_t>(verification_key->verification_key->num_public_inputs.get_value()));
+        static_cast<size_t>(static_cast<uint32_t>(decider_vk->vk_and_hash->vk->num_public_inputs.get_value()));
     std::vector<FF> public_inputs;
     for (size_t i = 0; i < num_public_inputs; ++i) {
         public_inputs.emplace_back(
@@ -109,8 +110,8 @@ template <typename Flavor> void OinkRecursiveVerifier_<Flavor>::verify()
         public_inputs,
         beta,
         gamma,
-        verification_key->verification_key->circuit_size,
-        static_cast<uint32_t>(verification_key->verification_key->pub_inputs_offset.get_value()));
+        decider_vk->vk_and_hash->vk->circuit_size,
+        static_cast<uint32_t>(decider_vk->vk_and_hash->vk->pub_inputs_offset.get_value()));
 
     // Get commitment to permutation and lookup grand products
     commitments.z_perm = transcript->template receive_from_prover<Commitment>(domain_separator + labels.z_perm);
@@ -122,11 +123,11 @@ template <typename Flavor> void OinkRecursiveVerifier_<Flavor>::verify()
     }
     alphas = transcript->template get_challenges<FF>(args);
 
-    verification_key->relation_parameters =
+    decider_vk->relation_parameters =
         RelationParameters<FF>{ eta, eta_two, eta_three, beta, gamma, public_input_delta };
-    verification_key->witness_commitments = std::move(commitments);
-    verification_key->public_inputs = std::move(public_inputs);
-    verification_key->alphas = std::move(alphas);
+    decider_vk->witness_commitments = std::move(commitments);
+    decider_vk->public_inputs = std::move(public_inputs);
+    decider_vk->alphas = std::move(alphas);
 }
 
 template class OinkRecursiveVerifier_<bb::UltraRecursiveFlavor_<UltraCircuitBuilder>>;

--- a/barretenberg/cpp/src/barretenberg/stdlib/honk_verifier/oink_recursive_verifier.hpp
+++ b/barretenberg/cpp/src/barretenberg/stdlib/honk_verifier/oink_recursive_verifier.hpp
@@ -34,7 +34,7 @@ template <typename Flavor> class OinkRecursiveVerifier_ {
      * @param domain_separator string used for differentiating verification_keys in the transcript (PG only)
      */
     explicit OinkRecursiveVerifier_(Builder* builder,
-                                    const std::shared_ptr<RecursiveDeciderVK>& verification_key,
+                                    const std::shared_ptr<RecursiveDeciderVK>& decider_vk,
                                     const std::shared_ptr<Transcript>& transcript,
                                     std::string domain_separator = "");
 
@@ -46,7 +46,7 @@ template <typename Flavor> class OinkRecursiveVerifier_ {
      * @param domain_separator string used for differentiating verification_keys in the transcript (PG only)
      */
     explicit OinkRecursiveVerifier_(Builder* builder,
-                                    const std::shared_ptr<RecursiveDeciderVK>& verification_key,
+                                    const std::shared_ptr<RecursiveDeciderVK>& decider_vk,
                                     std::string domain_separator = "");
 
     /**
@@ -61,7 +61,7 @@ template <typename Flavor> class OinkRecursiveVerifier_ {
      */
     void verify_proof(const OinkProof& proof);
 
-    std::shared_ptr<RecursiveDeciderVK> verification_key;
+    std::shared_ptr<RecursiveDeciderVK> decider_vk;
     Builder* builder;
     std::shared_ptr<Transcript> transcript = std::make_shared<Transcript>();
     std::string domain_separator; // used in PG to distinguish between verification_keys in transcript

--- a/barretenberg/cpp/src/barretenberg/stdlib/honk_verifier/ultra_recursive_verifier.hpp
+++ b/barretenberg/cpp/src/barretenberg/stdlib/honk_verifier/ultra_recursive_verifier.hpp
@@ -31,7 +31,7 @@ template <typename Flavor> class UltraRecursiveVerifier_ {
     using GroupElement = typename Flavor::GroupElement;
     using RecursiveDeciderVK = RecursiveDeciderVerificationKey_<Flavor>;
     using VerificationKey = typename Flavor::VerificationKey;
-    using NativeVerificationKey = typename Flavor::NativeVerificationKey;
+    using VKAndHash = typename Flavor::VKAndHash;
     using VerifierCommitmentKey = typename Flavor::VerifierCommitmentKey;
     using Builder = typename Flavor::CircuitBuilder;
     using RelationSeparator = typename Flavor::RelationSeparator;
@@ -42,10 +42,7 @@ template <typename Flavor> class UltraRecursiveVerifier_ {
     using StdlibProof = stdlib::Proof<Builder>;
 
     explicit UltraRecursiveVerifier_(Builder* builder,
-                                     const std::shared_ptr<NativeVerificationKey>& native_verifier_key,
-                                     const std::shared_ptr<Transcript>& transcript = std::make_shared<Transcript>());
-    explicit UltraRecursiveVerifier_(Builder* builder,
-                                     const std::shared_ptr<VerificationKey>& vkey,
+                                     const std::shared_ptr<VKAndHash>& vk_and_hash,
                                      const std::shared_ptr<Transcript>& transcript = std::make_shared<Transcript>());
 
     [[nodiscard("IPA claim and Pairing points should be accumulated")]] Output verify_proof(const HonkProof& proof);

--- a/barretenberg/cpp/src/barretenberg/stdlib/honk_verifier/ultra_recursive_verifier.test.cpp
+++ b/barretenberg/cpp/src/barretenberg/stdlib/honk_verifier/ultra_recursive_verifier.test.cpp
@@ -125,18 +125,18 @@ template <typename RecursiveFlavor> class RecursiveVerifierTest : public testing
         // Compute native verification key
         auto proving_key = std::make_shared<InnerDeciderProvingKey>(inner_circuit);
         auto honk_vk = std::make_shared<typename InnerFlavor::VerificationKey>(proving_key->proving_key);
-        InnerProver prover(proving_key, honk_vk); // A prerequisite for computing VK
+        auto stdlib_vk_and_hash = std::make_shared<typename RecursiveFlavor::VKAndHash>(outer_circuit, honk_vk);
         // Instantiate the recursive verifier using the native verification key
-        RecursiveVerifier verifier{ &outer_circuit, honk_vk };
+        RecursiveVerifier verifier{ &outer_circuit, stdlib_vk_and_hash };
 
         // Spot check some values in the recursive VK to ensure it was constructed correctly
-        EXPECT_EQ(static_cast<uint64_t>(verifier.key->verification_key->circuit_size.get_value()),
+        EXPECT_EQ(static_cast<uint64_t>(verifier.key->vk_and_hash->vk->circuit_size.get_value()),
                   honk_vk->circuit_size);
-        EXPECT_EQ(static_cast<uint64_t>(verifier.key->verification_key->log_circuit_size.get_value()),
+        EXPECT_EQ(static_cast<uint64_t>(verifier.key->vk_and_hash->vk->log_circuit_size.get_value()),
                   honk_vk->log_circuit_size);
-        EXPECT_EQ(static_cast<uint64_t>(verifier.key->verification_key->num_public_inputs.get_value()),
+        EXPECT_EQ(static_cast<uint64_t>(verifier.key->vk_and_hash->vk->num_public_inputs.get_value()),
                   honk_vk->num_public_inputs);
-        for (auto [vk_poly, native_vk_poly] : zip_view(verifier.key->verification_key->get_all(), honk_vk->get_all())) {
+        for (auto [vk_poly, native_vk_poly] : zip_view(verifier.key->vk_and_hash->vk->get_all(), honk_vk->get_all())) {
             EXPECT_EQ(vk_poly.get_value(), native_vk_poly);
         }
     }
@@ -165,7 +165,9 @@ template <typename RecursiveFlavor> class RecursiveVerifierTest : public testing
 
             // Create a recursive verification circuit for the proof of the inner circuit
             OuterBuilder outer_circuit;
-            RecursiveVerifier verifier{ &outer_circuit, verification_key };
+            auto stdlib_vk_and_hash =
+                std::make_shared<typename RecursiveFlavor::VKAndHash>(outer_circuit, verification_key);
+            RecursiveVerifier verifier{ &outer_circuit, stdlib_vk_and_hash };
 
             typename RecursiveVerifier::Output verifier_output = verifier.verify_proof(inner_proof);
             verifier_output.points_accumulator.set_public();
@@ -205,7 +207,9 @@ template <typename RecursiveFlavor> class RecursiveVerifierTest : public testing
 
         // Create a recursive verification circuit for the proof of the inner circuit
         OuterBuilder outer_circuit;
-        RecursiveVerifier verifier{ &outer_circuit, verification_key };
+        auto stdlib_vk_and_hash =
+            std::make_shared<typename RecursiveFlavor::VKAndHash>(outer_circuit, verification_key);
+        RecursiveVerifier verifier{ &outer_circuit, stdlib_vk_and_hash };
         verifier.transcript->enable_manifest();
 
         VerifierOutput output = verifier.verify_proof(inner_proof);
@@ -249,6 +253,7 @@ template <typename RecursiveFlavor> class RecursiveVerifierTest : public testing
         {
             auto proving_key = std::make_shared<OuterDeciderProvingKey>(outer_circuit);
             auto verification_key = std::make_shared<typename OuterFlavor::VerificationKey>(proving_key->proving_key);
+
             info("Recursive Verifier: num gates = ", outer_circuit.get_num_finalized_gates());
             OuterProver prover(proving_key, verification_key);
             auto proof = prover.construct_proof();
@@ -296,7 +301,9 @@ template <typename RecursiveFlavor> class RecursiveVerifierTest : public testing
 
             // Create a recursive verification circuit for the proof of the inner circuit
             OuterBuilder outer_circuit;
-            RecursiveVerifier verifier{ &outer_circuit, inner_verification_key };
+            auto stdlib_vk_and_hash =
+                std::make_shared<typename RecursiveFlavor::VKAndHash>(outer_circuit, inner_verification_key);
+            RecursiveVerifier verifier{ &outer_circuit, stdlib_vk_and_hash };
             VerifierOutput output = verifier.verify_proof(inner_proof);
 
             // Wrong Gemini witnesses lead to the pairing check failure in non-ZK case but don't break any
@@ -341,7 +348,9 @@ template <typename RecursiveFlavor> class RecursiveVerifierTest : public testing
 
             // Create a recursive verification circuit for the proof of the inner circuit
             OuterBuilder outer_circuit;
-            RecursiveVerifier verifier{ &outer_circuit, inner_verification_key };
+            auto stdlib_vk_and_hash =
+                std::make_shared<typename RecursiveFlavor::VKAndHash>(outer_circuit, inner_verification_key);
+            RecursiveVerifier verifier{ &outer_circuit, stdlib_vk_and_hash };
             VerifierOutput output = verifier.verify_proof(inner_proof);
 
             if (idx == 0) {

--- a/barretenberg/cpp/src/barretenberg/stdlib/protogalaxy_verifier/protogalaxy_recursive_verifier.cpp
+++ b/barretenberg/cpp/src/barretenberg/stdlib/protogalaxy_verifier/protogalaxy_recursive_verifier.cpp
@@ -186,8 +186,8 @@ std::shared_ptr<typename DeciderVerificationKeys::DeciderVK> ProtogalaxyRecursiv
 
     // Set the accumulator circuit size data based on the max of the keys being accumulated
     auto [accumulator_circuit_size, accumulator_log_circuit_size] = keys_to_fold.get_max_circuit_size_and_log_size();
-    accumulator->verification_key->log_circuit_size = accumulator_log_circuit_size;
-    accumulator->verification_key->circuit_size = accumulator_circuit_size;
+    accumulator->vk_and_hash->vk->log_circuit_size = accumulator_log_circuit_size;
+    accumulator->vk_and_hash->vk->circuit_size = accumulator_circuit_size;
 
     // Fold the relation parameters
     for (auto [combination, to_combine] : zip_view(accumulator->alphas, keys_to_fold.get_alphas())) {
@@ -199,7 +199,7 @@ std::shared_ptr<typename DeciderVerificationKeys::DeciderVK> ProtogalaxyRecursiv
         combination = linear_combination(to_combine, lagranges);
     }
 
-    auto accumulator_vkey = accumulator->verification_key->get_all();
+    auto accumulator_vkey = accumulator->vk_and_hash->vk->get_all();
     for (size_t i = 0; i < Flavor::NUM_PRECOMPUTED_ENTITIES; ++i) {
         accumulator_vkey[i] = output_commitments[i];
     }

--- a/barretenberg/cpp/src/barretenberg/stdlib/protogalaxy_verifier/protogalaxy_recursive_verifier.hpp
+++ b/barretenberg/cpp/src/barretenberg/stdlib/protogalaxy_verifier/protogalaxy_recursive_verifier.hpp
@@ -21,21 +21,12 @@ template <class DeciderVerificationKeys> class ProtogalaxyRecursiveVerifier_ {
     using FF = typename Flavor::FF;
     using Commitment = typename Flavor::Commitment;
     using DeciderVK = typename DeciderVerificationKeys::DeciderVK;
-    using VerificationKey = typename Flavor::VerificationKey;
+    using VKAndHash = typename Flavor::VKAndHash;
 
     using Builder = typename Flavor::CircuitBuilder;
     using Transcript = bb::BaseTranscript<bb::stdlib::recursion::honk::StdlibTranscriptParams<Builder>>;
 
     static constexpr size_t NUM_SUBRELATIONS = Flavor::NUM_SUBRELATIONS;
-
-    struct VerifierInput {
-      public:
-        using NativeFlavor = typename Flavor::NativeFlavor;
-        using DeciderVK = bb::DeciderVerificationKey_<NativeFlavor>;
-        using NativeVerificationKey = typename Flavor::NativeVerificationKey;
-        std::shared_ptr<DeciderVK> accumulator;
-        std::vector<std::shared_ptr<NativeVerificationKey>> decider_vks;
-    };
 
     Builder* builder;
 
@@ -45,10 +36,10 @@ template <class DeciderVerificationKeys> class ProtogalaxyRecursiveVerifier_ {
 
     ProtogalaxyRecursiveVerifier_(Builder* builder,
                                   const std::shared_ptr<DeciderVK>& accumulator,
-                                  const std::vector<std::shared_ptr<VerificationKey>>& decider_vks,
+                                  const std::vector<std::shared_ptr<VKAndHash>>& vk_and_hashs,
                                   const std::shared_ptr<Transcript>& transcript)
         : builder(builder)
-        , keys_to_fold(DeciderVerificationKeys(builder, accumulator, decider_vks))
+        , keys_to_fold(DeciderVerificationKeys(builder, accumulator, vk_and_hashs))
         , transcript(transcript){};
 
     /**

--- a/barretenberg/cpp/src/barretenberg/stdlib/protogalaxy_verifier/protogalaxy_recursive_verifier.test.cpp
+++ b/barretenberg/cpp/src/barretenberg/stdlib/protogalaxy_verifier/protogalaxy_recursive_verifier.test.cpp
@@ -43,6 +43,7 @@ template <typename RecursiveFlavor> class ProtogalaxyRecursiveTests : public tes
         ::bb::stdlib::recursion::honk::RecursiveDeciderVerificationKeys_<RecursiveFlavor, 2>;
     using RecursiveDeciderVerificationKey = RecursiveDeciderVerificationKeys::DeciderVK;
     using RecursiveVerificationKey = RecursiveDeciderVerificationKeys::VerificationKey;
+    using RecursiveVKAndHash = RecursiveDeciderVerificationKeys::VKAndHash;
     using FoldingRecursiveVerifier = ProtogalaxyRecursiveVerifier_<RecursiveDeciderVerificationKeys>;
     using DeciderRecursiveVerifier = DeciderRecursiveVerifier_<RecursiveFlavor>;
     using InnerDeciderProver = DeciderProver_<InnerFlavor>;
@@ -207,26 +208,24 @@ template <typename RecursiveFlavor> class ProtogalaxyRecursiveTests : public tes
         OuterBuilder folding_circuit;
 
         auto recursive_decider_vk_1 = std::make_shared<RecursiveDeciderVerificationKey>(&folding_circuit, decider_vk_1);
-        auto recursive_decider_vk_2 =
-            std::make_shared<RecursiveVerificationKey>(&folding_circuit, decider_vk_2->verification_key);
+        auto recursive_vk_and_hash_2 = std::make_shared<RecursiveVKAndHash>(folding_circuit, decider_vk_2->vk);
         stdlib::Proof<OuterBuilder> stdlib_proof(folding_circuit, folding_proof.proof);
 
         auto verifier = FoldingRecursiveVerifier{ &folding_circuit,
                                                   recursive_decider_vk_1,
-                                                  { recursive_decider_vk_2 },
+                                                  { recursive_vk_and_hash_2 },
                                                   std::make_shared<typename FoldingRecursiveVerifier::Transcript>() };
-        verifier.transcript->enable_manifest();
         std::shared_ptr<RecursiveDeciderVerificationKey> accumulator;
         for (size_t idx = 0; idx < num_verifiers; idx++) {
+            verifier.transcript->enable_manifest();
             accumulator = verifier.verify_folding_proof(stdlib_proof);
             if (idx < num_verifiers - 1) { // else the transcript is null in the test below
-                verifier = FoldingRecursiveVerifier{
-                    &folding_circuit,
-                    accumulator,
-                    { std::make_shared<RecursiveVerificationKey>(&folding_circuit, decider_vk_1->verification_key) },
-                    std::make_shared<typename FoldingRecursiveVerifier::Transcript>()
-                };
-                verifier.transcript->enable_manifest();
+                auto recursive_vk_and_hash = std::make_shared<RecursiveVKAndHash>(folding_circuit, decider_vk_1->vk);
+                verifier =
+                    FoldingRecursiveVerifier{ &folding_circuit,
+                                              accumulator,
+                                              { recursive_vk_and_hash },
+                                              std::make_shared<typename FoldingRecursiveVerifier::Transcript>() };
             }
         }
         info("Folding Recursive Verifier: num gates unfinalized = ", folding_circuit.num_gates);
@@ -309,13 +308,12 @@ template <typename RecursiveFlavor> class ProtogalaxyRecursiveTests : public tes
         // Create a folding verifier circuit
         OuterBuilder folding_circuit;
         auto recursive_decider_vk_1 = std::make_shared<RecursiveDeciderVerificationKey>(&folding_circuit, decider_vk_1);
-        auto recursive_decider_vk_2 =
-            std::make_shared<RecursiveVerificationKey>(&folding_circuit, decider_vk_2->verification_key);
+        auto recursive_vk_and_hash_2 = std::make_shared<RecursiveVKAndHash>(folding_circuit, decider_vk_2->vk);
         stdlib::Proof<OuterBuilder> stdlib_proof(folding_circuit, folding_proof.proof);
 
         auto verifier = FoldingRecursiveVerifier{ &folding_circuit,
                                                   recursive_decider_vk_1,
-                                                  { recursive_decider_vk_2 },
+                                                  { recursive_vk_and_hash_2 },
                                                   std::make_shared<typename FoldingRecursiveVerifier::Transcript>() };
         verifier.transcript->enable_manifest();
         auto recursive_verifier_accumulator = verifier.verify_folding_proof(stdlib_proof);
@@ -427,13 +425,12 @@ template <typename RecursiveFlavor> class ProtogalaxyRecursiveTests : public tes
         OuterBuilder folding_circuit;
         auto recursive_decider_vk_1 =
             std::make_shared<RecursiveDeciderVerificationKey>(&folding_circuit, verifier_accumulator);
-        auto recursive_decider_vk_2 =
-            std::make_shared<RecursiveVerificationKey>(&folding_circuit, verifier_inst->verification_key);
+        auto recursive_vk_and_hash_2 = std::make_shared<RecursiveVKAndHash>(folding_circuit, verifier_inst->vk);
         stdlib::Proof<OuterBuilder> stdlib_proof(folding_circuit, folding_proof.proof);
 
         auto verifier = FoldingRecursiveVerifier{ &folding_circuit,
                                                   recursive_decider_vk_1,
-                                                  { recursive_decider_vk_2 },
+                                                  { recursive_vk_and_hash_2 },
                                                   std::make_shared<typename FoldingRecursiveVerifier::Transcript>() };
         auto recursive_verifier_acc = verifier.verify_folding_proof(stdlib_proof);
 
@@ -471,14 +468,14 @@ template <typename RecursiveFlavor> class ProtogalaxyRecursiveTests : public tes
             // Create a folding verifier circuit
             OuterBuilder verifier_circuit;
             auto recursive_decider_vk_1 =
-                std::make_shared<RecursiveDeciderVerificationKey>(&verifier_circuit, honk_vk_1);
-            auto recursive_decider_vk_2 = std::make_shared<RecursiveVerificationKey>(&verifier_circuit, honk_vk_2);
+                std::make_shared<RecursiveDeciderVerificationKey>(&verifier_circuit, decider_vk_1);
+            auto recursive_vk_and_hash_2 = std::make_shared<RecursiveVKAndHash>(verifier_circuit, decider_vk_2->vk);
             stdlib::Proof<OuterBuilder> stdlib_proof(verifier_circuit, fold_result.proof);
 
             auto verifier =
                 FoldingRecursiveVerifier{ &verifier_circuit,
                                           recursive_decider_vk_1,
-                                          { recursive_decider_vk_2 },
+                                          { recursive_vk_and_hash_2 },
                                           std::make_shared<typename FoldingRecursiveVerifier::Transcript>() };
             auto recursive_verifier_accumulator = verifier.verify_folding_proof(stdlib_proof);
 

--- a/barretenberg/cpp/src/barretenberg/stdlib/protogalaxy_verifier/recursive_decider_verification_key.hpp
+++ b/barretenberg/cpp/src/barretenberg/stdlib/protogalaxy_verifier/recursive_decider_verification_key.hpp
@@ -21,18 +21,19 @@ template <IsRecursiveFlavor Flavor> class RecursiveDeciderVerificationKey_ {
     using NativeFF = typename Flavor::Curve::ScalarFieldNative;
     using Commitment = typename Flavor::Commitment;
     using VerificationKey = typename Flavor::VerificationKey;
-    using NativeVerificationKey = typename Flavor::NativeVerificationKey;
+    using VKAndHash = typename Flavor::VKAndHash;
     using WitnessCommitments = typename Flavor::WitnessCommitments;
     using CommitmentLabels = typename Flavor::CommitmentLabels;
     using RelationSeparator = typename Flavor::RelationSeparator;
     using Builder = typename Flavor::CircuitBuilder;
     using NativeFlavor = typename Flavor::NativeFlavor;
-    using DeciderVerificationKey = bb::DeciderVerificationKey_<NativeFlavor>;
+    using NativeVerificationKey = typename Flavor::NativeFlavor::VerificationKey;
+    using NativeDeciderVerificationKey = bb::DeciderVerificationKey_<NativeFlavor>;
     using VerifierCommitmentKey = typename NativeFlavor::VerifierCommitmentKey;
 
     Builder* builder;
 
-    std::shared_ptr<VerificationKey> verification_key;
+    std::shared_ptr<VKAndHash> vk_and_hash;
 
     bool is_accumulator = false;
     std::vector<FF> public_inputs;
@@ -48,18 +49,20 @@ template <IsRecursiveFlavor Flavor> class RecursiveDeciderVerificationKey_ {
     RecursiveDeciderVerificationKey_(Builder* builder)
         : builder(builder){};
 
+    // Constructor from native vk
     RecursiveDeciderVerificationKey_(Builder* builder, std::shared_ptr<NativeVerificationKey> vk)
         : builder(builder)
-        , verification_key(std::make_shared<VerificationKey>(builder, vk)){};
-
-    // Constructor from stdlib vkey
-    RecursiveDeciderVerificationKey_(Builder* builder, std::shared_ptr<VerificationKey> vk)
-        : builder(builder)
-        , verification_key(vk)
+        , vk_and_hash(std::make_shared<VKAndHash>(std::make_shared<VerificationKey>(builder, vk),
+                                                  FF::from_witness(builder, vk->hash())))
     {}
 
-    RecursiveDeciderVerificationKey_(Builder* builder, const std::shared_ptr<DeciderVerificationKey>& verification_key)
-        : RecursiveDeciderVerificationKey_(builder, verification_key->verification_key)
+    // Constructor from stdlib vk and hash
+    RecursiveDeciderVerificationKey_(Builder* builder, std::shared_ptr<VKAndHash> vk_and_hash)
+        : builder(builder)
+        , vk_and_hash(vk_and_hash){};
+
+    RecursiveDeciderVerificationKey_(Builder* builder, std::shared_ptr<NativeDeciderVerificationKey> verification_key)
+        : RecursiveDeciderVerificationKey_(builder, verification_key->vk)
     {
         is_accumulator = verification_key->is_accumulator;
         if (is_accumulator) {
@@ -104,26 +107,27 @@ template <IsRecursiveFlavor Flavor> class RecursiveDeciderVerificationKey_ {
      * RecursiveDeciderVerificationKey is tied to the builder in whose context it was created so in order to preserve
      * the accumulator values between several iterations we need to retrieve the native DeciderVerificationKey values.
      */
-    DeciderVerificationKey get_value()
+    NativeDeciderVerificationKey get_value()
     {
+        using NativeVerificationKey = typename Flavor::NativeFlavor::VerificationKey;
         auto native_honk_vk = std::make_shared<NativeVerificationKey>(
-            static_cast<uint64_t>(verification_key->circuit_size.get_value()),
-            static_cast<uint64_t>(verification_key->num_public_inputs.get_value()));
-        native_honk_vk->pub_inputs_offset = static_cast<uint64_t>(verification_key->pub_inputs_offset.get_value());
-        native_honk_vk->pairing_inputs_public_input_key = verification_key->pairing_inputs_public_input_key;
+            static_cast<uint64_t>(vk_and_hash->vk->circuit_size.get_value()),
+            static_cast<uint64_t>(vk_and_hash->vk->num_public_inputs.get_value()));
+        native_honk_vk->pub_inputs_offset = static_cast<uint64_t>(vk_and_hash->vk->pub_inputs_offset.get_value());
+        native_honk_vk->pairing_inputs_public_input_key = vk_and_hash->vk->pairing_inputs_public_input_key;
         if constexpr (IsMegaFlavor<Flavor>) {
-            native_honk_vk->databus_propagation_data = verification_key->databus_propagation_data;
+            native_honk_vk->databus_propagation_data = vk_and_hash->vk->databus_propagation_data;
         }
 
-        for (auto [vk, final_decider_vk] : zip_view(verification_key->get_all(), native_honk_vk->get_all())) {
+        for (auto [vk, final_decider_vk] : zip_view(vk_and_hash->vk->get_all(), native_honk_vk->get_all())) {
             final_decider_vk = vk.get_value();
         }
 
-        DeciderVerificationKey decider_vk(native_honk_vk);
+        NativeDeciderVerificationKey decider_vk(native_honk_vk);
         decider_vk.is_accumulator = is_accumulator;
 
         decider_vk.public_inputs = std::vector<NativeFF>(
-            static_cast<size_t>(static_cast<uint32_t>(verification_key->num_public_inputs.get_value())));
+            static_cast<size_t>(static_cast<uint32_t>(vk_and_hash->vk->num_public_inputs.get_value())));
         for (auto [public_input, inst_public_input] : zip_view(public_inputs, decider_vk.public_inputs)) {
             inst_public_input = public_input.get_value();
         }

--- a/barretenberg/cpp/src/barretenberg/stdlib/protogalaxy_verifier/recursive_decider_verification_keys.hpp
+++ b/barretenberg/cpp/src/barretenberg/stdlib/protogalaxy_verifier/recursive_decider_verification_keys.hpp
@@ -14,6 +14,7 @@ template <IsRecursiveFlavor Flavor_, size_t NUM_> struct RecursiveDeciderVerific
     using Flavor = Flavor_;
     using Builder = typename Flavor::CircuitBuilder;
     using VerificationKey = typename Flavor::VerificationKey;
+    using VKAndHash = typename Flavor::VKAndHash;
     using DeciderVK = RecursiveDeciderVerificationKey_<Flavor>;
     using ArrayType = std::array<std::shared_ptr<DeciderVK>, NUM_>;
     using FF = typename Flavor::FF;
@@ -29,16 +30,16 @@ template <IsRecursiveFlavor Flavor_, size_t NUM_> struct RecursiveDeciderVerific
 
     RecursiveDeciderVerificationKeys_(Builder* builder,
                                       const std::shared_ptr<DeciderVK>& accumulator,
-                                      const std::vector<std::shared_ptr<VerificationKey>>& vks)
+                                      const std::vector<std::shared_ptr<VKAndHash>>& vk_and_hashs)
         : builder(builder)
     {
-        ASSERT(vks.size() == NUM - 1);
+        ASSERT(vk_and_hashs.size() == NUM - 1);
 
         _data[0] = accumulator;
 
         size_t idx = 1;
-        for (auto& vk : vks) {
-            _data[idx] = std::make_shared<DeciderVK>(builder, vk);
+        for (auto& vk_and_hash : vk_and_hashs) {
+            _data[idx] = std::make_shared<DeciderVK>(builder, vk_and_hash);
             idx++;
         }
     }
@@ -54,14 +55,14 @@ template <IsRecursiveFlavor Flavor_, size_t NUM_> struct RecursiveDeciderVerific
         // Find the key with the largest circuit size and reaturn its circuit size and log circuit size
         auto* max_key = _data[0].get();
         size_t max_circuit_size =
-            static_cast<size_t>(static_cast<uint32_t>(max_key->verification_key->circuit_size.get_value()));
+            static_cast<size_t>(static_cast<uint32_t>(max_key->vk_and_hash->vk->circuit_size.get_value()));
         for (const auto& key : _data) {
-            if (static_cast<size_t>(static_cast<uint32_t>(key->verification_key->circuit_size.get_value())) >
+            if (static_cast<size_t>(static_cast<uint32_t>(key->vk_and_hash->vk->circuit_size.get_value())) >
                 max_circuit_size) {
                 max_key = key.get();
             }
         }
-        return { max_key->verification_key->circuit_size, max_key->verification_key->log_circuit_size };
+        return { max_key->vk_and_hash->vk->circuit_size, max_key->vk_and_hash->vk->log_circuit_size };
     }
 
     /**
@@ -78,12 +79,12 @@ template <IsRecursiveFlavor Flavor_, size_t NUM_> struct RecursiveDeciderVerific
      */
     std::vector<std::vector<typename Flavor::Commitment>> get_precomputed_commitments() const
     {
-        const size_t num_commitments_to_fold = _data[0]->verification_key->get_all().size();
+        const size_t num_commitments_to_fold = _data[0]->vk_and_hash->vk->get_all().size();
         std::vector<std::vector<typename Flavor::Commitment>> result(num_commitments_to_fold,
                                                                      std::vector<typename Flavor::Commitment>(NUM));
         for (size_t idx = 0; auto& commitment_at_idx : result) {
             for (auto [elt, key] : zip_view(commitment_at_idx, _data)) {
-                elt = key->verification_key->get_all()[idx];
+                elt = key->vk_and_hash->vk->get_all()[idx];
             }
             idx++;
         }

--- a/barretenberg/cpp/src/barretenberg/stdlib/translator_vm_verifier/translator_recursive_flavor.hpp
+++ b/barretenberg/cpp/src/barretenberg/stdlib/translator_vm_verifier/translator_recursive_flavor.hpp
@@ -134,5 +134,7 @@ template <typename BuilderType> class TranslatorRecursiveFlavor_ {
     using VerifierCommitments = TranslatorFlavor::VerifierCommitments_<Commitment, VerificationKey>;
     // Reuse the transcript from Translator
     using Transcript = bb::BaseTranscript<bb::stdlib::recursion::honk::StdlibTranscriptParams<CircuitBuilder>>;
+
+    using VKAndHash = VKAndHash_<VerificationKey, FF>;
 };
 } // namespace bb

--- a/barretenberg/cpp/src/barretenberg/ultra_honk/databus.test.cpp
+++ b/barretenberg/cpp/src/barretenberg/ultra_honk/databus.test.cpp
@@ -32,6 +32,7 @@ template <typename Flavor> class DataBusTests : public ::testing::Test {
     {
         auto proving_key = std::make_shared<DeciderProvingKey_<Flavor>>(builder);
         auto verification_key = std::make_shared<typename Flavor::VerificationKey>(proving_key->proving_key);
+
         Prover prover{ proving_key, verification_key };
         auto proof = prover.construct_proof();
         Verifier verifier{ verification_key };

--- a/barretenberg/cpp/src/barretenberg/ultra_honk/databus.test.cpp
+++ b/barretenberg/cpp/src/barretenberg/ultra_honk/databus.test.cpp
@@ -32,7 +32,6 @@ template <typename Flavor> class DataBusTests : public ::testing::Test {
     {
         auto proving_key = std::make_shared<DeciderProvingKey_<Flavor>>(builder);
         auto verification_key = std::make_shared<typename Flavor::VerificationKey>(proving_key->proving_key);
-
         Prover prover{ proving_key, verification_key };
         auto proof = prover.construct_proof();
         Verifier verifier{ verification_key };

--- a/barretenberg/cpp/src/barretenberg/ultra_honk/decider_keys.hpp
+++ b/barretenberg/cpp/src/barretenberg/ultra_honk/decider_keys.hpp
@@ -139,8 +139,7 @@ template <IsUltraOrMegaHonk Flavor_, size_t NUM_ = 2> struct DeciderVerification
     {
         size_t max_log_circuit_size{ 0 };
         for (auto key : _data) {
-            max_log_circuit_size =
-                std::max(max_log_circuit_size, static_cast<size_t>(key->verification_key->log_circuit_size));
+            max_log_circuit_size = std::max(max_log_circuit_size, static_cast<size_t>(key->vk->log_circuit_size));
         }
         return max_log_circuit_size;
     }
@@ -159,11 +158,11 @@ template <IsUltraOrMegaHonk Flavor_, size_t NUM_ = 2> struct DeciderVerification
      */
     std::vector<std::vector<Commitment>> get_precomputed_commitments() const
     {
-        const size_t num_commitments_to_fold = _data[0]->verification_key->get_all().size();
+        const size_t num_commitments_to_fold = _data[0]->vk->get_all().size();
         std::vector<std::vector<Commitment>> result(num_commitments_to_fold, std::vector<Commitment>(NUM));
         for (size_t idx = 0; auto& commitment_at_idx : result) {
             for (auto [elt, key] : zip_view(commitment_at_idx, _data)) {
-                elt = key->verification_key->get_all()[idx];
+                elt = key->vk->get_all()[idx];
             }
             idx++;
         }

--- a/barretenberg/cpp/src/barretenberg/ultra_honk/decider_verification_key.hpp
+++ b/barretenberg/cpp/src/barretenberg/ultra_honk/decider_verification_key.hpp
@@ -26,7 +26,7 @@ template <IsUltraOrMegaHonk Flavor> class DeciderVerificationKey_ {
     using CommitmentLabels = typename Flavor::CommitmentLabels;
     using RelationSeparator = typename Flavor::RelationSeparator;
 
-    std::shared_ptr<VerificationKey> verification_key;
+    std::shared_ptr<VerificationKey> vk;
 
     bool is_accumulator = false;
     std::vector<FF> public_inputs;
@@ -41,10 +41,10 @@ template <IsUltraOrMegaHonk Flavor> class DeciderVerificationKey_ {
 
     DeciderVerificationKey_() = default;
     DeciderVerificationKey_(std::shared_ptr<VerificationKey> vk)
-        : verification_key(vk)
+        : vk(vk)
     {}
 
-    MSGPACK_FIELDS(verification_key,
+    MSGPACK_FIELDS(vk,
                    relation_parameters,
                    alphas,
                    is_accumulator,

--- a/barretenberg/cpp/src/barretenberg/ultra_honk/decider_verifier.cpp
+++ b/barretenberg/cpp/src/barretenberg/ultra_honk/decider_verifier.cpp
@@ -44,9 +44,9 @@ template <typename Flavor> typename DeciderVerifier_<Flavor>::Output DeciderVeri
     using ClaimBatcher = ClaimBatcher_<Curve>;
     using ClaimBatch = ClaimBatcher::Batch;
 
-    VerifierCommitments commitments{ accumulator->verification_key, accumulator->witness_commitments };
+    VerifierCommitments commitments{ accumulator->vk, accumulator->witness_commitments };
 
-    const size_t log_circuit_size = static_cast<size_t>(accumulator->verification_key->log_circuit_size);
+    const size_t log_circuit_size = static_cast<size_t>(accumulator->vk->log_circuit_size);
 
     std::array<FF, CONST_PROOF_SIZE_LOG_N> padding_indicator_array;
 

--- a/barretenberg/cpp/src/barretenberg/ultra_honk/mega_transcript.test.cpp
+++ b/barretenberg/cpp/src/barretenberg/ultra_honk/mega_transcript.test.cpp
@@ -45,17 +45,17 @@ template <typename Flavor> class MegaTranscriptTests : public ::testing::Test {
         size_t frs_per_evals = (Flavor::NUM_ALL_ENTITIES)*frs_per_Fr;
 
         size_t round = 0;
-        manifest_expected.add_entry(round, "vkey_circuit_size", frs_per_Fr);
-        manifest_expected.add_entry(round, "vkey_num_public_inputs", frs_per_Fr);
-        manifest_expected.add_entry(round, "vkey_pub_inputs_offset", frs_per_Fr);
-        manifest_expected.add_entry(round, "vkey_pairing_points_start_idx", frs_per_Fr);
-        manifest_expected.add_entry(round, "vkey_app_return_data_commitment_start_idx", frs_per_Fr);
-        manifest_expected.add_entry(round, "vkey_kernel_return_data_commitment_start_idx", frs_per_Fr);
-        manifest_expected.add_entry(round, "vkey_is_kernel", frs_per_Fr);
+        manifest_expected.add_entry(round, "vk_circuit_size", frs_per_Fr);
+        manifest_expected.add_entry(round, "vk_num_public_inputs", frs_per_Fr);
+        manifest_expected.add_entry(round, "vk_pub_inputs_offset", frs_per_Fr);
+        manifest_expected.add_entry(round, "vk_pairing_points_start_idx", frs_per_Fr);
+        manifest_expected.add_entry(round, "vk_app_return_data_commitment_start_idx", frs_per_Fr);
+        manifest_expected.add_entry(round, "vk_kernel_return_data_commitment_start_idx", frs_per_Fr);
+        manifest_expected.add_entry(round, "vk_is_kernel", frs_per_Fr);
         for (size_t i = 0; i < Flavor::NUM_PRECOMPUTED_ENTITIES; i++) {
-            manifest_expected.add_entry(round, "vkey_commitment", frs_per_G);
+            manifest_expected.add_entry(round, "vk_commitment", frs_per_G);
         }
-        manifest_expected.add_challenge(round, "vkey_hash");
+        manifest_expected.add_challenge(round, "vk_hash");
         round++;
         manifest_expected.add_entry(round, "public_input_0", frs_per_Fr);
         for (size_t i = 0; i < PAIRING_POINTS_SIZE; i++) {

--- a/barretenberg/cpp/src/barretenberg/ultra_honk/oink_prover.cpp
+++ b/barretenberg/cpp/src/barretenberg/ultra_honk/oink_prover.cpp
@@ -88,8 +88,8 @@ template <IsUltraOrMegaHonk Flavor> void OinkProver<Flavor>::execute_preamble_ro
     honk_vk->add_to_transcript(domain_separator, *transcript);
     // TODO(https://github.com/AztecProtocol/barretenberg/issues/1427): Add VK FS to solidity verifier.
     if constexpr (!IsAnyOf<Flavor, UltraKeccakFlavor, UltraKeccakZKFlavor>) {
-        auto [vkey_hash] = transcript->template get_challenges<FF>(domain_separator + "vkey_hash");
-        vinfo("vkey hash in Oink prover: ", vkey_hash);
+        auto [vkey_hash] = transcript->template get_challenges<FF>(domain_separator + "vk_hash");
+        vinfo("vk hash in Oink prover: ", vkey_hash);
     }
     BB_ASSERT_EQ(proving_key->proving_key.num_public_inputs, proving_key->proving_key.public_inputs.size());
 

--- a/barretenberg/cpp/src/barretenberg/ultra_honk/oink_verifier.cpp
+++ b/barretenberg/cpp/src/barretenberg/ultra_honk/oink_verifier.cpp
@@ -46,15 +46,15 @@ template <IsUltraOrMegaHonk Flavor> void OinkVerifier<Flavor>::verify()
  */
 template <IsUltraOrMegaHonk Flavor> void OinkVerifier<Flavor>::execute_preamble_round()
 {
-    verification_key->verification_key->add_to_transcript(domain_separator, *transcript);
+    verification_key->vk->add_to_transcript(domain_separator, *transcript);
     // TODO(https://github.com/AztecProtocol/barretenberg/issues/1427): Update solidity contract to generate vkey hash
     // from transcript.
     if constexpr (!IsAnyOf<Flavor, UltraKeccakFlavor, UltraKeccakZKFlavor>) {
-        auto [vkey_hash] = transcript->template get_challenges<FF>(domain_separator + "vkey_hash");
-        vinfo("vkey hash in Oink verifier: ", vkey_hash);
+        auto [vkey_hash] = transcript->template get_challenges<FF>(domain_separator + "vk_hash");
+        vinfo("vk hash in Oink verifier: ", vkey_hash);
     }
 
-    for (size_t i = 0; i < verification_key->verification_key->num_public_inputs; ++i) {
+    for (size_t i = 0; i < verification_key->vk->num_public_inputs; ++i) {
         auto public_input_i =
             transcript->template receive_from_prover<FF>(domain_separator + "public_input_" + std::to_string(i));
         public_inputs.emplace_back(public_input_i);
@@ -142,8 +142,8 @@ template <IsUltraOrMegaHonk Flavor> void OinkVerifier<Flavor>::execute_grand_pro
         compute_public_input_delta<Flavor>(public_inputs,
                                            relation_parameters.beta,
                                            relation_parameters.gamma,
-                                           verification_key->verification_key->circuit_size,
-                                           static_cast<size_t>(verification_key->verification_key->pub_inputs_offset));
+                                           verification_key->vk->circuit_size,
+                                           static_cast<size_t>(verification_key->vk->pub_inputs_offset));
 
     relation_parameters.public_input_delta = public_input_delta;
 

--- a/barretenberg/cpp/src/barretenberg/ultra_honk/ultra_transcript.test.cpp
+++ b/barretenberg/cpp/src/barretenberg/ultra_honk/ultra_transcript.test.cpp
@@ -65,23 +65,23 @@ template <typename Flavor> class UltraTranscriptTests : public ::testing::Test {
         size_t round = 0;
         // TODO(https://github.com/AztecProtocol/barretenberg/issues/1427): Add VK FS to solidity verifier.
         if constexpr (!IsAnyOf<Flavor, UltraKeccakFlavor, UltraKeccakZKFlavor>) {
-            manifest_expected.add_entry(round, "vkey_circuit_size", frs_per_Fr);
-            manifest_expected.add_entry(round, "vkey_num_public_inputs", frs_per_Fr);
-            manifest_expected.add_entry(round, "vkey_pub_inputs_offset", frs_per_Fr);
-            manifest_expected.add_entry(round, "vkey_pairing_points_start_idx", frs_per_Fr);
+            manifest_expected.add_entry(round, "vk_circuit_size", frs_per_Fr);
+            manifest_expected.add_entry(round, "vk_num_public_inputs", frs_per_Fr);
+            manifest_expected.add_entry(round, "vk_pub_inputs_offset", frs_per_Fr);
+            manifest_expected.add_entry(round, "vk_pairing_points_start_idx", frs_per_Fr);
             if constexpr (IsAnyOf<Flavor, UltraRollupFlavor>) {
-                manifest_expected.add_entry(round, "vkey_ipa_claim_start_idx", frs_per_Fr);
+                manifest_expected.add_entry(round, "vk_ipa_claim_start_idx", frs_per_Fr);
             }
             for (size_t i = 0; i < Flavor::NUM_PRECOMPUTED_ENTITIES; i++) {
-                manifest_expected.add_entry(round, "vkey_commitment", frs_per_G);
+                manifest_expected.add_entry(round, "vk_commitment", frs_per_G);
             }
-            manifest_expected.add_challenge(round, "vkey_hash");
+            manifest_expected.add_challenge(round, "vk_hash");
             round++;
         } else {
             size_t frs_per_uint32 = bb::field_conversion::calc_num_bn254_frs<uint32_t>();
-            manifest_expected.add_entry(round, "vkey_circuit_size", frs_per_uint32);
-            manifest_expected.add_entry(round, "vkey_num_public_inputs", frs_per_uint32);
-            manifest_expected.add_entry(round, "vkey_pub_inputs_offset", frs_per_uint32);
+            manifest_expected.add_entry(round, "vk_circuit_size", frs_per_uint32);
+            manifest_expected.add_entry(round, "vk_num_public_inputs", frs_per_uint32);
+            manifest_expected.add_entry(round, "vk_pub_inputs_offset", frs_per_uint32);
         }
 
         manifest_expected.add_entry(round, "public_input_0", frs_per_Fr);

--- a/barretenberg/cpp/src/barretenberg/ultra_honk/ultra_verifier.cpp
+++ b/barretenberg/cpp/src/barretenberg/ultra_honk/ultra_verifier.cpp
@@ -46,7 +46,7 @@ template <typename Flavor> bool UltraVerifier_<Flavor>::verify_proof(const HonkP
 
         // Extract the public inputs containing the IPA claim
         std::array<FF, IPA_CLAIM_SIZE> ipa_claim_limbs;
-        const uint32_t start_idx = verification_key->verification_key->ipa_claim_public_input_key.start_idx;
+        const uint32_t start_idx = verification_key->vk->ipa_claim_public_input_key.start_idx;
         for (size_t k = 0; k < IPA_CLAIM_SIZE; k++) {
             ipa_claim_limbs[k] = verification_key->public_inputs[start_idx + k];
         }
@@ -85,7 +85,7 @@ template <typename Flavor> bool UltraVerifier_<Flavor>::verify_proof(const HonkP
     // Extract nested pairing points from the proof
     // TODO(https://github.com/AztecProtocol/barretenberg/issues/1094): Handle pairing points in keccak flavors.
     if constexpr (!std::is_same_v<Flavor, UltraKeccakFlavor> && !std::is_same_v<Flavor, UltraKeccakZKFlavor>) {
-        const size_t limb_offset = verification_key->verification_key->pairing_inputs_public_input_key.start_idx;
+        const size_t limb_offset = verification_key->vk->pairing_inputs_public_input_key.start_idx;
         BB_ASSERT_GTE(verification_key->public_inputs.size(),
                       limb_offset + PAIRING_POINTS_SIZE,
                       "Not enough public inputs to extract pairing points");

--- a/barretenberg/cpp/src/barretenberg/ultra_honk/ultra_verifier.hpp
+++ b/barretenberg/cpp/src/barretenberg/ultra_honk/ultra_verifier.hpp
@@ -26,10 +26,10 @@ template <typename Flavor> class UltraVerifier_ {
 
   public:
     explicit UltraVerifier_(
-        const std::shared_ptr<VerificationKey>& verifier_key,
+        const std::shared_ptr<VerificationKey>& vk,
         VerifierCommitmentKey<curve::Grumpkin> ipa_verification_key = VerifierCommitmentKey<curve::Grumpkin>(),
         const std::shared_ptr<Transcript>& transcript = std::make_shared<Transcript>())
-        : verification_key(std::make_shared<DeciderVK>(verifier_key))
+        : verification_key(std::make_shared<DeciderVK>(vk))
         , ipa_verification_key(std::move(ipa_verification_key))
         , transcript(transcript)
     {}

--- a/yarn-project/aztec/public_include_metric_prefixes.json
+++ b/yarn-project/aztec/public_include_metric_prefixes.json
@@ -1,8 +1,1 @@
-[
-  "aztec.validator",
-  "aztec.tx_collector",
-  "aztec.mempool",
-  "aztec.p2p.gossip.agg_",
-  "aztec.ivc_verifier.agg_"
-]
-
+["aztec.validator", "aztec.tx_collector", "aztec.mempool", "aztec.p2p.gossip.agg_", "aztec.ivc_verifier.agg_"]


### PR DESCRIPTION
Creates new VKAndHash that contains the VerificationKey and the hash. The hash is needed, pretty much only in the recursive verifier case, where we must take the hash and check that its equal to the hash produced by Fiat-Shamir in Oink. We don't do this check in this PR yet, so no VKs are changed.