### PR TITLE
test: migrate all tests off of the old contract call flow

### DIFF
--- a/docs/docs/developers/guides/smart_contracts/testing.md
+++ b/docs/docs/developers/guides/smart_contracts/testing.md
@@ -209,10 +209,6 @@ For example:
 
 #include_code fail_with_message /noir-projects/noir-contracts/contracts/app/token_contract/src/test/transfer_in_private.nr rust
 
-You can also use the `assert_public_call_fails` or `assert_private_call_fails` methods on the `TestEnvironment` to check that a call fails.
-
-#include_code assert_public_fail /noir-projects/noir-contracts/contracts/app/token_contract/src/test/access_control.nr rust
-
 ### Logging
 
 You can use `aztec.nr`'s oracles as usual for debug logging, as explained [here](../../reference/debugging/index.md)

--- a/noir-projects/aztec-nr/aztec/src/test/helpers/authwit.nr
+++ b/noir-projects/aztec-nr/aztec/src/test/helpers/authwit.nr
@@ -1,12 +1,15 @@
 use crate::{
-    authwit::auth::{compute_authwit_message_hash, compute_inner_authwit_hash, set_authorized},
-    context::{call_interfaces::CallInterface, public_context::PublicContext},
+    authwit::auth::{compute_authwit_message_hash, compute_inner_authwit_hash},
+    context::call_interfaces::{CallInterface, PublicVoidCallInterface},
     hash::hash_args,
-    oracle::execution::get_contract_address,
-    test::helpers::txe_oracles,
+    oracle::execution::{get_chain_id, get_version},
+    test::helpers::{test_environment::TestEnvironment, txe_oracles},
 };
 
-use protocol_types::{address::AztecAddress, traits::ToField};
+use protocol_types::{
+    abis::function_selector::FunctionSelector, address::AztecAddress,
+    constants::CANONICAL_AUTH_REGISTRY_ADDRESS, traits::ToField,
+};
 
 pub unconstrained fn add_private_authwit_from_call_interface<C, let M: u32>(
     on_behalf_of: AztecAddress,
@@ -17,9 +20,8 @@ where
     C: CallInterface<M>,
 {
     let target = call_interface.get_contract_address();
-    let inputs = txe_oracles::get_private_context_inputs(Option::none());
-    let chain_id = inputs.tx_context.chain_id;
-    let version = inputs.tx_context.version;
+    let chain_id = get_chain_id();
+    let version = get_version();
     let args_hash = hash_args(call_interface.get_args());
     let selector = call_interface.get_selector();
     let inner_hash =
@@ -29,6 +31,7 @@ where
 }
 
 pub unconstrained fn add_public_authwit_from_call_interface<C, let M: u32>(
+    env: &mut TestEnvironment,
     on_behalf_of: AztecAddress,
     caller: AztecAddress,
     call_interface: C,
@@ -36,19 +39,23 @@ pub unconstrained fn add_public_authwit_from_call_interface<C, let M: u32>(
 where
     C: CallInterface<M>,
 {
-    let current_contract = get_contract_address();
-    txe_oracles::set_contract_address(on_behalf_of);
     let target = call_interface.get_contract_address();
-    let inputs = txe_oracles::get_private_context_inputs(Option::none());
-    let chain_id = inputs.tx_context.chain_id;
-    let version = inputs.tx_context.version;
+    let chain_id = get_chain_id();
+    let version = get_version();
     let args_hash = hash_args(call_interface.get_args());
     let selector = call_interface.get_selector();
     let inner_hash =
         compute_inner_authwit_hash([caller.to_field(), selector.to_field(), args_hash]);
     let message_hash = compute_authwit_message_hash(target, chain_id, version, inner_hash);
-    let mut context = PublicContext::new(|| panic(f"Provide args hash manually"));
-    context.args_hash = Option::some(args_hash);
-    set_authorized(&mut context, message_hash, true);
-    txe_oracles::set_contract_address(current_contract);
+
+    let _ = env.call_public_void(
+        on_behalf_of,
+        PublicVoidCallInterface::<_, ()>::new(
+            CANONICAL_AUTH_REGISTRY_ADDRESS,
+            comptime { FunctionSelector::from_signature("set_authorized(Field,bool)") },
+            "set_authorized",
+            [message_hash, true as Field].as_slice(),
+            false,
+        ),
+    );
 }

--- a/noir-projects/aztec-nr/aztec/src/test/helpers/test_environment.nr
+++ b/noir-projects/aztec-nr/aztec/src/test/helpers/test_environment.nr
@@ -139,6 +139,20 @@ impl TestEnvironment {
         ret_value
     }
 
+    pub unconstrained fn private_context_at<Env, T>(
+        &mut self,
+        addr: AztecAddress,
+        f: fn[Env](&mut PrivateContext) -> T,
+    ) -> T {
+        // temporary hack until we reimplement the public context oracle and have it take this as a param
+        let pre = txe_oracles::get_contract_address();
+        txe_oracles::set_contract_address(addr);
+        let ret = self.private_context(f);
+        txe_oracles::set_contract_address(pre);
+
+        ret
+    }
+
     /// EXPERIMENTAL FEATURE - NOT MEANT FOR EXTERNAL USE
     pub unconstrained fn utility_context<Env, T>(&mut self, f: fn[Env](UtilityContext) -> T) -> T {
         txe_oracles::set_utility_txe_context();

--- a/noir-projects/noir-contracts/contracts/app/easy_private_voting_contract/src/test/first.nr
+++ b/noir-projects/noir-contracts/contracts/app/easy_private_voting_contract/src/test/first.nr
@@ -47,7 +47,6 @@ unconstrained fn test_fail_end_vote_by_non_admin() {
 unconstrained fn test_cast_vote() {
     let (env, voting_contract_address, _) = utils::setup();
     let alice = env.create_account(2);
-    env.impersonate(alice);
 
     let candidate = 1;
     let _ = env.call_private_void(

--- a/noir-projects/noir-contracts/contracts/app/nft_contract/src/test/transfer_in_private.nr
+++ b/noir-projects/noir-contracts/contracts/app/nft_contract/src/test/transfer_in_private.nr
@@ -12,12 +12,13 @@ unconstrained fn transfer_in_private() {
         utils::setup_mint_and_transfer_to_private(/* with_account_contracts */ false);
 
     // Transfer the NFT to the recipient
-    NFT::at(nft_contract_address).transfer_in_private(sender, recipient, token_id, 0).call(
-        &mut env.private(),
+    let _ = env.call_private_void(
+        sender,
+        NFT::at(nft_contract_address).transfer_in_private(sender, recipient, token_id, 0),
     );
 
     // Recipient should have the note in their private nfts
-    utils::assert_owns_private_nft(nft_contract_address, recipient, token_id);
+    utils::assert_owns_private_nft(env, nft_contract_address, recipient, token_id);
 }
 
 #[test]
@@ -27,12 +28,13 @@ unconstrained fn transfer_in_private_to_self() {
         utils::setup_mint_and_transfer_to_private(/* with_account_contracts */ false);
 
     // Transfer the NFT back to the owner
-    NFT::at(nft_contract_address).transfer_in_private(owner, owner, token_id, 0).call(
-        &mut env.private(),
+    let _ = env.call_private_void(
+        owner,
+        NFT::at(nft_contract_address).transfer_in_private(owner, owner, token_id, 0),
     );
 
     // NFT owner should stay the same
-    utils::assert_owns_private_nft(nft_contract_address, owner, token_id);
+    utils::assert_owns_private_nft(env, nft_contract_address, owner, token_id);
 }
 
 #[test]
@@ -43,12 +45,13 @@ unconstrained fn transfer_in_private_to_non_deployed_account() {
     let not_deployed = txe_oracles::create_account(999);
 
     // Transfer the NFT to the recipient
-    NFT::at(nft_contract_address)
-        .transfer_in_private(sender, not_deployed.address, token_id, 0)
-        .call(&mut env.private());
+    let _ = env.call_private_void(
+        sender,
+        NFT::at(nft_contract_address).transfer_in_private(sender, not_deployed.address, token_id, 0),
+    );
 
     // Owner of the private NFT should be the not_deployed account
-    utils::assert_owns_private_nft(nft_contract_address, not_deployed.address, token_id);
+    utils::assert_owns_private_nft(env, nft_contract_address, not_deployed.address, token_id);
 }
 
 #[test]
@@ -62,13 +65,11 @@ unconstrained fn transfer_in_private_on_behalf_of_other() {
         NFT::at(nft_contract_address).transfer_in_private(sender, recipient, token_id, 1);
     add_private_authwit_from_call_interface(sender, recipient, transfer_in_private_call_interface);
 
-    // Impersonate recipient to perform the call
-    env.impersonate(recipient);
     // Transfer the NFT to the recipient
-    transfer_in_private_call_interface.call(&mut env.private());
+    let _ = env.call_private_void(recipient, transfer_in_private_call_interface);
 
     // Recipient should be the private NFT owner
-    utils::assert_owns_private_nft(nft_contract_address, recipient, token_id);
+    utils::assert_owns_private_nft(env, nft_contract_address, recipient, token_id);
 }
 
 #[test(should_fail_with = "NFT not found when transferring")]
@@ -76,10 +77,10 @@ unconstrained fn transfer_in_private_failure_not_an_owner() {
     // Setup without account contracts. We are not using authwits here, so dummy accounts are enough
     let (env, nft_contract_address, owner, not_owner, token_id) =
         utils::setup_mint_and_transfer_to_private(/* with_account_contracts */ false);
-    // Try transferring the NFT from not_owner
-    env.impersonate(not_owner);
-    NFT::at(nft_contract_address).transfer_in_private(not_owner, owner, token_id, 0).call(
-        &mut env.private(),
+
+    let _ = env.call_private_void(
+        not_owner,
+        NFT::at(nft_contract_address).transfer_in_private(not_owner, owner, token_id, 0),
     );
 }
 
@@ -95,8 +96,9 @@ unconstrained fn transfer_in_private_failure_on_behalf_of_self_non_zero_nonce() 
     let token_id = random();
 
     // Try transferring the NFT
-    NFT::at(nft_contract_address).transfer_in_private(sender, recipient, token_id, 1).call(
-        &mut env.private(),
+    let _ = env.call_private_void(
+        sender,
+        NFT::at(nft_contract_address).transfer_in_private(sender, recipient, token_id, 1),
     );
 }
 
@@ -111,11 +113,10 @@ unconstrained fn transfer_in_private_failure_on_behalf_of_other_without_approval
     // We set random value for the token_id as the authwit nonce check is before we use the value.
     let token_id = random();
 
-    // Impersonate recipient to perform the call
-    env.impersonate(recipient);
     // Try transferring the NFT
-    NFT::at(nft_contract_address).transfer_in_private(sender, recipient, token_id, 1).call(
-        &mut env.private(),
+    let _ = env.call_private_void(
+        recipient,
+        NFT::at(nft_contract_address).transfer_in_private(sender, recipient, token_id, 1),
     );
 }
 
@@ -137,8 +138,7 @@ unconstrained fn transfer_in_private_failure_on_behalf_of_other_wrong_caller() {
         sender,
         transfer_in_private_from_call_interface,
     );
-    // Impersonate recipient to perform the call
-    env.impersonate(recipient);
+
     // Try transferring the NFT
-    transfer_in_private_from_call_interface.call(&mut env.private());
+    let _ = env.call_private_void(recipient, transfer_in_private_from_call_interface);
 }

--- a/noir-projects/noir-contracts/contracts/app/nft_contract/src/test/transfer_in_public.nr
+++ b/noir-projects/noir-contracts/contracts/app/nft_contract/src/test/transfer_in_public.nr
@@ -42,14 +42,14 @@ unconstrained fn transfer_in_public_on_behalf_of_other() {
     let transfer_in_public_from_call_interface =
         NFT::at(nft_contract_address).transfer_in_public(sender, recipient, token_id, 1);
     add_public_authwit_from_call_interface(
+        env,
         sender,
         recipient,
         transfer_in_public_from_call_interface,
     );
-    // Impersonate recipient to perform the call
-    env.impersonate(recipient);
+
     // Transfer the NFT
-    transfer_in_public_from_call_interface.call(&mut env.public());
+    let _ = env.call_public_void(recipient, transfer_in_public_from_call_interface);
 
     // Check the is recipient is the new public owner
     utils::assert_owns_public_nft(env, nft_contract_address, recipient, token_id);
@@ -95,16 +95,20 @@ unconstrained fn transfer_in_public_failure_on_behalf_of_other_without_approval(
     );
 }
 
-#[test(should_fail_with = "unauthorized")]
+#[test(should_fail)] // should_fail_with = "unauthorized"
 unconstrained fn transfer_in_public_failure_on_behalf_of_other_wrong_caller() {
     // Setup with account contracts. Slower since we actually deploy them, but needed for authwits.
     let (env, nft_contract_address, sender, recipient, token_id) =
         utils::setup_and_mint(/* with_account_contracts */ true);
     let transfer_in_public_from_call_interface =
         NFT::at(nft_contract_address).transfer_in_public(sender, recipient, token_id, 1);
-    add_public_authwit_from_call_interface(sender, sender, transfer_in_public_from_call_interface);
-    // Impersonate recipient to perform the call
-    env.impersonate(recipient);
+    add_public_authwit_from_call_interface(
+        env,
+        sender,
+        sender,
+        transfer_in_public_from_call_interface,
+    );
+
     // Try to transfer tokens
-    transfer_in_public_from_call_interface.call(&mut env.public());
+    let _ = env.call_public_void(recipient, transfer_in_public_from_call_interface);
 }

--- a/noir-projects/noir-contracts/contracts/app/nft_contract/src/test/transfer_to_private.nr
+++ b/noir-projects/noir-contracts/contracts/app/nft_contract/src/test/transfer_to_private.nr
@@ -14,7 +14,7 @@ unconstrained fn transfer_to_private_internal_orchestration() {
         utils::setup_mint_and_transfer_to_private(/* with_account_contracts */ false);
 
     // User should have the note in their private nfts
-    utils::assert_owns_private_nft(nft_contract_address, user, token_id);
+    utils::assert_owns_private_nft(env, nft_contract_address, user, token_id);
 
     // Since the NFT was sent to private, the public owner should be zero address
     utils::assert_owns_public_nft(env, nft_contract_address, AztecAddress::zero(), token_id);
@@ -25,83 +25,90 @@ unconstrained fn transfer_to_private_internal_orchestration() {
 #[test]
 unconstrained fn transfer_to_private_external_orchestration() {
     // Setup without account contracts. We are not using authwits here, so dummy accounts are enough
-    let (env, nft_contract_address, _, recipient, token_id) =
+    let (env, nft_contract_address, owner, recipient, token_id) =
         utils::setup_and_mint(/* with_account_contracts */ false);
 
     // We prepare the transfer
-    let partial_note = NFT::at(nft_contract_address)
-        .prepare_private_balance_increase(recipient)
-        .call(&mut env.private());
+    let partial_note = env
+        .call_private(
+            owner,
+            NFT::at(nft_contract_address).prepare_private_balance_increase(recipient),
+        )
+        .return_value;
 
     // Finalize the transfer of the NFT (message sender owns the NFT in public)
-    NFT::at(nft_contract_address).finalize_transfer_to_private(token_id, partial_note).call(
-        &mut env.public(),
+    let _ = env.call_public_void(
+        owner,
+        NFT::at(nft_contract_address).finalize_transfer_to_private(token_id, partial_note),
     );
 
-    env.mine_block();
-
     // Recipient should have the note in their private nfts
-    utils::assert_owns_private_nft(nft_contract_address, recipient, token_id);
+    utils::assert_owns_private_nft(env, nft_contract_address, recipient, token_id);
 
     // Since the NFT got transferred to private public owner should be zero address
     utils::assert_owns_public_nft(env, nft_contract_address, AztecAddress::zero(), token_id);
 }
 
-#[test(should_fail_with = "Invalid partial note or completer")]
+#[test(should_fail)] // should_fail_with = "Invalid partial note or completer"
 unconstrained fn transfer_to_private_transfer_not_prepared() {
     // Setup without account contracts. We are not using authwits here, so dummy accounts are enough
-    let (env, nft_contract_address, _, _, token_id) =
+    let (env, nft_contract_address, owner, _, token_id) =
         utils::setup_and_mint(/* with_account_contracts */ false);
 
     // Transfer was not prepared so we can use random value for the partial note
     let partial_note = PartialNFTNote { commitment: random() };
 
     // Try finalizing the transfer without preparing it
-    NFT::at(nft_contract_address).finalize_transfer_to_private(token_id, partial_note).call(
-        &mut env.public(),
+    let _ = env.call_public_void(
+        owner,
+        NFT::at(nft_contract_address).finalize_transfer_to_private(token_id, partial_note),
     );
 }
 
-#[test(should_fail_with = "invalid NFT owner")]
+#[test(should_fail)] // should_fail_with = "invalid NFT owner"
 unconstrained fn transfer_to_private_failure_not_an_owner() {
     // Setup without account contracts. We are not using authwits here, so dummy accounts are enough
-    let (env, nft_contract_address, _, not_owner, token_id) =
+    let (env, nft_contract_address, owner, not_owner, token_id) =
         utils::setup_and_mint(/* with_account_contracts */ false);
 
     // (For this specific test we could set a random value for the commitment and not do the call to `prepare...`
     // as the NFT owner check is before we use the value but that would made the test less robust against changes
     // in the contract.)
-    let partial_note = NFT::at(nft_contract_address)
-        .prepare_private_balance_increase(not_owner)
-        .call(&mut env.private());
+    let partial_note = env
+        .call_private(
+            owner,
+            NFT::at(nft_contract_address).prepare_private_balance_increase(not_owner),
+        )
+        .return_value;
 
     // Try transferring someone else's public NFT
-    env.impersonate(not_owner);
-    NFT::at(nft_contract_address).finalize_transfer_to_private(token_id, partial_note).call(
-        &mut env.public(),
+    let _ = env.call_public_void(
+        not_owner,
+        NFT::at(nft_contract_address).finalize_transfer_to_private(token_id, partial_note),
     );
 }
 
-#[test(should_fail_with = "Invalid partial note or completer")]
+#[test(should_fail)] // should_fail_with = "Invalid partial note or completer"
 unconstrained fn incorrect_completer_cannot_complete_partial_note() {
     // Setup without account contracts. We are not using authwits here, so dummy accounts are enough.
-    // We mint to the incorrect completer to avoid the test failing due to the NFT owner check (we want to fail on
-    // the partial note validity check).
-    let (env, nft_contract_address, incorrect_completer, recipient, token_id) =
+    let (env, nft_contract_address, owner, recipient, token_id) =
         utils::setup_and_mint(/* with_account_contracts */ false);
 
     // We set up the completer
     let completer = env.create_account(3);
 
-    // We prepare the partial note as a completer
-    env.impersonate(completer);
-    let partial_note = NFT::at(nft_contract_address)
-        .prepare_private_balance_increase(recipient)
-        .call(&mut env.private());
+    // We prepare the partial note as a completer.
+    let partial_note = env
+        .call_private(
+            completer,
+            NFT::at(nft_contract_address).prepare_private_balance_increase(recipient),
+        )
+        .return_value;
 
-    // Now we try to complete the partial note as the incorrect completer
-    env.impersonate(incorrect_completer);
-    NFT::at(nft_contract_address).finalize_transfer_to_private(token_id, partial_note).call(
-        &mut env.public(),
+    // Now we try to complete the partial note as another completer. Note that the completer is the owner of the token
+    // we're transferring - this is so that we pass the owner check and fail on the partial note completer check.
+    let _ = env.call_public_void(
+        owner,
+        NFT::at(nft_contract_address).finalize_transfer_to_private(token_id, partial_note),
     );
 }

--- a/noir-projects/noir-contracts/contracts/app/nft_contract/src/test/transfer_to_private.nr
+++ b/noir-projects/noir-contracts/contracts/app/nft_contract/src/test/transfer_to_private.nr
@@ -105,7 +105,7 @@ unconstrained fn incorrect_completer_cannot_complete_partial_note() {
         )
         .return_value;
 
-    // Now we try to complete the partial note as another completer. Note that the completer is the owner of the token
+    // Now we try to complete the partial note as another completer. Note that the caller here is the owner of the token
     // we're transferring - this is so that we pass the owner check and fail on the partial note completer check.
     let _ = env.call_public_void(
         owner,

--- a/noir-projects/noir-contracts/contracts/app/nft_contract/src/test/transfer_to_public.nr
+++ b/noir-projects/noir-contracts/contracts/app/nft_contract/src/test/transfer_to_public.nr
@@ -10,8 +10,9 @@ unconstrained fn transfer_to_public() {
     let (env, nft_contract_address, sender, recipient, token_id) =
         utils::setup_mint_and_transfer_to_private(/* with_account_contracts */ false);
 
-    NFT::at(nft_contract_address).transfer_to_public(sender, recipient, token_id, 0).call(
-        &mut env.private(),
+    let _ = env.call_private_void(
+        sender,
+        NFT::at(nft_contract_address).transfer_to_public(sender, recipient, token_id, 0),
     );
 
     // Recipient should be the public owner
@@ -24,8 +25,9 @@ unconstrained fn transfer_to_public_to_self() {
     let (env, nft_contract_address, user, _, token_id) =
         utils::setup_mint_and_transfer_to_private(/* with_account_contracts */ false);
 
-    NFT::at(nft_contract_address).transfer_to_public(user, user, token_id, 0).call(
-        &mut env.private(),
+    let _ = env.call_private_void(
+        user,
+        NFT::at(nft_contract_address).transfer_to_public(user, user, token_id, 0),
     );
 
     // Check the user stayed the public owner
@@ -40,10 +42,9 @@ unconstrained fn transfer_to_public_on_behalf_of_other() {
     let transfer_to_public_call_interface =
         NFT::at(nft_contract_address).transfer_to_public(sender, recipient, token_id, 0);
     add_private_authwit_from_call_interface(sender, recipient, transfer_to_public_call_interface);
-    // Impersonate recipient
-    env.impersonate(recipient);
+
     // transfer_to_public the NFT
-    transfer_to_public_call_interface.call(&mut env.private());
+    let _ = env.call_private_void(recipient, transfer_to_public_call_interface);
 
     // Recipient should be the public owner
     utils::assert_owns_public_nft(env, nft_contract_address, recipient, token_id);
@@ -55,9 +56,9 @@ unconstrained fn transfer_to_public_failure_not_an_owner() {
     let (env, nft_contract_address, _, not_owner, token_id) =
         utils::setup_mint_and_transfer_to_private(/* with_account_contracts */ false);
 
-    env.impersonate(not_owner);
-    NFT::at(nft_contract_address).transfer_to_public(not_owner, not_owner, token_id, 0).call(
-        &mut env.private(),
+    let _ = env.call_private_void(
+        not_owner,
+        NFT::at(nft_contract_address).transfer_to_public(not_owner, not_owner, token_id, 0),
     );
 }
 
@@ -67,8 +68,9 @@ unconstrained fn transfer_to_public_failure_on_behalf_of_self_non_zero_nonce() {
     let (env, nft_contract_address, user, _, token_id) =
         utils::setup_mint_and_transfer_to_private(/* with_account_contracts */ false);
 
-    NFT::at(nft_contract_address).transfer_to_public(user, user, token_id, random()).call(
-        &mut env.private(),
+    let _ = env.call_private_void(
+        user,
+        NFT::at(nft_contract_address).transfer_to_public(user, user, token_id, random()),
     );
 }
 
@@ -80,10 +82,9 @@ unconstrained fn transfer_to_public_failure_on_behalf_of_other_invalid_designate
     let transfer_to_public_call_interface =
         NFT::at(nft_contract_address).transfer_to_public(sender, recipient, token_id, 0);
     add_private_authwit_from_call_interface(sender, sender, transfer_to_public_call_interface);
-    // Impersonate recipient
-    env.impersonate(recipient);
+
     // transfer_to_public the NFT
-    transfer_to_public_call_interface.call(&mut env.private());
+    let _ = env.call_private_void(recipient, transfer_to_public_call_interface);
 }
 
 #[test(should_fail_with = "Unknown auth witness for message hash")]
@@ -91,10 +92,9 @@ unconstrained fn transfer_to_public_failure_on_behalf_of_other_no_approval() {
     let (env, nft_contract_address, sender, recipient, token_id) =
         utils::setup_mint_and_transfer_to_private(/* with_account_contracts */ true);
 
-    // Impersonate recipient
-    env.impersonate(recipient);
     // transfer_to_public the NFT
-    NFT::at(nft_contract_address).transfer_to_public(sender, recipient, token_id, 0).call(
-        &mut env.private(),
+    let _ = env.call_private_void(
+        recipient,
+        NFT::at(nft_contract_address).transfer_to_public(sender, recipient, token_id, 0),
     );
 }

--- a/noir-projects/noir-contracts/contracts/app/nft_contract/src/test/utils.nr
+++ b/noir-projects/noir-contracts/contracts/app/nft_contract/src/test/utils.nr
@@ -26,9 +26,6 @@ pub unconstrained fn setup(
         (owner, recipient)
     };
 
-    // Start the test in the account contract address
-    env.impersonate(owner);
-
     // Deploy token contract
     let initializer_call_interface = NFT::interface().constructor(
         owner,

--- a/noir-projects/noir-contracts/contracts/app/nft_contract/src/test/utils.nr
+++ b/noir-projects/noir-contracts/contracts/app/nft_contract/src/test/utils.nr
@@ -61,10 +61,10 @@ pub unconstrained fn setup_mint_and_transfer_to_private(
         setup_and_mint(with_account_contracts);
 
     // We transfer the public NFT to private.
-    NFT::at(nft_contract_address).transfer_to_private(owner, minted_token_id).call(
-        &mut env.private(),
+    let _ = env.call_private_void(
+        owner,
+        NFT::at(nft_contract_address).transfer_to_private(owner, minted_token_id),
     );
-    env.mine_block();
 
     (env, nft_contract_address, owner, recipient, minted_token_id)
 }
@@ -80,15 +80,13 @@ pub unconstrained fn assert_owns_public_nft(
 }
 
 pub unconstrained fn assert_owns_private_nft(
+    env: &mut TestEnvironment,
     nft_contract_address: AztecAddress,
     owner: AztecAddress,
     token_id: Field,
 ) {
-    let current_contract_address = get_contract_address();
-    txe_oracles::set_contract_address(nft_contract_address);
-
-    // Direct call to unconstrained
-    let (private_nfts, _) = NFT::get_private_nfts(owner, 0);
+    let (private_nfts, _) = env.simulate_utility(NFT::at(nft_contract_address)
+        ._experimental_get_private_nfts(owner, 0));
 
     let mut nft_found = false;
     for obtained_token_id in private_nfts {
@@ -96,8 +94,6 @@ pub unconstrained fn assert_owns_private_nft(
             nft_found = true;
         }
     }
-
-    txe_oracles::set_contract_address(current_contract_address);
 
     assert(nft_found, "NFT not found in private nfts");
 }

--- a/noir-projects/noir-contracts/contracts/app/token_contract/src/test/access_control.nr
+++ b/noir-projects/noir-contracts/contracts/app/token_contract/src/test/access_control.nr
@@ -5,38 +5,43 @@ use aztec::protocol_types::traits::ToField;
 #[test]
 unconstrained fn access_control() {
     // Setup without account contracts. We are not using authwits here, so dummy accounts are enough
-    let (env, token_contract_address, owner, recipient) =
+    let (env, token_contract_address, owner, new_admin) =
         utils::setup(/* with_account_contracts */ false);
 
+    let token = Token::at(token_contract_address);
+
     // Set a new admin
-    Token::at(token_contract_address).set_admin(recipient).call(&mut env.public());
-    // Check it worked
-    let admin = Token::at(token_contract_address).get_admin().view(&mut env.public());
-    assert(admin == recipient.to_field());
-    // Impersonate new admin
-    env.impersonate(recipient);
+    let _ = env.call_public_void(owner, token.set_admin(new_admin));
+    assert_eq(env.view_public(token.get_admin()), new_admin.to_field());
+
     // Check new admin is not a minter
-    let is_minter_call_interface = Token::at(token_contract_address).is_minter(recipient);
-    let is_minter = is_minter_call_interface.view(&mut env.public());
-    assert(is_minter == false);
-    // Set admin as minter
-    Token::at(token_contract_address).set_minter(recipient, true).call(&mut env.public());
-    // Check it worked
-    let is_minter = is_minter_call_interface.view(&mut env.public());
-    assert(is_minter);
+    assert(!env.view_public(token.is_minter(new_admin)));
+
+    // Set new admin as minter
+    let _ = env.call_public_void(new_admin, token.set_minter(new_admin, true));
+    assert(env.view_public(token.is_minter(new_admin)));
+
     // Revoke minter as admin
-    Token::at(token_contract_address).set_minter(recipient, false).call(&mut env.public());
-    // Check it worked
-    let is_minter = is_minter_call_interface.view(&mut env.public());
-    assert(is_minter == false);
-    // Impersonate original admin
-    env.impersonate(owner);
-    // docs:start:assert_public_fail
-    // Try to set ourselves as admin, fail miserably
-    let set_admin_call_interface = Token::at(token_contract_address).set_admin(recipient);
-    env.assert_public_call_fails(set_admin_call_interface);
-    // docs:end:assert_public_fail
-    // Try to revoke minter status to recipient, fail miserably
-    let set_minter_call_interface = Token::at(token_contract_address).set_minter(recipient, false);
-    env.assert_public_call_fails(set_minter_call_interface);
+    let _ = env.call_public_void(new_admin, token.set_minter(new_admin, false));
+    assert(!env.view_public(token.is_minter(new_admin)));
+}
+
+#[test(should_fail)]
+unconstrained fn set_admin_requires_admin_caller() {
+    // Setup without account contracts. We are not using authwits here, so dummy accounts are enough
+    let (env, token_contract_address, _, other) = utils::setup(/* with_account_contracts */ false);
+
+    let token = Token::at(token_contract_address);
+
+    let _ = env.call_public_void(other, token.set_admin(other));
+}
+
+#[test(should_fail)]
+unconstrained fn set_minter_requires_admin_caller() {
+    // Setup without account contracts. We are not using authwits here, so dummy accounts are enough
+    let (env, token_contract_address, _, other) = utils::setup(/* with_account_contracts */ false);
+
+    let token = Token::at(token_contract_address);
+
+    let _ = env.call_public_void(other, token.set_minter(other, true));
 }

--- a/noir-projects/noir-contracts/contracts/app/token_contract/src/test/burn_private.nr
+++ b/noir-projects/noir-contracts/contracts/app/token_contract/src/test/burn_private.nr
@@ -1,8 +1,8 @@
 use crate::test::utils;
 use crate::Token;
-use aztec::{
-    oracle::random::random, test::helpers::authwit::add_private_authwit_from_call_interface,
-};
+use aztec::test::helpers::authwit::add_private_authwit_from_call_interface;
+
+global AUTHWIT_NONCE: Field = 7;
 
 #[test]
 unconstrained fn burn_private_on_behalf_of_self() {
@@ -11,8 +11,16 @@ unconstrained fn burn_private_on_behalf_of_self() {
     let burn_amount = mint_amount / (10 as u128);
 
     // Burn less than balance
-    Token::at(token_contract_address).burn_private(owner, burn_amount, 0).call(&mut env.private());
-    utils::check_private_balance(token_contract_address, owner, mint_amount - burn_amount);
+    let _ = env.call_private_void(
+        owner,
+        Token::at(token_contract_address).burn_private(owner, burn_amount, 0),
+    );
+    utils::check_private_balance(
+        env,
+        token_contract_address,
+        owner,
+        mint_amount - burn_amount,
+    );
 }
 
 #[test]
@@ -23,13 +31,16 @@ unconstrained fn burn_private_on_behalf_of_other() {
 
     // Burn on behalf of other
     let burn_call_interface =
-        Token::at(token_contract_address).burn_private(owner, burn_amount, random());
+        Token::at(token_contract_address).burn_private(owner, burn_amount, AUTHWIT_NONCE);
     add_private_authwit_from_call_interface(owner, recipient, burn_call_interface);
-    // Impersonate recipient to perform the call
-    env.impersonate(recipient);
     // Burn tokens
-    burn_call_interface.call(&mut env.private());
-    utils::check_private_balance(token_contract_address, owner, mint_amount - burn_amount);
+    let _ = env.call_private_void(recipient, burn_call_interface);
+    utils::check_private_balance(
+        env,
+        token_contract_address,
+        owner,
+        mint_amount - burn_amount,
+    );
 }
 
 #[test(should_fail_with = "Balance too low")]
@@ -39,7 +50,10 @@ unconstrained fn burn_private_failure_more_than_balance() {
 
     // Burn more than balance
     let burn_amount = mint_amount * (10 as u128);
-    Token::at(token_contract_address).burn_private(owner, burn_amount, 0).call(&mut env.private());
+    let _ = env.call_private_void(
+        owner,
+        Token::at(token_contract_address).burn_private(owner, burn_amount, 0),
+    );
 }
 
 #[test(should_fail_with = "Assertion failed: Invalid authwit nonce. When 'from' and 'msg_sender' are the same, 'authwit_nonce' must be zero")]
@@ -47,10 +61,10 @@ unconstrained fn burn_private_failure_on_behalf_of_self_non_zero_nonce() {
     let (env, token_contract_address, owner, _, mint_amount) =
         utils::setup_and_mint_to_public(/* with_account_contracts */ false);
 
-    // Burn more than balance
-    let burn_amount = mint_amount / (10 as u128);
-    Token::at(token_contract_address).burn_private(owner, burn_amount, random()).call(
-        &mut env.private(),
+    let burn_amount = mint_amount;
+    let _ = env.call_private_void(
+        owner,
+        Token::at(token_contract_address).burn_private(owner, burn_amount, 1),
     );
 }
 
@@ -63,11 +77,10 @@ unconstrained fn burn_private_failure_on_behalf_of_other_more_than_balance() {
     let burn_amount = mint_amount * (10 as u128);
     // Burn on behalf of other
     let burn_call_interface =
-        Token::at(token_contract_address).burn_private(owner, burn_amount, random());
+        Token::at(token_contract_address).burn_private(owner, burn_amount, AUTHWIT_NONCE);
     add_private_authwit_from_call_interface(owner, recipient, burn_call_interface);
     // Impersonate recipient to perform the call
-    env.impersonate(recipient);
-    burn_call_interface.call(&mut env.private());
+    let _ = env.call_private_void(recipient, burn_call_interface);
 }
 
 #[test(should_fail_with = "Unknown auth witness for message hash")]
@@ -78,10 +91,10 @@ unconstrained fn burn_private_failure_on_behalf_of_other_without_approval() {
     // Burn more than balance
     let burn_amount = mint_amount / (10 as u128);
     // Burn on behalf of other
-    let burn_call_interface = Token::at(token_contract_address).burn_private(owner, burn_amount, 3);
+    let burn_call_interface =
+        Token::at(token_contract_address).burn_private(owner, burn_amount, AUTHWIT_NONCE);
     // Impersonate recipient to perform the call
-    env.impersonate(recipient);
-    burn_call_interface.call(&mut env.private());
+    let _ = env.call_private_void(recipient, burn_call_interface);
 }
 
 #[test(should_fail_with = "Unknown auth witness for message hash")]
@@ -92,9 +105,9 @@ unconstrained fn burn_private_failure_on_behalf_of_other_wrong_designated_caller
     // Burn more than balance
     let burn_amount = mint_amount / (10 as u128);
     // Burn on behalf of other
-    let burn_call_interface = Token::at(token_contract_address).burn_private(owner, burn_amount, 3);
+    let burn_call_interface =
+        Token::at(token_contract_address).burn_private(owner, burn_amount, AUTHWIT_NONCE);
     add_private_authwit_from_call_interface(owner, owner, burn_call_interface);
     // Impersonate recipient to perform the call
-    env.impersonate(recipient);
-    burn_call_interface.call(&mut env.private());
+    let _ = env.call_private_void(recipient, burn_call_interface);
 }

--- a/noir-projects/noir-contracts/contracts/app/token_contract/src/test/burn_public.nr
+++ b/noir-projects/noir-contracts/contracts/app/token_contract/src/test/burn_public.nr
@@ -22,7 +22,7 @@ unconstrained fn burn_public_on_behalf_of_other() {
     // Burn on behalf of other
     let burn_call_interface =
         Token::at(token_contract_address).burn_public(owner, burn_amount, random());
-    add_public_authwit_from_call_interface(owner, recipient, burn_call_interface);
+    add_public_authwit_from_call_interface(env, owner, recipient, burn_call_interface);
     // Impersonate recipient to perform the call
     env.impersonate(recipient);
     // Burn tokens
@@ -77,7 +77,7 @@ unconstrained fn burn_public_failure_on_behalf_of_other_wrong_caller() {
     let burn_amount = mint_amount / (10 as u128);
     let burn_call_interface =
         Token::at(token_contract_address).burn_public(owner, burn_amount, random());
-    add_public_authwit_from_call_interface(owner, owner, burn_call_interface);
+    add_public_authwit_from_call_interface(env, owner, owner, burn_call_interface);
     // Impersonate recipient to perform the call
     env.impersonate(recipient);
     burn_call_interface.call(&mut env.public());

--- a/noir-projects/noir-contracts/contracts/app/token_contract/src/test/burn_public.nr
+++ b/noir-projects/noir-contracts/contracts/app/token_contract/src/test/burn_public.nr
@@ -4,13 +4,18 @@ use aztec::{oracle::random::random, test::helpers::authwit::add_public_authwit_f
 
 #[test]
 unconstrained fn burn_public_success() {
-    let (env, token_contract_address, owner, recipient, mint_amount) =
+    let (env, token_contract_address, owner, _, mint_amount) =
         utils::setup_and_mint_to_public(/* with_account_contracts */ false);
     let burn_amount = mint_amount / (10 as u128);
 
     // Burn less than balance
-    Token::at(token_contract_address).burn_public(owner, burn_amount, 0).call(&mut env.public());
-    utils::check_public_balance(token_contract_address, owner, mint_amount - burn_amount);
+    env.call_public_void(owner, Token::at(token_contract_address).burn_public(owner, burn_amount, 0));
+    utils::check_public_balance(
+        env,
+        token_contract_address,
+        owner,
+        mint_amount - burn_amount,
+    );
 }
 
 #[test]
@@ -23,14 +28,19 @@ unconstrained fn burn_public_on_behalf_of_other() {
     let burn_call_interface =
         Token::at(token_contract_address).burn_public(owner, burn_amount, random());
     add_public_authwit_from_call_interface(env, owner, recipient, burn_call_interface);
-    // Impersonate recipient to perform the call
-    env.impersonate(recipient);
+
     // Burn tokens
-    burn_call_interface.call(&mut env.public());
-    utils::check_public_balance(token_contract_address, owner, mint_amount - burn_amount);
+    let _ = env.call_public_void(recipient, burn_call_interface);
+
+    utils::check_public_balance(
+        env,
+        token_contract_address,
+        owner,
+        mint_amount - burn_amount,
+    );
 }
 
-#[test(should_fail_with = "Assertion failed: attempt to subtract with overflow")]
+#[test(should_fail)] // should_fail_with = "Assertion failed: attempt to subtract with overflow"
 unconstrained fn burn_public_failure_more_than_balance() {
     let (env, token_contract_address, owner, _, mint_amount) =
         utils::setup_and_mint_to_public(/* with_account_contracts */ false);
@@ -38,10 +48,13 @@ unconstrained fn burn_public_failure_more_than_balance() {
     // Burn more than balance
     let burn_amount = mint_amount * (10 as u128);
     // Try to burn
-    Token::at(token_contract_address).burn_public(owner, burn_amount, 0).call(&mut env.public());
+    let _ = env.call_public_void(
+        owner,
+        Token::at(token_contract_address).burn_public(owner, burn_amount, 0),
+    );
 }
 
-#[test(should_fail_with = "Assertion failed: Invalid authwit nonce. When 'from' and 'msg_sender' are the same, 'authwit_nonce' must be zero")]
+#[test(should_fail)] // should_fail_with = "Assertion failed: Invalid authwit nonce. When 'from' and 'msg_sender' are the same, 'authwit_nonce' must be zero"
 unconstrained fn burn_public_failure_on_behalf_of_self_non_zero_nonce() {
     let (env, token_contract_address, owner, _, mint_amount) =
         utils::setup_and_mint_to_public(/* with_account_contracts */ false);
@@ -49,12 +62,13 @@ unconstrained fn burn_public_failure_on_behalf_of_self_non_zero_nonce() {
     // Burn on behalf of self with non-zero nonce
     let burn_amount = mint_amount / (10 as u128);
     // Try to burn
-    Token::at(token_contract_address).burn_public(owner, burn_amount, random()).call(
-        &mut env.public(),
+    let _ = env.call_public_void(
+        owner,
+        Token::at(token_contract_address).burn_public(owner, burn_amount, random()),
     );
 }
 
-#[test(should_fail_with = "unauthorized")]
+#[test(should_fail)] // should_fail_with = "unauthorized"
 unconstrained fn burn_public_failure_on_behalf_of_other_without_approval() {
     let (env, token_contract_address, owner, recipient, mint_amount) =
         utils::setup_and_mint_to_public(/* with_account_contracts */ true);
@@ -63,12 +77,11 @@ unconstrained fn burn_public_failure_on_behalf_of_other_without_approval() {
     let burn_amount = mint_amount / (10 as u128);
     let burn_call_interface =
         Token::at(token_contract_address).burn_public(owner, burn_amount, random());
-    // Impersonate recipient to perform the call
-    env.impersonate(recipient);
-    burn_call_interface.call(&mut env.public());
+
+    let _ = env.call_public_void(recipient, burn_call_interface);
 }
 
-#[test(should_fail_with = "unauthorized")]
+#[test(should_fail)] // should_fail_with = "unauthorized"
 unconstrained fn burn_public_failure_on_behalf_of_other_wrong_caller() {
     let (env, token_contract_address, owner, recipient, mint_amount) =
         utils::setup_and_mint_to_public(/* with_account_contracts */ true);
@@ -78,7 +91,6 @@ unconstrained fn burn_public_failure_on_behalf_of_other_wrong_caller() {
     let burn_call_interface =
         Token::at(token_contract_address).burn_public(owner, burn_amount, random());
     add_public_authwit_from_call_interface(env, owner, owner, burn_call_interface);
-    // Impersonate recipient to perform the call
-    env.impersonate(recipient);
-    burn_call_interface.call(&mut env.public());
+
+    let _ = env.call_public_void(recipient, burn_call_interface);
 }

--- a/noir-projects/noir-contracts/contracts/app/token_contract/src/test/mint_to_public.nr
+++ b/noir-projects/noir-contracts/contracts/app/token_contract/src/test/mint_to_public.nr
@@ -6,50 +6,47 @@ unconstrained fn mint_to_public_success() {
     let (env, token_contract_address, owner, _) = utils::setup(/* with_account_contracts */ false);
 
     let mint_amount = 10_000 as u128;
-    Token::at(token_contract_address).mint_to_public(owner, mint_amount).call(&mut env.public());
+    let _ = env.call_public_void(
+        owner,
+        Token::at(token_contract_address).mint_to_public(owner, mint_amount),
+    );
 
-    utils::check_public_balance(token_contract_address, owner, mint_amount);
+    utils::check_public_balance(env, token_contract_address, owner, mint_amount);
 
-    let total_supply = Token::at(token_contract_address).total_supply().view(&mut env.public());
+    let total_supply = env.view_public(Token::at(token_contract_address).total_supply());
     assert(total_supply == mint_amount);
 }
 
-#[test]
-unconstrained fn mint_to_public_failures() {
+#[test(should_fail)]
+unconstrained fn mint_as_non_minter() {
     // Setup without account contracts. We are not using authwits here, so dummy accounts are enough
-    let (env, token_contract_address, owner, recipient) =
+    let (env, token_contract_address, _, recipient) =
         utils::setup(/* with_account_contracts */ false);
 
     // As non-minter
     let mint_amount = 10_000 as u128;
-    env.impersonate(recipient);
-    let mint_to_public_call_interface =
-        Token::at(token_contract_address).mint_to_public(owner, mint_amount);
-    env.assert_public_call_fails(mint_to_public_call_interface);
+    let _ = env.call_public_void(
+        recipient,
+        Token::at(token_contract_address).mint_to_public(recipient, mint_amount),
+    );
+}
 
-    utils::check_public_balance(token_contract_address, owner, 0 as u128);
+#[test(should_fail)]
+unconstrained fn mint_overflow() {
+    // Setup without account contracts. We are not using authwits here, so dummy accounts are enough
+    let (env, token_contract_address, owner, recipient) =
+        utils::setup(/* with_account_contracts */ false);
 
-    env.impersonate(owner);
-
-    // Overflow recipient
-
-    // We have to do this in 2 steps because we have to pass in a valid u128
+    // We mint twice because each mint amount must be a valid u128
     let amount_until_overflow = 1000 as u128;
     let mint_amount = (2.pow_32(128) - amount_until_overflow as Field) as u128;
 
-    Token::at(token_contract_address).mint_to_public(recipient, mint_amount).call(&mut env.public());
-
-    let mint_to_public_call_interface =
-        Token::at(token_contract_address).mint_to_public(owner, amount_until_overflow);
-    env.assert_public_call_fails(mint_to_public_call_interface);
-
-    utils::check_public_balance(token_contract_address, owner, 0 as u128);
-    utils::check_total_supply(token_contract_address, mint_amount);
-
-    // Overflow total supply
-    let mint_to_public_call_interface =
-        Token::at(token_contract_address).mint_to_public(owner, mint_amount);
-    env.assert_public_call_fails(mint_to_public_call_interface);
-
-    utils::check_public_balance(token_contract_address, owner, 0 as u128);
+    let _ = env.call_public_void(
+        owner,
+        Token::at(token_contract_address).mint_to_public(recipient, mint_amount),
+    );
+    let _ = env.call_public_void(
+        owner,
+        Token::at(token_contract_address).mint_to_public(recipient, amount_until_overflow),
+    );
 }

--- a/noir-projects/noir-contracts/contracts/app/token_contract/src/test/reading_constants.nr
+++ b/noir-projects/noir-contracts/contracts/app/token_contract/src/test/reading_constants.nr
@@ -1,16 +1,15 @@
 use crate::test::utils;
 use crate::Token;
-use dep::aztec::test::helpers::txe_oracles;
 
 // It is not possible to deserialize strings in Noir ATM, so name and symbol cannot be checked yet.
 
 #[test]
 unconstrained fn check_decimals_private() {
     // Setup without account contracts. We are not using authwits here, so dummy accounts are enough
-    let (env, token_contract_address, _, _) = utils::setup(/* with_account_contracts */ false);
+    let (env, token_contract_address, owner, _) = utils::setup(/* with_account_contracts */ false);
 
-    // Check decimals
-    let result = Token::at(token_contract_address).private_get_decimals().view(&mut env.private());
+    // Check decimals - the 'from' parameter is irrelevant
+    let result = env.view_private(owner, Token::at(token_contract_address).private_get_decimals());
 
     assert(result == 18);
 }
@@ -21,7 +20,7 @@ unconstrained fn check_decimals_public() {
     let (env, token_contract_address, _, _) = utils::setup(/* with_account_contracts */ false);
 
     // Check decimals
-    let result = Token::at(token_contract_address).public_get_decimals().view(&mut env.public());
+    let result = env.view_public(Token::at(token_contract_address).public_get_decimals());
 
     assert(result == 18);
 }

--- a/noir-projects/noir-contracts/contracts/app/token_contract/src/test/transfer.nr
+++ b/noir-projects/noir-contracts/contracts/app/token_contract/src/test/transfer.nr
@@ -1,6 +1,5 @@
 use crate::test::utils;
 use crate::Token;
-use dep::aztec::test::helpers::txe_oracles;
 
 #[test]
 unconstrained fn transfer_private() {
@@ -11,11 +10,19 @@ unconstrained fn transfer_private() {
     // docs:start:txe_test_transfer_private
     // Transfer tokens
     let transfer_amount = 1000 as u128;
-    Token::at(token_contract_address).transfer(recipient, transfer_amount).call(&mut env.private());
+    let _ = env.call_private_void(
+        owner,
+        Token::at(token_contract_address).transfer(recipient, transfer_amount),
+    );
     // docs:end:txe_test_transfer_private
     // Check balances
-    utils::check_private_balance(token_contract_address, owner, mint_amount - transfer_amount);
-    utils::check_private_balance(token_contract_address, recipient, transfer_amount);
+    utils::check_private_balance(
+        env,
+        token_contract_address,
+        owner,
+        mint_amount - transfer_amount,
+    );
+    utils::check_private_balance(env, token_contract_address, recipient, transfer_amount);
 }
 
 #[test]
@@ -25,10 +32,13 @@ unconstrained fn transfer_private_to_self() {
         utils::setup_and_mint_to_private(/* with_account_contracts */ false);
     // Transfer tokens
     let transfer_amount = 1000 as u128;
-    Token::at(token_contract_address).transfer(owner, transfer_amount).call(&mut env.private());
+    let _ = env.call_private_void(
+        owner,
+        Token::at(token_contract_address).transfer(owner, transfer_amount),
+    );
 
     // Check balances
-    utils::check_private_balance(token_contract_address, owner, mint_amount);
+    utils::check_private_balance(env, token_contract_address, owner, mint_amount);
 }
 
 #[test]
@@ -36,28 +46,34 @@ unconstrained fn transfer_private_to_non_deployed_account() {
     // Setup without account contracts. We are not using authwits here, so dummy accounts are enough
     let (env, token_contract_address, owner, _, mint_amount) =
         utils::setup_and_mint_to_private(/* with_account_contracts */ false);
-    let not_deployed = txe_oracles::create_account(999);
+    let not_deployed = env.create_account(999);
+
     // Transfer tokens
     let transfer_amount = 1000 as u128;
-    Token::at(token_contract_address).transfer(not_deployed.address, transfer_amount).call(
-        &mut env.private(),
+    let _ = env.call_private_void(
+        owner,
+        Token::at(token_contract_address).transfer(not_deployed, transfer_amount),
     );
 
     // Check balances
-    utils::check_private_balance(token_contract_address, owner, mint_amount - transfer_amount);
     utils::check_private_balance(
+        env,
         token_contract_address,
-        not_deployed.address,
-        transfer_amount,
+        owner,
+        mint_amount - transfer_amount,
     );
+    utils::check_private_balance(env, token_contract_address, not_deployed, transfer_amount);
 }
 
 #[test(should_fail_with = "Balance too low")]
 unconstrained fn transfer_private_failure_more_than_balance() {
     // Setup without account contracts. We are not using authwits here, so dummy accounts are enough
-    let (env, token_contract_address, _, recipient, mint_amount) =
+    let (env, token_contract_address, owner, recipient, mint_amount) =
         utils::setup_and_mint_to_private(/* with_account_contracts */ false);
     // Transfer tokens
     let transfer_amount = mint_amount + (1 as u128);
-    Token::at(token_contract_address).transfer(recipient, transfer_amount).call(&mut env.private());
+    let _ = env.call_private_void(
+        owner,
+        Token::at(token_contract_address).transfer(recipient, transfer_amount),
+    );
 }

--- a/noir-projects/noir-contracts/contracts/app/token_contract/src/test/transfer_in_private.nr
+++ b/noir-projects/noir-contracts/contracts/app/token_contract/src/test/transfer_in_private.nr
@@ -13,14 +13,17 @@ unconstrained fn transfer_private_on_behalf_of_other() {
     let transfer_private_from_call_interface =
         Token::at(token_contract_address).transfer_in_private(owner, recipient, transfer_amount, 1);
     add_private_authwit_from_call_interface(owner, recipient, transfer_private_from_call_interface);
-    // Impersonate recipient to perform the call
-    env.impersonate(recipient);
     // Transfer tokens
-    transfer_private_from_call_interface.call(&mut env.private());
+    let _ = env.call_private_void(recipient, transfer_private_from_call_interface);
     // docs:end:private_authwit
     // Check balances
-    utils::check_private_balance(token_contract_address, owner, mint_amount - transfer_amount);
-    utils::check_private_balance(token_contract_address, recipient, transfer_amount);
+    utils::check_private_balance(
+        env,
+        token_contract_address,
+        owner,
+        mint_amount - transfer_amount,
+    );
+    utils::check_private_balance(env, token_contract_address, recipient, transfer_amount);
 }
 
 // docs:start:fail_with_message
@@ -35,7 +38,7 @@ unconstrained fn transfer_private_failure_on_behalf_of_self_non_zero_nonce() {
         Token::at(token_contract_address).transfer_in_private(owner, recipient, transfer_amount, 1);
     add_private_authwit_from_call_interface(owner, recipient, transfer_private_from_call_interface);
     // Transfer tokens
-    transfer_private_from_call_interface.call(&mut env.private());
+    let _ = env.call_private_void(owner, transfer_private_from_call_interface);
 }
 // docs:end:fail_with_message
 
@@ -49,10 +52,8 @@ unconstrained fn transfer_private_failure_on_behalf_of_more_than_balance() {
     let transfer_private_from_call_interface =
         Token::at(token_contract_address).transfer_in_private(owner, recipient, transfer_amount, 1);
     add_private_authwit_from_call_interface(owner, recipient, transfer_private_from_call_interface);
-    // Impersonate recipient to perform the call
-    env.impersonate(recipient);
     // Transfer tokens
-    transfer_private_from_call_interface.call(&mut env.private());
+    let _ = env.call_private_void(recipient, transfer_private_from_call_interface);
 }
 
 #[test(should_fail_with = "Unknown auth witness for message hash")]
@@ -64,10 +65,8 @@ unconstrained fn transfer_private_failure_on_behalf_of_other_without_approval() 
     let transfer_amount = 1000 as u128;
     let transfer_private_from_call_interface =
         Token::at(token_contract_address).transfer_in_private(owner, recipient, transfer_amount, 1);
-    // Impersonate recipient to perform the call
-    env.impersonate(recipient);
     // Transfer tokens
-    transfer_private_from_call_interface.call(&mut env.private());
+    let _ = env.call_private_void(recipient, transfer_private_from_call_interface);
 }
 
 #[test(should_fail_with = "Unknown auth witness for message hash")]
@@ -80,8 +79,6 @@ unconstrained fn transfer_private_failure_on_behalf_of_other_wrong_caller() {
     let transfer_private_from_call_interface =
         Token::at(token_contract_address).transfer_in_private(owner, recipient, transfer_amount, 1);
     add_private_authwit_from_call_interface(owner, owner, transfer_private_from_call_interface);
-    // Impersonate recipient to perform the call
-    env.impersonate(recipient);
     // Transfer tokens
-    transfer_private_from_call_interface.call(&mut env.private());
+    let _ = env.call_private_void(recipient, transfer_private_from_call_interface);
 }

--- a/noir-projects/noir-contracts/contracts/app/token_contract/src/test/transfer_in_public.nr
+++ b/noir-projects/noir-contracts/contracts/app/token_contract/src/test/transfer_in_public.nr
@@ -1,6 +1,6 @@
 use crate::test::utils;
 use crate::Token;
-use aztec::{oracle::random::random, test::helpers::authwit::add_public_authwit_from_call_interface};
+use aztec::test::helpers::authwit::add_public_authwit_from_call_interface;
 
 #[test]
 unconstrained fn public_transfer() {
@@ -9,13 +9,19 @@ unconstrained fn public_transfer() {
         utils::setup_and_mint_to_public(/* with_account_contracts */ false);
     // Transfer tokens
     let transfer_amount = mint_amount / (10 as u128);
-    Token::at(token_contract_address).transfer_in_public(owner, recipient, transfer_amount, 0).call(
-        &mut env.public(),
+    let _ = env.call_public_void(
+        owner,
+        Token::at(token_contract_address).transfer_in_public(owner, recipient, transfer_amount, 0),
     );
 
     // Check balances
-    utils::check_public_balance(token_contract_address, owner, mint_amount - transfer_amount);
-    utils::check_public_balance(token_contract_address, recipient, transfer_amount);
+    utils::check_public_balance(
+        env,
+        token_contract_address,
+        owner,
+        mint_amount - transfer_amount,
+    );
+    utils::check_public_balance(env, token_contract_address, recipient, transfer_amount);
 }
 
 #[test]
@@ -26,12 +32,13 @@ unconstrained fn public_transfer_to_self() {
     // Transfer tokens
     let transfer_amount = mint_amount / (10 as u128);
     // docs:start:call_public
-    Token::at(token_contract_address).transfer_in_public(owner, owner, transfer_amount, 0).call(
-        &mut env.public(),
+    let _ = env.call_public_void(
+        owner,
+        Token::at(token_contract_address).transfer_in_public(owner, owner, transfer_amount, 0),
     );
     // docs:end:call_public
     // Check balances
-    utils::check_public_balance(token_contract_address, owner, mint_amount);
+    utils::check_public_balance(env, token_contract_address, owner, mint_amount);
 }
 
 #[test]
@@ -48,16 +55,19 @@ unconstrained fn public_transfer_on_behalf_of_other() {
         recipient,
         public_transfer_in_private_call_interface,
     );
-    // Impersonate recipient to perform the call
-    env.impersonate(recipient);
     // Transfer tokens
-    public_transfer_in_private_call_interface.call(&mut env.public());
+    let _ = env.call_public_void(recipient, public_transfer_in_private_call_interface);
     // Check balances
-    utils::check_public_balance(token_contract_address, owner, mint_amount - transfer_amount);
-    utils::check_public_balance(token_contract_address, recipient, transfer_amount);
+    utils::check_public_balance(
+        env,
+        token_contract_address,
+        owner,
+        mint_amount - transfer_amount,
+    );
+    utils::check_public_balance(env, token_contract_address, recipient, transfer_amount);
 }
 
-#[test(should_fail_with = "Assertion failed: attempt to subtract with overflow")]
+#[test(should_fail)] // should_fail_with = "Assertion failed: attempt to subtract with overflow"
 unconstrained fn public_transfer_failure_more_than_balance() {
     // Setup without account contracts. We are not using authwits here, so dummy accounts are enough
     let (env, token_contract_address, owner, recipient, mint_amount) =
@@ -67,28 +77,24 @@ unconstrained fn public_transfer_failure_more_than_balance() {
     let public_transfer_call_interface =
         Token::at(token_contract_address).transfer_in_public(owner, recipient, transfer_amount, 0);
     // Try to transfer tokens
-    public_transfer_call_interface.call(&mut env.public());
+    let _ = env.call_public_void(owner, public_transfer_call_interface);
 }
 
-#[test(should_fail_with = "Assertion failed: Invalid authwit nonce. When 'from' and 'msg_sender' are the same, 'authwit_nonce' must be zero")]
+#[test(should_fail)] // should_fail_with = "Assertion failed: Invalid authwit nonce. When 'from' and 'msg_sender' are the same, 'authwit_nonce' must be zero"
 unconstrained fn public_transfer_failure_on_behalf_of_self_non_zero_nonce() {
     // Setup without account contracts. We are not using authwits here, so dummy accounts are enough
     let (env, token_contract_address, owner, recipient, mint_amount) =
         utils::setup_and_mint_to_public(/* with_account_contracts */ false);
     // Transfer tokens
     let transfer_amount = mint_amount / (10 as u128);
-    let public_transfer_call_interface = Token::at(token_contract_address).transfer_in_public(
-        owner,
-        recipient,
-        transfer_amount,
-        random(),
-    );
+    let public_transfer_call_interface =
+        Token::at(token_contract_address).transfer_in_public(owner, recipient, transfer_amount, 1);
     add_public_authwit_from_call_interface(env, owner, recipient, public_transfer_call_interface);
     // Try to transfer tokens
-    public_transfer_call_interface.call(&mut env.public());
+    let _ = env.call_public_void(owner, public_transfer_call_interface);
 }
 
-#[test(should_fail_with = "unauthorized")]
+#[test(should_fail)] // should_fail_with = "unauthorized"
 unconstrained fn public_transfer_failure_on_behalf_of_other_without_approval() {
     // Setup with account contracts. Slower since we actually deploy them, but needed for authwits.
     let (env, token_contract_address, owner, recipient, mint_amount) =
@@ -96,13 +102,12 @@ unconstrained fn public_transfer_failure_on_behalf_of_other_without_approval() {
     let transfer_amount = mint_amount / (10 as u128);
     let public_transfer_in_private_call_interface =
         Token::at(token_contract_address).transfer_in_public(owner, recipient, transfer_amount, 1);
-    // Impersonate recipient to perform the call
-    env.impersonate(recipient);
+
     // Try to transfer tokens
-    public_transfer_in_private_call_interface.call(&mut env.public());
+    let _ = env.call_public_void(recipient, public_transfer_in_private_call_interface);
 }
 
-#[test(should_fail_with = "Assertion failed: attempt to subtract with overflow")]
+#[test(should_fail)] // should_fail_with = "Assertion failed: attempt to subtract with overflow"
 unconstrained fn public_transfer_failure_on_behalf_of_other_more_than_balance() {
     // Setup with account contracts. Slower since we actually deploy them, but needed for authwits.
     let (env, token_contract_address, owner, recipient, mint_amount) =
@@ -118,13 +123,12 @@ unconstrained fn public_transfer_failure_on_behalf_of_other_more_than_balance() 
         public_transfer_in_private_call_interface,
     );
     // docs:end:public_authwit
-    // Impersonate recipient to perform the call
-    env.impersonate(recipient);
+
     // Try to transfer tokens
-    public_transfer_in_private_call_interface.call(&mut env.public());
+    let _ = env.call_public_void(recipient, public_transfer_in_private_call_interface);
 }
 
-#[test(should_fail_with = "unauthorized")]
+#[test(should_fail)] // should_fail_with = "unauthorized"
 unconstrained fn public_transfer_failure_on_behalf_of_other_wrong_caller() {
     // Setup with account contracts. Slower since we actually deploy them, but needed for authwits.
     let (env, token_contract_address, owner, recipient, mint_amount) =
@@ -138,8 +142,7 @@ unconstrained fn public_transfer_failure_on_behalf_of_other_wrong_caller() {
         owner,
         public_transfer_in_private_call_interface,
     );
-    // Impersonate recipient to perform the call
-    env.impersonate(recipient);
+
     // Try to transfer tokens
-    public_transfer_in_private_call_interface.call(&mut env.public());
+    let _ = env.call_public_void(recipient, public_transfer_in_private_call_interface);
 }

--- a/noir-projects/noir-contracts/contracts/app/token_contract/src/test/transfer_in_public.nr
+++ b/noir-projects/noir-contracts/contracts/app/token_contract/src/test/transfer_in_public.nr
@@ -43,6 +43,7 @@ unconstrained fn public_transfer_on_behalf_of_other() {
     let public_transfer_in_private_call_interface =
         Token::at(token_contract_address).transfer_in_public(owner, recipient, transfer_amount, 1);
     add_public_authwit_from_call_interface(
+        env,
         owner,
         recipient,
         public_transfer_in_private_call_interface,
@@ -82,7 +83,7 @@ unconstrained fn public_transfer_failure_on_behalf_of_self_non_zero_nonce() {
         transfer_amount,
         random(),
     );
-    add_public_authwit_from_call_interface(owner, recipient, public_transfer_call_interface);
+    add_public_authwit_from_call_interface(env, owner, recipient, public_transfer_call_interface);
     // Try to transfer tokens
     public_transfer_call_interface.call(&mut env.public());
 }
@@ -111,6 +112,7 @@ unconstrained fn public_transfer_failure_on_behalf_of_other_more_than_balance() 
     let public_transfer_in_private_call_interface =
         Token::at(token_contract_address).transfer_in_public(owner, recipient, transfer_amount, 1);
     add_public_authwit_from_call_interface(
+        env,
         owner,
         recipient,
         public_transfer_in_private_call_interface,
@@ -130,7 +132,12 @@ unconstrained fn public_transfer_failure_on_behalf_of_other_wrong_caller() {
     let transfer_amount = mint_amount / (10 as u128);
     let public_transfer_in_private_call_interface =
         Token::at(token_contract_address).transfer_in_public(owner, recipient, transfer_amount, 1);
-    add_public_authwit_from_call_interface(owner, owner, public_transfer_in_private_call_interface);
+    add_public_authwit_from_call_interface(
+        env,
+        owner,
+        owner,
+        public_transfer_in_private_call_interface,
+    );
     // Impersonate recipient to perform the call
     env.impersonate(recipient);
     // Try to transfer tokens

--- a/noir-projects/noir-contracts/contracts/app/token_contract/src/test/transfer_to_private.nr
+++ b/noir-projects/noir-contracts/contracts/app/token_contract/src/test/transfer_to_private.nr
@@ -11,11 +11,11 @@ unconstrained fn transfer_to_private_internal_orchestration() {
     // The transfer to private is done in `utils::setup_and_mint_to_private` and for this reason
     // in this test we just call it and check the outcome.
     // Setup without account contracts. We are not using authwits here, so dummy accounts are enough
-    let (_, token_contract_address, user, _, amount) =
+    let (env, token_contract_address, user, _, amount) =
         utils::setup_and_mint_to_private(/* with_account_contracts */ false);
 
     // User's private balance should be equal to the amount
-    utils::check_private_balance(token_contract_address, user, amount);
+    utils::check_private_balance(env, token_contract_address, user, amount);
 }
 
 /// External orchestration means that the calls to prepare and finalize are not done by the Token contract. This flow
@@ -23,110 +23,118 @@ unconstrained fn transfer_to_private_internal_orchestration() {
 #[test]
 unconstrained fn transfer_to_private_external_orchestration() {
     // Setup without account contracts. We are not using authwits here, so dummy accounts are enough
-    let (env, token_contract_address, _, recipient, amount) =
+    let (env, token_contract_address, owner, recipient, amount) =
         utils::setup_and_mint_to_public(/* with_account_contracts */ false);
 
     // We prepare the transfer
-    let partial_uint_note = Token::at(token_contract_address)
-        .prepare_private_balance_increase(recipient)
-        .call(&mut env.private());
+    let partial_uint_note = env
+        .call_private(
+            owner,
+            Token::at(token_contract_address).prepare_private_balance_increase(recipient),
+        )
+        .return_value;
 
     // Finalize the transfer of the tokens (message sender owns the tokens in public)
-    Token::at(token_contract_address).finalize_transfer_to_private(amount, partial_uint_note).call(
-        &mut env.public(),
+    let _ = env.call_public_void(
+        owner,
+        Token::at(token_contract_address).finalize_transfer_to_private(amount, partial_uint_note),
     );
 
-    env.mine_block();
-
     // Recipient's private balance should be equal to the amount
-    utils::check_private_balance(token_contract_address, recipient, amount);
+    utils::check_private_balance(env, token_contract_address, recipient, amount);
 }
 
-// TODO(#10289): Enable this test once TXE handles partial notes properly. Currently it fails on the recipient amount
-// check.
-// /// External orchestration means that the calls to prepare and finalize are not done by the Token contract. This flow
-// /// will typically be used by a DEX.
-// #[test]
-// unconstrained fn transfer_to_private_from_private_external_orchestration() {
-//     // Setup without account contracts. We are not using authwits here, so dummy accounts are enough
-//     let (env, token_contract_address, owner, recipient, amount) =
-//         utils::setup_and_mint_to_private(/* with_account_contracts */ false);
+/// External orchestration means that the calls to prepare and finalize are not done by the Token contract. This flow
+/// will typically be used by a DEX.
+#[test]
+unconstrained fn transfer_to_private_from_private_external_orchestration() {
+    // Setup without account contracts. We are not using authwits here, so dummy accounts are enough
+    let (env, token_contract_address, owner, recipient, amount) =
+        utils::setup_and_mint_to_private(/* with_account_contracts */ false);
 
-//     // We prepare the transfer
-//     let partial_uint_note = Token::at(token_contract_address)
-//         .prepare_private_balance_increase(recipient)
-//         .call(&mut env.private());
+    // We prepare the transfer
+    let partial_uint_note = env
+        .call_private(
+            owner,
+            Token::at(token_contract_address).prepare_private_balance_increase(recipient),
+        )
+        .return_value;
+    // Finalize the transfer of the tokens (message sender owns the tokens in public)
+    let _ = env.call_private_void(
+        owner,
+        Token::at(token_contract_address).finalize_transfer_to_private_from_private(
+            owner,
+            partial_uint_note,
+            amount,
+            0,
+        ),
+    );
 
-//     // Finalize the transfer of the tokens (message sender owns the tokens in public)
-//     Token::at(token_contract_address).finalize_transfer_to_private_from_private(
-//         owner,
-//         partial_uint_note,
-//         amount,
-//         0,
-//     ).call(&mut env.private());
+    // Recipient's private balance should be equal to the amount
+    utils::check_private_balance(env, token_contract_address, recipient, amount);
+    utils::check_private_balance(env, token_contract_address, owner, 0);
+}
 
-//     env.mine_block();
-
-//     // Recipient's private balance should be equal to the amount
-//     utils::check_private_balance(token_contract_address, recipient, amount);
-//     utils::check_private_balance(token_contract_address, owner, 0);
-// }
-
-#[test(should_fail_with = "Invalid partial note or completer")]
+#[test(should_fail)] // should_fail_with = "Invalid partial note or completer"
 unconstrained fn transfer_to_private_transfer_not_prepared() {
     // Setup without account contracts. We are not using authwits here, so dummy accounts are enough
-    let (env, token_contract_address, _, _, amount) =
+    let (env, token_contract_address, owner, _, amount) =
         utils::setup_and_mint_to_public(/* with_account_contracts */ false);
 
     // Transfer was not prepared so we can use random value for the partial note
     let partial_uint_note = PartialUintNote { commitment: random() };
 
     // Try finalizing the transfer without preparing it
-    Token::at(token_contract_address).finalize_transfer_to_private(amount, partial_uint_note).call(
-        &mut env.public(),
+    let _ = env.call_public_void(
+        owner,
+        Token::at(token_contract_address).finalize_transfer_to_private(amount, partial_uint_note),
     );
 }
 
-#[test(should_fail_with = "Assertion failed: attempt to subtract with overflow")]
+#[test(should_fail)] // should_fail_with = "Assertion failed: attempt to subtract with overflow"
 unconstrained fn transfer_to_private_failure_not_an_owner() {
     // Setup without account contracts. We are not using authwits here, so dummy accounts are enough
-    let (env, token_contract_address, _, not_owner, amount) =
+    let (env, token_contract_address, owner, not_owner, amount) =
         utils::setup_and_mint_to_public(/* with_account_contracts */ false);
 
     // (For this specific test we could set a random value for the commitment and not do the call to `prepare...`
     // as the token balance check is before we use the value but that would made the test less robust against changes
     // in the contract.)
-    let partial_uint_note = Token::at(token_contract_address)
-        .prepare_private_balance_increase(not_owner)
-        .call(&mut env.private());
+    let partial_uint_note = env
+        .call_private(
+            owner,
+            Token::at(token_contract_address).prepare_private_balance_increase(not_owner),
+        )
+        .return_value;
 
     // Try transferring someone else's token balance
-    env.impersonate(not_owner);
-    Token::at(token_contract_address).finalize_transfer_to_private(amount, partial_uint_note).call(
-        &mut env.public(),
+    let _ = env.call_public_void(
+        not_owner,
+        Token::at(token_contract_address).finalize_transfer_to_private(amount, partial_uint_note),
     );
 }
 
-#[test(should_fail_with = "Invalid partial note or completer")]
+#[test(should_fail)] // should_fail_with = "Invalid partial note or completer"
 unconstrained fn incorrect_completer_cannot_complete_partial_note() {
     // Setup without account contracts. We are not using authwits here, so dummy accounts are enough.
-    // We mint to the incorrect completer to avoid the test failing due to the NFT owner check (we want to fail on
-    // the partial note validity check).
-    let (env, token_contract_address, incorrect_completer, recipient, amount) =
+    let (env, token_contract_address, owner, recipient, amount) =
         utils::setup_and_mint_to_public(/* with_account_contracts */ false);
 
     // We set up the completer
     let completer = env.create_account(3);
 
     // We prepare the partial note as a completer
-    env.impersonate(completer);
-    let partial_uint_note = Token::at(token_contract_address)
-        .prepare_private_balance_increase(recipient)
-        .call(&mut env.private());
+    let partial_uint_note = env
+        .call_private(
+            completer,
+            Token::at(token_contract_address).prepare_private_balance_increase(recipient),
+        )
+        .return_value;
 
-    // We impersonate the incorrect completer and try to finalize the transfer
-    env.impersonate(incorrect_completer);
-    Token::at(token_contract_address).finalize_transfer_to_private(amount, partial_uint_note).call(
-        &mut env.public(),
+    // Now we try to complete the partial note as another completer. Note that the caller here owns the tokens - this is
+    // so that we pass the balance check and fail on the partial note completer check.
+    let _ = env.call_public_void(
+        owner,
+        Token::at(token_contract_address).finalize_transfer_to_private(amount, partial_uint_note),
     );
 }

--- a/noir-projects/noir-contracts/contracts/app/token_contract/src/test/transfer_to_public.nr
+++ b/noir-projects/noir-contracts/contracts/app/token_contract/src/test/transfer_to_public.nr
@@ -11,15 +11,27 @@ unconstrained fn transfer_to_public_on_behalf_of_self() {
         utils::setup_and_mint_to_private(/* with_account_contracts */ false);
 
     let transfer_to_public_amount = mint_amount / (10 as u128);
-    Token::at(token_contract_address)
-        .transfer_to_public(owner, owner, transfer_to_public_amount, 0)
-        .call(&mut env.private());
+    let _ = env.call_private_void(
+        owner,
+        Token::at(token_contract_address).transfer_to_public(
+            owner,
+            owner,
+            transfer_to_public_amount,
+            0,
+        ),
+    );
     utils::check_private_balance(
+        env,
         token_contract_address,
         owner,
         mint_amount - transfer_to_public_amount,
     );
-    utils::check_public_balance(token_contract_address, owner, transfer_to_public_amount);
+    utils::check_public_balance(
+        env,
+        token_contract_address,
+        owner,
+        transfer_to_public_amount,
+    );
 }
 
 #[test]
@@ -35,16 +47,20 @@ unconstrained fn transfer_to_public_on_behalf_of_other() {
         0,
     );
     add_private_authwit_from_call_interface(owner, recipient, transfer_to_public_call_interface);
-    // Impersonate recipient
-    env.impersonate(recipient);
     // transfer_to_public tokens
-    transfer_to_public_call_interface.call(&mut env.private());
+    let _ = env.call_private_void(recipient, transfer_to_public_call_interface);
     utils::check_private_balance(
+        env,
         token_contract_address,
         owner,
         mint_amount - transfer_to_public_amount,
     );
-    utils::check_public_balance(token_contract_address, recipient, transfer_to_public_amount);
+    utils::check_public_balance(
+        env,
+        token_contract_address,
+        recipient,
+        transfer_to_public_amount,
+    );
 }
 
 #[test(should_fail_with = "Balance too low")]
@@ -54,9 +70,15 @@ unconstrained fn transfer_to_public_failure_more_than_balance() {
         utils::setup_and_mint_to_private(/* with_account_contracts */ false);
 
     let transfer_to_public_amount = mint_amount + (1 as u128);
-    Token::at(token_contract_address)
-        .transfer_to_public(owner, owner, transfer_to_public_amount, 0)
-        .call(&mut env.private());
+    let _ = env.call_private_void(
+        owner,
+        Token::at(token_contract_address).transfer_to_public(
+            owner,
+            owner,
+            transfer_to_public_amount,
+            0,
+        ),
+    );
 }
 
 #[test(should_fail_with = "Assertion failed: Invalid authwit nonce. When 'from' and 'msg_sender' are the same, 'authwit_nonce' must be zero")]
@@ -66,9 +88,15 @@ unconstrained fn transfer_to_public_failure_on_behalf_of_self_non_zero_nonce() {
         utils::setup_and_mint_to_private(/* with_account_contracts */ false);
 
     let transfer_to_public_amount = mint_amount + (1 as u128);
-    Token::at(token_contract_address)
-        .transfer_to_public(owner, owner, transfer_to_public_amount, random())
-        .call(&mut env.private());
+    let _ = env.call_private_void(
+        owner,
+        Token::at(token_contract_address).transfer_to_public(
+            owner,
+            owner,
+            transfer_to_public_amount,
+            random(),
+        ),
+    );
 }
 
 #[test(should_fail_with = "Balance too low")]
@@ -84,10 +112,9 @@ unconstrained fn transfer_to_public_failure_on_behalf_of_other_more_than_balance
         0,
     );
     add_private_authwit_from_call_interface(owner, recipient, transfer_to_public_call_interface);
-    // Impersonate recipient
-    env.impersonate(recipient);
+
     // transfer_to_public tokens
-    transfer_to_public_call_interface.call(&mut env.private());
+    let _ = env.call_private_void(recipient, transfer_to_public_call_interface);
 }
 
 #[test(should_fail_with = "Unknown auth witness for message hash")]
@@ -103,10 +130,9 @@ unconstrained fn transfer_to_public_failure_on_behalf_of_other_invalid_designate
         0,
     );
     add_private_authwit_from_call_interface(owner, owner, transfer_to_public_call_interface);
-    // Impersonate recipient
-    env.impersonate(recipient);
+
     // transfer_to_public tokens
-    transfer_to_public_call_interface.call(&mut env.private());
+    let _ = env.call_private_void(recipient, transfer_to_public_call_interface);
 }
 
 #[test(should_fail_with = "Unknown auth witness for message hash")]
@@ -121,8 +147,7 @@ unconstrained fn transfer_to_public_failure_on_behalf_of_other_no_approval() {
         transfer_to_public_amount,
         0,
     );
-    // Impersonate recipient
-    env.impersonate(recipient);
+
     // transfer_to_public tokens
-    transfer_to_public_call_interface.call(&mut env.private());
+    let _ = env.call_private_void(recipient, transfer_to_public_call_interface);
 }

--- a/noir-projects/noir-contracts/contracts/app/token_contract/src/test/transfer_to_public_and_prepare_private_balance_increase.nr
+++ b/noir-projects/noir-contracts/contracts/app/token_contract/src/test/transfer_to_public_and_prepare_private_balance_increase.nr
@@ -35,39 +35,35 @@ unconstrained fn transfer_to_public_and_prepare_private_balance_increase_and_fin
     );
 
     // Impersonate the AMM and initiate the transfer
-    env.impersonate(amm_contract);
-    let partial_note = transfer_call_interface.call(&mut env.private());
+    let partial_note = env.call_private(amm_contract, transfer_call_interface).return_value;
 
     // Check balances before the partial note is finalized
     utils::check_private_balance(
+        env,
         token_contract_address,
         liquidity_provider,
         mint_amount - deposit_amount,
     );
-    utils::check_public_balance(token_contract_address, amm_contract, deposit_amount);
-
-    // We need to advance the block by 1 for the partial note validity commitment to be committed to the nullifier
-    // tree.
-    env.mine_block();
+    utils::check_public_balance(env, token_contract_address, amm_contract, deposit_amount);
 
     // Now we finalize the partial change note by impersonating the AMM contract and calling the finalize function
     // --> this should send the `change_amount` from AMM's public balance to liquidity provider's private balance
     let change_amount = deposit_amount / (2 as u128);
 
-    env.impersonate(amm_contract);
-    Token::at(token_contract_address)
-        .finalize_transfer_to_private(change_amount, partial_note)
-        .call(&mut env.public());
-
-    env.mine_block();
+    let _ = env.call_public_void(
+        amm_contract,
+        Token::at(token_contract_address).finalize_transfer_to_private(change_amount, partial_note),
+    );
 
     // Check balances after the partial note is finalized
     utils::check_private_balance(
+        env,
         token_contract_address,
         liquidity_provider,
         mint_amount - deposit_amount + change_amount,
     );
     utils::check_public_balance(
+        env,
         token_contract_address,
         amm_contract,
         deposit_amount - change_amount,
@@ -81,14 +77,15 @@ unconstrained fn transfer_to_public_and_prepare_private_balance_increase_failure
         utils::setup_and_mint_to_private(/* with_account_contracts */ false);
 
     let transfer_amount = mint_amount + (1 as u128);
-    let _ = Token::at(token_contract_address)
-        .transfer_to_public_and_prepare_private_balance_increase(
+    let _ = env.call_private(
+        sender,
+        Token::at(token_contract_address).transfer_to_public_and_prepare_private_balance_increase(
             sender,
             recipient,
             transfer_amount,
             0,
-        )
-        .call(&mut env.private());
+        ),
+    );
 }
 
 #[test(should_fail_with = "Assertion failed: Invalid authwit nonce. When 'from' and 'msg_sender' are the same, 'authwit_nonce' must be zero")]
@@ -98,14 +95,15 @@ unconstrained fn transfer_to_public_and_prepare_private_balance_increase_failure
         utils::setup_and_mint_to_private(/* with_account_contracts */ false);
 
     let transfer_amount = mint_amount / (10 as u128);
-    let _ = Token::at(token_contract_address)
-        .transfer_to_public_and_prepare_private_balance_increase(
+    let _ = env.call_private(
+        sender,
+        Token::at(token_contract_address).transfer_to_public_and_prepare_private_balance_increase(
             sender,
             recipient,
             transfer_amount,
             random(),
-        )
-        .call(&mut env.private());
+        ),
+    );
 }
 
 #[test(should_fail_with = "Unknown auth witness for message hash")]
@@ -122,9 +120,6 @@ unconstrained fn transfer_to_public_and_prepare_private_balance_increase_failure
             1,
         );
 
-    // Impersonate recipient without adding authwit
-    env.impersonate(recipient);
-
     // Try executing transfer without approval
-    let _ = transfer_call_interface.call(&mut env.private());
+    let _ = env.call_private(recipient, transfer_call_interface);
 }

--- a/noir-projects/noir-contracts/contracts/app/token_contract/src/test/utils.nr
+++ b/noir-projects/noir-contracts/contracts/app/token_contract/src/test/utils.nr
@@ -74,7 +74,7 @@ pub unconstrained fn setup_and_mint_amount_to_private(
     // Mint some tokens
     let _ = env.call_private_void(
         owner,
-        Token::at(token_contract_address).mint_to_private(recipient, mint_amount),
+        Token::at(token_contract_address).mint_to_private(owner, mint_amount),
     );
 
     (env, token_contract_address, owner, recipient, mint_amount)

--- a/noir-projects/noir-contracts/contracts/app/token_contract/src/test/utils.nr
+++ b/noir-projects/noir-contracts/contracts/app/token_contract/src/test/utils.nr
@@ -54,8 +54,12 @@ pub unconstrained fn setup_and_mint_to_public(
     // Setup
     let (env, token_contract_address, owner, recipient) = setup(with_account_contracts);
     let mint_amount = 10000 as u128;
+
     // Mint some tokens
-    Token::at(token_contract_address).mint_to_public(owner, mint_amount).call(&mut env.public());
+    let _ = env.call_public_void(
+        owner,
+        Token::at(token_contract_address).mint_to_public(owner, mint_amount),
+    );
 
     (env, token_contract_address, owner, recipient, mint_amount)
 }
@@ -68,7 +72,10 @@ pub unconstrained fn setup_and_mint_amount_to_private(
     let (env, token_contract_address, owner, recipient) = setup(with_account_contracts);
 
     // Mint some tokens
-    mint_to_private(env, token_contract_address, owner, mint_amount);
+    let _ = env.call_private_void(
+        owner,
+        Token::at(token_contract_address).mint_to_private(recipient, mint_amount),
+    );
 
     (env, token_contract_address, owner, recipient, mint_amount)
 }
@@ -80,32 +87,17 @@ pub unconstrained fn setup_and_mint_to_private(
     setup_and_mint_amount_to_private(with_account_contracts, mint_amount)
 }
 
-pub unconstrained fn mint_to_private(
-    env: &mut TestEnvironment,
-    token_contract_address: AztecAddress,
-    recipient: AztecAddress,
-    amount: u128,
-) {
-    Token::at(token_contract_address).mint_to_private(recipient, amount).call(&mut env.private());
-
-    env.mine_block();
-}
-
 // docs:start:txe_test_read_public
 pub unconstrained fn check_public_balance(
+    env: &mut TestEnvironment,
     token_contract_address: AztecAddress,
     address: AztecAddress,
     address_amount: u128,
 ) {
-    let current_contract_address = get_contract_address();
-    txe_oracles::set_contract_address(token_contract_address);
-    let block_number = get_block_number();
-
-    let balances_slot = Token::storage_layout().public_balances.slot;
-    let address_slot = derive_storage_slot_in_map(balances_slot, address);
-    let amount: u128 = storage_read(token_contract_address, address_slot, block_number);
-    assert(amount == address_amount, "Public balance is not correct");
-    txe_oracles::set_contract_address(current_contract_address);
+    assert_eq(
+        env.view_public(Token::at(token_contract_address).balance_of_public(address)),
+        address_amount,
+    );
 }
 // docs:end:txe_test_read_public
 
@@ -140,16 +132,17 @@ pub unconstrained fn check_total_supply(
 
 // docs:start:txe_test_call_utility
 pub unconstrained fn check_private_balance(
+    env: &mut TestEnvironment,
     token_contract_address: AztecAddress,
     address: AztecAddress,
     address_amount: u128,
 ) {
-    let current_contract_address = get_contract_address();
-    txe_oracles::set_contract_address(token_contract_address);
-    // Direct call to a utility function
-    let balance_of_private = Token::balance_of_private(address);
-    assert(balance_of_private == address_amount, "Private balance is not correct");
-    txe_oracles::set_contract_address(current_contract_address);
+    assert_eq(
+        env.simulate_utility(Token::at(token_contract_address)._experimental_balance_of_private(
+            address,
+        )),
+        address_amount,
+    );
 }
 // docs:end:txe_test_call_utility
 

--- a/noir-projects/noir-contracts/contracts/app/token_contract/src/types/balance_set.nr
+++ b/noir-projects/noir-contracts/contracts/app/token_contract/src/types/balance_set.nr
@@ -167,6 +167,7 @@ mod test {
         // We check the recipient balance is correct both as a sanity check and as a way to make sure we've discovered
         // the notes.
         utils::check_private_balance(
+            env,
             token_contract_address,
             recipient,
             small_mint_amount + large_mint_amount,
@@ -210,6 +211,7 @@ mod test {
         // We check the recipient balance is correct both as a sanity check and as a way to make sure we've discovered
         // the notes.
         utils::check_private_balance(
+            env,
             token_contract_address,
             recipient,
             small_mint_amount + large_mint_amount,

--- a/noir-projects/noir-contracts/contracts/app/token_contract/src/types/balance_set.nr
+++ b/noir-projects/noir-contracts/contracts/app/token_contract/src/types/balance_set.nr
@@ -140,73 +140,33 @@ pub fn preprocess_notes_min_sum(
 mod test {
     use crate::{test::utils, Token};
     use super::BalanceSet;
-    use dep::aztec::{
-        protocol_types::{storage::map::derive_storage_slot_in_map, traits::ToField},
-        test::helpers::txe_oracles,
-    };
+    use dep::aztec::protocol_types::{storage::map::derive_storage_slot_in_map, traits::ToField};
 
     #[test]
     unconstrained fn subtract_balance_small_note_first() {
-        let (env, token_contract_address, owner, recipient) = utils::setup(false);
-
-        // The owner mints two notes for the recipient: first one for a small amount, and then one for a large amount.
-        env.impersonate(owner);
-
-        let small_mint_amount: u128 = 5;
-        Token::at(token_contract_address).mint_to_private(recipient, small_mint_amount).call(
-            &mut env.private(),
-        );
-        env.mine_block();
-
-        let large_mint_amount: u128 = 50;
-        Token::at(token_contract_address).mint_to_private(recipient, large_mint_amount).call(
-            &mut env.private(),
-        );
-        env.mine_block();
-
-        // We check the recipient balance is correct both as a sanity check and as a way to make sure we've discovered
-        // the notes.
-        utils::check_private_balance(
-            env,
-            token_contract_address,
-            recipient,
-            small_mint_amount + large_mint_amount,
-        );
-
-        // We now instantiate a BalanceSet state variable for the recipient and subtract an amount equal to the small
-        // note. Because large notes are consumed first, we should see that a change note is created with amount equal
-        // to large - small, indicating that the large note was consumed.
-        txe_oracles::set_contract_address(token_contract_address);
-        let recipient_balance_storage_slot =
-            derive_storage_slot_in_map(Token::storage_layout().balances.slot, recipient.to_field());
-
-        let recipient_balance_set =
-            BalanceSet::new(&mut env.private(), recipient_balance_storage_slot);
-        let emission = recipient_balance_set.sub(recipient, small_mint_amount);
-        assert_eq(emission.emission.unwrap().note.value, large_mint_amount - small_mint_amount);
-
-        // The subtract_balance_large_note_first test does the same as this one, except creating the large note first.
-        // Put together, these two tests check that large notes are consumed first regardless of creation order.
+        check_large_balance_note_used_first([5, 50]);
     }
 
     #[test]
     unconstrained fn subtract_balance_large_note_first() {
+        check_large_balance_note_used_first([50, 5]);
+    }
+
+    unconstrained fn check_large_balance_note_used_first(note_values: [u128; 2]) {
         let (env, token_contract_address, owner, recipient) = utils::setup(false);
 
-        // The owner mints two notes for the recipient: first one for a large amount, and then one for a small amount.
-        env.impersonate(owner);
-
-        let large_mint_amount: u128 = 50;
-        Token::at(token_contract_address).mint_to_private(recipient, large_mint_amount).call(
-            &mut env.private(),
+        // The owner mints two notes for the recipient
+        let first_note_value = note_values[0];
+        let _ = env.call_private_void(
+            owner,
+            Token::at(token_contract_address).mint_to_private(recipient, first_note_value),
         );
-        env.mine_block();
 
-        let small_mint_amount: u128 = 5;
-        Token::at(token_contract_address).mint_to_private(recipient, small_mint_amount).call(
-            &mut env.private(),
+        let second_note_value = note_values[1];
+        let _ = env.call_private_void(
+            owner,
+            Token::at(token_contract_address).mint_to_private(recipient, second_note_value),
         );
-        env.mine_block();
 
         // We check the recipient balance is correct both as a sanity check and as a way to make sure we've discovered
         // the notes.
@@ -214,22 +174,28 @@ mod test {
             env,
             token_contract_address,
             recipient,
-            small_mint_amount + large_mint_amount,
+            first_note_value + second_note_value,
         );
 
-        // We now instantiate a BalanceSet state variable for the recipient and subtract an amount equal to the small
-        // note. Because large notes are consumed first, we should see that a change note is created with amount equal
-        // to large - small, indicating that the large note was consumed.
-        txe_oracles::set_contract_address(token_contract_address);
-        let recipient_balance_storage_slot =
-            derive_storage_slot_in_map(Token::storage_layout().balances.slot, recipient.to_field());
+        // We now instantiate a BalanceSet state variable for the recipient and subtract an amount equal to the smallest
+        // of the two notes. Because large notes are consumed first, we should see that a change note is created with
+        // amount equal to large - small, indicating that the larger note was consumed regardless of the order in which
+        // the notes were created.
+        env.private_context_at(token_contract_address, |context| {
+            let recipient_balance_set = BalanceSet::new(
+                context,
+                derive_storage_slot_in_map(
+                    Token::storage_layout().balances.slot,
+                    recipient.to_field(),
+                ),
+            );
 
-        let recipient_balance_set =
-            BalanceSet::new(&mut env.private(), recipient_balance_storage_slot);
-        let emission = recipient_balance_set.sub(recipient, small_mint_amount);
-        assert_eq(emission.emission.unwrap().note.value, large_mint_amount - small_mint_amount);
+            let smaller_note_value = std::cmp::min(first_note_value, second_note_value);
+            let larger_note_value = std::cmp::max(first_note_value, second_note_value);
 
-        // The subtract_balance_small_note_first test does the same as this one, except creating the small note first.
-        // Put together, these two tests check that large notes are consumed first regardless of creation order.
+            let note =
+                recipient_balance_set.sub(recipient, smaller_note_value).emission.unwrap().note;
+            assert_eq(note.value, larger_note_value - smaller_note_value);
+        });
     }
 }

--- a/noir-projects/noir-contracts/contracts/test/counter_contract/src/main.nr
+++ b/noir-projects/noir-contracts/contracts/test/counter_contract/src/main.nr
@@ -118,13 +118,6 @@ pub contract Counter {
     // docs:end:get_counter
     // docs:start:test_imports
     use crate::test;
-    use aztec::{
-        note::{
-            note_getter::{MAX_NOTES_PER_PAGE, view_notes},
-            note_viewer_options::NoteViewerOptions,
-        },
-        protocol_types::storage::map::derive_storage_slot_in_map,
-    };
 
     // docs:end:test_imports
     // docs:start:txe_test_increment
@@ -162,64 +155,30 @@ pub contract Counter {
         let (env, contract_address, owner) = test::setup(initial_value);
 
         // Checking that the note was discovered from private logs
-        env.impersonate(contract_address);
-        sync_private_state();
-        let counter_slot = Counter::storage_layout().counters.slot;
-        let owner_storage_slot = derive_storage_slot_in_map(counter_slot, owner);
-        let mut options = NoteViewerOptions::new();
-        let notes: BoundedVec<ValueNote, MAX_NOTES_PER_PAGE> =
-            view_notes(owner_storage_slot, options);
-        let initial_note_value = notes.get(0).value;
-        assert(
-            initial_note_value == initial_value,
-            f"Expected {initial_value} but got {initial_note_value}",
+        let initial_note_value =
+            env.simulate_utility(Counter::at(contract_address)._experimental_get_counter(owner));
+        assert(initial_note_value == initial_value);
+
+        let _ = env.call_private_void(owner, Counter::at(contract_address).increment_twice(owner));
+
+        assert_eq(
+            env.simulate_utility(Counter::at(contract_address)._experimental_get_counter(owner)),
+            7,
         );
 
-        Counter::at(contract_address).increment_twice(owner).call(&mut env.private());
+        let _ = env.call_private_void(
+            owner,
+            Counter::at(contract_address).increment_and_decrement(owner),
+        );
+        assert_eq(
+            env.simulate_utility(Counter::at(contract_address)._experimental_get_counter(owner)),
+            7,
+        );
 
-        // Checking from the note cache
-        let notes: BoundedVec<ValueNote, MAX_NOTES_PER_PAGE> =
-            view_notes(owner_storage_slot, options);
-        assert(notes.len() == 3);
-        assert(get_counter(owner) == 7);
-
-        // Checking that the note was discovered from private logs
-        env.mine_block();
-        sync_private_state();
-        let notes: BoundedVec<ValueNote, MAX_NOTES_PER_PAGE> =
-            view_notes(owner_storage_slot, options);
-        assert(get_counter(owner) == 7);
-        assert(notes.len() == 3);
-
-        // Checking from the note cache
-        Counter::at(contract_address).increment_and_decrement(owner).call(&mut env.private());
-        let notes: BoundedVec<ValueNote, MAX_NOTES_PER_PAGE> =
-            view_notes(owner_storage_slot, options);
-        assert(get_counter(owner) == 7);
-        // We have a change note of 0
-        assert(notes.len() == 4);
-
-        // Checking that the note was discovered from private logs
-        env.mine_block();
-        sync_private_state();
-        let notes: BoundedVec<ValueNote, MAX_NOTES_PER_PAGE> =
-            view_notes(owner_storage_slot, options);
-        assert(notes.len() == 4);
-        assert(get_counter(owner) == 7);
-
-        // Checking from the note cache
-        Counter::at(contract_address).decrement(owner).call(&mut env.private());
-        let notes: BoundedVec<ValueNote, MAX_NOTES_PER_PAGE> =
-            view_notes(owner_storage_slot, options);
-        assert(get_counter(owner) == 6);
-        assert(notes.len() == 4);
-
-        // Checking that the note was discovered from private logs
-        env.mine_block();
-        sync_private_state();
-        let notes: BoundedVec<ValueNote, MAX_NOTES_PER_PAGE> =
-            view_notes(owner_storage_slot, options);
-        assert(get_counter(owner) == 6);
-        assert(notes.len() == 4);
+        let _ = env.call_private_void(owner, Counter::at(contract_address).decrement(owner));
+        assert_eq(
+            env.simulate_utility(Counter::at(contract_address)._experimental_get_counter(owner)),
+            6,
+        );
     }
 }

--- a/noir-projects/noir-contracts/contracts/test/parent_contract/src/main.nr
+++ b/noir-projects/noir-contracts/contracts/test/parent_contract/src/main.nr
@@ -260,58 +260,64 @@ pub contract Parent {
         // Call the target private function
         context.static_call_public_function(target_contract, target_selector, args);
     }
-    use dep::aztec::note::note_getter::{MAX_NOTES_PER_PAGE, view_notes};
-    use dep::aztec::note::note_viewer_options::NoteViewerOptions;
-    use dep::aztec::oracle::notes::set_sender_for_tags;
-    use dep::aztec::protocol_types::storage::map::derive_storage_slot_in_map;
-    use dep::aztec::test::helpers::{test_environment::TestEnvironment, txe_oracles};
+    use dep::aztec::test::helpers::test_environment::TestEnvironment;
     use dep::child_contract::Child;
-    use dep::value_note::value_note::ValueNote;
+
     #[test]
     unconstrained fn test_private_call() {
-        // Setup env, generate keys
         let mut env = TestEnvironment::new();
         let owner = env.create_account(1);
-
-        // We are not deploying any account contracts and so we need to manually set the sender for tags. This is
-        // usually done by account contract's entrypoint.
         let sender = env.create_account(7097070);
-        set_sender_for_tags(sender);
 
         // Deploy parent contract
         let parent_contract = env.deploy_self("Parent").without_initializer();
         let parent_contract_address = parent_contract.to_address();
+
         // Deploy child contract
         let child_contract = env.deploy("./@child_contract", "Child").without_initializer();
         let child_contract_address = child_contract.to_address();
-        txe_oracles::advance_blocks_by(1);
+
+        // The 'from' param is irrelevant in all tests below.
+        let from = owner;
+
         // Set value in child through parent
         let value_to_set = 7;
-        let result = Parent::at(parent_contract_address)
-            .private_call(
-                child_contract_address,
-                comptime { FunctionSelector::from_signature("private_set_value(Field,(Field))") },
-                [value_to_set, owner.to_field()],
+        let result = env
+            .call_private(
+                from,
+                Parent::at(parent_contract_address).private_call(
+                    child_contract_address,
+                    comptime {
+                        FunctionSelector::from_signature("private_set_value(Field,(Field))")
+                    },
+                    [value_to_set, owner.to_field()],
+                ),
             )
-            .call(&mut env.private());
+            .return_value;
         assert(result == value_to_set);
-        // Read the stored value in the note. We have to change the contract address to the child contract in order to read its notes
-        env.impersonate(child_contract_address);
-        let counter_slot = Child::storage_layout().a_map_with_private_values.slot;
-        let owner_slot = derive_storage_slot_in_map(counter_slot, owner);
-        let mut options = NoteViewerOptions::new();
-        let notes: BoundedVec<ValueNote, MAX_NOTES_PER_PAGE> = view_notes(owner_slot, options);
-        let note_value = notes.get(0).value;
-        assert(note_value == value_to_set);
-        assert(note_value == result);
-        // Get value from child through parent
-        let read_result = Parent::at(parent_contract_address)
-            .private_call(
-                child_contract_address,
-                comptime { FunctionSelector::from_signature("private_get_value(Field,(Field))") },
-                [7, owner.to_field()],
+
+        // Read the stored value in the note.
+        let note_value = env
+            .call_private(
+                from,
+                Child::at(child_contract_address).private_get_value(value_to_set, owner),
             )
-            .call(&mut env.private());
+            .return_value;
+        assert(note_value == value_to_set);
+
+        // Get value from child through parent
+        let read_result = env
+            .call_private(
+                from,
+                Parent::at(parent_contract_address).private_call(
+                    child_contract_address,
+                    comptime {
+                        FunctionSelector::from_signature("private_get_value(Field,(Field))")
+                    },
+                    [7, owner.to_field()],
+                ),
+            )
+            .return_value;
         assert(note_value == read_result);
     }
 }

--- a/noir-projects/noir-contracts/contracts/test/test_contract/src/test/deployment_proofs.nr
+++ b/noir-projects/noir-contracts/contracts/test/test_contract/src/test/deployment_proofs.nr
@@ -21,7 +21,6 @@ global CONTRACT_INITIALIZED_AT: u32 = CONTRACT_DEPLOYED_AT + 1;
 pub unconstrained fn setup() -> (&mut TestEnvironment, AztecAddress, AztecAddress) {
     let mut env = TestEnvironment::new();
     let owner = env.create_account(1);
-    env.impersonate(owner);
 
     // We sanity check that the deployment block will be the next one
     assert_eq(env.next_block_number(), CONTRACT_DEPLOYED_AT);

--- a/yarn-project/txe/package.json
+++ b/yarn-project/txe/package.json
@@ -16,7 +16,7 @@
     "build:dev": "tsc -b --watch",
     "clean": "rm -rf ./dest .tsbuildinfo",
     "test": "NODE_NO_WARNINGS=1 node --experimental-vm-modules ../node_modules/.bin/jest --passWithNoTests --maxWorkers=${JEST_MAX_WORKERS:-8}",
-    "dev": "LOG_LEVEL=\"debug; info: json-rpc:proxy\" node ./dest/bin/index.js",
+    "dev": "LOG_LEVEL=\"debug; trace: simulator:state_manager; info: json-rpc:proxy\" node ./dest/bin/index.js",
     "start": "node --no-warnings ./dest/bin/index.js"
   },
   "inherits": [

--- a/yarn-project/txe/src/oracle/txe_oracle.ts
+++ b/yarn-project/txe/src/oracle/txe_oracle.ts
@@ -1437,6 +1437,8 @@ export class TXE implements TypedOracle {
     const globals = makeGlobalVariables();
     globals.blockNumber = this.blockNumber;
     globals.timestamp = this.timestamp;
+    globals.chainId = new Fr(this.CHAIN_ID);
+    globals.version = new Fr(this.ROLLUP_VERSION);
     globals.gasFees = GasFees.empty();
 
     const contractsDB = new PublicContractsDB(new TXEPublicContractDataSource(this));
@@ -1550,6 +1552,8 @@ export class TXE implements TypedOracle {
     const globals = makeGlobalVariables();
     globals.blockNumber = this.blockNumber;
     globals.timestamp = this.timestamp;
+    globals.chainId = new Fr(this.CHAIN_ID);
+    globals.version = new Fr(this.ROLLUP_VERSION);
     globals.gasFees = GasFees.empty();
 
     const contractsDB = new PublicContractsDB(new TXEPublicContractDataSource(this));


### PR DESCRIPTION
`CallInterface.call(context)` is dead! Long live `env.call(CallInterface)`!

With this PR, we no longer ever make contract calls using the old flow (I think). The migration was straightforward, the only thing I had to fix was the new flow not correctly setting chaind and version, which caused authwit validation to fail.