### PR TITLE
fix: Try fix epochs monitor block building flake

### DIFF
--- a/yarn-project/end-to-end/src/bench/client_flows/client_flows_benchmark.ts
+++ b/yarn-project/end-to-end/src/bench/client_flows/client_flows_benchmark.ts
@@ -145,7 +145,7 @@ export class ClientFlowsBenchmark {
     await context.aztecNode.setConfig({ feeRecipient: this.sequencerAddress, coinbase: this.coinbase });
 
     const rollupContract = RollupContract.getFromConfig(context.aztecNodeConfig);
-    this.chainMonitor = new ChainMonitor(rollupContract, this.logger, 200).start();
+    this.chainMonitor = new ChainMonitor(rollupContract, context.dateProvider, this.logger, 200).start();
 
     return this;
   }

--- a/yarn-project/end-to-end/src/e2e_epochs/epochs_test.ts
+++ b/yarn-project/end-to-end/src/e2e_epochs/epochs_test.ts
@@ -140,7 +140,7 @@ export class EpochsTestContext {
     this.rollup = RollupContract.getFromConfig(context.config);
 
     // Loop that tracks L1 and L2 block numbers and logs whenever there's a new one.
-    this.monitor = new ChainMonitor(this.rollup, this.logger).start();
+    this.monitor = new ChainMonitor(this.rollup, context.dateProvider, this.logger).start();
 
     // This is hideous.
     // We ought to have a definite reference to the l1TxUtils that we're using in both places, provided by the test context.

--- a/yarn-project/end-to-end/src/e2e_fees/fees_test.ts
+++ b/yarn-project/end-to-end/src/e2e_fees/fees_test.ts
@@ -125,7 +125,7 @@ export class FeesTest {
     await context.aztecNode.setConfig({ feeRecipient: this.sequencerAddress, coinbase: this.coinbase });
 
     const rollupContract = RollupContract.getFromConfig(context.aztecNodeConfig);
-    this.chainMonitor = new ChainMonitor(rollupContract, this.logger, 200).start();
+    this.chainMonitor = new ChainMonitor(rollupContract, context.dateProvider, this.logger, 200).start();
 
     return this;
   }

--- a/yarn-project/end-to-end/src/e2e_p2p/p2p_network.ts
+++ b/yarn-project/end-to-end/src/e2e_p2p/p2p_network.ts
@@ -335,7 +335,8 @@ export class P2PNetworkTest {
     const { prefilledPublicData } = await getGenesisValues(initialFundedAccounts);
     this.prefilledPublicData = prefilledPublicData;
 
-    this.monitor = new ChainMonitor(RollupContract.getFromL1ContractsValues(this.ctx.deployL1ContractsValues)).start();
+    const rollupContract = RollupContract.getFromL1ContractsValues(this.ctx.deployL1ContractsValues);
+    this.monitor = new ChainMonitor(rollupContract, this.ctx.dateProvider).start();
     this.monitor.on('l1-block', ({ timestamp }) => this.ctx.dateProvider.setTime(Number(timestamp) * 1000));
   }
 

--- a/yarn-project/end-to-end/src/e2e_snapshot_sync.test.ts
+++ b/yarn-project/end-to-end/src/e2e_snapshot_sync.test.ts
@@ -39,7 +39,7 @@ describe('e2e_snapshot_sync', () => {
     log = context.logger;
     snapshotDir = await mkdtemp(join(tmpdir(), 'snapshots-'));
     snapshotLocation = `file://${snapshotDir}`;
-    monitor = new ChainMonitor(RollupContract.getFromConfig(context.config), log).start();
+    monitor = new ChainMonitor(RollupContract.getFromConfig(context.config), context.dateProvider, log).start();
   });
 
   afterAll(async () => {

--- a/yarn-project/end-to-end/src/fixtures/utils.ts
+++ b/yarn-project/end-to-end/src/fixtures/utils.ts
@@ -609,7 +609,7 @@ export async function setup(
     ) {
       // We need to advance to epoch 2 such that the committee is set up.
       logger.info(`Advancing to epoch 2`);
-      await cheatCodes.rollup.advanceToEpoch(2n, { updateDateProvider: dateProvider });
+      await cheatCodes.rollup.advanceToEpoch(2n, { resetBlockInterval: true, updateDateProvider: dateProvider });
       await cheatCodes.rollup.setupEpoch();
       await cheatCodes.rollup.debugRollup();
     }

--- a/yarn-project/ethereum/src/test/chain_monitor.ts
+++ b/yarn-project/ethereum/src/test/chain_monitor.ts
@@ -1,6 +1,7 @@
 import { InboxContract, type RollupContract } from '@aztec/ethereum/contracts';
 import { createLogger } from '@aztec/foundation/log';
 import { promiseWithResolvers } from '@aztec/foundation/promise';
+import { DateProvider } from '@aztec/foundation/timer';
 
 import { EventEmitter } from 'events';
 
@@ -35,7 +36,8 @@ export class ChainMonitor extends EventEmitter<ChainMonitorEventMap> {
 
   constructor(
     private readonly rollup: RollupContract,
-    private logger = createLogger('aztecjs:utils:chain_monitor'),
+    private readonly dateProvider: DateProvider = new DateProvider(),
+    private readonly logger = createLogger('aztecjs:utils:chain_monitor'),
     private readonly intervalMs = 200,
   ) {
     super();
@@ -130,6 +132,7 @@ export class ChainMonitor extends EventEmitter<ChainMonitorEventMap> {
     }
 
     this.logger.info(msg, {
+      currentTimestamp: this.dateProvider.nowInSeconds(),
       l1Timestamp: timestamp,
       l1BlockNumber: this.l1BlockNumber,
       l2SlotNumber: await this.rollup.getSlotNumber(),


### PR DESCRIPTION
Test logs show an issue on anvil vs node timestamps (color me shocked!). Note how the L1 timestamp that the sequencer is synced to is 2s in the future wrt its own timestamp.

```
[18:45:35.613] WARN: sequencer:4 Cannot propose block 3 at slot 10 due to failed rollup contract check {"now":1751050219,"syncedToL1Ts":1751050221,"syncedToL2Slot":10,"nextL2Slot":10,"nextL2SlotTs":1751050213,"l1SlotDuration":8}
```

This PR attempts to fix it by adding a missing `resetBlockInterval` to a time warp during test setup. See [this Slack message](https://aztecprotocol.slack.com/archives/C04BTJAA694/p1749668609629979) for more context on what this option does:

> In some e2e tests we set IntervalMining, so that anvil produces blocks at regular N-second intervals. 
> And in deployL1Contracts we are also manually setting anvil's BlockTimestampInterval to N, which controls how much the L1 timestamp increases from block to block. 
> We also use setNextBlockTimestamp + mine to force a warp to a given timestamp in the future.
> 
> The catch is that, when we warp, we are producing a block halfway through the interval mining process. The next block mined by interval mining is produced N seconds after the previous block mined by interval mining, not after the block we manually mined. But thanks to the BlockTimestampInterval, its timestamp is N seconds after the block we manually mined. This creates a drift between our clock in ts-land vs the one in L1, which was causing the sync issues we were seeing in e2e tests.
> 
> To illustrate with an example, with N=4s
> ```
> 15:54:33     Block Number: 1 # First block mined by Anvil with interval mining
> 15:54:33     Block Time: "Wed, 11 Jun 2025 18:54:33 +0000"
> 15:54:33 
> 15:54:37     Block Number: 2 # Second block mined with interval mining
> 15:54:37     Block Hash: 0xba80aceb782704f5b114c0ed8d1199b261c08ec78f076e3a4683eb4cf3d48175
> 15:54:37     Block Time: "Wed, 11 Jun 2025 18:54:37 +0000"
> 15:54:37 
> 15:54:40 # Here we call "warp" 60 seconds into the future
> 15:54:40 evm_setNextBlockTimestamp # Calling `cast rpc anvil_setNextBlockTimestamp $(date -d "+1 minute" +%s)`
> 15:54:40 evm_mine # `cast rpc evm_mine`
> 15:54:40  
> 15:54:40     Block Number: 3 # Block mined as a result of evm_mine above
> 15:54:40     Block Time: "Wed, 11 Jun 2025 18:55:40 +0000"
> 15:54:40 # And now we sync our ts-clock to the new timestamp
> 15:54:41 
> 15:54:41     Block Number: 4 # Block produced by interval mining
> 15:54:41     Block Time: "Wed, 11 Jun 2025 18:55:44 +0000" # Note that the timestamp is 4 seconds after the previous one, but only 1 second has passed!
> ```
> The solution I've found is to disable and reenable interval mining around the warp, to "reset" the production of blocks via interval mining.
> Though a cleaner solution would be not to mix interval mining, block timestamp interval, and forcefully mined blocks. But I don't dare remove the call to setBlockTimestampInterval in deploy-l1-contracts, since all tests depend on it.

In case this doesn't fix it, this PR also has the L1 chain-monitor log the current value for the date provider, to make it easier to detect drifts.