### PR TITLE
fix(ci): spot evict retry

### DIFF
--- a/ci3/bootstrap_ec2
+++ b/ci3/bootstrap_ec2
@@ -268,7 +268,7 @@ function run {
       # While the docker container is running, check for spot termination notices.
       while kill -0 \$build_pid &>/dev/null; do
         # The check for the file allows for testing spot termination logic.
-        if [ -f /tmp/spot_term ] || curl -fs -H 'X-aws-ec2-metadata-token: \$aws_token' http://169.254.169.254/latest/meta-data/spot/termination-time &>/dev/null; then
+        if [ -f /tmp/spot_term ] || curl -fs -H 'X-aws-ec2-metadata-token: '\$aws_token http://169.254.169.254/latest/meta-data/spot/termination-time &>/dev/null; then
           # Termination notice found, exit with 155.
           echo 'Spot will be terminated! Exiting early.'
           docker kill aztec_build &>/dev/null || true


### PR DESCRIPTION
Nested quoting bites us again. Recent PR fixed interact ci-shell but broke spot evict because '$aws_token' was literally being passed as the token Manifested here: http://ci.aztec-labs.com/215afb8714a16c87

We rely instead on string concat of nearby strings e.g. a=1; 'a'$a becoming 'a1'