### PR TITLE
chore: assert size == virtual_size in polynomial::evaluate

### DIFF
--- a/barretenberg/cpp/src/barretenberg/polynomials/polynomial.cpp
+++ b/barretenberg/cpp/src/barretenberg/polynomials/polynomial.cpp
@@ -191,11 +191,13 @@ template <typename Fr> Polynomial<Fr>& Polynomial<Fr>::operator+=(PolynomialSpan
 
 template <typename Fr> Fr Polynomial<Fr>::evaluate(const Fr& z, const size_t target_size) const
 {
+    ASSERT(size() == virtual_size());
     return polynomial_arithmetic::evaluate(data(), z, target_size);
 }
 
 template <typename Fr> Fr Polynomial<Fr>::evaluate(const Fr& z) const
 {
+    ASSERT(size() == virtual_size());
     return polynomial_arithmetic::evaluate(data(), z, size());
 }
 


### PR DESCRIPTION
This implementation of `evalutate` sends the raw data to `polynomial_arithmetic` but didn't send the `start/end` indices, which means that it only works when the polynomial occupies all of the memory, implied by `size() == virtual_size()`.