### PR TITLE
fix: don't use `self` in invalid position

### DIFF
--- a/noir-projects/noir-contracts/contracts/app/lending_contract/src/helpers.nr
+++ b/noir-projects/noir-contracts/contracts/app/lending_contract/src/helpers.nr
@@ -4,11 +4,11 @@ use std::ops::{Add, Sub};
 // Utility used to easily get a "id" for a private user that sits in the same
 // "space" as the public users.
 // It help us to have a single mapping for collateral that have both public and private users.
-pub fn compute_identifier(secret: Field, on_behalf_of: Field, self: Field) -> Field {
+pub fn compute_identifier(secret: Field, on_behalf_of: Field, this: Field) -> Field {
     // EITHER secret OR on_behalf_of MUST be set. But not both
     assert(!((secret == 0) as bool & (on_behalf_of == 0) as bool));
     if (secret != 0) {
-        pedersen_hash([self, secret], 0)
+        pedersen_hash([this, secret], 0)
     } else {
         on_behalf_of
     }


### PR DESCRIPTION
Currently in Noir a `self` parameter is allowed in pretty much any place. But [soon](https://github.com/noir-lang/noir/pull/9043) it will only be allowed as the first parameter of associated functions, like in Rust.

This PR fixes the only issue with moving forward with the above PR.