### PR TITLE
chore: deflake data withholding

### DIFF
--- a/yarn-project/end-to-end/src/e2e_p2p/data_withholding_slash.test.ts
+++ b/yarn-project/end-to-end/src/e2e_p2p/data_withholding_slash.test.ts
@@ -1,5 +1,4 @@
 import type { AztecNodeService } from '@aztec/aztec-node';
-import { sleep } from '@aztec/aztec.js';
 import { Offense } from '@aztec/slasher';
 
 import { jest } from '@jest/globals';
@@ -115,19 +114,15 @@ describe('e2e_p2p_data_withholding_slash', () => {
     );
 
     await debugRollup();
-    await sleep(4000);
-    await debugRollup();
-
     const committee = await awaitCommitteeExists({ rollup, logger: t.logger });
     await debugRollup();
 
     // Jump forward more time to ensure we're at the beginning of an epoch.
     // This should reduce flake, since we need to have the transaction included
     // and the nodes recreated, prior to the reorg.
-    // Considering the epoch duration is 1,
-    // the proof submission window is 1,
-    // and the aztec slot duration is 20,
-    // we have ~20 seconds to do this.
+    // Considering the slot duration is 32 seconds,
+    // Considering the epoch duration is 2 slots,
+    // we have ~64 seconds to do this.
     {
       const newTime = await t.ctx.cheatCodes.rollup.advanceToEpoch(8n);
       t.ctx.dateProvider.setTime(Number(newTime * 1000n));
@@ -136,15 +131,9 @@ describe('e2e_p2p_data_withholding_slash', () => {
       await debugRollup();
     }
 
-    // Sleep for a few seconds to allow the *previous* epoch to be pruned.
-    await sleep(4000);
-
     // Send Aztec txs
     t.logger.info('Setup account');
     await t.setupAccount();
-    t.logger.info('Deploy spam contract');
-    await t.deploySpamContract();
-
     t.logger.info('Stopping nodes');
     // Note, we needed to keep the initial node running, as that is the one the txs were sent to.
     await t.removeInitialNode();

--- a/yarn-project/slasher/src/epoch_prune_watcher.ts
+++ b/yarn-project/slasher/src/epoch_prune_watcher.ts
@@ -35,6 +35,9 @@ export class EpochPruneWatcher extends (EventEmitter as new () => WatcherEmitter
   // Only keep track of the last N slashable epochs
   private maxSlashableEpochs = 100;
 
+  // Store bound function reference for proper listener removal
+  private boundHandlePruneL2Blocks = this.handlePruneL2Blocks.bind(this);
+
   constructor(
     private l2BlockSource: L2BlockSourceEventEmitter,
     private l1ToL2MessageSource: L1ToL2MessageSource,
@@ -49,12 +52,12 @@ export class EpochPruneWatcher extends (EventEmitter as new () => WatcherEmitter
   }
 
   public start() {
-    this.l2BlockSource.on(L2BlockSourceEvents.L2PruneDetected, this.handlePruneL2Blocks.bind(this));
+    this.l2BlockSource.on(L2BlockSourceEvents.L2PruneDetected, this.boundHandlePruneL2Blocks);
     return Promise.resolve();
   }
 
   public stop() {
-    this.l2BlockSource.removeListener(L2BlockSourceEvents.L2PruneDetected, this.handlePruneL2Blocks.bind(this));
+    this.l2BlockSource.removeListener(L2BlockSourceEvents.L2PruneDetected, this.boundHandlePruneL2Blocks);
     return Promise.resolve();
   }
 


### PR DESCRIPTION
Fixes an issue in the data withholding test where the prune would happen while the node was shutting down. 

The test only works when the node has been restarted and is up/processing and *then* sees the reorg.

Accomplish this by only submitting 1 transaction, rather than 2, which should give the nodes *ample* time (36 seconds) to restart. 

Previously, since we were submitting two transactions in successive blocks, we were too close the the epoch boundary when we went to restart the nodes. 

Separately, fixes an issue with event listener management in the epoch prune watcher.