### PR TITLE
chore: use const ref commitment keys

### DIFF
--- a/barretenberg/cpp/src/barretenberg/sumcheck/zk_sumcheck_data.hpp
+++ b/barretenberg/cpp/src/barretenberg/sumcheck/zk_sumcheck_data.hpp
@@ -58,7 +58,7 @@ template <typename Flavor> struct ZKSumcheckData {
     // Main constructor
     ZKSumcheckData(const size_t multivariate_d,
                    std::shared_ptr<typename Flavor::Transcript> transcript = nullptr,
-                   typename Flavor::CommitmentKey commitment_key = typename Flavor::CommitmentKey())
+                   const typename Flavor::CommitmentKey& commitment_key = typename Flavor::CommitmentKey())
         : constant_term(FF::random_element())
         , libra_concatenated_monomial_form(SUBGROUP_SIZE + 2) // includes masking
         , libra_univariates(generate_libra_univariates(multivariate_d, LIBRA_UNIVARIATES_LENGTH))

--- a/barretenberg/cpp/src/barretenberg/translator_vm/translator_flavor.hpp
+++ b/barretenberg/cpp/src/barretenberg/translator_vm/translator_flavor.hpp
@@ -709,7 +709,7 @@ class TranslatorFlavor {
         ProverPolynomials polynomials; // storage for all polynomials evaluated by the prover
         CommitmentKey commitment_key = CommitmentKey();
 
-        ProvingKey(CommitmentKey commitment_key = CommitmentKey())
+        ProvingKey(const CommitmentKey& commitment_key = CommitmentKey())
             : commitment_key(commitment_key)
         {}
     };

--- a/barretenberg/cpp/src/barretenberg/translator_vm/translator_proving_key.hpp
+++ b/barretenberg/cpp/src/barretenberg/translator_vm/translator_proving_key.hpp
@@ -41,7 +41,7 @@ class TranslatorProvingKey {
 
     TranslatorProvingKey() = default;
 
-    TranslatorProvingKey(const Circuit& circuit, CommitmentKey commitment_key = CommitmentKey())
+    TranslatorProvingKey(const Circuit& circuit, const CommitmentKey& commitment_key = CommitmentKey())
         : batching_challenge_v(circuit.batching_challenge_v)
         , evaluation_input_x(circuit.evaluation_input_x)
     {

--- a/barretenberg/cpp/src/barretenberg/ultra_honk/decider_proving_key.hpp
+++ b/barretenberg/cpp/src/barretenberg/ultra_honk/decider_proving_key.hpp
@@ -90,7 +90,7 @@ template <IsUltraOrMegaHonk Flavor> class DeciderProvingKey_ {
 
     DeciderProvingKey_(Circuit& circuit,
                        TraceSettings trace_settings = {},
-                       CommitmentKey commitment_key = CommitmentKey())
+                       const CommitmentKey& commitment_key = CommitmentKey())
         : is_structured(trace_settings.structure.has_value())
         , commitment_key(commitment_key)
     {

--- a/barretenberg/cpp/src/barretenberg/ultra_honk/merge_prover.cpp
+++ b/barretenberg/cpp/src/barretenberg/ultra_honk/merge_prover.cpp
@@ -15,7 +15,7 @@ namespace bb {
  * TODO(https://github.com/AztecProtocol/barretenberg/issues/1267): consider possible efficiency improvements
  */
 MergeProver::MergeProver(const std::shared_ptr<ECCOpQueue>& op_queue,
-                         CommitmentKey commitment_key,
+                         const CommitmentKey& commitment_key,
                          const std::shared_ptr<Transcript>& transcript)
     : op_queue(op_queue)
     // TODO(https://github.com/AztecProtocol/barretenberg/issues/1420): pass commitment keys by value

--- a/barretenberg/cpp/src/barretenberg/ultra_honk/merge_prover.hpp
+++ b/barretenberg/cpp/src/barretenberg/ultra_honk/merge_prover.hpp
@@ -34,7 +34,7 @@ class MergeProver {
     using MergeProof = std::vector<FF>;
 
     explicit MergeProver(const std::shared_ptr<ECCOpQueue>& op_queue,
-                         CommitmentKey commitment_key = CommitmentKey(),
+                         const CommitmentKey& commitment_key = CommitmentKey(),
                          const std::shared_ptr<Transcript>& transcript = std::make_shared<Transcript>());
 
     BB_PROFILE MergeProof construct_proof();


### PR DESCRIPTION
I had thought that const ref can't get a default parameter but it can!