### PR TITLE
chore: rm reset oracle

### DIFF
--- a/noir-projects/aztec-nr/aztec/src/test/helpers/test_environment.nr
+++ b/noir-projects/aztec-nr/aztec/src/test/helpers/test_environment.nr
@@ -43,12 +43,10 @@ pub struct CallResult<T> {
 
 impl TestEnvironment {
     pub unconstrained fn new() -> Self {
-        txe_oracles::reset();
         Self {}
     }
 
     pub unconstrained fn _new() -> Self {
-        txe_oracles::reset();
         txe_oracles::enable_context_checks();
         Self {}
     }

--- a/noir-projects/aztec-nr/aztec/src/test/helpers/txe_oracles.nr
+++ b/noir-projects/aztec-nr/aztec/src/test/helpers/txe_oracles.nr
@@ -72,9 +72,6 @@ pub unconstrained fn public_call_new_flow(
     (returns_hash, tx_hash)
 }
 
-#[oracle(reset)]
-pub unconstrained fn reset() {}
-
 #[oracle(getLastBlockTimestamp)]
 pub unconstrained fn get_last_block_timestamp() -> u64 {}
 

--- a/yarn-project/txe/src/index.ts
+++ b/yarn-project/txe/src/index.ts
@@ -54,7 +54,7 @@ type MethodNames<T> = {
 
 type TXEForeignCallInput = {
   session_id: number;
-  function: MethodNames<TXEService> | 'reset';
+  function: MethodNames<TXEService>;
   root_path: string;
   package_name: string;
   inputs: ForeignCallArgs;
@@ -63,7 +63,7 @@ type TXEForeignCallInput = {
 const TXEForeignCallInputSchema = z.object({
   // eslint-disable-next-line camelcase
   session_id: z.number().int().nonnegative(),
-  function: z.string() as ZodFor<MethodNames<TXEService> | 'reset'>,
+  function: z.string() as ZodFor<MethodNames<TXEService>>,
   // eslint-disable-next-line camelcase
   root_path: z.string(),
   // eslint-disable-next-line camelcase
@@ -205,7 +205,7 @@ class TXEDispatcher {
     const { session_id: sessionId, function: functionName, inputs } = callData;
     this.logger.debug(`Calling ${functionName} on session ${sessionId}`);
 
-    if (!TXESessions.has(sessionId) && functionName != 'reset') {
+    if (!TXESessions.has(sessionId)) {
       this.logger.debug(`Creating new session ${sessionId}`);
       if (!this.protocolContracts) {
         this.protocolContracts = await Promise.all(

--- a/yarn-project/txe/src/index.ts
+++ b/yarn-project/txe/src/index.ts
@@ -216,11 +216,6 @@ class TXEDispatcher {
     }
 
     switch (functionName) {
-      case 'reset': {
-        TXESessions.delete(sessionId) &&
-          this.logger.debug(`Called reset on session ${sessionId}, yeeting it out of existence`);
-        return toForeignCallResult([]);
-      }
       case 'deploy': {
         await this.#processDeployInputs(callData);
         break;

--- a/yarn-project/txe/src/index.ts
+++ b/yarn-project/txe/src/index.ts
@@ -32,7 +32,6 @@ import {
   type ForeignCallSingle,
   fromArray,
   fromSingle,
-  toForeignCallResult,
   toSingle,
 } from './util/encoding.js';
 import type { ContractArtifactWithHash } from './util/txe_contract_data_provider.js';


### PR DESCRIPTION
We don't need this since we create a new session on the spot, so it does nothing. We've never tried actually resetting a session, and I'd rather not have to worry about supporting that.