### PR TITLE
chore: make TestERC20 ownable2step

### DIFF
--- a/l1-contracts/src/governance/CoinIssuer.sol
+++ b/l1-contracts/src/governance/CoinIssuer.sol
@@ -6,6 +6,7 @@ import {ICoinIssuer} from "@aztec/governance/interfaces/ICoinIssuer.sol";
 import {Errors} from "@aztec/governance/libraries/Errors.sol";
 import {IMintableERC20} from "@aztec/shared/interfaces/IMintableERC20.sol";
 import {Ownable} from "@oz/access/Ownable.sol";
+import {Ownable2Step} from "@oz/access/Ownable2Step.sol";
 
 /**
  * @title CoinIssuer
@@ -21,6 +22,10 @@ contract CoinIssuer is ICoinIssuer, Ownable {
     ASSET = _asset;
     RATE = _rate;
     timeOfLastMint = block.timestamp;
+  }
+
+  function acceptTokenOwnership() external override(ICoinIssuer) onlyOwner {
+    Ownable2Step(address(ASSET)).acceptOwnership();
   }
 
   /**

--- a/l1-contracts/src/governance/interfaces/ICoinIssuer.sol
+++ b/l1-contracts/src/governance/interfaces/ICoinIssuer.sol
@@ -4,5 +4,6 @@ pragma solidity >=0.8.27;
 
 interface ICoinIssuer {
   function mint(address _to, uint256 _amount) external;
+  function acceptTokenOwnership() external;
   function mintAvailable() external view returns (uint256);
 }

--- a/l1-contracts/src/mock/TestERC20.sol
+++ b/l1-contracts/src/mock/TestERC20.sol
@@ -3,10 +3,10 @@
 pragma solidity >=0.8.27;
 
 import {IMintableERC20} from "@aztec/shared/interfaces/IMintableERC20.sol";
-import {Ownable} from "@oz/access/Ownable.sol";
+import {Ownable, Ownable2Step} from "@oz/access/Ownable2Step.sol";
 import {ERC20} from "@oz/token/ERC20/ERC20.sol";
 
-contract TestERC20 is ERC20, IMintableERC20, Ownable {
+contract TestERC20 is ERC20, IMintableERC20, Ownable2Step {
   mapping(address minter => bool isMinter) public minters;
 
   modifier onlyMinter() {
@@ -36,13 +36,13 @@ contract TestERC20 is ERC20, IMintableERC20, Ownable {
     emit MinterRemoved(_minter);
   }
 
-  function transferOwnership(address _newOwner) public override(Ownable) onlyOwner {
-    if (_newOwner == address(0)) {
-      revert OwnableInvalidOwner(address(0));
-    }
-    removeMinter(owner());
-    addMinter(_newOwner);
-    _transferOwnership(_newOwner);
+  function acceptOwnership() public virtual override(Ownable2Step) {
+    address oldOwner = owner();
+    address newOwner = pendingOwner();
+    super.acceptOwnership();
+
+    removeMinter(oldOwner);
+    addMinter(newOwner);
   }
 }
 // docs:end:contract

--- a/l1-contracts/test/Rollup.t.sol
+++ b/l1-contracts/test/Rollup.t.sol
@@ -507,6 +507,7 @@ contract RollupTest is RollupBase {
     assertEq(rollup.getCollectiveProverRewardsForEpoch(Epoch.wrap(0)), 0, "invalid prover rewards");
 
     {
+      vm.prank(testERC20.owner());
       testERC20.mint(address(feeJuicePortal), interim.feeAmount - interim.portalBalance);
 
       // When the block is proven we should have received the funds

--- a/l1-contracts/test/builder/RollupBuilder.sol
+++ b/l1-contracts/test/builder/RollupBuilder.sol
@@ -16,6 +16,7 @@ import {MockVerifier} from "@aztec/mock/MockVerifier.sol";
 import {StakingQueueConfig} from "@aztec/core/libraries/compressed-data/StakingQueueConfig.sol";
 import {Test} from "forge-std/Test.sol";
 import {MultiAdder, CheatDepositArgs} from "@aztec/mock/MultiAdder.sol";
+import {CoinIssuer} from "@aztec/governance/CoinIssuer.sol";
 
 // Stack the layers to avoid the stack too deep 🧌
 struct ConfigFlags {
@@ -33,6 +34,7 @@ struct ConfigValues {
 
 struct Config {
   address deployer;
+  CoinIssuer coinIssuer;
   TestERC20 testERC20;
   Registry registry;
   Governance governance;
@@ -209,6 +211,10 @@ contract RollupBuilder is Test {
       config.testERC20 = new TestERC20("test", "TEST", address(this));
     }
 
+    if (address(config.coinIssuer) == address(0)) {
+      config.coinIssuer = new CoinIssuer(config.testERC20, 1e18, address(this));
+    }
+
     if (address(config.gse) == address(0)) {
       config.gse = new GSE(
         address(this), config.testERC20, TestConstants.DEPOSIT_AMOUNT, TestConstants.MINIMUM_STAKE
@@ -285,9 +291,10 @@ contract RollupBuilder is Test {
     }
 
     if (config.flags.updateOwnerships) {
-      if (config.deployer != config.testERC20.owner()) {
+      if (address(config.coinIssuer) != config.testERC20.owner()) {
         vm.prank(config.testERC20.owner());
-        config.testERC20.transferOwnership(config.deployer);
+        config.testERC20.transferOwnership(address(config.coinIssuer));
+        config.coinIssuer.acceptTokenOwnership();
       }
 
       if (config.deployer != config.registry.owner()) {
@@ -304,6 +311,11 @@ contract RollupBuilder is Test {
       if (expGov != config.gse.owner()) {
         vm.prank(config.gse.owner());
         config.gse.transferOwnership(expGov);
+      }
+
+      if (expGov != config.coinIssuer.owner()) {
+        vm.prank(config.coinIssuer.owner());
+        config.coinIssuer.transferOwnership(expGov);
       }
     }
 

--- a/l1-contracts/test/delegation/base.t.sol
+++ b/l1-contracts/test/delegation/base.t.sol
@@ -45,6 +45,7 @@ contract GSEBase is TestBase {
 
   function help__deposit(address _attester, address _withdrawer, bool _onCanonical) internal {
     uint256 depositAmount = ROLLUP.getDepositAmount();
+    vm.prank(stakingAsset.owner());
     stakingAsset.mint(address(this), depositAmount);
     stakingAsset.approve(address(ROLLUP), depositAmount);
 

--- a/l1-contracts/test/fee_portal/depositToAztecPublic.t.sol
+++ b/l1-contracts/test/fee_portal/depositToAztecPublic.t.sol
@@ -83,6 +83,7 @@ contract DepositToAztecPublic is Test {
 
     bytes32 expectedKey = message.sha256ToField();
 
+    vm.prank(token.owner());
     token.mint(address(this), amount);
     token.approve(address(feeJuicePortal), amount);
 

--- a/l1-contracts/test/governance/coin-issuer/Base.t.sol
+++ b/l1-contracts/test/governance/coin-issuer/Base.t.sol
@@ -18,5 +18,6 @@ contract CoinIssuerBase is Test {
     token = IMintableERC20(address(testERC20));
     nom = new CoinIssuer(token, _rate, address(this));
     testERC20.transferOwnership(address(nom));
+    nom.acceptTokenOwnership();
   }
 }

--- a/l1-contracts/test/governance/scenario/AddRollup.t.sol
+++ b/l1-contracts/test/governance/scenario/AddRollup.t.sol
@@ -49,7 +49,7 @@ contract BadRollup {
 contract AddRollupTest is TestBase {
   using ProposalLib for Proposal;
 
-  IMintableERC20 internal token;
+  TestERC20 internal token;
   Registry internal registry;
   Governance internal governance;
   GovernanceProposer internal governanceProposer;
@@ -93,7 +93,9 @@ contract AddRollupTest is TestBase {
     }
 
     MultiAdder multiAdder = new MultiAdder(address(rollup), address(this));
-    token.mint(address(multiAdder), rollup.getDepositAmount() * VALIDATOR_COUNT);
+    uint256 depositAmount = rollup.getDepositAmount();
+    vm.prank(token.owner());
+    token.mint(address(multiAdder), depositAmount * VALIDATOR_COUNT);
     multiAdder.addValidators(initialValidators);
 
     registry.transferOwnership(address(governance));
@@ -121,6 +123,7 @@ contract AddRollupTest is TestBase {
 
     assertEq(originalPayload, address(payload));
 
+    vm.prank(token.owner());
     token.mint(EMPEROR, 10000 ether);
 
     vm.startPrank(EMPEROR);
@@ -151,9 +154,11 @@ contract AddRollupTest is TestBase {
       // The result is that 1/3 of the new total supply is off canonical
       uint256 validatorsNeeded = (gse.totalSupply() / 2) / rollup.getDepositAmount() + 1;
 
+      uint256 depositAmount = rollup.getDepositAmount();
       while (val <= validatorsNeeded) {
-        token.mint(address(this), rollup.getDepositAmount());
-        token.approve(address(rollup), rollup.getDepositAmount());
+        vm.prank(token.owner());
+        token.mint(address(this), depositAmount);
+        token.approve(address(rollup), depositAmount);
         rollup.deposit(address(uint160(val)), address(this), false);
         val++;
       }

--- a/l1-contracts/test/governance/scenario/UpgradeGovernanceProposerTest.t.sol
+++ b/l1-contracts/test/governance/scenario/UpgradeGovernanceProposerTest.t.sol
@@ -33,7 +33,7 @@ import {TimeCheater} from "../../staking/TimeCheater.sol";
 contract UpgradeGovernanceProposerTest is TestBase {
   using ProposalLib for Proposal;
 
-  IMintableERC20 internal token;
+  TestERC20 internal token;
   Registry internal registry;
   Governance internal governance;
   GovernanceProposer internal governanceProposer;
@@ -103,6 +103,7 @@ contract UpgradeGovernanceProposerTest is TestBase {
 
     assertEq(originalPayload, address(payload));
 
+    vm.prank(token.owner());
     token.mint(EMPEROR, 10000 ether);
 
     vm.startPrank(EMPEROR);

--- a/l1-contracts/test/ignition.t.sol
+++ b/l1-contracts/test/ignition.t.sol
@@ -79,7 +79,6 @@ contract IgnitionTest is RollupBase {
 
     feeJuicePortal = FeeJuicePortal(address(rollup.getFeeAssetPortal()));
     rewardDistributor = RewardDistributor(address(registry.getRewardDistributor()));
-    testERC20.mint(address(rewardDistributor), 1e6 ether);
 
     _;
   }

--- a/l1-contracts/test/portals/TokenPortal.t.sol
+++ b/l1-contracts/test/portals/TokenPortal.t.sol
@@ -119,6 +119,7 @@ contract TokenPortalTest is Test {
 
   function testDepositPrivate() public returns (bytes32) {
     // mint token and approve to the portal
+    vm.prank(testERC20.owner());
     testERC20.mint(address(this), mintAmount);
     testERC20.approve(address(tokenPortal), mintAmount);
 
@@ -148,6 +149,7 @@ contract TokenPortalTest is Test {
 
   function testDepositPublic() public returns (bytes32) {
     // mint token and approve to the portal
+    vm.prank(testERC20.owner());
     testERC20.mint(address(this), mintAmount);
     testERC20.approve(address(tokenPortal), mintAmount);
 
@@ -205,6 +207,7 @@ contract TokenPortalTest is Test {
     returns (bytes32, bytes32[] memory, bytes32)
   {
     // send assets to the portal
+    vm.prank(testERC20.owner());
     testERC20.mint(address(tokenPortal), withdrawAmount);
 
     // Create the message

--- a/l1-contracts/test/staking/15050.t.sol
+++ b/l1-contracts/test/staking/15050.t.sol
@@ -22,6 +22,7 @@ contract Test15050 is StakingBase {
   }
 
   function test_15050() external {
+    vm.prank(stakingAsset.owner());
     stakingAsset.mint(address(this), DEPOSIT_AMOUNT);
     stakingAsset.approve(address(staking), DEPOSIT_AMOUNT);
 

--- a/l1-contracts/test/staking/base.t.sol
+++ b/l1-contracts/test/staking/base.t.sol
@@ -42,4 +42,9 @@ contract StakingBase is TestBase {
     MINIMUM_STAKE = staking.getMinimumStake();
     SLASHER = staking.getSlasher();
   }
+
+  function mint(address _to, uint256 _amount) internal {
+    vm.prank(stakingAsset.owner());
+    stakingAsset.mint(_to, _amount);
+  }
 }

--- a/l1-contracts/test/staking/deposit.t.sol
+++ b/l1-contracts/test/staking/deposit.t.sol
@@ -49,7 +49,7 @@ contract DepositTest is StakingBase {
   }
 
   modifier givenCallerHasSufficientFunds() {
-    stakingAsset.mint(address(this), DEPOSIT_AMOUNT);
+    mint(address(this), DEPOSIT_AMOUNT);
     _;
   }
 
@@ -63,7 +63,7 @@ contract DepositTest is StakingBase {
     staking.deposit({_attester: ATTESTER, _withdrawer: WITHDRAWER, _onCanonical: true});
     staking.flushEntryQueue();
 
-    stakingAsset.mint(address(this), DEPOSIT_AMOUNT);
+    mint(address(this), DEPOSIT_AMOUNT);
     stakingAsset.approve(address(staking), type(uint256).max);
 
     // Now reset the next flushable epoch to 0

--- a/l1-contracts/test/staking/finaliseWithdraw.t.sol
+++ b/l1-contracts/test/staking/finaliseWithdraw.t.sol
@@ -13,7 +13,7 @@ contract FinaliseWithdrawTest is StakingBase {
     vm.expectRevert(abi.encodeWithSelector(Errors.Staking__NotExiting.selector, ATTESTER));
     staking.finaliseWithdraw(ATTESTER);
 
-    stakingAsset.mint(address(this), DEPOSIT_AMOUNT);
+    mint(address(this), DEPOSIT_AMOUNT);
     stakingAsset.approve(address(staking), DEPOSIT_AMOUNT);
 
     staking.deposit({_attester: ATTESTER, _withdrawer: WITHDRAWER, _onCanonical: true});
@@ -32,7 +32,7 @@ contract FinaliseWithdrawTest is StakingBase {
   modifier givenStatusIsExiting() {
     // We deposit and initiate a withdraw
 
-    stakingAsset.mint(address(this), DEPOSIT_AMOUNT);
+    mint(address(this), DEPOSIT_AMOUNT);
     stakingAsset.approve(address(staking), DEPOSIT_AMOUNT);
 
     staking.deposit({_attester: ATTESTER, _withdrawer: WITHDRAWER, _onCanonical: true});

--- a/l1-contracts/test/staking/flushEntryQueue.t.sol
+++ b/l1-contracts/test/staking/flushEntryQueue.t.sol
@@ -198,7 +198,7 @@ contract FlushEntryQueueTest is StakingBase {
   }
 
   function _help_deposit(address _attester, address _withdrawer, bool _onCanonical) internal {
-    stakingAsset.mint(address(this), DEPOSIT_AMOUNT);
+    mint(address(this), DEPOSIT_AMOUNT);
     stakingAsset.approve(address(staking), DEPOSIT_AMOUNT);
     uint256 balance = stakingAsset.balanceOf(address(staking));
 

--- a/l1-contracts/test/staking/getters.t.sol
+++ b/l1-contracts/test/staking/getters.t.sol
@@ -7,6 +7,7 @@ contract GettersTest is StakingBase {
   function setUp() public override {
     super.setUp();
 
+    vm.prank(stakingAsset.owner());
     stakingAsset.mint(address(this), DEPOSIT_AMOUNT);
     stakingAsset.approve(address(staking), DEPOSIT_AMOUNT);
     staking.deposit({_attester: ATTESTER, _withdrawer: WITHDRAWER, _onCanonical: true});

--- a/l1-contracts/test/staking/initiateWithdraw.t.sol
+++ b/l1-contracts/test/staking/initiateWithdraw.t.sol
@@ -16,7 +16,7 @@ contract InitiateWithdrawTest is StakingBase {
   }
 
   modifier whenAttesterIsRegistered() {
-    stakingAsset.mint(address(this), DEPOSIT_AMOUNT);
+    mint(address(this), DEPOSIT_AMOUNT);
     stakingAsset.approve(address(staking), DEPOSIT_AMOUNT);
     staking.deposit({_attester: ATTESTER, _withdrawer: WITHDRAWER, _onCanonical: true});
     staking.flushEntryQueue();

--- a/l1-contracts/test/staking/move.t.sol
+++ b/l1-contracts/test/staking/move.t.sol
@@ -63,7 +63,7 @@ contract MoveTest is StakingBase {
     IInstance oldRollup = IInstance(address(staking));
     IInstance newRollup = IInstance(address(builder.getConfig().rollup));
 
-    stakingAsset.mint(address(this), DEPOSIT_AMOUNT * n);
+    mint(address(this), DEPOSIT_AMOUNT * n);
     stakingAsset.approve(address(oldRollup), DEPOSIT_AMOUNT * n);
 
     for (uint256 i = 0; i < n; i++) {

--- a/l1-contracts/test/staking/slash.t.sol
+++ b/l1-contracts/test/staking/slash.t.sol
@@ -15,7 +15,7 @@ contract SlashTest is StakingBase {
   }
 
   function test_WhenCallerIsNotTheSlasher() external {
-    stakingAsset.mint(address(this), DEPOSIT_AMOUNT);
+    mint(address(this), DEPOSIT_AMOUNT);
     stakingAsset.approve(address(staking), DEPOSIT_AMOUNT);
     staking.deposit({_attester: ATTESTER, _withdrawer: WITHDRAWER, _onCanonical: true});
     staking.flushEntryQueue();
@@ -40,7 +40,7 @@ contract SlashTest is StakingBase {
   }
 
   modifier whenAttesterIsRegistered() {
-    stakingAsset.mint(address(this), DEPOSIT_AMOUNT);
+    mint(address(this), DEPOSIT_AMOUNT);
     stakingAsset.approve(address(staking), DEPOSIT_AMOUNT);
 
     staking.deposit({_attester: ATTESTER, _withdrawer: WITHDRAWER, _onCanonical: true});

--- a/l1-contracts/test/staking_asset_handler/base.t.sol
+++ b/l1-contracts/test/staking_asset_handler/base.t.sol
@@ -63,6 +63,7 @@ contract StakingAssetHandlerBase is ZKPassportBase, TestBase {
     });
 
     stakingAssetHandler = new StakingAssetHandler(stakingAssetHandlerArgs);
+    vm.prank(stakingAsset.owner());
     stakingAsset.addMinter(address(stakingAssetHandler));
   }
 

--- a/l1-contracts/test/test_erc20/transferOwnership.t.sol
+++ b/l1-contracts/test/test_erc20/transferOwnership.t.sol
@@ -2,6 +2,7 @@
 pragma solidity >=0.8.27;
 
 import {Ownable} from "@oz/access/Ownable.sol";
+import {Ownable2Step} from "@oz/access/Ownable2Step.sol";
 
 import {TestERC20TestBase} from "./base.t.sol";
 
@@ -25,33 +26,41 @@ contract TransferOwnershipTest is TestERC20TestBase {
     testERC20.transferOwnership(_newOwner);
   }
 
-  // solhint-disable-next-line ordering
-  modifier whenTheCallerIsTheOwner() {
-    vm.startPrank(testERC20.owner());
-    _;
-    vm.stopPrank();
-  }
-
-  function test_WhenTheNewOwnerIsTheZeroAddress() external whenTheCallerIsTheOwner {
+  function test_WhenRecipientIsNotPending(address _caller) external {
     // it reverts
-    vm.expectRevert(abi.encodeWithSelector(Ownable.OwnableInvalidOwner.selector, address(0)));
-    testERC20.transferOwnership(address(0));
+
+    vm.assume(_caller != address(0xdead));
+
+    address oldOwner = testERC20.owner();
+
+    vm.expectEmit(true, true, true, true, address(testERC20));
+    emit Ownable2Step.OwnershipTransferStarted(oldOwner, address(0xdead));
+    vm.prank(oldOwner);
+    testERC20.transferOwnership(address(0xdead));
+
+    vm.prank(_caller);
+    vm.expectRevert(abi.encodeWithSelector(Ownable.OwnableUnauthorizedAccount.selector, _caller));
+    testERC20.acceptOwnership();
   }
 
-  function test_WhenTheNewOwnerIsNotTheZeroAddress(address _newOwner)
-    external
-    whenTheCallerIsTheOwner
-  {
+  function test_WhenRecipientIsPending(address _newOwner) external {
     // it removes the old owner as a minter
     // it adds the new owner as a minter
     // it transfers the ownership to the new owner
     // it emits a OwnershipTransferred event
-    address oldOwner = testERC20.owner();
 
-    vm.assume(_newOwner != address(0));
+    address oldOwner = testERC20.owner();
+    vm.assume(_newOwner != oldOwner);
+
     vm.expectEmit(true, true, true, true, address(testERC20));
-    emit Ownable.OwnershipTransferred(testERC20.owner(), _newOwner);
+    emit Ownable2Step.OwnershipTransferStarted(oldOwner, _newOwner);
+    vm.prank(oldOwner);
     testERC20.transferOwnership(_newOwner);
+
+    vm.expectEmit(true, true, true, true, address(testERC20));
+    emit Ownable.OwnershipTransferred(oldOwner, _newOwner);
+    vm.prank(_newOwner);
+    testERC20.acceptOwnership();
 
     assertEq(testERC20.owner(), _newOwner);
     assertEq(testERC20.minters(_newOwner), true);

--- a/l1-contracts/test/validator-selection/ValidatorSelection.t.sol
+++ b/l1-contracts/test/validator-selection/ValidatorSelection.t.sol
@@ -93,8 +93,10 @@ contract ValidatorSelectionTest is ValidatorSelectionTestBase {
     address expectedProposer = rollup.getCurrentProposer();
 
     // Add a validator which will also setup the epoch
-    testERC20.mint(address(this), rollup.getDepositAmount());
-    testERC20.approve(address(rollup), rollup.getDepositAmount());
+    uint256 depositAmount = rollup.getDepositAmount();
+    vm.prank(testERC20.owner());
+    testERC20.mint(address(this), depositAmount);
+    testERC20.approve(address(rollup), depositAmount);
     rollup.deposit(address(0xdead), address(0xdead), true);
 
     address actualProposer = rollup.getCurrentProposer();
@@ -140,8 +142,10 @@ contract ValidatorSelectionTest is ValidatorSelectionTestBase {
     vm.warp(ts2);
 
     // add a new validator
-    testERC20.mint(address(this), rollup.getDepositAmount());
-    testERC20.approve(address(rollup), rollup.getDepositAmount());
+    uint256 depositAmount = rollup.getDepositAmount();
+    vm.prank(testERC20.owner());
+    testERC20.mint(address(this), depositAmount);
+    testERC20.approve(address(rollup), depositAmount);
     rollup.deposit(address(0xdead), address(0xdead), true);
     rollup.flushEntryQueue();
 

--- a/l1-contracts/test/validator-selection/setupEpoch.t.sol
+++ b/l1-contracts/test/validator-selection/setupEpoch.t.sol
@@ -236,7 +236,9 @@ contract SetupEpochTest is ValidatorSelectionTestBase {
     }
 
     MultiAdder multiAdder = new MultiAdder(address(rollup), address(this));
-    testERC20.mint(address(multiAdder), rollup.getDepositAmount() * validators.length);
+    uint256 amount = rollup.getDepositAmount() * validators.length;
+    vm.prank(testERC20.owner());
+    testERC20.mint(address(multiAdder), amount);
     multiAdder.addValidators(validators);
   }
 }


### PR DESCRIPTION
Fixes #15790.

Adds a function `acceptTokenOwnership` on the `CoinIssuer` to cover cases of `Ownable2Step` and updates a bunch of tests to handle minting.
