### PR TITLE
chore: Reset block interval when warping to a future slot

### DIFF
--- a/yarn-project/aztec.js/src/test/anvil_test_watcher.ts
+++ b/yarn-project/aztec.js/src/test/anvil_test_watcher.ts
@@ -132,8 +132,10 @@ export class AnvilTestWatcher {
       if (currentSlot === blockLog.slotNumber) {
         // We should jump to the next slot
         try {
-          await this.cheatcodes.warp(nextSlotTimestamp);
-          this.dateProvider?.setTime(nextSlotTimestamp * 1000);
+          await this.cheatcodes.warp(nextSlotTimestamp, {
+            resetBlockInterval: true,
+            updateDateProvider: this.dateProvider,
+          });
         } catch (e) {
           this.logger.error(`Failed to warp to timestamp ${nextSlotTimestamp}: ${e}`);
         }
@@ -150,8 +152,10 @@ export class AnvilTestWatcher {
       const currentTimestamp = this.dateProvider?.now() ?? Date.now();
       if (currentTimestamp > nextSlotTimestamp * 1000) {
         try {
-          await this.cheatcodes.warp(nextSlotTimestamp);
-          this.dateProvider?.setTime(nextSlotTimestamp * 1000);
+          await this.cheatcodes.warp(nextSlotTimestamp, {
+            resetBlockInterval: true,
+            updateDateProvider: this.dateProvider,
+          });
         } catch (e) {
           this.logger.error(`Failed to warp to timestamp ${nextSlotTimestamp}: ${e}`);
         }

--- a/yarn-project/cli/src/cmds/l1/update_l1_validators.ts
+++ b/yarn-project/cli/src/cmds/l1/update_l1_validators.ts
@@ -181,7 +181,7 @@ export async function fastForwardEpochs({
   const timestamp = await rollup.read.getTimestampForSlot([currentSlot + l2SlotsInEpoch * numEpochs]);
   dualLog(`Fast forwarding ${numEpochs} epochs to ${timestamp}`);
   try {
-    await cheatCodes.warp(Number(timestamp));
+    await cheatCodes.warp(Number(timestamp), { resetBlockInterval: true });
     dualLog(`Fast forwarded ${numEpochs} epochs to ${timestamp}`);
   } catch (error) {
     if (error instanceof Error && error.message.includes("is lower than or equal to previous block's timestamp")) {

--- a/yarn-project/end-to-end/src/composed/integration_l1_publisher.test.ts
+++ b/yarn-project/end-to-end/src/composed/integration_l1_publisher.test.ts
@@ -115,7 +115,7 @@ describe('L1Publisher integration', () => {
     const currentSlot = await rollup.getSlotNumber();
     const timestamp = await rollup.getTimestampForSlot(currentSlot + slotsToJump);
     if (timestamp > currentTime) {
-      await ethCheatCodes.warp(Number(timestamp));
+      await ethCheatCodes.warp(Number(timestamp), { resetBlockInterval: true });
     }
   };
 

--- a/yarn-project/end-to-end/src/e2e_p2p/upgrade_governance_proposer.test.ts
+++ b/yarn-project/end-to-end/src/e2e_p2p/upgrade_governance_proposer.test.ts
@@ -174,7 +174,7 @@ describe('e2e_p2p_governance_proposer', () => {
     const nextRoundTimestamp2 = await rollup.getTimestampForSlot(
       ((await rollup.getSlotNumber()) / roundSize) * roundSize + roundSize,
     );
-    t.logger.info(`Warpping to ${nextRoundTimestamp2}`);
+    t.logger.info(`Warping to ${nextRoundTimestamp2}`);
     await t.ctx.cheatCodes.eth.warp(Number(nextRoundTimestamp2));
 
     await waitL1Block();

--- a/yarn-project/end-to-end/src/e2e_sequencer/gov_proposal.test.ts
+++ b/yarn-project/end-to-end/src/e2e_sequencer/gov_proposal.test.ts
@@ -78,7 +78,7 @@ describe('e2e_gov_proposal', () => {
       const nextRoundBeginsAtSlot = (slot / roundDuration) * roundDuration + roundDuration;
       const nextRoundBeginsAtTimestamp = await rollup.getTimestampForSlot(nextRoundBeginsAtSlot);
       logger.info(`Warping to round ${round + 1n} at slot ${nextRoundBeginsAtSlot}`);
-      await cheatCodes.eth.warp(Number(nextRoundBeginsAtTimestamp));
+      await cheatCodes.eth.warp(Number(nextRoundBeginsAtTimestamp), { resetBlockInterval: true });
 
       // Now we submit a bunch of transactions to the PXE.
       // We know that this will last at least as long as the round duration,

--- a/yarn-project/end-to-end/src/e2e_synching.test.ts
+++ b/yarn-project/end-to-end/src/e2e_synching.test.ts
@@ -554,7 +554,7 @@ describe('e2e_synching', () => {
           const blockLog = await rollup.read.getBlock([(await rollup.read.getProvenBlockNumber()) + 1n]);
           const timeJumpTo = await rollup.read.getTimestampForSlot([blockLog.slotNumber + timeliness]);
 
-          await opts.cheatCodes!.eth.warp(Number(timeJumpTo));
+          await opts.cheatCodes!.eth.warp(Number(timeJumpTo), { resetBlockInterval: true });
 
           expect(await archiver.getBlockNumber()).toBeGreaterThan(Number(provenThrough));
           const blockTip = (await archiver.getBlock(await archiver.getBlockNumber()))!;
@@ -638,7 +638,7 @@ describe('e2e_synching', () => {
           const blockLog = await rollup.read.getBlock([(await rollup.read.getProvenBlockNumber()) + 1n]);
           const timeJumpTo = await rollup.read.getTimestampForSlot([blockLog.slotNumber + timeliness]);
 
-          await opts.cheatCodes!.eth.warp(Number(timeJumpTo));
+          await opts.cheatCodes!.eth.warp(Number(timeJumpTo), { resetBlockInterval: true });
 
           const watcher = new AnvilTestWatcher(
             opts.cheatCodes!.eth,
@@ -698,7 +698,7 @@ describe('e2e_synching', () => {
           const blockLog = await rollup.read.getBlock([(await rollup.read.getProvenBlockNumber()) + 1n]);
           const timeJumpTo = await rollup.read.getTimestampForSlot([blockLog.slotNumber + timeliness]);
 
-          await opts.cheatCodes!.eth.warp(Number(timeJumpTo));
+          await opts.cheatCodes!.eth.warp(Number(timeJumpTo), { resetBlockInterval: true });
 
           await rollup.write.prune();
 

--- a/yarn-project/end-to-end/src/fixtures/snapshot_manager.ts
+++ b/yarn-project/end-to-end/src/fixtures/snapshot_manager.ts
@@ -348,7 +348,7 @@ async function setupFromFresh(
   const ethCheatCodes = new EthCheatCodesWithState(aztecNodeConfig.l1RpcUrls);
 
   if (opts.l1StartTime) {
-    await ethCheatCodes.warp(opts.l1StartTime);
+    await ethCheatCodes.warp(opts.l1StartTime, { resetBlockInterval: true });
   }
 
   const initialFundedAccounts = await generateSchnorrAccounts(numberOfInitialFundedAccounts);

--- a/yarn-project/end-to-end/src/fixtures/utils.ts
+++ b/yarn-project/end-to-end/src/fixtures/utils.ts
@@ -420,7 +420,7 @@ export async function setup(
     }
 
     if (opts.l1StartTime) {
-      await ethCheatCodes.warp(opts.l1StartTime);
+      await ethCheatCodes.warp(opts.l1StartTime, { resetBlockInterval: true });
     }
 
     let publisherPrivKey = undefined;
@@ -509,7 +509,7 @@ export async function setup(
     if (opts.l2StartTime) {
       // This should only be used in synching test or when you need to have a stable
       // timestamp for the first l2 block.
-      await ethCheatCodes.warp(opts.l2StartTime);
+      await ethCheatCodes.warp(opts.l2StartTime, { resetBlockInterval: true });
     }
 
     const dateProvider = new TestDateProvider();
@@ -609,7 +609,7 @@ export async function setup(
     ) {
       // We need to advance to epoch 2 such that the committee is set up.
       logger.info(`Advancing to epoch 2`);
-      await cheatCodes.rollup.advanceToEpoch(2n, { resetBlockInterval: true, updateDateProvider: dateProvider });
+      await cheatCodes.rollup.advanceToEpoch(2n, { updateDateProvider: dateProvider });
       await cheatCodes.rollup.setupEpoch();
       await cheatCodes.rollup.debugRollup();
     }


### PR DESCRIPTION
Should avoid block building issues where sequencers fail to build a block immediately after a warp, in the cases where anvil is set up with interval mining.
