### PR TITLE
fix: addressing tuple return value tech debt

### DIFF
--- a/noir-projects/noir-contracts/contracts/app/auth_contract/src/main.nr
+++ b/noir-projects/noir-contracts/contracts/app/auth_contract/src/main.nr
@@ -51,22 +51,10 @@ pub contract Auth {
 
     #[public]
     #[view]
-    fn get_scheduled_authorized() -> AztecAddress {
+    fn get_scheduled_authorized() -> (AztecAddress, u64) {
         // docs:start:shared_mutable_get_scheduled_public
-        let (scheduled_value, _timestamp_of_change): (AztecAddress, u64) =
-            storage.authorized.get_scheduled_value();
+        storage.authorized.get_scheduled_value()
         // docs:end:shared_mutable_get_scheduled_public
-        scheduled_value
-    }
-
-    // TODO(benesjan): Didn't return the timestamp of change directly from `get_scheduled_authorized` as there is some
-    // issue with tuple serialization and it does not compile. Will fix in a followup PR.
-    #[public]
-    #[view]
-    fn get_scheduled_authorized_timestamp() -> u64 {
-        let (_scheduled_value, timestamp_of_change): (_, u64) =
-            storage.authorized.get_scheduled_value();
-        timestamp_of_change
     }
 
     #[public]

--- a/noir-projects/noir-contracts/contracts/app/auth_contract/src/test/main.nr
+++ b/noir-projects/noir-contracts/contracts/app/auth_contract/src/test/main.nr
@@ -31,12 +31,9 @@ unconstrained fn main() {
         Auth::at(auth_contract_address).set_authorized(to_authorize).call(&mut env.public());
         env.advance_block_by(1);
 
-        let scheduled_authorized =
+        let (scheduled_authorized, timestamp_of_change) =
             Auth::at(auth_contract_address).get_scheduled_authorized().view(&mut env.public());
         assert_eq(scheduled_authorized, to_authorize);
-        let timestamp_of_change = Auth::at(auth_contract_address)
-            .get_scheduled_authorized_timestamp()
-            .view(&mut env.public());
         assert_eq(timestamp_of_change, expected_timestamp_of_first_change);
     };
     admin_sets_authorized();
@@ -107,12 +104,9 @@ unconstrained fn main() {
         Auth::at(auth_contract_address).set_authorized(other).call(&mut env.public());
         env.advance_block_by(1);
 
-        let scheduled_authorized =
+        let (scheduled_authorized, timestamp_of_change) =
             Auth::at(auth_contract_address).get_scheduled_authorized().view(&mut env.public());
         assert_eq(scheduled_authorized, other);
-        let timestamp_of_change = Auth::at(auth_contract_address)
-            .get_scheduled_authorized_timestamp()
-            .view(&mut env.public());
         assert_eq(timestamp_of_change, expected_timestamp_of_second_change);
 
         // We have not yet crossed the timestamp of change, so the authorized address is still set to `to_authorize`


### PR DESCRIPTION
Before https://github.com/AztecProtocol/aztec-packages/pull/15283 it was impossible to return a tuple from a contract function. Since it's implemented now I address a related forgotten TODO in this PR.
