### PR TITLE
feat: Replace pending txs in sequencer publisher with new blocks

### DIFF
--- a/yarn-project/.gitignore
+++ b/yarn-project/.gitignore
@@ -62,3 +62,4 @@ cli-wallet/test/data
 !.yarn/releases
 !.yarn/sdks
 !.yarn/versions
+.claude

--- a/yarn-project/aztec-node/src/aztec-node/server.ts
+++ b/yarn-project/aztec-node/src/aztec-node/server.ts
@@ -352,7 +352,10 @@ export class AztecNodeService implements AztecNode, AztecNodeAdmin, Traceable {
       }
 
       const l1Client = createExtendedL1Client(l1RpcUrls, publisherPrivateKey.getValue(), ethereumChain.chainInfo);
-      const l1TxUtils = new L1TxUtilsWithBlobs(l1Client, log, dateProvider, config);
+      const l1TxUtils = new L1TxUtilsWithBlobs(l1Client, log, dateProvider, {
+        ...config,
+        replacePreviousPendingTx: true,
+      });
 
       sequencer = await SequencerClient.new(config, {
         // if deps were provided, they should override the defaults,

--- a/yarn-project/end-to-end/src/integration/integration_l1_publisher.test.ts
+++ b/yarn-project/end-to-end/src/integration/integration_l1_publisher.test.ts
@@ -1,12 +1,13 @@
 import type { ArchiveSource } from '@aztec/archiver';
 import { getConfigEnvVars } from '@aztec/aztec-node';
-import { AztecAddress, Fr, GlobalVariables, type L2Block, createLogger } from '@aztec/aztec.js';
+import { AztecAddress, Fr, GlobalVariables, type L2Block, createLogger, retryUntil } from '@aztec/aztec.js';
 import { BatchedBlob, Blob } from '@aztec/blob-lib';
 import { createBlobSinkClient } from '@aztec/blob-sink/client';
 import { GENESIS_ARCHIVE_ROOT, MAX_NULLIFIERS_PER_TX, NUMBER_OF_L1_L2_MESSAGES_PER_ROLLUP } from '@aztec/constants';
 import { EpochCache } from '@aztec/epoch-cache';
 import {
   type ExtendedViemWalletClient,
+  FormattedViemError,
   GovernanceProposerContract,
   type L1ContractAddresses,
   RollupContract,
@@ -189,7 +190,10 @@ describe('L1Publisher integration', () => {
 
     const dateProvider = new TestDateProvider();
     const sequencerL1Client = createExtendedL1Client(config.l1RpcUrls, sequencerPK, foundry);
-    const l1TxUtils = new L1TxUtilsWithBlobs(sequencerL1Client, logger, dateProvider, config);
+    const l1TxUtils = new L1TxUtilsWithBlobs(sequencerL1Client, logger, dateProvider, {
+      ...config,
+      replacePreviousPendingTx: true,
+    });
     const rollupContract = new RollupContract(sequencerL1Client, l1ContractAddresses.rollupAddress.toString());
     const slashingProposerAddress = await rollupContract.getSlashingProposerAddress();
     const slashingProposerContract = new SlashingProposerContract(
@@ -532,32 +536,32 @@ describe('L1Publisher integration', () => {
     );
   });
 
+  const buildSingleBlock = async (opts: { blockNumber?: number; l1ToL2Messages?: Fr[] } = {}) => {
+    const archiveInRollup = await rollup.archive();
+    expect(hexToBuffer(archiveInRollup.toString())).toEqual(new Fr(GENESIS_ARCHIVE_ROOT).toBuffer());
+
+    const l1ToL2Messages = opts.l1ToL2Messages ?? new Array(NUMBER_OF_L1_L2_MESSAGES_PER_ROLLUP).fill(Fr.ZERO);
+
+    const txs = await Promise.all([makeProcessedTx(0x1000), makeProcessedTx(0x2000)]);
+    const ts = (await l1Client.getBlock()).timestamp;
+    const slot = await rollup.getSlotAt(ts + BigInt(config.ethereumSlotDuration));
+    const timestamp = await rollup.getTimestampForSlot(slot);
+    const globalVariables = new GlobalVariables(
+      new Fr(chainId),
+      new Fr(version),
+      opts.blockNumber ?? 1,
+      new Fr(slot),
+      timestamp,
+      coinbase,
+      feeRecipient,
+      new GasFees(0, await rollup.getManaBaseFeeAt(timestamp, true)),
+    );
+    const block = await buildBlock(globalVariables, txs, l1ToL2Messages);
+    blockSource.getL1ToL2Messages.mockResolvedValueOnce(l1ToL2Messages);
+    return block;
+  };
+
   describe('error handling', () => {
-    const buildSingleBlock = async (opts: { l1ToL2Messages?: Fr[] } = {}) => {
-      const archiveInRollup = await rollup.archive();
-      expect(hexToBuffer(archiveInRollup.toString())).toEqual(new Fr(GENESIS_ARCHIVE_ROOT).toBuffer());
-
-      const l1ToL2Messages = opts.l1ToL2Messages ?? new Array(NUMBER_OF_L1_L2_MESSAGES_PER_ROLLUP).fill(Fr.ZERO);
-
-      const txs = await Promise.all([makeProcessedTx(0x1000), makeProcessedTx(0x2000)]);
-      const ts = (await l1Client.getBlock()).timestamp;
-      const slot = await rollup.getSlotAt(ts + BigInt(config.ethereumSlotDuration));
-      const timestamp = await rollup.getTimestampForSlot(slot);
-      const globalVariables = new GlobalVariables(
-        new Fr(chainId),
-        new Fr(version),
-        1, // block number
-        new Fr(slot),
-        timestamp,
-        coinbase,
-        feeRecipient,
-        new GasFees(0, await rollup.getManaBaseFeeAt(timestamp, true)),
-      );
-      const block = await buildBlock(globalVariables, txs, l1ToL2Messages);
-      blockSource.getL1ToL2Messages.mockResolvedValueOnce(l1ToL2Messages);
-      return block;
-    };
-
     it(`succeeds proposing new block when vote fails`, async () => {
       const block = await buildSingleBlock();
       publisher.registerSlashPayloadGetter(() => Promise.resolve(EthAddress.random()));
@@ -593,6 +597,48 @@ describe('L1Publisher integration', () => {
         undefined,
         expect.objectContaining({ blockNumber: 1 }),
       );
+    });
+  });
+
+  describe('replacements', () => {
+    it('replaces the latest L1 tx with a new block if previous one never landed', async () => {
+      publisher.l1TxUtils.config.cancelTxOnTimeout = false;
+      await ethCheatCodes.setAutomine(false);
+      await ethCheatCodes.setIntervalMining(0);
+
+      const blockForSlot1 = await buildSingleBlock();
+      await publisher.enqueueProposeL2Block(blockForSlot1);
+
+      logger.warn(`Sending request for block for first slot`);
+      const requestPromise1 = publisher.sendRequests();
+      requestPromise1.catch(err => logger.error(`Expected error sending request`, err));
+
+      logger.warn(`Sent request for block for first slot`);
+      await retryUntil(() => publisher.l1TxUtils.pendingRequest?.txHash !== undefined, 'block1', 10, 0.1);
+      const txHash1 = publisher.l1TxUtils.pendingRequest?.txHash;
+      const nonce1 = await l1Client.getTransaction({ hash: txHash1! }).then(tx => tx.nonce);
+
+      logger.warn(`Dropping tx for first slot ${txHash1}`);
+      await ethCheatCodes.dropTransaction(txHash1!);
+      await ethCheatCodes.mine(config.aztecSlotDuration / config.ethereumSlotDuration + 1);
+      await ethCheatCodes.setIntervalMining(1);
+
+      logger.warn(`Sending request for block for next slot`);
+      const blockForSlot2 = await buildSingleBlock();
+      await publisher.enqueueProposeL2Block(blockForSlot2);
+      const result2 = await publisher.sendRequests();
+
+      expect((await requestPromise1)?.failedActions).toEqual(['propose']);
+      expect(result2?.successfulActions).toEqual(['propose']);
+
+      if (result2?.result instanceof FormattedViemError) {
+        throw new Error(`Expected successful propose, got error: ${result2.result.message}`);
+      }
+
+      const nonce2 = await l1Client
+        .getTransaction({ hash: result2!.result.receipt.transactionHash! })
+        .then(tx => tx.nonce);
+      expect(nonce2).toEqual(nonce1);
     });
   });
 });

--- a/yarn-project/ethereum/src/l1_tx_utils.test.ts
+++ b/yarn-project/ethereum/src/l1_tx_utils.test.ts
@@ -3,7 +3,7 @@ import { EthAddress } from '@aztec/foundation/eth-address';
 import { jsonStringify } from '@aztec/foundation/json-rpc';
 import { createLogger } from '@aztec/foundation/log';
 import { sleep } from '@aztec/foundation/sleep';
-import { DateProvider, TestDateProvider } from '@aztec/foundation/timer';
+import { TestDateProvider } from '@aztec/foundation/timer';
 
 import { jest } from '@jest/globals';
 import type { Anvil } from '@viem/anvil';
@@ -794,335 +794,296 @@ describe('L1TxUtils', () => {
       }).toThrow();
     });
   });
-});
 
-describe('With replacePreviousPendingTx', () => {
-  let gasUtils: L1TxUtils;
-  let l1Client: ExtendedViemWalletClient;
-  let anvil: Anvil;
-  let cheatCodes: EthCheatCodes;
-  let dateProvider: DateProvider;
-
-  const initialBaseFee = WEI_CONST; // 1 gwei
-
-  beforeAll(async () => {
-    const { anvil: anvilInstance, rpcUrl } = await startAnvil({ l1BlockTime: 1, log: true });
-    anvil = anvilInstance;
-    cheatCodes = new EthCheatCodes([rpcUrl]);
-    const hdAccount = mnemonicToAccount(MNEMONIC, { addressIndex: 0 });
-    const privKeyRaw = hdAccount.getHdKey().privateKey;
-    if (!privKeyRaw) {
-      throw new Error('Failed to get private key');
-    }
-    const privKey = Buffer.from(privKeyRaw).toString('hex');
-    const account = privateKeyToAccount(`0x${privKey}`);
-
-    dateProvider = new TestDateProvider();
-    l1Client = createExtendedL1Client([rpcUrl], account, foundry);
-
-    // set base fee
-    await l1Client.transport.request({
-      method: 'anvil_setNextBlockBaseFeePerGas',
-      params: [initialBaseFee.toString()],
+  describe('With replacePreviousPendingTx', () => {
+    afterEach(async () => {
+      await cheatCodes.setAutomine(true);
+      await cheatCodes.setIntervalMining(0);
     });
-    await cheatCodes.evmMine();
+
+    it('replaces pending transaction when replacePreviousPendingTx is true', async () => {
+      // Create gas utils with replacePreviousPendingTx enabled
+      const gasUtils = new L1TxUtils(l1Client, logger, dateProvider, {
+        ...defaultL1TxUtilsConfig,
+        replacePreviousPendingTx: true,
+        checkIntervalMs: 100,
+        stallTimeMs: 10000,
+      });
+
+      // Disable mining to keep transactions pending
+      await cheatCodes.setAutomine(false);
+      await cheatCodes.setIntervalMining(0);
+
+      // Send first transaction
+      const request1 = {
+        to: '0x1234567890123456789012345678901234567890' as `0x${string}`,
+        data: '0x1234' as `0x${string}`,
+        value: 1n,
+      };
+
+      const { txHash: txHash1 } = await gasUtils.sendTransaction(request1);
+      const tx1 = await l1Client.getTransaction({ hash: txHash1 });
+
+      // Send second transaction (should replace the first one)
+      const request2 = {
+        to: '0xabcdefabcdefabcdefabcdefabcdefabcdefabcd' as `0x${string}`,
+        data: '0x5678' as `0x${string}`,
+        value: 2n,
+      };
+
+      const { txHash: txHash2 } = await gasUtils.sendTransaction(request2);
+      const tx2 = await l1Client.getTransaction({ hash: txHash2 });
+
+      // Verify both transactions have the same nonce
+      expect(tx2.nonce).toBe(tx1.nonce);
+
+      // Verify the second transaction has higher gas prices
+      expect(tx2.maxFeePerGas!).toBeGreaterThan(tx1.maxFeePerGas!);
+      expect(tx2.maxPriorityFeePerGas!).toBeGreaterThan(tx1.maxPriorityFeePerGas!);
+
+      // Verify the transaction details match the second request
+      expect(tx2.to!.toLowerCase()).toBe(request2.to.toLowerCase());
+      expect(tx2.input).toBe(request2.data);
+      expect(tx2.value).toBe(request2.value);
+
+      // Mine a block to process the transaction
+      await cheatCodes.evmMine();
+
+      // Only the second transaction should be mined
+      const receipt2 = await l1Client.getTransactionReceipt({ hash: txHash2 });
+      expect(receipt2.status).toBe('success');
+
+      // The first transaction should not exist anymore
+      await expect(l1Client.getTransaction({ hash: txHash1 })).rejects.toThrow();
+    }, 20_000);
+
+    it('does not replace pending transaction when replacePreviousPendingTx is false', async () => {
+      // Create gas utils with replacePreviousPendingTx disabled (default)
+      const gasUtils = new L1TxUtils(l1Client, logger, dateProvider, {
+        ...defaultL1TxUtilsConfig,
+        replacePreviousPendingTx: false,
+      });
+
+      // Disable mining to keep transactions pending
+      await cheatCodes.setAutomine(false);
+      await cheatCodes.setIntervalMining(0);
+
+      // Send first transaction
+      const request1 = {
+        to: '0x1234567890123456789012345678901234567890' as `0x${string}`,
+        data: '0x1234' as `0x${string}`,
+        value: 1n,
+      };
+
+      const { txHash: txHash1 } = await gasUtils.sendTransaction(request1);
+      const tx1 = await l1Client.getTransaction({ hash: txHash1 });
+
+      // Send second transaction (should NOT replace the first one)
+      const request2 = {
+        to: '0xabcdefabcdefabcdefabcdefabcdefabcdefabcd' as `0x${string}`,
+        data: '0x5678' as `0x${string}`,
+        value: 2n,
+      };
+
+      const { txHash: txHash2 } = await gasUtils.sendTransaction(request2);
+      const tx2 = await l1Client.getTransaction({ hash: txHash2 });
+
+      // Verify transactions have different nonces
+      expect(tx2.nonce).toBe(tx1.nonce + 1);
+
+      // Mine blocks to process both transactions
+      await cheatCodes.evmMine();
+      await cheatCodes.evmMine();
+
+      // Both transactions should be mined
+      const receipt1 = await l1Client.getTransactionReceipt({ hash: txHash1 });
+      const receipt2 = await l1Client.getTransactionReceipt({ hash: txHash2 });
+      expect(receipt1.status).toBe('success');
+      expect(receipt2.status).toBe('success');
+    }, 20_000);
+
+    it('clears stale pending request when nonce has advanced', async () => {
+      // Create gas utils with replacePreviousPendingTx enabled
+      const gasUtils = new L1TxUtils(l1Client, logger, dateProvider, {
+        ...defaultL1TxUtilsConfig,
+        replacePreviousPendingTx: true,
+      });
+
+      // Disable mining to keep first transaction pending
+      await cheatCodes.setAutomine(false);
+      await cheatCodes.setIntervalMining(0);
+
+      // Send first transaction
+      const request1 = {
+        to: '0x1234567890123456789012345678901234567890' as `0x${string}`,
+        data: '0x1234' as `0x${string}`,
+        value: 1n,
+      };
+
+      const { txHash: txHash1 } = await gasUtils.sendTransaction(request1);
+      const tx1 = await l1Client.getTransaction({ hash: txHash1 });
+
+      // Mine the transaction
+      await cheatCodes.evmMine();
+
+      // Wait for receipt
+      const receipt1 = await l1Client.getTransactionReceipt({ hash: txHash1 });
+      expect(receipt1.status).toBe('success');
+
+      // Send second transaction (should get a new nonce since first is mined)
+      const request2 = {
+        to: '0xabcdefabcdefabcdefabcdefabcdefabcdefabcd' as `0x${string}`,
+        data: '0x5678' as `0x${string}`,
+        value: 2n,
+      };
+
+      const { txHash: txHash2 } = await gasUtils.sendTransaction(request2);
+      const tx2 = await l1Client.getTransaction({ hash: txHash2 });
+
+      // Verify the second transaction has a new nonce
+      expect(tx2.nonce).toBe(tx1.nonce + 1);
+    }, 20_000);
+
+    it('throws ReplacedL1TxError when transaction is replaced externally', async () => {
+      // Create gas utils
+      const gasUtils = new L1TxUtils(l1Client, logger, dateProvider, {
+        ...defaultL1TxUtilsConfig,
+        checkIntervalMs: 100,
+        stallTimeMs: 10000,
+      });
+
+      // Disable mining to keep transactions pending
+      await cheatCodes.setAutomine(false);
+      await cheatCodes.setIntervalMining(0);
+
+      // Send first transaction
+      const request1 = {
+        to: '0x1234567890123456789012345678901234567890' as `0x${string}`,
+        data: '0x1234' as `0x${string}`,
+        value: 1n,
+      };
+
+      const { txHash: txHash1 } = await gasUtils.sendTransaction(request1);
+      const tx1 = await l1Client.getTransaction({ hash: txHash1 });
+
+      const monitorPromise = gasUtils.monitorTransaction(request1, txHash1, { gasLimit: tx1.gas! });
+
+      // Manually send a replacement transaction with the same nonce but different request
+      await l1Client.sendTransaction({
+        to: '0xdeadbeefdeadbeefdeadbeefdeadbeefdeadbeef' as `0x${string}`,
+        data: '0xdead' as `0x${string}`,
+        value: 10n,
+        nonce: tx1.nonce,
+        maxFeePerGas: tx1.maxFeePerGas! * 2n,
+        maxPriorityFeePerGas: tx1.maxPriorityFeePerGas! * 2n,
+        gas: 100_000n,
+      });
+
+      // Mine the replacement transaction
+      await cheatCodes.evmMine();
+
+      // Monitor should throw ReplacedL1TxError
+      await expect(monitorPromise).rejects.toThrow('was replaced by a different tx');
+    }, 20_000);
+
+    it('correctly handles multiple replacements with blob transactions', async () => {
+      // Create gas utils with replacePreviousPendingTx enabled
+      const blobGasUtils = new L1TxUtilsWithBlobs(l1Client, logger, dateProvider, {
+        ...defaultL1TxUtilsConfig,
+        replacePreviousPendingTx: true,
+        checkIntervalMs: 100,
+        stallTimeMs: 10000,
+      });
+
+      // Disable mining to keep transactions pending
+      await cheatCodes.setAutomine(false);
+      await cheatCodes.setIntervalMining(0);
+
+      // Create blob data
+      const blobData = new Uint8Array(131072).fill(1);
+      const kzg = Blob.getViemKzgInstance();
+
+      // Send first blob transaction
+      const request1 = {
+        to: '0x1234567890123456789012345678901234567890' as `0x${string}`,
+        data: '0x1234' as `0x${string}`,
+        value: 1n,
+      };
+
+      const { txHash: txHash1 } = await blobGasUtils.sendTransaction(request1, undefined, {
+        blobs: [blobData],
+        kzg,
+        maxFeePerBlobGas: 100n * WEI_CONST,
+      });
+      const tx1 = await l1Client.getTransaction({ hash: txHash1 });
+
+      // Send second blob transaction (should replace the first one)
+      const request2 = {
+        to: '0xabcdefabcdefabcdefabcdefabcdefabcdefabcd' as `0x${string}`,
+        data: '0x5678' as `0x${string}`,
+        value: 2n,
+      };
+
+      const { txHash: txHash2 } = await blobGasUtils.sendTransaction(request2, undefined, {
+        blobs: [blobData],
+        kzg,
+        maxFeePerBlobGas: 100n * WEI_CONST,
+      });
+      const tx2 = await l1Client.getTransaction({ hash: txHash2 });
+
+      // Verify both transactions have the same nonce
+      expect(tx2.nonce).toBe(tx1.nonce);
+
+      // Verify the second transaction has higher gas prices (including blob gas)
+      expect(tx2.maxFeePerGas!).toBeGreaterThan(tx1.maxFeePerGas!);
+      expect(tx2.maxPriorityFeePerGas!).toBeGreaterThan(tx1.maxPriorityFeePerGas!);
+      expect(tx2.maxFeePerBlobGas!).toBeGreaterThan(tx1.maxFeePerBlobGas!);
+
+      // Mine a block to process the transaction
+      await cheatCodes.evmMine();
+
+      // Only the second transaction should be mined
+      const receipt2 = await l1Client.getTransactionReceipt({ hash: txHash2 });
+      expect(receipt2.status).toBe('success');
+      expect(receipt2.blobGasUsed).toBeDefined();
+
+      // The first transaction should not exist anymore
+      await expect(l1Client.getTransaction({ hash: txHash1 })).rejects.toThrow();
+    }, 20_000);
+
+    it('clears pending request after successful monitoring', async () => {
+      // Create gas utils with replacePreviousPendingTx enabled
+      const gasUtils = new L1TxUtils(l1Client, logger, dateProvider, {
+        ...defaultL1TxUtilsConfig,
+        replacePreviousPendingTx: true,
+      });
+
+      await cheatCodes.evmMine();
+      await cheatCodes.setAutomine(false);
+      await cheatCodes.setIntervalMining(1);
+
+      // Send and monitor a transaction
+      const request = {
+        to: '0x1234567890123456789012345678901234567890' as `0x${string}`,
+        data: '0x1234' as `0x${string}`,
+        value: 1n,
+      };
+
+      const { receipt } = await gasUtils.sendAndMonitorTransaction(request);
+      expect(receipt.status).toBe('success');
+
+      // Send another transaction - should get a new nonce
+      const request2 = {
+        to: '0xabcdefabcdefabcdefabcdefabcdefabcdefabcd' as `0x${string}`,
+        data: '0x5678' as `0x${string}`,
+        value: 2n,
+      };
+
+      const { txHash: txHash2 } = await gasUtils.sendTransaction(request2);
+      const tx2 = await l1Client.getTransaction({ hash: txHash2 });
+
+      // Verify it got a new nonce (not replacing anything)
+      expect(tx2.nonce).toBeGreaterThan(0);
+    }, 20_000);
   });
-
-  afterEach(async () => {
-    // Reset base fee
-    await cheatCodes.setNextBlockBaseFeePerGas(initialBaseFee);
-    await cheatCodes.evmMine();
-    // Re-enable mining
-    await cheatCodes.setAutomine(true);
-    await cheatCodes.setIntervalMining(0);
-  });
-
-  afterAll(async () => {
-    await anvil.stop().catch(err => createLogger('cleanup').error(err));
-  }, 5_000);
-
-  it('replaces pending transaction when replacePreviousPendingTx is true', async () => {
-    // Create gas utils with replacePreviousPendingTx enabled
-    gasUtils = new L1TxUtils(l1Client, logger, dateProvider, {
-      ...defaultL1TxUtilsConfig,
-      replacePreviousPendingTx: true,
-      checkIntervalMs: 100,
-      stallTimeMs: 10000,
-    });
-
-    // Disable mining to keep transactions pending
-    await cheatCodes.setAutomine(false);
-    await cheatCodes.setIntervalMining(0);
-
-    // Send first transaction
-    const request1 = {
-      to: '0x1234567890123456789012345678901234567890' as `0x${string}`,
-      data: '0x1234' as `0x${string}`,
-      value: 1n,
-    };
-
-    const { txHash: txHash1 } = await gasUtils.sendTransaction(request1);
-    const tx1 = await l1Client.getTransaction({ hash: txHash1 });
-
-    // Send second transaction (should replace the first one)
-    const request2 = {
-      to: '0xabcdefabcdefabcdefabcdefabcdefabcdefabcd' as `0x${string}`,
-      data: '0x5678' as `0x${string}`,
-      value: 2n,
-    };
-
-    const { txHash: txHash2 } = await gasUtils.sendTransaction(request2);
-    const tx2 = await l1Client.getTransaction({ hash: txHash2 });
-
-    // Verify both transactions have the same nonce
-    expect(tx2.nonce).toBe(tx1.nonce);
-
-    // Verify the second transaction has higher gas prices
-    expect(tx2.maxFeePerGas!).toBeGreaterThan(tx1.maxFeePerGas!);
-    expect(tx2.maxPriorityFeePerGas!).toBeGreaterThan(tx1.maxPriorityFeePerGas!);
-
-    // Verify the transaction details match the second request
-    expect(tx2.to!.toLowerCase()).toBe(request2.to.toLowerCase());
-    expect(tx2.input).toBe(request2.data);
-    expect(tx2.value).toBe(request2.value);
-
-    // Mine a block to process the transaction
-    await cheatCodes.evmMine();
-
-    // Only the second transaction should be mined
-    const receipt2 = await l1Client.getTransactionReceipt({ hash: txHash2 });
-    expect(receipt2.status).toBe('success');
-
-    // The first transaction should not exist anymore
-    await expect(l1Client.getTransaction({ hash: txHash1 })).rejects.toThrow();
-  }, 20_000);
-
-  it('does not replace pending transaction when replacePreviousPendingTx is false', async () => {
-    // Create gas utils with replacePreviousPendingTx disabled (default)
-    gasUtils = new L1TxUtils(l1Client, logger, dateProvider, {
-      ...defaultL1TxUtilsConfig,
-      replacePreviousPendingTx: false,
-    });
-
-    // Disable mining to keep transactions pending
-    await cheatCodes.setAutomine(false);
-    await cheatCodes.setIntervalMining(0);
-
-    // Send first transaction
-    const request1 = {
-      to: '0x1234567890123456789012345678901234567890' as `0x${string}`,
-      data: '0x1234' as `0x${string}`,
-      value: 1n,
-    };
-
-    const { txHash: txHash1 } = await gasUtils.sendTransaction(request1);
-    const tx1 = await l1Client.getTransaction({ hash: txHash1 });
-
-    // Send second transaction (should NOT replace the first one)
-    const request2 = {
-      to: '0xabcdefabcdefabcdefabcdefabcdefabcdefabcd' as `0x${string}`,
-      data: '0x5678' as `0x${string}`,
-      value: 2n,
-    };
-
-    const { txHash: txHash2 } = await gasUtils.sendTransaction(request2);
-    const tx2 = await l1Client.getTransaction({ hash: txHash2 });
-
-    // Verify transactions have different nonces
-    expect(tx2.nonce).toBe(tx1.nonce + 1);
-
-    // Mine blocks to process both transactions
-    await cheatCodes.evmMine();
-    await cheatCodes.evmMine();
-
-    // Both transactions should be mined
-    const receipt1 = await l1Client.getTransactionReceipt({ hash: txHash1 });
-    const receipt2 = await l1Client.getTransactionReceipt({ hash: txHash2 });
-    expect(receipt1.status).toBe('success');
-    expect(receipt2.status).toBe('success');
-  }, 20_000);
-
-  it('clears stale pending request when nonce has advanced', async () => {
-    // Create gas utils with replacePreviousPendingTx enabled
-    gasUtils = new L1TxUtils(l1Client, logger, dateProvider, {
-      ...defaultL1TxUtilsConfig,
-      replacePreviousPendingTx: true,
-    });
-
-    // Disable mining to keep first transaction pending
-    await cheatCodes.setAutomine(false);
-    await cheatCodes.setIntervalMining(0);
-
-    // Send first transaction
-    const request1 = {
-      to: '0x1234567890123456789012345678901234567890' as `0x${string}`,
-      data: '0x1234' as `0x${string}`,
-      value: 1n,
-    };
-
-    const { txHash: txHash1 } = await gasUtils.sendTransaction(request1);
-    const tx1 = await l1Client.getTransaction({ hash: txHash1 });
-
-    // Mine the transaction
-    await cheatCodes.evmMine();
-
-    // Wait for receipt
-    const receipt1 = await l1Client.getTransactionReceipt({ hash: txHash1 });
-    expect(receipt1.status).toBe('success');
-
-    // Send second transaction (should get a new nonce since first is mined)
-    const request2 = {
-      to: '0xabcdefabcdefabcdefabcdefabcdefabcdefabcd' as `0x${string}`,
-      data: '0x5678' as `0x${string}`,
-      value: 2n,
-    };
-
-    const { txHash: txHash2 } = await gasUtils.sendTransaction(request2);
-    const tx2 = await l1Client.getTransaction({ hash: txHash2 });
-
-    // Verify the second transaction has a new nonce
-    expect(tx2.nonce).toBe(tx1.nonce + 1);
-  }, 20_000);
-
-  it('throws ReplacedL1TxError when transaction is replaced externally', async () => {
-    // Create gas utils
-    gasUtils = new L1TxUtils(l1Client, logger, dateProvider, {
-      ...defaultL1TxUtilsConfig,
-      checkIntervalMs: 100,
-      stallTimeMs: 10000,
-    });
-
-    // Disable mining to keep transactions pending
-    await cheatCodes.setAutomine(false);
-    await cheatCodes.setIntervalMining(0);
-
-    // Send first transaction
-    const request1 = {
-      to: '0x1234567890123456789012345678901234567890' as `0x${string}`,
-      data: '0x1234' as `0x${string}`,
-      value: 1n,
-    };
-
-    const { txHash: txHash1 } = await gasUtils.sendTransaction(request1);
-    const tx1 = await l1Client.getTransaction({ hash: txHash1 });
-
-    const monitorPromise = gasUtils.monitorTransaction(request1, txHash1, { gasLimit: tx1.gas! });
-
-    // Manually send a replacement transaction with the same nonce but different request
-    await l1Client.sendTransaction({
-      to: '0xdeadbeefdeadbeefdeadbeefdeadbeefdeadbeef' as `0x${string}`,
-      data: '0xdead' as `0x${string}`,
-      value: 10n,
-      nonce: tx1.nonce,
-      maxFeePerGas: tx1.maxFeePerGas! * 2n,
-      maxPriorityFeePerGas: tx1.maxPriorityFeePerGas! * 2n,
-      gas: 100_000n,
-    });
-
-    // Mine the replacement transaction
-    await cheatCodes.evmMine();
-
-    // Monitor should throw ReplacedL1TxError
-    await expect(monitorPromise).rejects.toThrow('was replaced by a different tx');
-  }, 20_000);
-
-  it('correctly handles multiple replacements with blob transactions', async () => {
-    // Create gas utils with replacePreviousPendingTx enabled
-    const blobGasUtils = new L1TxUtilsWithBlobs(l1Client, logger, dateProvider, {
-      ...defaultL1TxUtilsConfig,
-      replacePreviousPendingTx: true,
-      checkIntervalMs: 100,
-      stallTimeMs: 10000,
-    });
-
-    // Disable mining to keep transactions pending
-    await cheatCodes.setAutomine(false);
-    await cheatCodes.setIntervalMining(0);
-
-    // Create blob data
-    const blobData = new Uint8Array(131072).fill(1);
-    const kzg = Blob.getViemKzgInstance();
-
-    // Send first blob transaction
-    const request1 = {
-      to: '0x1234567890123456789012345678901234567890' as `0x${string}`,
-      data: '0x1234' as `0x${string}`,
-      value: 1n,
-    };
-
-    const { txHash: txHash1 } = await blobGasUtils.sendTransaction(request1, undefined, {
-      blobs: [blobData],
-      kzg,
-      maxFeePerBlobGas: 100n * WEI_CONST,
-    });
-    const tx1 = await l1Client.getTransaction({ hash: txHash1 });
-
-    // Send second blob transaction (should replace the first one)
-    const request2 = {
-      to: '0xabcdefabcdefabcdefabcdefabcdefabcdefabcd' as `0x${string}`,
-      data: '0x5678' as `0x${string}`,
-      value: 2n,
-    };
-
-    const { txHash: txHash2 } = await blobGasUtils.sendTransaction(request2, undefined, {
-      blobs: [blobData],
-      kzg,
-      maxFeePerBlobGas: 100n * WEI_CONST,
-    });
-    const tx2 = await l1Client.getTransaction({ hash: txHash2 });
-
-    // Verify both transactions have the same nonce
-    expect(tx2.nonce).toBe(tx1.nonce);
-
-    // Verify the second transaction has higher gas prices (including blob gas)
-    expect(tx2.maxFeePerGas!).toBeGreaterThan(tx1.maxFeePerGas!);
-    expect(tx2.maxPriorityFeePerGas!).toBeGreaterThan(tx1.maxPriorityFeePerGas!);
-    expect(tx2.maxFeePerBlobGas!).toBeGreaterThan(tx1.maxFeePerBlobGas!);
-
-    // Mine a block to process the transaction
-    await cheatCodes.evmMine();
-
-    // Only the second transaction should be mined
-    const receipt2 = await l1Client.getTransactionReceipt({ hash: txHash2 });
-    expect(receipt2.status).toBe('success');
-    expect(receipt2.blobGasUsed).toBeDefined();
-
-    // The first transaction should not exist anymore
-    await expect(l1Client.getTransaction({ hash: txHash1 })).rejects.toThrow();
-  }, 20_000);
-
-  it('clears pending request after successful monitoring', async () => {
-    // Create gas utils with replacePreviousPendingTx enabled
-    gasUtils = new L1TxUtils(l1Client, logger, dateProvider, {
-      ...defaultL1TxUtilsConfig,
-      replacePreviousPendingTx: true,
-    });
-
-    await cheatCodes.evmMine();
-    await cheatCodes.setAutomine(false);
-    await cheatCodes.setIntervalMining(1);
-
-    // Send and monitor a transaction
-    const request = {
-      to: '0x1234567890123456789012345678901234567890' as `0x${string}`,
-      data: '0x1234' as `0x${string}`,
-      value: 1n,
-    };
-
-    const { receipt } = await gasUtils.sendAndMonitorTransaction(request);
-    expect(receipt.status).toBe('success');
-
-    // Send another transaction - should get a new nonce
-    const request2 = {
-      to: '0xabcdefabcdefabcdefabcdefabcdefabcdefabcd' as `0x${string}`,
-      data: '0x5678' as `0x${string}`,
-      value: 2n,
-    };
-
-    const { txHash: txHash2 } = await gasUtils.sendTransaction(request2);
-    const tx2 = await l1Client.getTransaction({ hash: txHash2 });
-
-    // Verify it got a new nonce (not replacing anything)
-    expect(tx2.nonce).toBeGreaterThan(0);
-  }, 20_000);
 });

--- a/yarn-project/ethereum/src/l1_tx_utils.test.ts
+++ b/yarn-project/ethereum/src/l1_tx_utils.test.ts
@@ -3,7 +3,7 @@ import { EthAddress } from '@aztec/foundation/eth-address';
 import { jsonStringify } from '@aztec/foundation/json-rpc';
 import { createLogger } from '@aztec/foundation/log';
 import { sleep } from '@aztec/foundation/sleep';
-import { TestDateProvider } from '@aztec/foundation/timer';
+import { DateProvider, TestDateProvider } from '@aztec/foundation/timer';
 
 import { jest } from '@jest/globals';
 import type { Anvil } from '@viem/anvil';
@@ -794,4 +794,335 @@ describe('L1TxUtils', () => {
       }).toThrow();
     });
   });
+});
+
+describe('With replacePreviousPendingTx', () => {
+  let gasUtils: L1TxUtils;
+  let l1Client: ExtendedViemWalletClient;
+  let anvil: Anvil;
+  let cheatCodes: EthCheatCodes;
+  let dateProvider: DateProvider;
+
+  const initialBaseFee = WEI_CONST; // 1 gwei
+
+  beforeAll(async () => {
+    const { anvil: anvilInstance, rpcUrl } = await startAnvil({ l1BlockTime: 1, log: true });
+    anvil = anvilInstance;
+    cheatCodes = new EthCheatCodes([rpcUrl]);
+    const hdAccount = mnemonicToAccount(MNEMONIC, { addressIndex: 0 });
+    const privKeyRaw = hdAccount.getHdKey().privateKey;
+    if (!privKeyRaw) {
+      throw new Error('Failed to get private key');
+    }
+    const privKey = Buffer.from(privKeyRaw).toString('hex');
+    const account = privateKeyToAccount(`0x${privKey}`);
+
+    dateProvider = new TestDateProvider();
+    l1Client = createExtendedL1Client([rpcUrl], account, foundry);
+
+    // set base fee
+    await l1Client.transport.request({
+      method: 'anvil_setNextBlockBaseFeePerGas',
+      params: [initialBaseFee.toString()],
+    });
+    await cheatCodes.evmMine();
+  });
+
+  afterEach(async () => {
+    // Reset base fee
+    await cheatCodes.setNextBlockBaseFeePerGas(initialBaseFee);
+    await cheatCodes.evmMine();
+    // Re-enable mining
+    await cheatCodes.setAutomine(true);
+    await cheatCodes.setIntervalMining(0);
+  });
+
+  afterAll(async () => {
+    await anvil.stop().catch(err => createLogger('cleanup').error(err));
+  }, 5_000);
+
+  it('replaces pending transaction when replacePreviousPendingTx is true', async () => {
+    // Create gas utils with replacePreviousPendingTx enabled
+    gasUtils = new L1TxUtils(l1Client, logger, dateProvider, {
+      ...defaultL1TxUtilsConfig,
+      replacePreviousPendingTx: true,
+      checkIntervalMs: 100,
+      stallTimeMs: 10000,
+    });
+
+    // Disable mining to keep transactions pending
+    await cheatCodes.setAutomine(false);
+    await cheatCodes.setIntervalMining(0);
+
+    // Send first transaction
+    const request1 = {
+      to: '0x1234567890123456789012345678901234567890' as `0x${string}`,
+      data: '0x1234' as `0x${string}`,
+      value: 1n,
+    };
+
+    const { txHash: txHash1 } = await gasUtils.sendTransaction(request1);
+    const tx1 = await l1Client.getTransaction({ hash: txHash1 });
+
+    // Send second transaction (should replace the first one)
+    const request2 = {
+      to: '0xabcdefabcdefabcdefabcdefabcdefabcdefabcd' as `0x${string}`,
+      data: '0x5678' as `0x${string}`,
+      value: 2n,
+    };
+
+    const { txHash: txHash2 } = await gasUtils.sendTransaction(request2);
+    const tx2 = await l1Client.getTransaction({ hash: txHash2 });
+
+    // Verify both transactions have the same nonce
+    expect(tx2.nonce).toBe(tx1.nonce);
+
+    // Verify the second transaction has higher gas prices
+    expect(tx2.maxFeePerGas!).toBeGreaterThan(tx1.maxFeePerGas!);
+    expect(tx2.maxPriorityFeePerGas!).toBeGreaterThan(tx1.maxPriorityFeePerGas!);
+
+    // Verify the transaction details match the second request
+    expect(tx2.to!.toLowerCase()).toBe(request2.to.toLowerCase());
+    expect(tx2.input).toBe(request2.data);
+    expect(tx2.value).toBe(request2.value);
+
+    // Mine a block to process the transaction
+    await cheatCodes.evmMine();
+
+    // Only the second transaction should be mined
+    const receipt2 = await l1Client.getTransactionReceipt({ hash: txHash2 });
+    expect(receipt2.status).toBe('success');
+
+    // The first transaction should not exist anymore
+    await expect(l1Client.getTransaction({ hash: txHash1 })).rejects.toThrow();
+  }, 20_000);
+
+  it('does not replace pending transaction when replacePreviousPendingTx is false', async () => {
+    // Create gas utils with replacePreviousPendingTx disabled (default)
+    gasUtils = new L1TxUtils(l1Client, logger, dateProvider, {
+      ...defaultL1TxUtilsConfig,
+      replacePreviousPendingTx: false,
+    });
+
+    // Disable mining to keep transactions pending
+    await cheatCodes.setAutomine(false);
+    await cheatCodes.setIntervalMining(0);
+
+    // Send first transaction
+    const request1 = {
+      to: '0x1234567890123456789012345678901234567890' as `0x${string}`,
+      data: '0x1234' as `0x${string}`,
+      value: 1n,
+    };
+
+    const { txHash: txHash1 } = await gasUtils.sendTransaction(request1);
+    const tx1 = await l1Client.getTransaction({ hash: txHash1 });
+
+    // Send second transaction (should NOT replace the first one)
+    const request2 = {
+      to: '0xabcdefabcdefabcdefabcdefabcdefabcdefabcd' as `0x${string}`,
+      data: '0x5678' as `0x${string}`,
+      value: 2n,
+    };
+
+    const { txHash: txHash2 } = await gasUtils.sendTransaction(request2);
+    const tx2 = await l1Client.getTransaction({ hash: txHash2 });
+
+    // Verify transactions have different nonces
+    expect(tx2.nonce).toBe(tx1.nonce + 1);
+
+    // Mine blocks to process both transactions
+    await cheatCodes.evmMine();
+    await cheatCodes.evmMine();
+
+    // Both transactions should be mined
+    const receipt1 = await l1Client.getTransactionReceipt({ hash: txHash1 });
+    const receipt2 = await l1Client.getTransactionReceipt({ hash: txHash2 });
+    expect(receipt1.status).toBe('success');
+    expect(receipt2.status).toBe('success');
+  }, 20_000);
+
+  it('clears stale pending request when nonce has advanced', async () => {
+    // Create gas utils with replacePreviousPendingTx enabled
+    gasUtils = new L1TxUtils(l1Client, logger, dateProvider, {
+      ...defaultL1TxUtilsConfig,
+      replacePreviousPendingTx: true,
+    });
+
+    // Disable mining to keep first transaction pending
+    await cheatCodes.setAutomine(false);
+    await cheatCodes.setIntervalMining(0);
+
+    // Send first transaction
+    const request1 = {
+      to: '0x1234567890123456789012345678901234567890' as `0x${string}`,
+      data: '0x1234' as `0x${string}`,
+      value: 1n,
+    };
+
+    const { txHash: txHash1 } = await gasUtils.sendTransaction(request1);
+    const tx1 = await l1Client.getTransaction({ hash: txHash1 });
+
+    // Mine the transaction
+    await cheatCodes.evmMine();
+
+    // Wait for receipt
+    const receipt1 = await l1Client.getTransactionReceipt({ hash: txHash1 });
+    expect(receipt1.status).toBe('success');
+
+    // Send second transaction (should get a new nonce since first is mined)
+    const request2 = {
+      to: '0xabcdefabcdefabcdefabcdefabcdefabcdefabcd' as `0x${string}`,
+      data: '0x5678' as `0x${string}`,
+      value: 2n,
+    };
+
+    const { txHash: txHash2 } = await gasUtils.sendTransaction(request2);
+    const tx2 = await l1Client.getTransaction({ hash: txHash2 });
+
+    // Verify the second transaction has a new nonce
+    expect(tx2.nonce).toBe(tx1.nonce + 1);
+  }, 20_000);
+
+  it('throws ReplacedL1TxError when transaction is replaced externally', async () => {
+    // Create gas utils
+    gasUtils = new L1TxUtils(l1Client, logger, dateProvider, {
+      ...defaultL1TxUtilsConfig,
+      checkIntervalMs: 100,
+      stallTimeMs: 10000,
+    });
+
+    // Disable mining to keep transactions pending
+    await cheatCodes.setAutomine(false);
+    await cheatCodes.setIntervalMining(0);
+
+    // Send first transaction
+    const request1 = {
+      to: '0x1234567890123456789012345678901234567890' as `0x${string}`,
+      data: '0x1234' as `0x${string}`,
+      value: 1n,
+    };
+
+    const { txHash: txHash1 } = await gasUtils.sendTransaction(request1);
+    const tx1 = await l1Client.getTransaction({ hash: txHash1 });
+
+    const monitorPromise = gasUtils.monitorTransaction(request1, txHash1, { gasLimit: tx1.gas! });
+
+    // Manually send a replacement transaction with the same nonce but different request
+    await l1Client.sendTransaction({
+      to: '0xdeadbeefdeadbeefdeadbeefdeadbeefdeadbeef' as `0x${string}`,
+      data: '0xdead' as `0x${string}`,
+      value: 10n,
+      nonce: tx1.nonce,
+      maxFeePerGas: tx1.maxFeePerGas! * 2n,
+      maxPriorityFeePerGas: tx1.maxPriorityFeePerGas! * 2n,
+      gas: 100_000n,
+    });
+
+    // Mine the replacement transaction
+    await cheatCodes.evmMine();
+
+    // Monitor should throw ReplacedL1TxError
+    await expect(monitorPromise).rejects.toThrow('was replaced by a different tx');
+  }, 20_000);
+
+  it('correctly handles multiple replacements with blob transactions', async () => {
+    // Create gas utils with replacePreviousPendingTx enabled
+    const blobGasUtils = new L1TxUtilsWithBlobs(l1Client, logger, dateProvider, {
+      ...defaultL1TxUtilsConfig,
+      replacePreviousPendingTx: true,
+      checkIntervalMs: 100,
+      stallTimeMs: 10000,
+    });
+
+    // Disable mining to keep transactions pending
+    await cheatCodes.setAutomine(false);
+    await cheatCodes.setIntervalMining(0);
+
+    // Create blob data
+    const blobData = new Uint8Array(131072).fill(1);
+    const kzg = Blob.getViemKzgInstance();
+
+    // Send first blob transaction
+    const request1 = {
+      to: '0x1234567890123456789012345678901234567890' as `0x${string}`,
+      data: '0x1234' as `0x${string}`,
+      value: 1n,
+    };
+
+    const { txHash: txHash1 } = await blobGasUtils.sendTransaction(request1, undefined, {
+      blobs: [blobData],
+      kzg,
+      maxFeePerBlobGas: 100n * WEI_CONST,
+    });
+    const tx1 = await l1Client.getTransaction({ hash: txHash1 });
+
+    // Send second blob transaction (should replace the first one)
+    const request2 = {
+      to: '0xabcdefabcdefabcdefabcdefabcdefabcdefabcd' as `0x${string}`,
+      data: '0x5678' as `0x${string}`,
+      value: 2n,
+    };
+
+    const { txHash: txHash2 } = await blobGasUtils.sendTransaction(request2, undefined, {
+      blobs: [blobData],
+      kzg,
+      maxFeePerBlobGas: 100n * WEI_CONST,
+    });
+    const tx2 = await l1Client.getTransaction({ hash: txHash2 });
+
+    // Verify both transactions have the same nonce
+    expect(tx2.nonce).toBe(tx1.nonce);
+
+    // Verify the second transaction has higher gas prices (including blob gas)
+    expect(tx2.maxFeePerGas!).toBeGreaterThan(tx1.maxFeePerGas!);
+    expect(tx2.maxPriorityFeePerGas!).toBeGreaterThan(tx1.maxPriorityFeePerGas!);
+    expect(tx2.maxFeePerBlobGas!).toBeGreaterThan(tx1.maxFeePerBlobGas!);
+
+    // Mine a block to process the transaction
+    await cheatCodes.evmMine();
+
+    // Only the second transaction should be mined
+    const receipt2 = await l1Client.getTransactionReceipt({ hash: txHash2 });
+    expect(receipt2.status).toBe('success');
+    expect(receipt2.blobGasUsed).toBeDefined();
+
+    // The first transaction should not exist anymore
+    await expect(l1Client.getTransaction({ hash: txHash1 })).rejects.toThrow();
+  }, 20_000);
+
+  it('clears pending request after successful monitoring', async () => {
+    // Create gas utils with replacePreviousPendingTx enabled
+    gasUtils = new L1TxUtils(l1Client, logger, dateProvider, {
+      ...defaultL1TxUtilsConfig,
+      replacePreviousPendingTx: true,
+    });
+
+    await cheatCodes.evmMine();
+    await cheatCodes.setAutomine(false);
+    await cheatCodes.setIntervalMining(1);
+
+    // Send and monitor a transaction
+    const request = {
+      to: '0x1234567890123456789012345678901234567890' as `0x${string}`,
+      data: '0x1234' as `0x${string}`,
+      value: 1n,
+    };
+
+    const { receipt } = await gasUtils.sendAndMonitorTransaction(request);
+    expect(receipt.status).toBe('success');
+
+    // Send another transaction - should get a new nonce
+    const request2 = {
+      to: '0xabcdefabcdefabcdefabcdefabcdefabcdefabcd' as `0x${string}`,
+      data: '0x5678' as `0x${string}`,
+      value: 2n,
+    };
+
+    const { txHash: txHash2 } = await gasUtils.sendTransaction(request2);
+    const tx2 = await l1Client.getTransaction({ hash: txHash2 });
+
+    // Verify it got a new nonce (not replacing anything)
+    expect(tx2.nonce).toBeGreaterThan(0);
+  }, 20_000);
 });

--- a/yarn-project/ethereum/src/l1_tx_utils.ts
+++ b/yarn-project/ethereum/src/l1_tx_utils.ts
@@ -548,7 +548,7 @@ type L1PendingTx = {
   attempts: number;
   nonce: number;
   gasPrice: GasPrice;
-  txHash?: Hex;
+  txHash: Hex | undefined;
 };
 
 export class L1TxUtils extends ReadOnlyL1TxUtils {
@@ -623,7 +623,7 @@ export class L1TxUtils extends ReadOnlyL1TxUtils {
         : baseTxRequestOpts;
 
       const viemRequest = await this.client.prepareTransactionRequest(txRequestOpts);
-      this.pendingRequest = { request, attempts: 0, nonce: viemRequest.nonce, gasPrice };
+      this.pendingRequest = { request, attempts: 0, nonce: viemRequest.nonce, gasPrice, txHash: undefined };
 
       const txHash = await this.client.sendTransaction(viemRequest);
       if (this.pendingRequest?.request === request) {
@@ -868,6 +868,12 @@ export class L1TxUtils extends ReadOnlyL1TxUtils {
             maxPriorityFeePerGas: newGasPrice.maxPriorityFeePerGas,
           });
 
+          if (this.pendingRequest && this.pendingRequest.request === request) {
+            this.pendingRequest.txHash = newHash;
+            this.pendingRequest.attempts = attempts;
+            this.pendingRequest.gasPrice = newGasPrice;
+          }
+
           const cleanGasConfig = pickBy(gasConfig, (_, key) => key in l1TxUtilsConfigMappings);
           this.logger?.verbose(`Sent L1 speed-up tx ${newHash}, replacing ${currentTxHash}`, {
             gasLimit: params.gasLimit,
@@ -1018,6 +1024,13 @@ export class L1TxUtils extends ReadOnlyL1TxUtils {
       maxFeePerGas: cancelGasPrice.maxFeePerGas,
       maxPriorityFeePerGas: cancelGasPrice.maxPriorityFeePerGas,
     });
+    this.pendingRequest = {
+      request,
+      attempts: attempts + 1,
+      nonce,
+      gasPrice: cancelGasPrice,
+      txHash: cancelTxHash,
+    };
 
     this.logger?.debug(`Sent cancellation tx ${cancelTxHash} for timed out tx ${currentTxHash}`, { nonce });
 

--- a/yarn-project/ethereum/src/l1_tx_utils.ts
+++ b/yarn-project/ethereum/src/l1_tx_utils.ts
@@ -552,7 +552,8 @@ type L1PendingTx = {
 };
 
 export class L1TxUtils extends ReadOnlyL1TxUtils {
-  private pendingRequest: L1PendingTx | undefined;
+  /** Latest pending tx. Exposed for testing purposes. */
+  public pendingRequest: L1PendingTx | undefined;
 
   constructor(
     public override client: ExtendedViemWalletClient,

--- a/yarn-project/ethereum/src/l1_tx_utils.ts
+++ b/yarn-project/ethereum/src/l1_tx_utils.ts
@@ -681,7 +681,7 @@ export class L1TxUtils extends ReadOnlyL1TxUtils {
 
     // If there is indeed a pending request, then replace it with the new one.
     if (this.pendingRequest) {
-      this.logger?.debug(
+      this.logger?.verbose(
         `Replacing previous pending transaction ${this.pendingRequest.txHash ?? this.pendingRequest.nonce} with new request`,
         { pending: this.pendingRequest, request },
       );

--- a/yarn-project/ethereum/src/l1_tx_utils.ts
+++ b/yarn-project/ethereum/src/l1_tx_utils.ts
@@ -106,6 +106,8 @@ export interface L1TxUtilsConfig {
    * Whether to attempt to cancel a tx if it's not mined after txTimeoutMs
    */
   cancelTxOnTimeout?: boolean;
+  /** True to replace the previous pending tx (if any) by using its same nonce. */
+  replacePreviousPendingTx?: boolean;
 }
 
 export const l1TxUtilsConfigMappings: ConfigMappingsType<L1TxUtilsConfig> = {
@@ -168,6 +170,10 @@ export const l1TxUtilsConfigMappings: ConfigMappingsType<L1TxUtilsConfig> = {
     description: "Whether to attempt to cancel a tx if it's not mined after txTimeoutMs",
     env: 'L1_TX_MONITOR_CANCEL_TX_ON_TIMEOUT',
     ...booleanConfigHelper(true),
+  },
+  replacePreviousPendingTx: {
+    description: 'True to replace the previous pending tx (if any) by using its same nonce.',
+    ...booleanConfigHelper(false),
   },
 };
 
@@ -537,7 +543,17 @@ export class ReadOnlyL1TxUtils {
   }
 }
 
+type L1PendingTx = {
+  request: L1TxRequest;
+  attempts: number;
+  nonce: number;
+  gasPrice: GasPrice;
+  txHash?: Hex;
+};
+
 export class L1TxUtils extends ReadOnlyL1TxUtils {
+  private pendingRequest: L1PendingTx | undefined;
+
   constructor(
     public override client: ExtendedViemWalletClient,
     protected override logger: Logger = createLogger('L1TxUtils'),
@@ -569,11 +585,11 @@ export class L1TxUtils extends ReadOnlyL1TxUtils {
    */
   public async sendTransaction(
     request: L1TxRequest,
-    _gasConfig?: L1GasConfig,
+    gasConfigOverrides?: L1GasConfig,
     blobInputs?: L1BlobInputs,
   ): Promise<{ txHash: Hex; gasLimit: bigint; gasPrice: GasPrice }> {
     try {
-      const gasConfig = { ...this.config, ..._gasConfig };
+      const gasConfig = { ...this.config, ...gasConfigOverrides };
       const account = this.client.account;
 
       let gasLimit: bigint;
@@ -584,32 +600,35 @@ export class L1TxUtils extends ReadOnlyL1TxUtils {
       } else {
         gasLimit = await this.estimateGas(account, request, gasConfig);
       }
-      this.logger?.debug(`Gas limit for request is ${gasLimit}`, { gasLimit, ...request });
 
-      const gasPrice = await this.getGasPrice(gasConfig, !!blobInputs);
+      this.logger?.debug(`Computed gas limit for L1 tx request is ${gasLimit}`, { gasLimit, request });
 
       if (gasConfig.txTimeoutAt && this.dateProvider.now() > gasConfig.txTimeoutAt.getTime()) {
         throw new Error('Transaction timed out before sending');
       }
 
-      let txHash: Hex;
-      if (blobInputs) {
-        txHash = await this.client.sendTransaction({
-          ...request,
-          ...blobInputs,
-          gas: gasLimit,
-          maxFeePerGas: gasPrice.maxFeePerGas,
-          maxPriorityFeePerGas: gasPrice.maxPriorityFeePerGas,
-          maxFeePerBlobGas: gasPrice.maxFeePerBlobGas!,
-        });
-      } else {
-        txHash = await this.client.sendTransaction({
-          ...request,
-          gas: gasLimit,
-          maxFeePerGas: gasPrice.maxFeePerGas,
-          maxPriorityFeePerGas: gasPrice.maxPriorityFeePerGas,
-        });
+      const { gasPrice, nonce } = await this.getTxOpts(request, gasConfig, blobInputs);
+
+      const baseTxRequestOpts = {
+        ...request,
+        gas: gasLimit,
+        maxFeePerGas: gasPrice.maxFeePerGas,
+        maxPriorityFeePerGas: gasPrice.maxPriorityFeePerGas,
+        nonce,
+      };
+
+      const txRequestOpts = blobInputs
+        ? { ...blobInputs, ...baseTxRequestOpts, maxFeePerBlobGas: gasPrice.maxFeePerBlobGas! }
+        : baseTxRequestOpts;
+
+      const viemRequest = await this.client.prepareTransactionRequest(txRequestOpts);
+      this.pendingRequest = { request, attempts: 0, nonce: viemRequest.nonce, gasPrice };
+
+      const txHash = await this.client.sendTransaction(viemRequest);
+      if (this.pendingRequest?.request === request) {
+        this.pendingRequest.txHash = txHash;
       }
+
       const cleanGasConfig = pickBy(gasConfig, (_, key) => key in l1TxUtilsConfigMappings);
       this.logger?.verbose(`Sent L1 transaction ${txHash}`, {
         gasLimit,
@@ -627,6 +646,54 @@ export class L1TxUtils extends ReadOnlyL1TxUtils {
       });
       throw viemError;
     }
+  }
+
+  private async getTxOpts(request: L1TxRequest, gasConfig?: L1GasConfig, blobInputs?: L1BlobInputs) {
+    const getDefaultTxOpts = async () => ({
+      gasPrice: await this.getGasPrice(gasConfig, !!blobInputs),
+      nonce: undefined,
+    });
+
+    // If we dont care about replacing the previous pending tx, just return the gas price
+    if (!this.config.replacePreviousPendingTx) {
+      return getDefaultTxOpts();
+    }
+
+    // Otherwise, first check if the pending request is still pending; if not, clear it.
+    // TODO(palla/txs): It could be the case that, if we rebooted the node recently, we lost track of the pendingRequest.
+    // We could detect that by comparing the latest and pending nonces, if they differ, it means there are outstanding pending txs.
+    // Issue is we have no way of retrieving that pending tx (since eth_getTransactionBySenderAndNonce is not standard yet), so
+    // we should persist the tx request to db.
+    if (this.pendingRequest) {
+      const currentNonce = await this.client.getTransactionCount({
+        address: this.client.account.address,
+        blockTag: 'latest',
+      });
+      if (currentNonce > this.pendingRequest.nonce) {
+        this.logger?.debug(
+          `Clearing pending tx request with nonce ${this.pendingRequest.nonce} since current nonce is ${currentNonce}`,
+          { pending: this.pendingRequest, currentNonce },
+        );
+        this.pendingRequest = undefined;
+      }
+    }
+
+    // If there is indeed a pending request, then replace it with the new one.
+    if (this.pendingRequest) {
+      this.logger?.debug(
+        `Replacing previous pending transaction ${this.pendingRequest.txHash ?? this.pendingRequest.nonce} with new request`,
+        { pending: this.pendingRequest, request },
+      );
+      const gasPrice = await this.getGasPrice(
+        gasConfig,
+        !!blobInputs,
+        this.pendingRequest.attempts + 1,
+        this.pendingRequest.gasPrice,
+      );
+      return { gasPrice, nonce: this.pendingRequest.nonce };
+    }
+
+    return getDefaultTxOpts();
   }
 
   /**
@@ -713,6 +780,9 @@ export class L1TxUtils extends ReadOnlyL1TxUtils {
                 } else {
                   this.logger?.debug(`L1 transaction ${hash} mined`);
                 }
+                if (this.pendingRequest && this.pendingRequest.request === request) {
+                  this.pendingRequest = undefined; // Clear pending request if we find the receipt
+                }
                 return receipt;
               }
             } catch (err) {
@@ -721,6 +791,12 @@ export class L1TxUtils extends ReadOnlyL1TxUtils {
               }
             }
           }
+          // If the nonce has changed but we cannot find the receipt, it means the transaction was replaced by another transaction
+          // not sent as part of this monitoring process, so we throw an error, since the original request could not be fulfilled.
+          throw new ReplacedL1TxError(
+            `L1 transaction ${currentTxHash} was replaced by a different tx with nonce ${currentNonce}.`,
+            currentNonce,
+          );
         }
 
         this.logger?.trace(`Tx timeout check for ${currentTxHash}: ${isTimedOut()}`, {
@@ -807,6 +883,10 @@ export class L1TxUtils extends ReadOnlyL1TxUtils {
         }
         await sleep(gasConfig.checkIntervalMs!);
       } catch (err: any) {
+        if (err instanceof ReplacedL1TxError) {
+          this.logger?.debug(`L1 transaction ${currentTxHash} replaced by a different tx with nonce ${err.nonce}`);
+          throw err;
+        }
         const viemError = formatViemError(err);
         this.logger?.warn(`Error monitoring L1 transaction ${currentTxHash}:`, viemError.message);
         if (viemError.message?.includes('reverted')) {
@@ -821,10 +901,12 @@ export class L1TxUtils extends ReadOnlyL1TxUtils {
     if (!isCancelTx && gasConfig.cancelTxOnTimeout) {
       // Fire cancellation without awaiting to avoid blocking the main thread
       this.attemptTxCancellation(currentTxHash, nonce, isBlobTx, lastGasPrice, attempts).catch(err => {
-        const viemError = formatViemError(err);
-        this.logger?.error(`Failed to send cancellation for timed out tx ${currentTxHash}:`, viemError.message, {
-          metaMessages: viemError.metaMessages,
-        });
+        if (!(err instanceof ReplacedL1TxError)) {
+          const viemError = formatViemError(err);
+          this.logger?.error(`Failed to send cancellation for timed out tx ${currentTxHash}:`, viemError.message, {
+            metaMessages: viemError.metaMessages,
+          });
+        }
       });
     }
 
@@ -962,4 +1044,14 @@ export function tryGetCustomErrorNameContractFunction(err: ContractFunctionExecu
  */
 export function getCalldataGasUsage(data: Uint8Array) {
   return data.filter(byte => byte === 0).length * 4 + data.filter(byte => byte !== 0).length * 16;
+}
+
+export class ReplacedL1TxError extends Error {
+  constructor(
+    message: string,
+    public readonly nonce?: number,
+  ) {
+    super(message);
+    this.name = 'ReplacedL1TxError';
+  }
 }


### PR DESCRIPTION
Adds a config to `L1TxUtils` to replace the previous tx if there is a pending one.

Builds on #15712