### PR TITLE
fix: slashing fixes

### DIFF
--- a/yarn-project/ethereum/src/contracts/slashing_proposer.ts
+++ b/yarn-project/ethereum/src/contracts/slashing_proposer.ts
@@ -164,7 +164,7 @@ export class SlashingProposerContract extends EventEmitter implements IEmpireBas
         {
           // Gas estimation is way off for this, likely because we are creating the contract/selector to call
           // for the actual slashing dynamically.
-          gasLimitBufferPercentage: 1000,
+          gasLimitBufferPercentage: 50, // +50% gas
         },
       )
       .catch(err => {

--- a/yarn-project/foundation/src/config/index.ts
+++ b/yarn-project/foundation/src/config/index.ts
@@ -114,9 +114,16 @@ export function numberConfigHelper(defaultVal: number): Pick<ConfigMapping, 'par
  * @param defaultVal - The default numerical value to use if the environment variable is not set or is invalid
  * @returns Object with parseEnv and default values for a numerical config value
  */
-export function floatConfigHelper(defaultVal: number): Pick<ConfigMapping, 'parseEnv' | 'defaultValue'> {
+export function floatConfigHelper(
+  defaultVal: number,
+  validationFn?: (val: number) => void,
+): Pick<ConfigMapping, 'parseEnv' | 'defaultValue'> {
   return {
-    parseEnv: (val: string) => safeParseFloat(val, defaultVal),
+    parseEnv: (val: string): number => {
+      const parsed = safeParseFloat(val, defaultVal);
+      validationFn?.(parsed);
+      return parsed;
+    },
     defaultValue: defaultVal,
   };
 }

--- a/yarn-project/slasher/src/config.ts
+++ b/yarn-project/slasher/src/config.ts
@@ -1,5 +1,10 @@
 import type { ConfigMappingsType } from '@aztec/foundation/config';
-import { bigintConfigHelper, booleanConfigHelper, numberConfigHelper } from '@aztec/foundation/config';
+import {
+  bigintConfigHelper,
+  booleanConfigHelper,
+  floatConfigHelper,
+  numberConfigHelper,
+} from '@aztec/foundation/config';
 import { EthAddress } from '@aztec/foundation/eth-address';
 import type { TypedEventEmitter } from '@aztec/foundation/types';
 
@@ -70,8 +75,8 @@ export interface SlasherConfig {
   slashInvalidBlockPenalty: bigint;
   slashInvalidBlockMaxPenalty: bigint;
   slashInactivityEnabled: boolean;
-  slashInactivityCreateTargetPercentage: number; // 0-1, 0.9 means 90%
-  slashInactivitySignalTargetPercentage: number; // 0-1, 0.6 means 60%
+  slashInactivityCreateTargetPercentage: number; // 0-1, 0.9 means 90%. Must be greater than 0
+  slashInactivitySignalTargetPercentage: number; // 0-1, 0.6 means 60%. Must be greater than 0
   slashInactivityCreatePenalty: bigint;
   slashInactivityMaxPenalty: bigint;
   slashProposerRoundPollingIntervalSeconds: number;
@@ -144,13 +149,23 @@ export const slasherConfigMappings: ConfigMappingsType<SlasherConfig> = {
   },
   slashInactivityCreateTargetPercentage: {
     env: 'SLASH_INACTIVITY_CREATE_TARGET_PERCENTAGE',
-    description: 'Missed attestation percentage to trigger creation of inactivity slash payload (0-100).',
-    ...numberConfigHelper(DefaultSlasherConfig.slashInactivityCreateTargetPercentage),
+    description:
+      'Missed attestation percentage to trigger creation of inactivity slash payload (0, 1]. Must be greater than 0',
+    ...floatConfigHelper(DefaultSlasherConfig.slashInactivityCreateTargetPercentage, v => {
+      if (v <= 0 || v > 1) {
+        throw new RangeError(`SLASH_INACTIVITY_CREATE_TARGET_PERCENTAGE out of range. Expected (0, 1] got ${v}`);
+      }
+    }),
   },
   slashInactivitySignalTargetPercentage: {
     env: 'SLASH_INACTIVITY_SIGNAL_TARGET_PERCENTAGE',
-    description: 'Missed attestation percentage to trigger voting for an inactivity slash payload (0-100).',
-    ...numberConfigHelper(DefaultSlasherConfig.slashInactivitySignalTargetPercentage),
+    description:
+      'Missed attestation percentage to trigger voting for an inactivity slash payload (0, 1]. Must be greater than 0',
+    ...floatConfigHelper(DefaultSlasherConfig.slashInactivitySignalTargetPercentage, v => {
+      if (v <= 0 || v > 1) {
+        throw new RangeError(`SLASH_INACTIVITY_SIGNAL_TARGET_PERCENTAGE out of range. Expected (0, 1] got ${v}`);
+      }
+    }),
   },
   slashInactivityCreatePenalty: {
     env: 'SLASH_INACTIVITY_CREATE_PENALTY',

--- a/yarn-project/slasher/src/slasher_client.ts
+++ b/yarn-project/slasher/src/slasher_client.ts
@@ -454,7 +454,7 @@ export class SlasherClient {
       this.config.slashProposerRoundPollingIntervalSeconds,
     );
     if (!reached) {
-      this.log.error('Round not reached', { proposal, round });
+      this.log.warn('Round not reached', { proposal, round });
       return;
     }
     this.log.info('Executing round', { proposal, round });
@@ -469,8 +469,7 @@ export class SlasherClient {
           this.log.debug('Round already executed', { round });
           return;
         } else {
-          this.log.error('Error executing round', err);
-          throw err;
+          this.log.warn('Error executing round', err);
         }
       });
   }


### PR DESCRIPTION
This PR does three things:
1. it prevents the node from crashing if it can't execute a slashing round
2. it lowers the gas buffer from +1,000% to +50% to execute a slashing round in order to fit in a block 
3. it fixes config parsing for percentage values related to slashing and rejects 0% (since that would mean slashing everyone all the time)