### PR TITLE
chore: flag to update inputs when precomputed vk fails

### DIFF
--- a/barretenberg/cpp/scripts/test_civc_standalone_vks_havent_changed.sh
+++ b/barretenberg/cpp/scripts/test_civc_standalone_vks_havent_changed.sh
@@ -54,7 +54,6 @@ curl -s -f "$pinned_civc_inputs_url" | tar -xzf - -C "$inputs_tmp_dir" &>/dev/nu
 function check_circuit_vks {
   set -eu
   local flow_folder="$inputs_tmp_dir/$1"
-  echo $flow_folder
   ./build/bin/bb check --scheme client_ivc --ivc_inputs_path "$flow_folder/ivc-inputs.msgpack" || { echo_stderr "Error: Likely VK change detected in $flow_folder!"; exit 1; }
 }
 

--- a/barretenberg/cpp/scripts/test_civc_standalone_vks_havent_changed.sh
+++ b/barretenberg/cpp/scripts/test_civc_standalone_vks_havent_changed.sh
@@ -54,6 +54,7 @@ curl -s -f "$pinned_civc_inputs_url" | tar -xzf - -C "$inputs_tmp_dir" &>/dev/nu
 function check_circuit_vks {
   set -eu
   local flow_folder="$inputs_tmp_dir/$1"
+  echo $flow_folder
   ./build/bin/bb check --scheme client_ivc --ivc_inputs_path "$flow_folder/ivc-inputs.msgpack" || { echo_stderr "Error: Likely VK change detected in $flow_folder!"; exit 1; }
 }
 

--- a/barretenberg/cpp/src/barretenberg/api/api.hpp
+++ b/barretenberg/cpp/src/barretenberg/api/api.hpp
@@ -25,6 +25,7 @@ class API {
         bool write_vk{ false };    // should we addditionally write the verification key when writing the proof
         bool include_gates_per_opcode{ false }; // should we include gates_per_opcode in the gates command output
         bool slow_low_memory{ false };          // use file backed memory for polynomials
+        bool update_inputs{ false };            // use file backed memory for polynomials
 
         friend std::ostream& operator<<(std::ostream& os, const Flags& flags)
         {

--- a/barretenberg/cpp/src/barretenberg/api/api_client_ivc.cpp
+++ b/barretenberg/cpp/src/barretenberg/api/api_client_ivc.cpp
@@ -195,7 +195,6 @@ void ClientIVCAPI::write_solidity_verifier([[maybe_unused]] const Flags& flags,
 
 bool ClientIVCAPI::check_precomputed_vks(const Flags& flags, const std::filesystem::path& input_path)
 {
-    info("JONATHAN: check_precomputed_vks started.");
     bbapi::BBApiRequest request;
     std::vector<PrivateExecutionStepRaw> raw_steps = PrivateExecutionStepRaw::load_and_decompress(input_path);
 
@@ -220,7 +219,6 @@ bool ClientIVCAPI::check_precomputed_vks(const Flags& flags, const std::filesyst
         }
     }
     if (check_failed) {
-        info("JONATHAN: check failed.");
         PrivateExecutionStepRaw::compress_and_save(std::move(raw_steps), input_path);
         return false;
     }

--- a/barretenberg/cpp/src/barretenberg/api/api_client_ivc.cpp
+++ b/barretenberg/cpp/src/barretenberg/api/api_client_ivc.cpp
@@ -193,7 +193,7 @@ void ClientIVCAPI::write_solidity_verifier([[maybe_unused]] const Flags& flags,
     throw_or_abort("API function contract not implemented");
 }
 
-bool ClientIVCAPI::check_precomputed_vks(const std::filesystem::path& input_path)
+bool ClientIVCAPI::check_precomputed_vks(const Flags& flags, const std::filesystem::path& input_path)
 {
     bbapi::BBApiRequest request;
     std::vector<PrivateExecutionStepRaw> raw_steps = PrivateExecutionStepRaw::load_and_decompress(input_path);

--- a/barretenberg/cpp/src/barretenberg/api/api_client_ivc.cpp
+++ b/barretenberg/cpp/src/barretenberg/api/api_client_ivc.cpp
@@ -195,10 +195,12 @@ void ClientIVCAPI::write_solidity_verifier([[maybe_unused]] const Flags& flags,
 
 bool ClientIVCAPI::check_precomputed_vks(const Flags& flags, const std::filesystem::path& input_path)
 {
+    info("JONATHAN: check_precomputed_vks started.");
     bbapi::BBApiRequest request;
     std::vector<PrivateExecutionStepRaw> raw_steps = PrivateExecutionStepRaw::load_and_decompress(input_path);
 
-    for (const auto& step : raw_steps) {
+    bool check_failed = false;
+    for (auto& step : raw_steps) {
         if (step.vk.empty()) {
             info("FAIL: Expected precomputed vk for function ", step.function_name);
             return false;
@@ -210,8 +212,17 @@ bool ClientIVCAPI::check_precomputed_vks(const Flags& flags, const std::filesyst
                             .execute();
 
         if (!response.valid) {
-            return false;
+            if (!flags.update_inputs) {
+                return false;
+            }
+            step.vk = response.actual_vk;
+            check_failed = true;
         }
+    }
+    if (check_failed) {
+        info("JONATHAN: check failed.");
+        PrivateExecutionStepRaw::compress_and_save(std::move(raw_steps), input_path);
+        return false;
     }
     return true;
 }

--- a/barretenberg/cpp/src/barretenberg/api/api_client_ivc.hpp
+++ b/barretenberg/cpp/src/barretenberg/api/api_client_ivc.hpp
@@ -34,7 +34,7 @@ class ClientIVCAPI : public API {
                   const std::filesystem::path& bytecode_path,
                   const std::filesystem::path& output_path) override;
 
-    bool check_precomputed_vks(const std::filesystem::path& input_path);
+    bool check_precomputed_vks(const Flags& flags, const std::filesystem::path& input_path);
     bool check(const Flags& flags,
                const std::filesystem::path& bytecode_path,
                const std::filesystem::path& witness_path) override;

--- a/barretenberg/cpp/src/barretenberg/api/api_client_ivc.test.cpp
+++ b/barretenberg/cpp/src/barretenberg/api/api_client_ivc.test.cpp
@@ -289,6 +289,14 @@ TEST_F(ClientIVCAPITests, CheckPrecomputedVksMismatch)
 
     // Should fail because VK doesn't match
     ClientIVCAPI api;
-    bool result = api.check_precomputed_vks(input_path);
+    bool result = api.check_precomputed_vks(ClientIVCAPI::Flags{}, input_path);
     EXPECT_FALSE(result);
+
+    // Check with --update_input should still fail but update the VK in the input.
+    result = api.check_precomputed_vks(ClientIVCAPI::Flags{ .update_inputs = true }, input_path);
+    EXPECT_FALSE(result);
+
+    // Check again and it should succeed with the updated VK.
+    result = api.check_precomputed_vks(ClientIVCAPI::Flags{}, input_path);
+    EXPECT_TRUE(result);
 }

--- a/barretenberg/cpp/src/barretenberg/api/api_client_ivc.test.cpp
+++ b/barretenberg/cpp/src/barretenberg/api/api_client_ivc.test.cpp
@@ -251,7 +251,7 @@ TEST_F(ClientIVCAPITests, CheckPrecomputedVks)
     create_test_private_execution_steps(input_path);
 
     ClientIVCAPI api;
-    EXPECT_TRUE(api.check_precomputed_vks(input_path));
+    EXPECT_TRUE(api.check_precomputed_vks(ClientIVCAPI::Flags{}, input_path));
 }
 
 // Check a case where precomputed VKs don't match

--- a/barretenberg/cpp/src/barretenberg/api/bbapi_client_ivc.cpp
+++ b/barretenberg/cpp/src/barretenberg/api/bbapi_client_ivc.cpp
@@ -177,7 +177,7 @@ ClientIvcCheckPrecomputedVk::Response ClientIvcCheckPrecomputedVk::execute(const
     std::string error_message = "Precomputed vk does not match computed vk for function " + function_name;
     if (!msgpack::msgpack_check_eq(*computed_vk, *precomputed_vk, error_message)) {
         response.valid = false;
-        response.actual_vk = to_buffer(precomputed_vk);
+        response.actual_vk = to_buffer(computed_vk);
     }
     return response;
 }

--- a/barretenberg/cpp/src/barretenberg/api/bbapi_client_ivc.cpp
+++ b/barretenberg/cpp/src/barretenberg/api/bbapi_client_ivc.cpp
@@ -177,6 +177,7 @@ ClientIvcCheckPrecomputedVk::Response ClientIvcCheckPrecomputedVk::execute(const
     std::string error_message = "Precomputed vk does not match computed vk for function " + function_name;
     if (!msgpack::msgpack_check_eq(*computed_vk, *precomputed_vk, error_message)) {
         response.valid = false;
+        response.actual_vk = to_buffer(precomputed_vk);
     }
     return response;
 }

--- a/barretenberg/cpp/src/barretenberg/api/bbapi_client_ivc.hpp
+++ b/barretenberg/cpp/src/barretenberg/api/bbapi_client_ivc.hpp
@@ -170,6 +170,8 @@ struct ClientIvcCheckPrecomputedVk {
 
         /** @brief True if the precomputed VK matches the circuit */
         bool valid;
+
+        std::vector<uint8_t> actual_vk;
     };
 
     /** @brief Circuit with its precomputed verification key */

--- a/barretenberg/cpp/src/barretenberg/bb/cli.cpp
+++ b/barretenberg/cpp/src/barretenberg/bb/cli.cpp
@@ -291,6 +291,10 @@ int parse_and_run_cli_command(int argc, char* argv[])
             "--slow_low_memory", flags.slow_low_memory, "Enable low memory mode (can be 2x slower or more).");
     };
 
+    const auto add_update_inputs_flag = [&](CLI::App* subcommand) {
+        return subcommand->add_flag("--update_inputs", flags.update_inputs, "Update inputs if vk check fails.");
+    };
+
     /***************************************************************************************************************
      * Top-level flags
      ***************************************************************************************************************/
@@ -316,6 +320,7 @@ int parse_and_run_cli_command(int argc, char* argv[])
     add_bytecode_path_option(check);
     add_witness_path_option(check);
     add_ivc_inputs_path_options(check);
+    add_update_inputs_flag(check);
 
     /***************************************************************************************************************
      * Subcommand: gates

--- a/barretenberg/cpp/src/barretenberg/bb/cli.cpp
+++ b/barretenberg/cpp/src/barretenberg/bb/cli.cpp
@@ -692,7 +692,7 @@ int parse_and_run_cli_command(int argc, char* argv[])
                     throw_or_abort("The check command for ClientIVC expect a valid file passed with --ivc_inputs_path "
                                    "<ivc-inputs.msgpack> (default ./ivc-inputs.msgpack)");
                 }
-                return api.check_precomputed_vks(ivc_inputs_path) ? 0 : 1;
+                return api.check_precomputed_vks(flags, ivc_inputs_path) ? 0 : 1;
             }
             return execute_non_prove_command(api);
         } else if (flags.scheme == "ultra_honk") {


### PR DESCRIPTION
This is the first part to fix https://github.com/AztecProtocol/barretenberg/issues/1464. Once we have this, we can add an option to `test_civc_standalone_vks_havent_changed.sh` that generates inputs with this option.