### PR TITLE
fix: Simulate rollup contract instead of multicall

### DIFF
--- a/yarn-project/end-to-end/src/integration/integration_l1_publisher.test.ts
+++ b/yarn-project/end-to-end/src/integration/integration_l1_publisher.test.ts
@@ -2,6 +2,7 @@ import type { ArchiveSource } from '@aztec/archiver';
 import { getConfigEnvVars } from '@aztec/aztec-node';
 import { AztecAddress, Fr, GlobalVariables, type L2Block, createLogger } from '@aztec/aztec.js';
 import { BatchedBlob, Blob } from '@aztec/blob-lib';
+import { createBlobSinkClient } from '@aztec/blob-sink/client';
 import { GENESIS_ARCHIVE_ROOT, MAX_NULLIFIERS_PER_TX, NUMBER_OF_L1_L2_MESSAGES_PER_ROLLUP } from '@aztec/constants';
 import { EpochCache } from '@aztec/epoch-cache';
 import {
@@ -14,12 +15,13 @@ import {
   createExtendedL1Client,
 } from '@aztec/ethereum';
 import { L1TxUtilsWithBlobs } from '@aztec/ethereum/l1-tx-utils-with-blobs';
-import { EthCheatCodesWithState } from '@aztec/ethereum/test';
+import { EthCheatCodesWithState, startAnvil } from '@aztec/ethereum/test';
 import { range } from '@aztec/foundation/array';
 import { timesParallel } from '@aztec/foundation/collection';
 import { SecretValue } from '@aztec/foundation/config';
 import { SHA256Trunc, sha256ToField } from '@aztec/foundation/crypto';
 import { EthAddress } from '@aztec/foundation/eth-address';
+import { hexToBuffer } from '@aztec/foundation/string';
 import { TestDateProvider } from '@aztec/foundation/timer';
 import { openTmpStore } from '@aztec/kv-store/lmdb';
 import { OutboxAbi, RollupAbi } from '@aztec/l1-artifacts';
@@ -40,6 +42,7 @@ import {
 } from '@aztec/world-state';
 
 import { beforeEach, describe, expect, it, jest } from '@jest/globals';
+import type { Anvil } from '@viem/anvil';
 import { writeFile } from 'fs/promises';
 import { type MockProxy, mock } from 'jest-mock-extended';
 import {
@@ -64,12 +67,8 @@ const deployerPK = '0x8b3a350cf5c34c9194ca85829a2df0ec3153be0318b5e2d3348e872092
 const logger = createLogger('integration_l1_publisher');
 
 const config = getConfigEnvVars();
-config.l1RpcUrls = config.l1RpcUrls || ['http://127.0.0.1:8545'];
 
 const numberOfConsecutiveBlocks = 2;
-
-const BLOB_SINK_PORT = 5052;
-const BLOB_SINK_URL = `http://localhost:${BLOB_SINK_PORT}`;
 
 jest.setTimeout(1000000);
 
@@ -105,6 +104,9 @@ describe('L1Publisher integration', () => {
   let ethCheatCodes: EthCheatCodesWithState;
   let worldStateSynchronizer: ServerWorldStateSynchronizer;
 
+  let rpcUrl: string;
+  let anvil: Anvil;
+
   // To update the test data, run "export AZTEC_GENERATE_TEST_DATA=1" in shell and run the tests again
   // If you have issues with RPC_URL, it is likely that you need to set the RPC_URL in the shell as well
   // If running ANVIL locally, you can use ETHEREUM_HOSTS="http://0.0.0.0:8545"
@@ -120,6 +122,9 @@ describe('L1Publisher integration', () => {
   };
 
   beforeEach(async () => {
+    ({ rpcUrl, anvil } = await startAnvil());
+    config.l1RpcUrls = [rpcUrl];
+
     deployerAccount = privateKeyToAccount(deployerPK);
     ({ l1ContractAddresses, l1Client } = await setupL1Contracts(config.l1RpcUrls, deployerAccount, logger, {
       aztecTargetCommitteeSize: 0,
@@ -195,19 +200,21 @@ describe('L1Publisher integration', () => {
     );
     const dateProvider = new TestDateProvider();
     const epochCache = await EpochCache.create(l1ContractAddresses.rollupAddress, config, { dateProvider });
+    const blobSinkClient = createBlobSinkClient();
+
     publisher = new SequencerPublisher(
       {
         l1RpcUrls: config.l1RpcUrls,
         l1Contracts: l1ContractAddresses,
         publisherPrivateKey: new SecretValue(sequencerPK),
         l1PublishRetryIntervalMS: 100,
-        l1ChainId: 31337,
+        l1ChainId: chainId,
         viemPollingIntervalMS: 100,
         ethereumSlotDuration: config.ethereumSlotDuration,
-        blobSinkUrl: BLOB_SINK_URL,
         customForwarderContractAddress: EthAddress.ZERO,
       },
       {
+        blobSinkClient,
         l1TxUtils,
         rollupContract,
         epochCache,
@@ -235,6 +242,7 @@ describe('L1Publisher integration', () => {
   });
 
   afterEach(async () => {
+    await anvil.stop();
     await worldStateSynchronizer.stop();
   });
 
@@ -346,7 +354,7 @@ describe('L1Publisher integration', () => {
 
     const buildAndPublishBlock = async (numTxs: number, jsonFileNamePrefix: string) => {
       const archiveInRollup_ = await rollup.archive();
-      expect(hexStringToBuffer(archiveInRollup_.toString())).toEqual(new Fr(GENESIS_ARCHIVE_ROOT).toBuffer());
+      expect(hexToBuffer(archiveInRollup_.toString())).toEqual(new Fr(GENESIS_ARCHIVE_ROOT).toBuffer());
 
       const blockNumber = await l1Client.getBlockNumber();
 
@@ -409,7 +417,7 @@ describe('L1Publisher integration', () => {
           sha256ToField(blockBlobs.map(b => b.getEthVersionedBlobHash())),
         );
 
-        let prevBlobAccumulatorHash = hexStringToBuffer(await rollup.getCurrentBlobCommitmentsHash());
+        let prevBlobAccumulatorHash = hexToBuffer(await rollup.getCurrentBlobCommitmentsHash());
 
         blocks.push(block);
         allBlobs.push(...blockBlobs);
@@ -446,7 +454,7 @@ describe('L1Publisher integration', () => {
           (await rollup.getEpochNumber(thisBlockNumber)) > (await rollup.getEpochNumber(thisBlockNumber - 1n));
         // If we are at the first blob of the epoch, we must initialise the hash:
         prevBlobAccumulatorHash = isFirstBlockOfEpoch ? Buffer.alloc(0) : prevBlobAccumulatorHash;
-        const currentBlobAccumulatorHash = hexStringToBuffer(await rollup.getCurrentBlobCommitmentsHash());
+        const currentBlobAccumulatorHash = hexToBuffer(await rollup.getCurrentBlobCommitmentsHash());
         let expectedBlobAccumulatorHash = prevBlobAccumulatorHash;
         blockBlobs
           .map(b => b.commitment)
@@ -526,10 +534,10 @@ describe('L1Publisher integration', () => {
   describe('error handling', () => {
     let loggerErrorSpy: ReturnType<(typeof jest)['spyOn']>;
 
-    it.skip(`shows propose custom errors if tx reverts`, async () => {
+    it(`shows propose custom errors if tx simulation fails`, async () => {
       // REFACTOR: code below is duplicated from "builds blocks of 2 empty txs building on each other"
       const archiveInRollup_ = await rollup.archive();
-      expect(hexStringToBuffer(archiveInRollup_.toString())).toEqual(new Fr(GENESIS_ARCHIVE_ROOT).toBuffer());
+      expect(hexToBuffer(archiveInRollup_.toString())).toEqual(new Fr(GENESIS_ARCHIVE_ROOT).toBuffer());
 
       // Set up different l1-to-l2 messages than the ones on the inbox, so this submission reverts
       // because the INBOX.consume does not match the header.contentCommitment.inHash and we get
@@ -554,65 +562,15 @@ describe('L1Publisher integration', () => {
       prevHeader = block.header;
       blockSource.getL1ToL2Messages.mockResolvedValueOnce(l1ToL2Messages);
 
-      // Inspect logger
+      // Expect the simulation to fail
       loggerErrorSpy = jest.spyOn((publisher as any).log, 'error');
-
-      // Expect the tx to revert
-      expect(await publisher.enqueueProposeL2Block(block)).toEqual(true);
-
-      await expect(publisher.sendRequests()).resolves.toMatchObject({
-        errorMsg: expect.stringContaining('Rollup__InvalidInHash'),
-      });
-
-      // Test for both calls
-      // NOTE: First error is from the simulate fn, which isn't supported by anvil
-      expect(loggerErrorSpy).toHaveBeenCalledTimes(3);
-
-      expect(loggerErrorSpy).toHaveBeenNthCalledWith(
-        1,
-        'Forwarder transaction failed',
-        undefined,
-        expect.objectContaining({
-          receipt: expect.objectContaining({
-            type: 'eip4844',
-            blockHash: expect.any(String),
-            blockNumber: expect.any(BigInt),
-            transactionHash: expect.any(String),
-          }),
-        }),
-      );
+      await expect(publisher.enqueueProposeL2Block(block)).rejects.toThrow(/Rollup__InvalidInHash/);
       expect(loggerErrorSpy).toHaveBeenNthCalledWith(
         2,
-        expect.stringContaining('Bundled [propose] transaction [failed]'),
-      );
-
-      expect(loggerErrorSpy).toHaveBeenNthCalledWith(
-        3,
-        expect.stringMatching(
-          /^Rollup process tx reverted\. The contract function "forward" reverted\. Error: Rollup__InvalidInHash/i,
-        ),
+        expect.stringMatching('Rollup__InvalidInHash'),
         undefined,
-        expect.objectContaining({
-          blockNumber: expect.any(Number),
-          slotNumber: expect.any(BigInt),
-          txHash: expect.any(String),
-          txCount: expect.any(Number),
-          blockTimestamp: expect.any(Number),
-        }),
+        expect.objectContaining({ blockNumber: 1 }),
       );
     });
   });
 });
-
-/**
- * Converts a hex string into a buffer. String may be 0x-prefixed or not.
- */
-function hexStringToBuffer(hex: string): Buffer {
-  if (!/^(0x)?[a-fA-F0-9]+$/.test(hex)) {
-    throw new Error(`Invalid format for hex string: "${hex}"`);
-  }
-  if (hex.length % 2 === 1) {
-    throw new Error(`Invalid length for hex string: "${hex}"`);
-  }
-  return Buffer.from(hex.replace(/^0x/, ''), 'hex');
-}

--- a/yarn-project/ethereum/src/contracts/multicall.ts
+++ b/yarn-project/ethereum/src/contracts/multicall.ts
@@ -119,6 +119,12 @@ export class Multicall3 {
 }
 
 export async function deployMulticall3(l1Client: ExtendedViemWalletClient, logger: Logger) {
+  const existing = await l1Client.getCode({ address: MULTI_CALL_3_ADDRESS });
+  if (existing && existing !== '0x') {
+    logger.verbose('Multicall3 already deployed', { address: MULTI_CALL_3_ADDRESS });
+    return;
+  }
+
   const deployer = '0x05f32b3cc3888453ff71b01135b34ff8e41263f2';
   const sendEth = await l1Client.sendTransaction({ to: deployer, value: 10n ** 17n });
   logger.info('Sent 0.1 ETH to deployer', { deployer, value: 10n ** 17n });

--- a/yarn-project/ethereum/src/deploy_l1_contracts.ts
+++ b/yarn-project/ethereum/src/deploy_l1_contracts.ts
@@ -76,6 +76,7 @@ import {
   getRewardBoostConfig,
   getRewardConfig,
 } from './config.js';
+import { deployMulticall3 } from './contracts/multicall.js';
 import { RegistryContract } from './contracts/registry.js';
 import { RollupContract } from './contracts/rollup.js';
 import type { L1ContractAddresses } from './l1_contract_addresses.js';
@@ -986,6 +987,9 @@ export const deployL1Contracts = async (
   txUtilsConfig: L1TxUtilsConfig = getL1TxUtilsConfigEnvVars(),
 ): Promise<DeployL1ContractsReturnType> => {
   const l1Client = createExtendedL1Client(rpcUrls, account, chain);
+
+  // Deploy multicall3 if it does not exist in this network
+  await deployMulticall3(l1Client, logger);
 
   // We are assuming that you are running this on a local anvil node which have 1s block times
   // To align better with actual deployment, we update the block interval to 12s

--- a/yarn-project/ethereum/src/l1_tx_utils.ts
+++ b/yarn-project/ethereum/src/l1_tx_utils.ts
@@ -490,20 +490,15 @@ export class ReadOnlyL1TxUtils {
         ],
       });
 
-      this.logger?.debug(`L1 gas used in simulation: ${result[0].calls[0].gasUsed}`, {
-        result,
-      });
       if (result[0].calls[0].status === 'failure') {
-        this.logger?.error('L1 transaction simulation failed', {
-          error: result[0].calls[0].error,
-        });
-        const decodedError = decodeErrorResult({
-          abi,
-          data: result[0].calls[0].data,
-        });
+        this.logger?.error('L1 transaction simulation failed', result[0].calls[0].error);
+        const decodedError = decodeErrorResult({ abi, data: result[0].calls[0].data });
 
-        throw new Error(`L1 transaction simulation failed with error: ${decodedError.errorName}`);
+        throw new Error(
+          `L1 transaction simulation failed with error ${decodedError.errorName}(${decodedError.args?.join(',')})`,
+        );
       }
+      this.logger?.debug(`L1 transaction simulation succeeded`, { ...result[0].calls[0] });
       return { gasUsed: result[0].gasUsed, result: result[0].calls[0].data as `0x${string}` };
     } catch (err) {
       if (err instanceof MethodNotFoundRpcError || err instanceof MethodNotSupportedRpcError) {

--- a/yarn-project/sequencer-client/src/publisher/sequencer-publisher.test.ts
+++ b/yarn-project/sequencer-client/src/publisher/sequencer-publisher.test.ts
@@ -259,9 +259,8 @@ describe('SequencerPublisher', () => {
         },
       ],
       l1TxUtils,
-      // vote + val + (val * 20n) / 100n
       {
-        gasLimit: SequencerPublisher.VOTE_GAS_GUESS + 1_000_000n + GAS_GUESS + ((1_000_000n + GAS_GUESS) * 20n) / 100n,
+        gasLimit: 2085048n,
         txTimeoutAt: undefined,
       },
       { blobs: expectedBlobs.map(b => b.data), kzg },


### PR DESCRIPTION
When simulating a propose on the rollup contract, do it by calling the rollup contract directly instead of multicall. This allows us to extract the simulation error. To account for that, we add some extra gas to the result of the simulation before funneling it through multicall.

The simulation error now looks like this in the logs:
```
[18:05:11.052] ERROR: sequencer:publisher Failed to simulate propose tx: Error: L1 transaction simulation failed with error Rollup__InvalidInHash(0x00089a9d421a82c4a25f7acbebe69e638d5b064fa8a60e018793dcb0be53752c,0x00a5a12af159e0608de45d825718827a36d8a7cdfa9ecc7955bc62180ae78e51)
```

This PR includes other small changes:
- The `integration_l1_publisher` test is no longer a `composed` test. Instead, it just starts its own anvil. This makes it easier to iterate since we do not need to run a full docker-compose environment nor build an aztec image.
- Adds an option to log anvil messages in our log (pass `log: true` to anvil opts). Everything is outputted in debug level.
- When deploying L1 contracts, first checks if multicall3 exists and tries to deploy it if not. I lost over an hour to trying to figure out why my L1 txs were succeeding but not doing anything, and it was because they were sent to the multicall address where there was nothing, and the EVM does not complain if you CALL an empty address.

Fixes https://github.com/AztecProtocol/aztec-packages/issues/15418