### PR TITLE
fix type signature of isSyncStore function to correctly identify Azte…

### DIFF
--- a/yarn-project/kv-store/src/interfaces/utils.ts
+++ b/yarn-project/kv-store/src/interfaces/utils.ts
@@ -17,6 +17,6 @@ export const mockLogger = {
 };
 /* eslint-enable no-console */
 
-export function isSyncStore(store: AztecKVStore | AztecAsyncKVStore): store is AztecAsyncKVStore {
+export function isSyncStore(store: AztecKVStore | AztecAsyncKVStore): store is AztecKVStore {
   return (store as AztecKVStore).syncGetters === true;
 }


### PR DESCRIPTION
### Description:
Fixes a critical type signature issue in the `isSyncStore` function in the kv-store module. The function was incorrectly typed to return `store is AztecAsyncKVStore` while its implementation actually checks for `AztecKVStore` instances by verifying the presence of the `syncGetters === true` property