### PR TITLE
chore: Deflake e2e validators sentinel

### DIFF
--- a/yarn-project/end-to-end/src/e2e_p2p/validators_sentinel.test.ts
+++ b/yarn-project/end-to-end/src/e2e_p2p/validators_sentinel.test.ts
@@ -94,6 +94,8 @@ describe('e2e_p2p_validators_sentinel', () => {
       const currentBlock = t.monitor.l2BlockNumber;
       const blockCount = BLOCK_COUNT;
       const timeout = AZTEC_SLOT_DURATION * blockCount * 8;
+      const offlineValidator = t.validators.at(-1)!.attester.toString().toLowerCase();
+
       t.logger.info(`Waiting until L2 block ${currentBlock + blockCount}`, { currentBlock, blockCount, timeout });
       await retryUntil(() => t.monitor.l2BlockNumber >= currentBlock + blockCount, 'blocks mined', timeout);
 
@@ -110,7 +112,9 @@ describe('e2e_p2p_validators_sentinel', () => {
             lastProcessedSlot &&
             lastProcessedSlot - initialSlot >= blockCount - 1 &&
             Object.values(stats).some(stat => stat.history.some(h => h.status === 'block-mined')) &&
-            Object.values(stats).some(stat => stat.history.some(h => h.status === 'block-missed'))
+            Object.values(stats).some(stat => stat.history.some(h => h.status === 'block-missed')) &&
+            stats[offlineValidator] &&
+            stats[offlineValidator].history.length > 0
           );
         },
         'sentinel processed blocks',
@@ -127,7 +131,7 @@ describe('e2e_p2p_validators_sentinel', () => {
       t.logger.info(`Asserting stats for offline validator ${offlineValidator}`);
       const offlineStats = stats.stats[offlineValidator];
       const historyLength = offlineStats.history.length;
-      expect(offlineStats.history.length).toBeGreaterThanOrEqual(BLOCK_COUNT - 1);
+      expect(offlineStats.history.length).toBeGreaterThan(0);
       expect(offlineStats.history.every(h => h.status.endsWith('-missed'))).toBeTrue();
       expect(offlineStats.missedAttestations.count + offlineStats.missedProposals.count).toEqual(historyLength);
       expect(offlineStats.missedAttestations.rate).toEqual(1);


### PR DESCRIPTION
Sample failed run [here](http://ci.aztec-labs.com/bfb52a42988553b2)

The e2e validator sentinel test was sometimes failing because the history reported for a given validator was too small. This could happen if some proposals were missed: if a proposal is missed, stats for the attestors in that slot are not reported, since there was nothing for them to do, as no block proposal reached them.

This PR fixes it so we wait until _something_ happened for the offline validator.
