### PR TITLE
fix(avm): descriptive tag mismatch err

### DIFF
--- a/barretenberg/cpp/src/barretenberg/vm2/common/tagged_value.cpp
+++ b/barretenberg/cpp/src/barretenberg/vm2/common/tagged_value.cpp
@@ -87,7 +87,8 @@ template <typename Op> struct BinaryOperationVisitor {
                 return static_cast<T>(Op{}(a, b));
             }
         } else {
-            throw TagMismatchException();
+            throw TagMismatchException("Cannot perform operation between different types: " +
+                                       std::to_string(tag_for_type<T>()) + " and " + std::to_string(tag_for_type<U>()));
         }
     }
 };

--- a/barretenberg/cpp/src/barretenberg/vm2/common/tagged_value.hpp
+++ b/barretenberg/cpp/src/barretenberg/vm2/common/tagged_value.hpp
@@ -14,8 +14,8 @@ namespace bb::avm2 {
 
 class TagMismatchException : public std::runtime_error {
   public:
-    TagMismatchException()
-        : std::runtime_error("Mismatched tags")
+    TagMismatchException(const std::string& msg)
+        : std::runtime_error("Mismatched tags: " + msg)
     {}
 };
 


### PR DESCRIPTION
Running `AvmSimulationAluTest.NegativeAddTag`
### Before
`"ALU Exception: ADD, Mismatched tags"`
### After
`"ALU Exception: ADD, Mismatched tags: Cannot perform operation between different types: U32 and U64"`