### PR TITLE
fix: readd senders on wallet change

### DIFF
--- a/playground/src/components/sidebar/components/AccountSelector.tsx
+++ b/playground/src/components/sidebar/components/AccountSelector.tsx
@@ -137,7 +137,13 @@ export function AccountSelector() {
       }
     }
     await accountManager.register();
-    setWallet(await accountManager.getWallet());
+    const senders = await walletDB.listAliases('senders');
+    const senderAddresses = parseAliasedBuffersAsString(senders).map(({ value }) => AztecAddress.fromString(value));
+    const wallet = await accountManager.getWallet();
+    for(const senderAddress of senderAddresses) {
+      await wallet.registerSender(senderAddress);
+    }
+    setWallet(wallet);
     setIsAccountsLoading(false);
   };
 


### PR DESCRIPTION
Detected while testing staging. Changing networks wipes PXE's db, which will also erase senders. Just like contracts and accounts, this PR forces adding existing senders to PXE on account change.
