### PR TITLE
chore: remove some unneeded test_ prefixes

### DIFF
--- a/noir-projects/aztec-nr/aztec/src/state_vars/shared_mutable/test.nr
+++ b/noir-projects/aztec-nr/aztec/src/state_vars/shared_mutable/test.nr
@@ -34,7 +34,7 @@ unconstrained fn in_utility(
 }
 
 #[test]
-unconstrained fn test_get_current_value_in_public_initial() {
+unconstrained fn get_current_value_in_public_initial() {
     let env = TestEnvironment::_new();
 
     env.public_context(|context| {
@@ -44,7 +44,7 @@ unconstrained fn test_get_current_value_in_public_initial() {
 }
 
 #[test]
-unconstrained fn test_get_scheduled_value_in_public() {
+unconstrained fn get_scheduled_value_in_public() {
     let mut env = TestEnvironment::_new();
 
     env.public_context(|context| {
@@ -61,7 +61,7 @@ unconstrained fn test_get_scheduled_value_in_public() {
 }
 
 #[test]
-unconstrained fn test_get_current_value_in_public_before_scheduled_change() {
+unconstrained fn get_current_value_in_public_before_scheduled_change() {
     let mut env = TestEnvironment::_new();
 
     let (original_value, timestamp_of_change) = env.public_context(|context| {
@@ -89,7 +89,7 @@ unconstrained fn test_get_current_value_in_public_before_scheduled_change() {
 }
 
 #[test]
-unconstrained fn test_get_current_value_in_public_at_scheduled_change() {
+unconstrained fn get_current_value_in_public_at_scheduled_change() {
     let mut env = TestEnvironment::_new();
 
     let (_, timestamp_of_change) = env.public_context(|context| {
@@ -108,7 +108,7 @@ unconstrained fn test_get_current_value_in_public_at_scheduled_change() {
 }
 
 #[test]
-unconstrained fn test_get_current_value_in_public_after_scheduled_change() {
+unconstrained fn get_current_value_in_public_after_scheduled_change() {
     let mut env = TestEnvironment::_new();
 
     let (_, timestamp_of_change) = env.public_context(|context| {
@@ -128,7 +128,7 @@ unconstrained fn test_get_current_value_in_public_after_scheduled_change() {
 }
 
 #[test]
-unconstrained fn test_get_current_delay_in_public_initial() {
+unconstrained fn get_current_delay_in_public_initial() {
     let env = TestEnvironment::_new();
     env.public_context(|context| {
         let state_var = in_public(context);
@@ -137,7 +137,7 @@ unconstrained fn test_get_current_delay_in_public_initial() {
 }
 
 #[test]
-unconstrained fn test_get_scheduled_delay_in_public() {
+unconstrained fn get_scheduled_delay_in_public() {
     let mut env = TestEnvironment::_new();
 
     env.public_context(|context| {
@@ -153,7 +153,7 @@ unconstrained fn test_get_scheduled_delay_in_public() {
 }
 
 #[test]
-unconstrained fn test_get_current_delay_in_public_before_scheduled_change() {
+unconstrained fn get_current_delay_in_public_before_scheduled_change() {
     let mut env = TestEnvironment::_new();
 
     let (original_delay, timestamp_of_change) = env.public_context(|context| {
@@ -181,7 +181,7 @@ unconstrained fn test_get_current_delay_in_public_before_scheduled_change() {
 }
 
 #[test]
-unconstrained fn test_get_current_delay_in_public_at_scheduled_change() {
+unconstrained fn get_current_delay_in_public_at_scheduled_change() {
     let mut env = TestEnvironment::_new();
 
     let (_, timestamp_of_change) = env.public_context(|context| {
@@ -201,7 +201,7 @@ unconstrained fn test_get_current_delay_in_public_at_scheduled_change() {
 }
 
 #[test]
-unconstrained fn test_get_current_delay_in_public_after_scheduled_change() {
+unconstrained fn get_current_delay_in_public_after_scheduled_change() {
     let mut env = TestEnvironment::_new();
 
     let (_, timestamp_of_change) = env.public_context(|context| {
@@ -221,7 +221,7 @@ unconstrained fn test_get_current_delay_in_public_after_scheduled_change() {
 }
 
 #[test]
-unconstrained fn test_get_current_value_in_private_initial() {
+unconstrained fn get_current_value_in_private_initial() {
     let mut env = TestEnvironment::_new();
 
     env.private_context(|context| {
@@ -236,7 +236,7 @@ unconstrained fn test_get_current_value_in_private_initial() {
 }
 
 #[test]
-unconstrained fn test_get_current_value_in_private_before_change() {
+unconstrained fn get_current_value_in_private_before_change() {
     let mut env = TestEnvironment::_new();
 
     let (_, timestamp_of_change) = env.public_context(|context| {
@@ -256,7 +256,7 @@ unconstrained fn test_get_current_value_in_private_before_change() {
 }
 
 #[test]
-unconstrained fn test_get_current_value_in_private_immediately_before_change() {
+unconstrained fn get_current_value_in_private_immediately_before_change() {
     let mut env = TestEnvironment::_new();
 
     let (_, timestamp_of_change) = env.public_context(|context| {
@@ -283,7 +283,7 @@ unconstrained fn test_get_current_value_in_private_immediately_before_change() {
 }
 
 #[test]
-unconstrained fn test_get_current_value_in_private_at_change() {
+unconstrained fn get_current_value_in_private_at_change() {
     let mut env = TestEnvironment::_new();
 
     let (_, timestamp_of_change) = env.public_context(|context| {
@@ -311,7 +311,7 @@ unconstrained fn test_get_current_value_in_private_at_change() {
 }
 
 #[test]
-unconstrained fn test_get_current_value_in_private_after_change() {
+unconstrained fn get_current_value_in_private_after_change() {
     let mut env = TestEnvironment::_new();
 
     let (_, timestamp_of_change) = env.public_context(|context| {
@@ -339,7 +339,7 @@ unconstrained fn test_get_current_value_in_private_after_change() {
 }
 
 #[test]
-unconstrained fn test_get_current_value_in_private_with_non_initial_delay() {
+unconstrained fn get_current_value_in_private_with_non_initial_delay() {
     let mut env = TestEnvironment::_new();
 
     let ((_, value_timestamp_of_change), (_, delay_timestamp_of_change)) = env
@@ -367,7 +367,7 @@ unconstrained fn test_get_current_value_in_private_with_non_initial_delay() {
 }
 
 #[test]
-unconstrained fn test_get_current_value_in_utility_initial() {
+unconstrained fn get_current_value_in_utility_initial() {
     let mut env = TestEnvironment::_new();
     env.utility_context(|context| {
         let state_var = in_utility(context);
@@ -376,7 +376,7 @@ unconstrained fn test_get_current_value_in_utility_initial() {
 }
 
 #[test]
-unconstrained fn test_get_current_value_in_utility_before_scheduled_change() {
+unconstrained fn get_current_value_in_utility_before_scheduled_change() {
     let mut env = TestEnvironment::_new();
 
     let (_, timestamp_of_change) = env.public_context(|context| {
@@ -399,7 +399,7 @@ unconstrained fn test_get_current_value_in_utility_before_scheduled_change() {
 }
 
 #[test]
-unconstrained fn test_get_current_value_in_utility_at_scheduled_change() {
+unconstrained fn get_current_value_in_utility_at_scheduled_change() {
     let mut env = TestEnvironment::_new();
 
     let (_, timestamp_of_change) = env.public_context(|context| {
@@ -422,7 +422,7 @@ unconstrained fn test_get_current_value_in_utility_at_scheduled_change() {
 }
 
 #[test]
-unconstrained fn test_get_current_value_in_utility_after_scheduled_change() {
+unconstrained fn get_current_value_in_utility_after_scheduled_change() {
     let mut env = TestEnvironment::_new();
 
     let (_, timestamp_of_change) = env.public_context(|context| {

--- a/noir-projects/aztec-nr/aztec/src/utils/with_hash.nr
+++ b/noir-projects/aztec-nr/aztec/src/utils/with_hash.nr
@@ -182,7 +182,7 @@ mod test {
     }
 
     #[test(should_fail_with = "Non-zero hint for zero hash")]
-    unconstrained fn test_bad_hint_uninitialized_value() {
+    unconstrained fn bad_hint_uninitialized_value() {
         let mut env = TestEnvironment::new();
 
         env.mine_block();
@@ -210,7 +210,7 @@ mod test {
     }
 
     #[test(should_fail_with = "Hint values do not match hash")]
-    unconstrained fn test_bad_hint_initialized_value() {
+    unconstrained fn bad_hint_initialized_value() {
         let mut env = TestEnvironment::new();
 
         let value_packed = MockStruct { a: 5, b: 3 }.pack();


### PR DESCRIPTION
Due to the `mod test` these show up as `test::test` and made searching annoying.