### PR TITLE
feat: update vk in test_civc_standalone_vks_havent_changed.sh via `bb check --update_inputs`

### DIFF
--- a/barretenberg/cpp/scripts/test_civc_standalone_vks_havent_changed.sh
+++ b/barretenberg/cpp/scripts/test_civc_standalone_vks_havent_changed.sh
@@ -13,28 +13,18 @@ cd ..
 # Note: In case of the "Test suite failed to run ... Unexpected token 'with' " error, need to run: docker pull aztecprotocol/build:3.0
 pinned_civc_inputs_url="https://aztec-ci-artifacts.s3.us-east-2.amazonaws.com/protocol/bb-civc-inputs-73c73907.tar.gz"
 
-# For easily rerunning the inputs generation
-if [[ "${1:-}" == "--update_inputs" ]]; then
-    set -eu
-    echo "Updating pinned IVC inputs..."
-
-    # 1) Generate new inputs
-    echo "Running bootstrap to generate new IVC inputs..."
-
-    ../../bootstrap.sh # bootstrap aztec-packages from root
-    ../../yarn-project/end-to-end/bootstrap.sh build_bench # build bench to generate IVC inputs
-
-    # 2) Compress the results
+function compress_and_upload {
+    # 1) Compress the results
     echo "Compressing the generated inputs..."
-    tar -czf bb-civc-inputs.tar.gz -C ../../yarn-project/end-to-end/example-app-ivc-inputs-out .
+    tar -czf bb-civc-inputs.tar.gz -C $1 .
 
-    # 3) Compute a short hash for versioning
+    # 2) Compute a short hash for versioning
     echo "Computing SHA256 hash for versioning..."
     full_hash=$(sha256sum bb-civc-inputs.tar.gz | awk '{ print $1 }')
     short_hash=${full_hash:0:8}
     echo "Short hash is: $short_hash"
 
-    # 4) Upload to S3
+    # 3) Upload to S3
     s3_key="bb-civc-inputs-${short_hash}.tar.gz"
     s3_uri="s3://aztec-ci-artifacts/protocol/${s3_key}"
     echo "Uploading bb-civc-inputs.tar.gz to ${s3_uri}..."
@@ -43,6 +33,21 @@ if [[ "${1:-}" == "--update_inputs" ]]; then
     echo "Done. New inputs available at:"
     echo "  ${s3_uri}"
     echo "Update the pinned_civc_inputs_url in this script to point to the new location."
+}
+
+# For easily rerunning the inputs generation
+if [[ "${1:-}" == "--update_inputs" ]]; then
+    set -eu
+    echo "Updating pinned IVC inputs..."
+
+    # Generate new inputs
+    echo "Running bootstrap to generate new IVC inputs..."
+
+    ../../bootstrap.sh # bootstrap aztec-packages from root
+    ../../yarn-project/end-to-end/bootstrap.sh build_bench # build bench to generate IVC inputs
+
+    compress_and_upload ../../yarn-project/end-to-end/example-app-ivc-inputs-out
+
     exit 0
 fi
 
@@ -54,11 +59,21 @@ curl -s -f "$pinned_civc_inputs_url" | tar -xzf - -C "$inputs_tmp_dir" &>/dev/nu
 function check_circuit_vks {
   set -eu
   local flow_folder="$inputs_tmp_dir/$1"
-  ./build/bin/bb check --scheme client_ivc --ivc_inputs_path "$flow_folder/ivc-inputs.msgpack" || { echo_stderr "Error: Likely VK change detected in $flow_folder!"; exit 1; }
+
+  if [[ "${2:-}" == "--update_inputs" ]]; then
+    ./build/bin/bb check --update_inputs --scheme client_ivc --ivc_inputs_path "$flow_folder/ivc-inputs.msgpack" || { echo_stderr "Error: Likely VK change detected in $flow_folder! Updating inputs."; exit 1; }
+  else
+    ./build/bin/bb check --scheme client_ivc --ivc_inputs_path "$flow_folder/ivc-inputs.msgpack" || { echo_stderr "Error: Likely VK change detected in $flow_folder!"; exit 1; }
+  fi
 }
 
 export -f check_circuit_vks
 
 # Run on one public and one private input.
 ls "$inputs_tmp_dir"
-parallel -v --line-buffer --tag check_circuit_vks {} ::: $(ls "$inputs_tmp_dir")
+
+if [[ "${1:-}" == "--update_fast" ]]; then
+  parallel -v --line-buffer --tag check_circuit_vks {} --update_inputs ::: $(ls "$inputs_tmp_dir") ||  compress_and_upload $inputs_tmp_dir
+else
+  parallel -v --line-buffer --tag check_circuit_vks {} ::: $(ls "$inputs_tmp_dir")
+fi


### PR DESCRIPTION
When `--update_fast` is enabled, `test_civc_standalone_vks_havent_changed.sh` will run `bb check --update_inputs` and upload.

Fixes https://github.com/AztecProtocol/barretenberg/issues/1464