### PR TITLE
fix: tie votes to rounds

### DIFF
--- a/l1-contracts/script/InternalGov.s.sol
+++ b/l1-contracts/script/InternalGov.s.sol
@@ -100,18 +100,18 @@ contract GovScript is Test {
 
     emit log_named_address("# Governance proposer", address(governanceProposer));
     emit log_named_uint("\tLifetime in rounds", governanceProposer.LIFETIME_IN_ROUNDS());
-    emit log_named_uint("\tN", governanceProposer.N());
-    emit log_named_uint("\tM", governanceProposer.M());
+    emit log_named_uint("\tQuorum size", governanceProposer.QUORUM_SIZE());
+    emit log_named_uint("\tRound size", governanceProposer.ROUND_SIZE());
   }
 
   function lookAtRounds() public {
     uint256 lifetime = governanceProposer.LIFETIME_IN_ROUNDS();
-    uint256 n = governanceProposer.N();
-    uint256 m = governanceProposer.M();
+    uint256 n = governanceProposer.QUORUM_SIZE();
+    uint256 m = governanceProposer.ROUND_SIZE();
 
     emit log_named_uint("lifetime", lifetime);
-    emit log_named_uint("n       ", n);
-    emit log_named_uint("m       ", m);
+    emit log_named_uint("quorum size", n);
+    emit log_named_uint("round size  ", m);
 
     Slot currentSlot = validatorSelection.getCurrentSlot();
     uint256 currentRound = governanceProposer.computeRound(currentSlot);

--- a/l1-contracts/test/compression/PreHeating.t.sol
+++ b/l1-contracts/test/compression/PreHeating.t.sol
@@ -409,16 +409,17 @@ contract PreHeatingTest is FeeModelTestPoints, DecoderBase {
    * @notice Creates an EIP-712 signature for voteWithSig
    * @param _signer The address that should sign (must match a proposer)
    * @param _proposal The proposal to vote on
+   * @param _round The round to vote in
    * @return The EIP-712 signature
    */
-  function createVoteSignature(address _signer, IPayload _proposal)
+  function createVoteSignature(address _signer, IPayload _proposal, uint256 _round)
     internal
     view
     returns (Signature memory)
   {
     uint256 privateKey = attesterPrivateKeys[_signer];
     require(privateKey != 0, "Private key not found for signer");
-    bytes32 digest = slashingProposer.getVoteSignatureDigest(_proposal, _signer);
+    bytes32 digest = slashingProposer.getVoteSignatureDigest(_proposal, _signer, _round);
 
     (uint8 v, bytes32 r, bytes32 s) = vm.sign(privateKey, digest);
 

--- a/l1-contracts/test/governance/governance-proposer/Base.t.sol
+++ b/l1-contracts/test/governance/governance-proposer/Base.t.sol
@@ -9,7 +9,8 @@ import {GovernanceProposer} from "@aztec/governance/proposer/GovernanceProposer.
 import {IPayload} from "@aztec/governance/interfaces/IPayload.sol";
 import {TestERC20} from "@aztec/mock/TestERC20.sol";
 import {IGSE} from "@aztec/governance/GSE.sol";
-import {IGovernance} from "@aztec/governance/interfaces/IGovernance.sol";
+import {IHaveVersion} from "@aztec/core/interfaces/IRollup.sol";
+import {RollupBuilder} from "../../builder/RollupBuilder.sol";
 
 contract FakeGovernance {
   address immutable GOVERNANCE_PROPOSER;
@@ -44,5 +45,12 @@ contract GovernanceProposerBase is Test {
 
     registry.updateGovernance(address(governance));
     registry.transferOwnership(address(governance));
+
+    RollupBuilder builder = new RollupBuilder(address(this));
+    builder.setMakeGovernance(false).deploy();
+    IHaveVersion rollup = IHaveVersion(address(builder.getConfig().rollup));
+
+    vm.prank(address(governance));
+    registry.addRollup(rollup);
   }
 }

--- a/l1-contracts/test/governance/governance-proposer/constructor.t.sol
+++ b/l1-contracts/test/governance/governance-proposer/constructor.t.sol
@@ -52,8 +52,8 @@ contract ConstructorTest is Test {
     GovernanceProposer g = new GovernanceProposer(REGISTRY, GSE, n, m);
 
     assertEq(address(g.REGISTRY()), address(REGISTRY));
-    assertEq(g.N(), n);
-    assertEq(g.M(), m);
+    assertEq(g.QUORUM_SIZE(), n);
+    assertEq(g.ROUND_SIZE(), m);
     assertEq(g.getExecutor(), address(REGISTRY.getGovernance()), "executor");
     assertEq(g.getInstance(), address(REGISTRY.getCanonicalRollup()), "instance");
   }

--- a/l1-contracts/test/governance/governance-proposer/executeProposal.t.sol
+++ b/l1-contracts/test/governance/governance-proposer/executeProposal.t.sol
@@ -53,7 +53,9 @@ contract ExecuteProposalTest is GovernanceProposerBase {
 
   modifier whenRoundInPast() {
     vm.warp(
-      Timestamp.unwrap(validatorSelection.getTimestampForSlot(Slot.wrap(governanceProposer.M())))
+      Timestamp.unwrap(
+        validatorSelection.getTimestampForSlot(Slot.wrap(governanceProposer.ROUND_SIZE()))
+      )
     );
     _;
   }
@@ -66,7 +68,7 @@ contract ExecuteProposalTest is GovernanceProposerBase {
     // it revert
 
     Slot lower = validatorSelection.getCurrentSlot()
-      + Slot.wrap(governanceProposer.M() * governanceProposer.LIFETIME_IN_ROUNDS() + 1);
+      + Slot.wrap(governanceProposer.ROUND_SIZE() * governanceProposer.LIFETIME_IN_ROUNDS() + 1);
     Slot upper = Slot.wrap(
       (type(uint64).max - Timestamp.unwrap(validatorSelection.getGenesisTime()))
         / validatorSelection.getSlotDuration()
@@ -98,7 +100,7 @@ contract ExecuteProposalTest is GovernanceProposerBase {
 
     {
       // Need to execute a proposal first here.
-      for (uint256 i = 0; i < governanceProposer.N(); i++) {
+      for (uint256 i = 0; i < governanceProposer.QUORUM_SIZE(); i++) {
         vm.prank(proposer);
         assertTrue(governanceProposer.vote(proposal));
         vm.warp(
@@ -112,7 +114,7 @@ contract ExecuteProposalTest is GovernanceProposerBase {
       vm.warp(
         Timestamp.unwrap(
           validatorSelection.getTimestampForSlot(
-            validatorSelection.getCurrentSlot() + Slot.wrap(governanceProposer.M())
+            validatorSelection.getCurrentSlot() + Slot.wrap(governanceProposer.ROUND_SIZE())
           )
         )
       );
@@ -139,13 +141,13 @@ contract ExecuteProposalTest is GovernanceProposerBase {
     // it revert
 
     // The first slot in the next round (round 1)
-    Slot lowerSlot = Slot.wrap(governanceProposer.M());
+    Slot lowerSlot = Slot.wrap(governanceProposer.ROUND_SIZE());
     uint256 lower = Timestamp.unwrap(validatorSelection.getTimestampForSlot(lowerSlot));
     // the last slot in the LIFETIME_IN_ROUNDS next round
     uint256 upper = Timestamp.unwrap(
       validatorSelection.getTimestampForSlot(
         lowerSlot
-          + Slot.wrap(governanceProposer.M() * (governanceProposer.LIFETIME_IN_ROUNDS() - 1))
+          + Slot.wrap(governanceProposer.ROUND_SIZE() * (governanceProposer.LIFETIME_IN_ROUNDS() - 1))
       )
     );
     uint256 time = bound(_slotsToJump, lower, upper);
@@ -175,12 +177,12 @@ contract ExecuteProposalTest is GovernanceProposerBase {
     vm.prank(proposer);
     governanceProposer.vote(proposal);
 
-    uint256 votesNeeded = governanceProposer.N();
+    uint256 votesNeeded = governanceProposer.QUORUM_SIZE();
 
     vm.warp(
       Timestamp.unwrap(
         validatorSelection.getTimestampForSlot(
-          validatorSelection.getCurrentSlot() + Slot.wrap(governanceProposer.M())
+          validatorSelection.getCurrentSlot() + Slot.wrap(governanceProposer.ROUND_SIZE())
         )
       )
     );
@@ -191,7 +193,7 @@ contract ExecuteProposalTest is GovernanceProposerBase {
   }
 
   modifier givenSufficientYea(uint256 _yeas) {
-    uint256 limit = bound(_yeas, governanceProposer.N(), governanceProposer.M());
+    uint256 limit = bound(_yeas, governanceProposer.QUORUM_SIZE(), governanceProposer.ROUND_SIZE());
 
     for (uint256 i = 0; i < limit; i++) {
       vm.prank(proposer);
@@ -205,7 +207,7 @@ contract ExecuteProposalTest is GovernanceProposerBase {
     vm.warp(
       Timestamp.unwrap(
         validatorSelection.getTimestampForSlot(
-          validatorSelection.getCurrentSlot() + Slot.wrap(governanceProposer.M())
+          validatorSelection.getCurrentSlot() + Slot.wrap(governanceProposer.ROUND_SIZE())
         )
       )
     );
@@ -244,7 +246,7 @@ contract ExecuteProposalTest is GovernanceProposerBase {
     vm.warp(
       Timestamp.unwrap(
         validatorSelection.getTimestampForSlot(
-          validatorSelection.getCurrentSlot() + Slot.wrap(2 * governanceProposer.M())
+          validatorSelection.getCurrentSlot() + Slot.wrap(2 * governanceProposer.ROUND_SIZE())
         )
       )
     );

--- a/l1-contracts/test/governance/governance-proposer/scenario/15123.t.sol
+++ b/l1-contracts/test/governance/governance-proposer/scenario/15123.t.sol
@@ -58,7 +58,8 @@ contract Test15123 is GovernanceProposerBase {
     registry.addRollup(IRollup(address(validatorSelection)));
     vm.warp(Timestamp.unwrap(validatorSelection.getTimestampForSlot(Slot.wrap(1))));
 
-    signature = createSignature(privateKey, address(proposal), 0);
+    uint256 round = governanceProposer.getCurrentRound();
+    signature = createSignature(privateKey, address(proposal), 0, round);
 
     governanceProposer.voteWithSig(proposal, signature);
 
@@ -80,7 +81,7 @@ contract Test15123 is GovernanceProposerBase {
     );
   }
 
-  function createSignature(uint256 _privateKey, address _payload, uint256 _nonce)
+  function createSignature(uint256 _privateKey, address _payload, uint256 _nonce, uint256 _round)
     internal
     view
     returns (Signature memory)
@@ -94,7 +95,8 @@ contract Test15123 is GovernanceProposerBase {
       abi.encode(TYPE_HASH, hashedName, hashedVersion, block.chainid, address(governanceProposer))
     );
     bytes32 digest = MessageHashUtils.toTypedDataHash(
-      domainSeparator, keccak256(abi.encode(governanceProposer.VOTE_TYPEHASH(), _payload, _nonce))
+      domainSeparator,
+      keccak256(abi.encode(governanceProposer.VOTE_TYPEHASH(), _payload, _nonce, _round))
     );
 
     (uint8 v, bytes32 r, bytes32 s) = vm.sign(_privateKey, digest);

--- a/l1-contracts/test/governance/governance-proposer/vote.t.sol
+++ b/l1-contracts/test/governance/governance-proposer/vote.t.sol
@@ -76,6 +76,18 @@ contract VoteTest is GovernanceProposerBase {
     governanceProposer.vote(proposal);
   }
 
+  function test_GivenVoteIsForPriorRound()
+    external
+    whenProposalHoldCode
+    givenCanonicalRollupHoldCode
+  // solhint-disable-next-line no-empty-blocks
+  {
+    // it revert
+
+    // This case is not possible unless you are voting with a signature.
+    // See `voteWithSig.t.sol` for the test case.
+  }
+
   modifier givenNoVoteAlreadyCastInTheSlot() {
     _;
   }

--- a/l1-contracts/test/governance/governance-proposer/vote.tree
+++ b/l1-contracts/test/governance/governance-proposer/vote.tree
@@ -7,6 +7,8 @@ VoteTest
     └── given canonical rollup hold code
         ├── given a vote already cast in the slot
         │   └── it revert
+        ├── given vote is for prior round
+        │   └── it revert
         └── given no vote already cast in the slot
             ├── when caller is not proposer
             │   └── it revert

--- a/l1-contracts/test/governance/scenario/slashing/Slashing.t.sol
+++ b/l1-contracts/test/governance/scenario/slashing/Slashing.t.sol
@@ -44,7 +44,7 @@ contract SlashingTest is TestBase {
   function _createAndExecutePayload(address[] memory _attesters, uint96 _slashAmount) internal {
     // Lets make a proposal to slash! For
     // We jump to perfectly land at the start of the next round
-    uint256 desiredSlot = (slashingProposer.getCurrentRound() + 1) * slashingProposer.M();
+    uint256 desiredSlot = (slashingProposer.getCurrentRound() + 1) * slashingProposer.ROUND_SIZE();
 
     timeCheater.cheat__jumpToSlot(desiredSlot);
     uint256 round = slashingProposer.getCurrentRound();

--- a/l1-contracts/test/staking/15050.t.sol
+++ b/l1-contracts/test/staking/15050.t.sol
@@ -52,7 +52,7 @@ contract Test15050 is StakingBase {
     stdstore.clear();
     stdstore.target(address(caller)).sig("yeaCount(address,uint256,address)").with_key(
       address(staking)
-    ).with_key(uint256(0)).with_key(address(payload)).checked_write(caller.M());
+    ).with_key(uint256(0)).with_key(address(payload)).checked_write(caller.ROUND_SIZE());
 
     assertEq(caller.getCurrentRound(), 0);
 

--- a/yarn-project/end-to-end/src/e2e_p2p/add_rollup.test.ts
+++ b/yarn-project/end-to-end/src/e2e_p2p/add_rollup.test.ts
@@ -111,7 +111,7 @@ describe('e2e_p2p_add_rollup', () => {
       client: t.ctx.deployL1ContractsValues.l1Client,
     });
 
-    const roundSize = await governanceProposer.read.M();
+    const roundSize = await governanceProposer.read.ROUND_SIZE();
 
     const governance = getContract({
       address: getAddress(t.ctx.deployL1ContractsValues.l1ContractAddresses.governanceAddress.toString()),
@@ -231,8 +231,8 @@ describe('e2e_p2p_add_rollup', () => {
     await sleep(4000);
 
     t.logger.info('Start progressing time to cast votes');
-    const quorumSize = await governanceProposer.read.N();
-    t.logger.info(`Quorum size: ${quorumSize}, round size: ${await governanceProposer.read.M()}`);
+    const quorumSize = await governanceProposer.read.QUORUM_SIZE();
+    t.logger.info(`Quorum size: ${quorumSize}, round size: ${await governanceProposer.read.ROUND_SIZE()}`);
 
     const bridging = async (
       node: AztecNodeService,

--- a/yarn-project/end-to-end/src/e2e_p2p/upgrade_governance_proposer.test.ts
+++ b/yarn-project/end-to-end/src/e2e_p2p/upgrade_governance_proposer.test.ts
@@ -80,7 +80,7 @@ describe('e2e_p2p_governance_proposer', () => {
       client: t.ctx.deployL1ContractsValues.l1Client,
     });
 
-    const roundSize = await governanceProposer.read.M();
+    const roundSize = await governanceProposer.read.ROUND_SIZE();
 
     const governance = getContract({
       address: getAddress(t.ctx.deployL1ContractsValues.l1ContractAddresses.governanceAddress.toString()),
@@ -157,8 +157,8 @@ describe('e2e_p2p_governance_proposer', () => {
     await sleep(4000);
 
     t.logger.info('Start progressing time to cast votes');
-    const quorumSize = await governanceProposer.read.N();
-    t.logger.info(`Quorum size: ${quorumSize}, round size: ${await governanceProposer.read.M()}`);
+    const quorumSize = await governanceProposer.read.QUORUM_SIZE();
+    t.logger.info(`Quorum size: ${quorumSize}, round size: ${await governanceProposer.read.ROUND_SIZE()}`);
 
     let govData;
     while (true) {

--- a/yarn-project/ethereum/src/contracts/empire_base.ts
+++ b/yarn-project/ethereum/src/contracts/empire_base.ts
@@ -11,6 +11,7 @@ export interface IEmpireBase {
   createVoteRequest(payload: Hex): L1TxRequest;
   createVoteRequestWithSignature(
     payload: Hex,
+    round: bigint,
     chainId: number,
     signerAddress: Hex,
     signer: (msg: Hex) => Promise<Hex>,
@@ -46,6 +47,7 @@ export async function signVoteWithSig(
   signer: (msg: Hex) => Promise<Hex>,
   proposal: Hex,
   nonce: bigint,
+  round: bigint,
   verifyingContract: Hex,
   chainId: number,
 ): Promise<Signature> {
@@ -60,12 +62,14 @@ export async function signVoteWithSig(
     Vote: [
       { name: 'proposal', type: 'address' },
       { name: 'nonce', type: 'uint256' },
+      { name: 'round', type: 'uint256' },
     ],
   };
 
   const message = {
     proposal,
     nonce,
+    round,
   };
 
   const msg = hashTypedData({ domain, types, primaryType: 'Vote', message });

--- a/yarn-project/ethereum/src/contracts/governance_proposer.ts
+++ b/yarn-project/ethereum/src/contracts/governance_proposer.ts
@@ -33,11 +33,11 @@ export class GovernanceProposerContract implements IEmpireBase {
   }
 
   public getQuorumSize(): Promise<bigint> {
-    return this.proposer.read.N();
+    return this.proposer.read.QUORUM_SIZE();
   }
 
   public getRoundSize(): Promise<bigint> {
-    return this.proposer.read.M();
+    return this.proposer.read.ROUND_SIZE();
   }
 
   public computeRound(slot: bigint): Promise<bigint> {
@@ -68,12 +68,13 @@ export class GovernanceProposerContract implements IEmpireBase {
 
   public async createVoteRequestWithSignature(
     payload: Hex,
+    round: bigint,
     chainId: number,
     signerAddress: Hex,
     signer: (msg: Hex) => Promise<Hex>,
   ): Promise<L1TxRequest> {
     const nonce = await this.getNonce(signerAddress);
-    const signature = await signVoteWithSig(signer, payload, nonce, this.address.toString(), chainId);
+    const signature = await signVoteWithSig(signer, payload, nonce, round, this.address.toString(), chainId);
     return {
       to: this.address.toString(),
       data: encodeVoteWithSignature(payload, signature),

--- a/yarn-project/ethereum/src/contracts/slashing_proposer.ts
+++ b/yarn-project/ethereum/src/contracts/slashing_proposer.ts
@@ -40,11 +40,11 @@ export class SlashingProposerContract extends EventEmitter implements IEmpireBas
   }
 
   public getQuorumSize() {
-    return this.proposer.read.N();
+    return this.proposer.read.QUORUM_SIZE();
   }
 
   public getRoundSize() {
-    return this.proposer.read.M();
+    return this.proposer.read.ROUND_SIZE();
   }
 
   public computeRound(slot: bigint): Promise<bigint> {
@@ -75,12 +75,13 @@ export class SlashingProposerContract extends EventEmitter implements IEmpireBas
 
   public async createVoteRequestWithSignature(
     payload: Hex,
+    round: bigint,
     chainId: number,
     signerAddress: Hex,
     signer: (msg: Hex) => Promise<Hex>,
   ): Promise<L1TxRequest> {
     const nonce = await this.getNonce(signerAddress);
-    const signature = await signVoteWithSig(signer, payload, nonce, this.address.toString(), chainId);
+    const signature = await signVoteWithSig(signer, payload, nonce, round, this.address.toString(), chainId);
     return {
       to: this.address.toString(),
       data: encodeVoteWithSignature(payload, signature),

--- a/yarn-project/sequencer-client/src/publisher/sequencer-publisher.ts
+++ b/yarn-project/sequencer-client/src/publisher/sequencer-publisher.ts
@@ -432,6 +432,7 @@ export class SequencerPublisher {
 
     const request = await base.createVoteRequestWithSignature(
       payload.toString(),
+      round,
       this.config.l1ChainId,
       signerAddress.toString(),
       signer,


### PR DESCRIPTION
Updates the signature scheme for votes by adding the round number to the EIP-712 signature, which provides additional security by preventing signature reuse across different rounds.

Also renames the variables `N` and `M` in the `EmpireBase` contract to `QUORUM_SIZE` and `ROUND_SIZE` respectively to improve code readability and make their purpose more explicit.
