### PR TITLE
fix: bug in PXE::getNotes

### DIFF
--- a/yarn-project/cli/src/utils/inspect.ts
+++ b/yarn-project/cli/src/utils/inspect.ts
@@ -110,7 +110,9 @@ export async function inspectTx(
     log(' Nullifiers:');
     for (const nullifier of effects.nullifiers) {
       const deployed = deployNullifiers[nullifier.toString()];
-      const [note] = await pxe.getNotes({ siloedNullifier: nullifier, contractAddress: deployed });
+      const note = deployed
+        ? (await pxe.getNotes({ siloedNullifier: nullifier, contractAddress: deployed }))[0]
+        : undefined;
       const initialized = initNullifiers[nullifier.toString()];
       const registered = classNullifiers[nullifier.toString()];
       if (nullifier.toBuffer().equals(txHash.toBuffer())) {

--- a/yarn-project/cli/src/utils/inspect.ts
+++ b/yarn-project/cli/src/utils/inspect.ts
@@ -40,14 +40,7 @@ export async function inspectTx(
   log: LogFn,
   opts: { includeBlockInfo?: boolean; artifactMap?: ArtifactMap } = {},
 ) {
-  const [receipt, effectsInBlock] = await Promise.all([
-    pxe.getTxReceipt(txHash),
-    pxe.getTxEffect(txHash),
-    // Disabled getting notes here as now we need to provide the contract address on input. Since until now it
-    // basically didn't work as we didn't call sync_private_state() I don't think anyone cares about this. Getting
-    // the addresses this tx interacted with here is problematic.
-    // pxe.getNotes({ txHash, status: NoteStatus.ACTIVE_OR_NULLIFIED }),
-  ]);
+  const [receipt, effectsInBlock] = await Promise.all([pxe.getTxReceipt(txHash), pxe.getTxEffect(txHash)]);
   // Base tx data
   log(`Tx ${txHash.toString()}`);
   log(` Status: ${receipt.status} ${effectsInBlock ? `(${effectsInBlock.data.revertCode.getDescription()})` : ''}`);
@@ -87,21 +80,15 @@ export async function inspectTx(
     }
   }
 
-  // Disabled getting notes here as now we need to provide the contract address on input. Since until now it
-  // basically didn't work as we didn't call sync_private_state() I don't think anyone cares about this. Getting
-  // the addresses this tx interacted with here is problematic.
-  // // Created notes
-  // const notes = effects.noteHashes;
-  // if (notes.length > 0) {
-  //   log(' Created notes:');
-  //   log(`  Total: ${notes.length}. Found: ${getNotes.length}.`);
-  //   if (getNotes.length) {
-  //     log('  Found notes:');
-  //     for (const note of getNotes) {
-  //       inspectNote(note, artifactMap, log);
-  //     }
-  //   }
-  // }
+  // Created notes
+  const notes = effects.noteHashes;
+  if (notes.length > 0) {
+    log(' Created notes:');
+    log(`  Total: ${notes.length}`);
+    for (const note of notes) {
+      log(`  Note hash: ${note.toShortString()}`);
+    }
+  }
 
   // Nullifiers
   const nullifierCount = effects.nullifiers.length;

--- a/yarn-project/end-to-end/src/e2e_blacklist_token_contract/minting.test.ts
+++ b/yarn-project/end-to-end/src/e2e_blacklist_token_contract/minting.test.ts
@@ -93,10 +93,8 @@ describe('e2e_blacklist_token_contract mint', () => {
         const receiptClaim = await asset.methods.redeem_shield(wallets[0].getAddress(), amount, secret).send().wait();
 
         tokenSim.mintPrivate(wallets[0].getAddress(), amount);
-        // Trigger a note sync
-        await asset.methods.sync_private_state().simulate();
         // 1 note should have been created containing `amount` of tokens
-        const visibleNotes = await pxe.getNotes({ txHash: receiptClaim.txHash });
+        const visibleNotes = await pxe.getNotes({ txHash: receiptClaim.txHash, contractAddress: asset.address });
         expect(visibleNotes.length).toBe(1);
         expect(visibleNotes[0].note.items[0].toBigInt()).toBe(amount);
       });

--- a/yarn-project/end-to-end/src/e2e_crowdfunding_and_claim.test.ts
+++ b/yarn-project/end-to-end/src/e2e_crowdfunding_and_claim.test.ts
@@ -161,8 +161,10 @@ describe('e2e_crowdfunding_and_claim', () => {
         .wait();
 
       // Get the notes emitted by the Crowdfunding contract and check that only 1 was emitted (the UintNote)
-      await crowdfundingContract.withWallet(donorWallets[0]).methods.sync_private_state().simulate();
-      const notes = await pxe.getNotes({ txHash: donateTxReceipt.txHash });
+      const notes = await pxe.getNotes({
+        txHash: donateTxReceipt.txHash,
+        contractAddress: crowdfundingContract.address,
+      });
       const filteredNotes = notes.filter(x => x.contractAddress.equals(crowdfundingContract.address));
       expect(filteredNotes!.length).toEqual(1);
 
@@ -225,8 +227,7 @@ describe('e2e_crowdfunding_and_claim', () => {
       .wait();
 
     // Get the notes emitted by the Crowdfunding contract and check that only 1 was emitted (the UintNote)
-    await crowdfundingContract.withWallet(unrelatedWallet).methods.sync_private_state().simulate();
-    const notes = await pxe.getNotes({ txHash: donateTxReceipt.txHash });
+    const notes = await pxe.getNotes({ contractAddress: crowdfundingContract.address, txHash: donateTxReceipt.txHash });
     const filtered = notes.filter(x => x.contractAddress.equals(crowdfundingContract.address));
     expect(filtered!.length).toEqual(1);
 
@@ -272,8 +273,7 @@ describe('e2e_crowdfunding_and_claim', () => {
         .call_create_note(arbitraryValue, owner, sender, arbitraryStorageSlot)
         .send()
         .wait();
-      await testContract.methods.sync_private_state().simulate();
-      const notes = await pxe.getNotes({ txHash: receipt.txHash });
+      const notes = await pxe.getNotes({ txHash: receipt.txHash, contractAddress: testContract.address });
       expect(notes.length).toEqual(1);
       note = processUniqueNote(notes[0]);
     }

--- a/yarn-project/end-to-end/src/e2e_pending_note_hashes_contract.test.ts
+++ b/yarn-project/end-to-end/src/e2e_pending_note_hashes_contract.test.ts
@@ -293,9 +293,7 @@ describe('e2e_pending_note_hashes_contract', () => {
     // Then emit another note log with the same counter as the one above, but with value 5
     const txReceipt = await deployedContract.methods.test_emit_bad_note_log(owner, sender).send().wait();
 
-    await deployedContract.methods.sync_private_state().simulate();
-
-    const notes = await pxe.getNotes({ txHash: txReceipt.txHash });
+    const notes = await pxe.getNotes({ txHash: txReceipt.txHash, contractAddress: deployedContract.address });
 
     expect(notes.length).toBe(1);
   });

--- a/yarn-project/pxe/src/contract_function_simulator/pxe_oracle_interface.test.ts
+++ b/yarn-project/pxe/src/contract_function_simulator/pxe_oracle_interface.test.ts
@@ -487,7 +487,7 @@ describe('PXEOracleInterface', () => {
       );
 
       // Verify note was stored
-      const notes = await noteDataProvider.getNotes({ recipient: recipient.address });
+      const notes = await noteDataProvider.getNotes({ recipient: recipient.address, contractAddress });
       expect(notes).toHaveLength(1);
       expect(notes[0].noteHash.equals(noteHash)).toBe(true);
     });
@@ -537,7 +537,7 @@ describe('PXEOracleInterface', () => {
       );
 
       // Verify note was removed
-      const notes = await noteDataProvider.getNotes({ recipient: recipient.address });
+      const notes = await noteDataProvider.getNotes({ recipient: recipient.address, contractAddress });
       expect(notes).toHaveLength(0);
     });
 
@@ -607,7 +607,11 @@ describe('PXEOracleInterface', () => {
       );
 
       // Verify note was stored and not removed
-      const notes = await noteDataProvider.getNotes({ recipient: recipient.address, status: NoteStatus.ACTIVE });
+      const notes = await noteDataProvider.getNotes({
+        recipient: recipient.address,
+        contractAddress,
+        status: NoteStatus.ACTIVE,
+      });
       expect(notes).toHaveLength(1);
       expect(notes[0].noteHash.equals(noteHash)).toBe(true);
     });
@@ -823,7 +827,7 @@ describe('PXEOracleInterface', () => {
 
     beforeEach(async () => {
       // Check that there are no notes in the database
-      const notes = await noteDataProvider.getNotes({});
+      const notes = await noteDataProvider.getNotes({ contractAddress });
       expect(notes).toHaveLength(0);
 
       // Check that the expected number of accounts is present

--- a/yarn-project/pxe/src/pxe_service/pxe_service.ts
+++ b/yarn-project/pxe/src/pxe_service/pxe_service.ts
@@ -658,6 +658,9 @@ export class PXEService implements PXE {
   }
 
   public async getNotes(filter: NotesFilter): Promise<UniqueNote[]> {
+    // We need to manually trigger private state sync to have a guarantee that all the events are available.
+    await this.simulateUtility('sync_private_state', [], filter.contractAddress);
+
     const noteDaos = await this.noteDataProvider.getNotes(filter);
 
     const extendedNotes = noteDaos.map(async dao => {

--- a/yarn-project/stdlib/src/note/notes_filter.ts
+++ b/yarn-project/stdlib/src/note/notes_filter.ts
@@ -12,10 +12,13 @@ import { NoteStatus } from './note_status.js';
  * @remarks This filter is applied as an intersection of all its params.
  */
 export type NotesFilter = {
+  /**
+   * The contract address the note belongs to.
+   * @remarks Providing a contract address is required as we need that information to trigger private state sync.
+   */
+  contractAddress: AztecAddress;
   /** Hash of a transaction from which to fetch the notes. */
   txHash?: TxHash;
-  /** The contract address the note belongs to. */
-  contractAddress?: AztecAddress;
   /** The specific storage location of the note on the contract. */
   storageSlot?: Fr;
   /** The recipient of the note (whose public key was used to encrypt the note). */
@@ -29,8 +32,8 @@ export type NotesFilter = {
 };
 
 export const NotesFilterSchema: ZodFor<NotesFilter> = z.object({
+  contractAddress: schemas.AztecAddress,
   txHash: TxHash.schema.optional(),
-  contractAddress: schemas.AztecAddress.optional(),
   storageSlot: schemas.Fr.optional(),
   recipient: schemas.AztecAddress.optional(),
   status: z.nativeEnum(NoteStatus).optional(),


### PR DESCRIPTION
`PXE::getNotes` didn't trigger private state sync.This had an impact on the `NotesFilter` as now the contract address is mandatory as it's needed for the note sync. `PXE::getPrivateEvents` behaves the same way.