### PR TITLE
fix: Proper slot start time in sequencer

### DIFF
--- a/yarn-project/end-to-end/src/e2e_epochs/epochs_monitor_block_building.test.ts
+++ b/yarn-project/end-to-end/src/e2e_epochs/epochs_monitor_block_building.test.ts
@@ -46,6 +46,7 @@ describe('e2e_epochs/epochs_monitor_block_building', () => {
       disableAnvilTestWatcher: true,
       aztecProofSubmissionEpochs: 1024,
       startProverNode: false,
+      enforceTimeTable: true,
     });
 
     ({ context, logger } = test);

--- a/yarn-project/end-to-end/src/e2e_epochs/epochs_test.ts
+++ b/yarn-project/end-to-end/src/e2e_epochs/epochs_test.ts
@@ -56,6 +56,7 @@ export type EpochsTestOpts = Partial<
     | 'initialValidators'
     | 'mockGossipSubNetwork'
     | 'disableAnvilTestWatcher'
+    | 'enforceTimeTable'
   >
 > & { numberOfAccounts?: number };
 

--- a/yarn-project/sequencer-client/src/sequencer/sequencer.test.ts
+++ b/yarn-project/sequencer-client/src/sequencer/sequencer.test.ts
@@ -570,7 +570,7 @@ class TestSubject extends Sequencer {
   }
 
   public override doRealWork() {
-    this.setState(SequencerState.IDLE, 0n, true /** force */);
+    this.setState(SequencerState.IDLE, undefined, { force: true });
     return super.doRealWork();
   }
 

--- a/yarn-project/sequencer-client/src/sequencer/sequencer.test.ts
+++ b/yarn-project/sequencer-client/src/sequencer/sequencer.test.ts
@@ -1,7 +1,6 @@
 import { Body, L2Block } from '@aztec/aztec.js';
 import { NUMBER_OF_L1_L2_MESSAGES_PER_ROLLUP } from '@aztec/constants';
 import type { EpochCache } from '@aztec/epoch-cache';
-import { DefaultL1ContractsConfig } from '@aztec/ethereum';
 import { timesParallel } from '@aztec/foundation/collection';
 import { Secp256k1Signer } from '@aztec/foundation/crypto';
 import { EthAddress } from '@aztec/foundation/eth-address';
@@ -51,6 +50,9 @@ describe('sequencer', () => {
   let merkleTreeOps: MockProxy<MerkleTreeReadOperations>;
   let l2BlockSource: MockProxy<L2BlockSource>;
   let l1ToL2MessageSource: MockProxy<L1ToL2MessageSource>;
+  let slasherClient: MockProxy<SlasherClient>;
+
+  let dateProvider: TestDateProvider;
 
   let initialBlockHeader: BlockHeader;
   let lastBlockNumber: number;
@@ -64,7 +66,8 @@ describe('sequencer', () => {
 
   let sequencer: TestSubject;
 
-  const { aztecSlotDuration: slotDuration, ethereumSlotDuration } = DefaultL1ContractsConfig;
+  const slotDuration = 8;
+  const ethereumSlotDuration = 4;
 
   const chainId = new Fr(12345);
   const version = Fr.ZERO;
@@ -245,7 +248,10 @@ describe('sequencer', () => {
     validatorClient.collectAttestations.mockImplementation(() => Promise.resolve(getAttestations()));
     validatorClient.createBlockProposal.mockImplementation(() => Promise.resolve(createBlockProposal()));
 
-    const slasherClient = mock<SlasherClient>();
+    slasherClient = mock<SlasherClient>();
+
+    dateProvider = new TestDateProvider();
+
     const config = { enforceTimeTable: true, maxTxsPerBlock: 4 };
     sequencer = new TestSubject(
       publisher,
@@ -259,7 +265,7 @@ describe('sequencer', () => {
       l1ToL2MessageSource,
       blockBuilder,
       l1Constants,
-      new TestDateProvider(),
+      dateProvider,
     );
     sequencer.updateConfig(config);
   });
@@ -276,15 +282,14 @@ describe('sequencer', () => {
   });
 
   it('does not build a block if it does not have enough time left in the slot', async () => {
-    // Trick the sequencer into thinking that we are just too far into slot 1
-    sequencer.setL1GenesisTime(
-      Math.floor(Date.now() / 1000) - slotDuration * 1 - (sequencer.getTimeTable().initializeDeadline + 1),
-    );
-
     const tx = await makeTx();
     mockPendingTxs([tx]);
     block = await makeBlock([tx]);
 
+    // deadline for initializing proposal is 1s, so we go 2s past it
+    expect(sequencer.getTimeTable().initializeDeadline).toEqual(1);
+    const l1TsForL2Slot1 = Number(l1Constants.l1GenesisTime) + slotDuration;
+    dateProvider.setTime((l1TsForL2Slot1 + 2) * 1000);
     await expect(sequencer.doRealWork()).rejects.toThrow(
       expect.objectContaining({
         name: 'SequencerTooSlowError',
@@ -293,6 +298,30 @@ describe('sequencer', () => {
     );
 
     expect(blockBuilder.buildBlock).not.toHaveBeenCalled();
+    expect(publisher.enqueueProposeL2Block).not.toHaveBeenCalled();
+  });
+
+  it('does not publish a block if it does not have enough time left in the slot after collecting attestations', async () => {
+    expect(sequencer.getTimeTable().l1PublishingTime).toEqual(ethereumSlotDuration);
+    const l1TsForL2Slot1 = Number(l1Constants.l1GenesisTime) + slotDuration;
+
+    const tx = await makeTx();
+    mockPendingTxs([tx]);
+    block = await makeBlock([tx]);
+
+    validatorClient.collectAttestations.mockImplementation(() => {
+      // after collecting attestations, "warp" to 1s before the last L1 slot of the L2 slot is mined,
+      // meaning that we have lost our chance to get mined given our l1PublishingTime is a full L1 slot
+      dateProvider.setTime((l1TsForL2Slot1 + ethereumSlotDuration - 1) * 1000);
+      return Promise.resolve(getAttestations());
+    });
+
+    // we begin immediately after the last L1 block for the previous slot has been mined
+    dateProvider.setTime((l1TsForL2Slot1 - ethereumSlotDuration + 0.1) * 1000);
+    await sequencer.doRealWork();
+
+    expect(blockBuilder.buildBlock).toHaveBeenCalled();
+    expect(validatorClient.collectAttestations).toHaveBeenCalled();
     expect(publisher.enqueueProposeL2Block).not.toHaveBeenCalled();
   });
 

--- a/yarn-project/sequencer-client/src/sequencer/sequencer.ts
+++ b/yarn-project/sequencer-client/src/sequencer/sequencer.ts
@@ -51,7 +51,7 @@ import { type Action, type SequencerPublisher, VoteType } from '../publisher/seq
 import type { SequencerConfig } from './config.js';
 import { SequencerMetrics } from './metrics.js';
 import { SequencerTimetable, SequencerTooSlowError } from './timetable.js';
-import { SequencerState, orderAttestations } from './utils.js';
+import { SequencerState, type SequencerStateWithSlot, orderAttestations } from './utils.js';
 
 export { SequencerState };
 
@@ -61,8 +61,8 @@ export type SequencerEvents = {
   ['state-changed']: (args: {
     oldState: SequencerState;
     newState: SequencerState;
-    secondsIntoSlot: number;
-    slotNumber: bigint;
+    secondsIntoSlot?: number;
+    slotNumber?: bigint;
   }) => void;
   ['proposer-rollup-check-failed']: (args: { reason: string }) => void;
   ['tx-count-check-failed']: (args: { minTxs: number; availableTxs: number }) => void;
@@ -215,7 +215,7 @@ export class Sequencer extends (EventEmitter as new () => TypedEventEmitter<Sequ
     this.updateConfig(this.config);
     this.metrics.start();
     this.runningPromise = new RunningPromise(this.work.bind(this), this.log, this.pollingIntervalMs);
-    this.setState(SequencerState.IDLE, 0n, true /** force */);
+    this.setState(SequencerState.IDLE, undefined, { force: true });
     this.runningPromise.start();
     this.l1Metrics.start();
     this.log.info(`Sequencer started with address ${this.publisher.getSenderAddress().toString()}`);
@@ -230,7 +230,7 @@ export class Sequencer extends (EventEmitter as new () => TypedEventEmitter<Sequ
     await this.validatorClient?.stop();
     await this.runningPromise?.stop();
     this.publisher.interrupt();
-    this.setState(SequencerState.STOPPED, 0n, true /** force */);
+    this.setState(SequencerState.STOPPED, undefined, { force: true });
     this.l1Metrics.stop();
     this.log.info('Stopped sequencer');
   }
@@ -242,7 +242,7 @@ export class Sequencer extends (EventEmitter as new () => TypedEventEmitter<Sequ
     this.log.info('Restarting sequencer');
     this.publisher.restart();
     this.runningPromise!.start();
-    this.setState(SequencerState.IDLE, 0n, true /** force */);
+    this.setState(SequencerState.IDLE, undefined, { force: true });
   }
 
   /**
@@ -267,7 +267,7 @@ export class Sequencer extends (EventEmitter as new () => TypedEventEmitter<Sequ
    *          - If our block for some reason is not included, revert the state
    */
   protected async doRealWork() {
-    this.setState(SequencerState.SYNCHRONIZING, 0n);
+    this.setState(SequencerState.SYNCHRONIZING, undefined);
 
     // Check all components are synced to latest as seen by the archiver
     const syncedTo = await this.getChainTip();
@@ -277,7 +277,7 @@ export class Sequencer extends (EventEmitter as new () => TypedEventEmitter<Sequ
       return;
     }
 
-    this.setState(SequencerState.PROPOSER_CHECK, 0n);
+    this.setState(SequencerState.PROPOSER_CHECK, undefined);
 
     const chainTipArchive = syncedTo.archive;
     const newBlockNumber = syncedTo.blockNumber + 1;
@@ -474,7 +474,7 @@ export class Sequencer extends (EventEmitter as new () => TypedEventEmitter<Sequ
       });
     }
 
-    this.setState(SequencerState.IDLE, 0n);
+    this.setState(SequencerState.IDLE, undefined);
   }
 
   @trackSpan('Sequencer.work')
@@ -489,32 +489,39 @@ export class Sequencer extends (EventEmitter as new () => TypedEventEmitter<Sequ
         throw err;
       }
     } finally {
-      this.setState(SequencerState.IDLE, 0n);
+      this.setState(SequencerState.IDLE, undefined);
     }
   }
 
   /**
    * Sets the sequencer state and checks if we have enough time left in the slot to transition to the new state.
    * @param proposedState - The new state to transition to.
-   * @param currentSlotNumber - The current slot number.
+   * @param slotNumber - The current slot number.
    * @param force - Whether to force the transition even if the sequencer is stopped.
-   *
-   * @dev If the `currentSlotNumber` doesn't matter (e.g. transitioning to IDLE), pass in `0n`;
-   * it is only used to check if we have enough time left in the slot to transition to the new state.
    */
-  setState(proposedState: SequencerState, currentSlotNumber: bigint, force: boolean = false) {
-    if (this.state === SequencerState.STOPPED && force !== true) {
+  setState(proposedState: SequencerStateWithSlot, slotNumber: bigint, opts?: { force?: boolean }): void;
+  setState(
+    proposedState: Exclude<SequencerState, SequencerStateWithSlot>,
+    slotNumber?: undefined,
+    opts?: { force?: boolean },
+  ): void;
+  setState(proposedState: SequencerState, slotNumber: bigint | undefined, opts: { force?: boolean } = {}): void {
+    if (this.state === SequencerState.STOPPED && !opts.force) {
       this.log.warn(`Cannot set sequencer from ${this.state} to ${proposedState} as it is stopped.`);
       return;
     }
-    const secondsIntoSlot = this.getSecondsIntoSlot(currentSlotNumber);
-    this.timetable.assertTimeLeft(proposedState, secondsIntoSlot);
-    this.log.debug(`Transitioning from ${this.state} to ${proposedState}`);
+    let secondsIntoSlot = undefined;
+    if (slotNumber !== undefined) {
+      secondsIntoSlot = this.getSecondsIntoSlot(slotNumber);
+      this.timetable.assertTimeLeft(proposedState, secondsIntoSlot);
+    }
+
+    this.log.debug(`Transitioning from ${this.state} to ${proposedState}`, { slotNumber, secondsIntoSlot });
     this.emit('state-changed', {
       oldState: this.state,
       newState: proposedState,
       secondsIntoSlot,
-      slotNumber: currentSlotNumber,
+      slotNumber,
     });
     this.state = proposedState;
   }
@@ -536,7 +543,7 @@ export class Sequencer extends (EventEmitter as new () => TypedEventEmitter<Sequ
 
     // Deadline is only set if enforceTimeTable is enabled.
     const deadline = this.enforceTimeTable
-      ? new Date((this.getSlotStartTimestamp(slot) + processingEndTimeWithinSlot) * 1000)
+      ? new Date((this.getSlotStartBuildTimestamp(slot) + processingEndTimeWithinSlot) * 1000)
       : undefined;
     return {
       maxTransactions: this.maxTxsPerBlock,
@@ -744,7 +751,7 @@ export class Sequencer extends (EventEmitter as new () => TypedEventEmitter<Sequ
 
     // Time out tx at the end of the slot
     const slot = block.header.globalVariables.slotNumber.toNumber();
-    const txTimeoutAt = new Date((this.getSlotStartTimestamp(slot) + this.aztecSlotDuration) * 1000);
+    const txTimeoutAt = new Date((this.getSlotStartBuildTimestamp(slot) + this.aztecSlotDuration) * 1000);
 
     const enqueued = await this.publisher.enqueueProposeL2Block(block, attestations, txHashes, {
       txTimeoutAt,
@@ -813,12 +820,16 @@ export class Sequencer extends (EventEmitter as new () => TypedEventEmitter<Sequ
     }
   }
 
-  private getSlotStartTimestamp(slotNumber: number | bigint): number {
-    return Number(this.l1Constants.l1GenesisTime) + Number(slotNumber) * this.l1Constants.slotDuration;
+  private getSlotStartBuildTimestamp(slotNumber: number | bigint): number {
+    return (
+      Number(this.l1Constants.l1GenesisTime) +
+      Number(slotNumber) * this.l1Constants.slotDuration -
+      this.l1Constants.ethereumSlotDuration
+    );
   }
 
   private getSecondsIntoSlot(slotNumber: number | bigint): number {
-    const slotStartTimestamp = this.getSlotStartTimestamp(slotNumber);
+    const slotStartTimestamp = this.getSlotStartBuildTimestamp(slotNumber);
     return Number((this.dateProvider.now() / 1000 - slotStartTimestamp).toFixed(3));
   }
 

--- a/yarn-project/sequencer-client/src/sequencer/utils.ts
+++ b/yarn-project/sequencer-client/src/sequencer/utils.ts
@@ -37,6 +37,12 @@ export enum SequencerState {
   PUBLISHING_BLOCK = 'PUBLISHING_BLOCK',
 }
 
+export type SequencerStateWithSlot =
+  | SequencerState.INITIALIZING_PROPOSAL
+  | SequencerState.CREATING_BLOCK
+  | SequencerState.COLLECTING_ATTESTATIONS
+  | SequencerState.PUBLISHING_BLOCK;
+
 export type SequencerStateCallback = () => SequencerState;
 
 export function sequencerStateToNumber(state: SequencerState): number {


### PR DESCRIPTION
Fixes the slot start time computed on the sequencer.

Let's say we have the following, with genesis at L1 block 1, L1 block time 10s, L2 block time 20s:

| Time    | L1 block | L2 slot | Notes |
| -------- | ------- | ------- | --- |
| 10  | 1 | 0 | |
| 20  | 2 | 0 | L2 block for slot 0 lands, start building for L2 slot 1 now (once we have sync'd) |
| 30  | 3 | 1 | Send the L1 tx for L2 slot 1 now (could have a few seconds leeway) |
| 40  | 4 | 1 | The L1 tx for L2 slot 1 gets mined here |
| 50  | 5 | 2 |
| 60  | 6 | 2 |

The sequencer would compute the start time of the L2 slot as the L1 timestamp in which the first L1 block of the L2 slot is mined. Above, the result of `getSlotStartTimestamp(1)` would be 30.

The sequencer timetable then works by checking how far into the slot each state transition is, considering an L2 block time of 20s. In a non-anvil chain, we assume L1 tx propagation requires a full L1 slot (10s here), which means that the L1 tx for block proposal needs to be sent at least 10s before the last L1 block of the L2 slot is mined. In the example above, the L1 tx for slot 1 needs to be sent at ts=30.

However, if the sequencer computed the start of the slot as ts=30, the timetable would be 10s off, believing it can send the L1 tx up until ts=40. This PR should fix it, and set `getSlotStartTimestamp(1)` to ts=20 instead of ts=30.

