### PR TITLE
feat: better time warping cheatcodes

### DIFF
--- a/noir-projects/noir-contracts/contracts/app/token_blacklist_contract/src/main.nr
+++ b/noir-projects/noir-contracts/contracts/app/token_blacklist_contract/src/main.nr
@@ -36,7 +36,7 @@ pub contract TokenBlacklist {
         utils::comparison::Comparator,
     };
 
-    use std::{meta::ctstring::AsCtString, ops::{Add, Sub}};
+    use std::ops::{Add, Sub};
 
     use crate::types::{
         balances_map::BalancesMap, roles::UserFlags, token_note::TokenNote,
@@ -46,8 +46,8 @@ pub contract TokenBlacklist {
         address::AztecAddress, constants::MAX_NOTE_HASHES_PER_TX, traits::Packable,
     };
 
-    // Changing an address' roles has a certain delay before it goes into effect. Here set to half a day.
-    global CHANGE_ROLES_DELAY: u64 = 43200;
+    // Changing an address' roles has a certain delay before it goes into effect. Here set to 1 day.
+    global CHANGE_ROLES_DELAY: u64 = 86400;
 
     #[storage]
     struct Storage<Context> {

--- a/noir-projects/noir-contracts/contracts/app/token_blacklist_contract/src/main.nr
+++ b/noir-projects/noir-contracts/contracts/app/token_blacklist_contract/src/main.nr
@@ -46,8 +46,8 @@ pub contract TokenBlacklist {
         address::AztecAddress, constants::MAX_NOTE_HASHES_PER_TX, traits::Packable,
     };
 
-    // Changing an address' roles has a certain delay before it goes into effect. Here set to 2 slots.
-    global CHANGE_ROLES_DELAY: u64 = 72;
+    // Changing an address' roles has a certain delay before it goes into effect. Here set to half a day.
+    global CHANGE_ROLES_DELAY: u64 = 43200;
 
     #[storage]
     struct Storage<Context> {

--- a/yarn-project/aztec/src/testing/cheat_codes.ts
+++ b/yarn-project/aztec/src/testing/cheat_codes.ts
@@ -1,5 +1,7 @@
 import { EthCheatCodes, RollupCheatCodes } from '@aztec/ethereum/test';
-import type { PXE } from '@aztec/stdlib/interfaces/client';
+import { sleep } from '@aztec/foundation/sleep';
+import type { SequencerClient } from '@aztec/sequencer-client';
+import type { AztecNode, PXE } from '@aztec/stdlib/interfaces/client';
 
 import { AztecCheatCodes } from './aztec_cheat_codes.js';
 
@@ -24,5 +26,44 @@ export class CheatCodes {
       await pxe.getNodeInfo().then(n => n.l1ContractAddresses),
     );
     return new CheatCodes(ethCheatCodes, aztecCheatCodes, rollupCheatCodes);
+  }
+
+  /**
+   * Warps the L1 timestamp to a target timestamp and mines an L2 block that advances the L2 timestamp to at least
+   * the target timestamp. L2 timestamp is not advanced exactly to the target timestamp because it is determined
+   * by the slot number, which advances in fixed intervals.
+   * This is useful for testing time-dependent contract behavior.
+   * @param sequencerClient - The sequencer client to use for configuring min txs per block
+   * @param node - The Aztec node to query for new blocks
+   * @param targetTimestamp - The target timestamp to warp to (in seconds)
+   */
+  async warpL2TimeAtLeastTo(sequencerClient: SequencerClient, node: AztecNode, targetTimestamp: bigint | number) {
+    const currentL2BlockNumber = await node.getBlockNumber();
+
+    // We warp the L1 timestamp
+    await this.eth.warp(targetTimestamp, { resetBlockInterval: true });
+
+    // Force an empty block to be mined
+    sequencerClient!.getSequencer().flush();
+
+    // Wait for a new block to be mined by polling the node
+    while ((await node.getBlockNumber()) === currentL2BlockNumber) {
+      await sleep(2000);
+    }
+  }
+
+  /**
+   * Warps the L1 timestamp forward by a specified duration and mines an L2 block that advances the L2 timestamp at
+   * least by the duration. L2 timestamp is not advanced exactly by the duration because it is determined by the slot
+   * number, which advances in fixed intervals.
+   * This is useful for testing time-dependent contract behavior.
+   * @param sequencerClient - The sequencer client to use for configuring min txs per block
+   * @param node - The Aztec node to query for new blocks
+   * @param duration - The duration to advance time by (in seconds)
+   */
+  async warpL2TimeAtLeastBy(sequencerClient: SequencerClient, node: AztecNode, duration: bigint | number) {
+    const currentTimestamp = await this.eth.timestamp();
+    const targetTimestamp = BigInt(currentTimestamp) + BigInt(duration);
+    await this.warpL2TimeAtLeastTo(sequencerClient, node, targetTimestamp);
   }
 }

--- a/yarn-project/aztec/src/testing/cheat_codes.ts
+++ b/yarn-project/aztec/src/testing/cheat_codes.ts
@@ -33,8 +33,8 @@ export class CheatCodes {
    * the target timestamp. L2 timestamp is not advanced exactly to the target timestamp because it is determined
    * by the slot number, which advances in fixed intervals.
    * This is useful for testing time-dependent contract behavior.
-   * @param sequencerClient - The sequencer client to use for configuring min txs per block
-   * @param node - The Aztec node to query for new blocks
+   * @param sequencerClient - The sequencer client to use to force an empty block to be mined.
+   * @param node - The Aztec node used to query if a new block has been mined.
    * @param targetTimestamp - The target timestamp to warp to (in seconds)
    */
   async warpL2TimeAtLeastTo(sequencerClient: SequencerClient, node: AztecNode, targetTimestamp: bigint | number) {
@@ -43,8 +43,8 @@ export class CheatCodes {
     // We warp the L1 timestamp
     await this.eth.warp(targetTimestamp, { resetBlockInterval: true });
 
-    // Force an empty block to be mined
-    sequencerClient!.getSequencer().flush();
+    // Force an empty block to be mined by "flushing" the sequencer.
+    sequencerClient.getSequencer().flush();
 
     // Wait for a new block to be mined by polling the node
     while ((await node.getBlockNumber()) === currentL2BlockNumber) {
@@ -57,8 +57,8 @@ export class CheatCodes {
    * least by the duration. L2 timestamp is not advanced exactly by the duration because it is determined by the slot
    * number, which advances in fixed intervals.
    * This is useful for testing time-dependent contract behavior.
-   * @param sequencerClient - The sequencer client to use for configuring min txs per block
-   * @param node - The Aztec node to query for new blocks
+   * @param sequencerClient - The sequencer client to use to force an empty block to be mined.
+   * @param node - The Aztec node used to query if a new block has been mined.
    * @param duration - The duration to advance time by (in seconds)
    */
   async warpL2TimeAtLeastBy(sequencerClient: SequencerClient, node: AztecNode, duration: bigint | number) {

--- a/yarn-project/end-to-end/src/composed/e2e_persistence.test.ts
+++ b/yarn-project/end-to-end/src/composed/e2e_persistence.test.ts
@@ -104,7 +104,7 @@ describe('Aztec persistence', () => {
   }, 180_000);
 
   const progressBlocksPastDelay = async (contract: TokenBlacklistContract) => {
-    for (let i = 0; i < BlacklistTokenContractTest.DELAY; ++i) {
+    for (let i = 0; i < BlacklistTokenContractTest.CHANGE_ROLES_DELAY; ++i) {
       await contract.methods.get_roles(owner.address).send().wait();
     }
   };

--- a/yarn-project/end-to-end/src/e2e_blacklist_token_contract/access_control.test.ts
+++ b/yarn-project/end-to-end/src/e2e_blacklist_token_contract/access_control.test.ts
@@ -26,7 +26,7 @@ describe('e2e_blacklist_token_contract access control', () => {
       .send()
       .wait();
 
-    await t.mineBlocks(); // This gets us past the block of change
+    await t.crossTimestampOfChange();
 
     expect(await t.asset.methods.get_roles(t.admin.getAddress()).simulate()).toEqual(adminMinterRole.toNoirStruct());
   });
@@ -39,7 +39,7 @@ describe('e2e_blacklist_token_contract access control', () => {
       .send()
       .wait();
 
-    await t.mineBlocks(); // This gets us past the block of change
+    await t.crossTimestampOfChange();
 
     expect(await t.asset.methods.get_roles(t.other.getAddress()).simulate()).toEqual(adminRole.toNoirStruct());
   });
@@ -48,7 +48,7 @@ describe('e2e_blacklist_token_contract access control', () => {
     const noRole = new Role();
     await t.asset.withWallet(t.admin).methods.update_roles(t.other.getAddress(), noRole.toNoirStruct()).send().wait();
 
-    await t.mineBlocks(); // This gets us past the block of change
+    await t.crossTimestampOfChange();
 
     expect(await t.asset.methods.get_roles(t.other.getAddress()).simulate()).toEqual(noRole.toNoirStruct());
   });
@@ -61,7 +61,7 @@ describe('e2e_blacklist_token_contract access control', () => {
       .send()
       .wait();
 
-    await t.mineBlocks(); // This gets us past the block of change
+    await t.crossTimestampOfChange();
 
     expect(await t.asset.methods.get_roles(t.blacklisted.getAddress()).simulate()).toEqual(
       blacklistRole.toNoirStruct(),

--- a/yarn-project/end-to-end/src/e2e_blacklist_token_contract/blacklist_token_contract_test.ts
+++ b/yarn-project/end-to-end/src/e2e_blacklist_token_contract/blacklist_token_contract_test.ts
@@ -59,7 +59,7 @@ export class Role {
 
 export class BlacklistTokenContractTest {
   // This value MUST match the same value that we have in the contract
-  static CHANGE_ROLES_DELAY = 43200;
+  static CHANGE_ROLES_DELAY = 86400;
 
   private snapshotManager: ISnapshotManager;
   logger: Logger;

--- a/yarn-project/end-to-end/src/fixtures/snapshot_manager.ts
+++ b/yarn-project/end-to-end/src/fixtures/snapshot_manager.ts
@@ -35,6 +35,7 @@ import { resolver, reviver } from '@aztec/foundation/serialize';
 import { TestDateProvider } from '@aztec/foundation/timer';
 import type { ProverNode } from '@aztec/prover-node';
 import { type PXEService, createPXEService, getPXEServiceConfig } from '@aztec/pxe/server';
+import type { SequencerClient } from '@aztec/sequencer-client';
 import { tryStop } from '@aztec/stdlib/interfaces/server';
 import { getConfigEnvVars as getTelemetryConfig, initTelemetryClient } from '@aztec/telemetry-client';
 import { getGenesisValues } from '@aztec/world-state/testing';
@@ -74,6 +75,7 @@ export type SubsystemsContext = {
   proverNode?: ProverNode;
   watcher: AnvilTestWatcher;
   cheatCodes: CheatCodes;
+  sequencer: SequencerClient;
   dateProvider: TestDateProvider;
   blobSink: BlobSinkServer;
   initialFundedAccounts: InitialAccountData[];
@@ -472,6 +474,7 @@ async function setupFromFresh(
     anvil,
     aztecNode,
     pxe,
+    sequencer: aztecNode.getSequencer()!,
     acvmConfig,
     bbConfig,
     deployL1ContractsValues,
@@ -590,6 +593,7 @@ async function setupFromState(statePath: string, logger: Logger): Promise<Subsys
     anvil,
     aztecNode,
     pxe,
+    sequencer: aztecNode.getSequencer()!,
     acvmConfig,
     bbConfig,
     proverNode,

--- a/yarn-project/end-to-end/src/fixtures/utils.ts
+++ b/yarn-project/end-to-end/src/fixtures/utils.ts
@@ -576,6 +576,11 @@ export async function setup(
     // handled by the if-else branches on line 632.
     // For more details on why the tx would be dropped see `validate_include_by_timestamp` function in
     // `noir-projects/noir-protocol-circuits/crates/rollup-lib/src/base/components/validation_requests.nr`.
+    //
+    // Note: If the following seems too convoluted or if it starts making problems, we could drop the "progressing
+    // past genesis via an account contract deployment" optimization and just call flush() on the sequencer and wait
+    // for an empty block to be mined. This would simplify it all quite a bit but the setup would be slower for tests
+    // deploying accounts.
     const originalMinTxsPerBlock = config.minTxsPerBlock;
     if (originalMinTxsPerBlock === undefined) {
       throw new Error('minTxsPerBlock is undefined in e2e test setup');


### PR DESCRIPTION
We didn't have a cheatcode that would reliably warp L2 time. In this PR I add it and use it in a few tests that have worked around this until now.

How the new cheatcode works is that it warps L1 anvil time and then we mine an empty block for the L2 time to progress as well. Placed it on the `CheatCode` class as it works with both aztec and eth cheatcodes.

The only disadvantage here is that it requires `sequencerClient` on the input which I am not sure external devs will have an easy job of getting a hold off. But I don't think there is a way around this since exposing some kind of test API endpoints on AztecNode that would allow us to force mine an empty block ultimately seem like a worse tradeoff.