### PR TITLE
chore: uint audit part 1 (`operator<<, operator>>, ror`)

### DIFF
--- a/barretenberg/cpp/src/barretenberg/stdlib/primitives/field/field.cpp
+++ b/barretenberg/cpp/src/barretenberg/stdlib/primitives/field/field.cpp
@@ -1290,6 +1290,53 @@ std::array<field_t<Builder>, 3> field_t<Builder>::slice(const uint8_t msb, const
     return result;
 }
 
+template <typename Builder>
+std::pair<field_t<Builder>, field_t<Builder>> field_t<Builder>::split_at(const size_t lsb_index,
+                                                                         const size_t num_bits) const
+{
+    ASSERT(lsb_index < num_bits);
+
+    const uint256_t value = get_value();
+    const uint256_t hi = value >> lsb_index;
+    const uint256_t lo = value % (uint256_t(1) << lsb_index);
+
+    if (is_constant()) {
+        // If `*this` is constant, we can return the split values directly
+        ASSERT(lo + (hi << lsb_index) == value);
+        return std::make_pair(field_t<Builder>(lo), field_t<Builder>(hi));
+    }
+
+    // Handle edge case when lsb_index == 0
+    if (lsb_index == 0) {
+        ASSERT(hi == value);
+        ASSERT(lo == 0);
+        create_range_constraint(num_bits, "split_at: hi value too large.");
+        return std::make_pair(field_t<Builder>(0), *this);
+    }
+
+    Builder* ctx = get_context();
+    ASSERT(ctx != nullptr);
+
+    field_t<Builder> lo_wit(witness_t(ctx, lo));
+    field_t<Builder> hi_wit(witness_t(ctx, hi));
+
+    // Ensure that `lo_wit` is in the range [0, 2^lsb_index - 1]
+    lo_wit.create_range_constraint(lsb_index, "split_at: lo value too large.");
+
+    // Ensure that `hi_wit` is in the range [0, 2^(num_bits - lsb_index) - 1]
+    hi_wit.create_range_constraint(num_bits - lsb_index, "split_at: hi value too large.");
+
+    // Check that *this = lo_wit + hi_wit * 2^{lsb_index}
+    const field_t<Builder> decomposed = lo_wit + (hi_wit * field_t<Builder>(uint256_t(1) << lsb_index));
+    assert_equal(decomposed, "split_at: decomposition failed");
+
+    // Set the origin tag for both witnesses
+    lo_wit.set_origin_tag(tag);
+    hi_wit.set_origin_tag(tag);
+
+    return std::make_pair(lo_wit, hi_wit);
+}
+
 /**
  * @brief Build constraints establishing the decomposition of `*this` into bits.
  *

--- a/barretenberg/cpp/src/barretenberg/stdlib/primitives/field/field.cpp
+++ b/barretenberg/cpp/src/barretenberg/stdlib/primitives/field/field.cpp
@@ -1327,8 +1327,8 @@ std::pair<field_t<Builder>, field_t<Builder>> field_t<Builder>::split_at(const s
     hi_wit.create_range_constraint(num_bits - lsb_index, "split_at: hi value too large.");
 
     // Check that *this = lo_wit + hi_wit * 2^{lsb_index}
-    const field_t<Builder> decomposed = lo_wit + (hi_wit * field_t<Builder>(uint256_t(1) << lsb_index));
-    assert_equal(decomposed, "split_at: decomposition failed");
+    const field_t<Builder> reconstructed = lo_wit + (hi_wit * field_t<Builder>(uint256_t(1) << lsb_index));
+    assert_equal(reconstructed, "split_at: decomposition failed");
 
     // Set the origin tag for both witnesses
     lo_wit.set_origin_tag(tag);

--- a/barretenberg/cpp/src/barretenberg/stdlib/primitives/field/field.hpp
+++ b/barretenberg/cpp/src/barretenberg/stdlib/primitives/field/field.hpp
@@ -339,6 +339,9 @@ template <typename Builder> class field_t {
 
     std::array<field_t, 3> slice(uint8_t msb, uint8_t lsb) const;
 
+    std::pair<field_t<Builder>, field_t<Builder>> split_at(
+        const size_t lsb_index, const size_t num_bits = grumpkin::MAX_NO_WRAP_INTEGER_BIT_LENGTH) const;
+
     bool_t<Builder> is_zero() const;
 
     void create_range_constraint(size_t num_bits, std::string const& msg = "field_t::range_constraint") const;

--- a/barretenberg/cpp/src/barretenberg/stdlib/primitives/field/field.test.cpp
+++ b/barretenberg/cpp/src/barretenberg/stdlib/primitives/field/field.test.cpp
@@ -4,6 +4,7 @@
 #include "barretenberg/circuit_checker/circuit_checker.hpp"
 #include "barretenberg/common/streams.hpp"
 #include "barretenberg/numeric/random/engine.hpp"
+#include "barretenberg/numeric/uint256/uint256.hpp"
 #include "barretenberg/stdlib/primitives/circuit_builders/circuit_builders.hpp"
 #include <gtest/gtest.h>
 #include <utility>
@@ -859,6 +860,56 @@ template <typename Builder> class stdlib_field : public testing::Test {
         EXPECT_TRUE(builder.err() == "slice: hi value too large.");
     }
 
+    static void test_split_at()
+    {
+        Builder builder = Builder();
+
+        // Test different bit sizes
+        std::vector<size_t> test_bit_sizes = { 8, 16, 32, 100, 252 };
+
+        // Lambda to check split_at functionality
+        auto check_split_at = [&](const field_ct& a, size_t start, size_t num_bits) {
+            const uint256_t a_native = a.get_value();
+            auto split_data = a.split_at(start, num_bits);
+            EXPECT_EQ(split_data.first.get_value(), a_native & ((uint256_t(1) << start) - 1));
+            EXPECT_EQ(split_data.second.get_value(), (a_native >> start) & ((uint256_t(1) << num_bits) - 1));
+
+            if (a.is_constant()) {
+                EXPECT_TRUE(split_data.first.is_constant());
+                EXPECT_TRUE(split_data.second.is_constant());
+            }
+
+            if (start == 0) {
+                EXPECT_TRUE(split_data.first.is_constant());
+                EXPECT_TRUE(split_data.first.get_value() == 0);
+                EXPECT_EQ(split_data.second.get_value(), a.get_value());
+            }
+        };
+
+        for (size_t num_bits : test_bit_sizes) {
+            uint256_t a_native = engine.get_random_uint256() & ((uint256_t(1) << num_bits) - 1);
+
+            // check split_at for a constant
+            field_ct a_constant(a_native);
+            check_split_at(a_constant, 0, num_bits);
+            check_split_at(a_constant, num_bits / 4, num_bits);
+            check_split_at(a_constant, num_bits / 3, num_bits);
+            check_split_at(a_constant, num_bits / 2, num_bits);
+            check_split_at(a_constant, num_bits - 1, num_bits);
+
+            // check split_at for a witness
+            field_ct a_witness(witness_ct(&builder, a_native));
+            check_split_at(a_witness, 0, num_bits);
+            check_split_at(a_witness, num_bits / 4, num_bits);
+            check_split_at(a_witness, num_bits / 3, num_bits);
+            check_split_at(a_witness, num_bits / 2, num_bits);
+            check_split_at(a_witness, num_bits - 1, num_bits);
+        }
+
+        bool result = CircuitChecker::check(builder);
+        EXPECT_EQ(result, true);
+    }
+
     static void test_three_bit_table()
     {
         Builder builder = Builder();
@@ -1362,6 +1413,12 @@ template <typename Builder> class stdlib_field : public testing::Test {
             EXPECT_EQ(element.get_origin_tag(), submitted_value_origin_tag);
         }
 
+        // Split preserves tags
+        const size_t num_bits = uint256_t(a.get_value()).get_msb() + 1;
+        auto split_data = a.split_at(num_bits / 2, num_bits);
+        EXPECT_EQ(split_data.first.get_origin_tag(), submitted_value_origin_tag);
+        EXPECT_EQ(split_data.second.get_origin_tag(), submitted_value_origin_tag);
+
         // Decomposition preserves tags
 
         auto decomposed_bits = a.decompose_into_bits();
@@ -1554,6 +1611,10 @@ TYPED_TEST(stdlib_field, test_slice_equal_msb_lsb)
 TYPED_TEST(stdlib_field, test_slice_random)
 {
     TestFixture::test_slice_random();
+}
+TYPED_TEST(stdlib_field, test_split_at)
+{
+    TestFixture::test_split_at();
 }
 TYPED_TEST(stdlib_field, test_three_bit_table)
 {

--- a/barretenberg/cpp/src/barretenberg/stdlib/primitives/uint/logic.cpp
+++ b/barretenberg/cpp/src/barretenberg/stdlib/primitives/uint/logic.cpp
@@ -79,7 +79,7 @@ uint<Builder, Native> uint<Builder, Native>::operator>>(const size_t shift) cons
     // Now, lets calculate:
     // (i) bit position (from lsb) at which we need to slice.
     // (ii) number of bits in the slice based on whether it is the highest slice or not.
-    const uint64_t slice_bit_position = shift % bits_per_limb;
+    const size_t slice_bit_position = shift % bits_per_limb;
     const bool is_slice_hi = (accumulator_index == num_accumulators() - 1);
     const uint8_t num_bits_per_limb = is_slice_hi ? bits_in_high_limb : bits_per_limb;
 
@@ -155,7 +155,7 @@ uint<Builder, Native> uint<Builder, Native>::operator<<(const size_t shift) cons
     // (i) bit position (from lsb) at which we need to slice.
     // (ii) number of bits in the slice based on whether it is the highest slice or not.
     const bool is_slice_hi = (accumulator_index == num_accumulators() - 1);
-    const uint64_t slice_bit_position = adjusted_shift % bits_per_limb;
+    const size_t slice_bit_position = adjusted_shift % bits_per_limb;
     const uint8_t num_bits_per_limb = is_slice_hi ? bits_in_high_limb : bits_per_limb;
 
     // We can now slice the accumulator.
@@ -229,7 +229,7 @@ uint<Builder, Native> uint<Builder, Native>::ror(const size_t target_rotation) c
     // Now, lets calculate:
     // (i) bit position (from lsb) at which we need to slice.
     // (ii) number of bits in the slice based on whether it is the highest slice or not.
-    const uint64_t slice_bit_position = shift % bits_per_limb;
+    const size_t slice_bit_position = shift % bits_per_limb;
     const bool is_slice_hi = (accumulator_index == num_accumulators() - 1);
     const uint8_t num_bits_per_limb = is_slice_hi ? bits_in_high_limb : bits_per_limb;
 

--- a/barretenberg/cpp/src/barretenberg/stdlib/primitives/uint/logic.cpp
+++ b/barretenberg/cpp/src/barretenberg/stdlib/primitives/uint/logic.cpp
@@ -55,40 +55,50 @@ uint<Builder, Native> uint<Builder, Native>::operator>>(const size_t shift) cons
         return *this;
     }
 
-    uint64_t bits_per_hi_limb;
-    // last limb will not likely bit `bits_per_limb`. Need to be careful with our range check
-    if (shift >= ((width / bits_per_limb) * bits_per_limb)) {
-        bits_per_hi_limb = width % bits_per_limb;
-    } else {
-        bits_per_hi_limb = bits_per_limb;
-    }
-    const uint64_t slice_bit_position = shift % bits_per_limb;
+    // Example for uint32_t:
+    //
+    //      |<------  acc[2]  ------>||<-----------   acc[1]  ----------->||<-------  acc[0]  ------->|
+    // val: [ 31 30 29 28 27 26 25 24  23 22 21 20 19 18 17 16 15 14 13 12  11 10 9 8 7 6 5 4 3 2 1 0 ]
+    //                                                         ↑
+    //      [<---------------        keep        --------------->][<--------     discard     -------->]
+    //
+    // out: [ 31 30 29 28 27 26 25 24  23 22 21 20 19 18 17 16 15 ]
+    //      |<------  acc[2]  ------>||<-----   acc[1].hi   ----->|
+    //
+    // Suppose the shift is 15, then we must discard the 15 least significant bits of the accumulator.
+    // The accumulator is split into three parts, so we clearly need to split acc[1]. On splitting, we must
+    // discard the lower slice of acc[1] and keep the upper slice. Thus, the updated uint value will be:
+    //
+    // acc[1].hi + (acc[2] << (24 - 15))
+    //
+    // Let us first fetch the accumlator that needs to be sliced.
     const size_t accumulator_index = shift / bits_per_limb;
-    const uint32_t slice_index = accumulators[accumulator_index];
-    const uint64_t slice_value = uint256_t(context->get_variable(slice_index)).data[0];
+    const uint32_t slice_witness_index = accumulators[accumulator_index];
+    const field_t<Builder> acc_to_be_sliced = field_t<Builder>::from_witness_index(context, slice_witness_index);
 
-    const uint64_t slice_lo = slice_value % (1ULL << slice_bit_position);
-    const uint64_t slice_hi = slice_value >> slice_bit_position;
-    const uint32_t slice_lo_idx = slice_bit_position ? context->add_variable(slice_lo) : context->zero_idx;
-    const uint32_t slice_hi_idx =
-        (slice_bit_position != bits_per_limb) ? context->add_variable(slice_hi) : context->zero_idx;
+    // Now, lets calculate:
+    // (i) bit position (from lsb) at which we need to slice.
+    // (ii) number of bits in the slice based on whether it is the highest slice or not.
+    const uint64_t slice_bit_position = shift % bits_per_limb;
+    const bool is_slice_hi = (accumulator_index == num_accumulators() - 1);
+    const uint8_t num_bits_per_limb = is_slice_hi ? bits_in_high_limb : bits_per_limb;
 
-    context->create_big_add_gate(
-        { slice_index, slice_lo_idx, context->zero_idx, slice_hi_idx, -1, 1, 0, (1 << slice_bit_position), 0 });
+    // Finally, we can slice the accumulator.
+    // The slice_hi will be the upper slice of the accumulator, which we will keep.
+    // The slice_lo will be the lower slice of the accumulator, which we will discard.
+    // Its important to note that although slice_lo is not used here, it is still created and properly constrained
+    // in the split_at function.
+    field_t<Builder> slice_hi = acc_to_be_sliced.split_at(slice_bit_position, num_bits_per_limb).second;
 
-    if (slice_bit_position != 0) {
-        context->create_new_range_constraint(slice_lo_idx, (1ULL << slice_bit_position) - 1);
-    }
-    context->create_new_range_constraint(slice_hi_idx, (1ULL << (bits_per_hi_limb - slice_bit_position)) - 1);
+    // Now we reconstruct the shifted uint value.
     std::vector<field_t<Builder>> sublimbs;
-    sublimbs.emplace_back(field_t<Builder>::from_witness_index(context, slice_hi_idx));
+    sublimbs.emplace_back(slice_hi);
 
     const size_t start = accumulator_index + 1;
     field_t<Builder> coefficient(context, uint64_t(1ULL << (start * bits_per_limb - shift)));
     field_t<Builder> shifter(context, uint64_t(1ULL << bits_per_limb));
     for (size_t i = accumulator_index + 1; i < num_accumulators(); ++i) {
-        sublimbs.emplace_back(field_t<Builder>::from_witness_index(context, accumulators[i]) *
-                              field_t<Builder>(coefficient));
+        sublimbs.emplace_back(field_t<Builder>::from_witness_index(context, accumulators[i]) * coefficient);
         coefficient *= shifter;
     }
 
@@ -117,49 +127,48 @@ uint<Builder, Native> uint<Builder, Native>::operator<<(const size_t shift) cons
         return *this;
     }
 
-    uint64_t slice_bit_position;
-    size_t accumulator_index;
-    size_t bits_per_hi_limb;
-    // most significant limb is only 2 bits long (for u32), need to be careful about which slice we index,
-    // and how large the range check is on our hi limb
-    if (shift < (width - ((width / bits_per_limb) * bits_per_limb))) {
-        bits_per_hi_limb = width % bits_per_limb;
-        slice_bit_position = bits_per_hi_limb - (shift % bits_per_hi_limb);
-        accumulator_index = num_accumulators() - 1;
-    } else {
-        const size_t offset = width % bits_per_limb;
-        slice_bit_position = bits_per_limb - ((shift - offset) % bits_per_limb);
-        accumulator_index = num_accumulators() - 2 - ((shift - offset) / bits_per_limb);
-        bits_per_hi_limb = bits_per_limb;
-    }
+    // Example for uint32_t:
+    //
+    //      |<------  acc[2]  ------->||<-----------   acc[1]  ----------->||<-------  acc[0]  ------->|
+    // val: [ 31 30 29 28 27 26 25  24  23 22 21 20 19 18 17 16 15 14 13 12  11 10 9 8 7 6 5 4 3 2 1 0 ]
+    //                          ↑
+    //      [<----  discard  ---->][<----------------------        keep        ----------------------->]
+    //
+    // out: [       24        23 22 21 20 19 18 17 16 15 14 13 12  11 10 9 8 7 6 5 4 3 2 1 0 ]
+    //      [<- acc[2].lo ->||<-----------   acc[1]  ----------->||<-------  acc[0]  ------->|
+    //
+    // Suppose the shift is 7, then we must discard the 7 most significant bits of the accumulator, and move
+    // the remaining bits to the left. The accumulator is split into three parts, so in this case we clearly
+    // need to split acc[2]. On splitting, we must discard the higher slice of acc[2] and keep the lower slice.
+    // Thus, the updated uint value will be:
+    //
+    // (acc[2].lo << (24 + 7))  +  (acc[1] << (12 + 7))  +  (acc[0] << 7)
+    //
+    // Let us first fetch the accumulator that needs to be sliced.
+    // We will do so by adjusting the shift from the most-significant bit.
+    size_t adjusted_shift = width - shift;
+    const size_t accumulator_index = adjusted_shift / bits_per_limb;
+    const uint32_t slice_witness_index = accumulators[accumulator_index];
+    const field_t<Builder> acc_to_be_sliced = field_t<Builder>::from_witness_index(context, slice_witness_index);
 
-    const uint32_t slice_index = accumulators[accumulator_index];
-    const uint64_t slice_value = uint256_t(context->get_variable(slice_index)).data[0];
+    // Now, lets calculate:
+    // (i) bit position (from lsb) at which we need to slice.
+    // (ii) number of bits in the slice based on whether it is the highest slice or not.
+    const bool is_slice_hi = (accumulator_index == num_accumulators() - 1);
+    const uint64_t slice_bit_position = adjusted_shift % bits_per_limb;
+    const uint8_t num_bits_per_limb = is_slice_hi ? bits_in_high_limb : bits_per_limb;
 
-    const uint64_t slice_lo = slice_value % (1ULL << slice_bit_position);
-    const uint64_t slice_hi = slice_value >> slice_bit_position;
-    const uint32_t slice_lo_idx = slice_bit_position ? context->add_variable(slice_lo) : context->zero_idx;
-    const uint32_t slice_hi_idx =
-        (slice_bit_position != bits_per_hi_limb) ? context->add_variable(slice_hi) : context->zero_idx;
+    // We can now slice the accumulator.
+    field_t<Builder> slice_lo = acc_to_be_sliced.split_at(slice_bit_position, num_bits_per_limb).first;
 
-    context->create_big_add_gate(
-        { slice_index, slice_lo_idx, context->zero_idx, slice_hi_idx, -1, 1, 0, (1 << slice_bit_position), 0 });
-
-    context->create_new_range_constraint(slice_lo_idx, (1ULL << slice_bit_position) - 1);
-
-    if (slice_bit_position != bits_per_limb) {
-        context->create_new_range_constraint(slice_hi_idx, (1ULL << (bits_per_hi_limb - slice_bit_position)) - 1);
-    }
-
+    // Now we reconstruct the shifted uint value.
     std::vector<field_t<Builder>> sublimbs;
-    sublimbs.emplace_back(field_t<Builder>::from_witness_index(context, slice_lo_idx) *
-                          field_t<Builder>(context, 1ULL << ((accumulator_index)*bits_per_limb + shift)));
+    sublimbs.emplace_back(slice_lo * field_t<Builder>(context, 1ULL << ((accumulator_index * bits_per_limb) + shift)));
 
     field_t<Builder> coefficient(context, uint64_t(1ULL << shift));
     field_t<Builder> shifter(context, uint64_t(1ULL << bits_per_limb));
     for (size_t i = 0; i < accumulator_index; ++i) {
-        sublimbs.emplace_back(field_t<Builder>::from_witness_index(context, accumulators[i]) *
-                              field_t<Builder>(coefficient));
+        sublimbs.emplace_back(field_t<Builder>::from_witness_index(context, accumulators[i]) * coefficient);
         coefficient *= shifter;
     }
 
@@ -173,6 +182,7 @@ uint<Builder, Native> uint<Builder, Native>::operator<<(const size_t shift) cons
 template <typename Builder, typename Native>
 uint<Builder, Native> uint<Builder, Native>::ror(const size_t target_rotation) const
 {
+    // Note: width is always a power of two, so we can use bitwise AND.
     const size_t rotation = target_rotation & (width - 1);
 
     const auto rotate = [](const uint256_t input, const uint64_t rot) {
@@ -193,51 +203,57 @@ uint<Builder, Native> uint<Builder, Native>::ror(const size_t target_rotation) c
         return *this;
     }
 
-    const size_t shift = rotation;
-    uint64_t bits_per_hi_limb;
-    // last limb will not likely bit `bits_per_limb`. Need to be careful with our range check
-    if (shift >= ((width / bits_per_limb) * bits_per_limb)) {
-        bits_per_hi_limb = width % bits_per_limb;
-    } else {
-        bits_per_hi_limb = bits_per_limb;
-    }
-    const uint64_t slice_bit_position = shift % bits_per_limb;
+    // Example for uint32_t:
+    //
+    //      |<------  acc[2]  ------>||<-----------   acc[1]  ----------->||<-------  acc[0]  ------->|
+    // val: [ 31 30 29 28 27 26 25 24  23 22 21 20 19 18 17 16 15 14 13 12  11 10 9 8 7 6 5 4 3 2 1 0 ]
+    //                                                         ↑
+    //      [<---------------        keep        --------------->][<--------  right rotate   -------->]
+    //
+    // out: [  14   13   12   11 10 9 8 7 6 5 4 3 2 1 0 ] [ 31 30 29 28 27 26 25 24  23 22 21 20 19 18 17 16 15 ]
+    //      [<- acc[1].lo ->||<-------  acc[0]  ------->| |<------  acc[2]  ------>||<-----   acc[1].hi  ------>]
+    //
+    // Suppose the right-rotation is 15 (i.e., rotate = 15), then we must right-rotate the 15 least
+    // significant bits of the accumulator. The accumulator is split into three parts, so in this case we need to split
+    // acc[1]. On splitting, we must "rotate" the lower slice of acc[1] and keep the upper slice. Thus, the updated uint
+    // value will be:
+    //
+    // acc[1].hi + (acc[2] << (24 - 15)) + (acc[0] >> (32 - 15)) + (acc[1].lo >> (32 - 15 + 12))
+    //
+    // Let us first fetch the accumlator that needs to be sliced.
+    size_t shift = rotation;
     const size_t accumulator_index = shift / bits_per_limb;
-    const uint32_t slice_index = accumulators[accumulator_index];
-    const uint64_t slice_value = uint256_t(context->get_variable(slice_index)).data[0];
+    const uint32_t slice_witness_index = accumulators[accumulator_index];
+    const field_t<Builder> acc_to_be_sliced = field_t<Builder>::from_witness_index(context, slice_witness_index);
 
-    const uint64_t slice_lo = slice_value % (1ULL << slice_bit_position);
-    const uint64_t slice_hi = slice_value >> slice_bit_position;
-    const uint32_t slice_lo_idx = slice_bit_position ? context->add_variable(slice_lo) : context->zero_idx;
-    const uint32_t slice_hi_idx =
-        (slice_bit_position != bits_per_limb) ? context->add_variable(slice_hi) : context->zero_idx;
+    // Now, lets calculate:
+    // (i) bit position (from lsb) at which we need to slice.
+    // (ii) number of bits in the slice based on whether it is the highest slice or not.
+    const uint64_t slice_bit_position = shift % bits_per_limb;
+    const bool is_slice_hi = (accumulator_index == num_accumulators() - 1);
+    const uint8_t num_bits_per_limb = is_slice_hi ? bits_in_high_limb : bits_per_limb;
 
-    context->create_big_add_gate(
-        { slice_index, slice_lo_idx, context->zero_idx, slice_hi_idx, -1, 1, 0, (1 << slice_bit_position), 0 });
+    // Finally, we can slice the accumulator.
+    auto [slice_lo, slice_hi] = acc_to_be_sliced.split_at(slice_bit_position, num_bits_per_limb);
 
-    if (slice_bit_position != 0) {
-        context->create_new_range_constraint(slice_lo_idx, (1ULL << slice_bit_position) - 1);
-    }
-    context->create_new_range_constraint(slice_hi_idx, (1ULL << (bits_per_hi_limb - slice_bit_position)) - 1);
+    // Now we reconstruct the shifted uint value.
     std::vector<field_t<Builder>> sublimbs;
-    sublimbs.emplace_back(field_t<Builder>::from_witness_index(context, slice_hi_idx));
+    sublimbs.emplace_back(slice_hi);
 
     const size_t start = accumulator_index + 1;
     field_t<Builder> coefficient(context, uint64_t(1ULL << (start * bits_per_limb - shift)));
     field_t<Builder> shifter(context, uint64_t(1ULL << bits_per_limb));
     for (size_t i = accumulator_index + 1; i < num_accumulators(); ++i) {
-        sublimbs.emplace_back(field_t<Builder>::from_witness_index(context, accumulators[i]) *
-                              field_t<Builder>(coefficient));
+        sublimbs.emplace_back(field_t<Builder>::from_witness_index(context, accumulators[i]) * coefficient);
         coefficient *= shifter;
     }
 
     coefficient = field_t<Builder>(context, uint64_t(1ULL << (width - shift)));
     for (size_t i = 0; i < accumulator_index; ++i) {
-        sublimbs.emplace_back(field_t<Builder>::from_witness_index(context, accumulators[i]) *
-                              field_t<Builder>(coefficient));
+        sublimbs.emplace_back(field_t<Builder>::from_witness_index(context, accumulators[i]) * coefficient);
         coefficient *= shifter;
     }
-    sublimbs.emplace_back(field_t<Builder>::from_witness_index(context, slice_lo_idx) * field_t<Builder>(coefficient));
+    sublimbs.emplace_back(slice_lo * field_t<Builder>(coefficient));
 
     uint32_t result_index = field_t<Builder>::accumulate(sublimbs).get_witness_index();
     uint result(context);

--- a/barretenberg/cpp/src/barretenberg/stdlib/primitives/uint/uint.cpp
+++ b/barretenberg/cpp/src/barretenberg/stdlib/primitives/uint/uint.cpp
@@ -13,35 +13,35 @@ template <typename Builder, typename Native>
 std::vector<uint32_t> uint<Builder, Native>::constrain_accumulators(Builder* context,
                                                                     const uint32_t witness_index) const
 {
-    const auto res = context->decompose_into_default_range(witness_index, width, bits_per_limb);
+    std::vector<uint32_t> res = context->decompose_into_default_range(witness_index, width, bits_per_limb);
     return res;
 }
 
 template <typename Builder, typename Native>
-uint<Builder, Native>::uint(const witness_t<Builder>& witness)
-    : context(witness.context)
+uint<Builder, Native>::uint(const witness_t<Builder>& other)
+    : context(other.context)
     , witness_status(WitnessStatus::OK)
 {
-    if (witness.witness_index == IS_CONSTANT) {
-        additive_constant = witness.witness;
+    if (other.is_constant()) {
+        additive_constant = other.witness;
         witness_index = IS_CONSTANT;
     } else {
-        accumulators = constrain_accumulators(context, witness.witness_index);
-        witness_index = witness.witness_index;
+        accumulators = constrain_accumulators(context, other.witness_index);
+        witness_index = other.witness_index;
     }
 }
 
 template <typename Builder, typename Native>
-uint<Builder, Native>::uint(const field_t<Builder>& value)
-    : context(value.context)
+uint<Builder, Native>::uint(const field_t<Builder>& other)
+    : context(other.context)
     , additive_constant(0)
     , witness_status(WitnessStatus::OK)
 {
-    if (value.witness_index == IS_CONSTANT) {
-        additive_constant = value.additive_constant;
+    if (other.is_constant()) {
+        additive_constant = other.additive_constant;
         witness_index = IS_CONSTANT;
     } else {
-        field_t<Builder> norm = value.normalize();
+        field_t<Builder> norm = other.normalize();
         accumulators = constrain_accumulators(context, norm.get_witness_index());
         witness_index = norm.get_witness_index();
     }
@@ -129,7 +129,7 @@ uint<Builder, Native>::uint(const uint& other)
 {}
 
 template <typename Builder, typename Native>
-uint<Builder, Native>::uint(uint&& other)
+uint<Builder, Native>::uint(uint&& other) noexcept
     : context(other.context)
     , additive_constant(other.additive_constant)
     , witness_status(other.witness_status)
@@ -139,6 +139,9 @@ uint<Builder, Native>::uint(uint&& other)
 
 template <typename Builder, typename Native> uint<Builder, Native>& uint<Builder, Native>::operator=(const uint& other)
 {
+    if (this == &other) {
+        return *this;
+    }
     context = other.context;
     additive_constant = other.additive_constant;
     witness_status = other.witness_status;
@@ -147,7 +150,8 @@ template <typename Builder, typename Native> uint<Builder, Native>& uint<Builder
     return *this;
 }
 
-template <typename Builder, typename Native> uint<Builder, Native>& uint<Builder, Native>::operator=(uint&& other)
+template <typename Builder, typename Native>
+uint<Builder, Native>& uint<Builder, Native>::operator=(uint&& other) noexcept
 {
     context = other.context;
     additive_constant = other.additive_constant;

--- a/barretenberg/cpp/src/barretenberg/stdlib/primitives/uint/uint.cpp
+++ b/barretenberg/cpp/src/barretenberg/stdlib/primitives/uint/uint.cpp
@@ -118,14 +118,27 @@ uint<Builder, Native>::uint(Builder* parent_context, const std::vector<bool_t<Bu
 {
     field_t<Builder> accumulator(context, fr::zero());
     field_t<Builder> scaling_factor(context, fr::one());
+    const size_t num_wires = wires.size();
 
-    // TODO JUMP IN STEPS OF TWO
-    for (size_t i = 0; i < wires.size(); ++i) {
-        accumulator = accumulator + scaling_factor * field_t<Builder>(wires[i]);
-        scaling_factor = scaling_factor + scaling_factor;
+    for (size_t i = 0; i < (num_wires / 2); ++i) {
+        const field_t<Builder> even_scaling_factor = scaling_factor;
+        const field_t<Builder> odd_scaling_factor = scaling_factor * fr(2);
+
+        accumulator = accumulator.add_two(field_t<Builder>(wires[2 * i]) * even_scaling_factor,
+                                          field_t<Builder>(wires[2 * i + 1]) * odd_scaling_factor);
+
+        scaling_factor = scaling_factor * fr(4); // Scale by (2^1 * 2^1).
     }
+
+    // Process the last wire if the number of wires is odd.
+    if (num_wires % 2 == 1) {
+        const field_t<Builder>& last_wire = field_t<Builder>(wires[num_wires - 1]);
+        accumulator = accumulator + (scaling_factor * last_wire);
+    }
+
+    // Normalize the accumulator and set the witness index or additive constant.
     accumulator = accumulator.normalize();
-    if (accumulator.witness_index == IS_CONSTANT) {
+    if (accumulator.is_constant()) {
         additive_constant = uint256_t(accumulator.additive_constant);
     } else {
         witness_index = accumulator.witness_index;

--- a/barretenberg/cpp/src/barretenberg/stdlib/primitives/uint/uint.cpp
+++ b/barretenberg/cpp/src/barretenberg/stdlib/primitives/uint/uint.cpp
@@ -75,15 +75,28 @@ uint<Builder, Native>::uint(const byte_array<Builder>& other)
 {
     field_t<Builder> accumulator(context, fr::zero());
     field_t<Builder> scaling_factor(context, fr::one());
-    const auto bytes = other.bytes();
+    const auto& bytes = other.bytes();
+    const size_t num_bytes = bytes.size();
 
-    // TODO JUMP IN STEPS OF TWO
-    for (size_t i = 0; i < bytes.size(); ++i) {
-        accumulator = accumulator + scaling_factor * bytes[bytes.size() - 1 - i];
-        scaling_factor = scaling_factor * fr(256);
+    // Process pairs of bytes from the end of the byte array.
+    for (size_t i = 0; i < (num_bytes / 2); ++i) {
+        const field_t<Builder> even_scaling_factor = scaling_factor;
+        const field_t<Builder> odd_scaling_factor = scaling_factor * fr(256);
+        accumulator = accumulator.add_two(bytes[num_bytes - 1 - (2 * i)] * even_scaling_factor,
+                                          bytes[num_bytes - 1 - (2 * i + 1)] * odd_scaling_factor);
+
+        scaling_factor = scaling_factor * fr(256 * 256); // Scale by (2^8 * 2^8).
     }
+
+    // Process the last byte if the byte array has an odd number of bytes.
+    if (num_bytes % 2 == 1) {
+        const field_t<Builder>& last_byte = bytes[0];
+        accumulator = accumulator + (scaling_factor * last_byte);
+    }
+
+    // Normalize the accumulator and set the witness index or additive constant.
     accumulator = accumulator.normalize();
-    if (accumulator.witness_index == IS_CONSTANT) {
+    if (accumulator.is_constant()) {
         additive_constant = uint256_t(accumulator.additive_constant);
     } else {
         witness_index = accumulator.witness_index;

--- a/barretenberg/cpp/src/barretenberg/stdlib/primitives/uint/uint.hpp
+++ b/barretenberg/cpp/src/barretenberg/stdlib/primitives/uint/uint.hpp
@@ -30,16 +30,18 @@ template <typename Builder, typename Native> class uint {
         : uint(static_cast<uint256_t>(v))
     {}
 
-    std::vector<uint32_t> constrain_accumulators(Builder* ctx, const uint32_t witness_index) const;
+    std::vector<uint32_t> constrain_accumulators(Builder* context, const uint32_t witness_index) const;
 
     static constexpr size_t bits_per_limb = 12;
     static constexpr size_t num_accumulators() { return (width + bits_per_limb - 1) / bits_per_limb; }
 
     uint(const uint& other);
-    uint(uint&& other);
+    uint(uint&& other) noexcept;
+
+    ~uint() = default;
 
     uint& operator=(const uint& other);
-    uint& operator=(uint&& other);
+    uint& operator=(uint&& other) noexcept;
 
     explicit operator byte_array<Builder>() const;
     explicit operator field_t<Builder>() const;

--- a/barretenberg/cpp/src/barretenberg/stdlib/primitives/uint/uint.hpp
+++ b/barretenberg/cpp/src/barretenberg/stdlib/primitives/uint/uint.hpp
@@ -18,6 +18,9 @@ template <typename Builder, typename Native> class uint {
     using FF = typename Builder::FF;
     static constexpr size_t width = sizeof(Native) * 8;
 
+    static_assert(width == 8 || width == 16 || width == 32 || width == 64,
+                  "unsupported uint width, supported uint widths are: 8, 16, 32, and 64 bits.");
+
     uint(const witness_t<Builder>& other);
     uint(const field_t<Builder>& other);
     uint(const uint256_t& value = 0);
@@ -33,6 +36,7 @@ template <typename Builder, typename Native> class uint {
     std::vector<uint32_t> constrain_accumulators(Builder* context, const uint32_t witness_index) const;
 
     static constexpr size_t bits_per_limb = 12;
+    static constexpr size_t bits_in_high_limb = width % bits_per_limb == 0 ? bits_per_limb : width % bits_per_limb;
     static constexpr size_t num_accumulators() { return (width + bits_per_limb - 1) / bits_per_limb; }
 
     uint(const uint& other);

--- a/barretenberg/cpp/src/barretenberg/stdlib/primitives/witness/witness.hpp
+++ b/barretenberg/cpp/src/barretenberg/stdlib/primitives/witness/witness.hpp
@@ -49,6 +49,8 @@ template <typename Builder> class witness_t {
         return out;
     }
 
+    bool is_constant() const { return witness_index == IS_CONSTANT; }
+
     bb::fr witness;
     uint32_t witness_index = IS_CONSTANT;
     Builder* context = nullptr;


### PR DESCRIPTION
### 🧾 Audit Context

Audit of the `uint` module in stdlib, specifically the methods: `operator>>`, `operator<<` and `ror` (bitwise operations).

### 🛠️ Changes Made

- All three methods were manually "slicing" a field element which was very error-prone. I replaced it with `split_at` method (wrote a generic method `split_at`[^1] that splits a field_t at a given bit index and returns the lower and higher slices). 
- Cleaned up and optimised `uint` constructor from `byte_array` and `std::vector<bool_t>` (resolving old TODO)
- Added static assert on `width` so that we restrict `uint` to 8, 16, 32, and 64 bits only.

### ✅ Checklist

- [x] Audited all methods of the relevant module/class
- [x] Audited the interface of the module/class with other (relevant) components
- [x] Documented existing functionality and any changes made (as per Doxygen requirements)
- [x] Resolved and/or closed all issues/TODOs pertaining to the audited files
- [x] Confirmed and documented any security or other issues found (if applicable)
- [ ] Verified that tests cover all critical paths (and added tests if necessary)
- [ ] Updated audit tracking for the files audited (check the start of each file you audited)

### 📌 Notes for Reviewers

Please review the `split_at` function carefully, and check if we are testing it thoroughly. We're soon going to remove the function `slice(msb, lsb)` from field_t since we no longer need it (used only in `logic` module). Instead, the new function `split_at` will replace the use of `slice` in `logic` module:

https://github.com/AztecProtocol/aztec-packages/blob/6434f3193683748d31d94c787e87252234c6a6fd/barretenberg/cpp/src/barretenberg/stdlib/primitives/logic/logic.cpp#L99

will be changed to:

`field_pt a_slice = a.split_at(0, num_bits).second;`

Note: we are not going to merge any PRs that change anything in `field` or `bigfield` as they're undergoing external audits at the moment. Thus, this PR will be merged after the external audit of `field` (and its fixes) are done.

[^1]: The existing `slice(msb, lsb)` method could be used but there were three issues in doing so: 
(a) found a [bug](https://github.com/AztecProtocol/aztec-packages/commit/eb3f3ec4aece2ec548e6083a9cc4ca5e22468789) in range-constraint on the `hi` limb in it, 
(b) `slice(...)` returns three limbs: hi, mid and lo so it naturally requires three range constraints. We only need two parts of a field element. 
(c) `slice(...)` assumes a 252-bit field element which results in (unnecessary) costly range-constraints. We'd have to change the function to accept `num_bits` as a parameter (or template parameter).
