### PR TITLE
chore: Fix race condition in l1 tx utils

### DIFF
--- a/yarn-project/end-to-end/src/e2e_epochs/epochs_test.ts
+++ b/yarn-project/end-to-end/src/e2e_epochs/epochs_test.ts
@@ -189,6 +189,8 @@ export class EpochsTestContext {
         { ...this.context.config, proverId: Fr.fromString(suffix) },
         { dataDirectory: join(this.context.config.dataDirectory!, randomBytes(8).toString('hex')) },
         this.context.aztecNode,
+        undefined,
+        { dateProvider: this.context.dateProvider },
       ),
     );
     this.proverNodes.push(proverNode);
@@ -247,8 +249,7 @@ export class EpochsTestContext {
       );
       const sequencer = node.getSequencer() as TestSequencerClient;
       const publisher = sequencer.sequencer.publisher;
-      const dateProvider = this.context.dateProvider!;
-      const delayed = DelayedTxUtils.fromL1TxUtils(publisher.l1TxUtils, dateProvider, this.L1_BLOCK_TIME_IN_S);
+      const delayed = DelayedTxUtils.fromL1TxUtils(publisher.l1TxUtils, this.L1_BLOCK_TIME_IN_S);
       delayed.delayer!.setMaxInclusionTimeIntoSlot(opts.txDelayerMaxInclusionTimeIntoSlot);
       publisher.l1TxUtils = delayed;
     }

--- a/yarn-project/end-to-end/src/e2e_synching.test.ts
+++ b/yarn-project/end-to-end/src/e2e_synching.test.ts
@@ -57,7 +57,7 @@ import {
 import { L1TxUtilsWithBlobs } from '@aztec/ethereum/l1-tx-utils-with-blobs';
 import { SecretValue } from '@aztec/foundation/config';
 import { EthAddress } from '@aztec/foundation/eth-address';
-import { TestDateProvider, Timer } from '@aztec/foundation/timer';
+import { Timer } from '@aztec/foundation/timer';
 import { RollupAbi } from '@aztec/l1-artifacts';
 import { SchnorrHardcodedAccountContract } from '@aztec/noir-contracts.js/SchnorrHardcodedAccount';
 import { TokenContract } from '@aztec/noir-contracts.js/Token';
@@ -378,6 +378,7 @@ describe('e2e_synching', () => {
       pxe,
       blobSink,
       initialFundedAccounts,
+      dateProvider,
     } = await setup(0, {
       salt: SALT,
       l1StartTime: START_TIME,
@@ -395,7 +396,7 @@ describe('e2e_synching', () => {
 
     const sequencerPK: `0x${string}` = `0x${getPrivateKeyFromIndex(0)!.toString('hex')}`;
 
-    const l1TxUtils = new L1TxUtilsWithBlobs(deployL1ContractsValues.l1Client, logger, config);
+    const l1TxUtils = new L1TxUtilsWithBlobs(deployL1ContractsValues.l1Client, logger, dateProvider!, config);
     const rollupAddress = deployL1ContractsValues.l1ContractAddresses.rollupAddress.toString();
     const rollupContract = new RollupContract(deployL1ContractsValues.l1Client, rollupAddress);
     const governanceProposerContract = new GovernanceProposerContract(
@@ -407,7 +408,6 @@ describe('e2e_synching', () => {
       deployL1ContractsValues.l1Client,
       slashingProposerAddress.toString(),
     );
-    const dateProvider = new TestDateProvider();
     const epochCache = await EpochCache.create(config.l1Contracts.rollupAddress, config, { dateProvider });
     const publisher = new SequencerPublisher(
       {
@@ -428,7 +428,7 @@ describe('e2e_synching', () => {
         governanceProposerContract,
         slashingProposerContract,
         epochCache,
-        dateProvider,
+        dateProvider: dateProvider!,
       },
     );
 

--- a/yarn-project/end-to-end/src/integration/integration_l1_publisher.test.ts
+++ b/yarn-project/end-to-end/src/integration/integration_l1_publisher.test.ts
@@ -187,8 +187,9 @@ describe('L1Publisher integration', () => {
     worldStateSynchronizer = new ServerWorldStateSynchronizer(builderDb, blockSource, worldStateConfig);
     await worldStateSynchronizer.start();
 
+    const dateProvider = new TestDateProvider();
     const sequencerL1Client = createExtendedL1Client(config.l1RpcUrls, sequencerPK, foundry);
-    const l1TxUtils = new L1TxUtilsWithBlobs(sequencerL1Client, logger, config);
+    const l1TxUtils = new L1TxUtilsWithBlobs(sequencerL1Client, logger, dateProvider, config);
     const rollupContract = new RollupContract(sequencerL1Client, l1ContractAddresses.rollupAddress.toString());
     const slashingProposerAddress = await rollupContract.getSlashingProposerAddress();
     const slashingProposerContract = new SlashingProposerContract(
@@ -199,7 +200,6 @@ describe('L1Publisher integration', () => {
       sequencerL1Client,
       l1ContractAddresses.governanceProposerAddress.toString(),
     );
-    const dateProvider = new TestDateProvider();
     const epochCache = await EpochCache.create(l1ContractAddresses.rollupAddress, config, { dateProvider });
     const blobSinkClient = createBlobSinkClient();
 

--- a/yarn-project/ethereum/src/contracts/registry.test.ts
+++ b/yarn-project/ethereum/src/contracts/registry.test.ts
@@ -119,7 +119,7 @@ describe('Registry', () => {
   it('adds a version to the registry', async () => {
     const newVersionSalt = originalVersionSalt + 1;
 
-    const deployer = new L1Deployer(l1Client, newVersionSalt, undefined, logger, defaultL1TxUtilsConfig);
+    const deployer = new L1Deployer(l1Client, newVersionSalt, undefined, undefined, logger, defaultL1TxUtilsConfig);
 
     // We need to steal ownership of the registry to add a rollup without going through governance
     await setRegistryOwnership(EthAddress.fromString(deployer.client.account.address));

--- a/yarn-project/ethereum/src/l1_tx_utils.test.ts
+++ b/yarn-project/ethereum/src/l1_tx_utils.test.ts
@@ -519,7 +519,7 @@ describe('GasUtils', () => {
   }, 20_000);
 
   it('attempts to cancel timed out transactions', async () => {
-    // Disable auto-mining to control block production
+    await cheatCodes.mine(1);
     await cheatCodes.setIntervalMining(0);
     await cheatCodes.setAutomine(false);
 
@@ -557,8 +557,8 @@ describe('GasUtils', () => {
 
     // Verify cancellation tx
     expect(cancelTx).toBeDefined();
-    expect(cancelTx!.nonce).toBe(nonce);
     expect(cancelTx!.to!.toLowerCase()).toBe(l1Client.account.address.toLowerCase());
+    expect(cancelTx!.nonce).toBe(nonce);
     expect(cancelTx!.value).toBe(0n);
     expect(cancelTx!.maxFeePerGas).toBeGreaterThan(initialTx.maxFeePerGas!);
     expect(cancelTx!.maxPriorityFeePerGas).toBeGreaterThan(initialTx.maxPriorityFeePerGas!);

--- a/yarn-project/ethereum/src/l1_tx_utils.test.ts
+++ b/yarn-project/ethereum/src/l1_tx_utils.test.ts
@@ -31,19 +31,18 @@ export type PendingTransaction = {
   maxPriorityFeePerGas: bigint;
 };
 
-describe('GasUtils', () => {
-  let gasUtils: L1TxUtilsWithBlobs;
-  let l1Client: ExtendedViemWalletClient;
-  let anvil: Anvil;
-  let cheatCodes: EthCheatCodes;
-  let dateProvider: TestDateProvider;
-
+describe('L1TxUtils', () => {
   const initialBaseFee = WEI_CONST; // 1 gwei
 
-  beforeAll(async () => {
-    dateProvider = new TestDateProvider();
-    const { anvil: anvilInstance, rpcUrl } = await startAnvil({ l1BlockTime: 1, log: true });
-    anvil = anvilInstance;
+  let l1Client: ExtendedViemWalletClient;
+  let anvil: Anvil;
+  let rpcUrl: string;
+  let cheatCodes: EthCheatCodes;
+  let dateProvider: TestDateProvider;
+  let port: number = 8545;
+
+  beforeEach(async () => {
+    ({ anvil, rpcUrl } = await startAnvil({ l1BlockTime: 1, port: port++ }));
     cheatCodes = new EthCheatCodes([rpcUrl]);
     const hdAccount = mnemonicToAccount(MNEMONIC, { addressIndex: 0 });
     const privKeyRaw = hdAccount.getHdKey().privateKey;
@@ -54,761 +53,745 @@ describe('GasUtils', () => {
     const account = privateKeyToAccount(`0x${privKey}`);
 
     l1Client = createExtendedL1Client([rpcUrl], account, foundry);
+    dateProvider = new TestDateProvider();
 
-    // set base fee
-    await l1Client.transport.request({
-      method: 'anvil_setNextBlockBaseFeePerGas',
-      params: [initialBaseFee.toString()],
-    });
-    await cheatCodes.evmMine();
-
-    gasUtils = new L1TxUtilsWithBlobs(l1Client, logger, dateProvider, {
-      gasLimitBufferPercentage: 20,
-      maxGwei: 500n,
-      maxAttempts: 3,
-      checkIntervalMs: 100,
-      stallTimeMs: 1000,
-    });
-  });
-
-  afterEach(async () => {
-    // Reset base fee
     await cheatCodes.setNextBlockBaseFeePerGas(initialBaseFee);
     await cheatCodes.evmMine();
   });
 
-  afterAll(async () => {
-    // disabling interval mining as it seems to cause issues with stopping anvil
-    await cheatCodes.setIntervalMining(0); // Disable interval mining
+  afterEach(async () => {
+    await cheatCodes.setIntervalMining(0); // Disable interval mining to ensure anvil stops properly
     await anvil.stop().catch(err => createLogger('cleanup').error(err));
-  }, 5_000);
+  }, 5000);
 
-  it('sends and monitors a simple transaction', async () => {
-    const { receipt } = await gasUtils.sendAndMonitorTransaction({
-      to: '0x1234567890123456789012345678901234567890',
-      data: '0x',
-      value: 0n,
+  describe('L1TxUtilsWithBlobs', () => {
+    let gasUtils: L1TxUtilsWithBlobs;
+
+    beforeEach(() => {
+      gasUtils = new L1TxUtilsWithBlobs(l1Client, logger, dateProvider, {
+        gasLimitBufferPercentage: 20,
+        maxGwei: 500n,
+        maxAttempts: 3,
+        checkIntervalMs: 100,
+        stallTimeMs: 1000,
+      });
     });
 
-    expect(receipt.status).toBe('success');
-  }, 10_000);
-
-  it('handles gas price spikes by retrying with higher gas price', async () => {
-    // Disable all forms of mining
-    await cheatCodes.setAutomine(false);
-    await cheatCodes.setIntervalMining(0);
-
-    // Add blob data
-    const blobData = new Uint8Array(131072).fill(1);
-    const kzg = Blob.getViemKzgInstance();
-
-    const request = {
-      to: '0x1234567890123456789012345678901234567890' as `0x${string}`,
-      data: '0x' as `0x${string}`,
-      value: 0n,
-    };
-
-    const estimatedGas = await l1Client.estimateGas(request);
-
-    const originalMaxFeePerGas = WEI_CONST * 10n;
-    const originalMaxPriorityFeePerGas = WEI_CONST;
-    const originalMaxFeePerBlobGas = WEI_CONST * 10n;
-
-    const txHash = await l1Client.sendTransaction({
-      ...request,
-      gas: estimatedGas,
-      maxFeePerGas: originalMaxFeePerGas,
-      maxPriorityFeePerGas: originalMaxPriorityFeePerGas,
-      blobs: [blobData],
-      kzg,
-      maxFeePerBlobGas: originalMaxFeePerBlobGas,
-    });
-
-    const rawTx = await cheatCodes.getRawTransaction(txHash);
-
-    // Temporarily drop the transaction
-    await cheatCodes.dropTransaction(txHash);
-
-    // Mine a block with higher base fee
-    await cheatCodes.setNextBlockBaseFeePerGas((WEI_CONST * 15n) / 10n);
-    await cheatCodes.evmMine();
-
-    // Re-add the original tx
-    await l1Client.transport.request({
-      method: 'eth_sendRawTransaction',
-      params: [rawTx],
-    });
-
-    // Monitor should detect stall and replace with higher gas price
-    const monitorFn = gasUtils.monitorTransaction(request, txHash, { gasLimit: estimatedGas }, undefined, {
-      blobs: [blobData],
-      kzg,
-      maxFeePerBlobGas: WEI_CONST * 20n,
-    });
-
-    await sleep(2000);
-    // re-enable mining
-    await cheatCodes.setIntervalMining(1);
-    const receipt = await monitorFn;
-    expect(receipt.status).toBe('success');
-    // Verify that a replacement transaction was created
-    expect(receipt.transactionHash).not.toBe(txHash);
-
-    // Get details of replacement tx to verify higher gas prices
-    const replacementTx = await l1Client.getTransaction({ hash: receipt.transactionHash });
-
-    expect(replacementTx.maxFeePerGas!).toBeGreaterThan(originalMaxFeePerGas);
-    expect(replacementTx.maxPriorityFeePerGas!).toBeGreaterThan(originalMaxPriorityFeePerGas);
-    expect(replacementTx.maxFeePerBlobGas!).toBeGreaterThan(originalMaxFeePerBlobGas);
-  }, 20_000);
-
-  it('respects max gas price limits during spikes', async () => {
-    const maxGwei = 500n;
-    const newBaseFee = (maxGwei - 10n) * WEI_CONST;
-
-    // Set base fee high but still under our max
-    await cheatCodes.setNextBlockBaseFeePerGas(newBaseFee);
-
-    // Mine a new block to make the base fee change take effect
-    await cheatCodes.evmMine();
-
-    const { receipt } = await gasUtils.sendAndMonitorTransaction(
-      {
-        to: '0x1234567890123456789012345678901234567890',
-        data: '0x',
-        value: 0n,
-      },
-      { maxGwei },
-    );
-
-    expect(receipt.effectiveGasPrice).toBeLessThanOrEqual(maxGwei * WEI_CONST);
-  }, 60_000);
-
-  it('adds appropriate buffer to gas estimation', async () => {
-    const stableBaseFee = WEI_CONST * 10n;
-    await cheatCodes.setNextBlockBaseFeePerGas(stableBaseFee);
-    await cheatCodes.evmMine();
-
-    // First deploy without any buffer
-    const baselineGasUtils = new L1TxUtilsWithBlobs(l1Client, logger, dateProvider, {
-      gasLimitBufferPercentage: 0,
-      maxGwei: 500n,
-      maxAttempts: 5,
-      checkIntervalMs: 100,
-      stallTimeMs: 1000,
-    });
-
-    const { receipt: baselineTx } = await baselineGasUtils.sendAndMonitorTransaction({
-      to: EthAddress.ZERO.toString(),
-      data: SIMPLE_CONTRACT_BYTECODE,
-    });
-
-    // Get the transaction details to see the gas limit
-    const baselineDetails = await l1Client.getTransaction({
-      hash: baselineTx.transactionHash,
-    });
-
-    // Now deploy with 20% buffer
-    const bufferedGasUtils = new L1TxUtilsWithBlobs(l1Client, logger, dateProvider, {
-      gasLimitBufferPercentage: 20,
-      maxGwei: 500n,
-      maxAttempts: 3,
-      checkIntervalMs: 100,
-      stallTimeMs: 1000,
-    });
-
-    const { receipt: bufferedTx } = await bufferedGasUtils.sendAndMonitorTransaction({
-      to: EthAddress.ZERO.toString(),
-      data: SIMPLE_CONTRACT_BYTECODE,
-    });
-
-    const bufferedDetails = await l1Client.getTransaction({
-      hash: bufferedTx.transactionHash,
-    });
-
-    // The gas limit should be ~20% higher
-    expect(bufferedDetails.gas).toBeGreaterThan(baselineDetails.gas);
-    expect(bufferedDetails.gas).toBeLessThanOrEqual((baselineDetails.gas * 120n) / 100n);
-  }, 20_000);
-
-  it('calculates correct gas prices for initial attempt', async () => {
-    // Set base fee to 1 gwei
-    await cheatCodes.setNextBlockBaseFeePerGas(WEI_CONST);
-    await cheatCodes.evmMine();
-
-    // Mock estimateMaxPriorityFeePerGas to return a consistent value (1 gwei)
-    const originalEstimate = l1Client.estimateMaxPriorityFeePerGas;
-    const mockBasePriorityFee = WEI_CONST; // 1 gwei
-    l1Client.estimateMaxPriorityFeePerGas = () => Promise.resolve(mockBasePriorityFee);
-
-    try {
-      const gasPrice = await gasUtils['getGasPrice']();
-
-      // With default config, priority fee should be bumped by 20%
-      const expectedPriorityFee = (mockBasePriorityFee * 120n) / 100n;
-
-      // Base fee should be bumped for potential stalls (1.125^(stallTimeMs/12000) = ~1.125 for default config)
-      const expectedMaxFee = (WEI_CONST * 1125n) / 1000n + expectedPriorityFee;
-
-      expect(gasPrice.maxPriorityFeePerGas).toBe(expectedPriorityFee);
-      expect(gasPrice.maxFeePerGas).toBe(expectedMaxFee);
-    } finally {
-      // Restore original method
-      l1Client.estimateMaxPriorityFeePerGas = originalEstimate;
-    }
-  });
-
-  it('calculates correct gas prices for retry attempts', async () => {
-    await cheatCodes.setNextBlockBaseFeePerGas(WEI_CONST);
-    await cheatCodes.evmMine();
-
-    const initialGasPrice = await gasUtils['getGasPrice']();
-
-    // Get retry gas price for 2nd attempt
-    const retryGasPrice = await gasUtils['getGasPrice'](undefined, false, 1, initialGasPrice);
-
-    // With default config, retry should bump fees by 50%
-    const expectedPriorityFee = (initialGasPrice.maxPriorityFeePerGas * 150n) / 100n;
-    const expectedMaxFee = (initialGasPrice.maxFeePerGas * 150n) / 100n;
-
-    expect(retryGasPrice.maxPriorityFeePerGas).toBe(expectedPriorityFee);
-    expect(retryGasPrice.maxFeePerGas).toBe(expectedMaxFee);
-  });
-
-  it('respects minimum gas price bump for replacements', async () => {
-    const gasUtils = new L1TxUtilsWithBlobs(l1Client, logger, dateProvider, {
-      ...defaultL1TxUtilsConfig,
-      priorityFeeRetryBumpPercentage: 5, // Set lower than minimum 10%
-    });
-
-    const initialGasPrice = await gasUtils['getGasPrice']();
-
-    // Get retry gas price with attempt = 1
-    const retryGasPrice = await gasUtils['getGasPrice'](undefined, false, 1, initialGasPrice);
-
-    // Should use 10% minimum bump even though config specified 5%
-    const expectedPriorityFee = (initialGasPrice.maxPriorityFeePerGas * 110n) / 100n;
-    const expectedMaxFee = (initialGasPrice.maxFeePerGas * 110n) / 100n;
-
-    expect(retryGasPrice.maxPriorityFeePerGas).toBe(expectedPriorityFee);
-    expect(retryGasPrice.maxFeePerGas).toBe(expectedMaxFee);
-  });
-
-  it('adds correct buffer to gas estimation', async () => {
-    const request = {
-      to: '0x1234567890123456789012345678901234567890' as `0x${string}`,
-      data: '0x' as `0x${string}`,
-      value: 0n,
-    };
-
-    const baseEstimate = await l1Client.estimateGas(request);
-    const bufferedEstimate = await gasUtils.estimateGas(l1Client.account!, request);
-
-    // adds 20% buffer
-    const expectedEstimate = baseEstimate + (baseEstimate * 20n) / 100n;
-    expect(bufferedEstimate).toBe(expectedEstimate);
-  });
-
-  it('correctly handles transactions with blobs', async () => {
-    // Create a sample blob
-    const blobData = new Uint8Array(131072).fill(1); // 128KB blob
-    const kzg = Blob.getViemKzgInstance();
-
-    const { receipt } = await gasUtils.sendAndMonitorTransaction(
-      {
-        to: '0x1234567890123456789012345678901234567890',
-        data: '0x',
-        value: 0n,
-      },
-      undefined,
-      {
-        blobs: [blobData],
-        kzg,
-        maxFeePerBlobGas: 10000000000n, // 10 gwei
-      },
-    );
-
-    expect(receipt.status).toBe('success');
-    expect(receipt.blobGasUsed).toBeDefined();
-    expect(receipt.blobGasPrice).toBeDefined();
-  }, 20_000);
-
-  it('estimates gas correctly for blob transactions', async () => {
-    // Create a sample blob
-    const blobData = new Uint8Array(131072).fill(1); // 128KB blob
-    const kzg = Blob.getViemKzgInstance();
-
-    const request = {
-      to: '0x1234567890123456789012345678901234567890' as `0x${string}`,
-      data: '0x' as `0x${string}`,
-      value: 0n,
-    };
-
-    // Estimate gas without blobs first
-    const baseEstimate = await gasUtils.estimateGas(l1Client.account!, request);
-
-    // Estimate gas with blobs
-    const blobEstimate = await gasUtils.estimateGas(l1Client.account!, request, undefined, {
-      blobs: [blobData],
-      kzg,
-      maxFeePerBlobGas: 10000000000n,
-    });
-    // Blob transactions should require more gas
-    expect(blobEstimate).toBeGreaterThan(baseEstimate);
-  }, 20_000);
-
-  it('formats eth node errors correctly', async () => {
-    // Set base fee extremely high to trigger error
-    const extremelyHighBaseFee = WEI_CONST * 1_000_000n; // 1M gwei
-    await cheatCodes.setNextBlockBaseFeePerGas(extremelyHighBaseFee);
-    await cheatCodes.evmMine();
-
-    try {
-      await gasUtils.sendAndMonitorTransaction({
+    it('sends and monitors a simple transaction', async () => {
+      const { receipt } = await gasUtils.sendAndMonitorTransaction({
         to: '0x1234567890123456789012345678901234567890',
         data: '0x',
         value: 0n,
       });
-      fail('Should have thrown');
-    } catch (err: any) {
-      const res = err;
-      const { message } = res;
-      // Verify the error contains actual newlines, not escaped \n
-      expect(message).not.toContain('\\n');
-      expect(message.split('\n').length).toBeGreaterThan(1);
 
-      // Check that we have the key error information
-      expect(message).toContain('fee cap');
+      expect(receipt.status).toBe('success');
+    }, 10_000);
 
-      // Check request body formatting if present
-      if (message.includes('Request body:')) {
-        const bodyStart = message.indexOf('Request body:');
-        const body = message.slice(bodyStart);
-        expect(body).toContain('eth_sendRawTransaction');
-        // Check params are truncated if too long
-        if (body.includes('0x')) {
-          expect(body).toContain('...');
+    it('handles gas price spikes by retrying with higher gas price', async () => {
+      // Disable all forms of mining
+      await cheatCodes.setAutomine(false);
+      await cheatCodes.setIntervalMining(0);
+
+      // Add blob data
+      const blobData = new Uint8Array(131072).fill(1);
+      const kzg = Blob.getViemKzgInstance();
+
+      const request = {
+        to: '0x1234567890123456789012345678901234567890' as `0x${string}`,
+        data: '0x' as `0x${string}`,
+        value: 0n,
+      };
+
+      const estimatedGas = await l1Client.estimateGas(request);
+
+      const originalMaxFeePerGas = WEI_CONST * 10n;
+      const originalMaxPriorityFeePerGas = WEI_CONST;
+      const originalMaxFeePerBlobGas = WEI_CONST * 10n;
+
+      const txHash = await l1Client.sendTransaction({
+        ...request,
+        gas: estimatedGas,
+        maxFeePerGas: originalMaxFeePerGas,
+        maxPriorityFeePerGas: originalMaxPriorityFeePerGas,
+        blobs: [blobData],
+        kzg,
+        maxFeePerBlobGas: originalMaxFeePerBlobGas,
+      });
+
+      const rawTx = await cheatCodes.getRawTransaction(txHash);
+
+      // Temporarily drop the transaction
+      await cheatCodes.dropTransaction(txHash);
+
+      // Mine a block with higher base fee
+      await cheatCodes.setNextBlockBaseFeePerGas((WEI_CONST * 15n) / 10n);
+      await cheatCodes.evmMine();
+
+      // Re-add the original tx
+      await l1Client.transport.request({
+        method: 'eth_sendRawTransaction',
+        params: [rawTx],
+      });
+
+      // Monitor should detect stall and replace with higher gas price
+      const monitorFn = gasUtils.monitorTransaction(request, txHash, { gasLimit: estimatedGas }, undefined, {
+        blobs: [blobData],
+        kzg,
+        maxFeePerBlobGas: WEI_CONST * 20n,
+      });
+
+      await sleep(2000);
+      // re-enable mining
+      await cheatCodes.setIntervalMining(1);
+      const receipt = await monitorFn;
+      expect(receipt.status).toBe('success');
+      // Verify that a replacement transaction was created
+      expect(receipt.transactionHash).not.toBe(txHash);
+
+      // Get details of replacement tx to verify higher gas prices
+      const replacementTx = await l1Client.getTransaction({ hash: receipt.transactionHash });
+
+      expect(replacementTx.maxFeePerGas!).toBeGreaterThan(originalMaxFeePerGas);
+      expect(replacementTx.maxPriorityFeePerGas!).toBeGreaterThan(originalMaxPriorityFeePerGas);
+      expect(replacementTx.maxFeePerBlobGas!).toBeGreaterThan(originalMaxFeePerBlobGas);
+    }, 20_000);
+
+    it('respects max gas price limits during spikes', async () => {
+      const maxGwei = 500n;
+      const newBaseFee = (maxGwei - 10n) * WEI_CONST;
+
+      // Set base fee high but still under our max
+      await cheatCodes.setNextBlockBaseFeePerGas(newBaseFee);
+
+      // Mine a new block to make the base fee change take effect
+      await cheatCodes.evmMine();
+
+      const { receipt } = await gasUtils.sendAndMonitorTransaction(
+        {
+          to: '0x1234567890123456789012345678901234567890',
+          data: '0x',
+          value: 0n,
+        },
+        { maxGwei },
+      );
+
+      expect(receipt.effectiveGasPrice).toBeLessThanOrEqual(maxGwei * WEI_CONST);
+    }, 60_000);
+
+    it('adds appropriate buffer to gas estimation', async () => {
+      const stableBaseFee = WEI_CONST * 10n;
+      await cheatCodes.setNextBlockBaseFeePerGas(stableBaseFee);
+      await cheatCodes.evmMine();
+
+      // First deploy without any buffer
+      const baselineGasUtils = new L1TxUtilsWithBlobs(l1Client, logger, dateProvider, {
+        gasLimitBufferPercentage: 0,
+        maxGwei: 500n,
+        maxAttempts: 5,
+        checkIntervalMs: 100,
+        stallTimeMs: 1000,
+      });
+
+      const { receipt: baselineTx } = await baselineGasUtils.sendAndMonitorTransaction({
+        to: EthAddress.ZERO.toString(),
+        data: SIMPLE_CONTRACT_BYTECODE,
+      });
+
+      // Get the transaction details to see the gas limit
+      const baselineDetails = await l1Client.getTransaction({
+        hash: baselineTx.transactionHash,
+      });
+
+      // Now deploy with 20% buffer
+      const bufferedGasUtils = new L1TxUtilsWithBlobs(l1Client, logger, dateProvider, {
+        gasLimitBufferPercentage: 20,
+        maxGwei: 500n,
+        maxAttempts: 3,
+        checkIntervalMs: 100,
+        stallTimeMs: 1000,
+      });
+
+      const { receipt: bufferedTx } = await bufferedGasUtils.sendAndMonitorTransaction({
+        to: EthAddress.ZERO.toString(),
+        data: SIMPLE_CONTRACT_BYTECODE,
+      });
+
+      const bufferedDetails = await l1Client.getTransaction({
+        hash: bufferedTx.transactionHash,
+      });
+
+      // The gas limit should be ~20% higher
+      expect(bufferedDetails.gas).toBeGreaterThan(baselineDetails.gas);
+      expect(bufferedDetails.gas).toBeLessThanOrEqual((baselineDetails.gas * 120n) / 100n);
+    }, 20_000);
+
+    it('calculates correct gas prices for initial attempt', async () => {
+      // Set base fee to 1 gwei
+      await cheatCodes.setNextBlockBaseFeePerGas(WEI_CONST);
+      await cheatCodes.evmMine();
+
+      // Mock estimateMaxPriorityFeePerGas to return a consistent value (1 gwei)
+      const originalEstimate = l1Client.estimateMaxPriorityFeePerGas;
+      const mockBasePriorityFee = WEI_CONST; // 1 gwei
+      l1Client.estimateMaxPriorityFeePerGas = () => Promise.resolve(mockBasePriorityFee);
+
+      try {
+        const gasPrice = await gasUtils['getGasPrice']();
+
+        // With default config, priority fee should be bumped by 20%
+        const expectedPriorityFee = (mockBasePriorityFee * 120n) / 100n;
+
+        // Base fee should be bumped for potential stalls (1.125^(stallTimeMs/12000) = ~1.125 for default config)
+        const expectedMaxFee = (WEI_CONST * 1125n) / 1000n + expectedPriorityFee;
+
+        expect(gasPrice.maxPriorityFeePerGas).toBe(expectedPriorityFee);
+        expect(gasPrice.maxFeePerGas).toBe(expectedMaxFee);
+      } finally {
+        // Restore original method
+        l1Client.estimateMaxPriorityFeePerGas = originalEstimate;
+      }
+    });
+
+    it('calculates correct gas prices for retry attempts', async () => {
+      await cheatCodes.setNextBlockBaseFeePerGas(WEI_CONST);
+      await cheatCodes.evmMine();
+
+      const initialGasPrice = await gasUtils['getGasPrice']();
+
+      // Get retry gas price for 2nd attempt
+      const retryGasPrice = await gasUtils['getGasPrice'](undefined, false, 1, initialGasPrice);
+
+      // With default config, retry should bump fees by 50%
+      const expectedPriorityFee = (initialGasPrice.maxPriorityFeePerGas * 150n) / 100n;
+      const expectedMaxFee = (initialGasPrice.maxFeePerGas * 150n) / 100n;
+
+      expect(retryGasPrice.maxPriorityFeePerGas).toBe(expectedPriorityFee);
+      expect(retryGasPrice.maxFeePerGas).toBe(expectedMaxFee);
+    });
+
+    it('respects minimum gas price bump for replacements', async () => {
+      const gasUtils = new L1TxUtilsWithBlobs(l1Client, logger, dateProvider, {
+        ...defaultL1TxUtilsConfig,
+        priorityFeeRetryBumpPercentage: 5, // Set lower than minimum 10%
+      });
+
+      const initialGasPrice = await gasUtils['getGasPrice']();
+
+      // Get retry gas price with attempt = 1
+      const retryGasPrice = await gasUtils['getGasPrice'](undefined, false, 1, initialGasPrice);
+
+      // Should use 10% minimum bump even though config specified 5%
+      const expectedPriorityFee = (initialGasPrice.maxPriorityFeePerGas * 110n) / 100n;
+      const expectedMaxFee = (initialGasPrice.maxFeePerGas * 110n) / 100n;
+
+      expect(retryGasPrice.maxPriorityFeePerGas).toBe(expectedPriorityFee);
+      expect(retryGasPrice.maxFeePerGas).toBe(expectedMaxFee);
+    });
+
+    it('adds correct buffer to gas estimation', async () => {
+      const request = {
+        to: '0x1234567890123456789012345678901234567890' as `0x${string}`,
+        data: '0x' as `0x${string}`,
+        value: 0n,
+      };
+
+      const baseEstimate = await l1Client.estimateGas(request);
+      const bufferedEstimate = await gasUtils.estimateGas(l1Client.account!, request);
+
+      // adds 20% buffer
+      const expectedEstimate = baseEstimate + (baseEstimate * 20n) / 100n;
+      expect(bufferedEstimate).toBe(expectedEstimate);
+    });
+
+    it('correctly handles transactions with blobs', async () => {
+      // Create a sample blob
+      const blobData = new Uint8Array(131072).fill(1); // 128KB blob
+      const kzg = Blob.getViemKzgInstance();
+
+      const { receipt } = await gasUtils.sendAndMonitorTransaction(
+        {
+          to: '0x1234567890123456789012345678901234567890',
+          data: '0x',
+          value: 0n,
+        },
+        undefined,
+        {
+          blobs: [blobData],
+          kzg,
+          maxFeePerBlobGas: 10000000000n, // 10 gwei
+        },
+      );
+
+      expect(receipt.status).toBe('success');
+      expect(receipt.blobGasUsed).toBeDefined();
+      expect(receipt.blobGasPrice).toBeDefined();
+    }, 20_000);
+
+    it('estimates gas correctly for blob transactions', async () => {
+      // Create a sample blob
+      const blobData = new Uint8Array(131072).fill(1); // 128KB blob
+      const kzg = Blob.getViemKzgInstance();
+
+      const request = {
+        to: '0x1234567890123456789012345678901234567890' as `0x${string}`,
+        data: '0x' as `0x${string}`,
+        value: 0n,
+      };
+
+      // Estimate gas without blobs first
+      const baseEstimate = await gasUtils.estimateGas(l1Client.account!, request);
+
+      // Estimate gas with blobs
+      const blobEstimate = await gasUtils.estimateGas(l1Client.account!, request, undefined, {
+        blobs: [blobData],
+        kzg,
+        maxFeePerBlobGas: 10000000000n,
+      });
+      // Blob transactions should require more gas
+      expect(blobEstimate).toBeGreaterThan(baseEstimate);
+    }, 20_000);
+
+    it('formats eth node errors correctly', async () => {
+      // Set base fee extremely high to trigger error
+      const extremelyHighBaseFee = WEI_CONST * 1_000_000n; // 1M gwei
+      await cheatCodes.setNextBlockBaseFeePerGas(extremelyHighBaseFee);
+      await cheatCodes.evmMine();
+
+      try {
+        await gasUtils.sendAndMonitorTransaction({
+          to: '0x1234567890123456789012345678901234567890',
+          data: '0x',
+          value: 0n,
+        });
+        fail('Should have thrown');
+      } catch (err: any) {
+        const res = err;
+        const { message } = res;
+        // Verify the error contains actual newlines, not escaped \n
+        expect(message).not.toContain('\\n');
+        expect(message.split('\n').length).toBeGreaterThan(1);
+
+        // Check that we have the key error information
+        expect(message).toContain('fee cap');
+
+        // Check request body formatting if present
+        if (message.includes('Request body:')) {
+          const bodyStart = message.indexOf('Request body:');
+          const body = message.slice(bodyStart);
+          expect(body).toContain('eth_sendRawTransaction');
+          // Check params are truncated if too long
+          if (body.includes('0x')) {
+            expect(body).toContain('...');
+          }
         }
       }
-    }
-  }, 10_000);
+    }, 10_000);
 
-  it('strips ABI from non-revert errors', async () => {
-    // Create a client with an invalid RPC URL to trigger a real error
-    const invalidClient = createPublicClient({
-      transport: http('https://foobar.com'),
-      chain: foundry,
-    });
-
-    // Define a test ABI to have something to look for
-    const testAbi = [
-      {
-        type: 'function',
-        name: 'uniqueTestFunction',
-        inputs: [{ type: 'uint256', name: 'param1' }],
-        outputs: [{ type: 'bool' }],
-        stateMutability: 'view',
-      },
-    ] as const;
-
-    try {
-      // Try to make a request that will fail
-      await invalidClient.readContract({
-        address: '0x1234567890123456789012345678901234567890',
-        abi: testAbi,
-        functionName: 'uniqueTestFunction',
-        args: [123n],
+    it('strips ABI from non-revert errors', async () => {
+      // Create a client with an invalid RPC URL to trigger a real error
+      const invalidClient = createPublicClient({
+        transport: http('https://foobar.com'),
+        chain: foundry,
       });
 
-      fail('Should have thrown an error');
-    } catch (err: any) {
-      // Verify the original error has the ABI
-      const originalError = jsonStringify(err);
-      expect(originalError).toContain('uniqueTestFunction');
+      // Define a test ABI to have something to look for
+      const testAbi = [
+        {
+          type: 'function',
+          name: 'uniqueTestFunction',
+          inputs: [{ type: 'uint256', name: 'param1' }],
+          outputs: [{ type: 'bool' }],
+          stateMutability: 'view',
+        },
+      ] as const;
 
-      // Check that the formatted error doesn't have the ABI
-      const formatted = formatViemError(err);
-      const serialized = jsonStringify(formatted);
-      expect(serialized).not.toContain('uniqueTestFunction');
-      expect(formatted.message).toContain('failed');
-    }
-  }, 10_000);
+      try {
+        // Try to make a request that will fail
+        await invalidClient.readContract({
+          address: '0x1234567890123456789012345678901234567890',
+          abi: testAbi,
+          functionName: 'uniqueTestFunction',
+          args: [123n],
+        });
 
-  it('handles custom errors', async () => {
-    // We're deploying this contract:
-    // pragma solidity >=0.8.27;
+        fail('Should have thrown an error');
+      } catch (err: any) {
+        // Verify the original error has the ABI
+        const originalError = jsonStringify(err);
+        expect(originalError).toContain('uniqueTestFunction');
 
-    // library Errors {
-    //     error Test_Error(uint256 val);
-    // }
+        // Check that the formatted error doesn't have the ABI
+        const formatted = formatViemError(err);
+        const serialized = jsonStringify(formatted);
+        expect(serialized).not.toContain('uniqueTestFunction');
+        expect(formatted.message).toContain('failed');
+      }
+    }, 10_000);
 
-    // contract TestContract {
-    //     function triggerError(uint256 num) external pure {
-    //         require(false, Errors.Test_Error(num));
-    //     }
-    // }
-    const abi = [
-      {
-        inputs: [
-          {
-            internalType: 'uint256',
-            name: 'val',
-            type: 'uint256',
-          },
-        ],
-        name: 'Test_Error',
-        type: 'error',
-      },
-      {
-        inputs: [
-          {
-            internalType: 'uint256',
-            name: 'num',
-            type: 'uint256',
-          },
-        ],
-        name: 'triggerError',
-        outputs: [],
-        stateMutability: 'pure',
-        type: 'function',
-      },
-    ] as Abi;
-    const deployHash = await l1Client.deployContract({
-      abi,
-      bytecode:
-        // contract bytecode
-        '0x6080604052348015600e575f5ffd5b506101508061001c5f395ff3fe608060405234801561000f575f5ffd5b5060043610610029575f3560e01c80638291d6871461002d575b5f5ffd5b610047600480360381019061004291906100c7565b610049565b005b5f819061008c576040517fcdae48f50000000000000000000000000000000000000000000000000000000081526004016100839190610101565b60405180910390fd5b5050565b5f5ffd5b5f819050919050565b6100a681610094565b81146100b0575f5ffd5b50565b5f813590506100c18161009d565b92915050565b5f602082840312156100dc576100db610090565b5b5f6100e9848285016100b3565b91505092915050565b6100fb81610094565b82525050565b5f6020820190506101145f8301846100f2565b9291505056fea264697066735822122011972815480b23be1e371aa7c11caa30281e61b164209ae84edcd3fee026278364736f6c634300081b0033',
-    });
+    it('handles custom errors', async () => {
+      // We're deploying this contract:
+      // pragma solidity >=0.8.27;
 
-    const receipt = await l1Client.waitForTransactionReceipt({ hash: deployHash });
-    if (!receipt.contractAddress) {
-      throw new Error('No contract address');
-    }
-    const contractAddress = receipt.contractAddress;
+      // library Errors {
+      //     error Test_Error(uint256 val);
+      // }
 
-    try {
-      await l1Client.simulateContract({
-        address: contractAddress!,
+      // contract TestContract {
+      //     function triggerError(uint256 num) external pure {
+      //         require(false, Errors.Test_Error(num));
+      //     }
+      // }
+      const abi = [
+        {
+          inputs: [
+            {
+              internalType: 'uint256',
+              name: 'val',
+              type: 'uint256',
+            },
+          ],
+          name: 'Test_Error',
+          type: 'error',
+        },
+        {
+          inputs: [
+            {
+              internalType: 'uint256',
+              name: 'num',
+              type: 'uint256',
+            },
+          ],
+          name: 'triggerError',
+          outputs: [],
+          stateMutability: 'pure',
+          type: 'function',
+        },
+      ] as Abi;
+      const deployHash = await l1Client.deployContract({
         abi,
-        functionName: 'triggerError',
-        args: [33],
+        bytecode:
+          // contract bytecode
+          '0x6080604052348015600e575f5ffd5b506101508061001c5f395ff3fe608060405234801561000f575f5ffd5b5060043610610029575f3560e01c80638291d6871461002d575b5f5ffd5b610047600480360381019061004291906100c7565b610049565b005b5f819061008c576040517fcdae48f50000000000000000000000000000000000000000000000000000000081526004016100839190610101565b60405180910390fd5b5050565b5f5ffd5b5f819050919050565b6100a681610094565b81146100b0575f5ffd5b50565b5f813590506100c18161009d565b92915050565b5f602082840312156100dc576100db610090565b5b5f6100e9848285016100b3565b91505092915050565b6100fb81610094565b82525050565b5f6020820190506101145f8301846100f2565b9291505056fea264697066735822122011972815480b23be1e371aa7c11caa30281e61b164209ae84edcd3fee026278364736f6c634300081b0033',
       });
-    } catch (err: any) {
-      const { message } = formatViemError(err, abi);
-      expect(message).toBe('Test_Error(33)');
-    }
-  });
 
-  it('stops trying after timeout once block is mined', async () => {
-    await cheatCodes.setAutomine(false);
-    await cheatCodes.setIntervalMining(0);
-    gasUtils.config.txPropagationMaxQueryAttempts = 0;
+      const receipt = await l1Client.waitForTransactionReceipt({ hash: deployHash });
+      if (!receipt.contractAddress) {
+        throw new Error('No contract address');
+      }
+      const contractAddress = receipt.contractAddress;
 
-    const now = dateProvider.nowInSeconds() * 1000;
-    const txTimeoutAt = new Date(now + 1000);
-    const txRequest: L1TxRequest = { to: '0x1234567890123456789012345678901234567890', data: '0x', value: 0n };
-    const tx = await gasUtils.sendTransaction(txRequest);
-    const monitorPromise = gasUtils.monitorTransaction(txRequest, tx.txHash, tx, { txTimeoutAt });
-
-    await sleep(1000);
-    await cheatCodes.dropTransaction(tx.txHash);
-    await cheatCodes.setNextBlockTimestamp(txTimeoutAt);
-    await cheatCodes.mine();
-    await expect(monitorPromise).rejects.toThrow(/timed out/);
-    expect(dateProvider.now() - now).toBeGreaterThanOrEqual(990);
-  }, 20_000);
-
-  it('attempts to cancel timed out transactions', async () => {
-    await cheatCodes.mine(1);
-    await cheatCodes.setIntervalMining(0);
-    await cheatCodes.setAutomine(false);
-
-    const request = {
-      to: '0x1234567890123456789012345678901234567890' as `0x${string}`,
-      data: '0x' as `0x${string}`,
-      value: 1n,
-    };
-
-    // Send initial transaction
-    const { txHash } = await gasUtils.sendTransaction(request);
-    const initialTx = await l1Client.getTransaction({ hash: txHash });
-
-    // Try to monitor with a short timeout
-    const monitorPromise = gasUtils.monitorTransaction(
-      request,
-      txHash,
-      { gasLimit: initialTx.gas! },
-      { txTimeoutMs: 100, checkIntervalMs: 10 }, // Short timeout to trigger cancellation quickly
-    );
-
-    // Wait for timeout and catch the error
-    await expect(monitorPromise).rejects.toThrow('timed out');
-
-    // Wait for cancellation tx to be sent
-    await sleep(100);
-
-    // Get the nonce that was used
-    const nonce = initialTx.nonce;
-
-    // Get pending transactions
-    const pendingBlock = await l1Client.getBlock({ blockTag: 'pending' });
-    const pendingTxHash = pendingBlock.transactions[0];
-    const cancelTx = await l1Client.getTransaction({ hash: pendingTxHash });
-
-    // Verify cancellation tx
-    expect(cancelTx).toBeDefined();
-    expect(cancelTx!.to!.toLowerCase()).toBe(l1Client.account.address.toLowerCase());
-    expect(cancelTx!.nonce).toBe(nonce);
-    expect(cancelTx!.value).toBe(0n);
-    expect(cancelTx!.maxFeePerGas).toBeGreaterThan(initialTx.maxFeePerGas!);
-    expect(cancelTx!.maxPriorityFeePerGas).toBeGreaterThan(initialTx.maxPriorityFeePerGas!);
-    expect(cancelTx!.gas).toBe(21000n);
-
-    // Mine a block to process the cancellation
-    await cheatCodes.evmMine();
-
-    // Verify the original transaction is no longer present
-    await expect(l1Client.getTransaction({ hash: txHash })).rejects.toThrow();
-  }, 10_000);
-
-  it('attempts to cancel timed out blob transactions with correct parameters', async () => {
-    // Disable auto-mining to control block production
-    await cheatCodes.setAutomine(false);
-    await cheatCodes.setIntervalMining(0);
-
-    // Create blob data
-    const blobData = new Uint8Array(131072).fill(1);
-    const kzg = Blob.getViemKzgInstance();
-
-    const request = {
-      to: '0x1234567890123456789012345678901234567890' as `0x${string}`,
-      data: '0x' as `0x${string}`,
-      value: 0n,
-    };
-
-    // Send initial blob transaction
-    const { txHash } = await gasUtils.sendTransaction(request, undefined, {
-      blobs: [blobData],
-      kzg,
-      maxFeePerBlobGas: 100n * WEI_CONST, // 100 gwei
+      try {
+        await l1Client.simulateContract({
+          address: contractAddress!,
+          abi,
+          functionName: 'triggerError',
+          args: [33],
+        });
+      } catch (err: any) {
+        const { message } = formatViemError(err, abi);
+        expect(message).toBe('Test_Error(33)');
+      }
     });
-    const initialTx = await l1Client.getTransaction({ hash: txHash });
 
-    // Try to monitor with a short timeout
-    const monitorPromise = gasUtils.monitorTransaction(
-      request,
-      txHash,
-      { gasLimit: initialTx.gas! },
-      { txTimeoutMs: 100, checkIntervalMs: 10 }, // Short timeout to trigger cancellation quickly
-      {
+    it('stops trying after timeout once block is mined', async () => {
+      await cheatCodes.setAutomine(false);
+      await cheatCodes.setIntervalMining(0);
+      gasUtils.config.txPropagationMaxQueryAttempts = 0;
+
+      const now = dateProvider.nowInSeconds() * 1000;
+      const txTimeoutAt = new Date(now + 1000);
+      const txRequest: L1TxRequest = { to: '0x1234567890123456789012345678901234567890', data: '0x', value: 0n };
+      const tx = await gasUtils.sendTransaction(txRequest);
+      const monitorPromise = gasUtils.monitorTransaction(txRequest, tx.txHash, tx, { txTimeoutAt });
+
+      await sleep(1000);
+      await cheatCodes.dropTransaction(tx.txHash);
+      await cheatCodes.setNextBlockTimestamp(txTimeoutAt);
+      await cheatCodes.mine();
+      await expect(monitorPromise).rejects.toThrow(/timed out/);
+      expect(dateProvider.now() - now).toBeGreaterThanOrEqual(990);
+    }, 20_000);
+
+    it('attempts to cancel timed out transactions', async () => {
+      // Disable auto-mining to control block production
+      await cheatCodes.setIntervalMining(0);
+      await cheatCodes.setAutomine(false);
+
+      const request = {
+        to: '0x1234567890123456789012345678901234567890' as `0x${string}`,
+        data: '0x' as `0x${string}`,
+        value: 1n,
+      };
+
+      // Send initial transaction
+      const { txHash } = await gasUtils.sendTransaction(request);
+      const initialTx = await l1Client.getTransaction({ hash: txHash });
+
+      // Try to monitor with a short timeout
+      const monitorPromise = gasUtils.monitorTransaction(
+        request,
+        txHash,
+        { gasLimit: initialTx.gas! },
+        { txTimeoutMs: 100, checkIntervalMs: 10 }, // Short timeout to trigger cancellation quickly
+      );
+
+      // Wait for timeout and catch the error
+      await expect(monitorPromise).rejects.toThrow('timed out');
+
+      // Wait for cancellation tx to be sent
+      await sleep(100);
+
+      // Get the nonce that was used
+      const nonce = initialTx.nonce;
+
+      // Get pending transactions
+      const pendingBlock = await l1Client.getBlock({ blockTag: 'pending' });
+      const pendingTxHash = pendingBlock.transactions[0];
+      const cancelTx = await l1Client.getTransaction({ hash: pendingTxHash });
+
+      // Verify cancellation tx
+      expect(cancelTx).toBeDefined();
+      expect(cancelTx!.to!.toLowerCase()).toBe(l1Client.account.address.toLowerCase());
+      expect(cancelTx!.value).toBe(0n);
+      expect(cancelTx!.nonce).toBe(nonce);
+      expect(cancelTx!.maxFeePerGas).toBeGreaterThan(initialTx.maxFeePerGas!);
+      expect(cancelTx!.maxPriorityFeePerGas).toBeGreaterThan(initialTx.maxPriorityFeePerGas!);
+      expect(cancelTx!.gas).toBe(21000n);
+
+      // Mine a block to process the cancellation
+      await cheatCodes.evmMine();
+
+      // Verify the original transaction is no longer present
+      await expect(l1Client.getTransaction({ hash: txHash })).rejects.toThrow();
+    }, 10_000);
+
+    it('attempts to cancel timed out blob transactions with correct parameters', async () => {
+      // Disable auto-mining to control block production
+      await cheatCodes.setAutomine(false);
+      await cheatCodes.setIntervalMining(0);
+
+      // Create blob data
+      const blobData = new Uint8Array(131072).fill(1);
+      const kzg = Blob.getViemKzgInstance();
+
+      const request = {
+        to: '0x1234567890123456789012345678901234567890' as `0x${string}`,
+        data: '0x' as `0x${string}`,
+        value: 0n,
+      };
+
+      // Send initial blob transaction
+      const { txHash } = await gasUtils.sendTransaction(request, undefined, {
         blobs: [blobData],
         kzg,
-        maxFeePerBlobGas: 100n * WEI_CONST,
-      },
-    );
-
-    // Wait for timeout and catch the error
-    await expect(monitorPromise).rejects.toThrow('timed out');
-
-    // Wait for cancellation tx to be sent
-    await sleep(100);
-
-    // Get the nonce that was used
-    const nonce = initialTx.nonce;
-
-    // Get pending transactions
-    const pendingBlock = await l1Client.getBlock({ blockTag: 'pending' });
-    const pendingTxHash = pendingBlock.transactions[0];
-    const cancelTx = await l1Client.getTransaction({ hash: pendingTxHash });
-
-    // Verify cancellation tx
-    expect(cancelTx).toBeDefined();
-    expect(cancelTx!.nonce).toBe(nonce);
-    expect(cancelTx!.to!.toLowerCase()).toBe(l1Client.account.address.toLowerCase());
-    expect(cancelTx!.value).toBe(0n);
-    expect(cancelTx!.maxFeePerGas).toBeGreaterThan(initialTx.maxFeePerGas!);
-    expect(cancelTx!.maxPriorityFeePerGas).toBeGreaterThan(initialTx.maxPriorityFeePerGas!);
-    expect(cancelTx!.maxFeePerBlobGas).toBeGreaterThan(initialTx.maxFeePerBlobGas!);
-    expect(cancelTx!.blobVersionedHashes).toBeDefined();
-    expect(cancelTx!.blobVersionedHashes!.length).toBe(1);
-
-    // Mine a block to process the cancellation
-    await cheatCodes.evmMine();
-
-    // Verify the original transaction is no longer present
-    await expect(l1Client.getTransaction({ hash: txHash })).rejects.toThrow();
-  }, 10_000);
-
-  it('does not attempt to cancel a timed out tx when cancelTxOnTimeout is false', async () => {
-    const request = {
-      to: '0x1234567890123456789012345678901234567890' as `0x${string}`,
-      data: '0x' as `0x${string}`,
-      value: 0n,
-    };
-
-    const { txHash } = await gasUtils.sendTransaction(request);
-    const initialTx = await l1Client.getTransaction({ hash: txHash });
-
-    // monitor with a short timeout and cancellation disabled
-    const monitorPromise = gasUtils.monitorTransaction(
-      request,
-      txHash,
-      { gasLimit: initialTx.gas! },
-      { txTimeoutMs: 100, checkIntervalMs: 10, cancelTxOnTimeout: false }, // Disable cancellation
-    );
-
-    // Wait for timeout and catch the error
-    await expect(monitorPromise).rejects.toThrow('timed out');
-
-    // Wait to ensure no cancellation tx is sent
-    await sleep(100);
-
-    // Get the nonce that was used
-    const nonce = initialTx.nonce;
-
-    // Get pending transactions
-    const pendingBlock = await l1Client.getBlock({ blockTag: 'pending' });
-
-    // Check no additional transactions were sent (only the initial tx should be present)
-    expect(pendingBlock.transactions.length).toBe(1);
-    expect(pendingBlock.transactions[0]).toBe(txHash);
-
-    // Original tx should still be available
-    const tx = await l1Client.getTransaction({ hash: txHash });
-    expect(tx).toBeDefined();
-    expect(tx!.nonce).toBe(nonce);
-  }, 10_000);
-
-  it('ensures block gas limit is set when using LARGE_GAS_LIMIT', async () => {
-    const request = {
-      to: '0x1234567890123456789012345678901234567890' as `0x${string}`,
-      data: '0x' as `0x${string}`,
-      value: 0n,
-    };
-
-    let capturedBlockOverrides: any = {};
-    const originalSimulate = gasUtils['_simulate'].bind(gasUtils);
-
-    const spy = jest
-      .spyOn(gasUtils as any, '_simulate')
-      .mockImplementation((call: any, blockOverrides: any, stateOverrides: any, gasConfig: any, abi: any) => {
-        capturedBlockOverrides = blockOverrides;
-        return originalSimulate(call, blockOverrides, stateOverrides, gasConfig, abi);
+        maxFeePerBlobGas: 100n * WEI_CONST, // 100 gwei
       });
+      const initialTx = await l1Client.getTransaction({ hash: txHash });
 
-    try {
-      // Test with ensureBlockGasLimit: true (default)
-      await gasUtils.simulate(request, {}, [], undefined, { ignoreBlockGasLimit: false });
-      expect(capturedBlockOverrides.gasLimit).toBe(24_000_000n);
+      // Try to monitor with a short timeout
+      const monitorPromise = gasUtils.monitorTransaction(
+        request,
+        txHash,
+        { gasLimit: initialTx.gas! },
+        { txTimeoutMs: 100, checkIntervalMs: 10 }, // Short timeout to trigger cancellation quickly
+        {
+          blobs: [blobData],
+          kzg,
+          maxFeePerBlobGas: 100n * WEI_CONST,
+        },
+      );
 
-      // Test with ensureBlockGasLimit: false
-      capturedBlockOverrides = {};
-      await gasUtils.simulate(request, {}, [], undefined, { ignoreBlockGasLimit: true });
-      expect(capturedBlockOverrides.gasLimit).toBeUndefined();
+      // Wait for timeout and catch the error
+      await expect(monitorPromise).rejects.toThrow('timed out');
 
-      // Test with explicit gas in request
-      capturedBlockOverrides = {};
-      await gasUtils.simulate({ ...request, gas: 1_000_000n }, {}, [], undefined, { ignoreBlockGasLimit: false });
-      expect(capturedBlockOverrides.gasLimit).toBeUndefined();
-    } finally {
-      spy.mockRestore();
-    }
+      // Wait for cancellation tx to be sent
+      await sleep(100);
+
+      // Get the nonce that was used
+      const nonce = initialTx.nonce;
+
+      // Get pending transactions
+      const pendingBlock = await l1Client.getBlock({ blockTag: 'pending' });
+      const pendingTxHash = pendingBlock.transactions[0];
+      const cancelTx = await l1Client.getTransaction({ hash: pendingTxHash });
+
+      // Verify cancellation tx
+      expect(cancelTx).toBeDefined();
+      expect(cancelTx!.nonce).toBe(nonce);
+      expect(cancelTx!.to!.toLowerCase()).toBe(l1Client.account.address.toLowerCase());
+      expect(cancelTx!.value).toBe(0n);
+      expect(cancelTx!.maxFeePerGas).toBeGreaterThan(initialTx.maxFeePerGas!);
+      expect(cancelTx!.maxPriorityFeePerGas).toBeGreaterThan(initialTx.maxPriorityFeePerGas!);
+      expect(cancelTx!.maxFeePerBlobGas).toBeGreaterThan(initialTx.maxFeePerBlobGas!);
+      expect(cancelTx!.blobVersionedHashes).toBeDefined();
+      expect(cancelTx!.blobVersionedHashes!.length).toBe(1);
+
+      // Mine a block to process the cancellation
+      await cheatCodes.evmMine();
+
+      // Verify the original transaction is no longer present
+      await expect(l1Client.getTransaction({ hash: txHash })).rejects.toThrow();
+    }, 10_000);
+
+    it('does not attempt to cancel a timed out tx when cancelTxOnTimeout is false', async () => {
+      const request = {
+        to: '0x1234567890123456789012345678901234567890' as `0x${string}`,
+        data: '0x' as `0x${string}`,
+        value: 0n,
+      };
+
+      const { txHash } = await gasUtils.sendTransaction(request);
+      const initialTx = await l1Client.getTransaction({ hash: txHash });
+
+      // monitor with a short timeout and cancellation disabled
+      const monitorPromise = gasUtils.monitorTransaction(
+        request,
+        txHash,
+        { gasLimit: initialTx.gas! },
+        { txTimeoutMs: 100, checkIntervalMs: 10, cancelTxOnTimeout: false }, // Disable cancellation
+      );
+
+      // Wait for timeout and catch the error
+      await expect(monitorPromise).rejects.toThrow('timed out');
+
+      // Wait to ensure no cancellation tx is sent
+      await sleep(100);
+
+      // Get the nonce that was used
+      const nonce = initialTx.nonce;
+
+      // Get pending transactions
+      const pendingBlock = await l1Client.getBlock({ blockTag: 'pending' });
+
+      // Check no additional transactions were sent (only the initial tx should be present)
+      expect(pendingBlock.transactions.length).toBe(1);
+      expect(pendingBlock.transactions[0]).toBe(txHash);
+
+      // Original tx should still be available
+      const tx = await l1Client.getTransaction({ hash: txHash });
+      expect(tx).toBeDefined();
+      expect(tx!.nonce).toBe(nonce);
+    }, 10_000);
+
+    it('ensures block gas limit is set when using LARGE_GAS_LIMIT', async () => {
+      const request = {
+        to: '0x1234567890123456789012345678901234567890' as `0x${string}`,
+        data: '0x' as `0x${string}`,
+        value: 0n,
+      };
+
+      let capturedBlockOverrides: any = {};
+      const originalSimulate = gasUtils['_simulate'].bind(gasUtils);
+
+      const spy = jest
+        .spyOn(gasUtils as any, '_simulate')
+        .mockImplementation((call: any, blockOverrides: any, stateOverrides: any, gasConfig: any, abi: any) => {
+          capturedBlockOverrides = blockOverrides;
+          return originalSimulate(call, blockOverrides, stateOverrides, gasConfig, abi);
+        });
+
+      try {
+        // Test with ensureBlockGasLimit: true (default)
+        await gasUtils.simulate(request, {}, [], undefined, { ignoreBlockGasLimit: false });
+        expect(capturedBlockOverrides.gasLimit).toBe(24_000_000n);
+
+        // Test with ensureBlockGasLimit: false
+        capturedBlockOverrides = {};
+        await gasUtils.simulate(request, {}, [], undefined, { ignoreBlockGasLimit: true });
+        expect(capturedBlockOverrides.gasLimit).toBeUndefined();
+
+        // Test with explicit gas in request
+        capturedBlockOverrides = {};
+        await gasUtils.simulate({ ...request, gas: 1_000_000n }, {}, [], undefined, { ignoreBlockGasLimit: false });
+        expect(capturedBlockOverrides.gasLimit).toBeUndefined();
+      } finally {
+        spy.mockRestore();
+      }
+    });
+
+    it('ensures block gas limit is set when using LARGE_GAS_LIMIT with custom block overrides', async () => {
+      const request = {
+        to: '0x1234567890123456789012345678901234567890' as `0x${string}`,
+        data: '0x' as `0x${string}`,
+        value: 0n,
+      };
+
+      let capturedBlockOverrides: any = {};
+      const originalSimulate = gasUtils['_simulate'].bind(gasUtils);
+
+      const spy = jest
+        .spyOn(gasUtils as any, '_simulate')
+        .mockImplementation((call: any, blockOverrides: any, stateOverrides: any, gasConfig: any, abi: any) => {
+          capturedBlockOverrides = blockOverrides;
+          return originalSimulate(call, blockOverrides, stateOverrides, gasConfig, abi);
+        });
+
+      try {
+        // Test with custom block overrides and ensureBlockGasLimit: true
+        const myCustomBlockOverrides = { baseFeePerGas: 1000000000n };
+        await gasUtils.simulate(request, myCustomBlockOverrides, [], undefined, { ignoreBlockGasLimit: false });
+
+        // Verify that block gas limit is set while preserving custom overrides
+        expect(capturedBlockOverrides.gasLimit).toBe(24_000_000n); // 12_000_000 * 2
+        expect(capturedBlockOverrides.baseFeePerGas).toBe(1000000000n);
+      } finally {
+        spy.mockRestore();
+      }
+    });
   });
 
-  it('ensures block gas limit is set when using LARGE_GAS_LIMIT with custom block overrides', async () => {
-    const request = {
-      to: '0x1234567890123456789012345678901234567890' as `0x${string}`,
-      data: '0x' as `0x${string}`,
-      value: 0n,
-    };
+  describe('L1TxUtils vs ReadOnlyL1TxUtils', () => {
+    let publicClient: ViemClient;
+    let walletClient: ExtendedViemWalletClient;
 
-    let capturedBlockOverrides: any = {};
-    const originalSimulate = gasUtils['_simulate'].bind(gasUtils);
+    beforeEach(() => {
+      walletClient = l1Client;
+      publicClient = getPublicClient({ l1RpcUrls: [rpcUrl], l1ChainId: 31337 });
+    });
 
-    const spy = jest
-      .spyOn(gasUtils as any, '_simulate')
-      .mockImplementation((call: any, blockOverrides: any, stateOverrides: any, gasConfig: any, abi: any) => {
-        capturedBlockOverrides = blockOverrides;
-        return originalSimulate(call, blockOverrides, stateOverrides, gasConfig, abi);
-      });
+    it('ReadOnlyL1TxUtils can be instantiated with public client but not wallet methods', () => {
+      const readOnlyUtils = new ReadOnlyL1TxUtils(publicClient, logger, dateProvider);
+      expect(readOnlyUtils).toBeDefined();
+      expect(readOnlyUtils.client).toBe(publicClient);
 
-    try {
-      // Test with custom block overrides and ensureBlockGasLimit: true
-      const myCustomBlockOverrides = { baseFeePerGas: 1000000000n };
-      await gasUtils.simulate(request, myCustomBlockOverrides, [], undefined, { ignoreBlockGasLimit: false });
+      // Verify wallet-specific methods are not available
+      expect(readOnlyUtils).not.toHaveProperty('getSenderAddress');
+      expect(readOnlyUtils).not.toHaveProperty('getSenderBalance');
+      expect(readOnlyUtils).not.toHaveProperty('sendTransaction');
+      expect(readOnlyUtils).not.toHaveProperty('monitorTransaction');
+      expect(readOnlyUtils).not.toHaveProperty('sendAndMonitorTransaction');
+    });
 
-      // Verify that block gas limit is set while preserving custom overrides
-      expect(capturedBlockOverrides.gasLimit).toBe(24_000_000n); // 12_000_000 * 2
-      expect(capturedBlockOverrides.baseFeePerGas).toBe(1000000000n);
-    } finally {
-      spy.mockRestore();
-    }
-  });
-});
+    it('L1TxUtils can be instantiated with wallet client and has write methods', () => {
+      const l1TxUtils = new L1TxUtils(walletClient, logger);
+      expect(l1TxUtils).toBeDefined();
+      expect(l1TxUtils.client).toBe(walletClient);
 
-describe('L1TxUtils vs ReadOnlyL1TxUtils', () => {
-  let publicClient: ViemClient;
-  let walletClient: ExtendedViemWalletClient;
-  let dateProvider: TestDateProvider;
+      // Verify wallet-specific methods are available
+      expect(l1TxUtils.getSenderAddress).toBeDefined();
+      expect(l1TxUtils.getSenderBalance).toBeDefined();
+      expect(l1TxUtils.sendTransaction).toBeDefined();
+      expect(l1TxUtils.monitorTransaction).toBeDefined();
+      expect(l1TxUtils.sendAndMonitorTransaction).toBeDefined();
+    });
 
-  beforeAll(async () => {
-    dateProvider = new TestDateProvider();
-    const { rpcUrl } = await startAnvil({ l1BlockTime: 1 });
+    it('L1TxUtils inherits all read-only methods from ReadOnlyL1TxUtils', () => {
+      const l1TxUtils = new L1TxUtils(walletClient, logger);
 
-    const hdAccount = mnemonicToAccount(MNEMONIC, { addressIndex: 0 });
-    const privKeyRaw = hdAccount.getHdKey().privateKey;
-    if (!privKeyRaw) {
-      throw new Error('Failed to get private key');
-    }
-    const privKey = Buffer.from(privKeyRaw).toString('hex');
-    const account = privateKeyToAccount(`0x${privKey}`);
+      // Verify all read-only methods are available
+      expect(l1TxUtils.getBlock).toBeDefined();
+      expect(l1TxUtils.getBlockNumber).toBeDefined();
+      expect(l1TxUtils.getGasPrice).toBeDefined();
+      expect(l1TxUtils.estimateGas).toBeDefined();
+      expect(l1TxUtils.getTransactionStats).toBeDefined();
+      expect(l1TxUtils.simulate).toBeDefined();
+      expect(l1TxUtils.bumpGasLimit).toBeDefined();
+    });
 
-    walletClient = createExtendedL1Client([rpcUrl], account, foundry);
-    publicClient = getPublicClient({ l1RpcUrls: [rpcUrl], l1ChainId: 31337 });
-  });
-
-  it('ReadOnlyL1TxUtils can be instantiated with public client but not wallet methods', () => {
-    const readOnlyUtils = new ReadOnlyL1TxUtils(publicClient, logger, dateProvider);
-    expect(readOnlyUtils).toBeDefined();
-    expect(readOnlyUtils.client).toBe(publicClient);
-
-    // Verify wallet-specific methods are not available
-    expect(readOnlyUtils).not.toHaveProperty('getSenderAddress');
-    expect(readOnlyUtils).not.toHaveProperty('getSenderBalance');
-    expect(readOnlyUtils).not.toHaveProperty('sendTransaction');
-    expect(readOnlyUtils).not.toHaveProperty('monitorTransaction');
-    expect(readOnlyUtils).not.toHaveProperty('sendAndMonitorTransaction');
-  });
-
-  it('L1TxUtils can be instantiated with wallet client and has write methods', () => {
-    const l1TxUtils = new L1TxUtils(walletClient, logger, dateProvider);
-    expect(l1TxUtils).toBeDefined();
-    expect(l1TxUtils.client).toBe(walletClient);
-
-    // Verify wallet-specific methods are available
-    expect(l1TxUtils.getSenderAddress).toBeDefined();
-    expect(l1TxUtils.getSenderBalance).toBeDefined();
-    expect(l1TxUtils.sendTransaction).toBeDefined();
-    expect(l1TxUtils.monitorTransaction).toBeDefined();
-    expect(l1TxUtils.sendAndMonitorTransaction).toBeDefined();
-  });
-
-  it('L1TxUtils inherits all read-only methods from ReadOnlyL1TxUtils', () => {
-    const l1TxUtils = new L1TxUtils(walletClient, logger, dateProvider);
-
-    // Verify all read-only methods are available
-    expect(l1TxUtils.getBlock).toBeDefined();
-    expect(l1TxUtils.getBlockNumber).toBeDefined();
-    expect(l1TxUtils.getGasPrice).toBeDefined();
-    expect(l1TxUtils.estimateGas).toBeDefined();
-    expect(l1TxUtils.getTransactionStats).toBeDefined();
-    expect(l1TxUtils.simulate).toBeDefined();
-    expect(l1TxUtils.bumpGasLimit).toBeDefined();
-  });
-
-  it('L1TxUtils cannot be instantiated with public client', () => {
-    expect(() => {
-      new L1TxUtils(publicClient as any, logger, dateProvider);
-    }).toThrow();
+    it('L1TxUtils cannot be instantiated with public client', () => {
+      expect(() => {
+        new L1TxUtils(publicClient as any, logger);
+      }).toThrow();
+    });
   });
 });

--- a/yarn-project/ethereum/src/test/delayed_tx_utils.ts
+++ b/yarn-project/ethereum/src/test/delayed_tx_utils.ts
@@ -1,18 +1,14 @@
-import type { DateProvider } from '@aztec/foundation/timer';
-
 import { L1TxUtilsWithBlobs } from '../l1_tx_utils_with_blobs.js';
 import { type Delayer, withDelayer } from './tx_delayer.js';
 
 export class DelayedTxUtils extends L1TxUtilsWithBlobs {
   public delayer: Delayer | undefined;
-  public dateProvider!: DateProvider;
 
-  public static fromL1TxUtils(l1TxUtils: L1TxUtilsWithBlobs, dateProvider: DateProvider, ethereumSlotDuration: number) {
-    const { client, delayer } = withDelayer(l1TxUtils.client, dateProvider, {
+  public static fromL1TxUtils(l1TxUtils: L1TxUtilsWithBlobs, ethereumSlotDuration: number) {
+    const { client, delayer } = withDelayer(l1TxUtils.client, l1TxUtils.dateProvider, {
       ethereumSlotDuration,
     });
     const casted = l1TxUtils as unknown as DelayedTxUtils;
-    casted.dateProvider = dateProvider;
     casted.delayer = delayer;
     casted.client = client;
     return casted;

--- a/yarn-project/ethereum/src/test/eth_cheat_codes.ts
+++ b/yarn-project/ethereum/src/test/eth_cheat_codes.ts
@@ -206,9 +206,11 @@ export class EthCheatCodes {
    * Set the next block timestamp
    * @param timestamp - The timestamp to set the next block to
    */
-  public async setNextBlockTimestamp(timestamp: number): Promise<void> {
+  public async setNextBlockTimestamp(timestamp: number | Date): Promise<void> {
     try {
-      await this.rpcCall('evm_setNextBlockTimestamp', [timestamp]);
+      await this.rpcCall('evm_setNextBlockTimestamp', [
+        timestamp instanceof Date ? Math.floor(timestamp.getTime() / 1000) : timestamp,
+      ]);
     } catch (err: any) {
       throw new Error(`Error setting next block timestamp: ${err.message}`);
     }

--- a/yarn-project/ethereum/src/test/start_anvil.ts
+++ b/yarn-project/ethereum/src/test/start_anvil.ts
@@ -37,7 +37,7 @@ export async function startAnvil(
 
       // Listen to the anvil output to get the port.
       const removeHandler = anvil.on('message', (message: string) => {
-        logger?.debug(message);
+        logger?.debug(message.trim());
 
         methodCalls?.push(...(message.match(/eth_[^\s]+/g) || []));
         if (port === undefined && message.includes('Listening on')) {

--- a/yarn-project/prover-node/src/factory.ts
+++ b/yarn-project/prover-node/src/factory.ts
@@ -73,7 +73,7 @@ export async function createProverNode(
 
   const rollupContract = new RollupContract(l1Client, config.l1Contracts.rollupAddress.toString());
 
-  const l1TxUtils = deps.l1TxUtils ?? new L1TxUtils(l1Client, log, config);
+  const l1TxUtils = deps.l1TxUtils ?? new L1TxUtils(l1Client, log, deps.dateProvider, config);
   const publisher = deps.publisher ?? new ProverNodePublisher(config, { telemetry, rollupContract, l1TxUtils });
 
   const epochCache = await EpochCache.create(config.l1Contracts.rollupAddress, config);

--- a/yarn-project/sequencer-client/src/client/sequencer-client.ts
+++ b/yarn-project/sequencer-client/src/client/sequencer-client.ts
@@ -79,7 +79,7 @@ export class SequencerClient {
     const chain = createEthereumChain(rpcUrls, chainId);
     const log = createLogger('sequencer-client');
     const l1Client = createExtendedL1Client(rpcUrls, publisherPrivateKey.getValue(), chain.chainInfo);
-    const l1TxUtils = deps.l1TxUtils ?? new L1TxUtilsWithBlobs(l1Client, log, config);
+    const l1TxUtils = deps.l1TxUtils ?? new L1TxUtilsWithBlobs(l1Client, log, deps.dateProvider, config);
     const rollupContract = new RollupContract(l1Client, config.l1Contracts.rollupAddress.toString());
     const [l1GenesisTime, slotDuration] = await Promise.all([
       rollupContract.getL1GenesisTime(),


### PR DESCRIPTION
Attempt at fixing the following flakes:

http://ci.aztec-labs.com/c49566dcb187d204
http://ci.aztec-labs.com/b4c0c357709ad3dc
http://ci.aztec-labs.com/7638dcd6b600ac3a

What I understand is happening is that:
- The sequencer publisher sends the tx to L1
- For some reason, it fails to retrieve its receipt and thinks it timed out
- Since it failed, it does not send the blob to the local blob sink
- The archiver ends up in a broken state where it can see a block but cannot fetch its blob
- Node stops progressing

Looking at the logs from one of the flakes, we see:
```
15:46:14 [15:46:14.835] ERROR: node:4 L1 transaction 0x720427cf19b5d95f429afb943fa82659774ee12cc5b581b8d3ac9612da314677 timed out: {
txHash: '0x720427cf19b5d95f429afb943fa82659774ee12cc5b581b8d3ac9612da314677',
txTimeoutAt: 2025-07-17T15:50:51.000Z,
txTimeoutMs: 120000,
txInitialTime: 1752767444472,
now: 1752767451032,
```

Where `txTimeoutAt` above is `1752767451000`, just 32 milliseconds past `now`. What I believe is happening is that the timeout condition is kicking _before_ we had a chance to request the receipt for the tx. 

In `monitorTransaction` we first see if the tx is mined, then do a few other things, and then check if we have timed out. If the tx gets mined in a block with timestamp equal to the `txTimeoutAt` inbetween those two operations, then we'll miss it and consider it as timed out. And note that in block building we set `txTimeoutAt` to the timestamp of the last block in which the tx can be mined, so it's very likely we run into this race condition often.
