### PR TITLE
fix: flaky slasher_client.test.ts

### DIFF
--- a/yarn-project/ethereum/src/contracts/slashing_proposer.ts
+++ b/yarn-project/ethereum/src/contracts/slashing_proposer.ts
@@ -113,16 +113,23 @@ export class SlashingProposerContract extends EventEmitter implements IEmpireBas
     );
   }
 
-  public waitForRound(round: bigint, pollingIntervalSeconds: number = 1) {
+  /**
+   * Wait for a round to be reached.
+   *
+   * @param round - The round to wait for.
+   * @param pollingIntervalSeconds - The interval in seconds to poll for the round.
+   * @returns True if the round was reached, false otherwise.
+   */
+  public waitForRound(round: bigint, pollingIntervalSeconds: number = 1): Promise<boolean> {
     return retryUntil(
       async () => {
-        const currentRound = await this.proposer.read.getCurrentRound();
+        const currentRound = await this.proposer.read.getCurrentRound().catch(() => 0n);
         return currentRound >= round;
       },
       `Waiting for round ${round} to be reached`,
       0, // no timeout
       pollingIntervalSeconds,
-    );
+    ).catch(() => false);
   }
 
   public async executeRound(

--- a/yarn-project/slasher/src/slasher_client.ts
+++ b/yarn-project/slasher/src/slasher_client.ts
@@ -449,7 +449,14 @@ export class SlasherClient {
 
     const nextRound = round + 1n;
     this.log.info(`Waiting for round ${nextRound} to be reached`);
-    await this.slashingProposer.waitForRound(nextRound, this.config.slashProposerRoundPollingIntervalSeconds);
+    const reached = await this.slashingProposer.waitForRound(
+      nextRound,
+      this.config.slashProposerRoundPollingIntervalSeconds,
+    );
+    if (!reached) {
+      this.log.error('Round not reached', { proposal, round });
+      return;
+    }
     this.log.info('Executing round', { proposal, round });
 
     await this.slashingProposer


### PR DESCRIPTION
Fixes a bug in the slasher client and slashing proposer.

For the slashing_proposer, if the getting the current round throws, we handle that case and return that the current round is 0.

For the slasher_client, if we timeout waiting for a round, we return early from the `executeRoundIfAgree` function