### PR TITLE
feat!: disconnect from peers on heartbeat

### DIFF
--- a/yarn-project/p2p/src/services/peer-manager/peer_manager.ts
+++ b/yarn-project/p2p/src/services/peer-manager/peer_manager.ts
@@ -59,6 +59,7 @@ export class PeerManager implements PeerManagerInterface {
   private preferredPeers: Set<string> = new Set();
   private authenticatedPeerIdToValidatorAddress: Map<string, EthAddress> = new Map();
   private authenticatedValidatorAddressToPeerId: Map<string, PeerId> = new Map();
+  private peersToBeDisconnected: Set<string> = new Set();
 
   private metrics: PeerManagerMetrics;
   private handlers: {
@@ -153,9 +154,10 @@ export class PeerManager implements PeerManagerInterface {
   public async heartbeat() {
     this.heartbeatCounter++;
     this.peerScoring.decayAllScores();
-    await this.updateAuthenticatedPeers();
-
     this.cleanupExpiredTimeouts();
+
+    await this.updateAuthenticatedPeers();
+    await this.processScheduledDisconnects();
 
     this.discover();
   }
@@ -174,6 +176,28 @@ export class PeerManager implements PeerManagerInterface {
       if (now >= timedOutPeer.timeoutUntilMs) {
         this.timedOutPeers.delete(peerId);
       }
+    }
+  }
+
+  /**
+   * Processes scheduled disconnects during heartbeat.
+   *
+   * This batch processes all peers that have been marked for disconnect.
+   * preventing immediate disconnects that could cause libp2p state corruption.
+   */
+  private async processScheduledDisconnects() {
+    if (this.peersToBeDisconnected.size === 0) {
+      return;
+    }
+
+    const peersToDisconnect = Array.from(this.peersToBeDisconnected);
+    this.peersToBeDisconnected.clear();
+
+    this.logger.debug(`Processing ${peersToDisconnect.length} scheduled disconnects`);
+    try {
+      await Promise.all(peersToDisconnect.map(peerIdStr => this.disconnectPeer(peerIdFromString(peerIdStr))));
+    } catch (error) {
+      this.logger.error(`Error when disconnecting from peers: ${inspect(error)}`);
     }
   }
 
@@ -314,7 +338,7 @@ export class PeerManager implements PeerManagerInterface {
 
     this.metrics.recordGoodbyeReceived(reason);
 
-    void this.disconnectPeer(peerId);
+    this.markPeerForDisconnect(peerId);
   }
 
   public penalizePeer(peerId: PeerId, penalty: PeerErrorSeverity) {
@@ -558,15 +582,32 @@ export class PeerManager implements PeerManagerInterface {
     } catch (error) {
       this.logger.debug(`Failed to send goodbye to peer ${peer.toString()}: ${error}`);
     } finally {
-      await this.disconnectPeer(peer);
+      this.markPeerForDisconnect(peer);
     }
   }
 
+  /*
+   * Marks peer to be disconnected on the next heartbeat
+   * */
+  private markPeerForDisconnect(peer: PeerId) {
+    const peerIdStr = peer.toString();
+    this.logger.debug(`Scheduling peer ${peerIdStr} for disconnection`);
+    this.peersToBeDisconnected.add(peerIdStr);
+  }
+
+  /**
+   * Performs the actual disconnection of a peer.
+   * This is called during heartbeat processing to avoid immediate disconnections.
+   */
   private async disconnectPeer(peer: PeerId) {
+    const peerIdStr = peer.toString();
+
     try {
       await this.libP2PNode.hangUp(peer);
+
+      this.logger.debug(`Successfully disconnected peer ${peerIdStr}`);
     } catch (error) {
-      this.logger.debug(`Failed to disconnect peer ${peer.toString()}`, { error: inspect(error) });
+      this.logger.debug(`Failed to disconnect peer ${peerIdStr}`, { error });
     }
   }
 
@@ -578,6 +619,12 @@ export class PeerManager implements PeerManagerInterface {
     // Check that the peer has not already been banned
     const peerId = await enr.peerId();
     const peerIdString = peerId.toString();
+
+    // Don't attempt to connect to peers scheduled for disconnection
+    if (this.peersToBeDisconnected.has(peerIdString)) {
+      this.logger.trace(`Skipping peer scheduled for disconnection ${peerId}`);
+      return;
+    }
 
     // Check if peer is temporarily timed out
     const timedOutPeer = this.timedOutPeers.get(peerIdString);
@@ -727,7 +774,7 @@ export class PeerManager implements PeerManagerInterface {
           peerId,
           status: ReqRespStatus[status],
         });
-        await this.disconnectPeer(peerId);
+        this.markPeerForDisconnect(peerId);
         return;
       }
 
@@ -736,7 +783,7 @@ export class PeerManager implements PeerManagerInterface {
       const peerStatusMessage = StatusMessage.fromBuffer(data);
       if (!ourStatus.validate(peerStatusMessage)) {
         this.logger.warn(`Disconnecting peer ${peerId} due to failed status handshake.`, logData);
-        await this.disconnectPeer(peerId);
+        this.markPeerForDisconnect(peerId);
         return;
       }
       this.logger.debug(`Successfully completed status handshake with peer ${peerId}`, logData);
@@ -745,7 +792,7 @@ export class PeerManager implements PeerManagerInterface {
       this.logger.warn(`Disconnecting peer ${peerId} due to error during status handshake: ${err.message ?? err}`, {
         peerId,
       });
-      await this.disconnectPeer(peerId);
+      this.markPeerForDisconnect(peerId);
     }
   }
 
@@ -770,7 +817,7 @@ export class PeerManager implements PeerManagerInterface {
           peerId,
           status: ReqRespStatus[status],
         });
-        await this.disconnectPeer(peerId);
+        this.markPeerForDisconnect(peerId);
         return;
       }
 
@@ -782,7 +829,7 @@ export class PeerManager implements PeerManagerInterface {
       const peerStatusMessage = peerAuthResponse.status;
       if (!ourStatus.validate(peerStatusMessage)) {
         this.logger.warn(`Disconnecting peer ${peerId} due to failed status handshake as part of auth.`, logData);
-        await this.disconnectPeer(peerId);
+        this.markPeerForDisconnect(peerId);
         return;
       }
 
@@ -798,7 +845,7 @@ export class PeerManager implements PeerManagerInterface {
             address: sender.toString(),
           },
         );
-        await this.disconnectPeer(peerId);
+        this.markPeerForDisconnect(peerId);
         return;
       }
 
@@ -824,7 +871,7 @@ export class PeerManager implements PeerManagerInterface {
       this.logger.warn(`Disconnecting peer ${peerId} due to error during auth handshake: ${err.message ?? err}`, {
         peerId,
       });
-      await this.disconnectPeer(peerId);
+      this.markPeerForDisconnect(peerId);
     }
   }
 

--- a/yarn-project/p2p/src/services/peer-manager/peer_manager.ts
+++ b/yarn-project/p2p/src/services/peer-manager/peer_manager.ts
@@ -196,8 +196,9 @@ export class PeerManager implements PeerManagerInterface {
     this.logger.debug(`Processing ${peersToDisconnect.length} scheduled disconnects`);
     try {
       await Promise.all(peersToDisconnect.map(peerIdStr => this.disconnectPeer(peerIdFromString(peerIdStr))));
+      this.logger.verbose(`Disconnected ${peersToDisconnect.length} peers`, { peersToDisconnect });
     } catch (error) {
-      this.logger.error(`Error when disconnecting from peers: ${inspect(error)}`);
+      this.logger.error('Error when disconnecting from peers', error);
     }
   }
 
@@ -607,7 +608,7 @@ export class PeerManager implements PeerManagerInterface {
 
       this.logger.debug(`Successfully disconnected peer ${peerIdStr}`);
     } catch (error) {
-      this.logger.debug(`Failed to disconnect peer ${peerIdStr}`, { error });
+      this.logger.warn(`Failed to disconnect peer ${peerIdStr}`, { error });
     }
   }
 


### PR DESCRIPTION
These changes were made as an attempt to deflake e2e/preferred_gossip test.

PR brings that peers are disconnected on a heartbeat instead of immediately. 

I still cannot point to the exact cause of the issues when disconnecting peers, but it all points to some race condition or not handling errors correctly within libp2p or gossipsub.
For example, this is the error I was seeing in tests, which I don't see after applying this fix:

```
CodeError: unexpected end of input
    at DefaultUpgrader._encryptOutbound (/workspaces/aztec-packages/yarn-project/node_modules/libp2p/src/upgrader.ts:682:13)
    at processTicksAndRejections (node:internal/process/task_queues:105:5)
    at DefaultUpgrader.upgradeOutbound (/workspaces/aztec-packages/yarn-project/node_modules/libp2p/src/upgrader.ts:292:13)
    at TCP.dial (/workspaces/aztec-packages/yarn-project/node_modules/@libp2p/tcp/src/index.ts:181:18)
    at DefaultTransportManager.dial (/workspaces/aztec-packages/yarn-project/node_modules/libp2p/src/transport-manager.ts:116:14)
    at Job.queue.add.peerId.peerId [as fn] (/workspaces/aztec-packages/yarn-project/node_modules/libp2p/src/connection-manager/dial-queue.ts:236:26)
    at raceSignal (/workspaces/aztec-packages/yarn-project/node_modules/race-signal/src/index.ts:46:12)
    at Job.run (/workspaces/aztec-packages/yarn-project/node_modules/@libp2p/utils/src/queue/job.ts:79:22) {
  code: 'ERR_ENCRYPTION_FAILED',
  props: {}
```
