### PR TITLE
chore: call flushEntryQueue from staking asset handler

### DIFF
--- a/l1-contracts/src/mock/StakingAssetHandler.sol
+++ b/l1-contracts/src/mock/StakingAssetHandler.sol
@@ -344,6 +344,16 @@ contract StakingAssetHandler is IStakingAssetHandler, Ownable {
     STAKING_ASSET.approve(address(_rollup), _depositAmount);
     _rollup.deposit(_attester, withdrawer, true);
     emit ValidatorAdded(address(_rollup), _attester, withdrawer);
+
+    // Try to flush the entry queue, but don't let it revert the deposit
+    // solhint-disable-next-line no-empty-blocks
+    try _rollup.flushEntryQueue() {
+      // Flush succeeded, no action needed
+      // solhint-disable-next-line no-empty-blocks
+    } catch {
+      // Flush failed, but we don't want to revert the deposit
+      // The validator is still in the queue and can be flushed later
+    }
   }
 
   /**

--- a/l1-contracts/test/staking_asset_handler/addValidator.tree
+++ b/l1-contracts/test/staking_asset_handler/addValidator.tree
@@ -20,14 +20,17 @@ AddValidatorTest
     └── given balance GE depositAmount
         ├── given passport proof is not valid
         │   └── it reverts
-        └── given passport proof is valid
-            ├── when user is new
-            │   ├── it exits the attester if needed
-            │   ├── it deposits into the rollup
-            │   └── it emits a {ValidatorAdded} event
-            ├── when passport proof has been used
-            │   └── it reverts
-            ├── when passport proof is in devMode
-            │   └── it reverts
-            └── when passport proof is in the past
-                └── it reverts
+        ├── given passport proof is valid
+        │   ├── when user is new
+        │   │   ├── it exits the attester if needed
+        │   │   ├── it deposits into the rollup
+        │   │   └── it emits a {ValidatorAdded} event
+        │   ├── when passport proof has been used
+        │   │   └── it reverts
+        │   ├── when passport proof is in devMode
+        │   │   └── it reverts
+        │   └── when passport proof is in the past
+        │       └── it reverts
+        └── given call to flushEntryQueue reverts
+            ├── it exits the attester if needed
+            └── it adds the validator to the queue

--- a/l1-contracts/test/staking_asset_handler/reenterExitedValidator.t.sol
+++ b/l1-contracts/test/staking_asset_handler/reenterExitedValidator.t.sol
@@ -39,10 +39,8 @@ contract ReenterExitedValidatorTest is StakingAssetHandlerBase {
 
     // 1. Perform a valid deposit
     vm.prank(_caller);
-    stakingAssetHandler.addValidator(_attester, validMerkleProof, realProof);
-
     emit IStakingAssetHandler.ValidatorAdded(address(staking), _attester, WITHDRAWER);
-    staking.flushEntryQueue();
+    stakingAssetHandler.addValidator(_attester, validMerkleProof, realProof);
 
     // 2. Exit the validator
     vm.prank(WITHDRAWER);

--- a/l1-contracts/test/staking_asset_handler/setWithdrawer.t.sol
+++ b/l1-contracts/test/staking_asset_handler/setWithdrawer.t.sol
@@ -50,7 +50,6 @@ contract SetWithdrawerTest is StakingAssetHandlerBase {
     vm.expectEmit(true, true, true, true, address(stakingAssetHandler));
     emit IStakingAssetHandler.ValidatorAdded(rollup, attester, _newWithdrawer);
     stakingAssetHandler.addValidator(attester, validMerkleProof, realProof);
-    staking.flushEntryQueue();
     assertEq(staking.getAttesterView(attester).config.withdrawer, _newWithdrawer);
   }
 }


### PR DESCRIPTION
We now call flushEntryQueue whenever someone successfully deposits from the staking asset handler. 

We do nothing if the call reverts, but should improve the experience of people trying to join.