### PR TITLE
fix: Allow for 1s before publishing block in anvil

### DIFF
--- a/yarn-project/end-to-end/src/composed/integration_l1_publisher.test.ts
+++ b/yarn-project/end-to-end/src/composed/integration_l1_publisher.test.ts
@@ -193,9 +193,8 @@ describe('L1Publisher integration', () => {
       sequencerL1Client,
       l1ContractAddresses.governanceProposerAddress.toString(),
     );
-    const epochCache = await EpochCache.create(l1ContractAddresses.rollupAddress, config, {
-      dateProvider: new TestDateProvider(),
-    });
+    const dateProvider = new TestDateProvider();
+    const epochCache = await EpochCache.create(l1ContractAddresses.rollupAddress, config, { dateProvider });
     publisher = new SequencerPublisher(
       {
         l1RpcUrls: config.l1RpcUrls,
@@ -214,6 +213,7 @@ describe('L1Publisher integration', () => {
         epochCache,
         governanceProposerContract,
         slashingProposerContract,
+        dateProvider,
       },
     );
 

--- a/yarn-project/end-to-end/src/e2e_synching.test.ts
+++ b/yarn-project/end-to-end/src/e2e_synching.test.ts
@@ -407,9 +407,8 @@ describe('e2e_synching', () => {
       deployL1ContractsValues.l1Client,
       slashingProposerAddress.toString(),
     );
-    const epochCache = await EpochCache.create(config.l1Contracts.rollupAddress, config, {
-      dateProvider: new TestDateProvider(),
-    });
+    const dateProvider = new TestDateProvider();
+    const epochCache = await EpochCache.create(config.l1Contracts.rollupAddress, config, { dateProvider });
     const publisher = new SequencerPublisher(
       {
         l1RpcUrls: config.l1RpcUrls,
@@ -429,6 +428,7 @@ describe('e2e_synching', () => {
         governanceProposerContract,
         slashingProposerContract,
         epochCache,
+        dateProvider,
       },
     );
 

--- a/yarn-project/ethereum/src/l1_tx_utils.ts
+++ b/yarn-project/ethereum/src/l1_tx_utils.ts
@@ -494,7 +494,7 @@ export class ReadOnlyL1TxUtils {
         result,
       });
       if (result[0].calls[0].status === 'failure') {
-        this.logger?.error('L1 transaction Simulation failed', {
+        this.logger?.error('L1 transaction simulation failed', {
           error: result[0].calls[0].error,
         });
         const decodedError = decodeErrorResult({

--- a/yarn-project/sequencer-client/src/client/sequencer-client.ts
+++ b/yarn-project/sequencer-client/src/client/sequencer-client.ts
@@ -117,6 +117,7 @@ export class SequencerClient {
         epochCache,
         governanceProposerContract,
         slashingProposerContract,
+        dateProvider: deps.dateProvider,
       });
     const globalsBuilder = new GlobalVariableBuilder(config);
 
@@ -131,14 +132,14 @@ export class SequencerClient {
       sequencerManaLimit = rollupManaLimit;
     }
 
-    // When running in anvil, assume we can post a tx up until the very last second of an L1 slot.
+    // When running in anvil, assume we can post a tx up until one second before the end of an L1 slot.
     // Otherwise, assume we must have broadcasted the tx before the slot started (we use a default
     // maxL1TxInclusionTimeIntoSlot of zero) to get the tx into that L1 slot.
     // In theory, the L1 slot has an initial 4s phase where the block is propagated, so we could
     // make it with a propagation time into slot equal to 4s. However, we prefer being conservative.
     // See https://www.blocknative.com/blog/anatomy-of-a-slot#7 for more info.
     const maxL1TxInclusionTimeIntoSlot =
-      (config.maxL1TxInclusionTimeIntoSlot ?? isAnvilTestChain(config.l1ChainId)) ? ethereumSlotDuration : 0;
+      (config.maxL1TxInclusionTimeIntoSlot ?? isAnvilTestChain(config.l1ChainId)) ? ethereumSlotDuration - 1 : 0;
 
     const l1Constants = {
       l1GenesisTime,

--- a/yarn-project/sequencer-client/src/publisher/sequencer-publisher.test.ts
+++ b/yarn-project/sequencer-client/src/publisher/sequencer-publisher.test.ts
@@ -17,6 +17,7 @@ import {
 import type { L1TxUtilsWithBlobs } from '@aztec/ethereum/l1-tx-utils-with-blobs';
 import { EthAddress } from '@aztec/foundation/eth-address';
 import { sleep } from '@aztec/foundation/sleep';
+import { TestDateProvider } from '@aztec/foundation/timer';
 import { EmpireBaseAbi, RollupAbi } from '@aztec/l1-artifacts';
 import { L2Block, Signature } from '@aztec/stdlib/block';
 import type { ProposedBlockHeader } from '@aztec/stdlib/tx';
@@ -120,6 +121,7 @@ describe('SequencerPublisher', () => {
       epochCache,
       slashingProposerContract,
       governanceProposerContract,
+      dateProvider: new TestDateProvider(),
     });
 
     (publisher as any)['l1TxUtils'] = l1TxUtils;

--- a/yarn-project/sequencer-client/src/sequencer/sequencer.ts
+++ b/yarn-project/sequencer-client/src/sequencer/sequencer.ts
@@ -58,7 +58,12 @@ export { SequencerState };
 type SequencerRollupConstants = Pick<L1RollupConstants, 'ethereumSlotDuration' | 'l1GenesisTime' | 'slotDuration'>;
 
 export type SequencerEvents = {
-  ['state-changed']: (args: { oldState: SequencerState; newState: SequencerState }) => void;
+  ['state-changed']: (args: {
+    oldState: SequencerState;
+    newState: SequencerState;
+    secondsIntoSlot: number;
+    slotNumber: bigint;
+  }) => void;
   ['proposer-rollup-check-failed']: (args: { reason: string }) => void;
   ['tx-count-check-failed']: (args: { minTxs: number; availableTxs: number }) => void;
   ['block-build-failed']: (args: { reason: string }) => void;
@@ -201,7 +206,6 @@ export class Sequencer extends (EventEmitter as new () => TypedEventEmitter<Sequ
       this.metrics,
       this.log,
     );
-    this.log.verbose(`Sequencer timetable updated`, { enforceTimeTable: this.enforceTimeTable });
   }
 
   /**
@@ -506,7 +510,12 @@ export class Sequencer extends (EventEmitter as new () => TypedEventEmitter<Sequ
     const secondsIntoSlot = this.getSecondsIntoSlot(currentSlotNumber);
     this.timetable.assertTimeLeft(proposedState, secondsIntoSlot);
     this.log.debug(`Transitioning from ${this.state} to ${proposedState}`);
-    this.emit('state-changed', { oldState: this.state, newState: proposedState });
+    this.emit('state-changed', {
+      oldState: this.state,
+      newState: proposedState,
+      secondsIntoSlot,
+      slotNumber: currentSlotNumber,
+    });
     this.state = proposedState;
   }
 

--- a/yarn-project/sequencer-client/src/sequencer/timetable.ts
+++ b/yarn-project/sequencer-client/src/sequencer/timetable.ts
@@ -65,6 +65,19 @@ export class SequencerTimetable {
       );
     }
     this.initializeDeadline = initializeDeadline;
+    this.log.verbose(`Sequencer timetable initialized (${this.enforce ? 'enforced' : 'not enforced'})`, {
+      ethereumSlotDuration: this.ethereumSlotDuration,
+      aztecSlotDuration: this.aztecSlotDuration,
+      maxL1TxInclusionTimeIntoSlot: this.maxL1TxInclusionTimeIntoSlot,
+      l1PublishingTime: this.l1PublishingTime,
+      minExecutionTime: this.minExecutionTime,
+      blockPrepareTime: this.blockPrepareTime,
+      attestationPropagationTime: this.attestationPropagationTime,
+      blockValidationTime: this.blockValidationTime,
+      initializeDeadline: this.initializeDeadline,
+      enforce: this.enforce,
+      allWorkToDo,
+    });
   }
 
   private get afterBlockBuildingTimeNeededWithoutReexec() {


### PR DESCRIPTION
Try fix flake in `end-to-end/src/e2e_epochs/epochs_monitor_block_building.test.ts` (example run [here](http://ci.aztec-labs.com/43d0b7d6c2d5534a)).

The error hints at simulation failing immediately before a new L1 block is mined. It seems like we're checking we have enough time to publish the block (which the timetable enforces as zero seconds because we are in anvil!), but then we go past it.
