### PR TITLE
chore: remove test from flake file

### DIFF
--- a/.test_patterns.yml
+++ b/.test_patterns.yml
@@ -219,10 +219,6 @@ tests:
   - regex: "ethereum/src/deploy_l1_contracts.test.ts"
     owners:
       - *palla
-  - regex: "prover-client/src/proving_broker/proving_broker.test.ts"
-    error_regex: "✕ keeps the jobs in progress while it is alive"
-    owners:
-      - *alex
   - regex: "ethereum/src/test/tx_delayer.test.ts"
     error_regex: "delays a transaction until a given L1 timestamp"
     owners:


### PR DESCRIPTION
This PR removes the broker test from the flake file as it hasn't flaked in months since the number of parallel tests run has been reduced to 50% of available CPU cores.
 
close #13181 