### PR TITLE
chore: fix avm build in merge-train/bb

### DIFF
--- a/barretenberg/cpp/src/barretenberg/vm2/constraining/flavor.hpp
+++ b/barretenberg/cpp/src/barretenberg/vm2/constraining/flavor.hpp
@@ -270,11 +270,7 @@ class AvmFlavor {
          *
          * @return std::vector<FF>
          */
-        std::vector<fr> to_field_elements() const override
-        {
-            // TODO(https://github.com/AztecProtocol/barretenberg/issues/1466): Implement this function.
-            throw_or_abort("Not implemented yet!");
-        }
+        std::vector<fr> to_field_elements() const override;
 
         /**
          * @brief Adds the verification key hash to the transcript and returns the hash.


### PR DESCRIPTION
Accidentally broke build by redefining to_field_elements in avm VK