### PR TITLE
feat: hardcode vks of ECCVM and Translator

### DIFF
--- a/barretenberg/cpp/src/barretenberg/eccvm/eccvm_flavor.hpp
+++ b/barretenberg/cpp/src/barretenberg/eccvm/eccvm_flavor.hpp
@@ -864,8 +864,8 @@ class ECCVMFlavor {
          * @param transcript
          * @returns The hash of the verification key
          */
-        fr add_hash_to_transcript([[maybe_unused]] const std::string& domain_separator,
-                                  [[maybe_unused]] Transcript& transcript) const override
+        fr add_hash_to_transcript(const std::string& domain_separator,
+                                  Transcript& transcript) const override
         {
             for (const Commitment& commitment : this->get_all()) {
                 transcript.add_to_independent_hash_buffer(domain_separator + "vk_commitment", commitment);

--- a/barretenberg/cpp/src/barretenberg/eccvm/eccvm_flavor.hpp
+++ b/barretenberg/cpp/src/barretenberg/eccvm/eccvm_flavor.hpp
@@ -864,8 +864,7 @@ class ECCVMFlavor {
          * @param transcript
          * @returns The hash of the verification key
          */
-        fr add_hash_to_transcript(const std::string& domain_separator,
-                                  Transcript& transcript) const override
+        fr add_hash_to_transcript(const std::string& domain_separator, Transcript& transcript) const override
         {
             for (const Commitment& commitment : this->get_all()) {
                 transcript.add_to_independent_hash_buffer(domain_separator + "vk_commitment", commitment);

--- a/barretenberg/cpp/src/barretenberg/eccvm/eccvm_flavor.hpp
+++ b/barretenberg/cpp/src/barretenberg/eccvm/eccvm_flavor.hpp
@@ -856,20 +856,16 @@ class ECCVMFlavor {
             return elements;
         }
         /**
-         * @brief Adds the verification key hash to the transcript and returns the hash.
-         * @details Needed to make sure the Origin Tag system works. See the base class function for
-         * more details.
+         * @brief Unused function because vk is hardcoded in recursive verifier, so no transcript hashing is needed.
          *
          * @param domain_separator
          * @param transcript
          * @returns The hash of the verification key
          */
-        fr add_hash_to_transcript(const std::string& domain_separator, Transcript& transcript) const override
+        fr add_hash_to_transcript([[maybe_unused]] const std::string& domain_separator,
+                                  [[maybe_unused]] Transcript& transcript) const override
         {
-            for (const Commitment& commitment : this->get_all()) {
-                transcript.add_to_independent_hash_buffer(domain_separator + "vk_commitment", commitment);
-            }
-            return transcript.hash_independent_buffer(domain_separator + "vk_hash");
+            throw_or_abort("Not intended to be used because vk is hardcoded in circuit.");
         }
 
         // TODO(https://github.com/AztecProtocol/barretenberg/issues/1324): Remove `circuit_size` and `log_circuit_size`

--- a/barretenberg/cpp/src/barretenberg/eccvm/eccvm_prover.cpp
+++ b/barretenberg/cpp/src/barretenberg/eccvm/eccvm_prover.cpp
@@ -45,8 +45,9 @@ void ECCVMProver::execute_preamble_round()
 
     // Fiat-Shamir the vk hash
     VerificationKey vk;
-    typename Flavor::BF vkey_hash = vk.add_hash_to_transcript("", *transcript);
-    vinfo("ECCVM vk hash in prover: ", vkey_hash);
+    typename Flavor::BF vk_hash = vk.hash();
+    transcript->add_to_hash_buffer("vk_hash", vk_hash);
+    vinfo("ECCVM vk hash in prover: ", vk_hash);
 }
 
 /**

--- a/barretenberg/cpp/src/barretenberg/eccvm/eccvm_verifier.cpp
+++ b/barretenberg/cpp/src/barretenberg/eccvm/eccvm_verifier.cpp
@@ -30,8 +30,9 @@ bool ECCVMVerifier::verify_proof(const ECCVMProof& proof)
     transcript->load_proof(proof.pre_ipa_proof);
 
     // Fiat-Shamir the vk hash
-    typename Flavor::BF vkey_hash = key->add_hash_to_transcript("", *transcript);
-    vinfo("ECCVM vk hash in verifier: ", vkey_hash);
+    typename Flavor::BF vk_hash = key->hash();
+    transcript->add_to_hash_buffer("vk_hash", vk_hash);
+    vinfo("ECCVM vk hash in verifier: ", vk_hash);
 
     VerifierCommitments commitments{ key };
     CommitmentLabels commitment_labels;

--- a/barretenberg/cpp/src/barretenberg/flavor/native_verification_key.test.cpp
+++ b/barretenberg/cpp/src/barretenberg/flavor/native_verification_key.test.cpp
@@ -83,7 +83,7 @@ TYPED_TEST(NativeVerificationKeyTests, VKHashingConsistency)
     EXPECT_EQ(vkey_hash_1, vkey_hash_2);
     // TODO(https://github.com/AztecProtocol/barretenberg/issues/1427): Solidity verifier does not fiat shamir the full
     // verification key. This will be fixed in a followup PR.
-    if constexpr (!IsAnyOf<Flavor, UltraKeccakFlavor>) {
+    if constexpr (!IsAnyOf<Flavor, UltraKeccakFlavor, ECCVMFlavor, TranslatorFlavor>) {
         // Third method of hashing: using add_hash_to_transcript.
         typename Flavor::Transcript transcript_2;
         fr vkey_hash_3 = vk.add_hash_to_transcript("", transcript_2);

--- a/barretenberg/cpp/src/barretenberg/flavor/stdlib_verification_key.test.cpp
+++ b/barretenberg/cpp/src/barretenberg/flavor/stdlib_verification_key.test.cpp
@@ -82,7 +82,9 @@ TYPED_TEST(StdlibVerificationKeyTests, VKHashingConsistency)
     FF vkey_hash_2 = vk.hash(outer_builder);
     EXPECT_EQ(vkey_hash_1.get_value(), vkey_hash_2.get_value());
     // Third method of hashing: using add_hash_to_transcript.
-    StdlibTranscript transcript_2;
-    FF vkey_hash_3 = vk.add_hash_to_transcript("", transcript_2);
-    EXPECT_EQ(vkey_hash_2.get_value(), vkey_hash_3.get_value());
+    if constexpr (!IsAnyOf<Flavor, TranslatorRecursiveFlavor, ECCVMRecursiveFlavor>) {
+        StdlibTranscript transcript_2;
+        FF vkey_hash_3 = vk.add_hash_to_transcript("", transcript_2);
+        EXPECT_EQ(vkey_hash_2.get_value(), vkey_hash_3.get_value());
+    }
 }

--- a/barretenberg/cpp/src/barretenberg/stdlib/eccvm_verifier/eccvm_recursive_flavor.hpp
+++ b/barretenberg/cpp/src/barretenberg/stdlib/eccvm_verifier/eccvm_recursive_flavor.hpp
@@ -155,14 +155,20 @@ class ECCVMRecursiveFlavor {
          * @param domain_separator
          * @param transcript
          */
-        FF add_hash_to_transcript([[maybe_unused]] const std::string& domain_separator,
-                                  [[maybe_unused]] Transcript& transcript) const override
+        FF add_hash_to_transcript(const std::string& domain_separator,
+                                  Transcript& transcript) const override
         {
             for (const Commitment& commitment : this->get_all()) {
                 transcript.add_to_independent_hash_buffer(domain_separator + "vk_commitment", commitment);
             }
 
             return transcript.hash_independent_buffer(domain_separator + "vk_hash");
+        }
+
+        void fix_witness() {
+            for (Commitment& commitment : this->get_all()) {
+                commitment.fix_witness();
+            }
         }
     };
 

--- a/barretenberg/cpp/src/barretenberg/stdlib/eccvm_verifier/eccvm_recursive_flavor.hpp
+++ b/barretenberg/cpp/src/barretenberg/stdlib/eccvm_verifier/eccvm_recursive_flavor.hpp
@@ -148,20 +148,15 @@ class ECCVMRecursiveFlavor {
         }
 
         /**
-         * @brief Adds the verification key hash to the transcript and returns the hash.
-         * @details Needed to make sure the Origin Tag system works. See the base class function for
-         * more details.
+         * @brief Unused function because vk is hardcoded in recursive verifier, so no transcript hashing is needed.
          *
          * @param domain_separator
          * @param transcript
          */
-        FF add_hash_to_transcript(const std::string& domain_separator, Transcript& transcript) const override
+        FF add_hash_to_transcript([[maybe_unused]] const std::string& domain_separator,
+                                  [[maybe_unused]] Transcript& transcript) const override
         {
-            for (const Commitment& commitment : this->get_all()) {
-                transcript.add_to_independent_hash_buffer(domain_separator + "vk_commitment", commitment);
-            }
-
-            return transcript.hash_independent_buffer(domain_separator + "vk_hash");
+            throw_or_abort("Not intended to be used because vk is hardcoded in circuit.");
         }
 
         void fix_witness()

--- a/barretenberg/cpp/src/barretenberg/stdlib/eccvm_verifier/eccvm_recursive_flavor.hpp
+++ b/barretenberg/cpp/src/barretenberg/stdlib/eccvm_verifier/eccvm_recursive_flavor.hpp
@@ -159,6 +159,10 @@ class ECCVMRecursiveFlavor {
             throw_or_abort("Not intended to be used because vk is hardcoded in circuit.");
         }
 
+        /**
+         * @brief Fixes witnesses of VK to be constants.
+         *
+         */
         void fix_witness()
         {
             for (Commitment& commitment : this->get_all()) {

--- a/barretenberg/cpp/src/barretenberg/stdlib/eccvm_verifier/eccvm_recursive_flavor.hpp
+++ b/barretenberg/cpp/src/barretenberg/stdlib/eccvm_verifier/eccvm_recursive_flavor.hpp
@@ -155,8 +155,7 @@ class ECCVMRecursiveFlavor {
          * @param domain_separator
          * @param transcript
          */
-        FF add_hash_to_transcript(const std::string& domain_separator,
-                                  Transcript& transcript) const override
+        FF add_hash_to_transcript(const std::string& domain_separator, Transcript& transcript) const override
         {
             for (const Commitment& commitment : this->get_all()) {
                 transcript.add_to_independent_hash_buffer(domain_separator + "vk_commitment", commitment);
@@ -165,7 +164,8 @@ class ECCVMRecursiveFlavor {
             return transcript.hash_independent_buffer(domain_separator + "vk_hash");
         }
 
-        void fix_witness() {
+        void fix_witness()
+        {
             for (Commitment& commitment : this->get_all()) {
                 commitment.fix_witness();
             }

--- a/barretenberg/cpp/src/barretenberg/stdlib/eccvm_verifier/eccvm_recursive_verifier.cpp
+++ b/barretenberg/cpp/src/barretenberg/stdlib/eccvm_verifier/eccvm_recursive_verifier.cpp
@@ -16,7 +16,7 @@ ECCVMRecursiveVerifier::ECCVMRecursiveVerifier(Builder* builder,
                                                const std::shared_ptr<NativeVerificationKey>& native_verifier_key,
                                                const std::shared_ptr<Transcript>& transcript)
     : key(std::make_shared<VerificationKey>(builder, native_verifier_key))
-    , vk_hash(builder, native_verifier_key->hash())
+    , vk_hash(stdlib::witness_t<Builder>(builder, native_verifier_key->hash()))
     , builder(builder)
     , transcript(transcript)
 {

--- a/barretenberg/cpp/src/barretenberg/stdlib/eccvm_verifier/eccvm_recursive_verifier.cpp
+++ b/barretenberg/cpp/src/barretenberg/stdlib/eccvm_verifier/eccvm_recursive_verifier.cpp
@@ -58,6 +58,7 @@ ECCVMRecursiveVerifier::IpaClaimAndProof ECCVMRecursiveVerifier::verify_proof(co
     transcript->load_proof(proof.pre_ipa_proof);
 
     // Fiat-Shamir the vk hash
+    // We do not need to hash the vk in-circuit because both the vk and vk hash are hardcoded as constants.
     transcript->add_to_hash_buffer("vk_hash", vk_hash);
     vinfo("ECCVM vk hash in recursive verifier: ", vk_hash);
 

--- a/barretenberg/cpp/src/barretenberg/stdlib/eccvm_verifier/eccvm_recursive_verifier.cpp
+++ b/barretenberg/cpp/src/barretenberg/stdlib/eccvm_verifier/eccvm_recursive_verifier.cpp
@@ -16,9 +16,13 @@ ECCVMRecursiveVerifier::ECCVMRecursiveVerifier(Builder* builder,
                                                const std::shared_ptr<NativeVerificationKey>& native_verifier_key,
                                                const std::shared_ptr<Transcript>& transcript)
     : key(std::make_shared<VerificationKey>(builder, native_verifier_key))
+    , vk_hash(native_verifier_key->hash())
     , builder(builder)
     , transcript(transcript)
-{}
+{
+    key->fix_witness(); // fixed to a constant
+    vk_hash.convert_constant_to_fixed_witness(builder); // fixed to a constant
+}
 
 /**
  * @brief Creates a circuit that executes the ECCVM verifier algorithm up to IPA verification.
@@ -54,10 +58,8 @@ ECCVMRecursiveVerifier::IpaClaimAndProof ECCVMRecursiveVerifier::verify_proof(co
     transcript->load_proof(proof.pre_ipa_proof);
 
     // Fiat-Shamir the vk hash
-    // TODO(https://github.com/AztecProtocol/barretenberg/issues/1472): Hardcode this into the circuit to avoid any
-    // in-circuit hashing.
-    typename Flavor::BF vkey_hash = key->add_hash_to_transcript("", *transcript);
-    vinfo("ECCVM vk hash in recursive verifier: ", vkey_hash);
+    transcript->add_to_hash_buffer("vk_hash", vk_hash);
+    vinfo("ECCVM vk hash in recursive verifier: ", vk_hash);
 
     VerifierCommitments commitments{ key };
     CommitmentLabels commitment_labels;

--- a/barretenberg/cpp/src/barretenberg/stdlib/eccvm_verifier/eccvm_recursive_verifier.cpp
+++ b/barretenberg/cpp/src/barretenberg/stdlib/eccvm_verifier/eccvm_recursive_verifier.cpp
@@ -20,7 +20,7 @@ ECCVMRecursiveVerifier::ECCVMRecursiveVerifier(Builder* builder,
     , builder(builder)
     , transcript(transcript)
 {
-    key->fix_witness(); // fixed to a constant
+    key->fix_witness();                                 // fixed to a constant
     vk_hash.convert_constant_to_fixed_witness(builder); // fixed to a constant
 }
 

--- a/barretenberg/cpp/src/barretenberg/stdlib/eccvm_verifier/eccvm_recursive_verifier.cpp
+++ b/barretenberg/cpp/src/barretenberg/stdlib/eccvm_verifier/eccvm_recursive_verifier.cpp
@@ -16,12 +16,12 @@ ECCVMRecursiveVerifier::ECCVMRecursiveVerifier(Builder* builder,
                                                const std::shared_ptr<NativeVerificationKey>& native_verifier_key,
                                                const std::shared_ptr<Transcript>& transcript)
     : key(std::make_shared<VerificationKey>(builder, native_verifier_key))
-    , vk_hash(native_verifier_key->hash())
+    , vk_hash(builder, native_verifier_key->hash())
     , builder(builder)
     , transcript(transcript)
 {
-    key->fix_witness();                                 // fixed to a constant
-    vk_hash.convert_constant_to_fixed_witness(builder); // fixed to a constant
+    key->fix_witness();    // fixed to a constant
+    vk_hash.fix_witness(); // fixed to a constant
 }
 
 /**

--- a/barretenberg/cpp/src/barretenberg/stdlib/eccvm_verifier/eccvm_recursive_verifier.hpp
+++ b/barretenberg/cpp/src/barretenberg/stdlib/eccvm_verifier/eccvm_recursive_verifier.hpp
@@ -48,6 +48,7 @@ class ECCVMRecursiveVerifier {
     void compute_translation_opening_claims(const std::vector<Commitment>& translation_commitments);
 
     std::shared_ptr<VerificationKey> key;
+    FF vk_hash;
 
     Builder* builder;
     std::shared_ptr<Transcript> transcript;

--- a/barretenberg/cpp/src/barretenberg/stdlib/eccvm_verifier/eccvm_recursive_verifier.hpp
+++ b/barretenberg/cpp/src/barretenberg/stdlib/eccvm_verifier/eccvm_recursive_verifier.hpp
@@ -48,7 +48,7 @@ class ECCVMRecursiveVerifier {
     void compute_translation_opening_claims(const std::vector<Commitment>& translation_commitments);
 
     std::shared_ptr<VerificationKey> key;
-    FF vk_hash;
+    BF vk_hash;
 
     Builder* builder;
     std::shared_ptr<Transcript> transcript;

--- a/barretenberg/cpp/src/barretenberg/stdlib/primitives/biggroup/biggroup.hpp
+++ b/barretenberg/cpp/src/barretenberg/stdlib/primitives/biggroup/biggroup.hpp
@@ -141,6 +141,19 @@ template <class Builder, class Fq, class Fr, class NativeGroup> class element {
         unset_free_witness_tag();
     }
 
+    /**
+     * Fix a witness. The value of the witness is constrained with a selector
+     **/
+    void fix_witness()
+    {
+        // Origin tags should be updated within
+        this->x.fix_witness();
+        this->y.fix_witness();
+
+        // This is now effectively a constant
+        unset_free_witness_tag();
+    }
+
     static element one(Builder* ctx)
     {
         uint256_t x = uint256_t(NativeGroup::one.x);

--- a/barretenberg/cpp/src/barretenberg/stdlib/primitives/biggroup/biggroup.hpp
+++ b/barretenberg/cpp/src/barretenberg/stdlib/primitives/biggroup/biggroup.hpp
@@ -236,7 +236,7 @@ template <class Builder, class Fq, class Fr, class NativeGroup> class element {
         Fq y3_prev;
         bool is_element = false;
 
-        chain_add_accumulator() {};
+        chain_add_accumulator(){};
         explicit chain_add_accumulator(const element& input)
         {
             x3_prev = input.x;
@@ -412,7 +412,7 @@ template <class Builder, class Fq, class Fr, class NativeGroup> class element {
     static typename NativeGroup::affine_element compute_table_offset_generator();
 
     struct four_bit_table_plookup {
-        four_bit_table_plookup() {};
+        four_bit_table_plookup(){};
         four_bit_table_plookup(const element& input);
 
         four_bit_table_plookup(const four_bit_table_plookup& other) = default;
@@ -429,7 +429,7 @@ template <class Builder, class Fq, class Fr, class NativeGroup> class element {
         enum CurveType { BN254, SECP256K1, SECP256R1 };
         eight_bit_fixed_base_table(const CurveType input_curve_type, bool use_endo)
             : curve_type(input_curve_type)
-            , use_endomorphism(use_endo) {};
+            , use_endomorphism(use_endo){};
 
         eight_bit_fixed_base_table(const eight_bit_fixed_base_table& other) = default;
         eight_bit_fixed_base_table& operator=(const eight_bit_fixed_base_table& other) = default;

--- a/barretenberg/cpp/src/barretenberg/stdlib/primitives/biggroup/biggroup.hpp
+++ b/barretenberg/cpp/src/barretenberg/stdlib/primitives/biggroup/biggroup.hpp
@@ -236,7 +236,7 @@ template <class Builder, class Fq, class Fr, class NativeGroup> class element {
         Fq y3_prev;
         bool is_element = false;
 
-        chain_add_accumulator(){};
+        chain_add_accumulator() {};
         explicit chain_add_accumulator(const element& input)
         {
             x3_prev = input.x;
@@ -412,7 +412,7 @@ template <class Builder, class Fq, class Fr, class NativeGroup> class element {
     static typename NativeGroup::affine_element compute_table_offset_generator();
 
     struct four_bit_table_plookup {
-        four_bit_table_plookup(){};
+        four_bit_table_plookup() {};
         four_bit_table_plookup(const element& input);
 
         four_bit_table_plookup(const four_bit_table_plookup& other) = default;
@@ -429,7 +429,7 @@ template <class Builder, class Fq, class Fr, class NativeGroup> class element {
         enum CurveType { BN254, SECP256K1, SECP256R1 };
         eight_bit_fixed_base_table(const CurveType input_curve_type, bool use_endo)
             : curve_type(input_curve_type)
-            , use_endomorphism(use_endo){};
+            , use_endomorphism(use_endo) {};
 
         eight_bit_fixed_base_table(const eight_bit_fixed_base_table& other) = default;
         eight_bit_fixed_base_table& operator=(const eight_bit_fixed_base_table& other) = default;

--- a/barretenberg/cpp/src/barretenberg/stdlib/primitives/bool/bool.hpp
+++ b/barretenberg/cpp/src/barretenberg/stdlib/primitives/bool/bool.hpp
@@ -120,6 +120,15 @@ template <typename Builder> class bool_t {
     OriginTag get_origin_tag() const { return tag; }
     void set_free_witness_tag() { tag.set_free_witness(); }
     void unset_free_witness_tag() { tag.unset_free_witness(); }
+    void convert_constant_to_fixed_witness(Builder* ctx) { 
+      ASSERT(is_constant() && ctx);
+        context = ctx;
+        (*this) = bool_t<Builder>(witness_t<Builder>(context, get_value()));
+        context->fix_witness(witness_index, get_value());
+        unset_free_witness_tag();
+      }
+    void fix_witness() { ASSERT(!is_constant()); ASSERT(context); context->fix_witness(witness_index, get_value());
+        unset_free_witness_tag(); }
     mutable Builder* context = nullptr;
     mutable bool witness_bool = false;
     mutable bool witness_inverted = false;

--- a/barretenberg/cpp/src/barretenberg/stdlib/primitives/bool/bool.hpp
+++ b/barretenberg/cpp/src/barretenberg/stdlib/primitives/bool/bool.hpp
@@ -120,14 +120,6 @@ template <typename Builder> class bool_t {
     OriginTag get_origin_tag() const { return tag; }
     void set_free_witness_tag() { tag.set_free_witness(); }
     void unset_free_witness_tag() { tag.unset_free_witness(); }
-    void convert_constant_to_fixed_witness(Builder* ctx)
-    {
-        ASSERT(is_constant() && ctx);
-        context = ctx;
-        (*this) = bool_t<Builder>(witness_t<Builder>(context, get_value()));
-        context->fix_witness(witness_index, get_value());
-        unset_free_witness_tag();
-    }
     void fix_witness()
     {
         ASSERT(!is_constant());

--- a/barretenberg/cpp/src/barretenberg/stdlib/primitives/bool/bool.hpp
+++ b/barretenberg/cpp/src/barretenberg/stdlib/primitives/bool/bool.hpp
@@ -120,15 +120,21 @@ template <typename Builder> class bool_t {
     OriginTag get_origin_tag() const { return tag; }
     void set_free_witness_tag() { tag.set_free_witness(); }
     void unset_free_witness_tag() { tag.unset_free_witness(); }
-    void convert_constant_to_fixed_witness(Builder* ctx) { 
-      ASSERT(is_constant() && ctx);
+    void convert_constant_to_fixed_witness(Builder* ctx)
+    {
+        ASSERT(is_constant() && ctx);
         context = ctx;
         (*this) = bool_t<Builder>(witness_t<Builder>(context, get_value()));
         context->fix_witness(witness_index, get_value());
         unset_free_witness_tag();
-      }
-    void fix_witness() { ASSERT(!is_constant()); ASSERT(context); context->fix_witness(witness_index, get_value());
-        unset_free_witness_tag(); }
+    }
+    void fix_witness()
+    {
+        ASSERT(!is_constant());
+        ASSERT(context);
+        context->fix_witness(witness_index, get_value());
+        unset_free_witness_tag();
+    }
     mutable Builder* context = nullptr;
     mutable bool witness_bool = false;
     mutable bool witness_inverted = false;

--- a/barretenberg/cpp/src/barretenberg/stdlib/primitives/group/cycle_group.hpp
+++ b/barretenberg/cpp/src/barretenberg/stdlib/primitives/group/cycle_group.hpp
@@ -98,7 +98,7 @@ template <typename Builder> class cycle_group {
             , hi(_hi)
             , _num_bits(bits)
             , _skip_primality_test(skip_primality_test)
-            , _use_bn254_scalar_field_for_primality_test(use_bn254_scalar_field_for_primality_test){};
+            , _use_bn254_scalar_field_for_primality_test(use_bn254_scalar_field_for_primality_test) {};
         cycle_scalar(const ScalarField& _in = 0);
         cycle_scalar(const field_t& _lo, const field_t& _hi);
         cycle_scalar(const field_t& _in);

--- a/barretenberg/cpp/src/barretenberg/stdlib/primitives/group/cycle_group.hpp
+++ b/barretenberg/cpp/src/barretenberg/stdlib/primitives/group/cycle_group.hpp
@@ -98,7 +98,7 @@ template <typename Builder> class cycle_group {
             , hi(_hi)
             , _num_bits(bits)
             , _skip_primality_test(skip_primality_test)
-            , _use_bn254_scalar_field_for_primality_test(use_bn254_scalar_field_for_primality_test) {};
+            , _use_bn254_scalar_field_for_primality_test(use_bn254_scalar_field_for_primality_test){};
         cycle_scalar(const ScalarField& _in = 0);
         cycle_scalar(const field_t& _lo, const field_t& _hi);
         cycle_scalar(const field_t& _in);

--- a/barretenberg/cpp/src/barretenberg/stdlib/primitives/group/cycle_group.hpp
+++ b/barretenberg/cpp/src/barretenberg/stdlib/primitives/group/cycle_group.hpp
@@ -320,6 +320,32 @@ template <typename Builder> class cycle_group {
         y.unset_free_witness_tag();
         _is_infinity.unset_free_witness_tag();
     }
+
+    /**
+     * @brief Creates fixed witnesses from a constant element.
+     **/
+    void convert_constant_to_fixed_witness(Builder* builder)
+    {
+        x.convert_constant_to_fixed_witness(builder);
+        y.convert_constant_to_fixed_witness(builder);
+        _is_infinity.convert_constant_to_fixed_witness(builder);
+        // Origin tags should be unset after fixing the witness
+        unset_free_witness_tag();
+    }
+
+    /**
+     * Fix a witness. The value of the witness is constrained with a selector
+     **/
+    void fix_witness()
+    {
+        // Origin tags should be updated within
+        x.fix_witness();
+        y.fix_witness();
+        _is_infinity.fix_witness();
+
+        // This is now effectively a constant
+        unset_free_witness_tag();
+    }
     /**
      * @brief Set the witness indices representing the cycle_group to public
      *

--- a/barretenberg/cpp/src/barretenberg/stdlib/primitives/group/cycle_group.hpp
+++ b/barretenberg/cpp/src/barretenberg/stdlib/primitives/group/cycle_group.hpp
@@ -322,18 +322,6 @@ template <typename Builder> class cycle_group {
     }
 
     /**
-     * @brief Creates fixed witnesses from a constant element.
-     **/
-    void convert_constant_to_fixed_witness(Builder* builder)
-    {
-        x.convert_constant_to_fixed_witness(builder);
-        y.convert_constant_to_fixed_witness(builder);
-        _is_infinity.convert_constant_to_fixed_witness(builder);
-        // Origin tags should be unset after fixing the witness
-        unset_free_witness_tag();
-    }
-
-    /**
      * Fix a witness. The value of the witness is constrained with a selector
      **/
     void fix_witness()

--- a/barretenberg/cpp/src/barretenberg/stdlib/translator_vm_verifier/translator_recursive_flavor.hpp
+++ b/barretenberg/cpp/src/barretenberg/stdlib/translator_vm_verifier/translator_recursive_flavor.hpp
@@ -162,7 +162,8 @@ class TranslatorRecursiveFlavor {
             return transcript.hash_independent_buffer(domain_separator + "vk_hash");
         }
 
-        void fix_witness() {
+        void fix_witness()
+        {
             for (Commitment& commitment : this->get_all()) {
                 commitment.fix_witness();
             }

--- a/barretenberg/cpp/src/barretenberg/stdlib/translator_vm_verifier/translator_recursive_flavor.hpp
+++ b/barretenberg/cpp/src/barretenberg/stdlib/translator_vm_verifier/translator_recursive_flavor.hpp
@@ -146,20 +146,15 @@ class TranslatorRecursiveFlavor {
         }
 
         /**
-         * @brief Adds the verification key hash to the transcript and returns the hash.
-         * @details Needed to make sure the Origin Tag system works. See the base class function for
-         * more details.
+         * @brief Unused function because vk is hardcoded in recursive verifier, so no transcript hashing is needed.
          *
          * @param domain_separator
          * @param transcript
          */
-        FF add_hash_to_transcript(const std::string& domain_separator, Transcript& transcript) const override
+        FF add_hash_to_transcript([[maybe_unused]] const std::string& domain_separator,
+                                  [[maybe_unused]] Transcript& transcript) const override
         {
-            for (const Commitment& commitment : this->get_all()) {
-                transcript.add_to_independent_hash_buffer(domain_separator + "vk_commitment", commitment);
-            }
-
-            return transcript.hash_independent_buffer(domain_separator + "vk_hash");
+            throw_or_abort("Not intended to be used because vk is hardcoded in circuit.");
         }
 
         void fix_witness()

--- a/barretenberg/cpp/src/barretenberg/stdlib/translator_vm_verifier/translator_recursive_flavor.hpp
+++ b/barretenberg/cpp/src/barretenberg/stdlib/translator_vm_verifier/translator_recursive_flavor.hpp
@@ -153,14 +153,19 @@ class TranslatorRecursiveFlavor {
          * @param domain_separator
          * @param transcript
          */
-        FF add_hash_to_transcript([[maybe_unused]] const std::string& domain_separator,
-                                  [[maybe_unused]] Transcript& transcript) const override
+        FF add_hash_to_transcript(const std::string& domain_separator, Transcript& transcript) const override
         {
             for (const Commitment& commitment : this->get_all()) {
                 transcript.add_to_independent_hash_buffer(domain_separator + "vk_commitment", commitment);
             }
 
             return transcript.hash_independent_buffer(domain_separator + "vk_hash");
+        }
+
+        void fix_witness() {
+            for (Commitment& commitment : this->get_all()) {
+                commitment.fix_witness();
+            }
         }
     };
 

--- a/barretenberg/cpp/src/barretenberg/stdlib/translator_vm_verifier/translator_recursive_verifier.cpp
+++ b/barretenberg/cpp/src/barretenberg/stdlib/translator_vm_verifier/translator_recursive_verifier.cpp
@@ -21,11 +21,11 @@ TranslatorRecursiveVerifier::TranslatorRecursiveVerifier(
     const std::shared_ptr<NativeVerificationKey>& native_verifier_key,
     const std::shared_ptr<Transcript>& transcript)
     : key(std::make_shared<VerificationKey>(builder, native_verifier_key))
-     , vk_hash(native_verifier_key->hash())
+    , vk_hash(native_verifier_key->hash())
     , transcript(transcript)
     , builder(builder)
 {
-    key->fix_witness(); // fixed to a constant
+    key->fix_witness();                                 // fixed to a constant
     vk_hash.convert_constant_to_fixed_witness(builder); // fixed to a constant
 }
 

--- a/barretenberg/cpp/src/barretenberg/stdlib/translator_vm_verifier/translator_recursive_verifier.cpp
+++ b/barretenberg/cpp/src/barretenberg/stdlib/translator_vm_verifier/translator_recursive_verifier.cpp
@@ -21,9 +21,13 @@ TranslatorRecursiveVerifier::TranslatorRecursiveVerifier(
     const std::shared_ptr<NativeVerificationKey>& native_verifier_key,
     const std::shared_ptr<Transcript>& transcript)
     : key(std::make_shared<VerificationKey>(builder, native_verifier_key))
+     , vk_hash(native_verifier_key->hash())
     , transcript(transcript)
     , builder(builder)
-{}
+{
+    key->fix_witness(); // fixed to a constant
+    vk_hash.convert_constant_to_fixed_witness(builder); // fixed to a constant
+}
 
 // Relation params used in sumcheck which is done over FF but the received data is from BF
 void TranslatorRecursiveVerifier::put_translation_data_in_relation_parameters(const BF& evaluation_input_x,

--- a/barretenberg/cpp/src/barretenberg/stdlib/translator_vm_verifier/translator_recursive_verifier.cpp
+++ b/barretenberg/cpp/src/barretenberg/stdlib/translator_vm_verifier/translator_recursive_verifier.cpp
@@ -104,6 +104,7 @@ TranslatorRecursiveVerifier::PairingPoints TranslatorRecursiveVerifier::verify_p
     transcript->load_proof(proof);
 
     // Fiat-Shamir the vk hash
+    // We do not need to hash the vk in-circuit because both the vk and vk hash are hardcoded as constants.
     transcript->add_to_hash_buffer("vk_hash", vk_hash);
     vinfo("Translator vk hash in recursive verifier: ", vk_hash);
 

--- a/barretenberg/cpp/src/barretenberg/stdlib/translator_vm_verifier/translator_recursive_verifier.cpp
+++ b/barretenberg/cpp/src/barretenberg/stdlib/translator_vm_verifier/translator_recursive_verifier.cpp
@@ -21,12 +21,12 @@ TranslatorRecursiveVerifier::TranslatorRecursiveVerifier(
     const std::shared_ptr<NativeVerificationKey>& native_verifier_key,
     const std::shared_ptr<Transcript>& transcript)
     : key(std::make_shared<VerificationKey>(builder, native_verifier_key))
-    , vk_hash(native_verifier_key->hash())
+    , vk_hash(builder, native_verifier_key->hash())
     , transcript(transcript)
     , builder(builder)
 {
-    key->fix_witness();                                 // fixed to a constant
-    vk_hash.convert_constant_to_fixed_witness(builder); // fixed to a constant
+    key->fix_witness();    // fixed to a constant
+    vk_hash.fix_witness(); // fixed to a constant
 }
 
 // Relation params used in sumcheck which is done over FF but the received data is from BF

--- a/barretenberg/cpp/src/barretenberg/stdlib/translator_vm_verifier/translator_recursive_verifier.cpp
+++ b/barretenberg/cpp/src/barretenberg/stdlib/translator_vm_verifier/translator_recursive_verifier.cpp
@@ -104,10 +104,8 @@ TranslatorRecursiveVerifier::PairingPoints TranslatorRecursiveVerifier::verify_p
     transcript->load_proof(proof);
 
     // Fiat-Shamir the vk hash
-    // TODO(https://github.com/AztecProtocol/barretenberg/issues/1472): Hardcode this into the circuit to avoid any
-    // in-circuit hashing.
-    typename Flavor::FF vkey_hash = key->add_hash_to_transcript("", *transcript);
-    vinfo("Translator vk hash in recursive verifier: ", vkey_hash);
+    transcript->add_to_hash_buffer("vk_hash", vk_hash);
+    vinfo("Translator vk hash in recursive verifier: ", vk_hash);
 
     VerifierCommitments commitments{ key };
     CommitmentLabels commitment_labels;

--- a/barretenberg/cpp/src/barretenberg/stdlib/translator_vm_verifier/translator_recursive_verifier.cpp
+++ b/barretenberg/cpp/src/barretenberg/stdlib/translator_vm_verifier/translator_recursive_verifier.cpp
@@ -21,7 +21,7 @@ TranslatorRecursiveVerifier::TranslatorRecursiveVerifier(
     const std::shared_ptr<NativeVerificationKey>& native_verifier_key,
     const std::shared_ptr<Transcript>& transcript)
     : key(std::make_shared<VerificationKey>(builder, native_verifier_key))
-    , vk_hash(builder, native_verifier_key->hash())
+    , vk_hash(stdlib::witness_t<Builder>(builder, native_verifier_key->hash()))
     , transcript(transcript)
     , builder(builder)
 {

--- a/barretenberg/cpp/src/barretenberg/stdlib/translator_vm_verifier/translator_recursive_verifier.hpp
+++ b/barretenberg/cpp/src/barretenberg/stdlib/translator_vm_verifier/translator_recursive_verifier.hpp
@@ -35,6 +35,7 @@ class TranslatorRecursiveVerifier {
     using StdlibProof = stdlib::Proof<Builder>;
 
     std::shared_ptr<VerificationKey> key;
+    FF vk_hash;
     std::shared_ptr<Transcript> transcript;
     VerifierCommitmentKey pcs_verification_key; // can remove maybe hopefully
     std::array<Commitment, TranslatorFlavor::NUM_OP_QUEUE_WIRES> op_queue_commitments;

--- a/barretenberg/cpp/src/barretenberg/translator_vm/translator_flavor.hpp
+++ b/barretenberg/cpp/src/barretenberg/translator_vm/translator_flavor.hpp
@@ -815,8 +815,7 @@ class TranslatorFlavor {
          * @param transcript
          * @returns The hash of the verification key
          */
-        fr add_hash_to_transcript([[maybe_unused]] const std::string& domain_separator,
-                                  [[maybe_unused]] Transcript& transcript) const override
+        fr add_hash_to_transcript(const std::string& domain_separator,  Transcript& transcript) const override
         {
             for (const Commitment& commitment : this->get_all()) {
                 transcript.add_to_independent_hash_buffer(domain_separator + "vk_commitment", commitment);

--- a/barretenberg/cpp/src/barretenberg/translator_vm/translator_flavor.hpp
+++ b/barretenberg/cpp/src/barretenberg/translator_vm/translator_flavor.hpp
@@ -815,7 +815,7 @@ class TranslatorFlavor {
          * @param transcript
          * @returns The hash of the verification key
          */
-        fr add_hash_to_transcript(const std::string& domain_separator,  Transcript& transcript) const override
+        fr add_hash_to_transcript(const std::string& domain_separator, Transcript& transcript) const override
         {
             for (const Commitment& commitment : this->get_all()) {
                 transcript.add_to_independent_hash_buffer(domain_separator + "vk_commitment", commitment);

--- a/barretenberg/cpp/src/barretenberg/translator_vm/translator_flavor.hpp
+++ b/barretenberg/cpp/src/barretenberg/translator_vm/translator_flavor.hpp
@@ -807,20 +807,15 @@ class TranslatorFlavor {
         }
 
         /**
-         * @brief Adds the verification key hash to the transcript and returns the hash.
-         * @details Needed to make sure the Origin Tag system works. See the base class function for
-         * more details.
+         * @brief Unused function because vk is hardcoded in recursive verifier, so no transcript hashing is needed.
          *
          * @param domain_separator
          * @param transcript
-         * @returns The hash of the verification key
          */
-        fr add_hash_to_transcript(const std::string& domain_separator, Transcript& transcript) const override
+        fr add_hash_to_transcript([[maybe_unused]] const std::string& domain_separator,
+                                  [[maybe_unused]] Transcript& transcript) const override
         {
-            for (const Commitment& commitment : this->get_all()) {
-                transcript.add_to_independent_hash_buffer(domain_separator + "vk_commitment", commitment);
-            }
-            return transcript.hash_independent_buffer(domain_separator + "vk_hash");
+            throw_or_abort("Not intended to be used because vk is hardcoded in circuit.");
         }
 
         // Don't statically check for object completeness.

--- a/barretenberg/cpp/src/barretenberg/translator_vm/translator_prover.cpp
+++ b/barretenberg/cpp/src/barretenberg/translator_vm/translator_prover.cpp
@@ -33,8 +33,9 @@ void TranslatorProver::execute_preamble_round()
 {
     // Fiat-Shamir the vk hash
     Flavor::VerificationKey vk;
-    typename Flavor::FF vkey_hash = vk.add_hash_to_transcript("", *transcript);
-    vinfo("Translator vk hash in prover: ", vkey_hash);
+    typename Flavor::FF vk_hash = vk.hash();
+    transcript->add_to_hash_buffer("vk_hash", vk_hash);
+    vinfo("Translator vk hash in prover: ", vk_hash);
 
     const auto SHIFT = uint256_t(1) << Flavor::NUM_LIMB_BITS;
     const auto SHIFTx2 = uint256_t(1) << (Flavor::NUM_LIMB_BITS * 2);

--- a/barretenberg/cpp/src/barretenberg/translator_vm/translator_verifier.cpp
+++ b/barretenberg/cpp/src/barretenberg/translator_vm/translator_verifier.cpp
@@ -74,8 +74,9 @@ bool TranslatorVerifier::verify_proof(const HonkProof& proof,
     transcript->load_proof(proof);
 
     // Fiat-Shamir the vk hash
-    typename Flavor::FF vkey_hash = key->add_hash_to_transcript("", *transcript);
-    vinfo("Translator vk hash in verifier: ", vkey_hash);
+    typename Flavor::FF vk_hash = key->hash();
+    transcript->add_to_hash_buffer("vk_hash", vk_hash);
+    vinfo("Translator vk hash in verifier: ", vk_hash);
 
     Flavor::VerifierCommitments commitments{ key };
     Flavor::CommitmentLabels commitment_labels;


### PR DESCRIPTION
Closes https://github.com/AztecProtocol/barretenberg/issues/1472.

Hardcode the vks and vk hashes in recursive verifiers. We no longer need to do the hash consistency check between them since they're constant witnesses.