### PR TITLE
chore: remove large vk constructors meant for msgpack

### DIFF
--- a/barretenberg/cpp/src/barretenberg/eccvm/eccvm_flavor.hpp
+++ b/barretenberg/cpp/src/barretenberg/eccvm/eccvm_flavor.hpp
@@ -801,9 +801,26 @@ class ECCVMFlavor {
             // TODO(https://github.com/AztecProtocol/barretenberg/issues/1466): Implement this function.
             throw_or_abort("Not implemented yet!");
         }
-        // TODO(https://github.com/AztecProtocol/barretenberg/issues/1324): Remove `circuit_size` and
-        // `log_circuit_size` from MSGPACK and the verification key. Don't statically check for object completion.
+        /**
+         * @brief Adds the verification key hash to the transcript and returns the hash.
+         * @details Needed to make sure the Origin Tag system works. See the base class function for
+         * more details.
+         *
+         * @param domain_separator
+         * @param transcript
+         * @returns The hash of the verification key
+         */
+        fr add_hash_to_transcript([[maybe_unused]] const std::string& domain_separator,
+                                  [[maybe_unused]] Transcript& transcript) const override
+        {
+            for (const Commitment& commitment : this->get_all()) {
+                transcript.add_to_independent_hash_buffer(domain_separator + "vk_commitment", commitment);
+            }
+            return transcript.hash_independent_buffer(domain_separator + "vk_hash");
+        }
 
+        // TODO(https://github.com/AztecProtocol/barretenberg/issues/1324): Remove `circuit_size` and `log_circuit_size`
+        // from MSGPACK and the verification key.
         // Don't statically check for object completeness.
         using MSGPACK_NO_STATIC_CHECK = std::true_type;
         MSGPACK_FIELDS(circuit_size,

--- a/barretenberg/cpp/src/barretenberg/eccvm/eccvm_flavor.hpp
+++ b/barretenberg/cpp/src/barretenberg/eccvm/eccvm_flavor.hpp
@@ -801,27 +801,11 @@ class ECCVMFlavor {
             // TODO(https://github.com/AztecProtocol/barretenberg/issues/1466): Implement this function.
             throw_or_abort("Not implemented yet!");
         }
+        // TODO(https://github.com/AztecProtocol/barretenberg/issues/1324): Remove `circuit_size` and
+        // `log_circuit_size` from MSGPACK and the verification key. Don't statically check for object completion.
 
-        /**
-         * @brief Adds the verification key hash to the transcript and returns the hash.
-         * @details Needed to make sure the Origin Tag system works. See the base class function for
-         * more details.
-         *
-         * @param domain_separator
-         * @param transcript
-         * @returns The hash of the verification key
-         */
-        fr add_hash_to_transcript([[maybe_unused]] const std::string& domain_separator,
-                                  [[maybe_unused]] Transcript& transcript) const override
-        {
-            for (const Commitment& commitment : this->get_all()) {
-                transcript.add_to_independent_hash_buffer(domain_separator + "vk_commitment", commitment);
-            }
-            return transcript.hash_independent_buffer(domain_separator + "vk_hash");
-        }
-
-        // TODO(https://github.com/AztecProtocol/barretenberg/issues/1324): Remove `circuit_size` and `log_circuit_size`
-        // from MSGPACK and the verification key.
+        // Don't statically check for object completeness.
+        using MSGPACK_NO_STATIC_CHECK = std::true_type;
         MSGPACK_FIELDS(circuit_size,
                        log_circuit_size,
                        num_public_inputs,

--- a/barretenberg/cpp/src/barretenberg/flavor/mega_flavor.hpp
+++ b/barretenberg/cpp/src/barretenberg/flavor/mega_flavor.hpp
@@ -535,7 +535,6 @@ class MegaFlavor {
             return transcript.hash_independent_buffer(domain_separator + "vk_hash");
         }
 
-        // WORKTODO closes https://github.com/AztecProtocol/barretenberg/issues/964
         // Don't statically check for object completeness.
         using MSGPACK_NO_STATIC_CHECK = std::true_type;
         MSGPACK_FIELDS(circuit_size,

--- a/barretenberg/cpp/src/barretenberg/flavor/mega_flavor.hpp
+++ b/barretenberg/cpp/src/barretenberg/flavor/mega_flavor.hpp
@@ -535,81 +535,9 @@ class MegaFlavor {
             return transcript.hash_independent_buffer(domain_separator + "vk_hash");
         }
 
-        // TODO(https://github.com/AztecProtocol/barretenberg/issues/964): Clean the boilerplate up.
-        // Explicit constructor for msgpack serialization
-        VerificationKey(const size_t circuit_size,
-                        const size_t num_public_inputs,
-                        const size_t pub_inputs_offset,
-                        const PublicComponentKey& pairing_inputs_public_input_key,
-                        const DatabusPropagationData& databus_propagation_data,
-                        const Commitment& q_m,
-                        const Commitment& q_c,
-                        const Commitment& q_l,
-                        const Commitment& q_r,
-                        const Commitment& q_o,
-                        const Commitment& q_4,
-                        const Commitment& q_busread,
-                        const Commitment& q_lookup,
-                        const Commitment& q_arith,
-                        const Commitment& q_delta_range,
-                        const Commitment& q_elliptic,
-                        const Commitment& q_aux,
-                        const Commitment& q_poseidon2_external,
-                        const Commitment& q_poseidon2_internal,
-                        const Commitment& sigma_1,
-                        const Commitment& sigma_2,
-                        const Commitment& sigma_3,
-                        const Commitment& sigma_4,
-                        const Commitment& id_1,
-                        const Commitment& id_2,
-                        const Commitment& id_3,
-                        const Commitment& id_4,
-                        const Commitment& table_1,
-                        const Commitment& table_2,
-                        const Commitment& table_3,
-                        const Commitment& table_4,
-                        const Commitment& lagrange_first,
-                        const Commitment& lagrange_last,
-                        const Commitment& lagrange_ecc_op,
-                        const Commitment& databus_id)
-        {
-            this->circuit_size = circuit_size;
-            this->log_circuit_size = numeric::get_msb(this->circuit_size);
-            this->num_public_inputs = num_public_inputs;
-            this->pub_inputs_offset = pub_inputs_offset;
-            this->pairing_inputs_public_input_key = pairing_inputs_public_input_key;
-            this->databus_propagation_data = databus_propagation_data;
-            this->q_m = q_m;
-            this->q_c = q_c;
-            this->q_l = q_l;
-            this->q_r = q_r;
-            this->q_o = q_o;
-            this->q_4 = q_4;
-            this->q_busread = q_busread;
-            this->q_lookup = q_lookup;
-            this->q_arith = q_arith;
-            this->q_delta_range = q_delta_range;
-            this->q_elliptic = q_elliptic;
-            this->q_aux = q_aux;
-            this->q_poseidon2_external = q_poseidon2_external;
-            this->q_poseidon2_internal = q_poseidon2_internal;
-            this->sigma_1 = sigma_1;
-            this->sigma_2 = sigma_2;
-            this->sigma_3 = sigma_3;
-            this->sigma_4 = sigma_4;
-            this->id_1 = id_1;
-            this->id_2 = id_2;
-            this->id_3 = id_3;
-            this->id_4 = id_4;
-            this->table_1 = table_1;
-            this->table_2 = table_2;
-            this->table_3 = table_3;
-            this->table_4 = table_4;
-            this->lagrange_first = lagrange_first;
-            this->lagrange_last = lagrange_last;
-            this->lagrange_ecc_op = lagrange_ecc_op;
-            this->databus_id = databus_id;
-        }
+        // WORKTODO closes https://github.com/AztecProtocol/barretenberg/issues/964
+        // Don't statically check for object completeness.
+        using MSGPACK_NO_STATIC_CHECK = std::true_type;
         MSGPACK_FIELDS(circuit_size,
                        log_circuit_size,
                        num_public_inputs,

--- a/barretenberg/cpp/src/barretenberg/serialize/msgpack_impl/struct_map_impl.hpp
+++ b/barretenberg/cpp/src/barretenberg/serialize/msgpack_impl/struct_map_impl.hpp
@@ -24,8 +24,8 @@ template <msgpack_concepts::HasMsgPack T> struct convert<T> {
                               "MSGPACK_FIELDS requires a constructor that can take the types listed in MSGPACK_FIELDS. "
                               "Type or arg count mismatch, or member initializer constructor not available.");
             };
+            // Call static checker to ensure we have a constructor that takes all fields - unless we opt-out.
             if constexpr (!requires { typename T::MSGPACK_NO_STATIC_CHECK; }) {
-                // static check that the types match
                 std::apply(static_checker, drop_keys(std::tie(args...)));
             }
             msgpack::type::define_map<decltype(args)...>{ args... }.msgpack_unpack(o);
@@ -49,6 +49,7 @@ template <msgpack_concepts::HasMsgPack T> struct pack<T> {
                               "Alternatively, a matching member initializer constructor might not be available for T "
                               "and should be defined.");
             };
+            // Call static checker to ensure we have a constructor that takes all fields - unless we opt-out.
             if constexpr (!requires { typename T::MSGPACK_NO_STATIC_CHECK; }) {
                 std::apply(static_checker, drop_keys(std::tie(args...)));
             }

--- a/barretenberg/cpp/src/barretenberg/serialize/msgpack_impl/struct_map_impl.hpp
+++ b/barretenberg/cpp/src/barretenberg/serialize/msgpack_impl/struct_map_impl.hpp
@@ -24,7 +24,10 @@ template <msgpack_concepts::HasMsgPack T> struct convert<T> {
                               "MSGPACK_FIELDS requires a constructor that can take the types listed in MSGPACK_FIELDS. "
                               "Type or arg count mismatch, or member initializer constructor not available.");
             };
-            std::apply(static_checker, drop_keys(std::tie(args...)));
+            if constexpr (!requires { typename T::MSGPACK_NO_STATIC_CHECK; }) {
+                // static check that the types match
+                std::apply(static_checker, drop_keys(std::tie(args...)));
+            }
             msgpack::type::define_map<decltype(args)...>{ args... }.msgpack_unpack(o);
         });
         return o;
@@ -42,11 +45,13 @@ template <msgpack_concepts::HasMsgPack T> struct pack<T> {
                 static_assert(msgpack_concepts::MsgpackConstructible<T, decltype(value_args)...>,
                               "T requires a constructor that can take the fields listed in MSGPACK_FIELDS (T will be "
                               "in template parameters in the compiler stack trace)"
-                              "Check the MSGPACK_FIELDS macro usage in T for incompleteness or wrong order."
+                              "Check the MSGPACK_FIELDS macro usage in T for incompleteness or wrong order. "
                               "Alternatively, a matching member initializer constructor might not be available for T "
                               "and should be defined.");
             };
-            std::apply(static_checker, drop_keys(std::tie(args...)));
+            if constexpr (!requires { typename T::MSGPACK_NO_STATIC_CHECK; }) {
+                std::apply(static_checker, drop_keys(std::tie(args...)));
+            }
             msgpack::type::define_map<decltype(args)...>{ args... }.msgpack_pack(o);
         });
         return o;

--- a/barretenberg/cpp/src/barretenberg/translator_vm/translator_flavor.hpp
+++ b/barretenberg/cpp/src/barretenberg/translator_vm/translator_flavor.hpp
@@ -782,11 +782,10 @@ class TranslatorFlavor {
             return transcript.hash_independent_buffer(domain_separator + "vk_hash");
         }
 
-        // TODO(https://github.com/AztecProtocol/barretenberg/issues/1324): Remove `circuit_size` and `log_circuit_size`
-        // from MSGPACK and the verification key.
-        MSGPACK_FIELDS(circuit_size,
-                       log_circuit_size,
-                       num_public_inputs,
+        // Don't statically check for object completeness.
+        using MSGPACK_NO_STATIC_CHECK = std::true_type;
+
+        MSGPACK_FIELDS(num_public_inputs,
                        pub_inputs_offset,
                        ordered_extra_range_constraints_numerator,
                        lagrange_first,


### PR DESCRIPTION
This was just an additional safety check. Where these constructors are not otherwise used it can be tedious to have, its more meant to encourage 'no explicit constructor' structs. This adds a bypass. Closes https://github.com/AztecProtocol/barretenberg/issues/964