### PR TITLE
test: add initial TXE tests, begin API deprecation

### DIFF
--- a/docs/docs/migration_notes.md
+++ b/docs/docs/migration_notes.md
@@ -9,6 +9,15 @@ Aztec is in full-speed development. Literally every version breaks compatibility
 
 ## TBD
 
+## [TXE]
+
+### API overhaul
+
+As part of a broader effort to make TXE easier to use and reason about, large parts of it are being changed or adapted.
+
+- `committed_block_number` and `committed_timestamp` removed: these functions did not work correctly, and were not generally very useful
+- `private_at_timestamp`: this function was not really meaningful: private contexts are built from block numbers, not timestamp
+
 ## [Aztec.js]
 
 Cheatcodes where moved out of the `@aztec/aztec.js` package to `@aztec/ethereum` and `@aztec/aztec` packages.

--- a/noir-projects/aztec-nr/aztec/src/test/helpers/test_environment.nr
+++ b/noir-projects/aztec-nr/aztec/src/test/helpers/test_environment.nr
@@ -27,10 +27,12 @@ use crate::{
         execution_cache,
         notes::notify_created_note,
     },
-    test::{helpers::{cheatcodes, utils::Deployer}, txe_constants::AZTEC_SLOT_DURATION},
+    test::helpers::{cheatcodes, utils::Deployer},
 };
 
 use super::cheatcodes::public_call_new_flow;
+
+mod test;
 
 pub struct TestEnvironment {}
 
@@ -156,16 +158,6 @@ impl TestEnvironment {
         self.pending_block_number()
     }
 
-    /// Returns the block number of the last committed block - this is the block number that gets used in production
-    /// to execute the private part of transactions when your PXE managed to successfully sync to the tip of the chain.
-    pub unconstrained fn committed_block_number(self: Self) -> u32 {
-        self.pending_block_number() - 1
-    }
-
-    pub unconstrained fn committed_timestamp(self: Self) -> u64 {
-        self.pending_timestamp() - AZTEC_SLOT_DURATION
-    }
-
     /// With TXe tests, every test is run in a mock "contract". This facilitates the ability to write to and read from storage,
     /// emit and retrieve nullifiers (because they are hashed with a contract address), and formulate notes in a canonical way.
     /// The contract_address also represents the "msg_sender" when we call a contract with a private or public context; and when
@@ -234,7 +226,7 @@ impl TestEnvironment {
     /// Instantiates a private context at the latest committed block number - this is the block number that gets used
     /// in production to build transactions when your PXE managed to successfully sync to the tip of the chain.
     pub unconstrained fn private(&mut self) -> PrivateContext {
-        self.private_at(self.committed_block_number())
+        self.private_at(self.pending_block_number() - 1)
     }
 
     pub unconstrained fn utility(_self: Self) -> UtilityContext {
@@ -248,16 +240,6 @@ impl TestEnvironment {
         }
 
         let mut inputs = cheatcodes::get_private_context_inputs_at_block(historical_block_number);
-
-        PrivateContext::new(inputs, 0)
-    }
-
-    /// Instantiates a private context at a specific historical timestamp.
-    pub unconstrained fn private_at_timestamp(
-        _self: &mut Self,
-        historical_timestamp: u64,
-    ) -> PrivateContext {
-        let mut inputs = cheatcodes::get_private_context_inputs_at_timestamp(historical_timestamp);
 
         PrivateContext::new(inputs, 0)
     }

--- a/noir-projects/aztec-nr/aztec/src/test/helpers/test_environment/test.nr
+++ b/noir-projects/aztec-nr/aztec/src/test/helpers/test_environment/test.nr
@@ -1,0 +1,173 @@
+use crate::test::{helpers::test_environment::TestEnvironment, mocks::mock_struct::MockStruct};
+
+use dep::std::mem::zeroed;
+
+global storage_slot: Field = 13;
+global value: MockStruct = MockStruct { a: 17, b: 42 };
+
+#[test(should_fail_with = "cannot be less than current timestamp")] // should be called 'next' timestamp probably
+unconstrained fn advance_time_to_past_fails() {
+    let mut env = TestEnvironment::_new();
+
+    let pending = env.pending_timestamp();
+    env.advance_timestamp_to(pending - 1);
+}
+
+#[test]
+unconstrained fn advance_time_to_now_does_nothing() {
+    let mut env = TestEnvironment::_new();
+
+    let pending_timestamp_before = env.pending_timestamp();
+    let pending_block_number_before = env.pending_block_number();
+    env.advance_timestamp_to(pending_timestamp_before);
+
+    let pending_timestamp_after = env.pending_timestamp();
+    let pending_block_number_after = env.pending_block_number();
+
+    assert_eq(pending_timestamp_after, pending_timestamp_before);
+    assert_eq(pending_block_number_after, pending_block_number_before);
+}
+
+#[test]
+unconstrained fn advance_time_to_future_updates_next_public_context_timestamp() {
+    // should be called 'advance_next_block_timestamp_to' probably
+    let mut env = TestEnvironment::_new();
+
+    let pending_block_number_before = env.pending_block_number();
+    let pending_timestamp_before = env.pending_timestamp();
+    env.advance_timestamp_to(pending_timestamp_before + 1);
+
+    let pending_block_number_after = env.pending_block_number();
+    assert_eq(pending_block_number_after, pending_block_number_before);
+
+    env.public_context(|context| { assert_eq(pending_timestamp_before + 1, context.timestamp()); });
+}
+
+#[test]
+unconstrained fn advance_time_by_zero_does_nothing() {
+    let mut env = TestEnvironment::_new();
+
+    let pending_timestamp_before = env.pending_timestamp();
+    let pending_block_number_before = env.pending_block_number();
+    env.advance_timestamp_by(0);
+
+    let pending_timestamp_after = env.pending_timestamp();
+    let pending_block_number_after = env.pending_block_number();
+
+    assert_eq(pending_timestamp_after, pending_timestamp_before);
+    assert_eq(pending_block_number_after, pending_block_number_before);
+}
+
+#[test]
+unconstrained fn advance_time_by_updates_next_public_context_timestamp() {
+    // should be called 'advance_next_block_timestamp_by' probably
+    let mut env = TestEnvironment::_new();
+
+    let pending_block_number_before = env.pending_block_number();
+    let pending_timestamp_before = env.pending_timestamp();
+    env.advance_timestamp_by(1);
+
+    let pending_block_number_after = env.pending_block_number();
+    assert_eq(pending_block_number_after, pending_block_number_before);
+
+    env.public_context(|context| { assert_eq(pending_timestamp_before + 1, context.timestamp()); });
+}
+
+#[test]
+unconstrained fn public_context_uses_pending_block_number() {
+    let mut env = TestEnvironment::_new();
+
+    let pending = env.pending_block_number();
+
+    env.public_context(|context| { assert_eq(pending, context.block_number()); });
+}
+
+#[test]
+unconstrained fn public_context_advances_block_number() {
+    let mut env = TestEnvironment::_new();
+
+    let pending_before_first = env.pending_block_number();
+    env.public_context(|_| {});
+
+    let pending_before_second = env.pending_block_number();
+    let second_block_number = env.public_context(|context| context.block_number());
+
+    assert_eq(pending_before_second, pending_before_first + 1);
+    assert_eq(pending_before_second, second_block_number);
+}
+
+#[test]
+unconstrained fn public_context_uses_pending_timestamp() {
+    let mut env = TestEnvironment::_new();
+
+    let pending = env.pending_timestamp();
+
+    env.public_context(|context| { assert_eq(pending, context.timestamp()); });
+}
+
+#[test]
+unconstrained fn public_context_advances_timestamp() {
+    let mut env = TestEnvironment::_new();
+
+    let pending_before_first = env.pending_timestamp();
+    env.public_context(|_| {});
+
+    let pending_before_second = env.pending_timestamp();
+    let second_timestamp = env.public_context(|context| context.timestamp());
+
+    assert(pending_before_second > pending_before_first);
+    assert_eq(pending_before_second, second_timestamp);
+}
+
+#[test]
+unconstrained fn public_context_default_storage_value() {
+    let mut env = TestEnvironment::_new();
+
+    env.public_context(|context| {
+        assert_eq(context.storage_read::<MockStruct, _>(storage_slot), zeroed());
+    });
+}
+
+#[test]
+unconstrained fn public_context_storage_write_in_same_context() {
+    let mut env = TestEnvironment::_new();
+
+    env.public_context(|context| {
+        context.storage_write(storage_slot, value);
+        assert_eq(context.storage_read(storage_slot), value);
+    });
+}
+
+#[test]
+unconstrained fn public_context_storage_write_in_future_context() {
+    let mut env = TestEnvironment::_new();
+
+    env.public_context(|context| { context.storage_write(storage_slot, value); });
+
+    env.public_context(|context| { assert_eq(context.storage_read(storage_slot), value); });
+}
+
+#[test]
+unconstrained fn private_context_uses_previous_block_number() {
+    let mut env = TestEnvironment::_new();
+
+    let pending = env.pending_block_number();
+
+    env.private_context(|context| {
+        assert_eq(pending - 1, context.get_block_header().global_variables.block_number);
+    });
+}
+
+// #[test]
+// unconstrained fn private_context_uses_previous_block() {
+//     let mut env = TestEnvironment::_new();
+
+//     let (previous_block_number, previous_timestamp) = env.public_context(|context| {
+//         (context.block_number(), context.timestamp())
+//     });
+
+//     env.private_context(|context| {
+//         assert_eq(previous_block_number, context.get_block_header().global_variables.block_number);
+//         assert_eq(previous_timestamp, context.get_block_header().global_variables.timestamp); // fails, we subtract 36 here
+//     });
+// }


### PR DESCRIPTION
This adds some initial tests to ensure TXE works as expected. Spoilers, it doesn't. Most tests from this point on begin failing, so future PRs will also include fixes/changes.