### PR TITLE
fix(flows): make prove_and_verify_program.sh POSIX-compliant by removing bash-specific syntax

### DIFF
--- a/barretenberg/acir_tests/flows/prove_and_verify_program.sh
+++ b/barretenberg/acir_tests/flows/prove_and_verify_program.sh
@@ -4,6 +4,8 @@ set -eu
 
 VFLAG=${VERBOSE:+-v}
 FLAGS="-c $CRS_PATH $VFLAG"
-[ "${RECURSIVE}" = "true" ] && FLAGS+=" --recursive"
+if [ "${RECURSIVE:-}" = "true" ]; then
+  FLAGS="$FLAGS --recursive"
+fi
 
 $BIN prove_and_verify_${SYS}_program $FLAGS -b ./target/program.json


### PR DESCRIPTION
The script barretenberg/acir_tests/flows/prove_and_verify_program.sh used the bash-specific '+=' operator for string concatenation when adding the '--recursive' flag. However, the script's shebang is '/bin/sh', which on many systems (e.g., Debian/Ubuntu) points to dash, a POSIX shell that does not support '+=' for strings. This caused a syntax error when running the script with /bin/sh.

This commit replaces the '+=' operation with a POSIX-compliant if-block that appends the flag using standard variable assignment. As a result, the script now works correctly in any POSIX shell, including dash.