### PR TITLE
fix: Load proper committee for first slot in the epoch

### DIFF
--- a/.test_patterns.yml
+++ b/.test_patterns.yml
@@ -178,11 +178,7 @@ tests:
     error_regex: "✕ should attest ONLY with the correct validator keys"
     owners:
       - *spyros
-  - regex: "src/e2e_epochs/epochs_simple_block_building.test.ts"
-    error_regex: "Failed events from sequencers"
-    owners:
-      - *palla
-  - regex: "src/e2e_epochs/epochs_high_tps_block_building.test.ts"
+  - regex: "src/e2e_epochs/(epochs_simple_block_building|epochs_high_tps_block_building|epochs_first_slot).test.ts"
     error_regex: "Failed events from sequencers"
     owners:
       - *palla

--- a/yarn-project/end-to-end/src/e2e_epochs/epochs_first_slot.test.ts
+++ b/yarn-project/end-to-end/src/e2e_epochs/epochs_first_slot.test.ts
@@ -1,0 +1,126 @@
+import type { AztecNodeService } from '@aztec/aztec-node';
+import { EthAddress, type Logger, getTimestampRangeForEpoch } from '@aztec/aztec.js';
+import type { Operator } from '@aztec/ethereum';
+import { asyncMap } from '@aztec/foundation/async-map';
+import { times, timesAsync } from '@aztec/foundation/collection';
+import { bufferToHex } from '@aztec/foundation/string';
+import { executeTimeout } from '@aztec/foundation/timer';
+import type { SpamContract } from '@aztec/noir-test-contracts.js/Spam';
+import { getSlotRangeForEpoch } from '@aztec/stdlib/epoch-helpers';
+
+import { jest } from '@jest/globals';
+import { privateKeyToAccount } from 'viem/accounts';
+
+import { type EndToEndContext, getPrivateKeyFromIndex } from '../fixtures/utils.js';
+import { EpochsTestContext } from './epochs_test.js';
+
+jest.setTimeout(1000 * 60 * 10);
+
+const NODE_COUNT = 8;
+const COMMITTEE_SIZE = 3;
+const TX_COUNT = 2;
+const EPOCH = 3n;
+
+// Spawns NODE_COUNT validator nodes, connected via a mocked gossip sub network, but sets
+// committee size to 3. Warps to immediately before the beginning of an epoch, and checks
+// that the first slot of the epoch is mined without any errors.
+// Regression test for https://github.com/AztecProtocol/aztec-packages/issues/15414
+describe('e2e_epochs/epochs_first_slot', () => {
+  let context: EndToEndContext;
+  let logger: Logger;
+
+  let test: EpochsTestContext;
+  let validators: (Operator & { privateKey: `0x${string}` })[];
+  let nodes: AztecNodeService[];
+  let contract: SpamContract;
+
+  beforeEach(async () => {
+    validators = times(NODE_COUNT, i => {
+      const privateKey = bufferToHex(getPrivateKeyFromIndex(i + 3)!);
+      const attester = EthAddress.fromString(privateKeyToAccount(privateKey).address);
+      return { attester, withdrawer: attester, privateKey };
+    });
+
+    // Setup context with the given set of validators, no reorgs, mocked gossip sub network, and no anvil test watcher.
+    test = await EpochsTestContext.setup({
+      numberOfAccounts: 1,
+      initialValidators: validators,
+      mockGossipSubNetwork: true,
+      disableAnvilTestWatcher: true,
+      aztecProofSubmissionEpochs: 1024,
+      startProverNode: false,
+      aztecTargetCommitteeSize: COMMITTEE_SIZE,
+      enforceTimeTable: true,
+      minTxsPerBlock: 1,
+      maxTxsPerBlock: 1,
+      attestationPropagationTime: 0.5,
+      maxL1TxInclusionTimeIntoSlot: 0,
+    });
+
+    ({ context, logger } = test);
+
+    // Halt block building in initial aztec node, which was not set up as a validator.
+    logger.warn(`Stopping sequencer in initial aztec node.`);
+    await context.sequencer!.stop();
+
+    // Start the validator nodes
+    logger.warn(`Initial setup complete. Starting ${NODE_COUNT} validator nodes.`);
+    nodes = await asyncMap(validators, ({ privateKey }) =>
+      test.createValidatorNode([privateKey], { dontStartSequencer: true, txDelayerMaxInclusionTimeIntoSlot: 1 }),
+    );
+    logger.warn(`Started ${NODE_COUNT} validator nodes.`, { validators: validators.map(v => v.attester.toString()) });
+
+    // Register spam contract for sending txs.
+    contract = await test.registerSpamContract(context.wallet);
+    logger.warn(`Test setup completed.`, { validators: validators.map(v => v.attester.toString()) });
+  });
+
+  afterEach(async () => {
+    jest.restoreAllMocks();
+    await test.teardown();
+  });
+
+  it('builds blocks on the first two slots of the epoch', async () => {
+    // Create and submit txs for the first two slots of the epoch
+    // We set maxTxsPerBlock to 1, so two txs mean two consecutive blocks
+    const txs = await timesAsync(TX_COUNT, i => contract.methods.spam(i, 1n, false).prove());
+    const sentTxs = await Promise.all(txs.map(tx => tx.send()));
+    logger.warn(`Sent ${sentTxs.length} transactions`, {
+      txs: await Promise.all(sentTxs.map(tx => tx.getTxHash())),
+    });
+
+    const sequencers = nodes.map(node => node.getSequencer()!);
+    const { failEvents } = test.watchSequencerEvents(sequencers, i => ({ validator: validators[i].attester }));
+
+    // Warp to before the first slot of an epoch, so that the sequencers are ready to build blocks.
+    const [epochStart] = getTimestampRangeForEpoch(EPOCH, test.constants);
+    await test.context.cheatCodes.eth.warp(Number(epochStart) - test.L1_BLOCK_TIME_IN_S, {
+      resetBlockInterval: true,
+      updateDateProvider: test.context.dateProvider,
+    });
+
+    // Start the sequencers
+    await Promise.all(sequencers.map(sequencer => sequencer.start()));
+    logger.warn(`Started all sequencers`);
+
+    // Wait until all txs are mined
+    const timeout = test.L2_SLOT_DURATION_IN_S * (TX_COUNT * 2 + 1) * 1000;
+    await executeTimeout(() => Promise.all(sentTxs.map(tx => tx.wait())), timeout);
+    logger.warn(`All txs have been mined`);
+
+    // Check that the first two slots of the epoch have a block
+    const blocks = await nodes[0].getBlocks(1, 10);
+    const slots = blocks.map(block => block.header.getSlot());
+    const [firstSlot] = getSlotRangeForEpoch(EPOCH, test.constants);
+    expect(slots).toContain(firstSlot);
+    expect(slots).toContain(firstSlot + 1n);
+
+    // Expect no failures from sequencers during block building.
+    // The following error is marked as a flake on the test ignore patterns,
+    // so we can have this test run for a while before it breaks CI on a recoverable error.
+    if (failEvents.length > 0) {
+      logger.error(`Failed events from sequencers`, failEvents);
+    }
+    expect(failEvents).toEqual([]);
+  });
+});

--- a/yarn-project/end-to-end/src/e2e_epochs/epochs_first_slot.test.ts
+++ b/yarn-project/end-to-end/src/e2e_epochs/epochs_first_slot.test.ts
@@ -1,5 +1,5 @@
 import type { AztecNodeService } from '@aztec/aztec-node';
-import { EthAddress, type Logger, getTimestampRangeForEpoch } from '@aztec/aztec.js';
+import { EthAddress, type Logger, getTimestampRangeForEpoch, sleep } from '@aztec/aztec.js';
 import type { Operator } from '@aztec/ethereum';
 import { asyncMap } from '@aztec/foundation/async-map';
 import { times, timesAsync } from '@aztec/foundation/collection';
@@ -108,6 +108,7 @@ describe('e2e_epochs/epochs_first_slot', () => {
     const timeout = test.L2_SLOT_DURATION_IN_S * (TX_COUNT * 2 + 1) * 1000;
     await executeTimeout(() => Promise.all(sentTxs.map(tx => tx.wait())), timeout);
     logger.warn(`All txs have been mined`);
+    await sleep(1000);
 
     // Check that the first two slots of the epoch have a block
     const blocks = await nodes[0].getBlocks(1, 10);

--- a/yarn-project/end-to-end/src/e2e_epochs/epochs_first_slot.test.ts
+++ b/yarn-project/end-to-end/src/e2e_epochs/epochs_first_slot.test.ts
@@ -48,6 +48,7 @@ describe('e2e_epochs/epochs_first_slot', () => {
       mockGossipSubNetwork: true,
       disableAnvilTestWatcher: true,
       aztecProofSubmissionEpochs: 1024,
+      aztecEpochDuration: 32,
       startProverNode: false,
       aztecTargetCommitteeSize: COMMITTEE_SIZE,
       enforceTimeTable: true,

--- a/yarn-project/epoch-cache/src/epoch_cache.ts
+++ b/yarn-project/epoch-cache/src/epoch_cache.ts
@@ -29,8 +29,10 @@ export type EpochCommitteeInfo = {
   epoch: bigint;
 };
 
+export type SlotTag = 'now' | 'next' | bigint;
+
 export interface EpochCacheInterface {
-  getCommittee(slot: 'now' | 'next' | bigint | undefined): Promise<EpochCommitteeInfo>;
+  getCommittee(slot: SlotTag | undefined): Promise<EpochCommitteeInfo>;
   getEpochAndSlotNow(): EpochAndSlot;
   getEpochAndSlotInNextL1Slot(): EpochAndSlot & { now: bigint };
   getProposerIndexEncoding(epoch: bigint, slot: bigint, seed: bigint): `0x${string}`;
@@ -41,7 +43,8 @@ export interface EpochCacheInterface {
     currentSlot: bigint;
     nextSlot: bigint;
   }>;
-  isInCommittee(validator: EthAddress): Promise<boolean>;
+  isInCommittee(slot: SlotTag, validator: EthAddress): Promise<boolean>;
+  filterInCommittee(slot: SlotTag, validators: EthAddress[]): Promise<EthAddress[]>;
 }
 
 /**
@@ -163,7 +166,7 @@ export class EpochCache implements EpochCacheInterface {
    * @param nextSlot - If true, get the validator set for the next slot.
    * @returns The current validator set.
    */
-  public async getCommittee(slot: 'now' | 'next' | bigint = 'now'): Promise<EpochCommitteeInfo> {
+  public async getCommittee(slot: SlotTag = 'now'): Promise<EpochCommitteeInfo> {
     const { epoch, ts } = this.getEpochAndTimestamp(slot);
 
     if (this.cache.has(epoch)) {
@@ -185,7 +188,7 @@ export class EpochCache implements EpochCacheInterface {
     return epochData;
   }
 
-  private getEpochAndTimestamp(slot: 'now' | 'next' | bigint = 'now') {
+  private getEpochAndTimestamp(slot: SlotTag = 'now') {
     if (slot === 'now') {
       return this.getEpochAndSlotNow();
     } else if (slot === 'next') {
@@ -277,19 +280,18 @@ export class EpochCache implements EpochCacheInterface {
     return committee[Number(proposerIndex)];
   }
 
-  /**
-   * Check if a validator is in the current epoch's committee
-   */
-  async isInCommittee(validator: EthAddress): Promise<boolean> {
-    const { committee } = await this.getCommittee();
+  /** Check if a validator is in the given slot's committee */
+  async isInCommittee(slot: SlotTag, validator: EthAddress): Promise<boolean> {
+    const { committee } = await this.getCommittee(slot);
     if (!committee) {
       return false;
     }
     return committee.some(v => v.equals(validator));
   }
 
-  async filterInCommittee(validators: EthAddress[]): Promise<EthAddress[]> {
-    const { committee } = await this.getCommittee();
+  /** From the set of given addresses, return all that are on the committee for the given slot */
+  async filterInCommittee(slot: SlotTag, validators: EthAddress[]): Promise<EthAddress[]> {
+    const { committee } = await this.getCommittee(slot);
     if (!committee) {
       return [];
     }

--- a/yarn-project/ethereum/src/test/eth_cheat_codes.ts
+++ b/yarn-project/ethereum/src/test/eth_cheat_codes.ts
@@ -163,26 +163,30 @@ export class EthCheatCodes {
    * Enable interval mining at the given interval (block time)
    * @param seconds - The interval to use between blocks
    */
-  public async setIntervalMining(seconds: number): Promise<void> {
+  public async setIntervalMining(seconds: number, opts: { silent?: boolean } = {}): Promise<void> {
     try {
       await this.rpcCall('anvil_setIntervalMining', [seconds]);
     } catch (err) {
       throw new Error(`Error setting interval mining: ${err}`);
     }
-    this.logger.warn(`Set L1 interval mining to ${seconds} seconds`);
+    if (!opts.silent) {
+      this.logger.warn(`Set L1 interval mining to ${seconds} seconds`);
+    }
   }
 
   /**
    * Set the automine status of the underlying anvil chain
    * @param automine - The automine status to set
    */
-  public async setAutomine(automine: boolean): Promise<void> {
+  public async setAutomine(automine: boolean, opts: { silent?: boolean } = {}): Promise<void> {
     try {
       await this.rpcCall('anvil_setAutomine', [automine]);
     } catch (err) {
       throw new Error(`Error setting automine: ${err}`);
     }
-    this.logger.warn(`Set L1 automine to ${automine}`);
+    if (!opts.silent) {
+      this.logger.warn(`Set L1 automine to ${automine}`);
+    }
   }
 
   /**
@@ -227,7 +231,7 @@ export class EthCheatCodes {
       if (opts.resetBlockInterval) {
         blockInterval = await this.getIntervalMining();
         if (blockInterval !== null) {
-          await this.setIntervalMining(0);
+          await this.setIntervalMining(0, { silent: true });
         }
       }
       // Set the timestamp of the next block to be mined
@@ -241,7 +245,7 @@ export class EthCheatCodes {
     } finally {
       // Restore interval mining so the next block is mined in `blockInterval` seconds from this one
       if (opts.resetBlockInterval && blockInterval !== null && blockInterval > 0) {
-        await this.setIntervalMining(blockInterval);
+        await this.setIntervalMining(blockInterval, { silent: true });
       }
     }
     if (!opts.silent) {
@@ -422,11 +426,11 @@ export class EthCheatCodes {
     const [blockInterval, wasAutoMining] = await Promise.all([this.getIntervalMining(), this.isAutoMining()]);
     try {
       if (blockInterval !== null) {
-        await this.setIntervalMining(0);
+        await this.setIntervalMining(0, { silent: true });
       }
 
       if (wasAutoMining) {
-        await this.setAutomine(false);
+        await this.setAutomine(false, { silent: true });
       }
 
       await fn();
@@ -434,7 +438,7 @@ export class EthCheatCodes {
       try {
         // restore automine if necessary
         if (wasAutoMining) {
-          await this.setAutomine(true);
+          await this.setAutomine(true, { silent: true });
         }
       } catch (err) {
         this.logger.warn(`Failed to reenable automining: ${err}`);
@@ -443,7 +447,7 @@ export class EthCheatCodes {
       try {
         // restore automine if necessary
         if (blockInterval !== null) {
-          await this.setIntervalMining(blockInterval);
+          await this.setIntervalMining(blockInterval, { silent: true });
         }
       } catch (err) {
         this.logger.warn(`Failed to reenable interval mining: ${err}`);

--- a/yarn-project/p2p/src/msg_validators/attestation_validator/attestation_validator.ts
+++ b/yarn-project/p2p/src/msg_validators/attestation_validator/attestation_validator.ts
@@ -19,7 +19,7 @@ export class AttestationValidator implements P2PValidator<BlockAttestation> {
       }
 
       const attester = message.getSender();
-      if (!(await this.epochCache.isInCommittee(attester))) {
+      if (!(await this.epochCache.isInCommittee(slotNumberBigInt, attester))) {
         return PeerErrorSeverity.HighToleranceError;
       }
       return undefined;

--- a/yarn-project/p2p/src/testbench/p2p_client_testbench_worker.ts
+++ b/yarn-project/p2p/src/testbench/p2p_client_testbench_worker.ts
@@ -86,6 +86,7 @@ function mockEpochCache(): EpochCacheInterface {
       }),
     getEpochAndSlotInNextL1Slot: () => ({ epoch: 0n, slot: 0n, ts: 0n, now: 0n }),
     isInCommittee: () => Promise.resolve(false),
+    filterInCommittee: () => Promise.resolve([]),
   };
 }
 

--- a/yarn-project/txe/src/state_machine/mock_epoch_cache.ts
+++ b/yarn-project/txe/src/state_machine/mock_epoch_cache.ts
@@ -1,4 +1,4 @@
-import type { EpochAndSlot, EpochCacheInterface, EpochCommitteeInfo } from '@aztec/epoch-cache';
+import type { EpochAndSlot, EpochCacheInterface, EpochCommitteeInfo, SlotTag } from '@aztec/epoch-cache';
 import { EthAddress } from '@aztec/foundation/eth-address';
 
 /**
@@ -53,7 +53,11 @@ export class MockEpochCache implements EpochCacheInterface {
     });
   }
 
-  isInCommittee(_validator: EthAddress): Promise<boolean> {
+  isInCommittee(_slot: SlotTag, _validator: EthAddress): Promise<boolean> {
     return Promise.resolve(false);
+  }
+
+  filterInCommittee(_slot: SlotTag, _validators: EthAddress[]): Promise<EthAddress[]> {
+    return Promise.resolve([]);
   }
 }

--- a/yarn-project/validator-client/src/validator.ts
+++ b/yarn-project/validator-client/src/validator.ts
@@ -80,7 +80,7 @@ export class ValidatorClient extends (EventEmitter as new () => WatcherEmitter) 
   private previousProposal?: BlockProposal;
 
   private myAddresses: EthAddress[];
-  private lastEpoch: bigint | undefined;
+  private lastEpochForCommitteeUpdateLoop: bigint | undefined;
   private epochCacheUpdateLoop: RunningPromise;
 
   private blockProposalValidator: BlockProposalValidator;
@@ -119,12 +119,12 @@ export class ValidatorClient extends (EventEmitter as new () => WatcherEmitter) 
 
   private async handleEpochCommitteeUpdate() {
     try {
-      const { committee, epoch } = await this.epochCache.getCommittee('now');
+      const { committee, epoch } = await this.epochCache.getCommittee('next');
       if (!committee) {
         this.log.trace(`No committee found for slot`);
         return;
       }
-      if (epoch !== this.lastEpoch) {
+      if (epoch !== this.lastEpochForCommitteeUpdateLoop) {
         const me = this.myAddresses;
         const committeeSet = new Set(committee.map(v => v.toString()));
         const inCommittee = me.filter(a => committeeSet.has(a.toString()));
@@ -137,7 +137,7 @@ export class ValidatorClient extends (EventEmitter as new () => WatcherEmitter) 
             `Validators ${me.map(a => a.toString()).join(', ')} are not on the validator committee for epoch ${epoch}`,
           );
         }
-        this.lastEpoch = epoch;
+        this.lastEpochForCommitteeUpdateLoop = epoch;
       }
     } catch (err) {
       this.log.error(`Error updating epoch committee`, err);
@@ -200,7 +200,7 @@ export class ValidatorClient extends (EventEmitter as new () => WatcherEmitter) 
 
     const myAddresses = this.keyStore.getAddresses();
 
-    const inCommittee = await this.epochCache.filterInCommittee(myAddresses);
+    const inCommittee = await this.epochCache.filterInCommittee('now', myAddresses);
     if (inCommittee.length > 0) {
       this.log.info(
         `Started validator with addresses in current validator committee: ${inCommittee.map(a => a.toString()).join(', ')}`,
@@ -223,12 +223,12 @@ export class ValidatorClient extends (EventEmitter as new () => WatcherEmitter) 
   }
 
   async attestToProposal(proposal: BlockProposal, proposalSender: PeerId): Promise<BlockAttestation[] | undefined> {
-    const slotNumber = proposal.slotNumber.toNumber();
+    const slotNumber = proposal.slotNumber.toBigInt();
     const blockNumber = proposal.blockNumber;
     const proposer = proposal.getSender();
 
     // Check that I have any address in current committee before attesting
-    const inCommittee = await this.epochCache.filterInCommittee(this.keyStore.getAddresses());
+    const inCommittee = await this.epochCache.filterInCommittee(slotNumber, this.keyStore.getAddresses());
     const partOfCommittee = inCommittee.length > 0;
 
     const proposalInfo = {
@@ -514,7 +514,7 @@ export class ValidatorClient extends (EventEmitter as new () => WatcherEmitter) 
 
     const proposalId = proposal.archive.toString();
     // adds attestations for all of my addresses locally
-    const inCommittee = await this.epochCache.filterInCommittee(this.keyStore.getAddresses());
+    const inCommittee = await this.epochCache.filterInCommittee(slot, this.keyStore.getAddresses());
     await this.doAttestToProposal(proposal, inCommittee);
 
     const myAddresses = this.keyStore.getAddresses();


### PR DESCRIPTION
Explicitly checks for the proposal/attestation slot when checking if a given validator is in the committee. Note that the p2p client already checks that the slot is either the current or next.

As @aminsammara pointed out:
> [...] validators only call epochCache to check "am in the committee now", instead of checking "am I in the committee for the slot this proposal is meant to be for"

Fixes #15414

Builds on top of #15504 since I needed some test utils from that PR.