### PR TITLE
feat!: fiat-shamir AVM vk

### DIFF
--- a/barretenberg/cpp/src/barretenberg/dsl/acir_format/avm2_recursion_constraint.cpp
+++ b/barretenberg/cpp/src/barretenberg/dsl/acir_format/avm2_recursion_constraint.cpp
@@ -52,6 +52,22 @@ void create_dummy_vkey_and_proof(Builder& builder,
 {
     using Flavor = avm2::AvmFlavor;
 
+    // a lambda that sets dummy commitments
+    auto set_dummy_commitment = [&builder](const std::vector<stdlib::field_t<Builder>>& fields, size_t& offset) {
+        auto comm = curve::BN254::AffineElement::one() * fr::random_element();
+        auto frs = field_conversion::convert_to_bn254_frs(comm);
+        builder.set_variable(fields[offset].witness_index, frs[0]);
+        builder.set_variable(fields[offset + 1].witness_index, frs[1]);
+        builder.set_variable(fields[offset + 2].witness_index, frs[2]);
+        builder.set_variable(fields[offset + 3].witness_index, frs[3]);
+        offset += 4;
+    };
+    // a lambda that sets dummy evaluation in proof fields vector
+    auto set_dummy_evaluation_in_proof_fields = [&](size_t& offset) {
+        builder.set_variable(proof_fields[offset].witness_index, fr::random_element());
+        offset++;
+    };
+
     // Relevant source for proof layout: AvmFlavor::Transcript::serialize_full_transcript()
     // TODO(#13390): Revive this assertion (and remove the >= 0 one) once we freeze the number of colums in AVM.
     // assert((proof_size - Flavor::NUM_WITNESS_ENTITIES * Flavor::NUM_FRS_COM -
@@ -74,70 +90,42 @@ void create_dummy_vkey_and_proof(Builder& builder,
 
     size_t offset = 2;
     for (size_t i = 0; i < Flavor::NUM_PRECOMPUTED_ENTITIES; ++i) {
-        auto comm = curve::BN254::AffineElement::one() * fr::random_element();
-        auto frs = field_conversion::convert_to_bn254_frs(comm);
-        builder.set_variable(key_fields[offset].witness_index, frs[0]);
-        builder.set_variable(key_fields[offset + 1].witness_index, frs[1]);
-        builder.set_variable(key_fields[offset + 2].witness_index, frs[2]);
-        builder.set_variable(key_fields[offset + 3].witness_index, frs[3]);
-        offset += 4;
+        set_dummy_commitment(key_fields, offset);
     }
 
     // This routine is adding some placeholders for avm proof and avm vk in the case where witnesses are not present.
     // TODO(#14234)[Unconditional PIs validation]: Remove next line and use offset == 0 for subsequent line.
     builder.set_variable(proof_fields[0].witness_index, 1);
-    builder.set_variable(proof_fields[1].witness_index, 1 << log_circuit_size);
-    offset = 2; // TODO(#14234)[Unconditional PIs validation]: reset offset = 1
+    offset = 1; // TODO(#14234)[Unconditional PIs validation]: reset offset = 1
 
     // Witness Commitments
     for (size_t i = 0; i < Flavor::NUM_WITNESS_ENTITIES; i++) {
-        auto comm = curve::BN254::AffineElement::one() * fr::random_element();
-        auto frs = field_conversion::convert_to_bn254_frs(comm);
-        builder.set_variable(proof_fields[offset].witness_index, frs[0]);
-        builder.set_variable(proof_fields[offset + 1].witness_index, frs[1]);
-        builder.set_variable(proof_fields[offset + 2].witness_index, frs[2]);
-        builder.set_variable(proof_fields[offset + 3].witness_index, frs[3]);
-        offset += 4;
+        set_dummy_commitment(proof_fields, offset);
     }
 
     // now the univariates
     for (size_t i = 0; i < CONST_PROOF_SIZE_LOG_N * Flavor::BATCHED_RELATION_PARTIAL_LENGTH; i++) {
-        builder.set_variable(proof_fields[offset].witness_index, fr::random_element());
-        offset++;
+        set_dummy_evaluation_in_proof_fields(offset);
     }
 
     // now the sumcheck evaluations
     for (size_t i = 0; i < Flavor::NUM_ALL_ENTITIES; i++) {
-        builder.set_variable(proof_fields[offset].witness_index, fr::random_element());
-        offset++;
+        set_dummy_evaluation_in_proof_fields(offset);
     }
 
     // now the gemini fold commitments which are CONST_PROOF_SIZE_LOG_N - 1
     for (size_t i = 1; i < CONST_PROOF_SIZE_LOG_N; i++) {
-        auto comm = curve::BN254::AffineElement::one() * fr::random_element();
-        auto frs = field_conversion::convert_to_bn254_frs(comm);
-        builder.set_variable(proof_fields[offset].witness_index, frs[0]);
-        builder.set_variable(proof_fields[offset + 1].witness_index, frs[1]);
-        builder.set_variable(proof_fields[offset + 2].witness_index, frs[2]);
-        builder.set_variable(proof_fields[offset + 3].witness_index, frs[3]);
-        offset += 4;
+        set_dummy_commitment(proof_fields, offset);
     }
 
     // the gemini fold evaluations which are CONST_PROOF_SIZE_LOG_N
     for (size_t i = 0; i < CONST_PROOF_SIZE_LOG_N; i++) {
-        builder.set_variable(proof_fields[offset].witness_index, fr::random_element());
-        offset++;
+        set_dummy_evaluation_in_proof_fields(offset);
     }
 
     // lastly the shplonk batched quotient commitment and kzg quotient commitment
     for (size_t i = 0; i < 2; i++) {
-        auto comm = curve::BN254::AffineElement::one() * fr::random_element();
-        auto frs = field_conversion::convert_to_bn254_frs(comm);
-        builder.set_variable(proof_fields[offset].witness_index, frs[0]);
-        builder.set_variable(proof_fields[offset + 1].witness_index, frs[1]);
-        builder.set_variable(proof_fields[offset + 2].witness_index, frs[2]);
-        builder.set_variable(proof_fields[offset + 3].witness_index, frs[3]);
-        offset += 4;
+        set_dummy_commitment(proof_fields, offset);
     }
 
     // TODO(#13390): Revive the following assertion once we freeze the number of colums in AVM.

--- a/barretenberg/cpp/src/barretenberg/stdlib/primitives/bigfield/goblin_field.hpp
+++ b/barretenberg/cpp/src/barretenberg/stdlib/primitives/bigfield/goblin_field.hpp
@@ -103,6 +103,18 @@ template <class Builder> class goblin_field {
         this->unset_free_witness_tag();
     }
 
+    /**
+     * Fix a witness. The value of the witness is constrained with a selector
+     **/
+    void fix_witness()
+    {
+        for (auto& limb : limbs) {
+            limb.fix_witness();
+        }
+        // This is now effectively a constant
+        unset_free_witness_tag();
+    }
+
     static goblin_field conditional_assign(const bool_ct& predicate, const goblin_field& lhs, goblin_field& rhs)
     {
         goblin_field result;

--- a/barretenberg/cpp/src/barretenberg/stdlib/primitives/biggroup/biggroup_goblin.hpp
+++ b/barretenberg/cpp/src/barretenberg/stdlib/primitives/biggroup/biggroup_goblin.hpp
@@ -101,6 +101,19 @@ template <class Builder_, class Fq, class Fr, class NativeGroup> class goblin_el
         this->unset_free_witness_tag();
     }
 
+    /**
+     * Fix a witness. The value of the witness is constrained with a selector
+     **/
+    void fix_witness()
+    {
+        // Origin tags should be updated within
+        this->x.fix_witness();
+        this->y.fix_witness();
+
+        // This is now effectively a constant
+        unset_free_witness_tag();
+    }
+
     void validate_on_curve() const
     {
         // happens in goblin eccvm

--- a/barretenberg/cpp/src/barretenberg/vm2/constraining/flavor.hpp
+++ b/barretenberg/cpp/src/barretenberg/vm2/constraining/flavor.hpp
@@ -266,27 +266,15 @@ class AvmFlavor {
             }
         }
 
-        /**
-         * @brief Serialize verification key to field elements
-         *
-         * @return std::vector<FF>
-         */
         std::vector<fr> to_field_elements() const override;
-
         /**
-         * @brief Hashes the vk using the transcript's independent buffer and returns the hash.
-         * @details Needed to make sure the Origin Tag system works. See the base class function for
-         * more details.
-         *
-         * @param domain_separator
-         * @param transcript
-         * @returns The hash of the verification key
+         * @brief Unimplemented because AVM VK is hardcoded so hash does not need to be computed. Rather, we just add
+         * the provided VK hash directly to the transcript.
          */
         fr hash_through_transcript([[maybe_unused]] const std::string& domain_separator,
                                    [[maybe_unused]] Transcript& transcript) const override
         {
-            // TODO(https://github.com/AztecProtocol/barretenberg/issues/1466): Implement this function.
-            throw_or_abort("Not implemented yet!");
+            throw_or_abort("Not intended to be used because vk is hardcoded in circuit.");
         }
     };
 

--- a/barretenberg/cpp/src/barretenberg/vm2/constraining/prover.hpp
+++ b/barretenberg/cpp/src/barretenberg/vm2/constraining/prover.hpp
@@ -16,12 +16,15 @@ class AvmProver {
     using Curve = Flavor::Curve;
     using PCSCommitmentKey = Flavor::CommitmentKey;
     using ProvingKey = Flavor::ProvingKey;
+    using VerificationKey = Flavor::VerificationKey;
     using Polynomial = Flavor::Polynomial;
     using ProverPolynomials = Flavor::ProverPolynomials;
     using Transcript = Flavor::Transcript;
     using Proof = HonkProof;
 
-    explicit AvmProver(std::shared_ptr<ProvingKey> input_key, const PCSCommitmentKey& commitment_key);
+    explicit AvmProver(std::shared_ptr<ProvingKey> input_key,
+                       std::shared_ptr<VerificationKey> vk,
+                       const PCSCommitmentKey& commitment_key);
     AvmProver(AvmProver&& prover) = default;
     virtual ~AvmProver() = default;
 
@@ -44,6 +47,7 @@ class AvmProver {
     bb::RelationParameters<FF> relation_parameters;
 
     std::shared_ptr<ProvingKey> key;
+    std::shared_ptr<VerificationKey> vk;
 
     // Container for spans of all polynomials required by the prover (i.e. all multivariates evaluated by Sumcheck).
     ProverPolynomials prover_polynomials;

--- a/barretenberg/cpp/src/barretenberg/vm2/constraining/recursion/recursive_flavor.hpp
+++ b/barretenberg/cpp/src/barretenberg/vm2/constraining/recursion/recursive_flavor.hpp
@@ -84,13 +84,11 @@ class AvmRecursiveFlavor {
             size_t num_frs_FF = stdlib::field_conversion::calc_num_bn254_frs<CircuitBuilder, FF>();
             size_t num_frs_Comm = stdlib::field_conversion::calc_num_bn254_frs<CircuitBuilder, Commitment>();
 
-            this->log_circuit_size = uint64_t(stdlib::field_conversion::convert_from_bn254_frs<CircuitBuilder, FF>(
-                                                  builder, elements.subspan(num_frs_read, num_frs_FF))
-                                                  .get_value());
+            this->log_circuit_size = stdlib::field_conversion::convert_from_bn254_frs<CircuitBuilder, FF>(
+                builder, elements.subspan(num_frs_read, num_frs_FF));
             num_frs_read += num_frs_FF;
-            this->num_public_inputs = uint64_t(stdlib::field_conversion::convert_from_bn254_frs<CircuitBuilder, FF>(
-                                                   builder, elements.subspan(num_frs_read, num_frs_FF))
-                                                   .get_value());
+            this->num_public_inputs = stdlib::field_conversion::convert_from_bn254_frs<CircuitBuilder, FF>(
+                builder, elements.subspan(num_frs_read, num_frs_FF));
             num_frs_read += num_frs_FF;
 
             for (Commitment& comm : this->get_all()) {
@@ -100,12 +98,22 @@ class AvmRecursiveFlavor {
             }
         }
 
-        // TODO(https://github.com/AztecProtocol/barretenberg/issues/1466): Implement these functions.
-        std::vector<FF> to_field_elements() const override { throw_or_abort("Not implemented yet!"); }
+        std::vector<FF> to_field_elements() const override { throw_or_abort("Not intended to be used."); }
         FF hash_through_transcript([[maybe_unused]] const std::string& domain_separator,
                                    [[maybe_unused]] Transcript& transcript) const override
         {
-            throw_or_abort("Not implemented yet!");
+            throw_or_abort("Not intended to be used because vk is hardcoded in circuit.");
+        }
+
+        /**
+         * @brief Fixes witnesses of VK to be constants.
+         *
+         */
+        void fix_witness()
+        {
+            for (Commitment& commitment : this->get_all()) {
+                commitment.fix_witness();
+            }
         }
     };
 

--- a/barretenberg/cpp/src/barretenberg/vm2/constraining/recursion/recursive_verifier.cpp
+++ b/barretenberg/cpp/src/barretenberg/vm2/constraining/recursion/recursive_verifier.cpp
@@ -16,16 +16,17 @@
 
 namespace bb::avm2 {
 
-AvmRecursiveVerifier::AvmRecursiveVerifier(Builder& builder,
-                                           const std::shared_ptr<NativeVerificationKey>& native_verification_key)
-    : key(std::make_shared<VerificationKey>(&builder, native_verification_key))
-    , builder(builder)
-{}
-
+// TODO(#15892): Remove vk argument from all functions once its fixed.
 AvmRecursiveVerifier::AvmRecursiveVerifier(Builder& builder, const std::shared_ptr<VerificationKey>& vkey)
-    : key(vkey)
-    , builder(builder)
-{}
+    : builder(builder)
+    , key(vkey)
+{
+    // TODO(#15892): Uncomment this when we make the AVM vk and vk
+    // hash fixed.
+    // key->fix_witness();
+    // compute the vk hash from the native vk fields
+    // this->vk_hash.fix_witness();
+}
 
 // Evaluate the given public input column over the multivariate challenge points
 AvmRecursiveVerifier::FF AvmRecursiveVerifier::evaluate_public_input_column(const std::vector<FF>& points,
@@ -90,14 +91,12 @@ AvmRecursiveVerifier::PairingPoints AvmRecursiveVerifier::verify_proof(
 
     transcript->load_proof(stdlib_proof);
 
+    // TODO(#15892): Fiat-Shamir the vk hash by uncommenting the add_to_hash_buffer.
+    // transcript->add_to_hash_buffer("avm_vk_hash", vk_hash);
+    info("AVM vk hash in recursive verifier: ", vk_hash);
+
     RelationParams relation_parameters;
     VerifierCommitments commitments{ key };
-
-    const auto circuit_size = transcript->template receive_from_prover<FF>("circuit_size");
-    uint32_t vk_circuit_size = 1 << static_cast<uint32_t>(key->log_circuit_size.get_value());
-    if (static_cast<uint32_t>(circuit_size.get_value()) != vk_circuit_size) {
-        throw_or_abort("AvmRecursiveVerifier::verify_proof: proof circuit size does not match verification key!");
-    }
 
     // Get commitments to VM wires
     for (auto [comm, label] : zip_view(commitments.get_wires(), commitments.get_wires_labels())) {
@@ -114,7 +113,7 @@ AvmRecursiveVerifier::PairingPoints AvmRecursiveVerifier::verify_proof(
     }
 
     // unconstrained
-    const size_t log_circuit_size = numeric::get_msb(static_cast<uint32_t>(circuit_size.get_value()));
+    const size_t log_circuit_size = static_cast<uint32_t>(key->log_circuit_size.get_value());
     const auto padding_indicator_array =
         stdlib::compute_padding_indicator_array<Curve, CONST_PROOF_SIZE_LOG_N>(FF(log_circuit_size));
 

--- a/barretenberg/cpp/src/barretenberg/vm2/constraining/recursion/recursive_verifier.hpp
+++ b/barretenberg/cpp/src/barretenberg/vm2/constraining/recursion/recursive_verifier.hpp
@@ -24,8 +24,6 @@ class AvmRecursiveVerifier {
     using StdlibProof = stdlib::Proof<Builder>;
 
   public:
-    explicit AvmRecursiveVerifier(Builder& builder,
-                                  const std::shared_ptr<NativeVerificationKey>& native_verification_key);
     explicit AvmRecursiveVerifier(Builder& builder, const std::shared_ptr<VerificationKey>& vkey);
 
     [[nodiscard("IPA claim and Pairing points should be accumulated")]] PairingPoints verify_proof(
@@ -35,8 +33,9 @@ class AvmRecursiveVerifier {
                                                       // stdlib_proof_with_pi_flag to stdlib_proof
         const std::vector<std::vector<typename Flavor::FF>>& public_inputs);
 
-    std::shared_ptr<VerificationKey> key;
     Builder& builder;
+    std::shared_ptr<VerificationKey> key;
+    FF vk_hash;
     std::shared_ptr<Transcript> transcript = std::make_shared<Transcript>();
 
   private:

--- a/barretenberg/cpp/src/barretenberg/vm2/constraining/recursion/recursive_verifier.test.cpp
+++ b/barretenberg/cpp/src/barretenberg/vm2/constraining/recursion/recursive_verifier.test.cpp
@@ -68,8 +68,7 @@ TEST_F(AvmRecursiveTests, GoblinRecursion)
     // Type aliases specific to GoblinRecursion test
     using AvmRecursiveVerifier = AvmGoblinRecursiveVerifier;
     using OuterBuilder = typename UltraRollupFlavor::CircuitBuilder;
-    using UltraRollupRecursiveFlavor = UltraRollupRecursiveFlavor_<OuterBuilder>;
-    using UltraFF = UltraRollupRecursiveFlavor::FF;
+    using UltraFF = UltraRecursiveFlavor_<OuterBuilder>::FF;
     using UltraRollupProver = UltraProver_<UltraRollupFlavor>;
     using NativeVerifierCommitmentKey = typename AvmFlavor::VerifierCommitmentKey;
 

--- a/barretenberg/cpp/src/barretenberg/vm2/proving_helper.cpp
+++ b/barretenberg/cpp/src/barretenberg/vm2/proving_helper.cpp
@@ -70,10 +70,11 @@ std::pair<AvmProvingHelper::Proof, AvmProvingHelper::VkData> AvmProvingHelper::p
 {
     auto polynomials = AVM_TRACK_TIME_V("proving/prove:compute_polynomials", constraining::compute_polynomials(trace));
     auto proving_key = AVM_TRACK_TIME_V("proving/prove:proving_key", create_proving_key(polynomials));
-    auto prover =
-        AVM_TRACK_TIME_V("proving/prove:construct_prover", AvmProver(proving_key, proving_key->commitment_key));
+    // TODO(#15892): VK needs to be hardcoded. Computing it here is not efficient.
     auto verification_key =
         AVM_TRACK_TIME_V("proving/prove:verification_key", std::make_shared<AvmVerifier::VerificationKey>(proving_key));
+    auto prover = AVM_TRACK_TIME_V("proving/prove:construct_prover",
+                                   AvmProver(proving_key, verification_key, proving_key->commitment_key));
 
     auto proof = AVM_TRACK_TIME_V("proving/construct_proof", prover.construct_proof());
     auto serialized_vk = to_buffer(verification_key->to_field_elements());


### PR DESCRIPTION
Passes the vk to the prover and hardcodes the vk and vk hash in the recursive verifier. Adds logic to fiat-shamir VK hash in AVM, but stops short of doing it because padding makes things inconsistent in the recursive verifier. Also fixes NegativeBadPublicInputs test.