### PR TITLE
test: improved `e2e_contract_updates.test.ts`

### DIFF
--- a/.test_patterns.yml
+++ b/.test_patterns.yml
@@ -178,11 +178,6 @@ tests:
     error_regex: "Failed events from sequencers"
     owners:
       - *palla
-  # http://ci.aztec-labs.com/fbd46dc29335ec8c
-  - regex: "src/e2e_contract_updates.test.ts"
-    error_regex: "TimeoutError: Timeout awaiting isMined"
-    owners:
-      - *jan
 
   # yarn-project tests
   - regex: "p2p/src/services/discv5/discv5_service.test.ts"

--- a/noir-projects/noir-contracts/contracts/test/updatable_contract/src/main.nr
+++ b/noir-projects/noir-contracts/contracts/test/updatable_contract/src/main.nr
@@ -1,5 +1,6 @@
 use dep::aztec::macros::aztec;
 
+/// A contract that can be updated to a new contract class. Used to test contract updates in e2e_contract_updates.test.ts.
 #[aztec]
 contract Updatable {
     use aztec::macros::{functions::{initializer, private, public, utility}, storage::storage};

--- a/noir-projects/noir-contracts/contracts/test/updated_contract/src/main.nr
+++ b/noir-projects/noir-contracts/contracts/test/updated_contract/src/main.nr
@@ -1,5 +1,6 @@
 use dep::aztec::macros::aztec;
 
+/// A contract to whose contract class the `Updatable` contract is updated to in `e2e_contract_updates.test.ts`.
 #[aztec]
 contract Updated {
     use aztec::macros::{functions::{private, public, utility}, storage::storage};

--- a/yarn-project/stdlib/src/interfaces/pxe.ts
+++ b/yarn-project/stdlib/src/interfaces/pxe.ts
@@ -125,6 +125,8 @@ export interface PXE {
    * This is called by aztec.js when instantiating a contract in a given address with a mismatching artifact.
    * @param contractAddress - The address of the contract to update.
    * @param artifact - The updated artifact for the contract.
+   * @throws If the artifact's contract class is not found in the PXE or if the contract class is different from
+   * the current one (current one from the point of view of the node to which the PXE is connected).
    */
   updateContract(contractAddress: AztecAddress, artifact: ContractArtifact): Promise<void>;
 


### PR DESCRIPTION
When recently modifying the `e2e_contract_updates.test.ts` I warped L2 time a stupid way - I mined blocks until the timestamp progressed by duration. This caused is a flake and is inefficient. In this PR I changed it to instead directly warp the time. Also did a few random improvements.
