### PR TITLE
chore: clean up bridging

### DIFF
--- a/aztec-up/test/bridge_and_claim.sh
+++ b/aztec-up/test/bridge_and_claim.sh
@@ -42,8 +42,7 @@ aztec-wallet \
   --register-only
 
 aztec-wallet \
-  bridge-fee-juice 1000000000000000000 accounts:main \
-  --mint \
+  bridge-fee-juice accounts:main \
   --no-wait
 
 # We need to send these transactions to advance the chain to claim our bridged funds.

--- a/yarn-project/bot/src/factory.ts
+++ b/yarn-project/bot/src/factory.ts
@@ -382,13 +382,12 @@ export class BotFactory {
     const extendedClient = createExtendedL1Client(chain.rpcUrls, mnemonicOrPrivateKey, chain.chainInfo);
 
     const portal = await L1FeeJuicePortalManager.new(this.pxe, extendedClient, this.log);
-    const mintAmount = await portal.getTokenManager().getMintAmount();
-    const claim = await portal.bridgeTokensPublic(recipient, mintAmount, true /* mint */);
+    const claim = await portal.bridgeTokensFromFaucet(recipient);
 
     const isSynced = async () => await this.pxe.isL1ToL2MessageSynced(Fr.fromHexString(claim.messageHash));
     await retryUntil(isSynced, `message ${claim.messageHash} sync`, this.config.l1ToL2MessageTimeoutSeconds, 1);
 
-    this.log.info(`Created a claim for ${mintAmount} L1 fee juice to ${recipient}.`, claim);
+    this.log.info(`Created a claim for ${claim.claimAmount} L1 fee juice to ${recipient}.`, claim);
 
     // Progress by 2 L2 blocks so that the l1ToL2Message added above will be available to use on L2.
     await this.advanceL2Block();

--- a/yarn-project/cli-wallet/src/cmds/bridge_fee_juice.ts
+++ b/yarn-project/cli-wallet/src/cmds/bridge_fee_juice.ts
@@ -6,14 +6,12 @@ import type { LogFn, Logger } from '@aztec/foundation/log';
 import type { AztecAddress } from '@aztec/stdlib/aztec-address';
 
 export async function bridgeL1FeeJuice(
-  amount: bigint,
   recipient: AztecAddress,
   pxe: PXE,
   l1RpcUrls: string[],
   chainId: number,
   privateKey: string | undefined,
   mnemonic: string,
-  mint: boolean,
   json: boolean,
   wait: boolean,
   interval = 60_000,
@@ -30,11 +28,7 @@ export async function bridgeL1FeeJuice(
 
   // Setup portal manager
   const portal = await L1FeeJuicePortalManager.new(pxe, client, debugLogger);
-  const { claimAmount, claimSecret, messageHash, messageLeafIndex } = await portal.bridgeTokensPublic(
-    recipient,
-    amount,
-    mint,
-  );
+  const { claimAmount, claimSecret, messageHash, messageLeafIndex } = await portal.bridgeTokensFromFaucet(recipient);
 
   if (json) {
     const out = {
@@ -44,11 +38,7 @@ export async function bridgeL1FeeJuice(
     };
     log(prettyPrintJSON(out));
   } else {
-    if (mint) {
-      log(`Minted ${claimAmount} fee juice on L1 and pushed to L2 portal`);
-    } else {
-      log(`Bridged ${claimAmount} fee juice to L2 portal`);
-    }
+    log(`Minted ${claimAmount} fee juice on L1 and pushed to L2 portal`);
     log(
       `claimAmount=${claimAmount},claimSecret=${claimSecret},messageHash=${messageHash},messageLeafIndex=${messageLeafIndex}\n`,
     );
@@ -84,5 +74,5 @@ export async function bridgeL1FeeJuice(
     }
   }
 
-  return [claimSecret, messageLeafIndex] as const;
+  return [claimSecret, messageLeafIndex, claimAmount] as const;
 }

--- a/yarn-project/cli-wallet/test/flows/create_account_pay_native.sh
+++ b/yarn-project/cli-wallet/test/flows/create_account_pay_native.sh
@@ -7,7 +7,7 @@ test_title "Create an account and deploy using native fee payment with bridging"
 
 # docs:start:bridge-fee-juice
 aztec-wallet create-account -a main --register-only
-aztec-wallet bridge-fee-juice 1000000000000000000 main --mint --no-wait
+aztec-wallet bridge-fee-juice main --no-wait
 # docs:end:bridge-fee-juice
 
 

--- a/yarn-project/cli-wallet/test/flows/shared/create_funded_account.sh
+++ b/yarn-project/cli-wallet/test/flows/shared/create_funded_account.sh
@@ -3,7 +3,7 @@ ALIAS=$1
 section "Creating a funded account (alias: $ALIAS)"
 
 aztec-wallet create-account -a $ALIAS --register-only
-aztec-wallet bridge-fee-juice 1000000000000000000 $ALIAS --mint --no-wait
+aztec-wallet bridge-fee-juice $ALIAS --no-wait
 
 # The following produces two blocks, allowing the claim to be used in the next block.
 source $flows/shared/deploy_token.sh tmp-token-$ALIAS $ALIAS

--- a/yarn-project/cli-wallet/test/flows/shared/deploy_main_account_and_token.sh
+++ b/yarn-project/cli-wallet/test/flows/shared/deploy_main_account_and_token.sh
@@ -4,7 +4,7 @@ ACCOUNT_ALIAS=main
 section "Deploying token contract (alias: $TOKEN_ALIAS) and creating a funded account (alias: $ACCOUNT_ALIAS)"
 
 aztec-wallet create-account -a $ACCOUNT_ALIAS --register-only
-aztec-wallet bridge-fee-juice 1000000000000000000 $ACCOUNT_ALIAS --mint --no-wait
+aztec-wallet bridge-fee-juice $ACCOUNT_ALIAS --no-wait
 
 # Deploy token contract and set the main account as a minter.
 # The following produces two blocks, allowing the claim to be used in the next block.

--- a/yarn-project/cli-wallet/test/flows/shared/deploy_sponsored_fpc_and_token.sh
+++ b/yarn-project/cli-wallet/test/flows/shared/deploy_sponsored_fpc_and_token.sh
@@ -6,7 +6,7 @@ section "Deploying token contract (alias: $TOKEN_ALIAS) and creating a sponsored
 aztec-wallet import-test-accounts
 aztec-wallet deploy sponsored_fpc_contract@SponsoredFPC -f test0 -a $FPC_ALIAS --no-init
 
-CLAIM=$(aztec-wallet bridge-fee-juice 1000000000000000000 contracts:$FPC_ALIAS --mint --no-wait --json)
+CLAIM=$(aztec-wallet bridge-fee-juice contracts:$FPC_ALIAS --no-wait --json)
 
 retrieve () {
   echo "$CLAIM" | grep "\"$1\"" | awk -F ': ' '{print $2}' | tr -d '",'

--- a/yarn-project/cli/src/cmds/devnet/bootstrap_network.ts
+++ b/yarn-project/cli/src/cmds/devnet/bootstrap_network.ts
@@ -13,6 +13,7 @@ import {
   retryUntil,
   waitForProven,
 } from '@aztec/aztec.js';
+import { FEE_FUNDING_FOR_TESTER_ACCOUNT } from '@aztec/constants';
 import {
   type ContractArtifacts,
   type ExtendedViemWalletClient,
@@ -283,10 +284,9 @@ async function fundFPC(
 
   const feeJuicePortal = await L1FeeJuicePortalManager.new(wallet, l1Client, debugLog);
 
-  const { claimAmount, claimSecret, messageLeafIndex, messageHash } = await feeJuicePortal.bridgeTokensPublic(
+  const { claimAmount, claimSecret, messageLeafIndex, messageHash } = await feeJuicePortal.bridgeTokensAsMinter(
     fpcAddress,
-    undefined,
-    true,
+    FEE_FUNDING_FOR_TESTER_ACCOUNT,
   );
 
   await retryUntil(async () => await pxe.isL1ToL2MessageSynced(Fr.fromHexString(messageHash)), 'message sync', 600, 1);

--- a/yarn-project/cli/src/cmds/l1/bridge_erc20.ts
+++ b/yarn-project/cli/src/cmds/l1/bridge_erc20.ts
@@ -12,7 +12,6 @@ export async function bridgeERC20(
   privateKey: string | undefined,
   mnemonic: string,
   tokenAddress: EthAddress,
-  handlerAddress: EthAddress | undefined,
   portalAddress: EthAddress,
   privateTransfer: boolean,
   mint: boolean,
@@ -25,7 +24,7 @@ export async function bridgeERC20(
   const l1Client = createExtendedL1Client(chain.rpcUrls, privateKey ?? mnemonic, chain.chainInfo);
 
   // Setup portal manager
-  const manager = new L1ToL2TokenPortalManager(portalAddress, tokenAddress, handlerAddress, l1Client, debugLogger);
+  const manager = new L1ToL2TokenPortalManager(portalAddress, tokenAddress, l1Client, debugLogger);
   let claimSecret: Fr;
   let messageHash: `0x${string}`;
   if (privateTransfer) {

--- a/yarn-project/cli/src/cmds/l1/index.ts
+++ b/yarn-project/cli/src/cmds/l1/index.ts
@@ -477,7 +477,6 @@ export function injectCommands(program: Command, log: LogFn, debugLogger: Logger
     .addOption(l1ChainIdOption)
     .requiredOption('-t, --token <string>', 'The address of the token to bridge', parseEthereumAddress)
     .requiredOption('-p, --portal <string>', 'The address of the portal contract', parseEthereumAddress)
-    .option('-f, --faucet <string>', 'The address of the faucet contract (only used if minting)', parseEthereumAddress)
     .option('--l1-private-key <string>', 'The private key to use for deployment', PRIVATE_KEY)
     .option('--json', 'Output the claim in JSON format')
     .action(async (amount, recipient, options) => {
@@ -490,7 +489,6 @@ export function injectCommands(program: Command, log: LogFn, debugLogger: Logger
         options.l1PrivateKey,
         options.mnemonic,
         options.token,
-        options.faucet,
         options.portal,
         options.private,
         options.mint,

--- a/yarn-project/end-to-end/src/shared/cross_chain_test_harness.ts
+++ b/yarn-project/end-to-end/src/shared/cross_chain_test_harness.ts
@@ -200,7 +200,6 @@ export class CrossChainTestHarness {
     this.l1TokenPortalManager = new L1TokenPortalManager(
       this.tokenPortalAddress,
       this.underlyingERC20Address,
-      this.l1ContractAddresses.feeAssetHandlerAddress,
       this.l1ContractAddresses.outboxAddress,
       this.l1Client,
       this.logger,
@@ -210,14 +209,8 @@ export class CrossChainTestHarness {
   }
 
   async mintTokensOnL1(amount: bigint) {
-    const contract = getContract({
-      abi: TestERC20Abi,
-      address: this.l1TokenManager.tokenAddress.toString(),
-      client: this.l1Client,
-    });
     const balanceBefore = await this.l1TokenManager.getL1TokenBalance(this.ethAccount.toString());
-    const hash = await contract.write.mint([this.ethAccount.toString(), amount]);
-    await this.l1Client.waitForTransactionReceipt({ hash });
+    await this.l1TokenManager.mint(amount, this.ethAccount.toString());
     expect(await this.l1TokenManager.getL1TokenBalance(this.ethAccount.toString())).toEqual(balanceBefore + amount);
   }
 

--- a/yarn-project/end-to-end/src/shared/gas_portal_test_harness.ts
+++ b/yarn-project/end-to-end/src/shared/gas_portal_test_harness.ts
@@ -12,12 +12,9 @@ import {
   retryUntil,
 } from '@aztec/aztec.js';
 import type { ExtendedViemWalletClient } from '@aztec/ethereum';
-import { TestERC20Abi } from '@aztec/l1-artifacts/TestERC20Abi';
 import { FeeJuiceContract } from '@aztec/noir-contracts.js/FeeJuice';
 import { ProtocolContractAddress } from '@aztec/protocol-contracts';
 import type { AztecNodeAdmin } from '@aztec/stdlib/interfaces/client';
-
-import { getContract } from 'viem';
 
 export interface IGasBridgingTestHarness {
   getL1FeeJuiceBalance(address: EthAddress): Promise<bigint>;
@@ -64,7 +61,6 @@ export class FeeJuicePortalTestingHarnessFactory {
       ethAccount,
       feeJuicePortalAddress,
       feeJuiceAddress,
-      l1ContractAddresses.feeAssetHandlerAddress!,
       l1Client,
     );
   }
@@ -103,15 +99,12 @@ export class GasBridgingTestHarness implements IGasBridgingTestHarness {
     public feeJuicePortalAddress: EthAddress,
     /** Underlying token for portal tests. */
     public l1FeeJuiceAddress: EthAddress,
-    /** Fee asset handler address. */
-    public feeAssetHandlerAddress: EthAddress,
     /** Viem Extended client instance. */
     public l1Client: ExtendedViemWalletClient,
   ) {
     this.feeJuicePortalManager = new L1FeeJuicePortalManager(
       this.feeJuicePortalAddress,
       this.l1FeeJuiceAddress,
-      this.feeAssetHandlerAddress,
       this.l1Client,
       this.logger,
     );
@@ -120,25 +113,11 @@ export class GasBridgingTestHarness implements IGasBridgingTestHarness {
   }
 
   async mintTokensOnL1(amount: bigint, to: EthAddress = this.ethAccount) {
-    // const balanceBefore = await this.l1TokenManager.getL1TokenBalance(to.toString());
-    await this.l1TokenManager.mint(to.toString());
-    const feeAssetL1 = getContract({
-      address: this.l1FeeJuiceAddress.toString(),
-      abi: TestERC20Abi,
-      client: this.l1Client,
-    });
-
-    await feeAssetL1.write.mint([to.toString(), amount]);
-
-    // expect(await this.l1TokenManager.getL1TokenBalance(to.toString())).toEqual(balanceBefore + amount);
+    await this.l1TokenManager.mint(amount, to.toString());
   }
 
   async getL1FeeJuiceBalance(address: EthAddress) {
     return await this.l1TokenManager.getL1TokenBalance(address.toString());
-  }
-
-  sendTokensToPortalPublic(bridgeAmount: bigint, l2Address: AztecAddress) {
-    return this.feeJuicePortalManager.bridgeTokensPublic(l2Address, bridgeAmount, false);
   }
 
   async consumeMessageOnAztecAndClaimPrivately(owner: AztecAddress, claim: L2AmountClaim) {
@@ -158,7 +137,7 @@ export class GasBridgingTestHarness implements IGasBridgingTestHarness {
 
   async prepareTokensOnL1(bridgeAmount: bigint, owner: AztecAddress) {
     await this.mintTokensOnL1(bridgeAmount);
-    const claim = await this.sendTokensToPortalPublic(bridgeAmount, owner);
+    const claim = await this.feeJuicePortalManager.bridgeTokensAsMinter(owner, bridgeAmount);
 
     const isSynced = async () => await this.aztecNode.isL1ToL2MessageSynced(Fr.fromHexString(claim.messageHash));
     await retryUntil(isSynced, `message ${claim.messageHash} sync`, 24, 1);

--- a/yarn-project/end-to-end/src/spartan/setup_test_wallets.ts
+++ b/yarn-project/end-to-end/src/spartan/setup_test_wallets.ts
@@ -156,7 +156,7 @@ async function bridgeL1FeeJuice(
 
   // docs:start:bridge_fee_juice
   const portal = await L1FeeJuicePortalManager.new(pxe, l1Client, log);
-  const claim = await portal.bridgeTokensPublic(recipient, amount, true /* mint */);
+  const claim = await portal.bridgeTokensFromFaucet(recipient);
   // docs:end:bridge_fee_juice
 
   const isSynced = async () => await pxe.isL1ToL2MessageSynced(Fr.fromHexString(claim.messageHash));


### PR DESCRIPTION
The FeeJuicePortalManager now can be used either as someone who is a "minter" on the underlying token, or as a regular use. They can use `bridgeTokensAsMinter` or `bridgeTokensFromFaucet` respectively. 

Use of a handler is now optional in the L1TokenManager, and the other portal managers- in the `mint` function, if a handler is provided, it will be used. Else, admin/minting rights are assumed (caller beware). 

The bridging tutorial test was updated to remove any notion of a handler, since it is more generic than fee juice. 

Also, the `bridge-fee-juice` cli was streamlined to support the case where (non-admin) users are trying to mint/bridge fee juice. So it mints by default, and an "amount" is not accepted as an arg, since it is determined by the handler.