### PR TITLE
fix: use cached VK for public base rollup

### DIFF
--- a/ci.sh
+++ b/ci.sh
@@ -111,40 +111,40 @@ case "$cmd" in
     prep_vars
     # Spin up ec2 instance and run the merge-queue flow.
     run() {
-      JOB_ID=$1 INSTANCE_POSTFIX=$1 ARCH=$2 exec denoise "bootstrap_ec2 './bootstrap.sh $3'"
+      JOB_ID=$1 INSTANCE_POSTFIX=$1 ARCH=$2 USE_CIRCUITS_CACHE=$3 exec denoise "bootstrap_ec2 './bootstrap.sh $4'"
     }
     export -f run
     # We perform two full runs of all tests on x86, and a single fast run on arm64 (allowing use of test cache).
     parallel --jobs 10 --termseq 'TERM,10000' --tagstring '{= $_=~s/run (\w+).*/$1/; =}' --line-buffered --halt now,fail=1 ::: \
-      'run x1-full amd64 ci-full' \
-      'run x2-full amd64 ci-full' \
-      'run x3-full amd64 ci-full' \
-      'run x4-full amd64 ci-full' \
-      'run a1-fast arm64 ci-fast' | DUP=1 cache_log "Merge queue CI run" $RUN_ID
+      'run x1-full amd64 0 ci-full' \
+      'run x2-full amd64 0 ci-full' \
+      'run x3-full amd64 0 ci-full' \
+      'run x4-full amd64 0 ci-full' \
+      'run a1-fast arm64 1 ci-fast' | DUP=1 cache_log "Merge queue CI run" $RUN_ID
     ;;
   "nightly")
     prep_vars
     # Spin up ec2 instance and run the nightly flow.
     run() {
-      JOB_ID=$1 INSTANCE_POSTFIX=$1 ARCH=$2 exec denoise "bootstrap_ec2 './bootstrap.sh ci-nightly'"
+      JOB_ID=$1 INSTANCE_POSTFIX=$1 ARCH=$2 USE_CIRCUITS_CACHE=${3:-0} exec denoise "bootstrap_ec2 './bootstrap.sh ci-nightly'"
     }
     export -f run
     # We need to run the release flow on both x86 and arm64.
     parallel --termseq 'TERM,10000' --tagstring '{= $_=~s/run (\w+).*/$1/; =}' --line-buffered --halt now,fail=1 ::: \
       'run x-nightly amd64' \
-      'run a-nightly arm64' | DUP=1 cache_log "Nightly CI run" $RUN_ID
+      'run a-nightly arm64 1' | DUP=1 cache_log "Nightly CI run" $RUN_ID
     ;;
   "release")
     prep_vars
     # Spin up ec2 instance and run the release flow.
     run() {
-      JOB_ID=$1 INSTANCE_POSTFIX=$1 ARCH=$2 exec denoise "bootstrap_ec2 './bootstrap.sh ci-release'"
+      JOB_ID=$1 INSTANCE_POSTFIX=$1 ARCH=$2 USE_CIRCUITS_CACHE=${3:-0} exec denoise "bootstrap_ec2 './bootstrap.sh ci-release'"
     }
     export -f run
     # We need to run the release flow on both x86 and arm64.
     parallel --termseq 'TERM,10000' --tagstring '{= $_=~s/run (\w+).*/$1/; =}' --line-buffered --halt now,fail=1 ::: \
       'run x-release amd64' \
-      'run a-release arm64' | DUP=1 cache_log "Release CI run" $RUN_ID
+      'run a-release arm64 1' | DUP=1 cache_log "Release CI run" $RUN_ID
     ;;
   "shell-new")
     # Spin up ec2 instance, clone, and drop into shell.

--- a/noir-projects/noir-protocol-circuits/bootstrap.sh
+++ b/noir-projects/noir-protocol-circuits/bootstrap.sh
@@ -10,6 +10,7 @@ export PLATFORM_TAG=any
 export BB=${BB:-../../barretenberg/cpp/build/bin/bb}
 export NARGO=${NARGO:-../../noir/noir-repo/target/release/nargo}
 export BB_HASH=$(cache_content_hash ../../barretenberg/cpp/.rebuild_patterns)
+export BB_HASH_FOR_PUBLIC_BASE_ROLLUP=$(PLATFORM_TAG="x86_64" cache_content_hash ../../barretenberg/cpp/.rebuild_patterns)
 export NOIR_HASH=${NOIR_HASH:-$(../../noir/bootstrap.sh hash)}
 
 export key_dir=./target/keys
@@ -94,10 +95,23 @@ function compile {
   # TODO: Change this to add verification_key to original json, like contracts does.
   # Will require changing TS code downstream.
   bytecode_hash=$(jq -r '.bytecode' $json_path | sha256sum | tr -d ' -')
+  if echo "$name" | grep -qE "rollup_base_public"; then
+    hash=$(hash_str "$BB_HASH_FOR_PUBLIC_BASE_ROLLUP-$bytecode_hash-$proto")
+  else
+    hash=$(hash_str "$BB_HASH-$bytecode_hash-$proto")
+  fi
+
   hash=$(hash_str "$BB_HASH-$bytecode_hash-$proto")
   if [ "${USE_CIRCUITS_CACHE:-0}" -eq 0 ] || ! cache_download vk-$hash.tar.gz 1>&2; then
     local key_path="$key_dir/$name.vk.data.json"
     echo_stderr "Generating vk for function: $name..."
+
+    # on ARM builds the AVM is disabled which leads to a different VK. Avoid this issue by reading the VK from the cache for x86
+    if echo "$name" | grep -qE "rollup_base_public" && [ $(uname -m) != "x86_64" ]; then
+      echo_stderr "Refusing to generate VK for $name on $(uname -m)"
+      exit 1
+    fi
+
     SECONDS=0
     outdir=$(mktemp -d)
     trap "rm -rf $outdir" EXIT


### PR DESCRIPTION
This PR attempts to fix the public base rollup's VK being different on ARM vs x86. The ARM build disables the AVM (due to build times being too long) which leads to a different VK entirely.

This PR forces ARM builds to read that specific VK from x86's cache. 

**NOTE**: this means there's going to be an inherent dependency between x86 and ARM. x86 beeds to have built bb, generated the VK and uploaded it to the cache before ARM can run correctly.
