### PR TITLE
docs: updated code docs

### DIFF
--- a/noir-projects/noir-protocol-circuits/crates/types/src/traits.nr
+++ b/noir-projects/noir-protocol-circuits/crates/types/src/traits.nr
@@ -139,28 +139,28 @@ where
 
 // pub fn is_empty<T>(item: T) -> bool
 // where
-//     T: Empty + Eq,
+//     T: Empty,
 // {
 //     item.eq(T::empty())
 // }
 
 // pub fn is_empty_array<T, let N: u32>(array: [T; N]) -> bool
 // where
-//     T: Empty + Eq,
+//     T: Empty,
 // {
 //     array.all(|elem| is_empty(elem))
 // }
 
 // pub fn assert_empty<T>(item: T) -> ()
 // where
-//     T: Empty + Eq,
+//     T: Empty,
 // {
 //     assert(item.eq(T::empty()))
 // }
 
 // pub fn assert_empty_array<T, let N: u32>(array: [T; N]) -> ()
 // where
-//     T: Empty + Eq,
+//     T: Empty,
 // {
 //     // A cheaper option than `is_empty_array` for if you don't need to gracefully
 //     // handle a bool result.


### PR DESCRIPTION
With `Empty` being a supertrait of `Eq`, `Empty + Eq` becomes meaningless - this was emitting warnings.

@LeilaWang what do you think about setting up a CI job that checks the protocol circuit crates emit no warnings? That's what we use in aztec-nr and it's been working wonderfully. tldr you need to run `nargo check --deny-warnings`.