### PR TITLE
Fix logical operator in tag validation in OperandCollector::finish

### DIFF
--- a/avm-transpiler/src/procedures/compiler/operand_collector.rs
+++ b/avm-transpiler/src/procedures/compiler/operand_collector.rs
@@ -143,7 +143,7 @@ impl OperandCollector {
         if self.operand_index < self.parsed_opcode.operands.len() {
             return Err("Too many operands".to_string());
         }
-        if !self.extracted_tag & self.parsed_opcode.tag.is_some() {
+        if !self.extracted_tag && self.parsed_opcode.tag.is_some() {
             return Err("Extra tag".to_string());
         }
         Ok(OperandCollectionResult {


### PR DESCRIPTION
Replaced the bitwise AND operator (&) with the logical AND operator (&&) in the tag validation check within the OperandCollector::finish method. This ensures correct logical evaluation when determining if an extra tag is present.