### PR TITLE
chore(docs): add 'ci' command to bootstrap script for building and testing documentation

### DIFF
--- a/docs/bootstrap.sh
+++ b/docs/bootstrap.sh
@@ -59,6 +59,10 @@ case "$cmd" in
   "clean")
     git clean -fdx
     ;;
+  "ci")
+    build_docs
+    test
+    ;;
   ""|"full"|"fast")
     build_docs
     ;;


### PR DESCRIPTION
Docs are not being built or tested on next. This PR fixes it