### PR TITLE
feat!: batch txs in reqresp

### DIFF
--- a/yarn-project/p2p/src/client/interface.ts
+++ b/yarn-project/p2p/src/client/interface.ts
@@ -60,7 +60,7 @@ export type P2P<T extends P2PClientType = P2PClientType.Full> = P2PApiFull<T> & 
    * @param pinnedPeerId - An optional peer id that will be used to request the tx from (in addition to other random peers).
    * @returns A list of transactions or undefined if the transactions are not found.
    */
-  requestTxsByHash(txHashes: TxHash[], pinnedPeerId: PeerId): Promise<(Tx | undefined)[]>;
+  requestTxsByHash(txHashes: TxHash[], pinnedPeerId: PeerId): Promise<Tx[]>;
 
   /**
    * Verifies the 'tx' and, if valid, adds it to local tx pool and forwards it to other peers.

--- a/yarn-project/p2p/src/client/p2p_client.integration.test.ts
+++ b/yarn-project/p2p/src/client/p2p_client.integration.test.ts
@@ -1,5 +1,6 @@
 // An integration test for the p2p client to test req resp protocols
 import type { EpochCache } from '@aztec/epoch-cache';
+import { times } from '@aztec/foundation/collection';
 import { Secp256k1Signer } from '@aztec/foundation/crypto';
 import { Fr } from '@aztec/foundation/fields';
 import { type Logger, createLogger } from '@aztec/foundation/log';
@@ -22,6 +23,8 @@ import type { AttestationPool } from '../mem_pools/attestation_pool/attestation_
 import { mockAttestation } from '../mem_pools/attestation_pool/mocks.js';
 import type { TxPool } from '../mem_pools/tx_pool/index.js';
 import type { LibP2PService } from '../services/libp2p/libp2p_service.js';
+import { ReqRespSubProtocol } from '../services/reqresp/interface.js';
+import { chunkTxHashesRequest } from '../services/reqresp/protocols/tx.js';
 import { ReqRespStatus } from '../services/reqresp/status.js';
 import {
   type MakeTestP2PClientOptions,
@@ -279,6 +282,139 @@ describe('p2p client integration', () => {
 
       // Expect the tx to be the returned tx to be the same as the one we mocked
       expect(requestedTx?.toBuffer()).toStrictEqual(tx.toBuffer());
+
+      await shutdown(clients);
+    },
+    TEST_TIMEOUT,
+  );
+
+  it(
+    'request batch of txs from another peer',
+    async () => {
+      const txBatchSize = 8;
+      // We want to create a set of nodes and request transaction from them
+      clients = (
+        await makeAndStartTestP2PClients(3, {
+          p2pBaseConfig,
+          mockAttestationPool: attestationPool,
+          mockTxPool: txPool,
+          mockEpochCache: epochCache,
+          mockWorldState: worldState,
+          logger,
+        })
+      ).map(x => x.client);
+      const [client1] = clients;
+
+      // Give the nodes time to discover each other
+      await sleep(6000);
+      logger.info(`Finished waiting for clients to connect`);
+
+      // Perform a get tx request from client 1
+      const txs = await Promise.all(times(txBatchSize, () => mockTx()));
+      const txHashes = await Promise.all(txs.map(tx => tx.getTxHash()));
+
+      // Mock the tx pool to return the tx we are looking for
+      //@ts-expect-error - txHash is protected and should not be accessed directly outside of the test env.
+      txPool.getTxByHash.mockImplementation((hash: TxHash) => Promise.resolve(txs.find(t => t.txHash?.equals(hash))));
+      //@ts-expect-error - we want to spy on the sendBatchRequest method
+      const sendBatchSpy = jest.spyOn(client1.p2pService, 'sendBatchRequest');
+      //@ts-expect-error - we want to spy on the sendRequestToPeer method
+      const sendRequestToPeerSpy = jest.spyOn(client1.p2pService.reqresp, 'sendRequestToPeer');
+
+      const resultingTxs = await client1.requestTxsByHash(txHashes, undefined);
+      expect(resultingTxs).toHaveLength(txs.length);
+
+      // Expect the tx to be the returned tx to be the same as the one we mocked
+      resultingTxs.forEach((requestedTx, i) => {
+        expect(requestedTx.toBuffer()).toStrictEqual(txs[i].toBuffer());
+      });
+
+      const request = chunkTxHashesRequest(txHashes, txBatchSize);
+      // We have created txs equal to the number of hashes, so we expect the request
+      // length to be just 1, since we are creating only one batch
+      expect(request).toHaveLength(1);
+
+      expect(sendBatchSpy).toHaveBeenCalledWith(
+        ReqRespSubProtocol.TX,
+        request,
+        undefined, // pinnedPeer
+        expect.anything(), // timeoutMs
+        expect.anything(), // maxPeers
+        expect.anything(), // maxRetryAttempts
+      );
+
+      // since we have only 1 batch we send only 1 request
+      expect(sendRequestToPeerSpy).toHaveBeenCalledTimes(1);
+
+      await shutdown(clients);
+    },
+    TEST_TIMEOUT,
+  );
+
+  it(
+    'request batches of txs from another peers',
+    async () => {
+      const txBatchSize = 8;
+      // We want to create a set of nodes and request transaction from them
+      clients = (
+        await makeAndStartTestP2PClients(3, {
+          p2pBaseConfig,
+          mockAttestationPool: attestationPool,
+          mockTxPool: txPool,
+          mockEpochCache: epochCache,
+          mockWorldState: worldState,
+          logger,
+        })
+      ).map(x => x.client);
+      const [client1] = clients;
+
+      // Give the nodes time to discover each other
+      await sleep(6000);
+      logger.info(`Finished waiting for clients to connect`);
+
+      // Perform a get tx request from client 1
+      const txs = await Promise.all(times(txBatchSize + 2, () => mockTx()));
+      const txHashes = await Promise.all(txs.map(tx => tx.getTxHash()));
+
+      // Mock the tx pool to return every other tx we are looking for
+      txPool.getTxByHash.mockImplementation((hash: TxHash) => {
+        //@ts-expect-error - txHash is protected and should not be accessed directly outside of the test env.
+        const idx = txs.findIndex(t => t.txHash.equals(hash));
+        return idx % 2 === 0 ? Promise.resolve(txs[idx]) : Promise.resolve(undefined);
+      });
+      //@ts-expect-error - we want to spy on the sendBatchRequest method
+      const sendBatchSpy = jest.spyOn(client1.p2pService, 'sendBatchRequest');
+      //@ts-expect-error - we want to spy on the sendRequestToPeer method
+      const sendRequestToPeerSpy = jest.spyOn(client1.p2pService.reqresp, 'sendRequestToPeer');
+
+      const resultingTxs = await client1.requestTxsByHash(txHashes, undefined);
+      expect(resultingTxs).toHaveLength(txs.length / 2);
+
+      // Expect the tx to be the returned tx to be the same as the one we mocked
+      // Note we have only returned the half of the txs, so we expect the resulting txs to be every other tx
+      resultingTxs.forEach((requestedTx, i) => {
+        expect(requestedTx.toBuffer()).toStrictEqual(txs[2 * i].toBuffer());
+      });
+
+      const request = chunkTxHashesRequest(txHashes, txBatchSize);
+      // We have created txs equal to the number of hashes + 1, so we expect the request
+      // length to be 2, since we are creating only 2 batches,
+      // 1 with the size of txBatchSize and the other with the size of 1
+      expect(request).toHaveLength(2);
+      expect(request[0]).toHaveLength(txBatchSize);
+      expect(request[1]).toHaveLength(txs.length - txBatchSize);
+
+      expect(sendBatchSpy).toHaveBeenCalledWith(
+        ReqRespSubProtocol.TX,
+        request,
+        undefined, // pinnedPeer
+        expect.anything(), // timeoutMs
+        expect.anything(), // maxPeers
+        expect.anything(), // maxRetryAttempts
+      );
+
+      // since we have only 1 batch we send only 1 request
+      expect(sendRequestToPeerSpy).toHaveBeenCalledTimes(2);
 
       await shutdown(clients);
     },

--- a/yarn-project/p2p/src/client/p2p_client.test.ts
+++ b/yarn-project/p2p/src/client/p2p_client.test.ts
@@ -166,10 +166,8 @@ describe('P2P Client', () => {
     const addTxsSpy = jest.spyOn(txPool, 'addTxs');
 
     // We query for all 3 txs
-    const query = new TxHashArray(
-      ...(await Promise.all([mockTx1.getTxHash(), mockTx2.getTxHash(), mockTx3.getTxHash()])),
-    );
-    const results = await client.requestTxsByHash(query, undefined);
+    const txHashes = await Promise.all([mockTx1.getTxHash(), mockTx2.getTxHash(), mockTx3.getTxHash()]);
+    const results = await client.requestTxsByHash(txHashes, undefined);
 
     // We should receive the found transactions
     expect(results).toEqual([mockTx1, mockTx3]);
@@ -177,7 +175,7 @@ describe('P2P Client', () => {
     // P2P should have been called with the 3 tx hashes
     expect(p2pService.sendBatchRequest).toHaveBeenCalledWith(
       ReqRespSubProtocol.TX,
-      [query],
+      txHashes.map(hash => new TxHashArray(...[hash])),
       undefined,
       expect.anything(),
       expect.anything(),

--- a/yarn-project/p2p/src/client/p2p_client.ts
+++ b/yarn-project/p2p/src/client/p2p_client.ts
@@ -15,7 +15,7 @@ import type { ContractDataSource } from '@aztec/stdlib/contract';
 import { getTimestampForSlot } from '@aztec/stdlib/epoch-helpers';
 import { type PeerInfo, tryStop } from '@aztec/stdlib/interfaces/server';
 import { BlockAttestation, type BlockProposal, type P2PClientType } from '@aztec/stdlib/p2p';
-import type { Tx, TxHash } from '@aztec/stdlib/tx';
+import { type Tx, type TxHash, TxHashArray } from '@aztec/stdlib/tx';
 import {
   Attributes,
   type TelemetryClient,
@@ -373,27 +373,34 @@ export class P2PClient<T extends P2PClientType = P2PClientType.Full>
   /**
    * Uses the batched Request Response protocol to request a set of transactions from the network.
    */
-  public async requestTxsByHash(txHashes: TxHash[], pinnedPeerId: PeerId | undefined): Promise<(Tx | undefined)[]> {
+  public async requestTxsByHash(txHashes: TxHash[], pinnedPeerId: PeerId | undefined): Promise<Tx[]> {
     const timeoutMs = 8000; // Longer timeout for now
     const maxPeers = Math.min(Math.ceil(txHashes.length / 3), 10);
     const maxRetryAttempts = 10; // Keep retrying within the timeout
+    // Per: https://github.com/AztecProtocol/aztec-packages/issues/15149#issuecomment-2999054485
+    // we define Q as max number of transactions per batch, the comment explains why we use 8.
+    const maxTxsPerBatch = 8;
+    const batches: Array<TxHashArray> = [];
+    for (let i = 0; i < txHashes.length; i += maxTxsPerBatch) {
+      batches.push(new TxHashArray(...txHashes.slice(i, i + maxTxsPerBatch)));
+    }
 
-    const txs = await this.p2pService.sendBatchRequest(
+    const txBatches = await this.p2pService.sendBatchRequest(
       ReqRespSubProtocol.TX,
-      txHashes,
+      batches,
       pinnedPeerId,
       timeoutMs,
       maxPeers,
       maxRetryAttempts,
     );
 
-    // Some transactions may return undefined, so we filter them out
-    const filteredTxs = txs.filter((tx): tx is Tx => !!tx);
-    if (filteredTxs.length > 0) {
-      await this.txPool.addTxs(filteredTxs);
+    const txs = txBatches.flatMap(t => t);
+    if (txs.length > 0) {
+      await this.txPool.addTxs(txs);
     }
-    const txHashesStr = txHashes.map(tx => tx.toString()).join(', ');
-    this.log.debug(`Requested txs ${txHashesStr} (${filteredTxs.length} / ${txHashes.length}) from peers`);
+
+    //const txHashesStr = txHashes.map(tx => tx.toString()).join(', ');
+    //this.log.debug(`Requested txs ${txHashesStr} (${filteredTxs.length} / ${txHashes.length}) from peers`);
 
     // We return all transactions, even the not found ones to the caller, such they can handle missing items themselves.
     return txs;
@@ -514,8 +521,6 @@ export class P2PClient<T extends P2PClientType = P2PClientType.Full>
     }
 
     const missingTxs = await this.requestTxsByHash(missingTxHashes, pinnedPeerId);
-    const fetchedMissingTxs = missingTxs.filter((tx): tx is Tx => !!tx);
-
     // TODO: optimize
     // Merge the found txs in order
     const mergingTxsPromises = txHashes.map(async txHash => {
@@ -527,8 +532,9 @@ export class P2PClient<T extends P2PClientType = P2PClientType.Full>
       }
 
       // Is it in the fetched missing txs?
-      for (const tx of fetchedMissingTxs) {
-        if (tx !== undefined && (await tx.getTxHash()).equals(txHash)) {
+      // Note: this is an O(n^2) operation, but we expect the number of missing txs to be small.
+      for (const tx of missingTxs) {
+        if ((await tx.getTxHash()).equals(txHash)) {
           return tx;
         }
       }

--- a/yarn-project/p2p/src/services/dummy_service.ts
+++ b/yarn-project/p2p/src/services/dummy_service.ts
@@ -209,13 +209,13 @@ export class DummyReqResp implements ReqRespInterface {
   }
   sendBatchRequest<SubProtocol extends ReqRespSubProtocol>(
     _subProtocol: SubProtocol,
-    requests: InstanceType<SubProtocolMap[SubProtocol]['request']>[],
+    _requests: InstanceType<SubProtocolMap[SubProtocol]['request']>[],
     _pinnedPeer: PeerId | undefined,
     _timeoutMs?: number,
     _maxPeers?: number,
     _maxRetryAttempts?: number,
-  ): Promise<(InstanceType<SubProtocolMap[SubProtocol]['response']> | undefined)[]> {
-    return Promise.resolve(requests.map(() => undefined));
+  ): Promise<InstanceType<SubProtocolMap[SubProtocol]['response']>[]> {
+    return Promise.resolve([]);
   }
   public sendRequestToPeer(
     _peerId: PeerId,

--- a/yarn-project/p2p/src/services/reqresp/interface.ts
+++ b/yarn-project/p2p/src/services/reqresp/interface.ts
@@ -94,6 +94,14 @@ export const DEFAULT_SUB_PROTOCOL_VALIDATORS: ReqRespSubProtocolValidators = {
   [ReqRespSubProtocol.BLOCK]: noopValidator,
 };
 
+/*
+ * Helper class to sub-protocol validation error*/
+export class ValidationError extends Error {
+  constructor(message: string) {
+    super(message);
+  }
+}
+
 /**
  * Sub protocol map determines the request and response types for each
  * Req Resp protocol

--- a/yarn-project/p2p/src/services/reqresp/interface.ts
+++ b/yarn-project/p2p/src/services/reqresp/interface.ts
@@ -1,6 +1,6 @@
 import { Fr } from '@aztec/foundation/fields';
 import { L2Block } from '@aztec/stdlib/block';
-import { Tx, TxHash } from '@aztec/stdlib/tx';
+import { TxArray, TxHashArray } from '@aztec/stdlib/tx';
 
 import type { PeerId } from '@libp2p/interface';
 
@@ -191,8 +191,8 @@ export const subProtocolMap = {
     response: StatusMessage,
   },
   [ReqRespSubProtocol.TX]: {
-    request: TxHash,
-    response: Tx,
+    request: TxHashArray,
+    response: TxArray,
   },
   [ReqRespSubProtocol.GOODBYE]: {
     request: RequestableBuffer,
@@ -217,7 +217,7 @@ export interface ReqRespInterface {
     timeoutMs?: number,
     maxPeers?: number,
     maxRetryAttempts?: number,
-  ): Promise<(InstanceType<SubProtocolMap[SubProtocol]['response']> | undefined)[]>;
+  ): Promise<InstanceType<SubProtocolMap[SubProtocol]['response']>[]>;
   sendRequestToPeer(
     peerId: PeerId,
     subProtocol: ReqRespSubProtocol,

--- a/yarn-project/p2p/src/services/reqresp/protocols/tx.ts
+++ b/yarn-project/p2p/src/services/reqresp/protocols/tx.ts
@@ -1,5 +1,6 @@
+import { chunk } from '@aztec/foundation/collection';
 import type { P2PClientType } from '@aztec/stdlib/p2p';
-import { TxArray, TxHashArray } from '@aztec/stdlib/tx';
+import { TxArray, TxHash, TxHashArray } from '@aztec/stdlib/tx';
 
 import type { PeerId } from '@libp2p/interface';
 
@@ -34,10 +35,22 @@ export function reqRespTxHandler<T extends P2PClientType>(mempools: MemPools<T>)
       const txs = new TxArray(
         ...(await Promise.all(txHashes.map(txHash => mempools.txPool.getTxByHash(txHash)))).filter(t => !!t),
       );
-      const buf = txs.length > 0 ? txs.toBuffer() : Buffer.alloc(0);
-      return buf;
+      return txs.toBuffer();
     } catch (err: any) {
       throw new ReqRespStatusError(ReqRespStatus.INTERNAL_ERROR, { cause: err });
     }
   };
+}
+
+/**
+ * Helper function to chunk an array of transaction hashes into chunks of a specified size.
+ * This is mainly used in ReqResp in order not to request too many transactions at once from the single peer.
+ *
+ * @param hashes - The array of transaction hashes to chunk.
+ * @param chunkSize - The size of each chunk. Default is 8. Reasoning:
+ *  Per: https://github.com/AztecProtocol/aztec-packages/issues/15149#issuecomment-2999054485
+ *  we define Q as max number of transactions per batch, the comment explains why we use 8.
+ */
+export function chunkTxHashesRequest(hashes: TxHash[], chunkSize = 8): Array<TxHashArray> {
+  return chunk(hashes, chunkSize).map(chunk => new TxHashArray(...chunk));
 }

--- a/yarn-project/p2p/src/services/reqresp/protocols/tx.ts
+++ b/yarn-project/p2p/src/services/reqresp/protocols/tx.ts
@@ -51,6 +51,8 @@ export function reqRespTxHandler<T extends P2PClientType>(mempools: MemPools<T>)
  *  Per: https://github.com/AztecProtocol/aztec-packages/issues/15149#issuecomment-2999054485
  *  we define Q as max number of transactions per batch, the comment explains why we use 8.
  */
-export function chunkTxHashesRequest(hashes: TxHash[], chunkSize = 8): Array<TxHashArray> {
+//TODO: (mralj) chunk size should by default be 8, this is just temporary until the protocol is implemented correctly
+//more info:  https://github.com/AztecProtocol/aztec-packages/pull/15516#pullrequestreview-2995474321
+export function chunkTxHashesRequest(hashes: TxHash[], chunkSize = 1): Array<TxHashArray> {
   return chunk(hashes, chunkSize).map(chunk => new TxHashArray(...chunk));
 }

--- a/yarn-project/p2p/src/services/reqresp/reqresp.ts
+++ b/yarn-project/p2p/src/services/reqresp/reqresp.ts
@@ -178,9 +178,9 @@ export class ReqResp implements ReqRespInterface {
     timeoutMs = 10000,
     maxPeers = Math.max(10, Math.ceil(requests.length / 3)),
     maxRetryAttempts = 3,
-  ): Promise<(InstanceType<SubProtocolMap[SubProtocol]['response']> | undefined)[]> {
+  ): Promise<InstanceType<SubProtocolMap[SubProtocol]['response']>[]> {
     const responseValidator = this.subProtocolValidators[subProtocol];
-    const responses: (InstanceType<SubProtocolMap[SubProtocol]['response']> | undefined)[] = new Array(requests.length);
+    const responses: InstanceType<SubProtocolMap[SubProtocol]['response']>[] = new Array(requests.length);
     const requestBuffers = requests.map(req => req.toBuffer());
 
     const requestFunction = async (signal: AbortSignal) => {
@@ -311,7 +311,7 @@ export class ReqResp implements ReqRespInterface {
     };
 
     try {
-      return await executeTimeout<(InstanceType<SubProtocolMap[SubProtocol]['response']> | undefined)[]>(
+      return await executeTimeout<InstanceType<SubProtocolMap[SubProtocol]['response']>[]>(
         requestFunction,
         timeoutMs,
         () => new CollectiveReqRespTimeoutError(),

--- a/yarn-project/p2p/src/services/service.ts
+++ b/yarn-project/p2p/src/services/service.ts
@@ -54,7 +54,7 @@ export interface P2PService {
     timeoutMs?: number,
     maxPeers?: number,
     maxRetryAttempts?: number,
-  ): Promise<(InstanceType<SubProtocolMap[Protocol]['response']> | undefined)[]>;
+  ): Promise<InstanceType<SubProtocolMap[Protocol]['response']>[]>;
 
   // Leaky abstraction: fix https://github.com/AztecProtocol/aztec-packages/issues/7963
   registerBlockReceivedCallback(callback: P2PBlockReceivedCallback): void;

--- a/yarn-project/p2p/src/services/tx_collection/tx_collection.test.ts
+++ b/yarn-project/p2p/src/services/tx_collection/tx_collection.test.ts
@@ -6,7 +6,7 @@ import { TestDateProvider } from '@aztec/foundation/timer';
 import { L2Block } from '@aztec/stdlib/block';
 import { EmptyL1RollupConstants, type L1RollupConstants } from '@aztec/stdlib/epoch-helpers';
 import type { BlockProposal } from '@aztec/stdlib/p2p';
-import { Tx, TxArray, TxHash, TxHashArray, type TxWithHash } from '@aztec/stdlib/tx';
+import { Tx, TxArray, TxHash, type TxWithHash } from '@aztec/stdlib/tx';
 
 import { jest } from '@jest/globals';
 import type { PeerId } from '@libp2p/interface';
@@ -15,6 +15,7 @@ import { type MockProxy, mock } from 'jest-mock-extended';
 import type { TxPool } from '../../mem_pools/index.js';
 import type { TxPoolEvents } from '../../mem_pools/tx_pool/tx_pool.js';
 import { type ReqRespInterface, ReqRespSubProtocol } from '../reqresp/interface.js';
+import { chunkTxHashesRequest } from '../reqresp/protocols/tx.js';
 import { type TxCollectionConfig, txCollectionConfigMappings } from './config.js';
 import { FastTxCollection } from './fast_tx_collection.js';
 import type { SlowTxCollection } from './slow_tx_collection.js';
@@ -77,15 +78,9 @@ describe('TxCollection', () => {
   };
 
   const expectReqRespToHaveBeenCalledWith = (txHashes: TxHash[], opts: { pinnedPeer?: PeerId } = {}) => {
-    const maxTxsPerBatch = 8;
-    const batches: Array<TxHashArray> = [];
-    for (let i = 0; i < txHashes.length; i += maxTxsPerBatch) {
-      batches.push(new TxHashArray(...txHashes.slice(i, i + maxTxsPerBatch)));
-    }
-
     expect(reqResp.sendBatchRequest).toHaveBeenCalledWith(
       ReqRespSubProtocol.TX,
-      batches,
+      chunkTxHashesRequest(txHashes),
       opts.pinnedPeer,
       expect.any(Number),
       expect.any(Number),

--- a/yarn-project/stdlib/src/tx/tx.ts
+++ b/yarn-project/stdlib/src/tx/tx.ts
@@ -332,3 +332,19 @@ function hasHash(tx: Tx | HasHash): tx is HasHash {
 }
 
 export type TxWithHash = Tx & { txHash: TxHash };
+
+/**
+ * Helper class to handle Serialization and Deserialization of Txs array.
+ **/
+export class TxArray extends Array<Tx> {
+  static fromBuffer(buffer: Buffer | BufferReader): TxArray {
+    const reader = BufferReader.asReader(buffer);
+    const txs = reader.readVector(Tx);
+
+    return new TxArray(...txs);
+  }
+
+  public toBuffer(): Buffer {
+    return serializeArrayOfBufferableToVector(this);
+  }
+}

--- a/yarn-project/stdlib/src/tx/tx.ts
+++ b/yarn-project/stdlib/src/tx/tx.ts
@@ -338,10 +338,14 @@ export type TxWithHash = Tx & { txHash: TxHash };
  **/
 export class TxArray extends Array<Tx> {
   static fromBuffer(buffer: Buffer | BufferReader): TxArray {
-    const reader = BufferReader.asReader(buffer);
-    const txs = reader.readVector(Tx);
+    try {
+      const reader = BufferReader.asReader(buffer);
+      const txs = reader.readVector(Tx);
 
-    return new TxArray(...txs);
+      return new TxArray(...txs);
+    } catch {
+      return new TxArray();
+    }
   }
 
   public toBuffer(): Buffer {

--- a/yarn-project/stdlib/src/tx/tx_hash.ts
+++ b/yarn-project/stdlib/src/tx/tx_hash.ts
@@ -1,5 +1,5 @@
 import { Fr } from '@aztec/foundation/fields';
-import { BufferReader } from '@aztec/foundation/serialize';
+import { BufferReader, serializeArrayOfBufferableToVector } from '@aztec/foundation/serialize';
 
 import { schemas } from '../schemas/index.js';
 
@@ -64,5 +64,21 @@ export class TxHash {
 
   static get SIZE() {
     return Fr.SIZE_IN_BYTES;
+  }
+}
+
+/**
+ * Helper class to handle Serialization and Deserialization of TxHashes array.
+ **/
+export class TxHashArray extends Array<TxHash> {
+  static fromBuffer(buffer: Buffer | BufferReader) {
+    const reader = BufferReader.asReader(buffer);
+    const hashes = reader.readVector(TxHash);
+
+    return new TxHashArray(...hashes);
+  }
+
+  public toBuffer(): Buffer {
+    return serializeArrayOfBufferableToVector([...this]);
   }
 }

--- a/yarn-project/stdlib/src/tx/tx_hash.ts
+++ b/yarn-project/stdlib/src/tx/tx_hash.ts
@@ -72,10 +72,14 @@ export class TxHash {
  **/
 export class TxHashArray extends Array<TxHash> {
   static fromBuffer(buffer: Buffer | BufferReader) {
-    const reader = BufferReader.asReader(buffer);
-    const hashes = reader.readVector(TxHash);
+    try {
+      const reader = BufferReader.asReader(buffer);
+      const hashes = reader.readVector(TxHash);
 
-    return new TxHashArray(...hashes);
+      return new TxHashArray(...hashes);
+    } catch {
+      return new TxHashArray();
+    }
   }
 
   public toBuffer(): Buffer {

--- a/yarn-project/txe/src/state_machine/dummy_p2p_client.ts
+++ b/yarn-project/txe/src/state_machine/dummy_p2p_client.ts
@@ -129,7 +129,7 @@ export class DummyP2P implements P2P {
     throw new Error('DummyP2P does not implement "sync"');
   }
 
-  public requestTxsByHash(_txHashes: TxHash[]): Promise<(Tx | undefined)[]> {
+  public requestTxsByHash(_txHashes: TxHash[]): Promise<Tx[]> {
     throw new Error('DummyP2P does not implement "requestTxsByHash"');
   }
 


### PR DESCRIPTION
When requesting Transaction(s) from a peer, always request them as a batch of transactions. 
This implies that a single transaction is encoded as a batch of `[tx]`.