### PR TITLE
fix: MaxBlockNumber --> IncludeByTimestamp related fixes

### DIFF
--- a/barretenberg/cpp/src/barretenberg/vm2/constraining/relations/update_check.test.cpp
+++ b/barretenberg/cpp/src/barretenberg/vm2/constraining/relations/update_check.test.cpp
@@ -86,7 +86,7 @@ UpdateCheckEvent update_previous_timestamp = {
     .update_preimage_post_class_id = 3,
 };
 
-UpdateCheckEvent update_timestamp = {
+UpdateCheckEvent update_current_timestamp = {
     .address = 0xdeadbeef,
     .current_class_id = 3,
     .original_class_id = 1,
@@ -103,7 +103,7 @@ std::vector<UpdateCheckEvent> positive_tests = {
     update_from_original_next_timestamp,
     update_next_timestamp,
     update_previous_timestamp,
-    update_timestamp,
+    update_current_timestamp,
 };
 
 class UpdateCheckPositiveConstrainingTest : public TestWithParam<UpdateCheckEvent> {};

--- a/noir-projects/aztec-nr/aztec/src/state_vars/shared_mutable.nr
+++ b/noir-projects/aztec-nr/aztec/src/state_vars/shared_mutable.nr
@@ -206,12 +206,12 @@ where
         // only considered the current delay.
         let effective_minimum_delay =
             delay_change.get_effective_minimum_delay_at(historical_timestamp);
-        let timestamp_horizon =
-            value_change.get_timestamp_horizon(historical_timestamp, effective_minimum_delay);
+        let time_horizon =
+            value_change.get_time_horizon(historical_timestamp, effective_minimum_delay);
 
-        // We prevent this transaction from being included in any timestamp after the timestamp horizon, ensuring that the
+        // We prevent this transaction from being included in any timestamp after the time horizon, ensuring that the
         // historical public value matches the current one, since it can only change after the horizon.
-        self.context.set_include_by_timestamp(timestamp_horizon);
+        self.context.set_include_by_timestamp(time_horizon);
 
         value_change.get_current_at(historical_timestamp)
     }

--- a/noir-projects/noir-contracts/contracts/app/auth_contract/src/main.nr
+++ b/noir-projects/noir-contracts/contracts/app/auth_contract/src/main.nr
@@ -83,7 +83,7 @@ pub contract Auth {
     #[private]
     fn do_private_authorized_thing() {
         // Reading a value from authorized in private automatically adds an extra validity condition: the base rollup
-        // circuit will reject this tx if timestamp of the block being built is past the timestamp horizon of
+        // circuit will reject this tx if timestamp of the block being built is past the time horizon of
         // the SharedMutable, which is as far as the circuit can guarantee the value will not change from some
         // historical value (due to CHANGE_AUTHORIZED_DELAY).
         // docs:start:shared_mutable_get_current_private

--- a/noir-projects/noir-protocol-circuits/crates/private-kernel-lib/src/components/private_call_data_validator/validate_contract_address.nr
+++ b/noir-projects/noir-protocol-circuits/crates/private-kernel-lib/src/components/private_call_data_validator/validate_contract_address.nr
@@ -65,7 +65,7 @@ pub fn validate_contract_address(
     let shared_mutable_values: SharedMutableValues<ContractClassId, DEFAULT_UPDATE_DELAY> =
         Packable::unpack(hints.updated_class_id_shared_mutable_values);
 
-    // A timestamp horizon for this shared mutable should be set separately when generating/validating kernel output.
+    // A time horizon for this shared mutable should be set separately when generating/validating kernel output.
     // This is a confusingly-named function.
     validate_with_hash_hints(
         private_call_data.public_inputs.historical_header,

--- a/noir-projects/noir-protocol-circuits/crates/private-kernel-lib/src/components/private_kernel_circuit_output_validator.nr
+++ b/noir-projects/noir-protocol-circuits/crates/private-kernel-lib/src/components/private_kernel_circuit_output_validator.nr
@@ -8,7 +8,7 @@ use dep::types::{
     address::AztecAddress,
     constants::DEFAULT_UPDATE_DELAY,
     contract_class_id::ContractClassId,
-    shared_mutable::{compute_shared_mutable_timestamp_horizon, SharedMutableValues},
+    shared_mutable::{compute_shared_mutable_time_horizon, SharedMutableValues},
     traits::{Empty, Packable},
     transaction::tx_request::TxRequest,
     utils::arrays::{
@@ -410,7 +410,7 @@ impl PrivateKernelCircuitOutputValidator {
 
             IncludeByTimestamp::min(
                 include_by_timestamp,
-                IncludeByTimestamp::new(compute_shared_mutable_timestamp_horizon(
+                IncludeByTimestamp::new(compute_shared_mutable_time_horizon(
                     shared_mutable_values,
                     private_call.public_inputs.historical_header.global_variables.timestamp,
                 )),

--- a/noir-projects/noir-protocol-circuits/crates/private-kernel-lib/src/components/private_kernel_circuit_public_inputs_composer.nr
+++ b/noir-projects/noir-protocol-circuits/crates/private-kernel-lib/src/components/private_kernel_circuit_public_inputs_composer.nr
@@ -14,7 +14,7 @@ use dep::types::{
     constants::DEFAULT_UPDATE_DELAY,
     contract_class_id::ContractClassId,
     debug::no_op,
-    shared_mutable::{compute_shared_mutable_timestamp_horizon, SharedMutableValues},
+    shared_mutable::{compute_shared_mutable_time_horizon, SharedMutableValues},
     traits::{Empty, Hash, Packable},
     transaction::tx_request::TxRequest,
     utils::arrays::{ClaimedLengthArray, sort_by_counter_asc},
@@ -206,7 +206,7 @@ impl PrivateKernelCircuitPublicInputsComposer {
 
             self.public_inputs_builder.validation_requests.include_by_timestamp = IncludeByTimestamp::min(
                 self.public_inputs_builder.validation_requests.include_by_timestamp,
-                IncludeByTimestamp::new(compute_shared_mutable_timestamp_horizon(
+                IncludeByTimestamp::new(compute_shared_mutable_time_horizon(
                     shared_mutable_values,
                     private_call.public_inputs.historical_header.global_variables.timestamp,
                 )),

--- a/noir-projects/noir-protocol-circuits/crates/types/src/shared_mutable/mod.nr
+++ b/noir-projects/noir-protocol-circuits/crates/types/src/shared_mutable/mod.nr
@@ -9,7 +9,7 @@ pub mod scheduled_value_change;
 pub mod shared_mutable_values;
 pub mod with_hash;
 
-pub fn compute_shared_mutable_timestamp_horizon<T, let INITIAL_DELAY: u64>(
+pub fn compute_shared_mutable_time_horizon<T, let INITIAL_DELAY: u64>(
     shared_mutable_values: SharedMutableValues<T, INITIAL_DELAY>,
     historical_timestamp: u64,
 ) -> u64
@@ -18,5 +18,5 @@ where
 {
     let effective_minimum_delay =
         shared_mutable_values.sdc.get_effective_minimum_delay_at(historical_timestamp);
-    shared_mutable_values.svc.get_timestamp_horizon(historical_timestamp, effective_minimum_delay)
+    shared_mutable_values.svc.get_time_horizon(historical_timestamp, effective_minimum_delay)
 }

--- a/noir-projects/noir-protocol-circuits/crates/types/src/shared_mutable/scheduled_delay_change.nr
+++ b/noir-projects/noir-protocol-circuits/crates/types/src/shared_mutable/scheduled_delay_change.nr
@@ -84,7 +84,7 @@ impl<let INITIAL_DELAY: u64> ScheduledDelayChange<INITIAL_DELAY> {
     /// Returns the minimum delay before a value might mutate due to a scheduled change, from the perspective of some
     /// historical timestamp (timestamp of a historical block). It only returns a meaningful value when called in
     /// private with historical timestamps. This function can be used alongside
-    /// `ScheduledValueChange.get_timestamp_horizon` to properly constrain the `include_by_timestamp` transaction
+    /// `ScheduledValueChange.get_time_horizon` to properly constrain the `include_by_timestamp` transaction
     /// property when reading mutable shared state.
     /// This value typically equals the current delay at the timestamp following the historical one (the earliest one in
     /// which a value change could be scheduled), but it also considers scenarios in which a delay reduction is

--- a/noir-projects/noir-protocol-circuits/crates/types/src/shared_mutable/scheduled_value_change.nr
+++ b/noir-projects/noir-protocol-circuits/crates/types/src/shared_mutable/scheduled_value_change.nr
@@ -7,7 +7,7 @@ mod test;
 // called the `timestamp_of_change`. The value can only be made to change by scheduling a change event at some future
 // timestamp after some minimum delay measured in seconds has elapsed. This means that at any given timestamp we know
 // both the current value and the smallest timestamp at which the value might change - this is called the
-// 'timestamp horizon'.
+// 'time horizon'.
 pub struct ScheduledValueChange<T> {
     pub(crate) pre: T,
     pub(crate) post: T,
@@ -24,7 +24,7 @@ impl<T> ScheduledValueChange<T> {
     /// (where `timestamp` is simply the current timestamp, i.e. the timestamp at which the current transaction will be
     /// included) and in private (where `timestamp` is the historical timestamp that is used to construct the proof).
     /// Reading in private is only safe if the transaction's `include_by_timestamp` property is set to a value lower or
-    /// equal to the timestamp horizon (see `get_timestamp_horizon()`).
+    /// equal to the time horizon (see `get_time_horizon()`).
     pub fn get_current_at(self, timestamp: u64) -> T {
         // The post value becomes the current one at the timestamp of change. This means different things in each realm:
         // - in public, any transaction that is included at the timestamp of change will use the post value
@@ -60,23 +60,23 @@ impl<T> ScheduledValueChange<T> {
     /// `ScheduledDelayChange.get_effective_minimum_delay_at`), which equals the minimum time in seconds that needs to
     /// elapse from the next block's timestamp until the value changes, regardless of further delay changes.
     /// The value returned by `get_current_at` in private when called with a historical timestamp is only safe to use
-    /// if the transaction's `include_by_timestamp` property is set to a value lower or equal to the timestamp horizon
+    /// if the transaction's `include_by_timestamp` property is set to a value lower or equal to the time horizon
     /// computed using the same historical timestamp.
-    pub fn get_timestamp_horizon(self, historical_timestamp: u64, minimum_delay: u64) -> u64 {
-        // The timestamp horizon is the very last timestamp in which the current value is known. Any timestamp past the
-        // horizon (i.e. with a timestamp larger than the timestamp horizon) may have a different current value.
+    pub fn get_time_horizon(self, historical_timestamp: u64, minimum_delay: u64) -> u64 {
+        // The time horizon is the very last timestamp in which the current value is known. Any timestamp past the
+        // horizon (i.e. with a timestamp larger than the time horizon) may have a different current value.
         // Reading the current value in private typically requires constraining the maximum valid timestamp to be equal
-        // to the timestamp horizon.
+        // to the time horizon.
         if historical_timestamp >= self.timestamp_of_change {
             // Once the timestamp of change has passed (block with timestamp >= timestamp_of_change was mined),
             // the current value (post) will not change unless a new value change is scheduled. This did not happen at
             // the historical timestamp (or else it would not be greater or equal to the timestamp of change), and
             // therefore could only happen after the historical timestamp. The earliest would be the immediate next
             // timestamp, and so the smallest possible next timestamp of change equals `historical_timestamp + 1 +
-            // minimum_delay`. Our timestamp horizon is simply the previous timestamp to that one.
+            // minimum_delay`. Our time horizon is simply the previous timestamp to that one.
             //
             //   timestamp of    historical
-            //      change       timestamp          timestamp horizon
+            //      change       timestamp          time horizon
             //   =======|=============N===================H===========>
             //                         ^                   ^
             //                         ---------------------
@@ -84,13 +84,13 @@ impl<T> ScheduledValueChange<T> {
             historical_timestamp + minimum_delay
         } else {
             // If the timestamp of change has not yet been reached however, then there are two possible scenarios.
-            //   a) It could be so far into the future that the timestamp horizon is actually determined by the minimum
+            //   a) It could be so far into the future that the time horizon is actually determined by the minimum
             //      delay, because a new change could be scheduled and take place _before_ the currently scheduled one.
             //      This is similar to the scenario where the timestamp of change is in the past: the time horizon is
             //      the timestamp prior to the earliest one in which a new timestamp of change might land.
             //
             //         historical
-            //         timestamp                      timestamp horizon    timestamp of change
+            //         timestamp                      time horizon    timestamp of change
             //        =====N=================================H=================|=========>
             //              ^                                 ^
             //              |                                 |
@@ -102,7 +102,7 @@ impl<T> ScheduledValueChange<T> {
             //      the timestamp right before the timestamp of change (since by definition the value changes at the
             //      timestamp of change).
             //
-            //           historical                         timestamp horizon
+            //           historical                         time horizon
             //           timestamp   timestamp of change    if not scheduled
             //        =======N=============|===================H=================>
             //                ^           ^                     ^

--- a/noir-projects/noir-protocol-circuits/crates/types/src/shared_mutable/scheduled_value_change/test.nr
+++ b/noir-projects/noir-protocol-circuits/crates/types/src/shared_mutable/scheduled_value_change/test.nr
@@ -29,18 +29,18 @@ unconstrained fn test_get_scheduled() {
     assert_eq(value_change.get_scheduled(), (post, timestamp_of_change));
 }
 
-unconstrained fn assert_timestamp_horizon_invariants(
+unconstrained fn assert_time_horizon_invariants(
     value_change: &mut ScheduledValueChange<Field>,
     historical_timestamp: u64,
-    timestamp_horizon: u64,
+    time_horizon: u64,
 ) {
-    // The current value should not change at the timestamp horizon (but it might later).
+    // The current value should not change at the time horizon (but it might later).
     let current_at_historical = value_change.get_current_at(historical_timestamp);
-    assert_eq(current_at_historical, value_change.get_current_at(timestamp_horizon));
+    assert_eq(current_at_historical, value_change.get_current_at(time_horizon));
 
     // The earliest a new change could be scheduled in would be the immediate next timestamp to the historical one. This
-    // should result in the new timestamp of change landing *after* the timestamp horizon, and the current value still not
-    // changing at the previously determined timestamp_horizon.
+    // should result in the new timestamp of change landing *after* the time horizon, and the current value still not
+    // changing at the previously determined time_horizon.
     let new = value_change.pre + value_change.post; // Make sure it's different to both pre and post
     value_change.schedule_change(
         new,
@@ -49,81 +49,81 @@ unconstrained fn assert_timestamp_horizon_invariants(
         historical_timestamp + 1 + TEST_DELAY,
     );
 
-    assert(value_change.timestamp_of_change > timestamp_horizon);
-    assert_eq(current_at_historical, value_change.get_current_at(timestamp_horizon));
+    assert(value_change.timestamp_of_change > time_horizon);
+    assert_eq(current_at_historical, value_change.get_current_at(time_horizon));
 }
 
 #[test]
-unconstrained fn test_get_timestamp_horizon_change_in_past() {
+unconstrained fn test_get_time_horizon_change_in_past() {
     let historical_timestamp = 100;
     let timestamp_of_change = 50;
 
     let mut value_change: ScheduledValueChange<Field> =
         ScheduledValueChange::new(1, 2, timestamp_of_change);
 
-    let timestamp_horizon = value_change.get_timestamp_horizon(historical_timestamp, TEST_DELAY);
-    assert_eq(timestamp_horizon, historical_timestamp + TEST_DELAY);
+    let time_horizon = value_change.get_time_horizon(historical_timestamp, TEST_DELAY);
+    assert_eq(time_horizon, historical_timestamp + TEST_DELAY);
 
-    assert_timestamp_horizon_invariants(&mut value_change, historical_timestamp, timestamp_horizon);
+    assert_time_horizon_invariants(&mut value_change, historical_timestamp, time_horizon);
 }
 
 #[test]
-unconstrained fn test_get_timestamp_horizon_change_in_immediate_past() {
+unconstrained fn test_get_time_horizon_change_in_immediate_past() {
     let historical_timestamp = 100;
     let timestamp_of_change = 100;
 
     let mut value_change: ScheduledValueChange<Field> =
         ScheduledValueChange::new(1, 2, timestamp_of_change);
 
-    let timestamp_horizon = value_change.get_timestamp_horizon(historical_timestamp, TEST_DELAY);
-    assert_eq(timestamp_horizon, historical_timestamp + TEST_DELAY);
+    let time_horizon = value_change.get_time_horizon(historical_timestamp, TEST_DELAY);
+    assert_eq(time_horizon, historical_timestamp + TEST_DELAY);
 
-    assert_timestamp_horizon_invariants(&mut value_change, historical_timestamp, timestamp_horizon);
+    assert_time_horizon_invariants(&mut value_change, historical_timestamp, time_horizon);
 }
 
 #[test]
-unconstrained fn test_get_timestamp_horizon_change_in_near_future() {
+unconstrained fn test_get_time_horizon_change_in_near_future() {
     let historical_timestamp = 100;
     let timestamp_of_change = 120;
 
     let mut value_change: ScheduledValueChange<Field> =
         ScheduledValueChange::new(1, 2, timestamp_of_change);
 
-    // Note that this is the only scenario in which the timestamp of change informs the timestamp horizon.
+    // Note that this is the only scenario in which the timestamp of change informs the time horizon.
     // This may result in privacy leaks when interacting with applications that have a scheduled change
     // in the near future.
-    let timestamp_horizon = value_change.get_timestamp_horizon(historical_timestamp, TEST_DELAY);
-    assert_eq(timestamp_horizon, timestamp_of_change - 1);
+    let time_horizon = value_change.get_time_horizon(historical_timestamp, TEST_DELAY);
+    assert_eq(time_horizon, timestamp_of_change - 1);
 
-    assert_timestamp_horizon_invariants(&mut value_change, historical_timestamp, timestamp_horizon);
+    assert_time_horizon_invariants(&mut value_change, historical_timestamp, time_horizon);
 }
 
 #[test]
-unconstrained fn test_get_timestamp_horizon_change_in_far_future() {
+unconstrained fn test_get_time_horizon_change_in_far_future() {
     let historical_timestamp = 100;
     let timestamp_of_change = 500;
 
     let mut value_change: ScheduledValueChange<Field> =
         ScheduledValueChange::new(1, 2, timestamp_of_change);
 
-    let timestamp_horizon = value_change.get_timestamp_horizon(historical_timestamp, TEST_DELAY);
-    assert_eq(timestamp_horizon, historical_timestamp + TEST_DELAY);
+    let time_horizon = value_change.get_time_horizon(historical_timestamp, TEST_DELAY);
+    assert_eq(time_horizon, historical_timestamp + TEST_DELAY);
 
-    assert_timestamp_horizon_invariants(&mut value_change, historical_timestamp, timestamp_horizon);
+    assert_time_horizon_invariants(&mut value_change, historical_timestamp, time_horizon);
 }
 
 #[test]
-unconstrained fn test_get_timestamp_horizon_n0_delay() {
+unconstrained fn test_get_time_horizon_n0_delay() {
     let historical_timestamp = 100;
     let timestamp_of_change = 50;
 
     let mut value_change: ScheduledValueChange<Field> =
         ScheduledValueChange::new(1, 2, timestamp_of_change);
 
-    let timestamp_horizon = value_change.get_timestamp_horizon(historical_timestamp, 0);
-    // Since the timestamp horizon equals the historical timestamp, it is not possible to read the current value in
+    let time_horizon = value_change.get_time_horizon(historical_timestamp, 0);
+    // Since the time horizon equals the historical timestamp, it is not possible to read the current value in
     // private since the transaction `include_by_timestamp` property would equal an already mined timestamp.
-    assert_eq(timestamp_horizon, historical_timestamp);
+    assert_eq(time_horizon, historical_timestamp);
 }
 
 #[test]

--- a/yarn-project/end-to-end/src/e2e_contract_updates.test.ts
+++ b/yarn-project/end-to-end/src/e2e_contract_updates.test.ts
@@ -2,6 +2,7 @@ import { getSchnorrAccountContractAddress } from '@aztec/accounts/schnorr';
 import { type AztecNode, Fr, type Wallet, getContractClassFromArtifact } from '@aztec/aztec.js';
 import { registerContractClass } from '@aztec/aztec.js/deployment';
 import { MINIMUM_UPDATE_DELAY, UPDATED_CLASS_IDS_SLOT } from '@aztec/constants';
+import { getL1ContractsConfigEnvVars } from '@aztec/ethereum';
 import { UpdatableContract } from '@aztec/noir-test-contracts.js/Updatable';
 import { UpdatedContract, UpdatedContractArtifact } from '@aztec/noir-test-contracts.js/Updated';
 import { ProtocolContractAddress } from '@aztec/protocol-contracts';
@@ -16,7 +17,8 @@ import type { UInt64 } from '@aztec/stdlib/types';
 import { setup } from './fixtures/utils.js';
 
 // Set the update delay in genesis data so it's feasible to test in an e2e test
-const DEFAULT_TEST_UPDATE_DELAY = 360n; // 10 slots
+const { aztecSlotDuration } = getL1ContractsConfigEnvVars();
+const DEFAULT_TEST_UPDATE_DELAY = BigInt(aztecSlotDuration) * 10n;
 
 describe('e2e_contract_updates', () => {
   let wallet: Wallet;


### PR DESCRIPTION
Fixing some of the issues pointed out on https://github.com/AztecProtocol/aztec-packages/pull/14980 that I didn't address in the original PR.

The issues are:
1. Replacing hardcoded `DEFAULT_TEST_UPDATE_DELAY` with one derived from `aztecSlotDuration`,
2. renaming "timestamp horizon" as "time horizon",
3. fixing fixture name: "update_timestamp" --> "update_current_timestamp".

I don't think the `get_time_horizon` function is ever used by external devs (we only ever use it in our SharedMutable tests) so I didn't write migration notes.
