### PR TITLE
feat!: begin TXE API overhaul

### DIFF
--- a/docs/docs/migration_notes.md
+++ b/docs/docs/migration_notes.md
@@ -15,7 +15,7 @@ Aztec is in full-speed development. Literally every version breaks compatibility
 
 As part of a broader effort to make TXE easier to use and reason about, large parts of it are being changed or adapted.
 
-- `committed_block_number` and `committed_timestamp` removed: these functions did not work correctly, and were not generally very useful
+- `committed_timestamp` removed: this function did not work correctly
 - `private_at_timestamp`: this function was not really meaningful: private contexts are built from block numbers, not timestamps
 - `pending_block_number` was renamed to `next_block_number`. `pending_timestamp` was removed since it was confusing and not useful
 - `committed_block_number` was renamed to `last_block_number`

--- a/docs/docs/migration_notes.md
+++ b/docs/docs/migration_notes.md
@@ -16,7 +16,12 @@ Aztec is in full-speed development. Literally every version breaks compatibility
 As part of a broader effort to make TXE easier to use and reason about, large parts of it are being changed or adapted.
 
 - `committed_block_number` and `committed_timestamp` removed: these functions did not work correctly, and were not generally very useful
-- `private_at_timestamp`: this function was not really meaningful: private contexts are built from block numbers, not timestamp
+- `private_at_timestamp`: this function was not really meaningful: private contexts are built from block numbers, not timestamps
+- `pending_block_number` was renamed to `next_block_number`. `pending_timestamp` was removed since it was confusing and not useful
+- `committed_block_number` was renamed to `last_block_number`
+- `advance_timestamp_to` and `advance_timestamp_by` were renamed to `set_next_block_timestamp` and `advance_next_block_timestamp_by` respectively
+- `advance_block_to` was renamed to `mine_block_at`, which takes a timestamp instead of a target block number
+- `advance_block_by` was renamed to `mine_block`, which now mines a single block
 
 ## [Aztec.js]
 

--- a/noir-projects/aztec-nr/aztec/src/history/nullifier_inclusion/test.nr
+++ b/noir-projects/aztec-nr/aztec/src/history/nullifier_inclusion/test.nr
@@ -51,9 +51,9 @@ unconstrained fn nullifier_inclusion() {
 
     notify_created_nullifier(unsiloed_nullifier);
 
-    let nullifier_created_at = env.pending_block_number();
+    let nullifier_created_at = env.next_block_number();
 
-    env.advance_block_by(1);
+    env.mine_block();
 
     let context = &mut env.private_at(nullifier_created_at);
 

--- a/noir-projects/aztec-nr/aztec/src/history/nullifier_non_inclusion/test.nr
+++ b/noir-projects/aztec-nr/aztec/src/history/nullifier_non_inclusion/test.nr
@@ -64,9 +64,9 @@ unconstrained fn nullifier_non_inclusion_fails() {
 
     notify_created_nullifier(unsiloed_nullifier);
 
-    let nullifier_created_at = env.pending_block_number();
+    let nullifier_created_at = env.next_block_number();
 
-    env.advance_block_by(1);
+    env.mine_block();
 
     let context = &mut env.private_at(nullifier_created_at);
 

--- a/noir-projects/aztec-nr/aztec/src/history/public_storage/test.nr
+++ b/noir-projects/aztec-nr/aztec/src/history/public_storage/test.nr
@@ -13,11 +13,11 @@ unconstrained fn setup() -> &mut TestEnvironment {
     let context = &mut env.public();
 
     // We sanity check that we are building block 2, and thus block 2 is where the following storage write will occur.
-    assert_eq(env.pending_block_number(), WRITTEN_TO_STORAGE_AT);
+    assert_eq(env.next_block_number(), WRITTEN_TO_STORAGE_AT);
 
     context.storage_write(STORAGE_SLOT, VALUE);
 
-    env.advance_block_by(1);
+    env.mine_block();
 
     &mut env
 }

--- a/noir-projects/aztec-nr/aztec/src/history/test.nr
+++ b/noir-projects/aztec-nr/aztec/src/history/test.nr
@@ -18,7 +18,7 @@ pub(crate) unconstrained fn create_note() -> (&mut TestEnvironment, RetrievedNot
     let context = &mut env.private();
 
     // We sanity check that we are building block 2, thus block 2 is where the note will be added.
-    assert_eq(env.pending_block_number(), NOTE_CREATED_AT);
+    assert_eq(env.next_block_number(), NOTE_CREATED_AT);
 
     let contract_address = get_contract_address();
 
@@ -34,7 +34,7 @@ pub(crate) unconstrained fn create_note() -> (&mut TestEnvironment, RetrievedNot
 
     // TODO(#12226): FIX
     // context.push_note_hash(retrieved_note.note.compute_note_hash(15));
-    env.advance_block_by(1);
+    env.mine_block();
 
     (&mut env, retrieved_note)
 }
@@ -46,11 +46,11 @@ pub(crate) unconstrained fn create_note_and_nullify_it() -> (&mut TestEnvironmen
     let context = &mut env.private();
 
     // We sanity check that we are building block 3, thus block 3 is where the note will be nullified.
-    assert_eq(env.pending_block_number(), NOTE_NULLIFIED_AT);
+    assert_eq(env.next_block_number(), NOTE_NULLIFIED_AT);
 
     destroy_note(context, retrieved_note, NOTE_STORAGE_SLOT);
 
-    env.advance_block_by(1);
+    env.mine_block();
 
     (env, retrieved_note)
 }

--- a/noir-projects/aztec-nr/aztec/src/messages/encryption/aes128.nr
+++ b/noir-projects/aztec-nr/aztec/src/messages/encryption/aes128.nr
@@ -383,7 +383,7 @@ mod test {
     unconstrained fn encrypt_decrypt_log() {
         let mut env = TestEnvironment::new();
         // Advance 1 block so we can read historic state from private
-        env.advance_block_by(1);
+        env.mine_block();
 
         let plaintext = [1, 2, 3];
 

--- a/noir-projects/aztec-nr/aztec/src/note/note_getter/test.nr
+++ b/noir-projects/aztec-nr/aztec/src/note/note_getter/test.nr
@@ -16,7 +16,7 @@ global storage_slot: Field = 42;
 unconstrained fn setup() -> TestEnvironment {
     let mut env = TestEnvironment::new();
     // Advance 1 block so we can read historic state from private
-    env.advance_block_by(1);
+    env.mine_block();
     env
 }
 

--- a/noir-projects/aztec-nr/aztec/src/oracle/block_header.nr
+++ b/noir-projects/aztec-nr/aztec/src/oracle/block_header.nr
@@ -88,7 +88,10 @@ mod test {
     unconstrained fn fetching_a_valid_but_different_header_should_fail() {
         let mut env = TestEnvironment::new();
 
-        env.advance_block_by(4);
+        env.mine_block();
+        env.mine_block();
+        env.mine_block();
+        env.mine_block();
 
         // We get our current header for the last archive values.
         let current_header = env.private().historical_header;

--- a/noir-projects/aztec-nr/aztec/src/state_vars/private_mutable/test.nr
+++ b/noir-projects/aztec-nr/aztec/src/state_vars/private_mutable/test.nr
@@ -10,7 +10,7 @@ global storage_slot: Field = 17;
 unconstrained fn setup() -> TestEnvironment {
     let mut env = TestEnvironment::new();
     // Advance 1 block so we can read historic state from private
-    env.advance_block_by(1);
+    env.mine_block();
     env
 }
 

--- a/noir-projects/aztec-nr/aztec/src/state_vars/private_set/test.nr
+++ b/noir-projects/aztec-nr/aztec/src/state_vars/private_set/test.nr
@@ -12,7 +12,7 @@ unconstrained fn setup() -> TestEnvironment {
     let mut env = TestEnvironment::new();
 
     // Advance 1 block so we can read historic state from private
-    env.advance_block_by(1);
+    env.mine_block();
 
     env
 }

--- a/noir-projects/aztec-nr/aztec/src/state_vars/shared_mutable/test.nr
+++ b/noir-projects/aztec-nr/aztec/src/state_vars/shared_mutable/test.nr
@@ -86,7 +86,7 @@ unconstrained fn test_get_current_value_in_public_before_scheduled_change() {
         (original_value, timestamp_of_change)
     });
 
-    env.advance_timestamp_to(timestamp_of_change - 1);
+    env.set_next_block_timestamp(timestamp_of_change - 1);
 
     env.public_context(|context| {
         let state_var = in_public(context);
@@ -106,7 +106,7 @@ unconstrained fn test_get_current_value_in_public_at_scheduled_change() {
         state_var.get_scheduled_value()
     });
 
-    env.advance_timestamp_to(timestamp_of_change);
+    env.set_next_block_timestamp(timestamp_of_change);
 
     env.public_context(|context| {
         let state_var = in_public(context);
@@ -126,7 +126,7 @@ unconstrained fn test_get_current_value_in_public_after_scheduled_change() {
         state_var.get_scheduled_value()
     });
 
-    env.advance_timestamp_to(timestamp_of_change + 10);
+    env.set_next_block_timestamp(timestamp_of_change + 10);
 
     env.public_context(|context| {
         let state_var = in_public(context);
@@ -179,7 +179,7 @@ unconstrained fn test_get_current_delay_in_public_before_scheduled_change() {
     });
 
     // The current delay still does not change right before the timestamp of change
-    env.advance_timestamp_to(timestamp_of_change - 1);
+    env.set_next_block_timestamp(timestamp_of_change - 1);
 
     env.public_context(|context| {
         let state_var = in_public(context);
@@ -199,7 +199,7 @@ unconstrained fn test_get_current_delay_in_public_at_scheduled_change() {
         state_var.get_scheduled_delay()
     });
 
-    env.advance_timestamp_to(timestamp_of_change);
+    env.set_next_block_timestamp(timestamp_of_change);
 
     env.public_context(|context| {
         let state_var = in_public(context);
@@ -219,7 +219,7 @@ unconstrained fn test_get_current_delay_in_public_after_scheduled_change() {
         state_var.get_scheduled_delay()
     });
 
-    env.advance_timestamp_to(timestamp_of_change + 10);
+    env.set_next_block_timestamp(timestamp_of_change + 10);
 
     env.public_context(|context| {
         let state_var = in_public(context);
@@ -274,7 +274,7 @@ unconstrained fn test_get_current_value_in_private_immediately_before_change() {
         state_var.get_scheduled_value()
     });
 
-    env.advance_timestamp_to(timestamp_of_change - 1);
+    env.set_next_block_timestamp(timestamp_of_change - 1);
     cheatcodes::advance_blocks_by(1);
 
     env.private_context(|context| {
@@ -302,7 +302,7 @@ unconstrained fn test_get_current_value_in_private_at_change() {
         state_var.get_scheduled_value()
     });
 
-    env.advance_timestamp_to(timestamp_of_change);
+    env.set_next_block_timestamp(timestamp_of_change);
     cheatcodes::advance_blocks_by(1);
 
     env.private_context(|context| {
@@ -331,7 +331,7 @@ unconstrained fn test_get_current_value_in_private_after_change() {
         state_var.get_scheduled_value()
     });
 
-    env.advance_timestamp_to(timestamp_of_change + 10);
+    env.set_next_block_timestamp(timestamp_of_change + 10);
     cheatcodes::advance_blocks_by(1);
 
     env.private_context(|context| {
@@ -363,7 +363,7 @@ unconstrained fn test_get_current_value_in_private_with_non_initial_delay() {
         });
 
     let historical_timestamp = std::cmp::max(value_timestamp_of_change, delay_timestamp_of_change);
-    env.advance_timestamp_to(historical_timestamp);
+    env.set_next_block_timestamp(historical_timestamp);
     cheatcodes::advance_blocks_by(1);
 
     env.private_context(|context| {
@@ -398,7 +398,7 @@ unconstrained fn test_get_current_value_in_utility_before_scheduled_change() {
         state_var.get_scheduled_value()
     });
 
-    env.advance_timestamp_to(timestamp_of_change - 1);
+    env.set_next_block_timestamp(timestamp_of_change - 1);
     cheatcodes::advance_blocks_by(1);
 
     env.utility_context(|context| {
@@ -422,7 +422,7 @@ unconstrained fn test_get_current_value_in_utility_at_scheduled_change() {
         state_var.get_scheduled_value()
     });
 
-    env.advance_timestamp_to(timestamp_of_change);
+    env.set_next_block_timestamp(timestamp_of_change);
 
     env.utility_context(|context| {
         // Make sure we're at a block with the expected timestamp
@@ -445,7 +445,7 @@ unconstrained fn test_get_current_value_in_utility_after_scheduled_change() {
         state_var.get_scheduled_value()
     });
 
-    env.advance_timestamp_to(timestamp_of_change + 10);
+    env.set_next_block_timestamp(timestamp_of_change + 10);
 
     env.utility_context(|context| {
         // Make sure we're at a block with the expected timestamp

--- a/noir-projects/aztec-nr/aztec/src/test/helpers/cheatcodes.nr
+++ b/noir-projects/aztec-nr/aztec/src/test/helpers/cheatcodes.nr
@@ -1,8 +1,10 @@
 use crate::{
     context::inputs::PrivateContextInputs,
-    oracle::execution::{get_block_number, get_timestamp},
+    oracle::execution::get_block_number,
     test::{helpers::utils::TestAccount, txe_constants::AZTEC_SLOT_DURATION},
 };
+
+pub use crate::oracle::execution::get_timestamp;
 
 use protocol_types::{
     abis::function_selector::FunctionSelector,

--- a/noir-projects/aztec-nr/aztec/src/test/helpers/test_environment.nr
+++ b/noir-projects/aztec-nr/aztec/src/test/helpers/test_environment.nr
@@ -193,7 +193,7 @@ impl TestEnvironment {
     }
 
     /// Instantiates a public context. The block number returned from public_context.block_number() will be the
-    /// block number of the block currently being built (same as the one returned by self.pending_block_number()).
+    /// block number of the block currently being built (same as the one returned by self.next_block_number()).
     pub unconstrained fn public(_self: Self) -> PublicContext {
         PublicContext::new(|| 0)
     }

--- a/noir-projects/aztec-nr/aztec/src/test/helpers/test_environment.nr
+++ b/noir-projects/aztec-nr/aztec/src/test/helpers/test_environment.nr
@@ -137,25 +137,14 @@ impl TestEnvironment {
         ret_value
     }
 
-    /// Returns the block number of the block currently being built. Since sequencer is executing the public part
-    /// of transactions when building blocks, this block number is also returned by public_context.block_number().
-    pub unconstrained fn pending_block_number(_self: Self) -> u32 {
-        // TODO: This oracle when used in PXE returns the latest synched block number by the node and not the pending
-        // block number! But TXE handles this in some messed up custom way so this might actually be kinda correct.
-        // Terrible.
+    /// Returns the number of the next block to be built.
+    pub unconstrained fn next_block_number(_self: Self) -> u32 {
         get_block_number()
     }
 
-    /// Returns the timestamp of the block currently being built. Since sequencer is executing the public part
-    /// of transactions when building blocks, this timestamp is also returned by public_context.timestamp().
-    pub unconstrained fn pending_timestamp(_self: Self) -> u64 {
-        // TODO: This has the same behavior as pending_block_number() so it's also messed up.
-        get_timestamp()
-    }
-
-    /// This does what the above does but should be considered deprecated as the naming is subpar.
-    pub unconstrained fn block_number(self: Self) -> u32 {
-        self.pending_block_number()
+    /// Returns the number of the last mined block. This is the default historical block for private transactions.
+    pub unconstrained fn last_block_number(_self: Self) -> u32 {
+        get_block_number() - 1
     }
 
     /// With TXe tests, every test is run in a mock "contract". This facilitates the ability to write to and read from storage,
@@ -177,37 +166,29 @@ impl TestEnvironment {
         cheatcodes::set_contract_address(address)
     }
 
-    /// Advances the internal TXe state to specified block number.
-    /// Note that this block number describes the block being built. i.e. If you advance the block to 5 from 1,
-    /// the pending block number will be 5, and your last committed block number will be 4.
-    pub unconstrained fn advance_block_to(&mut self, block_number: u32) {
-        let pending_block_number = self.pending_block_number();
-        assert(pending_block_number <= block_number, "Cannot advance block to a previous block.");
-
-        let difference = block_number - pending_block_number;
-        self.advance_block_by(difference);
+    pub unconstrained fn mine_block_at(&mut self, timestamp: u64) {
+        self.set_next_block_timestamp(timestamp);
+        self.mine_block();
     }
 
     /// Advances the internal TXe timestamp to the specified timestamp.
-    pub unconstrained fn advance_timestamp_to(&mut self, timestamp: u64) {
-        let pending_timestamp = self.pending_timestamp();
+    pub unconstrained fn set_next_block_timestamp(&mut self, timestamp: u64) {
+        let pending_timestamp = get_timestamp();
         assert(
             pending_timestamp <= timestamp,
-            "Cannot go back in time. Timestamp cannot be less than current timestamp.",
+            "Cannot go back in time. Timestamp cannot be before next timestamp.",
         );
         let difference: u64 = timestamp - pending_timestamp;
-        self.advance_timestamp_by(difference);
+        self.advance_next_block_timestamp_by(difference);
     }
 
-    /// Advances the internal TXe state by the amount of blocks specified. The TXe produces a valid block for every
-    /// block advanced, and we are able to fetch historical data from warped over blocks.
-    // TODO(benesjan): Fix naming inconsistency between advance_block_by and advance_blockS_by.
-    pub unconstrained fn advance_block_by(_self: &mut Self, blocks: u32) {
-        cheatcodes::advance_blocks_by(blocks);
+    /// Advances the internal TXe state by one valid block.
+    pub unconstrained fn mine_block(_self: &mut Self) {
+        cheatcodes::advance_blocks_by(1);
     }
 
     /// Advances the internal TXe timestamp by the specified duration in seconds.
-    pub unconstrained fn advance_timestamp_by(_self: &mut Self, duration: u64) {
+    pub unconstrained fn advance_next_block_timestamp_by(_self: &mut Self, duration: u64) {
         cheatcodes::advance_timestamp_by(duration);
     }
 
@@ -226,7 +207,7 @@ impl TestEnvironment {
     /// Instantiates a private context at the latest committed block number - this is the block number that gets used
     /// in production to build transactions when your PXE managed to successfully sync to the tip of the chain.
     pub unconstrained fn private(&mut self) -> PrivateContext {
-        self.private_at(self.pending_block_number() - 1)
+        self.private_at(self.next_block_number() - 1)
     }
 
     pub unconstrained fn utility(_self: Self) -> UtilityContext {
@@ -235,8 +216,8 @@ impl TestEnvironment {
 
     /// Instantiates a private context at a specific historical block number.
     pub unconstrained fn private_at(&mut self, historical_block_number: u32) -> PrivateContext {
-        if historical_block_number >= get_block_number() {
-            self.advance_block_to(historical_block_number + 1);
+        if historical_block_number > self.next_block_number() {
+            cheatcodes::advance_blocks_by(1 + historical_block_number - self.next_block_number())
         }
 
         let mut inputs = cheatcodes::get_private_context_inputs_at_block(historical_block_number);

--- a/noir-projects/aztec-nr/aztec/src/test/helpers/test_environment.nr
+++ b/noir-projects/aztec-nr/aztec/src/test/helpers/test_environment.nr
@@ -207,7 +207,7 @@ impl TestEnvironment {
     /// Instantiates a private context at the latest committed block number - this is the block number that gets used
     /// in production to build transactions when your PXE managed to successfully sync to the tip of the chain.
     pub unconstrained fn private(&mut self) -> PrivateContext {
-        self.private_at(self.next_block_number() - 1)
+        self.private_at(self.last_block_number())
     }
 
     pub unconstrained fn utility(_self: Self) -> UtilityContext {

--- a/noir-projects/aztec-nr/aztec/src/test/helpers/test_environment/test.nr
+++ b/noir-projects/aztec-nr/aztec/src/test/helpers/test_environment/test.nr
@@ -5,79 +5,75 @@ use dep::std::mem::zeroed;
 global storage_slot: Field = 13;
 global value: MockStruct = MockStruct { a: 17, b: 42 };
 
-#[test(should_fail_with = "cannot be less than current timestamp")] // should be called 'next' timestamp probably
-unconstrained fn advance_time_to_past_fails() {
+#[test(should_fail_with = "cannot be before next timestamp")]
+unconstrained fn set_next_block_timestamp_to_past_fails() {
     let mut env = TestEnvironment::_new();
 
-    let pending = env.pending_timestamp();
-    env.advance_timestamp_to(pending - 1);
+    env.set_next_block_timestamp(1);
 }
 
 #[test]
-unconstrained fn advance_time_to_now_does_nothing() {
+unconstrained fn set_next_block_timestamp_does_not_mine_a_block() {
     let mut env = TestEnvironment::_new();
 
-    let pending_timestamp_before = env.pending_timestamp();
-    let pending_block_number_before = env.pending_block_number();
-    env.advance_timestamp_to(pending_timestamp_before);
+    let last_block_timestamp = env.public_context(|context| context.timestamp());
 
-    let pending_timestamp_after = env.pending_timestamp();
-    let pending_block_number_after = env.pending_block_number();
-
-    assert_eq(pending_timestamp_after, pending_timestamp_before);
-    assert_eq(pending_block_number_after, pending_block_number_before);
+    let next_block_number_before = env.next_block_number();
+    env.set_next_block_timestamp(last_block_timestamp + 3600);
+    let next_block_number_after = env.next_block_number();
+    assert_eq(next_block_number_after, next_block_number_before);
 }
 
 #[test]
-unconstrained fn advance_time_to_future_updates_next_public_context_timestamp() {
-    // should be called 'advance_next_block_timestamp_to' probably
+unconstrained fn set_next_block_timestamp_sets_next_public_context_timestamp() {
     let mut env = TestEnvironment::_new();
 
-    let pending_block_number_before = env.pending_block_number();
-    let pending_timestamp_before = env.pending_timestamp();
-    env.advance_timestamp_to(pending_timestamp_before + 1);
+    let last_block_timestamp = env.public_context(|context| context.timestamp());
 
-    let pending_block_number_after = env.pending_block_number();
-    assert_eq(pending_block_number_after, pending_block_number_before);
+    let expected_next_block_timestamp = last_block_timestamp + 3600;
+    env.set_next_block_timestamp(expected_next_block_timestamp);
 
-    env.public_context(|context| { assert_eq(pending_timestamp_before + 1, context.timestamp()); });
+    env.public_context(|context| { assert_eq(context.timestamp(), expected_next_block_timestamp); });
 }
 
 #[test]
-unconstrained fn advance_time_by_zero_does_nothing() {
+unconstrained fn advance_next_block_timestamp_does_not_mine_a_block() {
     let mut env = TestEnvironment::_new();
 
-    let pending_timestamp_before = env.pending_timestamp();
-    let pending_block_number_before = env.pending_block_number();
-    env.advance_timestamp_by(0);
-
-    let pending_timestamp_after = env.pending_timestamp();
-    let pending_block_number_after = env.pending_block_number();
-
-    assert_eq(pending_timestamp_after, pending_timestamp_before);
-    assert_eq(pending_block_number_after, pending_block_number_before);
+    let next_block_number_before = env.next_block_number();
+    env.advance_next_block_timestamp_by(0);
+    let next_block_number_after = env.next_block_number();
+    assert_eq(next_block_number_after, next_block_number_before);
 }
 
 #[test]
-unconstrained fn advance_time_by_updates_next_public_context_timestamp() {
-    // should be called 'advance_next_block_timestamp_by' probably
+unconstrained fn advance_next_block_timestamp_sets_next_public_context_timestamp() {
     let mut env = TestEnvironment::_new();
 
-    let pending_block_number_before = env.pending_block_number();
-    let pending_timestamp_before = env.pending_timestamp();
-    env.advance_timestamp_by(1);
+    let last_block_timestamp = env.public_context(|context| context.timestamp());
 
-    let pending_block_number_after = env.pending_block_number();
-    assert_eq(pending_block_number_after, pending_block_number_before);
+    env.advance_next_block_timestamp_by(3600);
 
-    env.public_context(|context| { assert_eq(pending_timestamp_before + 1, context.timestamp()); });
+    // Note that we don't know exactly what the next block timestamp will be, since we don't know the timestamp the next
+    // block would've had - we just now it will be larger than the last one by at least whatever we advanced it.
+    env.public_context(|context| { assert(context.timestamp() >= last_block_timestamp + 3600); });
 }
 
 #[test]
-unconstrained fn public_context_uses_pending_block_number() {
+unconstrained fn mine_block_mines_a_block() {
     let mut env = TestEnvironment::_new();
 
-    let pending = env.pending_block_number();
+    let next_block_number_before = env.next_block_number();
+    env.mine_block();
+    let next_block_number_after = env.next_block_number();
+    assert_eq(next_block_number_after, next_block_number_before + 1);
+}
+
+#[test]
+unconstrained fn public_context_uses_next_block_number() {
+    let mut env = TestEnvironment::_new();
+
+    let pending = env.next_block_number();
 
     env.public_context(|context| { assert_eq(pending, context.block_number()); });
 }
@@ -86,37 +82,20 @@ unconstrained fn public_context_uses_pending_block_number() {
 unconstrained fn public_context_advances_block_number() {
     let mut env = TestEnvironment::_new();
 
-    let pending_before_first = env.pending_block_number();
-    env.public_context(|_| {});
-
-    let pending_before_second = env.pending_block_number();
+    let first_block_number = env.public_context(|context| context.block_number());
     let second_block_number = env.public_context(|context| context.block_number());
 
-    assert_eq(pending_before_second, pending_before_first + 1);
-    assert_eq(pending_before_second, second_block_number);
-}
-
-#[test]
-unconstrained fn public_context_uses_pending_timestamp() {
-    let mut env = TestEnvironment::_new();
-
-    let pending = env.pending_timestamp();
-
-    env.public_context(|context| { assert_eq(pending, context.timestamp()); });
+    assert_eq(second_block_number, first_block_number + 1);
 }
 
 #[test]
 unconstrained fn public_context_advances_timestamp() {
     let mut env = TestEnvironment::_new();
 
-    let pending_before_first = env.pending_timestamp();
-    env.public_context(|_| {});
-
-    let pending_before_second = env.pending_timestamp();
+    let first_timestamp = env.public_context(|context| context.timestamp());
     let second_timestamp = env.public_context(|context| context.timestamp());
 
-    assert(pending_before_second > pending_before_first);
-    assert_eq(pending_before_second, second_timestamp);
+    assert(second_timestamp > first_timestamp);
 }
 
 #[test]
@@ -151,23 +130,9 @@ unconstrained fn public_context_storage_write_in_future_context() {
 unconstrained fn private_context_uses_previous_block_number() {
     let mut env = TestEnvironment::_new();
 
-    let pending = env.pending_block_number();
+    let pending = env.next_block_number();
 
     env.private_context(|context| {
         assert_eq(pending - 1, context.get_block_header().global_variables.block_number);
     });
 }
-
-// #[test]
-// unconstrained fn private_context_uses_previous_block() {
-//     let mut env = TestEnvironment::_new();
-
-//     let (previous_block_number, previous_timestamp) = env.public_context(|context| {
-//         (context.block_number(), context.timestamp())
-//     });
-
-//     env.private_context(|context| {
-//         assert_eq(previous_block_number, context.get_block_header().global_variables.block_number);
-//         assert_eq(previous_timestamp, context.get_block_header().global_variables.timestamp); // fails, we subtract 36 here
-//     });
-// }

--- a/noir-projects/aztec-nr/aztec/src/utils/with_hash.nr
+++ b/noir-projects/aztec-nr/aztec/src/utils/with_hash.nr
@@ -170,7 +170,7 @@ mod test {
         );
 
         // We advance block by 1 because env.private() currently returns context at latest_block - 1
-        env.advance_block_by(1);
+        env.mine_block();
 
         let result = WithHash::<MockStruct, _>::historical_public_storage_read(
             env.private().historical_header,
@@ -185,7 +185,7 @@ mod test {
     unconstrained fn test_bad_hint_uninitialized_value() {
         let mut env = TestEnvironment::new();
 
-        env.advance_block_to(6);
+        env.mine_block();
 
         let value_packed = MockStruct { a: 1, b: 1 }.pack();
 
@@ -228,7 +228,7 @@ mod test {
         );
 
         // We advance block by 1 because env.private() currently returns context at latest_block - 1
-        env.advance_block_by(1);
+        env.mine_block();
 
         let _ = WithHash::<MockStruct, _>::historical_public_storage_read(
             env.private().historical_header,

--- a/noir-projects/noir-contracts/contracts/app/auth_contract/src/test/main.nr
+++ b/noir-projects/noir-contracts/contracts/app/auth_contract/src/test/main.nr
@@ -84,7 +84,11 @@ unconstrained fn main() {
         //                                   get_authorized() (public) called here with block_number = 7
         //                                                                      ^
         //                                        get_authorized() (private) called here with block_number = 8
+        // TODO: We should not need to advance time, since we've already mined a block at the time of change. Something
+        // about private calls is setting the wrong time or block.
+        env.advance_next_block_timestamp_by(AZTEC_SLOT_DURATION);
         env.mine_block();
+
         let authorized_in_private_again =
             Auth::at(auth_contract_address).get_authorized_in_private().view(&mut env.private());
         assert_eq(authorized_in_private_again, to_authorize);

--- a/noir-projects/noir-contracts/contracts/app/auth_contract/src/test/main.nr
+++ b/noir-projects/noir-contracts/contracts/app/auth_contract/src/test/main.nr
@@ -2,7 +2,7 @@ use crate::{Auth, test::utils};
 
 use aztec::{
     protocol_types::{address::AztecAddress, traits::FromField},
-    test::txe_constants::{AZTEC_SLOT_DURATION, GENESIS_TIMESTAMP},
+    test::txe_constants::GENESIS_TIMESTAMP,
 };
 
 // TODO (#8588): These were ported over directly from e2e tests. Refactor these in the correct TXe style.
@@ -50,45 +50,13 @@ unconstrained fn main() {
     let authorized_becomes_effective_after_delay = || {
         env.impersonate(to_authorize);
 
+        env.set_next_block_timestamp(expected_timestamp_of_first_change);
+
         // We advance time to timestamp of change. At that point we should get the `post` value.
-        env.mine_block_at(expected_timestamp_of_first_change);
         let authorized = Auth::at(auth_contract_address).get_authorized().view(&mut env.public());
         assert_eq(authorized, to_authorize);
 
-        let authorized_in_private: AztecAddress =
-            Auth::at(auth_contract_address).get_authorized_in_private().view(&mut env.private());
-        assert_eq(authorized_in_private, AztecAddress::zero());
-
-        // (Note that in the following comment we assume that each slot has a block and that delay is set to
-        // the duration of 5 slots (currently 180 seconds).)
-        // We need to always advance the block one more time to get the current value in private, compared to the value
-        // in public.
-        // To see why let's see this diagram.
-        // When we schedule a change in public, lets say we are at block 2 (building a tx to be included in block 2),
-        // which means the latest committed block is block 1.
-        // Thus, the value change will be set to timestamp of block 7 (2 + 5).
-        // If we now advance our env by 5 blocks, we will be at block 7 (building a tx to be included in block 7),
-        // which means the latest committed block is block 6.
-        // Reading the value in public will work, because the timestamp of the current block will be used (timestamp of
-        // block 7), and the timestamp of the current block is the timestamp of change; but if we try to create a
-        // historical proof, we do not have access to block 7 yet, and have to build the proof off of block 6, but at
-        // this time, the value change will not have taken place yet, therefore we need to be at block 8 (building a
-        // tx to be included in block 8), for the historical proof to work, as at that time the value will be changed
-        // in the historical block we have access to.
-        // Note: We do not see this behavior in the e2e tests because setting the value implicitly advances the block number by 1.
-        //                              1     2     3     4     5     6     7     8     9
-        //                              |     |     |     |     |     |     |     |     |
-        //                                 ^
-        //                    value change scheduled here
-        //                                                                ^
-        //                                   get_authorized() (public) called here with block_number = 7
-        //                                                                      ^
-        //                                        get_authorized() (private) called here with block_number = 8
-        // TODO: We should not need to advance time, since we've already mined a block at the time of change. Something
-        // about private calls is setting the wrong time or block.
-        env.advance_next_block_timestamp_by(AZTEC_SLOT_DURATION);
         env.mine_block();
-
         let authorized_in_private_again =
             Auth::at(auth_contract_address).get_authorized_in_private().view(&mut env.private());
         assert_eq(authorized_in_private_again, to_authorize);
@@ -98,7 +66,7 @@ unconstrained fn main() {
     authorized_becomes_effective_after_delay();
 
     let expected_timestamp_of_second_change =
-        expected_timestamp_of_first_change + AZTEC_SLOT_DURATION + Auth::CHANGE_AUTHORIZED_DELAY;
+        expected_timestamp_of_first_change + Auth::CHANGE_AUTHORIZED_DELAY;
 
     let authorize_other = || {
         env.impersonate(admin);

--- a/noir-projects/noir-contracts/contracts/app/auth_contract/src/test/main.nr
+++ b/noir-projects/noir-contracts/contracts/app/auth_contract/src/test/main.nr
@@ -29,7 +29,7 @@ unconstrained fn main() {
     let admin_sets_authorized = || {
         env.impersonate(admin);
         Auth::at(auth_contract_address).set_authorized(to_authorize).call(&mut env.public());
-        env.advance_block_by(1);
+        env.mine_block();
 
         let (scheduled_authorized, timestamp_of_change) =
             Auth::at(auth_contract_address).get_scheduled_authorized().view(&mut env.public());
@@ -51,8 +51,7 @@ unconstrained fn main() {
         env.impersonate(to_authorize);
 
         // We advance time to timestamp of change. At that point we should get the `post` value.
-        env.advance_timestamp_to(expected_timestamp_of_first_change);
-        env.advance_block_by(1);
+        env.mine_block_at(expected_timestamp_of_first_change);
         let authorized = Auth::at(auth_contract_address).get_authorized().view(&mut env.public());
         assert_eq(authorized, to_authorize);
 
@@ -85,9 +84,7 @@ unconstrained fn main() {
         //                                   get_authorized() (public) called here with block_number = 7
         //                                                                      ^
         //                                        get_authorized() (private) called here with block_number = 8
-        // Note: Currently TXE does not progress time when a block is advanced so we mimic "the real block progression"
-        // by advancing the timestamp of the env manually by the duration of 1 slot.
-        env.advance_timestamp_by(AZTEC_SLOT_DURATION);
+        env.mine_block();
         let authorized_in_private_again =
             Auth::at(auth_contract_address).get_authorized_in_private().view(&mut env.private());
         assert_eq(authorized_in_private_again, to_authorize);
@@ -102,7 +99,7 @@ unconstrained fn main() {
     let authorize_other = || {
         env.impersonate(admin);
         Auth::at(auth_contract_address).set_authorized(other).call(&mut env.public());
-        env.advance_block_by(1);
+        env.mine_block();
 
         let (scheduled_authorized, timestamp_of_change) =
             Auth::at(auth_contract_address).get_scheduled_authorized().view(&mut env.public());
@@ -127,7 +124,7 @@ unconstrained fn main() {
         env.impersonate(to_authorize);
 
         // We advance the block to the timestamp of the second change.
-        env.advance_timestamp_to(expected_timestamp_of_second_change);
+        env.set_next_block_timestamp(expected_timestamp_of_second_change);
         let authorized = Auth::at(auth_contract_address).get_authorized().view(&mut env.public());
         assert_eq(authorized, other);
 
@@ -135,7 +132,7 @@ unconstrained fn main() {
             Auth::at(auth_contract_address).get_authorized_in_private().view(&mut env.private());
         assert_eq(authorized_in_private, to_authorize);
 
-        env.advance_timestamp_by(AZTEC_SLOT_DURATION);
+        env.mine_block();
         let authorized_in_private_again =
             Auth::at(auth_contract_address).get_authorized_in_private().view(&mut env.private());
         assert_eq(authorized_in_private_again, other);

--- a/noir-projects/noir-contracts/contracts/app/easy_private_voting_contract/src/test/first.nr
+++ b/noir-projects/noir-contracts/contracts/app/easy_private_voting_contract/src/test/first.nr
@@ -57,7 +57,7 @@ unconstrained fn test_cast_vote() {
     env.impersonate(alice);
 
     let candidate = 1;
-    env.advance_block_by(6);
+    env.mine_block();
     EasyPrivateVoting::at(voting_contract_address).cast_vote(candidate).call(&mut env.private());
 
     // Read vote count from storage
@@ -78,11 +78,11 @@ unconstrained fn test_cast_vote_with_separate_accounts() {
     let candidate = 101;
 
     env.impersonate(alice);
-    env.advance_block_by(1);
+    env.mine_block();
     EasyPrivateVoting::at(voting_contract_address).cast_vote(candidate).call(&mut env.private());
 
     env.impersonate(bob);
-    env.advance_block_by(1);
+    env.mine_block();
     EasyPrivateVoting::at(voting_contract_address).cast_vote(candidate).call(&mut env.private());
 
     // Read vote count from storage
@@ -102,10 +102,10 @@ unconstrained fn test_fail_vote_twice() {
     let candidate = 101;
 
     env.impersonate(alice);
-    env.advance_block_by(1);
+    env.mine_block();
     EasyPrivateVoting::at(voting_contract_address).cast_vote(candidate).call(&mut env.private());
 
     // Vote again as alice
-    env.advance_block_by(1);
+    env.mine_block();
     EasyPrivateVoting::at(voting_contract_address).cast_vote(candidate).call(&mut env.private());
 }

--- a/noir-projects/noir-contracts/contracts/app/easy_private_voting_contract/src/test/utils.nr
+++ b/noir-projects/noir-contracts/contracts/app/easy_private_voting_contract/src/test/utils.nr
@@ -15,6 +15,6 @@ pub unconstrained fn setup() -> (&mut TestEnvironment, AztecAddress, AztecAddres
         initializer_call_interface,
     );
 
-    env.advance_block_by(1);
+    env.mine_block();
     (&mut env, voting_contract.to_address(), admin)
 }

--- a/noir-projects/noir-contracts/contracts/app/escrow_contract/src/test.nr
+++ b/noir-projects/noir-contracts/contracts/app/escrow_contract/src/test.nr
@@ -55,7 +55,7 @@
 //         .deploy("./@token_contract", "Token")
 //         .with_public_void_initializer(donation_token_initializer_call_interface);
 //     let token_contract_address = donation_token_contract.to_address();
-//     env.advance_block_by(1);
+//     env.mine_block();
 
 //     // Deploy Escrow contract with public keys
 //     let escrow_contract_initializer_call_interface =
@@ -65,13 +65,13 @@
 //         .with_private_initializer(escrow_contract_initializer_call_interface);
 //     let escrow_contract_address = escrow_contract.to_address();
 
-//     env.advance_block_by(1);
+//     env.mine_block();
 
 //     Token::at(token_contract_address)
 //         .mint_to_private(admin_and_owner, admin_and_owner, MINT_AMOUNT)
 //         .call(&mut env.private());
 
-//     env.advance_block_by(1);
+//     env.mine_block();
 
 //     let private_balance_after_mint = get_private_balance(token_contract_address, admin_and_owner);
 //     assert(private_balance_after_mint == MINT_AMOUNT);
@@ -92,7 +92,7 @@
 //     Token::at(token_contract_address).transfer(escrow_contract_address, TRANSFER_AMOUNT).call(
 //         &mut env.private(),
 //     );
-//     env.advance_block_by(1);
+//     env.mine_block();
 
 //     let balance_of_escrow_after_transfer =
 //         get_private_balance(token_contract_address, escrow_contract_address);
@@ -108,7 +108,7 @@
 //     Escrow::at(escrow_contract_address)
 //         .withdraw(token_contract_address, WITHDRAWAL_AMOUNT, account_2)
 //         .call(&mut env.private());
-//     env.advance_block_by(1);
+//     env.mine_block();
 
 //     let balance_of_account_2_after_withdrawal =
 //         get_private_balance(token_contract_address, account_2);

--- a/noir-projects/noir-contracts/contracts/app/nft_contract/src/test/access_control.nr
+++ b/noir-projects/noir-contracts/contracts/app/nft_contract/src/test/access_control.nr
@@ -11,7 +11,7 @@ unconstrained fn access_control() {
     // Set a new admin
     NFT::at(nft_contract_address).set_admin(recipient).call(&mut env.public());
 
-    env.advance_block_by(1);
+    env.mine_block();
 
     // Check it worked
     let admin = NFT::at(nft_contract_address).get_admin().view(&mut env.public());
@@ -27,7 +27,7 @@ unconstrained fn access_control() {
     // Set admin as minter
     NFT::at(nft_contract_address).set_minter(recipient, true).call(&mut env.public());
 
-    env.advance_block_by(1);
+    env.mine_block();
 
     // Check it worked
     let is_minter = is_minter_call_interface.view(&mut env.public());
@@ -36,7 +36,7 @@ unconstrained fn access_control() {
     // Revoke minter as admin
     NFT::at(nft_contract_address).set_minter(recipient, false).call(&mut env.public());
 
-    env.advance_block_by(1);
+    env.mine_block();
 
     // Check it worked
     let is_minter = is_minter_call_interface.view(&mut env.public());

--- a/noir-projects/noir-contracts/contracts/app/nft_contract/src/test/minting.nr
+++ b/noir-projects/noir-contracts/contracts/app/nft_contract/src/test/minting.nr
@@ -9,7 +9,7 @@ unconstrained fn mint_success() {
     let token_id = 10000;
     NFT::at(nft_contract_address).mint(owner, token_id).call(&mut env.public());
 
-    env.advance_block_by(1);
+    env.mine_block();
 
     utils::assert_owns_public_nft(env, nft_contract_address, owner, token_id);
 }

--- a/noir-projects/noir-contracts/contracts/app/nft_contract/src/test/transfer_in_public.nr
+++ b/noir-projects/noir-contracts/contracts/app/nft_contract/src/test/transfer_in_public.nr
@@ -13,7 +13,7 @@ unconstrained fn transfer_in_public() {
         &mut env.public(),
     );
 
-    env.advance_block_by(1);
+    env.mine_block();
 
     utils::assert_owns_public_nft(env, nft_contract_address, recipient, token_id);
 }
@@ -27,7 +27,7 @@ unconstrained fn transfer_in_public_to_self() {
     // Transfer the NFT
     NFT::at(nft_contract_address).transfer_in_public(user, user, token_id, 0).call(&mut env.public());
 
-    env.advance_block_by(1);
+    env.mine_block();
 
     // Check the user stayed the public owner
     utils::assert_owns_public_nft(env, nft_contract_address, user, token_id);

--- a/noir-projects/noir-contracts/contracts/app/nft_contract/src/test/transfer_to_private.nr
+++ b/noir-projects/noir-contracts/contracts/app/nft_contract/src/test/transfer_to_private.nr
@@ -38,7 +38,7 @@ unconstrained fn transfer_to_private_external_orchestration() {
         &mut env.public(),
     );
 
-    env.advance_block_by(1);
+    env.mine_block();
 
     // Recipient should have the note in their private nfts
     utils::assert_owns_private_nft(nft_contract_address, recipient, token_id);

--- a/noir-projects/noir-contracts/contracts/app/nft_contract/src/test/utils.nr
+++ b/noir-projects/noir-contracts/contracts/app/nft_contract/src/test/utils.nr
@@ -44,7 +44,7 @@ pub unconstrained fn setup_and_mint(
     let minted_token_id = 615;
 
     NFT::at(nft_contract_address).mint(owner, minted_token_id).call(&mut env.public());
-    env.advance_block_by(1);
+    env.mine_block();
 
     (env, nft_contract_address, owner, recipient, minted_token_id)
 }

--- a/noir-projects/noir-contracts/contracts/app/token_contract/src/test/transfer_to_private.nr
+++ b/noir-projects/noir-contracts/contracts/app/token_contract/src/test/transfer_to_private.nr
@@ -36,7 +36,7 @@ unconstrained fn transfer_to_private_external_orchestration() {
         &mut env.public(),
     );
 
-    env.advance_block_by(1);
+    env.mine_block();
 
     // Recipient's private balance should be equal to the amount
     utils::check_private_balance(token_contract_address, recipient, amount);
@@ -65,7 +65,7 @@ unconstrained fn transfer_to_private_external_orchestration() {
 //         0,
 //     ).call(&mut env.private());
 
-//     env.advance_block_by(1);
+//     env.mine_block();
 
 //     // Recipient's private balance should be equal to the amount
 //     utils::check_private_balance(token_contract_address, recipient, amount);

--- a/noir-projects/noir-contracts/contracts/app/token_contract/src/test/transfer_to_public_and_prepare_private_balance_increase.nr
+++ b/noir-projects/noir-contracts/contracts/app/token_contract/src/test/transfer_to_public_and_prepare_private_balance_increase.nr
@@ -48,7 +48,7 @@ unconstrained fn transfer_to_public_and_prepare_private_balance_increase_and_fin
 
     // We need to advance the block by 1 for the partial note validity commitment to be committed to the nullifier
     // tree.
-    env.advance_block_by(1);
+    env.mine_block();
 
     // Now we finalize the partial change note by impersonating the AMM contract and calling the finalize function
     // --> this should send the `change_amount` from AMM's public balance to liquidity provider's private balance
@@ -59,7 +59,7 @@ unconstrained fn transfer_to_public_and_prepare_private_balance_increase_and_fin
         .finalize_transfer_to_private(change_amount, partial_note)
         .call(&mut env.public());
 
-    env.advance_block_by(1);
+    env.mine_block();
 
     // Check balances after the partial note is finalized
     utils::check_private_balance(

--- a/noir-projects/noir-contracts/contracts/app/token_contract/src/test/utils.nr
+++ b/noir-projects/noir-contracts/contracts/app/token_contract/src/test/utils.nr
@@ -34,7 +34,7 @@ pub unconstrained fn setup(
     let token_contract =
         env.deploy_self("Token").with_public_void_initializer(owner, initializer_call_interface);
     let token_contract_address = token_contract.to_address();
-    env.advance_block_by(1);
+    env.mine_block();
     (&mut env, token_contract_address, owner, recipient)
 }
 
@@ -81,7 +81,7 @@ pub unconstrained fn mint_to_private(
         &mut env.private(),
     );
 
-    env.advance_block_by(1);
+    env.mine_block();
 }
 
 // docs:start:txe_test_read_public

--- a/noir-projects/noir-contracts/contracts/app/token_contract/src/types/balance_set.nr
+++ b/noir-projects/noir-contracts/contracts/app/token_contract/src/types/balance_set.nr
@@ -156,13 +156,13 @@ mod test {
         Token::at(token_contract_address).mint_to_private(owner, recipient, small_mint_amount).call(
             &mut env.private(),
         );
-        env.advance_block_by(1);
+        env.mine_block();
 
         let large_mint_amount: u128 = 50;
         Token::at(token_contract_address).mint_to_private(owner, recipient, large_mint_amount).call(
             &mut env.private(),
         );
-        env.advance_block_by(1);
+        env.mine_block();
 
         // We check the recipient balance is correct both as a sanity check and as a way to make sure we've discovered
         // the notes.
@@ -199,13 +199,13 @@ mod test {
         Token::at(token_contract_address).mint_to_private(owner, recipient, large_mint_amount).call(
             &mut env.private(),
         );
-        env.advance_block_by(1);
+        env.mine_block();
 
         let small_mint_amount: u128 = 5;
         Token::at(token_contract_address).mint_to_private(owner, recipient, small_mint_amount).call(
             &mut env.private(),
         );
-        env.advance_block_by(1);
+        env.mine_block();
 
         // We check the recipient balance is correct both as a sanity check and as a way to make sure we've discovered
         // the notes.

--- a/noir-projects/noir-contracts/contracts/protocol/router_contract/src/test.nr
+++ b/noir-projects/noir-contracts/contracts/protocol/router_contract/src/test.nr
@@ -10,10 +10,12 @@ unconstrained fn test_check_block_number() {
     let router_contract_address = router_contract.to_address();
     let router = Router::at(router_contract_address);
 
-    env.advance_block_by(8);
+    for _ in 0..7 {
+        env.mine_block();
+    }
 
     // First we sanity-check that current block number is as expected
-    let current_block_number = env.pending_block_number();
+    let current_block_number = env.next_block_number();
     assert(current_block_number == 10, "Expected pending block number to be 10");
 
     // We test just one success case and 1 failure case in this test as the rest is tested in the comparator unit tests
@@ -28,10 +30,12 @@ unconstrained fn test_fail_check_block_number() {
     let router_contract_address = router_contract.to_address();
     let router = Router::at(router_contract_address);
 
-    env.advance_block_by(8);
+    for _ in 0..7 {
+        env.mine_block();
+    }
 
     // First we sanity-check that current block number is as expected
-    let current_block_number = env.pending_block_number();
+    let current_block_number = env.next_block_number();
     assert(current_block_number == 10, "Expected block number to be 10");
 
     router.check_block_number(Comparator.LT, 5).call(&mut env.private());

--- a/noir-projects/noir-contracts/contracts/protocol/router_contract/src/test.nr
+++ b/noir-projects/noir-contracts/contracts/protocol/router_contract/src/test.nr
@@ -2,43 +2,55 @@ use crate::Router;
 use dep::aztec::test::helpers::test_environment::TestEnvironment;
 use aztec::utils::comparison::Comparator;
 
+// For both block number and timestamp we only test one success and one failure case, as the rest are more thoroughly
+// covered in the comparator unit tests.
+
 #[test]
-unconstrained fn test_check_block_number() {
+unconstrained fn check_block_number() {
     let mut env = TestEnvironment::new();
 
     let router_contract = env.deploy_self("Router").without_initializer();
     let router_contract_address = router_contract.to_address();
     let router = Router::at(router_contract_address);
 
-    for _ in 0..7 {
-        env.mine_block();
-    }
-
-    // First we sanity-check that current block number is as expected
-    let current_block_number = env.next_block_number();
-    assert(current_block_number == 10, "Expected pending block number to be 10");
-
-    // We test just one success case and 1 failure case in this test as the rest is tested in the comparator unit tests
-    router.check_block_number(Comparator.LT, 11).call(&mut env.private());
+    let expected_next_block_number = env.next_block_number();
+    router.check_block_number(Comparator.LT, expected_next_block_number + 1).call(&mut env.private());
 }
 
 #[test(should_fail_with = "Block number mismatch.")]
-unconstrained fn test_fail_check_block_number() {
+unconstrained fn check_block_number_fail() {
     let mut env = TestEnvironment::new();
 
     let router_contract = env.deploy_self("Router").without_initializer();
     let router_contract_address = router_contract.to_address();
     let router = Router::at(router_contract_address);
 
-    for _ in 0..7 {
-        env.mine_block();
-    }
-
-    // First we sanity-check that current block number is as expected
-    let current_block_number = env.next_block_number();
-    assert(current_block_number == 10, "Expected block number to be 10");
-
-    router.check_block_number(Comparator.LT, 5).call(&mut env.private());
+    let expected_next_block_number = env.next_block_number();
+    router.check_block_number(Comparator.LT, expected_next_block_number).call(&mut env.private());
 }
 
-// TODO(#8372): Add test for check_timestamp --> setting timestamp currently not supported by TXE
+#[test]
+unconstrained fn check_timestamp() {
+    let mut env = TestEnvironment::new();
+
+    let router_contract = env.deploy_self("Router").without_initializer();
+    let router_contract_address = router_contract.to_address();
+    let router = Router::at(router_contract_address);
+
+    let expected_next_block_timestamp = 99999999999999999;
+    env.set_next_block_timestamp(expected_next_block_timestamp);
+    router.check_timestamp(Comparator.LT, expected_next_block_timestamp + 1).call(&mut env.private());
+}
+
+#[test(should_fail_with = "Timestamp mismatch.")]
+unconstrained fn check_timestamp_fail() {
+    let mut env = TestEnvironment::new();
+
+    let router_contract = env.deploy_self("Router").without_initializer();
+    let router_contract_address = router_contract.to_address();
+    let router = Router::at(router_contract_address);
+
+    let expected_next_block_timestamp = 99999999999999999;
+    env.set_next_block_timestamp(expected_next_block_timestamp);
+    router.check_timestamp(Comparator.LT, expected_next_block_timestamp).call(&mut env.private());
+}

--- a/noir-projects/noir-contracts/contracts/test/counter_contract/src/main.nr
+++ b/noir-projects/noir-contracts/contracts/test/counter_contract/src/main.nr
@@ -196,7 +196,7 @@ pub contract Counter {
         assert(get_counter(owner) == 7);
 
         // Checking that the note was discovered from private logs
-        env.advance_block_by(1);
+        env.mine_block();
         sync_private_state();
         let notes: BoundedVec<ValueNote, MAX_NOTES_PER_PAGE> =
             view_notes(owner_storage_slot, options);
@@ -212,7 +212,7 @@ pub contract Counter {
         assert(notes.len() == 4);
 
         // Checking that the note was discovered from private logs
-        env.advance_block_by(1);
+        env.mine_block();
         sync_private_state();
         let notes: BoundedVec<ValueNote, MAX_NOTES_PER_PAGE> =
             view_notes(owner_storage_slot, options);
@@ -227,7 +227,7 @@ pub contract Counter {
         assert(notes.len() == 4);
 
         // Checking that the note was discovered from private logs
-        env.advance_block_by(1);
+        env.mine_block();
         sync_private_state();
         let notes: BoundedVec<ValueNote, MAX_NOTES_PER_PAGE> =
             view_notes(owner_storage_slot, options);

--- a/noir-projects/noir-contracts/contracts/test/public_immutable_contract/src/main.nr
+++ b/noir-projects/noir-contracts/contracts/test/public_immutable_contract/src/main.nr
@@ -53,7 +53,7 @@ mod tests {
         test_contract.initialize_value(x).call(&mut env.public());
 
         // We advance block to commit state and have the nullifier available for reading.
-        env.advance_block_by(1);
+        env.mine_block();
 
         // Read value and verify it matches
         let read_value = test_contract.read_value().call(&mut env.public());

--- a/noir-projects/noir-contracts/contracts/test/test_contract/src/test.nr
+++ b/noir-projects/noir-contracts/contracts/test/test_contract/src/test.nr
@@ -115,10 +115,10 @@ pub unconstrained fn setup() -> (&mut TestEnvironment, AztecAddress, AztecAddres
     env.impersonate(owner);
 
     // TODO(#12276): This is here because we are testing historical proofs, and we cannot get a valid block_header at 1 due to a bug in world state.
-    env.advance_block_by(1);
+    env.mine_block();
 
     // We sanity check that we are building block 3, thus block 3 is where the contract will be deployed.
-    assert_eq(env.pending_block_number(), CONTRACT_DEPLOYED_AT);
+    assert_eq(env.next_block_number(), CONTRACT_DEPLOYED_AT);
 
     // Deploy contract and initialize
     let initializer = Test::interface().initialize();

--- a/yarn-project/txe/src/oracle/txe_oracle.ts
+++ b/yarn-project/txe/src/oracle/txe_oracle.ts
@@ -955,9 +955,11 @@ export class TXE implements TypedOracle {
       throw new Error('Invalid arguments size');
     }
 
+    const historicalBlockNumber = this.blockNumber - 1; // i.e. latest
+
     const privateContextInputs = await this.getPrivateContextInputs(
-      this.blockNumber - 1,
-      this.timestamp - AZTEC_SLOT_DURATION,
+      historicalBlockNumber,
+      await this.getBlockTimestamp(historicalBlockNumber),
       sideEffectCounter,
       isStaticCall,
     );
@@ -1672,5 +1674,14 @@ export class TXE implements TypedOracle {
       returnsHash: returnValuesHash ?? Fr.ZERO,
       txHash: txRequestHash,
     };
+  }
+
+  private async getBlockTimestamp(blockNumber: number) {
+    const blockHeader = await this.stateMachine.archiver.getBlockHeader(blockNumber);
+    if (!blockHeader) {
+      throw new Error(`Requested timestamp for block ${blockNumber}, which does not exist`);
+    }
+
+    return blockHeader.globalVariables.timestamp;
   }
 }


### PR DESCRIPTION
This introduces some renamings and small adjustments to `TestEnvironment`'s API. I only changed the surface API and no the impl to keep those things separate, updating the internals will be its own thing.

Justifications for the renames:

- `committed_timestamp` removed: this didn't really do what it said, it just guessed that the last timestamp was the current one minus the slot duration. I'll reintroduce it later since it is useful, but it needs to fetch the actual timestamp from the archiver.
- `private_at_timestamp`: we can do this by mining a block at a timestamp and then building a private context off of that block. shorthand for `env.mine_block_at(timestamp); env.private()`. Might not introduce since requesting arbitrary timestamps in the past makes no sense and might confuse people.
- `pending_block_number` was renamed to `next_block_number`. `pending_timestamp` was removed since it was confusing and not useful
- `committed_block_number` was renamed to `last_block_number`
- `advance_timestamp_to` and `advance_timestamp_by` were renamed to `set_next_block_timestamp` and `advance_next_block_timestamp_by` respectively
- `advance_block_to` was renamed to `mine_block_at`, which takes a timestamp instead of a target block number. Getting to an arbitrary block was useful with the old shared mutable block number based design, but with it being timestamp based there is no point. Mining a block at a timestamp is instead very useful.
- `advance_block_by` was renamed to `mine_block`, which now mines a single block. I've found no reason for us to mine multiple blocks - perhaps two at most, to get a historical one and one prior to that (which we do in _one_ aztec-nr test). 

I had to update some of the contract tests to use the new versions of these functions. It's clear from a cursory overview that many (most) of those tests are either incomplete or make very poor use of TXE's abstractions - likely due to it providing poor guarantees in terms of block production etc. I'll make a pass over those later to make sure that the new primitives allow for sane testing of these use cases.

Fixes #8372