### PR TITLE
chore(avm): Remove template in avm recursive verifier and clean-ups

### DIFF
--- a/barretenberg/cpp/src/barretenberg/dsl/acir_format/avm2_recursion_constraint.cpp
+++ b/barretenberg/cpp/src/barretenberg/dsl/acir_format/avm2_recursion_constraint.cpp
@@ -145,53 +145,6 @@ void create_dummy_vkey_and_proof(Builder& builder,
 } // namespace
 
 /**
- * @brief Add constraints required to recursively verify an AVM2 proof
- *
- * @param builder
- * @param input
- * @param input_points_accumulator_indices. The aggregation object coming from previous Honk/Avm recursion constraints.
- * @param has_valid_witness_assignment. Do we have witnesses or are we just generating keys?
- */
-PairingPoints create_avm2_recursion_constraints(Builder& builder,
-                                                const RecursionConstraint& input,
-                                                bool has_valid_witness_assignments)
-{
-    using Flavor = avm2::AvmRecursiveFlavor_<Builder>;
-    using RecursiveVerificationKey = Flavor::VerificationKey;
-    using RecursiveVerifier = avm2::AvmRecursiveVerifier_<Flavor>;
-
-    BB_ASSERT_EQ(input.proof_type, AVM);
-
-    auto fields_from_witnesses = [&](const std::vector<uint32_t>& input) {
-        std::vector<field_ct> result;
-        result.reserve(input.size());
-        for (const auto& idx : input) {
-            result.emplace_back(field_ct::from_witness_index(&builder, idx));
-        }
-        return result;
-    };
-
-    // Construct in-circuit representation of the verification key, proof and public inputs
-    const auto key_fields = fields_from_witnesses(input.key);
-    const auto proof_fields = fields_from_witnesses(input.proof);
-    const auto public_inputs_flattened = fields_from_witnesses(input.public_inputs);
-
-    // Populate the key fields and proof fields with dummy values to prevent issues (e.g. points must be on curve).
-    if (!has_valid_witness_assignments) {
-        create_dummy_vkey_and_proof(builder, input.proof.size(), input.public_inputs.size(), key_fields, proof_fields);
-    }
-
-    // Recursively verify the proof
-    auto vkey = std::make_shared<RecursiveVerificationKey>(builder, key_fields);
-    RecursiveVerifier verifier(builder, vkey);
-
-    PairingPoints output_points_accumulator =
-        verifier.verify_proof(proof_fields, bb::avm2::PublicInputs::flat_to_columns(public_inputs_flattened));
-
-    return output_points_accumulator;
-}
-
-/**
  * @brief Add constraints associated with recursive verification of an AVM2 proof using Goblin
  *
  * @param builder

--- a/barretenberg/cpp/src/barretenberg/dsl/acir_format/avm2_recursion_constraint.hpp
+++ b/barretenberg/cpp/src/barretenberg/dsl/acir_format/avm2_recursion_constraint.hpp
@@ -17,11 +17,6 @@ using Builder = bb::UltraCircuitBuilder;
 
 using namespace bb;
 
-[[nodiscard("Pairing points should be accumulated")]] stdlib::recursion::PairingPoints<Builder>
-create_avm2_recursion_constraints(Builder& builder,
-                                  const RecursionConstraint& input,
-                                  bool has_valid_witness_assignments);
-
 [[nodiscard("IPA claim and Pairing points should be accumulated")]] HonkRecursionConstraintOutput<Builder>
 create_avm2_recursion_constraints_goblin(Builder& builder,
                                          const RecursionConstraint& input,

--- a/barretenberg/cpp/src/barretenberg/flavor/flavor.hpp
+++ b/barretenberg/cpp/src/barretenberg/flavor/flavor.hpp
@@ -450,17 +450,16 @@ class MegaZKFlavor;
 class TranslatorFlavor;
 class ECCVMRecursiveFlavor;
 class TranslatorRecursiveFlavor;
+class AvmRecursiveFlavor;
 
 template <typename BuilderType> class UltraRecursiveFlavor_;
 template <typename BuilderType> class UltraZKRecursiveFlavor_;
 template <typename BuilderType> class UltraRollupRecursiveFlavor_;
 template <typename BuilderType> class MegaRecursiveFlavor_;
 template <typename BuilderType> class MegaZKRecursiveFlavor_;
-template <typename BuilderType> class AvmRecursiveFlavor_;
 namespace avm2 {
 
-template <typename BuilderType> class AvmRecursiveFlavor_;
-
+class AvmRecursiveFlavor;
 }
 
 } // namespace bb

--- a/barretenberg/cpp/src/barretenberg/flavor/flavor_concepts.hpp
+++ b/barretenberg/cpp/src/barretenberg/flavor/flavor_concepts.hpp
@@ -54,10 +54,8 @@ concept IsRecursiveFlavor = IsAnyOf<T, UltraRecursiveFlavor_<UltraCircuitBuilder
                                        MegaZKRecursiveFlavor_<UltraCircuitBuilder>,
                                        TranslatorRecursiveFlavor,
                                        ECCVMRecursiveFlavor,
-                                       AvmRecursiveFlavor_<UltraCircuitBuilder>,
-                                       AvmRecursiveFlavor_<MegaCircuitBuilder>,
-                                       avm2::AvmRecursiveFlavor_<UltraCircuitBuilder>,
-                                       avm2::AvmRecursiveFlavor_<MegaCircuitBuilder>>;
+                                       AvmRecursiveFlavor,
+                                       avm2::AvmRecursiveFlavor>;
 
 // These concepts are relevant for Sumcheck, where the logic is different for BN254 and Grumpkin Flavors
 template <typename T> concept IsGrumpkinFlavor = IsAnyOf<T, ECCVMFlavor, ECCVMRecursiveFlavor>;

--- a/barretenberg/cpp/src/barretenberg/stdlib/primitives/circuit_builders/circuit_builders_fwd.hpp
+++ b/barretenberg/cpp/src/barretenberg/stdlib/primitives/circuit_builders/circuit_builders_fwd.hpp
@@ -37,6 +37,7 @@ class ECCVMFlavor;
 class TranslatorFlavor;
 class TranslatorRecursiveFlavor;
 class ECCVMRecursiveFlavor;
+class AvmRecursiveFlavor;
 
 template <typename BuilderType> class UltraRecursiveFlavor_;
 template <typename BuilderType> class UltraZKRecursiveFlavor_;
@@ -44,9 +45,8 @@ template <typename BuilderType> class UltraKeccakRecursiveFlavor_;
 template <typename BuilderType> class UltraRollupRecursiveFlavor_;
 template <typename BuilderType> class MegaRecursiveFlavor_;
 template <typename BuilderType> class MegaZKRecursiveFlavor_;
-template <typename BuilderType> class AvmRecursiveFlavor_;
 namespace avm2 {
-template <typename BuilderType> class AvmRecursiveFlavor_;
+class AvmRecursiveFlavor;
 }
 
 #ifdef STARKNET_GARAGA_FLAVORS

--- a/barretenberg/cpp/src/barretenberg/vm2/constraining/recursion/goblin_avm_recursive_verifier.hpp
+++ b/barretenberg/cpp/src/barretenberg/vm2/constraining/recursion/goblin_avm_recursive_verifier.hpp
@@ -164,12 +164,9 @@ class AvmGoblinRecursiveVerifier {
     InnerProverOutput construct_and_prove_inner_recursive_verification_circuit(
         const stdlib::Proof<UltraBuilder>& stdlib_proof, const std::vector<std::vector<UltraFF>>& public_inputs) const
     {
-        using AvmRecursiveFlavor = AvmRecursiveFlavor_<MegaBuilder>;
         using AvmRecursiveVerificationKey = AvmRecursiveFlavor::VerificationKey;
-        using AvmRecursiveVerifier = AvmRecursiveVerifier_<AvmRecursiveFlavor>;
         using ECCVMVK = Goblin::ECCVMVerificationKey;
         using TranslatorVK = Goblin::TranslatorVerificationKey;
-        using MegaProver = UltraProver_<MegaFlavor>;
         using MegaVerificationKey = MegaFlavor::VerificationKey;
         using FF = AvmRecursiveFlavor::FF;
 

--- a/barretenberg/cpp/src/barretenberg/vm2/constraining/recursion/recursive_flavor.hpp
+++ b/barretenberg/cpp/src/barretenberg/vm2/constraining/recursion/recursive_flavor.hpp
@@ -9,9 +9,9 @@
 
 namespace bb::avm2 {
 
-template <typename BuilderType> class AvmRecursiveFlavor_ {
+class AvmRecursiveFlavor {
   public:
-    using CircuitBuilder = BuilderType;
+    using CircuitBuilder = MegaCircuitBuilder;
     using Curve = stdlib::bn254<CircuitBuilder>;
     using PCS = KZG<Curve>;
     using GroupElement = typename Curve::Element;
@@ -60,7 +60,8 @@ template <typename BuilderType> class AvmRecursiveFlavor_ {
         using Base::Base;
     };
 
-    class VerificationKey : public StdlibVerificationKey_<BuilderType, NativeFlavor::PrecomputedEntities<Commitment>> {
+    class VerificationKey
+        : public StdlibVerificationKey_<CircuitBuilder, NativeFlavor::PrecomputedEntities<Commitment>> {
       public:
         VerificationKey(CircuitBuilder* builder, const std::shared_ptr<NativeVerificationKey>& native_key)
         {

--- a/barretenberg/cpp/src/barretenberg/vm2/constraining/recursion/recursive_verifier.cpp
+++ b/barretenberg/cpp/src/barretenberg/vm2/constraining/recursion/recursive_verifier.cpp
@@ -17,23 +17,20 @@
 
 namespace bb::avm2 {
 
-template <typename Flavor>
-AvmRecursiveVerifier_<Flavor>::AvmRecursiveVerifier_(
-    Builder& builder, const std::shared_ptr<NativeVerificationKey>& native_verification_key)
+AvmRecursiveVerifier::AvmRecursiveVerifier(Builder& builder,
+                                           const std::shared_ptr<NativeVerificationKey>& native_verification_key)
     : key(std::make_shared<VerificationKey>(&builder, native_verification_key))
     , builder(builder)
 {}
 
-template <typename Flavor>
-AvmRecursiveVerifier_<Flavor>::AvmRecursiveVerifier_(Builder& builder, const std::shared_ptr<VerificationKey>& vkey)
+AvmRecursiveVerifier::AvmRecursiveVerifier(Builder& builder, const std::shared_ptr<VerificationKey>& vkey)
     : key(vkey)
     , builder(builder)
 {}
 
 // Evaluate the given public input column over the multivariate challenge points
-template <typename Flavor>
-Flavor::FF AvmRecursiveVerifier_<Flavor>::evaluate_public_input_column(const std::vector<FF>& points,
-                                                                       const std::vector<FF>& challenges)
+AvmRecursiveVerifier::FF AvmRecursiveVerifier::evaluate_public_input_column(const std::vector<FF>& points,
+                                                                            const std::vector<FF>& challenges)
 {
     auto coefficients = SharedShiftedVirtualZeroesArray<FF>{
         .start_ = 0,
@@ -49,8 +46,7 @@ Flavor::FF AvmRecursiveVerifier_<Flavor>::evaluate_public_input_column(const std
     return generic_evaluate_mle<FF>(challenges, coefficients);
 }
 
-template <typename Flavor>
-AvmRecursiveVerifier_<Flavor>::PairingPoints AvmRecursiveVerifier_<Flavor>::verify_proof(
+AvmRecursiveVerifier::PairingPoints AvmRecursiveVerifier::verify_proof(
     const HonkProof& proof, const std::vector<std::vector<fr>>& public_inputs_vec_nt)
 {
     StdlibProof stdlib_proof(builder, proof);
@@ -72,8 +68,7 @@ AvmRecursiveVerifier_<Flavor>::PairingPoints AvmRecursiveVerifier_<Flavor>::veri
 
 // TODO(#991): (see https://github.com/AztecProtocol/barretenberg/issues/991)
 // TODO(#14234)[Unconditional PIs validation]: rename stdlib_proof_with_pi_flag to stdlib_proof
-template <typename Flavor>
-AvmRecursiveVerifier_<Flavor>::PairingPoints AvmRecursiveVerifier_<Flavor>::verify_proof(
+AvmRecursiveVerifier::PairingPoints AvmRecursiveVerifier::verify_proof(
     const stdlib::Proof<Builder>& stdlib_proof_with_pi_flag, const std::vector<std::vector<FF>>& public_inputs)
 {
     using Curve = typename Flavor::Curve;
@@ -167,10 +162,5 @@ AvmRecursiveVerifier_<Flavor>::PairingPoints AvmRecursiveVerifier_<Flavor>::veri
     auto pairing_points = PCS::reduce_verify_batch_opening_claim(opening_claim, transcript);
     return pairing_points;
 }
-
-// TODO: Once Goblinized version is mature, we can remove this one and we only to template
-// with MegaCircuitBuilder and therefore we can remove the templat in AvmRecursiveVerifier_.
-template class AvmRecursiveVerifier_<AvmRecursiveFlavor_<UltraCircuitBuilder>>;
-template class AvmRecursiveVerifier_<AvmRecursiveFlavor_<MegaCircuitBuilder>>;
 
 } // namespace bb::avm2

--- a/barretenberg/cpp/src/barretenberg/vm2/constraining/recursion/recursive_verifier.hpp
+++ b/barretenberg/cpp/src/barretenberg/vm2/constraining/recursion/recursive_verifier.hpp
@@ -7,10 +7,8 @@
 
 namespace bb::avm2 {
 
-// TODO: Ultimately we will not need to template with Flavor as
-// we will only support RecursiveFlavor with MegaCircuitBuilder.
-// We will simply add in the body: using Flavor = ....
-template <typename Flavor> class AvmRecursiveVerifier_ {
+class AvmRecursiveVerifier {
+    using Flavor = AvmRecursiveFlavor;
     using FF = typename Flavor::FF;
     using BF = typename Flavor::BF;
     using Curve = typename Flavor::Curve;
@@ -26,9 +24,9 @@ template <typename Flavor> class AvmRecursiveVerifier_ {
     using StdlibProof = stdlib::Proof<Builder>;
 
   public:
-    explicit AvmRecursiveVerifier_(Builder& builder,
-                                   const std::shared_ptr<NativeVerificationKey>& native_verification_key);
-    explicit AvmRecursiveVerifier_(Builder& builder, const std::shared_ptr<VerificationKey>& vkey);
+    explicit AvmRecursiveVerifier(Builder& builder,
+                                  const std::shared_ptr<NativeVerificationKey>& native_verification_key);
+    explicit AvmRecursiveVerifier(Builder& builder, const std::shared_ptr<VerificationKey>& vkey);
 
     [[nodiscard("IPA claim and Pairing points should be accumulated")]] PairingPoints verify_proof(
         const HonkProof& proof, const std::vector<std::vector<fr>>& public_inputs_vec_nt);

--- a/barretenberg/cpp/src/barretenberg/vm2/constraining/recursion/recursive_verifier.test.cpp
+++ b/barretenberg/cpp/src/barretenberg/vm2/constraining/recursion/recursive_verifier.test.cpp
@@ -19,7 +19,7 @@ namespace bb::avm2::constraining {
 
 class AvmRecursiveTests : public ::testing::Test {
   public:
-    using RecursiveFlavor = AvmRecursiveFlavor_<UltraCircuitBuilder>;
+    using RecursiveFlavor = AvmRecursiveFlavor;
     using InnerProver = AvmProvingHelper;
     using InnerVerifier = AvmVerifier;
     using OuterBuilder = typename RecursiveFlavor::CircuitBuilder;
@@ -43,7 +43,7 @@ class AvmRecursiveTests : public ::testing::Test {
 
         InnerProver prover;
         const auto [proof, vk_data] = prover.prove(std::move(trace));
-        const auto verification_key = prover.create_verification_key(vk_data);
+        const auto verification_key = InnerProver::create_verification_key(vk_data);
         InnerVerifier verifier(verification_key);
 
         const auto public_inputs_cols = public_inputs.to_columns();
@@ -56,96 +56,6 @@ class AvmRecursiveTests : public ::testing::Test {
     }
 };
 
-// TODO: Makes more sense to migrate this one over a Mega-arithmetized AVM recursive verifier?
-/**
- * @brief A test of the "vanilla" Ultra-arithmetized AVM recursive verifier.
- *
- */
-TEST_F(AvmRecursiveTests, StandardRecursion)
-{
-    using RecursiveVerifier = AvmRecursiveVerifier_<RecursiveFlavor>;
-    using OuterProver = UltraProver;
-    using OuterVerifier = UltraVerifier;
-    using OuterDeciderProvingKey = DeciderProvingKey_<UltraFlavor>;
-    using NativeVerifierCommitmentKey = typename AvmFlavor::VerifierCommitmentKey;
-
-    if (testing::skip_slow_tests()) {
-        GTEST_SKIP();
-    }
-
-    NativeProofResult proof_result;
-    ASSERT_NO_FATAL_FAILURE({ create_and_verify_native_proof(proof_result); });
-
-    auto [proof, verification_key, public_inputs_cols] = proof_result;
-    proof.insert(proof.begin(), 0); // TODO(#14234)[Unconditional PIs validation]: remove this
-
-    // Create the outer verifier, to verify the proof
-    OuterBuilder outer_circuit;
-
-    // Scoped to free memory of RecursiveVerifier.
-    {
-        RecursiveVerifier recursive_verifier{ outer_circuit, verification_key };
-
-        auto pairing_points = recursive_verifier.verify_proof(proof, public_inputs_cols);
-
-        NativeVerifierCommitmentKey pcs_vkey{};
-        bool pairing_points_valid =
-            pcs_vkey.pairing_check(pairing_points.P0.get_value(), pairing_points.P1.get_value());
-
-        // Check that the output of the recursive verifier is well-formed for aggregation as this pair of points will
-        // be aggregated with others.
-        ASSERT_TRUE(pairing_points_valid) << "Pairing points are not valid.";
-
-        // Check that no failure flag was raised in the recursive verifier circuit
-        ASSERT_FALSE(outer_circuit.failed()) << outer_circuit.err();
-
-        // Check that the circuit is valid.
-        bool outer_circuit_checked = CircuitChecker::check(outer_circuit);
-        ASSERT_TRUE(outer_circuit_checked) << "outer circuit check failed";
-
-        auto avm_transcript = AvmFlavor::Transcript();
-        avm_transcript.load_proof(proof);
-        auto manifest = avm_transcript.get_manifest();
-        auto recursive_manifest = recursive_verifier.transcript->get_manifest();
-
-        // We sanity check that the recursive manifest matches its counterpart one.
-        ASSERT_EQ(manifest.size(), recursive_manifest.size());
-        for (size_t i = 0; i < recursive_manifest.size(); ++i) {
-            EXPECT_EQ(recursive_manifest[i], manifest[i]);
-        }
-
-        // We sanity check that the recursive verifier key (precomputed columns) matches its counterpart one.
-        for (const auto [key_el, rec_key_el] :
-             zip_view(verification_key->get_all(), recursive_verifier.key->get_all())) {
-            EXPECT_EQ(key_el, rec_key_el.get_value());
-        }
-
-        // Sanity checks on circuit_size and num_public_inputs match.
-        EXPECT_EQ(verification_key->circuit_size,
-                  static_cast<uint64_t>(recursive_verifier.key->circuit_size.get_value()));
-        EXPECT_EQ(verification_key->num_public_inputs,
-                  static_cast<uint64_t>(recursive_verifier.key->num_public_inputs.get_value()));
-    }
-
-    // Make a proof of the verification of an AVM proof
-    const size_t srs_size = 1 << 24; // Current outer_circuit size is 9.6 millions
-    auto ultra_instance = std::make_shared<OuterDeciderProvingKey>(
-        outer_circuit, TraceSettings{}, bb::CommitmentKey<curve::BN254>(srs_size));
-
-    // Scoped to free memory of OuterProver.
-    auto outer_proof = [&]() {
-        auto verification_key = std::make_shared<UltraFlavor::VerificationKey>(ultra_instance->proving_key);
-        OuterProver ultra_prover(ultra_instance, verification_key);
-        return ultra_prover.construct_proof();
-    }();
-
-    vinfo("Recursive verifier: finalized num gates = ", outer_circuit.num_gates);
-
-    auto ultra_verification_key = std::make_shared<UltraFlavor::VerificationKey>(ultra_instance->proving_key);
-    OuterVerifier ultra_verifier(ultra_verification_key);
-    EXPECT_TRUE(ultra_verifier.verify_proof(outer_proof)) << "outer/recursion proof verification failed";
-}
-
 /**
  * @brief A test of the Goblinized AVM recursive verifier.
  * @details Constructs a simple AVM circuit for which a proof is verified using the Goblinized AVM recursive verifier. A
@@ -157,7 +67,8 @@ TEST_F(AvmRecursiveTests, GoblinRecursion)
 {
     // Type aliases specific to GoblinRecursion test
     using AvmRecursiveVerifier = AvmGoblinRecursiveVerifier;
-    using UltraRollupRecursiveFlavor = UltraRollupRecursiveFlavor_<UltraRollupFlavor::CircuitBuilder>;
+    using OuterBuilder = typename UltraRollupFlavor::CircuitBuilder;
+    using UltraRollupRecursiveFlavor = UltraRollupRecursiveFlavor_<OuterBuilder>;
     using UltraFF = UltraRollupRecursiveFlavor::FF;
     using UltraRollupProver = UltraProver_<UltraRollupFlavor>;
     using NativeVerifierCommitmentKey = typename AvmFlavor::VerifierCommitmentKey;


### PR DESCRIPTION
- Remove template "BuilderType" from AvmRecursiveFlavor and use MegaCircuitBuilder inside.
- Remove template "Flavor" template from AvmRecursiveVerifier and use AvmRecursiveFlavor inside.
- Remove unused non-goblin recursion constraint handling from the DSL layer: create_avm2_recursion_constraints() in avm2_recursion_constraint.cpp
- Remove non-goblin recursion test