### PR TITLE
fix: yarn project cache hash when AVM is disabled (#15758) (backport)

### DIFF
--- a/yarn-project/bootstrap.sh
+++ b/yarn-project/bootstrap.sh
@@ -4,10 +4,6 @@ source $(git rev-parse --show-toplevel)/ci3/source_bootstrap
 cmd=${1:-}
 [ -n "$cmd" ] && shift
 
-if [[ $(arch) == "arm64" && "$CI" -eq 1 ]]; then
-  export DISABLE_AZTEC_VM=1
-fi
-
 function hash {
   hash_str \
     $(../noir/bootstrap.sh hash) \
@@ -111,8 +107,9 @@ function test_cmds {
   # noir-bb-bench: A slow pain. Figure out later.
   for test in !(end-to-end|kv-store|noir-bb-bench|aztec)/src/**/*.test.ts; do
     # If DISABLE_AZTEC_VM, filter out avm_proving_tests/*.test.ts and avm_integration.test.ts
+    # If AVM is disabled, filter out avm_proving_tests/*.test.ts and avm_integration.test.ts
     # Also must filter out rollup_ivc_integration.test.ts as it includes AVM proving.
-    if [[ "${DISABLE_AZTEC_VM:-0}" -eq 1 && "$test" =~ (avm_proving_tests|avm_integration|rollup_ivc_integration) ]]; then
+    if ../barretenberg/cpp/bootstrap.sh hash | grep -qE no-avm && [[ "$test" =~ (avm_proving_tests|avm_integration|rollup_ivc_integration) ]]; then
       continue
     fi
 

--- a/yarn-project/end-to-end/bootstrap.sh
+++ b/yarn-project/end-to-end/bootstrap.sh
@@ -3,10 +3,6 @@ source $(git rev-parse --show-toplevel)/ci3/source_bootstrap
 
 cmd=${1:-}
 
-if [[ $(arch) == "arm64" && "$CI" -eq 1 ]]; then
-  export DISABLE_AZTEC_VM=1
-fi
-
 hash=$(../bootstrap.sh hash)
 bench_fixtures_dir=example-app-ivc-inputs-out
 
@@ -16,7 +12,7 @@ function test_cmds {
 
   # Longest-running tests first
   # Can't run full prover tests on ARM because AVM is disabled.
-  if [ "${DISABLE_AZTEC_VM:-0}" -eq 1 ]; then
+  if ../../barretenberg/cpp/bootstrap.sh hash | grep -qE no-avm; then
     if [ "$CI_FULL" -eq 1 ]; then
       echo "$prefix:TIMEOUT=15m:CPUS=16:MEM=96g:NAME=e2e_prover_client_real $run_test_script simple e2e_prover/client"
     else


### PR DESCRIPTION
Backport of #15758