### PR TITLE
chore(docs): Remove references to deprecated grants program

### DIFF
--- a/docs/docs/aztec/how_to_participate.md
+++ b/docs/docs/aztec/how_to_participate.md
@@ -15,8 +15,3 @@ Decentralization is one of our core values, so we want to encourage participatio
 - We have some [good first issues](https://github.com/AztecProtocol/aztec-packages/labels/good%20first%20issue) for newcomers
 - Anyone can open an issue, so please feel free to create one
 - If you've built something for the ecosystem that others should see, add it to the [Awesome-Aztec Repo](https://github.com/AztecProtocol/awesome-aztec)
-
-## Grants
-
-- The Aztec Labs Grants Program supports developers building with, and contributing to, the Noir programming language and the Aztec network. Applications can be submitted on the [Grants page](https://aztec.network/grants/) of the Aztec website. 
-- We are currently operating with a retroactive grants funding model, and we strive to respond back to grants applications with a decision within a few days. Check out our [grants page](https://aztec.network/grants/) for more information

--- a/docs/docusaurus.config.js
+++ b/docs/docusaurus.config.js
@@ -381,10 +381,6 @@ const config = {
                 label: "Awesome Aztec",
                 to: "https://github.com/AztecProtocol/awesome-aztec",
               },
-              {
-                label: "Grants",
-                href: "https://aztec.network/grants",
-              },
             ],
           },
         ],

--- a/docs/versioned_docs/version-v0.87.9/aztec/how_to_participate.md
+++ b/docs/versioned_docs/version-v0.87.9/aztec/how_to_participate.md
@@ -15,8 +15,3 @@ Decentralization is one of our core values, so we want to encourage participatio
 - We have some [good first issues](https://github.com/AztecProtocol/aztec-packages/labels/good%20first%20issue) for newcomers
 - Anyone can open an issue, so please feel free to create one
 - If you've built something for the ecosystem that others should see, add it to the [Awesome-Aztec Repo](https://github.com/AztecProtocol/awesome-aztec)
-
-## Grants
-
-- The Aztec Labs Grants Program supports developers building with, and contributing to, the Noir programming language and the Aztec network. Applications can be submitted on the [Grants page](https://aztec.network/grants/) of the Aztec website. 
-- We are currently operating with a retroactive grants funding model, and we strive to respond back to grants applications with a decision within a few days. Check out our [grants page](https://aztec.network/grants/) for more information


### PR DESCRIPTION
Removes links and mentions of the deprecated grants program at https://aztec.network/grants.