### PR TITLE
feat(avm): opcode execution exceptions

### DIFF
--- a/barretenberg/cpp/src/barretenberg/vm2/simulation/alu.cpp
+++ b/barretenberg/cpp/src/barretenberg/vm2/simulation/alu.cpp
@@ -7,7 +7,7 @@ namespace bb::avm2::simulation {
 
 MemoryValue Alu::add(const MemoryValue& a, const MemoryValue& b)
 {
-    MemoryValue c;
+    MemoryValue c = MemoryValue::from_tag(a.get_tag(), 0); // Initialize c with the same tag as a
     try {
         if (a.get_tag() != b.get_tag()) {
             throw AluError::TAG_ERROR;
@@ -15,10 +15,10 @@ MemoryValue Alu::add(const MemoryValue& a, const MemoryValue& b)
         // TODO(MW): Apart from tags, how can the below fail and how to catch/assign the errors?
         c = a + b;
         events.emit({ .operation = AluOperation::ADD, .a = a, .b = b, .c = c });
-    } catch (AluError e) {
-        c = MemoryValue::from_tag(a.get_tag(), 0);
+    } catch (const AluError& e) {
+        debug("ALU operation failed: ", to_string(e));
         events.emit({ .operation = AluOperation::ADD, .a = a, .b = b, .c = c, .error = e });
-        throw e;
+        throw AluException();
     }
     return c;
 }

--- a/barretenberg/cpp/src/barretenberg/vm2/simulation/alu.test.cpp
+++ b/barretenberg/cpp/src/barretenberg/vm2/simulation/alu.test.cpp
@@ -56,7 +56,7 @@ TEST(AvmSimulationAluTest, NegativeAddTag)
     auto a = MemoryValue::from<uint32_t>(1);
     auto b = MemoryValue::from<uint64_t>(2);
 
-    EXPECT_THROW(alu.add(a, b), AluError);
+    EXPECT_THROW(alu.add(a, b), AluException);
 
     auto events = alu_event_emitter.dump_events();
     EXPECT_THAT(

--- a/barretenberg/cpp/src/barretenberg/vm2/simulation/events/alu_event.hpp
+++ b/barretenberg/cpp/src/barretenberg/vm2/simulation/events/alu_event.hpp
@@ -18,6 +18,24 @@ enum class AluError {
     TAG_ERROR,
 };
 
+inline std::string to_string(AluError e)
+{
+    switch (e) {
+    case AluError::TAG_ERROR:
+        return "TAG_ERROR";
+    }
+
+    // We should be catching all the cases above.
+    __builtin_unreachable();
+}
+
+class AluException : public std::runtime_error {
+  public:
+    explicit AluException()
+        : std::runtime_error("ALU operation failed")
+    {}
+};
+
 struct AluEvent {
     AluOperation operation;
     MemoryValue a;

--- a/barretenberg/cpp/src/barretenberg/vm2/simulation/events/execution_event.hpp
+++ b/barretenberg/cpp/src/barretenberg/vm2/simulation/events/execution_event.hpp
@@ -27,6 +27,7 @@ enum class ExecutionError {
     REGISTER_READ,
     DISPATCHING,
     GAS_DYNAMIC,
+    OPCODE_EXECUTION,
 };
 
 class TagCheckError : public std::exception {

--- a/barretenberg/cpp/src/barretenberg/vm2/simulation/execution.cpp
+++ b/barretenberg/cpp/src/barretenberg/vm2/simulation/execution.cpp
@@ -46,8 +46,7 @@ void Execution::add(ContextInterface& context, MemoryAddress a_addr, MemoryAddre
         memory.set(dst_addr, c);
         set_output(opcode, c);
     } catch (AluError& e) {
-        // TODO(MW): Possibly handle the error here.
-        throw e;
+        throw OpcodeExecutionException("Alu add operation failed");
     }
 }
 
@@ -285,7 +284,6 @@ void Execution::keccak_permutation(ContextInterface& context, MemoryAddress dst_
     try {
         keccakf1600.permutation(context.get_memory(), dst_addr, src_addr);
     } catch (const KeccakF1600Exception& e) {
-        // Re-throw
         throw OpcodeExecutionException("Keccak permutation failed: " + std::string(e.what()));
     }
 }

--- a/barretenberg/cpp/src/barretenberg/vm2/simulation/execution.cpp
+++ b/barretenberg/cpp/src/barretenberg/vm2/simulation/execution.cpp
@@ -25,6 +25,13 @@ class RegisterValidationException : public std::runtime_error {
     {}
 };
 
+class OpcodeExecutionException : public std::runtime_error {
+  public:
+    OpcodeExecutionException(const std::string& message)
+        : std::runtime_error(message)
+    {}
+};
+
 } // namespace
 
 void Execution::add(ContextInterface& context, MemoryAddress a_addr, MemoryAddress b_addr, MemoryAddress dst_addr)
@@ -89,7 +96,7 @@ void Execution::get_env_var(ContextInterface& context, MemoryAddress dst_addr, u
         result = TaggedValue::from<uint32_t>(context.gas_left().daGas);
         break;
     default:
-        throw std::runtime_error("Invalid environment variable enum value");
+        throw OpcodeExecutionException("Invalid environment variable enum value");
     }
 
     memory.set(dst_addr, result);
@@ -171,8 +178,7 @@ void Execution::cd_copy(ContextInterface& context,
     try {
         data_copy.cd_copy(context, cd_copy_size.as<uint32_t>(), cd_offset_read.as<uint32_t>(), dst_addr);
     } catch (const std::exception& e) {
-        // re throw - change to a more specific exception later
-        throw std::runtime_error("cd copy failed: " + std::string(e.what()));
+        throw OpcodeExecutionException("cd copy failed: " + std::string(e.what()));
     }
 }
 
@@ -192,8 +198,7 @@ void Execution::rd_copy(ContextInterface& context,
     try {
         data_copy.rd_copy(context, rd_copy_size.as<uint32_t>(), rd_offset_read.as<uint32_t>(), dst_addr);
     } catch (const std::exception& e) {
-        // re throw - change to a more specific exception later
-        throw std::runtime_error("rd copy failed: " + std::string(e.what()));
+        throw OpcodeExecutionException("rd copy failed: " + std::string(e.what()));
     }
 }
 
@@ -270,8 +275,8 @@ void Execution::internal_return(ContextInterface& context)
         auto next_pc = internal_call_stack_manager.pop();
         context.set_next_pc(next_pc);
     } catch (const std::exception& e) {
-        // Re-throw - so execution can handle it.
-        throw std::runtime_error("Internal return failed: " + std::string(e.what()));
+        // Re-throw
+        throw OpcodeExecutionException("Internal return failed: " + std::string(e.what()));
     }
 }
 
@@ -280,8 +285,8 @@ void Execution::keccak_permutation(ContextInterface& context, MemoryAddress dst_
     try {
         keccakf1600.permutation(context.get_memory(), dst_addr, src_addr);
     } catch (const KeccakF1600Exception& e) {
-        // TODO: Possibly handle the error here.
-        throw e;
+        // Re-throw
+        throw OpcodeExecutionException("Keccak permutation failed: " + std::string(e.what()));
     }
 }
 
@@ -375,6 +380,11 @@ ExecutionResult Execution::execute(std::unique_ptr<ContextInterface> enqueued_ca
         } catch (const RegisterValidationException& e) {
             vinfo("Register validation exception: ", e.what());
             ex_event.error = ExecutionError::REGISTER_READ;
+            context.halt();
+            set_execution_result({ .success = false });
+        } catch (const OpcodeExecutionException& e) {
+            vinfo("Opcode execution exception: ", e.what());
+            ex_event.error = ExecutionError::OPCODE_EXECUTION;
             context.halt();
             set_execution_result({ .success = false });
         } catch (const std::exception& e) {

--- a/barretenberg/cpp/src/barretenberg/vm2/tracegen/execution_trace.cpp
+++ b/barretenberg/cpp/src/barretenberg/vm2/tracegen/execution_trace.cpp
@@ -591,6 +591,8 @@ void ExecutionTraceBuilder::process(
             row,
             { {
 
+                // sel_exit_call and rollback has to be set here because they include sel_error
+                { C::execution_sel_exit_call, sel_exit_call ? 1 : 0 },
                 { C::execution_rollback_context, rollback_context ? 1 : 0 },
                 { C::execution_sel_error, is_err ? 1 : 0 },
                 { C::execution_sel_failure, is_failure ? 1 : 0 },

--- a/barretenberg/cpp/src/barretenberg/vm2/tracegen/execution_trace.cpp
+++ b/barretenberg/cpp/src/barretenberg/vm2/tracegen/execution_trace.cpp
@@ -334,12 +334,23 @@ void ExecutionTraceBuilder::process(
             dying_context_id_inv = FF(dying_context_id).invert();
         }
 
+        // Cache the parent id inversion since we will repeatedly just be doing the same expensive inversion
+        bool has_parent = ex_event.after_context_event.parent_id != 0;
+        if (last_seen_parent_id != ex_event.after_context_event.parent_id) {
+            last_seen_parent_id = ex_event.after_context_event.parent_id;
+            cached_parent_id_inv = has_parent ? FF(ex_event.after_context_event.parent_id).invert() : 0;
+        }
+
         /**************************************************************************************************
          *  Setup.
          **************************************************************************************************/
 
         trace.set(row,
                   { {
+                      { C::execution_sel, 1 },
+                      // Selectors that indicate "dispatch" from tx trace
+                      // Note: Enqueued Call End is determined during the opcode execution temporality group
+                      { C::execution_enqueued_call_start, is_first_event_in_enqueued_call ? 1 : 0 },
                       // Context
                       { C::execution_context_id, ex_event.after_context_event.id },
                       { C::execution_parent_id, ex_event.after_context_event.parent_id },
@@ -366,6 +377,9 @@ void ExecutionTraceBuilder::process(
                       { C::execution_prev_da_gas_used, ex_event.before_context_event.gas_used.daGas },
                       // Other.
                       { C::execution_bytecode_id, ex_event.bytecode_id },
+                      // Helpers for identifying parent context
+                      { C::execution_has_parent_ctx, has_parent ? 1 : 0 },
+                      { C::execution_is_parent_id_inv, cached_parent_id_inv },
                   } });
 
         // Internal stack
@@ -461,59 +475,28 @@ void ExecutionTraceBuilder::process(
         /**************************************************************************************************
          *  Temporality group 5: Opcode execution.
          **************************************************************************************************/
+        bool should_execute_opcode = should_process_dynamic_gas && !oog_dynamic;
 
         // TODO(ilyas): This can possibly be gated with some boolean but I'm not sure what is going on.
+        bool opcode_execution_failed = ex_event.error == ExecutionError::OPCODE_EXECUTION;
 
         // Overly verbose but maximising readibility here
+        // FIXME(ilyas): We currently cannot move this into the if statement because they are used outside of this
+        // temporality group (e..g in recomputing discard)
         bool is_call = exec_opcode.has_value() && *exec_opcode == ExecutionOpCode::CALL;
         bool is_static_call = exec_opcode.has_value() && *exec_opcode == ExecutionOpCode::STATICCALL;
         bool is_return = exec_opcode.has_value() && *exec_opcode == ExecutionOpCode::RETURN;
         bool is_revert = exec_opcode.has_value() && *exec_opcode == ExecutionOpCode::REVERT;
-        bool is_opcode_error = ex_event.error == ExecutionError::DISPATCHING;
         bool is_err = ex_event.error != ExecutionError::NONE;
         bool is_failure = is_revert || is_err;
-        bool has_parent = ex_event.after_context_event.parent_id != 0;
         bool sel_enter_call = (is_call || is_static_call) && !is_err;
         bool sel_exit_call = is_return || is_revert || is_err;
-        bool nested_exit_call = sel_exit_call && has_parent;
-        // We rollback if we revert or error and we have a parent context.
-        bool rollback_context =
-            ((exec_opcode.has_value() && *exec_opcode == ExecutionOpCode::REVERT) || is_err) && has_parent;
 
-        // Cache the parent id inversion since we will repeatedly just be doing the same expensive inversion
-        if (last_seen_parent_id != ex_event.after_context_event.parent_id) {
-            last_seen_parent_id = ex_event.after_context_event.parent_id;
-            cached_parent_id_inv = has_parent ? FF(ex_event.after_context_event.parent_id).invert() : 0;
-        }
-
-        // Nested Context Control Flow and helper columns
-        trace.set(row,
-                  { {
-                      // Selectors that indicate "dispatch" from tx trace
-                      { C::execution_enqueued_call_start, is_first_event_in_enqueued_call ? 1 : 0 },
-                      { C::execution_enqueued_call_end, sel_exit_call && !has_parent ? 1 : 0 },
-                      // Context & control flow
-                      { C::execution_has_parent_ctx, has_parent ? 1 : 0 },
-                      { C::execution_is_parent_id_inv, cached_parent_id_inv },
-                      { C::execution_nested_exit_call, nested_exit_call ? 1 : 0 },
-                      { C::execution_rollback_context, rollback_context ? 1 : 0 },
-                      // Helper columns
-                      { C::execution_sel, 1 },
-                      { C::execution_sel_error, is_err ? 1 : 0 },
-                      { C::execution_sel_call, is_call ? 1 : 0 },
-                      { C::execution_sel_static_call, is_static_call ? 1 : 0 },
-                      { C::execution_sel_enter_call, sel_enter_call ? 1 : 0 },
-                      { C::execution_sel_return, is_return ? 1 : 0 },
-                      { C::execution_sel_revert, is_revert ? 1 : 0 },
-                      { C::execution_sel_exit_call, sel_exit_call ? 1 : 0 },
-                  } });
-
-        bool should_execute_opcode = should_process_dynamic_gas && !oog_dynamic;
         if (should_execute_opcode) {
             trace.set(row,
                       { {
                           { C::execution_should_execute_opcode, 1 },
-                          { C::execution_sel_opcode_error, is_opcode_error ? 1 : 0 },
+                          { C::execution_sel_opcode_error, opcode_execution_failed ? 1 : 0 },
                       } });
 
             // Call specific logic
@@ -534,11 +517,26 @@ void ExecutionTraceBuilder::process(
 
                 trace.set(row,
                           { {
+                              { C::execution_sel_enter_call, sel_enter_call ? 1 : 0 },
+                              { C::execution_sel_call, is_call ? 1 : 0 },
+                              { C::execution_sel_static_call, is_static_call ? 1 : 0 },
                               { C::execution_constant_32, 32 },
                               { C::execution_call_is_l2_gas_allocated_lt_left, is_l2_gas_allocated_lt_left },
                               { C::execution_call_allocated_left_l2_cmp_diff, allocated_left_l2_cmp_diff },
                               { C::execution_call_is_da_gas_allocated_lt_left, is_da_gas_allocated_lt_left },
                               { C::execution_call_allocated_left_da_cmp_diff, allocated_left_da_cmp_diff },
+                          } });
+            } else if (sel_exit_call) {
+                // We rollback if we revert or error and we have a parent context.
+                trace.set(row,
+                          { {
+                              // Exit reason - opcode or error
+                              { C::execution_sel_return, is_return ? 1 : 0 },
+                              { C::execution_sel_revert, is_revert ? 1 : 0 },
+                              { C::execution_sel_exit_call, sel_exit_call ? 1 : 0 },
+                              // Enqueued or nested exit dependent on if we are a child context
+                              { C::execution_enqueued_call_end, !has_parent ? 1 : 0 },
+                              { C::execution_nested_exit_call, has_parent ? 1 : 0 },
                           } });
             } else if (exec_opcode == ExecutionOpCode::GETENVVAR) {
                 assert(ex_event.addressing_event.resolution_info.size() == 2 &&
@@ -559,7 +557,7 @@ void ExecutionTraceBuilder::process(
          *  Temporality group 6: Register write.
          **************************************************************************************************/
 
-        bool should_process_register_write = should_execute_opcode && !is_opcode_error;
+        bool should_process_register_write = should_execute_opcode && !opcode_execution_failed;
         if (should_process_register_write) {
             process_registers_write(*exec_opcode, trace, row);
         }
@@ -585,9 +583,16 @@ void ExecutionTraceBuilder::process(
         bool nested_call_rom_undiscarded_context = sel_enter_call && discard == 0;
         bool propagate_discard = !enqueued_call_end && !resolves_dying_context && !nested_call_rom_undiscarded_context;
 
+        // This is here instead of guarded by `should_execute_opcode` because is_err is a higher level error than just
+        // an opcode error (i.e., it is on if there are any errors in any temporality group).
+        bool rollback_context = (is_revert || is_err) && has_parent;
+
         trace.set(
             row,
             { {
+
+                { C::execution_rollback_context, rollback_context ? 1 : 0 },
+                { C::execution_sel_error, is_err ? 1 : 0 },
                 { C::execution_sel_failure, is_failure ? 1 : 0 },
                 { C::execution_discard, discard },
                 { C::execution_dying_context_id, dying_context_id },

--- a/barretenberg/cpp/src/barretenberg/vm2/tracegen/execution_trace.test.cpp
+++ b/barretenberg/cpp/src/barretenberg/vm2/tracegen/execution_trace.test.cpp
@@ -559,7 +559,7 @@ TEST(ExecutionTraceGenTest, InternalRetError)
     const auto instr = InstructionBuilder(WireOpCode::INTERNALRETURN).build();
 
     simulation::ExecutionEvent ex_event = {
-        .error = simulation::ExecutionError::DISPATCHING,
+        .error = simulation::ExecutionError::OPCODE_EXECUTION,
         .wire_instruction = instr,
         .addressing_event = {
             .instruction = instr,


### PR DESCRIPTION
Update error handling execution by introducing a `OpcodeExecutionException`. This exception is throw by executing opcodes and translates into `sel_opcode_error` in the execution trace.

Also somewhat cleaned up some of the columsn being set in the  opcode execution temporality group in tracegen. Some columns (which are meant to be set unconditionally) have been moved to the start in the Setup group, while truly opcode execution columns have been gated by `should_execute_opcode`