### PR TITLE
test: add public context txe + state var tests

### DIFF
--- a/noir-projects/aztec-nr/aztec/src/state_vars/public_immutable.nr
+++ b/noir-projects/aztec-nr/aztec/src/state_vars/public_immutable.nr
@@ -8,6 +8,8 @@ use protocol_types::{
     traits::Packable,
 };
 
+mod test;
+
 /// Stores an immutable value in public state which can be read from public, private and unconstrained execution
 /// contexts.
 ///
@@ -126,6 +128,7 @@ impl<T> PublicImmutable<T, UtilityContext> {
     where
         T: Packable<T_PACKED_LEN> + Eq,
     {
+        // TODO(#15703): this fn should fail if the variable is not initialized
         WithHash::utility_public_storage_read(self.context, self.storage_slot)
     }
 }
@@ -135,6 +138,7 @@ impl<T> PublicImmutable<T, &mut PrivateContext> {
     where
         T: Packable<T_PACKED_LEN> + Eq,
     {
+        // TODO(#15703): this fn should fail if the variable is not initialized
         WithHash::historical_public_storage_read(
             self.context.get_block_header(),
             self.context.this_address(),

--- a/noir-projects/aztec-nr/aztec/src/state_vars/public_immutable/test.nr
+++ b/noir-projects/aztec-nr/aztec/src/state_vars/public_immutable/test.nr
@@ -1,53 +1,186 @@
-use crate::{context::PublicContext, state_vars::public_immutable::PublicImmutable};
+use crate::{
+    context::{PrivateContext, PublicContext, UtilityContext},
+    state_vars::public_immutable::PublicImmutable,
+};
 use crate::test::{helpers::test_environment::TestEnvironment, mocks::mock_struct::MockStruct};
-use dep::protocol_types::traits::Serialize;
+use std::mem::zeroed;
 
-global storage_slot = 7;
+global storage_slot: Field = 7;
 
-fn setup() -> TestEnvironment {
-    TestEnvironment::new()
+fn in_public(context: &mut PublicContext) -> PublicImmutable<MockStruct, &mut PublicContext> {
+    PublicImmutable::new(context, storage_slot)
 }
 
-fn in_public(env: TestEnvironment) -> PublicImmutable<MockStruct, &mut PublicContext> {
-    PublicImmutable::new(&mut env.public(), storage_slot)
+fn in_private(context: &mut PrivateContext) -> PublicImmutable<MockStruct, &mut PrivateContext> {
+    PublicImmutable::new(context, storage_slot)
 }
 
-#[test]
-fn test_uninitialized_by_default() {
-    let env = setup();
-    let state_var = in_public(env);
-
-    assert_eq(state_var.is_initialized(), false);
+fn in_utility(context: UtilityContext) -> PublicImmutable<MockStruct, UtilityContext> {
+    PublicImmutable::new(context, storage_slot)
 }
 
 #[test]
-fn test_initialize_uninitialized() {
-    let env = setup();
-    let state_var = in_public(env);
+unconstrained fn is_uninitialized_by_default() {
+    let mut env = TestEnvironment::_new();
 
-    let value = MockStruct::new(5, 6);
-
-    state_var.initialize(value);
-
-    assert(state_var.is_initialized());
-    assert(state_var.read() == value);
+    env.public_context(|context| {
+        let state_var = in_public(context);
+        assert_eq(state_var.is_initialized(), false);
+    });
 }
 
-#[test(should_fail_with = "PublicImmutable already initialized")]
-fn test_initialize_already_initialized() {
-    let env = setup();
-    let state_var = in_public(env);
+#[test]
+unconstrained fn initialize_uninitialized_same_tx() {
+    let mut env = TestEnvironment::_new();
 
-    let value = MockStruct::new(5, 6);
+    env.public_context(|context| {
+        let state_var = in_public(context);
 
-    state_var.initialize(value);
-    state_var.initialize(value);
+        let value = MockStruct::new(5, 6);
+        state_var.initialize(value);
+
+        assert(state_var.is_initialized());
+    });
 }
 
-#[test(should_fail_with = "PublicImmutable not initialized")]
-fn test_read_uninitialized() {
-    let env = setup();
-    let state_var = in_public(env);
+#[test]
+unconstrained fn initialize_uninitialized_other_tx() {
+    let mut env = TestEnvironment::_new();
 
-    let _ = state_var.read();
+    env.public_context(|context| {
+        let state_var = in_public(context);
+
+        let value = MockStruct::new(5, 6);
+        state_var.initialize(value);
+    });
+
+    env.public_context(|context| {
+        let state_var = in_public(context);
+        assert(state_var.is_initialized());
+    });
+}
+
+#[test(should_fail)]
+unconstrained fn initialize_already_initialized_same_tx() {
+    let mut env = TestEnvironment::_new();
+
+    env.public_context(|context| {
+        let state_var = in_public(context);
+
+        let value = MockStruct::new(5, 6);
+        state_var.initialize(value);
+
+        let other_value = MockStruct::new(7, 8);
+        state_var.initialize(other_value);
+    });
+}
+
+#[test(should_fail)]
+unconstrained fn initialize_already_initialized_other_tx() {
+    let mut env = TestEnvironment::_new();
+
+    env.public_context(|context| {
+        let state_var = in_public(context);
+        let value = MockStruct::new(5, 6);
+        state_var.initialize(value);
+    });
+
+    env.public_context(|context| {
+        let state_var = in_public(context);
+        let other_value = MockStruct::new(7, 8);
+        state_var.initialize(other_value);
+    });
+}
+
+#[test(should_fail_with = "Trying to read from uninitialized PublicImmutable")]
+unconstrained fn read_uninitialized_public_fails() {
+    let mut env = TestEnvironment::_new();
+
+    env.public_context(|context| {
+        let state_var = in_public(context);
+        let _ = state_var.read();
+    });
+}
+
+// TODO(#15703): this test should be made to fail
+#[test]
+unconstrained fn read_uninitialized_private_returns_default() {
+    let mut env = TestEnvironment::_new();
+
+    env.private_context(|context| {
+        let state_var = in_private(context);
+        assert_eq(state_var.read(), zeroed());
+    });
+}
+
+// TODO(#15703): this test should be made to fail
+#[test]
+unconstrained fn read_uninitialized_utility_returns_default() {
+    let mut env = TestEnvironment::_new();
+
+    env.utility_context(|context| {
+        let state_var = in_utility(context);
+        assert_eq(state_var.read(), zeroed());
+    });
+}
+
+#[test]
+unconstrained fn read_uninitialized_public_same_tx() {
+    let mut env = TestEnvironment::_new();
+
+    env.public_context(|context| {
+        let state_var = in_public(context);
+        let value = MockStruct::new(5, 6);
+        state_var.initialize(value);
+
+        assert_eq(state_var.read(), value);
+    });
+}
+
+#[test]
+unconstrained fn read_uninitialized_public_other_tx() {
+    let mut env = TestEnvironment::_new();
+    let value = MockStruct::new(5, 6);
+
+    env.public_context(|context| {
+        let state_var = in_public(context);
+        state_var.initialize(value);
+    });
+
+    env.public_context(|context| {
+        let state_var = in_public(context);
+        assert_eq(state_var.read(), value);
+    });
+}
+
+#[test]
+unconstrained fn read_uninitialized_private() {
+    let mut env = TestEnvironment::_new();
+    let value = MockStruct::new(5, 6);
+
+    env.public_context(|context| {
+        let state_var = in_public(context);
+        state_var.initialize(value);
+    });
+
+    env.private_context(|context| {
+        let state_var = in_private(context);
+        assert_eq(state_var.read(), value);
+    });
+}
+
+#[test]
+unconstrained fn read_uninitialized_utility() {
+    let mut env = TestEnvironment::_new();
+    let value = MockStruct::new(5, 6);
+
+    env.public_context(|context| {
+        let state_var = in_public(context);
+        state_var.initialize(value);
+    });
+
+    env.utility_context(|context| {
+        let state_var = in_utility(context);
+        assert_eq(state_var.read(), value);
+    });
 }

--- a/noir-projects/aztec-nr/aztec/src/state_vars/public_mutable.nr
+++ b/noir-projects/aztec-nr/aztec/src/state_vars/public_mutable.nr
@@ -2,6 +2,8 @@ use crate::context::{PublicContext, UtilityContext};
 use crate::state_vars::storage::HasStorageSlot;
 use dep::protocol_types::traits::Packable;
 
+mod test;
+
 // docs:start:public_mutable_struct
 pub struct PublicMutable<T, Context> {
     context: Context,

--- a/noir-projects/aztec-nr/aztec/src/state_vars/public_mutable/test.nr
+++ b/noir-projects/aztec-nr/aztec/src/state_vars/public_mutable/test.nr
@@ -1,0 +1,79 @@
+use crate::{context::{PublicContext, UtilityContext}, state_vars::public_mutable::PublicMutable};
+use crate::test::{helpers::test_environment::TestEnvironment, mocks::mock_struct::MockStruct};
+use std::mem::zeroed;
+
+global storage_slot: Field = 7;
+
+fn in_public(context: &mut PublicContext) -> PublicMutable<MockStruct, &mut PublicContext> {
+    PublicMutable::new(context, storage_slot)
+}
+
+fn in_utility(context: UtilityContext) -> PublicMutable<MockStruct, UtilityContext> {
+    PublicMutable::new(context, storage_slot)
+}
+
+#[test]
+unconstrained fn read_uninitialized_public_returns_zero() {
+    let mut env = TestEnvironment::_new();
+
+    env.public_context(|context| {
+        let state_var = in_public(context);
+        assert_eq(state_var.read(), zeroed());
+    });
+}
+
+#[test]
+unconstrained fn read_uninitialized_utility_returns_default() {
+    let mut env = TestEnvironment::_new();
+
+    env.utility_context(|context| {
+        let state_var = in_utility(context);
+        assert_eq(state_var.read(), zeroed());
+    });
+}
+
+#[test]
+unconstrained fn write_read_public_same_tx() {
+    let mut env = TestEnvironment::_new();
+
+    env.public_context(|context| {
+        let state_var = in_public(context);
+        let value = MockStruct::new(5, 6);
+
+        state_var.write(value);
+        assert_eq(state_var.read(), value);
+    });
+}
+
+#[test]
+unconstrained fn write_read_public_other_tx() {
+    let mut env = TestEnvironment::_new();
+
+    let value = MockStruct::new(5, 6);
+
+    env.public_context(|context| {
+        let state_var = in_public(context);
+        state_var.write(value);
+    });
+
+    env.public_context(|context| {
+        let state_var = in_public(context);
+        assert_eq(state_var.read(), value);
+    });
+}
+
+#[test]
+unconstrained fn write_read_utility() {
+    let mut env = TestEnvironment::_new();
+    let value = MockStruct::new(5, 6);
+
+    env.public_context(|context| {
+        let state_var = in_public(context);
+        state_var.write(value);
+    });
+
+    env.utility_context(|context| {
+        let state_var = in_utility(context);
+        assert_eq(state_var.read(), value);
+    });
+}

--- a/noir-projects/aztec-nr/aztec/src/test/helpers/test_environment.nr
+++ b/noir-projects/aztec-nr/aztec/src/test/helpers/test_environment.nr
@@ -122,7 +122,9 @@ impl TestEnvironment {
         let ret_value = f(&mut context);
         cheatcodes::set_top_level_txe_context();
 
-        // todo: should commit the context to mine a block with the side effects of the context
+        // todo: should commit the context to mine a block with the side effects of the context. we should have an
+        // oracle that receives the context we produced probably
+        self.mine_block();
 
         ret_value
     }

--- a/noir-projects/aztec-nr/aztec/src/test/helpers/test_environment/test.nr
+++ b/noir-projects/aztec-nr/aztec/src/test/helpers/test_environment/test.nr
@@ -1,9 +1,6 @@
-use crate::test::{helpers::test_environment::TestEnvironment, mocks::mock_struct::MockStruct};
+use crate::test::helpers::test_environment::TestEnvironment;
 
-use dep::std::mem::zeroed;
-
-global storage_slot: Field = 13;
-global value: MockStruct = MockStruct { a: 17, b: 42 };
+mod public_context;
 
 #[test(should_fail_with = "cannot be before next timestamp")]
 unconstrained fn set_next_block_timestamp_to_past_fails() {
@@ -96,34 +93,6 @@ unconstrained fn public_context_advances_timestamp() {
     let second_timestamp = env.public_context(|context| context.timestamp());
 
     assert(second_timestamp > first_timestamp);
-}
-
-#[test]
-unconstrained fn public_context_default_storage_value() {
-    let mut env = TestEnvironment::_new();
-
-    env.public_context(|context| {
-        assert_eq(context.storage_read::<MockStruct, _>(storage_slot), zeroed());
-    });
-}
-
-#[test]
-unconstrained fn public_context_storage_write_in_same_context() {
-    let mut env = TestEnvironment::_new();
-
-    env.public_context(|context| {
-        context.storage_write(storage_slot, value);
-        assert_eq(context.storage_read(storage_slot), value);
-    });
-}
-
-#[test]
-unconstrained fn public_context_storage_write_in_future_context() {
-    let mut env = TestEnvironment::_new();
-
-    env.public_context(|context| { context.storage_write(storage_slot, value); });
-
-    env.public_context(|context| { assert_eq(context.storage_read(storage_slot), value); });
 }
 
 #[test]

--- a/noir-projects/aztec-nr/aztec/src/test/helpers/test_environment/test/public_context.nr
+++ b/noir-projects/aztec-nr/aztec/src/test/helpers/test_environment/test/public_context.nr
@@ -1,0 +1,103 @@
+use crate::test::{helpers::test_environment::TestEnvironment, mocks::mock_struct::MockStruct};
+
+use dep::std::mem::zeroed;
+
+global storage_slot: Field = 13;
+
+global value: MockStruct = MockStruct { a: 17, b: 42 };
+global other_value: MockStruct = MockStruct { a: 7, b: 8 };
+
+global nullifier: Field = 9;
+
+#[test]
+unconstrained fn default_storage_value() {
+    let mut env = TestEnvironment::_new();
+
+    env.public_context(|context| {
+        assert_eq(context.storage_read::<MockStruct, _>(storage_slot), zeroed());
+    });
+}
+
+#[test]
+unconstrained fn storage_write_in_same_context() {
+    let mut env = TestEnvironment::_new();
+
+    env.public_context(|context| {
+        context.storage_write(storage_slot, value);
+        assert_eq(context.storage_read(storage_slot), value);
+    });
+}
+
+#[test]
+unconstrained fn storage_write_in_future_context() {
+    let mut env = TestEnvironment::_new();
+
+    env.public_context(|context| { context.storage_write(storage_slot, value); });
+
+    env.public_context(|context| { assert_eq(context.storage_read(storage_slot), value); });
+}
+
+#[test]
+unconstrained fn storage_multiple_writes_in_same_context() {
+    let mut env = TestEnvironment::_new();
+
+    env.public_context(|context| {
+        context.storage_write(storage_slot, value);
+        context.storage_write(storage_slot, other_value);
+
+        assert_eq(context.storage_read(storage_slot), other_value);
+    });
+}
+
+#[test]
+unconstrained fn storage_multiple_writes_in_future_context() {
+    let mut env = TestEnvironment::_new();
+
+    env.public_context(|context| { context.storage_write(storage_slot, value); });
+
+    env.public_context(|context| {
+        context.storage_write(storage_slot, other_value);
+        assert_eq(context.storage_read(storage_slot), other_value);
+    });
+}
+
+#[test]
+unconstrained fn read_nonexistent_nullifier() {
+    let mut env = TestEnvironment::_new();
+
+    env.public_context(|context| {
+        assert(!context.nullifier_exists(nullifier, context.this_address()));
+    });
+}
+
+#[test]
+unconstrained fn read_public_nullifier_same_context() {
+    let mut env = TestEnvironment::_new();
+
+    env.public_context(|context| {
+        context.push_nullifier(nullifier);
+        assert(context.nullifier_exists(nullifier, context.this_address()));
+    });
+}
+
+#[test]
+unconstrained fn read_public_nullifier_other_context() {
+    let mut env = TestEnvironment::_new();
+
+    env.public_context(|context| { context.push_nullifier(nullifier); });
+
+    env.public_context(|context| {
+        assert(context.nullifier_exists(nullifier, context.this_address()));
+    });
+}
+
+#[test]
+unconstrained fn read_private_nullifier() {
+    let mut env = TestEnvironment::_new();
+
+    env.private_context(|context| { context.push_nullifier(nullifier); });
+
+    env.public_context(|context| {
+        assert(context.nullifier_exists(nullifier, context.this_address()));
+    });
+}

--- a/yarn-project/txe/src/oracle/txe_oracle.ts
+++ b/yarn-project/txe/src/oracle/txe_oracle.ts
@@ -1239,8 +1239,11 @@ export class TXE implements TypedOracle {
   async avmOpcodeNullifierExists(innerNullifier: Fr, targetAddress: AztecAddress): Promise<boolean> {
     const nullifier = await siloNullifier(targetAddress, innerNullifier!);
     const db = this.baseFork;
-    const index = (await db.findLeafIndices(MerkleTreeId.NULLIFIER_TREE, [nullifier.toBuffer()]))[0];
-    return index !== undefined;
+
+    const treeIndex = (await db.findLeafIndices(MerkleTreeId.NULLIFIER_TREE, [nullifier.toBuffer()]))[0];
+    const transientIndex = this.siloedNullifiersFromPublic.find(n => n.equals(nullifier));
+
+    return treeIndex !== undefined || transientIndex !== undefined;
   }
 
   async avmOpcodeEmitNullifier(nullifier: Fr) {


### PR DESCRIPTION
This does a couple things, all closely related:
 - it enables the `PublicImmutable` tests, which were included in #6985 but never run, with some rewriting using the new features
 - it adds `PublicMutable` tests
 - it adds `env.public_context` tests
 - it makes `public_context` smarter by being able to combine the committed and transient state for nullifiers in a pub context, allowing us to read transient nullifiers. This is avm behavior that we need to replicate in txe, but I don't think there'll be too much more of it.
