### PR TITLE
fix: nullifier rpc limit

### DIFF
--- a/yarn-project/pxe/src/contract_function_simulator/pxe_oracle_interface.ts
+++ b/yarn-project/pxe/src/contract_function_simulator/pxe_oracle_interface.ts
@@ -925,14 +925,17 @@ export class PXEOracleInterface implements ExecutionDataProvider {
       }
 
       const nullifiersToCheck = currentNotesForRecipient.map(note => note.siloedNullifier);
-      const nullifierBatches = nullifiersToCheck.reduce((acc, nullifier) => {
-        if (acc[acc.length - 1].length < MAX_RPC_LEN) {
-          acc[acc.length - 1].push(nullifier);
-        } else {
-          acc.push([nullifier]);
-        }
-        return acc;
-      }, [] as Fr[][]);
+      const nullifierBatches = nullifiersToCheck.reduce(
+        (acc, nullifier) => {
+          if (acc[acc.length - 1].length < MAX_RPC_LEN) {
+            acc[acc.length - 1].push(nullifier);
+          } else {
+            acc.push([nullifier]);
+          }
+          return acc;
+        },
+        [[]] as Fr[][],
+      );
       const nullifierIndexes = (
         await Promise.all(
           nullifierBatches.map(batch =>

--- a/yarn-project/pxe/src/contract_function_simulator/pxe_oracle_interface.ts
+++ b/yarn-project/pxe/src/contract_function_simulator/pxe_oracle_interface.ts
@@ -933,15 +933,13 @@ export class PXEOracleInterface implements ExecutionDataProvider {
         }
         return acc;
       }, [] as Fr[][]);
-      const nullifierIndexes: (InBlock<bigint> | undefined)[] = [];
-      for (const batch of nullifierBatches) {
-        const batchIndexes = await this.aztecNode.findLeavesIndexes(
-          syncedBlockNumber,
-          MerkleTreeId.NULLIFIER_TREE,
-          batch,
-        );
-        nullifierIndexes.push(...batchIndexes);
-      }
+      const nullifierIndexes = (
+        await Promise.all(
+          nullifierBatches.map(batch =>
+            this.aztecNode.findLeavesIndexes(syncedBlockNumber, MerkleTreeId.NULLIFIER_TREE, batch),
+          ),
+        )
+      ).flat();
 
       const foundNullifiers = nullifiersToCheck
         .map((nullifier, i) => {

--- a/yarn-project/stdlib/src/interfaces/client.ts
+++ b/yarn-project/stdlib/src/interfaces/client.ts
@@ -3,3 +3,4 @@ export * from './aztec-node.js';
 export * from './aztec-node-admin.js';
 export * from './private_kernel_prover.js';
 export * from './get_logs_response.js';
+export * from './api_limit.js';

--- a/yarn-project/stdlib/src/interfaces/server.ts
+++ b/yarn-project/stdlib/src/interfaces/server.ts
@@ -19,3 +19,4 @@ export * from './server_circuit_prover.js';
 export * from './service.js';
 export * from './tx-collector.js';
 export * from './world_state.js';
+export * from './api_limit.js';


### PR DESCRIPTION
This is very inelegant. We should find a better way of enforcing RPC limits in the consumer side, but we have to unlock staging too.
