### PR TITLE
fix: update telemetry if metrics have been captured

### DIFF
--- a/yarn-project/bb-prover/src/verifier/queued_ivc_verifier.ts
+++ b/yarn-project/bb-prover/src/verifier/queued_ivc_verifier.ts
@@ -100,6 +100,9 @@ class IVCVerifierMetrics {
       [this.localHistogramOk, true],
       [this.localHistogramFails, false],
     ] as const) {
+      if (histogram.count === 0) {
+        continue;
+      }
       res.observe(this.aggDurationMetrics.avg, histogram.mean, { [Attributes.OK]: ok });
       res.observe(this.aggDurationMetrics.max, histogram.max, { [Attributes.OK]: ok });
       res.observe(this.aggDurationMetrics.min, histogram.min, { [Attributes.OK]: ok });

--- a/yarn-project/p2p/src/services/libp2p/instrumentation.ts
+++ b/yarn-project/p2p/src/services/libp2p/instrumentation.ts
@@ -143,7 +143,7 @@ export class P2PInstrumentation {
     ] as const) {
       for (const topicName of Object.values(TopicType)) {
         const histogram = histograms.get(topicName);
-        if (!histogram) {
+        if (!histogram || histogram.count === 0) {
           continue;
         }
 


### PR DESCRIPTION
`histogram.mean` returns `NaN` if no observations have been made which breaks the telemetry export