### PR TITLE
chore(ci): redefine CI_FULL, add CI_MERGE_QUEUE

### DIFF
--- a/.github/workflows/ci3.yml
+++ b/.github/workflows/ci3.yml
@@ -35,7 +35,7 @@ jobs:
           # The commit to checkout. We want our actual commit, and not the result of merging the PR to the target.
           ref: ${{ github.event.pull_request.head.sha || github.sha }}
 
-      - name: CI Full Override
+      - name: CI Merge Queue Override (grind on PR)
         if: contains(github.event.pull_request.labels.*.name, 'ci-merge-queue')
         run: echo "CI_MERGE_QUEUE=1" >> $GITHUB_ENV
 

--- a/.github/workflows/ci3.yml
+++ b/.github/workflows/ci3.yml
@@ -36,6 +36,10 @@ jobs:
           ref: ${{ github.event.pull_request.head.sha || github.sha }}
 
       - name: CI Full Override
+        if: contains(github.event.pull_request.labels.*.name, 'ci-merge-queue')
+        run: echo "CI_MERGE_QUEUE=1" >> $GITHUB_ENV
+
+      - name: CI Full Override
         if: contains(github.event.pull_request.labels.*.name, 'ci-full')
         run: echo "CI_FULL=1" >> $GITHUB_ENV
 
@@ -66,17 +70,11 @@ jobs:
           echo "TARGET_BRANCH=${target_branch}" >> $GITHUB_ENV
 
       - name: Docs CI Override
-        if: |
-          (contains(github.event.pull_request.labels.*.name, 'ci-docs') ||
-           steps.target_branch.outputs.target_branch == 'merge-train/docs') &&
-          !contains(github.event.pull_request.labels.*.name, 'ci-full')
+        if: contains(github.event.pull_request.labels.*.name, 'ci-docs') || (steps.target_branch.outputs.target_branch == 'merge-train/docs')
         run: echo "CI_DOCS=1" >> $GITHUB_ENV
 
       - name: Barretenberg CI Override
-        if: |
-          (contains(github.event.pull_request.labels.*.name, 'barretenberg-ci') ||
-           github.event.pull_request.base.ref == 'merge-train/barretenberg') &&
-          !contains(github.event.pull_request.labels.*.name, 'ci-full')
+        if: contains(github.event.pull_request.labels.*.name, 'barretenberg-ci') || (github.event.pull_request.base.ref == 'merge-train/barretenberg')
         run: echo "CI_BARRETENBERG=1" >> $GITHUB_ENV
 
       # Allow full concurrency for merge-train PRs, one-run-per-branch for everything else.
@@ -122,16 +120,18 @@ jobs:
           EXTERNAL_ETHEREUM_CONSENSUS_HOST_API_KEY_HEADER: "X-goog-api-key"
           GCP_PROJECT_ID: ${{ secrets.GCP_PROJECT_ID }}
         run: |
-          if [ "${{ github.event_name }}" == "merge_group" ] || [ "${CI_FULL:-0}" -eq 1 ]; then
+          if [ "${{ github.event_name }}" == "merge_group" ] || [ "${CI_MERGE_QUEUE:-0}" -eq 1 ]; then
             exec ./ci.sh merge-queue
-          elif [ "${CI_DOCS:-0}" -eq 1 ]; then
-            exec ./ci.sh docs
-          elif [ "${CI_BARRETENBERG:-0}" -eq 1 ]; then
-            exec ./ci.sh barretenberg
           elif [ "${{ contains(github.ref, '-nightly.') }}" == "true" ]; then
             exec ./ci.sh nightly
           elif [ "${{ startsWith(github.ref, 'refs/tags/v') }}" == "true" ]; then
             exec ./ci.sh release
+          elif [ "${CI_FULL:-0}" -eq 1 ]; then
+            exec ./ci.sh full
+          elif [ "${CI_DOCS:-0}" -eq 1 ]; then
+            exec ./ci.sh docs
+          elif [ "${CI_BARRETENBERG:-0}" -eq 1 ]; then
+            exec ./ci.sh barretenberg
           else
             exec ./ci.sh fast
           fi

--- a/.github/workflows/ci3.yml
+++ b/.github/workflows/ci3.yml
@@ -122,16 +122,16 @@ jobs:
         run: |
           if [ "${{ github.event_name }}" == "merge_group" ] || [ "${CI_MERGE_QUEUE:-0}" -eq 1 ]; then
             exec ./ci.sh merge-queue
-          elif [ "${{ contains(github.ref, '-nightly.') }}" == "true" ]; then
-            exec ./ci.sh nightly
-          elif [ "${{ startsWith(github.ref, 'refs/tags/v') }}" == "true" ]; then
-            exec ./ci.sh release
           elif [ "${CI_FULL:-0}" -eq 1 ]; then
             exec ./ci.sh full
           elif [ "${CI_DOCS:-0}" -eq 1 ]; then
             exec ./ci.sh docs
           elif [ "${CI_BARRETENBERG:-0}" -eq 1 ]; then
             exec ./ci.sh barretenberg
+          elif [ "${{ contains(github.ref, '-nightly.') }}" == "true" ]; then
+            exec ./ci.sh nightly
+          elif [ "${{ startsWith(github.ref, 'refs/tags/v') }}" == "true" ]; then
+            exec ./ci.sh release
           else
             exec ./ci.sh fast
           fi


### PR DESCRIPTION
Context:
We've been using ci-full more because of merge-train. Most people don't really want the grind aspect of it. This PR makes CI_MERGE_QUEUE do what CI_FULL used to. With this PR, CI_FULL runs a single amd64 run with benches and tests - this is what most people really want I imagine. To use CI_MERGE_QUEUE mode after you add label `ci-merge-queue`