### PR TITLE
feat!: small improvements for direct peers

### DIFF
--- a/yarn-project/p2p/src/client/p2p_client.integration.test.ts
+++ b/yarn-project/p2p/src/client/p2p_client.integration.test.ts
@@ -63,6 +63,7 @@ describe('p2p client integration', () => {
 
     //@ts-expect-error - we want to mock the getEpochAndSlotInNextL1Slot method, mocking ts is enough
     epochCache.getEpochAndSlotInNextL1Slot.mockReturnValue({ ts: BigInt(0) });
+    epochCache.getRegisteredValidators.mockResolvedValue([]);
 
     txPool.hasTxs.mockResolvedValue([]);
     txPool.getAllTxs.mockImplementation(() => {
@@ -722,11 +723,16 @@ describe('p2p client integration', () => {
     const realSend = c1PeerManager.reqresp.sendRequestToPeer;
 
     // @ts-expect-error arguments not expected
-    jest.spyOn(c1PeerManager.reqresp, 'sendRequestToPeer').mockImplementation(function (peerId: PeerId, ...rest) {
-      if (peerId.toString() === badPeerId.toString()) {
-        return { status: ReqRespStatus.SUCCESS, data: Buffer.from('invalid status') };
+    jest.spyOn(c1PeerManager.reqresp, 'sendRequestToPeer').mockImplementation(async function (
+      peerId: PeerId,
+      protocol: ReqRespSubProtocol,
+      ...rest
+    ) {
+      if (peerId.toString() === badPeerId.toString() && protocol === ReqRespSubProtocol.STATUS) {
+        return Promise.resolve({ status: ReqRespStatus.SUCCESS, data: Buffer.from('invalid status') });
       }
-      return realSend.apply(c1PeerManager.reqresp, [peerId, ...rest]); // no bound closure
+
+      return await realSend.apply(c1PeerManager.reqresp, [peerId, protocol, ...rest]);
     });
 
     await startTestP2PClients(clients);

--- a/yarn-project/p2p/src/services/dummy_service.ts
+++ b/yarn-project/p2p/src/services/dummy_service.ts
@@ -195,6 +195,11 @@ export class DummyPeerManager implements PeerManagerInterface {
   public getPeerScore(_peerId: string): number {
     return 0;
   }
+
+  public shouldDisableP2PGossip(_peerId: string): boolean {
+    return false;
+  }
+
   public stop(): Promise<void> {
     return Promise.resolve();
   }

--- a/yarn-project/p2p/src/services/libp2p/libp2p_service.ts
+++ b/yarn-project/p2p/src/services/libp2p/libp2p_service.ts
@@ -361,7 +361,8 @@ export class LibP2PService<T extends P2PClientType = P2PClientType.Full> extends
 
     // Update gossipsub score params
     node.services.pubsub.score.params.appSpecificWeight = 10;
-    node.services.pubsub.score.params.appSpecificScore = (peerId: string) => peerManager.getPeerScore(peerId);
+    node.services.pubsub.score.params.appSpecificScore = (peerId: string) =>
+      peerManager.shouldDisableP2PGossip(peerId) ? -Infinity : peerManager.getPeerScore(peerId);
 
     return new LibP2PService(
       clientType,

--- a/yarn-project/p2p/src/services/peer-manager/interface.ts
+++ b/yarn-project/p2p/src/services/peer-manager/interface.ts
@@ -19,5 +19,7 @@ export interface PeerManagerInterface {
   handleAuthRequestFromPeer(authRequest: AuthRequest, peerId: PeerId): Promise<StatusMessage>;
 
   getPeerScore(peerId: string): number;
+  shouldDisableP2PGossip(peerId: string): boolean;
+
   stop(): Promise<void>;
 }

--- a/yarn-project/p2p/src/services/peer-manager/peer_manager.test.ts
+++ b/yarn-project/p2p/src/services/peer-manager/peer_manager.test.ts
@@ -1248,8 +1248,8 @@ describe('PeerManager', () => {
       );
       expect(newPeerManager.isAuthenticatedPeer(peerId)).toBe(false);
 
-      // An unauthenticated peer should have a -Infinity peer score
-      expect(newPeerManager.getPeerScore(peerId.toString())).toBe(-Infinity);
+      //For an unauthenticated peer, the peer we should disable gossiping
+      expect(newPeerManager.shouldDisableP2PGossip(peerId.toString())).toBeTruthy();
     });
 
     it('should authenticate peer if auth handshake succeeds', async () => {
@@ -1389,8 +1389,8 @@ describe('PeerManager', () => {
       expect(receivedAuth?.status.latestBlockHash).toEqual(blockHash);
       expect(newPeerManager.isAuthenticatedPeer(peerId)).toBe(false);
 
-      // An unauthenticated peer should have a -Infinity peer score
-      expect(newPeerManager.getPeerScore(peerId.toString())).toBe(-Infinity);
+      //For an unauthenticated peer, the peer we should disable gossiping
+      expect(newPeerManager.shouldDisableP2PGossip(peerId.toString())).toBeTruthy();
     });
 
     it('should remove authentication if peer is no longer a registered validator', async () => {
@@ -1468,8 +1468,8 @@ describe('PeerManager', () => {
 
       expect(newPeerManager.isAuthenticatedPeer(peerId)).toBe(false);
 
-      // An unauthenticated peer should have a -Infinity peer score
-      expect(newPeerManager.getPeerScore(peerId.toString())).toBe(-Infinity);
+      //For an unauthenticated peer, the peer we should disable gossiping
+      expect(newPeerManager.shouldDisableP2PGossip(peerId.toString())).toBeTruthy();
     });
 
     it('should remove authentication if peer is disconnected', async () => {

--- a/yarn-project/p2p/src/services/peer-manager/peer_manager.ts
+++ b/yarn-project/p2p/src/services/peer-manager/peer_manager.ts
@@ -103,7 +103,6 @@ export class PeerManager implements PeerManagerInterface {
     // Display peer counts every 60 seconds
     this.displayPeerCountsPeerHeartbeat = Math.floor(60_000 / this.config.peerCheckIntervalMS);
   }
-
   /**
    * Initializes the trusted peers.
    *
@@ -323,11 +322,12 @@ export class PeerManager implements PeerManagerInterface {
   }
 
   public getPeerScore(peerId: string): number {
-    const isAuthenticated = this.isAuthenticatedPeer(peerIdFromString(peerId));
-    if (this.config.p2pAllowOnlyValidators && !isAuthenticated) {
-      return -Infinity;
-    }
     return this.peerScoring.getScore(peerId);
+  }
+
+  public shouldDisableP2PGossip(peerId: string): boolean {
+    const isAuthenticated = this.isAuthenticatedPeer(peerIdFromString(peerId));
+    return (this.config.p2pAllowOnlyValidators ?? false) && !isAuthenticated;
   }
 
   public getPeers(includePending = false): PeerInfo[] {

--- a/yarn-project/p2p/src/test-helpers/reqresp-nodes.ts
+++ b/yarn-project/p2p/src/test-helpers/reqresp-nodes.ts
@@ -155,7 +155,8 @@ export async function createTestLibP2PService<T extends P2PClientType>(
   );
 
   p2pNode.services.pubsub.score.params.appSpecificWeight = 10;
-  p2pNode.services.pubsub.score.params.appSpecificScore = (peerId: string) => peerManager.getPeerScore(peerId);
+  p2pNode.services.pubsub.score.params.appSpecificScore = (peerId: string) =>
+    peerManager.shouldDisableP2PGossip(peerId) ? -Infinity : peerManager.getPeerScore(peerId);
 
   return new LibP2PService<T>(
     clientType,


### PR DESCRIPTION
This PR is a copy of the: https://github.com/AztecProtocol/aztec-packages/pull/15655

----
This PR brings a slight improvement in code ergonomics around handling peer scores.

Previously, we were returning —Infinity by peerManager.getPeerScore to block all gossiping until the node was authenticated. While this is a great solution to that problem, I found that this new change makes the code a bit more error-prone.
We should only use peerManager.getPeerScore to set the score in gossipSub, but the peer manager uses a similarly named method called `peerScoring.getScore. They are pretty similarly named and even have the same signature.

Calling one instead of the other could have bad consequences.

Finally, I noticed that 1/2 of the tests in p2p_client.integration are failing. Now all the tests are green on my machine.