### PR TITLE
chore!: correctly propagate tail kernel public inputs in the hiding circuit

### DIFF
--- a/barretenberg/cpp/src/barretenberg/stdlib/primitives/field/field.test.cpp
+++ b/barretenberg/cpp/src/barretenberg/stdlib/primitives/field/field.test.cpp
@@ -1066,7 +1066,7 @@ template <typename Builder> class stdlib_field : public testing::Test {
         uint64_t exponent_val = engine.get_random_uint32();
         exponent_val += (uint64_t(1) << 32);
 
-        field_ct base = witness_ct(&builder, base_val);
+        [[maybe_unused]] field_ct base = witness_ct(&builder, base_val);
         field_ct exponent = witness_ct(&builder, exponent_val);
 #ifndef NDEBUG
         EXPECT_DEATH(base.pow(exponent), "Assertion failed: \\(exponent_value.get_msb\\(\\) < 32\\)");


### PR DESCRIPTION
Extract the public inputs directly from the stdlib tail kernel proof in the hiding circuit and set them public to propagate them to the tube. (This was previously done by extracting the public inputs from the native proof which would cause them to be disconnected from those used in the recursive verifier).

Partially addresses https://github.com/AztecProtocol/barretenberg/issues/1048