### PR TITLE
fix: optimize checkAddressChecksum method by caching parsed hash digit

### DIFF
--- a/yarn-project/foundation/src/eth-address/index.ts
+++ b/yarn-project/foundation/src/eth-address/index.ts
@@ -97,9 +97,10 @@ export class EthAddress {
 
     for (let i = 0; i < 40; i++) {
       // The nth letter should be uppercase if the nth digit of casemap is 1.
+      const hashDigit = parseInt(addressHash[i], 16);
       if (
-        (parseInt(addressHash[i], 16) > 7 && address[i].toUpperCase() !== address[i]) ||
-        (parseInt(addressHash[i], 16) <= 7 && address[i].toLowerCase() !== address[i])
+        (hashDigit > 7 && address[i].toUpperCase() !== address[i]) ||
+        (hashDigit <= 7 && address[i].toLowerCase() !== address[i])
       ) {
         return false;
       }


### PR DESCRIPTION
Optimizes the EthAddress.checkAddressChecksum method by storing the result of parseInt(addressHash[i], 16) in a local variable to avoid redundant calculations in each loop iteration. This improves performance without changing the function's behavior.