### PR TITLE
chore: fix and ignore flake in validators_sentinel.test.ts

### DIFF
--- a/.test_patterns.yml
+++ b/.test_patterns.yml
@@ -127,6 +127,10 @@ tests:
     owners:
       - *palla
   - regex: "e2e_p2p/validators_sentinel"
+    error_regex: "Received: 49999999999999999999n"
+    owners:
+      - *mitch
+  - regex: "e2e_p2p/validators_sentinel"
     error_regex: "Expected: >= 2"
     owners:
       - *palla

--- a/yarn-project/end-to-end/src/e2e_p2p/validators_sentinel.test.ts
+++ b/yarn-project/end-to-end/src/e2e_p2p/validators_sentinel.test.ts
@@ -227,7 +227,15 @@ describe('e2e_p2p_validators_sentinel', () => {
 
       await retryUntil(
         async () => {
-          const currentProposer = await rollup.getCurrentProposer();
+          const ignoreExpectedErrors = (err: Error) => {
+            const permissibleErrors = ['ValidatorSelection__InsufficientCommitteeSize', '0x98673597'];
+            if (permissibleErrors.some(error => err.message.includes(error))) {
+              return undefined;
+            }
+            t.logger.error('Error:', err);
+            throw err;
+          };
+          const currentProposer = await rollup.getCurrentProposer().catch(ignoreExpectedErrors);
           t.logger.verbose(`Current proposer is ${currentProposer}`);
           const round = await slashingProposer.computeRound(await rollup.getSlotNumber());
           const roundInfo = await slashingProposer.getRoundInfo(rollup.address, round);


### PR DESCRIPTION
Add the flake associated with https://github.com/AztecProtocol/aztec-packages/issues/15458 to the .test_patterns. Looking at [the test history](http://ci.aztec-labs.com/list/history_2da406b53513c829_next), this happens about once in 200 runs, so I'm deprioritizing it for the moment.

Fix a different flake that was due to validator getting kicked before we actually saw the slash event.