### PR TITLE
feat: `derive_serialize`, `derive_deserialize` and `derive_packable` generics support

### DIFF
--- a/noir-projects/noir-protocol-circuits/crates/types/src/abis/log.nr
+++ b/noir-projects/noir-protocol-circuits/crates/types/src/abis/log.nr
@@ -1,7 +1,7 @@
 use crate::traits::{Deserialize, Empty, Serialize};
 use std::meta::derive;
 
-#[derive(Eq)]
+#[derive(Eq, Serialize)]
 pub struct Log<let N: u32> {
     pub fields: [Field; N],
     // The actual length (number of fields) of the log to be included in the blobs.
@@ -17,27 +17,6 @@ impl<let N: u32> Log<N> {
 impl<let N: u32> Empty for Log<N> {
     fn empty() -> Log<N> {
         Log { fields: [0; N], length: 0 }
-    }
-}
-
-// Note: We currently don't support derivation of Serialize and Deserialize traits for types with generics so we have
-// the manual implementation below.
-impl<let N: u32> Serialize for Log<N> {
-    let N: u32 = N + 1; // +1 for length field
-
-    #[inline_always]
-    fn serialize(self) -> [Field; Self::N] {
-        let mut result = [0; Self::N];
-
-        // Copy log fields
-        for i in 0..N {
-            result[i] = self.fields[i];
-        }
-
-        // Store length as last field
-        result[N] = self.length as Field;
-
-        result
     }
 }
 

--- a/noir-projects/noir-protocol-circuits/crates/types/src/abis/log.nr
+++ b/noir-projects/noir-protocol-circuits/crates/types/src/abis/log.nr
@@ -1,7 +1,7 @@
 use crate::traits::{Deserialize, Empty, Serialize};
 use std::meta::derive;
 
-#[derive(Eq, Serialize)]
+#[derive(Deserialize, Eq, Serialize)]
 pub struct Log<let N: u32> {
     pub fields: [Field; N],
     // The actual length (number of fields) of the log to be included in the blobs.
@@ -17,24 +17,5 @@ impl<let N: u32> Log<N> {
 impl<let N: u32> Empty for Log<N> {
     fn empty() -> Log<N> {
         Log { fields: [0; N], length: 0 }
-    }
-}
-
-impl<let N: u32> Deserialize for Log<N> {
-    let N: u32 = N + 1; // +1 for length field
-
-    #[inline_always]
-    fn deserialize(fields: [Field; Self::N]) -> Self {
-        let mut log_fields = [0; N];
-
-        // Copy log fields
-        for i in 0..N {
-            log_fields[i] = fields[i];
-        }
-
-        // Get length from last field
-        let length = fields[N] as u32;
-
-        Self { fields: log_fields, length }
     }
 }

--- a/noir-projects/noir-protocol-circuits/crates/types/src/meta/mod.nr
+++ b/noir-projects/noir-protocol-circuits/crates/types/src/meta/mod.nr
@@ -111,7 +111,7 @@ pub comptime fn derive_serialize(s: TypeDefinition) -> Quoted {
         .join(quote {});
 
     quote {
-        impl $crate::traits::Serialize for $typ {
+        impl$generics_declarations $crate::traits::Serialize for $typ {
             let N: u32 = $right_hand_side_of_definition_of_n;
 
             #[inline_always]
@@ -131,6 +131,8 @@ pub(crate) comptime fn derive_deserialize(s: TypeDefinition) -> Quoted {
     let typ = s.as_type();
     let nested_struct = typ.as_data_type().unwrap();
     let params = nested_struct.0.fields(nested_struct.1);
+
+    let generics_declarations = get_generics_declarations(s);
 
     // The following will give us <type_of_struct_member_1 as Deserialize>::N + <type_of_struct_member_2 as Deserialize>::N + ...
     let right_hand_side_of_definition_of_n = params
@@ -162,7 +164,7 @@ pub(crate) comptime fn derive_deserialize(s: TypeDefinition) -> Quoted {
         .join(quote {,});
 
     quote {
-        impl $crate::traits::Deserialize for $typ {
+        impl$generics_declarations $crate::traits::Deserialize for $typ {
             let N: u32 = $right_hand_side_of_definition_of_n;
 
             #[inline_always]

--- a/noir-projects/noir-protocol-circuits/crates/types/src/meta/mod.nr
+++ b/noir-projects/noir-protocol-circuits/crates/types/src/meta/mod.nr
@@ -1,14 +1,37 @@
+/// Generates the generic parameter declarations for a struct's trait implementation.
+///
+/// This function takes a struct type definition and generates the generic parameter declarations
+/// that go after the `impl` keyword. For example, given a struct with generics `N: u32` and `T`,
+/// it generates `<let N: u32, T>`.
+///
+/// # Parameters
+/// - `s`: The struct type definition to generate generic declarations for
+///
+/// # Returns
+/// A quoted code block containing the generic parameter declarations, or an empty quote if the struct
+/// has no generic parameters
+///
+/// # Example
+/// For a struct defined as:
+/// ```
+/// struct Container<T, let N: u32> {
+///     items: [T; N],
+///     count: u32
+/// }
+/// ```
+///
+/// This function generates:
+/// ```
+/// <let N: u32, T>
+/// ```
 comptime fn get_generics_declarations(s: TypeDefinition) -> Quoted {
     let generics = s.generics();
 
-    // Constructs the "<let N: u32, let M: u8>" string that is injected after the "impl" keyword in e.g.
-    // "impl<let N: u32, let M: u8> Serialize for Foo<N, M>".
-    // Returns an empty quote if the struct has no generics.
     if generics.len() > 0 {
         let generics_declarations_items = generics
             .map(|(name, maybe_integer_typ)| {
-                // The second item in the generics tuple is an Option of an integer type that is Some if the generic is
-                //numeric.
+                // The second item in the generics tuple is an Option of an integer type that is Some only if
+                // the generic is numeric.
                 if maybe_integer_typ.is_some() {
                     // The generic is numeric, so we return a quote defined as e.g. "let N: u32"
                     let integer_type = maybe_integer_typ.unwrap();
@@ -26,10 +49,36 @@ comptime fn get_generics_declarations(s: TypeDefinition) -> Quoted {
     }
 }
 
+/// Generates the `where` clause for a trait implementation that constrains non-numeric generic type parameters.
+///
+/// This function takes a struct type definition and a trait name, and generates a `where` clause that
+/// requires all non-numeric generic type parameters to implement the specified trait.
+///
+/// # Parameters
+/// - `s`: The struct type definition to generate the where clause for
+/// - `trait_name`: The name of the trait that non-numeric generic parameters must implement
+///
+/// # Returns
+/// A quoted code block containing the where clause, or an empty quote if the struct has no non-numeric
+/// generic parameters
+///
+/// # Example
+/// For a struct defined as:
+/// ```
+/// struct Container<T, let N: u32> {
+///     items: [T; N],
+///     count: u32
+/// }
+/// ```
+///
+/// And trait name "Serialize", this function generates:
+/// ```
+/// where T: Serialize
+/// ```
 comptime fn get_where_trait_clause(s: TypeDefinition, trait_name: Quoted) -> Quoted {
     let generics = s.generics();
 
-    // The second item in the generics tuple is an Option of an integer type that is Some if the generic is
+    // The second item in the generics tuple is an Option of an integer type that is Some only if the generic is
     // numeric.
     let non_numeric_generics =
         generics.filter(|(_, maybe_integer_typ)| maybe_integer_typ.is_none());

--- a/noir-projects/noir-protocol-circuits/crates/types/src/meta/mod.nr
+++ b/noir-projects/noir-protocol-circuits/crates/types/src/meta/mod.nr
@@ -143,6 +143,8 @@ pub comptime fn derive_serialize(s: TypeDefinition) -> Quoted {
     let nested_struct = typ.as_data_type().unwrap();
     let params = nested_struct.0.fields(nested_struct.1);
 
+    // Generates the generic parameter declarations (to be placed after the `impl` keyword) and the `where` clause
+    // for the `Serialize` trait.
     let generics_declarations = get_generics_declarations(s);
     let where_serialize_clause = get_where_trait_clause(s, quote {Serialize});
 
@@ -241,6 +243,8 @@ pub(crate) comptime fn derive_deserialize(s: TypeDefinition) -> Quoted {
     let nested_struct = typ.as_data_type().unwrap();
     let params = nested_struct.0.fields(nested_struct.1);
 
+    // Generates the generic parameter declarations (to be placed after the `impl` keyword) and the `where` clause
+    // for the `Deserialize` trait.
     let generics_declarations = get_generics_declarations(s);
     let where_deserialize_clause = get_where_trait_clause(s, quote {Deserialize});
 
@@ -361,6 +365,11 @@ pub comptime fn derive_packable(s: TypeDefinition) -> Quoted {
     let nested_struct = typ.as_data_type().unwrap();
     let params = nested_struct.0.fields(nested_struct.1);
 
+    // Generates the generic parameter declarations (to be placed after the `impl` keyword) and the `where` clause
+    // for the `Packable` trait.
+    let generics_declarations = get_generics_declarations(s);
+    let where_packable_clause = get_where_trait_clause(s, quote {Packable});
+
     // The following will give us <type_of_struct_member_1 as Packable>::N + <type_of_struct_member_2 as Packable>::N + ...
     let right_hand_side_of_definition_of_n = params
         .map(|(_, param_type, _): (Quoted, Type, Quoted)| {
@@ -407,7 +416,9 @@ pub comptime fn derive_packable(s: TypeDefinition) -> Quoted {
         .join(quote {,});
 
     quote {
-        impl $crate::traits::Packable for $typ {
+        impl$generics_declarations $crate::traits::Packable for $typ
+            $where_packable_clause
+        {
             let N: u32 = $right_hand_side_of_definition_of_n;
 
             fn pack(self) -> [Field; Self::N] {
@@ -431,22 +442,21 @@ pub comptime fn derive_packable(s: TypeDefinition) -> Quoted {
 }
 
 mod test {
-
     use crate::traits::{Deserialize, Packable, Serialize};
 
-    #[derive(Packable, Serialize, Deserialize, Eq)]
+    #[derive(Deserialize, Eq, Packable, Serialize)]
     pub struct Smol {
         a: Field,
         b: Field,
     }
 
-    #[derive(Serialize, Deserialize, Eq)]
+    #[derive(Deserialize, Eq, Serialize)]
     pub struct HasArray {
         a: [Field; 2],
         b: bool,
     }
 
-    #[derive(Serialize, Deserialize, Eq)]
+    #[derive(Deserialize, Eq, Serialize)]
     pub struct Fancier {
         a: Smol,
         b: [Field; 2],
@@ -454,18 +464,14 @@ mod test {
         d: str<16>,
     }
 
-    #[derive(Serialize, Deserialize, Eq)]
-    pub struct ContainsArrayWithGenerics<T, let N: u32> {
+    #[derive(Deserialize, Eq, Packable, Serialize)]
+    pub struct HasArrayWithGenerics<T, let N: u32> {
         pub fields: [T; N],
         pub length: u32,
     }
 
-    fn main() {
-        assert(false);
-    }
-
     #[test]
-    fn smol_test() {
+    fn serde_on_smol() {
         let smol = Smol { a: 1, b: 2 };
         let serialized = smol.serialize();
         assert(serialized == [1, 2], serialized);
@@ -478,7 +484,7 @@ mod test {
     }
 
     #[test]
-    fn has_array_test() {
+    fn serde_on_has_array() {
         let has_array = HasArray { a: [1, 2], b: true };
         let serialized = has_array.serialize();
         assert(serialized == [1, 2, 1], serialized);
@@ -487,7 +493,7 @@ mod test {
     }
 
     #[test]
-    fn fancier_test() {
+    fn serde_on_fancier() {
         let fancier =
             Fancier { a: Smol { a: 1, b: 2 }, b: [0, 1], c: [1, 2, 3], d: "metaprogramming!" };
         let serialized = fancier.serialize();
@@ -504,13 +510,22 @@ mod test {
     }
 
     #[test]
-    fn struct_with_array_of_generics_test() {
-        let struct_with_array_of_generics =
-            ContainsArrayWithGenerics { fields: [1, 2, 3], length: 3 };
+    fn serde_on_contains_array_with_generics() {
+        let struct_with_array_of_generics = HasArrayWithGenerics { fields: [1, 2, 3], length: 3 };
         let serialized = struct_with_array_of_generics.serialize();
         assert(serialized == [1, 2, 3, 3], serialized);
-        let deserialized = ContainsArrayWithGenerics::deserialize(serialized);
+        let deserialized = HasArrayWithGenerics::deserialize(serialized);
         assert(deserialized == struct_with_array_of_generics);
+    }
+
+    #[test]
+    fn packable_on_contains_array_with_generics() {
+        let struct_with_array_of_generics = HasArrayWithGenerics { fields: [1, 2, 3], length: 3 };
+        let packed = struct_with_array_of_generics.pack();
+        assert(packed == [1, 2, 3, 3], packed);
+
+        let unpacked = HasArrayWithGenerics::unpack(packed);
+        assert(unpacked == struct_with_array_of_generics);
     }
 
 }

--- a/noir-projects/noir-protocol-circuits/crates/types/src/meta/mod.nr
+++ b/noir-projects/noir-protocol-circuits/crates/types/src/meta/mod.nr
@@ -1,5 +1,3 @@
-use super::traits::{Deserialize, Packable, Serialize};
-
 comptime fn get_generics_declarations(s: TypeDefinition) -> Quoted {
     let generics = s.generics();
 
@@ -28,7 +26,7 @@ comptime fn get_generics_declarations(s: TypeDefinition) -> Quoted {
     }
 }
 
-comptime fn get_where_serialize_clause(s: TypeDefinition) -> Quoted {
+comptime fn get_where_trait_clause(s: TypeDefinition, trait_name: Quoted) -> Quoted {
     let generics = s.generics();
 
     // The second item in the generics tuple is an Option of an integer type that is Some if the generic is
@@ -38,7 +36,7 @@ comptime fn get_where_serialize_clause(s: TypeDefinition) -> Quoted {
 
     if non_numeric_generics.len() > 0 {
         let non_numeric_generics_declarations =
-            non_numeric_generics.map(|(name, _)| quote {$name: Serialize}).join(quote {,});
+            non_numeric_generics.map(|(name, _)| quote {$name: $trait_name}).join(quote {,});
         quote {where $non_numeric_generics_declarations}
     } else {
         // There are no non-numeric generics, so we return an empty quote.
@@ -97,7 +95,7 @@ pub comptime fn derive_serialize(s: TypeDefinition) -> Quoted {
     let params = nested_struct.0.fields(nested_struct.1);
 
     let generics_declarations = get_generics_declarations(s);
-    let where_serialize_clause = get_where_serialize_clause(s);
+    let where_serialize_clause = get_where_trait_clause(s, quote {Serialize});
 
     // The following will give us <type_of_struct_member_1 as Serialize>::N + <type_of_struct_member_2 as Serialize>::N + ...
     let right_hand_side_of_definition_of_n = params
@@ -150,6 +148,7 @@ pub(crate) comptime fn derive_deserialize(s: TypeDefinition) -> Quoted {
     let params = nested_struct.0.fields(nested_struct.1);
 
     let generics_declarations = get_generics_declarations(s);
+    let where_deserialize_clause = get_where_trait_clause(s, quote {Deserialize});
 
     // The following will give us <type_of_struct_member_1 as Deserialize>::N + <type_of_struct_member_2 as Deserialize>::N + ...
     let right_hand_side_of_definition_of_n = params
@@ -181,7 +180,9 @@ pub(crate) comptime fn derive_deserialize(s: TypeDefinition) -> Quoted {
         .join(quote {,});
 
     quote {
-        impl$generics_declarations $crate::traits::Deserialize for $typ {
+        impl$generics_declarations $crate::traits::Deserialize for $typ
+            $where_deserialize_clause
+        {
             let N: u32 = $right_hand_side_of_definition_of_n;
 
             #[inline_always]
@@ -335,71 +336,87 @@ pub comptime fn derive_packable(s: TypeDefinition) -> Quoted {
     }
 }
 
-#[derive(Packable, Serialize, Deserialize, Eq)]
-pub struct Smol {
-    a: Field,
-    b: Field,
-}
+mod test {
 
-#[derive(Serialize, Deserialize, Eq)]
-pub struct HasArray {
-    a: [Field; 2],
-    b: bool,
-}
+    use crate::traits::{Deserialize, Packable, Serialize};
 
-#[derive(Serialize, Deserialize, Eq)]
-pub struct Fancier {
-    a: Smol,
-    b: [Field; 2],
-    c: [u8; 3],
-    d: str<16>,
-}
+    #[derive(Packable, Serialize, Deserialize, Eq)]
+    pub struct Smol {
+        a: Field,
+        b: Field,
+    }
 
-#[derive(Serialize)]
-pub struct ContainsArrayWithGenerics<T, let N: u32> {
-    pub fields: [T; N],
-    pub length: u32,
-}
+    #[derive(Serialize, Deserialize, Eq)]
+    pub struct HasArray {
+        a: [Field; 2],
+        b: bool,
+    }
 
-fn main() {
-    assert(false);
-}
+    #[derive(Serialize, Deserialize, Eq)]
+    pub struct Fancier {
+        a: Smol,
+        b: [Field; 2],
+        c: [u8; 3],
+        d: str<16>,
+    }
 
-#[test]
-fn smol_test() {
-    let smol = Smol { a: 1, b: 2 };
-    let serialized = smol.serialize();
-    assert(serialized == [1, 2], serialized);
-    let deserialized = Smol::deserialize(serialized);
-    assert(deserialized == smol);
+    #[derive(Serialize, Deserialize, Eq)]
+    pub struct ContainsArrayWithGenerics<T, let N: u32> {
+        pub fields: [T; N],
+        pub length: u32,
+    }
 
-    // None of the struct members implements the `Packable` trait so the packed and serialized data should be the same
-    let packed = smol.pack();
-    assert_eq(packed, serialized, "Packed does not match serialized");
-}
+    fn main() {
+        assert(false);
+    }
 
-#[test]
-fn has_array_test() {
-    let has_array = HasArray { a: [1, 2], b: true };
-    let serialized = has_array.serialize();
-    assert(serialized == [1, 2, 1], serialized);
-    let deserialized = HasArray::deserialize(serialized);
-    assert(deserialized == has_array);
-}
+    #[test]
+    fn smol_test() {
+        let smol = Smol { a: 1, b: 2 };
+        let serialized = smol.serialize();
+        assert(serialized == [1, 2], serialized);
+        let deserialized = Smol::deserialize(serialized);
+        assert(deserialized == smol);
 
-#[test]
-fn fancier_test() {
-    let fancier =
-        Fancier { a: Smol { a: 1, b: 2 }, b: [0, 1], c: [1, 2, 3], d: "metaprogramming!" };
-    let serialized = fancier.serialize();
-    assert(
-        serialized
-            == [
-                1, 2, 0, 1, 1, 2, 3, 0x6d, 0x65, 0x74, 0x61, 0x70, 0x72, 0x6f, 0x67, 0x72, 0x61,
-                0x6d, 0x6d, 0x69, 0x6e, 0x67, 0x21,
-            ],
-        serialized,
-    );
-    let deserialized = Fancier::deserialize(serialized);
-    assert(deserialized == fancier);
+        // None of the struct members implements the `Packable` trait so the packed and serialized data should be the same
+        let packed = smol.pack();
+        assert_eq(packed, serialized, "Packed does not match serialized");
+    }
+
+    #[test]
+    fn has_array_test() {
+        let has_array = HasArray { a: [1, 2], b: true };
+        let serialized = has_array.serialize();
+        assert(serialized == [1, 2, 1], serialized);
+        let deserialized = HasArray::deserialize(serialized);
+        assert(deserialized == has_array);
+    }
+
+    #[test]
+    fn fancier_test() {
+        let fancier =
+            Fancier { a: Smol { a: 1, b: 2 }, b: [0, 1], c: [1, 2, 3], d: "metaprogramming!" };
+        let serialized = fancier.serialize();
+        assert(
+            serialized
+                == [
+                    1, 2, 0, 1, 1, 2, 3, 0x6d, 0x65, 0x74, 0x61, 0x70, 0x72, 0x6f, 0x67, 0x72, 0x61,
+                    0x6d, 0x6d, 0x69, 0x6e, 0x67, 0x21,
+                ],
+            serialized,
+        );
+        let deserialized = Fancier::deserialize(serialized);
+        assert(deserialized == fancier);
+    }
+
+    #[test]
+    fn struct_with_array_of_generics_test() {
+        let struct_with_array_of_generics =
+            ContainsArrayWithGenerics { fields: [1, 2, 3], length: 3 };
+        let serialized = struct_with_array_of_generics.serialize();
+        assert(serialized == [1, 2, 3, 3], serialized);
+        let deserialized = ContainsArrayWithGenerics::deserialize(serialized);
+        assert(deserialized == struct_with_array_of_generics);
+    }
+
 }

--- a/noir-projects/noir-protocol-circuits/crates/types/src/meta/mod.nr
+++ b/noir-projects/noir-protocol-circuits/crates/types/src/meta/mod.nr
@@ -3,27 +3,45 @@ use super::traits::{Deserialize, Packable, Serialize};
 comptime fn get_generics_declarations(s: TypeDefinition) -> Quoted {
     let generics = s.generics();
 
-    // We check that each generic's second tuple field (maybe_numeric_generic) is Some,
-    // which indicates it's a numeric generic parameter (like N in Foo<N>).
-    // Non-numeric generics (like T in Foo<T>) would have None in this field.
-    // derive_serialize requires all generics to be numeric.
-    generics.for_each(|(_, maybe_numeric_generic)| {
-        assert(maybe_numeric_generic.is_some(), "All generic parameters must be numeric");
-    });
-
     // Constructs the "<let N: u32, let M: u8>" string that is injected after the "impl" keyword in e.g.
     // "impl<let N: u32, let M: u8> Serialize for Foo<N, M>".
     // Returns an empty quote if the struct has no generics.
     if generics.len() > 0 {
         let generics_declarations_items = generics
-            .map(|(name, typ)| {
-                let integer_type = typ.unwrap();
-                quote {let $name: $integer_type}
+            .map(|(name, maybe_integer_typ)| {
+                // The second item in the generics tuple is an Option of an integer type that is Some if the generic is
+                //numeric.
+                if maybe_integer_typ.is_some() {
+                    // The generic is numeric, so we return a quote defined as e.g. "let N: u32"
+                    let integer_type = maybe_integer_typ.unwrap();
+                    quote {let $name: $integer_type}
+                } else {
+                    // The generic is not numeric, so we return a quote containing the name of the generic (e.g. "T")
+                    quote {$name}
+                }
             })
             .join(quote {,});
         quote {<$generics_declarations_items>}
     } else {
         // The struct doesn't have any generics defined, so we just return an empty quote.
+        quote {}
+    }
+}
+
+comptime fn get_where_serialize_clause(s: TypeDefinition) -> Quoted {
+    let generics = s.generics();
+
+    // The second item in the generics tuple is an Option of an integer type that is Some if the generic is
+    // numeric.
+    let non_numeric_generics =
+        generics.filter(|(_, maybe_integer_typ)| maybe_integer_typ.is_none());
+
+    if non_numeric_generics.len() > 0 {
+        let non_numeric_generics_declarations =
+            non_numeric_generics.map(|(name, _)| quote {$name: Serialize}).join(quote {,});
+        quote {where $non_numeric_generics_declarations}
+    } else {
+        // There are no non-numeric generics, so we return an empty quote.
         quote {}
     }
 }
@@ -73,16 +91,13 @@ comptime fn get_generics_declarations(s: TypeDefinition) -> Quoted {
 ///     }
 /// }
 /// ```
-///
-/// TODO(benesjan): does this make sense? Can we just slap there the non-numeric generics?
-/// Note that numeric generic parameters (like `N` in `Log<N>`) are supported.
-/// Non-numeric generic parameters (like `T` in `Container<T>`) are not supported.
 pub comptime fn derive_serialize(s: TypeDefinition) -> Quoted {
     let typ = s.as_type();
     let nested_struct = typ.as_data_type().unwrap();
     let params = nested_struct.0.fields(nested_struct.1);
 
     let generics_declarations = get_generics_declarations(s);
+    let where_serialize_clause = get_where_serialize_clause(s);
 
     // The following will give us <type_of_struct_member_1 as Serialize>::N + <type_of_struct_member_2 as Serialize>::N + ...
     let right_hand_side_of_definition_of_n = params
@@ -111,7 +126,9 @@ pub comptime fn derive_serialize(s: TypeDefinition) -> Quoted {
         .join(quote {});
 
     quote {
-        impl$generics_declarations $crate::traits::Serialize for $typ {
+        impl$generics_declarations $crate::traits::Serialize for $typ
+            $where_serialize_clause
+        {
             let N: u32 = $right_hand_side_of_definition_of_n;
 
             #[inline_always]
@@ -336,6 +353,12 @@ pub struct Fancier {
     b: [Field; 2],
     c: [u8; 3],
     d: str<16>,
+}
+
+#[derive(Serialize)]
+pub struct ContainsArrayWithGenerics<T, let N: u32> {
+    pub fields: [T; N],
+    pub length: u32,
 }
 
 fn main() {

--- a/noir-projects/noir-protocol-circuits/crates/types/src/meta/mod.nr
+++ b/noir-projects/noir-protocol-circuits/crates/types/src/meta/mod.nr
@@ -191,6 +191,51 @@ pub comptime fn derive_serialize(s: TypeDefinition) -> Quoted {
     }
 }
 
+/// Generates a `Deserialize` trait implementation for a given struct `s`.
+///
+/// # Arguments
+/// * `s` - The struct type definition to generate the implementation for
+///
+/// # Returns
+/// A `Quoted` block containing the generated trait implementation
+///
+/// # Requirements
+/// Each struct member type must implement the `Deserialize` trait (it gets used in the generated code).
+///
+/// # Example
+/// For a struct like:
+/// ```
+/// struct MyStruct {
+///     x: AztecAddress,
+///     y: Field,
+/// }
+/// ```
+///
+/// This generates:
+/// ```
+/// impl Deserialize for MyStruct {
+///     let N: u32 = <AztecAddress as Deserialize>::N + <Field as Deserialize>::N;
+///
+///     fn deserialize(serialized: [Field; Self::N]) -> Self {
+///         let mut offset = 0;
+///         let mut member_fields = [0; <AztecAddress as Deserialize>::N];
+///         for i in 0..<AztecAddress as Deserialize>::N {
+///             member_fields[i] = serialized[i + offset];
+///         }
+///         let x = <AztecAddress as Deserialize>::deserialize(member_fields);
+///         offset += <AztecAddress as Deserialize>::N;
+///
+///         let mut member_fields = [0; <Field as Deserialize>::N];
+///         for i in 0..<Field as Deserialize>::N {
+///             member_fields[i] = serialized[i + offset];
+///         }
+///         let y = <Field as Deserialize>::deserialize(member_fields);
+///         offset += <Field as Deserialize>::N;
+///
+///         Self { x, y }
+///     }
+/// }
+/// ```
 pub(crate) comptime fn derive_deserialize(s: TypeDefinition) -> Quoted {
     let typ = s.as_type();
     let nested_struct = typ.as_data_type().unwrap();

--- a/noir-projects/noir-protocol-circuits/crates/types/src/meta/mod.nr
+++ b/noir-projects/noir-protocol-circuits/crates/types/src/meta/mod.nr
@@ -1,9 +1,88 @@
 use super::traits::{Deserialize, Packable, Serialize};
 
+comptime fn get_generics_declarations(s: TypeDefinition) -> Quoted {
+    let generics = s.generics();
+
+    // We check that each generic's second tuple field (maybe_numeric_generic) is Some,
+    // which indicates it's a numeric generic parameter (like N in Foo<N>).
+    // Non-numeric generics (like T in Foo<T>) would have None in this field.
+    // derive_serialize requires all generics to be numeric.
+    generics.for_each(|(_, maybe_numeric_generic)| {
+        assert(maybe_numeric_generic.is_some(), "All generic parameters must be numeric");
+    });
+
+    // Constructs the "<let N: u32, let M: u8>" string that is injected after the "impl" keyword in e.g.
+    // "impl<let N: u32, let M: u8> Serialize for Foo<N, M>".
+    // Returns an empty quote if the struct has no generics.
+    if generics.len() > 0 {
+        let generics_declarations_items = generics
+            .map(|(name, typ)| {
+                let integer_type = typ.unwrap();
+                quote {let $name: $integer_type}
+            })
+            .join(quote {,});
+        quote {<$generics_declarations_items>}
+    } else {
+        // The struct doesn't have any generics defined, so we just return an empty quote.
+        quote {}
+    }
+}
+
+/// Generates a `Serialize` trait implementation for a struct type.
+///
+/// # Parameters
+/// - `s`: The struct type definition to generate the implementation for
+///
+/// # Returns
+/// A quoted code block containing the trait implementation
+///
+/// # Example
+/// For a struct defined as:
+/// ```
+/// struct Log<N> {
+///     fields: [Field; N],
+///     length: u32
+/// }
+/// ```
+///
+/// This function generates code equivalent to:
+/// ```
+/// impl<let N: u32> Serialize for Log<N> {
+///     let N: u32 = <[Field; N] as Serialize>::N + <u32 as Serialize>::N;
+///
+///     #[inline_always]
+///     fn serialize(self) -> [Field; Self::N] {
+///         let mut result = [0; _];
+///         let mut offset = 0;
+///
+///         let serialized_member = Serialize::serialize(self.fields);
+///         let serialized_member_len = <[Field; N] as Serialize>::N;
+///         for i in 0..serialized_member_len {
+///             result[i + offset] = serialized_member[i];
+///         }
+///         offset += serialized_member_len;
+///
+///         let serialized_member = Serialize::serialize(self.length);
+///         let serialized_member_len = <u32 as Serialize>::N;
+///         for i in 0..serialized_member_len {
+///             result[i + offset] = serialized_member[i];
+///         }
+///         offset += serialized_member_len;
+///
+///         result
+///     }
+/// }
+/// ```
+///
+/// TODO(benesjan): does this make sense? Can we just slap there the non-numeric generics?
+/// Note that numeric generic parameters (like `N` in `Log<N>`) are supported.
+/// Non-numeric generic parameters (like `T` in `Container<T>`) are not supported.
 pub comptime fn derive_serialize(s: TypeDefinition) -> Quoted {
     let typ = s.as_type();
     let nested_struct = typ.as_data_type().unwrap();
     let params = nested_struct.0.fields(nested_struct.1);
+
+    let generics_declarations = get_generics_declarations(s);
 
     // The following will give us <type_of_struct_member_1 as Serialize>::N + <type_of_struct_member_2 as Serialize>::N + ...
     let right_hand_side_of_definition_of_n = params
@@ -62,7 +141,7 @@ pub(crate) comptime fn derive_deserialize(s: TypeDefinition) -> Quoted {
         })
         .join(quote {+});
 
-    // This generates deserialization code for each struct member that and concatenates them together.
+    // This generates deserialization code for each struct member and concatenates them together.
     let deserialization_of_struct_members = params
         .map(|(param_name, param_type, _): (Quoted, Type, Quoted)| {
             quote {

--- a/noir-projects/noir-protocol-circuits/crates/types/src/point.nr
+++ b/noir-projects/noir-protocol-circuits/crates/types/src/point.nr
@@ -3,8 +3,8 @@ use crate::{hash::poseidon2_hash, traits::{Deserialize, Empty, Hash, Packable, S
 
 pub global POINT_LENGTH: u32 = 3;
 
-// Note: Not deriving this because it's currently not supported to call derive_serialize on a "remote" struct.
-// See this conversation on slack for more details: https://aztecprotocol.slack.com/archives/C04QF64EDNV/p1745445181590219
+// Note: Not deriving this because it's not supported to call derive_serialize on a "remote" struct (and it will never
+// be supported).
 impl Serialize for Point {
     let N: u32 = POINT_LENGTH;
 

--- a/noir-projects/noir-protocol-circuits/crates/types/src/scalar.nr
+++ b/noir-projects/noir-protocol-circuits/crates/types/src/scalar.nr
@@ -9,8 +9,8 @@ impl Empty for Scalar {
     }
 }
 
-// Note: Not deriving this because it's currently not supported to call derive_serialize on a "remote" struct.
-// See this conversation on slack for more details: https://aztecprotocol.slack.com/archives/C04QF64EDNV/p1745445181590219
+// Note: Not deriving this because it's not supported to call derive_serialize on a "remote" struct (and it will never
+// be supported).
 impl Serialize for Scalar {
     let N: u32 = SCALAR_SIZE;
 

--- a/noir-projects/noir-protocol-circuits/crates/types/src/traits.nr
+++ b/noir-projects/noir-protocol-circuits/crates/types/src/traits.nr
@@ -302,15 +302,17 @@ impl FromField for u128 {
 /// Noir's intrinsic serialization and the implementation of this trait. If there is a mismatch, the function calls
 /// fail with an arguments hash mismatch error message.
 ///
-/// # Type Parameters
+/// # Associated Constants
 /// * `N` - The length of the output Field array, known at compile time
 ///
 /// # Example
 /// ```
-/// impl<let N: u32> Serialize<N> for str<N> {
-///     fn serialize(self) -> [Field; N] {
+/// impl<let N: u32> Serialize for str<N> {
+///     let N: u32 = N;
+///
+///     fn serialize(self) -> [Field; Self::N] {
 ///         let bytes = self.as_bytes();
-///         let mut fields = [0; N];
+///         let mut fields = [0; Self::N];
 ///         for i in 0..bytes.len() {
 ///             fields[i] = bytes[i] as Field;  // Each byte gets its own Field
 ///         }


### PR DESCRIPTION
Until this PR `derive_serialize`, `derive_deserialize` and `derive_packable` did not support types with generics. In this PR I do the necessary changes to allow for that.

~Currently blocked by https://github.com/noir-lang/noir/issues/9248~

~Currently blocked by https://github.com/noir-lang/noir/issues/9210~

Note that there are more places we can now auto-derive the traits. However when doing that it started to result in a larger refactor so I decided to do that in a separate PR.