### PR TITLE
fix: Do not delegate vote signature to rpc

### DIFF
--- a/yarn-project/ethereum/src/contracts/empire_base.ts
+++ b/yarn-project/ethereum/src/contracts/empire_base.ts
@@ -69,7 +69,7 @@ export async function signVoteWithSig(
   }
 
   const signatureHex = await walletClient.signTypedData({
-    account: walletClient.account.address,
+    account: walletClient.account,
     domain,
     types,
     primaryType: 'Vote',

--- a/yarn-project/slasher/src/slasher_client.test.ts
+++ b/yarn-project/slasher/src/slasher_client.test.ts
@@ -41,6 +41,7 @@ const ethereumSlotDuration = 2;
 
 describe('SlasherClient', () => {
   let anvil: Anvil;
+  let anvilMethodCalls: string[] | undefined;
   let rpcUrl: string;
   let slasherPrivateKey: PrivateKeyAccount;
   let testHarnessPrivateKey: PrivateKeyAccount;
@@ -67,7 +68,7 @@ describe('SlasherClient', () => {
     vkTreeRoot = Fr.random();
     protocolContractTreeRoot = Fr.random();
 
-    ({ anvil, rpcUrl } = await startAnvil());
+    ({ anvil, rpcUrl, methodCalls: anvilMethodCalls } = await startAnvil({ captureMethodCalls: true }));
 
     // Need separate clients for slasher and test harness to avoid nonce conflicts.
     slasherL1Client = createExtendedL1Client([rpcUrl], slasherPrivateKey, foundry);
@@ -142,6 +143,8 @@ describe('SlasherClient', () => {
   });
 
   afterEach(async () => {
+    // Make sure we do not ask anvil to sign, this should be handled by the wallet client
+    expect(anvilMethodCalls).not.toContain('eth_signTypedData_v4');
     await slasherClient.stop();
     await anvil.stop().catch(logger.error);
   });


### PR DESCRIPTION
We were getting ` The method "eth_signTypedData_v4" does not exist / is not available` error in logs, with the following request body:

```
{"method":"eth_signTypedData_v4","params":["0x43C4F95823353D4Dabc9d9308D0e4F2247F79030","{\"domain\":{\"name\":\"EmpireBase\",\"version\":\"1\",\"chainId\":1337,\"verifyingContract\":\"0x353511fd048f6cf3f1bf8fa00de79de019a8395b\"},\"message\":{\"proposal\":\"0x21f9140adba0fa1679242423349ee58925012199\",\"nonce\":\"0\"},\"primaryType\":\"Vote\",\"types\":{\"EIP712Domain\":[{\"name\":\"name\",\"type\":\"string\"},{\"name\":\"version\",\"type\":\"string\"},{\"name\":\"chainId\",\"type\":\"uint256\"},{\"name\":\"verifyingContract\",\"type\":\"address\"}],\"Vote\":[{\"name\":\"proposal\",\"type\":\"address\"},{\"name\":\"nonce\",\"type\":\"uint256\"}]}}"]}
```

This was coming from the slasher client, which uses `eth_signTypedData_v4` for signing:

It seems that `viem`, when specifying the signer, behaves differently when you pass an `Account` object vs its address. If it's an address, it assumes that the corresponding account is unlocked in the RPC (in this case `anvil`). See [here](https://github.com/wevm/viem/blob/ba8319f71503af8033fd3c77cfb64c7eb235c6a9/src/accounts/utils/parseAccount.ts#L12), called from [here](https://github.com/wevm/viem/blob/ba8319f71503af8033fd3c77cfb64c7eb235c6a9/src/actions/wallet/signTypedData.ts#L173). And since `anvil` is meant as a development server, it has a set of accounts already unlocked, so it happily obliges. But when we run this in an actual network, it fails.

In the future, we should tweak our anvil setup so we do not unlock any account at all, but rather seed the accounts for the mnemonic we use everywhere.
