### PR TITLE
fix: unwrap entrypoint from bash so the container can be used as a binary

### DIFF
--- a/release-image/Dockerfile
+++ b/release-image/Dockerfile
@@ -18,4 +18,4 @@ WORKDIR "/usr/src/yarn-project"
 ARG VERSION
 RUN echo '{".": "'$VERSION'"}' > /usr/src/.release-please-manifest.json
 
-ENTRYPOINT ["/bin/bash", "-c", "node --no-warnings /usr/src/yarn-project/aztec/dest/bin/index.js"]
+ENTRYPOINT ["node", "--no-warnings", "/usr/src/yarn-project/aztec/dest/bin/index.js"]

--- a/release-image/README.md
+++ b/release-image/README.md
@@ -27,5 +27,5 @@ We then manually install our required version of node, and a handful of require 
 
 # Entrypoint
 
-The entrypoint will the aztec cli, you should pass as arguments the desired entrypoint and arguments.
+The entrypoint will be the aztec cli, you should pass as arguments the desired entrypoint and arguments.
 When wanting to run nargo, aztec-wallet, aztec cli, anvil, etc, update the entrypoint to just be bash before executing.


### PR DESCRIPTION
With it being run as `bash -c '...'`, arguments and flags are passed to `bash` and not `node` (aka _aztec_), so running something like `docker run -it --rm aztecprotocol/aztec start -h` doesn't print the `start` command's help info.
