### PR TITLE
chore: add FORCE_LOCAL_ENTRY_QUEUE_CONFIG

### DIFF
--- a/yarn-project/ethereum/src/config.test.ts
+++ b/yarn-project/ethereum/src/config.test.ts
@@ -1,0 +1,116 @@
+import type { NetworkNames } from '@aztec/foundation/config';
+
+import { afterEach, beforeEach, describe, expect, it, jest } from '@jest/globals';
+
+describe('Config', () => {
+  // Store original environment value
+  const originalEnv = process.env.FORCE_LOCAL_ENTRY_QUEUE_CONFIG;
+
+  beforeEach(() => {
+    // Clear the module cache to ensure fresh imports
+    jest.resetModules();
+  });
+
+  afterEach(() => {
+    // Restore original environment value
+    if (originalEnv !== undefined) {
+      process.env.FORCE_LOCAL_ENTRY_QUEUE_CONFIG = originalEnv;
+    } else {
+      delete process.env.FORCE_LOCAL_ENTRY_QUEUE_CONFIG;
+    }
+  });
+
+  describe('getEntryQueueConfig', () => {
+    const dummyNetworks: NetworkNames[] = ['local', 'testnet-ignition'];
+    const realNetworks: NetworkNames[] = ['alpha-testnet', 'testnet'];
+    const allNetworks = [...dummyNetworks, ...realNetworks];
+    it.each(allNetworks)(
+      'should return LocalEntryQueueConfig when FORCE_LOCAL_ENTRY_QUEUE_CONFIG is "true" for %s',
+      async networkName => {
+        // Set environment variable
+        process.env.FORCE_LOCAL_ENTRY_QUEUE_CONFIG = 'true';
+
+        // Dynamic import to get fresh module with new env var
+        const { getEntryQueueConfig } = await import('./config.js');
+
+        const result = getEntryQueueConfig(networkName);
+
+        expect(result).toEqual({
+          bootstrapValidatorSetSize: 0,
+          bootstrapFlushSize: 0,
+          normalFlushSizeMin: 48,
+          normalFlushSizeQuotient: 2,
+        });
+      },
+    );
+
+    it.each(realNetworks)(
+      'should return TestnetEntryQueueConfig for %s when FORCE_LOCAL_ENTRY_QUEUE_CONFIG is not set',
+      async networkName => {
+        delete process.env.FORCE_LOCAL_ENTRY_QUEUE_CONFIG;
+
+        const { getEntryQueueConfig } = await import('./config.js');
+
+        const result = getEntryQueueConfig(networkName);
+
+        expect(result).toEqual({
+          bootstrapValidatorSetSize: 750,
+          bootstrapFlushSize: 75,
+          normalFlushSizeMin: 1,
+          normalFlushSizeQuotient: 2475,
+        });
+      },
+    );
+
+    it.each(dummyNetworks)(
+      'should return LocalEntryQueueConfig for %s when FORCE_LOCAL_ENTRY_QUEUE_CONFIG is not set',
+      async networkName => {
+        delete process.env.FORCE_LOCAL_ENTRY_QUEUE_CONFIG;
+
+        const { getEntryQueueConfig } = await import('./config.js');
+
+        const result = getEntryQueueConfig(networkName);
+
+        expect(result).toEqual({
+          bootstrapValidatorSetSize: 0,
+          bootstrapFlushSize: 0,
+          normalFlushSizeMin: 48,
+          normalFlushSizeQuotient: 2,
+        });
+      },
+    );
+
+    it.each(realNetworks)(
+      'should return TestnetEntryQueueConfig for %s when FORCE_LOCAL_ENTRY_QUEUE_CONFIG is "false"',
+      async networkName => {
+        process.env.FORCE_LOCAL_ENTRY_QUEUE_CONFIG = 'false';
+
+        const { getEntryQueueConfig } = await import('./config.js');
+
+        const result = getEntryQueueConfig(networkName);
+
+        expect(result).toEqual({
+          bootstrapValidatorSetSize: 750,
+          bootstrapFlushSize: 75,
+          normalFlushSizeMin: 1,
+          normalFlushSizeQuotient: 2475,
+        });
+      },
+    );
+
+    it('should return LocalEntryQueueConfig for unknown network when FORCE_LOCAL_ENTRY_QUEUE_CONFIG is not set', async () => {
+      delete process.env.FORCE_LOCAL_ENTRY_QUEUE_CONFIG;
+
+      const { getEntryQueueConfig } = await import('./config.js');
+
+      const result = getEntryQueueConfig('unknown-network' as any);
+
+      expect(result).toEqual({
+        bootstrapValidatorSetSize: 0,
+        bootstrapFlushSize: 0,
+        normalFlushSizeMin: 48,
+        normalFlushSizeQuotient: 2,
+      });
+    });
+  });
+});

--- a/yarn-project/ethereum/src/config.ts
+++ b/yarn-project/ethereum/src/config.ts
@@ -10,6 +10,8 @@ import { EthAddress } from '@aztec/foundation/eth-address';
 
 import { type L1TxUtilsConfig, l1TxUtilsConfigMappings } from './l1_tx_utils.js';
 
+const FORCE_LOCAL_ENTRY_QUEUE_CONFIG = process.env.FORCE_LOCAL_ENTRY_QUEUE_CONFIG === 'true';
+
 export type GenesisStateConfig = {
   /** Whether to populate the genesis state with initial fee juice for the test accounts */
   testAccounts: boolean;
@@ -158,7 +160,9 @@ const TestnetEntryQueueConfig = {
 };
 
 export const getEntryQueueConfig = (networkName: NetworkNames) => {
-  if (networkName === 'alpha-testnet' || networkName === 'testnet') {
+  if (FORCE_LOCAL_ENTRY_QUEUE_CONFIG) {
+    return LocalEntryQueueConfig;
+  } else if (networkName === 'alpha-testnet' || networkName === 'testnet') {
     return TestnetEntryQueueConfig;
   }
   return LocalEntryQueueConfig;


### PR DESCRIPTION
DO NOT MERGE. It is currently unknown if this is desired.

setting the env var `FORCE_LOCAL_ENTRY_QUEUE_CONFIG=true` allows the deployer of contracts to effectively ignore the staking queue. 