### PR TITLE
fix: Use committee ordering for target epoch

### DIFF
--- a/yarn-project/sequencer-client/src/publisher/sequencer-publisher.ts
+++ b/yarn-project/sequencer-client/src/publisher/sequencer-publisher.ts
@@ -398,11 +398,6 @@ export class SequencerPublisher {
     return ts;
   }
 
-  public async getCurrentEpochCommittee(): Promise<EthAddress[] | undefined> {
-    const committee = await this.rollupContract.getCurrentEpochCommittee();
-    return committee?.map(EthAddress.fromString);
-  }
-
   private async enqueueCastVoteHelper(
     slotNumber: bigint,
     timestamp: bigint,

--- a/yarn-project/sequencer-client/src/sequencer/sequencer.test.ts
+++ b/yarn-project/sequencer-client/src/sequencer/sequencer.test.ts
@@ -1,6 +1,6 @@
 import { Body, L2Block } from '@aztec/aztec.js';
 import { NUMBER_OF_L1_L2_MESSAGES_PER_ROLLUP } from '@aztec/constants';
-import type { EpochCache } from '@aztec/epoch-cache';
+import type { EpochCache, EpochCommitteeInfo } from '@aztec/epoch-cache';
 import { timesParallel } from '@aztec/foundation/collection';
 import { Secp256k1Signer } from '@aztec/foundation/crypto';
 import { EthAddress } from '@aztec/foundation/eth-address';
@@ -31,7 +31,7 @@ import type { MerkleTreeId } from '@aztec/stdlib/trees';
 import { BlockHeader, GlobalVariables, type Tx, TxHash, makeProcessedTxFromPrivateOnlyTx } from '@aztec/stdlib/tx';
 import type { ValidatorClient } from '@aztec/validator-client';
 
-import { expect, jest } from '@jest/globals';
+import { expect } from '@jest/globals';
 import { type MockProxy, mock, mockDeep, mockFn } from 'jest-mock-extended';
 
 import type { GlobalVariableBuilder } from '../global_variable_builder/global_builder.js';
@@ -41,6 +41,7 @@ import { SequencerState } from './utils.js';
 
 describe('sequencer', () => {
   let publisher: MockProxy<SequencerPublisher>;
+  let epochCache: MockProxy<EpochCache>;
   let validatorClient: MockProxy<ValidatorClient>;
   let globalVariableBuilder: MockProxy<GlobalVariableBuilder>;
   let p2p: MockProxy<P2P>;
@@ -162,13 +163,13 @@ describe('sequencer', () => {
     const l1GenesisTime = BigInt(Math.floor(Date.now() / 1000));
     l1Constants = { l1GenesisTime, slotDuration, ethereumSlotDuration };
 
-    const epochCache = mockDeep<EpochCache>();
+    epochCache = mockDeep<EpochCache>();
     epochCache.getEpochAndSlotInNextL1Slot.mockImplementation(() => ({ epoch: 1n, slot: 1n, ts: 1000n, now: 1000n }));
+    epochCache.getCommittee.mockResolvedValue({ committee } as EpochCommitteeInfo);
 
     publisher = mockDeep<SequencerPublisher>();
     publisher.epochCache = epochCache;
     publisher.getSenderAddress.mockImplementation(() => EthAddress.random());
-    publisher.getCurrentEpochCommittee.mockResolvedValue(committee);
     publisher.validateBlockHeader.mockResolvedValue();
     publisher.enqueueProposeL2Block.mockResolvedValue(true);
     publisher.enqueueCastVote.mockResolvedValue(true);
@@ -566,11 +567,8 @@ describe('sequencer', () => {
 
   it('should proceed with block proposal when there is no proposer yet', async () => {
     // Mock that there is no official proposer yet
-    publisher.epochCache.getProposerAttesterAddressInNextSlot = jest
-      .fn()
-      .mockImplementationOnce(() => Promise.resolve(undefined)) as jest.Mock<() => Promise<EthAddress | undefined>>;
-
-    publisher.getCurrentEpochCommittee.mockResolvedValueOnce([]);
+    epochCache.getProposerAttesterAddressInNextSlot.mockResolvedValueOnce(undefined);
+    epochCache.getCommittee.mockResolvedValueOnce({ committee: [] as EthAddress[] } as EpochCommitteeInfo);
 
     // Mock that we have some pending transactions
     const txs = [await makeTx(1), await makeTx(2)];

--- a/yarn-project/sequencer-client/src/sequencer/sequencer.ts
+++ b/yarn-project/sequencer-client/src/sequencer/sequencer.ts
@@ -671,8 +671,7 @@ export class Sequencer extends (EventEmitter as new () => TypedEventEmitter<Sequ
     txs: Tx[],
     proposerAddress: EthAddress | undefined,
   ): Promise<CommitteeAttestation[] | undefined> {
-    // TODO(https://github.com/AztecProtocol/aztec-packages/issues/7962): inefficient to have a round trip in here - this should be cached
-    const committee = await this.publisher.getCurrentEpochCommittee();
+    const { committee } = await this.publisher.epochCache.getCommittee(block.header.getSlot());
 
     // We checked above that the committee is defined, so this should never happen.
     if (!committee) {


### PR DESCRIPTION
When deciding how to sort attestations, we were using the committee ordering from the current epoch, as opposed to the epoch we were targetting. This caused errors in the first slot of the epoch (see http://ci.aztec-labs.com/45490fb70a334ee3).