### PR TITLE
fix: update default benchmark in benchmark_remote.sh

### DIFF
--- a/barretenberg/cpp/scripts/benchmark_remote.sh
+++ b/barretenberg/cpp/scripts/benchmark_remote.sh
@@ -7,7 +7,7 @@
 #    - BB_SSH_CPP_PATH: Path to barretenberg/cpp in a cloned repository on the EC2 instance
 set -eu
 
-BENCHMARK=${1:-goblin_bench}
+BENCHMARK=${1:-client_ivc_bench}
 COMMAND=${2:-./$BENCHMARK}
 PRESET=${3:-clang16}
 BUILD_DIR=${4:-build}


### PR DESCRIPTION
`goblin_bench` does not seem to exist anymore. `client_ivc_bench` should be a sensible default.