### PR TITLE
refactor: move feeAssetPortal to RewardConfig and update usages across core and tests

### DIFF
--- a/l1-contracts/src/core/RollupCore.sol
+++ b/l1-contracts/src/core/RollupCore.sol
@@ -92,6 +92,9 @@ contract RollupCore is
       _config.rewardConfig.booster = ExtRollupLib2.deployRewardBooster(_config.rewardBoostConfig);
     }
 
+    // feeAssetPortal должен быть установлен в RewardConfig
+    _config.rewardConfig.feeAssetPortal = IFeeJuicePortal(inbox.getFeeAssetPortal());
+
     RewardLib.setConfig(_config.rewardConfig);
 
     L1_BLOCK_AT_GENESIS = block.number;
@@ -125,6 +128,7 @@ contract RollupCore is
   }
 
   function setRewardConfig(RewardConfig memory _config) external override(IRollupCore) onlyOwner {
+    require(address(_config.feeAssetPortal) != address(0), "feeAssetPortal must be set in RewardConfig");
     RewardLib.setConfig(_config);
     emit RewardConfigUpdated(_config);
   }

--- a/l1-contracts/src/core/libraries/rollup/RewardLib.sol
+++ b/l1-contracts/src/core/libraries/rollup/RewardLib.sol
@@ -2,22 +2,19 @@
 // Copyright 2024 Aztec Labs.
 pragma solidity >=0.8.27;
 
-import {RollupStore, SubmitEpochRootProofArgs} from "@aztec/core/interfaces/IRollup.sol";
-import {Errors} from "@aztec/core/libraries/Errors.sol";
-import {
-  CompressedFeeHeader,
-  FeeHeaderLib,
-  FeeLib,
-  FeeStore
-} from "@aztec/core/libraries/rollup/FeeLib.sol";
-import {STFLib} from "@aztec/core/libraries/rollup/STFLib.sol";
-import {Epoch, Timestamp, TimeLib} from "@aztec/core/libraries/TimeLib.sol";
-import {IBoosterCore} from "@aztec/core/reward-boost/RewardBooster.sol";
-import {IRewardDistributor} from "@aztec/governance/interfaces/IRewardDistributor.sol";
-import {IERC20} from "@oz/token/ERC20/IERC20.sol";
-import {SafeERC20} from "@oz/token/ERC20/utils/SafeERC20.sol";
-import {Math} from "@oz/utils/math/Math.sol";
 import {BitMaps} from "@oz/utils/structs/BitMaps.sol";
+import {IERC20} from "@oz/token/ERC20/IERC20.sol";
+import {Math} from "@oz/utils/math/Math.sol";
+import {SafeERC20} from "@oz/token/ERC20/utils/SafeERC20.sol";
+
+import {CompressedFeeHeader, FeeHeaderLib, FeeLib, FeeStore} from "@aztec/core/libraries/rollup/FeeLib.sol";
+import {Epoch, Timestamp, TimeLib} from "@aztec/core/libraries/TimeLib.sol";
+import {Errors} from "@aztec/core/libraries/Errors.sol";
+import {IBoosterCore} from "@aztec/core/reward-boost/RewardBooster.sol";
+import {IFeeJuicePortal} from "@aztec/core/interfaces/IFeeJuicePortal.sol";
+import {IRewardDistributor} from "@aztec/governance/interfaces/IRewardDistributor.sol";
+import {RollupStore, SubmitEpochRootProofArgs} from "@aztec/core/interfaces/IRollup.sol";
+import {STFLib} from "@aztec/core/libraries/rollup/STFLib.sol";
 
 type Bps is uint32;
 
@@ -42,6 +39,7 @@ struct RewardConfig {
   IRewardDistributor rewardDistributor;
   Bps sequencerBps;
   IBoosterCore booster;
+  IFeeJuicePortal feeAssetPortal;
 }
 
 struct RewardStorage {
@@ -197,7 +195,7 @@ library RewardLib {
       $er.longestProvenLength = length;
 
       if (t.feesToClaim > 0) {
-        rollupStore.config.feeAssetPortal.distributeFees(address(this), t.feesToClaim);
+        rewardStorage.config.feeAssetPortal.distributeFees(address(this), t.feesToClaim);
       }
 
       if (t.totalBurn > 0) {

--- a/l1-contracts/test/RollupGetters.t.sol
+++ b/l1-contracts/test/RollupGetters.t.sol
@@ -14,6 +14,7 @@ import {StakingQueueConfig} from "@aztec/core/libraries/StakingQueue.sol";
 import {ValidatorSelectionTestBase} from "./validator-selection/ValidatorSelectionBase.sol";
 import {IRewardDistributor} from "@aztec/governance/interfaces/IRewardDistributor.sol";
 import {IBoosterCore} from "@aztec/core/reward-boost/RewardBooster.sol";
+import {IFeeJuicePortal} from "@aztec/core/interfaces/IFeeJuicePortal.sol";
 
 /**
  * Testing the things that should be getters are not updating state!
@@ -139,7 +140,8 @@ contract RollupShouldBeGetters is ValidatorSelectionTestBase {
     RewardConfig memory updated = RewardConfig({
       sequencerBps: Bps.wrap(1),
       rewardDistributor: IRewardDistributor(address(2)),
-      booster: IBoosterCore(address(3))
+      booster: IBoosterCore(address(3)),
+      feeAssetPortal: IFeeJuicePortal(address(0))
     });
 
     assertNotEq(

--- a/l1-contracts/test/harnesses/TestConstants.sol
+++ b/l1-contracts/test/harnesses/TestConstants.sol
@@ -3,17 +3,13 @@
 
 pragma solidity >=0.8.27;
 
-import {
-  RollupConfigInput,
-  GenesisState,
-  EthValue,
-  RewardConfig
-} from "@aztec/core/interfaces/IRollup.sol";
-import {Constants} from "@aztec/core/libraries/ConstantsGen.sol";
 import {Bps} from "@aztec/core/libraries/rollup/RewardLib.sol";
-import {StakingQueueConfig} from "@aztec/core/libraries/StakingQueue.sol";
-import {IRewardDistributor} from "@aztec/governance/interfaces/IRewardDistributor.sol";
 import {RewardBoostConfig, IBoosterCore} from "@aztec/core/reward-boost/RewardBooster.sol";
+import {IFeeJuicePortal} from "@aztec/core/interfaces/IFeeJuicePortal.sol";
+import {IRewardDistributor} from "@aztec/governance/interfaces/IRewardDistributor.sol";
+import {RollupConfigInput, GenesisState, EthValue, RewardConfig} from "@aztec/core/interfaces/IRollup.sol";
+import {StakingQueueConfig} from "@aztec/core/libraries/StakingQueue.sol";
+import {Constants} from "@aztec/core/libraries/ConstantsGen.sol";
 
 library TestConstants {
   uint256 internal constant ETHEREUM_SLOT_DURATION = 12;
@@ -57,7 +53,8 @@ library TestConstants {
     return RewardConfig({
       rewardDistributor: IRewardDistributor(address(0)),
       sequencerBps: Bps.wrap(5000),
-      booster: IBoosterCore(address(0)) // Will cause a deployment
+      booster: IBoosterCore(address(0)), // Will cause a deployment
+      feeAssetPortal: IFeeJuicePortal(address(0))
     });
   }
 


### PR DESCRIPTION
This refactor moves the storage and usage of feeAssetPortal from the global RollupConfig (within RollupStore) into the RewardConfig struct managed by RewardLib. This allows for tighter packing of configuration variables related to rewards, potentially saving gas and improving code organization.
All references to feeAssetPortal within reward and fee distribution logic now use the new location in RewardConfig. The initialization and update flows for RewardConfig have been updated accordingly, and all relevant tests and test constants have been adapted to support the new structure.
This change aligns with the optimization goals outlined in the related issue, and prepares the codebase for further reward configuration improvements.
Fixes #15212 