### PR TITLE
fix: Do not revert block proposal if vote fails and viceversa

### DIFF
--- a/l1-contracts/src/core/libraries/Errors.sol
+++ b/l1-contracts/src/core/libraries/Errors.sol
@@ -151,7 +151,7 @@ library Errors {
   error FeeLib__AlreadyPreheated();
 
   // SignatureLib (duplicated)
-  error SignatureLib__InvalidSignature(address, address);
+  error SignatureLib__InvalidSignature(address, address); // 0xd9cbae6c
 
   // RewardBooster
   error RewardBooster__OnlyRollup(address caller);

--- a/l1-contracts/src/core/libraries/Errors.sol
+++ b/l1-contracts/src/core/libraries/Errors.sol
@@ -150,6 +150,9 @@ library Errors {
   error FeeLib__InvalidFeeAssetPriceModifier(); // 0xf2fb32ad
   error FeeLib__AlreadyPreheated();
 
+  // SignatureLib (duplicated)
+  error SignatureLib__InvalidSignature(address, address);
+
   // RewardBooster
   error RewardBooster__OnlyRollup(address caller);
 }

--- a/yarn-project/end-to-end/src/integration/integration_l1_publisher.test.ts
+++ b/yarn-project/end-to-end/src/integration/integration_l1_publisher.test.ts
@@ -567,6 +567,7 @@ describe('L1Publisher integration', () => {
         block.header.getSlot(),
         block.header.globalVariables.timestamp,
         VoteType.SLASHING,
+        EthAddress.random(),
         (_payload: `0x${string}`) => Promise.resolve(Signature.random().toString()),
       );
 

--- a/yarn-project/ethereum/src/contracts/multicall.ts
+++ b/yarn-project/ethereum/src/contracts/multicall.ts
@@ -23,7 +23,7 @@ export class Multicall3 {
     const args = requests.map(r => ({
       target: r.to!,
       callData: r.data!,
-      allowFailure: false,
+      allowFailure: true,
     }));
     const forwarderFunctionData: Required<EncodeFunctionDataParameters<typeof multicall3Abi, 'aggregate3'>> = {
       abi: multicall3Abi,

--- a/yarn-project/ethereum/src/contracts/multicall.ts
+++ b/yarn-project/ethereum/src/contracts/multicall.ts
@@ -18,12 +18,13 @@ export class Multicall3 {
     blobConfig: L1BlobInputs | undefined,
     rollupAddress: Hex,
     logger: Logger,
+    opts: { revertOnFailure?: boolean } = {},
   ) {
     requests = requests.filter(request => request.to !== null);
     const args = requests.map(r => ({
       target: r.to!,
       callData: r.data!,
-      allowFailure: true,
+      allowFailure: !opts.revertOnFailure,
     }));
     const forwarderFunctionData: Required<EncodeFunctionDataParameters<typeof multicall3Abi, 'aggregate3'>> = {
       abi: multicall3Abi,

--- a/yarn-project/sequencer-client/src/publisher/index.ts
+++ b/yarn-project/sequencer-client/src/publisher/index.ts
@@ -1,1 +1,1 @@
-export { SequencerPublisher } from './sequencer-publisher.js';
+export { SequencerPublisher, VoteType } from './sequencer-publisher.js';

--- a/yarn-project/sequencer-client/src/publisher/sequencer-publisher.test.ts
+++ b/yarn-project/sequencer-client/src/publisher/sequencer-publisher.test.ts
@@ -360,6 +360,7 @@ describe('SequencerPublisher', () => {
         data: encodeFunctionData({ abi: EmpireBaseAbi, functionName: 'vote', args: [EthAddress.random().toString()] }),
       },
       lastValidL2Slot: 1n,
+      checkSuccess: () => true,
     });
 
     const resultPromise = publisher.sendRequests();

--- a/yarn-project/sequencer-client/src/publisher/sequencer-publisher.ts
+++ b/yarn-project/sequencer-client/src/publisher/sequencer-publisher.ts
@@ -27,7 +27,7 @@ import { toHex as toPaddedHex } from '@aztec/foundation/bigint-buffer';
 import { EthAddress } from '@aztec/foundation/eth-address';
 import { createLogger } from '@aztec/foundation/log';
 import { DateProvider, Timer } from '@aztec/foundation/timer';
-import { RollupAbi } from '@aztec/l1-artifacts';
+import { EmpireBaseAbi, ErrorsAbi, RollupAbi } from '@aztec/l1-artifacts';
 import { CommitteeAttestation } from '@aztec/stdlib/block';
 import { ConsensusPayload, SignatureDomainSeparator, getHashedSignaturePayload } from '@aztec/stdlib/p2p';
 import type { L1PublishBlockStats } from '@aztec/stdlib/stats';
@@ -35,7 +35,7 @@ import { type ProposedBlockHeader, StateReference, TxHash } from '@aztec/stdlib/
 import { type TelemetryClient, getTelemetryClient } from '@aztec/telemetry-client';
 
 import pick from 'lodash.pick';
-import { type TransactionReceipt, encodeFunctionData, toHex } from 'viem';
+import { type TransactionReceipt, encodeFunctionData, getAbiItem, toEventSelector, toHex } from 'viem';
 
 import type { PublisherConfig, TxSenderConfig } from './config.js';
 import { SequencerPublisherMetrics } from './sequencer-publisher-metrics.js';
@@ -71,10 +71,10 @@ interface RequestWithExpiry {
   lastValidL2Slot: bigint;
   gasConfig?: Pick<L1GasConfig, 'txTimeoutAt' | 'gasLimit'>;
   blobConfig?: L1BlobInputs;
-  onResult?: (
+  checkSuccess: (
     request: L1TxRequest,
     result?: { receipt: TransactionReceipt; gasPrice: GasPrice; stats?: TransactionStats; errorMsg?: string },
-  ) => void;
+  ) => boolean;
 }
 
 export class SequencerPublisher {
@@ -235,9 +235,7 @@ export class SequencerPublisher {
     const gasConfig: RequestWithExpiry['gasConfig'] = { gasLimit, txTimeoutAt };
 
     try {
-      this.log.debug('Forwarding transactions', {
-        validRequests: validRequests.map(request => request.action),
-      });
+      this.log.debug('Forwarding transactions', { validRequests: validRequests.map(request => request.action) });
       const result = await Multicall3.forward(
         validRequests.map(request => request.request),
         this.l1TxUtils,
@@ -246,8 +244,8 @@ export class SequencerPublisher {
         this.rollupContract.address,
         this.log,
       );
-      this.callbackBundledTransactions(validRequests, result);
-      return { result, expiredActions, validActions };
+      const { successfulActions = [], failedActions = [] } = this.callbackBundledTransactions(validRequests, result);
+      return { result, expiredActions, sentActions: validActions, successfulActions, failedActions };
     } catch (err) {
       const viemError = formatViemError(err);
       this.log.error(`Failed to publish bundled transactions`, viemError);
@@ -265,17 +263,22 @@ export class SequencerPublisher {
     requests: RequestWithExpiry[],
     result?: { receipt: TransactionReceipt; gasPrice: GasPrice } | FormattedViemError,
   ) {
-    const isError = result instanceof FormattedViemError;
-    const success = isError ? false : result?.receipt.status === 'success';
-    const logger = success ? this.log.info : this.log.error;
-    for (const request of requests) {
-      logger(`Bundled [${request.action}] transaction [${success ? 'succeeded' : 'failed'}]`);
-      if (!isError) {
-        request.onResult?.(request.request, result);
+    const actionsListStr = requests.map(r => r.action).join(', ');
+    if (result instanceof FormattedViemError) {
+      this.log.error(`Failed to publish bundled transactions (${actionsListStr})`, result);
+      return { failedActions: requests.map(r => r.action) };
+    } else {
+      this.log.verbose(`Published bundled transactions (${actionsListStr})`, { result, requests });
+      const successfulActions: Action[] = [];
+      const failedActions: Action[] = [];
+      for (const request of requests) {
+        if (request.checkSuccess(request.request, result)) {
+          successfulActions.push(request.action);
+        } else {
+          failedActions.push(request.action);
+        }
       }
-    }
-    if (isError) {
-      this.log.error('Failed to publish bundled transactions', result);
+      return { successfulActions, failedActions };
     }
   }
 
@@ -440,16 +443,42 @@ export class SequencerPublisher {
       lastValidL2Slot: slotNumber,
     });
 
+    try {
+      await this.l1TxUtils.simulate(request, { time: timestamp }, [], ErrorsAbi);
+      this.log.debug(`Simulation for ${action} at slot ${slotNumber} succeeded`, { request });
+    } catch (err) {
+      this.log.error(`Failed simulation for ${action} at slot ${slotNumber}`, err);
+      // Yes, we enqueue the request anyway, in case there was a bug with the simulation itself
+    }
+
     this.addRequest({
       gasConfig: { gasLimit: SequencerPublisher.VOTE_GAS_GUESS },
       action,
       request,
       lastValidL2Slot: slotNumber,
-      onResult: (_request, result) => {
-        if (!result || result.receipt.status !== 'success') {
+      checkSuccess: (_request, result) => {
+        const success =
+          result &&
+          result.receipt &&
+          result.receipt.status === 'success' &&
+          result.receipt.logs.find(
+            log => log.topics[0] === toEventSelector(getAbiItem({ abi: EmpireBaseAbi, name: 'VoteCast' })),
+          );
+
+        const logData = { ...result, slotNumber, round, payload: payload.toString() };
+        if (!success) {
+          this.log.error(
+            `Voting in [${action}] for ${payload} at slot ${slotNumber} in round ${round} failed`,
+            logData,
+          );
           this.myLastVotes[voteType] = cachedLastVote;
+          return false;
         } else {
-          this.log.info(`Voting in [${action}] for ${payload} at slot ${slotNumber} in round ${round}`);
+          this.log.info(
+            `Voting in [${action}] for ${payload} at slot ${slotNumber} in round ${round} succeeded`,
+            logData,
+          );
+          return true;
         }
       },
     });
@@ -472,8 +501,10 @@ export class SequencerPublisher {
       }
       this.log.info(`Slash payload: ${slashPayload}`);
       return { payload: slashPayload, base: this.slashingProposerContract };
+    } else {
+      const _: never = voteType;
+      throw new Error('Unreachable: Invalid vote type');
     }
-    throw new Error('Unreachable: Invalid vote type');
   }
 
   /**
@@ -714,12 +745,18 @@ export class SequencerPublisher {
         blobs: encodedData.blobs.map(b => b.data),
         kzg,
       },
-      onResult: (request, result) => {
+      checkSuccess: (request, result) => {
         if (!result) {
-          return;
+          return false;
         }
         const { receipt, stats, errorMsg } = result;
-        if (receipt.status === 'success') {
+        const success =
+          receipt &&
+          receipt.status === 'success' &&
+          receipt.logs.find(
+            log => log.topics[0] === toEventSelector(getAbiItem({ abi: RollupAbi, name: 'L2BlockProposed' })),
+          );
+        if (success) {
           const endBlock = receipt.blockNumber;
           const inclusionBlocks = Number(endBlock - startBlock);
           const publishStats: L1PublishBlockStats = {
@@ -734,23 +771,23 @@ export class SequencerPublisher {
             blobCount: encodedData.blobs.length,
             inclusionBlocks,
           };
-          this.log.verbose(`Published L2 block to L1 rollup contract`, { ...stats, ...block.getStats(), ...receipt });
+          this.log.info(`Published L2 block to L1 rollup contract`, { ...stats, ...block.getStats(), ...receipt });
           this.metrics.recordProcessBlockTx(timer.ms(), publishStats);
 
           // Send the blobs to the blob sink
           this.sendBlobsToBlobSink(receipt.blockHash, encodedData.blobs).catch(_err => {
             this.log.error('Failed to send blobs to blob sink');
           });
-
           return true;
         } else {
           this.metrics.recordFailedTx('process');
-
-          this.log.error(`Rollup process tx reverted. ${errorMsg ?? 'No error message'}`, undefined, {
+          this.log.error(`Rollup process tx failed. ${errorMsg ?? 'No error message'}`, undefined, {
             ...block.getStats(),
+            receipt,
             txHash: receipt.transactionHash,
             slotNumber: block.header.globalVariables.slotNumber.toBigInt(),
           });
+          return false;
         }
       },
     });

--- a/yarn-project/sequencer-client/src/publisher/sequencer-publisher.ts
+++ b/yarn-project/sequencer-client/src/publisher/sequencer-publisher.ts
@@ -447,7 +447,7 @@ export class SequencerPublisher {
       await this.l1TxUtils.simulate(request, { time: timestamp }, [], ErrorsAbi);
       this.log.debug(`Simulation for ${action} at slot ${slotNumber} succeeded`, { request });
     } catch (err) {
-      this.log.error(`Failed simulation for ${action} at slot ${slotNumber}`, err);
+      this.log.warn(`Failed simulation for ${action} at slot ${slotNumber} (enqueuing the action anyway)`, err);
       // Yes, we enqueue the request anyway, in case there was a bug with the simulation itself
     }
 

--- a/yarn-project/sequencer-client/src/sequencer/sequencer.ts
+++ b/yarn-project/sequencer-client/src/sequencer/sequencer.ts
@@ -68,7 +68,12 @@ export type SequencerEvents = {
   ['proposer-rollup-check-failed']: (args: { reason: string }) => void;
   ['tx-count-check-failed']: (args: { minTxs: number; availableTxs: number }) => void;
   ['block-build-failed']: (args: { reason: string }) => void;
-  ['block-publish-failed']: (args: { validActions?: Action[]; expiredActions?: Action[] }) => void;
+  ['block-publish-failed']: (args: {
+    successfulActions?: Action[];
+    failedActions?: Action[];
+    sentActions?: Action[];
+    expiredActions?: Action[];
+  }) => void;
   ['block-published']: (args: { blockNumber: number; slot: number }) => void;
 };
 
@@ -468,7 +473,7 @@ export class Sequencer extends (EventEmitter as new () => TypedEventEmitter<Sequ
     });
 
     const l1Response = await this.publisher.sendRequests();
-    const proposedBlock = l1Response?.validActions.find(a => a === 'propose');
+    const proposedBlock = l1Response?.successfulActions.find(a => a === 'propose');
     if (proposedBlock) {
       this.lastBlockPublished = block;
       this.emit('block-published', { blockNumber: newBlockNumber, slot: Number(slot) });
@@ -477,10 +482,7 @@ export class Sequencer extends (EventEmitter as new () => TypedEventEmitter<Sequ
         this.isFlushing = false;
       }
     } else if (block) {
-      this.emit('block-publish-failed', {
-        validActions: l1Response?.validActions,
-        expiredActions: l1Response?.expiredActions,
-      });
+      this.emit('block-publish-failed', l1Response ?? {});
     }
 
     this.setState(SequencerState.IDLE, undefined);


### PR DESCRIPTION
We were calling multicall3 with `allowFailure: false` for each request, which means that the entire tx reverted if any of the aggregated calls failed. This meant that, if block proposal failed, the vote would be reverted, and viceversa. This PR sets `allowFailure` to true.

This change means we can no longer rely on the receipt `status` to know if an action succeeded or not. So we overload the old `onResult` callback for L1 requests, and have it inspect the tx logs to determine if the action succeeded or not.